### PR TITLE
fix(namespaces): refresh open editor tab when restoring a file revision

### DIFF
--- a/ui/src/components/flows/useFilesPanels.ts
+++ b/ui/src/components/flows/useFilesPanels.ts
@@ -1,5 +1,5 @@
-import {h, markRaw, onScopeDispose, provide, Ref, watchEffect} from "vue"
-import FlowFileEditorTab, {EditorTabProps, FILES_SET_DIRTY_INJECTION_KEY, FILES_UPDATE_CONTENT_INJECTION_KEY} from "../inputs/FlowFileEditorTab.vue"
+import {h, markRaw, onScopeDispose, provide, ref, Ref, watchEffect} from "vue"
+import FlowFileEditorTab, {EditorTabProps, FILES_REFRESH_CONTENT_INJECTION_KEY, FILES_SET_DIRTY_INJECTION_KEY, FILES_UPDATE_CONTENT_INJECTION_KEY} from "../inputs/FlowFileEditorTab.vue"
 import TypeIcon from "../utils/icons/Type.vue"
 import {EditorElement, Panel, Tab, TabLive} from "../../utils/multiPanelTypes"
 import {FILES_CLOSE_TAB_INJECTION_KEY, FILES_OPEN_TAB_INJECTION_KEY} from "../inputs/FileExplorer.vue"
@@ -100,9 +100,9 @@ export function useFilesPanels(panels: Ref<Panel[]>, namespace: Ref<string | und
         const uid = generateUid(tab)
         for(const panel of panels.value){
             const tabIndex = panel.tabs.findIndex(e => e.uid.startsWith(uid))
-            
+
             if (tabIndex > -1) {
-                // if the closed tab is the active one, 
+                // if the closed tab is the active one,
                 // we need to set a new active tab
                 panel.tabs.splice(tabIndex, 1)
                 if (panel.tabs.length === 0) {
@@ -111,7 +111,7 @@ export function useFilesPanels(panels: Ref<Panel[]>, namespace: Ref<string | und
                 }
                 panel.activeTab = panel.tabs[
                     Math.min(
-                        tabIndex, 
+                        tabIndex,
                         panel.tabs.length - 1,
                     )
                 ]
@@ -135,6 +135,9 @@ export function useFilesPanels(panels: Ref<Panel[]>, namespace: Ref<string | und
             tab.path = path
         }
     })
+
+    const externalContentUpdates = ref<Record<string, {content: string}>>({})
+    provide(FILES_REFRESH_CONTENT_INJECTION_KEY, externalContentUpdates)
 
     const namespacesStore = useNamespacesStore()
 

--- a/ui/src/components/inputs/FileExplorer.vue
+++ b/ui/src/components/inputs/FileExplorer.vue
@@ -396,6 +396,7 @@
         useFileExplorerStore,
     } from "../../stores/fileExplorer"
     import Revisions, {Revision} from "../layout/Revisions.vue"
+    import {FILES_REFRESH_CONTENT_INJECTION_KEY} from "./FlowFileEditorTab.vue"
     import Crud from "override/components/auth/Crud.vue"
     import Checkbox from "../layout/Checkbox.vue"
     import {useAuthStore} from "override/stores/auth"
@@ -422,6 +423,7 @@
     }>()
 
     const openTab = inject(FILES_OPEN_TAB_INJECTION_KEY)
+    const refreshTabContent = inject(FILES_REFRESH_CONTENT_INJECTION_KEY, undefined)
 
     // exposed so parents (e.g. the dedicated empty state) can reuse the
     // create dialog instead of duplicating file-creation logic
@@ -675,19 +677,24 @@
     }
 
     async function restore(source: string) {
+        const path = revisionsHistory.value.path
+
         await namespacesStore.saveOrCreateFile({
             namespace: namespaceId.value,
-            path: revisionsHistory.value.path,
+            path,
             content: source,
         })
 
         toast.success(t("namespace files.revisions.restore.success"))
 
-        closeTab?.({path: revisionsHistory.value.path})
+        if (refreshTabContent) {
+            refreshTabContent.value[path] = {content: source}
+        }
+
         openTab?.({
-            name: revisionsHistory.value.path.split("/").pop()!,
-            path: revisionsHistory.value.path,
-            extension: revisionsHistory.value.path.split(".").pop()!,
+            name: path.split("/").pop()!,
+            path,
+            extension: path.split(".").pop()!,
             flow: false,
             dirty: false,
         })

--- a/ui/src/components/inputs/FlowFileEditorTab.vue
+++ b/ui/src/components/inputs/FlowFileEditorTab.vue
@@ -63,6 +63,11 @@
 <script lang="ts">
     export const FILES_SET_DIRTY_INJECTION_KEY = Symbol("files-set-dirty-injection-key") as InjectionKey<(payload: { path: string; dirty: boolean }) => void>
     export const FILES_UPDATE_CONTENT_INJECTION_KEY = Symbol("files-update-content-injection-key") as InjectionKey<(payload: { path: string; content: string }) => void>
+    // Shared channel that lets actions outside the editor (e.g. restoring a revision)
+    // push fresh content into an already-open file tab so it refreshes in place.
+    // Keyed by file path; the entry object reference changes on each push so the
+    // editor tab can react even when restoring the same content twice.
+    export const FILES_REFRESH_CONTENT_INJECTION_KEY = Symbol("files-refresh-content-injection-key") as InjectionKey<Ref<Record<string, { content: string }>>>
 
     export interface EditorTabProps {
         name: string;
@@ -74,7 +79,7 @@
 </script>
 
 <script setup lang="ts">
-    import {computed, onActivated, onMounted, ref, provide, onBeforeUnmount, watch, InjectionKey, inject} from "vue"
+    import {computed, onActivated, onMounted, ref, provide, onBeforeUnmount, watch, InjectionKey, inject, type Ref} from "vue"
     import {useRoute, useRouter} from "vue-router"
     import {apiUrl} from "override/utils/route"
     import type * as monaco from "monaco-editor/esm/vs/editor/editor.api"
@@ -284,6 +289,20 @@
 
 
     const updateContent = inject(FILES_UPDATE_CONTENT_INJECTION_KEY)
+
+    // React to content pushed from outside the editor (e.g. restoring a revision):
+    // refresh the already-open tab in place instead of relying on a close/reopen,
+    // which is a no-op for an open file because the tab keeps the same cached uid.
+    const externalContentUpdates = inject(FILES_REFRESH_CONTENT_INJECTION_KEY, undefined)
+    watch(() => (props.path ? externalContentUpdates?.value[props.path] : undefined), (update) => {
+        if (!update || props.flow) return
+        sourceNS.value = update.content
+        // restored content becomes the new clean baseline so the tab is not flagged dirty
+        savedSourceNS.value = update.content
+        if (props.path) {
+            updateContent?.({path: props.path, content: update.content})
+        }
+    })
 
     function editorUpdate(newValue: string){
         if (editorContent.value === newValue) {


### PR DESCRIPTION
Fixes restoring a revision from the Namespace Files Revision history having no visible effect when the file is already open in the editor. restore() used a closeTab() + openTab() in the same tick to refresh the editor, but the tab keeps the same cached uid, so MultiPanelTabs never remounts FlowFileEditorTab and the editor keeps showing stale content (the file was saved on the backend). Replaced the no-op close/reopen with a reactive channel that pushes the restored content straight into the open tab.

🔗 Related Issue

Closes https://github.com/kestra-io/kestra-ee/issues/8951