### PR TITLE
fix(core): match enum task states in tasksWithState() [backport v1.3.x]

### DIFF
--- a/core/src/main/java/io/kestra/core/runners/pebble/functions/TasksWithStateFunction.java
+++ b/core/src/main/java/io/kestra/core/runners/pebble/functions/TasksWithStateFunction.java
@@ -45,35 +45,28 @@ public class TasksWithStateFunction implements Function {
                         transformedTask.put("taskId", taskId);
 
                         if ("state".equals(key)) {
-                            if (valueObj instanceof String) {
-                                String state = ((String) valueObj).toUpperCase();
+                            if (valueObj instanceof Map) {
+                                Map<String, Object> nestedMap = (Map<String, Object>) valueObj;
+                                String state = toState(nestedMap.get("state"));
+                                if (stateToFilter.equals(state)) {
+                                    transformedTask.put("state", state);
+                                    transformedTask.put("value", "state");
+                                    filteredTasks.add(transformedTask);
+                                }
+                            } else {
+                                String state = toState(valueObj);
                                 if (stateToFilter.equals(state)) {
                                     transformedTask.put("state", state);
                                     filteredTasks.add(transformedTask);
-                                }
-
-                            } else if (valueObj instanceof Map) {
-                                Map<String, Object> nestedMap = (Map<String, Object>) valueObj;
-                                Object stateFromNested = nestedMap.get("state");
-                                if (stateFromNested instanceof String) {
-                                    String state = ((String) stateFromNested).toUpperCase();
-                                    if (stateToFilter.equals(state)) {
-                                        transformedTask.put("state", state);
-                                        transformedTask.put("value", "state");
-                                        filteredTasks.add(transformedTask);
-                                    }
                                 }
                             }
                         } else if (valueObj instanceof Map) {
                             Map<String, Object> nestedMap = (Map<String, Object>) valueObj;
-                            Object stateFromNested = nestedMap.get("state");
-                            if (stateFromNested instanceof String) {
-                                String state = ((String) stateFromNested).toUpperCase();
-                                if (stateToFilter.equals(state)) {
-                                    transformedTask.put("state", state);
-                                    transformedTask.put("value", key);
-                                    filteredTasks.add(transformedTask);
-                                }
+                            String state = toState(nestedMap.get("state"));
+                            if (stateToFilter.equals(state)) {
+                                transformedTask.put("state", state);
+                                transformedTask.put("value", key);
+                                filteredTasks.add(transformedTask);
                             }
                         }
                     });
@@ -82,5 +75,18 @@ public class TasksWithStateFunction implements Function {
         }
 
         return filteredTasks;
+    }
+
+    /**
+     * Normalizes a task state value to its uppercase name.
+     * The {@code tasks} variable holds the state as a {@link io.kestra.core.models.flows.State.Type}
+     * enum when rendered executor-side (e.g. {@code runIf}) and as a {@link String} when rendered
+     * worker-side after serialization; both must be matched. Returns {@code null} for unsupported values.
+     */
+    private static String toState(Object value) {
+        if (value instanceof String || value instanceof Enum) {
+            return value.toString().toUpperCase();
+        }
+        return null;
     }
 }

--- a/core/src/test/java/io/kestra/core/runners/TaskWithRunIfTest.java
+++ b/core/src/test/java/io/kestra/core/runners/TaskWithRunIfTest.java
@@ -38,6 +38,21 @@ class TaskWithRunIfTest {
     }
 
     @Test
+    @ExecuteFlow("flows/valids/task-runif-taskswithstate.yml")
+    void runIfWithTasksWithStateFunction(Execution execution) {
+        // Pylon #1984: tasksWithState() must work in runIf (rendered executor-side, enum state).
+        assertThat(execution.getState().getCurrent()).isEqualTo(State.Type.FAILED);
+        assertThat(execution.findTaskRunsByTaskId("will_fail").getFirst().getState().getCurrent()).isEqualTo(State.Type.FAILED);
+
+        // runIf {{ tasksWithState('FAILED') is not empty }} -> a failure exists -> must RUN
+        assertThat(execution.findTaskRunsByTaskId("write_execution_context").getFirst().getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
+        assertThat(execution.getVariables()).containsEntry("hadFailure", List.of("yes"));
+
+        // runIf {{ tasksWithState('FAILED') is empty }} -> a failure exists -> must be SKIPPED
+        assertThat(execution.findTaskRunsByTaskId("skipped_when_failures_exist").getFirst().getState().getCurrent()).isEqualTo(State.Type.SKIPPED);
+    }
+
+    @Test
     @ExecuteFlow("flows/valids/task-runif-executionupdating.yml")
     void executionUpdatingTask(Execution execution) {
         assertThat(execution.getState().getCurrent()).isEqualTo(State.Type.SUCCESS);

--- a/core/src/test/java/io/kestra/core/runners/pebble/functions/TasksWithStateFunctionTest.java
+++ b/core/src/test/java/io/kestra/core/runners/pebble/functions/TasksWithStateFunctionTest.java
@@ -1,0 +1,59 @@
+package io.kestra.core.runners.pebble.functions;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import io.kestra.core.exceptions.IllegalVariableEvaluationException;
+import io.kestra.core.models.flows.State;
+import io.kestra.core.runners.VariableRenderer;
+
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import jakarta.inject.Inject;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@MicronautTest
+class TasksWithStateFunctionTest {
+    @Inject
+    private VariableRenderer variableRenderer;
+
+    private Map<String, Object> tasksVar(Object helloState) {
+        Map<String, Object> tasks = new LinkedHashMap<>();
+        tasks.put("hello", Map.of("state", helloState));
+        return Map.of("tasks", tasks);
+    }
+
+    // state as a plain String — how worker-side variables look after JSON serialization.
+    @Test
+    void shouldMatchWhenStateIsString() throws IllegalVariableEvaluationException {
+        Map<String, Object> vars = tasksVar("SUCCESS");
+
+        assertThat(variableRenderer.render("{{ tasksWithState(state='SUCCESS') is empty }}", vars)).isEqualTo("false");
+        assertThat(variableRenderer.render("{{ tasksWithState(state='SUCCESS') is not empty }}", vars)).isEqualTo("true");
+        assertThat(variableRenderer.render("{{ tasksWithState(state='FAILED') is empty }}", vars)).isEqualTo("true");
+    }
+
+    // state as a State.Type enum — how the executor renders runIf (computeTasksMap stores the enum).
+    // Regression for Pylon #1984: tasksWithState() must behave the same as the String case.
+    @Test
+    void shouldMatchWhenStateIsEnum() throws IllegalVariableEvaluationException {
+        Map<String, Object> vars = tasksVar(State.Type.SUCCESS);
+
+        assertThat(variableRenderer.render("{{ tasksWithState(state='SUCCESS') is empty }}", vars)).isEqualTo("false");
+        assertThat(variableRenderer.render("{{ tasksWithState(state='SUCCESS') is not empty }}", vars)).isEqualTo("true");
+        assertThat(variableRenderer.render("{{ tasksWithState(state='FAILED') is empty }}", vars)).isEqualTo("true");
+    }
+
+    // task-with-value (loop / iteration): tasks.<id>.<value> = { state: <enum> } — nested branch.
+    @Test
+    void shouldMatchNestedValueWhenStateIsEnum() throws IllegalVariableEvaluationException {
+        Map<String, Object> tasks = new LinkedHashMap<>();
+        tasks.put("loop", Map.of("item-1", Map.of("state", State.Type.FAILED)));
+        Map<String, Object> vars = Map.of("tasks", tasks);
+
+        assertThat(variableRenderer.render("{{ tasksWithState(state='FAILED') is not empty }}", vars)).isEqualTo("true");
+        assertThat(variableRenderer.render("{{ tasksWithState(state='SUCCESS') is empty }}", vars)).isEqualTo("true");
+    }
+}

--- a/core/src/test/resources/flows/valids/task-runif-taskswithstate.yml
+++ b/core/src/test/resources/flows/valids/task-runif-taskswithstate.yml
@@ -1,0 +1,28 @@
+id: task-runif-taskswithstate
+namespace: io.kestra.tests
+
+# Reproduces Pylon #1984: tasksWithState() inside runIf is rendered executor-side,
+# where tasks.<id>.state is a State.Type enum. The function must match it the same
+# way it matches the String form used in worker-side message rendering.
+
+tasks:
+  - id: hello
+    type: io.kestra.plugin.core.log.Log
+    message: Hello World!
+
+  - id: will_fail
+    type: io.kestra.plugin.core.execution.Fail
+
+finally:
+  # runIf TRUE: there is a FAILED task -> must RUN (this is the bug: was skipped)
+  - id: write_execution_context
+    type: io.kestra.plugin.core.execution.SetVariables
+    runIf: "{{ tasksWithState(state='FAILED') is not empty }}"
+    variables:
+      hadFailure: ["yes"]
+
+  # runIf FALSE: there IS a failure so 'is empty' is false -> must be SKIPPED
+  - id: skipped_when_failures_exist
+    type: io.kestra.plugin.core.log.Log
+    runIf: "{{ tasksWithState(state='FAILED') is empty }}"
+    message: should be skipped because a failure exists


### PR DESCRIPTION
## Backport

This backports #17077 to `releases/v1.3.x`.

This will fix https://github.com/kestra-io/kestra-ee/issues/8980 (EE consumes this function from `core` and inherits the fix).

---

## What

`tasksWithState()` silently returns an empty list whenever a task's `state` is a `State.Type` enum rather than a `String`. This makes `{{ tasksWithState('X') is (not) empty }}` always evaluate as *empty* inside `runIf`, even when matching tasks exist.

## Why

The `tasks` Pebble variable (`RunVariables.computeTasksMap`) stores each task's state as `taskRun.getState().getCurrent()` — a **`State.Type` enum**. `TasksWithStateFunction` only matched `valueObj instanceof String`, so the enum was never matched.

The two render contexts differ in how `state` is typed:

| Render context | Where | `tasks.<id>.state` type | Result |
|---|---|---|---|
| `runIf` | **executor** (`ExecutionEventMessageHandler`, `ExecutorService`) — in-memory vars | `State.Type` **enum** | ❌ always empty |
| `message` / outputs | **worker** — vars round-tripped through JSON | `String` | ✅ works |

So `tasksWithState()` is effectively broken in any `runIf`, while it works in task messages — exactly the discrepancy reported.

## Fix

Normalize the state value (String **or** enum) to its uppercase name before comparison, in both the direct-`state` and nested-value (loop/iteration) branches.

## Test (TDD)

Added `TasksWithStateFunctionTest`:
- `shouldMatchWhenStateIsString` — worker-side representation (was already green)
- `shouldMatchWhenStateIsEnum` — executor/`runIf` representation (**red → green**)
- `shouldMatchNestedValueWhenStateIsEnum` — loop/iteration nested branch (**red → green**)

## Reproducer

```yaml
id: taskswithstate_runif
namespace: company.team
tasks:
  - id: hello
    type: io.kestra.plugin.core.log.Log
    message: Hello World!
  - id: run_if_no_success
    type: io.kestra.plugin.core.log.Log
    runIf: "{{ tasksWithState(state='SUCCESS') is empty }}"
    message: "{{ tasksWithState(state='SUCCESS') }}"
```

Before: `run_if_no_success` **runs** (runIf sees the SUCCESS list as empty). After: it is correctly **skipped**.

Fixes Pylon #1984. OSS-only — EE consumes this function from `core` and inherits the fix.
