### PR TITLE
fix(worker): keep outputs of timeout-protected tasks

### DIFF
--- a/worker/src/main/java/io/kestra/worker/WorkerTaskCallable.java
+++ b/worker/src/main/java/io/kestra/worker/WorkerTaskCallable.java
@@ -2,6 +2,8 @@ package io.kestra.worker;
 
 import java.time.Duration;
 
+import org.apache.commons.lang3.exception.ExceptionUtils;
+
 import io.kestra.core.exceptions.TimeoutExceededException;
 import io.kestra.core.metrics.MetricRegistry;
 import io.kestra.core.models.flows.State;
@@ -93,9 +95,20 @@ public class WorkerTaskCallable extends AbstractWorkerCallable {
             // to the caller (e.g., queue emission after timeout).
             Thread.interrupted();
             return this.exceptionHandler(new TimeoutExceededException(workerTaskTimeout));
-        } catch (RunnableTaskException e) {
-            taskOutput = e.getOutput();
+        } catch (dev.failsafe.FailsafeException e) {
+            // Failsafe wraps non-timeout exceptions; unwrap to preserve task output.
+            final RunnableTaskException originalException = ExceptionUtils.throwableOfType(e, RunnableTaskException.class);
+            if (originalException != null) {
+                return this.handleRunnableTaskException(originalException);
+            }
             return this.exceptionHandler(e);
+        } catch (RunnableTaskException e) {
+            return this.handleRunnableTaskException(e);
         }
+    }
+
+    private State.Type handleRunnableTaskException(RunnableTaskException exception) {
+        taskOutput = exception.getOutput();
+        return this.exceptionHandler(exception);
     }
 }

--- a/worker/src/test/java/io/kestra/worker/WorkerTaskCallableTest.java
+++ b/worker/src/test/java/io/kestra/worker/WorkerTaskCallableTest.java
@@ -1,0 +1,102 @@
+package io.kestra.worker;
+
+import java.time.Duration;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.Test;
+
+import com.google.common.collect.ImmutableMap;
+
+import io.kestra.core.junit.annotations.KestraTest;
+import io.kestra.core.models.executions.Execution;
+import io.kestra.core.models.executions.TaskRun;
+import io.kestra.core.models.flows.Flow;
+import io.kestra.core.models.flows.State;
+import io.kestra.core.models.property.Property;
+import io.kestra.core.models.tasks.ResolvedTask;
+import io.kestra.core.queues.QueueException;
+import io.kestra.core.queues.QueueFactoryInterface;
+import io.kestra.core.queues.QueueInterface;
+import io.kestra.core.runners.*;
+import io.kestra.core.runners.test.TaskThatFail;
+import io.kestra.core.utils.IdUtils;
+import io.kestra.core.utils.TestsUtils;
+
+import io.micronaut.context.ApplicationContext;
+import jakarta.inject.Inject;
+import jakarta.inject.Named;
+import reactor.core.publisher.Flux;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@KestraTest(rebuildContext = true)
+class WorkerTaskCallableTest {
+    @Inject
+    ApplicationContext applicationContext;
+
+    @Inject
+    @Named(QueueFactoryInterface.WORKERJOB_NAMED)
+    QueueInterface<WorkerJob> workerTaskQueue;
+
+    @Inject
+    @Named(QueueFactoryInterface.WORKERTASKRESULT_NAMED)
+    QueueInterface<WorkerTaskResult> workerTaskResultQueue;
+
+    @Inject
+    RunContextFactory runContextFactory;
+
+    @Test
+    void failedTaskWithTimeoutPreservesOutput() throws QueueException {
+        DefaultWorker worker = applicationContext.createBean(DefaultWorker.class, IdUtils.create(), 8, null);
+        worker.run();
+
+        List<WorkerTaskResult> workerTaskResults = new CopyOnWriteArrayList<>();
+        Flux<WorkerTaskResult> receive = TestsUtils.receive(workerTaskResultQueue, either -> workerTaskResults.add(either.getLeft()));
+
+        // Task that fails with output, timeout configured but NOT exceeded
+        TaskThatFail task = TaskThatFail.builder()
+            .type(TaskThatFail.class.getName())
+            .id("fail-with-output")
+            .message("preserved-output")
+            .timeout(Property.ofValue(Duration.ofSeconds(30)))
+            .build();
+
+        Flow flow = Flow.builder()
+            .id(IdUtils.create())
+            .namespace("io.kestra.unit-test")
+            .tasks(Collections.singletonList(task))
+            .build();
+
+        Execution execution = TestsUtils.mockExecution(flow, ImmutableMap.of());
+        ResolvedTask resolvedTask = ResolvedTask.of(task);
+        String executionId = execution.getId();
+
+        WorkerTask workerTask = WorkerTask.builder()
+            .runContext(runContextFactory.of(ImmutableMap.of("key", "value")))
+            .task(task)
+            .taskRun(TaskRun.of(execution, resolvedTask))
+            .build();
+
+        workerTaskQueue.emit(workerTask);
+
+        Awaitility.await().pollInterval(Duration.ofMillis(100)).atMost(Duration.ofMinutes(1))
+            .until(
+                () -> workerTaskResults.stream()
+                    .anyMatch(r -> r.getTaskRun().getExecutionId().equals(executionId) && r.getTaskRun().getState().isTerminated())
+            );
+        receive.blockLast();
+        worker.shutdown();
+
+        WorkerTaskResult result = workerTaskResults.stream()
+            .filter(r -> r.getTaskRun().getExecutionId().equals(executionId) && r.getTaskRun().getState().isTerminated())
+            .findFirst()
+            .orElseThrow();
+
+        assertThat(result.getTaskRun().getState().getCurrent()).isEqualTo(State.Type.FAILED);
+        assertThat(result.getTaskRun().getOutputs()).isNotNull();
+        assertThat(result.getTaskRun().getOutputs()).containsEntry("message", "preserved-output");
+    }
+}


### PR DESCRIPTION
### ✨ Description

Failed runs of tasks having the `timeout` property set did not set their outputs. Therefore it was not possible to inspect outputs of such failed tasks.

Running the following flow, the `timeout` property causes no task outputs getting set:

```yaml
id: timeout_error
namespace: company.team

tasks:
  - id: task_outputs_at_fail
    type: io.kestra.plugin.scripts.shell.Commands
    description: |
      Failed tasks should produce outputs.
    commands: 
      - echo 'foo' > test.txt
      - exit 1
    outputFiles:
      - '*.txt'
    timeout: PT5S # FIXME: There should be a task output
```

### 🛠️ Backend Checklist

- [x] Code compiles successfully and passes all checks
- [x] All unit and integration tests pass

> 2063 passing (14m 9s)  6 pending

### 📝 Additional Notes

* This PR does not solve the issue of an actually timed out task runs, as these still do not produce any task outputs.
* A backport to v1.2 would be appreciated 🙂
