### PR TITLE
fix(core): replace O(2^N) cycle detection in DAG with iterative DFS

### DIFF
--- a/core/src/main/java/io/kestra/plugin/core/flow/Dag.java
+++ b/core/src/main/java/io/kestra/plugin/core/flow/Dag.java
@@ -215,7 +215,8 @@ public class Dag extends Task implements FlowableTask<VoidOutput> {
         Map<String, List<String>> depMap = taskDepends.stream()
             .collect(Collectors.toMap(
                 t -> t.getTask().getId(),
-                t -> t.getDependsOn() != null ? t.getDependsOn() : List.of()
+                t -> t.getDependsOn() != null ? t.getDependsOn() : List.of(),
+                (first, second) -> first
             ));
 
         ArrayList<String> cyclicDependency = new ArrayList<>();

--- a/core/src/main/java/io/kestra/plugin/core/flow/Dag.java
+++ b/core/src/main/java/io/kestra/plugin/core/flow/Dag.java
@@ -1,6 +1,7 @@
 package io.kestra.plugin.core.flow;
 
 import java.util.*;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -211,40 +212,40 @@ public class Dag extends Task implements FlowableTask<VoidOutput> {
     }
 
     public ArrayList<String> dagCheckCyclicDependencies(List<DagTask> taskDepends) {
+        Map<String, List<String>> depMap = taskDepends.stream()
+            .collect(Collectors.toMap(
+                t -> t.getTask().getId(),
+                t -> t.getDependsOn() != null ? t.getDependsOn() : List.of()
+            ));
+
         ArrayList<String> cyclicDependency = new ArrayList<>();
-        taskDepends.forEach(taskDepend ->
-        {
+        for (DagTask taskDepend : taskDepends) {
             if (taskDepend.getDependsOn() != null) {
-                List<String> nestedDependencies = this.nestedDependencies(taskDepend, taskDepends, new ArrayList<>());
-                if (nestedDependencies.contains(taskDepend.getTask().getId())) {
-                    cyclicDependency.add(taskDepend.getTask().getId());
+                String startId = taskDepend.getTask().getId();
+                if (hasCycle(startId, depMap)) {
+                    cyclicDependency.add(startId);
                 }
             }
-        });
-
+        }
         return cyclicDependency;
     }
 
-    private ArrayList<String> nestedDependencies(DagTask taskDepend, List<DagTask> tasks, List<String> visited) {
-        final ArrayList<String> localVisited = new ArrayList<>(visited);
-        if (taskDepend.getDependsOn() != null) {
-            taskDepend.getDependsOn()
-                .stream()
-                .filter(depend -> !localVisited.contains(depend))
-                .forEach(depend ->
-                {
-                    localVisited.add(depend);
-                    Optional<DagTask> task = tasks
-                        .stream()
-                        .filter(t -> t.getTask().getId().equals(depend))
-                        .findFirst();
-
-                    if (task.isPresent()) {
-                        localVisited.addAll(this.nestedDependencies(task.get(), tasks, localVisited));
-                    }
-                });
+    private boolean hasCycle(String startId, Map<String, List<String>> depMap) {
+        Set<String> visited = new HashSet<>();
+        Deque<String> stack = new ArrayDeque<>();
+        stack.push(startId);
+        while (!stack.isEmpty()) {
+            String current = stack.pop();
+            for (String dep : depMap.getOrDefault(current, List.of())) {
+                if (dep.equals(startId)) {
+                    return true;
+                }
+                if (visited.add(dep)) {
+                    stack.push(dep);
+                }
+            }
         }
-        return localVisited;
+        return false;
     }
 
     @SuperBuilder


### PR DESCRIPTION
## Summary

Fix exponential time complexity in `dagCheckCyclicDependencies`.

## Problem

The `nestedDependencies` method recursively copies the entire visited list and appends it back via `addAll`, causing the list to **double in size on each iteration**. For a DAG with 27 parallel tasks + 1 summary task (which depends on all 27), the `localVisited` ArrayList grows to **134,217,727 elements** (2²⁷-1).

Evidence from Arthas profiling:
```
watch io.kestra.plugin.core.flow.Dag nestedDependencies '{params[2].size(), returnObj.size()}'
result=@ArrayList[@Integer[134217727], @Integer[134217727]]
cost=432ms (single call)
```
<img width="1132" height="321" alt="image" src="https://github.com/user-attachments/assets/023d6a07-0428-4983-bf39-af6344feb4b8" />
This causes:
- Each cycle detection call takes 11+ seconds
- DAG execution of 28 trivial Log tasks takes 13+ minutes
- executionQueue backlog of 18 minutes
- Flow save/update with large DAGs can timeout

## Changes

1. **Replace `nestedDependencies` (ArrayList recursion) with `hasCycle` (iterative DFS + HashSet)**
   - `HashSet.contains` is O(1) vs ArrayList O(n)
   - No list copying or `addAll` — visited set grows linearly
   - Iterative approach avoids stack overflow risk

2. **Pre-build `Map<String, List<String>>` dependency index**
   - Eliminates repeated `tasks.stream().filter().findFirst()` linear scans

## Performance

| Metric | Before | After |
|--------|--------|-------|
| Cycle detection ops (27 tasks) | 134,217,727 | ≤756 |
| Execution time (28 tasks) | 13 min | 20s |
| Queue backlog | 18 min | 0 |
| Improvement | — | **39x** |

## Test plan

- Existing `DagTest` unit tests cover cycle detection correctness (direct cycles, indirect cycles, no-cycle cases)
- `DagTaskValidator` is exercised on flow save — validates the same code path
- Manual verification with 28-task DAG on staging environment confirmed zero backlog