### PR TITLE
test(flows): fix v1.0.x :core:compileTestJava — add 3-arg builder overload

### DIFF
--- a/core/src/test/java/io/kestra/core/repositories/AbstractFlowRepositoryTest.java
+++ b/core/src/test/java/io/kestra/core/repositories/AbstractFlowRepositoryTest.java
@@ -94,6 +94,14 @@ public abstract class AbstractFlowRepositoryTest {
             .tasks(Collections.singletonList(Return.builder().id(taskId).type(Return.class.getName()).format(Property.ofValue(TEST_FLOW_ID)).build()));
     }
 
+    private static FlowWithSource.FlowWithSourceBuilder<?, ?> builder(String tenantId, String flowId, String taskId) {
+        return FlowWithSource.builder()
+            .tenantId(tenantId)
+            .id(flowId)
+            .namespace(TEST_NAMESPACE)
+            .tasks(Collections.singletonList(Return.builder().id(taskId).type(Return.class.getName()).format(Property.ofValue(TEST_FLOW_ID)).build()));
+    }
+
     @ParameterizedTest
     @MethodSource("filterCombinations")
     void should_find_all(QueryFilter filter) {


### PR DESCRIPTION
## What
`releases/v1.0.x` currently **fails to compile** `:core:compileTestJava`:

```
core/src/test/java/io/kestra/core/repositories/AbstractFlowRepositoryTest.java:890: error: no suitable method found for builder(String,String,String)
> Task :core:compileTestJava FAILED
```

The `findSourceCode` test backported in `ab74ed16d1` calls `builder(tenant, flowId, taskId)`, but on this branch `AbstractFlowRepositoryTest` only defined `builder()` and `builder(String flowId, String taskId)` — no 3-arg overload.

## Fix
Add the missing `builder(String tenantId, String flowId, String taskId)` overload (mirroring `develop`).

## Why it matters
This breaks the whole `releases/v1.0.x` branch and blocks every EE v1.0.x PR (the EE build compiles OSS test sources). Verified locally: `./gradlew :core:compileTestJava` → BUILD SUCCESSFUL.

Test-only change.