### PR TITLE
fix(plugins): filter plugin type dropdown correctly in plugin defaults

### DIFF
--- a/ui/src/components/plugins/PluginSelect.vue
+++ b/ui/src/components/plugins/PluginSelect.vue
@@ -3,10 +3,11 @@
         v-model="modelValue"
         :placeholder="$te(`no_code.select.${blockType}`) ? $t(`no_code.select.${blockType}`) : $t('no_code.select.default')"
         filterable
+        :filterMethod="onFilter"
         clearable
     >
         <KsOption
-            v-for="item in taskModels"
+            v-for="item in filteredTaskModels"
             :key="item.cls"
             :label="item.cls"
             :value="item.cls"
@@ -118,7 +119,21 @@
             : (Array.from(taskModelsSets.value) as [string, string][])
                 .map(([cls, title]) => ({cls, title}))
 
-        return entries.sort((a, b) => a.cls.localeCompare(b.cls))
+        const unique = Array.from(new Map(entries.map(e => [e.cls, e])).values())
+        return unique.sort((a, b) => a.cls.localeCompare(b.cls))
+    })
+    
+    const query = ref("")
+    const onFilter = (value: string) => {
+        query.value = value ?? ""
+    }
+
+    const filteredTaskModels = computed(() => {
+        const q = query.value.trim().toLowerCase()
+        if (!q) {
+            return taskModels.value
+        }
+        return taskModels.value.filter(({cls}) => cls.toLowerCase().includes(q))
     })
 
     const hasIcons = computed(() => {


### PR DESCRIPTION
### ✨ Description

Fixes the **type** field filtering in the *Add Plugin Default* modal (Namespaces → Plugin Defaults → Add Plugin Default). Typing in the type field did not narrow the plugin list — e.g. typing `log.log` still showed unrelated plugins.

Closes https://github.com/kestra-io/kestra-ee/issues/8948