### PR TITLE
refactor(ui): let context-drawer buttons supply their own unread source

### DIFF
--- a/ui/packages/design-system/src/components/Navigation/KsTopNavBar/KsTopNavBar.vue
+++ b/ui/packages/design-system/src/components/Navigation/KsTopNavBar/KsTopNavBar.vue
@@ -57,6 +57,7 @@
         <div class="side d-flex gap-2 flex-shrink-0 align-items-center">
             <slot name="search" />
             <slot name="actions" />
+            <slot name="panel-toggle" />
             <KsIconButton
                 v-if="showDockToggle"
                 class="icon-btn dock-toggle"
@@ -120,6 +121,7 @@
         description?(): unknown
         search?(): unknown
         actions?(): unknown
+        "panel-toggle"?(): unknown
     }>()
 
     const {t} = useI18n({useScope: "global"})

--- a/ui/packages/design-system/tests/units/Navigation/KsTopNavBar.test.ts
+++ b/ui/packages/design-system/tests/units/Navigation/KsTopNavBar.test.ts
@@ -188,6 +188,15 @@ describe("KsTopNavBar", () => {
         expect(wrapper.find(".delete-btn").exists()).toBe(true)
     })
 
+    test("renders panel-toggle slot", () => {
+        const wrapper = mount(KsTopNavBar, {
+            props: {title: "Flows"},
+            slots: {"panel-toggle": "<button class=\"bell-btn\">Bell</button>"},
+            global: globalConfig,
+        })
+        expect(wrapper.find(".bell-btn").exists()).toBe(true)
+    })
+
     test("description slot is hidden via v-show when showDescription is false", () => {
         const wrapper = mount(KsTopNavBar, {
             props: {title: "Flows", showDescription: false},

--- a/ui/src/components/ContextDrawer.vue
+++ b/ui/src/components/ContextDrawer.vue
@@ -8,7 +8,7 @@
 
             <KsSplitterPanel v-model:size="drawerWidth" :min="MIN_DRAWER_WIDTH" :max="maxDrawerWidth">
                 <div class="drawerContent">
-                    <div class="tabBar">
+                    <div v-if="showTabBar" class="tabBar">
                         <KsTabs
                             class="context-tabs"
                             :modelValue="activeTab"
@@ -16,7 +16,7 @@
                             :beforeLeave="handleBeforeLeave"
                         >
                             <KsTabPane
-                                v-for="(button, key) of contextButtons"
+                                v-for="(button, key) of visibleTabButtons"
                                 :key="key"
                                 :name="key as string"
                             >
@@ -25,7 +25,7 @@
                                         <component :is="button.icon" class="tab-icon" />
                                         {{ button.title }}
                                         <OpenInNew v-if="button.url" class="open-in-new" />
-                                        <span v-if="button.hasUnreadMarker === true && hasUnread" class="newsDot" />
+                                        <span v-if="isUnread(button)" class="newsDot" />
                                     </span>
                                 </template>
                             </KsTabPane>
@@ -49,44 +49,40 @@
 </template>
 
 <script setup lang="ts">
-    import {computed, ref, watch, type Component, PropType} from "vue"
-    import {useStorage, useWindowSize} from "@vueuse/core"
+    import {computed, ref, watch, PropType} from "vue"
+    import {useWindowSize} from "@vueuse/core"
 
     import OpenInNew from "vue-material-design-icons/OpenInNew.vue"
 
-    import {useApiStore} from "../stores/api"
     import {useMiscStore} from "override/stores/misc"
-    import {useContextButtons} from "override/composables/contextButtons"
+    import {useContextButtons, type Button} from "override/composables/contextButtons"
 
     const props = defineProps({
         additionalButtons: {
-            type: Object as PropType<Record<string, {
-                title: string;
-                icon?: Component;
-                component?: Component;
-                url?: string;
-                hasUnreadMarker?: boolean;
-            }>>,
+            type: Object as PropType<Record<string, Button>>,
             default: () => ({}),
         },
     })
 
     const {buttons} = useContextButtons()
-    const apiStore = useApiStore()
     const miscStore = useMiscStore()
 
     const activeTab = computed(() => miscStore.contextInfoBarOpenTab)
     const contextButtons = computed(() => ({...buttons, ...props.additionalButtons}))
     const hasButtons = computed(() => Object.keys(contextButtons.value).length > 0)
 
-    const lastNewsReadDate = useStorage<string | null>("feeds", null)
-    const hasUnread = computed(() => {
-        const feeds = apiStore.feeds
-        return (
-            lastNewsReadDate.value === null ||
-            (feeds?.[0] && (new Date(lastNewsReadDate.value) < new Date(feeds[0].publicationDate)))
-        )
-    })
+    // `hidden: true` opts a button out of the tab strip while still letting it resolve panel content.
+    const visibleTabButtons = computed(() => Object.fromEntries(
+        Object.entries(contextButtons.value).filter(([, button]) => !button.hidden),
+    ))
+
+    // Hide the strip entirely while a hidden button's panel is active.
+    const showTabBar = computed(() => contextButtons.value[activeTab.value]?.hidden !== true)
+
+    // Each button supplies its own unread source; the drawer just renders the dot.
+    function isUnread(button: {hasUnreadMarker?: boolean; unread?: {readonly value: boolean}}) {
+        return button.hasUnreadMarker === true && !!button.unread?.value
+    }
 
     const MIN_DRAWER_WIDTH = 200
     const drawerWidth = ref(640)

--- a/ui/src/components/layout/AppTopNavBar.vue
+++ b/ui/src/components/layout/AppTopNavBar.vue
@@ -34,6 +34,9 @@
         <template #actions>
             <div id="topnav-actions-slot" class="d-flex gap-2 align-items-center" />
         </template>
+        <template #panel-toggle>
+            <slot name="panel-toggle" />
+        </template>
     </KsTopNavBar>
 </template>
 

--- a/ui/src/override/composables/contextButtons.ts
+++ b/ui/src/override/composables/contextButtons.ts
@@ -1,12 +1,14 @@
 import type {Component} from "vue"
+import {computed} from "vue"
 
 import {useI18n} from "vue-i18n"
 
-import {useNetwork} from "@vueuse/core"
+import {useNetwork, useStorage} from "@vueuse/core"
 const {isOnline} = useNetwork()
 
 import ContextNews from "../../components/layout/ContextNews.vue"
 import ContextDocs from "../../components/docs/ContextDocs.vue"
+import {useApiStore} from "../../stores/api"
 
 import MessageOutline from "vue-material-design-icons/MessageOutline.vue"
 import FileDocument from "vue-material-design-icons/FileDocument.vue"
@@ -15,18 +17,30 @@ import Github from "vue-material-design-icons/Github.vue"
 import Calendar from "vue-material-design-icons/Calendar.vue"
 import Star from "vue-material-design-icons/Star.vue"
 
-interface Button {
+export interface Button {
     title: string;
-    icon: Component;
+    icon?: Component;
 
     component?: Component;
     hasUnreadMarker?: boolean;
+    unread?: {readonly value: boolean};
+    hidden?: boolean;
 
     url?: string;
 }
 
 export function useContextButtons() {
     const {t} = useI18n({useScope: "global"})
+
+    const apiStore = useApiStore()
+    const lastNewsReadDate = useStorage<string | null>("feeds", null)
+    const newsUnread = computed<boolean>(() => {
+        const feeds = apiStore.feeds
+        return Boolean(
+            lastNewsReadDate.value === null ||
+            (feeds?.[0] && (new Date(lastNewsReadDate.value) < new Date(feeds[0].publicationDate))),
+        )
+    })
 
     const buttons: Record<string, Button> = isOnline.value
         ? {
@@ -36,6 +50,7 @@ export function useContextButtons() {
 
                   component: ContextNews,
                   hasUnreadMarker: true,
+                  unread: newsUnread,
               },
               docs: {
                   title: t("contextBar.docs"),

--- a/ui/tests/unit/components/ContextDrawer.spec.ts
+++ b/ui/tests/unit/components/ContextDrawer.spec.ts
@@ -1,0 +1,55 @@
+import {describe, it, expect, beforeEach, vi} from "vitest"
+import {mount} from "@vue/test-utils"
+
+const StubIcon = {template: "<span />"}
+
+const mockButtons = {
+    news: {title: "News", icon: StubIcon, hasUnreadMarker: false},
+    // Mirrors the EE notifications button: resolvable for panel content, but excluded
+    // from the visible tab strip because it has its own dedicated bell entry point.
+    notifications: {title: "Notifications", icon: StubIcon, hasUnreadMarker: true, unread: {value: false}, hidden: true},
+}
+vi.mock("override/composables/contextButtons", () => ({
+    useContextButtons: () => ({buttons: mockButtons}),
+}))
+
+let mockOpenTab = "news"
+vi.mock("override/stores/misc", () => ({
+    useMiscStore: () => ({
+        get contextInfoBarOpenTab() { return mockOpenTab },
+        set contextInfoBarOpenTab(value: string) { mockOpenTab = value },
+        lastContextTab: "news",
+    }),
+}))
+
+import ContextDrawer from "../../../src/components/ContextDrawer.vue"
+
+function mountComponent() {
+    return mount(ContextDrawer)
+}
+
+describe("ContextDrawer", () => {
+    beforeEach(() => {
+        mockOpenTab = "news"
+    })
+
+    it("excludes hidden buttons from the visible tab strip", () => {
+        const wrapper = mountComponent()
+
+        expect(wrapper.html()).toContain("name=\"news\"")
+        expect(wrapper.html()).not.toContain("name=\"notifications\"")
+    })
+
+    it("shows the tab strip when a visible tab is active", () => {
+        const wrapper = mountComponent()
+
+        expect(wrapper.find(".tabBar").exists()).toBe(true)
+    })
+
+    it("hides the tab strip entirely when the notifications pane is active", () => {
+        mockOpenTab = "notifications"
+        const wrapper = mountComponent()
+
+        expect(wrapper.find(".tabBar").exists()).toBe(false)
+    })
+})

--- a/ui/tests/unit/composables/contextButtons.spec.ts
+++ b/ui/tests/unit/composables/contextButtons.spec.ts
@@ -1,0 +1,76 @@
+import {describe, it, expect, beforeEach, vi} from "vitest"
+import {defineComponent} from "vue"
+import {mount} from "@vue/test-utils"
+import {createI18n} from "vue-i18n"
+
+const mockFeeds: {value: Array<{publicationDate: string}>} = {value: []}
+vi.mock("../../../src/stores/api", () => ({
+    useApiStore: () => ({feeds: mockFeeds.value}),
+}))
+
+vi.mock("@vueuse/core", async (importOriginal) => {
+    const actual = await importOriginal<typeof import("@vueuse/core")>()
+    return {...actual, useNetwork: () => ({isOnline: {value: true}})}
+})
+
+import {useContextButtons} from "../../../src/override/composables/contextButtons"
+
+const i18n = createI18n({
+    legacy: false,
+    locale: "en",
+    messages: {en: {contextBar: {news: "News", docs: "Docs", help: "Help", issue: "Issue", demo: "Demo", star: "Star"}}},
+})
+
+function mountButtons() {
+    let api: ReturnType<typeof useContextButtons>
+    const Comp = defineComponent({
+        setup() {
+            api = useContextButtons()
+            return () => null
+        },
+    })
+    mount(Comp, {global: {plugins: [i18n]}})
+    return api!
+}
+
+describe("useContextButtons news unread", () => {
+    beforeEach(() => {
+        localStorage.clear()
+        mockFeeds.value = []
+    })
+
+    it("is unread when no read date has been stored yet", () => {
+        mockFeeds.value = [{publicationDate: "2024-01-01T00:00:00Z"}]
+
+        const {buttons} = mountButtons()
+
+        expect(buttons.news.unread?.value).toBe(true)
+    })
+
+    it("is unread when the latest feed is newer than the last read date", () => {
+        localStorage.setItem("feeds", "2024-01-01T00:00:00Z")
+        mockFeeds.value = [{publicationDate: "2024-06-01T00:00:00Z"}]
+
+        const {buttons} = mountButtons()
+
+        expect(buttons.news.unread?.value).toBe(true)
+    })
+
+    it("is read once the last read date is at or after the latest feed", () => {
+        localStorage.setItem("feeds", "2024-06-01T00:00:00Z")
+        mockFeeds.value = [{publicationDate: "2024-01-01T00:00:00Z"}]
+
+        const {buttons} = mountButtons()
+
+        expect(buttons.news.unread?.value).toBe(false)
+    })
+
+    it("is read when there are no feeds at all", () => {
+        localStorage.setItem("feeds", "2024-01-01T00:00:00Z")
+        mockFeeds.value = []
+
+        const {buttons} = mountButtons()
+
+        expect(buttons.news.unread?.value).toBe(false)
+    })
+})


### PR DESCRIPTION
- ContextDrawer.vue hardcoded News' unread computation (localStorage read-date vs. latest feed publicationDate)
- Move that into contextButtons.ts as the news button's own unread source; the drawer now just renders button.unread generically
- Enables other context-bar panels (e.g. the new EE notifications bell) to supply their own unread source without forking the drawer
- Companion EE PR: https://github.com/kestra-io/kestra-ee/pull/9144