### PR TITLE
fix(namespaces): make namespace file reads resilient to index/storage drift

### DIFF
--- a/core/src/main/java/io/kestra/core/storages/InternalNamespace.java
+++ b/core/src/main/java/io/kestra/core/storages/InternalNamespace.java
@@ -287,8 +287,32 @@ public class InternalNamespace implements Namespace {
         // Throw if file not found OR if it's deleted
         NamespaceFileMetadata namespaceFileMetadata = findByPath(normalizedPath, version).orElseThrow(() -> fileNotFound(normalizedPath, version));
 
-        Path namespaceFilePath = NamespaceFile.of(namespace, normalizedPath, namespaceFileMetadata.getVersion()).storagePath();
-        return storage.get(tenant, namespace, namespaceFilePath.toUri());
+        return storage.get(tenant, namespace, resolveExistingRevisionUri(normalizedPath, namespaceFileMetadata.getVersion()));
+    }
+
+    /**
+     * Resolves the storage URI for the given revision of a namespace file, falling back to the most
+     * recent lower revision whose object still exists when the metadata index and the storage have
+     * drifted. This keeps reads resilient to an index entry pointing at a revision whose object was
+     * removed out-of-band (e.g. an object deleted/replaced directly, or a migration that left the
+     * index ahead of storage), serving the latest available revision instead of failing with a 404.
+     *
+     * @throws FileNotFoundException if no revision down to the first has a backing object in storage.
+     */
+    private URI resolveExistingRevisionUri(Path normalizedPath, int revision) throws IOException {
+        for (int candidate = revision; candidate >= 1; candidate--) {
+            URI uri = NamespaceFile.of(namespace, normalizedPath, candidate).storagePath().toUri();
+            if (storage.exists(tenant, namespace, uri)) {
+                if (candidate != revision) {
+                    logger.warn(
+                        "Namespace file '{}' revision {} is missing from storage in namespace '{}' (metadata/storage drift); serving the latest available revision {} instead.",
+                        normalizedPath, revision, namespace, candidate
+                    );
+                }
+                return uri;
+            }
+        }
+        throw fileNotFound(normalizedPath, revision);
     }
 
     @Override
@@ -491,8 +515,10 @@ public class InternalNamespace implements Namespace {
 
     @Override
     public boolean purge(NamespaceFile namespaceFile) throws IOException {
-        storage.delete(tenant, namespace, namespaceFile.storagePath().toUri());
+        // Purge the metadata entry before removing the object, so an interrupted purge leaves a
+        // reclaimable orphan object rather than a dangling index entry that would 404 on read.
         namespaceFileMetadataRepository.purge(List.of(NamespaceFileMetadata.of(tenant, namespaceFile)));
+        storage.delete(tenant, namespace, namespaceFile.storagePath().toUri());
         return true;
     }
 

--- a/core/src/test/java/io/kestra/core/storages/InternalNamespaceTest.java
+++ b/core/src/test/java/io/kestra/core/storages/InternalNamespaceTest.java
@@ -1,8 +1,10 @@
 package io.kestra.core.storages;
 
 import java.io.ByteArrayInputStream;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.file.Path;
 import java.util.List;
@@ -285,5 +287,43 @@ class InternalNamespaceTest {
         // Then
         assertThat(directory.isDirectory()).isTrue();
         assertThat(directory.uri().toString()).matches(uri -> uri.endsWith("my-directory/"));
+    }
+
+    @Test
+    void shouldServeLatestAvailableRevisionWhenLatestRevisionObjectIsMissing() throws IOException, URISyntaxException {
+        // Given a file with two revisions whose latest-revision object has been removed from storage
+        // out-of-band, leaving the metadata index ahead of storage (the drift that produced 404s).
+        final String namespaceId = TestsUtils.randomNamespace();
+        final InternalNamespace namespace = new InternalNamespace(log, MAIN_TENANT, namespaceId, storageInterface, namespaceFileMetadataRepository);
+
+        namespace.putFile(Path.of("/a.txt"), new ByteArrayInputStream("v1".getBytes()));
+        namespace.putFile(Path.of("/a.txt"), new ByteArrayInputStream("v2".getBytes())); // OVERWRITE -> revision 2
+
+        URI latestRevisionUri = NamespaceFile.of(namespaceId, Path.of("a.txt"), 2).storagePath().toUri();
+        storageInterface.delete(MAIN_TENANT, namespaceId, latestRevisionUri);
+
+        // When
+        String content;
+        try (InputStream is = namespace.getFileContent(Path.of("/a.txt"), null)) {
+            content = new String(is.readAllBytes());
+        }
+
+        // Then it falls back to the latest revision still present in storage instead of throwing
+        assertThat(content).isEqualTo("v1");
+    }
+
+    @Test
+    void shouldThrowWhenNoRevisionObjectExistsInStorage() throws IOException, URISyntaxException {
+        // Given a file whose every revision object has been removed from storage
+        final String namespaceId = TestsUtils.randomNamespace();
+        final InternalNamespace namespace = new InternalNamespace(log, MAIN_TENANT, namespaceId, storageInterface, namespaceFileMetadataRepository);
+
+        namespace.putFile(Path.of("/a.txt"), new ByteArrayInputStream("v1".getBytes()));
+        namespace.putFile(Path.of("/a.txt"), new ByteArrayInputStream("v2".getBytes())); // OVERWRITE -> revision 2
+        storageInterface.delete(MAIN_TENANT, namespaceId, NamespaceFile.of(namespaceId, Path.of("a.txt"), 1).storagePath().toUri());
+        storageInterface.delete(MAIN_TENANT, namespaceId, NamespaceFile.of(namespaceId, Path.of("a.txt"), 2).storagePath().toUri());
+
+        // When / Then
+        Assertions.assertThrows(FileNotFoundException.class, () -> namespace.getFileContent(Path.of("/a.txt"), null));
     }
 }


### PR DESCRIPTION
When the metadata index pointed at a revision whose storage object no longer existed, reads failed with a hard 404. Now getFileContent falls back to the most recent lower revision present in storage, and purge() deletes metadata before the object so an interrupted purge can't strand the index ahead of storage.