### PR TITLE
fix(chart): allow explicit replicas 0 on a deployment

### DIFF
--- a/charts/kestra/templates/deployment.yaml
+++ b/charts/kestra/templates/deployment.yaml
@@ -47,7 +47,8 @@ metadata:
     {{- toYaml . | nindent 4 }}
     {{- end }}
 spec:
-  replicas: {{ hasKey $content "replicas" | ternary $content.replicas $common.replicas }}
+  {{- /* kindIs "invalid" is true only when replicas is unset or explicit null, so an explicit `replicas: 0` is preserved (unlike Sprig's `default`, which treats 0 as empty) */}}
+  replicas: {{ kindIs "invalid" $content.replicas | ternary $common.replicas $content.replicas }}
   revisionHistoryLimit: {{ default $common.revisionHistoryLimit $content.revisionHistoryLimit }}
   selector:
     matchLabels:

--- a/charts/kestra/templates/deployment.yaml
+++ b/charts/kestra/templates/deployment.yaml
@@ -47,7 +47,6 @@ metadata:
     {{- toYaml . | nindent 4 }}
     {{- end }}
 spec:
-  {{- /* kindIs "invalid" is true only when replicas is unset or explicit null, so an explicit `replicas: 0` is preserved (unlike Sprig's `default`, which treats 0 as empty) */}}
   replicas: {{ kindIs "invalid" $content.replicas | ternary $common.replicas $content.replicas }}
   revisionHistoryLimit: {{ default $common.revisionHistoryLimit $content.revisionHistoryLimit }}
   selector:

--- a/charts/kestra/templates/deployment.yaml
+++ b/charts/kestra/templates/deployment.yaml
@@ -47,7 +47,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
     {{- end }}
 spec:
-  replicas: {{ default $common.replicas $content.replicas }}
+  replicas: {{ hasKey $content "replicas" | ternary $content.replicas $common.replicas }}
   revisionHistoryLimit: {{ default $common.revisionHistoryLimit $content.revisionHistoryLimit }}
   selector:
     matchLabels:

--- a/charts/kestra/tests/deployment_replicas_test.yaml
+++ b/charts/kestra/tests/deployment_replicas_test.yaml
@@ -1,0 +1,51 @@
+suite: Deployment replicas
+
+templates:
+  - templates/deployment.yaml
+
+tests:
+  - it: defaults to common.replicas when not set on the deployment
+    set:
+      deployments:
+        standalone:
+          enabled: true
+    asserts:
+      - isKind:
+          of: Deployment
+      - equal:
+          path: spec.replicas
+          value: 1
+
+  - it: uses common.replicas when overridden globally
+    set:
+      common:
+        replicas: 0
+      deployments:
+        standalone:
+          enabled: true
+    asserts:
+      - equal:
+          path: spec.replicas
+          value: 0
+
+  - it: uses the deployment-level replicas over common.replicas
+    set:
+      deployments:
+        standalone:
+          enabled: true
+          replicas: 2
+    asserts:
+      - equal:
+          path: spec.replicas
+          value: 2
+
+  - it: respects an explicit replicas 0 on the deployment
+    set:
+      deployments:
+        standalone:
+          enabled: true
+          replicas: 0
+    asserts:
+      - equal:
+          path: spec.replicas
+          value: 0

--- a/charts/kestra/tests/deployment_replicas_test.yaml
+++ b/charts/kestra/tests/deployment_replicas_test.yaml
@@ -49,3 +49,16 @@ tests:
       - equal:
           path: spec.replicas
           value: 0
+
+  - it: falls back to common.replicas when the deployment sets replicas to null
+    set:
+      common:
+        replicas: 3
+      deployments:
+        standalone:
+          enabled: true
+          replicas: null
+    asserts:
+      - equal:
+          path: spec.replicas
+          value: 3


### PR DESCRIPTION
Helm's `default` function treats `0` as an empty value, so setting `replicas: 0` on a specific deployment (e.g. `deployments.executor.replicas: 0`) was silently falling back to `common.replicas` and rendering `1`. This prevents declaring a dormant deployment scaled to zero, which we need for KEDA-driven autoscaling of cloud instances (a deployment must exist at 0 replicas so KEDA can scale it 0→1).

Replaced `default` with an explicit `hasKey` check so a deployment-level `replicas: 0` is respected, while the fallback to `common.replicas` (including offboarding's `common.replicas: 0`) is unchanged. Added a helm-unittest suite covering the four replica resolution cases.