### PR TITLE
fix(executions): cancelled task run must not yield a SUCCESS execution

### DIFF
--- a/core/src/main/java/io/kestra/core/models/executions/Execution.java
+++ b/core/src/main/java/io/kestra/core/models/executions/Execution.java
@@ -770,7 +770,7 @@ public class Execution implements SoftDeletable<Execution>, TenantInterface, Has
         List<TaskRun> taskRuns = this.findTaskRunByTasks(currentTasks, parentTaskRun);
 
         // Single pass over taskRuns, tracking the highest-priority terminal state found.
-        // Priority order: KILLED > FAILED > WARNING > PAUSED
+        // Priority order: KILLED > FAILED > CANCELLED > WARNING > PAUSED
         State.Type state = terminalState;
         for (TaskRun taskRun : taskRuns) {
             State.Type current = taskRun.getState().getCurrent();
@@ -779,7 +779,9 @@ public class Execution implements SoftDeletable<Execution>, TenantInterface, Has
                 break; // highest priority, no need to continue
             } else if (current == State.Type.FAILED && state != State.Type.KILLED) {
                 state = State.Type.FAILED;
-            } else if (current == State.Type.WARNING && state != State.Type.KILLED && state != State.Type.FAILED) {
+            } else if (current == State.Type.CANCELLED && state != State.Type.KILLED && state != State.Type.FAILED) {
+                state = State.Type.CANCELLED;
+            } else if (current == State.Type.WARNING && state != State.Type.KILLED && state != State.Type.FAILED && state != State.Type.CANCELLED) {
                 state = State.Type.WARNING;
             } else if (current == State.Type.PAUSED && state == terminalState) {
                 state = State.Type.PAUSED;

--- a/core/src/test/java/io/kestra/core/models/executions/ExecutionTest.java
+++ b/core/src/test/java/io/kestra/core/models/executions/ExecutionTest.java
@@ -8,8 +8,10 @@ import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import io.kestra.core.models.Label;
+import io.kestra.core.models.flows.Flow;
 import io.kestra.core.models.flows.State;
 import io.kestra.core.utils.IdUtils;
+import io.kestra.plugin.core.debug.Return;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -283,5 +285,62 @@ class ExecutionTest {
             null
         );
         assertThat(executionNew.getLabels()).containsExactly(new Label("test", "value2"));
+    }
+
+    @Test
+    void shouldGuessCancelledWhenTaskRunCancelled() {
+        // Given a flow whose single task run ended CANCELLED (e.g. workerSelector fallback: CANCEL)
+        Flow flow = flowWithTask("will-cancel");
+        Execution execution = executionWithTaskRun("will-cancel", State.Type.CANCELLED);
+
+        // When guessing the final state
+
+        // Then the execution must not be silently reported as SUCCESS
+        assertThat(execution.guessFinalState(flow)).isEqualTo(State.Type.CANCELLED);
+    }
+
+    @Test
+    void shouldGuessFailedWhenTaskRunFailedTakesPrecedenceOverCancelled() {
+        // Given one FAILED and one CANCELLED task run
+        Return failed = Return.builder().id("failed").type(Return.class.getName()).build();
+        Return cancelled = Return.builder().id("cancelled").type(Return.class.getName()).build();
+        Flow flow = Flow.builder()
+            .id(IdUtils.create())
+            .namespace("io.kestra.test")
+            .tasks(List.of(failed, cancelled))
+            .build();
+        Execution execution = Execution.builder()
+            .id(IdUtils.create())
+            .taskRunList(List.of(
+                TaskRun.builder().id(IdUtils.create()).taskId("failed").state(new State(State.Type.FAILED, new State())).build(),
+                TaskRun.builder().id(IdUtils.create()).taskId("cancelled").state(new State(State.Type.CANCELLED, new State())).build()
+            ))
+            .build();
+
+        // When guessing the final state
+
+        // Then FAILED takes precedence over CANCELLED
+        assertThat(execution.guessFinalState(flow)).isEqualTo(State.Type.FAILED);
+    }
+
+    private static Flow flowWithTask(String taskId) {
+        return Flow.builder()
+            .id(IdUtils.create())
+            .namespace("io.kestra.test")
+            .tasks(List.of(Return.builder().id(taskId).type(Return.class.getName()).build()))
+            .build();
+    }
+
+    private static Execution executionWithTaskRun(String taskId, State.Type state) {
+        return Execution.builder()
+            .id(IdUtils.create())
+            .taskRunList(List.of(
+                TaskRun.builder()
+                    .id(IdUtils.create())
+                    .taskId(taskId)
+                    .state(new State(state, new State()))
+                    .build()
+            ))
+            .build();
     }
 }


### PR DESCRIPTION
Fix: kestra-io/kestra-ee#8815