### PR TITLE
fix(core): report the full conflicting key path in flattenToNestedMap warning

### DIFF
--- a/core/src/main/java/io/kestra/core/utils/MapUtils.java
+++ b/core/src/main/java/io/kestra/core/utils/MapUtils.java
@@ -202,7 +202,7 @@ public class MapUtils {
                 if (!currentMap.containsKey(key)) {
                     currentMap.put(key, new HashMap<>());
                 } else if (!(currentMap.get(key) instanceof Map)) {
-                    var invalidKey = String.join(",", Arrays.copyOfRange(keys, 0, i));
+                    var invalidKey = String.join(".", Arrays.copyOfRange(keys, 0, i + 1));
                     log.warn(CONFLICT_AT_KEY_MSG, invalidKey, flatMap.keySet());
                     continue;
                 }

--- a/core/src/test/java/io/kestra/core/utils/MapUtilsTest.java
+++ b/core/src/test/java/io/kestra/core/utils/MapUtilsTest.java
@@ -2,11 +2,17 @@ package io.kestra.core.utils;
 
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.slf4j.LoggerFactory;
+
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -220,6 +226,33 @@ class MapUtilsTest {
 
         assertThat(results).hasSize(1);
         // due to ordering change on each JVM restart, the result map would be different as different entries will be skipped
+    }
+
+    @Test
+    void shouldReportFullDottedKeyPathOnConflict() {
+        // Given an appender capturing MapUtils warnings
+        Logger logger = (Logger) LoggerFactory.getLogger(MapUtils.class);
+        ListAppender<ILoggingEvent> appender = new ListAppender<>();
+        appender.start();
+        logger.addAppender(appender);
+
+        try {
+            // A deeper key ("k1.k2.k3") conflicts with a value already set at "k1.k2".
+            // LinkedHashMap keeps the insertion order so the conflict is deterministic.
+            Map<String, Object> flatMap = new LinkedHashMap<>();
+            flatMap.put("k1.k2", "v1");
+            flatMap.put("k1.k2.k3", "v2");
+
+            // When
+            MapUtils.flattenToNestedMap(flatMap);
+
+            // Then the warning reports the full dotted path where the conflict happens ("k1.k2"),
+            // not a comma-joined prefix that omits the conflicting segment ("k1").
+            assertThat(appender.list)
+                .anyMatch(event -> event.getFormattedMessage().contains("Conflict at key: 'k1.k2'"));
+        } finally {
+            logger.detachAppender(appender);
+        }
     }
 
     @Test


### PR DESCRIPTION
### Description

`MapUtils.flattenToNestedMap` reassembles dotted keys (for example form inputs) into a nested map and warns when a key conflicts with an existing value. For a conflict at an intermediate key it built the reported key with:

```java
var invalidKey = String.join(",", Arrays.copyOfRange(keys, 0, i));
```

The keys were split on `"."` (`entry.getKey().split("\\.")`), so this had two problems:

- It rejoined with `","` instead of `"."`, so the reported key did not match the user's original dotted key.
- `Arrays.copyOfRange(keys, 0, i)` is exclusive of `i`, so it dropped the segment that actually conflicts.

A conflict at `k1.k2` was therefore logged as `k1`. This changes it to `String.join(".", Arrays.copyOfRange(keys, 0, i + 1))` so the warning points at the real key. The other conflict branch in the same method already reports the correct key.

### Related Issue

No existing issue. Self-identified while reading the input-expansion path. Happy to open a tracking issue if you'd prefer one.

### Backend Checklist

- [x] Code compiles successfully and passes all checks
- [x] All unit and integration tests pass

Added `MapUtilsTest.shouldReportFullDottedKeyPathOnConflict`, which captures the log output and asserts the full path. It fails on `develop` (reports `k1`) and passes with the fix. Verified with `./gradlew :core:test --tests "io.kestra.core.utils.MapUtilsTest"`.

### Additional Notes

Diagnostic-only change: the map result is unchanged, only the warning message is corrected.
