### PR TITLE
feat(core): REUSABLE_INPUTS input type, validation, and editor seam

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -95,6 +95,8 @@ public class MyService {
 * Use static methods only
 * Use existing utility classes (e.g., `ListUtils`, `MapUtils`) instead of creating new ones (`io.kestra.core.utils.*`)
 
+**MANDATORY — never hand-roll Pebble delimiter detection.** Pebble has two block delimiter pairs — print blocks (`{{ ... }}`) and execute/statement blocks (`{% ... %}`) — and code that only checks for `{{`/`}}` silently misses `{%`/`%}` blocks. Use `io.kestra.core.utils.PebbleUtil` (`containsOpeningBlockDelimiter`, `startsWithOpeningBlockDelimiter`, `endsWithClosingBlockDelimiter`, `openingBlockDelimiters()`/`closingBlockDelimiters()`) instead of writing a new delimiter regex or literal — it derives the delimiter pairs from Pebble's own `Syntax.Builder` defaults, so it never drifts from what Pebble actually parses.
+
 ### Enums
 - Use enums for fixed sets of constants
 - Use `@JsonValue` for custom serialization if needed
@@ -375,6 +377,8 @@ This copies the gitignored `cli/src/main/resources/application-*.yml` files from
 This document should be updated as the codebase evolves. When in doubt, follow existing patterns in the codebase and maintain consistency with established conventions.
 
 ## UI Translations
+
+**MANDATORY — never hardcode user-facing strings.** Every label, button, tooltip, placeholder, dialog/section title, table-column header, and toast/confirm message rendered to the user MUST go through vue-i18n: `t("key")` (or `:label`/`:tooltip` bindings) in components, and `<i18n-t keypath="...">` with named slots when the string embeds markup or a component (e.g. a `<code>` fragment). Never write a literal user-facing string in a template, a `:tooltip`/`:label` attribute, or a `toast.*` call. Reuse existing generic keys (`cancel`, `delete`, `edit`, `save`, `add`, `id`, `description`, `namespace`, `revision`, …) instead of duplicating them; put feature-specific strings under one namespaced object (e.g. `"reusableInputs": { … }`). After adding keys to `en.json`, propagate them to every language (translation generation script) so the missing-keys check stays clean — a key present only in `en.json` fails the check.
 
 Translation files live in `ui/src/translations/`. There is one JSON file per language code (e.g. `de.json`, `fr.json`) plus the source `en.json`.
 

--- a/core/src/main/java/io/kestra/core/docs/JsonSchemaGenerator.java
+++ b/core/src/main/java/io/kestra/core/docs/JsonSchemaGenerator.java
@@ -141,10 +141,60 @@ public class JsonSchemaGenerator {
             pullDocumentationAndDefaultFromAnyOf(objectNode);
             removeRequiredOnPropsWithDefaults(objectNode);
 
-            return MAPPER.convertValue(objectNode, MAP_TYPE_REFERENCE);
+            Map<String, Object> schema = MAPPER.convertValue(objectNode, MAP_TYPE_REFERENCE);
+            stripEditionRestrictedInputTypes(schema);
+            return schema;
         } catch (Exception e) {
             throw new IllegalArgumentException("Unable to generate jsonschema for '" + cls.getName() + "'", e);
         }
+    }
+
+    /**
+     * Strip edition-restricted input types (those excluded by {@link #includeInputSubtype}, i.e. {@code @EeOnly} ones
+     * such as {@code REUSABLE_INPUTS}) from the generated flow schema. The {@code Type} enum is carried in two places:
+     * the {@code enum} arrays (the {@code type} discriminator and {@code ArrayInput.itemType}) AND the polymorphic
+     * {@code anyOf}/{@code oneOf}/{@code allOf} discriminator branches ({@code {properties:{type:{const:...}}}}); both
+     * must be pruned. Open-source removes the {@code @EeOnly} types; the Enterprise override of
+     * {@code includeInputSubtype} keeps them all, so the excluded set is empty here (no-op).
+     */
+    private void stripEditionRestrictedInputTypes(Object node) {
+        Set<String> excluded = Arrays.stream(io.kestra.core.models.flows.Type.values())
+            .filter(type -> !this.includeInputSubtype(type.cls()))
+            .map(Enum::name)
+            .collect(Collectors.toSet());
+
+        if (!excluded.isEmpty()) {
+            stripEditionRestrictedInputTypes(node, excluded);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private static void stripEditionRestrictedInputTypes(Object node, Set<String> excluded) {
+        if (node instanceof Map<?, ?> rawMap) {
+            Map<String, Object> map = (Map<String, Object>) rawMap;
+
+            if (map.get("enum") instanceof List<?> enumValues) {
+                enumValues.removeIf(value -> excluded.contains(String.valueOf(value)));
+            }
+            for (String key : List.of("anyOf", "oneOf", "allOf")) {
+                if (map.get(key) instanceof List<?> branches) {
+                    branches.removeIf(branch -> isExcludedDiscriminatorBranch(branch, excluded));
+                }
+            }
+            map.values().forEach(value -> stripEditionRestrictedInputTypes(value, excluded));
+        } else if (node instanceof List<?> list) {
+            list.forEach(value -> stripEditionRestrictedInputTypes(value, excluded));
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private static boolean isExcludedDiscriminatorBranch(Object branch, Set<String> excluded) {
+        if (branch instanceof Map<?, ?> map
+            && ((Map<String, Object>) map).get("properties") instanceof Map<?, ?> properties
+            && ((Map<String, Object>) properties).get("type") instanceof Map<?, ?> type) {
+            return excluded.contains(String.valueOf(((Map<String, Object>) type).get("const")));
+        }
+        return false;
     }
 
     private void removeRequiredOnPropsWithDefaults(ObjectNode objectNode) {
@@ -905,9 +955,31 @@ public class JsonSchemaGenerator {
                 .filter(Predicate.not(io.kestra.core.models.Plugin::isInternal))
                 .map(typeContext::resolve)
                 .toList();
+        } else if (declaredType.getErasedType() == io.kestra.core.models.flows.Input.class) {
+            // Resolve the input subtypes from the @JsonSubTypes registry, filtering out edition-restricted ones
+            // (e.g. REUSABLE_INPUTS) so they don't appear in the open-source flow schema. EE includes them all.
+            com.fasterxml.jackson.annotation.JsonSubTypes subTypes =
+                io.kestra.core.models.flows.Input.class.getAnnotation(com.fasterxml.jackson.annotation.JsonSubTypes.class);
+            if (subTypes == null) {
+                return null;
+            }
+            return java.util.Arrays.stream(subTypes.value())
+                .map(com.fasterxml.jackson.annotation.JsonSubTypes.Type::value)
+                .filter(this::includeInputSubtype)
+                .flatMap(clz -> safelyResolveSubtype(declaredType, clz, typeContext).stream())
+                .collect(Collectors.toList());
         }
 
         return null;
+    }
+
+    /**
+     * Whether the given {@link io.kestra.core.models.flows.Input} subtype should appear in the generated flow
+     * schema. The open-source generator hides {@link io.kestra.core.models.flows.input.EeOnly}-annotated inputs;
+     * the EE generator overrides this to include them.
+     */
+    protected boolean includeInputSubtype(Class<?> subtype) {
+        return !subtype.isAnnotationPresent(io.kestra.core.models.flows.input.EeOnly.class);
     }
 
     protected static Optional<ResolvedType> safelyResolveSubtype(ResolvedType declaredType, Class<?> clz, TypeContext typeContext) {

--- a/core/src/main/java/io/kestra/core/docs/SchemaType.java
+++ b/core/src/main/java/io/kestra/core/docs/SchemaType.java
@@ -11,7 +11,8 @@ public enum SchemaType {
     PLUGINDEFAULT,
     APPS,
     TESTSUITES,
-    DASHBOARD;
+    DASHBOARD,
+    REUSABLEINPUTS;
 
     @JsonCreator
     public static SchemaType fromString(final String value) {

--- a/core/src/main/java/io/kestra/core/models/flows/FlowForExecution.java
+++ b/core/src/main/java/io/kestra/core/models/flows/FlowForExecution.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 import io.kestra.core.models.tasks.TaskForExecution;
 import io.kestra.core.models.triggers.AbstractTriggerForExecution;
+import io.kestra.core.runners.ReusableInputsExpander;
 import io.kestra.core.utils.ListUtils;
 
 import jakarta.validation.Valid;
@@ -37,6 +38,17 @@ public class FlowForExecution extends AbstractFlow {
 
     @Valid
     List<AbstractTriggerForExecution> triggers;
+
+    /**
+     * Like {@link #of(Flow)} but inlines every {@code REUSABLE_INPUTS} reference (FORM grouping preserved) so the
+     * execute form receives — and submits — the block's resolved inputs under the reference id. Use this on the
+     * execute-form endpoints; {@link #of(Flow)} stays a pure projection for callers without an expander.
+     */
+    public static FlowForExecution of(Flow flow, ReusableInputsExpander reusableInputsExpander) {
+        return of(flow).toBuilder()
+            .inputs(flow.inlinedInputs(reusableInputsExpander))
+            .build();
+    }
 
     public static FlowForExecution of(Flow flow) {
         return FlowForExecution.builder()

--- a/core/src/main/java/io/kestra/core/models/flows/FlowInterface.java
+++ b/core/src/main/java/io/kestra/core/models/flows/FlowInterface.java
@@ -24,6 +24,9 @@ import io.kestra.core.models.flows.quota.Quota;
 import io.kestra.core.models.flows.sla.SLA;
 import io.kestra.core.models.tasks.WorkerSelector;
 import io.kestra.core.queues.event.BroadcastEvent;
+import io.kestra.core.runners.ReusableInputsExpander;
+
+import io.micronaut.core.annotation.Nullable;
 import io.kestra.core.serializers.JacksonMapper;
 
 /**
@@ -66,8 +69,33 @@ public interface FlowInterface extends FlowId, SoftDeletable<FlowInterface>, Ten
      */
     @JsonIgnore
     default List<Input<?>> resolvableInputs() {
+        return resolvableInputs(null);
+    }
+
+    /**
+     * Same as {@link #resolvableInputs()} but also inlines every {@code REUSABLE_INPUTS} reference (via the given
+     * {@link ReusableInputsExpander}) before flattening — use this overload on resolution paths that may encounter a
+     * reference. A {@code null} expander means "no reusable inputs to resolve" (FORM flattening only), so open-source
+     * call sites and flows without references can pass {@code null}.
+     */
+    default List<Input<?>> resolvableInputs(@Nullable ReusableInputsExpander reusableInputsExpander) {
+        return Input.expandToLeaves(inlinedInputs(reusableInputsExpander));
+    }
+
+    /**
+     * The authored inputs with every {@code REUSABLE_INPUTS} reference inlined (the block's inputs spliced in, ids
+     * prefixed by the reference id) but {@code FORM} grouping left intact — the structure the execute form renders.
+     * {@link #resolvableInputs(ReusableInputsExpander)} layers FORM flattening on top of this. A {@code null} expander
+     * returns the authored inputs unchanged.
+     */
+    default List<Input<?>> inlinedInputs(@Nullable ReusableInputsExpander reusableInputsExpander) {
         List<Input<?>> inputs = getInputs();
-        return inputs == null ? List.of() : Input.expandToLeaves(inputs);
+        if (inputs == null) {
+            return List.of();
+        }
+        return reusableInputsExpander == null
+            ? inputs
+            : reusableInputsExpander.expand(getTenantId(), getNamespace(), inputs);
     }
 
     List<Output> getOutputs();

--- a/core/src/main/java/io/kestra/core/models/flows/Input.java
+++ b/core/src/main/java/io/kestra/core/models/flows/Input.java
@@ -47,6 +47,7 @@ import java.util.Map;
         @JsonSubTypes.Type(value = YamlInput.class, name = "YAML"),
         @JsonSubTypes.Type(value = EmailInput.class, name = "EMAIL"),
         @JsonSubTypes.Type(value = FormInput.class, name = "FORM"),
+        @JsonSubTypes.Type(value = ReusableInputsInput.class, name = "REUSABLE_INPUTS"),
     }
 )
 @InputValidation

--- a/core/src/main/java/io/kestra/core/models/flows/Type.java
+++ b/core/src/main/java/io/kestra/core/models/flows/Type.java
@@ -23,7 +23,8 @@ public enum Type {
     MULTISELECT(MultiselectInput.class.getName()),
     YAML(YamlInput.class.getName()),
     EMAIL(EmailInput.class.getName()),
-    FORM(FormInput.class.getName());
+    FORM(FormInput.class.getName()),
+    REUSABLE_INPUTS(ReusableInputsInput.class.getName());
 
     private final String clsName;
 

--- a/core/src/main/java/io/kestra/core/models/flows/input/EeOnly.java
+++ b/core/src/main/java/io/kestra/core/models/flows/input/EeOnly.java
@@ -1,0 +1,16 @@
+package io.kestra.core.models.flows.input;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Marks an {@link io.kestra.core.models.flows.Input} subtype as an Enterprise Edition feature. Such inputs are
+ * registered in the polymorphic type system (so EE flows parse) but are excluded from the open-source flow JSON
+ * schema, so the open-source editor neither proposes nor validates them. The EE schema generator includes them.
+ */
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface EeOnly {
+}

--- a/core/src/main/java/io/kestra/core/models/flows/input/ReusableInputsInput.java
+++ b/core/src/main/java/io/kestra/core/models/flows/input/ReusableInputsInput.java
@@ -1,0 +1,53 @@
+package io.kestra.core.models.flows.input;
+
+import io.kestra.core.models.flows.Input;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.ConstraintViolationException;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+/**
+ * References a reusable inputs block defined at the namespace (or tenant) level. Before an execution
+ * starts the reference is replaced by a {@link FormInput} carrying the block's inputs as children, so
+ * the children resolve under the reference id as a nested path (e.g. {@code {{ inputs.myRef.anInput }}}),
+ * exactly like a hand-written {@code FORM}.
+ *
+ * <p>This is an Enterprise Edition feature: the block storage and resolution live in EE. The type is
+ * registered here only because the {@code type} discriminator is a closed {@link io.kestra.core.models.flows.Type}
+ * enum; the open-source build cannot resolve it (the default expander errors) and it is hidden from the
+ * open-source flow schema.
+ */
+@SuperBuilder
+@Getter
+@NoArgsConstructor
+@EeOnly
+public class ReusableInputsInput extends Input<Void> {
+    @Schema(
+        title = "The id of the reusable inputs block to reference."
+    )
+    @NotNull
+    @NotBlank
+    private String ref;
+
+    @Schema(
+        title = "The namespace where the reusable inputs block is defined.",
+        description = "Optional, defaults to the flow's namespace. Resolution walks the namespace hierarchy, " +
+            "so a block defined in a parent namespace is usable from its child namespaces."
+    )
+    private String namespace;
+
+    @Schema(
+        title = "Pin a specific revision of the reusable inputs block.",
+        description = "Optional, defaults to the latest revision."
+    )
+    private Integer revision;
+
+    @Override
+    public void validate(Void input) throws ConstraintViolationException {
+        // no-op: a REUSABLE_INPUTS reference is a structural wrapper, replaced by its referenced block before resolution
+    }
+}

--- a/core/src/main/java/io/kestra/core/runners/DisabledReusableInputsExpander.java
+++ b/core/src/main/java/io/kestra/core/runners/DisabledReusableInputsExpander.java
@@ -1,0 +1,23 @@
+package io.kestra.core.runners;
+
+import java.util.List;
+
+import io.kestra.core.models.flows.Input;
+import io.kestra.core.models.flows.input.ReusableInputsInput;
+
+import jakarta.inject.Singleton;
+
+/**
+ * Open-source default: reusable inputs are an Enterprise Edition feature, so any attempt to resolve a
+ * {@code REUSABLE_INPUTS} reference fails. The EE build replaces this with a store-backed implementation.
+ */
+@Singleton
+public class DisabledReusableInputsExpander implements ReusableInputsExpander {
+    @Override
+    public List<Input<?>> resolve(String tenantId, String flowNamespace, ReusableInputsInput input, List<String> parentPath) {
+        throw new IllegalArgumentException(
+            "Reusable inputs require Kestra Enterprise Edition (input '" + input.getId() +
+                "' references reusable inputs '" + input.getRef() + "')."
+        );
+    }
+}

--- a/core/src/main/java/io/kestra/core/runners/FlowInputOutput.java
+++ b/core/src/main/java/io/kestra/core/runners/FlowInputOutput.java
@@ -63,15 +63,18 @@ public class FlowInputOutput {
     private final StorageInterface storageInterface;
     private final Optional<String> secretKey;
     private final Provider<RunContextFactory> runContextFactory; // Lazy init: avoid circular dependency error.
+    private final ReusableInputsExpander reusableInputsExpander;
 
     @Inject
     public FlowInputOutput(
         StorageInterface storageInterface,
         Provider<RunContextFactory> runContextFactory,
-        EncryptionConfig encryptionConfig) {
+        EncryptionConfig encryptionConfig,
+        ReusableInputsExpander reusableInputsExpander) {
         this.storageInterface = storageInterface;
         this.runContextFactory = runContextFactory;
         this.secretKey = encryptionConfig.asOptional();
+        this.reusableInputsExpander = reusableInputsExpander;
     }
 
     /**
@@ -140,8 +143,8 @@ public class FlowInputOutput {
     }
 
     private Mono<Map<String, Object>> readData(List<Input<?>> rawInputs, Execution execution, Publisher<CompletedPart> data, boolean uploadFiles) {
-        // Expand FORM inputs so FILE part matching works against dotted leaf ids.
-        final List<Input<?>> inputs = Input.expandToLeaves(rawInputs);
+        // Inline reusable-inputs references, then flatten FORMs so FILE part matching works against dotted leaf ids.
+        final List<Input<?>> inputs = Input.expandToLeaves(reusableInputsExpander.expand(execution.getTenantId(), execution.getNamespace(), rawInputs));
         return Flux.from(data)
             .publishOn(Schedulers.boundedElastic()).<Map.Entry<String, String>> handle((input, sink) ->
             {
@@ -283,9 +286,9 @@ public class FlowInputOutput {
             return Collections.emptyList();
         }
 
-        // Expand FORM inputs into dotted-id leaves so resolution runs on a flat list and the nested
-        // payload reassembles via flattenToNestedMap. Idempotent on already-expanded leaves.
-        final List<Input<?>> leafInputs = Input.expandToLeaves(inputs);
+        // Inline reusable-inputs references, then flatten FORMs into dotted-id leaves so resolution runs on a flat
+        // list and the nested payload reassembles via flattenToNestedMap. Idempotent on leaves.
+        final List<Input<?>> leafInputs = Input.expandToLeaves(reusableInputsExpander.expand(execution.getTenantId(), execution.getNamespace(), inputs));
 
         final Map<String, ResolvableInput> resolvableInputMap = Collections.unmodifiableMap(
             leafInputs.stream()
@@ -419,7 +422,7 @@ public class FlowInputOutput {
             case JSON, YAML -> resolveDefaultPropertyAs(input, renderer, Object.class);
             case ARRAY -> resolveDefaultPropertyAsList(input, renderer, Object.class);
             case MULTISELECT -> resolveDefaultPropertyAsList(input, renderer, String.class);
-            case FORM -> throw new IllegalStateException("FORM inputs must be expanded before resolution");
+            case FORM, REUSABLE_INPUTS -> throw new IllegalStateException("FORM and REUSABLE_INPUTS inputs must be expanded before resolution");
         };
     }
 
@@ -453,7 +456,7 @@ public class FlowInputOutput {
         // otherwise cause an exception if a Pebble expression is involved.
         // FORM inputs are expanded to dotted leaves first, and defaults are injected into the flat map
         // before nesting so they end up under the form key (e.g. inputs.environment.region).
-        List<Input<?>> inputs = flow == null ? List.of() : flow.resolvableInputs();
+        List<Input<?>> inputs = flow == null ? List.of() : flow.resolvableInputs(reusableInputsExpander);
         for (Input<?> input : inputs) {
             if (input.getDefaults() != null && !flatInputs.containsKey(input.getId())) {
                 flatInputs.put(input.getId(), null);
@@ -594,7 +597,7 @@ public class FlowInputOutput {
                         yield asList;
                     }
                 }
-                case FORM -> throw new IllegalStateException("FORM inputs must be expanded before resolution");
+                case FORM, REUSABLE_INPUTS -> throw new IllegalStateException("FORM and REUSABLE_INPUTS inputs must be expanded before resolution");
             };
         } catch (IllegalArgumentException | ConstraintViolationException e) {
             throw e;

--- a/core/src/main/java/io/kestra/core/runners/ReusableInputsExpander.java
+++ b/core/src/main/java/io/kestra/core/runners/ReusableInputsExpander.java
@@ -1,0 +1,90 @@
+package io.kestra.core.runners;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+
+import io.kestra.core.models.flows.Input;
+import io.kestra.core.models.flows.input.FormInput;
+import io.kestra.core.models.flows.input.ReusableInputsInput;
+import io.kestra.core.serializers.JacksonMapper;
+
+/**
+ * Resolves a {@link ReusableInputsInput} reference into the referenced block's inputs, inlined into the flow as if
+ * the block were copy-pasted: each input's id is prefixed with the reference id, so children resolve as
+ * {@code {{ inputs.<refId>.<childId> }}}. Inlining (rather than wrapping in a single FORM) lets a block contain a
+ * {@code FORM} of its own, since the spliced inputs are flattened by the normal input-resolution machinery.
+ *
+ * <p>A reference may also sit inside a flow's {@code FORM} input; inlining recurses into FORM children, and the block's
+ * self-references are scoped to their full runtime path (e.g. {@code inputs.<form>.<refId>...}).
+ *
+ * <p>This is an Enterprise Edition concern: the open-source default ({@code DisabledReusableInputsExpander}) errors, and
+ * the EE implementation looks the block up from its namespace/tenant-scoped store, walking the namespace hierarchy.
+ */
+public interface ReusableInputsExpander {
+    /**
+     * Load-bearing signature kept for callers that resolve a top-level reference; delegates to the path-aware overload
+     * with no enclosing FORM.
+     */
+    default List<Input<?>> resolve(String tenantId, String flowNamespace, ReusableInputsInput input) {
+        return resolve(tenantId, flowNamespace, input, List.of());
+    }
+
+    /**
+     * @param tenantId      the tenant of the flow being executed
+     * @param flowNamespace the namespace of the flow, used as the default when the reference omits one
+     * @param input         the reference to resolve
+     * @param parentPath    ids of the enclosing {@code FORM}(s), root&rarr;leaf; empty at the flow root. Used to scope the
+     *                      inlined block's self-references to their full runtime path when the reference is nested in a
+     *                      FORM (the spliced ids stay FORM-relative, since {@link Input#expandToLeaves} adds the FORM
+     *                      prefix).
+     * @return the block's inputs, spliced into the flow with each id prefixed by {@code input.getId() + "."}
+     */
+    List<Input<?>> resolve(String tenantId, String flowNamespace, ReusableInputsInput input, List<String> parentPath);
+
+    /**
+     * Inlines every {@link ReusableInputsInput} reference in {@code inputs} — at the top level or nested inside a
+     * {@code FORM} — via {@link #resolve}; other inputs pass through unchanged. Returns the list untouched when it holds
+     * no reference (directly or in a FORM), so flows without reusable inputs never hit the store. This is the
+     * reusable-inputs counterpart of {@link Input#expandToLeaves} — the single place the inlining happens, called from
+     * {@code FlowInterface.resolvableInputs(expander)} and the input-resolution paths.
+     */
+    default List<Input<?>> expand(String tenantId, String flowNamespace, List<Input<?>> inputs) {
+        return expandInternal(tenantId, flowNamespace, inputs, List.of());
+    }
+
+    private List<Input<?>> expandInternal(String tenantId, String flowNamespace, List<Input<?>> inputs, List<String> parentPath) {
+        if (inputs == null || !containsReusable(inputs)) {
+            return inputs;
+        }
+
+        return inputs.stream()
+            .flatMap(input -> {
+                if (input instanceof ReusableInputsInput reusable) {
+                    return resolve(tenantId, flowNamespace, reusable, parentPath).stream();
+                }
+                if (input instanceof FormInput form && containsReusable(form.getInputs())) {
+                    List<String> childPath = new ArrayList<>(parentPath);
+                    childPath.add(form.getId());
+                    List<Input<?>> expandedChildren = expandInternal(tenantId, flowNamespace, form.getInputs(), childPath);
+                    return Stream.<Input<?>>of(withFormInputs(form, expandedChildren));
+                }
+                return Stream.<Input<?>>of(input);
+            })
+            .toList();
+    }
+
+    private static boolean containsReusable(List<Input<?>> inputs) {
+        return inputs != null && inputs.stream().anyMatch(input ->
+            input instanceof ReusableInputsInput
+                || (input instanceof FormInput form && containsReusable(form.getInputs())));
+    }
+
+    /** Re-creates a {@code FORM} with new children via a Jackson round-trip ({@code FormInput} has no {@code toBuilder}). */
+    private static FormInput withFormInputs(FormInput form, List<Input<?>> newInputs) {
+        Map<String, Object> map = JacksonMapper.toMap(form);
+        map.put("inputs", newInputs);
+        return (FormInput) JacksonMapper.toMap(map, Input.class);
+    }
+}

--- a/core/src/main/java/io/kestra/core/runners/RunContextFactory.java
+++ b/core/src/main/java/io/kestra/core/runners/RunContextFactory.java
@@ -16,6 +16,7 @@ import io.kestra.core.metrics.MetricRegistry;
 import io.kestra.core.models.executions.Execution;
 import io.kestra.core.models.executions.TaskRun;
 import io.kestra.core.models.flows.FlowInterface;
+import io.kestra.core.models.flows.Input;
 import io.kestra.core.models.flows.Type;
 import io.kestra.core.models.property.PropertyContext;
 import io.kestra.core.models.tasks.Task;
@@ -88,6 +89,9 @@ public class RunContextFactory {
 
     @Inject
     private Provider<RunContextInitializer> runContextInitializerProvider;
+
+    @Inject
+    private Provider<ReusableInputsExpander> reusableInputsExpanderProvider;
 
     // hacky
     public RunContextInitializer initializer() {
@@ -254,10 +258,11 @@ public class RunContextFactory {
             return Collections.emptyList();
         }
 
-        // FORM inputs are expanded to dotted leaves so a SECRET grouped under a form is masked by its dotted path.
-        return flow.resolvableInputs().stream()
+        // Use the expander so that REUSABLE_INPUTS-referenced SECRETs are inlined alongside FORM-nested ones.
+        // On OSS the expander is a no-op when no REUSABLE_INPUTS are present, so FORM-nested SECRETs still work.
+        return flow.resolvableInputs(reusableInputsExpanderProvider.get()).stream()
             .filter(input -> input.getType() == Type.SECRET)
-            .map(input -> input.getId()).toList();
+            .map(Input::getId).toList();
     }
 
     private DefaultRunContext.Builder newBuilder() {

--- a/core/src/main/java/io/kestra/core/runners/RunVariables.java
+++ b/core/src/main/java/io/kestra/core/runners/RunVariables.java
@@ -12,9 +12,7 @@ import io.kestra.core.models.executions.LoopRun;
 import io.kestra.core.models.executions.TaskRun;
 import io.kestra.core.models.flows.FlowInterface;
 import io.kestra.core.models.flows.GenericFlow;
-import io.kestra.core.models.flows.Input;
 import io.kestra.core.models.flows.State;
-import io.kestra.core.models.flows.input.SecretInput;
 import io.kestra.core.models.property.PropertyContext;
 import io.kestra.core.models.tasks.Task;
 import io.kestra.core.models.triggers.AbstractTrigger;
@@ -420,15 +418,10 @@ public final class RunVariables {
                 Map<String, Object> inputs = this.inputs == null ? new HashMap<>() : new HashMap<>(this.inputs);
                 if (realExecution.getInputs() != null) {
                     inputs.putAll(realExecution.getInputs());
-                    if (decryptVariables && flow != null && flow.getInputs() != null) {
-                        // if some inputs are of type secret, we decode them
+                    if (decryptVariables && !ListUtils.isEmpty(secretInputs)) {
                         final Secret secret = new Secret(secretKey, logger);
-                        // Expand FORM inputs so SECRET children are decoded by their dotted path; decodeInput already
-                        // navigates the nested inputs map for dotted ids.
-                        for (Input<?> input : flow.resolvableInputs()) {
-                            if (input instanceof SecretInput) {
-                                decodeInput(secret, input.getId(), inputs);
-                            }
+                        for (String secretId : secretInputs) {
+                            decodeInput(secret, secretId, inputs);
                         }
                     }
                 }

--- a/core/src/main/java/io/kestra/core/utils/PebbleUtil.java
+++ b/core/src/main/java/io/kestra/core/utils/PebbleUtil.java
@@ -3,6 +3,11 @@ package io.kestra.core.utils;
 import io.pebbletemplates.pebble.lexer.Syntax;
 
 import java.util.List;
+import java.util.function.UnaryOperator;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 /**
  * Utility for Pebble template delimiter detection.
@@ -19,6 +24,14 @@ public final class PebbleUtil {
     private static final List<String> CLOSING_BLOCK_DELIMITERS = List.of(
         DEFAULT_SYNTAX.getPrintCloseDelimiter(),
         DEFAULT_SYNTAX.getExecuteCloseDelimiter()
+    );
+
+    /** Matches a full Pebble block ({@code {{ ... }}} or {@code {% ... %}}), built from the delimiter pairs above. */
+    private static final Pattern BLOCK_PATTERN = Pattern.compile(
+        IntStream.range(0, OPENING_BLOCK_DELIMITERS.size())
+            .mapToObj(i -> Pattern.quote(OPENING_BLOCK_DELIMITERS.get(i)) + ".*?" + Pattern.quote(CLOSING_BLOCK_DELIMITERS.get(i)))
+            .collect(Collectors.joining("|")),
+        Pattern.DOTALL
     );
 
     private PebbleUtil() {}
@@ -56,5 +69,19 @@ public final class PebbleUtil {
      */
     public static boolean endsWithClosingBlockDelimiter(String value) {
         return CLOSING_BLOCK_DELIMITERS.stream().anyMatch(value::endsWith);
+    }
+
+    /**
+     * Applies {@code transform} to the content of each Pebble block ({@code {{ ... }}} or {@code {% ... %}}) found in
+     * {@code value}, leaving any text outside a block untouched.
+     */
+    public static String replaceInBlock(String value, UnaryOperator<String> transform) {
+        Matcher matcher = BLOCK_PATTERN.matcher(value);
+        StringBuilder out = new StringBuilder();
+        while (matcher.find()) {
+            matcher.appendReplacement(out, Matcher.quoteReplacement(transform.apply(matcher.group())));
+        }
+        matcher.appendTail(out);
+        return out.toString();
     }
 }

--- a/core/src/main/java/io/kestra/core/validations/validator/FlowValidator.java
+++ b/core/src/main/java/io/kestra/core/validations/validator/FlowValidator.java
@@ -3,6 +3,8 @@ package io.kestra.core.validations.validator;
 import io.kestra.core.models.flows.Data;
 import io.kestra.core.models.flows.Flow;
 import io.kestra.core.models.flows.Input;
+import io.kestra.core.models.flows.input.EeOnly;
+import io.kestra.core.models.flows.input.FormInput;
 import io.kestra.core.models.tasks.ExecutableTask;
 import io.kestra.core.models.tasks.Task;
 import io.kestra.core.services.NamespaceService;
@@ -97,6 +99,10 @@ public class FlowValidator implements ConstraintValidator<FlowValidation, Flow> 
         }
         checkFlowInputsDependencyGraph(value, violations);
 
+        // EE-only input types (e.g. REUSABLE_INPUTS) cannot run on the open-source edition, so reject a flow
+        // declaring one at save/validation time rather than letting it fail only at execution. EE allows them.
+        violations.addAll(eeOnlyInputsViolations(value.getInputs()));
+
         // output unique name
         duplicateIds = getDuplicates(ListUtils.emptyOnNull(value.getOutputs()).stream().map(Data::getId).toList());
         if (!duplicateIds.isEmpty()) {
@@ -175,6 +181,28 @@ public class FlowValidator implements ConstraintValidator<FlowValidation, Flow> 
         return allTasks.stream().filter(task -> task.getAssets() != null)
             .map(taskWithAssets -> "Task '" + taskWithAssets.getId() + "' can't have any `assets` because assets are only available in Enterprise Edition.")
             .toList();
+    }
+
+    /**
+     * Inputs whose type is annotated {@link EeOnly} (e.g. {@code REUSABLE_INPUTS}) are not available in the
+     * open-source edition, so a flow declaring one is rejected here rather than failing only at execution time.
+     * Recurses into {@code FORM} children. The Enterprise build overrides this to allow such inputs.
+     */
+    protected List<String> eeOnlyInputsViolations(List<Input<?>> inputs) {
+        List<String> violations = new ArrayList<>();
+        collectEeOnlyInputs(inputs, violations);
+        return violations;
+    }
+
+    private static void collectEeOnlyInputs(List<Input<?>> inputs, List<String> violations) {
+        for (Input<?> input : ListUtils.emptyOnNull(inputs)) {
+            if (input.getClass().isAnnotationPresent(EeOnly.class)) {
+                violations.add("Input '" + input.getId() + "' of type " + input.getType() + " is only available in Enterprise Edition.");
+            }
+            if (input instanceof FormInput form) {
+                collectEeOnlyInputs(form.getInputs(), violations);
+            }
+        }
     }
 
     private static boolean checkObjectFieldsWithPatterns(Object object, List<Pattern> patterns) {

--- a/core/src/test/java/io/kestra/core/docs/JsonSchemaGeneratorTest.java
+++ b/core/src/test/java/io/kestra/core/docs/JsonSchemaGeneratorTest.java
@@ -148,6 +148,23 @@ class JsonSchemaGeneratorTest {
         });
     }
 
+    @Test
+    void flowSchemaExcludesEeOnlyInputTypes() throws URISyntaxException {
+        Helpers.runApplicationContext((applicationContext) ->
+        {
+            JsonSchemaGenerator jsonSchemaGenerator = applicationContext.getBean(JsonSchemaGenerator.class);
+
+            String schema = jsonSchemaGenerator.schemas(Flow.class).toString();
+
+            // @EeOnly input types (e.g. REUSABLE_INPUTS) must not surface in the open-source flow schema — neither in
+            // the polymorphic anyOf/const subtype branches nor in the type/itemType enum arrays (REUSABLE_INPUTS was
+            // leaking through the latter).
+            assertThat(schema, not(containsString("REUSABLE_INPUTS")));
+            // sanity: ordinary input types are still present
+            assertThat(schema, containsString("EMAIL"));
+        });
+    }
+
     @SuppressWarnings("unchecked")
     @Test
     void task() throws URISyntaxException {

--- a/core/src/test/java/io/kestra/core/runners/DisabledReusableInputsExpanderTest.java
+++ b/core/src/test/java/io/kestra/core/runners/DisabledReusableInputsExpanderTest.java
@@ -1,0 +1,56 @@
+package io.kestra.core.runners;
+
+import java.util.List;
+
+import io.kestra.core.models.flows.Input;
+import io.kestra.core.models.flows.Type;
+import io.kestra.core.models.flows.input.ReusableInputsInput;
+import io.kestra.core.models.flows.input.StringInput;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class DisabledReusableInputsExpanderTest {
+
+    /** Reusable inputs are an Enterprise Edition feature: the open-source default errors when one is referenced. */
+    @Test
+    void erroringWhenReferencedInOpenSource() {
+        DisabledReusableInputsExpander expander = new DisabledReusableInputsExpander();
+
+        ReusableInputsInput reference = ReusableInputsInput.builder()
+            .id("myBlock").type(Type.REUSABLE_INPUTS).ref("infra_request").build();
+
+        assertThatThrownBy(() -> expander.resolve("main", "company", reference))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("Enterprise Edition");
+    }
+
+    /**
+     * {@code expand()} only touches the store-backed {@code resolve()} for actual references, so a flow with no
+     * reusable inputs returns its inputs unchanged even on open-source (never hitting the erroring default).
+     */
+    @Test
+    void expandIsANoOpWhenNoReferencePresent() {
+        DisabledReusableInputsExpander expander = new DisabledReusableInputsExpander();
+
+        List<Input<?>> inputs = List.of(StringInput.builder().id("a").type(Type.STRING).build());
+
+        assertThat(expander.expand("main", "company", inputs)).isSameAs(inputs);
+    }
+
+    /** A reference present in open-source still errors through {@code expand()} (it delegates to {@code resolve()}). */
+    @Test
+    void expandErrorsWhenAReferenceIsPresentInOpenSource() {
+        DisabledReusableInputsExpander expander = new DisabledReusableInputsExpander();
+
+        List<Input<?>> inputs = List.of(
+            ReusableInputsInput.builder().id("myBlock").type(Type.REUSABLE_INPUTS).ref("infra_request").build()
+        );
+
+        assertThatThrownBy(() -> expander.expand("main", "company", inputs))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("Enterprise Edition");
+    }
+}

--- a/core/src/test/java/io/kestra/core/runners/FlowInputOutputTest.java
+++ b/core/src/test/java/io/kestra/core/runners/FlowInputOutputTest.java
@@ -29,6 +29,7 @@ import io.kestra.core.models.flows.input.EmailInput;
 import io.kestra.core.models.flows.input.FloatInput;
 import io.kestra.core.models.flows.input.IntInput;
 import io.kestra.core.models.flows.input.MultiselectInput;
+import io.kestra.core.models.flows.input.ReusableInputsInput;
 import io.kestra.core.models.flows.input.SecretInput;
 import io.kestra.core.models.flows.input.StringInput;
 import io.kestra.core.models.flows.input.URIInput;
@@ -788,6 +789,70 @@ class FlowInputOutputTest {
         Object apiKey = ((Map<?, ?>) result.get("credentials")).get("api_key");
         assertThat(apiKey).isInstanceOf(EncryptedString.class);
         assertThat(EncryptionService.decrypt(secretKey, ((EncryptedString) apiKey).getValue())).isEqualTo(TEST_SECRET_VALUE);
+    }
+
+    @Test
+    void shouldEncryptSubmittedFormNestedSecret() throws GeneralSecurityException {
+        Flow flow = Flow.builder()
+            .id("test-flow")
+            .namespace("io.kestra.test")
+            .inputs(List.of(
+                FormInput.builder()
+                    .id("credentials")
+                    .type(Type.FORM)
+                    .inputs(List.of(
+                        SecretInput.builder()
+                            .id("api_key")
+                            .type(Type.SECRET)
+                            .required(true)
+                            .build()
+                    ))
+                    .build()
+            ))
+            .build();
+
+        Map<String, Object> result = flowInputOutput.readExecutionInputs(
+            flow, DEFAULT_TEST_EXECUTION, Map.of("credentials.api_key", "my-plaintext-secret")
+        );
+
+        Object apiKey = ((Map<?, ?>) result.get("credentials")).get("api_key");
+        assertThat(apiKey).isInstanceOf(EncryptedString.class);
+        assertThat(EncryptionService.decrypt(secretKey, ((EncryptedString) apiKey).getValue()))
+            .isEqualTo("my-plaintext-secret");
+    }
+
+    @Test
+    void shouldIncludeBothFormAndReusableRefSecretIdsInResolvableInputs() {
+        Flow flow = Flow.builder()
+            .id("test-flow")
+            .namespace("io.kestra.test")
+            .inputs(List.of(
+                FormInput.builder()
+                    .id("creds")
+                    .type(Type.FORM)
+                    .inputs(List.of(
+                        SecretInput.builder().id("token").type(Type.SECRET).required(true).build()
+                    ))
+                    .build(),
+                ReusableInputsInput.builder()
+                    .id("block")
+                    .type(Type.REUSABLE_INPUTS)
+                    .ref("my-block")
+                    .required(false)
+                    .build()
+            ))
+            .build();
+
+        // Stub expander: resolves the REUSABLE_INPUTS reference to a single SECRET child
+        ReusableInputsExpander stubExpander = (tenantId, ns, input, path) ->
+            List.of(SecretInput.builder().id(input.getId() + ".api_key").type(Type.SECRET).required(true).build());
+
+        List<String> secretIds = flow.resolvableInputs(stubExpander).stream()
+            .filter(i -> i.getType() == Type.SECRET)
+            .map(Input::getId)
+            .toList();
+
+        assertThat(secretIds).containsExactlyInAnyOrder("creds.token", "block.api_key");
     }
 
     @Test

--- a/core/src/test/java/io/kestra/core/utils/PebbleUtilTest.java
+++ b/core/src/test/java/io/kestra/core/utils/PebbleUtilTest.java
@@ -57,4 +57,27 @@ class PebbleUtilTest {
     void endsWithClosingBlockDelimiterReturnsFalse(String value) {
         assertThat(PebbleUtil.endsWithClosingBlockDelimiter(value)).isFalse();
     }
+
+    @Test
+    void replaceInBlockTransformsPrintAndExecuteBlocks() {
+        String result = PebbleUtil.replaceInBlock(
+            "prefix {{ foo }} middle {% if bar %}baz{% endif %} suffix",
+            String::toUpperCase
+        );
+        // {% ... %} blocks are matched non-greedily, so "{% if bar %}" and "{% endif %}" are separate blocks and the
+        // free text "baz" between them is untouched.
+        assertThat(result).isEqualTo("prefix {{ FOO }} middle {% IF BAR %}baz{% ENDIF %} suffix");
+    }
+
+    @Test
+    void replaceInBlockLeavesTextWithoutBlocksUnchanged() {
+        assertThat(PebbleUtil.replaceInBlock("plain text, no blocks", String::toUpperCase))
+            .isEqualTo("plain text, no blocks");
+    }
+
+    @Test
+    void replaceInBlockHandlesMultilineBlocks() {
+        assertThat(PebbleUtil.replaceInBlock("{%\n if true \n%}", block -> "X"))
+            .isEqualTo("X");
+    }
 }

--- a/core/src/test/java/io/kestra/core/validations/FlowValidationTest.java
+++ b/core/src/test/java/io/kestra/core/validations/FlowValidationTest.java
@@ -358,6 +358,28 @@ class FlowValidationTest {
     }
 
     @Test
+    void eeOnlyInputFailsValidationOnOpenSource() {
+        Flow flow = YamlParser.parse("""
+            id: test
+            namespace: unittest
+            inputs:
+              - id: cfg
+                type: REUSABLE_INPUTS
+                ref: my_block
+            tasks:
+              - id: hello
+                type: io.kestra.plugin.core.log.Log
+                message: hi
+            """, Flow.class);
+
+        Optional<ConstraintViolationException> validate = modelValidator.isValid(flow);
+
+        assertThat(validate.isPresent()).isTrue();
+        assertThat(validate.get().getMessage())
+            .contains("Input 'cfg' of type REUSABLE_INPUTS is only available in Enterprise Edition.");
+    }
+
+    @Test
     void formInputs_sameChildIdInDifferentForms_succeeds() {
         // Scoped uniqueness: a child id may repeat across different forms because the expanded paths differ.
         Flow flow = YamlParser.parse("""

--- a/ui/src/components/inputs/InputsForm.vue
+++ b/ui/src/components/inputs/InputsForm.vue
@@ -903,7 +903,11 @@
     let keyListener: ((e: KeyboardEvent) => void) | null = null
 
     // Initialization
+    // A REUSABLE_INPUTS reference is resolved server-side (the execute-form endpoint inlines it into the referenced
+    // block's inputs), so the form normally never sees the raw node. Filter it out defensively anyway, so a caller
+    // that passes un-inlined inputs renders nothing for it rather than a broken field.
     inputsMetaData.value = JSON.parse(JSON.stringify(flattenInputs(props.initialInputs)))
+        .filter((input: InputMetaData) => (input.type as string) !== "REUSABLE_INPUTS")
 
     if (props.selectedTrigger?.inputs) {
         Object.assign(inputsValues, toRaw(props.selectedTrigger.inputs))

--- a/ui/src/components/layout/Revisions.vue
+++ b/ui/src/components/layout/Revisions.vue
@@ -33,7 +33,7 @@
                                 <TrashCanOutline
                                     @mousedown.stop.prevent
                                     @click.stop.prevent="onDelete(item.value)"
-                                    v-if="item.value !== undefined && currentRevision !== revisionNumber(item.value)"
+                                    v-if="canDelete && item.value !== undefined && currentRevision !== revisionNumber(item.value)"
                                 />
                             </KsOption>
                         </KsSelect>
@@ -75,7 +75,7 @@
                                 <TrashCanOutline
                                     @mousedown.stop.prevent
                                     @click.stop.prevent="onDelete(item.value)"
-                                    v-if="item.value !== undefined && currentRevision !== revisionNumber(item.value)"
+                                    v-if="canDelete && item.value !== undefined && currentRevision !== revisionNumber(item.value)"
                                 />
                             </KsOption>
                         </KsSelect>
@@ -172,8 +172,11 @@
         lang: string,
         revisions: Revision[],
         revisionSource: (revisionNumber: number) => Promise<string | undefined>,
-        editRouteQuery?: boolean
-    }>(), {editRouteQuery: true})
+        editRouteQuery?: boolean,
+        // Whether per-revision delete is available. Flows support it (default); consumers without a
+        // delete-by-revision backend (e.g. reusable inputs) pass false to hide the delete control.
+        canDelete?: boolean
+    }>(), {editRouteQuery: true, canDelete: true})
 
     const sortedRevisions = computed(() => {
         return props.revisions.toSorted((a, b) => a.revision - b.revision)

--- a/ui/src/components/namespaces/utils/useHelpers.ts
+++ b/ui/src/components/namespaces/utils/useHelpers.ts
@@ -51,6 +51,7 @@ export const ORDER = [
     "variables",
     "plugin-defaults",
     "kv",
+    "reusable-inputs",
     "files",
     "history",
     "audit-logs",

--- a/ui/src/composables/monaco/languages/languagesConfigurator.ts
+++ b/ui/src/composables/monaco/languages/languagesConfigurator.ts
@@ -2,7 +2,7 @@ import {computed} from "vue"
 import {useI18n} from "vue-i18n"
 import type {Router} from "vue-router"
 import {editor} from "monaco-editor/esm/vs/editor/editor.api"
-import {YamlLanguageConfigurator} from "./yamlLanguageConfigurator"
+import {YamlLanguageConfigurator} from "override/composables/monaco/languages/yamlLanguageConfigurator"
 import {PebbleLanguageConfigurator} from "./pebbleLanguageConfigurator"
 import {FlowAutoCompletion} from "override/services/flowAutoCompletionProvider"
 import {YamlAutoCompletion} from "../../../services/autoCompletionProvider"
@@ -24,8 +24,9 @@ export default async function configure(
     const mcpStore = useMcpStore()
     let yamlAutocompletion
     if (language === "yaml") {
-        if (domain === "flow" || domain === "testsuites") {
-            // flow completion seems to work fine for testsuites, quickwin
+        if (domain === "flow" || domain === "testsuites" || domain === "reusableinputs") {
+            // flow completion works for testsuites and the reusable-inputs block editor (so `{{ inputs.<sibling> }}`
+            // suggests the block's own inputs); the reusable-inputs-only providers gate on the model URI anyway.
             yamlAutocompletion = new FlowAutoCompletion(flowStore, pluginsStore, namespacesStore, mcpStore)
         } else {
             yamlAutocompletion = new YamlAutoCompletion()

--- a/ui/src/composables/monaco/languages/yamlLanguageConfigurator.ts
+++ b/ui/src/composables/monaco/languages/yamlLanguageConfigurator.ts
@@ -115,9 +115,9 @@ function filterMissingRequiredTaskProperties({
 }
 
 export class YamlLanguageConfigurator extends AbstractLanguageConfigurator {
-    private readonly yamlAutoCompletionObject: YamlAutoCompletion
-    private readonly router?: Router
-    private readonly flowStore?: ReturnType<typeof useFlowStore>
+    protected readonly yamlAutoCompletionObject: YamlAutoCompletion
+    protected readonly router?: Router
+    protected readonly flowStore?: ReturnType<typeof useFlowStore>
 
     constructor(yamlAutoCompletion: YamlAutoCompletion, router?: Router, flowStore?: ReturnType<typeof useFlowStore>) {
         super("yaml")
@@ -637,8 +637,17 @@ export class YamlLanguageConfigurator extends AbstractLanguageConfigurator {
         )
 
         this.registerSubflowLinks(autoCompletionProviders)
+        this.registerEditionProviders(autoCompletionProviders, t)
 
         return autoCompletionProviders
+    }
+
+    /**
+     * Seam for edition-specific Monaco providers (hover/definition/etc.). Empty in open-source; the Enterprise
+     * {@link YamlLanguageConfigurator} subclass overrides it to register the reusable-inputs flow-editor providers.
+     */
+    protected registerEditionProviders(_disposables: IDisposable[], _t: ReturnType<typeof useI18n>["t"]): void {
+        // no-op in open-source
     }
 
     private registerEditorArtifacts(t: ReturnType<typeof useI18n>["t"]): IDisposable[] {

--- a/ui/src/override/composables/monaco/languages/yamlLanguageConfigurator.ts
+++ b/ui/src/override/composables/monaco/languages/yamlLanguageConfigurator.ts
@@ -1,0 +1,3 @@
+// Open-source: the base YAML language configurator (no edition-specific providers). The Enterprise build supplies its
+// own `override/composables/monaco/languages/yamlLanguageConfigurator` that subclasses this to add reusable-inputs.
+export {YamlLanguageConfigurator} from "../../../../composables/monaco/languages/yamlLanguageConfigurator"

--- a/webserver/src/main/java/io/kestra/mcp/FlowToolSchemaMapper.java
+++ b/webserver/src/main/java/io/kestra/mcp/FlowToolSchemaMapper.java
@@ -335,7 +335,7 @@ public class FlowToolSchemaMapper {
             case FLOAT -> "number";
             case BOOL -> "boolean";
             case ARRAY, MULTISELECT -> "array";
-            case FORM -> throw new IllegalStateException("FORM inputs must be expanded before resolution");
+            case FORM, REUSABLE_INPUTS -> throw new IllegalStateException("FORM and REUSABLE_INPUTS inputs must be expanded before resolution");
         };
     }
 }

--- a/webserver/src/main/java/io/kestra/webserver/controllers/api/ExecutionController.java
+++ b/webserver/src/main/java/io/kestra/webserver/controllers/api/ExecutionController.java
@@ -166,6 +166,9 @@ public class ExecutionController {
     private FlowInputOutput flowInputOutput;
 
     @Inject
+    private io.kestra.core.runners.ReusableInputsExpander reusableInputsExpander;
+
+    @Inject
     private StorageInterface storageInterface;
 
     @Inject
@@ -2330,7 +2333,8 @@ public class ExecutionController {
         Execution execution = executionRepository.findById(tenantService.resolveTenant(), executionId)
             .orElseThrow(() -> new io.kestra.core.exceptions.NotFoundException("Execution %s not found when fetching flow".formatted(executionId)));
 
-        return FlowForExecution.of(flowRepository.findByExecutionWithoutAcl(execution));
+        Flow flow = flowRepository.findByExecutionWithoutAcl(execution);
+        return FlowForExecution.of(flow, reusableInputsExpander);
     }
 
     @ExecuteOn(TaskExecutors.IO)
@@ -2341,7 +2345,8 @@ public class ExecutionController {
         @Parameter(description = "The flow id") @PathVariable String flowId,
         @Parameter(description = "The flow revision") @Nullable Integer revision) {
 
-        return FlowForExecution.of(flowRepository.findByIdWithoutAcl(tenantService.resolveTenant(), namespace, flowId, Optional.ofNullable(revision)).orElseThrow());
+        Flow flow = flowRepository.findByIdWithoutAcl(tenantService.resolveTenant(), namespace, flowId, Optional.ofNullable(revision)).orElseThrow();
+        return FlowForExecution.of(flow, reusableInputsExpander);
     }
 
     @ExecuteOn(TaskExecutors.IO)

--- a/webserver/src/main/java/io/kestra/webserver/controllers/api/PluginController.java
+++ b/webserver/src/main/java/io/kestra/webserver/controllers/api/PluginController.java
@@ -11,6 +11,7 @@ import io.kestra.core.exceptions.NotFoundException;
 import io.kestra.core.models.QueryFilter;
 import io.kestra.core.models.flows.Input;
 import io.kestra.core.models.flows.Type;
+import io.kestra.core.models.flows.input.EeOnly;
 import io.kestra.core.models.tasks.FlowableTask;
 import io.kestra.core.models.triggers.AbstractTrigger;
 import io.kestra.core.models.ui.PluginDistribution;
@@ -110,6 +111,8 @@ public class PluginController {
     )
     public List<InputType> getAllInputTypes() throws ClassNotFoundException {
         return Stream.of(Type.values())
+            // exclude edition-restricted (@EeOnly) input types (e.g. REUSABLE_INPUTS) from the open-source listing
+            .filter(type -> !type.cls().isAnnotationPresent(EeOnly.class))
             .map(throwFunction(type -> new InputType(type.name(), type.cls().getName())))
             .toList();
     }


### PR DESCRIPTION
Open-source primitives for reusable inputs (the Enterprise feature that stores and resolves the definitions lives in the companion kestra-ee PR). Kept in OSS because the input `type` is a core enum used as Jackson's discriminator, so the type must be registered here for any flow to parse `type: REUSABLE_INPUTS`.

- New `REUSABLE_INPUTS` input type referencing a definition by `ref` (+ optional `namespace`/`revision`). Marked `@EeOnly` so it is excluded from the OSS-served flow schema — the open-source editor neither proposes nor flags it, while the EE-served schema includes it.
- `ReusableInputsExpander` interface with an `expand()` inlining primitive (the reusable-inputs counterpart of `Input.expandToLeaves`). The OSS default errors ("requires Enterprise Edition"); the EE build replaces it with a store-backed implementation.
- `FlowInterface.resolvableInputs(expander)` / `inlinedInputs(expander)` centralise reusable-inputs inlining alongside FORM flattening, so resolution paths inline references before flattening to dotted leaves; `FlowForExecution.of(flow, expander)` makes the execution form render and submit the resolved inputs under the reference id.
- `FlowValidator` rejects `@EeOnly` inputs at validation time on open-source (the EE build overrides to allow them), so a `REUSABLE_INPUTS` flow can't be saved on OSS.
- Editor: a generic `registerEditionProviders()` seam on the YAML language configurator (swapped per-edition via the `override` alias) lets the EE build attach the reusable-inputs hover / go-to-definition without shipping any reusable-inputs UI code in open-source; plus reusable-inputs sibling-input autocompletion in the definition editor. The execution form also skips an un-inlined reference node defensively.
- Docs: AGENTS.md now requires i18n for all user-facing UI strings.

Companion EE PR: https://github.com/kestra-io/kestra-ee/pull/8926
