### PR TITLE
fix(docs): enable xss protection when rendering documentation markdown

### DIFF
--- a/ui/packages/design-system/src/components/Data/KsMarkdown/KsMarkdown.vue
+++ b/ui/packages/design-system/src/components/Data/KsMarkdown/KsMarkdown.vue
@@ -150,7 +150,7 @@
 
         const attrs = parseHtmlAttributes(attrsStr.trim())
         const slots = innerHtml.trim()
-            ? {default: () => [h("span", {innerHTML: innerHtml})]}
+            ? {default: () => [h("span", {innerHTML: props.xssProtection ? htmlEscape(innerHtml) : innerHtml})]}
             : undefined
         return h(component as any, attrs, slots)
     }

--- a/ui/packages/design-system/tests/units/Data/KsMarkdown/KsMarkdown.test.ts
+++ b/ui/packages/design-system/tests/units/Data/KsMarkdown/KsMarkdown.test.ts
@@ -404,4 +404,59 @@ describe("KsMarkdown", () => {
             expect(shikiDiv.text()).toContain("greeting")
         }
     })
+
+    // ─── XSS protection ──────────────────────────────────────────────────────
+
+    test("strips <script> tag from raw HTML by default (xssProtection on)", () => {
+        const wrapper = mount(KsMarkdown, {
+            props: {content: "<script>alert('xss')</script>"},
+            global: globalConfig,
+        })
+        // The <script> element is removed entirely, so nothing can execute.
+        // Its former body survives only as inert text — never as a live tag.
+        expect(wrapper.html()).not.toContain("<script")
+        expect(wrapper.find("script").exists()).toBe(false)
+    })
+
+    test("strips event-handler attributes from raw HTML by default", () => {
+        const wrapper = mount(KsMarkdown, {
+            props: {content: "<img src=\"x\" onerror=\"alert('xss')\">"},
+            global: globalConfig,
+        })
+        expect(wrapper.html()).not.toContain("onerror")
+    })
+
+    test("injects raw HTML verbatim when xssProtection is disabled (escape hatch)", () => {
+        const wrapper = mount(KsMarkdown, {
+            props: {content: "<img src=\"x\" onerror=\"alert('xss')\">", xssProtection: false},
+            global: globalConfig,
+        })
+        expect(wrapper.html()).toContain("onerror")
+    })
+
+    test("sanitizes custom-component inner HTML when xssProtection is on", () => {
+        const ChildCard = {name: "ChildCard", template: "<div class=\"child-card\"><slot /></div>"}
+        const wrapper = mount(KsMarkdown, {
+            props: {
+                content: "<ChildCard><img src=x onerror=\"alert('xss')\"></ChildCard>",
+                components: {ChildCard},
+            },
+            global: globalConfig,
+        })
+        expect(wrapper.find(".child-card").exists()).toBe(true)
+        expect(wrapper.html()).not.toContain("onerror")
+    })
+
+    test("injects custom-component inner HTML verbatim when xssProtection is disabled", () => {
+        const ChildCard = {name: "ChildCard", template: "<div class=\"child-card\"><slot /></div>"}
+        const wrapper = mount(KsMarkdown, {
+            props: {
+                content: "<ChildCard><img src=x onerror=\"alert('xss')\"></ChildCard>",
+                components: {ChildCard},
+                xssProtection: false,
+            },
+            global: globalConfig,
+        })
+        expect(wrapper.html()).toContain("onerror")
+    })
 })

--- a/ui/src/components/docs/ContextDocs.vue
+++ b/ui/src/components/docs/ContextDocs.vue
@@ -34,11 +34,10 @@
                 </div>
                 <DocsLayout>
                     <template #content>
-                        <KsMarkdown 
-                            class="markdown" 
-                            :content="markdownContent" 
-                            :xssProtection="false" 
-                            :components="markdownComponents" 
+                        <KsMarkdown
+                            class="markdown"
+                            :content="markdownContent"
+                            :components="markdownComponents"
                         />
                     </template>
                 </DocsLayout>

--- a/ui/src/components/docs/Docs.vue
+++ b/ui/src/components/docs/Docs.vue
@@ -6,7 +6,7 @@
         </template>
         <template #content>
             <template>
-                <KsMarkdown class="markdown" :content="markdownContent" :xssProtection="false" :components="markdownComponents" />
+                <KsMarkdown class="markdown" :content="markdownContent" :components="markdownComponents" />
             </template>
         </template>
     </DocsLayout>


### PR DESCRIPTION
## What this does

The two in-app documentation renderers passed `:xssProtection="false"` to `KsMarkdown`, so any HTML in the server-returned docs markdown was injected into the DOM verbatim, bypassing the `xss` allowlist sanitization the rest of the app relies on.

- Remove `:xssProtection="false"` from `Docs.vue` and `ContextDocs.vue` so the default (`true`) applies.
- Harden `KsMarkdown.tryRenderCustomComponent`: a custom component's inner HTML was injected via `innerHTML` **with no guard at all**, regardless of the `xssProtection` prop. It now runs through the `xss` allowlist (`htmlEscape`) when protection is on — otherwise removing the prop above would be incomplete (`<ChildCard><img onerror=…></ChildCard>` would still fire).

The custom doc components (`BigChildCards`, `CardLogos`, etc.) render via a dedicated path and do not need protection disabled to work.

## Tests

Added XSS cases to `KsMarkdown.test.ts`:
- `<script>` element stripped from raw HTML by default (nothing executes).
- `onerror` event-handler attribute stripped from raw HTML by default.
- escape hatch: raw HTML injected verbatim only when `xssProtection` is explicitly `false`.
- custom-component inner HTML sanitized when protection is on, injected verbatim when off.

## Note

`xss` uses `stripIgnoreTag`, so a `<script>` tag is removed entirely (no execution) while its former body survives as inert text — safe, and asserted in the tests.

Closes https://github.com/kestra-io/kestra-ee/issues/9055.