### PR TITLE
feat(system): add 'configs validate' command to validate configuration on demand

### DIFF
--- a/cli/src/main/java/io/kestra/cli/commands/configs/sys/ConfigCommand.java
+++ b/cli/src/main/java/io/kestra/cli/commands/configs/sys/ConfigCommand.java
@@ -12,6 +12,7 @@ import picocli.CommandLine;
     mixinStandardHelpOptions = true,
     subcommands = {
         ConfigPropertiesCommand.class,
+        ConfigValidateCommand.class,
     }
 )
 @Slf4j

--- a/cli/src/main/java/io/kestra/cli/commands/configs/sys/ConfigValidateCommand.java
+++ b/cli/src/main/java/io/kestra/cli/commands/configs/sys/ConfigValidateCommand.java
@@ -1,0 +1,76 @@
+package io.kestra.cli.commands.configs.sys;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import io.kestra.cli.AbstractCommand;
+import io.kestra.core.models.ServerType;
+import io.kestra.core.utils.Enums;
+import io.kestra.core.validations.AppConfigValidator;
+import io.kestra.core.validations.ConfigValidationResult;
+import io.kestra.core.validations.ServerCommandValidator;
+
+import io.micronaut.context.env.Environment;
+import jakarta.inject.Inject;
+import lombok.extern.slf4j.Slf4j;
+import picocli.CommandLine;
+
+@CommandLine.Command(
+    name = "validate",
+    description = { "Validate the current configuration." }
+)
+@Slf4j
+public class ConfigValidateCommand extends AbstractCommand {
+    @Inject
+    private Environment environment;
+
+    @CommandLine.Spec
+    private CommandLine.Model.CommandSpec spec;
+
+    @CommandLine.Option(
+        names = { "--server-type" },
+        description = "Also validate the properties required to start the given server type (values: ${COMPLETION-CANDIDATES})."
+    )
+    private String serverType;
+
+    @Override
+    public Integer call() throws Exception {
+        super.call();
+
+        final List<ConfigValidationResult> results = new ArrayList<>(AppConfigValidator.validateConfiguration(environment));
+
+        if (serverType != null) {
+            results.addAll(ServerCommandValidator.validateServerConfiguration(environment, parseServerType()));
+        }
+
+        results.stream()
+            .filter(ConfigValidationResult::valid)
+            .forEach(result -> stdOut("@|green ✓|@ - {0}", result.key()));
+
+        final List<ConfigValidationResult> failures = results.stream()
+            .filter(result -> !result.valid())
+            .toList();
+
+        failures.forEach(result ->
+        {
+            stdErr("@|red ✘|@ - {0}", result.key());
+            stdErr("\t- @|bold,yellow {0}|@", result.message().replace("\n", " - "));
+        });
+
+        if (failures.isEmpty()) {
+            stdOut("@|green Configuration is valid.|@");
+            return 0;
+        }
+
+        stdErr("@|red Configuration is invalid: {0} error(s) found.|@", failures.size());
+        return 1;
+    }
+
+    private ServerType parseServerType() {
+        try {
+            return Enums.getForNameIgnoreCase(serverType, ServerType.class);
+        } catch (IllegalArgumentException e) {
+            throw new CommandLine.ParameterException(this.spec.commandLine(), e.getMessage());
+        }
+    }
+}

--- a/cli/src/test/java/io/kestra/cli/commands/configs/sys/ConfigValidateCommandTest.java
+++ b/cli/src/test/java/io/kestra/cli/commands/configs/sys/ConfigValidateCommandTest.java
@@ -1,0 +1,51 @@
+package io.kestra.cli.commands.configs.sys;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+
+import org.junit.jupiter.api.Test;
+
+import io.micronaut.configuration.picocli.PicocliRunner;
+import io.micronaut.context.ApplicationContext;
+import io.micronaut.context.env.Environment;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ConfigValidateCommandTest {
+
+    @Test
+    void shouldReturnZeroAndReportValidWhenConfigurationValid() throws Exception {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        System.setOut(new PrintStream(out));
+
+        try (ApplicationContext ctx = ApplicationContext.run(Environment.CLI, Environment.TEST)) {
+            ConfigValidateCommand cmd = ctx.createBean(ConfigValidateCommand.class);
+            int result = cmd.call();
+
+            assertThat(result).as("A valid configuration returns exit code 0").isZero();
+            assertThat(out.toString())
+                .as("The kestra.url check is reported as valid")
+                .contains("✓ - kestra.url");
+            assertThat(out.toString())
+                .as("A summary line confirms the configuration is valid")
+                .contains("Configuration is valid.");
+        }
+    }
+
+    @Test
+    void shouldValidateServerRequiredPropertiesWhenServerTypeGiven() {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        System.setOut(new PrintStream(out));
+
+        // The CLI test environment defines the queue/repository/storage types, so a webserver
+        // server-type validation must pass.
+        try (ApplicationContext ctx = ApplicationContext.run(Environment.CLI, Environment.TEST)) {
+            Integer result = PicocliRunner.call(ConfigValidateCommand.class, ctx, "--server-type", "webserver");
+
+            assertThat(result).as("A complete server configuration returns exit code 0").isZero();
+            assertThat(out.toString())
+                .as("The required server properties are reported as valid")
+                .contains("✓ - kestra.queue.type");
+        }
+    }
+}

--- a/core/src/main/java/io/kestra/core/validations/AppConfigValidator.java
+++ b/core/src/main/java/io/kestra/core/validations/AppConfigValidator.java
@@ -29,18 +29,35 @@ public class AppConfigValidator {
 
     @PostConstruct
     void validate() {
-        final List<Boolean> validationResults = List.of(
-            isKestraUrlValid()
-        );
+        final List<ConfigValidationResult> results = validateConfiguration(environment);
 
-        if (validationResults.contains(false)) {
+        results.stream()
+            .filter(result -> !result.valid())
+            .forEach(result -> log.error(result.message()));
+
+        if (results.stream().anyMatch(result -> !result.valid())) {
             throw new AppConfigException("Invalid configuration");
         }
     }
 
-    private boolean isKestraUrlValid() {
+    /**
+     * Validates the application-wide configuration and returns the outcome of each check.
+     *
+     * <p>This method is side-effect free (it neither logs nor throws) so the same checks can be
+     * reused for on-demand validation.
+     *
+     * @param environment the configuration environment to validate
+     * @return the outcome of each check, never {@code null}
+     */
+    public static List<ConfigValidationResult> validateConfiguration(final Environment environment) {
+        return List.of(
+            validateKestraUrl(environment)
+        );
+    }
+
+    private static ConfigValidationResult validateKestraUrl(final Environment environment) {
         if (!environment.containsProperty(KESTRA_URL_KEY)) {
-            return true;
+            return ConfigValidationResult.valid(KESTRA_URL_KEY);
         }
         final String rawUrl = environment.getProperty(KESTRA_URL_KEY, String.class).orElseThrow();
         final URL url;
@@ -48,22 +65,20 @@ public class AppConfigValidator {
         try {
             url = URI.create(rawUrl).toURL();
         } catch (IllegalArgumentException | MalformedURLException e) {
-            log.error(
-                "Value of the '{}' configuration property must be a valid URL - e.g. https://your.company.com",
-                KESTRA_URL_KEY
+            return ConfigValidationResult.invalid(
+                KESTRA_URL_KEY,
+                "Value of the '" + KESTRA_URL_KEY + "' configuration property must be a valid URL - e.g. https://your.company.com"
             );
-            return false;
         }
 
         if (!List.of("http", "https").contains(url.getProtocol())) {
-            log.error(
-                "Value of the '{}' configuration property must contain either HTTP or HTTPS scheme - e.g. https://your.company.com",
-                KESTRA_URL_KEY
+            return ConfigValidationResult.invalid(
+                KESTRA_URL_KEY,
+                "Value of the '" + KESTRA_URL_KEY + "' configuration property must contain either HTTP or HTTPS scheme - e.g. https://your.company.com"
             );
-            return false;
         }
 
-        return true;
+        return ConfigValidationResult.valid(KESTRA_URL_KEY);
     }
 
     public static class AppConfigException extends RuntimeException {

--- a/core/src/main/java/io/kestra/core/validations/ConfigValidationResult.java
+++ b/core/src/main/java/io/kestra/core/validations/ConfigValidationResult.java
@@ -1,0 +1,22 @@
+package io.kestra.core.validations;
+
+/**
+ * Outcome of a single configuration validation check.
+ *
+ * <p>Instances are produced by the configuration validators (e.g. {@link AppConfigValidator},
+ * {@link ServerCommandValidator}) so that the same checks can be reused both at boot time and
+ * for on-demand validation (e.g. the {@code configs validate} CLI command).
+ *
+ * @param key     the configuration property (or logical check name) that was validated
+ * @param valid   whether the check passed
+ * @param message a human-readable explanation of the failure, {@code null} when the check passed
+ */
+public record ConfigValidationResult(String key, boolean valid, String message) {
+    public static ConfigValidationResult valid(final String key) {
+        return new ConfigValidationResult(key, true, null);
+    }
+
+    public static ConfigValidationResult invalid(final String key, final String message) {
+        return new ConfigValidationResult(key, false, message);
+    }
+}

--- a/core/src/main/java/io/kestra/core/validations/ServerCommandValidator.java
+++ b/core/src/main/java/io/kestra/core/validations/ServerCommandValidator.java
@@ -40,20 +40,41 @@ public class ServerCommandValidator {
 
     @PostConstruct
     void validate() {
-        Map<String, String> required = ServerType.WORKER.equals(serverType) ? WORKER_REQUIRED_PROPERTIES : ALL_REQUIRED_PROPERTIES;
-        final List<Map.Entry<String, String>> missingProperties = required.entrySet().stream()
-            .filter((property) -> !environment.containsProperty(property.getKey()))
-            .toList();
+        final List<ConfigValidationResult> results = validateServerConfiguration(environment, serverType);
 
-        missingProperties.forEach(
-            property -> log.error("""
-                Server configuration requires the '{}' property to be defined.
-                For more details, please follow the official setup guide at: {}""", property.getKey(), property.getValue())
-        );
+        results.stream()
+            .filter(result -> !result.valid())
+            .forEach(result -> log.error(result.message()));
 
-        if (!missingProperties.isEmpty()) {
+        if (results.stream().anyMatch(result -> !result.valid())) {
             throw new ServerCommandException("Incomplete server configuration - missing required properties");
         }
+    }
+
+    /**
+     * Validates that the properties required to start the given {@link ServerType} are defined.
+     *
+     * <p>This method is side-effect free (it neither logs nor throws) so the same checks can be
+     * reused for on-demand validation.
+     *
+     * @param environment the configuration environment to validate
+     * @param serverType  the server type whose required properties must be present
+     * @return the outcome of each required-property check, never {@code null}
+     */
+    public static List<ConfigValidationResult> validateServerConfiguration(final Environment environment, final ServerType serverType) {
+        final Map<String, String> required = ServerType.WORKER.equals(serverType) ? WORKER_REQUIRED_PROPERTIES : ALL_REQUIRED_PROPERTIES;
+
+        return required.entrySet().stream()
+            .map(property -> environment.containsProperty(property.getKey())
+                ? ConfigValidationResult.valid(property.getKey())
+                : ConfigValidationResult.invalid(property.getKey(), missingPropertyMessage(property.getKey(), property.getValue())))
+            .toList();
+    }
+
+    private static String missingPropertyMessage(final String key, final String documentationUrl) {
+        return """
+            Server configuration requires the '%s' property to be defined.
+            For more details, please follow the official setup guide at: %s""".formatted(key, documentationUrl);
     }
 
     public static class ServerCommandException extends RuntimeException {

--- a/core/src/test/java/io/kestra/core/validations/AppConfigValidatorTest.java
+++ b/core/src/test/java/io/kestra/core/validations/AppConfigValidatorTest.java
@@ -1,14 +1,20 @@
 package io.kestra.core.validations;
 
+import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import org.junit.jupiter.api.Test;
 
 import io.micronaut.context.ApplicationContext;
+import io.micronaut.context.env.Environment;
 import io.micronaut.context.exceptions.BeanInstantiationException;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 class AppConfigValidatorTest {
 
@@ -84,5 +90,56 @@ class AppConfigValidatorTest {
             .as("The bean initialization failed at PostConstruct")
             .isInstanceOf(BeanInstantiationException.class)
             .hasMessageContaining("Invalid configuration");
+    }
+
+    @Test
+    void shouldReturnValidResultWhenKestraUrlAbsent() {
+        Environment environment = mock(Environment.class);
+        when(environment.containsProperty("kestra.url")).thenReturn(false);
+
+        List<ConfigValidationResult> results = AppConfigValidator.validateConfiguration(environment);
+
+        assertThat(results)
+            .as("An absent kestra.url is valid")
+            .allMatch(ConfigValidationResult::valid);
+    }
+
+    @Test
+    void shouldReturnValidResultWhenKestraUrlValid() {
+        Environment environment = mock(Environment.class);
+        when(environment.containsProperty("kestra.url")).thenReturn(true);
+        when(environment.getProperty("kestra.url", String.class)).thenReturn(Optional.of("https://your.company.com"));
+
+        List<ConfigValidationResult> results = AppConfigValidator.validateConfiguration(environment);
+
+        assertThat(results)
+            .as("A well-formed HTTPS kestra.url is valid")
+            .allMatch(ConfigValidationResult::valid);
+    }
+
+    @Test
+    void shouldReturnInvalidResultWhenKestraUrlMalformed() {
+        Environment environment = mock(Environment.class);
+        when(environment.containsProperty("kestra.url")).thenReturn(true);
+        when(environment.getProperty("kestra.url", String.class)).thenReturn(Optional.of("not a url"));
+
+        List<ConfigValidationResult> results = AppConfigValidator.validateConfiguration(environment);
+
+        assertThat(results)
+            .as("A malformed kestra.url is reported as invalid with a message")
+            .anyMatch(result -> !result.valid() && result.key().equals("kestra.url") && result.message() != null);
+    }
+
+    @Test
+    void shouldReturnInvalidResultWhenKestraUrlNotHttp() {
+        Environment environment = mock(Environment.class);
+        when(environment.containsProperty("kestra.url")).thenReturn(true);
+        when(environment.getProperty("kestra.url", String.class)).thenReturn(Optional.of("ftp://your.company.com"));
+
+        List<ConfigValidationResult> results = AppConfigValidator.validateConfiguration(environment);
+
+        assertThat(results)
+            .as("A non-HTTP kestra.url scheme is reported as invalid")
+            .anyMatch(result -> !result.valid() && result.key().equals("kestra.url"));
     }
 }

--- a/core/src/test/java/io/kestra/core/validations/ServerCommandValidatorTest.java
+++ b/core/src/test/java/io/kestra/core/validations/ServerCommandValidatorTest.java
@@ -1,15 +1,21 @@
 package io.kestra.core.validations;
 
+import java.util.List;
 import java.util.Map;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import io.kestra.core.models.ServerType;
+
 import io.micronaut.context.ApplicationContext;
+import io.micronaut.context.env.Environment;
 import io.micronaut.context.exceptions.BeanInstantiationException;
 import io.micronaut.context.exceptions.NoSuchBeanException;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 class ServerCommandValidatorTest {
 
@@ -71,5 +77,47 @@ class ServerCommandValidatorTest {
             exception = exception.getCause();
         }
         return exception;
+    }
+
+    @Test
+    void shouldReturnValidResultsWhenAllRequiredPropertiesPresent() {
+        Environment environment = mock(Environment.class);
+        when(environment.containsProperty("kestra.queue.type")).thenReturn(true);
+        when(environment.containsProperty("kestra.repository.type")).thenReturn(true);
+        when(environment.containsProperty("kestra.storage.type")).thenReturn(true);
+
+        List<ConfigValidationResult> results = ServerCommandValidator.validateServerConfiguration(environment, ServerType.WEBSERVER);
+
+        assertThat(results)
+            .as("All required webserver properties present is valid")
+            .isNotEmpty()
+            .allMatch(ConfigValidationResult::valid);
+    }
+
+    @Test
+    void shouldReturnInvalidResultWhenRequiredPropertyMissing() {
+        Environment environment = mock(Environment.class);
+        when(environment.containsProperty("kestra.queue.type")).thenReturn(true);
+        when(environment.containsProperty("kestra.repository.type")).thenReturn(true);
+        when(environment.containsProperty("kestra.storage.type")).thenReturn(false);
+
+        List<ConfigValidationResult> results = ServerCommandValidator.validateServerConfiguration(environment, ServerType.WEBSERVER);
+
+        assertThat(results)
+            .as("A missing kestra.storage.type is reported as invalid with a message")
+            .anyMatch(result -> !result.valid() && result.key().equals("kestra.storage.type") && result.message() != null);
+    }
+
+    @Test
+    void shouldOnlyRequireStorageForWorker() {
+        Environment environment = mock(Environment.class);
+        when(environment.containsProperty("kestra.storage.type")).thenReturn(true);
+
+        List<ConfigValidationResult> results = ServerCommandValidator.validateServerConfiguration(environment, ServerType.WORKER);
+
+        assertThat(results)
+            .as("A worker only requires kestra.storage.type")
+            .hasSize(1)
+            .allMatch(ConfigValidationResult::valid);
     }
 }


### PR DESCRIPTION
## What

Adds a new `kestra configs validate` CLI subcommand that validates the currently-loaded configuration **on demand** and reports the outcome of each check with a `✓`/`✘` summary and a `0`/`1` exit code.

```
$ kestra configs validate
✓ - kestra.url
Configuration is valid.

$ kestra configs validate --server-type webserver
✓ - kestra.url
✘ - kestra.storage.type
	- Server configuration requires the 'kestra.storage.type' property to be defined. - For more details, please follow the official setup guide at: https://kestra.io/docs/configuration-guide/setup#internal-storage-configuration
...
Configuration is invalid: 3 error(s) found.   # exit code 1
```

The optional `--server-type` flag additionally checks the properties required to start a given server type (`kestra.queue.type`, `kestra.repository.type`, `kestra.storage.type`) **without booting that server** — useful as a pre-flight check before a deployment.

## Why

First iteration toward **kestra-io/kestra-ee#7493** — *"add warning or error for not yet migrated Kestra configuration"*. This iteration establishes the on-demand validation command and its reporting harness. Follow-up iterations will (2) evaluate running the checks at boot time, and (3) add detection of removed/renamed configuration keys from the 1.3 → 2.0 migration.

## How

- The check logic in `AppConfigValidator` and `ServerCommandValidator` is extracted into **side-effect-free static methods** that return a shared `ConfigValidationResult`.
- Both the existing **boot-time validation** (`@Context` + `@PostConstruct`) and the new command call the same logic. Boot behavior is unchanged — same `log.error` lines, same `AppConfigException` / `ServerCommandException` with identical messages (covered by the pre-existing `AppConfigValidatorTest` / `ServerCommandValidatorTest`, still green).
- The command injects `Environment` directly and is registered under the existing `configs` command group (one-line change to `ConfigCommand`). No new dependencies.

## Tests

- `ConfigValidateCommandTest` — happy path (`exit 0`, `✓` output, valid summary) and `--server-type` validation, run through the real Micronaut CLI runtime via `PicocliRunner`.
- New unit tests on `AppConfigValidatorTest` / `ServerCommandValidatorTest` for the extracted static methods (valid **and** invalid results, incl. malformed/non-HTTP `kestra.url` and missing required server properties), using a mocked `Environment`.

## Verification

Beyond the test suite, the command was driven end-to-end against a real CLI runtime:

| Invocation | Output | Exit code |
|---|---|---|
| `configs validate` | `✓ - kestra.url` / `Configuration is valid.` | `0` |
| `configs validate --server-type webserver` (types unset) | `✘` per missing property + docs URL | `1` |
| `configs validate --server-type bogus` | `Unsupported enum value 'bogus'. Expected one of: [...]` | param error |

`configs --help` confirms the new subcommand is listed.