### PR TITLE
feat(worker): advertise worker thread count on connect

### DIFF
--- a/worker-controller/src/main/java/io/kestra/controller/grpc/services/GrpcConnectControllerService.java
+++ b/worker-controller/src/main/java/io/kestra/controller/grpc/services/GrpcConnectControllerService.java
@@ -31,7 +31,7 @@ public class GrpcConnectControllerService extends ConnectControllerServiceGrpc.C
 
     @Override
     public void connect(ConnectRequest request, StreamObserver<ConnectResponse> responseObserver) {
-        String workerGroupId = resolveWorkerGroupId();
+        String workerGroupId = resolveWorkerGroupId(request);
         log.info("Worker connect request received with workerGroup: {}", workerGroupId);
 
         ConnectResponse response = ConnectResponse.newBuilder()
@@ -45,10 +45,11 @@ public class GrpcConnectControllerService extends ConnectControllerServiceGrpc.C
     }
 
     /**
-     * Resolves the Worker Group id. OSS always returns {@link WorkerGroups#DEFAULT_ID};
-     * the EE override resolves it from the authenticated worker context.
+     * Resolves the Worker Group id for the connecting worker. OSS always returns
+     * {@link WorkerGroups#DEFAULT_ID}; the EE override resolves it from the authenticated
+     * worker context and may reject the connection.
      */
-    protected String resolveWorkerGroupId() {
+    protected String resolveWorkerGroupId(ConnectRequest request) {
         return WorkerGroups.DEFAULT_ID;
     }
 }

--- a/worker-controller/src/main/proto/connect_controller.proto
+++ b/worker-controller/src/main/proto/connect_controller.proto
@@ -14,6 +14,7 @@ service ConnectControllerService {
 // Request message for worker connection
 message ConnectRequest {
   RequestOrResponseHeader header = 1;
+  int32 worker_num_threads = 2;
 }
 
 // Response message for worker connection

--- a/worker/src/main/java/io/kestra/worker/services/GrpcWorkerConnectionService.java
+++ b/worker/src/main/java/io/kestra/worker/services/GrpcWorkerConnectionService.java
@@ -12,6 +12,7 @@ import io.kestra.controller.grpc.ConnectRequest;
 import io.kestra.controller.grpc.ConnectResponse;
 import io.kestra.controller.messages.MessageFormats;
 import io.kestra.controller.messages.RequestOrResponseHeaderFactory;
+import io.kestra.core.contexts.KestraContext;
 import io.kestra.core.encryption.EncryptionConfig;
 import io.kestra.core.reporter.UsageReportConfig;
 import io.kestra.core.serializers.JacksonMapper;
@@ -61,6 +62,7 @@ public class GrpcWorkerConnectionService implements WorkerConnectionService {
 
         ConnectRequest request = ConnectRequest.newBuilder()
             .setHeader(RequestOrResponseHeaderFactory.create(workerId))
+            .setWorkerNumThreads(KestraContext.getContext().getWorkerMaxNumThreads().orElse(0))
             .build();
 
         try {


### PR DESCRIPTION
Add worker_num_threads to ConnectRequest so the controller can validate a connecting worker's thread count, and change resolveWorkerGroupId to take the ConnectRequests.
