### PR TITLE
Optimize JdbcQueueConfiguration by lowering poll intervals

### DIFF
--- a/cli/src/main/resources/application.yml
+++ b/cli/src/main/resources/application.yml
@@ -204,8 +204,8 @@ kestra:
   jdbc:
     queues:
       min-poll-interval: 25ms
-      max-poll-interval: 500ms
-      poll-switch-interval: 60s
+      max-poll-interval: 100ms
+      poll-switch-interval: 10s
 
     cleaner:
       initial-delay: 1h

--- a/jdbc/src/main/java/io/kestra/jdbc/runner/JdbcQueueConfiguration.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/runner/JdbcQueueConfiguration.java
@@ -8,8 +8,8 @@ import io.micronaut.core.bind.annotation.Bindable;
 @ConfigurationProperties("kestra.jdbc.queues")
 public record JdbcQueueConfiguration(
     @Bindable(defaultValue = "PT0.025S") Duration minPollInterval,
-    @Bindable(defaultValue = "PT0.5S") Duration maxPollInterval,
-    @Bindable(defaultValue = "PT60S") Duration pollSwitchInterval,
+    @Bindable(defaultValue = "PT0.1S") Duration maxPollInterval,
+    @Bindable(defaultValue = "PT10S") Duration pollSwitchInterval,
     @Bindable(defaultValue = "100") Integer pollSize,
     @Bindable(defaultValue = "5") Integer switchSteps,
     @Bindable(defaultValue = "true") Boolean immediateRepoll) {

--- a/queue/src/test/java/io/kestra/queue/poller/QueuePollerConfigurationTest.java
+++ b/queue/src/test/java/io/kestra/queue/poller/QueuePollerConfigurationTest.java
@@ -28,8 +28,8 @@ public class QueuePollerConfigurationTest {
     void shouldCompute5StepsByDefault() {
         var configuration = new QueuePollerConfiguration(
             Duration.ofMillis(25),
-            Duration.ofMillis(500),
-            Duration.ofSeconds(60),
+            Duration.ofMillis(100),
+            Duration.ofSeconds(10),
             100,
             5,
             true
@@ -39,12 +39,12 @@ public class QueuePollerConfigurationTest {
         List<QueuePollerConfiguration.Step> steps = configuration.computeSteps();
         assertThat(steps.size()).isEqualTo(6);
         assertThat(steps).contains(
-            new QueuePollerConfiguration.Step(Duration.ofMillis(25), Duration.ofMillis(1875)),
-            new QueuePollerConfiguration.Step(Duration.ofMillis(31), Duration.ofMillis(3750)),
-            new QueuePollerConfiguration.Step(Duration.ofMillis(62), Duration.ofMillis(7500)),
-            new QueuePollerConfiguration.Step(Duration.ofMillis(125), Duration.ofSeconds(15)),
-            new QueuePollerConfiguration.Step(Duration.ofMillis(250), Duration.ofSeconds(30)),
-            new QueuePollerConfiguration.Step(Duration.ofMillis(500), Duration.ofSeconds(60))
+            new QueuePollerConfiguration.Step(Duration.ofMillis(25), Duration.ofMillis(312)),
+            new QueuePollerConfiguration.Step(Duration.ofMillis(25), Duration.ofMillis(625)),
+            new QueuePollerConfiguration.Step(Duration.ofMillis(25), Duration.ofMillis(1250)),
+            new QueuePollerConfiguration.Step(Duration.ofMillis(25), Duration.ofMillis(2500)),
+            new QueuePollerConfiguration.Step(Duration.ofMillis(50), Duration.ofMillis(5000)),
+            new QueuePollerConfiguration.Step(Duration.ofMillis(100), Duration.ofSeconds(10))
         );
     }
 


### PR DESCRIPTION
### ✨ Description

This PR lowers the default adaptive back-off polling intervals in `JdbcQueueConfiguration` and the CLI application configuration to reduce worst-case queuing latency on JDBC backends:

- **`maxPollInterval`**: Lowered from `PT0.5S` (500 ms) to `PT0.1S` (100 ms).
- **`pollSwitchInterval`**: Lowered from `PT60S` (60 s) to `PT10S` (10 s).

Previously, a flow that hadn't run recently saw up to 500 ms of queuing latency before its first message was picked up. By capping the maximum polling interval at 100 ms and reducing the time before back-off recovery from 60 s to 10 s, we cut perceived "cold start" latency by 5× while keeping database query load conservative during idle periods (1 SELECT every 100 ms).

Additionally, the step computation unit tests in `QueuePollerConfigurationTest` have been updated to reflect and verify these new default intervals.

### 🔗 Related Issue

Closes https://github.com/kestra-io/kestra/issues/17168

### 🛠️ Backend Checklist

- [x] Code compiles successfully and passes all checks
- [x] All unit and integration tests pass

### 📝 Additional Notes

- Cuts worst-case idle queuing latency by 5× (from 500 ms down to 100 ms).
- Recovery after an idle period starts within 10 s instead of 60 s.
- Values remain fully configurable via `kestra.jdbc.queues.min-poll-interval`, `max-poll-interval`, and `poll-switch-interval`.
