### PR TITLE
fix(storage): optimise logs table indexes

### DIFF
--- a/jdbc-h2/src/main/java/io/kestra/repository/h2/migration/V2_0_11LogsFlowIndexMigration.java
+++ b/jdbc-h2/src/main/java/io/kestra/repository/h2/migration/V2_0_11LogsFlowIndexMigration.java
@@ -1,0 +1,51 @@
+package io.kestra.repository.h2.migration;
+
+import javax.sql.DataSource;
+
+import io.kestra.core.migration.MigrationScript;
+import io.kestra.jdbc.migration.AbstractSQLMigrationScript;
+
+import io.micronaut.context.annotation.Requires;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+
+/**
+ * OSS H2 migration: drops the redundant {@code logs_execution_id} and {@code logs_timestamp}
+ * indexes from the {@code logs} table and adds a composite
+ * {@code logs_tenant_namespace_flow_id_timestamp} index to fix full-scan on flow-scoped log
+ * queries.
+ */
+@Singleton
+@Requires(property = "kestra.repository.type", pattern = "h2|memory")
+public class V2_0_11LogsFlowIndexMigration extends AbstractSQLMigrationScript {
+
+    private static final String SCRIPT_ID = "2.0.11-logs-flow-index";
+    private static final String RESOURCE = "/migrations/2.0.11-logs-flow-index-h2.sql";
+
+    private final DataSource dataSource;
+
+    @Inject
+    public V2_0_11LogsFlowIndexMigration(final DataSource dataSource) {
+        this.dataSource = dataSource;
+    }
+
+    @Override
+    public String scriptId() {
+        return SCRIPT_ID;
+    }
+
+    @Override
+    public String description() {
+        return "OSS H2: optimise logs table indexes — drop redundant logs_execution_id and logs_timestamp, add logs_tenant_namespace_flow_id_timestamp";
+    }
+
+    @Override
+    public String checksum() {
+        return MigrationScript.checksumOfResources(RESOURCE);
+    }
+
+    @Override
+    public void migrate() throws Exception {
+        executeSqlResource(dataSource, RESOURCE);
+    }
+}

--- a/jdbc-h2/src/main/resources/migrations/2.0.11-logs-flow-index-h2.sql
+++ b/jdbc-h2/src/main/resources/migrations/2.0.11-logs-flow-index-h2.sql
@@ -1,0 +1,11 @@
+-- Drop the redundant logs_execution_id index: it is a strict leftmost prefix of
+-- logs_execution_id__task_id (execution_id, task_id) and provides no extra coverage.
+DROP INDEX IF EXISTS logs_execution_id;
+
+-- Drop the redundant logs_timestamp index: every timestamp-range query on logs always carries a
+-- tenant_id predicate, so logs_tenant_timestamp (tenant_id, timestamp, level) covers it fully.
+DROP INDEX IF EXISTS logs_timestamp;
+
+-- Add a composite index for the flow-scoped logs query (tenant + namespace + flow_id + timestamp
+-- range). Fixes full-scan on large log datasets when filtering by namespace, flow_id and timestamp.
+CREATE INDEX IF NOT EXISTS logs_tenant_namespace_flow_id_timestamp ON logs ("tenant_id", "namespace", "flow_id", "timestamp", "level");

--- a/jdbc-mysql/src/main/java/io/kestra/repository/mysql/migration/V2_0_11LogsFlowIndexMigration.java
+++ b/jdbc-mysql/src/main/java/io/kestra/repository/mysql/migration/V2_0_11LogsFlowIndexMigration.java
@@ -1,0 +1,50 @@
+package io.kestra.repository.mysql.migration;
+
+import javax.sql.DataSource;
+
+import io.kestra.core.migration.MigrationScript;
+import io.kestra.jdbc.migration.AbstractSQLMigrationScript;
+import io.kestra.repository.mysql.MysqlRepositoryEnabled;
+
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+
+/**
+ * OSS MySQL migration: drops the redundant {@code ix_execution_id} and {@code ix_timestamp}
+ * indexes from the {@code logs} table and adds a composite
+ * {@code ix_tenant_namespace_flow_id_timestamp} index to fix full-scan on flow-scoped log queries.
+ */
+@Singleton
+@MysqlRepositoryEnabled
+public class V2_0_11LogsFlowIndexMigration extends AbstractSQLMigrationScript {
+
+    private static final String SCRIPT_ID = "2.0.11-logs-flow-index";
+    private static final String RESOURCE = "/migrations/2.0.11-logs-flow-index-mysql.sql";
+
+    private final DataSource dataSource;
+
+    @Inject
+    public V2_0_11LogsFlowIndexMigration(final DataSource dataSource) {
+        this.dataSource = dataSource;
+    }
+
+    @Override
+    public String scriptId() {
+        return SCRIPT_ID;
+    }
+
+    @Override
+    public String description() {
+        return "OSS MySQL: optimise logs table indexes — drop redundant ix_execution_id and ix_timestamp, add ix_tenant_namespace_flow_id_timestamp";
+    }
+
+    @Override
+    public String checksum() {
+        return MigrationScript.checksumOfResources(RESOURCE);
+    }
+
+    @Override
+    public void migrate() throws Exception {
+        executeSqlResource(dataSource, RESOURCE);
+    }
+}

--- a/jdbc-mysql/src/main/resources/migrations/2.0.11-logs-flow-index-mysql.sql
+++ b/jdbc-mysql/src/main/resources/migrations/2.0.11-logs-flow-index-mysql.sql
@@ -1,0 +1,23 @@
+-- Drop the redundant ix_execution_id index: it is a strict leftmost prefix of
+-- ix_execution_id__task_id (execution_id, task_id) and provides no extra coverage.
+SET @idx_exists = (SELECT COUNT(*) FROM information_schema.statistics WHERE table_schema = DATABASE() AND table_name = 'logs' AND index_name = 'ix_execution_id');
+SET @sql = IF(@idx_exists > 0, 'ALTER TABLE logs DROP INDEX ix_execution_id', 'SELECT 1');
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+-- Drop the redundant ix_timestamp index: every timestamp-range query on logs always carries a
+-- tenant_id predicate, so ix_tenant_timestamp (tenant_id, timestamp, level) covers it fully.
+SET @idx_exists = (SELECT COUNT(*) FROM information_schema.statistics WHERE table_schema = DATABASE() AND table_name = 'logs' AND index_name = 'ix_timestamp');
+SET @sql = IF(@idx_exists > 0, 'ALTER TABLE logs DROP INDEX ix_timestamp', 'SELECT 1');
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+-- Add a composite index for the flow-scoped logs query (tenant + namespace + flow_id + timestamp
+-- range). Fixes full-scan on large log datasets when filtering by namespace, flow_id and timestamp.
+SET @idx_exists = (SELECT COUNT(*) FROM information_schema.statistics WHERE table_schema = DATABASE() AND table_name = 'logs' AND index_name = 'ix_tenant_namespace_flow_id_timestamp');
+SET @sql = IF(@idx_exists = 0, 'ALTER TABLE logs ADD INDEX ix_tenant_namespace_flow_id_timestamp (tenant_id, namespace, flow_id, timestamp, level), ALGORITHM=INPLACE, LOCK=NONE', 'SELECT 1');
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;

--- a/jdbc-postgres/src/main/java/io/kestra/repository/postgres/migration/V2_0_11LogsFlowIndexMigration.java
+++ b/jdbc-postgres/src/main/java/io/kestra/repository/postgres/migration/V2_0_11LogsFlowIndexMigration.java
@@ -1,0 +1,51 @@
+package io.kestra.repository.postgres.migration;
+
+import javax.sql.DataSource;
+
+import io.kestra.core.migration.MigrationScript;
+import io.kestra.jdbc.migration.AbstractSQLMigrationScript;
+import io.kestra.repository.postgres.PostgresRepositoryEnabled;
+
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+
+/**
+ * OSS PostgreSQL migration: drops the redundant {@code logs_execution_id} and
+ * {@code logs_timestamp} indexes from the {@code logs} table and adds a composite
+ * {@code logs_tenant_namespace_flow_id_timestamp} index to fix full-scan on flow-scoped log
+ * queries.
+ */
+@Singleton
+@PostgresRepositoryEnabled
+public class V2_0_11LogsFlowIndexMigration extends AbstractSQLMigrationScript {
+
+    private static final String SCRIPT_ID = "2.0.11-logs-flow-index";
+    private static final String RESOURCE = "/migrations/2.0.11-logs-flow-index-postgres.sql";
+
+    private final DataSource dataSource;
+
+    @Inject
+    public V2_0_11LogsFlowIndexMigration(final DataSource dataSource) {
+        this.dataSource = dataSource;
+    }
+
+    @Override
+    public String scriptId() {
+        return SCRIPT_ID;
+    }
+
+    @Override
+    public String description() {
+        return "OSS PostgreSQL: optimise logs table indexes — drop redundant logs_execution_id and logs_timestamp, add logs_tenant_namespace_flow_id_timestamp";
+    }
+
+    @Override
+    public String checksum() {
+        return MigrationScript.checksumOfResources(RESOURCE);
+    }
+
+    @Override
+    public void migrate() throws Exception {
+        executeSqlResource(dataSource, RESOURCE);
+    }
+}

--- a/jdbc-postgres/src/main/resources/migrations/2.0.11-logs-flow-index-postgres.sql
+++ b/jdbc-postgres/src/main/resources/migrations/2.0.11-logs-flow-index-postgres.sql
@@ -1,0 +1,11 @@
+-- Drop the redundant logs_execution_id index: it is a strict leftmost prefix of
+-- logs_execution_id__task_id (execution_id, task_id) and provides no extra coverage.
+DROP INDEX CONCURRENTLY IF EXISTS logs_execution_id;
+
+-- Drop the redundant logs_timestamp index: every timestamp-range query on logs always carries a
+-- tenant_id predicate, so logs_tenant_timestamp (tenant_id, timestamp, level) covers it fully.
+DROP INDEX CONCURRENTLY IF EXISTS logs_timestamp;
+
+-- Add a composite index for the flow-scoped logs query (tenant + namespace + flow_id + timestamp
+-- range). Fixes full-scan on large log datasets when filtering by namespace, flow_id and timestamp.
+CREATE INDEX CONCURRENTLY IF NOT EXISTS logs_tenant_namespace_flow_id_timestamp ON logs ("tenant_id", "namespace", "flow_id", "timestamp", "level");


### PR DESCRIPTION
## Summary

Fixes a MySQL timeout on large log datasets (~15 GB) when browsing flow-scoped logs
(filters: `tenant_id`, `namespace`, `flow_id`, `timestamp >=`). 

Fixes kestra-io/kestra-ee#6714.

**Root cause:** no index covered `flow_id`. The best existing index,
`ix_tenant_namespace_timestamp (tenant_id, namespace, timestamp, level)`, forced MySQL to
range-scan the full time window and filter `flow_id` as a residual — effectively a full scan.

**Changes (drop 2, add 1 — net 7 → 6 indexes per dialect):**

- **DROP** `ix_execution_id / logs_execution_id` — redundant strict prefix of
  `ix_execution_id__task_id`; all `execution_id`-only queries use the composite prefix.
- **DROP** `ix_timestamp / logs_timestamp` — redundant given `ix_tenant_timestamp
  (tenant_id, timestamp, level)`; every timestamp-range query on the logs table always carries
  a `tenant_id` predicate via `defaultFilter(tenantId)` → `buildTenantCondition`.
- **ADD** `ix_tenant_namespace_flow_id_timestamp (tenant_id, namespace, flow_id, timestamp, level)` —
  lets the engine seek directly to the `(tenant, namespace, flow)` slice and range-scan only
  that flow's timestamps.

Applied as migration `2.0.11-logs-flow-index` to all three dialects (MySQL, Postgres, H2).
Baselines are intentionally left unchanged (they are checksummed by `V2_0Migration` and
modifying them would fail startup on existing installations).

## Test plan

- [x] H2 tests: 930/930 passing (`./gradlew :jdbc-h2:test`)
- [ ] MySQL tests: `./gradlew :jdbc-mysql:test` (requires Docker)
- [ ] Postgres tests: `./gradlew :jdbc-postgres:test` (requires Docker)
- [ ] Idempotency: run migration twice on fresh and existing DB — should be a no-op on second run
- [ ] On MySQL: `EXPLAIN SELECT value FROM logs WHERE tenant_id=? AND namespace=? AND flow_id=? AND timestamp>=?` confirms `key = ix_tenant_namespace_flow_id_timestamp`
- [ ] On MySQL: `EXPLAIN SELECT value FROM logs WHERE execution_id=?` still resolves via `ix_execution_id__task_id` prefix after `ix_execution_id` is dropped