### PR TITLE
fix(plugins): align github icon in release notes button on docs panel

### DIFF
--- a/ui/src/components/plugins/PluginDocumentation.vue
+++ b/ui/src/components/plugins/PluginDocumentation.vue
@@ -123,11 +123,6 @@
         border: 1px solid var(--ks-border-info);
         white-space: nowrap;
 
-        :deep(.material-design-icon) {
-            position: absolute;
-            bottom: 0;
-        }
-
         @media (max-width: 576px) {
             padding: 6px 12px;
             font-size: var(--ks-font-size-sm);


### PR DESCRIPTION
### What does this PR do?

On the plugin Docs panel, the GitHub icon in the **Release notes** button sat higher than the label, looking misaligned.

The button styled the icon with a `:deep(.material-design-icon)` override that absolutely positioned it to the bottom of the button, pulling it out of normal flow. This both caused the misalignment and violated the design-system rule against `:deep()` selectors.

Removing the override lets the icon align with the text through `KsButton`'s default icon slot — the same way every other `:icon` button in the app behaves.

### How to test

1. Deploy a flow with a `io.kestra.plugin.scripts.shell.Commands` task and open it in Edit.
2. Open the Docs tab and view the Commands task docs.
3. The GitHub icon in the Release notes button is now vertically centered with the label.

Closes https://github.com/kestra-io/kestra-ee/issues/8935.