### PR TITLE
fix(iam): allow EE to secure pebble expression endpoints

### DIFF
--- a/webserver/src/main/java/io/kestra/webserver/controllers/api/MiscController.java
+++ b/webserver/src/main/java/io/kestra/webserver/controllers/api/MiscController.java
@@ -119,7 +119,7 @@ public class MiscController {
     protected EditionProvider editionProvider;
 
     @Inject
-    PebbleExpressionService pebbleExpressionService;
+    protected PebbleExpressionService pebbleExpressionService;
 
     @Get("/configs")
     @ExecuteOn(TaskExecutors.IO)


### PR DESCRIPTION
## What

Widen the `pebbleExpressionService` field in `MiscController` from package-private to `protected`.

## Why

Companion change for the EE fix that secures the pebble expression endpoints. EE subclasses `MiscController` and overrides `getExpressionFilters()` / `getExpressionFunctions()` to attach `@Secured(SecurityRule.IS_AUTHENTICATED)` (so the flow-editor autocomplete can reach `GET /api/v1/pebble/{filters,functions}` with a valid session instead of getting a 401). Those overrides delegate to `pebbleExpressionService`, which the subclass can only reach if the field is `protected`.

No behaviour change in OSS — purely a visibility relaxation.

## Companion PR

- EE: kestra-io/kestra-ee#8970
