### PR TITLE
fix(webserver): use constant-time comparison for secret webhook key and BasicAuth token cache

### DIFF
--- a/webserver/src/main/java/io/kestra/webserver/controllers/api/ExecutionController.java
+++ b/webserver/src/main/java/io/kestra/webserver/controllers/api/ExecutionController.java
@@ -15,6 +15,7 @@ import java.nio.charset.IllegalCharsetNameException;
 import java.nio.charset.StandardCharsets;
 import java.nio.charset.UnsupportedCharsetException;
 import java.nio.file.Path;
+import java.security.MessageDigest;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.ZonedDateTime;
@@ -600,7 +601,8 @@ public class ExecutionController {
                 RunContext runContext = runContextFactory.of(flow, w);
                 try {
                     String webhookKey = runContext.render(w.getKey()).trim();
-                    return webhookKey.equals(key);
+                    // compare via MessageDigest.isEqual to prevent timing attacks
+                    return MessageDigest.isEqual(webhookKey.getBytes(StandardCharsets.UTF_8), key.getBytes(StandardCharsets.UTF_8));
                 } catch (IllegalVariableEvaluationException e) {
                     // be conservative, don't crash but filter the webhook
                     log.warn("Unable to render the webhook key {}, the webhook will be ignored", key, e);

--- a/webserver/src/main/java/io/kestra/webserver/services/BasicAuthService.java
+++ b/webserver/src/main/java/io/kestra/webserver/services/BasicAuthService.java
@@ -227,7 +227,11 @@ public class BasicAuthService {
             String tokenSha256 = sha256Hex(token);
 
             // Fast path: same token as last verified — skip bcrypt entirely.
-            if (tokenSha256.equals(lastVerifiedTokenSha256.get())) {
+            // compare via MessageDigest.isEqual to prevent timing attacks
+            String cachedTokenSha256 = lastVerifiedTokenSha256.get();
+            if (cachedTokenSha256 != null && MessageDigest.isEqual(
+                tokenSha256.getBytes(StandardCharsets.UTF_8),
+                cachedTokenSha256.getBytes(StandardCharsets.UTF_8))) {
                 return true;
             }
 


### PR DESCRIPTION
## Summary
- The webhook trigger endpoint compared the caller-supplied `key` against the flow's configured secret webhook key using `String.equals()`, which short-circuits on the first differing character. Since this endpoint is public and unauthenticated by design, the timing side-channel is directly exploitable by a remote attacker to recover a valid webhook key.
- The Basic-Auth fast-path cache check compared the SHA-256 digest of the incoming token against the last successfully verified token's digest using `String.equals()`, exposing the same class of timing side-channel on an authentication-bypass path.
- Both are replaced with `MessageDigest.isEqual()`, which the JDK specifies as constant-time. Same fix pattern already applied to `SecureApiToken.matches()` in the EE repo.

Fixes https://github.com/kestra-io/kestra-ee/issues/9142
Fixes https://github.com/kestra-io/kestra-ee/issues/9141

## Test plan
- [x] `./gradlew :webserver:test --tests "io.kestra.webserver.services.BasicAuthServiceTest"` — 28/28 passing
- [x] `./gradlew :webserver:test --tests "io.kestra.webserver.controllers.api.ExecutionControllerRunnerTest.webhook"` — passing