### PR TITLE
[backport releases/v1.3.x] feat(ui): FORM wizard bottom progress bar + single primary button

### DIFF
--- a/ui/src/components/inputs/InputsForm.vue
+++ b/ui/src/components/inputs/InputsForm.vue
@@ -1,14 +1,13 @@
 <template>
     <template v-if="initialInputs">
-        <!-- Wizard progress: one step per fillable step (FORM titles, "Inputs" for ungrouped runs).
-             active = currentStep, so earlier steps render as finished and the recap marks them all done. -->
-        <el-steps v-if="isWizard" :active="currentStep" finishStatus="success" class="wizard-steps" data-testid="wizard-steps">
-            <el-step v-for="section in recapSections" :key="section.index" :title="section.title" />
-        </el-steps>
-        <!-- The section name lives in the stepper (bold when active); only the optional description
-             is shown above the fields. -->
-        <div v-if="isWizard && current?.kind === 'form' && current.description" class="wizard-step-header">
-            <Markdown :source="current.description" class="text-description" />
+        <!-- Active FORM header: its displayName (only when set), with the optional description beneath.
+             A FORM without a displayName, or an ungrouped inputs run, shows no header. Step progress
+             now lives in the bottom bar (see .wizard-progress below). -->
+        <div v-if="isWizard && current?.kind === 'form' && (current.displayName || current.description)" class="wizard-step-header">
+            <h5 v-if="current.displayName" class="wizard-step-title">
+                {{ current.displayName }}
+            </h5>
+            <Markdown v-if="current.description" :source="current.description" class="text-description" />
         </div>
 
         <el-form-item
@@ -305,6 +304,21 @@
                 {{ showComputingLabel ? $t('loading') : $t(returnToRecap ? 'done' : 'next') }}
             </el-button>
         </div>
+
+        <!-- Label-less progress bar pinned to the bottom of the pane; hidden on the recap, returns on Edit.
+             One segment per fillable step; fills only once the step is passed via Next (stepStatus).
+             1.3 has no design-system KsSteps variant, so the bar is inlined here as plain markup. -->
+        <div v-if="isWizard && !isOnRecap" class="wizard-progress" role="list" data-testid="wizard-progress">
+            <span
+                v-for="section in recapSections"
+                :key="section.index"
+                class="wizard-progress__seg"
+                :class="`is-${stepStatus(section.index)}`"
+                role="listitem"
+                :aria-label="section.title"
+                :aria-current="stepStatus(section.index) === 'process' ? 'step' : undefined"
+            />
+        </div>
     </template>
 
     <el-alert type="info" :showIcon="true" :closable="false" class="mb-3" v-else>
@@ -439,6 +453,7 @@
         navLoading,
         showComputingLabel,
         isOnRecap,
+        stepStatus,
         visibleInputs,
         inputLabel,
         recapSections,
@@ -947,27 +962,31 @@
 </script>
 
 <style scoped lang="scss">
-.wizard-steps {
-    margin-bottom: 1.5rem;
+.wizard-progress {
+    // Label-less, equal-width segmented progress meter, pinned to the bottom of the Inputs pane.
+    // 1.3 has no design-system KsSteps, so this is inlined (vs develop's KsSteps variant="bar").
+    // Tokens are 1.3 ui-libs names: --ks-border-active = brand violet, --ks-border-primary = neutral track.
+    position: sticky;
+    bottom: 0;
+    margin-top: 1rem;
+    padding: 0.75rem 0 0.25rem;
+    background: var(--ks-background-card);
+    border-top: 1px solid var(--ks-border-primary, #3d3d42);
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
 
-    // Tune the active ("process") and completed ("success") step palette for the light execution
-    // form (element-plus el-steps defaults are built for other surfaces); keep it readable, no glow.
-    :deep(.el-step__head.is-process) {
-        color: var(--ks-content-primary);
+    .wizard-progress__seg {
+        flex: 1 1 0;
+        height: 0.375rem;
+        border-radius: 999px;
+        background: var(--ks-border-primary, #3d3d42);
+        transition: background 0.18s ease;
 
-        .el-step__icon {
-            border-color: var(--ks-border-active, #8405ff);
-            box-shadow: none;
-        }
-    }
-
-    :deep(.el-step__title.is-process) {
-        color: var(--ks-content-primary);
-        font-weight: 600;
-    }
-
-    :deep(.el-step__head.is-success .el-step__icon) {
-        box-shadow: none;
+        // stepStatus(): success = passed via Next (filled), process = current (active), wait = upcoming.
+        &.is-success { background: var(--ks-border-active, #8405ff); }
+        &.is-process { background: rgba(132, 5, 255, 0.45); }
+        &.is-wait { background: var(--ks-border-primary, #3d3d42); }
     }
 }
 

--- a/ui/src/composables/useInputsWizard.ts
+++ b/ui/src/composables/useInputsWizard.ts
@@ -46,6 +46,10 @@ export function useInputsWizard(deps: UseInputsWizardDeps) {
     const steps = computed<WizardStep[]>(() => isWizard.value ? buildWizardSteps(props.initialInputs as any) : [])
 
     const currentStep = ref(0)
+    // Steps the user has passed via Next (sticky — never cleared, so editing from recap and
+    // navigating Back keep earlier segments filled). A step is "filled" iff visited; the active
+    // step is never filled (see stepStatus).
+    const visited = ref<Set<number>>(new Set())
     const current = computed<WizardStep | undefined>(() => steps.value[currentStep.value])
     const recapIndex = computed(() => steps.value.length - 1)
     const returnToRecap = ref(false)
@@ -113,6 +117,13 @@ export function useInputsWizard(deps: UseInputsWizardDeps) {
         })
     }
 
+    // Per-step state for the bottom progress bar. active beats filled beats upcoming.
+    function stepStatus(i: number): "process" | "success" | "wait" {
+        if (i === currentStep.value) return "process"
+        if (visited.value.has(i)) return "success"
+        return "wait"
+    }
+
     async function goNext(): Promise<void> {
         const step = current.value
         if (!step || step.kind === "recap") return
@@ -131,6 +142,7 @@ export function useInputsWizard(deps: UseInputsWizardDeps) {
         // reveal any per-field errors for this step now (bypass the 2s onChange delay)
         ;(step.leafIds ?? []).forEach(id => inputsValidated.value.add(id))
         if (!stepIsValid(step)) return
+        visited.value.add(currentStep.value)
         if (returnToRecap.value) {
             currentStep.value = recapIndex.value
             returnToRecap.value = false
@@ -189,6 +201,8 @@ export function useInputsWizard(deps: UseInputsWizardDeps) {
         navLoading,
         showComputingLabel,
         isOnRecap,
+        visited,
+        stepStatus,
         visibleInputs,
         formIds,
         inputLabel,

--- a/ui/src/utils/inputs.ts
+++ b/ui/src/utils/inputs.ts
@@ -124,6 +124,7 @@ export function executeFormValuesStorageKey(flow: {tenantId?: string; namespace:
 export interface WizardStep {
     kind: "plain" | "form" | "recap";
     title?: string;
+    displayName?: string;
     description?: string;
     leafIds?: string[];
 }
@@ -148,7 +149,7 @@ export function buildWizardSteps(inputs: FlowInput[] | undefined): WizardStep[] 
             flushRun()
             const leafIds = flattenInputs([input]).map((l) => l.id)
             if (leafIds.length) {
-                result.push({kind: "form", title: input.displayName || input.id, description: input.description, leafIds})
+                result.push({kind: "form", title: input.displayName || input.id, displayName: input.displayName, description: input.description, leafIds})
             }
         } else {
             run.push(input.id)

--- a/ui/tests/storybook/components/inputs/InputsForm.stories.jsx
+++ b/ui/tests/storybook/components/inputs/InputsForm.stories.jsx
@@ -181,21 +181,23 @@ export const Wizard = {
         expect(can.queryByTestId("inputs-wizard-recap")).toBeNull();
         expect(can.getByTestId("on-recap")).toHaveTextContent("false");
 
-        // Progress stepper (el-steps): one step per fillable step ("Inputs", "Environment", "Inputs"),
-        // the current one in the "process" state.
-        const stepper = can.getByTestId("wizard-steps");
-        expect(stepper.querySelectorAll(".el-step")).toHaveLength(3);
-        expect(stepper).toHaveTextContent("Environment");
-        expect(stepper.querySelectorAll(".el-step__head")[0].className).toContain("is-process");
+        // Progress bar (inlined — 1.3 has no design-system): one label-less segment per fillable step
+        // (name, Environment, team). stepStatus drives the class: is-process = current, is-wait = upcoming.
+        const bar = can.getByTestId("wizard-progress");
+        expect(bar.querySelectorAll(".wizard-progress__seg")).toHaveLength(3);
+        expect(bar.querySelectorAll(".wizard-progress__seg")[0].className).toContain("is-process");
 
         // Next -> step 2 (the FORM "Environment", showing its dotted child region).
         await userEvent.click(can.getByTestId("wizard-next"));
         await waitFor(() => expect(can.getByTestId("input-form-environment.region")).toBeTruthy());
         expect(can.getByTestId("wizard-back")).toBeTruthy();
+        // The active FORM's displayName shows as a header above its fields.
+        expect(canvasElement.querySelector(".wizard-step-title")).toHaveTextContent("Environment");
 
-        // Stepper tracks progress: step 0 completed (success), step 1 ("Environment") now in process.
-        expect(stepper.querySelectorAll(".el-step__head")[0].className).toContain("is-success");
-        expect(stepper.querySelectorAll(".el-step__head")[1].className).toContain("is-process");
+        // Bar tracks progress: step 0 passed (is-success), step 1 ("Environment") now current (is-process).
+        const segs = can.getByTestId("wizard-progress").querySelectorAll(".wizard-progress__seg");
+        expect(segs[0].className).toContain("is-success");
+        expect(segs[1].className).toContain("is-process");
 
         // Next -> step 3 (plain "team").
         await userEvent.click(can.getByTestId("wizard-next"));

--- a/ui/tests/unit/composables/useInputsWizard.spec.ts
+++ b/ui/tests/unit/composables/useInputsWizard.spec.ts
@@ -1,0 +1,73 @@
+import {describe, test, expect} from "vitest"
+import {defineComponent, ref, reactive} from "vue"
+import {mount, flushPromises} from "@vue/test-utils"
+import {createI18n} from "vue-i18n"
+import {useInputsWizard} from "../../../src/composables/useInputsWizard"
+import type {InputMetaData} from "../../../src/stores/executions"
+
+// A flow with one FORM (env.region) + one ungrouped input (name) -> steps: [form, plain, recap].
+const FORM_INPUTS = [
+    {id: "env", type: "FORM", displayName: "Environment", inputs: [{id: "region", type: "STRING"}]},
+    {id: "name", type: "STRING"},
+] as unknown as InputMetaData[]
+
+function mountWizard(meta: InputMetaData[]) {
+    let api!: ReturnType<typeof useInputsWizard>
+    const inputsValues = reactive<Record<string, any>>({})
+    const inputsMetaData = ref<InputMetaData[]>(meta)
+    const Comp = defineComponent({
+        setup() {
+            api = useInputsWizard({
+                props: {initialInputs: FORM_INPUTS, mode: "wizard"},
+                inputsMetaData,
+                inputsValues,
+                multiSelectInputs: reactive({}),
+                inputsValidated: ref(new Set<string>()),
+                validateInputs: async () => {},
+                onRecapChange: () => {},
+            })
+            return () => null
+        },
+    })
+    mount(Comp, {global: {plugins: [createI18n({legacy: false, locale: "en"})]}})
+    return {api, inputsValues, inputsMetaData}
+}
+
+describe("useInputsWizard visited / stepStatus", () => {
+    test("active step is process, others wait; no step filled initially", () => {
+        const {api} = mountWizard([
+            {id: "env.region", type: "STRING", required: true} as InputMetaData,
+            {id: "name", type: "STRING", required: true} as InputMetaData,
+        ])
+        expect(api.isWizard.value).toBe(true)
+        expect(api.stepStatus(0)).toBe("process") // currentStep = 0
+        expect(api.stepStatus(1)).toBe("wait")
+        expect(api.visited.value.size).toBe(0)
+    })
+
+    test("goNext marks the passed step visited (filled) and advances active", async () => {
+        const {api, inputsValues} = mountWizard([
+            {id: "env.region", type: "STRING", required: true} as InputMetaData,
+            {id: "name", type: "STRING", required: true} as InputMetaData,
+        ])
+        inputsValues["env.region"] = "us-east" // make step 0 valid so goNext advances
+        await api.goNext()
+        await flushPromises()
+        expect(api.currentStep.value).toBe(1)
+        expect(api.visited.value.has(0)).toBe(true)
+        expect(api.stepStatus(0)).toBe("success") // visited + not active
+        expect(api.stepStatus(1)).toBe("process") // now active
+    })
+
+    test("goNext does NOT advance or mark visited when the step is invalid", async () => {
+        const {api} = mountWizard([
+            {id: "env.region", type: "STRING", required: true} as InputMetaData,
+            {id: "name", type: "STRING", required: true} as InputMetaData,
+        ])
+        // env.region has no value -> stepIsValid false
+        await api.goNext()
+        await flushPromises()
+        expect(api.currentStep.value).toBe(0)
+        expect(api.visited.value.size).toBe(0)
+    })
+})

--- a/ui/tests/unit/utils/inputs.spec.ts
+++ b/ui/tests/unit/utils/inputs.spec.ts
@@ -190,6 +190,17 @@ describe("buildWizardSteps", () => {
         expect(steps.map(s => s.kind)).toEqual(["plain", "recap"])
         expect(steps[0].leafIds).toEqual(["a", "b"])
     })
+
+    it("carries the FORM displayName separately from title", () => {
+        const steps = buildWizardSteps([
+            {id: "env", type: "FORM", displayName: "Environment", inputs: [{id: "region", type: "STRING"}]},
+            {id: "creds", type: "FORM", inputs: [{id: "token", type: "SECRET"}]},
+        ])
+        expect(steps[0].displayName).toBe("Environment")
+        expect(steps[0].title).toBe("Environment")
+        expect(steps[1].displayName).toBeUndefined() // no displayName -> undefined, title falls back to id
+        expect(steps[1].title).toBe("creds")
+    })
 })
 
 describe("inputsToFormData over flattened FORM inputs (submit contract)", () => {


### PR DESCRIPTION
Backport of #17118 to `releases/v1.3.x`.

1.3 has a different UI structure than develop (no in-repo design-system, no `FlowRunActions`), so this is a structural port rather than a clean cherry-pick:

- The label-less segmented progress bar is **inlined** in `InputsForm.vue` (plain markup + CSS) rather than a `KsSteps variant="bar"` — 1.3's stepper was raw Element Plus `<el-steps>`, removed here. Uses 1.3 tokens (`--ks-border-active`, `--ks-border-primary`, `--ks-background-card`).
- The active FORM's `displayName` shows as a header above its fields, only when set (`WizardStep.displayName`).
- `useInputsWizard` gains a sticky `visited` set + `stepStatus` so a segment fills only once its step is passed via **Next** (verbatim from develop — the composable is byte-identical in 1.3).
- Single primary button needs no change: 1.3's `FlowRun` already gates the Execute button on `!hasFormInputs || inputsOnRecap` and has no `FlowRunActions` split (that refactor post-dates 1.3).

Updated the `InputsForm` Wizard storybook story for the inlined bar.

Original PR: #17118 — feat(ui): FORM wizard bottom progress bar + single primary button.
