### PR TITLE
fix(iam): require mcp server creation before connect and tool flow tabs

### DIFF
--- a/ui/src/components/admin/McpServer.vue
+++ b/ui/src/components/admin/McpServer.vue
@@ -11,7 +11,7 @@
 
 <script lang="ts" setup>
     import {computed, watch, onMounted} from "vue"
-    import {useRoute} from "vue-router"
+    import {useRoute, useRouter} from "vue-router"
     import {useI18n} from "vue-i18n"
     import Plus from "vue-material-design-icons/Plus.vue"
     import TopNavBar from "../layout/TopNavBar.vue"
@@ -24,6 +24,7 @@
 
     const {t} = useI18n({useScope: "global"})
     const route = useRoute()
+    const router = useRouter()
     const mcpStore = useMcpStore()
     const {details, serverId} = useHelpers()
     const {tabs} = useMcpTabs()
@@ -32,6 +33,20 @@
     const showCreateToolFlow = computed(() =>
         route.params.tab === "tool-flows" && canCreateFlow.value,
     )
+
+    /**
+     * The Connect and Tool Flows tabs depend on a persisted server configuration,
+     * so they must stay unreachable until the server exists. Disabling the tab
+     * buttons only guards clicks; this redirects direct URL access back to Edit.
+     */
+    const enforceLifecycle = () => {
+        if (!serverId.value && route.params.tab && route.params.tab !== "edit") {
+            router.replace({
+                name: String(route.name),
+                params: {...route.params, tab: "edit"},
+            })
+        }
+    }
 
     const context = computed(() => ({title: details.value.title}))
     useRouteContext(context)
@@ -44,9 +59,13 @@
         }
     })
 
+    watch(() => route.params.tab, enforceLifecycle)
+
     onMounted(() => {
         const main = document.querySelector("main")
         if (main) main.scrollTop = 0
+
+        enforceLifecycle()
 
         if (serverId.value) {
             mcpStore.load(serverId.value)


### PR DESCRIPTION
## What

The **Connect** and **Tool Flows** tabs on the MCP server admin page depend on a persisted server configuration. They were only disabled as tab *buttons*, so direct URL access (e.g. `/admin/mcp-servers/new/connect`) still rendered them against a non-existent server — the Server URL and generated client config showed `.../mcp/undefined`.

This adds an `enforceLifecycle` guard in `McpServer.vue` that redirects any non-`edit` tab back to **Edit** while the server is still being created (runs on mount and on tab change, so both direct navigation and manual URL edits are caught). Update mode (existing server) is unaffected.

## Why

Closes https://github.com/kestra-io/kestra-ee/issues/8090.

> **Note:** the issue also asks for wide-screen layout constraints (centered, max-width card). Those were **already delivered** by the MCP 2.0 redesign (#16988), which merged after the issue was filed — the create form, Connect tab, and server list are already capped and centered. This PR therefore only covers the remaining tab/flow lifecycle-enforcement gap.

## Testing

Verified against a running EE instance:
- `/new/connect` → redirects to `/new/edit` ✅
- `/new/tool-flows` → redirects to `/new/edit` ✅
- `/edit/<id>/connect` (existing server) → Connect renders normally, guard does not over-fire ✅