### PR TITLE
feat(ui): FORM wizard bottom progress bar + single primary button

### DIFF
--- a/ui/packages/design-system/src/components/Navigation/KsSteps/KsStep.vue
+++ b/ui/packages/design-system/src/components/Navigation/KsSteps/KsStep.vue
@@ -1,5 +1,15 @@
 <template>
+    <!-- Inside <KsSteps variant="bar">: render as a single label-less progress segment. -->
+    <span
+        v-if="isBar"
+        class="ks-stepbar__seg"
+        :class="`is-${segState}`"
+        role="listitem"
+        :aria-label="title || undefined"
+        :aria-current="segState === 'active' ? 'step' : undefined"
+    />
     <ElStep
+        v-else
         v-bind="({...filteredProps(), ...$attrs} as any)"
     >
         <template v-if="$slots.default" #default>
@@ -28,6 +38,7 @@
 <script setup lang="ts">
     import {ElStep, ElIcon} from "element-plus"
     import CheckBold from "vue-material-design-icons/CheckBold.vue"
+    import {inject, computed, type Ref} from "vue"
     import {useFilteredProps} from "../../../utils/filteredProps"
 
     defineOptions({inheritAttrs: false})
@@ -40,6 +51,16 @@
     }>()
 
     const filteredProps = useFilteredProps(props)
+
+    // Provided by a parent KsSteps. In the "bar" variant this step is a progress segment whose state
+    // comes from its own `status`: process -> active, success/finish -> filled, anything else -> upcoming.
+    const ksStepsVariant = inject<Ref<"steps" | "bar" | undefined> | undefined>("ksStepsVariant", undefined)
+    const isBar = computed(() => ksStepsVariant?.value === "bar")
+    const segState = computed(() =>
+        props.status === "process"
+            ? "active"
+            : (props.status === "success" || props.status === "finish") ? "filled" : "upcoming",
+    )
 
     defineSlots<{
         default?(): unknown

--- a/ui/packages/design-system/src/components/Navigation/KsSteps/KsSteps.vue
+++ b/ui/packages/design-system/src/components/Navigation/KsSteps/KsSteps.vue
@@ -1,5 +1,9 @@
 <template>
+    <div v-if="variant === 'bar'" class="ks-stepbar" role="list" v-bind="$attrs">
+        <slot />
+    </div>
     <ElSteps
+        v-else
         :class="{'kel-steps--small': size === 'small'}"
         v-bind="({...filteredProps(), ...$attrs} as any)"
     >
@@ -11,6 +15,7 @@
 
 <script setup lang="ts">
     import {ElSteps} from "element-plus"
+    import {provide, toRef} from "vue"
     import {useFilteredProps} from "../../../utils/filteredProps"
 
     defineOptions({inheritAttrs: false})
@@ -24,9 +29,14 @@
         simple?: boolean
         alignCenter?: boolean
         size?: "default" | "small"
+        variant?: "steps" | "bar"
     }>()
 
-    const filteredProps = useFilteredProps(props, ["size"])
+    const filteredProps = useFilteredProps(props, ["size", "variant"])
+
+    // In the "bar" variant each child KsStep renders itself as a single progress segment (instead of
+    // an ElStep), reading this injected variant — the same provide/inject pattern ElSteps/ElStep use.
+    provide("ksStepsVariant", toRef(props, "variant"))
 
     defineSlots<{
         default?(): unknown
@@ -36,4 +46,25 @@
 <style lang="scss">
     @use '../../../assets/styles/el-ns';
     @use 'element-plus/theme-chalk/src/steps';
+
+    // variant="bar": a label-less, equal-width segmented progress meter. State comes from each
+    // KsStep's `status` (see barSegments): filled = a passed step, active = current, upcoming = rest.
+    .ks-stepbar {
+        display: flex;
+        align-items: center;
+        gap: var(--ks-spacing-2, 0.5rem);
+        width: 100%;
+
+        &__seg {
+            flex: 1 1 0;
+            height: 0.375rem;
+            border-radius: var(--ks-radius-xl);
+            background: var(--ks-border-default);
+            transition: background 0.18s ease;
+
+            &.is-filled { background: var(--ks-primary-500); }
+            &.is-active { background: var(--ks-primary-300); }
+            &.is-upcoming { background: var(--ks-border-default); }
+        }
+    }
 </style>

--- a/ui/packages/design-system/tests/units/Navigation/KsSteps.test.ts
+++ b/ui/packages/design-system/tests/units/Navigation/KsSteps.test.ts
@@ -52,4 +52,49 @@ describe("KsSteps", () => {
         }, {global: globalConfig})
         expect(wrapper.findAll(".kel-step").length).toBe(3)
     })
+
+    test("variant=bar renders one segment per step with state from status", () => {
+        const wrapper = mount({
+            components: {KsSteps, KsStep},
+            template: `
+                <ks-steps variant="bar" :active="1">
+                    <ks-step title="A" status="success" />
+                    <ks-step title="B" status="process" />
+                    <ks-step title="C" status="wait" />
+                </ks-steps>
+            `,
+        }, {global: globalConfig})
+
+        const segs = wrapper.findAll(".ks-stepbar__seg")
+        expect(segs.length).toBe(3)
+        expect(segs[0].classes()).toContain("is-filled")
+        expect(segs[1].classes()).toContain("is-active")
+        expect(segs[2].classes()).toContain("is-upcoming")
+        expect(segs[0].attributes("aria-label")).toBe("A")
+        expect(wrapper.find(".kel-steps").exists()).toBe(false)
+    })
+
+    test("variant=bar treats missing/unknown status as upcoming", () => {
+        const wrapper = mount({
+            components: {KsSteps, KsStep},
+            template: `
+                <ks-steps variant="bar" :active="0">
+                    <ks-step title="A" />
+                    <ks-step title="B" status="finish" />
+                </ks-steps>
+            `,
+        }, {global: globalConfig})
+        const segs = wrapper.findAll(".ks-stepbar__seg")
+        expect(segs[0].classes()).toContain("is-upcoming")
+        expect(segs[1].classes()).toContain("is-filled")
+    })
+
+    test("default variant still renders ElSteps", () => {
+        const wrapper = mount({
+            components: {KsSteps, KsStep},
+            template: "<ks-steps :active=\"0\"><ks-step title=\"A\" /></ks-steps>",
+        }, {global: globalConfig})
+        expect(wrapper.find(".kel-steps").exists()).toBe(true)
+        expect(wrapper.find(".ks-stepbar").exists()).toBe(false)
+    })
 })

--- a/ui/src/components/flows/FlowRun.vue
+++ b/ui/src/components/flows/FlowRun.vue
@@ -247,6 +247,10 @@
         checks.value.some(check => check.behavior === "BLOCK_EXECUTION"),
     )
 
+    // The dialog-footer Execute (FlowRunActions) must follow the wizard: hidden until the recap when
+    // the flow has FORM inputs, so only one primary button shows (Next in-step, Execute on recap).
+    const showExecuteButton = computed(() => !hasFormInputs.value || inputsOnRecap.value)
+
     const canPrefill = computed(() =>
         Boolean(execution.value && (execution.value.inputs || hasExecutionLabels())),
     )
@@ -263,6 +267,7 @@
         canPrefill,
         flowCanBeExecuted,
         hasBlockingChecks,
+        showExecuteButton,
         buttonText: props.buttonText,
         buttonIcon: props.buttonIcon,
         buttonTestId: props.buttonTestId,

--- a/ui/src/components/flows/FlowRunActions.vue
+++ b/ui/src/components/flows/FlowRunActions.vue
@@ -8,7 +8,7 @@
         >
             {{ $t("prefill inputs") }}
         </KsButton>
-        <span data-onboarding-target="flow-execute-confirm-button">
+        <span v-if="flowRun?.showExecuteButton" data-onboarding-target="flow-execute-confirm-button">
             <KsButton
                 class="flow-run-trigger-button"
                 type="primary"
@@ -36,6 +36,7 @@
         buttonText: string
         buttonIcon: Component
         buttonTestId: string
+        showExecuteButton: boolean
     }
 
     defineProps<{flowRun: FlowRunInstance | null}>()

--- a/ui/src/components/inputs/InputsForm.vue
+++ b/ui/src/components/inputs/InputsForm.vue
@@ -1,14 +1,11 @@
 <template>
     <template v-if="initialInputs">
-        <!-- Wizard progress: one KsStep per fillable step (FORM titles, "Inputs" for ungrouped runs).
-             active = currentStep, so earlier steps render as finished and the recap marks them all done. -->
-        <KsSteps v-if="isWizard" :active="currentStep" finishStatus="success" class="wizard-steps" data-testid="wizard-steps">
-            <KsStep v-for="section in recapSections" :key="section.index" :title="section.title" />
-        </KsSteps>
-        <!-- The section name lives in the stepper (bold when active); only the optional description
-             is shown above the fields. -->
-        <div v-if="isWizard && current?.kind === 'form' && current.description" class="wizard-step-header">
-            <KsMarkdown :content="current.description" class="text-description" />
+        <!-- Active FORM header: its displayName (only when set), with the optional description beneath.
+             A FORM without a displayName, or an ungrouped inputs run, shows no header. The step
+             progress now lives in the bottom bar (see .wizard-progress below). -->
+        <div v-if="isWizard && current?.kind === 'form' && (current.displayName || current.description)" class="wizard-step-header">
+            <h5 v-if="current.displayName" class="wizard-step-title">{{ current.displayName }}</h5>
+            <KsMarkdown v-if="current.description" :content="current.description" class="text-description" />
         </div>
 
         <template v-for="input in visibleInputs" :key="input.id">
@@ -289,6 +286,19 @@
                 {{ showComputingLabel ? $t('loading') : $t(returnToRecap ? 'done' : 'next') }}
             </KsButton>
         </div>
+
+        <!-- Label-less progress bar pinned to the bottom of the pane; hidden on the recap, returns on Edit.
+             One segment per fillable step; fills only once the step is passed via Next (stepStatus). -->
+        <div v-if="isWizard && !isOnRecap" class="wizard-progress">
+            <KsSteps variant="bar" :active="currentStep" data-testid="wizard-progress">
+                <KsStep
+                    v-for="section in recapSections"
+                    :key="section.index"
+                    :title="section.title"
+                    :status="stepStatus(section.index)"
+                />
+            </KsSteps>
+        </div>
     </template>
 
     <KsAlert type="info" :closable="false" class="mb-3" v-else>
@@ -416,6 +426,7 @@
         navLoading,
         showComputingLabel,
         isOnRecap,
+        stepStatus,
         visibleInputs,
         inputLabel,
         recapSections,
@@ -1000,31 +1011,13 @@
     height: var(--ks-font-size-lg);
 }
 
-.wizard-steps {
-    margin-bottom: 1.5rem;
-
-    // The design system marks the active ("process") step with white text + a white-bordered icon
-    // and a heavy glow, built for a dark surface; on the light execution form that hides the
-    // title/number and the glow looks out of place. Restore a visible palette and drop the glow.
-    // (These per-state selectors must match the design system's own specificity to win.)
-    :deep(.kel-step__head.is-process) {
-        color: var(--ks-text-primary);
-
-        .kel-step__icon {
-            border-color: var(--ks-border-focus, #631bf3);
-            box-shadow: none;
-        }
-    }
-
-    :deep(.kel-step__title.is-process) {
-        color: var(--ks-text-primary);
-        font-weight: 600;
-    }
-
-    // Completed steps: drop the green glow too — a plain green check reads cleaner.
-    :deep(.kel-step__head.is-success .kel-step__icon) {
-        box-shadow: none;
-    }
+.wizard-progress {
+    position: sticky;
+    bottom: 0;
+    margin-top: 1rem;
+    padding: 0.75rem 0 0.25rem;
+    background: var(--ks-bg-surface);
+    border-top: 1px solid var(--ks-border-default);
 }
 
 .wizard-step-header {

--- a/ui/src/composables/useInputsWizard.ts
+++ b/ui/src/composables/useInputsWizard.ts
@@ -46,6 +46,10 @@ export function useInputsWizard(deps: UseInputsWizardDeps) {
     const steps = computed<WizardStep[]>(() => isWizard.value ? buildWizardSteps(props.initialInputs as any) : [])
 
     const currentStep = ref(0)
+    // Steps the user has passed via Next (sticky — never cleared, so editing from recap and
+    // navigating Back keep earlier segments filled). A step is "filled" iff visited; the active
+    // step is never filled (see stepStatus).
+    const visited = ref<Set<number>>(new Set())
     const current = computed<WizardStep | undefined>(() => steps.value[currentStep.value])
     const recapIndex = computed(() => steps.value.length - 1)
     const returnToRecap = ref(false)
@@ -113,6 +117,13 @@ export function useInputsWizard(deps: UseInputsWizardDeps) {
         })
     }
 
+    // Per-step state for the bottom progress bar. active beats filled beats upcoming.
+    function stepStatus(i: number): "process" | "success" | "wait" {
+        if (i === currentStep.value) return "process"
+        if (visited.value.has(i)) return "success"
+        return "wait"
+    }
+
     async function goNext(): Promise<void> {
         const step = current.value
         if (!step || step.kind === "recap") return
@@ -131,6 +142,7 @@ export function useInputsWizard(deps: UseInputsWizardDeps) {
         // reveal any per-field errors for this step now (bypass the 2s onChange delay)
         ;(step.leafIds ?? []).forEach(id => inputsValidated.value.add(id))
         if (!stepIsValid(step)) return
+        visited.value.add(currentStep.value)
         if (returnToRecap.value) {
             currentStep.value = recapIndex.value
             returnToRecap.value = false
@@ -189,6 +201,8 @@ export function useInputsWizard(deps: UseInputsWizardDeps) {
         navLoading,
         showComputingLabel,
         isOnRecap,
+        visited,
+        stepStatus,
         visibleInputs,
         formIds,
         inputLabel,

--- a/ui/src/utils/inputs.ts
+++ b/ui/src/utils/inputs.ts
@@ -124,6 +124,7 @@ export function executeFormValuesStorageKey(flow: {tenantId?: string; namespace:
 export interface WizardStep {
     kind: "plain" | "form" | "recap";
     title?: string;
+    displayName?: string;
     description?: string;
     leafIds?: string[];
 }
@@ -148,7 +149,7 @@ export function buildWizardSteps(inputs: FlowInput[] | undefined): WizardStep[] 
             flushRun()
             const leafIds = flattenInputs([input]).map((l) => l.id)
             if (leafIds.length) {
-                result.push({kind: "form", title: input.displayName || input.id, description: input.description, leafIds})
+                result.push({kind: "form", title: input.displayName || input.id, displayName: input.displayName, description: input.description, leafIds})
             }
         } else {
             run.push(input.id)

--- a/ui/tests/storybook/components/inputs/InputsForm.stories.jsx
+++ b/ui/tests/storybook/components/inputs/InputsForm.stories.jsx
@@ -196,21 +196,23 @@ export const Wizard = {
         expect(can.queryByTestId("inputs-wizard-recap")).toBeNull();
         expect(can.getByTestId("on-recap")).toHaveTextContent("false");
 
-        // Progress stepper (KsSteps): one step per fillable step ("Inputs", "Environment", "Inputs"),
-        // the current one in the "process" state.
-        const stepper = can.getByTestId("wizard-steps");
-        expect(stepper.querySelectorAll(".kel-step")).toHaveLength(3);
-        expect(stepper).toHaveTextContent("Environment");
-        expect(stepper.querySelectorAll(".kel-step__head")[0].className).toContain("is-process");
+        // Progress bar (KsSteps variant="bar"): one label-less segment per fillable step
+        // (name, Environment, team); the current one is "active", the rest "upcoming".
+        const bar = can.getByTestId("wizard-progress");
+        expect(bar.querySelectorAll(".ks-stepbar__seg")).toHaveLength(3);
+        expect(bar.querySelectorAll(".ks-stepbar__seg")[0].className).toContain("is-active");
 
         // Next -> step 2 (the FORM "Environment", showing its dotted child region).
         await userEvent.click(can.getByTestId("wizard-next"));
         await waitFor(() => expect(can.getByTestId("input-form-environment.region")).toBeTruthy());
         expect(can.getByTestId("wizard-back")).toBeTruthy();
+        // The active FORM's displayName shows as a header above its fields.
+        expect(canvasElement.querySelector(".wizard-step-title")).toHaveTextContent("Environment");
 
-        // Stepper tracks progress: step 0 completed (success), step 1 ("Environment") now in process.
-        expect(stepper.querySelectorAll(".kel-step__head")[0].className).toContain("is-success");
-        expect(stepper.querySelectorAll(".kel-step__head")[1].className).toContain("is-process");
+        // Bar tracks progress: step 0 passed (filled), step 1 ("Environment") now active.
+        const segs = can.getByTestId("wizard-progress").querySelectorAll(".ks-stepbar__seg");
+        expect(segs[0].className).toContain("is-filled");
+        expect(segs[1].className).toContain("is-active");
 
         // Next -> step 3 (plain "team").
         await userEvent.click(can.getByTestId("wizard-next"));

--- a/ui/tests/unit/components/flows/FlowRunActions.spec.ts
+++ b/ui/tests/unit/components/flows/FlowRunActions.spec.ts
@@ -1,0 +1,39 @@
+import {describe, test, expect} from "vitest"
+import {mount} from "@vue/test-utils"
+import {createI18n} from "vue-i18n"
+import FlowRunActions from "../../../../src/components/flows/FlowRunActions.vue"
+
+const i18n = createI18n({legacy: false, locale: "en", messages: {en: {"launch execution": "Execute"}}})
+
+function makeFlowRun(over: Record<string, unknown> = {}) {
+    return {
+        submit: () => {},
+        prefill: () => {},
+        canPrefill: false,
+        flowCanBeExecuted: true,
+        hasBlockingChecks: false,
+        buttonText: "launch execution",
+        buttonIcon: {},
+        buttonTestId: "execute-dialog-button",
+        showExecuteButton: true,
+        ...over,
+    }
+}
+
+describe("FlowRunActions Execute gating", () => {
+    test("shows Execute when showExecuteButton is true", () => {
+        const wrapper = mount(FlowRunActions, {
+            props: {flowRun: makeFlowRun({showExecuteButton: true})},
+            global: {plugins: [i18n], stubs: {KsButton: {template: "<button class=\"ks-button-stub\"><slot/></button>"}}},
+        })
+        expect(wrapper.find("[data-onboarding-target='flow-execute-confirm-button']").exists()).toBe(true)
+    })
+
+    test("hides Execute when showExecuteButton is false (mid-wizard)", () => {
+        const wrapper = mount(FlowRunActions, {
+            props: {flowRun: makeFlowRun({showExecuteButton: false})},
+            global: {plugins: [i18n], stubs: {KsButton: {template: "<button class=\"ks-button-stub\"><slot/></button>"}}},
+        })
+        expect(wrapper.find("[data-onboarding-target='flow-execute-confirm-button']").exists()).toBe(false)
+    })
+})

--- a/ui/tests/unit/composables/useInputsWizard.spec.ts
+++ b/ui/tests/unit/composables/useInputsWizard.spec.ts
@@ -1,0 +1,73 @@
+import {describe, test, expect} from "vitest"
+import {defineComponent, ref, reactive} from "vue"
+import {mount, flushPromises} from "@vue/test-utils"
+import {createI18n} from "vue-i18n"
+import {useInputsWizard} from "../../../src/composables/useInputsWizard"
+import type {InputMetaData} from "../../../src/stores/executions"
+
+// A flow with one FORM (env.region) + one ungrouped input (name) -> steps: [form, plain, recap].
+const FORM_INPUTS = [
+    {id: "env", type: "FORM", displayName: "Environment", inputs: [{id: "region", type: "STRING"}]},
+    {id: "name", type: "STRING"},
+] as unknown as InputMetaData[]
+
+function mountWizard(meta: InputMetaData[]) {
+    let api!: ReturnType<typeof useInputsWizard>
+    const inputsValues = reactive<Record<string, any>>({})
+    const inputsMetaData = ref<InputMetaData[]>(meta)
+    const Comp = defineComponent({
+        setup() {
+            api = useInputsWizard({
+                props: {initialInputs: FORM_INPUTS, mode: "wizard"},
+                inputsMetaData,
+                inputsValues,
+                multiSelectInputs: reactive({}),
+                inputsValidated: ref(new Set<string>()),
+                validateInputs: async () => {},
+                onRecapChange: () => {},
+            })
+            return () => null
+        },
+    })
+    mount(Comp, {global: {plugins: [createI18n({legacy: false, locale: "en"})]}})
+    return {api, inputsValues, inputsMetaData}
+}
+
+describe("useInputsWizard visited / stepStatus", () => {
+    test("active step is process, others wait; no step filled initially", () => {
+        const {api} = mountWizard([
+            {id: "env.region", type: "STRING", required: true} as InputMetaData,
+            {id: "name", type: "STRING", required: true} as InputMetaData,
+        ])
+        expect(api.isWizard.value).toBe(true)
+        expect(api.stepStatus(0)).toBe("process") // currentStep = 0
+        expect(api.stepStatus(1)).toBe("wait")
+        expect(api.visited.value.size).toBe(0)
+    })
+
+    test("goNext marks the passed step visited (filled) and advances active", async () => {
+        const {api, inputsValues} = mountWizard([
+            {id: "env.region", type: "STRING", required: true} as InputMetaData,
+            {id: "name", type: "STRING", required: true} as InputMetaData,
+        ])
+        inputsValues["env.region"] = "us-east" // make step 0 valid so goNext advances
+        await api.goNext()
+        await flushPromises()
+        expect(api.currentStep.value).toBe(1)
+        expect(api.visited.value.has(0)).toBe(true)
+        expect(api.stepStatus(0)).toBe("success") // visited + not active
+        expect(api.stepStatus(1)).toBe("process") // now active
+    })
+
+    test("goNext does NOT advance or mark visited when the step is invalid", async () => {
+        const {api} = mountWizard([
+            {id: "env.region", type: "STRING", required: true} as InputMetaData,
+            {id: "name", type: "STRING", required: true} as InputMetaData,
+        ])
+        // env.region has no value -> stepIsValid false
+        await api.goNext()
+        await flushPromises()
+        expect(api.currentStep.value).toBe(0)
+        expect(api.visited.value.size).toBe(0)
+    })
+})

--- a/ui/tests/unit/utils/inputs.spec.ts
+++ b/ui/tests/unit/utils/inputs.spec.ts
@@ -189,6 +189,17 @@ describe("buildWizardSteps", () => {
         expect(steps.map(s => s.kind)).toEqual(["plain", "recap"])
         expect(steps[0].leafIds).toEqual(["a", "b"])
     })
+
+    it("carries the FORM displayName separately from title", () => {
+        const steps = buildWizardSteps([
+            {id: "env", type: "FORM", displayName: "Environment", inputs: [{id: "region", type: "STRING"}]},
+            {id: "creds", type: "FORM", inputs: [{id: "token", type: "SECRET"}]},
+        ])
+        expect(steps[0].displayName).toBe("Environment")
+        expect(steps[0].title).toBe("Environment")
+        expect(steps[1].displayName).toBeUndefined() // no displayName -> undefined, title falls back to id
+        expect(steps[1].title).toBe("creds")
+    })
 })
 
 describe("inputsToFormData over flattened FORM inputs (submit contract)", () => {


### PR DESCRIPTION
Replaces the top numbered stepper in the FORM execution wizard with a label-less segmented progress bar at the bottom of the Inputs pane, and ensures only one primary button is shown at a time.

- `KsSteps` gains a `variant="bar"` segmented progress meter; the default `variant="steps"` rendering is unchanged, so existing usages (basic-auth setup, EE instance setup / worker-group wizard) are unaffected. Per-step state is driven by each `KsStep`'s `status` via provide/inject.
- `InputsForm` drops the top stepper, renders the sticky bottom bar (hidden on the recap, restored when editing a section from it), and shows the active FORM's `displayName` as a header above its fields — only when it has one (ungrouped inputs and FORMs without a displayName show none). The old `.wizard-steps` CSS is removed.
- A segment fills only once its step has been passed via **Next** (a sticky `visited` set in `useInputsWizard` + a new `stepStatus`), so progress reflects what's actually completed.
- The dialog-footer Execute (`FlowRunActions`) is gated on a new `FlowRun.showExecuteButton`, so the wizard shows **Next** while stepping and **Execute** only on the recap — fixing the case where both showed at once.

Unit tests cover the bar variant, the wizard `visited`/`stepStatus` state, and the Execute gating. Verified in-browser on an EE instance: the bar fills after Next, the header shows only for named FORMs, a single primary button at a time, the recap hides the bar, Edit returns and keeps prior segments filled, and FORM children show bare labels.
