### PR TITLE
fix(core): return a clear error when importing a file without an extension

### DIFF
--- a/core/src/main/java/io/kestra/core/models/HasSource.java
+++ b/core/src/main/java/io/kestra/core/models/HasSource.java
@@ -83,7 +83,9 @@ public interface HasSource {
                     }
                 }
             } else {
-                throw new IllegalArgumentException("Cannot import file of type " + fileName.substring(fileName.lastIndexOf('.')));
+                int extensionIndex = fileName.lastIndexOf('.');
+                String type = extensionIndex >= 0 ? fileName.substring(extensionIndex) : fileName;
+                throw new IllegalArgumentException("Cannot import file of type " + type);
             }
         }
     }

--- a/core/src/test/java/io/kestra/core/models/HasSourceTest.java
+++ b/core/src/test/java/io/kestra/core/models/HasSourceTest.java
@@ -1,0 +1,27 @@
+package io.kestra.core.models;
+
+import io.micronaut.http.multipart.CompletedFileUpload;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class HasSourceTest {
+
+    @Test
+    void shouldThrowIllegalArgumentWhenImportingFileWithoutExtension() throws Exception {
+        // Given a file whose name has no extension
+        CompletedFileUpload fileUpload = mock(CompletedFileUpload.class);
+        when(fileUpload.getFilename()).thenReturn("no-extension");
+        when(fileUpload.getInputStream()).thenReturn(new ByteArrayInputStream(new byte[0]));
+
+        // When - Then the unsupported type is reported as an IllegalArgumentException
+        // instead of a StringIndexOutOfBoundsException raised by substring(-1)
+        assertThatThrownBy(() -> HasSource.readSourceFile(fileUpload, (source, name) -> {}))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("Cannot import file of type");
+    }
+}


### PR DESCRIPTION
### Description

`HasSource.readSourceFile` handles uploaded flow files (used by the flow-import endpoint). When an upload is neither YAML nor a `.zip`, it rejects it with:

```java
throw new IllegalArgumentException("Cannot import file of type " + fileName.substring(fileName.lastIndexOf('.')));
```

If the uploaded filename has no extension, `fileName.lastIndexOf('.')` returns `-1`, so `substring(-1)` throws `StringIndexOutOfBoundsException`. That surfaces as a 500 on the import endpoint instead of the intended, descriptive `IllegalArgumentException`.

This guards the extension lookup: if there is no `.`, the whole filename is reported instead of calling `substring(-1)`. The descriptive error is now returned for extensionless filenames too.

### Related Issue

No existing issue. Self-identified while reading the import path. Happy to open a tracking issue if you'd prefer one.

### Backend Checklist

- [x] Code compiles successfully and passes all checks
- [x] All unit and integration tests pass

Added `HasSourceTest.shouldThrowIllegalArgumentWhenImportingFileWithoutExtension`. On `develop` it fails with `StringIndexOutOfBoundsException: Range [-1, 12)`; it passes with the fix. Verified with `./gradlew :core:test --tests "io.kestra.core.models.HasSourceTest"`.

### Additional Notes

Small guard plus a regression test; no change for files that already have an extension.
