### PR TITLE
feat(cli): add 'sys database plan' to preview pending schema migrations

### DIFF
--- a/cli/build.gradle
+++ b/cli/build.gradle
@@ -34,6 +34,9 @@ dependencies {
     // OTLP metrics
     implementation "io.micronaut.micrometer:micronaut-micrometer-registry-otlp"
 
+    // Flyway, for the 'sys database plan' command to inspect pending schema migrations
+    implementation "io.micronaut.flyway:micronaut-flyway"
+
     // aether still use javax.inject
     compileOnly 'javax.inject:javax.inject:1'
 

--- a/cli/src/main/java/io/kestra/cli/commands/sys/database/DatabaseCommand.java
+++ b/cli/src/main/java/io/kestra/cli/commands/sys/database/DatabaseCommand.java
@@ -12,6 +12,7 @@ import picocli.CommandLine;
     mixinStandardHelpOptions = true,
     subcommands = {
         DatabaseMigrateCommand.class,
+        DatabasePlanCommand.class,
     }
 )
 public class DatabaseCommand extends AbstractCommand {

--- a/cli/src/main/java/io/kestra/cli/commands/sys/database/DatabasePlanCommand.java
+++ b/cli/src/main/java/io/kestra/cli/commands/sys/database/DatabasePlanCommand.java
@@ -1,0 +1,154 @@
+package io.kestra.cli.commands.sys.database;
+
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collection;
+import java.util.Map;
+
+import javax.sql.DataSource;
+
+import io.kestra.cli.AbstractCommand;
+
+import io.micronaut.context.ApplicationContext;
+import io.micronaut.inject.qualifiers.Qualifiers;
+import io.micronaut.jdbc.DataSourceResolver;
+import jakarta.inject.Inject;
+import lombok.extern.slf4j.Slf4j;
+import org.flywaydb.core.Flyway;
+import org.flywaydb.core.api.Location;
+import org.flywaydb.core.api.MigrationInfo;
+import org.flywaydb.core.api.MigrationVersion;
+import io.micronaut.flyway.FlywayConfigurationProperties;
+import picocli.CommandLine;
+
+@CommandLine.Command(
+    name = "plan",
+    description = "Show the pending database schema migrations without applying them.\n" +
+        "Kestra uses Flyway to manage database schema evolution; this command lists the migrations that 'sys database migrate' would run, then exits without modifying the database.",
+    mixinStandardHelpOptions = true
+)
+@Slf4j
+public class DatabasePlanCommand extends AbstractCommand {
+    @Inject
+    private ApplicationContext applicationContext;
+
+    @CommandLine.Option(names = { "-s", "--sql" }, description = "Also print the SQL content of each pending migration.")
+    private boolean sql = false;
+
+    @Override
+    public Integer call() throws Exception {
+        super.call();
+
+        Collection<FlywayConfigurationProperties> configurations = applicationContext.getBeansOfType(FlywayConfigurationProperties.class);
+        if (configurations.isEmpty()) {
+            stdErr("No Flyway datasource is configured.");
+            return 1;
+        }
+
+        DataSourceResolver dataSourceResolver = applicationContext.findBean(DataSourceResolver.class).orElse(DataSourceResolver.DEFAULT);
+
+        int total = 0;
+        for (FlywayConfigurationProperties configuration : configurations) {
+            String name = configuration.getNameQualifier();
+
+            // Only the datasource configured at runtime has a DataSource bean; skip the others.
+            DataSource dataSource = applicationContext.findBean(DataSource.class, Qualifiers.byName(name)).orElse(null);
+            if (dataSource == null) {
+                continue;
+            }
+
+            // Unwrap the contextual proxy added by Micronaut Data to the underlying pooled DataSource;
+            // otherwise Flyway fails with NoConnectionException as there is no transaction in scope.
+            dataSource = dataSourceResolver.resolve(dataSource);
+
+            // info() only reads the schema history table, it never modifies the database.
+            Flyway flyway = configuration.getFluentConfiguration().dataSource(dataSource).load();
+            MigrationInfo[] pending = flyway.info().pending();
+
+            stdOut("@|bold Datasource '" + name + "'|@: " + pending.length + " pending migration(s).");
+            if (pending.length == 0) {
+                stdOut("  No pending migrations.");
+                continue;
+            }
+
+            for (MigrationInfo migration : pending) {
+                MigrationVersion version = migration.getVersion();
+                stdOut(String.format(
+                    "  %-10s %-9s %s — %s",
+                    version != null ? version.getVersion() : "repeatable",
+                    migration.getType(),
+                    migration.getScript(),
+                    migration.getDescription()
+                ));
+
+                if (sql) {
+                    String content = readScript(configuration, migration);
+                    if (content != null) {
+                        stdOut("");
+                        stdOut(content);
+                        stdOut("");
+                    }
+                }
+            }
+
+            total += pending.length;
+        }
+
+        stdOut("@|bold Total|@: " + total + " pending migration(s).");
+        return 0;
+    }
+
+    /**
+     * Reads the SQL of a pending migration. Tries the physical file location first (when running from sources),
+     * then falls back to the classpath resource (when running from the packaged jar).
+     */
+    private String readScript(FlywayConfigurationProperties configuration, MigrationInfo migration) {
+        String physicalLocation = migration.getPhysicalLocation();
+        if (physicalLocation != null) {
+            Path path = Path.of(physicalLocation);
+            if (Files.isReadable(path)) {
+                try {
+                    return Files.readString(path);
+                } catch (Exception e) {
+                    log.debug("Unable to read migration file {}", physicalLocation, e);
+                }
+            }
+        }
+
+        for (Location location : configuration.getFluentConfiguration().getLocations()) {
+            String resource = location.getPath() + "/" + migration.getScript();
+            try (InputStream is = applicationContext.getClassLoader().getResourceAsStream(resource)) {
+                if (is != null) {
+                    return new String(is.readAllBytes(), StandardCharsets.UTF_8);
+                }
+            } catch (Exception e) {
+                log.debug("Unable to read migration resource {}", resource, e);
+            }
+        }
+
+        stdErr("  Unable to read SQL for " + migration.getScript());
+        return null;
+    }
+
+    public static Map<String, Object> propertiesOverrides() {
+        // Disable automatic Flyway migration on startup so this command can report the pending migrations
+        // without applying them (the inverse of 'sys database migrate', which force-enables Flyway).
+        return Map.of(
+            "flyway.datasources.postgres.enabled", "false",
+            "flyway.datasources.mysql.enabled", "false",
+            "flyway.datasources.h2.enabled", "false"
+        );
+    }
+
+    @Override
+    protected boolean loadExternalPlugins() {
+        return false;
+    }
+
+    @Override
+    protected boolean isPluginManagerEnabled() {
+        return false;
+    }
+}

--- a/cli/src/test/java/io/kestra/cli/commands/sys/database/DatabasePlanCommandTest.java
+++ b/cli/src/test/java/io/kestra/cli/commands/sys/database/DatabasePlanCommandTest.java
@@ -1,0 +1,101 @@
+package io.kestra.cli.commands.sys.database;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+import org.junit.jupiter.api.Test;
+
+import io.micronaut.configuration.picocli.PicocliRunner;
+import io.micronaut.context.ApplicationContext;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class DatabasePlanCommandTest {
+    /**
+     * Builds the base properties for an isolated H2 datasource. Flyway is left to the caller to enable/disable
+     * so we can exercise both the "pending" and "up to date" states.
+     */
+    private static Map<String, Object> h2Properties(boolean flywayEnabled) {
+        Map<String, Object> properties = new HashMap<>();
+        properties.put("datasources.h2.url", "jdbc:h2:mem:plan-" + UUID.randomUUID() + ";DB_CLOSE_DELAY=-1");
+        properties.put("datasources.h2.username", "sa");
+        properties.put("datasources.h2.password", "");
+        properties.put("datasources.h2.driver-class-name", "org.h2.Driver");
+        // postgres/mysql are declared in application.yml but have no datasource here, so they are skipped
+        properties.put("flyway.datasources.postgres.enabled", false);
+        properties.put("flyway.datasources.mysql.enabled", false);
+        properties.put("flyway.datasources.h2.enabled", flywayEnabled);
+        return properties;
+    }
+
+    @Test
+    void shouldListPendingMigrationsOnAFreshDatabase() {
+        PrintStream originalOut = System.out;
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        System.setOut(new PrintStream(out));
+
+        // Flyway disabled: nothing is migrated on startup, so every migration is reported as pending.
+        try (ApplicationContext ctx = ApplicationContext.builder()
+            .deduceEnvironment(false)
+            .environments("test")
+            .properties(h2Properties(false))
+            .start()) {
+            Integer call = PicocliRunner.call(DatabasePlanCommand.class, ctx);
+
+            String output = out.toString();
+            assertThat(call).isZero();
+            assertThat(output).contains("pending migration(s)");
+            assertThat(output).contains("V1_1__initial.sql");
+        } finally {
+            System.setOut(originalOut);
+        }
+    }
+
+    @Test
+    void shouldPrintSqlWhenRequested() {
+        PrintStream originalOut = System.out;
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        System.setOut(new PrintStream(out));
+
+        try (ApplicationContext ctx = ApplicationContext.builder()
+            .deduceEnvironment(false)
+            .environments("test")
+            .properties(h2Properties(false))
+            .start()) {
+            Integer call = PicocliRunner.call(DatabasePlanCommand.class, ctx, "--sql");
+
+            String output = out.toString();
+            assertThat(call).isZero();
+            // the actual SQL of the first migration must be printed, not only its name
+            assertThat(output).contains("CREATE TABLE IF NOT EXISTS queues");
+        } finally {
+            System.setOut(originalOut);
+        }
+    }
+
+    @Test
+    void shouldReportNoPendingMigrationWhenUpToDate() {
+        PrintStream originalOut = System.out;
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        System.setOut(new PrintStream(out));
+
+        // Flyway enabled: migrations are applied on startup, so the plan must report nothing pending.
+        try (ApplicationContext ctx = ApplicationContext.builder()
+            .deduceEnvironment(false)
+            .environments("test")
+            .properties(h2Properties(true))
+            .start()) {
+            Integer call = PicocliRunner.call(DatabasePlanCommand.class, ctx);
+
+            String output = out.toString();
+            assertThat(call).isZero();
+            assertThat(output).contains("No pending migrations.");
+            assertThat(output).contains("Total: 0 pending migration(s).");
+        } finally {
+            System.setOut(originalOut);
+        }
+    }
+}


### PR DESCRIPTION
### What

Adds a new read-only CLI command:

```
kestra sys database plan          # list pending Flyway schema migrations
kestra sys database plan --sql    # also print the SQL of each pending migration
```

It lists the database schema migrations that `kestra sys database migrate` *would* apply, **without running them**.

### Why

Implements kestra-io/kestra-ee#8745. Customers preparing migrations — notably the 1.3 → 2.0 upgrade — want to see exactly which migrations (especially the SQL ones) are planned before applying them.

### How

- New `DatabasePlanCommand` registered under `sys database`, next to the existing `migrate`.
- `propertiesOverrides()` **disables** Flyway auto-migration at startup (the inverse of `DatabaseMigrateCommand`), so the context boots without migrating.
- The command then queries `flyway.info().pending()` for each configured Flyway datasource, against the underlying pooled `DataSource` (unwrapped via `DataSourceResolver`, otherwise Flyway fails with `NoConnectionException` on the Micronaut Data contextual proxy). `info()` is read-only and never touches the database.
- `--sql` prints each pending migration's SQL (read from the migration's physical location, falling back to the classpath resource).
- Works for OSS and EE — EE `V2_*` scripts share the same `classpath:migrations/<db>` location, so they are listed automatically with no EE-specific code.
- `micronaut-flyway` added to `cli/build.gradle` (it was only an `implementation` dep of `:jdbc`, not exposed to `:cli`).

### Testing

Verified end-to-end against a fresh H2 file database:

- Fresh DB → lists all 50 pending `V1_*` migrations; `--sql` prints their SQL.
- Re-running `plan` still shows 50 pending → confirms it does **not** modify the DB.
- After `sys database migrate` (applies 50) → `plan` reports `0 pending migration(s). / No pending migrations.`

The mechanism is database-agnostic (Flyway), so Postgres/MySQL behave identically.