### PR TITLE
fix(dashboard): apply active dashboard filters to chart CSV export

### DIFF
--- a/ui/src/components/dashboard/sections/Sections.vue
+++ b/ui/src/components/dashboard/sections/Sections.vue
@@ -30,7 +30,7 @@
                                 :tooltip="$t('dashboards.export')"
                             >
                                 <KsButton
-                                    @click="dashboardStore.export(dashboard, chart, {filters})"
+                                    @click="exportChart(chart)"
                                     :icon="Download"
                                     link
                                     class="ms-2"
@@ -81,6 +81,8 @@
     import {useRoute} from "vue-router"
     const route = useRoute()
 
+    import {decodeSearchParams} from "@kestra-io/design-system"
+
     import {useDashboardStore} from "../../../stores/dashboard"
     const dashboardStore = useDashboardStore()
 
@@ -124,6 +126,12 @@
 
         return baseFilters
     })
+
+    function exportChart(chart: Chart) {
+        dashboardStore.export(props.dashboard, chart, {
+            filters: filters.value.concat(decodeSearchParams(route.query) ?? []),
+        })
+    }
 </script>
 
 <style scoped lang="scss">


### PR DESCRIPTION
✨ Description

Dashboard table chart CSV export now uses the same filters as the table shown on screen.

Previously the export button sent only the base filters (empty for a standalone dashboard; namespace/flowId only when embedded in a flow or namespace page). It did not include the filters the table display decodes from the URL via decodeSearchParams(route.query). This had two effects:

1. The selected time range was never sent, so the backend fell back to its fixed default window (TimeLineSearch → now − 8 days). Exporting a table while viewing data older than that default returned an empty 0-byte CSV even though the table was full of rows.
2. Other applied filters (namespace, state, scope, labels, flowId) were also dropped, so the export could include rows the user had filtered out on screen.

Sections.vue now builds the export filters identically to the display (useChartGenerator):

function exportChart(chart) {
    dashboardStore.export(props.dashboard, chart, {
        filters: filters.value.concat(decodeSearchParams(route.query) ?? []),
    })
}

So the export and the displayed table can no longer disagree about which window or filters to query.