### PR TITLE
fix(topology): use props.source as fallback for runner type resolution

### DIFF
--- a/ui/src/components/executions/Topology.vue
+++ b/ui/src/components/executions/Topology.vue
@@ -90,6 +90,13 @@
 
     function loadData() {
         loadGraph()
+        loadFlowSource()
+    }
+
+    function loadFlowSource() {
+        const exec = execution.value
+        if (!exec || flowStore.flow?.id === exec.flowId && flowStore.flow?.namespace === exec.namespace) return
+        flowStore.loadFlow({namespace: exec.namespace, id: exec.flowId})
     }
 
     function loadGraph(force?: boolean) {

--- a/ui/src/components/inputs/LowCodeEditor.vue
+++ b/ui/src/components/inputs/LowCodeEditor.vue
@@ -254,7 +254,11 @@
     // burger-menu "Show Details" item work correctly in execution view too.
     const runnerTypeByTaskId = computed((): Record<string, string> => {
         const result: Record<string, string> = {}
-        const parsed = flowStore.flowParsed
+        const flowParsed = flowStore.flowParsed
+        const flowParsedHasRunners = (flowParsed?.tasks ?? []).some((t: any) => t?.taskRunner?.type)
+        // When flowParsed has no runner types, fall back to props.source (has taskRunner intact;
+        // execution view may have stale flowYaml without taskRunner, or forExecution() strips it)
+        const parsed = flowParsedHasRunners ? flowParsed : (props.source ? YAML_UTILS.parse(props.source) : flowParsed)
         for (const task of [...(parsed?.tasks ?? []), ...(parsed?.errors ?? []), ...(parsed?.finally ?? [])]) {
             if (task?.id && task?.taskRunner?.type) {
                 result[task.id] = task.taskRunner.type
@@ -402,10 +406,30 @@
         () => props.flowGraph,
         async (flowGraph) => {
             if (flowStore.flowParsed?.tasks?.length) return
-            const tasks = (flowGraph?.nodes ?? [])
-                .filter((n: any) => n.task?.type)
-                .map((n: any) => ({type: n.task.type, version: n.task.version, taskRunner: n.task.taskRunner}))
+            // props.source has taskRunner intact; graph nodes may have it stripped (forExecution)
+            const sourceParsed = props.source ? YAML_UTILS.parse(props.source) : null
+            const tasks = sourceParsed?.tasks?.length
+                ? sourceParsed.tasks
+                : (flowGraph?.nodes ?? [])
+                    .filter((n: any) => n.task?.type)
+                    .map((n: any) => ({type: n.task.type, version: n.task.version, taskRunner: n.task.taskRunner}))
             await resolveTaskTopologyDetails(tasks)
+        },
+        {immediate: true},
+    )
+
+    // When props.source has runner types that flowParsed lacks (e.g. stale/absent flowYaml
+    // in execution view), re-resolve so the pluginUiManifest call includes runner types.
+    watch(
+        () => props.source,
+        async (source) => {
+            if (!source) return
+            const parsed = YAML_UTILS.parse(source)
+            const sourceHasRunners = (parsed?.tasks ?? []).some((t: any) => t?.taskRunner?.type)
+            const flowParsedHasRunners = (flowStore.flowParsed?.tasks ?? []).some((t: any) => t?.taskRunner?.type)
+            if (sourceHasRunners && !flowParsedHasRunners) {
+                await resolveTaskTopologyDetails(parsed.tasks)
+            }
         },
         {immediate: true},
     )


### PR DESCRIPTION
## Problem

`forExecution()` strips `taskRunner` from graph nodes server-side. `flowStore.flowParsed` can also come from server responses that lack `taskRunner`. Because of this, `resolveRemoteComponent` is never called with the runner type, so `taskAdditionalInfoRemote` stays empty and the **"Show more details" toggle never appears** for task-runner plugins when navigating directly to a flow or execution page.

`plugin-ee-aws` and `plugin-ee-gcp` appeared to work because their tests happened to navigate via paths that already had the flow loaded in the store (luck of navigation order), not because of any structural difference.

## Fix

- **`runnerTypeByTaskId`**: fall back to `props.source` (always has `taskRunner` intact) when `flowParsed` has no runner types
- **`flowGraph` watch**: use `props.source` tasks instead of graph nodes (which may be stripped) when resolving topology details
- **New `props.source` watch**: re-trigger `resolveTaskTopologyDetails` when source gains runner types that `flowParsed` lacks
- **`Topology.vue`**: eagerly load the flow into the store in execution view so `flowParsed` is available

## Test plan

- [ ] Open a flow that uses a task runner (e.g. `io.kestra.plugin.ee.kubernetes.runner.Kubernetes`) by navigating **directly** to the flow URL (not via the flow list)
- [ ] Confirm **"Show more details"** toggle appears on the topology node
- [ ] Repeat from an execution URL directly — toggle should still appear
- [ ] Verify `plugin-ee-aws` and `plugin-ee-gcp` topology details still work