### PR TITLE
fix(build): amend reported Gradle deprecations

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -137,34 +137,34 @@ allprojects {
             implementation "org.slf4j:slf4j-api"
             implementation "ch.qos.logback:logback-classic"
             implementation "org.codehaus.janino:janino"
-            implementation group: 'org.apache.logging.log4j', name: 'log4j-to-slf4j'
-            implementation group: 'org.slf4j', name: 'jul-to-slf4j'
-            implementation group: 'org.slf4j', name: 'jcl-over-slf4j'
-            implementation group: 'org.fusesource.jansi', name: 'jansi'
+            implementation "org.apache.logging.log4j:log4j-to-slf4j"
+            implementation "org.slf4j:jul-to-slf4j"
+            implementation "org.slf4j:jcl-over-slf4j"
+            implementation "org.fusesource.jansi:jansi"
 
             // OTEL
             implementation "io.opentelemetry:opentelemetry-exporter-otlp"
 
             // jackson
-            implementation group: 'com.fasterxml.jackson.core', name: 'jackson-core'
-            implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind'
-            implementation group: 'com.fasterxml.jackson.core', name: 'jackson-annotations'
-            implementation group: 'com.fasterxml.jackson.dataformat', name: 'jackson-dataformat-yaml'
-            implementation group: 'com.fasterxml.jackson.module', name: 'jackson-module-parameter-names'
-            implementation group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-guava'
-            implementation group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jsr310'
-            implementation group: 'com.fasterxml.uuid', name: 'java-uuid-generator'
+            implementation "com.fasterxml.jackson.core:jackson-core"
+            implementation "com.fasterxml.jackson.core:jackson-databind"
+            implementation "com.fasterxml.jackson.core:jackson-annotations"
+            implementation "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml"
+            implementation "com.fasterxml.jackson.module:jackson-module-parameter-names"
+            implementation "com.fasterxml.jackson.datatype:jackson-datatype-guava"
+            implementation "com.fasterxml.jackson.datatype:jackson-datatype-jsr310"
+            implementation "com.fasterxml.uuid:java-uuid-generator"
 
             // kestra
-            implementation group: 'com.devskiller.friendly-id', name: 'friendly-id'
-            implementation (group: 'net.thisptr', name: 'jackson-jq') {
+            implementation "com.devskiller.friendly-id:friendly-id"
+            implementation ("net.thisptr:jackson-jq") {
                 exclude group: 'com.fasterxml.jackson.core'
             }
 
             // exposed utils
-            api group: 'com.google.guava', name: 'guava'
-            api group: 'commons-io', name: 'commons-io'
-            api group: 'org.apache.commons', name: 'commons-lang3'
+            api "com.google.guava:guava"
+            api "commons-io:commons-io"
+            api "org.apache.commons:commons-lang3"
             api "io.swagger.core.v3:swagger-annotations"
             api "com.google.code.findbugs:jsr305" // brings @CheckReturnValue and already in path in core
         }

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -19,7 +19,7 @@ dependencies {
     annotationProcessor project(':processor')
 
     // serializers
-    implementation group: 'com.fasterxml.jackson.dataformat', name: 'jackson-dataformat-ion'
+    implementation "com.fasterxml.jackson.dataformat:jackson-dataformat-ion"
 
     // reactor
     api "io.projectreactor:reactor-core"
@@ -34,11 +34,11 @@ dependencies {
     // utils
     implementation 'com.github.oshi:oshi-core'
     implementation 'io.pebbletemplates:pebble'
-    implementation group: 'co.elastic.logging', name: 'logback-ecs-encoder'
-    implementation group: 'de.focus-shift', name: 'jollyday-core'
-    implementation group: 'de.focus-shift', name: 'jollyday-jaxb'
+    implementation "co.elastic.logging:logback-ecs-encoder"
+    implementation "de.focus-shift:jollyday-core"
+    implementation "de.focus-shift:jollyday-jaxb"
     implementation 'nl.basjes.gitignore:gitignore-reader'
-    implementation group: 'dev.failsafe', name: 'failsafe'
+    implementation "dev.failsafe:failsafe"
     implementation 'com.github.ben-manes.caffeine:caffeine'
     implementation 'org.bouncycastle:bcprov-jdk18on'
     implementation 'com.github.ksuid:ksuid:1.1.4'
@@ -52,15 +52,15 @@ dependencies {
     implementation 'org.apache.maven.resolver:maven-resolver-transport-apache'
 
     // scheduler
-    implementation group: 'com.cronutils', name: 'cron-utils'
+    implementation "com.cronutils:cron-utils"
 
     // schema
     implementation ("com.github.victools:jsonschema-generator") {
         exclude group: 'com.fasterxml.jackson.core'
     }
-    implementation group: 'com.github.victools', name: 'jsonschema-module-jakarta-validation'
-    implementation group: 'com.github.victools', name: 'jsonschema-module-jackson'
-    implementation group: 'com.github.victools', name: 'jsonschema-module-swagger-2'
+    implementation "com.github.victools:jsonschema-module-jakarta-validation"
+    implementation "com.github.victools:jsonschema-module-jackson"
+    implementation "com.github.victools:jsonschema-module-swagger-2"
 
     // Json Diff
     implementation ('com.github.java-json-tools:json-patch') {

--- a/platform/build.gradle
+++ b/platform/build.gradle
@@ -82,55 +82,55 @@ dependencies {
         api 'software.amazon.awssdk.crt:aws-crt:0.47.1'
 
         // Other libs
-        api("org.projectlombok:lombok:1.18.46")
-        api("org.codehaus.janino:janino:3.1.12")
-        api group: 'org.apache.logging.log4j', name: 'log4j-to-slf4j', version: '2.26.0'
-        api group: 'org.slf4j', name: 'jul-to-slf4j', version: slf4jVersion
-        api group: 'org.slf4j', name: 'jcl-over-slf4j', version: slf4jVersion
-        api group: 'org.fusesource.jansi', name: 'jansi', version: '2.4.3'
-        api group: 'com.devskiller.friendly-id', name: 'friendly-id', version: '1.1.0'
-        api group: 'net.thisptr', name: 'jackson-jq', version: '1.6.2'
-        api group: 'com.google.guava', name: 'guava', version: '33.6.0-jre'
-        api group: 'commons-io', name: 'commons-io', version: '2.22.0'
-        api group: 'org.apache.commons', name: 'commons-lang3', version: '3.20.0'
+        api "org.projectlombok:lombok:1.18.46"
+        api "org.codehaus.janino:janino:3.1.12"
+        api "org.apache.logging.log4j:log4j-to-slf4j:2.26.0"
+        api "org.slf4j:jul-to-slf4j:$slf4jVersion"
+        api "org.slf4j:jcl-over-slf4j:$slf4jVersion"
+        api "org.fusesource.jansi:jansi:2.4.3"
+        api "com.devskiller.friendly-id:friendly-id:1.1.0"
+        api "net.thisptr:jackson-jq:1.6.2"
+        api "com.google.guava:guava:33.6.0-jre"
+        api "commons-io:commons-io:2.22.0"
+        api "org.apache.commons:commons-lang3:3.20.0"
         api 'ch.qos.logback.contrib:logback-json-classic:0.1.5'
         api 'ch.qos.logback.contrib:logback-jackson:0.1.5'
-        api group: 'org.apache.maven.resolver', name: 'maven-resolver-impl', version: mavenResolverVersion
-        api group: 'org.apache.maven.resolver', name: 'maven-resolver-supplier-mvn3', version: mavenResolverVersion
-        api group: 'org.apache.maven.resolver', name: 'maven-resolver-connector-basic', version: mavenResolverVersion
-        api group: 'org.apache.maven.resolver', name: 'maven-resolver-transport-file', version: mavenResolverVersion
-        api group: 'org.apache.maven.resolver', name: 'maven-resolver-transport-apache', version: mavenResolverVersion
+        api "org.apache.maven.resolver:maven-resolver-impl:$mavenResolverVersion"
+        api "org.apache.maven.resolver:maven-resolver-supplier-mvn3:$mavenResolverVersion"
+        api "org.apache.maven.resolver:maven-resolver-connector-basic:$mavenResolverVersion"
+        api "org.apache.maven.resolver:maven-resolver-transport-file:$mavenResolverVersion"
+        api "org.apache.maven.resolver:maven-resolver-transport-apache:$mavenResolverVersion"
         api 'com.github.oshi:oshi-core:7.3.1'
         api 'io.pebbletemplates:pebble:4.1.2'
-        api group: 'co.elastic.logging', name: 'logback-ecs-encoder', version: '1.8.0'
-        api group: 'de.focus-shift', name: 'jollyday-core', version: jollydayVersion
-        api group: 'de.focus-shift', name: 'jollyday-jaxb', version: jollydayVersion
+        api "co.elastic.logging:logback-ecs-encoder:1.8.0"
+        api "de.focus-shift:jollyday-core:$jollydayVersion"
+        api "de.focus-shift:jollyday-jaxb:$jollydayVersion"
         api 'nl.basjes.gitignore:gitignore-reader:2.0.0'
-        api group: 'dev.failsafe', name: 'failsafe', version: '3.3.2'
-        api group: 'com.cronutils', name: 'cron-utils', version: '9.2.1'
-        api group: 'com.github.victools', name: 'jsonschema-generator', version: jsonschemaVersion
-        api group: 'com.github.victools', name: 'jsonschema-module-jakarta-validation', version: jsonschemaVersion
-        api group: 'com.github.victools', name: 'jsonschema-module-jackson', version: jsonschemaVersion
-        api group: 'com.github.victools', name: 'jsonschema-module-swagger-2', version: jsonschemaVersion
-        api group: 'com.networknt', name: 'json-schema-validator', version: '3.0.5'
+        api "dev.failsafe:failsafe:3.3.2"
+        api "com.cronutils:cron-utils:9.2.1"
+        api "com.github.victools:jsonschema-generator:$jsonschemaVersion"
+        api "com.github.victools:jsonschema-module-jakarta-validation:$jsonschemaVersion"
+        api "com.github.victools:jsonschema-module-jackson:$jsonschemaVersion"
+        api "com.github.victools:jsonschema-module-swagger-2:$jsonschemaVersion"
+        api "com.networknt:json-schema-validator:3.0.5"
         api 'com.h2database:h2:2.4.240'
         api 'com.mysql:mysql-connector-j:9.7.0'
         api 'org.postgresql:postgresql:42.7.11'
         api 'com.github.docker-java:docker-java:3.7.1'
         api 'com.github.docker-java:docker-java-transport-httpclient5:3.7.1'
-        api (group: 'org.opensearch.client', name: 'opensearch-java', version: "$opensearchVersion")
-        api (group: 'org.opensearch.client', name: 'opensearch-rest-client', version: "$opensearchRestVersion")
-        api (group: 'org.opensearch.client', name: 'opensearch-rest-high-level-client', version: "$opensearchRestVersion") // used by the elasticsearch plugin
+        api "org.opensearch.client:opensearch-java:$opensearchVersion"
+        api "org.opensearch.client:opensearch-rest-client:$opensearchRestVersion"
+        api "org.opensearch.client:opensearch-rest-high-level-client:$opensearchRestVersion" // used by the elasticsearch plugin
         api 'org.jsoup:jsoup:1.22.2'
         api "org.xhtmlrenderer:flying-saucer-core:$flyingSaucerVersion"
         api "org.xhtmlrenderer:flying-saucer-pdf:$flyingSaucerVersion"
-        api group: 'jakarta.mail', name: 'jakarta.mail-api', version: '2.1.5'
-        api group: 'jakarta.annotation', name: 'jakarta.annotation-api', version: '3.0.0'
-        api group: 'org.eclipse.angus', name: 'jakarta.mail', version: '2.0.5'
-        api group: 'com.github.ben-manes.caffeine', name: 'caffeine', version: '3.2.4'
-        api group: 'de.siegmar', name: 'fastcsv', version: '4.3.0'
+        api "jakarta.mail:jakarta.mail-api:2.1.5"
+        api "jakarta.annotation:jakarta.annotation-api:3.0.0"
+        api "org.eclipse.angus:jakarta.mail:2.0.5"
+        api "com.github.ben-manes.caffeine:caffeine:3.2.4"
+        api "de.siegmar:fastcsv:4.3.0"
         // Json Diff
-        api group: 'com.github.java-json-tools', name: 'json-patch', version: '1.13'
+        api "com.github.java-json-tools:json-patch:1.13"
         api 'com.rabbitmq:amqp-client:5.32.0'
         api 'org.apache.commons:commons-pool2:2.13.1'
         api 'io.lettuce:lettuce-core:7.6.0.RELEASE'
@@ -139,13 +139,13 @@ dependencies {
         api 'org.codehaus.plexus:plexus-utils:4.0.3' // https://nvd.nist.gov/vuln/detail/CVE-2022-4244
 
         // for jOOQ to the same version as we use in EE
-        api ("org.jooq:jooq:3.21.6")
+        api "org.jooq:jooq:3.21.6"
 
         // Tests
         api "org.junit-pioneer:junit-pioneer:2.3.0"
         api 'org.hamcrest:hamcrest:3.0'
         api 'org.hamcrest:hamcrest-library:3.0'
-        api group: 'org.exparity', name: 'hamcrest-date', version: '2.0.8'
+        api "org.exparity:hamcrest-date:2.0.8"
         api "org.wiremock:wiremock-jetty12:3.13.2"
         api "org.apache.kafka:kafka-streams-test-utils:$kafkaVersion"
         api "com.microsoft.playwright:playwright:1.60.0"

--- a/worker-controller/build.gradle
+++ b/worker-controller/build.gradle
@@ -17,9 +17,9 @@ dependencies {
     annotationProcessor project(':processor')
     implementation project(":core")
 
-    implementation group: 'dev.failsafe', name: 'failsafe'
-    implementation 'com.github.ben-manes.caffeine:caffeine'
-    
+    implementation "dev.failsafe:failsafe"
+    implementation "com.github.ben-manes.caffeine:caffeine"
+
     // test
     testAnnotationProcessor project(':processor')
     testImplementation project(':core').sourceSets.test.output
@@ -30,7 +30,7 @@ dependencies {
     testImplementation project(':jdbc').sourceSets.test.output
     testImplementation project(':jdbc-h2')
     testImplementation("io.micronaut.sql:micronaut-jooq")
-    
+
     // gRPC
     implementation("io.micronaut.grpc:micronaut-grpc-server-runtime")
     implementation("io.micronaut.grpc:micronaut-grpc-client-runtime")

--- a/worker/build.gradle
+++ b/worker/build.gradle
@@ -9,8 +9,8 @@ dependencies {
     implementation project(":core")
     implementation project(":worker-controller")
 
-    implementation group: 'dev.failsafe', name: 'failsafe'
-    implementation 'com.github.ben-manes.caffeine:caffeine'
+    implementation "dev.failsafe:failsafe"
+    implementation "com.github.ben-manes.caffeine:caffeine"
 
     // test
     testAnnotationProcessor project(':processor')
@@ -24,7 +24,7 @@ dependencies {
 
     testImplementation project(':jdbc-h2')
     testImplementation("io.micronaut.sql:micronaut-jooq")
-    
+
     // gRPC
     implementation("io.micronaut.grpc:micronaut-grpc-server-runtime")
     implementation("io.micronaut.grpc:micronaut-grpc-client-runtime")


### PR DESCRIPTION
### ✨ Description

This PR fixes multiple instances of Gradle warnings related to [Deprecation of multi-string dependency notation](https://docs.gradle.org/9.3.1/userguide/upgrading_version_9.html#dependency_multi_string_notation).

### 📝 Additional Notes

`./gradlew runLocal --warning-mode all` is clear