### PR TITLE
feat(topology): live-progress UI wiring for plugin task steps

### DIFF
--- a/core/src/main/java/io/kestra/core/runners/FollowLogEvent.java
+++ b/core/src/main/java/io/kestra/core/runners/FollowLogEvent.java
@@ -23,11 +23,12 @@ public record FollowLogEvent(
     Level level,
     String thread,
     String message,
-    ExecutionKind executionKind) implements BroadcastEvent {
+    ExecutionKind executionKind,
+    String progress) implements BroadcastEvent {
     public static FollowLogEvent from(LogEntry logEntry) {
         return new FollowLogEvent(
             logEntry.getTenantId(), logEntry.getNamespace(), logEntry.getFlowId(), logEntry.getTaskId(), logEntry.getExecutionId(), logEntry.getTaskRunId(), logEntry.getAttemptNumber(),
-            logEntry.getTriggerId(), logEntry.getTimestamp(), logEntry.getLevel(), logEntry.getThread(), logEntry.getMessage(), logEntry.getExecutionKind()
+            logEntry.getTriggerId(), logEntry.getTimestamp(), logEntry.getLevel(), logEntry.getThread(), logEntry.getMessage(), logEntry.getExecutionKind(), logEntry.getProgress()
         );
     }
 

--- a/ui/packages/slot-contracts/src/topology-details.ts
+++ b/ui/packages/slot-contracts/src/topology-details.ts
@@ -2,6 +2,13 @@ import type {Execution, MetricEntry, Task} from "@kestra-io/kestra-sdk"
 import {z} from "zod"
 import {defineArtifactSlot} from "./define-artifact-slot"
 
+export const progressEventSchema = z.object({
+    taskId: z.string(),
+    taskRunId: z.string(),
+    step: z.string(),
+    timestamp: z.string(),
+})
+
 export const propsSchema = z.object({
     taskType: z.string(),
     task: z.custom<Task>(),
@@ -9,6 +16,7 @@ export const propsSchema = z.object({
     namespace: z.string().optional(),
     flowId: z.string().optional(),
     metrics: z.custom<MetricEntry>().array(),
+    progress: progressEventSchema.array(),
 })
 
 export default defineArtifactSlot(() => ({

--- a/ui/packages/topology/src/Topology.vue
+++ b/ui/packages/topology/src/Topology.vue
@@ -193,6 +193,10 @@
         customActions?: Record<string, CustomActionConfig>;
         showDetails?: Record<string, ShowDetailsConfig>;
         showDetailsToggle?: boolean;
+        // Bump this from the caller whenever data rendered *inside* the taskDetails slot (e.g.
+        // live metrics or progress) changes but isn't itself part of `execution`/`flowGraph` — the
+        // slot content is only re-evaluated when a node's graph data is regenerated.
+        taskDetailsVersion?: number;
     }>(), {
         isHorizontal: true,
         isReadOnly: true,
@@ -213,6 +217,7 @@
         customActions: () => ({}),
         showDetails: () => ({}),
         showDetailsToggle: true,
+        taskDetailsVersion: undefined,
     })
 
     const isRunning = computed(() => State.isRunning(props.execution?.state?.current) === true)
@@ -300,6 +305,10 @@
             refitOnNodesInitialized.value = false
             fitView()
         }
+    })
+
+    watch(() => props.taskDetailsVersion, () => {
+        generateGraph()
     })
 
     const generateGraph = () => {

--- a/ui/src/components/executions/Topology.vue
+++ b/ui/src/components/executions/Topology.vue
@@ -149,6 +149,13 @@
 
     function loadData() {
         loadGraph()
+        loadFlowSource()
+    }
+
+    function loadFlowSource() {
+        const exec = execution.value
+        if (!exec || flowStore.flow?.id === exec.flowId && flowStore.flow?.namespace === exec.namespace) return
+        flowStore.loadFlow({namespace: exec.namespace, id: exec.flowId})
     }
 
     function loadGraph(force?: boolean) {

--- a/ui/src/components/executions/Topology.vue
+++ b/ui/src/components/executions/Topology.vue
@@ -61,6 +61,10 @@
     // SSE as a typed field, so plugin topology-details slots can track per-step progress in real
     // time — metrics/outputs only materialise once the task run completes.
     let progressSSE: EventSource | undefined
+    // followLogs()/followExecution() resolve asynchronously; if the component unmounts in that
+    // window, the EventSource would land in a ref no one closes again. Guard against it explicitly
+    // instead of relying on onUnmounted alone.
+    let unmounted = false
 
     function closeProgressSSE() {
         progressSSE?.close()
@@ -72,6 +76,10 @@
         const id = execution.value?.id
         if (!id) return
         executionsStore.followLogs({id, params: levelToRequestParams({value: "INFO", direction: "min"})}).then((sse: EventSource) => {
+            if (unmounted) {
+                sse.close()
+                return
+            }
             progressSSE = sse
             sse.onmessage = (event: MessageEvent) => {
                 if (event.lastEventId === "start") return
@@ -128,6 +136,7 @@
     })
 
     onUnmounted(() => {
+        unmounted = true
         Object.keys(sseBySubflow.value).forEach(closeSSE)
         closeProgressSSE()
     })
@@ -221,8 +230,17 @@
             return
         }
 
-        executionsStore.followExecution({id: executionId}, t)
+        // rawSSE: true is required here — without it, followExecution() treats this as *the*
+        // followed execution: it nulls executionsStore.execution, closes, and overwrites the
+        // single shared executionsStore.sse ref. Expanding a subflow would silently kill the
+        // parent execution's own live SSE (see useExecutionRoot.ts) and, with several subflows
+        // expanded, each new one would kill the previous one's shared-ref tracking too.
+        executionsStore.followExecution({id: executionId, rawSSE: true}, t)
             .then((sse: {onmessage: ((event: MessageEvent) => void) | null; close: () => void}) => {
+                if (unmounted) {
+                    sse.close()
+                    return
+                }
                 sseBySubflow.value[subflow] = sse
                 sse.onmessage = (executionEvent: MessageEvent) => {
                     const isEnd = executionEvent && executionEvent.lastEventId === "end"

--- a/ui/src/components/executions/Topology.vue
+++ b/ui/src/components/executions/Topology.vue
@@ -27,7 +27,7 @@
     import {ref, computed, watch, onMounted, onUnmounted} from "vue"
     import {useI18n} from "vue-i18n"
     import throttle from "lodash/throttle"
-    import {stringUtils, State} from "@kestra-io/design-system"
+    import {stringUtils, State, levelToRequestParams} from "@kestra-io/design-system"
     import LowCodeEditor from "../inputs/LowCodeEditor.vue"
     import {useExecutionsStore} from "../../stores/executions"
     import {useFlowStore} from "../../stores/flow"
@@ -57,6 +57,55 @@
     // FIXME: any - SSE objects don't have a consistent type in this codebase
     const sseBySubflow = ref<Record<string, any>>({}) // FIXME: any
 
+    // Live lifecycle-step progress (see RunContext#emitProgress) rides the existing follow-logs
+    // SSE as a typed field, so plugin topology-details slots can track per-step progress in real
+    // time — metrics/outputs only materialise once the task run completes.
+    let progressSSE: EventSource | undefined
+
+    function closeProgressSSE() {
+        progressSSE?.close()
+        progressSSE = undefined
+    }
+
+    function followProgress() {
+        closeProgressSSE()
+        const id = execution.value?.id
+        if (!id) return
+        executionsStore.followLogs({id, params: levelToRequestParams({value: "INFO", direction: "min"})}).then((sse: EventSource) => {
+            progressSSE = sse
+            sse.onmessage = (event: MessageEvent) => {
+                if (event.lastEventId === "start") return
+                const data = JSON.parse(event.data)
+                if (!data.progress) return
+                executionsStore.addProgressEvent({
+                    taskId: data.taskId,
+                    taskRunId: data.taskRunId,
+                    step: data.progress,
+                    timestamp: data.timestamp,
+                })
+            }
+            // No onerror handler: closing here on a transient drop is what previously froze the
+            // stepper (kestra-io/kestra#16982's leak fear doesn't apply — closeProgressSSE()
+            // below still runs once the execution terminates). Let EventSource auto-reconnect;
+            // the historical replay it gets on reconnect is idempotent thanks to the dedup in
+            // addProgressEvent, so a reconnect can only ever catch up, never regress.
+        })
+    }
+
+    const isExecutionRunning = computed(() => {
+        const current = execution.value?.state?.current
+        return !!current && State.isRunning(current)
+    })
+
+    watch(
+        [() => execution.value?.id, isExecutionRunning],
+        ([id, running]) => {
+            if (id && running) followProgress()
+            else closeProgressSSE()
+        },
+        {immediate: true},
+    )
+
     const throttledExecutionUpdate = throttle(function(subflow: string, executionEvent: MessageEvent) {
         const previousExecution = executionsStore.subflowsExecutions[subflow]
         executionsStore.addSubflowExecution({
@@ -80,6 +129,7 @@
 
     onUnmounted(() => {
         Object.keys(sseBySubflow.value).forEach(closeSSE)
+        closeProgressSSE()
     })
 
     function closeSSE(subflow: string) {

--- a/ui/src/components/inputs/LowCodeEditor.vue
+++ b/ui/src/components/inputs/LowCodeEditor.vue
@@ -257,7 +257,11 @@
     // burger-menu "Show Details" item work correctly in execution view too.
     const runnerTypeByTaskId = computed((): Record<string, string> => {
         const result: Record<string, string> = {}
-        const parsed = flowStore.flowParsed
+        const flowParsed = flowStore.flowParsed
+        const flowParsedHasRunners = (flowParsed?.tasks ?? []).some((t: any) => t?.taskRunner?.type)
+        // When flowParsed has no runner types, fall back to props.source (has taskRunner intact;
+        // execution view may have stale flowYaml without taskRunner, or forExecution() strips it)
+        const parsed = flowParsedHasRunners ? flowParsed : (props.source ? YAML_UTILS.parse(props.source) : flowParsed)
         for (const task of [...(parsed?.tasks ?? []), ...(parsed?.errors ?? []), ...(parsed?.finally ?? [])]) {
             if (task?.id && task?.taskRunner?.type) {
                 result[task.id] = task.taskRunner.type
@@ -416,10 +420,30 @@
         () => props.flowGraph,
         async (flowGraph) => {
             if (flowStore.flowParsed?.tasks?.length) return
-            const tasks = (flowGraph?.nodes ?? [])
-                .filter((n: any) => n.task?.type)
-                .map((n: any) => ({type: n.task.type, version: n.task.version, taskRunner: n.task.taskRunner}))
+            // props.source has taskRunner intact; graph nodes may have it stripped (forExecution)
+            const sourceParsed = props.source ? YAML_UTILS.parse(props.source) : null
+            const tasks = sourceParsed?.tasks?.length
+                ? sourceParsed.tasks
+                : (flowGraph?.nodes ?? [])
+                    .filter((n: any) => n.task?.type)
+                    .map((n: any) => ({type: n.task.type, version: n.task.version, taskRunner: n.task.taskRunner}))
             await resolveTaskTopologyDetails(tasks)
+        },
+        {immediate: true},
+    )
+
+    // When props.source has runner types that flowParsed lacks (e.g. stale/absent flowYaml
+    // in execution view), re-resolve so the pluginUiManifest call includes runner types.
+    watch(
+        () => props.source,
+        async (source) => {
+            if (!source) return
+            const parsed = YAML_UTILS.parse(source)
+            const sourceHasRunners = (parsed?.tasks ?? []).some((t: any) => t?.taskRunner?.type)
+            const flowParsedHasRunners = (flowStore.flowParsed?.tasks ?? []).some((t: any) => t?.taskRunner?.type)
+            if (sourceHasRunners && !flowParsedHasRunners) {
+                await resolveTaskTopologyDetails(parsed.tasks)
+            }
         },
         {immediate: true},
     )

--- a/ui/src/components/inputs/LowCodeEditor.vue
+++ b/ui/src/components/inputs/LowCodeEditor.vue
@@ -23,6 +23,7 @@
             :getNodeDimensions="getNodeDimensions"
             :customActions="customActions"
             :showDetailsToggle="hasExtraDetails"
+            :taskDetailsVersion="taskDetailsVersion"
             @toggle-orientation="toggleOrientation"
             @edit="onEditTask"
             @delete="onDelete"
@@ -309,6 +310,14 @@
 
     const taskProgress = (taskId: string | undefined) =>
         executionsStore.progressEvents.filter((p) => p.taskId === taskId)
+
+    // Topology nodes only re-evaluate their taskDetails slot (where taskMetrics/taskProgress are
+    // read) when the graph is regenerated — bump this so a live metrics/progress update (which
+    // isn't part of `execution` or `flowGraph`) still reaches an already-rendered node.
+    const taskDetailsVersion = ref(0)
+    watch([() => executionsStore.metrics, () => executionsStore.progressEvents], () => {
+        taskDetailsVersion.value++
+    })
 
     const isTaskModalOpen = ref(false)
     const taskModalCtx = ref<Record<string, any> | null>(null)

--- a/ui/src/components/inputs/LowCodeEditor.vue
+++ b/ui/src/components/inputs/LowCodeEditor.vue
@@ -49,6 +49,7 @@
                         :namespace="props.namespace"
                         :flowId="props.flowId"
                         :metrics="taskMetrics(taskProps.data.node?.task?.id)"
+                        :progress="taskProgress(taskProps.data.node?.task?.id)"
                     />
                 </slot>
             </template>
@@ -178,6 +179,7 @@
                     :namespace="props.namespace"
                     :flowId="props.flowId"
                     :metrics="taskMetrics(selectedTask?.id)"
+                    :progress="taskProgress(selectedTask?.id)"
                     displayMode="full"
                     class="mt-3"
                 />
@@ -304,6 +306,9 @@
 
     const taskMetrics = (taskId: string | undefined) =>
         executionsStore.metrics.filter((m) => m.taskId === taskId)
+
+    const taskProgress = (taskId: string | undefined) =>
+        executionsStore.progressEvents.filter((p) => p.taskId === taskId)
 
     const isTaskModalOpen = ref(false)
     const taskModalCtx = ref<Record<string, any> | null>(null)

--- a/ui/src/components/inputs/LowCodeEditor.vue
+++ b/ui/src/components/inputs/LowCodeEditor.vue
@@ -309,11 +309,28 @@
         )
     })
 
-    const taskMetrics = (taskId: string | undefined) =>
-        executionsStore.metrics.filter((m) => m.taskId === taskId)
+    // metrics/progressEvents are never reset across execution navigations (taskRunId is globally
+    // unique so old entries are harmless in isolation) — but filtering on taskId alone lets a
+    // PREVIOUS taskRun's entries leak into a fresh run of the same task, or into a pre-execution
+    // view with no run at all. Resolve this task's CURRENT taskRun from the execution and filter
+    // on that instead: no current taskRun means nothing to show.
+    const currentTaskRunId = (taskId: string | undefined): string | undefined => {
+        const list = exec.value?.taskRunList as any[] | undefined
+        const filtered = list?.filter((r: any) => r.taskId === taskId) ?? []
+        return filtered[filtered.length - 1]?.id
+    }
 
-    const taskProgress = (taskId: string | undefined) =>
-        executionsStore.progressEvents.filter((p) => p.taskId === taskId)
+    const taskMetrics = (taskId: string | undefined) => {
+        const taskRunId = currentTaskRunId(taskId)
+        if (!taskRunId) return []
+        return executionsStore.metrics.filter((m) => m.taskRunId === taskRunId)
+    }
+
+    const taskProgress = (taskId: string | undefined) => {
+        const taskRunId = currentTaskRunId(taskId)
+        if (!taskRunId) return []
+        return executionsStore.progressEvents.filter((p) => p.taskRunId === taskRunId)
+    }
 
     // Topology nodes only re-evaluate their taskDetails slot (where taskMetrics/taskProgress are
     // read) when the graph is regenerated — bump this so a live metrics/progress update (which

--- a/ui/src/stores/executions.ts
+++ b/ui/src/stores/executions.ts
@@ -834,9 +834,20 @@ export const useExecutionsStore = defineStore("executions", () => {
     }
 
     const addProgressEvent = (event: {taskId: string; taskRunId: string; step: string; timestamp: string}) => {
-        const alreadyKnown = progressEvents.value.some(e => e.taskRunId === event.taskRunId && e.step === event.step)
-        if (alreadyKnown) return
-        progressEvents.value.push(event)
+        // Overwrite (not skip) on a matching (taskRunId, step): a retried task reuses the same
+        // taskRunId, so a later attempt re-emitting the same step must replace the stale value
+        // from an earlier attempt, not be dropped. Idempotent for genuine SSE reconnect replay
+        // since that resends the identical timestamp.
+        //
+        // Reassign the array (like `metrics` does on every loadMetrics()) rather than push/splice
+        // in place: consumers watching this ref shallowly (e.g. to know when to re-render a
+        // topology node) only see a change on reference reassignment, not on in-place mutation.
+        const existingIndex = progressEvents.value.findIndex(e => e.taskRunId === event.taskRunId && e.step === event.step)
+        if (existingIndex === -1) {
+            progressEvents.value = [...progressEvents.value, event]
+        } else {
+            progressEvents.value = progressEvents.value.map((e, i) => i === existingIndex ? event : e)
+        }
     }
 
     const resetLogs = () => {

--- a/ui/src/stores/executions.ts
+++ b/ui/src/stores/executions.ts
@@ -139,6 +139,10 @@ export const useExecutionsStore = defineStore("executions", () => {
     const metrics = ref<any[]>([])
     const metricsTotal = ref<number>(0)
     const subflowsExecutions = ref<Record<string, any>>({})
+    // live lifecycle-step progress reported by plugins mid-run (see RunContext#emitProgress),
+    // read off the follow-logs SSE stream; taskRunId is globally unique so this is safe to
+    // never reset across execution navigations, like subflowsExecutions above
+    const progressEvents = ref<{taskId: string; taskRunId: string; step: string; timestamp: string}[]>([])
     const flow = ref<any | undefined>(undefined)
     const flowGraph = ref<any | undefined>(undefined)
     const namespaces = ref<string[]>([])
@@ -829,6 +833,12 @@ export const useExecutionsStore = defineStore("executions", () => {
         delete subflowsExecutions.value[subflow]
     }
 
+    const addProgressEvent = (event: {taskId: string; taskRunId: string; step: string; timestamp: string}) => {
+        const alreadyKnown = progressEvents.value.some(e => e.taskRunId === event.taskRunId && e.step === event.step)
+        if (alreadyKnown) return
+        progressEvents.value.push(event)
+    }
+
     const resetLogs = () => {
         logs.value = {results: [], total: 0}
     }
@@ -880,6 +890,7 @@ export const useExecutionsStore = defineStore("executions", () => {
         metrics,
         metricsTotal,
         subflowsExecutions,
+        progressEvents,
         flow,
         flowGraph,
         namespaces,
@@ -944,6 +955,7 @@ export const useExecutionsStore = defineStore("executions", () => {
         loadLatestExecutions,
         addSubflowExecution,
         removeSubflowExecution,
+        addProgressEvent,
         resetLogs,
         appendLogs,
         appendFollowedLogs,

--- a/ui/tests/unit/stores/executionsProgress.spec.ts
+++ b/ui/tests/unit/stores/executionsProgress.spec.ts
@@ -40,15 +40,27 @@ describe("executions store progress events", () => {
         ])
     })
 
-    it("addProgressEvent dedupes on (taskRunId, step), keeping the first-seen timestamp", () => {
+    it("addProgressEvent dedupes on (taskRunId, step) without duplicating entries", () => {
         const store = useExecutionsStore()
 
         store.addProgressEvent({taskId: "launch", taskRunId: "tr-1", step: "pod.created", timestamp: "2026-07-01T10:00:00Z"})
         // same taskRunId+step arriving again (e.g. SSE reconnect replay) must not duplicate
-        store.addProgressEvent({taskId: "launch", taskRunId: "tr-1", step: "pod.created", timestamp: "2026-07-01T10:00:05Z"})
+        store.addProgressEvent({taskId: "launch", taskRunId: "tr-1", step: "pod.created", timestamp: "2026-07-01T10:00:00Z"})
 
         expect(store.progressEvents).toHaveLength(1)
-        expect(store.progressEvents[0].timestamp).toBe("2026-07-01T10:00:00Z")
+    })
+
+    it("addProgressEvent overwrites a stale timestamp when a task retries", () => {
+        const store = useExecutionsStore()
+
+        // first attempt
+        store.addProgressEvent({taskId: "launch", taskRunId: "tr-1", step: "pod.created", timestamp: "2026-07-01T10:00:00Z"})
+        // retry reuses the same taskRunId but reports a later, correct timestamp — must replace,
+        // not be silently dropped, or the UI gets stuck showing the failed attempt's numbers
+        store.addProgressEvent({taskId: "launch", taskRunId: "tr-1", step: "pod.created", timestamp: "2026-07-01T10:00:30Z"})
+
+        expect(store.progressEvents).toHaveLength(1)
+        expect(store.progressEvents[0].timestamp).toBe("2026-07-01T10:00:30Z")
     })
 
     it("addProgressEvent keeps distinct steps and distinct taskRunIds separate", () => {

--- a/ui/tests/unit/stores/executionsProgress.spec.ts
+++ b/ui/tests/unit/stores/executionsProgress.spec.ts
@@ -1,0 +1,63 @@
+import {beforeEach, describe, expect, it, vi} from "vitest"
+import {createPinia, setActivePinia} from "pinia"
+
+vi.mock("vue-router", () => ({
+    useRoute: () => ({query: {}, params: {}}),
+    useRouter: () => ({
+        push: vi.fn(),
+        replace: vi.fn(),
+        beforeEach: vi.fn(),
+        afterEach: vi.fn(),
+    }),
+}))
+
+vi.mock("@kestra-io/kestra-sdk", () => ({
+    useClient: () => ({
+        get: vi.fn(),
+        post: vi.fn(),
+        put: vi.fn(),
+        patch: vi.fn(),
+        delete: vi.fn(),
+    }),
+}))
+
+// static import: the store module drags in heavy singletons (e.g. Monaco); re-importing it
+// per test via vi.resetModules() re-runs those singleton registrations and throws
+const {useExecutionsStore} = await import("../../../src/stores/executions")
+
+describe("executions store progress events", () => {
+    beforeEach(() => {
+        setActivePinia(createPinia())
+    })
+
+    it("addProgressEvent appends a new (taskRunId, step) pair", () => {
+        const store = useExecutionsStore()
+
+        store.addProgressEvent({taskId: "launch", taskRunId: "tr-1", step: "pod.created", timestamp: "2026-07-01T10:00:00Z"})
+
+        expect(store.progressEvents).toEqual([
+            {taskId: "launch", taskRunId: "tr-1", step: "pod.created", timestamp: "2026-07-01T10:00:00Z"},
+        ])
+    })
+
+    it("addProgressEvent dedupes on (taskRunId, step), keeping the first-seen timestamp", () => {
+        const store = useExecutionsStore()
+
+        store.addProgressEvent({taskId: "launch", taskRunId: "tr-1", step: "pod.created", timestamp: "2026-07-01T10:00:00Z"})
+        // same taskRunId+step arriving again (e.g. SSE reconnect replay) must not duplicate
+        store.addProgressEvent({taskId: "launch", taskRunId: "tr-1", step: "pod.created", timestamp: "2026-07-01T10:00:05Z"})
+
+        expect(store.progressEvents).toHaveLength(1)
+        expect(store.progressEvents[0].timestamp).toBe("2026-07-01T10:00:00Z")
+    })
+
+    it("addProgressEvent keeps distinct steps and distinct taskRunIds separate", () => {
+        const store = useExecutionsStore()
+
+        store.addProgressEvent({taskId: "launch", taskRunId: "tr-1", step: "pod.created", timestamp: "t0"})
+        store.addProgressEvent({taskId: "launch", taskRunId: "tr-1", step: "pod.scheduled", timestamp: "t1"})
+        store.addProgressEvent({taskId: "launch", taskRunId: "tr-2", step: "pod.created", timestamp: "t2"})
+
+        expect(store.progressEvents).toHaveLength(3)
+    })
+})

--- a/webserver/src/test/java/io/kestra/core/services/LogStreamingServiceTest.java
+++ b/webserver/src/test/java/io/kestra/core/services/LogStreamingServiceTest.java
@@ -190,6 +190,7 @@ class LogStreamingServiceTest {
             level,
             "main",
             message,
+            null,
             null
         );
     }

--- a/webserver/src/test/java/io/kestra/webserver/services/FollowLogEventSearchableTest.java
+++ b/webserver/src/test/java/io/kestra/webserver/services/FollowLogEventSearchableTest.java
@@ -52,22 +52,23 @@ class FollowLogEventSearchableTest {
         Level.INFO,
         "main",
         "hello world",
+        null,
         null
     );
 
     private static final FollowLogEvent systemEvent = new FollowLogEvent(
         null, "system", "demo-flow", "load-data", "exec-sys",
-        "tr-sys", 0, "demo-trigger", T_NOW, Level.INFO, "main", "system message", null
+        "tr-sys", 0, "demo-trigger", T_NOW, Level.INFO, "main", "system message", null, null
     );
 
     private static final FollowLogEvent pastEvent = new FollowLogEvent(
         null, "io.kestra.demo", "demo-flow", "load-data", "exec-past",
-        "tr-past", 0, "demo-trigger", T_PAST, Level.INFO, "main", "past", null
+        "tr-past", 0, "demo-trigger", T_PAST, Level.INFO, "main", "past", null, null
     );
 
     private static final FollowLogEvent futureEvent = new FollowLogEvent(
         null, "io.kestra.demo", "demo-flow", "load-data", "exec-future",
-        "tr-future", 0, "demo-trigger", T_FUTURE, Level.INFO, "main", "future", null
+        "tr-future", 0, "demo-trigger", T_FUTURE, Level.INFO, "main", "future", null, null
     );
 
     private static QueryFilter filter(Field field, Op op, Object value) {


### PR DESCRIPTION
## Summary

Stacked on #17166 (base branch is that PR's head — will retarget to `develop` once #17166 merges). Adds the live-progress UI wiring that consumes `RunContext#emitProgress`:

- `FollowLogEvent` gains the `progress` field so the follow-logs SSE stream carries it
- `ui/packages/slot-contracts/src/topology-details.ts`: typed `progress` prop on the `topology-details` slot contract
- `ui/src/components/executions/Topology.vue`: subscribes to the existing follow-logs SSE, filters/dedupes progress events, feeds them into the executions store
- `ui/src/stores/executions.ts`: `progressEvents` store + `addProgressEvent` (dedup/overwrite by `taskRunId`+`step`, handles retries)
- `ui/packages/topology/src/Topology.vue` + `ui/src/components/inputs/LowCodeEditor.vue`: `taskDetailsVersion` bump so an already-rendered topology node re-renders on a live metrics/progress update
- Assorted fixes: subflow SSE isolation, runner-type resolution fallback on `props.source`, scoping metrics/progress to the current `taskRun` (not stale ones from a previous run/retry)
- webserver test updates for `FollowLogEvent`'s new field

## Test plan
- [x] `cd ui && npx vitest run tests/unit/stores/executionsProgress.spec.ts`
- [ ] Retarget to `develop` once #17166 merges