### PR TITLE
chore(e2e): remove redundant npm ci from e2e script

### DIFF
--- a/build-and-start-e2e-tests.sh
+++ b/build-and-start-e2e-tests.sh
@@ -29,8 +29,6 @@ start_time2=$(date +%s)
 
 echo "cd ./ui"
 cd ./ui
-echo "npm ci"
-npm ci
 
 echo 'sh ./run-e2e-tests.sh --kestra-docker-image-to-test "kestra/kestra:$LOCAL_IMAGE_VERSION"'
 ./run-e2e-tests.sh --kestra-docker-image-to-test "kestra/kestra:$LOCAL_IMAGE_VERSION"


### PR DESCRIPTION
## What

Removes the explicit `npm ci` step from `build-and-start-e2e-tests.sh`.

## Why

`npm ci` is already run as part of `make build-docker` (via `build-exec` → `build-frontend`), which the script invokes just before. Running it a second time before the e2e tests is redundant and only adds build time.