### PR TITLE
feat(ui): stream task logs to the topology-details plugin slot

### DIFF
--- a/ui/packages/slot-contracts/src/topology-details.ts
+++ b/ui/packages/slot-contracts/src/topology-details.ts
@@ -1,4 +1,4 @@
-import type {Execution, MetricEntry, Task} from "@kestra-io/kestra-sdk"
+import type {Execution, LogEntry, MetricEntry, Task} from "@kestra-io/kestra-sdk"
 import {z} from "zod"
 import {defineArtifactSlot} from "./define-artifact-slot"
 
@@ -9,6 +9,9 @@ export const propsSchema = z.object({
     namespace: z.string().optional(),
     flowId: z.string().optional(),
     metrics: z.custom<MetricEntry>().array(),
+    // Live log lines for the selected task, streamed while the execution is running.
+    // Lets a slot follow per-step progress in real time (metrics/outputs only exist post-completion).
+    logs: z.custom<LogEntry>().array().optional(),
 })
 
 export default defineArtifactSlot(() => ({

--- a/ui/src/components/executions/Topology.vue
+++ b/ui/src/components/executions/Topology.vue
@@ -58,52 +58,47 @@
     // FIXME: any - SSE objects don't have a consistent type in this codebase
     const sseBySubflow = ref<Record<string, any>>({}) // FIXME: any
 
-    // Live task logs, streamed only while the execution is running, so plugin
+    // Live task logs, polled while the execution is running, so plugin
     // topology-details slots can follow per-step progress in real time (metrics
     // and outputs only materialise once the task run completes).
+    //
+    // Polled, not streamed: the follow SSE only reliably delivers the snapshot
+    // replayed at connect time, and its realtime push isn't a dependable catch-up
+    // path — a stable connection never reconnects, so any lifecycle marker emitted
+    // after connect froze the stepper until the execution ended. A 1s GET snapshot
+    // is plenty (steps last seconds) and avoids the reconnect loop that caused the
+    // kestra-io/kestra#16982 off-heap leak.
     const executionLogs = ref<any[]>([]) // FIXME: any
-    let logsSSE: EventSource | undefined
-    let logsBuffer: any[] = []
-    let logsFlushTimer: ReturnType<typeof setTimeout> | undefined
+    let logsPollTimer: ReturnType<typeof setInterval> | undefined
 
-    function closeLogsSSE() {
-        logsSSE?.close()
-        logsSSE = undefined
-        if (logsFlushTimer) {
-            clearTimeout(logsFlushTimer)
-            logsFlushTimer = undefined
+    function stopLogsPolling() {
+        if (logsPollTimer) {
+            clearInterval(logsPollTimer)
+            logsPollTimer = undefined
         }
-        logsBuffer = []
     }
 
-    function flushLogsBuffer() {
-        logsFlushTimer = undefined
-        if (!logsBuffer.length) return
-        executionLogs.value = executionLogs.value.concat(logsBuffer)
-        logsBuffer = []
-    }
-
-    function streamExecutionLogs() {
-        closeLogsSSE()
-        executionLogs.value = []
+    function refreshExecutionLogs() {
         const id = execution.value?.id
         if (!id) return
         // INFO floor: the lifecycle step markers plugins emit are INFO, so this is
         // enough to drive live progress while filtering out DEBUG/TRACE log volume.
-        executionsStore.followLogs({id, params: {"filters[level][GREATER_THAN_OR_EQUAL_TO]": "INFO"}}).then((sse: EventSource) => {
-            logsSSE = sse
-            sse.onmessage = (event: MessageEvent) => {
-                if (event.lastEventId === "start") return
-                logsBuffer.push(JSON.parse(event.data))
-                if (!logsFlushTimer) logsFlushTimer = setTimeout(flushLogsBuffer, 200)
-            }
-            // No onerror handler: let EventSource auto-reconnect if the stream drops
-            // mid-execution. On reconnect the server replays all historical logs, so the
-            // stepper catches up without missing any lifecycle marker.
-            // The isExecutionRunning watch calls closeLogsSSE() when the execution
-            // terminates, which calls logsSSE.close() and prevents the reconnect loop
-            // that previously caused the kestra-io/kestra#16982 off-heap leak.
-        })
+        executionsStore.loadLogs({
+            executionId: id,
+            params: {"filters[level][GREATER_THAN_OR_EQUAL_TO]": "INFO"},
+            store: false,
+            showMessageOnError: false,
+        }).then((logs: any[]) => {
+            executionLogs.value = logs ?? []
+        }).catch(() => {})
+    }
+
+    function startLogsPolling() {
+        stopLogsPolling()
+        executionLogs.value = []
+        if (!execution.value?.id) return
+        refreshExecutionLogs()
+        logsPollTimer = setInterval(refreshExecutionLogs, 1000)
     }
 
     const isExecutionRunning = computed(() => {
@@ -114,8 +109,10 @@
     watch(
         [() => execution.value?.id, isExecutionRunning],
         ([id, running]) => {
-            if (id && running) streamExecutionLogs()
-            else closeLogsSSE()
+            if (id && running) startLogsPolling()
+            // One final fetch on terminate so the stepper lands on the complete
+            // marker set even if the last poll missed the closing steps.
+            else { stopLogsPolling(); refreshExecutionLogs() }
         },
         {immediate: true},
     )
@@ -143,7 +140,7 @@
 
     onUnmounted(() => {
         Object.keys(sseBySubflow.value).forEach(closeSSE)
-        closeLogsSSE()
+        stopLogsPolling()
     })
 
     function closeSSE(subflow: string) {

--- a/ui/src/components/executions/Topology.vue
+++ b/ui/src/components/executions/Topology.vue
@@ -28,7 +28,7 @@
     import {ref, computed, watch, onMounted, onUnmounted} from "vue"
     import {useI18n} from "vue-i18n"
     import throttle from "lodash/throttle"
-    import {stringUtils, State, levelToRequestParams} from "@kestra-io/design-system"
+    import {stringUtils, State} from "@kestra-io/design-system"
     import LowCodeEditor from "../inputs/LowCodeEditor.vue"
     import {useExecutionsStore} from "../../stores/executions"
     import {useFlowStore} from "../../stores/flow"
@@ -90,16 +90,19 @@
         if (!id) return
         // INFO floor: the lifecycle step markers plugins emit are INFO, so this is
         // enough to drive live progress while filtering out DEBUG/TRACE log volume.
-        executionsStore.followLogs({id, params: levelToRequestParams("INFO")}).then((sse: EventSource) => {
+        executionsStore.followLogs({id, params: {"filters[level][GREATER_THAN_OR_EQUAL_TO]": "INFO"}}).then((sse: EventSource) => {
             logsSSE = sse
             sse.onmessage = (event: MessageEvent) => {
                 if (event.lastEventId === "start") return
                 logsBuffer.push(JSON.parse(event.data))
                 if (!logsFlushTimer) logsFlushTimer = setTimeout(flushLogsBuffer, 200)
             }
-            // Close on error: EventSource otherwise auto-reconnects every ~3s, each
-            // reconnect leaking a server-side log-follow stream. See kestra-io/kestra#16982.
-            sse.onerror = () => closeLogsSSE()
+            // No onerror handler: let EventSource auto-reconnect if the stream drops
+            // mid-execution. On reconnect the server replays all historical logs, so the
+            // stepper catches up without missing any lifecycle marker.
+            // The isExecutionRunning watch calls closeLogsSSE() when the execution
+            // terminates, which calls logsSSE.close() and prevents the reconnect loop
+            // that previously caused the kestra-io/kestra#16982 off-heap leak.
         })
     }
 

--- a/ui/src/components/executions/Topology.vue
+++ b/ui/src/components/executions/Topology.vue
@@ -9,6 +9,7 @@
                 :flowGraph="flowGraph"
                 :source="flowStore.flow?.source"
                 :execution="execution"
+                :executionLogs="executionLogs"
                 :expandedSubflows="expandedSubflows"
                 :horizontalDefault="horizontalDefault"
                 isReadOnly
@@ -27,7 +28,7 @@
     import {ref, computed, watch, onMounted, onUnmounted} from "vue"
     import {useI18n} from "vue-i18n"
     import throttle from "lodash/throttle"
-    import {stringUtils, State} from "@kestra-io/design-system"
+    import {stringUtils, State, levelToRequestParams} from "@kestra-io/design-system"
     import LowCodeEditor from "../inputs/LowCodeEditor.vue"
     import {useExecutionsStore} from "../../stores/executions"
     import {useFlowStore} from "../../stores/flow"
@@ -57,6 +58,65 @@
     // FIXME: any - SSE objects don't have a consistent type in this codebase
     const sseBySubflow = ref<Record<string, any>>({}) // FIXME: any
 
+    // Live task logs, streamed only while the execution is running, so plugin
+    // topology-details slots can follow per-step progress in real time (metrics
+    // and outputs only materialise once the task run completes).
+    const executionLogs = ref<any[]>([]) // FIXME: any
+    let logsSSE: EventSource | undefined
+    let logsBuffer: any[] = []
+    let logsFlushTimer: ReturnType<typeof setTimeout> | undefined
+
+    function closeLogsSSE() {
+        logsSSE?.close()
+        logsSSE = undefined
+        if (logsFlushTimer) {
+            clearTimeout(logsFlushTimer)
+            logsFlushTimer = undefined
+        }
+        logsBuffer = []
+    }
+
+    function flushLogsBuffer() {
+        logsFlushTimer = undefined
+        if (!logsBuffer.length) return
+        executionLogs.value = executionLogs.value.concat(logsBuffer)
+        logsBuffer = []
+    }
+
+    function streamExecutionLogs() {
+        closeLogsSSE()
+        executionLogs.value = []
+        const id = execution.value?.id
+        if (!id) return
+        // INFO floor: the lifecycle step markers plugins emit are INFO, so this is
+        // enough to drive live progress while filtering out DEBUG/TRACE log volume.
+        executionsStore.followLogs({id, params: levelToRequestParams("INFO")}).then((sse: EventSource) => {
+            logsSSE = sse
+            sse.onmessage = (event: MessageEvent) => {
+                if (event.lastEventId === "start") return
+                logsBuffer.push(JSON.parse(event.data))
+                if (!logsFlushTimer) logsFlushTimer = setTimeout(flushLogsBuffer, 200)
+            }
+            // Close on error: EventSource otherwise auto-reconnects every ~3s, each
+            // reconnect leaking a server-side log-follow stream. See kestra-io/kestra#16982.
+            sse.onerror = () => closeLogsSSE()
+        })
+    }
+
+    const isExecutionRunning = computed(() => {
+        const current = execution.value?.state?.current
+        return !!current && State.isRunning(current)
+    })
+
+    watch(
+        [() => execution.value?.id, isExecutionRunning],
+        ([id, running]) => {
+            if (id && running) streamExecutionLogs()
+            else closeLogsSSE()
+        },
+        {immediate: true},
+    )
+
     const throttledExecutionUpdate = throttle(function(subflow: string, executionEvent: MessageEvent) {
         const previousExecution = executionsStore.subflowsExecutions[subflow]
         executionsStore.addSubflowExecution({
@@ -80,6 +140,7 @@
 
     onUnmounted(() => {
         Object.keys(sseBySubflow.value).forEach(closeSSE)
+        closeLogsSSE()
     })
 
     function closeSSE(subflow: string) {

--- a/ui/src/components/inputs/LowCodeEditor.vue
+++ b/ui/src/components/inputs/LowCodeEditor.vue
@@ -49,6 +49,7 @@
                         :namespace="props.namespace"
                         :flowId="props.flowId"
                         :metrics="taskMetrics(taskProps.data.node?.task?.id)"
+                        :logs="taskLogs(taskProps.data.node?.task?.id)"
                     />
                 </slot>
             </template>
@@ -305,6 +306,9 @@
     const taskMetrics = (taskId: string | undefined) =>
         executionsStore.metrics.filter((m) => m.taskId === taskId)
 
+    const taskLogs = (taskId: string | undefined) =>
+        (props.executionLogs ?? []).filter((l: any) => l.taskId === taskId)
+
     const isTaskModalOpen = ref(false)
     const taskModalCtx = ref<Record<string, any> | null>(null)
 
@@ -385,6 +389,7 @@
             horizontalDefault?: boolean;
             toggleOrientationButton?: boolean;
             expandedSubflows?: string[];
+            executionLogs?: Record<string, any>[];
         }>(),
         {
             flowId: undefined,
@@ -396,6 +401,7 @@
             horizontalDefault: undefined,
             toggleOrientationButton: true,
             expandedSubflows: () => [],
+            executionLogs: () => [],
         })
 
     watch(


### PR DESCRIPTION
## What

Adds an optional `logs` prop to the `topology-details` plugin UI slot, fed by a live `followLogs` SSE subscription, so plugin slots can follow per-step progress **while a task is running**.

## Why

Plugin `topology-details` slots currently receive `metrics` and `execution`, but neither carries live per-step progress during a run:

- **Metrics** accumulate in-memory and flush only *after* the task run completes (`WorkerTaskProcessor`), then go through the indexer. The UI also only loads them on demand (Metrics tab).
- **Outputs** likewise only exist post-completion.
- The **execution SSE follow** stream emits only on execution *state* changes, so it's static through a single long-running task.

The **log stream is the only channel that delivers data mid-task** (`/logs/{id}/follow`). This PR routes it to the slot so a plugin (e.g. the Kubernetes runner) can advance a live lifecycle stepper instead of jumping straight from "started" to "all done".

## How

- **`topology-details` contract**: add optional `logs: LogEntry[]`.
- **`LowCodeEditor`**: pass per-task logs to the slot, filtered by `taskId` (mirrors the existing `taskMetrics` pattern).
- **`executions/Topology`**: own the `followLogs` SSE lifecycle — subscribe only while the execution is running, buffer + throttle-flush into a reactive array, and **close on error** to avoid the EventSource reconnect leak documented in #16982.

The prop is **optional and additive** — existing slots are unaffected.

## Companion PR

The consumer side lives in the Kubernetes EE plugin (`plugin-ee-kubernetes` PR #132), which emits `[lifecycle] <step>` markers and parses them from these streamed logs to drive the live stepper.

## Test

- `oxlint` + `eslint` clean on the changed files.
- Manual QA of the live stepper is done via the companion plugin PR.