### PR TITLE
fix(topology): dot-node position

### DIFF
--- a/ui/packages/topology/src/Topology.vue
+++ b/ui/packages/topology/src/Topology.vue
@@ -99,32 +99,32 @@
         </template>
 
         <Controls v-if="controlsShown" :showZoom="false" :showInteractive="false" :showFitView="false">
-            <KsTooltip :content="$t('topology-graph.zoom-in')" placement="top">
+            <KsTooltip :content="$t('topology-graph.zoom-in')" placement="right">
                 <ControlButton @click.stop="zoomIn()">
                     <Plus />
                 </ControlButton>
             </KsTooltip>
-            <KsTooltip :content="$t('topology-graph.zoom-out')" placement="top">
+            <KsTooltip :content="$t('topology-graph.zoom-out')" placement="right">
                 <ControlButton @click.stop="zoomOut()">
                     <Minus />
                 </ControlButton>
             </KsTooltip>
-            <KsTooltip :content="$t('topology-graph.zoom-fit')" placement="top">
+            <KsTooltip :content="$t('topology-graph.zoom-fit')" placement="right">
                 <ControlButton @click.stop="fitView()">
                     <Fullscreen />
                 </ControlButton>
             </KsTooltip>
-            <KsTooltip v-if="toggleOrientationButton" :content="$t('topology-graph.graph-orientation')" placement="top">
+            <KsTooltip v-if="toggleOrientationButton" :content="$t('topology-graph.graph-orientation')" placement="right">
                 <ControlButton @click.stop="emit('toggle-orientation', $event)">
                     <component :is="isHorizontal ? AlignHorizontalCenter : AlignVerticalCenter" />
                 </ControlButton>
             </KsTooltip>
-            <KsTooltip :content="$t('download')" placement="top">
+            <KsTooltip :content="$t('download')" placement="right">
                 <ControlButton @click.stop="toggleDropdown">
                     <Download />
                 </ControlButton>
             </KsTooltip>
-            <KsTooltip v-if="collapsed.size > 0" :content="$t('expand all')" placement="top">
+            <KsTooltip v-if="collapsed.size > 0" :content="$t('expand all')" placement="right">
                 <ControlButton @click.stop="uncollapseAll()">
                     <ArrowExpandAll />
                 </ControlButton>

--- a/ui/packages/topology/src/Topology.vue
+++ b/ui/packages/topology/src/Topology.vue
@@ -220,7 +220,7 @@
     const dragging = ref(false)
     const showExtraDetails = ref(false)
     const lastPosition = ref<XYPosition | null>()
-    const {getNodes, getEdges, getElements, onNodeDrag, onNodeDragStart, onNodeDragStop, fitView, zoomIn, zoomOut, setElements, removeEdges, removeNodes, removeSelectedElements, vueFlowRef} = useVueFlow(props.id)
+    const {getNodes, getEdges, getElements, onNodeDrag, onNodeDragStart, onNodeDragStop, onNodesInitialized, fitView, zoomIn, zoomOut, setElements, removeEdges, removeNodes, removeSelectedElements, vueFlowRef} = useVueFlow(props.id)
     const edgeReplacer = ref({})
     const hiddenNodes = ref<string[]>([])
     const collapsed = ref(new Set<string>())
@@ -294,6 +294,14 @@
         generateGraph()
     })
 
+    const refitOnNodesInitialized = ref(false)
+    onNodesInitialized(() => {
+        if (refitOnNodesInitialized.value) {
+            refitOnNodesInitialized.value = false
+            fitView()
+        }
+    })
+
     const generateGraph = () => {
         removeEdges(getEdges.value)
         removeNodes(getNodes.value)
@@ -329,7 +337,7 @@
 
             if (elements) {
                 setElements(elements)
-                fitView()
+                refitOnNodesInitialized.value = true
                 emit("loading", false)
             }
         })

--- a/ui/packages/topology/src/nodes/DotNode.vue
+++ b/ui/packages/topology/src/nodes/DotNode.vue
@@ -1,5 +1,5 @@
 <template>
-    <div :class="classes">
+    <div class="dot-node" :class="classes">
         <Handle type="source" class="custom-handle" :position="sourcePosition" />
         <div class="dot" :class="classes">
             <CircleIcon :class="{'text-danger': data.node.branchType === 'ERROR'}" class="circle" alt="circle" :size="5" />
@@ -32,6 +32,14 @@
 <style scoped>
     .custom-handle {
         visibility: hidden;
+    }
+
+    .dot-node {
+        position: absolute;
+        inset: 0;
+        display: flex;
+        align-items: center;
+        justify-content: center;
     }
 
     .dot {


### PR DESCRIPTION
<img width="1136" height="276" alt="Capture d’écran 2026-07-01 à 17 58 39" src="https://github.com/user-attachments/assets/24275276-1fc5-46c4-92ed-1b5b05b44526" />


This pull request improves the usability and layout consistency of the topology graph controls and nodes. The most significant changes are adjustments to tooltip placement for better user experience, enhancements to the graph initialization and fitting logic, and improved styling for node components.

**UI/UX Improvements:**

* Changed the tooltip placement for all control buttons in `Topology.vue` from `top` to `right` for improved visibility and consistency.

**Graph Initialization and Fit Logic:**

* Added the `onNodesInitialized` hook from `useVueFlow`, and introduced a mechanism to defer calling `fitView()` until nodes are fully initialized, ensuring the graph fits correctly after data loads. [[1]](diffhunk://#diff-d4db08ff92e481eaba44480fd7e89fa6e2883ee7cbe6ec74c0f407006b410431L223-R223) [[2]](diffhunk://#diff-d4db08ff92e481eaba44480fd7e89fa6e2883ee7cbe6ec74c0f407006b410431R297-R304) [[3]](diffhunk://#diff-d4db08ff92e481eaba44480fd7e89fa6e2883ee7cbe6ec74c0f407006b410431L332-R340)

**Styling Enhancements:**

* Added a `dot-node` wrapper class in `DotNode.vue` and corresponding styles to improve positioning and alignment of dot nodes. [[1]](diffhunk://#diff-b811891e592a90a7f448666fbf6b992771ad3f87e4b9acb183a0df835a52df0dL2-R2) [[2]](diffhunk://#diff-b811891e592a90a7f448666fbf6b992771ad3f87e4b9acb183a0df835a52df0dR37-R44)


closes https://github.com/kestra-io/kestra-ee/issues/8962
