### PR TITLE
feat(system): increase the default database pool size from 10 to 25

### DIFF
--- a/jdbc/src/main/java/io/kestra/jdbc/DatasourcePoolSizeDefaulter.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/DatasourcePoolSizeDefaulter.java
@@ -1,0 +1,41 @@
+package io.kestra.jdbc;
+
+import java.util.Objects;
+
+import io.micronaut.configuration.jdbc.hikari.DatasourceConfiguration;
+import io.micronaut.context.env.Environment;
+import io.micronaut.context.event.BeanCreatedEvent;
+import io.micronaut.context.event.BeanCreatedEventListener;
+
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+
+/**
+ * Raises HikariCP's default maximum pool size (10) to a value better suited to the JDBC queue,
+ * which polls with one dedicated thread per queue type/routing key and can hold a connection for
+ * the duration of message processing. Only applies when the user has not explicitly configured
+ * {@code datasources.<name>.maximum-pool-size} themselves, and only for whichever datasource is
+ * actually declared (it never creates a datasource for a dialect that isn't configured).
+ */
+@Singleton
+public class DatasourcePoolSizeDefaulter implements BeanCreatedEventListener<DatasourceConfiguration> {
+    private static final int DEFAULT_MAXIMUM_POOL_SIZE = 25;
+
+    private final Environment environment;
+
+    @Inject
+    public DatasourcePoolSizeDefaulter(Environment environment) {
+        this.environment = Objects.requireNonNull(environment);
+    }
+
+    @Override
+    public DatasourceConfiguration onCreated(BeanCreatedEvent<DatasourceConfiguration> event) {
+        DatasourceConfiguration configuration = event.getBean();
+
+        if (!environment.containsProperty("datasources." + configuration.getName() + ".maximum-pool-size")) {
+            configuration.setMaximumPoolSize(DEFAULT_MAXIMUM_POOL_SIZE);
+        }
+
+        return configuration;
+    }
+}

--- a/jdbc/src/test/java/io/kestra/jdbc/DatasourcePoolSizeDefaulterTest.java
+++ b/jdbc/src/test/java/io/kestra/jdbc/DatasourcePoolSizeDefaulterTest.java
@@ -1,0 +1,66 @@
+package io.kestra.jdbc;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import io.micronaut.configuration.jdbc.hikari.DatasourceConfiguration;
+import io.micronaut.context.env.Environment;
+import io.micronaut.context.event.BeanCreatedEvent;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class DatasourcePoolSizeDefaulterTest {
+
+    @Mock
+    private Environment environment;
+
+    @Mock
+    private BeanCreatedEvent<DatasourceConfiguration> event;
+
+    @Test
+    void shouldRaiseDefaultPoolSizeWhenNotExplicitlyConfigured() {
+        // Given
+        DatasourceConfiguration configuration = new DatasourceConfiguration("postgres");
+        when(event.getBean()).thenReturn(configuration);
+        when(environment.containsProperty("datasources.postgres.maximum-pool-size")).thenReturn(false);
+
+        // When
+        DatasourceConfiguration result = new DatasourcePoolSizeDefaulter(environment).onCreated(event);
+
+        // Then
+        assertThat(result.getMaximumPoolSize()).isEqualTo(25);
+    }
+
+    @Test
+    void shouldNotOverrideExplicitlyConfiguredPoolSize() {
+        // Given
+        DatasourceConfiguration configuration = new DatasourceConfiguration("postgres");
+        configuration.setMaximumPoolSize(10);
+        when(event.getBean()).thenReturn(configuration);
+        when(environment.containsProperty("datasources.postgres.maximum-pool-size")).thenReturn(true);
+
+        // When
+        DatasourceConfiguration result = new DatasourcePoolSizeDefaulter(environment).onCreated(event);
+
+        // Then
+        assertThat(result.getMaximumPoolSize()).isEqualTo(10);
+    }
+
+    @Test
+    void shouldDeriveThePropertyPathFromTheDatasourceName() {
+        // Given
+        DatasourceConfiguration configuration = new DatasourceConfiguration("mysql");
+        when(event.getBean()).thenReturn(configuration);
+
+        // When
+        new DatasourcePoolSizeDefaulter(environment).onCreated(event);
+
+        // Then
+        verify(environment).containsProperty("datasources.mysql.maximum-pool-size");
+    }
+}


### PR DESCRIPTION
We have 20 queues in OSS (more in EE) and queues are polling frequently the queues table and process messages inside a transaction so the connection is retain for the full select/process/delete sequence.

On a busy instance, the default 10 connections can all be used by queues without talking about other queries form the UI. Using a default of 25 (if not configured otherwise by the user) offers better performance and is a sane default as production databases can usually suppport way more open connections.
