### PR TITLE
fix(worker): emit failed result when task fails on its own during graceful shutdown drain

### DIFF
--- a/worker/src/main/java/io/kestra/worker/WorkerJobExecutor.java
+++ b/worker/src/main/java/io/kestra/worker/WorkerJobExecutor.java
@@ -214,6 +214,7 @@ public class WorkerJobExecutor {
 
         if (terminationGracePeriod == null || terminationGracePeriod.equals(Duration.ZERO)) {
             // Force: kill in-flight tasks, then unblock consumers
+            signalShutdownInterruptToRunningJobs();
             this.executorService.shutdownNow();
             this.consumerThreads.forEach(Thread::interrupt);
             return false;
@@ -236,11 +237,22 @@ public class WorkerJobExecutor {
 
         if (!terminated) {
             log.warn("Worker still has pending jobs after the termination grace period. Forcing shutdown.");
+            signalShutdownInterruptToRunningJobs();
             this.executorService.shutdownNow();
             this.consumerThreads.forEach(Thread::interrupt);
         }
 
         return terminated;
+    }
+
+    /**
+     * Marks every in-flight job as interrupted by the shutdown right before the executor is forcibly stopped,
+     * so a task that gets torn down here is deferred for resubmission rather than reported as a genuine failure.
+     * A task that already reached a terminal state on its own during the grace period is unaffected — it is not
+     * interrupted, so its result is emitted as usual.
+     */
+    private void signalShutdownInterruptToRunningJobs() {
+        this.workerJobConsumers.forEach(WorkerJobConsumer::signalShutdownInterrupt);
     }
 
     /**
@@ -342,6 +354,17 @@ public class WorkerJobExecutor {
             WorkerJobProcessor<WorkerJob> processor = running.get();
             if (processor != null) {
                 processor.stop();
+            }
+        }
+
+        /**
+         * Signals the currently running job — if any — that it is being forcibly interrupted by the
+         * worker shutdown.
+         */
+        void signalShutdownInterrupt() {
+            WorkerJobProcessor<WorkerJob> processor = running.get();
+            if (processor != null) {
+                processor.signalShutdownInterrupt();
             }
         }
 

--- a/worker/src/main/java/io/kestra/worker/processors/AbstractWorkerJobProcessor.java
+++ b/worker/src/main/java/io/kestra/worker/processors/AbstractWorkerJobProcessor.java
@@ -32,6 +32,7 @@ public abstract class AbstractWorkerJobProcessor<T extends WorkerJob> implements
 
     private final AtomicBoolean stopped = new AtomicBoolean(false);
     private final AtomicBoolean killRequested = new AtomicBoolean(false);
+    private final AtomicBoolean shutdownInterrupted = new AtomicBoolean(false);
 
     public AbstractWorkerJobProcessor(String workerGroup,
         MetricRegistry metricRegistry,
@@ -109,7 +110,19 @@ public abstract class AbstractWorkerJobProcessor<T extends WorkerJob> implements
         Optional.ofNullable(currentWorkerCallable.get()).ifPresent(AbstractWorkerCallable::kill);
     }
 
+    @Override
+    public void signalShutdownInterrupt() {
+        shutdownInterrupted.set(true);
+        // interrupt() (not kill()) so the callable still reports FAILED rather than KILLED;
+        // the shutdownInterrupted flag is what tells the processor to drop/defer the result.
+        Optional.ofNullable(currentWorkerCallable.get()).ifPresent(AbstractWorkerCallable::interrupt);
+    }
+
     protected boolean isStopped() {
         return this.stopped.get();
+    }
+
+    protected boolean isShutdownInterrupted() {
+        return this.shutdownInterrupted.get();
     }
 }

--- a/worker/src/main/java/io/kestra/worker/processors/WorkerJobProcessor.java
+++ b/worker/src/main/java/io/kestra/worker/processors/WorkerJobProcessor.java
@@ -38,4 +38,17 @@ public interface WorkerJobProcessor<T extends WorkerJob> {
      * If no job is currently running, the method returns immediately without any side effects.
      */
     void kill();
+
+    /**
+     * Signals that the currently running job is being forcibly interrupted by the worker shutdown,
+     * because the termination grace period elapsed (or a force shutdown was requested).
+     * <p>
+     * Unlike {@link #stop()} — the cooperative drain signal sent at the start of shutdown, which lets an
+     * in-flight task keep running and possibly reach its own terminal state — this marks the job as
+     * <em>interrupted by the shutdown</em> so a task torn down here can be told apart from one that failed
+     * on its own during the drain window.
+     * <p>
+     * If no job is currently running, the method returns immediately without any side effects.
+     */
+    void signalShutdownInterrupt();
 }

--- a/worker/src/main/java/io/kestra/worker/processors/WorkerTaskProcessor.java
+++ b/worker/src/main/java/io/kestra/worker/processors/WorkerTaskProcessor.java
@@ -267,9 +267,14 @@ public class WorkerTaskProcessor extends AbstractWorkerJobProcessor<WorkerTask> 
             }
             io.kestra.core.models.flows.State.Type state = lastAttempt.getState().getCurrent();
 
-            if (isStopped() && serverConfig.workerTaskRestartStrategy() != WorkerTaskRestartStrategy.NEVER && state.isFailed()) {
-                // if the Worker is terminating and the task is not in success, it may have been terminated by the worker
-                // in this case; we return immediately without emitting any result as it would be resubmitted (except if WorkerTaskRestartStrategy is NEVER)
+            if (isStopped() && isShutdownInterrupted() && serverConfig.workerTaskRestartStrategy() != WorkerTaskRestartStrategy.NEVER && state.isFailed()) {
+                // The Worker is terminating and forcibly interrupted this still-running task (grace period
+                // elapsed or force shutdown), so its failed state is an artifact of the shutdown, not a real
+                // failure: we return immediately without emitting any result as it will be resubmitted
+                // (except if WorkerTaskRestartStrategy is NEVER).
+                // A task that reached a FAILED state on its own during the drain window is NOT interrupted
+                // (isShutdownInterrupted() is false), so it falls through and its terminal result is emitted —
+                // otherwise its genuine failure would be silently dropped and the execution stuck RUNNING.
                 List<WorkerTaskResult> dynamicWorkerResults = runContext.dynamicWorkerResults();
                 List<TaskRun> dynamicTaskRuns = dynamicWorkerResults(dynamicWorkerResults);
                 return new WorkerTaskResult(taskRunWithOutput.taskRun(), dynamicTaskRuns, taskRunWithOutput.outputs());

--- a/worker/src/test/java/io/kestra/worker/processors/WorkerTaskProcessorTest.java
+++ b/worker/src/test/java/io/kestra/worker/processors/WorkerTaskProcessorTest.java
@@ -1,0 +1,173 @@
+package io.kestra.worker.processors;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import io.kestra.core.junit.annotations.KestraTest;
+import io.kestra.core.metrics.MetricRegistry;
+import io.kestra.core.models.executions.Execution;
+import io.kestra.core.models.executions.MetricEntry;
+import io.kestra.core.models.executions.TaskRun;
+import io.kestra.core.models.flows.Flow;
+import io.kestra.core.models.tasks.ResolvedTask;
+import io.kestra.core.models.tasks.RunnableTask;
+import io.kestra.core.models.tasks.Task;
+import io.kestra.core.models.tasks.VoidOutput;
+import io.kestra.core.runners.RunContext;
+import io.kestra.core.runners.RunContextFactory;
+import io.kestra.core.runners.RunContextInitializer;
+import io.kestra.core.runners.RunContextLoggerFactory;
+import io.kestra.core.runners.Worker;
+import io.kestra.core.runners.WorkerTask;
+import io.kestra.core.runners.WorkerTaskData;
+import io.kestra.core.runners.WorkerTaskResult;
+import io.kestra.core.server.ServerConfig;
+import io.kestra.core.trace.TracerFactory;
+import io.kestra.core.utils.IdUtils;
+import io.kestra.core.utils.TestsUtils;
+import io.kestra.core.worker.WorkerGroups;
+import io.kestra.worker.WorkerSecurityService;
+import io.kestra.worker.queues.InMemoryWorkerQueue;
+import io.kestra.worker.queues.WorkerQueue;
+import io.kestra.worker.services.ExecutionKilledManager;
+
+import jakarta.inject.Inject;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Component-level tests for {@link WorkerTaskProcessor}'s behavior when the worker is shutting down,
+ * covering the regression from <a href="https://github.com/kestra-io/kestra/issues/17124">#17124</a>:
+ * a task that fails on its own during the termination grace period must still have its terminal
+ * result emitted, while a task the shutdown actually interrupted is deferred for resubmission.
+ */
+@KestraTest
+class WorkerTaskProcessorTest {
+
+    @Inject
+    private ServerConfig serverConfig;
+
+    @Inject
+    private MetricRegistry metricRegistry;
+
+    @Inject
+    private WorkerSecurityService workerSecurityService;
+
+    @Inject
+    private TracerFactory tracerFactory;
+
+    @Inject
+    private RunContextInitializer runContextInitializer;
+
+    @Inject
+    private RunContextLoggerFactory runContextLoggerFactory;
+
+    @Inject
+    private ExecutionKilledManager executionKilledManager;
+
+    @Inject
+    private RunContextFactory runContextFactory;
+
+    @Test
+    void shouldEmitFailedResultWhenTaskFailsOnItsOwnDuringShutdownDrain() throws Exception {
+        // Given a processor in the graceful drain window (stopped) that did NOT interrupt the task
+        InMemoryWorkerQueue<WorkerTaskResult> resultQueue = new InMemoryWorkerQueue<>(100);
+        WorkerTaskProcessor processor = newProcessor(resultQueue);
+        processor.stop();
+
+        // When the task reaches a FAILED state on its own during the drain window
+        processor.process(failingWorkerTask());
+
+        // Then its terminal FAILED result is emitted, not silently dropped
+        List<WorkerTaskResult> results = drain(resultQueue);
+        assertThat(results)
+            .as("a genuine failure during the drain window must be emitted, not dropped (#17124)")
+            .anyMatch(result -> result.getTaskRun().getState().isFailed());
+    }
+
+    @Test
+    void shouldDropFailedResultWhenTaskWasInterruptedByShutdown() throws Exception {
+        // Given a processor whose task is forcibly interrupted by the shutdown
+        InMemoryWorkerQueue<WorkerTaskResult> resultQueue = new InMemoryWorkerQueue<>(100);
+        WorkerTaskProcessor processor = newProcessor(resultQueue);
+        processor.signalShutdownInterrupt();
+        processor.stop();
+
+        // When the interrupted task ends in a failed state
+        processor.process(failingWorkerTask());
+
+        // Then no terminal result is emitted (it will be resubmitted) — only the RUNNING preamble
+        List<WorkerTaskResult> results = drain(resultQueue);
+        assertThat(results)
+            .as("an interrupted task's failure must be deferred for resubmission, not reported")
+            .noneMatch(result -> result.getTaskRun().getState().isFailed());
+    }
+
+    private WorkerTaskProcessor newProcessor(WorkerQueue<WorkerTaskResult> resultQueue) {
+        return new WorkerTaskProcessor(
+            "test-worker",
+            WorkerGroups.DEFAULT_ID,
+            serverConfig,
+            metricRegistry,
+            workerSecurityService,
+            tracerFactory.getTracer(Worker.class, "WORKER"),
+            runContextInitializer,
+            runContextLoggerFactory,
+            resultQueue,
+            new InMemoryWorkerQueue<>(100),
+            executionKilledManager
+        );
+    }
+
+    private WorkerTask failingWorkerTask() {
+        AlwaysFail task = AlwaysFail.builder()
+            .type(AlwaysFail.class.getName())
+            .id("fail-task")
+            .build();
+
+        Flow flow = Flow.builder()
+            .id(IdUtils.create())
+            .namespace("io.kestra.unit-test")
+            .tasks(List.of(task))
+            .build();
+
+        Execution execution = TestsUtils.mockExecution(flow, Map.of());
+        ResolvedTask resolvedTask = ResolvedTask.of(task);
+
+        return WorkerTask.builder()
+            .data(WorkerTaskData.from(runContextFactory.of(Map.of("key", "value"))))
+            .task(task)
+            .taskRun(TaskRun.of(execution, resolvedTask))
+            .build();
+    }
+
+    private static List<WorkerTaskResult> drain(WorkerQueue<WorkerTaskResult> queue) throws InterruptedException {
+        List<WorkerTaskResult> results = new ArrayList<>();
+        WorkerTaskResult result;
+        while ((result = queue.poll(Duration.ZERO)) != null) {
+            results.add(result);
+        }
+        return results;
+    }
+
+    /**
+     * A task that always fails on its own (throws when run), modeling e.g. a script container exiting
+     * non-zero. Constructed and executed directly by the processor, so no plugin registration is needed.
+     */
+    @SuperBuilder
+    @Getter
+    @NoArgsConstructor
+    public static class AlwaysFail extends Task implements RunnableTask<VoidOutput> {
+        @Override
+        public VoidOutput run(RunContext runContext) {
+            throw new RuntimeException("simulated task failure during shutdown drain");
+        }
+    }
+}


### PR DESCRIPTION
Closes #17124

During a worker's graceful shutdown drain window, `isStopped()` returns `true` for the entire window — not only when the worker forcibly interrupts a still-running task. This caused tasks that reached a FAILED state on their own during the drain to have their result silently dropped (the `WorkerTaskResult` was returned without being enqueued), leaving the execution stuck in RUNNING forever.

Fix: introduce `isShutdownInterrupted()` (backed by an `AtomicBoolean shutdownInterrupted` set only when `executorService.shutdownNow()` is actually called) and gate the early-return on both `isStopped() && isShutdownInterrupted()`. Tasks that fail organically during the drain window fall through and their terminal result is emitted normally.

`WorkerJobExecutor` calls `signalShutdownInterrupt()` on all running job processors immediately before `shutdownNow()`, both in the zero-grace-period path and when the grace period elapses.

Regression test in `WorkerTaskProcessorTest` covers:
- task fails on its own during drain (result must be emitted — was the bug)
- task interrupted by forced shutdown (result must be dropped for resubmission)