### PR TITLE
test(core): tolerate backend-dependent boundary bucket in metric aggregation test

### DIFF
--- a/core/src/test/java/io/kestra/core/repositories/AbstractMetricRepositoryTest.java
+++ b/core/src/test/java/io/kestra/core/repositories/AbstractMetricRepositoryTest.java
@@ -70,7 +70,12 @@ public abstract class AbstractMetricRepositoryTest {
             "sum"
         );
 
-        assertThat(aggregationResults.getAggregations().size()).isEqualTo(30);
+        // The exact bucket count at the range boundary is backend-dependent: JDBC fills
+        // the half-open range [start, end) in fixed 1-unit steps (30 buckets), whereas
+        // Elasticsearch uses a calendar_interval date_histogram with inclusive extended
+        // bounds [floor(start), floor(end)] (31 buckets). Both are valid groupings, so we
+        // accept either; the meaningful assertion is that grouping is by day.
+        assertThat(aggregationResults.getAggregations().size()).isBetween(30, 31);
         assertThat(aggregationResults.getGroupBy()).isEqualTo("day");
 
         aggregationResults = metricRepository.aggregateByFlowId(
@@ -84,7 +89,9 @@ public abstract class AbstractMetricRepositoryTest {
             "sum"
         );
 
-        assertThat(aggregationResults.getAggregations().size()).isEqualTo(26);
+        // Same backend-dependent boundary as above: JDBC yields 26 weekly buckets,
+        // Elasticsearch's calendar-aligned histogram yields 27.
+        assertThat(aggregationResults.getAggregations().size()).isBetween(26, 27);
         assertThat(aggregationResults.getGroupBy()).isEqualTo("week");
 
     }


### PR DESCRIPTION
## What

`AbstractMetricRepositoryTest#all()` asserts an exact bucket count returned by `aggregateByFlowId` over a 30-day range (grouped by day) and a 26-week range (grouped by week).

Commit ea282076a5 tightened these assertions to `30` and `26`, matching the JDBC backends (H2/MySQL/Postgres). This **consistently breaks the Elasticsearch backend** — `io.kestra.ee.repository.elasticsearch.ElasticSearchMetricRepositoryTest#all()` — which buckets differently.

## Why the backends differ (both are valid)

- **JDBC** (`AbstractJdbcMetricRepository#fillDate`) fills the half-open range `[start, end)` in fixed 1-unit steps from the raw timestamp → **30** daily / **26** weekly buckets.
- **Elasticsearch** (`ElasticSearchMetricRepository#aggregateByFlowId`) uses a `calendar_interval` `date_histogram` with `min_doc_count=0` and inclusive `extended_bounds [floor(start), floor(end)]` → **31** daily / **27** weekly buckets (one bucket per calendar day/week, both endpoints inclusive).

The exact count at the range boundary is not what this test verifies. Before ea282076a5 the test used two separate `ZonedDateTime.now()` calls (span slightly > 30d/26w) and asserted `31`/`27`, which both backends happened to satisfy.

## Fix

Accept either boundary value via `isBetween(30, 31)` / `isBetween(26, 27)` while keeping the `groupBy` assertions (`day`/`week`) exact.

## Testing

- `:jdbc-h2:test --tests H2MetricRepositoryTest.all` — PASS (30/26, in range).
- Elasticsearch backend could not be run locally (needs `localhost:9200` + EE license); the divergence is proven by the regressing commit's diff and the two implementations' bucketing semantics. The EE `ElasticSearchMetricRepositoryTest` (empty subclass) inherits this abstract test and goes green once this lands.