### PR TITLE
fix(executions): LowCodeEditor replay button checks REPLAY permission instead of CREATE

### DIFF
--- a/ui/src/components/inputs/LowCodeEditor.vue
+++ b/ui/src/components/inputs/LowCodeEditor.vue
@@ -457,7 +457,7 @@
         if (!currentExecution?.state || State.isRunning(currentExecution.state.current)) {
             return false
         }
-        return authStore.user?.isAllowed(resource.EXECUTION, action.CREATE, currentExecution.namespace) === true
+        return authStore.user?.isAllowed(resource.EXECUTION, action.REPLAY, currentExecution.namespace) === true
     })
 
     const replayAttemptIndex = computed(() =>


### PR DESCRIPTION
## Summary

- The `replayEnabled` computed in `LowCodeEditor.vue` was gating the replay button on `action.CREATE` instead of `action.REPLAY`
- Users with `EXECUTION.REPLAY` but not `EXECUTION.CREATE` could not see the button even though they are entitled to use it
- Users with `EXECUTION.CREATE` but not `EXECUTION.REPLAY` would see the button but receive a 403 from the backend

This is the same class of bug fixed in `7b3804d1cd` across `ExecutionRootTopBar`, `Executions`, `Restart`, and `Actions` — the instance in `LowCodeEditor` was missed.

Closes kestra-io/kestra-ee#9057

## Test plan

- [ ] Log in as a user with `EXECUTION.REPLAY` but **not** `EXECUTION.CREATE` → open the topology/low-code editor for a completed execution → replay button **is visible**
- [ ] Log in as a user with `EXECUTION.CREATE` but **not** `EXECUTION.REPLAY` → replay button **is not visible**