### PR TITLE
fix(namespaces): preserve spaces and distinguish '+' in namespace file paths

### DIFF
--- a/core/src/main/java/io/kestra/core/storages/NamespaceFile.java
+++ b/core/src/main/java/io/kestra/core/storages/NamespaceFile.java
@@ -1,6 +1,7 @@
 package io.kestra.core.storages;
 
 import java.net.URI;
+import java.net.URISyntaxException;
 import java.nio.file.Path;
 import java.util.Objects;
 import java.util.regex.Matcher;
@@ -146,12 +147,21 @@ public record NamespaceFile(
             storagePath += ".v" + revision;
         }
 
-        return new NamespaceFile(
-            pathWithoutLeadingSlash,
-            URI.create(StorageContext.KESTRA_PROTOCOL + namespacePrefixPath.resolve(storagePath).toString().replace("\\", "/") + (isDirectory(path) ? "/" : "")),
-            namespace,
-            revision
-        );
+        // Use the multi-argument URI constructor so that URI-illegal characters (e.g. spaces)
+        // are percent-encoded (space → %20) while legal URI path characters (e.g. '+') are
+        // preserved unchanged — keeping "a b.txt" and "a+b.txt" as two distinct stored objects.
+        String uriPath = namespacePrefixPath.resolve(storagePath).toString().replace("\\", "/")
+            + (isDirectory(path) ? "/" : "");
+        try {
+            return new NamespaceFile(
+                pathWithoutLeadingSlash,
+                new URI(StorageContext.KESTRA_SCHEME, "", uriPath, null),
+                namespace,
+                revision
+            );
+        } catch (URISyntaxException e) {
+            throw new IllegalArgumentException("Invalid namespace file path: " + path, e);
+        }
     }
 
     public static Path normalize(Path path) {

--- a/core/src/test/java/io/kestra/core/storages/NamespaceFileTest.java
+++ b/core/src/test/java/io/kestra/core/storages/NamespaceFileTest.java
@@ -173,4 +173,25 @@ class NamespaceFileTest {
         assertThat(toLogicalPath(NamespaceFile.normalize(Path.of("/file..with..dots")))).isEqualTo("/file..with..dots");
     }
 
+    @Test
+    void shouldDistinguishSpaceAndPlusInStorageUri() {
+        // Regression: "a b.txt" (space) and "a+b.txt" (literal '+') must map to distinct storage URIs.
+        // Previously, URLEncoder.encode(space) = '+', causing both names to collide on the same object.
+        NamespaceFile spaceFile = NamespaceFile.of(NAMESPACE, Path.of("/a b.txt"));
+        NamespaceFile plusFile  = NamespaceFile.of(NAMESPACE, Path.of("/a+b.txt"));
+
+        // Space must be percent-encoded in the URI (URI-illegal → %20); '+' must remain '+' (URI-legal).
+        assertThat(spaceFile.uri().toString()).contains("%20");
+        assertThat(spaceFile.uri().toString()).doesNotContain("a+b.txt");
+        assertThat(plusFile.uri().toString()).contains("a+b.txt");
+        assertThat(plusFile.uri().toString()).doesNotContain("%20");
+
+        // The two URIs must be distinct — no silent collision.
+        assertThat(spaceFile.uri()).isNotEqualTo(plusFile.uri());
+
+        // storagePath() must round-trip back to the decoded path.
+        assertThat(spaceFile.storagePath().toString()).endsWith("a b.txt");
+        assertThat(plusFile.storagePath().toString()).endsWith("a+b.txt");
+    }
+
 }

--- a/webserver/src/main/java/io/kestra/webserver/controllers/api/NamespaceFileController.java
+++ b/webserver/src/main/java/io/kestra/webserver/controllers/api/NamespaceFileController.java
@@ -3,8 +3,6 @@ package io.kestra.webserver.controllers.api;
 import java.io.*;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.net.URLEncoder;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -85,7 +83,7 @@ public class NamespaceFileController {
         @Nullable @Parameter(description = "The revision, if not provided, the latest revision will be returned") @QueryValue Integer revision) throws IOException, URISyntaxException {
         URI encodedPath = null;
         if (path != null) {
-            encodedPath = new URI(URLEncoder.encode(path, StandardCharsets.UTF_8));
+            encodedPath = toFileUri(path);
         }
         forbiddenPathsGuard(encodedPath);
 
@@ -103,7 +101,7 @@ public class NamespaceFileController {
         @Parameter(description = "The internal storage uri") @Nullable @QueryValue String path) throws IOException, URISyntaxException {
         URI encodedPath = null;
         if (path != null) {
-            encodedPath = new URI(URLEncoder.encode(path, StandardCharsets.UTF_8));
+            encodedPath = toFileUri(path);
         }
         forbiddenPathsGuard(encodedPath);
 
@@ -128,7 +126,7 @@ public class NamespaceFileController {
         @Parameter(description = "The internal storage uri") @Nullable @QueryValue String path) throws IOException, URISyntaxException {
         URI encodedPath = null;
         if (path != null) {
-            encodedPath = new URI(URLEncoder.encode(path, StandardCharsets.UTF_8));
+            encodedPath = toFileUri(path);
         }
         forbiddenPathsGuard(encodedPath);
 
@@ -156,7 +154,7 @@ public class NamespaceFileController {
         @Parameter(description = "The internal storage uri") @Nullable @QueryValue String path) throws IOException, URISyntaxException {
         URI encodedPath = null;
         if (path != null) {
-            encodedPath = new URI(URLEncoder.encode(path, StandardCharsets.UTF_8));
+            encodedPath = toFileUri(path);
         }
         forbiddenPathsGuard(encodedPath);
 
@@ -182,7 +180,7 @@ public class NamespaceFileController {
         @Parameter(description = "The internal storage uri") @Nullable @QueryValue String path) throws IOException, URISyntaxException {
         URI encodedPath = null;
         if (path != null) {
-            encodedPath = new URI(URLEncoder.encode(path, StandardCharsets.UTF_8));
+            encodedPath = toFileUri(path);
         }
         forbiddenPathsGuard(encodedPath);
 
@@ -212,7 +210,7 @@ public class NamespaceFileController {
                     }
 
                     try (BufferedInputStream inputStream = new BufferedInputStream(new ByteArrayInputStream(archive.readAllBytes()))) {
-                        createdFiles.addAll(putNamespaceFile(tenantId, namespace, URI.create("/" + entry.getName()), inputStream));
+                        createdFiles.addAll(putNamespaceFile(tenantId, namespace, toFileUri("/" + entry.getName()), inputStream));
                     }
                 }
             }
@@ -224,7 +222,7 @@ public class NamespaceFileController {
                     return (int) fileContent.getSize();
                 }
             }) {
-                createdFiles.addAll(putNamespaceFile(tenantId, namespace, new URI(URLEncoder.encode(path, StandardCharsets.UTF_8)), inputStream));
+                createdFiles.addAll(putNamespaceFile(tenantId, namespace, toFileUri(path), inputStream));
             }
         }
 
@@ -340,7 +338,7 @@ public class NamespaceFileController {
         if (!path.startsWith("/")) {
             path = "/" + path;
         }
-        encodedPath = new URI(URLEncoder.encode(path, StandardCharsets.UTF_8));
+        encodedPath = toFileUri(path);
         ensureWritableNamespaceFile(encodedPath);
 
         String pathWithoutScheme = encodedPath.getPath();
@@ -362,6 +360,16 @@ public class NamespaceFileController {
 
         Namespace namespaceStorage = namespaceFactory.of(tenantId, namespace, storageInterface);
         return namespaceStorage.delete(Path.of(zombieAwarePathToDelete));
+    }
+
+    /**
+     * Builds a URI from an already-decoded namespace file path.
+     * Uses the multi-argument URI constructor so that only URI-illegal characters are percent-encoded
+     * (e.g. space → %20) while legal characters such as '+' are preserved,
+     * keeping "a b.txt" and "a+b.txt" as two distinct paths.
+     */
+    private static URI toFileUri(String path) throws URISyntaxException {
+        return new URI(null, null, path, null);
     }
 
     private void forbiddenPathsGuard(URI path) {

--- a/webserver/src/test/java/io/kestra/webserver/controllers/api/NamespaceFileControllerTest.java
+++ b/webserver/src/test/java/io/kestra/webserver/controllers/api/NamespaceFileControllerTest.java
@@ -398,6 +398,52 @@ class NamespaceFileControllerTest {
     }
 
     @Test
+    @SuppressWarnings("unchecked")
+    void shouldNotCollideSpaceAndPlusInFileName() throws IOException {
+        // Given: two distinct filenames — one with a space, one with a literal '+'
+        String namespace = TestsUtils.randomNamespace();
+        MultipartBody spaceBody = MultipartBody.builder()
+            .addPart("fileContent", "a b.txt", "SPACE-version".getBytes())
+            .build();
+        MultipartBody plusBody = MultipartBody.builder()
+            .addPart("fileContent", "a+b.txt", "PLUS-version".getBytes())
+            .build();
+
+        // When: upload both files (%20 = space, %2B = literal '+' in the query param)
+        client.toBlocking().exchange(
+            HttpRequest.POST("/api/v1/main/namespaces/" + namespace + "/files?path=/c/a%20b.txt", spaceBody)
+                .contentType(MediaType.MULTIPART_FORM_DATA_TYPE)
+        );
+        client.toBlocking().exchange(
+            HttpRequest.POST("/api/v1/main/namespaces/" + namespace + "/files?path=/c/a%2Bb.txt", plusBody)
+                .contentType(MediaType.MULTIPART_FORM_DATA_TYPE)
+        );
+
+        // Then: reading back each file via the HTTP API returns its own distinct content
+        String spaceContent = client.toBlocking().retrieve(
+            HttpRequest.GET("/api/v1/main/namespaces/" + namespace + "/files?path=/c/a%20b.txt")
+        );
+        assertThat(spaceContent)
+            .as("file with space in name should return SPACE-version, not be silently overwritten by the '+' file")
+            .isEqualTo("SPACE-version");
+
+        String plusContent = client.toBlocking().retrieve(
+            HttpRequest.GET("/api/v1/main/namespaces/" + namespace + "/files?path=/c/a%2Bb.txt")
+        );
+        assertThat(plusContent)
+            .as("file with literal '+' in name should return PLUS-version")
+            .isEqualTo("PLUS-version");
+
+        // And: the directory listing shows two distinct entries with the correct displayed names
+        List<Map<String, Object>> listing = (List<Map<String, Object>>) JacksonMapper.toObject(
+            client.toBlocking().retrieve(HttpRequest.GET("/api/v1/main/namespaces/" + namespace + "/files/directory?path=/c"))
+        );
+        assertThat(listing).hasSize(2);
+        assertThat(listing.stream().map(e -> (String) e.get("fileName")).toList())
+            .containsExactlyInAnyOrder("a b.txt", "a+b.txt");
+    }
+
+    @Test
     void forbiddenPaths() {
         String namespace = TestsUtils.randomNamespace();
         assertForbiddenErrorThrown(() -> client.toBlocking().retrieve(HttpRequest.GET("/api/v1/main/namespaces/" + namespace + "/files?path=/_flows/test.yml")));


### PR DESCRIPTION
## Summary

- Fixes a silent data-loss bug where uploading a file named `a b.txt` (space) would silently overwrite an existing file named `a+b.txt` (literal `+`), and vice versa, because both names collapsed to the same internal storage object.
- Root cause: `URLEncoder.encode()` (form-encoding rules: space→`+`) was applied to the already-decoded `path` query parameter in `NamespaceFileController`, and `URI.getPath()` does not reverse form-encoding — so `" "` and `"+"` both became `"+"` in the stored path.
- Same bug existed one level deeper in `NamespaceFile.of(String, String, int)`, where `URI.create()` was used to build the internal `kestra://` storage URI and would throw `IllegalArgumentException` for any path containing a space.

**Changes:**
- `NamespaceFileController`: replace all 7 `new URI(URLEncoder.encode(path, UTF_8))` calls with a shared `toFileUri(path)` helper using `new URI(null, null, path, null)` (multi-arg constructor encodes URI-illegal chars only, space→`%20`, `+`→`+`). Remove now-unused `URLEncoder`/`StandardCharsets` imports. Fix ZIP import path (same `URI.create()` issue for space-named entries).
- `NamespaceFile.of(String, String, int)`: replace `URI.create(KESTRA_PROTOCOL + rawPath)` with `new URI(KESTRA_SCHEME, "", rawPath, null)` so the internal storage URI is properly encoded.

## Test plan

- [ ] `NamespaceFileControllerTest.shouldNotCollideSpaceAndPlusInFileName` — new integration test: upload `a b.txt` and `a+b.txt`, read each back via HTTP, assert distinct content; check directory listing shows two entries with correct names.
- [ ] `NamespaceFileTest.shouldDistinguishSpaceAndPlusInStorageUri` — new unit test: asserts `NamespaceFile.of()` produces `%20`-encoded URI for space filenames, preserves `+` for plus filenames, and that `storagePath()` round-trips correctly.
- [ ] All 22 `NamespaceFileControllerTest` tests pass (was 21 before).
- [ ] All 18 `NamespaceFileTest` tests pass (was 17 before).

Closes #16896