### PR TITLE
feat(system): add a hook inside the DefaultServiceLivenessCoordinator…

### DIFF
--- a/core/src/main/java/io/kestra/core/lock/LockServiceResourceReleaser.java
+++ b/core/src/main/java/io/kestra/core/lock/LockServiceResourceReleaser.java
@@ -1,0 +1,30 @@
+package io.kestra.core.lock;
+
+import io.kestra.core.server.ServiceResourceReleaser;
+import io.kestra.core.server.ServiceInstance;
+import io.kestra.core.utils.IdUtils;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Release locks for dead services.
+ */
+@Slf4j
+@Singleton
+public class LockServiceResourceReleaser implements ServiceResourceReleaser {
+    private final LockService lockService;
+
+    @Inject
+    public LockServiceResourceReleaser(LockService lockService) {
+        this.lockService = lockService;
+    }
+
+    @Override
+    public void releaseResources(ServiceInstance serviceInstance, String reason) {
+        // Eventually release all owned locks
+        lockService.releaseAllLocks(serviceInstance.server().id())
+            .forEach(l -> log.info("Released lock '{}' for service instance '{}'. Reason: {}", IdUtils.fromParts(l.getCategory(), l.getId()), serviceInstance.server().id(), reason));
+
+    }
+}

--- a/core/src/main/java/io/kestra/core/server/ServiceResourceReleaser.java
+++ b/core/src/main/java/io/kestra/core/server/ServiceResourceReleaser.java
@@ -1,0 +1,16 @@
+package io.kestra.core.server;
+
+/**
+ * This interface defines a contract for releasing resources associated with a service instance.
+ * It is called by the {@link io.kestra.executor.DefaultServiceLivenessCoordinator} when a service instance is disconnected or inactive.
+ * Multiple implementations of this interface can be registered to handle different types of resources.
+ */
+public interface ServiceResourceReleaser {
+    /**
+     * Release resources associated with the given service instance.
+     *
+     * @param serviceInstance the service instance for which resources are to be released
+     * @param reason          the reason for releasing the resources
+     */
+    void releaseResources(ServiceInstance serviceInstance, String reason);
+}

--- a/executor/src/main/java/io/kestra/executor/DefaultServiceLivenessCoordinator.java
+++ b/executor/src/main/java/io/kestra/executor/DefaultServiceLivenessCoordinator.java
@@ -2,6 +2,7 @@ package io.kestra.executor;
 
 import java.time.Duration;
 import java.time.Instant;
+import java.util.List;
 import java.util.Optional;
 import java.util.Random;
 import java.util.Set;
@@ -13,7 +14,6 @@ import com.google.common.annotations.VisibleForTesting;
 import io.kestra.core.executor.WorkerJobRunningStateStore;
 import io.kestra.core.killswitch.EvaluationType;
 import io.kestra.core.killswitch.KillSwitchService;
-import io.kestra.core.lock.LockService;
 import io.kestra.core.metrics.MetricRegistry;
 import io.kestra.core.models.triggers.TriggerId;
 import io.kestra.core.queues.KeyedDispatchQueueInterface;
@@ -24,7 +24,6 @@ import io.kestra.core.scheduler.events.TriggerWorkerLost;
 import io.kestra.core.scheduler.queue.TriggerEventQueue;
 import io.kestra.core.scheduler.vnodes.VNodeController;
 import io.kestra.core.server.*;
-import io.kestra.core.utils.IdUtils;
 import io.kestra.core.utils.Logs;
 
 import io.micrometer.core.instrument.Counter;
@@ -63,13 +62,14 @@ public class DefaultServiceLivenessCoordinator extends AbstractServiceLivenessTa
     private final ServiceInstanceRepositoryInterface serviceInstanceRepository;
     private final Duration purgeRetention;
 
-    private final LockService lockService;
     private final KillSwitchService killSwitchService;
     private final KeyedDispatchQueueInterface<WorkerJobEvent> workerJobEventQueue;
     private final WorkerJobRunningStateStore workerJobRunningStateStore;
     private final TriggerEventQueue triggerEventQueue;
     private final MetricRegistry metricRegistry;
     private final VNodeController vNodeController;
+    private final List<ServiceResourceReleaser> serviceResourceReleasers;
+
     private Counter workerJobResubmitCounter;
     // mutable for testing purpose
     String serverId = ServerInstance.INSTANCE_ID;
@@ -90,14 +90,14 @@ public class DefaultServiceLivenessCoordinator extends AbstractServiceLivenessTa
         final ServiceRegistry serviceRegistry,
         final ServiceLivenessUpdater serviceLivenessUpdater,
         final ServiceInstanceRepositoryInterface serviceInstanceRepository,
-        final LockService lockService,
         final KillSwitchService killSwitchService,
         final KeyedDispatchQueueInterface<WorkerJobEvent> workerJobEventQueue,
         final WorkerJobRunningStateStore workerJobRunningStateStore,
         final TriggerEventQueue triggerEventQueue,
         final ServerConfig serverConfig,
         final MetricRegistry metricRegistry,
-        final VNodeController vNodeController) {
+        final VNodeController vNodeController,
+        final List<ServiceResourceReleaser> serviceResourceReleasers) {
         super(TASK_NAME, serverConfig);
         this.serviceRegistry = serviceRegistry;
         this.serviceLivenessUpdater = serviceLivenessUpdater;
@@ -107,12 +107,12 @@ public class DefaultServiceLivenessCoordinator extends AbstractServiceLivenessTa
         this.workerJobEventQueue = workerJobEventQueue;
         this.workerJobRunningStateStore = workerJobRunningStateStore;
         this.triggerEventQueue = triggerEventQueue;
-        this.lockService = lockService;
         this.metricRegistry = metricRegistry;
         this.purgeRetention = serverConfig.service() != null && serverConfig.service().purge() != null
             ? serverConfig.service().purge().retention()
             : null;
         this.vNodeController = vNodeController;
+        this.serviceResourceReleasers = serviceResourceReleasers;
     }
 
     @PostConstruct
@@ -235,15 +235,11 @@ public class DefaultServiceLivenessCoordinator extends AbstractServiceLivenessTa
                     log.info("Trigger task restart for non-responding worker after timeout: {}.", serviceInstance.uid());
                     reEmitWorkerJobsForWorker(txContext, serviceInstance.uid());
                 }
-                mayReleaseLocksForService(serviceInstance, "service disconnected");
+
+                // release service resources
+                serviceResourceReleasers.forEach(releaser -> releaser.releaseResources(serviceInstance, DEFAULT_REASON_FOR_DISCONNECTED));
             }
         });
-    }
-
-    private void mayReleaseLocksForService(ServiceInstance serviceInstance, String reason) {
-        // Eventually release all owned locks
-        lockService.releaseAllLocks(serviceInstance.server().id())
-            .forEach(l -> log.info("Released lock '{}' for service instance '{}'. Reason: {}", IdUtils.fromParts(l.getCategory(), l.getId()), serviceInstance.uid(), reason));
     }
 
     @Scheduled(initialDelay = "${kestra.server.service.purge.initial-delay}", fixedDelay = "${kestra.server.service.purge.fixed-delay}")
@@ -326,7 +322,9 @@ public class DefaultServiceLivenessCoordinator extends AbstractServiceLivenessTa
             .forEach(instance ->
             {
                 safelyUpdate(instance, Service.ServiceState.INACTIVE, null);
-                mayReleaseLocksForService(instance, "service inactive");
+
+                // release service resources
+                serviceResourceReleasers.forEach(releaser -> releaser.releaseResources(instance, "service inactive"));
             });
     }
 


### PR DESCRIPTION
… to release resrouces when a service dies

Retrofit the existing lock releasing mechanism to use it.

It opens the door to more features to release resources (for ex our Redis queue implementation).
