### PR TITLE
fix(core): repair v1.3.x test compile from incomplete #6624 backport

### DIFF
--- a/core/src/main/java/io/kestra/core/models/flows/input/EmailInput.java
+++ b/core/src/main/java/io/kestra/core/models/flows/input/EmailInput.java
@@ -6,7 +6,13 @@ import io.kestra.core.models.flows.Input;
 import io.kestra.core.models.validations.ManualConstraintViolation;
 
 import jakarta.validation.ConstraintViolationException;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
 
+@SuperBuilder
+@Getter
+@NoArgsConstructor
 public class EmailInput extends Input<String> {
 
     private static final String EMAIL_PATTERN = "^$|^[a-zA-Z0-9_!#$%&’*+/=?`{|}~^.-]+@[a-zA-Z0-9.-]+$";

--- a/core/src/test/java/io/kestra/plugin/core/flow/SubflowRunnerTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/flow/SubflowRunnerTest.java
@@ -143,8 +143,7 @@ class SubflowRunnerTest {
         // Then — parent reaches SUCCESS
         assertThat(parentExecution.getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
 
-        String childExecutionId = (String) taskOutputService.getOutputs(
-            parentExecution.findTaskRunsByTaskId("subflow").getFirst()).get("executionId");
+        String childExecutionId = (String) parentExecution.findTaskRunsByTaskId("subflow").getFirst().getOutputs().get("executionId");
         assertThat(childExecutionId).isNotBlank();
 
         Execution childExecution = executionRepository.findById(MAIN_TENANT, childExecutionId).orElseThrow();


### PR DESCRIPTION
## What

Repairs `:core:compileTestJava` on `releases/v1.3.x`, which is currently broken: the branch HEAD does not compile.

## Why

The backport of #6624 *("fix(executions): nullable inputs cannot be passed from parent flow to subflow")* — commit `2399fac243` — brought **test code** that depends on APIs not present on this release branch, but not the corresponding source. Two compile errors result:

| File | Symptom | Cause |
|------|---------|-------|
| `FlowInputOutputTest.java:889` | `EmailInput.builder()` — cannot find symbol | `EmailInput` on `develop` is `@SuperBuilder`; on `v1.3.x` it was still a plain class with no builder. |
| `SubflowRunnerTest.java:146` | `taskOutputService` — cannot find symbol | `TaskOutputService` is a `develop`-only service; it does not exist on `v1.3.x`. |

## Fix

- **`EmailInput`** — added `@SuperBuilder` / `@Getter` / `@NoArgsConstructor`, matching every sibling `Input` subclass on this branch (e.g. `StringInput`) and the `@SuperBuilder` base `Input`. This is the minimal source change the backported test expects.
- **`SubflowRunnerTest`** — replaced the develop-only `taskOutputService.getOutputs(taskRun)` call with `taskRun.getOutputs()`, the idiom the other tests in this same file already use on `v1.3.x` (outputs still live on the `TaskRun` here).

No behavior change — purely restores compilation of the backported test on the release branch.

## Verification

`./gradlew :core:compileTestJava --rerun-tasks` → **exit 0** (both errors gone).