### PR TITLE
chore: coverage include patterns across vitest configs

### DIFF
--- a/ui/packages/design-system/vitest.config.ts
+++ b/ui/packages/design-system/vitest.config.ts
@@ -48,9 +48,6 @@ export default defineConfig({
                         instances: [{browser: "chromium"}],
                     },
                     setupFiles: ["./.storybook/vitest.setup.ts"],
-                    coverage: {
-                        include: ["src/**/*.{ts,vue}"],
-                    },
                 },
             },
 
@@ -65,11 +62,11 @@ export default defineConfig({
                     globals: true,
                     browser: {enabled: false},
                     include: ["tests/**/*.test.ts"],
-                    coverage: {
-                        include: ["src/**/*.{ts,vue}"],
-                    },
                 },
             },
         ],
+        coverage: {
+            include: ["src/**/*.{ts,vue}"],
+        },
     },
 })

--- a/ui/packages/design-system/vitest.config.ts
+++ b/ui/packages/design-system/vitest.config.ts
@@ -48,6 +48,9 @@ export default defineConfig({
                         instances: [{browser: "chromium"}],
                     },
                     setupFiles: ["./.storybook/vitest.setup.ts"],
+                    coverage: {
+                        include: ["src/**/*.{ts,vue}"],
+                    },
                 },
             },
 
@@ -62,6 +65,9 @@ export default defineConfig({
                     globals: true,
                     browser: {enabled: false},
                     include: ["tests/**/*.test.ts"],
+                    coverage: {
+                        include: ["src/**/*.{ts,vue}"],
+                    },
                 },
             },
         ],

--- a/ui/packages/topology/vitest.unit.config.ts
+++ b/ui/packages/topology/vitest.unit.config.ts
@@ -8,5 +8,8 @@ export default defineConfig({
         globals: true,
         include: ["tests/**/*.test.ts"],
         setupFiles: ["./tests/units/setup.ts"],
+        coverage: {
+            include: ["src/**/*.{ts,vue}"],
+        },
     },
 })

--- a/ui/vitest.config.js
+++ b/ui/vitest.config.js
@@ -59,9 +59,6 @@ export default defineConfig({
             ...resolvedViteConfig.resolve.alias,
         ],
     },
-    coverage: {
-        include: ["src/**/*.{ts,vue}"],
-    },
     test: {
         projects: [
             "./vitest.config.unit.js",
@@ -86,20 +83,24 @@ export default defineConfig({
                             },
                         ],
                     },
-                    coverage: {
-                        reporter: ["text", "html"],
-                        include: [
-                            "src/**/*.{ts,vue}",
-                        ],
-                        exclude: [
-                            "**/*.stories.{ts,tsx}",
-                            "**/*.spec.{ts,tsx}",
-                            "**/node_modules/**",
-                        ],
-                    },
                 },
             }),
         ],
+        coverage: {
+            reporter: ["text", "html"],
+            include: [
+                "src/**/*.{ts,vue}",
+            ],
+            exclude: [
+                "**/node_modules/**",
+                "**/*.stories.*",
+                "**/*.spec.{ts,tsx}",
+                "**/*.d.ts",
+                "**/.storybook/**",
+                "storybook-static/**",
+                "stylelint.config.mjs",
+            ],
+        },
     },
     define: {
         "window.KESTRA_BASE_PATH": "/ui/",

--- a/ui/vitest.config.js
+++ b/ui/vitest.config.js
@@ -60,6 +60,7 @@ export default defineConfig({
         ],
     },
     coverage: {
+        include: ["src/**/*.{ts,vue}"],
         exclude: ["**/*.json"],
     },
     test: {
@@ -88,6 +89,9 @@ export default defineConfig({
                     },
                     coverage: {
                         reporter: ["text", "html"],
+                        include: [
+                            "src/**/*.{ts,vue}",
+                        ],
                         exclude: [
                             "**/*.stories.{ts,tsx}",
                             "**/*.spec.{ts,tsx}",

--- a/ui/vitest.config.js
+++ b/ui/vitest.config.js
@@ -61,7 +61,6 @@ export default defineConfig({
     },
     coverage: {
         include: ["src/**/*.{ts,vue}"],
-        exclude: ["**/*.json"],
     },
     test: {
         projects: [
@@ -96,7 +95,6 @@ export default defineConfig({
                             "**/*.stories.{ts,tsx}",
                             "**/*.spec.{ts,tsx}",
                             "**/node_modules/**",
-                            "**/*.json",
                         ],
                     },
                 },

--- a/ui/vitest.config.unit.js
+++ b/ui/vitest.config.unit.js
@@ -28,7 +28,7 @@ export default defineProject({
         ],
         coverage: {
             include: [
-                "src/**/*.{js,ts,vue}",
+                "src/**/*.{ts,vue}",
             ],
             exclude: [
                 "stylelint.config.mjs",

--- a/ui/vitest.config.unit.js
+++ b/ui/vitest.config.unit.js
@@ -36,7 +36,6 @@ export default defineProject({
                 "**/.storybook/**",
                 "**/*.stories.*",
                 "**/*.d.ts",
-                "**/*.json",
             ],
         },
     },

--- a/ui/vitest.config.unit.js
+++ b/ui/vitest.config.unit.js
@@ -26,18 +26,6 @@ export default defineProject({
             "node_modules/**",
             "tests/unit/**/translation.spec.js",
         ],
-        coverage: {
-            include: [
-                "src/**/*.{ts,vue}",
-            ],
-            exclude: [
-                "stylelint.config.mjs",
-                "storybook-static/**",
-                "**/.storybook/**",
-                "**/*.stories.*",
-                "**/*.d.ts",
-            ],
-        },
     },
     define: {
         "window.KESTRA_BASE_PATH": "/ui/",


### PR DESCRIPTION
### ✨ Description

Standardizes coverage configuration across vitest config files by explicitly defining `include` patterns to focus on source files (`src/**/*.{ts,vue}`). This ensures consistent coverage reporting and excludes non-source files from coverage metrics.

Changes made:
- Added `coverage.include` configuration to design-system vitest configs (storybook and unit test configs)
- Added `coverage.include` configuration to topology unit test config
- Updated root vitest config to include the pattern at the top level
- Updated root vitest config workspace to include the pattern in reporter config
- Removed `.js` extension from root unit test config include pattern for consistency

### 🔗 Related Issue

No related issue.

### 📝 Additional Notes

These changes ensure that coverage reports only track TypeScript and Vue source files, providing more accurate and focused coverage metrics across all test configurations in the monorepo.

https://claude.ai/code/session_017haJ8ZSZ6oZS46PANi8LFf