### PR TITLE
fix(triggers): emit valid JSON schema for MCP tool temporal inputs an…

### DIFF
--- a/webserver/src/main/java/io/kestra/mcp/FlowToolSchemaMapper.java
+++ b/webserver/src/main/java/io/kestra/mcp/FlowToolSchemaMapper.java
@@ -163,11 +163,11 @@ public class FlowToolSchemaMapper {
         );
 
         if (input.getAfter() != null) {
-            baseSchema.put("minimum", input.getAfter().toString());
+            appendConstraint(baseSchema, "Must be on or after " + input.getAfter() + ".");
         }
 
         if (input.getBefore() != null) {
-            baseSchema.put("maximum", input.getBefore().toString());
+            appendConstraint(baseSchema, "Must be on or before " + input.getBefore() + ".");
         }
 
         return baseSchema;
@@ -179,11 +179,11 @@ public class FlowToolSchemaMapper {
         );
 
         if (input.getAfter() != null) {
-            baseSchema.put("minimum", input.getAfter().toString());
+            appendConstraint(baseSchema, "Must be on or after " + input.getAfter() + ".");
         }
 
         if (input.getBefore() != null) {
-            baseSchema.put("maximum", input.getBefore().toString());
+            appendConstraint(baseSchema, "Must be on or before " + input.getBefore() + ".");
         }
 
         return baseSchema;
@@ -195,11 +195,11 @@ public class FlowToolSchemaMapper {
         );
 
         if (input.getMin() != null) {
-            baseSchema.put("minimum", input.getMin().toString());
+            appendConstraint(baseSchema, "Must be at least " + input.getMin() + ".");
         }
 
         if (input.getMax() != null) {
-            baseSchema.put("maximum", input.getMax().toString());
+            appendConstraint(baseSchema, "Must be at most " + input.getMax() + ".");
         }
 
         return baseSchema;
@@ -301,14 +301,22 @@ public class FlowToolSchemaMapper {
         );
 
         if (input.getAfter() != null) {
-            baseSchema.put("minimum", input.getAfter().toString());
+            appendConstraint(baseSchema, "Must be on or after " + input.getAfter() + ".");
         }
 
         if (input.getBefore() != null) {
-            baseSchema.put("maximum", input.getBefore().toString());
+            appendConstraint(baseSchema, "Must be on or before " + input.getBefore() + ".");
         }
 
         return baseSchema;
+    }
+
+    private static void appendConstraint(Map<String, Object> baseSchema, String constraint) {
+        String existing = (String) baseSchema.get("description");
+        baseSchema.put(
+            "description",
+            existing == null || existing.isBlank() ? constraint : existing + " " + constraint
+        );
     }
 
     private static Map<String, Object> toURIType(URIInput input, Map<String, Object> baseSchema) {

--- a/webserver/src/main/java/io/kestra/mcp/McpToolService.java
+++ b/webserver/src/main/java/io/kestra/mcp/McpToolService.java
@@ -17,6 +17,7 @@ import io.kestra.core.queues.DispatchQueueInterface;
 import io.kestra.core.queues.QueueException;
 import io.kestra.core.mcp.models.McpServer;
 import io.kestra.core.repositories.FlowRepositoryInterface;
+import io.kestra.core.runners.FlowInputOutput;
 import io.kestra.core.services.ExecutionStreamingService;
 import io.kestra.plugin.core.trigger.McpToolTrigger;
 import io.micronaut.context.event.ApplicationEventPublisher;
@@ -44,6 +45,7 @@ public class McpToolService {
     private final ExecutionStreamingService streamingService;
     private final ApplicationEventPublisher<CrudEvent<Execution>> eventPublisher;
     private final McpConfig mcpConfig;
+    private final FlowInputOutput flowInputOutput;
     private final Cache<ToolHandlerCacheKey, McpServerFeatures.AsyncToolSpecification> asyncToolSpecificationCache;
 
     private static final McpSchema.CallToolResult FLOW_ERROR_CALL_TOOL_RESULT = McpSchema.CallToolResult.builder()
@@ -56,7 +58,8 @@ public class McpToolService {
         FlowRepositoryInterface flowRepositoryInterface,
         FlowToolSchemaMapper flowToolSchemaMapper,
         ExecutionStreamingService streamingService, ApplicationEventPublisher<CrudEvent<Execution>> eventPublisher,
-        McpConfig mcpConfig
+        McpConfig mcpConfig,
+        FlowInputOutput flowInputOutput
         ) {
         this.executionCommandQueue = executionCommandQueue;
         this.flowRepositoryInterface = flowRepositoryInterface;
@@ -64,6 +67,7 @@ public class McpToolService {
         this.streamingService = streamingService;
         this.eventPublisher = eventPublisher;
         this.mcpConfig = mcpConfig;
+        this.flowInputOutput = flowInputOutput;
         asyncToolSpecificationCache = Caffeine.newBuilder()
             .maximumSize(mcpConfig.toolCacheConfig().maximumSize())
             .expireAfterAccess(mcpConfig.toolCacheConfig().expireAfterAccess())
@@ -114,28 +118,52 @@ public class McpToolService {
                 .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
 
             KestraMcpTransportContext context = (KestraMcpTransportContext) exchange.transportContext();
-            return runFlowForMcpTask(flow, input, additionalInputs, toolTrigger, context)
-                .map(execution -> McpSchema.CallToolResult.builder()
-                    .structuredContent(execution.getOutputs() != null && execution.getState().isSuccess() ? execution.getOutputs() : Map.of())
-                    .isError(!execution.getState().isSuccess())
+
+            Execution execution = toolTrigger.evaluate(flow, input, additionalInputs, Label.from(Map.of(
+                Label.FROM, "mcp",
+                Label.MCP_SERVER_ID, context.getServerId(),
+                Label.MCP_SESSION_ID, context.getSessionId()
+            )));
+
+            List<String> validationErrors = collectInputValidationErrors(flow, execution, input);
+            if (!validationErrors.isEmpty()) {
+                log.debug(
+                    "Rejecting MCP tool '{}' call for flow {}/{}/{} (execution {}): {} invalid input(s): {}",
+                    toolTrigger.getToolName(), flow.getTenantId(), flow.getNamespace(), flow.getId(),
+                    execution.getId(), validationErrors.size(), validationErrors
+                );
+                return Mono.just(invalidInputResult(validationErrors));
+            }
+
+            return runFlowForMcpTask(flow, execution)
+                .map(executionResult -> McpSchema.CallToolResult.builder()
+                    .structuredContent(executionResult.getOutputs() != null && executionResult.getState().isSuccess() ? executionResult.getOutputs() : Map.of())
+                    .isError(!executionResult.getState().isSuccess())
                     .build())
                 .onErrorReturn(Exception.class, FLOW_ERROR_CALL_TOOL_RESULT);
         };
     }
 
+    List<String> collectInputValidationErrors(Flow flow, Execution execution, Map<String, Object> input) {
+        return flowInputOutput.resolveInputs(flow.getInputs(), flow, execution, input).stream()
+            .filter(resolved -> resolved.exceptions() != null && !resolved.exceptions().isEmpty())
+            .flatMap(resolved -> resolved.exceptions().stream())
+            .map(Throwable::getMessage)
+            .toList();
+    }
+
+    private static McpSchema.CallToolResult invalidInputResult(List<String> validationErrors) {
+        return McpSchema.CallToolResult.builder()
+            .isError(true)
+            .addTextContent("Invalid input provided to the tool:" + System.lineSeparator()
+                + String.join(System.lineSeparator(), validationErrors))
+            .build();
+    }
+
     private Mono<Execution> runFlowForMcpTask(
         Flow flow,
-        Map<String, Object> input,
-        Map<String, Object> additionalInputs,
-        McpToolTrigger toolTrigger,
-        KestraMcpTransportContext context
+        Execution execution
     ) {
-        Execution execution = toolTrigger.evaluate(flow, input, additionalInputs, Label.from(Map.of(
-            Label.FROM, "mcp",
-            Label.MCP_SERVER_ID, context.getServerId(),
-            Label.MCP_SESSION_ID, context.getSessionId()
-        )));
-
         try {
             executionCommandQueue.emit(Create.of(new ExecutionId(execution.getTenantId(), execution.getNamespace(), execution.getFlowId(), execution.getId(), execution.getFlowRevision()))
                 .withKind(execution.getKind())

--- a/webserver/src/test/java/io/kestra/mcp/FlowToolSchemaMapperTest.java
+++ b/webserver/src/test/java/io/kestra/mcp/FlowToolSchemaMapperTest.java
@@ -50,7 +50,11 @@ class FlowToolSchemaMapperTest {
             .build(),
         InputConversionTestCase.builder()
             .input(DateInput.builder().type(Type.DATE).after(LocalDate.of(2024, 1, 1)).before(LocalDate.of(2025, 1, 1)).build())
-            .expectedSchema(Map.of("type", "string", "format", "date", "minimum", "2024-01-01", "maximum", "2025-01-01"))
+             .expectedSchema(Map.of("type", "string", "format", "date", "description", "Must be on or after 2024-01-01. Must be on or before 2025-01-01."))
+            .build(),
+        InputConversionTestCase.builder()
+            .input(DateInput.builder().type(Type.DATE).description("The target day.").after(LocalDate.of(2024, 1, 1)).build())
+            .expectedSchema(Map.of("type", "string", "format", "date", "description", "The target day. Must be on or after 2024-01-01."))
             .build(),
         InputConversionTestCase.builder()
             .input(DateTimeInput.builder().type(Type.DATETIME).build())
@@ -58,7 +62,7 @@ class FlowToolSchemaMapperTest {
             .build(),
         InputConversionTestCase.builder()
             .input(DateTimeInput.builder().type(Type.DATETIME).after(Instant.ofEpochMilli(0)).before(Instant.ofEpochMilli(1000)).build())
-            .expectedSchema(Map.of("type", "string", "format", "date-time", "minimum", "1970-01-01T00:00:00Z", "maximum", "1970-01-01T00:00:01Z"))
+            .expectedSchema(Map.of("type", "string", "format", "date-time", "description", "Must be on or after 1970-01-01T00:00:00Z. Must be on or before 1970-01-01T00:00:01Z."))
             .build(),
         InputConversionTestCase.builder()
             .input(DurationInput.builder().type(Type.DURATION).build())
@@ -66,7 +70,7 @@ class FlowToolSchemaMapperTest {
             .build(),
         InputConversionTestCase.builder()
             .input(DurationInput.builder().type(Type.DURATION).min(Duration.ofSeconds(1)).max(Duration.ofSeconds(60)).build())
-            .expectedSchema(Map.of("type", "string", "format", "duration", "minimum", "PT1S", "maximum", "PT1M"))
+            .expectedSchema(Map.of("type", "string", "format", "duration", "description", "Must be at least PT1S. Must be at most PT1M."))
             .build(),
         InputConversionTestCase.builder()
             .input(EmailInput.builder().type(Type.EMAIL).build())
@@ -132,7 +136,7 @@ class FlowToolSchemaMapperTest {
             .build(),
         InputConversionTestCase.builder()
             .input(TimeInput.builder().type(Type.TIME).after(LocalTime.of(9, 0)).before(LocalTime.of(17, 0)).build())
-            .expectedSchema(Map.of("type", "string", "format", "time", "minimum", "09:00", "maximum", "17:00"))
+            .expectedSchema(Map.of("type", "string", "format", "time", "description", "Must be on or after 09:00. Must be on or before 17:00."))
             .build(),
         InputConversionTestCase.builder()
             .input(URIInput.builder().type(Type.URI).build())

--- a/webserver/src/test/java/io/kestra/mcp/McpToolServiceTest.java
+++ b/webserver/src/test/java/io/kestra/mcp/McpToolServiceTest.java
@@ -1,8 +1,13 @@
 package io.kestra.mcp;
 
+import io.kestra.core.models.executions.Execution;
 import io.kestra.core.models.flows.Flow;
 import io.kestra.core.models.flows.GenericFlow;
 import io.kestra.core.models.flows.FlowWithSource;
+import io.kestra.core.models.flows.State;
+import io.kestra.core.models.flows.Type;
+import io.kestra.core.models.flows.input.DateInput;
+import io.kestra.core.models.flows.input.StringInput;
 import io.kestra.core.models.namespaces.Namespace;
 import io.kestra.core.models.property.Property;
 import io.kestra.core.models.triggers.AbstractTrigger;
@@ -20,7 +25,9 @@ import jakarta.inject.Inject;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.time.LocalDate;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -198,6 +205,73 @@ class McpToolServiceTest {
         } finally {
             flowRepository.deleteWithoutAcl(savedFlow);
         }
+    }
+
+    @Test
+    void shouldReturnInputValidationErrorWhenValueViolatesBound() {
+        // Given — a DATE input that must be on or after 2024-01-01, called with an earlier date
+        Flow flow = buildFlowWithInputs(List.of(
+            DateInput.builder().id("time").type(Type.DATE).required(true).after(LocalDate.of(2024, 1, 1)).build()
+        ));
+
+        // When
+        List<String> errors = mcpToolService.collectInputValidationErrors(flow, minimalExecution(flow), Map.of("time", "2020-01-01"));
+
+        // Then
+        assertThat(errors).hasSize(1);
+        assertThat(errors.getFirst()).contains("time").contains("2024-01-01");
+    }
+
+    @Test
+    void shouldReturnNoInputValidationErrorWhenValueWithinBound() {
+        // Given
+        Flow flow = buildFlowWithInputs(List.of(
+            DateInput.builder().id("time").type(Type.DATE).required(true).after(LocalDate.of(2024, 1, 1)).build()
+        ));
+
+        // When
+        List<String> errors = mcpToolService.collectInputValidationErrors(flow, minimalExecution(flow), Map.of("time", "2024-06-01"));
+
+        // Then
+        assertThat(errors).isEmpty();
+    }
+
+    @Test
+    void shouldReturnInputValidationErrorWhenRequiredInputMissing() {
+        // Given
+        Flow flow = buildFlowWithInputs(List.of(
+            StringInput.builder().id("name").type(Type.STRING).required(true).build()
+        ));
+
+        // When
+        List<String> errors = mcpToolService.collectInputValidationErrors(flow, minimalExecution(flow), Map.of());
+
+        // Then
+        assertThat(errors).anyMatch(error -> error.contains("name"));
+    }
+
+    private static Execution minimalExecution(Flow flow) {
+        return Execution.builder()
+            .id(IdUtils.create())
+            .namespace(flow.getNamespace())
+            .flowId(flow.getId())
+            .state(new State())
+            .build();
+    }
+
+    private Flow buildFlowWithInputs(List<io.kestra.core.models.flows.Input<?>> inputs) {
+        return Flow.builder()
+            .id(IdUtils.create())
+            .namespace("namespace")
+            .inputs(inputs)
+            .tasks(List.of(
+                Return.builder()
+                    .id("task")
+                    .type(Return.class.getName())
+                    .format(Property.ofValue("test"))
+                    .build()
+            ))
+            .build();
     }
 
     @SuppressWarnings("unchecked")


### PR DESCRIPTION
### ✨ Description

Fixes flows exposed as MCP tools via `McpToolTrigger`:

- **Valid tool input schema for temporal inputs.** `DATE`/`DATETIME`/`TIME`/`DURATION` inputs with bounds emitted string `minimum`/`maximum` keywords on a string-typed field, which are numeric-only in JSON Schema draft 2020-12. The whole tool schema failed meta-schema validation and MCP clients rejected it with a `400 input_schema: JSON schema is invalid`. Bounds are now conveyed as plain language in the input `description` (e.g. "Must be on or after 2024-01-01."), keeping the valid `format` keyword.
- **Clear feedback on invalid inputs.** The MCP path bypassed input validation, so bad inputs failed opaquely. Inputs are now validated up-front (reusing the same logic as the REST path); invalid calls are rejected before execution with a precise per-input reason. A debug log records rejections for live debugging.

### 🔗 Related Issue

Closes https://github.com/kestra-io/kestra-ee/issues/8704.

### 🛠️ Backend Checklist

- [x] Code compiles successfully and passes all checks
- [x] All unit and integration tests pass

### 📝 Additional Notes

Numeric `INT`/`FLOAT` bounds are unchanged (their `minimum`/`maximum` are genuine numbers and stay valid). Happy-path inputs are still stored raw on the execution — validation only short-circuits bad calls. OSS-only; EE worktree mirrors not included.
