### PR TITLE
ci: run EE compile check for OSS PRs via Kestra webhook

### DIFF
--- a/.github/actions/ee-compile-check/action.yml
+++ b/.github/actions/ee-compile-check/action.yml
@@ -1,0 +1,135 @@
+name: "EE compile check via Kestra webhook"
+description: >-
+  Run the kestra-ee compileJava check for an OSS ref on a Kestra instance via a
+  synchronous webhook, and surface the result inline (job summary + log group).
+  Because kestra-ee extends OSS via Micronaut @Replaces/@Override, an OSS change
+  can compile in OSS yet break EE — this catches that at PR time. The step fails
+  on a compile failure, a non-JSON response, or an inconclusive verdict, so it
+  never reports a false green.
+
+inputs:
+  webhook-url:
+    description: "Full Kestra webhook URL, including its key. Pass from a secret — never hardcode."
+    required: true
+  ref:
+    description: "Branch, tag, or SHA to compile. The flow resolves the matching kestra-ee ref (falls back to develop)."
+    required: true
+  commit-sha:
+    description: "PR head SHA. When set, the flow posts a commit-status callback to the PR."
+    required: false
+    default: ""
+  pr-number:
+    description: "PR number (context only)."
+    required: false
+    default: ""
+  pr-repo:
+    description: "OSS repo 'owner/name' for the commit-status callback."
+    required: false
+    default: ""
+
+runs:
+  using: "composite"
+  steps:
+    - name: "Trigger EE compile check and surface result"
+      shell: bash
+      env:
+        WEBHOOK_URL: ${{ inputs.webhook-url }}
+        REF: ${{ inputs.ref }}
+        COMMIT_SHA: ${{ inputs.commit-sha }}
+        PR_NUMBER: ${{ inputs.pr-number }}
+        PR_REPO: ${{ inputs.pr-repo }}
+      run: |
+        set -uo pipefail
+
+        if [ -z "${WEBHOOK_URL:-}" ]; then
+          echo "::error::Kestra webhook URL is not set (missing secret?)."
+          exit 1
+        fi
+
+        echo "Triggering EE compile check for ref: $REF"
+        # integrateWithGithub turns on the commit-status callback; the flow gates
+        # the actual post on commit_sha being present too. No test_filter is sent,
+        # so the flow runs compile-only (skip_test).
+        PAYLOAD=$(jq -n \
+          --arg ref         "$REF" \
+          --arg commit_sha  "${COMMIT_SHA:-}" \
+          --arg pr_number   "${PR_NUMBER:-}" \
+          --arg pr_repo     "${PR_REPO:-}" \
+          '{ref: $ref, commit_sha: $commit_sha, pr_number: $pr_number, pr_repo: $pr_repo, integrateWithGithub: true}')
+
+        # Print the params we're about to send (the webhook URL/key stays secret).
+        echo "::group::Webhook payload"
+        echo "$PAYLOAD" | jq .
+        echo "::endgroup::"
+
+        BODY=$(mktemp)
+        STATUS=$(curl -sS -o "$BODY" -w '%{http_code}' \
+          -X POST "$WEBHOOK_URL" \
+          -H 'Content-Type: application/json' \
+          --max-time 1800 \
+          -d "$PAYLOAD" || echo "000")
+
+        echo "Webhook HTTP status: $STATUS"
+
+        # The body must be JSON with our outputs even on HTTP 500 (a compile
+        # failure makes the flow terminate FAILED). A non-JSON body means an
+        # infra/auth error, not a compile result — surface it raw and fail.
+        if ! jq -e . "$BODY" >/dev/null 2>&1; then
+          echo "::error::Webhook did not return a JSON result (HTTP $STATUS). Raw response:"
+          cat "$BODY"
+          exit 1
+        fi
+
+        COMPILE_FAILED=$(jq -r '.compileFailed // ""' "$BODY")
+        COMPILE_ERROR=$(jq -r '.compileError // ""' "$BODY")
+
+        # The flow always sets compileFailed to "true"/"false". An empty value
+        # means the Kestra flow terminated BEFORE producing a verdict (e.g. a
+        # transient Kubernetes pod-scheduling timeout, or a clone/auth error).
+        # That is inconclusive, NOT a pass — fail the check so it isn't a false
+        # green, and surface the raw response + status for debugging.
+        if [ "$COMPILE_FAILED" != "true" ] && [ "$COMPILE_FAILED" != "false" ]; then
+          {
+            echo "## :warning: EE compile check inconclusive for \`$REF\`"
+            echo ""
+            echo "The Kestra flow did not return a compile verdict (HTTP $STATUS)."
+            echo "This is usually a transient infra error (e.g. a runner pod failed to schedule). Re-run the job."
+            echo ""
+            echo "<details><summary>Raw webhook response</summary>"
+            echo ""
+            echo '```json'
+            cat "$BODY"
+            echo '```'
+            echo ""
+            echo "</details>"
+          } >> "$GITHUB_STEP_SUMMARY"
+          echo "::group::Raw webhook response (HTTP $STATUS)"
+          cat "$BODY"
+          echo "::endgroup::"
+          echo "::error::EE compile check inconclusive for ref $REF (no compile verdict; HTTP $STATUS). Likely a transient runner error — re-run the job."
+          exit 1
+        fi
+
+        {
+          echo "## EE compile check for \`$REF\`"
+          echo ""
+          if [ "$COMPILE_FAILED" = "true" ]; then
+            echo "### :x: EE compilation failed"
+            echo ""
+            echo '```'
+            echo "$COMPILE_ERROR"
+            echo '```'
+          else
+            echo "### :white_check_mark: EE compilation passed"
+          fi
+        } >> "$GITHUB_STEP_SUMMARY"
+
+        if [ "$COMPILE_FAILED" = "true" ]; then
+          echo "::group::EE compile error"
+          echo "$COMPILE_ERROR"
+          echo "::endgroup::"
+          echo "::error::EE compilation failed for ref $REF"
+          exit 1
+        fi
+
+        echo "EE compilation passed for ref $REF"

--- a/.github/workflows/ee-compile-check-manual.yml
+++ b/.github/workflows/ee-compile-check-manual.yml
@@ -1,0 +1,31 @@
+name: EE compile check via Kestra webhook (manual)
+
+# Ad-hoc EE compile check for an arbitrary OSS ref, on demand.
+# Pull requests get this check automatically via pull-request.yml (job:
+# trigger-ee); this workflow only exists to run it manually against any
+# branch/tag/SHA. Both entry points share the same composite action:
+# .github/actions/ee-compile-check.
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Branch, tag, or SHA to compile"
+        required: true
+
+concurrency:
+  group: ee-compile-check-manual-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  ee-compile:
+    name: EE compile check
+    runs-on: ubuntu-latest
+    if: github.repository == 'kestra-io/kestra'
+    steps:
+      - uses: actions/checkout@v4
+      - name: EE compile check (via Kestra webhook)
+        uses: ./.github/actions/ee-compile-check
+        with:
+          webhook-url: ${{ secrets.KESTRA_CI_EEBUILD_WEBHOOK_URL }}
+          ref: ${{ inputs.ref }}

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -8,10 +8,15 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  # When an OSS ci start, we trigger an EE one
+  # When an OSS PR opens, run the kestra-ee compile check for its ref (via a
+  # Kestra webhook) and trigger the EE OpenAPI spec check.
   trigger-ee:
     runs-on: ubuntu-latest
     steps:
+    - name: Checkout  # required so the local composite action below can resolve
+      if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false }}
+      uses: actions/checkout@v4
+
     - name: Generate GitHub App token for kestra-ee dispatch
       id: ee-token
       if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false }}
@@ -22,9 +27,44 @@ jobs:
         owner: kestra-io
         repositories: kestra-ee
 
-    # PR pre-check: skip if PR from a fork OR EE already has a branch with same name
+      # Run the EE compileJava check for this PR's ref on a Kestra instance and
+      # surface the result inline. The flow resolves the matching kestra-ee ref
+      # itself (same-name branch, else develop), so no branch pre-check is needed.
+    - name: EE compile check (via Kestra webhook)
+      if: ${{ github.event_name == 'pull_request'
+        && github.event.pull_request.number != ''
+        && github.event.pull_request.head.repo.fork == false }}
+      uses: ./.github/actions/ee-compile-check
+      with:
+        webhook-url: ${{ secrets.KESTRA_CI_EEBUILD_WEBHOOK_URL }}
+        ref: ${{ github.event.pull_request.head.ref }}
+        commit-sha: ${{ github.event.pull_request.head.sha }}
+        pr-number: ${{ github.event.pull_request.number }}
+        pr-repo: ${{ github.repository }}
+
+      # Always trigger EE OpenAPI check on non-fork PRs
+    - name: Trigger EE OpenAPI spec check
+      uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697
+      if: ${{ github.event_name == 'pull_request'
+        && github.event.pull_request.number != ''
+        && github.event.pull_request.head.repo.fork == false }}
+      with:
+        token: ${{ steps.ee-token.outputs.token }}
+        repository: kestra-io/kestra-ee
+        event-type: "oss-pr-openapi-check"
+        client-payload: >-
+          {"commit_sha":"${{ github.event.pull_request.head.sha }}","pr_number":"${{ github.event.pull_request.number }}","oss_branch":"${{ github.event.pull_request.head.ref }}"}
+
+      # ------------------------------------------------------------------------
+      # LEGACY (DISABLED): EE CI used to be triggered by a repository dispatch
+      # ("oss-updated") that ran the full kestra-ee workflow asynchronously and
+      # reported back a commit status. It is superseded by the synchronous
+      # "EE compile check (via Kestra webhook)" step above. Kept here, guarded
+      # by `false &&`, for quick rollback — drop the `false &&` in both `if:`
+      # blocks to re-enable (and disable the webhook step above).
+      # ------------------------------------------------------------------------
     - name: Check EE repo for branch with same name
-      if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false }}
+      if: ${{ false && (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false) }}
       id: check-ee-branch
       uses: actions/github-script@v9
       with:
@@ -48,32 +88,18 @@ jobs:
             }
           }
 
-      # Targeting pull request (only if not from a fork and EE has no branch with same name)
     - name: Trigger EE Workflow (pull request, with payload)
       uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697
-      if: ${{ github.event_name == 'pull_request'
+      if: ${{ false && (github.event_name == 'pull_request'
         && github.event.pull_request.number != ''
         && github.event.pull_request.head.repo.fork == false
-        && steps.check-ee-branch.outputs.exists == 'false' }}
+        && steps.check-ee-branch.outputs.exists == 'false') }}
       with:
         token: ${{ steps.ee-token.outputs.token }}
         repository: kestra-io/kestra-ee
         event-type: "oss-updated"
         client-payload: >-
           {"commit_sha":"${{ github.event.pull_request.head.sha }}","pr_repo":"${{ github.repository }}"}
-
-      # Always trigger EE OpenAPI check on non-fork PRs (regardless of EE same-name branch)
-    - name: Trigger EE OpenAPI spec check
-      uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697
-      if: ${{ github.event_name == 'pull_request'
-        && github.event.pull_request.number != ''
-        && github.event.pull_request.head.repo.fork == false }}
-      with:
-        token: ${{ steps.ee-token.outputs.token }}
-        repository: kestra-io/kestra-ee
-        event-type: "oss-pr-openapi-check"
-        client-payload: >-
-          {"commit_sha":"${{ github.event.pull_request.head.sha }}","pr_number":"${{ github.event.pull_request.number }}","oss_branch":"${{ github.event.pull_request.head.ref }}"}
 
   file-changes:
     if: ${{ github.event.pull_request.draft == false }}


### PR DESCRIPTION
Run the kestra-ee `compileJava` check for an OSS PR's ref through a Kestra webhook and surface the result inline as a required status — replacing the async `oss-updated` repository_dispatch round-trip.

here is the Flow that does everything: https://prd.kestra-tech.kestra.cloud/ui/main/flows/edit/kestra.engineering.ci/run_backend_ee_ci_webhook/edit

The flow resolves the matching kestra-ee ref itself (same-name branch, else `develop`), so no branch pre-check is needed. Consumes the `KESTRA_CI_EEBUILD_WEBHOOK_URL` repo secret (published by terraform in flows-engineering).

Adds a shared composite action `.github/actions/ee-compile-check`, used by both the PR job (`pull-request.yml`) and an on-demand manual workflow (`ee-compile-check-manual.yml`).

The legacy `oss-updated` EE trigger is kept but disabled (`if: false && …`) for quick rollback.