### PR TITLE
fix(tests): write test-metadata.json when a test task times out

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -438,6 +438,17 @@ tasks.register('generateTestMetadata') {
     }
 }
 
+// Finalize every Test task (not just `check`) with generateTestMetadata. When a module's
+// test task exceeds its timeout, Gradle aborts the build before `check` runs, so a finalizer
+// of `check` is skipped and the metadata file is never written — leaving kestra-devtools to
+// silently report success for the timed-out module. A finalizer of the Test task itself still
+// runs on timeout (same as jacocoTestReport above), guaranteeing test-metadata.json is written.
+subprojects {
+    tasks.withType(Test).configureEach {
+        finalizedBy rootProject.tasks.named('generateTestMetadata')
+    }
+}
+
 tasks.named('check') {
     dependsOn tasks.named('testCodeCoverageReport', JacocoReport)
     dependsOn(tasks.named('flakyTest'))


### PR DESCRIPTION
## Problem

When a module's `test` task exceeds its 30-minute timeout, Gradle kills the JVM hard and fails the build. Under `./gradlew check --parallel` (no `--continue`) the build aborts, so the aggregate `check` task **never executes** — and `generateTestMetadata`, wired only as a finalizer of `check`, never runs. `build/test-metadata.json` is therefore missing on exactly the runs that need it, and `kestra-devtools generateTestReportSummary` falls back to its no-metadata path and reports the timed-out module as **success**.

Real example: kestra-ee PR #8816 CI — `:webserver-ee:test` timed out at 30m (`Requesting stop of task ':webserver-ee:test' as it has exceeded its configured timeout of 30m`), every other module passed, and the PR comment showed a green report with `failed: 0`.

## Fix

Finalize **every** `Test` task with `generateTestMetadata`, mirroring how `jacocoTestReport` is already wired per test task. A finalizer of the test task itself runs even when that task fails on timeout — proven in the same CI log, where `:webserver-ee:jacocoTestReport` (a per-test-task finalizer) ran after the timeout. This guarantees `test-metadata.json` is written, so kestra-devtools can flag the timed-out module.

## Verification

`./gradlew :processor:test --dry-run` now lists `:generateTestMetadata` as a finalizer of the test task (previously it appeared only under `check`).

## Companion PRs
- kestra-io/kestra-ee — same Gradle fix
- kestra-io/kestra-devtools — report consumer: flag FAILED modules even with partial XML