### PR TITLE
feat(system): add 'migrate plan' to preview pending database migrations

### DIFF
--- a/cli/src/main/java/io/kestra/cli/commands/migrations/MigrationCommand.java
+++ b/cli/src/main/java/io/kestra/cli/commands/migrations/MigrationCommand.java
@@ -13,6 +13,7 @@ import picocli.CommandLine;
     mixinStandardHelpOptions = true,
     subcommands = {
         RunMigrationCommand.class,
+        PlanMigrationCommand.class,
         UnlockMigrationCommand.class
     }
 )

--- a/cli/src/main/java/io/kestra/cli/commands/migrations/PlanMigrationCommand.java
+++ b/cli/src/main/java/io/kestra/cli/commands/migrations/PlanMigrationCommand.java
@@ -1,0 +1,57 @@
+package io.kestra.cli.commands.migrations;
+
+import io.kestra.cli.AbstractCommand;
+import io.kestra.core.migration.MigrationRunner;
+import io.kestra.core.migration.MigrationScript;
+import jakarta.inject.Inject;
+import lombok.extern.slf4j.Slf4j;
+import picocli.CommandLine;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * CLI command that lists the pending database migration scripts without applying them.
+ *
+ * <p>This is the read-only counterpart of {@code kestra migrate run}: it reports the migrations
+ * that would be applied (e.g. what an upgrade would run) and then exits without touching the data.
+ * It is useful to prepare an upgrade by knowing exactly which migrations are planned.
+ *
+ * <p>Usage: {@code kestra migrate plan}
+ */
+@Slf4j
+@CommandLine.Command(
+    name = "plan",
+    description = "Show the pending database migration scripts without applying them",
+    mixinStandardHelpOptions = true
+)
+public class PlanMigrationCommand extends AbstractCommand {
+
+    @Inject
+    private MigrationRunner migrationRunner;
+
+    @SuppressWarnings("unused")
+    public static Map<String, Object> propertiesOverrides() {
+        // Prevent the eager @Context MigrationRunner from applying migrations on startup,
+        // so this command can report what is pending without changing the database.
+        MigrationRunner.setSkipAutoRun(true);
+        return Map.of();
+    }
+
+    @Override
+    public Integer call() throws Exception {
+        super.call();
+
+        List<MigrationScript> pending = migrationRunner.pendingScripts();
+        if (pending.isEmpty()) {
+            stdOut("No pending migrations.");
+            return 0;
+        }
+
+        stdOut(pending.size() + " pending migration(s):");
+        for (MigrationScript script : pending) {
+            stdOut("  " + script.scriptId() + " — " + script.description());
+        }
+        return 0;
+    }
+}

--- a/cli/src/main/java/io/kestra/cli/commands/migrations/PlanMigrationCommand.java
+++ b/cli/src/main/java/io/kestra/cli/commands/migrations/PlanMigrationCommand.java
@@ -3,6 +3,7 @@ package io.kestra.cli.commands.migrations;
 import io.kestra.cli.AbstractCommand;
 import io.kestra.core.migration.MigrationRunner;
 import io.kestra.core.migration.MigrationScript;
+import io.kestra.jdbc.migration.AbstractSQLMigrationScript;
 import jakarta.inject.Inject;
 import lombok.extern.slf4j.Slf4j;
 import picocli.CommandLine;
@@ -17,7 +18,7 @@ import java.util.Map;
  * that would be applied (e.g. what an upgrade would run) and then exits without touching the data.
  * It is useful to prepare an upgrade by knowing exactly which migrations are planned.
  *
- * <p>Usage: {@code kestra migrate plan}
+ * <p>Usage: {@code kestra migrate plan} (add {@code --sql} to also print the SQL of each migration).
  */
 @Slf4j
 @CommandLine.Command(
@@ -29,6 +30,9 @@ public class PlanMigrationCommand extends AbstractCommand {
 
     @Inject
     private MigrationRunner migrationRunner;
+
+    @CommandLine.Option(names = { "-s", "--sql" }, description = "Also print the SQL of each pending migration (SQL-based migrations only).")
+    private boolean sql = false;
 
     @SuppressWarnings("unused")
     public static Map<String, Object> propertiesOverrides() {
@@ -51,7 +55,26 @@ public class PlanMigrationCommand extends AbstractCommand {
         stdOut(pending.size() + " pending migration(s):");
         for (MigrationScript script : pending) {
             stdOut("  " + script.scriptId() + " — " + script.description());
+
+            if (sql) {
+                printSql(script);
+            }
         }
         return 0;
+    }
+
+    private void printSql(final MigrationScript script) throws Exception {
+        List<String> resources = script.sqlResources();
+
+        if (resources.isEmpty()) {
+            stdOut("    (no SQL — Java-based migration)");
+            return;
+        }
+
+        for (String resource : resources) {
+            stdOut("");
+            stdOut(AbstractSQLMigrationScript.readSqlResource(resource));
+            stdOut("");
+        }
     }
 }

--- a/cli/src/test/java/io/kestra/cli/commands/migrations/PlanMigrationCommandTest.java
+++ b/cli/src/test/java/io/kestra/cli/commands/migrations/PlanMigrationCommandTest.java
@@ -35,6 +35,26 @@ class PlanMigrationCommandTest {
     }
 
     @Test
+    void plan_printsSql_whenSqlFlagSet() {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        PrintStream originalOut = System.out;
+        System.setOut(new PrintStream(out));
+
+        MigrationRunner.setSkipAutoRun(true);
+        try (ApplicationContext ctx = ApplicationContext.run(Environment.CLI, Environment.TEST)) {
+            Integer call = PicocliRunner.call(PlanMigrationCommand.class, ctx, "--sql");
+            assertThat(call).isZero();
+        } finally {
+            MigrationRunner.setSkipAutoRun(false);
+            System.setOut(originalOut);
+        }
+
+        // the actual SQL of the pending migrations must be printed, not only their ids
+        assertThat(out.toString()).contains("0-init");
+        assertThat(out.toString()).containsIgnoringCase("CREATE TABLE");
+    }
+
+    @Test
     void plan_reportsNoPending_whenDatabaseUpToDate() {
         ByteArrayOutputStream out = new ByteArrayOutputStream();
         PrintStream originalOut = System.out;

--- a/cli/src/test/java/io/kestra/cli/commands/migrations/PlanMigrationCommandTest.java
+++ b/cli/src/test/java/io/kestra/cli/commands/migrations/PlanMigrationCommandTest.java
@@ -1,0 +1,54 @@
+package io.kestra.cli.commands.migrations;
+
+import io.kestra.core.migration.MigrationRunner;
+import io.micronaut.configuration.picocli.PicocliRunner;
+import io.micronaut.context.ApplicationContext;
+import io.micronaut.context.env.Environment;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class PlanMigrationCommandTest {
+
+    @Test
+    void plan_listsPendingMigrations_whenNothingApplied() {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        PrintStream originalOut = System.out;
+        System.setOut(new PrintStream(out));
+
+        // Skip auto-run so the fresh in-memory H2 keeps every migration pending
+        // (this is what PlanMigrationCommand.propertiesOverrides() does in production).
+        MigrationRunner.setSkipAutoRun(true);
+        try (ApplicationContext ctx = ApplicationContext.run(Environment.CLI, Environment.TEST)) {
+            Integer call = PicocliRunner.call(PlanMigrationCommand.class, ctx);
+            assertThat(call).isZero();
+        } finally {
+            MigrationRunner.setSkipAutoRun(false);
+            System.setOut(originalOut);
+        }
+
+        assertThat(out.toString()).contains("pending migration(s):");
+        assertThat(out.toString()).contains("0-init");
+    }
+
+    @Test
+    void plan_reportsNoPending_whenDatabaseUpToDate() {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        PrintStream originalOut = System.out;
+        System.setOut(new PrintStream(out));
+
+        // Default behaviour: migrations auto-run on startup, so nothing should be pending afterwards.
+        MigrationRunner.setSkipAutoRun(false);
+        try (ApplicationContext ctx = ApplicationContext.run(Environment.CLI, Environment.TEST)) {
+            Integer call = PicocliRunner.call(PlanMigrationCommand.class, ctx);
+            assertThat(call).isZero();
+        } finally {
+            System.setOut(originalOut);
+        }
+
+        assertThat(out.toString()).contains("No pending migrations.");
+    }
+}

--- a/core/src/main/java/io/kestra/core/migration/AbstractV2_0_01UpgradeMigration.java
+++ b/core/src/main/java/io/kestra/core/migration/AbstractV2_0_01UpgradeMigration.java
@@ -19,6 +19,16 @@ public abstract class AbstractV2_0_01UpgradeMigration implements MigrationScript
     }
 
     /**
+     * {@inheritDoc}
+     *
+     * <p>Derived from {@link #sqlResources()} so the resource path is declared only once.
+     */
+    @Override
+    public String checksum() {
+        return MigrationScript.checksumOfResources(sqlResources().toArray(String[]::new));
+    }
+
+    /**
      * Applies the backend-specific schema changes for the 2.0 upgrade.
      */
     protected abstract void doSchemaUpgrade() throws Exception;

--- a/core/src/main/java/io/kestra/core/migration/MigrationScript.java
+++ b/core/src/main/java/io/kestra/core/migration/MigrationScript.java
@@ -7,6 +7,7 @@ import java.io.InputStream;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.HexFormat;
+import java.util.List;
 
 /**
  * Represents a single versioned migration script.
@@ -79,6 +80,21 @@ public interface MigrationScript {
      * @throws Exception if the migration fails
      */
     void migrate() throws Exception;
+
+    /**
+     * Classpath path(s) to the SQL resource(s) this migration executes, in execution order.
+     *
+     * <p>This is the single source of truth for a SQL-backed migration's resource: SQL migrations
+     * declare it here and derive their {@link #checksum()} (and, where applicable, {@link #migrate()})
+     * from it. It also lets tooling preview the SQL a migration would run without applying it
+     * (e.g. the {@code migrate plan --sql} command).
+     *
+     * @return the classpath resource path(s), or an empty list for migrations that run no SQL resource
+     *         (e.g. pure-Java migrations)
+     */
+    default List<String> sqlResources() {
+        return List.of();
+    }
 
     /**
      * Computes a SHA-256 checksum from the content of one or more classpath resources.

--- a/jdbc-h2/src/main/java/io/kestra/repository/h2/migration/V2_0Migration.java
+++ b/jdbc-h2/src/main/java/io/kestra/repository/h2/migration/V2_0Migration.java
@@ -1,8 +1,9 @@
 package io.kestra.repository.h2.migration;
 
+import java.util.List;
+
 import javax.sql.DataSource;
 
-import io.kestra.core.migration.MigrationScript;
 import io.kestra.jdbc.migration.AbstractSQLMigrationScript;
 
 import io.micronaut.context.annotation.Requires;
@@ -45,12 +46,12 @@ public class V2_0Migration extends AbstractSQLMigrationScript {
     }
 
     @Override
-    public String checksum() {
-        return MigrationScript.checksumOfResources("/migrations/baseline-h2.sql");
+    public List<String> sqlResources() {
+        return List.of("/migrations/baseline-h2.sql");
     }
 
     @Override
-    public void migrate() throws Exception {
-        executeSqlResource(dataSource, "/migrations/baseline-h2.sql");
+    protected DataSource dataSource() {
+        return dataSource;
     }
 }

--- a/jdbc-h2/src/main/java/io/kestra/repository/h2/migration/V2_0QueueMigration.java
+++ b/jdbc-h2/src/main/java/io/kestra/repository/h2/migration/V2_0QueueMigration.java
@@ -1,8 +1,9 @@
 package io.kestra.repository.h2.migration;
 
+import java.util.List;
+
 import javax.sql.DataSource;
 
-import io.kestra.core.migration.MigrationScript;
 import io.kestra.jdbc.migration.AbstractSQLMigrationScript;
 
 import io.micronaut.context.annotation.Requires;
@@ -41,12 +42,12 @@ public class V2_0QueueMigration extends AbstractSQLMigrationScript {
     }
 
     @Override
-    public String checksum() {
-        return MigrationScript.checksumOfResources("/migrations/baseline-queue-h2.sql");
+    public List<String> sqlResources() {
+        return List.of("/migrations/baseline-queue-h2.sql");
     }
 
     @Override
-    public void migrate() throws Exception {
-        executeSqlResource(dataSource, "/migrations/baseline-queue-h2.sql");
+    protected DataSource dataSource() {
+        return dataSource;
     }
 }

--- a/jdbc-h2/src/main/java/io/kestra/repository/h2/migration/V2_0_01UpgradeMigration.java
+++ b/jdbc-h2/src/main/java/io/kestra/repository/h2/migration/V2_0_01UpgradeMigration.java
@@ -1,9 +1,10 @@
 package io.kestra.repository.h2.migration;
 
+import java.util.List;
+
 import javax.sql.DataSource;
 
 import io.kestra.core.migration.AbstractV2_0_01UpgradeMigration;
-import io.kestra.core.migration.MigrationScript;
 import io.kestra.jdbc.migration.AbstractSQLMigrationScript;
 
 import io.micronaut.context.annotation.Requires;
@@ -42,12 +43,14 @@ public class V2_0_01UpgradeMigration extends AbstractV2_0_01UpgradeMigration {
     }
 
     @Override
-    public String checksum() {
-        return MigrationScript.checksumOfResources("/migrations/2.0.01-upgrade-h2.sql");
+    public List<String> sqlResources() {
+        return List.of("/migrations/2.0.01-upgrade-h2.sql");
     }
 
     @Override
     protected void doSchemaUpgrade() throws Exception {
-        AbstractSQLMigrationScript.executeSqlScript(dataSource, "/migrations/2.0.01-upgrade-h2.sql");
+        for (String resource : sqlResources()) {
+            AbstractSQLMigrationScript.executeSqlScript(dataSource, resource);
+        }
     }
 }

--- a/jdbc-h2/src/main/java/io/kestra/repository/h2/migration/V2_0_04McpMigration.java
+++ b/jdbc-h2/src/main/java/io/kestra/repository/h2/migration/V2_0_04McpMigration.java
@@ -1,8 +1,9 @@
 package io.kestra.repository.h2.migration;
 
+import java.util.List;
+
 import javax.sql.DataSource;
 
-import io.kestra.core.migration.MigrationScript;
 import io.kestra.jdbc.migration.AbstractSQLMigrationScript;
 
 import io.micronaut.context.annotation.Requires;
@@ -40,12 +41,12 @@ public class V2_0_04McpMigration extends AbstractSQLMigrationScript {
     }
 
     @Override
-    public String checksum() {
-        return MigrationScript.checksumOfResources("/migrations/2.0.04-mcp-h2.sql");
+    public List<String> sqlResources() {
+        return List.of("/migrations/2.0.04-mcp-h2.sql");
     }
 
     @Override
-    public void migrate() throws Exception {
-        executeSqlResource(dataSource, "/migrations/2.0.04-mcp-h2.sql");
+    protected DataSource dataSource() {
+        return dataSource;
     }
 }

--- a/jdbc-h2/src/main/java/io/kestra/repository/h2/migration/V2_0_05QueueUpgradeMigration.java
+++ b/jdbc-h2/src/main/java/io/kestra/repository/h2/migration/V2_0_05QueueUpgradeMigration.java
@@ -1,8 +1,9 @@
 package io.kestra.repository.h2.migration;
 
+import java.util.List;
+
 import javax.sql.DataSource;
 
-import io.kestra.core.migration.MigrationScript;
 import io.kestra.jdbc.migration.AbstractSQLMigrationScript;
 
 import io.micronaut.context.annotation.Requires;
@@ -46,12 +47,12 @@ public class V2_0_05QueueUpgradeMigration extends AbstractSQLMigrationScript {
     }
 
     @Override
-    public String checksum() {
-        return MigrationScript.checksumOfResources("/migrations/2.0.05-queue-h2.sql");
+    public List<String> sqlResources() {
+        return List.of("/migrations/2.0.05-queue-h2.sql");
     }
 
     @Override
-    public void migrate() throws Exception {
-        executeSqlResource(dataSource, "/migrations/2.0.05-queue-h2.sql");
+    protected DataSource dataSource() {
+        return dataSource;
     }
 }

--- a/jdbc-h2/src/main/java/io/kestra/repository/h2/migration/V2_0_06TriggerFiltersMigration.java
+++ b/jdbc-h2/src/main/java/io/kestra/repository/h2/migration/V2_0_06TriggerFiltersMigration.java
@@ -1,8 +1,9 @@
 package io.kestra.repository.h2.migration;
 
+import java.util.List;
+
 import javax.sql.DataSource;
 
-import io.kestra.core.migration.MigrationScript;
 import io.kestra.jdbc.migration.AbstractSQLMigrationScript;
 
 import io.micronaut.context.annotation.Requires;
@@ -38,12 +39,12 @@ public class V2_0_06TriggerFiltersMigration extends AbstractSQLMigrationScript {
     }
 
     @Override
-    public String checksum() {
-        return MigrationScript.checksumOfResources(RESOURCE);
+    public List<String> sqlResources() {
+        return List.of(RESOURCE);
     }
 
     @Override
-    public void migrate() throws Exception {
-        executeSqlResource(dataSource, RESOURCE);
+    protected DataSource dataSource() {
+        return dataSource;
     }
 }

--- a/jdbc-h2/src/main/java/io/kestra/repository/h2/migration/V2_0_09QueueIndexAndTypeMigration.java
+++ b/jdbc-h2/src/main/java/io/kestra/repository/h2/migration/V2_0_09QueueIndexAndTypeMigration.java
@@ -1,8 +1,9 @@
 package io.kestra.repository.h2.migration;
 
+import java.util.List;
+
 import javax.sql.DataSource;
 
-import io.kestra.core.migration.MigrationScript;
 import io.kestra.jdbc.migration.AbstractSQLMigrationScript;
 import io.kestra.repository.h2.H2QueueEnabled;
 
@@ -39,12 +40,12 @@ public class V2_0_09QueueIndexAndTypeMigration extends AbstractSQLMigrationScrip
     }
 
     @Override
-    public String checksum() {
-        return MigrationScript.checksumOfResources("/migrations/2.0.09-queue-index-and-type-h2.sql");
+    public List<String> sqlResources() {
+        return List.of("/migrations/2.0.09-queue-index-and-type-h2.sql");
     }
 
     @Override
-    public void migrate() throws Exception {
-        executeSqlResource(dataSource, "/migrations/2.0.09-queue-index-and-type-h2.sql");
+    protected DataSource dataSource() {
+        return dataSource;
     }
 }

--- a/jdbc-h2/src/main/java/io/kestra/repository/h2/migration/V2_0_10ServiceInstanceFulltextMigration.java
+++ b/jdbc-h2/src/main/java/io/kestra/repository/h2/migration/V2_0_10ServiceInstanceFulltextMigration.java
@@ -1,8 +1,9 @@
 package io.kestra.repository.h2.migration;
 
+import java.util.List;
+
 import javax.sql.DataSource;
 
-import io.kestra.core.migration.MigrationScript;
 import io.kestra.jdbc.migration.AbstractSQLMigrationScript;
 
 import io.micronaut.context.annotation.Requires;
@@ -38,12 +39,12 @@ public class V2_0_10ServiceInstanceFulltextMigration extends AbstractSQLMigratio
     }
 
     @Override
-    public String checksum() {
-        return MigrationScript.checksumOfResources(RESOURCE);
+    public List<String> sqlResources() {
+        return List.of(RESOURCE);
     }
 
     @Override
-    public void migrate() throws Exception {
-        executeSqlResource(dataSource, RESOURCE);
+    protected DataSource dataSource() {
+        return dataSource;
     }
 }

--- a/jdbc-h2/src/main/java/io/kestra/repository/h2/migration/V2_0_11LogsFlowIndexMigration.java
+++ b/jdbc-h2/src/main/java/io/kestra/repository/h2/migration/V2_0_11LogsFlowIndexMigration.java
@@ -1,8 +1,9 @@
 package io.kestra.repository.h2.migration;
 
+import java.util.List;
+
 import javax.sql.DataSource;
 
-import io.kestra.core.migration.MigrationScript;
 import io.kestra.jdbc.migration.AbstractSQLMigrationScript;
 
 import io.micronaut.context.annotation.Requires;
@@ -40,12 +41,12 @@ public class V2_0_11LogsFlowIndexMigration extends AbstractSQLMigrationScript {
     }
 
     @Override
-    public String checksum() {
-        return MigrationScript.checksumOfResources(RESOURCE);
+    public List<String> sqlResources() {
+        return List.of(RESOURCE);
     }
 
     @Override
-    public void migrate() throws Exception {
-        executeSqlResource(dataSource, RESOURCE);
+    protected DataSource dataSource() {
+        return dataSource;
     }
 }

--- a/jdbc-h2/src/main/java/io/kestra/repository/h2/migration/V2_0_12ExecutionsDateIndexMigration.java
+++ b/jdbc-h2/src/main/java/io/kestra/repository/h2/migration/V2_0_12ExecutionsDateIndexMigration.java
@@ -1,8 +1,9 @@
 package io.kestra.repository.h2.migration;
 
+import java.util.List;
+
 import javax.sql.DataSource;
 
-import io.kestra.core.migration.MigrationScript;
 import io.kestra.jdbc.migration.AbstractSQLMigrationScript;
 
 import io.micronaut.context.annotation.Requires;
@@ -38,12 +39,12 @@ public class V2_0_12ExecutionsDateIndexMigration extends AbstractSQLMigrationScr
     }
 
     @Override
-    public String checksum() {
-        return MigrationScript.checksumOfResources(RESOURCE);
+    public List<String> sqlResources() {
+        return List.of(RESOURCE);
     }
 
     @Override
-    public void migrate() throws Exception {
-        executeSqlResource(dataSource, RESOURCE);
+    protected DataSource dataSource() {
+        return dataSource;
     }
 }

--- a/jdbc-mysql/src/main/java/io/kestra/repository/mysql/migration/V2_0Migration.java
+++ b/jdbc-mysql/src/main/java/io/kestra/repository/mysql/migration/V2_0Migration.java
@@ -1,8 +1,9 @@
 package io.kestra.repository.mysql.migration;
 
+import java.util.List;
+
 import javax.sql.DataSource;
 
-import io.kestra.core.migration.MigrationScript;
 import io.kestra.jdbc.migration.AbstractSQLMigrationScript;
 import io.kestra.repository.mysql.MysqlRepositoryEnabled;
 
@@ -42,12 +43,12 @@ public class V2_0Migration extends AbstractSQLMigrationScript {
     }
 
     @Override
-    public String checksum() {
-        return MigrationScript.checksumOfResources("/migrations/baseline-mysql.sql");
+    public List<String> sqlResources() {
+        return List.of("/migrations/baseline-mysql.sql");
     }
 
     @Override
-    public void migrate() throws Exception {
-        executeSqlResource(dataSource, "/migrations/baseline-mysql.sql");
+    protected DataSource dataSource() {
+        return dataSource;
     }
 }

--- a/jdbc-mysql/src/main/java/io/kestra/repository/mysql/migration/V2_0QueueMigration.java
+++ b/jdbc-mysql/src/main/java/io/kestra/repository/mysql/migration/V2_0QueueMigration.java
@@ -1,8 +1,9 @@
 package io.kestra.repository.mysql.migration;
 
+import java.util.List;
+
 import javax.sql.DataSource;
 
-import io.kestra.core.migration.MigrationScript;
 import io.kestra.jdbc.migration.AbstractSQLMigrationScript;
 
 import io.micronaut.context.annotation.Requires;
@@ -40,12 +41,12 @@ public class V2_0QueueMigration extends AbstractSQLMigrationScript {
     }
 
     @Override
-    public String checksum() {
-        return MigrationScript.checksumOfResources("/migrations/baseline-queue-mysql.sql");
+    public List<String> sqlResources() {
+        return List.of("/migrations/baseline-queue-mysql.sql");
     }
 
     @Override
-    public void migrate() throws Exception {
-        executeSqlResource(dataSource, "/migrations/baseline-queue-mysql.sql");
+    protected DataSource dataSource() {
+        return dataSource;
     }
 }

--- a/jdbc-mysql/src/main/java/io/kestra/repository/mysql/migration/V2_0_01UpgradeMigration.java
+++ b/jdbc-mysql/src/main/java/io/kestra/repository/mysql/migration/V2_0_01UpgradeMigration.java
@@ -1,9 +1,10 @@
 package io.kestra.repository.mysql.migration;
 
+import java.util.List;
+
 import javax.sql.DataSource;
 
 import io.kestra.core.migration.AbstractV2_0_01UpgradeMigration;
-import io.kestra.core.migration.MigrationScript;
 import io.kestra.jdbc.migration.AbstractSQLMigrationScript;
 import io.kestra.repository.mysql.MysqlRepositoryEnabled;
 
@@ -42,12 +43,14 @@ public class V2_0_01UpgradeMigration extends AbstractV2_0_01UpgradeMigration {
     }
 
     @Override
-    public String checksum() {
-        return MigrationScript.checksumOfResources("/migrations/2.0.01-upgrade-mysql.sql");
+    public List<String> sqlResources() {
+        return List.of("/migrations/2.0.01-upgrade-mysql.sql");
     }
 
     @Override
     protected void doSchemaUpgrade() throws Exception {
-        AbstractSQLMigrationScript.executeSqlScript(dataSource, "/migrations/2.0.01-upgrade-mysql.sql");
+        for (String resource : sqlResources()) {
+            AbstractSQLMigrationScript.executeSqlScript(dataSource, resource);
+        }
     }
 }

--- a/jdbc-mysql/src/main/java/io/kestra/repository/mysql/migration/V2_0_04McpMigration.java
+++ b/jdbc-mysql/src/main/java/io/kestra/repository/mysql/migration/V2_0_04McpMigration.java
@@ -1,8 +1,9 @@
 package io.kestra.repository.mysql.migration;
 
+import java.util.List;
+
 import javax.sql.DataSource;
 
-import io.kestra.core.migration.MigrationScript;
 import io.kestra.jdbc.migration.AbstractSQLMigrationScript;
 import io.kestra.repository.mysql.MysqlRepositoryEnabled;
 
@@ -39,12 +40,12 @@ public class V2_0_04McpMigration extends AbstractSQLMigrationScript {
     }
 
     @Override
-    public String checksum() {
-        return MigrationScript.checksumOfResources("/migrations/2.0.04-mcp-mysql.sql");
+    public List<String> sqlResources() {
+        return List.of("/migrations/2.0.04-mcp-mysql.sql");
     }
 
     @Override
-    public void migrate() throws Exception {
-        executeSqlResource(dataSource, "/migrations/2.0.04-mcp-mysql.sql");
+    protected DataSource dataSource() {
+        return dataSource;
     }
 }

--- a/jdbc-mysql/src/main/java/io/kestra/repository/mysql/migration/V2_0_05QueueUpgradeMigration.java
+++ b/jdbc-mysql/src/main/java/io/kestra/repository/mysql/migration/V2_0_05QueueUpgradeMigration.java
@@ -1,8 +1,9 @@
 package io.kestra.repository.mysql.migration;
 
+import java.util.List;
+
 import javax.sql.DataSource;
 
-import io.kestra.core.migration.MigrationScript;
 import io.kestra.jdbc.migration.AbstractSQLMigrationScript;
 
 import io.micronaut.context.annotation.Requires;
@@ -46,12 +47,12 @@ public class V2_0_05QueueUpgradeMigration extends AbstractSQLMigrationScript {
     }
 
     @Override
-    public String checksum() {
-        return MigrationScript.checksumOfResources("/migrations/2.0.05-queue-mysql.sql");
+    public List<String> sqlResources() {
+        return List.of("/migrations/2.0.05-queue-mysql.sql");
     }
 
     @Override
-    public void migrate() throws Exception {
-        executeSqlResource(dataSource, "/migrations/2.0.05-queue-mysql.sql");
+    protected DataSource dataSource() {
+        return dataSource;
     }
 }

--- a/jdbc-mysql/src/main/java/io/kestra/repository/mysql/migration/V2_0_06TriggerFiltersMigration.java
+++ b/jdbc-mysql/src/main/java/io/kestra/repository/mysql/migration/V2_0_06TriggerFiltersMigration.java
@@ -1,8 +1,9 @@
 package io.kestra.repository.mysql.migration;
 
+import java.util.List;
+
 import javax.sql.DataSource;
 
-import io.kestra.core.migration.MigrationScript;
 import io.kestra.jdbc.migration.AbstractSQLMigrationScript;
 import io.kestra.repository.mysql.MysqlRepositoryEnabled;
 
@@ -38,12 +39,12 @@ public class V2_0_06TriggerFiltersMigration extends AbstractSQLMigrationScript {
     }
 
     @Override
-    public String checksum() {
-        return MigrationScript.checksumOfResources(RESOURCE);
+    public List<String> sqlResources() {
+        return List.of(RESOURCE);
     }
 
     @Override
-    public void migrate() throws Exception {
-        executeSqlResource(dataSource, RESOURCE);
+    protected DataSource dataSource() {
+        return dataSource;
     }
 }

--- a/jdbc-mysql/src/main/java/io/kestra/repository/mysql/migration/V2_0_09QueueIndexAndTypeMigration.java
+++ b/jdbc-mysql/src/main/java/io/kestra/repository/mysql/migration/V2_0_09QueueIndexAndTypeMigration.java
@@ -1,8 +1,9 @@
 package io.kestra.repository.mysql.migration;
 
+import java.util.List;
+
 import javax.sql.DataSource;
 
-import io.kestra.core.migration.MigrationScript;
 import io.kestra.jdbc.migration.AbstractSQLMigrationScript;
 import io.kestra.repository.mysql.MysqlQueueEnabled;
 
@@ -39,12 +40,12 @@ public class V2_0_09QueueIndexAndTypeMigration extends AbstractSQLMigrationScrip
     }
 
     @Override
-    public String checksum() {
-        return MigrationScript.checksumOfResources("/migrations/2.0.09-queue-index-and-type-mysql.sql");
+    public List<String> sqlResources() {
+        return List.of("/migrations/2.0.09-queue-index-and-type-mysql.sql");
     }
 
     @Override
-    public void migrate() throws Exception {
-        executeSqlResource(dataSource, "/migrations/2.0.09-queue-index-and-type-mysql.sql");
+    protected DataSource dataSource() {
+        return dataSource;
     }
 }

--- a/jdbc-mysql/src/main/java/io/kestra/repository/mysql/migration/V2_0_10ServiceInstanceFulltextMigration.java
+++ b/jdbc-mysql/src/main/java/io/kestra/repository/mysql/migration/V2_0_10ServiceInstanceFulltextMigration.java
@@ -1,8 +1,9 @@
 package io.kestra.repository.mysql.migration;
 
+import java.util.List;
+
 import javax.sql.DataSource;
 
-import io.kestra.core.migration.MigrationScript;
 import io.kestra.jdbc.migration.AbstractSQLMigrationScript;
 import io.kestra.repository.mysql.MysqlRepositoryEnabled;
 
@@ -39,12 +40,12 @@ public class V2_0_10ServiceInstanceFulltextMigration extends AbstractSQLMigratio
     }
 
     @Override
-    public String checksum() {
-        return MigrationScript.checksumOfResources(RESOURCE);
+    public List<String> sqlResources() {
+        return List.of(RESOURCE);
     }
 
     @Override
-    public void migrate() throws Exception {
-        executeSqlResource(dataSource, RESOURCE);
+    protected DataSource dataSource() {
+        return dataSource;
     }
 }

--- a/jdbc-mysql/src/main/java/io/kestra/repository/mysql/migration/V2_0_11LogsFlowIndexMigration.java
+++ b/jdbc-mysql/src/main/java/io/kestra/repository/mysql/migration/V2_0_11LogsFlowIndexMigration.java
@@ -1,8 +1,9 @@
 package io.kestra.repository.mysql.migration;
 
+import java.util.List;
+
 import javax.sql.DataSource;
 
-import io.kestra.core.migration.MigrationScript;
 import io.kestra.jdbc.migration.AbstractSQLMigrationScript;
 import io.kestra.repository.mysql.MysqlRepositoryEnabled;
 
@@ -39,12 +40,12 @@ public class V2_0_11LogsFlowIndexMigration extends AbstractSQLMigrationScript {
     }
 
     @Override
-    public String checksum() {
-        return MigrationScript.checksumOfResources(RESOURCE);
+    public List<String> sqlResources() {
+        return List.of(RESOURCE);
     }
 
     @Override
-    public void migrate() throws Exception {
-        executeSqlResource(dataSource, RESOURCE);
+    protected DataSource dataSource() {
+        return dataSource;
     }
 }

--- a/jdbc-postgres/src/main/java/io/kestra/repository/postgres/migration/V2_0Migration.java
+++ b/jdbc-postgres/src/main/java/io/kestra/repository/postgres/migration/V2_0Migration.java
@@ -1,8 +1,9 @@
 package io.kestra.repository.postgres.migration;
 
+import java.util.List;
+
 import javax.sql.DataSource;
 
-import io.kestra.core.migration.MigrationScript;
 import io.kestra.jdbc.migration.AbstractSQLMigrationScript;
 import io.kestra.repository.postgres.PostgresRepositoryEnabled;
 
@@ -41,12 +42,12 @@ public class V2_0Migration extends AbstractSQLMigrationScript {
     }
 
     @Override
-    public String checksum() {
-        return MigrationScript.checksumOfResources("/migrations/baseline-postgres.sql");
+    public List<String> sqlResources() {
+        return List.of("/migrations/baseline-postgres.sql");
     }
 
     @Override
-    public void migrate() throws Exception {
-        executeSqlResource(dataSource, "/migrations/baseline-postgres.sql");
+    protected DataSource dataSource() {
+        return dataSource;
     }
 }

--- a/jdbc-postgres/src/main/java/io/kestra/repository/postgres/migration/V2_0QueueMigration.java
+++ b/jdbc-postgres/src/main/java/io/kestra/repository/postgres/migration/V2_0QueueMigration.java
@@ -1,8 +1,9 @@
 package io.kestra.repository.postgres.migration;
 
+import java.util.List;
+
 import javax.sql.DataSource;
 
-import io.kestra.core.migration.MigrationScript;
 import io.kestra.jdbc.migration.AbstractSQLMigrationScript;
 
 import io.micronaut.context.annotation.Requires;
@@ -40,12 +41,12 @@ public class V2_0QueueMigration extends AbstractSQLMigrationScript {
     }
 
     @Override
-    public String checksum() {
-        return MigrationScript.checksumOfResources("/migrations/baseline-queue-postgres.sql");
+    public List<String> sqlResources() {
+        return List.of("/migrations/baseline-queue-postgres.sql");
     }
 
     @Override
-    public void migrate() throws Exception {
-        executeSqlResource(dataSource, "/migrations/baseline-queue-postgres.sql");
+    protected DataSource dataSource() {
+        return dataSource;
     }
 }

--- a/jdbc-postgres/src/main/java/io/kestra/repository/postgres/migration/V2_0_01UpgradeMigration.java
+++ b/jdbc-postgres/src/main/java/io/kestra/repository/postgres/migration/V2_0_01UpgradeMigration.java
@@ -1,9 +1,10 @@
 package io.kestra.repository.postgres.migration;
 
+import java.util.List;
+
 import javax.sql.DataSource;
 
 import io.kestra.core.migration.AbstractV2_0_01UpgradeMigration;
-import io.kestra.core.migration.MigrationScript;
 import io.kestra.jdbc.migration.AbstractSQLMigrationScript;
 import io.kestra.repository.postgres.PostgresRepositoryEnabled;
 
@@ -42,12 +43,14 @@ public class V2_0_01UpgradeMigration extends AbstractV2_0_01UpgradeMigration {
     }
 
     @Override
-    public String checksum() {
-        return MigrationScript.checksumOfResources("/migrations/2.0.01-upgrade-postgres.sql");
+    public List<String> sqlResources() {
+        return List.of("/migrations/2.0.01-upgrade-postgres.sql");
     }
 
     @Override
     protected void doSchemaUpgrade() throws Exception {
-        AbstractSQLMigrationScript.executeSqlScript(dataSource, "/migrations/2.0.01-upgrade-postgres.sql");
+        for (String resource : sqlResources()) {
+            AbstractSQLMigrationScript.executeSqlScript(dataSource, resource);
+        }
     }
 }

--- a/jdbc-postgres/src/main/java/io/kestra/repository/postgres/migration/V2_0_04McpMigration.java
+++ b/jdbc-postgres/src/main/java/io/kestra/repository/postgres/migration/V2_0_04McpMigration.java
@@ -1,8 +1,9 @@
 package io.kestra.repository.postgres.migration;
 
+import java.util.List;
+
 import javax.sql.DataSource;
 
-import io.kestra.core.migration.MigrationScript;
 import io.kestra.jdbc.migration.AbstractSQLMigrationScript;
 import io.kestra.repository.postgres.PostgresRepositoryEnabled;
 
@@ -39,12 +40,12 @@ public class V2_0_04McpMigration extends AbstractSQLMigrationScript {
     }
 
     @Override
-    public String checksum() {
-        return MigrationScript.checksumOfResources("/migrations/2.0.04-mcp-postgres.sql");
+    public List<String> sqlResources() {
+        return List.of("/migrations/2.0.04-mcp-postgres.sql");
     }
 
     @Override
-    public void migrate() throws Exception {
-        executeSqlResource(dataSource, "/migrations/2.0.04-mcp-postgres.sql");
+    protected DataSource dataSource() {
+        return dataSource;
     }
 }

--- a/jdbc-postgres/src/main/java/io/kestra/repository/postgres/migration/V2_0_05QueueUpgradeMigration.java
+++ b/jdbc-postgres/src/main/java/io/kestra/repository/postgres/migration/V2_0_05QueueUpgradeMigration.java
@@ -1,8 +1,9 @@
 package io.kestra.repository.postgres.migration;
 
+import java.util.List;
+
 import javax.sql.DataSource;
 
-import io.kestra.core.migration.MigrationScript;
 import io.kestra.jdbc.migration.AbstractSQLMigrationScript;
 
 import io.micronaut.context.annotation.Requires;
@@ -46,12 +47,12 @@ public class V2_0_05QueueUpgradeMigration extends AbstractSQLMigrationScript {
     }
 
     @Override
-    public String checksum() {
-        return MigrationScript.checksumOfResources("/migrations/2.0.05-queue-postgres.sql");
+    public List<String> sqlResources() {
+        return List.of("/migrations/2.0.05-queue-postgres.sql");
     }
 
     @Override
-    public void migrate() throws Exception {
-        executeSqlResource(dataSource, "/migrations/2.0.05-queue-postgres.sql");
+    protected DataSource dataSource() {
+        return dataSource;
     }
 }

--- a/jdbc-postgres/src/main/java/io/kestra/repository/postgres/migration/V2_0_06TriggerFiltersMigration.java
+++ b/jdbc-postgres/src/main/java/io/kestra/repository/postgres/migration/V2_0_06TriggerFiltersMigration.java
@@ -1,8 +1,9 @@
 package io.kestra.repository.postgres.migration;
 
+import java.util.List;
+
 import javax.sql.DataSource;
 
-import io.kestra.core.migration.MigrationScript;
 import io.kestra.jdbc.migration.AbstractSQLMigrationScript;
 import io.kestra.repository.postgres.PostgresRepositoryEnabled;
 
@@ -38,12 +39,12 @@ public class V2_0_06TriggerFiltersMigration extends AbstractSQLMigrationScript {
     }
 
     @Override
-    public String checksum() {
-        return MigrationScript.checksumOfResources(RESOURCE);
+    public List<String> sqlResources() {
+        return List.of(RESOURCE);
     }
 
     @Override
-    public void migrate() throws Exception {
-        executeSqlResource(dataSource, RESOURCE);
+    protected DataSource dataSource() {
+        return dataSource;
     }
 }

--- a/jdbc-postgres/src/main/java/io/kestra/repository/postgres/migration/V2_0_09QueueIndexAndTypeMigration.java
+++ b/jdbc-postgres/src/main/java/io/kestra/repository/postgres/migration/V2_0_09QueueIndexAndTypeMigration.java
@@ -1,8 +1,9 @@
 package io.kestra.repository.postgres.migration;
 
+import java.util.List;
+
 import javax.sql.DataSource;
 
-import io.kestra.core.migration.MigrationScript;
 import io.kestra.jdbc.migration.AbstractSQLMigrationScript;
 import io.kestra.repository.postgres.PostgresQueueEnabled;
 
@@ -39,12 +40,12 @@ public class V2_0_09QueueIndexAndTypeMigration extends AbstractSQLMigrationScrip
     }
 
     @Override
-    public String checksum() {
-        return MigrationScript.checksumOfResources("/migrations/2.0.09-queue-index-and-type-postgres.sql");
+    public List<String> sqlResources() {
+        return List.of("/migrations/2.0.09-queue-index-and-type-postgres.sql");
     }
 
     @Override
-    public void migrate() throws Exception {
-        executeSqlResource(dataSource, "/migrations/2.0.09-queue-index-and-type-postgres.sql");
+    protected DataSource dataSource() {
+        return dataSource;
     }
 }

--- a/jdbc-postgres/src/main/java/io/kestra/repository/postgres/migration/V2_0_10ServiceInstanceFulltextMigration.java
+++ b/jdbc-postgres/src/main/java/io/kestra/repository/postgres/migration/V2_0_10ServiceInstanceFulltextMigration.java
@@ -1,8 +1,9 @@
 package io.kestra.repository.postgres.migration;
 
+import java.util.List;
+
 import javax.sql.DataSource;
 
-import io.kestra.core.migration.MigrationScript;
 import io.kestra.jdbc.migration.AbstractSQLMigrationScript;
 import io.kestra.repository.postgres.PostgresRepositoryEnabled;
 
@@ -39,12 +40,12 @@ public class V2_0_10ServiceInstanceFulltextMigration extends AbstractSQLMigratio
     }
 
     @Override
-    public String checksum() {
-        return MigrationScript.checksumOfResources(RESOURCE);
+    public List<String> sqlResources() {
+        return List.of(RESOURCE);
     }
 
     @Override
-    public void migrate() throws Exception {
-        executeSqlResource(dataSource, RESOURCE);
+    protected DataSource dataSource() {
+        return dataSource;
     }
 }

--- a/jdbc-postgres/src/main/java/io/kestra/repository/postgres/migration/V2_0_11LogsFlowIndexMigration.java
+++ b/jdbc-postgres/src/main/java/io/kestra/repository/postgres/migration/V2_0_11LogsFlowIndexMigration.java
@@ -1,8 +1,9 @@
 package io.kestra.repository.postgres.migration;
 
+import java.util.List;
+
 import javax.sql.DataSource;
 
-import io.kestra.core.migration.MigrationScript;
 import io.kestra.jdbc.migration.AbstractSQLMigrationScript;
 import io.kestra.repository.postgres.PostgresRepositoryEnabled;
 
@@ -40,12 +41,12 @@ public class V2_0_11LogsFlowIndexMigration extends AbstractSQLMigrationScript {
     }
 
     @Override
-    public String checksum() {
-        return MigrationScript.checksumOfResources(RESOURCE);
+    public List<String> sqlResources() {
+        return List.of(RESOURCE);
     }
 
     @Override
-    public void migrate() throws Exception {
-        executeSqlResource(dataSource, RESOURCE);
+    protected DataSource dataSource() {
+        return dataSource;
     }
 }

--- a/jdbc/src/main/java/io/kestra/jdbc/migration/AbstractSQLMigrationScript.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/migration/AbstractSQLMigrationScript.java
@@ -25,6 +25,60 @@ import io.micronaut.data.connection.jdbc.advice.DelegatingDataSource;
 public abstract class AbstractSQLMigrationScript implements MigrationScript {
 
     /**
+     * The {@link DataSource} this migration runs against, used by the default {@link #migrate()}.
+     * SQL-backed subclasses override this to return their injected data source.
+     *
+     * @return the data source, or {@code null} if the subclass provides its own {@link #migrate()}
+     */
+    protected DataSource dataSource() {
+        return null;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>Derived from {@link #sqlResources()} so the resource path is declared only once.
+     */
+    @Override
+    public String checksum() {
+        return MigrationScript.checksumOfResources(sqlResources().toArray(String[]::new));
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>Executes each SQL resource declared by {@link #sqlResources()} against {@link #dataSource()}.
+     */
+    @Override
+    public void migrate() throws Exception {
+        for (String resource : sqlResources()) {
+            executeSqlResource(dataSource(), resource);
+        }
+    }
+
+    /**
+     * Reads a SQL resource from the classpath and returns its raw content.
+     *
+     * @param resourcePath classpath resource path to the SQL file (e.g. {@code "/migrations/baseline-h2.sql"})
+     * @return the SQL file content
+     * @throws IOException if the resource cannot be read
+     * @throws IllegalArgumentException if the resource is not found on the classpath
+     */
+    public static String readSqlResource(final String resourcePath) throws IOException {
+        ClassLoader cl = Thread.currentThread().getContextClassLoader();
+        if (cl == null) {
+            cl = AbstractSQLMigrationScript.class.getClassLoader();
+        }
+        String normalizedPath = resourcePath.startsWith("/") ? resourcePath.substring(1) : resourcePath;
+        try (InputStream is = cl.getResourceAsStream(normalizedPath)) {
+            if (is == null) {
+                throw new IllegalArgumentException("SQL resource not found on classpath: " + resourcePath);
+            }
+            return new String(is.readAllBytes(), StandardCharsets.UTF_8);
+        }
+    }
+
+    /**
      * Loads a SQL file from the classpath and executes all statements against the given
      * {@link DataSource}.
      *


### PR DESCRIPTION
### What

Adds a new read-only CLI command:

```
kestra migrate plan          # list the pending database migration scripts
kestra migrate plan --sql    # also print the SQL of each pending migration
```

It lists the migration scripts that `kestra migrate run` **would** apply, then exits **without applying them or modifying the database**. `--sql` additionally prints the SQL each migration would run.

### Why

Backport of the intent behind #17135 (`sys database plan`, on `releases/v1.3.x`) to `develop`. Customers preparing an upgrade want to preview which migrations are planned — and, especially, the SQL — before running them. On `develop` this is particularly useful for the 1.x → 2.0 jump.

### How (differs from the 1.3 version — Flyway is gone on develop)

`develop` replaced Flyway with the custom `MigrationScript` / `MigrationRunner` framework:

- `PlanMigrationCommand` mirrors `RunMigrationCommand`: its `propertiesOverrides()` sets `MigrationRunner.setSkipAutoRun(true)` so the eager `@Context` `MigrationRunner` does **not** auto-apply migrations during context startup.
- It then calls the framework's read-only `MigrationRunner.pendingScripts()` (no lock, applies nothing) and prints each pending script's `scriptId` + `description`.
- Registered as a subcommand of the existing `migrate` group, alongside `run` and `unlock`.

#### `--sql` — single source of truth for the resource path

`sqlResources()` on the `MigrationScript` interface is the **one place** a SQL migration declares its resource path (default empty for pure-Java migrations). The base classes derive everything else from it, so the path is never duplicated:

- `AbstractSQLMigrationScript` derives `checksum()` and `migrate()` from `sqlResources()`.
- `AbstractV2_0_01UpgradeMigration` derives `checksum()` from `sqlResources()`.

Concrete migrations therefore only declare `scriptId` / `description` / `sqlResources` (+ a `dataSource()` accessor) — `checksum()`/`migrate()` are inherited (net removal of code). `migrate plan --sql` reads and prints the SQL for each pending migration; Java-based migrations report they have none.

This is behavior-preserving: a single-element resource list yields the same checksum (same varargs call) and the same single execution as before.

- OSS-only change: EE inherits the `migrate` group and subclasses the runner, so `migrate plan` works in EE too with no EE code. Base methods are non-abstract defaults, so EE subclasses that keep their own `checksum()`/`migrate()` are unaffected.

### Testing

`PlanMigrationCommandTest` (3 tests, passing) via `PicocliRunner` against a fresh in-memory H2:
- auto-run skipped → lists all pending migrations (`0-init` + the `N pending migration(s):` header)
- `--sql` → prints the actual SQL (asserts a `CREATE TABLE`)
- auto-run enabled → `No pending migrations.`

No migration regressions: `MigrationRunnerTest` (15), `AbstractSQLMigrationScriptTest` (11), `JdbcMigrationHistoryStoreTest` (7) all pass.

Also QA'd end-to-end on Postgres: seeded a DB to 1.3 (Flyway-managed) then ran `migrate plan --sql` — it detected the legacy schema, **skipped the init/baseline scripts**, and listed exactly the 9 pending 2.0 migrations with their real Postgres DDL (and `(no SQL — Java-based migration)` for the Java ones), without applying anything.