### PR TITLE
fix(executions): nullable inputs cannot be passed from parent flow to subflow

### DIFF
--- a/core/src/main/java/io/kestra/core/runners/FlowInputOutput.java
+++ b/core/src/main/java/io/kestra/core/runners/FlowInputOutput.java
@@ -358,6 +358,11 @@ public class FlowInputOutput {
 
             Object value = resolvable.get().value();
 
+            // Pebble renders a null reference as ""; treat "" as absent for non-text types.
+            if (value instanceof String s && s.isEmpty() && !isTextType(input.getType())) {
+                value = null;
+            }
+
             // resolve default if needed; a `defaults` that is a Pebble expression (e.g. subflow()/secret())
             // can itself fail to render — that is also a broken field, so flag it as a render error.
             if (value == null && input.getDefaults() != null) {
@@ -416,6 +421,17 @@ public class FlowInputOutput {
             case MULTISELECT -> resolveDefaultPropertyAsList(input, renderer, String.class);
             case FORM -> throw new IllegalStateException("FORM inputs must be expanded before resolution");
         };
+    }
+
+    /**
+     * Returns {@code true} for input types that treat an empty string as a valid value.
+     * All other types (INT, FLOAT, BOOL, DATE/TIME variants, DURATION, JSON, YAML, URI, FILE,
+     * ARRAY, MULTISELECT) cannot be meaningfully parsed from {@code ""} and should treat it as absent.
+     * FORM inputs are always expanded before reaching this point, so they are intentionally omitted.
+     */
+    private static boolean isTextType(Type type) {
+        return type == Type.STRING || type == Type.SELECT
+            || type == Type.EMAIL || type == Type.SECRET;
     }
 
     @SuppressWarnings("unchecked")

--- a/core/src/test/java/io/kestra/core/runners/FlowInputOutputTest.java
+++ b/core/src/test/java/io/kestra/core/runners/FlowInputOutputTest.java
@@ -25,6 +25,8 @@ import io.kestra.core.models.flows.*;
 import io.kestra.core.models.flows.input.FileInput;
 import io.kestra.core.models.flows.input.FormInput;
 import io.kestra.core.models.flows.input.InputAndValue;
+import io.kestra.core.models.flows.input.EmailInput;
+import io.kestra.core.models.flows.input.FloatInput;
 import io.kestra.core.models.flows.input.IntInput;
 import io.kestra.core.models.flows.input.MultiselectInput;
 import io.kestra.core.models.flows.input.SecretInput;
@@ -107,7 +109,6 @@ class FlowInputOutputTest {
     @Test
     void shouldResolveEnabledInputsGivenInputWithConditionalExpressionMatchingTrue() {
         // Given
-
         StringInput input1 = StringInput.builder()
             .id("input1")
             .build();
@@ -141,7 +142,6 @@ class FlowInputOutputTest {
     @Test
     void shouldResolveEnabledInputsGivenInputWithConditionalInputTrue() {
         // Given
-
         StringInput input1 = StringInput.builder()
             .id("input1")
             .build();
@@ -176,7 +176,6 @@ class FlowInputOutputTest {
     @Test
     void shouldResolveDisabledInputsGivenInputWithConditionalInputFalse() {
         // Given
-
         StringInput input1 = StringInput.builder()
             .id("input1")
             .build();
@@ -824,6 +823,125 @@ class FlowInputOutputTest {
         InputAndValue region = values.stream()
             .filter(v -> v.input().getId().equals("environment.region")).findFirst().orElseThrow();
         assertThat(region.value()).isEqualTo("EU");
+    }
+
+    @Test
+    void shouldResolveEmptyStringAsNullForOptionalIntInput() {
+        // Given — an optional INT input receiving "" (Pebble renders a null reference as "")
+        IntInput input = IntInput.builder()
+            .id("integerValue")
+            .type(Type.INT)
+            .required(false)
+            .build();
+
+        // When
+        List<InputAndValue> values = flowInputOutput.resolveInputs(
+            List.of(input), null, DEFAULT_TEST_EXECUTION, Map.of("integerValue", ""));
+
+        // Then — resolves to null without throwing
+        assertThat(values).hasSize(1);
+        assertThat(values.getFirst().value()).isNull();
+        assertThat(values.getFirst().exceptions()).isNull();
+    }
+
+    @Test
+    void shouldApplyDefaultWhenOptionalIntInputIsEmptyString() {
+        // Given — an optional INT input with a default, receiving "" from a Pebble expression
+        IntInput input = IntInput.builder()
+            .id("integerValue")
+            .type(Type.INT)
+            .required(false)
+            .defaults(Property.ofValue(42))
+            .build();
+
+        // When
+        List<InputAndValue> values = flowInputOutput.resolveInputs(
+            List.of(input), null, DEFAULT_TEST_EXECUTION, Map.of("integerValue", ""));
+
+        // Then — the declared default is applied instead of throwing
+        assertThat(values).hasSize(1);
+        assertThat(values.getFirst().value()).isEqualTo(42);
+        assertThat(values.getFirst().isDefault()).isTrue();
+        assertThat(values.getFirst().exceptions()).isNull();
+    }
+
+    @Test
+    void shouldFailWithMissingRequiredWhenRequiredIntInputIsEmptyString() {
+        // Given — a required INT input receiving "" (regression guard: error must not say "For input string")
+        IntInput input = IntInput.builder()
+            .id("integerValue")
+            .type(Type.INT)
+            .required(true)
+            .build();
+
+        // When
+        List<InputAndValue> values = flowInputOutput.resolveInputs(
+            List.of(input), null, DEFAULT_TEST_EXECUTION, Map.of("integerValue", ""));
+
+        // Then — a "missing required" validation error, not a parse error
+        assertThat(values).hasSize(1);
+        assertThat(values.getFirst().exceptions()).isNotNull().isNotEmpty();
+        assertThat(values.getFirst().exceptions().stream().map(InputOutputValidationException::getMessage).findFirst())
+            .isPresent()
+            .hasValueSatisfying(msg -> assertThat(msg).contains("Missing required input"));
+    }
+
+    @Test
+    void shouldKeepEmptyStringForStringInput() {
+        // Given — STRING is a text type; "" must remain a valid value (regression guard)
+        StringInput input = StringInput.builder()
+            .id("textValue")
+            .type(Type.STRING)
+            .required(false)
+            .build();
+
+        // When
+        List<InputAndValue> values = flowInputOutput.resolveInputs(
+            List.of(input), null, DEFAULT_TEST_EXECUTION, Map.of("textValue", ""));
+
+        // Then — "" is preserved as-is for text types
+        assertThat(values).hasSize(1);
+        assertThat(values.getFirst().value()).isEqualTo("");
+        assertThat(values.getFirst().exceptions()).isNull();
+    }
+
+    @Test
+    void shouldResolveEmptyStringAsNullForOptionalFloatInput() {
+        // Given — FLOAT is also a non-text type; same normalization should apply
+        FloatInput input = FloatInput.builder()
+            .id("floatValue")
+            .type(Type.FLOAT)
+            .required(false)
+            .build();
+
+        // When
+        List<InputAndValue> values = flowInputOutput.resolveInputs(
+            List.of(input), null, DEFAULT_TEST_EXECUTION, Map.of("floatValue", ""));
+
+        // Then — resolves to null without throwing
+        assertThat(values).hasSize(1);
+        assertThat(values.getFirst().value()).isNull();
+        assertThat(values.getFirst().exceptions()).isNull();
+    }
+
+    @Test
+    void shouldKeepEmptyStringForEmailInput() {
+        // Given — EMAIL is a text type; "" is allowed by EmailInput's validator pattern (which includes ^$).
+        // An optional EMAIL receiving "" resolves to "" (not null), matching the existing validator design.
+        EmailInput input = EmailInput.builder()
+            .id("emailValue")
+            .type(Type.EMAIL)
+            .required(false)
+            .build();
+
+        // When
+        List<InputAndValue> values = flowInputOutput.resolveInputs(
+            List.of(input), null, DEFAULT_TEST_EXECUTION, Map.of("emailValue", ""));
+
+        // Then — "" is preserved for EMAIL inputs
+        assertThat(values).hasSize(1);
+        assertThat(values.getFirst().value()).isEqualTo("");
+        assertThat(values.getFirst().exceptions()).isNull();
     }
 
     private static class MemoryCompletedPart implements CompletedPart {

--- a/core/src/test/java/io/kestra/plugin/core/flow/SubflowRunnerTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/flow/SubflowRunnerTest.java
@@ -2,6 +2,7 @@ package io.kestra.plugin.core.flow;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -133,6 +134,32 @@ class SubflowRunnerTest {
         assertThat(childExecution.stream().filter(e -> e.getState().getCurrent() == State.Type.SUCCESS).count()).isEqualTo(2);
         assertThat(childExecution.stream().filter(e -> e.getState().getCurrent() == State.Type.FAILED).count()).isEqualTo(2);
         closing.close();
+    }
+
+    @Test
+    @LoadFlows({ "flows/valids/subflow-nullable-input-parent.yaml", "flows/valids/subflow-nullable-input-child.yaml" })
+    void shouldPassNullableInputFromParentToSubflow() throws QueueException, TimeoutException, io.kestra.core.exceptions.InternalException {
+        // Given — the parent flow has an optional INT input provided as an empty string, reproducing
+        // the case where a user leaves an optional input blank in the UI (or the API sends "").
+        // The Subflow task forwards it via "{{ inputs.integerValue }}", which Pebble renders to "".
+        // Without the fix this fails with "Invalid input for integerValue, For input string: \"\"";
+        // with the fix both parent and child should reach SUCCESS.
+
+        // When
+        Execution parentExecution = runnerUtils.runOne(MAIN_TENANT, "io.kestra.tests", "subflow-nullable-input-parent",
+            null, (f, e) -> Map.of("integerValue", ""));
+
+        // Then — parent reaches SUCCESS
+        assertThat(parentExecution.getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
+
+        String childExecutionId = (String) taskOutputService.getOutputs(
+            parentExecution.findTaskRunsByTaskId("subflow").getFirst()).get("executionId");
+        assertThat(childExecutionId).isNotBlank();
+
+        Execution childExecution = executionRepository.findById(MAIN_TENANT, childExecutionId).orElseThrow();
+
+        // Then — child also reaches SUCCESS with null input
+        assertThat(childExecution.getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
     }
 
     @Test

--- a/core/src/test/resources/flows/valids/subflow-nullable-input-child.yaml
+++ b/core/src/test/resources/flows/valids/subflow-nullable-input-child.yaml
@@ -1,0 +1,12 @@
+id: subflow-nullable-input-child
+namespace: io.kestra.tests
+
+inputs:
+  - id: integerValue
+    type: INT
+    required: false
+
+tasks:
+  - id: log
+    type: io.kestra.plugin.core.log.Log
+    message: "{{ inputs.integerValue }}"

--- a/core/src/test/resources/flows/valids/subflow-nullable-input-parent.yaml
+++ b/core/src/test/resources/flows/valids/subflow-nullable-input-parent.yaml
@@ -1,0 +1,17 @@
+id: subflow-nullable-input-parent
+namespace: io.kestra.tests
+
+inputs:
+  - id: integerValue
+    type: INT
+    required: false
+
+tasks:
+  - id: subflow
+    type: io.kestra.plugin.core.flow.Subflow
+    namespace: io.kestra.tests
+    flowId: subflow-nullable-input-child
+    wait: true
+    transmitFailed: true
+    inputs:
+      integerValue: "{{ inputs.integerValue }}"


### PR DESCRIPTION
## Summary

Fixes #6624.

When a parent flow passes an optional non-text input (e.g. `INT`) to a subflow via a Pebble expression such as `{{ inputs.integerNull }}` and the parent value is null, Pebble renders the null reference as an empty string `""`. `FlowInputOutput.resolveInputValue` only treated literal `null` as "absent", so `""` fell through to `Integer.valueOf("")` which threw:

```
integerNull: Invalid input for integerNull, For input string: "", but received ``
```

**Root cause:** `Subflow.createSubflowExecutions` calls `runContext.render(this.inputs)` — Pebble renders a null value as `""`. The input resolution code only normalized literal `null`, not empty strings.

**Fix:** In `FlowInputOutput.resolveInputValue`, coerce `""` to `null` for non-text input types before the default/required check. Text-like types (`STRING`, `SELECT`, `EMAIL`, `SECRET`) keep `""` as a legitimate value. This fix applies to all entry paths (subflow, webhook, API) since they all share `resolveInputValue`.

## Changes

- `core/.../runners/FlowInputOutput.java` — 2-line normalization + `isTextType` helper
- `core/.../runners/FlowInputOutputTest.java` — 6 new unit tests (INT/FLOAT/STRING/EMAIL edge cases)
- `core/.../flow/SubflowRunnerTest.java` — end-to-end test reproducing the reported scenario
- 2 new YAML flow fixtures for the end-to-end test

## Test plan

- [x] `FlowInputOutputTest` — 45/45 passing
- [x] `SubflowRunnerTest` — 5/5 passing (includes new `shouldPassNullableInputFromParentToSubflow`)
- [x] `H2RunnerTest` — 100/100 passing