### PR TITLE
fix(worker): emit failed result when task fails on its own during graceful shutdown drain

### DIFF
--- a/worker/src/main/java/io/kestra/worker/DefaultWorker.java
+++ b/worker/src/main/java/io/kestra/worker/DefaultWorker.java
@@ -158,6 +158,7 @@ public class DefaultWorker implements Worker {
     private final ExecutorService executorService;
 
     private final AtomicBoolean shutdown = new AtomicBoolean(false);
+    private final AtomicBoolean shutdownInterrupted = new AtomicBoolean(false);
     private final AtomicBoolean init = new AtomicBoolean(false);
 
     private final AtomicReference<ServiceState> state = new AtomicReference<>();
@@ -752,9 +753,14 @@ public class DefaultWorker implements Worker {
             }
             io.kestra.core.models.flows.State.Type state = lastAttempt.getState().getCurrent();
 
-            if (shutdown.get() && serverConfig.workerTaskRestartStrategy() != WorkerTaskRestartStrategy.NEVER && state.isFailed()) {
-                // if the Worker is terminating and the task is not in success, it may have been terminated by the worker
-                // in this case; we return immediately without emitting any result as it would be resubmitted (except if WorkerTaskRestartStrategy is NEVER)
+            if (shutdown.get() && shutdownInterrupted.get() && serverConfig.workerTaskRestartStrategy() != WorkerTaskRestartStrategy.NEVER && state.isFailed()) {
+                // The Worker is terminating and forcibly interrupted this still-running task (grace period
+                // elapsed or force shutdown), so its failed state is an artifact of the shutdown, not a real
+                // failure: we return immediately without emitting any result as it will be resubmitted
+                // (except if WorkerTaskRestartStrategy is NEVER).
+                // A task that reached a FAILED state on its own during the drain window is NOT interrupted
+                // (shutdownInterrupted is false), so it falls through and its terminal result is emitted —
+                // otherwise its genuine failure would be silently dropped and the execution stuck RUNNING.
                 List<WorkerTaskResult> dynamicWorkerResults = workerTask.getRunContext().dynamicWorkerResults();
                 List<TaskRun> dynamicTaskRuns = dynamicWorkerResults(dynamicWorkerResults);
                 return new WorkerTaskResult(workerTask.getTaskRun(), dynamicTaskRuns);
@@ -1090,6 +1096,7 @@ public class DefaultWorker implements Worker {
         } else {
             log.info("Terminating now and skip waiting for tasks completions.");
             this.receiveCancellations.forEach(Runnable::run);
+            this.shutdownInterrupted.set(true);
             this.executorService.shutdownNow();
             closeQueue();
             terminatedGracefully = false;
@@ -1132,6 +1139,7 @@ public class DefaultWorker implements Worker {
                     boolean gracefullyShutdown = this.executorService.awaitTermination(remaining, TimeUnit.MILLISECONDS);
                     if (!gracefullyShutdown) {
                         log.warn("Worker still has some pending threads after `terminationGracePeriod`. Forcing shutdown now.");
+                        this.shutdownInterrupted.set(true);
                         this.executorService.shutdownNow();
                     }
 

--- a/worker/src/test/java/io/kestra/worker/WorkerTest.java
+++ b/worker/src/test/java/io/kestra/worker/WorkerTest.java
@@ -1,11 +1,14 @@
 package io.kestra.worker;
 
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.junit.jupiter.api.Assertions;
@@ -29,6 +32,7 @@ import io.kestra.core.serializers.JacksonMapper;
 import io.kestra.core.utils.Await;
 import io.kestra.core.utils.IdUtils;
 import io.kestra.core.utils.TestsUtils;
+import io.kestra.plugin.core.execution.Fail;
 import io.kestra.plugin.core.flow.Pause;
 import io.kestra.plugin.core.flow.Sleep;
 import io.kestra.plugin.core.flow.WorkingDirectory;
@@ -271,6 +275,83 @@ class WorkerTest {
             .findFirst()
             .orElseThrow();
         assertThat(result.getTaskRun().getState().getCurrent()).isEqualTo(State.Type.FAILED);
+    }
+
+    @Test
+    void shouldEmitFailedResultWhenTaskFailsOnItsOwnDuringShutdownDrain() throws Exception {
+        // Given: shutdown=true (drain window active) but shutdownInterrupted=false (grace period not elapsed)
+        DefaultWorker worker = applicationContext.createBean(DefaultWorker.class, IdUtils.create(), 8, null);
+        setWorkerFlag(worker, "shutdown", true);
+        setWorkerFlag(worker, "shutdownInterrupted", false);
+
+        List<WorkerTaskResult> results = new CopyOnWriteArrayList<>();
+        Flux<WorkerTaskResult> receive = TestsUtils.receive(workerTaskResultQueue, either -> results.add(either.getLeft()));
+
+        // When: run a task that fails on its own (not interrupted by the worker)
+        invokeRun(worker, failWorkerTask());
+
+        // Then: result must be emitted — the genuine failure must not be swallowed (regression for #17124)
+        Await.until(
+            () -> results.stream().anyMatch(r -> r.getTaskRun().getState().isFailed()),
+            Duration.ofMillis(100),
+            Duration.ofSeconds(10)
+        );
+        assertThat(results).anyMatch(r -> r.getTaskRun().getState().isFailed());
+        receive.blockLast(Duration.ofSeconds(1));
+    }
+
+    @Test
+    void shouldDropFailedResultWhenTaskWasInterruptedByShutdown() throws Exception {
+        // Given: shutdown=true AND shutdownInterrupted=true (grace period elapsed, worker forcibly interrupted)
+        DefaultWorker worker = applicationContext.createBean(DefaultWorker.class, IdUtils.create(), 8, null);
+        setWorkerFlag(worker, "shutdown", true);
+        setWorkerFlag(worker, "shutdownInterrupted", true);
+
+        List<WorkerTaskResult> results = new CopyOnWriteArrayList<>();
+        Flux<WorkerTaskResult> receive = TestsUtils.receive(workerTaskResultQueue, either -> results.add(either.getLeft()));
+
+        // When: run a task that ends in FAILED state (because it was interrupted by the forced shutdown)
+        invokeRun(worker, failWorkerTask());
+
+        // Then: result must NOT be emitted — the executor will resubmit the task
+        // (all results except the RUNNING interim emit come from run(); RUNNING emits before the shutdown check)
+        Thread.sleep(200);
+        assertThat(results).noneMatch(r -> r.getTaskRun().getState().isFailed());
+        receive.blockLast(Duration.ofSeconds(1));
+    }
+
+    private void setWorkerFlag(DefaultWorker worker, String fieldName, boolean value) throws Exception {
+        Field field = DefaultWorker.class.getDeclaredField(fieldName);
+        field.setAccessible(true);
+        ((AtomicBoolean) field.get(worker)).set(value);
+    }
+
+    private void invokeRun(DefaultWorker worker, WorkerTask workerTask) throws Exception {
+        Method runMethod = DefaultWorker.class.getDeclaredMethod("run", WorkerTask.class, Boolean.class);
+        runMethod.setAccessible(true);
+        runMethod.invoke(worker, workerTask, false);
+    }
+
+    private WorkerTask failWorkerTask() {
+        Fail task = Fail.builder()
+            .type(Fail.class.getName())
+            .id("drain-fail-test")
+            .build();
+
+        Flow flow = Flow.builder()
+            .id(IdUtils.create())
+            .namespace("io.kestra.unit-test")
+            .tasks(Collections.singletonList(task))
+            .build();
+
+        Execution execution = TestsUtils.mockExecution(flow, ImmutableMap.of());
+        ResolvedTask resolvedTask = ResolvedTask.of(task);
+
+        return WorkerTask.builder()
+            .runContext(runContextFactory.of(ImmutableMap.of("key", "value")))
+            .task(task)
+            .taskRun(TaskRun.of(execution, resolvedTask))
+            .build();
     }
 
     private WorkerTask workerTask(long sleepDuration) {


### PR DESCRIPTION
Backport of #17129 to `releases/v1.3.x`.

Closes #17124

During a worker's graceful shutdown drain window, `shutdown.get()` returns `true` for the entire window — not only when the worker forcibly interrupts a still-running task. This caused tasks that reached a FAILED state on their own during the drain to have their `WorkerTaskResult` silently dropped, leaving the execution stuck in RUNNING forever.

Fix: introduce `shutdownInterrupted` (`AtomicBoolean` set only when `executorService.shutdownNow()` is actually called) and gate the early-return on both `shutdown.get() && shutdownInterrupted.get()`. Tasks that fail organically during the drain window fall through and emit their terminal result normally.

`shutdownInterrupted` is set to `true` before `shutdownNow()` in both paths:
- the `skipGracefulTermination` (force-shutdown) path
- the `waitForTasksCompletion` path when the grace period elapses

Regression tests in `WorkerTest` cover:
- task fails on its own during drain (result must be emitted — was the bug)
- task interrupted by forced shutdown (result must be dropped for resubmission)