### PR TITLE
test(tests): raise H2 LOCK_TIMEOUT on shared in-memory test datasources

### DIFF
--- a/executor/src/test/resources/application-test.yml
+++ b/executor/src/test/resources/application-test.yml
@@ -79,7 +79,7 @@ kestra:
             port: ${kestra.controller.port}
 datasources:
   h2:
-    url: jdbc:h2:mem:public;TIME ZONE=UTC;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+    url: jdbc:h2:mem:public;LOCK_TIMEOUT=30000;TIME ZONE=UTC;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
     username: sa
     password: ""
     driverClassName: org.h2.Driver

--- a/jdbc-h2/src/test/resources/application-test.yml
+++ b/jdbc-h2/src/test/resources/application-test.yml
@@ -1,6 +1,6 @@
 datasources:
   h2:
-    url: jdbc:h2:mem:public;TIME ZONE=UTC;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+    url: jdbc:h2:mem:public;LOCK_TIMEOUT=30000;TIME ZONE=UTC;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
     username: sa
     password: ""
     driverClassName: org.h2.Driver

--- a/scheduler/src/test/resources/application-test.yml
+++ b/scheduler/src/test/resources/application-test.yml
@@ -67,7 +67,7 @@ kestra:
 
 datasources:
   h2:
-    url: jdbc:h2:mem:public;TIME ZONE=UTC;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+    url: jdbc:h2:mem:public;LOCK_TIMEOUT=30000;TIME ZONE=UTC;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
     username: sa
     password: ""
     driverClassName: org.h2.Driver

--- a/webserver/src/test/resources/application-test.yml
+++ b/webserver/src/test/resources/application-test.yml
@@ -205,7 +205,7 @@ kestra:
 
 datasources:
   h2:
-    url: jdbc:h2:mem:public_webserver;TIME ZONE=UTC;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+    url: jdbc:h2:mem:public_webserver;LOCK_TIMEOUT=30000;TIME ZONE=UTC;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
     username: sa
     password: ""
     driverClassName: org.h2.Driver

--- a/worker-controller/src/test/resources/application-test.yml
+++ b/worker-controller/src/test/resources/application-test.yml
@@ -84,7 +84,7 @@ grpc:
       enabled: false
 datasources:
   h2:
-    url: jdbc:h2:mem:public;TIME ZONE=UTC;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+    url: jdbc:h2:mem:public;LOCK_TIMEOUT=30000;TIME ZONE=UTC;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
     username: sa
     password: ""
     driverClassName: org.h2.Driver

--- a/worker/src/test/resources/application-test.yml
+++ b/worker/src/test/resources/application-test.yml
@@ -84,7 +84,7 @@ grpc:
       enabled: false
 datasources:
   h2:
-    url: jdbc:h2:mem:public;TIME ZONE=UTC;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+    url: jdbc:h2:mem:public;LOCK_TIMEOUT=30000;TIME ZONE=UTC;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
     username: sa
     password: ""
     driverClassName: org.h2.Driver


### PR DESCRIPTION
## What

Adds `LOCK_TIMEOUT=30000` to the **shared** in-memory H2 test datasources (`jdbc:h2:mem:public` / `jdbc:h2:mem:public_webserver`) in: `webserver`, `scheduler`, `executor`, `worker`, `worker-controller`, `jdbc-h2`.

## Why

The dominant recurring `develop` CI failure is a **transient H2 MVStore lock timeout** on the shared test DBs, not a logic bug. Over the last 14 days on `develop` (Develocity), the top failures are:

- `MiscControllerTest.canTriggerAWebhookWithoutBasicAuth` — **45 failures** (the single largest source of develop-CI noise)
- `TriggerControllerFilterTest.shouldReturnExpectedTriggersForFilterQuery` — 4 failures

Both share one root cause, confirmed from the GitHub Actions logs of failed `develop` runs:

```
org.jooq.exception.DataAccessException: SQL [delete from "PUBLIC"."QUEUES"]; Timeout trying to lock table "QUEUES"
Caused by: org.h2.mvstore.MVStoreException: Map entry <table.122> ... 'worker_task_result' ...
  is locked by tx 2 and can not be updated by tx 1 within allocated time interval 2000 ms.
```

The shared datasources are written to by background executor/worker/queue-consumer threads belonging to one test while another test's `@BeforeEach` `JdbcTestUtils.drop()` (`delete from QUEUES`) — or a webhook-triggered execution insert — contends for the same rows. With H2's **default `LOCK_TIMEOUT` of 2000 ms**, that brief contention surfaces as a `DataAccessException`:

- `MiscControllerTest.canTriggerAWebhookWithoutBasicAuth` fails at the webhook call (`MiscControllerTest.java:220`) with **HTTP 500** (lock timeout during the execution insert) — not the 401 it might appear to be.
- `TriggerControllerFilterTest.setup` fails directly in `JdbcTestUtils.drop()`.

## Fix

Raise `LOCK_TIMEOUT` to 30 s so transient contention waits and resolves instead of failing fast. H2 still detects genuine deadlocks independently of `LOCK_TIMEOUT`, so this only lengthens waits for locks that will be released — it does not mask deadlocks.

## Verification

- `:webserver:test --tests MiscControllerTest` → green with the new setting.
- Config-only change to test resources; no production code touched.

_These failures are CI-load-dependent and do not reproduce on a fast local machine; this targets the exact mechanism shown in the CI stack traces._