### PR TITLE
fix(core): keep task runner job names within the 63-char limit

### DIFF
--- a/core/src/main/java/io/kestra/core/models/tasks/runners/ScriptService.java
+++ b/core/src/main/java/io/kestra/core/models/tasks/runners/ScriptService.java
@@ -262,7 +262,7 @@ public final class ScriptService {
             )
         );
         String normalized = normalizeValue(name, true, true);
-        if (normalized.length() > 55) {
+        if (normalized.length() > 54) {
             normalized = normalized.substring(0, 54);
         }
 

--- a/core/src/test/java/io/kestra/core/models/tasks/runners/ScriptServiceTest.java
+++ b/core/src/test/java/io/kestra/core/models/tasks/runners/ScriptServiceTest.java
@@ -268,6 +268,14 @@ class ScriptServiceTest {
 
         // Assert the truncated prefix is correct
         assertThat(baseName).startsWith("veryveryveryveryveryveryveryveryveryveryveryverylong");
+
+        // A 43-char namespace yields a 55-char base name ("<43 chars>-flowid-task"), which is
+        // exactly one over the 54-char budget (63 total - 8 suffix - 1 hyphen). Assert it is
+        // still truncated so the total stays within the 63-char Kubernetes limit.
+        runContext = runContext(runContextFactory, "a".repeat(43));
+        jobName = ScriptService.jobName(runContext);
+        assertThat(jobName.length()).isEqualTo(63);
+        assertThat(jobName.substring(jobName.lastIndexOf('-') + 1).length()).isEqualTo(8);
     }
 
     @Test


### PR DESCRIPTION
### Description

`ScriptService.jobName` builds task-runner job names as `{normalizedBase}-{8-char suffix}`. To respect the RFC 1123 / Kubernetes 63-character limit, the base has to be capped at 54 characters (63 total, minus 8 for the suffix, minus 1 for the hyphen).

The truncation guard only kicked in when the base was longer than 55 characters, so a base of exactly 55 characters was left untouched and produced a 64-character job name. Kubernetes rejects names over 63 characters, so any namespace/flow/task combination that normalizes to a 55-character base fails to launch its job.

The fix truncates when the base exceeds 54 characters. I also extended the existing `jobName` test with a boundary case: a 43-character namespace yields a 55-character base (`<43 chars>-flowid-task`), which now stays within 63 characters.

### Related Issue

No existing issue. This is a self-identified off-by-one found while reading the task-runner code. Happy to open a tracking issue if you'd prefer one.

### Backend Checklist

- [x] Code compiles successfully and passes all checks
- [x] All unit and integration tests pass

Verified with `./gradlew :core:test --tests "io.kestra.core.models.tasks.runners.ScriptServiceTest"` (11/11 pass). The new assertion fails on `develop` (`expected: 63 but was: 64`) and passes with the fix, confirming the boundary.

### Additional Notes

Single-line change plus a regression test; no behavior change for names that were already within the limit.
