### PR TITLE
fix(design-system): cleaner default KsTag (borderless + muted icon)

### DIFF
--- a/ui/packages/design-system/src/components/Data/KsTag/KsTag.vue
+++ b/ui/packages/design-system/src/components/Data/KsTag/KsTag.vue
@@ -104,6 +104,10 @@
             line-height: 0;
         }
 
+        &.kel-tag--default .material-design-icon {
+            color: var(--ks-icon-muted);
+        }
+
         &.kel-tag--plain {
             --kel-tag-bg-color: var(--ks-bg-tag);
             --kel-tag-text-color: var(--ks-bg-tag);

--- a/ui/packages/design-system/src/components/Data/KsTag/KsTag.vue
+++ b/ui/packages/design-system/src/components/Data/KsTag/KsTag.vue
@@ -148,7 +148,7 @@
             &.kel-tag--plain {
                 --kel-tag-bg-color: var(--ks-bg-tag);
                 --kel-tag-text-color: var(--ks-text-primary);
-                --kel-tag-border-color: var(--ks-border-strong);
+                --kel-tag-border-color: transparent;
                 --kel-tag-hover-color: var(--ks-text-primary);
 
                 a {

--- a/ui/packages/design-system/src/components/Data/KsTag/KsTag.vue
+++ b/ui/packages/design-system/src/components/Data/KsTag/KsTag.vue
@@ -104,7 +104,7 @@
             line-height: 0;
         }
 
-        &.kel-tag--default .material-design-icon {
+        &.kel-tag--default.kel-tag--plain [class*="kel-icon"] .material-design-icon {
             color: var(--ks-icon-muted);
         }
 


### PR DESCRIPTION
## What

Two small refinements to the **default (grey) `KsTag`** so plain tags match the borderless grey label style used across the product:

1. **Borderless** — drop the 1px border (`--ks-border-strong`) on the default plain tag.
2. **Muted icon** — render decorative icons inside the default tag with `--ks-icon-muted` instead of full text strength, matching how secondary icons are treated elsewhere (sidebar, alerts, filters, top nav).

Typed/status tags (`success`, `warning`, `danger`, `info`) are untouched — they keep their colored borders and icons.

## Why

Surfaced during the EE IAM unification ([kestra-ee#8778](https://github.com/kestra-io/kestra-ee/pull/8778)): tag borders and heavy icons showed up inconsistently across every IAM page, and patching them per-component was whack-a-mole. The border/icon styling is a design-system default, so the fix belongs here.

## Scope / impact

**App-wide** (visual only): every default `KsTag` becomes borderless with a muted icon. Design review welcome.

The EE IAM unification PR depends on this — it drops its local per-component overrides in favor of these defaults.

🤖 Generated with [Claude Code](https://claude.com/claude-code)