### PR TITLE
feat: filter out plugin artifacts with distribution EE

### DIFF
--- a/core/src/main/java/io/kestra/core/models/ui/PluginDistribution.java
+++ b/core/src/main/java/io/kestra/core/models/ui/PluginDistribution.java
@@ -1,0 +1,18 @@
+package io.kestra.core.models.ui;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import io.kestra.core.utils.Enums;
+
+/**
+ * Indicates whether a plugin UI artifact is available in OSS or requires Enterprise Edition.
+ * Absent or unrecognized values default to {@code OSS}.
+ */
+public enum PluginDistribution {
+    OSS,
+    EE;
+
+    @JsonCreator
+    public static PluginDistribution fromString(final String value) {
+        return Enums.getForNameIgnoreCase(value, PluginDistribution.class, OSS);
+    }
+}

--- a/core/src/main/java/io/kestra/core/models/ui/PluginUiModule.java
+++ b/core/src/main/java/io/kestra/core/models/ui/PluginUiModule.java
@@ -2,7 +2,10 @@ package io.kestra.core.models.ui;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
-public record PluginUiModule(String uiModule, Map<String, Object> staticInfo, List<String> styles) {
-
+public record PluginUiModule(String uiModule, Map<String, Object> staticInfo, List<String> styles, PluginDistribution distribution) {
+    public PluginUiModule {
+        distribution = Objects.requireNonNullElse(distribution, PluginDistribution.OSS);
+    }
 }

--- a/core/src/main/java/io/kestra/core/models/ui/PluginUiModuleWithGroup.java
+++ b/core/src/main/java/io/kestra/core/models/ui/PluginUiModuleWithGroup.java
@@ -3,6 +3,6 @@ package io.kestra.core.models.ui;
 import java.util.List;
 import java.util.Map;
 
-public record PluginUiModuleWithGroup(String uiModule, String group, Map<String, Object> staticInfo, List<String> styles, String sourceHash) {
+public record PluginUiModuleWithGroup(String uiModule, String group, Map<String, Object> staticInfo, List<String> styles, String sourceHash, PluginDistribution distribution) {
 
 }

--- a/ui/src/components/inputs/LowCodeEditor.vue
+++ b/ui/src/components/inputs/LowCodeEditor.vue
@@ -45,7 +45,7 @@
                     <TopologyDetailsRemote
                         :taskType="taskProps.data.node?.task?.taskRunner?.type ?? taskProps.data.node?.task?.type"
                         :task="taskProps.data.node?.task"
-                        :execution="execution"
+                        :execution="exec"
                         :namespace="props.namespace"
                         :flowId="props.flowId"
                         :metrics="taskMetrics(taskProps.data.node?.task?.id)"

--- a/ui/src/components/inputs/LowCodeEditor.vue
+++ b/ui/src/components/inputs/LowCodeEditor.vue
@@ -674,7 +674,7 @@
                 taskType: runnerType ?? fullTask?.type,
                 title: event.customAction.label,
                 task: fullTask,
-                execution: execution.value,
+                execution: exec.value,
                 namespace: props.namespace,
                 flowId: props.flowId,
                 metrics: taskMetrics(fullTask?.id),

--- a/ui/src/components/inputs/LowCodeEditor.vue
+++ b/ui/src/components/inputs/LowCodeEditor.vue
@@ -174,7 +174,7 @@
                 <TaskDrawerRemote
                     :taskType="selectedTask.type"
                     :task="selectedTask"
-                    :execution="execution"
+                    :execution="exec"
                     :namespace="props.namespace"
                     :flowId="props.flowId"
                     :metrics="taskMetrics(selectedTask?.id)"
@@ -226,12 +226,12 @@
     import {useCoreStore} from "../../stores/core"
     import {usePluginsStore} from "../../stores/plugins"
     import {useExecutionsStore} from "../../stores/executions"
-    import {usePlaygroundStore} from "../../stores/playground"    
+    import {usePlaygroundStore} from "../../stores/playground"
     import {useFlowStore} from "../../stores/flow"
     import {useToast} from "../../utils/toast"
     import {useFederatedModule} from "../../remoteComponents/useFederatedModule"
     import {openFlowInNewTab} from "../../utils/openFlow"
-    
+
     const router = useRouter()
 
     const vueflowId = ref(Math.random().toString())
@@ -243,7 +243,7 @@
     const playgroundStore = usePlaygroundStore()
     const flowStore = useFlowStore()
 
-    const execution = computed(() => executionsStore.execution as any as Execution)
+    const exec = computed(() => executionsStore.execution as any as Execution)
 
     const effectiveFlowGraph = computed(() =>
         playgroundStore.enabled ? (executionsStore.flowGraph ?? props.flowGraph) : props.flowGraph,
@@ -278,9 +278,9 @@
         }
     })
 
-    const {RemoteComponent:TopologyDetailsRemote, taskAdditionalInfoRemote, manifestReady, resolveRemoteComponent} = useFederatedModule("topology-details")
-    const {RemoteComponent:TaskDrawerRemote, resolveRemoteComponent: resolveDrawerComponent} = useFederatedModule("topology-task-drawer")
-    const {RemoteComponent:TopologyTaskModalRemote, resolveRemoteComponent: resolveTaskModalComponent} = useFederatedModule("topology-task-modal")
+    const {RemoteComponent: TopologyDetailsRemote, taskAdditionalInfoRemote, manifestReady, resolveRemoteComponent} = useFederatedModule("topology-details")
+    const {RemoteComponent: TaskDrawerRemote, resolveRemoteComponent: resolveDrawerComponent} = useFederatedModule("topology-task-drawer")
+    const {RemoteComponent: TopologyTaskModalRemote, resolveRemoteComponent: resolveTaskModalComponent} = useFederatedModule("topology-task-modal")
 
 
     const customActions = computed(() => {

--- a/webserver/src/main/java/io/kestra/webserver/controllers/api/PluginController.java
+++ b/webserver/src/main/java/io/kestra/webserver/controllers/api/PluginController.java
@@ -13,9 +13,11 @@ import io.kestra.core.models.flows.Input;
 import io.kestra.core.models.flows.Type;
 import io.kestra.core.models.tasks.FlowableTask;
 import io.kestra.core.models.triggers.AbstractTrigger;
+import io.kestra.core.models.ui.PluginDistribution;
 import io.kestra.core.models.ui.PluginUiManifest;
 import io.kestra.core.models.ui.PluginUiModuleWithGroup;
 import io.kestra.core.models.ui.TaskWithVersion;
+import io.kestra.core.utils.EditionProvider;
 import io.kestra.core.plugins.PluginRegistry;
 import io.kestra.core.plugins.RegisteredPlugin;
 import io.kestra.core.repositories.ArrayListTotal;
@@ -67,6 +69,9 @@ public class PluginController {
     @Inject
     @Named("PLUGIN")
     protected Searchable<Plugin> pluginSearchable;
+
+    @Inject
+    protected EditionProvider editionProvider;
 
     @Get(uri = "schemas/{type}")
     @ExecuteOn(TaskExecutors.IO)
@@ -393,7 +398,8 @@ public class PluginController {
                         manifest.put(
                             task, plugin.getPluginUiManifest().get(task)
                                 .stream()
-                                .map(module -> new PluginUiModuleWithGroup(module.uiModule(), plugin.group(), module.staticInfo(), module.styles(), plugin.getPluginUiSourceHash()))
+                                .filter(module -> isDistributionAllowed(module.distribution()))
+                                .map(module -> new PluginUiModuleWithGroup(module.uiModule(), plugin.group(), module.staticInfo(), module.styles(), plugin.getPluginUiSourceHash(), module.distribution()))
                                 .toList()
                         );
                     }
@@ -402,6 +408,13 @@ public class PluginController {
         }
 
         return new PluginUiManifest(manifest);
+    }
+
+    private boolean isDistributionAllowed(PluginDistribution distribution) {
+        if (editionProvider.get() == EditionProvider.Edition.OSS) {
+            return distribution != PluginDistribution.EE;
+        }
+        return true;
     }
 
     @Get(value = "/{group}/pluginUi/{path:.*}")

--- a/webserver/src/test/java/io/kestra/webserver/controllers/api/PluginControllerTest.java
+++ b/webserver/src/test/java/io/kestra/webserver/controllers/api/PluginControllerTest.java
@@ -13,6 +13,7 @@ import io.kestra.core.docs.Plugin;
 import io.kestra.core.docs.PluginIcon;
 import io.kestra.core.junit.annotations.KestraTest;
 import io.kestra.core.models.annotations.PluginSubGroup;
+import io.kestra.core.models.ui.PluginDistribution;
 import io.kestra.core.models.ui.PluginUiManifest;
 import io.kestra.core.models.ui.PluginUiModuleWithGroup;
 import io.kestra.webserver.responses.PagedResults;
@@ -259,8 +260,8 @@ class PluginControllerTest {
         assertThat(manifest.manifest()).containsKey("io.kestra.plugin.redis.list.ListPop");
         List<PluginUiModuleWithGroup> pluginUiModules = manifest.manifest().get("io.kestra.plugin.redis.list.ListPop");
         assertThat(pluginUiModules).containsExactly(
-            new PluginUiModuleWithGroup("topology-details", "io.kestra.plugin.redis", Map.of("height", 80), List.of("assets/style-D6_t4U2l.css"), "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"),
-            new PluginUiModuleWithGroup("log-details", "io.kestra.plugin.redis", null, List.of("assets/style-D6_t4U2l.css"), "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855")
+            new PluginUiModuleWithGroup("topology-details", "io.kestra.plugin.redis", Map.of("height", 80), List.of("assets/style-D6_t4U2l.css"), "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855", PluginDistribution.OSS),
+            new PluginUiModuleWithGroup("log-details", "io.kestra.plugin.redis", null, List.of("assets/style-D6_t4U2l.css"), "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855", PluginDistribution.OSS)
         );
     }
 


### PR DESCRIPTION
So we can allow some plugins UIs to only appear in EE, this PR filters out all plugins with `"distribution": "EE"` in their manifest from the lis of manifests.