### PR TITLE
[backport releases/v1.3.x] feat(core): attach logs to dynamically-generated taskruns and nest them in the UI

### DIFF
--- a/core/src/main/java/io/kestra/core/runners/DefaultRunContext.java
+++ b/core/src/main/java/io/kestra/core/runners/DefaultRunContext.java
@@ -515,6 +515,15 @@ public class DefaultRunContext extends RunContext {
         return dynamicWorkerTaskResult;
     }
 
+    @Override
+    public void dynamicWorkerResult(WorkerTaskResult workerTaskResult, List<DynamicTaskRunLog> logs) {
+        this.dynamicWorkerTaskResult.add(workerTaskResult);
+
+        if (logs != null && !logs.isEmpty() && workerTaskResult.getTaskRun() != null) {
+            this.logger.emitDynamicTaskRunLogs(workerTaskResult.getTaskRun(), logs);
+        }
+    }
+
     /**
      * {@inheritDoc}
      */

--- a/core/src/main/java/io/kestra/core/runners/DynamicTaskRunLog.java
+++ b/core/src/main/java/io/kestra/core/runners/DynamicTaskRunLog.java
@@ -1,0 +1,14 @@
+package io.kestra.core.runners;
+
+import org.slf4j.event.Level;
+
+/**
+ * A log line to attach to a dynamically-generated taskrun when it is registered through
+ * {@link RunContext#dynamicWorkerResult(WorkerTaskResult, java.util.List)}.
+ * <p>
+ * Callers only provide the level and message — the execution, tenant, namespace, flow, taskrun
+ * identity and attempt are filled in from the run context, and secrets are masked, so a plugin
+ * never builds (nor can tamper with) a full {@link io.kestra.core.models.executions.LogEntry}.
+ */
+public record DynamicTaskRunLog(Level level, String message) {
+}

--- a/core/src/main/java/io/kestra/core/runners/RunContext.java
+++ b/core/src/main/java/io/kestra/core/runners/RunContext.java
@@ -129,6 +129,22 @@ public abstract class RunContext implements PropertyContext {
     public abstract List<WorkerTaskResult> dynamicWorkerResults();
 
     /**
+     * Registers a dynamically-generated taskrun together with the log lines to attach to it, in a
+     * single call — the way plugins surface logs under the sub-taskruns they create at runtime
+     * (these taskruns are synthesized after their underlying work has finished, so their logs are
+     * already available at registration time).
+     * <p>
+     * The logs ride with the taskrun being registered, so they can only ever target that taskrun;
+     * their execution, tenant, namespace, flow and attempt are taken from this context (a plugin
+     * cannot target another execution or tenant) and secrets are masked. The default registers the
+     * taskrun and drops the logs, so runtimes that don't support per-taskrun logs (and older ones)
+     * still show the taskrun rather than failing the task.
+     */
+    public void dynamicWorkerResult(WorkerTaskResult workerTaskResult, List<DynamicTaskRunLog> logs) {
+        this.dynamicWorkerResult(List.of(workerTaskResult));
+    }
+
+    /**
      * Gets access to the working directory.
      *
      * @return The {@link WorkingDir}.

--- a/core/src/main/java/io/kestra/core/runners/RunContextLogger.java
+++ b/core/src/main/java/io/kestra/core/runners/RunContextLogger.java
@@ -15,6 +15,7 @@ import com.google.common.base.Throwables;
 
 import io.kestra.core.exceptions.IllegalVariableEvaluationException;
 import io.kestra.core.models.executions.LogEntry;
+import io.kestra.core.models.executions.TaskRun;
 import io.kestra.core.queues.QueueException;
 import io.kestra.core.queues.QueueInterface;
 
@@ -169,6 +170,59 @@ public class RunContextLogger implements Supplier<org.slf4j.Logger> {
         }
 
         return this.logger;
+    }
+
+    /**
+     * Emit the log lines attached to a dynamically-generated taskrun through the regular logging
+     * pipeline, so the standard appender behaviour (secret masking, long-message splitting, level
+     * filtering, forwarding to the server log, file vs queue routing) applies natively — the only
+     * thing that changes is the taskrun the lines are attributed to.
+     * <p>
+     * When this context logs to a file ({@code logToFile}), its logs are file-only (no inline/queue
+     * display): the lines are routed through this context's own logger so they land in the same
+     * downloadable file. A flat file has no taskrun, so there is nothing to link there.
+     * <p>
+     * Otherwise the lines go through a child logger bound to a {@link LogEntry} whose execution,
+     * tenant, namespace and flow are taken from this context's bound entry — a caller cannot target
+     * another execution or tenant — with the dynamic taskrun's id and a fixed attempt 0 (these
+     * taskruns have a single attempt and the log view groups by the 0-based attempt). The level
+     * filter and the secrets known to this context are inherited so nothing else is lost.
+     */
+    public void emitDynamicTaskRunLogs(TaskRun dynamicTaskRun, List<DynamicTaskRunLog> logs) {
+        // A logToFile task logs to a file only (no inline display): route the lines through this
+        // context's own logger so they join the same downloadable file (a flat file has no taskrun
+        // to link to). Otherwise emit through a logger bound to the dynamic taskrun, so the lines
+        // are attributed to it while still passing through the regular appender pipeline.
+        org.slf4j.Logger logger = this.logToFile ? this.logger() : deriveLoggerFor(dynamicTaskRun).logger();
+
+        for (DynamicTaskRunLog log : logs) {
+            logger.atLevel(log.level()).log(log.message());
+        }
+    }
+
+    /**
+     * Derive a logger bound to a dynamically-generated taskrun: a child of this context that shares
+     * its log emitter, level filter and known secrets, but emits under the taskrun's id with a fixed
+     * attempt 0 (these taskruns have a single attempt and the log view groups by the 0-based
+     * attempt). Execution, tenant, namespace and flow are taken from this context, so a caller can
+     * only ever target this execution's taskrun — never forge a log for another execution or tenant.
+     */
+    private RunContextLogger deriveLoggerFor(TaskRun dynamicTaskRun) {
+        LogEntry boundLogEntry = LogEntry.builder()
+            .tenantId(this.logEntry.getTenantId())
+            .executionId(this.logEntry.getExecutionId())
+            .namespace(this.logEntry.getNamespace())
+            .flowId(this.logEntry.getFlowId())
+            .executionKind(this.logEntry.getExecutionKind())
+            .taskId(dynamicTaskRun.getTaskId())
+            .taskRunId(dynamicTaskRun.getId())
+            .attemptNumber(0)
+            .build();
+
+        RunContextLogger taskRunLogger = new RunContextLogger(this.logQueue, boundLogEntry, null, false);
+        taskRunLogger.loglevel = this.loglevel; // inherit this context's level filter as-is (logback Level)
+        taskRunLogger.useSecrets.addAll(this.useSecrets);
+        return taskRunLogger;
     }
 
     private Logger initializeLogger() {

--- a/core/src/test/java/io/kestra/core/runners/RunContextLoggerTest.java
+++ b/core/src/test/java/io/kestra/core/runners/RunContextLoggerTest.java
@@ -15,6 +15,8 @@ import org.slf4j.event.Level;
 import io.kestra.core.junit.annotations.KestraTest;
 import io.kestra.core.models.executions.Execution;
 import io.kestra.core.models.executions.LogEntry;
+import io.kestra.core.models.executions.TaskRun;
+import io.kestra.core.models.executions.TaskRunAttempt;
 import io.kestra.core.models.flows.Flow;
 import io.kestra.core.queues.QueueFactoryInterface;
 import io.kestra.core.queues.QueueInterface;
@@ -193,6 +195,155 @@ class RunContextLoggerTest {
         runContextLogger.resetMDC();
 
         assertThat(adapter.getCopyOfContextMap()).isNullOrEmpty();
+    }
+
+    @Test
+    void emitDynamicTaskRunLogs_forcesContextAndAttemptZeroAndMasks() {
+        List<LogEntry> logs = new CopyOnWriteArrayList<>();
+        Flux<LogEntry> receive = TestsUtils.receive(logQueue, either -> logs.add(either.getLeft()));
+
+        Flow flow = TestsUtils.mockFlow();
+        Execution execution = TestsUtils.mockExecution(flow, Map.of());
+
+        RunContextLogger runContextLogger = new RunContextLogger(
+            logQueue,
+            LogEntry.of(execution),
+            Level.TRACE,
+            false
+        );
+        runContextLogger.usedSecret("super-secret-value");
+
+        // a dynamic taskrun that (deliberately) carries a foreign execution/tenant and one attempt:
+        // the emitted entry must NOT inherit those — execution/tenant/namespace/flow come from the context.
+        TaskRun dynamicTaskRun = TaskRun.builder()
+            .id("dyn-taskrun-id")
+            .taskId("Play | Task 1")
+            .tenantId("other-tenant")
+            .executionId("other-execution")
+            .namespace("other.namespace")
+            .flowId("other-flow")
+            .attempts(List.of(TaskRunAttempt.builder().build()))
+            .build();
+
+        runContextLogger.emitDynamicTaskRunLogs(dynamicTaskRun, List.of(new DynamicTaskRunLog(Level.ERROR, "leak super-secret-value here")));
+
+        List<LogEntry> queueLogs = TestsUtils.awaitLogs(logs, 1);
+        receive.blockLast();
+        assertThat(queueLogs).hasSize(1);
+        LogEntry emitted = queueLogs.getFirst();
+        assertThat(emitted.getTaskRunId()).isEqualTo("dyn-taskrun-id");
+        assertThat(emitted.getTaskId()).isEqualTo("Play | Task 1");
+        assertThat(emitted.getAttemptNumber()).isEqualTo(0);
+        assertThat(emitted.getExecutionId()).isEqualTo(execution.getId());
+        assertThat(emitted.getExecutionId()).isNotEqualTo("other-execution");
+        assertThat(emitted.getTenantId()).isEqualTo(execution.getTenantId());
+        assertThat(emitted.getNamespace()).isEqualTo(execution.getNamespace());
+        assertThat(emitted.getFlowId()).isEqualTo(execution.getFlowId());
+        assertThat(emitted.getLevel()).isEqualTo(Level.ERROR);
+        assertThat(emitted.getMessage()).isEqualTo("leak ****** here");
+    }
+
+    @Test
+    void emitDynamicTaskRunLogs_inheritsLevelFilter() {
+        List<LogEntry> logs = new CopyOnWriteArrayList<>();
+        Flux<LogEntry> receive = TestsUtils.receive(logQueue, either -> logs.add(either.getLeft()));
+
+        Flow flow = TestsUtils.mockFlow();
+        Execution execution = TestsUtils.mockExecution(flow, Map.of());
+
+        // the context filters at WARN: an INFO dynamic line must be dropped, like any task log
+        RunContextLogger runContextLogger = new RunContextLogger(
+            logQueue,
+            LogEntry.of(execution),
+            Level.WARN,
+            false
+        );
+
+        TaskRun dynamicTaskRun = TaskRun.builder()
+            .id("dyn-taskrun-id")
+            .taskId("Play | Task 1")
+            .attempts(List.of(TaskRunAttempt.builder().build()))
+            .build();
+
+        runContextLogger.emitDynamicTaskRunLogs(dynamicTaskRun, List.of(
+            new DynamicTaskRunLog(Level.INFO, "info dropped by filter"),
+            new DynamicTaskRunLog(Level.ERROR, "error kept")
+        ));
+
+        List<LogEntry> queueLogs = TestsUtils.awaitLogs(logs, 1);
+        receive.blockLast();
+        assertThat(queueLogs).hasSize(1);
+        assertThat(queueLogs.getFirst().getLevel()).isEqualTo(Level.ERROR);
+        assertThat(queueLogs.getFirst().getMessage()).isEqualTo("error kept");
+        assertThat(queueLogs).noneMatch(l -> l.getLevel().equals(Level.INFO));
+    }
+
+    @Test
+    void emitDynamicTaskRunLogs_underLogToFileGoesToFileNotQueue() throws Exception {
+        List<LogEntry> logs = new CopyOnWriteArrayList<>();
+        Flux<LogEntry> receive = TestsUtils.receive(logQueue, either -> logs.add(either.getLeft()));
+
+        Flow flow = TestsUtils.mockFlow();
+        Execution execution = TestsUtils.mockExecution(flow, Map.of());
+
+        // logToFile=true: task logs are file-only, so the dynamic lines must land in the file
+        // (with masking) and never reach the inline log queue
+        RunContextLogger runContextLogger = new RunContextLogger(
+            logQueue,
+            LogEntry.of(execution),
+            Level.TRACE,
+            true
+        );
+        runContextLogger.usedSecret("super-secret-value");
+
+        TaskRun dynamicTaskRun = TaskRun.builder()
+            .id("dyn-taskrun-id")
+            .taskId("Play | Task 1")
+            .attempts(List.of(TaskRunAttempt.builder().build()))
+            .build();
+
+        runContextLogger.emitDynamicTaskRunLogs(dynamicTaskRun, List.of(
+            new DynamicTaskRunLog(Level.INFO, "to file super-secret-value")
+        ));
+
+        runContextLogger.closeLogFile();
+        String fileContent = java.nio.file.Files.readString(runContextLogger.getLogFile().toPath());
+        receive.blockLast();
+        assertThat(fileContent).contains("to file ******");
+        // file-only: ContextAppender is not attached, so nothing reaches the inline queue
+        assertThat(logs).isEmpty();
+    }
+
+    @Test
+    void emitDynamicTaskRunLogs_seedsMDCWithDynamicTaskRunIdentity() {
+        Flow flow = TestsUtils.mockFlow();
+        Execution execution = TestsUtils.mockExecution(flow, Map.of());
+
+        // mirror exactly how emitDynamicTaskRunLogs binds the child logger for a dynamic taskrun:
+        // execution context + the dynamic taskrun's id/taskId, attempt 0
+        LogEntry boundLogEntry = LogEntry.of(execution).toBuilder()
+            .taskId("Play | Task 1")
+            .taskRunId("dyn-taskrun-id")
+            .attemptNumber(0)
+            .build();
+
+        RunContextLogger runContextLogger = new RunContextLogger(
+            logQueue,
+            boundLogEntry,
+            Level.TRACE,
+            false
+        );
+        ch.qos.logback.classic.Logger perRunLogger =
+            (ch.qos.logback.classic.Logger) runContextLogger.logger();
+
+        // the per-run MDC carries the dynamic taskrun identity (taskRunId/taskId), not just the
+        // execution context — so forwarded server logs are attributed to the dynamic taskrun too
+        assertThat(perRunLogger.getLoggerContext().getMDCAdapter().getCopyOfContextMap())
+            .containsEntry("taskRunId", "dyn-taskrun-id")
+            .containsEntry("taskId", "Play | Task 1")
+            .containsEntry("executionId", execution.getId())
+            .containsEntry("namespace", execution.getNamespace())
+            .containsEntry("flowId", execution.getFlowId());
     }
 
     /**

--- a/ui/src/components/executions/Gantt.vue
+++ b/ui/src/components/executions/Gantt.vue
@@ -54,20 +54,22 @@
                                             <ChevronRight v-if="!selectedTaskRuns.includes(item.id)" />
                                             <ChevronDown v-else />
                                         </div>
-                                        <el-tooltip placement="top-start" :persistent="false" transition="el-fade-in-linear" :autoClose="2000" effect="light">
-                                            <template #content>
-                                                <code>{{ item.name }}</code>
-                                                <small v-if="item.task && item.task.value"><br>{{ item.task.value }}</small>
-                                            </template>
-                                            <span v-if="verticalLayout" class="task-name">
-                                                <code :title="item.name">{{ item.name }}</code>
-                                                <small v-if="item.task && item.task.value"> {{ item.task.value }}</small>
-                                            </span>
-                                            <span v-else>
-                                                <code>{{ item.name }}</code>
-                                                <small v-if="item.task && item.task.value"> {{ item.task.value }}</small>
-                                            </span>
-                                        </el-tooltip>
+                                        <div class="task-label" :style="{'--depth': item.depth || 0}">
+                                            <el-tooltip placement="top-start" :persistent="false" transition="el-fade-in-linear" :autoClose="2000" effect="light">
+                                                <template #content>
+                                                    <code>{{ item.name }}</code>
+                                                    <small v-if="item.task && item.task.value"><br>{{ item.task.value }}</small>
+                                                </template>
+                                                <span v-if="verticalLayout" class="task-name">
+                                                    <code :title="item.name">{{ item.name }}</code>
+                                                    <small v-if="item.task && item.task.value"> {{ item.task.value }}</small>
+                                                </span>
+                                                <span v-else>
+                                                    <code>{{ item.name }}</code>
+                                                    <small v-if="item.task && item.task.value"> {{ item.task.value }}</small>
+                                                </span>
+                                            </el-tooltip>
+                                        </div>
                                         <div>
                                             <el-tooltip v-if="item.attempts > 1" placement="right" :persistent="false" transition="el-fade-in-linear" :autoClose="2000" effect="light">
                                                 <template #content>
@@ -676,6 +678,15 @@
 
                 > * {
                     padding: 1rem .5rem;
+                }
+
+                .task-label {
+                    flex: 1;
+                    min-width: 0;
+                    display: flex;
+                    align-items: center;
+                    // indent dynamically-generated child taskruns under their parent
+                    padding-left: calc(.5rem + (var(--depth, 0) * 1.5rem));
                 }
 
                 .el-tooltip__trigger {

--- a/ui/src/components/executions/TaskRunLine.vue
+++ b/ui/src/components/executions/TaskRunLine.vue
@@ -1,5 +1,5 @@
 <template>
-    <div class="taskrun-header">
+    <div class="taskrun-header" :style="{'--depth': depth}">
         <div>
             <el-icon
                 v-if="!taskRunId && shouldDisplayChevron(currentTaskRun)"
@@ -221,6 +221,10 @@
             AiIcon
         },
         props: {
+            depth: {
+                type: Number,
+                default: 0,
+            },
             currentTaskRun: {
                 type: Object,
                 required: true
@@ -438,6 +442,8 @@
 
     .taskrun-header {
         background-color: var(--ks-background-table-header);
+        // indent dynamically-generated child taskruns under their parent
+        padding-left: calc(1rem + (var(--depth, 0) * 1.5rem));
         .task-icon {
             width: 36px;
             padding: 6px 6px 6px 0;

--- a/ui/src/components/inputs/LowCodeEditor.vue
+++ b/ui/src/components/inputs/LowCodeEditor.vue
@@ -330,8 +330,15 @@
         }
     };
 
-    const showLogs = (event: string) => {
-        selectedTask.value = event;
+    const showLogs = (event: any) => {
+        // include the task's dynamically-generated child taskruns (e.g. Ansible plays/tasks,
+        // dbt models) so their logs show alongside the task's own, not just the root taskrun
+        const taskRuns = event?.taskRuns ?? [];
+        const ids = new Set(taskRuns.map((t: any) => t.id));
+        const children = (executionsStore.execution?.taskRunList ?? []).filter(
+            (t: any) => t.parentTaskRunId && ids.has(t.parentTaskRunId),
+        );
+        selectedTask.value = {...event, taskRuns: [...taskRuns, ...children]};
         isShowLogsOpen.value = true;
         isDrawerOpen.value = true;
     };

--- a/ui/src/components/logs/TaskRunDetails.vue
+++ b/ui/src/components/logs/TaskRunDetails.vue
@@ -23,6 +23,7 @@
                 <el-card class="attempt-wrapper">
                     <TaskRunLine
                         :currentTaskRun="currentTaskRun"
+                        :depth="currentTaskRun.depth ?? 0"
                         :followedExecution="followedExecution"
                         :flow="flow"
                         :forcedAttemptNumber="forcedAttemptNumber"
@@ -459,11 +460,40 @@
                 return Download;
             },
             currentTaskRuns() {
-                return (
-                    this.followedExecution?.taskRunList?.filter((tr) =>
-                        this.taskRunId ? tr.id === this.taskRunId : true,
-                    ) ?? []
-                );
+                const taskRunList = this.followedExecution?.taskRunList ?? [];
+
+                if (this.taskRunId) {
+                    return taskRunList
+                        .filter((tr) => tr.id === this.taskRunId)
+                        .map((tr) => ({...tr, depth: 0}));
+                }
+
+                // Order taskruns parent → child and annotate depth, so dynamically-generated
+                // taskruns (e.g. each Ansible play/task or dbt model) render indented under
+                // their parent taskrun.
+                const byId = Object.fromEntries(taskRunList.map((tr) => [tr.id, tr]));
+                const childrenByParent = {};
+                const roots = [];
+                for (const tr of taskRunList) {
+                    if (tr.parentTaskRunId && byId[tr.parentTaskRunId]) {
+                        (childrenByParent[tr.parentTaskRunId] ??= []).push(tr);
+                    } else {
+                        roots.push(tr);
+                    }
+                }
+
+                const ordered = [];
+                const walk = (nodes, depth) => {
+                    for (const node of nodes) {
+                        ordered.push({...node, depth});
+                        const children = childrenByParent[node.id];
+                        if (children) {
+                            walk(children, depth + 1);
+                        }
+                    }
+                };
+                walk(roots, 0);
+                return ordered;
             },
             params() {
                 let params = {minLevel: this.level};

--- a/ui/vite.config.js
+++ b/ui/vite.config.js
@@ -33,7 +33,7 @@ export default defineConfig({
     server: {
         proxy: {
             "^/api": {
-                target: "http://localhost:8080",
+                target: process.env.VITE_APP_LOGIN_URL || "http://localhost:8080",
                 ws: true,
                 changeOrigin: true
             }


### PR DESCRIPTION
Backport of kestra-io/kestra#16898 (cherry-picked from d0a7fe087f) to releases/v1.3.x.

Adaptations required for 1.3.x (not a clean cherry-pick):
- Core: `RunContextLogger` rewired to 1.3.x's `QueueInterface<LogEntry> logQueue` (develop renamed this to `LogEntryEmitter`, which doesn't exist on 1.3.x). The develop-only `emitLog`/`emitLogs` helpers were omitted (the feature doesn't use them). The 4 new tests use the 1.3.x `TestsUtils.receive`/`awaitLogs` idiom.
- UI re-implemented against 1.3.x's Options-API + Element-Plus components: depth indentation in `Gantt.vue`, `TaskRunLine.vue` (new `depth` prop) and the Logs view (`TaskRunDetails.vue`, parent → child ordering).
- The topology "show task logs includes dynamic child taskruns" lands in `LowCodeEditor.vue` (1.3.x has no `ui/packages/topology/.../TaskNode.vue`; the show-logs handler there now appends the node's dynamic children by `parentTaskRunId`).

Verified: core `compileJava`/`compileTestJava` green; UI `vue-tsc --noEmit` green.
