### PR TITLE
fix(security): escape jq/regex metacharacters in H2 label-key filters

### DIFF
--- a/jdbc-h2/src/main/java/io/kestra/repository/h2/H2ExecutionRepositoryService.java
+++ b/jdbc-h2/src/main/java/io/kestra/repository/h2/H2ExecutionRepositoryService.java
@@ -13,6 +13,7 @@ import io.kestra.core.models.QueryFilter;
 import io.kestra.core.models.executions.Execution;
 import io.kestra.core.utils.Either;
 import io.kestra.jdbc.AbstractJdbcRepository;
+import io.kestra.runner.h2.H2Functions;
 
 public abstract class H2ExecutionRepositoryService {
     public static Condition findCondition(AbstractJdbcRepository<Execution> jdbcRepository, String query, Map<String, String> labels) {
@@ -25,7 +26,7 @@ public abstract class H2ExecutionRepositoryService {
         if (labels != null) {
             labels.forEach((key, value) ->
             {
-                Field<String> valueField = DSL.field("JQ_STRING(\"value\", CONCAT('.labels[]? | select(.key == \"', {0}, '\") | .value'))", String.class, DSL.val(key, String.class));
+                Field<String> valueField = DSL.field("JQ_STRING(\"value\", CONCAT('.labels[]? | select(.key == \"', {0}, '\") | .value'))", String.class, DSL.val(H2Functions.escapeJqString(key), String.class));
                 if (value == null) {
                     conditions.add(valueField.isNull());
                 } else {
@@ -53,7 +54,7 @@ public abstract class H2ExecutionRepositoryService {
             var labels = input.left().get();
             labels.forEach((key, value) ->
             {
-                Field<String> valueField = DSL.field("JQ_STRING(\"value\", CONCAT('.labels[]? | select(.key == \"', {0}, '\") | .value'))", String.class, DSL.val((String) key, String.class));
+                Field<String> valueField = DSL.field("JQ_STRING(\"value\", CONCAT('.labels[]? | select(.key == \"', {0}, '\") | .value'))", String.class, DSL.val(H2Functions.escapeJqString((String) key), String.class));
                 switch (operation) {
                     case EQUALS -> conditions.add(value == null ? valueField.isNull() : valueField.eq((String) value));
                     case NOT_EQUALS, NOT_IN ->

--- a/jdbc-h2/src/main/java/io/kestra/repository/h2/H2FlowRepositoryService.java
+++ b/jdbc-h2/src/main/java/io/kestra/repository/h2/H2FlowRepositoryService.java
@@ -11,6 +11,7 @@ import org.jooq.impl.DSL;
 import io.kestra.core.models.QueryFilter;
 import io.kestra.core.models.flows.FlowInterface;
 import io.kestra.jdbc.AbstractJdbcRepository;
+import io.kestra.runner.h2.H2Functions;
 
 public abstract class H2FlowRepositoryService {
     public static Condition findCondition(AbstractJdbcRepository<? extends FlowInterface> jdbcRepository, String query, Map<String, String> labels) {
@@ -23,7 +24,7 @@ public abstract class H2FlowRepositoryService {
         if (labels != null) {
             labels.forEach((key, value) ->
             {
-                Field<String> valueField = DSL.field("JQ_STRING(\"value\", CONCAT('.labels[]? | select(.key == \"', {0}, '\") | .value'))", String.class, DSL.val(key, String.class));
+                Field<String> valueField = DSL.field("JQ_STRING(\"value\", CONCAT('.labels[]? | select(.key == \"', {0}, '\") | .value'))", String.class, DSL.val(H2Functions.escapeJqString(key), String.class));
                 if (value == null) {
                     conditions.add(valueField.isNull());
                 } else {
@@ -64,7 +65,7 @@ public abstract class H2FlowRepositoryService {
         if (labels instanceof Map<?, ?> labelValues) {
             labelValues.forEach((key, value) ->
             {
-                Field<String> valueField = DSL.field("JQ_STRING(\"value\", CONCAT('.labels[]? | select(.key == \"', {0}, '\") | .value'))", String.class, DSL.val(key, String.class));
+                Field<String> valueField = DSL.field("JQ_STRING(\"value\", CONCAT('.labels[]? | select(.key == \"', {0}, '\") | .value'))", String.class, DSL.val(H2Functions.escapeJqString((String) key), String.class));
                 Condition condition = switch (operation) {
                     case EQUALS -> value == null ? valueField.isNull() : valueField.eq((String) value);
                     case NOT_EQUALS -> value == null ? valueField.isNotNull() : valueField.isNull().or(valueField.ne((String) value));

--- a/jdbc-h2/src/main/java/io/kestra/runner/h2/H2Functions.java
+++ b/jdbc-h2/src/main/java/io/kestra/runner/h2/H2Functions.java
@@ -18,7 +18,9 @@ import net.thisptr.jackson.jq.JsonQuery;
 import net.thisptr.jackson.jq.Scope;
 import net.thisptr.jackson.jq.Versions;
 
-public class H2Functions {
+public final class H2Functions {
+
+    private H2Functions() {}
     private static final Scope scope = Scope.newEmptyScope();
     private static final ConcurrentHashMap<String, JsonQuery> QUERY_CACHE = new ConcurrentHashMap<>();
 
@@ -28,8 +30,9 @@ public class H2Functions {
 
     /**
      * Escapes a value for safe embedding inside a jq string literal ({@code "..."}).
-     * Escapes backslashes first, then double-quotes, so the resulting string can be
-     * safely concatenated into a jq filter without altering the program structure.
+     * Follows JSON string escaping rules: backslash, double-quote, and all control
+     * characters (U+0000–U+001F) are escaped so the resulting string can be safely
+     * concatenated into a jq filter without altering the program structure.
      *
      * @param value the raw user-supplied key or value to embed in a jq string literal
      * @return the escaped string, or {@code null} if {@code value} is {@code null}
@@ -38,8 +41,28 @@ public class H2Functions {
         if (value == null) {
             return null;
         }
-        // Backslash must be escaped before double-quote to avoid double-escaping
-        return value.replace("\\", "\\\\").replace("\"", "\\\"");
+        StringBuilder sb = new StringBuilder(value.length());
+        for (int i = 0; i < value.length(); i++) {
+            char c = value.charAt(i);
+            // Backslash must be handled before double-quote to avoid double-escaping
+            switch (c) {
+                case '\\' -> sb.append("\\\\");
+                case '"' -> sb.append("\\\"");
+                case '\b' -> sb.append("\\b");
+                case '\f' -> sb.append("\\f");
+                case '\n' -> sb.append("\\n");
+                case '\r' -> sb.append("\\r");
+                case '\t' -> sb.append("\\t");
+                default -> {
+                    if (c < 0x20) {
+                        sb.append(String.format("\\u%04x", (int) c));
+                    } else {
+                        sb.append(c);
+                    }
+                }
+            }
+        }
+        return sb.toString();
     }
 
     public static Boolean jqBoolean(String value, String expression) {

--- a/jdbc-h2/src/main/java/io/kestra/runner/h2/H2Functions.java
+++ b/jdbc-h2/src/main/java/io/kestra/runner/h2/H2Functions.java
@@ -26,6 +26,22 @@ public class H2Functions {
         BuiltinFunctionLoader.getInstance().loadFunctions(Versions.JQ_1_6, scope);
     }
 
+    /**
+     * Escapes a value for safe embedding inside a jq string literal ({@code "..."}).
+     * Escapes backslashes first, then double-quotes, so the resulting string can be
+     * safely concatenated into a jq filter without altering the program structure.
+     *
+     * @param value the raw user-supplied key or value to embed in a jq string literal
+     * @return the escaped string, or {@code null} if {@code value} is {@code null}
+     */
+    public static String escapeJqString(String value) {
+        if (value == null) {
+            return null;
+        }
+        // Backslash must be escaped before double-quote to avoid double-escaping
+        return value.replace("\\", "\\\\").replace("\"", "\\\"");
+    }
+
     public static Boolean jqBoolean(String value, String expression) {
         return H2Functions.jq(value, expression, JsonNode::asBoolean);
     }

--- a/jdbc-h2/src/test/java/io/kestra/runner/h2/H2FunctionsTest.java
+++ b/jdbc-h2/src/test/java/io/kestra/runner/h2/H2FunctionsTest.java
@@ -54,4 +54,54 @@ class H2FunctionsTest {
         String[] jqString = H2Functions.jqStringArray("{\"a\": [\"1\", \"2\", \"3\"]}", ".a");
         assertThat(List.of(jqString)).containsExactlyInAnyOrder("1", "2", "3");
     }
+
+    @Test
+    void shouldEscapeJqStringNullValue() {
+        // Given / When / Then
+        assertThat(H2Functions.escapeJqString(null)).isNull();
+    }
+
+    @Test
+    void shouldEscapeJqStringMetacharacters() {
+        // Given
+        String input = "key\\with\"quotes";
+
+        // When
+        String escaped = H2Functions.escapeJqString(input);
+
+        // Then — backslash must be escaped before double-quote to avoid double-escaping
+        assertThat(escaped).isEqualTo("key\\\\with\\\"quotes");
+    }
+
+    @Test
+    void shouldEscapeJqStringNamedControlCharacters() {
+        // Given — named control characters: LF, CR, TAB, BS, FF
+        assertThat(H2Functions.escapeJqString("\n")).isEqualTo("\\n");
+        assertThat(H2Functions.escapeJqString("\r")).isEqualTo("\\r");
+        assertThat(H2Functions.escapeJqString("\t")).isEqualTo("\\t");
+        assertThat(H2Functions.escapeJqString("\b")).isEqualTo("\\b");
+        assertThat(H2Functions.escapeJqString("\f")).isEqualTo("\\f");
+    }
+
+    @Test
+    void shouldEscapeJqStringRawControlCharacters() {
+        // Given — U+0001 (SOH) and U+001F (US), which have no named JSON escape
+        assertThat(H2Functions.escapeJqString("")).isEqualTo("\\u0001");
+        assertThat(H2Functions.escapeJqString("")).isEqualTo("\\u001f");
+    }
+
+    @Test
+    void shouldEscapeJqStringAndProduceValidJqProgram() {
+        // Given — a key crafted to break out of a jq string literal if unescaped
+        String maliciousKey = "x\") | .password | (\"";
+        String escaped = H2Functions.escapeJqString(maliciousKey);
+
+        // When — embed in a real jq expression and evaluate
+        String json = "{\"labels\":[{\"key\":\"safe\",\"value\":\"v\"}]}";
+        String expression = ".labels[]? | select(.key == \"" + escaped + "\") | .value";
+        String result = H2Functions.jqString(json, expression);
+
+        // Then — no match (injection neutralised), no exception
+        assertThat(result).isNull();
+    }
 }


### PR DESCRIPTION
## Summary

- **JQ program injection (H2 label filters)**: `H2FlowRepositoryService` and `H2ExecutionRepositoryService` embedded user-supplied label keys directly into jq string literals via string concatenation. A key containing `"` could alter the jq program and broaden or redirect matching. Fix: escape `key` via `H2Functions.escapeJqString()` before embedding.
- **`H2Functions` utility-class convention**: Class is now `final` with a private constructor per AGENTS.md.
- **`H2Functions.escapeJqString` — complete control-character coverage**: Extended from escaping only `\` and `"` to also escaping all JSON/jq-illegal control characters (U+0000–U+001F) via named sequences (`\n`, `\r`, `\t`, `\b`, `\f`) and `\uXXXX` for the rest. EE `Tag.key` has no `@Pattern` validation (unlike OSS `Label.key`), making the control-character gap reachable in EE scenarios.
- **Dead-code jq injection in `JdbcFlowRepositoryService`**: The base-class `findCondition` (overridden by all concrete backends) embedded `key` unescaped into a jq expression; fixed by escaping via a local `escapeJqStringLiteral` helper.
- **Unit tests**: Added 5 new tests in `H2FunctionsTest` covering null input, backslash/quote escaping, named control chars, raw control chars (U+0001, U+001F), and an end-to-end injection-neutralisation test.

Companion EE PR: kestra-io/kestra-ee#8941 (fixes `H2SecretMetadataRepository`, `H2AssetRepositoryService`, `H2AuditLogRepository`, `MysqlAuditLogRepository`).

Closes part of kestra-io/kestra-ee#8940.

## Test plan

- [ ] `./gradlew :jdbc-h2:test` — all existing tests pass; 5 new `H2FunctionsTest` tests pass
- [ ] Label filter with a normal key returns expected flows (no behavior change for benign keys)
- [ ] Label filter with `key = "x\") | .password | (\""` returns no results and does not throw