### PR TITLE
feat(executions): track saved-filters usage in PostHog

### DIFF
--- a/ui/packages/design-system/src/components/Data/KsDataTable/KsFilter.vue
+++ b/ui/packages/design-system/src/components/Data/KsDataTable/KsFilter.vue
@@ -35,7 +35,8 @@
 </template>
 
 <script setup lang="ts">
-    import {ref, computed, provide, onMounted, watch} from "vue"
+    import {ref, computed, provide, inject, onMounted, watch} from "vue"
+    import {useRoute} from "vue-router"
     import {useMediaQuery} from "@vueuse/core"
     import type {
         AppliedFilter,
@@ -49,6 +50,7 @@
     import {newGroupId} from "./filter/composables/useFilterGroups"
     import {useDataOptions} from "./filter/composables/useDataOptions"
     import {FILTER_CONTEXT_INJECTION_KEY} from "./filter/utils/filterInjectionKeys.ts"
+    import {SAVED_FILTER_ANALYTICS_INJECTION_KEY, type SavedFilterAction} from "./filter/utils/filterAnalytics"
     import MainFilter from "./filter/MainFilter.vue"
     import MobileFilter from "./filter/MobileFilter.vue"
     import RawFilter from "./filter/RawFilter.vue"
@@ -133,9 +135,33 @@
         props.defaultDuration,
     )
 
-    const {savedFilters, saveFilter, updateSavedFilter, deleteSavedFilter} = useSavedFilters(
-        props.prefix,
-    )
+    const {
+        savedFilters,
+        saveFilter: persistFilter,
+        updateSavedFilter: persistFilterUpdate,
+        deleteSavedFilter: removeSavedFilter,
+    } = useSavedFilters(props.prefix)
+
+    const route = useRoute()
+    const trackSavedFilter = inject(SAVED_FILTER_ANALYTICS_INJECTION_KEY, undefined)
+    const reportSavedFilter = (action: SavedFilterAction, filtersCount: number) => {
+        trackSavedFilter?.({action, page: String(route.name ?? route.path), filtersCount})
+    }
+
+    const saveFilter = (name: string, description: string, filters: AppliedFilter[]) => {
+        persistFilter(name, description, filters)
+        reportSavedFilter("save", filters.length)
+    }
+
+    const updateSavedFilter = (id: string, name: string, description: string, filters: AppliedFilter[]) => {
+        persistFilterUpdate(id, name, description, filters)
+        reportSavedFilter("update", filters.length)
+    }
+
+    const deleteSavedFilter = (savedFilter: SavedFilter) => {
+        removeSavedFilter(savedFilter)
+        reportSavedFilter("delete", savedFilter.filters.length)
+    }
 
     const {chartVisible, updateChart, refreshData: tableRefreshData} = useDataOptions(
         props.tableOptions,
@@ -162,6 +188,8 @@
     const hasAppliedFilters = computed(() => appliedFilters.value?.length > 0)
 
     const loadSavedFilter = (savedFilter: SavedFilter) => {
+        reportSavedFilter("apply", savedFilter.filters.length)
+
         // Filters saved before nested groups were supported only carry a flat list.
         if (savedFilter.groups && savedFilter.groups.length > 0) {
             replaceTree(savedFilter.groups, savedFilter.topLogical ?? "OR")

--- a/ui/packages/design-system/src/components/Data/KsDataTable/filter/utils/filterAnalytics.ts
+++ b/ui/packages/design-system/src/components/Data/KsDataTable/filter/utils/filterAnalytics.ts
@@ -1,0 +1,13 @@
+import type {InjectionKey} from "vue"
+
+export type SavedFilterAction = "save" | "apply" | "update" | "delete"
+
+export interface SavedFilterAnalyticsEvent {
+    action: SavedFilterAction;
+    page: string;
+    filtersCount: number;
+}
+
+export type SavedFilterAnalyticsTracker = (event: SavedFilterAnalyticsEvent) => void
+
+export const SAVED_FILTER_ANALYTICS_INJECTION_KEY = Symbol("saved-filter-analytics") as InjectionKey<SavedFilterAnalyticsTracker>

--- a/ui/packages/design-system/src/index.ts
+++ b/ui/packages/design-system/src/index.ts
@@ -142,6 +142,8 @@ export type {InputInstance, FormItemRule, FormRules, FormInstance, CascaderOptio
 export {TooltipType, ChartRenderer, ChartFeature} from "./components/Charts/ksChartUtils"
 export {designSystemLocale, setDesignSystemLocale, registerDesignSystemI18n} from "./i18n"
 export type {FilterContext} from "./components/Data/KsDataTable/filter/utils/filterInjectionKeys"
+export {SAVED_FILTER_ANALYTICS_INJECTION_KEY} from "./components/Data/KsDataTable/filter/utils/filterAnalytics"
+export type {SavedFilterAction, SavedFilterAnalyticsEvent, SavedFilterAnalyticsTracker} from "./components/Data/KsDataTable/filter/utils/filterAnalytics"
 export {applyDefaultFilters} from "./components/Data/KsDataTable/filter/composables/useDefaultFilter"
 export {useRouteFilterPolicy} from "./components/Data/KsDataTable/filter/composables/useRouteFilterPolicy"
 export {

--- a/ui/packages/design-system/tests/units/Data/KsFilter/KsFilter.test.ts
+++ b/ui/packages/design-system/tests/units/Data/KsFilter/KsFilter.test.ts
@@ -1,9 +1,14 @@
-import {describe, test, expect} from "vitest"
+import {describe, test, expect, vi, beforeEach} from "vitest"
 import {mount} from "@vue/test-utils"
+import {defineComponent, h, inject} from "vue"
 import {createI18n} from "vue-i18n"
 import {createRouter, createMemoryHistory} from "vue-router"
 import KestraDesignSystem from "../../../../src/index"
 import KsFilter from "../../../../src/components/Data/KsDataTable/KsFilter.vue"
+import {FILTER_CONTEXT_INJECTION_KEY} from "../../../../src/components/Data/KsDataTable/filter/utils/filterInjectionKeys"
+import {SAVED_FILTER_ANALYTICS_INJECTION_KEY} from "../../../../src/components/Data/KsDataTable/filter/utils/filterAnalytics"
+import {Comparators} from "../../../../src/components/Data/KsDataTable/filter/utils/filterTypes"
+import type {AppliedFilter, FilterContext, SavedFilter} from "../../../../src/index"
 
 const router = createRouter({
     history: createMemoryHistory(),
@@ -63,5 +68,104 @@ describe("KsFilter", () => {
         })
         // FilterOptions is hidden by default (showOptions starts false)
         expect(wrapper.find(".expand-panel").exists()).toBe(false)
+    })
+})
+
+describe("KsFilter saved-filter analytics", () => {
+    const makeAppliedFilter = (id = "f1"): AppliedFilter => ({
+        id,
+        key: "namespace",
+        keyLabel: "Namespace",
+        comparator: Comparators.EQUALS,
+        comparatorLabel: "Equals",
+        value: "io.kestra",
+        valueLabel: "io.kestra",
+    })
+
+    const mountWithTracker = async () => {
+        const tracker = vi.fn()
+        const router = createRouter({
+            history: createMemoryHistory(),
+            routes: [{path: "/executions", name: "executions", component: {template: "<div/>"}}],
+        })
+        await router.push("/executions")
+        await router.isReady()
+
+        let context: FilterContext | undefined
+        const Harness = defineComponent({
+            setup() {
+                context = inject(FILTER_CONTEXT_INJECTION_KEY)
+                return () => h("div")
+            },
+        })
+
+        mount(KsFilter, {
+            props: {configuration: {title: "", keys: []}, prefix: "test"},
+            slots: {extra: () => h(Harness)},
+            global: {
+                plugins: [createI18n({legacy: false, locale: "en"}), KestraDesignSystem, router],
+                provide: {[SAVED_FILTER_ANALYTICS_INJECTION_KEY as symbol]: tracker},
+            },
+        })
+
+        return {tracker, context: context as FilterContext}
+    }
+
+    beforeEach(() => localStorage.clear())
+
+    test("tracks a save action with page and filters count", async () => {
+        const {tracker, context} = await mountWithTracker()
+
+        context.saveFilter("My filter", "", [makeAppliedFilter()])
+
+        expect(tracker).toHaveBeenCalledWith({action: "save", page: "executions", filtersCount: 1})
+    })
+
+    test("tracks an apply action when a saved filter is loaded", async () => {
+        const {tracker, context} = await mountWithTracker()
+        const savedFilter: SavedFilter = {
+            id: "saved_1",
+            name: "My filter",
+            description: "",
+            filters: [],
+            createdAt: new Date(),
+        }
+
+        context.loadSavedFilter(savedFilter)
+
+        expect(tracker).toHaveBeenCalledWith({action: "apply", page: "executions", filtersCount: 0})
+    })
+
+    test("tracks update and delete actions", async () => {
+        const {tracker, context} = await mountWithTracker()
+        context.saveFilter("My filter", "", [makeAppliedFilter()])
+        const saved = context.savedFilters.value[0]
+
+        context.updateSavedFilter(saved.id, "Renamed", "", [makeAppliedFilter("f1"), makeAppliedFilter("f2")])
+        expect(tracker).toHaveBeenCalledWith({action: "update", page: "executions", filtersCount: 2})
+
+        context.deleteSavedFilter(context.savedFilters.value[0])
+        expect(tracker).toHaveBeenCalledWith({action: "delete", page: "executions", filtersCount: 2})
+    })
+
+    test("does not throw when no analytics tracker is provided", async () => {
+        const router = createRouter({
+            history: createMemoryHistory(),
+            routes: [{path: "/", component: {template: "<div/>"}}],
+        })
+        let context: FilterContext | undefined
+        const Harness = defineComponent({
+            setup() {
+                context = inject(FILTER_CONTEXT_INJECTION_KEY)
+                return () => h("div")
+            },
+        })
+        mount(KsFilter, {
+            props: {configuration: {title: "", keys: []}, prefix: "test"},
+            slots: {extra: () => h(Harness)},
+            global: {plugins: [createI18n({legacy: false, locale: "en"}), KestraDesignSystem, router]},
+        })
+
+        expect(() => context!.saveFilter("X", "", [makeAppliedFilter()])).not.toThrow()
     })
 })

--- a/ui/packages/design-system/tests/units/Data/KsFilter/useSavedFilters.test.ts
+++ b/ui/packages/design-system/tests/units/Data/KsFilter/useSavedFilters.test.ts
@@ -226,7 +226,7 @@ describe("useSavedFilters", () => {
 
         // Then: the value inside groups[].filters is deserialized back into a Date, same as the flat list
         const saved = savedFilters.value[0]
-        const groupValue = (saved.groups?.[0] as {filters: AppliedFilter[]}).filters[0].value
+        const groupValue = (saved.groups![0] as {filters: AppliedFilter[]}).filters[0].value
         expect(groupValue).toBeInstanceOf(Date)
         expect((groupValue as Date).toISOString()).toBe(isoDate.toISOString())
     })

--- a/ui/src/App.vue
+++ b/ui/src/App.vue
@@ -19,8 +19,9 @@
     import "./styles/vendor.scss"
     import "./styles/app.scss"
 
-    import {ref, computed, watch, onMounted} from "vue"
+    import {ref, computed, watch, onMounted, provide} from "vue"
     import {useRoute} from "vue-router"
+    import {SAVED_FILTER_ANALYTICS_INJECTION_KEY} from "@kestra-io/design-system"
     import {useApiStore} from "./stores/api"
     import {useLayoutStore} from "./stores/layout"
     import {useCoreStore} from "./stores/core"
@@ -30,6 +31,7 @@
     import * as BasicAuth from "./utils/basicAuth"
     import {applyFontScale, getAppFontSizeMode} from "./utils/appFontSize"
     import {initPosthogIfEnabled} from "./utils/posthog"
+    import {trackSavedFilter} from "./utils/savedFilterTracking"
     import ErrorToast from "./components/ErrorToast.vue"
     import OnboardingOverlay from "./components/onboarding/OnboardingOverlay.vue"
     import DefaultLayout from "override/components/layout/DefaultLayout.vue"
@@ -50,6 +52,8 @@
 
     const miscStore = useMiscStore()
     useThemeCycle(miscStore)
+
+    provide(SAVED_FILTER_ANALYTICS_INJECTION_KEY, trackSavedFilter)
 
     const route = useRoute()
 

--- a/ui/src/utils/savedFilterTracking.ts
+++ b/ui/src/utils/savedFilterTracking.ts
@@ -1,0 +1,18 @@
+import type {SavedFilterAnalyticsEvent} from "@kestra-io/design-system"
+import {useApiStore} from "../stores/api"
+import {useMiscStore} from "override/stores/misc"
+
+export function trackSavedFilter({action, page, filtersCount}: SavedFilterAnalyticsEvent) {
+    try {
+        if (useMiscStore().configs?.isUiAnonymousUsageEnabled === false) return
+
+        useApiStore().posthogEvents({
+            type: "SAVED_FILTER",
+            action,
+            filter_page: page,
+            filters_count: filtersCount,
+        })
+    } catch {
+        //
+    }
+}


### PR DESCRIPTION
## What

Adds a `saved_filter` PostHog event so we can measure **how many users use the Saved filters feature and on which pages** — the ask in kestra-io/kestra-ee#9082.

Today there is no instrumentation for saved filters (and autocapture is off), so PostHog literally cannot answer the question. This adds it.

## How

`KsFilter` is the single chokepoint for every saved-filter mutation (save / apply / update / delete), so tracking lives there — wired through a **decoupled analytics injection** (`SAVED_FILTER_ANALYTICS_INJECTION_KEY`, default no-op) so the design system stays independent of the app. The app provides the real PostHog implementation once in `App.vue`.

The emitted event `saved_filter` carries:

| Property | Values | Answers |
|---|---|---|
| `action` | `save` \| `apply` \| `update` \| `delete` | real usage vs. mere creation |
| `filter_page` | route name (`executions`, `flows`, `logs`, `kv`, …) | "on which pages" |
| `filters_count` | number of criteria | richness of saved filters |
| `$host` (auto) | instance host | segment to customer **production** instances |

This automatically covers every page mounting `KsFilter` (Flows, Executions, Logs, KV, Secrets, Triggers, Blueprints, Namespaces) without touching each page.

## Notes

- PostHog is disabled in `development` mode (existing behaviour), so events only fire in real builds.
- EE mounts its own `App.vue`; a companion EE PR provides the same tracker there. **Merge this OSS PR first.**

## Tests

- DS unit tests assert the injected tracker fires with the correct `action` / `page` / `filtersCount` on save, apply, update and delete, plus a no-tracker-no-throw case.
- `check:types` (DS + app + tests), eslint, and the full KsFilter test suite (59 tests) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)