### PR TITLE
feat(runners): add RunContext#emitProgress typed live-progress API

### DIFF
--- a/core/src/main/java/io/kestra/core/models/executions/LogEntry.java
+++ b/core/src/main/java/io/kestra/core/models/executions/LogEntry.java
@@ -66,6 +66,10 @@ public class LogEntry implements TenantInterface, DispatchEvent {
     @Nullable
     ExecutionKind executionKind;
 
+    // Opaque plugin-defined step token; wrap in a record if percent/total is ever needed
+    @Nullable
+    String progress;
+
     public static List<Level> findLevelsByMin(Level minLevel) {
         if (minLevel == null) {
             return Arrays.asList(Level.values());

--- a/core/src/main/java/io/kestra/core/runners/RunContext.java
+++ b/core/src/main/java/io/kestra/core/runners/RunContext.java
@@ -2,6 +2,7 @@ package io.kestra.core.runners;
 
 import java.net.URI;
 import java.security.GeneralSecurityException;
+import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -108,6 +109,19 @@ public abstract class RunContext implements PropertyContext {
      */
     public void emitProgress(String step, String message) {
         logger().atInfo().addKeyValue(RunContextLogger.PROGRESS_KEY, step).log(message);
+    }
+
+    /**
+     * Same as {@link #emitProgress(String, String)}, but backdates the log entry to a real
+     * event time known only after the fact (e.g. a Kubernetes condition's {@code lastTransitionTime})
+     * instead of the moment this method is called, using the same override {@code RunContextLogger}
+     * already applies for {@link io.kestra.core.models.tasks.runners.TaskLogLineMatcher}.
+     */
+    public void emitProgress(String step, String message, Instant timestamp) {
+        logger().atInfo()
+            .addKeyValue(RunContextLogger.PROGRESS_KEY, step)
+            .addKeyValue(RunContextLogger.ORIGINAL_TIMESTAMP_KEY, timestamp)
+            .log(message);
     }
 
     /**

--- a/core/src/main/java/io/kestra/core/runners/RunContext.java
+++ b/core/src/main/java/io/kestra/core/runners/RunContext.java
@@ -99,6 +99,18 @@ public abstract class RunContext implements PropertyContext {
     public abstract Logger logger();
 
     /**
+     * Reports a lifecycle step of a multi-step task (e.g. a batch job or a runner that launches
+     * an external resource) so UIs following the execution live can track progress. Emitted as a
+     * regular INFO log line carrying a typed {@code step} token, so it rides the existing log
+     * queue and follow-logs SSE — no separate channel or endpoint needed. {@code step} is an
+     * opaque, plugin-defined identifier (e.g. {@code "pod.created"}); {@code message} is the
+     * human-readable text shown in the log console.
+     */
+    public void emitProgress(String step, String message) {
+        logger().atInfo().addKeyValue(RunContextLogger.PROGRESS_KEY, step).log(message);
+    }
+
+    /**
      * Gets the log file URI inside the internal storage.
      * Only populated if the task or trigger is configured to log o a file.<br>
      *

--- a/core/src/main/java/io/kestra/core/runners/RunContextLogger.java
+++ b/core/src/main/java/io/kestra/core/runners/RunContextLogger.java
@@ -34,6 +34,7 @@ import lombok.extern.slf4j.Slf4j;
 public class RunContextLogger implements Supplier<org.slf4j.Logger> {
     private static final int MAX_MESSAGE_LENGTH = 1024 * 15;
     public static final String ORIGINAL_TIMESTAMP_KEY = "originalTimestamp";
+    public static final String PROGRESS_KEY = "progress";
 
     private final String loggerName;
     private volatile Logger logger; // must be volatile as it is built lazily via DCL
@@ -104,6 +105,12 @@ public class RunContextLogger implements Supplier<org.slf4j.Logger> {
             return new ArrayList<>();
         }
 
+        String progress = event.getKeyValuePairs() == null ? null : event.getKeyValuePairs().stream()
+            .filter(kv -> kv.key.equals(PROGRESS_KEY))
+            .map(kv -> (String) kv.value)
+            .findFirst()
+            .orElse(null);
+
         if (message.length() > MAX_MESSAGE_LENGTH) {
             split = Splitter.fixedLength(MAX_MESSAGE_LENGTH).split(message);
         } else {
@@ -127,6 +134,7 @@ public class RunContextLogger implements Supplier<org.slf4j.Logger> {
                     .message(s)
                     .timestamp(event.getInstant())
                     .thread(event.getThreadName())
+                    .progress(progress)
                     .build()
             );
         }
@@ -425,6 +433,11 @@ public class RunContextLogger implements Supplier<org.slf4j.Logger> {
                 }
                 if (customTimestamp != null) {
                     lle.setTimeStamp(customTimestamp.toEpochMilli());
+                }
+                // the new LoggingEvent starts with no key-value pairs; carry the original ones
+                // over (e.g. PROGRESS_KEY) so logEntry() below can still read them
+                if (event.getKeyValuePairs() != null) {
+                    lle.setKeyValuePairs(event.getKeyValuePairs());
                 }
                 return lle;
             } catch (Throwable e) {

--- a/core/src/test/java/io/kestra/core/runners/RunContextLoggerTest.java
+++ b/core/src/test/java/io/kestra/core/runners/RunContextLoggerTest.java
@@ -27,6 +27,7 @@ import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.classic.spi.LoggingEvent;
 import jakarta.inject.Inject;
+import org.slf4j.event.KeyValuePair;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
@@ -430,6 +431,68 @@ class RunContextLoggerTest {
         runContextLogger.resetMDC();
 
         assertThat(adapter.getCopyOfContextMap()).isNullOrEmpty();
+    }
+
+    @Test
+    void emitProgress_setsTypedProgressOnLogEntry() {
+        List<LogEntry> logs = new CopyOnWriteArrayList<>();
+        logQueue.addListener(logs::add);
+
+        Flow flow = TestsUtils.mockFlow();
+        Execution execution = TestsUtils.mockExecution(flow, Map.of());
+
+        RunContextLogger runContextLogger = new RunContextLogger(
+            logEntryEmitter,
+            LogEntry.of(execution),
+            Level.TRACE,
+            false
+        );
+
+        // mirrors RunContext#emitProgress, which is a thin wrapper over this exact call
+        runContextLogger.logger().atInfo().addKeyValue(RunContextLogger.PROGRESS_KEY, "pod.created").log("Pod created");
+        runContextLogger.logger().info("a plain log line has no progress");
+
+        List<LogEntry> matchingLog = TestsUtils.awaitLogs(logs, 2);
+        LogEntry progressEntry = matchingLog.stream().filter(l -> "Pod created".equals(l.getMessage())).findFirst().orElseThrow();
+        LogEntry plainEntry = matchingLog.stream().filter(l -> l.getMessage().startsWith("a plain log line")).findFirst().orElseThrow();
+
+        assertThat(progressEntry.getProgress()).isEqualTo("pod.created");
+        assertThat(plainEntry.getProgress()).isNull();
+    }
+
+    @Test
+    void transformPreservesKeyValuePairs() throws Exception {
+        Flow flow = TestsUtils.mockFlow();
+        Execution execution = TestsUtils.mockExecution(flow, Map.of());
+        LogEntry logEntry = LogEntry.of(execution);
+
+        RunContextLogger runContextLogger = new RunContextLogger(
+            logEntryEmitter,
+            logEntry,
+            Level.TRACE,
+            false
+        );
+        ch.qos.logback.classic.Logger perRunLogger =
+            (ch.qos.logback.classic.Logger) runContextLogger.logger();
+
+        LoggingEvent original = new LoggingEvent(
+            RunContextLoggerTest.class.getName(),
+            perRunLogger,
+            ch.qos.logback.classic.Level.INFO,
+            "msg",
+            null,
+            null
+        );
+        original.addKeyValuePair(new KeyValuePair(RunContextLogger.PROGRESS_KEY, "pod.created"));
+
+        // transform() rebuilds the event from scratch; without re-attaching key-value pairs
+        // the progress token would be silently lost before logEntry() ever gets to read it
+        ILoggingEvent transformed = new TransformExposingAppender(runContextLogger, perRunLogger)
+            .transform(original);
+
+        assertThat(transformed.getKeyValuePairs())
+            .extracting(kv -> kv.key, kv -> kv.value)
+            .contains(org.assertj.core.groups.Tuple.tuple(RunContextLogger.PROGRESS_KEY, "pod.created"));
     }
 
     /**


### PR DESCRIPTION
## Summary

Minimal core plumbing for a typed live-progress channel: plugins report a lifecycle step via `RunContext#emitProgress(step, message)` (or with an explicit backdated `Instant`), emitted as a regular INFO log line carrying a typed `progress` key-value pair — rides the existing log queue, no new channel/endpoint needed.

- `LogEntry` gains a nullable `progress` field
- `RunContext#emitProgress(String, String)` and `#emitProgress(String, String, Instant)`
- `RunContextLogger` preserves key-value pairs across the appender's event rebuild (`transform()`) so `progress` survives to the persisted `LogEntry`

Trimmed down from the original PR to just this: `plugin-ee-kubernetes` needs `emitProgress` to compile against (kestra-io/plugin-ee-kubernetes#132), and this piece is intended to be backported to `releases/v1.3.x` so that plugin can consume it without tracking `develop`/2.0.0-SNAPSHOT.

The topology UI wiring that actually consumes `progress` end-to-end (follow-logs SSE, `Topology.vue`, executions store) moved to a follow-up PR: #17200.

## Test plan
- [x] `./gradlew :core:test --tests "*RunContextLoggerTest*"` — 13/13 green
- [x] `./gradlew :core:compileJava :core:compileTestJava` — clean