### PR TITLE
chore(core): store translation files in `en.json` key order

### DIFF
--- a/ui/scripts/generate_translations.ts
+++ b/ui/scripts/generate_translations.ts
@@ -191,22 +191,6 @@ function removeEnPrefix(dictionary: FlatDict, prefix = "en|"): FlatDict {
     return result
 }
 
-// Recursively sort object keys to mirror Python's json.dump(sort_keys=True).
-// Arrays keep their element order (only their nested objects get sorted).
-function sortKeysRecursively(value: NestedValue): NestedValue {
-    if (value === null || typeof value !== "object") {
-        return value
-    }
-    if (Array.isArray(value)) {
-        return value.map(sortKeysRecursively)
-    }
-    const sorted: NestedDict = {}
-    for (const key of Object.keys(value).sort()) {
-        sorted[key] = sortKeysRecursively(value[key])
-    }
-    return sorted
-}
-
 async function main(
     languageCode: string,
     targetLanguage: string,
@@ -246,18 +230,20 @@ async function main(
 
     Object.assign(targetFlat, translatedFlatDict)
 
-    // Drop any key that no longer exists in en.json (e.g. removed from the source language).
-    const prunedTargetFlat: FlatDict = {}
-    for (const [k, v] of Object.entries(targetFlat)) {
-        if (k in enFlat) {
-            prunedTargetFlat[k] = v
+    // Rebuild the language dict in en.json key order so the output mirrors the
+    // reference ordering. This keeps regeneration from reordering existing
+    // key/value pairs — which would otherwise open PRs that only rearrange keys —
+    // and, by iterating enFlat, also drops any key no longer present in en.json.
+    const orderedTargetFlat: FlatDict = {}
+    for (const k of Object.keys(enFlat)) {
+        if (k in targetFlat) {
+            orderedTargetFlat[k] = targetFlat[k]
         }
     }
 
-    const updatedTargetDict = unflattenDict(prunedTargetFlat)
+    const updatedTargetDict = unflattenDict(orderedTargetFlat)
 
-    // Sort keys to keep output stable
-    const output = sortKeysRecursively({[languageCode]: updatedTargetDict})
+    const output = {[languageCode]: updatedTargetDict}
     writeFileSync(`ui/src/translations/${languageCode}.json`, JSON.stringify(output, null, 2))
 }
 

--- a/ui/src/translations/de.json
+++ b/ui/src/translations/de.json
@@ -1,1678 +1,722 @@
 {
   "de": {
-    "Add flow": "Flow hinzufügen",
-    "Default log level": "Standard-Log-Ebene",
-    "Default namespace": "Standard-Namespace",
-    "Default page": "Standardseite",
-    "Editor fontfamily": "Editor-Schriftfamilie",
-    "Editor fontsize": "Editor-Schriftgröße",
-    "Editor theme": "Editor-Modus",
-    "Fold auto": "Editor: Automatisches Falten von Mehrzeilen",
-    "Fold content lines": "Mehrzeilige Zeichenfolgen falten",
-    "Hover description": "Editor: Beschreibung des Feldes anzeigen, wenn auf Key oder Value gehalten wird",
-    "Language": "Sprache",
-    "Per page": "pro Seite",
-    "Set default page": "Standardseite festlegen",
-    "Set labels": "Labels festlegen",
-    "Set labels done": "Labels der Ausführung erfolgreich festgelegt",
-    "Set labels to execution": "Labels der Ausführung <code>{id}</code> hinzufügen oder aktualisieren",
-    "Set labels tooltip": "Labels für die Ausführung festlegen",
-    "Task Id already exist in the flow": "Task-Id {taskId} existiert bereits im Flow.",
-    "Total": "Gesamt",
-    "Unfold content lines": "Mehrzeilige Zeichenfolgen entfalten",
-    "about_this_blueprint": "Über dieses Blueprint",
-    "absolute": "Absolut",
-    "accept": "Akzeptieren",
-    "actions": "Aktionen",
-    "activate_basic_auth": "Aktiviere Basis-Authentifizierung",
-    "active": "Aktiv",
-    "active-slots": "Aktive Slots",
-    "actual state": "Aktueller Zustand",
-    "add": "Hinzufügen",
-    "add at position": "{position} <code>{task}</code> hinzufügen",
-    "add error handler": "Fehler-Handler hinzufügen",
-    "add flow": "Flow hinzufügen",
+    "loading": "Wird geladen...",
+    "more actions": "Weitere Aktionen",
+    "toggle menu": "Menü umschalten",
+    "panel actions": "Panelaktionen",
+    "playground actions": "Aktionen im Playground",
+    "bulk actions": "Massenaktionen",
+    "view metrics": "Metriken anzeigen",
+    "remove this item": "Diesen Eintrag entfernen",
     "add label": "Label hinzufügen",
-    "add task": "Einen Task hinzufügen",
-    "add-trigger-in-editor": "Fügen Sie zuerst einen Trigger zu Ihrem Flow hinzu",
-    "add_new_item": "Neues Element hinzufügen",
-    "additionalPlugins": "Zusätzliche Plugins",
-    "admin": "Admin",
-    "admin_preferences": "Preferences",
-    "administration": "Administration",
-    "advanced configuration": "Andere Eigenschaften",
-    "after": "nach",
-    "aggregation": "Aggregation",
-    "ai": {
-      "dashboard": {
-        "prompt_placeholder": "Stellen Sie eine Frage zu Ihren Daten. Beispielaufforderung: Zeigen Sie mir die Erfolgsrate meiner flows in den letzten 7 Tagen."
+    "remove label": "Label entfernen",
+    "id": "Id",
+    "type": "Typ",
+    "ok": "OK",
+    "valid": "Gültig",
+    "close": "Schließen",
+    "namespace": "Namespace",
+    "description": "Beschreibung",
+    "show description": "Beschreibung anzeigen",
+    "show details": "Details anzeigen",
+    "show more details": "Mehr Details anzeigen",
+    "skipped": "Übersprungen",
+    "revision": "Revision",
+    "Language": "Sprache",
+    "Set default page": "Standardseite festlegen",
+    "theme": "Modus",
+    "flows": "Flows",
+    "flow": "Flow",
+    "invalid source": "Ungültiger Quellcode",
+    "missingSource": "Fehlende Quelle",
+    "update": "Aktualisieren",
+    "update ok": "ist aktualisiert",
+    "delete ok": "ist gelöscht",
+    "Default page": "Standardseite",
+    "confirmation": "Bestätigung",
+    "common": {
+      "back": "Zurück"
+    },
+    "delete confirm": "Sind Sie sicher, dass Sie <code>{name}</code> löschen möchten?",
+    "outdated revision save confirmation": {
+      "confirm": "Möchten Sie es überschreiben?",
+      "update": {
+        "title": "Veraltete Revision",
+        "description": "Die Revision, die Sie bearbeiten, ist veraltet.",
+        "details": "Überprüfen Sie die Registerkarte \"Revisionen\" für weitere Details zur neuesten Version."
       },
-      "flow": {
-        "enable_instructions": {
-          "footer": "Hinweis: Derzeit wird nur Gemini als KI-Anbieter für die Open Source Edition unterstützt. Für die Enterprise Edition konsultieren Sie bitte die AI Copilot-Dokumentation für die Konfiguration anderer Modellanbieter.\n\nStarten Sie Ihre Kestra-Instanz neu, nachdem Sie die Konfiguration gespeichert haben.",
-          "header": "<b>AI Copilot wurde noch nicht konfiguriert.</b>\n\nUm AI Copilot zu aktivieren, fügen Sie den folgenden Ausschnitt in die Konfigurationsdatei Ihrer Kestra-Instanz ein (z. B. <code>application.yml</code>) und ersetzen Sie <code>geminiApiKey</code> durch Ihren tatsächlichen Schlüssel:"
-        },
-        "generating": {
-          "app": "Erzeuge App YAML für Sie...",
-          "dashboard": "Erzeuge Dashboard YAML für Sie...",
-          "flow": "Erzeuge Flow YAML für Sie...",
-          "test": "Erzeuge Test-YAML für Sie..."
-        },
-        "prompt_placeholder": "Geben Sie Anweisungen ein, um Ihren Kestra flow zu erstellen. Beispielaufforderung: Erstellen Sie einen flow, der jeden Montag um 9 Uhr ausgeführt wird.",
-        "select_provider": "Anbieter auswählen",
-        "title": "KI-Agent"
+      "create": {
+        "title": "Flow existiert bereits",
+        "description": "Ein flow mit derselben id existiert bereits in diesem namespace.",
+        "details": "Speichern, um zu überschreiben und eine neue Revision zu erstellen."
       }
     },
-    "all executions": "Alle Ausführungen",
-    "all tags": "Alle Tags",
-    "api": "API",
-    "appBlocks": "App-Blöcke",
-    "apps": "Apps",
-    "are you sure change state": "Sind Sie sicher, dass Sie den Zustand ändern möchten?",
-    "assets": {
-      "title": "Vermögenswerte"
+    "override": {
+      "title": "Sie werden den aktuellen Flow überschreiben",
+      "details": "Der vorherige flow kann über die Registerkarte \"Revisions\" wiederhergestellt werden."
     },
-    "attempt": "Versuch",
-    "attempts": "Versuch(e)",
-    "auditlogs": "Audit Logs",
-    "automatic refresh": "Automatische Aktualisierung",
-    "avg": "Durchschnitt",
-    "avg duration": "Durchschnittliche Ausführungsdauer",
+    "is deprecated": "ist veraltet",
+    "success": "Erfolg",
+    "save": "Speichern",
+    "save_as_draft": "Als Entwurf speichern",
+    "draft": "Entwurf",
+    "draft_flow_warning": "Diese flow-Revision ist ein Entwurf. Die Ausführung verwendet diese Entwurfsrevision und kann sofort fehlschlagen, wenn die flow-Definition ungültig ist.",
+    "save task": "Task speichern",
+    "saved": "Erfolgreich gespeichert",
+    "saved as draft": "Erfolgreich als Entwurf gespeichert",
+    "saved done": "<em>{name}</em> ist erfolgreich gespeichert",
+    "saved as draft done": "<em>{name}</em> wurde erfolgreich als Entwurf gespeichert",
+    "multiple saved done": "{name} wurde(n) gespeichert",
+    "fileTypeNotAllowed": "Dateityp nicht erlaubt. Akzeptierte Typen: {types}",
+    "delete": "Löschen",
+    "deleted": "Erfolgreich gelöscht",
+    "deleted confirm": "<em>{name}</em> ist erfolgreich gelöscht!",
+    "Add flow": "Flow hinzufügen",
+    "add": "Hinzufügen",
+    "add_new_item": "Neues Element hinzufügen",
+    "copy": "Kopieren",
+    "copy_to_clipboard": "In die Zwischenablage kopieren",
+    "copy_and_close": "Kopieren und schließen",
+    "Per page": "pro Seite",
+    "new": "Neu",
+    "edit": "Bearbeiten",
     "back": "Zurück",
-    "back_to_dashboard": "Zurück zum Dashboard",
-    "backfill": "Backfill",
-    "backfill executions": "Backfill-Ausführungen",
-    "backfill paused": "Backfill PAUSED",
-    "backfill running": "Backfill läuft",
-    "bar": "Bar",
-    "before": "vor",
-    "behavior": "Verhalten",
-    "blueprints": {
-      "all": "Alle",
-      "apps": "App-Blueprints",
-      "community": "Gemeinschaft",
-      "create": "Erstellen Sie ein Blueprint",
-      "custom": "Benutzerdefinierte Blueprints",
-      "dashboards": "Dashboard Blueprints",
-      "detail": {
-        "category": "Kategorietyp",
-        "links": "Link & Ressourcen",
-        "openInEditor": "In Flow bearbeiten öffnen"
-      },
-      "edit": "Bearbeiten Sie ein Blueprint",
-      "empty": "Keine Blueprints zum Anzeigen.",
-      "flows": "Flow-Blueprints",
-      "header": {
-        "alt": "Blueprints-Symbol",
-        "catch phrase": {
-          "1": "Der erste Schritt ist immer der schwerste.",
-          "2": "Erkunden Sie Blueprints, um Ihr nächstes {kind} zu starten."
-        }
-      },
-      "missingPlugins": {
-        "card": "Erfordert Plugin(s), die auf dieser Instanz nicht installiert sind: {plugins}",
-        "description": "Dieses Blueprint verwendet Tasks aus Plugin(s), die auf dieser Instanz nicht installiert sind: {plugins}. Installieren Sie sie, um dieses Blueprint zu verwenden.",
-        "install": "Plugins installieren",
-        "title": "Fehlende Plugins"
-      },
-      "title": "Blueprints"
+    "next": "Weiter",
+    "done": "Fertig",
+    "review your inputs": "Überprüfen Sie Ihre Eingaben",
+    "edit flow": "Flow bearbeiten",
+    "executions": "Ausführungen",
+    "execution": "Ausführung",
+    "execution id": "Ausführungs-ID",
+    "recent_executions": "Letzte Ausführungen",
+    "details": "Details",
+    "overview": "Übersicht",
+    "gantt": "Gantt",
+    "gantt_no_tasks_executed": "Diese Ausführung endete, ohne dass eine Task ausgeführt wurde. Überprüfen Sie die Übersicht und die Logs, um den Grund zu erfahren.",
+    "gantt_no_tasks_match_filters": "Versuchen Sie, die Such-, Zustands- oder Log-Ebenen-Filter anzupassen.",
+    "gantt_no_tasks_match_filters_title": "Keine Tasks entsprechen den ausgewählten Filtern.",
+    "logs": "Logs",
+    "no_logs_data": "Keine Daten",
+    "no_logs_data_description": "Bitte versuchen Sie, Ihre Filter anzupassen, den Zeitraum zu ändern oder überprüfen Sie, ob der flow kürzlich ausgeführt wurde.",
+    "no_logs_data_title": "Keine Logs für die ausgewählten Filter gefunden.",
+    "duration": "Dauer",
+    "total_duration": "Gesamtdauer",
+    "running duration": "Laufzeitdauer",
+    "queued duration": "Warteschlangendauer",
+    "choose file": "Wählen Sie eine Datei oder ziehen Sie sie hierher...",
+    "launch execution": "Ausführen",
+    "warning flow with triggers": "Dieser Flow enthält Trigger und eine manuelle Ausführung wird fehlschlagen, wenn dieser Flow von Trigger-Ausdrücken abhängt.",
+    "triggered": "Ausführungstrigger",
+    "triggered done": "Ausführung <em>{name}</em> ist erfolgreich ausgelöst",
+    "topology": "Topologie",
+    "date": "Datum",
+    "prev_execution": "Vorherige Ausführung",
+    "next_execution": "Nächste Ausführung",
+    "datepicker": {
+      "leave empty for infinite": "Leer lassen für unendliche Dauer oder eine ISO 8601-Dauer eingeben (Beispiel: 'P1DT1H1M1S')",
+      "duration example": "Beispiel: 'P1DT1H1M1S'",
+      "error": "Ungültiges Dauerformat, muss eine ISO 8601-Dauer sein (z.B. P1DT1H1M1S)",
+      "custom": "Benutzerdefiniert",
+      "last5minutes": "Letzte 5 Minuten",
+      "last15minutes": "Letzte 15 Minuten",
+      "last1hour": "Letzte 1 Stunde",
+      "last12hours": "Letzte 12 Stunden",
+      "last24hours": "Letzte 24 Stunden",
+      "last48hours": "Letzte 48 Stunden",
+      "last7days": "Letzte 7 Tage",
+      "last30days": "Letzte 30 Tage",
+      "last365days": "Letzte 365 Tage",
+      "next5minutes": "Nächste 5 Minuten",
+      "next15minutes": "Nächste 15 Minuten",
+      "next1hour": "Nächste 1 Stunde",
+      "next12hours": "Nächste 12 Stunden",
+      "next24hours": "Nächste 24 Stunden",
+      "next48hours": "Nächste 48 Stunden",
+      "next7days": "Nächste 7 Tage",
+      "next30days": "Nächste 30 Tage",
+      "next365days": "Nächste 365 Tage",
+      "5minutes": "5 Minuten",
+      "15minutes": "15 Minuten",
+      "1hour": "1 Stunde",
+      "12hours": "12 Stunden",
+      "24hours": "24 Stunden",
+      "48hours": "48 Stunden",
+      "7days": "7 Tage",
+      "30days": "30 Tage",
+      "365days": "365 Tage",
+      "never": "Nie",
+      "today": "Heute",
+      "yesterday": "Gestern",
+      "dayBeforeYesterday": "Vorgestern",
+      "thisWeek": "Diese Woche",
+      "thisWeekSoFar": "Diese Woche bisher",
+      "previousWeek": "Vorherige Woche",
+      "thisMonth": "Dieser Monat",
+      "thisMonthSoFar": "Dieser Monat bisher",
+      "previousMonth": "Vorheriger Monat",
+      "thisYear": "Dieses Jahr",
+      "thisYearSoFar": "Dieses Jahr bisher",
+      "previousYear": "Vorheriges Jahr",
+      "short": {
+        "15m": "15 Min.",
+        "1h": "1 Std.",
+        "12h": "12h",
+        "1d": "1T",
+        "7d": "7T"
+      }
     },
-    "body_line_clamp": "Limit line height",
-    "bookmark": "Lesezeichen",
-    "breakpoints": "Haltepunkte",
-    "bulk action async warning": "Dies kann einige Augenblicke dauern.",
-    "bulk actions": "Massenaktionen",
-    "bulk change state": "Sind Sie sicher, dass Sie den Zustand von <code>{executionCount}</code> Ausführung(en) ändern möchten?",
-    "bulk delete": "Sind Sie sicher, dass Sie <code>{executionCount}</code> Ausführung(en) löschen möchten?",
-    "bulk delete backfills": "{count} Backfill löschen",
-    "bulk delete triggers": "Möchten Sie wirklich {count} Trigger löschen?",
-    "bulk disabled status": {
-      "false": "{count} Trigger aktivieren",
-      "true": "{count} Trigger deaktivieren"
+    "created date": "Erstellungsdatum",
+    "latest_update": "Letztes Update",
+    "updated date": "Aktualisierungsdatum",
+    "expiration date": "Ablaufdatum",
+    "started date": "Startdatum",
+    "healthcheck date": "HealthCheck-Datum",
+    "next execution date": "Nächstes Ausführungsdatum",
+    "last execution status": "Letzter Ausführungsstatus",
+    "jump to...": "Springe zu...",
+    "contextBar": {
+      "news": "Nachrichten",
+      "docs": "Dokumentation",
+      "help": "Hilfe",
+      "issue": "Problem",
+      "demo": "Demo",
+      "star": "Geben Sie uns einen Stern"
     },
-    "bulk force run": "Sind Sie sicher, dass Sie <code>{executionCount}</code> Ausführung(en) erzwingen möchten?<br/><br/>WARNUNG: Das Erzwingen einer Ausführung ist nicht garantiert und kann doppelte Task-Ausführungen erzeugen.<br/><br/>Die folgenden Übergänge werden durchgeführt:<br/><ul><li>CREATED Tasks werden in den RUNNING Zustand versetzt.</li><li>RUNNING Tasks werden erneut eingereicht.</li><li>QUEUED Tasks werden aus der Warteschlange entfernt.</li><li>PAUSED Tasks werden fortgesetzt.</li></ul>",
-    "bulk kill": "Sind Sie sicher, dass Sie <code>{executionCount}</code> Ausführung(en) beenden möchten?",
-    "bulk pause": "Sind Sie sicher, dass Sie die Ausführung(en) <code>{executionCount}</code> pausieren möchten?",
-    "bulk pause backfills": "{count} Backfill pausieren",
-    "bulk replay": "Sind Sie sicher, dass Sie <code>{executionCount}</code> Ausführung(en) erneut abspielen möchten?",
-    "bulk restart": "Sind Sie sicher, dass Sie <code>{executionCount}</code> Ausführung(en) neu starten möchten?",
-    "bulk resume": "Sind Sie sicher, dass Sie <code>{executionCount}</code> Ausführung(en) fortsetzen möchten?",
-    "bulk set labels": "Sind Sie sicher, dass Sie Labels für <code>{executionCount}</code> Ausführung(en) festlegen möchten?",
-    "bulk success delete backfills": "{count} Backfills gelöscht",
-    "bulk success delete triggers": "{count} Trigger wurden erfolgreich gelöscht",
-    "bulk success disabled status": {
-      "false": "{count} Trigger aktiviert",
-      "true": "{count} Trigger deaktiviert"
+    "source": "Quelle",
+    "source only": "Nur Quelle",
+    "home": "Startseite",
+    "create": "Erstellen",
+    "create_flow": "Flow erstellen",
+    "add flow": "Flow hinzufügen",
+    "from": "Von",
+    "to": "Bis",
+    "search filters": {
+      "saved": "Gespeicherte Filter",
+      "manage": "Suchfilter verwalten",
+      "manage desc": "Gespeicherte Suchfilter verwalten",
+      "save filter": "Filter speichern",
+      "filter name": "Filtername",
+      "filters": "Filter"
     },
-    "bulk success pause backfills": "{count} Backfills pausiert",
-    "bulk success unlock": "{count} Trigger entsperrt",
-    "bulk success unpause backfills": "{count} Backfills fortgesetzt",
-    "bulk unlock": "{count} Trigger entsperren",
-    "bulk unpause backfills": "{count} Backfill fortsetzen",
-    "bulk unqueue": "Sind Sie sicher, dass Sie <code>{executionCount}</code> Ausführung(en) aus der Warteschlange entfernen möchten?",
-    "can not delete": "Kann nicht gelöscht werden",
-    "can not have less than 1 task": "Jeder Flow muss mindestens einen Task haben.",
-    "can not save": "Kann nicht gespeichert werden",
-    "cancel": "Abbrechen",
+    "steps": "Schritte",
+    "state": "Zustand",
+    "state_history": "Zustandshistorie",
+    "search term in message": "Suchbegriff in Nachricht",
+    "search": "Suche",
+    "search blueprint": "Blueprints durchsuchen",
+    "all tags": "Alle Tags",
+    "source search": "Quellensuche",
+    "filter by log level": "Nach Log-Ebene filtern",
+    "selected": "Ausgewählt",
+    "task": "Task",
+    "task logs": "Task Logs",
+    "display flow {id} executions": "Ausführungen des Flows {id} anzeigen",
+    "actions": "Aktionen",
+    "select datetime": "Datum auswählen",
+    "select view": "Ansicht auswählen",
+    "invalid field": "Ungültiges Feld: {name}",
+    "required field": "Erforderliches Feld",
+    "is required": "{field} ist erforderlich",
+    "error": "Fehler",
+    "form": "Formular",
+    "form error": "Formularfehler",
+    "display topology for flow": "Topologie für Flow anzeigen",
     "cannot create topology": "Topologie für Flow konnte nicht erstellt werden",
-    "cannot swap tasks": "Tasks können nicht getauscht werden",
-    "change execution state confirm": "Sind Sie sicher, dass Sie den Zustand der Ausführung <code>{id}</code> ändern möchten?",
-    "change execution state done": "Ausführungszustand aktualisiert",
-    "change queue confirm": "Möchten Sie den Zustand der Warteschlange für die Ausführung <code>{id}</code> wirklich ändern?<br/>",
+    "start date": "Startdatum",
+    "end date": "Enddatum",
+    "creation": "Erstellung",
+    "flow creation": "Flow-Erstellung",
+    "start datetime": "Startdatum und -zeit",
+    "end datetime": "Enddatum und -zeit",
+    "restart": "Neustart",
+    "restart latest revision": "Neueste Revision neu starten",
+    "restart tooltip": "Die Ausführung vom <code>{state}</code> Task neu starten",
+    "restarted": "Die Ausführung wird neu gestartet",
+    "restart confirm": "Sind Sie sicher, dass Sie die Ausführung <code>{id}</code> neu starten möchten?",
+    "restart change revision": "Sie können die Revision ändern, die für die neue Ausführung verwendet wird.",
+    "replay": "Wiederholen",
+    "replay from task tooltip": "Eine ähnliche Ausführung ab Task <code>{taskId}</code> erstellen",
+    "replay from beginning tooltip": "Eine ähnliche Ausführung von Anfang an erstellen",
+    "replay latest revision": "Wiederholen mit neuester Revision",
+    "replayed": "Die Ausführung wird wiederholt",
+    "replay confirm": "Sind Sie sicher, dass Sie diese Ausführung <code>{id}</code> wiederholen und eine neue erstellen möchten?",
+    "replay with inputs": "Wiedergabe mit Inputs",
+    "reuse_original_inputs": "Ursprüngliche Inputs wiederverwenden",
+    "modify_inputs": "Eingaben ändern",
+    "replay the execution": "Führen Sie die Ausführung <code>{executionId}</code> für den flow <code>{flowId}</code> erneut aus.",
+    "prefill inputs": "Vorausfüllen",
+    "current": "aktuell",
     "change state": "Zustand ändern",
-    "change state confirm": "Sind Sie sicher, dass Sie den Task-Laufzustand für den <code>{task}</code>-Task in der Ausführung <code>{id}</code> ändern möchten?",
-    "change state current state": "Aktueller Zustand ist:",
+    "actual state": "Aktueller Zustand",
+    "select a state": "Wählen Sie einen Zustand",
+    "are you sure change state": "Sind Sie sicher, dass Sie den Zustand ändern möchten?",
+    "yes": "Ja",
     "change state done": "Der Task-Zustand wurde aktualisiert",
+    "change state confirm": "Sind Sie sicher, dass Sie den Task-Laufzustand für den <code>{task}</code>-Task in der Ausführung <code>{id}</code> ändern möchten?",
+    "change queue confirm": "Möchten Sie den Zustand der Warteschlange für die Ausführung <code>{id}</code> wirklich ändern?<br/>",
+    "change state current state": "Aktueller Zustand ist:",
     "change state hint": {
+      "WARNING": [
+        "Der Flow wird als WARNING markiert.",
+        "Die nächsten Tasks werden ausgeführt.",
+        "Die Fehler-Tasks werden ausgeführt."
+      ],
       "FAILED": [
         "Der Flow wird als FAILED markiert.",
         "Keine andere Task wird ausgeführt.",
         "Die Fehler-Tasks werden ausgeführt."
-      ],
-      "RUNNING": [
-        "Der flow wird neu gestartet und alle nächsten Tasks werden ausgeführt.",
-        "Alle blockierten Tasks werden ausgeführt."
       ],
       "SUCCESS": [
         "Der Flow wird neu gestartet, da dieser Task erfolgreich war.",
         "Alle blockierten Tasks werden ausgeführt.",
         "Der Flow wird im Zustand SUCCESS sein, wenn alle Task-Ausführungen erfolgreich sind."
       ],
-      "WARNING": [
-        "Der Flow wird als WARNING markiert.",
-        "Die nächsten Tasks werden ausgeführt.",
-        "Die Fehler-Tasks werden ausgeführt."
+      "RUNNING": [
+        "Der flow wird neu gestartet und alle nächsten Tasks werden ausgeführt.",
+        "Alle blockierten Tasks werden ausgeführt."
       ]
     },
+    "replay execution title": "Ausführung wiederholen",
+    "restart execution title": "Ausführung neu starten",
+    "replay execution description": "Dies wird eine neue Ausführung basierend auf der ausgewählten Ausführung erstellen.",
+    "replay using": "Wiederholen mit",
+    "flow revision original": "Ursprüngliche flow-Revision",
+    "flow revision latest": "Neueste flow-Revision",
+    "flow revision specific": "Spezifische flow-Revision",
+    "replay inputs": "Eingaben",
+    "reuse original inputs": "Original-Inputs wiederverwenden",
+    "modify inputs": "Eingaben ändern",
+    "replay inputs new required": "Diese Revision hat Inputs. Sie werden aufgefordert, diese auszufüllen.",
+    "replay select taskrun": "Wählen Sie den Task-Lauf aus, von dem aus Sie die Wiedergabe starten möchten:",
     "change state tooltip": "Ändern Sie den Ausführungszustand",
-    "chart": "Diagramm",
-    "chart preview": "Diagrammvorschau",
-    "chart type": "Diagrammtyp",
-    "charts": "Diagramme",
-    "choice": "Wahl",
-    "choose file": "Wählen Sie eine Datei oder ziehen Sie sie hierher...",
-    "close": "Schließen",
-    "close sidebar": "Seitenleiste schließen",
-    "codeDisabled": "In Flow deaktiviert",
-    "collapse": "Einklappen",
-    "collapse all": "Alle einklappen",
-    "commit_id": "Commit-ID",
-    "common": {
-      "back": "Zurück"
-    },
-    "concurrency": "Nebenläufigkeit",
-    "concurrency limits": "Nebenläufigkeitsgrenzen",
-    "concurrency_limit": {
-      "dialog_title": "Nebenläufigkeitsgrenzen",
-      "warning": "Das Ändern des laufenden Zählers kann die Nebenläufigkeit beeinträchtigen, sodass Ausführungen das erlaubte Limit überschreiten können."
-    },
-    "conditions": "Bedingungen",
-    "configure basic auth": "Basis-Authentifizierung konfigurieren",
-    "confirm": "Bestätigen",
-    "confirm password": "Passwort bestätigen",
-    "confirmation": "Bestätigung",
-    "context updated date": "Aktualisierungsdatum des Kontexts",
-    "context updated date tooltip": "Wann der Kontext des Triggers zuletzt aktualisiert wurde. Dies tritt auf, wenn die Ausführung ausgelöst wird, abgeschlossen ist (Sperre freigegeben) oder nach einer Bewertung (auch wenn keine Ausführung stattfindet).",
-    "contextBar": {
-      "demo": "Demo",
-      "docs": "Dokumentation",
-      "help": "Hilfe",
-      "issue": "Problem",
-      "news": "Nachrichten",
-      "star": "Geben Sie uns einen Stern"
-    },
-    "continue backfill": "Backfill fortsetzen",
-    "continue backfills": "Backfills fortsetzen",
-    "copied": "Kopiert",
-    "copied_logs_to_clipboard": "Logs in die Zwischenablage kopiert.",
-    "copy": "Kopieren",
-    "copy all logs": "Alle Logs kopieren",
-    "copy logs": "Logs kopieren",
-    "copy url": "URL kopieren",
-    "copy_and_close": "Kopieren und schließen",
-    "copy_to_clipboard": "In die Zwischenablage kopieren",
-    "copy_value": "Copy value",
-    "create": "Erstellen",
-    "create first task": "Erstellen Sie Ihren ersten Task",
-    "create_flow": "Flow erstellen",
-    "created date": "Erstellungsdatum",
-    "creation": "Erstellung",
-    "cron": "Cron",
-    "curl": {
-      "command": "cURL-Befehl",
-      "note": "Beachten Sie, dass bei den Eingabetypen SECRET und FILE der Befehl angepasst werden muss, um den tatsächlichen Werten zu entsprechen."
-    },
-    "current": "aktuell",
-    "current execution": "Aktuelle Ausführung",
-    "custom value": "Benutzerdefinierter Wert",
-    "customize sidebar": "Seitenleiste anpassen",
-    "dark_version": "Dunkler Modus",
-    "dashboards": {
-      "chart_preview": "Klicken Sie auf einen Chart-Quellcode, um die Vorschau anzuzeigen.",
-      "creation": {
-        "confirmation": "Das Dashboard <code>{title}</code> wurde erstellt.",
-        "label": "Dashboard erstellen"
-      },
-      "default": "Standard-Dashboard",
-      "deletion": {
-        "confirmation": "Möchten Sie das Dashboard <code>{title}</code> wirklich löschen?"
-      },
-      "edition": {
-        "chart": "Bearbeiten Sie dieses Diagramm",
-        "confirmation": "Änderungen im Dashboard <code>{title}</code> werden gespeichert.",
-        "id readonly": "Die Eigenschaft `id` kann nicht geändert werden — sie ist jetzt auf ihre Anfangswerte festgelegt. Wenn Sie sie ändern möchten, können Sie ein neues Dashboard erstellen und das alte entfernen.",
-        "label": "Dashboard bearbeiten"
-      },
-      "empty": "Es gibt keine Ergebnisse anzuzeigen.",
-      "export": "Exportieren nach CSV",
-      "labels": {
-        "plural": "Dashboards",
-        "singular": "Dashboard"
-      },
-      "no_description": "Keine Beschreibung",
-      "no_description_hint": "Füge eine Beschreibung zu diesem flow hinzu, um zu dokumentieren, was er tut.<br>Markdown wird unterstützt.",
-      "others": "Andere",
-      "preview": "Vorschau-Dashboard",
-      "quick_filters": {
-        "all": "Alle",
-        "failed": "Fehlgeschlagen",
-        "paused": "Pausiert",
-        "running": "Läuft",
-        "success": "Erfolg",
-        "warning": "Warnung"
-      },
-      "switch": "Dashboard wechseln",
-      "viewAll": "Alle anzeigen"
-    },
-    "data": "Daten",
-    "dataFilters": "Datenfilter",
-    "data_not_protected": "Ihre Daten sind nicht geschützt. Verlieren Sie sie nicht. <b>Aktivieren Sie unsere kostenlosen Sicherheitsfunktionen oder probieren Sie unser kostenpflichtiges Angebot aus.</b>",
-    "date": "Datum",
-    "date count": "{count} am {date}",
-    "date format": "Datumsformat",
-    "date range count": "{count} zwischen dem {startDate} und dem {endDate}",
-    "datepicker": {
-      "12hours": "12 Stunden",
-      "15minutes": "15 Minuten",
-      "1hour": "1 Stunde",
-      "24hours": "24 Stunden",
-      "30days": "30 Tage",
-      "365days": "365 Tage",
-      "48hours": "48 Stunden",
-      "5minutes": "5 Minuten",
-      "7days": "7 Tage",
-      "custom": "Benutzerdefiniert",
-      "dayBeforeYesterday": "Vorgestern",
-      "duration example": "Beispiel: 'P1DT1H1M1S'",
-      "error": "Ungültiges Dauerformat, muss eine ISO 8601-Dauer sein (z.B. P1DT1H1M1S)",
-      "last12hours": "Letzte 12 Stunden",
-      "last15minutes": "Letzte 15 Minuten",
-      "last1hour": "Letzte 1 Stunde",
-      "last24hours": "Letzte 24 Stunden",
-      "last30days": "Letzte 30 Tage",
-      "last365days": "Letzte 365 Tage",
-      "last48hours": "Letzte 48 Stunden",
-      "last5minutes": "Letzte 5 Minuten",
-      "last7days": "Letzte 7 Tage",
-      "leave empty for infinite": "Leer lassen für unendliche Dauer oder eine ISO 8601-Dauer eingeben (Beispiel: 'P1DT1H1M1S')",
-      "never": "Nie",
-      "next12hours": "Nächste 12 Stunden",
-      "next15minutes": "Nächste 15 Minuten",
-      "next1hour": "Nächste 1 Stunde",
-      "next24hours": "Nächste 24 Stunden",
-      "next30days": "Nächste 30 Tage",
-      "next365days": "Nächste 365 Tage",
-      "next48hours": "Nächste 48 Stunden",
-      "next5minutes": "Nächste 5 Minuten",
-      "next7days": "Nächste 7 Tage",
-      "previousMonth": "Vorheriger Monat",
-      "previousWeek": "Vorherige Woche",
-      "previousYear": "Vorheriges Jahr",
-      "short": {
-        "12h": "12h",
-        "15m": "15 Min.",
-        "1d": "1T",
-        "1h": "1 Std.",
-        "7d": "7T"
-      },
-      "thisMonth": "Dieser Monat",
-      "thisMonthSoFar": "Dieser Monat bisher",
-      "thisWeek": "Diese Woche",
-      "thisWeekSoFar": "Diese Woche bisher",
-      "thisYear": "Dieses Jahr",
-      "thisYearSoFar": "Dieses Jahr bisher",
-      "today": "Heute",
-      "yesterday": "Gestern"
-    },
-    "debug": "Debuggen",
-    "default": "Standard",
-    "defaultsToNamespaceFile": "Standardmäßig auf namespace-Datei: <code>{name}</code> eingestellt",
-    "delete": "Löschen",
-    "delete backfill": "Backfill löschen",
-    "delete backfills": "Backfills löschen",
-    "delete confirm": "Sind Sie sicher, dass Sie <code>{name}</code> löschen möchten?",
-    "delete execution running": "<div class=\"alert alert-warning mt-2 mb-0\">Diese Ausführung läuft noch, das Löschen wird sie nicht stoppen.<br />Sie müssen die Ausführung beenden, um sie zu stoppen.</div>",
-    "delete logs": "Logs löschen",
-    "delete ok": "ist gelöscht",
-    "delete revision confirm": "Möchten Sie die Revision {revision} wirklich löschen?",
-    "delete revision error": "Fehler beim Löschen der Revision {revision} mit Fehler {error}",
-    "delete task confirm": "Möchten Sie den Task <code>{taskId}</code> wirklich löschen?",
-    "delete trigger": "Trigger löschen",
-    "delete trigger confirmation": "Möchten Sie den Trigger {id} wirklich löschen? WARNING: Das Löschen eines Triggers kann zu doppelten Ausführungen führen, wenn der Trigger noch in einem flow aktiv ist.",
-    "delete trigger error": "Fehler beim Löschen des Triggers {id}",
-    "delete trigger success": "Trigger {id} wurde erfolgreich gelöscht",
-    "delete triggers": "Trigger löschen",
-    "delete_all_logs": "Sind Sie sicher, dass Sie alle Logs löschen möchten?",
-    "delete_log": "Sind Sie sicher, dass Sie das Log löschen möchten?",
-    "deleted": "Erfolgreich gelöscht",
-    "deleted confirm": "<em>{name}</em> ist erfolgreich gelöscht!",
-    "deleted_label": "Gelöscht",
-    "demos": {
-      "IAM": {
-        "message": "Kestra Enterprise Edition verfügt über integrierte IAM-Funktionen mit Single Sign-On (SSO), SCIM-Verzeichnissynchronisation und rollenbasierter Zugriffskontrolle (RBAC). Es integriert sich mit mehreren Identitätsanbietern und ermöglicht Ihnen, feingranulare Berechtigungen für Benutzer und Dienstkonten zuzuweisen.",
-        "title": "Benutzer über IAM mit SSO, SCIM und RBAC verwalten"
-      },
-      "apps": {
-        "message": "Apps in der Kestra Enterprise Edition ermöglichen es Ihnen, benutzerdefinierte UIs zu erstellen, die mit Kestra-Workflows außerhalb der Plattform interagieren. Diese Funktion erlaubt es Ihnen, Ihre Workflows als Backend für benutzerdefinierte Anwendungen zu nutzen, sodass nicht-technische Benutzer Daten über Formulare einreichen oder pausierte Workflows, die auf eine Genehmigung warten, fortsetzen können.",
-        "title": "Erstellen Sie benutzerdefinierte Apps mit Kestra"
-      },
-      "assets": {
-        "header": "Assets-Metadaten und Observability",
-        "label": "Assets",
-        "message": "Assets verbinden Observability-, Lineage- und Ownership-Metadaten, damit Plattformteams schneller Probleme beheben und mit Vertrauen bereitstellen können.",
-        "title": "Bringen Sie jedes Dataset, jeden Service und jede Abhängigkeit in Sicht."
-      },
-      "audit-logs": {
-        "message": "Kestra Enterprise Edition protokolliert jede Aktivität mit robusten, unveränderlichen Aufzeichnungen, was es einfach macht, Änderungen nachzuverfolgen, die Einhaltung von Vorschriften zu gewährleisten und Probleme zu beheben.",
-        "title": "Änderungen mit Audit Logs nachverfolgen"
-      },
-      "blueprints": {
-        "message": "In der Kestra Enterprise Edition können Sie benutzerdefinierte Blueprints erstellen, die nur für Ihre Organisation verfügbar sind. Sie können diese als Best-Practice-Vorlagen verwenden, um häufig genutzte Workflows in Ihrem Team zu teilen, zu zentralisieren und zu dokumentieren.",
-        "title": "Benutzerdefinierte Blueprints hinzufügen"
-      },
-      "contact_sales": "Vertrieb kontaktieren",
-      "enterprise_edition": "Enterprise Edition",
-      "get_a_demo_button": "Demo anfordern",
-      "instance": {
-        "message": "Kestra Enterprise Edition bietet ein operatives Dashboard, das Ihnen hilft, die Gesundheit Ihrer Plattform zu überwachen und die Betriebszeitmetriken aller Dienste wie z.B. Workers, Schedulers und Executors zu verfolgen. Auf derselben Seite können Sie auch Ankündigungen erstellen, um Ihre Benutzer über geplante Ausfallzeiten zu informieren, und Sie können einen Wartungsmodus aktivieren, der vorübergehend alle Dienste und Workflow-Ausführungen in einen PAUSED-Zustand versetzt, um ein Upgrade durchzuführen.",
-        "title": "Verwalten Sie die Infrastruktur in Ihrer Instanz"
-      },
-      "namespace": {
-        "assets": {
-          "message": "In Kestra Enterprise Edition führt Assets ein Live-Inventar der Ressourcen, mit denen Ihre Workflows interagieren. Diese Ressourcen können Datenbanktabellen, virtuelle Maschinen, Dateien oder jedes externe System sein, mit dem Sie arbeiten.",
-          "title": "Zentralisiere Asset-Management"
-        },
-        "audit-logs": {
-          "message": "In der Kestra Enterprise Edition können Sie Audit-Logs auf Namespace-Ebene mit detaillierten Diffs anzeigen, die Ihnen eine klare Historie darüber geben, wer was und wann an allen Ressourcen geändert hat.",
-          "title": "Alle Änderungen an einem Ort verfolgen"
-        },
-        "edit": {
-          "message": "In der Kestra Enterprise Edition bieten Namespaces erweiterte Isolation und Governance von Secrets, Variablen und Plugin-Standardeinstellungen im großen Maßstab. Administratoren können benutzerdefinierte Secrets-Manager, isolierte Speicher-Backends, dedizierte Worker-Gruppen und fein abgestufte Berechtigungen auf Basis von Namespaces konfigurieren. Dies stellt sicher, dass Secrets, Variablen und Plugin-Konfigurationen über verschiedene Teams und Projekte hinweg sicher und einfach zu verwalten bleiben.",
-          "title": "Verbessern Sie Ihr Namespace-Management"
-        },
-        "history": {
-          "message": "In der Kestra Enterprise Edition können Sie die Versionshistorie Ihrer Namespaces verwalten.",
-          "title": "Verwalten Sie die Revisionshistorie an einem Ort"
-        },
-        "plugin-defaults": {
-          "message": "In der Kestra Enterprise Edition können Sie namespace-spezifische Plugin-Standardeinstellungen festlegen, wodurch der Bedarf an doppelter Einrichtung in jedem Flow reduziert wird. Diese zentrale Plugin-Verwaltung erzwingt konsistente Konfigurationen, ermöglicht die sichere Referenzierung von Geheimnissen oder Variablen und vereinfacht die Wartung Ihrer Workflows.",
-          "title": "Konfiguration mit Plugin-Standards standardisieren"
-        },
-        "secrets": {
-          "message": "In der Kestra Enterprise Edition können Sie Geheimnisse auf der Namespace-Ebene speichern und verwalten, um Risiken zu minimieren und sicherzustellen, dass die Anmeldedaten jedes Teams isoliert bleiben. Dank der verschachtelten Hierarchie können Sie auch Anmeldedaten in einem übergeordneten Namespace konfigurieren, die dann von allen untergeordneten Namespaces geerbt werden. Die Unterstützung für dedizierte Geheimnis-Manager und fein abgestufte Berechtigungseinstellungen auf Namespace-Ebene stärkt die Sicherheit und Compliance weiter.",
-          "title": "Geheimnisse auf sichere Weise verwalten"
-        },
-        "variables": {
-          "message": "In der Kestra Enterprise Edition können Sie namespace-spezifische Variablen definieren und verwalten, um wiederholte Konfigurationen über Flows hinweg zu eliminieren. Diese Variablen gewährleisten Konsistenz, vereinfachen Konfigurationsaktualisierungen und können von jedem Task oder Trigger leicht referenziert werden, um sauberere und besser wartbare Workflows zu ermöglichen.",
-          "title": "Verwalten Sie Ihre Variablen zentral"
-        }
-      },
-      "quotas": {
-        "message": "Kestra Enterprise Edition ermöglicht es Ihnen, Kontingente für Flows festzulegen, um die Anzahl gleichzeitiger oder gesamter Ausführungen in einem Zeitfenster zu begrenzen. Kontingente helfen Ihnen, gemeinsam genutzte Infrastruktur zu schützen, SLAs durchzusetzen und unkontrollierte Workflows daran zu hindern, übermäßige Ressourcen zu verbrauchen.",
-        "title": "Ausführungskontingente für Flows festlegen"
-      },
-      "secrets": {
-        "add_env": {
-          "first": "Kodieren Sie den <a href=\"https://kestra.io/docs/how-to-guides/secrets?utm_source=app&utm_medium=referral&utm_campaign=secrets-inlinedoc#using-secrets-in-kestra\" target=\"_blank\">geheimen Wert in Base64</a>",
-          "intro": "Um ein neues Secret zu erstellen:",
-          "second": "Fügen Sie eine Umgebungsvariable mit dem Namen '<strong>SECRET_{'{MY_SECRET_KEY}'}</strong>' mit dem obigen Wert hinzu",
-          "third": "Starte deine Kestra-Instanz neu"
-        },
-        "detected_env": "Hier sind Umgebungsvariablen vom Typ \"secret\", die beim Start der Instanz identifiziert wurden:",
-        "empty_env": "Sie haben noch keine Secrets in Ihrer Umgebung.",
-        "message": "Die Enterprise Edition (EE) ermöglicht es Ihnen, Geheimnisse direkt in der UI hinzuzufügen, zu bearbeiten oder zu löschen – ohne Neustart der Instanz. Organisieren Sie Geheimnisse nach namespace mit detaillierten RBAC-Berechtigungen und erben Sie sie von übergeordneten zu untergeordneten namespaces. EE integriert sich mit Geheimnis-Managern wie HashiCorp Vault, AWS Secrets Manager, Azure Key Vault, Google Secret Manager und Elasticsearch. Richten Sie dedizierte Backends pro namespace, Mandant oder Instanz ein, um Geheimnisse zwischen Teams zu isolieren, oder aktivieren Sie schreibgeschützte Geheimnisse, die in externen Tresoren gespeichert sind. Geheimnisse bleiben sowohl im Ruhezustand als auch während der Übertragung verschlüsselt. Optionales Caching reduziert API-Aufrufe, und Prüfpfade protokollieren alle Zugriffe.",
-        "title": "Aktualisieren Sie Ihr Secrets Management"
-      },
-      "tenants": {
-        "message": "Die Kestra Enterprise Edition unterstützt Multi-Tenancy und bietet vollständig isolierte Umgebungen für verschiedene Teams oder Projekte, jeweils mit eigenen Ressourcen wie dedizierten Worker-Gruppen oder Secrets und internen Speicher-Backends.",
-        "title": "Verwalten Sie Workflows in isolierten Tenants"
-      },
-      "tests": {
-        "header": "Unittests für Flows",
-        "label": "Tests",
-        "message": "Überprüfen Sie die Logik Ihrer flows isoliert, erkennen Sie frühzeitig Regressionen und bewahren Sie das Vertrauen in Ihre Automatisierungen, während sie sich ändern und wachsen.",
-        "title": "Sicherstellen der Zuverlässigkeit bei jeder Änderung"
-      },
-      "watch_the_video": "Sieh dir das Video an"
-    },
-    "density": "Density",
-    "density_compact": "Compact",
-    "density_expanded": "Expanded",
-    "density_normal": "Normal",
-    "dependencies": "Abhängigkeiten",
-    "dependencies delete flow": "Dieser Flow hat Abhängigkeiten. Das Löschen verhindert, dass deren Abhängigkeiten ausgeführt werden.<br /><br /> Hier ist die Liste der betroffenen Flows:",
-    "dependencies loaded": "Abhängigkeiten geladen",
-    "dependencies missing acls": "Keine Berechtigungen für diesen Flow",
-    "dependency": {
-      "controls": {
-        "clear_selection": "Auswahl aufheben",
-        "fit_view": "An Bildschirm anpassen",
-        "zoom_in": "Hineinzoomen",
-        "zoom_out": "Rauszoomen"
-      },
-      "search": {
-        "flow": {
-          "display": "Flow-Abhängigkeiten einbeziehen"
-        },
-        "namespace": {
-          "no_namespace": "Ohne namespace",
-          "select": "Wählen Sie ein namespace aus"
-        },
-        "no_results": "Keine Ergebnisse gefunden für {term}",
-        "placeholders": {
-          "asset": "Suche nach Asset, flow oder namespace...",
-          "default": "Suche nach flow oder namespace..."
-        }
-      }
-    },
-    "dependency task": "Task {taskId} ist eine Abhängigkeit eines anderen Tasks",
-    "description": "Beschreibung",
-    "details": "Details",
-    "disable": "Deaktivieren",
-    "disabled": "Deaktiviert",
-    "disabled flow desc": "Dieser Flow ist deaktiviert, bitte aktivieren Sie ihn, um ihn auszuführen.",
-    "disabled flow title": "Dieser Flow ist deaktiviert",
-    "discard changes confirmation": "Sie haben ungespeicherte Änderungen. Sind Sie sicher, dass Sie diese verwerfen möchten?",
-    "discard execution confirmation": "Sie haben ungespeicherte Eingaben. Sind Sie sicher, dass Sie diese Ausführung verwerfen möchten?",
-    "display direct sub tasks count": "Direkte Subtask-Anzahl anzeigen",
-    "display flow {id} executions": "Ausführungen des Flows {id} anzeigen",
-    "display metric for specific task": "Metrik für einen spezifischen Task anzeigen",
-    "display output for specific task": "Output für einen spezifischen Task anzeigen",
-    "display topology for flow": "Topologie für Flow anzeigen",
-    "display_settings": "Display settings",
-    "docs": "Dokumentation",
-    "documentation": {
-      "documentation": "Dokumentation",
-      "github": "GitHub-Issue öffnen"
-    },
-    "documentationMenu": "Dokumentationsmenü",
-    "done": "Fertig",
-    "down trend": "Sinkend",
-    "download": "Herunterladen",
-    "download logs": "Logs herunterladen",
-    "download_logos": "Logo-Paket herunterladen",
-    "download_logs_description": "Choose which logs to export. Filters default to your current view.",
-    "draft": "Entwurf",
-    "draft_available": "Ein Entwurf der Änderung ist im Editor verfügbar",
-    "draft_flow_warning": "Diese flow-Revision ist ein Entwurf. Die Ausführung verwendet diese Entwurfsrevision und kann sofort fehlschlagen, wenn die flow-Definition ungültig ist.",
-    "drill down preview": "Vorschau",
-    "drop items here": "Elemente hier ablegen",
-    "duplicate-pair": "{label} \"{key}\" ist dupliziert, erster Schlüssel ignoriert.",
-    "duration": "Dauer",
-    "dynamic": "Dynamisch",
-    "each value": "Iterationswert",
-    "edit": "Bearbeiten",
-    "edit flow": "Flow bearbeiten",
-    "editor": "Editor",
-    "editor_shortcuts": {
-      "command_palette": "Befehlsübersicht anzeigen",
-      "comment": "Kommentar",
-      "comment_uncomment": "Kommentar/Kommentar entfernen",
-      "decrease_fontsize": "Editor-Schriftgröße verkleinern",
-      "duplicate_cursor": "Kursor duplizieren",
-      "execute_flow": "Flow ausführen",
-      "fold_unfold": "Code ein-/ausklappen",
-      "increase_fontsize": "Editor-Schriftgröße erhöhen",
-      "label": "Tastenkombinationen",
-      "move_line": "Zeile verschieben",
-      "reset_fontsize": "Schriftgröße des Editors zurücksetzen",
-      "save_flow": "Flow speichern",
-      "toggle_ai_agent": "AI-Agent umschalten",
-      "trigger_autocompletion": "Autovervollständigung auslösen",
-      "uncomment": "Entkommentieren"
-    },
-    "ee-tooltip": {
-      "button": "Sprechen Sie mit uns",
-      "features-blocked": "Diese Funktion erfordert die Enterprise Edition."
-    },
-    "email": "E-Mail",
-    "email length constraint": "E-Mail darf 256 Zeichen nicht überschreiten",
-    "empty": {
-      "announcements": {
-        "content": "Ankündigungen ermöglichen es Ihnen, Ihre Benutzer über Änderungen zu informieren oder sie über geplante Wartungsarbeiten zu benachrichtigen. Wählen Sie einfach den Ankündigungstyp, den Zeitraum, in dem sie angezeigt werden soll, und schreiben Sie die Ankündigungsnachricht.",
-        "title": "Sie haben noch keine Ankündigungen!"
-      },
-      "apiTokens": {
-        "content": "API-Tokens werden verwendet, wenn Sie programmatischen Zugriff auf die Kestra-API gewähren möchten.",
-        "title": "Verwalten Sie Ihre API-Tokens"
-      },
-      "apps": {
-        "content": "Beginnen Sie mit dem Erstellen von Apps, um mit Kestra von der Außenwelt zu interagieren.",
-        "title": "Sie haben noch keine Apps!"
-      },
-      "assets": {
-        "content": "Fügen Sie Assets hinzu, um Ihre Daten-Assets, Dienste und Infrastruktur zu verfolgen und zu verwalten.",
-        "title": "Sie haben noch keine Assets!"
-      },
-      "concurrency_executions": {
-        "content": "Erfahren Sie mehr über <strong><a href=\"https://kestra.io/docs/workflow-components/execution?utm_source=app&utm_medium=referral&utm_campaign=concurrency-inlinedoc\" target=\"_blank\">Ausführungen</a></strong> in unserer Dokumentation.",
-        "title": "Keine laufenden Ausführungen für diesen Flow."
-      },
-      "concurrency_limit": {
-        "content": "Erfahren Sie mehr über <strong><a href=\"https://kestra.io/docs/workflow-components/concurrency?utm_source=app&utm_medium=referral&utm_campaign=concurrency-inlinedoc\" target=\"_blank\">Nebenläufigkeitsgrenzen</a></strong> in unserer Dokumentation.",
-        "title": "Für diesen Flow sind keine Grenzen festgelegt."
-      },
-      "concurrency_limits": {
-        "content": "Lesen Sie mehr über <strong><a href=\"https://kestra.io/docs/workflow-components/concurrency?utm_source=app&utm_medium=referral&utm_campaign=concurrency-inlinedoc\" target=\"_blank\">Nebenläufigkeitsgrenzen</a></strong> in unserer Dokumentation.",
-        "title": "Es sind keine Nebenläufigkeitsgrenzen festgelegt."
-      },
-      "dependencies": {
-        "ASSET": {
-          "content": "Dieses Asset hat keine Upstream- oder Downstream-Abhängigkeiten mit flows oder anderen Assets.",
-          "title": "Derzeit gibt es keine Abhängigkeiten."
-        },
-        "EXECUTION": {
-          "content": "Erfahren Sie mehr über <a href=\"https://kestra.io/docs/ui/executions?utm_source=app&utm_medium=referral&utm_campaign=dependencies-inlinedoc#dependencies\" target=\"_blank\">Ausführungsabhängigkeiten</a> in unserer Dokumentation.",
-          "title": "Derzeit gibt es keine Abhängigkeiten."
-        },
-        "FLOW": {
-          "content": "Erfahren Sie mehr über <a href=\"https://kestra.io/docs/ui/flows?utm_source=app&utm_medium=referral&utm_campaign=dependencies-inlinedoc#dependencies\" target=\"_blank\">Flow-Abhängigkeiten</a> in unserer Dokumentation.",
-          "title": "Derzeit gibt es keine Abhängigkeiten."
-        },
-        "NAMESPACE": {
-          "content": "Lesen Sie mehr über <a href=\"https://kestra.io/docs/ui/namespaces?utm_source=app&utm_medium=referral&utm_campaign=dependencies-inlinedoc#dependencies\" target=\"_blank\">Namespace Dependencies</a> in unserer Dokumentation.",
-          "title": "Derzeit gibt es keine Abhängigkeiten."
-        }
-      },
-      "groups": {
-        "content": "Gruppen ermöglichen es Ihnen, Benutzer zusammenzufassen, sodass Sie Berechtigungen und Rollenbindungen gemeinsam über Ihren Mandanten verwalten können.",
-        "title": "Sie haben noch keine Gruppen!"
-      },
-      "kill_switches": {
-        "content": "Die Kill Switch-Funktion bietet einen UI-basierten Mechanismus, um problematische Ausführungen zu stoppen. Sie ersetzt die nur CLI-basierten Befehle <code>--skip-executions</code> und <code>--skip-flows</code> durch eine umfassende Verwaltungsoberfläche.",
-        "title": "Sie haben noch keine Kill Switches!"
-      },
-      "mcpToolFlows": {
-        "content": "Expose einen flow als MCP-Tool, indem Sie einen <code>McpToolTrigger</code> hinzufügen. Lesen Sie mehr über den <strong><a href=\"https://kestra.io/docs/workflow-components/triggers/mcp-tool-trigger?utm_source=app&utm_medium=referral&utm_campaign=mcp-tool-trigger-inlinedoc\" target=\"_blank\">MCP Tool Trigger</a></strong> in unserer Dokumentation.",
-        "title": "Auf diesem Server sind noch keine Tool flows registriert."
-      },
-      "namespaceFiles": {
-        "content": "Namespace-Dateien funktionieren wie ein Projektordner für diesen Namespace. Speichern Sie Python-, SQL-, dbt- oder Terraform-Code und referenzieren Sie anschließend jede Datei in Ihren Flows mit",
-        "title": "Noch keine Dateien in diesem Namespace"
-      },
-      "panels": {
-        "content": "Du hast alle Panels geschlossen.  \nWähle oben eine Registerkarte, um fortzufahren.",
-        "title": "Kein Panel geöffnet"
-      },
-      "pluginDefaults": {
-        "content": "Plugin-Standardeinstellungen ermöglichen es Ihnen, Ihre Plugin-Konfiguration zentral zu verwalten und mit allen flows in Ihrem namespace zu teilen.",
-        "title": "Sie haben noch keine Plugin-Standards!"
-      },
-      "plugins": {
-        "content": "Lesen Sie mehr über <strong><a href=\"https://kestra.io/docs/workflow-components/plugin-defaults?utm_source=app&utm_medium=referral&utm_campaign=plugin-default-inlinedoc\" target=\"_blank\">Nebenläufigkeitsgrenzen</a></strong> in unserer Dokumentation.",
-        "title": "Für diesen Namespace sind keine Plugin-Standardeinstellungen festgelegt."
-      },
-      "testSuites": {
-        "content": "Beginnen Sie mit der Erstellung von Testsuiten, um Ihre Flows zu testen.",
-        "title": "Sie haben noch keine Test-Suites!"
-      },
-      "triggers": {
-        "content": "Lesen Sie mehr über <strong><a href=\"https://kestra.io/docs/workflow-components/triggers?utm_source=app&utm_medium=referral&utm_campaign=trigger-inlinedoc\" target=\"_blank\">Triggers</a></strong> in unserer Dokumentation.",
-        "title": "Ihr flow hat keine Trigger."
-      },
-      "variables": {
-        "content": "Fügen Sie kv store-Paare hinzu, um Konfigurationen über flows hinweg zu teilen. Untergeordnete namespaces erben sie automatisch, und Sie können jeden Wert mit referenzieren.",
-        "title": "Noch keine Variablen vorhanden"
-      },
-      "versionPlugin": {
-        "content": "Hier können Sie alle Plugins verwalten, die auf Ihrer Kestra-Instanz installiert sind. Neu installierte Plugins sind möglicherweise nicht sofort in allen Kestra-Diensten verfügbar, abhängig von der Konfiguration Ihrer Instanz.",
-        "title": "Sie haben noch kein versioniertes Plugin!"
-      },
-      "workerRegistrationTokens": {
-        "content": "Registrierungstoken ermöglichen es Remote-Workern, sich sicher zu authentifizieren und bei Ihrer Kestra-Instanz zu registrieren. Erstellen Sie ein Token und verwenden Sie es, um neue Worker mit diesem Cluster zu verbinden.",
-        "title": "Sie haben noch keine Registrierungstoken!"
-      }
-    },
-    "empty search": "Suchergebnisse sind leer",
-    "enable": "Aktivieren",
-    "enable concurrency": "Nebenläufigkeit aktivieren",
-    "enabled": "Aktiviert",
-    "encoding": "Kodierung",
-    "end date": "Enddatum",
-    "end datetime": "Enddatum und -zeit",
-    "environment": "Umgebung",
-    "environment color setting": "Umgebungsfarbe",
-    "environment name setting": "Umgebungsname",
-    "error": "Fehler",
-    "error detected": "Fehler erkannt.",
-    "error in editor": "Ein Fehler wurde im Editor gefunden",
-    "errorLogs": "Fehlerprotokolle",
-    "errors": {
-      "401": {
-        "content": "Sie müssen authentifiziert sein, um auf diese Seite zuzugreifen.",
-        "title": "Unbefugt"
-      },
-      "403": {
-        "content": "Sie haben nicht die erforderlichen Berechtigungen, um auf diese Seite zuzugreifen.",
-        "title": "Zugriff verweigert"
-      },
-      "404": {
-        "content": "Die angeforderte URL wurde auf diesem Server nicht gefunden.<br />Das ist alles, was wir wissen.",
-        "flow or execution": "Der Flow oder die Ausführung, die Sie suchen, existiert nicht.",
-        "title": "Seite nicht gefunden"
-      }
-    },
+    "change execution state confirm": "Sind Sie sicher, dass Sie den Zustand der Ausführung <code>{id}</code> ändern möchten?",
+    "change execution state done": "Ausführungszustand aktualisiert",
+    "mark as": "Als <code>{status}</code> markieren",
+    "unqueue as": "Aus der Warteschlange entfernen als <code>{status}</code>",
+    "kill": "Beenden",
+    "kill parents and subflow": "Aktuelle und Subflows beenden",
+    "kill only parents": "Nur aktuellen beenden",
+    "killed confirm": "Sind Sie sicher, dass Sie die Ausführung <code>{id}</code> beenden möchten?",
+    "killed done": "Ausführung ist zum Beenden eingereiht",
+    "resume": "Fortsetzen",
+    "resumed title": "Ausführung <code>{id}</code> fortsetzen",
+    "resumed confirm": "Sind Sie sicher, dass Sie die Ausführung <code>{id}</code> fortsetzen möchten?",
+    "resumed done": "Ausführung ist fortgesetzt",
+    "resume from breakpoint title": "Ausführung `<code>{id}</code>` vom Haltepunkt fortsetzen",
+    "resume from breakpoint done": "Ausführung wird vom Breakpoint fortgesetzt",
+    "breakpoints": "Haltepunkte",
+    "pause": "Pause",
+    "pause title": "Ausführung <code>{id}</code> pausieren.<br/>Bitte beachten Sie, dass derzeit laufende Tasks weiterhin verarbeitet werden und die Ausführung manuell fortgesetzt werden muss.",
+    "pause confirm": "Sind Sie sicher, dass Sie die Ausführung <code>{id}</code> pausieren möchten?",
+    "pause done": "Die Ausführung ist PAUSED.",
+    "unqueue": "Aus Warteschlange entfernen",
+    "unqueue title": "Ausführung <code>{id}</code> aus der Warteschlange entfernen.<br/>Bitte beachten Sie, dass dies das Nebenläufigkeitslimit des Flows nicht berücksichtigt, sodass mehr Ausführungen laufen könnten als das erlaubte Limit.",
+    "unqueue title multiple": "Sind Sie sicher, dass Sie <code>{count}</code> Ausführungen aus der Warteschlange entfernen möchten?<br/><br/>Beachten Sie, dass dies das Nebenläufigkeitslimit des flow nicht beachtet, sodass mehr Ausführungen laufen könnten als das erlaubte Limit.",
+    "unqueue confirm": "Sind Sie sicher, dass Sie die Ausführung <code>{id}</code> aus der Warteschlange entfernen möchten?",
+    "unqueue done": "Ausführung ist nicht in der Warteschlange",
+    "force run": "Erzwungene Ausführung",
+    "force run title": "Erzwinge die Ausführung <code>{id}</code>.",
+    "force run tooltip": "Erzwingen Sie die Ausführung. Es kann zu doppelten Task-Ausführungen führen; verwenden Sie nach Möglichkeit eine andere Aktion.",
+    "force run confirm": "Sind Sie sicher, dass Sie die Ausführung <code>{id}</code> erzwingen möchten?<br/><br/>WARNING: Das Erzwingen einer Ausführung ist nicht garantiert und kann doppelte Task-Ausführungen erzeugen.<br/><br/>Die folgenden Übergänge werden durchgeführt:<br/><ul><li>CREATED Tasks werden in den RUNNING Zustand versetzt.</li><li>RUNNING Tasks werden erneut eingereicht.</li><li>QUEUED Tasks werden aus der Warteschlange entfernt.</li><li>PAUSED Tasks werden fortgesetzt.</li></ul>",
+    "force run done": "Ausführung ist erzwungener Lauf",
+    "toggle output": "Outputs umschalten",
+    "metrics": "Metriken",
+    "no data current task": "Für die aktuelle Task sind keine Daten verfügbar.",
+    "no metrics available": "Für diesen Task-Lauf wurden keine Metriken aufgezeichnet.",
+    "no outputs available": "Keine Outputs für diesen Task Run verfügbar.",
+    "outputs": "Outputs",
+    "flow_outputs": "Flow Outputs",
+    "no_flow_outputs": "Keine Outputs verfügbar.",
+    "output": "Output",
     "eval": {
-      "expression": "Ausdruck",
-      "preview": "Vorschau",
-      "render": "Ausdruck rendern",
       "title": "Debug-Ausdruck",
-      "tooltip": "Beliebigen Pebble-Ausdruck rendern und den Ausführungskontext inspizieren."
+      "render": "Ausdruck rendern",
+      "tooltip": "Beliebigen Pebble-Ausdruck rendern und den Ausführungskontext inspizieren.",
+      "preview": "Vorschau",
+      "expression": "Ausdruck"
     },
-    "evaluation lock date": "Evaluationssperrdatum",
-    "execute": "Ausführen",
-    "execute backfill": "Backfill ausführen",
-    "execute flow behaviour": "Den Flow ausführen",
-    "execute flow now ?": "Möchten Sie diesen Flow ausführen?",
-    "execute the flow": "Den Flow <code>{id}</code> ausführen",
-    "execution": "Ausführung",
-    "execution already finished": "Ausführung <code>{executionId}</code> bereits abgeschlossen",
-    "execution id": "Ausführungs-ID",
-    "execution labels": "Ausführungs-Labels",
-    "execution not found": "Ausführung {executionId} wurde nicht gefunden.",
-    "execution not in state FAILED": "Ausführung <code>{executionId}</code> nicht im Zustand FAILED",
-    "execution not in state PAUSED": "Ausführung <code>{executionId}</code> nicht im Zustand PAUSED",
-    "execution replay": "Diese Ausführung ist eine Wiederholung von",
-    "execution replayed": "Diese Ausführung wurde erneut abgespielt.",
-    "execution restarted": "Diese Ausführung wurde {nbRestart} Mal neu gestartet.",
+    "attempt": "Versuch",
+    "toggle output display": "Outputanzeige umschalten",
+    "name": "Name",
+    "key": "Key",
+    "value": "Value",
+    "each value": "Iterationswert",
+    "current execution": "Aktuelle Ausführung",
+    "parent execution": "Elternausführung",
+    "original execution": "Originalausführung",
+    "automatic refresh": "Automatische Aktualisierung",
+    "toggle periodic refresh each x seconds": "Periodische Aktualisierung alle {interval} Sekunden umschalten",
+    "trigger refresh": "Aktualisierung auslösen",
+    "add-trigger-in-editor": "Fügen Sie zuerst einen Trigger zu Ihrem Flow hinzu",
+    "refresh": "Aktualisieren",
+    "filter by status": "Filtere Ausführungen nach {status} Status",
+    "topology-graph": {
+      "graph-orientation": "Graph-Ausrichtung",
+      "zoom-in": "Vergrößern",
+      "zoom-out": "Verkleinern",
+      "zoom-reset": "Zoom zurücksetzen",
+      "zoom-fit": "Anpassen",
+      "invalid": "Graph-Fehler",
+      "invalid_description": "Beim Laden des Graphen ist ein Fehler aufgetreten. Bitte überprüfen Sie den Quellcode auf Fehler."
+    },
+    "show task logs": "Task Logs anzeigen",
+    "show task condition": "Bedingung des Tasks anzeigen",
+    "show task outputs": "Task-Outputs anzeigen",
+    "show task source": "Task-Quelle anzeigen",
+    "specific task": "Spezifischer Task",
+    "display output for specific task": "Output für einen spezifischen Task anzeigen",
+    "display metric for specific task": "Metrik für einen spezifischen Task anzeigen",
+    "display direct sub tasks count": "Direkte Subtask-Anzahl anzeigen",
+    "stream": "Stream",
     "execution statistics": "Ausführungsstatistiken",
-    "execution-include-non-terminated": "Nicht beendete Ausführungen einbeziehen?",
-    "execution-warn-deleting-still-running": "Wir empfehlen dringend, diese Aktion abzubrechen und alle laufenden Ausführungen zuerst zu beenden. Das Löschen nicht beendeter Ausführungen kann zu Nebenläufigkeitsproblemen, Inkonsistenzen im Flow-Abhängigkeitsmanagement und Zombie-Prozessen auf Ihrer Instanz führen, was die Systemleistung beeinträchtigen kann. Stellen Sie sicher, dass Sie diese Risiken vollständig verstehen, bevor Sie mit dem Löschen fortfahren.",
-    "execution-warn-title": "Wichtige Warnung!",
-    "execution_deletion": {
-      "logs": "Logs löschen",
-      "metrics": "Metriken löschen",
-      "storage": "Interne Speicherdateien löschen"
-    },
-    "execution_failed": "Ausführung fehlgeschlagen!",
-    "execution_guide": {
-      "get_started": {
-        "text": "Befolgen Sie den Quickstart-Guide, um Kestra zu installieren und mit dem Erstellen Ihrer ersten Workflows zu beginnen.",
-        "title": "Loslegen ⚡"
-      },
-      "namespaces": {
-        "text": "Namespaces sind logische Gruppierungen von flows und deren Komponenten.",
-        "title": "Über Namespaces"
-      },
-      "videos_tutorials": {
-        "text": "Loslegen mit unseren Video-Tutorials.",
-        "title": "Videoanleitungen"
-      },
-      "workflow_components": {
-        "text": "Lernen Sie die Hauptkomponenten der Orchestrierung eines Kestra-Workflows kennen.",
-        "title": "Workflow-Komponenten"
-      }
-    },
-    "execution_started": "Die Ausführung hat begonnen!",
-    "execution_starts_progress": "Sobald die Ausführung beginnt, sehen Sie hier Fortschrittsaktualisierungen.",
-    "execution_status": "Die Ausführung ist:",
-    "executions": "Ausführungen",
-    "executions deleted": "<code>{executionCount}</code> Ausführung(en) gelöscht",
+    "stats": "Statistiken",
+    "concurrency limits": "Nebenläufigkeitsgrenzen",
+    "system overview": "Systemübersicht",
+    "usage": "Verwendung",
+    "namespaces": "Namespaces",
+    "tasks": "Tasks",
     "executions duration (in minutes)": "Gesamte Ausführungsdauer (in Minuten)",
-    "executions force run": "<code>{executionCount}</code> Ausführung(en) erzwungener Lauf",
-    "executions killed": "<code>{executionCount}</code> Ausführung(en) beendet",
-    "executions paused": "<code>{executionCount}</code> Ausführung(en) PAUSED",
-    "executions replayed": "<code>{executionCount}</code> Ausführung(en) erneut abgespielt",
-    "executions restarted": "<code>{executionCount}</code> Ausführung(en) neu gestartet",
-    "executions resumed": "<code>{executionCount}</code> Ausführung(en) fortgesetzt",
-    "executions state changed": "Der Zustand von <code>{executionCount}</code> Ausführung(en) wurde geändert",
-    "executions unqueue": "<code>{executionCount}</code> Ausführung(en) aus der Warteschlange entfernen",
-    "expand": "Ausklappen",
-    "expand all": "Alle ausklappen",
-    "expand dependencies": "Abhängigkeiten ausklappen",
-    "expand error": "Nur fehlgeschlagene Tasks ausklappen",
-    "expand_by_default": "Expand structured logs by default",
-    "expiration": "Ablauf",
-    "expiration date": "Ablaufdatum",
-    "export": "Exportieren",
-    "export all flows": "Alle Flows exportieren",
-    "export all templates": "Alle Vorlagen exportieren",
-    "export_as": "Als .{format} exportieren",
-    "export_csv": "Als CSV exportieren",
-    "exports": "Exporte",
-    "failed to export plugin defaults": "Fehler beim Exportieren der Plugin-Standardeinstellungen",
-    "failed to import plugin defaults": "Fehler beim Importieren der Plugin-Standardeinstellungen",
-    "failed to render pdf": "PDF-Vorschau konnte nicht gerendert werden",
-    "false": "Falsch",
-    "feeds": {
-      "heading": "Alles rund um Kestra.",
-      "subheading": "Die neuesten Updates, Anleitungen und Geschichten",
-      "title": "Was gibt's Neues bei Kestra"
+    "last 48 hours": "letzte 48 Stunden",
+    "configure basic auth": "Basis-Authentifizierung konfigurieren",
+    "email": "E-Mail",
+    "password": "Passwort",
+    "confirm password": "Passwort bestätigen",
+    "email length constraint": "E-Mail darf 256 Zeichen nicht überschreiten",
+    "password length constraint": "Passwort darf 256 Zeichen nicht überschreiten",
+    "password empty constraint": "Falscher Benutzername oder Passwort",
+    "passwords do not match": "Passwörter stimmen nicht überein",
+    "avg duration": "Durchschnittliche Ausführungsdauer",
+    "neutral trend": "Stabil",
+    "up trend": "Steigend",
+    "down trend": "Sinkend",
+    "update aborted": "Aktualisierung abgebrochen",
+    "invalid flow": "Ungültiger Flow",
+    "invalid yaml": "Ungültiges YAML",
+    "inputs": "Inputs",
+    "no_inputs": "Keine Inputs verfügbar.",
+    "input": "Input",
+    "variables": "Variablen",
+    "variable_explorer": {
+      "title": "Eingabe/Ausgabe",
+      "search_placeholder": "Key oder value suchen...",
+      "tasks_outputs": "Tasks outputs",
+      "tree": "Baum",
+      "raw_json": "Raw JSON",
+      "select_prompt": "Wählen Sie eine Variable aus, um ihren value anzuzeigen.",
+      "empty": "Keine Variablen für diese Ausführung verfügbar.",
+      "one_key": "\\{ 1 key \\}",
+      "n_keys": "\\{ {count} keys \\}",
+      "one_item": "[ 1 Element ]",
+      "n_items": "[ {count} Elemente ]"
     },
-    "file preview truncated": "Angezeigter Inhalt wurde abgeschnitten",
-    "file unavailable": "Datei nicht verfügbar",
-    "file unavailable description": "Diese Datei ist nicht mehr verfügbar – sie wurde möglicherweise gelöscht oder ist abgelaufen.",
-    "fileTypeNotAllowed": "Dateityp nicht erlaubt. Akzeptierte Typen: {types}",
     "file_preview": {
       "big_file_warning": "Diese Datei ist {size}. Es kann eine Weile dauern, sie zu laden, was Ihren Browser blockieren könnte. Möchten Sie sie trotzdem laden?",
       "load_anyway": "Trotzdem laden"
     },
-    "files": "Dateien",
-    "filter by log level": "Nach Log-Ebene filtern",
-    "filter by status": "Filtere Ausführungen nach {status} Status",
-    "filter by this value": "Filter by this value",
-    "filter_for": "Filter for",
-    "filter_out": "Filter out",
-    "filters": {
-      "comparators": {
-        "between": "zwischen",
-        "contains": "enthält",
-        "ends_with": "endet mit",
-        "greater_than": "größer als",
-        "greater_than_or_equal_to": "größer als oder gleich",
-        "in": "im",
-        "is": "ist",
-        "is_not": "ist nicht",
-        "is_one_of": "ist eine von",
-        "less_than": "weniger als",
-        "less_than_or_equal_to": "kleiner oder gleich",
-        "not_contains": "nicht enthält",
-        "not_in": "nicht in",
-        "starts_with": "beginnt mit"
-      },
-      "empty": "Keine Daten.",
-      "format": "Geben Sie den Parameter als 'key:value' ein",
-      "label": "Filter auswählen",
-      "options": {
-        "absolute_date": "Absolutes Datum",
-        "action": "Aktion",
-        "aggregation": "Aggregation",
-        "child": "Kind",
-        "details": "Details",
-        "endDate": "Enddatum",
-        "flow": "Flow",
-        "labels": "Labels",
-        "level": "Log-Ebene",
-        "metric": "Metrik",
-        "namespace": "Namespace",
-        "permission": "Berechtigung",
-        "relative_date": "Relatives Datum",
-        "scope": "Umfang",
-        "service_type": "Typ",
-        "startDate": "Startdatum",
-        "state": "Zustand",
-        "status": "Status",
-        "task": "Aufgabe",
-        "text": "I'm sorry, but it seems that there is no text provided after \"----------\" for translation. Could you please provide the text you would like me to translate?",
-        "type": "Typ",
-        "user": "Benutzer"
-      },
-      "save": {
-        "dialog": {
-          "confirmation": "Suchkriterien <code>{name}</code>",
-          "heading": "Aktuelle Suche speichern",
-          "hint": "Wie möchten Sie dieses Suchkriterium labeln?",
-          "placeholder": "Label"
-        },
-        "empty": "Sie haben noch keine Suche gespeichert.",
-        "label": "Gespeicherte Suchen",
-        "name_already_used": "Suchbegriff {label} bereits verwendet.",
-        "remove": "Entfernen",
-        "tooltip": "Sie können keine leeren Suchkriterien speichern."
-      },
-      "settings": {
-        "label": "Seiteneinstellungen",
-        "show_chart": "Hauptdiagramm anzeigen"
-      },
-      "text_search": "Nach diesem Text suchen"
-    },
-    "fix_with_ai": "Mit KI beheben",
-    "flow": "Flow",
-    "flow already exists": "Flow existiert bereits",
-    "flow already exists message": "Flow <code>{id}</code> existiert bereits im namespace <code>{namespace}</code>. Möchten Sie eine neue Revision erstellen?",
-    "flow creation": "Flow-Erstellung",
-    "flow creation denied in namespace": "Sie haben keine Berechtigung, Flows im Namespace `{namespace}` zu erstellen.",
-    "flow delete": "Sind Sie sicher, dass Sie <code>{flowCount}</code> Flow(s) löschen möchten?",
-    "flow deleted, you can restore it": "Der Flow wurde gelöscht und dies ist eine schreibgeschützte Ansicht. Sie können ihn dennoch wiederherstellen.",
-    "flow disable": "Sind Sie sicher, dass Sie <code>{flowCount}</code> Flow(s) deaktivieren möchten?",
-    "flow enable": "Sind Sie sicher, dass Sie <code>{flowCount}</code> Flow(s) aktivieren möchten?",
-    "flow export": "Sind Sie sicher, dass Sie <code>{flowCount}</code> Flow(s) exportieren möchten?",
-    "flow must have id and namespace": "Flow muss eine Id und einen Namespace haben.",
-    "flow must not be empty": "Flow darf nicht leer sein",
-    "flow not imported": "Einige Flows konnten nicht importiert werden",
-    "flow revision latest": "Neueste flow-Revision",
-    "flow revision original": "Ursprüngliche flow-Revision",
-    "flow revision specific": "Spezifische flow-Revision",
-    "flow source not found": "Flow-Quelle nicht gefunden",
-    "flow-dependencies": "Abhängigkeiten",
-    "flow-no-dependencies": "Ihr Flow hat keine Abhängigkeiten.",
-    "flow_editor_stats": {
-      "apps": {
-        "suffix": "App(s)",
-        "tooltip": "Apps anzeigen, die diesen flow verwenden"
-      },
-      "dependencies": {
-        "suffix": "Abhängigkeiten",
-        "tooltip": "Flow-Abhängigkeiten anzeigen"
-      },
-      "errors": {
-        "label": "{count} Fehler"
-      },
-      "revisions": {
-        "suffix": "Revision(en)",
-        "tooltip": "Flow-Revisionen anzeigen"
-      },
-      "tests": {
-        "suffix": "Test(s)",
-        "tooltip": "Flow-Tests anzeigen"
-      }
-    },
-    "flow_export": "Flow exportieren",
-    "flow_only": "Nur auf der Flow-Registerkarte verfügbar.",
-    "flow_outputs": "Flow Outputs",
-    "flows": "Flows",
-    "flows deleted": "<code>{count}</code> Flow(s) gelöscht",
-    "flows disabled": "<code>{count}</code> Flow(s) deaktiviert",
-    "flows enabled": "<code>{count}</code> Flow(s) aktiviert",
-    "flows exported": "<code>{count}</code> Flow(s) exportiert",
-    "flows imported": "Flows importiert",
-    "focus task": "Klicken Sie auf ein Element, um dessen Dokumentation zu sehen.",
-    "fold_all_multi_lines": "Alle Mehrzeiligen Einklappen",
-    "font size": "Font size",
-    "for flow": "für Flow",
-    "forbidden system labels": "Nur system.correlationId kann als System-Label verwendet werden",
-    "force run": "Erzwungene Ausführung",
-    "force run confirm": "Sind Sie sicher, dass Sie die Ausführung <code>{id}</code> erzwingen möchten?<br/><br/>WARNING: Das Erzwingen einer Ausführung ist nicht garantiert und kann doppelte Task-Ausführungen erzeugen.<br/><br/>Die folgenden Übergänge werden durchgeführt:<br/><ul><li>CREATED Tasks werden in den RUNNING Zustand versetzt.</li><li>RUNNING Tasks werden erneut eingereicht.</li><li>QUEUED Tasks werden aus der Warteschlange entfernt.</li><li>PAUSED Tasks werden fortgesetzt.</li></ul>",
-    "force run done": "Ausführung ist erzwungener Lauf",
-    "force run title": "Erzwinge die Ausführung <code>{id}</code>.",
-    "force run tooltip": "Erzwingen Sie die Ausführung. Es kann zu doppelten Task-Ausführungen führen; verwenden Sie nach Möglichkeit eine andere Aktion.",
-    "form": "Formular",
-    "form error": "Formularfehler",
-    "from": "Von",
-    "gantt": "Gantt",
-    "gantt_no_tasks_executed": "Diese Ausführung endete, ohne dass eine Task ausgeführt wurde. Überprüfen Sie die Übersicht und die Logs, um den Grund zu erfahren.",
-    "gantt_no_tasks_match_filters": "Versuchen Sie, die Such-, Zustands- oder Log-Ebenen-Filter anzupassen.",
-    "gantt_no_tasks_match_filters_title": "Keine Tasks entsprechen den ausgewählten Filtern.",
-    "healthcheck date": "HealthCheck-Datum",
-    "hide task documentation": "Task-Dokumentation ausblenden",
-    "home": "Startseite",
-    "hostname": "Hostname",
-    "iam": "IAM",
-    "id": "Id",
-    "import": "Importieren",
-    "in-our-documentation": "in unserer Dokumentation.",
-    "informative notice": "Hinweis(e)",
-    "input": "Input",
-    "inputs": "Inputs",
-    "instance": "Instanz",
-    "invalid bulk delete": "Ausführungen konnten nicht gelöscht werden",
-    "invalid bulk force run": "Konnte Ausführungen nicht erzwingen",
-    "invalid bulk kill": "Ausführungen konnten nicht beendet werden",
-    "invalid bulk pause": "Konnte Ausführungen nicht pausieren",
-    "invalid bulk replay": "Ausführungen konnten nicht erneut abgespielt werden",
-    "invalid bulk restart": "Ausführungen konnten nicht neu gestartet werden",
-    "invalid bulk resume": "Ausführungen konnten nicht fortgesetzt werden",
-    "invalid bulk unqueue": "Konnte Ausführungen nicht aus der Warteschlange entfernen",
-    "invalid field": "Ungültiges Feld: {name}",
-    "invalid flow": "Ungültiger Flow",
-    "invalid source": "Ungültiger Quellcode",
-    "invalid yaml": "Ungültiges YAML",
-    "is deprecated": "ist veraltet",
-    "is required": "{field} ist erforderlich",
-    "item": "Element",
-    "items": "Elemente",
-    "join community": "Community beitreten",
-    "join_slack": "Slack beitreten",
-    "jsonl": "JSONL",
-    "jump to...": "Springe zu...",
-    "kestra": "Kestra",
-    "key": "Key",
-    "kill": "Beenden",
-    "kill only parents": "Nur aktuellen beenden",
-    "kill parents and subflow": "Aktuelle und Subflows beenden",
-    "killed confirm": "Sind Sie sicher, dass Sie die Ausführung <code>{id}</code> beenden möchten?",
-    "killed done": "Ausführung ist zum Beenden eingereiht",
-    "kv": {
-      "add": "Erstellen",
-      "delete multiple": {
-        "confirm": "Möchten Sie wirklich <code>{name}</code> KV(s) löschen?",
-        "warning": "Du hast keine Berechtigungen für diese namespaces, daher werden sie ausgelassen: <code>{namespaces}</code>"
-      },
-      "duplicate": "Dieser Key existiert bereits",
-      "inherited": "Geerbte KV-Paare",
-      "name": "KV Store",
-      "type": "Typ",
-      "update": "Wert für Key '{key}' aktualisieren"
-    },
-    "label": "Label",
-    "label filter placeholder": "Label als 'key:value'",
-    "labels": "Labels",
-    "last 48 hours": "letzte 48 Stunden",
-    "last X days count": "{count} in den letzten {days} Tagen",
-    "last error was": "Letzter Fehler war",
-    "last evaluation date": "Letztes Bewertungsdatum",
-    "last evaluation date tooltip": "When the trigger was last evaluated by the scheduler, regardless of whether it produced an execution.",
-    "last execution date": "Letztes Ausführungsdatum",
-    "last execution state": "Letzter Zustand",
-    "last execution status": "Letzter Ausführungsstatus",
-    "last modified": "Zuletzt geändert",
-    "last trigger date": "Letztes Trigger-Datum",
-    "last trigger date tooltip": "Wann der Trigger zuletzt ausgeführt wurde. Kann in der Vergangenheit liegen, wenn ein Backfill ausgeführt wird.",
-    "latest_update": "Letztes Update",
-    "launch execution": "Ausführen",
-    "learn_more": "Erfahren Sie mehr",
-    "leave page": "Seite verlassen",
-    "license": "Lizenz",
-    "light_background": "Dies ist die bevorzugte Option bei der Arbeit mit einem hellen Hintergrund.",
-    "light_version": "Helle Version",
-    "line": "Linie",
-    "line-by-line": "Zeile für Zeile",
-    "loaded x dependencies": "{count} Abhängigkeiten geladen",
-    "loading": "Wird geladen...",
-    "log expand setting": "Log-Standardanzeige",
-    "logExporters": "Log-Exporteure",
-    "logs": "Logs",
-    "logs_copied": "Logs copied to your clipboard",
-    "logs_view": {
-      "compact": "Standardansicht",
-      "compact_details": "Task Logs in einer kompakten Ansicht, gruppiert nach jedem Task, anzeigen",
-      "raw": "Temporale Ansicht",
-      "raw_details": "Vollständige Task Logs und Flow Logs in einem rohen, nach Zeitstempel geordneten Format anzeigen"
-    },
-    "main_configuration": "Hauptkonfiguration",
-    "manage labels": "Labels verwalten",
-    "management port": "Management-Port",
-    "mark as": "Als <code>{status}</code> markieren",
-    "max": "Max",
-    "mcp": {
-      "api_token": "API-Token",
-      "auth_type": "Authentifizierung",
-      "basic_auth": "Basis-Authentifizierung",
-      "bearer_token": "Authentifizierung mit Bearer-Token",
-      "client_setup": "Client-Einrichtung",
-      "connect": "Verbinden",
-      "connect_tab": {
-        "auth_api_token_hint": "Setzen Sie <code>KESTRA_TOKEN</code> als Umgebungsvariable, bevor Sie den Client starten.",
-        "auth_basic_hint": "Setzen Sie <code>KESTRA_BASIC_AUTH</code> als Umgebungsvariable, die einen base64-kodierten <code>username:password</code>-String enthält, bevor Sie den Client starten.",
-        "auth_oauth_browser_hint": "Ihr Browser öffnet beim ersten Verbindungsaufbau die Anmeldeseite des Identitätsanbieters.",
-        "auth_oauth_client_id_hint": "Ersetzen Sie <code>&lt;client-id&gt;</code> durch die OAuth-Client-ID und registrieren Sie <code>http://localhost:7777</code> als gültige Weiterleitungs-URI auf diesem Client.",
-        "claude_code": "Claude-Code",
-        "claude_code_hint": "Führen Sie den folgenden Befehl in Ihrem Terminal aus:",
-        "claude_desktop": "Claude Desktop",
-        "claude_desktop_hint": "Fügen Sie Folgendes zu Ihrer claude_desktop_config.json-Datei hinzu:",
-        "claude_desktop_mac": "macOS: ~/Library/Application Support/Claude/claude_desktop_config.json",
-        "claude_desktop_win": "Windows: %APPDATA%\\Claude\\claude_desktop_config.json",
-        "client_picker_label": "Wählen Sie Ihren KI-Client",
-        "codex": "Codex (OpenAI)",
-        "codex_hint": "Fügen Sie Folgendes zu Ihrer codex.json MCP-Konfiguration hinzu:",
-        "cursor": "Cursor",
-        "cursor_hint": "Fügen Sie Folgendes zu ~/.cursor/mcp.json hinzu:",
-        "server_url": "Server-URL"
-      },
-      "copy_url": "URL kopieren",
-      "create": "Server erstellen",
-      "delete_confirm": "Möchten Sie diesen MCP-Server wirklich löschen?",
-      "id_invalid": "Die ID muss mit einem Kleinbuchstaben oder einer Ziffer beginnen und darf nur Kleinbuchstaben, Ziffern, Bindestriche oder Unterstriche enthalten.",
-      "id_placeholder": "z.B. mein-mcp-server",
-      "instructions": "Anweisungen",
-      "main_tenant": "Haupt",
-      "managed_by_kestra": "Verwaltet von Kestra",
-      "no_oauth_providers": "Keine OIDC-Anbieter in dieser Instanz konfiguriert",
-      "no_servers": "Keine MCP-Server gefunden. Erstellen Sie Ihren ersten Server, um MCP Tool Trigger für externe KI-Agenten bereitzustellen.",
-      "oauth": "OAuth",
-      "oauth_hint": "Bearer JWT von Ihrem OIDC-Anbieter",
-      "oauth_provider": "OAuth-Anbieter",
-      "oauth_provider_placeholder": "Wählen Sie einen konfigurierten OIDC-Anbieter",
-      "oauth_provider_required": "OAuth-Anbieter ist erforderlich, wenn der Authentifizierungstyp OAuth ist",
-      "page_description": "Stellen Sie Ihre Kestra flows als Werkzeuge für MCP-kompatible KI-Agenten bereit",
-      "private": "Privat",
-      "private_server": "Privater Server",
-      "public": "Öffentlich",
-      "public_hint": "Warnung: Öffentliche Server erfordern keine Authentifizierung. Jeder mit der URL kann jedes Tool aufrufen, das von diesem Server bereitgestellt wird, ohne namespace- oder Berechtigungsprüfungen. Nur für Server verwenden, die sicher extern zugänglich gemacht werden können.",
-      "save": "Änderungen speichern",
-      "scopes_supported": "Unterstützte Scopes",
-      "scopes_supported_hint": "Scopes, die im Protected Resource Metadata-Dokument dieses Servers angekündigt werden. Spezifikationskonforme MCP-Clients beschränken ihre Autorisierungsanfragen auf diese Liste. Leer lassen, um das Feld auszulassen und den Clients die vom IdP angekündigten Scopes zu verwenden.",
-      "scopes_supported_placeholder": "openid, profile, email",
-      "server": "MCP-Server",
-      "server_id": "Server-ID",
-      "server_type": "Servertyp",
-      "servers": "MCP-Server",
-      "servers_count": "{count} MCP-Server",
-      "tab_connect": "Verbinden",
-      "tab_edit": "Bearbeiten",
-      "tab_tool_flows": "Tool-Flows",
-      "tab_tool_flows_placeholder": "Das Management von Tool flows kommt bald.",
-      "tools": {
-        "annotations": "Anmerkungen",
-        "create_tool_flow": "Erstelle einen Tool flow",
-        "description": "Beschreibung",
-        "destructive": "Destruktiv",
-        "flow": "flow",
-        "idempotent": "Idempotent",
-        "no_tools": "Keine Tool-Flows entsprechen Ihrer Suche.",
-        "open_world": "Open world",
-        "read_only": "Schreibgeschützt",
-        "return_direct": "Direktrückgabe",
-        "state": "Zustand",
-        "title": "Titel",
-        "tool_name": "Tool-Name",
-        "trigger_id": "Trigger-ID",
-        "view_flow": "flow öffnen"
-      },
-      "url_copied": "URL kopiert!",
-      "username_password": "Benutzername & Passwort",
-      "your_servers": "Ihre Server"
-    },
-    "metric": "Metrik",
-    "metric choice": "Keine Metriken für diesen flow verfügbar",
-    "metrics": "Metriken",
-    "min": "Min",
-    "missingSource": "Fehlende Quelle",
-    "modify inputs": "Eingaben ändern",
-    "modify_inputs": "Eingaben ändern",
-    "monogram": "Monogramm",
-    "more actions": "Weitere Aktionen",
-    "more_actions": "Weitere Aktionen",
-    "multi_panel_editor": {
-      "close_all_panels": "Alle Panels schließen",
-      "close_all_tabs": "Alle Registerkarten schließen",
-      "move_left": "Nach links verschieben",
-      "move_right": "Nach rechts verschieben"
-    },
-    "multiple saved done": "{name} wurde(n) gespeichert",
-    "name": "Name",
-    "namespace": "Namespace",
-    "namespace and id readonly": "Die Eigenschaften `namespace` und `id` können nicht geändert werden — sie sind jetzt auf ihre Anfangswerte gesetzt. Wenn Sie einen Flow umbenennen oder seinen Namespace ändern möchten, können Sie einen neuen Flow erstellen und den alten entfernen.",
-    "namespace files": {
-      "create": {
-        "file": "Datei erstellen",
-        "file_already_exists": "Eine Datei mit diesem Namen existiert bereits",
-        "file_conflicts_with_folder": "Ein Ordner mit diesem Namen existiert bereits",
-        "file_error": "Fehler beim Erstellen der Datei aufgetreten",
-        "folder": "Ordner erstellen",
-        "folder_already_exists": "Ein Ordner mit diesem Namen existiert bereits",
-        "folder_conflicts_with_file": "Eine Datei mit diesem Namen existiert bereits",
-        "folder_error": "Beim Erstellen des Ordners ist ein Fehler aufgetreten",
-        "label": "Erstellen"
-      },
-      "delete": {
-        "file": "Datei löschen",
-        "files": "Lösche {count} ausgewählte Dateien",
-        "folder": "Ordner löschen",
-        "folders": "Lösche {count} ausgewählte Ordner",
-        "label": "Löschen"
-      },
-      "dialog": {
-        "deletion": {
-          "confirm": "Bestätigen",
-          "file_single": "Möchten Sie die Datei <code>{name}</code> wirklich löschen?",
-          "files": "Möchten Sie wirklich <code>{count}</code> Datei(en) löschen?",
-          "folder_single": "Möchten Sie den Ordner <code>{name}</code> und alle seine Inhalte wirklich löschen?",
-          "folders": "Möchten Sie wirklich <code>{count}</code> Ordner und alle seine Inhalte löschen?",
-          "mixed": "Möchten Sie wirklich den Ordner <code>{folders}</code> und die Datei <code>{files}</code> löschen?",
-          "title": "Bestätigen Sie das Löschen des Inhalts"
-        },
-        "name": {
-          "file": "Name mit Erweiterung:",
-          "folder": "Ordnername:"
-        },
-        "parent_folder": "Übergeordneter Ordner:"
-      },
-      "export": "Namespace-Dateien exportieren",
-      "export_single": "Datei exportieren",
-      "filter": "Filter",
-      "import": {
-        "error": "Fehler beim Importieren der Datei(en)",
-        "files": "Dateien importieren",
-        "folder": "Ordner importieren",
-        "import": "Importieren",
-        "success": "Datei(en) erfolgreich importiert"
-      },
-      "new_file": "Neue Datei",
-      "no_items": {
-        "heading": "Noch keine Dateien in Ihrem Namespace gefunden.",
-        "paragraph": "Erstellen oder importieren Sie Dateien, um Code zwischen Flows in Ihrem Namespace zu teilen."
-      },
-      "no_selection": {
-        "description": "Wählen Sie eine Datei aus dem Baum aus, um ihren Inhalt anzuzeigen.",
-        "heading": "Keine Dateien ausgewählt"
-      },
-      "path": {
-        "copy": "Pfad kopieren",
-        "error": "Fehler beim Kopieren des Pfads in die Zwischenablage",
-        "success": "Pfad in die Zwischenablage kopiert"
-      },
-      "rename": {
-        "file": "Datei umbenennen",
-        "folder": "Ordner umbenennen",
-        "label": "Umbenennen",
-        "new_file": "Neuer Name mit Erweiterung:",
-        "new_folder": "Neuer Ordnername:"
-      },
-      "revisions": {
-        "history": "Versionsverlauf",
-        "restore": {
-          "success": "Dateirevision erfolgreich wiederhergestellt"
-        }
-      },
-      "toggle": {
-        "hide": "Namespace-Dateien ausblenden",
-        "show": "Namespace-Dateien anzeigen"
-      },
-      "tree": {
-        "collapse": "Alle Ordner einklappen",
-        "expand": "Alle Ordner ausklappen"
-      }
-    },
-    "namespace not allowed": "Namespace nicht erlaubt",
-    "namespace_editor": {
-      "close": {
-        "all": "Alle Registerkarten schließen",
-        "other": "Andere Registerkarten schließen",
-        "right": "Rechts schließen",
-        "tab": "Registerkarte schließen"
-      },
-      "empty": {
-        "create_message": "Sie können namespace-Dateien erstellen oder importieren.",
-        "title": "Derzeit keine Registerkarten geöffnet",
-        "video_message": "Sie können sich das Einführungsvideo für unseren Editor ansehen."
-      }
-    },
-    "namespaces": "Namespaces",
-    "neutral trend": "Stabil",
-    "new": "Neu",
-    "new version": "Neue Version {version} verfügbar!",
-    "next": "Weiter",
-    "next evaluation date": "Nächstes Bewertungsdatum",
-    "next evaluation date tooltip": "Wann der Trigger das nächste Mal basierend auf seinem Intervall ausgewertet wird. Nicht immer dasselbe wie das nächste Ausführungsdatum, wenn Bedingungen nicht erfüllt sind.",
-    "next execution date": "Nächstes Ausführungsdatum",
-    "next_execution": "Nächste Ausführung",
-    "no data current task": "Für die aktuelle Task sind keine Daten verfügbar.",
-    "no inputs": "Dieser Flow hat keine Inputs.",
-    "no metrics available": "Für diesen Task-Lauf wurden keine Metriken aufgezeichnet.",
-    "no outputs available": "Keine Outputs für diesen Task Run verfügbar.",
-    "no result": "Es gibt keine Ergebnisse anzuzeigen.",
-    "no revisions": "Keine Revisionen",
-    "no revisions found": "Es existiert nur eine Revision für diesen Flow",
-    "no-executions-view": {
-      "guidance_desc": "Benötigen Sie Unterstützung, um Ihren Flow auszuführen?",
-      "guidance_sub_desc": "Folgen Sie der Dokumentation für alle Informationen, die Sie benötigen.",
-      "namespace_guidance_desc": "Brauchen Sie Unterstützung bei der Verwaltung Ihres Namespace?",
-      "namespace_sub_title": "Führen Sie einen oder mehrere flows aus diesem namespace aus, um dieses Dashboard zu füllen.",
-      "sub_title": "Klicken Sie auf die Ausführen-Schaltfläche, um die erste Workflow-Ausführung zu starten.",
-      "title": "Beginnen Sie mit der Automatisierung mit"
-    },
-    "no_code": {
-      "add_field": "Hinzufügen {field}",
-      "adding": "+ {what} hinzufügen",
-      "adding_default": "+ Neuen Wert hinzufügen",
-      "clearSelection": "Auswahl aufheben",
-      "creation": {
-        "afterExecution": "Fügen Sie einen Block nach der Ausführung hinzu",
-        "charts": "Ein Diagramm hinzufügen",
-        "conditions": "Bedingung hinzufügen",
-        "default": "Hinzufügen",
-        "errors": "Einen Fehler-Handler hinzufügen",
-        "finally": "Fügen Sie einen Finally-Block hinzu",
-        "inputs": "Ein Eingabefeld hinzufügen",
-        "numerator": "Fügen Sie einen Zähler hinzu",
-        "pluginDefaults": "Fügen Sie ein Plugin-Default hinzu",
-        "tasks": "Aufgabe hinzufügen",
-        "triggers": "Füge einen Trigger hinzu",
-        "where": "Filtern Sie Ihre Daten"
-      },
-      "fields": {
-        "general": {
-          "checks": "Überprüfungen",
-          "concurrency": "Nebenläufigkeit",
-          "disabled": "Deaktiviert",
-          "labels": "Labels",
-          "listeners": "Listener",
-          "outputs": "Ausgaben",
-          "retry": "Wiederholen",
-          "sla": "SLA",
-          "taskDefaults": "Standardwerte für Tasks",
-          "updated": "Aktualisiert",
-          "variables": "Variablen",
-          "workerGroup": "Worker-Gruppe",
-          "workerSelector": "Worker-Selektor"
-        },
-        "main": {
-          "description": "Beschreibung",
-          "id": "Flow-ID",
-          "inputs": "Eingaben",
-          "namespace": "Namespace"
-        }
-      },
-      "labels": {
-        "label": "Label",
-        "no_code": "Kein Code-Editor",
-        "variable": "Variable",
-        "yaml": "YAML-Editor"
-      },
-      "remove": {
-        "cases": "Diesen Fall entfernen",
-        "default": "Diesen Eintrag entfernen"
-      },
-      "sections": {
-        "afterExecution": "Nach Ausführung",
-        "deprecated": "Veraltete Eigenschaften",
-        "errors": "Fehlerbehandler",
-        "finally": "Schließlich",
-        "pluginDefaults": "Plugin-Standardeinstellungen",
-        "tasks": "Aufgaben",
-        "triggers": "Trigger"
-      },
-      "select": {
-        "afterExecution": "Wählen Sie eine Task aus",
-        "charts": "Wählen Sie einen Diagrammtyp aus",
-        "conditions": "Wählen Sie eine Bedingung aus",
-        "default": "Wählen Sie einen Typ aus",
-        "errors": "Wählen Sie eine Task aus",
-        "finally": "Wählen Sie eine Task aus",
-        "inputs": "Wählen Sie einen Input-Feldtyp aus",
-        "numerator": "Wählen Sie einen Zähler aus",
-        "pluginDefaults": "Wählen Sie ein Plugin aus",
-        "task": "Wählen Sie eine Task aus",
-        "tasks": "Wählen Sie eine Task aus",
-        "triggers": "Wählen Sie einen Trigger aus",
-        "where": "Wählen Sie einen Filtertyp aus"
-      },
-      "toggle_pebble": "Pebble-Editor umschalten",
-      "unnamed": "Kein Name",
-      "version_oss_placeholder": "Entsperren Sie die Plugin-Versionierung mit der Enterprise Edition"
-    },
-    "no_data": "Es sieht so aus, als wäre hier noch nichts... bisher!<br/>Passen Sie Ihre Filter an oder versuchen Sie es erneut!",
-    "no_file_choosen": "Keine Datei ausgewählt",
-    "no_flow_outputs": "Keine Outputs verfügbar.",
-    "no_history": "Keine Historie verfügbar",
-    "no_inputs": "Keine Inputs verfügbar.",
-    "no_logs_data": "Keine Daten",
-    "no_logs_data_description": "Bitte versuchen Sie, Ihre Filter anzupassen, den Zeitraum zu ändern oder überprüfen Sie, ob der flow kürzlich ausgeführt wurde.",
-    "no_logs_data_title": "Keine Logs für die ausgewählten Filter gefunden.",
-    "no_namespaces": "Keine Namespaces entsprechen den Suchkriterien.",
-    "no_results": {
-      "assets": "Keine Assets gefunden",
-      "executions": "Keine Ausführungen gefunden",
-      "flows": "Keine Flows gefunden",
-      "kv_pairs": "Keine Key-Value-Paare gefunden",
-      "secrets": "Keine Secrets gefunden",
-      "templates": "Keine Vorlagen gefunden",
-      "triggers": "Keine Trigger gefunden"
-    },
-    "no_results_found": "Keine Ergebnisse gefunden",
-    "no_tasks_running": "Noch keine Tasks laufen.",
-    "no_trigger": "Kein Trigger verfügbar.",
     "no_variables": "Keine Variablen verfügbar.",
-    "now": "Jetzt",
-    "of": "von",
-    "ok": "OK",
-    "onboarding": {
-      "actions": {
-        "cancel_tutorial": "Tutorial abbrechen",
-        "complete": "Abschließen",
-        "edit_flow_to_continue": "Klicken Sie oben rechts in der Leiste auf „Flow bearbeiten“.",
-        "execute_to_continue": "1. Klicken Sie oben rechts in der Leiste auf „Ausführen“.\n2. Geben Sie einen Wert für <strong>name</strong> an.\n3. Klicken Sie im Dialog erneut auf „Ausführen“.",
-        "finish_tutorial": "Tutorial beenden",
-        "next": "Weiter",
-        "save_to_continue": "Klicken Sie oben rechts in der Leiste auf „Speichern“."
-      },
-      "cancel_modal": {
-        "confirm": "Tutorial abbrechen",
-        "description": "Möchten Sie das Tutorial „Erster Flow“ abbrechen?",
-        "keep": "Tutorial fortsetzen",
-        "title": "Tutorial „Erster Flow“ abbrechen"
-      },
-      "editor_hints": {
-        "build_intro": "Erstellen Sie Ihren ersten Flow Schritt für Schritt.",
-        "step_1": "# 1) ID hinzufügen",
-        "step_2": "# 2) Namespace hinzufügen",
-        "step_3": "# 3) Eingabe hinzufügen",
-        "step_4": "# 4) Tasks hinzufügen und Ihren ersten Python-Task erstellen",
-        "step_5": "# 5) Cron-Trigger hinzufügen"
-      },
-      "finish_actions": {
-        "create_flow": "Flow erstellen",
-        "explore_blueprints": "Blueprints entdecken"
-      },
-      "steps": {
-        "add_cron_trigger": {
-          "description": "Trigger können Läufe anhand von Zeitplänen oder externen Ereignissen starten (z. B. Webhooks oder MQTT-Nachrichten).<br><br>Fügen Sie nun einen Cron-Schedule-Trigger hinzu, damit dieser Flow alle 5 Minuten ausgeführt wird.",
-          "title": "Cron-Trigger hinzufügen"
-        },
-        "add_id": {
-          "description": "Die ID ist der eindeutige Name Ihres Flows, damit Sie ihn finden, ausführen und konsistent referenzieren können.<br><br>Fügen Sie nun <code>id</code> auf der Root-Ebene hinzu.",
-          "title": "Flow-ID hinzufügen"
-        },
-        "add_input": {
-          "description": "Inputs sind Flow-Parameter, die innerhalb von Tasks referenziert werden können, um das Verhalten zur Laufzeit dynamisch zu steuern.<br><br>Fügen Sie nun einen Input namens <code>name</code> mit dem Typ <code>STRING</code> hinzu.",
-          "title": "Eingabe hinzufügen"
-        },
-        "add_input_default": {
-          "description": "Wenn ein Flow automatisch ausgelöst wird, benötigen Inputs trotzdem Werte zur Laufzeit.<br><br>Der Input <code>name</code> wurde bereits im vorherigen Schritt erstellt, daher müssen Sie ihn nicht erneut hinzufügen. Setzen Sie einfach einen Standardwert für den bestehenden Input <code>name</code>.",
-          "title": "Standardwert für Input setzen"
-        },
-        "add_log_task": {
-          "description": "Tasks sind die Arbeitseinheiten, die Ihr Flow ausführt. Sie werden als geordnete Liste von Schritten definiert. Jeder Task benötigt eine eindeutige <code>id</code> und einen <code>type</code>. Kestra bietet viele Task-Plugins für externe Systeme; hier verwenden wir einen Python-Script-Task.<br><br>Die Syntax <code>&#123;&#123; ... &#125;&#125;</code> ist ein Pebble-Ausdruck, um Variablen zur Laufzeit dynamisch zu referenzieren, z. B. <code>&#123;&#123; inputs.name &#125;&#125;</code> aus Ihren Flow-Inputs.<br><br>Fügen Sie nun den ersten Task unter <code>tasks</code> hinzu – mit <code>id</code>, <code>type</code> und einem <code>script</code>, das eine Begrüßung ausgibt.",
-          "title": "Ersten Task hinzufügen"
-        },
-        "add_namespace": {
-          "description": "Der Namespace ist eine ordnerähnliche Gruppierung, die Flows nach Team, Projekt oder Umgebung organisiert.<br><br>Fügen Sie nun <code>namespace</code> auf der Root-Ebene hinzu.",
-          "title": "Namespace hinzufügen"
-        },
-        "background_runs_info": {
-          "description": "Dieser Flow wird nun alle 5 Minuten im Hintergrund ausgeführt.<br><br>Sie können über das linke Menü zur Übersicht „Ausführungen“ navigieren, um geplante Runs zu überwachen.",
-          "title": "Geplante Ausführungen"
-        },
-        "edit_flow_from_execution": {
-          "description": "Sie können direkt aus einer Ausführung zurück zur Flow-Definition springen, um schnell weiter zu iterieren.",
-          "title": "Zurück zum Flow-Editor"
-        },
-        "execute_flow": {
-          "description": "Durch das Ausführen starten Sie einen Lauf Ihres Flows mit Eingabewerten zur Laufzeit.",
-          "title": "Flow ausführen"
-        },
-        "finish": {
-          "description": "Guter Start. Sie haben einen Flow erstellt, ausgeführt, parametrisiert und geplant.<br><br>Wählen Sie als Nächstes aus, was Sie tun möchten ...",
-          "title": "Sie haben das Tutorial „Erster Flow“ abgeschlossen"
-        },
-        "flow_basics": {
-          "description": "In Kestra ist ein <code>flow</code> die zentrale Orchestrierungseinheit. Sie definieren ihn in YAML mit Metadaten und geordneten Tasks.<br><br>Sehen Sie sich die Beispielstruktur unten an und erstellen Sie sie anschließend Schritt für Schritt.",
-          "title": "Flow-Grundlagen"
-        },
-        "save_flow": {
-          "description": "Durch das Speichern wird Ihre Flow-Definition dauerhaft gespeichert, damit sie ausgeführt werden kann.",
-          "title": "Flow speichern"
-        },
-        "save_flow_again": {
-          "description": "Ihr Flow hat jetzt einen Zeitplan und einen Standardwert für automatische Ausführungen.",
-          "title": "Flow speichern"
-        },
-        "view_logs_status": {
-          "description": "Ausführungsdetails zeigen den Status des Laufs, Zeitinformationen und Task-spezifische Ausgabelogs.<br><br>Öffnen Sie nun die Ausführungsdetails und klicken Sie im Gantt-Diagramm auf <code>greet</code>, um die Logs zu sehen.",
-          "title": "Ausführung prüfen"
-        }
-      },
-      "validation": {
-        "add_cron_trigger_cron": "Fügen Sie einen Cron-Ausdruck hinzu, z. B.: `\"*/5 * * * *\"`.",
-        "add_cron_trigger_section": "Erstellen Sie einen Abschnitt `triggers` mit einem Schedule-Trigger.",
-        "add_cron_trigger_type": "Setzen Sie den Trigger-Typ auf `io.kestra.plugin.core.trigger.Schedule`.",
-        "add_id": "Fügen Sie oben eine Flow-ID hinzu. Beispiel: `id: hello_flow`.",
-        "add_input_default_defaults": "Fügen Sie einen Standardwert für `name` hinzu, z. B.: `defaults: \"Kestra\"`.",
-        "add_input_default_id": "Behalten Sie die bestehende Input-ID als `name`.",
-        "add_input_default_section": "Gehen Sie zurück zu `inputs` und behalten Sie einen bestehenden Input namens `name` (fügen Sie keinen zweiten Input hinzu).",
-        "add_input_id": "Fügen Sie innerhalb von `inputs` `id: name` hinzu.",
-        "add_input_section": "Erstellen Sie einen Abschnitt `inputs` mit einem Input.",
-        "add_input_type": "Setzen Sie den Input-Typ auf `STRING`.",
-        "add_log_task_id": "Geben Sie dem Task eine ID, z. B.: `id: greet`.",
-        "add_log_task_message": "Fügen Sie dem Task ein Feld `script` hinzu.",
-        "add_log_task_pebble": "Verwenden Sie im Script einen Pebble-Ausdruck, damit Ihr Input-Wert genutzt wird (z. B.: `inputs.name`).",
-        "add_log_task_section": "Erstellen Sie einen Abschnitt `tasks` und fügen Sie Ihren ersten Task hinzu.",
-        "add_log_task_type": "Setzen Sie den Task-Typ auf `io.kestra.plugin.scripts.python.Script`.",
-        "add_namespace": "Fügen Sie oben einen Namespace hinzu. Beispiel: `namespace: company.team`.",
-        "complete_step": "Fast geschafft. Schließen Sie diesen Schritt ab, um fortzufahren.",
-        "edit_flow_from_execution": "Klicken Sie oben in der Leiste auf „Flow bearbeiten“, um fortzufahren.",
-        "execute_flow": "Führen Sie den Flow einmal aus, um fortzufahren.",
-        "fix_yaml": "Es gibt ein kleines YAML-Formatierungsproblem. Beheben Sie es und fahren Sie dann fort.",
-        "save_flow": "Klicken Sie auf „Speichern“, um fortzufahren.",
-        "save_flow_again": "Klicken Sie erneut auf „Speichern“, um fortzufahren.",
-        "view_logs_status": "Öffnen Sie die Ausführungsdetails und prüfen Sie die Logs für `greet`."
-      },
-      "welcome": {
-        "additional_help": "Weitere Hilfe",
-        "badge": "Tutorial",
-        "blueprints": "Blueprints",
-        "docs": "Dokumentation",
-        "guided_description": "Erfahren Sie mit geführten Schritten, wie Sie Ihren ersten Flow erstellen und ausführen.",
-        "guided_duration": "Für die meisten empfohlen",
-        "guided_title": "Erstellen Sie Ihren ersten Flow",
-        "headline": "Erstellen und starten Sie Ihren ersten Workflow in wenigen Minuten",
-        "self_serve_description": "Gehen Sie direkt zum Editor und erstellen Sie Ihren eigenen Flow.",
-        "self_serve_note": "Für erfahrene Nutzer",
-        "self_serve_title": "Flow von Grund auf erstellen",
-        "slack": "Slack-Community",
-        "tutorial": "Tutorial"
-      }
+    "download": "Herunterladen",
+    "jsonl": "JSONL",
+    "concurrency_limit": {
+      "dialog_title": "Nebenläufigkeitsgrenzen",
+      "warning": "Das Ändern des laufenden Zählers kann die Nebenläufigkeit beeinträchtigen, sodass Ausführungen das erlaubte Limit überschreiten können."
     },
-    "open": "Öffnen",
-    "open full page": "Ganze Seite öffnen",
-    "open in new tab": "In einem neuen Tab",
-    "open in same tab": "Im selben Tab",
-    "open sidebar": "Seitenleiste öffnen",
-    "open source": "Open Source",
-    "open_page": "Open page",
-    "optional": "Optional",
-    "original execution": "Originalausführung",
-    "originalCreatedDate": "Ursprüngliches Erstellungsdatum",
-    "outdated revision save confirmation": {
-      "confirm": "Möchten Sie es überschreiben?",
-      "create": {
-        "description": "Ein flow mit derselben id existiert bereits in diesem namespace.",
-        "details": "Speichern, um zu überschreiben und eine neue Revision zu erstellen.",
-        "title": "Flow existiert bereits"
-      },
-      "update": {
-        "description": "Die Revision, die Sie bearbeiten, ist veraltet.",
-        "details": "Überprüfen Sie die Registerkarte \"Revisionen\" für weitere Details zur neuesten Version.",
-        "title": "Veraltete Revision"
-      }
+    "documentation": {
+      "documentation": "Dokumentation",
+      "github": "GitHub-Issue öffnen"
     },
-    "output": "Output",
-    "outputs": "Outputs",
-    "override": {
-      "details": "Der vorherige flow kann über die Registerkarte \"Revisions\" wiederhergestellt werden.",
-      "title": "Sie werden den aktuellen Flow überschreiben"
-    },
-    "overview": "Übersicht",
-    "page": {
-      "next": "Nächste Seite",
-      "previous": "Vorherige Seite"
-    },
-    "panel actions": "Panelaktionen",
-    "parent execution": "Elternausführung",
-    "password": "Passwort",
-    "password empty constraint": "Falscher Benutzername oder Passwort",
-    "password length constraint": "Passwort darf 256 Zeichen nicht überschreiten",
-    "passwords do not match": "Passwörter stimmen nicht überein",
-    "pause": "Pause",
-    "pause backfill": "Backfill pausieren",
-    "pause backfills": "Backfills pausieren",
-    "pause confirm": "Sind Sie sicher, dass Sie die Ausführung <code>{id}</code> pausieren möchten?",
-    "pause done": "Die Ausführung ist PAUSED.",
-    "pause title": "Ausführung <code>{id}</code> pausieren.<br/>Bitte beachten Sie, dass derzeit laufende Tasks weiterhin verarbeitet werden und die Ausführung manuell fortgesetzt werden muss.",
-    "paused": "PAUSED",
-    "playground": {
-      "clear_history": "Verlauf löschen",
-      "confirm_create": "Sie können den Playground nicht ausführen, während Sie einen flow erstellen. Das Starten eines Playground-Laufs wird den flow erstellen.",
-      "history": "Letzte 10 Ausführungen",
-      "play_icon_info": "Sie können auch das Play-Symbol in den No-Code- oder Topologie-Ansichten anklicken.",
-      "run_all_tasks": "Alle Tasks ausführen",
-      "run_task": "Task ausführen",
-      "run_task_and_downstream": "Task & Downstream ausführen",
-      "run_task_info": "Bewegen Sie den Mauszeiger über eine beliebige Task im Flow-Code-Editor und klicken Sie auf die Schaltfläche \"Run task\", um Ihre Task zu testen.",
-      "run_this_task": "Führe diese Task aus",
-      "title": "Spielwiese",
-      "toggle": "Spielplatz",
-      "tooltip_persistence": "Wenn Sie den Playground ausschalten und wieder einschalten, bleiben die Informationen erhalten, solange Sie auf der Seite bleiben."
-    },
-    "playground actions": "Aktionen im Playground",
-    "plugin defaults exported": "Plugin-Standardeinstellungen exportiert",
-    "plugin defaults imported": "Plugin-Standardeinstellungen importiert",
-    "plugin defaults not imported": "Einige Plugin-Standardeinstellungen konnten nicht importiert werden",
-    "pluginDefaults": {
-      "add": "Plugin-Standard hinzufügen",
-      "add_subtitle": "Konfigurieren Sie ein neues Plugin-Standard mit seinen Eigenschaften",
-      "cancel": "Abbrechen",
-      "custom": "Benutzerdefiniertes Plugin",
-      "custom_configure": "Benutzerdefinierter Plugin-Typ - Konfiguration mit YAML",
-      "custom_placeholder": "Geben Sie den Plugin-Typ ein",
-      "custom_type": "Benutzerdefinierter Plugin-Typ",
-      "edit": "Standard-Plugin bearbeiten",
-      "edit_subtitle": "Ändern Sie die bestehende Standardkonfiguration des Plugins",
-      "form": "Formular",
-      "predefined": "Vordefiniertes Plugin",
-      "select_predefined": "Wählen Sie vordefiniertes Plugin",
-      "show_yaml": "YAML anzeigen",
-      "title": "Plugin-Standardeinstellungen",
-      "update": "Plugin-Standard aktualisieren",
-      "use_custom": "Benutzerdefiniert verwenden",
-      "yaml": "YAML",
-      "yaml_configuration": "YAML-Konfiguration"
-    },
-    "pluginPage": {
-      "elementType": {
-        "apps": "Anwendung",
-        "charts": "Diagramm",
-        "conditions": "Bedingung",
-        "logExporters": "Log-Exporter",
-        "secrets": "Geheimnis",
-        "taskRunners": "Task-Runner",
-        "tasks": "Aufgabe",
-        "triggers": "Trigger"
-      },
-      "group": {
-        "blueprints": "Blueprints ({count})",
-        "plugins": "Plugins ({count})",
-        "tasks": "Aufgaben ({count})"
-      },
+    "blueprints": {
+      "all": "Alle",
+      "community": "Gemeinschaft",
+      "create": "Erstellen Sie ein Blueprint",
+      "edit": "Bearbeiten Sie ein Blueprint",
+      "title": "Blueprints",
+      "empty": "Keine Blueprints zum Anzeigen.",
       "header": {
-        "back": "Zurück zu Plugins",
-        "certified": "Zertifiziert",
-        "enterpriseEdition": "Enterprise Edition"
+        "catch phrase": {
+          "1": "Der erste Schritt ist immer der schwerste.",
+          "2": "Erkunden Sie Blueprints, um Ihr nächstes {kind} zu starten."
+        },
+        "alt": "Blueprints-Symbol"
       },
-      "loadError": "Konnte Plugins nicht laden. Bitte versuchen Sie es erneut.",
-      "noResults": "Keine Plugins entsprechen Ihrer Suche.",
-      "notFound": "Dieses Plugin konnte nicht gefunden werden.",
-      "overview": {
-        "createdBy": "Erstellt von",
-        "latest": "Neueste",
-        "linksResources": "Links & Ressourcen",
-        "managedBy": "Verwaltet von",
-        "minKestraVersion": "Min. kompatible Kestra-Version: {version}",
-        "minKestraVersionShort": "Min. Kestra-Version {version}",
-        "pluginType": "Plugintyp",
-        "previousVersions": "Vorherige Versionen",
-        "releaseNotes": "Versionshinweise",
-        "title": "Übersicht",
-        "versions": "Versionen"
+      "custom": "Benutzerdefinierte Blueprints",
+      "flows": "Flow-Blueprints",
+      "apps": "App-Blueprints",
+      "dashboards": "Dashboard Blueprints",
+      "detail": {
+        "category": "Kategorietyp",
+        "links": "Link & Ressourcen",
+        "openInEditor": "In Flow bearbeiten öffnen"
       },
-      "search": "Suche in {count}+ Plugins",
-      "searchTasks": "Suche {count} Tasks",
-      "sort": {
-        "mostUsed": "Am häufigsten verwendet",
-        "nameAsc": "Name A-Z",
-        "nameDesc": "Name Z-A",
-        "newest": "Neueste"
-      },
-      "sortBy": "Sortieren nach"
+      "missingPlugins": {
+        "title": "Fehlende Plugins",
+        "description": "Dieses Blueprint verwendet Tasks aus Plugin(s), die auf dieser Instanz nicht installiert sind: {plugins}. Installieren Sie sie, um dieses Blueprint zu verwenden.",
+        "card": "Erfordert Plugin(s), die auf dieser Instanz nicht installiert sind: {plugins}",
+        "install": "Plugins installieren"
+      }
     },
-    "plugin_default_already_exists": "Standard-Plugin für <code>{type}</code> existiert bereits.",
+    "use": "Verwenden",
     "plugins": {
       "name": "Plugin",
       "names": "Plugins",
       "please": "Bitte wählen Sie rechts einen Task aus, um dessen Dokumentation zu sehen",
       "release": "Versionshinweise"
     },
-    "port": "Port",
-    "prefill inputs": "Vorausfüllen",
-    "pretty_json": "Pretty JSON",
-    "prev_execution": "Vorherige Ausführung",
-    "preview": {
-      "auto-view": "Automatische Ansicht",
-      "collapse": "Einklappen",
-      "expand": "Ausklappen",
-      "force-editor": "Editoransicht erzwingen",
-      "label": "Vorschau",
-      "next": "Weiter",
-      "page_of": "Seite {current} von {total}",
-      "pagination_info": "Zeige Zeilen {start}-{end} von {total}.",
-      "previous": "Zurück",
-      "rows_truncated": "Zeige {shown} von {total} Zeilen. Laden Sie die Datei herunter, um alle Daten anzuzeigen.",
-      "showing_rows": "Zeige Zeilen {start}-{end} von {total}",
-      "view": "Anzeigen"
+    "last execution date": "Letztes Ausführungsdatum",
+    "last execution state": "Letzter Zustand",
+    "last X days count": "{count} in den letzten {days} Tagen",
+    "date range count": "{count} zwischen dem {startDate} und dem {endDate}",
+    "date count": "{count} am {date}",
+    "revisions": "Revisionen",
+    "no revisions found": "Es existiert nur eine Revision für diesen Flow",
+    "no revisions": "Keine Revisionen",
+    "see full revision": "Vollständige Revision anzeigen",
+    "side-by-side": "nebeneinander",
+    "line-by-line": "Zeile für Zeile",
+    "template": "Vorlage",
+    "template creation": "Vorlagenerstellung",
+    "templates": "Vorlagen",
+    "templates deprecated": "Vorlagen sind veraltet. Bitte verwenden Sie stattdessen Subflows. Siehe den <a href=\"https://kestra.io/docs/migration-guide/0.11.0/templates?utm_source=app&utm_medium=referral&utm_campaign=template-inlinedoc\" target=\"_blank\">Migrationsabschnitt</a>, der erklärt, wie Sie von Vorlagen zu Subflows migrieren können.",
+    "no result": "Es gibt keine Ergebnisse anzuzeigen.",
+    "empty search": "Suchergebnisse sind leer",
+    "trigger": "Trigger",
+    "no_trigger": "Kein Trigger verfügbar.",
+    "triggers": "Trigger",
+    "triggers_header_description": "Durchsuchen, hinzufügen und verwalten Sie Trigger, um Ihre flows zu automatisieren. Wählen Sie aus, ob Sie Ihren flow als AI-Tool bereitstellen, planen, einen Webhook-Trigger hinzufügen, Änderungen in externen Apps abfragen oder Echtzeit-Ereignislistener verwenden möchten.",
+    "triggers_tabs_add": "Hinzufügen",
+    "triggers_tabs_manage": "Verwalten",
+    "triggers_add_search_placeholder": "Suche Trigger...",
+    "triggers_add_filter_core": "Kern",
+    "triggers_add_filter_realtime": "Echtzeit",
+    "triggers_add_filter_all": "Alle",
+    "triggers_add_filter_app": "App",
+    "triggers_add_empty_title": "Keine Trigger gefunden",
+    "triggers_add_ee_tooltip": "Dieser Trigger erfordert die Enterprise Edition.",
+    "triggers_add_category_empty": "Keine Trigger in dieser Kategorie.",
+    "triggers_add_card_add_to_flow": "Zum flow hinzufügen",
+    "triggers_add_card_add": "Hinzufügen",
+    "triggers_add_modal_title": "{name}",
+    "triggers_add_modal_tab_form": "Formular",
+    "triggers_add_modal_tab_source": "Quelle",
+    "triggers_add_modal_tab_documentation": "Dokumentation",
+    "triggers_add_modal_namespace_placeholder": "Wählen Sie ein namespace",
+    "triggers_add_modal_flow_placeholder": "Wählen Sie einen flow aus",
+    "triggers_add_modal_trigger_id": "Trigger-ID",
+    "triggers_add_modal_trigger_id_placeholder": "Eindeutiger Bezeichner für diesen Trigger",
+    "triggers_add_modal_properties_hint": "Konfigurieren Sie die Trigger-Eigenschaften im Flow-Editor, nachdem Sie den Trigger hinzugefügt haben.",
+    "triggers_add_modal_ee_notice": "Dieser Trigger erfordert die Enterprise Edition.",
+    "triggers_add_modal_add_button": "Trigger zum Flow hinzufügen",
+    "trigger details": "Trigger-Details",
+    "triggerflow disabled": "Trigger ist in der Flow-Definition deaktiviert",
+    "last trigger date": "Letztes Trigger-Datum",
+    "trigger_states": "Zustände",
+    "context updated date": "Aktualisierungsdatum des Kontexts",
+    "state updated date": "Datum der Zustandsaktualisierung",
+    "next evaluation date": "Nächstes Bewertungsdatum",
+    "last evaluation date": "Letztes Bewertungsdatum",
+    "last trigger date tooltip": "Wann der Trigger zuletzt ausgeführt wurde. Kann in der Vergangenheit liegen, wenn ein Backfill ausgeführt wird.",
+    "context updated date tooltip": "Wann der Kontext des Triggers zuletzt aktualisiert wurde. Dies tritt auf, wenn die Ausführung ausgelöst wird, abgeschlossen ist (Sperre freigegeben) oder nach einer Bewertung (auch wenn keine Ausführung stattfindet).",
+    "next evaluation date tooltip": "Wann der Trigger das nächste Mal basierend auf seinem Intervall ausgewertet wird. Nicht immer dasselbe wie das nächste Ausführungsdatum, wenn Bedingungen nicht erfüllt sind.",
+    "last evaluation date tooltip": "When the trigger was last evaluated by the scheduler, regardless of whether it produced an execution.",
+    "conditions": "Bedingungen",
+    "triggerId": "Trigger-ID",
+    "tenantId": "Mandanten-ID",
+    "codeDisabled": "In Flow deaktiviert",
+    "paused": "PAUSED",
+    "running": "RUNNING",
+    "Fold auto": "Editor: Automatisches Falten von Mehrzeilen",
+    "Hover description": "Editor: Beschreibung des Feldes anzeigen, wenn auf Key oder Value gehalten wird",
+    "Fold content lines": "Mehrzeilige Zeichenfolgen falten",
+    "Unfold content lines": "Mehrzeilige Zeichenfolgen entfalten",
+    "Total": "Gesamt",
+    "sub flow": "Subflow",
+    "execute": "Ausführen",
+    "execute flow behaviour": "Den Flow ausführen",
+    "open in same tab": "Im selben Tab",
+    "open in new tab": "In einem neuen Tab",
+    "execute the flow": "Den Flow <code>{id}</code> ausführen",
+    "execute flow now ?": "Möchten Sie diesen Flow ausführen?",
+    "discard execution confirmation": "Sie haben ungespeicherte Eingaben. Sind Sie sicher, dass Sie diese Ausführung verwerfen möchten?",
+    "discard changes confirmation": "Sie haben ungespeicherte Änderungen. Sind Sie sicher, dass Sie diese verwerfen möchten?",
+    "Default namespace": "Standard-Namespace",
+    "Default log level": "Standard-Log-Ebene",
+    "unsaved changed ?": "Sie haben ungespeicherte Änderungen, möchten Sie diese Seite verlassen?",
+    "unsaved changes": "Nicht gespeicherte Änderungen",
+    "unsaved changes warning": "Sie haben ungespeicherte Änderungen. Wenn Sie diese Seite verlassen, gehen Ihre Änderungen verloren.",
+    "leave page": "Seite verlassen",
+    "open full page": "Ganze Seite öffnen",
+    "drill down preview": "Vorschau",
+    "Editor theme": "Editor-Modus",
+    "Editor fontsize": "Editor-Schriftgröße",
+    "Editor fontfamily": "Editor-Schriftfamilie",
+    "errors": {
+      "401": {
+        "title": "Unbefugt",
+        "content": "Sie müssen authentifiziert sein, um auf diese Seite zuzugreifen."
+      },
+      "403": {
+        "title": "Zugriff verweigert",
+        "content": "Sie haben nicht die erforderlichen Berechtigungen, um auf diese Seite zuzugreifen."
+      },
+      "404": {
+        "title": "Seite nicht gefunden",
+        "content": "Die angeforderte URL wurde auf diesem Server nicht gefunden.<br />Das ist alles, was wir wissen.",
+        "flow or execution": "Der Flow oder die Ausführung, die Sie suchen, existiert nicht."
+      }
     },
-    "pricing": "Preise",
-    "product_tour": "Produkteinführung",
-    "properties": {
-      "hidden": "In Tabelle versteckt",
-      "hint": "Sichtbare Spalten auswählen",
-      "label": "Eigenschaften",
-      "shown": "In Tabelle angezeigt"
+    "back_to_dashboard": "Zurück zum Dashboard",
+    "copy all logs": "Alle Logs kopieren",
+    "copy logs": "Logs kopieren",
+    "fix_with_ai": "Mit KI beheben",
+    "download logs": "Logs herunterladen",
+    "delete logs": "Logs löschen",
+    "delete_all_logs": "Sind Sie sicher, dass Sie alle Logs löschen möchten?",
+    "delete_log": "Sind Sie sicher, dass Sie das Log löschen möchten?",
+    "toggle fullscreen": "Vollbild umschalten",
+    "copied": "Kopiert",
+    "tags": "Tags",
+    "disabled flow title": "Dieser Flow ist deaktiviert",
+    "disabled flow desc": "Dieser Flow ist deaktiviert, bitte aktivieren Sie ihn, um ihn auszuführen.",
+    "label": "Label",
+    "labels": "Labels",
+    "label filter placeholder": "Label als 'key:value'",
+    "execution labels": "Ausführungs-Labels",
+    "wrong labels": "Leerer Key oder Value ist in Labels nicht erlaubt",
+    "feeds": {
+      "title": "Was gibt's Neues bei Kestra",
+      "heading": "Alles rund um Kestra.",
+      "subheading": "Die neuesten Updates, Anleitungen und Geschichten"
     },
-    "queued duration": "Warteschlangendauer",
-    "quotas": "Quotas",
-    "reach us": "Sprechen Sie mit uns",
-    "read-more": "Mehr erfahren über",
-    "readonly property": "Schreibgeschützte Eigenschaft",
-    "recent_executions": "Letzte Ausführungen",
-    "refresh": "Aktualisieren",
-    "reject": "Ablehnen",
-    "relative": "Relativ",
-    "relative end date": "Relatives Enddatum",
-    "relative start date": "Relatives Startdatum",
-    "remove label": "Label entfernen",
-    "remove this item": "Diesen Eintrag entfernen",
-    "remove_bookmark": "Sind Sie sicher, dass Sie dieses Lesezeichen entfernen möchten?",
-    "replay": "Wiederholen",
-    "replay confirm": "Sind Sie sicher, dass Sie diese Ausführung <code>{id}</code> wiederholen und eine neue erstellen möchten?",
-    "replay execution description": "Dies wird eine neue Ausführung basierend auf der ausgewählten Ausführung erstellen.",
-    "replay execution title": "Ausführung wiederholen",
-    "replay from beginning tooltip": "Eine ähnliche Ausführung von Anfang an erstellen",
-    "replay from task tooltip": "Eine ähnliche Ausführung ab Task <code>{taskId}</code> erstellen",
-    "replay inputs": "Eingaben",
-    "replay inputs new required": "Diese Revision hat Inputs. Sie werden aufgefordert, diese auszufüllen.",
-    "replay latest revision": "Wiederholen mit neuester Revision",
-    "replay select taskrun": "Wählen Sie den Task-Lauf aus, von dem aus Sie die Wiedergabe starten möchten:",
-    "replay the execution": "Führen Sie die Ausführung <code>{executionId}</code> für den flow <code>{flowId}</code> erneut aus.",
-    "replay using": "Wiederholen mit",
-    "replay with inputs": "Wiedergabe mit Inputs",
-    "replayed": "Die Ausführung wird wiederholt",
-    "required field": "Erforderliches Feld",
-    "reset": "Neustarten",
-    "reset to defaults": "Zurücksetzen auf Standardwerte",
-    "restart": "Neustart",
-    "restart change revision": "Sie können die Revision ändern, die für die neue Ausführung verwendet wird.",
-    "restart confirm": "Sind Sie sicher, dass Sie die Ausführung <code>{id}</code> neu starten möchten?",
-    "restart execution title": "Ausführung neu starten",
-    "restart latest revision": "Neueste Revision neu starten",
-    "restart tooltip": "Die Ausführung vom <code>{state}</code> Task neu starten",
-    "restart trigger": {
-      "button": "Trigger neu starten",
-      "tooltip": "Den Trigger neu starten"
-    },
-    "restarted": "Die Ausführung wird neu gestartet",
+    "delete execution running": "<div class=\"alert alert-warning mt-2 mb-0\">Diese Ausführung läuft noch, das Löschen wird sie nicht stoppen.<br />Sie müssen die Ausführung beenden, um sie zu stoppen.</div>",
     "restore": "Wiederherstellen",
     "restore confirm": "Sind Sie sicher, dass Sie die Revision <code>{revision}</code> wiederherstellen möchten?",
+    "bulk delete": "Sind Sie sicher, dass Sie <code>{executionCount}</code> Ausführung(en) löschen möchten?",
+    "bulk replay": "Sind Sie sicher, dass Sie <code>{executionCount}</code> Ausführung(en) erneut abspielen möchten?",
+    "bulk change state": "Sind Sie sicher, dass Sie den Zustand von <code>{executionCount}</code> Ausführung(en) ändern möchten?",
+    "bulk resume": "Sind Sie sicher, dass Sie <code>{executionCount}</code> Ausführung(en) fortsetzen möchten?",
+    "bulk pause": "Sind Sie sicher, dass Sie die Ausführung(en) <code>{executionCount}</code> pausieren möchten?",
+    "bulk unqueue": "Sind Sie sicher, dass Sie <code>{executionCount}</code> Ausführung(en) aus der Warteschlange entfernen möchten?",
+    "bulk force run": "Sind Sie sicher, dass Sie <code>{executionCount}</code> Ausführung(en) erzwingen möchten?<br/><br/>WARNUNG: Das Erzwingen einer Ausführung ist nicht garantiert und kann doppelte Task-Ausführungen erzeugen.<br/><br/>Die folgenden Übergänge werden durchgeführt:<br/><ul><li>CREATED Tasks werden in den RUNNING Zustand versetzt.</li><li>RUNNING Tasks werden erneut eingereicht.</li><li>QUEUED Tasks werden aus der Warteschlange entfernt.</li><li>PAUSED Tasks werden fortgesetzt.</li></ul>",
+    "bulk restart": "Sind Sie sicher, dass Sie <code>{executionCount}</code> Ausführung(en) neu starten möchten?",
+    "bulk kill": "Sind Sie sicher, dass Sie <code>{executionCount}</code> Ausführung(en) beenden möchten?",
+    "selection": {
+      "selected": "<strong>{count}</strong> ausgewählt",
+      "all": "Alle auswählen ({count})"
+    },
+    "cancel": "Abbrechen",
+    "errorLogs": "Fehlerprotokolle",
+    "welcome_page": {
+      "welcome": "Willkommen bei Kestra",
+      "guide": "Benötigen Sie Unterstützung, um Ihren ersten flow auszuführen?"
+    },
+    "product_tour": "Produkteinführung",
+    "executions replayed": "<code>{executionCount}</code> Ausführung(en) erneut abgespielt",
+    "executions state changed": "Der Zustand von <code>{executionCount}</code> Ausführung(en) wurde geändert",
+    "executions resumed": "<code>{executionCount}</code> Ausführung(en) fortgesetzt",
+    "executions paused": "<code>{executionCount}</code> Ausführung(en) PAUSED",
+    "executions unqueue": "<code>{executionCount}</code> Ausführung(en) aus der Warteschlange entfernen",
+    "executions force run": "<code>{executionCount}</code> Ausführung(en) erzwungener Lauf",
+    "executions restarted": "<code>{executionCount}</code> Ausführung(en) neu gestartet",
+    "executions killed": "<code>{executionCount}</code> Ausführung(en) beendet",
+    "executions deleted": "<code>{executionCount}</code> Ausführung(en) gelöscht",
+    "invalid bulk replay": "Ausführungen konnten nicht erneut abgespielt werden",
+    "invalid bulk resume": "Ausführungen konnten nicht fortgesetzt werden",
+    "invalid bulk pause": "Konnte Ausführungen nicht pausieren",
+    "invalid bulk unqueue": "Konnte Ausführungen nicht aus der Warteschlange entfernen",
+    "invalid bulk force run": "Konnte Ausführungen nicht erzwingen",
+    "invalid bulk restart": "Ausführungen konnten nicht neu gestartet werden",
+    "invalid bulk kill": "Ausführungen konnten nicht beendet werden",
+    "invalid bulk delete": "Ausführungen konnten nicht gelöscht werden",
+    "execution not found": "Ausführung {executionId} wurde nicht gefunden.",
+    "execution not in state PAUSED": "Ausführung <code>{executionId}</code> nicht im Zustand PAUSED",
+    "execution not in state FAILED": "Ausführung <code>{executionId}</code> nicht im Zustand FAILED",
+    "execution already finished": "Ausführung <code>{executionId}</code> bereits abgeschlossen",
     "restore revision": "Sind Sie sicher, dass Sie die Revision <code>{revision}</code> wiederherstellen möchten?",
-    "resume": "Fortsetzen",
-    "resume from breakpoint done": "Ausführung wird vom Breakpoint fortgesetzt",
-    "resume from breakpoint title": "Ausführung `<code>{id}</code>` vom Haltepunkt fortsetzen",
-    "resumed confirm": "Sind Sie sicher, dass Sie die Ausführung <code>{id}</code> fortsetzen möchten?",
-    "resumed done": "Ausführung ist fortgesetzt",
-    "resumed title": "Ausführung <code>{id}</code> fortsetzen",
-    "reuse original inputs": "Original-Inputs wiederverwenden",
-    "reuse_original_inputs": "Ursprüngliche Inputs wiederverwenden",
-    "review your inputs": "Überprüfen Sie Ihre Eingaben",
-    "revision": "Revision",
-    "revision deleted": "Revision {revision} wurde erfolgreich gelöscht",
-    "revisions": "Revisionen",
-    "row count": "Zeilenanzahl",
-    "run task in playground": "Task im Playground ausführen",
+    "seeing old revision": "Sie sehen eine alte Revision: {revision}",
+    "export": "Exportieren",
+    "exports": "Exporte",
+    "export_csv": "Als CSV exportieren",
+    "template export": "Sind Sie sicher, dass Sie <code>{templateCount}</code> Vorlage(n) exportieren möchten?",
+    "templates exported": "Vorlagen exportiert",
+    "export all templates": "Alle Vorlagen exportieren",
+    "flow_export": "Flow exportieren",
+    "flow export": "Sind Sie sicher, dass Sie <code>{flowCount}</code> Flow(s) exportieren möchten?",
+    "flows exported": "<code>{count}</code> Flow(s) exportiert",
+    "export all flows": "Alle Flows exportieren",
+    "import": "Importieren",
+    "disable": "Deaktivieren",
+    "enable": "Aktivieren",
+    "enabled": "Aktiviert",
+    "template delete": "Sind Sie sicher, dass Sie <code>{templateCount}</code> Vorlage(n) löschen möchten?",
+    "flow delete": "Sind Sie sicher, dass Sie <code>{flowCount}</code> Flow(s) löschen möchten?",
+    "templates deleted": "<code>{count}</code> Vorlage(n) gelöscht",
+    "flows deleted": "<code>{count}</code> Flow(s) gelöscht",
+    "flow disable": "Sind Sie sicher, dass Sie <code>{flowCount}</code> Flow(s) deaktivieren möchten?",
+    "flow enable": "Sind Sie sicher, dass Sie <code>{flowCount}</code> Flow(s) aktivieren möchten?",
+    "flows disabled": "<code>{count}</code> Flow(s) deaktiviert",
+    "flows enabled": "<code>{count}</code> Flow(s) aktiviert",
+    "flow-no-dependencies": "Ihr Flow hat keine Abhängigkeiten.",
+    "flow-dependencies": "Abhängigkeiten",
+    "read-more": "Mehr erfahren über",
+    "in-our-documentation": "in unserer Dokumentation.",
+    "dependencies": "Abhängigkeiten",
+    "see dependencies": "Abhängigkeiten anzeigen",
+    "see timeline": "Zeitachse anzeigen",
     "run timeline": "Ablaufzeitachse",
-    "runners": "Läufer",
-    "running": "RUNNING",
-    "running duration": "Laufzeitdauer",
-    "save": "Speichern",
+    "dependencies missing acls": "Keine Berechtigungen für diesen Flow",
+    "dependencies delete flow": "Dieser Flow hat Abhängigkeiten. Das Löschen verhindert, dass deren Abhängigkeiten ausgeführt werden.<br /><br /> Hier ist die Liste der betroffenen Flows:",
+    "expand dependencies": "Abhängigkeiten ausklappen",
+    "reset": "Neustarten",
+    "show task documentation": "Task-Dokumentation anzeigen",
+    "hide task documentation": "Task-Dokumentation ausblenden",
+    "show task documentation in editor": "Task-Dokumentation im Editor anzeigen",
+    "show documentation": "Dokumentation anzeigen",
+    "focus task": "Klicken Sie auf ein Element, um dessen Dokumentation zu sehen.",
+    "validate": "Validieren",
+    "add error handler": "Fehler-Handler hinzufügen",
+    "taskDefaults": "Task-Standards",
+    "disabled": "Deaktiviert",
+    "before": "vor",
+    "after": "nach",
+    "add at position": "{position} <code>{task}</code> hinzufügen",
+    "create first task": "Erstellen Sie Ihren ersten Task",
+    "dynamic": "Dynamisch",
+    "choice": "Wahl",
+    "sequential": "Sequenziell",
+    "can not delete": "Kann nicht gelöscht werden",
+    "can not have less than 1 task": "Jeder Flow muss mindestens einen Task haben.",
+    "task id already exists": "Task-Id existiert bereits",
+    "Task Id already exist in the flow": "Task-Id {taskId} existiert bereits im Flow.",
+    "task id": "Task-ID",
+    "taskid column details": "Letzter Task, der ausgeführt wird, und seine Anzahl der Versuche.",
+    "flow already exists": "Flow existiert bereits",
+    "flow already exists message": "Flow <code>{id}</code> existiert bereits im namespace <code>{namespace}</code>. Möchten Sie eine neue Revision erstellen?",
+    "plugin_default_already_exists": "Standard-Plugin für <code>{type}</code> existiert bereits.",
+    "namespace not allowed": "Namespace nicht erlaubt",
+    "switch-view": "Ansicht wechseln",
+    "source and topology": "Quelle und Topologie",
+    "source and doc": "Quelle und Dokumentation",
+    "source and blueprints": "Quelle und Blueprints",
+    "editor": "Editor",
+    "error in editor": "Ein Fehler wurde im Editor gefunden",
+    "delete task confirm": "Möchten Sie den Task <code>{taskId}</code> wirklich löschen?",
+    "can not save": "Kann nicht gespeichert werden",
+    "flow must not be empty": "Flow darf nicht leer sein",
+    "flow must have id and namespace": "Flow muss eine Id und einen Namespace haben.",
+    "flow creation denied in namespace": "Sie haben keine Berechtigung, Flows im Namespace `{namespace}` zu erstellen.",
+    "readonly property": "Schreibgeschützte Eigenschaft",
+    "namespace and id readonly": "Die Eigenschaften `namespace` und `id` können nicht geändert werden — sie sind jetzt auf ihre Anfangswerte gesetzt. Wenn Sie einen Flow umbenennen oder seinen Namespace ändern möchten, können Sie einen neuen Flow erstellen und den alten entfernen.",
+    "avg": "Durchschnitt",
+    "sum": "Summe",
+    "min": "Min",
+    "max": "Max",
+    "bar": "Bar",
+    "line": "Linie",
+    "metric": "Metrik",
+    "aggregation": "Aggregation",
+    "chart type": "Diagrammtyp",
+    "metric choice": "Keine Metriken für diesen flow verfügbar",
+    "of": "von",
+    "see_all_states": "Alle Zustände anzeigen",
     "save draft": {
       "message": "Entwurf gespeichert",
       "retrieval": {
@@ -1680,164 +724,336 @@
         "existing": "Ein <code>{flowFullName}</code> Flow-Entwurf wurde gespeichert, möchten Sie den Flow weiter bearbeiten?"
       }
     },
-    "save task": "Task speichern",
-    "save_and_execute": "Speichern & Ausführen",
-    "save_as_draft": "Als Entwurf speichern",
-    "saved": "Erfolgreich gespeichert",
-    "saved as draft": "Erfolgreich als Entwurf gespeichert",
-    "saved as draft done": "<em>{name}</em> wurde erfolgreich als Entwurf gespeichert",
-    "saved done": "<em>{name}</em> ist erfolgreich gespeichert",
-    "scheduleDate": "Geplantes Datum",
-    "scope_filter": {
-      "all": "Alle {label}",
-      "system": "System {label}",
-      "system_description": "Systemwartung {label}",
-      "user": "Benutzer {label}",
-      "user_description": "Regulärer Benutzer initiierte {label}"
+    "title": "Titel",
+    "api": "API",
+    "more_actions": "Weitere Aktionen",
+    "expand error": "Nur fehlgeschlagene Tasks ausklappen",
+    "expand all": "Alle ausklappen",
+    "collapse all": "Alle einklappen",
+    "expand": "Ausklappen",
+    "collapse": "Einklappen",
+    "filter by this value": "Filter by this value",
+    "filter_for": "Filter for",
+    "filter_out": "Filter out",
+    "copy_value": "Copy value",
+    "open_page": "Open page",
+    "logs_copied": "Logs copied to your clipboard",
+    "expand_by_default": "Expand structured logs by default",
+    "show raw": "Show raw",
+    "similar lines": "similar lines",
+    "download_logs_description": "Choose which logs to export. Filters default to your current view.",
+    "display_settings": "Display settings",
+    "density": "Density",
+    "density_compact": "Compact",
+    "density_normal": "Normal",
+    "density_expanded": "Expanded",
+    "pretty_json": "Pretty JSON",
+    "body_line_clamp": "Limit line height",
+    "font size": "Font size",
+    "log expand setting": "Log-Standardanzeige",
+    "environment": "Umgebung",
+    "environment name setting": "Umgebungsname",
+    "environment color setting": "Umgebungsfarbe",
+    "slack support": "Fragen Sie via Slack",
+    "join community": "Community beitreten",
+    "join_slack": "Slack beitreten",
+    "kestra": "Kestra",
+    "reach us": "Sprechen Sie mit uns",
+    "new version": "Neue Version {version} verfügbar!",
+    "error detected": "Fehler erkannt.",
+    "warning detected": "Warnungen erkannt",
+    "informative notice": "Hinweis(e)",
+    "cannot swap tasks": "Tasks können nicht getauscht werden",
+    "open": "Öffnen",
+    "dependency task": "Task {taskId} ist eine Abhängigkeit eines anderen Tasks",
+    "administration": "Administration",
+    "admin": "Admin",
+    "main_configuration": "Hauptkonfiguration",
+    "commit_id": "Commit-ID",
+    "evaluation lock date": "Evaluationssperrdatum",
+    "unlock trigger": {
+      "tooltip": {
+        "execution": "Es läuft eine Ausführung für diesen Trigger",
+        "evaluation": "Der Trigger wird derzeit ausgewertet"
+      },
+      "confirmation": "Sind Sie sicher, dass Sie den Trigger entsperren möchten?",
+      "warning": "Dies könnte zu gleichzeitigen Ausführungen für denselben Trigger führen und sollte als letzte Option betrachtet werden.",
+      "button": "Trigger entsperren",
+      "success": "Trigger ist entsperrt"
     },
-    "search": "Suche",
-    "search blueprint": "Blueprints durchsuchen",
-    "search filters": {
-      "filter name": "Filtername",
-      "filters": "Filter",
-      "manage": "Suchfilter verwalten",
-      "manage desc": "Gespeicherte Suchfilter verwalten",
-      "save filter": "Filter speichern",
-      "saved": "Gespeicherte Filter"
+    "restart trigger": {
+      "button": "Trigger neu starten",
+      "tooltip": "Den Trigger neu starten"
     },
-    "search term in message": "Suchbegriff in Nachricht",
-    "search_docs": "Suche",
-    "searching": "Suche läuft...",
-    "secret": {
-      "add": "Erstellen",
-      "inherited": "Geerbte Secrets",
-      "isReadOnly": "Geheimnis ist schreibgeschützt",
-      "names": "Secrets",
-      "update": "Aktualisiere Secret '{name}'"
-    },
-    "security_advice": {
-      "content": "Aktivieren Sie die Basisauthentifizierung, um Ihre Instanz zu schützen.",
-      "enable": "Authentifizierung aktivieren",
-      "switch_text": "Nicht mehr anzeigen",
-      "title": "Schützen Sie Ihre Instanz"
-    },
-    "see dependencies": "Abhängigkeiten anzeigen",
-    "see full revision": "Vollständige Revision anzeigen",
-    "see timeline": "Zeitachse anzeigen",
-    "see_all_states": "Alle Zustände anzeigen",
-    "seeing old revision": "Sie sehen eine alte Revision: {revision}",
-    "select": "Wählen Sie Ihren {{section}} aus",
-    "select a state": "Wählen Sie einen Zustand",
-    "select datetime": "Datum auswählen",
-    "select view": "Ansicht auswählen",
-    "selected": "Ausgewählt",
-    "selection": {
-      "all": "Alle auswählen ({count})",
-      "selected": "<strong>{count}</strong> ausgewählt"
-    },
-    "sequential": "Sequenziell",
-    "server type": "Servertyp",
+    "trigger disabled": "Trigger ist in der Flow-Quelle deaktiviert",
+    "flow source not found": "Flow-Quelle nicht gefunden",
+    "date format": "Datumsformat",
+    "timezone": "Zeitzone",
+    "add task": "Einen Task hinzufügen",
+    "unable to generate graph": "Ein Problem ist beim Generieren des Graphen aufgetreten, wodurch die Topologie nicht angezeigt werden kann.",
+    "attempts": "Versuch(e)",
+    "flow deleted, you can restore it": "Der Flow wurde gelöscht und dies ist eine schreibgeschützte Ansicht. Sie können ihn dennoch wiederherstellen.",
+    "workers": "Workers",
+    "worker group": "Worker-Gruppe",
+    "worker group key": "Worker-Gruppe Schlüssel",
+    "worker group fallback": "Arbeitsgruppe Fallback",
+    "version": "Version",
     "services": "Dienste",
+    "server type": "Servertyp",
+    "hostname": "Hostname",
+    "port": "Port",
+    "management port": "Management-Port",
+    "file preview truncated": "Angezeigter Inhalt wurde abgeschnitten",
+    "file unavailable": "Datei nicht verfügbar",
+    "file unavailable description": "Diese Datei ist nicht mehr verfügbar – sie wurde möglicherweise gelöscht oder ist abgelaufen.",
+    "row count": "Zeilenanzahl",
+    "encoding": "Kodierung",
+    "show": "Anzeigen",
+    "advanced configuration": "Andere Eigenschaften",
+    "all executions": "Alle Ausführungen",
+    "trigger execution id": "Trigger-Ausführungs-Id",
+    "execution_status": "Die Ausführung ist:",
+    "no_tasks_running": "Noch keine Tasks laufen.",
+    "execution_starts_progress": "Sobald die Ausführung beginnt, sehen Sie hier Fortschrittsaktualisierungen.",
+    "triggers_state": {
+      "state": "Zustand",
+      "options": {
+        "enabled": "Aktiviert",
+        "disabled": "Deaktiviert"
+      }
+    },
+    "trigger filter": {
+      "title": "Kinder-Ausführungen filtern",
+      "options": {
+        "ALL": "Alle Ausführungen",
+        "CHILD": "Kinder-Ausführungen",
+        "MAIN": "Eltern-Ausführungen"
+      }
+    },
+    "show chart": "Diagramm anzeigen",
+    "namespace files": {
+      "toggle": {
+        "show": "Namespace-Dateien anzeigen",
+        "hide": "Namespace-Dateien ausblenden"
+      },
+      "filter": "Filter",
+      "new_file": "Neue Datei",
+      "no_items": {
+        "heading": "Noch keine Dateien in Ihrem Namespace gefunden.",
+        "paragraph": "Erstellen oder importieren Sie Dateien, um Code zwischen Flows in Ihrem Namespace zu teilen."
+      },
+      "no_selection": {
+        "heading": "Keine Dateien ausgewählt",
+        "description": "Wählen Sie eine Datei aus dem Baum aus, um ihren Inhalt anzuzeigen."
+      },
+      "tree": {
+        "expand": "Alle Ordner ausklappen",
+        "collapse": "Alle Ordner einklappen"
+      },
+      "create": {
+        "label": "Erstellen",
+        "file": "Datei erstellen",
+        "file_already_exists": "Eine Datei mit diesem Namen existiert bereits",
+        "file_conflicts_with_folder": "Ein Ordner mit diesem Namen existiert bereits",
+        "file_error": "Fehler beim Erstellen der Datei aufgetreten",
+        "folder": "Ordner erstellen",
+        "folder_already_exists": "Ein Ordner mit diesem Namen existiert bereits",
+        "folder_conflicts_with_file": "Eine Datei mit diesem Namen existiert bereits",
+        "folder_error": "Beim Erstellen des Ordners ist ein Fehler aufgetreten"
+      },
+      "rename": {
+        "label": "Umbenennen",
+        "file": "Datei umbenennen",
+        "folder": "Ordner umbenennen",
+        "new_file": "Neuer Name mit Erweiterung:",
+        "new_folder": "Neuer Ordnername:"
+      },
+      "delete": {
+        "label": "Löschen",
+        "file": "Datei löschen",
+        "folder": "Ordner löschen",
+        "files": "Lösche {count} ausgewählte Dateien",
+        "folders": "Lösche {count} ausgewählte Ordner"
+      },
+      "import": {
+        "import": "Importieren",
+        "files": "Dateien importieren",
+        "folder": "Ordner importieren",
+        "success": "Datei(en) erfolgreich importiert",
+        "error": "Fehler beim Importieren der Datei(en)"
+      },
+      "export": "Namespace-Dateien exportieren",
+      "export_single": "Datei exportieren",
+      "dialog": {
+        "name": {
+          "file": "Name mit Erweiterung:",
+          "folder": "Ordnername:"
+        },
+        "parent_folder": "Übergeordneter Ordner:",
+        "deletion": {
+          "confirm": "Bestätigen",
+          "title": "Bestätigen Sie das Löschen des Inhalts",
+          "files": "Möchten Sie wirklich <code>{count}</code> Datei(en) löschen?",
+          "folders": "Möchten Sie wirklich <code>{count}</code> Ordner und alle seine Inhalte löschen?",
+          "mixed": "Möchten Sie wirklich den Ordner <code>{folders}</code> und die Datei <code>{files}</code> löschen?",
+          "file_single": "Möchten Sie die Datei <code>{name}</code> wirklich löschen?",
+          "folder_single": "Möchten Sie den Ordner <code>{name}</code> und alle seine Inhalte wirklich löschen?"
+        }
+      },
+      "revisions": {
+        "history": "Versionsverlauf",
+        "restore": {
+          "success": "Dateirevision erfolgreich wiederhergestellt"
+        }
+      },
+      "path": {
+        "copy": "Pfad kopieren",
+        "success": "Pfad in die Zwischenablage kopiert",
+        "error": "Fehler beim Kopieren des Pfads in die Zwischenablage"
+      }
+    },
+    "continue backfill": "Backfill fortsetzen",
+    "delete backfill": "Backfill löschen",
+    "pause backfill": "Backfill pausieren",
+    "continue backfills": "Backfills fortsetzen",
+    "delete backfills": "Backfills löschen",
+    "pause backfills": "Backfills pausieren",
+    "backfill executions": "Backfill-Ausführungen",
+    "execute backfill": "Backfill ausführen",
+    "backfill paused": "Backfill PAUSED",
+    "backfill running": "Backfill läuft",
+    "relative": "Relativ",
+    "relative start date": "Relatives Startdatum",
+    "relative end date": "Relatives Enddatum",
+    "now": "Jetzt",
+    "absolute": "Absolut",
+    "backfill": "Backfill",
+    "Set labels tooltip": "Labels für die Ausführung festlegen",
+    "Set labels": "Labels festlegen",
+    "manage labels": "Labels verwalten",
+    "Set labels to execution": "Labels der Ausführung <code>{id}</code> hinzufügen oder aktualisieren",
+    "Set labels done": "Labels der Ausführung erfolgreich festgelegt",
+    "bulk set labels": "Sind Sie sicher, dass Sie Labels für <code>{executionCount}</code> Ausführung(en) festlegen möchten?",
+    "dependencies loaded": "Abhängigkeiten geladen",
+    "loaded x dependencies": "{count} Abhängigkeiten geladen",
+    "security_advice": {
+      "title": "Schützen Sie Ihre Instanz",
+      "content": "Aktivieren Sie die Basisauthentifizierung, um Ihre Instanz zu schützen.",
+      "switch_text": "Nicht mehr anzeigen",
+      "enable": "Authentifizierung aktivieren"
+    },
+    "true": "Wahr",
+    "false": "Falsch",
+    "undefined": "Nicht definiert",
+    "execution-include-non-terminated": "Nicht beendete Ausführungen einbeziehen?",
+    "execution-warn-title": "Wichtige Warnung!",
+    "execution-warn-deleting-still-running": "Wir empfehlen dringend, diese Aktion abzubrechen und alle laufenden Ausführungen zuerst zu beenden. Das Löschen nicht beendeter Ausführungen kann zu Nebenläufigkeitsproblemen, Inkonsistenzen im Flow-Abhängigkeitsmanagement und Zombie-Prozessen auf Ihrer Instanz führen, was die Systemleistung beeinträchtigen kann. Stellen Sie sicher, dass Sie diese Risiken vollständig verstehen, bevor Sie mit dem Löschen fortfahren.",
+    "originalCreatedDate": "Ursprüngliches Erstellungsdatum",
+    "welcome": {
+      "menu": "Welcome",
+      "tour": {
+        "title": "Produkt-Tour starten",
+        "text": "Wählen Sie Ihren Anwendungsfall und folgen Sie einer Schritt-für-Schritt-Anleitung, um die Funktionen und Möglichkeiten von Kestra kennenzulernen. ❤️"
+      },
+      "tutorial": {
+        "title": "Tutorial",
+        "text": "* <a href=\"https://kestra.io/tutorial-videos/all?utm_source=app&utm_medium=referral&utm_campaign=welcome-tutorial\" target=\"_blank\">Video-Tutorials</a>  \n* <a href=\"https://kestra.io/docs?utm_source=app&utm_medium=referral&utm_campaign=welcome-tutorial\" target=\"_blank\">Dokumentation</a>  \n* <a href=\"https://kestra.io/blueprints?utm_source=app&utm_medium=referral&utm_campaign=welcome-tutorial\" target=\"_blank\">Blueprints</a>"
+      },
+      "help": {
+        "title": "Brauchen Sie Hilfe?",
+        "text": "Stellen Sie jede Frage in unserer Slack-Community. Wenn Sie feststecken, sind wir hier, um Ihnen zu helfen. ✋"
+      }
+    },
+    "pluginPage": {
+      "search": "Suche in {count}+ Plugins",
+      "searchTasks": "Suche {count} Tasks",
+      "noResults": "Keine Plugins entsprechen Ihrer Suche.",
+      "loadError": "Konnte Plugins nicht laden. Bitte versuchen Sie es erneut.",
+      "notFound": "Dieses Plugin konnte nicht gefunden werden.",
+      "elementType": {
+        "tasks": "Aufgabe",
+        "triggers": "Trigger",
+        "conditions": "Bedingung",
+        "taskRunners": "Task-Runner",
+        "charts": "Diagramm",
+        "apps": "Anwendung",
+        "logExporters": "Log-Exporter",
+        "secrets": "Geheimnis"
+      },
+      "sortBy": "Sortieren nach",
+      "sort": {
+        "nameAsc": "Name A-Z",
+        "nameDesc": "Name Z-A",
+        "newest": "Neueste",
+        "mostUsed": "Am häufigsten verwendet"
+      },
+      "group": {
+        "plugins": "Plugins ({count})",
+        "tasks": "Aufgaben ({count})",
+        "blueprints": "Blueprints ({count})"
+      },
+      "overview": {
+        "title": "Übersicht",
+        "versions": "Versionen",
+        "latest": "Neueste",
+        "releaseNotes": "Versionshinweise",
+        "previousVersions": "Vorherige Versionen",
+        "createdBy": "Erstellt von",
+        "managedBy": "Verwaltet von",
+        "pluginType": "Plugintyp",
+        "linksResources": "Links & Ressourcen",
+        "minKestraVersion": "Min. kompatible Kestra-Version: {version}",
+        "minKestraVersionShort": "Min. Kestra-Version {version}"
+      },
+      "header": {
+        "enterpriseEdition": "Enterprise Edition",
+        "certified": "Zertifiziert",
+        "back": "Zurück zu Plugins"
+      }
+    },
+    "no inputs": "Dieser Flow hat keine Inputs.",
+    "admin_preferences": "Preferences",
     "settings": {
+      "label": "Einstellungen",
+      "updated": "{name} aktualisiert",
       "blocks": {
         "configuration": {
-          "descriptions": {
-            "auto_refresh_interval": "Sekunden zwischen automatischen Datenaktualisierungen auf Listen-Seiten.",
-            "default_namespace": "Wird verwendet, wenn neue flows ohne namespace erstellt werden.",
-            "editor_type": "Editor wird angezeigt, wenn ein flow zum ersten Mal geöffnet wird.",
-            "execute_default_tab": "Registerkarte ausgewählt beim Navigieren zu einer Ausführung.",
-            "execute_flow": "Wo Ausführungsergebnisse nach dem Auslösen eines Runs geöffnet werden.",
-            "flow_default_tab": "Registerkarte ausgewählt beim Navigieren zu einem flow.",
-            "log_display": "Wie Logs bei der Öffnung einer Ausführung dargestellt werden.",
-            "log_level": "Minimale Log-Ebene, die in den Ausführungs-Logs angezeigt wird.",
-            "playground": "Führen Sie Tasks einzeln im Editor-Spielplatz aus.",
-            "triggers_default_tab": "Registerkarte ausgewählt beim Navigieren zur Trigger-Seite."
-          },
+          "label": "Hauptkonfiguration",
           "fields": {
-            "auto_refresh_interval": "Automatisches Aktualisierungsintervall",
-            "default_namespace": "Standard-Namespace",
-            "editor_type": "Standard-Editor-Typ",
-            "execute_default_tab": "Standard-Ausführungs-Registerkarte",
-            "execute_flow": "Flow ausführen",
-            "flow_default_tab": "Standard-Flow-Registerkarte",
             "language": "Sprache",
-            "log_display": "Standard-Log-Anzeige",
+            "default_namespace": "Standard-Namespace",
             "log_level": "Standard-Log-Ebene",
+            "log_display": "Standard-Log-Anzeige",
+            "editor_type": "Standard-Editor-Typ",
+            "execute_flow": "Flow ausführen",
+            "execute_default_tab": "Standard-Ausführungs-Registerkarte",
             "multi_panel_editor": "Multi-Panel-Editor",
+            "flow_default_tab": "Standard-Flow-Registerkarte",
+            "triggers_default_tab": "Standard-Trigger-Registerkarte",
             "playground": "Spielplatz",
-            "triggers_default_tab": "Standard-Trigger-Registerkarte"
+            "auto_refresh_interval": "Automatisches Aktualisierungsintervall"
           },
-          "label": "Hauptkonfiguration"
-        },
-        "export": {
-          "fields": {
-            "flows": "Alle Flows exportieren",
-            "templates": "Alle Vorlagen exportieren"
-          },
-          "label": "Exportieren"
-        },
-        "localization": {
           "descriptions": {
-            "date_format": "Format zur Anzeige von Datumsangaben im gesamten Dashboard.",
-            "language": "Oberflächensprache für Menüs und Labels.",
-            "time_zone": "Wird zur Anzeige von Ausführungsdaten und geplanten Triggers verwendet."
-          },
-          "fields": {
-            "date_format": "Datumsformat",
-            "time_zone": "Zeitzone"
-          },
-          "label": "Sprache und Region",
-          "note": "Beachten Sie, dass diese Einstellung für die Anzeige von Datums- und Uhrzeiteigenschaften in der Benutzeroberfläche verwendet wird. Um Ihre Flows in einer anderen Zeitzone als UTC zu konfigurieren, stellen Sie sicher, dass Sie die Zeitzoneneigenschaft im Schedule-Trigger in Ihrem Flow-Code oder in Ihren Plugin-Standardeinstellungen festlegen."
-        },
-        "reset_section_to_defaults": "Stellen Sie die Standardwerte dieses Abschnitts wieder her",
-        "save": {
-          "discard": "Verwerfen",
-          "label": "Präferenzen speichern",
-          "unsaved_title": "Nicht gespeicherte Änderungen",
-          "unsaved_warning": "Sie haben ungespeicherte Änderungen. Möchten Sie diese speichern, bevor Sie die Seite verlassen?"
-        },
-        "sidebar": {
-          "descriptions": {
-            "items": "Elemente in der Seitenleiste anzeigen, ausblenden und neu anordnen."
-          },
-          "fields": {
-            "items": "Navigationspunkte"
-          },
-          "label": "Seitenleiste"
+            "default_namespace": "Wird verwendet, wenn neue flows ohne namespace erstellt werden.",
+            "log_level": "Minimale Log-Ebene, die in den Ausführungs-Logs angezeigt wird.",
+            "log_display": "Wie Logs bei der Öffnung einer Ausführung dargestellt werden.",
+            "editor_type": "Editor wird angezeigt, wenn ein flow zum ersten Mal geöffnet wird.",
+            "execute_flow": "Wo Ausführungsergebnisse nach dem Auslösen eines Runs geöffnet werden.",
+            "execute_default_tab": "Registerkarte ausgewählt beim Navigieren zu einer Ausführung.",
+            "flow_default_tab": "Registerkarte ausgewählt beim Navigieren zu einem flow.",
+            "triggers_default_tab": "Registerkarte ausgewählt beim Navigieren zur Trigger-Seite.",
+            "auto_refresh_interval": "Sekunden zwischen automatischen Datenaktualisierungen auf Listen-Seiten.",
+            "playground": "Führen Sie Tasks einzeln im Editor-Spielplatz aus."
+          }
         },
         "theme": {
-          "app_font_size_options": {
-            "large": "Groß",
-            "medium": "Mittel",
-            "small": "Klein"
-          },
-          "color_modes": {
-            "dark_1": "Dunkel 1.0",
-            "dark_2": "Dunkel 2.0",
-            "light": "Hell",
-            "sync": "Mit System synchronisieren"
-          },
-          "confirmations": {
-            "color_mode": "Ihre Oberfläche verwendet jetzt das Design `{mode}`."
-          },
-          "descriptions": {
-            "app_font_size": "Skalierungsfaktor für alle Schriftgrößen der Benutzeroberfläche.",
-            "color_mode": "Wählen Sie Ihren bevorzugten Interface-Modus.",
-            "color_mode_shortcut": "Tipp: Drücken Sie <kbd>Strg</kbd>+<kbd>Umschalt</kbd>+<kbd>L</kbd>, um Designs von überall zu wechseln.",
-            "editor_folding_stratgy": "Standardmäßig lange YAML-Blöcke beim Öffnen eines flow ausklappen.",
-            "editor_font_family": "Monospace-Schriftart, die im YAML-Editor verwendet wird.",
-            "editor_font_size": "Schriftgröße, die in den YAML- und No-Code-Editoren verwendet wird.",
-            "editor_hover_description": "Eigenschaftsbeschreibungen beim Hover im Editor anzeigen.",
-            "environment_color": "Auffälligkeitsfarbe, die für die aktuelle Umgebung in der Navigation verwendet wird.",
-            "environment_name": "Anzeigename für die aktuelle Umgebung, der in der Navigation angezeigt wird.",
-            "logs_font_size": "Schriftgröße, die in Log-Viewern und Terminals verwendet wird."
-          },
+          "label": "Modus-Einstellungen",
           "fields": {
             "app_font_size": "App-Schriftgröße",
             "chart_color_scheme": {
+              "label": "Diagramm-Farbschema",
               "classic": "Klassisch",
-              "kestra": "Kestra",
-              "label": "Diagramm-Farbschema"
+              "kestra": "Kestra"
             },
             "color_mode": "Farbmodus",
             "editor_folding_stratgy": "Automatisch Code im Editor zusammenklappen",
@@ -1850,24 +1066,867 @@
             "logs_font_size": "Logs Schriftgröße",
             "theme": "Modus"
           },
-          "label": "Modus-Einstellungen"
+          "color_modes": {
+            "dark_2": "Dunkel 2.0",
+            "dark_1": "Dunkel 1.0",
+            "light": "Hell",
+            "sync": "Mit System synchronisieren"
+          },
+          "confirmations": {
+            "color_mode": "Ihre Oberfläche verwendet jetzt das Design `{mode}`."
+          },
+          "descriptions": {
+            "color_mode": "Wählen Sie Ihren bevorzugten Interface-Modus.",
+            "color_mode_shortcut": "Tipp: Drücken Sie <kbd>Strg</kbd>+<kbd>Umschalt</kbd>+<kbd>L</kbd>, um Designs von überall zu wechseln.",
+            "logs_font_size": "Schriftgröße, die in Log-Viewern und Terminals verwendet wird.",
+            "editor_font_family": "Monospace-Schriftart, die im YAML-Editor verwendet wird.",
+            "editor_font_size": "Schriftgröße, die in den YAML- und No-Code-Editoren verwendet wird.",
+            "editor_folding_stratgy": "Standardmäßig lange YAML-Blöcke beim Öffnen eines flow ausklappen.",
+            "editor_hover_description": "Eigenschaftsbeschreibungen beim Hover im Editor anzeigen.",
+            "environment_name": "Anzeigename für die aktuelle Umgebung, der in der Navigation angezeigt wird.",
+            "environment_color": "Auffälligkeitsfarbe, die für die aktuelle Umgebung in der Navigation verwendet wird.",
+            "app_font_size": "Skalierungsfaktor für alle Schriftgrößen der Benutzeroberfläche."
+          },
+          "app_font_size_options": {
+            "small": "Klein",
+            "medium": "Mittel",
+            "large": "Groß"
+          }
+        },
+        "localization": {
+          "label": "Sprache und Region",
+          "note": "Beachten Sie, dass diese Einstellung für die Anzeige von Datums- und Uhrzeiteigenschaften in der Benutzeroberfläche verwendet wird. Um Ihre Flows in einer anderen Zeitzone als UTC zu konfigurieren, stellen Sie sicher, dass Sie die Zeitzoneneigenschaft im Schedule-Trigger in Ihrem Flow-Code oder in Ihren Plugin-Standardeinstellungen festlegen.",
+          "fields": {
+            "time_zone": "Zeitzone",
+            "date_format": "Datumsformat"
+          },
+          "descriptions": {
+            "language": "Oberflächensprache für Menüs und Labels.",
+            "time_zone": "Wird zur Anzeige von Ausführungsdaten und geplanten Triggers verwendet.",
+            "date_format": "Format zur Anzeige von Datumsangaben im gesamten Dashboard."
+          }
+        },
+        "export": {
+          "label": "Exportieren",
+          "fields": {
+            "flows": "Alle Flows exportieren",
+            "templates": "Alle Vorlagen exportieren"
+          }
+        },
+        "save": {
+          "label": "Präferenzen speichern",
+          "discard": "Verwerfen",
+          "unsaved_title": "Nicht gespeicherte Änderungen",
+          "unsaved_warning": "Sie haben ungespeicherte Änderungen. Möchten Sie diese speichern, bevor Sie die Seite verlassen?"
+        },
+        "reset_section_to_defaults": "Stellen Sie die Standardwerte dieses Abschnitts wieder her",
+        "sidebar": {
+          "label": "Seitenleiste",
+          "fields": {
+            "items": "Navigationspunkte"
+          },
+          "descriptions": {
+            "items": "Elemente in der Seitenleiste anzeigen, ausblenden und neu anordnen."
+          }
+        }
+      }
+    },
+    "apps": "Apps",
+    "demos": {
+      "enterprise_edition": "Enterprise Edition",
+      "get_a_demo_button": "Demo anfordern",
+      "contact_sales": "Vertrieb kontaktieren",
+      "watch_the_video": "Sieh dir das Video an",
+      "secrets": {
+        "title": "Aktualisieren Sie Ihr Secrets Management",
+        "message": "Die Enterprise Edition (EE) ermöglicht es Ihnen, Geheimnisse direkt in der UI hinzuzufügen, zu bearbeiten oder zu löschen – ohne Neustart der Instanz. Organisieren Sie Geheimnisse nach namespace mit detaillierten RBAC-Berechtigungen und erben Sie sie von übergeordneten zu untergeordneten namespaces. EE integriert sich mit Geheimnis-Managern wie HashiCorp Vault, AWS Secrets Manager, Azure Key Vault, Google Secret Manager und Elasticsearch. Richten Sie dedizierte Backends pro namespace, Mandant oder Instanz ein, um Geheimnisse zwischen Teams zu isolieren, oder aktivieren Sie schreibgeschützte Geheimnisse, die in externen Tresoren gespeichert sind. Geheimnisse bleiben sowohl im Ruhezustand als auch während der Übertragung verschlüsselt. Optionales Caching reduziert API-Aufrufe, und Prüfpfade protokollieren alle Zugriffe.",
+        "detected_env": "Hier sind Umgebungsvariablen vom Typ \"secret\", die beim Start der Instanz identifiziert wurden:",
+        "empty_env": "Sie haben noch keine Secrets in Ihrer Umgebung.",
+        "add_env": {
+          "intro": "Um ein neues Secret zu erstellen:",
+          "first": "Kodieren Sie den <a href=\"https://kestra.io/docs/how-to-guides/secrets?utm_source=app&utm_medium=referral&utm_campaign=secrets-inlinedoc#using-secrets-in-kestra\" target=\"_blank\">geheimen Wert in Base64</a>",
+          "second": "Fügen Sie eine Umgebungsvariable mit dem Namen '<strong>SECRET_{'{MY_SECRET_KEY}'}</strong>' mit dem obigen Wert hinzu",
+          "third": "Starte deine Kestra-Instanz neu"
         }
       },
-      "label": "Einstellungen",
-      "updated": "{name} aktualisiert"
+      "apps": {
+        "title": "Erstellen Sie benutzerdefinierte Apps mit Kestra",
+        "message": "Apps in der Kestra Enterprise Edition ermöglichen es Ihnen, benutzerdefinierte UIs zu erstellen, die mit Kestra-Workflows außerhalb der Plattform interagieren. Diese Funktion erlaubt es Ihnen, Ihre Workflows als Backend für benutzerdefinierte Anwendungen zu nutzen, sodass nicht-technische Benutzer Daten über Formulare einreichen oder pausierte Workflows, die auf eine Genehmigung warten, fortsetzen können."
+      },
+      "tests": {
+        "label": "Tests",
+        "header": "Unittests für Flows",
+        "title": "Sicherstellen der Zuverlässigkeit bei jeder Änderung",
+        "message": "Überprüfen Sie die Logik Ihrer flows isoliert, erkennen Sie frühzeitig Regressionen und bewahren Sie das Vertrauen in Ihre Automatisierungen, während sie sich ändern und wachsen."
+      },
+      "assets": {
+        "label": "Assets",
+        "header": "Assets-Metadaten und Observability",
+        "title": "Bringen Sie jedes Dataset, jeden Service und jede Abhängigkeit in Sicht.",
+        "message": "Assets verbinden Observability-, Lineage- und Ownership-Metadaten, damit Plattformteams schneller Probleme beheben und mit Vertrauen bereitstellen können."
+      },
+      "IAM": {
+        "title": "Benutzer über IAM mit SSO, SCIM und RBAC verwalten",
+        "message": "Kestra Enterprise Edition verfügt über integrierte IAM-Funktionen mit Single Sign-On (SSO), SCIM-Verzeichnissynchronisation und rollenbasierter Zugriffskontrolle (RBAC). Es integriert sich mit mehreren Identitätsanbietern und ermöglicht Ihnen, feingranulare Berechtigungen für Benutzer und Dienstkonten zuzuweisen."
+      },
+      "tenants": {
+        "title": "Verwalten Sie Workflows in isolierten Tenants",
+        "message": "Die Kestra Enterprise Edition unterstützt Multi-Tenancy und bietet vollständig isolierte Umgebungen für verschiedene Teams oder Projekte, jeweils mit eigenen Ressourcen wie dedizierten Worker-Gruppen oder Secrets und internen Speicher-Backends."
+      },
+      "audit-logs": {
+        "title": "Änderungen mit Audit Logs nachverfolgen",
+        "message": "Kestra Enterprise Edition protokolliert jede Aktivität mit robusten, unveränderlichen Aufzeichnungen, was es einfach macht, Änderungen nachzuverfolgen, die Einhaltung von Vorschriften zu gewährleisten und Probleme zu beheben."
+      },
+      "quotas": {
+        "title": "Ausführungskontingente für Flows festlegen",
+        "message": "Kestra Enterprise Edition ermöglicht es Ihnen, Kontingente für Flows festzulegen, um die Anzahl gleichzeitiger oder gesamter Ausführungen in einem Zeitfenster zu begrenzen. Kontingente helfen Ihnen, gemeinsam genutzte Infrastruktur zu schützen, SLAs durchzusetzen und unkontrollierte Workflows daran zu hindern, übermäßige Ressourcen zu verbrauchen."
+      },
+      "instance": {
+        "title": "Verwalten Sie die Infrastruktur in Ihrer Instanz",
+        "message": "Kestra Enterprise Edition bietet ein operatives Dashboard, das Ihnen hilft, die Gesundheit Ihrer Plattform zu überwachen und die Betriebszeitmetriken aller Dienste wie z.B. Workers, Schedulers und Executors zu verfolgen. Auf derselben Seite können Sie auch Ankündigungen erstellen, um Ihre Benutzer über geplante Ausfallzeiten zu informieren, und Sie können einen Wartungsmodus aktivieren, der vorübergehend alle Dienste und Workflow-Ausführungen in einen PAUSED-Zustand versetzt, um ein Upgrade durchzuführen."
+      },
+      "blueprints": {
+        "title": "Benutzerdefinierte Blueprints hinzufügen",
+        "message": "In der Kestra Enterprise Edition können Sie benutzerdefinierte Blueprints erstellen, die nur für Ihre Organisation verfügbar sind. Sie können diese als Best-Practice-Vorlagen verwenden, um häufig genutzte Workflows in Ihrem Team zu teilen, zu zentralisieren und zu dokumentieren."
+      },
+      "namespace": {
+        "edit": {
+          "title": "Verbessern Sie Ihr Namespace-Management",
+          "message": "In der Kestra Enterprise Edition bieten Namespaces erweiterte Isolation und Governance von Secrets, Variablen und Plugin-Standardeinstellungen im großen Maßstab. Administratoren können benutzerdefinierte Secrets-Manager, isolierte Speicher-Backends, dedizierte Worker-Gruppen und fein abgestufte Berechtigungen auf Basis von Namespaces konfigurieren. Dies stellt sicher, dass Secrets, Variablen und Plugin-Konfigurationen über verschiedene Teams und Projekte hinweg sicher und einfach zu verwalten bleiben."
+        },
+        "secrets": {
+          "title": "Geheimnisse auf sichere Weise verwalten",
+          "message": "In der Kestra Enterprise Edition können Sie Geheimnisse auf der Namespace-Ebene speichern und verwalten, um Risiken zu minimieren und sicherzustellen, dass die Anmeldedaten jedes Teams isoliert bleiben. Dank der verschachtelten Hierarchie können Sie auch Anmeldedaten in einem übergeordneten Namespace konfigurieren, die dann von allen untergeordneten Namespaces geerbt werden. Die Unterstützung für dedizierte Geheimnis-Manager und fein abgestufte Berechtigungseinstellungen auf Namespace-Ebene stärkt die Sicherheit und Compliance weiter."
+        },
+        "assets": {
+          "title": "Zentralisiere Asset-Management",
+          "message": "In Kestra Enterprise Edition führt Assets ein Live-Inventar der Ressourcen, mit denen Ihre Workflows interagieren. Diese Ressourcen können Datenbanktabellen, virtuelle Maschinen, Dateien oder jedes externe System sein, mit dem Sie arbeiten."
+        },
+        "variables": {
+          "title": "Verwalten Sie Ihre Variablen zentral",
+          "message": "In der Kestra Enterprise Edition können Sie namespace-spezifische Variablen definieren und verwalten, um wiederholte Konfigurationen über Flows hinweg zu eliminieren. Diese Variablen gewährleisten Konsistenz, vereinfachen Konfigurationsaktualisierungen und können von jedem Task oder Trigger leicht referenziert werden, um sauberere und besser wartbare Workflows zu ermöglichen."
+        },
+        "plugin-defaults": {
+          "title": "Konfiguration mit Plugin-Standards standardisieren",
+          "message": "In der Kestra Enterprise Edition können Sie namespace-spezifische Plugin-Standardeinstellungen festlegen, wodurch der Bedarf an doppelter Einrichtung in jedem Flow reduziert wird. Diese zentrale Plugin-Verwaltung erzwingt konsistente Konfigurationen, ermöglicht die sichere Referenzierung von Geheimnissen oder Variablen und vereinfacht die Wartung Ihrer Workflows."
+        },
+        "history": {
+          "title": "Verwalten Sie die Revisionshistorie an einem Ort",
+          "message": "In der Kestra Enterprise Edition können Sie die Versionshistorie Ihrer Namespaces verwalten."
+        },
+        "audit-logs": {
+          "title": "Alle Änderungen an einem Ort verfolgen",
+          "message": "In der Kestra Enterprise Edition können Sie Audit-Logs auf Namespace-Ebene mit detaillierten Diffs anzeigen, die Ihnen eine klare Historie darüber geben, wer was und wann an allen Ressourcen geändert hat."
+        }
+      }
+    },
+    "assets": {
+      "title": "Vermögenswerte"
+    },
+    "onboarding": {
+      "welcome": {
+        "headline": "Erstellen und starten Sie Ihren ersten Workflow in wenigen Minuten",
+        "guided_title": "Erstellen Sie Ihren ersten Flow",
+        "badge": "Tutorial",
+        "guided_description": "Erfahren Sie mit geführten Schritten, wie Sie Ihren ersten Flow erstellen und ausführen.",
+        "guided_duration": "Für die meisten empfohlen",
+        "self_serve_title": "Flow von Grund auf erstellen",
+        "self_serve_description": "Gehen Sie direkt zum Editor und erstellen Sie Ihren eigenen Flow.",
+        "self_serve_note": "Für erfahrene Nutzer",
+        "additional_help": "Weitere Hilfe",
+        "docs": "Dokumentation",
+        "tutorial": "Tutorial",
+        "blueprints": "Blueprints",
+        "slack": "Slack-Community"
+      },
+      "steps": {
+        "flow_basics": {
+          "title": "Flow-Grundlagen",
+          "description": "In Kestra ist ein <code>flow</code> die zentrale Orchestrierungseinheit. Sie definieren ihn in YAML mit Metadaten und geordneten Tasks.<br><br>Sehen Sie sich die Beispielstruktur unten an und erstellen Sie sie anschließend Schritt für Schritt."
+        },
+        "add_id": {
+          "title": "Flow-ID hinzufügen",
+          "description": "Die ID ist der eindeutige Name Ihres Flows, damit Sie ihn finden, ausführen und konsistent referenzieren können.<br><br>Fügen Sie nun <code>id</code> auf der Root-Ebene hinzu."
+        },
+        "add_namespace": {
+          "title": "Namespace hinzufügen",
+          "description": "Der Namespace ist eine ordnerähnliche Gruppierung, die Flows nach Team, Projekt oder Umgebung organisiert.<br><br>Fügen Sie nun <code>namespace</code> auf der Root-Ebene hinzu."
+        },
+        "add_input": {
+          "title": "Eingabe hinzufügen",
+          "description": "Inputs sind Flow-Parameter, die innerhalb von Tasks referenziert werden können, um das Verhalten zur Laufzeit dynamisch zu steuern.<br><br>Fügen Sie nun einen Input namens <code>name</code> mit dem Typ <code>STRING</code> hinzu."
+        },
+        "add_log_task": {
+          "title": "Ersten Task hinzufügen",
+          "description": "Tasks sind die Arbeitseinheiten, die Ihr Flow ausführt. Sie werden als geordnete Liste von Schritten definiert. Jeder Task benötigt eine eindeutige <code>id</code> und einen <code>type</code>. Kestra bietet viele Task-Plugins für externe Systeme; hier verwenden wir einen Python-Script-Task.<br><br>Die Syntax <code>&#123;&#123; ... &#125;&#125;</code> ist ein Pebble-Ausdruck, um Variablen zur Laufzeit dynamisch zu referenzieren, z. B. <code>&#123;&#123; inputs.name &#125;&#125;</code> aus Ihren Flow-Inputs.<br><br>Fügen Sie nun den ersten Task unter <code>tasks</code> hinzu – mit <code>id</code>, <code>type</code> und einem <code>script</code>, das eine Begrüßung ausgibt."
+        },
+        "save_flow": {
+          "title": "Flow speichern",
+          "description": "Durch das Speichern wird Ihre Flow-Definition dauerhaft gespeichert, damit sie ausgeführt werden kann."
+        },
+        "execute_flow": {
+          "title": "Flow ausführen",
+          "description": "Durch das Ausführen starten Sie einen Lauf Ihres Flows mit Eingabewerten zur Laufzeit."
+        },
+        "view_logs_status": {
+          "title": "Ausführung prüfen",
+          "description": "Ausführungsdetails zeigen den Status des Laufs, Zeitinformationen und Task-spezifische Ausgabelogs.<br><br>Öffnen Sie nun die Ausführungsdetails und klicken Sie im Gantt-Diagramm auf <code>greet</code>, um die Logs zu sehen."
+        },
+        "edit_flow_from_execution": {
+          "title": "Zurück zum Flow-Editor",
+          "description": "Sie können direkt aus einer Ausführung zurück zur Flow-Definition springen, um schnell weiter zu iterieren."
+        },
+        "add_cron_trigger": {
+          "title": "Cron-Trigger hinzufügen",
+          "description": "Trigger können Läufe anhand von Zeitplänen oder externen Ereignissen starten (z. B. Webhooks oder MQTT-Nachrichten).<br><br>Fügen Sie nun einen Cron-Schedule-Trigger hinzu, damit dieser Flow alle 5 Minuten ausgeführt wird."
+        },
+        "add_input_default": {
+          "title": "Standardwert für Input setzen",
+          "description": "Wenn ein Flow automatisch ausgelöst wird, benötigen Inputs trotzdem Werte zur Laufzeit.<br><br>Der Input <code>name</code> wurde bereits im vorherigen Schritt erstellt, daher müssen Sie ihn nicht erneut hinzufügen. Setzen Sie einfach einen Standardwert für den bestehenden Input <code>name</code>."
+        },
+        "save_flow_again": {
+          "title": "Flow speichern",
+          "description": "Ihr Flow hat jetzt einen Zeitplan und einen Standardwert für automatische Ausführungen."
+        },
+        "background_runs_info": {
+          "title": "Geplante Ausführungen",
+          "description": "Dieser Flow wird nun alle 5 Minuten im Hintergrund ausgeführt.<br><br>Sie können über das linke Menü zur Übersicht „Ausführungen“ navigieren, um geplante Runs zu überwachen."
+        },
+        "finish": {
+          "title": "Sie haben das Tutorial „Erster Flow“ abgeschlossen",
+          "description": "Guter Start. Sie haben einen Flow erstellt, ausgeführt, parametrisiert und geplant.<br><br>Wählen Sie als Nächstes aus, was Sie tun möchten ..."
+        }
+      },
+      "actions": {
+        "next": "Weiter",
+        "complete": "Abschließen",
+        "save_to_continue": "Klicken Sie oben rechts in der Leiste auf „Speichern“.",
+        "execute_to_continue": "1. Klicken Sie oben rechts in der Leiste auf „Ausführen“.\n2. Geben Sie einen Wert für <strong>name</strong> an.\n3. Klicken Sie im Dialog erneut auf „Ausführen“.",
+        "edit_flow_to_continue": "Klicken Sie oben rechts in der Leiste auf „Flow bearbeiten“.",
+        "cancel_tutorial": "Tutorial abbrechen",
+        "finish_tutorial": "Tutorial beenden"
+      },
+      "finish_actions": {
+        "explore_blueprints": "Blueprints entdecken",
+        "create_flow": "Flow erstellen"
+      },
+      "editor_hints": {
+        "build_intro": "Erstellen Sie Ihren ersten Flow Schritt für Schritt.",
+        "step_1": "# 1) ID hinzufügen",
+        "step_2": "# 2) Namespace hinzufügen",
+        "step_3": "# 3) Eingabe hinzufügen",
+        "step_4": "# 4) Tasks hinzufügen und Ihren ersten Python-Task erstellen",
+        "step_5": "# 5) Cron-Trigger hinzufügen"
+      },
+      "cancel_modal": {
+        "title": "Tutorial „Erster Flow“ abbrechen",
+        "description": "Möchten Sie das Tutorial „Erster Flow“ abbrechen?",
+        "confirm": "Tutorial abbrechen",
+        "keep": "Tutorial fortsetzen"
+      },
+      "validation": {
+        "complete_step": "Fast geschafft. Schließen Sie diesen Schritt ab, um fortzufahren.",
+        "fix_yaml": "Es gibt ein kleines YAML-Formatierungsproblem. Beheben Sie es und fahren Sie dann fort.",
+        "add_id": "Fügen Sie oben eine Flow-ID hinzu. Beispiel: `id: hello_flow`.",
+        "add_namespace": "Fügen Sie oben einen Namespace hinzu. Beispiel: `namespace: company.team`.",
+        "add_input_section": "Erstellen Sie einen Abschnitt `inputs` mit einem Input.",
+        "add_input_id": "Fügen Sie innerhalb von `inputs` `id: name` hinzu.",
+        "add_input_type": "Setzen Sie den Input-Typ auf `STRING`.",
+        "add_log_task_section": "Erstellen Sie einen Abschnitt `tasks` und fügen Sie Ihren ersten Task hinzu.",
+        "add_log_task_id": "Geben Sie dem Task eine ID, z. B.: `id: greet`.",
+        "add_log_task_type": "Setzen Sie den Task-Typ auf `io.kestra.plugin.scripts.python.Script`.",
+        "add_log_task_message": "Fügen Sie dem Task ein Feld `script` hinzu.",
+        "add_log_task_pebble": "Verwenden Sie im Script einen Pebble-Ausdruck, damit Ihr Input-Wert genutzt wird (z. B.: `inputs.name`).",
+        "save_flow": "Klicken Sie auf „Speichern“, um fortzufahren.",
+        "execute_flow": "Führen Sie den Flow einmal aus, um fortzufahren.",
+        "view_logs_status": "Öffnen Sie die Ausführungsdetails und prüfen Sie die Logs für `greet`.",
+        "edit_flow_from_execution": "Klicken Sie oben in der Leiste auf „Flow bearbeiten“, um fortzufahren.",
+        "add_cron_trigger_section": "Erstellen Sie einen Abschnitt `triggers` mit einem Schedule-Trigger.",
+        "add_cron_trigger_type": "Setzen Sie den Trigger-Typ auf `io.kestra.plugin.core.trigger.Schedule`.",
+        "add_cron_trigger_cron": "Fügen Sie einen Cron-Ausdruck hinzu, z. B.: `\"*/5 * * * *\"`.",
+        "add_input_default_section": "Gehen Sie zurück zu `inputs` und behalten Sie einen bestehenden Input namens `name` (fügen Sie keinen zweiten Input hinzu).",
+        "add_input_default_id": "Behalten Sie die bestehende Input-ID als `name`.",
+        "add_input_default_defaults": "Fügen Sie einen Standardwert für `name` hinzu, z. B.: `defaults: \"Kestra\"`.",
+        "save_flow_again": "Klicken Sie erneut auf „Speichern“, um fortzufahren."
+      }
+    },
+    "enable concurrency": "Nebenläufigkeit aktivieren",
+    "auditlogs": "Audit Logs",
+    "quotas": "Quotas",
+    "iam": "IAM",
+    "tenant": {
+      "name": "Mandant",
+      "names": "Mandanten"
+    },
+    "ee-tooltip": {
+      "features-blocked": "Diese Funktion erfordert die Enterprise Edition.",
+      "button": "Sprechen Sie mit uns"
+    },
+    "flow_only": "Nur auf der Flow-Registerkarte verfügbar.",
+    "bulk action async warning": "Dies kann einige Augenblicke dauern.",
+    "bulk unpause backfills": "{count} Backfill fortsetzen",
+    "bulk pause backfills": "{count} Backfill pausieren",
+    "bulk delete backfills": "{count} Backfill löschen",
+    "bulk unlock": "{count} Trigger entsperren",
+    "bulk disabled status": {
+      "true": "{count} Trigger deaktivieren",
+      "false": "{count} Trigger aktivieren"
+    },
+    "unlock": "Entsperren",
+    "bulk success unpause backfills": "{count} Backfills fortgesetzt",
+    "bulk success pause backfills": "{count} Backfills pausiert",
+    "bulk success delete backfills": "{count} Backfills gelöscht",
+    "bulk success unlock": "{count} Trigger entsperrt",
+    "bulk success disabled status": {
+      "true": "{count} Trigger deaktiviert",
+      "false": "{count} Trigger aktiviert"
+    },
+    "no_namespaces": "Keine Namespaces entsprechen den Suchkriterien.",
+    "system_namespace": "Behalten Sie Ihre Plattform mit Systemflows im Blick.",
+    "system_namespace_description": "Automatisieren Sie Wartungsaufgaben, von Fehlerwarnungen bis hin zu automatisierten Bereinigungen.",
+    "pluginDefaults": {
+      "title": "Plugin-Standardeinstellungen",
+      "add": "Plugin-Standard hinzufügen",
+      "edit": "Standard-Plugin bearbeiten",
+      "add_subtitle": "Konfigurieren Sie ein neues Plugin-Standard mit seinen Eigenschaften",
+      "edit_subtitle": "Ändern Sie die bestehende Standardkonfiguration des Plugins",
+      "predefined": "Vordefiniertes Plugin",
+      "custom": "Benutzerdefiniertes Plugin",
+      "form": "Formular",
+      "yaml": "YAML",
+      "select_predefined": "Wählen Sie vordefiniertes Plugin",
+      "cancel": "Abbrechen",
+      "update": "Plugin-Standard aktualisieren",
+      "custom_type": "Benutzerdefinierter Plugin-Typ",
+      "custom_placeholder": "Geben Sie den Plugin-Typ ein",
+      "use_custom": "Benutzerdefiniert verwenden",
+      "custom_configure": "Benutzerdefinierter Plugin-Typ - Konfiguration mit YAML",
+      "yaml_configuration": "YAML-Konfiguration",
+      "show_yaml": "YAML anzeigen"
+    },
+    "secret": {
+      "add": "Erstellen",
+      "update": "Aktualisiere Secret '{name}'",
+      "isReadOnly": "Geheimnis ist schreibgeschützt",
+      "names": "Secrets",
+      "inherited": "Geerbte Secrets"
+    },
+    "workerId": "Worker Id",
+    "kv": {
+      "name": "KV Store",
+      "type": "Typ",
+      "add": "Erstellen",
+      "update": "Wert für Key '{key}' aktualisieren",
+      "duplicate": "Dieser Key existiert bereits",
+      "delete multiple": {
+        "confirm": "Möchten Sie wirklich <code>{name}</code> KV(s) löschen?",
+        "warning": "Du hast keine Berechtigungen für diese namespaces, daher werden sie ausgelassen: <code>{namespaces}</code>"
+      },
+      "inherited": "Geerbte KV-Paare"
+    },
+    "expiration": "Ablauf",
+    "failed to render pdf": "PDF-Vorschau konnte nicht gerendert werden",
+    "page": {
+      "previous": "Vorherige Seite",
+      "next": "Nächste Seite"
+    },
+    "namespace_editor": {
+      "empty": {
+        "title": "Derzeit keine Registerkarten geöffnet",
+        "create_message": "Sie können namespace-Dateien erstellen oder importieren.",
+        "video_message": "Sie können sich das Einführungsvideo für unseren Editor ansehen."
+      },
+      "close": {
+        "tab": "Registerkarte schließen",
+        "all": "Alle Registerkarten schließen",
+        "other": "Andere Registerkarten schließen",
+        "right": "Rechts schließen"
+      }
+    },
+    "curl": {
+      "command": "cURL-Befehl",
+      "note": "Beachten Sie, dass bei den Eingabetypen SECRET und FILE der Befehl angepasst werden muss, um den tatsächlichen Werten zu entsprechen."
+    },
+    "webhook": {
+      "curl_command": "Webhook-cURL-Befehl",
+      "payload": "Webhook-Payload (JSON)",
+      "curl_note": "Verwenden Sie diesen cURL-Befehl, um den flow über Webhook mit benutzerdefiniertem JSON-Payload zu triggern.",
+      "no_triggers": "Dieser flow hat keine aktivierten Webhook-Triggers.",
+      "copy_url": "Webhook-URL kopieren"
+    },
+    "logs_view": {
+      "raw": "Temporale Ansicht",
+      "raw_details": "Vollständige Task Logs und Flow Logs in einem rohen, nach Zeitstempel geordneten Format anzeigen",
+      "compact": "Standardansicht",
+      "compact_details": "Task Logs in einer kompakten Ansicht, gruppiert nach jedem Task, anzeigen"
+    },
+    "execution_deletion": {
+      "logs": "Logs löschen",
+      "metrics": "Metriken löschen",
+      "storage": "Interne Speicherdateien löschen"
+    },
+    "scope_filter": {
+      "all": "Alle {label}",
+      "user": "Benutzer {label}",
+      "system": "System {label}",
+      "user_description": "Regulärer Benutzer initiierte {label}",
+      "system_description": "Systemwartung {label}"
+    },
+    "data": "Daten",
+    "webhook link copied": "Webhook-Link kopiert.",
+    "copy url": "URL kopieren",
+    "scheduleDate": "Geplantes Datum",
+    "warning": "Warnung",
+    "trigger_check_warning": "Die Verwendung von Trigger-Variablen funktioniert nicht bei manueller Flow-Ausführung. Fügen Sie den `??`-Koaleszenz-Operator hinzu, um das Problem zu lösen. Verwenden Sie zum Beispiel anstelle von `trigger.date` den Ausdruck `trigger.date ?? execution.startDate`.",
+    "docs": "Dokumentation",
+    "active-slots": "Aktive Slots",
+    "behavior": "Verhalten",
+    "concurrency": "Nebenläufigkeit",
+    "no-executions-view": {
+      "title": "Beginnen Sie mit der Automatisierung mit",
+      "sub_title": "Klicken Sie auf die Ausführen-Schaltfläche, um die erste Workflow-Ausführung zu starten.",
+      "namespace_sub_title": "Führen Sie einen oder mehrere flows aus diesem namespace aus, um dieses Dashboard zu füllen.",
+      "guidance_desc": "Benötigen Sie Unterstützung, um Ihren Flow auszuführen?",
+      "namespace_guidance_desc": "Brauchen Sie Unterstützung bei der Verwaltung Ihres Namespace?",
+      "guidance_sub_desc": "Folgen Sie der Dokumentation für alle Informationen, die Sie benötigen."
+    },
+    "execution_guide": {
+      "get_started": {
+        "title": "Loslegen ⚡",
+        "text": "Befolgen Sie den Quickstart-Guide, um Kestra zu installieren und mit dem Erstellen Ihrer ersten Workflows zu beginnen."
+      },
+      "namespaces": {
+        "title": "Über Namespaces",
+        "text": "Namespaces sind logische Gruppierungen von flows und deren Komponenten."
+      },
+      "workflow_components": {
+        "title": "Workflow-Komponenten",
+        "text": "Lernen Sie die Hauptkomponenten der Orchestrierung eines Kestra-Workflows kennen."
+      },
+      "videos_tutorials": {
+        "title": "Videoanleitungen",
+        "text": "Loslegen mit unseren Video-Tutorials."
+      }
+    },
+    "open sidebar": "Seitenleiste öffnen",
+    "close sidebar": "Seitenleiste schließen",
+    "customize sidebar": "Seitenleiste anpassen",
+    "reset to defaults": "Zurücksetzen auf Standardwerte",
+    "drop items here": "Elemente hier ablegen",
+    "files": "Dateien",
+    "optional": "Optional",
+    "no_data": "Es sieht so aus, als wäre hier noch nichts... bisher!<br/>Passen Sie Ihre Filter an oder versuchen Sie es erneut!",
+    "bookmark": "Lesezeichen",
+    "remove_bookmark": "Sind Sie sicher, dass Sie dieses Lesezeichen entfernen möchten?",
+    "showLess": "Es scheint, dass der Text, den Sie übersetzen möchten, nicht bereitgestellt wurde. Bitte geben Sie den Text nach der Linie \"----------\" ein, damit ich Ihnen bei der Übersetzung ins Deutsche helfen kann.",
+    "showMore": "Mehr anzeigen",
+    "documentationMenu": "Dokumentationsmenü",
+    "item": "Element",
+    "items": "Elemente",
+    "cron": "Cron",
+    "execution_started": "Die Ausführung hat begonnen!",
+    "execution_failed": "Ausführung fehlgeschlagen!",
+    "last error was": "Letzter Fehler war",
+    "execution restarted": "Diese Ausführung wurde {nbRestart} Mal neu gestartet.",
+    "execution replay": "Diese Ausführung ist eine Wiederholung von",
+    "execution replayed": "Diese Ausführung wurde erneut abgespielt.",
+    "task run id": "TaskRun-ID",
+    "active": "Aktiv",
+    "flows imported": "Flows importiert",
+    "flow not imported": "Einige Flows konnten nicht importiert werden",
+    "plugin defaults exported": "Plugin-Standardeinstellungen exportiert",
+    "failed to export plugin defaults": "Fehler beim Exportieren der Plugin-Standardeinstellungen",
+    "plugin defaults imported": "Plugin-Standardeinstellungen importiert",
+    "plugin defaults not imported": "Einige Plugin-Standardeinstellungen konnten nicht importiert werden",
+    "failed to import plugin defaults": "Fehler beim Importieren der Plugin-Standardeinstellungen",
+    "filters": {
+      "label": "Filter auswählen",
+      "empty": "Keine Daten.",
+      "format": "Geben Sie den Parameter als 'key:value' ein",
+      "text_search": "Nach diesem Text suchen",
+      "options": {
+        "namespace": "Namespace",
+        "flow": "Flow",
+        "state": "Zustand",
+        "scope": "Umfang",
+        "child": "Kind",
+        "level": "Log-Ebene",
+        "task": "Aufgabe",
+        "metric": "Metrik",
+        "user": "Benutzer",
+        "type": "Typ",
+        "service_type": "Typ",
+        "permission": "Berechtigung",
+        "action": "Aktion",
+        "status": "Status",
+        "details": "Details",
+        "aggregation": "Aggregation",
+        "relative_date": "Relatives Datum",
+        "absolute_date": "Absolutes Datum",
+        "labels": "Labels",
+        "text": "I'm sorry, but it seems that there is no text provided after \"----------\" for translation. Could you please provide the text you would like me to translate?",
+        "startDate": "Startdatum",
+        "endDate": "Enddatum"
+      },
+      "comparators": {
+        "is": "ist",
+        "is_one_of": "ist eine von",
+        "is_not": "ist nicht",
+        "not_in": "nicht in",
+        "contains": "enthält",
+        "not_contains": "nicht enthält",
+        "in": "im",
+        "between": "zwischen",
+        "starts_with": "beginnt mit",
+        "greater_than": "größer als",
+        "greater_than_or_equal_to": "größer als oder gleich",
+        "less_than": "weniger als",
+        "less_than_or_equal_to": "kleiner oder gleich",
+        "ends_with": "endet mit"
+      },
+      "save": {
+        "label": "Gespeicherte Suchen",
+        "remove": "Entfernen",
+        "empty": "Sie haben noch keine Suche gespeichert.",
+        "tooltip": "Sie können keine leeren Suchkriterien speichern.",
+        "name_already_used": "Suchbegriff {label} bereits verwendet.",
+        "dialog": {
+          "heading": "Aktuelle Suche speichern",
+          "placeholder": "Label",
+          "hint": "Wie möchten Sie dieses Suchkriterium labeln?",
+          "confirmation": "Suchkriterien <code>{name}</code>"
+        }
+      },
+      "settings": {
+        "label": "Seiteneinstellungen",
+        "show_chart": "Hauptdiagramm anzeigen"
+      }
+    },
+    "custom value": "Benutzerdefinierter Wert",
+    "chart": "Diagramm",
+    "chart preview": "Diagrammvorschau",
+    "no_code": {
+      "toggle_pebble": "Pebble-Editor umschalten",
+      "version_oss_placeholder": "Entsperren Sie die Plugin-Versionierung mit der Enterprise Edition",
+      "unnamed": "Kein Name",
+      "adding": "+ {what} hinzufügen",
+      "adding_default": "+ Neuen Wert hinzufügen",
+      "add_field": "Hinzufügen {field}",
+      "clearSelection": "Auswahl aufheben",
+      "labels": {
+        "yaml": "YAML-Editor",
+        "no_code": "Kein Code-Editor",
+        "label": "Label",
+        "variable": "Variable"
+      },
+      "sections": {
+        "deprecated": "Veraltete Eigenschaften",
+        "tasks": "Aufgaben",
+        "triggers": "Trigger",
+        "errors": "Fehlerbehandler",
+        "afterExecution": "Nach Ausführung",
+        "finally": "Schließlich",
+        "pluginDefaults": "Plugin-Standardeinstellungen"
+      },
+      "fields": {
+        "main": {
+          "id": "Flow-ID",
+          "namespace": "Namespace",
+          "description": "Beschreibung",
+          "inputs": "Eingaben"
+        },
+        "general": {
+          "retry": "Wiederholen",
+          "sla": "SLA",
+          "labels": "Labels",
+          "outputs": "Ausgaben",
+          "variables": "Variablen",
+          "concurrency": "Nebenläufigkeit",
+          "disabled": "Deaktiviert",
+          "listeners": "Listener",
+          "taskDefaults": "Standardwerte für Tasks",
+          "workerGroup": "Worker-Gruppe",
+          "workerSelector": "Worker-Selektor",
+          "checks": "Überprüfungen",
+          "updated": "Aktualisiert"
+        }
+      },
+      "select": {
+        "default": "Wählen Sie einen Typ aus",
+        "task": "Wählen Sie eine Task aus",
+        "tasks": "Wählen Sie eine Task aus",
+        "triggers": "Wählen Sie einen Trigger aus",
+        "errors": "Wählen Sie eine Task aus",
+        "finally": "Wählen Sie eine Task aus",
+        "pluginDefaults": "Wählen Sie ein Plugin aus",
+        "afterExecution": "Wählen Sie eine Task aus",
+        "conditions": "Wählen Sie eine Bedingung aus",
+        "inputs": "Wählen Sie einen Input-Feldtyp aus",
+        "charts": "Wählen Sie einen Diagrammtyp aus",
+        "where": "Wählen Sie einen Filtertyp aus",
+        "numerator": "Wählen Sie einen Zähler aus"
+      },
+      "creation": {
+        "default": "Hinzufügen",
+        "tasks": "Aufgabe hinzufügen",
+        "triggers": "Füge einen Trigger hinzu",
+        "errors": "Einen Fehler-Handler hinzufügen",
+        "finally": "Fügen Sie einen Finally-Block hinzu",
+        "pluginDefaults": "Fügen Sie ein Plugin-Default hinzu",
+        "afterExecution": "Fügen Sie einen Block nach der Ausführung hinzu",
+        "conditions": "Bedingung hinzufügen",
+        "inputs": "Ein Eingabefeld hinzufügen",
+        "charts": "Ein Diagramm hinzufügen",
+        "where": "Filtern Sie Ihre Daten",
+        "numerator": "Fügen Sie einen Zähler hinzu"
+      },
+      "remove": {
+        "default": "Diesen Eintrag entfernen",
+        "cases": "Diesen Fall entfernen"
+      }
+    },
+    "properties": {
+      "label": "Eigenschaften",
+      "hint": "Sichtbare Spalten auswählen",
+      "shown": "In Tabelle angezeigt",
+      "hidden": "In Tabelle versteckt"
+    },
+    "editor_shortcuts": {
+      "label": "Tastenkombinationen",
+      "trigger_autocompletion": "Autovervollständigung auslösen",
+      "command_palette": "Befehlsübersicht anzeigen",
+      "save_flow": "Flow speichern",
+      "execute_flow": "Flow ausführen",
+      "toggle_ai_agent": "AI-Agent umschalten",
+      "move_line": "Zeile verschieben",
+      "duplicate_cursor": "Kursor duplizieren",
+      "fold_unfold": "Code ein-/ausklappen",
+      "comment_uncomment": "Kommentar/Kommentar entfernen",
+      "comment": "Kommentar",
+      "uncomment": "Entkommentieren",
+      "decrease_fontsize": "Editor-Schriftgröße verkleinern",
+      "increase_fontsize": "Editor-Schriftgröße erhöhen",
+      "reset_fontsize": "Schriftgröße des Editors zurücksetzen"
+    },
+    "instance": "Instanz",
+    "something_went_wrong": {
+      "loading_execution": "Beim Laden der Ausführung ist etwas schiefgelaufen.",
+      "connection_lost": {
+        "title": "Verbindung unterbrochen",
+        "message": "Wir konnten Ihre Kestra-Instanz nicht erreichen. Stellen Sie sicher, dass sie läuft, und aktualisieren Sie dann die Seite."
+      }
+    },
+    "debug": "Debuggen",
+    "default": "Standard",
+    "data_not_protected": "Ihre Daten sind nicht geschützt. Verlieren Sie sie nicht. <b>Aktivieren Sie unsere kostenlosen Sicherheitsfunktionen oder probieren Sie unser kostenpflichtiges Angebot aus.</b>",
+    "activate_basic_auth": "Aktiviere Basis-Authentifizierung",
+    "dark_version": "Dunkler Modus",
+    "use_dark_background": "Verwenden Sie diese Version, wenn Sie auf einem dunklen Hintergrund arbeiten, um sicherzustellen, dass unser Name lesbar bleibt.",
+    "light_version": "Helle Version",
+    "light_background": "Dies ist die bevorzugte Option bei der Arbeit mit einem hellen Hintergrund.",
+    "monogram": "Monogramm",
+    "wordmark_colors": "Die Farben des Wortzeichens passen sich dem Hintergrund an, während das Icon auf einem dunklen Hintergrund ohne Hintergrund bleibt.",
+    "download_logos": "Logo-Paket herunterladen",
+    "this_task_has": "Diese Task hat",
+    "about_this_blueprint": "Über dieses Blueprint",
+    "deleted_label": "Gelöscht",
+    "fold_all_multi_lines": "Alle Mehrzeiligen Einklappen",
+    "task_id_exists": "Task-ID existiert bereits",
+    "task_id_message": "Task-ID ${existingTask} existiert bereits im Flow.",
+    "trigger_id_exists": "Trigger-ID existiert bereits",
+    "trigger_id_message": "Trigger-ID ${existingTrigger} existiert bereits im Flow.",
+    "watch": "Beobachten",
+    "learn_more": "Erfahren Sie mehr",
+    "watch_video": "Video ansehen",
+    "runners": "Läufer",
+    "select": "Wählen Sie Ihren {{section}} aus",
+    "for flow": "für Flow",
+    "forbidden system labels": "Nur system.correlationId kann als System-Label verwendet werden",
+    "confirm": "Bestätigen",
+    "taskRunners": "Task Runners",
+    "additionalPlugins": "Zusätzliche Plugins",
+    "appBlocks": "App-Blöcke",
+    "charts": "Diagramme",
+    "dataFilters": "Datenfilter",
+    "logExporters": "Log-Exporteure",
+    "empty": {
+      "namespaceFiles": {
+        "title": "Noch keine Dateien in diesem Namespace",
+        "content": "Namespace-Dateien funktionieren wie ein Projektordner für diesen Namespace. Speichern Sie Python-, SQL-, dbt- oder Terraform-Code und referenzieren Sie anschließend jede Datei in Ihren Flows mit"
+      },
+      "announcements": {
+        "title": "Sie haben noch keine Ankündigungen!",
+        "content": "Ankündigungen ermöglichen es Ihnen, Ihre Benutzer über Änderungen zu informieren oder sie über geplante Wartungsarbeiten zu benachrichtigen. Wählen Sie einfach den Ankündigungstyp, den Zeitraum, in dem sie angezeigt werden soll, und schreiben Sie die Ankündigungsnachricht."
+      },
+      "kill_switches": {
+        "title": "Sie haben noch keine Kill Switches!",
+        "content": "Die Kill Switch-Funktion bietet einen UI-basierten Mechanismus, um problematische Ausführungen zu stoppen. Sie ersetzt die nur CLI-basierten Befehle <code>--skip-executions</code> und <code>--skip-flows</code> durch eine umfassende Verwaltungsoberfläche."
+      },
+      "apps": {
+        "title": "Sie haben noch keine Apps!",
+        "content": "Beginnen Sie mit dem Erstellen von Apps, um mit Kestra von der Außenwelt zu interagieren."
+      },
+      "testSuites": {
+        "title": "Sie haben noch keine Test-Suites!",
+        "content": "Beginnen Sie mit der Erstellung von Testsuiten, um Ihre Flows zu testen."
+      },
+      "assets": {
+        "title": "Sie haben noch keine Assets!",
+        "content": "Fügen Sie Assets hinzu, um Ihre Daten-Assets, Dienste und Infrastruktur zu verfolgen und zu verwalten."
+      },
+      "apiTokens": {
+        "title": "Verwalten Sie Ihre API-Tokens",
+        "content": "API-Tokens werden verwendet, wenn Sie programmatischen Zugriff auf die Kestra-API gewähren möchten."
+      },
+      "concurrency_executions": {
+        "title": "Keine laufenden Ausführungen für diesen Flow.",
+        "content": "Erfahren Sie mehr über <strong><a href=\"https://kestra.io/docs/workflow-components/execution?utm_source=app&utm_medium=referral&utm_campaign=concurrency-inlinedoc\" target=\"_blank\">Ausführungen</a></strong> in unserer Dokumentation."
+      },
+      "concurrency_limit": {
+        "title": "Für diesen Flow sind keine Grenzen festgelegt.",
+        "content": "Erfahren Sie mehr über <strong><a href=\"https://kestra.io/docs/workflow-components/concurrency?utm_source=app&utm_medium=referral&utm_campaign=concurrency-inlinedoc\" target=\"_blank\">Nebenläufigkeitsgrenzen</a></strong> in unserer Dokumentation."
+      },
+      "concurrency_limits": {
+        "title": "Es sind keine Nebenläufigkeitsgrenzen festgelegt.",
+        "content": "Lesen Sie mehr über <strong><a href=\"https://kestra.io/docs/workflow-components/concurrency?utm_source=app&utm_medium=referral&utm_campaign=concurrency-inlinedoc\" target=\"_blank\">Nebenläufigkeitsgrenzen</a></strong> in unserer Dokumentation."
+      },
+      "pluginDefaults": {
+        "title": "Sie haben noch keine Plugin-Standards!",
+        "content": "Plugin-Standardeinstellungen ermöglichen es Ihnen, Ihre Plugin-Konfiguration zentral zu verwalten und mit allen flows in Ihrem namespace zu teilen."
+      },
+      "variables": {
+        "title": "Noch keine Variablen vorhanden",
+        "content": "Fügen Sie kv store-Paare hinzu, um Konfigurationen über flows hinweg zu teilen. Untergeordnete namespaces erben sie automatisch, und Sie können jeden Wert mit referenzieren."
+      },
+      "workerRegistrationTokens": {
+        "title": "Sie haben noch keine Registrierungstoken!",
+        "content": "Registrierungstoken ermöglichen es Remote-Workern, sich sicher zu authentifizieren und bei Ihrer Kestra-Instanz zu registrieren. Erstellen Sie ein Token und verwenden Sie es, um neue Worker mit diesem Cluster zu verbinden."
+      },
+      "groups": {
+        "title": "Sie haben noch keine Gruppen!",
+        "content": "Gruppen ermöglichen es Ihnen, Benutzer zusammenzufassen, sodass Sie Berechtigungen und Rollenbindungen gemeinsam über Ihren Mandanten verwalten können."
+      },
+      "dependencies": {
+        "FLOW": {
+          "title": "Derzeit gibt es keine Abhängigkeiten.",
+          "content": "Erfahren Sie mehr über <a href=\"https://kestra.io/docs/ui/flows?utm_source=app&utm_medium=referral&utm_campaign=dependencies-inlinedoc#dependencies\" target=\"_blank\">Flow-Abhängigkeiten</a> in unserer Dokumentation."
+        },
+        "EXECUTION": {
+          "title": "Derzeit gibt es keine Abhängigkeiten.",
+          "content": "Erfahren Sie mehr über <a href=\"https://kestra.io/docs/ui/executions?utm_source=app&utm_medium=referral&utm_campaign=dependencies-inlinedoc#dependencies\" target=\"_blank\">Ausführungsabhängigkeiten</a> in unserer Dokumentation."
+        },
+        "NAMESPACE": {
+          "title": "Derzeit gibt es keine Abhängigkeiten.",
+          "content": "Lesen Sie mehr über <a href=\"https://kestra.io/docs/ui/namespaces?utm_source=app&utm_medium=referral&utm_campaign=dependencies-inlinedoc#dependencies\" target=\"_blank\">Namespace Dependencies</a> in unserer Dokumentation."
+        },
+        "ASSET": {
+          "title": "Derzeit gibt es keine Abhängigkeiten.",
+          "content": "Dieses Asset hat keine Upstream- oder Downstream-Abhängigkeiten mit flows oder anderen Assets."
+        }
+      },
+      "plugins": {
+        "title": "Für diesen Namespace sind keine Plugin-Standardeinstellungen festgelegt.",
+        "content": "Lesen Sie mehr über <strong><a href=\"https://kestra.io/docs/workflow-components/plugin-defaults?utm_source=app&utm_medium=referral&utm_campaign=plugin-default-inlinedoc\" target=\"_blank\">Nebenläufigkeitsgrenzen</a></strong> in unserer Dokumentation."
+      },
+      "triggers": {
+        "title": "Ihr flow hat keine Trigger.",
+        "content": "Lesen Sie mehr über <strong><a href=\"https://kestra.io/docs/workflow-components/triggers?utm_source=app&utm_medium=referral&utm_campaign=trigger-inlinedoc\" target=\"_blank\">Triggers</a></strong> in unserer Dokumentation."
+      },
+      "mcpToolFlows": {
+        "title": "Auf diesem Server sind noch keine Tool flows registriert.",
+        "content": "Expose einen flow als MCP-Tool, indem Sie einen <code>McpToolTrigger</code> hinzufügen. Lesen Sie mehr über den <strong><a href=\"https://kestra.io/docs/workflow-components/triggers/mcp-tool-trigger?utm_source=app&utm_medium=referral&utm_campaign=mcp-tool-trigger-inlinedoc\" target=\"_blank\">MCP Tool Trigger</a></strong> in unserer Dokumentation."
+      },
+      "versionPlugin": {
+        "title": "Sie haben noch kein versioniertes Plugin!",
+        "content": "Hier können Sie alle Plugins verwalten, die auf Ihrer Kestra-Instanz installiert sind. Neu installierte Plugins sind möglicherweise nicht sofort in allen Kestra-Diensten verfügbar, abhängig von der Konfiguration Ihrer Instanz."
+      },
+      "panels": {
+        "title": "Kein Panel geöffnet",
+        "content": "Du hast alle Panels geschlossen.  \nWähle oben eine Registerkarte, um fortzufahren."
+      }
+    },
+    "toggle_word_wrap": "Zeilenumbruch umschalten",
+    "copied_logs_to_clipboard": "Logs in die Zwischenablage kopiert.",
+    "multi_panel_editor": {
+      "move_right": "Nach rechts verschieben",
+      "move_left": "Nach links verschieben",
+      "close_all_tabs": "Alle Registerkarten schließen",
+      "close_all_panels": "Alle Panels schließen"
+    },
+    "search_docs": "Suche",
+    "no_results_found": "Keine Ergebnisse gefunden",
+    "searching": "Suche läuft...",
+    "worker information": "Worker-Informationen",
+    "test-badge-text": "Test",
+    "test-badge-tooltip": "Diese Ausführung wurde durch einen Test erstellt",
+    "total_executions": "Gesamte Ausführungen",
+    "no_results": {
+      "executions": "Keine Ausführungen gefunden",
+      "triggers": "Keine Trigger gefunden",
+      "flows": "Keine Flows gefunden",
+      "kv_pairs": "Keine Key-Value-Paare gefunden",
+      "secrets": "Keine Secrets gefunden",
+      "templates": "Keine Vorlagen gefunden",
+      "assets": "Keine Assets gefunden"
+    },
+    "duplicate-pair": "{label} \"{key}\" ist dupliziert, erster Schlüssel ignoriert.",
+    "dashboards": {
+      "labels": {
+        "singular": "Dashboard",
+        "plural": "Dashboards"
+      },
+      "default": "Standard-Dashboard",
+      "switch": "Dashboard wechseln",
+      "preview": "Vorschau-Dashboard",
+      "empty": "Es gibt keine Ergebnisse anzuzeigen.",
+      "creation": {
+        "label": "Dashboard erstellen",
+        "confirmation": "Das Dashboard <code>{title}</code> wurde erstellt."
+      },
+      "edition": {
+        "label": "Dashboard bearbeiten",
+        "confirmation": "Änderungen im Dashboard <code>{title}</code> werden gespeichert.",
+        "chart": "Bearbeiten Sie dieses Diagramm",
+        "id readonly": "Die Eigenschaft `id` kann nicht geändert werden — sie ist jetzt auf ihre Anfangswerte festgelegt. Wenn Sie sie ändern möchten, können Sie ein neues Dashboard erstellen und das alte entfernen."
+      },
+      "deletion": {
+        "confirmation": "Möchten Sie das Dashboard <code>{title}</code> wirklich löschen?"
+      },
+      "no_description": "Keine Beschreibung",
+      "no_description_hint": "Füge eine Beschreibung zu diesem flow hinzu, um zu dokumentieren, was er tut.<br>Markdown wird unterstützt.",
+      "others": "Andere",
+      "viewAll": "Alle anzeigen",
+      "chart_preview": "Klicken Sie auf einen Chart-Quellcode, um die Vorschau anzuzeigen.",
+      "export": "Exportieren nach CSV",
+      "quick_filters": {
+        "all": "Alle",
+        "running": "Läuft",
+        "paused": "Pausiert",
+        "success": "Erfolg",
+        "warning": "Warnung",
+        "failed": "Fehlgeschlagen"
+      }
     },
     "setup": {
-      "config": {
-        "basicauth": "Einfache Authentifizierung",
-        "queue": "Warteschlange",
-        "repository": "Datenbank",
-        "storage": "Interner Speicher"
+      "login": "Anmelden",
+      "login_title": "Anmelden",
+      "logout": "Abmelden",
+      "troubleshooting": "Passwort vergessen?",
+      "steps": {
+        "user": "Admin-Benutzer erstellen",
+        "config": "Konfiguration validieren",
+        "survey": "Erzählen Sie uns mehr",
+        "complete": "Kestra UI starten"
       },
-      "confirm": {
-        "config_title": "Bestätigen Sie, dass die Konfiguration gültig ist",
-        "confirm": "Admin-Benutzer erstellen",
-        "not_valid": "Nein, es ist nicht gültig.",
-        "valid": "Ja, es ist gültig"
+      "titles": {
+        "user": "Admin-Benutzer erstellen",
+        "survey": "Hilf uns, Kestra OSS zu verbessern"
+      },
+      "subtitles": {
+        "user": "Sichern Sie Ihre Instanz, um zu beginnen.",
+        "config": "Hier sind die Details Ihrer Konfiguration",
+        "survey": "Es scheint, dass der Text, den Sie übersetzen möchten, nicht bereitgestellt wurde. Bitte geben Sie den Text nach der Linie \"----------\" ein, damit ich ihn für Sie übersetzen kann.",
+        "complete": "Einrichtung erfolgreich abgeschlossen!"
       },
       "form": {
         "email": "E-Mail",
@@ -1878,351 +1937,249 @@
         "username": "Benutzername",
         "username_hint": "Muss eine gültige E-Mail-Adresse sein."
       },
-      "login": "Anmelden",
-      "login_title": "Anmelden",
-      "logout": "Abmelden",
-      "steps": {
-        "complete": "Kestra UI starten",
-        "config": "Konfiguration validieren",
-        "survey": "Erzählen Sie uns mehr",
-        "user": "Admin-Benutzer erstellen"
-      },
-      "subtitles": {
-        "complete": "Einrichtung erfolgreich abgeschlossen!",
-        "config": "Hier sind die Details Ihrer Konfiguration",
-        "survey": "Es scheint, dass der Text, den Sie übersetzen möchten, nicht bereitgestellt wurde. Bitte geben Sie den Text nach der Linie \"----------\" ein, damit ich ihn für Sie übersetzen kann.",
-        "user": "Sichern Sie Ihre Instanz, um zu beginnen."
-      },
-      "success": {
-        "subtitle": "Alles bereit!",
-        "title": "Herzlichen Glückwunsch!"
-      },
-      "survey": {
-        "company_11_50": "Persönliches Projekt",
-        "company_1_10": "Lernen / Erkunden",
-        "company_250_plus": "Produktionsbereitstellung",
-        "company_50_250": "Bewertung für mein Team/Unternehmen",
-        "company_personal": "Andere",
-        "company_size": "Was ist Ihr Hauptziel mit Kestra?",
-        "continue": "Fortfahren",
-        "newsletter": "Erhalten Sie Produktaktualisierungen per E-Mail.",
-        "newsletter_heading": "Bleiben Sie informiert",
-        "skip": "Überspringen",
-        "use_case": "Wofür planen Sie es zu verwenden?",
-        "use_case_business": "Geschäfts-Workflows",
-        "use_case_data": "Daten-Workflows",
-        "use_case_infrastructure": "Infrastrukturautomatisierung",
-        "use_case_ml": "ML-Pipelines",
-        "use_case_other": "Andere",
-        "use_case_scheduling": "Planung & wiederkehrende Jobs"
-      },
-      "titles": {
-        "survey": "Hilf uns, Kestra OSS zu verbessern",
-        "user": "Admin-Benutzer erstellen"
-      },
-      "troubleshooting": "Passwort vergessen?",
       "validation": {
-        "config_message": "Stellen Sie sicher, dass Sie Ihre Konfiguration aktualisieren, um diese Fehlermeldung zu beheben.",
-        "email_invalid": "Ungültige E-Mail-Adresse",
         "email_required": "E-Mail ist erforderlich",
+        "email_invalid": "Ungültige E-Mail-Adresse",
         "email_temporary_not_allowed": "Temporäre oder Einweg-E-Mail-Adressen sind nicht erlaubt",
         "firstName_required": "Vorname erforderlich",
-        "incorrect_creds": "Ungültiger Benutzername oder Passwort. Stellen Sie sicher, dass Ihre Anmeldedaten korrekt sind.",
         "lastName_required": "Nachname erforderlich",
         "password_invalid": "Ungültiges Passwort",
-        "password_required": "Passwort ist erforderlich"
+        "password_required": "Passwort ist erforderlich",
+        "incorrect_creds": "Ungültiger Benutzername oder Passwort. Stellen Sie sicher, dass Ihre Anmeldedaten korrekt sind.",
+        "config_message": "Stellen Sie sicher, dass Sie Ihre Konfiguration aktualisieren, um diese Fehlermeldung zu beheben."
+      },
+      "config": {
+        "repository": "Datenbank",
+        "queue": "Warteschlange",
+        "storage": "Interner Speicher",
+        "basicauth": "Einfache Authentifizierung"
+      },
+      "confirm": {
+        "confirm": "Admin-Benutzer erstellen",
+        "config_title": "Bestätigen Sie, dass die Konfiguration gültig ist",
+        "not_valid": "Nein, es ist nicht gültig.",
+        "valid": "Ja, es ist gültig"
+      },
+      "survey": {
+        "skip": "Überspringen",
+        "company_size": "Was ist Ihr Hauptziel mit Kestra?",
+        "company_1_10": "Lernen / Erkunden",
+        "company_11_50": "Persönliches Projekt",
+        "company_50_250": "Bewertung für mein Team/Unternehmen",
+        "company_250_plus": "Produktionsbereitstellung",
+        "company_personal": "Andere",
+        "use_case": "Wofür planen Sie es zu verwenden?",
+        "use_case_infrastructure": "Infrastrukturautomatisierung",
+        "use_case_business": "Geschäfts-Workflows",
+        "use_case_data": "Daten-Workflows",
+        "use_case_ml": "ML-Pipelines",
+        "use_case_scheduling": "Planung & wiederkehrende Jobs",
+        "use_case_other": "Andere",
+        "newsletter_heading": "Bleiben Sie informiert",
+        "newsletter": "Erhalten Sie Produktaktualisierungen per E-Mail.",
+        "continue": "Fortfahren"
+      },
+      "success": {
+        "title": "Herzlichen Glückwunsch!",
+        "subtitle": "Alles bereit!"
       }
     },
-    "show": "Anzeigen",
-    "show chart": "Diagramm anzeigen",
-    "show description": "Beschreibung anzeigen",
-    "show details": "Details anzeigen",
-    "show documentation": "Dokumentation anzeigen",
-    "show more details": "Mehr Details anzeigen",
-    "show raw": "Show raw",
-    "show task condition": "Bedingung des Tasks anzeigen",
-    "show task documentation": "Task-Dokumentation anzeigen",
-    "show task documentation in editor": "Task-Dokumentation im Editor anzeigen",
-    "show task logs": "Task Logs anzeigen",
-    "show task outputs": "Task-Outputs anzeigen",
-    "show task source": "Task-Quelle anzeigen",
-    "showLess": "Es scheint, dass der Text, den Sie übersetzen möchten, nicht bereitgestellt wurde. Bitte geben Sie den Text nach der Linie \"----------\" ein, damit ich Ihnen bei der Übersetzung ins Deutsche helfen kann.",
-    "showMore": "Mehr anzeigen",
-    "side-by-side": "nebeneinander",
-    "similar lines": "similar lines",
-    "skipped": "Übersprungen",
-    "slack support": "Fragen Sie via Slack",
-    "something_went_wrong": {
-      "connection_lost": {
-        "message": "Wir konnten Ihre Kestra-Instanz nicht erreichen. Stellen Sie sicher, dass sie läuft, und aktualisieren Sie dann die Seite.",
-        "title": "Verbindung unterbrochen"
+    "ai": {
+      "flow": {
+        "title": "KI-Agent",
+        "prompt_placeholder": "Geben Sie Anweisungen ein, um Ihren Kestra flow zu erstellen. Beispielaufforderung: Erstellen Sie einen flow, der jeden Montag um 9 Uhr ausgeführt wird.",
+        "select_provider": "Anbieter auswählen",
+        "generating": {
+          "flow": "Erzeuge Flow YAML für Sie...",
+          "dashboard": "Erzeuge Dashboard YAML für Sie...",
+          "app": "Erzeuge App YAML für Sie...",
+          "test": "Erzeuge Test-YAML für Sie..."
+        },
+        "enable_instructions": {
+          "header": "<b>AI Copilot wurde noch nicht konfiguriert.</b>\n\nUm AI Copilot zu aktivieren, fügen Sie den folgenden Ausschnitt in die Konfigurationsdatei Ihrer Kestra-Instanz ein (z. B. <code>application.yml</code>) und ersetzen Sie <code>geminiApiKey</code> durch Ihren tatsächlichen Schlüssel:",
+          "footer": "Hinweis: Derzeit wird nur Gemini als KI-Anbieter für die Open Source Edition unterstützt. Für die Enterprise Edition konsultieren Sie bitte die AI Copilot-Dokumentation für die Konfiguration anderer Modellanbieter.\n\nStarten Sie Ihre Kestra-Instanz neu, nachdem Sie die Konfiguration gespeichert haben."
+        }
       },
-      "loading_execution": "Beim Laden der Ausführung ist etwas schiefgelaufen."
+      "dashboard": {
+        "prompt_placeholder": "Stellen Sie eine Frage zu Ihren Daten. Beispielaufforderung: Zeigen Sie mir die Erfolgsrate meiner flows in den letzten 7 Tagen."
+      }
     },
-    "source": "Quelle",
-    "source and blueprints": "Quelle und Blueprints",
-    "source and doc": "Quelle und Dokumentation",
-    "source and topology": "Quelle und Topologie",
-    "source only": "Nur Quelle",
-    "source search": "Quellensuche",
-    "source_search": {
-      "match_count": "{count} Treffer | {count} Treffer",
-      "open_flow": "flow öffnen",
-      "preview_empty": "Wähle ein Ergebnis zur Vorschau aus. Klicke auf einen flow in der Ergebnisliste, um dessen Quellcode zu sehen.",
-      "preview_error": "Fehler beim Laden des flow-Quellcodes"
+    "playground": {
+      "title": "Spielwiese",
+      "run_task_info": "Bewegen Sie den Mauszeiger über eine beliebige Task im Flow-Code-Editor und klicken Sie auf die Schaltfläche \"Run task\", um Ihre Task zu testen.",
+      "play_icon_info": "Sie können auch das Play-Symbol in den No-Code- oder Topologie-Ansichten anklicken.",
+      "toggle": "Spielplatz",
+      "run_task": "Task ausführen",
+      "run_this_task": "Führe diese Task aus",
+      "run_task_and_downstream": "Task & Downstream ausführen",
+      "run_all_tasks": "Alle Tasks ausführen",
+      "history": "Letzte 10 Ausführungen",
+      "clear_history": "Verlauf löschen",
+      "confirm_create": "Sie können den Playground nicht ausführen, während Sie einen flow erstellen. Das Starten eines Playground-Laufs wird den flow erstellen.",
+      "tooltip_persistence": "Wenn Sie den Playground ausschalten und wieder einschalten, bleiben die Informationen erhalten, solange Sie auf der Seite bleiben."
     },
-    "specific task": "Spezifischer Task",
-    "start date": "Startdatum",
-    "start datetime": "Startdatum und -zeit",
-    "started date": "Startdatum",
-    "state": "Zustand",
-    "state updated date": "Datum der Zustandsaktualisierung",
-    "state_history": "Zustandshistorie",
-    "stats": "Statistiken",
-    "steps": "Schritte",
-    "stream": "Stream",
-    "sub flow": "Subflow",
     "submit": "Einreichen",
-    "success": "Erfolg",
-    "sum": "Summe",
-    "switch-view": "Ansicht wechseln",
-    "system overview": "Systemübersicht",
-    "system_namespace": "Behalten Sie Ihre Plattform mit Systemflows im Blick.",
-    "system_namespace_description": "Automatisieren Sie Wartungsaufgaben, von Fehlerwarnungen bis hin zu automatisierten Bereinigungen.",
-    "tags": "Tags",
-    "task": "Task",
-    "task failed": "Task fehlgeschlagen",
-    "task id": "Task-ID",
-    "task id already exists": "Task-Id existiert bereits",
-    "task is running": "Task läuft",
-    "task logs": "Task Logs",
-    "task run id": "TaskRun-ID",
-    "task sent a warning": "Task hat eine Warnung gesendet",
-    "task was skipped": "Task wurde übersprungen",
-    "task was successful": "Task war erfolgreich",
-    "taskDefaults": "Task-Standards",
-    "taskRunners": "Task Runners",
-    "task_id_exists": "Task-ID existiert bereits",
-    "task_id_message": "Task-ID ${existingTask} existiert bereits im Flow.",
-    "taskid column details": "Letzter Task, der ausgeführt wird, und seine Anzahl der Versuche.",
-    "tasks": "Tasks",
-    "template": "Vorlage",
-    "template creation": "Vorlagenerstellung",
-    "template delete": "Sind Sie sicher, dass Sie <code>{templateCount}</code> Vorlage(n) löschen möchten?",
-    "template export": "Sind Sie sicher, dass Sie <code>{templateCount}</code> Vorlage(n) exportieren möchten?",
-    "templates": "Vorlagen",
-    "templates deleted": "<code>{count}</code> Vorlage(n) gelöscht",
-    "templates deprecated": "Vorlagen sind veraltet. Bitte verwenden Sie stattdessen Subflows. Siehe den <a href=\"https://kestra.io/docs/migration-guide/0.11.0/templates?utm_source=app&utm_medium=referral&utm_campaign=template-inlinedoc\" target=\"_blank\">Migrationsabschnitt</a>, der erklärt, wie Sie von Vorlagen zu Subflows migrieren können.",
-    "templates exported": "Vorlagen exportiert",
-    "tenant": {
-      "name": "Mandant",
-      "names": "Mandanten"
-    },
-    "tenantId": "Mandanten-ID",
-    "test-badge-text": "Test",
-    "test-badge-tooltip": "Diese Ausführung wurde durch einen Test erstellt",
-    "theme": "Modus",
-    "this_task_has": "Diese Task hat",
-    "timezone": "Zeitzone",
-    "title": "Titel",
-    "to": "Bis",
     "to toggle": "umschalten",
-    "toggle fullscreen": "Vollbild umschalten",
-    "toggle menu": "Menü umschalten",
-    "toggle output": "Outputs umschalten",
-    "toggle output display": "Outputanzeige umschalten",
-    "toggle periodic refresh each x seconds": "Periodische Aktualisierung alle {interval} Sekunden umschalten",
-    "toggle_word_wrap": "Zeilenumbruch umschalten",
-    "topology": "Topologie",
-    "topology-graph": {
-      "graph-orientation": "Graph-Ausrichtung",
-      "invalid": "Graph-Fehler",
-      "invalid_description": "Beim Laden des Graphen ist ein Fehler aufgetreten. Bitte überprüfen Sie den Quellcode auf Fehler.",
-      "zoom-fit": "Anpassen",
-      "zoom-in": "Vergrößern",
-      "zoom-out": "Verkleinern",
-      "zoom-reset": "Zoom zurücksetzen"
-    },
-    "total_duration": "Gesamtdauer",
-    "total_executions": "Gesamte Ausführungen",
-    "trigger": "Trigger",
-    "trigger details": "Trigger-Details",
-    "trigger disabled": "Trigger ist in der Flow-Quelle deaktiviert",
-    "trigger execution id": "Trigger-Ausführungs-Id",
-    "trigger filter": {
-      "options": {
-        "ALL": "Alle Ausführungen",
-        "CHILD": "Kinder-Ausführungen",
-        "MAIN": "Eltern-Ausführungen"
+    "accept": "Akzeptieren",
+    "reject": "Ablehnen",
+    "draft_available": "Ein Entwurf der Änderung ist im Editor verfügbar",
+    "last modified": "Zuletzt geändert",
+    "run task in playground": "Task im Playground ausführen",
+    "task is running": "Task läuft",
+    "task was successful": "Task war erfolgreich",
+    "task failed": "Task fehlgeschlagen",
+    "task was skipped": "Task wurde übersprungen",
+    "task sent a warning": "Task hat eine Warnung gesendet",
+    "defaultsToNamespaceFile": "Standardmäßig auf namespace-Datei: <code>{name}</code> eingestellt",
+    "no_file_choosen": "Keine Datei ausgewählt",
+    "dependency": {
+      "controls": {
+        "zoom_in": "Hineinzoomen",
+        "zoom_out": "Rauszoomen",
+        "clear_selection": "Auswahl aufheben",
+        "fit_view": "An Bildschirm anpassen"
       },
-      "title": "Kinder-Ausführungen filtern"
-    },
-    "trigger refresh": "Aktualisierung auslösen",
-    "triggerId": "Trigger-ID",
-    "trigger_check_warning": "Die Verwendung von Trigger-Variablen funktioniert nicht bei manueller Flow-Ausführung. Fügen Sie den `??`-Koaleszenz-Operator hinzu, um das Problem zu lösen. Verwenden Sie zum Beispiel anstelle von `trigger.date` den Ausdruck `trigger.date ?? execution.startDate`.",
-    "trigger_id_exists": "Trigger-ID existiert bereits",
-    "trigger_id_message": "Trigger-ID ${existingTrigger} existiert bereits im Flow.",
-    "trigger_states": "Zustände",
-    "triggered": "Ausführungstrigger",
-    "triggered done": "Ausführung <em>{name}</em> ist erfolgreich ausgelöst",
-    "triggerflow disabled": "Trigger ist in der Flow-Definition deaktiviert",
-    "triggers": "Trigger",
-    "triggers_add_card_add": "Hinzufügen",
-    "triggers_add_card_add_to_flow": "Zum flow hinzufügen",
-    "triggers_add_category_empty": "Keine Trigger in dieser Kategorie.",
-    "triggers_add_ee_tooltip": "Dieser Trigger erfordert die Enterprise Edition.",
-    "triggers_add_empty_title": "Keine Trigger gefunden",
-    "triggers_add_filter_all": "Alle",
-    "triggers_add_filter_app": "App",
-    "triggers_add_filter_core": "Kern",
-    "triggers_add_filter_realtime": "Echtzeit",
-    "triggers_add_modal_add_button": "Trigger zum Flow hinzufügen",
-    "triggers_add_modal_ee_notice": "Dieser Trigger erfordert die Enterprise Edition.",
-    "triggers_add_modal_flow_placeholder": "Wählen Sie einen flow aus",
-    "triggers_add_modal_namespace_placeholder": "Wählen Sie ein namespace",
-    "triggers_add_modal_properties_hint": "Konfigurieren Sie die Trigger-Eigenschaften im Flow-Editor, nachdem Sie den Trigger hinzugefügt haben.",
-    "triggers_add_modal_tab_documentation": "Dokumentation",
-    "triggers_add_modal_tab_form": "Formular",
-    "triggers_add_modal_tab_source": "Quelle",
-    "triggers_add_modal_title": "{name}",
-    "triggers_add_modal_trigger_id": "Trigger-ID",
-    "triggers_add_modal_trigger_id_placeholder": "Eindeutiger Bezeichner für diesen Trigger",
-    "triggers_add_search_placeholder": "Suche Trigger...",
-    "triggers_header_description": "Durchsuchen, hinzufügen und verwalten Sie Trigger, um Ihre flows zu automatisieren. Wählen Sie aus, ob Sie Ihren flow als AI-Tool bereitstellen, planen, einen Webhook-Trigger hinzufügen, Änderungen in externen Apps abfragen oder Echtzeit-Ereignislistener verwenden möchten.",
-    "triggers_state": {
-      "options": {
-        "disabled": "Deaktiviert",
-        "enabled": "Aktiviert"
-      },
-      "state": "Zustand"
-    },
-    "triggers_tabs_add": "Hinzufügen",
-    "triggers_tabs_manage": "Verwalten",
-    "true": "Wahr",
-    "type": "Typ",
-    "unable to generate graph": "Ein Problem ist beim Generieren des Graphen aufgetreten, wodurch die Topologie nicht angezeigt werden kann.",
-    "undefined": "Nicht definiert",
-    "unlock": "Entsperren",
-    "unlock trigger": {
-      "button": "Trigger entsperren",
-      "confirmation": "Sind Sie sicher, dass Sie den Trigger entsperren möchten?",
-      "success": "Trigger ist entsperrt",
-      "tooltip": {
-        "evaluation": "Der Trigger wird derzeit ausgewertet",
-        "execution": "Es läuft eine Ausführung für diesen Trigger"
-      },
-      "warning": "Dies könnte zu gleichzeitigen Ausführungen für denselben Trigger führen und sollte als letzte Option betrachtet werden."
-    },
-    "unqueue": "Aus Warteschlange entfernen",
-    "unqueue as": "Aus der Warteschlange entfernen als <code>{status}</code>",
-    "unqueue confirm": "Sind Sie sicher, dass Sie die Ausführung <code>{id}</code> aus der Warteschlange entfernen möchten?",
-    "unqueue done": "Ausführung ist nicht in der Warteschlange",
-    "unqueue title": "Ausführung <code>{id}</code> aus der Warteschlange entfernen.<br/>Bitte beachten Sie, dass dies das Nebenläufigkeitslimit des Flows nicht berücksichtigt, sodass mehr Ausführungen laufen könnten als das erlaubte Limit.",
-    "unqueue title multiple": "Sind Sie sicher, dass Sie <code>{count}</code> Ausführungen aus der Warteschlange entfernen möchten?<br/><br/>Beachten Sie, dass dies das Nebenläufigkeitslimit des flow nicht beachtet, sodass mehr Ausführungen laufen könnten als das erlaubte Limit.",
-    "unsaved changed ?": "Sie haben ungespeicherte Änderungen, möchten Sie diese Seite verlassen?",
-    "unsaved changes": "Nicht gespeicherte Änderungen",
-    "unsaved changes warning": "Sie haben ungespeicherte Änderungen. Wenn Sie diese Seite verlassen, gehen Ihre Änderungen verloren.",
-    "up trend": "Steigend",
-    "update": "Aktualisieren",
-    "update aborted": "Aktualisierung abgebrochen",
-    "update ok": "ist aktualisiert",
-    "updated date": "Aktualisierungsdatum",
-    "usage": "Verwendung",
-    "use": "Verwenden",
-    "use_dark_background": "Verwenden Sie diese Version, wenn Sie auf einem dunklen Hintergrund arbeiten, um sicherzustellen, dass unser Name lesbar bleibt.",
-    "valid": "Gültig",
-    "validate": "Validieren",
-    "value": "Value",
-    "variable_explorer": {
-      "empty": "Keine Variablen für diese Ausführung verfügbar.",
-      "n_items": "[ {count} Elemente ]",
-      "n_keys": "\\{ {count} keys \\}",
-      "one_item": "[ 1 Element ]",
-      "one_key": "\\{ 1 key \\}",
-      "raw_json": "Raw JSON",
-      "search_placeholder": "Key oder value suchen...",
-      "select_prompt": "Wählen Sie eine Variable aus, um ihren value anzuzeigen.",
-      "tasks_outputs": "Tasks outputs",
-      "title": "Eingabe/Ausgabe",
-      "tree": "Baum"
-    },
-    "variables": "Variablen",
-    "version": "Version",
-    "view metrics": "Metriken anzeigen",
-    "warning": "Warnung",
-    "warning detected": "Warnungen erkannt",
-    "warning flow with triggers": "Dieser Flow enthält Trigger und eine manuelle Ausführung wird fehlschlagen, wenn dieser Flow von Trigger-Ausdrücken abhängt.",
-    "watch": "Beobachten",
-    "watch_video": "Video ansehen",
-    "webhook": {
-      "copy_url": "Webhook-URL kopieren",
-      "curl_command": "Webhook-cURL-Befehl",
-      "curl_note": "Verwenden Sie diesen cURL-Befehl, um den flow über Webhook mit benutzerdefiniertem JSON-Payload zu triggern.",
-      "no_triggers": "Dieser flow hat keine aktivierten Webhook-Triggers.",
-      "payload": "Webhook-Payload (JSON)"
-    },
-    "webhook link copied": "Webhook-Link kopiert.",
-    "welcome": {
-      "help": {
-        "text": "Stellen Sie jede Frage in unserer Slack-Community. Wenn Sie feststecken, sind wir hier, um Ihnen zu helfen. ✋",
-        "title": "Brauchen Sie Hilfe?"
-      },
-      "menu": "Welcome",
-      "tour": {
-        "text": "Wählen Sie Ihren Anwendungsfall und folgen Sie einer Schritt-für-Schritt-Anleitung, um die Funktionen und Möglichkeiten von Kestra kennenzulernen. ❤️",
-        "title": "Produkt-Tour starten"
-      },
-      "tutorial": {
-        "text": "* <a href=\"https://kestra.io/tutorial-videos/all?utm_source=app&utm_medium=referral&utm_campaign=welcome-tutorial\" target=\"_blank\">Video-Tutorials</a>  \n* <a href=\"https://kestra.io/docs?utm_source=app&utm_medium=referral&utm_campaign=welcome-tutorial\" target=\"_blank\">Dokumentation</a>  \n* <a href=\"https://kestra.io/blueprints?utm_source=app&utm_medium=referral&utm_campaign=welcome-tutorial\" target=\"_blank\">Blueprints</a>",
-        "title": "Tutorial"
+      "search": {
+        "placeholders": {
+          "default": "Suche nach flow oder namespace...",
+          "asset": "Suche nach Asset, flow oder namespace..."
+        },
+        "namespace": {
+          "select": "Wählen Sie ein namespace aus",
+          "no_namespace": "Ohne namespace"
+        },
+        "flow": {
+          "display": "Flow-Abhängigkeiten einbeziehen"
+        },
+        "no_results": "Keine Ergebnisse gefunden für {term}"
       }
     },
+    "preview": {
+      "label": "Vorschau",
+      "force-editor": "Editoransicht erzwingen",
+      "auto-view": "Automatische Ansicht",
+      "view": "Anzeigen",
+      "rows_truncated": "Zeige {shown} von {total} Zeilen. Laden Sie die Datei herunter, um alle Daten anzuzeigen.",
+      "pagination_info": "Zeige Zeilen {start}-{end} von {total}.",
+      "showing_rows": "Zeige Zeilen {start}-{end} von {total}",
+      "expand": "Ausklappen",
+      "collapse": "Einklappen",
+      "previous": "Zurück",
+      "next": "Weiter",
+      "page_of": "Seite {current} von {total}"
+    },
+    "delete trigger": "Trigger löschen",
+    "delete triggers": "Trigger löschen",
+    "bulk delete triggers": "Möchten Sie wirklich {count} Trigger löschen?",
+    "bulk success delete triggers": "{count} Trigger wurden erfolgreich gelöscht",
+    "delete trigger confirmation": "Möchten Sie den Trigger {id} wirklich löschen? WARNING: Das Löschen eines Triggers kann zu doppelten Ausführungen führen, wenn der Trigger noch in einem flow aktiv ist.",
+    "delete trigger success": "Trigger {id} wurde erfolgreich gelöscht",
+    "delete trigger error": "Fehler beim Löschen des Triggers {id}",
+    "revision deleted": "Revision {revision} wurde erfolgreich gelöscht",
+    "delete revision confirm": "Möchten Sie die Revision {revision} wirklich löschen?",
+    "delete revision error": "Fehler beim Löschen der Revision {revision} mit Fehler {error}",
+    "no_history": "Keine Historie verfügbar",
+    "export_as": "Als .{format} exportieren",
+    "save_and_execute": "Speichern & Ausführen",
     "welcome_copilot": {
       "button_cta": "Flow von Grund auf neu erstellen",
       "create_manually": {
-        "description": "Von Grund auf mit dem Editor erstellen",
-        "title": "Manuell erstellen"
+        "title": "Manuell erstellen",
+        "description": "Von Grund auf mit dem Editor erstellen"
       },
       "docs": {
-        "description": "Erfahren Sie mehr in der offiziellen Dokumentation",
-        "title": "Dokumentation lesen"
+        "title": "Dokumentation lesen",
+        "description": "Erfahren Sie mehr in der offiziellen Dokumentation"
       },
+      "title": "Verwandeln Sie Ihre Idee in einen Workflow",
+      "need_help": "Brauchen Sie Hilfe?",
+      "placeholder_prompt": "Sende mir um 9 Uhr morgens eine tägliche Begrüßungsnachricht.",
+      "show_more": "Mehr Eingabeaufforderungen anzeigen",
+      "show_less": "Weniger Eingabeaufforderungen anzeigen",
+      "remaining_quota": "Sie haben {count} AI-Generationen übrig. Das Limit wird täglich um Mitternacht UTC zurückgesetzt.",
       "execute_hint": {
-        "description": "Klicken Sie, um Ihren Workflow zu speichern und sofort auszuführen.",
-        "title": "Speichern & Ausführen Ihres flow"
+        "title": "Speichern & Ausführen Ihres flow",
+        "description": "Klicken Sie, um Ihren Workflow zu speichern und sofort auszuführen."
+      },
+      "success_popup": {
+        "title": "Herzlichen Glückwunsch!",
+        "description": "Sie haben erfolgreich Ihren ersten flow ausgeführt! Sie sind auf dem besten Weg, ein Kestra-Profi zu werden.",
+        "tutorial": "Deep-Dive-Tutorial",
+        "explore": "Mehr erkunden"
+      },
+      "success_page": {
+        "title": "Alles bereit!",
+        "description": "Sie haben die Grundlagen von Kestra gelernt. Hier sind einige Ressourcen, die Ihnen helfen, Ihre Reise fortzusetzen.",
+        "restart": "Tutorial neu starten",
+        "items": {
+          "tutorial": {
+            "title": "Ein Tutorial starten",
+            "description": "Interaktives Tutorial aller Kestra-Funktionen"
+          },
+          "blueprints": {
+            "title": "Blueprints",
+            "description": "Vorlagen für vorgefertigte Workflows für gängige Anwendungsfälle"
+          },
+          "slack": {
+            "title": "Slack-Community",
+            "description": "Verbinden Sie sich mit anderen Benutzern und erhalten Sie Unterstützung von der Community"
+          },
+          "videos": {
+            "title": "Video-Tutorials",
+            "description": "Schritt-für-Schritt-Videoleitfäden für erweiterte Funktionen"
+          },
+          "demo": {
+            "title": "Demo anfordern",
+            "description": "Entdecken Sie die Kestra Enterprise Edition mit einer personalisierten Demo"
+          }
+        }
+      },
+      "help": {
+        "tutorial": {
+          "title": "Ein Tutorial starten",
+          "description": "Erfahren Sie, wie Sie Ihren ersten flow mit geführten Schritten erstellen und ausführen."
+        },
+        "blueprints": {
+          "title": "Blueprints",
+          "description": "Entdecken Sie einsatzbereite Beispiele und Vorlagen für gängige Workflow-Muster."
+        },
+        "slack": {
+          "title": "Slack-Community",
+          "description": "Treten Sie uns bei, um Ideen und Best Practices auszutauschen und Unterstützung bei technischen Fragen zu erhalten."
+        }
       },
       "flows": {
-        "buildDbtPipeline": {
-          "label": "Erstellen Sie eine dbt-Pipeline",
-          "prompt": "Erstellen Sie einen Kestra flow, der ein dbt-Projekt-Repository klont und dbt build mit einem DuckDB-Profil ausführt."
-        },
-        "buildDockerImageAndRunIt": {
-          "label": "Erstellen Sie ein Docker-Image und führen Sie es aus",
-          "prompt": "Erstellen Sie einen Kestra flow, der ein Docker-Image aus einem Inline-Dockerfile erstellt und den resultierenden Container ausführt."
-        },
-        "convertCsvToExcel": {
-          "label": "CSV in Excel umwandeln",
-          "prompt": "Erstellen Sie einen flow, der eine CSV-Datei herunterlädt, sie in Ion konvertiert und das Ergebnis als Excel-Datei exportiert."
-        },
-        "etlWorkflow": {
-          "label": "ETL-Workflow",
-          "prompt": "Erstellen Sie einen ETL-flow, der JSON-Daten herunterlädt, sie mit Python verarbeitet und das transformierte Ergebnis mit DuckDB abfragt."
+        "jsonApiToDuckdb": {
+          "label": "JSON-API zu DuckDB",
+          "prompt": "Erstellen Sie einen flow, der eine JSON-Datei von einer öffentlichen API herunterlädt, sie mit einem Python-Skript transformiert und mit einer DuckDB Queries Task verarbeitet."
         },
         "installNginxViaAnsible": {
           "label": "Installiere Nginx über Ansible",
           "prompt": "Erstellen Sie einen Kestra flow, der Nginx auf einer Zielmaschine mit Ansible installiert und die installierte Version überprüft."
         },
-        "jsonApiToDuckdb": {
-          "label": "JSON-API zu DuckDB",
-          "prompt": "Erstellen Sie einen flow, der eine JSON-Datei von einer öffentlichen API herunterlädt, sie mit einem Python-Skript transformiert und mit einer DuckDB Queries Task verarbeitet."
+        "buildDbtPipeline": {
+          "label": "Erstellen Sie eine dbt-Pipeline",
+          "prompt": "Erstellen Sie einen Kestra flow, der ein dbt-Projekt-Repository klont und dbt build mit einem DuckDB-Profil ausführt."
+        },
+        "etlWorkflow": {
+          "label": "ETL-Workflow",
+          "prompt": "Erstellen Sie einen ETL-flow, der JSON-Daten herunterlädt, sie mit Python verarbeitet und das transformierte Ergebnis mit DuckDB abfragt."
+        },
+        "microservicesApis": {
+          "label": "Microservices & APIs",
+          "prompt": "Erstellen Sie einen flow, der die Antwort einer Website-API überprüft und einen Slack-Alarm sendet, wenn der Statuscode nicht erfolgreich ist."
+        },
+        "buildDockerImageAndRunIt": {
+          "label": "Erstellen Sie ein Docker-Image und führen Sie es aus",
+          "prompt": "Erstellen Sie einen Kestra flow, der ein Docker-Image aus einem Inline-Dockerfile erstellt und den resultierenden Container ausführt."
         },
         "manualApproval": {
           "label": "Manuelle Genehmigung",
           "prompt": "Erstellen Sie einen flow mit einem initialen Verarbeitungsschritt, einer manuellen Genehmigungspause und einem abschließenden Bereitstellungsschritt nach der Genehmigung."
         },
-        "microservicesApis": {
-          "label": "Microservices & APIs",
-          "prompt": "Erstellen Sie einen flow, der die Antwort einer Website-API überprüft und einen Slack-Alarm sendet, wenn der Statuscode nicht erfolgreich ist."
+        "convertCsvToExcel": {
+          "label": "CSV in Excel umwandeln",
+          "prompt": "Erstellen Sie einen flow, der eine CSV-Datei herunterlädt, sie in Ion konvertiert und das Ergebnis als Excel-Datei exportiert."
         },
         "scheduledPdfReports": {
           "label": "Geplante PDF-Berichte",
@@ -2232,73 +2189,116 @@
           "label": "Wöchentliche Verkaufs-KPIs an Slack",
           "prompt": "Erstellen Sie einen wöchentlich geplanten flow, der Verkaufs-KPIs mit DuckDB berechnet und die Zusammenfassung an Slack sendet."
         }
-      },
-      "help": {
-        "blueprints": {
-          "description": "Entdecken Sie einsatzbereite Beispiele und Vorlagen für gängige Workflow-Muster.",
-          "title": "Blueprints"
-        },
-        "slack": {
-          "description": "Treten Sie uns bei, um Ideen und Best Practices auszutauschen und Unterstützung bei technischen Fragen zu erhalten.",
-          "title": "Slack-Community"
-        },
-        "tutorial": {
-          "description": "Erfahren Sie, wie Sie Ihren ersten flow mit geführten Schritten erstellen und ausführen.",
-          "title": "Ein Tutorial starten"
-        }
-      },
-      "need_help": "Brauchen Sie Hilfe?",
-      "placeholder_prompt": "Sende mir um 9 Uhr morgens eine tägliche Begrüßungsnachricht.",
-      "remaining_quota": "Sie haben {count} AI-Generationen übrig. Das Limit wird täglich um Mitternacht UTC zurückgesetzt.",
-      "show_less": "Weniger Eingabeaufforderungen anzeigen",
-      "show_more": "Mehr Eingabeaufforderungen anzeigen",
-      "success_page": {
-        "description": "Sie haben die Grundlagen von Kestra gelernt. Hier sind einige Ressourcen, die Ihnen helfen, Ihre Reise fortzusetzen.",
-        "items": {
-          "blueprints": {
-            "description": "Vorlagen für vorgefertigte Workflows für gängige Anwendungsfälle",
-            "title": "Blueprints"
-          },
-          "demo": {
-            "description": "Entdecken Sie die Kestra Enterprise Edition mit einer personalisierten Demo",
-            "title": "Demo anfordern"
-          },
-          "slack": {
-            "description": "Verbinden Sie sich mit anderen Benutzern und erhalten Sie Unterstützung von der Community",
-            "title": "Slack-Community"
-          },
-          "tutorial": {
-            "description": "Interaktives Tutorial aller Kestra-Funktionen",
-            "title": "Ein Tutorial starten"
-          },
-          "videos": {
-            "description": "Schritt-für-Schritt-Videoleitfäden für erweiterte Funktionen",
-            "title": "Video-Tutorials"
-          }
-        },
-        "restart": "Tutorial neu starten",
-        "title": "Alles bereit!"
-      },
-      "success_popup": {
-        "description": "Sie haben erfolgreich Ihren ersten flow ausgeführt! Sie sind auf dem besten Weg, ein Kestra-Profi zu werden.",
-        "explore": "Mehr erkunden",
-        "title": "Herzlichen Glückwunsch!",
-        "tutorial": "Deep-Dive-Tutorial"
-      },
-      "title": "Verwandeln Sie Ihre Idee in einen Workflow"
+      }
     },
-    "welcome_page": {
-      "guide": "Benötigen Sie Unterstützung, um Ihren ersten flow auszuführen?",
-      "welcome": "Willkommen bei Kestra"
+    "mcp": {
+      "your_servers": "Ihre Server",
+      "servers_count": "{count} MCP-Server",
+      "managed_by_kestra": "Verwaltet von Kestra",
+      "servers": "MCP-Server",
+      "server": "MCP-Server",
+      "client_setup": "Client-Einrichtung",
+      "page_description": "Stellen Sie Ihre Kestra flows als Werkzeuge für MCP-kompatible KI-Agenten bereit",
+      "create": "Server erstellen",
+      "save": "Änderungen speichern",
+      "connect": "Verbinden",
+      "copy_url": "URL kopieren",
+      "url_copied": "URL kopiert!",
+      "instructions": "Anweisungen",
+      "server_type": "Servertyp",
+      "auth_type": "Authentifizierung",
+      "private": "Privat",
+      "private_server": "Privater Server",
+      "public": "Öffentlich",
+      "public_hint": "Warnung: Öffentliche Server erfordern keine Authentifizierung. Jeder mit der URL kann jedes Tool aufrufen, das von diesem Server bereitgestellt wird, ohne namespace- oder Berechtigungsprüfungen. Nur für Server verwenden, die sicher extern zugänglich gemacht werden können.",
+      "basic_auth": "Basis-Authentifizierung",
+      "api_token": "API-Token",
+      "oauth": "OAuth",
+      "username_password": "Benutzername & Passwort",
+      "bearer_token": "Authentifizierung mit Bearer-Token",
+      "oauth_hint": "Bearer JWT von Ihrem OIDC-Anbieter",
+      "oauth_provider": "OAuth-Anbieter",
+      "oauth_provider_placeholder": "Wählen Sie einen konfigurierten OIDC-Anbieter",
+      "oauth_provider_required": "OAuth-Anbieter ist erforderlich, wenn der Authentifizierungstyp OAuth ist",
+      "scopes_supported": "Unterstützte Scopes",
+      "scopes_supported_placeholder": "openid, profile, email",
+      "scopes_supported_hint": "Scopes, die im Protected Resource Metadata-Dokument dieses Servers angekündigt werden. Spezifikationskonforme MCP-Clients beschränken ihre Autorisierungsanfragen auf diese Liste. Leer lassen, um das Feld auszulassen und den Clients die vom IdP angekündigten Scopes zu verwenden.",
+      "no_oauth_providers": "Keine OIDC-Anbieter in dieser Instanz konfiguriert",
+      "delete_confirm": "Möchten Sie diesen MCP-Server wirklich löschen?",
+      "no_servers": "Keine MCP-Server gefunden. Erstellen Sie Ihren ersten Server, um MCP Tool Trigger für externe KI-Agenten bereitzustellen.",
+      "server_id": "Server-ID",
+      "id_placeholder": "z.B. mein-mcp-server",
+      "id_invalid": "Die ID muss mit einem Kleinbuchstaben oder einer Ziffer beginnen und darf nur Kleinbuchstaben, Ziffern, Bindestriche oder Unterstriche enthalten.",
+      "main_tenant": "Haupt",
+      "tab_edit": "Bearbeiten",
+      "tab_connect": "Verbinden",
+      "tab_tool_flows": "Tool-Flows",
+      "tab_tool_flows_placeholder": "Das Management von Tool flows kommt bald.",
+      "tools": {
+        "no_tools": "Keine Tool-Flows entsprechen Ihrer Suche.",
+        "create_tool_flow": "Erstelle einen Tool flow",
+        "tool_name": "Tool-Name",
+        "trigger_id": "Trigger-ID",
+        "title": "Titel",
+        "description": "Beschreibung",
+        "annotations": "Anmerkungen",
+        "flow": "flow",
+        "state": "Zustand",
+        "read_only": "Schreibgeschützt",
+        "open_world": "Open world",
+        "destructive": "Destruktiv",
+        "idempotent": "Idempotent",
+        "return_direct": "Direktrückgabe",
+        "view_flow": "flow öffnen"
+      },
+      "connect_tab": {
+        "server_url": "Server-URL",
+        "client_picker_label": "Wählen Sie Ihren KI-Client",
+        "claude_desktop": "Claude Desktop",
+        "claude_desktop_hint": "Fügen Sie Folgendes zu Ihrer claude_desktop_config.json-Datei hinzu:",
+        "claude_desktop_mac": "macOS: ~/Library/Application Support/Claude/claude_desktop_config.json",
+        "claude_desktop_win": "Windows: %APPDATA%\\Claude\\claude_desktop_config.json",
+        "claude_code": "Claude-Code",
+        "claude_code_hint": "Führen Sie den folgenden Befehl in Ihrem Terminal aus:",
+        "cursor": "Cursor",
+        "cursor_hint": "Fügen Sie Folgendes zu ~/.cursor/mcp.json hinzu:",
+        "codex": "Codex (OpenAI)",
+        "codex_hint": "Fügen Sie Folgendes zu Ihrer codex.json MCP-Konfiguration hinzu:",
+        "auth_basic_hint": "Setzen Sie <code>KESTRA_BASIC_AUTH</code> als Umgebungsvariable, die einen base64-kodierten <code>username:password</code>-String enthält, bevor Sie den Client starten.",
+        "auth_api_token_hint": "Setzen Sie <code>KESTRA_TOKEN</code> als Umgebungsvariable, bevor Sie den Client starten.",
+        "auth_oauth_client_id_hint": "Ersetzen Sie <code>&lt;client-id&gt;</code> durch die OAuth-Client-ID und registrieren Sie <code>http://localhost:7777</code> als gültige Weiterleitungs-URI auf diesem Client.",
+        "auth_oauth_browser_hint": "Ihr Browser öffnet beim ersten Verbindungsaufbau die Anmeldeseite des Identitätsanbieters."
+      }
     },
-    "wordmark_colors": "Die Farben des Wortzeichens passen sich dem Hintergrund an, während das Icon auf einem dunklen Hintergrund ohne Hintergrund bleibt.",
-    "worker group": "Worker-Gruppe",
-    "worker group fallback": "Arbeitsgruppe Fallback",
-    "worker group key": "Worker-Gruppe Schlüssel",
-    "worker information": "Worker-Informationen",
-    "workerId": "Worker Id",
-    "workers": "Workers",
-    "wrong labels": "Leerer Key oder Value ist in Labels nicht erlaubt",
-    "yes": "Ja"
+    "flow_editor_stats": {
+      "revisions": {
+        "suffix": "Revision(en)",
+        "tooltip": "Flow-Revisionen anzeigen"
+      },
+      "dependencies": {
+        "suffix": "Abhängigkeiten",
+        "tooltip": "Flow-Abhängigkeiten anzeigen"
+      },
+      "apps": {
+        "suffix": "App(s)",
+        "tooltip": "Apps anzeigen, die diesen flow verwenden"
+      },
+      "tests": {
+        "suffix": "Test(s)",
+        "tooltip": "Flow-Tests anzeigen"
+      },
+      "errors": {
+        "label": "{count} Fehler"
+      }
+    },
+    "source_search": {
+      "match_count": "{count} Treffer | {count} Treffer",
+      "open_flow": "flow öffnen",
+      "preview_empty": "Wähle ein Ergebnis zur Vorschau aus. Klicke auf einen flow in der Ergebnisliste, um dessen Quellcode zu sehen.",
+      "preview_error": "Fehler beim Laden des flow-Quellcodes"
+    },
+    "open source": "Open Source",
+    "pricing": "Preise",
+    "license": "Lizenz"
   }
 }

--- a/ui/src/translations/es.json
+++ b/ui/src/translations/es.json
@@ -1,1678 +1,722 @@
 {
   "es": {
-    "Add flow": "Añadir flujo",
-    "Default log level": "Nivel de log predeterminado",
-    "Default namespace": "Namespace predeterminado",
-    "Default page": "Página predeterminada",
-    "Editor fontfamily": "Familia de fuentes del editor",
-    "Editor fontsize": "Tamaño de fuente del editor",
-    "Editor theme": "Tema del editor",
-    "Fold auto": "Editor: plegado automático de multilíneas",
-    "Fold content lines": "Plegar cadenas multilínea",
-    "Hover description": "Editor: Mostrar descripción del campo al pasar el cursor sobre key o value",
-    "Language": "Idioma",
-    "Per page": "por página",
-    "Set default page": "Establecer página predeterminada",
-    "Set labels": "Establecer etiquetas",
-    "Set labels done": "Etiquetas de la ejecución establecidas con éxito",
-    "Set labels to execution": "Añadir o actualizar las etiquetas de la ejecución <code>{id}</code>",
-    "Set labels tooltip": "Establecer etiquetas a la ejecución",
-    "Task Id already exist in the flow": "Task Id {taskId} ya existe en el flow.",
-    "Total": "Total",
-    "Unfold content lines": "Desplegar cadenas multilínea",
-    "about_this_blueprint": "Acerca de este blueprint",
-    "absolute": "Absoluto",
-    "accept": "Aceptar",
-    "actions": "Acciones",
-    "activate_basic_auth": "Activar Autenticación Básica",
-    "active": "Activo",
-    "active-slots": "Ranuras activas",
-    "actual state": "Estado actual",
-    "add": "Añadir",
-    "add at position": "Añadir {position} <code>{task}</code>",
-    "add error handler": "Añadir un manejador de errores",
-    "add flow": "Añadir flujo",
+    "loading": "Cargando...",
+    "more actions": "Más acciones",
+    "toggle menu": "Alternar menú",
+    "panel actions": "Acciones del panel",
+    "playground actions": "Acciones del Playground",
+    "bulk actions": "Acciones masivas",
+    "view metrics": "Ver métricas",
+    "remove this item": "Eliminar este elemento",
     "add label": "Agregar label",
-    "add task": "Añadir una task",
-    "add-trigger-in-editor": "Agrega un Trigger a tu Flow primero",
-    "add_new_item": "Agregar nuevo elemento",
-    "additionalPlugins": "Plugins Adicionales",
-    "admin": "Administrador",
-    "admin_preferences": "Preferences",
-    "administration": "Administración",
-    "advanced configuration": "Otras propiedades",
-    "after": "después",
-    "aggregation": "Agregación",
-    "ai": {
-      "dashboard": {
-        "prompt_placeholder": "Haz una pregunta sobre tus datos. Ejemplo de solicitud: Muéstrame la tasa de éxito de mis flows en los últimos 7 días."
+    "remove label": "Eliminar label",
+    "id": "Id",
+    "type": "Tipo",
+    "ok": "OK",
+    "valid": "Válido",
+    "close": "Cerrar",
+    "namespace": "Namespace",
+    "description": "Descripción",
+    "show description": "Mostrar una descripción",
+    "show details": "Mostrar detalles",
+    "show more details": "Mostrar más detalles",
+    "skipped": "Omitido",
+    "revision": "Revisión",
+    "Language": "Idioma",
+    "Set default page": "Establecer página predeterminada",
+    "theme": "Tema",
+    "flows": "Flujos",
+    "flow": "Flujo",
+    "invalid source": "Código fuente inválido",
+    "missingSource": "Fuente faltante",
+    "update": "Actualizar",
+    "update ok": "está actualizado",
+    "delete ok": "está eliminado",
+    "Default page": "Página predeterminada",
+    "confirmation": "Confirmación",
+    "common": {
+      "back": "Atrás"
+    },
+    "delete confirm": "¿Estás seguro de eliminar <code>{name}</code>?",
+    "outdated revision save confirmation": {
+      "confirm": "¿Quieres sobrescribirlo?",
+      "update": {
+        "title": "Revisión desactualizada",
+        "description": "La revisión que estás editando está desactualizada.",
+        "details": "Revisa la pestaña de Revisiones para más detalles sobre la última versión."
       },
-      "flow": {
-        "enable_instructions": {
-          "footer": "Nota: En este momento, solo se admite Gemini como proveedor de AI para la Edición de Código Abierto. Para la Edición Empresarial, consulte la documentación de AI Copilot para la configuración de otros proveedores de modelos.\n\nReinicie su instancia de Kestra después de guardar la configuración.",
-          "header": "<b>AI Copilot aún no ha sido configurado.</b>\n\nPara habilitar AI Copilot, añade el siguiente fragmento a tu archivo de configuración de la instancia de Kestra (por ejemplo, <code>application.yml</code>), reemplazando <code>geminiApiKey</code> con tu key real:"
-        },
-        "generating": {
-          "app": "Generando YAML de la aplicación para ti...",
-          "dashboard": "Generando Dashboard YAML para ti...",
-          "flow": "Generando YAML de Flow para ti...",
-          "test": "Generando YAML de prueba para ti..."
-        },
-        "prompt_placeholder": "Ingrese instrucciones para crear su flow de Kestra. Ejemplo de solicitud: Crear un flow que se ejecute todos los lunes a las 9 AM.",
-        "select_provider": "Seleccionar un proveedor",
-        "title": "Agente de IA"
+      "create": {
+        "title": "El flujo ya existe",
+        "description": "Un flow con el mismo id ya existe en este namespace.",
+        "details": "Guardar para sobrescribir y crear una nueva revisión."
       }
     },
-    "all executions": "Todas las ejecuciones",
-    "all tags": "Todas las etiquetas",
-    "api": "API",
-    "appBlocks": "Bloques de la App",
-    "apps": "Aplicaciones",
-    "are you sure change state": "¿Está seguro de que desea cambiar el estado?",
-    "assets": {
-      "title": "Activos"
+    "override": {
+      "title": "Vas a sobrescribir el flujo actual",
+      "details": "El flow anterior se puede restaurar desde la pestaña de Revisions."
     },
-    "attempt": "Intento",
-    "attempts": "Intento(s)",
-    "auditlogs": "Audit Logs",
-    "automatic refresh": "Actualización automática",
-    "avg": "Promedio",
-    "avg duration": "Duración promedio de ejecución",
+    "is deprecated": "está obsoleto",
+    "success": "Éxito",
+    "save": "Guardar",
+    "save_as_draft": "Guardar como borrador",
+    "draft": "Borrador",
+    "draft_flow_warning": "Esta revisión del flow es un borrador. La ejecución se realizará sobre esta revisión en borrador y puede fallar inmediatamente si la definición del flow no es válida.",
+    "save task": "Guardar tarea",
+    "saved": "Guardado exitosamente",
+    "saved as draft": "Guardado como borrador correctamente",
+    "saved done": "<em>{name}</em> se ha guardado exitosamente",
+    "saved as draft done": "<em>{name}</em> se ha guardado correctamente como borrador",
+    "multiple saved done": "{name} se ha guardado",
+    "fileTypeNotAllowed": "Tipo de archivo no permitido. Tipos aceptados: {types}",
+    "delete": "Eliminar",
+    "deleted": "Eliminado exitosamente",
+    "deleted confirm": "<em>{name}</em> se ha eliminado exitosamente",
+    "Add flow": "Añadir flujo",
+    "add": "Añadir",
+    "add_new_item": "Agregar nuevo elemento",
+    "copy": "Copiar",
+    "copy_to_clipboard": "Copiar al portapapeles",
+    "copy_and_close": "Copiar y cerrar",
+    "Per page": "por página",
+    "new": "Nuevo",
+    "edit": "Editar",
     "back": "Atrás",
-    "back_to_dashboard": "Volver al panel de control",
-    "backfill": "Backfill",
-    "backfill executions": "Ejecuciones de backfill",
-    "backfill paused": "Backfill pausado",
-    "backfill running": "Backfill en ejecución",
-    "bar": "Bar",
-    "before": "antes",
-    "behavior": "Comportamiento",
-    "blueprints": {
-      "all": "Todo",
-      "apps": "Planos de la Aplicación",
-      "community": "Comunidad",
-      "create": "Crear un blueprint",
-      "custom": "Planos personalizados",
-      "dashboards": "Planos del Dashboard",
-      "detail": {
-        "category": "Tipo de categoría",
-        "links": "Enlace y Recursos",
-        "openInEditor": "Abrir en Edit Flow"
-      },
-      "edit": "Editar un blueprint",
-      "empty": "No hay blueprints para mostrar.",
-      "flows": "Planos de Flow",
-      "header": {
-        "alt": "Icono de Blueprints",
-        "catch phrase": {
-          "1": "El primer paso siempre es el más difícil.",
-          "2": "Explora blueprints para iniciar tu próximo {kind}."
-        }
-      },
-      "missingPlugins": {
-        "card": "Requiere plugin(s) no instalados en esta instancia: {plugins}",
-        "description": "Este blueprint usa tasks de plugin(s) que no están instalados en esta instancia: {plugins}. Instálalos para usar este blueprint.",
-        "install": "Instalar plugins",
-        "title": "Plugins faltantes"
-      },
-      "title": "Blueprints"
+    "next": "Siguiente",
+    "done": "Hecho",
+    "review your inputs": "Revise sus entradas",
+    "edit flow": "Editar flujo",
+    "executions": "Ejecuciones",
+    "execution": "Ejecución",
+    "execution id": "Id de Ejecución",
+    "recent_executions": "Ejecuciones Recientes",
+    "details": "Detalles",
+    "overview": "Resumen",
+    "gantt": "Gantt",
+    "gantt_no_tasks_executed": "Esta ejecución terminó sin ejecutar ninguna task.\nVerifique su resumen y logs para conocer la razón.",
+    "gantt_no_tasks_match_filters": "Intenta ajustar los filtros de búsqueda, estado o nivel de log.",
+    "gantt_no_tasks_match_filters_title": "No hay tareas que coincidan con los filtros seleccionados.",
+    "logs": "Logs",
+    "no_logs_data": "Sin datos",
+    "no_logs_data_description": "Por favor, intente ajustar sus filtros, cambiar el rango de tiempo o verifique si el flow se ha ejecutado recientemente.",
+    "no_logs_data_title": "No se encontraron logs para los filtros seleccionados.",
+    "duration": "Duración",
+    "total_duration": "Duración total",
+    "running duration": "Duración en ejecución",
+    "queued duration": "Duración en cola",
+    "choose file": "Elige un archivo o suéltalo aquí...",
+    "launch execution": "Ejecutar",
+    "warning flow with triggers": "Este flujo contiene triggers y una ejecución manual fallará si este flujo depende de expresiones de trigger.",
+    "triggered": "Trigger de ejecución",
+    "triggered done": "Ejecución <em>{name}</em> se ha activado exitosamente",
+    "topology": "Topología",
+    "date": "Fecha",
+    "prev_execution": "Ejecución anterior",
+    "next_execution": "Próxima ejecución",
+    "datepicker": {
+      "leave empty for infinite": "Dejar vacío para duración infinita o escribir una duración ISO 8601 (ejemplo: 'P1DT1H1M1S)'",
+      "duration example": "Ejemplo: 'P1DT1H1M1S'",
+      "error": "Formato de duración inválido, debe ser una duración ISO 8601 (P1DT1H1M1S por ej.)",
+      "custom": "Personalizado",
+      "last5minutes": "Últimos 5 minutos",
+      "last15minutes": "Últimos 15 minutos",
+      "last1hour": "Última 1 hora",
+      "last12hours": "Últimas 12 horas",
+      "last24hours": "Últimas 24 horas",
+      "last48hours": "Últimas 48 horas",
+      "last7days": "Últimos 7 días",
+      "last30days": "Últimos 30 días",
+      "last365days": "Últimos 365 días",
+      "next5minutes": "Próximos 5 minutos",
+      "next15minutes": "Próximos 15 minutos",
+      "next1hour": "Próxima 1 hora",
+      "next12hours": "Próximas 12 horas",
+      "next24hours": "Próximas 24 horas",
+      "next48hours": "Próximas 48 horas",
+      "next7days": "Próximos 7 días",
+      "next30days": "Próximos 30 días",
+      "next365days": "Próximos 365 días",
+      "5minutes": "5 minutos",
+      "15minutes": "15 minutos",
+      "1hour": "1 hora",
+      "12hours": "12 horas",
+      "24hours": "24 horas",
+      "48hours": "48 horas",
+      "7days": "7 días",
+      "30days": "30 días",
+      "365days": "365 días",
+      "never": "Nunca",
+      "today": "Hoy",
+      "yesterday": "Ayer",
+      "dayBeforeYesterday": "Anteayer",
+      "thisWeek": "Esta semana",
+      "thisWeekSoFar": "Esta semana hasta ahora",
+      "previousWeek": "Semana anterior",
+      "thisMonth": "Este mes",
+      "thisMonthSoFar": "Este mes hasta ahora",
+      "previousMonth": "Mes anterior",
+      "thisYear": "Este año",
+      "thisYearSoFar": "Este año hasta ahora",
+      "previousYear": "Año anterior",
+      "short": {
+        "15m": "15m",
+        "1h": "1h",
+        "12h": "12h",
+        "1d": "1d",
+        "7d": "7d"
+      }
     },
-    "body_line_clamp": "Limit line height",
-    "bookmark": "Marcadores",
-    "breakpoints": "Puntos de interrupción",
-    "bulk action async warning": "Esto podría tardar unos momentos.",
-    "bulk actions": "Acciones masivas",
-    "bulk change state": "¿Está seguro de que desea cambiar el estado de <code>{executionCount}</code> ejecución(es)?",
-    "bulk delete": "¿Estás seguro de que quieres eliminar <code>{executionCount}</code> ejecución(es)?",
-    "bulk delete backfills": "Eliminar {count} backfill",
-    "bulk delete triggers": "¿Está seguro de que desea eliminar {count} triggers?",
-    "bulk disabled status": {
-      "false": "Habilitar {count} triggers",
-      "true": "Deshabilitar {count} triggers"
+    "created date": "Fecha de creación",
+    "latest_update": "Última actualización",
+    "updated date": "Fecha de actualización",
+    "expiration date": "Fecha de expiración",
+    "started date": "Fecha de inicio",
+    "healthcheck date": "Fecha de HealthCheck",
+    "next execution date": "Fecha de próxima ejecución",
+    "last execution status": "Último estado de ejecución",
+    "jump to...": "Saltar a...",
+    "contextBar": {
+      "news": "Noticias",
+      "docs": "Documentos",
+      "help": "Ayuda",
+      "issue": "Problema",
+      "demo": "Demo",
+      "star": "Danos una estrella"
     },
-    "bulk force run": "¿Está seguro de que desea forzar la ejecución de <code>{executionCount}</code> ejecución(es)?<br/><br/>ADVERTENCIA: forzar la ejecución de una ejecución no está garantizado y puede crear ejecuciones de tareas duplicadas.<br/><br/>Las siguientes transiciones se realizarán:<br/><ul><li>Las tareas en estado CREATED se moverán al estado RUNNING.</li><li>Las tareas en estado RUNNING se volverán a enviar.</li><li>Las tareas en estado QUEUED se des-encolarán.</li><li>Las tareas en estado PAUSED se reanudarán.</li></ul>",
-    "bulk kill": "¿Estás seguro de que quieres matar <code>{executionCount}</code> ejecución(es)?",
-    "bulk pause": "¿Está seguro de que desea pausar la(s) ejecución(es) <code>{executionCount}</code>?",
-    "bulk pause backfills": "Pausar {count} backfill",
-    "bulk replay": "¿Estás seguro de que quieres reproducir <code>{executionCount}</code> ejecución(es)?",
-    "bulk restart": "¿Estás seguro de que quieres reiniciar <code>{executionCount}</code> ejecución(es)?",
-    "bulk resume": "¿Estás seguro de que quieres reanudar <code>{executionCount}</code> ejecución(es)?",
-    "bulk set labels": "¿Estás seguro de que quieres establecer etiquetas a <code>{executionCount}</code> ejecución(es)?",
-    "bulk success delete backfills": "{count} backfills eliminados",
-    "bulk success delete triggers": "{count} triggers han sido eliminados exitosamente",
-    "bulk success disabled status": {
-      "false": "{count} trigger(s) habilitado(s)",
-      "true": "{count} trigger(s) deshabilitado(s)"
+    "source": "Fuente",
+    "source only": "Solo fuente",
+    "home": "Inicio",
+    "create": "Crear",
+    "create_flow": "Crear Flow",
+    "add flow": "Añadir flujo",
+    "from": "Desde",
+    "to": "Hasta",
+    "search filters": {
+      "saved": "Filtros guardados",
+      "manage": "Administrar filtros de búsqueda",
+      "manage desc": "Administrar filtros de búsqueda guardados",
+      "save filter": "Guardar filtro",
+      "filter name": "Nombre del filtro",
+      "filters": "Filtros"
     },
-    "bulk success pause backfills": "{count} backfills pausados",
-    "bulk success unlock": "{count} triggers desbloqueados",
-    "bulk success unpause backfills": "{count} backfills despausados",
-    "bulk unlock": "Desbloquear {count} triggers",
-    "bulk unpause backfills": "Despausar {count} backfill",
-    "bulk unqueue": "¿Está seguro de que desea descolar <code>{executionCount}</code> ejecución(es)?",
-    "can not delete": "No se puede eliminar",
-    "can not have less than 1 task": "Cada flow debe tener al menos una task.",
-    "can not save": "No se puede guardar",
-    "cancel": "Cancelar",
+    "steps": "Pasos",
+    "state": "Estado",
+    "state_history": "Historial de estado",
+    "search term in message": "Término de búsqueda en mensaje",
+    "search": "Buscar",
+    "search blueprint": "Buscar blueprints",
+    "all tags": "Todas las etiquetas",
+    "source search": "Búsqueda de fuente",
+    "filter by log level": "Filtrar por nivel de log",
+    "selected": "Seleccionado",
+    "task": "Tarea",
+    "task logs": "Task logs",
+    "display flow {id} executions": "Mostrar ejecuciones del flujo {id}",
+    "actions": "Acciones",
+    "select datetime": "Seleccionar una fecha",
+    "select view": "Seleccionar vista",
+    "invalid field": "Campo inválido: {name}",
+    "required field": "Campo requerido",
+    "is required": "{field} es obligatorio",
+    "error": "Error",
+    "form": "Formulario",
+    "form error": "Error en formulario",
+    "display topology for flow": "Mostrar topología para flujo",
     "cannot create topology": "No se puede crear la topología para el flujo",
-    "cannot swap tasks": "No se pueden intercambiar las tasks",
-    "change execution state confirm": "¿Está seguro de que desea cambiar el estado de la ejecución <code>{id}</code>?",
-    "change execution state done": "Estado de ejecución actualizado",
-    "change queue confirm": "¿Está seguro de que desea cambiar el estado de la cola para la ejecución <code>{id}</code>?<br/>",
+    "start date": "Fecha de inicio",
+    "end date": "Fecha de fin",
+    "creation": "Creación",
+    "flow creation": "Creación de flujo",
+    "start datetime": "Fecha y hora de inicio",
+    "end datetime": "Fecha y hora de fin",
+    "restart": "Reiniciar",
+    "restart latest revision": "Reiniciar última revisión",
+    "restart tooltip": "Reiniciar la ejecución desde la tarea <code>{state}</code>",
+    "restarted": "La ejecución se reinicia",
+    "restart confirm": "¿Estás seguro de reiniciar la ejecución <code>{id}</code>?",
+    "restart change revision": "Puedes cambiar la revisión que se usará para la nueva ejecución.",
+    "replay": "Repetir",
+    "replay from task tooltip": "Crear una ejecución similar comenzando desde la tarea <code>{taskId}</code>",
+    "replay from beginning tooltip": "Crear una ejecución similar comenzando desde el principio",
+    "replay latest revision": "Repetir usando la última revisión",
+    "replayed": "La ejecución se ha reproducido",
+    "replay confirm": "¿Estás seguro de repetir esta ejecución <code>{id}</code> y crear una nueva?",
+    "replay with inputs": "Repetir con inputs",
+    "reuse_original_inputs": "Reutilizar inputs originales",
+    "modify_inputs": "Modificar inputs",
+    "replay the execution": "Repetir la ejecución <code>{executionId}</code> para el flow <code>{flowId}</code>",
+    "prefill inputs": "Prefill",
+    "current": "actual",
     "change state": "Cambiar estado",
-    "change state confirm": "¿Está seguro de que desea cambiar el estado de ejecución de la tarea <code>{task}</code> en la ejecución <code>{id}</code>?",
-    "change state current state": "Estado actual es:",
+    "actual state": "Estado actual",
+    "select a state": "Seleccionar un estado",
+    "are you sure change state": "¿Está seguro de que desea cambiar el estado?",
+    "yes": "Sí",
     "change state done": "El estado del task ha sido actualizado",
+    "change state confirm": "¿Está seguro de que desea cambiar el estado de ejecución de la tarea <code>{task}</code> en la ejecución <code>{id}</code>?",
+    "change queue confirm": "¿Está seguro de que desea cambiar el estado de la cola para la ejecución <code>{id}</code>?<br/>",
+    "change state current state": "Estado actual es:",
     "change state hint": {
+      "WARNING": [
+        "El flow se marcará como WARNING.",
+        "Las próximas tasks se ejecutarán.",
+        "Las tasks con error se ejecutarán."
+      ],
       "FAILED": [
         "El flow se marcará como FAILED.",
         "No se ejecutará ninguna otra task.",
         "Se ejecutarán las tasks de error."
-      ],
-      "RUNNING": [
-        "El flow se reiniciará y ejecutará todas las siguientes tasks.",
-        "Todas las tasks bloqueadas serán ejecutadas."
       ],
       "SUCCESS": [
         "El flow se reiniciará ya que esta task fue exitosa.",
         "Todas las tasks bloqueadas serán ejecutadas.",
         "El flow estará en un estado de SUCCESS si todas las ejecuciones de tasks son exitosas."
       ],
-      "WARNING": [
-        "El flow se marcará como WARNING.",
-        "Las próximas tasks se ejecutarán.",
-        "Las tasks con error se ejecutarán."
+      "RUNNING": [
+        "El flow se reiniciará y ejecutará todas las siguientes tasks.",
+        "Todas las tasks bloqueadas serán ejecutadas."
       ]
     },
+    "replay execution title": "Repetir ejecución",
+    "restart execution title": "Reiniciar ejecución",
+    "replay execution description": "Esto creará una nueva ejecución basada en la ejecución seleccionada.",
+    "replay using": "Repetir usando",
+    "flow revision original": "Revisión original del flow",
+    "flow revision latest": "Última revisión del flow",
+    "flow revision specific": "Revisión específica del flow",
+    "replay inputs": "Entradas",
+    "reuse original inputs": "Reutilizar inputs originales",
+    "modify inputs": "Modificar inputs",
+    "replay inputs new required": "Esta revisión tiene inputs. Se le pedirá que los complete.",
+    "replay select taskrun": "Seleccione la ejecución de task para reproducir desde:",
     "change state tooltip": "Cambiar el estado de ejecución",
-    "chart": "Gráfico",
-    "chart preview": "Vista previa del gráfico",
-    "chart type": "Tipo de gráfico",
-    "charts": "Gráficos",
-    "choice": "Opción",
-    "choose file": "Elige un archivo o suéltalo aquí...",
-    "close": "Cerrar",
-    "close sidebar": "cerrar barra lateral",
-    "codeDisabled": "Desactivado en Flow",
-    "collapse": "Colapsar",
-    "collapse all": "Colapsar todo",
-    "commit_id": "ID de commit",
-    "common": {
-      "back": "Atrás"
-    },
-    "concurrency": "Concurrente",
-    "concurrency limits": "Límites de Concurrencia",
-    "concurrency_limit": {
-      "dialog_title": "Límites de Concurrencia",
-      "warning": "Cambiar el contador en ejecución puede corromper la concurrencia, por lo que las ejecuciones pueden exceder el límite permitido."
-    },
-    "conditions": "Condiciones",
-    "configure basic auth": "Configurar autenticación básica",
-    "confirm": "Confirmar",
-    "confirm password": "Confirmar contraseña",
-    "confirmation": "Confirmación",
-    "context updated date": "Fecha de actualización del contexto",
-    "context updated date tooltip": "Cuando se actualizó por última vez el contexto del trigger. Esto ocurre cuando se inicia la ejecución, finaliza (se libera el bloqueo) o después de una evaluación (incluso si no ocurre ninguna ejecución).",
-    "contextBar": {
-      "demo": "Demo",
-      "docs": "Documentos",
-      "help": "Ayuda",
-      "issue": "Problema",
-      "news": "Noticias",
-      "star": "Danos una estrella"
-    },
-    "continue backfill": "Continuar el backfill",
-    "continue backfills": "Continuar backfills",
-    "copied": "Copiado",
-    "copied_logs_to_clipboard": "Copiado logs al portapapeles.",
-    "copy": "Copiar",
-    "copy all logs": "Copiar todos los Logs",
-    "copy logs": "Copiar logs",
-    "copy url": "Copiar URL",
-    "copy_and_close": "Copiar y cerrar",
-    "copy_to_clipboard": "Copiar al portapapeles",
-    "copy_value": "Copy value",
-    "create": "Crear",
-    "create first task": "Crea tu primera task",
-    "create_flow": "Crear Flow",
-    "created date": "Fecha de creación",
-    "creation": "Creación",
-    "cron": "Cron",
-    "curl": {
-      "command": "Comando cURL",
-      "note": "Tenga en cuenta que para el tipo de input SECRET y FILE, el comando debe adaptarse para coincidir con los valores reales."
-    },
-    "current": "actual",
-    "current execution": "Ejecución actual",
-    "custom value": "Valor personalizado",
-    "customize sidebar": "Personalizar barra lateral",
-    "dark_version": "Versión oscura",
-    "dashboards": {
-      "chart_preview": "Haz clic en un código fuente del gráfico para ver su vista previa",
-      "creation": {
-        "confirmation": "El Dashboard <code>{title}</code> ha sido creado.",
-        "label": "Crear Dashboard"
-      },
-      "default": "Dashboard predeterminado",
-      "deletion": {
-        "confirmation": "¿Está seguro de que desea eliminar el dashboard <code>{title}</code>?"
-      },
-      "edition": {
-        "chart": "Editar este gráfico",
-        "confirmation": "Los cambios en el dashboard <code>{title}</code> se han guardado.",
-        "id readonly": "La propiedad `id` no se puede cambiar — ahora está establecida en sus valores iniciales. Si deseas cambiarla, puedes crear un nuevo dashboard y eliminar el antiguo.",
-        "label": "Editar Dashboard"
-      },
-      "empty": "No hay resultados para mostrar.",
-      "export": "Exportar a CSV",
-      "labels": {
-        "plural": "Dashboards",
-        "singular": "Panel de control"
-      },
-      "no_description": "Sin descripción",
-      "no_description_hint": "Agrega una descripción a este flow para documentar qué hace.<br>Markdown es compatible.",
-      "others": "Otros",
-      "preview": "Vista previa del Dashboard",
-      "quick_filters": {
-        "all": "Todos",
-        "failed": "Fallido",
-        "paused": "Pausado",
-        "running": "En ejecución",
-        "success": "Éxito",
-        "warning": "Advertencia"
-      },
-      "switch": "Cambiar Dashboard",
-      "viewAll": "Ver todo"
-    },
-    "data": "Datos",
-    "dataFilters": "Filtros de Datos",
-    "data_not_protected": "Tus datos no están protegidos. No los pierdas. <b>Activa nuestras funciones de seguridad gratuitas o prueba nuestra oferta de pago.</b>",
-    "date": "Fecha",
-    "date count": "{count} en el {date}",
-    "date format": "Formato de fecha",
-    "date range count": "{count} entre el {startDate} y el {endDate}",
-    "datepicker": {
-      "12hours": "12 horas",
-      "15minutes": "15 minutos",
-      "1hour": "1 hora",
-      "24hours": "24 horas",
-      "30days": "30 días",
-      "365days": "365 días",
-      "48hours": "48 horas",
-      "5minutes": "5 minutos",
-      "7days": "7 días",
-      "custom": "Personalizado",
-      "dayBeforeYesterday": "Anteayer",
-      "duration example": "Ejemplo: 'P1DT1H1M1S'",
-      "error": "Formato de duración inválido, debe ser una duración ISO 8601 (P1DT1H1M1S por ej.)",
-      "last12hours": "Últimas 12 horas",
-      "last15minutes": "Últimos 15 minutos",
-      "last1hour": "Última 1 hora",
-      "last24hours": "Últimas 24 horas",
-      "last30days": "Últimos 30 días",
-      "last365days": "Últimos 365 días",
-      "last48hours": "Últimas 48 horas",
-      "last5minutes": "Últimos 5 minutos",
-      "last7days": "Últimos 7 días",
-      "leave empty for infinite": "Dejar vacío para duración infinita o escribir una duración ISO 8601 (ejemplo: 'P1DT1H1M1S)'",
-      "never": "Nunca",
-      "next12hours": "Próximas 12 horas",
-      "next15minutes": "Próximos 15 minutos",
-      "next1hour": "Próxima 1 hora",
-      "next24hours": "Próximas 24 horas",
-      "next30days": "Próximos 30 días",
-      "next365days": "Próximos 365 días",
-      "next48hours": "Próximas 48 horas",
-      "next5minutes": "Próximos 5 minutos",
-      "next7days": "Próximos 7 días",
-      "previousMonth": "Mes anterior",
-      "previousWeek": "Semana anterior",
-      "previousYear": "Año anterior",
-      "short": {
-        "12h": "12h",
-        "15m": "15m",
-        "1d": "1d",
-        "1h": "1h",
-        "7d": "7d"
-      },
-      "thisMonth": "Este mes",
-      "thisMonthSoFar": "Este mes hasta ahora",
-      "thisWeek": "Esta semana",
-      "thisWeekSoFar": "Esta semana hasta ahora",
-      "thisYear": "Este año",
-      "thisYearSoFar": "Este año hasta ahora",
-      "today": "Hoy",
-      "yesterday": "Ayer"
-    },
-    "debug": "Depuración",
-    "default": "Predeterminado",
-    "defaultsToNamespaceFile": "Por defecto en el archivo de namespace: <code>{name}</code>",
-    "delete": "Eliminar",
-    "delete backfill": "Eliminar el backfill",
-    "delete backfills": "Eliminar backfills",
-    "delete confirm": "¿Estás seguro de eliminar <code>{name}</code>?",
-    "delete execution running": "<div class=\"alert alert-warning mt-2 mb-0\">Esta ejecución aún está RUNNING, eliminarla no la detendrá.<br />Necesitas matar la ejecución para detenerla.</div>",
-    "delete logs": "Eliminar logs",
-    "delete ok": "está eliminado",
-    "delete revision confirm": "¿Está seguro de que desea eliminar la revisión {revision}?",
-    "delete revision error": "Error al eliminar la revisión {revision} con el error {error}",
-    "delete task confirm": "¿Quieres eliminar la task <code>{taskId}</code>?",
-    "delete trigger": "Eliminar trigger",
-    "delete trigger confirmation": "¿Está seguro de que desea eliminar el trigger {id}? WARNING: eliminar un trigger puede llevar a ejecuciones duplicadas si el trigger aún está activo en un flow.",
-    "delete trigger error": "Error al eliminar trigger {id}",
-    "delete trigger success": "El trigger {id} ha sido eliminado con éxito",
-    "delete triggers": "Eliminar triggers",
-    "delete_all_logs": "¿Estás seguro de que quieres eliminar todos los logs?",
-    "delete_log": "¿Está seguro de que desea eliminar el log?",
-    "deleted": "Eliminado exitosamente",
-    "deleted confirm": "<em>{name}</em> se ha eliminado exitosamente",
-    "deleted_label": "Eliminado",
-    "demos": {
-      "IAM": {
-        "message": "La Edición Empresarial de Kestra tiene capacidades integradas de IAM con inicio de sesión único (SSO), sincronización de directorios SCIM y control de acceso basado en roles (RBAC), integrándose con múltiples proveedores de identidad y permitiéndote asignar permisos detallados para usuarios y cuentas de servicio.",
-        "title": "Gestionar usuarios a través de IAM con SSO, SCIM y RBAC"
-      },
-      "apps": {
-        "message": "Las aplicaciones en Kestra Enterprise Edition te permiten construir interfaces de usuario personalizadas que interactúan con los workflows de Kestra desde fuera de la plataforma. Esta función te permite usar tus workflows como un backend para aplicaciones personalizadas, permitiendo a usuarios no técnicos enviar datos a través de formularios o reanudar workflows PAUSED que esperan aprobación.",
-        "title": "Crea aplicaciones personalizadas con Kestra"
-      },
-      "assets": {
-        "header": "Metadatos de Activos y Observabilidad",
-        "label": "Activos",
-        "message": "Los assets conectan la observabilidad, el linaje y los metadatos de propiedad para que los equipos de la plataforma puedan solucionar problemas más rápido y desplegar con confianza.",
-        "title": "Lleva cada dataset, servicio y dependencia a la vista."
-      },
-      "audit-logs": {
-        "message": "La edición Enterprise de Kestra registra cada actividad con registros robustos e inmutables, lo que facilita el seguimiento de cambios, el mantenimiento de la conformidad y la resolución de problemas.",
-        "title": "Rastrear Cambios con Audit Logs"
-      },
-      "blueprints": {
-        "message": "En Kestra Enterprise Edition, puedes crear Blueprints personalizados disponibles solo para tu organización. Puedes usarlos como plantillas de mejores prácticas para compartir, centralizar y documentar flujos de trabajo comúnmente utilizados en tu equipo.",
-        "title": "Agregar Blueprints Personalizados"
-      },
-      "contact_sales": "Contactar Ventas",
-      "enterprise_edition": "Edición Enterprise",
-      "get_a_demo_button": "Obtener una Demo",
-      "instance": {
-        "message": "La Edición Enterprise de Kestra proporciona un panel de control operativo para ayudarte a observar la salud de tu plataforma y rastrear las métricas de tiempo de actividad de todos los servicios como, entre otros, Workers, Schedulers y Executors. Desde la misma página, también puedes crear Anuncios para notificar a tus usuarios sobre el tiempo de inactividad planificado, y puedes entrar en un modo de mantenimiento que pone temporalmente todos los servicios y ejecuciones de workflow en un estado de PAUSED para realizar una actualización.",
-        "title": "Gestionar la Infraestructura en Toda su Instancia"
-      },
-      "namespace": {
-        "assets": {
-          "message": "En Kestra Enterprise Edition, Assets mantiene un inventario en vivo de los recursos con los que interactúan tus flujos de trabajo. Estos recursos pueden ser tablas de bases de datos, máquinas virtuales, archivos o cualquier sistema externo con el que trabajes.",
-          "title": "Centralizar la Gestión de Activos"
-        },
-        "audit-logs": {
-          "message": "En la Edición Enterprise de Kestra, puedes ver los logs de auditoría a nivel de namespace con diferencias detalladas, proporcionándote un historial claro de quién cambió qué y cuándo en todos los recursos.",
-          "title": "Rastrea todos los cambios en un solo lugar"
-        },
-        "edit": {
-          "message": "En Kestra Enterprise Edition, los namespaces proporcionan aislamiento avanzado y gobernanza de secretos, variables y configuraciones predeterminadas de plugins a escala. Los administradores pueden configurar gestores de secretos personalizados, backends de almacenamiento aislados, grupos de workers dedicados y permisos detallados por cada namespace. Esto asegura que los secretos, variables y configuraciones de plugins permanezcan seguros y sean fáciles de mantener a través de diferentes equipos y proyectos.",
-          "title": "Mejora la Gestión de tu Namespace"
-        },
-        "history": {
-          "message": "En Kestra Enterprise Edition, puedes gestionar el historial de revisiones de tus Namespaces",
-          "title": "Gestionar el Historial de Revisiones en un Solo Lugar"
-        },
-        "plugin-defaults": {
-          "message": "En Kestra Enterprise Edition, puedes establecer valores predeterminados de plugins específicos del namespace, reduciendo la necesidad de configuraciones duplicadas en cada flow. Esta gobernanza central de plugins aplica configuraciones consistentes, permite la referencia segura de secretos o variables, y simplifica el mantenimiento de tus workflows.",
-          "title": "Estandarizar la Configuración con Valores Predeterminados del Plugin"
-        },
-        "secrets": {
-          "message": "En Kestra Enterprise Edition, puedes almacenar y controlar secretos a nivel de namespace, minimizando el riesgo y asegurando que las credenciales de cada equipo permanezcan aisladas. Gracias a la jerarquía anidada, también puedes configurar credenciales en un namespace padre y serán heredadas por todos los namespaces hijos. El soporte para gestores de secretos dedicados y configuraciones de permisos a nivel de namespace detalladas fortalece aún más la seguridad y el cumplimiento.",
-          "title": "Gestionar Secretos de Forma Segura"
-        },
-        "variables": {
-          "message": "En Kestra Enterprise Edition, puedes definir y gestionar variables a nivel de namespace para eliminar configuraciones repetitivas a través de los flows. Estas variables aseguran consistencia, simplifican las actualizaciones de configuración y pueden ser fácilmente referenciadas por cualquier task o trigger para flujos de trabajo más limpios y mantenibles.",
-          "title": "Gobierne Centralmente Sus Variables"
-        }
-      },
-      "quotas": {
-        "message": "Kestra Enterprise Edition le permite definir cuotas en los flujos para limitar el número de ejecuciones simultáneas o totales dentro de una ventana de tiempo. Las cuotas le ayudan a proteger la infraestructura compartida, aplicar SLAs y evitar que los flujos descontrolados consuman recursos excesivos.",
-        "title": "Aplicar cuotas de ejecución en flujos"
-      },
-      "secrets": {
-        "add_env": {
-          "first": "Codifica el <a href=\"https://kestra.io/docs/how-to-guides/secrets?utm_source=app&utm_medium=referral&utm_campaign=secrets-inlinedoc#using-secrets-in-kestra\" target=\"_blank\">valor secreto en Base64</a>",
-          "intro": "Para crear un nuevo Secret:",
-          "second": "Agrega una variable de entorno llamada '<strong>SECRET_{'{MY_SECRET_KEY}'}</strong>' con el valor anterior",
-          "third": "Reinicia tu instancia de Kestra"
-        },
-        "detected_env": "Aquí están las variables de entorno de tipo secreto identificadas al momento de inicio de la instancia:",
-        "empty_env": "Todavía no tienes ningún Secret en tu entorno.",
-        "message": "La Enterprise Edition (EE) te permite agregar, editar o eliminar secretos directamente en la UI, sin necesidad de reiniciar la instancia. Organiza secretos por namespace con permisos RBAC granulares, y herédalos de namespaces padre a hijo. EE se integra con gestores de secretos como HashiCorp Vault, AWS Secrets Manager, Azure Key Vault, Google Secret Manager y Elasticsearch. Configura backends dedicados por namespace, tenant o instancia para aislar secretos entre equipos, o habilita secretos de solo lectura almacenados en vaults externos. Los secretos permanecen cifrados en reposo y en tránsito. El almacenamiento en caché opcional reduce las llamadas a la API, y las auditorías registran todo el acceso.",
-        "title": "Mejora tu Gestión de Secrets"
-      },
-      "tenants": {
-        "message": "La Edición Enterprise de Kestra admite la multi-tenancy, proporcionándote entornos completamente aislados para diferentes equipos o proyectos, cada uno con sus propios recursos, como grupos de worker dedicados o secretos y backends de almacenamiento interno.",
-        "title": "Gestionar Flujos de Trabajo en Tenants Aislados"
-      },
-      "tests": {
-        "header": "Pruebas Unitarias para Flows",
-        "label": "Pruebas",
-        "message": "Verifica la lógica de tus flows de forma aislada, detecta regresiones temprano y mantén la confianza en tus automatizaciones a medida que cambian y crecen.",
-        "title": "Garantiza la Fiabilidad con Cada Cambio"
-      },
-      "watch_the_video": "Mira el video"
-    },
-    "density": "Density",
-    "density_compact": "Compact",
-    "density_expanded": "Expanded",
-    "density_normal": "Normal",
-    "dependencies": "Dependencias",
-    "dependencies delete flow": "Este flow tiene dependencias. Eliminarlo impedirá que se ejecuten sus dependencias.<br /><br /> Aquí está la lista de flows afectados:",
-    "dependencies loaded": "Dependencias cargadas",
-    "dependencies missing acls": "Sin permisos en este flow",
-    "dependency": {
-      "controls": {
-        "clear_selection": "Borrar selección",
-        "fit_view": "Ajustar a la pantalla",
-        "zoom_in": "Acercar",
-        "zoom_out": "Alejar"
-      },
-      "search": {
-        "flow": {
-          "display": "Incluir dependencias del flow"
-        },
-        "namespace": {
-          "no_namespace": "Sin namespace",
-          "select": "Seleccione un namespace"
-        },
-        "no_results": "No se encontraron resultados para {term}",
-        "placeholders": {
-          "asset": "Buscar por asset, flow o namespace...",
-          "default": "Buscar por flow o namespace..."
-        }
-      }
-    },
-    "dependency task": "Task {taskId} es una dependencia de otra task",
-    "description": "Descripción",
-    "details": "Detalles",
-    "disable": "Deshabilitar",
-    "disabled": "Deshabilitado",
-    "disabled flow desc": "Este flujo está deshabilitado, por favor habilítalo para poder ejecutarlo.",
-    "disabled flow title": "Este flujo está deshabilitado",
-    "discard changes confirmation": "Tienes cambios no guardados. ¿Estás seguro de que deseas descartarlos?",
-    "discard execution confirmation": "Tienes entradas no guardadas. ¿Estás seguro de que deseas descartar esta ejecución?",
-    "display direct sub tasks count": "Mostrar conteo directo de subtareas",
-    "display flow {id} executions": "Mostrar ejecuciones del flujo {id}",
-    "display metric for specific task": "Mostrar métrica para una tarea específica",
-    "display output for specific task": "Mostrar salida para una tarea específica",
-    "display topology for flow": "Mostrar topología para flujo",
-    "display_settings": "Display settings",
-    "docs": "Documentos",
-    "documentation": {
-      "documentation": "Documentación",
-      "github": "Abrir un issue en GitHub"
-    },
-    "documentationMenu": "Menú de documentación",
-    "done": "Hecho",
-    "down trend": "Disminuyendo",
-    "download": "Descargar",
-    "download logs": "Descargar logs",
-    "download_logos": "Descargar Paquete de Logos",
-    "download_logs_description": "Choose which logs to export. Filters default to your current view.",
-    "draft": "Borrador",
-    "draft_available": "El cambio en borrador está disponible en el editor",
-    "draft_flow_warning": "Esta revisión del flow es un borrador. La ejecución se realizará sobre esta revisión en borrador y puede fallar inmediatamente si la definición del flow no es válida.",
-    "drill down preview": "Vista previa",
-    "drop items here": "Suelta los elementos aquí",
-    "duplicate-pair": "{label} \"{key}\" está duplicado, se ignora la primera clave.",
-    "duration": "Duración",
-    "dynamic": "Dinámico",
-    "each value": "Valor de iteración",
-    "edit": "Editar",
-    "edit flow": "Editar flujo",
-    "editor": "Editor",
-    "editor_shortcuts": {
-      "command_palette": "Mostrar paleta de comandos",
-      "comment": "Comentario",
-      "comment_uncomment": "Comentar/Descomentar",
-      "decrease_fontsize": "Disminuir el tamaño de fuente del editor",
-      "duplicate_cursor": "Duplicar cursor",
-      "execute_flow": "Ejecutar flow",
-      "fold_unfold": "Plegar/Desplegar código",
-      "increase_fontsize": "Aumentar el tamaño de fuente del editor",
-      "label": "Atajos de teclado",
-      "move_line": "Mover línea",
-      "reset_fontsize": "Restablecer el tamaño de fuente del editor",
-      "save_flow": "Guardar flow",
-      "toggle_ai_agent": "Alternar agente de AI",
-      "trigger_autocompletion": "Activar autocompletado",
-      "uncomment": "Descomentar"
-    },
-    "ee-tooltip": {
-      "button": "Habla con nosotros",
-      "features-blocked": "Esta función requiere la Edición Enterprise."
-    },
-    "email": "Correo electrónico",
-    "email length constraint": "El correo electrónico no debe exceder los 256 caracteres",
-    "empty": {
-      "announcements": {
-        "content": "Los anuncios te permiten notificar a tus usuarios sobre cualquier cambio o informarles sobre el tiempo de inactividad planificado para mantenimiento. Simplemente selecciona el tipo de anuncio, el rango de fechas en el que debe mostrarse y escribe el mensaje del anuncio.",
-        "title": "¡No tienes anuncios todavía!"
-      },
-      "apiTokens": {
-        "content": "Los tokens de API se utilizan cada vez que deseas otorgar acceso programático a la API de Kestra.",
-        "title": "Administra tus API Tokens"
-      },
-      "apps": {
-        "content": "Comienza a crear Apps para interactuar con Kestra desde el mundo exterior.",
-        "title": "¡Aún no tienes aplicaciones!"
-      },
-      "assets": {
-        "content": "Agrega activos para rastrear y gestionar tus activos de datos, servicios e infraestructura.",
-        "title": "¡Aún no tienes Assets!"
-      },
-      "concurrency_executions": {
-        "content": "Lee más sobre <strong><a href=\"https://kestra.io/docs/workflow-components/execution?utm_source=app&utm_medium=referral&utm_campaign=concurrency-inlinedoc\" target=\"_blank\">Ejecuciones</a></strong> en nuestra documentación.",
-        "title": "No hay Ejecuciones en curso para este Flow."
-      },
-      "concurrency_limit": {
-        "content": "Lea más sobre los <strong><a href=\"https://kestra.io/docs/workflow-components/concurrency?utm_source=app&utm_medium=referral&utm_campaign=concurrency-inlinedoc\" target=\"_blank\">Límites de Concurrencia</a></strong> en nuestra documentación.",
-        "title": "No se han establecido límites para este Flow."
-      },
-      "concurrency_limits": {
-        "content": "Lea más sobre los <strong><a href=\"https://kestra.io/docs/workflow-components/concurrency?utm_source=app&utm_medium=referral&utm_campaign=concurrency-inlinedoc\" target=\"_blank\">Límites de Concurrency</a></strong> en nuestra documentación.",
-        "title": "No se han establecido límites de concurrencia."
-      },
-      "dependencies": {
-        "ASSET": {
-          "content": "Este recurso no tiene dependencias ascendentes o descendentes con flows u otros recursos.",
-          "title": "Actualmente no hay dependencias."
-        },
-        "EXECUTION": {
-          "content": "Lea más sobre <a href=\"https://kestra.io/docs/ui/executions?utm_source=app&utm_medium=referral&utm_campaign=dependencies-inlinedoc#dependencies\" target=\"_blank\">Dependencias de Ejecución</a> en nuestra documentación.",
-          "title": "Actualmente no hay dependencias."
-        },
-        "FLOW": {
-          "content": "Lea más sobre <a href=\"https://kestra.io/docs/ui/flows?utm_source=app&utm_medium=referral&utm_campaign=dependencies-inlinedoc#dependencies\" target=\"_blank\">Flow Dependencies</a> en nuestra documentación.",
-          "title": "Actualmente no hay dependencias."
-        },
-        "NAMESPACE": {
-          "content": "Lea más sobre <a href=\"https://kestra.io/docs/ui/namespaces?utm_source=app&utm_medium=referral&utm_campaign=dependencies-inlinedoc#dependencies\" target=\"_blank\">Namespace Dependencies</a> en nuestra documentación.",
-          "title": "Actualmente no hay dependencias."
-        }
-      },
-      "groups": {
-        "content": "Los grupos te permiten agrupar usuarios para que puedas gestionar permisos y asignaciones de roles colectivamente en tu mandante.",
-        "title": "¡Aún no tienes grupos!"
-      },
-      "kill_switches": {
-        "content": "La función Kill Switch proporciona un mecanismo basado en la UI para detener ejecuciones problemáticas. Reemplaza los comandos de solo CLI <code>--skip-executions</code> y <code>--skip-flows</code> con una interfaz de administración integral.",
-        "title": "¡Aún no tienes Kill Switches!"
-      },
-      "mcpToolFlows": {
-        "content": "Exponga un flow como una herramienta MCP añadiendo un <code>McpToolTrigger</code> a él. Lea más sobre el <strong><a href=\"https://kestra.io/docs/workflow-components/triggers/mcp-tool-trigger?utm_source=app&utm_medium=referral&utm_campaign=mcp-tool-trigger-inlinedoc\" target=\"_blank\">MCP Tool Trigger</a></strong> en nuestra documentación.",
-        "title": "Aún no hay flows de herramientas registrados en este servidor."
-      },
-      "namespaceFiles": {
-        "content": "Los archivos del namespace funcionan como una carpeta de proyecto para este namespace. Almacena código Python, SQL, dbt o Terraform y luego referencia cualquier archivo en tus flows con",
-        "title": "Aún no hay archivos en este namespace"
-      },
-      "panels": {
-        "content": "Has cerrado todos los paneles.  \nElige una pestaña arriba para continuar.",
-        "title": "No hay panel abierto"
-      },
-      "pluginDefaults": {
-        "content": "Los valores predeterminados del plugin te permiten gobernar centralmente la configuración de tu plugin y compartirla con todos los flows en tu namespace.",
-        "title": "¡Aún no tienes valores predeterminados de plugin!"
-      },
-      "plugins": {
-        "content": "Lee más sobre <strong><a href=\"https://kestra.io/docs/workflow-components/plugin-defaults?utm_source=app&utm_medium=referral&utm_campaign=plugin-default-inlinedoc\" target=\"_blank\">Concurrency Limits</a></strong> en nuestra documentación.",
-        "title": "No se han establecido valores predeterminados de plugin para este Namespace."
-      },
-      "testSuites": {
-        "content": "Comienza a crear suites de prueba para probar tus Flows.",
-        "title": "¡Aún no tienes Test suites!"
-      },
-      "triggers": {
-        "content": "Lee más sobre <strong><a href=\"https://kestra.io/docs/workflow-components/triggers?utm_source=app&utm_medium=referral&utm_campaign=trigger-inlinedoc\" target=\"_blank\">Triggers</a></strong> en nuestra documentación.",
-        "title": "Tu flow no tiene ningún trigger."
-      },
-      "variables": {
-        "content": "Agrega pares de key-value para compartir la configuración entre flows. Los namespaces secundarios los heredan automáticamente, y puedes referenciar cualquier value con",
-        "title": "Aún no hay variables"
-      },
-      "versionPlugin": {
-        "content": "Aquí puedes gestionar todos los plugins instalados en tu instancia de Kestra. Los plugins recién instalados pueden no estar disponibles de inmediato en todos los servicios de Kestra, dependiendo de la configuración de tu instancia.",
-        "title": "¡Aún no tienes ningún plugin versionado!"
-      },
-      "workerRegistrationTokens": {
-        "content": "Los tokens de registro permiten que los workers remotos se autentiquen y registren de manera segura con tu instancia de Kestra. Crea un token y luego úsalo para conectar nuevos workers a este clúster.",
-        "title": "¡Aún no tienes tokens de registro!"
-      }
-    },
-    "empty search": "Resultados de búsqueda vacíos",
-    "enable": "Habilitar",
-    "enable concurrency": "Habilitar concurrencia",
-    "enabled": "Habilitado",
-    "encoding": "Codificación",
-    "end date": "Fecha de fin",
-    "end datetime": "Fecha y hora de fin",
-    "environment": "Entorno",
-    "environment color setting": "Color del entorno",
-    "environment name setting": "Nombre del entorno",
-    "error": "Error",
-    "error detected": "Se detectaron errores.",
-    "error in editor": "Se ha encontrado un error en el editor",
-    "errorLogs": "Registros de errores",
-    "errors": {
-      "401": {
-        "content": "Necesitas estar autenticado para acceder a esta página.",
-        "title": "No autorizado"
-      },
-      "403": {
-        "content": "No tienes los permisos necesarios para acceder a esta página.",
-        "title": "Acceso denegado"
-      },
-      "404": {
-        "content": "La URL solicitada no fue encontrada en este servidor.<br />Eso es todo lo que sabemos.",
-        "flow or execution": "El flujo o la ejecución que estás buscando no existe.",
-        "title": "Página no encontrada"
-      }
-    },
+    "change execution state confirm": "¿Está seguro de que desea cambiar el estado de la ejecución <code>{id}</code>?",
+    "change execution state done": "Estado de ejecución actualizado",
+    "mark as": "Marcar como <code>{status}</code>",
+    "unqueue as": "Desencolar como <code>{status}</code>",
+    "kill": "Terminar",
+    "kill parents and subflow": "Terminar el flujo actual y los subflows",
+    "kill only parents": "Matar solo el actual",
+    "killed confirm": "¿Estás seguro de terminar la ejecución <code>{id}</code>?",
+    "killed done": "La ejecución está en cola para ser terminada",
+    "resume": "Reanudar",
+    "resumed title": "Reanudar ejecución <code>{id}</code>",
+    "resumed confirm": "¿Estás seguro de reanudar la ejecución <code>{id}</code>?",
+    "resumed done": "La ejecución se ha reanudado",
+    "resume from breakpoint title": "Reanudar ejecución `<code>{id}</code>` desde el punto de interrupción",
+    "resume from breakpoint done": "Ejecución reanudada desde el punto de interrupción",
+    "breakpoints": "Puntos de interrupción",
+    "pause": "Pausar",
+    "pause title": "Pausar la ejecución <code>{id}</code>.<br/>Tenga en cuenta que las tasks que se están ejecutando actualmente seguirán siendo procesadas, y la ejecución tendrá que reanudarse manualmente.",
+    "pause confirm": "¿Está seguro de pausar la ejecución <code>{id}</code>?",
+    "pause done": "La ejecución está PAUSED",
+    "unqueue": "Desencolar",
+    "unqueue title": "Desencolar ejecución <code>{id}</code>.<br/>Tenga en cuenta que no respetará el límite de concurrencia del flow, por lo que podrían estar ejecutándose más ejecuciones de las permitidas.",
+    "unqueue title multiple": "¿Está seguro de que desea descolar <code>{count}</code> ejecuciones?<br/><br/>Tenga en cuenta que no respetará el límite de concurrencia del flow, por lo que podrían estar ejecutándose más ejecuciones de las permitidas.",
+    "unqueue confirm": "¿Está seguro de descolar la ejecución <code>{id}</code>?",
+    "unqueue done": "La ejecución está descolada",
+    "force run": "Forzar ejecución",
+    "force run title": "Forzar la ejecución de <code>{id}</code>.",
+    "force run tooltip": "Forzar la ejecución para que se ejecute. Puede crear ejecuciones de task duplicadas; si es posible, use otra acción.",
+    "force run confirm": "¿Está seguro de forzar la ejecución <code>{id}</code>?<br/><br/>ADVERTENCIA: forzar la ejecución no está garantizado y puede crear ejecuciones de tareas duplicadas.<br/><br/>Las siguientes transiciones se realizarán:<br/><ul><li>Las tareas en estado CREATED se moverán al estado RUNNING.</li><li>Las tareas en estado RUNNING se volverán a enviar.</li><li>Las tareas en estado QUEUED se descolarán.</li><li>Las tareas en estado PAUSED se reanudarán.</li></ul>",
+    "force run done": "La ejecución es forzada a RUNNING",
+    "toggle output": "Alternar salidas",
+    "metrics": "Métricas",
+    "no data current task": "No hay datos disponibles para el task actual.",
+    "no metrics available": "No se registraron métricas para esta ejecución de task.",
+    "no outputs available": "No hay outputs disponibles para esta ejecución de task.",
+    "outputs": "Salidas",
+    "flow_outputs": "Salidas del Flow",
+    "no_flow_outputs": "No hay outputs disponibles.",
+    "output": "Salida",
     "eval": {
-      "expression": "Expresión",
-      "preview": "Vista previa",
-      "render": "Renderizar Expresión",
       "title": "Depurar Expresión",
-      "tooltip": "Renderiza cualquier expresión Pebble e inspecciona el contexto de la ejecución."
+      "render": "Renderizar Expresión",
+      "tooltip": "Renderiza cualquier expresión Pebble e inspecciona el contexto de la ejecución.",
+      "preview": "Vista previa",
+      "expression": "Expresión"
     },
-    "evaluation lock date": "Fecha de bloqueo de evaluación",
-    "execute": "Ejecutar",
-    "execute backfill": "Ejecutar backfill",
-    "execute flow behaviour": "Ejecutar el flujo",
-    "execute flow now ?": "¿Quieres ejecutar este flujo?",
-    "execute the flow": "Ejecutar el flujo <code>{id}</code>",
-    "execution": "Ejecución",
-    "execution already finished": "Ejecución <code>{executionId}</code> ya finalizada",
-    "execution id": "Id de Ejecución",
-    "execution labels": "Etiquetas de ejecución",
-    "execution not found": "La ejecución {executionId} no se encuentra.",
-    "execution not in state FAILED": "Ejecución <code>{executionId}</code> no está en estado FAILED",
-    "execution not in state PAUSED": "Ejecución <code>{executionId}</code> no está en estado PAUSED",
-    "execution replay": "Esta ejecución es una repetición de",
-    "execution replayed": "Esta ejecución ha sido reproducida.",
-    "execution restarted": "Esta ejecución se ha reiniciado {nbRestart} vez/veces.",
+    "attempt": "Intento",
+    "toggle output display": "Alternar visualización de salida",
+    "name": "Nombre",
+    "key": "Key",
+    "value": "Value",
+    "each value": "Valor de iteración",
+    "current execution": "Ejecución actual",
+    "parent execution": "Ejecución padre",
+    "original execution": "Ejecución original",
+    "automatic refresh": "Actualización automática",
+    "toggle periodic refresh each x seconds": "Alternar actualización periódica cada {interval} segundos",
+    "trigger refresh": "Actualizar trigger",
+    "add-trigger-in-editor": "Agrega un Trigger a tu Flow primero",
+    "refresh": "Actualizar",
+    "filter by status": "Filtrar ejecuciones por estado {status}",
+    "topology-graph": {
+      "graph-orientation": "Orientación del gráfico",
+      "zoom-in": "Acercar",
+      "zoom-out": "Alejar",
+      "zoom-reset": "Restablecer zoom",
+      "zoom-fit": "Ajustar",
+      "invalid": "Error de gráfico",
+      "invalid_description": "Ocurrió un error al cargar el gráfico. Por favor, verifica el código fuente en busca de errores."
+    },
+    "show task logs": "Mostrar task logs",
+    "show task condition": "Mostrar condición de task",
+    "show task outputs": "Mostrar salidas de tarea",
+    "show task source": "Mostrar fuente de tarea",
+    "specific task": "Tarea específica",
+    "display output for specific task": "Mostrar salida para una tarea específica",
+    "display metric for specific task": "Mostrar métrica para una tarea específica",
+    "display direct sub tasks count": "Mostrar conteo directo de subtareas",
+    "stream": "Stream",
     "execution statistics": "Estadísticas de ejecución",
-    "execution-include-non-terminated": "¿Incluir ejecuciones no terminadas?",
-    "execution-warn-deleting-still-running": "Recomendamos encarecidamente que canceles esta acción y detengas cualquier ejecución en curso primero. Eliminar ejecuciones no terminadas puede llevar a problemas de concurrencia, inconsistencias en la gestión de dependencias de flow y procesos zombie en tu instancia, lo que puede degradar el rendimiento del sistema. Asegúrate de comprender completamente estos riesgos antes de proceder con la eliminación.",
-    "execution-warn-title": "¡Advertencia Importante!",
-    "execution_deletion": {
-      "logs": "Eliminar logs",
-      "metrics": "Eliminar métricas",
-      "storage": "Eliminar archivos de almacenamiento interno"
-    },
-    "execution_failed": "¡Ejecución fallida!",
-    "execution_guide": {
-      "get_started": {
-        "text": "Sigue la Guía de inicio rápido para instalar Kestra y comenzar a crear tus primeros flujos de trabajo.",
-        "title": "Comenzar ⚡"
-      },
-      "namespaces": {
-        "text": "Los namespaces son agrupaciones lógicas de flows y sus componentes.",
-        "title": "Acerca de Namespaces"
-      },
-      "videos_tutorials": {
-        "text": "Comienza con nuestros tutoriales en video.",
-        "title": "Tutoriales en Video"
-      },
-      "workflow_components": {
-        "text": "Conozca los principales componentes de orquestación de un flujo de trabajo de Kestra.",
-        "title": "Componentes del Workflow"
-      }
-    },
-    "execution_started": "¡La ejecución ha comenzado!",
-    "execution_starts_progress": "Una vez que la ejecución comience, verás actualizaciones de progreso aquí.",
-    "execution_status": "La ejecución es:",
-    "executions": "Ejecuciones",
-    "executions deleted": "<code>{executionCount}</code> ejecución(es) eliminadas",
+    "stats": "Estadísticas",
+    "concurrency limits": "Límites de Concurrencia",
+    "system overview": "Visión General del Sistema",
+    "usage": "Uso",
+    "namespaces": "Namespaces",
+    "tasks": "Tareas",
     "executions duration (in minutes)": "Duración total de ejecuciones (en minutos)",
-    "executions force run": "<code>{executionCount}</code> ejecución(es) forzada(s) en ejecución",
-    "executions killed": "<code>{executionCount}</code> ejecución(es) matadas",
-    "executions paused": "<code>{executionCount}</code> ejecución(es) PAUSED",
-    "executions replayed": "<code>{executionCount}</code> ejecución(es) reproducidas",
-    "executions restarted": "<code>{executionCount}</code> ejecución(es) reiniciadas",
-    "executions resumed": "<code>{executionCount}</code> ejecución(es) reanudadas",
-    "executions state changed": "El estado de <code>{executionCount}</code> ejecución(es) ha sido cambiado",
-    "executions unqueue": "<code>{executionCount}</code> ejecución(es) en cola",
-    "expand": "Expandir",
-    "expand all": "Expandir todo",
-    "expand dependencies": "Expandir dependencias",
-    "expand error": "Expandir solo tasks fallidas",
-    "expand_by_default": "Expand structured logs by default",
-    "expiration": "Expiración",
-    "expiration date": "Fecha de expiración",
-    "export": "Exportar",
-    "export all flows": "Exportar todos los flows",
-    "export all templates": "Exportar todas las plantillas",
-    "export_as": "Exportar como .{format}",
-    "export_csv": "Exportar como CSV",
-    "exports": "Exportaciones",
-    "failed to export plugin defaults": "Error al exportar los valores predeterminados del plugin",
-    "failed to import plugin defaults": "Error al importar los valores predeterminados del plugin",
-    "failed to render pdf": "Error al renderizar la vista previa del PDF",
-    "false": "Falso",
-    "feeds": {
-      "heading": "Todo sobre Kestra.",
-      "subheading": "Las últimas actualizaciones, guías e historias",
-      "title": "Novedades en Kestra"
+    "last 48 hours": "últimas 48 horas",
+    "configure basic auth": "Configurar autenticación básica",
+    "email": "Correo electrónico",
+    "password": "Contraseña",
+    "confirm password": "Confirmar contraseña",
+    "email length constraint": "El correo electrónico no debe exceder los 256 caracteres",
+    "password length constraint": "La contraseña no debe exceder los 256 caracteres",
+    "password empty constraint": "Nombre de usuario o contraseña incorrectos",
+    "passwords do not match": "Las contraseñas no coinciden",
+    "avg duration": "Duración promedio de ejecución",
+    "neutral trend": "Estable",
+    "up trend": "Aumentando",
+    "down trend": "Disminuyendo",
+    "update aborted": "actualización abortada",
+    "invalid flow": "Flujo inválido",
+    "invalid yaml": "YAML inválido",
+    "inputs": "Entradas",
+    "no_inputs": "No hay inputs disponibles.",
+    "input": "Entrada",
+    "variables": "Variables",
+    "variable_explorer": {
+      "title": "Entrada/Salida",
+      "search_placeholder": "Buscar Key o value...",
+      "tasks_outputs": "Tasks outputs",
+      "tree": "Árbol",
+      "raw_json": "Raw JSON",
+      "select_prompt": "Selecciona una variable para inspeccionar su value.",
+      "empty": "No hay variables disponibles para esta ejecución.",
+      "one_key": "\\{ 1 key \\}",
+      "n_keys": "\\{ {count} keys \\}",
+      "one_item": "[ 1 elemento ]",
+      "n_items": "[ {count} elementos ]"
     },
-    "file preview truncated": "El contenido mostrado ha sido truncado",
-    "file unavailable": "Archivo no disponible",
-    "file unavailable description": "Este archivo ya no está disponible; puede haber sido eliminado o haber expirado.",
-    "fileTypeNotAllowed": "Tipo de archivo no permitido. Tipos aceptados: {types}",
     "file_preview": {
       "big_file_warning": "Este archivo tiene un tamaño de {size}. Puede tardar un tiempo en cargarse, bloqueando su navegador. ¿Desea cargarlo de todos modos?",
       "load_anyway": "Cargar de todos modos"
     },
-    "files": "Archivos",
-    "filter by log level": "Filtrar por nivel de log",
-    "filter by status": "Filtrar ejecuciones por estado {status}",
-    "filter by this value": "Filter by this value",
-    "filter_for": "Filter for",
-    "filter_out": "Filter out",
-    "filters": {
-      "comparators": {
-        "between": "entre",
-        "contains": "contiene",
-        "ends_with": "termina con",
-        "greater_than": "mayor que",
-        "greater_than_or_equal_to": "mayor o igual que",
-        "in": "en",
-        "is": "es",
-        "is_not": "no es",
-        "is_one_of": "es uno de",
-        "less_than": "menos de",
-        "less_than_or_equal_to": "menor o igual que",
-        "not_contains": "no contiene",
-        "not_in": "no en",
-        "starts_with": "comienza con"
-      },
-      "empty": "Sin datos.",
-      "format": "Escriba el parámetro como 'key:value'",
-      "label": "Elegir filtros",
-      "options": {
-        "absolute_date": "Fecha absoluta",
-        "action": "Acción",
-        "aggregation": "Agregación",
-        "child": "Niño",
-        "details": "Detalles",
-        "endDate": "Fecha de finalización",
-        "flow": "Flujo",
-        "labels": "Etiquetas",
-        "level": "Nivel de log",
-        "metric": "Métrica",
-        "namespace": "Namespace",
-        "permission": "Permiso",
-        "relative_date": "Fecha relativa",
-        "scope": "Ámbito",
-        "service_type": "Tipo",
-        "startDate": "Fecha de inicio",
-        "state": "Estado",
-        "status": "Estado",
-        "task": "Tarea",
-        "text": "I'm sorry, but it seems like the text you want me to translate is missing. Could you please provide the text again?",
-        "type": "Tipo",
-        "user": "Usuario"
-      },
-      "save": {
-        "dialog": {
-          "confirmation": "Criterios de búsqueda <code>{name}</code>",
-          "heading": "Guardar búsqueda actual",
-          "hint": "¿Cómo desea etiquetar este criterio de búsqueda?",
-          "placeholder": "Etiqueta"
-        },
-        "empty": "Todavía no has guardado ninguna búsqueda.",
-        "label": "Búsquedas guardadas",
-        "name_already_used": "La etiqueta de búsqueda ya está en uso.",
-        "remove": "Eliminar",
-        "tooltip": "No puedes guardar criterios de búsqueda vacíos."
-      },
-      "settings": {
-        "label": "Configuración de la página",
-        "show_chart": "Mostrar gráfico principal"
-      },
-      "text_search": "Buscar este texto"
-    },
-    "fix_with_ai": "Solucionar con IA",
-    "flow": "Flujo",
-    "flow already exists": "Flow ya existe",
-    "flow already exists message": "El flow <code>{id}</code> ya existe en el namespace <code>{namespace}</code>. ¿Desea crear una nueva revisión?",
-    "flow creation": "Creación de flujo",
-    "flow creation denied in namespace": "No tienes permiso para crear flows en el namespace `{namespace}`.",
-    "flow delete": "¿Estás seguro de que quieres eliminar <code>{flowCount}</code> flow(s)?",
-    "flow deleted, you can restore it": "El flow ha sido eliminado y esta es una vista de solo lectura. Aún puedes restaurarlo.",
-    "flow disable": "¿Estás seguro de que quieres deshabilitar <code>{flowCount}</code> flow(s)?",
-    "flow enable": "¿Estás seguro de que quieres habilitar <code>{flowCount}</code> flow(s)?",
-    "flow export": "¿Estás seguro de que quieres exportar <code>{flowCount}</code> flow(s)?",
-    "flow must have id and namespace": "El flow debe tener un id y un namespace.",
-    "flow must not be empty": "El flow no debe estar vacío",
-    "flow not imported": "Algunos flow no pudieron ser importados",
-    "flow revision latest": "Última revisión del flow",
-    "flow revision original": "Revisión original del flow",
-    "flow revision specific": "Revisión específica del flow",
-    "flow source not found": "Fuente de flow no encontrada",
-    "flow-dependencies": "dependencias",
-    "flow-no-dependencies": "Tu flow no tiene dependencias.",
-    "flow_editor_stats": {
-      "apps": {
-        "suffix": "Aplicación(es)",
-        "tooltip": "Ver aplicaciones que usan este flow"
-      },
-      "dependencies": {
-        "suffix": "Dependencias",
-        "tooltip": "Ver dependencias del flow"
-      },
-      "errors": {
-        "label": "{count} Error(es)"
-      },
-      "revisions": {
-        "suffix": "Revisión(es)",
-        "tooltip": "Ver revisiones de flow"
-      },
-      "tests": {
-        "suffix": "Prueba(s)",
-        "tooltip": "Ver pruebas de flow"
-      }
-    },
-    "flow_export": "Exportar flow",
-    "flow_only": "Solo disponible en la pestaña Flow.",
-    "flow_outputs": "Salidas del Flow",
-    "flows": "Flujos",
-    "flows deleted": "<code>{count}</code> Flow(s) eliminados",
-    "flows disabled": "<code>{count}</code> Flow(s) deshabilitados",
-    "flows enabled": "<code>{count}</code> Flow(s) habilitados",
-    "flows exported": "<code>{count}</code> Flow(s) exportado(s)",
-    "flows imported": "Flujos importados",
-    "focus task": "Haz clic en cualquier elemento para ver su documentación.",
-    "fold_all_multi_lines": "Plegar Todas las Líneas Múltiples",
-    "font size": "Font size",
-    "for flow": "para flow",
-    "forbidden system labels": "Solo system.correlationId puede usarse como label del sistema",
-    "force run": "Forzar ejecución",
-    "force run confirm": "¿Está seguro de forzar la ejecución <code>{id}</code>?<br/><br/>ADVERTENCIA: forzar la ejecución no está garantizado y puede crear ejecuciones de tareas duplicadas.<br/><br/>Las siguientes transiciones se realizarán:<br/><ul><li>Las tareas en estado CREATED se moverán al estado RUNNING.</li><li>Las tareas en estado RUNNING se volverán a enviar.</li><li>Las tareas en estado QUEUED se descolarán.</li><li>Las tareas en estado PAUSED se reanudarán.</li></ul>",
-    "force run done": "La ejecución es forzada a RUNNING",
-    "force run title": "Forzar la ejecución de <code>{id}</code>.",
-    "force run tooltip": "Forzar la ejecución para que se ejecute. Puede crear ejecuciones de task duplicadas; si es posible, use otra acción.",
-    "form": "Formulario",
-    "form error": "Error en formulario",
-    "from": "Desde",
-    "gantt": "Gantt",
-    "gantt_no_tasks_executed": "Esta ejecución terminó sin ejecutar ninguna task.\nVerifique su resumen y logs para conocer la razón.",
-    "gantt_no_tasks_match_filters": "Intenta ajustar los filtros de búsqueda, estado o nivel de log.",
-    "gantt_no_tasks_match_filters_title": "No hay tareas que coincidan con los filtros seleccionados.",
-    "healthcheck date": "Fecha de HealthCheck",
-    "hide task documentation": "Ocultar documentación de la task",
-    "home": "Inicio",
-    "hostname": "Nombre del host",
-    "iam": "IAM",
-    "id": "Id",
-    "import": "Importar",
-    "in-our-documentation": "en nuestra documentación.",
-    "informative notice": "Nota(s)",
-    "input": "Entrada",
-    "inputs": "Entradas",
-    "instance": "Instancia",
-    "invalid bulk delete": "No se pudieron eliminar las ejecuciones",
-    "invalid bulk force run": "No se pudo forzar la ejecución de ejecuciones",
-    "invalid bulk kill": "No se pudieron matar las ejecuciones",
-    "invalid bulk pause": "No se pudo pausar las ejecuciones",
-    "invalid bulk replay": "No se pudieron reproducir las ejecuciones",
-    "invalid bulk restart": "No se pudieron reiniciar las ejecuciones",
-    "invalid bulk resume": "No se pudieron reanudar las ejecuciones",
-    "invalid bulk unqueue": "No se pudieron desencolar ejecuciones",
-    "invalid field": "Campo inválido: {name}",
-    "invalid flow": "Flujo inválido",
-    "invalid source": "Código fuente inválido",
-    "invalid yaml": "YAML inválido",
-    "is deprecated": "está obsoleto",
-    "is required": "{field} es obligatorio",
-    "item": "elemento",
-    "items": "elementos",
-    "join community": "Únete a la Comunidad",
-    "join_slack": "Unirse a Slack",
-    "jsonl": "JSONL",
-    "jump to...": "Saltar a...",
-    "kestra": "Kestra",
-    "key": "Key",
-    "kill": "Terminar",
-    "kill only parents": "Matar solo el actual",
-    "kill parents and subflow": "Terminar el flujo actual y los subflows",
-    "killed confirm": "¿Estás seguro de terminar la ejecución <code>{id}</code>?",
-    "killed done": "La ejecución está en cola para ser terminada",
-    "kv": {
-      "add": "Crear",
-      "delete multiple": {
-        "confirm": "¿Está seguro de que desea eliminar: <code>{name}</code> kv(s)?",
-        "warning": "No tienes permisos para esos namespaces, por lo que se omitirán: <code>{namespaces}</code>"
-      },
-      "duplicate": "Esta key ya existe",
-      "inherited": "Pares KV heredados",
-      "name": "KV Store",
-      "type": "Tipo",
-      "update": "Actualizar value para key '{key}'"
-    },
-    "label": "Label",
-    "label filter placeholder": "Etiqueta como 'key:value'",
-    "labels": "Etiquetas",
-    "last 48 hours": "últimas 48 horas",
-    "last X days count": "{count} en los últimos {days} días",
-    "last error was": "Último error fue",
-    "last evaluation date": "Última fecha de evaluación",
-    "last evaluation date tooltip": "When the trigger was last evaluated by the scheduler, regardless of whether it produced an execution.",
-    "last execution date": "Fecha de última ejecución",
-    "last execution state": "Último estado",
-    "last execution status": "Último estado de ejecución",
-    "last modified": "Última modificación",
-    "last trigger date": "Fecha de último trigger",
-    "last trigger date tooltip": "Cuando el trigger se ejecutó por última vez. Puede estar en el pasado al ejecutar un backfill.",
-    "latest_update": "Última actualización",
-    "launch execution": "Ejecutar",
-    "learn_more": "Aprender más",
-    "leave page": "Salir de la página",
-    "license": "Licencia",
-    "light_background": "Esta es la opción preferida al trabajar con un fondo claro.",
-    "light_version": "Versión ligera",
-    "line": "Línea",
-    "line-by-line": "línea por línea",
-    "loaded x dependencies": "{count} dependencias cargadas",
-    "loading": "Cargando...",
-    "log expand setting": "Visualización predeterminada del Log",
-    "logExporters": "Exportadores de Logs",
-    "logs": "Logs",
-    "logs_copied": "Logs copied to your clipboard",
-    "logs_view": {
-      "compact": "Vista predeterminada",
-      "compact_details": "Mostrar task logs en una vista compacta agrupada por cada task",
-      "raw": "Vista temporal",
-      "raw_details": "Mostrar task logs y flow logs completos en un formato crudo ordenado por marca de tiempo"
-    },
-    "main_configuration": "Configuración Principal",
-    "manage labels": "Gestionar etiquetas",
-    "management port": "Puerto de gestión",
-    "mark as": "Marcar como <code>{status}</code>",
-    "max": "Max",
-    "mcp": {
-      "api_token": "Token de API",
-      "auth_type": "Autenticación",
-      "basic_auth": "Autenticación Básica",
-      "bearer_token": "Autenticación de token Bearer",
-      "client_setup": "Configuración del cliente",
-      "connect": "Conectar",
-      "connect_tab": {
-        "auth_api_token_hint": "Configure <code>KESTRA_TOKEN</code> como variable de entorno antes de iniciar el cliente.",
-        "auth_basic_hint": "Configure <code>KESTRA_BASIC_AUTH</code> como variable de entorno que contenga una cadena <code>username:password</code> codificada en base64 antes de iniciar el cliente.",
-        "auth_oauth_browser_hint": "Su navegador abrirá la página de inicio de sesión del proveedor de identidad en la primera conexión.",
-        "auth_oauth_client_id_hint": "Reemplace <code>&lt;client-id&gt;</code> con el ID de cliente OAuth y registre <code>http://localhost:7777</code> como URI de redirección válida en ese cliente.",
-        "claude_code": "Código Claude",
-        "claude_code_hint": "Ejecute el siguiente comando en su terminal:",
-        "claude_desktop": "Claude Desktop",
-        "claude_desktop_hint": "Agrega lo siguiente a tu archivo claude_desktop_config.json:",
-        "claude_desktop_mac": "macOS: ~/Library/Application Support/Claude/claude_desktop_config.json",
-        "claude_desktop_win": "Windows: %APPDATA%\\Claude\\claude_desktop_config.json",
-        "client_picker_label": "Elija su cliente de IA",
-        "codex": "Codex (OpenAI)",
-        "codex_hint": "Agrega lo siguiente a tu configuración MCP en codex.json:",
-        "cursor": "Cursor",
-        "cursor_hint": "Agrega lo siguiente a ~/.cursor/mcp.json:",
-        "server_url": "URL del servidor"
-      },
-      "copy_url": "Copiar URL",
-      "create": "Crear Servidor",
-      "delete_confirm": "¿Está seguro de que desea eliminar este servidor MCP?",
-      "id_invalid": "El id debe comenzar con una letra minúscula o un dígito, y contener solo letras minúsculas, dígitos, guiones o guiones bajos.",
-      "id_placeholder": "p. ej. my-mcp-server",
-      "instructions": "Instrucciones",
-      "main_tenant": "principal",
-      "managed_by_kestra": "Gestionado por Kestra",
-      "no_oauth_providers": "No hay proveedores OIDC configurados en esta instancia",
-      "no_servers": "No se encontraron servidores MCP. Cree su primer servidor para exponer los triggers de la herramienta MCP a agentes de IA externos.",
-      "oauth": "OAuth",
-      "oauth_hint": "JWT Bearer de su proveedor OIDC",
-      "oauth_provider": "Proveedor OAuth",
-      "oauth_provider_placeholder": "Seleccione un proveedor OIDC configurado",
-      "oauth_provider_required": "El proveedor OAuth es obligatorio cuando el tipo de autenticación es OAuth",
-      "page_description": "Exponga sus flows de Kestra como herramientas para agentes de IA compatibles con MCP",
-      "private": "Privado",
-      "private_server": "Servidor privado",
-      "public": "Público",
-      "public_hint": "Advertencia: Los servidores públicos no requieren autenticación. Cualquiera con la URL puede invocar cada herramienta expuesta por este servidor, sin namespace ni comprobaciones de permisos. Úselo solo para servidores seguros de exponer externamente.",
-      "save": "Guardar cambios",
-      "scopes_supported": "Scopes admitidos",
-      "scopes_supported_hint": "Scopes anunciados en el documento Protected Resource Metadata de este servidor. Los clientes MCP que cumplen con la especificación limitan su solicitud de autorización a esta lista. Déjelo vacío para omitir el campo y dejar que los clientes utilicen los scopes anunciados por el IdP.",
-      "scopes_supported_placeholder": "openid, profile, email",
-      "server": "Servidor MCP",
-      "server_id": "ID del servidor",
-      "server_type": "Tipo de Servidor",
-      "servers": "Servidores MCP",
-      "servers_count": "{{count}} Servidores MCP",
-      "tab_connect": "Conectar",
-      "tab_edit": "Editar",
-      "tab_tool_flows": "Flujos de Herramientas",
-      "tab_tool_flows_placeholder": "La gestión de flows de herramientas llegará pronto.",
-      "tools": {
-        "annotations": "Anotaciones",
-        "create_tool_flow": "Crear un flow de herramienta",
-        "description": "Descripción",
-        "destructive": "Destructivo",
-        "flow": "flow",
-        "idempotent": "Idempotente",
-        "no_tools": "No hay flows de herramientas que coincidan con tu búsqueda.",
-        "open_world": "Open world",
-        "read_only": "Solo lectura",
-        "return_direct": "Retorno directo",
-        "state": "Estado",
-        "title": "Título",
-        "tool_name": "Nombre de la herramienta",
-        "trigger_id": "ID del trigger",
-        "view_flow": "Abrir flow"
-      },
-      "url_copied": "¡URL copiada!",
-      "username_password": "Nombre de usuario y contraseña",
-      "your_servers": "Sus Servidores"
-    },
-    "metric": "Métrica",
-    "metric choice": "No hay métricas disponibles para este flow",
-    "metrics": "Métricas",
-    "min": "Min",
-    "missingSource": "Fuente faltante",
-    "modify inputs": "Modificar inputs",
-    "modify_inputs": "Modificar inputs",
-    "monogram": "Monograma",
-    "more actions": "Más acciones",
-    "more_actions": "Más acciones",
-    "multi_panel_editor": {
-      "close_all_panels": "Cerrar todos los paneles",
-      "close_all_tabs": "Cerrar todas las pestañas",
-      "move_left": "Mover a la izquierda",
-      "move_right": "Mover a la derecha"
-    },
-    "multiple saved done": "{name} se ha guardado",
-    "name": "Nombre",
-    "namespace": "Namespace",
-    "namespace and id readonly": "Las propiedades `namespace` y `id` no se pueden cambiar — ahora están configuradas a sus valores iniciales. Si deseas renombrar un flow o cambiar su namespace, puedes crear un nuevo flow y eliminar el antiguo.",
-    "namespace files": {
-      "create": {
-        "file": "Crear archivo",
-        "file_already_exists": "Ya existe un archivo con este nombre",
-        "file_conflicts_with_folder": "Ya existe una carpeta con este nombre",
-        "file_error": "Se produjo un error al crear el archivo",
-        "folder": "Crear carpeta",
-        "folder_already_exists": "Ya existe una carpeta con este nombre",
-        "folder_conflicts_with_file": "Ya existe un archivo con este nombre",
-        "folder_error": "Se produjo un error al crear la carpeta",
-        "label": "Crear"
-      },
-      "delete": {
-        "file": "Eliminar archivo",
-        "files": "Eliminar {count} archivos seleccionados",
-        "folder": "Eliminar carpeta",
-        "folders": "Eliminar {count} carpetas seleccionadas",
-        "label": "Eliminar"
-      },
-      "dialog": {
-        "deletion": {
-          "confirm": "Confirmar",
-          "file_single": "¿Está seguro de que desea eliminar el archivo <code>{name}</code>?",
-          "files": "¿Está seguro de que desea eliminar <code>{count}</code> archivo(s)?",
-          "folder_single": "¿Está seguro de que desea eliminar la carpeta <code>{name}</code> y todo su contenido?",
-          "folders": "¿Está seguro de que desea eliminar <code>{count}</code> carpeta(s) y todo su contenido?",
-          "mixed": "¿Está seguro de que desea eliminar la(s) carpeta(s) <code>{folders}</code> y el/los archivo(s) <code>{files}</code>?",
-          "title": "Confirmar eliminación de contenido"
-        },
-        "name": {
-          "file": "Nombre con extensión:",
-          "folder": "Nombre de la carpeta:"
-        },
-        "parent_folder": "Carpeta padre:"
-      },
-      "export": "Exportar archivos del namespace",
-      "export_single": "Exportar archivo",
-      "filter": "Filtro",
-      "import": {
-        "error": "Ocurrieron errores al importar el/los archivo(s)",
-        "files": "Importar archivos",
-        "folder": "Importar carpeta",
-        "import": "Importar",
-        "success": "Archivo(s) importado(s) exitosamente"
-      },
-      "new_file": "Nuevo archivo",
-      "no_items": {
-        "heading": "No se encontraron archivos en tu namespace aún.",
-        "paragraph": "Crea o importa archivos para compartir código entre flows en tu namespace."
-      },
-      "no_selection": {
-        "description": "Selecciona un archivo del árbol para ver su contenido.",
-        "heading": "Ningún archivo seleccionado"
-      },
-      "path": {
-        "copy": "Copiar ruta",
-        "error": "Ocurrieron errores al copiar la ruta al portapapeles",
-        "success": "Ruta copiada al portapapeles"
-      },
-      "rename": {
-        "file": "Renombrar archivo",
-        "folder": "Renombrar carpeta",
-        "label": "Renombrar",
-        "new_file": "Nuevo nombre con extensión:",
-        "new_folder": "Nuevo nombre de carpeta:"
-      },
-      "revisions": {
-        "history": "Historial de revisiones",
-        "restore": {
-          "success": "Revisión del archivo restaurada con éxito"
-        }
-      },
-      "toggle": {
-        "hide": "Ocultar archivos del namespace",
-        "show": "Mostrar archivos del namespace"
-      },
-      "tree": {
-        "collapse": "Colapsar todas las carpetas",
-        "expand": "Expandir todas las carpetas"
-      }
-    },
-    "namespace not allowed": "Namespace no permitido",
-    "namespace_editor": {
-      "close": {
-        "all": "Cerrar todas las pestañas",
-        "other": "Cerrar otras pestañas",
-        "right": "Cerrar a la derecha",
-        "tab": "Cerrar pestaña"
-      },
-      "empty": {
-        "create_message": "Puedes crear o importar archivos de namespace.",
-        "title": "No hay pestañas abiertas actualmente",
-        "video_message": "Puedes ver el Video de Introducción para nuestro Editor."
-      }
-    },
-    "namespaces": "Namespaces",
-    "neutral trend": "Estable",
-    "new": "Nuevo",
-    "new version": "¡Nueva versión {version} disponible!",
-    "next": "Siguiente",
-    "next evaluation date": "Próxima fecha de evaluación",
-    "next evaluation date tooltip": "Cuando el trigger se evaluará la próxima vez, basado en su intervalo. No siempre es lo mismo que la próxima fecha de ejecución si no se cumplen las condiciones.",
-    "next execution date": "Fecha de próxima ejecución",
-    "next_execution": "Próxima ejecución",
-    "no data current task": "No hay datos disponibles para el task actual.",
-    "no inputs": "Este flow no tiene inputs.",
-    "no metrics available": "No se registraron métricas para esta ejecución de task.",
-    "no outputs available": "No hay outputs disponibles para esta ejecución de task.",
-    "no result": "No hay resultados para mostrar.",
-    "no revisions": "Sin revisiones",
-    "no revisions found": "Solo existe una revisión para este flujo",
-    "no-executions-view": {
-      "guidance_desc": "¿Necesitas orientación para ejecutar tu flow?",
-      "guidance_sub_desc": "Sigue la documentación para toda la información que necesitas.",
-      "namespace_guidance_desc": "¿Necesitas orientación para gestionar tu Namespace?",
-      "namespace_sub_title": "Ejecuta uno o más flows de este namespace para llenar este panel.",
-      "sub_title": "Haz clic en el botón Ejecutar para iniciar la ejecución de tu primer flujo de trabajo.",
-      "title": "Comienza a automatizar con"
-    },
-    "no_code": {
-      "add_field": "Agregar {field}",
-      "adding": "+ Agregar un {what}",
-      "adding_default": "+ Añadir un nuevo value",
-      "clearSelection": "Borrar selección",
-      "creation": {
-        "afterExecution": "Agregar un bloque después de la ejecución",
-        "charts": "Agregar un gráfico",
-        "conditions": "Agregar una condición",
-        "default": "Agregar",
-        "errors": "Agregar un manejador de errores",
-        "finally": "Agregar un bloque finally",
-        "inputs": "Agregar un campo de input",
-        "numerator": "Agregar un numerador",
-        "pluginDefaults": "Agregar un plugin predeterminado",
-        "tasks": "Agregar una task",
-        "triggers": "Agregar un trigger",
-        "where": "Filtra tus datos"
-      },
-      "fields": {
-        "general": {
-          "checks": "Comprobaciones",
-          "concurrency": "Concurrente",
-          "disabled": "Desactivado",
-          "labels": "Etiquetas",
-          "listeners": "Oyentes",
-          "outputs": "Salidas",
-          "retry": "Reintentar",
-          "sla": "SLA",
-          "taskDefaults": "Predeterminados de Task",
-          "updated": "Actualizado",
-          "variables": "Variables",
-          "workerGroup": "Grupo de Worker",
-          "workerSelector": "Selector de Worker"
-        },
-        "main": {
-          "description": "Descripción",
-          "id": "ID de Flow",
-          "inputs": "Entradas",
-          "namespace": "Namespace"
-        }
-      },
-      "labels": {
-        "label": "Etiqueta",
-        "no_code": "Editor Sin Código",
-        "variable": "Variable",
-        "yaml": "Editor YAML"
-      },
-      "remove": {
-        "cases": "Eliminar este caso",
-        "default": "Eliminar esta entrada"
-      },
-      "sections": {
-        "afterExecution": "Después de la Ejecución",
-        "deprecated": "Propiedades obsoletas",
-        "errors": "Manejadores de Errores",
-        "finally": "Finalmente",
-        "pluginDefaults": "Predeterminados del Plugin",
-        "tasks": "Tareas",
-        "triggers": "Disparadores"
-      },
-      "select": {
-        "afterExecution": "Seleccionar una task",
-        "charts": "Seleccione un tipo de gráfico",
-        "conditions": "Seleccione una condición",
-        "default": "Seleccionar un tipo",
-        "errors": "Selecciona una task",
-        "finally": "Seleccionar una task",
-        "inputs": "Seleccione un tipo de campo de input",
-        "numerator": "Seleccione un numerador",
-        "pluginDefaults": "Seleccionar un plugin",
-        "task": "Selecciona una task",
-        "tasks": "Seleccionar una task",
-        "triggers": "Seleccione un trigger",
-        "where": "Seleccione un tipo de filtro"
-      },
-      "toggle_pebble": "Alternar editor de Pebble",
-      "unnamed": "Sin Nombre",
-      "version_oss_placeholder": "Desbloquea la Versionado de Plugins con la Enterprise Edition"
-    },
-    "no_data": "Parece que no hay nada aquí... ¡todavía!<br/>Ajusta tus filtros o inténtalo de nuevo.",
-    "no_file_choosen": "No se ha elegido archivo",
-    "no_flow_outputs": "No hay outputs disponibles.",
-    "no_history": "No hay historial disponible",
-    "no_inputs": "No hay inputs disponibles.",
-    "no_logs_data": "Sin datos",
-    "no_logs_data_description": "Por favor, intente ajustar sus filtros, cambiar el rango de tiempo o verifique si el flow se ha ejecutado recientemente.",
-    "no_logs_data_title": "No se encontraron logs para los filtros seleccionados.",
-    "no_namespaces": "Ningún namespace coincide con los criterios de búsqueda.",
-    "no_results": {
-      "assets": "No se encontraron activos",
-      "executions": "No se encontraron ejecuciones",
-      "flows": "No se encontraron Flows",
-      "kv_pairs": "No se encontraron pares Key-Value",
-      "secrets": "No se encontraron Secrets",
-      "templates": "No se encontraron plantillas",
-      "triggers": "No se encontraron Triggers"
-    },
-    "no_results_found": "No se encontraron resultados",
-    "no_tasks_running": "Todavía no hay tasks en ejecución.",
-    "no_trigger": "No hay trigger disponible.",
     "no_variables": "No hay variables disponibles.",
-    "now": "Ahora",
-    "of": "de",
-    "ok": "OK",
-    "onboarding": {
-      "actions": {
-        "cancel_tutorial": "Cancelar tutorial",
-        "complete": "Completar",
-        "edit_flow_to_continue": "Pulsa Editar flujo en la barra superior (derecha).",
-        "execute_to_continue": "1. Pulsa Ejecutar en la barra superior (derecha).\n2. Proporciona un valor para <strong>name</strong>.\n3. Pulsa Ejecutar de nuevo en el modal.",
-        "finish_tutorial": "Finalizar tutorial",
-        "next": "Siguiente",
-        "save_to_continue": "Pulsa Guardar en la barra superior (derecha)."
-      },
-      "cancel_modal": {
-        "confirm": "Cancelar tutorial",
-        "description": "¿Quieres cancelar el tutorial de Primer Flujo?",
-        "keep": "Mantener tutorial",
-        "title": "Cancelar el tutorial de Primer Flujo"
-      },
-      "editor_hints": {
-        "build_intro": "Crea tu primer flujo paso a paso.",
-        "step_1": "# 1) Añadir id",
-        "step_2": "# 2) Añadir namespace",
-        "step_3": "# 3) Añadir una entrada",
-        "step_4": "# 4) Añadir tareas y tu primera tarea de Python",
-        "step_5": "# 5) Añadir un trigger cron"
-      },
-      "finish_actions": {
-        "create_flow": "Crear flujo",
-        "explore_blueprints": "Explorar Blueprints"
-      },
-      "steps": {
-        "add_cron_trigger": {
-          "description": "Los triggers pueden iniciar ejecuciones según horarios o eventos externos (por ejemplo, webhooks o mensajes MQTT).<br><br>Ahora añade un trigger de programación cron para que este flujo se ejecute cada 5 minutos.",
-          "title": "Añadir un trigger cron"
-        },
-        "add_id": {
-          "description": "El ID es el nombre único de tu flujo, para que puedas encontrarlo, ejecutarlo y referenciarlo de forma consistente.<br><br>Ahora añade <code>id</code> en el nivel raíz.",
-          "title": "Añadir ID del flujo"
-        },
-        "add_input": {
-          "description": "Las entradas (inputs) son parámetros a nivel de flujo que pueden referenciarse dentro de las tareas para controlar dinámicamente el comportamiento en tiempo de ejecución.<br><br>Ahora añade una entrada llamada <code>name</code> con tipo <code>STRING</code>.",
-          "title": "Añadir una entrada"
-        },
-        "add_input_default": {
-          "description": "Cuando un flujo se activa automáticamente, las entradas aún necesitan valores en tiempo de ejecución.<br><br>La entrada <code>name</code> ya se creó en el paso anterior, así que no es necesario añadirla de nuevo. Solo establece un valor por defecto para la entrada existente <code>name</code>.",
-          "title": "Establecer un valor por defecto para la entrada"
-        },
-        "add_log_task": {
-          "description": "Las tareas (tasks) son las unidades de trabajo que ejecuta tu flujo, definidas como una lista ordenada de pasos. Cada tarea necesita un <code>id</code> único y un <code>type</code>. Kestra ofrece muchos plugins de tareas para sistemas externos; aquí usamos una tarea de script de Python.<br><br>La sintaxis <code>&#123;&#123; ... &#125;&#125;</code> es una expresión Pebble, usada para referenciar variables dinámicamente en tiempo de ejecución, como <code>&#123;&#123; inputs.name &#125;&#125;</code> desde las entradas del flujo.<br><br>Ahora añade la primera tarea bajo <code>tasks</code> con <code>id</code>, <code>type</code> y un <code>script</code> que imprima un saludo.",
-          "title": "Añadir la primera tarea"
-        },
-        "add_namespace": {
-          "description": "El Namespace es una agrupación similar a una carpeta que organiza los flujos por equipo, proyecto o entorno.<br><br>Ahora añade <code>namespace</code> en el nivel raíz.",
-          "title": "Añadir namespace"
-        },
-        "background_runs_info": {
-          "description": "Este flujo ahora se ejecutará en segundo plano cada 5 minutos.<br><br>Puedes navegar a la vista general de Ejecuciones desde el menú de la izquierda para supervisar las ejecuciones programadas.",
-          "title": "Ejecuciones programadas"
-        },
-        "edit_flow_from_execution": {
-          "description": "Puedes saltar directamente desde una ejecución a la definición del flujo para iterar rápidamente.",
-          "title": "Volver al editor de flujos"
-        },
-        "execute_flow": {
-          "description": "Ejecutar inicia una ejecución de tu flujo con valores de entrada en tiempo de ejecución.",
-          "title": "Ejecutar flujo"
-        },
-        "finish": {
-          "description": "Buen comienzo. Creaste, ejecutaste, parametrizaste y programaste un flujo.<br><br>Elige qué hacer a continuación ...",
-          "title": "Has completado el tutorial de Primer Flujo"
-        },
-        "flow_basics": {
-          "description": "En Kestra, un <code>flow</code> es la unidad central de orquestación. Lo defines en YAML con metadatos y tareas ordenadas.<br><br>Revisa la estructura de ejemplo a continuación y luego continúa construyéndola paso a paso.",
-          "title": "Conceptos básicos del flujo"
-        },
-        "save_flow": {
-          "description": "Guardar conserva la definición de tu flujo para que pueda ejecutarse.",
-          "title": "Guardar flujo"
-        },
-        "save_flow_again": {
-          "description": "Tu flujo ahora tiene una programación y un valor por defecto de entrada para ejecuciones automáticas.",
-          "title": "Guardar flujo"
-        },
-        "view_logs_status": {
-          "description": "Los detalles de ejecución muestran el estado, los tiempos y los logs de salida a nivel de tarea.<br><br>Ahora abre los detalles de ejecución y haz clic en <code>greet</code> en el diagrama de Gantt para ver los logs.",
-          "title": "Comprobar la ejecución"
-        }
-      },
-      "validation": {
-        "add_cron_trigger_cron": "Añade una expresión cron, por ejemplo: `\"*/5 * * * *\"`.",
-        "add_cron_trigger_section": "Crea una sección `triggers` con un trigger de programación.",
-        "add_cron_trigger_type": "Establece el tipo de trigger en `io.kestra.plugin.core.trigger.Schedule`.",
-        "add_id": "Añade un ID de flujo en la parte superior. Ejemplo: `id: hello_flow`.",
-        "add_input_default_defaults": "Añade un valor por defecto para `name`, por ejemplo: `defaults: \"Kestra\"`.",
-        "add_input_default_id": "Mantén el ID de la entrada existente como `name`.",
-        "add_input_default_section": "Vuelve a `inputs` y conserva una entrada existente llamada `name` (no añadas una segunda entrada).",
-        "add_input_id": "Dentro de `inputs`, añade `id: name`.",
-        "add_input_section": "Crea una sección `inputs` con una entrada.",
-        "add_input_type": "Establece el tipo de entrada en `STRING`.",
-        "add_log_task_id": "Dale un ID a la tarea, por ejemplo: `id: greet`.",
-        "add_log_task_message": "Añade un campo `script` a la tarea.",
-        "add_log_task_pebble": "Usa una expresión Pebble en el script para que use tu valor de entrada (por ejemplo: `inputs.name`).",
-        "add_log_task_section": "Crea una sección `tasks` y añade tu primera tarea.",
-        "add_log_task_type": "Establece el tipo de tarea en `io.kestra.plugin.scripts.python.Script`.",
-        "add_namespace": "Añade un namespace en la parte superior. Ejemplo: `namespace: company.team`.",
-        "complete_step": "Ya casi está. Completa este paso para continuar.",
-        "edit_flow_from_execution": "Haz clic en `Editar flujo` en la barra superior para continuar.",
-        "execute_flow": "Ejecuta el flujo una vez para continuar.",
-        "fix_yaml": "Hay un pequeño problema de formato YAML. Arréglalo y luego continúa.",
-        "save_flow": "Haz clic en Guardar para continuar.",
-        "save_flow_again": "Haz clic en Guardar de nuevo para continuar.",
-        "view_logs_status": "Abre los detalles de ejecución y revisa los logs de `greet`."
-      },
-      "welcome": {
-        "additional_help": "Ayuda adicional",
-        "badge": "Tutorial",
-        "blueprints": "Blueprints",
-        "docs": "Documentación",
-        "guided_description": "Aprende a crear y ejecutar tu primer flujo con pasos guiados.",
-        "guided_duration": "Recomendado para la mayoría",
-        "guided_title": "Crea tu primer flujo",
-        "headline": "Crea y ejecuta tu primer flujo de trabajo en minutos",
-        "self_serve_description": "Ve directamente al editor y crea tu propio flujo.",
-        "self_serve_note": "Para usuarios avanzados",
-        "self_serve_title": "Crear flujo desde cero",
-        "slack": "Comunidad de Slack",
-        "tutorial": "Tutorial"
-      }
+    "download": "Descargar",
+    "jsonl": "JSONL",
+    "concurrency_limit": {
+      "dialog_title": "Límites de Concurrencia",
+      "warning": "Cambiar el contador en ejecución puede corromper la concurrencia, por lo que las ejecuciones pueden exceder el límite permitido."
     },
-    "open": "Abrir",
-    "open full page": "Abrir página completa",
-    "open in new tab": "En una nueva pestaña",
-    "open in same tab": "En la misma pestaña",
-    "open sidebar": "abrir barra lateral",
-    "open source": "Código Abierto",
-    "open_page": "Open page",
-    "optional": "Opcional",
-    "original execution": "Ejecución original",
-    "originalCreatedDate": "Fecha de creación original",
-    "outdated revision save confirmation": {
-      "confirm": "¿Quieres sobrescribirlo?",
-      "create": {
-        "description": "Un flow con el mismo id ya existe en este namespace.",
-        "details": "Guardar para sobrescribir y crear una nueva revisión.",
-        "title": "El flujo ya existe"
-      },
-      "update": {
-        "description": "La revisión que estás editando está desactualizada.",
-        "details": "Revisa la pestaña de Revisiones para más detalles sobre la última versión.",
-        "title": "Revisión desactualizada"
-      }
+    "documentation": {
+      "documentation": "Documentación",
+      "github": "Abrir un issue en GitHub"
     },
-    "output": "Salida",
-    "outputs": "Salidas",
-    "override": {
-      "details": "El flow anterior se puede restaurar desde la pestaña de Revisions.",
-      "title": "Vas a sobrescribir el flujo actual"
-    },
-    "overview": "Resumen",
-    "page": {
-      "next": "Página siguiente",
-      "previous": "Página anterior"
-    },
-    "panel actions": "Acciones del panel",
-    "parent execution": "Ejecución padre",
-    "password": "Contraseña",
-    "password empty constraint": "Nombre de usuario o contraseña incorrectos",
-    "password length constraint": "La contraseña no debe exceder los 256 caracteres",
-    "passwords do not match": "Las contraseñas no coinciden",
-    "pause": "Pausar",
-    "pause backfill": "Pausar el backfill",
-    "pause backfills": "Pausar backfills",
-    "pause confirm": "¿Está seguro de pausar la ejecución <code>{id}</code>?",
-    "pause done": "La ejecución está PAUSED",
-    "pause title": "Pausar la ejecución <code>{id}</code>.<br/>Tenga en cuenta que las tasks que se están ejecutando actualmente seguirán siendo procesadas, y la ejecución tendrá que reanudarse manualmente.",
-    "paused": "Pausado",
-    "playground": {
-      "clear_history": "Borrar historial",
-      "confirm_create": "No puedes ejecutar el playground mientras creas un flow. Iniciar una ejecución de playground creará el flow.",
-      "history": "Últimas 10 ejecuciones",
-      "play_icon_info": "También puedes presionar el ícono de Play en las vistas No-Code o Topology.",
-      "run_all_tasks": "Ejecutar Todas las Tasks",
-      "run_task": "Ejecutar Task",
-      "run_task_and_downstream": "Ejecutar task y downstream",
-      "run_task_info": "Pasa el cursor sobre cualquier task en el editor de Flow Code y haz clic en el botón \"Run task\" para probar tu task.",
-      "run_this_task": "Ejecutar esta task",
-      "title": "Área de Pruebas",
-      "toggle": "Área de pruebas",
-      "tooltip_persistence": "Si desactivas y vuelves a activar el Playground, la información permanece mientras te mantengas en la página."
-    },
-    "playground actions": "Acciones del Playground",
-    "plugin defaults exported": "Valores predeterminados del plugin exportados",
-    "plugin defaults imported": "Valores predeterminados del plugin importados",
-    "plugin defaults not imported": "Algunos valores predeterminados del plugin no se pudieron importar",
-    "pluginDefaults": {
-      "add": "Agregar Plugin Predeterminado",
-      "add_subtitle": "Configurar un nuevo plugin predeterminado con sus propiedades",
-      "cancel": "Cancelar",
-      "custom": "Plugin Personalizado",
-      "custom_configure": "Tipo de plugin personalizado - configurar usando YAML",
-      "custom_placeholder": "Ingrese el tipo de plugin",
-      "custom_type": "Tipo de plugin personalizado",
-      "edit": "Editar Plugin Default",
-      "edit_subtitle": "Modificar la configuración predeterminada del plugin existente",
-      "form": "Formulario",
-      "predefined": "Plugin Predefinido",
-      "select_predefined": "Seleccionar Plugin Predefinido",
-      "show_yaml": "Mostrar YAML",
-      "title": "Valores Predeterminados del Plugin",
-      "update": "Actualizar Plugin Default",
-      "use_custom": "Usar Personalizado",
-      "yaml": "YAML",
-      "yaml_configuration": "Configuración YAML"
-    },
-    "pluginPage": {
-      "elementType": {
-        "apps": "Aplicación",
-        "charts": "Gráfico",
-        "conditions": "Condición",
-        "logExporters": "Exportador de logs",
-        "secrets": "Secreto",
-        "taskRunners": "Ejecutor de task",
-        "tasks": "Tarea",
-        "triggers": "Trigger"
-      },
-      "group": {
-        "blueprints": "Planos ({count})",
-        "plugins": "Plugins ({count})",
-        "tasks": "Tareas ({count})"
-      },
+    "blueprints": {
+      "all": "Todo",
+      "community": "Comunidad",
+      "create": "Crear un blueprint",
+      "edit": "Editar un blueprint",
+      "title": "Blueprints",
+      "empty": "No hay blueprints para mostrar.",
       "header": {
-        "back": "Volver a plugins",
-        "certified": "Certificado",
-        "enterpriseEdition": "Edición Enterprise"
+        "catch phrase": {
+          "1": "El primer paso siempre es el más difícil.",
+          "2": "Explora blueprints para iniciar tu próximo {kind}."
+        },
+        "alt": "Icono de Blueprints"
       },
-      "loadError": "No se pudieron cargar los plugins. Por favor, inténtelo de nuevo.",
-      "noResults": "No hay plugins que coincidan con tu búsqueda.",
-      "notFound": "Este plugin no pudo ser encontrado.",
-      "overview": {
-        "createdBy": "Creado por",
-        "latest": "Último",
-        "linksResources": "Enlaces y Recursos",
-        "managedBy": "Gestionado por",
-        "minKestraVersion": "Vers. mínima compatible de Kestra: {version}",
-        "minKestraVersionShort": "Versión mínima de Kestra {version}",
-        "pluginType": "Tipo de plugin",
-        "previousVersions": "Versiones anteriores",
-        "releaseNotes": "Notas de la versión",
-        "title": "Visión general",
-        "versions": "Versiones"
+      "custom": "Planos personalizados",
+      "flows": "Planos de Flow",
+      "apps": "Planos de la Aplicación",
+      "dashboards": "Planos del Dashboard",
+      "detail": {
+        "category": "Tipo de categoría",
+        "links": "Enlace y Recursos",
+        "openInEditor": "Abrir en Edit Flow"
       },
-      "search": "Buscar en más de {count} plugins",
-      "searchTasks": "Buscar {count} tasks",
-      "sort": {
-        "mostUsed": "Más usados",
-        "nameAsc": "Nombre A-Z",
-        "nameDesc": "Nombre Z-A",
-        "newest": "Más reciente"
-      },
-      "sortBy": "Ordenar por"
+      "missingPlugins": {
+        "title": "Plugins faltantes",
+        "description": "Este blueprint usa tasks de plugin(s) que no están instalados en esta instancia: {plugins}. Instálalos para usar este blueprint.",
+        "card": "Requiere plugin(s) no instalados en esta instancia: {plugins}",
+        "install": "Instalar plugins"
+      }
     },
-    "plugin_default_already_exists": "El plugin predeterminado para <code>{type}</code> ya existe.",
+    "use": "Usar",
     "plugins": {
       "name": "Plugin",
       "names": "Plugins",
       "please": "Por favor elige una tarea a la derecha para ver su documentación",
       "release": "Notas de la versión"
     },
-    "port": "Puerto",
-    "prefill inputs": "Prefill",
-    "pretty_json": "Pretty JSON",
-    "prev_execution": "Ejecución anterior",
-    "preview": {
-      "auto-view": "Vista automática",
-      "collapse": "Contraer",
-      "expand": "Desplegar",
-      "force-editor": "Forzar vista del editor",
-      "label": "Vista previa",
-      "next": "Siguiente",
-      "page_of": "Página {current} de {total}",
-      "pagination_info": "Mostrando filas {start}-{end} de {total}.",
-      "previous": "Anterior",
-      "rows_truncated": "Mostrando {shown} de {total} filas. Descargue el archivo para ver todos los datos.",
-      "showing_rows": "Mostrando filas {start}-{end} de {total}",
-      "view": "Ver"
+    "last execution date": "Fecha de última ejecución",
+    "last execution state": "Último estado",
+    "last X days count": "{count} en los últimos {days} días",
+    "date range count": "{count} entre el {startDate} y el {endDate}",
+    "date count": "{count} en el {date}",
+    "revisions": "Revisiones",
+    "no revisions found": "Solo existe una revisión para este flujo",
+    "no revisions": "Sin revisiones",
+    "see full revision": "Ver revisión completa",
+    "side-by-side": "lado a lado",
+    "line-by-line": "línea por línea",
+    "template": "Plantilla",
+    "template creation": "Creación de plantilla",
+    "templates": "Plantillas",
+    "templates deprecated": "Las plantillas están obsoletas. Por favor usa subflows en su lugar. Consulta la <a href=\"https://kestra.io/docs/migration-guide/0.11.0/templates?utm_source=app&utm_medium=referral&utm_campaign=template-inlinedoc\" target=\"_blank\">sección de Migraciones</a> que explica cómo puedes migrar de plantillas a subflows.",
+    "no result": "No hay resultados para mostrar.",
+    "empty search": "Resultados de búsqueda vacíos",
+    "trigger": "Trigger",
+    "no_trigger": "No hay trigger disponible.",
+    "triggers": "Triggers",
+    "triggers_header_description": "Navega, añade y gestiona triggers para automatizar tus flows. Elige entre exponer tu flow como una herramienta de IA, programar, añadir un webhook trigger, sondear cambios en aplicaciones externas o escuchar eventos en tiempo real.",
+    "triggers_tabs_add": "Agregar",
+    "triggers_tabs_manage": "Administrar",
+    "triggers_add_search_placeholder": "Buscar triggers...",
+    "triggers_add_filter_core": "Núcleo",
+    "triggers_add_filter_realtime": "Tiempo real",
+    "triggers_add_filter_all": "Todo",
+    "triggers_add_filter_app": "Aplicación",
+    "triggers_add_empty_title": "No se encontraron triggers",
+    "triggers_add_ee_tooltip": "Este trigger requiere la Enterprise Edition.",
+    "triggers_add_category_empty": "No hay triggers en esta categoría.",
+    "triggers_add_card_add_to_flow": "Agregar al flow",
+    "triggers_add_card_add": "Agregar",
+    "triggers_add_modal_title": "{name}",
+    "triggers_add_modal_tab_form": "Formulario",
+    "triggers_add_modal_tab_source": "Origen",
+    "triggers_add_modal_tab_documentation": "Documentación",
+    "triggers_add_modal_namespace_placeholder": "Seleccione un namespace",
+    "triggers_add_modal_flow_placeholder": "Seleccione un flow",
+    "triggers_add_modal_trigger_id": "ID de Trigger",
+    "triggers_add_modal_trigger_id_placeholder": "Identificador único para este trigger",
+    "triggers_add_modal_properties_hint": "Configura las propiedades del trigger en el editor de flow después de añadir el trigger.",
+    "triggers_add_modal_ee_notice": "Este trigger requiere Enterprise Edition.",
+    "triggers_add_modal_add_button": "Agregar Trigger al Flow",
+    "trigger details": "Detalles del trigger",
+    "triggerflow disabled": "El trigger está deshabilitado en la definición del flujo",
+    "last trigger date": "Fecha de último trigger",
+    "trigger_states": "Estados",
+    "context updated date": "Fecha de actualización del contexto",
+    "state updated date": "Fecha de actualización del estado",
+    "next evaluation date": "Próxima fecha de evaluación",
+    "last evaluation date": "Última fecha de evaluación",
+    "last trigger date tooltip": "Cuando el trigger se ejecutó por última vez. Puede estar en el pasado al ejecutar un backfill.",
+    "context updated date tooltip": "Cuando se actualizó por última vez el contexto del trigger. Esto ocurre cuando se inicia la ejecución, finaliza (se libera el bloqueo) o después de una evaluación (incluso si no ocurre ninguna ejecución).",
+    "next evaluation date tooltip": "Cuando el trigger se evaluará la próxima vez, basado en su intervalo. No siempre es lo mismo que la próxima fecha de ejecución si no se cumplen las condiciones.",
+    "last evaluation date tooltip": "When the trigger was last evaluated by the scheduler, regardless of whether it produced an execution.",
+    "conditions": "Condiciones",
+    "triggerId": "ID del Trigger",
+    "tenantId": "ID de Mandante",
+    "codeDisabled": "Desactivado en Flow",
+    "paused": "Pausado",
+    "running": "RUNNING",
+    "Fold auto": "Editor: plegado automático de multilíneas",
+    "Hover description": "Editor: Mostrar descripción del campo al pasar el cursor sobre key o value",
+    "Fold content lines": "Plegar cadenas multilínea",
+    "Unfold content lines": "Desplegar cadenas multilínea",
+    "Total": "Total",
+    "sub flow": "Subflow",
+    "execute": "Ejecutar",
+    "execute flow behaviour": "Ejecutar el flujo",
+    "open in same tab": "En la misma pestaña",
+    "open in new tab": "En una nueva pestaña",
+    "execute the flow": "Ejecutar el flujo <code>{id}</code>",
+    "execute flow now ?": "¿Quieres ejecutar este flujo?",
+    "discard execution confirmation": "Tienes entradas no guardadas. ¿Estás seguro de que deseas descartar esta ejecución?",
+    "discard changes confirmation": "Tienes cambios no guardados. ¿Estás seguro de que deseas descartarlos?",
+    "Default namespace": "Namespace predeterminado",
+    "Default log level": "Nivel de log predeterminado",
+    "unsaved changed ?": "Tienes cambios no guardados, ¿quieres salir de esta página?",
+    "unsaved changes": "Cambios no guardados",
+    "unsaved changes warning": "Tienes cambios no guardados. Si abandonas esta página, tus cambios se perderán.",
+    "leave page": "Salir de la página",
+    "open full page": "Abrir página completa",
+    "drill down preview": "Vista previa",
+    "Editor theme": "Tema del editor",
+    "Editor fontsize": "Tamaño de fuente del editor",
+    "Editor fontfamily": "Familia de fuentes del editor",
+    "errors": {
+      "401": {
+        "title": "No autorizado",
+        "content": "Necesitas estar autenticado para acceder a esta página."
+      },
+      "403": {
+        "title": "Acceso denegado",
+        "content": "No tienes los permisos necesarios para acceder a esta página."
+      },
+      "404": {
+        "title": "Página no encontrada",
+        "content": "La URL solicitada no fue encontrada en este servidor.<br />Eso es todo lo que sabemos.",
+        "flow or execution": "El flujo o la ejecución que estás buscando no existe."
+      }
     },
-    "pricing": "Precios",
-    "product_tour": "Recorrido del Producto",
-    "properties": {
-      "hidden": "Oculto en la Tabla",
-      "hint": "Elegir Columnas Visibles",
-      "label": "Propiedades",
-      "shown": "Mostrado en Tabla"
+    "back_to_dashboard": "Volver al panel de control",
+    "copy all logs": "Copiar todos los Logs",
+    "copy logs": "Copiar logs",
+    "fix_with_ai": "Solucionar con IA",
+    "download logs": "Descargar logs",
+    "delete logs": "Eliminar logs",
+    "delete_all_logs": "¿Estás seguro de que quieres eliminar todos los logs?",
+    "delete_log": "¿Está seguro de que desea eliminar el log?",
+    "toggle fullscreen": "Alternar pantalla completa",
+    "copied": "Copiado",
+    "tags": "Etiquetas",
+    "disabled flow title": "Este flujo está deshabilitado",
+    "disabled flow desc": "Este flujo está deshabilitado, por favor habilítalo para poder ejecutarlo.",
+    "label": "Label",
+    "labels": "Etiquetas",
+    "label filter placeholder": "Etiqueta como 'key:value'",
+    "execution labels": "Etiquetas de ejecución",
+    "wrong labels": "No se permite una key o value vacía en las etiquetas",
+    "feeds": {
+      "title": "Novedades en Kestra",
+      "heading": "Todo sobre Kestra.",
+      "subheading": "Las últimas actualizaciones, guías e historias"
     },
-    "queued duration": "Duración en cola",
-    "quotas": "Cuotas",
-    "reach us": "Habla con nosotros",
-    "read-more": "Leer más sobre",
-    "readonly property": "Propiedad de solo lectura",
-    "recent_executions": "Ejecuciones Recientes",
-    "refresh": "Actualizar",
-    "reject": "Rechazar",
-    "relative": "Relativo",
-    "relative end date": "Fecha de fin relativa",
-    "relative start date": "Fecha de inicio relativa",
-    "remove label": "Eliminar label",
-    "remove this item": "Eliminar este elemento",
-    "remove_bookmark": "¿Está seguro de que desea eliminar este marcador?",
-    "replay": "Repetir",
-    "replay confirm": "¿Estás seguro de repetir esta ejecución <code>{id}</code> y crear una nueva?",
-    "replay execution description": "Esto creará una nueva ejecución basada en la ejecución seleccionada.",
-    "replay execution title": "Repetir ejecución",
-    "replay from beginning tooltip": "Crear una ejecución similar comenzando desde el principio",
-    "replay from task tooltip": "Crear una ejecución similar comenzando desde la tarea <code>{taskId}</code>",
-    "replay inputs": "Entradas",
-    "replay inputs new required": "Esta revisión tiene inputs. Se le pedirá que los complete.",
-    "replay latest revision": "Repetir usando la última revisión",
-    "replay select taskrun": "Seleccione la ejecución de task para reproducir desde:",
-    "replay the execution": "Repetir la ejecución <code>{executionId}</code> para el flow <code>{flowId}</code>",
-    "replay using": "Repetir usando",
-    "replay with inputs": "Repetir con inputs",
-    "replayed": "La ejecución se ha reproducido",
-    "required field": "Campo requerido",
-    "reset": "Reiniciar",
-    "reset to defaults": "Restablecer a los valores predeterminados",
-    "restart": "Reiniciar",
-    "restart change revision": "Puedes cambiar la revisión que se usará para la nueva ejecución.",
-    "restart confirm": "¿Estás seguro de reiniciar la ejecución <code>{id}</code>?",
-    "restart execution title": "Reiniciar ejecución",
-    "restart latest revision": "Reiniciar última revisión",
-    "restart tooltip": "Reiniciar la ejecución desde la tarea <code>{state}</code>",
-    "restart trigger": {
-      "button": "Reiniciar trigger",
-      "tooltip": "Reiniciar el trigger"
-    },
-    "restarted": "La ejecución se reinicia",
+    "delete execution running": "<div class=\"alert alert-warning mt-2 mb-0\">Esta ejecución aún está RUNNING, eliminarla no la detendrá.<br />Necesitas matar la ejecución para detenerla.</div>",
     "restore": "Restaurar",
     "restore confirm": "¿Estás seguro de restaurar la revisión <code>{revision}</code>?",
+    "bulk delete": "¿Estás seguro de que quieres eliminar <code>{executionCount}</code> ejecución(es)?",
+    "bulk replay": "¿Estás seguro de que quieres reproducir <code>{executionCount}</code> ejecución(es)?",
+    "bulk change state": "¿Está seguro de que desea cambiar el estado de <code>{executionCount}</code> ejecución(es)?",
+    "bulk resume": "¿Estás seguro de que quieres reanudar <code>{executionCount}</code> ejecución(es)?",
+    "bulk pause": "¿Está seguro de que desea pausar la(s) ejecución(es) <code>{executionCount}</code>?",
+    "bulk unqueue": "¿Está seguro de que desea descolar <code>{executionCount}</code> ejecución(es)?",
+    "bulk force run": "¿Está seguro de que desea forzar la ejecución de <code>{executionCount}</code> ejecución(es)?<br/><br/>ADVERTENCIA: forzar la ejecución de una ejecución no está garantizado y puede crear ejecuciones de tareas duplicadas.<br/><br/>Las siguientes transiciones se realizarán:<br/><ul><li>Las tareas en estado CREATED se moverán al estado RUNNING.</li><li>Las tareas en estado RUNNING se volverán a enviar.</li><li>Las tareas en estado QUEUED se des-encolarán.</li><li>Las tareas en estado PAUSED se reanudarán.</li></ul>",
+    "bulk restart": "¿Estás seguro de que quieres reiniciar <code>{executionCount}</code> ejecución(es)?",
+    "bulk kill": "¿Estás seguro de que quieres matar <code>{executionCount}</code> ejecución(es)?",
+    "selection": {
+      "selected": "<strong>{count}</strong> seleccionados",
+      "all": "Seleccionar todo ({count})"
+    },
+    "cancel": "Cancelar",
+    "errorLogs": "Registros de errores",
+    "welcome_page": {
+      "welcome": "Bienvenido a Kestra",
+      "guide": "¿Necesitas orientación para ejecutar tu primer flow?"
+    },
+    "product_tour": "Recorrido del Producto",
+    "executions replayed": "<code>{executionCount}</code> ejecución(es) reproducidas",
+    "executions state changed": "El estado de <code>{executionCount}</code> ejecución(es) ha sido cambiado",
+    "executions resumed": "<code>{executionCount}</code> ejecución(es) reanudadas",
+    "executions paused": "<code>{executionCount}</code> ejecución(es) PAUSED",
+    "executions unqueue": "<code>{executionCount}</code> ejecución(es) en cola",
+    "executions force run": "<code>{executionCount}</code> ejecución(es) forzada(s) en ejecución",
+    "executions restarted": "<code>{executionCount}</code> ejecución(es) reiniciadas",
+    "executions killed": "<code>{executionCount}</code> ejecución(es) matadas",
+    "executions deleted": "<code>{executionCount}</code> ejecución(es) eliminadas",
+    "invalid bulk replay": "No se pudieron reproducir las ejecuciones",
+    "invalid bulk resume": "No se pudieron reanudar las ejecuciones",
+    "invalid bulk pause": "No se pudo pausar las ejecuciones",
+    "invalid bulk unqueue": "No se pudieron desencolar ejecuciones",
+    "invalid bulk force run": "No se pudo forzar la ejecución de ejecuciones",
+    "invalid bulk restart": "No se pudieron reiniciar las ejecuciones",
+    "invalid bulk kill": "No se pudieron matar las ejecuciones",
+    "invalid bulk delete": "No se pudieron eliminar las ejecuciones",
+    "execution not found": "La ejecución {executionId} no se encuentra.",
+    "execution not in state PAUSED": "Ejecución <code>{executionId}</code> no está en estado PAUSED",
+    "execution not in state FAILED": "Ejecución <code>{executionId}</code> no está en estado FAILED",
+    "execution already finished": "Ejecución <code>{executionId}</code> ya finalizada",
     "restore revision": "¿Estás seguro de que quieres restaurar la revisión <code>{revision}</code>?",
-    "resume": "Reanudar",
-    "resume from breakpoint done": "Ejecución reanudada desde el punto de interrupción",
-    "resume from breakpoint title": "Reanudar ejecución `<code>{id}</code>` desde el punto de interrupción",
-    "resumed confirm": "¿Estás seguro de reanudar la ejecución <code>{id}</code>?",
-    "resumed done": "La ejecución se ha reanudado",
-    "resumed title": "Reanudar ejecución <code>{id}</code>",
-    "reuse original inputs": "Reutilizar inputs originales",
-    "reuse_original_inputs": "Reutilizar inputs originales",
-    "review your inputs": "Revise sus entradas",
-    "revision": "Revisión",
-    "revision deleted": "La revisión {revision} ha sido eliminada con éxito",
-    "revisions": "Revisiones",
-    "row count": "Recuento de filas",
-    "run task in playground": "Ejecutar task en el playground",
+    "seeing old revision": "Estás viendo una revisión antigua: {revision}",
+    "export": "Exportar",
+    "exports": "Exportaciones",
+    "export_csv": "Exportar como CSV",
+    "template export": "¿Estás seguro de que quieres exportar <code>{templateCount}</code> plantilla(s)?",
+    "templates exported": "Plantillas exportadas",
+    "export all templates": "Exportar todas las plantillas",
+    "flow_export": "Exportar flow",
+    "flow export": "¿Estás seguro de que quieres exportar <code>{flowCount}</code> flow(s)?",
+    "flows exported": "<code>{count}</code> Flow(s) exportado(s)",
+    "export all flows": "Exportar todos los flows",
+    "import": "Importar",
+    "disable": "Deshabilitar",
+    "enable": "Habilitar",
+    "enabled": "Habilitado",
+    "template delete": "¿Estás seguro de que quieres eliminar <code>{templateCount}</code> plantilla(s)?",
+    "flow delete": "¿Estás seguro de que quieres eliminar <code>{flowCount}</code> flow(s)?",
+    "templates deleted": "<code>{count}</code> Plantilla(s) eliminadas",
+    "flows deleted": "<code>{count}</code> Flow(s) eliminados",
+    "flow disable": "¿Estás seguro de que quieres deshabilitar <code>{flowCount}</code> flow(s)?",
+    "flow enable": "¿Estás seguro de que quieres habilitar <code>{flowCount}</code> flow(s)?",
+    "flows disabled": "<code>{count}</code> Flow(s) deshabilitados",
+    "flows enabled": "<code>{count}</code> Flow(s) habilitados",
+    "flow-no-dependencies": "Tu flow no tiene dependencias.",
+    "flow-dependencies": "dependencias",
+    "read-more": "Leer más sobre",
+    "in-our-documentation": "en nuestra documentación.",
+    "dependencies": "Dependencias",
+    "see dependencies": "Ver dependencias",
+    "see timeline": "Ver línea de tiempo",
     "run timeline": "Cronograma de Ejecución",
-    "runners": "Corredores",
-    "running": "RUNNING",
-    "running duration": "Duración en ejecución",
-    "save": "Guardar",
+    "dependencies missing acls": "Sin permisos en este flow",
+    "dependencies delete flow": "Este flow tiene dependencias. Eliminarlo impedirá que se ejecuten sus dependencias.<br /><br /> Aquí está la lista de flows afectados:",
+    "expand dependencies": "Expandir dependencias",
+    "reset": "Reiniciar",
+    "show task documentation": "Mostrar documentación de la task",
+    "hide task documentation": "Ocultar documentación de la task",
+    "show task documentation in editor": "Mostrar documentación de la task en el editor",
+    "show documentation": "Mostrar documentación",
+    "focus task": "Haz clic en cualquier elemento para ver su documentación.",
+    "validate": "Validar",
+    "add error handler": "Añadir un manejador de errores",
+    "taskDefaults": "Predeterminados de la task",
+    "disabled": "Deshabilitado",
+    "before": "antes",
+    "after": "después",
+    "add at position": "Añadir {position} <code>{task}</code>",
+    "create first task": "Crea tu primera task",
+    "dynamic": "Dinámico",
+    "choice": "Opción",
+    "sequential": "Secuencial",
+    "can not delete": "No se puede eliminar",
+    "can not have less than 1 task": "Cada flow debe tener al menos una task.",
+    "task id already exists": "Task Id ya existe",
+    "Task Id already exist in the flow": "Task Id {taskId} ya existe en el flow.",
+    "task id": "Task ID",
+    "taskid column details": "Última task siendo ejecutada y su número de intentos.",
+    "flow already exists": "Flow ya existe",
+    "flow already exists message": "El flow <code>{id}</code> ya existe en el namespace <code>{namespace}</code>. ¿Desea crear una nueva revisión?",
+    "plugin_default_already_exists": "El plugin predeterminado para <code>{type}</code> ya existe.",
+    "namespace not allowed": "Namespace no permitido",
+    "switch-view": "Cambiar vista",
+    "source and topology": "Fuente y topología",
+    "source and doc": "Fuente y documentación",
+    "source and blueprints": "Fuente y blueprints",
+    "editor": "Editor",
+    "error in editor": "Se ha encontrado un error en el editor",
+    "delete task confirm": "¿Quieres eliminar la task <code>{taskId}</code>?",
+    "can not save": "No se puede guardar",
+    "flow must not be empty": "El flow no debe estar vacío",
+    "flow must have id and namespace": "El flow debe tener un id y un namespace.",
+    "flow creation denied in namespace": "No tienes permiso para crear flows en el namespace `{namespace}`.",
+    "readonly property": "Propiedad de solo lectura",
+    "namespace and id readonly": "Las propiedades `namespace` y `id` no se pueden cambiar — ahora están configuradas a sus valores iniciales. Si deseas renombrar un flow o cambiar su namespace, puedes crear un nuevo flow y eliminar el antiguo.",
+    "avg": "Promedio",
+    "sum": "Suma",
+    "min": "Min",
+    "max": "Max",
+    "bar": "Bar",
+    "line": "Línea",
+    "metric": "Métrica",
+    "aggregation": "Agregación",
+    "chart type": "Tipo de gráfico",
+    "metric choice": "No hay métricas disponibles para este flow",
+    "of": "de",
+    "see_all_states": "Ver todos los estados",
     "save draft": {
       "message": "Borrador guardado",
       "retrieval": {
@@ -1680,164 +724,336 @@
         "existing": "Un borrador del Flow <code>{flowFullName}</code> fue guardado, ¿quieres continuar editando el flow?"
       }
     },
-    "save task": "Guardar tarea",
-    "save_and_execute": "Guardar y Ejecutar",
-    "save_as_draft": "Guardar como borrador",
-    "saved": "Guardado exitosamente",
-    "saved as draft": "Guardado como borrador correctamente",
-    "saved as draft done": "<em>{name}</em> se ha guardado correctamente como borrador",
-    "saved done": "<em>{name}</em> se ha guardado exitosamente",
-    "scheduleDate": "Fecha de programación",
-    "scope_filter": {
-      "all": "Todos los {label}",
-      "system": "Sistema {label}",
-      "system_description": "Mantenimiento del sistema {label}",
-      "user": "Usuario {label}",
-      "user_description": "Usuario regular inició {label}"
+    "title": "Título",
+    "api": "API",
+    "more_actions": "Más acciones",
+    "expand error": "Expandir solo tasks fallidas",
+    "expand all": "Expandir todo",
+    "collapse all": "Colapsar todo",
+    "expand": "Expandir",
+    "collapse": "Colapsar",
+    "filter by this value": "Filter by this value",
+    "filter_for": "Filter for",
+    "filter_out": "Filter out",
+    "copy_value": "Copy value",
+    "open_page": "Open page",
+    "logs_copied": "Logs copied to your clipboard",
+    "expand_by_default": "Expand structured logs by default",
+    "show raw": "Show raw",
+    "similar lines": "similar lines",
+    "download_logs_description": "Choose which logs to export. Filters default to your current view.",
+    "display_settings": "Display settings",
+    "density": "Density",
+    "density_compact": "Compact",
+    "density_normal": "Normal",
+    "density_expanded": "Expanded",
+    "pretty_json": "Pretty JSON",
+    "body_line_clamp": "Limit line height",
+    "font size": "Font size",
+    "log expand setting": "Visualización predeterminada del Log",
+    "environment": "Entorno",
+    "environment name setting": "Nombre del entorno",
+    "environment color setting": "Color del entorno",
+    "slack support": "Haz cualquier pregunta vía Slack",
+    "join community": "Únete a la Comunidad",
+    "join_slack": "Unirse a Slack",
+    "kestra": "Kestra",
+    "reach us": "Habla con nosotros",
+    "new version": "¡Nueva versión {version} disponible!",
+    "error detected": "Se detectaron errores.",
+    "warning detected": "Advertencia(s) detectada(s)",
+    "informative notice": "Nota(s)",
+    "cannot swap tasks": "No se pueden intercambiar las tasks",
+    "open": "Abrir",
+    "dependency task": "Task {taskId} es una dependencia de otra task",
+    "administration": "Administración",
+    "admin": "Administrador",
+    "main_configuration": "Configuración Principal",
+    "commit_id": "ID de commit",
+    "evaluation lock date": "Fecha de bloqueo de evaluación",
+    "unlock trigger": {
+      "tooltip": {
+        "execution": "Hay una ejecución en curso para este trigger",
+        "evaluation": "El trigger está actualmente en evaluación"
+      },
+      "confirmation": "¿Estás seguro de que quieres desbloquear el trigger?",
+      "warning": "Podría llevar a ejecuciones concurrentes para el mismo trigger y debe considerarse como una opción de último recurso.",
+      "button": "Desbloquear trigger",
+      "success": "Trigger desbloqueado"
     },
-    "search": "Buscar",
-    "search blueprint": "Buscar blueprints",
-    "search filters": {
-      "filter name": "Nombre del filtro",
-      "filters": "Filtros",
-      "manage": "Administrar filtros de búsqueda",
-      "manage desc": "Administrar filtros de búsqueda guardados",
-      "save filter": "Guardar filtro",
-      "saved": "Filtros guardados"
+    "restart trigger": {
+      "button": "Reiniciar trigger",
+      "tooltip": "Reiniciar el trigger"
     },
-    "search term in message": "Término de búsqueda en mensaje",
-    "search_docs": "Buscar",
-    "searching": "Buscando...",
-    "secret": {
-      "add": "Crear",
-      "inherited": "Secrets heredados",
-      "isReadOnly": "El secreto es de solo lectura",
-      "names": "Secrets",
-      "update": "Actualizar secreto '{name}'"
-    },
-    "security_advice": {
-      "content": "Habilita la autenticación básica para proteger tu instancia.",
-      "enable": "Habilitar autenticación",
-      "switch_text": "No mostrar de nuevo",
-      "title": "Protege tu instancia"
-    },
-    "see dependencies": "Ver dependencias",
-    "see full revision": "Ver revisión completa",
-    "see timeline": "Ver línea de tiempo",
-    "see_all_states": "Ver todos los estados",
-    "seeing old revision": "Estás viendo una revisión antigua: {revision}",
-    "select": "Seleccione su {{section}}",
-    "select a state": "Seleccionar un estado",
-    "select datetime": "Seleccionar una fecha",
-    "select view": "Seleccionar vista",
-    "selected": "Seleccionado",
-    "selection": {
-      "all": "Seleccionar todo ({count})",
-      "selected": "<strong>{count}</strong> seleccionados"
-    },
-    "sequential": "Secuencial",
-    "server type": "Tipo de servidor",
+    "trigger disabled": "El trigger está deshabilitado dentro del Flow source",
+    "flow source not found": "Fuente de flow no encontrada",
+    "date format": "Formato de fecha",
+    "timezone": "Zona horaria",
+    "add task": "Añadir una task",
+    "unable to generate graph": "Ocurrió un problema al generar el gráfico que impide que se muestre la topología.",
+    "attempts": "Intento(s)",
+    "flow deleted, you can restore it": "El flow ha sido eliminado y esta es una vista de solo lectura. Aún puedes restaurarlo.",
+    "workers": "Workers",
+    "worker group": "Grupo de Workers",
+    "worker group key": "Clave del grupo de Worker",
+    "worker group fallback": "Grupo de Worker de respaldo",
+    "version": "Versión",
     "services": "Servicios",
+    "server type": "Tipo de servidor",
+    "hostname": "Nombre del host",
+    "port": "Puerto",
+    "management port": "Puerto de gestión",
+    "file preview truncated": "El contenido mostrado ha sido truncado",
+    "file unavailable": "Archivo no disponible",
+    "file unavailable description": "Este archivo ya no está disponible; puede haber sido eliminado o haber expirado.",
+    "row count": "Recuento de filas",
+    "encoding": "Codificación",
+    "show": "Mostrar",
+    "advanced configuration": "Otras propiedades",
+    "all executions": "Todas las ejecuciones",
+    "trigger execution id": "Trigger Execution Id",
+    "execution_status": "La ejecución es:",
+    "no_tasks_running": "Todavía no hay tasks en ejecución.",
+    "execution_starts_progress": "Una vez que la ejecución comience, verás actualizaciones de progreso aquí.",
+    "triggers_state": {
+      "state": "Estado",
+      "options": {
+        "enabled": "Habilitado",
+        "disabled": "Deshabilitado"
+      }
+    },
+    "trigger filter": {
+      "title": "Filtrar ejecuciones hijas",
+      "options": {
+        "ALL": "Todas las Ejecuciones",
+        "CHILD": "Ejecuciones Hijas",
+        "MAIN": "Ejecuciones Padres"
+      }
+    },
+    "show chart": "Mostrar Gráfico",
+    "namespace files": {
+      "toggle": {
+        "show": "Mostrar archivos del namespace",
+        "hide": "Ocultar archivos del namespace"
+      },
+      "filter": "Filtro",
+      "new_file": "Nuevo archivo",
+      "no_items": {
+        "heading": "No se encontraron archivos en tu namespace aún.",
+        "paragraph": "Crea o importa archivos para compartir código entre flows en tu namespace."
+      },
+      "no_selection": {
+        "heading": "Ningún archivo seleccionado",
+        "description": "Selecciona un archivo del árbol para ver su contenido."
+      },
+      "tree": {
+        "expand": "Expandir todas las carpetas",
+        "collapse": "Colapsar todas las carpetas"
+      },
+      "create": {
+        "label": "Crear",
+        "file": "Crear archivo",
+        "file_already_exists": "Ya existe un archivo con este nombre",
+        "file_conflicts_with_folder": "Ya existe una carpeta con este nombre",
+        "file_error": "Se produjo un error al crear el archivo",
+        "folder": "Crear carpeta",
+        "folder_already_exists": "Ya existe una carpeta con este nombre",
+        "folder_conflicts_with_file": "Ya existe un archivo con este nombre",
+        "folder_error": "Se produjo un error al crear la carpeta"
+      },
+      "rename": {
+        "label": "Renombrar",
+        "file": "Renombrar archivo",
+        "folder": "Renombrar carpeta",
+        "new_file": "Nuevo nombre con extensión:",
+        "new_folder": "Nuevo nombre de carpeta:"
+      },
+      "delete": {
+        "label": "Eliminar",
+        "file": "Eliminar archivo",
+        "folder": "Eliminar carpeta",
+        "files": "Eliminar {count} archivos seleccionados",
+        "folders": "Eliminar {count} carpetas seleccionadas"
+      },
+      "import": {
+        "import": "Importar",
+        "files": "Importar archivos",
+        "folder": "Importar carpeta",
+        "success": "Archivo(s) importado(s) exitosamente",
+        "error": "Ocurrieron errores al importar el/los archivo(s)"
+      },
+      "export": "Exportar archivos del namespace",
+      "export_single": "Exportar archivo",
+      "dialog": {
+        "name": {
+          "file": "Nombre con extensión:",
+          "folder": "Nombre de la carpeta:"
+        },
+        "parent_folder": "Carpeta padre:",
+        "deletion": {
+          "confirm": "Confirmar",
+          "title": "Confirmar eliminación de contenido",
+          "files": "¿Está seguro de que desea eliminar <code>{count}</code> archivo(s)?",
+          "folders": "¿Está seguro de que desea eliminar <code>{count}</code> carpeta(s) y todo su contenido?",
+          "mixed": "¿Está seguro de que desea eliminar la(s) carpeta(s) <code>{folders}</code> y el/los archivo(s) <code>{files}</code>?",
+          "file_single": "¿Está seguro de que desea eliminar el archivo <code>{name}</code>?",
+          "folder_single": "¿Está seguro de que desea eliminar la carpeta <code>{name}</code> y todo su contenido?"
+        }
+      },
+      "revisions": {
+        "history": "Historial de revisiones",
+        "restore": {
+          "success": "Revisión del archivo restaurada con éxito"
+        }
+      },
+      "path": {
+        "copy": "Copiar ruta",
+        "success": "Ruta copiada al portapapeles",
+        "error": "Ocurrieron errores al copiar la ruta al portapapeles"
+      }
+    },
+    "continue backfill": "Continuar el backfill",
+    "delete backfill": "Eliminar el backfill",
+    "pause backfill": "Pausar el backfill",
+    "continue backfills": "Continuar backfills",
+    "delete backfills": "Eliminar backfills",
+    "pause backfills": "Pausar backfills",
+    "backfill executions": "Ejecuciones de backfill",
+    "execute backfill": "Ejecutar backfill",
+    "backfill paused": "Backfill pausado",
+    "backfill running": "Backfill en ejecución",
+    "relative": "Relativo",
+    "relative start date": "Fecha de inicio relativa",
+    "relative end date": "Fecha de fin relativa",
+    "now": "Ahora",
+    "absolute": "Absoluto",
+    "backfill": "Backfill",
+    "Set labels tooltip": "Establecer etiquetas a la ejecución",
+    "Set labels": "Establecer etiquetas",
+    "manage labels": "Gestionar etiquetas",
+    "Set labels to execution": "Añadir o actualizar las etiquetas de la ejecución <code>{id}</code>",
+    "Set labels done": "Etiquetas de la ejecución establecidas con éxito",
+    "bulk set labels": "¿Estás seguro de que quieres establecer etiquetas a <code>{executionCount}</code> ejecución(es)?",
+    "dependencies loaded": "Dependencias cargadas",
+    "loaded x dependencies": "{count} dependencias cargadas",
+    "security_advice": {
+      "title": "Protege tu instancia",
+      "content": "Habilita la autenticación básica para proteger tu instancia.",
+      "switch_text": "No mostrar de nuevo",
+      "enable": "Habilitar autenticación"
+    },
+    "true": "Verdadero",
+    "false": "Falso",
+    "undefined": "Indefinido",
+    "execution-include-non-terminated": "¿Incluir ejecuciones no terminadas?",
+    "execution-warn-title": "¡Advertencia Importante!",
+    "execution-warn-deleting-still-running": "Recomendamos encarecidamente que canceles esta acción y detengas cualquier ejecución en curso primero. Eliminar ejecuciones no terminadas puede llevar a problemas de concurrencia, inconsistencias en la gestión de dependencias de flow y procesos zombie en tu instancia, lo que puede degradar el rendimiento del sistema. Asegúrate de comprender completamente estos riesgos antes de proceder con la eliminación.",
+    "originalCreatedDate": "Fecha de creación original",
+    "welcome": {
+      "menu": "Welcome",
+      "tour": {
+        "title": "Realiza un recorrido por el producto",
+        "text": "Elige tu caso de uso y sigue una guía paso a paso para aprender las características y capacidades de Kestra. ❤️"
+      },
+      "tutorial": {
+        "title": "Tutorial",
+        "text": "* <a href=\"https://kestra.io/tutorial-videos/all?utm_source=app&utm_medium=referral&utm_campaign=welcome-tutorial\" target=\"_blank\">Tutoriales en Video</a>  \n* <a href=\"https://kestra.io/docs?utm_source=app&utm_medium=referral&utm_campaign=welcome-tutorial\" target=\"_blank\">Documentación</a>  \n* <a href=\"https://kestra.io/blueprints?utm_source=app&utm_medium=referral&utm_campaign=welcome-tutorial\" target=\"_blank\">Blueprints</a>"
+      },
+      "help": {
+        "title": "¿Necesitas ayuda?",
+        "text": "Haz cualquier pregunta en nuestra comunidad de Slack. Si estás atascado, estamos aquí para ayudarte. ✋"
+      }
+    },
+    "pluginPage": {
+      "search": "Buscar en más de {count} plugins",
+      "searchTasks": "Buscar {count} tasks",
+      "noResults": "No hay plugins que coincidan con tu búsqueda.",
+      "loadError": "No se pudieron cargar los plugins. Por favor, inténtelo de nuevo.",
+      "notFound": "Este plugin no pudo ser encontrado.",
+      "elementType": {
+        "tasks": "Tarea",
+        "triggers": "Trigger",
+        "conditions": "Condición",
+        "taskRunners": "Ejecutor de task",
+        "charts": "Gráfico",
+        "apps": "Aplicación",
+        "logExporters": "Exportador de logs",
+        "secrets": "Secreto"
+      },
+      "sortBy": "Ordenar por",
+      "sort": {
+        "nameAsc": "Nombre A-Z",
+        "nameDesc": "Nombre Z-A",
+        "newest": "Más reciente",
+        "mostUsed": "Más usados"
+      },
+      "group": {
+        "plugins": "Plugins ({count})",
+        "tasks": "Tareas ({count})",
+        "blueprints": "Planos ({count})"
+      },
+      "overview": {
+        "title": "Visión general",
+        "versions": "Versiones",
+        "latest": "Último",
+        "releaseNotes": "Notas de la versión",
+        "previousVersions": "Versiones anteriores",
+        "createdBy": "Creado por",
+        "managedBy": "Gestionado por",
+        "pluginType": "Tipo de plugin",
+        "linksResources": "Enlaces y Recursos",
+        "minKestraVersion": "Vers. mínima compatible de Kestra: {version}",
+        "minKestraVersionShort": "Versión mínima de Kestra {version}"
+      },
+      "header": {
+        "enterpriseEdition": "Edición Enterprise",
+        "certified": "Certificado",
+        "back": "Volver a plugins"
+      }
+    },
+    "no inputs": "Este flow no tiene inputs.",
+    "admin_preferences": "Preferences",
     "settings": {
+      "label": "Configuración",
+      "updated": "{name} actualizado",
       "blocks": {
         "configuration": {
-          "descriptions": {
-            "auto_refresh_interval": "Segundos entre actualizaciones automáticas de datos en las páginas de lista.",
-            "default_namespace": "Se utiliza al crear nuevos flows sin un namespace.",
-            "editor_type": "Editor mostrado al abrir un flow por primera vez.",
-            "execute_default_tab": "Pestaña seleccionada al navegar a una ejecución.",
-            "execute_flow": "Dónde se abren los resultados de ejecución después de activar una ejecución.",
-            "flow_default_tab": "Pestaña seleccionada al navegar a un flow.",
-            "log_display": "Cómo se presentan los logs al abrir una ejecución.",
-            "log_level": "Nivel mínimo de log mostrado en los logs de ejecución.",
-            "playground": "Ejecutar tasks individualmente en el editor de pruebas.",
-            "triggers_default_tab": "Pestaña seleccionada al navegar a la página de triggers."
-          },
+          "label": "Configuración Principal",
           "fields": {
-            "auto_refresh_interval": "Intervalo de Auto Refresh",
-            "default_namespace": "Namespace Predeterminado",
-            "editor_type": "Tipo de Editor Predeterminado",
-            "execute_default_tab": "Pestaña de Ejecución Predeterminada",
-            "execute_flow": "Ejecutar el Flow",
-            "flow_default_tab": "Pestaña de Flow Predeterminada",
             "language": "Idioma",
-            "log_display": "Visualización de Log Predeterminada",
+            "default_namespace": "Namespace Predeterminado",
             "log_level": "Nivel de Log Predeterminado",
+            "log_display": "Visualización de Log Predeterminada",
+            "editor_type": "Tipo de Editor Predeterminado",
+            "execute_flow": "Ejecutar el Flow",
+            "execute_default_tab": "Pestaña de Ejecución Predeterminada",
             "multi_panel_editor": "Editor de Panel Múltiple",
+            "flow_default_tab": "Pestaña de Flow Predeterminada",
+            "triggers_default_tab": "Pestaña de Triggers Predeterminados",
             "playground": "Área de pruebas",
-            "triggers_default_tab": "Pestaña de Triggers Predeterminados"
+            "auto_refresh_interval": "Intervalo de Auto Refresh"
           },
-          "label": "Configuración Principal"
-        },
-        "export": {
-          "fields": {
-            "flows": "Exportar Todos los Flows",
-            "templates": "Exportar Todas las Plantillas"
-          },
-          "label": "Exportar"
-        },
-        "localization": {
           "descriptions": {
-            "date_format": "Formato utilizado para mostrar fechas en todo el dashboard.",
-            "language": "Idioma de la interfaz para menús y etiquetas.",
-            "time_zone": "Se utiliza para mostrar las fechas de ejecución y los triggers programados."
-          },
-          "fields": {
-            "date_format": "Formato de Fecha",
-            "time_zone": "Zona Horaria"
-          },
-          "label": "Idioma y Región",
-          "note": "Ten en cuenta que esta configuración se usa para mostrar las propiedades de fecha y hora en la UI. Para programar tus flows en una zona horaria diferente a UTC, asegúrate de configurar la propiedad de zona horaria en el trigger de Schedule en tu código de flow o en los predeterminados de tu plugin."
-        },
-        "reset_section_to_defaults": "Restaurar los valores predeterminados de esta sección",
-        "save": {
-          "discard": "Descartar",
-          "label": "Guardar preferencias",
-          "unsaved_title": "Cambios no guardados",
-          "unsaved_warning": "Tienes cambios no guardados. ¿Quieres guardarlos antes de salir?"
-        },
-        "sidebar": {
-          "descriptions": {
-            "items": "Mostrar, ocultar y reordenar elementos en la barra lateral."
-          },
-          "fields": {
-            "items": "Elementos de Navegación"
-          },
-          "label": "Barra lateral"
+            "default_namespace": "Se utiliza al crear nuevos flows sin un namespace.",
+            "log_level": "Nivel mínimo de log mostrado en los logs de ejecución.",
+            "log_display": "Cómo se presentan los logs al abrir una ejecución.",
+            "editor_type": "Editor mostrado al abrir un flow por primera vez.",
+            "execute_flow": "Dónde se abren los resultados de ejecución después de activar una ejecución.",
+            "execute_default_tab": "Pestaña seleccionada al navegar a una ejecución.",
+            "flow_default_tab": "Pestaña seleccionada al navegar a un flow.",
+            "triggers_default_tab": "Pestaña seleccionada al navegar a la página de triggers.",
+            "auto_refresh_interval": "Segundos entre actualizaciones automáticas de datos en las páginas de lista.",
+            "playground": "Ejecutar tasks individualmente en el editor de pruebas."
+          }
         },
         "theme": {
-          "app_font_size_options": {
-            "large": "Grande",
-            "medium": "Mediano",
-            "small": "Pequeño"
-          },
-          "color_modes": {
-            "dark_1": "Oscuro 1.0",
-            "dark_2": "Oscuro 2.0",
-            "light": "Claro",
-            "sync": "Sincronizar con el sistema"
-          },
-          "confirmations": {
-            "color_mode": "Tu interfaz ahora usa el tema `{mode}`."
-          },
-          "descriptions": {
-            "app_font_size": "Factor de escala aplicado a todos los tamaños de fuente de la interfaz.",
-            "color_mode": "Elige tu tema de interfaz preferido.",
-            "color_mode_shortcut": "Consejo: pulsa <kbd>Ctrl</kbd>+<kbd>Mayús</kbd>+<kbd>L</kbd> para cambiar de tema desde cualquier lugar.",
-            "editor_folding_stratgy": "Colapsar bloques largos de YAML por defecto al abrir un flow.",
-            "editor_font_family": "Fuente monoespaciada utilizada en el editor YAML.",
-            "editor_font_size": "Tamaño de fuente utilizado en los editores YAML y sin código.",
-            "editor_hover_description": "Mostrar descripciones de propiedades al pasar el cursor en el editor.",
-            "environment_color": "Color de acento utilizado para el entorno actual en la navegación.",
-            "environment_name": "Nombre para mostrar del entorno actual, mostrado en la navegación.",
-            "logs_font_size": "Tamaño de fuente utilizado en visores de log y terminales."
-          },
+          "label": "Preferencias de Tema",
           "fields": {
             "app_font_size": "Tamaño de fuente de la aplicación",
             "chart_color_scheme": {
+              "label": "Esquema de Colores del Gráfico",
               "classic": "Clásico",
-              "kestra": "Kestra",
-              "label": "Esquema de Colores del Gráfico"
+              "kestra": "Kestra"
             },
             "color_mode": "Modo de color",
             "editor_folding_stratgy": "Plegado Automático de Código en el Editor",
@@ -1850,24 +1066,867 @@
             "logs_font_size": "Tamaño de Fuente de Logs",
             "theme": "Tema"
           },
-          "label": "Preferencias de Tema"
+          "color_modes": {
+            "dark_2": "Oscuro 2.0",
+            "dark_1": "Oscuro 1.0",
+            "light": "Claro",
+            "sync": "Sincronizar con el sistema"
+          },
+          "confirmations": {
+            "color_mode": "Tu interfaz ahora usa el tema `{mode}`."
+          },
+          "descriptions": {
+            "color_mode": "Elige tu tema de interfaz preferido.",
+            "color_mode_shortcut": "Consejo: pulsa <kbd>Ctrl</kbd>+<kbd>Mayús</kbd>+<kbd>L</kbd> para cambiar de tema desde cualquier lugar.",
+            "logs_font_size": "Tamaño de fuente utilizado en visores de log y terminales.",
+            "editor_font_family": "Fuente monoespaciada utilizada en el editor YAML.",
+            "editor_font_size": "Tamaño de fuente utilizado en los editores YAML y sin código.",
+            "editor_folding_stratgy": "Colapsar bloques largos de YAML por defecto al abrir un flow.",
+            "editor_hover_description": "Mostrar descripciones de propiedades al pasar el cursor en el editor.",
+            "environment_name": "Nombre para mostrar del entorno actual, mostrado en la navegación.",
+            "environment_color": "Color de acento utilizado para el entorno actual en la navegación.",
+            "app_font_size": "Factor de escala aplicado a todos los tamaños de fuente de la interfaz."
+          },
+          "app_font_size_options": {
+            "small": "Pequeño",
+            "medium": "Mediano",
+            "large": "Grande"
+          }
+        },
+        "localization": {
+          "label": "Idioma y Región",
+          "note": "Ten en cuenta que esta configuración se usa para mostrar las propiedades de fecha y hora en la UI. Para programar tus flows en una zona horaria diferente a UTC, asegúrate de configurar la propiedad de zona horaria en el trigger de Schedule en tu código de flow o en los predeterminados de tu plugin.",
+          "fields": {
+            "time_zone": "Zona Horaria",
+            "date_format": "Formato de Fecha"
+          },
+          "descriptions": {
+            "language": "Idioma de la interfaz para menús y etiquetas.",
+            "time_zone": "Se utiliza para mostrar las fechas de ejecución y los triggers programados.",
+            "date_format": "Formato utilizado para mostrar fechas en todo el dashboard."
+          }
+        },
+        "export": {
+          "label": "Exportar",
+          "fields": {
+            "flows": "Exportar Todos los Flows",
+            "templates": "Exportar Todas las Plantillas"
+          }
+        },
+        "save": {
+          "label": "Guardar preferencias",
+          "discard": "Descartar",
+          "unsaved_title": "Cambios no guardados",
+          "unsaved_warning": "Tienes cambios no guardados. ¿Quieres guardarlos antes de salir?"
+        },
+        "reset_section_to_defaults": "Restaurar los valores predeterminados de esta sección",
+        "sidebar": {
+          "label": "Barra lateral",
+          "fields": {
+            "items": "Elementos de Navegación"
+          },
+          "descriptions": {
+            "items": "Mostrar, ocultar y reordenar elementos en la barra lateral."
+          }
+        }
+      }
+    },
+    "apps": "Aplicaciones",
+    "demos": {
+      "enterprise_edition": "Edición Enterprise",
+      "get_a_demo_button": "Obtener una Demo",
+      "contact_sales": "Contactar Ventas",
+      "watch_the_video": "Mira el video",
+      "secrets": {
+        "title": "Mejora tu Gestión de Secrets",
+        "message": "La Enterprise Edition (EE) te permite agregar, editar o eliminar secretos directamente en la UI, sin necesidad de reiniciar la instancia. Organiza secretos por namespace con permisos RBAC granulares, y herédalos de namespaces padre a hijo. EE se integra con gestores de secretos como HashiCorp Vault, AWS Secrets Manager, Azure Key Vault, Google Secret Manager y Elasticsearch. Configura backends dedicados por namespace, tenant o instancia para aislar secretos entre equipos, o habilita secretos de solo lectura almacenados en vaults externos. Los secretos permanecen cifrados en reposo y en tránsito. El almacenamiento en caché opcional reduce las llamadas a la API, y las auditorías registran todo el acceso.",
+        "detected_env": "Aquí están las variables de entorno de tipo secreto identificadas al momento de inicio de la instancia:",
+        "empty_env": "Todavía no tienes ningún Secret en tu entorno.",
+        "add_env": {
+          "intro": "Para crear un nuevo Secret:",
+          "first": "Codifica el <a href=\"https://kestra.io/docs/how-to-guides/secrets?utm_source=app&utm_medium=referral&utm_campaign=secrets-inlinedoc#using-secrets-in-kestra\" target=\"_blank\">valor secreto en Base64</a>",
+          "second": "Agrega una variable de entorno llamada '<strong>SECRET_{'{MY_SECRET_KEY}'}</strong>' con el valor anterior",
+          "third": "Reinicia tu instancia de Kestra"
         }
       },
-      "label": "Configuración",
-      "updated": "{name} actualizado"
+      "apps": {
+        "title": "Crea aplicaciones personalizadas con Kestra",
+        "message": "Las aplicaciones en Kestra Enterprise Edition te permiten construir interfaces de usuario personalizadas que interactúan con los workflows de Kestra desde fuera de la plataforma. Esta función te permite usar tus workflows como un backend para aplicaciones personalizadas, permitiendo a usuarios no técnicos enviar datos a través de formularios o reanudar workflows PAUSED que esperan aprobación."
+      },
+      "tests": {
+        "label": "Pruebas",
+        "header": "Pruebas Unitarias para Flows",
+        "title": "Garantiza la Fiabilidad con Cada Cambio",
+        "message": "Verifica la lógica de tus flows de forma aislada, detecta regresiones temprano y mantén la confianza en tus automatizaciones a medida que cambian y crecen."
+      },
+      "assets": {
+        "label": "Activos",
+        "header": "Metadatos de Activos y Observabilidad",
+        "title": "Lleva cada dataset, servicio y dependencia a la vista.",
+        "message": "Los assets conectan la observabilidad, el linaje y los metadatos de propiedad para que los equipos de la plataforma puedan solucionar problemas más rápido y desplegar con confianza."
+      },
+      "IAM": {
+        "title": "Gestionar usuarios a través de IAM con SSO, SCIM y RBAC",
+        "message": "La Edición Empresarial de Kestra tiene capacidades integradas de IAM con inicio de sesión único (SSO), sincronización de directorios SCIM y control de acceso basado en roles (RBAC), integrándose con múltiples proveedores de identidad y permitiéndote asignar permisos detallados para usuarios y cuentas de servicio."
+      },
+      "tenants": {
+        "title": "Gestionar Flujos de Trabajo en Tenants Aislados",
+        "message": "La Edición Enterprise de Kestra admite la multi-tenancy, proporcionándote entornos completamente aislados para diferentes equipos o proyectos, cada uno con sus propios recursos, como grupos de worker dedicados o secretos y backends de almacenamiento interno."
+      },
+      "audit-logs": {
+        "title": "Rastrear Cambios con Audit Logs",
+        "message": "La edición Enterprise de Kestra registra cada actividad con registros robustos e inmutables, lo que facilita el seguimiento de cambios, el mantenimiento de la conformidad y la resolución de problemas."
+      },
+      "quotas": {
+        "title": "Aplicar cuotas de ejecución en flujos",
+        "message": "Kestra Enterprise Edition le permite definir cuotas en los flujos para limitar el número de ejecuciones simultáneas o totales dentro de una ventana de tiempo. Las cuotas le ayudan a proteger la infraestructura compartida, aplicar SLAs y evitar que los flujos descontrolados consuman recursos excesivos."
+      },
+      "instance": {
+        "title": "Gestionar la Infraestructura en Toda su Instancia",
+        "message": "La Edición Enterprise de Kestra proporciona un panel de control operativo para ayudarte a observar la salud de tu plataforma y rastrear las métricas de tiempo de actividad de todos los servicios como, entre otros, Workers, Schedulers y Executors. Desde la misma página, también puedes crear Anuncios para notificar a tus usuarios sobre el tiempo de inactividad planificado, y puedes entrar en un modo de mantenimiento que pone temporalmente todos los servicios y ejecuciones de workflow en un estado de PAUSED para realizar una actualización."
+      },
+      "blueprints": {
+        "title": "Agregar Blueprints Personalizados",
+        "message": "En Kestra Enterprise Edition, puedes crear Blueprints personalizados disponibles solo para tu organización. Puedes usarlos como plantillas de mejores prácticas para compartir, centralizar y documentar flujos de trabajo comúnmente utilizados en tu equipo."
+      },
+      "namespace": {
+        "edit": {
+          "title": "Mejora la Gestión de tu Namespace",
+          "message": "En Kestra Enterprise Edition, los namespaces proporcionan aislamiento avanzado y gobernanza de secretos, variables y configuraciones predeterminadas de plugins a escala. Los administradores pueden configurar gestores de secretos personalizados, backends de almacenamiento aislados, grupos de workers dedicados y permisos detallados por cada namespace. Esto asegura que los secretos, variables y configuraciones de plugins permanezcan seguros y sean fáciles de mantener a través de diferentes equipos y proyectos."
+        },
+        "secrets": {
+          "title": "Gestionar Secretos de Forma Segura",
+          "message": "En Kestra Enterprise Edition, puedes almacenar y controlar secretos a nivel de namespace, minimizando el riesgo y asegurando que las credenciales de cada equipo permanezcan aisladas. Gracias a la jerarquía anidada, también puedes configurar credenciales en un namespace padre y serán heredadas por todos los namespaces hijos. El soporte para gestores de secretos dedicados y configuraciones de permisos a nivel de namespace detalladas fortalece aún más la seguridad y el cumplimiento."
+        },
+        "assets": {
+          "title": "Centralizar la Gestión de Activos",
+          "message": "En Kestra Enterprise Edition, Assets mantiene un inventario en vivo de los recursos con los que interactúan tus flujos de trabajo. Estos recursos pueden ser tablas de bases de datos, máquinas virtuales, archivos o cualquier sistema externo con el que trabajes."
+        },
+        "variables": {
+          "title": "Gobierne Centralmente Sus Variables",
+          "message": "En Kestra Enterprise Edition, puedes definir y gestionar variables a nivel de namespace para eliminar configuraciones repetitivas a través de los flows. Estas variables aseguran consistencia, simplifican las actualizaciones de configuración y pueden ser fácilmente referenciadas por cualquier task o trigger para flujos de trabajo más limpios y mantenibles."
+        },
+        "plugin-defaults": {
+          "title": "Estandarizar la Configuración con Valores Predeterminados del Plugin",
+          "message": "En Kestra Enterprise Edition, puedes establecer valores predeterminados de plugins específicos del namespace, reduciendo la necesidad de configuraciones duplicadas en cada flow. Esta gobernanza central de plugins aplica configuraciones consistentes, permite la referencia segura de secretos o variables, y simplifica el mantenimiento de tus workflows."
+        },
+        "history": {
+          "title": "Gestionar el Historial de Revisiones en un Solo Lugar",
+          "message": "En Kestra Enterprise Edition, puedes gestionar el historial de revisiones de tus Namespaces"
+        },
+        "audit-logs": {
+          "title": "Rastrea todos los cambios en un solo lugar",
+          "message": "En la Edición Enterprise de Kestra, puedes ver los logs de auditoría a nivel de namespace con diferencias detalladas, proporcionándote un historial claro de quién cambió qué y cuándo en todos los recursos."
+        }
+      }
+    },
+    "assets": {
+      "title": "Activos"
+    },
+    "onboarding": {
+      "welcome": {
+        "headline": "Crea y ejecuta tu primer flujo de trabajo en minutos",
+        "guided_title": "Crea tu primer flujo",
+        "badge": "Tutorial",
+        "guided_description": "Aprende a crear y ejecutar tu primer flujo con pasos guiados.",
+        "guided_duration": "Recomendado para la mayoría",
+        "self_serve_title": "Crear flujo desde cero",
+        "self_serve_description": "Ve directamente al editor y crea tu propio flujo.",
+        "self_serve_note": "Para usuarios avanzados",
+        "additional_help": "Ayuda adicional",
+        "docs": "Documentación",
+        "tutorial": "Tutorial",
+        "blueprints": "Blueprints",
+        "slack": "Comunidad de Slack"
+      },
+      "steps": {
+        "flow_basics": {
+          "title": "Conceptos básicos del flujo",
+          "description": "En Kestra, un <code>flow</code> es la unidad central de orquestación. Lo defines en YAML con metadatos y tareas ordenadas.<br><br>Revisa la estructura de ejemplo a continuación y luego continúa construyéndola paso a paso."
+        },
+        "add_id": {
+          "title": "Añadir ID del flujo",
+          "description": "El ID es el nombre único de tu flujo, para que puedas encontrarlo, ejecutarlo y referenciarlo de forma consistente.<br><br>Ahora añade <code>id</code> en el nivel raíz."
+        },
+        "add_namespace": {
+          "title": "Añadir namespace",
+          "description": "El Namespace es una agrupación similar a una carpeta que organiza los flujos por equipo, proyecto o entorno.<br><br>Ahora añade <code>namespace</code> en el nivel raíz."
+        },
+        "add_input": {
+          "title": "Añadir una entrada",
+          "description": "Las entradas (inputs) son parámetros a nivel de flujo que pueden referenciarse dentro de las tareas para controlar dinámicamente el comportamiento en tiempo de ejecución.<br><br>Ahora añade una entrada llamada <code>name</code> con tipo <code>STRING</code>."
+        },
+        "add_log_task": {
+          "title": "Añadir la primera tarea",
+          "description": "Las tareas (tasks) son las unidades de trabajo que ejecuta tu flujo, definidas como una lista ordenada de pasos. Cada tarea necesita un <code>id</code> único y un <code>type</code>. Kestra ofrece muchos plugins de tareas para sistemas externos; aquí usamos una tarea de script de Python.<br><br>La sintaxis <code>&#123;&#123; ... &#125;&#125;</code> es una expresión Pebble, usada para referenciar variables dinámicamente en tiempo de ejecución, como <code>&#123;&#123; inputs.name &#125;&#125;</code> desde las entradas del flujo.<br><br>Ahora añade la primera tarea bajo <code>tasks</code> con <code>id</code>, <code>type</code> y un <code>script</code> que imprima un saludo."
+        },
+        "save_flow": {
+          "title": "Guardar flujo",
+          "description": "Guardar conserva la definición de tu flujo para que pueda ejecutarse."
+        },
+        "execute_flow": {
+          "title": "Ejecutar flujo",
+          "description": "Ejecutar inicia una ejecución de tu flujo con valores de entrada en tiempo de ejecución."
+        },
+        "view_logs_status": {
+          "title": "Comprobar la ejecución",
+          "description": "Los detalles de ejecución muestran el estado, los tiempos y los logs de salida a nivel de tarea.<br><br>Ahora abre los detalles de ejecución y haz clic en <code>greet</code> en el diagrama de Gantt para ver los logs."
+        },
+        "edit_flow_from_execution": {
+          "title": "Volver al editor de flujos",
+          "description": "Puedes saltar directamente desde una ejecución a la definición del flujo para iterar rápidamente."
+        },
+        "add_cron_trigger": {
+          "title": "Añadir un trigger cron",
+          "description": "Los triggers pueden iniciar ejecuciones según horarios o eventos externos (por ejemplo, webhooks o mensajes MQTT).<br><br>Ahora añade un trigger de programación cron para que este flujo se ejecute cada 5 minutos."
+        },
+        "add_input_default": {
+          "title": "Establecer un valor por defecto para la entrada",
+          "description": "Cuando un flujo se activa automáticamente, las entradas aún necesitan valores en tiempo de ejecución.<br><br>La entrada <code>name</code> ya se creó en el paso anterior, así que no es necesario añadirla de nuevo. Solo establece un valor por defecto para la entrada existente <code>name</code>."
+        },
+        "save_flow_again": {
+          "title": "Guardar flujo",
+          "description": "Tu flujo ahora tiene una programación y un valor por defecto de entrada para ejecuciones automáticas."
+        },
+        "background_runs_info": {
+          "title": "Ejecuciones programadas",
+          "description": "Este flujo ahora se ejecutará en segundo plano cada 5 minutos.<br><br>Puedes navegar a la vista general de Ejecuciones desde el menú de la izquierda para supervisar las ejecuciones programadas."
+        },
+        "finish": {
+          "title": "Has completado el tutorial de Primer Flujo",
+          "description": "Buen comienzo. Creaste, ejecutaste, parametrizaste y programaste un flujo.<br><br>Elige qué hacer a continuación ..."
+        }
+      },
+      "actions": {
+        "next": "Siguiente",
+        "complete": "Completar",
+        "save_to_continue": "Pulsa Guardar en la barra superior (derecha).",
+        "execute_to_continue": "1. Pulsa Ejecutar en la barra superior (derecha).\n2. Proporciona un valor para <strong>name</strong>.\n3. Pulsa Ejecutar de nuevo en el modal.",
+        "edit_flow_to_continue": "Pulsa Editar flujo en la barra superior (derecha).",
+        "cancel_tutorial": "Cancelar tutorial",
+        "finish_tutorial": "Finalizar tutorial"
+      },
+      "finish_actions": {
+        "explore_blueprints": "Explorar Blueprints",
+        "create_flow": "Crear flujo"
+      },
+      "editor_hints": {
+        "build_intro": "Crea tu primer flujo paso a paso.",
+        "step_1": "# 1) Añadir id",
+        "step_2": "# 2) Añadir namespace",
+        "step_3": "# 3) Añadir una entrada",
+        "step_4": "# 4) Añadir tareas y tu primera tarea de Python",
+        "step_5": "# 5) Añadir un trigger cron"
+      },
+      "cancel_modal": {
+        "title": "Cancelar el tutorial de Primer Flujo",
+        "description": "¿Quieres cancelar el tutorial de Primer Flujo?",
+        "confirm": "Cancelar tutorial",
+        "keep": "Mantener tutorial"
+      },
+      "validation": {
+        "complete_step": "Ya casi está. Completa este paso para continuar.",
+        "fix_yaml": "Hay un pequeño problema de formato YAML. Arréglalo y luego continúa.",
+        "add_id": "Añade un ID de flujo en la parte superior. Ejemplo: `id: hello_flow`.",
+        "add_namespace": "Añade un namespace en la parte superior. Ejemplo: `namespace: company.team`.",
+        "add_input_section": "Crea una sección `inputs` con una entrada.",
+        "add_input_id": "Dentro de `inputs`, añade `id: name`.",
+        "add_input_type": "Establece el tipo de entrada en `STRING`.",
+        "add_log_task_section": "Crea una sección `tasks` y añade tu primera tarea.",
+        "add_log_task_id": "Dale un ID a la tarea, por ejemplo: `id: greet`.",
+        "add_log_task_type": "Establece el tipo de tarea en `io.kestra.plugin.scripts.python.Script`.",
+        "add_log_task_message": "Añade un campo `script` a la tarea.",
+        "add_log_task_pebble": "Usa una expresión Pebble en el script para que use tu valor de entrada (por ejemplo: `inputs.name`).",
+        "save_flow": "Haz clic en Guardar para continuar.",
+        "execute_flow": "Ejecuta el flujo una vez para continuar.",
+        "view_logs_status": "Abre los detalles de ejecución y revisa los logs de `greet`.",
+        "edit_flow_from_execution": "Haz clic en `Editar flujo` en la barra superior para continuar.",
+        "add_cron_trigger_section": "Crea una sección `triggers` con un trigger de programación.",
+        "add_cron_trigger_type": "Establece el tipo de trigger en `io.kestra.plugin.core.trigger.Schedule`.",
+        "add_cron_trigger_cron": "Añade una expresión cron, por ejemplo: `\"*/5 * * * *\"`.",
+        "add_input_default_section": "Vuelve a `inputs` y conserva una entrada existente llamada `name` (no añadas una segunda entrada).",
+        "add_input_default_id": "Mantén el ID de la entrada existente como `name`.",
+        "add_input_default_defaults": "Añade un valor por defecto para `name`, por ejemplo: `defaults: \"Kestra\"`.",
+        "save_flow_again": "Haz clic en Guardar de nuevo para continuar."
+      }
+    },
+    "enable concurrency": "Habilitar concurrencia",
+    "auditlogs": "Audit Logs",
+    "quotas": "Cuotas",
+    "iam": "IAM",
+    "tenant": {
+      "name": "Mandante",
+      "names": "Arrendatarios"
+    },
+    "ee-tooltip": {
+      "features-blocked": "Esta función requiere la Edición Enterprise.",
+      "button": "Habla con nosotros"
+    },
+    "flow_only": "Solo disponible en la pestaña Flow.",
+    "bulk action async warning": "Esto podría tardar unos momentos.",
+    "bulk unpause backfills": "Despausar {count} backfill",
+    "bulk pause backfills": "Pausar {count} backfill",
+    "bulk delete backfills": "Eliminar {count} backfill",
+    "bulk unlock": "Desbloquear {count} triggers",
+    "bulk disabled status": {
+      "true": "Deshabilitar {count} triggers",
+      "false": "Habilitar {count} triggers"
+    },
+    "unlock": "Desbloquear",
+    "bulk success unpause backfills": "{count} backfills despausados",
+    "bulk success pause backfills": "{count} backfills pausados",
+    "bulk success delete backfills": "{count} backfills eliminados",
+    "bulk success unlock": "{count} triggers desbloqueados",
+    "bulk success disabled status": {
+      "true": "{count} trigger(s) deshabilitado(s)",
+      "false": "{count} trigger(s) habilitado(s)"
+    },
+    "no_namespaces": "Ningún namespace coincide con los criterios de búsqueda.",
+    "system_namespace": "Mantén tu plataforma bajo control con los system flows.",
+    "system_namespace_description": "Automatiza tareas de mantenimiento, desde alertas de fallo hasta limpiezas automatizadas.",
+    "pluginDefaults": {
+      "title": "Valores Predeterminados del Plugin",
+      "add": "Agregar Plugin Predeterminado",
+      "edit": "Editar Plugin Default",
+      "add_subtitle": "Configurar un nuevo plugin predeterminado con sus propiedades",
+      "edit_subtitle": "Modificar la configuración predeterminada del plugin existente",
+      "predefined": "Plugin Predefinido",
+      "custom": "Plugin Personalizado",
+      "form": "Formulario",
+      "yaml": "YAML",
+      "select_predefined": "Seleccionar Plugin Predefinido",
+      "cancel": "Cancelar",
+      "update": "Actualizar Plugin Default",
+      "custom_type": "Tipo de plugin personalizado",
+      "custom_placeholder": "Ingrese el tipo de plugin",
+      "use_custom": "Usar Personalizado",
+      "custom_configure": "Tipo de plugin personalizado - configurar usando YAML",
+      "yaml_configuration": "Configuración YAML",
+      "show_yaml": "Mostrar YAML"
+    },
+    "secret": {
+      "add": "Crear",
+      "update": "Actualizar secreto '{name}'",
+      "isReadOnly": "El secreto es de solo lectura",
+      "names": "Secrets",
+      "inherited": "Secrets heredados"
+    },
+    "workerId": "Worker Id",
+    "kv": {
+      "name": "KV Store",
+      "type": "Tipo",
+      "add": "Crear",
+      "update": "Actualizar value para key '{key}'",
+      "duplicate": "Esta key ya existe",
+      "delete multiple": {
+        "confirm": "¿Está seguro de que desea eliminar: <code>{name}</code> kv(s)?",
+        "warning": "No tienes permisos para esos namespaces, por lo que se omitirán: <code>{namespaces}</code>"
+      },
+      "inherited": "Pares KV heredados"
+    },
+    "expiration": "Expiración",
+    "failed to render pdf": "Error al renderizar la vista previa del PDF",
+    "page": {
+      "previous": "Página anterior",
+      "next": "Página siguiente"
+    },
+    "namespace_editor": {
+      "empty": {
+        "title": "No hay pestañas abiertas actualmente",
+        "create_message": "Puedes crear o importar archivos de namespace.",
+        "video_message": "Puedes ver el Video de Introducción para nuestro Editor."
+      },
+      "close": {
+        "tab": "Cerrar pestaña",
+        "all": "Cerrar todas las pestañas",
+        "other": "Cerrar otras pestañas",
+        "right": "Cerrar a la derecha"
+      }
+    },
+    "curl": {
+      "command": "Comando cURL",
+      "note": "Tenga en cuenta que para el tipo de input SECRET y FILE, el comando debe adaptarse para coincidir con los valores reales."
+    },
+    "webhook": {
+      "curl_command": "Comando cURL de Webhook",
+      "payload": "Payload de Webhook (JSON)",
+      "curl_note": "Utiliza este comando cURL para trigger el flow a través de webhook con carga útil JSON personalizada",
+      "no_triggers": "Este flow no tiene triggers de webhook habilitados",
+      "copy_url": "Copiar URL del webhook"
+    },
+    "logs_view": {
+      "raw": "Vista temporal",
+      "raw_details": "Mostrar task logs y flow logs completos en un formato crudo ordenado por marca de tiempo",
+      "compact": "Vista predeterminada",
+      "compact_details": "Mostrar task logs en una vista compacta agrupada por cada task"
+    },
+    "execution_deletion": {
+      "logs": "Eliminar logs",
+      "metrics": "Eliminar métricas",
+      "storage": "Eliminar archivos de almacenamiento interno"
+    },
+    "scope_filter": {
+      "all": "Todos los {label}",
+      "user": "Usuario {label}",
+      "system": "Sistema {label}",
+      "user_description": "Usuario regular inició {label}",
+      "system_description": "Mantenimiento del sistema {label}"
+    },
+    "data": "Datos",
+    "webhook link copied": "Enlace de Webhook copiado.",
+    "copy url": "Copiar URL",
+    "scheduleDate": "Fecha de programación",
+    "warning": "Advertencia",
+    "trigger_check_warning": "Al usar variables de trigger no funcionará con la ejecución manual de flow. Agrega el operador de coalescencia `??` para resolver el problema. Por ejemplo, en lugar de `trigger.date`, usa `trigger.date ?? execution.startDate`.",
+    "docs": "Documentos",
+    "active-slots": "Ranuras activas",
+    "behavior": "Comportamiento",
+    "concurrency": "Concurrente",
+    "no-executions-view": {
+      "title": "Comienza a automatizar con",
+      "sub_title": "Haz clic en el botón Ejecutar para iniciar la ejecución de tu primer flujo de trabajo.",
+      "namespace_sub_title": "Ejecuta uno o más flows de este namespace para llenar este panel.",
+      "guidance_desc": "¿Necesitas orientación para ejecutar tu flow?",
+      "namespace_guidance_desc": "¿Necesitas orientación para gestionar tu Namespace?",
+      "guidance_sub_desc": "Sigue la documentación para toda la información que necesitas."
+    },
+    "execution_guide": {
+      "get_started": {
+        "title": "Comenzar ⚡",
+        "text": "Sigue la Guía de inicio rápido para instalar Kestra y comenzar a crear tus primeros flujos de trabajo."
+      },
+      "namespaces": {
+        "title": "Acerca de Namespaces",
+        "text": "Los namespaces son agrupaciones lógicas de flows y sus componentes."
+      },
+      "workflow_components": {
+        "title": "Componentes del Workflow",
+        "text": "Conozca los principales componentes de orquestación de un flujo de trabajo de Kestra."
+      },
+      "videos_tutorials": {
+        "title": "Tutoriales en Video",
+        "text": "Comienza con nuestros tutoriales en video."
+      }
+    },
+    "open sidebar": "abrir barra lateral",
+    "close sidebar": "cerrar barra lateral",
+    "customize sidebar": "Personalizar barra lateral",
+    "reset to defaults": "Restablecer a los valores predeterminados",
+    "drop items here": "Suelta los elementos aquí",
+    "files": "Archivos",
+    "optional": "Opcional",
+    "no_data": "Parece que no hay nada aquí... ¡todavía!<br/>Ajusta tus filtros o inténtalo de nuevo.",
+    "bookmark": "Marcadores",
+    "remove_bookmark": "¿Está seguro de que desea eliminar este marcador?",
+    "showLess": "Mostrar menos",
+    "showMore": "Mostrar más",
+    "documentationMenu": "Menú de documentación",
+    "item": "elemento",
+    "items": "elementos",
+    "cron": "Cron",
+    "execution_started": "¡La ejecución ha comenzado!",
+    "execution_failed": "¡Ejecución fallida!",
+    "last error was": "Último error fue",
+    "execution restarted": "Esta ejecución se ha reiniciado {nbRestart} vez/veces.",
+    "execution replay": "Esta ejecución es una repetición de",
+    "execution replayed": "Esta ejecución ha sido reproducida.",
+    "task run id": "ID de TaskRun",
+    "active": "Activo",
+    "flows imported": "Flujos importados",
+    "flow not imported": "Algunos flow no pudieron ser importados",
+    "plugin defaults exported": "Valores predeterminados del plugin exportados",
+    "failed to export plugin defaults": "Error al exportar los valores predeterminados del plugin",
+    "plugin defaults imported": "Valores predeterminados del plugin importados",
+    "plugin defaults not imported": "Algunos valores predeterminados del plugin no se pudieron importar",
+    "failed to import plugin defaults": "Error al importar los valores predeterminados del plugin",
+    "filters": {
+      "label": "Elegir filtros",
+      "empty": "Sin datos.",
+      "format": "Escriba el parámetro como 'key:value'",
+      "text_search": "Buscar este texto",
+      "options": {
+        "namespace": "Namespace",
+        "flow": "Flujo",
+        "state": "Estado",
+        "scope": "Ámbito",
+        "child": "Niño",
+        "level": "Nivel de log",
+        "task": "Tarea",
+        "metric": "Métrica",
+        "user": "Usuario",
+        "type": "Tipo",
+        "service_type": "Tipo",
+        "permission": "Permiso",
+        "action": "Acción",
+        "status": "Estado",
+        "details": "Detalles",
+        "aggregation": "Agregación",
+        "relative_date": "Fecha relativa",
+        "absolute_date": "Fecha absoluta",
+        "labels": "Etiquetas",
+        "text": "I'm sorry, but it seems like the text you want me to translate is missing. Could you please provide the text again?",
+        "startDate": "Fecha de inicio",
+        "endDate": "Fecha de finalización"
+      },
+      "comparators": {
+        "is": "es",
+        "is_one_of": "es uno de",
+        "is_not": "no es",
+        "not_in": "no en",
+        "contains": "contiene",
+        "not_contains": "no contiene",
+        "in": "en",
+        "between": "entre",
+        "starts_with": "comienza con",
+        "greater_than": "mayor que",
+        "greater_than_or_equal_to": "mayor o igual que",
+        "less_than": "menos de",
+        "less_than_or_equal_to": "menor o igual que",
+        "ends_with": "termina con"
+      },
+      "save": {
+        "label": "Búsquedas guardadas",
+        "remove": "Eliminar",
+        "empty": "Todavía no has guardado ninguna búsqueda.",
+        "tooltip": "No puedes guardar criterios de búsqueda vacíos.",
+        "name_already_used": "La etiqueta de búsqueda ya está en uso.",
+        "dialog": {
+          "heading": "Guardar búsqueda actual",
+          "placeholder": "Etiqueta",
+          "hint": "¿Cómo desea etiquetar este criterio de búsqueda?",
+          "confirmation": "Criterios de búsqueda <code>{name}</code>"
+        }
+      },
+      "settings": {
+        "label": "Configuración de la página",
+        "show_chart": "Mostrar gráfico principal"
+      }
+    },
+    "custom value": "Valor personalizado",
+    "chart": "Gráfico",
+    "chart preview": "Vista previa del gráfico",
+    "no_code": {
+      "toggle_pebble": "Alternar editor de Pebble",
+      "version_oss_placeholder": "Desbloquea la Versionado de Plugins con la Enterprise Edition",
+      "unnamed": "Sin Nombre",
+      "adding": "+ Agregar un {what}",
+      "adding_default": "+ Añadir un nuevo value",
+      "add_field": "Agregar {field}",
+      "clearSelection": "Borrar selección",
+      "labels": {
+        "yaml": "Editor YAML",
+        "no_code": "Editor Sin Código",
+        "label": "Etiqueta",
+        "variable": "Variable"
+      },
+      "sections": {
+        "deprecated": "Propiedades obsoletas",
+        "tasks": "Tareas",
+        "triggers": "Disparadores",
+        "errors": "Manejadores de Errores",
+        "afterExecution": "Después de la Ejecución",
+        "finally": "Finalmente",
+        "pluginDefaults": "Predeterminados del Plugin"
+      },
+      "fields": {
+        "main": {
+          "id": "ID de Flow",
+          "namespace": "Namespace",
+          "description": "Descripción",
+          "inputs": "Entradas"
+        },
+        "general": {
+          "retry": "Reintentar",
+          "sla": "SLA",
+          "labels": "Etiquetas",
+          "outputs": "Salidas",
+          "variables": "Variables",
+          "concurrency": "Concurrente",
+          "disabled": "Desactivado",
+          "listeners": "Oyentes",
+          "taskDefaults": "Predeterminados de Task",
+          "workerGroup": "Grupo de Worker",
+          "workerSelector": "Selector de Worker",
+          "checks": "Comprobaciones",
+          "updated": "Actualizado"
+        }
+      },
+      "select": {
+        "default": "Seleccionar un tipo",
+        "task": "Selecciona una task",
+        "tasks": "Seleccionar una task",
+        "triggers": "Seleccione un trigger",
+        "errors": "Selecciona una task",
+        "finally": "Seleccionar una task",
+        "pluginDefaults": "Seleccionar un plugin",
+        "afterExecution": "Seleccionar una task",
+        "conditions": "Seleccione una condición",
+        "inputs": "Seleccione un tipo de campo de input",
+        "charts": "Seleccione un tipo de gráfico",
+        "where": "Seleccione un tipo de filtro",
+        "numerator": "Seleccione un numerador"
+      },
+      "creation": {
+        "default": "Agregar",
+        "tasks": "Agregar una task",
+        "triggers": "Agregar un trigger",
+        "errors": "Agregar un manejador de errores",
+        "finally": "Agregar un bloque finally",
+        "pluginDefaults": "Agregar un plugin predeterminado",
+        "afterExecution": "Agregar un bloque después de la ejecución",
+        "conditions": "Agregar una condición",
+        "inputs": "Agregar un campo de input",
+        "charts": "Agregar un gráfico",
+        "where": "Filtra tus datos",
+        "numerator": "Agregar un numerador"
+      },
+      "remove": {
+        "default": "Eliminar esta entrada",
+        "cases": "Eliminar este caso"
+      }
+    },
+    "properties": {
+      "label": "Propiedades",
+      "hint": "Elegir Columnas Visibles",
+      "shown": "Mostrado en Tabla",
+      "hidden": "Oculto en la Tabla"
+    },
+    "editor_shortcuts": {
+      "label": "Atajos de teclado",
+      "trigger_autocompletion": "Activar autocompletado",
+      "command_palette": "Mostrar paleta de comandos",
+      "save_flow": "Guardar flow",
+      "execute_flow": "Ejecutar flow",
+      "toggle_ai_agent": "Alternar agente de AI",
+      "move_line": "Mover línea",
+      "duplicate_cursor": "Duplicar cursor",
+      "fold_unfold": "Plegar/Desplegar código",
+      "comment_uncomment": "Comentar/Descomentar",
+      "comment": "Comentario",
+      "uncomment": "Descomentar",
+      "decrease_fontsize": "Disminuir el tamaño de fuente del editor",
+      "increase_fontsize": "Aumentar el tamaño de fuente del editor",
+      "reset_fontsize": "Restablecer el tamaño de fuente del editor"
+    },
+    "instance": "Instancia",
+    "something_went_wrong": {
+      "loading_execution": "Algo salió mal al cargar la ejecución.",
+      "connection_lost": {
+        "title": "Conexión interrumpida",
+        "message": "No pudimos alcanzar tu instancia de Kestra. Asegúrate de que esté en ejecución, luego actualiza la página."
+      }
+    },
+    "debug": "Depuración",
+    "default": "Predeterminado",
+    "data_not_protected": "Tus datos no están protegidos. No los pierdas. <b>Activa nuestras funciones de seguridad gratuitas o prueba nuestra oferta de pago.</b>",
+    "activate_basic_auth": "Activar Autenticación Básica",
+    "dark_version": "Versión oscura",
+    "use_dark_background": "Utiliza esta versión cuando trabajes sobre un fondo oscuro para asegurar que nuestro nombre permanezca legible.",
+    "light_version": "Versión ligera",
+    "light_background": "Esta es la opción preferida al trabajar con un fondo claro.",
+    "monogram": "Monograma",
+    "wordmark_colors": "Los colores del logotipo se adaptan según el fondo, mientras que el icono permanece sin fondo cuando se coloca sobre un fondo oscuro.",
+    "download_logos": "Descargar Paquete de Logos",
+    "this_task_has": "Esta tarea tiene",
+    "about_this_blueprint": "Acerca de este blueprint",
+    "deleted_label": "Eliminado",
+    "fold_all_multi_lines": "Plegar Todas las Líneas Múltiples",
+    "task_id_exists": "El Id de Task ya existe",
+    "task_id_message": "El Task Id ${existingTask} ya existe en el flow.",
+    "trigger_id_exists": "El Trigger Id ya existe",
+    "trigger_id_message": "El Trigger Id ${existingTrigger} ya existe en el flow.",
+    "watch": "Ver",
+    "learn_more": "Aprender más",
+    "watch_video": "Ver Video",
+    "runners": "Corredores",
+    "select": "Seleccione su {{section}}",
+    "for flow": "para flow",
+    "forbidden system labels": "Solo system.correlationId puede usarse como label del sistema",
+    "confirm": "Confirmar",
+    "taskRunners": "Ejecutores de Task",
+    "additionalPlugins": "Plugins Adicionales",
+    "appBlocks": "Bloques de la App",
+    "charts": "Gráficos",
+    "dataFilters": "Filtros de Datos",
+    "logExporters": "Exportadores de Logs",
+    "empty": {
+      "namespaceFiles": {
+        "title": "Aún no hay archivos en este namespace",
+        "content": "Los archivos del namespace funcionan como una carpeta de proyecto para este namespace. Almacena código Python, SQL, dbt o Terraform y luego referencia cualquier archivo en tus flows con"
+      },
+      "announcements": {
+        "title": "¡No tienes anuncios todavía!",
+        "content": "Los anuncios te permiten notificar a tus usuarios sobre cualquier cambio o informarles sobre el tiempo de inactividad planificado para mantenimiento. Simplemente selecciona el tipo de anuncio, el rango de fechas en el que debe mostrarse y escribe el mensaje del anuncio."
+      },
+      "kill_switches": {
+        "title": "¡Aún no tienes Kill Switches!",
+        "content": "La función Kill Switch proporciona un mecanismo basado en la UI para detener ejecuciones problemáticas. Reemplaza los comandos de solo CLI <code>--skip-executions</code> y <code>--skip-flows</code> con una interfaz de administración integral."
+      },
+      "apps": {
+        "title": "¡Aún no tienes aplicaciones!",
+        "content": "Comienza a crear Apps para interactuar con Kestra desde el mundo exterior."
+      },
+      "testSuites": {
+        "title": "¡Aún no tienes Test suites!",
+        "content": "Comienza a crear suites de prueba para probar tus Flows."
+      },
+      "assets": {
+        "title": "¡Aún no tienes Assets!",
+        "content": "Agrega activos para rastrear y gestionar tus activos de datos, servicios e infraestructura."
+      },
+      "apiTokens": {
+        "title": "Administra tus API Tokens",
+        "content": "Los tokens de API se utilizan cada vez que deseas otorgar acceso programático a la API de Kestra."
+      },
+      "concurrency_executions": {
+        "title": "No hay Ejecuciones en curso para este Flow.",
+        "content": "Lee más sobre <strong><a href=\"https://kestra.io/docs/workflow-components/execution?utm_source=app&utm_medium=referral&utm_campaign=concurrency-inlinedoc\" target=\"_blank\">Ejecuciones</a></strong> en nuestra documentación."
+      },
+      "concurrency_limit": {
+        "title": "No se han establecido límites para este Flow.",
+        "content": "Lea más sobre los <strong><a href=\"https://kestra.io/docs/workflow-components/concurrency?utm_source=app&utm_medium=referral&utm_campaign=concurrency-inlinedoc\" target=\"_blank\">Límites de Concurrencia</a></strong> en nuestra documentación."
+      },
+      "concurrency_limits": {
+        "title": "No se han establecido límites de concurrencia.",
+        "content": "Lea más sobre los <strong><a href=\"https://kestra.io/docs/workflow-components/concurrency?utm_source=app&utm_medium=referral&utm_campaign=concurrency-inlinedoc\" target=\"_blank\">Límites de Concurrency</a></strong> en nuestra documentación."
+      },
+      "pluginDefaults": {
+        "title": "¡Aún no tienes valores predeterminados de plugin!",
+        "content": "Los valores predeterminados del plugin te permiten gobernar centralmente la configuración de tu plugin y compartirla con todos los flows en tu namespace."
+      },
+      "variables": {
+        "title": "Aún no hay variables",
+        "content": "Agrega pares de key-value para compartir la configuración entre flows. Los namespaces secundarios los heredan automáticamente, y puedes referenciar cualquier value con"
+      },
+      "workerRegistrationTokens": {
+        "title": "¡Aún no tienes tokens de registro!",
+        "content": "Los tokens de registro permiten que los workers remotos se autentiquen y registren de manera segura con tu instancia de Kestra. Crea un token y luego úsalo para conectar nuevos workers a este clúster."
+      },
+      "groups": {
+        "title": "¡Aún no tienes grupos!",
+        "content": "Los grupos te permiten agrupar usuarios para que puedas gestionar permisos y asignaciones de roles colectivamente en tu mandante."
+      },
+      "dependencies": {
+        "FLOW": {
+          "title": "Actualmente no hay dependencias.",
+          "content": "Lea más sobre <a href=\"https://kestra.io/docs/ui/flows?utm_source=app&utm_medium=referral&utm_campaign=dependencies-inlinedoc#dependencies\" target=\"_blank\">Flow Dependencies</a> en nuestra documentación."
+        },
+        "EXECUTION": {
+          "title": "Actualmente no hay dependencias.",
+          "content": "Lea más sobre <a href=\"https://kestra.io/docs/ui/executions?utm_source=app&utm_medium=referral&utm_campaign=dependencies-inlinedoc#dependencies\" target=\"_blank\">Dependencias de Ejecución</a> en nuestra documentación."
+        },
+        "NAMESPACE": {
+          "title": "Actualmente no hay dependencias.",
+          "content": "Lea más sobre <a href=\"https://kestra.io/docs/ui/namespaces?utm_source=app&utm_medium=referral&utm_campaign=dependencies-inlinedoc#dependencies\" target=\"_blank\">Namespace Dependencies</a> en nuestra documentación."
+        },
+        "ASSET": {
+          "title": "Actualmente no hay dependencias.",
+          "content": "Este recurso no tiene dependencias ascendentes o descendentes con flows u otros recursos."
+        }
+      },
+      "plugins": {
+        "title": "No se han establecido valores predeterminados de plugin para este Namespace.",
+        "content": "Lee más sobre <strong><a href=\"https://kestra.io/docs/workflow-components/plugin-defaults?utm_source=app&utm_medium=referral&utm_campaign=plugin-default-inlinedoc\" target=\"_blank\">Concurrency Limits</a></strong> en nuestra documentación."
+      },
+      "triggers": {
+        "title": "Tu flow no tiene ningún trigger.",
+        "content": "Lee más sobre <strong><a href=\"https://kestra.io/docs/workflow-components/triggers?utm_source=app&utm_medium=referral&utm_campaign=trigger-inlinedoc\" target=\"_blank\">Triggers</a></strong> en nuestra documentación."
+      },
+      "mcpToolFlows": {
+        "title": "Aún no hay flows de herramientas registrados en este servidor.",
+        "content": "Exponga un flow como una herramienta MCP añadiendo un <code>McpToolTrigger</code> a él. Lea más sobre el <strong><a href=\"https://kestra.io/docs/workflow-components/triggers/mcp-tool-trigger?utm_source=app&utm_medium=referral&utm_campaign=mcp-tool-trigger-inlinedoc\" target=\"_blank\">MCP Tool Trigger</a></strong> en nuestra documentación."
+      },
+      "versionPlugin": {
+        "title": "¡Aún no tienes ningún plugin versionado!",
+        "content": "Aquí puedes gestionar todos los plugins instalados en tu instancia de Kestra. Los plugins recién instalados pueden no estar disponibles de inmediato en todos los servicios de Kestra, dependiendo de la configuración de tu instancia."
+      },
+      "panels": {
+        "title": "No hay panel abierto",
+        "content": "Has cerrado todos los paneles.  \nElige una pestaña arriba para continuar."
+      }
+    },
+    "toggle_word_wrap": "Alternar ajuste de línea",
+    "copied_logs_to_clipboard": "Copiado logs al portapapeles.",
+    "multi_panel_editor": {
+      "move_right": "Mover a la derecha",
+      "move_left": "Mover a la izquierda",
+      "close_all_tabs": "Cerrar todas las pestañas",
+      "close_all_panels": "Cerrar todos los paneles"
+    },
+    "search_docs": "Buscar",
+    "no_results_found": "No se encontraron resultados",
+    "searching": "Buscando...",
+    "worker information": "Información del Worker",
+    "test-badge-text": "Prueba",
+    "test-badge-tooltip": "Esta ejecución fue creada por una prueba",
+    "total_executions": "Total de Ejecuciones",
+    "no_results": {
+      "executions": "No se encontraron ejecuciones",
+      "triggers": "No se encontraron Triggers",
+      "flows": "No se encontraron Flows",
+      "kv_pairs": "No se encontraron pares Key-Value",
+      "secrets": "No se encontraron Secrets",
+      "templates": "No se encontraron plantillas",
+      "assets": "No se encontraron activos"
+    },
+    "duplicate-pair": "{label} \"{key}\" está duplicado, se ignora la primera clave.",
+    "dashboards": {
+      "labels": {
+        "singular": "Panel de control",
+        "plural": "Dashboards"
+      },
+      "default": "Dashboard predeterminado",
+      "switch": "Cambiar Dashboard",
+      "preview": "Vista previa del Dashboard",
+      "empty": "No hay resultados para mostrar.",
+      "creation": {
+        "label": "Crear Dashboard",
+        "confirmation": "El Dashboard <code>{title}</code> ha sido creado."
+      },
+      "edition": {
+        "label": "Editar Dashboard",
+        "confirmation": "Los cambios en el dashboard <code>{title}</code> se han guardado.",
+        "chart": "Editar este gráfico",
+        "id readonly": "La propiedad `id` no se puede cambiar — ahora está establecida en sus valores iniciales. Si deseas cambiarla, puedes crear un nuevo dashboard y eliminar el antiguo."
+      },
+      "deletion": {
+        "confirmation": "¿Está seguro de que desea eliminar el dashboard <code>{title}</code>?"
+      },
+      "no_description": "Sin descripción",
+      "no_description_hint": "Agrega una descripción a este flow para documentar qué hace.<br>Markdown es compatible.",
+      "others": "Otros",
+      "viewAll": "Ver todo",
+      "chart_preview": "Haz clic en un código fuente del gráfico para ver su vista previa",
+      "export": "Exportar a CSV",
+      "quick_filters": {
+        "all": "Todos",
+        "running": "En ejecución",
+        "paused": "Pausado",
+        "success": "Éxito",
+        "warning": "Advertencia",
+        "failed": "Fallido"
+      }
     },
     "setup": {
-      "config": {
-        "basicauth": "Autenticación básica",
-        "queue": "Cola",
-        "repository": "Base de datos",
-        "storage": "Almacenamiento Interno"
+      "login": "Iniciar sesión",
+      "login_title": "Iniciar sesión",
+      "logout": "Cerrar sesión",
+      "troubleshooting": "¿Olvidaste la contraseña?",
+      "steps": {
+        "user": "Crear usuario administrador",
+        "config": "Validar Configuración",
+        "survey": "Cuéntanos más",
+        "complete": "Iniciar Kestra UI"
       },
-      "confirm": {
-        "config_title": "Confirme que la configuración es válida",
-        "confirm": "Crear usuario administrador",
-        "not_valid": "No, no es válido",
-        "valid": "Sí, es válido"
+      "titles": {
+        "user": "Crear un usuario administrador",
+        "survey": "Ayúdanos a mejorar Kestra OSS"
+      },
+      "subtitles": {
+        "user": "Asegura tu instancia para comenzar.",
+        "config": "Aquí están los detalles de tu configuración",
+        "survey": "Lo siento, parece que no se ha proporcionado ningún texto para traducir. Por favor, proporciona el texto que necesitas traducir después de \"----------\".",
+        "complete": "¡Configuración completada con éxito!"
       },
       "form": {
         "email": "Correo electrónico",
@@ -1878,351 +1937,249 @@
         "username": "Nombre de usuario",
         "username_hint": "Debe ser una dirección de correo electrónico válida."
       },
-      "login": "Iniciar sesión",
-      "login_title": "Iniciar sesión",
-      "logout": "Cerrar sesión",
-      "steps": {
-        "complete": "Iniciar Kestra UI",
-        "config": "Validar Configuración",
-        "survey": "Cuéntanos más",
-        "user": "Crear usuario administrador"
-      },
-      "subtitles": {
-        "complete": "¡Configuración completada con éxito!",
-        "config": "Aquí están los detalles de tu configuración",
-        "survey": "Lo siento, parece que no se ha proporcionado ningún texto para traducir. Por favor, proporciona el texto que necesitas traducir después de \"----------\".",
-        "user": "Asegura tu instancia para comenzar."
-      },
-      "success": {
-        "subtitle": "¡Todo listo!",
-        "title": "¡Felicidades!"
-      },
-      "survey": {
-        "company_11_50": "Proyecto personal",
-        "company_1_10": "Aprendizaje / exploración",
-        "company_250_plus": "Despliegue de producción",
-        "company_50_250": "Evaluando para mi equipo/empresa",
-        "company_personal": "Otro",
-        "company_size": "¿Cuál es tu objetivo principal con Kestra?",
-        "continue": "Continuar",
-        "newsletter": "Recibe actualizaciones de productos por correo electrónico.",
-        "newsletter_heading": "Mantente informado",
-        "skip": "Omitir",
-        "use_case": "¿Para qué planeas usarlo?",
-        "use_case_business": "Flujos de trabajo empresariales",
-        "use_case_data": "Flujos de trabajo de datos",
-        "use_case_infrastructure": "Automatización de infraestructura",
-        "use_case_ml": "Canales de ML",
-        "use_case_other": "Otros",
-        "use_case_scheduling": "Programación y trabajos recurrentes"
-      },
-      "titles": {
-        "survey": "Ayúdanos a mejorar Kestra OSS",
-        "user": "Crear un usuario administrador"
-      },
-      "troubleshooting": "¿Olvidaste la contraseña?",
       "validation": {
-        "config_message": "Asegúrate de actualizar tu configuración para corregir este mensaje de error",
-        "email_invalid": "Correo electrónico no válido",
         "email_required": "Se requiere el email",
+        "email_invalid": "Correo electrónico no válido",
         "email_temporary_not_allowed": "No se permiten direcciones de correo electrónico temporales o desechables.",
         "firstName_required": "Nombre requerido",
-        "incorrect_creds": "Nombre de usuario o contraseña inválidos. Asegúrate de que tus credenciales sean correctas.",
         "lastName_required": "Apellido requerido",
         "password_invalid": "Contraseña inválida",
-        "password_required": "La contraseña es obligatoria"
+        "password_required": "La contraseña es obligatoria",
+        "incorrect_creds": "Nombre de usuario o contraseña inválidos. Asegúrate de que tus credenciales sean correctas.",
+        "config_message": "Asegúrate de actualizar tu configuración para corregir este mensaje de error"
+      },
+      "config": {
+        "repository": "Base de datos",
+        "queue": "Cola",
+        "storage": "Almacenamiento Interno",
+        "basicauth": "Autenticación básica"
+      },
+      "confirm": {
+        "confirm": "Crear usuario administrador",
+        "config_title": "Confirme que la configuración es válida",
+        "not_valid": "No, no es válido",
+        "valid": "Sí, es válido"
+      },
+      "survey": {
+        "skip": "Omitir",
+        "company_size": "¿Cuál es tu objetivo principal con Kestra?",
+        "company_1_10": "Aprendizaje / exploración",
+        "company_11_50": "Proyecto personal",
+        "company_50_250": "Evaluando para mi equipo/empresa",
+        "company_250_plus": "Despliegue de producción",
+        "company_personal": "Otro",
+        "use_case": "¿Para qué planeas usarlo?",
+        "use_case_infrastructure": "Automatización de infraestructura",
+        "use_case_business": "Flujos de trabajo empresariales",
+        "use_case_data": "Flujos de trabajo de datos",
+        "use_case_ml": "Canales de ML",
+        "use_case_scheduling": "Programación y trabajos recurrentes",
+        "use_case_other": "Otros",
+        "newsletter_heading": "Mantente informado",
+        "newsletter": "Recibe actualizaciones de productos por correo electrónico.",
+        "continue": "Continuar"
+      },
+      "success": {
+        "title": "¡Felicidades!",
+        "subtitle": "¡Todo listo!"
       }
     },
-    "show": "Mostrar",
-    "show chart": "Mostrar Gráfico",
-    "show description": "Mostrar una descripción",
-    "show details": "Mostrar detalles",
-    "show documentation": "Mostrar documentación",
-    "show more details": "Mostrar más detalles",
-    "show raw": "Show raw",
-    "show task condition": "Mostrar condición de task",
-    "show task documentation": "Mostrar documentación de la task",
-    "show task documentation in editor": "Mostrar documentación de la task en el editor",
-    "show task logs": "Mostrar task logs",
-    "show task outputs": "Mostrar salidas de tarea",
-    "show task source": "Mostrar fuente de tarea",
-    "showLess": "Mostrar menos",
-    "showMore": "Mostrar más",
-    "side-by-side": "lado a lado",
-    "similar lines": "similar lines",
-    "skipped": "Omitido",
-    "slack support": "Haz cualquier pregunta vía Slack",
-    "something_went_wrong": {
-      "connection_lost": {
-        "message": "No pudimos alcanzar tu instancia de Kestra. Asegúrate de que esté en ejecución, luego actualiza la página.",
-        "title": "Conexión interrumpida"
+    "ai": {
+      "flow": {
+        "title": "Agente de IA",
+        "prompt_placeholder": "Ingrese instrucciones para crear su flow de Kestra. Ejemplo de solicitud: Crear un flow que se ejecute todos los lunes a las 9 AM.",
+        "select_provider": "Seleccionar un proveedor",
+        "generating": {
+          "flow": "Generando YAML de Flow para ti...",
+          "dashboard": "Generando Dashboard YAML para ti...",
+          "app": "Generando YAML de la aplicación para ti...",
+          "test": "Generando YAML de prueba para ti..."
+        },
+        "enable_instructions": {
+          "header": "<b>AI Copilot aún no ha sido configurado.</b>\n\nPara habilitar AI Copilot, añade el siguiente fragmento a tu archivo de configuración de la instancia de Kestra (por ejemplo, <code>application.yml</code>), reemplazando <code>geminiApiKey</code> con tu key real:",
+          "footer": "Nota: En este momento, solo se admite Gemini como proveedor de AI para la Edición de Código Abierto. Para la Edición Empresarial, consulte la documentación de AI Copilot para la configuración de otros proveedores de modelos.\n\nReinicie su instancia de Kestra después de guardar la configuración."
+        }
       },
-      "loading_execution": "Algo salió mal al cargar la ejecución."
+      "dashboard": {
+        "prompt_placeholder": "Haz una pregunta sobre tus datos. Ejemplo de solicitud: Muéstrame la tasa de éxito de mis flows en los últimos 7 días."
+      }
     },
-    "source": "Fuente",
-    "source and blueprints": "Fuente y blueprints",
-    "source and doc": "Fuente y documentación",
-    "source and topology": "Fuente y topología",
-    "source only": "Solo fuente",
-    "source search": "Búsqueda de fuente",
-    "source_search": {
-      "match_count": "{count} coincidencia | {count} coincidencias",
-      "open_flow": "Abrir flow",
-      "preview_empty": "Selecciona un resultado para previsualizarlo. Haz clic en un flow de la lista de resultados para ver su código fuente.",
-      "preview_error": "Error al cargar el código fuente del flow"
+    "playground": {
+      "title": "Área de Pruebas",
+      "run_task_info": "Pasa el cursor sobre cualquier task en el editor de Flow Code y haz clic en el botón \"Run task\" para probar tu task.",
+      "play_icon_info": "También puedes presionar el ícono de Play en las vistas No-Code o Topology.",
+      "toggle": "Área de pruebas",
+      "run_task": "Ejecutar Task",
+      "run_this_task": "Ejecutar esta task",
+      "run_task_and_downstream": "Ejecutar task y downstream",
+      "run_all_tasks": "Ejecutar Todas las Tasks",
+      "history": "Últimas 10 ejecuciones",
+      "clear_history": "Borrar historial",
+      "confirm_create": "No puedes ejecutar el playground mientras creas un flow. Iniciar una ejecución de playground creará el flow.",
+      "tooltip_persistence": "Si desactivas y vuelves a activar el Playground, la información permanece mientras te mantengas en la página."
     },
-    "specific task": "Tarea específica",
-    "start date": "Fecha de inicio",
-    "start datetime": "Fecha y hora de inicio",
-    "started date": "Fecha de inicio",
-    "state": "Estado",
-    "state updated date": "Fecha de actualización del estado",
-    "state_history": "Historial de estado",
-    "stats": "Estadísticas",
-    "steps": "Pasos",
-    "stream": "Stream",
-    "sub flow": "Subflow",
     "submit": "Enviar",
-    "success": "Éxito",
-    "sum": "Suma",
-    "switch-view": "Cambiar vista",
-    "system overview": "Visión General del Sistema",
-    "system_namespace": "Mantén tu plataforma bajo control con los system flows.",
-    "system_namespace_description": "Automatiza tareas de mantenimiento, desde alertas de fallo hasta limpiezas automatizadas.",
-    "tags": "Etiquetas",
-    "task": "Tarea",
-    "task failed": "Tarea FAILED",
-    "task id": "Task ID",
-    "task id already exists": "Task Id ya existe",
-    "task is running": "La tarea está RUNNING",
-    "task logs": "Task logs",
-    "task run id": "ID de TaskRun",
-    "task sent a warning": "La task envió un WARNING",
-    "task was skipped": "La task fue omitida",
-    "task was successful": "La tarea fue exitosa",
-    "taskDefaults": "Predeterminados de la task",
-    "taskRunners": "Ejecutores de Task",
-    "task_id_exists": "El Id de Task ya existe",
-    "task_id_message": "El Task Id ${existingTask} ya existe en el flow.",
-    "taskid column details": "Última task siendo ejecutada y su número de intentos.",
-    "tasks": "Tareas",
-    "template": "Plantilla",
-    "template creation": "Creación de plantilla",
-    "template delete": "¿Estás seguro de que quieres eliminar <code>{templateCount}</code> plantilla(s)?",
-    "template export": "¿Estás seguro de que quieres exportar <code>{templateCount}</code> plantilla(s)?",
-    "templates": "Plantillas",
-    "templates deleted": "<code>{count}</code> Plantilla(s) eliminadas",
-    "templates deprecated": "Las plantillas están obsoletas. Por favor usa subflows en su lugar. Consulta la <a href=\"https://kestra.io/docs/migration-guide/0.11.0/templates?utm_source=app&utm_medium=referral&utm_campaign=template-inlinedoc\" target=\"_blank\">sección de Migraciones</a> que explica cómo puedes migrar de plantillas a subflows.",
-    "templates exported": "Plantillas exportadas",
-    "tenant": {
-      "name": "Mandante",
-      "names": "Arrendatarios"
-    },
-    "tenantId": "ID de Mandante",
-    "test-badge-text": "Prueba",
-    "test-badge-tooltip": "Esta ejecución fue creada por una prueba",
-    "theme": "Tema",
-    "this_task_has": "Esta tarea tiene",
-    "timezone": "Zona horaria",
-    "title": "Título",
-    "to": "Hasta",
     "to toggle": "para alternar",
-    "toggle fullscreen": "Alternar pantalla completa",
-    "toggle menu": "Alternar menú",
-    "toggle output": "Alternar salidas",
-    "toggle output display": "Alternar visualización de salida",
-    "toggle periodic refresh each x seconds": "Alternar actualización periódica cada {interval} segundos",
-    "toggle_word_wrap": "Alternar ajuste de línea",
-    "topology": "Topología",
-    "topology-graph": {
-      "graph-orientation": "Orientación del gráfico",
-      "invalid": "Error de gráfico",
-      "invalid_description": "Ocurrió un error al cargar el gráfico. Por favor, verifica el código fuente en busca de errores.",
-      "zoom-fit": "Ajustar",
-      "zoom-in": "Acercar",
-      "zoom-out": "Alejar",
-      "zoom-reset": "Restablecer zoom"
-    },
-    "total_duration": "Duración total",
-    "total_executions": "Total de Ejecuciones",
-    "trigger": "Trigger",
-    "trigger details": "Detalles del trigger",
-    "trigger disabled": "El trigger está deshabilitado dentro del Flow source",
-    "trigger execution id": "Trigger Execution Id",
-    "trigger filter": {
-      "options": {
-        "ALL": "Todas las Ejecuciones",
-        "CHILD": "Ejecuciones Hijas",
-        "MAIN": "Ejecuciones Padres"
+    "accept": "Aceptar",
+    "reject": "Rechazar",
+    "draft_available": "El cambio en borrador está disponible en el editor",
+    "last modified": "Última modificación",
+    "run task in playground": "Ejecutar task en el playground",
+    "task is running": "La tarea está RUNNING",
+    "task was successful": "La tarea fue exitosa",
+    "task failed": "Tarea FAILED",
+    "task was skipped": "La task fue omitida",
+    "task sent a warning": "La task envió un WARNING",
+    "defaultsToNamespaceFile": "Por defecto en el archivo de namespace: <code>{name}</code>",
+    "no_file_choosen": "No se ha elegido archivo",
+    "dependency": {
+      "controls": {
+        "zoom_in": "Acercar",
+        "zoom_out": "Alejar",
+        "clear_selection": "Borrar selección",
+        "fit_view": "Ajustar a la pantalla"
       },
-      "title": "Filtrar ejecuciones hijas"
-    },
-    "trigger refresh": "Actualizar trigger",
-    "triggerId": "ID del Trigger",
-    "trigger_check_warning": "Al usar variables de trigger no funcionará con la ejecución manual de flow. Agrega el operador de coalescencia `??` para resolver el problema. Por ejemplo, en lugar de `trigger.date`, usa `trigger.date ?? execution.startDate`.",
-    "trigger_id_exists": "El Trigger Id ya existe",
-    "trigger_id_message": "El Trigger Id ${existingTrigger} ya existe en el flow.",
-    "trigger_states": "Estados",
-    "triggered": "Trigger de ejecución",
-    "triggered done": "Ejecución <em>{name}</em> se ha activado exitosamente",
-    "triggerflow disabled": "El trigger está deshabilitado en la definición del flujo",
-    "triggers": "Triggers",
-    "triggers_add_card_add": "Agregar",
-    "triggers_add_card_add_to_flow": "Agregar al flow",
-    "triggers_add_category_empty": "No hay triggers en esta categoría.",
-    "triggers_add_ee_tooltip": "Este trigger requiere la Enterprise Edition.",
-    "triggers_add_empty_title": "No se encontraron triggers",
-    "triggers_add_filter_all": "Todo",
-    "triggers_add_filter_app": "Aplicación",
-    "triggers_add_filter_core": "Núcleo",
-    "triggers_add_filter_realtime": "Tiempo real",
-    "triggers_add_modal_add_button": "Agregar Trigger al Flow",
-    "triggers_add_modal_ee_notice": "Este trigger requiere Enterprise Edition.",
-    "triggers_add_modal_flow_placeholder": "Seleccione un flow",
-    "triggers_add_modal_namespace_placeholder": "Seleccione un namespace",
-    "triggers_add_modal_properties_hint": "Configura las propiedades del trigger en el editor de flow después de añadir el trigger.",
-    "triggers_add_modal_tab_documentation": "Documentación",
-    "triggers_add_modal_tab_form": "Formulario",
-    "triggers_add_modal_tab_source": "Origen",
-    "triggers_add_modal_title": "{name}",
-    "triggers_add_modal_trigger_id": "ID de Trigger",
-    "triggers_add_modal_trigger_id_placeholder": "Identificador único para este trigger",
-    "triggers_add_search_placeholder": "Buscar triggers...",
-    "triggers_header_description": "Navega, añade y gestiona triggers para automatizar tus flows. Elige entre exponer tu flow como una herramienta de IA, programar, añadir un webhook trigger, sondear cambios en aplicaciones externas o escuchar eventos en tiempo real.",
-    "triggers_state": {
-      "options": {
-        "disabled": "Deshabilitado",
-        "enabled": "Habilitado"
-      },
-      "state": "Estado"
-    },
-    "triggers_tabs_add": "Agregar",
-    "triggers_tabs_manage": "Administrar",
-    "true": "Verdadero",
-    "type": "Tipo",
-    "unable to generate graph": "Ocurrió un problema al generar el gráfico que impide que se muestre la topología.",
-    "undefined": "Indefinido",
-    "unlock": "Desbloquear",
-    "unlock trigger": {
-      "button": "Desbloquear trigger",
-      "confirmation": "¿Estás seguro de que quieres desbloquear el trigger?",
-      "success": "Trigger desbloqueado",
-      "tooltip": {
-        "evaluation": "El trigger está actualmente en evaluación",
-        "execution": "Hay una ejecución en curso para este trigger"
-      },
-      "warning": "Podría llevar a ejecuciones concurrentes para el mismo trigger y debe considerarse como una opción de último recurso."
-    },
-    "unqueue": "Desencolar",
-    "unqueue as": "Desencolar como <code>{status}</code>",
-    "unqueue confirm": "¿Está seguro de descolar la ejecución <code>{id}</code>?",
-    "unqueue done": "La ejecución está descolada",
-    "unqueue title": "Desencolar ejecución <code>{id}</code>.<br/>Tenga en cuenta que no respetará el límite de concurrencia del flow, por lo que podrían estar ejecutándose más ejecuciones de las permitidas.",
-    "unqueue title multiple": "¿Está seguro de que desea descolar <code>{count}</code> ejecuciones?<br/><br/>Tenga en cuenta que no respetará el límite de concurrencia del flow, por lo que podrían estar ejecutándose más ejecuciones de las permitidas.",
-    "unsaved changed ?": "Tienes cambios no guardados, ¿quieres salir de esta página?",
-    "unsaved changes": "Cambios no guardados",
-    "unsaved changes warning": "Tienes cambios no guardados. Si abandonas esta página, tus cambios se perderán.",
-    "up trend": "Aumentando",
-    "update": "Actualizar",
-    "update aborted": "actualización abortada",
-    "update ok": "está actualizado",
-    "updated date": "Fecha de actualización",
-    "usage": "Uso",
-    "use": "Usar",
-    "use_dark_background": "Utiliza esta versión cuando trabajes sobre un fondo oscuro para asegurar que nuestro nombre permanezca legible.",
-    "valid": "Válido",
-    "validate": "Validar",
-    "value": "Value",
-    "variable_explorer": {
-      "empty": "No hay variables disponibles para esta ejecución.",
-      "n_items": "[ {count} elementos ]",
-      "n_keys": "\\{ {count} keys \\}",
-      "one_item": "[ 1 elemento ]",
-      "one_key": "\\{ 1 key \\}",
-      "raw_json": "Raw JSON",
-      "search_placeholder": "Buscar Key o value...",
-      "select_prompt": "Selecciona una variable para inspeccionar su value.",
-      "tasks_outputs": "Tasks outputs",
-      "title": "Entrada/Salida",
-      "tree": "Árbol"
-    },
-    "variables": "Variables",
-    "version": "Versión",
-    "view metrics": "Ver métricas",
-    "warning": "Advertencia",
-    "warning detected": "Advertencia(s) detectada(s)",
-    "warning flow with triggers": "Este flujo contiene triggers y una ejecución manual fallará si este flujo depende de expresiones de trigger.",
-    "watch": "Ver",
-    "watch_video": "Ver Video",
-    "webhook": {
-      "copy_url": "Copiar URL del webhook",
-      "curl_command": "Comando cURL de Webhook",
-      "curl_note": "Utiliza este comando cURL para trigger el flow a través de webhook con carga útil JSON personalizada",
-      "no_triggers": "Este flow no tiene triggers de webhook habilitados",
-      "payload": "Payload de Webhook (JSON)"
-    },
-    "webhook link copied": "Enlace de Webhook copiado.",
-    "welcome": {
-      "help": {
-        "text": "Haz cualquier pregunta en nuestra comunidad de Slack. Si estás atascado, estamos aquí para ayudarte. ✋",
-        "title": "¿Necesitas ayuda?"
-      },
-      "menu": "Welcome",
-      "tour": {
-        "text": "Elige tu caso de uso y sigue una guía paso a paso para aprender las características y capacidades de Kestra. ❤️",
-        "title": "Realiza un recorrido por el producto"
-      },
-      "tutorial": {
-        "text": "* <a href=\"https://kestra.io/tutorial-videos/all?utm_source=app&utm_medium=referral&utm_campaign=welcome-tutorial\" target=\"_blank\">Tutoriales en Video</a>  \n* <a href=\"https://kestra.io/docs?utm_source=app&utm_medium=referral&utm_campaign=welcome-tutorial\" target=\"_blank\">Documentación</a>  \n* <a href=\"https://kestra.io/blueprints?utm_source=app&utm_medium=referral&utm_campaign=welcome-tutorial\" target=\"_blank\">Blueprints</a>",
-        "title": "Tutorial"
+      "search": {
+        "placeholders": {
+          "default": "Buscar por flow o namespace...",
+          "asset": "Buscar por asset, flow o namespace..."
+        },
+        "namespace": {
+          "select": "Seleccione un namespace",
+          "no_namespace": "Sin namespace"
+        },
+        "flow": {
+          "display": "Incluir dependencias del flow"
+        },
+        "no_results": "No se encontraron resultados para {term}"
       }
     },
+    "preview": {
+      "label": "Vista previa",
+      "force-editor": "Forzar vista del editor",
+      "auto-view": "Vista automática",
+      "view": "Ver",
+      "rows_truncated": "Mostrando {shown} de {total} filas. Descargue el archivo para ver todos los datos.",
+      "pagination_info": "Mostrando filas {start}-{end} de {total}.",
+      "showing_rows": "Mostrando filas {start}-{end} de {total}",
+      "expand": "Desplegar",
+      "collapse": "Contraer",
+      "previous": "Anterior",
+      "next": "Siguiente",
+      "page_of": "Página {current} de {total}"
+    },
+    "delete trigger": "Eliminar trigger",
+    "delete triggers": "Eliminar triggers",
+    "bulk delete triggers": "¿Está seguro de que desea eliminar {count} triggers?",
+    "bulk success delete triggers": "{count} triggers han sido eliminados exitosamente",
+    "delete trigger confirmation": "¿Está seguro de que desea eliminar el trigger {id}? WARNING: eliminar un trigger puede llevar a ejecuciones duplicadas si el trigger aún está activo en un flow.",
+    "delete trigger success": "El trigger {id} ha sido eliminado con éxito",
+    "delete trigger error": "Error al eliminar trigger {id}",
+    "revision deleted": "La revisión {revision} ha sido eliminada con éxito",
+    "delete revision confirm": "¿Está seguro de que desea eliminar la revisión {revision}?",
+    "delete revision error": "Error al eliminar la revisión {revision} con el error {error}",
+    "no_history": "No hay historial disponible",
+    "export_as": "Exportar como .{format}",
+    "save_and_execute": "Guardar y Ejecutar",
     "welcome_copilot": {
       "button_cta": "Crear flow desde cero",
       "create_manually": {
-        "description": "Construir desde cero usando el editor",
-        "title": "Crear manualmente"
+        "title": "Crear manualmente",
+        "description": "Construir desde cero usando el editor"
       },
       "docs": {
-        "description": "Aprende más en la documentación oficial",
-        "title": "Lee la documentación"
+        "title": "Lee la documentación",
+        "description": "Aprende más en la documentación oficial"
       },
+      "title": "Convierte tu idea en un flujo de trabajo",
+      "need_help": "¿Necesitas ayuda?",
+      "placeholder_prompt": "Envíame un mensaje de saludo diario a las 9am.",
+      "show_more": "Mostrar más indicaciones",
+      "show_less": "Mostrar menos mensajes",
+      "remaining_quota": "Te quedan {count} generaciones de IA. El límite se restablece diariamente a medianoche UTC.",
       "execute_hint": {
-        "description": "Haz clic para guardar tu flujo de trabajo y ejecutarlo inmediatamente.",
-        "title": "Guardar y ejecutar tu flow"
+        "title": "Guardar y ejecutar tu flow",
+        "description": "Haz clic para guardar tu flujo de trabajo y ejecutarlo inmediatamente."
+      },
+      "success_popup": {
+        "title": "¡Felicidades!",
+        "description": "¡Has ejecutado con éxito tu primer flow! Estás en camino de convertirte en un experto en Kestra.",
+        "tutorial": "Tutorial de inmersión profunda",
+        "explore": "Explorar más"
+      },
+      "success_page": {
+        "title": "¡Todo listo!",
+        "description": "Has aprendido lo básico de Kestra. Aquí tienes algunos recursos para ayudarte a continuar tu viaje.",
+        "restart": "Reiniciar Tutorial",
+        "items": {
+          "tutorial": {
+            "title": "Iniciar un Tutorial",
+            "description": "Recorrido interactivo de todas las funciones de Kestra"
+          },
+          "blueprints": {
+            "title": "Planos",
+            "description": "Plantillas de flujo de trabajo preconstruidas para casos de uso comunes"
+          },
+          "slack": {
+            "title": "Comunidad de Slack",
+            "description": "Conéctate con otros usuarios y obtén ayuda de la comunidad"
+          },
+          "videos": {
+            "title": "Tutoriales de Videos",
+            "description": "Guías en video paso a paso para funciones avanzadas"
+          },
+          "demo": {
+            "title": "Solicitar una Demo",
+            "description": "Explore Kestra Enterprise Edition con una demostración personalizada"
+          }
+        }
+      },
+      "help": {
+        "tutorial": {
+          "title": "Iniciar un Tutorial",
+          "description": "Aprende cómo crear y ejecutar tu primer flow con pasos guiados."
+        },
+        "blueprints": {
+          "title": "Planos",
+          "description": "Explore ejemplos y plantillas listos para usar para patrones comunes de workflow."
+        },
+        "slack": {
+          "title": "Comunidad de Slack",
+          "description": "Únete a nosotros para compartir ideas y mejores prácticas, y obtener ayuda con preguntas técnicas."
+        }
       },
       "flows": {
-        "buildDbtPipeline": {
-          "label": "Construir un pipeline de dbt",
-          "prompt": "Crea un flow de Kestra que clone un repositorio de proyecto dbt y ejecute dbt build con un perfil de DuckDB."
-        },
-        "buildDockerImageAndRunIt": {
-          "label": "Construir una imagen de Docker y ejecutarla",
-          "prompt": "Crea un flow de Kestra que construya una imagen de Docker a partir de un Dockerfile en línea y ejecute el contenedor resultante."
-        },
-        "convertCsvToExcel": {
-          "label": "Convertir un CSV a Excel",
-          "prompt": "Crea un flow que descargue un archivo CSV, lo convierta a Ion y exporte el resultado como un archivo Excel."
-        },
-        "etlWorkflow": {
-          "label": "Flujo de trabajo ETL",
-          "prompt": "Crea un flow ETL que descargue datos JSON, los procese con Python y consulte el resultado transformado con DuckDB."
+        "jsonApiToDuckdb": {
+          "label": "API JSON a DuckDB",
+          "prompt": "Crea un flow que descargue un archivo JSON desde una API pública, lo transforme con un script de Python y lo procese con una tarea de DuckDB Queries."
         },
         "installNginxViaAnsible": {
           "label": "Instalar Nginx a través de Ansible",
           "prompt": "Crea un flow de Kestra que instale Nginx en una máquina objetivo con Ansible y verifique la versión instalada."
         },
-        "jsonApiToDuckdb": {
-          "label": "API JSON a DuckDB",
-          "prompt": "Crea un flow que descargue un archivo JSON desde una API pública, lo transforme con un script de Python y lo procese con una tarea de DuckDB Queries."
+        "buildDbtPipeline": {
+          "label": "Construir un pipeline de dbt",
+          "prompt": "Crea un flow de Kestra que clone un repositorio de proyecto dbt y ejecute dbt build con un perfil de DuckDB."
+        },
+        "etlWorkflow": {
+          "label": "Flujo de trabajo ETL",
+          "prompt": "Crea un flow ETL que descargue datos JSON, los procese con Python y consulte el resultado transformado con DuckDB."
+        },
+        "microservicesApis": {
+          "label": "Microservicios y APIs",
+          "prompt": "Crea un flow que verifique la respuesta de la API de un sitio web y envíe una alerta de Slack cuando el código de estado no sea exitoso."
+        },
+        "buildDockerImageAndRunIt": {
+          "label": "Construir una imagen de Docker y ejecutarla",
+          "prompt": "Crea un flow de Kestra que construya una imagen de Docker a partir de un Dockerfile en línea y ejecute el contenedor resultante."
         },
         "manualApproval": {
           "label": "Aprobación manual",
           "prompt": "Crea un flow con un paso de procesamiento inicial, una pausa para aprobación manual y un paso final de despliegue después de la aprobación."
         },
-        "microservicesApis": {
-          "label": "Microservicios y APIs",
-          "prompt": "Crea un flow que verifique la respuesta de la API de un sitio web y envíe una alerta de Slack cuando el código de estado no sea exitoso."
+        "convertCsvToExcel": {
+          "label": "Convertir un CSV a Excel",
+          "prompt": "Crea un flow que descargue un archivo CSV, lo convierta a Ion y exporte el resultado como un archivo Excel."
         },
         "scheduledPdfReports": {
           "label": "Informes PDF programados",
@@ -2232,73 +2189,116 @@
           "label": "KPIs de Ventas Semanales a Slack",
           "prompt": "Crea un flow programado semanalmente que calcule los KPIs de ventas con DuckDB y publique el resumen en Slack."
         }
-      },
-      "help": {
-        "blueprints": {
-          "description": "Explore ejemplos y plantillas listos para usar para patrones comunes de workflow.",
-          "title": "Planos"
-        },
-        "slack": {
-          "description": "Únete a nosotros para compartir ideas y mejores prácticas, y obtener ayuda con preguntas técnicas.",
-          "title": "Comunidad de Slack"
-        },
-        "tutorial": {
-          "description": "Aprende cómo crear y ejecutar tu primer flow con pasos guiados.",
-          "title": "Iniciar un Tutorial"
-        }
-      },
-      "need_help": "¿Necesitas ayuda?",
-      "placeholder_prompt": "Envíame un mensaje de saludo diario a las 9am.",
-      "remaining_quota": "Te quedan {count} generaciones de IA. El límite se restablece diariamente a medianoche UTC.",
-      "show_less": "Mostrar menos mensajes",
-      "show_more": "Mostrar más indicaciones",
-      "success_page": {
-        "description": "Has aprendido lo básico de Kestra. Aquí tienes algunos recursos para ayudarte a continuar tu viaje.",
-        "items": {
-          "blueprints": {
-            "description": "Plantillas de flujo de trabajo preconstruidas para casos de uso comunes",
-            "title": "Planos"
-          },
-          "demo": {
-            "description": "Explore Kestra Enterprise Edition con una demostración personalizada",
-            "title": "Solicitar una Demo"
-          },
-          "slack": {
-            "description": "Conéctate con otros usuarios y obtén ayuda de la comunidad",
-            "title": "Comunidad de Slack"
-          },
-          "tutorial": {
-            "description": "Recorrido interactivo de todas las funciones de Kestra",
-            "title": "Iniciar un Tutorial"
-          },
-          "videos": {
-            "description": "Guías en video paso a paso para funciones avanzadas",
-            "title": "Tutoriales de Videos"
-          }
-        },
-        "restart": "Reiniciar Tutorial",
-        "title": "¡Todo listo!"
-      },
-      "success_popup": {
-        "description": "¡Has ejecutado con éxito tu primer flow! Estás en camino de convertirte en un experto en Kestra.",
-        "explore": "Explorar más",
-        "title": "¡Felicidades!",
-        "tutorial": "Tutorial de inmersión profunda"
-      },
-      "title": "Convierte tu idea en un flujo de trabajo"
+      }
     },
-    "welcome_page": {
-      "guide": "¿Necesitas orientación para ejecutar tu primer flow?",
-      "welcome": "Bienvenido a Kestra"
+    "mcp": {
+      "your_servers": "Sus Servidores",
+      "servers_count": "{{count}} Servidores MCP",
+      "managed_by_kestra": "Gestionado por Kestra",
+      "servers": "Servidores MCP",
+      "server": "Servidor MCP",
+      "client_setup": "Configuración del cliente",
+      "page_description": "Exponga sus flows de Kestra como herramientas para agentes de IA compatibles con MCP",
+      "create": "Crear Servidor",
+      "save": "Guardar cambios",
+      "connect": "Conectar",
+      "copy_url": "Copiar URL",
+      "url_copied": "¡URL copiada!",
+      "instructions": "Instrucciones",
+      "server_type": "Tipo de Servidor",
+      "auth_type": "Autenticación",
+      "private": "Privado",
+      "private_server": "Servidor privado",
+      "public": "Público",
+      "public_hint": "Advertencia: Los servidores públicos no requieren autenticación. Cualquiera con la URL puede invocar cada herramienta expuesta por este servidor, sin namespace ni comprobaciones de permisos. Úselo solo para servidores seguros de exponer externamente.",
+      "basic_auth": "Autenticación Básica",
+      "api_token": "Token de API",
+      "oauth": "OAuth",
+      "username_password": "Nombre de usuario y contraseña",
+      "bearer_token": "Autenticación de token Bearer",
+      "oauth_hint": "JWT Bearer de su proveedor OIDC",
+      "oauth_provider": "Proveedor OAuth",
+      "oauth_provider_placeholder": "Seleccione un proveedor OIDC configurado",
+      "oauth_provider_required": "El proveedor OAuth es obligatorio cuando el tipo de autenticación es OAuth",
+      "scopes_supported": "Scopes admitidos",
+      "scopes_supported_placeholder": "openid, profile, email",
+      "scopes_supported_hint": "Scopes anunciados en el documento Protected Resource Metadata de este servidor. Los clientes MCP que cumplen con la especificación limitan su solicitud de autorización a esta lista. Déjelo vacío para omitir el campo y dejar que los clientes utilicen los scopes anunciados por el IdP.",
+      "no_oauth_providers": "No hay proveedores OIDC configurados en esta instancia",
+      "delete_confirm": "¿Está seguro de que desea eliminar este servidor MCP?",
+      "no_servers": "No se encontraron servidores MCP. Cree su primer servidor para exponer los triggers de la herramienta MCP a agentes de IA externos.",
+      "server_id": "ID del servidor",
+      "id_placeholder": "p. ej. my-mcp-server",
+      "id_invalid": "El id debe comenzar con una letra minúscula o un dígito, y contener solo letras minúsculas, dígitos, guiones o guiones bajos.",
+      "main_tenant": "principal",
+      "tab_edit": "Editar",
+      "tab_connect": "Conectar",
+      "tab_tool_flows": "Flujos de Herramientas",
+      "tab_tool_flows_placeholder": "La gestión de flows de herramientas llegará pronto.",
+      "tools": {
+        "no_tools": "No hay flows de herramientas que coincidan con tu búsqueda.",
+        "create_tool_flow": "Crear un flow de herramienta",
+        "tool_name": "Nombre de la herramienta",
+        "trigger_id": "ID del trigger",
+        "title": "Título",
+        "description": "Descripción",
+        "annotations": "Anotaciones",
+        "flow": "flow",
+        "state": "Estado",
+        "read_only": "Solo lectura",
+        "open_world": "Open world",
+        "destructive": "Destructivo",
+        "idempotent": "Idempotente",
+        "return_direct": "Retorno directo",
+        "view_flow": "Abrir flow"
+      },
+      "connect_tab": {
+        "server_url": "URL del servidor",
+        "client_picker_label": "Elija su cliente de IA",
+        "claude_desktop": "Claude Desktop",
+        "claude_desktop_hint": "Agrega lo siguiente a tu archivo claude_desktop_config.json:",
+        "claude_desktop_mac": "macOS: ~/Library/Application Support/Claude/claude_desktop_config.json",
+        "claude_desktop_win": "Windows: %APPDATA%\\Claude\\claude_desktop_config.json",
+        "claude_code": "Código Claude",
+        "claude_code_hint": "Ejecute el siguiente comando en su terminal:",
+        "cursor": "Cursor",
+        "cursor_hint": "Agrega lo siguiente a ~/.cursor/mcp.json:",
+        "codex": "Codex (OpenAI)",
+        "codex_hint": "Agrega lo siguiente a tu configuración MCP en codex.json:",
+        "auth_basic_hint": "Configure <code>KESTRA_BASIC_AUTH</code> como variable de entorno que contenga una cadena <code>username:password</code> codificada en base64 antes de iniciar el cliente.",
+        "auth_api_token_hint": "Configure <code>KESTRA_TOKEN</code> como variable de entorno antes de iniciar el cliente.",
+        "auth_oauth_client_id_hint": "Reemplace <code>&lt;client-id&gt;</code> con el ID de cliente OAuth y registre <code>http://localhost:7777</code> como URI de redirección válida en ese cliente.",
+        "auth_oauth_browser_hint": "Su navegador abrirá la página de inicio de sesión del proveedor de identidad en la primera conexión."
+      }
     },
-    "wordmark_colors": "Los colores del logotipo se adaptan según el fondo, mientras que el icono permanece sin fondo cuando se coloca sobre un fondo oscuro.",
-    "worker group": "Grupo de Workers",
-    "worker group fallback": "Grupo de Worker de respaldo",
-    "worker group key": "Clave del grupo de Worker",
-    "worker information": "Información del Worker",
-    "workerId": "Worker Id",
-    "workers": "Workers",
-    "wrong labels": "No se permite una key o value vacía en las etiquetas",
-    "yes": "Sí"
+    "flow_editor_stats": {
+      "revisions": {
+        "suffix": "Revisión(es)",
+        "tooltip": "Ver revisiones de flow"
+      },
+      "dependencies": {
+        "suffix": "Dependencias",
+        "tooltip": "Ver dependencias del flow"
+      },
+      "apps": {
+        "suffix": "Aplicación(es)",
+        "tooltip": "Ver aplicaciones que usan este flow"
+      },
+      "tests": {
+        "suffix": "Prueba(s)",
+        "tooltip": "Ver pruebas de flow"
+      },
+      "errors": {
+        "label": "{count} Error(es)"
+      }
+    },
+    "source_search": {
+      "match_count": "{count} coincidencia | {count} coincidencias",
+      "open_flow": "Abrir flow",
+      "preview_empty": "Selecciona un resultado para previsualizarlo. Haz clic en un flow de la lista de resultados para ver su código fuente.",
+      "preview_error": "Error al cargar el código fuente del flow"
+    },
+    "open source": "Código Abierto",
+    "pricing": "Precios",
+    "license": "Licencia"
   }
 }

--- a/ui/src/translations/fr.json
+++ b/ui/src/translations/fr.json
@@ -1,1678 +1,722 @@
 {
   "fr": {
-    "Add flow": "Ajouter un flow",
-    "Default log level": "Niveau de log par défaut",
-    "Default namespace": "Espace de nom par défaut",
-    "Default page": "Page par défaut",
-    "Editor fontfamily": "Police de l'éditeur",
-    "Editor fontsize": "Taille de police de l'éditeur",
-    "Editor theme": "Theme de l'éditeur",
-    "Fold auto": "Éditeur : Replier automatiquement le contenu multi-lignes",
-    "Fold content lines": "Replier les multilignes",
-    "Hover description": "Éditeur : Afficher la description du champ lors du survol du key ou value",
-    "Language": "Langue",
-    "Per page": "par page",
-    "Set default page": "Définir la page par défaut",
-    "Set labels": "Ajouter des labels",
-    "Set labels done": "Labels ajoutés avec succès à l'exécution",
-    "Set labels to execution": "Ajouter ou mettre à jour des labels à l'exécution <code>{id}</code>",
-    "Set labels tooltip": "Ajouter des labels à l'exécution",
-    "Task Id already exist in the flow": "L'identifiant {taskId} est déjà utilisé dans le flow.",
-    "Total": "Total",
-    "Unfold content lines": "Déplier les multilignes",
-    "about_this_blueprint": "À propos de ce blueprint",
-    "absolute": "Absolu",
-    "accept": "Accepter",
-    "actions": "Actions",
-    "activate_basic_auth": "Activer l'authentification de base",
-    "active": "Actif",
-    "active-slots": "Slots actifs",
-    "actual state": "État actuel",
-    "add": "Ajouter",
-    "add at position": "Ajouter {position} <code>{task}</code>",
-    "add error handler": "Gérer les erreurs",
-    "add flow": "Ajouter un flow",
+    "loading": "Chargement...",
+    "more actions": "Plus d'actions",
+    "toggle menu": "Basculer le menu",
+    "panel actions": "Actions du panneau",
+    "playground actions": "Actions du Playground",
+    "bulk actions": "Actions en masse",
+    "view metrics": "Voir les métriques",
+    "remove this item": "Supprimer cet élément",
     "add label": "Ajouter un label",
-    "add task": "Ajouter une tâche",
-    "add-trigger-in-editor": "Ajoutez d'abord un Trigger à votre Flow",
-    "add_new_item": "Ajouter un nouvel élément",
-    "additionalPlugins": "Plugins supplémentaires",
-    "admin": "Administrateur",
-    "admin_preferences": "Preferences",
-    "administration": "Administration",
-    "advanced configuration": "Autres propriétés",
-    "after": "après",
-    "aggregation": "Agrégation",
-    "ai": {
-      "dashboard": {
-        "prompt_placeholder": "Posez une question sur vos données. Exemple de demande : Montrez-moi le taux de réussite de mes flows au cours des 7 derniers jours."
+    "remove label": "Supprimer le label",
+    "id": "Identifiant",
+    "type": "Type",
+    "ok": "OK",
+    "valid": "Valide",
+    "close": "Fermer",
+    "namespace": "Espace de nom",
+    "description": "Description",
+    "show description": "Afficher une description",
+    "show details": "Afficher les détails",
+    "show more details": "Afficher plus de détails",
+    "skipped": "Ignoré",
+    "revision": "Révision",
+    "Language": "Langue",
+    "Set default page": "Définir la page par défaut",
+    "theme": "Thème",
+    "flows": "Flows",
+    "flow": "Flow",
+    "invalid source": "Code source invalide",
+    "missingSource": "Source manquant",
+    "update": "Mettre à jour",
+    "update ok": "est mis à jour",
+    "delete ok": "est effacé",
+    "Default page": "Page par défaut",
+    "confirmation": "Confirmation",
+    "common": {
+      "back": "Retour"
+    },
+    "delete confirm": "Êtes-vous sur de vouloir effacer <code>{name}</code> ?",
+    "outdated revision save confirmation": {
+      "confirm": "Êtes-vous sûr de vouloir l'écraser ?",
+      "update": {
+        "title": "Révision dépassée",
+        "description": "Une révision plus récente du Flow existe.",
+        "details": "Regardez l'onglet Révisions pour plus de détails sur la dernière version."
       },
-      "flow": {
-        "enable_instructions": {
-          "footer": "Remarque : Actuellement, seul Gemini est pris en charge comme fournisseur d'IA pour l'édition Open Source. Pour l'édition Enterprise, veuillez vous référer à la documentation AI Copilot pour la configuration d'autres fournisseurs de modèles.\n\nRedémarrez votre instance Kestra après avoir enregistré la configuration.",
-          "header": "<b>AI Copilot n'a pas encore été configuré.</b>\n\nPour activer AI Copilot, ajoutez l'extrait suivant à votre fichier de configuration de l'instance Kestra (par exemple, <code>application.yml</code>), en remplaçant <code>geminiApiKey</code> par votre clé réelle :"
-        },
-        "generating": {
-          "app": "Génération du YAML de l'application pour vous...",
-          "dashboard": "Génération du YAML du tableau de bord pour vous...",
-          "flow": "Génération du YAML de flow pour vous...",
-          "test": "Génération du YAML de test pour vous..."
-        },
-        "prompt_placeholder": "Entrez des instructions pour créer votre flow Kestra. Exemple d'invite : Créez un flow qui s'exécute tous les lundis à 9h.",
-        "select_provider": "Sélectionner un fournisseur",
-        "title": "Agent IA"
+      "create": {
+        "title": "Le flux existe déjà",
+        "description": "Un flow avec le même id existe déjà dans ce namespace.",
+        "details": "Enregistrer pour remplacer et créer une nouvelle révision."
       }
     },
-    "all executions": "Toutes les exécutions",
-    "all tags": "Toutes catégories",
-    "api": "API",
-    "appBlocks": "Blocs d'application",
-    "apps": "Applications",
-    "are you sure change state": "Êtes-vous sûr de vouloir changer l'état ?",
-    "assets": {
-      "title": "Ressources"
+    "override": {
+      "title": "Vous allez écraser le flow actuel",
+      "details": "Le flow précédent peut être restauré depuis l'onglet Revisions."
     },
-    "attempt": "Essai",
-    "attempts": "Tentative(s)",
-    "auditlogs": "Journaux d'audit",
-    "automatic refresh": "rafraîchissement automatique",
-    "avg": "Moyenne",
-    "avg duration": "Durée moyenne d'exécution",
+    "is deprecated": "est déprécié(e)",
+    "success": "Succès",
+    "save": "Enregistrer",
+    "save_as_draft": "Enregistrer comme brouillon",
+    "draft": "Brouillon",
+    "draft_flow_warning": "Cette révision du flow est un brouillon. L'exécution utilisera cette révision brouillon et peut échouer immédiatement si la définition du flow est invalide.",
+    "save task": "Enregistrer la tâche",
+    "saved": "Enregistrement réussi",
+    "saved as draft": "Enregistré comme brouillon",
+    "saved done": "<em>{name}</em> est enregistré avec succès",
+    "saved as draft done": "<em>{name}</em> a été enregistré comme brouillon",
+    "multiple saved done": "{name} ont été enregistré(e)s",
+    "fileTypeNotAllowed": "Type de fichier non autorisé. Types acceptés : {types}",
+    "delete": "Effacer",
+    "deleted": "Effacement réussi",
+    "deleted confirm": "<em>{name}</em> est effacé !",
+    "Add flow": "Ajouter un flow",
+    "add": "Ajouter",
+    "add_new_item": "Ajouter un nouvel élément",
+    "copy": "Copier",
+    "copy_to_clipboard": "Copier dans le presse-papiers",
+    "copy_and_close": "Copier et fermer",
+    "Per page": "par page",
+    "new": "Nouveau",
+    "edit": "Modifier",
     "back": "Retour",
-    "back_to_dashboard": "Retour au tableau de bord",
-    "backfill": "Backfill",
-    "backfill executions": "Backfill d'exécutions",
-    "backfill paused": "Backfill en pause",
-    "backfill running": "Backfill en cours",
-    "bar": "Bar",
-    "before": "avant",
-    "behavior": "Comportement",
-    "blueprints": {
-      "all": "Tous",
-      "apps": "Plans d'application",
-      "community": "Communauté",
-      "create": "Créer un blueprint",
-      "custom": "Plans personnalisés",
-      "dashboards": "Tableaux de bord Blueprints",
-      "detail": {
-        "category": "Type de catégorie",
-        "links": "Liens et ressources",
-        "openInEditor": "Ouvrir dans Modifier Flow"
-      },
-      "edit": "Modifier un blueprint",
-      "empty": "Aucun blueprint à afficher.",
-      "flows": "Plans de Flow",
-      "header": {
-        "alt": "Icône des Blueprints",
-        "catch phrase": {
-          "1": "La première étape est toujours la plus difficile.",
-          "2": "Explorez les blueprints pour démarrer votre prochain {kind}."
-        }
-      },
-      "missingPlugins": {
-        "card": "Nécessite des plugin(s) non installés sur cette instance : {plugins}",
-        "description": "Ce blueprint utilise des tasks de plugin(s) qui ne sont pas installés sur cette instance : {plugins}. Installez-les pour utiliser ce blueprint.",
-        "install": "Installer les plugins",
-        "title": "Plugins manquants"
-      },
-      "title": "Blueprints"
+    "next": "Suivant",
+    "done": "Terminé",
+    "review your inputs": "Vérifiez vos entrées",
+    "edit flow": "Modifier le flow",
+    "executions": "Exécutions",
+    "execution": "Exécution",
+    "execution id": "Identifiant d'exécution",
+    "recent_executions": "Exécutions Récentes",
+    "details": "Détails",
+    "overview": "Vue générale",
+    "gantt": "Gantt",
+    "gantt_no_tasks_executed": "Cette exécution s'est terminée sans exécuter de tâche.  \nConsultez son aperçu et ses logs pour en connaître la raison.",
+    "gantt_no_tasks_match_filters": "Essayez d'ajuster les filtres de recherche, d'état ou de niveau de log.",
+    "gantt_no_tasks_match_filters_title": "Aucune tâche ne correspond aux filtres sélectionnés.",
+    "logs": "Fichiers journaux",
+    "no_logs_data": "Pas de données",
+    "no_logs_data_description": "Veuillez essayer d'ajuster vos filtres, de changer la plage de temps, ou vérifier si le flow a été exécuté récemment.",
+    "no_logs_data_title": "Aucun log trouvé pour les filtres sélectionnés.",
+    "duration": "Durée",
+    "total_duration": "Durée totale",
+    "running duration": "Durée de traitement",
+    "queued duration": "Durée d'attente",
+    "choose file": "Choisir un fichier ou le glisser le ici...",
+    "launch execution": "Déclencher",
+    "warning flow with triggers": "Ce flow contient des déclencheurs, une exécution manuelle peut ne pas fonctionner si celui-ci dépend de variables de déclencheurs !",
+    "triggered": "Exécution déclenchée",
+    "triggered done": "L'exécution <em>{name}</em> est déclenchée !",
+    "topology": "Topologie",
+    "date": "Date",
+    "prev_execution": "Exécution précédente",
+    "next_execution": "Prochaine exécution",
+    "datepicker": {
+      "leave empty for infinite": "Laisser vide pour une durée infinie ou entrer une durée ISO 8601 (exemple: 'P1DT1H1M1S)'",
+      "duration example": "Exemple: 'P1DT1H1M1S'",
+      "error": "Format de durée invalide, un format ISO 8601 est attendu (ex: P1DT1H1M1S)",
+      "custom": "Personnalisé",
+      "last5minutes": "5 dernières minutes",
+      "last15minutes": "15 dernières minutes",
+      "last1hour": "Dernière heure",
+      "last12hours": "12 dernières heures",
+      "last24hours": "24 dernières heures",
+      "last48hours": "48 dernières heures",
+      "last7days": "7 derniers jours",
+      "last30days": "30 derniers jours",
+      "last365days": "365 derniers jours",
+      "next5minutes": "Les 5 prochaines minutes",
+      "next15minutes": "Prochaines 15 minutes",
+      "next1hour": "Prochaine 1 heure",
+      "next12hours": "Prochaines 12 heures",
+      "next24hours": "Les prochaines 24 heures",
+      "next48hours": "Prochaines 48 heures",
+      "next7days": "Les 7 prochains jours",
+      "next30days": "Les 30 prochains jours",
+      "next365days": "Les 365 prochains jours",
+      "5minutes": "5 minutes",
+      "15minutes": "15 minutes",
+      "1hour": "1 heure",
+      "12hours": "12 heures",
+      "24hours": "24 heures",
+      "48hours": "48 heures",
+      "7days": "7 jours",
+      "30days": "30 jours",
+      "365days": "365 jours",
+      "never": "Jamais",
+      "today": "Aujourd'hui",
+      "yesterday": "Hier",
+      "dayBeforeYesterday": "Avant-hier",
+      "thisWeek": "Cette semaine",
+      "thisWeekSoFar": "Une semaine",
+      "previousWeek": "Semaine précédente",
+      "thisMonth": "Ce mois",
+      "thisMonthSoFar": "Un mois",
+      "previousMonth": "Mois précédent",
+      "thisYear": "Cette année",
+      "thisYearSoFar": "Une année",
+      "previousYear": "Année précédente",
+      "short": {
+        "15m": "15 min",
+        "1h": "1h",
+        "12h": "12h",
+        "1d": "1j",
+        "7d": "7j"
+      }
     },
-    "body_line_clamp": "Limit line height",
-    "bookmark": "Favoris",
-    "breakpoints": "Points d'arrêt",
-    "bulk action async warning": "Cela peut prendre quelques instants.",
-    "bulk actions": "Actions en masse",
-    "bulk change state": "Êtes-vous sûr de vouloir changer l'état de <code>{executionCount}</code> exécution(s) ?",
-    "bulk delete": "Êtes-vous sur de vouloir supprimer <code>{executionCount}</code> exécution(s) ?",
-    "bulk delete backfills": "Supprimer {count} backfill",
-    "bulk delete triggers": "Êtes-vous sûr de vouloir supprimer {count} triggers ?",
-    "bulk disabled status": {
-      "false": "Activer {count} triggers",
-      "true": "Désactiver {count} triggers"
+    "created date": "Date de création",
+    "latest_update": "Dernière mise à jour",
+    "updated date": "Date de mise à jour",
+    "expiration date": "Date d'expiration",
+    "started date": "Date de démarrage",
+    "healthcheck date": "Dernier Healthcheck",
+    "next execution date": "Prochaine date d'exécution",
+    "last execution status": "Statut de la dernière exécution",
+    "jump to...": "Aller à...",
+    "contextBar": {
+      "news": "Nouvelles",
+      "docs": "Docs",
+      "help": "Aide",
+      "issue": "Problème",
+      "demo": "Démo",
+      "star": "Ajoutez-nous aux favoris"
     },
-    "bulk force run": "Êtes-vous sûr de vouloir forcer l'exécution de <code>{executionCount}</code> exécution(s) ?<br/><br/>WARNING : forcer l'exécution n'est pas garanti et peut créer des exécutions de tâches en double.<br/><br/>Les transitions suivantes seront effectuées :<br/><ul><li>Les tâches CREATED seront déplacées à l'état RUNNING.</li><li>Les tâches RUNNING seront soumises à nouveau.</li><li>Les tâches QUEUED seront désenfilées.</li><li>Les tâches PAUSED seront reprises.</li></ul>",
-    "bulk kill": "Êtes-vous sur de vouloir arrêter <code>{executionCount}</code> exécution(s) ?",
-    "bulk pause": "Êtes-vous sûr de vouloir mettre en pause l'exécution de <code>{executionCount}</code> ?",
-    "bulk pause backfills": "Mettre en pause {count} backfill",
-    "bulk replay": "Êtes-vous sur de vouloir rejouer <code>{executionCount}</code> exécution(s)?",
-    "bulk restart": "Êtes-vous sur de vouloir redémarrer <code>{executionCount}</code> exécution(s) ?",
-    "bulk resume": "Êtes-vous sur de vouloir reprendre <code>{executionCount}</code> exécution(s)?",
-    "bulk set labels": "Êtes-vous sûr de vouloir ajouter des labels à <code>{executionCount}</code>  exécutions(s)?",
-    "bulk success delete backfills": "{count} backfills supprimés",
-    "bulk success delete triggers": "{count} triggers ont été supprimés avec succès",
-    "bulk success disabled status": {
-      "false": "{count} triggers activés",
-      "true": "{count} triggers désactivés"
+    "source": "Source",
+    "source only": "Source uniquement",
+    "home": "Accueil",
+    "create": "Créer",
+    "create_flow": "Créer Flow",
+    "add flow": "Ajouter un flow",
+    "from": "De",
+    "to": "à",
+    "search filters": {
+      "saved": "Filtres sauvegardés",
+      "manage": "Gestion des filtres",
+      "manage desc": "Gestion des filtres sauvegardés",
+      "save filter": "Sauvegarder le filtre",
+      "filter name": "Nom du filtre",
+      "filters": "Filtres"
     },
-    "bulk success pause backfills": "{count} backfills mis en pause",
-    "bulk success unlock": "{count} triggers débloqués",
-    "bulk success unpause backfills": "{count} backfills redémarrés",
-    "bulk unlock": "Débloquer {count} triggers",
-    "bulk unpause backfills": "Reprendre {count} backfill",
-    "bulk unqueue": "Êtes-vous sûr de vouloir retirer de la file d'attente <code>{executionCount}</code> exécution(s) ?",
-    "can not delete": "Suppression impossible",
-    "can not have less than 1 task": "Un flow ne peut avoir moins d'1 tâche.",
-    "can not save": "Impossible de sauvegarder",
-    "cancel": "Annuler",
+    "steps": "Étapes",
+    "state": "État",
+    "state_history": "Historique des états",
+    "search term in message": "Chercher dans le message",
+    "search": "Chercher",
+    "search blueprint": "Chercher un blueprint",
+    "all tags": "Toutes catégories",
+    "source search": "Recherche de code source",
+    "filter by log level": "Filtrer par niveau de log",
+    "selected": "Sélectionné",
+    "task": "Tâche",
+    "task logs": "Journaux de la tâche",
+    "display flow {id} executions": "Voir les exécutions du flow {id}",
+    "actions": "Actions",
+    "select datetime": "Sélectionner une date",
+    "select view": "Sélectionner la vue",
+    "invalid field": "Champ invalide: {name}",
+    "required field": "Champ requis",
+    "is required": "{field} est requis",
+    "error": "Erreur",
+    "form": "Formulaire",
+    "form error": "Formulaire invalid",
+    "display topology for flow": "Afficher la topologie du flow",
     "cannot create topology": "Impossible de créer la topologie du flow",
-    "cannot swap tasks": "Impossible de permuter les tâches",
-    "change execution state confirm": "Êtes-vous sûr de vouloir changer l'état de l'exécution <code>{id}</code> ?",
-    "change execution state done": "État d'exécution mis à jour",
-    "change queue confirm": "Êtes-vous sûr de vouloir changer l'état de la file d'attente pour l'exécution <code>{id}</code>?<br/>",
+    "start date": "Date de début",
+    "end date": "Date de fin",
+    "creation": "Création",
+    "flow creation": "Création de flow",
+    "start datetime": "Date de départ",
+    "end datetime": "Date de fin",
+    "restart": "Relancer",
+    "restart latest revision": "Relancer avec la dernière révision",
+    "restart tooltip": "Relancer l'exécution depuis la tâche dans l'état <code>{state}</code>",
+    "restarted": "L'exécution est redémarrée",
+    "restart confirm": "Êtes-vous sur de vouloir relancer <code>{id}</code> ?",
+    "restart change revision": "Vous pouvez changer la révision qui sera utilisé pour la nouvelle exécution relancée.",
+    "replay": "Rejouer",
+    "replay from task tooltip": "Créer une nouvelle exécution similaire démarrant de la tâche <code>{taskId}</code>",
+    "replay from beginning tooltip": "Créer une nouvelle exécution similaire depuis le début",
+    "replay latest revision": "Rejouer avec la dernière révision",
+    "replayed": "L'exécution est rejouée",
+    "replay confirm": "Êtes-vous sur de vouloir relancer l'exécution <code>{id}</code> et créer une nouvelle exécution ?",
+    "replay with inputs": "Rejouer avec inputs",
+    "reuse_original_inputs": "Réutiliser les inputs d'origine",
+    "modify_inputs": "Modifier les inputs",
+    "replay the execution": "Rejouer l'exécution <code>{executionId}</code> pour le flow <code>{flowId}</code>",
+    "prefill inputs": "Pré-remplir",
+    "current": "actuel",
     "change state": "Changer l'état",
-    "change state confirm": "Êtes-vous sûr de vouloir changer l'état d'exécution de la tâche <code>{task}</code> dans l'exécution <code>{id}</code> ?",
-    "change state current state": "Statut actuel :",
+    "actual state": "État actuel",
+    "select a state": "Sélectionner un état",
+    "are you sure change state": "Êtes-vous sûr de vouloir changer l'état ?",
+    "yes": "Oui",
     "change state done": "L'état de la task a été mis à jour",
+    "change state confirm": "Êtes-vous sûr de vouloir changer l'état d'exécution de la tâche <code>{task}</code> dans l'exécution <code>{id}</code> ?",
+    "change queue confirm": "Êtes-vous sûr de vouloir changer l'état de la file d'attente pour l'exécution <code>{id}</code>?<br/>",
+    "change state current state": "Statut actuel :",
     "change state hint": {
+      "WARNING": [
+        "Le flow sera marqué comme WARNING.",
+        "Les prochaines tasks seront exécutées.",
+        "Les tasks d'erreur seront exécutées."
+      ],
       "FAILED": [
         "Le flow sera marqué comme FAILED.",
         "Aucune autre task ne sera exécutée.",
         "Les tasks d'erreur seront exécutées."
-      ],
-      "RUNNING": [
-        "Le flow redémarrera et exécutera toutes les tâches suivantes.",
-        "Toutes les tâches bloquées seront exécutées."
       ],
       "SUCCESS": [
         "Le flow redémarrera car cette task a réussi.",
         "Toutes les tasks bloquées seront exécutées.",
         "Le flow sera en état SUCCESS si toutes les exécutions de task réussissent."
       ],
-      "WARNING": [
-        "Le flow sera marqué comme WARNING.",
-        "Les prochaines tasks seront exécutées.",
-        "Les tasks d'erreur seront exécutées."
+      "RUNNING": [
+        "Le flow redémarrera et exécutera toutes les tâches suivantes.",
+        "Toutes les tâches bloquées seront exécutées."
       ]
     },
+    "replay execution title": "Rejouer l'exécution",
+    "restart execution title": "Redémarrer l'exécution",
+    "replay execution description": "Cela créera une nouvelle exécution basée sur l'exécution sélectionnée.",
+    "replay using": "Rejouer en utilisant",
+    "flow revision original": "Révision originale du flow",
+    "flow revision latest": "Dernière révision du flow",
+    "flow revision specific": "Révision spécifique du flow",
+    "replay inputs": "Entrées",
+    "reuse original inputs": "Réutiliser les inputs d'origine",
+    "modify inputs": "Modifier les inputs",
+    "replay inputs new required": "Cette révision a des inputs. Vous serez invité à les remplir.",
+    "replay select taskrun": "Sélectionnez le task run à rejouer à partir de :",
     "change state tooltip": "Changer l'état d'exécution",
-    "chart": "Graphique",
-    "chart preview": "Aperçu du graphique",
-    "chart type": "Type de graphique",
-    "charts": "Graphiques",
-    "choice": "Choix",
-    "choose file": "Choisir un fichier ou le glisser le ici...",
-    "close": "Fermer",
-    "close sidebar": "fermer la barre latérale",
-    "codeDisabled": "Désactivé dans le flow",
-    "collapse": "Masquer",
-    "collapse all": "Masquer tout",
-    "commit_id": "ID de commit",
-    "common": {
-      "back": "Retour"
-    },
-    "concurrency": "Concurrence",
-    "concurrency limits": "Limites de Concurrence",
-    "concurrency_limit": {
-      "dialog_title": "Limites de Concurrence",
-      "warning": "Modifier le compteur en cours peut corrompre la concurrence, de sorte que les exécutions peuvent dépasser la limite autorisée."
-    },
-    "conditions": "Conditions",
-    "configure basic auth": "Configurer l'authentification basique",
-    "confirm": "Confirmer",
-    "confirm password": "Confirmer le mot de passe",
-    "confirmation": "Confirmation",
-    "context updated date": "Date de mise à jour du contexte",
-    "context updated date tooltip": "Dernière mise à jour du contexte du trigger. Cela se produit lorsque l'exécution est déclenchée, se termine (verrou libéré), ou après une évaluation (même si aucune exécution n'a lieu).",
-    "contextBar": {
-      "demo": "Démo",
-      "docs": "Docs",
-      "help": "Aide",
-      "issue": "Problème",
-      "news": "Nouvelles",
-      "star": "Ajoutez-nous aux favoris"
-    },
-    "continue backfill": "Continuer le backfill",
-    "continue backfills": "Continuer les backfills",
-    "copied": "Copié",
-    "copied_logs_to_clipboard": "Logs copiés dans le presse-papiers.",
-    "copy": "Copier",
-    "copy all logs": "Copier tous les logs",
-    "copy logs": "Copier les logs",
-    "copy url": "Copier l'URL",
-    "copy_and_close": "Copier et fermer",
-    "copy_to_clipboard": "Copier dans le presse-papiers",
-    "copy_value": "Copy value",
-    "create": "Créer",
-    "create first task": "Créer votre première tâche",
-    "create_flow": "Créer Flow",
-    "created date": "Date de création",
-    "creation": "Création",
-    "cron": "Cron",
-    "curl": {
-      "command": "Commande cURL",
-      "note": "Notez que pour les types d'input SECRET et FILE, la commande doit être adaptée pour correspondre aux valeurs réelles."
-    },
-    "current": "actuel",
-    "current execution": "Exécution en cours",
-    "custom value": "Valeur personnalisée",
-    "customize sidebar": "Personnaliser la barre latérale",
-    "dark_version": "Version sombre",
-    "dashboards": {
-      "chart_preview": "Cliquez sur un code source de graphique pour voir son aperçu",
-      "creation": {
-        "confirmation": "Le tableau de bord <code>{title}</code> est créé.",
-        "label": "Créer un tableau de bord"
-      },
-      "default": "Tableau de bord par défaut",
-      "deletion": {
-        "confirmation": "Êtes-vous sûr de vouloir supprimer le tableau de bord <code>{title}</code> ?"
-      },
-      "edition": {
-        "chart": "Modifier ce graphique",
-        "confirmation": "Les modifications dans le tableau de bord <code>{title}</code> sont enregistrées.",
-        "id readonly": "La propriété `id` ne peut pas être modifiée — elle est maintenant définie sur ses valeurs initiales. Si vous souhaitez la changer, vous pouvez créer un nouveau tableau de bord et supprimer l'ancien.",
-        "label": "Modifier le tableau de bord"
-      },
-      "empty": "Il n'y a aucun résultat à afficher.",
-      "export": "Exporter vers CSV",
-      "labels": {
-        "plural": "Tableaux de bord",
-        "singular": "Tableau de bord"
-      },
-      "no_description": "Aucune description",
-      "no_description_hint": "Ajoutez une description à ce flow pour documenter ce qu'il fait.<br>Markdown est pris en charge.",
-      "others": "Autres",
-      "preview": "Aperçu du Dashboard",
-      "quick_filters": {
-        "all": "Tout",
-        "failed": "Échoué",
-        "paused": "En pause",
-        "running": "En cours",
-        "success": "Succès",
-        "warning": "Avertissement"
-      },
-      "switch": "Changer de tableau de bord",
-      "viewAll": "Tout voir"
-    },
-    "data": "Données",
-    "dataFilters": "Filtres de données",
-    "data_not_protected": "Vos données ne sont pas protégées. Ne les perdez pas. <b>Activez nos fonctionnalités de sécurité gratuites ou essayez notre offre payante.</b>",
-    "date": "Date",
-    "date count": "{count} le {date}",
-    "date format": "Format de date",
-    "date range count": "{count} entre le {startDate} et le {endDate}",
-    "datepicker": {
-      "12hours": "12 heures",
-      "15minutes": "15 minutes",
-      "1hour": "1 heure",
-      "24hours": "24 heures",
-      "30days": "30 jours",
-      "365days": "365 jours",
-      "48hours": "48 heures",
-      "5minutes": "5 minutes",
-      "7days": "7 jours",
-      "custom": "Personnalisé",
-      "dayBeforeYesterday": "Avant-hier",
-      "duration example": "Exemple: 'P1DT1H1M1S'",
-      "error": "Format de durée invalide, un format ISO 8601 est attendu (ex: P1DT1H1M1S)",
-      "last12hours": "12 dernières heures",
-      "last15minutes": "15 dernières minutes",
-      "last1hour": "Dernière heure",
-      "last24hours": "24 dernières heures",
-      "last30days": "30 derniers jours",
-      "last365days": "365 derniers jours",
-      "last48hours": "48 dernières heures",
-      "last5minutes": "5 dernières minutes",
-      "last7days": "7 derniers jours",
-      "leave empty for infinite": "Laisser vide pour une durée infinie ou entrer une durée ISO 8601 (exemple: 'P1DT1H1M1S)'",
-      "never": "Jamais",
-      "next12hours": "Prochaines 12 heures",
-      "next15minutes": "Prochaines 15 minutes",
-      "next1hour": "Prochaine 1 heure",
-      "next24hours": "Les prochaines 24 heures",
-      "next30days": "Les 30 prochains jours",
-      "next365days": "Les 365 prochains jours",
-      "next48hours": "Prochaines 48 heures",
-      "next5minutes": "Les 5 prochaines minutes",
-      "next7days": "Les 7 prochains jours",
-      "previousMonth": "Mois précédent",
-      "previousWeek": "Semaine précédente",
-      "previousYear": "Année précédente",
-      "short": {
-        "12h": "12h",
-        "15m": "15 min",
-        "1d": "1j",
-        "1h": "1h",
-        "7d": "7j"
-      },
-      "thisMonth": "Ce mois",
-      "thisMonthSoFar": "Un mois",
-      "thisWeek": "Cette semaine",
-      "thisWeekSoFar": "Une semaine",
-      "thisYear": "Cette année",
-      "thisYearSoFar": "Une année",
-      "today": "Aujourd'hui",
-      "yesterday": "Hier"
-    },
-    "debug": "Déboguer",
-    "default": "Par défaut",
-    "defaultsToNamespaceFile": "Par défaut, fichier de namespace : <code>{name}</code>",
-    "delete": "Effacer",
-    "delete backfill": "Supprimer le backfill",
-    "delete backfills": "Supprimer les backfills",
-    "delete confirm": "Êtes-vous sur de vouloir effacer <code>{name}</code> ?",
-    "delete execution running": "<div class=\"alert alert-warning mt-2 mb-0\">Cette exécution est en cours, l'effacer ne stoppera pas celle-ci.<br />Vous devez l'arrêter auparavant!</div>",
-    "delete logs": "Supprimer les logs",
-    "delete ok": "est effacé",
-    "delete revision confirm": "Êtes-vous sûr de vouloir supprimer la révision {revision} ?",
-    "delete revision error": "Erreur lors de la suppression de la révision {revision} avec l'erreur {error}",
-    "delete task confirm": "Êtes-vous sûr de vouloir supprimer la tâche <code>{taskId}</code> ?",
-    "delete trigger": "Supprimer le trigger",
-    "delete trigger confirmation": "Êtes-vous sûr de vouloir supprimer le trigger {id} ? WARNING : supprimer un trigger peut entraîner des exécutions en double si le trigger est toujours actif dans un flow.",
-    "delete trigger error": "Erreur lors de la suppression du trigger {id}",
-    "delete trigger success": "Le trigger {id} a été supprimé avec succès",
-    "delete triggers": "Supprimer les triggers",
-    "delete_all_logs": "Êtes-vous sûr de vouloir supprimer tous les journaux ?",
-    "delete_log": "Êtes-vous sûr de vouloir supprimer le log ?",
-    "deleted": "Effacement réussi",
-    "deleted confirm": "<em>{name}</em> est effacé !",
-    "deleted_label": "Supprimé",
-    "demos": {
-      "IAM": {
-        "message": "L'édition Kestra Enterprise dispose de capacités IAM intégrées avec une authentification unique (SSO), une synchronisation de répertoire SCIM et un contrôle d'accès basé sur les rôles (RBAC), s'intégrant avec plusieurs fournisseurs d'identité et vous permettant d'attribuer des permissions détaillées aux utilisateurs et aux comptes de service.",
-        "title": "Gérer les utilisateurs via IAM avec SSO, SCIM et RBAC"
-      },
-      "apps": {
-        "message": "Les applications dans Kestra Enterprise Edition vous permettent de créer des interfaces utilisateur personnalisées qui interagissent avec les workflows Kestra depuis l'extérieur de la plateforme. Cette fonctionnalité vous permet d'utiliser vos workflows comme un backend pour des applications personnalisées, permettant aux utilisateurs non techniques de soumettre des données via des formulaires ou de reprendre des workflows PAUSED en attente d'approbation.",
-        "title": "Créez des applications personnalisées avec Kestra"
-      },
-      "assets": {
-        "header": "Métadonnées des actifs et Observabilité",
-        "label": "Actifs",
-        "message": "Les assets connectent les métadonnées d'observabilité, de lignée et de propriété afin que les équipes de la plateforme puissent résoudre les problèmes plus rapidement et déployer en toute confiance.",
-        "title": "Amenez chaque dataset, service et dépendance en vue."
-      },
-      "audit-logs": {
-        "message": "L'édition Kestra Enterprise enregistre chaque activité avec des enregistrements robustes et immuables, ce qui facilite le suivi des modifications, le maintien de la conformité et la résolution des problèmes.",
-        "title": "Suivre les modifications avec les Audit Logs"
-      },
-      "blueprints": {
-        "message": "Dans l'édition Kestra Enterprise, vous pouvez créer des Blueprints personnalisés uniquement disponibles pour votre organisation. Vous pouvez les utiliser comme modèles de bonnes pratiques pour partager, centraliser et documenter les workflows couramment utilisés dans votre équipe.",
-        "title": "Ajouter des Blueprints Personnalisés"
-      },
-      "contact_sales": "Contactez les ventes",
-      "enterprise_edition": "Édition Enterprise",
-      "get_a_demo_button": "Obtenir une démo",
-      "instance": {
-        "message": "L'édition Enterprise de Kestra fournit un tableau de bord opérationnel pour vous aider à observer la santé de votre plateforme et à suivre les métriques de disponibilité de tous les services tels que, entre autres, les Workers, les Schedulers et les Executors. Depuis la même page, vous pouvez également créer des annonces pour informer vos utilisateurs des interruptions planifiées, et vous pouvez entrer en mode maintenance, ce qui met temporairement tous les services et les exécutions de workflow dans un état PAUSED pour effectuer une mise à niveau.",
-        "title": "Gérer l'infrastructure sur votre instance"
-      },
-      "namespace": {
-        "assets": {
-          "message": "Dans Kestra Enterprise Edition, Assets maintient un inventaire en temps réel des ressources avec lesquelles vos workflows interagissent. Ces ressources peuvent être des tables de base de données, des machines virtuelles, des fichiers ou tout système externe avec lequel vous travaillez.",
-          "title": "Centraliser la gestion des actifs"
-        },
-        "audit-logs": {
-          "message": "Dans Kestra Enterprise Edition, vous pouvez consulter les logs d'audit au niveau du namespace avec des différences détaillées, vous offrant un historique clair de qui a modifié quoi et quand à travers toutes les ressources.",
-          "title": "Suivez tous les changements en un seul endroit"
-        },
-        "edit": {
-          "message": "Dans l'édition Kestra Enterprise, les namespaces offrent une isolation avancée et une gouvernance des secrets, variables et paramètres par défaut des plugins à grande échelle. Les administrateurs peuvent configurer des gestionnaires de secrets personnalisés, des stockages backends isolés, des groupes de workers dédiés, et des permissions fines par namespace. Cela garantit que les secrets, variables et configurations de plugins restent sécurisés et faciles à maintenir à travers différentes équipes et projets.",
-          "title": "Améliorez la Gestion de votre Namespace"
-        },
-        "history": {
-          "message": "Dans Kestra Enterprise Edition, vous pouvez gérer l'historique des révisions de vos namespaces",
-          "title": "Gérer l'historique des révisions en un seul endroit"
-        },
-        "plugin-defaults": {
-          "message": "Dans Kestra Enterprise Edition, vous pouvez définir des paramètres par défaut spécifiques au namespace pour les plugins, réduisant ainsi le besoin de configurations dupliquées dans chaque flow. Cette gouvernance centrale des plugins impose des configurations cohérentes, permet une référence sécurisée des secrets ou des variables, et simplifie la maintenance de vos workflows.",
-          "title": "Standardiser la Configuration avec les Valeurs par Défaut du Plugin"
-        },
-        "secrets": {
-          "message": "Dans Kestra Enterprise Edition, vous pouvez stocker et contrôler les secrets au niveau du namespace, minimisant ainsi les risques et garantissant que les identifiants de chaque équipe restent isolés. Grâce à la hiérarchie imbriquée, vous pouvez également configurer des identifiants dans un namespace parent et ils seront hérités par tous les namespaces enfants. Le support pour les gestionnaires de secrets dédiés et les paramètres de permission au niveau du namespace renforcent encore la sécurité et la conformité.",
-          "title": "Gérer les secrets de manière sécurisée"
-        },
-        "variables": {
-          "message": "Dans Kestra Enterprise Edition, vous pouvez définir et gérer des variables au niveau du namespace pour éliminer les configurations répétitives à travers les flows. Ces variables assurent la cohérence, simplifient les mises à jour de configuration et peuvent être facilement référencées par n'importe quel task ou trigger pour des workflows plus propres et plus faciles à maintenir.",
-          "title": "Gérez vos Variables de manière centralisée"
-        }
-      },
-      "quotas": {
-        "message": "Kestra Enterprise Edition vous permet de définir des quotas sur les flows pour limiter le nombre d'exécutions simultanées ou totales dans une fenêtre de temps. Les quotas vous aident à protéger l'infrastructure partagée, à appliquer les SLAs et à empêcher les workflows incontrôlés de consommer des ressources excessives.",
-        "title": "Appliquer des quotas d'exécution sur les flows"
-      },
-      "secrets": {
-        "add_env": {
-          "first": "Encodez la <a href=\"https://kestra.io/docs/how-to-guides/secrets?utm_source=app&utm_medium=referral&utm_campaign=secrets-inlinedoc#using-secrets-in-kestra\" target=\"_blank\">valeur secrète en Base64</a>",
-          "intro": "Pour créer un nouveau Secret :",
-          "second": "Ajoutez une variable d'environnement nommée '<strong>SECRET_{'{MY_SECRET_KEY}'}</strong>' avec la valeur ci-dessus.",
-          "third": "Redémarrez votre instance Kestra"
-        },
-        "detected_env": "Voici les variables d'environnement de type secret identifiées au démarrage de l'instance :",
-        "empty_env": "Vous n'avez pas encore de Secrets dans votre environnement.",
-        "message": "L'Enterprise Edition (EE) vous permet d'ajouter, de modifier ou de supprimer des secrets directement dans l'UI, sans redémarrage de l'instance. Organisez les secrets par namespace avec des permissions RBAC granulaires, et héritez-les des namespaces parents aux namespaces enfants. EE s'intègre avec des gestionnaires de secrets comme HashiCorp Vault, AWS Secrets Manager, Azure Key Vault, Google Secret Manager et Elasticsearch. Configurez des backends dédiés par namespace, tenant ou instance pour isoler les secrets entre les équipes, ou activez des secrets en lecture seule stockés dans des coffres externes. Les secrets restent chiffrés au repos et en transit. Un cache optionnel réduit les appels API, et les pistes d'audit loguent tous les accès.",
-        "title": "Améliorez votre gestion des Secrets"
-      },
-      "tenants": {
-        "message": "L'édition Kestra Enterprise prend en charge la multi-tenance, vous offrant des environnements entièrement isolés pour différentes équipes ou projets, chacun avec ses propres ressources telles que des groupes de workers dédiés ou des secrets et des backends de stockage internes.",
-        "title": "Gérer les flux de travail dans des tenants isolés"
-      },
-      "tests": {
-        "header": "Tests unitaires pour les flows",
-        "label": "Tests",
-        "message": "Vérifiez la logique de vos flows de manière isolée, détectez les régressions tôt et maintenez la confiance dans vos automatisations à mesure qu'elles évoluent et se développent.",
-        "title": "Assurez la fiabilité à chaque changement"
-      },
-      "watch_the_video": "Regarder la vidéo"
-    },
-    "density": "Density",
-    "density_compact": "Compact",
-    "density_expanded": "Expanded",
-    "density_normal": "Normal",
-    "dependencies": "Dépendances",
-    "dependencies delete flow": "Ce flow a des dépendances, effacer celui-ci empêchera les dépendances de s'exécuter !<br /><br /> Voici la liste des flows concernés :",
-    "dependencies loaded": "Dépendances chargées",
-    "dependencies missing acls": "Aucune permission sur ce flow",
-    "dependency": {
-      "controls": {
-        "clear_selection": "Effacer la sélection",
-        "fit_view": "Ajuster à l'écran",
-        "zoom_in": "Zoomer",
-        "zoom_out": "Dézoomer"
-      },
-      "search": {
-        "flow": {
-          "display": "Inclure les dépendances de flow"
-        },
-        "namespace": {
-          "no_namespace": "Sans namespace",
-          "select": "Sélectionner un namespace"
-        },
-        "no_results": "Aucun résultat trouvé pour {term}",
-        "placeholders": {
-          "asset": "Rechercher par asset, flow ou namespace...",
-          "default": "Rechercher par flow ou namespace..."
-        }
-      }
-    },
-    "dependency task": "La tâche {taskId} est une dépendance d'une autre tâche",
-    "description": "Description",
-    "details": "Détails",
-    "disable": "Désactiver",
-    "disabled": "Désactivé",
-    "disabled flow desc": "Ce flow est désactivé, veuillez le réactiver pour l'exécuter.",
-    "disabled flow title": "Ce flow est désactivé",
-    "discard changes confirmation": "Vous avez des modifications non enregistrées. Êtes-vous sûr de vouloir les abandonner ?",
-    "discard execution confirmation": "Vous avez des inputs non enregistrés. Êtes-vous sûr de vouloir abandonner cette exécution ?",
-    "display direct sub tasks count": "Display les sous tâches directes",
-    "display flow {id} executions": "Voir les exécutions du flow {id}",
-    "display metric for specific task": "Afficher les mesures pour cette tâche",
-    "display output for specific task": "Afficher les sorties pour cette tâche",
-    "display topology for flow": "Afficher la topologie du flow",
-    "display_settings": "Display settings",
-    "docs": "Documentation",
-    "documentation": {
-      "documentation": "Documentation",
-      "github": "Bugs GitHub"
-    },
-    "documentationMenu": "Menu de documentation",
-    "done": "Terminé",
-    "down trend": "En baisse",
-    "download": "Télécharger",
-    "download logs": "Télécharger les logs",
-    "download_logos": "Télécharger le pack de logos",
-    "download_logs_description": "Choose which logs to export. Filters default to your current view.",
-    "draft": "Brouillon",
-    "draft_available": "Un changement de brouillon est disponible dans l'éditeur",
-    "draft_flow_warning": "Cette révision du flow est un brouillon. L'exécution utilisera cette révision brouillon et peut échouer immédiatement si la définition du flow est invalide.",
-    "drill down preview": "Aperçu",
-    "drop items here": "Déposez les éléments ici",
-    "duplicate-pair": "{label} \"{key}\" est dupliqué, première clé ignorée.",
-    "duration": "Durée",
-    "dynamic": "Dynamique",
-    "each value": "Valeur d'itération",
-    "edit": "Modifier",
-    "edit flow": "Modifier le flow",
-    "editor": "Éditeur",
-    "editor_shortcuts": {
-      "command_palette": "Afficher la palette de commandes",
-      "comment": "Commentaire",
-      "comment_uncomment": "Commenter/Décommenter",
-      "decrease_fontsize": "Diminuer la taille de la police de l'éditeur",
-      "duplicate_cursor": "Dupliquer le curseur",
-      "execute_flow": "Exécuter le flow",
-      "fold_unfold": "Plier/Déplier le code",
-      "increase_fontsize": "Augmenter la taille de la police de l'éditeur",
-      "label": "Raccourcis clavier",
-      "move_line": "Déplacer la ligne",
-      "reset_fontsize": "Réinitialiser la taille de police de l'éditeur",
-      "save_flow": "Enregistrer le flow",
-      "toggle_ai_agent": "Basculer l'agent AI",
-      "trigger_autocompletion": "Déclencher l'autocomplétion",
-      "uncomment": "Décommenter"
-    },
-    "ee-tooltip": {
-      "button": "Contactez-nous",
-      "features-blocked": "Cette fonctionnalité nécessite l'édition Enterprise."
-    },
-    "email": "Email",
-    "email length constraint": "L'e-mail ne doit pas dépasser 256 caractères.",
-    "empty": {
-      "announcements": {
-        "content": "Les annonces vous permettent de notifier vos utilisateurs de tout changement ou de les informer des temps d'arrêt de maintenance planifiés. Sélectionnez simplement le type d'annonce, la plage de dates pendant laquelle elle doit être affichée, et rédigez le message d'annonce.",
-        "title": "Vous n'avez pas encore d'annonces !"
-      },
-      "apiTokens": {
-        "content": "Les jetons API sont utilisés chaque fois que vous souhaitez accorder un accès programmatique à l'API Kestra.",
-        "title": "Gérez vos jetons API"
-      },
-      "apps": {
-        "content": "Commencez à créer des Apps pour interagir avec Kestra depuis le monde extérieur.",
-        "title": "Vous n'avez pas encore d'applications !"
-      },
-      "assets": {
-        "content": "Ajoutez des ressources pour suivre et gérer vos ressources de données, services et infrastructures.",
-        "title": "Vous n'avez pas encore d'Assets !"
-      },
-      "concurrency_executions": {
-        "content": "En savoir plus sur les <strong><a href=\"https://kestra.io/docs/workflow-components/execution?utm_source=app&utm_medium=referral&utm_campaign=concurrency-inlinedoc\" target=\"_blank\">Exécutions</a></strong> dans notre documentation.",
-        "title": "Aucune exécution en cours pour ce flow."
-      },
-      "concurrency_limit": {
-        "content": "En savoir plus sur les <strong><a href=\"https://kestra.io/docs/workflow-components/concurrency?utm_source=app&utm_medium=referral&utm_campaign=concurrency-inlinedoc\" target=\"_blank\">limites de Concurrency</a></strong> dans notre documentation.",
-        "title": "Aucune limite n'est définie pour ce flow."
-      },
-      "concurrency_limits": {
-        "content": "En savoir plus sur les <strong><a href=\"https://kestra.io/docs/workflow-components/concurrency?utm_source=app&utm_medium=referral&utm_campaign=concurrency-inlinedoc\" target=\"_blank\">limites de Concurrency</a></strong> dans notre documentation.",
-        "title": "Aucune limite de concurrence n'est définie."
-      },
-      "dependencies": {
-        "ASSET": {
-          "content": "Cet actif n'a pas de dépendances amont ou aval avec des flows ou d'autres actifs.",
-          "title": "Il n'y a actuellement aucune dépendance."
-        },
-        "EXECUTION": {
-          "content": "En savoir plus sur les <a href=\"https://kestra.io/docs/ui/executions?utm_source=app&utm_medium=referral&utm_campaign=dependencies-inlinedoc#dependencies\" target=\"_blank\">dépendances d'exécution</a> dans notre documentation.",
-          "title": "Il n'y a actuellement aucune dépendance."
-        },
-        "FLOW": {
-          "content": "En savoir plus sur les <a href=\"https://kestra.io/docs/ui/flows?utm_source=app&utm_medium=referral&utm_campaign=dependencies-inlinedoc#dependencies\" target=\"_blank\">Flow Dependencies</a> dans notre documentation.",
-          "title": "Il n'y a actuellement aucune dépendance."
-        },
-        "NAMESPACE": {
-          "content": "En savoir plus sur les <a href=\"https://kestra.io/docs/ui/namespaces?utm_source=app&utm_medium=referral&utm_campaign=dependencies-inlinedoc#dependencies\" target=\"_blank\">dépendances de namespace</a> dans notre documentation.",
-          "title": "Il n'y a actuellement aucune dépendance."
-        }
-      },
-      "groups": {
-        "content": "Les groupes vous permettent de regrouper des utilisateurs afin de gérer les autorisations et les liaisons de rôles collectivement dans votre locataire.",
-        "title": "Vous n'avez pas encore de groupes !"
-      },
-      "kill_switches": {
-        "content": "La fonctionnalité Kill Switch offre un mécanisme basé sur l'interface utilisateur pour arrêter les exécutions problématiques. Elle remplace les commandes <code>--skip-executions</code> et <code>--skip-flows</code> disponibles uniquement en ligne de commande par une interface d'administration complète.",
-        "title": "Vous n'avez pas encore de Kill Switches !"
-      },
-      "mcpToolFlows": {
-        "content": "Exposez un flow comme un outil MCP en y ajoutant un <code>McpToolTrigger</code>. Lisez-en plus sur le <strong><a href=\"https://kestra.io/docs/workflow-components/triggers/mcp-tool-trigger?utm_source=app&utm_medium=referral&utm_campaign=mcp-tool-trigger-inlinedoc\" target=\"_blank\">MCP Tool Trigger</a></strong> dans notre documentation.",
-        "title": "Aucun flow d'outil n'est encore enregistré sur ce serveur."
-      },
-      "namespaceFiles": {
-        "content": "Les fichiers de l'espace de noms fonctionnent comme un dossier de projet pour cet espace de noms. Stockez du code Python, SQL, dbt ou Terraform, puis référencez n'importe quel fichier dans vos flows avec",
-        "title": "Aucun fichier dans cet espace de noms pour le moment"
-      },
-      "panels": {
-        "content": "Vous avez fermé tous les panneaux.  \nChoisissez un onglet ci-dessus pour continuer.",
-        "title": "Aucun panneau ouvert"
-      },
-      "pluginDefaults": {
-        "content": "Les paramètres par défaut des plugins vous permettent de gérer centralement la configuration de votre plugin et de la partager avec tous les flows dans votre namespace.",
-        "title": "Vous n'avez pas encore de paramètres par défaut pour les plugins !"
-      },
-      "plugins": {
-        "content": "En savoir plus sur les <strong><a href=\"https://kestra.io/docs/workflow-components/plugin-defaults?utm_source=app&utm_medium=referral&utm_campaign=plugin-default-inlinedoc\" target=\"_blank\">limites de Concurrency</a></strong> dans notre documentation.",
-        "title": "Aucun paramètre par défaut de plugin n'est défini pour ce namespace."
-      },
-      "testSuites": {
-        "content": "Commencez à créer des suites de test pour tester vos Flows.",
-        "title": "Vous n'avez pas encore de Test suites !"
-      },
-      "triggers": {
-        "content": "En savoir plus sur les <strong><a href=\"https://kestra.io/docs/workflow-components/triggers?utm_source=app&utm_medium=referral&utm_campaign=trigger-inlinedoc\" target=\"_blank\">Triggers</a></strong> dans notre documentation.",
-        "title": "Votre flow n'a pas de triggers."
-      },
-      "variables": {
-        "content": "Ajoutez des paires clé-valeur pour partager la configuration entre les flows. Les namespaces enfants les héritent automatiquement, et vous pouvez référencer n'importe quelle valeur avec",
-        "title": "Aucune variable pour le moment"
-      },
-      "versionPlugin": {
-        "content": "Ici, vous pouvez gérer tous les plugins installés sur votre instance Kestra. Les plugins nouvellement installés peuvent ne pas être immédiatement disponibles dans tous les services Kestra, selon la configuration de votre instance.",
-        "title": "Vous n'avez pas encore de plugin versionné !"
-      },
-      "workerRegistrationTokens": {
-        "content": "Les jetons d'enregistrement permettent aux workers distants de s'authentifier et de s'enregistrer en toute sécurité avec votre instance Kestra. Créez un jeton, puis utilisez-le pour connecter de nouveaux workers à ce cluster.",
-        "title": "Vous n'avez pas encore de jetons d'enregistrement !"
-      }
-    },
-    "empty search": "Les résultats de recherche sont vides",
-    "enable": "Activer",
-    "enable concurrency": "Activer la concurrence",
-    "enabled": "Activé",
-    "encoding": "Encodage",
-    "end date": "Date de fin",
-    "end datetime": "Date de fin",
-    "environment": "Environnement",
-    "environment color setting": "Couleur de l'environnement",
-    "environment name setting": "Nom de l'environnement",
-    "error": "Erreur",
-    "error detected": "Erreur(s) détectée(s).",
-    "error in editor": "Une erreur a été trouvé dans l'éditeur",
-    "errorLogs": "Logs des erreurs",
-    "errors": {
-      "401": {
-        "content": "Vous devez être authentifié pour accéder à cette page.",
-        "title": "Non authentifié"
-      },
-      "403": {
-        "content": "Vous n'avez pas les permissions suffisantes pour accéder à cette page.",
-        "title": "Accès refusé"
-      },
-      "404": {
-        "content": "L'URL demandée n'a pas été trouvée sur ce serveur.<br />C'est tout ce que nous savons.",
-        "flow or execution": "Le flow ou l'exécution demandé est introuvable.",
-        "title": "Page introuvable"
-      }
-    },
+    "change execution state confirm": "Êtes-vous sûr de vouloir changer l'état de l'exécution <code>{id}</code> ?",
+    "change execution state done": "État d'exécution mis à jour",
+    "mark as": "Marqué comme <code>{status}</code>",
+    "unqueue as": "Se désenfile en tant que <code>{status}</code>",
+    "kill": "Arrêter",
+    "kill parents and subflow": "Tuer le flow actuel et les subflows",
+    "kill only parents": "Tuer uniquement le courant",
+    "killed confirm": "Êtes-vous sur de vouloir arrêter l'exécution <code>{id}</code> ?",
+    "killed done": "L'exécution est en attente d'arrêt",
+    "resume": "Reprendre",
+    "resumed title": "Reprendre l'exécution <code>{id}</code>",
+    "resumed confirm": "Êtes-vous sur de vouloir reprendre l'exécution <code>{id}</code>?",
+    "resumed done": "L'exécution est reprise",
+    "resume from breakpoint title": "Reprendre l'exécution <code>{id}</code> depuis le point d'arrêt",
+    "resume from breakpoint done": "L'exécution est reprise depuis le point d'arrêt",
+    "breakpoints": "Points d'arrêt",
+    "pause": "Pause",
+    "pause title": "Mettre en pause l'exécution <code>{id}</code>.<br/>Notez que les tasks actuellement en cours d'exécution seront toujours traitées, et l'exécution devra être reprise manuellement.",
+    "pause confirm": "Êtes-vous sûr de vouloir mettre en pause l'exécution <code>{id}</code> ?",
+    "pause done": "L'exécution est en PAUSE",
+    "unqueue": "Défilement",
+    "unqueue title": "Défilér l'exécution <code>{id}</code>.<br/>Notez qu'elle ne respectera pas la limite de concurrence du flow, donc plus d'exécutions pourraient être en cours que la limite autorisée.",
+    "unqueue title multiple": "Êtes-vous sûr de vouloir désenfiler <code>{count}</code> exécutions ?<br/><br/>Notez que cela ne respectera pas la limite de concurrence du flow, donc plus d'exécutions pourraient être en cours que la limite autorisée.",
+    "unqueue confirm": "Êtes-vous sûr de vouloir retirer de la file d'attente l'exécution <code>{id}</code> ?",
+    "unqueue done": "L'exécution est retirée de la file d'attente",
+    "force run": "Forcer l'exécution",
+    "force run title": "Forcer l'exécution de l'exécution <code>{id}</code>.",
+    "force run tooltip": "Forcer l'exécution à s'exécuter. Cela peut créer des exécutions de tâche en double, si possible utilisez une autre action.",
+    "force run confirm": "Êtes-vous sûr de vouloir forcer l'exécution <code>{id}</code>?<br/><br/>WARNING : forcer l'exécution n'est pas garanti et peut créer des exécutions de tâche en double.<br/><br/>Les transitions suivantes seront effectuées :<br/><ul><li>Les tâches CREATED seront déplacées à l'état RUNNING.</li><li>Les tâches RUNNING seront soumises à nouveau.</li><li>Les tâches QUEUED seront retirées de la file d'attente.</li><li>Les tâches PAUSED seront reprises.</li></ul>",
+    "force run done": "L'exécution est forcée d'exécuter",
+    "toggle output": "Voir les sorties",
+    "metrics": "Mesures",
+    "no data current task": "Il n'y a pas de données disponibles pour la tâche actuelle.",
+    "no metrics available": "Aucune métrique enregistrée pour cette exécution de task.",
+    "no outputs available": "Aucune sortie disponible pour cette exécution de task.",
+    "outputs": "Sorties",
+    "flow_outputs": "Sorties du flow",
+    "no_flow_outputs": "Aucune sortie disponible.",
+    "output": "Sortie",
     "eval": {
-      "expression": "Expression",
-      "preview": "Aperçu",
-      "render": "Rendre l'expression",
       "title": "Expression de débogage",
-      "tooltip": "Vous devez choisir une tâche pour évaluer une expression."
+      "render": "Rendre l'expression",
+      "tooltip": "Vous devez choisir une tâche pour évaluer une expression.",
+      "preview": "Aperçu",
+      "expression": "Expression"
     },
-    "evaluation lock date": "Date verrou évaluation",
-    "execute": "Exécuter",
-    "execute backfill": "Exécuter le backfill",
-    "execute flow behaviour": "Exécuter le flow",
-    "execute flow now ?": "Voulez-vous exécuter ce flow ?",
-    "execute the flow": "Exécuter le flow <code>{id}</code>",
-    "execution": "Exécution",
-    "execution already finished": "Exécution <code>{executionId}</code> déjà terminée",
-    "execution id": "Identifiant d'exécution",
-    "execution labels": "Labels d'exécution",
-    "execution not found": "L'exécution {executionId} est introuvable.",
-    "execution not in state FAILED": "Exécution <code>{executionId}</code> n'est pas dans l'état FAILED",
-    "execution not in state PAUSED": "Exécution <code>{executionId}</code> n'est pas dans l'état PAUSED",
-    "execution replay": "Cette exécution est une relecture de",
-    "execution replayed": "Cette exécution a été rejouée.",
-    "execution restarted": "Cette exécution a été redémarrée {nbRestart} fois.",
+    "attempt": "Essai",
+    "toggle output display": "Permuter l'affichage de sortie",
+    "name": "Nom",
+    "key": "Clé",
+    "value": "Valeur",
+    "each value": "Valeur d'itération",
+    "current execution": "Exécution en cours",
+    "parent execution": "Exécution parente",
+    "original execution": "Exécution d'origine",
+    "automatic refresh": "rafraîchissement automatique",
+    "toggle periodic refresh each x seconds": "Basculer le rafraîchissement périodique toutes les {interval} secondes",
+    "trigger refresh": "Déclencher le rafraîchissement",
+    "add-trigger-in-editor": "Ajoutez d'abord un Trigger à votre Flow",
+    "refresh": "Rafraîchir",
+    "filter by status": "Filtrer les exécutions par statut {status}",
+    "topology-graph": {
+      "graph-orientation": "Orientation du graph",
+      "zoom-in": "Zoomer",
+      "zoom-out": "Dézoomer",
+      "zoom-reset": "Zoom par défaut",
+      "zoom-fit": "Voir tout",
+      "invalid": "Erreur de graphe",
+      "invalid_description": "Une erreur s'est produite lors du chargement du graphique. Veuillez vérifier le code source pour les erreurs."
+    },
+    "show task logs": "Afficher les journaux de la tâche",
+    "show task condition": "Afficher la condition de la task",
+    "show task outputs": "Afficher les outputs de la tâche",
+    "show task source": "Afficher le code source de la tâche",
+    "specific task": "Tâche spécifique",
+    "display output for specific task": "Afficher les sorties pour cette tâche",
+    "display metric for specific task": "Afficher les mesures pour cette tâche",
+    "display direct sub tasks count": "Display les sous tâches directes",
+    "stream": "Flow",
     "execution statistics": "Statistiques d'exécution ",
-    "execution-include-non-terminated": "Inclure les exécutions non terminées ?",
-    "execution-warn-deleting-still-running": "Nous vous recommandons fortement d'annuler cette action et de terminer toute exécution en cours d'abord. Supprimer des exécutions non terminées peut entraîner des problèmes de concurrence, des incohérences dans la gestion des dépendances de flow, et des processus zombies sur votre instance, ce qui peut dégrader les performances du système. Assurez-vous de bien comprendre ces risques avant de procéder à la suppression.",
-    "execution-warn-title": "Avertissement Important !",
-    "execution_deletion": {
-      "logs": "Supprimer les journaux",
-      "metrics": "Supprimer les métriques",
-      "storage": "Supprimer les fichiers de stockage interne"
-    },
-    "execution_failed": "Échec de l'exécution !",
-    "execution_guide": {
-      "get_started": {
-        "text": "Suivez le Guide de démarrage rapide pour installer Kestra et commencer à créer vos premiers workflows.",
-        "title": "Commencer ⚡"
-      },
-      "namespaces": {
-        "text": "Les namespaces sont des regroupements logiques de flows et de leurs composants.",
-        "title": "À propos des namespaces"
-      },
-      "videos_tutorials": {
-        "text": "Commencez avec nos tutoriels vidéo.",
-        "title": "Tutoriels Vidéo"
-      },
-      "workflow_components": {
-        "text": "Découvrez les principaux composants d'orchestration d'un workflow Kestra.",
-        "title": "Composants du Workflow"
-      }
-    },
-    "execution_started": "L'exécution a commencé !",
-    "execution_starts_progress": "Une fois l'exécution commencée, vous verrez les mises à jour de progression ici.",
-    "execution_status": "L'exécution est :",
-    "executions": "Exécutions",
-    "executions deleted": "<code>{executionCount}</code> exécution(s) supprimée(s)",
+    "stats": "Stats",
+    "concurrency limits": "Limites de Concurrence",
+    "system overview": "Vue d'ensemble du système",
+    "usage": "Utilisation",
+    "namespaces": "Espaces de nom",
+    "tasks": "Tâches",
     "executions duration (in minutes)": "Durée totale d'exécutions (en minutes)",
-    "executions force run": "<code>{executionCount}</code> exécution(s) forcée(s) en cours d'exécution",
-    "executions killed": "<code>{executionCount}</code> exécution(s) arrêtée(s)",
-    "executions paused": "<code>{executionCount}</code> exécution(s) en PAUSED",
-    "executions replayed": "<code>{executionCount}</code> exécution(s) rejouée(s)",
-    "executions restarted": "<code>{executionCount}</code> exécution(s) redémarrée(s)",
-    "executions resumed": "<code>{executionCount}</code> exécution(s) reprise(s)",
-    "executions state changed": "L'état de <code>{executionCount}</code> exécution(s) a été modifié",
-    "executions unqueue": "<code>{executionCount}</code> exécution(s) en attente",
-    "expand": "Afficher",
-    "expand all": "Afficher tout",
-    "expand dependencies": "Voir les dépendances",
-    "expand error": "Afficher uniquement les erreurs",
-    "expand_by_default": "Expand structured logs by default",
-    "expiration": "Expiration",
-    "expiration date": "Date d'expiration",
-    "export": "Exporter",
-    "export all flows": "Exporter tous les flows",
-    "export all templates": "Exporter tous les templates",
-    "export_as": "Exporter en .{format}",
-    "export_csv": "Exporter en CSV",
-    "exports": "Exporter",
-    "failed to export plugin defaults": "Échec de l'exportation des paramètres par défaut du plugin",
-    "failed to import plugin defaults": "Échec de l'importation des paramètres par défaut du plugin",
-    "failed to render pdf": "Impossible de rendre l'aperçu PDF",
-    "false": "Faux",
-    "feeds": {
-      "heading": "Tout sur Kestra.",
-      "subheading": "Les dernières mises à jour, guides et histoires",
-      "title": "Quoi de neuf sur Kestra"
+    "last 48 hours": "dernières 48 heures",
+    "configure basic auth": "Configurer l'authentification basique",
+    "email": "Email",
+    "password": "Mot de passe",
+    "confirm password": "Confirmer le mot de passe",
+    "email length constraint": "L'e-mail ne doit pas dépasser 256 caractères.",
+    "password length constraint": "Le mot de passe ne doit pas dépasser 256 caractères.",
+    "password empty constraint": "Nom d'utilisateur ou mot de passe incorrect",
+    "passwords do not match": "Les mots de passe ne correspondent pas",
+    "avg duration": "Durée moyenne d'exécution",
+    "neutral trend": "Stable",
+    "up trend": "En augmentation",
+    "down trend": "En baisse",
+    "update aborted": "Mise à jour annulée",
+    "invalid flow": "Flow invalide",
+    "invalid yaml": "YAML invalide",
+    "inputs": "Entrées",
+    "no_inputs": "Aucun input disponible.",
+    "input": "Entré",
+    "variables": "Variables",
+    "variable_explorer": {
+      "title": "Entrée/Sortie",
+      "search_placeholder": "Rechercher une Key ou une value...",
+      "tasks_outputs": "Tasks outputs",
+      "tree": "Arborescence",
+      "raw_json": "Raw JSON",
+      "select_prompt": "Sélectionnez une variable pour inspecter sa value.",
+      "empty": "Aucune variable disponible pour cette exécution.",
+      "one_key": "\\{ 1 key \\}",
+      "n_keys": "\\{ {count} keys \\}",
+      "one_item": "[ 1 élément ]",
+      "n_items": "[ {count} éléments ]"
     },
-    "file preview truncated": "Displayed content has been truncated",
-    "file unavailable": "Fichier indisponible",
-    "file unavailable description": "Ce fichier n'est plus disponible — il a peut-être été supprimé ou expiré.",
-    "fileTypeNotAllowed": "Type de fichier non autorisé. Types acceptés : {types}",
     "file_preview": {
       "big_file_warning": "Ce fichier fait {size}. Le chargement peut prendre un certain temps et bloquer votre navigateur. Voulez-vous quand même le charger ?",
       "load_anyway": "Charger quand même"
     },
-    "files": "Fichiers",
-    "filter by log level": "Filtrer par niveau de log",
-    "filter by status": "Filtrer les exécutions par statut {status}",
-    "filter by this value": "Filter by this value",
-    "filter_for": "Filter for",
-    "filter_out": "Filter out",
-    "filters": {
-      "comparators": {
-        "between": "entre",
-        "contains": "contient",
-        "ends_with": "se termine par",
-        "greater_than": "plus grand que",
-        "greater_than_or_equal_to": "supérieur ou égal à",
-        "in": "dans",
-        "is": "est",
-        "is_not": "n'est pas",
-        "is_one_of": "est l'un de",
-        "less_than": "moins de",
-        "less_than_or_equal_to": "inférieur ou égal à",
-        "not_contains": "ne contient pas",
-        "not_in": "n'est pas dans",
-        "starts_with": "commence par"
-      },
-      "empty": "Aucune donnée.",
-      "format": "Tapez le paramètre comme 'key:value'",
-      "label": "Choisir des filtres",
-      "options": {
-        "absolute_date": "Date absolue",
-        "action": "Action",
-        "aggregation": "Agrégation",
-        "child": "Enfant",
-        "details": "Détails",
-        "endDate": "Date de fin",
-        "flow": "Flux",
-        "labels": "Étiquettes",
-        "level": "Niveau de log",
-        "metric": "Métrique",
-        "namespace": "Namespace",
-        "permission": "Permission",
-        "relative_date": "Date relative",
-        "scope": "Portée",
-        "service_type": "Type",
-        "startDate": "Date de début",
-        "state": "État",
-        "status": "Statut",
-        "task": "Tâche",
-        "text": "I'm sorry, but it seems like there is no text provided for translation. Could you please provide the text you would like to have translated into French?",
-        "type": "Type",
-        "user": "Utilisateur"
-      },
-      "save": {
-        "dialog": {
-          "confirmation": "Critères de recherche <code>{name}</code>",
-          "heading": "Enregistrer la recherche actuelle",
-          "hint": "Comment souhaitez-vous étiqueter ce critère de recherche ?",
-          "placeholder": "Étiquette"
-        },
-        "empty": "Vous n'avez pas encore enregistré de recherche.",
-        "label": "Recherches enregistrées",
-        "name_already_used": "Le label de recherche est déjà utilisé.",
-        "remove": "Supprimer",
-        "tooltip": "Vous ne pouvez pas enregistrer des critères de recherche vides."
-      },
-      "settings": {
-        "label": "Paramètres de la page",
-        "show_chart": "Afficher le graphique principal"
-      },
-      "text_search": "Rechercher ce texte"
-    },
-    "fix_with_ai": "Corriger avec l'IA",
-    "flow": "Flow",
-    "flow already exists": "Flow déjà existant",
-    "flow already exists message": "Le flow <code>{id}</code> existe déjà dans le namespace <code>{namespace}</code>. Voulez-vous créer une nouvelle révision ?",
-    "flow creation": "Création de flow",
-    "flow creation denied in namespace": "Vous n'avez pas la permission de créer des flows dans le namespace `{namespace}`.",
-    "flow delete": "Êtes vous sûr de vouloir supprimer <code>{flowCount}</code> flow(s)?",
-    "flow deleted, you can restore it": "Le flow a été supprimé et ceci est une vue en lecture seule, mais vous pouvez toujours le restaurer.",
-    "flow disable": "Êtes vous sûr de vouloir désactiver <code>{flowCount}</code> flow(s)?",
-    "flow enable": "Êtes vous sûr de vouloir activer <code>{flowCount}</code> flow(s)?",
-    "flow export": "Êtes vous sûr de vouloir exporter <code>{flowCount}</code> flow(s)?",
-    "flow must have id and namespace": "Le flow doit avoir un id et un namespace.",
-    "flow must not be empty": "Le flow ne doit pas être vide",
-    "flow not imported": "Certains flow n'ont pas pu être importés",
-    "flow revision latest": "Dernière révision du flow",
-    "flow revision original": "Révision originale du flow",
-    "flow revision specific": "Révision spécifique du flow",
-    "flow source not found": "Source du flow introuvable",
-    "flow-dependencies": "dépendances",
-    "flow-no-dependencies": "Votre flow n'a pas de dépendances.",
-    "flow_editor_stats": {
-      "apps": {
-        "suffix": "Application(s)",
-        "tooltip": "Voir les applications utilisant ce flow"
-      },
-      "dependencies": {
-        "suffix": "Dépendances",
-        "tooltip": "Voir les dépendances du flow"
-      },
-      "errors": {
-        "label": "{count} Erreur(s)"
-      },
-      "revisions": {
-        "suffix": "Révision(s)",
-        "tooltip": "Voir les révisions du flow"
-      },
-      "tests": {
-        "suffix": "Test(s)",
-        "tooltip": "Voir les tests de flow"
-      }
-    },
-    "flow_export": "Exporter le flow",
-    "flow_only": "Disponible uniquement sur l'onglet Flow.",
-    "flow_outputs": "Sorties du flow",
-    "flows": "Flows",
-    "flows deleted": "<code>{count}</code> Flow(s) supprimé(s)",
-    "flows disabled": "<code>{count}</code> Flow(s) désactivé(s)",
-    "flows enabled": "<code>{count}</code> Flow(s) activé(s)",
-    "flows exported": "<code>{count}</code> Flow(s) exporté(s)",
-    "flows imported": "Flux importés",
-    "focus task": "Cliquer sur une tâche pour voir sa documentation",
-    "fold_all_multi_lines": "Replier toutes les lignes multiples",
-    "font size": "Font size",
-    "for flow": "pour flow",
-    "forbidden system labels": "Seul system.correlationId peut être utilisé comme system label",
-    "force run": "Forcer l'exécution",
-    "force run confirm": "Êtes-vous sûr de vouloir forcer l'exécution <code>{id}</code>?<br/><br/>WARNING : forcer l'exécution n'est pas garanti et peut créer des exécutions de tâche en double.<br/><br/>Les transitions suivantes seront effectuées :<br/><ul><li>Les tâches CREATED seront déplacées à l'état RUNNING.</li><li>Les tâches RUNNING seront soumises à nouveau.</li><li>Les tâches QUEUED seront retirées de la file d'attente.</li><li>Les tâches PAUSED seront reprises.</li></ul>",
-    "force run done": "L'exécution est forcée d'exécuter",
-    "force run title": "Forcer l'exécution de l'exécution <code>{id}</code>.",
-    "force run tooltip": "Forcer l'exécution à s'exécuter. Cela peut créer des exécutions de tâche en double, si possible utilisez une autre action.",
-    "form": "Formulaire",
-    "form error": "Formulaire invalid",
-    "from": "De",
-    "gantt": "Gantt",
-    "gantt_no_tasks_executed": "Cette exécution s'est terminée sans exécuter de tâche.  \nConsultez son aperçu et ses logs pour en connaître la raison.",
-    "gantt_no_tasks_match_filters": "Essayez d'ajuster les filtres de recherche, d'état ou de niveau de log.",
-    "gantt_no_tasks_match_filters_title": "Aucune tâche ne correspond aux filtres sélectionnés.",
-    "healthcheck date": "Dernier Healthcheck",
-    "hide task documentation": "Cacher la documentation des tâches",
-    "home": "Accueil",
-    "hostname": "Nom d'hôte",
-    "iam": "IAM",
-    "id": "Identifiant",
-    "import": "Importer",
-    "in-our-documentation": "dans notre documentation.",
-    "informative notice": "Note(s)",
-    "input": "Entré",
-    "inputs": "Entrées",
-    "instance": "Instance",
-    "invalid bulk delete": "Impossible de supprimer les exécutions",
-    "invalid bulk force run": "Impossible de forcer l'exécution des exécutions",
-    "invalid bulk kill": "Impossible d'arrêter les exécutions",
-    "invalid bulk pause": "Impossible de mettre en pause les exécutions",
-    "invalid bulk replay": "Impossible de rejouer les exécutions",
-    "invalid bulk restart": "Impossible de redémarrer les exécutions",
-    "invalid bulk resume": "Impossible de reprendre les exécutions",
-    "invalid bulk unqueue": "Impossible de retirer les exécutions de la file d'attente",
-    "invalid field": "Champ invalide: {name}",
-    "invalid flow": "Flow invalide",
-    "invalid source": "Code source invalide",
-    "invalid yaml": "YAML invalide",
-    "is deprecated": "est déprécié(e)",
-    "is required": "{field} est requis",
-    "item": "élément",
-    "items": "éléments",
-    "join community": "Rejoignez la communauté",
-    "join_slack": "Rejoindre Slack",
-    "jsonl": "JSONL",
-    "jump to...": "Aller à...",
-    "kestra": "Kestra",
-    "key": "Clé",
-    "kill": "Arrêter",
-    "kill only parents": "Tuer uniquement le courant",
-    "kill parents and subflow": "Tuer le flow actuel et les subflows",
-    "killed confirm": "Êtes-vous sur de vouloir arrêter l'exécution <code>{id}</code> ?",
-    "killed done": "L'exécution est en attente d'arrêt",
-    "kv": {
-      "add": "Créer",
-      "delete multiple": {
-        "confirm": "Êtes-vous sûr de vouloir supprimer : <code>{name}</code> KV(s) ?",
-        "warning": "Vous n'avez pas les autorisations pour ces namespaces, ils seront donc omis : <code>{namespaces}</code>"
-      },
-      "duplicate": "Cette clé existe déjà",
-      "inherited": "Paires KV héritées",
-      "name": "Stockage de clés/valeurs",
-      "type": "Type",
-      "update": "Mettre à jour la valeur pour la clé '{key}'"
-    },
-    "label": "Label",
-    "label filter placeholder": "Label au format 'clé:valeur'",
-    "labels": "Labels",
-    "last 48 hours": "dernières 48 heures",
-    "last X days count": "{count} lors des {days} derniers jours",
-    "last error was": "La dernière erreur était",
-    "last evaluation date": "Date de la dernière évaluation",
-    "last evaluation date tooltip": "When the trigger was last evaluated by the scheduler, regardless of whether it produced an execution.",
-    "last execution date": "Dernière exécution",
-    "last execution state": "Dernier état",
-    "last execution status": "Statut de la dernière exécution",
-    "last modified": "Dernière modification",
-    "last trigger date": "Dernière date de trigger",
-    "last trigger date tooltip": "Dernière exécution du trigger. Peut être dans le passé lors de l'exécution d'un backfill.",
-    "latest_update": "Dernière mise à jour",
-    "launch execution": "Déclencher",
-    "learn_more": "En savoir plus",
-    "leave page": "Quitter la page",
-    "license": "Licence",
-    "light_background": "C'est l'option préférée lorsque vous travaillez avec un fond clair.",
-    "light_version": "Version légère",
-    "line": "Ligne",
-    "line-by-line": "ligne par ligne",
-    "loaded x dependencies": "{count} dépendances chargées",
-    "loading": "Chargement...",
-    "log expand setting": "Affichage par défaut des journaux",
-    "logExporters": "Exportateurs de Logs",
-    "logs": "Fichiers journaux",
-    "logs_copied": "Logs copied to your clipboard",
-    "logs_view": {
-      "compact": "Vue par défaut",
-      "compact_details": "Affiche les logs dans un format compacte regroupé par tâche",
-      "raw": "Vue temporelle",
-      "raw_details": "Affiche les logs des tâches et du flow dans un format brut ordonné par horodatage"
-    },
-    "main_configuration": "Configuration Principale",
-    "manage labels": "Gérer les labels",
-    "management port": "Port de gestion",
-    "mark as": "Marqué comme <code>{status}</code>",
-    "max": "Maximum",
-    "mcp": {
-      "api_token": "Jeton API",
-      "auth_type": "Authentification",
-      "basic_auth": "Authentification de base",
-      "bearer_token": "Authentification par jeton Bearer",
-      "client_setup": "Configuration du client",
-      "connect": "Connecter",
-      "connect_tab": {
-        "auth_api_token_hint": "Définissez <code>KESTRA_TOKEN</code> comme variable d'environnement avant de démarrer le client.",
-        "auth_basic_hint": "Définissez <code>KESTRA_BASIC_AUTH</code> comme variable d'environnement contenant une chaîne <code>username:password</code> encodée en base64 avant de démarrer le client.",
-        "auth_oauth_browser_hint": "Votre navigateur ouvrira la page de connexion du fournisseur d'identité lors de la première connexion.",
-        "auth_oauth_client_id_hint": "Remplacez <code>&lt;client-id&gt;</code> par l'ID client OAuth, et enregistrez <code>http://localhost:7777</code> comme URI de redirection valide sur ce client.",
-        "claude_code": "Code Claude",
-        "claude_code_hint": "Exécutez la commande suivante dans votre terminal :",
-        "claude_desktop": "Claude Desktop",
-        "claude_desktop_hint": "Ajoutez ce qui suit à votre fichier claude_desktop_config.json :",
-        "claude_desktop_mac": "macOS : ~/Library/Application Support/Claude/claude_desktop_config.json",
-        "claude_desktop_win": "Windows : %APPDATA%\\Claude\\claude_desktop_config.json",
-        "client_picker_label": "Choisissez votre client IA",
-        "codex": "Codex (OpenAI)",
-        "codex_hint": "Ajoutez ce qui suit à votre configuration MCP codex.json :",
-        "cursor": "Curseur",
-        "cursor_hint": "Ajoutez ce qui suit à ~/.cursor/mcp.json :",
-        "server_url": "URL du serveur"
-      },
-      "copy_url": "Copier l'URL",
-      "create": "Créer un serveur",
-      "delete_confirm": "Êtes-vous sûr de vouloir supprimer ce serveur MCP ?",
-      "id_invalid": "L'ID doit commencer par une lettre minuscule ou un chiffre, et ne contenir que des lettres minuscules, des chiffres, des tirets ou des underscores.",
-      "id_placeholder": "par exemple, mon-serveur-mcp",
-      "instructions": "Instructions",
-      "main_tenant": "principal",
-      "managed_by_kestra": "Géré par Kestra",
-      "no_oauth_providers": "Aucun fournisseur OIDC configuré dans cette instance",
-      "no_servers": "Aucun serveur MCP trouvé. Créez votre premier serveur pour exposer les triggers MCP Tool aux agents IA externes.",
-      "oauth": "OAuth",
-      "oauth_hint": "Bearer JWT de votre fournisseur OIDC",
-      "oauth_provider": "Fournisseur OAuth",
-      "oauth_provider_placeholder": "Sélectionnez un fournisseur OIDC configuré",
-      "oauth_provider_required": "Le fournisseur OAuth est requis lorsque le type d'authentification est OAuth",
-      "page_description": "Exposez vos flows Kestra comme outils pour les agents IA compatibles MCP",
-      "private": "Privé",
-      "private_server": "Serveur privé",
-      "public": "Public",
-      "public_hint": "Avertissement : Les serveurs publics ne nécessitent aucune authentification. Toute personne disposant de l'URL peut appeler chaque outil exposé par ce serveur, sans vérification de namespace ni de permissions. À utiliser uniquement pour les serveurs qu'il est sûr d'exposer en externe.",
-      "save": "Enregistrer les modifications",
-      "scopes_supported": "Scopes pris en charge",
-      "scopes_supported_hint": "Scopes annoncés dans le document Protected Resource Metadata de ce serveur. Les clients MCP conformes à la spécification limitent leur requête d'autorisation à cette liste. Laissez vide pour omettre le champ et laisser les clients utiliser les scopes annoncés par l'IdP.",
-      "scopes_supported_placeholder": "openid, profile, email",
-      "server": "Serveur MCP",
-      "server_id": "ID du serveur",
-      "server_type": "Type de serveur",
-      "servers": "Serveurs MCP",
-      "servers_count": "{count} serveurs MCP",
-      "tab_connect": "Connecter",
-      "tab_edit": "Modifier",
-      "tab_tool_flows": "Flux d'Outils",
-      "tab_tool_flows_placeholder": "La gestion des flows d'outils arrive bientôt.",
-      "tools": {
-        "annotations": "Annotations",
-        "create_tool_flow": "Créer un flow d'outil",
-        "description": "Description",
-        "destructive": "Destructif",
-        "flow": "flow",
-        "idempotent": "Idempotent",
-        "no_tools": "Aucun flow d'outil ne correspond à votre recherche.",
-        "open_world": "Open world",
-        "read_only": "Lecture seule",
-        "return_direct": "Retour direct",
-        "state": "État",
-        "title": "Titre",
-        "tool_name": "Nom de l'outil",
-        "trigger_id": "ID du trigger",
-        "view_flow": "Ouvrir le flow"
-      },
-      "url_copied": "URL copiée !",
-      "username_password": "Nom d'utilisateur & mot de passe",
-      "your_servers": "Vos Serveurs"
-    },
-    "metric": "Métrique",
-    "metric choice": "Aucune métrique disponible pour ce flow",
-    "metrics": "Mesures",
-    "min": "Minimum",
-    "missingSource": "Source manquant",
-    "modify inputs": "Modifier les inputs",
-    "modify_inputs": "Modifier les inputs",
-    "monogram": "Monogramme",
-    "more actions": "Plus d'actions",
-    "more_actions": "Plus d'actions",
-    "multi_panel_editor": {
-      "close_all_panels": "Fermer tous les panneaux",
-      "close_all_tabs": "Fermer tous les onglets",
-      "move_left": "Déplacer à gauche",
-      "move_right": "Déplacer vers la droite"
-    },
-    "multiple saved done": "{name} ont été enregistré(e)s",
-    "name": "Nom",
-    "namespace": "Espace de nom",
-    "namespace and id readonly": "Le namespace et l'id ne sont pas modifiables. Ils ont été réinitialisés à leur valeur initiale.",
-    "namespace files": {
-      "create": {
-        "file": "Créer un fichier",
-        "file_already_exists": "Un fichier avec ce nom existe déjà",
-        "file_conflicts_with_folder": "Un dossier avec ce nom existe déjà",
-        "file_error": "Une erreur s'est produite lors de la création du fichier",
-        "folder": "Créer un dossier",
-        "folder_already_exists": "Un dossier avec ce nom existe déjà",
-        "folder_conflicts_with_file": "Un fichier avec ce nom existe déjà",
-        "folder_error": "Une erreur s'est produite lors de la création du dossier",
-        "label": "Créer"
-      },
-      "delete": {
-        "file": "Supprimer le fichier",
-        "files": "Supprimer {count} fichiers sélectionnés",
-        "folder": "Supprimer le dossier",
-        "folders": "Supprimer {count} dossiers sélectionnés",
-        "label": "Supprimer"
-      },
-      "dialog": {
-        "deletion": {
-          "confirm": "Confirmer",
-          "file_single": "Êtes-vous sûr de vouloir supprimer le fichier <code>{name}</code> ?",
-          "files": "Êtes-vous sûr de vouloir supprimer <code>{count}</code> fichier(s) ?",
-          "folder_single": "Êtes-vous sûr de vouloir supprimer le dossier <code>{name}</code> et tout son contenu ?",
-          "folders": "Êtes-vous sûr de vouloir supprimer <code>{count}</code> dossier(s) et tout son contenu ?",
-          "mixed": "Êtes-vous sûr de vouloir supprimer le(s) dossier(s) <code>{folders}</code> et le(s) fichier(s) <code>{files}</code> ?",
-          "title": "Confirmer la suppression du contenu"
-        },
-        "name": {
-          "file": "Nom avec extension :",
-          "folder": "Nom du dossier :"
-        },
-        "parent_folder": "Dossier parent :"
-      },
-      "export": "Exporter les fichiers de l'espace de noms",
-      "export_single": "Exporter le fichier",
-      "filter": "Filtrer",
-      "import": {
-        "error": "Des erreurs se sont produites lors de l'importation du(des) fichier(s)",
-        "files": "Importer des fichiers",
-        "folder": "Importer un dossier",
-        "import": "Importer",
-        "success": "Fichier(s) importé(s) avec succès"
-      },
-      "new_file": "Nouveau fichier",
-      "no_items": {
-        "heading": "Aucun fichier trouvé dans votre namespace pour le moment.",
-        "paragraph": "Créer ou importer des fichiers pour partager du code entre les flows dans votre namespace."
-      },
-      "no_selection": {
-        "description": "Sélectionnez un fichier dans l'arborescence pour afficher son contenu.",
-        "heading": "Aucun fichier sélectionné"
-      },
-      "path": {
-        "copy": "Copier le chemin",
-        "error": "Des erreurs se sont produites lors de la copie du chemin dans le presse-papiers",
-        "success": "Chemin copié dans le presse-papiers"
-      },
-      "rename": {
-        "file": "Renommer le fichier",
-        "folder": "Renommer le dossier",
-        "label": "Renommer",
-        "new_file": "Nouveau nom avec extension :",
-        "new_folder": "Nouveau nom de dossier :"
-      },
-      "revisions": {
-        "history": "Historique des révisions",
-        "restore": {
-          "success": "Révision du fichier restaurée avec succès"
-        }
-      },
-      "toggle": {
-        "hide": "Masquer les fichiers de l'espace de noms",
-        "show": "Afficher les fichiers de l'espace de noms"
-      },
-      "tree": {
-        "collapse": "Réduire tous les dossiers",
-        "expand": "Développer tous les dossiers"
-      }
-    },
-    "namespace not allowed": "Espace de nom non autorisé",
-    "namespace_editor": {
-      "close": {
-        "all": "Fermer tous les onglets",
-        "other": "Fermer les autres onglets",
-        "right": "Fermer à droite",
-        "tab": "Fermer l'onglet"
-      },
-      "empty": {
-        "create_message": "Vous pouvez créer ou importer des fichiers de namespace.",
-        "title": "Aucun onglet actuellement ouvert",
-        "video_message": "Vous pouvez regarder la vidéo d'introduction pour notre éditeur."
-      }
-    },
-    "namespaces": "Espaces de nom",
-    "neutral trend": "Stable",
-    "new": "Nouveau",
-    "new version": "Nouvelle version {version} disponible!",
-    "next": "Suivant",
-    "next evaluation date": "Prochaine date d'évaluation",
-    "next evaluation date tooltip": "Quand le trigger sera évalué la prochaine fois, en fonction de son intervalle. Pas toujours identique à la prochaine date d'exécution si les conditions ne sont pas remplies.",
-    "next execution date": "Prochaine date d'exécution",
-    "next_execution": "Prochaine exécution",
-    "no data current task": "Il n'y a pas de données disponibles pour la tâche actuelle.",
-    "no inputs": "Ce flow n'a pas d'entrée.",
-    "no metrics available": "Aucune métrique enregistrée pour cette exécution de task.",
-    "no outputs available": "Aucune sortie disponible pour cette exécution de task.",
-    "no result": "Il n'y a aucun résultat à afficher.",
-    "no revisions": "Aucune révision",
-    "no revisions found": "Une seule révision existe pour ce flow",
-    "no-executions-view": {
-      "guidance_desc": "Besoin d'aide pour exécuter votre flow ?",
-      "guidance_sub_desc": "Suivez la documentation pour toutes les informations dont vous avez besoin.",
-      "namespace_guidance_desc": "Besoin de conseils pour gérer votre Namespace ?",
-      "namespace_sub_title": "Exécutez un ou plusieurs flows de ce namespace pour remplir ce tableau de bord.",
-      "sub_title": "Cliquez sur le bouton Exécuter pour démarrer l'exécution de votre premier workflow.",
-      "title": "Commencez à automatiser avec"
-    },
-    "no_code": {
-      "add_field": "Ajouter {field}",
-      "adding": "+ Ajouter un {what}",
-      "adding_default": "+ Ajouter une nouvelle valeur",
-      "clearSelection": "Effacer la sélection",
-      "creation": {
-        "afterExecution": "Ajouter un bloc après l'exécution",
-        "charts": "Ajouter un graphique",
-        "conditions": "Ajouter une condition",
-        "default": "Ajouter",
-        "errors": "Ajouter un gestionnaire d'erreurs",
-        "finally": "Ajouter un bloc finally",
-        "inputs": "Ajouter un champ d'input",
-        "numerator": "Ajouter un numérateur",
-        "pluginDefaults": "Ajouter un plugin par défaut",
-        "tasks": "Ajouter une tâche",
-        "triggers": "Ajouter un trigger",
-        "where": "Filtrer vos données"
-      },
-      "fields": {
-        "general": {
-          "checks": "Vérifications",
-          "concurrency": "Concurrence",
-          "disabled": "Désactivé",
-          "labels": "Étiquettes",
-          "listeners": "Auditeurs",
-          "outputs": "Sorties",
-          "retry": "Réessayer",
-          "sla": "SLA",
-          "taskDefaults": "Paramètres par défaut des Tasks",
-          "updated": "Mis à jour",
-          "variables": "Variables",
-          "workerGroup": "Groupe de Workers",
-          "workerSelector": "Sélecteur de Worker"
-        },
-        "main": {
-          "description": "Description",
-          "id": "ID de flow",
-          "inputs": "Entrées",
-          "namespace": "Namespace"
-        }
-      },
-      "labels": {
-        "label": "Étiquette",
-        "no_code": "Éditeur sans code",
-        "variable": "Variable",
-        "yaml": "Éditeur YAML"
-      },
-      "remove": {
-        "cases": "Supprimer ce cas",
-        "default": "Supprimer cette entrée"
-      },
-      "sections": {
-        "afterExecution": "Après l'Exécution",
-        "deprecated": "Propriétés obsolètes",
-        "errors": "Gestionnaires d'erreurs",
-        "finally": "Enfin",
-        "pluginDefaults": "Paramètres par défaut du plugin",
-        "tasks": "Tâches",
-        "triggers": "Déclencheurs"
-      },
-      "select": {
-        "afterExecution": "Sélectionnez une task",
-        "charts": "Sélectionner un type de graphique",
-        "conditions": "Sélectionner une condition",
-        "default": "Sélectionner un type",
-        "errors": "Sélectionner une task",
-        "finally": "Sélectionnez une task",
-        "inputs": "Sélectionnez un type de champ input",
-        "numerator": "Sélectionnez un numérateur",
-        "pluginDefaults": "Sélectionner un plugin",
-        "task": "Sélectionnez une task",
-        "tasks": "Sélectionnez une task",
-        "triggers": "Sélectionner un trigger",
-        "where": "Sélectionnez un type de filtre"
-      },
-      "toggle_pebble": "Basculer l'éditeur Pebble",
-      "unnamed": "Aucun Nom",
-      "version_oss_placeholder": "Kestra Enterprise permet de versionner les plugins"
-    },
-    "no_data": "On dirait qu'il n'y a rien ici… pour l'instant !<br/>Ajustez vos filtres, ou réessayez !",
-    "no_file_choosen": "Aucun fichier choisi",
-    "no_flow_outputs": "Aucune sortie disponible.",
-    "no_history": "Aucun historique disponible",
-    "no_inputs": "Aucun input disponible.",
-    "no_logs_data": "Pas de données",
-    "no_logs_data_description": "Veuillez essayer d'ajuster vos filtres, de changer la plage de temps, ou vérifier si le flow a été exécuté récemment.",
-    "no_logs_data_title": "Aucun log trouvé pour les filtres sélectionnés.",
-    "no_namespaces": "Zéro espace de noms correspond aux critères de recherche.",
-    "no_results": {
-      "assets": "Aucun actif trouvé",
-      "executions": "Aucune exécution trouvée",
-      "flows": "Aucun flow trouvé",
-      "kv_pairs": "Aucune paire clé-valeur trouvée",
-      "secrets": "Aucun secret trouvé",
-      "templates": "Aucun modèle trouvé",
-      "triggers": "Aucun Trigger trouvé"
-    },
-    "no_results_found": "Aucun résultat trouvé",
-    "no_tasks_running": "Aucune tâche n'est encore en cours d'exécution.",
-    "no_trigger": "Aucun trigger disponible.",
     "no_variables": "Aucune variable disponible.",
-    "now": "Maintenant",
-    "of": "de",
-    "ok": "OK",
-    "onboarding": {
-      "actions": {
-        "cancel_tutorial": "Annuler le tutoriel",
-        "complete": "Terminer",
-        "edit_flow_to_continue": "Cliquez sur Modifier le flow dans la barre du haut (à droite).",
-        "execute_to_continue": "1. Cliquez sur Exécuter dans la barre du haut (à droite).\n2. Fournissez une valeur pour <strong>name</strong>.\n3. Cliquez à nouveau sur Exécuter dans la fenêtre modale.",
-        "finish_tutorial": "Terminer le tutoriel",
-        "next": "Suivant",
-        "save_to_continue": "Cliquez sur Enregistrer dans la barre du haut (à droite)."
-      },
-      "cancel_modal": {
-        "confirm": "Annuler le tutoriel",
-        "description": "Voulez-vous annuler le tutoriel Premier Flow ?",
-        "keep": "Conserver le tutoriel",
-        "title": "Annuler le tutoriel Premier Flow"
-      },
-      "editor_hints": {
-        "build_intro": "Créez votre premier flow étape par étape.",
-        "step_1": "# 1) Ajouter l’id",
-        "step_2": "# 2) Ajouter le namespace",
-        "step_3": "# 3) Ajouter un input",
-        "step_4": "# 4) Ajouter des tâches et votre première tâche Python",
-        "step_5": "# 5) Ajouter un trigger cron"
-      },
-      "finish_actions": {
-        "create_flow": "Créer un flow",
-        "explore_blueprints": "Explorer les Blueprints"
-      },
-      "steps": {
-        "add_cron_trigger": {
-          "description": "Les triggers peuvent démarrer des runs selon des horaires ou des événements externes (par exemple des webhooks ou des messages MQTT).<br><br>Ajoutez maintenant un trigger de planification cron pour que ce flow s’exécute toutes les 5 minutes.",
-          "title": "Ajouter un trigger cron"
-        },
-        "add_id": {
-          "description": "L’ID est le nom unique de votre flow, afin que vous puissiez le retrouver, l’exécuter et le référencer de manière cohérente.<br><br>Ajoutez maintenant <code>id</code> au niveau racine.",
-          "title": "Ajouter l’ID du flow"
-        },
-        "add_input": {
-          "description": "Les inputs sont des paramètres au niveau du flow qui peuvent être référencés dans les tâches pour contrôler dynamiquement le comportement à l’exécution.<br><br>Ajoutez maintenant un input nommé <code>name</code> avec le type <code>STRING</code>.",
-          "title": "Ajouter une entrée"
-        },
-        "add_input_default": {
-          "description": "Lorsqu’un flow est déclenché automatiquement, les inputs ont tout de même besoin de valeurs à l’exécution.<br><br>L’input <code>name</code> a déjà été créé à l’étape précédente, il n’est donc pas nécessaire de l’ajouter à nouveau. Définissez simplement une valeur par défaut pour l’input existant <code>name</code>.",
-          "title": "Définir une valeur par défaut pour l’input"
-        },
-        "add_log_task": {
-          "description": "Les tâches sont les unités de travail exécutées par votre flow, définies comme une liste ordonnée d’étapes. Chaque tâche a besoin d’un <code>id</code> unique et d’un <code>type</code>. Kestra fournit de nombreux plugins de tâches pour des systèmes externes ; ici, nous utilisons une tâche de script Python.<br><br>La syntaxe <code>&#123;&#123; ... &#125;&#125;</code> est une expression Pebble, utilisée pour référencer des variables dynamiquement à l’exécution, comme <code>&#123;&#123; inputs.name &#125;&#125;</code> depuis vos inputs de flow.<br><br>Ajoutez maintenant la première tâche sous <code>tasks</code> avec <code>id</code>, <code>type</code> et un <code>script</code> qui affiche un message de bienvenue.",
-          "title": "Ajouter la première tâche"
-        },
-        "add_namespace": {
-          "description": "Le Namespace est un regroupement de type dossier qui organise les flows par équipe, projet ou environnement.<br><br>Ajoutez maintenant <code>namespace</code> au niveau racine.",
-          "title": "Ajouter un namespace"
-        },
-        "background_runs_info": {
-          "description": "Ce flow s’exécutera désormais en arrière-plan toutes les 5 minutes.<br><br>Vous pouvez accéder à la vue d’ensemble des Exécutions depuis le menu de gauche pour surveiller les runs planifiés.",
-          "title": "Exécutions planifiées"
-        },
-        "edit_flow_from_execution": {
-          "description": "Vous pouvez revenir directement d’une exécution à la définition du flow pour itérer rapidement.",
-          "title": "Retourner à l’éditeur de flows"
-        },
-        "execute_flow": {
-          "description": "L’exécution démarre un run de votre flow avec des valeurs d’input au moment de l’exécution.",
-          "title": "Exécuter le flow"
-        },
-        "finish": {
-          "description": "Bon début. Vous avez créé, exécuté, paramétré et planifié un flow.<br><br>Choisissez ce que vous souhaitez faire ensuite ...",
-          "title": "Vous avez terminé le tutoriel Premier Flow"
-        },
-        "flow_basics": {
-          "description": "Dans Kestra, un <code>flow</code> est l’unité centrale d’orchestration. Vous le définissez en YAML avec des métadonnées et des tâches ordonnées.<br><br>Examinez la structure d’exemple ci-dessous, puis continuez à la construire étape par étape.",
-          "title": "Les bases des flows"
-        },
-        "save_flow": {
-          "description": "L’enregistrement conserve la définition de votre flow afin qu’il puisse être exécuté.",
-          "title": "Enregistrer le flow"
-        },
-        "save_flow_again": {
-          "description": "Votre flow dispose maintenant d’un planning et d’une valeur d’input par défaut pour les exécutions automatiques.",
-          "title": "Enregistrer le flow"
-        },
-        "view_logs_status": {
-          "description": "Les détails d’exécution affichent le statut du run, les temps et les logs de sortie au niveau des tâches.<br><br>Ouvrez maintenant les détails d’exécution et cliquez sur <code>greet</code> dans le diagramme de Gantt pour voir les logs.",
-          "title": "Vérifier l’exécution"
-        }
-      },
-      "validation": {
-        "add_cron_trigger_cron": "Ajoutez une expression cron, par exemple : `\"*/5 * * * *\"`.",
-        "add_cron_trigger_section": "Créez une section `triggers` avec un trigger de planification.",
-        "add_cron_trigger_type": "Définissez le type du trigger sur `io.kestra.plugin.core.trigger.Schedule`.",
-        "add_id": "Ajoutez un ID de flow en haut. Exemple : `id: hello_flow`.",
-        "add_input_default_defaults": "Ajoutez une valeur par défaut pour `name`, par exemple : `defaults: \"Kestra\"`.",
-        "add_input_default_id": "Conservez l’ID de l’input existant comme `name`.",
-        "add_input_default_section": "Revenez à `inputs` et conservez un input existant nommé `name` (n’ajoutez pas un second input).",
-        "add_input_id": "Dans `inputs`, ajoutez `id: name`.",
-        "add_input_section": "Créez une section `inputs` avec un input.",
-        "add_input_type": "Définissez le type de l’input sur `STRING`.",
-        "add_log_task_id": "Donnez un ID à la tâche, par exemple : `id: greet`.",
-        "add_log_task_message": "Ajoutez un champ `script` à la tâche.",
-        "add_log_task_pebble": "Utilisez une expression Pebble dans le script afin qu’il utilise votre valeur d’input (par exemple : `inputs.name`).",
-        "add_log_task_section": "Créez une section `tasks` et ajoutez votre première tâche.",
-        "add_log_task_type": "Définissez le type de la tâche sur `io.kestra.plugin.scripts.python.Script`.",
-        "add_namespace": "Ajoutez un namespace en haut. Exemple : `namespace: company.team`.",
-        "complete_step": "Vous y êtes presque. Terminez cette étape pour continuer.",
-        "edit_flow_from_execution": "Cliquez sur `Modifier le flow` dans la barre du haut pour continuer.",
-        "execute_flow": "Exécutez le flow une fois pour continuer.",
-        "fix_yaml": "Il y a un petit problème de formatage YAML. Corrigez-le, puis continuez.",
-        "save_flow": "Cliquez sur Enregistrer pour continuer.",
-        "save_flow_again": "Cliquez à nouveau sur Enregistrer pour continuer.",
-        "view_logs_status": "Ouvrez les détails d’exécution et vérifiez les logs pour `greet`."
-      },
-      "welcome": {
-        "additional_help": "Aide supplémentaire",
-        "badge": "Tutoriel",
-        "blueprints": "Blueprints",
-        "docs": "Documentation",
-        "guided_description": "Apprenez à créer et exécuter votre premier flow grâce à des étapes guidées.",
-        "guided_duration": "Recommandé pour la plupart",
-        "guided_title": "Créez votre premier flow",
-        "headline": "Créez et exécutez votre premier workflow en quelques minutes",
-        "self_serve_description": "Accédez directement à l’éditeur et créez votre propre flow.",
-        "self_serve_note": "Pour les utilisateurs expérimentés",
-        "self_serve_title": "Créer un flow à partir de zéro",
-        "slack": "Communauté Slack",
-        "tutorial": "Tutoriel"
-      }
+    "download": "Télécharger",
+    "jsonl": "JSONL",
+    "concurrency_limit": {
+      "dialog_title": "Limites de Concurrence",
+      "warning": "Modifier le compteur en cours peut corrompre la concurrence, de sorte que les exécutions peuvent dépasser la limite autorisée."
     },
-    "open": "Afficher",
-    "open full page": "Ouvrir la page complète",
-    "open in new tab": "Dans un nouvel onglet",
-    "open in same tab": "Dans le même onglet",
-    "open sidebar": "ouvrir la barre latérale",
-    "open source": "Open Source",
-    "open_page": "Open page",
-    "optional": "Optionnel",
-    "original execution": "Exécution d'origine",
-    "originalCreatedDate": "Date de création originale",
-    "outdated revision save confirmation": {
-      "confirm": "Êtes-vous sûr de vouloir l'écraser ?",
-      "create": {
-        "description": "Un flow avec le même id existe déjà dans ce namespace.",
-        "details": "Enregistrer pour remplacer et créer une nouvelle révision.",
-        "title": "Le flux existe déjà"
-      },
-      "update": {
-        "description": "Une révision plus récente du Flow existe.",
-        "details": "Regardez l'onglet Révisions pour plus de détails sur la dernière version.",
-        "title": "Révision dépassée"
-      }
+    "documentation": {
+      "documentation": "Documentation",
+      "github": "Bugs GitHub"
     },
-    "output": "Sortie",
-    "outputs": "Sorties",
-    "override": {
-      "details": "Le flow précédent peut être restauré depuis l'onglet Revisions.",
-      "title": "Vous allez écraser le flow actuel"
-    },
-    "overview": "Vue générale",
-    "page": {
-      "next": "Page suivante",
-      "previous": "Page précédente"
-    },
-    "panel actions": "Actions du panneau",
-    "parent execution": "Exécution parente",
-    "password": "Mot de passe",
-    "password empty constraint": "Nom d'utilisateur ou mot de passe incorrect",
-    "password length constraint": "Le mot de passe ne doit pas dépasser 256 caractères.",
-    "passwords do not match": "Les mots de passe ne correspondent pas",
-    "pause": "Pause",
-    "pause backfill": "Mettre en pause le backfill",
-    "pause backfills": "Mettre en pause les backfills",
-    "pause confirm": "Êtes-vous sûr de vouloir mettre en pause l'exécution <code>{id}</code> ?",
-    "pause done": "L'exécution est en PAUSE",
-    "pause title": "Mettre en pause l'exécution <code>{id}</code>.<br/>Notez que les tasks actuellement en cours d'exécution seront toujours traitées, et l'exécution devra être reprise manuellement.",
-    "paused": "PAUSED",
-    "playground": {
-      "clear_history": "Effacer l'historique",
-      "confirm_create": "Vous ne pouvez pas exécuter le playground lors de la création d'un flow. Lancer une exécution de playground créera le flow.",
-      "history": "Dernières 10 exécutions",
-      "play_icon_info": "Vous pouvez également cliquer sur l'icône Play dans les vues No-Code ou Topology.",
-      "run_all_tasks": "Exécuter toutes les tasks",
-      "run_task": "Exécuter la Task",
-      "run_task_and_downstream": "Exécuter la task et en aval",
-      "run_task_info": "Survolez n'importe quelle task dans l'éditeur de Flow Code et cliquez sur le bouton \"Run task\" pour tester votre task.",
-      "run_this_task": "Exécuter cette task",
-      "title": "Aire de jeu",
-      "toggle": "Terrain de jeu",
-      "tooltip_persistence": "Si vous désactivez et réactivez le Playground, les informations restent tant que vous restez sur la page."
-    },
-    "playground actions": "Actions du Playground",
-    "plugin defaults exported": "Plugins par défaut exportés",
-    "plugin defaults imported": "Paramètres par défaut du plugin importés",
-    "plugin defaults not imported": "Certains paramètres par défaut du plugin n'ont pas pu être importés",
-    "pluginDefaults": {
-      "add": "Ajouter le Plugin par Défaut",
-      "add_subtitle": "Configurer un nouveau plugin par défaut avec ses propriétés",
-      "cancel": "Annuler",
-      "custom": "Plugin personnalisé",
-      "custom_configure": "Type de plugin personnalisé - configurer avec YAML",
-      "custom_placeholder": "Entrez le type de plugin",
-      "custom_type": "Type de plugin personnalisé",
-      "edit": "Modifier le Plugin par Défaut",
-      "edit_subtitle": "Modifier la configuration par défaut du plugin existant",
-      "form": "Formulaire",
-      "predefined": "Plugin Prédéfini",
-      "select_predefined": "Sélectionner un Plugin Prédéfini",
-      "show_yaml": "Afficher YAML",
-      "title": "Paramètres par défaut du plugin",
-      "update": "Mettre à jour le Plugin par Défaut",
-      "use_custom": "Utiliser personnalisé",
-      "yaml": "YAML",
-      "yaml_configuration": "Configuration YAML"
-    },
-    "pluginPage": {
-      "elementType": {
-        "apps": "Application",
-        "charts": "Graphique",
-        "conditions": "Condition",
-        "logExporters": "Exportateur de logs",
-        "secrets": "Secret",
-        "taskRunners": "Exécuteur de task",
-        "tasks": "Tâche",
-        "triggers": "Déclencheur"
-      },
-      "group": {
-        "blueprints": "Blueprints ({count})",
-        "plugins": "Plugins ({count})",
-        "tasks": "Tâches ({count})"
-      },
+    "blueprints": {
+      "all": "Tous",
+      "community": "Communauté",
+      "create": "Créer un blueprint",
+      "edit": "Modifier un blueprint",
+      "title": "Blueprints",
+      "empty": "Aucun blueprint à afficher.",
       "header": {
-        "back": "Retour aux plugins",
-        "certified": "Certifié",
-        "enterpriseEdition": "Édition Enterprise"
+        "catch phrase": {
+          "1": "La première étape est toujours la plus difficile.",
+          "2": "Explorez les blueprints pour démarrer votre prochain {kind}."
+        },
+        "alt": "Icône des Blueprints"
       },
-      "loadError": "Impossible de charger les plugins. Veuillez réessayer.",
-      "noResults": "Aucun plugin ne correspond à votre recherche.",
-      "notFound": "Ce plugin est introuvable.",
-      "overview": {
-        "createdBy": "Créé par",
-        "latest": "Dernier",
-        "linksResources": "Liens et ressources",
-        "managedBy": "Géré par",
-        "minKestraVersion": "Version min. compatible Kestra : {version}",
-        "minKestraVersionShort": "Version min. Kestra {version}",
-        "pluginType": "Type de plugin",
-        "previousVersions": "Versions précédentes",
-        "releaseNotes": "Notes de version",
-        "title": "Vue d'ensemble",
-        "versions": "Versions"
+      "custom": "Plans personnalisés",
+      "flows": "Plans de Flow",
+      "apps": "Plans d'application",
+      "dashboards": "Tableaux de bord Blueprints",
+      "detail": {
+        "category": "Type de catégorie",
+        "links": "Liens et ressources",
+        "openInEditor": "Ouvrir dans Modifier Flow"
       },
-      "search": "Rechercher parmi {count}+ plugins",
-      "searchTasks": "Rechercher {count} tasks",
-      "sort": {
-        "mostUsed": "Les plus utilisés",
-        "nameAsc": "Nom A-Z",
-        "nameDesc": "Nom Z-A",
-        "newest": "Le plus récent"
-      },
-      "sortBy": "Trier par"
+      "missingPlugins": {
+        "title": "Plugins manquants",
+        "description": "Ce blueprint utilise des tasks de plugin(s) qui ne sont pas installés sur cette instance : {plugins}. Installez-les pour utiliser ce blueprint.",
+        "card": "Nécessite des plugin(s) non installés sur cette instance : {plugins}",
+        "install": "Installer les plugins"
+      }
     },
-    "plugin_default_already_exists": "Le plugin par défaut pour <code>{type}</code> existe déjà.",
+    "use": "Utiliser",
     "plugins": {
       "name": "Plugin",
       "names": "Plugins",
       "please": "Veuillez choisir une tache sur la droite afin de voir sa documentation",
       "release": "Notes de version"
     },
-    "port": "Port",
-    "prefill inputs": "Pré-remplir",
-    "pretty_json": "Pretty JSON",
-    "prev_execution": "Exécution précédente",
-    "preview": {
-      "auto-view": "Vue automatique",
-      "collapse": "Réduire",
-      "expand": "Développer",
-      "force-editor": "Imposer la vue de l'éditeur",
-      "label": "Aperçu",
-      "next": "Suivant",
-      "page_of": "Page {current} sur {total}",
-      "pagination_info": "Affichage des lignes {start}-{end} sur {total}.",
-      "previous": "Précédent",
-      "rows_truncated": "Affichage de {shown} sur {total} lignes. Téléchargez le fichier pour voir toutes les données.",
-      "showing_rows": "Affichage des lignes {start}-{end} sur {total}",
-      "view": "Voir"
+    "last execution date": "Dernière exécution",
+    "last execution state": "Dernier état",
+    "last X days count": "{count} lors des {days} derniers jours",
+    "date range count": "{count} entre le {startDate} et le {endDate}",
+    "date count": "{count} le {date}",
+    "revisions": "Révisions",
+    "no revisions found": "Une seule révision existe pour ce flow",
+    "no revisions": "Aucune révision",
+    "see full revision": "Voir la révision complète",
+    "side-by-side": "côte à côte",
+    "line-by-line": "ligne par ligne",
+    "template": "Template",
+    "template creation": "Création de template",
+    "templates": "Templates",
+    "templates deprecated": "Les templates sont obsolètes. Veuillez utiliser des sous-flux au lieu des templates. Consultez <a href=\"https://kestra.io/docs/migration-guide/0.11.0/templates?utm_source=app&utm_medium=referral&utm_campaign=template-inlinedoc\" target=\"_blank\">section Migrations</a> expliquant comment vous pouvez migrer vers les sous-flux.",
+    "no result": "Il n'y a aucun résultat à afficher.",
+    "empty search": "Les résultats de recherche sont vides",
+    "trigger": "Déclencheur",
+    "no_trigger": "Aucun trigger disponible.",
+    "triggers": "Déclencheurs",
+    "triggers_header_description": "Parcourez, ajoutez et gérez des triggers pour automatiser vos flows. Choisissez parmi l'exposition de votre flow en tant qu'outil AI, la planification, l'ajout d'un trigger webhook, le sondage pour les changements dans les applications externes, ou les écouteurs d'événements en temps réel.",
+    "triggers_tabs_add": "Ajouter",
+    "triggers_tabs_manage": "Gérer",
+    "triggers_add_search_placeholder": "Rechercher des triggers...",
+    "triggers_add_filter_core": "Coeur",
+    "triggers_add_filter_realtime": "Temps réel",
+    "triggers_add_filter_all": "Tous",
+    "triggers_add_filter_app": "Application",
+    "triggers_add_empty_title": "Aucun trigger trouvé",
+    "triggers_add_ee_tooltip": "Ce trigger nécessite l'édition Enterprise.",
+    "triggers_add_category_empty": "Aucun trigger dans cette catégorie.",
+    "triggers_add_card_add_to_flow": "Ajouter au flow",
+    "triggers_add_card_add": "Ajouter",
+    "triggers_add_modal_title": "{name}",
+    "triggers_add_modal_tab_form": "Formulaire",
+    "triggers_add_modal_tab_source": "Source",
+    "triggers_add_modal_tab_documentation": "Documentation",
+    "triggers_add_modal_namespace_placeholder": "Sélectionner un namespace",
+    "triggers_add_modal_flow_placeholder": "Sélectionnez un flow",
+    "triggers_add_modal_trigger_id": "ID de trigger",
+    "triggers_add_modal_trigger_id_placeholder": "Identifiant unique pour ce trigger",
+    "triggers_add_modal_properties_hint": "Configurez les propriétés du trigger dans l'éditeur de flow après avoir ajouté le trigger.",
+    "triggers_add_modal_ee_notice": "Ce trigger nécessite l'édition Enterprise.",
+    "triggers_add_modal_add_button": "Ajouter un Trigger au Flow",
+    "trigger details": "Détails du déclencheur",
+    "triggerflow disabled": "Déclencheur désactivé depuis la définition du flow",
+    "last trigger date": "Dernière date de trigger",
+    "trigger_states": "États",
+    "context updated date": "Date de mise à jour du contexte",
+    "state updated date": "Date de mise à jour de l'état",
+    "next evaluation date": "Prochaine date d'évaluation",
+    "last evaluation date": "Date de la dernière évaluation",
+    "last trigger date tooltip": "Dernière exécution du trigger. Peut être dans le passé lors de l'exécution d'un backfill.",
+    "context updated date tooltip": "Dernière mise à jour du contexte du trigger. Cela se produit lorsque l'exécution est déclenchée, se termine (verrou libéré), ou après une évaluation (même si aucune exécution n'a lieu).",
+    "next evaluation date tooltip": "Quand le trigger sera évalué la prochaine fois, en fonction de son intervalle. Pas toujours identique à la prochaine date d'exécution si les conditions ne sont pas remplies.",
+    "last evaluation date tooltip": "When the trigger was last evaluated by the scheduler, regardless of whether it produced an execution.",
+    "conditions": "Conditions",
+    "triggerId": "ID de trigger",
+    "tenantId": "ID du mandant",
+    "codeDisabled": "Désactivé dans le flow",
+    "paused": "PAUSED",
+    "running": "RUNNING",
+    "Fold auto": "Éditeur : Replier automatiquement le contenu multi-lignes",
+    "Hover description": "Éditeur : Afficher la description du champ lors du survol du key ou value",
+    "Fold content lines": "Replier les multilignes",
+    "Unfold content lines": "Déplier les multilignes",
+    "Total": "Total",
+    "sub flow": "Sous-flow",
+    "execute": "Exécuter",
+    "execute flow behaviour": "Exécuter le flow",
+    "open in same tab": "Dans le même onglet",
+    "open in new tab": "Dans un nouvel onglet",
+    "execute the flow": "Exécuter le flow <code>{id}</code>",
+    "execute flow now ?": "Voulez-vous exécuter ce flow ?",
+    "discard execution confirmation": "Vous avez des inputs non enregistrés. Êtes-vous sûr de vouloir abandonner cette exécution ?",
+    "discard changes confirmation": "Vous avez des modifications non enregistrées. Êtes-vous sûr de vouloir les abandonner ?",
+    "Default namespace": "Espace de nom par défaut",
+    "Default log level": "Niveau de log par défaut",
+    "unsaved changed ?": "Vous avez des changements non sauvegardés, voulez-vous quitter la page ?",
+    "unsaved changes": "Modifications non enregistrées",
+    "unsaved changes warning": "Vous avez des modifications non enregistrées. Si vous quittez cette page, vos modifications seront perdues.",
+    "leave page": "Quitter la page",
+    "open full page": "Ouvrir la page complète",
+    "drill down preview": "Aperçu",
+    "Editor theme": "Theme de l'éditeur",
+    "Editor fontsize": "Taille de police de l'éditeur",
+    "Editor fontfamily": "Police de l'éditeur",
+    "errors": {
+      "401": {
+        "title": "Non authentifié",
+        "content": "Vous devez être authentifié pour accéder à cette page."
+      },
+      "403": {
+        "title": "Accès refusé",
+        "content": "Vous n'avez pas les permissions suffisantes pour accéder à cette page."
+      },
+      "404": {
+        "title": "Page introuvable",
+        "content": "L'URL demandée n'a pas été trouvée sur ce serveur.<br />C'est tout ce que nous savons.",
+        "flow or execution": "Le flow ou l'exécution demandé est introuvable."
+      }
     },
-    "pricing": "Tarification",
-    "product_tour": "Visite du produit",
-    "properties": {
-      "hidden": "Caché dans le tableau",
-      "hint": "Choisir les colonnes visibles",
-      "label": "Propriétés",
-      "shown": "Affiché dans le tableau"
+    "back_to_dashboard": "Retour au tableau de bord",
+    "copy all logs": "Copier tous les logs",
+    "copy logs": "Copier les logs",
+    "fix_with_ai": "Corriger avec l'IA",
+    "download logs": "Télécharger les logs",
+    "delete logs": "Supprimer les logs",
+    "delete_all_logs": "Êtes-vous sûr de vouloir supprimer tous les journaux ?",
+    "delete_log": "Êtes-vous sûr de vouloir supprimer le log ?",
+    "toggle fullscreen": "Permuter le plein écran",
+    "copied": "Copié",
+    "tags": "Tags",
+    "disabled flow title": "Ce flow est désactivé",
+    "disabled flow desc": "Ce flow est désactivé, veuillez le réactiver pour l'exécuter.",
+    "label": "Label",
+    "labels": "Labels",
+    "label filter placeholder": "Label au format 'clé:valeur'",
+    "execution labels": "Labels d'exécution",
+    "wrong labels": "Clé ou valeur vide détecté dans les labels",
+    "feeds": {
+      "title": "Quoi de neuf sur Kestra",
+      "heading": "Tout sur Kestra.",
+      "subheading": "Les dernières mises à jour, guides et histoires"
     },
-    "queued duration": "Durée d'attente",
-    "quotas": "Quotas",
-    "reach us": "Contactez-nous",
-    "read-more": "En savoir plus sur",
-    "readonly property": "Propriété non modifiable",
-    "recent_executions": "Exécutions Récentes",
-    "refresh": "Rafraîchir",
-    "reject": "Rejeter",
-    "relative": "Relative",
-    "relative end date": "Date de fin relative",
-    "relative start date": "Date de début relative",
-    "remove label": "Supprimer le label",
-    "remove this item": "Supprimer cet élément",
-    "remove_bookmark": "Êtes-vous sûr de vouloir supprimer ce signet ?",
-    "replay": "Rejouer",
-    "replay confirm": "Êtes-vous sur de vouloir relancer l'exécution <code>{id}</code> et créer une nouvelle exécution ?",
-    "replay execution description": "Cela créera une nouvelle exécution basée sur l'exécution sélectionnée.",
-    "replay execution title": "Rejouer l'exécution",
-    "replay from beginning tooltip": "Créer une nouvelle exécution similaire depuis le début",
-    "replay from task tooltip": "Créer une nouvelle exécution similaire démarrant de la tâche <code>{taskId}</code>",
-    "replay inputs": "Entrées",
-    "replay inputs new required": "Cette révision a des inputs. Vous serez invité à les remplir.",
-    "replay latest revision": "Rejouer avec la dernière révision",
-    "replay select taskrun": "Sélectionnez le task run à rejouer à partir de :",
-    "replay the execution": "Rejouer l'exécution <code>{executionId}</code> pour le flow <code>{flowId}</code>",
-    "replay using": "Rejouer en utilisant",
-    "replay with inputs": "Rejouer avec inputs",
-    "replayed": "L'exécution est rejouée",
-    "required field": "Champ requis",
-    "reset": "Recommencer",
-    "reset to defaults": "Réinitialiser aux valeurs par défaut",
-    "restart": "Relancer",
-    "restart change revision": "Vous pouvez changer la révision qui sera utilisé pour la nouvelle exécution relancée.",
-    "restart confirm": "Êtes-vous sur de vouloir relancer <code>{id}</code> ?",
-    "restart execution title": "Redémarrer l'exécution",
-    "restart latest revision": "Relancer avec la dernière révision",
-    "restart tooltip": "Relancer l'exécution depuis la tâche dans l'état <code>{state}</code>",
-    "restart trigger": {
-      "button": "Redémarrer trigger",
-      "tooltip": "Redémarrer le trigger"
-    },
-    "restarted": "L'exécution est redémarrée",
+    "delete execution running": "<div class=\"alert alert-warning mt-2 mb-0\">Cette exécution est en cours, l'effacer ne stoppera pas celle-ci.<br />Vous devez l'arrêter auparavant!</div>",
     "restore": "Restaurer",
     "restore confirm": "Êtes vous sûr de vouloir restaurer la révision <code>{revision}</code>?",
+    "bulk delete": "Êtes-vous sur de vouloir supprimer <code>{executionCount}</code> exécution(s) ?",
+    "bulk replay": "Êtes-vous sur de vouloir rejouer <code>{executionCount}</code> exécution(s)?",
+    "bulk change state": "Êtes-vous sûr de vouloir changer l'état de <code>{executionCount}</code> exécution(s) ?",
+    "bulk resume": "Êtes-vous sur de vouloir reprendre <code>{executionCount}</code> exécution(s)?",
+    "bulk pause": "Êtes-vous sûr de vouloir mettre en pause l'exécution de <code>{executionCount}</code> ?",
+    "bulk unqueue": "Êtes-vous sûr de vouloir retirer de la file d'attente <code>{executionCount}</code> exécution(s) ?",
+    "bulk force run": "Êtes-vous sûr de vouloir forcer l'exécution de <code>{executionCount}</code> exécution(s) ?<br/><br/>WARNING : forcer l'exécution n'est pas garanti et peut créer des exécutions de tâches en double.<br/><br/>Les transitions suivantes seront effectuées :<br/><ul><li>Les tâches CREATED seront déplacées à l'état RUNNING.</li><li>Les tâches RUNNING seront soumises à nouveau.</li><li>Les tâches QUEUED seront désenfilées.</li><li>Les tâches PAUSED seront reprises.</li></ul>",
+    "bulk restart": "Êtes-vous sur de vouloir redémarrer <code>{executionCount}</code> exécution(s) ?",
+    "bulk kill": "Êtes-vous sur de vouloir arrêter <code>{executionCount}</code> exécution(s) ?",
+    "selection": {
+      "selected": "<strong>{count}</strong> sélectionnés",
+      "all": "Tous sélectionnés ({count})"
+    },
+    "cancel": "Annuler",
+    "errorLogs": "Logs des erreurs",
+    "welcome_page": {
+      "welcome": "Bienvenue sur Kestra",
+      "guide": "Besoin d'aide pour exécuter votre premier flow ?"
+    },
+    "product_tour": "Visite du produit",
+    "executions replayed": "<code>{executionCount}</code> exécution(s) rejouée(s)",
+    "executions state changed": "L'état de <code>{executionCount}</code> exécution(s) a été modifié",
+    "executions resumed": "<code>{executionCount}</code> exécution(s) reprise(s)",
+    "executions paused": "<code>{executionCount}</code> exécution(s) en PAUSED",
+    "executions unqueue": "<code>{executionCount}</code> exécution(s) en attente",
+    "executions force run": "<code>{executionCount}</code> exécution(s) forcée(s) en cours d'exécution",
+    "executions restarted": "<code>{executionCount}</code> exécution(s) redémarrée(s)",
+    "executions killed": "<code>{executionCount}</code> exécution(s) arrêtée(s)",
+    "executions deleted": "<code>{executionCount}</code> exécution(s) supprimée(s)",
+    "invalid bulk replay": "Impossible de rejouer les exécutions",
+    "invalid bulk resume": "Impossible de reprendre les exécutions",
+    "invalid bulk pause": "Impossible de mettre en pause les exécutions",
+    "invalid bulk unqueue": "Impossible de retirer les exécutions de la file d'attente",
+    "invalid bulk force run": "Impossible de forcer l'exécution des exécutions",
+    "invalid bulk restart": "Impossible de redémarrer les exécutions",
+    "invalid bulk kill": "Impossible d'arrêter les exécutions",
+    "invalid bulk delete": "Impossible de supprimer les exécutions",
+    "execution not found": "L'exécution {executionId} est introuvable.",
+    "execution not in state PAUSED": "Exécution <code>{executionId}</code> n'est pas dans l'état PAUSED",
+    "execution not in state FAILED": "Exécution <code>{executionId}</code> n'est pas dans l'état FAILED",
+    "execution already finished": "Exécution <code>{executionId}</code> déjà terminée",
     "restore revision": "Êtes-vous sur de vouloir restaurer la revision <code>{revision}</code> ?",
-    "resume": "Reprendre",
-    "resume from breakpoint done": "L'exécution est reprise depuis le point d'arrêt",
-    "resume from breakpoint title": "Reprendre l'exécution <code>{id}</code> depuis le point d'arrêt",
-    "resumed confirm": "Êtes-vous sur de vouloir reprendre l'exécution <code>{id}</code>?",
-    "resumed done": "L'exécution est reprise",
-    "resumed title": "Reprendre l'exécution <code>{id}</code>",
-    "reuse original inputs": "Réutiliser les inputs d'origine",
-    "reuse_original_inputs": "Réutiliser les inputs d'origine",
-    "review your inputs": "Vérifiez vos entrées",
-    "revision": "Révision",
-    "revision deleted": "La révision {revision} a été supprimée avec succès",
-    "revisions": "Révisions",
-    "row count": "Nombre de lignes",
-    "run task in playground": "Exécuter la task dans le playground",
+    "seeing old revision": "Vous visualisez une ancienne revision : {revision}",
+    "export": "Exporter",
+    "exports": "Exporter",
+    "export_csv": "Exporter en CSV",
+    "template export": "Êtes vous sûr de vouloir exporter <code>{templateCount}</code> template(s)?",
+    "templates exported": "Templates exportés",
+    "export all templates": "Exporter tous les templates",
+    "flow_export": "Exporter le flow",
+    "flow export": "Êtes vous sûr de vouloir exporter <code>{flowCount}</code> flow(s)?",
+    "flows exported": "<code>{count}</code> Flow(s) exporté(s)",
+    "export all flows": "Exporter tous les flows",
+    "import": "Importer",
+    "disable": "Désactiver",
+    "enable": "Activer",
+    "enabled": "Activé",
+    "template delete": "Êtes vous sûr de vouloir supprimer <code>{templateCount}</code> template(s)?",
+    "flow delete": "Êtes vous sûr de vouloir supprimer <code>{flowCount}</code> flow(s)?",
+    "templates deleted": "<code>{count}</code> Template(s) supprimé(s)",
+    "flows deleted": "<code>{count}</code> Flow(s) supprimé(s)",
+    "flow disable": "Êtes vous sûr de vouloir désactiver <code>{flowCount}</code> flow(s)?",
+    "flow enable": "Êtes vous sûr de vouloir activer <code>{flowCount}</code> flow(s)?",
+    "flows disabled": "<code>{count}</code> Flow(s) désactivé(s)",
+    "flows enabled": "<code>{count}</code> Flow(s) activé(s)",
+    "flow-no-dependencies": "Votre flow n'a pas de dépendances.",
+    "flow-dependencies": "dépendances",
+    "read-more": "En savoir plus sur",
+    "in-our-documentation": "dans notre documentation.",
+    "dependencies": "Dépendances",
+    "see dependencies": "Voir les dépendances",
+    "see timeline": "Voir la chronologie",
     "run timeline": "Chronologie d'Exécution",
-    "runners": "Coureurs",
-    "running": "RUNNING",
-    "running duration": "Durée de traitement",
-    "save": "Enregistrer",
+    "dependencies missing acls": "Aucune permission sur ce flow",
+    "dependencies delete flow": "Ce flow a des dépendances, effacer celui-ci empêchera les dépendances de s'exécuter !<br /><br /> Voici la liste des flows concernés :",
+    "expand dependencies": "Voir les dépendances",
+    "reset": "Recommencer",
+    "show task documentation": "Afficher la documentation des tâches",
+    "hide task documentation": "Cacher la documentation des tâches",
+    "show task documentation in editor": "Afficher la documentation dans l'éditeur",
+    "show documentation": "Afficher la documentation",
+    "focus task": "Cliquer sur une tâche pour voir sa documentation",
+    "validate": "Valider",
+    "add error handler": "Gérer les erreurs",
+    "taskDefaults": "Valeur de tâches par défaut",
+    "disabled": "Désactivé",
+    "before": "avant",
+    "after": "après",
+    "add at position": "Ajouter {position} <code>{task}</code>",
+    "create first task": "Créer votre première tâche",
+    "dynamic": "Dynamique",
+    "choice": "Choix",
+    "sequential": "Séquentiel",
+    "can not delete": "Suppression impossible",
+    "can not have less than 1 task": "Un flow ne peut avoir moins d'1 tâche.",
+    "task id already exists": "Identifiant de tâche déjà utilisé",
+    "Task Id already exist in the flow": "L'identifiant {taskId} est déjà utilisé dans le flow.",
+    "task id": "ID de tâche",
+    "taskid column details": "ID de la dernière tâche exécuté ainsi que son nombre de tentatives.",
+    "flow already exists": "Flow déjà existant",
+    "flow already exists message": "Le flow <code>{id}</code> existe déjà dans le namespace <code>{namespace}</code>. Voulez-vous créer une nouvelle révision ?",
+    "plugin_default_already_exists": "Le plugin par défaut pour <code>{type}</code> existe déjà.",
+    "namespace not allowed": "Espace de nom non autorisé",
+    "switch-view": "Changer de vue",
+    "source and topology": "Source et topologie",
+    "source and doc": "Source et documentation",
+    "source and blueprints": "Source et blueprints",
+    "editor": "Éditeur",
+    "error in editor": "Une erreur a été trouvé dans l'éditeur",
+    "delete task confirm": "Êtes-vous sûr de vouloir supprimer la tâche <code>{taskId}</code> ?",
+    "can not save": "Impossible de sauvegarder",
+    "flow must not be empty": "Le flow ne doit pas être vide",
+    "flow must have id and namespace": "Le flow doit avoir un id et un namespace.",
+    "flow creation denied in namespace": "Vous n'avez pas la permission de créer des flows dans le namespace `{namespace}`.",
+    "readonly property": "Propriété non modifiable",
+    "namespace and id readonly": "Le namespace et l'id ne sont pas modifiables. Ils ont été réinitialisés à leur valeur initiale.",
+    "avg": "Moyenne",
+    "sum": "Somme",
+    "min": "Minimum",
+    "max": "Maximum",
+    "bar": "Bar",
+    "line": "Ligne",
+    "metric": "Métrique",
+    "aggregation": "Agrégation",
+    "chart type": "Type de graphique",
+    "metric choice": "Aucune métrique disponible pour ce flow",
+    "of": "de",
+    "see_all_states": "Voir tous les états",
     "save draft": {
       "message": "Brouillon sauvegardé",
       "retrieval": {
@@ -1680,164 +724,336 @@
         "existing": "Un brouillon pour le Flow <code>{flowFullName}</code> existe, voulez-vous reprendre son édition?"
       }
     },
-    "save task": "Enregistrer la tâche",
-    "save_and_execute": "Enregistrer & Exécuter",
-    "save_as_draft": "Enregistrer comme brouillon",
-    "saved": "Enregistrement réussi",
-    "saved as draft": "Enregistré comme brouillon",
-    "saved as draft done": "<em>{name}</em> a été enregistré comme brouillon",
-    "saved done": "<em>{name}</em> est enregistré avec succès",
-    "scheduleDate": "Date de planification",
-    "scope_filter": {
-      "all": "Tous les {label}",
-      "system": "Système {label}",
-      "system_description": "Maintenance du système {label}",
-      "user": "Utilisateur {label}",
-      "user_description": "Utilisateur régulier a initié {label}"
+    "title": "Titre",
+    "api": "API",
+    "more_actions": "Plus d'actions",
+    "expand error": "Afficher uniquement les erreurs",
+    "expand all": "Afficher tout",
+    "collapse all": "Masquer tout",
+    "expand": "Afficher",
+    "collapse": "Masquer",
+    "filter by this value": "Filter by this value",
+    "filter_for": "Filter for",
+    "filter_out": "Filter out",
+    "copy_value": "Copy value",
+    "open_page": "Open page",
+    "logs_copied": "Logs copied to your clipboard",
+    "expand_by_default": "Expand structured logs by default",
+    "show raw": "Show raw",
+    "similar lines": "similar lines",
+    "download_logs_description": "Choose which logs to export. Filters default to your current view.",
+    "display_settings": "Display settings",
+    "density": "Density",
+    "density_compact": "Compact",
+    "density_normal": "Normal",
+    "density_expanded": "Expanded",
+    "pretty_json": "Pretty JSON",
+    "body_line_clamp": "Limit line height",
+    "font size": "Font size",
+    "log expand setting": "Affichage par défaut des journaux",
+    "environment": "Environnement",
+    "environment name setting": "Nom de l'environnement",
+    "environment color setting": "Couleur de l'environnement",
+    "slack support": "Demandez de l'aide sur notre Slack",
+    "join community": "Rejoignez la communauté",
+    "join_slack": "Rejoindre Slack",
+    "kestra": "Kestra",
+    "reach us": "Contactez-nous",
+    "new version": "Nouvelle version {version} disponible!",
+    "error detected": "Erreur(s) détectée(s).",
+    "warning detected": "Avertissement(s) détecté(s)",
+    "informative notice": "Note(s)",
+    "cannot swap tasks": "Impossible de permuter les tâches",
+    "open": "Afficher",
+    "dependency task": "La tâche {taskId} est une dépendance d'une autre tâche",
+    "administration": "Administration",
+    "admin": "Administrateur",
+    "main_configuration": "Configuration Principale",
+    "commit_id": "ID de commit",
+    "evaluation lock date": "Date verrou évaluation",
+    "unlock trigger": {
+      "tooltip": {
+        "execution": "Il existe une exécution en cours pour ce trigger",
+        "evaluation": "Le déclencheur est en cours d'évaluation"
+      },
+      "confirmation": "Êtes vous sûr(e) de vouloir débloquer le déclencheur ?",
+      "warning": "Cela pourrait amener à de multiples exécutions concurrentes pour le même déclencheur et devrait être considéré comme une solution de dernier recours.",
+      "button": "Débloquer le déclencheur",
+      "success": "Le déclencheur est débloqué"
     },
-    "search": "Chercher",
-    "search blueprint": "Chercher un blueprint",
-    "search filters": {
-      "filter name": "Nom du filtre",
-      "filters": "Filtres",
-      "manage": "Gestion des filtres",
-      "manage desc": "Gestion des filtres sauvegardés",
-      "save filter": "Sauvegarder le filtre",
-      "saved": "Filtres sauvegardés"
+    "restart trigger": {
+      "button": "Redémarrer trigger",
+      "tooltip": "Redémarrer le trigger"
     },
-    "search term in message": "Chercher dans le message",
-    "search_docs": "Rechercher",
-    "searching": "Recherche en cours...",
-    "secret": {
-      "add": "Créer",
-      "inherited": "Secrets hérités",
-      "isReadOnly": "Le secret est en lecture seule",
-      "names": "Secrets",
-      "update": "Mettre à jour le secret '{name}'"
-    },
-    "security_advice": {
-      "content": "Activer l'authentification basique pour protéger votre instance.",
-      "enable": "Activer l'authentification",
-      "switch_text": "Ne plus montrer",
-      "title": "Vos données ne sont pas protégées !"
-    },
-    "see dependencies": "Voir les dépendances",
-    "see full revision": "Voir la révision complète",
-    "see timeline": "Voir la chronologie",
-    "see_all_states": "Voir tous les états",
-    "seeing old revision": "Vous visualisez une ancienne revision : {revision}",
-    "select": "Sélectionnez votre {{section}}",
-    "select a state": "Sélectionner un état",
-    "select datetime": "Sélectionner une date",
-    "select view": "Sélectionner la vue",
-    "selected": "Sélectionné",
-    "selection": {
-      "all": "Tous sélectionnés ({count})",
-      "selected": "<strong>{count}</strong> sélectionnés"
-    },
-    "sequential": "Séquentiel",
-    "server type": "Type de serveur",
+    "trigger disabled": "Le trigger est désactivé dans la source du flow",
+    "flow source not found": "Source du flow introuvable",
+    "date format": "Format de date",
+    "timezone": "Fuseau horaire",
+    "add task": "Ajouter une tâche",
+    "unable to generate graph": "Une erreur est survenue lors de la génération du graphe empêchant l'affichage de la topologie.",
+    "attempts": "Tentative(s)",
+    "flow deleted, you can restore it": "Le flow a été supprimé et ceci est une vue en lecture seule, mais vous pouvez toujours le restaurer.",
+    "workers": "Workers",
+    "worker group": "Worker Group",
+    "worker group key": "Clé du groupe de Worker",
+    "worker group fallback": "Groupe de Worker de secours",
+    "version": "Version",
     "services": "Services",
+    "server type": "Type de serveur",
+    "hostname": "Nom d'hôte",
+    "port": "Port",
+    "management port": "Port de gestion",
+    "file preview truncated": "Displayed content has been truncated",
+    "file unavailable": "Fichier indisponible",
+    "file unavailable description": "Ce fichier n'est plus disponible — il a peut-être été supprimé ou expiré.",
+    "row count": "Nombre de lignes",
+    "encoding": "Encodage",
+    "show": "Afficher",
+    "advanced configuration": "Autres propriétés",
+    "all executions": "Toutes les exécutions",
+    "trigger execution id": "Id parent",
+    "execution_status": "L'exécution est :",
+    "no_tasks_running": "Aucune tâche n'est encore en cours d'exécution.",
+    "execution_starts_progress": "Une fois l'exécution commencée, vous verrez les mises à jour de progression ici.",
+    "triggers_state": {
+      "state": "État",
+      "options": {
+        "enabled": "Activé",
+        "disabled": "Désactivé"
+      }
+    },
+    "trigger filter": {
+      "title": "Filtrer les enfants",
+      "options": {
+        "ALL": "Tous",
+        "CHILD": "Les exécutions enfantes",
+        "MAIN": "Les exécutions parentes"
+      }
+    },
+    "show chart": "Afficher le graphique",
+    "namespace files": {
+      "toggle": {
+        "show": "Afficher les fichiers de l'espace de noms",
+        "hide": "Masquer les fichiers de l'espace de noms"
+      },
+      "filter": "Filtrer",
+      "new_file": "Nouveau fichier",
+      "no_items": {
+        "heading": "Aucun fichier trouvé dans votre namespace pour le moment.",
+        "paragraph": "Créer ou importer des fichiers pour partager du code entre les flows dans votre namespace."
+      },
+      "no_selection": {
+        "heading": "Aucun fichier sélectionné",
+        "description": "Sélectionnez un fichier dans l'arborescence pour afficher son contenu."
+      },
+      "tree": {
+        "expand": "Développer tous les dossiers",
+        "collapse": "Réduire tous les dossiers"
+      },
+      "create": {
+        "label": "Créer",
+        "file": "Créer un fichier",
+        "file_already_exists": "Un fichier avec ce nom existe déjà",
+        "file_conflicts_with_folder": "Un dossier avec ce nom existe déjà",
+        "file_error": "Une erreur s'est produite lors de la création du fichier",
+        "folder": "Créer un dossier",
+        "folder_already_exists": "Un dossier avec ce nom existe déjà",
+        "folder_conflicts_with_file": "Un fichier avec ce nom existe déjà",
+        "folder_error": "Une erreur s'est produite lors de la création du dossier"
+      },
+      "rename": {
+        "label": "Renommer",
+        "file": "Renommer le fichier",
+        "folder": "Renommer le dossier",
+        "new_file": "Nouveau nom avec extension :",
+        "new_folder": "Nouveau nom de dossier :"
+      },
+      "delete": {
+        "label": "Supprimer",
+        "file": "Supprimer le fichier",
+        "folder": "Supprimer le dossier",
+        "files": "Supprimer {count} fichiers sélectionnés",
+        "folders": "Supprimer {count} dossiers sélectionnés"
+      },
+      "import": {
+        "import": "Importer",
+        "files": "Importer des fichiers",
+        "folder": "Importer un dossier",
+        "success": "Fichier(s) importé(s) avec succès",
+        "error": "Des erreurs se sont produites lors de l'importation du(des) fichier(s)"
+      },
+      "export": "Exporter les fichiers de l'espace de noms",
+      "export_single": "Exporter le fichier",
+      "dialog": {
+        "name": {
+          "file": "Nom avec extension :",
+          "folder": "Nom du dossier :"
+        },
+        "parent_folder": "Dossier parent :",
+        "deletion": {
+          "confirm": "Confirmer",
+          "title": "Confirmer la suppression du contenu",
+          "files": "Êtes-vous sûr de vouloir supprimer <code>{count}</code> fichier(s) ?",
+          "folders": "Êtes-vous sûr de vouloir supprimer <code>{count}</code> dossier(s) et tout son contenu ?",
+          "mixed": "Êtes-vous sûr de vouloir supprimer le(s) dossier(s) <code>{folders}</code> et le(s) fichier(s) <code>{files}</code> ?",
+          "file_single": "Êtes-vous sûr de vouloir supprimer le fichier <code>{name}</code> ?",
+          "folder_single": "Êtes-vous sûr de vouloir supprimer le dossier <code>{name}</code> et tout son contenu ?"
+        }
+      },
+      "revisions": {
+        "history": "Historique des révisions",
+        "restore": {
+          "success": "Révision du fichier restaurée avec succès"
+        }
+      },
+      "path": {
+        "copy": "Copier le chemin",
+        "success": "Chemin copié dans le presse-papiers",
+        "error": "Des erreurs se sont produites lors de la copie du chemin dans le presse-papiers"
+      }
+    },
+    "continue backfill": "Continuer le backfill",
+    "delete backfill": "Supprimer le backfill",
+    "pause backfill": "Mettre en pause le backfill",
+    "continue backfills": "Continuer les backfills",
+    "delete backfills": "Supprimer les backfills",
+    "pause backfills": "Mettre en pause les backfills",
+    "backfill executions": "Backfill d'exécutions",
+    "execute backfill": "Exécuter le backfill",
+    "backfill paused": "Backfill en pause",
+    "backfill running": "Backfill en cours",
+    "relative": "Relative",
+    "relative start date": "Date de début relative",
+    "relative end date": "Date de fin relative",
+    "now": "Maintenant",
+    "absolute": "Absolu",
+    "backfill": "Backfill",
+    "Set labels tooltip": "Ajouter des labels à l'exécution",
+    "Set labels": "Ajouter des labels",
+    "manage labels": "Gérer les labels",
+    "Set labels to execution": "Ajouter ou mettre à jour des labels à l'exécution <code>{id}</code>",
+    "Set labels done": "Labels ajoutés avec succès à l'exécution",
+    "bulk set labels": "Êtes-vous sûr de vouloir ajouter des labels à <code>{executionCount}</code>  exécutions(s)?",
+    "dependencies loaded": "Dépendances chargées",
+    "loaded x dependencies": "{count} dépendances chargées",
+    "security_advice": {
+      "title": "Vos données ne sont pas protégées !",
+      "content": "Activer l'authentification basique pour protéger votre instance.",
+      "switch_text": "Ne plus montrer",
+      "enable": "Activer l'authentification"
+    },
+    "true": "Vrai",
+    "false": "Faux",
+    "undefined": "Non défini",
+    "execution-include-non-terminated": "Inclure les exécutions non terminées ?",
+    "execution-warn-title": "Avertissement Important !",
+    "execution-warn-deleting-still-running": "Nous vous recommandons fortement d'annuler cette action et de terminer toute exécution en cours d'abord. Supprimer des exécutions non terminées peut entraîner des problèmes de concurrence, des incohérences dans la gestion des dépendances de flow, et des processus zombies sur votre instance, ce qui peut dégrader les performances du système. Assurez-vous de bien comprendre ces risques avant de procéder à la suppression.",
+    "originalCreatedDate": "Date de création originale",
+    "welcome": {
+      "menu": "Welcome",
+      "tour": {
+        "title": "Faire une visite guidée du produit",
+        "text": "Choisissez votre cas d'utilisation et suivez un guide étape par étape pour découvrir les fonctionnalités et capacités de Kestra. ❤️"
+      },
+      "tutorial": {
+        "title": "Tutoriel",
+        "text": "* <a href=\"https://kestra.io/tutorial-videos/all?utm_source=app&utm_medium=referral&utm_campaign=welcome-tutorial\" target=\"_blank\">Tutoriels Vidéo</a>  \n* <a href=\"https://kestra.io/docs?utm_source=app&utm_medium=referral&utm_campaign=welcome-tutorial\" target=\"_blank\">Documentation</a>  \n* <a href=\"https://kestra.io/blueprints?utm_source=app&utm_medium=referral&utm_campaign=welcome-tutorial\" target=\"_blank\">Blueprints</a>"
+      },
+      "help": {
+        "title": "Besoin d'aide ?",
+        "text": "Posez n'importe quelle question dans notre communauté Slack. Si vous êtes bloqué, nous sommes là pour vous aider. ✋"
+      }
+    },
+    "pluginPage": {
+      "search": "Rechercher parmi {count}+ plugins",
+      "searchTasks": "Rechercher {count} tasks",
+      "noResults": "Aucun plugin ne correspond à votre recherche.",
+      "loadError": "Impossible de charger les plugins. Veuillez réessayer.",
+      "notFound": "Ce plugin est introuvable.",
+      "elementType": {
+        "tasks": "Tâche",
+        "triggers": "Déclencheur",
+        "conditions": "Condition",
+        "taskRunners": "Exécuteur de task",
+        "charts": "Graphique",
+        "apps": "Application",
+        "logExporters": "Exportateur de logs",
+        "secrets": "Secret"
+      },
+      "sortBy": "Trier par",
+      "sort": {
+        "nameAsc": "Nom A-Z",
+        "nameDesc": "Nom Z-A",
+        "newest": "Le plus récent",
+        "mostUsed": "Les plus utilisés"
+      },
+      "group": {
+        "plugins": "Plugins ({count})",
+        "tasks": "Tâches ({count})",
+        "blueprints": "Blueprints ({count})"
+      },
+      "overview": {
+        "title": "Vue d'ensemble",
+        "versions": "Versions",
+        "latest": "Dernier",
+        "releaseNotes": "Notes de version",
+        "previousVersions": "Versions précédentes",
+        "createdBy": "Créé par",
+        "managedBy": "Géré par",
+        "pluginType": "Type de plugin",
+        "linksResources": "Liens et ressources",
+        "minKestraVersion": "Version min. compatible Kestra : {version}",
+        "minKestraVersionShort": "Version min. Kestra {version}"
+      },
+      "header": {
+        "enterpriseEdition": "Édition Enterprise",
+        "certified": "Certifié",
+        "back": "Retour aux plugins"
+      }
+    },
+    "no inputs": "Ce flow n'a pas d'entrée.",
+    "admin_preferences": "Preferences",
     "settings": {
+      "label": "Paramètres",
+      "updated": "{name} mis à jour",
       "blocks": {
         "configuration": {
-          "descriptions": {
-            "auto_refresh_interval": "Secondes entre les actualisations automatiques des données sur les pages de liste.",
-            "default_namespace": "Utilisé lors de la création de nouveaux flows sans namespace.",
-            "editor_type": "Éditeur affiché lors de l'ouverture d'un flow pour la première fois.",
-            "execute_default_tab": "Onglet sélectionné lors de la navigation vers une exécution.",
-            "execute_flow": "Où les résultats d'exécution s'ouvrent après le déclenchement d'un run.",
-            "flow_default_tab": "Onglet sélectionné lors de la navigation vers un flow.",
-            "log_display": "Comment les logs sont présentés lors de l'ouverture d'une exécution.",
-            "log_level": "Niveau de log minimum affiché dans les logs d'exécution.",
-            "playground": "Exécutez les tasks individuellement dans le bac à sable de l'éditeur.",
-            "triggers_default_tab": "Onglet sélectionné lors de la navigation vers la page des triggers."
-          },
+          "label": "Configuration Principale",
           "fields": {
-            "auto_refresh_interval": "Intervalle de rafraîchissement automatique",
-            "default_namespace": "Espace de noms par défaut",
-            "editor_type": "Type d'Éditeur par Défaut",
-            "execute_default_tab": "Onglet d'exécution par défaut",
-            "execute_flow": "Exécuter le flow",
-            "flow_default_tab": "Onglet Flow par Défaut",
             "language": "Langue",
-            "log_display": "Affichage des journaux par défaut",
+            "default_namespace": "Espace de noms par défaut",
             "log_level": "Niveau d'affichage des journaux par défaut",
+            "log_display": "Affichage des journaux par défaut",
+            "editor_type": "Type d'Éditeur par Défaut",
+            "execute_flow": "Exécuter le flow",
+            "execute_default_tab": "Onglet d'exécution par défaut",
             "multi_panel_editor": "Éditeur Multi-Panneaux",
+            "flow_default_tab": "Onglet Flow par Défaut",
+            "triggers_default_tab": "Onglet par défaut des Triggers",
             "playground": "Aire de jeu",
-            "triggers_default_tab": "Onglet par défaut des Triggers"
+            "auto_refresh_interval": "Intervalle de rafraîchissement automatique"
           },
-          "label": "Configuration Principale"
-        },
-        "export": {
-          "fields": {
-            "flows": "Exporter tous les Flux",
-            "templates": "Exporter tous les modèles"
-          },
-          "label": "Exporter"
-        },
-        "localization": {
           "descriptions": {
-            "date_format": "Format utilisé pour afficher les dates dans tout le tableau de bord.",
-            "language": "Langue de l'interface pour les menus et les labels.",
-            "time_zone": "Utilisé pour afficher les dates d'exécution et les triggers programmés."
-          },
-          "fields": {
-            "date_format": "Format de Date",
-            "time_zone": "Fuseau Horaire"
-          },
-          "label": "Langue et région",
-          "note": "Remarque ce paramètre est utilisé pour afficher les propriétés de date et d'heure dans l'interface utilisateur. Pour planifier vos flux dans un fuseau horaire différent de l'UTC, assurez-vous de définir la propriété de fuseau horaire sur le déclencheur de planification dans le code de votre"
-        },
-        "reset_section_to_defaults": "Restaurer les valeurs par défaut de cette section",
-        "save": {
-          "discard": "Jeter",
-          "label": "Enregistrer les préférences",
-          "unsaved_title": "Modifications non enregistrées",
-          "unsaved_warning": "Vous avez des modifications non enregistrées. Voulez-vous les enregistrer avant de quitter ?"
-        },
-        "sidebar": {
-          "descriptions": {
-            "items": "Afficher, masquer et réorganiser les éléments dans la barre latérale."
-          },
-          "fields": {
-            "items": "Éléments de Navigation"
-          },
-          "label": "Barre latérale"
+            "default_namespace": "Utilisé lors de la création de nouveaux flows sans namespace.",
+            "log_level": "Niveau de log minimum affiché dans les logs d'exécution.",
+            "log_display": "Comment les logs sont présentés lors de l'ouverture d'une exécution.",
+            "editor_type": "Éditeur affiché lors de l'ouverture d'un flow pour la première fois.",
+            "execute_flow": "Où les résultats d'exécution s'ouvrent après le déclenchement d'un run.",
+            "execute_default_tab": "Onglet sélectionné lors de la navigation vers une exécution.",
+            "flow_default_tab": "Onglet sélectionné lors de la navigation vers un flow.",
+            "triggers_default_tab": "Onglet sélectionné lors de la navigation vers la page des triggers.",
+            "auto_refresh_interval": "Secondes entre les actualisations automatiques des données sur les pages de liste.",
+            "playground": "Exécutez les tasks individuellement dans le bac à sable de l'éditeur."
+          }
         },
         "theme": {
-          "app_font_size_options": {
-            "large": "Grande",
-            "medium": "Moyenne",
-            "small": "Petite"
-          },
-          "color_modes": {
-            "dark_1": "Sombre 1.0",
-            "dark_2": "Sombre 2.0",
-            "light": "Lumière",
-            "sync": "Synchroniser avec le système"
-          },
-          "confirmations": {
-            "color_mode": "Votre interface utilise maintenant le thème `{mode}`."
-          },
-          "descriptions": {
-            "app_font_size": "Facteur d'échelle appliqué à toutes les tailles de police de l'interface.",
-            "color_mode": "Choisissez votre thème d'interface préféré.",
-            "color_mode_shortcut": "Astuce : appuyez sur <kbd>Ctrl</kbd>+<kbd>Maj</kbd>+<kbd>L</kbd> pour changer de thème depuis n'importe où.",
-            "editor_folding_stratgy": "Réduire les blocs YAML longs par défaut lors de l'ouverture d'un flow.",
-            "editor_font_family": "Police monospace utilisée dans l'éditeur YAML.",
-            "editor_font_size": "Taille de police utilisée dans les éditeurs YAML et sans code.",
-            "editor_hover_description": "Afficher les descriptions des propriétés au survol dans l'éditeur.",
-            "environment_color": "Couleur d'accent utilisée pour l'environnement actuel dans la navigation.",
-            "environment_name": "Nom d'affichage pour l'environnement actuel, affiché dans la navigation.",
-            "logs_font_size": "Taille de police utilisée dans les visionneuses de log et les terminaux."
-          },
+          "label": "Préférences de thème",
           "fields": {
             "app_font_size": "Taille de police de l'application",
             "chart_color_scheme": {
+              "label": "Schéma de Couleurs du Graphique",
               "classic": "Classique",
-              "kestra": "Kestra",
-              "label": "Schéma de Couleurs du Graphique"
+              "kestra": "Kestra"
             },
             "color_mode": "Mode couleur",
             "editor_folding_stratgy": "Stratégie de Pliage Automatique ou Multi-Lignes de l'Éditeur",
@@ -1850,24 +1066,867 @@
             "logs_font_size": "Taille de police des Logs",
             "theme": "Modèle"
           },
-          "label": "Préférences de thème"
+          "color_modes": {
+            "dark_2": "Sombre 2.0",
+            "dark_1": "Sombre 1.0",
+            "light": "Lumière",
+            "sync": "Synchroniser avec le système"
+          },
+          "confirmations": {
+            "color_mode": "Votre interface utilise maintenant le thème `{mode}`."
+          },
+          "descriptions": {
+            "color_mode": "Choisissez votre thème d'interface préféré.",
+            "color_mode_shortcut": "Astuce : appuyez sur <kbd>Ctrl</kbd>+<kbd>Maj</kbd>+<kbd>L</kbd> pour changer de thème depuis n'importe où.",
+            "logs_font_size": "Taille de police utilisée dans les visionneuses de log et les terminaux.",
+            "editor_font_family": "Police monospace utilisée dans l'éditeur YAML.",
+            "editor_font_size": "Taille de police utilisée dans les éditeurs YAML et sans code.",
+            "editor_folding_stratgy": "Réduire les blocs YAML longs par défaut lors de l'ouverture d'un flow.",
+            "editor_hover_description": "Afficher les descriptions des propriétés au survol dans l'éditeur.",
+            "environment_name": "Nom d'affichage pour l'environnement actuel, affiché dans la navigation.",
+            "environment_color": "Couleur d'accent utilisée pour l'environnement actuel dans la navigation.",
+            "app_font_size": "Facteur d'échelle appliqué à toutes les tailles de police de l'interface."
+          },
+          "app_font_size_options": {
+            "small": "Petite",
+            "medium": "Moyenne",
+            "large": "Grande"
+          }
+        },
+        "localization": {
+          "label": "Langue et région",
+          "note": "Remarque ce paramètre est utilisé pour afficher les propriétés de date et d'heure dans l'interface utilisateur. Pour planifier vos flux dans un fuseau horaire différent de l'UTC, assurez-vous de définir la propriété de fuseau horaire sur le déclencheur de planification dans le code de votre",
+          "fields": {
+            "time_zone": "Fuseau Horaire",
+            "date_format": "Format de Date"
+          },
+          "descriptions": {
+            "language": "Langue de l'interface pour les menus et les labels.",
+            "time_zone": "Utilisé pour afficher les dates d'exécution et les triggers programmés.",
+            "date_format": "Format utilisé pour afficher les dates dans tout le tableau de bord."
+          }
+        },
+        "export": {
+          "label": "Exporter",
+          "fields": {
+            "flows": "Exporter tous les Flux",
+            "templates": "Exporter tous les modèles"
+          }
+        },
+        "save": {
+          "label": "Enregistrer les préférences",
+          "discard": "Jeter",
+          "unsaved_title": "Modifications non enregistrées",
+          "unsaved_warning": "Vous avez des modifications non enregistrées. Voulez-vous les enregistrer avant de quitter ?"
+        },
+        "reset_section_to_defaults": "Restaurer les valeurs par défaut de cette section",
+        "sidebar": {
+          "label": "Barre latérale",
+          "fields": {
+            "items": "Éléments de Navigation"
+          },
+          "descriptions": {
+            "items": "Afficher, masquer et réorganiser les éléments dans la barre latérale."
+          }
+        }
+      }
+    },
+    "apps": "Applications",
+    "demos": {
+      "enterprise_edition": "Édition Enterprise",
+      "get_a_demo_button": "Obtenir une démo",
+      "contact_sales": "Contactez les ventes",
+      "watch_the_video": "Regarder la vidéo",
+      "secrets": {
+        "title": "Améliorez votre gestion des Secrets",
+        "message": "L'Enterprise Edition (EE) vous permet d'ajouter, de modifier ou de supprimer des secrets directement dans l'UI, sans redémarrage de l'instance. Organisez les secrets par namespace avec des permissions RBAC granulaires, et héritez-les des namespaces parents aux namespaces enfants. EE s'intègre avec des gestionnaires de secrets comme HashiCorp Vault, AWS Secrets Manager, Azure Key Vault, Google Secret Manager et Elasticsearch. Configurez des backends dédiés par namespace, tenant ou instance pour isoler les secrets entre les équipes, ou activez des secrets en lecture seule stockés dans des coffres externes. Les secrets restent chiffrés au repos et en transit. Un cache optionnel réduit les appels API, et les pistes d'audit loguent tous les accès.",
+        "detected_env": "Voici les variables d'environnement de type secret identifiées au démarrage de l'instance :",
+        "empty_env": "Vous n'avez pas encore de Secrets dans votre environnement.",
+        "add_env": {
+          "intro": "Pour créer un nouveau Secret :",
+          "first": "Encodez la <a href=\"https://kestra.io/docs/how-to-guides/secrets?utm_source=app&utm_medium=referral&utm_campaign=secrets-inlinedoc#using-secrets-in-kestra\" target=\"_blank\">valeur secrète en Base64</a>",
+          "second": "Ajoutez une variable d'environnement nommée '<strong>SECRET_{'{MY_SECRET_KEY}'}</strong>' avec la valeur ci-dessus.",
+          "third": "Redémarrez votre instance Kestra"
         }
       },
-      "label": "Paramètres",
-      "updated": "{name} mis à jour"
+      "apps": {
+        "title": "Créez des applications personnalisées avec Kestra",
+        "message": "Les applications dans Kestra Enterprise Edition vous permettent de créer des interfaces utilisateur personnalisées qui interagissent avec les workflows Kestra depuis l'extérieur de la plateforme. Cette fonctionnalité vous permet d'utiliser vos workflows comme un backend pour des applications personnalisées, permettant aux utilisateurs non techniques de soumettre des données via des formulaires ou de reprendre des workflows PAUSED en attente d'approbation."
+      },
+      "tests": {
+        "label": "Tests",
+        "header": "Tests unitaires pour les flows",
+        "title": "Assurez la fiabilité à chaque changement",
+        "message": "Vérifiez la logique de vos flows de manière isolée, détectez les régressions tôt et maintenez la confiance dans vos automatisations à mesure qu'elles évoluent et se développent."
+      },
+      "assets": {
+        "label": "Actifs",
+        "header": "Métadonnées des actifs et Observabilité",
+        "title": "Amenez chaque dataset, service et dépendance en vue.",
+        "message": "Les assets connectent les métadonnées d'observabilité, de lignée et de propriété afin que les équipes de la plateforme puissent résoudre les problèmes plus rapidement et déployer en toute confiance."
+      },
+      "IAM": {
+        "title": "Gérer les utilisateurs via IAM avec SSO, SCIM et RBAC",
+        "message": "L'édition Kestra Enterprise dispose de capacités IAM intégrées avec une authentification unique (SSO), une synchronisation de répertoire SCIM et un contrôle d'accès basé sur les rôles (RBAC), s'intégrant avec plusieurs fournisseurs d'identité et vous permettant d'attribuer des permissions détaillées aux utilisateurs et aux comptes de service."
+      },
+      "tenants": {
+        "title": "Gérer les flux de travail dans des tenants isolés",
+        "message": "L'édition Kestra Enterprise prend en charge la multi-tenance, vous offrant des environnements entièrement isolés pour différentes équipes ou projets, chacun avec ses propres ressources telles que des groupes de workers dédiés ou des secrets et des backends de stockage internes."
+      },
+      "audit-logs": {
+        "title": "Suivre les modifications avec les Audit Logs",
+        "message": "L'édition Kestra Enterprise enregistre chaque activité avec des enregistrements robustes et immuables, ce qui facilite le suivi des modifications, le maintien de la conformité et la résolution des problèmes."
+      },
+      "quotas": {
+        "title": "Appliquer des quotas d'exécution sur les flows",
+        "message": "Kestra Enterprise Edition vous permet de définir des quotas sur les flows pour limiter le nombre d'exécutions simultanées ou totales dans une fenêtre de temps. Les quotas vous aident à protéger l'infrastructure partagée, à appliquer les SLAs et à empêcher les workflows incontrôlés de consommer des ressources excessives."
+      },
+      "instance": {
+        "title": "Gérer l'infrastructure sur votre instance",
+        "message": "L'édition Enterprise de Kestra fournit un tableau de bord opérationnel pour vous aider à observer la santé de votre plateforme et à suivre les métriques de disponibilité de tous les services tels que, entre autres, les Workers, les Schedulers et les Executors. Depuis la même page, vous pouvez également créer des annonces pour informer vos utilisateurs des interruptions planifiées, et vous pouvez entrer en mode maintenance, ce qui met temporairement tous les services et les exécutions de workflow dans un état PAUSED pour effectuer une mise à niveau."
+      },
+      "blueprints": {
+        "title": "Ajouter des Blueprints Personnalisés",
+        "message": "Dans l'édition Kestra Enterprise, vous pouvez créer des Blueprints personnalisés uniquement disponibles pour votre organisation. Vous pouvez les utiliser comme modèles de bonnes pratiques pour partager, centraliser et documenter les workflows couramment utilisés dans votre équipe."
+      },
+      "namespace": {
+        "edit": {
+          "title": "Améliorez la Gestion de votre Namespace",
+          "message": "Dans l'édition Kestra Enterprise, les namespaces offrent une isolation avancée et une gouvernance des secrets, variables et paramètres par défaut des plugins à grande échelle. Les administrateurs peuvent configurer des gestionnaires de secrets personnalisés, des stockages backends isolés, des groupes de workers dédiés, et des permissions fines par namespace. Cela garantit que les secrets, variables et configurations de plugins restent sécurisés et faciles à maintenir à travers différentes équipes et projets."
+        },
+        "secrets": {
+          "title": "Gérer les secrets de manière sécurisée",
+          "message": "Dans Kestra Enterprise Edition, vous pouvez stocker et contrôler les secrets au niveau du namespace, minimisant ainsi les risques et garantissant que les identifiants de chaque équipe restent isolés. Grâce à la hiérarchie imbriquée, vous pouvez également configurer des identifiants dans un namespace parent et ils seront hérités par tous les namespaces enfants. Le support pour les gestionnaires de secrets dédiés et les paramètres de permission au niveau du namespace renforcent encore la sécurité et la conformité."
+        },
+        "assets": {
+          "title": "Centraliser la gestion des actifs",
+          "message": "Dans Kestra Enterprise Edition, Assets maintient un inventaire en temps réel des ressources avec lesquelles vos workflows interagissent. Ces ressources peuvent être des tables de base de données, des machines virtuelles, des fichiers ou tout système externe avec lequel vous travaillez."
+        },
+        "variables": {
+          "title": "Gérez vos Variables de manière centralisée",
+          "message": "Dans Kestra Enterprise Edition, vous pouvez définir et gérer des variables au niveau du namespace pour éliminer les configurations répétitives à travers les flows. Ces variables assurent la cohérence, simplifient les mises à jour de configuration et peuvent être facilement référencées par n'importe quel task ou trigger pour des workflows plus propres et plus faciles à maintenir."
+        },
+        "plugin-defaults": {
+          "title": "Standardiser la Configuration avec les Valeurs par Défaut du Plugin",
+          "message": "Dans Kestra Enterprise Edition, vous pouvez définir des paramètres par défaut spécifiques au namespace pour les plugins, réduisant ainsi le besoin de configurations dupliquées dans chaque flow. Cette gouvernance centrale des plugins impose des configurations cohérentes, permet une référence sécurisée des secrets ou des variables, et simplifie la maintenance de vos workflows."
+        },
+        "history": {
+          "title": "Gérer l'historique des révisions en un seul endroit",
+          "message": "Dans Kestra Enterprise Edition, vous pouvez gérer l'historique des révisions de vos namespaces"
+        },
+        "audit-logs": {
+          "title": "Suivez tous les changements en un seul endroit",
+          "message": "Dans Kestra Enterprise Edition, vous pouvez consulter les logs d'audit au niveau du namespace avec des différences détaillées, vous offrant un historique clair de qui a modifié quoi et quand à travers toutes les ressources."
+        }
+      }
+    },
+    "assets": {
+      "title": "Ressources"
+    },
+    "onboarding": {
+      "welcome": {
+        "headline": "Créez et exécutez votre premier workflow en quelques minutes",
+        "guided_title": "Créez votre premier flow",
+        "badge": "Tutoriel",
+        "guided_description": "Apprenez à créer et exécuter votre premier flow grâce à des étapes guidées.",
+        "guided_duration": "Recommandé pour la plupart",
+        "self_serve_title": "Créer un flow à partir de zéro",
+        "self_serve_description": "Accédez directement à l’éditeur et créez votre propre flow.",
+        "self_serve_note": "Pour les utilisateurs expérimentés",
+        "additional_help": "Aide supplémentaire",
+        "docs": "Documentation",
+        "tutorial": "Tutoriel",
+        "blueprints": "Blueprints",
+        "slack": "Communauté Slack"
+      },
+      "steps": {
+        "flow_basics": {
+          "title": "Les bases des flows",
+          "description": "Dans Kestra, un <code>flow</code> est l’unité centrale d’orchestration. Vous le définissez en YAML avec des métadonnées et des tâches ordonnées.<br><br>Examinez la structure d’exemple ci-dessous, puis continuez à la construire étape par étape."
+        },
+        "add_id": {
+          "title": "Ajouter l’ID du flow",
+          "description": "L’ID est le nom unique de votre flow, afin que vous puissiez le retrouver, l’exécuter et le référencer de manière cohérente.<br><br>Ajoutez maintenant <code>id</code> au niveau racine."
+        },
+        "add_namespace": {
+          "title": "Ajouter un namespace",
+          "description": "Le Namespace est un regroupement de type dossier qui organise les flows par équipe, projet ou environnement.<br><br>Ajoutez maintenant <code>namespace</code> au niveau racine."
+        },
+        "add_input": {
+          "title": "Ajouter une entrée",
+          "description": "Les inputs sont des paramètres au niveau du flow qui peuvent être référencés dans les tâches pour contrôler dynamiquement le comportement à l’exécution.<br><br>Ajoutez maintenant un input nommé <code>name</code> avec le type <code>STRING</code>."
+        },
+        "add_log_task": {
+          "title": "Ajouter la première tâche",
+          "description": "Les tâches sont les unités de travail exécutées par votre flow, définies comme une liste ordonnée d’étapes. Chaque tâche a besoin d’un <code>id</code> unique et d’un <code>type</code>. Kestra fournit de nombreux plugins de tâches pour des systèmes externes ; ici, nous utilisons une tâche de script Python.<br><br>La syntaxe <code>&#123;&#123; ... &#125;&#125;</code> est une expression Pebble, utilisée pour référencer des variables dynamiquement à l’exécution, comme <code>&#123;&#123; inputs.name &#125;&#125;</code> depuis vos inputs de flow.<br><br>Ajoutez maintenant la première tâche sous <code>tasks</code> avec <code>id</code>, <code>type</code> et un <code>script</code> qui affiche un message de bienvenue."
+        },
+        "save_flow": {
+          "title": "Enregistrer le flow",
+          "description": "L’enregistrement conserve la définition de votre flow afin qu’il puisse être exécuté."
+        },
+        "execute_flow": {
+          "title": "Exécuter le flow",
+          "description": "L’exécution démarre un run de votre flow avec des valeurs d’input au moment de l’exécution."
+        },
+        "view_logs_status": {
+          "title": "Vérifier l’exécution",
+          "description": "Les détails d’exécution affichent le statut du run, les temps et les logs de sortie au niveau des tâches.<br><br>Ouvrez maintenant les détails d’exécution et cliquez sur <code>greet</code> dans le diagramme de Gantt pour voir les logs."
+        },
+        "edit_flow_from_execution": {
+          "title": "Retourner à l’éditeur de flows",
+          "description": "Vous pouvez revenir directement d’une exécution à la définition du flow pour itérer rapidement."
+        },
+        "add_cron_trigger": {
+          "title": "Ajouter un trigger cron",
+          "description": "Les triggers peuvent démarrer des runs selon des horaires ou des événements externes (par exemple des webhooks ou des messages MQTT).<br><br>Ajoutez maintenant un trigger de planification cron pour que ce flow s’exécute toutes les 5 minutes."
+        },
+        "add_input_default": {
+          "title": "Définir une valeur par défaut pour l’input",
+          "description": "Lorsqu’un flow est déclenché automatiquement, les inputs ont tout de même besoin de valeurs à l’exécution.<br><br>L’input <code>name</code> a déjà été créé à l’étape précédente, il n’est donc pas nécessaire de l’ajouter à nouveau. Définissez simplement une valeur par défaut pour l’input existant <code>name</code>."
+        },
+        "save_flow_again": {
+          "title": "Enregistrer le flow",
+          "description": "Votre flow dispose maintenant d’un planning et d’une valeur d’input par défaut pour les exécutions automatiques."
+        },
+        "background_runs_info": {
+          "title": "Exécutions planifiées",
+          "description": "Ce flow s’exécutera désormais en arrière-plan toutes les 5 minutes.<br><br>Vous pouvez accéder à la vue d’ensemble des Exécutions depuis le menu de gauche pour surveiller les runs planifiés."
+        },
+        "finish": {
+          "title": "Vous avez terminé le tutoriel Premier Flow",
+          "description": "Bon début. Vous avez créé, exécuté, paramétré et planifié un flow.<br><br>Choisissez ce que vous souhaitez faire ensuite ..."
+        }
+      },
+      "actions": {
+        "next": "Suivant",
+        "complete": "Terminer",
+        "save_to_continue": "Cliquez sur Enregistrer dans la barre du haut (à droite).",
+        "execute_to_continue": "1. Cliquez sur Exécuter dans la barre du haut (à droite).\n2. Fournissez une valeur pour <strong>name</strong>.\n3. Cliquez à nouveau sur Exécuter dans la fenêtre modale.",
+        "edit_flow_to_continue": "Cliquez sur Modifier le flow dans la barre du haut (à droite).",
+        "cancel_tutorial": "Annuler le tutoriel",
+        "finish_tutorial": "Terminer le tutoriel"
+      },
+      "finish_actions": {
+        "explore_blueprints": "Explorer les Blueprints",
+        "create_flow": "Créer un flow"
+      },
+      "editor_hints": {
+        "build_intro": "Créez votre premier flow étape par étape.",
+        "step_1": "# 1) Ajouter l’id",
+        "step_2": "# 2) Ajouter le namespace",
+        "step_3": "# 3) Ajouter un input",
+        "step_4": "# 4) Ajouter des tâches et votre première tâche Python",
+        "step_5": "# 5) Ajouter un trigger cron"
+      },
+      "cancel_modal": {
+        "title": "Annuler le tutoriel Premier Flow",
+        "description": "Voulez-vous annuler le tutoriel Premier Flow ?",
+        "confirm": "Annuler le tutoriel",
+        "keep": "Conserver le tutoriel"
+      },
+      "validation": {
+        "complete_step": "Vous y êtes presque. Terminez cette étape pour continuer.",
+        "fix_yaml": "Il y a un petit problème de formatage YAML. Corrigez-le, puis continuez.",
+        "add_id": "Ajoutez un ID de flow en haut. Exemple : `id: hello_flow`.",
+        "add_namespace": "Ajoutez un namespace en haut. Exemple : `namespace: company.team`.",
+        "add_input_section": "Créez une section `inputs` avec un input.",
+        "add_input_id": "Dans `inputs`, ajoutez `id: name`.",
+        "add_input_type": "Définissez le type de l’input sur `STRING`.",
+        "add_log_task_section": "Créez une section `tasks` et ajoutez votre première tâche.",
+        "add_log_task_id": "Donnez un ID à la tâche, par exemple : `id: greet`.",
+        "add_log_task_type": "Définissez le type de la tâche sur `io.kestra.plugin.scripts.python.Script`.",
+        "add_log_task_message": "Ajoutez un champ `script` à la tâche.",
+        "add_log_task_pebble": "Utilisez une expression Pebble dans le script afin qu’il utilise votre valeur d’input (par exemple : `inputs.name`).",
+        "save_flow": "Cliquez sur Enregistrer pour continuer.",
+        "execute_flow": "Exécutez le flow une fois pour continuer.",
+        "view_logs_status": "Ouvrez les détails d’exécution et vérifiez les logs pour `greet`.",
+        "edit_flow_from_execution": "Cliquez sur `Modifier le flow` dans la barre du haut pour continuer.",
+        "add_cron_trigger_section": "Créez une section `triggers` avec un trigger de planification.",
+        "add_cron_trigger_type": "Définissez le type du trigger sur `io.kestra.plugin.core.trigger.Schedule`.",
+        "add_cron_trigger_cron": "Ajoutez une expression cron, par exemple : `\"*/5 * * * *\"`.",
+        "add_input_default_section": "Revenez à `inputs` et conservez un input existant nommé `name` (n’ajoutez pas un second input).",
+        "add_input_default_id": "Conservez l’ID de l’input existant comme `name`.",
+        "add_input_default_defaults": "Ajoutez une valeur par défaut pour `name`, par exemple : `defaults: \"Kestra\"`.",
+        "save_flow_again": "Cliquez à nouveau sur Enregistrer pour continuer."
+      }
+    },
+    "enable concurrency": "Activer la concurrence",
+    "auditlogs": "Journaux d'audit",
+    "quotas": "Quotas",
+    "iam": "IAM",
+    "tenant": {
+      "name": "Mandant",
+      "names": "Mandants"
+    },
+    "ee-tooltip": {
+      "features-blocked": "Cette fonctionnalité nécessite l'édition Enterprise.",
+      "button": "Contactez-nous"
+    },
+    "flow_only": "Disponible uniquement sur l'onglet Flow.",
+    "bulk action async warning": "Cela peut prendre quelques instants.",
+    "bulk unpause backfills": "Reprendre {count} backfill",
+    "bulk pause backfills": "Mettre en pause {count} backfill",
+    "bulk delete backfills": "Supprimer {count} backfill",
+    "bulk unlock": "Débloquer {count} triggers",
+    "bulk disabled status": {
+      "true": "Désactiver {count} triggers",
+      "false": "Activer {count} triggers"
+    },
+    "unlock": "Débloquer",
+    "bulk success unpause backfills": "{count} backfills redémarrés",
+    "bulk success pause backfills": "{count} backfills mis en pause",
+    "bulk success delete backfills": "{count} backfills supprimés",
+    "bulk success unlock": "{count} triggers débloqués",
+    "bulk success disabled status": {
+      "true": "{count} triggers désactivés",
+      "false": "{count} triggers activés"
+    },
+    "no_namespaces": "Zéro espace de noms correspond aux critères de recherche.",
+    "system_namespace": "Gardez votre plateforme sous contrôle avec les system flows.",
+    "system_namespace_description": "Automatisez les tâches de maintenance, des alertes de défaillance aux nettoyages automatisés.",
+    "pluginDefaults": {
+      "title": "Paramètres par défaut du plugin",
+      "add": "Ajouter le Plugin par Défaut",
+      "edit": "Modifier le Plugin par Défaut",
+      "add_subtitle": "Configurer un nouveau plugin par défaut avec ses propriétés",
+      "edit_subtitle": "Modifier la configuration par défaut du plugin existant",
+      "predefined": "Plugin Prédéfini",
+      "custom": "Plugin personnalisé",
+      "form": "Formulaire",
+      "yaml": "YAML",
+      "select_predefined": "Sélectionner un Plugin Prédéfini",
+      "cancel": "Annuler",
+      "update": "Mettre à jour le Plugin par Défaut",
+      "custom_type": "Type de plugin personnalisé",
+      "custom_placeholder": "Entrez le type de plugin",
+      "use_custom": "Utiliser personnalisé",
+      "custom_configure": "Type de plugin personnalisé - configurer avec YAML",
+      "yaml_configuration": "Configuration YAML",
+      "show_yaml": "Afficher YAML"
+    },
+    "secret": {
+      "add": "Créer",
+      "update": "Mettre à jour le secret '{name}'",
+      "isReadOnly": "Le secret est en lecture seule",
+      "names": "Secrets",
+      "inherited": "Secrets hérités"
+    },
+    "workerId": "Worker Id",
+    "kv": {
+      "name": "Stockage de clés/valeurs",
+      "type": "Type",
+      "add": "Créer",
+      "update": "Mettre à jour la valeur pour la clé '{key}'",
+      "duplicate": "Cette clé existe déjà",
+      "delete multiple": {
+        "confirm": "Êtes-vous sûr de vouloir supprimer : <code>{name}</code> KV(s) ?",
+        "warning": "Vous n'avez pas les autorisations pour ces namespaces, ils seront donc omis : <code>{namespaces}</code>"
+      },
+      "inherited": "Paires KV héritées"
+    },
+    "expiration": "Expiration",
+    "failed to render pdf": "Impossible de rendre l'aperçu PDF",
+    "page": {
+      "previous": "Page précédente",
+      "next": "Page suivante"
+    },
+    "namespace_editor": {
+      "empty": {
+        "title": "Aucun onglet actuellement ouvert",
+        "create_message": "Vous pouvez créer ou importer des fichiers de namespace.",
+        "video_message": "Vous pouvez regarder la vidéo d'introduction pour notre éditeur."
+      },
+      "close": {
+        "tab": "Fermer l'onglet",
+        "all": "Fermer tous les onglets",
+        "other": "Fermer les autres onglets",
+        "right": "Fermer à droite"
+      }
+    },
+    "curl": {
+      "command": "Commande cURL",
+      "note": "Notez que pour les types d'input SECRET et FILE, la commande doit être adaptée pour correspondre aux valeurs réelles."
+    },
+    "webhook": {
+      "curl_command": "Commande cURL Webhook",
+      "payload": "Payload Webhook (JSON)",
+      "curl_note": "Utilisez cette commande cURL pour déclencher le flow via webhook avec une charge utile JSON personnalisée",
+      "no_triggers": "Ce flow n'a pas de triggers webhook activés",
+      "copy_url": "Copier l'URL du webhook"
+    },
+    "logs_view": {
+      "raw": "Vue temporelle",
+      "raw_details": "Affiche les logs des tâches et du flow dans un format brut ordonné par horodatage",
+      "compact": "Vue par défaut",
+      "compact_details": "Affiche les logs dans un format compacte regroupé par tâche"
+    },
+    "execution_deletion": {
+      "logs": "Supprimer les journaux",
+      "metrics": "Supprimer les métriques",
+      "storage": "Supprimer les fichiers de stockage interne"
+    },
+    "scope_filter": {
+      "all": "Tous les {label}",
+      "user": "Utilisateur {label}",
+      "system": "Système {label}",
+      "user_description": "Utilisateur régulier a initié {label}",
+      "system_description": "Maintenance du système {label}"
+    },
+    "data": "Données",
+    "webhook link copied": "Lien du webhook copié.",
+    "copy url": "Copier l'URL",
+    "scheduleDate": "Date de planification",
+    "warning": "Avertissement",
+    "trigger_check_warning": "L'utilisation des variables de trigger ne fonctionnera pas avec l'exécution manuelle du flow. Ajoutez l'opérateur de coalescence `??` pour résoudre le problème. Par exemple, au lieu de `trigger.date`, utilisez `trigger.date ?? execution.startDate`.",
+    "docs": "Documentation",
+    "active-slots": "Slots actifs",
+    "behavior": "Comportement",
+    "concurrency": "Concurrence",
+    "no-executions-view": {
+      "title": "Commencez à automatiser avec",
+      "sub_title": "Cliquez sur le bouton Exécuter pour démarrer l'exécution de votre premier workflow.",
+      "namespace_sub_title": "Exécutez un ou plusieurs flows de ce namespace pour remplir ce tableau de bord.",
+      "guidance_desc": "Besoin d'aide pour exécuter votre flow ?",
+      "namespace_guidance_desc": "Besoin de conseils pour gérer votre Namespace ?",
+      "guidance_sub_desc": "Suivez la documentation pour toutes les informations dont vous avez besoin."
+    },
+    "execution_guide": {
+      "get_started": {
+        "title": "Commencer ⚡",
+        "text": "Suivez le Guide de démarrage rapide pour installer Kestra et commencer à créer vos premiers workflows."
+      },
+      "namespaces": {
+        "title": "À propos des namespaces",
+        "text": "Les namespaces sont des regroupements logiques de flows et de leurs composants."
+      },
+      "workflow_components": {
+        "title": "Composants du Workflow",
+        "text": "Découvrez les principaux composants d'orchestration d'un workflow Kestra."
+      },
+      "videos_tutorials": {
+        "title": "Tutoriels Vidéo",
+        "text": "Commencez avec nos tutoriels vidéo."
+      }
+    },
+    "open sidebar": "ouvrir la barre latérale",
+    "close sidebar": "fermer la barre latérale",
+    "customize sidebar": "Personnaliser la barre latérale",
+    "reset to defaults": "Réinitialiser aux valeurs par défaut",
+    "drop items here": "Déposez les éléments ici",
+    "files": "Fichiers",
+    "optional": "Optionnel",
+    "no_data": "On dirait qu'il n'y a rien ici… pour l'instant !<br/>Ajustez vos filtres, ou réessayez !",
+    "bookmark": "Favoris",
+    "remove_bookmark": "Êtes-vous sûr de vouloir supprimer ce signet ?",
+    "showLess": "Afficher moins",
+    "showMore": "Afficher plus",
+    "documentationMenu": "Menu de documentation",
+    "item": "élément",
+    "items": "éléments",
+    "cron": "Cron",
+    "execution_started": "L'exécution a commencé !",
+    "execution_failed": "Échec de l'exécution !",
+    "last error was": "La dernière erreur était",
+    "execution restarted": "Cette exécution a été redémarrée {nbRestart} fois.",
+    "execution replay": "Cette exécution est une relecture de",
+    "execution replayed": "Cette exécution a été rejouée.",
+    "task run id": "ID d'exécution de tâche",
+    "active": "Actif",
+    "flows imported": "Flux importés",
+    "flow not imported": "Certains flow n'ont pas pu être importés",
+    "plugin defaults exported": "Plugins par défaut exportés",
+    "failed to export plugin defaults": "Échec de l'exportation des paramètres par défaut du plugin",
+    "plugin defaults imported": "Paramètres par défaut du plugin importés",
+    "plugin defaults not imported": "Certains paramètres par défaut du plugin n'ont pas pu être importés",
+    "failed to import plugin defaults": "Échec de l'importation des paramètres par défaut du plugin",
+    "filters": {
+      "label": "Choisir des filtres",
+      "empty": "Aucune donnée.",
+      "format": "Tapez le paramètre comme 'key:value'",
+      "text_search": "Rechercher ce texte",
+      "options": {
+        "namespace": "Namespace",
+        "flow": "Flux",
+        "state": "État",
+        "scope": "Portée",
+        "child": "Enfant",
+        "level": "Niveau de log",
+        "task": "Tâche",
+        "metric": "Métrique",
+        "user": "Utilisateur",
+        "type": "Type",
+        "service_type": "Type",
+        "permission": "Permission",
+        "action": "Action",
+        "status": "Statut",
+        "details": "Détails",
+        "aggregation": "Agrégation",
+        "relative_date": "Date relative",
+        "absolute_date": "Date absolue",
+        "labels": "Étiquettes",
+        "text": "I'm sorry, but it seems like there is no text provided for translation. Could you please provide the text you would like to have translated into French?",
+        "startDate": "Date de début",
+        "endDate": "Date de fin"
+      },
+      "comparators": {
+        "is": "est",
+        "is_one_of": "est l'un de",
+        "is_not": "n'est pas",
+        "not_in": "n'est pas dans",
+        "contains": "contient",
+        "not_contains": "ne contient pas",
+        "in": "dans",
+        "between": "entre",
+        "starts_with": "commence par",
+        "greater_than": "plus grand que",
+        "greater_than_or_equal_to": "supérieur ou égal à",
+        "less_than": "moins de",
+        "less_than_or_equal_to": "inférieur ou égal à",
+        "ends_with": "se termine par"
+      },
+      "save": {
+        "label": "Recherches enregistrées",
+        "remove": "Supprimer",
+        "empty": "Vous n'avez pas encore enregistré de recherche.",
+        "tooltip": "Vous ne pouvez pas enregistrer des critères de recherche vides.",
+        "name_already_used": "Le label de recherche est déjà utilisé.",
+        "dialog": {
+          "heading": "Enregistrer la recherche actuelle",
+          "placeholder": "Étiquette",
+          "hint": "Comment souhaitez-vous étiqueter ce critère de recherche ?",
+          "confirmation": "Critères de recherche <code>{name}</code>"
+        }
+      },
+      "settings": {
+        "label": "Paramètres de la page",
+        "show_chart": "Afficher le graphique principal"
+      }
+    },
+    "custom value": "Valeur personnalisée",
+    "chart": "Graphique",
+    "chart preview": "Aperçu du graphique",
+    "no_code": {
+      "toggle_pebble": "Basculer l'éditeur Pebble",
+      "version_oss_placeholder": "Kestra Enterprise permet de versionner les plugins",
+      "unnamed": "Aucun Nom",
+      "adding": "+ Ajouter un {what}",
+      "adding_default": "+ Ajouter une nouvelle valeur",
+      "add_field": "Ajouter {field}",
+      "clearSelection": "Effacer la sélection",
+      "labels": {
+        "yaml": "Éditeur YAML",
+        "no_code": "Éditeur sans code",
+        "label": "Étiquette",
+        "variable": "Variable"
+      },
+      "sections": {
+        "deprecated": "Propriétés obsolètes",
+        "tasks": "Tâches",
+        "triggers": "Déclencheurs",
+        "errors": "Gestionnaires d'erreurs",
+        "afterExecution": "Après l'Exécution",
+        "finally": "Enfin",
+        "pluginDefaults": "Paramètres par défaut du plugin"
+      },
+      "fields": {
+        "main": {
+          "id": "ID de flow",
+          "namespace": "Namespace",
+          "description": "Description",
+          "inputs": "Entrées"
+        },
+        "general": {
+          "retry": "Réessayer",
+          "sla": "SLA",
+          "labels": "Étiquettes",
+          "outputs": "Sorties",
+          "variables": "Variables",
+          "concurrency": "Concurrence",
+          "disabled": "Désactivé",
+          "listeners": "Auditeurs",
+          "taskDefaults": "Paramètres par défaut des Tasks",
+          "workerGroup": "Groupe de Workers",
+          "workerSelector": "Sélecteur de Worker",
+          "checks": "Vérifications",
+          "updated": "Mis à jour"
+        }
+      },
+      "select": {
+        "default": "Sélectionner un type",
+        "task": "Sélectionnez une task",
+        "tasks": "Sélectionnez une task",
+        "triggers": "Sélectionner un trigger",
+        "errors": "Sélectionner une task",
+        "finally": "Sélectionnez une task",
+        "pluginDefaults": "Sélectionner un plugin",
+        "afterExecution": "Sélectionnez une task",
+        "conditions": "Sélectionner une condition",
+        "inputs": "Sélectionnez un type de champ input",
+        "charts": "Sélectionner un type de graphique",
+        "where": "Sélectionnez un type de filtre",
+        "numerator": "Sélectionnez un numérateur"
+      },
+      "creation": {
+        "default": "Ajouter",
+        "tasks": "Ajouter une tâche",
+        "triggers": "Ajouter un trigger",
+        "errors": "Ajouter un gestionnaire d'erreurs",
+        "finally": "Ajouter un bloc finally",
+        "pluginDefaults": "Ajouter un plugin par défaut",
+        "afterExecution": "Ajouter un bloc après l'exécution",
+        "conditions": "Ajouter une condition",
+        "inputs": "Ajouter un champ d'input",
+        "charts": "Ajouter un graphique",
+        "where": "Filtrer vos données",
+        "numerator": "Ajouter un numérateur"
+      },
+      "remove": {
+        "default": "Supprimer cette entrée",
+        "cases": "Supprimer ce cas"
+      }
+    },
+    "properties": {
+      "label": "Propriétés",
+      "hint": "Choisir les colonnes visibles",
+      "shown": "Affiché dans le tableau",
+      "hidden": "Caché dans le tableau"
+    },
+    "editor_shortcuts": {
+      "label": "Raccourcis clavier",
+      "trigger_autocompletion": "Déclencher l'autocomplétion",
+      "command_palette": "Afficher la palette de commandes",
+      "save_flow": "Enregistrer le flow",
+      "execute_flow": "Exécuter le flow",
+      "toggle_ai_agent": "Basculer l'agent AI",
+      "move_line": "Déplacer la ligne",
+      "duplicate_cursor": "Dupliquer le curseur",
+      "fold_unfold": "Plier/Déplier le code",
+      "comment_uncomment": "Commenter/Décommenter",
+      "comment": "Commentaire",
+      "uncomment": "Décommenter",
+      "decrease_fontsize": "Diminuer la taille de la police de l'éditeur",
+      "increase_fontsize": "Augmenter la taille de la police de l'éditeur",
+      "reset_fontsize": "Réinitialiser la taille de police de l'éditeur"
+    },
+    "instance": "Instance",
+    "something_went_wrong": {
+      "loading_execution": "Une erreur s'est produite lors du chargement de l'exécution",
+      "connection_lost": {
+        "title": "Connexion interrompue",
+        "message": "Nous n'avons pas pu atteindre votre instance Kestra. Assurez-vous qu'elle est en cours d'exécution, puis actualisez la page."
+      }
+    },
+    "debug": "Déboguer",
+    "default": "Par défaut",
+    "data_not_protected": "Vos données ne sont pas protégées. Ne les perdez pas. <b>Activez nos fonctionnalités de sécurité gratuites ou essayez notre offre payante.</b>",
+    "activate_basic_auth": "Activer l'authentification de base",
+    "dark_version": "Version sombre",
+    "use_dark_background": "Utilisez cette version lorsque vous travaillez sur un fond sombre pour garantir que notre nom reste lisible.",
+    "light_version": "Version légère",
+    "light_background": "C'est l'option préférée lorsque vous travaillez avec un fond clair.",
+    "monogram": "Monogramme",
+    "wordmark_colors": "Les couleurs du logotype s'adaptent en fonction de l'arrière-plan, tandis que l'icône reste sans arrière-plan lorsqu'elle est placée sur un fond sombre.",
+    "download_logos": "Télécharger le pack de logos",
+    "this_task_has": "Cette tâche a",
+    "about_this_blueprint": "À propos de ce blueprint",
+    "deleted_label": "Supprimé",
+    "fold_all_multi_lines": "Replier toutes les lignes multiples",
+    "task_id_exists": "L'ID de la tâche existe déjà",
+    "task_id_message": "L'Id de la tâche ${existingTask} existe déjà dans le flow.",
+    "trigger_id_exists": "L'identifiant de trigger existe déjà",
+    "trigger_id_message": "L'ID de trigger ${existingTrigger} existe déjà dans le flow.",
+    "watch": "Regarder",
+    "learn_more": "En savoir plus",
+    "watch_video": "Regarder la vidéo",
+    "runners": "Coureurs",
+    "select": "Sélectionnez votre {{section}}",
+    "for flow": "pour flow",
+    "forbidden system labels": "Seul system.correlationId peut être utilisé comme system label",
+    "confirm": "Confirmer",
+    "taskRunners": "Exécuteurs de Task",
+    "additionalPlugins": "Plugins supplémentaires",
+    "appBlocks": "Blocs d'application",
+    "charts": "Graphiques",
+    "dataFilters": "Filtres de données",
+    "logExporters": "Exportateurs de Logs",
+    "empty": {
+      "namespaceFiles": {
+        "title": "Aucun fichier dans cet espace de noms pour le moment",
+        "content": "Les fichiers de l'espace de noms fonctionnent comme un dossier de projet pour cet espace de noms. Stockez du code Python, SQL, dbt ou Terraform, puis référencez n'importe quel fichier dans vos flows avec"
+      },
+      "announcements": {
+        "title": "Vous n'avez pas encore d'annonces !",
+        "content": "Les annonces vous permettent de notifier vos utilisateurs de tout changement ou de les informer des temps d'arrêt de maintenance planifiés. Sélectionnez simplement le type d'annonce, la plage de dates pendant laquelle elle doit être affichée, et rédigez le message d'annonce."
+      },
+      "kill_switches": {
+        "title": "Vous n'avez pas encore de Kill Switches !",
+        "content": "La fonctionnalité Kill Switch offre un mécanisme basé sur l'interface utilisateur pour arrêter les exécutions problématiques. Elle remplace les commandes <code>--skip-executions</code> et <code>--skip-flows</code> disponibles uniquement en ligne de commande par une interface d'administration complète."
+      },
+      "apps": {
+        "title": "Vous n'avez pas encore d'applications !",
+        "content": "Commencez à créer des Apps pour interagir avec Kestra depuis le monde extérieur."
+      },
+      "testSuites": {
+        "title": "Vous n'avez pas encore de Test suites !",
+        "content": "Commencez à créer des suites de test pour tester vos Flows."
+      },
+      "assets": {
+        "title": "Vous n'avez pas encore d'Assets !",
+        "content": "Ajoutez des ressources pour suivre et gérer vos ressources de données, services et infrastructures."
+      },
+      "apiTokens": {
+        "title": "Gérez vos jetons API",
+        "content": "Les jetons API sont utilisés chaque fois que vous souhaitez accorder un accès programmatique à l'API Kestra."
+      },
+      "concurrency_executions": {
+        "title": "Aucune exécution en cours pour ce flow.",
+        "content": "En savoir plus sur les <strong><a href=\"https://kestra.io/docs/workflow-components/execution?utm_source=app&utm_medium=referral&utm_campaign=concurrency-inlinedoc\" target=\"_blank\">Exécutions</a></strong> dans notre documentation."
+      },
+      "concurrency_limit": {
+        "title": "Aucune limite n'est définie pour ce flow.",
+        "content": "En savoir plus sur les <strong><a href=\"https://kestra.io/docs/workflow-components/concurrency?utm_source=app&utm_medium=referral&utm_campaign=concurrency-inlinedoc\" target=\"_blank\">limites de Concurrency</a></strong> dans notre documentation."
+      },
+      "concurrency_limits": {
+        "title": "Aucune limite de concurrence n'est définie.",
+        "content": "En savoir plus sur les <strong><a href=\"https://kestra.io/docs/workflow-components/concurrency?utm_source=app&utm_medium=referral&utm_campaign=concurrency-inlinedoc\" target=\"_blank\">limites de Concurrency</a></strong> dans notre documentation."
+      },
+      "pluginDefaults": {
+        "title": "Vous n'avez pas encore de paramètres par défaut pour les plugins !",
+        "content": "Les paramètres par défaut des plugins vous permettent de gérer centralement la configuration de votre plugin et de la partager avec tous les flows dans votre namespace."
+      },
+      "variables": {
+        "title": "Aucune variable pour le moment",
+        "content": "Ajoutez des paires clé-valeur pour partager la configuration entre les flows. Les namespaces enfants les héritent automatiquement, et vous pouvez référencer n'importe quelle valeur avec"
+      },
+      "workerRegistrationTokens": {
+        "title": "Vous n'avez pas encore de jetons d'enregistrement !",
+        "content": "Les jetons d'enregistrement permettent aux workers distants de s'authentifier et de s'enregistrer en toute sécurité avec votre instance Kestra. Créez un jeton, puis utilisez-le pour connecter de nouveaux workers à ce cluster."
+      },
+      "groups": {
+        "title": "Vous n'avez pas encore de groupes !",
+        "content": "Les groupes vous permettent de regrouper des utilisateurs afin de gérer les autorisations et les liaisons de rôles collectivement dans votre locataire."
+      },
+      "dependencies": {
+        "FLOW": {
+          "title": "Il n'y a actuellement aucune dépendance.",
+          "content": "En savoir plus sur les <a href=\"https://kestra.io/docs/ui/flows?utm_source=app&utm_medium=referral&utm_campaign=dependencies-inlinedoc#dependencies\" target=\"_blank\">Flow Dependencies</a> dans notre documentation."
+        },
+        "EXECUTION": {
+          "title": "Il n'y a actuellement aucune dépendance.",
+          "content": "En savoir plus sur les <a href=\"https://kestra.io/docs/ui/executions?utm_source=app&utm_medium=referral&utm_campaign=dependencies-inlinedoc#dependencies\" target=\"_blank\">dépendances d'exécution</a> dans notre documentation."
+        },
+        "NAMESPACE": {
+          "title": "Il n'y a actuellement aucune dépendance.",
+          "content": "En savoir plus sur les <a href=\"https://kestra.io/docs/ui/namespaces?utm_source=app&utm_medium=referral&utm_campaign=dependencies-inlinedoc#dependencies\" target=\"_blank\">dépendances de namespace</a> dans notre documentation."
+        },
+        "ASSET": {
+          "title": "Il n'y a actuellement aucune dépendance.",
+          "content": "Cet actif n'a pas de dépendances amont ou aval avec des flows ou d'autres actifs."
+        }
+      },
+      "plugins": {
+        "title": "Aucun paramètre par défaut de plugin n'est défini pour ce namespace.",
+        "content": "En savoir plus sur les <strong><a href=\"https://kestra.io/docs/workflow-components/plugin-defaults?utm_source=app&utm_medium=referral&utm_campaign=plugin-default-inlinedoc\" target=\"_blank\">limites de Concurrency</a></strong> dans notre documentation."
+      },
+      "triggers": {
+        "title": "Votre flow n'a pas de triggers.",
+        "content": "En savoir plus sur les <strong><a href=\"https://kestra.io/docs/workflow-components/triggers?utm_source=app&utm_medium=referral&utm_campaign=trigger-inlinedoc\" target=\"_blank\">Triggers</a></strong> dans notre documentation."
+      },
+      "mcpToolFlows": {
+        "title": "Aucun flow d'outil n'est encore enregistré sur ce serveur.",
+        "content": "Exposez un flow comme un outil MCP en y ajoutant un <code>McpToolTrigger</code>. Lisez-en plus sur le <strong><a href=\"https://kestra.io/docs/workflow-components/triggers/mcp-tool-trigger?utm_source=app&utm_medium=referral&utm_campaign=mcp-tool-trigger-inlinedoc\" target=\"_blank\">MCP Tool Trigger</a></strong> dans notre documentation."
+      },
+      "versionPlugin": {
+        "title": "Vous n'avez pas encore de plugin versionné !",
+        "content": "Ici, vous pouvez gérer tous les plugins installés sur votre instance Kestra. Les plugins nouvellement installés peuvent ne pas être immédiatement disponibles dans tous les services Kestra, selon la configuration de votre instance."
+      },
+      "panels": {
+        "title": "Aucun panneau ouvert",
+        "content": "Vous avez fermé tous les panneaux.  \nChoisissez un onglet ci-dessus pour continuer."
+      }
+    },
+    "toggle_word_wrap": "Activer/Désactiver le retour à la ligne",
+    "copied_logs_to_clipboard": "Logs copiés dans le presse-papiers.",
+    "multi_panel_editor": {
+      "move_right": "Déplacer vers la droite",
+      "move_left": "Déplacer à gauche",
+      "close_all_tabs": "Fermer tous les onglets",
+      "close_all_panels": "Fermer tous les panneaux"
+    },
+    "search_docs": "Rechercher",
+    "no_results_found": "Aucun résultat trouvé",
+    "searching": "Recherche en cours...",
+    "worker information": "Informations sur le Worker",
+    "test-badge-text": "Test",
+    "test-badge-tooltip": "Cette exécution a été créée par un Test",
+    "total_executions": "Total des exécutions",
+    "no_results": {
+      "executions": "Aucune exécution trouvée",
+      "triggers": "Aucun Trigger trouvé",
+      "flows": "Aucun flow trouvé",
+      "kv_pairs": "Aucune paire clé-valeur trouvée",
+      "secrets": "Aucun secret trouvé",
+      "templates": "Aucun modèle trouvé",
+      "assets": "Aucun actif trouvé"
+    },
+    "duplicate-pair": "{label} \"{key}\" est dupliqué, première clé ignorée.",
+    "dashboards": {
+      "labels": {
+        "singular": "Tableau de bord",
+        "plural": "Tableaux de bord"
+      },
+      "default": "Tableau de bord par défaut",
+      "switch": "Changer de tableau de bord",
+      "preview": "Aperçu du Dashboard",
+      "empty": "Il n'y a aucun résultat à afficher.",
+      "creation": {
+        "label": "Créer un tableau de bord",
+        "confirmation": "Le tableau de bord <code>{title}</code> est créé."
+      },
+      "edition": {
+        "label": "Modifier le tableau de bord",
+        "confirmation": "Les modifications dans le tableau de bord <code>{title}</code> sont enregistrées.",
+        "chart": "Modifier ce graphique",
+        "id readonly": "La propriété `id` ne peut pas être modifiée — elle est maintenant définie sur ses valeurs initiales. Si vous souhaitez la changer, vous pouvez créer un nouveau tableau de bord et supprimer l'ancien."
+      },
+      "deletion": {
+        "confirmation": "Êtes-vous sûr de vouloir supprimer le tableau de bord <code>{title}</code> ?"
+      },
+      "no_description": "Aucune description",
+      "no_description_hint": "Ajoutez une description à ce flow pour documenter ce qu'il fait.<br>Markdown est pris en charge.",
+      "others": "Autres",
+      "viewAll": "Tout voir",
+      "chart_preview": "Cliquez sur un code source de graphique pour voir son aperçu",
+      "export": "Exporter vers CSV",
+      "quick_filters": {
+        "all": "Tout",
+        "running": "En cours",
+        "paused": "En pause",
+        "success": "Succès",
+        "warning": "Avertissement",
+        "failed": "Échoué"
+      }
     },
     "setup": {
-      "config": {
-        "basicauth": "Authentification basique",
-        "queue": "File d'attente",
-        "repository": "Base de données",
-        "storage": "Stockage Interne"
+      "login": "Connexion",
+      "login_title": "Se connecter",
+      "logout": "Déconnexion",
+      "troubleshooting": "Mot de passe oublié ?",
+      "steps": {
+        "user": "Créer un utilisateur admin",
+        "config": "Valider la Configuration",
+        "survey": "Dites-nous en plus",
+        "complete": "Démarrer l'UI de Kestra"
       },
-      "confirm": {
-        "config_title": "Confirmez que la configuration est valide",
-        "confirm": "Créer un utilisateur admin",
-        "not_valid": "Non, ce n'est pas valide",
-        "valid": "Oui, c'est valide"
+      "titles": {
+        "user": "Créer un utilisateur admin",
+        "survey": "Aidez-nous à améliorer Kestra OSS"
+      },
+      "subtitles": {
+        "user": "Sécurisez votre instance pour commencer.",
+        "config": "Voici les détails de votre configuration",
+        "survey": "I'm sorry, but it seems there is no text provided after the \"----------\" for translation. Could you please provide the text you would like translated into French?",
+        "complete": "Configuration terminée avec succès !"
       },
       "form": {
         "email": "E-mail",
@@ -1878,351 +1937,249 @@
         "username": "Nom d'utilisateur",
         "username_hint": "Doit être une adresse e-mail valide."
       },
-      "login": "Connexion",
-      "login_title": "Se connecter",
-      "logout": "Déconnexion",
-      "steps": {
-        "complete": "Démarrer l'UI de Kestra",
-        "config": "Valider la Configuration",
-        "survey": "Dites-nous en plus",
-        "user": "Créer un utilisateur admin"
-      },
-      "subtitles": {
-        "complete": "Configuration terminée avec succès !",
-        "config": "Voici les détails de votre configuration",
-        "survey": "I'm sorry, but it seems there is no text provided after the \"----------\" for translation. Could you please provide the text you would like translated into French?",
-        "user": "Sécurisez votre instance pour commencer."
-      },
-      "success": {
-        "subtitle": "Vous êtes prêt !",
-        "title": "Félicitations !"
-      },
-      "survey": {
-        "company_11_50": "Projet personnel",
-        "company_1_10": "Apprentissage / exploration",
-        "company_250_plus": "Déploiement en production",
-        "company_50_250": "Évaluation pour mon équipe/entreprise",
-        "company_personal": "Autre",
-        "company_size": "Quel est votre objectif principal avec Kestra ?",
-        "continue": "Continuer",
-        "newsletter": "Recevez les mises à jour des produits par email.",
-        "newsletter_heading": "Restez informé",
-        "skip": "Passer",
-        "use_case": "Pour quoi prévoyez-vous de l'utiliser ?",
-        "use_case_business": "Flux de travail métier",
-        "use_case_data": "Flux de données",
-        "use_case_infrastructure": "Automatisation de l'infrastructure",
-        "use_case_ml": "Pipelines ML",
-        "use_case_other": "Autre",
-        "use_case_scheduling": "Planification et tâches récurrentes"
-      },
-      "titles": {
-        "survey": "Aidez-nous à améliorer Kestra OSS",
-        "user": "Créer un utilisateur admin"
-      },
-      "troubleshooting": "Mot de passe oublié ?",
       "validation": {
-        "config_message": "Assurez-vous de mettre à jour votre configuration pour corriger ce message d'erreur",
-        "email_invalid": "E-mail invalide",
         "email_required": "L'email est requis",
+        "email_invalid": "E-mail invalide",
         "email_temporary_not_allowed": "Les adresses email temporaires ou jetables ne sont pas autorisées",
         "firstName_required": "Prénom requis",
-        "incorrect_creds": "Nom d'utilisateur ou mot de passe invalide. Assurez-vous que vos identifiants sont corrects.",
         "lastName_required": "Nom de famille requis",
         "password_invalid": "Mot de passe invalide",
-        "password_required": "Le mot de passe est requis"
+        "password_required": "Le mot de passe est requis",
+        "incorrect_creds": "Nom d'utilisateur ou mot de passe invalide. Assurez-vous que vos identifiants sont corrects.",
+        "config_message": "Assurez-vous de mettre à jour votre configuration pour corriger ce message d'erreur"
+      },
+      "config": {
+        "repository": "Base de données",
+        "queue": "File d'attente",
+        "storage": "Stockage Interne",
+        "basicauth": "Authentification basique"
+      },
+      "confirm": {
+        "confirm": "Créer un utilisateur admin",
+        "config_title": "Confirmez que la configuration est valide",
+        "not_valid": "Non, ce n'est pas valide",
+        "valid": "Oui, c'est valide"
+      },
+      "survey": {
+        "skip": "Passer",
+        "company_size": "Quel est votre objectif principal avec Kestra ?",
+        "company_1_10": "Apprentissage / exploration",
+        "company_11_50": "Projet personnel",
+        "company_50_250": "Évaluation pour mon équipe/entreprise",
+        "company_250_plus": "Déploiement en production",
+        "company_personal": "Autre",
+        "use_case": "Pour quoi prévoyez-vous de l'utiliser ?",
+        "use_case_infrastructure": "Automatisation de l'infrastructure",
+        "use_case_business": "Flux de travail métier",
+        "use_case_data": "Flux de données",
+        "use_case_ml": "Pipelines ML",
+        "use_case_scheduling": "Planification et tâches récurrentes",
+        "use_case_other": "Autre",
+        "newsletter_heading": "Restez informé",
+        "newsletter": "Recevez les mises à jour des produits par email.",
+        "continue": "Continuer"
+      },
+      "success": {
+        "title": "Félicitations !",
+        "subtitle": "Vous êtes prêt !"
       }
     },
-    "show": "Afficher",
-    "show chart": "Afficher le graphique",
-    "show description": "Afficher une description",
-    "show details": "Afficher les détails",
-    "show documentation": "Afficher la documentation",
-    "show more details": "Afficher plus de détails",
-    "show raw": "Show raw",
-    "show task condition": "Afficher la condition de la task",
-    "show task documentation": "Afficher la documentation des tâches",
-    "show task documentation in editor": "Afficher la documentation dans l'éditeur",
-    "show task logs": "Afficher les journaux de la tâche",
-    "show task outputs": "Afficher les outputs de la tâche",
-    "show task source": "Afficher le code source de la tâche",
-    "showLess": "Afficher moins",
-    "showMore": "Afficher plus",
-    "side-by-side": "côte à côte",
-    "similar lines": "similar lines",
-    "skipped": "Ignoré",
-    "slack support": "Demandez de l'aide sur notre Slack",
-    "something_went_wrong": {
-      "connection_lost": {
-        "message": "Nous n'avons pas pu atteindre votre instance Kestra. Assurez-vous qu'elle est en cours d'exécution, puis actualisez la page.",
-        "title": "Connexion interrompue"
+    "ai": {
+      "flow": {
+        "title": "Agent IA",
+        "prompt_placeholder": "Entrez des instructions pour créer votre flow Kestra. Exemple d'invite : Créez un flow qui s'exécute tous les lundis à 9h.",
+        "select_provider": "Sélectionner un fournisseur",
+        "generating": {
+          "flow": "Génération du YAML de flow pour vous...",
+          "dashboard": "Génération du YAML du tableau de bord pour vous...",
+          "app": "Génération du YAML de l'application pour vous...",
+          "test": "Génération du YAML de test pour vous..."
+        },
+        "enable_instructions": {
+          "header": "<b>AI Copilot n'a pas encore été configuré.</b>\n\nPour activer AI Copilot, ajoutez l'extrait suivant à votre fichier de configuration de l'instance Kestra (par exemple, <code>application.yml</code>), en remplaçant <code>geminiApiKey</code> par votre clé réelle :",
+          "footer": "Remarque : Actuellement, seul Gemini est pris en charge comme fournisseur d'IA pour l'édition Open Source. Pour l'édition Enterprise, veuillez vous référer à la documentation AI Copilot pour la configuration d'autres fournisseurs de modèles.\n\nRedémarrez votre instance Kestra après avoir enregistré la configuration."
+        }
       },
-      "loading_execution": "Une erreur s'est produite lors du chargement de l'exécution"
+      "dashboard": {
+        "prompt_placeholder": "Posez une question sur vos données. Exemple de demande : Montrez-moi le taux de réussite de mes flows au cours des 7 derniers jours."
+      }
     },
-    "source": "Source",
-    "source and blueprints": "Source et blueprints",
-    "source and doc": "Source et documentation",
-    "source and topology": "Source et topologie",
-    "source only": "Source uniquement",
-    "source search": "Recherche de code source",
-    "source_search": {
-      "match_count": "{count} résultat | {count} résultats",
-      "open_flow": "Ouvrir le flow",
-      "preview_empty": "Sélectionnez un résultat pour l'afficher. Cliquez sur un flow dans la liste des résultats pour voir sa source.",
-      "preview_error": "Échec du chargement de la source du flow"
+    "playground": {
+      "title": "Aire de jeu",
+      "run_task_info": "Survolez n'importe quelle task dans l'éditeur de Flow Code et cliquez sur le bouton \"Run task\" pour tester votre task.",
+      "play_icon_info": "Vous pouvez également cliquer sur l'icône Play dans les vues No-Code ou Topology.",
+      "toggle": "Terrain de jeu",
+      "run_task": "Exécuter la Task",
+      "run_this_task": "Exécuter cette task",
+      "run_task_and_downstream": "Exécuter la task et en aval",
+      "run_all_tasks": "Exécuter toutes les tasks",
+      "history": "Dernières 10 exécutions",
+      "clear_history": "Effacer l'historique",
+      "confirm_create": "Vous ne pouvez pas exécuter le playground lors de la création d'un flow. Lancer une exécution de playground créera le flow.",
+      "tooltip_persistence": "Si vous désactivez et réactivez le Playground, les informations restent tant que vous restez sur la page."
     },
-    "specific task": "Tâche spécifique",
-    "start date": "Date de début",
-    "start datetime": "Date de départ",
-    "started date": "Date de démarrage",
-    "state": "État",
-    "state updated date": "Date de mise à jour de l'état",
-    "state_history": "Historique des états",
-    "stats": "Stats",
-    "steps": "Étapes",
-    "stream": "Flow",
-    "sub flow": "Sous-flow",
     "submit": "Soumettre",
-    "success": "Succès",
-    "sum": "Somme",
-    "switch-view": "Changer de vue",
-    "system overview": "Vue d'ensemble du système",
-    "system_namespace": "Gardez votre plateforme sous contrôle avec les system flows.",
-    "system_namespace_description": "Automatisez les tâches de maintenance, des alertes de défaillance aux nettoyages automatisés.",
-    "tags": "Tags",
-    "task": "Tâche",
-    "task failed": "Échec de la task",
-    "task id": "ID de tâche",
-    "task id already exists": "Identifiant de tâche déjà utilisé",
-    "task is running": "La task est en cours d'exécution",
-    "task logs": "Journaux de la tâche",
-    "task run id": "ID d'exécution de tâche",
-    "task sent a warning": "La tâche a envoyé un WARNING",
-    "task was skipped": "La tâche a été ignorée",
-    "task was successful": "La tâche a été un succès",
-    "taskDefaults": "Valeur de tâches par défaut",
-    "taskRunners": "Exécuteurs de Task",
-    "task_id_exists": "L'ID de la tâche existe déjà",
-    "task_id_message": "L'Id de la tâche ${existingTask} existe déjà dans le flow.",
-    "taskid column details": "ID de la dernière tâche exécuté ainsi que son nombre de tentatives.",
-    "tasks": "Tâches",
-    "template": "Template",
-    "template creation": "Création de template",
-    "template delete": "Êtes vous sûr de vouloir supprimer <code>{templateCount}</code> template(s)?",
-    "template export": "Êtes vous sûr de vouloir exporter <code>{templateCount}</code> template(s)?",
-    "templates": "Templates",
-    "templates deleted": "<code>{count}</code> Template(s) supprimé(s)",
-    "templates deprecated": "Les templates sont obsolètes. Veuillez utiliser des sous-flux au lieu des templates. Consultez <a href=\"https://kestra.io/docs/migration-guide/0.11.0/templates?utm_source=app&utm_medium=referral&utm_campaign=template-inlinedoc\" target=\"_blank\">section Migrations</a> expliquant comment vous pouvez migrer vers les sous-flux.",
-    "templates exported": "Templates exportés",
-    "tenant": {
-      "name": "Mandant",
-      "names": "Mandants"
-    },
-    "tenantId": "ID du mandant",
-    "test-badge-text": "Test",
-    "test-badge-tooltip": "Cette exécution a été créée par un Test",
-    "theme": "Thème",
-    "this_task_has": "Cette tâche a",
-    "timezone": "Fuseau horaire",
-    "title": "Titre",
-    "to": "à",
     "to toggle": "pour basculer",
-    "toggle fullscreen": "Permuter le plein écran",
-    "toggle menu": "Basculer le menu",
-    "toggle output": "Voir les sorties",
-    "toggle output display": "Permuter l'affichage de sortie",
-    "toggle periodic refresh each x seconds": "Basculer le rafraîchissement périodique toutes les {interval} secondes",
-    "toggle_word_wrap": "Activer/Désactiver le retour à la ligne",
-    "topology": "Topologie",
-    "topology-graph": {
-      "graph-orientation": "Orientation du graph",
-      "invalid": "Erreur de graphe",
-      "invalid_description": "Une erreur s'est produite lors du chargement du graphique. Veuillez vérifier le code source pour les erreurs.",
-      "zoom-fit": "Voir tout",
-      "zoom-in": "Zoomer",
-      "zoom-out": "Dézoomer",
-      "zoom-reset": "Zoom par défaut"
-    },
-    "total_duration": "Durée totale",
-    "total_executions": "Total des exécutions",
-    "trigger": "Déclencheur",
-    "trigger details": "Détails du déclencheur",
-    "trigger disabled": "Le trigger est désactivé dans la source du flow",
-    "trigger execution id": "Id parent",
-    "trigger filter": {
-      "options": {
-        "ALL": "Tous",
-        "CHILD": "Les exécutions enfantes",
-        "MAIN": "Les exécutions parentes"
+    "accept": "Accepter",
+    "reject": "Rejeter",
+    "draft_available": "Un changement de brouillon est disponible dans l'éditeur",
+    "last modified": "Dernière modification",
+    "run task in playground": "Exécuter la task dans le playground",
+    "task is running": "La task est en cours d'exécution",
+    "task was successful": "La tâche a été un succès",
+    "task failed": "Échec de la task",
+    "task was skipped": "La tâche a été ignorée",
+    "task sent a warning": "La tâche a envoyé un WARNING",
+    "defaultsToNamespaceFile": "Par défaut, fichier de namespace : <code>{name}</code>",
+    "no_file_choosen": "Aucun fichier choisi",
+    "dependency": {
+      "controls": {
+        "zoom_in": "Zoomer",
+        "zoom_out": "Dézoomer",
+        "clear_selection": "Effacer la sélection",
+        "fit_view": "Ajuster à l'écran"
       },
-      "title": "Filtrer les enfants"
-    },
-    "trigger refresh": "Déclencher le rafraîchissement",
-    "triggerId": "ID de trigger",
-    "trigger_check_warning": "L'utilisation des variables de trigger ne fonctionnera pas avec l'exécution manuelle du flow. Ajoutez l'opérateur de coalescence `??` pour résoudre le problème. Par exemple, au lieu de `trigger.date`, utilisez `trigger.date ?? execution.startDate`.",
-    "trigger_id_exists": "L'identifiant de trigger existe déjà",
-    "trigger_id_message": "L'ID de trigger ${existingTrigger} existe déjà dans le flow.",
-    "trigger_states": "États",
-    "triggered": "Exécution déclenchée",
-    "triggered done": "L'exécution <em>{name}</em> est déclenchée !",
-    "triggerflow disabled": "Déclencheur désactivé depuis la définition du flow",
-    "triggers": "Déclencheurs",
-    "triggers_add_card_add": "Ajouter",
-    "triggers_add_card_add_to_flow": "Ajouter au flow",
-    "triggers_add_category_empty": "Aucun trigger dans cette catégorie.",
-    "triggers_add_ee_tooltip": "Ce trigger nécessite l'édition Enterprise.",
-    "triggers_add_empty_title": "Aucun trigger trouvé",
-    "triggers_add_filter_all": "Tous",
-    "triggers_add_filter_app": "Application",
-    "triggers_add_filter_core": "Coeur",
-    "triggers_add_filter_realtime": "Temps réel",
-    "triggers_add_modal_add_button": "Ajouter un Trigger au Flow",
-    "triggers_add_modal_ee_notice": "Ce trigger nécessite l'édition Enterprise.",
-    "triggers_add_modal_flow_placeholder": "Sélectionnez un flow",
-    "triggers_add_modal_namespace_placeholder": "Sélectionner un namespace",
-    "triggers_add_modal_properties_hint": "Configurez les propriétés du trigger dans l'éditeur de flow après avoir ajouté le trigger.",
-    "triggers_add_modal_tab_documentation": "Documentation",
-    "triggers_add_modal_tab_form": "Formulaire",
-    "triggers_add_modal_tab_source": "Source",
-    "triggers_add_modal_title": "{name}",
-    "triggers_add_modal_trigger_id": "ID de trigger",
-    "triggers_add_modal_trigger_id_placeholder": "Identifiant unique pour ce trigger",
-    "triggers_add_search_placeholder": "Rechercher des triggers...",
-    "triggers_header_description": "Parcourez, ajoutez et gérez des triggers pour automatiser vos flows. Choisissez parmi l'exposition de votre flow en tant qu'outil AI, la planification, l'ajout d'un trigger webhook, le sondage pour les changements dans les applications externes, ou les écouteurs d'événements en temps réel.",
-    "triggers_state": {
-      "options": {
-        "disabled": "Désactivé",
-        "enabled": "Activé"
-      },
-      "state": "État"
-    },
-    "triggers_tabs_add": "Ajouter",
-    "triggers_tabs_manage": "Gérer",
-    "true": "Vrai",
-    "type": "Type",
-    "unable to generate graph": "Une erreur est survenue lors de la génération du graphe empêchant l'affichage de la topologie.",
-    "undefined": "Non défini",
-    "unlock": "Débloquer",
-    "unlock trigger": {
-      "button": "Débloquer le déclencheur",
-      "confirmation": "Êtes vous sûr(e) de vouloir débloquer le déclencheur ?",
-      "success": "Le déclencheur est débloqué",
-      "tooltip": {
-        "evaluation": "Le déclencheur est en cours d'évaluation",
-        "execution": "Il existe une exécution en cours pour ce trigger"
-      },
-      "warning": "Cela pourrait amener à de multiples exécutions concurrentes pour le même déclencheur et devrait être considéré comme une solution de dernier recours."
-    },
-    "unqueue": "Défilement",
-    "unqueue as": "Se désenfile en tant que <code>{status}</code>",
-    "unqueue confirm": "Êtes-vous sûr de vouloir retirer de la file d'attente l'exécution <code>{id}</code> ?",
-    "unqueue done": "L'exécution est retirée de la file d'attente",
-    "unqueue title": "Défilér l'exécution <code>{id}</code>.<br/>Notez qu'elle ne respectera pas la limite de concurrence du flow, donc plus d'exécutions pourraient être en cours que la limite autorisée.",
-    "unqueue title multiple": "Êtes-vous sûr de vouloir désenfiler <code>{count}</code> exécutions ?<br/><br/>Notez que cela ne respectera pas la limite de concurrence du flow, donc plus d'exécutions pourraient être en cours que la limite autorisée.",
-    "unsaved changed ?": "Vous avez des changements non sauvegardés, voulez-vous quitter la page ?",
-    "unsaved changes": "Modifications non enregistrées",
-    "unsaved changes warning": "Vous avez des modifications non enregistrées. Si vous quittez cette page, vos modifications seront perdues.",
-    "up trend": "En augmentation",
-    "update": "Mettre à jour",
-    "update aborted": "Mise à jour annulée",
-    "update ok": "est mis à jour",
-    "updated date": "Date de mise à jour",
-    "usage": "Utilisation",
-    "use": "Utiliser",
-    "use_dark_background": "Utilisez cette version lorsque vous travaillez sur un fond sombre pour garantir que notre nom reste lisible.",
-    "valid": "Valide",
-    "validate": "Valider",
-    "value": "Valeur",
-    "variable_explorer": {
-      "empty": "Aucune variable disponible pour cette exécution.",
-      "n_items": "[ {count} éléments ]",
-      "n_keys": "\\{ {count} keys \\}",
-      "one_item": "[ 1 élément ]",
-      "one_key": "\\{ 1 key \\}",
-      "raw_json": "Raw JSON",
-      "search_placeholder": "Rechercher une Key ou une value...",
-      "select_prompt": "Sélectionnez une variable pour inspecter sa value.",
-      "tasks_outputs": "Tasks outputs",
-      "title": "Entrée/Sortie",
-      "tree": "Arborescence"
-    },
-    "variables": "Variables",
-    "version": "Version",
-    "view metrics": "Voir les métriques",
-    "warning": "Avertissement",
-    "warning detected": "Avertissement(s) détecté(s)",
-    "warning flow with triggers": "Ce flow contient des déclencheurs, une exécution manuelle peut ne pas fonctionner si celui-ci dépend de variables de déclencheurs !",
-    "watch": "Regarder",
-    "watch_video": "Regarder la vidéo",
-    "webhook": {
-      "copy_url": "Copier l'URL du webhook",
-      "curl_command": "Commande cURL Webhook",
-      "curl_note": "Utilisez cette commande cURL pour déclencher le flow via webhook avec une charge utile JSON personnalisée",
-      "no_triggers": "Ce flow n'a pas de triggers webhook activés",
-      "payload": "Payload Webhook (JSON)"
-    },
-    "webhook link copied": "Lien du webhook copié.",
-    "welcome": {
-      "help": {
-        "text": "Posez n'importe quelle question dans notre communauté Slack. Si vous êtes bloqué, nous sommes là pour vous aider. ✋",
-        "title": "Besoin d'aide ?"
-      },
-      "menu": "Welcome",
-      "tour": {
-        "text": "Choisissez votre cas d'utilisation et suivez un guide étape par étape pour découvrir les fonctionnalités et capacités de Kestra. ❤️",
-        "title": "Faire une visite guidée du produit"
-      },
-      "tutorial": {
-        "text": "* <a href=\"https://kestra.io/tutorial-videos/all?utm_source=app&utm_medium=referral&utm_campaign=welcome-tutorial\" target=\"_blank\">Tutoriels Vidéo</a>  \n* <a href=\"https://kestra.io/docs?utm_source=app&utm_medium=referral&utm_campaign=welcome-tutorial\" target=\"_blank\">Documentation</a>  \n* <a href=\"https://kestra.io/blueprints?utm_source=app&utm_medium=referral&utm_campaign=welcome-tutorial\" target=\"_blank\">Blueprints</a>",
-        "title": "Tutoriel"
+      "search": {
+        "placeholders": {
+          "default": "Rechercher par flow ou namespace...",
+          "asset": "Rechercher par asset, flow ou namespace..."
+        },
+        "namespace": {
+          "select": "Sélectionner un namespace",
+          "no_namespace": "Sans namespace"
+        },
+        "flow": {
+          "display": "Inclure les dépendances de flow"
+        },
+        "no_results": "Aucun résultat trouvé pour {term}"
       }
     },
+    "preview": {
+      "label": "Aperçu",
+      "force-editor": "Imposer la vue de l'éditeur",
+      "auto-view": "Vue automatique",
+      "view": "Voir",
+      "rows_truncated": "Affichage de {shown} sur {total} lignes. Téléchargez le fichier pour voir toutes les données.",
+      "pagination_info": "Affichage des lignes {start}-{end} sur {total}.",
+      "showing_rows": "Affichage des lignes {start}-{end} sur {total}",
+      "expand": "Développer",
+      "collapse": "Réduire",
+      "previous": "Précédent",
+      "next": "Suivant",
+      "page_of": "Page {current} sur {total}"
+    },
+    "delete trigger": "Supprimer le trigger",
+    "delete triggers": "Supprimer les triggers",
+    "bulk delete triggers": "Êtes-vous sûr de vouloir supprimer {count} triggers ?",
+    "bulk success delete triggers": "{count} triggers ont été supprimés avec succès",
+    "delete trigger confirmation": "Êtes-vous sûr de vouloir supprimer le trigger {id} ? WARNING : supprimer un trigger peut entraîner des exécutions en double si le trigger est toujours actif dans un flow.",
+    "delete trigger success": "Le trigger {id} a été supprimé avec succès",
+    "delete trigger error": "Erreur lors de la suppression du trigger {id}",
+    "revision deleted": "La révision {revision} a été supprimée avec succès",
+    "delete revision confirm": "Êtes-vous sûr de vouloir supprimer la révision {revision} ?",
+    "delete revision error": "Erreur lors de la suppression de la révision {revision} avec l'erreur {error}",
+    "no_history": "Aucun historique disponible",
+    "export_as": "Exporter en .{format}",
+    "save_and_execute": "Enregistrer & Exécuter",
     "welcome_copilot": {
       "button_cta": "Créer un flow à partir de zéro",
       "create_manually": {
-        "description": "Construire à partir de zéro en utilisant l'éditeur",
-        "title": "Créer manuellement"
+        "title": "Créer manuellement",
+        "description": "Construire à partir de zéro en utilisant l'éditeur"
       },
       "docs": {
-        "description": "En savoir plus dans la documentation officielle",
-        "title": "Lire la documentation"
+        "title": "Lire la documentation",
+        "description": "En savoir plus dans la documentation officielle"
       },
+      "title": "Transformez votre idée en workflow",
+      "need_help": "Besoin d'aide ?",
+      "placeholder_prompt": "Envoyez-moi un message de salutation quotidien à 9h.",
+      "show_more": "Afficher plus d'invites",
+      "show_less": "Afficher moins d'invites",
+      "remaining_quota": "Il vous reste {count} générations d'IA. La limite se réinitialise quotidiennement à minuit UTC.",
       "execute_hint": {
-        "description": "Cliquez pour enregistrer votre workflow et l'exécuter immédiatement.",
-        "title": "Enregistrer et exécuter votre flow"
+        "title": "Enregistrer et exécuter votre flow",
+        "description": "Cliquez pour enregistrer votre workflow et l'exécuter immédiatement."
+      },
+      "success_popup": {
+        "title": "Félicitations !",
+        "description": "Vous avez exécuté avec succès votre premier flow ! Vous êtes en bonne voie pour devenir un pro de Kestra.",
+        "tutorial": "Tutoriel Approfondi",
+        "explore": "Explorez Plus"
+      },
+      "success_page": {
+        "title": "Vous êtes prêt !",
+        "description": "Vous avez appris les bases de Kestra. Voici quelques ressources pour vous aider à poursuivre votre parcours.",
+        "restart": "Redémarrer le tutoriel",
+        "items": {
+          "tutorial": {
+            "title": "Démarrer un tutoriel",
+            "description": "Parcours interactif de toutes les fonctionnalités de Kestra"
+          },
+          "blueprints": {
+            "title": "Plans",
+            "description": "Modèles de workflow préconstruits pour des cas d'utilisation courants"
+          },
+          "slack": {
+            "title": "Communauté Slack",
+            "description": "Connectez-vous avec d'autres utilisateurs et obtenez de l'aide de la communauté"
+          },
+          "videos": {
+            "title": "Tutoriels Vidéo",
+            "description": "Guides vidéo étape par étape pour les fonctionnalités avancées"
+          },
+          "demo": {
+            "title": "Obtenez une démo",
+            "description": "Découvrez Kestra Enterprise Edition avec une démonstration personnalisée"
+          }
+        }
+      },
+      "help": {
+        "tutorial": {
+          "title": "Démarrer un tutoriel",
+          "description": "Découvrez comment créer et exécuter votre premier flow avec des étapes guidées."
+        },
+        "blueprints": {
+          "title": "Blueprints",
+          "description": "Explorez des exemples et modèles prêts à l'emploi pour des modèles de workflow courants."
+        },
+        "slack": {
+          "title": "Communauté Slack",
+          "description": "Rejoignez-nous pour partager des idées et des meilleures pratiques, et obtenir de l'aide pour des questions techniques."
+        }
       },
       "flows": {
-        "buildDbtPipeline": {
-          "label": "Créer un pipeline dbt",
-          "prompt": "Créer un flow Kestra qui clone un dépôt de projet dbt et exécute dbt build avec un profil DuckDB."
-        },
-        "buildDockerImageAndRunIt": {
-          "label": "Construire une image Docker et l'exécuter",
-          "prompt": "Créer un flow Kestra qui construit une image Docker à partir d'un Dockerfile en ligne et exécute le conteneur résultant."
-        },
-        "convertCsvToExcel": {
-          "label": "Convertir un CSV en Excel",
-          "prompt": "Créez un flow qui télécharge un fichier CSV, le convertit en Ion, et exporte le résultat en tant que fichier Excel."
-        },
-        "etlWorkflow": {
-          "label": "Flux de travail ETL",
-          "prompt": "Créer un flow ETL qui télécharge des données JSON, les traite avec Python, et interroge le résultat transformé avec DuckDB."
+        "jsonApiToDuckdb": {
+          "label": "API JSON vers DuckDB",
+          "prompt": "Créez un flow qui télécharge un fichier JSON depuis une API publique, le transforme avec un script Python, et le traite avec une tâche DuckDB Queries."
         },
         "installNginxViaAnsible": {
           "label": "Installer Nginx via Ansible",
           "prompt": "Créer un flow Kestra qui installe Nginx sur une machine cible avec Ansible et vérifie la version installée."
         },
-        "jsonApiToDuckdb": {
-          "label": "API JSON vers DuckDB",
-          "prompt": "Créez un flow qui télécharge un fichier JSON depuis une API publique, le transforme avec un script Python, et le traite avec une tâche DuckDB Queries."
+        "buildDbtPipeline": {
+          "label": "Créer un pipeline dbt",
+          "prompt": "Créer un flow Kestra qui clone un dépôt de projet dbt et exécute dbt build avec un profil DuckDB."
+        },
+        "etlWorkflow": {
+          "label": "Flux de travail ETL",
+          "prompt": "Créer un flow ETL qui télécharge des données JSON, les traite avec Python, et interroge le résultat transformé avec DuckDB."
+        },
+        "microservicesApis": {
+          "label": "Microservices & APIs",
+          "prompt": "Créer un flow qui vérifie la réponse de l'API d'un site web et envoie une alerte Slack lorsque le code de statut n'est pas réussi."
+        },
+        "buildDockerImageAndRunIt": {
+          "label": "Construire une image Docker et l'exécuter",
+          "prompt": "Créer un flow Kestra qui construit une image Docker à partir d'un Dockerfile en ligne et exécute le conteneur résultant."
         },
         "manualApproval": {
           "label": "Approbation manuelle",
           "prompt": "Créer un flow avec une étape de traitement initiale, une pause pour approbation manuelle, et une étape de déploiement finale après approbation."
         },
-        "microservicesApis": {
-          "label": "Microservices & APIs",
-          "prompt": "Créer un flow qui vérifie la réponse de l'API d'un site web et envoie une alerte Slack lorsque le code de statut n'est pas réussi."
+        "convertCsvToExcel": {
+          "label": "Convertir un CSV en Excel",
+          "prompt": "Créez un flow qui télécharge un fichier CSV, le convertit en Ion, et exporte le résultat en tant que fichier Excel."
         },
         "scheduledPdfReports": {
           "label": "Rapports PDF programmés",
@@ -2232,73 +2189,116 @@
           "label": "Indicateurs clés de performance hebdomadaires des ventes vers Slack",
           "prompt": "Créer un flow programmé hebdomadaire qui calcule les KPI de ventes avec DuckDB et publie le résumé sur Slack."
         }
-      },
-      "help": {
-        "blueprints": {
-          "description": "Explorez des exemples et modèles prêts à l'emploi pour des modèles de workflow courants.",
-          "title": "Blueprints"
-        },
-        "slack": {
-          "description": "Rejoignez-nous pour partager des idées et des meilleures pratiques, et obtenir de l'aide pour des questions techniques.",
-          "title": "Communauté Slack"
-        },
-        "tutorial": {
-          "description": "Découvrez comment créer et exécuter votre premier flow avec des étapes guidées.",
-          "title": "Démarrer un tutoriel"
-        }
-      },
-      "need_help": "Besoin d'aide ?",
-      "placeholder_prompt": "Envoyez-moi un message de salutation quotidien à 9h.",
-      "remaining_quota": "Il vous reste {count} générations d'IA. La limite se réinitialise quotidiennement à minuit UTC.",
-      "show_less": "Afficher moins d'invites",
-      "show_more": "Afficher plus d'invites",
-      "success_page": {
-        "description": "Vous avez appris les bases de Kestra. Voici quelques ressources pour vous aider à poursuivre votre parcours.",
-        "items": {
-          "blueprints": {
-            "description": "Modèles de workflow préconstruits pour des cas d'utilisation courants",
-            "title": "Plans"
-          },
-          "demo": {
-            "description": "Découvrez Kestra Enterprise Edition avec une démonstration personnalisée",
-            "title": "Obtenez une démo"
-          },
-          "slack": {
-            "description": "Connectez-vous avec d'autres utilisateurs et obtenez de l'aide de la communauté",
-            "title": "Communauté Slack"
-          },
-          "tutorial": {
-            "description": "Parcours interactif de toutes les fonctionnalités de Kestra",
-            "title": "Démarrer un tutoriel"
-          },
-          "videos": {
-            "description": "Guides vidéo étape par étape pour les fonctionnalités avancées",
-            "title": "Tutoriels Vidéo"
-          }
-        },
-        "restart": "Redémarrer le tutoriel",
-        "title": "Vous êtes prêt !"
-      },
-      "success_popup": {
-        "description": "Vous avez exécuté avec succès votre premier flow ! Vous êtes en bonne voie pour devenir un pro de Kestra.",
-        "explore": "Explorez Plus",
-        "title": "Félicitations !",
-        "tutorial": "Tutoriel Approfondi"
-      },
-      "title": "Transformez votre idée en workflow"
+      }
     },
-    "welcome_page": {
-      "guide": "Besoin d'aide pour exécuter votre premier flow ?",
-      "welcome": "Bienvenue sur Kestra"
+    "mcp": {
+      "your_servers": "Vos Serveurs",
+      "servers_count": "{count} serveurs MCP",
+      "managed_by_kestra": "Géré par Kestra",
+      "servers": "Serveurs MCP",
+      "server": "Serveur MCP",
+      "client_setup": "Configuration du client",
+      "page_description": "Exposez vos flows Kestra comme outils pour les agents IA compatibles MCP",
+      "create": "Créer un serveur",
+      "save": "Enregistrer les modifications",
+      "connect": "Connecter",
+      "copy_url": "Copier l'URL",
+      "url_copied": "URL copiée !",
+      "instructions": "Instructions",
+      "server_type": "Type de serveur",
+      "auth_type": "Authentification",
+      "private": "Privé",
+      "private_server": "Serveur privé",
+      "public": "Public",
+      "public_hint": "Avertissement : Les serveurs publics ne nécessitent aucune authentification. Toute personne disposant de l'URL peut appeler chaque outil exposé par ce serveur, sans vérification de namespace ni de permissions. À utiliser uniquement pour les serveurs qu'il est sûr d'exposer en externe.",
+      "basic_auth": "Authentification de base",
+      "api_token": "Jeton API",
+      "oauth": "OAuth",
+      "username_password": "Nom d'utilisateur & mot de passe",
+      "bearer_token": "Authentification par jeton Bearer",
+      "oauth_hint": "Bearer JWT de votre fournisseur OIDC",
+      "oauth_provider": "Fournisseur OAuth",
+      "oauth_provider_placeholder": "Sélectionnez un fournisseur OIDC configuré",
+      "oauth_provider_required": "Le fournisseur OAuth est requis lorsque le type d'authentification est OAuth",
+      "scopes_supported": "Scopes pris en charge",
+      "scopes_supported_placeholder": "openid, profile, email",
+      "scopes_supported_hint": "Scopes annoncés dans le document Protected Resource Metadata de ce serveur. Les clients MCP conformes à la spécification limitent leur requête d'autorisation à cette liste. Laissez vide pour omettre le champ et laisser les clients utiliser les scopes annoncés par l'IdP.",
+      "no_oauth_providers": "Aucun fournisseur OIDC configuré dans cette instance",
+      "delete_confirm": "Êtes-vous sûr de vouloir supprimer ce serveur MCP ?",
+      "no_servers": "Aucun serveur MCP trouvé. Créez votre premier serveur pour exposer les triggers MCP Tool aux agents IA externes.",
+      "server_id": "ID du serveur",
+      "id_placeholder": "par exemple, mon-serveur-mcp",
+      "id_invalid": "L'ID doit commencer par une lettre minuscule ou un chiffre, et ne contenir que des lettres minuscules, des chiffres, des tirets ou des underscores.",
+      "main_tenant": "principal",
+      "tab_edit": "Modifier",
+      "tab_connect": "Connecter",
+      "tab_tool_flows": "Flux d'Outils",
+      "tab_tool_flows_placeholder": "La gestion des flows d'outils arrive bientôt.",
+      "tools": {
+        "no_tools": "Aucun flow d'outil ne correspond à votre recherche.",
+        "create_tool_flow": "Créer un flow d'outil",
+        "tool_name": "Nom de l'outil",
+        "trigger_id": "ID du trigger",
+        "title": "Titre",
+        "description": "Description",
+        "annotations": "Annotations",
+        "flow": "flow",
+        "state": "État",
+        "read_only": "Lecture seule",
+        "open_world": "Open world",
+        "destructive": "Destructif",
+        "idempotent": "Idempotent",
+        "return_direct": "Retour direct",
+        "view_flow": "Ouvrir le flow"
+      },
+      "connect_tab": {
+        "server_url": "URL du serveur",
+        "client_picker_label": "Choisissez votre client IA",
+        "claude_desktop": "Claude Desktop",
+        "claude_desktop_hint": "Ajoutez ce qui suit à votre fichier claude_desktop_config.json :",
+        "claude_desktop_mac": "macOS : ~/Library/Application Support/Claude/claude_desktop_config.json",
+        "claude_desktop_win": "Windows : %APPDATA%\\Claude\\claude_desktop_config.json",
+        "claude_code": "Code Claude",
+        "claude_code_hint": "Exécutez la commande suivante dans votre terminal :",
+        "cursor": "Curseur",
+        "cursor_hint": "Ajoutez ce qui suit à ~/.cursor/mcp.json :",
+        "codex": "Codex (OpenAI)",
+        "codex_hint": "Ajoutez ce qui suit à votre configuration MCP codex.json :",
+        "auth_basic_hint": "Définissez <code>KESTRA_BASIC_AUTH</code> comme variable d'environnement contenant une chaîne <code>username:password</code> encodée en base64 avant de démarrer le client.",
+        "auth_api_token_hint": "Définissez <code>KESTRA_TOKEN</code> comme variable d'environnement avant de démarrer le client.",
+        "auth_oauth_client_id_hint": "Remplacez <code>&lt;client-id&gt;</code> par l'ID client OAuth, et enregistrez <code>http://localhost:7777</code> comme URI de redirection valide sur ce client.",
+        "auth_oauth_browser_hint": "Votre navigateur ouvrira la page de connexion du fournisseur d'identité lors de la première connexion."
+      }
     },
-    "wordmark_colors": "Les couleurs du logotype s'adaptent en fonction de l'arrière-plan, tandis que l'icône reste sans arrière-plan lorsqu'elle est placée sur un fond sombre.",
-    "worker group": "Worker Group",
-    "worker group fallback": "Groupe de Worker de secours",
-    "worker group key": "Clé du groupe de Worker",
-    "worker information": "Informations sur le Worker",
-    "workerId": "Worker Id",
-    "workers": "Workers",
-    "wrong labels": "Clé ou valeur vide détecté dans les labels",
-    "yes": "Oui"
+    "flow_editor_stats": {
+      "revisions": {
+        "suffix": "Révision(s)",
+        "tooltip": "Voir les révisions du flow"
+      },
+      "dependencies": {
+        "suffix": "Dépendances",
+        "tooltip": "Voir les dépendances du flow"
+      },
+      "apps": {
+        "suffix": "Application(s)",
+        "tooltip": "Voir les applications utilisant ce flow"
+      },
+      "tests": {
+        "suffix": "Test(s)",
+        "tooltip": "Voir les tests de flow"
+      },
+      "errors": {
+        "label": "{count} Erreur(s)"
+      }
+    },
+    "source_search": {
+      "match_count": "{count} résultat | {count} résultats",
+      "open_flow": "Ouvrir le flow",
+      "preview_empty": "Sélectionnez un résultat pour l'afficher. Cliquez sur un flow dans la liste des résultats pour voir sa source.",
+      "preview_error": "Échec du chargement de la source du flow"
+    },
+    "open source": "Open Source",
+    "pricing": "Tarification",
+    "license": "Licence"
   }
 }

--- a/ui/src/translations/hi.json
+++ b/ui/src/translations/hi.json
@@ -1,1678 +1,722 @@
 {
   "hi": {
-    "Add flow": "Flow जोड़ें",
-    "Default log level": "पूर्व-निर्धारित log स्तर",
-    "Default namespace": "पूर्व-निर्धारित namespace",
-    "Default page": "पूर्व-निर्धारित पृष्ठ",
-    "Editor fontfamily": "संपादक फ़ॉन्ट परिवार",
-    "Editor fontsize": "संपादक फ़ॉन्ट आकार",
-    "Editor theme": "संपादक थीम",
-    "Fold auto": "संपादक: मल्टीलाइन का स्वचालित फोल्ड",
-    "Fold content lines": "मल्टीलाइन स्ट्रिंग्स फोल्ड करें",
-    "Hover description": "संपादक: जब key या value पर होवर करें तो फ़ील्ड का विवरण दिखाएं",
-    "Language": "भाषा",
-    "Per page": "प्रति पृष्ठ",
-    "Set default page": "पूर्व-निर्धारित पृष्ठ सेट करें",
-    "Set labels": "लेबल्स सेट करें",
-    "Set labels done": "निष्पादन के लेबल्स सफलतापूर्वक सेट किए गए",
-    "Set labels to execution": "निष्पादन <code>{id}</code> के लेबल्स जोड़ें या अपडेट करें",
-    "Set labels tooltip": "निष्पादन के लिए लेबल्स सेट करें",
-    "Task Id already exist in the flow": "Task Id {taskId} पहले से ही flow में मौजूद है।",
-    "Total": "कुल",
-    "Unfold content lines": "मल्टीलाइन स्ट्रिंग्स अनफोल्ड करें",
-    "about_this_blueprint": "इस blueprint के बारे में",
-    "absolute": "पूर्ण",
-    "accept": "स्वीकारें",
-    "actions": "क्रियाएँ",
-    "activate_basic_auth": "बेसिक ऑथेंटिकेशन सक्रिय करें",
-    "active": "सक्रिय",
-    "active-slots": "सक्रिय स्लॉट्स",
-    "actual state": "वास्तविक स्थिति",
-    "add": "जोड़ें",
-    "add at position": "{position} <code>{task}</code> जोड़ें",
-    "add error handler": "एक त्रुटि हैंडलर जोड़ें",
-    "add flow": "Flow जोड़ें",
+    "loading": "लोड हो रहा है...",
+    "more actions": "अधिक क्रियाएँ",
+    "toggle menu": "मेनू टॉगल करें",
+    "panel actions": "पैनल क्रियाएँ",
+    "playground actions": "प्लेग्राउंड क्रियाएँ",
+    "bulk actions": "सामूहिक क्रियाएँ",
+    "view metrics": "मेट्रिक्स देखें",
+    "remove this item": "इस आइटम को हटाएं",
     "add label": "लेबल जोड़ें",
-    "add task": "एक Task जोड़ें",
-    "add-trigger-in-editor": "अपने Flow में पहले एक Trigger जोड़ें",
-    "add_new_item": "नया आइटम जोड़ें",
-    "additionalPlugins": "अतिरिक्त Plugins",
-    "admin": "प्रशासनिक",
-    "admin_preferences": "Preferences",
-    "administration": "प्रशासन",
-    "advanced configuration": "अन्य गुण",
-    "after": "बाद में",
-    "aggregation": "एकत्रीकरण",
-    "ai": {
-      "dashboard": {
-        "prompt_placeholder": "अपने डेटा के बारे में एक प्रश्न पूछें। उदाहरण प्रॉम्प्ट: पिछले 7 दिनों में मेरे flows की सफलता दर दिखाएं।"
+    "remove label": "लेबल हटाएं",
+    "id": "Id",
+    "type": "प्रकार",
+    "ok": "ठीक है",
+    "valid": "मान्य",
+    "close": "बंद करें",
+    "namespace": "Namespace",
+    "description": "विवरण",
+    "show description": "विवरण दिखाएं",
+    "show details": "विवरण दिखाएं",
+    "show more details": "अधिक विवरण दिखाएं",
+    "skipped": "छोड़ा गया",
+    "revision": "संशोधन",
+    "Language": "भाषा",
+    "Set default page": "पूर्व-निर्धारित पृष्ठ सेट करें",
+    "theme": "थीम",
+    "flows": "Flows",
+    "flow": "Flow",
+    "invalid source": "अमान्य स्रोत कोड",
+    "missingSource": "स्रोत अनुपलब्ध",
+    "update": "अपडेट करें",
+    "update ok": "अपडेट किया गया है",
+    "delete ok": "हटा दिया गया है",
+    "Default page": "पूर्व-निर्धारित पृष्ठ",
+    "confirmation": "पुष्टि",
+    "common": {
+      "back": "वापस"
+    },
+    "delete confirm": "क्या आप वाकई <code>{name}</code> को हटाना चाहते हैं?",
+    "outdated revision save confirmation": {
+      "confirm": "क्या आप इसे अधिलेखित करना चाहते हैं?",
+      "update": {
+        "title": "पुराना पुनरीक्षण",
+        "description": "आप जो पुनरीक्षण संपादित कर रहे हैं वह पुराना है।",
+        "details": "अपडेट संस्करण के बारे में अधिक विवरण के लिए पुनरीक्षण टैब देखें।"
       },
-      "flow": {
-        "enable_instructions": {
-          "footer": "ध्यान दें: इस समय, केवल Gemini को Open Source Edition के लिए AI प्रदाता के रूप में समर्थन दिया जाता है। Enterprise Edition के लिए, कृपया अन्य मॉडल प्रदाता कॉन्फ़िगरेशन के लिए AI Copilot दस्तावेज़ देखें।\n\nकॉन्फ़िगरेशन सहेजने के बाद अपनी Kestra instance को पुनः प्रारंभ करें।",
-          "header": "<b>AI Copilot अभी तक कॉन्फ़िगर नहीं किया गया है।</b>\n\nAI Copilot को सक्षम करने के लिए, अपने Kestra instance configuration file (जैसे <code>application.yml</code>) में निम्नलिखित स्निपेट जोड़ें, <code>geminiApiKey</code> को अपनी वास्तविक key से बदलें:"
-        },
-        "generating": {
-          "app": "आपके लिए App YAML तैयार किया जा रहा है...",
-          "dashboard": "आपके लिए Dashboard YAML तैयार किया जा रहा है...",
-          "flow": "आपके लिए Flow YAML उत्पन्न किया जा रहा है...",
-          "test": "आपके लिए टेस्ट YAML उत्पन्न किया जा रहा है..."
-        },
-        "prompt_placeholder": "अपने Kestra flow बनाने के लिए निर्देश दर्ज करें। उदाहरण प्रॉम्प्ट: एक flow बनाएं जो हर सोमवार को सुबह 9 बजे चलता है।",
-        "select_provider": "प्रदाता चुनें",
-        "title": "एआई एजेंट"
+      "create": {
+        "title": "Flow पहले से मौजूद है",
+        "description": "इस namespace में पहले से ही वही id वाला एक flow मौजूद है।",
+        "details": "ओवरराइड करने और एक नया संशोधन बनाने के लिए सहेजें।"
       }
     },
-    "all executions": "सभी निष्पादन",
-    "all tags": "सभी टैग",
-    "api": "API",
-    "appBlocks": "ऐप ब्लॉक्स",
-    "apps": "ऐप्स",
-    "are you sure change state": "क्या आप वाकई स्थिति बदलना चाहते हैं?",
-    "assets": {
-      "title": "संपत्तियाँ"
+    "override": {
+      "title": "आप वर्तमान flow को अधिलेखित करने जा रहे हैं",
+      "details": "पिछला flow Revisions टैब से पुनर्स्थापित किया जा सकता है।"
     },
-    "attempt": "प्रयास",
-    "attempts": "प्रयास",
-    "auditlogs": "Audit Logs",
-    "automatic refresh": "स्वचालित ताज़ा",
-    "avg": "औसत",
-    "avg duration": "औसत निष्पादन अवधि",
+    "is deprecated": "अप्रचलित है",
+    "success": "सफलता",
+    "save": "सहेजें",
+    "save_as_draft": "ड्राफ़्ट के रूप में सहेजें",
+    "draft": "ड्राफ़्ट",
+    "draft_flow_warning": "यह flow रिवीज़न एक ड्राफ़्ट है। निष्पादन इस ड्राफ़्ट रिवीज़न पर चलेगा और यदि flow परिभाषा अमान्य है तो तुरंत विफल हो सकता है।",
+    "save task": "Task सहेजें",
+    "saved": "सफलतापूर्वक सहेजा गया",
+    "saved as draft": "ड्राफ़्ट के रूप में सफलतापूर्वक सहेजा गया",
+    "saved done": "<em>{name}</em> सफलतापूर्वक सहेजा गया है",
+    "saved as draft done": "<em>{name}</em> सफलतापूर्वक ड्राफ़्ट के रूप में सहेजा गया",
+    "multiple saved done": "{name} सहेजे गए हैं",
+    "fileTypeNotAllowed": "फ़ाइल प्रकार की अनुमति नहीं है। स्वीकृत प्रकार: {types}",
+    "delete": "हटाएं",
+    "deleted": "सफलतापूर्वक हटाया गया",
+    "deleted confirm": "<em>{name}</em> सफलतापूर्वक हटाया गया है!",
+    "Add flow": "Flow जोड़ें",
+    "add": "जोड़ें",
+    "add_new_item": "नया आइटम जोड़ें",
+    "copy": "कॉपी करें",
+    "copy_to_clipboard": "क्लिपबोर्ड पर कॉपी करें",
+    "copy_and_close": "कॉपी करें और बंद करें",
+    "Per page": "प्रति पृष्ठ",
+    "new": "नया",
+    "edit": "संपादित करें",
     "back": "वापस",
-    "back_to_dashboard": "डैशबोर्ड पर वापस जाएं",
-    "backfill": "Backfill",
-    "backfill executions": "Backfill निष्पादन",
-    "backfill paused": "Backfill PAUSED",
-    "backfill running": "Backfill चल रहा है",
-    "bar": "बार",
-    "before": "पहले",
-    "behavior": "व्यवहार",
-    "blueprints": {
-      "all": "सभी",
-      "apps": "ऐप Blueprints",
-      "community": "समुदाय",
-      "create": "ब्लूप्रिंट बनाएं",
-      "custom": "कस्टम blueprints",
-      "dashboards": "डैशबोर्ड Blueprints",
-      "detail": {
-        "category": "श्रेणी प्रकार",
-        "links": "लिंक और संसाधन",
-        "openInEditor": "एडिट Flow में खोलें"
-      },
-      "edit": "ब्लूप्रिंट संपादित करें",
-      "empty": "कोई blueprints दिखाने के लिए नहीं हैं।",
-      "flows": "फ्लो Blueprints",
-      "header": {
-        "alt": "ब्लूप्रिंट्स आइकन",
-        "catch phrase": {
-          "1": "पहला कदम हमेशा सबसे कठिन होता है।",
-          "2": "अपने अगले {kind} को शुरू करने के लिए ब्लूप्रिंट्स का अन्वेषण करें।"
-        }
-      },
-      "missingPlugins": {
-        "card": "इस instance पर इंस्टॉल न किए गए plugin(s) की आवश्यकता है: {plugins}",
-        "description": "यह blueprint ऐसे plugin(s) के tasks का उपयोग करता है जो इस instance पर इंस्टॉल नहीं हैं: {plugins}। इस blueprint का उपयोग करने के लिए उन्हें इंस्टॉल करें।",
-        "install": "Plugins इंस्टॉल करें",
-        "title": "अनुपलब्ध plugins"
-      },
-      "title": "Blueprints"
+    "next": "अगला",
+    "done": "पूर्ण",
+    "review your inputs": "अपने इनपुट्स की समीक्षा करें",
+    "edit flow": "Flow संपादित करें",
+    "executions": "निष्पादन",
+    "execution": "निष्पादन",
+    "execution id": "निष्पादन Id",
+    "recent_executions": "हाल की Executions",
+    "details": "विवरण",
+    "overview": "अवलोकन",
+    "gantt": "गैंट",
+    "gantt_no_tasks_executed": "यह execution बिना किसी task के चलाए समाप्त हो गया।  \nकारण के लिए इसका अवलोकन और logs जांचें।",
+    "gantt_no_tasks_match_filters": "खोज, स्थिति, या log-level फ़िल्टर को समायोजित करने का प्रयास करें।",
+    "gantt_no_tasks_match_filters_title": "कोई task चयनित फ़िल्टर से मेल नहीं खाता।",
+    "logs": "Logs",
+    "no_logs_data": "कोई डेटा नहीं",
+    "no_logs_data_description": "कृपया अपने फ़िल्टर समायोजित करें, समय सीमा बदलें, या जांचें कि flow ने हाल ही में निष्पादन किया है या नहीं।",
+    "no_logs_data_title": "चयनित फ़िल्टर के लिए कोई logs नहीं मिले।",
+    "duration": "अवधि",
+    "total_duration": "कुल अवधि",
+    "running duration": "चलने की अवधि",
+    "queued duration": "कतारबद्ध अवधि",
+    "choose file": "एक फ़ाइल चुनें या इसे यहां छोड़ें...",
+    "launch execution": "निष्पादित करें",
+    "warning flow with triggers": "इस flow में triggers शामिल हैं और यदि यह flow trigger अभिव्यक्तियों पर निर्भर करता है तो मैन्युअल निष्पादन विफल हो जाएगा।",
+    "triggered": "निष्पादन trigger",
+    "triggered done": "निष्पादन <em>{name}</em> सफलतापूर्वक ट्रिगर किया गया है",
+    "topology": "टोपोलॉजी",
+    "date": "दिनांक",
+    "prev_execution": "पिछला निष्पादन",
+    "next_execution": "अगली निष्पादन",
+    "datepicker": {
+      "leave empty for infinite": "अनंत अवधि के लिए खाली छोड़ दें या एक ISO 8601 अवधि टाइप करें (उदाहरण: 'P1DT1H1M1S)'",
+      "duration example": "उदाहरण: 'P1DT1H1M1S'",
+      "error": "अमान्य अवधि प्रारूप, एक ISO 8601 अवधि होनी चाहिए (उदाहरण के लिए P1DT1H1M1S)",
+      "custom": "कस्टम",
+      "last5minutes": "पिछले 5 मिनट",
+      "last15minutes": "पिछले 15 मिनट",
+      "last1hour": "पिछले 1 घंटा",
+      "last12hours": "पिछले 12 घंटे",
+      "last24hours": "पिछले 24 घंटे",
+      "last48hours": "पिछले 48 घंटे",
+      "last7days": "पिछले 7 दिन",
+      "last30days": "पिछले 30 दिन",
+      "last365days": "पिछले 365 दिन",
+      "next5minutes": "अगले 5 मिनट",
+      "next15minutes": "अगले 15 मिनट",
+      "next1hour": "अगले 1 घंटे",
+      "next12hours": "अगले 12 घंटे",
+      "next24hours": "अगले 24 घंटे",
+      "next48hours": "अगले 48 घंटे",
+      "next7days": "अगले 7 दिन",
+      "next30days": "अगले 30 दिन",
+      "next365days": "अगले 365 दिन",
+      "5minutes": "5 मिनट",
+      "15minutes": "15 मिनट",
+      "1hour": "1 घंटा",
+      "12hours": "12 घंटे",
+      "24hours": "24 घंटे",
+      "48hours": "48 घंटे",
+      "7days": "7 दिन",
+      "30days": "30 दिन",
+      "365days": "365 दिन",
+      "never": "कभी नहीं",
+      "today": "आज",
+      "yesterday": "कल",
+      "dayBeforeYesterday": "परसों",
+      "thisWeek": "इस सप्ताह",
+      "thisWeekSoFar": "अब तक इस सप्ताह",
+      "previousWeek": "पिछला सप्ताह",
+      "thisMonth": "इस महीने",
+      "thisMonthSoFar": "अब तक इस महीने",
+      "previousMonth": "पिछला महीना",
+      "thisYear": "इस साल",
+      "thisYearSoFar": "अब तक इस साल",
+      "previousYear": "पिछला साल",
+      "short": {
+        "15m": "15मिनट",
+        "1h": "1घं",
+        "12h": "12घं",
+        "1d": "1दिन",
+        "7d": "7दिन"
+      }
     },
-    "body_line_clamp": "Limit line height",
-    "bookmark": "बुकमार्क्स",
-    "breakpoints": "ब्रेकपॉइंट्स",
-    "bulk action async warning": "यह कुछ क्षणों का समय ले सकता है।",
-    "bulk actions": "सामूहिक क्रियाएँ",
-    "bulk change state": "क्या आप सुनिश्चित हैं कि आप <code>{executionCount}</code> execution(s) की स्थिति बदलना चाहते हैं?",
-    "bulk delete": "क्या आप वाकई <code>{executionCount}</code> निष्पादन को हटाना चाहते हैं?",
-    "bulk delete backfills": "{count} backfill को हटाएं",
-    "bulk delete triggers": "क्या आप वाकई {count} triggers को हटाना चाहते हैं?",
-    "bulk disabled status": {
-      "false": "{count} triggers को सक्षम करें",
-      "true": "{count} triggers को अक्षम करें"
+    "created date": "निर्माण तिथि",
+    "latest_update": "नवीनतम अपडेट",
+    "updated date": "अपडेट तिथि",
+    "expiration date": "समाप्ति तिथि",
+    "started date": "प्रारंभ तिथि",
+    "healthcheck date": "HealthCheck तिथि",
+    "next execution date": "अगली निष्पादन तिथि",
+    "last execution status": "अंतिम निष्पादन स्थिति",
+    "jump to...": "कूदें...",
+    "contextBar": {
+      "news": "समाचार",
+      "docs": "डॉक्स",
+      "help": "मदद",
+      "issue": "समस्या",
+      "demo": "डेमो",
+      "star": "हमें स्टार दें"
     },
-    "bulk force run": "क्या आप वाकई <code>{executionCount}</code> execution(s) को जबरदस्ती चलाना चाहते हैं?<br/><br/>WARNING: किसी execution को जबरदस्ती चलाना सुनिश्चित नहीं है और यह डुप्लिकेट task executions बना सकता है।<br/><br/>निम्नलिखित परिवर्तन किए जाएंगे:<br/><ul><li>CREATED tasks को RUNNING स्थिति में ले जाया जाएगा।</li><li>RUNNING tasks को पुनः सबमिट किया जाएगा।</li><li>QUEUED tasks को अन-queued किया जाएगा।</li><li>PAUSED tasks को फिर से शुरू किया जाएगा।</li></ul>",
-    "bulk kill": "क्या आप वाकई <code>{executionCount}</code> निष्पादन को kill करना चाहते हैं?",
-    "bulk pause": "क्या आप वाकई <code>{executionCount}</code> execution(s) को PAUSE करना चाहते हैं?",
-    "bulk pause backfills": "{count} backfill को पॉज़ करें",
-    "bulk replay": "क्या आप वाकई <code>{executionCount}</code> निष्पादन को पुनः चलाना चाहते हैं?",
-    "bulk restart": "क्या आप वाकई <code>{executionCount}</code> निष्पादन को पुनः प्रारंभ करना चाहते हैं?",
-    "bulk resume": "क्या आप वाकई <code>{executionCount}</code> निष्पादन को फिर से शुरू करना चाहते हैं?",
-    "bulk set labels": "क्या आप वाकई <code>{executionCount}</code> निष्पादन के लिए लेबल्स सेट करना चाहते हैं?",
-    "bulk success delete backfills": "{count} backfills हटाए गए",
-    "bulk success delete triggers": "{count} triggers सफलतापूर्वक हटा दिए गए हैं",
-    "bulk success disabled status": {
-      "false": "{count} trigger(s) सक्षम किए गए",
-      "true": "{count} trigger(s) अक्षम किए गए"
+    "source": "स्रोत",
+    "source only": "केवल स्रोत",
+    "home": "होम",
+    "create": "बनाएँ",
+    "create_flow": "फ़्लो बनाएं",
+    "add flow": "Flow जोड़ें",
+    "from": "से",
+    "to": "तक",
+    "search filters": {
+      "saved": "सहेजे गए फ़िल्टर",
+      "manage": "खोज फ़िल्टर प्रबंधित करें",
+      "manage desc": "सहेजे गए खोज फ़िल्टर प्रबंधित करें",
+      "save filter": "फ़िल्टर सहेजें",
+      "filter name": "फ़िल्टर नाम",
+      "filters": "फ़िल्टर"
     },
-    "bulk success pause backfills": "{count} backfills पॉज़ किए गए",
-    "bulk success unlock": "{count} triggers अनलॉक किए गए",
-    "bulk success unpause backfills": "{count} backfills अनपॉज़ किए गए",
-    "bulk unlock": "{count} triggers को अनलॉक करें",
-    "bulk unpause backfills": "{count} backfill को अनपॉज़ करें",
-    "bulk unqueue": "क्या आप वाकई <code>{executionCount}</code> execution(s) को अनक्यू करना चाहते हैं?",
-    "can not delete": "हटाया नहीं जा सकता",
-    "can not have less than 1 task": "प्रत्येक flow में कम से कम एक Task होना चाहिए।",
-    "can not save": "सहेजा नहीं जा सकता",
-    "cancel": "रद्द करें",
+    "steps": "चरण",
+    "state": "स्थिति",
+    "state_history": "स्थिति इतिहास",
+    "search term in message": "संदेश में खोज शब्द",
+    "search": "खोजें",
+    "search blueprint": "Blueprints खोजें",
+    "all tags": "सभी टैग",
+    "source search": "स्रोत खोज",
+    "filter by log level": "Log स्तर द्वारा फ़िल्टर करें",
+    "selected": "चयनित",
+    "task": "Task",
+    "task logs": "Task Logs",
+    "display flow {id} executions": "Flow {id} निष्पादन प्रदर्शित करें",
+    "actions": "क्रियाएँ",
+    "select datetime": "एक तिथि चुनें",
+    "select view": "दृश्य चुनें",
+    "invalid field": "अमान्य फ़ील्ड: {name}",
+    "required field": "आवश्यक फ़ील्ड",
+    "is required": "{field} आवश्यक है",
+    "error": "त्रुटि",
+    "form": "फ़ॉर्म",
+    "form error": "फ़ॉर्म त्रुटि",
+    "display topology for flow": "Flow के लिए टोपोलॉजी प्रदर्शित करें",
     "cannot create topology": "Flow के लिए टोपोलॉजी बनाने में असमर्थ",
-    "cannot swap tasks": "Tasks को स्वैप नहीं कर सकते",
-    "change execution state confirm": "क्या आप वाकई <code>{id}</code> की execution की state बदलना चाहते हैं?",
-    "change execution state done": "निष्पादन स्थिति अपडेट की गई",
-    "change queue confirm": "क्या आप वाकई निष्पादन <code>{id}</code> के लिए queue स्थिति बदलना चाहते हैं?<br/>",
+    "start date": "प्रारंभ तिथि",
+    "end date": "समाप्ति तिथि",
+    "creation": "निर्माण",
+    "flow creation": "Flow निर्माण",
+    "start datetime": "प्रारंभ दिनांक और समय",
+    "end datetime": "समाप्ति दिनांक और समय",
+    "restart": "पुनः प्रारंभ करें",
+    "restart latest revision": "नवीनतम पुनरीक्षण पुनः प्रारंभ करें",
+    "restart tooltip": "<code>{state}</code> task से निष्पादन पुनः प्रारंभ करें",
+    "restarted": "निष्पादन पुनः आरंभ किया गया है",
+    "restart confirm": "क्या आप वाकई निष्पादन <code>{id}</code> को पुनः प्रारंभ करना चाहते हैं?",
+    "restart change revision": "आप उस पुनरीक्षण को बदल सकते हैं जिसका उपयोग नए निष्पादन के लिए किया जाएगा।",
+    "replay": "पुनः चलाएँ",
+    "replay from task tooltip": "Task <code>{taskId}</code> से शुरू होने वाला एक समान निष्पादन बनाएँ",
+    "replay from beginning tooltip": "शुरुआत से शुरू होने वाला एक समान निष्पादन बनाएँ",
+    "replay latest revision": "नवीनतम पुनरीक्षण का उपयोग करके पुनः चलाएँ",
+    "replayed": "निष्पादन को पुनः चलाया गया है",
+    "replay confirm": "क्या आप वाकई इस निष्पादन <code>{id}</code> को पुनः चलाना चाहते हैं और एक नया निष्पादन बनाना चाहते हैं?",
+    "replay with inputs": "इनपुट्स के साथ पुनः चलाएं",
+    "reuse_original_inputs": "मूल inputs का पुनः उपयोग करें",
+    "modify_inputs": "इनपुट्स संशोधित करें",
+    "replay the execution": "फ्लो <code>{flowId}</code> के लिए निष्पादन <code>{executionId}</code> को पुनः चलाएं",
+    "prefill inputs": "पूर्व-भरण",
+    "current": "वर्तमान",
     "change state": "स्थिति बदलें",
-    "change state confirm": "क्या आप सुनिश्चित हैं कि आप execution <code>{id}</code> में <code>{task}</code> task का run state बदलना चाहते हैं?",
-    "change state current state": "वर्तमान स्थिति है:",
+    "actual state": "वास्तविक स्थिति",
+    "select a state": "एक स्थिति चुनें",
+    "are you sure change state": "क्या आप वाकई स्थिति बदलना चाहते हैं?",
+    "yes": "हाँ",
     "change state done": "कार्य की स्थिति को अपडेट किया गया है",
+    "change state confirm": "क्या आप सुनिश्चित हैं कि आप execution <code>{id}</code> में <code>{task}</code> task का run state बदलना चाहते हैं?",
+    "change queue confirm": "क्या आप वाकई निष्पादन <code>{id}</code> के लिए queue स्थिति बदलना चाहते हैं?<br/>",
+    "change state current state": "वर्तमान स्थिति है:",
     "change state hint": {
+      "WARNING": [
+        "Flow को WARNING के रूप में चिह्नित किया जाएगा।",
+        "अगले tasks निष्पादित किए जाएंगे।",
+        "त्रुटि tasks निष्पादित किए जाएंगे।"
+      ],
       "FAILED": [
         "Flow को FAILED के रूप में चिह्नित किया जाएगा।",
         "कोई अन्य task निष्पादित नहीं किया जाएगा।",
         "Error tasks निष्पादित किए जाएंगे।"
-      ],
-      "RUNNING": [
-        "flow पुनः आरंभ होगा और सभी अगले tasks निष्पादित होंगे।",
-        "सभी अवरुद्ध tasks निष्पादित किए जाएंगे।"
       ],
       "SUCCESS": [
         "Flow पुनः शुरू होगा क्योंकि यह task सफल रहा।",
         "सभी अवरुद्ध tasks निष्पादित किए जाएंगे।",
         "यदि सभी task रन सफल होते हैं, तो Flow SUCCESS स्थिति में होगा।"
       ],
-      "WARNING": [
-        "Flow को WARNING के रूप में चिह्नित किया जाएगा।",
-        "अगले tasks निष्पादित किए जाएंगे।",
-        "त्रुटि tasks निष्पादित किए जाएंगे।"
+      "RUNNING": [
+        "flow पुनः आरंभ होगा और सभी अगले tasks निष्पादित होंगे।",
+        "सभी अवरुद्ध tasks निष्पादित किए जाएंगे।"
       ]
     },
+    "replay execution title": "प्रदर्शन पुनः चलाएं",
+    "restart execution title": "निष्पादन पुनः प्रारंभ करें",
+    "replay execution description": "यह चयनित execution के आधार पर एक नया execution बनाएगा।",
+    "replay using": "पुनः चलाएं उपयोग करते हुए",
+    "flow revision original": "मूल flow संशोधन",
+    "flow revision latest": "नवीनतम flow संशोधन",
+    "flow revision specific": "विशिष्ट flow संशोधन",
+    "replay inputs": "इनपुट्स",
+    "reuse original inputs": "मूल inputs का पुनः उपयोग करें",
+    "modify inputs": "इनपुट्स संशोधित करें",
+    "replay inputs new required": "इस संशोधन में inputs हैं। आपको इन्हें भरने के लिए कहा जाएगा।",
+    "replay select taskrun": "जिस task रन को पुनः चलाना है, उसे चुनें:",
     "change state tooltip": "निष्पादन स्थिति बदलें",
-    "chart": "चार्ट",
-    "chart preview": "चार्ट पूर्वावलोकन",
-    "chart type": "चार्ट प्रकार",
-    "charts": "चार्ट्स",
-    "choice": "विकल्प",
-    "choose file": "एक फ़ाइल चुनें या इसे यहां छोड़ें...",
-    "close": "बंद करें",
-    "close sidebar": "साइडबार बंद करें",
-    "codeDisabled": "Flow में अक्षम",
-    "collapse": "संक्षिप्त करें",
-    "collapse all": "सभी संक्षिप्त करें",
-    "commit_id": "कमिट id",
-    "common": {
-      "back": "वापस"
-    },
-    "concurrency": "समानांतरता",
-    "concurrency limits": "समानांतरता सीमाएँ",
-    "concurrency_limit": {
-      "dialog_title": "समानांतरता सीमाएँ",
-      "warning": "चल रहे काउंटर को बदलने से concurrency खराब हो सकती है जिससे executions अनुमत सीमा से अधिक हो सकते हैं।"
-    },
-    "conditions": "शर्तें",
-    "configure basic auth": "बेसिक प्रमाणीकरण कॉन्फ़िगर करें",
-    "confirm": "पुष्टि करें",
-    "confirm password": "पासवर्ड की पुष्टि करें",
-    "confirmation": "पुष्टि",
-    "context updated date": "संदर्भ अद्यतन तिथि",
-    "context updated date tooltip": "ट्रिगर के संदर्भ को आखिरी बार कब अपडेट किया गया था। यह तब होता है जब execution ट्रिगर होता है, समाप्त होता है (लॉक रिलीज़ होता है), या एक मूल्यांकन के बाद (भले ही कोई execution न हो)।",
-    "contextBar": {
-      "demo": "डेमो",
-      "docs": "डॉक्स",
-      "help": "मदद",
-      "issue": "समस्या",
-      "news": "समाचार",
-      "star": "हमें स्टार दें"
-    },
-    "continue backfill": "Backfill जारी रखें",
-    "continue backfills": "Backfills जारी रखें",
-    "copied": "कॉपी किया गया",
-    "copied_logs_to_clipboard": "लॉग्स को क्लिपबोर्ड पर कॉपी किया गया।",
-    "copy": "कॉपी करें",
-    "copy all logs": "सभी Logs कॉपी करें",
-    "copy logs": "Logs कॉपी करें",
-    "copy url": "URL कॉपी करें",
-    "copy_and_close": "कॉपी करें और बंद करें",
-    "copy_to_clipboard": "क्लिपबोर्ड पर कॉपी करें",
-    "copy_value": "Copy value",
-    "create": "बनाएँ",
-    "create first task": "अपना पहला Task बनाएं",
-    "create_flow": "फ़्लो बनाएं",
-    "created date": "निर्माण तिथि",
-    "creation": "निर्माण",
-    "cron": "क्रॉन",
-    "curl": {
-      "command": "cURL कमांड",
-      "note": "कृपया ध्यान दें कि SECRET और FILE इनपुट प्रकार के लिए, कमांड को वास्तविक मानों से मेल खाने के लिए समायोजित किया जाना चाहिए।"
-    },
-    "current": "वर्तमान",
-    "current execution": "वर्तमान निष्पादन",
-    "custom value": "कस्टम value",
-    "customize sidebar": "साइडबार को अनुकूलित करें",
-    "dark_version": "डार्क संस्करण",
-    "dashboards": {
-      "chart_preview": "किसी चार्ट के स्रोत कोड पर क्लिक करें ताकि उसका पूर्वावलोकन देखा जा सके।",
-      "creation": {
-        "confirmation": "डैशबोर्ड <code>{title}</code> बनाया गया है।",
-        "label": "डैशबोर्ड बनाएं"
-      },
-      "default": "डिफ़ॉल्ट डैशबोर्ड",
-      "deletion": {
-        "confirmation": "क्या आप वाकई <code>{title}</code> डैशबोर्ड को हटाना चाहते हैं?"
-      },
-      "edition": {
-        "chart": "इस चार्ट को संपादित करें",
-        "confirmation": "डैशबोर्ड <code>{title}</code> में परिवर्तन सहेजे गए हैं।",
-        "id readonly": "संपत्ति `id` को बदला नहीं जा सकता — यह अब अपनी प्रारंभिक मानों पर सेट है। यदि आप इसे बदलना चाहते हैं, तो आप एक नया डैशबोर्ड बना सकते हैं और पुराने को हटा सकते हैं।",
-        "label": "डैशबोर्ड संपादित करें"
-      },
-      "empty": "कोई परिणाम नहीं दिखाया जा सकता।",
-      "export": "CSV में निर्यात करें",
-      "labels": {
-        "plural": "डैशबोर्ड्स",
-        "singular": "डैशबोर्ड"
-      },
-      "no_description": "कोई विवरण नहीं",
-      "no_description_hint": "इस flow में एक विवरण जोड़ें ताकि यह दस्तावेज़ किया जा सके कि यह क्या करता है।<br>Markdown समर्थित है।",
-      "others": "अन्य",
-      "preview": "पूर्वावलोकन डैशबोर्ड",
-      "quick_filters": {
-        "all": "सभी",
-        "failed": "विफल",
-        "paused": "रुका हुआ",
-        "running": "चल रहा है",
-        "success": "सफलता",
-        "warning": "चेतावनी"
-      },
-      "switch": "डैशबोर्ड स्विच करें",
-      "viewAll": "सभी देखें"
-    },
-    "data": "डेटा",
-    "dataFilters": "डेटा फ़िल्टर",
-    "data_not_protected": "आपका डेटा सुरक्षित नहीं है। इसे न खोएं। <b>हमारी मुफ्त सुरक्षा सुविधाओं को सक्षम करें या हमारे भुगतान वाले ऑफर को आज़माएं।</b>",
-    "date": "दिनांक",
-    "date count": "{तारीख} पर {गिनती}",
-    "date format": "दिनांक प्रारूप",
-    "date range count": "{startDate} और {endDate} के बीच {गिनती}",
-    "datepicker": {
-      "12hours": "12 घंटे",
-      "15minutes": "15 मिनट",
-      "1hour": "1 घंटा",
-      "24hours": "24 घंटे",
-      "30days": "30 दिन",
-      "365days": "365 दिन",
-      "48hours": "48 घंटे",
-      "5minutes": "5 मिनट",
-      "7days": "7 दिन",
-      "custom": "कस्टम",
-      "dayBeforeYesterday": "परसों",
-      "duration example": "उदाहरण: 'P1DT1H1M1S'",
-      "error": "अमान्य अवधि प्रारूप, एक ISO 8601 अवधि होनी चाहिए (उदाहरण के लिए P1DT1H1M1S)",
-      "last12hours": "पिछले 12 घंटे",
-      "last15minutes": "पिछले 15 मिनट",
-      "last1hour": "पिछले 1 घंटा",
-      "last24hours": "पिछले 24 घंटे",
-      "last30days": "पिछले 30 दिन",
-      "last365days": "पिछले 365 दिन",
-      "last48hours": "पिछले 48 घंटे",
-      "last5minutes": "पिछले 5 मिनट",
-      "last7days": "पिछले 7 दिन",
-      "leave empty for infinite": "अनंत अवधि के लिए खाली छोड़ दें या एक ISO 8601 अवधि टाइप करें (उदाहरण: 'P1DT1H1M1S)'",
-      "never": "कभी नहीं",
-      "next12hours": "अगले 12 घंटे",
-      "next15minutes": "अगले 15 मिनट",
-      "next1hour": "अगले 1 घंटे",
-      "next24hours": "अगले 24 घंटे",
-      "next30days": "अगले 30 दिन",
-      "next365days": "अगले 365 दिन",
-      "next48hours": "अगले 48 घंटे",
-      "next5minutes": "अगले 5 मिनट",
-      "next7days": "अगले 7 दिन",
-      "previousMonth": "पिछला महीना",
-      "previousWeek": "पिछला सप्ताह",
-      "previousYear": "पिछला साल",
-      "short": {
-        "12h": "12घं",
-        "15m": "15मिनट",
-        "1d": "1दिन",
-        "1h": "1घं",
-        "7d": "7दिन"
-      },
-      "thisMonth": "इस महीने",
-      "thisMonthSoFar": "अब तक इस महीने",
-      "thisWeek": "इस सप्ताह",
-      "thisWeekSoFar": "अब तक इस सप्ताह",
-      "thisYear": "इस साल",
-      "thisYearSoFar": "अब तक इस साल",
-      "today": "आज",
-      "yesterday": "कल"
-    },
-    "debug": "डिबग",
-    "default": "डिफ़ॉल्ट",
-    "defaultsToNamespaceFile": "डिफ़ॉल्ट रूप से namespace फ़ाइल: <code>{name}</code>",
-    "delete": "हटाएं",
-    "delete backfill": "Backfill हटाएं",
-    "delete backfills": "Backfills हटाएं",
-    "delete confirm": "क्या आप वाकई <code>{name}</code> को हटाना चाहते हैं?",
-    "delete execution running": "<div class=\"alert alert-warning mt-2 mb-0\">यह निष्पादन अभी भी RUNNING है, इसे हटाने से यह बंद नहीं होगा।<br />इसे बंद करने के लिए आपको निष्पादन को kill करना होगा।</div>",
-    "delete logs": "Logs हटाएं",
-    "delete ok": "हटा दिया गया है",
-    "delete revision confirm": "क्या आप वाकई संशोधन {revision} को हटाना चाहते हैं?",
-    "delete revision error": "त्रुटि {error} के साथ संशोधन {revision} हटाने में त्रुटि",
-    "delete task confirm": "क्या आप वाकई Task <code>{taskId}</code> को हटाना चाहते हैं?",
-    "delete trigger": "ट्रिगर हटाएं",
-    "delete trigger confirmation": "क्या आप वाकई trigger {id} को हटाना चाहते हैं? WARNING: यदि trigger अभी भी किसी flow में सक्रिय है, तो उसे हटाने से duplicate executions हो सकते हैं।",
-    "delete trigger error": "ट्रिगर {id} को हटाने में त्रुटि",
-    "delete trigger success": "ट्रिगर {id} को सफलतापूर्वक हटा दिया गया है",
-    "delete triggers": "ट्रिगर्स हटाएं",
-    "delete_all_logs": "क्या आप वाकई सभी Logs हटाना चाहते हैं?",
-    "delete_log": "क्या आप वाकई log को हटाना चाहते हैं?",
-    "deleted": "सफलतापूर्वक हटाया गया",
-    "deleted confirm": "<em>{name}</em> सफलतापूर्वक हटाया गया है!",
-    "deleted_label": "हटाया गया",
-    "demos": {
-      "IAM": {
-        "message": "Kestra एंटरप्राइज एडिशन में IAM क्षमताएँ अंतर्निहित हैं, जिसमें सिंगल साइन-ऑन (SSO), SCIM डायरेक्टरी सिंक और रोल-आधारित एक्सेस कंट्रोल (RBAC) शामिल हैं। यह कई पहचान प्रदाताओं के साथ एकीकृत होता है और आपको उपयोगकर्ताओं और सेवा खातों के लिए सूक्ष्म अनुमतियाँ असाइन करने की अनुमति देता है।",
-        "title": "IAM के माध्यम से SSO, SCIM और RBAC के साथ उपयोगकर्ताओं का प्रबंधन करें।"
-      },
-      "apps": {
-        "message": "Kestra एंटरप्राइज एडिशन में ऐप्स आपको कस्टम UI बनाने की अनुमति देते हैं जो प्लेटफ़ॉर्म के बाहर से Kestra वर्कफ़्लोज़ के साथ इंटरैक्ट करते हैं। यह फीचर आपको अपने वर्कफ़्लोज़ को कस्टम एप्लिकेशनों के लिए बैकएंड के रूप में उपयोग करने देता है, जिससे गैर-तकनीकी उपयोगकर्ता फॉर्म के माध्यम से डेटा सबमिट कर सकते हैं या अप्रूवल की प्रतीक्षा कर रहे PAUSED वर्कफ़्लोज़ को फिर से शुरू कर सकते हैं।",
-        "title": "Kestra के साथ कस्टम ऐप्स बनाएं"
-      },
-      "assets": {
-        "header": "संपत्तियों का मेटाडेटा और अवलोकनीयता",
-        "label": "संपत्तियाँ",
-        "message": "एसेट्स अवलोकन, वंशावली, और स्वामित्व मेटाडेटा को जोड़ते हैं ताकि प्लेटफ़ॉर्म टीमें तेजी से समस्या निवारण कर सकें और आत्मविश्वास के साथ परिनियोजन कर सकें।",
-        "title": "हर dataset, सेवा, और निर्भरता को दृश्य में लाएं।"
-      },
-      "audit-logs": {
-        "message": "Kestra Enterprise Edition हर गतिविधि को मजबूत, अपरिवर्तनीय रिकॉर्ड के साथ लॉग करता है, जिससे परिवर्तनों को ट्रैक करना, अनुपालन बनाए रखना और समस्याओं का समाधान करना आसान हो जाता है।",
-        "title": "परिवर्तनों को ट्रैक करें Audit Logs के साथ"
-      },
-      "blueprints": {
-        "message": "Kestra एंटरप्राइज एडिशन में, आप अपनी संस्था के लिए केवल उपलब्ध कस्टम Blueprints बना सकते हैं। आप इन्हें अपनी टीम में साझा करने, केंद्रीकृत करने और सामान्य रूप से उपयोग किए जाने वाले workflows को दस्तावेज़ करने के लिए सर्वोत्तम-प्रथाओं के टेम्पलेट के रूप में उपयोग कर सकते हैं।",
-        "title": "कस्टम Blueprints जोड़ें"
-      },
-      "contact_sales": "सेल्स से संपर्क करें",
-      "enterprise_edition": "एंटरप्राइज एडिशन",
-      "get_a_demo_button": "डेमो प्राप्त करें",
-      "instance": {
-        "message": "Kestra Enterprise Edition आपके प्लेटफ़ॉर्म के स्वास्थ्य का अवलोकन करने और सभी सेवाओं जैसे कि Workers, Schedulers, और Executors की अपटाइम मेट्रिक्स को ट्रैक करने के लिए एक ऑपरेशनल डैशबोर्ड प्रदान करता है। इसी पृष्ठ से, आप अपने उपयोगकर्ताओं को नियोजित डाउनटाइम के बारे में सूचित करने के लिए Announcements भी बना सकते हैं, और आप एक maintenance mode में प्रवेश कर सकते हैं जो अस्थायी रूप से सभी सेवाओं और workflow executions को एक PAUSED स्थिति में डाल देता है ताकि एक अपग्रेड किया जा सके।",
-        "title": "अपने इंस्टेंस के पार Infrastructure प्रबंधित करें"
-      },
-      "namespace": {
-        "assets": {
-          "message": "Kestra एंटरप्राइज एडिशन में, Assets आपके workflows के साथ इंटरैक्ट करने वाले संसाधनों की लाइव इन्वेंट्री रखता है। ये संसाधन डेटाबेस टेबल, वर्चुअल मशीन, फाइलें, या कोई भी बाहरी सिस्टम हो सकते हैं जिनके साथ आप काम करते हैं।",
-          "title": "संपत्ति प्रबंधन को केंद्रीकृत करें"
-        },
-        "audit-logs": {
-          "message": "Kestra एंटरप्राइज एडिशन में, आप namespace-स्तर के ऑडिट logs को विस्तृत अंतर के साथ देख सकते हैं, जो आपको सभी संसाधनों में किसने क्या और कब बदला, इसका स्पष्ट इतिहास प्रदान करता है।",
-          "title": "सभी परिवर्तनों को एक स्थान पर ट्रैक करें"
-        },
-        "edit": {
-          "message": "Kestra एंटरप्राइज एडिशन में, namespaces बड़े पैमाने पर secrets, variables और plugin डिफ़ॉल्ट्स के उन्नत अलगाव और शासन प्रदान करते हैं। प्रशासक कस्टम secrets प्रबंधकों, अलग storage बैकएंड्स, समर्पित worker समूहों, और प्रति-namespace आधार पर सूक्ष्म अनुमतियाँ कॉन्फ़िगर कर सकते हैं। यह सुनिश्चित करता है कि secrets, variables और plugin कॉन्फ़िगरेशन विभिन्न टीमों और परियोजनाओं में सुरक्षित और बनाए रखने में आसान रहें।",
-          "title": "अपने Namespace प्रबंधन को अपग्रेड करें"
-        },
-        "history": {
-          "message": "Kestra एंटरप्राइज एडिशन में, आप अपने Namespaces के संशोधन इतिहास का प्रबंधन कर सकते हैं।",
-          "title": "एक ही स्थान पर Revision History प्रबंधित करें"
-        },
-        "plugin-defaults": {
-          "message": "Kestra एंटरप्राइज एडिशन में, आप namespace-विशिष्ट प्लगइन डिफ़ॉल्ट सेट कर सकते हैं, जिससे प्रत्येक flow में डुप्लिकेट सेटअप की आवश्यकता कम हो जाती है। यह केंद्रीय प्लगइन गवर्नेंस सुसंगत कॉन्फ़िगरेशन को लागू करता है, गुप्त या वेरिएबल्स के सुरक्षित संदर्भ की अनुमति देता है, और आपके workflows के रखरखाव को सरल बनाता है।",
-          "title": "प्लगइन डिफॉल्ट्स के साथ कॉन्फ़िगरेशन को मानकीकृत करें"
-        },
-        "secrets": {
-          "message": "Kestra एंटरप्राइज एडिशन में, आप secrets को namespace स्तर पर संग्रहीत और नियंत्रित कर सकते हैं, जिससे जोखिम कम होता है और प्रत्येक टीम की credentials अलग रहती हैं। nested hierarchy के कारण, आप एक parent namespace में credentials को कॉन्फ़िगर कर सकते हैं और वे सभी child namespaces द्वारा विरासत में प्राप्त हो जाएंगे। समर्पित secrets managers और सूक्ष्म namespace-स्तरीय अनुमति सेटिंग्स के लिए समर्थन सुरक्षा और अनुपालन को और मजबूत करता है।",
-          "title": "सुरक्षित तरीके से Secrets प्रबंधित करें"
-        },
-        "variables": {
-          "message": "Kestra Enterprise Edition में, आप namespace-स्तर के वेरिएबल्स को परिभाषित और प्रबंधित कर सकते हैं ताकि flows में दोहराव वाली कॉन्फ़िगरेशन को समाप्त किया जा सके। ये वेरिएबल्स स्थिरता सुनिश्चित करते हैं, कॉन्फ़िगरेशन अपडेट को सरल बनाते हैं, और किसी भी task या trigger द्वारा आसानी से संदर्भित किए जा सकते हैं, जिससे workflows को अधिक साफ और बनाए रखने योग्य बनाया जा सके।",
-          "title": "अपने वेरिएबल्स को केंद्रीय रूप से प्रबंधित करें"
-        }
-      },
-      "quotas": {
-        "message": "Kestra Enterprise Edition आपको flows पर कोटा परिभाषित करने देता है जो एक समय विंडो के भीतर समवर्ती या कुल निष्पादन की संख्या को सीमित करता है। कोटा आपको साझा बुनियादी ढांचे की रक्षा करने, SLAs लागू करने और अत्यधिक संसाधन खपत करने वाले workflows को रोकने में मदद करते हैं।",
-        "title": "Flows पर निष्पादन कोटा लागू करें"
-      },
-      "secrets": {
-        "add_env": {
-          "first": "<a href=\"https://kestra.io/docs/how-to-guides/secrets?utm_source=app&utm_medium=referral&utm_campaign=secrets-inlinedoc#using-secrets-in-kestra\" target=\"_blank\">गुप्त मान को Base64 में एन्कोड करें</a>",
-          "intro": "नया Secret बनाने के लिए:",
-          "second": "'<strong>SECRET_{'{MY_SECRET_KEY}'}</strong>' नामक एक environment variable जोड़ें उपरोक्त value के साथ",
-          "third": "अपने Kestra instance को पुनः प्रारंभ करें"
-        },
-        "detected_env": "यहाँ instance start-time पर पहचाने गए secret-type environment variables हैं:",
-        "empty_env": "आपके वातावरण में अभी तक कोई Secrets नहीं हैं।",
-        "message": "एंटरप्राइज एडिशन (EE) आपको UI में सीधे secrets जोड़ने, संपादित करने या हटाने की अनुमति देता है—कोई instance पुनरारंभ की आवश्यकता नहीं है। secrets को namespace द्वारा संगठित करें, जिसमें सूक्ष्म RBAC अनुमतियाँ हों, और उन्हें parent से child namespaces में विरासत में लें। EE HashiCorp Vault, AWS Secrets Manager, Azure Key Vault, Google Secret Manager, और Elasticsearch जैसे secrets प्रबंधकों के साथ एकीकृत होता है। टीमों के बीच secrets को अलग करने के लिए namespace, tenant, या instance के अनुसार समर्पित बैकएंड सेट करें, या बाहरी vaults में संग्रहीत read-only secrets को सक्षम करें। secrets को आराम और ट्रांजिट में एन्क्रिप्टेड रखा जाता है। वैकल्पिक caching API कॉल्स को कम करता है, और audit trails सभी एक्सेस को log करते हैं।",
-        "title": "अपने Secrets Management को अपग्रेड करें"
-      },
-      "tenants": {
-        "message": "Kestra एंटरप्राइज एडिशन मल्टी-टेनेंसी का समर्थन करता है, जो आपको विभिन्न टीमों या परियोजनाओं के लिए पूरी तरह से अलग वातावरण प्रदान करता है, जिनमें से प्रत्येक के पास अपने स्वयं के संसाधन होते हैं जैसे कि समर्पित worker समूह या secrets और आंतरिक storage backends।",
-        "title": "अलग-अलग Tenants में Workflows प्रबंधित करें"
-      },
-      "tests": {
-        "header": "फ्लो के लिए यूनिट टेस्ट्स",
-        "label": "टेस्ट्स",
-        "message": "अपने flows की लॉजिक को अलग-अलग सत्यापित करें, जल्दी से रिग्रेशन का पता लगाएं, और जैसे-जैसे आपके ऑटोमेशन बदलते और बढ़ते हैं, उन पर विश्वास बनाए रखें।",
-        "title": "हर परिवर्तन के साथ विश्वसनीयता सुनिश्चित करें"
-      },
-      "watch_the_video": "वीडियो देखें"
-    },
-    "density": "Density",
-    "density_compact": "Compact",
-    "density_expanded": "Expanded",
-    "density_normal": "Normal",
-    "dependencies": "निर्भरताएँ",
-    "dependencies delete flow": "इस flow में निर्भरताएँ हैं। इसे हटाने से उनकी निर्भरताओं को निष्पादित करने से रोका जाएगा।<br /><br /> यहाँ प्रभावित flows की सूची है:",
-    "dependencies loaded": "निर्भरताएँ लोड की गईं",
-    "dependencies missing acls": "इस flow पर कोई अनुमतियाँ नहीं हैं",
-    "dependency": {
-      "controls": {
-        "clear_selection": "चयन साफ़ करें",
-        "fit_view": "स्क्रीन के अनुसार फिट करें",
-        "zoom_in": "ज़ूम इन करें",
-        "zoom_out": "ज़ूम आउट"
-      },
-      "search": {
-        "flow": {
-          "display": "flow निर्भरताओं को शामिल करें"
-        },
-        "namespace": {
-          "no_namespace": "बिना namespace",
-          "select": "कृपया एक namespace चुनें"
-        },
-        "no_results": "{term} के लिए कोई परिणाम नहीं मिला",
-        "placeholders": {
-          "asset": "एसेट, flow या namespace द्वारा खोजें...",
-          "default": "flow या namespace द्वारा खोजें..."
-        }
-      }
-    },
-    "dependency task": "Task {taskId} किसी अन्य Task की निर्भरता है",
-    "description": "विवरण",
-    "details": "विवरण",
-    "disable": "अक्षम करें",
-    "disabled": "अक्षम",
-    "disabled flow desc": "यह flow अक्षम है, कृपया इसे निष्पादित करने के लिए सक्षम करें।",
-    "disabled flow title": "यह flow अक्षम है",
-    "discard changes confirmation": "आपके पास बिना सहेजे गए परिवर्तन हैं। क्या आप वाकई उन्हें छोड़ना चाहते हैं?",
-    "discard execution confirmation": "आपके पास बिना सहेजे गए input हैं। क्या आप वाकई इस execution को छोड़ना चाहते हैं?",
-    "display direct sub tasks count": "प्रत्यक्ष उप-कार्य गणना प्रदर्शित करें",
-    "display flow {id} executions": "Flow {id} निष्पादन प्रदर्शित करें",
-    "display metric for specific task": "विशिष्ट task के लिए मेट्रिक प्रदर्शित करें",
-    "display output for specific task": "विशिष्ट task के लिए आउटपुट प्रदर्शित करें",
-    "display topology for flow": "Flow के लिए टोपोलॉजी प्रदर्शित करें",
-    "display_settings": "Display settings",
-    "docs": "डॉक्स",
-    "documentation": {
-      "documentation": "दस्तावेज़ीकरण",
-      "github": "एक GitHub समस्या खोलें"
-    },
-    "documentationMenu": "डॉक्यूमेंटेशन मेनू",
-    "done": "पूर्ण",
-    "down trend": "घट रहा है",
-    "download": "डाउनलोड करें",
-    "download logs": "Logs डाउनलोड करें",
-    "download_logos": "लोगो पैक डाउनलोड करें",
-    "download_logs_description": "Choose which logs to export. Filters default to your current view.",
-    "draft": "ड्राफ़्ट",
-    "draft_available": "संपादक में ड्राफ्ट परिवर्तन उपलब्ध है",
-    "draft_flow_warning": "यह flow रिवीज़न एक ड्राफ़्ट है। निष्पादन इस ड्राफ़्ट रिवीज़न पर चलेगा और यदि flow परिभाषा अमान्य है तो तुरंत विफल हो सकता है।",
-    "drill down preview": "पूर्वावलोकन",
-    "drop items here": "यहाँ आइटम्स ड्रॉप करें",
-    "duplicate-pair": "{label} \"{key}\" दोहराया गया है, पहला key अनदेखा किया गया।",
-    "duration": "अवधि",
-    "dynamic": "डायनामिक",
-    "each value": "पुनरावृत्ति मूल्य",
-    "edit": "संपादित करें",
-    "edit flow": "Flow संपादित करें",
-    "editor": "संपादक",
-    "editor_shortcuts": {
-      "command_palette": "कमांड पैलेट दिखाएं",
-      "comment": "टिप्पणी",
-      "comment_uncomment": "टिप्पणी/अनटिप्पणी",
-      "decrease_fontsize": "संपादक फ़ॉन्ट आकार घटाएं",
-      "duplicate_cursor": "कर्सर को डुप्लिकेट करें",
-      "execute_flow": "flow निष्पादित करें",
-      "fold_unfold": "कोड को फोल्ड/अनफोल्ड करें",
-      "increase_fontsize": "संपादक फ़ॉन्ट आकार बढ़ाएँ",
-      "label": "कीबोर्ड शॉर्टकट्स",
-      "move_line": "लाइन को स्थानांतरित करें",
-      "reset_fontsize": "संपादक फ़ॉन्ट आकार रीसेट करें",
-      "save_flow": "फ्लो सहेजें",
-      "toggle_ai_agent": "AI एजेंट टॉगल करें",
-      "trigger_autocompletion": "ट्रिगर ऑटोकम्प्लीशन",
-      "uncomment": "अनकमेंट करें"
-    },
-    "ee-tooltip": {
-      "button": "हमसे बात करें",
-      "features-blocked": "यह सुविधा के लिए Enterprise Edition आवश्यक है।"
-    },
-    "email": "ईमेल",
-    "email length constraint": "ईमेल 256 वर्णों से अधिक नहीं होना चाहिए",
-    "empty": {
-      "announcements": {
-        "content": "घोषणाएँ आपको अपने उपयोगकर्ताओं को किसी भी परिवर्तन के बारे में सूचित करने या नियोजित रखरखाव डाउनटाइम के बारे में जानकारी देने की अनुमति देती हैं। बस घोषणा का प्रकार चुनें, वह तारीख सीमा चुनें जिसके लिए इसे प्रदर्शित किया जाना चाहिए, और घोषणा संदेश लिखें।",
-        "title": "आपके पास अभी तक कोई घोषणाएँ नहीं हैं!"
-      },
-      "apiTokens": {
-        "content": "API टोकन का उपयोग तब किया जाता है जब आप Kestra API के लिए प्रोग्रामेटिक एक्सेस प्रदान करना चाहते हैं।",
-        "title": "अपने API Tokens प्रबंधित करें"
-      },
-      "apps": {
-        "content": "बाहरी दुनिया से Kestra के साथ इंटरैक्ट करने के लिए Apps बनाना शुरू करें।",
-        "title": "आपके पास अभी तक कोई ऐप्स नहीं हैं!"
-      },
-      "assets": {
-        "content": "अपने डेटा एसेट्स, सेवाओं और इन्फ्रास्ट्रक्चर को ट्रैक और प्रबंधित करने के लिए एसेट्स जोड़ें।",
-        "title": "आपके पास अभी तक कोई Assets नहीं हैं!"
-      },
-      "concurrency_executions": {
-        "content": "हमारे दस्तावेज़ में <strong><a href=\"https://kestra.io/docs/workflow-components/execution?utm_source=app&utm_medium=referral&utm_campaign=concurrency-inlinedoc\" target=\"_blank\">Executions</a></strong> के बारे में अधिक पढ़ें।",
-        "title": "इस Flow के लिए कोई चल रही Executions नहीं हैं।"
-      },
-      "concurrency_limit": {
-        "content": "हमारे दस्तावेज़ में <strong><a href=\"https://kestra.io/docs/workflow-components/concurrency?utm_source=app&utm_medium=referral&utm_campaign=concurrency-inlinedoc\" target=\"_blank\">Concurrency Limits</a></strong> के बारे में अधिक पढ़ें।",
-        "title": "इस Flow के लिए कोई सीमाएँ निर्धारित नहीं हैं।"
-      },
-      "concurrency_limits": {
-        "content": "हमारे दस्तावेज़ में <strong><a href=\"https://kestra.io/docs/workflow-components/concurrency?utm_source=app&utm_medium=referral&utm_campaign=concurrency-inlinedoc\" target=\"_blank\">Concurrency Limits</a></strong> के बारे में अधिक पढ़ें।",
-        "title": "कोई concurrency सीमाएँ निर्धारित नहीं हैं।"
-      },
-      "dependencies": {
-        "ASSET": {
-          "content": "इस संपत्ति का flows या अन्य संपत्तियों के साथ कोई upstream या downstream निर्भरता नहीं है।",
-          "title": "वर्तमान में कोई निर्भरता नहीं है।"
-        },
-        "EXECUTION": {
-          "content": "हमारे दस्तावेज़ में <a href=\"https://kestra.io/docs/ui/executions?utm_source=app&utm_medium=referral&utm_campaign=dependencies-inlinedoc#dependencies\" target=\"_blank\">Execution Dependencies</a> के बारे में अधिक पढ़ें।",
-          "title": "वर्तमान में कोई निर्भरता नहीं है।"
-        },
-        "FLOW": {
-          "content": "हमारे दस्तावेज़ में <a href=\"https://kestra.io/docs/ui/flows?utm_source=app&utm_medium=referral&utm_campaign=dependencies-inlinedoc#dependencies\" target=\"_blank\">Flow Dependencies</a> के बारे में अधिक पढ़ें।",
-          "title": "वर्तमान में कोई dependencies नहीं हैं।"
-        },
-        "NAMESPACE": {
-          "content": "हमारे दस्तावेज़ में <a href=\"https://kestra.io/docs/ui/namespaces?utm_source=app&utm_medium=referral&utm_campaign=dependencies-inlinedoc#dependencies\" target=\"_blank\">Namespace Dependencies</a> के बारे में अधिक पढ़ें।",
-          "title": "वर्तमान में कोई निर्भरता नहीं है।"
-        }
-      },
-      "groups": {
-        "content": "समूह आपको उपयोगकर्ताओं को एक साथ जोड़ने की अनुमति देते हैं ताकि आप अपने tenant में अनुमतियों और भूमिका बाइंडिंग को सामूहिक रूप से प्रबंधित कर सकें।",
-        "title": "आपके पास अभी तक कोई समूह नहीं है!"
-      },
-      "kill_switches": {
-        "content": "किल स्विच फीचर एक UI आधारित तंत्र प्रदान करता है जो समस्याग्रस्त executions को रोकने के लिए है। यह केवल CLI <code>--skip-executions</code> और <code>--skip-flows</code> कमांड्स को एक व्यापक प्रशासनिक इंटरफेस के साथ बदलता है।",
-        "title": "आपके पास अभी तक कोई Kill Switches नहीं हैं!"
-      },
-      "mcpToolFlows": {
-        "content": "<code>McpToolTrigger</code> जोड़कर एक flow को MCP टूल के रूप में प्रदर्शित करें। हमारे दस्तावेज़ में <strong><a href=\"https://kestra.io/docs/workflow-components/triggers/mcp-tool-trigger?utm_source=app&utm_medium=referral&utm_campaign=mcp-tool-trigger-inlinedoc\" target=\"_blank\">MCP Tool Trigger</a></strong> के बारे में और पढ़ें।",
-        "title": "इस सर्वर पर अभी तक कोई टूल flows पंजीकृत नहीं हैं।"
-      },
-      "namespaceFiles": {
-        "content": "Namespace फ़ाइलें इस namespace के लिए एक प्रोजेक्ट फ़ोल्डर की तरह काम करती हैं। Python, SQL, dbt या Terraform कोड संग्रहीत करें, फिर अपने flows में किसी भी फ़ाइल को इसके साथ संदर्भित करें",
-        "title": "इस namespace में अभी तक कोई फ़ाइल नहीं है"
-      },
-      "panels": {
-        "content": "आपने सभी पैनल बंद कर दिए हैं।  \nजारी रखने के लिए ऊपर एक टैब चुनें।",
-        "title": "कोई पैनल खुला नहीं है"
-      },
-      "pluginDefaults": {
-        "content": "प्लगइन डिफॉल्ट्स आपको अपने प्लगइन कॉन्फ़िगरेशन को केंद्रीय रूप से प्रबंधित करने और इसे आपके namespace के सभी flows के साथ साझा करने की अनुमति देते हैं।",
-        "title": "आपके पास अभी तक कोई प्लगइन डिफॉल्ट नहीं है!"
-      },
-      "plugins": {
-        "content": "हमारे दस्तावेज़ में <strong><a href=\"https://kestra.io/docs/workflow-components/plugin-defaults?utm_source=app&utm_medium=referral&utm_campaign=plugin-default-inlinedoc\" target=\"_blank\">Concurrency Limits</a></strong> के बारे में अधिक पढ़ें।",
-        "title": "इस Namespace के लिए कोई प्लगइन डिफॉल्ट सेट नहीं हैं।"
-      },
-      "testSuites": {
-        "content": "अपने Flows का परीक्षण करने के लिए Test suites बनाना शुरू करें।",
-        "title": "आपके पास अभी तक कोई Test suites नहीं हैं!"
-      },
-      "triggers": {
-        "content": "हमारे दस्तावेज़ में <strong><a href=\"https://kestra.io/docs/workflow-components/triggers?utm_source=app&utm_medium=referral&utm_campaign=trigger-inlinedoc\" target=\"_blank\">Triggers</a></strong> के बारे में और पढ़ें।",
-        "title": "आपके flow में कोई Triggers नहीं हैं।"
-      },
-      "variables": {
-        "content": "फ्लो के बीच कॉन्फ़िगरेशन साझा करने के लिए key-value जोड़े जोड़ें। चाइल्ड namespaces उन्हें स्वचालित रूप से विरासत में ले लेते हैं, और आप किसी भी value को संदर्भित कर सकते हैं",
-        "title": "अभी तक कोई वेरिएबल नहीं है"
-      },
-      "versionPlugin": {
-        "content": "यहां आप अपने Kestra instance पर इंस्टॉल किए गए सभी प्लगइन्स का प्रबंधन कर सकते हैं। नए इंस्टॉल किए गए प्लगइन्स आपके instance की कॉन्फ़िगरेशन के आधार पर सभी Kestra सेवाओं में तुरंत उपलब्ध नहीं हो सकते हैं।",
-        "title": "आपके पास अभी तक कोई संस्करणित प्लगइन नहीं है!"
-      },
-      "workerRegistrationTokens": {
-        "content": "पंजीकरण टोकन दूरस्थ workers को सुरक्षित रूप से प्रमाणित और आपके Kestra instance के साथ पंजीकृत करने की अनुमति देते हैं। एक टोकन बनाएं, फिर इसे नए workers को इस क्लस्टर से जोड़ने के लिए उपयोग करें।",
-        "title": "आपके पास अभी तक कोई पंजीकरण टोकन नहीं है!"
-      }
-    },
-    "empty search": "खोज परिणाम खाली हैं",
-    "enable": "सक्षम करें",
-    "enable concurrency": "concurrency सक्षम करें",
-    "enabled": "सक्षम",
-    "encoding": "एन्कोडिंग",
-    "end date": "समाप्ति तिथि",
-    "end datetime": "समाप्ति दिनांक और समय",
-    "environment": "पर्यावरण",
-    "environment color setting": "पर्यावरण रंग",
-    "environment name setting": "पर्यावरण नाम",
-    "error": "त्रुटि",
-    "error detected": "त्रुटि(त्रुटियाँ) पाई गईं।",
-    "error in editor": "संपादक में एक त्रुटि पाई गई है",
-    "errorLogs": "त्रुटियाँ logs",
-    "errors": {
-      "401": {
-        "content": "इस पृष्ठ तक पहुँचने के लिए आपको प्रमाणित होना आवश्यक है।",
-        "title": "अनधिकृत"
-      },
-      "403": {
-        "content": "इस पृष्ठ तक पहुँचने के लिए आपके पास आवश्यक अनुमतियाँ नहीं हैं।",
-        "title": "पहुँच अस्वीकृत"
-      },
-      "404": {
-        "content": "अनुरोधित URL इस सर्वर पर नहीं मिला।<br />यही सब हमें पता है।",
-        "flow or execution": "वह flow या निष्पादन जिसे आप ढूंढ रहे हैं, मौजूद नहीं है।",
-        "title": "पृष्ठ नहीं मिला"
-      }
-    },
+    "change execution state confirm": "क्या आप वाकई <code>{id}</code> की execution की state बदलना चाहते हैं?",
+    "change execution state done": "निष्पादन स्थिति अपडेट की गई",
+    "mark as": "<code>{status}</code> के रूप में चिह्नित करें",
+    "unqueue as": "<code>{status}</code> के रूप में अनक्यू करें",
+    "kill": "समाप्त करें",
+    "kill parents and subflow": "वर्तमान और subflows को समाप्त करें",
+    "kill only parents": "केवल वर्तमान को समाप्त करें",
+    "killed confirm": "क्या आप वाकई निष्पादन <code>{id}</code> को समाप्त करना चाहते हैं?",
+    "killed done": "निष्पादन समाप्त करने के लिए कतारबद्ध है",
+    "resume": "पुनः आरंभ करें",
+    "resumed title": "निष्पादन <code>{id}</code> पुनः आरंभ करें",
+    "resumed confirm": "क्या आप वाकई निष्पादन <code>{id}</code> को पुनः आरंभ करना चाहते हैं?",
+    "resumed done": "निष्पादन पुनः आरंभ किया गया है",
+    "resume from breakpoint title": "ब्रेकपॉइंट से निष्पादन `<code>{id}</code>` को पुनः शुरू करें",
+    "resume from breakpoint done": "निष्पादन विराम बिंदु से फिर से शुरू किया गया है",
+    "breakpoints": "ब्रेकपॉइंट्स",
+    "pause": "रोकें",
+    "pause title": "प्रक्रिया को PAUSED करें <code>{id}</code>।<br/>ध्यान दें कि वर्तमान में चल रहे tasks अभी भी प्रक्रिया में होंगे, और प्रक्रिया को मैन्युअल रूप से पुनः शुरू करना होगा।",
+    "pause confirm": "क्या आप वाकई <code>{id}</code> की execution को PAUSE करना चाहते हैं?",
+    "pause done": "निष्पादन PAUSED है",
+    "unqueue": "अनक्यू करें",
+    "unqueue title": "प्रक्रिया <code>{id}</code> को कतार से बाहर करें।<br/>ध्यान दें कि यह flow concurrency सीमा का पालन नहीं करेगा, इसलिए अनुमत सीमा से अधिक प्रक्रियाएँ चल रही हो सकती हैं।",
+    "unqueue title multiple": "क्या आप वाकई <code>{count}</code> executions को Unqueue करना चाहते हैं?<br/><br/>ध्यान दें कि यह flow concurrency सीमा का पालन नहीं करेगा, इसलिए अनुमत सीमा से अधिक executions चल सकती हैं।",
+    "unqueue confirm": "क्या आप वाकई निष्पादन <code>{id}</code> को अनक्यू करना चाहते हैं?",
+    "unqueue done": "निष्पादन कतार से बाहर है",
+    "force run": "फोर्स रन",
+    "force run title": "<code>{id}</code> का निष्पादन जबरन चलाएँ।",
+    "force run tooltip": "प्रवर्तन को चलाने के लिए मजबूर करें। यह डुप्लिकेट task executions बना सकता है, यदि संभव हो तो कोई अन्य क्रिया का उपयोग करें।",
+    "force run confirm": "क्या आप सुनिश्चित हैं कि आप निष्पादन <code>{id}</code> को जबरदस्ती चलाना चाहते हैं?<br/><br/>WARNING: निष्पादन को जबरदस्ती चलाना सुनिश्चित नहीं है और यह डुप्लिकेट task निष्पादन बना सकता है।<br/><br/>निम्नलिखित परिवर्तन किए जाएंगे:<br/><ul><li>CREATED tasks को RUNNING स्थिति में ले जाया जाएगा।</li><li>RUNNING tasks को पुनः सबमिट किया जाएगा।</li><li>QUEUED tasks को अन-queued किया जाएगा।</li><li>PAUSED tasks को पुनः शुरू किया जाएगा।</li></ul>",
+    "force run done": "निष्पादन को मजबूरन चलाया गया है",
+    "toggle output": "आउटपुट टॉगल करें",
+    "metrics": "मेट्रिक्स",
+    "no data current task": "वर्तमान task के लिए कोई डेटा उपलब्ध नहीं है।",
+    "no metrics available": "इस task रन के लिए कोई मेट्रिक्स रिकॉर्ड नहीं किया गया है।",
+    "no outputs available": "इस task run के लिए कोई outputs उपलब्ध नहीं हैं।",
+    "outputs": "आउटपुट",
+    "flow_outputs": "फ्लो Outputs",
+    "no_flow_outputs": "कोई output उपलब्ध नहीं है।",
+    "output": "आउटपुट",
     "eval": {
-      "expression": "अभिव्यक्ति",
-      "preview": "पूर्वावलोकन",
-      "render": "एक्सप्रेशन रेंडर करें",
       "title": "डिबग अभिव्यक्ति",
-      "tooltip": "किसी भी Pebble अभिव्यक्ति को प्रस्तुत करें और निष्पादन संदर्भ का निरीक्षण करें।"
+      "render": "एक्सप्रेशन रेंडर करें",
+      "tooltip": "किसी भी Pebble अभिव्यक्ति को प्रस्तुत करें और निष्पादन संदर्भ का निरीक्षण करें।",
+      "preview": "पूर्वावलोकन",
+      "expression": "अभिव्यक्ति"
     },
-    "evaluation lock date": "मूल्यांकन लॉक तिथि",
-    "execute": "निष्पादित करें",
-    "execute backfill": "Backfill निष्पादित करें",
-    "execute flow behaviour": "Flow निष्पादित करें",
-    "execute flow now ?": "क्या आप इस flow को निष्पादित करना चाहते हैं?",
-    "execute the flow": "Flow <code>{id}</code> निष्पादित करें",
-    "execution": "निष्पादन",
-    "execution already finished": "निष्पादन <code>{executionId}</code> पहले ही समाप्त हो चुका है",
-    "execution id": "निष्पादन Id",
-    "execution labels": "निष्पादन labels",
-    "execution not found": "{executionId} निष्पादन नहीं मिला।",
-    "execution not in state FAILED": "निष्पादन <code>{executionId}</code> FAILED स्थिति में नहीं है",
-    "execution not in state PAUSED": "निष्पादन <code>{executionId}</code> PAUSED स्थिति में नहीं है",
-    "execution replay": "यह निष्पादन का पुनरावृत्ति है",
-    "execution replayed": "इस execution को पुनः चलाया गया है।",
-    "execution restarted": "इस execution को {nbRestart} बार पुनः प्रारंभ किया गया है।",
+    "attempt": "प्रयास",
+    "toggle output display": "आउटपुट प्रदर्शन टॉगल करें",
+    "name": "नाम",
+    "key": "Key",
+    "value": "Value",
+    "each value": "पुनरावृत्ति मूल्य",
+    "current execution": "वर्तमान निष्पादन",
+    "parent execution": "मूल निष्पादन",
+    "original execution": "मूल निष्पादन",
+    "automatic refresh": "स्वचालित ताज़ा",
+    "toggle periodic refresh each x seconds": "हर {interval} सेकंड में आवधिक रिफ्रेश टॉगल करें",
+    "trigger refresh": "ताज़ा करें",
+    "add-trigger-in-editor": "अपने Flow में पहले एक Trigger जोड़ें",
+    "refresh": "ताज़ा करें",
+    "filter by status": "{status} स्थिति द्वारा निष्पादन फ़िल्टर करें",
+    "topology-graph": {
+      "graph-orientation": "ग्राफ़ अभिविन्यास",
+      "zoom-in": "ज़ूम इन करें",
+      "zoom-out": "ज़ूम आउट करें",
+      "zoom-reset": "ज़ूम रीसेट करें",
+      "zoom-fit": "फिट",
+      "invalid": "ग्राफ़ त्रुटि",
+      "invalid_description": "ग्राफ़ लोड करते समय एक त्रुटि हुई। कृपया त्रुटियों के लिए स्रोत कोड की जाँच करें।"
+    },
+    "show task logs": "Task Logs दिखाएं",
+    "show task condition": "कार्य की स्थिति दिखाएं",
+    "show task outputs": "Task आउटपुट दिखाएं",
+    "show task source": "Task स्रोत दिखाएं",
+    "specific task": "विशिष्ट task",
+    "display output for specific task": "विशिष्ट task के लिए आउटपुट प्रदर्शित करें",
+    "display metric for specific task": "विशिष्ट task के लिए मेट्रिक प्रदर्शित करें",
+    "display direct sub tasks count": "प्रत्यक्ष उप-कार्य गणना प्रदर्शित करें",
+    "stream": "स्ट्रीम",
     "execution statistics": "निष्पादन सांख्यिकी",
-    "execution-include-non-terminated": "गैर-समाप्त निष्पादन शामिल करें?",
-    "execution-warn-deleting-still-running": "हम दृढ़ता से अनुशंसा करते हैं कि आप इस क्रिया को रद्द करें और पहले किसी भी चल रही executions को समाप्त करें। गैर-समाप्त executions को हटाने से concurrency समस्याएँ, flow निर्भरता प्रबंधन असंगतताएँ, और आपके instance पर zombie प्रक्रियाएँ हो सकती हैं, जो सिस्टम प्रदर्शन को खराब कर सकती हैं। सुनिश्चित करें कि आप इन जोखिमों को पूरी तरह से समझते हैं, इससे पहले कि आप deletion के साथ आगे बढ़ें।",
-    "execution-warn-title": "महत्वपूर्ण WARNING!",
-    "execution_deletion": {
-      "logs": "Logs हटाएं",
-      "metrics": "Metrics हटाएं",
-      "storage": "आंतरिक स्टोरेज फाइलें हटाएं"
-    },
-    "execution_failed": "निष्पादन FAILED!",
-    "execution_guide": {
-      "get_started": {
-        "text": "क्विकस्टार्ट गाइड का पालन करें ताकि आप Kestra को इंस्टॉल कर सकें और अपनी पहली workflows बनाना शुरू कर सकें।",
-        "title": "शुरू करें ⚡"
-      },
-      "namespaces": {
-        "text": "namespace लॉजिकल समूह होते हैं जो flow और उनके घटकों को संगठित करते हैं।",
-        "title": "Namespaces के बारे में"
-      },
-      "videos_tutorials": {
-        "text": "हमारे वीडियो ट्यूटोरियल के साथ शुरू करें।",
-        "title": "वीडियो ट्यूटोरियल्स"
-      },
-      "workflow_components": {
-        "text": "Kestra वर्कफ़्लो के मुख्य ऑर्केस्ट्रेशन घटकों को जानें।",
-        "title": "वर्कफ़्लो घटक"
-      }
-    },
-    "execution_started": "निष्पादन शुरू हो गया है!",
-    "execution_starts_progress": "जैसे ही execution शुरू होता है, आपको यहाँ प्रगति अपडेट दिखाई देंगे।",
-    "execution_status": "Execution है:",
-    "executions": "निष्पादन",
-    "executions deleted": "<code>{executionCount}</code> निष्पादन हटाए गए",
+    "stats": "आँकड़े",
+    "concurrency limits": "समानांतरता सीमाएँ",
+    "system overview": "सिस्टम अवलोकन",
+    "usage": "उपयोग",
+    "namespaces": "Namespaces",
+    "tasks": "Tasks",
     "executions duration (in minutes)": "कुल निष्पादन अवधि (मिनटों में)",
-    "executions force run": "<code>{executionCount}</code> execution(s) जबरन चलाया गया",
-    "executions killed": "<code>{executionCount}</code> निष्पादन kill किए गए",
-    "executions paused": "<code>{executionCount}</code> execution(s) PAUSED",
-    "executions replayed": "<code>{executionCount}</code> निष्पादन पुनः चलाए गए",
-    "executions restarted": "<code>{executionCount}</code> निष्पादन पुनः प्रारंभ किए गए",
-    "executions resumed": "<code>{executionCount}</code> निष्पादन फिर से शुरू किए गए",
-    "executions state changed": "<code>{executionCount}</code> निष्पादन की स्थिति बदल दी गई है",
-    "executions unqueue": "<code>{executionCount}</code> निष्पादन अनक्यू करें",
-    "expand": "विस्तारित करें",
-    "expand all": "सभी विस्तारित करें",
-    "expand dependencies": "निर्भरताएँ विस्तारित करें",
-    "expand error": "केवल असफल Tasks विस्तारित करें",
-    "expand_by_default": "Expand structured logs by default",
-    "expiration": "समाप्ति",
-    "expiration date": "समाप्ति तिथि",
-    "export": "निर्यात करें",
-    "export all flows": "सभी Flows निर्यात करें",
-    "export all templates": "सभी templates निर्यात करें",
-    "export_as": ".{format} के रूप में निर्यात करें",
-    "export_csv": "CSV के रूप में निर्यात करें",
-    "exports": "निर्यात",
-    "failed to export plugin defaults": "प्लगइन डिफॉल्ट्स को निर्यात करने में विफल",
-    "failed to import plugin defaults": "प्लगइन डिफॉल्ट्स आयात करने में विफल",
-    "failed to render pdf": "PDF प्रस्तुत करने में विफल",
-    "false": "असत्य",
-    "feeds": {
-      "heading": "सभी चीजें Kestra।",
-      "subheading": "नवीनतम अपडेट, गाइड और कहानियाँ",
-      "title": "केस्ट्रा में नया क्या है"
+    "last 48 hours": "पिछले 48 घंटे",
+    "configure basic auth": "बेसिक प्रमाणीकरण कॉन्फ़िगर करें",
+    "email": "ईमेल",
+    "password": "पासवर्ड",
+    "confirm password": "पासवर्ड की पुष्टि करें",
+    "email length constraint": "ईमेल 256 वर्णों से अधिक नहीं होना चाहिए",
+    "password length constraint": "पासवर्ड 256 वर्णों से अधिक नहीं होना चाहिए",
+    "password empty constraint": "गलत उपयोगकर्ता नाम या पासवर्ड",
+    "passwords do not match": "पासवर्ड मेल नहीं खाते",
+    "avg duration": "औसत निष्पादन अवधि",
+    "neutral trend": "स्थिर",
+    "up trend": "बढ़ रहा है",
+    "down trend": "घट रहा है",
+    "update aborted": "अपडेट रद्द कर दिया गया",
+    "invalid flow": "अमान्य flow",
+    "invalid yaml": "अमान्य YAML",
+    "inputs": "इनपुट्स",
+    "no_inputs": "कोई input उपलब्ध नहीं है।",
+    "input": "इनपुट",
+    "variables": "वेरिएबल्स",
+    "variable_explorer": {
+      "title": "इनपुट/आउटपुट",
+      "search_placeholder": "Key या value खोजें...",
+      "tasks_outputs": "Tasks outputs",
+      "tree": "ट्री",
+      "raw_json": "Raw JSON",
+      "select_prompt": "इसका value देखने के लिए एक वेरिएबल चुनें।",
+      "empty": "इस निष्पादन के लिए कोई वेरिएबल उपलब्ध नहीं है।",
+      "one_key": "\\{ 1 key \\}",
+      "n_keys": "\\{ {count} keys \\}",
+      "one_item": "[ 1 आइटम ]",
+      "n_items": "[ {count} आइटम ]"
     },
-    "file preview truncated": "प्रदर्शित सामग्री को संक्षिप्त किया गया है",
-    "file unavailable": "फ़ाइल उपलब्ध नहीं है",
-    "file unavailable description": "यह फ़ाइल अब उपलब्ध नहीं है — इसे हटाया जा सकता है या इसकी समय सीमा समाप्त हो गई है।",
-    "fileTypeNotAllowed": "फ़ाइल प्रकार की अनुमति नहीं है। स्वीकृत प्रकार: {types}",
     "file_preview": {
       "big_file_warning": "यह फ़ाइल {size} है। इसे लोड करने में कुछ समय लग सकता है जिससे आपका ब्राउज़र ब्लॉक हो सकता है। क्या आप इसे फिर भी लोड करना चाहते हैं?",
       "load_anyway": "फिर भी लोड करें"
     },
-    "files": "फ़ाइलें",
-    "filter by log level": "Log स्तर द्वारा फ़िल्टर करें",
-    "filter by status": "{status} स्थिति द्वारा निष्पादन फ़िल्टर करें",
-    "filter by this value": "Filter by this value",
-    "filter_for": "Filter for",
-    "filter_out": "Filter out",
-    "filters": {
-      "comparators": {
-        "between": "के बीच",
-        "contains": "शामिल है",
-        "ends_with": "समाप्त होता है",
-        "greater_than": "से अधिक",
-        "greater_than_or_equal_to": "से अधिक या बराबर",
-        "in": "में",
-        "is": "है",
-        "is_not": "नहीं है",
-        "is_one_of": "में से एक है",
-        "less_than": "से कम",
-        "less_than_or_equal_to": "से कम या बराबर",
-        "not_contains": "नहीं शामिल है",
-        "not_in": "में नहीं",
-        "starts_with": "शुरू होता है"
-      },
-      "empty": "कोई डेटा नहीं।",
-      "format": "'key:value' के रूप में पैरामीटर टाइप करें",
-      "label": "फिल्टर चुनें",
-      "options": {
-        "absolute_date": "सटीक दिनांक",
-        "action": "क्रिया",
-        "aggregation": "संकलन",
-        "child": "बच्चा",
-        "details": "विवरण",
-        "endDate": "समाप्ति तिथि",
-        "flow": "फ्लो",
-        "labels": "लेबल्स",
-        "level": "Log स्तर",
-        "metric": "मेट्रिक",
-        "namespace": "Namespace",
-        "permission": "अनुमति",
-        "relative_date": "सापेक्ष तिथि",
-        "scope": "स्कोप",
-        "service_type": "प्रकार",
-        "startDate": "आरंभ तिथि",
-        "state": "स्थिति",
-        "status": "स्थिति",
-        "task": "कार्य",
-        "text": "मुझे अनुवाद के लिए कोई पाठ नहीं मिला। कृपया अनुवाद के लिए पाठ प्रदान करें।",
-        "type": "प्रकार",
-        "user": "उपयोगकर्ता"
-      },
-      "save": {
-        "dialog": {
-          "confirmation": "खोज मापदंड <code>{name}</code>",
-          "heading": "वर्तमान खोज सहेजें",
-          "hint": "आप इस खोज मापदंड को किस तरह से लेबल करना चाहते हैं?",
-          "placeholder": "लेबल"
-        },
-        "empty": "आपने अभी तक कोई खोज सहेजी नहीं है।",
-        "label": "सहेजे गए खोजें",
-        "name_already_used": "खोज label पहले से उपयोग में है।",
-        "remove": "हटाएं",
-        "tooltip": "आप खाली खोज मानदंड सहेज नहीं सकते।"
-      },
-      "settings": {
-        "label": "पृष्ठ सेटिंग्स",
-        "show_chart": "मुख्य चार्ट दिखाएं"
-      },
-      "text_search": "इस पाठ के लिए खोजें"
-    },
-    "fix_with_ai": "AI से ठीक करें",
-    "flow": "Flow",
-    "flow already exists": "Flow पहले से मौजूद है",
-    "flow already exists message": "Flow <code>{id}</code> पहले से ही namespace <code>{namespace}</code> में मौजूद है। क्या आप एक नया संशोधन बनाना चाहते हैं?",
-    "flow creation": "Flow निर्माण",
-    "flow creation denied in namespace": "आपके पास namespace `{namespace}` में flows बनाने की अनुमति नहीं है।",
-    "flow delete": "क्या आप वाकई <code>{flowCount}</code> flow(s) को हटाना चाहते हैं?",
-    "flow deleted, you can restore it": "Flow हटा दिया गया है और यह एक केवल-पढ़ने का दृश्य है। आप इसे अभी भी पुनर्स्थापित कर सकते हैं।",
-    "flow disable": "क्या आप वाकई <code>{flowCount}</code> flow(s) को अक्षम करना चाहते हैं?",
-    "flow enable": "क्या आप वाकई <code>{flowCount}</code> flow(s) को सक्षम करना चाहते हैं?",
-    "flow export": "क्या आप वाकई <code>{flowCount}</code> flow(s) को निर्यात करना चाहते हैं?",
-    "flow must have id and namespace": "Flow में एक id और एक namespace होना चाहिए।",
-    "flow must not be empty": "Flow खाली नहीं होना चाहिए",
-    "flow not imported": "कुछ flow आयात नहीं किया जा सका",
-    "flow revision latest": "नवीनतम flow संशोधन",
-    "flow revision original": "मूल flow संशोधन",
-    "flow revision specific": "विशिष्ट flow संशोधन",
-    "flow source not found": "Flow source नहीं मिला",
-    "flow-dependencies": "निर्भरता",
-    "flow-no-dependencies": "आपके flow की कोई dependencies नहीं हैं।",
-    "flow_editor_stats": {
-      "apps": {
-        "suffix": "ऐप(s)",
-        "tooltip": "इस flow का उपयोग करने वाले ऐप्स देखें"
-      },
-      "dependencies": {
-        "suffix": "निर्भरताएं",
-        "tooltip": "flow निर्भरता देखें"
-      },
-      "errors": {
-        "label": "{count} त्रुटि(याँ)"
-      },
-      "revisions": {
-        "suffix": "संशोधन(संशोधन)",
-        "tooltip": "flow संशोधन देखें"
-      },
-      "tests": {
-        "suffix": "परीक्षण(परीक्षण)",
-        "tooltip": "flow परीक्षण देखें"
-      }
-    },
-    "flow_export": "flow निर्यात करें",
-    "flow_only": "केवल Flow टैब पर उपलब्ध है।",
-    "flow_outputs": "फ्लो Outputs",
-    "flows": "Flows",
-    "flows deleted": "<code>{count}</code> Flow(s) हटाए गए",
-    "flows disabled": "<code>{count}</code> Flow(s) अक्षम किए गए",
-    "flows enabled": "<code>{count}</code> Flow(s) सक्षम किए गए",
-    "flows exported": "<code>{count}</code> Flow(s) निर्यात किए गए",
-    "flows imported": "फ़्लोज़ आयात किए गए",
-    "focus task": "किसी भी तत्व पर क्लिक करें ताकि उसका दस्तावेज़ देखा जा सके।",
-    "fold_all_multi_lines": "सभी मल्टी लाइन्स को फोल्ड करें",
-    "font size": "Font size",
-    "for flow": "फ्लो के लिए",
-    "forbidden system labels": "सिर्फ़ system.correlationId को system label के रूप में उपयोग किया जा सकता है",
-    "force run": "फोर्स रन",
-    "force run confirm": "क्या आप सुनिश्चित हैं कि आप निष्पादन <code>{id}</code> को जबरदस्ती चलाना चाहते हैं?<br/><br/>WARNING: निष्पादन को जबरदस्ती चलाना सुनिश्चित नहीं है और यह डुप्लिकेट task निष्पादन बना सकता है।<br/><br/>निम्नलिखित परिवर्तन किए जाएंगे:<br/><ul><li>CREATED tasks को RUNNING स्थिति में ले जाया जाएगा।</li><li>RUNNING tasks को पुनः सबमिट किया जाएगा।</li><li>QUEUED tasks को अन-queued किया जाएगा।</li><li>PAUSED tasks को पुनः शुरू किया जाएगा।</li></ul>",
-    "force run done": "निष्पादन को मजबूरन चलाया गया है",
-    "force run title": "<code>{id}</code> का निष्पादन जबरन चलाएँ।",
-    "force run tooltip": "प्रवर्तन को चलाने के लिए मजबूर करें। यह डुप्लिकेट task executions बना सकता है, यदि संभव हो तो कोई अन्य क्रिया का उपयोग करें।",
-    "form": "फ़ॉर्म",
-    "form error": "फ़ॉर्म त्रुटि",
-    "from": "से",
-    "gantt": "गैंट",
-    "gantt_no_tasks_executed": "यह execution बिना किसी task के चलाए समाप्त हो गया।  \nकारण के लिए इसका अवलोकन और logs जांचें।",
-    "gantt_no_tasks_match_filters": "खोज, स्थिति, या log-level फ़िल्टर को समायोजित करने का प्रयास करें।",
-    "gantt_no_tasks_match_filters_title": "कोई task चयनित फ़िल्टर से मेल नहीं खाता।",
-    "healthcheck date": "HealthCheck तिथि",
-    "hide task documentation": "Task दस्तावेज़ छिपाएं",
-    "home": "होम",
-    "hostname": "होस्टनाम",
-    "iam": "IAM",
-    "id": "Id",
-    "import": "आयात करें",
-    "in-our-documentation": "हमारे दस्तावेज़ में।",
-    "informative notice": "नोट(s)",
-    "input": "इनपुट",
-    "inputs": "इनपुट्स",
-    "instance": "इंस्टेंस",
-    "invalid bulk delete": "निष्पादन हटाने में असमर्थ",
-    "invalid bulk force run": "निष्पादन को जबरन चलाने में असमर्थ",
-    "invalid bulk kill": "निष्पादन kill करने में असमर्थ",
-    "invalid bulk pause": "निष्पादन को PAUSE नहीं किया जा सका",
-    "invalid bulk replay": "निष्पादन पुनः चलाने में असमर्थ",
-    "invalid bulk restart": "निष्पादन पुनः प्रारंभ करने में असमर्थ",
-    "invalid bulk resume": "निष्पादन फिर से शुरू करने में असमर्थ",
-    "invalid bulk unqueue": "निष्पादन को अनक्यू नहीं किया जा सका",
-    "invalid field": "अमान्य फ़ील्ड: {name}",
-    "invalid flow": "अमान्य flow",
-    "invalid source": "अमान्य स्रोत कोड",
-    "invalid yaml": "अमान्य YAML",
-    "is deprecated": "अप्रचलित है",
-    "is required": "{field} आवश्यक है",
-    "item": "आइटम",
-    "items": "आइटम्स",
-    "join community": "समुदाय में शामिल हों",
-    "join_slack": "Slack से जुड़ें",
-    "jsonl": "JSONL",
-    "jump to...": "कूदें...",
-    "kestra": "केस्ट्रा",
-    "key": "Key",
-    "kill": "समाप्त करें",
-    "kill only parents": "केवल वर्तमान को समाप्त करें",
-    "kill parents and subflow": "वर्तमान और subflows को समाप्त करें",
-    "killed confirm": "क्या आप वाकई निष्पादन <code>{id}</code> को समाप्त करना चाहते हैं?",
-    "killed done": "निष्पादन समाप्त करने के लिए कतारबद्ध है",
-    "kv": {
-      "add": "बनाएँ",
-      "delete multiple": {
-        "confirm": "क्या आप वाकई हटाना चाहते हैं: <code>{name}</code> kv(s)?",
-        "warning": "आपके पास उन namespaces के लिए अनुमतियाँ नहीं हैं, इसलिए उन्हें हटा दिया जाएगा: <code>{namespaces}</code>"
-      },
-      "duplicate": "यह key पहले से मौजूद है",
-      "inherited": "विरासत में मिले KV जोड़े",
-      "name": "KV Store",
-      "type": "प्रकार",
-      "update": "key '{key}' के लिए value अपडेट करें"
-    },
-    "label": "Label",
-    "label filter placeholder": "'key:value' के रूप में लेबल करें",
-    "labels": "labels",
-    "last 48 hours": "पिछले 48 घंटे",
-    "last X days count": "{दिनों} दिनों में {गिनती}",
-    "last error was": "अंतिम त्रुटि थी",
-    "last evaluation date": "अंतिम मूल्यांकन तिथि",
-    "last evaluation date tooltip": "When the trigger was last evaluated by the scheduler, regardless of whether it produced an execution.",
-    "last execution date": "अंतिम निष्पादन तिथि",
-    "last execution state": "अंतिम स्थिति",
-    "last execution status": "अंतिम निष्पादन स्थिति",
-    "last modified": "अंतिम संशोधित",
-    "last trigger date": "अंतिम ट्रिगर की तारीख",
-    "last trigger date tooltip": "ट्रिगर ने आखिरी बार कब निष्पादित किया था। जब एक backfill चल रहा हो तो यह अतीत में हो सकता है।",
-    "latest_update": "नवीनतम अपडेट",
-    "launch execution": "निष्पादित करें",
-    "learn_more": "और जानें",
-    "leave page": "पृष्ठ छोड़ें",
-    "license": "लाइसेंस",
-    "light_background": "यह हल्की पृष्ठभूमि के साथ काम करते समय पसंदीदा विकल्प है।",
-    "light_version": "लाइट संस्करण",
-    "line": "रेखा",
-    "line-by-line": "लाइन-बाय-लाइन",
-    "loaded x dependencies": "{count} निर्भरताएँ लोड की गईं",
-    "loading": "लोड हो रहा है...",
-    "log expand setting": "Log डिफ़ॉल्ट प्रदर्शन",
-    "logExporters": "लॉग Exporters",
-    "logs": "Logs",
-    "logs_copied": "Logs copied to your clipboard",
-    "logs_view": {
-      "compact": "पूर्व-निर्धारित दृश्य",
-      "compact_details": "प्रत्येक task द्वारा समूहीकृत कॉम्पैक्ट दृश्य में task logs दिखाएं",
-      "raw": "Temporal दृश्य",
-      "raw_details": "कच्चे timestamp-क्रमबद्ध प्रारूप में पूर्ण task logs और flow logs दिखाएं"
-    },
-    "main_configuration": "मुख्य कॉन्फ़िगरेशन",
-    "manage labels": "labels प्रबंधित करें",
-    "management port": "प्रबंधन पोर्ट",
-    "mark as": "<code>{status}</code> के रूप में चिह्नित करें",
-    "max": "अधिकतम",
-    "mcp": {
-      "api_token": "एपीआई टोकन",
-      "auth_type": "प्रमाणीकरण",
-      "basic_auth": "बेसिक ऑथ",
-      "bearer_token": "बेयर टोकन प्रमाणीकरण",
-      "client_setup": "क्लाइंट सेटअप",
-      "connect": "कनेक्ट करें",
-      "connect_tab": {
-        "auth_api_token_hint": "क्लाइंट शुरू करने से पहले <code>KESTRA_TOKEN</code> को एक पर्यावरण चर के रूप में सेट करें।",
-        "auth_basic_hint": "क्लाइंट शुरू करने से पहले <code>KESTRA_BASIC_AUTH</code> को एक पर्यावरण चर के रूप में सेट करें जिसमें base64-एन्कोडेड <code>username:password</code> स्ट्रिंग हो।",
-        "auth_oauth_browser_hint": "पहले कनेक्शन पर आपका ब्राउज़र पहचान प्रदाता का लॉगिन पृष्ठ खोलेगा।",
-        "auth_oauth_client_id_hint": "<code>&lt;client-id&gt;</code> को OAuth client ID से बदलें, और उस client पर <code>http://localhost:7777</code> को वैध redirect URI के रूप में पंजीकृत करें।",
-        "claude_code": "क्लॉड कोड",
-        "claude_code_hint": "अपने टर्मिनल में निम्नलिखित कमांड चलाएँ:",
-        "claude_desktop": "क्लॉड डेस्कटॉप",
-        "claude_desktop_hint": "अपने claude_desktop_config.json फ़ाइल में निम्नलिखित जोड़ें:",
-        "claude_desktop_mac": "macOS: ~/Library/Application Support/Claude/claude_desktop_config.json",
-        "claude_desktop_win": "Windows: %APPDATA%\\Claude\\claude_desktop_config.json",
-        "client_picker_label": "अपना AI क्लाइंट चुनें",
-        "codex": "Codex (OpenAI)",
-        "codex_hint": "अपने codex.json MCP कॉन्फ़िगरेशन में निम्नलिखित जोड़ें:",
-        "cursor": "कर्सर",
-        "cursor_hint": "`~/.cursor/mcp.json` में निम्नलिखित जोड़ें:",
-        "server_url": "सर्वर URL"
-      },
-      "copy_url": "URL कॉपी करें",
-      "create": "सर्वर बनाएं",
-      "delete_confirm": "क्या आप वाकई इस MCP सर्वर को हटाना चाहते हैं?",
-      "id_invalid": "आईडी को एक छोटे अक्षर या अंक से शुरू होना चाहिए, और इसमें केवल छोटे अक्षर, अंक, हाइफन, या अंडरस्कोर शामिल होने चाहिए।",
-      "id_placeholder": "उदा. my-mcp-server",
-      "instructions": "निर्देश",
-      "main_tenant": "मुख्य",
-      "managed_by_kestra": "Kestra द्वारा प्रबंधित",
-      "no_oauth_providers": "इस इंस्टेंस में कोई OIDC प्रदाता कॉन्फ़िगर नहीं है",
-      "no_servers": "कोई MCP सर्वर नहीं मिला। बाहरी AI एजेंट्स के लिए MCP Tool triggers को एक्सपोज़ करने के लिए अपना पहला सर्वर बनाएं।",
-      "oauth": "OAuth",
-      "oauth_hint": "आपके OIDC प्रदाता से Bearer JWT",
-      "oauth_provider": "OAuth प्रदाता",
-      "oauth_provider_placeholder": "कोई कॉन्फ़िगर किया गया OIDC प्रदाता चुनें",
-      "oauth_provider_required": "जब प्रमाणीकरण प्रकार OAuth हो तो OAuth प्रदाता आवश्यक है",
-      "page_description": "अपने Kestra flows को MCP-संगत AI एजेंट्स के लिए उपकरण के रूप में प्रस्तुत करें",
-      "private": "निजी",
-      "private_server": "निजी सर्वर",
-      "public": "सार्वजनिक",
-      "public_hint": "चेतावनी: सार्वजनिक सर्वर को किसी प्रमाणीकरण की आवश्यकता नहीं होती है। URL वाला कोई भी व्यक्ति इस सर्वर द्वारा उजागर किए गए हर टूल को बिना किसी namespace या अनुमति जाँच के कॉल कर सकता है। इसका उपयोग केवल उन सर्वर के लिए करें जिन्हें बाहरी रूप से उजागर करना सुरक्षित हो।",
-      "save": "परिवर्तनों को सहेजें",
-      "scopes_supported": "समर्थित scopes",
-      "scopes_supported_hint": "इस सर्वर के Protected Resource Metadata दस्तावेज़ में विज्ञापित scopes। स्पेक-अनुपालक MCP क्लाइंट अपनी प्राधिकरण अनुरोध को इस सूची तक सीमित करते हैं। फ़ील्ड को छोड़ने और क्लाइंट को IdP के विज्ञापित scopes पर वापस जाने देने के लिए खाली छोड़ें।",
-      "scopes_supported_placeholder": "openid, profile, email",
-      "server": "MCP सर्वर",
-      "server_id": "सर्वर ID",
-      "server_type": "सर्वर प्रकार",
-      "servers": "MCP सर्वर",
-      "servers_count": "{{count}} MCP Servers",
-      "tab_connect": "कनेक्ट करें",
-      "tab_edit": "संपादित करें",
-      "tab_tool_flows": "टूल Flows",
-      "tab_tool_flows_placeholder": "टूल flows प्रबंधन जल्द ही आ रहा है।",
-      "tools": {
-        "annotations": "Annotations",
-        "create_tool_flow": "एक टूल flow बनाएँ",
-        "description": "विवरण",
-        "destructive": "विनाशकारी",
-        "flow": "flow",
-        "idempotent": "Idempotent",
-        "no_tools": "आपकी खोज से मेल खाने वाले कोई टूल flows नहीं हैं।",
-        "open_world": "Open world",
-        "read_only": "केवल पढ़ें",
-        "return_direct": "सीधा वापसी",
-        "state": "स्थिति",
-        "title": "शीर्षक",
-        "tool_name": "Tool का नाम",
-        "trigger_id": "Trigger ID",
-        "view_flow": "flow खोलें"
-      },
-      "url_copied": "URL कॉपी हो गया!",
-      "username_password": "यूज़रनेम और पासवर्ड",
-      "your_servers": "आपके सर्वर"
-    },
-    "metric": "मेट्रिक",
-    "metric choice": "इस flow के लिए कोई मेट्रिक्स उपलब्ध नहीं है",
-    "metrics": "मेट्रिक्स",
-    "min": "न्यूनतम",
-    "missingSource": "स्रोत अनुपलब्ध",
-    "modify inputs": "इनपुट्स संशोधित करें",
-    "modify_inputs": "इनपुट्स संशोधित करें",
-    "monogram": "मोनोग्राम",
-    "more actions": "अधिक क्रियाएँ",
-    "more_actions": "अधिक क्रियाएँ",
-    "multi_panel_editor": {
-      "close_all_panels": "सभी पैनल बंद करें",
-      "close_all_tabs": "सभी टैब बंद करें",
-      "move_left": "बाएँ ले जाएँ",
-      "move_right": "दाईं ओर ले जाएँ"
-    },
-    "multiple saved done": "{name} सहेजे गए हैं",
-    "name": "नाम",
-    "namespace": "Namespace",
-    "namespace and id readonly": "गुण `namespace` और `id` को बदला नहीं जा सकता — वे अब अपनी प्रारंभिक मानों पर सेट हैं। यदि आप किसी flow का नाम बदलना चाहते हैं या उसका namespace बदलना चाहते हैं, तो आप एक नया flow बना सकते हैं और पुराने को हटा सकते हैं।",
-    "namespace files": {
-      "create": {
-        "file": "फ़ाइल बनाएँ",
-        "file_already_exists": "इस नाम की एक फ़ाइल पहले से मौजूद है",
-        "file_conflicts_with_folder": "इस नाम का एक फ़ोल्डर पहले से मौजूद है",
-        "file_error": "फ़ाइल बनाते समय त्रुटि हुई",
-        "folder": "फ़ोल्डर बनाएँ",
-        "folder_already_exists": "इस नाम का एक फ़ोल्डर पहले से मौजूद है",
-        "folder_conflicts_with_file": "इस नाम की एक फ़ाइल पहले से मौजूद है",
-        "folder_error": "फ़ोल्डर बनाते समय त्रुटि हुई",
-        "label": "बनाएँ"
-      },
-      "delete": {
-        "file": "फ़ाइल हटाएं",
-        "files": "{count} चयनित फ़ाइलें हटाएं",
-        "folder": "फ़ोल्डर हटाएं",
-        "folders": "{count} चयनित फ़ोल्डर हटाएं",
-        "label": "हटाएं"
-      },
-      "dialog": {
-        "deletion": {
-          "confirm": "पुष्टि करें",
-          "file_single": "क्या आप वाकई <code>{name}</code> फ़ाइल को हटाना चाहते हैं?",
-          "files": "क्या आप वाकई <code>{count}</code> फ़ाइल(फ़ाइलें) हटाना चाहते हैं?",
-          "folder_single": "क्या आप वाकई <code>{name}</code> फ़ोल्डर और इसकी सभी सामग्री को हटाना चाहते हैं?",
-          "folders": "क्या आप वाकई <code>{count}</code> फ़ोल्डर और उसकी सभी सामग्री को हटाना चाहते हैं?",
-          "mixed": "क्या आप वाकई <code>{folders}</code> फ़ोल्डर(ओं) और <code>{files}</code> फ़ाइल(ओं) को हटाना चाहते हैं?",
-          "title": "सामग्री को हटाने की पुष्टि करें"
-        },
-        "name": {
-          "file": "एक्सटेंशन के साथ नाम:",
-          "folder": "फ़ोल्डर का नाम:"
-        },
-        "parent_folder": "मूल फ़ोल्डर:"
-      },
-      "export": "Namespace फ़ाइलें निर्यात करें",
-      "export_single": "फ़ाइल निर्यात करें",
-      "filter": "फ़िल्टर",
-      "import": {
-        "error": "फ़ाइलें आयात करते समय त्रुटि हुई",
-        "files": "फ़ाइलें आयात करें",
-        "folder": "फ़ोल्डर आयात करें",
-        "import": "आयात करें",
-        "success": "फ़ाइलें सफलतापूर्वक आयात की गईं"
-      },
-      "new_file": "नई फ़ाइल",
-      "no_items": {
-        "heading": "आपके namespace में अभी तक कोई फ़ाइलें नहीं मिली हैं।",
-        "paragraph": "फाइलें बनाने या आयात करने के लिए, अपने namespace में flows के बीच कोड साझा करें।"
-      },
-      "no_selection": {
-        "description": "इसकी सामग्री देखने के लिए ट्री से एक फ़ाइल चुनें।",
-        "heading": "कोई फ़ाइल चयनित नहीं"
-      },
-      "path": {
-        "copy": "पथ कॉपी करें",
-        "error": "पथ को क्लिपबोर्ड पर कॉपी करते समय त्रुटि हुई",
-        "success": "पथ क्लिपबोर्ड पर कॉपी किया गया"
-      },
-      "rename": {
-        "file": "फ़ाइल का नाम बदलें",
-        "folder": "फ़ोल्डर का नाम बदलें",
-        "label": "नाम बदलें",
-        "new_file": "एक्सटेंशन के साथ नया नाम:",
-        "new_folder": "नए फ़ोल्डर का नाम:"
-      },
-      "revisions": {
-        "history": "संशोधन इतिहास",
-        "restore": {
-          "success": "फ़ाइल संशोधन सफलतापूर्वक पुनर्स्थापित किया गया"
-        }
-      },
-      "toggle": {
-        "hide": "Namespace फ़ाइलें छिपाएं",
-        "show": "Namespace फ़ाइलें दिखाएं"
-      },
-      "tree": {
-        "collapse": "सभी फ़ोल्डर्स संक्षिप्त करें",
-        "expand": "सभी फ़ोल्डर्स विस्तारित करें"
-      }
-    },
-    "namespace not allowed": "Namespace की अनुमति नहीं है",
-    "namespace_editor": {
-      "close": {
-        "all": "सभी टैब बंद करें",
-        "other": "अन्य टैब्स बंद करें",
-        "right": "दाईं ओर बंद करें",
-        "tab": "टैब बंद करें"
-      },
-      "empty": {
-        "create_message": "आप namespace फाइलें बना सकते हैं या आयात कर सकते हैं।",
-        "title": "वर्तमान में कोई टैब्स खुले नहीं हैं",
-        "video_message": "आप हमारे Editor के लिए परिचय वीडियो देख सकते हैं।"
-      }
-    },
-    "namespaces": "Namespaces",
-    "neutral trend": "स्थिर",
-    "new": "नया",
-    "new version": "नया संस्करण {version} उपलब्ध है!",
-    "next": "अगला",
-    "next evaluation date": "अगली मूल्यांकन तिथि",
-    "next evaluation date tooltip": "ट्रिगर का अगला मूल्यांकन कब होगा, यह उसके अंतराल पर आधारित है। यदि शर्तें पूरी नहीं होती हैं, तो यह हमेशा अगले निष्पादन तिथि के समान नहीं होता।",
-    "next execution date": "अगली निष्पादन तिथि",
-    "next_execution": "अगली निष्पादन",
-    "no data current task": "वर्तमान task के लिए कोई डेटा उपलब्ध नहीं है।",
-    "no inputs": "इस flow में कोई इनपुट्स नहीं हैं।",
-    "no metrics available": "इस task रन के लिए कोई मेट्रिक्स रिकॉर्ड नहीं किया गया है।",
-    "no outputs available": "इस task run के लिए कोई outputs उपलब्ध नहीं हैं।",
-    "no result": "कोई परिणाम दिखाने के लिए नहीं हैं।",
-    "no revisions": "कोई संशोधन नहीं",
-    "no revisions found": "इस flow के लिए केवल एक पुनरीक्षण मौजूद है",
-    "no-executions-view": {
-      "guidance_desc": "क्या आपको अपने flow को निष्पादित करने के लिए मार्गदर्शन चाहिए?",
-      "guidance_sub_desc": "दस्तावेज़ीकरण का पालन करें ताकि आपको सभी जानकारी मिल सके जिसकी आपको आवश्यकता है।",
-      "namespace_guidance_desc": "क्या आपको अपने Namespace को प्रबंधित करने के लिए मार्गदर्शन चाहिए?",
-      "namespace_sub_title": "इस डैशबोर्ड को भरने के लिए इस namespace से एक या अधिक flows निष्पादित करें।",
-      "sub_title": "अपने पहले workflow execution को शुरू करने के लिए Execute बटन पर क्लिक करें।",
-      "title": "स्वचालन शुरू करें साथ में"
-    },
-    "no_code": {
-      "add_field": "{field} जोड़ें",
-      "adding": "+ एक {what} जोड़ें",
-      "adding_default": "+ एक नया value जोड़ें",
-      "clearSelection": "चयन साफ़ करें",
-      "creation": {
-        "afterExecution": "एक निष्पादन के बाद ब्लॉक जोड़ें",
-        "charts": "चार्ट जोड़ें",
-        "conditions": "एक शर्त जोड़ें",
-        "default": "जोड़ें",
-        "errors": "त्रुटि हैंडलर जोड़ें",
-        "finally": "अंत में एक finally ब्लॉक जोड़ें",
-        "inputs": "इनपुट फ़ील्ड जोड़ें",
-        "numerator": "संख्यांक जोड़ें",
-        "pluginDefaults": "प्लगइन डिफ़ॉल्ट जोड़ें",
-        "tasks": "कार्य जोड़ें",
-        "triggers": "ट्रिगर जोड़ें",
-        "where": "अपने डेटा को फ़िल्टर करें"
-      },
-      "fields": {
-        "general": {
-          "checks": "जांचें",
-          "concurrency": "समानांतरता",
-          "disabled": "अक्षम",
-          "labels": "लेबल्स",
-          "listeners": "श्रोता",
-          "outputs": "आउटपुट्स",
-          "retry": "पुनः प्रयास करें",
-          "sla": "SLA",
-          "taskDefaults": "डिफ़ॉल्ट Task",
-          "updated": "अपडेट किया गया",
-          "variables": "वेरिएबल्स",
-          "workerGroup": "वर्कर ग्रुप",
-          "workerSelector": "वर्कर सेलेक्टर"
-        },
-        "main": {
-          "description": "विवरण",
-          "id": "Flow ID",
-          "inputs": "इनपुट्स",
-          "namespace": "Namespace"
-        }
-      },
-      "labels": {
-        "label": "लेबल",
-        "no_code": "कोड संपादक नहीं",
-        "variable": "वेरिएबल",
-        "yaml": "YAML संपादक"
-      },
-      "remove": {
-        "cases": "इस केस को हटाएं",
-        "default": "इस प्रविष्टि को हटाएं"
-      },
-      "sections": {
-        "afterExecution": "Execution के बाद",
-        "deprecated": "अप्रचलित गुण",
-        "errors": "त्रुटि हैंडलर्स",
-        "finally": "अंत में",
-        "pluginDefaults": "डिफ़ॉल्ट प्लगइन",
-        "tasks": "कार्य",
-        "triggers": "ट्रिगर्स"
-      },
-      "select": {
-        "afterExecution": "एक task चुनें",
-        "charts": "चार्ट प्रकार चुनें",
-        "conditions": "कंडीशन चुनें",
-        "default": "एक प्रकार चुनें",
-        "errors": "एक task चुनें",
-        "finally": "एक task चुनें",
-        "inputs": "इनपुट फ़ील्ड प्रकार चुनें",
-        "numerator": "एक अंश चुनें",
-        "pluginDefaults": "एक प्लगइन चुनें",
-        "task": "किसी task का चयन करें",
-        "tasks": "कार्य चुनें",
-        "triggers": "ट्रिगर चुनें",
-        "where": "एक फ़िल्टर प्रकार चुनें"
-      },
-      "toggle_pebble": "Pebble संपादक टॉगल करें",
-      "unnamed": "कोई नाम नहीं",
-      "version_oss_placeholder": "एंटरप्राइज एडिशन के साथ प्लगइन वर्शनिंग अनलॉक करें"
-    },
-    "no_data": "ऐसा लगता है कि यहाँ कुछ नहीं है... अभी तक!<br/>अपने फ़िल्टर समायोजित करें, या इसे फिर से आज़माएँ!",
-    "no_file_choosen": "कोई फ़ाइल चयनित नहीं",
-    "no_flow_outputs": "कोई output उपलब्ध नहीं है।",
-    "no_history": "कोई इतिहास उपलब्ध नहीं है",
-    "no_inputs": "कोई input उपलब्ध नहीं है।",
-    "no_logs_data": "कोई डेटा नहीं",
-    "no_logs_data_description": "कृपया अपने फ़िल्टर समायोजित करें, समय सीमा बदलें, या जांचें कि flow ने हाल ही में निष्पादन किया है या नहीं।",
-    "no_logs_data_title": "चयनित फ़िल्टर के लिए कोई logs नहीं मिले।",
-    "no_namespaces": "कोई भी namespaces खोज मानदंड से मेल नहीं खाते।",
-    "no_results": {
-      "assets": "कोई Assets नहीं मिले",
-      "executions": "कोई Executions नहीं मिला",
-      "flows": "कोई Flows नहीं मिला",
-      "kv_pairs": "कोई Key-Value जोड़े नहीं मिले",
-      "secrets": "कोई Secrets नहीं मिले",
-      "templates": "कोई टेम्पलेट नहीं मिला",
-      "triggers": "कोई Triggers नहीं मिले"
-    },
-    "no_results_found": "कोई परिणाम नहीं मिला",
-    "no_tasks_running": "अभी कोई task नहीं चल रहा है।",
-    "no_trigger": "कोई trigger उपलब्ध नहीं है।",
     "no_variables": "कोई वेरिएबल उपलब्ध नहीं हैं।",
-    "now": "अब",
-    "of": "का",
-    "ok": "ठीक है",
-    "onboarding": {
-      "actions": {
-        "cancel_tutorial": "ट्यूटोरियल रद्द करें",
-        "complete": "पूर्ण करें",
-        "edit_flow_to_continue": "ऊपर दाईं ओर Edit flow दबाएँ।",
-        "execute_to_continue": "1. ऊपर दाईं ओर Execute दबाएँ।\n2. <strong>name</strong> के लिए एक मान प्रदान करें।\n3. मोडल में फिर से Execute दबाएँ।",
-        "finish_tutorial": "ट्यूटोरियल समाप्त करें",
-        "next": "अगला",
-        "save_to_continue": "जारी रखने के लिए ऊपर दाईं ओर Save दबाएँ।"
-      },
-      "cancel_modal": {
-        "confirm": "ट्यूटोरियल रद्द करें",
-        "description": "क्या आप पहला फ्लो ट्यूटोरियल रद्द करना चाहते हैं?",
-        "keep": "ट्यूटोरियल जारी रखें",
-        "title": "पहला फ्लो ट्यूटोरियल रद्द करें"
-      },
-      "editor_hints": {
-        "build_intro": "अपना पहला फ्लो चरण-दर-चरण बनाएँ।",
-        "step_1": "# 1) id जोड़ें",
-        "step_2": "# 2) namespace जोड़ें",
-        "step_3": "# 3) एक इनपुट जोड़ें",
-        "step_4": "# 4) टास्क्स जोड़ें और अपना पहला Python टास्क बनाएँ",
-        "step_5": "# 5) एक क्रॉन ट्रिगर जोड़ें"
-      },
-      "finish_actions": {
-        "create_flow": "फ्लो बनाएँ",
-        "explore_blueprints": "ब्लूप्रिंट्स देखें"
-      },
-      "steps": {
-        "add_cron_trigger": {
-          "description": "Triggers शेड्यूल या बाहरी घटनाओं (जैसे वेबहुक या MQTT संदेश) के आधार पर रन शुरू कर सकते हैं।<br><br>अब एक क्रॉन शेड्यूल ट्रिगर जोड़ें ताकि यह फ्लो हर 5 मिनट में चले।",
-          "title": "एक क्रॉन ट्रिगर जोड़ें"
-        },
-        "add_id": {
-          "description": "ID आपके फ्लो का अद्वितीय नाम है, ताकि आप इसे खोज सकें, चला सकें और लगातार संदर्भित कर सकें।<br><br>अब रूट स्तर पर <code>id</code> जोड़ें।",
-          "title": "फ्लो ID जोड़ें"
-        },
-        "add_input": {
-          "description": "Inputs फ्लो-स्तरीय पैरामीटर हैं जिन्हें टास्क्स के अंदर संदर्भित किया जा सकता है ताकि रनटाइम पर व्यवहार को गतिशील रूप से नियंत्रित किया जा सके।<br><br>अब <code>name</code> नाम का एक इनपुट <code>STRING</code> प्रकार के साथ जोड़ें।",
-          "title": "एक इनपुट जोड़ें"
-        },
-        "add_input_default": {
-          "description": "जब कोई फ्लो स्वचालित रूप से ट्रिगर होता है, तब भी रनटाइम पर इनपुट मानों की आवश्यकता होती है।<br><br><code>name</code> इनपुट पहले ही पिछले चरण में बनाया जा चुका है, इसलिए इसे फिर से जोड़ने की आवश्यकता नहीं है। केवल मौजूदा <code>name</code> इनपुट के लिए एक डिफ़ॉल्ट मान सेट करें।",
-          "title": "इनपुट के लिए डिफ़ॉल्ट मान सेट करें"
-        },
-        "add_log_task": {
-          "description": "Tasks वे कार्य इकाइयाँ हैं जिन्हें आपका फ्लो निष्पादित करता है, जिन्हें क्रमबद्ध चरणों की सूची के रूप में परिभाषित किया जाता है। प्रत्येक टास्क के लिए एक अद्वितीय <code>id</code> और एक <code>type</code> आवश्यक है। Kestra बाहरी प्रणालियों के लिए कई टास्क प्लगइन्स प्रदान करता है; यहाँ हम एक Python Script टास्क का उपयोग करते हैं।<br><br><code>&#123;&#123; ... &#125;&#125;</code> सिंटैक्स एक Pebble अभिव्यक्ति है, जिसका उपयोग रनटाइम पर वेरिएबल्स को गतिशील रूप से संदर्भित करने के लिए किया जाता है, जैसे <code>&#123;&#123; inputs.name &#125;&#125;</code> आपके फ्लो इनपुट्स से।<br><br>अब <code>tasks</code> के अंतर्गत पहला टास्क जोड़ें, जिसमें <code>id</code>, <code>type</code>, और एक <code>script</code> हो जो एक अभिवादन प्रिंट करे।",
-          "title": "पहला टास्क जोड़ें"
-        },
-        "add_namespace": {
-          "description": "Namespace एक फ़ोल्डर-जैसा समूह है जो फ्लो को टीम, प्रोजेक्ट या वातावरण के अनुसार व्यवस्थित करता है।<br><br>अब रूट स्तर पर <code>namespace</code> जोड़ें।",
-          "title": "नेमस्पेस जोड़ें"
-        },
-        "background_runs_info": {
-          "description": "यह फ्लो अब हर 5 मिनट में बैकग्राउंड में निष्पादित होगा।<br><br>निर्धारित रनों की निगरानी के लिए आप बाएँ मेनू से Executions ओवरव्यू पर जा सकते हैं।",
-          "title": "निर्धारित रन"
-        },
-        "edit_flow_from_execution": {
-          "description": "आप तेज़ी से पुनरावृत्ति करने के लिए सीधे किसी निष्पादन से फ्लो परिभाषा पर वापस जा सकते हैं।",
-          "title": "फ्लो एडिटर पर वापस जाएँ"
-        },
-        "execute_flow": {
-          "description": "निष्पादन आपके फ्लो का एक रन प्रारंभ करता है, जिसमें रनटाइम इनपुट मान शामिल होते हैं।",
-          "title": "फ्लो निष्पादित करें"
-        },
-        "finish": {
-          "description": "शानदार शुरुआत। आपने एक फ्लो बनाया, निष्पादित किया, पैरामीटराइज़ किया और शेड्यूल किया।<br><br>अब चुनें कि आप आगे क्या करना चाहते हैं ...",
-          "title": "आपने पहला फ्लो ट्यूटोरियल पूरा कर लिया है"
-        },
-        "flow_basics": {
-          "description": "Kestra में, एक <code>flow</code> मुख्य ऑर्केस्ट्रेशन इकाई है। आप इसे YAML में मेटाडेटा और क्रमबद्ध टास्क्स के साथ परिभाषित करते हैं।<br><br>नीचे दिए गए उदाहरण संरचना की समीक्षा करें, फिर इसे चरण-दर-चरण बनाना जारी रखें।",
-          "title": "फ्लो की मूल बातें"
-        },
-        "save_flow": {
-          "description": "सहेजने से आपकी फ्लो परिभाषा सुरक्षित हो जाती है ताकि इसे निष्पादित किया जा सके।",
-          "title": "फ्लो सहेजें"
-        },
-        "save_flow_again": {
-          "description": "अब आपके फ्लो में स्वचालित रन के लिए एक शेड्यूल और एक डिफ़ॉल्ट इनपुट मान है।",
-          "title": "फ्लो सहेजें"
-        },
-        "view_logs_status": {
-          "description": "निष्पादन विवरण रन की स्थिति, समय और टास्क-स्तरीय आउटपुट लॉग दिखाते हैं।<br><br>अब निष्पादन विवरण खोलें और लॉग देखने के लिए Gantt चार्ट में <code>greet</code> पर क्लिक करें।",
-          "title": "निष्पादन जाँचें"
-        }
-      },
-      "validation": {
-        "add_cron_trigger_cron": "एक cron अभिव्यक्ति जोड़ें, उदाहरण: `\"*/5 * * * *\"`।",
-        "add_cron_trigger_section": "`triggers` सेक्शन बनाएँ और एक schedule ट्रिगर जोड़ें।",
-        "add_cron_trigger_type": "ट्रिगर प्रकार को `io.kestra.plugin.core.trigger.Schedule` पर सेट करें।",
-        "add_id": "ऊपर एक फ्लो ID जोड़ें। उदाहरण: `id: hello_flow`।",
-        "add_input_default_defaults": "`name` के लिए एक डिफ़ॉल्ट मान जोड़ें, उदाहरण: `defaults: \"Kestra\"`।",
-        "add_input_default_id": "मौजूदा इनपुट ID को `name` ही रखें।",
-        "add_input_default_section": "`inputs` पर वापस जाएँ और `name` नाम का एक मौजूदा इनपुट रखें (दूसरा इनपुट न जोड़ें)।",
-        "add_input_id": "`inputs` के अंदर `id: name` जोड़ें।",
-        "add_input_section": "`inputs` सेक्शन बनाएँ जिसमें एक इनपुट हो।",
-        "add_input_type": "इनपुट प्रकार को `STRING` पर सेट करें।",
-        "add_log_task_id": "टास्क को एक ID दें, उदाहरण: `id: greet`।",
-        "add_log_task_message": "टास्क में एक `script` फ़ील्ड जोड़ें।",
-        "add_log_task_pebble": "स्क्रिप्ट में Pebble अभिव्यक्ति का उपयोग करें ताकि यह आपके इनपुट मान का उपयोग करे (उदाहरण: `inputs.name`)।",
-        "add_log_task_section": "`tasks` सेक्शन बनाएँ और अपना पहला टास्क जोड़ें।",
-        "add_log_task_type": "टास्क प्रकार को `io.kestra.plugin.scripts.python.Script` पर सेट करें।",
-        "add_namespace": "ऊपर एक namespace जोड़ें। उदाहरण: `namespace: company.team`।",
-        "complete_step": "आप करीब हैं। आगे बढ़ने के लिए यह चरण पूरा करें।",
-        "edit_flow_from_execution": "जारी रखने के लिए ऊपर बार में `Edit flow` पर क्लिक करें।",
-        "execute_flow": "जारी रखने के लिए फ्लो को एक बार चलाएँ।",
-        "fix_yaml": "YAML फॉर्मेट में एक छोटी समस्या है। इसे ठीक करें और फिर जारी रखें।",
-        "save_flow": "जारी रखने के लिए Save पर क्लिक करें।",
-        "save_flow_again": "जारी रखने के लिए फिर से Save पर क्लिक करें।",
-        "view_logs_status": "निष्पादन विवरण खोलें और `greet` के लॉग जाँचें।"
-      },
-      "welcome": {
-        "additional_help": "अतिरिक्त सहायता",
-        "badge": "ट्यूटोरियल",
-        "blueprints": "ब्लूप्रिंट्स",
-        "docs": "प्रलेखन",
-        "guided_description": "निर्देशित चरणों के साथ अपना पहला फ्लो बनाना और चलाना सीखें।",
-        "guided_duration": "अधिकांश उपयोगकर्ताओं के लिए अनुशंसित",
-        "guided_title": "अपना पहला फ्लो बनाएँ",
-        "headline": "कुछ ही मिनटों में अपना पहला वर्कफ़्लो बनाएँ और चलाएँ",
-        "self_serve_description": "सीधे एडिटर पर जाएँ और अपना स्वयं का फ्लो बनाएँ।",
-        "self_serve_note": "अनुभवी उपयोगकर्ताओं के लिए",
-        "self_serve_title": "शुरुआत से फ्लो बनाएँ",
-        "slack": "स्लैक समुदाय",
-        "tutorial": "ट्यूटोरियल"
-      }
+    "download": "डाउनलोड करें",
+    "jsonl": "JSONL",
+    "concurrency_limit": {
+      "dialog_title": "समानांतरता सीमाएँ",
+      "warning": "चल रहे काउंटर को बदलने से concurrency खराब हो सकती है जिससे executions अनुमत सीमा से अधिक हो सकते हैं।"
     },
-    "open": "खोलें",
-    "open full page": "पूरा पेज खोलें",
-    "open in new tab": "एक नए टैब में",
-    "open in same tab": "उसी टैब में",
-    "open sidebar": "साइडबार खोलें",
-    "open source": "ओपन सोर्स",
-    "open_page": "Open page",
-    "optional": "वैकल्पिक",
-    "original execution": "मूल निष्पादन",
-    "originalCreatedDate": "मूल निर्माण तिथि",
-    "outdated revision save confirmation": {
-      "confirm": "क्या आप इसे अधिलेखित करना चाहते हैं?",
-      "create": {
-        "description": "इस namespace में पहले से ही वही id वाला एक flow मौजूद है।",
-        "details": "ओवरराइड करने और एक नया संशोधन बनाने के लिए सहेजें।",
-        "title": "Flow पहले से मौजूद है"
-      },
-      "update": {
-        "description": "आप जो पुनरीक्षण संपादित कर रहे हैं वह पुराना है।",
-        "details": "अपडेट संस्करण के बारे में अधिक विवरण के लिए पुनरीक्षण टैब देखें।",
-        "title": "पुराना पुनरीक्षण"
-      }
+    "documentation": {
+      "documentation": "दस्तावेज़ीकरण",
+      "github": "एक GitHub समस्या खोलें"
     },
-    "output": "आउटपुट",
-    "outputs": "आउटपुट",
-    "override": {
-      "details": "पिछला flow Revisions टैब से पुनर्स्थापित किया जा सकता है।",
-      "title": "आप वर्तमान flow को अधिलेखित करने जा रहे हैं"
-    },
-    "overview": "अवलोकन",
-    "page": {
-      "next": "अगला पृष्ठ",
-      "previous": "पिछला पृष्ठ"
-    },
-    "panel actions": "पैनल क्रियाएँ",
-    "parent execution": "मूल निष्पादन",
-    "password": "पासवर्ड",
-    "password empty constraint": "गलत उपयोगकर्ता नाम या पासवर्ड",
-    "password length constraint": "पासवर्ड 256 वर्णों से अधिक नहीं होना चाहिए",
-    "passwords do not match": "पासवर्ड मेल नहीं खाते",
-    "pause": "रोकें",
-    "pause backfill": "Backfill को रोकें",
-    "pause backfills": "Backfills को रोकें",
-    "pause confirm": "क्या आप वाकई <code>{id}</code> की execution को PAUSE करना चाहते हैं?",
-    "pause done": "निष्पादन PAUSED है",
-    "pause title": "प्रक्रिया को PAUSED करें <code>{id}</code>।<br/>ध्यान दें कि वर्तमान में चल रहे tasks अभी भी प्रक्रिया में होंगे, और प्रक्रिया को मैन्युअल रूप से पुनः शुरू करना होगा।",
-    "paused": "PAUSED",
-    "playground": {
-      "clear_history": "इतिहास साफ़ करें",
-      "confirm_create": "आप एक flow बनाते समय playground नहीं चला सकते। एक playground रन शुरू करने से flow बन जाएगा।",
-      "history": "पिछले 10 रन",
-      "play_icon_info": "आप No-Code या Topology दृश्य में Play आइकन पर भी क्लिक कर सकते हैं।",
-      "run_all_tasks": "सभी Tasks चलाएं",
-      "run_task": "टास्क चलाएं",
-      "run_task_and_downstream": "टास्क चलाएं और डाउनस्ट्रीम",
-      "run_task_info": "Flow Code संपादक में किसी भी task पर होवर करें और अपने task का परीक्षण करने के लिए \"Run task\" बटन पर क्लिक करें।",
-      "run_this_task": "इस task को चलाएं",
-      "title": "प्लेग्राउंड",
-      "toggle": "प्लेग्राउंड",
-      "tooltip_persistence": "यदि आप Playground को बंद करके फिर से चालू करते हैं, तो जानकारी तब तक बनी रहती है जब तक आप पृष्ठ पर रहते हैं।"
-    },
-    "playground actions": "प्लेग्राउंड क्रियाएँ",
-    "plugin defaults exported": "प्लगइन डिफॉल्ट्स एक्सपोर्ट किए गए",
-    "plugin defaults imported": "प्लगइन डिफ़ॉल्ट्स आयातित",
-    "plugin defaults not imported": "कुछ प्लगइन डिफ़ॉल्ट आयात नहीं किए जा सके",
-    "pluginDefaults": {
-      "add": "प्लगइन डिफ़ॉल्ट जोड़ें",
-      "add_subtitle": "इसके गुणों के साथ एक नया प्लगइन डिफ़ॉल्ट कॉन्फ़िगर करें",
-      "cancel": "रद्द करें",
-      "custom": "कस्टम प्लगइन",
-      "custom_configure": "कस्टम प्लगइन प्रकार - YAML का उपयोग करके कॉन्फ़िगर करें",
-      "custom_placeholder": "प्लगइन प्रकार दर्ज करें",
-      "custom_type": "कस्टम प्लगइन प्रकार",
-      "edit": "प्लगइन डिफ़ॉल्ट संपादित करें",
-      "edit_subtitle": "मौजूदा प्लगइन डिफ़ॉल्ट कॉन्फ़िगरेशन को संशोधित करें",
-      "form": "फॉर्म",
-      "predefined": "पूर्वनिर्धारित प्लगइन",
-      "select_predefined": "पूर्वनिर्धारित प्लगइन चुनें",
-      "show_yaml": "YAML दिखाएं",
-      "title": "प्लगइन डिफॉल्ट्स",
-      "update": "प्लगइन डिफ़ॉल्ट अपडेट करें",
-      "use_custom": "कस्टम उपयोग करें",
-      "yaml": "YAML",
-      "yaml_configuration": "YAML कॉन्फ़िगरेशन"
-    },
-    "pluginPage": {
-      "elementType": {
-        "apps": "ऐप",
-        "charts": "चार्ट",
-        "conditions": "शर्त",
-        "logExporters": "लॉग एक्सपोर्टर",
-        "secrets": "गुप्त",
-        "taskRunners": "टास्क रनर",
-        "tasks": "कार्य",
-        "triggers": "ट्रिगर"
-      },
-      "group": {
-        "blueprints": "ब्लूप्रिंट्स ({count})",
-        "plugins": "प्लगइन्स ({count})",
-        "tasks": "टास्क ({count})"
-      },
+    "blueprints": {
+      "all": "सभी",
+      "community": "समुदाय",
+      "create": "ब्लूप्रिंट बनाएं",
+      "edit": "ब्लूप्रिंट संपादित करें",
+      "title": "Blueprints",
+      "empty": "कोई blueprints दिखाने के लिए नहीं हैं।",
       "header": {
-        "back": "प्लगइन्स पर वापस जाएँ",
-        "certified": "प्रमाणित",
-        "enterpriseEdition": "एंटरप्राइज एडिशन"
+        "catch phrase": {
+          "1": "पहला कदम हमेशा सबसे कठिन होता है।",
+          "2": "अपने अगले {kind} को शुरू करने के लिए ब्लूप्रिंट्स का अन्वेषण करें।"
+        },
+        "alt": "ब्लूप्रिंट्स आइकन"
       },
-      "loadError": "प्लगइन्स लोड नहीं हो सके। कृपया पुनः प्रयास करें।",
-      "noResults": "आपकी खोज से कोई प्लगइन मेल नहीं खाता।",
-      "notFound": "यह प्लगइन नहीं मिला।",
-      "overview": {
-        "createdBy": "द्वारा निर्मित",
-        "latest": "नवीनतम",
-        "linksResources": "लिंक और संसाधन",
-        "managedBy": "द्वारा प्रबंधित",
-        "minKestraVersion": "न्यूनतम संगत Kestra संस्करण: {version}",
-        "minKestraVersionShort": "न्यूनतम Kestra संस्करण {version}",
-        "pluginType": "प्लगइन प्रकार",
-        "previousVersions": "पिछले संस्करण",
-        "releaseNotes": "रिलीज़ नोट्स",
-        "title": "सारांश",
-        "versions": "संस्करण"
+      "custom": "कस्टम blueprints",
+      "flows": "फ्लो Blueprints",
+      "apps": "ऐप Blueprints",
+      "dashboards": "डैशबोर्ड Blueprints",
+      "detail": {
+        "category": "श्रेणी प्रकार",
+        "links": "लिंक और संसाधन",
+        "openInEditor": "एडिट Flow में खोलें"
       },
-      "search": "{count}+ प्लगइन्स में खोजें",
-      "searchTasks": "{count} tasks खोजें",
-      "sort": {
-        "mostUsed": "सबसे अधिक उपयोग किया गया",
-        "nameAsc": "नाम A-Z",
-        "nameDesc": "नाम Z-A",
-        "newest": "नवीनतम"
-      },
-      "sortBy": "क्रमबद्ध करें"
+      "missingPlugins": {
+        "title": "अनुपलब्ध plugins",
+        "description": "यह blueprint ऐसे plugin(s) के tasks का उपयोग करता है जो इस instance पर इंस्टॉल नहीं हैं: {plugins}। इस blueprint का उपयोग करने के लिए उन्हें इंस्टॉल करें।",
+        "card": "इस instance पर इंस्टॉल न किए गए plugin(s) की आवश्यकता है: {plugins}",
+        "install": "Plugins इंस्टॉल करें"
+      }
     },
-    "plugin_default_already_exists": "<code>{type}</code> के लिए प्लगइन डिफ़ॉल्ट पहले से मौजूद है।",
+    "use": "उपयोग करें",
     "plugins": {
       "name": "plugin",
       "names": "plugins",
       "please": "कृपया दाईं ओर एक task चुनें ताकि इसका दस्तावेज़ीकरण देखा जा सके",
       "release": "रिलीज़ नोट्स"
     },
-    "port": "पोर्ट",
-    "prefill inputs": "पूर्व-भरण",
-    "pretty_json": "Pretty JSON",
-    "prev_execution": "पिछला निष्पादन",
-    "preview": {
-      "auto-view": "स्वचालित दृश्य",
-      "collapse": "संक्षिप्त करें",
-      "expand": "विस्तार करें",
-      "force-editor": "संपादक दृश्य लागू करें",
-      "label": "पूर्वावलोकन",
-      "next": "अगला",
-      "page_of": "पृष्ठ {current} का {total}",
-      "pagination_info": "पंक्तियाँ {start}-{end} में से {total} दिखा रहा है।",
-      "previous": "पिछला",
-      "rows_truncated": "{total} में से {shown} पंक्तियाँ दिखा रहा है। सभी डेटा देखने के लिए फ़ाइल डाउनलोड करें।",
-      "showing_rows": "पंक्तियाँ {start}-{end} में से {total} दिखा रहा है",
-      "view": "देखें"
+    "last execution date": "अंतिम निष्पादन तिथि",
+    "last execution state": "अंतिम स्थिति",
+    "last X days count": "{दिनों} दिनों में {गिनती}",
+    "date range count": "{startDate} और {endDate} के बीच {गिनती}",
+    "date count": "{तारीख} पर {गिनती}",
+    "revisions": "पुनरीक्षण",
+    "no revisions found": "इस flow के लिए केवल एक पुनरीक्षण मौजूद है",
+    "no revisions": "कोई संशोधन नहीं",
+    "see full revision": "पूर्ण पुनरीक्षण देखें",
+    "side-by-side": "साइड-बाय-साइड",
+    "line-by-line": "लाइन-बाय-लाइन",
+    "template": "template",
+    "template creation": "template निर्माण",
+    "templates": "templates",
+    "templates deprecated": "templates अप्रचलित हैं। कृपया इसके बजाय subflows का उपयोग करें। यह समझाने वाला <a href=\"https://kestra.io/docs/migration-guide/0.11.0/templates?utm_source=app&utm_medium=referral&utm_campaign=template-inlinedoc\" target=\"_blank\">माइग्रेशन अनुभाग</a> देखें कि आप टेम्पलेट्स से subflows में कैसे माइग्रेट कर सकते हैं।",
+    "no result": "कोई परिणाम दिखाने के लिए नहीं हैं।",
+    "empty search": "खोज परिणाम खाली हैं",
+    "trigger": "Trigger",
+    "no_trigger": "कोई trigger उपलब्ध नहीं है।",
+    "triggers": "Triggers",
+    "triggers_header_description": "अपने flows को स्वचालित करने के लिए triggers को ब्राउज़ करें, जोड़ें और प्रबंधित करें। अपने flow को एक AI टूल के रूप में एक्सपोज़ करने, शेड्यूलिंग, एक webhook trigger जोड़ने, बाहरी ऐप्स में परिवर्तनों के लिए polling करने, या रीयलटाइम इवेंट listeners में से चुनें।",
+    "triggers_tabs_add": "जोड़ें",
+    "triggers_tabs_manage": "प्रबंधित करें",
+    "triggers_add_search_placeholder": "ट्रिगर्स खोजें...",
+    "triggers_add_filter_core": "कोर",
+    "triggers_add_filter_realtime": "रियलटाइम",
+    "triggers_add_filter_all": "सभी",
+    "triggers_add_filter_app": "ऐप",
+    "triggers_add_empty_title": "कोई triggers नहीं मिले",
+    "triggers_add_ee_tooltip": "यह trigger के लिए Enterprise Edition आवश्यक है।",
+    "triggers_add_category_empty": "इस श्रेणी में कोई triggers नहीं हैं।",
+    "triggers_add_card_add_to_flow": "flow में जोड़ें",
+    "triggers_add_card_add": "जोड़ें",
+    "triggers_add_modal_title": "{name}",
+    "triggers_add_modal_tab_form": "फॉर्म",
+    "triggers_add_modal_tab_source": "स्रोत",
+    "triggers_add_modal_tab_documentation": "दस्तावेज़ीकरण",
+    "triggers_add_modal_namespace_placeholder": "एक namespace चुनें",
+    "triggers_add_modal_flow_placeholder": "किसी flow का चयन करें",
+    "triggers_add_modal_trigger_id": "ट्रिगर ID",
+    "triggers_add_modal_trigger_id_placeholder": "इस trigger के लिए अद्वितीय पहचानकर्ता",
+    "triggers_add_modal_properties_hint": "ट्रिगर जोड़ने के बाद flow संपादक में ट्रिगर गुणों को कॉन्फ़िगर करें।",
+    "triggers_add_modal_ee_notice": "यह trigger Enterprise Edition की आवश्यकता है।",
+    "triggers_add_modal_add_button": "Flow में Trigger जोड़ें",
+    "trigger details": "Trigger विवरण",
+    "triggerflow disabled": "Flow परिभाषा से Trigger अक्षम है",
+    "last trigger date": "अंतिम ट्रिगर की तारीख",
+    "trigger_states": "राज्य",
+    "context updated date": "संदर्भ अद्यतन तिथि",
+    "state updated date": "स्थिति अद्यतन तिथि",
+    "next evaluation date": "अगली मूल्यांकन तिथि",
+    "last evaluation date": "अंतिम मूल्यांकन तिथि",
+    "last trigger date tooltip": "ट्रिगर ने आखिरी बार कब निष्पादित किया था। जब एक backfill चल रहा हो तो यह अतीत में हो सकता है।",
+    "context updated date tooltip": "ट्रिगर के संदर्भ को आखिरी बार कब अपडेट किया गया था। यह तब होता है जब execution ट्रिगर होता है, समाप्त होता है (लॉक रिलीज़ होता है), या एक मूल्यांकन के बाद (भले ही कोई execution न हो)।",
+    "next evaluation date tooltip": "ट्रिगर का अगला मूल्यांकन कब होगा, यह उसके अंतराल पर आधारित है। यदि शर्तें पूरी नहीं होती हैं, तो यह हमेशा अगले निष्पादन तिथि के समान नहीं होता।",
+    "last evaluation date tooltip": "When the trigger was last evaluated by the scheduler, regardless of whether it produced an execution.",
+    "conditions": "शर्तें",
+    "triggerId": "ट्रिगर ID",
+    "tenantId": "टेनेंट ID",
+    "codeDisabled": "Flow में अक्षम",
+    "paused": "PAUSED",
+    "running": "RUNNING",
+    "Fold auto": "संपादक: मल्टीलाइन का स्वचालित फोल्ड",
+    "Hover description": "संपादक: जब key या value पर होवर करें तो फ़ील्ड का विवरण दिखाएं",
+    "Fold content lines": "मल्टीलाइन स्ट्रिंग्स फोल्ड करें",
+    "Unfold content lines": "मल्टीलाइन स्ट्रिंग्स अनफोल्ड करें",
+    "Total": "कुल",
+    "sub flow": "Subflow",
+    "execute": "निष्पादित करें",
+    "execute flow behaviour": "Flow निष्पादित करें",
+    "open in same tab": "उसी टैब में",
+    "open in new tab": "एक नए टैब में",
+    "execute the flow": "Flow <code>{id}</code> निष्पादित करें",
+    "execute flow now ?": "क्या आप इस flow को निष्पादित करना चाहते हैं?",
+    "discard execution confirmation": "आपके पास बिना सहेजे गए input हैं। क्या आप वाकई इस execution को छोड़ना चाहते हैं?",
+    "discard changes confirmation": "आपके पास बिना सहेजे गए परिवर्तन हैं। क्या आप वाकई उन्हें छोड़ना चाहते हैं?",
+    "Default namespace": "पूर्व-निर्धारित namespace",
+    "Default log level": "पूर्व-निर्धारित log स्तर",
+    "unsaved changed ?": "आपके पास असहेजे गए परिवर्तन हैं, क्या आप इस पृष्ठ को छोड़ना चाहते हैं?",
+    "unsaved changes": "असहेजित परिवर्तन",
+    "unsaved changes warning": "आपके पास बिना सहेजे गए परिवर्तन हैं। यदि आप इस पृष्ठ को छोड़ते हैं, तो आपके परिवर्तन खो जाएंगे।",
+    "leave page": "पृष्ठ छोड़ें",
+    "open full page": "पूरा पेज खोलें",
+    "drill down preview": "पूर्वावलोकन",
+    "Editor theme": "संपादक थीम",
+    "Editor fontsize": "संपादक फ़ॉन्ट आकार",
+    "Editor fontfamily": "संपादक फ़ॉन्ट परिवार",
+    "errors": {
+      "401": {
+        "title": "अनधिकृत",
+        "content": "इस पृष्ठ तक पहुँचने के लिए आपको प्रमाणित होना आवश्यक है।"
+      },
+      "403": {
+        "title": "पहुँच अस्वीकृत",
+        "content": "इस पृष्ठ तक पहुँचने के लिए आपके पास आवश्यक अनुमतियाँ नहीं हैं।"
+      },
+      "404": {
+        "title": "पृष्ठ नहीं मिला",
+        "content": "अनुरोधित URL इस सर्वर पर नहीं मिला।<br />यही सब हमें पता है।",
+        "flow or execution": "वह flow या निष्पादन जिसे आप ढूंढ रहे हैं, मौजूद नहीं है।"
+      }
     },
-    "pricing": "मूल्य निर्धारण",
-    "product_tour": "उत्पाद यात्रा",
-    "properties": {
-      "hidden": "टेबल में छिपा हुआ",
-      "hint": "दृश्य स्तंभ चुनें",
-      "label": "गुणधर्म",
-      "shown": "तालिका में दिखाया गया"
+    "back_to_dashboard": "डैशबोर्ड पर वापस जाएं",
+    "copy all logs": "सभी Logs कॉपी करें",
+    "copy logs": "Logs कॉपी करें",
+    "fix_with_ai": "AI से ठीक करें",
+    "download logs": "Logs डाउनलोड करें",
+    "delete logs": "Logs हटाएं",
+    "delete_all_logs": "क्या आप वाकई सभी Logs हटाना चाहते हैं?",
+    "delete_log": "क्या आप वाकई log को हटाना चाहते हैं?",
+    "toggle fullscreen": "पूर्ण स्क्रीन टॉगल करें",
+    "copied": "कॉपी किया गया",
+    "tags": "टैग्स",
+    "disabled flow title": "यह flow अक्षम है",
+    "disabled flow desc": "यह flow अक्षम है, कृपया इसे निष्पादित करने के लिए सक्षम करें।",
+    "label": "Label",
+    "labels": "labels",
+    "label filter placeholder": "'key:value' के रूप में लेबल करें",
+    "execution labels": "निष्पादन labels",
+    "wrong labels": "labels में खाली key या value की अनुमति नहीं है",
+    "feeds": {
+      "title": "केस्ट्रा में नया क्या है",
+      "heading": "सभी चीजें Kestra।",
+      "subheading": "नवीनतम अपडेट, गाइड और कहानियाँ"
     },
-    "queued duration": "कतारबद्ध अवधि",
-    "quotas": "कोटा",
-    "reach us": "हमसे बात करें",
-    "read-more": "और अधिक पढ़ें",
-    "readonly property": "केवल-पढ़ने की संपत्ति",
-    "recent_executions": "हाल की Executions",
-    "refresh": "ताज़ा करें",
-    "reject": "अस्वीकार करें",
-    "relative": "सापेक्ष",
-    "relative end date": "सापेक्ष समाप्ति तिथि",
-    "relative start date": "सापेक्ष प्रारंभ तिथि",
-    "remove label": "लेबल हटाएं",
-    "remove this item": "इस आइटम को हटाएं",
-    "remove_bookmark": "क्या आप वाकई इस बुकमार्क को हटाना चाहते हैं?",
-    "replay": "पुनः चलाएँ",
-    "replay confirm": "क्या आप वाकई इस निष्पादन <code>{id}</code> को पुनः चलाना चाहते हैं और एक नया निष्पादन बनाना चाहते हैं?",
-    "replay execution description": "यह चयनित execution के आधार पर एक नया execution बनाएगा।",
-    "replay execution title": "प्रदर्शन पुनः चलाएं",
-    "replay from beginning tooltip": "शुरुआत से शुरू होने वाला एक समान निष्पादन बनाएँ",
-    "replay from task tooltip": "Task <code>{taskId}</code> से शुरू होने वाला एक समान निष्पादन बनाएँ",
-    "replay inputs": "इनपुट्स",
-    "replay inputs new required": "इस संशोधन में inputs हैं। आपको इन्हें भरने के लिए कहा जाएगा।",
-    "replay latest revision": "नवीनतम पुनरीक्षण का उपयोग करके पुनः चलाएँ",
-    "replay select taskrun": "जिस task रन को पुनः चलाना है, उसे चुनें:",
-    "replay the execution": "फ्लो <code>{flowId}</code> के लिए निष्पादन <code>{executionId}</code> को पुनः चलाएं",
-    "replay using": "पुनः चलाएं उपयोग करते हुए",
-    "replay with inputs": "इनपुट्स के साथ पुनः चलाएं",
-    "replayed": "निष्पादन को पुनः चलाया गया है",
-    "required field": "आवश्यक फ़ील्ड",
-    "reset": "पुनः प्रारंभ करें",
-    "reset to defaults": "डिफ़ॉल्ट पर रीसेट करें",
-    "restart": "पुनः प्रारंभ करें",
-    "restart change revision": "आप उस पुनरीक्षण को बदल सकते हैं जिसका उपयोग नए निष्पादन के लिए किया जाएगा।",
-    "restart confirm": "क्या आप वाकई निष्पादन <code>{id}</code> को पुनः प्रारंभ करना चाहते हैं?",
-    "restart execution title": "निष्पादन पुनः प्रारंभ करें",
-    "restart latest revision": "नवीनतम पुनरीक्षण पुनः प्रारंभ करें",
-    "restart tooltip": "<code>{state}</code> task से निष्पादन पुनः प्रारंभ करें",
-    "restart trigger": {
-      "button": "Trigger पुनः प्रारंभ करें",
-      "tooltip": "ट्रिगर को पुनः प्रारंभ करें"
-    },
-    "restarted": "निष्पादन पुनः आरंभ किया गया है",
+    "delete execution running": "<div class=\"alert alert-warning mt-2 mb-0\">यह निष्पादन अभी भी RUNNING है, इसे हटाने से यह बंद नहीं होगा।<br />इसे बंद करने के लिए आपको निष्पादन को kill करना होगा।</div>",
     "restore": "पुनर्स्थापित करें",
     "restore confirm": "क्या आप वाकई संशोधन <code>{revision}</code> को पुनर्स्थापित करना चाहते हैं?",
+    "bulk delete": "क्या आप वाकई <code>{executionCount}</code> निष्पादन को हटाना चाहते हैं?",
+    "bulk replay": "क्या आप वाकई <code>{executionCount}</code> निष्पादन को पुनः चलाना चाहते हैं?",
+    "bulk change state": "क्या आप सुनिश्चित हैं कि आप <code>{executionCount}</code> execution(s) की स्थिति बदलना चाहते हैं?",
+    "bulk resume": "क्या आप वाकई <code>{executionCount}</code> निष्पादन को फिर से शुरू करना चाहते हैं?",
+    "bulk pause": "क्या आप वाकई <code>{executionCount}</code> execution(s) को PAUSE करना चाहते हैं?",
+    "bulk unqueue": "क्या आप वाकई <code>{executionCount}</code> execution(s) को अनक्यू करना चाहते हैं?",
+    "bulk force run": "क्या आप वाकई <code>{executionCount}</code> execution(s) को जबरदस्ती चलाना चाहते हैं?<br/><br/>WARNING: किसी execution को जबरदस्ती चलाना सुनिश्चित नहीं है और यह डुप्लिकेट task executions बना सकता है।<br/><br/>निम्नलिखित परिवर्तन किए जाएंगे:<br/><ul><li>CREATED tasks को RUNNING स्थिति में ले जाया जाएगा।</li><li>RUNNING tasks को पुनः सबमिट किया जाएगा।</li><li>QUEUED tasks को अन-queued किया जाएगा।</li><li>PAUSED tasks को फिर से शुरू किया जाएगा।</li></ul>",
+    "bulk restart": "क्या आप वाकई <code>{executionCount}</code> निष्पादन को पुनः प्रारंभ करना चाहते हैं?",
+    "bulk kill": "क्या आप वाकई <code>{executionCount}</code> निष्पादन को kill करना चाहते हैं?",
+    "selection": {
+      "selected": "<strong>{count}</strong> चयनित",
+      "all": "सभी का चयन करें ({count})"
+    },
+    "cancel": "रद्द करें",
+    "errorLogs": "त्रुटियाँ logs",
+    "welcome_page": {
+      "welcome": "Kestra में आपका स्वागत है",
+      "guide": "क्या आपको अपना पहला flow निष्पादित करने के लिए मार्गदर्शन चाहिए?"
+    },
+    "product_tour": "उत्पाद यात्रा",
+    "executions replayed": "<code>{executionCount}</code> निष्पादन पुनः चलाए गए",
+    "executions state changed": "<code>{executionCount}</code> निष्पादन की स्थिति बदल दी गई है",
+    "executions resumed": "<code>{executionCount}</code> निष्पादन फिर से शुरू किए गए",
+    "executions paused": "<code>{executionCount}</code> execution(s) PAUSED",
+    "executions unqueue": "<code>{executionCount}</code> निष्पादन अनक्यू करें",
+    "executions force run": "<code>{executionCount}</code> execution(s) जबरन चलाया गया",
+    "executions restarted": "<code>{executionCount}</code> निष्पादन पुनः प्रारंभ किए गए",
+    "executions killed": "<code>{executionCount}</code> निष्पादन kill किए गए",
+    "executions deleted": "<code>{executionCount}</code> निष्पादन हटाए गए",
+    "invalid bulk replay": "निष्पादन पुनः चलाने में असमर्थ",
+    "invalid bulk resume": "निष्पादन फिर से शुरू करने में असमर्थ",
+    "invalid bulk pause": "निष्पादन को PAUSE नहीं किया जा सका",
+    "invalid bulk unqueue": "निष्पादन को अनक्यू नहीं किया जा सका",
+    "invalid bulk force run": "निष्पादन को जबरन चलाने में असमर्थ",
+    "invalid bulk restart": "निष्पादन पुनः प्रारंभ करने में असमर्थ",
+    "invalid bulk kill": "निष्पादन kill करने में असमर्थ",
+    "invalid bulk delete": "निष्पादन हटाने में असमर्थ",
+    "execution not found": "{executionId} निष्पादन नहीं मिला।",
+    "execution not in state PAUSED": "निष्पादन <code>{executionId}</code> PAUSED स्थिति में नहीं है",
+    "execution not in state FAILED": "निष्पादन <code>{executionId}</code> FAILED स्थिति में नहीं है",
+    "execution already finished": "निष्पादन <code>{executionId}</code> पहले ही समाप्त हो चुका है",
     "restore revision": "क्या आप वाकई संशोधन <code>{revision}</code> को पुनर्स्थापित करना चाहते हैं?",
-    "resume": "पुनः आरंभ करें",
-    "resume from breakpoint done": "निष्पादन विराम बिंदु से फिर से शुरू किया गया है",
-    "resume from breakpoint title": "ब्रेकपॉइंट से निष्पादन `<code>{id}</code>` को पुनः शुरू करें",
-    "resumed confirm": "क्या आप वाकई निष्पादन <code>{id}</code> को पुनः आरंभ करना चाहते हैं?",
-    "resumed done": "निष्पादन पुनः आरंभ किया गया है",
-    "resumed title": "निष्पादन <code>{id}</code> पुनः आरंभ करें",
-    "reuse original inputs": "मूल inputs का पुनः उपयोग करें",
-    "reuse_original_inputs": "मूल inputs का पुनः उपयोग करें",
-    "review your inputs": "अपने इनपुट्स की समीक्षा करें",
-    "revision": "संशोधन",
-    "revision deleted": "समीक्षा {revision} को सफलतापूर्वक हटा दिया गया है",
-    "revisions": "पुनरीक्षण",
-    "row count": "पंक्ति संख्या",
-    "run task in playground": "प्लेग्राउंड में task चलाएं",
+    "seeing old revision": "आप एक पुराना संशोधन देख रहे हैं: {revision}",
+    "export": "निर्यात करें",
+    "exports": "निर्यात",
+    "export_csv": "CSV के रूप में निर्यात करें",
+    "template export": "क्या आप वाकई <code>{templateCount}</code> template(s) को निर्यात करना चाहते हैं?",
+    "templates exported": "templates निर्यात किए गए",
+    "export all templates": "सभी templates निर्यात करें",
+    "flow_export": "flow निर्यात करें",
+    "flow export": "क्या आप वाकई <code>{flowCount}</code> flow(s) को निर्यात करना चाहते हैं?",
+    "flows exported": "<code>{count}</code> Flow(s) निर्यात किए गए",
+    "export all flows": "सभी Flows निर्यात करें",
+    "import": "आयात करें",
+    "disable": "अक्षम करें",
+    "enable": "सक्षम करें",
+    "enabled": "सक्षम",
+    "template delete": "क्या आप वाकई <code>{templateCount}</code> template(s) को हटाना चाहते हैं?",
+    "flow delete": "क्या आप वाकई <code>{flowCount}</code> flow(s) को हटाना चाहते हैं?",
+    "templates deleted": "<code>{count}</code> template(s) हटाए गए",
+    "flows deleted": "<code>{count}</code> Flow(s) हटाए गए",
+    "flow disable": "क्या आप वाकई <code>{flowCount}</code> flow(s) को अक्षम करना चाहते हैं?",
+    "flow enable": "क्या आप वाकई <code>{flowCount}</code> flow(s) को सक्षम करना चाहते हैं?",
+    "flows disabled": "<code>{count}</code> Flow(s) अक्षम किए गए",
+    "flows enabled": "<code>{count}</code> Flow(s) सक्षम किए गए",
+    "flow-no-dependencies": "आपके flow की कोई dependencies नहीं हैं।",
+    "flow-dependencies": "निर्भरता",
+    "read-more": "और अधिक पढ़ें",
+    "in-our-documentation": "हमारे दस्तावेज़ में।",
+    "dependencies": "निर्भरताएँ",
+    "see dependencies": "निर्भरताएँ देखें",
+    "see timeline": "समयरेखा देखें",
     "run timeline": "रन टाइमलाइन",
-    "runners": "धावक",
-    "running": "RUNNING",
-    "running duration": "चलने की अवधि",
-    "save": "सहेजें",
+    "dependencies missing acls": "इस flow पर कोई अनुमतियाँ नहीं हैं",
+    "dependencies delete flow": "इस flow में निर्भरताएँ हैं। इसे हटाने से उनकी निर्भरताओं को निष्पादित करने से रोका जाएगा।<br /><br /> यहाँ प्रभावित flows की सूची है:",
+    "expand dependencies": "निर्भरताएँ विस्तारित करें",
+    "reset": "पुनः प्रारंभ करें",
+    "show task documentation": "Task दस्तावेज़ दिखाएं",
+    "hide task documentation": "Task दस्तावेज़ छिपाएं",
+    "show task documentation in editor": "संपादक में Task दस्तावेज़ दिखाएं",
+    "show documentation": "दस्तावेज़ दिखाएं",
+    "focus task": "किसी भी तत्व पर क्लिक करें ताकि उसका दस्तावेज़ देखा जा सके।",
+    "validate": "मान्य करें",
+    "add error handler": "एक त्रुटि हैंडलर जोड़ें",
+    "taskDefaults": "taskDefaults",
+    "disabled": "अक्षम",
+    "before": "पहले",
+    "after": "बाद में",
+    "add at position": "{position} <code>{task}</code> जोड़ें",
+    "create first task": "अपना पहला Task बनाएं",
+    "dynamic": "डायनामिक",
+    "choice": "विकल्प",
+    "sequential": "अनुक्रमिक",
+    "can not delete": "हटाया नहीं जा सकता",
+    "can not have less than 1 task": "प्रत्येक flow में कम से कम एक Task होना चाहिए।",
+    "task id already exists": "Task Id पहले से मौजूद है",
+    "Task Id already exist in the flow": "Task Id {taskId} पहले से ही flow में मौजूद है।",
+    "task id": "Task ID",
+    "taskid column details": "निष्पादित होने वाला अंतिम Task और इसके प्रयासों की संख्या।",
+    "flow already exists": "Flow पहले से मौजूद है",
+    "flow already exists message": "Flow <code>{id}</code> पहले से ही namespace <code>{namespace}</code> में मौजूद है। क्या आप एक नया संशोधन बनाना चाहते हैं?",
+    "plugin_default_already_exists": "<code>{type}</code> के लिए प्लगइन डिफ़ॉल्ट पहले से मौजूद है।",
+    "namespace not allowed": "Namespace की अनुमति नहीं है",
+    "switch-view": "दृश्य स्विच करें",
+    "source and topology": "स्रोत और टोपोलॉजी",
+    "source and doc": "स्रोत और दस्तावेज़",
+    "source and blueprints": "स्रोत और ब्लूप्रिंट",
+    "editor": "संपादक",
+    "error in editor": "संपादक में एक त्रुटि पाई गई है",
+    "delete task confirm": "क्या आप वाकई Task <code>{taskId}</code> को हटाना चाहते हैं?",
+    "can not save": "सहेजा नहीं जा सकता",
+    "flow must not be empty": "Flow खाली नहीं होना चाहिए",
+    "flow must have id and namespace": "Flow में एक id और एक namespace होना चाहिए।",
+    "flow creation denied in namespace": "आपके पास namespace `{namespace}` में flows बनाने की अनुमति नहीं है।",
+    "readonly property": "केवल-पढ़ने की संपत्ति",
+    "namespace and id readonly": "गुण `namespace` और `id` को बदला नहीं जा सकता — वे अब अपनी प्रारंभिक मानों पर सेट हैं। यदि आप किसी flow का नाम बदलना चाहते हैं या उसका namespace बदलना चाहते हैं, तो आप एक नया flow बना सकते हैं और पुराने को हटा सकते हैं।",
+    "avg": "औसत",
+    "sum": "योग",
+    "min": "न्यूनतम",
+    "max": "अधिकतम",
+    "bar": "बार",
+    "line": "रेखा",
+    "metric": "मेट्रिक",
+    "aggregation": "एकत्रीकरण",
+    "chart type": "चार्ट प्रकार",
+    "metric choice": "इस flow के लिए कोई मेट्रिक्स उपलब्ध नहीं है",
+    "of": "का",
+    "see_all_states": "सभी अवस्थाएँ देखें",
     "save draft": {
       "message": "ड्राफ्ट सहेजा गया",
       "retrieval": {
@@ -1680,164 +724,336 @@
         "existing": "एक <code>{flowFullName}</code> Flow ड्राफ्ट सहेजा गया, क्या आप flow को संपादित करना जारी रखना चाहते हैं?"
       }
     },
-    "save task": "Task सहेजें",
-    "save_and_execute": "सहेजें और निष्पादित करें",
-    "save_as_draft": "ड्राफ़्ट के रूप में सहेजें",
-    "saved": "सफलतापूर्वक सहेजा गया",
-    "saved as draft": "ड्राफ़्ट के रूप में सफलतापूर्वक सहेजा गया",
-    "saved as draft done": "<em>{name}</em> सफलतापूर्वक ड्राफ़्ट के रूप में सहेजा गया",
-    "saved done": "<em>{name}</em> सफलतापूर्वक सहेजा गया है",
-    "scheduleDate": "अनुसूची तिथि",
-    "scope_filter": {
-      "all": "सभी {label}",
-      "system": "सिस्टम {label}",
-      "system_description": "सिस्टम रखरखाव {label}",
-      "user": "उपयोगकर्ता {label}",
-      "user_description": "साधारण उपयोगकर्ता द्वारा प्रारंभ किया गया {label}"
+    "title": "शीर्षक",
+    "api": "API",
+    "more_actions": "अधिक क्रियाएँ",
+    "expand error": "केवल असफल Tasks विस्तारित करें",
+    "expand all": "सभी विस्तारित करें",
+    "collapse all": "सभी संक्षिप्त करें",
+    "expand": "विस्तारित करें",
+    "collapse": "संक्षिप्त करें",
+    "filter by this value": "Filter by this value",
+    "filter_for": "Filter for",
+    "filter_out": "Filter out",
+    "copy_value": "Copy value",
+    "open_page": "Open page",
+    "logs_copied": "Logs copied to your clipboard",
+    "expand_by_default": "Expand structured logs by default",
+    "show raw": "Show raw",
+    "similar lines": "similar lines",
+    "download_logs_description": "Choose which logs to export. Filters default to your current view.",
+    "display_settings": "Display settings",
+    "density": "Density",
+    "density_compact": "Compact",
+    "density_normal": "Normal",
+    "density_expanded": "Expanded",
+    "pretty_json": "Pretty JSON",
+    "body_line_clamp": "Limit line height",
+    "font size": "Font size",
+    "log expand setting": "Log डिफ़ॉल्ट प्रदर्शन",
+    "environment": "पर्यावरण",
+    "environment name setting": "पर्यावरण नाम",
+    "environment color setting": "पर्यावरण रंग",
+    "slack support": "किसी भी प्रश्न को Slack के माध्यम से पूछें",
+    "join community": "समुदाय में शामिल हों",
+    "join_slack": "Slack से जुड़ें",
+    "kestra": "केस्ट्रा",
+    "reach us": "हमसे बात करें",
+    "new version": "नया संस्करण {version} उपलब्ध है!",
+    "error detected": "त्रुटि(त्रुटियाँ) पाई गईं।",
+    "warning detected": "चेतावनी का पता चला",
+    "informative notice": "नोट(s)",
+    "cannot swap tasks": "Tasks को स्वैप नहीं कर सकते",
+    "open": "खोलें",
+    "dependency task": "Task {taskId} किसी अन्य Task की निर्भरता है",
+    "administration": "प्रशासन",
+    "admin": "प्रशासनिक",
+    "main_configuration": "मुख्य कॉन्फ़िगरेशन",
+    "commit_id": "कमिट id",
+    "evaluation lock date": "मूल्यांकन लॉक तिथि",
+    "unlock trigger": {
+      "tooltip": {
+        "execution": "इस Trigger के लिए एक निष्पादन चल रहा है",
+        "evaluation": "Trigger वर्तमान में मूल्यांकन में है"
+      },
+      "confirmation": "क्या आप वाकई Trigger को अनलॉक करना चाहते हैं?",
+      "warning": "यह एक ही Trigger के लिए concurrent निष्पादन का कारण बन सकता है और इसे अंतिम उपाय के रूप में माना जाना चाहिए।",
+      "button": "Trigger अनलॉक करें",
+      "success": "Trigger अनलॉक किया गया"
     },
-    "search": "खोजें",
-    "search blueprint": "Blueprints खोजें",
-    "search filters": {
-      "filter name": "फ़िल्टर नाम",
-      "filters": "फ़िल्टर",
-      "manage": "खोज फ़िल्टर प्रबंधित करें",
-      "manage desc": "सहेजे गए खोज फ़िल्टर प्रबंधित करें",
-      "save filter": "फ़िल्टर सहेजें",
-      "saved": "सहेजे गए फ़िल्टर"
+    "restart trigger": {
+      "button": "Trigger पुनः प्रारंभ करें",
+      "tooltip": "ट्रिगर को पुनः प्रारंभ करें"
     },
-    "search term in message": "संदेश में खोज शब्द",
-    "search_docs": "खोजें",
-    "searching": "खोज जारी है...",
-    "secret": {
-      "add": "बनाएं",
-      "inherited": "Inherited secrets",
-      "isReadOnly": "सीक्रेट केवल पढ़ने के लिए है",
-      "names": "Secrets",
-      "update": "गुप्त जानकारी '{name}' अपडेट करें"
-    },
-    "security_advice": {
-      "content": "अपनी instance की सुरक्षा के लिए बुनियादी प्रमाणीकरण सक्षम करें।",
-      "enable": "प्रमाणीकरण सक्षम करें",
-      "switch_text": "फिर से न दिखाएं",
-      "title": "अपनी instance की सुरक्षा करें"
-    },
-    "see dependencies": "निर्भरताएँ देखें",
-    "see full revision": "पूर्ण पुनरीक्षण देखें",
-    "see timeline": "समयरेखा देखें",
-    "see_all_states": "सभी अवस्थाएँ देखें",
-    "seeing old revision": "आप एक पुराना संशोधन देख रहे हैं: {revision}",
-    "select": "अपने {{section}} का चयन करें",
-    "select a state": "एक स्थिति चुनें",
-    "select datetime": "एक तिथि चुनें",
-    "select view": "दृश्य चुनें",
-    "selected": "चयनित",
-    "selection": {
-      "all": "सभी का चयन करें ({count})",
-      "selected": "<strong>{count}</strong> चयनित"
-    },
-    "sequential": "अनुक्रमिक",
-    "server type": "सर्वर प्रकार",
+    "trigger disabled": "Flow स्रोत के भीतर Trigger अक्षम है",
+    "flow source not found": "Flow source नहीं मिला",
+    "date format": "दिनांक प्रारूप",
+    "timezone": "समय क्षेत्र",
+    "add task": "एक Task जोड़ें",
+    "unable to generate graph": "ग्राफ़ उत्पन्न करते समय एक समस्या उत्पन्न हुई जिससे टोपोलॉजी प्रदर्शित नहीं हो सकी।",
+    "attempts": "प्रयास",
+    "flow deleted, you can restore it": "Flow हटा दिया गया है और यह एक केवल-पढ़ने का दृश्य है। आप इसे अभी भी पुनर्स्थापित कर सकते हैं।",
+    "workers": "Workers",
+    "worker group": "Worker समूह",
+    "worker group key": "वर्कर ग्रुप key",
+    "worker group fallback": "वर्कर ग्रुप फॉलबैक",
+    "version": "संस्करण",
     "services": "सेवाएँ",
+    "server type": "सर्वर प्रकार",
+    "hostname": "होस्टनाम",
+    "port": "पोर्ट",
+    "management port": "प्रबंधन पोर्ट",
+    "file preview truncated": "प्रदर्शित सामग्री को संक्षिप्त किया गया है",
+    "file unavailable": "फ़ाइल उपलब्ध नहीं है",
+    "file unavailable description": "यह फ़ाइल अब उपलब्ध नहीं है — इसे हटाया जा सकता है या इसकी समय सीमा समाप्त हो गई है।",
+    "row count": "पंक्ति संख्या",
+    "encoding": "एन्कोडिंग",
+    "show": "दिखाएं",
+    "advanced configuration": "अन्य गुण",
+    "all executions": "सभी निष्पादन",
+    "trigger execution id": "Trigger निष्पादन Id",
+    "execution_status": "Execution है:",
+    "no_tasks_running": "अभी कोई task नहीं चल रहा है।",
+    "execution_starts_progress": "जैसे ही execution शुरू होता है, आपको यहाँ प्रगति अपडेट दिखाई देंगे।",
+    "triggers_state": {
+      "state": "स्थिति",
+      "options": {
+        "enabled": "सक्षम",
+        "disabled": "अक्षम"
+      }
+    },
+    "trigger filter": {
+      "title": "बाल निष्पादन फ़िल्टर करें",
+      "options": {
+        "ALL": "सभी निष्पादन",
+        "CHILD": "बाल निष्पादन",
+        "MAIN": "मूल निष्पादन"
+      }
+    },
+    "show chart": "चार्ट दिखाएं",
+    "namespace files": {
+      "toggle": {
+        "show": "Namespace फ़ाइलें दिखाएं",
+        "hide": "Namespace फ़ाइलें छिपाएं"
+      },
+      "filter": "फ़िल्टर",
+      "new_file": "नई फ़ाइल",
+      "no_items": {
+        "heading": "आपके namespace में अभी तक कोई फ़ाइलें नहीं मिली हैं।",
+        "paragraph": "फाइलें बनाने या आयात करने के लिए, अपने namespace में flows के बीच कोड साझा करें।"
+      },
+      "no_selection": {
+        "heading": "कोई फ़ाइल चयनित नहीं",
+        "description": "इसकी सामग्री देखने के लिए ट्री से एक फ़ाइल चुनें।"
+      },
+      "tree": {
+        "expand": "सभी फ़ोल्डर्स विस्तारित करें",
+        "collapse": "सभी फ़ोल्डर्स संक्षिप्त करें"
+      },
+      "create": {
+        "label": "बनाएँ",
+        "file": "फ़ाइल बनाएँ",
+        "file_already_exists": "इस नाम की एक फ़ाइल पहले से मौजूद है",
+        "file_conflicts_with_folder": "इस नाम का एक फ़ोल्डर पहले से मौजूद है",
+        "file_error": "फ़ाइल बनाते समय त्रुटि हुई",
+        "folder": "फ़ोल्डर बनाएँ",
+        "folder_already_exists": "इस नाम का एक फ़ोल्डर पहले से मौजूद है",
+        "folder_conflicts_with_file": "इस नाम की एक फ़ाइल पहले से मौजूद है",
+        "folder_error": "फ़ोल्डर बनाते समय त्रुटि हुई"
+      },
+      "rename": {
+        "label": "नाम बदलें",
+        "file": "फ़ाइल का नाम बदलें",
+        "folder": "फ़ोल्डर का नाम बदलें",
+        "new_file": "एक्सटेंशन के साथ नया नाम:",
+        "new_folder": "नए फ़ोल्डर का नाम:"
+      },
+      "delete": {
+        "label": "हटाएं",
+        "file": "फ़ाइल हटाएं",
+        "folder": "फ़ोल्डर हटाएं",
+        "files": "{count} चयनित फ़ाइलें हटाएं",
+        "folders": "{count} चयनित फ़ोल्डर हटाएं"
+      },
+      "import": {
+        "import": "आयात करें",
+        "files": "फ़ाइलें आयात करें",
+        "folder": "फ़ोल्डर आयात करें",
+        "success": "फ़ाइलें सफलतापूर्वक आयात की गईं",
+        "error": "फ़ाइलें आयात करते समय त्रुटि हुई"
+      },
+      "export": "Namespace फ़ाइलें निर्यात करें",
+      "export_single": "फ़ाइल निर्यात करें",
+      "dialog": {
+        "name": {
+          "file": "एक्सटेंशन के साथ नाम:",
+          "folder": "फ़ोल्डर का नाम:"
+        },
+        "parent_folder": "मूल फ़ोल्डर:",
+        "deletion": {
+          "confirm": "पुष्टि करें",
+          "title": "सामग्री को हटाने की पुष्टि करें",
+          "files": "क्या आप वाकई <code>{count}</code> फ़ाइल(फ़ाइलें) हटाना चाहते हैं?",
+          "folders": "क्या आप वाकई <code>{count}</code> फ़ोल्डर और उसकी सभी सामग्री को हटाना चाहते हैं?",
+          "mixed": "क्या आप वाकई <code>{folders}</code> फ़ोल्डर(ओं) और <code>{files}</code> फ़ाइल(ओं) को हटाना चाहते हैं?",
+          "file_single": "क्या आप वाकई <code>{name}</code> फ़ाइल को हटाना चाहते हैं?",
+          "folder_single": "क्या आप वाकई <code>{name}</code> फ़ोल्डर और इसकी सभी सामग्री को हटाना चाहते हैं?"
+        }
+      },
+      "revisions": {
+        "history": "संशोधन इतिहास",
+        "restore": {
+          "success": "फ़ाइल संशोधन सफलतापूर्वक पुनर्स्थापित किया गया"
+        }
+      },
+      "path": {
+        "copy": "पथ कॉपी करें",
+        "success": "पथ क्लिपबोर्ड पर कॉपी किया गया",
+        "error": "पथ को क्लिपबोर्ड पर कॉपी करते समय त्रुटि हुई"
+      }
+    },
+    "continue backfill": "Backfill जारी रखें",
+    "delete backfill": "Backfill हटाएं",
+    "pause backfill": "Backfill को रोकें",
+    "continue backfills": "Backfills जारी रखें",
+    "delete backfills": "Backfills हटाएं",
+    "pause backfills": "Backfills को रोकें",
+    "backfill executions": "Backfill निष्पादन",
+    "execute backfill": "Backfill निष्पादित करें",
+    "backfill paused": "Backfill PAUSED",
+    "backfill running": "Backfill चल रहा है",
+    "relative": "सापेक्ष",
+    "relative start date": "सापेक्ष प्रारंभ तिथि",
+    "relative end date": "सापेक्ष समाप्ति तिथि",
+    "now": "अब",
+    "absolute": "पूर्ण",
+    "backfill": "Backfill",
+    "Set labels tooltip": "निष्पादन के लिए लेबल्स सेट करें",
+    "Set labels": "लेबल्स सेट करें",
+    "manage labels": "labels प्रबंधित करें",
+    "Set labels to execution": "निष्पादन <code>{id}</code> के लेबल्स जोड़ें या अपडेट करें",
+    "Set labels done": "निष्पादन के लेबल्स सफलतापूर्वक सेट किए गए",
+    "bulk set labels": "क्या आप वाकई <code>{executionCount}</code> निष्पादन के लिए लेबल्स सेट करना चाहते हैं?",
+    "dependencies loaded": "निर्भरताएँ लोड की गईं",
+    "loaded x dependencies": "{count} निर्भरताएँ लोड की गईं",
+    "security_advice": {
+      "title": "अपनी instance की सुरक्षा करें",
+      "content": "अपनी instance की सुरक्षा के लिए बुनियादी प्रमाणीकरण सक्षम करें।",
+      "switch_text": "फिर से न दिखाएं",
+      "enable": "प्रमाणीकरण सक्षम करें"
+    },
+    "true": "सत्य",
+    "false": "असत्य",
+    "undefined": "अपरिभाषित",
+    "execution-include-non-terminated": "गैर-समाप्त निष्पादन शामिल करें?",
+    "execution-warn-title": "महत्वपूर्ण WARNING!",
+    "execution-warn-deleting-still-running": "हम दृढ़ता से अनुशंसा करते हैं कि आप इस क्रिया को रद्द करें और पहले किसी भी चल रही executions को समाप्त करें। गैर-समाप्त executions को हटाने से concurrency समस्याएँ, flow निर्भरता प्रबंधन असंगतताएँ, और आपके instance पर zombie प्रक्रियाएँ हो सकती हैं, जो सिस्टम प्रदर्शन को खराब कर सकती हैं। सुनिश्चित करें कि आप इन जोखिमों को पूरी तरह से समझते हैं, इससे पहले कि आप deletion के साथ आगे बढ़ें।",
+    "originalCreatedDate": "मूल निर्माण तिथि",
+    "welcome": {
+      "menu": "Welcome",
+      "tour": {
+        "title": "उत्पाद टूर लें",
+        "text": "अपना उपयोग मामला चुनें और Kestra की विशेषताओं और क्षमताओं को सीखने के लिए चरण-दर-चरण मार्गदर्शिका का पालन करें। ❤️"
+      },
+      "tutorial": {
+        "title": "ट्यूटोरियल",
+        "text": "* <a href=\"https://kestra.io/tutorial-videos/all?utm_source=app&utm_medium=referral&utm_campaign=welcome-tutorial\" target=\"_blank\">वीडियो ट्यूटोरियल्स</a>  \n* <a href=\"https://kestra.io/docs?utm_source=app&utm_medium=referral&utm_campaign=welcome-tutorial\" target=\"_blank\">दस्तावेज़ीकरण</a>  \n* <a href=\"https://kestra.io/blueprints?utm_source=app&utm_medium=referral&utm_campaign=welcome-tutorial\" target=\"_blank\">Blueprints</a>"
+      },
+      "help": {
+        "title": "मदद चाहिए?",
+        "text": "हमारे Slack समुदाय में कोई भी प्रश्न पूछें। यदि आप अटके हुए हैं, तो हम आपकी सहायता के लिए यहाँ हैं। ✋"
+      }
+    },
+    "pluginPage": {
+      "search": "{count}+ प्लगइन्स में खोजें",
+      "searchTasks": "{count} tasks खोजें",
+      "noResults": "आपकी खोज से कोई प्लगइन मेल नहीं खाता।",
+      "loadError": "प्लगइन्स लोड नहीं हो सके। कृपया पुनः प्रयास करें।",
+      "notFound": "यह प्लगइन नहीं मिला।",
+      "elementType": {
+        "tasks": "कार्य",
+        "triggers": "ट्रिगर",
+        "conditions": "शर्त",
+        "taskRunners": "टास्क रनर",
+        "charts": "चार्ट",
+        "apps": "ऐप",
+        "logExporters": "लॉग एक्सपोर्टर",
+        "secrets": "गुप्त"
+      },
+      "sortBy": "क्रमबद्ध करें",
+      "sort": {
+        "nameAsc": "नाम A-Z",
+        "nameDesc": "नाम Z-A",
+        "newest": "नवीनतम",
+        "mostUsed": "सबसे अधिक उपयोग किया गया"
+      },
+      "group": {
+        "plugins": "प्लगइन्स ({count})",
+        "tasks": "टास्क ({count})",
+        "blueprints": "ब्लूप्रिंट्स ({count})"
+      },
+      "overview": {
+        "title": "सारांश",
+        "versions": "संस्करण",
+        "latest": "नवीनतम",
+        "releaseNotes": "रिलीज़ नोट्स",
+        "previousVersions": "पिछले संस्करण",
+        "createdBy": "द्वारा निर्मित",
+        "managedBy": "द्वारा प्रबंधित",
+        "pluginType": "प्लगइन प्रकार",
+        "linksResources": "लिंक और संसाधन",
+        "minKestraVersion": "न्यूनतम संगत Kestra संस्करण: {version}",
+        "minKestraVersionShort": "न्यूनतम Kestra संस्करण {version}"
+      },
+      "header": {
+        "enterpriseEdition": "एंटरप्राइज एडिशन",
+        "certified": "प्रमाणित",
+        "back": "प्लगइन्स पर वापस जाएँ"
+      }
+    },
+    "no inputs": "इस flow में कोई इनपुट्स नहीं हैं।",
+    "admin_preferences": "Preferences",
     "settings": {
+      "label": "सेटिंग्स",
+      "updated": "{name} अपडेट किया गया",
       "blocks": {
         "configuration": {
-          "descriptions": {
-            "auto_refresh_interval": "सूची पृष्ठों पर स्वचालित डेटा ताज़ा करने के बीच सेकंड।",
-            "default_namespace": "नए flows को बिना namespace के बनाते समय उपयोग किया जाता है।",
-            "editor_type": "जब पहली बार किसी flow को खोलते हैं तो दिखाया गया संपादक।",
-            "execute_default_tab": "नेविगेशन के दौरान एक execution पर जाने पर चयनित Tab।",
-            "execute_flow": "ट्रिगर करने के बाद निष्पादन परिणाम कहाँ खुलते हैं।",
-            "flow_default_tab": "फ्लो पर नेविगेट करते समय चयनित टैब।",
-            "log_display": "जब एक execution खोला जाता है तो logs कैसे प्रस्तुत किए जाते हैं।",
-            "log_level": "न्यूनतम log स्तर जो execution logs में दिखाया गया है।",
-            "playground": "संपादक प्लेग्राउंड में व्यक्तिगत रूप से tasks चलाएं।",
-            "triggers_default_tab": "ट्रिगर्स पृष्ठ पर नेविगेट करते समय चयनित टैब।"
-          },
+          "label": "मुख्य कॉन्फ़िगरेशन",
           "fields": {
-            "auto_refresh_interval": "ऑटो रिफ्रेश अंतराल",
-            "default_namespace": "पूर्व-निर्धारित Namespace",
-            "editor_type": "डिफ़ॉल्ट एडिटर प्रकार",
-            "execute_default_tab": "डिफ़ॉल्ट Execution टैब",
-            "execute_flow": "Flow निष्पादित करें",
-            "flow_default_tab": "डिफ़ॉल्ट Flow टैब",
             "language": "भाषा",
-            "log_display": "Log प्रदर्शन",
+            "default_namespace": "पूर्व-निर्धारित Namespace",
             "log_level": "Log स्तर",
+            "log_display": "Log प्रदर्शन",
+            "editor_type": "डिफ़ॉल्ट एडिटर प्रकार",
+            "execute_flow": "Flow निष्पादित करें",
+            "execute_default_tab": "डिफ़ॉल्ट Execution टैब",
             "multi_panel_editor": "मल्टी पैनल एडिटर",
+            "flow_default_tab": "डिफ़ॉल्ट Flow टैब",
+            "triggers_default_tab": "डिफ़ॉल्ट Triggers टैब",
             "playground": "प्लेग्राउंड",
-            "triggers_default_tab": "डिफ़ॉल्ट Triggers टैब"
+            "auto_refresh_interval": "ऑटो रिफ्रेश अंतराल"
           },
-          "label": "मुख्य कॉन्फ़िगरेशन"
-        },
-        "export": {
-          "fields": {
-            "flows": "सभी Flows निर्यात करें",
-            "templates": "सभी templates निर्यात करें"
-          },
-          "label": "निर्यात करें"
-        },
-        "localization": {
           "descriptions": {
-            "date_format": "डैशबोर्ड में तारीखें प्रदर्शित करने के लिए उपयोग किया जाने वाला प्रारूप।",
-            "language": "मेनू और लेबल के लिए इंटरफ़ेस भाषा।",
-            "time_zone": "निष्पादन तिथियों और अनुसूचित triggers को प्रदर्शित करने के लिए उपयोग किया जाता है।"
-          },
-          "fields": {
-            "date_format": "दिनांक प्रारूप",
-            "time_zone": "समय क्षेत्र"
-          },
-          "label": "भाषा और क्षेत्र",
-          "note": "ध्यान दें कि यह सेटिंग UI में दिनांक और समय गुणों को प्रदर्शित करने के लिए उपयोग की जाती है। अपने flows को UTC से अलग समय क्षेत्र में शेड्यूल करने के लिए, सुनिश्चित करें कि आपने अपने flow कोड में या अपने प्लगइन डिफ़ॉल्ट्स में Schedule Trigger पर समय क्षेत्र गुण सेट किया है।"
-        },
-        "reset_section_to_defaults": "इस अनुभाग के डिफ़ॉल्ट मान पुनर्स्थापित करें",
-        "save": {
-          "discard": "रद्द करें",
-          "label": "प्राथमिकताएँ सहेजें",
-          "unsaved_title": "असहेजित परिवर्तन",
-          "unsaved_warning": "आपके पास बिना सहेजे गए परिवर्तन हैं। क्या आप उन्हें छोड़ने से पहले सहेजना चाहते हैं?"
-        },
-        "sidebar": {
-          "descriptions": {
-            "items": "साइडबार में आइटम दिखाएं, छुपाएं, और पुनः क्रमबद्ध करें।"
-          },
-          "fields": {
-            "items": "नेविगेशन आइटम्स"
-          },
-          "label": "साइडबार"
+            "default_namespace": "नए flows को बिना namespace के बनाते समय उपयोग किया जाता है।",
+            "log_level": "न्यूनतम log स्तर जो execution logs में दिखाया गया है।",
+            "log_display": "जब एक execution खोला जाता है तो logs कैसे प्रस्तुत किए जाते हैं।",
+            "editor_type": "जब पहली बार किसी flow को खोलते हैं तो दिखाया गया संपादक।",
+            "execute_flow": "ट्रिगर करने के बाद निष्पादन परिणाम कहाँ खुलते हैं।",
+            "execute_default_tab": "नेविगेशन के दौरान एक execution पर जाने पर चयनित Tab।",
+            "flow_default_tab": "फ्लो पर नेविगेट करते समय चयनित टैब।",
+            "triggers_default_tab": "ट्रिगर्स पृष्ठ पर नेविगेट करते समय चयनित टैब।",
+            "auto_refresh_interval": "सूची पृष्ठों पर स्वचालित डेटा ताज़ा करने के बीच सेकंड।",
+            "playground": "संपादक प्लेग्राउंड में व्यक्तिगत रूप से tasks चलाएं।"
+          }
         },
         "theme": {
-          "app_font_size_options": {
-            "large": "बड़ा",
-            "medium": "मध्यम",
-            "small": "छोटा"
-          },
-          "color_modes": {
-            "dark_1": "डार्क 1.0",
-            "dark_2": "डार्क 2.0",
-            "light": "लाइट",
-            "sync": "सिस्टम के साथ सिंक करें"
-          },
-          "confirmations": {
-            "color_mode": "आपका इंटरफेस अब `{mode}` थीम का उपयोग कर रहा है।"
-          },
-          "descriptions": {
-            "app_font_size": "इंटरफ़ेस के सभी फ़ॉन्ट आकारों पर लागू स्केल कारक।",
-            "color_mode": "अपना पसंदीदा इंटरफेस थीम चुनें।",
-            "color_mode_shortcut": "सुझाव: कहीं से भी थीम बदलने के लिए <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>L</kbd> दबाएं।",
-            "editor_folding_stratgy": "फ्लो खोलते समय लंबे YAML ब्लॉक्स को डिफ़ॉल्ट रूप से संक्षिप्त करें।",
-            "editor_font_family": "YAML संपादक में प्रयुक्त मोनोस्पेस फ़ॉन्ट।",
-            "editor_font_size": "YAML और no-code संपादकों में उपयोग किया गया फ़ॉन्ट आकार।",
-            "editor_hover_description": "संपादक में होवर पर प्रॉपर्टी विवरण दिखाएं।",
-            "environment_color": "नेविगेशन में वर्तमान वातावरण के लिए उपयोग किया गया एक्सेंट रंग।",
-            "environment_name": "वर्तमान वातावरण के लिए प्रदर्शन नाम, जो नेविगेशन में दिखाया जाता है।",
-            "logs_font_size": "लॉग व्यूअर्स और टर्मिनल्स में उपयोग किया जाने वाला फ़ॉन्ट आकार।"
-          },
+          "label": "थीम प्राथमिकताएँ",
           "fields": {
             "app_font_size": "ऐप फ़ॉन्ट आकार",
             "chart_color_scheme": {
+              "label": "चार्ट रंग योजना",
               "classic": "क्लासिक",
-              "kestra": "Kestra",
-              "label": "चार्ट रंग योजना"
+              "kestra": "Kestra"
             },
             "color_mode": "रंग मोड",
             "editor_folding_stratgy": "संपादक में स्वचालित कोड फोल्डिंग",
@@ -1850,24 +1066,867 @@
             "logs_font_size": "लॉग्स फ़ॉन्ट आकार",
             "theme": "मोडस"
           },
-          "label": "थीम प्राथमिकताएँ"
+          "color_modes": {
+            "dark_2": "डार्क 2.0",
+            "dark_1": "डार्क 1.0",
+            "light": "लाइट",
+            "sync": "सिस्टम के साथ सिंक करें"
+          },
+          "confirmations": {
+            "color_mode": "आपका इंटरफेस अब `{mode}` थीम का उपयोग कर रहा है।"
+          },
+          "descriptions": {
+            "color_mode": "अपना पसंदीदा इंटरफेस थीम चुनें।",
+            "color_mode_shortcut": "सुझाव: कहीं से भी थीम बदलने के लिए <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>L</kbd> दबाएं।",
+            "logs_font_size": "लॉग व्यूअर्स और टर्मिनल्स में उपयोग किया जाने वाला फ़ॉन्ट आकार।",
+            "editor_font_family": "YAML संपादक में प्रयुक्त मोनोस्पेस फ़ॉन्ट।",
+            "editor_font_size": "YAML और no-code संपादकों में उपयोग किया गया फ़ॉन्ट आकार।",
+            "editor_folding_stratgy": "फ्लो खोलते समय लंबे YAML ब्लॉक्स को डिफ़ॉल्ट रूप से संक्षिप्त करें।",
+            "editor_hover_description": "संपादक में होवर पर प्रॉपर्टी विवरण दिखाएं।",
+            "environment_name": "वर्तमान वातावरण के लिए प्रदर्शन नाम, जो नेविगेशन में दिखाया जाता है।",
+            "environment_color": "नेविगेशन में वर्तमान वातावरण के लिए उपयोग किया गया एक्सेंट रंग।",
+            "app_font_size": "इंटरफ़ेस के सभी फ़ॉन्ट आकारों पर लागू स्केल कारक।"
+          },
+          "app_font_size_options": {
+            "small": "छोटा",
+            "medium": "मध्यम",
+            "large": "बड़ा"
+          }
+        },
+        "localization": {
+          "label": "भाषा और क्षेत्र",
+          "note": "ध्यान दें कि यह सेटिंग UI में दिनांक और समय गुणों को प्रदर्शित करने के लिए उपयोग की जाती है। अपने flows को UTC से अलग समय क्षेत्र में शेड्यूल करने के लिए, सुनिश्चित करें कि आपने अपने flow कोड में या अपने प्लगइन डिफ़ॉल्ट्स में Schedule Trigger पर समय क्षेत्र गुण सेट किया है।",
+          "fields": {
+            "time_zone": "समय क्षेत्र",
+            "date_format": "दिनांक प्रारूप"
+          },
+          "descriptions": {
+            "language": "मेनू और लेबल के लिए इंटरफ़ेस भाषा।",
+            "time_zone": "निष्पादन तिथियों और अनुसूचित triggers को प्रदर्शित करने के लिए उपयोग किया जाता है।",
+            "date_format": "डैशबोर्ड में तारीखें प्रदर्शित करने के लिए उपयोग किया जाने वाला प्रारूप।"
+          }
+        },
+        "export": {
+          "label": "निर्यात करें",
+          "fields": {
+            "flows": "सभी Flows निर्यात करें",
+            "templates": "सभी templates निर्यात करें"
+          }
+        },
+        "save": {
+          "label": "प्राथमिकताएँ सहेजें",
+          "discard": "रद्द करें",
+          "unsaved_title": "असहेजित परिवर्तन",
+          "unsaved_warning": "आपके पास बिना सहेजे गए परिवर्तन हैं। क्या आप उन्हें छोड़ने से पहले सहेजना चाहते हैं?"
+        },
+        "reset_section_to_defaults": "इस अनुभाग के डिफ़ॉल्ट मान पुनर्स्थापित करें",
+        "sidebar": {
+          "label": "साइडबार",
+          "fields": {
+            "items": "नेविगेशन आइटम्स"
+          },
+          "descriptions": {
+            "items": "साइडबार में आइटम दिखाएं, छुपाएं, और पुनः क्रमबद्ध करें।"
+          }
+        }
+      }
+    },
+    "apps": "ऐप्स",
+    "demos": {
+      "enterprise_edition": "एंटरप्राइज एडिशन",
+      "get_a_demo_button": "डेमो प्राप्त करें",
+      "contact_sales": "सेल्स से संपर्क करें",
+      "watch_the_video": "वीडियो देखें",
+      "secrets": {
+        "title": "अपने Secrets Management को अपग्रेड करें",
+        "message": "एंटरप्राइज एडिशन (EE) आपको UI में सीधे secrets जोड़ने, संपादित करने या हटाने की अनुमति देता है—कोई instance पुनरारंभ की आवश्यकता नहीं है। secrets को namespace द्वारा संगठित करें, जिसमें सूक्ष्म RBAC अनुमतियाँ हों, और उन्हें parent से child namespaces में विरासत में लें। EE HashiCorp Vault, AWS Secrets Manager, Azure Key Vault, Google Secret Manager, और Elasticsearch जैसे secrets प्रबंधकों के साथ एकीकृत होता है। टीमों के बीच secrets को अलग करने के लिए namespace, tenant, या instance के अनुसार समर्पित बैकएंड सेट करें, या बाहरी vaults में संग्रहीत read-only secrets को सक्षम करें। secrets को आराम और ट्रांजिट में एन्क्रिप्टेड रखा जाता है। वैकल्पिक caching API कॉल्स को कम करता है, और audit trails सभी एक्सेस को log करते हैं।",
+        "detected_env": "यहाँ instance start-time पर पहचाने गए secret-type environment variables हैं:",
+        "empty_env": "आपके वातावरण में अभी तक कोई Secrets नहीं हैं।",
+        "add_env": {
+          "intro": "नया Secret बनाने के लिए:",
+          "first": "<a href=\"https://kestra.io/docs/how-to-guides/secrets?utm_source=app&utm_medium=referral&utm_campaign=secrets-inlinedoc#using-secrets-in-kestra\" target=\"_blank\">गुप्त मान को Base64 में एन्कोड करें</a>",
+          "second": "'<strong>SECRET_{'{MY_SECRET_KEY}'}</strong>' नामक एक environment variable जोड़ें उपरोक्त value के साथ",
+          "third": "अपने Kestra instance को पुनः प्रारंभ करें"
         }
       },
-      "label": "सेटिंग्स",
-      "updated": "{name} अपडेट किया गया"
+      "apps": {
+        "title": "Kestra के साथ कस्टम ऐप्स बनाएं",
+        "message": "Kestra एंटरप्राइज एडिशन में ऐप्स आपको कस्टम UI बनाने की अनुमति देते हैं जो प्लेटफ़ॉर्म के बाहर से Kestra वर्कफ़्लोज़ के साथ इंटरैक्ट करते हैं। यह फीचर आपको अपने वर्कफ़्लोज़ को कस्टम एप्लिकेशनों के लिए बैकएंड के रूप में उपयोग करने देता है, जिससे गैर-तकनीकी उपयोगकर्ता फॉर्म के माध्यम से डेटा सबमिट कर सकते हैं या अप्रूवल की प्रतीक्षा कर रहे PAUSED वर्कफ़्लोज़ को फिर से शुरू कर सकते हैं।"
+      },
+      "tests": {
+        "label": "टेस्ट्स",
+        "header": "फ्लो के लिए यूनिट टेस्ट्स",
+        "title": "हर परिवर्तन के साथ विश्वसनीयता सुनिश्चित करें",
+        "message": "अपने flows की लॉजिक को अलग-अलग सत्यापित करें, जल्दी से रिग्रेशन का पता लगाएं, और जैसे-जैसे आपके ऑटोमेशन बदलते और बढ़ते हैं, उन पर विश्वास बनाए रखें।"
+      },
+      "assets": {
+        "label": "संपत्तियाँ",
+        "header": "संपत्तियों का मेटाडेटा और अवलोकनीयता",
+        "title": "हर dataset, सेवा, और निर्भरता को दृश्य में लाएं।",
+        "message": "एसेट्स अवलोकन, वंशावली, और स्वामित्व मेटाडेटा को जोड़ते हैं ताकि प्लेटफ़ॉर्म टीमें तेजी से समस्या निवारण कर सकें और आत्मविश्वास के साथ परिनियोजन कर सकें।"
+      },
+      "IAM": {
+        "title": "IAM के माध्यम से SSO, SCIM और RBAC के साथ उपयोगकर्ताओं का प्रबंधन करें।",
+        "message": "Kestra एंटरप्राइज एडिशन में IAM क्षमताएँ अंतर्निहित हैं, जिसमें सिंगल साइन-ऑन (SSO), SCIM डायरेक्टरी सिंक और रोल-आधारित एक्सेस कंट्रोल (RBAC) शामिल हैं। यह कई पहचान प्रदाताओं के साथ एकीकृत होता है और आपको उपयोगकर्ताओं और सेवा खातों के लिए सूक्ष्म अनुमतियाँ असाइन करने की अनुमति देता है।"
+      },
+      "tenants": {
+        "title": "अलग-अलग Tenants में Workflows प्रबंधित करें",
+        "message": "Kestra एंटरप्राइज एडिशन मल्टी-टेनेंसी का समर्थन करता है, जो आपको विभिन्न टीमों या परियोजनाओं के लिए पूरी तरह से अलग वातावरण प्रदान करता है, जिनमें से प्रत्येक के पास अपने स्वयं के संसाधन होते हैं जैसे कि समर्पित worker समूह या secrets और आंतरिक storage backends।"
+      },
+      "audit-logs": {
+        "title": "परिवर्तनों को ट्रैक करें Audit Logs के साथ",
+        "message": "Kestra Enterprise Edition हर गतिविधि को मजबूत, अपरिवर्तनीय रिकॉर्ड के साथ लॉग करता है, जिससे परिवर्तनों को ट्रैक करना, अनुपालन बनाए रखना और समस्याओं का समाधान करना आसान हो जाता है।"
+      },
+      "quotas": {
+        "title": "Flows पर निष्पादन कोटा लागू करें",
+        "message": "Kestra Enterprise Edition आपको flows पर कोटा परिभाषित करने देता है जो एक समय विंडो के भीतर समवर्ती या कुल निष्पादन की संख्या को सीमित करता है। कोटा आपको साझा बुनियादी ढांचे की रक्षा करने, SLAs लागू करने और अत्यधिक संसाधन खपत करने वाले workflows को रोकने में मदद करते हैं।"
+      },
+      "instance": {
+        "title": "अपने इंस्टेंस के पार Infrastructure प्रबंधित करें",
+        "message": "Kestra Enterprise Edition आपके प्लेटफ़ॉर्म के स्वास्थ्य का अवलोकन करने और सभी सेवाओं जैसे कि Workers, Schedulers, और Executors की अपटाइम मेट्रिक्स को ट्रैक करने के लिए एक ऑपरेशनल डैशबोर्ड प्रदान करता है। इसी पृष्ठ से, आप अपने उपयोगकर्ताओं को नियोजित डाउनटाइम के बारे में सूचित करने के लिए Announcements भी बना सकते हैं, और आप एक maintenance mode में प्रवेश कर सकते हैं जो अस्थायी रूप से सभी सेवाओं और workflow executions को एक PAUSED स्थिति में डाल देता है ताकि एक अपग्रेड किया जा सके।"
+      },
+      "blueprints": {
+        "title": "कस्टम Blueprints जोड़ें",
+        "message": "Kestra एंटरप्राइज एडिशन में, आप अपनी संस्था के लिए केवल उपलब्ध कस्टम Blueprints बना सकते हैं। आप इन्हें अपनी टीम में साझा करने, केंद्रीकृत करने और सामान्य रूप से उपयोग किए जाने वाले workflows को दस्तावेज़ करने के लिए सर्वोत्तम-प्रथाओं के टेम्पलेट के रूप में उपयोग कर सकते हैं।"
+      },
+      "namespace": {
+        "edit": {
+          "title": "अपने Namespace प्रबंधन को अपग्रेड करें",
+          "message": "Kestra एंटरप्राइज एडिशन में, namespaces बड़े पैमाने पर secrets, variables और plugin डिफ़ॉल्ट्स के उन्नत अलगाव और शासन प्रदान करते हैं। प्रशासक कस्टम secrets प्रबंधकों, अलग storage बैकएंड्स, समर्पित worker समूहों, और प्रति-namespace आधार पर सूक्ष्म अनुमतियाँ कॉन्फ़िगर कर सकते हैं। यह सुनिश्चित करता है कि secrets, variables और plugin कॉन्फ़िगरेशन विभिन्न टीमों और परियोजनाओं में सुरक्षित और बनाए रखने में आसान रहें।"
+        },
+        "secrets": {
+          "title": "सुरक्षित तरीके से Secrets प्रबंधित करें",
+          "message": "Kestra एंटरप्राइज एडिशन में, आप secrets को namespace स्तर पर संग्रहीत और नियंत्रित कर सकते हैं, जिससे जोखिम कम होता है और प्रत्येक टीम की credentials अलग रहती हैं। nested hierarchy के कारण, आप एक parent namespace में credentials को कॉन्फ़िगर कर सकते हैं और वे सभी child namespaces द्वारा विरासत में प्राप्त हो जाएंगे। समर्पित secrets managers और सूक्ष्म namespace-स्तरीय अनुमति सेटिंग्स के लिए समर्थन सुरक्षा और अनुपालन को और मजबूत करता है।"
+        },
+        "assets": {
+          "title": "संपत्ति प्रबंधन को केंद्रीकृत करें",
+          "message": "Kestra एंटरप्राइज एडिशन में, Assets आपके workflows के साथ इंटरैक्ट करने वाले संसाधनों की लाइव इन्वेंट्री रखता है। ये संसाधन डेटाबेस टेबल, वर्चुअल मशीन, फाइलें, या कोई भी बाहरी सिस्टम हो सकते हैं जिनके साथ आप काम करते हैं।"
+        },
+        "variables": {
+          "title": "अपने वेरिएबल्स को केंद्रीय रूप से प्रबंधित करें",
+          "message": "Kestra Enterprise Edition में, आप namespace-स्तर के वेरिएबल्स को परिभाषित और प्रबंधित कर सकते हैं ताकि flows में दोहराव वाली कॉन्फ़िगरेशन को समाप्त किया जा सके। ये वेरिएबल्स स्थिरता सुनिश्चित करते हैं, कॉन्फ़िगरेशन अपडेट को सरल बनाते हैं, और किसी भी task या trigger द्वारा आसानी से संदर्भित किए जा सकते हैं, जिससे workflows को अधिक साफ और बनाए रखने योग्य बनाया जा सके।"
+        },
+        "plugin-defaults": {
+          "title": "प्लगइन डिफॉल्ट्स के साथ कॉन्फ़िगरेशन को मानकीकृत करें",
+          "message": "Kestra एंटरप्राइज एडिशन में, आप namespace-विशिष्ट प्लगइन डिफ़ॉल्ट सेट कर सकते हैं, जिससे प्रत्येक flow में डुप्लिकेट सेटअप की आवश्यकता कम हो जाती है। यह केंद्रीय प्लगइन गवर्नेंस सुसंगत कॉन्फ़िगरेशन को लागू करता है, गुप्त या वेरिएबल्स के सुरक्षित संदर्भ की अनुमति देता है, और आपके workflows के रखरखाव को सरल बनाता है।"
+        },
+        "history": {
+          "title": "एक ही स्थान पर Revision History प्रबंधित करें",
+          "message": "Kestra एंटरप्राइज एडिशन में, आप अपने Namespaces के संशोधन इतिहास का प्रबंधन कर सकते हैं।"
+        },
+        "audit-logs": {
+          "title": "सभी परिवर्तनों को एक स्थान पर ट्रैक करें",
+          "message": "Kestra एंटरप्राइज एडिशन में, आप namespace-स्तर के ऑडिट logs को विस्तृत अंतर के साथ देख सकते हैं, जो आपको सभी संसाधनों में किसने क्या और कब बदला, इसका स्पष्ट इतिहास प्रदान करता है।"
+        }
+      }
+    },
+    "assets": {
+      "title": "संपत्तियाँ"
+    },
+    "onboarding": {
+      "welcome": {
+        "headline": "कुछ ही मिनटों में अपना पहला वर्कफ़्लो बनाएँ और चलाएँ",
+        "guided_title": "अपना पहला फ्लो बनाएँ",
+        "badge": "ट्यूटोरियल",
+        "guided_description": "निर्देशित चरणों के साथ अपना पहला फ्लो बनाना और चलाना सीखें।",
+        "guided_duration": "अधिकांश उपयोगकर्ताओं के लिए अनुशंसित",
+        "self_serve_title": "शुरुआत से फ्लो बनाएँ",
+        "self_serve_description": "सीधे एडिटर पर जाएँ और अपना स्वयं का फ्लो बनाएँ।",
+        "self_serve_note": "अनुभवी उपयोगकर्ताओं के लिए",
+        "additional_help": "अतिरिक्त सहायता",
+        "docs": "प्रलेखन",
+        "tutorial": "ट्यूटोरियल",
+        "blueprints": "ब्लूप्रिंट्स",
+        "slack": "स्लैक समुदाय"
+      },
+      "steps": {
+        "flow_basics": {
+          "title": "फ्लो की मूल बातें",
+          "description": "Kestra में, एक <code>flow</code> मुख्य ऑर्केस्ट्रेशन इकाई है। आप इसे YAML में मेटाडेटा और क्रमबद्ध टास्क्स के साथ परिभाषित करते हैं।<br><br>नीचे दिए गए उदाहरण संरचना की समीक्षा करें, फिर इसे चरण-दर-चरण बनाना जारी रखें।"
+        },
+        "add_id": {
+          "title": "फ्लो ID जोड़ें",
+          "description": "ID आपके फ्लो का अद्वितीय नाम है, ताकि आप इसे खोज सकें, चला सकें और लगातार संदर्भित कर सकें।<br><br>अब रूट स्तर पर <code>id</code> जोड़ें।"
+        },
+        "add_namespace": {
+          "title": "नेमस्पेस जोड़ें",
+          "description": "Namespace एक फ़ोल्डर-जैसा समूह है जो फ्लो को टीम, प्रोजेक्ट या वातावरण के अनुसार व्यवस्थित करता है।<br><br>अब रूट स्तर पर <code>namespace</code> जोड़ें।"
+        },
+        "add_input": {
+          "title": "एक इनपुट जोड़ें",
+          "description": "Inputs फ्लो-स्तरीय पैरामीटर हैं जिन्हें टास्क्स के अंदर संदर्भित किया जा सकता है ताकि रनटाइम पर व्यवहार को गतिशील रूप से नियंत्रित किया जा सके।<br><br>अब <code>name</code> नाम का एक इनपुट <code>STRING</code> प्रकार के साथ जोड़ें।"
+        },
+        "add_log_task": {
+          "title": "पहला टास्क जोड़ें",
+          "description": "Tasks वे कार्य इकाइयाँ हैं जिन्हें आपका फ्लो निष्पादित करता है, जिन्हें क्रमबद्ध चरणों की सूची के रूप में परिभाषित किया जाता है। प्रत्येक टास्क के लिए एक अद्वितीय <code>id</code> और एक <code>type</code> आवश्यक है। Kestra बाहरी प्रणालियों के लिए कई टास्क प्लगइन्स प्रदान करता है; यहाँ हम एक Python Script टास्क का उपयोग करते हैं।<br><br><code>&#123;&#123; ... &#125;&#125;</code> सिंटैक्स एक Pebble अभिव्यक्ति है, जिसका उपयोग रनटाइम पर वेरिएबल्स को गतिशील रूप से संदर्भित करने के लिए किया जाता है, जैसे <code>&#123;&#123; inputs.name &#125;&#125;</code> आपके फ्लो इनपुट्स से।<br><br>अब <code>tasks</code> के अंतर्गत पहला टास्क जोड़ें, जिसमें <code>id</code>, <code>type</code>, और एक <code>script</code> हो जो एक अभिवादन प्रिंट करे।"
+        },
+        "save_flow": {
+          "title": "फ्लो सहेजें",
+          "description": "सहेजने से आपकी फ्लो परिभाषा सुरक्षित हो जाती है ताकि इसे निष्पादित किया जा सके।"
+        },
+        "execute_flow": {
+          "title": "फ्लो निष्पादित करें",
+          "description": "निष्पादन आपके फ्लो का एक रन प्रारंभ करता है, जिसमें रनटाइम इनपुट मान शामिल होते हैं।"
+        },
+        "view_logs_status": {
+          "title": "निष्पादन जाँचें",
+          "description": "निष्पादन विवरण रन की स्थिति, समय और टास्क-स्तरीय आउटपुट लॉग दिखाते हैं।<br><br>अब निष्पादन विवरण खोलें और लॉग देखने के लिए Gantt चार्ट में <code>greet</code> पर क्लिक करें।"
+        },
+        "edit_flow_from_execution": {
+          "title": "फ्लो एडिटर पर वापस जाएँ",
+          "description": "आप तेज़ी से पुनरावृत्ति करने के लिए सीधे किसी निष्पादन से फ्लो परिभाषा पर वापस जा सकते हैं।"
+        },
+        "add_cron_trigger": {
+          "title": "एक क्रॉन ट्रिगर जोड़ें",
+          "description": "Triggers शेड्यूल या बाहरी घटनाओं (जैसे वेबहुक या MQTT संदेश) के आधार पर रन शुरू कर सकते हैं।<br><br>अब एक क्रॉन शेड्यूल ट्रिगर जोड़ें ताकि यह फ्लो हर 5 मिनट में चले।"
+        },
+        "add_input_default": {
+          "title": "इनपुट के लिए डिफ़ॉल्ट मान सेट करें",
+          "description": "जब कोई फ्लो स्वचालित रूप से ट्रिगर होता है, तब भी रनटाइम पर इनपुट मानों की आवश्यकता होती है।<br><br><code>name</code> इनपुट पहले ही पिछले चरण में बनाया जा चुका है, इसलिए इसे फिर से जोड़ने की आवश्यकता नहीं है। केवल मौजूदा <code>name</code> इनपुट के लिए एक डिफ़ॉल्ट मान सेट करें।"
+        },
+        "save_flow_again": {
+          "title": "फ्लो सहेजें",
+          "description": "अब आपके फ्लो में स्वचालित रन के लिए एक शेड्यूल और एक डिफ़ॉल्ट इनपुट मान है।"
+        },
+        "background_runs_info": {
+          "title": "निर्धारित रन",
+          "description": "यह फ्लो अब हर 5 मिनट में बैकग्राउंड में निष्पादित होगा।<br><br>निर्धारित रनों की निगरानी के लिए आप बाएँ मेनू से Executions ओवरव्यू पर जा सकते हैं।"
+        },
+        "finish": {
+          "title": "आपने पहला फ्लो ट्यूटोरियल पूरा कर लिया है",
+          "description": "शानदार शुरुआत। आपने एक फ्लो बनाया, निष्पादित किया, पैरामीटराइज़ किया और शेड्यूल किया।<br><br>अब चुनें कि आप आगे क्या करना चाहते हैं ..."
+        }
+      },
+      "actions": {
+        "next": "अगला",
+        "complete": "पूर्ण करें",
+        "save_to_continue": "जारी रखने के लिए ऊपर दाईं ओर Save दबाएँ।",
+        "execute_to_continue": "1. ऊपर दाईं ओर Execute दबाएँ।\n2. <strong>name</strong> के लिए एक मान प्रदान करें।\n3. मोडल में फिर से Execute दबाएँ।",
+        "edit_flow_to_continue": "ऊपर दाईं ओर Edit flow दबाएँ।",
+        "cancel_tutorial": "ट्यूटोरियल रद्द करें",
+        "finish_tutorial": "ट्यूटोरियल समाप्त करें"
+      },
+      "finish_actions": {
+        "explore_blueprints": "ब्लूप्रिंट्स देखें",
+        "create_flow": "फ्लो बनाएँ"
+      },
+      "editor_hints": {
+        "build_intro": "अपना पहला फ्लो चरण-दर-चरण बनाएँ।",
+        "step_1": "# 1) id जोड़ें",
+        "step_2": "# 2) namespace जोड़ें",
+        "step_3": "# 3) एक इनपुट जोड़ें",
+        "step_4": "# 4) टास्क्स जोड़ें और अपना पहला Python टास्क बनाएँ",
+        "step_5": "# 5) एक क्रॉन ट्रिगर जोड़ें"
+      },
+      "cancel_modal": {
+        "title": "पहला फ्लो ट्यूटोरियल रद्द करें",
+        "description": "क्या आप पहला फ्लो ट्यूटोरियल रद्द करना चाहते हैं?",
+        "confirm": "ट्यूटोरियल रद्द करें",
+        "keep": "ट्यूटोरियल जारी रखें"
+      },
+      "validation": {
+        "complete_step": "आप करीब हैं। आगे बढ़ने के लिए यह चरण पूरा करें।",
+        "fix_yaml": "YAML फॉर्मेट में एक छोटी समस्या है। इसे ठीक करें और फिर जारी रखें।",
+        "add_id": "ऊपर एक फ्लो ID जोड़ें। उदाहरण: `id: hello_flow`।",
+        "add_namespace": "ऊपर एक namespace जोड़ें। उदाहरण: `namespace: company.team`।",
+        "add_input_section": "`inputs` सेक्शन बनाएँ जिसमें एक इनपुट हो।",
+        "add_input_id": "`inputs` के अंदर `id: name` जोड़ें।",
+        "add_input_type": "इनपुट प्रकार को `STRING` पर सेट करें।",
+        "add_log_task_section": "`tasks` सेक्शन बनाएँ और अपना पहला टास्क जोड़ें।",
+        "add_log_task_id": "टास्क को एक ID दें, उदाहरण: `id: greet`।",
+        "add_log_task_type": "टास्क प्रकार को `io.kestra.plugin.scripts.python.Script` पर सेट करें।",
+        "add_log_task_message": "टास्क में एक `script` फ़ील्ड जोड़ें।",
+        "add_log_task_pebble": "स्क्रिप्ट में Pebble अभिव्यक्ति का उपयोग करें ताकि यह आपके इनपुट मान का उपयोग करे (उदाहरण: `inputs.name`)।",
+        "save_flow": "जारी रखने के लिए Save पर क्लिक करें।",
+        "execute_flow": "जारी रखने के लिए फ्लो को एक बार चलाएँ।",
+        "view_logs_status": "निष्पादन विवरण खोलें और `greet` के लॉग जाँचें।",
+        "edit_flow_from_execution": "जारी रखने के लिए ऊपर बार में `Edit flow` पर क्लिक करें।",
+        "add_cron_trigger_section": "`triggers` सेक्शन बनाएँ और एक schedule ट्रिगर जोड़ें।",
+        "add_cron_trigger_type": "ट्रिगर प्रकार को `io.kestra.plugin.core.trigger.Schedule` पर सेट करें।",
+        "add_cron_trigger_cron": "एक cron अभिव्यक्ति जोड़ें, उदाहरण: `\"*/5 * * * *\"`।",
+        "add_input_default_section": "`inputs` पर वापस जाएँ और `name` नाम का एक मौजूदा इनपुट रखें (दूसरा इनपुट न जोड़ें)।",
+        "add_input_default_id": "मौजूदा इनपुट ID को `name` ही रखें।",
+        "add_input_default_defaults": "`name` के लिए एक डिफ़ॉल्ट मान जोड़ें, उदाहरण: `defaults: \"Kestra\"`।",
+        "save_flow_again": "जारी रखने के लिए फिर से Save पर क्लिक करें।"
+      }
+    },
+    "enable concurrency": "concurrency सक्षम करें",
+    "auditlogs": "Audit Logs",
+    "quotas": "कोटा",
+    "iam": "IAM",
+    "tenant": {
+      "name": "मंडल",
+      "names": "मंडल"
+    },
+    "ee-tooltip": {
+      "features-blocked": "यह सुविधा के लिए Enterprise Edition आवश्यक है।",
+      "button": "हमसे बात करें"
+    },
+    "flow_only": "केवल Flow टैब पर उपलब्ध है।",
+    "bulk action async warning": "यह कुछ क्षणों का समय ले सकता है।",
+    "bulk unpause backfills": "{count} backfill को अनपॉज़ करें",
+    "bulk pause backfills": "{count} backfill को पॉज़ करें",
+    "bulk delete backfills": "{count} backfill को हटाएं",
+    "bulk unlock": "{count} triggers को अनलॉक करें",
+    "bulk disabled status": {
+      "true": "{count} triggers को अक्षम करें",
+      "false": "{count} triggers को सक्षम करें"
+    },
+    "unlock": "अनलॉक करें",
+    "bulk success unpause backfills": "{count} backfills अनपॉज़ किए गए",
+    "bulk success pause backfills": "{count} backfills पॉज़ किए गए",
+    "bulk success delete backfills": "{count} backfills हटाए गए",
+    "bulk success unlock": "{count} triggers अनलॉक किए गए",
+    "bulk success disabled status": {
+      "true": "{count} trigger(s) अक्षम किए गए",
+      "false": "{count} trigger(s) सक्षम किए गए"
+    },
+    "no_namespaces": "कोई भी namespaces खोज मानदंड से मेल नहीं खाते।",
+    "system_namespace": "अपने प्लेटफ़ॉर्म को सिस्टम flows के साथ नियंत्रण में रखें।",
+    "system_namespace_description": "रखरखाव के tasks को स्वचालित करें, failure alerts से लेकर automated cleanups तक।",
+    "pluginDefaults": {
+      "title": "प्लगइन डिफॉल्ट्स",
+      "add": "प्लगइन डिफ़ॉल्ट जोड़ें",
+      "edit": "प्लगइन डिफ़ॉल्ट संपादित करें",
+      "add_subtitle": "इसके गुणों के साथ एक नया प्लगइन डिफ़ॉल्ट कॉन्फ़िगर करें",
+      "edit_subtitle": "मौजूदा प्लगइन डिफ़ॉल्ट कॉन्फ़िगरेशन को संशोधित करें",
+      "predefined": "पूर्वनिर्धारित प्लगइन",
+      "custom": "कस्टम प्लगइन",
+      "form": "फॉर्म",
+      "yaml": "YAML",
+      "select_predefined": "पूर्वनिर्धारित प्लगइन चुनें",
+      "cancel": "रद्द करें",
+      "update": "प्लगइन डिफ़ॉल्ट अपडेट करें",
+      "custom_type": "कस्टम प्लगइन प्रकार",
+      "custom_placeholder": "प्लगइन प्रकार दर्ज करें",
+      "use_custom": "कस्टम उपयोग करें",
+      "custom_configure": "कस्टम प्लगइन प्रकार - YAML का उपयोग करके कॉन्फ़िगर करें",
+      "yaml_configuration": "YAML कॉन्फ़िगरेशन",
+      "show_yaml": "YAML दिखाएं"
+    },
+    "secret": {
+      "add": "बनाएं",
+      "update": "गुप्त जानकारी '{name}' अपडेट करें",
+      "isReadOnly": "सीक्रेट केवल पढ़ने के लिए है",
+      "names": "Secrets",
+      "inherited": "Inherited secrets"
+    },
+    "workerId": "Worker Id",
+    "kv": {
+      "name": "KV Store",
+      "type": "प्रकार",
+      "add": "बनाएँ",
+      "update": "key '{key}' के लिए value अपडेट करें",
+      "duplicate": "यह key पहले से मौजूद है",
+      "delete multiple": {
+        "confirm": "क्या आप वाकई हटाना चाहते हैं: <code>{name}</code> kv(s)?",
+        "warning": "आपके पास उन namespaces के लिए अनुमतियाँ नहीं हैं, इसलिए उन्हें हटा दिया जाएगा: <code>{namespaces}</code>"
+      },
+      "inherited": "विरासत में मिले KV जोड़े"
+    },
+    "expiration": "समाप्ति",
+    "failed to render pdf": "PDF प्रस्तुत करने में विफल",
+    "page": {
+      "previous": "पिछला पृष्ठ",
+      "next": "अगला पृष्ठ"
+    },
+    "namespace_editor": {
+      "empty": {
+        "title": "वर्तमान में कोई टैब्स खुले नहीं हैं",
+        "create_message": "आप namespace फाइलें बना सकते हैं या आयात कर सकते हैं।",
+        "video_message": "आप हमारे Editor के लिए परिचय वीडियो देख सकते हैं।"
+      },
+      "close": {
+        "tab": "टैब बंद करें",
+        "all": "सभी टैब बंद करें",
+        "other": "अन्य टैब्स बंद करें",
+        "right": "दाईं ओर बंद करें"
+      }
+    },
+    "curl": {
+      "command": "cURL कमांड",
+      "note": "कृपया ध्यान दें कि SECRET और FILE इनपुट प्रकार के लिए, कमांड को वास्तविक मानों से मेल खाने के लिए समायोजित किया जाना चाहिए।"
+    },
+    "webhook": {
+      "curl_command": "Webhook cURL कमांड",
+      "payload": "Webhook Payload (JSON)",
+      "curl_note": "इस cURL कमांड का उपयोग कस्टम JSON payload के साथ webhook के माध्यम से flow को trigger करने के लिए करें।",
+      "no_triggers": "इस flow में कोई सक्षम वेबहुक triggers नहीं हैं",
+      "copy_url": "वेबहुक URL कॉपी करें"
+    },
+    "logs_view": {
+      "raw": "Temporal दृश्य",
+      "raw_details": "कच्चे timestamp-क्रमबद्ध प्रारूप में पूर्ण task logs और flow logs दिखाएं",
+      "compact": "पूर्व-निर्धारित दृश्य",
+      "compact_details": "प्रत्येक task द्वारा समूहीकृत कॉम्पैक्ट दृश्य में task logs दिखाएं"
+    },
+    "execution_deletion": {
+      "logs": "Logs हटाएं",
+      "metrics": "Metrics हटाएं",
+      "storage": "आंतरिक स्टोरेज फाइलें हटाएं"
+    },
+    "scope_filter": {
+      "all": "सभी {label}",
+      "user": "उपयोगकर्ता {label}",
+      "system": "सिस्टम {label}",
+      "user_description": "साधारण उपयोगकर्ता द्वारा प्रारंभ किया गया {label}",
+      "system_description": "सिस्टम रखरखाव {label}"
+    },
+    "data": "डेटा",
+    "webhook link copied": "Webhook लिंक कॉपी किया गया।",
+    "copy url": "URL कॉपी करें",
+    "scheduleDate": "अनुसूची तिथि",
+    "warning": "चेतावनी",
+    "trigger_check_warning": "ट्रिगर वेरिएबल्स का उपयोग मैनुअल flow निष्पादन के साथ काम नहीं करेगा। समस्या को हल करने के लिए `??` कोएलस ऑपरेटर जोड़ें। उदाहरण के लिए, `trigger.date` के बजाय `trigger.date ?? execution.startDate` का उपयोग करें।",
+    "docs": "डॉक्स",
+    "active-slots": "सक्रिय स्लॉट्स",
+    "behavior": "व्यवहार",
+    "concurrency": "समानांतरता",
+    "no-executions-view": {
+      "title": "स्वचालन शुरू करें साथ में",
+      "sub_title": "अपने पहले workflow execution को शुरू करने के लिए Execute बटन पर क्लिक करें।",
+      "namespace_sub_title": "इस डैशबोर्ड को भरने के लिए इस namespace से एक या अधिक flows निष्पादित करें।",
+      "guidance_desc": "क्या आपको अपने flow को निष्पादित करने के लिए मार्गदर्शन चाहिए?",
+      "namespace_guidance_desc": "क्या आपको अपने Namespace को प्रबंधित करने के लिए मार्गदर्शन चाहिए?",
+      "guidance_sub_desc": "दस्तावेज़ीकरण का पालन करें ताकि आपको सभी जानकारी मिल सके जिसकी आपको आवश्यकता है।"
+    },
+    "execution_guide": {
+      "get_started": {
+        "title": "शुरू करें ⚡",
+        "text": "क्विकस्टार्ट गाइड का पालन करें ताकि आप Kestra को इंस्टॉल कर सकें और अपनी पहली workflows बनाना शुरू कर सकें।"
+      },
+      "namespaces": {
+        "title": "Namespaces के बारे में",
+        "text": "namespace लॉजिकल समूह होते हैं जो flow और उनके घटकों को संगठित करते हैं।"
+      },
+      "workflow_components": {
+        "title": "वर्कफ़्लो घटक",
+        "text": "Kestra वर्कफ़्लो के मुख्य ऑर्केस्ट्रेशन घटकों को जानें।"
+      },
+      "videos_tutorials": {
+        "title": "वीडियो ट्यूटोरियल्स",
+        "text": "हमारे वीडियो ट्यूटोरियल के साथ शुरू करें।"
+      }
+    },
+    "open sidebar": "साइडबार खोलें",
+    "close sidebar": "साइडबार बंद करें",
+    "customize sidebar": "साइडबार को अनुकूलित करें",
+    "reset to defaults": "डिफ़ॉल्ट पर रीसेट करें",
+    "drop items here": "यहाँ आइटम्स ड्रॉप करें",
+    "files": "फ़ाइलें",
+    "optional": "वैकल्पिक",
+    "no_data": "ऐसा लगता है कि यहाँ कुछ नहीं है... अभी तक!<br/>अपने फ़िल्टर समायोजित करें, या इसे फिर से आज़माएँ!",
+    "bookmark": "बुकमार्क्स",
+    "remove_bookmark": "क्या आप वाकई इस बुकमार्क को हटाना चाहते हैं?",
+    "showLess": "कम दिखाएं",
+    "showMore": "और दिखाएँ",
+    "documentationMenu": "डॉक्यूमेंटेशन मेनू",
+    "item": "आइटम",
+    "items": "आइटम्स",
+    "cron": "क्रॉन",
+    "execution_started": "निष्पादन शुरू हो गया है!",
+    "execution_failed": "निष्पादन FAILED!",
+    "last error was": "अंतिम त्रुटि थी",
+    "execution restarted": "इस execution को {nbRestart} बार पुनः प्रारंभ किया गया है।",
+    "execution replay": "यह निष्पादन का पुनरावृत्ति है",
+    "execution replayed": "इस execution को पुनः चलाया गया है।",
+    "task run id": "टास्करन ID",
+    "active": "सक्रिय",
+    "flows imported": "फ़्लोज़ आयात किए गए",
+    "flow not imported": "कुछ flow आयात नहीं किया जा सका",
+    "plugin defaults exported": "प्लगइन डिफॉल्ट्स एक्सपोर्ट किए गए",
+    "failed to export plugin defaults": "प्लगइन डिफॉल्ट्स को निर्यात करने में विफल",
+    "plugin defaults imported": "प्लगइन डिफ़ॉल्ट्स आयातित",
+    "plugin defaults not imported": "कुछ प्लगइन डिफ़ॉल्ट आयात नहीं किए जा सके",
+    "failed to import plugin defaults": "प्लगइन डिफॉल्ट्स आयात करने में विफल",
+    "filters": {
+      "label": "फिल्टर चुनें",
+      "empty": "कोई डेटा नहीं।",
+      "format": "'key:value' के रूप में पैरामीटर टाइप करें",
+      "text_search": "इस पाठ के लिए खोजें",
+      "options": {
+        "namespace": "Namespace",
+        "flow": "फ्लो",
+        "state": "स्थिति",
+        "scope": "स्कोप",
+        "child": "बच्चा",
+        "level": "Log स्तर",
+        "task": "कार्य",
+        "metric": "मेट्रिक",
+        "user": "उपयोगकर्ता",
+        "type": "प्रकार",
+        "service_type": "प्रकार",
+        "permission": "अनुमति",
+        "action": "क्रिया",
+        "status": "स्थिति",
+        "details": "विवरण",
+        "aggregation": "संकलन",
+        "relative_date": "सापेक्ष तिथि",
+        "absolute_date": "सटीक दिनांक",
+        "labels": "लेबल्स",
+        "text": "मुझे अनुवाद के लिए कोई पाठ नहीं मिला। कृपया अनुवाद के लिए पाठ प्रदान करें।",
+        "startDate": "आरंभ तिथि",
+        "endDate": "समाप्ति तिथि"
+      },
+      "comparators": {
+        "is": "है",
+        "is_one_of": "में से एक है",
+        "is_not": "नहीं है",
+        "not_in": "में नहीं",
+        "contains": "शामिल है",
+        "not_contains": "नहीं शामिल है",
+        "in": "में",
+        "between": "के बीच",
+        "starts_with": "शुरू होता है",
+        "greater_than": "से अधिक",
+        "greater_than_or_equal_to": "से अधिक या बराबर",
+        "less_than": "से कम",
+        "less_than_or_equal_to": "से कम या बराबर",
+        "ends_with": "समाप्त होता है"
+      },
+      "save": {
+        "label": "सहेजे गए खोजें",
+        "remove": "हटाएं",
+        "empty": "आपने अभी तक कोई खोज सहेजी नहीं है।",
+        "tooltip": "आप खाली खोज मानदंड सहेज नहीं सकते।",
+        "name_already_used": "खोज label पहले से उपयोग में है।",
+        "dialog": {
+          "heading": "वर्तमान खोज सहेजें",
+          "placeholder": "लेबल",
+          "hint": "आप इस खोज मापदंड को किस तरह से लेबल करना चाहते हैं?",
+          "confirmation": "खोज मापदंड <code>{name}</code>"
+        }
+      },
+      "settings": {
+        "label": "पृष्ठ सेटिंग्स",
+        "show_chart": "मुख्य चार्ट दिखाएं"
+      }
+    },
+    "custom value": "कस्टम value",
+    "chart": "चार्ट",
+    "chart preview": "चार्ट पूर्वावलोकन",
+    "no_code": {
+      "toggle_pebble": "Pebble संपादक टॉगल करें",
+      "version_oss_placeholder": "एंटरप्राइज एडिशन के साथ प्लगइन वर्शनिंग अनलॉक करें",
+      "unnamed": "कोई नाम नहीं",
+      "adding": "+ एक {what} जोड़ें",
+      "adding_default": "+ एक नया value जोड़ें",
+      "add_field": "{field} जोड़ें",
+      "clearSelection": "चयन साफ़ करें",
+      "labels": {
+        "yaml": "YAML संपादक",
+        "no_code": "कोड संपादक नहीं",
+        "label": "लेबल",
+        "variable": "वेरिएबल"
+      },
+      "sections": {
+        "deprecated": "अप्रचलित गुण",
+        "tasks": "कार्य",
+        "triggers": "ट्रिगर्स",
+        "errors": "त्रुटि हैंडलर्स",
+        "afterExecution": "Execution के बाद",
+        "finally": "अंत में",
+        "pluginDefaults": "डिफ़ॉल्ट प्लगइन"
+      },
+      "fields": {
+        "main": {
+          "id": "Flow ID",
+          "namespace": "Namespace",
+          "description": "विवरण",
+          "inputs": "इनपुट्स"
+        },
+        "general": {
+          "retry": "पुनः प्रयास करें",
+          "sla": "SLA",
+          "labels": "लेबल्स",
+          "outputs": "आउटपुट्स",
+          "variables": "वेरिएबल्स",
+          "concurrency": "समानांतरता",
+          "disabled": "अक्षम",
+          "listeners": "श्रोता",
+          "taskDefaults": "डिफ़ॉल्ट Task",
+          "workerGroup": "वर्कर ग्रुप",
+          "workerSelector": "वर्कर सेलेक्टर",
+          "checks": "जांचें",
+          "updated": "अपडेट किया गया"
+        }
+      },
+      "select": {
+        "default": "एक प्रकार चुनें",
+        "task": "किसी task का चयन करें",
+        "tasks": "कार्य चुनें",
+        "triggers": "ट्रिगर चुनें",
+        "errors": "एक task चुनें",
+        "finally": "एक task चुनें",
+        "pluginDefaults": "एक प्लगइन चुनें",
+        "afterExecution": "एक task चुनें",
+        "conditions": "कंडीशन चुनें",
+        "inputs": "इनपुट फ़ील्ड प्रकार चुनें",
+        "charts": "चार्ट प्रकार चुनें",
+        "where": "एक फ़िल्टर प्रकार चुनें",
+        "numerator": "एक अंश चुनें"
+      },
+      "creation": {
+        "default": "जोड़ें",
+        "tasks": "कार्य जोड़ें",
+        "triggers": "ट्रिगर जोड़ें",
+        "errors": "त्रुटि हैंडलर जोड़ें",
+        "finally": "अंत में एक finally ब्लॉक जोड़ें",
+        "pluginDefaults": "प्लगइन डिफ़ॉल्ट जोड़ें",
+        "afterExecution": "एक निष्पादन के बाद ब्लॉक जोड़ें",
+        "conditions": "एक शर्त जोड़ें",
+        "inputs": "इनपुट फ़ील्ड जोड़ें",
+        "charts": "चार्ट जोड़ें",
+        "where": "अपने डेटा को फ़िल्टर करें",
+        "numerator": "संख्यांक जोड़ें"
+      },
+      "remove": {
+        "default": "इस प्रविष्टि को हटाएं",
+        "cases": "इस केस को हटाएं"
+      }
+    },
+    "properties": {
+      "label": "गुणधर्म",
+      "hint": "दृश्य स्तंभ चुनें",
+      "shown": "तालिका में दिखाया गया",
+      "hidden": "टेबल में छिपा हुआ"
+    },
+    "editor_shortcuts": {
+      "label": "कीबोर्ड शॉर्टकट्स",
+      "trigger_autocompletion": "ट्रिगर ऑटोकम्प्लीशन",
+      "command_palette": "कमांड पैलेट दिखाएं",
+      "save_flow": "फ्लो सहेजें",
+      "execute_flow": "flow निष्पादित करें",
+      "toggle_ai_agent": "AI एजेंट टॉगल करें",
+      "move_line": "लाइन को स्थानांतरित करें",
+      "duplicate_cursor": "कर्सर को डुप्लिकेट करें",
+      "fold_unfold": "कोड को फोल्ड/अनफोल्ड करें",
+      "comment_uncomment": "टिप्पणी/अनटिप्पणी",
+      "comment": "टिप्पणी",
+      "uncomment": "अनकमेंट करें",
+      "decrease_fontsize": "संपादक फ़ॉन्ट आकार घटाएं",
+      "increase_fontsize": "संपादक फ़ॉन्ट आकार बढ़ाएँ",
+      "reset_fontsize": "संपादक फ़ॉन्ट आकार रीसेट करें"
+    },
+    "instance": "इंस्टेंस",
+    "something_went_wrong": {
+      "loading_execution": "लोडिंग के दौरान कुछ गलत हो गया।",
+      "connection_lost": {
+        "title": "कनेक्शन बाधित",
+        "message": "हम आपकी Kestra instance तक नहीं पहुँच सके। सुनिश्चित करें कि यह चल रहा है, फिर पृष्ठ को रीफ्रेश करें।"
+      }
+    },
+    "debug": "डिबग",
+    "default": "डिफ़ॉल्ट",
+    "data_not_protected": "आपका डेटा सुरक्षित नहीं है। इसे न खोएं। <b>हमारी मुफ्त सुरक्षा सुविधाओं को सक्षम करें या हमारे भुगतान वाले ऑफर को आज़माएं।</b>",
+    "activate_basic_auth": "बेसिक ऑथेंटिकेशन सक्रिय करें",
+    "dark_version": "डार्क संस्करण",
+    "use_dark_background": "इस संस्करण का उपयोग तब करें जब आप एक गहरे पृष्ठभूमि पर काम कर रहे हों ताकि यह सुनिश्चित हो सके कि हमारा नाम पठनीय बना रहे।",
+    "light_version": "लाइट संस्करण",
+    "light_background": "यह हल्की पृष्ठभूमि के साथ काम करते समय पसंदीदा विकल्प है।",
+    "monogram": "मोनोग्राम",
+    "wordmark_colors": "शब्दचिह्न के रंग पृष्ठभूमि के आधार पर अनुकूलित होते हैं, जबकि आइकन एक गहरे पृष्ठभूमि पर रखे जाने पर बिना पृष्ठभूमि के रहता है।",
+    "download_logos": "लोगो पैक डाउनलोड करें",
+    "this_task_has": "यह task है",
+    "about_this_blueprint": "इस blueprint के बारे में",
+    "deleted_label": "हटाया गया",
+    "fold_all_multi_lines": "सभी मल्टी लाइन्स को फोल्ड करें",
+    "task_id_exists": "टास्क Id पहले से मौजूद है",
+    "task_id_message": "टास्क Id ${existingTask} पहले से ही flow में मौजूद है।",
+    "trigger_id_exists": "ट्रिगर Id पहले से मौजूद है",
+    "trigger_id_message": "ट्रिगर Id ${existingTrigger} पहले से ही flow में मौजूद है।",
+    "watch": "देखें",
+    "learn_more": "और जानें",
+    "watch_video": "वीडियो देखें",
+    "runners": "धावक",
+    "select": "अपने {{section}} का चयन करें",
+    "for flow": "फ्लो के लिए",
+    "forbidden system labels": "सिर्फ़ system.correlationId को system label के रूप में उपयोग किया जा सकता है",
+    "confirm": "पुष्टि करें",
+    "taskRunners": "टास्क Runners",
+    "additionalPlugins": "अतिरिक्त Plugins",
+    "appBlocks": "ऐप ब्लॉक्स",
+    "charts": "चार्ट्स",
+    "dataFilters": "डेटा फ़िल्टर",
+    "logExporters": "लॉग Exporters",
+    "empty": {
+      "namespaceFiles": {
+        "title": "इस namespace में अभी तक कोई फ़ाइल नहीं है",
+        "content": "Namespace फ़ाइलें इस namespace के लिए एक प्रोजेक्ट फ़ोल्डर की तरह काम करती हैं। Python, SQL, dbt या Terraform कोड संग्रहीत करें, फिर अपने flows में किसी भी फ़ाइल को इसके साथ संदर्भित करें"
+      },
+      "announcements": {
+        "title": "आपके पास अभी तक कोई घोषणाएँ नहीं हैं!",
+        "content": "घोषणाएँ आपको अपने उपयोगकर्ताओं को किसी भी परिवर्तन के बारे में सूचित करने या नियोजित रखरखाव डाउनटाइम के बारे में जानकारी देने की अनुमति देती हैं। बस घोषणा का प्रकार चुनें, वह तारीख सीमा चुनें जिसके लिए इसे प्रदर्शित किया जाना चाहिए, और घोषणा संदेश लिखें।"
+      },
+      "kill_switches": {
+        "title": "आपके पास अभी तक कोई Kill Switches नहीं हैं!",
+        "content": "किल स्विच फीचर एक UI आधारित तंत्र प्रदान करता है जो समस्याग्रस्त executions को रोकने के लिए है। यह केवल CLI <code>--skip-executions</code> और <code>--skip-flows</code> कमांड्स को एक व्यापक प्रशासनिक इंटरफेस के साथ बदलता है।"
+      },
+      "apps": {
+        "title": "आपके पास अभी तक कोई ऐप्स नहीं हैं!",
+        "content": "बाहरी दुनिया से Kestra के साथ इंटरैक्ट करने के लिए Apps बनाना शुरू करें।"
+      },
+      "testSuites": {
+        "title": "आपके पास अभी तक कोई Test suites नहीं हैं!",
+        "content": "अपने Flows का परीक्षण करने के लिए Test suites बनाना शुरू करें।"
+      },
+      "assets": {
+        "title": "आपके पास अभी तक कोई Assets नहीं हैं!",
+        "content": "अपने डेटा एसेट्स, सेवाओं और इन्फ्रास्ट्रक्चर को ट्रैक और प्रबंधित करने के लिए एसेट्स जोड़ें।"
+      },
+      "apiTokens": {
+        "title": "अपने API Tokens प्रबंधित करें",
+        "content": "API टोकन का उपयोग तब किया जाता है जब आप Kestra API के लिए प्रोग्रामेटिक एक्सेस प्रदान करना चाहते हैं।"
+      },
+      "concurrency_executions": {
+        "title": "इस Flow के लिए कोई चल रही Executions नहीं हैं।",
+        "content": "हमारे दस्तावेज़ में <strong><a href=\"https://kestra.io/docs/workflow-components/execution?utm_source=app&utm_medium=referral&utm_campaign=concurrency-inlinedoc\" target=\"_blank\">Executions</a></strong> के बारे में अधिक पढ़ें।"
+      },
+      "concurrency_limit": {
+        "title": "इस Flow के लिए कोई सीमाएँ निर्धारित नहीं हैं।",
+        "content": "हमारे दस्तावेज़ में <strong><a href=\"https://kestra.io/docs/workflow-components/concurrency?utm_source=app&utm_medium=referral&utm_campaign=concurrency-inlinedoc\" target=\"_blank\">Concurrency Limits</a></strong> के बारे में अधिक पढ़ें।"
+      },
+      "concurrency_limits": {
+        "title": "कोई concurrency सीमाएँ निर्धारित नहीं हैं।",
+        "content": "हमारे दस्तावेज़ में <strong><a href=\"https://kestra.io/docs/workflow-components/concurrency?utm_source=app&utm_medium=referral&utm_campaign=concurrency-inlinedoc\" target=\"_blank\">Concurrency Limits</a></strong> के बारे में अधिक पढ़ें।"
+      },
+      "pluginDefaults": {
+        "title": "आपके पास अभी तक कोई प्लगइन डिफॉल्ट नहीं है!",
+        "content": "प्लगइन डिफॉल्ट्स आपको अपने प्लगइन कॉन्फ़िगरेशन को केंद्रीय रूप से प्रबंधित करने और इसे आपके namespace के सभी flows के साथ साझा करने की अनुमति देते हैं।"
+      },
+      "variables": {
+        "title": "अभी तक कोई वेरिएबल नहीं है",
+        "content": "फ्लो के बीच कॉन्फ़िगरेशन साझा करने के लिए key-value जोड़े जोड़ें। चाइल्ड namespaces उन्हें स्वचालित रूप से विरासत में ले लेते हैं, और आप किसी भी value को संदर्भित कर सकते हैं"
+      },
+      "workerRegistrationTokens": {
+        "title": "आपके पास अभी तक कोई पंजीकरण टोकन नहीं है!",
+        "content": "पंजीकरण टोकन दूरस्थ workers को सुरक्षित रूप से प्रमाणित और आपके Kestra instance के साथ पंजीकृत करने की अनुमति देते हैं। एक टोकन बनाएं, फिर इसे नए workers को इस क्लस्टर से जोड़ने के लिए उपयोग करें।"
+      },
+      "groups": {
+        "title": "आपके पास अभी तक कोई समूह नहीं है!",
+        "content": "समूह आपको उपयोगकर्ताओं को एक साथ जोड़ने की अनुमति देते हैं ताकि आप अपने tenant में अनुमतियों और भूमिका बाइंडिंग को सामूहिक रूप से प्रबंधित कर सकें।"
+      },
+      "dependencies": {
+        "FLOW": {
+          "title": "वर्तमान में कोई dependencies नहीं हैं।",
+          "content": "हमारे दस्तावेज़ में <a href=\"https://kestra.io/docs/ui/flows?utm_source=app&utm_medium=referral&utm_campaign=dependencies-inlinedoc#dependencies\" target=\"_blank\">Flow Dependencies</a> के बारे में अधिक पढ़ें।"
+        },
+        "EXECUTION": {
+          "title": "वर्तमान में कोई निर्भरता नहीं है।",
+          "content": "हमारे दस्तावेज़ में <a href=\"https://kestra.io/docs/ui/executions?utm_source=app&utm_medium=referral&utm_campaign=dependencies-inlinedoc#dependencies\" target=\"_blank\">Execution Dependencies</a> के बारे में अधिक पढ़ें।"
+        },
+        "NAMESPACE": {
+          "title": "वर्तमान में कोई निर्भरता नहीं है।",
+          "content": "हमारे दस्तावेज़ में <a href=\"https://kestra.io/docs/ui/namespaces?utm_source=app&utm_medium=referral&utm_campaign=dependencies-inlinedoc#dependencies\" target=\"_blank\">Namespace Dependencies</a> के बारे में अधिक पढ़ें।"
+        },
+        "ASSET": {
+          "title": "वर्तमान में कोई निर्भरता नहीं है।",
+          "content": "इस संपत्ति का flows या अन्य संपत्तियों के साथ कोई upstream या downstream निर्भरता नहीं है।"
+        }
+      },
+      "plugins": {
+        "title": "इस Namespace के लिए कोई प्लगइन डिफॉल्ट सेट नहीं हैं।",
+        "content": "हमारे दस्तावेज़ में <strong><a href=\"https://kestra.io/docs/workflow-components/plugin-defaults?utm_source=app&utm_medium=referral&utm_campaign=plugin-default-inlinedoc\" target=\"_blank\">Concurrency Limits</a></strong> के बारे में अधिक पढ़ें।"
+      },
+      "triggers": {
+        "title": "आपके flow में कोई Triggers नहीं हैं।",
+        "content": "हमारे दस्तावेज़ में <strong><a href=\"https://kestra.io/docs/workflow-components/triggers?utm_source=app&utm_medium=referral&utm_campaign=trigger-inlinedoc\" target=\"_blank\">Triggers</a></strong> के बारे में और पढ़ें।"
+      },
+      "mcpToolFlows": {
+        "title": "इस सर्वर पर अभी तक कोई टूल flows पंजीकृत नहीं हैं।",
+        "content": "<code>McpToolTrigger</code> जोड़कर एक flow को MCP टूल के रूप में प्रदर्शित करें। हमारे दस्तावेज़ में <strong><a href=\"https://kestra.io/docs/workflow-components/triggers/mcp-tool-trigger?utm_source=app&utm_medium=referral&utm_campaign=mcp-tool-trigger-inlinedoc\" target=\"_blank\">MCP Tool Trigger</a></strong> के बारे में और पढ़ें।"
+      },
+      "versionPlugin": {
+        "title": "आपके पास अभी तक कोई संस्करणित प्लगइन नहीं है!",
+        "content": "यहां आप अपने Kestra instance पर इंस्टॉल किए गए सभी प्लगइन्स का प्रबंधन कर सकते हैं। नए इंस्टॉल किए गए प्लगइन्स आपके instance की कॉन्फ़िगरेशन के आधार पर सभी Kestra सेवाओं में तुरंत उपलब्ध नहीं हो सकते हैं।"
+      },
+      "panels": {
+        "title": "कोई पैनल खुला नहीं है",
+        "content": "आपने सभी पैनल बंद कर दिए हैं।  \nजारी रखने के लिए ऊपर एक टैब चुनें।"
+      }
+    },
+    "toggle_word_wrap": "शब्द रैप टॉगल करें",
+    "copied_logs_to_clipboard": "लॉग्स को क्लिपबोर्ड पर कॉपी किया गया।",
+    "multi_panel_editor": {
+      "move_right": "दाईं ओर ले जाएँ",
+      "move_left": "बाएँ ले जाएँ",
+      "close_all_tabs": "सभी टैब बंद करें",
+      "close_all_panels": "सभी पैनल बंद करें"
+    },
+    "search_docs": "खोजें",
+    "no_results_found": "कोई परिणाम नहीं मिला",
+    "searching": "खोज जारी है...",
+    "worker information": "वर्कर जानकारी",
+    "test-badge-text": "परीक्षण",
+    "test-badge-tooltip": "यह execution एक Test द्वारा बनाया गया था",
+    "total_executions": "कुल Executions",
+    "no_results": {
+      "executions": "कोई Executions नहीं मिला",
+      "triggers": "कोई Triggers नहीं मिले",
+      "flows": "कोई Flows नहीं मिला",
+      "kv_pairs": "कोई Key-Value जोड़े नहीं मिले",
+      "secrets": "कोई Secrets नहीं मिले",
+      "templates": "कोई टेम्पलेट नहीं मिला",
+      "assets": "कोई Assets नहीं मिले"
+    },
+    "duplicate-pair": "{label} \"{key}\" दोहराया गया है, पहला key अनदेखा किया गया।",
+    "dashboards": {
+      "labels": {
+        "singular": "डैशबोर्ड",
+        "plural": "डैशबोर्ड्स"
+      },
+      "default": "डिफ़ॉल्ट डैशबोर्ड",
+      "switch": "डैशबोर्ड स्विच करें",
+      "preview": "पूर्वावलोकन डैशबोर्ड",
+      "empty": "कोई परिणाम नहीं दिखाया जा सकता।",
+      "creation": {
+        "label": "डैशबोर्ड बनाएं",
+        "confirmation": "डैशबोर्ड <code>{title}</code> बनाया गया है।"
+      },
+      "edition": {
+        "label": "डैशबोर्ड संपादित करें",
+        "confirmation": "डैशबोर्ड <code>{title}</code> में परिवर्तन सहेजे गए हैं।",
+        "chart": "इस चार्ट को संपादित करें",
+        "id readonly": "संपत्ति `id` को बदला नहीं जा सकता — यह अब अपनी प्रारंभिक मानों पर सेट है। यदि आप इसे बदलना चाहते हैं, तो आप एक नया डैशबोर्ड बना सकते हैं और पुराने को हटा सकते हैं।"
+      },
+      "deletion": {
+        "confirmation": "क्या आप वाकई <code>{title}</code> डैशबोर्ड को हटाना चाहते हैं?"
+      },
+      "no_description": "कोई विवरण नहीं",
+      "no_description_hint": "इस flow में एक विवरण जोड़ें ताकि यह दस्तावेज़ किया जा सके कि यह क्या करता है।<br>Markdown समर्थित है।",
+      "others": "अन्य",
+      "viewAll": "सभी देखें",
+      "chart_preview": "किसी चार्ट के स्रोत कोड पर क्लिक करें ताकि उसका पूर्वावलोकन देखा जा सके।",
+      "export": "CSV में निर्यात करें",
+      "quick_filters": {
+        "all": "सभी",
+        "running": "चल रहा है",
+        "paused": "रुका हुआ",
+        "success": "सफलता",
+        "warning": "चेतावनी",
+        "failed": "विफल"
+      }
     },
     "setup": {
-      "config": {
-        "basicauth": "बेसिक authentication",
-        "queue": "पंक्ति",
-        "repository": "डेटाबेस",
-        "storage": "आंतरिक Storage"
+      "login": "लॉगिन",
+      "login_title": "साइन इन करें",
+      "logout": "लॉगआउट",
+      "troubleshooting": "पासवर्ड भूल गए?",
+      "steps": {
+        "user": "एडमिन उपयोगकर्ता बनाएं",
+        "config": "कॉन्फ़िगरेशन सत्यापित करें",
+        "survey": "हमें और बताएं",
+        "complete": "Kestra UI शुरू करें"
       },
-      "confirm": {
-        "config_title": "पुष्टि करें कि कॉन्फ़िगरेशन मान्य है",
-        "confirm": "एडमिन उपयोगकर्ता बनाएं",
-        "not_valid": "नहीं, यह मान्य नहीं है",
-        "valid": "हाँ, यह मान्य है"
+      "titles": {
+        "user": "एक एडमिन उपयोगकर्ता बनाएं",
+        "survey": "हमें Kestra OSS को बेहतर बनाने में मदद करें"
+      },
+      "subtitles": {
+        "user": "अपने instance को सुरक्षित करें ताकि शुरुआत कर सकें।",
+        "config": "यहाँ आपके कॉन्फ़िगरेशन का विवरण दिया गया है",
+        "survey": "I'm sorry, but it seems there is no text provided after the \"----------\" for translation. Could you please provide the text you would like translated into Hindi?",
+        "complete": "सेटअप सफलतापूर्वक पूरा हुआ!"
       },
       "form": {
         "email": "ईमेल",
@@ -1878,351 +1937,249 @@
         "username": "उपयोगकर्ता नाम",
         "username_hint": "मान्य ईमेल पता होना चाहिए।"
       },
-      "login": "लॉगिन",
-      "login_title": "साइन इन करें",
-      "logout": "लॉगआउट",
-      "steps": {
-        "complete": "Kestra UI शुरू करें",
-        "config": "कॉन्फ़िगरेशन सत्यापित करें",
-        "survey": "हमें और बताएं",
-        "user": "एडमिन उपयोगकर्ता बनाएं"
-      },
-      "subtitles": {
-        "complete": "सेटअप सफलतापूर्वक पूरा हुआ!",
-        "config": "यहाँ आपके कॉन्फ़िगरेशन का विवरण दिया गया है",
-        "survey": "I'm sorry, but it seems there is no text provided after the \"----------\" for translation. Could you please provide the text you would like translated into Hindi?",
-        "user": "अपने instance को सुरक्षित करें ताकि शुरुआत कर सकें।"
-      },
-      "success": {
-        "subtitle": "आप पूरी तरह से तैयार हैं!",
-        "title": "बधाई हो!"
-      },
-      "survey": {
-        "company_11_50": "व्यक्तिगत प्रोजेक्ट",
-        "company_1_10": "सीखना / अन्वेषण करना",
-        "company_250_plus": "उत्पादन परिनियोजन",
-        "company_50_250": "मेरी टीम/कंपनी के लिए मूल्यांकन करना",
-        "company_personal": "अन्य",
-        "company_size": "Kestra के साथ आपका मुख्य लक्ष्य क्या है?",
-        "continue": "जारी रखें",
-        "newsletter": "ईमेल द्वारा उत्पाद अपडेट प्राप्त करें।",
-        "newsletter_heading": "सूचित रहें",
-        "skip": "छोड़ें",
-        "use_case": "आप इसे किस उद्देश्य के लिए उपयोग करने की योजना बना रहे हैं?",
-        "use_case_business": "व्यवसाय वर्कफ़्लोज़",
-        "use_case_data": "डेटा वर्कफ्लोज़",
-        "use_case_infrastructure": "इन्फ्रास्ट्रक्चर ऑटोमेशन",
-        "use_case_ml": "एमएल पाइपलाइन्स",
-        "use_case_other": "अन्य",
-        "use_case_scheduling": "शेड्यूलिंग और आवर्ती जॉब्स"
-      },
-      "titles": {
-        "survey": "हमें Kestra OSS को बेहतर बनाने में मदद करें",
-        "user": "एक एडमिन उपयोगकर्ता बनाएं"
-      },
-      "troubleshooting": "पासवर्ड भूल गए?",
       "validation": {
-        "config_message": "अपने configuration को अपडेट करना सुनिश्चित करें ताकि इस त्रुटि संदेश को ठीक किया जा सके।",
-        "email_invalid": "अमान्य ईमेल",
         "email_required": "ईमेल आवश्यक है",
+        "email_invalid": "अमान्य ईमेल",
         "email_temporary_not_allowed": "अस्थायी या डिस्पोजेबल ईमेल पते की अनुमति नहीं है",
         "firstName_required": "पहला नाम आवश्यक है",
-        "incorrect_creds": "अमान्य उपयोगकर्ता नाम या पासवर्ड। सुनिश्चित करें कि आपके प्रमाण-पत्र सही हैं।",
         "lastName_required": "अंतिम नाम आवश्यक है",
         "password_invalid": "अमान्य पासवर्ड",
-        "password_required": "पासवर्ड आवश्यक है"
+        "password_required": "पासवर्ड आवश्यक है",
+        "incorrect_creds": "अमान्य उपयोगकर्ता नाम या पासवर्ड। सुनिश्चित करें कि आपके प्रमाण-पत्र सही हैं।",
+        "config_message": "अपने configuration को अपडेट करना सुनिश्चित करें ताकि इस त्रुटि संदेश को ठीक किया जा सके।"
+      },
+      "config": {
+        "repository": "डेटाबेस",
+        "queue": "पंक्ति",
+        "storage": "आंतरिक Storage",
+        "basicauth": "बेसिक authentication"
+      },
+      "confirm": {
+        "confirm": "एडमिन उपयोगकर्ता बनाएं",
+        "config_title": "पुष्टि करें कि कॉन्फ़िगरेशन मान्य है",
+        "not_valid": "नहीं, यह मान्य नहीं है",
+        "valid": "हाँ, यह मान्य है"
+      },
+      "survey": {
+        "skip": "छोड़ें",
+        "company_size": "Kestra के साथ आपका मुख्य लक्ष्य क्या है?",
+        "company_1_10": "सीखना / अन्वेषण करना",
+        "company_11_50": "व्यक्तिगत प्रोजेक्ट",
+        "company_50_250": "मेरी टीम/कंपनी के लिए मूल्यांकन करना",
+        "company_250_plus": "उत्पादन परिनियोजन",
+        "company_personal": "अन्य",
+        "use_case": "आप इसे किस उद्देश्य के लिए उपयोग करने की योजना बना रहे हैं?",
+        "use_case_infrastructure": "इन्फ्रास्ट्रक्चर ऑटोमेशन",
+        "use_case_business": "व्यवसाय वर्कफ़्लोज़",
+        "use_case_data": "डेटा वर्कफ्लोज़",
+        "use_case_ml": "एमएल पाइपलाइन्स",
+        "use_case_scheduling": "शेड्यूलिंग और आवर्ती जॉब्स",
+        "use_case_other": "अन्य",
+        "newsletter_heading": "सूचित रहें",
+        "newsletter": "ईमेल द्वारा उत्पाद अपडेट प्राप्त करें।",
+        "continue": "जारी रखें"
+      },
+      "success": {
+        "title": "बधाई हो!",
+        "subtitle": "आप पूरी तरह से तैयार हैं!"
       }
     },
-    "show": "दिखाएं",
-    "show chart": "चार्ट दिखाएं",
-    "show description": "विवरण दिखाएं",
-    "show details": "विवरण दिखाएं",
-    "show documentation": "दस्तावेज़ दिखाएं",
-    "show more details": "अधिक विवरण दिखाएं",
-    "show raw": "Show raw",
-    "show task condition": "कार्य की स्थिति दिखाएं",
-    "show task documentation": "Task दस्तावेज़ दिखाएं",
-    "show task documentation in editor": "संपादक में Task दस्तावेज़ दिखाएं",
-    "show task logs": "Task Logs दिखाएं",
-    "show task outputs": "Task आउटपुट दिखाएं",
-    "show task source": "Task स्रोत दिखाएं",
-    "showLess": "कम दिखाएं",
-    "showMore": "और दिखाएँ",
-    "side-by-side": "साइड-बाय-साइड",
-    "similar lines": "similar lines",
-    "skipped": "छोड़ा गया",
-    "slack support": "किसी भी प्रश्न को Slack के माध्यम से पूछें",
-    "something_went_wrong": {
-      "connection_lost": {
-        "message": "हम आपकी Kestra instance तक नहीं पहुँच सके। सुनिश्चित करें कि यह चल रहा है, फिर पृष्ठ को रीफ्रेश करें।",
-        "title": "कनेक्शन बाधित"
+    "ai": {
+      "flow": {
+        "title": "एआई एजेंट",
+        "prompt_placeholder": "अपने Kestra flow बनाने के लिए निर्देश दर्ज करें। उदाहरण प्रॉम्प्ट: एक flow बनाएं जो हर सोमवार को सुबह 9 बजे चलता है।",
+        "select_provider": "प्रदाता चुनें",
+        "generating": {
+          "flow": "आपके लिए Flow YAML उत्पन्न किया जा रहा है...",
+          "dashboard": "आपके लिए Dashboard YAML तैयार किया जा रहा है...",
+          "app": "आपके लिए App YAML तैयार किया जा रहा है...",
+          "test": "आपके लिए टेस्ट YAML उत्पन्न किया जा रहा है..."
+        },
+        "enable_instructions": {
+          "header": "<b>AI Copilot अभी तक कॉन्फ़िगर नहीं किया गया है।</b>\n\nAI Copilot को सक्षम करने के लिए, अपने Kestra instance configuration file (जैसे <code>application.yml</code>) में निम्नलिखित स्निपेट जोड़ें, <code>geminiApiKey</code> को अपनी वास्तविक key से बदलें:",
+          "footer": "ध्यान दें: इस समय, केवल Gemini को Open Source Edition के लिए AI प्रदाता के रूप में समर्थन दिया जाता है। Enterprise Edition के लिए, कृपया अन्य मॉडल प्रदाता कॉन्फ़िगरेशन के लिए AI Copilot दस्तावेज़ देखें।\n\nकॉन्फ़िगरेशन सहेजने के बाद अपनी Kestra instance को पुनः प्रारंभ करें।"
+        }
       },
-      "loading_execution": "लोडिंग के दौरान कुछ गलत हो गया।"
+      "dashboard": {
+        "prompt_placeholder": "अपने डेटा के बारे में एक प्रश्न पूछें। उदाहरण प्रॉम्प्ट: पिछले 7 दिनों में मेरे flows की सफलता दर दिखाएं।"
+      }
     },
-    "source": "स्रोत",
-    "source and blueprints": "स्रोत और ब्लूप्रिंट",
-    "source and doc": "स्रोत और दस्तावेज़",
-    "source and topology": "स्रोत और टोपोलॉजी",
-    "source only": "केवल स्रोत",
-    "source search": "स्रोत खोज",
-    "source_search": {
-      "match_count": "{count} मिलान | {count} मिलान",
-      "open_flow": "flow खोलें",
-      "preview_empty": "पूर्वावलोकन के लिए एक परिणाम चुनें। स्रोत देखने के लिए परिणाम सूची में किसी flow पर क्लिक करें।",
-      "preview_error": "flow स्रोत लोड करने में विफल"
+    "playground": {
+      "title": "प्लेग्राउंड",
+      "run_task_info": "Flow Code संपादक में किसी भी task पर होवर करें और अपने task का परीक्षण करने के लिए \"Run task\" बटन पर क्लिक करें।",
+      "play_icon_info": "आप No-Code या Topology दृश्य में Play आइकन पर भी क्लिक कर सकते हैं।",
+      "toggle": "प्लेग्राउंड",
+      "run_task": "टास्क चलाएं",
+      "run_this_task": "इस task को चलाएं",
+      "run_task_and_downstream": "टास्क चलाएं और डाउनस्ट्रीम",
+      "run_all_tasks": "सभी Tasks चलाएं",
+      "history": "पिछले 10 रन",
+      "clear_history": "इतिहास साफ़ करें",
+      "confirm_create": "आप एक flow बनाते समय playground नहीं चला सकते। एक playground रन शुरू करने से flow बन जाएगा।",
+      "tooltip_persistence": "यदि आप Playground को बंद करके फिर से चालू करते हैं, तो जानकारी तब तक बनी रहती है जब तक आप पृष्ठ पर रहते हैं।"
     },
-    "specific task": "विशिष्ट task",
-    "start date": "प्रारंभ तिथि",
-    "start datetime": "प्रारंभ दिनांक और समय",
-    "started date": "प्रारंभ तिथि",
-    "state": "स्थिति",
-    "state updated date": "स्थिति अद्यतन तिथि",
-    "state_history": "स्थिति इतिहास",
-    "stats": "आँकड़े",
-    "steps": "चरण",
-    "stream": "स्ट्रीम",
-    "sub flow": "Subflow",
     "submit": "प्रस्तुत करें",
-    "success": "सफलता",
-    "sum": "योग",
-    "switch-view": "दृश्य स्विच करें",
-    "system overview": "सिस्टम अवलोकन",
-    "system_namespace": "अपने प्लेटफ़ॉर्म को सिस्टम flows के साथ नियंत्रण में रखें।",
-    "system_namespace_description": "रखरखाव के tasks को स्वचालित करें, failure alerts से लेकर automated cleanups तक।",
-    "tags": "टैग्स",
-    "task": "Task",
-    "task failed": "टास्क FAILED",
-    "task id": "Task ID",
-    "task id already exists": "Task Id पहले से मौजूद है",
-    "task is running": "टास्क RUNNING है",
-    "task logs": "Task Logs",
-    "task run id": "टास्करन ID",
-    "task sent a warning": "टास्क ने एक WARNING भेजा",
-    "task was skipped": "टास्क को छोड़ दिया गया था",
-    "task was successful": "टास्क सफल रहा",
-    "taskDefaults": "taskDefaults",
-    "taskRunners": "टास्क Runners",
-    "task_id_exists": "टास्क Id पहले से मौजूद है",
-    "task_id_message": "टास्क Id ${existingTask} पहले से ही flow में मौजूद है।",
-    "taskid column details": "निष्पादित होने वाला अंतिम Task और इसके प्रयासों की संख्या।",
-    "tasks": "Tasks",
-    "template": "template",
-    "template creation": "template निर्माण",
-    "template delete": "क्या आप वाकई <code>{templateCount}</code> template(s) को हटाना चाहते हैं?",
-    "template export": "क्या आप वाकई <code>{templateCount}</code> template(s) को निर्यात करना चाहते हैं?",
-    "templates": "templates",
-    "templates deleted": "<code>{count}</code> template(s) हटाए गए",
-    "templates deprecated": "templates अप्रचलित हैं। कृपया इसके बजाय subflows का उपयोग करें। यह समझाने वाला <a href=\"https://kestra.io/docs/migration-guide/0.11.0/templates?utm_source=app&utm_medium=referral&utm_campaign=template-inlinedoc\" target=\"_blank\">माइग्रेशन अनुभाग</a> देखें कि आप टेम्पलेट्स से subflows में कैसे माइग्रेट कर सकते हैं।",
-    "templates exported": "templates निर्यात किए गए",
-    "tenant": {
-      "name": "मंडल",
-      "names": "मंडल"
-    },
-    "tenantId": "टेनेंट ID",
-    "test-badge-text": "परीक्षण",
-    "test-badge-tooltip": "यह execution एक Test द्वारा बनाया गया था",
-    "theme": "थीम",
-    "this_task_has": "यह task है",
-    "timezone": "समय क्षेत्र",
-    "title": "शीर्षक",
-    "to": "तक",
     "to toggle": "टॉगल करने के लिए",
-    "toggle fullscreen": "पूर्ण स्क्रीन टॉगल करें",
-    "toggle menu": "मेनू टॉगल करें",
-    "toggle output": "आउटपुट टॉगल करें",
-    "toggle output display": "आउटपुट प्रदर्शन टॉगल करें",
-    "toggle periodic refresh each x seconds": "हर {interval} सेकंड में आवधिक रिफ्रेश टॉगल करें",
-    "toggle_word_wrap": "शब्द रैप टॉगल करें",
-    "topology": "टोपोलॉजी",
-    "topology-graph": {
-      "graph-orientation": "ग्राफ़ अभिविन्यास",
-      "invalid": "ग्राफ़ त्रुटि",
-      "invalid_description": "ग्राफ़ लोड करते समय एक त्रुटि हुई। कृपया त्रुटियों के लिए स्रोत कोड की जाँच करें।",
-      "zoom-fit": "फिट",
-      "zoom-in": "ज़ूम इन करें",
-      "zoom-out": "ज़ूम आउट करें",
-      "zoom-reset": "ज़ूम रीसेट करें"
-    },
-    "total_duration": "कुल अवधि",
-    "total_executions": "कुल Executions",
-    "trigger": "Trigger",
-    "trigger details": "Trigger विवरण",
-    "trigger disabled": "Flow स्रोत के भीतर Trigger अक्षम है",
-    "trigger execution id": "Trigger निष्पादन Id",
-    "trigger filter": {
-      "options": {
-        "ALL": "सभी निष्पादन",
-        "CHILD": "बाल निष्पादन",
-        "MAIN": "मूल निष्पादन"
+    "accept": "स्वीकारें",
+    "reject": "अस्वीकार करें",
+    "draft_available": "संपादक में ड्राफ्ट परिवर्तन उपलब्ध है",
+    "last modified": "अंतिम संशोधित",
+    "run task in playground": "प्लेग्राउंड में task चलाएं",
+    "task is running": "टास्क RUNNING है",
+    "task was successful": "टास्क सफल रहा",
+    "task failed": "टास्क FAILED",
+    "task was skipped": "टास्क को छोड़ दिया गया था",
+    "task sent a warning": "टास्क ने एक WARNING भेजा",
+    "defaultsToNamespaceFile": "डिफ़ॉल्ट रूप से namespace फ़ाइल: <code>{name}</code>",
+    "no_file_choosen": "कोई फ़ाइल चयनित नहीं",
+    "dependency": {
+      "controls": {
+        "zoom_in": "ज़ूम इन करें",
+        "zoom_out": "ज़ूम आउट",
+        "clear_selection": "चयन साफ़ करें",
+        "fit_view": "स्क्रीन के अनुसार फिट करें"
       },
-      "title": "बाल निष्पादन फ़िल्टर करें"
-    },
-    "trigger refresh": "ताज़ा करें",
-    "triggerId": "ट्रिगर ID",
-    "trigger_check_warning": "ट्रिगर वेरिएबल्स का उपयोग मैनुअल flow निष्पादन के साथ काम नहीं करेगा। समस्या को हल करने के लिए `??` कोएलस ऑपरेटर जोड़ें। उदाहरण के लिए, `trigger.date` के बजाय `trigger.date ?? execution.startDate` का उपयोग करें।",
-    "trigger_id_exists": "ट्रिगर Id पहले से मौजूद है",
-    "trigger_id_message": "ट्रिगर Id ${existingTrigger} पहले से ही flow में मौजूद है।",
-    "trigger_states": "राज्य",
-    "triggered": "निष्पादन trigger",
-    "triggered done": "निष्पादन <em>{name}</em> सफलतापूर्वक ट्रिगर किया गया है",
-    "triggerflow disabled": "Flow परिभाषा से Trigger अक्षम है",
-    "triggers": "Triggers",
-    "triggers_add_card_add": "जोड़ें",
-    "triggers_add_card_add_to_flow": "flow में जोड़ें",
-    "triggers_add_category_empty": "इस श्रेणी में कोई triggers नहीं हैं।",
-    "triggers_add_ee_tooltip": "यह trigger के लिए Enterprise Edition आवश्यक है।",
-    "triggers_add_empty_title": "कोई triggers नहीं मिले",
-    "triggers_add_filter_all": "सभी",
-    "triggers_add_filter_app": "ऐप",
-    "triggers_add_filter_core": "कोर",
-    "triggers_add_filter_realtime": "रियलटाइम",
-    "triggers_add_modal_add_button": "Flow में Trigger जोड़ें",
-    "triggers_add_modal_ee_notice": "यह trigger Enterprise Edition की आवश्यकता है।",
-    "triggers_add_modal_flow_placeholder": "किसी flow का चयन करें",
-    "triggers_add_modal_namespace_placeholder": "एक namespace चुनें",
-    "triggers_add_modal_properties_hint": "ट्रिगर जोड़ने के बाद flow संपादक में ट्रिगर गुणों को कॉन्फ़िगर करें।",
-    "triggers_add_modal_tab_documentation": "दस्तावेज़ीकरण",
-    "triggers_add_modal_tab_form": "फॉर्म",
-    "triggers_add_modal_tab_source": "स्रोत",
-    "triggers_add_modal_title": "{name}",
-    "triggers_add_modal_trigger_id": "ट्रिगर ID",
-    "triggers_add_modal_trigger_id_placeholder": "इस trigger के लिए अद्वितीय पहचानकर्ता",
-    "triggers_add_search_placeholder": "ट्रिगर्स खोजें...",
-    "triggers_header_description": "अपने flows को स्वचालित करने के लिए triggers को ब्राउज़ करें, जोड़ें और प्रबंधित करें। अपने flow को एक AI टूल के रूप में एक्सपोज़ करने, शेड्यूलिंग, एक webhook trigger जोड़ने, बाहरी ऐप्स में परिवर्तनों के लिए polling करने, या रीयलटाइम इवेंट listeners में से चुनें।",
-    "triggers_state": {
-      "options": {
-        "disabled": "अक्षम",
-        "enabled": "सक्षम"
-      },
-      "state": "स्थिति"
-    },
-    "triggers_tabs_add": "जोड़ें",
-    "triggers_tabs_manage": "प्रबंधित करें",
-    "true": "सत्य",
-    "type": "प्रकार",
-    "unable to generate graph": "ग्राफ़ उत्पन्न करते समय एक समस्या उत्पन्न हुई जिससे टोपोलॉजी प्रदर्शित नहीं हो सकी।",
-    "undefined": "अपरिभाषित",
-    "unlock": "अनलॉक करें",
-    "unlock trigger": {
-      "button": "Trigger अनलॉक करें",
-      "confirmation": "क्या आप वाकई Trigger को अनलॉक करना चाहते हैं?",
-      "success": "Trigger अनलॉक किया गया",
-      "tooltip": {
-        "evaluation": "Trigger वर्तमान में मूल्यांकन में है",
-        "execution": "इस Trigger के लिए एक निष्पादन चल रहा है"
-      },
-      "warning": "यह एक ही Trigger के लिए concurrent निष्पादन का कारण बन सकता है और इसे अंतिम उपाय के रूप में माना जाना चाहिए।"
-    },
-    "unqueue": "अनक्यू करें",
-    "unqueue as": "<code>{status}</code> के रूप में अनक्यू करें",
-    "unqueue confirm": "क्या आप वाकई निष्पादन <code>{id}</code> को अनक्यू करना चाहते हैं?",
-    "unqueue done": "निष्पादन कतार से बाहर है",
-    "unqueue title": "प्रक्रिया <code>{id}</code> को कतार से बाहर करें।<br/>ध्यान दें कि यह flow concurrency सीमा का पालन नहीं करेगा, इसलिए अनुमत सीमा से अधिक प्रक्रियाएँ चल रही हो सकती हैं।",
-    "unqueue title multiple": "क्या आप वाकई <code>{count}</code> executions को Unqueue करना चाहते हैं?<br/><br/>ध्यान दें कि यह flow concurrency सीमा का पालन नहीं करेगा, इसलिए अनुमत सीमा से अधिक executions चल सकती हैं।",
-    "unsaved changed ?": "आपके पास असहेजे गए परिवर्तन हैं, क्या आप इस पृष्ठ को छोड़ना चाहते हैं?",
-    "unsaved changes": "असहेजित परिवर्तन",
-    "unsaved changes warning": "आपके पास बिना सहेजे गए परिवर्तन हैं। यदि आप इस पृष्ठ को छोड़ते हैं, तो आपके परिवर्तन खो जाएंगे।",
-    "up trend": "बढ़ रहा है",
-    "update": "अपडेट करें",
-    "update aborted": "अपडेट रद्द कर दिया गया",
-    "update ok": "अपडेट किया गया है",
-    "updated date": "अपडेट तिथि",
-    "usage": "उपयोग",
-    "use": "उपयोग करें",
-    "use_dark_background": "इस संस्करण का उपयोग तब करें जब आप एक गहरे पृष्ठभूमि पर काम कर रहे हों ताकि यह सुनिश्चित हो सके कि हमारा नाम पठनीय बना रहे।",
-    "valid": "मान्य",
-    "validate": "मान्य करें",
-    "value": "Value",
-    "variable_explorer": {
-      "empty": "इस निष्पादन के लिए कोई वेरिएबल उपलब्ध नहीं है।",
-      "n_items": "[ {count} आइटम ]",
-      "n_keys": "\\{ {count} keys \\}",
-      "one_item": "[ 1 आइटम ]",
-      "one_key": "\\{ 1 key \\}",
-      "raw_json": "Raw JSON",
-      "search_placeholder": "Key या value खोजें...",
-      "select_prompt": "इसका value देखने के लिए एक वेरिएबल चुनें।",
-      "tasks_outputs": "Tasks outputs",
-      "title": "इनपुट/आउटपुट",
-      "tree": "ट्री"
-    },
-    "variables": "वेरिएबल्स",
-    "version": "संस्करण",
-    "view metrics": "मेट्रिक्स देखें",
-    "warning": "चेतावनी",
-    "warning detected": "चेतावनी का पता चला",
-    "warning flow with triggers": "इस flow में triggers शामिल हैं और यदि यह flow trigger अभिव्यक्तियों पर निर्भर करता है तो मैन्युअल निष्पादन विफल हो जाएगा।",
-    "watch": "देखें",
-    "watch_video": "वीडियो देखें",
-    "webhook": {
-      "copy_url": "वेबहुक URL कॉपी करें",
-      "curl_command": "Webhook cURL कमांड",
-      "curl_note": "इस cURL कमांड का उपयोग कस्टम JSON payload के साथ webhook के माध्यम से flow को trigger करने के लिए करें।",
-      "no_triggers": "इस flow में कोई सक्षम वेबहुक triggers नहीं हैं",
-      "payload": "Webhook Payload (JSON)"
-    },
-    "webhook link copied": "Webhook लिंक कॉपी किया गया।",
-    "welcome": {
-      "help": {
-        "text": "हमारे Slack समुदाय में कोई भी प्रश्न पूछें। यदि आप अटके हुए हैं, तो हम आपकी सहायता के लिए यहाँ हैं। ✋",
-        "title": "मदद चाहिए?"
-      },
-      "menu": "Welcome",
-      "tour": {
-        "text": "अपना उपयोग मामला चुनें और Kestra की विशेषताओं और क्षमताओं को सीखने के लिए चरण-दर-चरण मार्गदर्शिका का पालन करें। ❤️",
-        "title": "उत्पाद टूर लें"
-      },
-      "tutorial": {
-        "text": "* <a href=\"https://kestra.io/tutorial-videos/all?utm_source=app&utm_medium=referral&utm_campaign=welcome-tutorial\" target=\"_blank\">वीडियो ट्यूटोरियल्स</a>  \n* <a href=\"https://kestra.io/docs?utm_source=app&utm_medium=referral&utm_campaign=welcome-tutorial\" target=\"_blank\">दस्तावेज़ीकरण</a>  \n* <a href=\"https://kestra.io/blueprints?utm_source=app&utm_medium=referral&utm_campaign=welcome-tutorial\" target=\"_blank\">Blueprints</a>",
-        "title": "ट्यूटोरियल"
+      "search": {
+        "placeholders": {
+          "default": "flow या namespace द्वारा खोजें...",
+          "asset": "एसेट, flow या namespace द्वारा खोजें..."
+        },
+        "namespace": {
+          "select": "कृपया एक namespace चुनें",
+          "no_namespace": "बिना namespace"
+        },
+        "flow": {
+          "display": "flow निर्भरताओं को शामिल करें"
+        },
+        "no_results": "{term} के लिए कोई परिणाम नहीं मिला"
       }
     },
+    "preview": {
+      "label": "पूर्वावलोकन",
+      "force-editor": "संपादक दृश्य लागू करें",
+      "auto-view": "स्वचालित दृश्य",
+      "view": "देखें",
+      "rows_truncated": "{total} में से {shown} पंक्तियाँ दिखा रहा है। सभी डेटा देखने के लिए फ़ाइल डाउनलोड करें।",
+      "pagination_info": "पंक्तियाँ {start}-{end} में से {total} दिखा रहा है।",
+      "showing_rows": "पंक्तियाँ {start}-{end} में से {total} दिखा रहा है",
+      "expand": "विस्तार करें",
+      "collapse": "संक्षिप्त करें",
+      "previous": "पिछला",
+      "next": "अगला",
+      "page_of": "पृष्ठ {current} का {total}"
+    },
+    "delete trigger": "ट्रिगर हटाएं",
+    "delete triggers": "ट्रिगर्स हटाएं",
+    "bulk delete triggers": "क्या आप वाकई {count} triggers को हटाना चाहते हैं?",
+    "bulk success delete triggers": "{count} triggers सफलतापूर्वक हटा दिए गए हैं",
+    "delete trigger confirmation": "क्या आप वाकई trigger {id} को हटाना चाहते हैं? WARNING: यदि trigger अभी भी किसी flow में सक्रिय है, तो उसे हटाने से duplicate executions हो सकते हैं।",
+    "delete trigger success": "ट्रिगर {id} को सफलतापूर्वक हटा दिया गया है",
+    "delete trigger error": "ट्रिगर {id} को हटाने में त्रुटि",
+    "revision deleted": "समीक्षा {revision} को सफलतापूर्वक हटा दिया गया है",
+    "delete revision confirm": "क्या आप वाकई संशोधन {revision} को हटाना चाहते हैं?",
+    "delete revision error": "त्रुटि {error} के साथ संशोधन {revision} हटाने में त्रुटि",
+    "no_history": "कोई इतिहास उपलब्ध नहीं है",
+    "export_as": ".{format} के रूप में निर्यात करें",
+    "save_and_execute": "सहेजें और निष्पादित करें",
     "welcome_copilot": {
       "button_cta": "नई flow से शुरू करें",
       "create_manually": {
-        "description": "संपादक का उपयोग करके शुरू से निर्माण करें",
-        "title": "मैन्युअली बनाएँ"
+        "title": "मैन्युअली बनाएँ",
+        "description": "संपादक का उपयोग करके शुरू से निर्माण करें"
       },
       "docs": {
-        "description": "आधिकारिक दस्तावेज़ में और जानें",
-        "title": "दस्तावेज़ पढ़ें"
+        "title": "दस्तावेज़ पढ़ें",
+        "description": "आधिकारिक दस्तावेज़ में और जानें"
       },
+      "title": "अपने विचार को एक workflow में बदलें",
+      "need_help": "मदद चाहिए?",
+      "placeholder_prompt": "मुझे सुबह 9 बजे एक दैनिक अभिवादन संदेश भेजें।",
+      "show_more": "अधिक प्रॉम्प्ट दिखाएं",
+      "show_less": "कम प्रॉम्प्ट दिखाएं",
+      "remaining_quota": "आपके पास {count} AI generations शेष हैं। सीमा प्रतिदिन मध्यरात्रि UTC पर रीसेट होती है।",
       "execute_hint": {
-        "description": "अपने workflow को सहेजने और तुरंत चलाने के लिए क्लिक करें।",
-        "title": "अपने flow को सहेजें और निष्पादित करें"
+        "title": "अपने flow को सहेजें और निष्पादित करें",
+        "description": "अपने workflow को सहेजने और तुरंत चलाने के लिए क्लिक करें।"
+      },
+      "success_popup": {
+        "title": "बधाई हो!",
+        "description": "आपने सफलतापूर्वक अपना पहला flow निष्पादित कर लिया है! आप Kestra विशेषज्ञ बनने की राह पर हैं।",
+        "tutorial": "डीप डाइव ट्यूटोरियल",
+        "explore": "और अन्वेषण करें"
+      },
+      "success_page": {
+        "title": "आप पूरी तरह से तैयार हैं!",
+        "description": "आपने Kestra की मूल बातें सीख ली हैं। यहाँ कुछ संसाधन हैं जो आपकी यात्रा को जारी रखने में मदद करेंगे।",
+        "restart": "ट्यूटोरियल पुनः प्रारंभ करें",
+        "items": {
+          "tutorial": {
+            "title": "ट्यूटोरियल शुरू करें",
+            "description": "Kestra की सभी विशेषताओं का इंटरएक्टिव वॉकथ्रू"
+          },
+          "blueprints": {
+            "title": "ब्लूप्रिंट्स",
+            "description": "सामान्य उपयोग मामलों के लिए पूर्व-निर्मित वर्कफ़्लो टेम्पलेट्स"
+          },
+          "slack": {
+            "title": "स्लैक कम्युनिटी",
+            "description": "अन्य उपयोगकर्ताओं के साथ जुड़ें और समुदाय से सहायता प्राप्त करें"
+          },
+          "videos": {
+            "title": "वीडियो ट्यूटोरियल्स",
+            "description": "उन्नत विशेषताओं के लिए चरण-दर-चरण वीडियो गाइड्स"
+          },
+          "demo": {
+            "title": "डेमो प्राप्त करें",
+            "description": "Kestra एंटरप्राइज एडिशन को एक व्यक्तिगत डेमो के साथ एक्सप्लोर करें"
+          }
+        }
+      },
+      "help": {
+        "tutorial": {
+          "title": "ट्यूटोरियल शुरू करें",
+          "description": "अपने पहले flow को बनाने और चलाने के लिए मार्गदर्शित चरणों के साथ सीखें।"
+        },
+        "blueprints": {
+          "title": "ब्लूप्रिंट्स",
+          "description": "सामान्य workflow पैटर्न के लिए तैयार-उपयोग उदाहरण और टेम्पलेट्स का अन्वेषण करें।"
+        },
+        "slack": {
+          "title": "स्लैक कम्युनिटी",
+          "description": "हमसे जुड़ें विचारों और सर्वोत्तम प्रथाओं को साझा करने के लिए, और तकनीकी प्रश्नों में सहायता प्राप्त करने के लिए।"
+        }
       },
       "flows": {
-        "buildDbtPipeline": {
-          "label": "एक dbt पाइपलाइन बनाएं",
-          "prompt": "Kestra flow बनाएँ जो एक dbt प्रोजेक्ट रिपॉजिटरी को क्लोन करता है और DuckDB प्रोफाइल के साथ dbt build चलाता है।"
-        },
-        "buildDockerImageAndRunIt": {
-          "label": "Docker इमेज बनाएं और इसे चलाएं",
-          "prompt": "एक Kestra flow बनाएँ जो एक इनलाइन Dockerfile से Docker इमेज बनाता है और परिणामी कंटेनर को चलाता है।"
-        },
-        "convertCsvToExcel": {
-          "label": "CSV को Excel में परिवर्तित करें",
-          "prompt": "एक flow बनाएँ जो एक CSV फ़ाइल डाउनलोड करता है, उसे Ion में परिवर्तित करता है, और परिणाम को Excel फ़ाइल के रूप में निर्यात करता है।"
-        },
-        "etlWorkflow": {
-          "label": "ETL वर्कफ़्लो",
-          "prompt": "ETL flow बनाएँ जो JSON डेटा डाउनलोड करता है, उसे Python के साथ प्रोसेस करता है, और DuckDB के साथ परिवर्तित परिणाम को क्वेरी करता है।"
+        "jsonApiToDuckdb": {
+          "label": "JSON API से DuckDB",
+          "prompt": "एक flow बनाएं जो एक सार्वजनिक API से JSON फ़ाइल डाउनलोड करता है, उसे एक Python स्क्रिप्ट के साथ परिवर्तित करता है, और उसे एक DuckDB Queries task के साथ प्रोसेस करता है।"
         },
         "installNginxViaAnsible": {
           "label": "Ansible के माध्यम से Nginx इंस्टॉल करें",
           "prompt": "Ansible के साथ लक्षित मशीन पर Nginx स्थापित करने और स्थापित संस्करण को सत्यापित करने के लिए एक Kestra flow बनाएं।"
         },
-        "jsonApiToDuckdb": {
-          "label": "JSON API से DuckDB",
-          "prompt": "एक flow बनाएं जो एक सार्वजनिक API से JSON फ़ाइल डाउनलोड करता है, उसे एक Python स्क्रिप्ट के साथ परिवर्तित करता है, और उसे एक DuckDB Queries task के साथ प्रोसेस करता है।"
+        "buildDbtPipeline": {
+          "label": "एक dbt पाइपलाइन बनाएं",
+          "prompt": "Kestra flow बनाएँ जो एक dbt प्रोजेक्ट रिपॉजिटरी को क्लोन करता है और DuckDB प्रोफाइल के साथ dbt build चलाता है।"
+        },
+        "etlWorkflow": {
+          "label": "ETL वर्कफ़्लो",
+          "prompt": "ETL flow बनाएँ जो JSON डेटा डाउनलोड करता है, उसे Python के साथ प्रोसेस करता है, और DuckDB के साथ परिवर्तित परिणाम को क्वेरी करता है।"
+        },
+        "microservicesApis": {
+          "label": "माइक्रोसर्विसेज़ और APIज़",
+          "prompt": "एक flow बनाएँ जो एक वेबसाइट API प्रतिक्रिया की जाँच करता है और जब स्थिति कोड सफल नहीं होता है तो एक Slack अलर्ट भेजता है।"
+        },
+        "buildDockerImageAndRunIt": {
+          "label": "Docker इमेज बनाएं और इसे चलाएं",
+          "prompt": "एक Kestra flow बनाएँ जो एक इनलाइन Dockerfile से Docker इमेज बनाता है और परिणामी कंटेनर को चलाता है।"
         },
         "manualApproval": {
           "label": "मैनुअल अनुमोदन",
           "prompt": "स्वीकृति के बाद एक प्रारंभिक प्रोसेसिंग चरण, एक मैनुअल अनुमोदन विराम, और एक अंतिम डिप्लॉयमेंट चरण के साथ एक flow बनाएं।"
         },
-        "microservicesApis": {
-          "label": "माइक्रोसर्विसेज़ और APIज़",
-          "prompt": "एक flow बनाएँ जो एक वेबसाइट API प्रतिक्रिया की जाँच करता है और जब स्थिति कोड सफल नहीं होता है तो एक Slack अलर्ट भेजता है।"
+        "convertCsvToExcel": {
+          "label": "CSV को Excel में परिवर्तित करें",
+          "prompt": "एक flow बनाएँ जो एक CSV फ़ाइल डाउनलोड करता है, उसे Ion में परिवर्तित करता है, और परिणाम को Excel फ़ाइल के रूप में निर्यात करता है।"
         },
         "scheduledPdfReports": {
           "label": "अनुसूचित PDF रिपोर्ट्स",
@@ -2232,73 +2189,116 @@
           "label": "साप्ताहिक बिक्री KPIs को Slack पर",
           "prompt": "साप्ताहिक अनुसूचित flow बनाएं जो DuckDB के साथ बिक्री KPIs की गणना करता है और सारांश को Slack पर पोस्ट करता है।"
         }
-      },
-      "help": {
-        "blueprints": {
-          "description": "सामान्य workflow पैटर्न के लिए तैयार-उपयोग उदाहरण और टेम्पलेट्स का अन्वेषण करें।",
-          "title": "ब्लूप्रिंट्स"
-        },
-        "slack": {
-          "description": "हमसे जुड़ें विचारों और सर्वोत्तम प्रथाओं को साझा करने के लिए, और तकनीकी प्रश्नों में सहायता प्राप्त करने के लिए।",
-          "title": "स्लैक कम्युनिटी"
-        },
-        "tutorial": {
-          "description": "अपने पहले flow को बनाने और चलाने के लिए मार्गदर्शित चरणों के साथ सीखें।",
-          "title": "ट्यूटोरियल शुरू करें"
-        }
-      },
-      "need_help": "मदद चाहिए?",
-      "placeholder_prompt": "मुझे सुबह 9 बजे एक दैनिक अभिवादन संदेश भेजें।",
-      "remaining_quota": "आपके पास {count} AI generations शेष हैं। सीमा प्रतिदिन मध्यरात्रि UTC पर रीसेट होती है।",
-      "show_less": "कम प्रॉम्प्ट दिखाएं",
-      "show_more": "अधिक प्रॉम्प्ट दिखाएं",
-      "success_page": {
-        "description": "आपने Kestra की मूल बातें सीख ली हैं। यहाँ कुछ संसाधन हैं जो आपकी यात्रा को जारी रखने में मदद करेंगे।",
-        "items": {
-          "blueprints": {
-            "description": "सामान्य उपयोग मामलों के लिए पूर्व-निर्मित वर्कफ़्लो टेम्पलेट्स",
-            "title": "ब्लूप्रिंट्स"
-          },
-          "demo": {
-            "description": "Kestra एंटरप्राइज एडिशन को एक व्यक्तिगत डेमो के साथ एक्सप्लोर करें",
-            "title": "डेमो प्राप्त करें"
-          },
-          "slack": {
-            "description": "अन्य उपयोगकर्ताओं के साथ जुड़ें और समुदाय से सहायता प्राप्त करें",
-            "title": "स्लैक कम्युनिटी"
-          },
-          "tutorial": {
-            "description": "Kestra की सभी विशेषताओं का इंटरएक्टिव वॉकथ्रू",
-            "title": "ट्यूटोरियल शुरू करें"
-          },
-          "videos": {
-            "description": "उन्नत विशेषताओं के लिए चरण-दर-चरण वीडियो गाइड्स",
-            "title": "वीडियो ट्यूटोरियल्स"
-          }
-        },
-        "restart": "ट्यूटोरियल पुनः प्रारंभ करें",
-        "title": "आप पूरी तरह से तैयार हैं!"
-      },
-      "success_popup": {
-        "description": "आपने सफलतापूर्वक अपना पहला flow निष्पादित कर लिया है! आप Kestra विशेषज्ञ बनने की राह पर हैं।",
-        "explore": "और अन्वेषण करें",
-        "title": "बधाई हो!",
-        "tutorial": "डीप डाइव ट्यूटोरियल"
-      },
-      "title": "अपने विचार को एक workflow में बदलें"
+      }
     },
-    "welcome_page": {
-      "guide": "क्या आपको अपना पहला flow निष्पादित करने के लिए मार्गदर्शन चाहिए?",
-      "welcome": "Kestra में आपका स्वागत है"
+    "mcp": {
+      "your_servers": "आपके सर्वर",
+      "servers_count": "{{count}} MCP Servers",
+      "managed_by_kestra": "Kestra द्वारा प्रबंधित",
+      "servers": "MCP सर्वर",
+      "server": "MCP सर्वर",
+      "client_setup": "क्लाइंट सेटअप",
+      "page_description": "अपने Kestra flows को MCP-संगत AI एजेंट्स के लिए उपकरण के रूप में प्रस्तुत करें",
+      "create": "सर्वर बनाएं",
+      "save": "परिवर्तनों को सहेजें",
+      "connect": "कनेक्ट करें",
+      "copy_url": "URL कॉपी करें",
+      "url_copied": "URL कॉपी हो गया!",
+      "instructions": "निर्देश",
+      "server_type": "सर्वर प्रकार",
+      "auth_type": "प्रमाणीकरण",
+      "private": "निजी",
+      "private_server": "निजी सर्वर",
+      "public": "सार्वजनिक",
+      "public_hint": "चेतावनी: सार्वजनिक सर्वर को किसी प्रमाणीकरण की आवश्यकता नहीं होती है। URL वाला कोई भी व्यक्ति इस सर्वर द्वारा उजागर किए गए हर टूल को बिना किसी namespace या अनुमति जाँच के कॉल कर सकता है। इसका उपयोग केवल उन सर्वर के लिए करें जिन्हें बाहरी रूप से उजागर करना सुरक्षित हो।",
+      "basic_auth": "बेसिक ऑथ",
+      "api_token": "एपीआई टोकन",
+      "oauth": "OAuth",
+      "username_password": "यूज़रनेम और पासवर्ड",
+      "bearer_token": "बेयर टोकन प्रमाणीकरण",
+      "oauth_hint": "आपके OIDC प्रदाता से Bearer JWT",
+      "oauth_provider": "OAuth प्रदाता",
+      "oauth_provider_placeholder": "कोई कॉन्फ़िगर किया गया OIDC प्रदाता चुनें",
+      "oauth_provider_required": "जब प्रमाणीकरण प्रकार OAuth हो तो OAuth प्रदाता आवश्यक है",
+      "scopes_supported": "समर्थित scopes",
+      "scopes_supported_placeholder": "openid, profile, email",
+      "scopes_supported_hint": "इस सर्वर के Protected Resource Metadata दस्तावेज़ में विज्ञापित scopes। स्पेक-अनुपालक MCP क्लाइंट अपनी प्राधिकरण अनुरोध को इस सूची तक सीमित करते हैं। फ़ील्ड को छोड़ने और क्लाइंट को IdP के विज्ञापित scopes पर वापस जाने देने के लिए खाली छोड़ें।",
+      "no_oauth_providers": "इस इंस्टेंस में कोई OIDC प्रदाता कॉन्फ़िगर नहीं है",
+      "delete_confirm": "क्या आप वाकई इस MCP सर्वर को हटाना चाहते हैं?",
+      "no_servers": "कोई MCP सर्वर नहीं मिला। बाहरी AI एजेंट्स के लिए MCP Tool triggers को एक्सपोज़ करने के लिए अपना पहला सर्वर बनाएं।",
+      "server_id": "सर्वर ID",
+      "id_placeholder": "उदा. my-mcp-server",
+      "id_invalid": "आईडी को एक छोटे अक्षर या अंक से शुरू होना चाहिए, और इसमें केवल छोटे अक्षर, अंक, हाइफन, या अंडरस्कोर शामिल होने चाहिए।",
+      "main_tenant": "मुख्य",
+      "tab_edit": "संपादित करें",
+      "tab_connect": "कनेक्ट करें",
+      "tab_tool_flows": "टूल Flows",
+      "tab_tool_flows_placeholder": "टूल flows प्रबंधन जल्द ही आ रहा है।",
+      "tools": {
+        "no_tools": "आपकी खोज से मेल खाने वाले कोई टूल flows नहीं हैं।",
+        "create_tool_flow": "एक टूल flow बनाएँ",
+        "tool_name": "Tool का नाम",
+        "trigger_id": "Trigger ID",
+        "title": "शीर्षक",
+        "description": "विवरण",
+        "annotations": "Annotations",
+        "flow": "flow",
+        "state": "स्थिति",
+        "read_only": "केवल पढ़ें",
+        "open_world": "Open world",
+        "destructive": "विनाशकारी",
+        "idempotent": "Idempotent",
+        "return_direct": "सीधा वापसी",
+        "view_flow": "flow खोलें"
+      },
+      "connect_tab": {
+        "server_url": "सर्वर URL",
+        "client_picker_label": "अपना AI क्लाइंट चुनें",
+        "claude_desktop": "क्लॉड डेस्कटॉप",
+        "claude_desktop_hint": "अपने claude_desktop_config.json फ़ाइल में निम्नलिखित जोड़ें:",
+        "claude_desktop_mac": "macOS: ~/Library/Application Support/Claude/claude_desktop_config.json",
+        "claude_desktop_win": "Windows: %APPDATA%\\Claude\\claude_desktop_config.json",
+        "claude_code": "क्लॉड कोड",
+        "claude_code_hint": "अपने टर्मिनल में निम्नलिखित कमांड चलाएँ:",
+        "cursor": "कर्सर",
+        "cursor_hint": "`~/.cursor/mcp.json` में निम्नलिखित जोड़ें:",
+        "codex": "Codex (OpenAI)",
+        "codex_hint": "अपने codex.json MCP कॉन्फ़िगरेशन में निम्नलिखित जोड़ें:",
+        "auth_basic_hint": "क्लाइंट शुरू करने से पहले <code>KESTRA_BASIC_AUTH</code> को एक पर्यावरण चर के रूप में सेट करें जिसमें base64-एन्कोडेड <code>username:password</code> स्ट्रिंग हो।",
+        "auth_api_token_hint": "क्लाइंट शुरू करने से पहले <code>KESTRA_TOKEN</code> को एक पर्यावरण चर के रूप में सेट करें।",
+        "auth_oauth_client_id_hint": "<code>&lt;client-id&gt;</code> को OAuth client ID से बदलें, और उस client पर <code>http://localhost:7777</code> को वैध redirect URI के रूप में पंजीकृत करें।",
+        "auth_oauth_browser_hint": "पहले कनेक्शन पर आपका ब्राउज़र पहचान प्रदाता का लॉगिन पृष्ठ खोलेगा।"
+      }
     },
-    "wordmark_colors": "शब्दचिह्न के रंग पृष्ठभूमि के आधार पर अनुकूलित होते हैं, जबकि आइकन एक गहरे पृष्ठभूमि पर रखे जाने पर बिना पृष्ठभूमि के रहता है।",
-    "worker group": "Worker समूह",
-    "worker group fallback": "वर्कर ग्रुप फॉलबैक",
-    "worker group key": "वर्कर ग्रुप key",
-    "worker information": "वर्कर जानकारी",
-    "workerId": "Worker Id",
-    "workers": "Workers",
-    "wrong labels": "labels में खाली key या value की अनुमति नहीं है",
-    "yes": "हाँ"
+    "flow_editor_stats": {
+      "revisions": {
+        "suffix": "संशोधन(संशोधन)",
+        "tooltip": "flow संशोधन देखें"
+      },
+      "dependencies": {
+        "suffix": "निर्भरताएं",
+        "tooltip": "flow निर्भरता देखें"
+      },
+      "apps": {
+        "suffix": "ऐप(s)",
+        "tooltip": "इस flow का उपयोग करने वाले ऐप्स देखें"
+      },
+      "tests": {
+        "suffix": "परीक्षण(परीक्षण)",
+        "tooltip": "flow परीक्षण देखें"
+      },
+      "errors": {
+        "label": "{count} त्रुटि(याँ)"
+      }
+    },
+    "source_search": {
+      "match_count": "{count} मिलान | {count} मिलान",
+      "open_flow": "flow खोलें",
+      "preview_empty": "पूर्वावलोकन के लिए एक परिणाम चुनें। स्रोत देखने के लिए परिणाम सूची में किसी flow पर क्लिक करें।",
+      "preview_error": "flow स्रोत लोड करने में विफल"
+    },
+    "open source": "ओपन सोर्स",
+    "pricing": "मूल्य निर्धारण",
+    "license": "लाइसेंस"
   }
 }

--- a/ui/src/translations/it.json
+++ b/ui/src/translations/it.json
@@ -1,1678 +1,722 @@
 {
   "it": {
-    "Add flow": "Aggiungi flow",
-    "Default log level": "Livello di log predefinito",
-    "Default namespace": "Namespace predefinito",
-    "Default page": "Pagina predefinita",
-    "Editor fontfamily": "Famiglia di font dell'editor",
-    "Editor fontsize": "Dimensione del font dell'editor",
-    "Editor theme": "Tema dell'editor",
-    "Fold auto": "Editor: piegatura automatica delle righe multiple",
-    "Fold content lines": "Piega stringhe multilinea",
-    "Hover description": "Editor: Mostra la descrizione del campo quando si passa il mouse su key o value",
-    "Language": "Lingua",
-    "Per page": "per pagina",
-    "Set default page": "Imposta pagina predefinita",
-    "Set labels": "Imposta etichette",
-    "Set labels done": "Etichette dell'esecuzione impostate con successo",
-    "Set labels to execution": "Aggiungi o aggiorna le etichette dell'esecuzione <code>{id}</code>",
-    "Set labels tooltip": "Imposta etichette all'esecuzione",
-    "Task Id already exist in the flow": "Task Id {taskId} già esistente nel flow.",
-    "Total": "Totale",
-    "Unfold content lines": "Spiega stringhe multilinea",
-    "about_this_blueprint": "Informazioni su questo blueprint",
-    "absolute": "Assoluto",
-    "accept": "Accetta",
-    "actions": "Azioni",
-    "activate_basic_auth": "Attiva l'Autenticazione di Base",
-    "active": "Attivo",
-    "active-slots": "Slot attivi",
-    "actual state": "Stato attuale",
-    "add": "Aggiungi",
-    "add at position": "Aggiungi {position} <code>{task}</code>",
-    "add error handler": "Aggiungi un gestore errori",
-    "add flow": "Aggiungi flow",
+    "loading": "Caricamento...",
+    "more actions": "Altre azioni",
+    "toggle menu": "Attiva/disattiva menu",
+    "panel actions": "Azioni del pannello",
+    "playground actions": "Azioni del playground",
+    "bulk actions": "Azioni collettive",
+    "view metrics": "Visualizza metriche",
+    "remove this item": "Rimuovi questo elemento",
     "add label": "Aggiungi label",
-    "add task": "Aggiungi un task",
-    "add-trigger-in-editor": "Aggiungi un Trigger al tuo Flow prima",
-    "add_new_item": "Aggiungi nuovo elemento",
-    "additionalPlugins": "Plugin Aggiuntivi",
-    "admin": "Amministratore",
-    "admin_preferences": "Preferences",
-    "administration": "Amministrazione",
-    "advanced configuration": "Altre proprietà",
-    "after": "dopo",
-    "aggregation": "Aggregazione",
-    "ai": {
-      "dashboard": {
-        "prompt_placeholder": "Fai una domanda sui tuoi dati. Esempio di prompt: Mostrami il tasso di successo dei miei flow negli ultimi 7 giorni."
+    "remove label": "Rimuovi label",
+    "id": "Id",
+    "type": "Tipo",
+    "ok": "OK",
+    "valid": "Valido",
+    "close": "Chiudi",
+    "namespace": "Namespace",
+    "description": "Descrizione",
+    "show description": "Mostra una descrizione",
+    "show details": "Mostra dettagli",
+    "show more details": "Mostra più dettagli",
+    "skipped": "Saltato",
+    "revision": "Revisione",
+    "Language": "Lingua",
+    "Set default page": "Imposta pagina predefinita",
+    "theme": "Tema",
+    "flows": "Flows",
+    "flow": "Flow",
+    "invalid source": "Codice sorgente non valido",
+    "missingSource": "Sorgente mancante",
+    "update": "Aggiorna",
+    "update ok": "è aggiornato",
+    "delete ok": "è eliminato",
+    "Default page": "Pagina predefinita",
+    "confirmation": "Conferma",
+    "common": {
+      "back": "Indietro"
+    },
+    "delete confirm": "Sei sicuro di voler eliminare <code>{name}</code>?",
+    "outdated revision save confirmation": {
+      "confirm": "Vuoi sovrascriverlo?",
+      "update": {
+        "title": "Revisione obsoleta",
+        "description": "La revisione che stai modificando è obsoleta.",
+        "details": "Controlla la scheda Revisions per maggiori dettagli sull'ultima versione."
       },
-      "flow": {
-        "enable_instructions": {
-          "footer": "Nota: Al momento, solo Gemini è supportato come provider AI per l'Open Source Edition. Per l'Enterprise Edition, fare riferimento alla documentazione di AI Copilot per la configurazione di altri provider di modelli.\n\nRiavvia la tua istanza di Kestra dopo aver salvato la configurazione.",
-          "header": "<b>AI Copilot non è stato ancora configurato.</b>\n\nPer abilitare AI Copilot, aggiungi il seguente snippet al file di configurazione della tua istanza di Kestra (ad esempio <code>application.yml</code>), sostituendo <code>geminiApiKey</code> con la tua chiave effettiva:"
-        },
-        "generating": {
-          "app": "Generazione del YAML dell'App per te...",
-          "dashboard": "Generazione del Dashboard YAML per te...",
-          "flow": "Generazione del Flow YAML per te...",
-          "test": "Generazione del Test YAML per te..."
-        },
-        "prompt_placeholder": "Inserisci le istruzioni per creare il tuo flow di Kestra. Esempio di prompt: Crea un flow che si esegue ogni lunedì alle 9 AM.",
-        "select_provider": "Seleziona un provider",
-        "title": "Agente AI"
+      "create": {
+        "title": "Flow già esistente",
+        "description": "Un flow con lo stesso id esiste già in questo namespace.",
+        "details": "Salva per sovrascrivere e creare una nuova revisione."
       }
     },
-    "all executions": "Tutte le esecuzioni",
-    "all tags": "Tutti i tag",
-    "api": "API",
-    "appBlocks": "Blocchi App",
-    "apps": "Applicazioni",
-    "are you sure change state": "Sei sicuro di voler cambiare lo stato?",
-    "assets": {
-      "title": "Risorse"
+    "override": {
+      "title": "Stai per sovrascrivere il flow corrente",
+      "details": "Il flow precedente può essere ripristinato dalla scheda Revisions."
     },
-    "attempt": "Tentativo",
-    "attempts": "Tentativi",
-    "auditlogs": "Audit Logs",
-    "automatic refresh": "Aggiornamento automatico",
-    "avg": "Media",
-    "avg duration": "Durata media dell'esecuzione",
+    "is deprecated": "è deprecato",
+    "success": "Success",
+    "save": "Salva",
+    "save_as_draft": "Salva come bozza",
+    "draft": "Bozza",
+    "draft_flow_warning": "Questa revisione del flow è una bozza. L'esecuzione verrà eseguita su questa revisione in bozza e potrebbe fallire immediatamente se la definizione del flow non è valida.",
+    "save task": "Salva Task",
+    "saved": "Salvato con successo",
+    "saved as draft": "Salvato come bozza con successo",
+    "saved done": "<em>{name}</em> è stato salvato con successo",
+    "saved as draft done": "<em>{name}</em> è stato salvato con successo come bozza",
+    "multiple saved done": "{name} è stato salvato",
+    "fileTypeNotAllowed": "Tipo di file non consentito. Tipi accettati: {types}",
+    "delete": "Elimina",
+    "deleted": "Eliminato con successo",
+    "deleted confirm": "<em>{name}</em> è stato eliminato con successo!",
+    "Add flow": "Aggiungi flow",
+    "add": "Aggiungi",
+    "add_new_item": "Aggiungi nuovo elemento",
+    "copy": "Copia",
+    "copy_to_clipboard": "Copia negli appunti",
+    "copy_and_close": "Copia e chiudi",
+    "Per page": "per pagina",
+    "new": "Nuovo",
+    "edit": "Modifica",
     "back": "Indietro",
-    "back_to_dashboard": "Torna alla dashboard",
-    "backfill": "Backfill",
-    "backfill executions": "Esecuzioni di backfill",
-    "backfill paused": "Backfill PAUSED",
-    "backfill running": "Esecuzione del backfill",
-    "bar": "Bar",
-    "before": "prima",
-    "behavior": "Comportamento",
-    "blueprints": {
-      "all": "Tutti",
-      "apps": "Blueprint delle App",
-      "community": "Comunità",
-      "create": "Crea un blueprint",
-      "custom": "Blueprint personalizzati",
-      "dashboards": "Blueprint del Dashboard",
-      "detail": {
-        "category": "Tipo di categoria",
-        "links": "Link e Risorse",
-        "openInEditor": "Apri in Modifica Flow"
-      },
-      "edit": "Modifica un blueprint",
-      "empty": "Nessun blueprint da mostrare.",
-      "flows": "Blueprint dei Flow",
-      "header": {
-        "alt": "Icona dei Blueprint",
-        "catch phrase": {
-          "1": "Il primo passo è sempre il più difficile.",
-          "2": "Esplora i blueprint per avviare il tuo prossimo {kind}."
-        }
-      },
-      "missingPlugins": {
-        "card": "Richiede plugin non installati su questa istanza: {plugins}",
-        "description": "Questo blueprint utilizza task di plugin non installati su questa istanza: {plugins}. Installali per usare questo blueprint.",
-        "install": "Installa plugin",
-        "title": "Plugin mancanti"
-      },
-      "title": "Blueprints"
+    "next": "Avanti",
+    "done": "Fatto",
+    "review your inputs": "Rivedi i tuoi input",
+    "edit flow": "Modifica flow",
+    "executions": "Esecuzioni",
+    "execution": "Esecuzione",
+    "execution id": "ID di Esecuzione",
+    "recent_executions": "Esecuzioni Recenti",
+    "details": "Dettagli",
+    "overview": "Panoramica",
+    "gantt": "Gantt",
+    "gantt_no_tasks_executed": "Questa esecuzione è terminata senza eseguire alcun task. Controlla la sua panoramica e i log per il motivo.",
+    "gantt_no_tasks_match_filters": "Prova a modificare i filtri di ricerca, stato o livello di log.",
+    "gantt_no_tasks_match_filters_title": "Nessun task corrisponde ai filtri selezionati.",
+    "logs": "Logs",
+    "no_logs_data": "Nessun dato",
+    "no_logs_data_description": "Prova a modificare i filtri, cambiare l'intervallo di tempo o verifica se il flow è stato eseguito di recente.",
+    "no_logs_data_title": "Nessun log trovato per i filtri selezionati.",
+    "duration": "Durata",
+    "total_duration": "Durata totale",
+    "running duration": "Durata in esecuzione",
+    "queued duration": "Durata in coda",
+    "choose file": "Scegli un file o trascinalo qui...",
+    "launch execution": "Esegui",
+    "warning flow with triggers": "Questo flow contiene triggers e un'esecuzione manuale fallirà se questo flow dipende da espressioni di trigger.",
+    "triggered": "Execution trigger",
+    "triggered done": "L'esecuzione <em>{name}</em> è stata attivata con successo",
+    "topology": "Topologia",
+    "date": "Data",
+    "prev_execution": "Esecuzione precedente",
+    "next_execution": "Prossima esecuzione",
+    "datepicker": {
+      "leave empty for infinite": "Lascia vuoto per durata infinita o digita una durata ISO 8601 (esempio: 'P1DT1H1M1S)'",
+      "duration example": "Esempio: 'P1DT1H1M1S'",
+      "error": "Formato durata non valido, deve essere una durata ISO 8601 (ad es. P1DT1H1M1S)",
+      "custom": "Personalizzato",
+      "last5minutes": "Ultimi 5 minuti",
+      "last15minutes": "Ultimi 15 minuti",
+      "last1hour": "Ultima 1 ora",
+      "last12hours": "Ultime 12 ore",
+      "last24hours": "Ultime 24 ore",
+      "last48hours": "Ultime 48 ore",
+      "last7days": "Ultimi 7 giorni",
+      "last30days": "Ultimi 30 giorni",
+      "last365days": "Ultimi 365 giorni",
+      "next5minutes": "Prossimi 5 minuti",
+      "next15minutes": "I prossimi 15 minuti",
+      "next1hour": "Prossima 1 ora",
+      "next12hours": "Prossime 12 ore",
+      "next24hours": "Prossime 24 ore",
+      "next48hours": "Prossime 48 ore",
+      "next7days": "Prossimi 7 giorni",
+      "next30days": "Prossimi 30 giorni",
+      "next365days": "Prossimi 365 giorni",
+      "5minutes": "5 minuti",
+      "15minutes": "15 minuti",
+      "1hour": "1 ora",
+      "12hours": "12 ore",
+      "24hours": "24 ore",
+      "48hours": "48 ore",
+      "7days": "7 giorni",
+      "30days": "30 giorni",
+      "365days": "365 giorni",
+      "never": "Mai",
+      "today": "Oggi",
+      "yesterday": "Ieri",
+      "dayBeforeYesterday": "L'altro ieri",
+      "thisWeek": "Questa settimana",
+      "thisWeekSoFar": "Questa settimana finora",
+      "previousWeek": "Settimana precedente",
+      "thisMonth": "Questo mese",
+      "thisMonthSoFar": "Questo mese finora",
+      "previousMonth": "Mese precedente",
+      "thisYear": "Quest'anno",
+      "thisYearSoFar": "Quest'anno finora",
+      "previousYear": "Anno precedente",
+      "short": {
+        "15m": "15m",
+        "1h": "1h",
+        "12h": "12h",
+        "1d": "1g",
+        "7d": "7g"
+      }
     },
-    "body_line_clamp": "Limit line height",
-    "bookmark": "Segnalibri",
-    "breakpoints": "Punti di interruzione",
-    "bulk action async warning": "Questo potrebbe richiedere alcuni istanti.",
-    "bulk actions": "Azioni collettive",
-    "bulk change state": "Sei sicuro di voler cambiare lo stato di <code>{executionCount}</code> esecuzione/i?",
-    "bulk delete": "Sei sicuro di voler eliminare <code>{executionCount}</code> esecuzione/i?",
-    "bulk delete backfills": "Elimina {count} backfill",
-    "bulk delete triggers": "Sei sicuro di voler eliminare {count} trigger?",
-    "bulk disabled status": {
-      "false": "Abilita {count} triggers",
-      "true": "Disabilita {count} triggers"
+    "created date": "Data di creazione",
+    "latest_update": "Ultimo aggiornamento",
+    "updated date": "Data di aggiornamento",
+    "expiration date": "Data di scadenza",
+    "started date": "Data di inizio",
+    "healthcheck date": "Data di HealthCheck",
+    "next execution date": "Data della prossima esecuzione",
+    "last execution status": "Ultimo stato di esecuzione",
+    "jump to...": "Vai a...",
+    "contextBar": {
+      "news": "Notizie",
+      "docs": "Documenti",
+      "help": "Aiuto",
+      "issue": "Problema",
+      "demo": "Demo",
+      "star": "Metti una stella"
     },
-    "bulk force run": "Sei sicuro di voler forzare l'esecuzione di <code>{executionCount}</code>?<br/><br/>WARNING: forzare l'esecuzione non è garantito e potrebbe creare esecuzioni duplicate dei task.<br/><br/>Le seguenti transizioni verranno effettuate:<br/><ul><li>I task in stato CREATED verranno spostati allo stato RUNNING.</li><li>I task in stato RUNNING verranno ri-sottomessi.</li><li>I task in stato QUEUED verranno rimossi dalla coda.</li><li>I task in stato PAUSED verranno ripresi.</li></ul>",
-    "bulk kill": "Sei sicuro di voler kill <code>{executionCount}</code> esecuzione/i?",
-    "bulk pause": "Sei sicuro di voler mettere in pausa l'esecuzione di <code>{executionCount}</code>?",
-    "bulk pause backfills": "Metti in pausa {count} backfill",
-    "bulk replay": "Sei sicuro di voler ripetere <code>{executionCount}</code> esecuzione/i?",
-    "bulk restart": "Sei sicuro di voler riavviare <code>{executionCount}</code> esecuzione/i?",
-    "bulk resume": "Sei sicuro di voler riprendere <code>{executionCount}</code> esecuzione/i?",
-    "bulk set labels": "Sei sicuro di voler impostare etichette a <code>{executionCount}</code> esecuzione/i?",
-    "bulk success delete backfills": "{count} backfills eliminati",
-    "bulk success delete triggers": "{count} trigger sono stati eliminati con successo",
-    "bulk success disabled status": {
-      "false": "{count} trigger(s) abilitati",
-      "true": "{count} trigger(s) disabilitati"
+    "source": "Fonte",
+    "source only": "Solo sorgente",
+    "home": "Home",
+    "create": "Crea",
+    "create_flow": "Crea Flow",
+    "add flow": "Aggiungi flow",
+    "from": "Da",
+    "to": "A",
+    "search filters": {
+      "saved": "Filtri salvati",
+      "manage": "Gestisci filtri di ricerca",
+      "manage desc": "Gestisci filtri di ricerca salvati",
+      "save filter": "Salva filtro",
+      "filter name": "Nome filtro",
+      "filters": "Filtri"
     },
-    "bulk success pause backfills": "{count} backfills messi in pausa",
-    "bulk success unlock": "{count} triggers sbloccati",
-    "bulk success unpause backfills": "{count} backfills riavviati",
-    "bulk unlock": "Sblocca {count} triggers",
-    "bulk unpause backfills": "Riavvia {count} backfill",
-    "bulk unqueue": "Sei sicuro di voler rimuovere dalla coda <code>{executionCount}</code> esecuzione/i?",
-    "can not delete": "Impossibile eliminare",
-    "can not have less than 1 task": "Ogni flow deve avere almeno un task.",
-    "can not save": "Impossibile salvare",
-    "cancel": "Annulla",
+    "steps": "Passaggi",
+    "state": "Stato",
+    "state_history": "Cronologia degli stati",
+    "search term in message": "Cerca termine nel messaggio",
+    "search": "Cerca",
+    "search blueprint": "Cerca blueprints",
+    "all tags": "Tutti i tag",
+    "source search": "Cerca fonte",
+    "filter by log level": "Filtra per livello di log",
+    "selected": "Selezionato",
+    "task": "Task",
+    "task logs": "Task logs",
+    "display flow {id} executions": "Visualizza esecuzioni del flow {id}",
+    "actions": "Azioni",
+    "select datetime": "Seleziona una data",
+    "select view": "Seleziona vista",
+    "invalid field": "Campo non valido: {name}",
+    "required field": "Campo obbligatorio",
+    "is required": "{field} è obbligatorio",
+    "error": "Errore",
+    "form": "Modulo",
+    "form error": "Errore del modulo",
+    "display topology for flow": "Visualizza topologia per flow",
     "cannot create topology": "Impossibile creare la topologia per il flow",
-    "cannot swap tasks": "Impossibile scambiare i tasks",
-    "change execution state confirm": "Sei sicuro di voler cambiare lo stato dell'esecuzione <code>{id}</code>?",
-    "change execution state done": "Stato di esecuzione aggiornato",
-    "change queue confirm": "Sei sicuro di voler cambiare lo stato della coda per l'esecuzione <code>{id}</code>?<br/>",
+    "start date": "Data di inizio",
+    "end date": "Data di fine",
+    "creation": "Creazione",
+    "flow creation": "Creazione del flow",
+    "start datetime": "Data e ora di inizio",
+    "end datetime": "Data e ora di fine",
+    "restart": "Riavvia",
+    "restart latest revision": "Riavvia ultima revisione",
+    "restart tooltip": "Riavvia l'esecuzione dal task <code>{state}</code>",
+    "restarted": "L'esecuzione è riavviata",
+    "restart confirm": "Sei sicuro di voler riavviare l'esecuzione <code>{id}</code>?",
+    "restart change revision": "Puoi cambiare la revisione che verrà utilizzata per la nuova esecuzione.",
+    "replay": "Ripeti",
+    "replay from task tooltip": "Crea un'esecuzione simile a partire dal task <code>{taskId}</code>",
+    "replay from beginning tooltip": "Crea un'esecuzione simile a partire dall'inizio",
+    "replay latest revision": "Ripeti utilizzando l'ultima revisione",
+    "replayed": "L'esecuzione è ripetuta",
+    "replay confirm": "Sei sicuro di voler ripetere questa esecuzione <code>{id}</code> e crearne una nuova?",
+    "replay with inputs": "Riesegui con input",
+    "reuse_original_inputs": "Riutilizza gli input originali",
+    "modify_inputs": "Modifica input",
+    "replay the execution": "Ripeti l'esecuzione <code>{executionId}</code> per il flow <code>{flowId}</code>",
+    "prefill inputs": "Precompila",
+    "current": "corrente",
     "change state": "Cambia stato",
-    "change state confirm": "Sei sicuro di voler cambiare lo stato di esecuzione del task <code>{task}</code> nell'esecuzione <code>{id}</code>?",
-    "change state current state": "Lo stato attuale è:",
+    "actual state": "Stato attuale",
+    "select a state": "Seleziona uno stato",
+    "are you sure change state": "Sei sicuro di voler cambiare lo stato?",
+    "yes": "Sì",
     "change state done": "Lo stato del task è stato aggiornato",
+    "change state confirm": "Sei sicuro di voler cambiare lo stato di esecuzione del task <code>{task}</code> nell'esecuzione <code>{id}</code>?",
+    "change queue confirm": "Sei sicuro di voler cambiare lo stato della coda per l'esecuzione <code>{id}</code>?<br/>",
+    "change state current state": "Lo stato attuale è:",
     "change state hint": {
+      "WARNING": [
+        "Il flow sarà contrassegnato come WARNING.",
+        "I prossimi task saranno eseguiti.",
+        "I task di errore saranno eseguiti."
+      ],
       "FAILED": [
         "Il flow sarà contrassegnato come FAILED.",
         "Nessun altro task verrà eseguito.",
         "I task di errore verranno eseguiti."
-      ],
-      "RUNNING": [
-        "Il flow verrà riavviato ed eseguirà tutti i task successivi.",
-        "Tutti i task bloccati verranno eseguiti."
       ],
       "SUCCESS": [
         "Il flow verrà riavviato poiché questo task è stato completato con successo.",
         "Tutti i task bloccati verranno eseguiti.",
         "Il flow sarà in stato SUCCESS se tutte le esecuzioni dei task avranno successo."
       ],
-      "WARNING": [
-        "Il flow sarà contrassegnato come WARNING.",
-        "I prossimi task saranno eseguiti.",
-        "I task di errore saranno eseguiti."
+      "RUNNING": [
+        "Il flow verrà riavviato ed eseguirà tutti i task successivi.",
+        "Tutti i task bloccati verranno eseguiti."
       ]
     },
+    "replay execution title": "Riesegui esecuzione",
+    "restart execution title": "Riavvia esecuzione",
+    "replay execution description": "Questo creerà una nuova esecuzione basata sull'esecuzione selezionata.",
+    "replay using": "Riproduci utilizzando",
+    "flow revision original": "Revisione originale del flow",
+    "flow revision latest": "Ultima revisione del flow",
+    "flow revision specific": "Revisione specifica del flow",
+    "replay inputs": "Ingressi",
+    "reuse original inputs": "Riutilizza gli input originali",
+    "modify inputs": "Modifica input",
+    "replay inputs new required": "Questa revisione ha degli input. Ti verrà chiesto di compilarli.",
+    "replay select taskrun": "Seleziona l'esecuzione del task da riprodurre:",
     "change state tooltip": "Cambia lo stato di esecuzione",
-    "chart": "Grafico",
-    "chart preview": "Anteprima grafico",
-    "chart type": "Tipo di grafico",
-    "charts": "Grafici",
-    "choice": "Scelta",
-    "choose file": "Scegli un file o trascinalo qui...",
-    "close": "Chiudi",
-    "close sidebar": "chiudi barra laterale",
-    "codeDisabled": "Disabilitato nel Flow",
-    "collapse": "Comprimi",
-    "collapse all": "Comprimi tutto",
-    "commit_id": "ID commit",
-    "common": {
-      "back": "Indietro"
-    },
-    "concurrency": "Concurrency",
-    "concurrency limits": "Limiti di Concorrenza",
-    "concurrency_limit": {
-      "dialog_title": "Limiti di Concorrenza",
-      "warning": "Modificare il contatore in esecuzione può corrompere la concorrenza, quindi le esecuzioni potrebbero superare il limite consentito."
-    },
-    "conditions": "Condizioni",
-    "configure basic auth": "Configura Autenticazione di Base",
-    "confirm": "Conferma",
-    "confirm password": "Conferma password",
-    "confirmation": "Conferma",
-    "context updated date": "Data di aggiornamento del contesto",
-    "context updated date tooltip": "Quando il contesto del trigger è stato aggiornato l'ultima volta. Questo avviene quando l'esecuzione è attivata, termina (blocco rilasciato) o dopo una valutazione (anche se non avviene alcuna esecuzione).",
-    "contextBar": {
-      "demo": "Demo",
-      "docs": "Documenti",
-      "help": "Aiuto",
-      "issue": "Problema",
-      "news": "Notizie",
-      "star": "Metti una stella"
-    },
-    "continue backfill": "Continua il backfill",
-    "continue backfills": "Continua i backfills",
-    "copied": "Copiato",
-    "copied_logs_to_clipboard": "Log copiati negli appunti.",
-    "copy": "Copia",
-    "copy all logs": "Copia tutti i Log",
-    "copy logs": "Copia logs",
-    "copy url": "Copia URL",
-    "copy_and_close": "Copia e chiudi",
-    "copy_to_clipboard": "Copia negli appunti",
-    "copy_value": "Copy value",
-    "create": "Crea",
-    "create first task": "Crea il tuo primo task",
-    "create_flow": "Crea Flow",
-    "created date": "Data di creazione",
-    "creation": "Creazione",
-    "cron": "Cron",
-    "curl": {
-      "command": "Comando cURL",
-      "note": "Nota che per il tipo di input SECRET e FILE, il comando deve essere adattato per corrispondere ai valori reali."
-    },
-    "current": "corrente",
-    "current execution": "Esecuzione corrente",
-    "custom value": "Valore personalizzato",
-    "customize sidebar": "Personalizza barra laterale",
-    "dark_version": "Versione scura",
-    "dashboards": {
-      "chart_preview": "Fai clic sul codice sorgente di un grafico per vedere l'anteprima",
-      "creation": {
-        "confirmation": "Il dashboard <code>{title}</code> è stato creato.",
-        "label": "Crea Dashboard"
-      },
-      "default": "Dashboard predefinito",
-      "deletion": {
-        "confirmation": "Sei sicuro di voler eliminare la dashboard <code>{title}</code>?"
-      },
-      "edition": {
-        "chart": "Modifica questo grafico",
-        "confirmation": "Le modifiche nel dashboard <code>{title}</code> sono state salvate.",
-        "id readonly": "La proprietà `id` non può essere modificata — è ora impostata sui suoi valori iniziali. Se desideri cambiarla, puoi creare una nuova dashboard e rimuovere quella vecchia.",
-        "label": "Modifica Dashboard"
-      },
-      "empty": "Non ci sono risultati da mostrare.",
-      "export": "Esporta in CSV",
-      "labels": {
-        "plural": "Dashboard",
-        "singular": "Dashboard"
-      },
-      "no_description": "Nessuna descrizione",
-      "no_description_hint": "Aggiungi una descrizione a questo flow per documentare cosa fa.<br>Markdown è supportato.",
-      "others": "Altri",
-      "preview": "Anteprima Dashboard",
-      "quick_filters": {
-        "all": "Tutti",
-        "failed": "Fallito",
-        "paused": "In pausa",
-        "running": "In esecuzione",
-        "success": "Successo",
-        "warning": "Avviso"
-      },
-      "switch": "Dashboard Switch",
-      "viewAll": "Vedi tutti"
-    },
-    "data": "Dati",
-    "dataFilters": "Filtri Dati",
-    "data_not_protected": "I tuoi dati non sono protetti. Non perderli. <b>Abilita le nostre funzionalità di sicurezza gratuite o prova la nostra offerta a pagamento.</b>",
-    "date": "Data",
-    "date count": "{count} il {date}",
-    "date format": "Formato data",
-    "date range count": "{count} tra il {startDate} e il {endDate}",
-    "datepicker": {
-      "12hours": "12 ore",
-      "15minutes": "15 minuti",
-      "1hour": "1 ora",
-      "24hours": "24 ore",
-      "30days": "30 giorni",
-      "365days": "365 giorni",
-      "48hours": "48 ore",
-      "5minutes": "5 minuti",
-      "7days": "7 giorni",
-      "custom": "Personalizzato",
-      "dayBeforeYesterday": "L'altro ieri",
-      "duration example": "Esempio: 'P1DT1H1M1S'",
-      "error": "Formato durata non valido, deve essere una durata ISO 8601 (ad es. P1DT1H1M1S)",
-      "last12hours": "Ultime 12 ore",
-      "last15minutes": "Ultimi 15 minuti",
-      "last1hour": "Ultima 1 ora",
-      "last24hours": "Ultime 24 ore",
-      "last30days": "Ultimi 30 giorni",
-      "last365days": "Ultimi 365 giorni",
-      "last48hours": "Ultime 48 ore",
-      "last5minutes": "Ultimi 5 minuti",
-      "last7days": "Ultimi 7 giorni",
-      "leave empty for infinite": "Lascia vuoto per durata infinita o digita una durata ISO 8601 (esempio: 'P1DT1H1M1S)'",
-      "never": "Mai",
-      "next12hours": "Prossime 12 ore",
-      "next15minutes": "I prossimi 15 minuti",
-      "next1hour": "Prossima 1 ora",
-      "next24hours": "Prossime 24 ore",
-      "next30days": "Prossimi 30 giorni",
-      "next365days": "Prossimi 365 giorni",
-      "next48hours": "Prossime 48 ore",
-      "next5minutes": "Prossimi 5 minuti",
-      "next7days": "Prossimi 7 giorni",
-      "previousMonth": "Mese precedente",
-      "previousWeek": "Settimana precedente",
-      "previousYear": "Anno precedente",
-      "short": {
-        "12h": "12h",
-        "15m": "15m",
-        "1d": "1g",
-        "1h": "1h",
-        "7d": "7g"
-      },
-      "thisMonth": "Questo mese",
-      "thisMonthSoFar": "Questo mese finora",
-      "thisWeek": "Questa settimana",
-      "thisWeekSoFar": "Questa settimana finora",
-      "thisYear": "Quest'anno",
-      "thisYearSoFar": "Quest'anno finora",
-      "today": "Oggi",
-      "yesterday": "Ieri"
-    },
-    "debug": "Debug",
-    "default": "Predefinito",
-    "defaultsToNamespaceFile": "Predefinito al file namespace: <code>{name}</code>",
-    "delete": "Elimina",
-    "delete backfill": "Elimina il backfill",
-    "delete backfills": "Elimina i backfills",
-    "delete confirm": "Sei sicuro di voler eliminare <code>{name}</code>?",
-    "delete execution running": "<div class=\"alert alert-warning mt-2 mb-0\">Questa esecuzione è ancora RUNNING, eliminarla non la fermerà.<br />È necessario kill l'esecuzione per fermarla.</div>",
-    "delete logs": "Elimina logs",
-    "delete ok": "è eliminato",
-    "delete revision confirm": "Sei sicuro di voler eliminare la revisione {revision}?",
-    "delete revision error": "Errore durante l'eliminazione della revisione {revision} con errore {error}",
-    "delete task confirm": "Vuoi eliminare il task <code>{taskId}</code>?",
-    "delete trigger": "Elimina trigger",
-    "delete trigger confirmation": "Sei sicuro di voler eliminare il trigger {id}? WARNING: eliminare un trigger potrebbe portare a esecuzioni duplicate se il trigger è ancora attivo in un flow.",
-    "delete trigger error": "Errore durante l'eliminazione del trigger {id}",
-    "delete trigger success": "Il trigger {id} è stato eliminato con successo",
-    "delete triggers": "Elimina trigger",
-    "delete_all_logs": "Sei sicuro di voler eliminare tutti i logs?",
-    "delete_log": "Sei sicuro di voler eliminare il log?",
-    "deleted": "Eliminato con successo",
-    "deleted confirm": "<em>{name}</em> è stato eliminato con successo!",
-    "deleted_label": "Eliminato",
-    "demos": {
-      "IAM": {
-        "message": "Kestra Enterprise Edition ha funzionalità IAM integrate con single sign-on (SSO), sincronizzazione della directory SCIM e controllo degli accessi basato sui ruoli (RBAC), integrandosi con diversi provider di identità e permettendo di assegnare permessi dettagliati per utenti e account di servizio.",
-        "title": "Gestisci gli utenti tramite IAM con SSO, SCIM e RBAC"
-      },
-      "apps": {
-        "message": "Le app nella Kestra Enterprise Edition ti consentono di creare interfacce utente personalizzate che interagiscono con i workflow di Kestra al di fuori della piattaforma. Questa funzionalità ti permette di utilizzare i tuoi workflow come backend per applicazioni personalizzate, consentendo agli utenti non tecnici di inviare dati tramite moduli o riprendere workflow PAUSED in attesa di approvazione.",
-        "title": "Crea App personalizzate con Kestra"
-      },
-      "assets": {
-        "header": "Metadati e Osservabilità degli Asset",
-        "label": "Risorse",
-        "message": "Le risorse collegano la osservabilità, la lineage e i metadati di proprietà in modo che i team della piattaforma possano risolvere i problemi più rapidamente e distribuire con fiducia.",
-        "title": "Porta ogni dataset, servizio e dipendenza in vista."
-      },
-      "audit-logs": {
-        "message": "Kestra Enterprise Edition registra ogni attività con record robusti e immutabili, rendendo facile tracciare le modifiche, mantenere la conformità e risolvere i problemi.",
-        "title": "Traccia le modifiche con i Log di Audit"
-      },
-      "blueprints": {
-        "message": "Nella Kestra Enterprise Edition, puoi creare blueprint personalizzati disponibili solo per la tua organizzazione. Puoi usarli come modelli di best-practice per condividere, centralizzare e documentare i flussi di lavoro comunemente utilizzati nel tuo team.",
-        "title": "Aggiungi Blueprint Personalizzati"
-      },
-      "contact_sales": "Contatta il reparto vendite",
-      "enterprise_edition": "Edizione Enterprise",
-      "get_a_demo_button": "Ottieni una Demo",
-      "instance": {
-        "message": "Kestra Enterprise Edition fornisce un dashboard operativo per aiutarti a osservare la salute della tua piattaforma e monitorare le metriche di uptime di tutti i servizi come, ad esempio, Workers, Schedulers e Executors. Dalla stessa pagina, puoi anche creare Annunci per notificare ai tuoi utenti il downtime pianificato e puoi entrare in una modalità di manutenzione che mette temporaneamente tutti i servizi e le esecuzioni dei workflow in uno stato di PAUSED per eseguire un aggiornamento.",
-        "title": "Gestisci l'Infrastruttura nella Tua Istanza"
-      },
-      "namespace": {
-        "assets": {
-          "message": "Nella Kestra Enterprise Edition, Assets mantiene un inventario aggiornato delle risorse con cui i tuoi workflow interagiscono. Queste risorse possono essere tabelle di database, macchine virtuali, file o qualsiasi sistema esterno con cui lavori.",
-          "title": "Centralizza la gestione delle risorse"
-        },
-        "audit-logs": {
-          "message": "Nella Kestra Enterprise Edition, puoi visualizzare i log di audit a livello di namespace con differenze dettagliate, offrendoti una chiara cronologia di chi ha modificato cosa e quando su tutte le risorse.",
-          "title": "Tieni traccia di tutte le modifiche in un unico posto"
-        },
-        "edit": {
-          "message": "Nella Kestra Enterprise Edition, i namespace forniscono un'isolamento avanzato e una governance dei segreti, delle variabili e dei plugin defaults su larga scala. Gli amministratori possono configurare gestori di segreti personalizzati, backend di storage isolati, gruppi di worker dedicati e permessi dettagliati su base per-namespace. Questo assicura che i segreti, le variabili e le configurazioni dei plugin rimangano sicuri e facili da gestire tra diversi team e progetti.",
-          "title": "Aggiorna la Gestione del tuo Namespace"
-        },
-        "history": {
-          "message": "Nella Kestra Enterprise Edition, puoi gestire la cronologia delle revisioni dei tuoi namespace",
-          "title": "Gestisci la Cronologia delle Revisioni in un Unico Luogo"
-        },
-        "plugin-defaults": {
-          "message": "Nella Kestra Enterprise Edition, puoi impostare i plugin predefiniti specifici per namespace, riducendo la necessità di configurazioni duplicate in ogni flow. Questa governance centrale dei plugin impone configurazioni coerenti, consente il riferimento sicuro a segreti o variabili e semplifica la manutenzione dei tuoi workflow.",
-          "title": "Standardizza la Configurazione con i Valori Predefiniti del Plugin"
-        },
-        "secrets": {
-          "message": "Nella Kestra Enterprise Edition, puoi memorizzare e controllare i segreti a livello di namespace, riducendo al minimo il rischio e garantendo che le credenziali di ciascun team rimangano isolate. Grazie alla gerarchia nidificata, puoi anche configurare le credenziali in un namespace genitore e queste verranno ereditate da tutti i namespace figli. Il supporto per gestori di segreti dedicati e impostazioni di autorizzazione a livello di namespace dettagliate rafforza ulteriormente la sicurezza e la conformità.",
-          "title": "Gestisci i Segreti in Modo Sicuro"
-        },
-        "variables": {
-          "message": "Nella Kestra Enterprise Edition, puoi definire e gestire variabili a livello di namespace per eliminare configurazioni ripetitive tra i flow. Queste variabili assicurano coerenza, semplificano gli aggiornamenti di configurazione e possono essere facilmente riferite da qualsiasi task o trigger per flussi di lavoro più puliti e manutenibili.",
-          "title": "Governa Centralmente le Tue Variabili"
-        }
-      },
-      "quotas": {
-        "message": "Kestra Enterprise Edition consente di definire quote sui flow per limitare il numero di esecuzioni simultanee o totali in una finestra temporale. Le quote aiutano a proteggere l'infrastruttura condivisa, applicare gli SLA e impedire che i workflow incontrollati consumino risorse eccessive.",
-        "title": "Applicare quote di esecuzione ai flow"
-      },
-      "secrets": {
-        "add_env": {
-          "first": "Codifica il <a href=\"https://kestra.io/docs/how-to-guides/secrets?utm_source=app&utm_medium=referral&utm_campaign=secrets-inlinedoc#using-secrets-in-kestra\" target=\"_blank\">valore segreto in Base64</a>",
-          "intro": "Per creare un nuovo Secret:",
-          "second": "Aggiungi una variabile di ambiente chiamata '<strong>SECRET_{'{MY_SECRET_KEY}'}</strong>' con il valore sopra indicato",
-          "third": "Riavvia la tua istanza di Kestra"
-        },
-        "detected_env": "Ecco le variabili d'ambiente di tipo secret identificate al momento dell'avvio dell'istanza:",
-        "empty_env": "Non hai ancora alcun Secret nel tuo ambiente.",
-        "message": "L'Enterprise Edition (EE) ti consente di aggiungere, modificare o eliminare segreti direttamente nell'interfaccia utente, senza bisogno di riavviare l'istanza. Organizza i segreti per namespace con permessi RBAC granulari e ereditali dai namespace genitori a quelli figli. EE si integra con gestori di segreti come HashiCorp Vault, AWS Secrets Manager, Azure Key Vault, Google Secret Manager ed Elasticsearch. Configura backend dedicati per namespace, tenant o istanza per isolare i segreti tra i team, oppure abilita segreti di sola lettura memorizzati in vault esterni. I segreti rimangono crittografati a riposo e in transito. La cache opzionale riduce le chiamate API e le tracce di audit registrano tutti gli accessi.",
-        "title": "Aggiorna il tuo Secrets Management"
-      },
-      "tenants": {
-        "message": "L'edizione Enterprise di Kestra supporta il multi-tenancy, offrendo ambienti completamente isolati per diversi team o progetti, ciascuno con le proprie risorse come gruppi di worker dedicati o segreti e backend di archiviazione interna.",
-        "title": "Gestisci i flussi di lavoro in tenant isolati"
-      },
-      "tests": {
-        "header": "Test unitari per i flow",
-        "label": "Test",
-        "message": "Verifica la logica dei tuoi flow in isolamento, rileva le regressioni in anticipo e mantieni la fiducia nelle tue automazioni mentre cambiano e crescono.",
-        "title": "Garantisci l'affidabilità con ogni modifica"
-      },
-      "watch_the_video": "Guarda il video"
-    },
-    "density": "Density",
-    "density_compact": "Compact",
-    "density_expanded": "Expanded",
-    "density_normal": "Normal",
-    "dependencies": "Dipendenze",
-    "dependencies delete flow": "Questo flow ha dipendenze. Eliminarlo impedirà l'esecuzione delle loro dipendenze.<br /><br /> Ecco l'elenco dei flows interessati:",
-    "dependencies loaded": "Dipendenze caricate",
-    "dependencies missing acls": "Nessun permesso su questo flow",
-    "dependency": {
-      "controls": {
-        "clear_selection": "Cancella selezione",
-        "fit_view": "Adatta allo schermo",
-        "zoom_in": "Ingrandisci",
-        "zoom_out": "Riduci zoom"
-      },
-      "search": {
-        "flow": {
-          "display": "Includi dipendenze del flow"
-        },
-        "namespace": {
-          "no_namespace": "Senza namespace",
-          "select": "Seleziona un namespace"
-        },
-        "no_results": "Nessun risultato trovato per {term}",
-        "placeholders": {
-          "asset": "Cerca per asset, flow o namespace...",
-          "default": "Cerca per flow o namespace..."
-        }
-      }
-    },
-    "dependency task": "Il task {taskId} è una dipendenza di un altro task",
-    "description": "Descrizione",
-    "details": "Dettagli",
-    "disable": "Disabilita",
-    "disabled": "Disabilitato",
-    "disabled flow desc": "Questo flow è disabilitato, per favore abilitalo per eseguirlo.",
-    "disabled flow title": "Questo flow è disabilitato",
-    "discard changes confirmation": "Hai modifiche non salvate. Sei sicuro di volerle scartare?",
-    "discard execution confirmation": "Hai degli input non salvati. Sei sicuro di voler scartare questa esecuzione?",
-    "display direct sub tasks count": "Visualizza conteggio subtasks diretti",
-    "display flow {id} executions": "Visualizza esecuzioni del flow {id}",
-    "display metric for specific task": "Visualizza metrica per un task specifico",
-    "display output for specific task": "Visualizza output per un task specifico",
-    "display topology for flow": "Visualizza topologia per flow",
-    "display_settings": "Display settings",
-    "docs": "Documenti",
-    "documentation": {
-      "documentation": "Documentazione",
-      "github": "Apri un problema su GitHub"
-    },
-    "documentationMenu": "Menu documentazione",
-    "done": "Fatto",
-    "down trend": "In diminuzione",
-    "download": "Scarica",
-    "download logs": "Scarica logs",
-    "download_logos": "Scarica il Pacchetto Logo",
-    "download_logs_description": "Choose which logs to export. Filters default to your current view.",
-    "draft": "Bozza",
-    "draft_available": "Una bozza di modifica è disponibile nell'editor",
-    "draft_flow_warning": "Questa revisione del flow è una bozza. L'esecuzione verrà eseguita su questa revisione in bozza e potrebbe fallire immediatamente se la definizione del flow non è valida.",
-    "drill down preview": "Anteprima",
-    "drop items here": "Trascina gli elementi qui",
-    "duplicate-pair": "Il {label} \"{key}\" è duplicato, il primo key è ignorato.",
-    "duration": "Durata",
-    "dynamic": "Dinamico",
-    "each value": "Valore di iterazione",
-    "edit": "Modifica",
-    "edit flow": "Modifica flow",
-    "editor": "Editor",
-    "editor_shortcuts": {
-      "command_palette": "Mostra la palette dei comandi",
-      "comment": "Commento",
-      "comment_uncomment": "Commenta/Decommenta",
-      "decrease_fontsize": "Diminuire la dimensione del carattere dell'editor",
-      "duplicate_cursor": "Duplica cursore",
-      "execute_flow": "Esegui flow",
-      "fold_unfold": "Piega/Spiega codice",
-      "increase_fontsize": "Aumenta la dimensione del font dell'editor",
-      "label": "Scorciatoie da tastiera",
-      "move_line": "Sposta linea",
-      "reset_fontsize": "Reimposta dimensione del carattere dell'editor",
-      "save_flow": "Salva flow",
-      "toggle_ai_agent": "Attiva/disattiva agente AI",
-      "trigger_autocompletion": "Attiva autocompletamento",
-      "uncomment": "Decommenta"
-    },
-    "ee-tooltip": {
-      "button": "Parlaci",
-      "features-blocked": "Questa funzione richiede l'Enterprise Edition."
-    },
-    "email": "Email",
-    "email length constraint": "L'email non deve superare i 256 caratteri",
-    "empty": {
-      "announcements": {
-        "content": "Gli annunci ti permettono di notificare ai tuoi utenti eventuali modifiche o di informarli su periodi di manutenzione programmata. Seleziona semplicemente il tipo di annuncio, l'intervallo di date in cui deve essere visualizzato e scrivi il messaggio dell'annuncio.",
-        "title": "Non hai ancora annunci!"
-      },
-      "apiTokens": {
-        "content": "I token API vengono utilizzati ogni volta che si desidera concedere l'accesso programmatico all'API di Kestra.",
-        "title": "Gestisci i tuoi Token API"
-      },
-      "apps": {
-        "content": "Inizia a creare App per interagire con Kestra dal mondo esterno.",
-        "title": "Non hai ancora app!"
-      },
-      "assets": {
-        "content": "Aggiungi asset per tracciare e gestire i tuoi asset di dati, servizi e infrastruttura.",
-        "title": "Non hai ancora Asset!"
-      },
-      "concurrency_executions": {
-        "content": "Leggi di più sulle <strong><a href=\"https://kestra.io/docs/workflow-components/execution?utm_source=app&utm_medium=referral&utm_campaign=concurrency-inlinedoc\" target=\"_blank\">Esecuzioni</a></strong> nella nostra documentazione.",
-        "title": "Nessuna Esecuzione in corso per questo Flow."
-      },
-      "concurrency_limit": {
-        "content": "Leggi di più sui <strong><a href=\"https://kestra.io/docs/workflow-components/concurrency?utm_source=app&utm_medium=referral&utm_campaign=concurrency-inlinedoc\" target=\"_blank\">Limiti di Concurrency</a></strong> nella nostra documentazione.",
-        "title": "Nessun limite è impostato per questo Flow."
-      },
-      "concurrency_limits": {
-        "content": "Leggi di più sui <strong><a href=\"https://kestra.io/docs/workflow-components/concurrency?utm_source=app&utm_medium=referral&utm_campaign=concurrency-inlinedoc\" target=\"_blank\">Limiti di Concurrency</a></strong> nella nostra documentazione.",
-        "title": "Nessun limite di concorrenza è impostato."
-      },
-      "dependencies": {
-        "ASSET": {
-          "content": "Questo asset non ha dipendenze upstream o downstream con flow o altri asset.",
-          "title": "Attualmente non ci sono dipendenze."
-        },
-        "EXECUTION": {
-          "content": "Per saperne di più sulle <a href=\"https://kestra.io/docs/ui/executions?utm_source=app&utm_medium=referral&utm_campaign=dependencies-inlinedoc#dependencies\" target=\"_blank\">Dipendenze di Esecuzione</a> nella nostra documentazione.",
-          "title": "Attualmente non ci sono dipendenze."
-        },
-        "FLOW": {
-          "content": "Leggi di più su <a href=\"https://kestra.io/docs/ui/flows?utm_source=app&utm_medium=referral&utm_campaign=dependencies-inlinedoc#dependencies\" target=\"_blank\">Flow Dependencies</a> nella nostra documentazione.",
-          "title": "Attualmente non ci sono dipendenze."
-        },
-        "NAMESPACE": {
-          "content": "Per saperne di più sulle <a href=\"https://kestra.io/docs/ui/namespaces?utm_source=app&utm_medium=referral&utm_campaign=dependencies-inlinedoc#dependencies\" target=\"_blank\">Namespace Dependencies</a>, consulta la nostra documentazione.",
-          "title": "Attualmente non ci sono dipendenze."
-        }
-      },
-      "groups": {
-        "content": "I gruppi ti permettono di raggruppare gli utenti in modo da poter gestire i permessi e i ruoli collettivamente all'interno del tuo tenant.",
-        "title": "Non hai ancora gruppi!"
-      },
-      "kill_switches": {
-        "content": "La funzione Kill Switch fornisce un meccanismo basato su UI per interrompere esecuzioni problematiche. Sostituisce i comandi <code>--skip-executions</code> e <code>--skip-flows</code> disponibili solo su CLI con un'interfaccia di amministrazione completa.",
-        "title": "Non hai ancora Kill Switch!"
-      },
-      "mcpToolFlows": {
-        "content": "Esporre un flow come uno strumento MCP aggiungendo un <code>McpToolTrigger</code> ad esso. Leggi di più sul <strong><a href=\"https://kestra.io/docs/workflow-components/triggers/mcp-tool-trigger?utm_source=app&utm_medium=referral&utm_campaign=mcp-tool-trigger-inlinedoc\" target=\"_blank\">MCP Tool Trigger</a></strong> nella nostra documentazione.",
-        "title": "Nessun flow di tool è ancora registrato su questo server."
-      },
-      "namespaceFiles": {
-        "content": "I file del namespace funzionano come una cartella di progetto per questo namespace. Archivia codice Python, SQL, dbt o Terraform, quindi fai riferimento a qualsiasi file nei tuoi flows con",
-        "title": "Nessun file in questo namespace per ora"
-      },
-      "panels": {
-        "content": "Hai chiuso tutti i pannelli.  \nSeleziona una scheda sopra per continuare.",
-        "title": "Nessun pannello aperto"
-      },
-      "pluginDefaults": {
-        "content": "I valori predefiniti del plugin ti permettono di gestire centralmente la configurazione del tuo plugin e condividerla con tutti i flow nel tuo namespace.",
-        "title": "Non hai ancora impostazioni predefinite per i plugin!"
-      },
-      "plugins": {
-        "content": "Leggi di più sui <strong><a href=\"https://kestra.io/docs/workflow-components/plugin-defaults?utm_source=app&utm_medium=referral&utm_campaign=plugin-default-inlinedoc\" target=\"_blank\">limiti di Concurrency</a></strong> nella nostra documentazione.",
-        "title": "Nessun valore predefinito del plugin è impostato per questo Namespace."
-      },
-      "testSuites": {
-        "content": "Inizia a creare suite di test per testare i tuoi flow.",
-        "title": "Non hai ancora Test suite!"
-      },
-      "triggers": {
-        "content": "Leggi di più sui <strong><a href=\"https://kestra.io/docs/workflow-components/triggers?utm_source=app&utm_medium=referral&utm_campaign=trigger-inlinedoc\" target=\"_blank\">Trigger</a></strong> nella nostra documentazione.",
-        "title": "Il tuo flow non ha alcun trigger."
-      },
-      "variables": {
-        "content": "Aggiungi coppie chiave-valore per condividere la configurazione tra i flow. I namespace figli le ereditano automaticamente e puoi fare riferimento a qualsiasi valore con",
-        "title": "Ancora nessuna variabile"
-      },
-      "versionPlugin": {
-        "content": "Qui puoi gestire tutti i plugin installati sulla tua istanza di Kestra. I plugin appena installati potrebbero non essere immediatamente disponibili in tutti i servizi di Kestra, a seconda della configurazione della tua istanza.",
-        "title": "Non hai ancora un plugin versionato!"
-      },
-      "workerRegistrationTokens": {
-        "content": "I token di registrazione consentono ai worker remoti di autenticarsi e registrarsi in modo sicuro con la tua istanza di Kestra. Crea un token, quindi usalo per connettere nuovi worker a questo cluster.",
-        "title": "Non hai ancora token di registrazione!"
-      }
-    },
-    "empty search": "Risultati di ricerca vuoti",
-    "enable": "Abilita",
-    "enable concurrency": "Abilita la concurrency",
-    "enabled": "Abilitato",
-    "encoding": "Codifica",
-    "end date": "Data di fine",
-    "end datetime": "Data e ora di fine",
-    "environment": "Ambiente",
-    "environment color setting": "Colore dell'ambiente",
-    "environment name setting": "Nome dell'ambiente",
-    "error": "Errore",
-    "error detected": "Errore(i) rilevato(i).",
-    "error in editor": "È stato trovato un errore nell'editor",
-    "errorLogs": "Log degli errori",
-    "errors": {
-      "401": {
-        "content": "Devi essere autenticato per accedere a questa pagina.",
-        "title": "Non autorizzato"
-      },
-      "403": {
-        "content": "Non hai i permessi necessari per accedere a questa pagina.",
-        "title": "Accesso negato"
-      },
-      "404": {
-        "content": "L'URL richiesto non è stato trovato su questo server.<br />Questo è tutto ciò che sappiamo.",
-        "flow or execution": "Il flow o l'esecuzione che stai cercando non esiste.",
-        "title": "Pagina non trovata"
-      }
-    },
+    "change execution state confirm": "Sei sicuro di voler cambiare lo stato dell'esecuzione <code>{id}</code>?",
+    "change execution state done": "Stato di esecuzione aggiornato",
+    "mark as": "Contrassegna come <code>{status}</code>",
+    "unqueue as": "Dequeued come <code>{status}</code>",
+    "kill": "Termina",
+    "kill parents and subflow": "Uccidi il flow corrente e i subflow",
+    "kill only parents": "Uccidi solo corrente",
+    "killed confirm": "Sei sicuro di voler terminare l'esecuzione <code>{id}</code>?",
+    "killed done": "L'esecuzione è in coda per la terminazione",
+    "resume": "Riprendi",
+    "resumed title": "Riprendi esecuzione <code>{id}</code>",
+    "resumed confirm": "Sei sicuro di voler riprendere l'esecuzione <code>{id}</code>?",
+    "resumed done": "L'esecuzione è stata ripresa",
+    "resume from breakpoint title": "Riprendi l'esecuzione <code>{id}</code> dal punto di interruzione",
+    "resume from breakpoint done": "L'esecuzione è ripresa dal breakpoint",
+    "breakpoints": "Punti di interruzione",
+    "pause": "Pausa",
+    "pause title": "Metti in pausa l'esecuzione <code>{id}</code>.<br/>Nota che i task attualmente in esecuzione verranno comunque elaborati e l'esecuzione dovrà essere ripresa manualmente.",
+    "pause confirm": "Sei sicuro di mettere in pausa l'esecuzione <code>{id}</code>?",
+    "pause done": "L'esecuzione è PAUSED",
+    "unqueue": "Rimuovi dalla coda",
+    "unqueue title": "Metti in coda l'esecuzione <code>{id}</code>.<br/>Nota che non rispetterà il limite di concorrenza del flow, quindi potrebbero esserci più esecuzioni in corso rispetto al limite consentito.",
+    "unqueue title multiple": "Sei sicuro di voler rimuovere dalla coda <code>{count}</code> esecuzioni?<br/><br/>Nota che non rispetterà il limite di concurrency del flow, quindi potrebbero essere in esecuzione più esecuzioni del limite consentito.",
+    "unqueue confirm": "Sei sicuro di voler rimuovere dalla coda l'esecuzione <code>{id}</code>?",
+    "unqueue done": "L'esecuzione è in coda",
+    "force run": "Esegui forzatamente",
+    "force run title": "Esegui forzatamente l'esecuzione <code>{id}</code>.",
+    "force run tooltip": "Forza l'esecuzione a partire. Può creare esecuzioni duplicate dei task, se possibile utilizza un'altra azione.",
+    "force run confirm": "Sei sicuro di voler forzare l'esecuzione <code>{id}</code>?<br/><br/>WARNING: forzare l'esecuzione non è garantito e potrebbe creare esecuzioni duplicate dei task.<br/><br/>Le seguenti transizioni saranno effettuate:<br/><ul><li>I task in stato CREATED saranno spostati allo stato RUNNING.</li><li>I task in stato RUNNING saranno ri-sottomessi.</li><li>I task in stato QUEUED saranno rimossi dalla coda.</li><li>I task in stato PAUSED saranno ripresi.</li></ul>",
+    "force run done": "L'esecuzione è forzata a RUNNING",
+    "toggle output": "Attiva/disattiva outputs",
+    "metrics": "Metriche",
+    "no data current task": "Non ci sono dati disponibili per il task corrente",
+    "no metrics available": "Nessuna metrica registrata per questa esecuzione del task.",
+    "no outputs available": "Nessun output disponibile per questa esecuzione del task.",
+    "outputs": "Outputs",
+    "flow_outputs": "Output del Flow",
+    "no_flow_outputs": "Nessun output disponibile.",
+    "output": "Output",
     "eval": {
-      "expression": "Espressione",
-      "preview": "Anteprima",
-      "render": "Espressione di Render",
       "title": "Espressione di Debug",
-      "tooltip": "Esegui qualsiasi espressione Pebble e ispeziona il contesto dell'esecuzione."
+      "render": "Espressione di Render",
+      "tooltip": "Esegui qualsiasi espressione Pebble e ispeziona il contesto dell'esecuzione.",
+      "preview": "Anteprima",
+      "expression": "Espressione"
     },
-    "evaluation lock date": "Data di blocco della valutazione",
-    "execute": "Esegui",
-    "execute backfill": "Esegui backfill",
-    "execute flow behaviour": "Esegui il flow",
-    "execute flow now ?": "Vuoi eseguire questo flow?",
-    "execute the flow": "Esegui il flow <code>{id}</code>",
-    "execution": "Esecuzione",
-    "execution already finished": "Esecuzione <code>{executionId}</code> già terminata",
-    "execution id": "ID di Esecuzione",
-    "execution labels": "Etichette di esecuzione",
-    "execution not found": "L'esecuzione {executionId} non è stata trovata.",
-    "execution not in state FAILED": "Esecuzione <code>{executionId}</code> non in stato FAILED",
-    "execution not in state PAUSED": "Esecuzione <code>{executionId}</code> non in stato PAUSED",
-    "execution replay": "Questa esecuzione è una ripetizione di",
-    "execution replayed": "Questa esecuzione è stata ripetuta.",
-    "execution restarted": "Questa esecuzione è stata riavviata {nbRestart} volta(e).",
+    "attempt": "Tentativo",
+    "toggle output display": "Attiva/disattiva visualizzazione output",
+    "name": "Nome",
+    "key": "Key",
+    "value": "Value",
+    "each value": "Valore di iterazione",
+    "current execution": "Esecuzione corrente",
+    "parent execution": "Esecuzione genitore",
+    "original execution": "Esecuzione originale",
+    "automatic refresh": "Aggiornamento automatico",
+    "toggle periodic refresh each x seconds": "Attiva/disattiva l'aggiornamento periodico ogni {interval} secondi",
+    "trigger refresh": "Aggiorna",
+    "add-trigger-in-editor": "Aggiungi un Trigger al tuo Flow prima",
+    "refresh": "Aggiorna",
+    "filter by status": "Filtra le esecuzioni per stato {status}",
+    "topology-graph": {
+      "graph-orientation": "Orientamento del grafico",
+      "zoom-in": "Zoom avanti",
+      "zoom-out": "Zoom indietro",
+      "zoom-reset": "Reimposta zoom",
+      "zoom-fit": "Adatta",
+      "invalid": "Errore del grafico",
+      "invalid_description": "Si è verificato un errore durante il caricamento del grafico. Si prega di controllare il codice sorgente per errori."
+    },
+    "show task logs": "Mostra task logs",
+    "show task condition": "Mostra condizione del task",
+    "show task outputs": "Mostra task outputs",
+    "show task source": "Mostra sorgente del task",
+    "specific task": "Task specifico",
+    "display output for specific task": "Visualizza output per un task specifico",
+    "display metric for specific task": "Visualizza metrica per un task specifico",
+    "display direct sub tasks count": "Visualizza conteggio subtasks diretti",
+    "stream": "Stream",
     "execution statistics": "Statistiche di esecuzione",
-    "execution-include-non-terminated": "Includere esecuzioni non terminate?",
-    "execution-warn-deleting-still-running": "Raccomandiamo vivamente di annullare questa azione e terminare eventuali esecuzioni in corso prima. Eliminare esecuzioni non terminate può portare a problemi di concorrenza, incoerenze nella gestione delle dipendenze del flow e processi zombie sulla tua istanza, che possono degradare le prestazioni del sistema. Assicurati di comprendere appieno questi rischi prima di procedere con l'eliminazione.",
-    "execution-warn-title": "Avviso Importante!",
-    "execution_deletion": {
-      "logs": "Elimina logs",
-      "metrics": "Elimina metriche",
-      "storage": "Elimina file di storage interni"
-    },
-    "execution_failed": "Esecuzione fallita!",
-    "execution_guide": {
-      "get_started": {
-        "text": "Segui la Guida rapida per installare Kestra e iniziare a creare i tuoi primi workflow.",
-        "title": "Inizia ⚡"
-      },
-      "namespaces": {
-        "text": "I namespace sono raggruppamenti logici di flow e dei loro componenti.",
-        "title": "Informazioni sui Namespace"
-      },
-      "videos_tutorials": {
-        "text": "Inizia con i nostri video tutorial.",
-        "title": "Tutorial Video"
-      },
-      "workflow_components": {
-        "text": "Conosci i principali componenti di orchestrazione di un workflow Kestra.",
-        "title": "Componenti del Workflow"
-      }
-    },
-    "execution_started": "L'esecuzione è iniziata!",
-    "execution_starts_progress": "Una volta avviata l'esecuzione, vedrai gli aggiornamenti sul progresso qui.",
-    "execution_status": "L'esecuzione è:",
-    "executions": "Esecuzioni",
-    "executions deleted": "<code>{executionCount}</code> esecuzione/i eliminate",
+    "stats": "Statistiche",
+    "concurrency limits": "Limiti di Concorrenza",
+    "system overview": "Panoramica del sistema",
+    "usage": "Utilizzo",
+    "namespaces": "Namespaces",
+    "tasks": "Tasks",
     "executions duration (in minutes)": "Durata totale delle esecuzioni (in minuti)",
-    "executions force run": "<code>{executionCount}</code> esecuzione/i forzata/e",
-    "executions killed": "<code>{executionCount}</code> esecuzione/i kill",
-    "executions paused": "<code>{executionCount}</code> esecuzione(i) PAUSED",
-    "executions replayed": "<code>{executionCount}</code> esecuzione/i ripetute",
-    "executions restarted": "<code>{executionCount}</code> esecuzione/i riavviate",
-    "executions resumed": "<code>{executionCount}</code> esecuzione/i riprese",
-    "executions state changed": "Lo stato di <code>{executionCount}</code> esecuzione/i è stato cambiato",
-    "executions unqueue": "<code>{executionCount}</code> esecuzione(i) in coda",
-    "expand": "Espandi",
-    "expand all": "Espandi tutto",
-    "expand dependencies": "Espandi dipendenze",
-    "expand error": "Espandi solo i tasks FAILED",
-    "expand_by_default": "Expand structured logs by default",
-    "expiration": "Scadenza",
-    "expiration date": "Data di scadenza",
-    "export": "Esporta",
-    "export all flows": "Esporta tutti i flows",
-    "export all templates": "Esporta tutti i template",
-    "export_as": "Esporta come .{format}",
-    "export_csv": "Esporta come CSV",
-    "exports": "Esportazioni",
-    "failed to export plugin defaults": "Impossibile esportare i valori predefiniti del plugin",
-    "failed to import plugin defaults": "Impossibile importare i default del plugin",
-    "failed to render pdf": "Impossibile visualizzare l'anteprima PDF",
-    "false": "Falso",
-    "feeds": {
-      "heading": "Tutto su Kestra.",
-      "subheading": "Gli ultimi aggiornamenti, guide e storie",
-      "title": "Novità su Kestra"
+    "last 48 hours": "ultime 48 ore",
+    "configure basic auth": "Configura Autenticazione di Base",
+    "email": "Email",
+    "password": "Password",
+    "confirm password": "Conferma password",
+    "email length constraint": "L'email non deve superare i 256 caratteri",
+    "password length constraint": "La password non deve superare i 256 caratteri",
+    "password empty constraint": "Nome utente o password errati",
+    "passwords do not match": "Le password non corrispondono",
+    "avg duration": "Durata media dell'esecuzione",
+    "neutral trend": "Stabile",
+    "up trend": "In aumento",
+    "down trend": "In diminuzione",
+    "update aborted": "aggiornamento annullato",
+    "invalid flow": "Flow non valido",
+    "invalid yaml": "YAML non valido",
+    "inputs": "Inputs",
+    "no_inputs": "Nessun input disponibile.",
+    "input": "Input",
+    "variables": "Variabili",
+    "variable_explorer": {
+      "title": "Input/Output",
+      "search_placeholder": "Cerca Key o value...",
+      "tasks_outputs": "Tasks outputs",
+      "tree": "Albero",
+      "raw_json": "Raw JSON",
+      "select_prompt": "Seleziona una variabile per ispezionarne la value.",
+      "empty": "Nessuna variabile disponibile per questa esecuzione.",
+      "one_key": "\\{ 1 key \\}",
+      "n_keys": "\\{ {count} keys \\}",
+      "one_item": "[ 1 elemento ]",
+      "n_items": "[ {count} elementi ]"
     },
-    "file preview truncated": "Il contenuto visualizzato è stato troncato",
-    "file unavailable": "File non disponibile",
-    "file unavailable description": "Questo file non è più disponibile — potrebbe essere stato eliminato o scaduto.",
-    "fileTypeNotAllowed": "Tipo di file non consentito. Tipi accettati: {types}",
     "file_preview": {
       "big_file_warning": "Questo file è {size}. Potrebbe richiedere del tempo per caricarsi bloccando il tuo browser. Vuoi caricarlo comunque?",
       "load_anyway": "Carica comunque"
     },
-    "files": "File",
-    "filter by log level": "Filtra per livello di log",
-    "filter by status": "Filtra le esecuzioni per stato {status}",
-    "filter by this value": "Filter by this value",
-    "filter_for": "Filter for",
-    "filter_out": "Filter out",
-    "filters": {
-      "comparators": {
-        "between": "tra",
-        "contains": "contiene",
-        "ends_with": "termina con",
-        "greater_than": "maggiore di",
-        "greater_than_or_equal_to": "maggiore o uguale a",
-        "in": "nel",
-        "is": "è",
-        "is_not": "non è",
-        "is_one_of": "è uno di",
-        "less_than": "minore di",
-        "less_than_or_equal_to": "minore o uguale a",
-        "not_contains": "non contiene",
-        "not_in": "non in",
-        "starts_with": "inizia con"
-      },
-      "empty": "Nessun dato.",
-      "format": "Digita il parametro come 'key:value'",
-      "label": "Scegli filtri",
-      "options": {
-        "absolute_date": "Data assoluta",
-        "action": "Azione",
-        "aggregation": "Aggregazione",
-        "child": "Bambino",
-        "details": "Dettagli",
-        "endDate": "Data di fine",
-        "flow": "Flusso",
-        "labels": "Etichette",
-        "level": "Livello di Log",
-        "metric": "Metrica",
-        "namespace": "Namespace",
-        "permission": "Permesso",
-        "relative_date": "Data relativa",
-        "scope": "Ambito",
-        "service_type": "Tipo",
-        "startDate": "Data di inizio",
-        "state": "Stato",
-        "status": "Stato",
-        "task": "Compito",
-        "text": "I'm sorry, but it seems like the text you want me to translate is missing. Could you please provide the text you would like translated?",
-        "type": "Tipo",
-        "user": "Utente"
-      },
-      "save": {
-        "dialog": {
-          "confirmation": "Criteri di ricerca <code>{name}</code>",
-          "heading": "Salva la ricerca corrente",
-          "hint": "Come vuoi etichettare questo criterio di ricerca?",
-          "placeholder": "Etichetta"
-        },
-        "empty": "Non hai ancora salvato alcuna ricerca.",
-        "label": "Ricerche salvate",
-        "name_already_used": "Etichetta di ricerca già utilizzata.",
-        "remove": "Rimuovi",
-        "tooltip": "Non puoi salvare criteri di ricerca vuoti."
-      },
-      "settings": {
-        "label": "Impostazioni pagina",
-        "show_chart": "Mostra il grafico principale"
-      },
-      "text_search": "Cerca questo testo"
-    },
-    "fix_with_ai": "Correggi con AI",
-    "flow": "Flow",
-    "flow already exists": "Flow già esistente",
-    "flow already exists message": "Il flow <code>{id}</code> esiste già nel namespace <code>{namespace}</code>. Vuoi creare una nuova revisione?",
-    "flow creation": "Creazione del flow",
-    "flow creation denied in namespace": "Non hai il permesso di creare flow nel namespace `{namespace}`.",
-    "flow delete": "Sei sicuro di voler eliminare <code>{flowCount}</code> flow?",
-    "flow deleted, you can restore it": "Il flow è stato eliminato e questa è una vista di sola lettura. Puoi ancora ripristinarlo.",
-    "flow disable": "Sei sicuro di voler disabilitare <code>{flowCount}</code> flow?",
-    "flow enable": "Sei sicuro di voler abilitare <code>{flowCount}</code> flow?",
-    "flow export": "Sei sicuro di voler esportare <code>{flowCount}</code> flow?",
-    "flow must have id and namespace": "Il flow deve avere un id e un namespace.",
-    "flow must not be empty": "Il flow non deve essere vuoto",
-    "flow not imported": "Alcuni flow non possono essere importati",
-    "flow revision latest": "Ultima revisione del flow",
-    "flow revision original": "Revisione originale del flow",
-    "flow revision specific": "Revisione specifica del flow",
-    "flow source not found": "Sorgente del flow non trovata",
-    "flow-dependencies": "dipendenze",
-    "flow-no-dependencies": "Il tuo flow non ha dipendenze",
-    "flow_editor_stats": {
-      "apps": {
-        "suffix": "App(s)",
-        "tooltip": "Visualizza le app che utilizzano questo flow"
-      },
-      "dependencies": {
-        "suffix": "Dipendenze",
-        "tooltip": "Visualizza le dipendenze del flow"
-      },
-      "errors": {
-        "label": "{count} Errore/i"
-      },
-      "revisions": {
-        "suffix": "Revisioni",
-        "tooltip": "Visualizza le revisioni del flow"
-      },
-      "tests": {
-        "suffix": "Test(s)",
-        "tooltip": "Visualizza i test del flow"
-      }
-    },
-    "flow_export": "Esporta flow",
-    "flow_only": "Disponibile solo nella scheda Flow.",
-    "flow_outputs": "Output del Flow",
-    "flows": "Flows",
-    "flows deleted": "<code>{count}</code> Flow eliminati",
-    "flows disabled": "<code>{count}</code> Flow disabilitati",
-    "flows enabled": "<code>{count}</code> Flow abilitati",
-    "flows exported": "<code>{count}</code> Flow esportati",
-    "flows imported": "Flussi importati",
-    "focus task": "Clicca su qualsiasi elemento per vedere la sua documentazione.",
-    "fold_all_multi_lines": "Comprimi Tutte le Linee Multiple",
-    "font size": "Font size",
-    "for flow": "per flow",
-    "forbidden system labels": "Solo system.correlationId può essere usato come label di sistema",
-    "force run": "Esegui forzatamente",
-    "force run confirm": "Sei sicuro di voler forzare l'esecuzione <code>{id}</code>?<br/><br/>WARNING: forzare l'esecuzione non è garantito e potrebbe creare esecuzioni duplicate dei task.<br/><br/>Le seguenti transizioni saranno effettuate:<br/><ul><li>I task in stato CREATED saranno spostati allo stato RUNNING.</li><li>I task in stato RUNNING saranno ri-sottomessi.</li><li>I task in stato QUEUED saranno rimossi dalla coda.</li><li>I task in stato PAUSED saranno ripresi.</li></ul>",
-    "force run done": "L'esecuzione è forzata a RUNNING",
-    "force run title": "Esegui forzatamente l'esecuzione <code>{id}</code>.",
-    "force run tooltip": "Forza l'esecuzione a partire. Può creare esecuzioni duplicate dei task, se possibile utilizza un'altra azione.",
-    "form": "Modulo",
-    "form error": "Errore del modulo",
-    "from": "Da",
-    "gantt": "Gantt",
-    "gantt_no_tasks_executed": "Questa esecuzione è terminata senza eseguire alcun task. Controlla la sua panoramica e i log per il motivo.",
-    "gantt_no_tasks_match_filters": "Prova a modificare i filtri di ricerca, stato o livello di log.",
-    "gantt_no_tasks_match_filters_title": "Nessun task corrisponde ai filtri selezionati.",
-    "healthcheck date": "Data di HealthCheck",
-    "hide task documentation": "Nascondi la documentazione del task",
-    "home": "Home",
-    "hostname": "Nome host",
-    "iam": "IAM",
-    "id": "Id",
-    "import": "Importa",
-    "in-our-documentation": "nella nostra documentazione.",
-    "informative notice": "Note(s)",
-    "input": "Input",
-    "inputs": "Inputs",
-    "instance": "Istanza",
-    "invalid bulk delete": "Impossibile eliminare le esecuzioni",
-    "invalid bulk force run": "Impossibile forzare l'esecuzione delle esecuzioni",
-    "invalid bulk kill": "Impossibile kill le esecuzioni",
-    "invalid bulk pause": "Impossibile mettere in pausa le esecuzioni",
-    "invalid bulk replay": "Impossibile ripetere le esecuzioni",
-    "invalid bulk restart": "Impossibile riavviare le esecuzioni",
-    "invalid bulk resume": "Impossibile riprendere le esecuzioni",
-    "invalid bulk unqueue": "Impossibile rimuovere dalla coda le esecuzioni",
-    "invalid field": "Campo non valido: {name}",
-    "invalid flow": "Flow non valido",
-    "invalid source": "Codice sorgente non valido",
-    "invalid yaml": "YAML non valido",
-    "is deprecated": "è deprecato",
-    "is required": "{field} è obbligatorio",
-    "item": "elemento",
-    "items": "elementi",
-    "join community": "Unisciti alla Community",
-    "join_slack": "Unisciti a Slack",
-    "jsonl": "JSONL",
-    "jump to...": "Vai a...",
-    "kestra": "Kestra",
-    "key": "Key",
-    "kill": "Termina",
-    "kill only parents": "Uccidi solo corrente",
-    "kill parents and subflow": "Uccidi il flow corrente e i subflow",
-    "killed confirm": "Sei sicuro di voler terminare l'esecuzione <code>{id}</code>?",
-    "killed done": "L'esecuzione è in coda per la terminazione",
-    "kv": {
-      "add": "Crea",
-      "delete multiple": {
-        "confirm": "Sei sicuro di voler eliminare: <code>{name}</code> KV?",
-        "warning": "Non hai i permessi per quei namespace, quindi verranno omessi: <code>{namespaces}</code>"
-      },
-      "duplicate": "Questo key esiste già",
-      "inherited": "Coppie KV ereditate",
-      "name": "KV Store",
-      "type": "Tipo",
-      "update": "Aggiorna il value per il key '{key}'"
-    },
-    "label": "Label",
-    "label filter placeholder": "Etichetta come 'key:value'",
-    "labels": "Etichette",
-    "last 48 hours": "ultime 48 ore",
-    "last X days count": "{count} negli ultimi {days} giorni",
-    "last error was": "L'ultimo errore è stato",
-    "last evaluation date": "Data ultima valutazione",
-    "last evaluation date tooltip": "When the trigger was last evaluated by the scheduler, regardless of whether it produced an execution.",
-    "last execution date": "Data ultima esecuzione",
-    "last execution state": "Ultimo stato",
-    "last execution status": "Ultimo stato di esecuzione",
-    "last modified": "Ultima modifica",
-    "last trigger date": "Data ultimo trigger",
-    "last trigger date tooltip": "Quando il trigger è stato eseguito l'ultima volta. Potrebbe essere nel passato quando si esegue un backfill.",
-    "latest_update": "Ultimo aggiornamento",
-    "launch execution": "Esegui",
-    "learn_more": "Scopri di più",
-    "leave page": "Lascia Pagina",
-    "license": "Licenza",
-    "light_background": "Questa è l'opzione preferita quando si lavora con uno sfondo chiaro.",
-    "light_version": "Versione leggera",
-    "line": "Linea",
-    "line-by-line": "riga per riga",
-    "loaded x dependencies": "{count} dipendenze caricate",
-    "loading": "Caricamento...",
-    "log expand setting": "Visualizzazione predefinita del Log",
-    "logExporters": "Esportatori di Log",
-    "logs": "Logs",
-    "logs_copied": "Logs copied to your clipboard",
-    "logs_view": {
-      "compact": "Vista predefinita",
-      "compact_details": "Mostra i task logs in una vista compatta raggruppata per ogni task",
-      "raw": "Vista temporale",
-      "raw_details": "Mostra i task logs e i flow logs completi in un formato grezzo ordinato per timestamp"
-    },
-    "main_configuration": "Configurazione Principale",
-    "manage labels": "Gestisci etichette",
-    "management port": "Porta di gestione",
-    "mark as": "Contrassegna come <code>{status}</code>",
-    "max": "Max",
-    "mcp": {
-      "api_token": "Token API",
-      "auth_type": "Autenticazione",
-      "basic_auth": "Autenticazione di base",
-      "bearer_token": "Autenticazione con token Bearer",
-      "client_setup": "Configurazione Client",
-      "connect": "Connetti",
-      "connect_tab": {
-        "auth_api_token_hint": "Imposta <code>KESTRA_TOKEN</code> come variabile d'ambiente prima di avviare il client.",
-        "auth_basic_hint": "Imposta <code>KESTRA_BASIC_AUTH</code> come variabile d'ambiente contenente una stringa <code>username:password</code> codificata in base64 prima di avviare il client.",
-        "auth_oauth_browser_hint": "Il browser aprirà la pagina di accesso del provider di identità alla prima connessione.",
-        "auth_oauth_client_id_hint": "Sostituisci <code>&lt;client-id&gt;</code> con l'ID client OAuth e registra <code>http://localhost:7777</code> come URI di reindirizzamento valido su quel client.",
-        "claude_code": "Claude Code",
-        "claude_code_hint": "Esegui il seguente comando nel tuo terminale:",
-        "claude_desktop": "Claude Desktop",
-        "claude_desktop_hint": "Aggiungi quanto segue al tuo file claude_desktop_config.json:",
-        "claude_desktop_mac": "macOS: ~/Library/Application Support/Claude/claude_desktop_config.json",
-        "claude_desktop_win": "Windows: %APPDATA%\\Claude\\claude_desktop_config.json",
-        "client_picker_label": "Scegli il tuo client AI",
-        "codex": "Codex (OpenAI)",
-        "codex_hint": "Aggiungi quanto segue alla configurazione MCP del tuo codex.json:",
-        "cursor": "Cursore",
-        "cursor_hint": "Aggiungi quanto segue a ~/.cursor/mcp.json:",
-        "server_url": "URL del server"
-      },
-      "copy_url": "Copia URL",
-      "create": "Crea Server",
-      "delete_confirm": "Sei sicuro di voler eliminare questo server MCP?",
-      "id_invalid": "L'ID deve iniziare con una lettera minuscola o una cifra e contenere solo lettere minuscole, cifre, trattini o underscore.",
-      "id_placeholder": "ad es. my-mcp-server",
-      "instructions": "Istruzioni",
-      "main_tenant": "principale",
-      "managed_by_kestra": "Gestito da Kestra",
-      "no_oauth_providers": "Nessun provider OIDC configurato in questa istanza",
-      "no_servers": "Nessun server MCP trovato. Crea il tuo primo server per esporre i trigger dello strumento MCP agli agenti AI esterni.",
-      "oauth": "OAuth",
-      "oauth_hint": "Bearer JWT dal proprio provider OIDC",
-      "oauth_provider": "Provider OAuth",
-      "oauth_provider_placeholder": "Selezionare un provider OIDC configurato",
-      "oauth_provider_required": "Il provider OAuth è obbligatorio quando il tipo di autenticazione è OAuth",
-      "page_description": "Esporre i tuoi flow di Kestra come strumenti per agenti AI compatibili con MCP",
-      "private": "Privato",
-      "private_server": "Server privato",
-      "public": "Pubblico",
-      "public_hint": "Avviso: I server pubblici non richiedono autenticazione. Chiunque abbia l'URL può richiamare ogni strumento esposto da questo server, senza controlli di namespace o permessi. Utilizzare solo per server sicuri da esporre esternamente.",
-      "save": "Salva modifiche",
-      "scopes_supported": "Scope supportati",
-      "scopes_supported_hint": "Scope pubblicizzati nel documento Protected Resource Metadata di questo server. I client MCP conformi alle specifiche limitano la richiesta di autorizzazione a questo elenco. Lasciare vuoto per omettere il campo e consentire ai client di utilizzare gli scope pubblicizzati dall'IdP.",
-      "scopes_supported_placeholder": "openid, profile, email",
-      "server": "Server MCP",
-      "server_id": "ID server",
-      "server_type": "Tipo di Server",
-      "servers": "Server MCP",
-      "servers_count": "{{count}} Server MCP",
-      "tab_connect": "Connetti",
-      "tab_edit": "Modifica",
-      "tab_tool_flows": "Flussi degli Strumenti",
-      "tab_tool_flows_placeholder": "La gestione dei flow degli strumenti arriverà presto.",
-      "tools": {
-        "annotations": "Annotazioni",
-        "create_tool_flow": "Crea un flow di tool",
-        "description": "Descrizione",
-        "destructive": "Distruttivo",
-        "flow": "flow",
-        "idempotent": "Idempotente",
-        "no_tools": "Nessun flow di strumenti corrisponde alla tua ricerca.",
-        "open_world": "Open world",
-        "read_only": "Sola lettura",
-        "return_direct": "Ritorno diretto",
-        "state": "Stato",
-        "title": "Titolo",
-        "tool_name": "Nome dello strumento",
-        "trigger_id": "ID del trigger",
-        "view_flow": "Apri flow"
-      },
-      "url_copied": "URL copiata!",
-      "username_password": "Nome utente e password",
-      "your_servers": "I tuoi server"
-    },
-    "metric": "Metrica",
-    "metric choice": "Nessuna metrica disponibile per questo flow",
-    "metrics": "Metriche",
-    "min": "Min",
-    "missingSource": "Sorgente mancante",
-    "modify inputs": "Modifica input",
-    "modify_inputs": "Modifica input",
-    "monogram": "Monogramma",
-    "more actions": "Altre azioni",
-    "more_actions": "Altre azioni",
-    "multi_panel_editor": {
-      "close_all_panels": "Chiudi tutti i pannelli",
-      "close_all_tabs": "Chiudi tutte le tab",
-      "move_left": "Sposta a sinistra",
-      "move_right": "Sposta a destra"
-    },
-    "multiple saved done": "{name} è stato salvato",
-    "name": "Nome",
-    "namespace": "Namespace",
-    "namespace and id readonly": "Le proprietà `namespace` e `id` non possono essere modificate — ora sono impostate sui loro valori iniziali. Se vuoi rinominare un flow o cambiare il suo namespace, puoi creare un nuovo flow e rimuovere quello vecchio.",
-    "namespace files": {
-      "create": {
-        "file": "Crea file",
-        "file_already_exists": "Un file con questo nome esiste già",
-        "file_conflicts_with_folder": "Una cartella con questo nome esiste già",
-        "file_error": "Si è verificato un errore durante la creazione del file",
-        "folder": "Crea cartella",
-        "folder_already_exists": "Una cartella con questo nome esiste già",
-        "folder_conflicts_with_file": "Un file con questo nome esiste già",
-        "folder_error": "Si è verificato un errore durante la creazione della cartella",
-        "label": "Crea"
-      },
-      "delete": {
-        "file": "Elimina file",
-        "files": "Elimina {count} file selezionati",
-        "folder": "Elimina cartella",
-        "folders": "Elimina {count} cartelle selezionate",
-        "label": "Elimina"
-      },
-      "dialog": {
-        "deletion": {
-          "confirm": "Conferma",
-          "file_single": "Sei sicuro di voler eliminare il file <code>{name}</code>?",
-          "files": "Sei sicuro di voler eliminare <code>{count}</code> file?",
-          "folder_single": "Sei sicuro di voler eliminare la cartella <code>{name}</code> e tutti i suoi contenuti?",
-          "folders": "Sei sicuro di voler eliminare <code>{count}</code> cartella/e e tutto il suo contenuto?",
-          "mixed": "Sei sicuro di voler eliminare la/le cartella/e <code>{folders}</code> e il/i file <code>{files}</code>?",
-          "title": "Conferma eliminazione del contenuto"
-        },
-        "name": {
-          "file": "Nome con estensione:",
-          "folder": "Nome della cartella:"
-        },
-        "parent_folder": "Cartella genitore:"
-      },
-      "export": "Esporta file del namespace",
-      "export_single": "Esporta file",
-      "filter": "Filtro",
-      "import": {
-        "error": "Si sono verificati errori durante l'importazione dei file",
-        "files": "Importa file",
-        "folder": "Importa cartella",
-        "import": "Importa",
-        "success": "File importati con successo"
-      },
-      "new_file": "Nuovo file",
-      "no_items": {
-        "heading": "Nessun file trovato nel tuo namespace.",
-        "paragraph": "Crea o importa file per condividere il codice tra i flow nel tuo namespace."
-      },
-      "no_selection": {
-        "description": "Seleziona un file dall'albero per visualizzarne il contenuto.",
-        "heading": "Nessun file selezionato"
-      },
-      "path": {
-        "copy": "Copia percorso",
-        "error": "Si sono verificati errori durante la copia del percorso negli appunti",
-        "success": "Percorso copiato negli appunti"
-      },
-      "rename": {
-        "file": "Rinomina file",
-        "folder": "Rinomina cartella",
-        "label": "Rinomina",
-        "new_file": "Nuovo nome con estensione:",
-        "new_folder": "Nuovo nome della cartella:"
-      },
-      "revisions": {
-        "history": "Cronologia delle revisioni",
-        "restore": {
-          "success": "Revisione del file ripristinata con successo"
-        }
-      },
-      "toggle": {
-        "hide": "Nascondi file del namespace",
-        "show": "Mostra file del namespace"
-      },
-      "tree": {
-        "collapse": "Comprimi tutte le cartelle",
-        "expand": "Espandi tutte le cartelle"
-      }
-    },
-    "namespace not allowed": "Namespace non consentito",
-    "namespace_editor": {
-      "close": {
-        "all": "Chiudi tutte le schede",
-        "other": "Chiudi le altre schede",
-        "right": "Chiudi a destra",
-        "tab": "Chiudi scheda"
-      },
-      "empty": {
-        "create_message": "Puoi creare o importare file namespace.",
-        "title": "Nessuna scheda attualmente aperta",
-        "video_message": "Puoi guardare il Video di Introduzione per il nostro Editor."
-      }
-    },
-    "namespaces": "Namespaces",
-    "neutral trend": "Stabile",
-    "new": "Nuovo",
-    "new version": "Nuova versione {version} disponibile!",
-    "next": "Avanti",
-    "next evaluation date": "Prossima data di valutazione",
-    "next evaluation date tooltip": "Quando il trigger verrà valutato nuovamente, in base al suo intervallo. Non sempre coincide con la prossima data di esecuzione se le condizioni non sono soddisfatte.",
-    "next execution date": "Data della prossima esecuzione",
-    "next_execution": "Prossima esecuzione",
-    "no data current task": "Non ci sono dati disponibili per il task corrente",
-    "no inputs": "Questo flow non ha inputs.",
-    "no metrics available": "Nessuna metrica registrata per questa esecuzione del task.",
-    "no outputs available": "Nessun output disponibile per questa esecuzione del task.",
-    "no result": "Non ci sono risultati da mostrare.",
-    "no revisions": "Nessuna revisione",
-    "no revisions found": "Esiste solo una revisione per questo flow",
-    "no-executions-view": {
-      "guidance_desc": "Hai bisogno di assistenza per eseguire il tuo flow?",
-      "guidance_sub_desc": "Segui la documentazione per tutte le informazioni di cui hai bisogno.",
-      "namespace_guidance_desc": "Hai bisogno di assistenza per gestire il tuo Namespace?",
-      "namespace_sub_title": "Esegui uno o più flow da questo namespace per popolare questa dashboard.",
-      "sub_title": "Fai clic sul pulsante Esegui per avviare l'esecuzione del tuo primo workflow.",
-      "title": "Inizia ad automatizzare con"
-    },
-    "no_code": {
-      "add_field": "Aggiungi {field}",
-      "adding": "+ Aggiungi un {what}",
-      "adding_default": "+ Aggiungi un nuovo value",
-      "clearSelection": "Cancella selezione",
-      "creation": {
-        "afterExecution": "Aggiungi un blocco after execution",
-        "charts": "Aggiungi un grafico",
-        "conditions": "Aggiungi una condizione",
-        "default": "Aggiungi",
-        "errors": "Aggiungi un gestore degli errori",
-        "finally": "Aggiungi un blocco finally",
-        "inputs": "Aggiungi un campo di input",
-        "numerator": "Aggiungi un numeratore",
-        "pluginDefaults": "Aggiungi un plugin predefinito",
-        "tasks": "Aggiungi un task",
-        "triggers": "Aggiungi un trigger",
-        "where": "Filtra i tuoi dati"
-      },
-      "fields": {
-        "general": {
-          "checks": "Controlli",
-          "concurrency": "Concorrenza",
-          "disabled": "Disabilitato",
-          "labels": "Etichette",
-          "listeners": "Ascoltatori",
-          "outputs": "Output",
-          "retry": "Riprova",
-          "sla": "SLA",
-          "taskDefaults": "Predefiniti Task",
-          "updated": "Aggiornato",
-          "variables": "Variabili",
-          "workerGroup": "Gruppo Worker",
-          "workerSelector": "Selettore Worker"
-        },
-        "main": {
-          "description": "Descrizione",
-          "id": "ID del flow",
-          "inputs": "Input",
-          "namespace": "Namespace"
-        }
-      },
-      "labels": {
-        "label": "Etichetta",
-        "no_code": "Editor Senza Codice",
-        "variable": "Variabile",
-        "yaml": "Editor YAML"
-      },
-      "remove": {
-        "cases": "Rimuovi questo caso",
-        "default": "Rimuovi questa voce"
-      },
-      "sections": {
-        "afterExecution": "Dopo l'Esecuzione",
-        "deprecated": "Proprietà deprecate",
-        "errors": "Gestori degli Errori",
-        "finally": "Infine",
-        "pluginDefaults": "Predefiniti del Plugin",
-        "tasks": "Attività",
-        "triggers": "Trigger"
-      },
-      "select": {
-        "afterExecution": "Seleziona un task",
-        "charts": "Seleziona un tipo di grafico",
-        "conditions": "Seleziona una condizione",
-        "default": "Seleziona un tipo",
-        "errors": "Seleziona un task",
-        "finally": "Seleziona un task",
-        "inputs": "Seleziona un tipo di input field",
-        "numerator": "Seleziona un numeratore",
-        "pluginDefaults": "Seleziona un plugin",
-        "task": "Seleziona un task",
-        "tasks": "Seleziona un task",
-        "triggers": "Seleziona un trigger",
-        "where": "Seleziona un tipo di filtro"
-      },
-      "toggle_pebble": "Attiva/disattiva editor Pebble",
-      "unnamed": "Nessun Nome",
-      "version_oss_placeholder": "Sblocca il Versioning dei Plugin con l'Enterprise Edition"
-    },
-    "no_data": "Sembra che non ci sia ancora nulla qui… per ora!<br/>Modifica i tuoi filtri o riprova!",
-    "no_file_choosen": "Nessun file selezionato",
-    "no_flow_outputs": "Nessun output disponibile.",
-    "no_history": "Nessuna cronologia disponibile",
-    "no_inputs": "Nessun input disponibile.",
-    "no_logs_data": "Nessun dato",
-    "no_logs_data_description": "Prova a modificare i filtri, cambiare l'intervallo di tempo o verifica se il flow è stato eseguito di recente.",
-    "no_logs_data_title": "Nessun log trovato per i filtri selezionati.",
-    "no_namespaces": "Nessun namespace corrisponde ai criteri di ricerca.",
-    "no_results": {
-      "assets": "Nessun asset trovato",
-      "executions": "Nessuna Esecuzione Trovata",
-      "flows": "Nessun Flow Trovato",
-      "kv_pairs": "Nessuna coppia Key-Value trovata",
-      "secrets": "Nessun Secret Trovato",
-      "templates": "Nessun Template Trovato",
-      "triggers": "Nessun Trigger Trovato"
-    },
-    "no_results_found": "Nessun risultato trovato",
-    "no_tasks_running": "Nessun task è ancora in esecuzione.",
-    "no_trigger": "Nessun trigger disponibile.",
     "no_variables": "Nessuna variabile disponibile.",
-    "now": "Ora",
-    "of": "di",
-    "ok": "OK",
-    "onboarding": {
-      "actions": {
-        "cancel_tutorial": "Annulla tutorial",
-        "complete": "Completa",
-        "edit_flow_to_continue": "Premi Modifica flow nella barra in alto (a destra).",
-        "execute_to_continue": "1. Premi Esegui nella barra in alto (a destra).\n2. Fornisci un valore per <strong>name</strong>.\n3. Premi di nuovo Esegui nella finestra modale.",
-        "finish_tutorial": "Termina tutorial",
-        "next": "Avanti",
-        "save_to_continue": "Premi Salva nella barra in alto (a destra)."
-      },
-      "cancel_modal": {
-        "confirm": "Annulla tutorial",
-        "description": "Vuoi annullare il tutorial Primo Flow?",
-        "keep": "Continua tutorial",
-        "title": "Annulla il tutorial Primo Flow"
-      },
-      "editor_hints": {
-        "build_intro": "Crea il tuo primo flow passo dopo passo.",
-        "step_1": "# 1) Aggiungi id",
-        "step_2": "# 2) Aggiungi namespace",
-        "step_3": "# 3) Aggiungi un input",
-        "step_4": "# 4) Aggiungi i task e il tuo primo task Python",
-        "step_5": "# 5) Aggiungi un trigger cron"
-      },
-      "finish_actions": {
-        "create_flow": "Crea flow",
-        "explore_blueprints": "Esplora i Blueprint"
-      },
-      "steps": {
-        "add_cron_trigger": {
-          "description": "I trigger possono avviare run in base a pianificazioni o eventi esterni (ad esempio webhook o messaggi MQTT).<br><br>Ora aggiungi un trigger di pianificazione cron affinché questo flow venga eseguito ogni 5 minuti.",
-          "title": "Aggiungi un trigger cron"
-        },
-        "add_id": {
-          "description": "L’ID è il nome univoco del tuo flow, così puoi trovarlo, eseguirlo e farvi riferimento in modo coerente.<br><br>Ora aggiungi <code>id</code> al livello root.",
-          "title": "Aggiungi l’ID del flow"
-        },
-        "add_input": {
-          "description": "Gli input sono parametri a livello di flow che possono essere referenziati all’interno dei task per controllare dinamicamente il comportamento in fase di esecuzione.<br><br>Ora aggiungi un input chiamato <code>name</code> con tipo <code>STRING</code>.",
-          "title": "Aggiungi un input"
-        },
-        "add_input_default": {
-          "description": "Quando un flow viene attivato automaticamente, gli input necessitano comunque di valori in fase di esecuzione.<br><br>L’input <code>name</code> è già stato creato nel passaggio precedente, quindi non è necessario aggiungerlo di nuovo. Imposta semplicemente un valore predefinito per l’input esistente <code>name</code>.",
-          "title": "Imposta un valore predefinito per l’input"
-        },
-        "add_log_task": {
-          "description": "I task sono le unità di lavoro eseguite dal tuo flow, definiti come un elenco ordinato di passaggi. Ogni task necessita di un <code>id</code> univoco e di un <code>type</code>. Kestra fornisce molti plugin di task per sistemi esterni; qui utilizziamo un task Python Script.<br><br>La sintassi <code>&#123;&#123; ... &#125;&#125;</code> è un’espressione Pebble, utilizzata per referenziare variabili dinamicamente in fase di esecuzione, come <code>&#123;&#123; inputs.name &#125;&#125;</code> dagli input del flow.<br><br>Ora aggiungi il primo task sotto <code>tasks</code> con <code>id</code>, <code>type</code> e uno <code>script</code> che stampi un messaggio di saluto.",
-          "title": "Aggiungi il primo task"
-        },
-        "add_namespace": {
-          "description": "Il Namespace è un raggruppamento simile a una cartella che organizza i flow per team, progetto o ambiente.<br><br>Ora aggiungi <code>namespace</code> al livello root.",
-          "title": "Aggiungi il namespace"
-        },
-        "background_runs_info": {
-          "description": "Questo flow verrà ora eseguito in background ogni 5 minuti.<br><br>Puoi navigare alla panoramica delle Esecuzioni dal menu a sinistra per monitorare le esecuzioni pianificate.",
-          "title": "Esecuzioni pianificate"
-        },
-        "edit_flow_from_execution": {
-          "description": "Puoi passare direttamente da un’esecuzione alla definizione del flow per iterare rapidamente.",
-          "title": "Torna all’Editor del flow"
-        },
-        "execute_flow": {
-          "description": "L’esecuzione avvia un run del tuo flow con valori di input forniti in fase di esecuzione.",
-          "title": "Esegui il flow"
-        },
-        "finish": {
-          "description": "Ottimo inizio. Hai creato, eseguito, parametrizzato e pianificato un flow.<br><br>Scegli cosa fare dopo ...",
-          "title": "Hai completato il tutorial Primo Flow"
-        },
-        "flow_basics": {
-          "description": "In Kestra, un <code>flow</code> è l’unità centrale di orchestrazione. Viene definito in YAML con metadati e task ordinati.<br><br>Esamina la struttura di esempio qui sotto, quindi continua a costruirla passo dopo passo.",
-          "title": "Nozioni di base sui flow"
-        },
-        "save_flow": {
-          "description": "Il salvataggio memorizza la definizione del tuo flow affinché possa essere eseguita.",
-          "title": "Salva il flow"
-        },
-        "save_flow_again": {
-          "description": "Il tuo flow ora ha una pianificazione e un valore di input predefinito per le esecuzioni automatiche.",
-          "title": "Salva il flow"
-        },
-        "view_logs_status": {
-          "description": "I dettagli di esecuzione mostrano lo stato del run, i tempi e i log di output a livello di task.<br><br>Ora apri i dettagli di esecuzione e fai clic su <code>greet</code> nel diagramma di Gantt per vedere i log.",
-          "title": "Verifica l’esecuzione"
-        }
-      },
-      "validation": {
-        "add_cron_trigger_cron": "Aggiungi un’espressione cron, ad esempio: `\"*/5 * * * *\"`.",
-        "add_cron_trigger_section": "Crea una sezione `triggers` con un trigger di pianificazione.",
-        "add_cron_trigger_type": "Imposta il tipo di trigger su `io.kestra.plugin.core.trigger.Schedule`.",
-        "add_id": "Aggiungi un ID del flow in alto. Esempio: `id: hello_flow`.",
-        "add_input_default_defaults": "Aggiungi un valore predefinito per `name`, ad esempio: `defaults: \"Kestra\"`.",
-        "add_input_default_id": "Mantieni l’ID dell’input esistente come `name`.",
-        "add_input_default_section": "Torna a `inputs` e mantieni un input esistente chiamato `name` (non aggiungere un secondo input).",
-        "add_input_id": "All’interno di `inputs`, aggiungi `id: name`.",
-        "add_input_section": "Crea una sezione `inputs` con un input.",
-        "add_input_type": "Imposta il tipo di input su `STRING`.",
-        "add_log_task_id": "Assegna un ID al task, ad esempio: `id: greet`.",
-        "add_log_task_message": "Aggiungi un campo `script` al task.",
-        "add_log_task_pebble": "Usa un’espressione Pebble nello script affinché utilizzi il valore del tuo input (ad esempio: `inputs.name`).",
-        "add_log_task_section": "Crea una sezione `tasks` e aggiungi il tuo primo task.",
-        "add_log_task_type": "Imposta il tipo di task su `io.kestra.plugin.scripts.python.Script`.",
-        "add_namespace": "Aggiungi un namespace in alto. Esempio: `namespace: company.team`.",
-        "complete_step": "Ci sei quasi. Completa questo passaggio per continuare.",
-        "edit_flow_from_execution": "Fai clic su `Modifica flow` nella barra in alto per continuare.",
-        "execute_flow": "Esegui il flow una volta per continuare.",
-        "fix_yaml": "C’è un piccolo problema di formattazione YAML. Correggilo e poi continua.",
-        "save_flow": "Fai clic su Salva per continuare.",
-        "save_flow_again": "Fai clic di nuovo su Salva per continuare.",
-        "view_logs_status": "Apri i dettagli di esecuzione e controlla i log di `greet`."
-      },
-      "welcome": {
-        "additional_help": "Aiuto aggiuntivo",
-        "badge": "Tutorial",
-        "blueprints": "Blueprint",
-        "docs": "Documentazione",
-        "guided_description": "Scopri come creare ed eseguire il tuo primo flow con passaggi guidati.",
-        "guided_duration": "Consigliato per la maggior parte degli utenti",
-        "guided_title": "Crea il tuo primo flow",
-        "headline": "Crea ed esegui il tuo primo workflow in pochi minuti",
-        "self_serve_description": "Vai direttamente all’editor e crea il tuo flow.",
-        "self_serve_note": "Per utenti esperti",
-        "self_serve_title": "Crea un flow da zero",
-        "slack": "Community Slack",
-        "tutorial": "Tutorial"
-      }
+    "download": "Scarica",
+    "jsonl": "JSONL",
+    "concurrency_limit": {
+      "dialog_title": "Limiti di Concorrenza",
+      "warning": "Modificare il contatore in esecuzione può corrompere la concorrenza, quindi le esecuzioni potrebbero superare il limite consentito."
     },
-    "open": "Apri",
-    "open full page": "Apri Pagina Completa",
-    "open in new tab": "In una nuova scheda",
-    "open in same tab": "Nella stessa scheda",
-    "open sidebar": "apri barra laterale",
-    "open source": "Open Source",
-    "open_page": "Open page",
-    "optional": "Opzionale",
-    "original execution": "Esecuzione originale",
-    "originalCreatedDate": "Data di creazione originale",
-    "outdated revision save confirmation": {
-      "confirm": "Vuoi sovrascriverlo?",
-      "create": {
-        "description": "Un flow con lo stesso id esiste già in questo namespace.",
-        "details": "Salva per sovrascrivere e creare una nuova revisione.",
-        "title": "Flow già esistente"
-      },
-      "update": {
-        "description": "La revisione che stai modificando è obsoleta.",
-        "details": "Controlla la scheda Revisions per maggiori dettagli sull'ultima versione.",
-        "title": "Revisione obsoleta"
-      }
+    "documentation": {
+      "documentation": "Documentazione",
+      "github": "Apri un problema su GitHub"
     },
-    "output": "Output",
-    "outputs": "Outputs",
-    "override": {
-      "details": "Il flow precedente può essere ripristinato dalla scheda Revisions.",
-      "title": "Stai per sovrascrivere il flow corrente"
-    },
-    "overview": "Panoramica",
-    "page": {
-      "next": "Pagina successiva",
-      "previous": "Pagina precedente"
-    },
-    "panel actions": "Azioni del pannello",
-    "parent execution": "Esecuzione genitore",
-    "password": "Password",
-    "password empty constraint": "Nome utente o password errati",
-    "password length constraint": "La password non deve superare i 256 caratteri",
-    "passwords do not match": "Le password non corrispondono",
-    "pause": "Pausa",
-    "pause backfill": "Metti in pausa il backfill",
-    "pause backfills": "Metti in pausa i backfills",
-    "pause confirm": "Sei sicuro di mettere in pausa l'esecuzione <code>{id}</code>?",
-    "pause done": "L'esecuzione è PAUSED",
-    "pause title": "Metti in pausa l'esecuzione <code>{id}</code>.<br/>Nota che i task attualmente in esecuzione verranno comunque elaborati e l'esecuzione dovrà essere ripresa manualmente.",
-    "paused": "PAUSED",
-    "playground": {
-      "clear_history": "Cancella cronologia",
-      "confirm_create": "Non puoi eseguire il playground mentre crei un flow. Avviare un'esecuzione del playground creerà il flow.",
-      "history": "Ultime 10 esecuzioni",
-      "play_icon_info": "Puoi anche fare clic sull'icona Play nelle viste No-Code o Topology.",
-      "run_all_tasks": "Esegui Tutti i Task",
-      "run_task": "Esegui Task",
-      "run_task_and_downstream": "Esegui task e downstream",
-      "run_task_info": "Passa il mouse su qualsiasi task nell'editor del Flow Code e fai clic sul pulsante \"Run task\" per testare il tuo task.",
-      "run_this_task": "Esegui questo task",
-      "title": "Playground",
-      "toggle": "Playground",
-      "tooltip_persistence": "Se disattivi e riattivi il Playground, le informazioni rimangono finché resti sulla pagina."
-    },
-    "playground actions": "Azioni del playground",
-    "plugin defaults exported": "Predefiniti del plugin esportati",
-    "plugin defaults imported": "Predefiniti del plugin importati",
-    "plugin defaults not imported": "Alcuni valori predefiniti del plugin non possono essere importati",
-    "pluginDefaults": {
-      "add": "Aggiungi Plugin Predefinito",
-      "add_subtitle": "Configura un nuovo plugin predefinito con le sue proprietà",
-      "cancel": "Annulla",
-      "custom": "Plugin Personalizzato",
-      "custom_configure": "Tipo di plugin personalizzato - configurare utilizzando YAML",
-      "custom_placeholder": "Inserisci il tipo di plugin",
-      "custom_type": "Tipo di plugin personalizzato",
-      "edit": "Modifica Plugin Predefinito",
-      "edit_subtitle": "Modifica la configurazione predefinita del plugin esistente",
-      "form": "Modulo",
-      "predefined": "Plugin Predefinito",
-      "select_predefined": "Seleziona Plugin Predefinito",
-      "show_yaml": "Mostra YAML",
-      "title": "Predefiniti del Plugin",
-      "update": "Aggiorna Plugin Default",
-      "use_custom": "Usa Personalizzato",
-      "yaml": "YAML",
-      "yaml_configuration": "Configurazione YAML"
-    },
-    "pluginPage": {
-      "elementType": {
-        "apps": "App",
-        "charts": "Grafico",
-        "conditions": "Condizione",
-        "logExporters": "Esportatore di log",
-        "secrets": "Segreto",
-        "taskRunners": "Esecutore di task",
-        "tasks": "Compito",
-        "triggers": "Trigger"
-      },
-      "group": {
-        "blueprints": "Blueprint ({count})",
-        "plugins": "Plugin ({count})",
-        "tasks": "Attività ({count})"
-      },
+    "blueprints": {
+      "all": "Tutti",
+      "community": "Comunità",
+      "create": "Crea un blueprint",
+      "edit": "Modifica un blueprint",
+      "title": "Blueprints",
+      "empty": "Nessun blueprint da mostrare.",
       "header": {
-        "back": "Torna ai plugin",
-        "certified": "Certificato",
-        "enterpriseEdition": "Edizione Enterprise"
+        "catch phrase": {
+          "1": "Il primo passo è sempre il più difficile.",
+          "2": "Esplora i blueprint per avviare il tuo prossimo {kind}."
+        },
+        "alt": "Icona dei Blueprint"
       },
-      "loadError": "Impossibile caricare i plugin. Per favore riprova.",
-      "noResults": "Nessun plugin corrisponde alla tua ricerca.",
-      "notFound": "Questo plugin non è stato trovato.",
-      "overview": {
-        "createdBy": "Creato da",
-        "latest": "Ultimo",
-        "linksResources": "Link e Risorse",
-        "managedBy": "Gestito da",
-        "minKestraVersion": "Min. versione compatibile di Kestra: {version}",
-        "minKestraVersionShort": "Versione minima di Kestra {version}",
-        "pluginType": "Tipo di plugin",
-        "previousVersions": "Versioni precedenti",
-        "releaseNotes": "Note di rilascio",
-        "title": "Panoramica",
-        "versions": "Versioni"
+      "custom": "Blueprint personalizzati",
+      "flows": "Blueprint dei Flow",
+      "apps": "Blueprint delle App",
+      "dashboards": "Blueprint del Dashboard",
+      "detail": {
+        "category": "Tipo di categoria",
+        "links": "Link e Risorse",
+        "openInEditor": "Apri in Modifica Flow"
       },
-      "search": "Cerca tra oltre {count} plugin",
-      "searchTasks": "Cerca {count} task",
-      "sort": {
-        "mostUsed": "Più usati",
-        "nameAsc": "Nome A-Z",
-        "nameDesc": "Nome Z-A",
-        "newest": "Più recente"
-      },
-      "sortBy": "Ordina per"
+      "missingPlugins": {
+        "title": "Plugin mancanti",
+        "description": "Questo blueprint utilizza task di plugin non installati su questa istanza: {plugins}. Installali per usare questo blueprint.",
+        "card": "Richiede plugin non installati su questa istanza: {plugins}",
+        "install": "Installa plugin"
+      }
     },
-    "plugin_default_already_exists": "Il plugin predefinito per <code>{type}</code> esiste già.",
+    "use": "Usa",
     "plugins": {
       "name": "Plugin",
       "names": "Plugins",
       "please": "Per favore scegli un task a destra per vedere la sua documentazione",
       "release": "Note di rilascio"
     },
-    "port": "Porta",
-    "prefill inputs": "Precompila",
-    "pretty_json": "Pretty JSON",
-    "prev_execution": "Esecuzione precedente",
-    "preview": {
-      "auto-view": "Visualizzazione automatica",
-      "collapse": "Comprimi",
-      "expand": "Espandi",
-      "force-editor": "Forza vista editor",
-      "label": "Anteprima",
-      "next": "Avanti",
-      "page_of": "Pagina {current} di {total}",
-      "pagination_info": "Visualizzazione righe {start}-{end} di {total}.",
-      "previous": "Precedente",
-      "rows_truncated": "Visualizzazione di {shown} di {total} righe. Scarica il file per visualizzare tutti i dati.",
-      "showing_rows": "Visualizzazione righe {start}-{end} di {total}",
-      "view": "Visualizza"
+    "last execution date": "Data ultima esecuzione",
+    "last execution state": "Ultimo stato",
+    "last X days count": "{count} negli ultimi {days} giorni",
+    "date range count": "{count} tra il {startDate} e il {endDate}",
+    "date count": "{count} il {date}",
+    "revisions": "Revisions",
+    "no revisions found": "Esiste solo una revisione per questo flow",
+    "no revisions": "Nessuna revisione",
+    "see full revision": "Vedi revisione completa",
+    "side-by-side": "affiancato",
+    "line-by-line": "riga per riga",
+    "template": "Template",
+    "template creation": "Creazione del template",
+    "templates": "Templates",
+    "templates deprecated": "I templates sono deprecati. Si prega di utilizzare i subflows. Vedi la <a href=\"https://kestra.io/docs/migration-guide/0.11.0/templates?utm_source=app&utm_medium=referral&utm_campaign=template-inlinedoc\" target=\"_blank\">sezione Migrazioni</a> che spiega come migrare dai templates ai subflows.",
+    "no result": "Non ci sono risultati da mostrare.",
+    "empty search": "Risultati di ricerca vuoti",
+    "trigger": "Trigger",
+    "no_trigger": "Nessun trigger disponibile.",
+    "triggers": "Triggers",
+    "triggers_header_description": "Sfoglia, aggiungi e gestisci i trigger per automatizzare i tuoi flow. Scegli tra esporre il tuo flow come uno strumento AI, pianificare, aggiungere un webhook trigger, controllare le modifiche nelle app esterne o ascoltare eventi in tempo reale.",
+    "triggers_tabs_add": "Aggiungi",
+    "triggers_tabs_manage": "Gestisci",
+    "triggers_add_search_placeholder": "Cerca trigger...",
+    "triggers_add_filter_core": "Core",
+    "triggers_add_filter_realtime": "Tempo reale",
+    "triggers_add_filter_all": "Tutti",
+    "triggers_add_filter_app": "App",
+    "triggers_add_empty_title": "Nessun trigger trovato",
+    "triggers_add_ee_tooltip": "Questo trigger richiede l'Enterprise Edition.",
+    "triggers_add_category_empty": "Nessun trigger in questa categoria.",
+    "triggers_add_card_add_to_flow": "Aggiungi al flow",
+    "triggers_add_card_add": "Aggiungi",
+    "triggers_add_modal_title": "{name}",
+    "triggers_add_modal_tab_form": "Modulo",
+    "triggers_add_modal_tab_source": "Sorgente",
+    "triggers_add_modal_tab_documentation": "Documentazione",
+    "triggers_add_modal_namespace_placeholder": "Seleziona un namespace",
+    "triggers_add_modal_flow_placeholder": "Seleziona un flow",
+    "triggers_add_modal_trigger_id": "ID del trigger",
+    "triggers_add_modal_trigger_id_placeholder": "Identificatore univoco per questo trigger",
+    "triggers_add_modal_properties_hint": "Configura le proprietà del trigger nell'editor del flow dopo aver aggiunto il trigger.",
+    "triggers_add_modal_ee_notice": "Questo trigger richiede l'Enterprise Edition.",
+    "triggers_add_modal_add_button": "Aggiungi Trigger al Flow",
+    "trigger details": "Dettagli del trigger",
+    "triggerflow disabled": "Il trigger è disabilitato dalla definizione del flow",
+    "last trigger date": "Data ultimo trigger",
+    "trigger_states": "Stati",
+    "context updated date": "Data di aggiornamento del contesto",
+    "state updated date": "Data di aggiornamento dello stato",
+    "next evaluation date": "Prossima data di valutazione",
+    "last evaluation date": "Data ultima valutazione",
+    "last trigger date tooltip": "Quando il trigger è stato eseguito l'ultima volta. Potrebbe essere nel passato quando si esegue un backfill.",
+    "context updated date tooltip": "Quando il contesto del trigger è stato aggiornato l'ultima volta. Questo avviene quando l'esecuzione è attivata, termina (blocco rilasciato) o dopo una valutazione (anche se non avviene alcuna esecuzione).",
+    "next evaluation date tooltip": "Quando il trigger verrà valutato nuovamente, in base al suo intervallo. Non sempre coincide con la prossima data di esecuzione se le condizioni non sono soddisfatte.",
+    "last evaluation date tooltip": "When the trigger was last evaluated by the scheduler, regardless of whether it produced an execution.",
+    "conditions": "Condizioni",
+    "triggerId": "ID del trigger",
+    "tenantId": "ID del Mandante",
+    "codeDisabled": "Disabilitato nel Flow",
+    "paused": "PAUSED",
+    "running": "RUNNING",
+    "Fold auto": "Editor: piegatura automatica delle righe multiple",
+    "Hover description": "Editor: Mostra la descrizione del campo quando si passa il mouse su key o value",
+    "Fold content lines": "Piega stringhe multilinea",
+    "Unfold content lines": "Spiega stringhe multilinea",
+    "Total": "Totale",
+    "sub flow": "Subflow",
+    "execute": "Esegui",
+    "execute flow behaviour": "Esegui il flow",
+    "open in same tab": "Nella stessa scheda",
+    "open in new tab": "In una nuova scheda",
+    "execute the flow": "Esegui il flow <code>{id}</code>",
+    "execute flow now ?": "Vuoi eseguire questo flow?",
+    "discard execution confirmation": "Hai degli input non salvati. Sei sicuro di voler scartare questa esecuzione?",
+    "discard changes confirmation": "Hai modifiche non salvate. Sei sicuro di volerle scartare?",
+    "Default namespace": "Namespace predefinito",
+    "Default log level": "Livello di log predefinito",
+    "unsaved changed ?": "Hai modifiche non salvate, vuoi lasciare questa pagina?",
+    "unsaved changes": "Modifiche Non Salvate",
+    "unsaved changes warning": "Hai modifiche non salvate. Se lasci questa pagina, le modifiche andranno perse.",
+    "leave page": "Lascia Pagina",
+    "open full page": "Apri Pagina Completa",
+    "drill down preview": "Anteprima",
+    "Editor theme": "Tema dell'editor",
+    "Editor fontsize": "Dimensione del font dell'editor",
+    "Editor fontfamily": "Famiglia di font dell'editor",
+    "errors": {
+      "401": {
+        "title": "Non autorizzato",
+        "content": "Devi essere autenticato per accedere a questa pagina."
+      },
+      "403": {
+        "title": "Accesso negato",
+        "content": "Non hai i permessi necessari per accedere a questa pagina."
+      },
+      "404": {
+        "title": "Pagina non trovata",
+        "content": "L'URL richiesto non è stato trovato su questo server.<br />Questo è tutto ciò che sappiamo.",
+        "flow or execution": "Il flow o l'esecuzione che stai cercando non esiste."
+      }
     },
-    "pricing": "Prezzi",
-    "product_tour": "Tour del prodotto",
-    "properties": {
-      "hidden": "Nascosto nella Tabella",
-      "hint": "Scegli colonne visibili",
-      "label": "Proprietà",
-      "shown": "Visualizzato nella tabella"
+    "back_to_dashboard": "Torna alla dashboard",
+    "copy all logs": "Copia tutti i Log",
+    "copy logs": "Copia logs",
+    "fix_with_ai": "Correggi con AI",
+    "download logs": "Scarica logs",
+    "delete logs": "Elimina logs",
+    "delete_all_logs": "Sei sicuro di voler eliminare tutti i logs?",
+    "delete_log": "Sei sicuro di voler eliminare il log?",
+    "toggle fullscreen": "Attiva/disattiva schermo intero",
+    "copied": "Copiato",
+    "tags": "Tag",
+    "disabled flow title": "Questo flow è disabilitato",
+    "disabled flow desc": "Questo flow è disabilitato, per favore abilitalo per eseguirlo.",
+    "label": "Label",
+    "labels": "Etichette",
+    "label filter placeholder": "Etichetta come 'key:value'",
+    "execution labels": "Etichette di esecuzione",
+    "wrong labels": "Chiave o valore vuoto non sono ammessi nelle etichette",
+    "feeds": {
+      "title": "Novità su Kestra",
+      "heading": "Tutto su Kestra.",
+      "subheading": "Gli ultimi aggiornamenti, guide e storie"
     },
-    "queued duration": "Durata in coda",
-    "quotas": "Quote",
-    "reach us": "Parlaci",
-    "read-more": "Leggi di più su",
-    "readonly property": "Proprietà di sola lettura",
-    "recent_executions": "Esecuzioni Recenti",
-    "refresh": "Aggiorna",
-    "reject": "Rifiuta",
-    "relative": "Relativo",
-    "relative end date": "Data di fine relativa",
-    "relative start date": "Data di inizio relativa",
-    "remove label": "Rimuovi label",
-    "remove this item": "Rimuovi questo elemento",
-    "remove_bookmark": "Sei sicuro di voler rimuovere questo segnalibro?",
-    "replay": "Ripeti",
-    "replay confirm": "Sei sicuro di voler ripetere questa esecuzione <code>{id}</code> e crearne una nuova?",
-    "replay execution description": "Questo creerà una nuova esecuzione basata sull'esecuzione selezionata.",
-    "replay execution title": "Riesegui esecuzione",
-    "replay from beginning tooltip": "Crea un'esecuzione simile a partire dall'inizio",
-    "replay from task tooltip": "Crea un'esecuzione simile a partire dal task <code>{taskId}</code>",
-    "replay inputs": "Ingressi",
-    "replay inputs new required": "Questa revisione ha degli input. Ti verrà chiesto di compilarli.",
-    "replay latest revision": "Ripeti utilizzando l'ultima revisione",
-    "replay select taskrun": "Seleziona l'esecuzione del task da riprodurre:",
-    "replay the execution": "Ripeti l'esecuzione <code>{executionId}</code> per il flow <code>{flowId}</code>",
-    "replay using": "Riproduci utilizzando",
-    "replay with inputs": "Riesegui con input",
-    "replayed": "L'esecuzione è ripetuta",
-    "required field": "Campo obbligatorio",
-    "reset": "Riavvia",
-    "reset to defaults": "Reimposta ai valori predefiniti",
-    "restart": "Riavvia",
-    "restart change revision": "Puoi cambiare la revisione che verrà utilizzata per la nuova esecuzione.",
-    "restart confirm": "Sei sicuro di voler riavviare l'esecuzione <code>{id}</code>?",
-    "restart execution title": "Riavvia esecuzione",
-    "restart latest revision": "Riavvia ultima revisione",
-    "restart tooltip": "Riavvia l'esecuzione dal task <code>{state}</code>",
-    "restart trigger": {
-      "button": "Riavvia trigger",
-      "tooltip": "Riavvia il trigger"
-    },
-    "restarted": "L'esecuzione è riavviata",
+    "delete execution running": "<div class=\"alert alert-warning mt-2 mb-0\">Questa esecuzione è ancora RUNNING, eliminarla non la fermerà.<br />È necessario kill l'esecuzione per fermarla.</div>",
     "restore": "Ripristina",
     "restore confirm": "Sei sicuro di voler ripristinare la revisione <code>{revision}</code>?",
+    "bulk delete": "Sei sicuro di voler eliminare <code>{executionCount}</code> esecuzione/i?",
+    "bulk replay": "Sei sicuro di voler ripetere <code>{executionCount}</code> esecuzione/i?",
+    "bulk change state": "Sei sicuro di voler cambiare lo stato di <code>{executionCount}</code> esecuzione/i?",
+    "bulk resume": "Sei sicuro di voler riprendere <code>{executionCount}</code> esecuzione/i?",
+    "bulk pause": "Sei sicuro di voler mettere in pausa l'esecuzione di <code>{executionCount}</code>?",
+    "bulk unqueue": "Sei sicuro di voler rimuovere dalla coda <code>{executionCount}</code> esecuzione/i?",
+    "bulk force run": "Sei sicuro di voler forzare l'esecuzione di <code>{executionCount}</code>?<br/><br/>WARNING: forzare l'esecuzione non è garantito e potrebbe creare esecuzioni duplicate dei task.<br/><br/>Le seguenti transizioni verranno effettuate:<br/><ul><li>I task in stato CREATED verranno spostati allo stato RUNNING.</li><li>I task in stato RUNNING verranno ri-sottomessi.</li><li>I task in stato QUEUED verranno rimossi dalla coda.</li><li>I task in stato PAUSED verranno ripresi.</li></ul>",
+    "bulk restart": "Sei sicuro di voler riavviare <code>{executionCount}</code> esecuzione/i?",
+    "bulk kill": "Sei sicuro di voler kill <code>{executionCount}</code> esecuzione/i?",
+    "selection": {
+      "selected": "<strong>{count}</strong> selezionati",
+      "all": "Seleziona tutto ({count})"
+    },
+    "cancel": "Annulla",
+    "errorLogs": "Log degli errori",
+    "welcome_page": {
+      "welcome": "Benvenuto in Kestra",
+      "guide": "Hai bisogno di assistenza per eseguire il tuo primo flow?"
+    },
+    "product_tour": "Tour del prodotto",
+    "executions replayed": "<code>{executionCount}</code> esecuzione/i ripetute",
+    "executions state changed": "Lo stato di <code>{executionCount}</code> esecuzione/i è stato cambiato",
+    "executions resumed": "<code>{executionCount}</code> esecuzione/i riprese",
+    "executions paused": "<code>{executionCount}</code> esecuzione(i) PAUSED",
+    "executions unqueue": "<code>{executionCount}</code> esecuzione(i) in coda",
+    "executions force run": "<code>{executionCount}</code> esecuzione/i forzata/e",
+    "executions restarted": "<code>{executionCount}</code> esecuzione/i riavviate",
+    "executions killed": "<code>{executionCount}</code> esecuzione/i kill",
+    "executions deleted": "<code>{executionCount}</code> esecuzione/i eliminate",
+    "invalid bulk replay": "Impossibile ripetere le esecuzioni",
+    "invalid bulk resume": "Impossibile riprendere le esecuzioni",
+    "invalid bulk pause": "Impossibile mettere in pausa le esecuzioni",
+    "invalid bulk unqueue": "Impossibile rimuovere dalla coda le esecuzioni",
+    "invalid bulk force run": "Impossibile forzare l'esecuzione delle esecuzioni",
+    "invalid bulk restart": "Impossibile riavviare le esecuzioni",
+    "invalid bulk kill": "Impossibile kill le esecuzioni",
+    "invalid bulk delete": "Impossibile eliminare le esecuzioni",
+    "execution not found": "L'esecuzione {executionId} non è stata trovata.",
+    "execution not in state PAUSED": "Esecuzione <code>{executionId}</code> non in stato PAUSED",
+    "execution not in state FAILED": "Esecuzione <code>{executionId}</code> non in stato FAILED",
+    "execution already finished": "Esecuzione <code>{executionId}</code> già terminata",
     "restore revision": "Sei sicuro di voler ripristinare la revisione <code>{revision}</code>?",
-    "resume": "Riprendi",
-    "resume from breakpoint done": "L'esecuzione è ripresa dal breakpoint",
-    "resume from breakpoint title": "Riprendi l'esecuzione <code>{id}</code> dal punto di interruzione",
-    "resumed confirm": "Sei sicuro di voler riprendere l'esecuzione <code>{id}</code>?",
-    "resumed done": "L'esecuzione è stata ripresa",
-    "resumed title": "Riprendi esecuzione <code>{id}</code>",
-    "reuse original inputs": "Riutilizza gli input originali",
-    "reuse_original_inputs": "Riutilizza gli input originali",
-    "review your inputs": "Rivedi i tuoi input",
-    "revision": "Revisione",
-    "revision deleted": "La revisione {revision} è stata eliminata con successo",
-    "revisions": "Revisions",
-    "row count": "Conteggio righe",
-    "run task in playground": "Esegui task nel playground",
+    "seeing old revision": "Stai vedendo una vecchia revisione: {revision}",
+    "export": "Esporta",
+    "exports": "Esportazioni",
+    "export_csv": "Esporta come CSV",
+    "template export": "Sei sicuro di voler esportare <code>{templateCount}</code> template/i?",
+    "templates exported": "Template esportati",
+    "export all templates": "Esporta tutti i template",
+    "flow_export": "Esporta flow",
+    "flow export": "Sei sicuro di voler esportare <code>{flowCount}</code> flow?",
+    "flows exported": "<code>{count}</code> Flow esportati",
+    "export all flows": "Esporta tutti i flows",
+    "import": "Importa",
+    "disable": "Disabilita",
+    "enable": "Abilita",
+    "enabled": "Abilitato",
+    "template delete": "Sei sicuro di voler eliminare <code>{templateCount}</code> template/i?",
+    "flow delete": "Sei sicuro di voler eliminare <code>{flowCount}</code> flow?",
+    "templates deleted": "<code>{count}</code> Template/i eliminati",
+    "flows deleted": "<code>{count}</code> Flow eliminati",
+    "flow disable": "Sei sicuro di voler disabilitare <code>{flowCount}</code> flow?",
+    "flow enable": "Sei sicuro di voler abilitare <code>{flowCount}</code> flow?",
+    "flows disabled": "<code>{count}</code> Flow disabilitati",
+    "flows enabled": "<code>{count}</code> Flow abilitati",
+    "flow-no-dependencies": "Il tuo flow non ha dipendenze",
+    "flow-dependencies": "dipendenze",
+    "read-more": "Leggi di più su",
+    "in-our-documentation": "nella nostra documentazione.",
+    "dependencies": "Dipendenze",
+    "see dependencies": "Vedi dipendenze",
+    "see timeline": "Vedi cronologia",
     "run timeline": "Cronologia Esecuzione",
-    "runners": "Corridori",
-    "running": "RUNNING",
-    "running duration": "Durata in esecuzione",
-    "save": "Salva",
+    "dependencies missing acls": "Nessun permesso su questo flow",
+    "dependencies delete flow": "Questo flow ha dipendenze. Eliminarlo impedirà l'esecuzione delle loro dipendenze.<br /><br /> Ecco l'elenco dei flows interessati:",
+    "expand dependencies": "Espandi dipendenze",
+    "reset": "Riavvia",
+    "show task documentation": "Mostra la documentazione del task",
+    "hide task documentation": "Nascondi la documentazione del task",
+    "show task documentation in editor": "Mostra la documentazione del task nell'editor",
+    "show documentation": "Mostra documentazione",
+    "focus task": "Clicca su qualsiasi elemento per vedere la sua documentazione.",
+    "validate": "Valida",
+    "add error handler": "Aggiungi un gestore errori",
+    "taskDefaults": "Task Defaults",
+    "disabled": "Disabilitato",
+    "before": "prima",
+    "after": "dopo",
+    "add at position": "Aggiungi {position} <code>{task}</code>",
+    "create first task": "Crea il tuo primo task",
+    "dynamic": "Dinamico",
+    "choice": "Scelta",
+    "sequential": "Sequenziale",
+    "can not delete": "Impossibile eliminare",
+    "can not have less than 1 task": "Ogni flow deve avere almeno un task.",
+    "task id already exists": "Task Id già esistente",
+    "Task Id already exist in the flow": "Task Id {taskId} già esistente nel flow.",
+    "task id": "Task ID",
+    "taskid column details": "Ultimo task in esecuzione e il numero di tentativi.",
+    "flow already exists": "Flow già esistente",
+    "flow already exists message": "Il flow <code>{id}</code> esiste già nel namespace <code>{namespace}</code>. Vuoi creare una nuova revisione?",
+    "plugin_default_already_exists": "Il plugin predefinito per <code>{type}</code> esiste già.",
+    "namespace not allowed": "Namespace non consentito",
+    "switch-view": "Cambia vista",
+    "source and topology": "Sorgente e topologia",
+    "source and doc": "Sorgente e documentazione",
+    "source and blueprints": "Sorgente e blueprints",
+    "editor": "Editor",
+    "error in editor": "È stato trovato un errore nell'editor",
+    "delete task confirm": "Vuoi eliminare il task <code>{taskId}</code>?",
+    "can not save": "Impossibile salvare",
+    "flow must not be empty": "Il flow non deve essere vuoto",
+    "flow must have id and namespace": "Il flow deve avere un id e un namespace.",
+    "flow creation denied in namespace": "Non hai il permesso di creare flow nel namespace `{namespace}`.",
+    "readonly property": "Proprietà di sola lettura",
+    "namespace and id readonly": "Le proprietà `namespace` e `id` non possono essere modificate — ora sono impostate sui loro valori iniziali. Se vuoi rinominare un flow o cambiare il suo namespace, puoi creare un nuovo flow e rimuovere quello vecchio.",
+    "avg": "Media",
+    "sum": "Somma",
+    "min": "Min",
+    "max": "Max",
+    "bar": "Bar",
+    "line": "Linea",
+    "metric": "Metrica",
+    "aggregation": "Aggregazione",
+    "chart type": "Tipo di grafico",
+    "metric choice": "Nessuna metrica disponibile per questo flow",
+    "of": "di",
+    "see_all_states": "Vedi tutti gli stati",
     "save draft": {
       "message": "Bozza salvata",
       "retrieval": {
@@ -1680,164 +724,336 @@
         "existing": "Una bozza del Flow <code>{flowFullName}</code> è stata salvata, vuoi continuare a modificare il flow?"
       }
     },
-    "save task": "Salva Task",
-    "save_and_execute": "Salva & Esegui",
-    "save_as_draft": "Salva come bozza",
-    "saved": "Salvato con successo",
-    "saved as draft": "Salvato come bozza con successo",
-    "saved as draft done": "<em>{name}</em> è stato salvato con successo come bozza",
-    "saved done": "<em>{name}</em> è stato salvato con successo",
-    "scheduleDate": "Data di pianificazione",
-    "scope_filter": {
-      "all": "Tutte le {label}",
-      "system": "Sistema {label}",
-      "system_description": "Manutenzione del sistema {label}",
-      "user": "Utente {label}",
-      "user_description": "Utente regolare ha avviato {label}"
+    "title": "Titolo",
+    "api": "API",
+    "more_actions": "Altre azioni",
+    "expand error": "Espandi solo i tasks FAILED",
+    "expand all": "Espandi tutto",
+    "collapse all": "Comprimi tutto",
+    "expand": "Espandi",
+    "collapse": "Comprimi",
+    "filter by this value": "Filter by this value",
+    "filter_for": "Filter for",
+    "filter_out": "Filter out",
+    "copy_value": "Copy value",
+    "open_page": "Open page",
+    "logs_copied": "Logs copied to your clipboard",
+    "expand_by_default": "Expand structured logs by default",
+    "show raw": "Show raw",
+    "similar lines": "similar lines",
+    "download_logs_description": "Choose which logs to export. Filters default to your current view.",
+    "display_settings": "Display settings",
+    "density": "Density",
+    "density_compact": "Compact",
+    "density_normal": "Normal",
+    "density_expanded": "Expanded",
+    "pretty_json": "Pretty JSON",
+    "body_line_clamp": "Limit line height",
+    "font size": "Font size",
+    "log expand setting": "Visualizzazione predefinita del Log",
+    "environment": "Ambiente",
+    "environment name setting": "Nome dell'ambiente",
+    "environment color setting": "Colore dell'ambiente",
+    "slack support": "Fai qualsiasi domanda via Slack",
+    "join community": "Unisciti alla Community",
+    "join_slack": "Unisciti a Slack",
+    "kestra": "Kestra",
+    "reach us": "Parlaci",
+    "new version": "Nuova versione {version} disponibile!",
+    "error detected": "Errore(i) rilevato(i).",
+    "warning detected": "Avvisi rilevati",
+    "informative notice": "Note(s)",
+    "cannot swap tasks": "Impossibile scambiare i tasks",
+    "open": "Apri",
+    "dependency task": "Il task {taskId} è una dipendenza di un altro task",
+    "administration": "Amministrazione",
+    "admin": "Amministratore",
+    "main_configuration": "Configurazione Principale",
+    "commit_id": "ID commit",
+    "evaluation lock date": "Data di blocco della valutazione",
+    "unlock trigger": {
+      "tooltip": {
+        "execution": "C'è un'esecuzione in corso per questo trigger",
+        "evaluation": "Il trigger è attualmente in valutazione"
+      },
+      "confirmation": "Sei sicuro di voler sbloccare il trigger?",
+      "warning": "Potrebbe portare a esecuzioni concorrenti per lo stesso trigger e dovrebbe essere considerata come ultima risorsa.",
+      "button": "Sblocca trigger",
+      "success": "Trigger sbloccato"
     },
-    "search": "Cerca",
-    "search blueprint": "Cerca blueprints",
-    "search filters": {
-      "filter name": "Nome filtro",
-      "filters": "Filtri",
-      "manage": "Gestisci filtri di ricerca",
-      "manage desc": "Gestisci filtri di ricerca salvati",
-      "save filter": "Salva filtro",
-      "saved": "Filtri salvati"
+    "restart trigger": {
+      "button": "Riavvia trigger",
+      "tooltip": "Riavvia il trigger"
     },
-    "search term in message": "Cerca termine nel messaggio",
-    "search_docs": "Cerca",
-    "searching": "Ricerca in corso...",
-    "secret": {
-      "add": "Crea",
-      "inherited": "Secrets ereditati",
-      "isReadOnly": "Il segreto è in sola lettura",
-      "names": "Secrets",
-      "update": "Aggiorna secret '{name}'"
-    },
-    "security_advice": {
-      "content": "Abilita l'autenticazione di base per proteggere la tua istanza.",
-      "enable": "Abilita autenticazione",
-      "switch_text": "Non mostrare più",
-      "title": "Proteggi la tua istanza"
-    },
-    "see dependencies": "Vedi dipendenze",
-    "see full revision": "Vedi revisione completa",
-    "see timeline": "Vedi cronologia",
-    "see_all_states": "Vedi tutti gli stati",
-    "seeing old revision": "Stai vedendo una vecchia revisione: {revision}",
-    "select": "Seleziona il tuo {{section}}",
-    "select a state": "Seleziona uno stato",
-    "select datetime": "Seleziona una data",
-    "select view": "Seleziona vista",
-    "selected": "Selezionato",
-    "selection": {
-      "all": "Seleziona tutto ({count})",
-      "selected": "<strong>{count}</strong> selezionati"
-    },
-    "sequential": "Sequenziale",
-    "server type": "Tipo di server",
+    "trigger disabled": "Il trigger è disabilitato all'interno della sorgente del flow",
+    "flow source not found": "Sorgente del flow non trovata",
+    "date format": "Formato data",
+    "timezone": "Fuso orario",
+    "add task": "Aggiungi un task",
+    "unable to generate graph": "Si è verificato un problema durante la generazione del grafico che impedisce la visualizzazione della topologia.",
+    "attempts": "Tentativi",
+    "flow deleted, you can restore it": "Il flow è stato eliminato e questa è una vista di sola lettura. Puoi ancora ripristinarlo.",
+    "workers": "Workers",
+    "worker group": "Gruppo di Workers",
+    "worker group key": "Chiave del gruppo Worker",
+    "worker group fallback": "Gruppo di Worker di riserva",
+    "version": "Versione",
     "services": "Servizi",
+    "server type": "Tipo di server",
+    "hostname": "Nome host",
+    "port": "Porta",
+    "management port": "Porta di gestione",
+    "file preview truncated": "Il contenuto visualizzato è stato troncato",
+    "file unavailable": "File non disponibile",
+    "file unavailable description": "Questo file non è più disponibile — potrebbe essere stato eliminato o scaduto.",
+    "row count": "Conteggio righe",
+    "encoding": "Codifica",
+    "show": "Mostra",
+    "advanced configuration": "Altre proprietà",
+    "all executions": "Tutte le esecuzioni",
+    "trigger execution id": "Trigger Execution Id",
+    "execution_status": "L'esecuzione è:",
+    "no_tasks_running": "Nessun task è ancora in esecuzione.",
+    "execution_starts_progress": "Una volta avviata l'esecuzione, vedrai gli aggiornamenti sul progresso qui.",
+    "triggers_state": {
+      "state": "Stato",
+      "options": {
+        "enabled": "Abilitato",
+        "disabled": "Disabilitato"
+      }
+    },
+    "trigger filter": {
+      "title": "Filtra esecuzioni figlie",
+      "options": {
+        "ALL": "Tutte le esecuzioni",
+        "CHILD": "Esecuzioni figlie",
+        "MAIN": "Esecuzioni genitori"
+      }
+    },
+    "show chart": "Mostra Grafico",
+    "namespace files": {
+      "toggle": {
+        "show": "Mostra file del namespace",
+        "hide": "Nascondi file del namespace"
+      },
+      "filter": "Filtro",
+      "new_file": "Nuovo file",
+      "no_items": {
+        "heading": "Nessun file trovato nel tuo namespace.",
+        "paragraph": "Crea o importa file per condividere il codice tra i flow nel tuo namespace."
+      },
+      "no_selection": {
+        "heading": "Nessun file selezionato",
+        "description": "Seleziona un file dall'albero per visualizzarne il contenuto."
+      },
+      "tree": {
+        "expand": "Espandi tutte le cartelle",
+        "collapse": "Comprimi tutte le cartelle"
+      },
+      "create": {
+        "label": "Crea",
+        "file": "Crea file",
+        "file_already_exists": "Un file con questo nome esiste già",
+        "file_conflicts_with_folder": "Una cartella con questo nome esiste già",
+        "file_error": "Si è verificato un errore durante la creazione del file",
+        "folder": "Crea cartella",
+        "folder_already_exists": "Una cartella con questo nome esiste già",
+        "folder_conflicts_with_file": "Un file con questo nome esiste già",
+        "folder_error": "Si è verificato un errore durante la creazione della cartella"
+      },
+      "rename": {
+        "label": "Rinomina",
+        "file": "Rinomina file",
+        "folder": "Rinomina cartella",
+        "new_file": "Nuovo nome con estensione:",
+        "new_folder": "Nuovo nome della cartella:"
+      },
+      "delete": {
+        "label": "Elimina",
+        "file": "Elimina file",
+        "folder": "Elimina cartella",
+        "files": "Elimina {count} file selezionati",
+        "folders": "Elimina {count} cartelle selezionate"
+      },
+      "import": {
+        "import": "Importa",
+        "files": "Importa file",
+        "folder": "Importa cartella",
+        "success": "File importati con successo",
+        "error": "Si sono verificati errori durante l'importazione dei file"
+      },
+      "export": "Esporta file del namespace",
+      "export_single": "Esporta file",
+      "dialog": {
+        "name": {
+          "file": "Nome con estensione:",
+          "folder": "Nome della cartella:"
+        },
+        "parent_folder": "Cartella genitore:",
+        "deletion": {
+          "confirm": "Conferma",
+          "title": "Conferma eliminazione del contenuto",
+          "files": "Sei sicuro di voler eliminare <code>{count}</code> file?",
+          "folders": "Sei sicuro di voler eliminare <code>{count}</code> cartella/e e tutto il suo contenuto?",
+          "mixed": "Sei sicuro di voler eliminare la/le cartella/e <code>{folders}</code> e il/i file <code>{files}</code>?",
+          "file_single": "Sei sicuro di voler eliminare il file <code>{name}</code>?",
+          "folder_single": "Sei sicuro di voler eliminare la cartella <code>{name}</code> e tutti i suoi contenuti?"
+        }
+      },
+      "revisions": {
+        "history": "Cronologia delle revisioni",
+        "restore": {
+          "success": "Revisione del file ripristinata con successo"
+        }
+      },
+      "path": {
+        "copy": "Copia percorso",
+        "success": "Percorso copiato negli appunti",
+        "error": "Si sono verificati errori durante la copia del percorso negli appunti"
+      }
+    },
+    "continue backfill": "Continua il backfill",
+    "delete backfill": "Elimina il backfill",
+    "pause backfill": "Metti in pausa il backfill",
+    "continue backfills": "Continua i backfills",
+    "delete backfills": "Elimina i backfills",
+    "pause backfills": "Metti in pausa i backfills",
+    "backfill executions": "Esecuzioni di backfill",
+    "execute backfill": "Esegui backfill",
+    "backfill paused": "Backfill PAUSED",
+    "backfill running": "Esecuzione del backfill",
+    "relative": "Relativo",
+    "relative start date": "Data di inizio relativa",
+    "relative end date": "Data di fine relativa",
+    "now": "Ora",
+    "absolute": "Assoluto",
+    "backfill": "Backfill",
+    "Set labels tooltip": "Imposta etichette all'esecuzione",
+    "Set labels": "Imposta etichette",
+    "manage labels": "Gestisci etichette",
+    "Set labels to execution": "Aggiungi o aggiorna le etichette dell'esecuzione <code>{id}</code>",
+    "Set labels done": "Etichette dell'esecuzione impostate con successo",
+    "bulk set labels": "Sei sicuro di voler impostare etichette a <code>{executionCount}</code> esecuzione/i?",
+    "dependencies loaded": "Dipendenze caricate",
+    "loaded x dependencies": "{count} dipendenze caricate",
+    "security_advice": {
+      "title": "Proteggi la tua istanza",
+      "content": "Abilita l'autenticazione di base per proteggere la tua istanza.",
+      "switch_text": "Non mostrare più",
+      "enable": "Abilita autenticazione"
+    },
+    "true": "Vero",
+    "false": "Falso",
+    "undefined": "Non definito",
+    "execution-include-non-terminated": "Includere esecuzioni non terminate?",
+    "execution-warn-title": "Avviso Importante!",
+    "execution-warn-deleting-still-running": "Raccomandiamo vivamente di annullare questa azione e terminare eventuali esecuzioni in corso prima. Eliminare esecuzioni non terminate può portare a problemi di concorrenza, incoerenze nella gestione delle dipendenze del flow e processi zombie sulla tua istanza, che possono degradare le prestazioni del sistema. Assicurati di comprendere appieno questi rischi prima di procedere con l'eliminazione.",
+    "originalCreatedDate": "Data di creazione originale",
+    "welcome": {
+      "menu": "Welcome",
+      "tour": {
+        "title": "Fai un tour del prodotto",
+        "text": "Scegli il tuo caso d'uso e segui una guida passo-passo per imparare le funzionalità e le capacità di Kestra. ❤️"
+      },
+      "tutorial": {
+        "title": "Tutorial",
+        "text": "* <a href=\"https://kestra.io/tutorial-videos/all?utm_source=app&utm_medium=referral&utm_campaign=welcome-tutorial\" target=\"_blank\">Video Tutorial</a> \n* <a href=\"https://kestra.io/docs?utm_source=app&utm_medium=referral&utm_campaign=welcome-tutorial\" target=\"_blank\">Documentazione</a> \n* <a href=\"https://kestra.io/blueprints?utm_source=app&utm_medium=referral&utm_campaign=welcome-tutorial\" target=\"_blank\">Blueprint</a>"
+      },
+      "help": {
+        "title": "Hai bisogno di aiuto?",
+        "text": "Fai qualsiasi domanda nella nostra community su Slack. Se sei bloccato, siamo qui per aiutarti. ✋"
+      }
+    },
+    "pluginPage": {
+      "search": "Cerca tra oltre {count} plugin",
+      "searchTasks": "Cerca {count} task",
+      "noResults": "Nessun plugin corrisponde alla tua ricerca.",
+      "loadError": "Impossibile caricare i plugin. Per favore riprova.",
+      "notFound": "Questo plugin non è stato trovato.",
+      "elementType": {
+        "tasks": "Compito",
+        "triggers": "Trigger",
+        "conditions": "Condizione",
+        "taskRunners": "Esecutore di task",
+        "charts": "Grafico",
+        "apps": "App",
+        "logExporters": "Esportatore di log",
+        "secrets": "Segreto"
+      },
+      "sortBy": "Ordina per",
+      "sort": {
+        "nameAsc": "Nome A-Z",
+        "nameDesc": "Nome Z-A",
+        "newest": "Più recente",
+        "mostUsed": "Più usati"
+      },
+      "group": {
+        "plugins": "Plugin ({count})",
+        "tasks": "Attività ({count})",
+        "blueprints": "Blueprint ({count})"
+      },
+      "overview": {
+        "title": "Panoramica",
+        "versions": "Versioni",
+        "latest": "Ultimo",
+        "releaseNotes": "Note di rilascio",
+        "previousVersions": "Versioni precedenti",
+        "createdBy": "Creato da",
+        "managedBy": "Gestito da",
+        "pluginType": "Tipo di plugin",
+        "linksResources": "Link e Risorse",
+        "minKestraVersion": "Min. versione compatibile di Kestra: {version}",
+        "minKestraVersionShort": "Versione minima di Kestra {version}"
+      },
+      "header": {
+        "enterpriseEdition": "Edizione Enterprise",
+        "certified": "Certificato",
+        "back": "Torna ai plugin"
+      }
+    },
+    "no inputs": "Questo flow non ha inputs.",
+    "admin_preferences": "Preferences",
     "settings": {
+      "label": "Impostazioni",
+      "updated": "{name} aggiornato",
       "blocks": {
         "configuration": {
-          "descriptions": {
-            "auto_refresh_interval": "Secondi tra gli aggiornamenti automatici dei dati nelle pagine elenco.",
-            "default_namespace": "Utilizzato quando si creano nuovi flow senza un namespace.",
-            "editor_type": "Editor mostrato quando si apre un flow per la prima volta.",
-            "execute_default_tab": "Scheda selezionata durante la navigazione a un'esecuzione.",
-            "execute_flow": "Dove si aprono i risultati dell'esecuzione dopo l'attivazione di un run.",
-            "flow_default_tab": "Scheda selezionata durante la navigazione a un flow.",
-            "log_display": "Come vengono presentati i log quando si apre un'esecuzione.",
-            "log_level": "Livello minimo di log mostrato nei log di esecuzione.",
-            "playground": "Esegui i task singolarmente nel playground dell'editor.",
-            "triggers_default_tab": "Scheda selezionata quando si naviga alla pagina dei trigger."
-          },
+          "label": "Configurazione principale",
           "fields": {
-            "auto_refresh_interval": "Intervallo di Aggiornamento Automatico",
-            "default_namespace": "Namespace predefinito",
-            "editor_type": "Tipo Editor Predefinito",
-            "execute_default_tab": "Scheda di Esecuzione Predefinita",
-            "execute_flow": "Esegui il Flow",
-            "flow_default_tab": "Scheda Flow Predefinita",
             "language": "Lingua",
-            "log_display": "Visualizzazione Log predefinita",
+            "default_namespace": "Namespace predefinito",
             "log_level": "Livello di Log predefinito",
+            "log_display": "Visualizzazione Log predefinita",
+            "editor_type": "Tipo Editor Predefinito",
+            "execute_flow": "Esegui il Flow",
+            "execute_default_tab": "Scheda di Esecuzione Predefinita",
             "multi_panel_editor": "Editor Multi Pannello",
+            "flow_default_tab": "Scheda Flow Predefinita",
+            "triggers_default_tab": "Scheda Trigger Predefiniti",
             "playground": "Playground",
-            "triggers_default_tab": "Scheda Trigger Predefiniti"
+            "auto_refresh_interval": "Intervallo di Aggiornamento Automatico"
           },
-          "label": "Configurazione principale"
-        },
-        "export": {
-          "fields": {
-            "flows": "Esporta tutti i Flows",
-            "templates": "Esporta tutti i Template"
-          },
-          "label": "Esporta"
-        },
-        "localization": {
           "descriptions": {
-            "date_format": "Formato utilizzato per visualizzare le date in tutto il dashboard.",
-            "language": "Lingua dell'interfaccia per menu ed etichette.",
-            "time_zone": "Utilizzato per visualizzare le date di esecuzione e i trigger programmati."
-          },
-          "fields": {
-            "date_format": "Formato Data",
-            "time_zone": "Fuso Orario"
-          },
-          "label": "Lingua e Regione",
-          "note": "Nota che questa impostazione viene utilizzata per visualizzare le proprietà di data e ora nell'interfaccia utente. Per pianificare i tuoi flows in un fuso orario diverso da UTC, assicurati di impostare la proprietà del fuso orario nel trigger Schedule nel codice del tuo flow o nei tuoi plugin defaults."
-        },
-        "reset_section_to_defaults": "Ripristina i valori predefiniti di questa sezione",
-        "save": {
-          "discard": "Scarta",
-          "label": "Salva Preferenze",
-          "unsaved_title": "Modifiche non salvate",
-          "unsaved_warning": "Hai modifiche non salvate. Vuoi salvarle prima di uscire?"
-        },
-        "sidebar": {
-          "descriptions": {
-            "items": "Mostra, nascondi e riordina gli elementi nella barra laterale."
-          },
-          "fields": {
-            "items": "Elementi di Navigazione"
-          },
-          "label": "Barra laterale"
+            "default_namespace": "Utilizzato quando si creano nuovi flow senza un namespace.",
+            "log_level": "Livello minimo di log mostrato nei log di esecuzione.",
+            "log_display": "Come vengono presentati i log quando si apre un'esecuzione.",
+            "editor_type": "Editor mostrato quando si apre un flow per la prima volta.",
+            "execute_flow": "Dove si aprono i risultati dell'esecuzione dopo l'attivazione di un run.",
+            "execute_default_tab": "Scheda selezionata durante la navigazione a un'esecuzione.",
+            "flow_default_tab": "Scheda selezionata durante la navigazione a un flow.",
+            "triggers_default_tab": "Scheda selezionata quando si naviga alla pagina dei trigger.",
+            "auto_refresh_interval": "Secondi tra gli aggiornamenti automatici dei dati nelle pagine elenco.",
+            "playground": "Esegui i task singolarmente nel playground dell'editor."
+          }
         },
         "theme": {
-          "app_font_size_options": {
-            "large": "Grande",
-            "medium": "Medio",
-            "small": "Piccolo"
-          },
-          "color_modes": {
-            "dark_1": "Dark 1.0",
-            "dark_2": "Dark 2.0",
-            "light": "Chiaro",
-            "sync": "Sincronizza con il sistema"
-          },
-          "confirmations": {
-            "color_mode": "La tua interfaccia ora usa il tema `{mode}`."
-          },
-          "descriptions": {
-            "app_font_size": "Fattore di scala applicato a tutte le dimensioni dei caratteri dell'interfaccia.",
-            "color_mode": "Scegli il tema dell'interfaccia preferito.",
-            "color_mode_shortcut": "Suggerimento: premi <kbd>Ctrl</kbd>+<kbd>Maiusc</kbd>+<kbd>L</kbd> per cambiare tema da qualsiasi punto.",
-            "editor_folding_stratgy": "Comprimi i blocchi YAML lunghi per impostazione predefinita quando si apre un flow.",
-            "editor_font_family": "Carattere monospazio utilizzato nell'editor YAML.",
-            "editor_font_size": "Dimensione del carattere utilizzata negli editor YAML e no-code.",
-            "editor_hover_description": "Mostra le descrizioni delle proprietà al passaggio del mouse nell'editor.",
-            "environment_color": "Colore di accento utilizzato per l'ambiente corrente nella navigazione.",
-            "environment_name": "Nome visualizzato per l'ambiente corrente, mostrato nella navigazione.",
-            "logs_font_size": "Dimensione del carattere utilizzata nei visualizzatori di log e nei terminali."
-          },
+          "label": "Preferenze del Tema",
           "fields": {
             "app_font_size": "Dimensione carattere applicazione",
             "chart_color_scheme": {
+              "label": "Schema Colori Grafico",
               "classic": "Classico",
-              "kestra": "Kestra",
-              "label": "Schema Colori Grafico"
+              "kestra": "Kestra"
             },
             "color_mode": "Modalità colore",
             "editor_folding_stratgy": "Piegatura automatica del codice nell'Editor",
@@ -1850,24 +1066,867 @@
             "logs_font_size": "Dimensione Font dei Log",
             "theme": "Modello"
           },
-          "label": "Preferenze del Tema"
+          "color_modes": {
+            "dark_2": "Dark 2.0",
+            "dark_1": "Dark 1.0",
+            "light": "Chiaro",
+            "sync": "Sincronizza con il sistema"
+          },
+          "confirmations": {
+            "color_mode": "La tua interfaccia ora usa il tema `{mode}`."
+          },
+          "descriptions": {
+            "color_mode": "Scegli il tema dell'interfaccia preferito.",
+            "color_mode_shortcut": "Suggerimento: premi <kbd>Ctrl</kbd>+<kbd>Maiusc</kbd>+<kbd>L</kbd> per cambiare tema da qualsiasi punto.",
+            "logs_font_size": "Dimensione del carattere utilizzata nei visualizzatori di log e nei terminali.",
+            "editor_font_family": "Carattere monospazio utilizzato nell'editor YAML.",
+            "editor_font_size": "Dimensione del carattere utilizzata negli editor YAML e no-code.",
+            "editor_folding_stratgy": "Comprimi i blocchi YAML lunghi per impostazione predefinita quando si apre un flow.",
+            "editor_hover_description": "Mostra le descrizioni delle proprietà al passaggio del mouse nell'editor.",
+            "environment_name": "Nome visualizzato per l'ambiente corrente, mostrato nella navigazione.",
+            "environment_color": "Colore di accento utilizzato per l'ambiente corrente nella navigazione.",
+            "app_font_size": "Fattore di scala applicato a tutte le dimensioni dei caratteri dell'interfaccia."
+          },
+          "app_font_size_options": {
+            "small": "Piccolo",
+            "medium": "Medio",
+            "large": "Grande"
+          }
+        },
+        "localization": {
+          "label": "Lingua e Regione",
+          "note": "Nota che questa impostazione viene utilizzata per visualizzare le proprietà di data e ora nell'interfaccia utente. Per pianificare i tuoi flows in un fuso orario diverso da UTC, assicurati di impostare la proprietà del fuso orario nel trigger Schedule nel codice del tuo flow o nei tuoi plugin defaults.",
+          "fields": {
+            "time_zone": "Fuso Orario",
+            "date_format": "Formato Data"
+          },
+          "descriptions": {
+            "language": "Lingua dell'interfaccia per menu ed etichette.",
+            "time_zone": "Utilizzato per visualizzare le date di esecuzione e i trigger programmati.",
+            "date_format": "Formato utilizzato per visualizzare le date in tutto il dashboard."
+          }
+        },
+        "export": {
+          "label": "Esporta",
+          "fields": {
+            "flows": "Esporta tutti i Flows",
+            "templates": "Esporta tutti i Template"
+          }
+        },
+        "save": {
+          "label": "Salva Preferenze",
+          "discard": "Scarta",
+          "unsaved_title": "Modifiche non salvate",
+          "unsaved_warning": "Hai modifiche non salvate. Vuoi salvarle prima di uscire?"
+        },
+        "reset_section_to_defaults": "Ripristina i valori predefiniti di questa sezione",
+        "sidebar": {
+          "label": "Barra laterale",
+          "fields": {
+            "items": "Elementi di Navigazione"
+          },
+          "descriptions": {
+            "items": "Mostra, nascondi e riordina gli elementi nella barra laterale."
+          }
+        }
+      }
+    },
+    "apps": "Applicazioni",
+    "demos": {
+      "enterprise_edition": "Edizione Enterprise",
+      "get_a_demo_button": "Ottieni una Demo",
+      "contact_sales": "Contatta il reparto vendite",
+      "watch_the_video": "Guarda il video",
+      "secrets": {
+        "title": "Aggiorna il tuo Secrets Management",
+        "message": "L'Enterprise Edition (EE) ti consente di aggiungere, modificare o eliminare segreti direttamente nell'interfaccia utente, senza bisogno di riavviare l'istanza. Organizza i segreti per namespace con permessi RBAC granulari e ereditali dai namespace genitori a quelli figli. EE si integra con gestori di segreti come HashiCorp Vault, AWS Secrets Manager, Azure Key Vault, Google Secret Manager ed Elasticsearch. Configura backend dedicati per namespace, tenant o istanza per isolare i segreti tra i team, oppure abilita segreti di sola lettura memorizzati in vault esterni. I segreti rimangono crittografati a riposo e in transito. La cache opzionale riduce le chiamate API e le tracce di audit registrano tutti gli accessi.",
+        "detected_env": "Ecco le variabili d'ambiente di tipo secret identificate al momento dell'avvio dell'istanza:",
+        "empty_env": "Non hai ancora alcun Secret nel tuo ambiente.",
+        "add_env": {
+          "intro": "Per creare un nuovo Secret:",
+          "first": "Codifica il <a href=\"https://kestra.io/docs/how-to-guides/secrets?utm_source=app&utm_medium=referral&utm_campaign=secrets-inlinedoc#using-secrets-in-kestra\" target=\"_blank\">valore segreto in Base64</a>",
+          "second": "Aggiungi una variabile di ambiente chiamata '<strong>SECRET_{'{MY_SECRET_KEY}'}</strong>' con il valore sopra indicato",
+          "third": "Riavvia la tua istanza di Kestra"
         }
       },
-      "label": "Impostazioni",
-      "updated": "{name} aggiornato"
+      "apps": {
+        "title": "Crea App personalizzate con Kestra",
+        "message": "Le app nella Kestra Enterprise Edition ti consentono di creare interfacce utente personalizzate che interagiscono con i workflow di Kestra al di fuori della piattaforma. Questa funzionalità ti permette di utilizzare i tuoi workflow come backend per applicazioni personalizzate, consentendo agli utenti non tecnici di inviare dati tramite moduli o riprendere workflow PAUSED in attesa di approvazione."
+      },
+      "tests": {
+        "label": "Test",
+        "header": "Test unitari per i flow",
+        "title": "Garantisci l'affidabilità con ogni modifica",
+        "message": "Verifica la logica dei tuoi flow in isolamento, rileva le regressioni in anticipo e mantieni la fiducia nelle tue automazioni mentre cambiano e crescono."
+      },
+      "assets": {
+        "label": "Risorse",
+        "header": "Metadati e Osservabilità degli Asset",
+        "title": "Porta ogni dataset, servizio e dipendenza in vista.",
+        "message": "Le risorse collegano la osservabilità, la lineage e i metadati di proprietà in modo che i team della piattaforma possano risolvere i problemi più rapidamente e distribuire con fiducia."
+      },
+      "IAM": {
+        "title": "Gestisci gli utenti tramite IAM con SSO, SCIM e RBAC",
+        "message": "Kestra Enterprise Edition ha funzionalità IAM integrate con single sign-on (SSO), sincronizzazione della directory SCIM e controllo degli accessi basato sui ruoli (RBAC), integrandosi con diversi provider di identità e permettendo di assegnare permessi dettagliati per utenti e account di servizio."
+      },
+      "tenants": {
+        "title": "Gestisci i flussi di lavoro in tenant isolati",
+        "message": "L'edizione Enterprise di Kestra supporta il multi-tenancy, offrendo ambienti completamente isolati per diversi team o progetti, ciascuno con le proprie risorse come gruppi di worker dedicati o segreti e backend di archiviazione interna."
+      },
+      "audit-logs": {
+        "title": "Traccia le modifiche con i Log di Audit",
+        "message": "Kestra Enterprise Edition registra ogni attività con record robusti e immutabili, rendendo facile tracciare le modifiche, mantenere la conformità e risolvere i problemi."
+      },
+      "quotas": {
+        "title": "Applicare quote di esecuzione ai flow",
+        "message": "Kestra Enterprise Edition consente di definire quote sui flow per limitare il numero di esecuzioni simultanee o totali in una finestra temporale. Le quote aiutano a proteggere l'infrastruttura condivisa, applicare gli SLA e impedire che i workflow incontrollati consumino risorse eccessive."
+      },
+      "instance": {
+        "title": "Gestisci l'Infrastruttura nella Tua Istanza",
+        "message": "Kestra Enterprise Edition fornisce un dashboard operativo per aiutarti a osservare la salute della tua piattaforma e monitorare le metriche di uptime di tutti i servizi come, ad esempio, Workers, Schedulers e Executors. Dalla stessa pagina, puoi anche creare Annunci per notificare ai tuoi utenti il downtime pianificato e puoi entrare in una modalità di manutenzione che mette temporaneamente tutti i servizi e le esecuzioni dei workflow in uno stato di PAUSED per eseguire un aggiornamento."
+      },
+      "blueprints": {
+        "title": "Aggiungi Blueprint Personalizzati",
+        "message": "Nella Kestra Enterprise Edition, puoi creare blueprint personalizzati disponibili solo per la tua organizzazione. Puoi usarli come modelli di best-practice per condividere, centralizzare e documentare i flussi di lavoro comunemente utilizzati nel tuo team."
+      },
+      "namespace": {
+        "edit": {
+          "title": "Aggiorna la Gestione del tuo Namespace",
+          "message": "Nella Kestra Enterprise Edition, i namespace forniscono un'isolamento avanzato e una governance dei segreti, delle variabili e dei plugin defaults su larga scala. Gli amministratori possono configurare gestori di segreti personalizzati, backend di storage isolati, gruppi di worker dedicati e permessi dettagliati su base per-namespace. Questo assicura che i segreti, le variabili e le configurazioni dei plugin rimangano sicuri e facili da gestire tra diversi team e progetti."
+        },
+        "secrets": {
+          "title": "Gestisci i Segreti in Modo Sicuro",
+          "message": "Nella Kestra Enterprise Edition, puoi memorizzare e controllare i segreti a livello di namespace, riducendo al minimo il rischio e garantendo che le credenziali di ciascun team rimangano isolate. Grazie alla gerarchia nidificata, puoi anche configurare le credenziali in un namespace genitore e queste verranno ereditate da tutti i namespace figli. Il supporto per gestori di segreti dedicati e impostazioni di autorizzazione a livello di namespace dettagliate rafforza ulteriormente la sicurezza e la conformità."
+        },
+        "assets": {
+          "title": "Centralizza la gestione delle risorse",
+          "message": "Nella Kestra Enterprise Edition, Assets mantiene un inventario aggiornato delle risorse con cui i tuoi workflow interagiscono. Queste risorse possono essere tabelle di database, macchine virtuali, file o qualsiasi sistema esterno con cui lavori."
+        },
+        "variables": {
+          "title": "Governa Centralmente le Tue Variabili",
+          "message": "Nella Kestra Enterprise Edition, puoi definire e gestire variabili a livello di namespace per eliminare configurazioni ripetitive tra i flow. Queste variabili assicurano coerenza, semplificano gli aggiornamenti di configurazione e possono essere facilmente riferite da qualsiasi task o trigger per flussi di lavoro più puliti e manutenibili."
+        },
+        "plugin-defaults": {
+          "title": "Standardizza la Configurazione con i Valori Predefiniti del Plugin",
+          "message": "Nella Kestra Enterprise Edition, puoi impostare i plugin predefiniti specifici per namespace, riducendo la necessità di configurazioni duplicate in ogni flow. Questa governance centrale dei plugin impone configurazioni coerenti, consente il riferimento sicuro a segreti o variabili e semplifica la manutenzione dei tuoi workflow."
+        },
+        "history": {
+          "title": "Gestisci la Cronologia delle Revisioni in un Unico Luogo",
+          "message": "Nella Kestra Enterprise Edition, puoi gestire la cronologia delle revisioni dei tuoi namespace"
+        },
+        "audit-logs": {
+          "title": "Tieni traccia di tutte le modifiche in un unico posto",
+          "message": "Nella Kestra Enterprise Edition, puoi visualizzare i log di audit a livello di namespace con differenze dettagliate, offrendoti una chiara cronologia di chi ha modificato cosa e quando su tutte le risorse."
+        }
+      }
+    },
+    "assets": {
+      "title": "Risorse"
+    },
+    "onboarding": {
+      "welcome": {
+        "headline": "Crea ed esegui il tuo primo workflow in pochi minuti",
+        "guided_title": "Crea il tuo primo flow",
+        "badge": "Tutorial",
+        "guided_description": "Scopri come creare ed eseguire il tuo primo flow con passaggi guidati.",
+        "guided_duration": "Consigliato per la maggior parte degli utenti",
+        "self_serve_title": "Crea un flow da zero",
+        "self_serve_description": "Vai direttamente all’editor e crea il tuo flow.",
+        "self_serve_note": "Per utenti esperti",
+        "additional_help": "Aiuto aggiuntivo",
+        "docs": "Documentazione",
+        "tutorial": "Tutorial",
+        "blueprints": "Blueprint",
+        "slack": "Community Slack"
+      },
+      "steps": {
+        "flow_basics": {
+          "title": "Nozioni di base sui flow",
+          "description": "In Kestra, un <code>flow</code> è l’unità centrale di orchestrazione. Viene definito in YAML con metadati e task ordinati.<br><br>Esamina la struttura di esempio qui sotto, quindi continua a costruirla passo dopo passo."
+        },
+        "add_id": {
+          "title": "Aggiungi l’ID del flow",
+          "description": "L’ID è il nome univoco del tuo flow, così puoi trovarlo, eseguirlo e farvi riferimento in modo coerente.<br><br>Ora aggiungi <code>id</code> al livello root."
+        },
+        "add_namespace": {
+          "title": "Aggiungi il namespace",
+          "description": "Il Namespace è un raggruppamento simile a una cartella che organizza i flow per team, progetto o ambiente.<br><br>Ora aggiungi <code>namespace</code> al livello root."
+        },
+        "add_input": {
+          "title": "Aggiungi un input",
+          "description": "Gli input sono parametri a livello di flow che possono essere referenziati all’interno dei task per controllare dinamicamente il comportamento in fase di esecuzione.<br><br>Ora aggiungi un input chiamato <code>name</code> con tipo <code>STRING</code>."
+        },
+        "add_log_task": {
+          "title": "Aggiungi il primo task",
+          "description": "I task sono le unità di lavoro eseguite dal tuo flow, definiti come un elenco ordinato di passaggi. Ogni task necessita di un <code>id</code> univoco e di un <code>type</code>. Kestra fornisce molti plugin di task per sistemi esterni; qui utilizziamo un task Python Script.<br><br>La sintassi <code>&#123;&#123; ... &#125;&#125;</code> è un’espressione Pebble, utilizzata per referenziare variabili dinamicamente in fase di esecuzione, come <code>&#123;&#123; inputs.name &#125;&#125;</code> dagli input del flow.<br><br>Ora aggiungi il primo task sotto <code>tasks</code> con <code>id</code>, <code>type</code> e uno <code>script</code> che stampi un messaggio di saluto."
+        },
+        "save_flow": {
+          "title": "Salva il flow",
+          "description": "Il salvataggio memorizza la definizione del tuo flow affinché possa essere eseguita."
+        },
+        "execute_flow": {
+          "title": "Esegui il flow",
+          "description": "L’esecuzione avvia un run del tuo flow con valori di input forniti in fase di esecuzione."
+        },
+        "view_logs_status": {
+          "title": "Verifica l’esecuzione",
+          "description": "I dettagli di esecuzione mostrano lo stato del run, i tempi e i log di output a livello di task.<br><br>Ora apri i dettagli di esecuzione e fai clic su <code>greet</code> nel diagramma di Gantt per vedere i log."
+        },
+        "edit_flow_from_execution": {
+          "title": "Torna all’Editor del flow",
+          "description": "Puoi passare direttamente da un’esecuzione alla definizione del flow per iterare rapidamente."
+        },
+        "add_cron_trigger": {
+          "title": "Aggiungi un trigger cron",
+          "description": "I trigger possono avviare run in base a pianificazioni o eventi esterni (ad esempio webhook o messaggi MQTT).<br><br>Ora aggiungi un trigger di pianificazione cron affinché questo flow venga eseguito ogni 5 minuti."
+        },
+        "add_input_default": {
+          "title": "Imposta un valore predefinito per l’input",
+          "description": "Quando un flow viene attivato automaticamente, gli input necessitano comunque di valori in fase di esecuzione.<br><br>L’input <code>name</code> è già stato creato nel passaggio precedente, quindi non è necessario aggiungerlo di nuovo. Imposta semplicemente un valore predefinito per l’input esistente <code>name</code>."
+        },
+        "save_flow_again": {
+          "title": "Salva il flow",
+          "description": "Il tuo flow ora ha una pianificazione e un valore di input predefinito per le esecuzioni automatiche."
+        },
+        "background_runs_info": {
+          "title": "Esecuzioni pianificate",
+          "description": "Questo flow verrà ora eseguito in background ogni 5 minuti.<br><br>Puoi navigare alla panoramica delle Esecuzioni dal menu a sinistra per monitorare le esecuzioni pianificate."
+        },
+        "finish": {
+          "title": "Hai completato il tutorial Primo Flow",
+          "description": "Ottimo inizio. Hai creato, eseguito, parametrizzato e pianificato un flow.<br><br>Scegli cosa fare dopo ..."
+        }
+      },
+      "actions": {
+        "next": "Avanti",
+        "complete": "Completa",
+        "save_to_continue": "Premi Salva nella barra in alto (a destra).",
+        "execute_to_continue": "1. Premi Esegui nella barra in alto (a destra).\n2. Fornisci un valore per <strong>name</strong>.\n3. Premi di nuovo Esegui nella finestra modale.",
+        "edit_flow_to_continue": "Premi Modifica flow nella barra in alto (a destra).",
+        "cancel_tutorial": "Annulla tutorial",
+        "finish_tutorial": "Termina tutorial"
+      },
+      "finish_actions": {
+        "explore_blueprints": "Esplora i Blueprint",
+        "create_flow": "Crea flow"
+      },
+      "editor_hints": {
+        "build_intro": "Crea il tuo primo flow passo dopo passo.",
+        "step_1": "# 1) Aggiungi id",
+        "step_2": "# 2) Aggiungi namespace",
+        "step_3": "# 3) Aggiungi un input",
+        "step_4": "# 4) Aggiungi i task e il tuo primo task Python",
+        "step_5": "# 5) Aggiungi un trigger cron"
+      },
+      "cancel_modal": {
+        "title": "Annulla il tutorial Primo Flow",
+        "description": "Vuoi annullare il tutorial Primo Flow?",
+        "confirm": "Annulla tutorial",
+        "keep": "Continua tutorial"
+      },
+      "validation": {
+        "complete_step": "Ci sei quasi. Completa questo passaggio per continuare.",
+        "fix_yaml": "C’è un piccolo problema di formattazione YAML. Correggilo e poi continua.",
+        "add_id": "Aggiungi un ID del flow in alto. Esempio: `id: hello_flow`.",
+        "add_namespace": "Aggiungi un namespace in alto. Esempio: `namespace: company.team`.",
+        "add_input_section": "Crea una sezione `inputs` con un input.",
+        "add_input_id": "All’interno di `inputs`, aggiungi `id: name`.",
+        "add_input_type": "Imposta il tipo di input su `STRING`.",
+        "add_log_task_section": "Crea una sezione `tasks` e aggiungi il tuo primo task.",
+        "add_log_task_id": "Assegna un ID al task, ad esempio: `id: greet`.",
+        "add_log_task_type": "Imposta il tipo di task su `io.kestra.plugin.scripts.python.Script`.",
+        "add_log_task_message": "Aggiungi un campo `script` al task.",
+        "add_log_task_pebble": "Usa un’espressione Pebble nello script affinché utilizzi il valore del tuo input (ad esempio: `inputs.name`).",
+        "save_flow": "Fai clic su Salva per continuare.",
+        "execute_flow": "Esegui il flow una volta per continuare.",
+        "view_logs_status": "Apri i dettagli di esecuzione e controlla i log di `greet`.",
+        "edit_flow_from_execution": "Fai clic su `Modifica flow` nella barra in alto per continuare.",
+        "add_cron_trigger_section": "Crea una sezione `triggers` con un trigger di pianificazione.",
+        "add_cron_trigger_type": "Imposta il tipo di trigger su `io.kestra.plugin.core.trigger.Schedule`.",
+        "add_cron_trigger_cron": "Aggiungi un’espressione cron, ad esempio: `\"*/5 * * * *\"`.",
+        "add_input_default_section": "Torna a `inputs` e mantieni un input esistente chiamato `name` (non aggiungere un secondo input).",
+        "add_input_default_id": "Mantieni l’ID dell’input esistente come `name`.",
+        "add_input_default_defaults": "Aggiungi un valore predefinito per `name`, ad esempio: `defaults: \"Kestra\"`.",
+        "save_flow_again": "Fai clic di nuovo su Salva per continuare."
+      }
+    },
+    "enable concurrency": "Abilita la concurrency",
+    "auditlogs": "Audit Logs",
+    "quotas": "Quote",
+    "iam": "IAM",
+    "tenant": {
+      "name": "Mandante",
+      "names": "Mandanti"
+    },
+    "ee-tooltip": {
+      "features-blocked": "Questa funzione richiede l'Enterprise Edition.",
+      "button": "Parlaci"
+    },
+    "flow_only": "Disponibile solo nella scheda Flow.",
+    "bulk action async warning": "Questo potrebbe richiedere alcuni istanti.",
+    "bulk unpause backfills": "Riavvia {count} backfill",
+    "bulk pause backfills": "Metti in pausa {count} backfill",
+    "bulk delete backfills": "Elimina {count} backfill",
+    "bulk unlock": "Sblocca {count} triggers",
+    "bulk disabled status": {
+      "true": "Disabilita {count} triggers",
+      "false": "Abilita {count} triggers"
+    },
+    "unlock": "Sblocca",
+    "bulk success unpause backfills": "{count} backfills riavviati",
+    "bulk success pause backfills": "{count} backfills messi in pausa",
+    "bulk success delete backfills": "{count} backfills eliminati",
+    "bulk success unlock": "{count} triggers sbloccati",
+    "bulk success disabled status": {
+      "true": "{count} trigger(s) disabilitati",
+      "false": "{count} trigger(s) abilitati"
+    },
+    "no_namespaces": "Nessun namespace corrisponde ai criteri di ricerca.",
+    "system_namespace": "Mantieni la tua piattaforma sotto controllo con i system flows.",
+    "system_namespace_description": "Automatizza le attività di manutenzione, dagli avvisi di errore alle pulizie automatiche.",
+    "pluginDefaults": {
+      "title": "Predefiniti del Plugin",
+      "add": "Aggiungi Plugin Predefinito",
+      "edit": "Modifica Plugin Predefinito",
+      "add_subtitle": "Configura un nuovo plugin predefinito con le sue proprietà",
+      "edit_subtitle": "Modifica la configurazione predefinita del plugin esistente",
+      "predefined": "Plugin Predefinito",
+      "custom": "Plugin Personalizzato",
+      "form": "Modulo",
+      "yaml": "YAML",
+      "select_predefined": "Seleziona Plugin Predefinito",
+      "cancel": "Annulla",
+      "update": "Aggiorna Plugin Default",
+      "custom_type": "Tipo di plugin personalizzato",
+      "custom_placeholder": "Inserisci il tipo di plugin",
+      "use_custom": "Usa Personalizzato",
+      "custom_configure": "Tipo di plugin personalizzato - configurare utilizzando YAML",
+      "yaml_configuration": "Configurazione YAML",
+      "show_yaml": "Mostra YAML"
+    },
+    "secret": {
+      "add": "Crea",
+      "update": "Aggiorna secret '{name}'",
+      "isReadOnly": "Il segreto è in sola lettura",
+      "names": "Secrets",
+      "inherited": "Secrets ereditati"
+    },
+    "workerId": "Worker Id",
+    "kv": {
+      "name": "KV Store",
+      "type": "Tipo",
+      "add": "Crea",
+      "update": "Aggiorna il value per il key '{key}'",
+      "duplicate": "Questo key esiste già",
+      "delete multiple": {
+        "confirm": "Sei sicuro di voler eliminare: <code>{name}</code> KV?",
+        "warning": "Non hai i permessi per quei namespace, quindi verranno omessi: <code>{namespaces}</code>"
+      },
+      "inherited": "Coppie KV ereditate"
+    },
+    "expiration": "Scadenza",
+    "failed to render pdf": "Impossibile visualizzare l'anteprima PDF",
+    "page": {
+      "previous": "Pagina precedente",
+      "next": "Pagina successiva"
+    },
+    "namespace_editor": {
+      "empty": {
+        "title": "Nessuna scheda attualmente aperta",
+        "create_message": "Puoi creare o importare file namespace.",
+        "video_message": "Puoi guardare il Video di Introduzione per il nostro Editor."
+      },
+      "close": {
+        "tab": "Chiudi scheda",
+        "all": "Chiudi tutte le schede",
+        "other": "Chiudi le altre schede",
+        "right": "Chiudi a destra"
+      }
+    },
+    "curl": {
+      "command": "Comando cURL",
+      "note": "Nota che per il tipo di input SECRET e FILE, il comando deve essere adattato per corrispondere ai valori reali."
+    },
+    "webhook": {
+      "curl_command": "Comando cURL Webhook",
+      "payload": "Payload Webhook (JSON)",
+      "curl_note": "Usa questo comando cURL per trigger il flow tramite webhook con payload JSON personalizzato",
+      "no_triggers": "Questo flow non ha webhook trigger abilitati",
+      "copy_url": "Copia URL del webhook"
+    },
+    "logs_view": {
+      "raw": "Vista temporale",
+      "raw_details": "Mostra i task logs e i flow logs completi in un formato grezzo ordinato per timestamp",
+      "compact": "Vista predefinita",
+      "compact_details": "Mostra i task logs in una vista compatta raggruppata per ogni task"
+    },
+    "execution_deletion": {
+      "logs": "Elimina logs",
+      "metrics": "Elimina metriche",
+      "storage": "Elimina file di storage interni"
+    },
+    "scope_filter": {
+      "all": "Tutte le {label}",
+      "user": "Utente {label}",
+      "system": "Sistema {label}",
+      "user_description": "Utente regolare ha avviato {label}",
+      "system_description": "Manutenzione del sistema {label}"
+    },
+    "data": "Dati",
+    "webhook link copied": "Link del Webhook copiato.",
+    "copy url": "Copia URL",
+    "scheduleDate": "Data di pianificazione",
+    "warning": "Avviso",
+    "trigger_check_warning": "Utilizzare le variabili trigger non funzionerà con l'esecuzione manuale del flow. Aggiungi l'operatore di coalescenza `??` per risolvere il problema. Ad esempio, invece di `trigger.date`, usa `trigger.date ?? execution.startDate`.",
+    "docs": "Documenti",
+    "active-slots": "Slot attivi",
+    "behavior": "Comportamento",
+    "concurrency": "Concurrency",
+    "no-executions-view": {
+      "title": "Inizia ad automatizzare con",
+      "sub_title": "Fai clic sul pulsante Esegui per avviare l'esecuzione del tuo primo workflow.",
+      "namespace_sub_title": "Esegui uno o più flow da questo namespace per popolare questa dashboard.",
+      "guidance_desc": "Hai bisogno di assistenza per eseguire il tuo flow?",
+      "namespace_guidance_desc": "Hai bisogno di assistenza per gestire il tuo Namespace?",
+      "guidance_sub_desc": "Segui la documentazione per tutte le informazioni di cui hai bisogno."
+    },
+    "execution_guide": {
+      "get_started": {
+        "title": "Inizia ⚡",
+        "text": "Segui la Guida rapida per installare Kestra e iniziare a creare i tuoi primi workflow."
+      },
+      "namespaces": {
+        "title": "Informazioni sui Namespace",
+        "text": "I namespace sono raggruppamenti logici di flow e dei loro componenti."
+      },
+      "workflow_components": {
+        "title": "Componenti del Workflow",
+        "text": "Conosci i principali componenti di orchestrazione di un workflow Kestra."
+      },
+      "videos_tutorials": {
+        "title": "Tutorial Video",
+        "text": "Inizia con i nostri video tutorial."
+      }
+    },
+    "open sidebar": "apri barra laterale",
+    "close sidebar": "chiudi barra laterale",
+    "customize sidebar": "Personalizza barra laterale",
+    "reset to defaults": "Reimposta ai valori predefiniti",
+    "drop items here": "Trascina gli elementi qui",
+    "files": "File",
+    "optional": "Opzionale",
+    "no_data": "Sembra che non ci sia ancora nulla qui… per ora!<br/>Modifica i tuoi filtri o riprova!",
+    "bookmark": "Segnalibri",
+    "remove_bookmark": "Sei sicuro di voler rimuovere questo segnalibro?",
+    "showLess": "Mostra meno",
+    "showMore": "Mostra di più",
+    "documentationMenu": "Menu documentazione",
+    "item": "elemento",
+    "items": "elementi",
+    "cron": "Cron",
+    "execution_started": "L'esecuzione è iniziata!",
+    "execution_failed": "Esecuzione fallita!",
+    "last error was": "L'ultimo errore è stato",
+    "execution restarted": "Questa esecuzione è stata riavviata {nbRestart} volta(e).",
+    "execution replay": "Questa esecuzione è una ripetizione di",
+    "execution replayed": "Questa esecuzione è stata ripetuta.",
+    "task run id": "ID di TaskRun",
+    "active": "Attivo",
+    "flows imported": "Flussi importati",
+    "flow not imported": "Alcuni flow non possono essere importati",
+    "plugin defaults exported": "Predefiniti del plugin esportati",
+    "failed to export plugin defaults": "Impossibile esportare i valori predefiniti del plugin",
+    "plugin defaults imported": "Predefiniti del plugin importati",
+    "plugin defaults not imported": "Alcuni valori predefiniti del plugin non possono essere importati",
+    "failed to import plugin defaults": "Impossibile importare i default del plugin",
+    "filters": {
+      "label": "Scegli filtri",
+      "empty": "Nessun dato.",
+      "format": "Digita il parametro come 'key:value'",
+      "text_search": "Cerca questo testo",
+      "options": {
+        "namespace": "Namespace",
+        "flow": "Flusso",
+        "state": "Stato",
+        "scope": "Ambito",
+        "child": "Bambino",
+        "level": "Livello di Log",
+        "task": "Compito",
+        "metric": "Metrica",
+        "user": "Utente",
+        "type": "Tipo",
+        "service_type": "Tipo",
+        "permission": "Permesso",
+        "action": "Azione",
+        "status": "Stato",
+        "details": "Dettagli",
+        "aggregation": "Aggregazione",
+        "relative_date": "Data relativa",
+        "absolute_date": "Data assoluta",
+        "labels": "Etichette",
+        "text": "I'm sorry, but it seems like the text you want me to translate is missing. Could you please provide the text you would like translated?",
+        "startDate": "Data di inizio",
+        "endDate": "Data di fine"
+      },
+      "comparators": {
+        "is": "è",
+        "is_one_of": "è uno di",
+        "is_not": "non è",
+        "not_in": "non in",
+        "contains": "contiene",
+        "not_contains": "non contiene",
+        "in": "nel",
+        "between": "tra",
+        "starts_with": "inizia con",
+        "greater_than": "maggiore di",
+        "greater_than_or_equal_to": "maggiore o uguale a",
+        "less_than": "minore di",
+        "less_than_or_equal_to": "minore o uguale a",
+        "ends_with": "termina con"
+      },
+      "save": {
+        "label": "Ricerche salvate",
+        "remove": "Rimuovi",
+        "empty": "Non hai ancora salvato alcuna ricerca.",
+        "tooltip": "Non puoi salvare criteri di ricerca vuoti.",
+        "name_already_used": "Etichetta di ricerca già utilizzata.",
+        "dialog": {
+          "heading": "Salva la ricerca corrente",
+          "placeholder": "Etichetta",
+          "hint": "Come vuoi etichettare questo criterio di ricerca?",
+          "confirmation": "Criteri di ricerca <code>{name}</code>"
+        }
+      },
+      "settings": {
+        "label": "Impostazioni pagina",
+        "show_chart": "Mostra il grafico principale"
+      }
+    },
+    "custom value": "Valore personalizzato",
+    "chart": "Grafico",
+    "chart preview": "Anteprima grafico",
+    "no_code": {
+      "toggle_pebble": "Attiva/disattiva editor Pebble",
+      "version_oss_placeholder": "Sblocca il Versioning dei Plugin con l'Enterprise Edition",
+      "unnamed": "Nessun Nome",
+      "adding": "+ Aggiungi un {what}",
+      "adding_default": "+ Aggiungi un nuovo value",
+      "add_field": "Aggiungi {field}",
+      "clearSelection": "Cancella selezione",
+      "labels": {
+        "yaml": "Editor YAML",
+        "no_code": "Editor Senza Codice",
+        "label": "Etichetta",
+        "variable": "Variabile"
+      },
+      "sections": {
+        "deprecated": "Proprietà deprecate",
+        "tasks": "Attività",
+        "triggers": "Trigger",
+        "errors": "Gestori degli Errori",
+        "afterExecution": "Dopo l'Esecuzione",
+        "finally": "Infine",
+        "pluginDefaults": "Predefiniti del Plugin"
+      },
+      "fields": {
+        "main": {
+          "id": "ID del flow",
+          "namespace": "Namespace",
+          "description": "Descrizione",
+          "inputs": "Input"
+        },
+        "general": {
+          "retry": "Riprova",
+          "sla": "SLA",
+          "labels": "Etichette",
+          "outputs": "Output",
+          "variables": "Variabili",
+          "concurrency": "Concorrenza",
+          "disabled": "Disabilitato",
+          "listeners": "Ascoltatori",
+          "taskDefaults": "Predefiniti Task",
+          "workerGroup": "Gruppo Worker",
+          "workerSelector": "Selettore Worker",
+          "checks": "Controlli",
+          "updated": "Aggiornato"
+        }
+      },
+      "select": {
+        "default": "Seleziona un tipo",
+        "task": "Seleziona un task",
+        "tasks": "Seleziona un task",
+        "triggers": "Seleziona un trigger",
+        "errors": "Seleziona un task",
+        "finally": "Seleziona un task",
+        "pluginDefaults": "Seleziona un plugin",
+        "afterExecution": "Seleziona un task",
+        "conditions": "Seleziona una condizione",
+        "inputs": "Seleziona un tipo di input field",
+        "charts": "Seleziona un tipo di grafico",
+        "where": "Seleziona un tipo di filtro",
+        "numerator": "Seleziona un numeratore"
+      },
+      "creation": {
+        "default": "Aggiungi",
+        "tasks": "Aggiungi un task",
+        "triggers": "Aggiungi un trigger",
+        "errors": "Aggiungi un gestore degli errori",
+        "finally": "Aggiungi un blocco finally",
+        "pluginDefaults": "Aggiungi un plugin predefinito",
+        "afterExecution": "Aggiungi un blocco after execution",
+        "conditions": "Aggiungi una condizione",
+        "inputs": "Aggiungi un campo di input",
+        "charts": "Aggiungi un grafico",
+        "where": "Filtra i tuoi dati",
+        "numerator": "Aggiungi un numeratore"
+      },
+      "remove": {
+        "default": "Rimuovi questa voce",
+        "cases": "Rimuovi questo caso"
+      }
+    },
+    "properties": {
+      "label": "Proprietà",
+      "hint": "Scegli colonne visibili",
+      "shown": "Visualizzato nella tabella",
+      "hidden": "Nascosto nella Tabella"
+    },
+    "editor_shortcuts": {
+      "label": "Scorciatoie da tastiera",
+      "trigger_autocompletion": "Attiva autocompletamento",
+      "command_palette": "Mostra la palette dei comandi",
+      "save_flow": "Salva flow",
+      "execute_flow": "Esegui flow",
+      "toggle_ai_agent": "Attiva/disattiva agente AI",
+      "move_line": "Sposta linea",
+      "duplicate_cursor": "Duplica cursore",
+      "fold_unfold": "Piega/Spiega codice",
+      "comment_uncomment": "Commenta/Decommenta",
+      "comment": "Commento",
+      "uncomment": "Decommenta",
+      "decrease_fontsize": "Diminuire la dimensione del carattere dell'editor",
+      "increase_fontsize": "Aumenta la dimensione del font dell'editor",
+      "reset_fontsize": "Reimposta dimensione del carattere dell'editor"
+    },
+    "instance": "Istanza",
+    "something_went_wrong": {
+      "loading_execution": "Si è verificato un errore durante il caricamento dell'esecuzione",
+      "connection_lost": {
+        "title": "Connessione interrotta",
+        "message": "Non siamo riusciti a raggiungere la tua istanza di Kestra. Assicurati che sia in esecuzione, quindi aggiorna la pagina."
+      }
+    },
+    "debug": "Debug",
+    "default": "Predefinito",
+    "data_not_protected": "I tuoi dati non sono protetti. Non perderli. <b>Abilita le nostre funzionalità di sicurezza gratuite o prova la nostra offerta a pagamento.</b>",
+    "activate_basic_auth": "Attiva l'Autenticazione di Base",
+    "dark_version": "Versione scura",
+    "use_dark_background": "Usa questa versione quando lavori su uno sfondo scuro per garantire che il nostro nome rimanga leggibile.",
+    "light_version": "Versione leggera",
+    "light_background": "Questa è l'opzione preferita quando si lavora con uno sfondo chiaro.",
+    "monogram": "Monogramma",
+    "wordmark_colors": "I colori del marchio si adattano in base allo sfondo, mentre l'icona rimane senza sfondo quando posizionata su uno sfondo scuro.",
+    "download_logos": "Scarica il Pacchetto Logo",
+    "this_task_has": "Questo task ha",
+    "about_this_blueprint": "Informazioni su questo blueprint",
+    "deleted_label": "Eliminato",
+    "fold_all_multi_lines": "Comprimi Tutte le Linee Multiple",
+    "task_id_exists": "L'ID del task esiste già",
+    "task_id_message": "L'ID del Task ${existingTask} esiste già nel flow.",
+    "trigger_id_exists": "L'ID del trigger esiste già",
+    "trigger_id_message": "L'ID del trigger ${existingTrigger} esiste già nel flow.",
+    "watch": "Guarda",
+    "learn_more": "Scopri di più",
+    "watch_video": "Guarda Video",
+    "runners": "Corridori",
+    "select": "Seleziona il tuo {{section}}",
+    "for flow": "per flow",
+    "forbidden system labels": "Solo system.correlationId può essere usato come label di sistema",
+    "confirm": "Conferma",
+    "taskRunners": "Runner di Task",
+    "additionalPlugins": "Plugin Aggiuntivi",
+    "appBlocks": "Blocchi App",
+    "charts": "Grafici",
+    "dataFilters": "Filtri Dati",
+    "logExporters": "Esportatori di Log",
+    "empty": {
+      "namespaceFiles": {
+        "title": "Nessun file in questo namespace per ora",
+        "content": "I file del namespace funzionano come una cartella di progetto per questo namespace. Archivia codice Python, SQL, dbt o Terraform, quindi fai riferimento a qualsiasi file nei tuoi flows con"
+      },
+      "announcements": {
+        "title": "Non hai ancora annunci!",
+        "content": "Gli annunci ti permettono di notificare ai tuoi utenti eventuali modifiche o di informarli su periodi di manutenzione programmata. Seleziona semplicemente il tipo di annuncio, l'intervallo di date in cui deve essere visualizzato e scrivi il messaggio dell'annuncio."
+      },
+      "kill_switches": {
+        "title": "Non hai ancora Kill Switch!",
+        "content": "La funzione Kill Switch fornisce un meccanismo basato su UI per interrompere esecuzioni problematiche. Sostituisce i comandi <code>--skip-executions</code> e <code>--skip-flows</code> disponibili solo su CLI con un'interfaccia di amministrazione completa."
+      },
+      "apps": {
+        "title": "Non hai ancora app!",
+        "content": "Inizia a creare App per interagire con Kestra dal mondo esterno."
+      },
+      "testSuites": {
+        "title": "Non hai ancora Test suite!",
+        "content": "Inizia a creare suite di test per testare i tuoi flow."
+      },
+      "assets": {
+        "title": "Non hai ancora Asset!",
+        "content": "Aggiungi asset per tracciare e gestire i tuoi asset di dati, servizi e infrastruttura."
+      },
+      "apiTokens": {
+        "title": "Gestisci i tuoi Token API",
+        "content": "I token API vengono utilizzati ogni volta che si desidera concedere l'accesso programmatico all'API di Kestra."
+      },
+      "concurrency_executions": {
+        "title": "Nessuna Esecuzione in corso per questo Flow.",
+        "content": "Leggi di più sulle <strong><a href=\"https://kestra.io/docs/workflow-components/execution?utm_source=app&utm_medium=referral&utm_campaign=concurrency-inlinedoc\" target=\"_blank\">Esecuzioni</a></strong> nella nostra documentazione."
+      },
+      "concurrency_limit": {
+        "title": "Nessun limite è impostato per questo Flow.",
+        "content": "Leggi di più sui <strong><a href=\"https://kestra.io/docs/workflow-components/concurrency?utm_source=app&utm_medium=referral&utm_campaign=concurrency-inlinedoc\" target=\"_blank\">Limiti di Concurrency</a></strong> nella nostra documentazione."
+      },
+      "concurrency_limits": {
+        "title": "Nessun limite di concorrenza è impostato.",
+        "content": "Leggi di più sui <strong><a href=\"https://kestra.io/docs/workflow-components/concurrency?utm_source=app&utm_medium=referral&utm_campaign=concurrency-inlinedoc\" target=\"_blank\">Limiti di Concurrency</a></strong> nella nostra documentazione."
+      },
+      "pluginDefaults": {
+        "title": "Non hai ancora impostazioni predefinite per i plugin!",
+        "content": "I valori predefiniti del plugin ti permettono di gestire centralmente la configurazione del tuo plugin e condividerla con tutti i flow nel tuo namespace."
+      },
+      "variables": {
+        "title": "Ancora nessuna variabile",
+        "content": "Aggiungi coppie chiave-valore per condividere la configurazione tra i flow. I namespace figli le ereditano automaticamente e puoi fare riferimento a qualsiasi valore con"
+      },
+      "workerRegistrationTokens": {
+        "title": "Non hai ancora token di registrazione!",
+        "content": "I token di registrazione consentono ai worker remoti di autenticarsi e registrarsi in modo sicuro con la tua istanza di Kestra. Crea un token, quindi usalo per connettere nuovi worker a questo cluster."
+      },
+      "groups": {
+        "title": "Non hai ancora gruppi!",
+        "content": "I gruppi ti permettono di raggruppare gli utenti in modo da poter gestire i permessi e i ruoli collettivamente all'interno del tuo tenant."
+      },
+      "dependencies": {
+        "FLOW": {
+          "title": "Attualmente non ci sono dipendenze.",
+          "content": "Leggi di più su <a href=\"https://kestra.io/docs/ui/flows?utm_source=app&utm_medium=referral&utm_campaign=dependencies-inlinedoc#dependencies\" target=\"_blank\">Flow Dependencies</a> nella nostra documentazione."
+        },
+        "EXECUTION": {
+          "title": "Attualmente non ci sono dipendenze.",
+          "content": "Per saperne di più sulle <a href=\"https://kestra.io/docs/ui/executions?utm_source=app&utm_medium=referral&utm_campaign=dependencies-inlinedoc#dependencies\" target=\"_blank\">Dipendenze di Esecuzione</a> nella nostra documentazione."
+        },
+        "NAMESPACE": {
+          "title": "Attualmente non ci sono dipendenze.",
+          "content": "Per saperne di più sulle <a href=\"https://kestra.io/docs/ui/namespaces?utm_source=app&utm_medium=referral&utm_campaign=dependencies-inlinedoc#dependencies\" target=\"_blank\">Namespace Dependencies</a>, consulta la nostra documentazione."
+        },
+        "ASSET": {
+          "title": "Attualmente non ci sono dipendenze.",
+          "content": "Questo asset non ha dipendenze upstream o downstream con flow o altri asset."
+        }
+      },
+      "plugins": {
+        "title": "Nessun valore predefinito del plugin è impostato per questo Namespace.",
+        "content": "Leggi di più sui <strong><a href=\"https://kestra.io/docs/workflow-components/plugin-defaults?utm_source=app&utm_medium=referral&utm_campaign=plugin-default-inlinedoc\" target=\"_blank\">limiti di Concurrency</a></strong> nella nostra documentazione."
+      },
+      "triggers": {
+        "title": "Il tuo flow non ha alcun trigger.",
+        "content": "Leggi di più sui <strong><a href=\"https://kestra.io/docs/workflow-components/triggers?utm_source=app&utm_medium=referral&utm_campaign=trigger-inlinedoc\" target=\"_blank\">Trigger</a></strong> nella nostra documentazione."
+      },
+      "mcpToolFlows": {
+        "title": "Nessun flow di tool è ancora registrato su questo server.",
+        "content": "Esporre un flow come uno strumento MCP aggiungendo un <code>McpToolTrigger</code> ad esso. Leggi di più sul <strong><a href=\"https://kestra.io/docs/workflow-components/triggers/mcp-tool-trigger?utm_source=app&utm_medium=referral&utm_campaign=mcp-tool-trigger-inlinedoc\" target=\"_blank\">MCP Tool Trigger</a></strong> nella nostra documentazione."
+      },
+      "versionPlugin": {
+        "title": "Non hai ancora un plugin versionato!",
+        "content": "Qui puoi gestire tutti i plugin installati sulla tua istanza di Kestra. I plugin appena installati potrebbero non essere immediatamente disponibili in tutti i servizi di Kestra, a seconda della configurazione della tua istanza."
+      },
+      "panels": {
+        "title": "Nessun pannello aperto",
+        "content": "Hai chiuso tutti i pannelli.  \nSeleziona una scheda sopra per continuare."
+      }
+    },
+    "toggle_word_wrap": "Attiva/disattiva Word Wrap",
+    "copied_logs_to_clipboard": "Log copiati negli appunti.",
+    "multi_panel_editor": {
+      "move_right": "Sposta a destra",
+      "move_left": "Sposta a sinistra",
+      "close_all_tabs": "Chiudi tutte le tab",
+      "close_all_panels": "Chiudi tutti i pannelli"
+    },
+    "search_docs": "Cerca",
+    "no_results_found": "Nessun risultato trovato",
+    "searching": "Ricerca in corso...",
+    "worker information": "Informazioni sul Worker",
+    "test-badge-text": "Test",
+    "test-badge-tooltip": "Questa esecuzione è stata creata da un Test",
+    "total_executions": "Esecuzioni Totali",
+    "no_results": {
+      "executions": "Nessuna Esecuzione Trovata",
+      "triggers": "Nessun Trigger Trovato",
+      "flows": "Nessun Flow Trovato",
+      "kv_pairs": "Nessuna coppia Key-Value trovata",
+      "secrets": "Nessun Secret Trovato",
+      "templates": "Nessun Template Trovato",
+      "assets": "Nessun asset trovato"
+    },
+    "duplicate-pair": "Il {label} \"{key}\" è duplicato, il primo key è ignorato.",
+    "dashboards": {
+      "labels": {
+        "singular": "Dashboard",
+        "plural": "Dashboard"
+      },
+      "default": "Dashboard predefinito",
+      "switch": "Dashboard Switch",
+      "preview": "Anteprima Dashboard",
+      "empty": "Non ci sono risultati da mostrare.",
+      "creation": {
+        "label": "Crea Dashboard",
+        "confirmation": "Il dashboard <code>{title}</code> è stato creato."
+      },
+      "edition": {
+        "label": "Modifica Dashboard",
+        "confirmation": "Le modifiche nel dashboard <code>{title}</code> sono state salvate.",
+        "chart": "Modifica questo grafico",
+        "id readonly": "La proprietà `id` non può essere modificata — è ora impostata sui suoi valori iniziali. Se desideri cambiarla, puoi creare una nuova dashboard e rimuovere quella vecchia."
+      },
+      "deletion": {
+        "confirmation": "Sei sicuro di voler eliminare la dashboard <code>{title}</code>?"
+      },
+      "no_description": "Nessuna descrizione",
+      "no_description_hint": "Aggiungi una descrizione a questo flow per documentare cosa fa.<br>Markdown è supportato.",
+      "others": "Altri",
+      "viewAll": "Vedi tutti",
+      "chart_preview": "Fai clic sul codice sorgente di un grafico per vedere l'anteprima",
+      "export": "Esporta in CSV",
+      "quick_filters": {
+        "all": "Tutti",
+        "running": "In esecuzione",
+        "paused": "In pausa",
+        "success": "Successo",
+        "warning": "Avviso",
+        "failed": "Fallito"
+      }
     },
     "setup": {
-      "config": {
-        "basicauth": "Autenticazione di base",
-        "queue": "Coda",
-        "repository": "Database",
-        "storage": "Archiviazione Interna"
+      "login": "Accedi",
+      "login_title": "Accedi",
+      "logout": "Logout",
+      "troubleshooting": "Password dimenticata?",
+      "steps": {
+        "user": "Crea utente admin",
+        "config": "Convalida Configurazione",
+        "survey": "Dicci di più",
+        "complete": "Avvia Kestra UI"
       },
-      "confirm": {
-        "config_title": "Conferma che la configurazione sia valida",
-        "confirm": "Crea utente admin",
-        "not_valid": "No, non è valido",
-        "valid": "Sì, è valido"
+      "titles": {
+        "user": "Crea un utente admin",
+        "survey": "Aiutaci a migliorare Kestra OSS"
+      },
+      "subtitles": {
+        "user": "Proteggi la tua istanza per iniziare.",
+        "config": "Ecco i dettagli della tua configurazione",
+        "survey": "Mi dispiace, ma non hai fornito alcun testo da tradurre. Per favore, inserisci il testo che desideri tradurre in italiano.",
+        "complete": "Impostazione completata con successo!"
       },
       "form": {
         "email": "Email",
@@ -1878,351 +1937,249 @@
         "username": "Nome utente",
         "username_hint": "Deve essere un indirizzo email valido."
       },
-      "login": "Accedi",
-      "login_title": "Accedi",
-      "logout": "Logout",
-      "steps": {
-        "complete": "Avvia Kestra UI",
-        "config": "Convalida Configurazione",
-        "survey": "Dicci di più",
-        "user": "Crea utente admin"
-      },
-      "subtitles": {
-        "complete": "Impostazione completata con successo!",
-        "config": "Ecco i dettagli della tua configurazione",
-        "survey": "Mi dispiace, ma non hai fornito alcun testo da tradurre. Per favore, inserisci il testo che desideri tradurre in italiano.",
-        "user": "Proteggi la tua istanza per iniziare."
-      },
-      "success": {
-        "subtitle": "Sei pronto!",
-        "title": "Congratulazioni!"
-      },
-      "survey": {
-        "company_11_50": "Progetto personale",
-        "company_1_10": "Apprendimento / esplorazione",
-        "company_250_plus": "Distribuzione in produzione",
-        "company_50_250": "Valutazione per il mio team/azienda",
-        "company_personal": "Altro",
-        "company_size": "Qual è il tuo obiettivo principale con Kestra?",
-        "continue": "Continua",
-        "newsletter": "Ricevi aggiornamenti sui prodotti via email.",
-        "newsletter_heading": "Rimani informato",
-        "skip": "Salta",
-        "use_case": "Per cosa hai intenzione di usarlo?",
-        "use_case_business": "Workflow aziendali",
-        "use_case_data": "Workflow dei dati",
-        "use_case_infrastructure": "Automazione dell'infrastruttura",
-        "use_case_ml": "Pipeline ML",
-        "use_case_other": "Altro",
-        "use_case_scheduling": "Pianificazione e lavori ricorrenti"
-      },
-      "titles": {
-        "survey": "Aiutaci a migliorare Kestra OSS",
-        "user": "Crea un utente admin"
-      },
-      "troubleshooting": "Password dimenticata?",
       "validation": {
-        "config_message": "Assicurati di aggiornare la tua configurazione per correggere questo messaggio di errore",
-        "email_invalid": "Email non valido",
         "email_required": "L'email è obbligatoria",
+        "email_invalid": "Email non valido",
         "email_temporary_not_allowed": "Indirizzi email temporanei o usa e getta non sono consentiti",
         "firstName_required": "Nome richiesto",
-        "incorrect_creds": "Nome utente o password non validi. Assicurati che le tue credenziali siano corrette.",
         "lastName_required": "Cognome obbligatorio",
         "password_invalid": "Password non valida",
-        "password_required": "La password è obbligatoria"
+        "password_required": "La password è obbligatoria",
+        "incorrect_creds": "Nome utente o password non validi. Assicurati che le tue credenziali siano corrette.",
+        "config_message": "Assicurati di aggiornare la tua configurazione per correggere questo messaggio di errore"
+      },
+      "config": {
+        "repository": "Database",
+        "queue": "Coda",
+        "storage": "Archiviazione Interna",
+        "basicauth": "Autenticazione di base"
+      },
+      "confirm": {
+        "confirm": "Crea utente admin",
+        "config_title": "Conferma che la configurazione sia valida",
+        "not_valid": "No, non è valido",
+        "valid": "Sì, è valido"
+      },
+      "survey": {
+        "skip": "Salta",
+        "company_size": "Qual è il tuo obiettivo principale con Kestra?",
+        "company_1_10": "Apprendimento / esplorazione",
+        "company_11_50": "Progetto personale",
+        "company_50_250": "Valutazione per il mio team/azienda",
+        "company_250_plus": "Distribuzione in produzione",
+        "company_personal": "Altro",
+        "use_case": "Per cosa hai intenzione di usarlo?",
+        "use_case_infrastructure": "Automazione dell'infrastruttura",
+        "use_case_business": "Workflow aziendali",
+        "use_case_data": "Workflow dei dati",
+        "use_case_ml": "Pipeline ML",
+        "use_case_scheduling": "Pianificazione e lavori ricorrenti",
+        "use_case_other": "Altro",
+        "newsletter_heading": "Rimani informato",
+        "newsletter": "Ricevi aggiornamenti sui prodotti via email.",
+        "continue": "Continua"
+      },
+      "success": {
+        "title": "Congratulazioni!",
+        "subtitle": "Sei pronto!"
       }
     },
-    "show": "Mostra",
-    "show chart": "Mostra Grafico",
-    "show description": "Mostra una descrizione",
-    "show details": "Mostra dettagli",
-    "show documentation": "Mostra documentazione",
-    "show more details": "Mostra più dettagli",
-    "show raw": "Show raw",
-    "show task condition": "Mostra condizione del task",
-    "show task documentation": "Mostra la documentazione del task",
-    "show task documentation in editor": "Mostra la documentazione del task nell'editor",
-    "show task logs": "Mostra task logs",
-    "show task outputs": "Mostra task outputs",
-    "show task source": "Mostra sorgente del task",
-    "showLess": "Mostra meno",
-    "showMore": "Mostra di più",
-    "side-by-side": "affiancato",
-    "similar lines": "similar lines",
-    "skipped": "Saltato",
-    "slack support": "Fai qualsiasi domanda via Slack",
-    "something_went_wrong": {
-      "connection_lost": {
-        "message": "Non siamo riusciti a raggiungere la tua istanza di Kestra. Assicurati che sia in esecuzione, quindi aggiorna la pagina.",
-        "title": "Connessione interrotta"
+    "ai": {
+      "flow": {
+        "title": "Agente AI",
+        "prompt_placeholder": "Inserisci le istruzioni per creare il tuo flow di Kestra. Esempio di prompt: Crea un flow che si esegue ogni lunedì alle 9 AM.",
+        "select_provider": "Seleziona un provider",
+        "generating": {
+          "flow": "Generazione del Flow YAML per te...",
+          "dashboard": "Generazione del Dashboard YAML per te...",
+          "app": "Generazione del YAML dell'App per te...",
+          "test": "Generazione del Test YAML per te..."
+        },
+        "enable_instructions": {
+          "header": "<b>AI Copilot non è stato ancora configurato.</b>\n\nPer abilitare AI Copilot, aggiungi il seguente snippet al file di configurazione della tua istanza di Kestra (ad esempio <code>application.yml</code>), sostituendo <code>geminiApiKey</code> con la tua chiave effettiva:",
+          "footer": "Nota: Al momento, solo Gemini è supportato come provider AI per l'Open Source Edition. Per l'Enterprise Edition, fare riferimento alla documentazione di AI Copilot per la configurazione di altri provider di modelli.\n\nRiavvia la tua istanza di Kestra dopo aver salvato la configurazione."
+        }
       },
-      "loading_execution": "Si è verificato un errore durante il caricamento dell'esecuzione"
+      "dashboard": {
+        "prompt_placeholder": "Fai una domanda sui tuoi dati. Esempio di prompt: Mostrami il tasso di successo dei miei flow negli ultimi 7 giorni."
+      }
     },
-    "source": "Fonte",
-    "source and blueprints": "Sorgente e blueprints",
-    "source and doc": "Sorgente e documentazione",
-    "source and topology": "Sorgente e topologia",
-    "source only": "Solo sorgente",
-    "source search": "Cerca fonte",
-    "source_search": {
-      "match_count": "{count} corrispondenza | {count} corrispondenze",
-      "open_flow": "Apri flow",
-      "preview_empty": "Seleziona un risultato per visualizzarne l'anteprima. Fai clic su un flow nell'elenco dei risultati per vedere il suo sorgente.",
-      "preview_error": "Impossibile caricare il sorgente del flow"
+    "playground": {
+      "title": "Playground",
+      "run_task_info": "Passa il mouse su qualsiasi task nell'editor del Flow Code e fai clic sul pulsante \"Run task\" per testare il tuo task.",
+      "play_icon_info": "Puoi anche fare clic sull'icona Play nelle viste No-Code o Topology.",
+      "toggle": "Playground",
+      "run_task": "Esegui Task",
+      "run_this_task": "Esegui questo task",
+      "run_task_and_downstream": "Esegui task e downstream",
+      "run_all_tasks": "Esegui Tutti i Task",
+      "history": "Ultime 10 esecuzioni",
+      "clear_history": "Cancella cronologia",
+      "confirm_create": "Non puoi eseguire il playground mentre crei un flow. Avviare un'esecuzione del playground creerà il flow.",
+      "tooltip_persistence": "Se disattivi e riattivi il Playground, le informazioni rimangono finché resti sulla pagina."
     },
-    "specific task": "Task specifico",
-    "start date": "Data di inizio",
-    "start datetime": "Data e ora di inizio",
-    "started date": "Data di inizio",
-    "state": "Stato",
-    "state updated date": "Data di aggiornamento dello stato",
-    "state_history": "Cronologia degli stati",
-    "stats": "Statistiche",
-    "steps": "Passaggi",
-    "stream": "Stream",
-    "sub flow": "Subflow",
     "submit": "Invia",
-    "success": "Success",
-    "sum": "Somma",
-    "switch-view": "Cambia vista",
-    "system overview": "Panoramica del sistema",
-    "system_namespace": "Mantieni la tua piattaforma sotto controllo con i system flows.",
-    "system_namespace_description": "Automatizza le attività di manutenzione, dagli avvisi di errore alle pulizie automatiche.",
-    "tags": "Tag",
-    "task": "Task",
-    "task failed": "Attività FAILED",
-    "task id": "Task ID",
-    "task id already exists": "Task Id già esistente",
-    "task is running": "Il task è in esecuzione",
-    "task logs": "Task logs",
-    "task run id": "ID di TaskRun",
-    "task sent a warning": "Task ha inviato un WARNING",
-    "task was skipped": "Il task è stato saltato",
-    "task was successful": "Il task è stato completato con SUCCESSO",
-    "taskDefaults": "Task Defaults",
-    "taskRunners": "Runner di Task",
-    "task_id_exists": "L'ID del task esiste già",
-    "task_id_message": "L'ID del Task ${existingTask} esiste già nel flow.",
-    "taskid column details": "Ultimo task in esecuzione e il numero di tentativi.",
-    "tasks": "Tasks",
-    "template": "Template",
-    "template creation": "Creazione del template",
-    "template delete": "Sei sicuro di voler eliminare <code>{templateCount}</code> template/i?",
-    "template export": "Sei sicuro di voler esportare <code>{templateCount}</code> template/i?",
-    "templates": "Templates",
-    "templates deleted": "<code>{count}</code> Template/i eliminati",
-    "templates deprecated": "I templates sono deprecati. Si prega di utilizzare i subflows. Vedi la <a href=\"https://kestra.io/docs/migration-guide/0.11.0/templates?utm_source=app&utm_medium=referral&utm_campaign=template-inlinedoc\" target=\"_blank\">sezione Migrazioni</a> che spiega come migrare dai templates ai subflows.",
-    "templates exported": "Template esportati",
-    "tenant": {
-      "name": "Mandante",
-      "names": "Mandanti"
-    },
-    "tenantId": "ID del Mandante",
-    "test-badge-text": "Test",
-    "test-badge-tooltip": "Questa esecuzione è stata creata da un Test",
-    "theme": "Tema",
-    "this_task_has": "Questo task ha",
-    "timezone": "Fuso orario",
-    "title": "Titolo",
-    "to": "A",
     "to toggle": "per attivare/disattivare",
-    "toggle fullscreen": "Attiva/disattiva schermo intero",
-    "toggle menu": "Attiva/disattiva menu",
-    "toggle output": "Attiva/disattiva outputs",
-    "toggle output display": "Attiva/disattiva visualizzazione output",
-    "toggle periodic refresh each x seconds": "Attiva/disattiva l'aggiornamento periodico ogni {interval} secondi",
-    "toggle_word_wrap": "Attiva/disattiva Word Wrap",
-    "topology": "Topologia",
-    "topology-graph": {
-      "graph-orientation": "Orientamento del grafico",
-      "invalid": "Errore del grafico",
-      "invalid_description": "Si è verificato un errore durante il caricamento del grafico. Si prega di controllare il codice sorgente per errori.",
-      "zoom-fit": "Adatta",
-      "zoom-in": "Zoom avanti",
-      "zoom-out": "Zoom indietro",
-      "zoom-reset": "Reimposta zoom"
-    },
-    "total_duration": "Durata totale",
-    "total_executions": "Esecuzioni Totali",
-    "trigger": "Trigger",
-    "trigger details": "Dettagli del trigger",
-    "trigger disabled": "Il trigger è disabilitato all'interno della sorgente del flow",
-    "trigger execution id": "Trigger Execution Id",
-    "trigger filter": {
-      "options": {
-        "ALL": "Tutte le esecuzioni",
-        "CHILD": "Esecuzioni figlie",
-        "MAIN": "Esecuzioni genitori"
+    "accept": "Accetta",
+    "reject": "Rifiuta",
+    "draft_available": "Una bozza di modifica è disponibile nell'editor",
+    "last modified": "Ultima modifica",
+    "run task in playground": "Esegui task nel playground",
+    "task is running": "Il task è in esecuzione",
+    "task was successful": "Il task è stato completato con SUCCESSO",
+    "task failed": "Attività FAILED",
+    "task was skipped": "Il task è stato saltato",
+    "task sent a warning": "Task ha inviato un WARNING",
+    "defaultsToNamespaceFile": "Predefinito al file namespace: <code>{name}</code>",
+    "no_file_choosen": "Nessun file selezionato",
+    "dependency": {
+      "controls": {
+        "zoom_in": "Ingrandisci",
+        "zoom_out": "Riduci zoom",
+        "clear_selection": "Cancella selezione",
+        "fit_view": "Adatta allo schermo"
       },
-      "title": "Filtra esecuzioni figlie"
-    },
-    "trigger refresh": "Aggiorna",
-    "triggerId": "ID del trigger",
-    "trigger_check_warning": "Utilizzare le variabili trigger non funzionerà con l'esecuzione manuale del flow. Aggiungi l'operatore di coalescenza `??` per risolvere il problema. Ad esempio, invece di `trigger.date`, usa `trigger.date ?? execution.startDate`.",
-    "trigger_id_exists": "L'ID del trigger esiste già",
-    "trigger_id_message": "L'ID del trigger ${existingTrigger} esiste già nel flow.",
-    "trigger_states": "Stati",
-    "triggered": "Execution trigger",
-    "triggered done": "L'esecuzione <em>{name}</em> è stata attivata con successo",
-    "triggerflow disabled": "Il trigger è disabilitato dalla definizione del flow",
-    "triggers": "Triggers",
-    "triggers_add_card_add": "Aggiungi",
-    "triggers_add_card_add_to_flow": "Aggiungi al flow",
-    "triggers_add_category_empty": "Nessun trigger in questa categoria.",
-    "triggers_add_ee_tooltip": "Questo trigger richiede l'Enterprise Edition.",
-    "triggers_add_empty_title": "Nessun trigger trovato",
-    "triggers_add_filter_all": "Tutti",
-    "triggers_add_filter_app": "App",
-    "triggers_add_filter_core": "Core",
-    "triggers_add_filter_realtime": "Tempo reale",
-    "triggers_add_modal_add_button": "Aggiungi Trigger al Flow",
-    "triggers_add_modal_ee_notice": "Questo trigger richiede l'Enterprise Edition.",
-    "triggers_add_modal_flow_placeholder": "Seleziona un flow",
-    "triggers_add_modal_namespace_placeholder": "Seleziona un namespace",
-    "triggers_add_modal_properties_hint": "Configura le proprietà del trigger nell'editor del flow dopo aver aggiunto il trigger.",
-    "triggers_add_modal_tab_documentation": "Documentazione",
-    "triggers_add_modal_tab_form": "Modulo",
-    "triggers_add_modal_tab_source": "Sorgente",
-    "triggers_add_modal_title": "{name}",
-    "triggers_add_modal_trigger_id": "ID del trigger",
-    "triggers_add_modal_trigger_id_placeholder": "Identificatore univoco per questo trigger",
-    "triggers_add_search_placeholder": "Cerca trigger...",
-    "triggers_header_description": "Sfoglia, aggiungi e gestisci i trigger per automatizzare i tuoi flow. Scegli tra esporre il tuo flow come uno strumento AI, pianificare, aggiungere un webhook trigger, controllare le modifiche nelle app esterne o ascoltare eventi in tempo reale.",
-    "triggers_state": {
-      "options": {
-        "disabled": "Disabilitato",
-        "enabled": "Abilitato"
-      },
-      "state": "Stato"
-    },
-    "triggers_tabs_add": "Aggiungi",
-    "triggers_tabs_manage": "Gestisci",
-    "true": "Vero",
-    "type": "Tipo",
-    "unable to generate graph": "Si è verificato un problema durante la generazione del grafico che impedisce la visualizzazione della topologia.",
-    "undefined": "Non definito",
-    "unlock": "Sblocca",
-    "unlock trigger": {
-      "button": "Sblocca trigger",
-      "confirmation": "Sei sicuro di voler sbloccare il trigger?",
-      "success": "Trigger sbloccato",
-      "tooltip": {
-        "evaluation": "Il trigger è attualmente in valutazione",
-        "execution": "C'è un'esecuzione in corso per questo trigger"
-      },
-      "warning": "Potrebbe portare a esecuzioni concorrenti per lo stesso trigger e dovrebbe essere considerata come ultima risorsa."
-    },
-    "unqueue": "Rimuovi dalla coda",
-    "unqueue as": "Dequeued come <code>{status}</code>",
-    "unqueue confirm": "Sei sicuro di voler rimuovere dalla coda l'esecuzione <code>{id}</code>?",
-    "unqueue done": "L'esecuzione è in coda",
-    "unqueue title": "Metti in coda l'esecuzione <code>{id}</code>.<br/>Nota che non rispetterà il limite di concorrenza del flow, quindi potrebbero esserci più esecuzioni in corso rispetto al limite consentito.",
-    "unqueue title multiple": "Sei sicuro di voler rimuovere dalla coda <code>{count}</code> esecuzioni?<br/><br/>Nota che non rispetterà il limite di concurrency del flow, quindi potrebbero essere in esecuzione più esecuzioni del limite consentito.",
-    "unsaved changed ?": "Hai modifiche non salvate, vuoi lasciare questa pagina?",
-    "unsaved changes": "Modifiche Non Salvate",
-    "unsaved changes warning": "Hai modifiche non salvate. Se lasci questa pagina, le modifiche andranno perse.",
-    "up trend": "In aumento",
-    "update": "Aggiorna",
-    "update aborted": "aggiornamento annullato",
-    "update ok": "è aggiornato",
-    "updated date": "Data di aggiornamento",
-    "usage": "Utilizzo",
-    "use": "Usa",
-    "use_dark_background": "Usa questa versione quando lavori su uno sfondo scuro per garantire che il nostro nome rimanga leggibile.",
-    "valid": "Valido",
-    "validate": "Valida",
-    "value": "Value",
-    "variable_explorer": {
-      "empty": "Nessuna variabile disponibile per questa esecuzione.",
-      "n_items": "[ {count} elementi ]",
-      "n_keys": "\\{ {count} keys \\}",
-      "one_item": "[ 1 elemento ]",
-      "one_key": "\\{ 1 key \\}",
-      "raw_json": "Raw JSON",
-      "search_placeholder": "Cerca Key o value...",
-      "select_prompt": "Seleziona una variabile per ispezionarne la value.",
-      "tasks_outputs": "Tasks outputs",
-      "title": "Input/Output",
-      "tree": "Albero"
-    },
-    "variables": "Variabili",
-    "version": "Versione",
-    "view metrics": "Visualizza metriche",
-    "warning": "Avviso",
-    "warning detected": "Avvisi rilevati",
-    "warning flow with triggers": "Questo flow contiene triggers e un'esecuzione manuale fallirà se questo flow dipende da espressioni di trigger.",
-    "watch": "Guarda",
-    "watch_video": "Guarda Video",
-    "webhook": {
-      "copy_url": "Copia URL del webhook",
-      "curl_command": "Comando cURL Webhook",
-      "curl_note": "Usa questo comando cURL per trigger il flow tramite webhook con payload JSON personalizzato",
-      "no_triggers": "Questo flow non ha webhook trigger abilitati",
-      "payload": "Payload Webhook (JSON)"
-    },
-    "webhook link copied": "Link del Webhook copiato.",
-    "welcome": {
-      "help": {
-        "text": "Fai qualsiasi domanda nella nostra community su Slack. Se sei bloccato, siamo qui per aiutarti. ✋",
-        "title": "Hai bisogno di aiuto?"
-      },
-      "menu": "Welcome",
-      "tour": {
-        "text": "Scegli il tuo caso d'uso e segui una guida passo-passo per imparare le funzionalità e le capacità di Kestra. ❤️",
-        "title": "Fai un tour del prodotto"
-      },
-      "tutorial": {
-        "text": "* <a href=\"https://kestra.io/tutorial-videos/all?utm_source=app&utm_medium=referral&utm_campaign=welcome-tutorial\" target=\"_blank\">Video Tutorial</a> \n* <a href=\"https://kestra.io/docs?utm_source=app&utm_medium=referral&utm_campaign=welcome-tutorial\" target=\"_blank\">Documentazione</a> \n* <a href=\"https://kestra.io/blueprints?utm_source=app&utm_medium=referral&utm_campaign=welcome-tutorial\" target=\"_blank\">Blueprint</a>",
-        "title": "Tutorial"
+      "search": {
+        "placeholders": {
+          "default": "Cerca per flow o namespace...",
+          "asset": "Cerca per asset, flow o namespace..."
+        },
+        "namespace": {
+          "select": "Seleziona un namespace",
+          "no_namespace": "Senza namespace"
+        },
+        "flow": {
+          "display": "Includi dipendenze del flow"
+        },
+        "no_results": "Nessun risultato trovato per {term}"
       }
     },
+    "preview": {
+      "label": "Anteprima",
+      "force-editor": "Forza vista editor",
+      "auto-view": "Visualizzazione automatica",
+      "view": "Visualizza",
+      "rows_truncated": "Visualizzazione di {shown} di {total} righe. Scarica il file per visualizzare tutti i dati.",
+      "pagination_info": "Visualizzazione righe {start}-{end} di {total}.",
+      "showing_rows": "Visualizzazione righe {start}-{end} di {total}",
+      "expand": "Espandi",
+      "collapse": "Comprimi",
+      "previous": "Precedente",
+      "next": "Avanti",
+      "page_of": "Pagina {current} di {total}"
+    },
+    "delete trigger": "Elimina trigger",
+    "delete triggers": "Elimina trigger",
+    "bulk delete triggers": "Sei sicuro di voler eliminare {count} trigger?",
+    "bulk success delete triggers": "{count} trigger sono stati eliminati con successo",
+    "delete trigger confirmation": "Sei sicuro di voler eliminare il trigger {id}? WARNING: eliminare un trigger potrebbe portare a esecuzioni duplicate se il trigger è ancora attivo in un flow.",
+    "delete trigger success": "Il trigger {id} è stato eliminato con successo",
+    "delete trigger error": "Errore durante l'eliminazione del trigger {id}",
+    "revision deleted": "La revisione {revision} è stata eliminata con successo",
+    "delete revision confirm": "Sei sicuro di voler eliminare la revisione {revision}?",
+    "delete revision error": "Errore durante l'eliminazione della revisione {revision} con errore {error}",
+    "no_history": "Nessuna cronologia disponibile",
+    "export_as": "Esporta come .{format}",
+    "save_and_execute": "Salva & Esegui",
     "welcome_copilot": {
       "button_cta": "Crea flow da zero",
       "create_manually": {
-        "description": "Crea da zero utilizzando l'editor",
-        "title": "Crea manualmente"
+        "title": "Crea manualmente",
+        "description": "Crea da zero utilizzando l'editor"
       },
       "docs": {
-        "description": "Scopri di più nella documentazione ufficiale",
-        "title": "Leggi la documentazione"
+        "title": "Leggi la documentazione",
+        "description": "Scopri di più nella documentazione ufficiale"
       },
+      "title": "Trasforma la tua idea in un workflow",
+      "need_help": "Hai bisogno di aiuto?",
+      "placeholder_prompt": "Mandami un messaggio di saluto giornaliero alle 9:00.",
+      "show_more": "Mostra più prompt",
+      "show_less": "Mostra meno prompt",
+      "remaining_quota": "Hai {count} generazioni AI rimanenti. Il limite si resetta ogni giorno a mezzanotte UTC.",
       "execute_hint": {
-        "description": "Fai clic per salvare il tuo workflow ed eseguirlo immediatamente.",
-        "title": "Salva ed Esegui il tuo flow"
+        "title": "Salva ed Esegui il tuo flow",
+        "description": "Fai clic per salvare il tuo workflow ed eseguirlo immediatamente."
+      },
+      "success_popup": {
+        "title": "Congratulazioni!",
+        "description": "Hai eseguito con successo il tuo primo flow! Sei sulla buona strada per diventare un esperto di Kestra.",
+        "tutorial": "Tutorial Approfondito",
+        "explore": "Esplora di più"
+      },
+      "success_page": {
+        "title": "Tutto pronto!",
+        "description": "Hai appreso le basi di Kestra. Ecco alcune risorse per aiutarti a continuare il tuo percorso.",
+        "restart": "Riavvia Tutorial",
+        "items": {
+          "tutorial": {
+            "title": "Avvia un Tutorial",
+            "description": "Guida interattiva a tutte le funzionalità di Kestra"
+          },
+          "blueprints": {
+            "title": "Blueprints",
+            "description": "Template di workflow predefiniti per casi d'uso comuni"
+          },
+          "slack": {
+            "title": "Comunità Slack",
+            "description": "Connettiti con altri utenti e ricevi aiuto dalla community"
+          },
+          "videos": {
+            "title": "Tutorial Video",
+            "description": "Guide video passo-passo per funzionalità avanzate"
+          },
+          "demo": {
+            "title": "Ottieni una Demo",
+            "description": "Esplora Kestra Enterprise Edition con una demo personalizzata"
+          }
+        }
+      },
+      "help": {
+        "tutorial": {
+          "title": "Inizia un Tutorial",
+          "description": "Scopri come creare ed eseguire il tuo primo flow con passaggi guidati."
+        },
+        "blueprints": {
+          "title": "Blueprints",
+          "description": "Esplora esempi e modelli pronti all'uso per schemi di workflow comuni."
+        },
+        "slack": {
+          "title": "Comunità Slack",
+          "description": "Unisciti a noi per condividere idee e best practice e ottenere aiuto con domande tecniche."
+        }
       },
       "flows": {
-        "buildDbtPipeline": {
-          "label": "Crea una pipeline dbt",
-          "prompt": "Crea un flow di Kestra che clona un repository di progetto dbt e esegue dbt build con un profilo DuckDB."
-        },
-        "buildDockerImageAndRunIt": {
-          "label": "Crea un'immagine Docker ed eseguila",
-          "prompt": "Crea un flow di Kestra che costruisce un'immagine Docker da un Dockerfile inline e esegue il container risultante."
-        },
-        "convertCsvToExcel": {
-          "label": "Converti un CSV in Excel",
-          "prompt": "Crea un flow che scarica un file CSV, lo converte in Ion e esporta il risultato come file Excel."
-        },
-        "etlWorkflow": {
-          "label": "Flusso di lavoro ETL",
-          "prompt": "Crea un flow ETL che scarica dati JSON, li elabora con Python e interroga il risultato trasformato con DuckDB."
+        "jsonApiToDuckdb": {
+          "label": "API JSON a DuckDB",
+          "prompt": "Crea un flow che scarica un file JSON da un'API pubblica, lo trasforma con uno script Python e lo elabora con un task DuckDB Queries."
         },
         "installNginxViaAnsible": {
           "label": "Installa Nginx tramite Ansible",
           "prompt": "Crea un flow di Kestra che installa Nginx su una macchina di destinazione con Ansible e verifica la versione installata."
         },
-        "jsonApiToDuckdb": {
-          "label": "API JSON a DuckDB",
-          "prompt": "Crea un flow che scarica un file JSON da un'API pubblica, lo trasforma con uno script Python e lo elabora con un task DuckDB Queries."
+        "buildDbtPipeline": {
+          "label": "Crea una pipeline dbt",
+          "prompt": "Crea un flow di Kestra che clona un repository di progetto dbt e esegue dbt build con un profilo DuckDB."
+        },
+        "etlWorkflow": {
+          "label": "Flusso di lavoro ETL",
+          "prompt": "Crea un flow ETL che scarica dati JSON, li elabora con Python e interroga il risultato trasformato con DuckDB."
+        },
+        "microservicesApis": {
+          "label": "Microservizi e API",
+          "prompt": "Crea un flow che verifica la risposta dell'API di un sito web e invia un avviso Slack quando il codice di stato non è di successo."
+        },
+        "buildDockerImageAndRunIt": {
+          "label": "Crea un'immagine Docker ed eseguila",
+          "prompt": "Crea un flow di Kestra che costruisce un'immagine Docker da un Dockerfile inline e esegue il container risultante."
         },
         "manualApproval": {
           "label": "Approvazione manuale",
           "prompt": "Crea un flow con un passaggio iniziale di elaborazione, una pausa per l'approvazione manuale e un passaggio finale di deployment dopo l'approvazione."
         },
-        "microservicesApis": {
-          "label": "Microservizi e API",
-          "prompt": "Crea un flow che verifica la risposta dell'API di un sito web e invia un avviso Slack quando il codice di stato non è di successo."
+        "convertCsvToExcel": {
+          "label": "Converti un CSV in Excel",
+          "prompt": "Crea un flow che scarica un file CSV, lo converte in Ion e esporta il risultato come file Excel."
         },
         "scheduledPdfReports": {
           "label": "Report PDF programmati",
@@ -2232,73 +2189,116 @@
           "label": "KPI di Vendite Settimanali su Slack",
           "prompt": "Crea un flow programmato settimanalmente che calcola i KPI delle vendite con DuckDB e pubblica il riepilogo su Slack."
         }
-      },
-      "help": {
-        "blueprints": {
-          "description": "Esplora esempi e modelli pronti all'uso per schemi di workflow comuni.",
-          "title": "Blueprints"
-        },
-        "slack": {
-          "description": "Unisciti a noi per condividere idee e best practice e ottenere aiuto con domande tecniche.",
-          "title": "Comunità Slack"
-        },
-        "tutorial": {
-          "description": "Scopri come creare ed eseguire il tuo primo flow con passaggi guidati.",
-          "title": "Inizia un Tutorial"
-        }
-      },
-      "need_help": "Hai bisogno di aiuto?",
-      "placeholder_prompt": "Mandami un messaggio di saluto giornaliero alle 9:00.",
-      "remaining_quota": "Hai {count} generazioni AI rimanenti. Il limite si resetta ogni giorno a mezzanotte UTC.",
-      "show_less": "Mostra meno prompt",
-      "show_more": "Mostra più prompt",
-      "success_page": {
-        "description": "Hai appreso le basi di Kestra. Ecco alcune risorse per aiutarti a continuare il tuo percorso.",
-        "items": {
-          "blueprints": {
-            "description": "Template di workflow predefiniti per casi d'uso comuni",
-            "title": "Blueprints"
-          },
-          "demo": {
-            "description": "Esplora Kestra Enterprise Edition con una demo personalizzata",
-            "title": "Ottieni una Demo"
-          },
-          "slack": {
-            "description": "Connettiti con altri utenti e ricevi aiuto dalla community",
-            "title": "Comunità Slack"
-          },
-          "tutorial": {
-            "description": "Guida interattiva a tutte le funzionalità di Kestra",
-            "title": "Avvia un Tutorial"
-          },
-          "videos": {
-            "description": "Guide video passo-passo per funzionalità avanzate",
-            "title": "Tutorial Video"
-          }
-        },
-        "restart": "Riavvia Tutorial",
-        "title": "Tutto pronto!"
-      },
-      "success_popup": {
-        "description": "Hai eseguito con successo il tuo primo flow! Sei sulla buona strada per diventare un esperto di Kestra.",
-        "explore": "Esplora di più",
-        "title": "Congratulazioni!",
-        "tutorial": "Tutorial Approfondito"
-      },
-      "title": "Trasforma la tua idea in un workflow"
+      }
     },
-    "welcome_page": {
-      "guide": "Hai bisogno di assistenza per eseguire il tuo primo flow?",
-      "welcome": "Benvenuto in Kestra"
+    "mcp": {
+      "your_servers": "I tuoi server",
+      "servers_count": "{{count}} Server MCP",
+      "managed_by_kestra": "Gestito da Kestra",
+      "servers": "Server MCP",
+      "server": "Server MCP",
+      "client_setup": "Configurazione Client",
+      "page_description": "Esporre i tuoi flow di Kestra come strumenti per agenti AI compatibili con MCP",
+      "create": "Crea Server",
+      "save": "Salva modifiche",
+      "connect": "Connetti",
+      "copy_url": "Copia URL",
+      "url_copied": "URL copiata!",
+      "instructions": "Istruzioni",
+      "server_type": "Tipo di Server",
+      "auth_type": "Autenticazione",
+      "private": "Privato",
+      "private_server": "Server privato",
+      "public": "Pubblico",
+      "public_hint": "Avviso: I server pubblici non richiedono autenticazione. Chiunque abbia l'URL può richiamare ogni strumento esposto da questo server, senza controlli di namespace o permessi. Utilizzare solo per server sicuri da esporre esternamente.",
+      "basic_auth": "Autenticazione di base",
+      "api_token": "Token API",
+      "oauth": "OAuth",
+      "username_password": "Nome utente e password",
+      "bearer_token": "Autenticazione con token Bearer",
+      "oauth_hint": "Bearer JWT dal proprio provider OIDC",
+      "oauth_provider": "Provider OAuth",
+      "oauth_provider_placeholder": "Selezionare un provider OIDC configurato",
+      "oauth_provider_required": "Il provider OAuth è obbligatorio quando il tipo di autenticazione è OAuth",
+      "scopes_supported": "Scope supportati",
+      "scopes_supported_placeholder": "openid, profile, email",
+      "scopes_supported_hint": "Scope pubblicizzati nel documento Protected Resource Metadata di questo server. I client MCP conformi alle specifiche limitano la richiesta di autorizzazione a questo elenco. Lasciare vuoto per omettere il campo e consentire ai client di utilizzare gli scope pubblicizzati dall'IdP.",
+      "no_oauth_providers": "Nessun provider OIDC configurato in questa istanza",
+      "delete_confirm": "Sei sicuro di voler eliminare questo server MCP?",
+      "no_servers": "Nessun server MCP trovato. Crea il tuo primo server per esporre i trigger dello strumento MCP agli agenti AI esterni.",
+      "server_id": "ID server",
+      "id_placeholder": "ad es. my-mcp-server",
+      "id_invalid": "L'ID deve iniziare con una lettera minuscola o una cifra e contenere solo lettere minuscole, cifre, trattini o underscore.",
+      "main_tenant": "principale",
+      "tab_edit": "Modifica",
+      "tab_connect": "Connetti",
+      "tab_tool_flows": "Flussi degli Strumenti",
+      "tab_tool_flows_placeholder": "La gestione dei flow degli strumenti arriverà presto.",
+      "tools": {
+        "no_tools": "Nessun flow di strumenti corrisponde alla tua ricerca.",
+        "create_tool_flow": "Crea un flow di tool",
+        "tool_name": "Nome dello strumento",
+        "trigger_id": "ID del trigger",
+        "title": "Titolo",
+        "description": "Descrizione",
+        "annotations": "Annotazioni",
+        "flow": "flow",
+        "state": "Stato",
+        "read_only": "Sola lettura",
+        "open_world": "Open world",
+        "destructive": "Distruttivo",
+        "idempotent": "Idempotente",
+        "return_direct": "Ritorno diretto",
+        "view_flow": "Apri flow"
+      },
+      "connect_tab": {
+        "server_url": "URL del server",
+        "client_picker_label": "Scegli il tuo client AI",
+        "claude_desktop": "Claude Desktop",
+        "claude_desktop_hint": "Aggiungi quanto segue al tuo file claude_desktop_config.json:",
+        "claude_desktop_mac": "macOS: ~/Library/Application Support/Claude/claude_desktop_config.json",
+        "claude_desktop_win": "Windows: %APPDATA%\\Claude\\claude_desktop_config.json",
+        "claude_code": "Claude Code",
+        "claude_code_hint": "Esegui il seguente comando nel tuo terminale:",
+        "cursor": "Cursore",
+        "cursor_hint": "Aggiungi quanto segue a ~/.cursor/mcp.json:",
+        "codex": "Codex (OpenAI)",
+        "codex_hint": "Aggiungi quanto segue alla configurazione MCP del tuo codex.json:",
+        "auth_basic_hint": "Imposta <code>KESTRA_BASIC_AUTH</code> come variabile d'ambiente contenente una stringa <code>username:password</code> codificata in base64 prima di avviare il client.",
+        "auth_api_token_hint": "Imposta <code>KESTRA_TOKEN</code> come variabile d'ambiente prima di avviare il client.",
+        "auth_oauth_client_id_hint": "Sostituisci <code>&lt;client-id&gt;</code> con l'ID client OAuth e registra <code>http://localhost:7777</code> come URI di reindirizzamento valido su quel client.",
+        "auth_oauth_browser_hint": "Il browser aprirà la pagina di accesso del provider di identità alla prima connessione."
+      }
     },
-    "wordmark_colors": "I colori del marchio si adattano in base allo sfondo, mentre l'icona rimane senza sfondo quando posizionata su uno sfondo scuro.",
-    "worker group": "Gruppo di Workers",
-    "worker group fallback": "Gruppo di Worker di riserva",
-    "worker group key": "Chiave del gruppo Worker",
-    "worker information": "Informazioni sul Worker",
-    "workerId": "Worker Id",
-    "workers": "Workers",
-    "wrong labels": "Chiave o valore vuoto non sono ammessi nelle etichette",
-    "yes": "Sì"
+    "flow_editor_stats": {
+      "revisions": {
+        "suffix": "Revisioni",
+        "tooltip": "Visualizza le revisioni del flow"
+      },
+      "dependencies": {
+        "suffix": "Dipendenze",
+        "tooltip": "Visualizza le dipendenze del flow"
+      },
+      "apps": {
+        "suffix": "App(s)",
+        "tooltip": "Visualizza le app che utilizzano questo flow"
+      },
+      "tests": {
+        "suffix": "Test(s)",
+        "tooltip": "Visualizza i test del flow"
+      },
+      "errors": {
+        "label": "{count} Errore/i"
+      }
+    },
+    "source_search": {
+      "match_count": "{count} corrispondenza | {count} corrispondenze",
+      "open_flow": "Apri flow",
+      "preview_empty": "Seleziona un risultato per visualizzarne l'anteprima. Fai clic su un flow nell'elenco dei risultati per vedere il suo sorgente.",
+      "preview_error": "Impossibile caricare il sorgente del flow"
+    },
+    "open source": "Open Source",
+    "pricing": "Prezzi",
+    "license": "Licenza"
   }
 }

--- a/ui/src/translations/ja.json
+++ b/ui/src/translations/ja.json
@@ -1,1678 +1,722 @@
 {
   "ja": {
-    "Add flow": "Flowを追加",
-    "Default log level": "デフォルトlogレベル",
-    "Default namespace": "デフォルトnamespace",
-    "Default page": "デフォルトページ",
-    "Editor fontfamily": "エディターのフォントファミリー",
-    "Editor fontsize": "エディターのフォントサイズ",
-    "Editor theme": "エディターテーマ",
-    "Fold auto": "エディター：複数行の自動折りたたみ",
-    "Fold content lines": "複数行文字列を折りたたむ",
-    "Hover description": "エディター: key または value にホバーするとフィールドの説明を表示",
-    "Language": "言語",
-    "Per page": "ページごと",
-    "Set default page": "デフォルトページを設定",
-    "Set labels": "ラベルを設定",
-    "Set labels done": "実行のラベルが正常に設定されました",
-    "Set labels to execution": "実行<code>{id}</code>のラベルを追加または更新",
-    "Set labels tooltip": "実行にラベルを設定",
-    "Task Id already exist in the flow": "Task Id {taskId}はflow内ですでに存在します。",
-    "Total": "合計",
-    "Unfold content lines": "複数行文字列を展開する",
-    "about_this_blueprint": "このblueprintについて",
-    "absolute": "絶対",
-    "accept": "承認",
-    "actions": "アクション",
-    "activate_basic_auth": "基本認証を有効化する",
-    "active": "アクティブ",
-    "active-slots": "アクティブスロット",
-    "actual state": "実際の状態",
-    "add": "追加",
-    "add at position": "{position}に<code>{task}</code>を追加",
-    "add error handler": "エラーハンドラを追加",
-    "add flow": "Flowを追加",
+    "loading": "読み込み中...",
+    "more actions": "その他のアクション",
+    "toggle menu": "メニューを切り替え",
+    "panel actions": "パネルアクション",
+    "playground actions": "プレイグラウンドアクション",
+    "bulk actions": "一括操作",
+    "view metrics": "メトリクスを表示",
+    "remove this item": "このアイテムを削除",
     "add label": "ラベルを追加",
-    "add task": "taskを追加",
-    "add-trigger-in-editor": "最初にFlowにTriggerを追加してください",
-    "add_new_item": "新しいアイテムを追加",
-    "additionalPlugins": "追加プラグイン",
-    "admin": "管理者",
-    "admin_preferences": "Preferences",
-    "administration": "管理",
-    "advanced configuration": "他のプロパティ",
-    "after": "後",
-    "aggregation": "集計",
-    "ai": {
-      "dashboard": {
-        "prompt_placeholder": "データについて質問してください。例: 過去7日間のflowの成功率を教えてください。"
+    "remove label": "ラベルを削除",
+    "id": "Id",
+    "type": "タイプ",
+    "ok": "OK",
+    "valid": "有効",
+    "close": "閉じる",
+    "namespace": "Namespace",
+    "description": "説明",
+    "show description": "説明を表示",
+    "show details": "詳細を表示",
+    "show more details": "詳細を表示",
+    "skipped": "スキップされました",
+    "revision": "リビジョン",
+    "Language": "言語",
+    "Set default page": "デフォルトページを設定",
+    "theme": "テーマ",
+    "flows": "Flows",
+    "flow": "Flow",
+    "invalid source": "無効なソースコード",
+    "missingSource": "ソースが見つかりません",
+    "update": "更新",
+    "update ok": "更新されました",
+    "delete ok": "削除されました",
+    "Default page": "デフォルトページ",
+    "confirmation": "確認",
+    "common": {
+      "back": "戻る"
+    },
+    "delete confirm": "<code>{name}</code>を削除してもよろしいですか？",
+    "outdated revision save confirmation": {
+      "confirm": "上書きしますか？",
+      "update": {
+        "title": "古いリビジョン",
+        "description": "編集しているリビジョンは古いです。",
+        "details": "最新バージョンの詳細については、リビジョンタブを確認してください。"
       },
-      "flow": {
-        "enable_instructions": {
-          "footer": "注意: 現時点では、オープンソース版のAIプロバイダーとしてGeminiのみがサポートされています。エンタープライズ版については、他のモデルプロバイダーの設定についてAI Copilotのドキュメントを参照してください。\n\n設定を保存した後、Kestraインスタンスを再起動してください。",
-          "header": "<b>AI Copilotはまだ設定されていません。</b>\n\nAI Copilotを有効にするには、次のスニペットをKestraインスタンスの構成ファイル（例：<code>application.yml</code>）に追加し、<code>geminiApiKey</code>を実際のキーに置き換えてください。"
-        },
-        "generating": {
-          "app": "アプリのYAMLを生成しています...",
-          "dashboard": "ダッシュボードのYAMLを生成しています...",
-          "flow": "フローのYAMLを生成しています...",
-          "test": "テストYAMLを生成しています..."
-        },
-        "prompt_placeholder": "指示を入力してKestra flowを作成してください。例: 毎週月曜日の午前9時に実行されるflowを作成してください。",
-        "select_provider": "プロバイダーを選択",
-        "title": "AIエージェント"
+      "create": {
+        "title": "Flowは既に存在します",
+        "description": "このnamespaceには、同じidのflowが既に存在します。",
+        "details": "上書きして新しいリビジョンを作成するために保存します。"
       }
     },
-    "all executions": "すべての実行",
-    "all tags": "すべてのタグ",
-    "api": "API",
-    "appBlocks": "アプリブロック",
-    "apps": "アプリケーション",
-    "are you sure change state": "状態を変更してもよろしいですか？",
-    "assets": {
-      "title": "アセット"
+    "override": {
+      "title": "現在のflowを上書きしようとしています",
+      "details": "以前のflowはRevisionsタブから復元できます。"
     },
-    "attempt": "試行",
-    "attempts": "試行回数",
-    "auditlogs": "Audit Logs",
-    "automatic refresh": "自動更新",
-    "avg": "平均",
-    "avg duration": "平均実行時間",
+    "is deprecated": "非推奨です",
+    "success": "Success",
+    "save": "保存",
+    "save_as_draft": "下書きとして保存",
+    "draft": "下書き",
+    "draft_flow_warning": "この flow リビジョンは下書きです。実行はこの下書きリビジョンに対して行われ、flow の定義が無効な場合はすぐに失敗する可能性があります。",
+    "save task": "Taskを保存",
+    "saved": "正常に保存されました",
+    "saved as draft": "下書きとして保存しました",
+    "saved done": "<em>{name}</em>は正常に保存されました",
+    "saved as draft done": "<em>{name}</em> を下書きとして保存しました",
+    "multiple saved done": "{name}が保存されました",
+    "fileTypeNotAllowed": "ファイルタイプが許可されていません。許可されているタイプ: {types}",
+    "delete": "削除",
+    "deleted": "正常に削除されました",
+    "deleted confirm": "<em>{name}</em>は正常に削除されました！",
+    "Add flow": "Flowを追加",
+    "add": "追加",
+    "add_new_item": "新しいアイテムを追加",
+    "copy": "コピー",
+    "copy_to_clipboard": "クリップボードにコピー",
+    "copy_and_close": "コピーして閉じる",
+    "Per page": "ページごと",
+    "new": "新規",
+    "edit": "編集",
     "back": "戻る",
-    "back_to_dashboard": "ダッシュボードに戻る",
-    "backfill": "Backfill",
-    "backfill executions": "backfill実行",
-    "backfill paused": "バックフィル PAUSED",
-    "backfill running": "バックフィル実行中",
-    "bar": "バー",
-    "before": "前",
-    "behavior": "動作",
-    "blueprints": {
-      "all": "すべて",
-      "apps": "アプリケーション Blueprints",
-      "community": "コミュニティ",
-      "create": "ブループリントを作成",
-      "custom": "カスタムblueprint",
-      "dashboards": "ダッシュボード Blueprints",
-      "detail": {
-        "category": "カテゴリタイプ",
-        "links": "リンクとリソース",
-        "openInEditor": "フローを編集で開く"
-      },
-      "edit": "ブループリントを編集する",
-      "empty": "設計図が表示されていません。",
-      "flows": "フローBlueprints",
-      "header": {
-        "alt": "ブループリントアイコン",
-        "catch phrase": {
-          "1": "最初の一歩が一番難しい。",
-          "2": "次の{kind}を始めるためにblueprintを探索してください。"
-        }
-      },
-      "missingPlugins": {
-        "card": "このインスタンスにインストールされていないpluginが必要です: {plugins}",
-        "description": "このblueprintは、このインスタンスにインストールされていないpluginのtaskを使用しています: {plugins}。このblueprintを使用するにはインストールしてください。",
-        "install": "pluginをインストール",
-        "title": "不足しているplugin"
-      },
-      "title": "Blueprints"
+    "next": "次へ",
+    "done": "完了",
+    "review your inputs": "入力内容を確認してください",
+    "edit flow": "Flowを編集",
+    "executions": "実行",
+    "execution": "Execution",
+    "execution id": "実行 Id",
+    "recent_executions": "最近の実行",
+    "details": "詳細",
+    "overview": "概要",
+    "gantt": "ガント",
+    "gantt_no_tasks_executed": "このExecutionは、タスクを実行せずに終了しました。  \n理由を確認するには、概要とLogsをチェックしてください。",
+    "gantt_no_tasks_match_filters": "検索、状態、またはログレベルのフィルターを調整してみてください。",
+    "gantt_no_tasks_match_filters_title": "選択したフィルターに一致するタスクがありません。",
+    "logs": "Logs",
+    "no_logs_data": "データなし",
+    "no_logs_data_description": "フィルターを調整するか、時間範囲を変更するか、flowが最近実行されたかを確認してください。",
+    "no_logs_data_title": "選択したフィルターに対してログが見つかりませんでした。",
+    "duration": "期間",
+    "total_duration": "合計時間",
+    "running duration": "実行期間",
+    "queued duration": "キュー待ち期間",
+    "choose file": "ファイルを選択するか、ここにドロップしてください...",
+    "launch execution": "実行",
+    "warning flow with triggers": "このflowにはtriggersが含まれており、trigger expressionsに依存する場合、手動実行は失敗します。",
+    "triggered": "実行trigger",
+    "triggered done": "実行<em>{name}</em>が正常にトリガーされました",
+    "topology": "トポロジー",
+    "date": "日付",
+    "prev_execution": "前回の実行",
+    "next_execution": "次回の実行",
+    "datepicker": {
+      "leave empty for infinite": "無限の期間にするには空白のままにするか、ISO 8601期間を入力してください（例：'P1DT1H1M1S'）",
+      "duration example": "例：'P1DT1H1M1S'",
+      "error": "無効な期間形式です。ISO 8601期間である必要があります（例：P1DT1H1M1S）",
+      "custom": "カスタム",
+      "last5minutes": "過去5分",
+      "last15minutes": "過去15分",
+      "last1hour": "過去1時間",
+      "last12hours": "過去12時間",
+      "last24hours": "過去24時間",
+      "last48hours": "過去48時間",
+      "last7days": "過去7日間",
+      "last30days": "過去30日間",
+      "last365days": "過去365日間",
+      "next5minutes": "次の5分",
+      "next15minutes": "次の15分",
+      "next1hour": "次の1時間",
+      "next12hours": "次の12時間",
+      "next24hours": "次の24時間",
+      "next48hours": "次の48時間",
+      "next7days": "次の7日間",
+      "next30days": "次の30日間",
+      "next365days": "次の365日",
+      "5minutes": "5分",
+      "15minutes": "15分",
+      "1hour": "1時間",
+      "12hours": "12時間",
+      "24hours": "24時間",
+      "48hours": "48時間",
+      "7days": "7日間",
+      "30days": "30日間",
+      "365days": "365日間",
+      "never": "無期限",
+      "today": "今日",
+      "yesterday": "昨日",
+      "dayBeforeYesterday": "一昨日",
+      "thisWeek": "今週",
+      "thisWeekSoFar": "今週これまで",
+      "previousWeek": "先週",
+      "thisMonth": "今月",
+      "thisMonthSoFar": "今月これまで",
+      "previousMonth": "先月",
+      "thisYear": "今年",
+      "thisYearSoFar": "今年これまで",
+      "previousYear": "昨年",
+      "short": {
+        "15m": "15分",
+        "1h": "1時間",
+        "12h": "12時間",
+        "1d": "1日",
+        "7d": "7日"
+      }
     },
-    "body_line_clamp": "Limit line height",
-    "bookmark": "ブックマーク",
-    "breakpoints": "ブレークポイント",
-    "bulk action async warning": "少々お待ちください。",
-    "bulk actions": "一括操作",
-    "bulk change state": "以下の実行の状態を変更してもよろしいですか？<code>{executionCount}</code> 実行。",
-    "bulk delete": "<code>{executionCount}</code>件の実行を削除してもよろしいですか？",
-    "bulk delete backfills": "{count}個のbackfillを削除",
-    "bulk delete triggers": "{count} 個のtriggerを削除してもよろしいですか？",
-    "bulk disabled status": {
-      "false": "{count}個のtriggersを有効化",
-      "true": "{count}個のtriggersを無効化"
+    "created date": "作成日",
+    "latest_update": "最新の更新",
+    "updated date": "更新日",
+    "expiration date": "有効期限",
+    "started date": "開始日",
+    "healthcheck date": "HealthCheck日",
+    "next execution date": "次の実行日",
+    "last execution status": "最後の実行ステータス",
+    "jump to...": "ジャンプ先...",
+    "contextBar": {
+      "news": "ニュース",
+      "docs": "ドキュメント",
+      "help": "ヘルプ",
+      "issue": "問題",
+      "demo": "デモ",
+      "star": "お気に入りに追加"
     },
-    "bulk force run": "実行を強制的に実行しますか <code>{executionCount}</code> 回の実行を行いますか？<br/><br/>WARNING: 実行を強制的に実行することは保証されておらず、重複したタスクの実行が発生する可能性があります。<br/><br/>以下の遷移が行われます:<br/><ul><li>CREATED タスクは RUNNING 状態に移行します。</li><li>RUNNING タスクは再送信されます。</li><li>QUEUED タスクはキューから外されます。</li><li>PAUSED タスクは再開されます。</li></ul>",
-    "bulk kill": "<code>{executionCount}</code>件の実行をkillしてもよろしいですか？",
-    "bulk pause": "<code>{executionCount}</code> 実行を一時停止してもよろしいですか？",
-    "bulk pause backfills": "{count}個のbackfillを一時停止",
-    "bulk replay": "<code>{executionCount}</code>件の実行を再実行してもよろしいですか？",
-    "bulk restart": "<code>{executionCount}</code>件の実行を再起動してもよろしいですか？",
-    "bulk resume": "<code>{executionCount}</code>件の実行を再開してもよろしいですか？",
-    "bulk set labels": "<code>{executionCount}</code>件の実行にラベルを設定してもよろしいですか？",
-    "bulk success delete backfills": "{count}個のbackfillsが削除されました",
-    "bulk success delete triggers": "{count} 個のtriggerが正常に削除されました",
-    "bulk success disabled status": {
-      "false": "{count}個のtrigger(s)が有効化されました",
-      "true": "{count}個のtrigger(s)が無効化されました"
+    "source": "ソース",
+    "source only": "ソースのみ",
+    "home": "ホーム",
+    "create": "作成",
+    "create_flow": "フローを作成",
+    "add flow": "Flowを追加",
+    "from": "から",
+    "to": "まで",
+    "search filters": {
+      "saved": "保存されたフィルター",
+      "manage": "検索フィルターを管理",
+      "manage desc": "保存された検索フィルターを管理",
+      "save filter": "フィルターを保存",
+      "filter name": "フィルター名",
+      "filters": "フィルター"
     },
-    "bulk success pause backfills": "{count}個のbackfillsが一時停止されました",
-    "bulk success unlock": "{count}個のtriggersが解除されました",
-    "bulk success unpause backfills": "{count}個のbackfillsが再開されました",
-    "bulk unlock": "{count}個のtriggersを解除",
-    "bulk unpause backfills": "{count}個のbackfillを再開",
-    "bulk unqueue": "<code>{executionCount}</code> 件の実行をキューから外してもよろしいですか？",
-    "can not delete": "削除できません",
-    "can not have less than 1 task": "各flowには少なくとも1つのtaskが必要です。",
-    "can not save": "保存できません",
-    "cancel": "キャンセル",
+    "steps": "ステップ",
+    "state": "状態",
+    "state_history": "状態履歴",
+    "search term in message": "メッセージ内の検索語",
+    "search": "検索",
+    "search blueprint": "Blueprintsを検索",
+    "all tags": "すべてのタグ",
+    "source search": "ソース検索",
+    "filter by log level": "Logレベルでフィルター",
+    "selected": "選択済み",
+    "task": "Task",
+    "task logs": "Task Logs",
+    "display flow {id} executions": "Flow {id}の実行を表示",
+    "actions": "アクション",
+    "select datetime": "日付を選択",
+    "select view": "ビューを選択",
+    "invalid field": "無効なフィールド：{name}",
+    "required field": "必須フィールド",
+    "is required": "{field} は必須です",
+    "error": "エラー",
+    "form": "フォーム",
+    "form error": "フォームエラー",
+    "display topology for flow": "Flowのトポロジーを表示",
     "cannot create topology": "Flowのトポロジーを作成できません",
-    "cannot swap tasks": "taskを入れ替えできません",
-    "change execution state confirm": "実行<code>{id}</code>の状態を変更してもよろしいですか？",
-    "change execution state done": "実行状態が更新されました",
-    "change queue confirm": "実行<code>{id}</code>のキュー状態を変更してもよろしいですか？<br/>",
+    "start date": "開始日",
+    "end date": "終了日",
+    "creation": "作成",
+    "flow creation": "Flow作成",
+    "start datetime": "開始日時",
+    "end datetime": "終了日時",
+    "restart": "再起動",
+    "restart latest revision": "最新のリビジョンを再起動",
+    "restart tooltip": "<code>{state}</code>タスクから実行を再起動",
+    "restarted": "実行が再開されました",
+    "restart confirm": "実行<code>{id}</code>を再起動してもよろしいですか？",
+    "restart change revision": "新しい実行に使用されるリビジョンを変更できます。",
+    "replay": "リプレイ",
+    "replay from task tooltip": "Task <code>{taskId}</code>から開始する同様の実行を作成",
+    "replay from beginning tooltip": "最初から開始する同様の実行を作成",
+    "replay latest revision": "最新のリビジョンを使用してリプレイ",
+    "replayed": "実行が再生されました",
+    "replay confirm": "この実行<code>{id}</code>をリプレイして新しいものを作成してもよろしいですか？",
+    "replay with inputs": "入力を使用してリプレイ",
+    "reuse_original_inputs": "元のinputを再利用",
+    "modify_inputs": "入力を変更",
+    "replay the execution": "フロー<code>{flowId}</code>の実行<code>{executionId}</code>を再実行する",
+    "prefill inputs": "自動入力",
+    "current": "現在",
     "change state": "状態を変更",
-    "change state confirm": "タスク <code>{task}</code> の実行 <code>{id}</code> のタスク実行状態を変更してもよろしいですか？",
-    "change state current state": "現在のステータスは:",
+    "actual state": "実際の状態",
+    "select a state": "状態を選択",
+    "are you sure change state": "状態を変更してもよろしいですか？",
+    "yes": "はい",
     "change state done": "タスクの状態が更新されました",
+    "change state confirm": "タスク <code>{task}</code> の実行 <code>{id}</code> のタスク実行状態を変更してもよろしいですか？",
+    "change queue confirm": "実行<code>{id}</code>のキュー状態を変更してもよろしいですか？<br/>",
+    "change state current state": "現在のステータスは:",
     "change state hint": {
+      "WARNING": [
+        "このflowはWARNINGとしてマークされます。",
+        "次のtasksが実行されます。",
+        "エラーtasksが実行されます。"
+      ],
       "FAILED": [
         "FlowはFAILEDとしてマークされます。",
         "他のTaskは実行されません。",
         "エラーTaskが実行されます。"
-      ],
-      "RUNNING": [
-        "flowは再起動し、すべての次のtaskが実行されます。",
-        "すべてのブロックされたtaskが実行されます。"
       ],
       "SUCCESS": [
         "このflowはこのtaskが成功したため再起動します。",
         "すべてのブロックされたtaskが実行されます。",
         "すべてのtaskの実行が成功した場合、flowはSUCCESS状態になります。"
       ],
-      "WARNING": [
-        "このflowはWARNINGとしてマークされます。",
-        "次のtasksが実行されます。",
-        "エラーtasksが実行されます。"
+      "RUNNING": [
+        "flowは再起動し、すべての次のtaskが実行されます。",
+        "すべてのブロックされたtaskが実行されます。"
       ]
     },
+    "replay execution title": "実行の再実行",
+    "restart execution title": "実行の再起動",
+    "replay execution description": "これにより、選択された実行に基づいて新しい実行が作成されます。",
+    "replay using": "を使用してリプレイ",
+    "flow revision original": "元のflowリビジョン",
+    "flow revision latest": "最新のflowリビジョン",
+    "flow revision specific": "特定のflowリビジョン",
+    "replay inputs": "入力",
+    "reuse original inputs": "元のinputを再利用",
+    "modify inputs": "入力を変更",
+    "replay inputs new required": "このリビジョンにはinputがあります。入力を求められます。",
+    "replay select taskrun": "再生するタスク実行を選択してください:",
     "change state tooltip": "実行状態を変更",
-    "chart": "チャート",
-    "chart preview": "チャートプレビュー",
-    "chart type": "チャートタイプ",
-    "charts": "チャート",
-    "choice": "選択",
-    "choose file": "ファイルを選択するか、ここにドロップしてください...",
-    "close": "閉じる",
-    "close sidebar": "サイドバーを閉じる",
-    "codeDisabled": "Flowで無効化",
-    "collapse": "折りたたむ",
-    "collapse all": "すべて折りたたむ",
-    "commit_id": "コミット id",
-    "common": {
-      "back": "戻る"
-    },
-    "concurrency": "並行性",
-    "concurrency limits": "同時実行制限",
-    "concurrency_limit": {
-      "dialog_title": "同時実行制限",
-      "warning": "実行中のカウンターを変更すると、並行性が損なわれ、実行が許可された制限を超える可能性があります。"
-    },
-    "conditions": "条件",
-    "configure basic auth": "基本認証を設定",
-    "confirm": "確認",
-    "confirm password": "パスワードを確認",
-    "confirmation": "確認",
-    "context updated date": "コンテキスト更新日",
-    "context updated date tooltip": "トリガーのコンテキストが最後に更新された時刻。これは、実行がトリガーされたとき、終了したとき（ロックが解除されたとき）、または評価後（実行が発生しない場合でも）に発生します。",
-    "contextBar": {
-      "demo": "デモ",
-      "docs": "ドキュメント",
-      "help": "ヘルプ",
-      "issue": "問題",
-      "news": "ニュース",
-      "star": "お気に入りに追加"
-    },
-    "continue backfill": "backfillを続行",
-    "continue backfills": "backfillを続行",
-    "copied": "コピーされました",
-    "copied_logs_to_clipboard": "クリップボードにログをコピーしました。",
-    "copy": "コピー",
-    "copy all logs": "すべてのLogをコピー",
-    "copy logs": "Logsをコピー",
-    "copy url": "URLをコピー",
-    "copy_and_close": "コピーして閉じる",
-    "copy_to_clipboard": "クリップボードにコピー",
-    "copy_value": "Copy value",
-    "create": "作成",
-    "create first task": "最初のtaskを作成",
-    "create_flow": "フローを作成",
-    "created date": "作成日",
-    "creation": "作成",
-    "cron": "Cron（クーロン）",
-    "curl": {
-      "command": "cURLコマンド",
-      "note": "SECRETおよびFILEのinputタイプの場合、コマンドは実際の値に合わせて調整する必要があります。"
-    },
-    "current": "現在",
-    "current execution": "現在の実行",
-    "custom value": "カスタム value",
-    "customize sidebar": "サイドバーをカスタマイズ",
-    "dark_version": "ダークバージョン",
-    "dashboards": {
-      "chart_preview": "チャートのソースコードをクリックしてプレビューを表示",
-      "creation": {
-        "confirmation": "ダッシュボード <code>{title}</code> が作成されました。",
-        "label": "ダッシュボードを作成"
-      },
-      "default": "デフォルトダッシュボード",
-      "deletion": {
-        "confirmation": "<code>{title}</code> ダッシュボードを削除してもよろしいですか？"
-      },
-      "edition": {
-        "chart": "このチャートを編集",
-        "confirmation": "ダッシュボード<code>{title}</code>の変更が保存されました。",
-        "id readonly": "プロパティ `id` は変更できません — 現在、初期値に設定されています。変更したい場合は、新しいダッシュボードを作成し、古いものを削除してください。",
-        "label": "ダッシュボードを編集"
-      },
-      "empty": "表示する結果がありません。",
-      "export": "CSVにエクスポート",
-      "labels": {
-        "plural": "ダッシュボード",
-        "singular": "ダッシュボード"
-      },
-      "no_description": "説明なし",
-      "no_description_hint": "このflowに説明を追加して、何をするかを文書化してください。<br>Markdownがサポートされています。",
-      "others": "その他",
-      "preview": "プレビュー ダッシュボード",
-      "quick_filters": {
-        "all": "すべて",
-        "failed": "失敗",
-        "paused": "一時停止中",
-        "running": "実行中",
-        "success": "成功",
-        "warning": "警告"
-      },
-      "switch": "ダッシュボードを切り替える",
-      "viewAll": "すべて表示"
-    },
-    "data": "データ",
-    "dataFilters": "データフィルター",
-    "data_not_protected": "あなたのデータは保護されていません。失わないようにしてください。<b>無料のセキュリティ機能を有効にするか、有料オプションをお試しください。</b>",
-    "date": "日付",
-    "date count": "{date}に{count}",
-    "date format": "日付形式",
-    "date range count": "{startDate}から{endDate}の間に{count}",
-    "datepicker": {
-      "12hours": "12時間",
-      "15minutes": "15分",
-      "1hour": "1時間",
-      "24hours": "24時間",
-      "30days": "30日間",
-      "365days": "365日間",
-      "48hours": "48時間",
-      "5minutes": "5分",
-      "7days": "7日間",
-      "custom": "カスタム",
-      "dayBeforeYesterday": "一昨日",
-      "duration example": "例：'P1DT1H1M1S'",
-      "error": "無効な期間形式です。ISO 8601期間である必要があります（例：P1DT1H1M1S）",
-      "last12hours": "過去12時間",
-      "last15minutes": "過去15分",
-      "last1hour": "過去1時間",
-      "last24hours": "過去24時間",
-      "last30days": "過去30日間",
-      "last365days": "過去365日間",
-      "last48hours": "過去48時間",
-      "last5minutes": "過去5分",
-      "last7days": "過去7日間",
-      "leave empty for infinite": "無限の期間にするには空白のままにするか、ISO 8601期間を入力してください（例：'P1DT1H1M1S'）",
-      "never": "無期限",
-      "next12hours": "次の12時間",
-      "next15minutes": "次の15分",
-      "next1hour": "次の1時間",
-      "next24hours": "次の24時間",
-      "next30days": "次の30日間",
-      "next365days": "次の365日",
-      "next48hours": "次の48時間",
-      "next5minutes": "次の5分",
-      "next7days": "次の7日間",
-      "previousMonth": "先月",
-      "previousWeek": "先週",
-      "previousYear": "昨年",
-      "short": {
-        "12h": "12時間",
-        "15m": "15分",
-        "1d": "1日",
-        "1h": "1時間",
-        "7d": "7日"
-      },
-      "thisMonth": "今月",
-      "thisMonthSoFar": "今月これまで",
-      "thisWeek": "今週",
-      "thisWeekSoFar": "今週これまで",
-      "thisYear": "今年",
-      "thisYearSoFar": "今年これまで",
-      "today": "今日",
-      "yesterday": "昨日"
-    },
-    "debug": "デバッグ",
-    "default": "デフォルト",
-    "defaultsToNamespaceFile": "デフォルトはnamespaceファイル: <code>{name}</code>",
-    "delete": "削除",
-    "delete backfill": "backfillを削除",
-    "delete backfills": "backfillを削除",
-    "delete confirm": "<code>{name}</code>を削除してもよろしいですか？",
-    "delete execution running": "<div class=\"alert alert-warning mt-2 mb-0\">この実行はまだRUNNINGです。削除しても停止しません。<br />実行を停止するには、実行をkillする必要があります。</div>",
-    "delete logs": "Logsを削除",
-    "delete ok": "削除されました",
-    "delete revision confirm": "リビジョン {revision} を削除してもよろしいですか？",
-    "delete revision error": "エラー: リビジョン {revision} の削除中にエラー {error} が発生しました。",
-    "delete task confirm": "task<code>{taskId}</code>を削除してもよろしいですか？",
-    "delete trigger": "トリガーを削除",
-    "delete trigger confirmation": "トリガー {id} を削除してもよろしいですか？WARNING: トリガーがまだflowでアクティブな場合、削除すると重複した実行が発生する可能性があります。",
-    "delete trigger error": "トリガー {id} の削除エラー",
-    "delete trigger success": "トリガー{id}が正常に削除されました",
-    "delete triggers": "トリガーを削除",
-    "delete_all_logs": "すべてのLogsを削除してもよろしいですか？",
-    "delete_log": "ログを削除してもよろしいですか？",
-    "deleted": "正常に削除されました",
-    "deleted confirm": "<em>{name}</em>は正常に削除されました！",
-    "deleted_label": "削除されました",
-    "demos": {
-      "IAM": {
-        "message": "Kestra Enterprise Editionには、シングルサインオン（SSO）、SCIMディレクトリ同期、ロールベースのアクセス制御（RBAC）を備えた組み込みのIAM機能があり、複数のアイデンティティプロバイダーと統合し、ユーザーおよびサービスアカウントに対して詳細な権限を割り当てることができます。",
-        "title": "IAMを通じてユーザーを管理（SSO、SCIM、RBACを使用）"
-      },
-      "apps": {
-        "message": "Kestra Enterprise Editionのアプリは、プラットフォーム外からKestraのworkflowと連携するカスタムUIを構築することを可能にします。この機能により、workflowをカスタムアプリケーションのバックエンドとして使用でき、技術的でないユーザーがフォームを通じてデータを送信したり、承認待ちのPAUSED状態のworkflowを再開したりすることができます。",
-        "title": "Kestraでカスタムアプリを構築する"
-      },
-      "assets": {
-        "header": "アセットメタデータとオブザーバビリティ",
-        "label": "アセット",
-        "message": "アセットは、観測性、系譜、および所有権のメタデータを接続し、プラットフォームチームが迅速にトラブルシューティングを行い、自信を持ってデプロイできるようにします。",
-        "title": "すべてのデータセット、サービス、および依存関係を表示します。"
-      },
-      "audit-logs": {
-        "message": "Kestra Enterprise Editionは、すべてのアクティビティを堅牢で不変の記録としてログに記録し、変更の追跡、コンプライアンスの維持、問題のトラブルシューティングを容易にします。",
-        "title": "監査Logで変更を追跡"
-      },
-      "blueprints": {
-        "message": "Kestra Enterprise Editionでは、組織専用のカスタムBlueprintを作成できます。これらをベストプラクティスのテンプレートとして使用し、チーム内で一般的に使用されるworkflowを共有、集中化、文書化することができます。",
-        "title": "カスタムBlueprintの追加"
-      },
-      "contact_sales": "営業に問い合わせる",
-      "enterprise_edition": "エンタープライズエディション",
-      "get_a_demo_button": "デモを取得",
-      "instance": {
-        "message": "Kestra Enterprise Editionは、プラットフォームの健康状態を観察し、Workers、Schedulers、Executorsなどのすべてのサービスの稼働時間メトリクスを追跡するための運用ダッシュボードを提供します。同じページから、計画されたダウンタイムについてユーザーに通知するためのアナウンスを作成することもでき、アップグレードを実行するためにすべてのサービスとワークフローの実行を一時的にPAUSED状態にするメンテナンスモードに入ることもできます。",
-        "title": "インスタンス全体のインフラストラクチャを管理する"
-      },
-      "namespace": {
-        "assets": {
-          "message": "Kestra Enterprise Editionでは、Assetsはワークフローがやり取りするリソースのライブインベントリを保持します。これらのリソースには、データベーステーブル、仮想マシン、ファイル、または使用する外部システムが含まれます。",
-          "title": "資産管理の集中化"
-        },
-        "audit-logs": {
-          "message": "Kestra Enterprise Editionでは、namespaceレベルの監査Logを詳細な差分とともに表示でき、すべてのリソースにわたって誰が何をいつ変更したかの履歴を明確に確認できます。",
-          "title": "すべての変更を一箇所で追跡"
-        },
-        "edit": {
-          "message": "Kestra Enterprise Editionでは、namespaceはシークレット、変数、プラグインのデフォルトの高度な分離とガバナンスを提供します。管理者は、カスタムシークレットマネージャー、分離されたストレージバックエンド、専用のworkerグループ、および詳細な権限をnamespaceごとに設定できます。これにより、シークレット、変数、およびプラグインの設定が異なるチームやプロジェクト間で安全かつ簡単に管理されることが保証されます。",
-          "title": "名前空間管理をアップグレードする"
-        },
-        "history": {
-          "message": "Kestra Enterprise Editionでは、Namespacesのリビジョン履歴を管理できます。",
-          "title": "一箇所でリビジョン履歴を管理"
-        },
-        "plugin-defaults": {
-          "message": "Kestra Enterprise Editionでは、namespace固有のプラグインデフォルトを設定でき、各flowでの重複した設定の必要性を減らします。この中央プラグインガバナンスは、一貫した設定を強制し、秘密情報や変数の安全な参照を可能にし、ワークフローのメンテナンスを簡素化します。",
-          "title": "プラグインのデフォルトで設定を標準化する"
-        },
-        "secrets": {
-          "message": "Kestra Enterprise Editionでは、namespaceレベルでシークレットを保存および管理することができ、リスクを最小限に抑え、各チームの認証情報を分離して保持します。ネストされた階層のおかげで、親namespaceで認証情報を設定すると、すべての子namespaceに継承されます。専用のシークレットマネージャーのサポートと詳細なnamespaceレベルの権限設定により、セキュリティとコンプライアンスがさらに強化されます。",
-          "title": "秘密を安全に管理する方法"
-        },
-        "variables": {
-          "message": "Kestra Enterprise Editionでは、namespaceレベルの変数を定義および管理することで、flow全体での繰り返しの設定を排除できます。これらの変数は一貫性を確保し、設定の更新を簡素化し、どのtaskやtriggerからも簡単に参照できるため、よりクリーンで保守しやすいワークフローを実現します。",
-          "title": "変数を中央で管理する"
-        }
-      },
-      "quotas": {
-        "message": "Kestra Enterprise Editionでは、フローにクォータを定義して、時間枠内の同時実行数または総実行数を制限できます。クォータは、共有インフラストラクチャの保護、SLAの適用、および過剰なリソースを消費する暴走ワークフローの防止に役立ちます。",
-        "title": "フローの実行クォータを設定する"
-      },
-      "secrets": {
-        "add_env": {
-          "first": "<a href=\"https://kestra.io/docs/how-to-guides/secrets?utm_source=app&utm_medium=referral&utm_campaign=secrets-inlinedoc#using-secrets-in-kestra\" target=\"_blank\">シークレットの値をBase64でエンコード</a>",
-          "intro": "新しいSecretを作成するには：",
-          "second": "`<strong>SECRET_{'{MY_SECRET_KEY}'}</strong>`という名前の環境変数を上記の値で追加してください。",
-          "third": "Kestraインスタンスを再起動する"
-        },
-        "detected_env": "インスタンス開始時に識別されたシークレットタイプの環境変数は次のとおりです:",
-        "empty_env": "まだ環境にSecretsがありません。",
-        "message": "エンタープライズエディション (EE) では、UIで直接シークレットを追加、編集、または削除できます。インスタンスの再起動は不要です。シークレットをnamespaceごとに整理し、詳細なRBAC権限を設定し、親namespaceから子namespaceに継承します。EEは、HashiCorp Vault、AWS Secrets Manager、Azure Key Vault、Google Secret Manager、Elasticsearchなどのシークレットマネージャーと統合します。namespace、テナント、またはインスタンスごとに専用のバックエンドを設定して、チーム間でシークレットを分離するか、外部のvaultに保存された読み取り専用のシークレットを有効にします。シークレットは、保存時および転送時に暗号化されたままです。オプションのキャッシュによりAPIコールが削減され、監査証跡がすべてのアクセスをログに記録します。",
-        "title": "シークレット管理をアップグレード"
-      },
-      "tenants": {
-        "message": "Kestra Enterprise Editionはマルチテナンシーをサポートしており、異なるチームやプロジェクトごとに完全に分離された環境を提供します。それぞれの環境には、専用のworkerグループやシークレット、内部ストレージバックエンドなどのリソースが含まれます。",
-        "title": "隔離されたTenantでWorkflowを管理する"
-      },
-      "tests": {
-        "header": "フローの単体テスト",
-        "label": "テスト",
-        "message": "フローのロジックを個別に検証し、リグレッションを早期に検出し、変更や成長に伴う自動化に自信を持ち続けましょう。",
-        "title": "すべての変更で信頼性を確保"
-      },
-      "watch_the_video": "ビデオを見る"
-    },
-    "density": "Density",
-    "density_compact": "Compact",
-    "density_expanded": "Expanded",
-    "density_normal": "Normal",
-    "dependencies": "依存関係",
-    "dependencies delete flow": "このflowには依存関係があります。削除すると、依存関係が実行されなくなります。<br /><br /> 影響を受けるflowのリストはこちらです:",
-    "dependencies loaded": "依存関係が読み込まれました",
-    "dependencies missing acls": "このflowには権限がありません",
-    "dependency": {
-      "controls": {
-        "clear_selection": "選択をクリア",
-        "fit_view": "画面に合わせる",
-        "zoom_in": "ズームイン",
-        "zoom_out": "ズームアウト"
-      },
-      "search": {
-        "flow": {
-          "display": "フローの依存関係を含める"
-        },
-        "namespace": {
-          "no_namespace": "namespaceなし",
-          "select": "namespaceを選択"
-        },
-        "no_results": "{term} に対する結果が見つかりませんでした",
-        "placeholders": {
-          "asset": "アセット、flow、またはnamespaceで検索...",
-          "default": "flow または namespace で検索..."
-        }
-      }
-    },
-    "dependency task": "Task {taskId}は他のtaskの依存関係です",
-    "description": "説明",
-    "details": "詳細",
-    "disable": "無効化",
-    "disabled": "無効",
-    "disabled flow desc": "このFlowは無効です。実行するには有効にしてください。",
-    "disabled flow title": "このFlowは無効です",
-    "discard changes confirmation": "保存されていない変更があります。本当に破棄しますか？",
-    "discard execution confirmation": "未保存のinputがあります。このexecutionを破棄してもよろしいですか？",
-    "display direct sub tasks count": "直接のサブタスク数を表示",
-    "display flow {id} executions": "Flow {id}の実行を表示",
-    "display metric for specific task": "特定のTaskのメトリクスを表示",
-    "display output for specific task": "特定のTaskの出力を表示",
-    "display topology for flow": "Flowのトポロジーを表示",
-    "display_settings": "Display settings",
-    "docs": "ドキュメント",
-    "documentation": {
-      "documentation": "ドキュメント",
-      "github": "GitHub issueを開く"
-    },
-    "documentationMenu": "ドキュメントメニュー",
-    "done": "完了",
-    "down trend": "減少",
-    "download": "ダウンロード",
-    "download logs": "Logsをダウンロード",
-    "download_logos": "ロゴパックをダウンロード",
-    "download_logs_description": "Choose which logs to export. Filters default to your current view.",
-    "draft": "下書き",
-    "draft_available": "エディターでドラフト変更が利用可能です",
-    "draft_flow_warning": "この flow リビジョンは下書きです。実行はこの下書きリビジョンに対して行われ、flow の定義が無効な場合はすぐに失敗する可能性があります。",
-    "drill down preview": "プレビュー",
-    "drop items here": "ここにアイテムをドロップしてください",
-    "duplicate-pair": "{label} \"{key}\" は重複しています。最初のキーは無視されます。",
-    "duration": "期間",
-    "dynamic": "動的",
-    "each value": "繰り返し値",
-    "edit": "編集",
-    "edit flow": "Flowを編集",
-    "editor": "エディタ",
-    "editor_shortcuts": {
-      "command_palette": "コマンドパレットを表示",
-      "comment": "コメント",
-      "comment_uncomment": "コメント/コメント解除",
-      "decrease_fontsize": "エディタのフォントサイズを小さくする",
-      "duplicate_cursor": "カーソルを複製",
-      "execute_flow": "フローを実行",
-      "fold_unfold": "コードを折りたたむ/展開する",
-      "increase_fontsize": "エディタのフォントサイズを大きくする",
-      "label": "キーボードショートカット",
-      "move_line": "行を移動",
-      "reset_fontsize": "エディタのフォントサイズをリセット",
-      "save_flow": "フローを保存",
-      "toggle_ai_agent": "AIエージェントを切り替える",
-      "trigger_autocompletion": "オートコンプリートをトリガー",
-      "uncomment": "コメント解除"
-    },
-    "ee-tooltip": {
-      "button": "お問い合わせ",
-      "features-blocked": "この機能はEnterprise Editionが必要です。"
-    },
-    "email": "メール",
-    "email length constraint": "メールは256文字を超えてはいけません",
-    "empty": {
-      "announcements": {
-        "content": "お知らせを使用すると、ユーザーに変更を通知したり、計画されたメンテナンスのダウンタイムについて知らせたりすることができます。お知らせの種類、表示する日付範囲を選択し、お知らせメッセージを作成してください。",
-        "title": "お知らせはまだありません！"
-      },
-      "apiTokens": {
-        "content": "APIトークンは、Kestra APIへのプログラムによるアクセスを許可したいときに使用されます。",
-        "title": "APIトークンを管理する"
-      },
-      "apps": {
-        "content": "外部からKestraと連携するアプリを作成し始めましょう。",
-        "title": "まだアプリがありません！"
-      },
-      "assets": {
-        "content": "データ資産、サービス、インフラストラクチャを追跡および管理するためのアセットを追加します。",
-        "title": "まだアセットがありません！"
-      },
-      "concurrency_executions": {
-        "content": "<strong><a href=\"https://kestra.io/docs/workflow-components/execution?utm_source=app&utm_medium=referral&utm_campaign=concurrency-inlinedoc\" target=\"_blank\">Executions</a></strong> についての詳細は、ドキュメントをご覧ください。",
-        "title": "このFlowには進行中の実行はありません。"
-      },
-      "concurrency_limit": {
-        "content": "<strong><a href=\"https://kestra.io/docs/workflow-components/concurrency?utm_source=app&utm_medium=referral&utm_campaign=concurrency-inlinedoc\" target=\"_blank\">同時実行制限</a></strong>についての詳細は、ドキュメントをご覧ください。",
-        "title": "このFlowには制限が設定されていません。"
-      },
-      "concurrency_limits": {
-        "content": "詳細については、<strong><a href=\"https://kestra.io/docs/workflow-components/concurrency?utm_source=app&utm_medium=referral&utm_campaign=concurrency-inlinedoc\" target=\"_blank\">Concurrency Limits</a></strong>に関するドキュメントをご覧ください。",
-        "title": "同時実行制限は設定されていません。"
-      },
-      "dependencies": {
-        "ASSET": {
-          "content": "このアセットは、flowや他のアセットとの上流または下流の依存関係がありません。",
-          "title": "現在、依存関係はありません。"
-        },
-        "EXECUTION": {
-          "content": "<a href=\"https://kestra.io/docs/ui/executions?utm_source=app&utm_medium=referral&utm_campaign=dependencies-inlinedoc#dependencies\" target=\"_blank\">実行の依存関係</a>についての詳細は、ドキュメントをご覧ください。",
-          "title": "現在、依存関係はありません。"
-        },
-        "FLOW": {
-          "content": "<a href=\"https://kestra.io/docs/ui/flows?utm_source=app&utm_medium=referral&utm_campaign=dependencies-inlinedoc#dependencies\" target=\"_blank\">Flow Dependencies</a> についての詳細は、ドキュメントをご覧ください。",
-          "title": "現在、依存関係はありません。"
-        },
-        "NAMESPACE": {
-          "content": "<a href=\"https://kestra.io/docs/ui/namespaces?utm_source=app&utm_medium=referral&utm_campaign=dependencies-inlinedoc#dependencies\" target=\"_blank\">Namespace Dependencies</a> についての詳細は、ドキュメントをご覧ください。",
-          "title": "現在、依存関係はありません。"
-        }
-      },
-      "groups": {
-        "content": "グループを使用すると、ユーザーをまとめてバンドルし、テナント全体で権限とロールバインディングを一括管理できます。",
-        "title": "まだグループがありません！"
-      },
-      "kill_switches": {
-        "content": "キルスイッチ機能は、問題のある実行を停止するためのUIベースのメカニズムを提供します。これは、CLI専用の<code>--skip-executions</code>および<code>--skip-flows</code>コマンドを包括的な管理インターフェースに置き換えます。",
-        "title": "まだKill Switchがありません！"
-      },
-      "mcpToolFlows": {
-        "content": "<code>McpToolTrigger</code>を追加して、flowをMCPツールとして公開します。<strong><a href=\"https://kestra.io/docs/workflow-components/triggers/mcp-tool-trigger?utm_source=app&utm_medium=referral&utm_campaign=mcp-tool-trigger-inlinedoc\" target=\"_blank\">MCP Tool Trigger</a></strong>についての詳細は、ドキュメントをご覧ください。",
-        "title": "このサーバーにはまだツールflowが登録されていません。"
-      },
-      "namespaceFiles": {
-        "content": "namespaceファイルは、このnamespaceのプロジェクトフォルダのように機能します。Python、SQL、dbt、Terraformのコードを保存し、flow内の任意のファイルを次の方法で参照できます",
-        "title": "このnamespaceにはまだファイルがありません"
-      },
-      "panels": {
-        "content": "すべてのパネルを閉じました。  \n続行するには上のタブを選択してください。",
-        "title": "パネルが開いていません"
-      },
-      "pluginDefaults": {
-        "content": "プラグインデフォルトを使用すると、プラグインの設定を一元管理し、namespace内のすべてのflowと共有できます。",
-        "title": "プラグインのデフォルトがまだありません！"
-      },
-      "plugins": {
-        "content": "詳細については、<strong><a href=\"https://kestra.io/docs/workflow-components/plugin-defaults?utm_source=app&utm_medium=referral&utm_campaign=plugin-default-inlinedoc\" target=\"_blank\">Concurrency Limits</a></strong>に関するドキュメントをご覧ください。",
-        "title": "このNamespaceにはプラグインのデフォルトが設定されていません。"
-      },
-      "testSuites": {
-        "content": "テストスイートを作成して、flowをテストし始めましょう。",
-        "title": "テストスイートがまだありません！"
-      },
-      "triggers": {
-        "content": "<strong><a href=\"https://kestra.io/docs/workflow-components/triggers?utm_source=app&utm_medium=referral&utm_campaign=trigger-inlinedoc\" target=\"_blank\">Triggers</a></strong> についての詳細は、ドキュメントをご覧ください。",
-        "title": "あなたのflowにはTriggerがありません。"
-      },
-      "variables": {
-        "content": "フロー間で設定を共有するためにkv storeにkey-valueペアを追加します。子namespaceはそれらを自動的に継承し、任意のvalueを参照することができます。",
-        "title": "変数はまだありません"
-      },
-      "versionPlugin": {
-        "content": "ここでは、Kestraインスタンスにインストールされているすべてのプラグインを管理できます。新しくインストールされたプラグインは、インスタンスの設定によっては、すべてのKestraサービスで直ちに利用可能にならない場合があります。",
-        "title": "まだバージョン管理されたプラグインがありません！"
-      },
-      "workerRegistrationTokens": {
-        "content": "登録トークンを使用すると、リモートworkerが安全に認証し、Kestraインスタンスに登録できます。トークンを作成し、それを使用して新しいworkerをこのクラスターに接続します。",
-        "title": "登録トークンがまだありません！"
-      }
-    },
-    "empty search": "検索結果がありません",
-    "enable": "有効化",
-    "enable concurrency": "同時実行を有効にする",
-    "enabled": "有効",
-    "encoding": "エンコーディング",
-    "end date": "終了日",
-    "end datetime": "終了日時",
-    "environment": "環境",
-    "environment color setting": "環境色",
-    "environment name setting": "環境名",
-    "error": "エラー",
-    "error detected": "エラーが検出されました。",
-    "error in editor": "エディタにエラーが見つかりました",
-    "errorLogs": "エラーログ",
-    "errors": {
-      "401": {
-        "content": "このページにアクセスするには認証が必要です。",
-        "title": "認証されていません"
-      },
-      "403": {
-        "content": "このページにアクセスするための権限がありません。",
-        "title": "アクセス拒否"
-      },
-      "404": {
-        "content": "リクエストされたURLはこのサーバー上に見つかりませんでした。<br />これが私たちの知っているすべてです。",
-        "flow or execution": "探しているflowまたは実行は存在しません。",
-        "title": "ページが見つかりません"
-      }
-    },
+    "change execution state confirm": "実行<code>{id}</code>の状態を変更してもよろしいですか？",
+    "change execution state done": "実行状態が更新されました",
+    "mark as": "<code>{status}</code>としてマーク",
+    "unqueue as": "<code>{status}</code>としてキューから外す",
+    "kill": "キル",
+    "kill parents and subflow": "現在のflowとsubflowを終了",
+    "kill only parents": "現在のもののみを終了",
+    "killed confirm": "実行<code>{id}</code>をキルしてもよろしいですか？",
+    "killed done": "実行はキルのためにキューに入れられました",
+    "resume": "再開",
+    "resumed title": "実行<code>{id}</code>を再開",
+    "resumed confirm": "実行<code>{id}</code>を再開してもよろしいですか？",
+    "resumed done": "実行が再開されました",
+    "resume from breakpoint title": "ブレークポイントから実行 <code>{id}</code> を再開します",
+    "resume from breakpoint done": "ブレークポイントから実行が再開されました",
+    "breakpoints": "ブレークポイント",
+    "pause": "一時停止",
+    "pause title": "実行を一時停止 <code>{id}</code>。<br/>現在実行中のタスクは引き続き処理されることに注意してください。実行は手動で再開する必要があります。",
+    "pause confirm": "実行 <code>{id}</code> を一時停止してもよろしいですか？",
+    "pause done": "実行がPAUSEDされています",
+    "unqueue": "キューから削除",
+    "unqueue title": "実行 <code>{id}</code> をキューから外します。<br/>ただし、flowの並行性制限には従わないため、許可された制限を超えて実行が行われる可能性があります。",
+    "unqueue title multiple": "<code>{count}</code>件の実行をキューから外してもよろしいですか？<br/><br/>flowの並行性制限を守らないため、許可された制限を超えて実行される可能性があります。",
+    "unqueue confirm": "実行 <code>{id}</code> をキューから外してもよろしいですか？",
+    "unqueue done": "実行はキューから外されました",
+    "force run": "強制実行",
+    "force run title": "実行 <code>{id}</code> を強制的に実行します。",
+    "force run tooltip": "実行を強制的に開始します。これにより、タスクの実行が重複する可能性があります。可能であれば、別のアクションを使用してください。",
+    "force run confirm": "実行 <code>{id}</code> を強制的に実行しますか？<br/><br/>WARNING: 実行を強制的に実行することは保証されておらず、重複したタスクの実行が発生する可能性があります。<br/><br/>以下の遷移が行われます:<br/><ul><li>CREATED タスクは RUNNING 状態に移行します。</li><li>RUNNING タスクは再提出されます。</li><li>QUEUED タスクはキューから外されます。</li><li>PAUSED タスクは再開されます。</li></ul>",
+    "force run done": "実行は強制的にRUNNINGです。",
+    "toggle output": "出力を切り替え",
+    "metrics": "メトリクス",
+    "no data current task": "現在のタスクに利用可能なデータがありません。",
+    "no metrics available": "このタスク実行には記録されたメトリクスがありません。",
+    "no outputs available": "このタスク実行には利用可能なoutputがありません。",
+    "outputs": "出力",
+    "flow_outputs": "フロー出力",
+    "no_flow_outputs": "出力は利用できません。",
+    "output": "Output",
     "eval": {
-      "expression": "式",
-      "preview": "プレビュー",
-      "render": "式をレンダリング",
       "title": "デバッグ式",
-      "tooltip": "任意のPebble式をレンダリングし、実行コンテキストを検査します。"
+      "render": "式をレンダリング",
+      "tooltip": "任意のPebble式をレンダリングし、実行コンテキストを検査します。",
+      "preview": "プレビュー",
+      "expression": "式"
     },
-    "evaluation lock date": "評価ロック日",
-    "execute": "実行",
-    "execute backfill": "backfillを実行",
-    "execute flow behaviour": "Flowを実行",
-    "execute flow now ?": "このFlowを実行しますか？",
-    "execute the flow": "Flow <code>{id}</code>を実行",
-    "execution": "Execution",
-    "execution already finished": "実行<code>{executionId}</code>はすでに終了しています",
-    "execution id": "実行 Id",
-    "execution labels": "実行ラベル",
-    "execution not found": "{executionId} の実行が見つかりません。",
-    "execution not in state FAILED": "実行<code>{executionId}</code>はFAILED状態ではありません",
-    "execution not in state PAUSED": "実行<code>{executionId}</code>はPAUSED状態ではありません",
-    "execution replay": "この実行は次のリプレイです",
-    "execution replayed": "この実行は再実行されました。",
-    "execution restarted": "この実行は{nbRestart}回再開されました。",
+    "attempt": "試行",
+    "toggle output display": "出力表示を切り替え",
+    "name": "名前",
+    "key": "Key",
+    "value": "Value",
+    "each value": "繰り返し値",
+    "current execution": "現在の実行",
+    "parent execution": "親実行",
+    "original execution": "元の実行",
+    "automatic refresh": "自動更新",
+    "toggle periodic refresh each x seconds": "{interval}秒ごとに定期的な更新を切り替える",
+    "trigger refresh": "更新をトリガー",
+    "add-trigger-in-editor": "最初にFlowにTriggerを追加してください",
+    "refresh": "更新",
+    "filter by status": "{status}ステータスで実行をフィルタリング",
+    "topology-graph": {
+      "graph-orientation": "グラフの向き",
+      "zoom-in": "ズームイン",
+      "zoom-out": "ズームアウト",
+      "zoom-reset": "ズームリセット",
+      "zoom-fit": "フィット",
+      "invalid": "グラフエラー",
+      "invalid_description": "グラフの読み込み中にエラーが発生しました。ソースコードにエラーがないか確認してください。"
+    },
+    "show task logs": "Task Logsを表示",
+    "show task condition": "タスク条件を表示",
+    "show task outputs": "Task出力を表示",
+    "show task source": "Taskソースを表示",
+    "specific task": "特定のTask",
+    "display output for specific task": "特定のTaskの出力を表示",
+    "display metric for specific task": "特定のTaskのメトリクスを表示",
+    "display direct sub tasks count": "直接のサブタスク数を表示",
+    "stream": "ストリーム",
     "execution statistics": "実行統計",
-    "execution-include-non-terminated": "終了していない実行を含めますか？",
-    "execution-warn-deleting-still-running": "この操作をキャンセルし、進行中のexecutionをまず停止することを強くお勧めします。未終了のexecutionを削除すると、concurrencyの問題、flow依存関係管理の不整合、インスタンス上のゾンビプロセスを引き起こし、システムパフォーマンスを低下させる可能性があります。削除を進める前に、これらのリスクを十分に理解してください。",
-    "execution-warn-title": "重要なWarning!",
-    "execution_deletion": {
-      "logs": "ログを削除",
-      "metrics": "メトリクスを削除",
-      "storage": "内部ストレージファイルを削除"
-    },
-    "execution_failed": "実行が失敗しました！",
-    "execution_guide": {
-      "get_started": {
-        "text": "クイックスタートガイドに従ってKestraをインストールし、最初のworkflowの構築を始めましょう。",
-        "title": "はじめに ⚡"
-      },
-      "namespaces": {
-        "text": "namespaceは、flowとそのコンポーネントの論理的なグループ化です。",
-        "title": "名前空間について"
-      },
-      "videos_tutorials": {
-        "text": "ビデオチュートリアルで始めましょう。",
-        "title": "ビデオチュートリアル"
-      },
-      "workflow_components": {
-        "text": "Kestraワークフローの主なオーケストレーションコンポーネントを知る。",
-        "title": "ワークフローコンポーネント"
-      }
-    },
-    "execution_started": "実行が開始されました！",
-    "execution_starts_progress": "実行が開始されると、ここに進行状況の更新が表示されます。",
-    "execution_status": "実行は:",
-    "executions": "実行",
-    "executions deleted": "<code>{executionCount}</code>件の実行が削除されました",
+    "stats": "統計",
+    "concurrency limits": "同時実行制限",
+    "system overview": "システム概要",
+    "usage": "使用",
+    "namespaces": "Namespaces",
+    "tasks": "Tasks",
     "executions duration (in minutes)": "総実行時間（分単位）",
-    "executions force run": "<code>{executionCount}</code> 回の実行が強制的に実行されました",
-    "executions killed": "<code>{executionCount}</code>件の実行がkillされました",
-    "executions paused": "<code>{executionCount}</code> 回の実行がPAUSEDされました",
-    "executions replayed": "<code>{executionCount}</code>件の実行が再実行されました",
-    "executions restarted": "<code>{executionCount}</code>件の実行が再起動されました",
-    "executions resumed": "<code>{executionCount}</code>件の実行が再開されました",
-    "executions state changed": "<code>{executionCount}</code> 回の実行の状態が変更されました",
-    "executions unqueue": "<code>{executionCount}</code> 回の実行がキューから外されました",
-    "expand": "展開",
-    "expand all": "すべて展開",
-    "expand dependencies": "依存関係を展開",
-    "expand error": "失敗したtaskのみ展開",
-    "expand_by_default": "Expand structured logs by default",
-    "expiration": "有効期限",
-    "expiration date": "有効期限",
-    "export": "エクスポート",
-    "export all flows": "すべてのflowをエクスポート",
-    "export all templates": "すべてのテンプレートをエクスポート",
-    "export_as": ".{format}としてエクスポート",
-    "export_csv": "CSVとしてエクスポート",
-    "exports": "エクスポート",
-    "failed to export plugin defaults": "プラグインのデフォルトのエクスポートに失敗しました",
-    "failed to import plugin defaults": "プラグインのデフォルトのインポートに失敗しました",
-    "failed to render pdf": "PDFプレビューのレンダリングに失敗しました",
-    "false": "False",
-    "feeds": {
-      "heading": "すべてのKestraに関すること。",
-      "subheading": "最新の更新情報、ガイド、ストーリー",
-      "title": "Kestraの新機能"
+    "last 48 hours": "過去48時間",
+    "configure basic auth": "基本認証を設定",
+    "email": "メール",
+    "password": "パスワード",
+    "confirm password": "パスワードを確認",
+    "email length constraint": "メールは256文字を超えてはいけません",
+    "password length constraint": "パスワードは256文字を超えてはいけません",
+    "password empty constraint": "ユーザー名またはパスワードが間違っています",
+    "passwords do not match": "パスワードが一致しません",
+    "avg duration": "平均実行時間",
+    "neutral trend": "安定",
+    "up trend": "増加",
+    "down trend": "減少",
+    "update aborted": "更新が中止されました",
+    "invalid flow": "無効なFlow",
+    "invalid yaml": "無効なYAML",
+    "inputs": "Inputs",
+    "no_inputs": "入力が利用できません。",
+    "input": "Input",
+    "variables": "変数",
+    "variable_explorer": {
+      "title": "入力/出力",
+      "search_placeholder": "Key または value を検索...",
+      "tasks_outputs": "Tasks outputs",
+      "tree": "ツリー",
+      "raw_json": "Raw JSON",
+      "select_prompt": "value を確認する変数を選択してください。",
+      "empty": "この実行に利用可能な変数はありません。",
+      "one_key": "\\{ 1 key \\}",
+      "n_keys": "\\{ {count} keys \\}",
+      "one_item": "[ 1 件 ]",
+      "n_items": "[ {count} 件 ]"
     },
-    "file preview truncated": "表示されたコンテンツが切り捨てられました",
-    "file unavailable": "ファイルが利用できません",
-    "file unavailable description": "このファイルは利用できなくなりました — 削除されたか、有効期限が切れた可能性があります。",
-    "fileTypeNotAllowed": "ファイルタイプが許可されていません。許可されているタイプ: {types}",
     "file_preview": {
       "big_file_warning": "このファイルのサイズは{size}です。読み込みに時間がかかり、ブラウザがブロックされる可能性があります。それでも読み込みますか？",
       "load_anyway": "読み込みを続行"
     },
-    "files": "ファイル",
-    "filter by log level": "Logレベルでフィルター",
-    "filter by status": "{status}ステータスで実行をフィルタリング",
-    "filter by this value": "Filter by this value",
-    "filter_for": "Filter for",
-    "filter_out": "Filter out",
-    "filters": {
-      "comparators": {
-        "between": "間",
-        "contains": "含む",
-        "ends_with": "で終了します",
-        "greater_than": "より大きい",
-        "greater_than_or_equal_to": "以上",
-        "in": "内",
-        "is": "です",
-        "is_not": "ではありません",
-        "is_one_of": "のいずれか",
-        "less_than": "未満",
-        "less_than_or_equal_to": "以下以下",
-        "not_contains": "含まれていない",
-        "not_in": "にない",
-        "starts_with": "で始まる"
-      },
-      "empty": "データがありません。",
-      "format": "「key:value」としてパラメータを入力してください。",
-      "label": "フィルターを選択",
-      "options": {
-        "absolute_date": "絶対日付",
-        "action": "アクション",
-        "aggregation": "集計",
-        "child": "子",
-        "details": "詳細",
-        "endDate": "終了日",
-        "flow": "フロー",
-        "labels": "ラベル",
-        "level": "ログレベル",
-        "metric": "メトリック",
-        "namespace": "Namespace（ネームスペース）",
-        "permission": "許可",
-        "relative_date": "相対日付",
-        "scope": "スコープ",
-        "service_type": "タイプ",
-        "startDate": "開始日",
-        "state": "状態",
-        "status": "ステータス",
-        "task": "タスク",
-        "text": "申し訳ありませんが、翻訳するためのテキストが提供されていないようです。翻訳が必要なテキストをもう一度送信してください。",
-        "type": "タイプ",
-        "user": "ユーザー"
-      },
-      "save": {
-        "dialog": {
-          "confirmation": "検索条件 <code>{name}</code>",
-          "heading": "現在の検索を保存",
-          "hint": "この検索条件にどのようなラベルを付けますか？",
-          "placeholder": "ラベル"
-        },
-        "empty": "検索をまだ保存していません。",
-        "label": "保存済み検索",
-        "name_already_used": "ラベルはすでに使用されています。",
-        "remove": "削除",
-        "tooltip": "空の検索条件を保存することはできません。"
-      },
-      "settings": {
-        "label": "ページ設定",
-        "show_chart": "メインチャートを表示"
-      },
-      "text_search": "このテキストを検索"
-    },
-    "fix_with_ai": "AIで修正",
-    "flow": "Flow",
-    "flow already exists": "Flowはすでに存在します",
-    "flow already exists message": "namespace <code>{namespace}</code> に flow <code>{id}</code> が既に存在します。新しいリビジョンを作成しますか？",
-    "flow creation": "Flow作成",
-    "flow creation denied in namespace": "`{namespace}`でflowを作成する権限がありません。",
-    "flow delete": "<code>{flowCount}</code>件のflowを削除してもよろしいですか？",
-    "flow deleted, you can restore it": "Flowは削除されており、これは読み取り専用ビューです。復元することは可能です。",
-    "flow disable": "<code>{flowCount}</code>件のflowを無効化してもよろしいですか？",
-    "flow enable": "<code>{flowCount}</code>件のflowを有効化してもよろしいですか？",
-    "flow export": "<code>{flowCount}</code>件のflowをエクスポートしてもよろしいですか？",
-    "flow must have id and namespace": "Flowにはidとnamespaceが必要です。",
-    "flow must not be empty": "フローは空であってはなりません",
-    "flow not imported": "一部のflowをインポートできませんでした",
-    "flow revision latest": "最新のflowリビジョン",
-    "flow revision original": "元のflowリビジョン",
-    "flow revision specific": "特定のflowリビジョン",
-    "flow source not found": "フローソースが見つかりません",
-    "flow-dependencies": "依存関係",
-    "flow-no-dependencies": "あなたのflowには依存関係がありません",
-    "flow_editor_stats": {
-      "apps": {
-        "suffix": "アプリケーション",
-        "tooltip": "このflowを使用しているアプリを表示"
-      },
-      "dependencies": {
-        "suffix": "依存関係",
-        "tooltip": "フローの依存関係を表示"
-      },
-      "errors": {
-        "label": "{count} エラー"
-      },
-      "revisions": {
-        "suffix": "リビジョン",
-        "tooltip": "フローのリビジョンを表示"
-      },
-      "tests": {
-        "suffix": "テスト",
-        "tooltip": "フローテストを表示"
-      }
-    },
-    "flow_export": "フローをエクスポート",
-    "flow_only": "Flowタブでのみ利用可能です。",
-    "flow_outputs": "フロー出力",
-    "flows": "Flows",
-    "flows deleted": "<code>{count}</code>件のflowが削除されました",
-    "flows disabled": "<code>{count}</code>件のflowが無効化されました",
-    "flows enabled": "<code>{count}</code>件のflowが有効化されました",
-    "flows exported": "<code>{count}</code> Flow(s) エクスポート済み",
-    "flows imported": "フローがインポートされました",
-    "focus task": "任意の要素をクリックしてそのドキュメントを表示します。",
-    "fold_all_multi_lines": "すべての複数行を折りたたむ",
-    "font size": "Font size",
-    "for flow": "フロー用",
-    "forbidden system labels": "system label として使用できるのは system.correlationId のみです",
-    "force run": "強制実行",
-    "force run confirm": "実行 <code>{id}</code> を強制的に実行しますか？<br/><br/>WARNING: 実行を強制的に実行することは保証されておらず、重複したタスクの実行が発生する可能性があります。<br/><br/>以下の遷移が行われます:<br/><ul><li>CREATED タスクは RUNNING 状態に移行します。</li><li>RUNNING タスクは再提出されます。</li><li>QUEUED タスクはキューから外されます。</li><li>PAUSED タスクは再開されます。</li></ul>",
-    "force run done": "実行は強制的にRUNNINGです。",
-    "force run title": "実行 <code>{id}</code> を強制的に実行します。",
-    "force run tooltip": "実行を強制的に開始します。これにより、タスクの実行が重複する可能性があります。可能であれば、別のアクションを使用してください。",
-    "form": "フォーム",
-    "form error": "フォームエラー",
-    "from": "から",
-    "gantt": "ガント",
-    "gantt_no_tasks_executed": "このExecutionは、タスクを実行せずに終了しました。  \n理由を確認するには、概要とLogsをチェックしてください。",
-    "gantt_no_tasks_match_filters": "検索、状態、またはログレベルのフィルターを調整してみてください。",
-    "gantt_no_tasks_match_filters_title": "選択したフィルターに一致するタスクがありません。",
-    "healthcheck date": "HealthCheck日",
-    "hide task documentation": "taskのドキュメントを非表示",
-    "home": "ホーム",
-    "hostname": "ホスト名",
-    "iam": "IAM",
-    "id": "Id",
-    "import": "インポート",
-    "in-our-documentation": "ドキュメント内で。",
-    "informative notice": "注記",
-    "input": "Input",
-    "inputs": "Inputs",
-    "instance": "インスタンス",
-    "invalid bulk delete": "実行を削除できませんでした",
-    "invalid bulk force run": "実行を強制的に開始できませんでした",
-    "invalid bulk kill": "実行をkillできませんでした",
-    "invalid bulk pause": "実行を一時停止できませんでした",
-    "invalid bulk replay": "実行を再実行できませんでした",
-    "invalid bulk restart": "実行を再起動できませんでした",
-    "invalid bulk resume": "実行を再開できませんでした",
-    "invalid bulk unqueue": "実行をキューから外すことができませんでした",
-    "invalid field": "無効なフィールド：{name}",
-    "invalid flow": "無効なFlow",
-    "invalid source": "無効なソースコード",
-    "invalid yaml": "無効なYAML",
-    "is deprecated": "非推奨です",
-    "is required": "{field} は必須です",
-    "item": "アイテム",
-    "items": "アイテム",
-    "join community": "コミュニティに参加",
-    "join_slack": "Slackに参加",
-    "jsonl": "JSONL",
-    "jump to...": "ジャンプ先...",
-    "kestra": "Kestra",
-    "key": "Key",
-    "kill": "キル",
-    "kill only parents": "現在のもののみを終了",
-    "kill parents and subflow": "現在のflowとsubflowを終了",
-    "killed confirm": "実行<code>{id}</code>をキルしてもよろしいですか？",
-    "killed done": "実行はキルのためにキューに入れられました",
-    "kv": {
-      "add": "作成",
-      "delete multiple": {
-        "confirm": "本当に削除しますか: <code>{name}</code> KV(s)?",
-        "warning": "あなたはこれらのnamespaceに対する権限がないため、省略されます: <code>{namespaces}</code>"
-      },
-      "duplicate": "このキーは既に存在します",
-      "inherited": "継承されたKVペア",
-      "name": "KV Store",
-      "type": "タイプ",
-      "update": "キー'{key}'の値を更新"
-    },
-    "label": "ラベル",
-    "label filter placeholder": "ラベルを 'key:value' として設定",
-    "labels": "ラベル",
-    "last 48 hours": "過去48時間",
-    "last X days count": "過去{days}日間に{count}",
-    "last error was": "最後のエラーは",
-    "last evaluation date": "最終評価日",
-    "last evaluation date tooltip": "When the trigger was last evaluated by the scheduler, regardless of whether it produced an execution.",
-    "last execution date": "最後の実行日",
-    "last execution state": "最終状態",
-    "last execution status": "最後の実行ステータス",
-    "last modified": "最終更新日時",
-    "last trigger date": "最終トリガー日時",
-    "last trigger date tooltip": "トリガーが最後に実行された時刻。バックフィルを実行している場合、過去の時刻になることがあります。",
-    "latest_update": "最新の更新",
-    "launch execution": "実行",
-    "learn_more": "詳細を確認",
-    "leave page": "ページを離れる",
-    "license": "ライセンス",
-    "light_background": "これは、明るい背景で作業する際の推奨オプションです。",
-    "light_version": "ライトバージョン",
-    "line": "ライン",
-    "line-by-line": "行ごと表示",
-    "loaded x dependencies": "{count}件の依存関係が読み込まれました",
-    "loading": "読み込み中...",
-    "log expand setting": "Logのデフォルト表示",
-    "logExporters": "ログエクスポーター",
-    "logs": "Logs",
-    "logs_copied": "Logs copied to your clipboard",
-    "logs_view": {
-      "compact": "デフォルトビュー",
-      "compact_details": "タスクログを各タスクごとにグループ化してコンパクトビューで表示",
-      "raw": "Temporalビュー",
-      "raw_details": "タスクログとフローのログをタイムスタンプ順に生の形式で表示"
-    },
-    "main_configuration": "メイン設定",
-    "manage labels": "ラベルを管理",
-    "management port": "管理ポート",
-    "mark as": "<code>{status}</code>としてマーク",
-    "max": "Max",
-    "mcp": {
-      "api_token": "APIトークン",
-      "auth_type": "認証",
-      "basic_auth": "ベーシック認証",
-      "bearer_token": "ベアラートークン認証",
-      "client_setup": "クライアント設定",
-      "connect": "接続",
-      "connect_tab": {
-        "auth_api_token_hint": "クライアントを起動する前に<code>KESTRA_TOKEN</code>を環境変数として設定してください。",
-        "auth_basic_hint": "クライアントを起動する前に、base64エンコードされた<code>username:password</code>文字列を含む<code>KESTRA_BASIC_AUTH</code>を環境変数として設定してください。",
-        "auth_oauth_browser_hint": "初回接続時にブラウザがIDプロバイダーのログインページを開きます。",
-        "auth_oauth_client_id_hint": "<code>&lt;client-id&gt;</code>をOAuthクライアントIDに置き換え、そのクライアントに有効なリダイレクトURIとして<code>http://localhost:7777</code>を登録してください。",
-        "claude_code": "クロードコード",
-        "claude_code_hint": "ターミナルで次のコマンドを実行してください:",
-        "claude_desktop": "Claudeデスクトップ",
-        "claude_desktop_hint": "claude_desktop_config.jsonファイルに次を追加してください：",
-        "claude_desktop_mac": "macOS: ~/Library/Application Support/Claude/claude_desktop_config.json",
-        "claude_desktop_win": "Windows: %APPDATA%\\Claude\\claude_desktop_config.json",
-        "client_picker_label": "AIクライアントを選択",
-        "codex": "Codex (OpenAI)",
-        "codex_hint": "codex.json MCP設定に次を追加してください:",
-        "cursor": "カーソル",
-        "cursor_hint": "次の内容を~/.cursor/mcp.jsonに追加してください:",
-        "server_url": "サーバーURL"
-      },
-      "copy_url": "URLをコピー",
-      "create": "サーバーを作成",
-      "delete_confirm": "このMCPサーバーを削除してもよろしいですか？",
-      "id_invalid": "IDは小文字のアルファベットまたは数字で始まり、小文字のアルファベット、数字、ハイフン、またはアンダースコアのみを含む必要があります。",
-      "id_placeholder": "例: my-mcp-server",
-      "instructions": "指示",
-      "main_tenant": "メイン",
-      "managed_by_kestra": "Kestraによって管理されています",
-      "no_oauth_providers": "このインスタンスにOIDCプロバイダーが設定されていません",
-      "no_servers": "MCPサーバーが見つかりません。最初のサーバーを作成して、MCP Tool triggerを外部AIエージェントに公開してください。",
-      "oauth": "OAuth",
-      "oauth_hint": "OIDCプロバイダーからのBearer JWT",
-      "oauth_provider": "OAuthプロバイダー",
-      "oauth_provider_placeholder": "設定済みのOIDCプロバイダーを選択",
-      "oauth_provider_required": "認証タイプがOAuthの場合、OAuthプロバイダーは必須です",
-      "page_description": "KestraのflowをMCP互換のAIエージェント用ツールとして公開する",
-      "private": "プライベート",
-      "private_server": "プライベートサーバー",
-      "public": "公開",
-      "public_hint": "警告: 公開サーバーは認証を必要としません。URLを知っている人なら誰でも、namespaceや権限のチェックなしに、このサーバーが公開するすべてのツールを呼び出すことができます。外部に公開しても安全なサーバーでのみ使用してください。",
-      "save": "変更を保存",
-      "scopes_supported": "サポートされているscope",
-      "scopes_supported_hint": "このサーバーのProtected Resource Metadataドキュメントに記載されたscope。仕様準拠のMCPクライアントは認可リクエストをこのリストに制限します。フィールドを省略してクライアントがIdPの公開scopeにフォールバックできるよう空のままにしてください。",
-      "scopes_supported_placeholder": "openid, profile, email",
-      "server": "MCPサーバー",
-      "server_id": "サーバー ID",
-      "server_type": "サーバータイプ",
-      "servers": "MCPサーバー",
-      "servers_count": "{{count}} MCPサーバー",
-      "tab_connect": "接続",
-      "tab_edit": "編集",
-      "tab_tool_flows": "ツールフローズ",
-      "tab_tool_flows_placeholder": "ツールフロー管理は近日公開予定です。",
-      "tools": {
-        "annotations": "アノテーション",
-        "create_tool_flow": "ツールフローを作成",
-        "description": "説明",
-        "destructive": "破壊的",
-        "flow": "flow",
-        "idempotent": "冪等",
-        "no_tools": "検索に一致するツールフローはありません。",
-        "open_world": "Open world",
-        "read_only": "読み取り専用",
-        "return_direct": "直接返却",
-        "state": "状態",
-        "title": "タイトル",
-        "tool_name": "ツール名",
-        "trigger_id": "Trigger ID",
-        "view_flow": "flowを開く"
-      },
-      "url_copied": "URLをコピーしました！",
-      "username_password": "ユーザー名 & パスワード",
-      "your_servers": "あなたのサーバー"
-    },
-    "metric": "メトリック",
-    "metric choice": "このflowには利用可能なメトリクスがありません",
-    "metrics": "メトリクス",
-    "min": "Min",
-    "missingSource": "ソースが見つかりません",
-    "modify inputs": "入力を変更",
-    "modify_inputs": "入力を変更",
-    "monogram": "モノグラム",
-    "more actions": "その他のアクション",
-    "more_actions": "その他のアクション",
-    "multi_panel_editor": {
-      "close_all_panels": "すべてのパネルを閉じる",
-      "close_all_tabs": "すべてのタブを閉じる",
-      "move_left": "左に移動",
-      "move_right": "右に移動"
-    },
-    "multiple saved done": "{name}が保存されました",
-    "name": "名前",
-    "namespace": "Namespace",
-    "namespace and id readonly": "プロパティ`namespace`と`id`は変更できません — 初期値に設定されています。flowの名前を変更したりnamespaceを変更したい場合は、新しいflowを作成して古いものを削除してください。",
-    "namespace files": {
-      "create": {
-        "file": "ファイルを作成",
-        "file_already_exists": "この名前のファイルはすでに存在します",
-        "file_conflicts_with_folder": "この名前のフォルダーはすでに存在します",
-        "file_error": "ファイルの作成中にエラーが発生しました",
-        "folder": "フォルダーを作成",
-        "folder_already_exists": "この名前のフォルダーはすでに存在します",
-        "folder_conflicts_with_file": "この名前のファイルはすでに存在します",
-        "folder_error": "フォルダーの作成中にエラーが発生しました",
-        "label": "作成"
-      },
-      "delete": {
-        "file": "ファイルを削除",
-        "files": "{count} 個の選択されたファイルを削除",
-        "folder": "フォルダーを削除",
-        "folders": "{count} 個の選択されたフォルダーを削除",
-        "label": "削除"
-      },
-      "dialog": {
-        "deletion": {
-          "confirm": "確認",
-          "file_single": "ファイル <code>{name}</code> を削除してもよろしいですか？",
-          "files": "<code>{count}</code> 個のファイルを削除してもよろしいですか？",
-          "folder_single": "フォルダー<code>{name}</code>とそのすべての内容を削除してもよろしいですか？",
-          "folders": "<code>{count}</code> 個のフォルダーとそのすべての内容を削除してもよろしいですか？",
-          "mixed": "<code>{folders}</code> フォルダーと <code>{files}</code> ファイルを削除してもよろしいですか？",
-          "title": "コンテンツの削除を確認"
-        },
-        "name": {
-          "file": "拡張子付きの名前:",
-          "folder": "フォルダー名:"
-        },
-        "parent_folder": "親フォルダー:"
-      },
-      "export": "namespaceファイルをエクスポート",
-      "export_single": "ファイルをエクスポート",
-      "filter": "フィルター",
-      "import": {
-        "error": "ファイルのインポート中にエラーが発生しました",
-        "files": "ファイルをインポート",
-        "folder": "フォルダーをインポート",
-        "import": "インポート",
-        "success": "ファイルが正常にインポートされました"
-      },
-      "new_file": "新規ファイル",
-      "no_items": {
-        "heading": "まだnamespaceにファイルが見つかりません。",
-        "paragraph": "フロー間でコードを共有するためにファイルを作成またはインポートします。"
-      },
-      "no_selection": {
-        "description": "ツリーからファイルを選択して内容を表示します。",
-        "heading": "ファイルが選択されていません"
-      },
-      "path": {
-        "copy": "パスをコピー",
-        "error": "パスをクリップボードにコピー中にエラーが発生しました",
-        "success": "パスがクリップボードにコピーされました"
-      },
-      "rename": {
-        "file": "ファイルの名前を変更",
-        "folder": "フォルダーの名前を変更",
-        "label": "名前を変更",
-        "new_file": "拡張子付きの新しい名前:",
-        "new_folder": "新しいフォルダー名:"
-      },
-      "revisions": {
-        "history": "リビジョン履歴",
-        "restore": {
-          "success": "ファイルのリビジョンが正常に復元されました"
-        }
-      },
-      "toggle": {
-        "hide": "namespaceファイルを非表示",
-        "show": "namespaceファイルを表示"
-      },
-      "tree": {
-        "collapse": "すべてのフォルダーを折りたたむ",
-        "expand": "すべてのフォルダーを展開"
-      }
-    },
-    "namespace not allowed": "Namespaceは許可されていません",
-    "namespace_editor": {
-      "close": {
-        "all": "すべてのタブを閉じる",
-        "other": "他のタブを閉じる",
-        "right": "右側に閉じる",
-        "tab": "タブを閉じる"
-      },
-      "empty": {
-        "create_message": "namespaceファイルを作成またはインポートできます。",
-        "title": "現在開いているタブはありません",
-        "video_message": "エディターの紹介ビデオをご覧いただけます。"
-      }
-    },
-    "namespaces": "Namespaces",
-    "neutral trend": "安定",
-    "new": "新規",
-    "new version": "新しいバージョン{version}が利用可能です！",
-    "next": "次へ",
-    "next evaluation date": "次の評価日",
-    "next evaluation date tooltip": "トリガーが次に評価されるタイミングは、その間隔に基づきます。条件が満たされない場合、次の実行日と常に同じとは限りません。",
-    "next execution date": "次の実行日",
-    "next_execution": "次回の実行",
-    "no data current task": "現在のタスクに利用可能なデータがありません。",
-    "no inputs": "このflowにはinputがありません。",
-    "no metrics available": "このタスク実行には記録されたメトリクスがありません。",
-    "no outputs available": "このタスク実行には利用可能なoutputがありません。",
-    "no result": "表示する結果がありません。",
-    "no revisions": "リビジョンなし",
-    "no revisions found": "このFlowには1つのリビジョンしか存在しません",
-    "no-executions-view": {
-      "guidance_desc": "フローを実行するためのガイダンスが必要ですか？",
-      "guidance_sub_desc": "ドキュメントを参照して、必要なすべての情報を確認してください。",
-      "namespace_guidance_desc": "Namespaceを管理するためのガイダンスが必要ですか？",
-      "namespace_sub_title": "このダッシュボードを埋めるために、このnamespaceから1つ以上のflowを実行します。",
-      "sub_title": "「Execute」ボタンをクリックして、最初のworkflowのexecutionを開始してください。",
-      "title": "自動化を開始"
-    },
-    "no_code": {
-      "add_field": "{field}を追加",
-      "adding": "+ {what}を追加",
-      "adding_default": "+ 新しいvalueを追加",
-      "clearSelection": "選択をクリア",
-      "creation": {
-        "afterExecution": "実行後ブロックを追加",
-        "charts": "チャートを追加",
-        "conditions": "条件を追加",
-        "default": "追加",
-        "errors": "エラーハンドラーを追加",
-        "finally": "finally ブロックを追加",
-        "inputs": "入力フィールドを追加",
-        "numerator": "分子を追加",
-        "pluginDefaults": "プラグインのデフォルトを追加",
-        "tasks": "タスクを追加",
-        "triggers": "トリガーを追加",
-        "where": "データをフィルタリングする"
-      },
-      "fields": {
-        "general": {
-          "checks": "チェック",
-          "concurrency": "並行性",
-          "disabled": "無効",
-          "labels": "ラベル",
-          "listeners": "リスナー",
-          "outputs": "出力",
-          "retry": "リトライ",
-          "sla": "SLA",
-          "taskDefaults": "タスクデフォルト",
-          "updated": "更新済み",
-          "variables": "変数",
-          "workerGroup": "ワーカーグループ",
-          "workerSelector": "ワーカーセレクター"
-        },
-        "main": {
-          "description": "説明",
-          "id": "Flow ID",
-          "inputs": "入力",
-          "namespace": "Namespace（ネームスペース）"
-        }
-      },
-      "labels": {
-        "label": "ラベル",
-        "no_code": "コードエディタなし",
-        "variable": "変数",
-        "yaml": "YAMLエディター"
-      },
-      "remove": {
-        "cases": "このケースを削除",
-        "default": "このエントリを削除"
-      },
-      "sections": {
-        "afterExecution": "実行後",
-        "deprecated": "非推奨プロパティ",
-        "errors": "エラーハンドラー",
-        "finally": "最後に",
-        "pluginDefaults": "プラグインデフォルト",
-        "tasks": "タスク",
-        "triggers": "トリガー"
-      },
-      "select": {
-        "afterExecution": "タスクを選択",
-        "charts": "チャートタイプを選択",
-        "conditions": "条件を選択",
-        "default": "タイプを選択",
-        "errors": "タスクを選択",
-        "finally": "タスクを選択",
-        "inputs": "入力フィールドタイプを選択",
-        "numerator": "分子を選択",
-        "pluginDefaults": "プラグインを選択",
-        "task": "タスクを選択",
-        "tasks": "タスクを選択",
-        "triggers": "トリガーを選択",
-        "where": "フィルタータイプを選択"
-      },
-      "toggle_pebble": "ペブルエディタを切り替え",
-      "unnamed": "名前なし",
-      "version_oss_placeholder": "エンタープライズエディションでプラグインバージョニングをアンロック"
-    },
-    "no_data": "ここにはまだ何もないようです…<br/>フィルターを調整するか、もう一度試してみてください！",
-    "no_file_choosen": "ファイルが選択されていません",
-    "no_flow_outputs": "出力は利用できません。",
-    "no_history": "履歴はありません",
-    "no_inputs": "入力が利用できません。",
-    "no_logs_data": "データなし",
-    "no_logs_data_description": "フィルターを調整するか、時間範囲を変更するか、flowが最近実行されたかを確認してください。",
-    "no_logs_data_title": "選択したフィルターに対してログが見つかりませんでした。",
-    "no_namespaces": "検索条件に一致するnamespaceはゼロです。",
-    "no_results": {
-      "assets": "アセットが見つかりません",
-      "executions": "実行が見つかりません",
-      "flows": "フローが見つかりません",
-      "kv_pairs": "キー-バリュー ペアが見つかりません",
-      "secrets": "シークレットが見つかりません",
-      "templates": "テンプレートが見つかりません",
-      "triggers": "トリガーが見つかりません"
-    },
-    "no_results_found": "結果が見つかりません",
-    "no_tasks_running": "タスクはまだ実行されていません。",
-    "no_trigger": "トリガーが利用できません。",
     "no_variables": "変数は利用できません。",
-    "now": "現在",
-    "of": "の",
-    "ok": "OK",
-    "onboarding": {
-      "actions": {
-        "cancel_tutorial": "チュートリアルをキャンセル",
-        "complete": "完了",
-        "edit_flow_to_continue": "右上の「Edit flow」をクリックしてください。",
-        "execute_to_continue": "1. 右上の「Execute」をクリックします。\n2. <strong>name</strong> に値を入力します。\n3. モーダルで再度「Execute」をクリックします。",
-        "finish_tutorial": "チュートリアルを終了",
-        "next": "次へ",
-        "save_to_continue": "右上の「Save」をクリックしてください。"
-      },
-      "cancel_modal": {
-        "confirm": "チュートリアルをキャンセル",
-        "description": "最初のフローチュートリアルをキャンセルしますか？",
-        "keep": "チュートリアルを続ける",
-        "title": "最初のフローチュートリアルをキャンセル"
-      },
-      "editor_hints": {
-        "build_intro": "ステップごとに最初のフローを作成しましょう。",
-        "step_1": "# 1) idを追加",
-        "step_2": "# 2) namespaceを追加",
-        "step_3": "# 3) 入力を追加",
-        "step_4": "# 4) タスクを追加し、最初のPythonタスクを作成",
-        "step_5": "# 5) cronトリガーを追加"
-      },
-      "finish_actions": {
-        "create_flow": "フローを作成",
-        "explore_blueprints": "ブループリントを見る"
-      },
-      "steps": {
-        "add_cron_trigger": {
-          "description": "Triggersはスケジュールや外部イベント（例：WebhookやMQTTメッセージ）に基づいて実行を開始できます。<br><br>このフローが5分ごとに実行されるように、cronスケジュールトリガーを追加してください。",
-          "title": "cronトリガーを追加"
-        },
-        "add_id": {
-          "description": "IDはフローの一意な名前です。検索、実行、一貫した参照のために使用されます。<br><br>ルートレベルに <code>id</code> を追加してください。",
-          "title": "フローIDを追加"
-        },
-        "add_input": {
-          "description": "Inputsはフローレベルのパラメータで、タスク内から参照し、実行時の動作を動的に制御できます。<br><br><code>name</code> という名前の入力を <code>STRING</code> 型で追加してください。",
-          "title": "入力を追加"
-        },
-        "add_input_default": {
-          "description": "フローが自動的にトリガーされる場合でも、入力には実行時の値が必要です。<br><br><code>name</code> 入力は前のステップで作成済みなので、再度追加する必要はありません。既存の <code>name</code> 入力にデフォルト値を設定してください。",
-          "title": "入力のデフォルト値を設定"
-        },
-        "add_log_task": {
-          "description": "Tasksはフローが実行する作業単位で、順序付けられたステップのリストとして定義されます。各タスクには一意の <code>id</code> と <code>type</code> が必要です。Kestraは外部システム向けに多くのタスクプラグインを提供していますが、ここではPython Scriptタスクを使用します。<br><br><code>&#123;&#123; ... &#125;&#125;</code> 構文はPebble式で、実行時に変数を動的に参照するために使用されます。例：<code>&#123;&#123; inputs.name &#125;&#125;</code>。<br><br><code>tasks</code> の下に、<code>id</code>、<code>type</code>、および挨拶を出力する <code>script</code> を含む最初のタスクを追加してください。",
-          "title": "最初のタスクを追加"
-        },
-        "add_namespace": {
-          "description": "Namespaceはチーム、プロジェクト、環境ごとにフローを整理するフォルダのようなグループです。<br><br>ルートレベルに <code>namespace</code> を追加してください。",
-          "title": "ネームスペースを追加"
-        },
-        "background_runs_info": {
-          "description": "このフローは5分ごとにバックグラウンドで実行されます。<br><br>左側メニューの「Executions」概要から、スケジュール実行を確認できます。",
-          "title": "スケジュール実行"
-        },
-        "edit_flow_from_execution": {
-          "description": "実行画面から直接フロー定義に戻り、素早く編集できます。",
-          "title": "フローエディタに戻る"
-        },
-        "execute_flow": {
-          "description": "実行すると、入力値を指定してフローの実行が開始されます。",
-          "title": "フローを実行"
-        },
-        "finish": {
-          "description": "素晴らしいスタートです。フローの作成、実行、パラメータ化、スケジュール設定を行いました。<br><br>次に何をしますか？",
-          "title": "最初のフローチュートリアルを完了しました"
-        },
-        "flow_basics": {
-          "description": "Kestraでは、<code>flow</code> は中核となるオーケストレーション単位です。メタデータと順序付けられたタスクを含むYAMLで定義します。<br><br>以下のサンプル構造を確認し、ステップごとに作成していきましょう。",
-          "title": "フローの基本"
-        },
-        "save_flow": {
-          "description": "保存すると、フロー定義が永続化され、実行できるようになります。",
-          "title": "フローを保存"
-        },
-        "save_flow_again": {
-          "description": "これでフローにはスケジュールと自動実行用のデフォルト入力値が設定されました。",
-          "title": "フローを保存"
-        },
-        "view_logs_status": {
-          "description": "実行の詳細には、ステータス、実行時間、タスクごとの出力ログが表示されます。<br><br>実行詳細を開き、ガントチャート内の <code>greet</code> をクリックしてログを確認してください。",
-          "title": "実行を確認"
-        }
-      },
-      "validation": {
-        "add_cron_trigger_cron": "cron式を追加してください。例：`\"*/5 * * * *\"`。",
-        "add_cron_trigger_section": "`triggers` セクションを作成し、スケジュールトリガーを追加してください。",
-        "add_cron_trigger_type": "トリガータイプを `io.kestra.plugin.core.trigger.Schedule` に設定してください。",
-        "add_id": "上部にフローIDを追加してください。例：`id: hello_flow`。",
-        "add_input_default_defaults": "`name` にデフォルト値を追加してください。例：`defaults: \"Kestra\"`。",
-        "add_input_default_id": "既存の入力IDを `name` のままにしてください。",
-        "add_input_default_section": "`inputs` に戻り、既存の `name` 入力をそのまま使用してください（2つ目の入力は追加しないでください）。",
-        "add_input_id": "`inputs` 内に `id: name` を追加してください。",
-        "add_input_section": "`inputs` セクションを作成し、1つの入力を追加してください。",
-        "add_input_type": "入力タイプを `STRING` に設定してください。",
-        "add_log_task_id": "タスクにIDを設定してください。例：`id: greet`。",
-        "add_log_task_message": "タスクに `script` フィールドを追加してください。",
-        "add_log_task_pebble": "スクリプト内でPebble式を使用し、入力値を参照してください（例：`inputs.name`）。",
-        "add_log_task_section": "`tasks` セクションを作成し、最初のタスクを追加してください。",
-        "add_log_task_type": "タスクタイプを `io.kestra.plugin.scripts.python.Script` に設定してください。",
-        "add_namespace": "上部にnamespaceを追加してください。例：`namespace: company.team`。",
-        "complete_step": "あと少しです。このステップを完了して続行してください。",
-        "edit_flow_from_execution": "上部バーの「Edit flow」をクリックして続行してください。",
-        "execute_flow": "続行するにはフローを一度実行してください。",
-        "fix_yaml": "YAMLの書式に小さな問題があります。修正してから続行してください。",
-        "save_flow": "続行するには「Save」をクリックしてください。",
-        "save_flow_again": "続行するには再度「Save」をクリックしてください。",
-        "view_logs_status": "実行詳細を開き、`greet` のログを確認してください。"
-      },
-      "welcome": {
-        "additional_help": "追加のヘルプ",
-        "badge": "チュートリアル",
-        "blueprints": "ブループリント",
-        "docs": "ドキュメント",
-        "guided_description": "ガイド付きステップで最初のフローを作成し、実行する方法を学びましょう。",
-        "guided_duration": "ほとんどのユーザーにおすすめ",
-        "guided_title": "最初のフローを作成",
-        "headline": "数分で最初のワークフローを作成して実行しましょう",
-        "self_serve_description": "エディタに直接移動して、自分のフローを作成します。",
-        "self_serve_note": "上級ユーザー向け",
-        "self_serve_title": "一からフローを作成",
-        "slack": "Slackコミュニティ",
-        "tutorial": "チュートリアル"
-      }
+    "download": "ダウンロード",
+    "jsonl": "JSONL",
+    "concurrency_limit": {
+      "dialog_title": "同時実行制限",
+      "warning": "実行中のカウンターを変更すると、並行性が損なわれ、実行が許可された制限を超える可能性があります。"
     },
-    "open": "開く",
-    "open full page": "フルページを開く",
-    "open in new tab": "新しいタブで",
-    "open in same tab": "同じタブで",
-    "open sidebar": "サイドバーを開く",
-    "open source": "オープンソース",
-    "open_page": "Open page",
-    "optional": "オプション",
-    "original execution": "元の実行",
-    "originalCreatedDate": "元の作成日",
-    "outdated revision save confirmation": {
-      "confirm": "上書きしますか？",
-      "create": {
-        "description": "このnamespaceには、同じidのflowが既に存在します。",
-        "details": "上書きして新しいリビジョンを作成するために保存します。",
-        "title": "Flowは既に存在します"
-      },
-      "update": {
-        "description": "編集しているリビジョンは古いです。",
-        "details": "最新バージョンの詳細については、リビジョンタブを確認してください。",
-        "title": "古いリビジョン"
-      }
+    "documentation": {
+      "documentation": "ドキュメント",
+      "github": "GitHub issueを開く"
     },
-    "output": "Output",
-    "outputs": "出力",
-    "override": {
-      "details": "以前のflowはRevisionsタブから復元できます。",
-      "title": "現在のflowを上書きしようとしています"
-    },
-    "overview": "概要",
-    "page": {
-      "next": "次のページ",
-      "previous": "前のページ"
-    },
-    "panel actions": "パネルアクション",
-    "parent execution": "親実行",
-    "password": "パスワード",
-    "password empty constraint": "ユーザー名またはパスワードが間違っています",
-    "password length constraint": "パスワードは256文字を超えてはいけません",
-    "passwords do not match": "パスワードが一致しません",
-    "pause": "一時停止",
-    "pause backfill": "backfillを一時停止",
-    "pause backfills": "backfillを一時停止",
-    "pause confirm": "実行 <code>{id}</code> を一時停止してもよろしいですか？",
-    "pause done": "実行がPAUSEDされています",
-    "pause title": "実行を一時停止 <code>{id}</code>。<br/>現在実行中のタスクは引き続き処理されることに注意してください。実行は手動で再開する必要があります。",
-    "paused": "一時停止中",
-    "playground": {
-      "clear_history": "履歴をクリア",
-      "confirm_create": "フローを作成中はプレイグラウンドを実行できません。プレイグラウンドの実行を開始すると、flowが作成されます。",
-      "history": "直近10回の実行",
-      "play_icon_info": "ノーコードまたはトポロジービューで再生アイコンをクリックすることもできます。",
-      "run_all_tasks": "すべてのタスクを実行",
-      "run_task": "タスクを実行",
-      "run_task_and_downstream": "タスクとダウンストリームを実行",
-      "run_task_info": "Flow Codeエディタ内の任意のtaskにカーソルを合わせ、「Run task」ボタンをクリックしてtaskをテストします。",
-      "run_this_task": "このtaskを実行",
-      "title": "プレイグラウンド",
-      "toggle": "プレイグラウンド",
-      "tooltip_persistence": "Playgroundをオフにしてから再度オンにすると、ページに留まっている限り情報は保持されます。"
-    },
-    "playground actions": "プレイグラウンドアクション",
-    "plugin defaults exported": "プラグインのデフォルトがエクスポートされました",
-    "plugin defaults imported": "プラグインのデフォルトがインポートされました",
-    "plugin defaults not imported": "一部のプラグインデフォルトをインポートできませんでした",
-    "pluginDefaults": {
-      "add": "プラグインデフォルトを追加",
-      "add_subtitle": "新しいプラグインのデフォルトをそのプロパティで設定する",
-      "cancel": "キャンセル",
-      "custom": "カスタムプラグイン",
-      "custom_configure": "カスタムプラグインタイプ - YAMLを使用して構成",
-      "custom_placeholder": "プラグインタイプを入力",
-      "custom_type": "カスタムプラグインタイプ",
-      "edit": "プラグインデフォルトを編集",
-      "edit_subtitle": "既存のプラグインのデフォルト設定を変更する",
-      "form": "フォーム",
-      "predefined": "定義済みプラグイン",
-      "select_predefined": "定義済みプラグインを選択",
-      "show_yaml": "YAMLを表示",
-      "title": "プラグインのデフォルト",
-      "update": "プラグインデフォルトを更新",
-      "use_custom": "カスタムを使用",
-      "yaml": "YAML",
-      "yaml_configuration": "YAML設定"
-    },
-    "pluginPage": {
-      "elementType": {
-        "apps": "アプリ",
-        "charts": "チャート",
-        "conditions": "条件",
-        "logExporters": "ログエクスポーター",
-        "secrets": "シークレット",
-        "taskRunners": "タスクランナー",
-        "tasks": "タスク",
-        "triggers": "トリガー"
-      },
-      "group": {
-        "blueprints": "ブループリント ({count})",
-        "plugins": "プラグイン ({count})",
-        "tasks": "タスク ({count})"
-      },
+    "blueprints": {
+      "all": "すべて",
+      "community": "コミュニティ",
+      "create": "ブループリントを作成",
+      "edit": "ブループリントを編集する",
+      "title": "Blueprints",
+      "empty": "設計図が表示されていません。",
       "header": {
-        "back": "プラグインに戻る",
-        "certified": "認定済み",
-        "enterpriseEdition": "エンタープライズエディション"
+        "catch phrase": {
+          "1": "最初の一歩が一番難しい。",
+          "2": "次の{kind}を始めるためにblueprintを探索してください。"
+        },
+        "alt": "ブループリントアイコン"
       },
-      "loadError": "プラグインを読み込めませんでした。もう一度お試しください。",
-      "noResults": "検索に一致するプラグインがありません。",
-      "notFound": "このプラグインが見つかりませんでした。",
-      "overview": {
-        "createdBy": "作成者",
-        "latest": "最新",
-        "linksResources": "リンクとリソース",
-        "managedBy": "管理者",
-        "minKestraVersion": "互換性のある最小Kestraバージョン: {version}",
-        "minKestraVersionShort": "最小 Kestra バージョン {version}",
-        "pluginType": "プラグインタイプ",
-        "previousVersions": "以前のバージョン",
-        "releaseNotes": "リリースノート",
-        "title": "概要",
-        "versions": "バージョン"
+      "custom": "カスタムblueprint",
+      "flows": "フローBlueprints",
+      "apps": "アプリケーション Blueprints",
+      "dashboards": "ダッシュボード Blueprints",
+      "detail": {
+        "category": "カテゴリタイプ",
+        "links": "リンクとリソース",
+        "openInEditor": "フローを編集で開く"
       },
-      "search": "{count}+ プラグインを検索",
-      "searchTasks": "{count} 件のタスクを検索",
-      "sort": {
-        "mostUsed": "最も使用されている",
-        "nameAsc": "名前 A-Z",
-        "nameDesc": "名前 Z-A",
-        "newest": "最新"
-      },
-      "sortBy": "並び替え"
+      "missingPlugins": {
+        "title": "不足しているplugin",
+        "description": "このblueprintは、このインスタンスにインストールされていないpluginのtaskを使用しています: {plugins}。このblueprintを使用するにはインストールしてください。",
+        "card": "このインスタンスにインストールされていないpluginが必要です: {plugins}",
+        "install": "pluginをインストール"
+      }
     },
-    "plugin_default_already_exists": "<code>{type}</code>のプラグインデフォルトはすでに存在します。",
+    "use": "使用",
     "plugins": {
       "name": "プラグイン",
       "names": "プラグイン",
       "please": "ドキュメントを見るには右側のTaskを選択してください",
       "release": "リリースノート"
     },
-    "port": "ポート",
-    "prefill inputs": "自動入力",
-    "pretty_json": "Pretty JSON",
-    "prev_execution": "前回の実行",
-    "preview": {
-      "auto-view": "自動ビュー",
-      "collapse": "折りたたむ",
-      "expand": "展開",
-      "force-editor": "エディタービューを強制する",
-      "label": "プレビュー",
-      "next": "次へ",
-      "page_of": "ページ {current} / {total}",
-      "pagination_info": "{total} のうち {start}-{end} 行を表示しています。",
-      "previous": "前へ",
-      "rows_truncated": "{total} 行中 {shown} 行を表示しています。すべてのデータを表示するにはファイルをダウンロードしてください。",
-      "showing_rows": "{total}のうち{start}から{end}の行を表示中",
-      "view": "表示"
+    "last execution date": "最後の実行日",
+    "last execution state": "最終状態",
+    "last X days count": "過去{days}日間に{count}",
+    "date range count": "{startDate}から{endDate}の間に{count}",
+    "date count": "{date}に{count}",
+    "revisions": "リビジョン",
+    "no revisions found": "このFlowには1つのリビジョンしか存在しません",
+    "no revisions": "リビジョンなし",
+    "see full revision": "完全なリビジョンを見る",
+    "side-by-side": "並列表示",
+    "line-by-line": "行ごと表示",
+    "template": "テンプレート",
+    "template creation": "テンプレート作成",
+    "templates": "テンプレート",
+    "templates deprecated": "テンプレートは非推奨です。代わりにsubflowsを使用してください。テンプレートからsubflowsへの移行方法については、<a href=\"https://kestra.io/docs/migration-guide/0.11.0/templates?utm_source=app&utm_medium=referral&utm_campaign=template-inlinedoc\" target=\"_blank\">移行セクション</a>を参照してください。",
+    "no result": "表示する結果がありません。",
+    "empty search": "検索結果がありません",
+    "trigger": "Trigger",
+    "no_trigger": "トリガーが利用できません。",
+    "triggers": "Triggers",
+    "triggers_header_description": "トリガーを閲覧、追加、管理して、flowを自動化します。flowをAIツールとして公開する、スケジューリング、Webhookトリガーの追加、外部アプリの変更をポーリング、またはリアルタイムイベントリスナーから選択します。",
+    "triggers_tabs_add": "追加",
+    "triggers_tabs_manage": "管理",
+    "triggers_add_search_placeholder": "トリガーを検索...",
+    "triggers_add_filter_core": "コア",
+    "triggers_add_filter_realtime": "リアルタイム",
+    "triggers_add_filter_all": "すべて",
+    "triggers_add_filter_app": "アプリケーション",
+    "triggers_add_empty_title": "トリガーが見つかりません",
+    "triggers_add_ee_tooltip": "このtriggerはEnterprise Editionが必要です。",
+    "triggers_add_category_empty": "このカテゴリにはトリガーがありません。",
+    "triggers_add_card_add_to_flow": "flowに追加",
+    "triggers_add_card_add": "追加",
+    "triggers_add_modal_title": "{name}",
+    "triggers_add_modal_tab_form": "フォーム",
+    "triggers_add_modal_tab_source": "ソース",
+    "triggers_add_modal_tab_documentation": "ドキュメント",
+    "triggers_add_modal_namespace_placeholder": "namespaceを選択",
+    "triggers_add_modal_flow_placeholder": "フローを選択",
+    "triggers_add_modal_trigger_id": "トリガーID",
+    "triggers_add_modal_trigger_id_placeholder": "このtriggerのユニークな識別子",
+    "triggers_add_modal_properties_hint": "トリガーを追加した後、flowエディターでトリガーのプロパティを設定します。",
+    "triggers_add_modal_ee_notice": "このtriggerはEnterprise Editionが必要です。",
+    "triggers_add_modal_add_button": "フローにトリガーを追加",
+    "trigger details": "Triggerの詳細",
+    "triggerflow disabled": "Flow定義からTriggerが無効になっています",
+    "last trigger date": "最終トリガー日時",
+    "trigger_states": "状態",
+    "context updated date": "コンテキスト更新日",
+    "state updated date": "状態更新日",
+    "next evaluation date": "次の評価日",
+    "last evaluation date": "最終評価日",
+    "last trigger date tooltip": "トリガーが最後に実行された時刻。バックフィルを実行している場合、過去の時刻になることがあります。",
+    "context updated date tooltip": "トリガーのコンテキストが最後に更新された時刻。これは、実行がトリガーされたとき、終了したとき（ロックが解除されたとき）、または評価後（実行が発生しない場合でも）に発生します。",
+    "next evaluation date tooltip": "トリガーが次に評価されるタイミングは、その間隔に基づきます。条件が満たされない場合、次の実行日と常に同じとは限りません。",
+    "last evaluation date tooltip": "When the trigger was last evaluated by the scheduler, regardless of whether it produced an execution.",
+    "conditions": "条件",
+    "triggerId": "トリガーID",
+    "tenantId": "テナントID",
+    "codeDisabled": "Flowで無効化",
+    "paused": "一時停止中",
+    "running": "RUNNING",
+    "Fold auto": "エディター：複数行の自動折りたたみ",
+    "Hover description": "エディター: key または value にホバーするとフィールドの説明を表示",
+    "Fold content lines": "複数行文字列を折りたたむ",
+    "Unfold content lines": "複数行文字列を展開する",
+    "Total": "合計",
+    "sub flow": "Subflow",
+    "execute": "実行",
+    "execute flow behaviour": "Flowを実行",
+    "open in same tab": "同じタブで",
+    "open in new tab": "新しいタブで",
+    "execute the flow": "Flow <code>{id}</code>を実行",
+    "execute flow now ?": "このFlowを実行しますか？",
+    "discard execution confirmation": "未保存のinputがあります。このexecutionを破棄してもよろしいですか？",
+    "discard changes confirmation": "保存されていない変更があります。本当に破棄しますか？",
+    "Default namespace": "デフォルトnamespace",
+    "Default log level": "デフォルトlogレベル",
+    "unsaved changed ?": "保存されていない変更があります。このページを離れますか？",
+    "unsaved changes": "未保存の変更",
+    "unsaved changes warning": "未保存の変更があります。このページを離れると、変更は失われます。",
+    "leave page": "ページを離れる",
+    "open full page": "フルページを開く",
+    "drill down preview": "プレビュー",
+    "Editor theme": "エディターテーマ",
+    "Editor fontsize": "エディターのフォントサイズ",
+    "Editor fontfamily": "エディターのフォントファミリー",
+    "errors": {
+      "401": {
+        "title": "認証されていません",
+        "content": "このページにアクセスするには認証が必要です。"
+      },
+      "403": {
+        "title": "アクセス拒否",
+        "content": "このページにアクセスするための権限がありません。"
+      },
+      "404": {
+        "title": "ページが見つかりません",
+        "content": "リクエストされたURLはこのサーバー上に見つかりませんでした。<br />これが私たちの知っているすべてです。",
+        "flow or execution": "探しているflowまたは実行は存在しません。"
+      }
     },
-    "pricing": "料金",
-    "product_tour": "プロダクトツアー",
-    "properties": {
-      "hidden": "テーブルに隠す",
-      "hint": "表示する列を選択",
-      "label": "プロパティ",
-      "shown": "表に表示"
+    "back_to_dashboard": "ダッシュボードに戻る",
+    "copy all logs": "すべてのLogをコピー",
+    "copy logs": "Logsをコピー",
+    "fix_with_ai": "AIで修正",
+    "download logs": "Logsをダウンロード",
+    "delete logs": "Logsを削除",
+    "delete_all_logs": "すべてのLogsを削除してもよろしいですか？",
+    "delete_log": "ログを削除してもよろしいですか？",
+    "toggle fullscreen": "フルスクリーンを切り替え",
+    "copied": "コピーされました",
+    "tags": "タグ",
+    "disabled flow title": "このFlowは無効です",
+    "disabled flow desc": "このFlowは無効です。実行するには有効にしてください。",
+    "label": "ラベル",
+    "labels": "ラベル",
+    "label filter placeholder": "ラベルを 'key:value' として設定",
+    "execution labels": "実行ラベル",
+    "wrong labels": "ラベルには空のkeyまたはvalueを設定できません",
+    "feeds": {
+      "title": "Kestraの新機能",
+      "heading": "すべてのKestraに関すること。",
+      "subheading": "最新の更新情報、ガイド、ストーリー"
     },
-    "queued duration": "キュー待ち期間",
-    "quotas": "クォータ",
-    "reach us": "お問い合わせ",
-    "read-more": "続きを読む",
-    "readonly property": "読み取り専用プロパティ",
-    "recent_executions": "最近の実行",
-    "refresh": "更新",
-    "reject": "拒否",
-    "relative": "相対",
-    "relative end date": "相対終了日",
-    "relative start date": "相対開始日",
-    "remove label": "ラベルを削除",
-    "remove this item": "このアイテムを削除",
-    "remove_bookmark": "このブックマークを削除してもよろしいですか？",
-    "replay": "リプレイ",
-    "replay confirm": "この実行<code>{id}</code>をリプレイして新しいものを作成してもよろしいですか？",
-    "replay execution description": "これにより、選択された実行に基づいて新しい実行が作成されます。",
-    "replay execution title": "実行の再実行",
-    "replay from beginning tooltip": "最初から開始する同様の実行を作成",
-    "replay from task tooltip": "Task <code>{taskId}</code>から開始する同様の実行を作成",
-    "replay inputs": "入力",
-    "replay inputs new required": "このリビジョンにはinputがあります。入力を求められます。",
-    "replay latest revision": "最新のリビジョンを使用してリプレイ",
-    "replay select taskrun": "再生するタスク実行を選択してください:",
-    "replay the execution": "フロー<code>{flowId}</code>の実行<code>{executionId}</code>を再実行する",
-    "replay using": "を使用してリプレイ",
-    "replay with inputs": "入力を使用してリプレイ",
-    "replayed": "実行が再生されました",
-    "required field": "必須フィールド",
-    "reset": "再起動",
-    "reset to defaults": "デフォルトにリセット",
-    "restart": "再起動",
-    "restart change revision": "新しい実行に使用されるリビジョンを変更できます。",
-    "restart confirm": "実行<code>{id}</code>を再起動してもよろしいですか？",
-    "restart execution title": "実行の再起動",
-    "restart latest revision": "最新のリビジョンを再起動",
-    "restart tooltip": "<code>{state}</code>タスクから実行を再起動",
-    "restart trigger": {
-      "button": "triggerを再起動",
-      "tooltip": "トリガーを再起動する"
-    },
-    "restarted": "実行が再開されました",
+    "delete execution running": "<div class=\"alert alert-warning mt-2 mb-0\">この実行はまだRUNNINGです。削除しても停止しません。<br />実行を停止するには、実行をkillする必要があります。</div>",
     "restore": "復元",
     "restore confirm": "リビジョン<code>{revision}</code>を復元してもよろしいですか？",
+    "bulk delete": "<code>{executionCount}</code>件の実行を削除してもよろしいですか？",
+    "bulk replay": "<code>{executionCount}</code>件の実行を再実行してもよろしいですか？",
+    "bulk change state": "以下の実行の状態を変更してもよろしいですか？<code>{executionCount}</code> 実行。",
+    "bulk resume": "<code>{executionCount}</code>件の実行を再開してもよろしいですか？",
+    "bulk pause": "<code>{executionCount}</code> 実行を一時停止してもよろしいですか？",
+    "bulk unqueue": "<code>{executionCount}</code> 件の実行をキューから外してもよろしいですか？",
+    "bulk force run": "実行を強制的に実行しますか <code>{executionCount}</code> 回の実行を行いますか？<br/><br/>WARNING: 実行を強制的に実行することは保証されておらず、重複したタスクの実行が発生する可能性があります。<br/><br/>以下の遷移が行われます:<br/><ul><li>CREATED タスクは RUNNING 状態に移行します。</li><li>RUNNING タスクは再送信されます。</li><li>QUEUED タスクはキューから外されます。</li><li>PAUSED タスクは再開されます。</li></ul>",
+    "bulk restart": "<code>{executionCount}</code>件の実行を再起動してもよろしいですか？",
+    "bulk kill": "<code>{executionCount}</code>件の実行をkillしてもよろしいですか？",
+    "selection": {
+      "selected": "<strong>{count}</strong>件選択済み",
+      "all": "すべて選択 ({count})"
+    },
+    "cancel": "キャンセル",
+    "errorLogs": "エラーログ",
+    "welcome_page": {
+      "welcome": "Kestraへようこそ",
+      "guide": "最初のflowを実行するためのガイダンスが必要ですか？"
+    },
+    "product_tour": "プロダクトツアー",
+    "executions replayed": "<code>{executionCount}</code>件の実行が再実行されました",
+    "executions state changed": "<code>{executionCount}</code> 回の実行の状態が変更されました",
+    "executions resumed": "<code>{executionCount}</code>件の実行が再開されました",
+    "executions paused": "<code>{executionCount}</code> 回の実行がPAUSEDされました",
+    "executions unqueue": "<code>{executionCount}</code> 回の実行がキューから外されました",
+    "executions force run": "<code>{executionCount}</code> 回の実行が強制的に実行されました",
+    "executions restarted": "<code>{executionCount}</code>件の実行が再起動されました",
+    "executions killed": "<code>{executionCount}</code>件の実行がkillされました",
+    "executions deleted": "<code>{executionCount}</code>件の実行が削除されました",
+    "invalid bulk replay": "実行を再実行できませんでした",
+    "invalid bulk resume": "実行を再開できませんでした",
+    "invalid bulk pause": "実行を一時停止できませんでした",
+    "invalid bulk unqueue": "実行をキューから外すことができませんでした",
+    "invalid bulk force run": "実行を強制的に開始できませんでした",
+    "invalid bulk restart": "実行を再起動できませんでした",
+    "invalid bulk kill": "実行をkillできませんでした",
+    "invalid bulk delete": "実行を削除できませんでした",
+    "execution not found": "{executionId} の実行が見つかりません。",
+    "execution not in state PAUSED": "実行<code>{executionId}</code>はPAUSED状態ではありません",
+    "execution not in state FAILED": "実行<code>{executionId}</code>はFAILED状態ではありません",
+    "execution already finished": "実行<code>{executionId}</code>はすでに終了しています",
     "restore revision": "リビジョン<code>{revision}</code>を復元してもよろしいですか？",
-    "resume": "再開",
-    "resume from breakpoint done": "ブレークポイントから実行が再開されました",
-    "resume from breakpoint title": "ブレークポイントから実行 <code>{id}</code> を再開します",
-    "resumed confirm": "実行<code>{id}</code>を再開してもよろしいですか？",
-    "resumed done": "実行が再開されました",
-    "resumed title": "実行<code>{id}</code>を再開",
-    "reuse original inputs": "元のinputを再利用",
-    "reuse_original_inputs": "元のinputを再利用",
-    "review your inputs": "入力内容を確認してください",
-    "revision": "リビジョン",
-    "revision deleted": "リビジョン{revision}が正常に削除されました",
-    "revisions": "リビジョン",
-    "row count": "行数",
-    "run task in playground": "プレイグラウンドでタスクを実行",
+    "seeing old revision": "古いリビジョンを表示しています: {revision}",
+    "export": "エクスポート",
+    "exports": "エクスポート",
+    "export_csv": "CSVとしてエクスポート",
+    "template export": "<code>{templateCount}</code>件のテンプレートをエクスポートしてもよろしいですか？",
+    "templates exported": "テンプレートがエクスポートされました",
+    "export all templates": "すべてのテンプレートをエクスポート",
+    "flow_export": "フローをエクスポート",
+    "flow export": "<code>{flowCount}</code>件のflowをエクスポートしてもよろしいですか？",
+    "flows exported": "<code>{count}</code> Flow(s) エクスポート済み",
+    "export all flows": "すべてのflowをエクスポート",
+    "import": "インポート",
+    "disable": "無効化",
+    "enable": "有効化",
+    "enabled": "有効",
+    "template delete": "<code>{templateCount}</code>件のテンプレートを削除してもよろしいですか？",
+    "flow delete": "<code>{flowCount}</code>件のflowを削除してもよろしいですか？",
+    "templates deleted": "<code>{count}</code>件のテンプレートが削除されました",
+    "flows deleted": "<code>{count}</code>件のflowが削除されました",
+    "flow disable": "<code>{flowCount}</code>件のflowを無効化してもよろしいですか？",
+    "flow enable": "<code>{flowCount}</code>件のflowを有効化してもよろしいですか？",
+    "flows disabled": "<code>{count}</code>件のflowが無効化されました",
+    "flows enabled": "<code>{count}</code>件のflowが有効化されました",
+    "flow-no-dependencies": "あなたのflowには依存関係がありません",
+    "flow-dependencies": "依存関係",
+    "read-more": "続きを読む",
+    "in-our-documentation": "ドキュメント内で。",
+    "dependencies": "依存関係",
+    "see dependencies": "依存関係を表示",
+    "see timeline": "タイムラインを見る",
     "run timeline": "実行タイムライン",
-    "runners": "ランナー",
-    "running": "RUNNING",
-    "running duration": "実行期間",
-    "save": "保存",
+    "dependencies missing acls": "このflowには権限がありません",
+    "dependencies delete flow": "このflowには依存関係があります。削除すると、依存関係が実行されなくなります。<br /><br /> 影響を受けるflowのリストはこちらです:",
+    "expand dependencies": "依存関係を展開",
+    "reset": "再起動",
+    "show task documentation": "taskのドキュメントを表示",
+    "hide task documentation": "taskのドキュメントを非表示",
+    "show task documentation in editor": "エディタでtaskのドキュメントを表示",
+    "show documentation": "ドキュメントを表示",
+    "focus task": "任意の要素をクリックしてそのドキュメントを表示します。",
+    "validate": "検証",
+    "add error handler": "エラーハンドラを追加",
+    "taskDefaults": "taskのデフォルト設定",
+    "disabled": "無効",
+    "before": "前",
+    "after": "後",
+    "add at position": "{position}に<code>{task}</code>を追加",
+    "create first task": "最初のtaskを作成",
+    "dynamic": "動的",
+    "choice": "選択",
+    "sequential": "逐次",
+    "can not delete": "削除できません",
+    "can not have less than 1 task": "各flowには少なくとも1つのtaskが必要です。",
+    "task id already exists": "Task Idはすでに存在します",
+    "Task Id already exist in the flow": "Task Id {taskId}はflow内ですでに存在します。",
+    "task id": "Task ID",
+    "taskid column details": "最後に実行されたtaskとその試行回数。",
+    "flow already exists": "Flowはすでに存在します",
+    "flow already exists message": "namespace <code>{namespace}</code> に flow <code>{id}</code> が既に存在します。新しいリビジョンを作成しますか？",
+    "plugin_default_already_exists": "<code>{type}</code>のプラグインデフォルトはすでに存在します。",
+    "namespace not allowed": "Namespaceは許可されていません",
+    "switch-view": "ビューを切り替え",
+    "source and topology": "ソースとトポロジー",
+    "source and doc": "ソースとドキュメント",
+    "source and blueprints": "ソースとblueprints",
+    "editor": "エディタ",
+    "error in editor": "エディタにエラーが見つかりました",
+    "delete task confirm": "task<code>{taskId}</code>を削除してもよろしいですか？",
+    "can not save": "保存できません",
+    "flow must not be empty": "フローは空であってはなりません",
+    "flow must have id and namespace": "Flowにはidとnamespaceが必要です。",
+    "flow creation denied in namespace": "`{namespace}`でflowを作成する権限がありません。",
+    "readonly property": "読み取り専用プロパティ",
+    "namespace and id readonly": "プロパティ`namespace`と`id`は変更できません — 初期値に設定されています。flowの名前を変更したりnamespaceを変更したい場合は、新しいflowを作成して古いものを削除してください。",
+    "avg": "平均",
+    "sum": "合計",
+    "min": "Min",
+    "max": "Max",
+    "bar": "バー",
+    "line": "ライン",
+    "metric": "メトリック",
+    "aggregation": "集計",
+    "chart type": "チャートタイプ",
+    "metric choice": "このflowには利用可能なメトリクスがありません",
+    "of": "の",
+    "see_all_states": "すべての状態を表示",
     "save draft": {
       "message": "下書き保存済み",
       "retrieval": {
@@ -1680,164 +724,336 @@
         "existing": "<code>{flowFullName}</code>のFlowの下書きが保存されました。flowの編集を続けますか？"
       }
     },
-    "save task": "Taskを保存",
-    "save_and_execute": "保存して実行",
-    "save_as_draft": "下書きとして保存",
-    "saved": "正常に保存されました",
-    "saved as draft": "下書きとして保存しました",
-    "saved as draft done": "<em>{name}</em> を下書きとして保存しました",
-    "saved done": "<em>{name}</em>は正常に保存されました",
-    "scheduleDate": "スケジュール日付",
-    "scope_filter": {
-      "all": "すべての{label}",
-      "system": "システム {label}",
-      "system_description": "システムメンテナンス {label}",
-      "user": "ユーザー {label}",
-      "user_description": "通常のユーザーが開始した{label}"
+    "title": "タイトル",
+    "api": "API",
+    "more_actions": "その他のアクション",
+    "expand error": "失敗したtaskのみ展開",
+    "expand all": "すべて展開",
+    "collapse all": "すべて折りたたむ",
+    "expand": "展開",
+    "collapse": "折りたたむ",
+    "filter by this value": "Filter by this value",
+    "filter_for": "Filter for",
+    "filter_out": "Filter out",
+    "copy_value": "Copy value",
+    "open_page": "Open page",
+    "logs_copied": "Logs copied to your clipboard",
+    "expand_by_default": "Expand structured logs by default",
+    "show raw": "Show raw",
+    "similar lines": "similar lines",
+    "download_logs_description": "Choose which logs to export. Filters default to your current view.",
+    "display_settings": "Display settings",
+    "density": "Density",
+    "density_compact": "Compact",
+    "density_normal": "Normal",
+    "density_expanded": "Expanded",
+    "pretty_json": "Pretty JSON",
+    "body_line_clamp": "Limit line height",
+    "font size": "Font size",
+    "log expand setting": "Logのデフォルト表示",
+    "environment": "環境",
+    "environment name setting": "環境名",
+    "environment color setting": "環境色",
+    "slack support": "Slackで質問する",
+    "join community": "コミュニティに参加",
+    "join_slack": "Slackに参加",
+    "kestra": "Kestra",
+    "reach us": "お問い合わせ",
+    "new version": "新しいバージョン{version}が利用可能です！",
+    "error detected": "エラーが検出されました。",
+    "warning detected": "警告が検出されました",
+    "informative notice": "注記",
+    "cannot swap tasks": "taskを入れ替えできません",
+    "open": "開く",
+    "dependency task": "Task {taskId}は他のtaskの依存関係です",
+    "administration": "管理",
+    "admin": "管理者",
+    "main_configuration": "メイン設定",
+    "commit_id": "コミット id",
+    "evaluation lock date": "評価ロック日",
+    "unlock trigger": {
+      "tooltip": {
+        "execution": "このtriggerに対して実行が進行中です",
+        "evaluation": "triggerは現在評価中です"
+      },
+      "confirmation": "triggerのロックを解除してもよろしいですか？",
+      "warning": "これは同じtriggerに対する並行実行につながる可能性があり、最後の手段として考慮されるべきです。",
+      "button": "triggerのロックを解除",
+      "success": "triggerのロックが解除されました"
     },
-    "search": "検索",
-    "search blueprint": "Blueprintsを検索",
-    "search filters": {
-      "filter name": "フィルター名",
-      "filters": "フィルター",
-      "manage": "検索フィルターを管理",
-      "manage desc": "保存された検索フィルターを管理",
-      "save filter": "フィルターを保存",
-      "saved": "保存されたフィルター"
+    "restart trigger": {
+      "button": "triggerを再起動",
+      "tooltip": "トリガーを再起動する"
     },
-    "search term in message": "メッセージ内の検索語",
-    "search_docs": "検索",
-    "searching": "検索中...",
-    "secret": {
-      "add": "作成",
-      "inherited": "継承されたsecrets",
-      "isReadOnly": "シークレットは読み取り専用です",
-      "names": "Secrets",
-      "update": "シークレット '{name}' を更新"
-    },
-    "security_advice": {
-      "content": "インスタンスを保護するために基本認証を有効にしてください。",
-      "enable": "認証を有効にする",
-      "switch_text": "再表示しない",
-      "title": "インスタンスを保護"
-    },
-    "see dependencies": "依存関係を表示",
-    "see full revision": "完全なリビジョンを見る",
-    "see timeline": "タイムラインを見る",
-    "see_all_states": "すべての状態を表示",
-    "seeing old revision": "古いリビジョンを表示しています: {revision}",
-    "select": "{{section}}を選択してください",
-    "select a state": "状態を選択",
-    "select datetime": "日付を選択",
-    "select view": "ビューを選択",
-    "selected": "選択済み",
-    "selection": {
-      "all": "すべて選択 ({count})",
-      "selected": "<strong>{count}</strong>件選択済み"
-    },
-    "sequential": "逐次",
-    "server type": "サーバータイプ",
+    "trigger disabled": "Flowソース内でTriggerが無効になっています",
+    "flow source not found": "フローソースが見つかりません",
+    "date format": "日付形式",
+    "timezone": "タイムゾーン",
+    "add task": "taskを追加",
+    "unable to generate graph": "グラフの生成中に問題が発生し、トポロジーが表示されません。",
+    "attempts": "試行回数",
+    "flow deleted, you can restore it": "Flowは削除されており、これは読み取り専用ビューです。復元することは可能です。",
+    "workers": "Workers",
+    "worker group": "Workerグループ",
+    "worker group key": "ワーカーグループキー",
+    "worker group fallback": "ワーカーグループフォールバック",
+    "version": "バージョン",
     "services": "サービス",
+    "server type": "サーバータイプ",
+    "hostname": "ホスト名",
+    "port": "ポート",
+    "management port": "管理ポート",
+    "file preview truncated": "表示されたコンテンツが切り捨てられました",
+    "file unavailable": "ファイルが利用できません",
+    "file unavailable description": "このファイルは利用できなくなりました — 削除されたか、有効期限が切れた可能性があります。",
+    "row count": "行数",
+    "encoding": "エンコーディング",
+    "show": "表示",
+    "advanced configuration": "他のプロパティ",
+    "all executions": "すべての実行",
+    "trigger execution id": "Trigger Execution Id",
+    "execution_status": "実行は:",
+    "no_tasks_running": "タスクはまだ実行されていません。",
+    "execution_starts_progress": "実行が開始されると、ここに進行状況の更新が表示されます。",
+    "triggers_state": {
+      "state": "状態",
+      "options": {
+        "enabled": "有効",
+        "disabled": "無効"
+      }
+    },
+    "trigger filter": {
+      "title": "子実行をフィルタリング",
+      "options": {
+        "ALL": "すべての実行",
+        "CHILD": "子実行",
+        "MAIN": "親実行"
+      }
+    },
+    "show chart": "チャートを表示",
+    "namespace files": {
+      "toggle": {
+        "show": "namespaceファイルを表示",
+        "hide": "namespaceファイルを非表示"
+      },
+      "filter": "フィルター",
+      "new_file": "新規ファイル",
+      "no_items": {
+        "heading": "まだnamespaceにファイルが見つかりません。",
+        "paragraph": "フロー間でコードを共有するためにファイルを作成またはインポートします。"
+      },
+      "no_selection": {
+        "heading": "ファイルが選択されていません",
+        "description": "ツリーからファイルを選択して内容を表示します。"
+      },
+      "tree": {
+        "expand": "すべてのフォルダーを展開",
+        "collapse": "すべてのフォルダーを折りたたむ"
+      },
+      "create": {
+        "label": "作成",
+        "file": "ファイルを作成",
+        "file_already_exists": "この名前のファイルはすでに存在します",
+        "file_conflicts_with_folder": "この名前のフォルダーはすでに存在します",
+        "file_error": "ファイルの作成中にエラーが発生しました",
+        "folder": "フォルダーを作成",
+        "folder_already_exists": "この名前のフォルダーはすでに存在します",
+        "folder_conflicts_with_file": "この名前のファイルはすでに存在します",
+        "folder_error": "フォルダーの作成中にエラーが発生しました"
+      },
+      "rename": {
+        "label": "名前を変更",
+        "file": "ファイルの名前を変更",
+        "folder": "フォルダーの名前を変更",
+        "new_file": "拡張子付きの新しい名前:",
+        "new_folder": "新しいフォルダー名:"
+      },
+      "delete": {
+        "label": "削除",
+        "file": "ファイルを削除",
+        "folder": "フォルダーを削除",
+        "files": "{count} 個の選択されたファイルを削除",
+        "folders": "{count} 個の選択されたフォルダーを削除"
+      },
+      "import": {
+        "import": "インポート",
+        "files": "ファイルをインポート",
+        "folder": "フォルダーをインポート",
+        "success": "ファイルが正常にインポートされました",
+        "error": "ファイルのインポート中にエラーが発生しました"
+      },
+      "export": "namespaceファイルをエクスポート",
+      "export_single": "ファイルをエクスポート",
+      "dialog": {
+        "name": {
+          "file": "拡張子付きの名前:",
+          "folder": "フォルダー名:"
+        },
+        "parent_folder": "親フォルダー:",
+        "deletion": {
+          "confirm": "確認",
+          "title": "コンテンツの削除を確認",
+          "files": "<code>{count}</code> 個のファイルを削除してもよろしいですか？",
+          "folders": "<code>{count}</code> 個のフォルダーとそのすべての内容を削除してもよろしいですか？",
+          "mixed": "<code>{folders}</code> フォルダーと <code>{files}</code> ファイルを削除してもよろしいですか？",
+          "file_single": "ファイル <code>{name}</code> を削除してもよろしいですか？",
+          "folder_single": "フォルダー<code>{name}</code>とそのすべての内容を削除してもよろしいですか？"
+        }
+      },
+      "revisions": {
+        "history": "リビジョン履歴",
+        "restore": {
+          "success": "ファイルのリビジョンが正常に復元されました"
+        }
+      },
+      "path": {
+        "copy": "パスをコピー",
+        "success": "パスがクリップボードにコピーされました",
+        "error": "パスをクリップボードにコピー中にエラーが発生しました"
+      }
+    },
+    "continue backfill": "backfillを続行",
+    "delete backfill": "backfillを削除",
+    "pause backfill": "backfillを一時停止",
+    "continue backfills": "backfillを続行",
+    "delete backfills": "backfillを削除",
+    "pause backfills": "backfillを一時停止",
+    "backfill executions": "backfill実行",
+    "execute backfill": "backfillを実行",
+    "backfill paused": "バックフィル PAUSED",
+    "backfill running": "バックフィル実行中",
+    "relative": "相対",
+    "relative start date": "相対開始日",
+    "relative end date": "相対終了日",
+    "now": "現在",
+    "absolute": "絶対",
+    "backfill": "Backfill",
+    "Set labels tooltip": "実行にラベルを設定",
+    "Set labels": "ラベルを設定",
+    "manage labels": "ラベルを管理",
+    "Set labels to execution": "実行<code>{id}</code>のラベルを追加または更新",
+    "Set labels done": "実行のラベルが正常に設定されました",
+    "bulk set labels": "<code>{executionCount}</code>件の実行にラベルを設定してもよろしいですか？",
+    "dependencies loaded": "依存関係が読み込まれました",
+    "loaded x dependencies": "{count}件の依存関係が読み込まれました",
+    "security_advice": {
+      "title": "インスタンスを保護",
+      "content": "インスタンスを保護するために基本認証を有効にしてください。",
+      "switch_text": "再表示しない",
+      "enable": "認証を有効にする"
+    },
+    "true": "True",
+    "false": "False",
+    "undefined": "未定義",
+    "execution-include-non-terminated": "終了していない実行を含めますか？",
+    "execution-warn-title": "重要なWarning!",
+    "execution-warn-deleting-still-running": "この操作をキャンセルし、進行中のexecutionをまず停止することを強くお勧めします。未終了のexecutionを削除すると、concurrencyの問題、flow依存関係管理の不整合、インスタンス上のゾンビプロセスを引き起こし、システムパフォーマンスを低下させる可能性があります。削除を進める前に、これらのリスクを十分に理解してください。",
+    "originalCreatedDate": "元の作成日",
+    "welcome": {
+      "menu": "Welcome",
+      "tour": {
+        "title": "製品ツアーを体験する",
+        "text": "ユースケースを選択し、ステップバイステップガイドに従って、Kestraの機能と能力を学びましょう。❤️"
+      },
+      "tutorial": {
+        "title": "チュートリアル",
+        "text": "----------\n\n * <a href=\"https://kestra.io/tutorial-videos/all?utm_source=app&utm_medium=referral&utm_campaign=welcome-tutorial\" target=\"_blank\">ビデオチュートリアル</a> \n* <a href=\"https://kestra.io/docs?utm_source=app&utm_medium=referral&utm_campaign=welcome-tutorial\" target=\"_blank\">ドキュメント</a> \n* <a href=\"https://kestra.io/blueprints?utm_source=app&utm_medium=referral&utm_campaign=welcome-tutorial\" target=\"_blank\">Blueprints</a>"
+      },
+      "help": {
+        "title": "お困りですか？",
+        "text": "Slackコミュニティで質問してください。行き詰まった場合は、私たちがサポートします。✋"
+      }
+    },
+    "pluginPage": {
+      "search": "{count}+ プラグインを検索",
+      "searchTasks": "{count} 件のタスクを検索",
+      "noResults": "検索に一致するプラグインがありません。",
+      "loadError": "プラグインを読み込めませんでした。もう一度お試しください。",
+      "notFound": "このプラグインが見つかりませんでした。",
+      "elementType": {
+        "tasks": "タスク",
+        "triggers": "トリガー",
+        "conditions": "条件",
+        "taskRunners": "タスクランナー",
+        "charts": "チャート",
+        "apps": "アプリ",
+        "logExporters": "ログエクスポーター",
+        "secrets": "シークレット"
+      },
+      "sortBy": "並び替え",
+      "sort": {
+        "nameAsc": "名前 A-Z",
+        "nameDesc": "名前 Z-A",
+        "newest": "最新",
+        "mostUsed": "最も使用されている"
+      },
+      "group": {
+        "plugins": "プラグイン ({count})",
+        "tasks": "タスク ({count})",
+        "blueprints": "ブループリント ({count})"
+      },
+      "overview": {
+        "title": "概要",
+        "versions": "バージョン",
+        "latest": "最新",
+        "releaseNotes": "リリースノート",
+        "previousVersions": "以前のバージョン",
+        "createdBy": "作成者",
+        "managedBy": "管理者",
+        "pluginType": "プラグインタイプ",
+        "linksResources": "リンクとリソース",
+        "minKestraVersion": "互換性のある最小Kestraバージョン: {version}",
+        "minKestraVersionShort": "最小 Kestra バージョン {version}"
+      },
+      "header": {
+        "enterpriseEdition": "エンタープライズエディション",
+        "certified": "認定済み",
+        "back": "プラグインに戻る"
+      }
+    },
+    "no inputs": "このflowにはinputがありません。",
+    "admin_preferences": "Preferences",
     "settings": {
+      "label": "設定",
+      "updated": "{name} が更新されました",
       "blocks": {
         "configuration": {
-          "descriptions": {
-            "auto_refresh_interval": "リストページでの自動データ更新の間隔（秒）。",
-            "default_namespace": "namespaceなしで新しいflowを作成する際に使用されます。",
-            "editor_type": "初めてflowを開くときに表示されるエディター。",
-            "execute_default_tab": "実行に移動するときに選択されたタブ。",
-            "execute_flow": "実行結果がトリガーされた後に開く場所。",
-            "flow_default_tab": "フローに移動するときに選択されたタブ。",
-            "log_display": "実行を開いたときにログが表示される方法。",
-            "log_level": "実行ログに表示される最小のLogレベル。",
-            "playground": "エディタープレイグラウンドでタスクを個別に実行します。",
-            "triggers_default_tab": "トリガーページに移動するときに選択されたタブ。"
-          },
+          "label": "メイン設定",
           "fields": {
-            "auto_refresh_interval": "自動更新間隔",
-            "default_namespace": "デフォルトNamespace",
-            "editor_type": "デフォルトエディタータイプ",
-            "execute_default_tab": "デフォルト実行タブ",
-            "execute_flow": "Flowを実行",
-            "flow_default_tab": "デフォルト Flow タブ",
             "language": "言語",
-            "log_display": "デフォルトLog表示",
+            "default_namespace": "デフォルトNamespace",
             "log_level": "デフォルトLogレベル",
+            "log_display": "デフォルトLog表示",
+            "editor_type": "デフォルトエディタータイプ",
+            "execute_flow": "Flowを実行",
+            "execute_default_tab": "デフォルト実行タブ",
             "multi_panel_editor": "マルチパネルエディタ",
+            "flow_default_tab": "デフォルト Flow タブ",
+            "triggers_default_tab": "デフォルトトリガーのタブ",
             "playground": "プレイグラウンド",
-            "triggers_default_tab": "デフォルトトリガーのタブ"
+            "auto_refresh_interval": "自動更新間隔"
           },
-          "label": "メイン設定"
-        },
-        "export": {
-          "fields": {
-            "flows": "すべてのflowをエクスポート",
-            "templates": "すべてのテンプレートをエクスポート"
-          },
-          "label": "エクスポート"
-        },
-        "localization": {
           "descriptions": {
-            "date_format": "ダッシュボード全体で日付を表示するために使用されるフォーマット。",
-            "language": "メニューとラベルのインターフェース言語。",
-            "time_zone": "実行日とスケジュールされたトリガーを表示するために使用されます。"
-          },
-          "fields": {
-            "date_format": "日付形式",
-            "time_zone": "タイムゾーン"
-          },
-          "label": "言語と地域",
-          "note": "この設定はUIでの日付と時刻のプロパティを表示するために使用されます。UTC以外のタイムゾーンでflowをスケジュールするには、flowコードやプラグインのデフォルトでSchedule triggerのtimezoneプロパティを設定してください。"
-        },
-        "reset_section_to_defaults": "このセクションのデフォルト値を復元する",
-        "save": {
-          "discard": "破棄",
-          "label": "設定を保存",
-          "unsaved_title": "未保存の変更",
-          "unsaved_warning": "保存されていない変更があります。離れる前に保存しますか？"
-        },
-        "sidebar": {
-          "descriptions": {
-            "items": "サイドバーの項目を表示、非表示、および並べ替えします。"
-          },
-          "fields": {
-            "items": "ナビゲーション項目"
-          },
-          "label": "サイドバー"
+            "default_namespace": "namespaceなしで新しいflowを作成する際に使用されます。",
+            "log_level": "実行ログに表示される最小のLogレベル。",
+            "log_display": "実行を開いたときにログが表示される方法。",
+            "editor_type": "初めてflowを開くときに表示されるエディター。",
+            "execute_flow": "実行結果がトリガーされた後に開く場所。",
+            "execute_default_tab": "実行に移動するときに選択されたタブ。",
+            "flow_default_tab": "フローに移動するときに選択されたタブ。",
+            "triggers_default_tab": "トリガーページに移動するときに選択されたタブ。",
+            "auto_refresh_interval": "リストページでの自動データ更新の間隔（秒）。",
+            "playground": "エディタープレイグラウンドでタスクを個別に実行します。"
+          }
         },
         "theme": {
-          "app_font_size_options": {
-            "large": "大",
-            "medium": "中",
-            "small": "小"
-          },
-          "color_modes": {
-            "dark_1": "ダーク 1.0",
-            "dark_2": "ダーク 2.0",
-            "light": "ライト",
-            "sync": "システムと同期"
-          },
-          "confirmations": {
-            "color_mode": "インターフェースは現在 `{mode}` テーマを使用しています。"
-          },
-          "descriptions": {
-            "app_font_size": "インターフェース全体のフォントサイズに適用されるスケール係数。",
-            "color_mode": "お好みのインターフェーステーマを選択してください。",
-            "color_mode_shortcut": "ヒント: <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>L</kbd> を押すとどこからでもテーマを切り替えられます。",
-            "editor_folding_stratgy": "フローを開くときに長いYAMLブロックをデフォルトで折りたたむ。",
-            "editor_font_family": "YAMLエディタで使用される等幅フォント。",
-            "editor_font_size": "YAMLおよびノーコードエディタで使用されるフォントサイズ。",
-            "editor_hover_description": "エディターでホバー時にプロパティの説明を表示します。",
-            "environment_color": "ナビゲーションで現在の環境に使用されるアクセントカラー。",
-            "environment_name": "現在の環境の表示名。ナビゲーションに表示されます。",
-            "logs_font_size": "ログビューアとターミナルで使用されるフォントサイズ。"
-          },
+          "label": "テーマ設定",
           "fields": {
             "app_font_size": "アプリのフォントサイズ",
             "chart_color_scheme": {
+              "label": "チャートのカラースキーム",
               "classic": "クラシック",
-              "kestra": "Kestra",
-              "label": "チャートのカラースキーム"
+              "kestra": "Kestra"
             },
             "color_mode": "カラーモード",
             "editor_folding_stratgy": "エディタでの自動コード折りたたみ",
@@ -1850,24 +1066,867 @@
             "logs_font_size": "ログフォントサイズ",
             "theme": "テーマ"
           },
-          "label": "テーマ設定"
+          "color_modes": {
+            "dark_2": "ダーク 2.0",
+            "dark_1": "ダーク 1.0",
+            "light": "ライト",
+            "sync": "システムと同期"
+          },
+          "confirmations": {
+            "color_mode": "インターフェースは現在 `{mode}` テーマを使用しています。"
+          },
+          "descriptions": {
+            "color_mode": "お好みのインターフェーステーマを選択してください。",
+            "color_mode_shortcut": "ヒント: <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>L</kbd> を押すとどこからでもテーマを切り替えられます。",
+            "logs_font_size": "ログビューアとターミナルで使用されるフォントサイズ。",
+            "editor_font_family": "YAMLエディタで使用される等幅フォント。",
+            "editor_font_size": "YAMLおよびノーコードエディタで使用されるフォントサイズ。",
+            "editor_folding_stratgy": "フローを開くときに長いYAMLブロックをデフォルトで折りたたむ。",
+            "editor_hover_description": "エディターでホバー時にプロパティの説明を表示します。",
+            "environment_name": "現在の環境の表示名。ナビゲーションに表示されます。",
+            "environment_color": "ナビゲーションで現在の環境に使用されるアクセントカラー。",
+            "app_font_size": "インターフェース全体のフォントサイズに適用されるスケール係数。"
+          },
+          "app_font_size_options": {
+            "small": "小",
+            "medium": "中",
+            "large": "大"
+          }
+        },
+        "localization": {
+          "label": "言語と地域",
+          "note": "この設定はUIでの日付と時刻のプロパティを表示するために使用されます。UTC以外のタイムゾーンでflowをスケジュールするには、flowコードやプラグインのデフォルトでSchedule triggerのtimezoneプロパティを設定してください。",
+          "fields": {
+            "time_zone": "タイムゾーン",
+            "date_format": "日付形式"
+          },
+          "descriptions": {
+            "language": "メニューとラベルのインターフェース言語。",
+            "time_zone": "実行日とスケジュールされたトリガーを表示するために使用されます。",
+            "date_format": "ダッシュボード全体で日付を表示するために使用されるフォーマット。"
+          }
+        },
+        "export": {
+          "label": "エクスポート",
+          "fields": {
+            "flows": "すべてのflowをエクスポート",
+            "templates": "すべてのテンプレートをエクスポート"
+          }
+        },
+        "save": {
+          "label": "設定を保存",
+          "discard": "破棄",
+          "unsaved_title": "未保存の変更",
+          "unsaved_warning": "保存されていない変更があります。離れる前に保存しますか？"
+        },
+        "reset_section_to_defaults": "このセクションのデフォルト値を復元する",
+        "sidebar": {
+          "label": "サイドバー",
+          "fields": {
+            "items": "ナビゲーション項目"
+          },
+          "descriptions": {
+            "items": "サイドバーの項目を表示、非表示、および並べ替えします。"
+          }
+        }
+      }
+    },
+    "apps": "アプリケーション",
+    "demos": {
+      "enterprise_edition": "エンタープライズエディション",
+      "get_a_demo_button": "デモを取得",
+      "contact_sales": "営業に問い合わせる",
+      "watch_the_video": "ビデオを見る",
+      "secrets": {
+        "title": "シークレット管理をアップグレード",
+        "message": "エンタープライズエディション (EE) では、UIで直接シークレットを追加、編集、または削除できます。インスタンスの再起動は不要です。シークレットをnamespaceごとに整理し、詳細なRBAC権限を設定し、親namespaceから子namespaceに継承します。EEは、HashiCorp Vault、AWS Secrets Manager、Azure Key Vault、Google Secret Manager、Elasticsearchなどのシークレットマネージャーと統合します。namespace、テナント、またはインスタンスごとに専用のバックエンドを設定して、チーム間でシークレットを分離するか、外部のvaultに保存された読み取り専用のシークレットを有効にします。シークレットは、保存時および転送時に暗号化されたままです。オプションのキャッシュによりAPIコールが削減され、監査証跡がすべてのアクセスをログに記録します。",
+        "detected_env": "インスタンス開始時に識別されたシークレットタイプの環境変数は次のとおりです:",
+        "empty_env": "まだ環境にSecretsがありません。",
+        "add_env": {
+          "intro": "新しいSecretを作成するには：",
+          "first": "<a href=\"https://kestra.io/docs/how-to-guides/secrets?utm_source=app&utm_medium=referral&utm_campaign=secrets-inlinedoc#using-secrets-in-kestra\" target=\"_blank\">シークレットの値をBase64でエンコード</a>",
+          "second": "`<strong>SECRET_{'{MY_SECRET_KEY}'}</strong>`という名前の環境変数を上記の値で追加してください。",
+          "third": "Kestraインスタンスを再起動する"
         }
       },
-      "label": "設定",
-      "updated": "{name} が更新されました"
+      "apps": {
+        "title": "Kestraでカスタムアプリを構築する",
+        "message": "Kestra Enterprise Editionのアプリは、プラットフォーム外からKestraのworkflowと連携するカスタムUIを構築することを可能にします。この機能により、workflowをカスタムアプリケーションのバックエンドとして使用でき、技術的でないユーザーがフォームを通じてデータを送信したり、承認待ちのPAUSED状態のworkflowを再開したりすることができます。"
+      },
+      "tests": {
+        "label": "テスト",
+        "header": "フローの単体テスト",
+        "title": "すべての変更で信頼性を確保",
+        "message": "フローのロジックを個別に検証し、リグレッションを早期に検出し、変更や成長に伴う自動化に自信を持ち続けましょう。"
+      },
+      "assets": {
+        "label": "アセット",
+        "header": "アセットメタデータとオブザーバビリティ",
+        "title": "すべてのデータセット、サービス、および依存関係を表示します。",
+        "message": "アセットは、観測性、系譜、および所有権のメタデータを接続し、プラットフォームチームが迅速にトラブルシューティングを行い、自信を持ってデプロイできるようにします。"
+      },
+      "IAM": {
+        "title": "IAMを通じてユーザーを管理（SSO、SCIM、RBACを使用）",
+        "message": "Kestra Enterprise Editionには、シングルサインオン（SSO）、SCIMディレクトリ同期、ロールベースのアクセス制御（RBAC）を備えた組み込みのIAM機能があり、複数のアイデンティティプロバイダーと統合し、ユーザーおよびサービスアカウントに対して詳細な権限を割り当てることができます。"
+      },
+      "tenants": {
+        "title": "隔離されたTenantでWorkflowを管理する",
+        "message": "Kestra Enterprise Editionはマルチテナンシーをサポートしており、異なるチームやプロジェクトごとに完全に分離された環境を提供します。それぞれの環境には、専用のworkerグループやシークレット、内部ストレージバックエンドなどのリソースが含まれます。"
+      },
+      "audit-logs": {
+        "title": "監査Logで変更を追跡",
+        "message": "Kestra Enterprise Editionは、すべてのアクティビティを堅牢で不変の記録としてログに記録し、変更の追跡、コンプライアンスの維持、問題のトラブルシューティングを容易にします。"
+      },
+      "quotas": {
+        "title": "フローの実行クォータを設定する",
+        "message": "Kestra Enterprise Editionでは、フローにクォータを定義して、時間枠内の同時実行数または総実行数を制限できます。クォータは、共有インフラストラクチャの保護、SLAの適用、および過剰なリソースを消費する暴走ワークフローの防止に役立ちます。"
+      },
+      "instance": {
+        "title": "インスタンス全体のインフラストラクチャを管理する",
+        "message": "Kestra Enterprise Editionは、プラットフォームの健康状態を観察し、Workers、Schedulers、Executorsなどのすべてのサービスの稼働時間メトリクスを追跡するための運用ダッシュボードを提供します。同じページから、計画されたダウンタイムについてユーザーに通知するためのアナウンスを作成することもでき、アップグレードを実行するためにすべてのサービスとワークフローの実行を一時的にPAUSED状態にするメンテナンスモードに入ることもできます。"
+      },
+      "blueprints": {
+        "title": "カスタムBlueprintの追加",
+        "message": "Kestra Enterprise Editionでは、組織専用のカスタムBlueprintを作成できます。これらをベストプラクティスのテンプレートとして使用し、チーム内で一般的に使用されるworkflowを共有、集中化、文書化することができます。"
+      },
+      "namespace": {
+        "edit": {
+          "title": "名前空間管理をアップグレードする",
+          "message": "Kestra Enterprise Editionでは、namespaceはシークレット、変数、プラグインのデフォルトの高度な分離とガバナンスを提供します。管理者は、カスタムシークレットマネージャー、分離されたストレージバックエンド、専用のworkerグループ、および詳細な権限をnamespaceごとに設定できます。これにより、シークレット、変数、およびプラグインの設定が異なるチームやプロジェクト間で安全かつ簡単に管理されることが保証されます。"
+        },
+        "secrets": {
+          "title": "秘密を安全に管理する方法",
+          "message": "Kestra Enterprise Editionでは、namespaceレベルでシークレットを保存および管理することができ、リスクを最小限に抑え、各チームの認証情報を分離して保持します。ネストされた階層のおかげで、親namespaceで認証情報を設定すると、すべての子namespaceに継承されます。専用のシークレットマネージャーのサポートと詳細なnamespaceレベルの権限設定により、セキュリティとコンプライアンスがさらに強化されます。"
+        },
+        "assets": {
+          "title": "資産管理の集中化",
+          "message": "Kestra Enterprise Editionでは、Assetsはワークフローがやり取りするリソースのライブインベントリを保持します。これらのリソースには、データベーステーブル、仮想マシン、ファイル、または使用する外部システムが含まれます。"
+        },
+        "variables": {
+          "title": "変数を中央で管理する",
+          "message": "Kestra Enterprise Editionでは、namespaceレベルの変数を定義および管理することで、flow全体での繰り返しの設定を排除できます。これらの変数は一貫性を確保し、設定の更新を簡素化し、どのtaskやtriggerからも簡単に参照できるため、よりクリーンで保守しやすいワークフローを実現します。"
+        },
+        "plugin-defaults": {
+          "title": "プラグインのデフォルトで設定を標準化する",
+          "message": "Kestra Enterprise Editionでは、namespace固有のプラグインデフォルトを設定でき、各flowでの重複した設定の必要性を減らします。この中央プラグインガバナンスは、一貫した設定を強制し、秘密情報や変数の安全な参照を可能にし、ワークフローのメンテナンスを簡素化します。"
+        },
+        "history": {
+          "title": "一箇所でリビジョン履歴を管理",
+          "message": "Kestra Enterprise Editionでは、Namespacesのリビジョン履歴を管理できます。"
+        },
+        "audit-logs": {
+          "title": "すべての変更を一箇所で追跡",
+          "message": "Kestra Enterprise Editionでは、namespaceレベルの監査Logを詳細な差分とともに表示でき、すべてのリソースにわたって誰が何をいつ変更したかの履歴を明確に確認できます。"
+        }
+      }
+    },
+    "assets": {
+      "title": "アセット"
+    },
+    "onboarding": {
+      "welcome": {
+        "headline": "数分で最初のワークフローを作成して実行しましょう",
+        "guided_title": "最初のフローを作成",
+        "badge": "チュートリアル",
+        "guided_description": "ガイド付きステップで最初のフローを作成し、実行する方法を学びましょう。",
+        "guided_duration": "ほとんどのユーザーにおすすめ",
+        "self_serve_title": "一からフローを作成",
+        "self_serve_description": "エディタに直接移動して、自分のフローを作成します。",
+        "self_serve_note": "上級ユーザー向け",
+        "additional_help": "追加のヘルプ",
+        "docs": "ドキュメント",
+        "tutorial": "チュートリアル",
+        "blueprints": "ブループリント",
+        "slack": "Slackコミュニティ"
+      },
+      "steps": {
+        "flow_basics": {
+          "title": "フローの基本",
+          "description": "Kestraでは、<code>flow</code> は中核となるオーケストレーション単位です。メタデータと順序付けられたタスクを含むYAMLで定義します。<br><br>以下のサンプル構造を確認し、ステップごとに作成していきましょう。"
+        },
+        "add_id": {
+          "title": "フローIDを追加",
+          "description": "IDはフローの一意な名前です。検索、実行、一貫した参照のために使用されます。<br><br>ルートレベルに <code>id</code> を追加してください。"
+        },
+        "add_namespace": {
+          "title": "ネームスペースを追加",
+          "description": "Namespaceはチーム、プロジェクト、環境ごとにフローを整理するフォルダのようなグループです。<br><br>ルートレベルに <code>namespace</code> を追加してください。"
+        },
+        "add_input": {
+          "title": "入力を追加",
+          "description": "Inputsはフローレベルのパラメータで、タスク内から参照し、実行時の動作を動的に制御できます。<br><br><code>name</code> という名前の入力を <code>STRING</code> 型で追加してください。"
+        },
+        "add_log_task": {
+          "title": "最初のタスクを追加",
+          "description": "Tasksはフローが実行する作業単位で、順序付けられたステップのリストとして定義されます。各タスクには一意の <code>id</code> と <code>type</code> が必要です。Kestraは外部システム向けに多くのタスクプラグインを提供していますが、ここではPython Scriptタスクを使用します。<br><br><code>&#123;&#123; ... &#125;&#125;</code> 構文はPebble式で、実行時に変数を動的に参照するために使用されます。例：<code>&#123;&#123; inputs.name &#125;&#125;</code>。<br><br><code>tasks</code> の下に、<code>id</code>、<code>type</code>、および挨拶を出力する <code>script</code> を含む最初のタスクを追加してください。"
+        },
+        "save_flow": {
+          "title": "フローを保存",
+          "description": "保存すると、フロー定義が永続化され、実行できるようになります。"
+        },
+        "execute_flow": {
+          "title": "フローを実行",
+          "description": "実行すると、入力値を指定してフローの実行が開始されます。"
+        },
+        "view_logs_status": {
+          "title": "実行を確認",
+          "description": "実行の詳細には、ステータス、実行時間、タスクごとの出力ログが表示されます。<br><br>実行詳細を開き、ガントチャート内の <code>greet</code> をクリックしてログを確認してください。"
+        },
+        "edit_flow_from_execution": {
+          "title": "フローエディタに戻る",
+          "description": "実行画面から直接フロー定義に戻り、素早く編集できます。"
+        },
+        "add_cron_trigger": {
+          "title": "cronトリガーを追加",
+          "description": "Triggersはスケジュールや外部イベント（例：WebhookやMQTTメッセージ）に基づいて実行を開始できます。<br><br>このフローが5分ごとに実行されるように、cronスケジュールトリガーを追加してください。"
+        },
+        "add_input_default": {
+          "title": "入力のデフォルト値を設定",
+          "description": "フローが自動的にトリガーされる場合でも、入力には実行時の値が必要です。<br><br><code>name</code> 入力は前のステップで作成済みなので、再度追加する必要はありません。既存の <code>name</code> 入力にデフォルト値を設定してください。"
+        },
+        "save_flow_again": {
+          "title": "フローを保存",
+          "description": "これでフローにはスケジュールと自動実行用のデフォルト入力値が設定されました。"
+        },
+        "background_runs_info": {
+          "title": "スケジュール実行",
+          "description": "このフローは5分ごとにバックグラウンドで実行されます。<br><br>左側メニューの「Executions」概要から、スケジュール実行を確認できます。"
+        },
+        "finish": {
+          "title": "最初のフローチュートリアルを完了しました",
+          "description": "素晴らしいスタートです。フローの作成、実行、パラメータ化、スケジュール設定を行いました。<br><br>次に何をしますか？"
+        }
+      },
+      "actions": {
+        "next": "次へ",
+        "complete": "完了",
+        "save_to_continue": "右上の「Save」をクリックしてください。",
+        "execute_to_continue": "1. 右上の「Execute」をクリックします。\n2. <strong>name</strong> に値を入力します。\n3. モーダルで再度「Execute」をクリックします。",
+        "edit_flow_to_continue": "右上の「Edit flow」をクリックしてください。",
+        "cancel_tutorial": "チュートリアルをキャンセル",
+        "finish_tutorial": "チュートリアルを終了"
+      },
+      "finish_actions": {
+        "explore_blueprints": "ブループリントを見る",
+        "create_flow": "フローを作成"
+      },
+      "editor_hints": {
+        "build_intro": "ステップごとに最初のフローを作成しましょう。",
+        "step_1": "# 1) idを追加",
+        "step_2": "# 2) namespaceを追加",
+        "step_3": "# 3) 入力を追加",
+        "step_4": "# 4) タスクを追加し、最初のPythonタスクを作成",
+        "step_5": "# 5) cronトリガーを追加"
+      },
+      "cancel_modal": {
+        "title": "最初のフローチュートリアルをキャンセル",
+        "description": "最初のフローチュートリアルをキャンセルしますか？",
+        "confirm": "チュートリアルをキャンセル",
+        "keep": "チュートリアルを続ける"
+      },
+      "validation": {
+        "complete_step": "あと少しです。このステップを完了して続行してください。",
+        "fix_yaml": "YAMLの書式に小さな問題があります。修正してから続行してください。",
+        "add_id": "上部にフローIDを追加してください。例：`id: hello_flow`。",
+        "add_namespace": "上部にnamespaceを追加してください。例：`namespace: company.team`。",
+        "add_input_section": "`inputs` セクションを作成し、1つの入力を追加してください。",
+        "add_input_id": "`inputs` 内に `id: name` を追加してください。",
+        "add_input_type": "入力タイプを `STRING` に設定してください。",
+        "add_log_task_section": "`tasks` セクションを作成し、最初のタスクを追加してください。",
+        "add_log_task_id": "タスクにIDを設定してください。例：`id: greet`。",
+        "add_log_task_type": "タスクタイプを `io.kestra.plugin.scripts.python.Script` に設定してください。",
+        "add_log_task_message": "タスクに `script` フィールドを追加してください。",
+        "add_log_task_pebble": "スクリプト内でPebble式を使用し、入力値を参照してください（例：`inputs.name`）。",
+        "save_flow": "続行するには「Save」をクリックしてください。",
+        "execute_flow": "続行するにはフローを一度実行してください。",
+        "view_logs_status": "実行詳細を開き、`greet` のログを確認してください。",
+        "edit_flow_from_execution": "上部バーの「Edit flow」をクリックして続行してください。",
+        "add_cron_trigger_section": "`triggers` セクションを作成し、スケジュールトリガーを追加してください。",
+        "add_cron_trigger_type": "トリガータイプを `io.kestra.plugin.core.trigger.Schedule` に設定してください。",
+        "add_cron_trigger_cron": "cron式を追加してください。例：`\"*/5 * * * *\"`。",
+        "add_input_default_section": "`inputs` に戻り、既存の `name` 入力をそのまま使用してください（2つ目の入力は追加しないでください）。",
+        "add_input_default_id": "既存の入力IDを `name` のままにしてください。",
+        "add_input_default_defaults": "`name` にデフォルト値を追加してください。例：`defaults: \"Kestra\"`。",
+        "save_flow_again": "続行するには再度「Save」をクリックしてください。"
+      }
+    },
+    "enable concurrency": "同時実行を有効にする",
+    "auditlogs": "Audit Logs",
+    "quotas": "クォータ",
+    "iam": "IAM",
+    "tenant": {
+      "name": "テナント",
+      "names": "テナント"
+    },
+    "ee-tooltip": {
+      "features-blocked": "この機能はEnterprise Editionが必要です。",
+      "button": "お問い合わせ"
+    },
+    "flow_only": "Flowタブでのみ利用可能です。",
+    "bulk action async warning": "少々お待ちください。",
+    "bulk unpause backfills": "{count}個のbackfillを再開",
+    "bulk pause backfills": "{count}個のbackfillを一時停止",
+    "bulk delete backfills": "{count}個のbackfillを削除",
+    "bulk unlock": "{count}個のtriggersを解除",
+    "bulk disabled status": {
+      "true": "{count}個のtriggersを無効化",
+      "false": "{count}個のtriggersを有効化"
+    },
+    "unlock": "解除",
+    "bulk success unpause backfills": "{count}個のbackfillsが再開されました",
+    "bulk success pause backfills": "{count}個のbackfillsが一時停止されました",
+    "bulk success delete backfills": "{count}個のbackfillsが削除されました",
+    "bulk success unlock": "{count}個のtriggersが解除されました",
+    "bulk success disabled status": {
+      "true": "{count}個のtrigger(s)が無効化されました",
+      "false": "{count}個のtrigger(s)が有効化されました"
+    },
+    "no_namespaces": "検索条件に一致するnamespaceはゼロです。",
+    "system_namespace": "プラットフォームをシステムフローで管理しましょう。",
+    "system_namespace_description": "メンテナンスタスクを自動化し、FAILUREアラートから自動クリーンアップまで対応します。",
+    "pluginDefaults": {
+      "title": "プラグインのデフォルト",
+      "add": "プラグインデフォルトを追加",
+      "edit": "プラグインデフォルトを編集",
+      "add_subtitle": "新しいプラグインのデフォルトをそのプロパティで設定する",
+      "edit_subtitle": "既存のプラグインのデフォルト設定を変更する",
+      "predefined": "定義済みプラグイン",
+      "custom": "カスタムプラグイン",
+      "form": "フォーム",
+      "yaml": "YAML",
+      "select_predefined": "定義済みプラグインを選択",
+      "cancel": "キャンセル",
+      "update": "プラグインデフォルトを更新",
+      "custom_type": "カスタムプラグインタイプ",
+      "custom_placeholder": "プラグインタイプを入力",
+      "use_custom": "カスタムを使用",
+      "custom_configure": "カスタムプラグインタイプ - YAMLを使用して構成",
+      "yaml_configuration": "YAML設定",
+      "show_yaml": "YAMLを表示"
+    },
+    "secret": {
+      "add": "作成",
+      "update": "シークレット '{name}' を更新",
+      "isReadOnly": "シークレットは読み取り専用です",
+      "names": "Secrets",
+      "inherited": "継承されたsecrets"
+    },
+    "workerId": "Worker Id",
+    "kv": {
+      "name": "KV Store",
+      "type": "タイプ",
+      "add": "作成",
+      "update": "キー'{key}'の値を更新",
+      "duplicate": "このキーは既に存在します",
+      "delete multiple": {
+        "confirm": "本当に削除しますか: <code>{name}</code> KV(s)?",
+        "warning": "あなたはこれらのnamespaceに対する権限がないため、省略されます: <code>{namespaces}</code>"
+      },
+      "inherited": "継承されたKVペア"
+    },
+    "expiration": "有効期限",
+    "failed to render pdf": "PDFプレビューのレンダリングに失敗しました",
+    "page": {
+      "previous": "前のページ",
+      "next": "次のページ"
+    },
+    "namespace_editor": {
+      "empty": {
+        "title": "現在開いているタブはありません",
+        "create_message": "namespaceファイルを作成またはインポートできます。",
+        "video_message": "エディターの紹介ビデオをご覧いただけます。"
+      },
+      "close": {
+        "tab": "タブを閉じる",
+        "all": "すべてのタブを閉じる",
+        "other": "他のタブを閉じる",
+        "right": "右側に閉じる"
+      }
+    },
+    "curl": {
+      "command": "cURLコマンド",
+      "note": "SECRETおよびFILEのinputタイプの場合、コマンドは実際の値に合わせて調整する必要があります。"
+    },
+    "webhook": {
+      "curl_command": "Webhook cURL コマンド",
+      "payload": "Webhookペイロード（JSON）",
+      "curl_note": "このcURLコマンドを使用して、カスタムJSONペイロードでwebhookを介してflowをtriggerします。",
+      "no_triggers": "このflowには有効なWebhookトリガーがありません",
+      "copy_url": "Webhook URLをコピー"
+    },
+    "logs_view": {
+      "raw": "Temporalビュー",
+      "raw_details": "タスクログとフローのログをタイムスタンプ順に生の形式で表示",
+      "compact": "デフォルトビュー",
+      "compact_details": "タスクログを各タスクごとにグループ化してコンパクトビューで表示"
+    },
+    "execution_deletion": {
+      "logs": "ログを削除",
+      "metrics": "メトリクスを削除",
+      "storage": "内部ストレージファイルを削除"
+    },
+    "scope_filter": {
+      "all": "すべての{label}",
+      "user": "ユーザー {label}",
+      "system": "システム {label}",
+      "user_description": "通常のユーザーが開始した{label}",
+      "system_description": "システムメンテナンス {label}"
+    },
+    "data": "データ",
+    "webhook link copied": "Webhookリンクがコピーされました。",
+    "copy url": "URLをコピー",
+    "scheduleDate": "スケジュール日付",
+    "warning": "警告",
+    "trigger_check_warning": "トリガー変数を使用すると、手動でのflow実行では機能しません。問題を解決するために`??`コアレス演算子を追加してください。例えば、`trigger.date`の代わりに`trigger.date ?? execution.startDate`を使用してください。",
+    "docs": "ドキュメント",
+    "active-slots": "アクティブスロット",
+    "behavior": "動作",
+    "concurrency": "並行性",
+    "no-executions-view": {
+      "title": "自動化を開始",
+      "sub_title": "「Execute」ボタンをクリックして、最初のworkflowのexecutionを開始してください。",
+      "namespace_sub_title": "このダッシュボードを埋めるために、このnamespaceから1つ以上のflowを実行します。",
+      "guidance_desc": "フローを実行するためのガイダンスが必要ですか？",
+      "namespace_guidance_desc": "Namespaceを管理するためのガイダンスが必要ですか？",
+      "guidance_sub_desc": "ドキュメントを参照して、必要なすべての情報を確認してください。"
+    },
+    "execution_guide": {
+      "get_started": {
+        "title": "はじめに ⚡",
+        "text": "クイックスタートガイドに従ってKestraをインストールし、最初のworkflowの構築を始めましょう。"
+      },
+      "namespaces": {
+        "title": "名前空間について",
+        "text": "namespaceは、flowとそのコンポーネントの論理的なグループ化です。"
+      },
+      "workflow_components": {
+        "title": "ワークフローコンポーネント",
+        "text": "Kestraワークフローの主なオーケストレーションコンポーネントを知る。"
+      },
+      "videos_tutorials": {
+        "title": "ビデオチュートリアル",
+        "text": "ビデオチュートリアルで始めましょう。"
+      }
+    },
+    "open sidebar": "サイドバーを開く",
+    "close sidebar": "サイドバーを閉じる",
+    "customize sidebar": "サイドバーをカスタマイズ",
+    "reset to defaults": "デフォルトにリセット",
+    "drop items here": "ここにアイテムをドロップしてください",
+    "files": "ファイル",
+    "optional": "オプション",
+    "no_data": "ここにはまだ何もないようです…<br/>フィルターを調整するか、もう一度試してみてください！",
+    "bookmark": "ブックマーク",
+    "remove_bookmark": "このブックマークを削除してもよろしいですか？",
+    "showLess": "表示を減らす",
+    "showMore": "もっと表示",
+    "documentationMenu": "ドキュメントメニュー",
+    "item": "アイテム",
+    "items": "アイテム",
+    "cron": "Cron（クーロン）",
+    "execution_started": "実行が開始されました！",
+    "execution_failed": "実行が失敗しました！",
+    "last error was": "最後のエラーは",
+    "execution restarted": "この実行は{nbRestart}回再開されました。",
+    "execution replay": "この実行は次のリプレイです",
+    "execution replayed": "この実行は再実行されました。",
+    "task run id": "タスクランID",
+    "active": "アクティブ",
+    "flows imported": "フローがインポートされました",
+    "flow not imported": "一部のflowをインポートできませんでした",
+    "plugin defaults exported": "プラグインのデフォルトがエクスポートされました",
+    "failed to export plugin defaults": "プラグインのデフォルトのエクスポートに失敗しました",
+    "plugin defaults imported": "プラグインのデフォルトがインポートされました",
+    "plugin defaults not imported": "一部のプラグインデフォルトをインポートできませんでした",
+    "failed to import plugin defaults": "プラグインのデフォルトのインポートに失敗しました",
+    "filters": {
+      "label": "フィルターを選択",
+      "empty": "データがありません。",
+      "format": "「key:value」としてパラメータを入力してください。",
+      "text_search": "このテキストを検索",
+      "options": {
+        "namespace": "Namespace（ネームスペース）",
+        "flow": "フロー",
+        "state": "状態",
+        "scope": "スコープ",
+        "child": "子",
+        "level": "ログレベル",
+        "task": "タスク",
+        "metric": "メトリック",
+        "user": "ユーザー",
+        "type": "タイプ",
+        "service_type": "タイプ",
+        "permission": "許可",
+        "action": "アクション",
+        "status": "ステータス",
+        "details": "詳細",
+        "aggregation": "集計",
+        "relative_date": "相対日付",
+        "absolute_date": "絶対日付",
+        "labels": "ラベル",
+        "text": "申し訳ありませんが、翻訳するためのテキストが提供されていないようです。翻訳が必要なテキストをもう一度送信してください。",
+        "startDate": "開始日",
+        "endDate": "終了日"
+      },
+      "comparators": {
+        "is": "です",
+        "is_one_of": "のいずれか",
+        "is_not": "ではありません",
+        "not_in": "にない",
+        "contains": "含む",
+        "not_contains": "含まれていない",
+        "in": "内",
+        "between": "間",
+        "starts_with": "で始まる",
+        "greater_than": "より大きい",
+        "greater_than_or_equal_to": "以上",
+        "less_than": "未満",
+        "less_than_or_equal_to": "以下以下",
+        "ends_with": "で終了します"
+      },
+      "save": {
+        "label": "保存済み検索",
+        "remove": "削除",
+        "empty": "検索をまだ保存していません。",
+        "tooltip": "空の検索条件を保存することはできません。",
+        "name_already_used": "ラベルはすでに使用されています。",
+        "dialog": {
+          "heading": "現在の検索を保存",
+          "placeholder": "ラベル",
+          "hint": "この検索条件にどのようなラベルを付けますか？",
+          "confirmation": "検索条件 <code>{name}</code>"
+        }
+      },
+      "settings": {
+        "label": "ページ設定",
+        "show_chart": "メインチャートを表示"
+      }
+    },
+    "custom value": "カスタム value",
+    "chart": "チャート",
+    "chart preview": "チャートプレビュー",
+    "no_code": {
+      "toggle_pebble": "ペブルエディタを切り替え",
+      "version_oss_placeholder": "エンタープライズエディションでプラグインバージョニングをアンロック",
+      "unnamed": "名前なし",
+      "adding": "+ {what}を追加",
+      "adding_default": "+ 新しいvalueを追加",
+      "add_field": "{field}を追加",
+      "clearSelection": "選択をクリア",
+      "labels": {
+        "yaml": "YAMLエディター",
+        "no_code": "コードエディタなし",
+        "label": "ラベル",
+        "variable": "変数"
+      },
+      "sections": {
+        "deprecated": "非推奨プロパティ",
+        "tasks": "タスク",
+        "triggers": "トリガー",
+        "errors": "エラーハンドラー",
+        "afterExecution": "実行後",
+        "finally": "最後に",
+        "pluginDefaults": "プラグインデフォルト"
+      },
+      "fields": {
+        "main": {
+          "id": "Flow ID",
+          "namespace": "Namespace（ネームスペース）",
+          "description": "説明",
+          "inputs": "入力"
+        },
+        "general": {
+          "retry": "リトライ",
+          "sla": "SLA",
+          "labels": "ラベル",
+          "outputs": "出力",
+          "variables": "変数",
+          "concurrency": "並行性",
+          "disabled": "無効",
+          "listeners": "リスナー",
+          "taskDefaults": "タスクデフォルト",
+          "workerGroup": "ワーカーグループ",
+          "workerSelector": "ワーカーセレクター",
+          "checks": "チェック",
+          "updated": "更新済み"
+        }
+      },
+      "select": {
+        "default": "タイプを選択",
+        "task": "タスクを選択",
+        "tasks": "タスクを選択",
+        "triggers": "トリガーを選択",
+        "errors": "タスクを選択",
+        "finally": "タスクを選択",
+        "pluginDefaults": "プラグインを選択",
+        "afterExecution": "タスクを選択",
+        "conditions": "条件を選択",
+        "inputs": "入力フィールドタイプを選択",
+        "charts": "チャートタイプを選択",
+        "where": "フィルタータイプを選択",
+        "numerator": "分子を選択"
+      },
+      "creation": {
+        "default": "追加",
+        "tasks": "タスクを追加",
+        "triggers": "トリガーを追加",
+        "errors": "エラーハンドラーを追加",
+        "finally": "finally ブロックを追加",
+        "pluginDefaults": "プラグインのデフォルトを追加",
+        "afterExecution": "実行後ブロックを追加",
+        "conditions": "条件を追加",
+        "inputs": "入力フィールドを追加",
+        "charts": "チャートを追加",
+        "where": "データをフィルタリングする",
+        "numerator": "分子を追加"
+      },
+      "remove": {
+        "default": "このエントリを削除",
+        "cases": "このケースを削除"
+      }
+    },
+    "properties": {
+      "label": "プロパティ",
+      "hint": "表示する列を選択",
+      "shown": "表に表示",
+      "hidden": "テーブルに隠す"
+    },
+    "editor_shortcuts": {
+      "label": "キーボードショートカット",
+      "trigger_autocompletion": "オートコンプリートをトリガー",
+      "command_palette": "コマンドパレットを表示",
+      "save_flow": "フローを保存",
+      "execute_flow": "フローを実行",
+      "toggle_ai_agent": "AIエージェントを切り替える",
+      "move_line": "行を移動",
+      "duplicate_cursor": "カーソルを複製",
+      "fold_unfold": "コードを折りたたむ/展開する",
+      "comment_uncomment": "コメント/コメント解除",
+      "comment": "コメント",
+      "uncomment": "コメント解除",
+      "decrease_fontsize": "エディタのフォントサイズを小さくする",
+      "increase_fontsize": "エディタのフォントサイズを大きくする",
+      "reset_fontsize": "エディタのフォントサイズをリセット"
+    },
+    "instance": "インスタンス",
+    "something_went_wrong": {
+      "loading_execution": "実行の読み込み中に問題が発生しました。",
+      "connection_lost": {
+        "title": "接続が中断されました",
+        "message": "Kestraインスタンスに接続できませんでした。実行中であることを確認し、ページを更新してください。"
+      }
+    },
+    "debug": "デバッグ",
+    "default": "デフォルト",
+    "data_not_protected": "あなたのデータは保護されていません。失わないようにしてください。<b>無料のセキュリティ機能を有効にするか、有料オプションをお試しください。</b>",
+    "activate_basic_auth": "基本認証を有効化する",
+    "dark_version": "ダークバージョン",
+    "use_dark_background": "暗い背景で作業する際には、このバージョンを使用して、私たちの名前が読みやすい状態を保ってください。",
+    "light_version": "ライトバージョン",
+    "light_background": "これは、明るい背景で作業する際の推奨オプションです。",
+    "monogram": "モノグラム",
+    "wordmark_colors": "ワードマークの色は背景に応じて変化し、アイコンは暗い背景に配置された場合、背景なしで表示されます。",
+    "download_logos": "ロゴパックをダウンロード",
+    "this_task_has": "このtaskは",
+    "about_this_blueprint": "このblueprintについて",
+    "deleted_label": "削除されました",
+    "fold_all_multi_lines": "すべての複数行を折りたたむ",
+    "task_id_exists": "タスクIDは既に存在します",
+    "task_id_message": "フロー内にTask Id ${existingTask}は既に存在します。",
+    "trigger_id_exists": "トリガーIDはすでに存在します。",
+    "trigger_id_message": "フロー内に既存のTrigger Id ${existingTrigger}が既に存在します。",
+    "watch": "ウォッチ",
+    "learn_more": "詳細を確認",
+    "watch_video": "ビデオを見る",
+    "runners": "ランナー",
+    "select": "{{section}}を選択してください",
+    "for flow": "フロー用",
+    "forbidden system labels": "system label として使用できるのは system.correlationId のみです",
+    "confirm": "確認",
+    "taskRunners": "タスクランナー",
+    "additionalPlugins": "追加プラグイン",
+    "appBlocks": "アプリブロック",
+    "charts": "チャート",
+    "dataFilters": "データフィルター",
+    "logExporters": "ログエクスポーター",
+    "empty": {
+      "namespaceFiles": {
+        "title": "このnamespaceにはまだファイルがありません",
+        "content": "namespaceファイルは、このnamespaceのプロジェクトフォルダのように機能します。Python、SQL、dbt、Terraformのコードを保存し、flow内の任意のファイルを次の方法で参照できます"
+      },
+      "announcements": {
+        "title": "お知らせはまだありません！",
+        "content": "お知らせを使用すると、ユーザーに変更を通知したり、計画されたメンテナンスのダウンタイムについて知らせたりすることができます。お知らせの種類、表示する日付範囲を選択し、お知らせメッセージを作成してください。"
+      },
+      "kill_switches": {
+        "title": "まだKill Switchがありません！",
+        "content": "キルスイッチ機能は、問題のある実行を停止するためのUIベースのメカニズムを提供します。これは、CLI専用の<code>--skip-executions</code>および<code>--skip-flows</code>コマンドを包括的な管理インターフェースに置き換えます。"
+      },
+      "apps": {
+        "title": "まだアプリがありません！",
+        "content": "外部からKestraと連携するアプリを作成し始めましょう。"
+      },
+      "testSuites": {
+        "title": "テストスイートがまだありません！",
+        "content": "テストスイートを作成して、flowをテストし始めましょう。"
+      },
+      "assets": {
+        "title": "まだアセットがありません！",
+        "content": "データ資産、サービス、インフラストラクチャを追跡および管理するためのアセットを追加します。"
+      },
+      "apiTokens": {
+        "title": "APIトークンを管理する",
+        "content": "APIトークンは、Kestra APIへのプログラムによるアクセスを許可したいときに使用されます。"
+      },
+      "concurrency_executions": {
+        "title": "このFlowには進行中の実行はありません。",
+        "content": "<strong><a href=\"https://kestra.io/docs/workflow-components/execution?utm_source=app&utm_medium=referral&utm_campaign=concurrency-inlinedoc\" target=\"_blank\">Executions</a></strong> についての詳細は、ドキュメントをご覧ください。"
+      },
+      "concurrency_limit": {
+        "title": "このFlowには制限が設定されていません。",
+        "content": "<strong><a href=\"https://kestra.io/docs/workflow-components/concurrency?utm_source=app&utm_medium=referral&utm_campaign=concurrency-inlinedoc\" target=\"_blank\">同時実行制限</a></strong>についての詳細は、ドキュメントをご覧ください。"
+      },
+      "concurrency_limits": {
+        "title": "同時実行制限は設定されていません。",
+        "content": "詳細については、<strong><a href=\"https://kestra.io/docs/workflow-components/concurrency?utm_source=app&utm_medium=referral&utm_campaign=concurrency-inlinedoc\" target=\"_blank\">Concurrency Limits</a></strong>に関するドキュメントをご覧ください。"
+      },
+      "pluginDefaults": {
+        "title": "プラグインのデフォルトがまだありません！",
+        "content": "プラグインデフォルトを使用すると、プラグインの設定を一元管理し、namespace内のすべてのflowと共有できます。"
+      },
+      "variables": {
+        "title": "変数はまだありません",
+        "content": "フロー間で設定を共有するためにkv storeにkey-valueペアを追加します。子namespaceはそれらを自動的に継承し、任意のvalueを参照することができます。"
+      },
+      "workerRegistrationTokens": {
+        "title": "登録トークンがまだありません！",
+        "content": "登録トークンを使用すると、リモートworkerが安全に認証し、Kestraインスタンスに登録できます。トークンを作成し、それを使用して新しいworkerをこのクラスターに接続します。"
+      },
+      "groups": {
+        "title": "まだグループがありません！",
+        "content": "グループを使用すると、ユーザーをまとめてバンドルし、テナント全体で権限とロールバインディングを一括管理できます。"
+      },
+      "dependencies": {
+        "FLOW": {
+          "title": "現在、依存関係はありません。",
+          "content": "<a href=\"https://kestra.io/docs/ui/flows?utm_source=app&utm_medium=referral&utm_campaign=dependencies-inlinedoc#dependencies\" target=\"_blank\">Flow Dependencies</a> についての詳細は、ドキュメントをご覧ください。"
+        },
+        "EXECUTION": {
+          "title": "現在、依存関係はありません。",
+          "content": "<a href=\"https://kestra.io/docs/ui/executions?utm_source=app&utm_medium=referral&utm_campaign=dependencies-inlinedoc#dependencies\" target=\"_blank\">実行の依存関係</a>についての詳細は、ドキュメントをご覧ください。"
+        },
+        "NAMESPACE": {
+          "title": "現在、依存関係はありません。",
+          "content": "<a href=\"https://kestra.io/docs/ui/namespaces?utm_source=app&utm_medium=referral&utm_campaign=dependencies-inlinedoc#dependencies\" target=\"_blank\">Namespace Dependencies</a> についての詳細は、ドキュメントをご覧ください。"
+        },
+        "ASSET": {
+          "title": "現在、依存関係はありません。",
+          "content": "このアセットは、flowや他のアセットとの上流または下流の依存関係がありません。"
+        }
+      },
+      "plugins": {
+        "title": "このNamespaceにはプラグインのデフォルトが設定されていません。",
+        "content": "詳細については、<strong><a href=\"https://kestra.io/docs/workflow-components/plugin-defaults?utm_source=app&utm_medium=referral&utm_campaign=plugin-default-inlinedoc\" target=\"_blank\">Concurrency Limits</a></strong>に関するドキュメントをご覧ください。"
+      },
+      "triggers": {
+        "title": "あなたのflowにはTriggerがありません。",
+        "content": "<strong><a href=\"https://kestra.io/docs/workflow-components/triggers?utm_source=app&utm_medium=referral&utm_campaign=trigger-inlinedoc\" target=\"_blank\">Triggers</a></strong> についての詳細は、ドキュメントをご覧ください。"
+      },
+      "mcpToolFlows": {
+        "title": "このサーバーにはまだツールflowが登録されていません。",
+        "content": "<code>McpToolTrigger</code>を追加して、flowをMCPツールとして公開します。<strong><a href=\"https://kestra.io/docs/workflow-components/triggers/mcp-tool-trigger?utm_source=app&utm_medium=referral&utm_campaign=mcp-tool-trigger-inlinedoc\" target=\"_blank\">MCP Tool Trigger</a></strong>についての詳細は、ドキュメントをご覧ください。"
+      },
+      "versionPlugin": {
+        "title": "まだバージョン管理されたプラグインがありません！",
+        "content": "ここでは、Kestraインスタンスにインストールされているすべてのプラグインを管理できます。新しくインストールされたプラグインは、インスタンスの設定によっては、すべてのKestraサービスで直ちに利用可能にならない場合があります。"
+      },
+      "panels": {
+        "title": "パネルが開いていません",
+        "content": "すべてのパネルを閉じました。  \n続行するには上のタブを選択してください。"
+      }
+    },
+    "toggle_word_wrap": "ワードラップを切り替え",
+    "copied_logs_to_clipboard": "クリップボードにログをコピーしました。",
+    "multi_panel_editor": {
+      "move_right": "右に移動",
+      "move_left": "左に移動",
+      "close_all_tabs": "すべてのタブを閉じる",
+      "close_all_panels": "すべてのパネルを閉じる"
+    },
+    "search_docs": "検索",
+    "no_results_found": "結果が見つかりません",
+    "searching": "検索中...",
+    "worker information": "ワーカー情報",
+    "test-badge-text": "テスト",
+    "test-badge-tooltip": "この実行はテストによって作成されました",
+    "total_executions": "実行の合計",
+    "no_results": {
+      "executions": "実行が見つかりません",
+      "triggers": "トリガーが見つかりません",
+      "flows": "フローが見つかりません",
+      "kv_pairs": "キー-バリュー ペアが見つかりません",
+      "secrets": "シークレットが見つかりません",
+      "templates": "テンプレートが見つかりません",
+      "assets": "アセットが見つかりません"
+    },
+    "duplicate-pair": "{label} \"{key}\" は重複しています。最初のキーは無視されます。",
+    "dashboards": {
+      "labels": {
+        "singular": "ダッシュボード",
+        "plural": "ダッシュボード"
+      },
+      "default": "デフォルトダッシュボード",
+      "switch": "ダッシュボードを切り替える",
+      "preview": "プレビュー ダッシュボード",
+      "empty": "表示する結果がありません。",
+      "creation": {
+        "label": "ダッシュボードを作成",
+        "confirmation": "ダッシュボード <code>{title}</code> が作成されました。"
+      },
+      "edition": {
+        "label": "ダッシュボードを編集",
+        "confirmation": "ダッシュボード<code>{title}</code>の変更が保存されました。",
+        "chart": "このチャートを編集",
+        "id readonly": "プロパティ `id` は変更できません — 現在、初期値に設定されています。変更したい場合は、新しいダッシュボードを作成し、古いものを削除してください。"
+      },
+      "deletion": {
+        "confirmation": "<code>{title}</code> ダッシュボードを削除してもよろしいですか？"
+      },
+      "no_description": "説明なし",
+      "no_description_hint": "このflowに説明を追加して、何をするかを文書化してください。<br>Markdownがサポートされています。",
+      "others": "その他",
+      "viewAll": "すべて表示",
+      "chart_preview": "チャートのソースコードをクリックしてプレビューを表示",
+      "export": "CSVにエクスポート",
+      "quick_filters": {
+        "all": "すべて",
+        "running": "実行中",
+        "paused": "一時停止中",
+        "success": "成功",
+        "warning": "警告",
+        "failed": "失敗"
+      }
     },
     "setup": {
-      "config": {
-        "basicauth": "基本認証",
-        "queue": "キュー",
-        "repository": "データベース",
-        "storage": "内部ストレージ"
+      "login": "ログイン",
+      "login_title": "サインイン",
+      "logout": "ログアウト",
+      "troubleshooting": "パスワードをお忘れですか？",
+      "steps": {
+        "user": "管理者ユーザーを作成",
+        "config": "設定を検証",
+        "survey": "詳細を教えてください",
+        "complete": "Kestra UIを開始"
       },
-      "confirm": {
-        "config_title": "設定が有効であることを確認してください",
-        "confirm": "管理者ユーザーを作成",
-        "not_valid": "いいえ、有効ではありません。",
-        "valid": "はい、有効です"
+      "titles": {
+        "user": "管理者ユーザーを作成",
+        "survey": "Kestra OSSの改善にご協力ください"
+      },
+      "subtitles": {
+        "user": "インスタンスを保護して開始します。",
+        "config": "こちらはあなたの設定の詳細です",
+        "survey": "申し訳ありませんが、翻訳するテキストが提供されていません。翻訳が必要なテキストを提供してください。",
+        "complete": "セットアップが正常に完了しました！"
       },
       "form": {
         "email": "メール",
@@ -1878,351 +1937,249 @@
         "username": "ユーザー名",
         "username_hint": "有効なメールアドレスである必要があります。"
       },
-      "login": "ログイン",
-      "login_title": "サインイン",
-      "logout": "ログアウト",
-      "steps": {
-        "complete": "Kestra UIを開始",
-        "config": "設定を検証",
-        "survey": "詳細を教えてください",
-        "user": "管理者ユーザーを作成"
-      },
-      "subtitles": {
-        "complete": "セットアップが正常に完了しました！",
-        "config": "こちらはあなたの設定の詳細です",
-        "survey": "申し訳ありませんが、翻訳するテキストが提供されていません。翻訳が必要なテキストを提供してください。",
-        "user": "インスタンスを保護して開始します。"
-      },
-      "success": {
-        "subtitle": "準備完了です！",
-        "title": "おめでとうございます！"
-      },
-      "survey": {
-        "company_11_50": "個人プロジェクト",
-        "company_1_10": "学習 / 探索",
-        "company_250_plus": "本番デプロイメント",
-        "company_50_250": "私のチーム/会社のために評価中",
-        "company_personal": "その他",
-        "company_size": "Kestraを使用する主な目的は何ですか？",
-        "continue": "続行",
-        "newsletter": "製品の更新情報をメールで受け取る。",
-        "newsletter_heading": "常に情報を把握",
-        "skip": "スキップ",
-        "use_case": "何に使用する予定ですか？",
-        "use_case_business": "ビジネスワークフロー",
-        "use_case_data": "データワークフロー",
-        "use_case_infrastructure": "インフラストラクチャ自動化",
-        "use_case_ml": "MLパイプライン",
-        "use_case_other": "その他",
-        "use_case_scheduling": "スケジューリングと定期ジョブ"
-      },
-      "titles": {
-        "survey": "Kestra OSSの改善にご協力ください",
-        "user": "管理者ユーザーを作成"
-      },
-      "troubleshooting": "パスワードをお忘れですか？",
       "validation": {
-        "config_message": "このエラーメッセージを修正するために設定を更新してください。",
-        "email_invalid": "無効なメールアドレス",
         "email_required": "メールが必要です",
+        "email_invalid": "無効なメールアドレス",
         "email_temporary_not_allowed": "一時的または使い捨てのメールアドレスは使用できません",
         "firstName_required": "名が必要です",
-        "incorrect_creds": "ユーザー名またはパスワードが無効です。資格情報が正しいことを確認してください。",
         "lastName_required": "姓が必要です",
         "password_invalid": "無効なパスワード",
-        "password_required": "パスワードは必須です"
+        "password_required": "パスワードは必須です",
+        "incorrect_creds": "ユーザー名またはパスワードが無効です。資格情報が正しいことを確認してください。",
+        "config_message": "このエラーメッセージを修正するために設定を更新してください。"
+      },
+      "config": {
+        "repository": "データベース",
+        "queue": "キュー",
+        "storage": "内部ストレージ",
+        "basicauth": "基本認証"
+      },
+      "confirm": {
+        "confirm": "管理者ユーザーを作成",
+        "config_title": "設定が有効であることを確認してください",
+        "not_valid": "いいえ、有効ではありません。",
+        "valid": "はい、有効です"
+      },
+      "survey": {
+        "skip": "スキップ",
+        "company_size": "Kestraを使用する主な目的は何ですか？",
+        "company_1_10": "学習 / 探索",
+        "company_11_50": "個人プロジェクト",
+        "company_50_250": "私のチーム/会社のために評価中",
+        "company_250_plus": "本番デプロイメント",
+        "company_personal": "その他",
+        "use_case": "何に使用する予定ですか？",
+        "use_case_infrastructure": "インフラストラクチャ自動化",
+        "use_case_business": "ビジネスワークフロー",
+        "use_case_data": "データワークフロー",
+        "use_case_ml": "MLパイプライン",
+        "use_case_scheduling": "スケジューリングと定期ジョブ",
+        "use_case_other": "その他",
+        "newsletter_heading": "常に情報を把握",
+        "newsletter": "製品の更新情報をメールで受け取る。",
+        "continue": "続行"
+      },
+      "success": {
+        "title": "おめでとうございます！",
+        "subtitle": "準備完了です！"
       }
     },
-    "show": "表示",
-    "show chart": "チャートを表示",
-    "show description": "説明を表示",
-    "show details": "詳細を表示",
-    "show documentation": "ドキュメントを表示",
-    "show more details": "詳細を表示",
-    "show raw": "Show raw",
-    "show task condition": "タスク条件を表示",
-    "show task documentation": "taskのドキュメントを表示",
-    "show task documentation in editor": "エディタでtaskのドキュメントを表示",
-    "show task logs": "Task Logsを表示",
-    "show task outputs": "Task出力を表示",
-    "show task source": "Taskソースを表示",
-    "showLess": "表示を減らす",
-    "showMore": "もっと表示",
-    "side-by-side": "並列表示",
-    "similar lines": "similar lines",
-    "skipped": "スキップされました",
-    "slack support": "Slackで質問する",
-    "something_went_wrong": {
-      "connection_lost": {
-        "message": "Kestraインスタンスに接続できませんでした。実行中であることを確認し、ページを更新してください。",
-        "title": "接続が中断されました"
+    "ai": {
+      "flow": {
+        "title": "AIエージェント",
+        "prompt_placeholder": "指示を入力してKestra flowを作成してください。例: 毎週月曜日の午前9時に実行されるflowを作成してください。",
+        "select_provider": "プロバイダーを選択",
+        "generating": {
+          "flow": "フローのYAMLを生成しています...",
+          "dashboard": "ダッシュボードのYAMLを生成しています...",
+          "app": "アプリのYAMLを生成しています...",
+          "test": "テストYAMLを生成しています..."
+        },
+        "enable_instructions": {
+          "header": "<b>AI Copilotはまだ設定されていません。</b>\n\nAI Copilotを有効にするには、次のスニペットをKestraインスタンスの構成ファイル（例：<code>application.yml</code>）に追加し、<code>geminiApiKey</code>を実際のキーに置き換えてください。",
+          "footer": "注意: 現時点では、オープンソース版のAIプロバイダーとしてGeminiのみがサポートされています。エンタープライズ版については、他のモデルプロバイダーの設定についてAI Copilotのドキュメントを参照してください。\n\n設定を保存した後、Kestraインスタンスを再起動してください。"
+        }
       },
-      "loading_execution": "実行の読み込み中に問題が発生しました。"
+      "dashboard": {
+        "prompt_placeholder": "データについて質問してください。例: 過去7日間のflowの成功率を教えてください。"
+      }
     },
-    "source": "ソース",
-    "source and blueprints": "ソースとblueprints",
-    "source and doc": "ソースとドキュメント",
-    "source and topology": "ソースとトポロジー",
-    "source only": "ソースのみ",
-    "source search": "ソース検索",
-    "source_search": {
-      "match_count": "{count} 件一致 | {count} 件一致",
-      "open_flow": "flow を開く",
-      "preview_empty": "プレビューする結果を選択してください。結果リストの flow をクリックするとソースが表示されます。",
-      "preview_error": "flow ソースの読み込みに失敗しました"
+    "playground": {
+      "title": "プレイグラウンド",
+      "run_task_info": "Flow Codeエディタ内の任意のtaskにカーソルを合わせ、「Run task」ボタンをクリックしてtaskをテストします。",
+      "play_icon_info": "ノーコードまたはトポロジービューで再生アイコンをクリックすることもできます。",
+      "toggle": "プレイグラウンド",
+      "run_task": "タスクを実行",
+      "run_this_task": "このtaskを実行",
+      "run_task_and_downstream": "タスクとダウンストリームを実行",
+      "run_all_tasks": "すべてのタスクを実行",
+      "history": "直近10回の実行",
+      "clear_history": "履歴をクリア",
+      "confirm_create": "フローを作成中はプレイグラウンドを実行できません。プレイグラウンドの実行を開始すると、flowが作成されます。",
+      "tooltip_persistence": "Playgroundをオフにしてから再度オンにすると、ページに留まっている限り情報は保持されます。"
     },
-    "specific task": "特定のTask",
-    "start date": "開始日",
-    "start datetime": "開始日時",
-    "started date": "開始日",
-    "state": "状態",
-    "state updated date": "状態更新日",
-    "state_history": "状態履歴",
-    "stats": "統計",
-    "steps": "ステップ",
-    "stream": "ストリーム",
-    "sub flow": "Subflow",
     "submit": "送信",
-    "success": "Success",
-    "sum": "合計",
-    "switch-view": "ビューを切り替え",
-    "system overview": "システム概要",
-    "system_namespace": "プラットフォームをシステムフローで管理しましょう。",
-    "system_namespace_description": "メンテナンスタスクを自動化し、FAILUREアラートから自動クリーンアップまで対応します。",
-    "tags": "タグ",
-    "task": "Task",
-    "task failed": "タスクが失敗しました",
-    "task id": "Task ID",
-    "task id already exists": "Task Idはすでに存在します",
-    "task is running": "タスクがRUNNING中",
-    "task logs": "Task Logs",
-    "task run id": "タスクランID",
-    "task sent a warning": "タスクがWARNINGを送信しました",
-    "task was skipped": "タスクがスキップされました",
-    "task was successful": "タスクは成功しました",
-    "taskDefaults": "taskのデフォルト設定",
-    "taskRunners": "タスクランナー",
-    "task_id_exists": "タスクIDは既に存在します",
-    "task_id_message": "フロー内にTask Id ${existingTask}は既に存在します。",
-    "taskid column details": "最後に実行されたtaskとその試行回数。",
-    "tasks": "Tasks",
-    "template": "テンプレート",
-    "template creation": "テンプレート作成",
-    "template delete": "<code>{templateCount}</code>件のテンプレートを削除してもよろしいですか？",
-    "template export": "<code>{templateCount}</code>件のテンプレートをエクスポートしてもよろしいですか？",
-    "templates": "テンプレート",
-    "templates deleted": "<code>{count}</code>件のテンプレートが削除されました",
-    "templates deprecated": "テンプレートは非推奨です。代わりにsubflowsを使用してください。テンプレートからsubflowsへの移行方法については、<a href=\"https://kestra.io/docs/migration-guide/0.11.0/templates?utm_source=app&utm_medium=referral&utm_campaign=template-inlinedoc\" target=\"_blank\">移行セクション</a>を参照してください。",
-    "templates exported": "テンプレートがエクスポートされました",
-    "tenant": {
-      "name": "テナント",
-      "names": "テナント"
-    },
-    "tenantId": "テナントID",
-    "test-badge-text": "テスト",
-    "test-badge-tooltip": "この実行はテストによって作成されました",
-    "theme": "テーマ",
-    "this_task_has": "このtaskは",
-    "timezone": "タイムゾーン",
-    "title": "タイトル",
-    "to": "まで",
     "to toggle": "切り替える",
-    "toggle fullscreen": "フルスクリーンを切り替え",
-    "toggle menu": "メニューを切り替え",
-    "toggle output": "出力を切り替え",
-    "toggle output display": "出力表示を切り替え",
-    "toggle periodic refresh each x seconds": "{interval}秒ごとに定期的な更新を切り替える",
-    "toggle_word_wrap": "ワードラップを切り替え",
-    "topology": "トポロジー",
-    "topology-graph": {
-      "graph-orientation": "グラフの向き",
-      "invalid": "グラフエラー",
-      "invalid_description": "グラフの読み込み中にエラーが発生しました。ソースコードにエラーがないか確認してください。",
-      "zoom-fit": "フィット",
-      "zoom-in": "ズームイン",
-      "zoom-out": "ズームアウト",
-      "zoom-reset": "ズームリセット"
-    },
-    "total_duration": "合計時間",
-    "total_executions": "実行の合計",
-    "trigger": "Trigger",
-    "trigger details": "Triggerの詳細",
-    "trigger disabled": "Flowソース内でTriggerが無効になっています",
-    "trigger execution id": "Trigger Execution Id",
-    "trigger filter": {
-      "options": {
-        "ALL": "すべての実行",
-        "CHILD": "子実行",
-        "MAIN": "親実行"
+    "accept": "承認",
+    "reject": "拒否",
+    "draft_available": "エディターでドラフト変更が利用可能です",
+    "last modified": "最終更新日時",
+    "run task in playground": "プレイグラウンドでタスクを実行",
+    "task is running": "タスクがRUNNING中",
+    "task was successful": "タスクは成功しました",
+    "task failed": "タスクが失敗しました",
+    "task was skipped": "タスクがスキップされました",
+    "task sent a warning": "タスクがWARNINGを送信しました",
+    "defaultsToNamespaceFile": "デフォルトはnamespaceファイル: <code>{name}</code>",
+    "no_file_choosen": "ファイルが選択されていません",
+    "dependency": {
+      "controls": {
+        "zoom_in": "ズームイン",
+        "zoom_out": "ズームアウト",
+        "clear_selection": "選択をクリア",
+        "fit_view": "画面に合わせる"
       },
-      "title": "子実行をフィルタリング"
-    },
-    "trigger refresh": "更新をトリガー",
-    "triggerId": "トリガーID",
-    "trigger_check_warning": "トリガー変数を使用すると、手動でのflow実行では機能しません。問題を解決するために`??`コアレス演算子を追加してください。例えば、`trigger.date`の代わりに`trigger.date ?? execution.startDate`を使用してください。",
-    "trigger_id_exists": "トリガーIDはすでに存在します。",
-    "trigger_id_message": "フロー内に既存のTrigger Id ${existingTrigger}が既に存在します。",
-    "trigger_states": "状態",
-    "triggered": "実行trigger",
-    "triggered done": "実行<em>{name}</em>が正常にトリガーされました",
-    "triggerflow disabled": "Flow定義からTriggerが無効になっています",
-    "triggers": "Triggers",
-    "triggers_add_card_add": "追加",
-    "triggers_add_card_add_to_flow": "flowに追加",
-    "triggers_add_category_empty": "このカテゴリにはトリガーがありません。",
-    "triggers_add_ee_tooltip": "このtriggerはEnterprise Editionが必要です。",
-    "triggers_add_empty_title": "トリガーが見つかりません",
-    "triggers_add_filter_all": "すべて",
-    "triggers_add_filter_app": "アプリケーション",
-    "triggers_add_filter_core": "コア",
-    "triggers_add_filter_realtime": "リアルタイム",
-    "triggers_add_modal_add_button": "フローにトリガーを追加",
-    "triggers_add_modal_ee_notice": "このtriggerはEnterprise Editionが必要です。",
-    "triggers_add_modal_flow_placeholder": "フローを選択",
-    "triggers_add_modal_namespace_placeholder": "namespaceを選択",
-    "triggers_add_modal_properties_hint": "トリガーを追加した後、flowエディターでトリガーのプロパティを設定します。",
-    "triggers_add_modal_tab_documentation": "ドキュメント",
-    "triggers_add_modal_tab_form": "フォーム",
-    "triggers_add_modal_tab_source": "ソース",
-    "triggers_add_modal_title": "{name}",
-    "triggers_add_modal_trigger_id": "トリガーID",
-    "triggers_add_modal_trigger_id_placeholder": "このtriggerのユニークな識別子",
-    "triggers_add_search_placeholder": "トリガーを検索...",
-    "triggers_header_description": "トリガーを閲覧、追加、管理して、flowを自動化します。flowをAIツールとして公開する、スケジューリング、Webhookトリガーの追加、外部アプリの変更をポーリング、またはリアルタイムイベントリスナーから選択します。",
-    "triggers_state": {
-      "options": {
-        "disabled": "無効",
-        "enabled": "有効"
-      },
-      "state": "状態"
-    },
-    "triggers_tabs_add": "追加",
-    "triggers_tabs_manage": "管理",
-    "true": "True",
-    "type": "タイプ",
-    "unable to generate graph": "グラフの生成中に問題が発生し、トポロジーが表示されません。",
-    "undefined": "未定義",
-    "unlock": "解除",
-    "unlock trigger": {
-      "button": "triggerのロックを解除",
-      "confirmation": "triggerのロックを解除してもよろしいですか？",
-      "success": "triggerのロックが解除されました",
-      "tooltip": {
-        "evaluation": "triggerは現在評価中です",
-        "execution": "このtriggerに対して実行が進行中です"
-      },
-      "warning": "これは同じtriggerに対する並行実行につながる可能性があり、最後の手段として考慮されるべきです。"
-    },
-    "unqueue": "キューから削除",
-    "unqueue as": "<code>{status}</code>としてキューから外す",
-    "unqueue confirm": "実行 <code>{id}</code> をキューから外してもよろしいですか？",
-    "unqueue done": "実行はキューから外されました",
-    "unqueue title": "実行 <code>{id}</code> をキューから外します。<br/>ただし、flowの並行性制限には従わないため、許可された制限を超えて実行が行われる可能性があります。",
-    "unqueue title multiple": "<code>{count}</code>件の実行をキューから外してもよろしいですか？<br/><br/>flowの並行性制限を守らないため、許可された制限を超えて実行される可能性があります。",
-    "unsaved changed ?": "保存されていない変更があります。このページを離れますか？",
-    "unsaved changes": "未保存の変更",
-    "unsaved changes warning": "未保存の変更があります。このページを離れると、変更は失われます。",
-    "up trend": "増加",
-    "update": "更新",
-    "update aborted": "更新が中止されました",
-    "update ok": "更新されました",
-    "updated date": "更新日",
-    "usage": "使用",
-    "use": "使用",
-    "use_dark_background": "暗い背景で作業する際には、このバージョンを使用して、私たちの名前が読みやすい状態を保ってください。",
-    "valid": "有効",
-    "validate": "検証",
-    "value": "Value",
-    "variable_explorer": {
-      "empty": "この実行に利用可能な変数はありません。",
-      "n_items": "[ {count} 件 ]",
-      "n_keys": "\\{ {count} keys \\}",
-      "one_item": "[ 1 件 ]",
-      "one_key": "\\{ 1 key \\}",
-      "raw_json": "Raw JSON",
-      "search_placeholder": "Key または value を検索...",
-      "select_prompt": "value を確認する変数を選択してください。",
-      "tasks_outputs": "Tasks outputs",
-      "title": "入力/出力",
-      "tree": "ツリー"
-    },
-    "variables": "変数",
-    "version": "バージョン",
-    "view metrics": "メトリクスを表示",
-    "warning": "警告",
-    "warning detected": "警告が検出されました",
-    "warning flow with triggers": "このflowにはtriggersが含まれており、trigger expressionsに依存する場合、手動実行は失敗します。",
-    "watch": "ウォッチ",
-    "watch_video": "ビデオを見る",
-    "webhook": {
-      "copy_url": "Webhook URLをコピー",
-      "curl_command": "Webhook cURL コマンド",
-      "curl_note": "このcURLコマンドを使用して、カスタムJSONペイロードでwebhookを介してflowをtriggerします。",
-      "no_triggers": "このflowには有効なWebhookトリガーがありません",
-      "payload": "Webhookペイロード（JSON）"
-    },
-    "webhook link copied": "Webhookリンクがコピーされました。",
-    "welcome": {
-      "help": {
-        "text": "Slackコミュニティで質問してください。行き詰まった場合は、私たちがサポートします。✋",
-        "title": "お困りですか？"
-      },
-      "menu": "Welcome",
-      "tour": {
-        "text": "ユースケースを選択し、ステップバイステップガイドに従って、Kestraの機能と能力を学びましょう。❤️",
-        "title": "製品ツアーを体験する"
-      },
-      "tutorial": {
-        "text": "----------\n\n * <a href=\"https://kestra.io/tutorial-videos/all?utm_source=app&utm_medium=referral&utm_campaign=welcome-tutorial\" target=\"_blank\">ビデオチュートリアル</a> \n* <a href=\"https://kestra.io/docs?utm_source=app&utm_medium=referral&utm_campaign=welcome-tutorial\" target=\"_blank\">ドキュメント</a> \n* <a href=\"https://kestra.io/blueprints?utm_source=app&utm_medium=referral&utm_campaign=welcome-tutorial\" target=\"_blank\">Blueprints</a>",
-        "title": "チュートリアル"
+      "search": {
+        "placeholders": {
+          "default": "flow または namespace で検索...",
+          "asset": "アセット、flow、またはnamespaceで検索..."
+        },
+        "namespace": {
+          "select": "namespaceを選択",
+          "no_namespace": "namespaceなし"
+        },
+        "flow": {
+          "display": "フローの依存関係を含める"
+        },
+        "no_results": "{term} に対する結果が見つかりませんでした"
       }
     },
+    "preview": {
+      "label": "プレビュー",
+      "force-editor": "エディタービューを強制する",
+      "auto-view": "自動ビュー",
+      "view": "表示",
+      "rows_truncated": "{total} 行中 {shown} 行を表示しています。すべてのデータを表示するにはファイルをダウンロードしてください。",
+      "pagination_info": "{total} のうち {start}-{end} 行を表示しています。",
+      "showing_rows": "{total}のうち{start}から{end}の行を表示中",
+      "expand": "展開",
+      "collapse": "折りたたむ",
+      "previous": "前へ",
+      "next": "次へ",
+      "page_of": "ページ {current} / {total}"
+    },
+    "delete trigger": "トリガーを削除",
+    "delete triggers": "トリガーを削除",
+    "bulk delete triggers": "{count} 個のtriggerを削除してもよろしいですか？",
+    "bulk success delete triggers": "{count} 個のtriggerが正常に削除されました",
+    "delete trigger confirmation": "トリガー {id} を削除してもよろしいですか？WARNING: トリガーがまだflowでアクティブな場合、削除すると重複した実行が発生する可能性があります。",
+    "delete trigger success": "トリガー{id}が正常に削除されました",
+    "delete trigger error": "トリガー {id} の削除エラー",
+    "revision deleted": "リビジョン{revision}が正常に削除されました",
+    "delete revision confirm": "リビジョン {revision} を削除してもよろしいですか？",
+    "delete revision error": "エラー: リビジョン {revision} の削除中にエラー {error} が発生しました。",
+    "no_history": "履歴はありません",
+    "export_as": ".{format}としてエクスポート",
+    "save_and_execute": "保存して実行",
     "welcome_copilot": {
       "button_cta": "フローをゼロから作成",
       "create_manually": {
-        "description": "エディタを使用してゼロから構築する",
-        "title": "手動で作成"
+        "title": "手動で作成",
+        "description": "エディタを使用してゼロから構築する"
       },
       "docs": {
-        "description": "公式ドキュメントで詳細を学ぶ",
-        "title": "ドキュメントを読む"
+        "title": "ドキュメントを読む",
+        "description": "公式ドキュメントで詳細を学ぶ"
       },
+      "title": "ワークフローにアイデアを変える",
+      "need_help": "お困りですか？",
+      "placeholder_prompt": "毎朝9時に挨拶メッセージを送ってください。",
+      "show_more": "さらにプロンプトを表示",
+      "show_less": "プロンプトを減らす",
+      "remaining_quota": "あなたはあと{count}回のAI生成が残っています。制限は毎日深夜0時 UTCにリセットされます。",
       "execute_hint": {
-        "description": "クリックしてワークフローを保存し、すぐに実行します。",
-        "title": "フローを保存して実行"
+        "title": "フローを保存して実行",
+        "description": "クリックしてワークフローを保存し、すぐに実行します。"
+      },
+      "success_popup": {
+        "title": "おめでとうございます！",
+        "description": "最初のflowを正常に実行しました！Kestraのプロになる道を進んでいます。",
+        "tutorial": "詳細チュートリアル",
+        "explore": "さらに探索する"
+      },
+      "success_page": {
+        "title": "すべての準備が整いました！",
+        "description": "Kestraの基本を学びました。ここから旅を続けるためのリソースをいくつかご紹介します。",
+        "restart": "チュートリアルを再起動",
+        "items": {
+          "tutorial": {
+            "title": "チュートリアルを開始",
+            "description": "Kestraのすべての機能のインタラクティブウォークスルー"
+          },
+          "blueprints": {
+            "title": "ブループリント",
+            "description": "一般的なユースケースのための事前構築されたワークフローテンプレート"
+          },
+          "slack": {
+            "title": "Slack コミュニティ",
+            "description": "他のユーザーとつながり、コミュニティからサポートを受ける"
+          },
+          "videos": {
+            "title": "ビデオチュートリアル",
+            "description": "高度な機能のためのステップバイステップのビデオガイド"
+          },
+          "demo": {
+            "title": "デモを取得",
+            "description": "パーソナライズされたデモでKestra Enterprise Editionを体験する"
+          }
+        }
+      },
+      "help": {
+        "tutorial": {
+          "title": "チュートリアルを開始",
+          "description": "ガイド付きステップで最初のflowを作成して実行する方法を学びましょう。"
+        },
+        "blueprints": {
+          "title": "ブループリント",
+          "description": "一般的なワークフローパターンのための、すぐに使用できる例とテンプレートを探索してください。"
+        },
+        "slack": {
+          "title": "Slackコミュニティ",
+          "description": "アイデアやベストプラクティスを共有し、技術的な質問についてサポートを受けるために参加してください。"
+        }
       },
       "flows": {
-        "buildDbtPipeline": {
-          "label": "dbtパイプラインを構築する",
-          "prompt": "Kestraのflowを作成し、dbtプロジェクトリポジトリをクローンして、DuckDBプロファイルでdbt buildを実行します。"
-        },
-        "buildDockerImageAndRunIt": {
-          "label": "Dockerイメージをビルドして実行する",
-          "prompt": "インラインDockerfileからDockerイメージをビルドし、結果として得られるコンテナを実行するKestra flowを作成します。"
-        },
-        "convertCsvToExcel": {
-          "label": "CSVをExcelに変換",
-          "prompt": "CSVファイルをダウンロードし、Ionに変換して、結果をExcelファイルとしてエクスポートするflowを作成します。"
-        },
-        "etlWorkflow": {
-          "label": "ETLワークフロー",
-          "prompt": "ETL flowを作成し、JSONデータをダウンロードし、Pythonで処理し、変換された結果をDuckDBでクエリします。"
+        "jsonApiToDuckdb": {
+          "label": "JSON APIからDuckDBへ",
+          "prompt": "パブリックAPIからJSONファイルをダウンロードし、Pythonスクリプトで変換し、DuckDB Queries Taskで処理するflowを作成します。"
         },
         "installNginxViaAnsible": {
           "label": "Ansibleを使用してNginxをインストール",
           "prompt": "Ansibleを使用してターゲットマシンにNginxをインストールし、インストールされたバージョンを確認するKestra flowを作成します。"
         },
-        "jsonApiToDuckdb": {
-          "label": "JSON APIからDuckDBへ",
-          "prompt": "パブリックAPIからJSONファイルをダウンロードし、Pythonスクリプトで変換し、DuckDB Queries Taskで処理するflowを作成します。"
+        "buildDbtPipeline": {
+          "label": "dbtパイプラインを構築する",
+          "prompt": "Kestraのflowを作成し、dbtプロジェクトリポジトリをクローンして、DuckDBプロファイルでdbt buildを実行します。"
+        },
+        "etlWorkflow": {
+          "label": "ETLワークフロー",
+          "prompt": "ETL flowを作成し、JSONデータをダウンロードし、Pythonで処理し、変換された結果をDuckDBでクエリします。"
+        },
+        "microservicesApis": {
+          "label": "マイクロサービス & APIs",
+          "prompt": "WebサイトのAPIレスポンスをチェックし、ステータスコードが成功でない場合にSlackアラートを送信するflowを作成します。"
+        },
+        "buildDockerImageAndRunIt": {
+          "label": "Dockerイメージをビルドして実行する",
+          "prompt": "インラインDockerfileからDockerイメージをビルドし、結果として得られるコンテナを実行するKestra flowを作成します。"
         },
         "manualApproval": {
           "label": "手動承認",
           "prompt": "承認後に初期処理ステップ、手動承認の一時停止、最終デプロイメントステップを含むflowを作成します。"
         },
-        "microservicesApis": {
-          "label": "マイクロサービス & APIs",
-          "prompt": "WebサイトのAPIレスポンスをチェックし、ステータスコードが成功でない場合にSlackアラートを送信するflowを作成します。"
+        "convertCsvToExcel": {
+          "label": "CSVをExcelに変換",
+          "prompt": "CSVファイルをダウンロードし、Ionに変換して、結果をExcelファイルとしてエクスポートするflowを作成します。"
         },
         "scheduledPdfReports": {
           "label": "スケジュールされたPDFレポート",
@@ -2232,73 +2189,116 @@
           "label": "週次販売KPIをSlackへ",
           "prompt": "毎週スケジュールされたflowを作成し、DuckDBで売上KPIを計算し、Slackにサマリーを投稿します。"
         }
-      },
-      "help": {
-        "blueprints": {
-          "description": "一般的なワークフローパターンのための、すぐに使用できる例とテンプレートを探索してください。",
-          "title": "ブループリント"
-        },
-        "slack": {
-          "description": "アイデアやベストプラクティスを共有し、技術的な質問についてサポートを受けるために参加してください。",
-          "title": "Slackコミュニティ"
-        },
-        "tutorial": {
-          "description": "ガイド付きステップで最初のflowを作成して実行する方法を学びましょう。",
-          "title": "チュートリアルを開始"
-        }
-      },
-      "need_help": "お困りですか？",
-      "placeholder_prompt": "毎朝9時に挨拶メッセージを送ってください。",
-      "remaining_quota": "あなたはあと{count}回のAI生成が残っています。制限は毎日深夜0時 UTCにリセットされます。",
-      "show_less": "プロンプトを減らす",
-      "show_more": "さらにプロンプトを表示",
-      "success_page": {
-        "description": "Kestraの基本を学びました。ここから旅を続けるためのリソースをいくつかご紹介します。",
-        "items": {
-          "blueprints": {
-            "description": "一般的なユースケースのための事前構築されたワークフローテンプレート",
-            "title": "ブループリント"
-          },
-          "demo": {
-            "description": "パーソナライズされたデモでKestra Enterprise Editionを体験する",
-            "title": "デモを取得"
-          },
-          "slack": {
-            "description": "他のユーザーとつながり、コミュニティからサポートを受ける",
-            "title": "Slack コミュニティ"
-          },
-          "tutorial": {
-            "description": "Kestraのすべての機能のインタラクティブウォークスルー",
-            "title": "チュートリアルを開始"
-          },
-          "videos": {
-            "description": "高度な機能のためのステップバイステップのビデオガイド",
-            "title": "ビデオチュートリアル"
-          }
-        },
-        "restart": "チュートリアルを再起動",
-        "title": "すべての準備が整いました！"
-      },
-      "success_popup": {
-        "description": "最初のflowを正常に実行しました！Kestraのプロになる道を進んでいます。",
-        "explore": "さらに探索する",
-        "title": "おめでとうございます！",
-        "tutorial": "詳細チュートリアル"
-      },
-      "title": "ワークフローにアイデアを変える"
+      }
     },
-    "welcome_page": {
-      "guide": "最初のflowを実行するためのガイダンスが必要ですか？",
-      "welcome": "Kestraへようこそ"
+    "mcp": {
+      "your_servers": "あなたのサーバー",
+      "servers_count": "{{count}} MCPサーバー",
+      "managed_by_kestra": "Kestraによって管理されています",
+      "servers": "MCPサーバー",
+      "server": "MCPサーバー",
+      "client_setup": "クライアント設定",
+      "page_description": "KestraのflowをMCP互換のAIエージェント用ツールとして公開する",
+      "create": "サーバーを作成",
+      "save": "変更を保存",
+      "connect": "接続",
+      "copy_url": "URLをコピー",
+      "url_copied": "URLをコピーしました！",
+      "instructions": "指示",
+      "server_type": "サーバータイプ",
+      "auth_type": "認証",
+      "private": "プライベート",
+      "private_server": "プライベートサーバー",
+      "public": "公開",
+      "public_hint": "警告: 公開サーバーは認証を必要としません。URLを知っている人なら誰でも、namespaceや権限のチェックなしに、このサーバーが公開するすべてのツールを呼び出すことができます。外部に公開しても安全なサーバーでのみ使用してください。",
+      "basic_auth": "ベーシック認証",
+      "api_token": "APIトークン",
+      "oauth": "OAuth",
+      "username_password": "ユーザー名 & パスワード",
+      "bearer_token": "ベアラートークン認証",
+      "oauth_hint": "OIDCプロバイダーからのBearer JWT",
+      "oauth_provider": "OAuthプロバイダー",
+      "oauth_provider_placeholder": "設定済みのOIDCプロバイダーを選択",
+      "oauth_provider_required": "認証タイプがOAuthの場合、OAuthプロバイダーは必須です",
+      "scopes_supported": "サポートされているscope",
+      "scopes_supported_placeholder": "openid, profile, email",
+      "scopes_supported_hint": "このサーバーのProtected Resource Metadataドキュメントに記載されたscope。仕様準拠のMCPクライアントは認可リクエストをこのリストに制限します。フィールドを省略してクライアントがIdPの公開scopeにフォールバックできるよう空のままにしてください。",
+      "no_oauth_providers": "このインスタンスにOIDCプロバイダーが設定されていません",
+      "delete_confirm": "このMCPサーバーを削除してもよろしいですか？",
+      "no_servers": "MCPサーバーが見つかりません。最初のサーバーを作成して、MCP Tool triggerを外部AIエージェントに公開してください。",
+      "server_id": "サーバー ID",
+      "id_placeholder": "例: my-mcp-server",
+      "id_invalid": "IDは小文字のアルファベットまたは数字で始まり、小文字のアルファベット、数字、ハイフン、またはアンダースコアのみを含む必要があります。",
+      "main_tenant": "メイン",
+      "tab_edit": "編集",
+      "tab_connect": "接続",
+      "tab_tool_flows": "ツールフローズ",
+      "tab_tool_flows_placeholder": "ツールフロー管理は近日公開予定です。",
+      "tools": {
+        "no_tools": "検索に一致するツールフローはありません。",
+        "create_tool_flow": "ツールフローを作成",
+        "tool_name": "ツール名",
+        "trigger_id": "Trigger ID",
+        "title": "タイトル",
+        "description": "説明",
+        "annotations": "アノテーション",
+        "flow": "flow",
+        "state": "状態",
+        "read_only": "読み取り専用",
+        "open_world": "Open world",
+        "destructive": "破壊的",
+        "idempotent": "冪等",
+        "return_direct": "直接返却",
+        "view_flow": "flowを開く"
+      },
+      "connect_tab": {
+        "server_url": "サーバーURL",
+        "client_picker_label": "AIクライアントを選択",
+        "claude_desktop": "Claudeデスクトップ",
+        "claude_desktop_hint": "claude_desktop_config.jsonファイルに次を追加してください：",
+        "claude_desktop_mac": "macOS: ~/Library/Application Support/Claude/claude_desktop_config.json",
+        "claude_desktop_win": "Windows: %APPDATA%\\Claude\\claude_desktop_config.json",
+        "claude_code": "クロードコード",
+        "claude_code_hint": "ターミナルで次のコマンドを実行してください:",
+        "cursor": "カーソル",
+        "cursor_hint": "次の内容を~/.cursor/mcp.jsonに追加してください:",
+        "codex": "Codex (OpenAI)",
+        "codex_hint": "codex.json MCP設定に次を追加してください:",
+        "auth_basic_hint": "クライアントを起動する前に、base64エンコードされた<code>username:password</code>文字列を含む<code>KESTRA_BASIC_AUTH</code>を環境変数として設定してください。",
+        "auth_api_token_hint": "クライアントを起動する前に<code>KESTRA_TOKEN</code>を環境変数として設定してください。",
+        "auth_oauth_client_id_hint": "<code>&lt;client-id&gt;</code>をOAuthクライアントIDに置き換え、そのクライアントに有効なリダイレクトURIとして<code>http://localhost:7777</code>を登録してください。",
+        "auth_oauth_browser_hint": "初回接続時にブラウザがIDプロバイダーのログインページを開きます。"
+      }
     },
-    "wordmark_colors": "ワードマークの色は背景に応じて変化し、アイコンは暗い背景に配置された場合、背景なしで表示されます。",
-    "worker group": "Workerグループ",
-    "worker group fallback": "ワーカーグループフォールバック",
-    "worker group key": "ワーカーグループキー",
-    "worker information": "ワーカー情報",
-    "workerId": "Worker Id",
-    "workers": "Workers",
-    "wrong labels": "ラベルには空のkeyまたはvalueを設定できません",
-    "yes": "はい"
+    "flow_editor_stats": {
+      "revisions": {
+        "suffix": "リビジョン",
+        "tooltip": "フローのリビジョンを表示"
+      },
+      "dependencies": {
+        "suffix": "依存関係",
+        "tooltip": "フローの依存関係を表示"
+      },
+      "apps": {
+        "suffix": "アプリケーション",
+        "tooltip": "このflowを使用しているアプリを表示"
+      },
+      "tests": {
+        "suffix": "テスト",
+        "tooltip": "フローテストを表示"
+      },
+      "errors": {
+        "label": "{count} エラー"
+      }
+    },
+    "source_search": {
+      "match_count": "{count} 件一致 | {count} 件一致",
+      "open_flow": "flow を開く",
+      "preview_empty": "プレビューする結果を選択してください。結果リストの flow をクリックするとソースが表示されます。",
+      "preview_error": "flow ソースの読み込みに失敗しました"
+    },
+    "open source": "オープンソース",
+    "pricing": "料金",
+    "license": "ライセンス"
   }
 }

--- a/ui/src/translations/ko.json
+++ b/ui/src/translations/ko.json
@@ -1,1678 +1,722 @@
 {
   "ko": {
-    "Add flow": "Flow 추가",
-    "Default log level": "기본 log 레벨",
-    "Default namespace": "기본 namespace",
-    "Default page": "기본 페이지",
-    "Editor fontfamily": "편집기 글꼴 패밀리",
-    "Editor fontsize": "편집기 글꼴 크기",
-    "Editor theme": "편집기 테마",
-    "Fold auto": "편집기: 다중 라인 자동 접기",
-    "Fold content lines": "다중 라인 문자열 접기",
-    "Hover description": "편집기: key 또는 value에 마우스를 올리면 필드 설명 표시",
-    "Language": "언어",
-    "Per page": "페이지당",
-    "Set default page": "기본 페이지 설정",
-    "Set labels": "라벨 설정",
-    "Set labels done": "실행의 라벨이 성공적으로 설정되었습니다",
-    "Set labels to execution": "실행 <code>{id}</code>의 라벨 추가 또는 업데이트",
-    "Set labels tooltip": "실행에 라벨 설정",
-    "Task Id already exist in the flow": "Task Id {taskId}가 flow에 이미 존재합니다.",
-    "Total": "총계",
-    "Unfold content lines": "다중 라인 문자열 펼치기",
-    "about_this_blueprint": "이 blueprint 정보",
-    "absolute": "절대적",
-    "accept": "수락",
-    "actions": "작업",
-    "activate_basic_auth": "기본 인증 활성화",
-    "active": "활성화됨",
-    "active-slots": "활성 슬롯",
-    "actual state": "현재 상태",
-    "add": "추가",
-    "add at position": "{position} <code>{task}</code> 추가",
-    "add error handler": "오류 처리기 추가",
-    "add flow": "Flow 추가",
+    "loading": "로딩 중...",
+    "more actions": "추가 작업",
+    "toggle menu": "메뉴 전환",
+    "panel actions": "패널 작업",
+    "playground actions": "플레이그라운드 작업",
+    "bulk actions": "일괄 작업",
+    "view metrics": "메트릭 보기",
+    "remove this item": "이 항목 제거",
     "add label": "레이블 추가",
-    "add task": "task 추가",
-    "add-trigger-in-editor": "먼저 Flow에 Trigger를 추가하세요.",
-    "add_new_item": "새 항목 추가",
-    "additionalPlugins": "추가 플러그인",
-    "admin": "관리자",
-    "admin_preferences": "Preferences",
-    "administration": "관리",
-    "advanced configuration": "다른 속성",
-    "after": "이후",
-    "aggregation": "집계",
-    "ai": {
-      "dashboard": {
-        "prompt_placeholder": "데이터에 대해 질문하세요. 예시 프롬프트: 지난 7일 동안 내 flows의 성공률을 보여줘."
+    "remove label": "레이블 제거",
+    "id": "Id",
+    "type": "유형",
+    "ok": "확인",
+    "valid": "유효",
+    "close": "닫기",
+    "namespace": "Namespace",
+    "description": "설명",
+    "show description": "설명을 표시",
+    "show details": "세부 정보 표시",
+    "show more details": "자세한 정보 보기",
+    "skipped": "건너뜀",
+    "revision": "수정본",
+    "Language": "언어",
+    "Set default page": "기본 페이지 설정",
+    "theme": "테마",
+    "flows": "Flows",
+    "flow": "Flow",
+    "invalid source": "잘못된 소스 코드",
+    "missingSource": "소스 누락",
+    "update": "업데이트",
+    "update ok": "업데이트됨",
+    "delete ok": "삭제됨",
+    "Default page": "기본 페이지",
+    "confirmation": "확인",
+    "common": {
+      "back": "뒤로"
+    },
+    "delete confirm": "<code>{name}</code>을(를) 삭제하시겠습니까?",
+    "outdated revision save confirmation": {
+      "confirm": "덮어쓰시겠습니까?",
+      "update": {
+        "title": "구버전",
+        "description": "현재 편집 중인 수정본이 구버전입니다.",
+        "details": "최신 수정본에 대한 자세한 내용은 수정본 탭을 확인하세요."
       },
-      "flow": {
-        "enable_instructions": {
-          "footer": "참고: 현재 오픈 소스 에디션에서는 AI 제공자로 Gemini만 지원됩니다. 엔터프라이즈 에디션의 경우, 다른 모델 제공자 구성을 위해 AI Copilot 문서를 참조하십시오.\n\n구성을 저장한 후 Kestra 인스턴스를 재시작하십시오.",
-          "header": "<b>AI Copilot이 아직 구성되지 않았습니다.</b>\n\nAI Copilot을 활성화하려면, 다음 코드 조각을 Kestra 인스턴스 구성 파일(예: <code>application.yml</code>)에 추가하고 <code>geminiApiKey</code>를 실제 key로 교체하십시오:"
-        },
-        "generating": {
-          "app": "앱 YAML을 생성 중입니다...",
-          "dashboard": "대시보드 YAML을 생성 중입니다...",
-          "flow": "Flow YAML을 생성 중입니다...",
-          "test": "테스트 YAML을 생성 중입니다..."
-        },
-        "prompt_placeholder": "Kestra flow를 생성하기 위한 지침을 입력하세요. 예시 프롬프트: 매주 월요일 오전 9시에 실행되는 flow를 생성하세요.",
-        "select_provider": "공급자 선택",
-        "title": "AI 에이전트"
+      "create": {
+        "title": "Flow가 이미 존재합니다",
+        "description": "이 namespace에는 동일한 id를 가진 flow가 이미 존재합니다.",
+        "details": "덮어쓰기를 저장하고 새 버전을 생성합니다."
       }
     },
-    "all executions": "모든 실행",
-    "all tags": "모든 태그",
-    "api": "API",
-    "appBlocks": "앱 블록",
-    "apps": "앱",
-    "are you sure change state": "상태를 변경하시겠습니까?",
-    "assets": {
-      "title": "자산"
+    "override": {
+      "title": "현재 Flow를 덮어쓸 예정입니다.",
+      "details": "이전 flow는 Revisions 탭에서 복원할 수 있습니다."
     },
-    "attempt": "시도",
-    "attempts": "시도 횟수",
-    "auditlogs": "감사 Logs",
-    "automatic refresh": "자동 새로 고침",
-    "avg": "평균",
-    "avg duration": "평균 실행 시간",
+    "is deprecated": "Deprecated 되었습니다",
+    "success": "성공",
+    "save": "저장",
+    "save_as_draft": "초안으로 저장",
+    "draft": "초안",
+    "draft_flow_warning": "이 flow 리비전은 초안입니다. 실행은 이 초안 리비전을 기준으로 수행되며 flow 정의가 유효하지 않으면 즉시 실패할 수 있습니다.",
+    "save task": "Task 저장",
+    "saved": "성공적으로 저장됨",
+    "saved as draft": "초안으로 저장되었습니다",
+    "saved done": "<em>{name}</em>이(가) 성공적으로 저장되었습니다.",
+    "saved as draft done": "<em>{name}</em>이(가) 초안으로 저장되었습니다",
+    "multiple saved done": "{name}이(가) 저장되었습니다.",
+    "fileTypeNotAllowed": "허용되지 않는 파일 유형입니다. 허용되는 유형: {types}",
+    "delete": "삭제",
+    "deleted": "성공적으로 삭제됨",
+    "deleted confirm": "<em>{name}</em>이(가) 성공적으로 삭제되었습니다!",
+    "Add flow": "Flow 추가",
+    "add": "추가",
+    "add_new_item": "새 항목 추가",
+    "copy": "복사",
+    "copy_to_clipboard": "클립보드에 복사",
+    "copy_and_close": "복사하고 닫기",
+    "Per page": "페이지당",
+    "new": "새로 만들기",
+    "edit": "편집",
     "back": "뒤로",
-    "back_to_dashboard": "대시보드로 돌아가기",
-    "backfill": "Backfill",
-    "backfill executions": "backfill 실행",
-    "backfill paused": "백필 일시 중지됨",
-    "backfill running": "백필 실행 중",
-    "bar": "바",
-    "before": "이전",
-    "behavior": "동작",
-    "blueprints": {
-      "all": "모두",
-      "apps": "앱 Blueprints",
-      "community": "커뮤니티",
-      "create": "블루프린트 생성",
-      "custom": "사용자 정의 blueprints",
-      "dashboards": "대시보드 Blueprints",
-      "detail": {
-        "category": "카테고리 유형",
-        "links": "링크 및 리소스",
-        "openInEditor": "편집 Flow에서 열기"
-      },
-      "edit": "블루프린트 편집",
-      "empty": "블루프린트가 없습니다.",
-      "flows": "플로우 Blueprints",
-      "header": {
-        "alt": "블루프린트 아이콘",
-        "catch phrase": {
-          "1": "첫 번째 단계가 항상 가장 어렵습니다.",
-          "2": "다음 {kind}을 시작하기 위해 blueprint를 탐색하세요."
-        }
-      },
-      "missingPlugins": {
-        "card": "이 인스턴스에 설치되지 않은 plugin이 필요합니다: {plugins}",
-        "description": "이 blueprint는 이 인스턴스에 설치되지 않은 plugin의 task를 사용합니다: {plugins}. 이 blueprint를 사용하려면 설치하세요.",
-        "install": "plugin 설치",
-        "title": "누락된 plugin"
-      },
-      "title": "Blueprints"
+    "next": "다음",
+    "done": "완료",
+    "review your inputs": "입력 내용을 검토하세요",
+    "edit flow": "Flow 편집",
+    "executions": "실행",
+    "execution": "실행",
+    "execution id": "실행 Id",
+    "recent_executions": "최근 실행",
+    "details": "세부 정보",
+    "overview": "개요",
+    "gantt": "간트",
+    "gantt_no_tasks_executed": "이 실행은 어떤 task도 실행하지 않고 종료되었습니다.  \n개요와 logs를 확인하여 이유를 알아보세요.",
+    "gantt_no_tasks_match_filters": "검색, 상태 또는 log-level 필터를 조정해 보세요.",
+    "gantt_no_tasks_match_filters_title": "선택한 필터와 일치하는 task가 없습니다.",
+    "logs": "Logs",
+    "no_logs_data": "데이터 없음",
+    "no_logs_data_description": "필터를 조정하거나, 시간 범위를 변경하거나, flow가 최근에 실행되었는지 확인해 주세요.",
+    "no_logs_data_title": "선택한 필터에 대한 로그가 없습니다.",
+    "duration": "지속 시간",
+    "total_duration": "총 지속 시간",
+    "running duration": "실행 중 지속 시간",
+    "queued duration": "대기 중 지속 시간",
+    "choose file": "파일을 선택하거나 여기에 드롭하세요...",
+    "launch execution": "실행",
+    "warning flow with triggers": "이 flow는 triggers를 포함하고 있으며, 이 flow가 trigger expressions에 의존하는 경우 수동 실행이 실패합니다. 해당 Flow는 Trigger를 포함하고 있으며,  Trigger Expression을 의존하는 경우 수동 실행이 실패할 수 있습니다. ",
+    "triggered": "Trigger 실행",
+    "triggered done": "<em>{name}</em>이(가) 성공적으로 Trigger 되었습니다.",
+    "topology": "토폴로지",
+    "date": "날짜",
+    "prev_execution": "이전 실행",
+    "next_execution": "다음 실행",
+    "datepicker": {
+      "leave empty for infinite": "무제한 지속 시간을 원하시면 비워 두거나 ISO 8601 형식의 지속 시간을 입력하세요 (예: 'P1DT1H1M1S').",
+      "duration example": "예: 'P1DT1H1M1S'",
+      "error": "잘못된 형식입니다. 지속 시간은 ISO 8601 형식이어야 합니다.(예: P1DT1H1M1S)",
+      "custom": "사용자 정의",
+      "last5minutes": "지난 5분",
+      "last15minutes": "지난 15분",
+      "last1hour": "지난 1시간",
+      "last12hours": "지난 12시간",
+      "last24hours": "지난 24시간",
+      "last48hours": "지난 48시간",
+      "last7days": "지난 7일",
+      "last30days": "지난 30일",
+      "last365days": "지난 365일",
+      "next5minutes": "다음 5분",
+      "next15minutes": "다음 15분",
+      "next1hour": "다음 1시간",
+      "next12hours": "다음 12시간",
+      "next24hours": "다음 24시간",
+      "next48hours": "다음 48시간",
+      "next7days": "다음 7일",
+      "next30days": "향후 30일",
+      "next365days": "다음 365일",
+      "5minutes": "5분",
+      "15minutes": "15분",
+      "1hour": "1시간",
+      "12hours": "12시간",
+      "24hours": "24시간",
+      "48hours": "48시간",
+      "7days": "7일",
+      "30days": "30일",
+      "365days": "365일",
+      "never": "절대 없음",
+      "today": "오늘",
+      "yesterday": "어제",
+      "dayBeforeYesterday": "그저께",
+      "thisWeek": "이번 주",
+      "thisWeekSoFar": "이번 주 현재까지",
+      "previousWeek": "지난 주",
+      "thisMonth": "이번 달",
+      "thisMonthSoFar": "이번 달 현재까지",
+      "previousMonth": "지난 달",
+      "thisYear": "올해",
+      "thisYearSoFar": "올해 현재까지",
+      "previousYear": "작년",
+      "short": {
+        "15m": "15분",
+        "1h": "1시간",
+        "12h": "12시간",
+        "1d": "1일",
+        "7d": "7일"
+      }
     },
-    "body_line_clamp": "Limit line height",
-    "bookmark": "북마크",
-    "breakpoints": "중단점",
-    "bulk action async warning": "잠시 시간이 걸릴 수 있습니다.",
-    "bulk actions": "일괄 작업",
-    "bulk change state": "<code>{executionCount}</code> 실행의 상태를 변경하시겠습니까?",
-    "bulk delete": "<code>{executionCount}</code> 개의 실행을 삭제하시겠습니까?",
-    "bulk delete backfills": "{count} backfill 삭제",
-    "bulk delete triggers": "{count}개의 trigger를 삭제하시겠습니까?",
-    "bulk disabled status": {
-      "false": "{count} triggers 활성화",
-      "true": "{count} triggers 비활성화"
+    "created date": "생성 날짜",
+    "latest_update": "최신 업데이트",
+    "updated date": "업데이트 날짜",
+    "expiration date": "만료 날짜",
+    "started date": "시작 날짜",
+    "healthcheck date": "HealthCheck 날짜",
+    "next execution date": "다음 실행 날짜",
+    "last execution status": "마지막 실행 상태",
+    "jump to...": "이동...",
+    "contextBar": {
+      "news": "뉴스",
+      "docs": "문서",
+      "help": "도움말",
+      "issue": "문제",
+      "demo": "데모",
+      "star": "우리를 Star 하세요"
     },
-    "bulk force run": "<code>{executionCount}</code> 실행을 강제로 실행하시겠습니까?<br/><br/>WARNING: 실행을 강제로 실행하는 것은 보장되지 않으며 중복된 task 실행을 생성할 수 있습니다.<br/><br/>다음 전환이 수행됩니다:<br/><ul><li>CREATED tasks는 RUNNING 상태로 이동됩니다.</li><li>RUNNING tasks는 다시 제출됩니다.</li><li>QUEUED tasks는 대기열에서 제거됩니다.</li><li>PAUSED tasks는 재개됩니다.</li></ul>",
-    "bulk kill": "<code>{executionCount}</code> 개의 실행을 강제 종료하시겠습니까?",
-    "bulk pause": "<code>{executionCount}</code> 실행을 일시 중지하시겠습니까?",
-    "bulk pause backfills": "{count} backfill 일시 중지",
-    "bulk replay": "<code>{executionCount}</code> 개의 실행을 재실행하시겠습니까?",
-    "bulk restart": "<code>{executionCount}</code> 개의 실행을 재시작하시겠습니까?",
-    "bulk resume": "<code>{executionCount}</code> 개의 실행을 재개하시겠습니까?",
-    "bulk set labels": "<code>{executionCount}</code> 개의 실행에 라벨을 설정하시겠습니까?",
-    "bulk success delete backfills": "{count} backfills 삭제됨",
-    "bulk success delete triggers": "{count} triggers가 성공적으로 삭제되었습니다",
-    "bulk success disabled status": {
-      "false": "{count} trigger(s) 활성화됨",
-      "true": "{count} trigger(s) 비활성화됨"
+    "source": "소스",
+    "source only": "소스 전용",
+    "home": "홈",
+    "create": "생성",
+    "create_flow": "Flow 생성",
+    "add flow": "Flow 추가",
+    "from": "시작",
+    "to": "종료",
+    "search filters": {
+      "saved": "저장된 필터",
+      "manage": "검색 필터 관리",
+      "manage desc": "저장된 검색 필터 관리",
+      "save filter": "필터 저장",
+      "filter name": "필터 이름",
+      "filters": "필터"
     },
-    "bulk success pause backfills": "{count} backfills 일시 중지됨",
-    "bulk success unlock": "{count} triggers 잠금 해제됨",
-    "bulk success unpause backfills": "{count} backfills 재개됨",
-    "bulk unlock": "{count} triggers 잠금 해제",
-    "bulk unpause backfills": "{count} backfill 재개",
-    "bulk unqueue": "<code>{executionCount}</code> 실행을 대기열에서 제거하시겠습니까?",
-    "can not delete": "삭제할 수 없음",
-    "can not have less than 1 task": "각 flow에는 최소한 하나의 task가 있어야 합니다.",
-    "can not save": "저장할 수 없음",
-    "cancel": "취소",
+    "steps": "단계",
+    "state": "상태",
+    "state_history": "상태 기록",
+    "search term in message": "메시지에서 검색어 찾기",
+    "search": "검색",
+    "search blueprint": "Blueprints 검색",
+    "all tags": "모든 태그",
+    "source search": "소스 검색",
+    "filter by log level": "Log 레벨로 필터링",
+    "selected": "선택됨",
+    "task": "Task",
+    "task logs": "Task Logs",
+    "display flow {id} executions": "Flow {id} 실행 표시",
+    "actions": "작업",
+    "select datetime": "날짜 선택",
+    "select view": "보기 선택",
+    "invalid field": "잘못된 필드: {name}",
+    "required field": "필수 필드",
+    "is required": "{field}는 필수 항목입니다.",
+    "error": "오류",
+    "form": "양식",
+    "form error": "양식 오류",
+    "display topology for flow": "Flow의 토폴로지 표시",
     "cannot create topology": "Flow의 토폴로지를 생성할 수 없습니다.",
-    "cannot swap tasks": "task를 교환할 수 없음",
-    "change execution state confirm": "실행 <code>{id}</code>의 상태를 변경하시겠습니까?",
-    "change execution state done": "실행 상태가 업데이트되었습니다",
-    "change queue confirm": "큐 상태를 실행 <code>{id}</code>에 대해 변경하시겠습니까?<br/>",
+    "start date": "시작 날짜",
+    "end date": "종료 날짜",
+    "creation": "생성",
+    "flow creation": "Flow 생성",
+    "start datetime": "시작 날짜 및 시간",
+    "end datetime": "종료 날짜 및 시간",
+    "restart": "재시작",
+    "restart latest revision": "최신 수정본으로 재시작",
+    "restart tooltip": "<code>{state}</code> Task에서 실행을 재시작합니다.",
+    "restarted": "실행이 재시작되었습니다.",
+    "restart confirm": "<code>{id}</code> 실행을 재시작하시겠습니까?",
+    "restart change revision": "선택하시는 수정본으로 재실행 할 수 있습니다.",
+    "replay": "재실행",
+    "replay from task tooltip": "<code>{taskId}</code> Task에서 재실행",
+    "replay from beginning tooltip": "처음부터 재실행",
+    "replay latest revision": "최신 수정본을 사용하여 재실행",
+    "replayed": "실행이 재생되었습니다.",
+    "replay confirm": "재실행 하시겠습니까?",
+    "replay with inputs": "입력과 함께 재실행",
+    "reuse_original_inputs": "원래 input 재사용",
+    "modify_inputs": "입력 수정",
+    "replay the execution": "flow <code>{flowId}</code>의 실행 <code>{executionId}</code>을(를) 다시 실행합니다.",
+    "prefill inputs": "미리 채우기",
+    "current": "현재",
     "change state": "상태 변경",
-    "change state confirm": "----------\n                \n정말로 실행 <code>{id}</code>에서 <code>{task}</code> task의 상태를 변경하시겠습니까?",
-    "change state current state": "현재 상태는:",
+    "actual state": "현재 상태",
+    "select a state": "상태 선택",
+    "are you sure change state": "상태를 변경하시겠습니까?",
+    "yes": "네",
     "change state done": "작업 상태가 업데이트되었습니다",
+    "change state confirm": "----------\n                \n정말로 실행 <code>{id}</code>에서 <code>{task}</code> task의 상태를 변경하시겠습니까?",
+    "change queue confirm": "큐 상태를 실행 <code>{id}</code>에 대해 변경하시겠습니까?<br/>",
+    "change state current state": "현재 상태는:",
     "change state hint": {
+      "WARNING": [
+        "Flow가 WARNING으로 표시됩니다.",
+        "다음 tasks가 실행됩니다.",
+        "오류 tasks가 실행됩니다."
+      ],
       "FAILED": [
         "Flow가 FAILED로 표시됩니다.",
         "다른 task는 실행되지 않습니다.",
         "오류 task가 실행됩니다."
-      ],
-      "RUNNING": [
-        "flow가 재시작되고 모든 다음 task가 실행됩니다.",
-        "모든 차단된 task가 실행됩니다."
       ],
       "SUCCESS": [
         "이 task가 성공했기 때문에 flow가 재시작됩니다.",
         "모든 차단된 task가 실행됩니다.",
         "모든 task 실행이 성공하면 flow는 SUCCESS 상태가 됩니다."
       ],
-      "WARNING": [
-        "Flow가 WARNING으로 표시됩니다.",
-        "다음 tasks가 실행됩니다.",
-        "오류 tasks가 실행됩니다."
+      "RUNNING": [
+        "flow가 재시작되고 모든 다음 task가 실행됩니다.",
+        "모든 차단된 task가 실행됩니다."
       ]
     },
+    "replay execution title": "실행 다시 실행",
+    "restart execution title": "실행 재시작",
+    "replay execution description": "선택한 실행을 기반으로 새 실행을 생성합니다.",
+    "replay using": "사용하여 재실행",
+    "flow revision original": "원본 flow 개정",
+    "flow revision latest": "최신 flow 개정판",
+    "flow revision specific": "특정 flow 개정",
+    "replay inputs": "입력",
+    "reuse original inputs": "원래 input 재사용",
+    "modify inputs": "입력 수정",
+    "replay inputs new required": "이 수정본에는 input이 있습니다. 입력하라는 메시지가 표시됩니다.",
+    "replay select taskrun": "어떤 task run을 재생할지 선택하십시오:",
     "change state tooltip": "실행 상태 변경",
-    "chart": "차트",
-    "chart preview": "차트 미리보기",
-    "chart type": "차트 유형",
-    "charts": "차트",
-    "choice": "선택",
-    "choose file": "파일을 선택하거나 여기에 드롭하세요...",
-    "close": "닫기",
-    "close sidebar": "사이드바 닫기",
-    "codeDisabled": "Flow에서 비활성화됨",
-    "collapse": "축소",
-    "collapse all": "모두 축소",
-    "commit_id": "커밋 id",
-    "common": {
-      "back": "뒤로"
-    },
-    "concurrency": "동시성",
-    "concurrency limits": "동시성 제한",
-    "concurrency_limit": {
-      "dialog_title": "동시성 제한",
-      "warning": "실행 중인 카운터를 변경하면 동시성이 손상되어 실행이 허용된 한도를 초과할 수 있습니다."
-    },
-    "conditions": "조건",
-    "configure basic auth": "기본 인증 구성",
-    "confirm": "확인",
-    "confirm password": "비밀번호 확인",
-    "confirmation": "확인",
-    "context updated date": "컨텍스트 업데이트 날짜",
-    "context updated date tooltip": "트리거의 컨텍스트가 마지막으로 업데이트된 시점입니다. 이는 실행이 트리거되거나, 완료되었을 때(잠금 해제), 또는 평가 후(실행이 발생하지 않더라도) 발생합니다.",
-    "contextBar": {
-      "demo": "데모",
-      "docs": "문서",
-      "help": "도움말",
-      "issue": "문제",
-      "news": "뉴스",
-      "star": "우리를 Star 하세요"
-    },
-    "continue backfill": "backfill 계속",
-    "continue backfills": "backfill 계속",
-    "copied": "복사됨",
-    "copied_logs_to_clipboard": "로그가 클립보드에 복사되었습니다.",
-    "copy": "복사",
-    "copy all logs": "모든 Log 복사",
-    "copy logs": "Logs 복사",
-    "copy url": "URL 복사",
-    "copy_and_close": "복사하고 닫기",
-    "copy_to_clipboard": "클립보드에 복사",
-    "copy_value": "Copy value",
-    "create": "생성",
-    "create first task": "첫 번째 task 만들기",
-    "create_flow": "Flow 생성",
-    "created date": "생성 날짜",
-    "creation": "생성",
-    "cron": "크론",
-    "curl": {
-      "command": "cURL 명령어",
-      "note": "SECRET 및 FILE 입력 유형의 경우, 명령어는 실제 값에 맞게 조정되어야 합니다."
-    },
-    "current": "현재",
-    "current execution": "현재 실행",
-    "custom value": "사용자 정의 value",
-    "customize sidebar": "사이드바 사용자 정의",
-    "dark_version": "다크 버전",
-    "dashboards": {
-      "chart_preview": "차트 소스 코드를 클릭하여 미리보기를 확인하세요.",
-      "creation": {
-        "confirmation": "대시보드 <code>{title}</code>이(가) 생성되었습니다.",
-        "label": "대시보드 생성"
-      },
-      "default": "기본 대시보드",
-      "deletion": {
-        "confirmation": "<code>{title}</code> 대시보드를 삭제하시겠습니까?"
-      },
-      "edition": {
-        "chart": "이 차트 편집",
-        "confirmation": "대시보드 <code>{title}</code>의 변경 사항이 저장되었습니다.",
-        "id readonly": "`id` 속성은 변경할 수 없습니다 — 현재 초기 값으로 설정되어 있습니다. 변경하려면 새 대시보드를 생성하고 기존 것을 제거할 수 있습니다.",
-        "label": "대시보드 편집"
-      },
-      "empty": "결과가 표시되지 않습니다.",
-      "export": "CSV로 내보내기",
-      "labels": {
-        "plural": "대시보드",
-        "singular": "대시보드"
-      },
-      "no_description": "설명 없음",
-      "no_description_hint": "이 flow에 설명을 추가하여 무엇을 하는지 문서화하세요.<br>Markdown이 지원됩니다.",
-      "others": "기타",
-      "preview": "미리보기 대시보드",
-      "quick_filters": {
-        "all": "전체",
-        "failed": "실패",
-        "paused": "일시 중지됨",
-        "running": "실행 중",
-        "success": "성공",
-        "warning": "경고"
-      },
-      "switch": "대시보드 전환",
-      "viewAll": "전체 보기"
-    },
-    "data": "데이터",
-    "dataFilters": "데이터 필터",
-    "data_not_protected": "귀하의 데이터는 보호되지 않습니다. 잃어버리지 마세요. <b>무료 보안 기능을 활성화하거나 유료 서비스를 시도해 보세요.</b>",
-    "date": "날짜",
-    "date count": "{date}에 {count}",
-    "date format": "날짜 형식",
-    "date range count": "{startDate}와 {endDate} 사이에 {count}",
-    "datepicker": {
-      "12hours": "12시간",
-      "15minutes": "15분",
-      "1hour": "1시간",
-      "24hours": "24시간",
-      "30days": "30일",
-      "365days": "365일",
-      "48hours": "48시간",
-      "5minutes": "5분",
-      "7days": "7일",
-      "custom": "사용자 정의",
-      "dayBeforeYesterday": "그저께",
-      "duration example": "예: 'P1DT1H1M1S'",
-      "error": "잘못된 형식입니다. 지속 시간은 ISO 8601 형식이어야 합니다.(예: P1DT1H1M1S)",
-      "last12hours": "지난 12시간",
-      "last15minutes": "지난 15분",
-      "last1hour": "지난 1시간",
-      "last24hours": "지난 24시간",
-      "last30days": "지난 30일",
-      "last365days": "지난 365일",
-      "last48hours": "지난 48시간",
-      "last5minutes": "지난 5분",
-      "last7days": "지난 7일",
-      "leave empty for infinite": "무제한 지속 시간을 원하시면 비워 두거나 ISO 8601 형식의 지속 시간을 입력하세요 (예: 'P1DT1H1M1S').",
-      "never": "절대 없음",
-      "next12hours": "다음 12시간",
-      "next15minutes": "다음 15분",
-      "next1hour": "다음 1시간",
-      "next24hours": "다음 24시간",
-      "next30days": "향후 30일",
-      "next365days": "다음 365일",
-      "next48hours": "다음 48시간",
-      "next5minutes": "다음 5분",
-      "next7days": "다음 7일",
-      "previousMonth": "지난 달",
-      "previousWeek": "지난 주",
-      "previousYear": "작년",
-      "short": {
-        "12h": "12시간",
-        "15m": "15분",
-        "1d": "1일",
-        "1h": "1시간",
-        "7d": "7일"
-      },
-      "thisMonth": "이번 달",
-      "thisMonthSoFar": "이번 달 현재까지",
-      "thisWeek": "이번 주",
-      "thisWeekSoFar": "이번 주 현재까지",
-      "thisYear": "올해",
-      "thisYearSoFar": "올해 현재까지",
-      "today": "오늘",
-      "yesterday": "어제"
-    },
-    "debug": "디버그",
-    "default": "기본값",
-    "defaultsToNamespaceFile": "기본값은 namespace 파일: <code>{name}</code>",
-    "delete": "삭제",
-    "delete backfill": "backfill 삭제",
-    "delete backfills": "backfill 삭제",
-    "delete confirm": "<code>{name}</code>을(를) 삭제하시겠습니까?",
-    "delete execution running": "<div class=\"alert alert-warning mt-2 mb-0\">이 실행은 아직 RUNNING 상태입니다. 삭제해도 중지되지 않습니다.<br />실행을 중지하려면 실행을 강제 종료해야 합니다.</div>",
-    "delete logs": "Logs 삭제",
-    "delete ok": "삭제됨",
-    "delete revision confirm": "{revision} 개정을 삭제하시겠습니까?",
-    "delete revision error": "{error} 오류로 인해 {revision} 수정본 삭제 오류 발생",
-    "delete task confirm": "task <code>{taskId}</code>을(를) 삭제하시겠습니까?",
-    "delete trigger": "트리거 삭제",
-    "delete trigger confirmation": "트리거 {id}를 삭제하시겠습니까? WARNING: 트리거가 flow에서 여전히 활성 상태인 경우 삭제하면 중복 실행이 발생할 수 있습니다.",
-    "delete trigger error": "트리거 {id} 삭제 오류",
-    "delete trigger success": "{id} 트리거가 성공적으로 삭제되었습니다",
-    "delete triggers": "트리거 삭제",
-    "delete_all_logs": "모든 logs를 삭제하시겠습니까?",
-    "delete_log": "로그를 삭제하시겠습니까?",
-    "deleted": "성공적으로 삭제됨",
-    "deleted confirm": "<em>{name}</em>이(가) 성공적으로 삭제되었습니다!",
-    "deleted_label": "삭제됨",
-    "demos": {
-      "IAM": {
-        "message": "Kestra Enterprise Edition은 단일 사인온(SSO), SCIM 디렉토리 동기화, 역할 기반 접근 제어(RBAC)와 같은 IAM 기능을 내장하고 있으며, 여러 ID 공급자와 통합하여 사용자 및 서비스 계정에 대해 세분화된 권한을 할당할 수 있습니다.",
-        "title": "IAM을 통해 SSO, SCIM 및 RBAC로 사용자 관리"
-      },
-      "apps": {
-        "message": "Kestra Enterprise Edition의 앱은 플랫폼 외부에서 Kestra 워크플로와 상호작용하는 맞춤형 UI를 구축할 수 있게 해줍니다. 이 기능을 통해 워크플로를 맞춤형 애플리케이션의 백엔드로 사용할 수 있으며, 비기술적 사용자도 양식을 통해 데이터를 제출하거나 승인을 기다리는 PAUSED 워크플로를 재개할 수 있습니다.",
-        "title": "Kestra로 맞춤형 앱 만들기"
-      },
-      "assets": {
-        "header": "자산 메타데이터 및 관측 가능성",
-        "label": "자산",
-        "message": "자산은 관측 가능성, 계보, 소유권 메타데이터를 연결하여 플랫폼 팀이 더 빠르게 문제를 해결하고 자신 있게 배포할 수 있도록 합니다.",
-        "title": "모든 데이터셋, 서비스 및 종속성을 한눈에 확인하세요."
-      },
-      "audit-logs": {
-        "message": "Kestra Enterprise Edition은 모든 활동을 강력하고 변경 불가능한 기록으로 로그하여 변경 사항을 추적하고, 규정을 준수하며, 문제를 해결하는 것을 쉽게 만듭니다.",
-        "title": "변경 사항 추적 - 감사 Log"
-      },
-      "blueprints": {
-        "message": "Kestra Enterprise Edition에서는 조직에만 사용할 수 있는 맞춤형 Blueprints를 생성할 수 있습니다. 이를 모범 사례 템플릿으로 사용하여 팀 내에서 자주 사용하는 workflow를 공유하고, 중앙 집중화하고, 문서화할 수 있습니다.",
-        "title": "사용자 정의 Blueprints 추가"
-      },
-      "contact_sales": "영업팀에 문의하세요",
-      "enterprise_edition": "엔터프라이즈 에디션",
-      "get_a_demo_button": "데모 받기",
-      "instance": {
-        "message": "Kestra Enterprise Edition은 플랫폼의 상태를 관찰하고 Workers, Schedulers, Executors와 같은 모든 서비스의 가동 시간 지표를 추적할 수 있는 운영 대시보드를 제공합니다. 같은 페이지에서 계획된 다운타임에 대해 사용자에게 알리기 위한 공지를 생성할 수 있으며, 모든 서비스와 workflow 실행을 일시적으로 PAUSED 상태로 전환하여 업그레이드를 수행할 수 있는 유지보수 모드로 진입할 수 있습니다.",
-        "title": "인스턴스 전반의 인프라 관리"
-      },
-      "namespace": {
-        "assets": {
-          "message": "Kestra Enterprise Edition에서 Assets는 워크플로우가 상호작용하는 리소스의 실시간 인벤토리를 유지합니다. 이러한 리소스는 데이터베이스 테이블, 가상 머신, 파일 또는 사용 중인 외부 시스템일 수 있습니다.",
-          "title": "자산 관리 중앙화"
-        },
-        "audit-logs": {
-          "message": "Kestra Enterprise Edition에서는 namespace 수준의 감사 로그를 상세한 차이점과 함께 볼 수 있어, 모든 리소스에 걸쳐 누가 무엇을 언제 변경했는지에 대한 명확한 기록을 제공합니다.",
-          "title": "모든 변경 사항을 한 곳에서 추적하기"
-        },
-        "edit": {
-          "message": "Kestra Enterprise Edition에서는 namespace가 비밀, 변수 및 플러그인 기본값의 고급 격리 및 관리를 제공합니다. 관리자는 사용자 정의 비밀 관리자, 격리된 저장소 백엔드, 전용 worker 그룹 및 세부적인 권한을 namespace별로 구성할 수 있습니다. 이를 통해 비밀, 변수 및 플러그인 구성이 다양한 팀과 프로젝트 전반에 걸쳐 안전하고 쉽게 유지될 수 있습니다.",
-          "title": "네임스페이스 관리 업그레이드"
-        },
-        "history": {
-          "message": "Kestra Enterprise Edition에서는 namespace의 수정 이력을 관리할 수 있습니다.",
-          "title": "한 곳에서 수정 기록 관리"
-        },
-        "plugin-defaults": {
-          "message": "Kestra Enterprise Edition에서는 각 flow에서 중복된 설정의 필요성을 줄이기 위해 namespace별 플러그인 기본값을 설정할 수 있습니다. 이 중앙 플러그인 관리 기능은 일관된 구성 설정을 강제하고, 비밀 정보나 변수를 안전하게 참조할 수 있게 하며, 워크플로우의 유지 관리를 간소화합니다.",
-          "title": "플러그인 기본값으로 구성 표준화"
-        },
-        "secrets": {
-          "message": "Kestra Enterprise Edition에서는 namespace 수준에서 비밀을 저장하고 제어할 수 있어 위험을 최소화하고 각 팀의 자격 증명이 격리된 상태로 유지됩니다. 중첩된 계층 구조 덕분에 상위 namespace에서 자격 증명을 구성하면 모든 하위 namespace에서 이를 상속받을 수 있습니다. 전용 비밀 관리자 지원 및 세분화된 namespace 수준의 권한 설정은 보안과 규정을 더욱 강화합니다.",
-          "title": "비밀을 안전하게 관리하기"
-        },
-        "variables": {
-          "message": "Kestra Enterprise Edition에서는 namespace 수준 변수들을 정의하고 관리하여 flow 전반에 걸친 반복적인 구성을 제거할 수 있습니다. 이러한 변수들은 일관성을 보장하고, 구성 업데이트를 간소화하며, 어떤 task나 trigger에서도 쉽게 참조할 수 있어 더 깔끔하고 유지보수하기 쉬운 워크플로우를 만듭니다.",
-          "title": "변수를 중앙에서 관리하세요"
-        }
-      },
-      "quotas": {
-        "message": "Kestra Enterprise Edition을 사용하면 플로우에 할당량을 정의하여 시간 창 내에서 동시 또는 총 실행 횟수를 제한할 수 있습니다. 할당량은 공유 인프라를 보호하고, SLA를 적용하며, 과도한 리소스를 소비하는 워크플로우를 방지하는 데 도움이 됩니다.",
-        "title": "플로우에 실행 할당량 적용"
-      },
-      "secrets": {
-        "add_env": {
-          "first": "<a href=\"https://kestra.io/docs/how-to-guides/secrets?utm_source=app&utm_medium=referral&utm_campaign=secrets-inlinedoc#using-secrets-in-kestra\" target=\"_blank\">비밀 값</a>을 Base64로 인코딩하십시오.",
-          "intro": "새 Secret을 생성하려면:",
-          "second": "위의 값을 사용하여 '<strong>SECRET_{'{MY_SECRET_KEY}'}</strong>'라는 환경 변수를 추가하세요.",
-          "third": "Kestra 인스턴스를 재시작하십시오"
-        },
-        "detected_env": "다음은 인스턴스 시작 시 식별된 secret-type 환경 변수입니다:",
-        "empty_env": "아직 환경에 Secrets가 없습니다.",
-        "message": "Enterprise Edition (EE)는 UI에서 비밀을 직접 추가, 편집 또는 삭제할 수 있게 해줍니다. 인스턴스를 재시작할 필요가 없습니다. 비밀을 namespace별로 세분화된 RBAC 권한으로 구성하고, 상위 namespace에서 하위 namespace로 상속할 수 있습니다. EE는 HashiCorp Vault, AWS Secrets Manager, Azure Key Vault, Google Secret Manager, Elasticsearch와 같은 비밀 관리자와 통합됩니다. namespace, tenant, 인스턴스별로 전용 백엔드를 설정하여 팀 간 비밀을 격리하거나 외부 vault에 저장된 읽기 전용 비밀을 활성화할 수 있습니다. 비밀은 저장 중 및 전송 중에 암호화된 상태로 유지됩니다. 선택적 캐싱은 API 호출을 줄이고, 감사 추적은 모든 접근을 log합니다.",
-        "title": "비밀 관리 업그레이드"
-      },
-      "tenants": {
-        "message": "Kestra Enterprise Edition은 멀티-tenancy를 지원하여, 각기 다른 팀이나 프로젝트를 위한 완전히 분리된 환경을 제공합니다. 각 환경은 전용 worker 그룹, 비밀 정보 및 내부 저장소 백엔드와 같은 자체 리소스를 갖추고 있습니다.",
-        "title": "격리된 Tenant에서 Workflow 관리"
-      },
-      "tests": {
-        "header": "플로우에 대한 단위 테스트",
-        "label": "테스트",
-        "message": "플로우의 로직을 개별적으로 검증하고, 회귀를 조기에 감지하며, 자동화가 변화하고 성장함에 따라 신뢰를 유지하세요.",
-        "title": "모든 변경 사항에 대한 신뢰성 보장"
-      },
-      "watch_the_video": "비디오 보기"
-    },
-    "density": "Density",
-    "density_compact": "Compact",
-    "density_expanded": "Expanded",
-    "density_normal": "Normal",
-    "dependencies": "종속성",
-    "dependencies delete flow": "이 flow는 종속성을 가지고 있습니다. 삭제하면 종속성이 실행되지 않습니다.<br /><br /> 영향을 받는 flow 목록은 다음과 같습니다:",
-    "dependencies loaded": "종속성이 로드되었습니다",
-    "dependencies missing acls": "이 flow에 대한 권한이 없습니다",
-    "dependency": {
-      "controls": {
-        "clear_selection": "선택 해제",
-        "fit_view": "화면에 맞추기",
-        "zoom_in": "확대하기",
-        "zoom_out": "축소"
-      },
-      "search": {
-        "flow": {
-          "display": "flow 종속성 포함"
-        },
-        "namespace": {
-          "no_namespace": "namespace 없음",
-          "select": "namespace 선택"
-        },
-        "no_results": "{term}에 대한 결과가 없습니다.",
-        "placeholders": {
-          "asset": "자산, flow 또는 namespace로 검색...",
-          "default": "flow 또는 namespace로 검색..."
-        }
-      }
-    },
-    "dependency task": "Task {taskId}가 다른 task의 종속성입니다",
-    "description": "설명",
-    "details": "세부 정보",
-    "disable": "비활성화",
-    "disabled": "비활성화됨",
-    "disabled flow desc": "이 flow는 비활성화되어 있습니다. 실행하려면 활성화하세요.",
-    "disabled flow title": "이 flow는 비활성화되었습니다.",
-    "discard changes confirmation": "저장되지 않은 변경 사항이 있습니다. 정말로 취소하시겠습니까?",
-    "discard execution confirmation": "저장되지 않은 input이 있습니다. 이 실행을 취소하시겠습니까?",
-    "display direct sub tasks count": "직접 subtask 수 표시",
-    "display flow {id} executions": "Flow {id} 실행 표시",
-    "display metric for specific task": "특정 task의 메트릭 표시",
-    "display output for specific task": "특정 task의 출력 표시",
-    "display topology for flow": "Flow의 토폴로지 표시",
-    "display_settings": "Display settings",
-    "docs": "문서",
-    "documentation": {
-      "documentation": "문서",
-      "github": "GitHub 이슈 열기"
-    },
-    "documentationMenu": "문서 메뉴",
-    "done": "완료",
-    "down trend": "감소 중",
-    "download": "다운로드",
-    "download logs": "Logs 다운로드",
-    "download_logos": "로고 팩 다운로드",
-    "download_logs_description": "Choose which logs to export. Filters default to your current view.",
-    "draft": "초안",
-    "draft_available": "편집기에서 초안 변경을 사용할 수 있습니다.",
-    "draft_flow_warning": "이 flow 리비전은 초안입니다. 실행은 이 초안 리비전을 기준으로 수행되며 flow 정의가 유효하지 않으면 즉시 실패할 수 있습니다.",
-    "drill down preview": "미리보기",
-    "drop items here": "여기에 항목을 드롭하세요",
-    "duplicate-pair": "{label} \"{key}\"가 중복되었습니다. 첫 번째 key는 무시됩니다.",
-    "duration": "지속 시간",
-    "dynamic": "동적",
-    "each value": "반복 값",
-    "edit": "편집",
-    "edit flow": "Flow 편집",
-    "editor": "편집기",
-    "editor_shortcuts": {
-      "command_palette": "명령 팔레트 표시",
-      "comment": "댓글",
-      "comment_uncomment": "주석 처리/주석 해제",
-      "decrease_fontsize": "편집기 글꼴 크기 줄이기",
-      "duplicate_cursor": "커서 복제",
-      "execute_flow": "flow 실행",
-      "fold_unfold": "코드 접기/펼치기",
-      "increase_fontsize": "에디터 글꼴 크기 증가",
-      "label": "키보드 단축키",
-      "move_line": "줄 이동",
-      "reset_fontsize": "편집기 글꼴 크기 재설정",
-      "save_flow": "Flow 저장",
-      "toggle_ai_agent": "AI 에이전트 전환",
-      "trigger_autocompletion": "자동 완성 트리거",
-      "uncomment": "주석 해제"
-    },
-    "ee-tooltip": {
-      "button": "문의하기",
-      "features-blocked": "이 기능은 Enterprise Edition이 필요합니다."
-    },
-    "email": "이메일",
-    "email length constraint": "이메일은 256자를 초과할 수 없습니다.",
-    "empty": {
-      "announcements": {
-        "content": "공지사항을 통해 사용자에게 변경 사항을 알리거나 계획된 유지보수 중단에 대해 알릴 수 있습니다. 공지사항 유형을 선택하고, 표시할 날짜 범위를 설정한 후 공지사항 메시지를 작성하세요.",
-        "title": "아직 공지가 없습니다!"
-      },
-      "apiTokens": {
-        "content": "API 토큰은 Kestra API에 대한 프로그래매틱 접근을 허용하고자 할 때 사용됩니다.",
-        "title": "API 토큰 관리"
-      },
-      "apps": {
-        "content": "Kestra와 외부 세계를 상호작용하는 앱을 만들기 시작하세요.",
-        "title": "앱이 아직 없습니다!"
-      },
-      "assets": {
-        "content": "데이터 자산, 서비스 및 인프라를 추적하고 관리하기 위해 자산을 추가하세요.",
-        "title": "아직 자산이 없습니다!"
-      },
-      "concurrency_executions": {
-        "content": "자세한 내용은 <strong><a href=\"https://kestra.io/docs/workflow-components/execution?utm_source=app&utm_medium=referral&utm_campaign=concurrency-inlinedoc\" target=\"_blank\">Executions</a></strong>에 대한 문서를 참조하세요.",
-        "title": "이 Flow에 대한 진행 중인 실행이 없습니다."
-      },
-      "concurrency_limit": {
-        "content": "우리 문서에서 <strong><a href=\"https://kestra.io/docs/workflow-components/concurrency?utm_source=app&utm_medium=referral&utm_campaign=concurrency-inlinedoc\" target=\"_blank\">Concurrency Limits</a></strong>에 대해 더 읽어보세요.",
-        "title": "이 Flow에 대한 제한이 설정되지 않았습니다."
-      },
-      "concurrency_limits": {
-        "content": "우리 문서에서 <strong><a href=\"https://kestra.io/docs/workflow-components/concurrency?utm_source=app&utm_medium=referral&utm_campaign=concurrency-inlinedoc\" target=\"_blank\">동시성 제한</a></strong>에 대해 더 읽어보세요.",
-        "title": "동시성 제한이 설정되지 않았습니다."
-      },
-      "dependencies": {
-        "ASSET": {
-          "content": "이 자산은 flow 또는 다른 자산과 상위 또는 하위 종속성이 없습니다.",
-          "title": "현재 종속성이 없습니다."
-        },
-        "EXECUTION": {
-          "content": "<a href=\"https://kestra.io/docs/ui/executions?utm_source=app&utm_medium=referral&utm_campaign=dependencies-inlinedoc#dependencies\" target=\"_blank\">실행 종속성</a>에 대한 자세한 내용은 문서를 참조하세요.",
-          "title": "현재 종속성이 없습니다."
-        },
-        "FLOW": {
-          "content": "<a href=\"https://kestra.io/docs/ui/flows?utm_source=app&utm_medium=referral&utm_campaign=dependencies-inlinedoc#dependencies\" target=\"_blank\">Flow Dependencies</a>에 대한 자세한 내용은 문서를 참조하세요.",
-          "title": "현재 종속성이 없습니다."
-        },
-        "NAMESPACE": {
-          "content": "<a href=\"https://kestra.io/docs/ui/namespaces?utm_source=app&utm_medium=referral&utm_campaign=dependencies-inlinedoc#dependencies\" target=\"_blank\">Namespace Dependencies</a>에 대한 자세한 내용은 문서를 참조하세요.",
-          "title": "현재 종속성이 없습니다."
-        }
-      },
-      "groups": {
-        "content": "그룹은 사용자를 함께 묶어 권한 및 역할 바인딩을 테넌트 전체에서 집합적으로 관리할 수 있도록 합니다.",
-        "title": "아직 그룹이 없습니다!"
-      },
-      "kill_switches": {
-        "content": "킬 스위치 기능은 문제 있는 실행을 중지할 수 있는 UI 기반 메커니즘을 제공합니다. 이는 CLI 전용 <code>--skip-executions</code> 및 <code>--skip-flows</code> 명령을 포괄적인 관리 인터페이스로 대체합니다.",
-        "title": "아직 Kill Switch가 없습니다!"
-      },
-      "mcpToolFlows": {
-        "content": "<code>McpToolTrigger</code>를 추가하여 flow를 MCP 도구로 노출합니다. <strong><a href=\"https://kestra.io/docs/workflow-components/triggers/mcp-tool-trigger?utm_source=app&utm_medium=referral&utm_campaign=mcp-tool-trigger-inlinedoc\" target=\"_blank\">MCP Tool Trigger</a></strong>에 대한 자세한 내용은 문서를 참조하세요.",
-        "title": "이 서버에는 아직 등록된 tool flow가 없습니다."
-      },
-      "namespaceFiles": {
-        "content": "namespace 파일은 이 namespace의 프로젝트 폴더처럼 작동합니다. Python, SQL, dbt 또는 Terraform 코드를 저장한 다음, flow에서 다음을 사용하여 모든 파일을 참조하세요",
-        "title": "이 namespace에 아직 파일이 없습니다"
-      },
-      "panels": {
-        "content": "모든 패널을 닫았습니다.  \n계속하려면 위의 탭을 선택하세요.",
-        "title": "패널이 열려 있지 않음"
-      },
-      "pluginDefaults": {
-        "content": "플러그인 기본값을 사용하면 플러그인 구성을 중앙에서 관리하고 namespace의 모든 flow와 공유할 수 있습니다.",
-        "title": "아직 플러그인 기본값이 없습니다!"
-      },
-      "plugins": {
-        "content": "우리 문서에서 <strong><a href=\"https://kestra.io/docs/workflow-components/plugin-defaults?utm_source=app&utm_medium=referral&utm_campaign=plugin-default-inlinedoc\" target=\"_blank\">Concurrency Limits</a></strong>에 대해 더 읽어보세요.",
-        "title": "이 Namespace에 대한 플러그인 기본값이 설정되지 않았습니다."
-      },
-      "testSuites": {
-        "content": "테스트 스위트를 생성하여 flow를 테스트하기 시작하세요.",
-        "title": "아직 Test suite가 없습니다!"
-      },
-      "triggers": {
-        "content": "<strong><a href=\"https://kestra.io/docs/workflow-components/triggers?utm_source=app&utm_medium=referral&utm_campaign=trigger-inlinedoc\" target=\"_blank\">Triggers</a></strong>에 대한 자세한 내용은 문서를 참조하세요.",
-        "title": "flow에 Triggers가 없습니다."
-      },
-      "variables": {
-        "content": "flow 간의 구성을 공유하기 위해 key-value 쌍을 추가하세요. 하위 namespace는 이를 자동으로 상속하며, 모든 value를 참조할 수 있습니다.",
-        "title": "아직 변수가 없습니다"
-      },
-      "versionPlugin": {
-        "content": "여기에서 Kestra 인스턴스에 설치된 모든 플러그인을 관리할 수 있습니다. 새로 설치된 플러그인은 인스턴스의 구성에 따라 모든 Kestra 서비스에서 즉시 사용 가능하지 않을 수 있습니다.",
-        "title": "아직 버전이 지정된 플러그인이 없습니다!"
-      },
-      "workerRegistrationTokens": {
-        "content": "등록 토큰은 원격 worker가 Kestra 인스턴스에 안전하게 인증하고 등록할 수 있도록 합니다. 토큰을 생성한 후 이를 사용하여 새로운 worker를 이 클러스터에 연결하세요.",
-        "title": "아직 등록 토큰이 없습니다!"
-      }
-    },
-    "empty search": "검색 결과가 없습니다",
-    "enable": "활성화",
-    "enable concurrency": "동시성 활성화",
-    "enabled": "활성화됨",
-    "encoding": "인코딩",
-    "end date": "종료 날짜",
-    "end datetime": "종료 날짜 및 시간",
-    "environment": "환경",
-    "environment color setting": "환경 색상",
-    "environment name setting": "환경 이름",
-    "error": "오류",
-    "error detected": "오류가 감지되었습니다.",
-    "error in editor": "편집기에서 오류가 발견되었습니다",
-    "errorLogs": "오류 logs",
-    "errors": {
-      "401": {
-        "content": "이 페이지에 접근하려면 인증이 필요합니다.",
-        "title": "인증되지 않았습니다."
-      },
-      "403": {
-        "content": "이 페이지에 접근할 권한이 없습니다.",
-        "title": "접근 거부됨"
-      },
-      "404": {
-        "content": "요청한 URL을 이 서버에서 찾을 수 없습니다.<br />알고 있는 전부입니다.",
-        "flow or execution": "찾고 있는 flow 또는 실행이 존재하지 않습니다.",
-        "title": "페이지를 찾을 수 없음"
-      }
-    },
+    "change execution state confirm": "실행 <code>{id}</code>의 상태를 변경하시겠습니까?",
+    "change execution state done": "실행 상태가 업데이트되었습니다",
+    "mark as": "<code>{status}</code>로 표시",
+    "unqueue as": "<code>{status}</code>로 대기열에서 제거",
+    "kill": "종료",
+    "kill parents and subflow": "현재 및 subflow 종료",
+    "kill only parents": "현재 것만 종료",
+    "killed confirm": "실행 <code>{id}</code>을(를) 종료하시겠습니까?",
+    "killed done": "종료 중입니다.",
+    "resume": "재개",
+    "resumed title": "실행 <code>{id}</code> 재개",
+    "resumed confirm": "실행 <code>{id}</code>을(를) 재개하시겠습니까?",
+    "resumed done": "실행이 재개되었습니다.",
+    "resume from breakpoint title": "`{{id}}` 실행을 중단점에서 재개",
+    "resume from breakpoint done": "실행이 중단점부터 재개되었습니다",
+    "breakpoints": "중단점",
+    "pause": "일시 중지",
+    "pause title": "실행 <code>{id}</code>을(를) 일시 중지합니다.<br/>현재 실행 중인 task는 계속 처리되며, 실행은 수동으로 다시 시작해야 합니다.",
+    "pause confirm": "실행 <code>{id}</code>을(를) 일시 중지하시겠습니까?",
+    "pause done": "실행이 PAUSED 상태입니다.",
+    "unqueue": "대기열에서 제거",
+    "unqueue title": "실행 <code>{id}</code>을(를) 대기열에서 제거합니다.<br/>이 작업은 flow 동시성 제한을 따르지 않으므로 허용된 제한보다 더 많은 실행이 진행될 수 있습니다.",
+    "unqueue title multiple": "<code>{count}</code>개의 실행을 대기열에서 제거하시겠습니까?<br/><br/>이 작업은 flow 동시성 제한을 따르지 않으므로 허용된 제한보다 더 많은 실행이 진행될 수 있습니다.",
+    "unqueue confirm": "실행 <code>{id}</code>의 대기열을 해제하시겠습니까?",
+    "unqueue done": "실행이 대기열에서 제거되었습니다.",
+    "force run": "강제 실행",
+    "force run title": "실행 <code>{id}</code> 강제 실행.",
+    "force run tooltip": "실행을 강제로 수행합니다. 이는 중복된 task 실행을 생성할 수 있으며, 가능하다면 다른 작업을 사용하십시오.",
+    "force run confirm": "실행 <code>{id}</code>을(를) 강제로 실행하시겠습니까?<br/><br/>WARNING: 실행을 강제로 실행하는 것은 보장되지 않으며 중복된 task 실행을 생성할 수 있습니다.<br/><br/>다음 전환이 수행됩니다:<br/><ul><li>CREATED tasks는 RUNNING 상태로 이동합니다.</li><li>RUNNING tasks는 다시 제출됩니다.</li><li>QUEUED tasks는 대기열에서 제거됩니다.</li><li>PAUSED tasks는 재개됩니다.</li></ul>",
+    "force run done": "실행이 강제 실행됩니다.",
+    "toggle output": "출력 전환",
+    "metrics": "메트릭",
+    "no data current task": "현재 task에 대한 데이터가 없습니다.",
+    "no metrics available": "이 task 실행에 대한 메트릭이 기록되지 않았습니다.",
+    "no outputs available": "이 task 실행에 대한 output이 없습니다.",
+    "outputs": "Outputs",
+    "flow_outputs": "Flow Outputs",
+    "no_flow_outputs": "출력 없음.",
+    "output": "Output",
     "eval": {
-      "expression": "표현식",
-      "preview": "미리보기",
-      "render": "식 렌더링",
       "title": "디버그 표현식",
-      "tooltip": "모든 Pebble 표현식을 렌더링하고 실행 컨텍스트를 검사합니다."
+      "render": "식 렌더링",
+      "tooltip": "모든 Pebble 표현식을 렌더링하고 실행 컨텍스트를 검사합니다.",
+      "preview": "미리보기",
+      "expression": "표현식"
     },
-    "evaluation lock date": "평가 잠금 날짜",
-    "execute": "실행",
-    "execute backfill": "backfill 실행",
-    "execute flow behaviour": "Flow 실행",
-    "execute flow now ?": "이 flow를 실행하시겠습니까?",
-    "execute the flow": "Flow <code>{id}</code> 실행",
-    "execution": "실행",
-    "execution already finished": "실행 <code>{executionId}</code>이(가) 이미 완료되었습니다",
-    "execution id": "실행 Id",
-    "execution labels": "실행 라벨",
-    "execution not found": "{executionId} 실행을 찾을 수 없습니다.",
-    "execution not in state FAILED": "실행 <code>{executionId}</code>이(가) FAILED 상태가 아닙니다",
-    "execution not in state PAUSED": "실행 <code>{executionId}</code>이(가) PAUSED 상태가 아닙니다",
-    "execution replay": "이 실행은 다음의 재실행입니다:",
-    "execution replayed": "이 실행은 재실행되었습니다.",
-    "execution restarted": "이 실행은 {nbRestart}번 다시 시작되었습니다.",
+    "attempt": "시도",
+    "toggle output display": "출력 표시 전환",
+    "name": "이름",
+    "key": "Key",
+    "value": "Value",
+    "each value": "반복 값",
+    "current execution": "현재 실행",
+    "parent execution": "부모 실행",
+    "original execution": "원래 실행",
+    "automatic refresh": "자동 새로 고침",
+    "toggle periodic refresh each x seconds": "주기적인 새로 고침을 {interval}초마다 전환",
+    "trigger refresh": "새로 고침 trigger",
+    "add-trigger-in-editor": "먼저 Flow에 Trigger를 추가하세요.",
+    "refresh": "새로 고침",
+    "filter by status": "{status} 상태로 실행 필터링",
+    "topology-graph": {
+      "graph-orientation": "그래프 방향",
+      "zoom-in": "확대",
+      "zoom-out": "축소",
+      "zoom-reset": "확대/축소 재설정",
+      "zoom-fit": "맞춤",
+      "invalid": "그래프 오류",
+      "invalid_description": "그래프를 로드하는 중 오류가 발생했습니다. 소스 코드에서 오류를 확인하세요."
+    },
+    "show task logs": "Task Logs 보기",
+    "show task condition": "작업 상태 표시",
+    "show task outputs": "Task Outputs 보기",
+    "show task source": "Task 소스 보기",
+    "specific task": "특정 task",
+    "display output for specific task": "특정 task의 출력 표시",
+    "display metric for specific task": "특정 task의 메트릭 표시",
+    "display direct sub tasks count": "직접 subtask 수 표시",
+    "stream": "스트림",
     "execution statistics": "실행 통계",
-    "execution-include-non-terminated": "종료되지 않은 실행을 포함하시겠습니까?",
-    "execution-warn-deleting-still-running": "이 작업을 취소하고 진행 중인 실행을 먼저 중지할 것을 강력히 권장합니다. 종료되지 않은 실행을 삭제하면 concurrency 문제, flow 종속성 관리 불일치, 인스턴스에서의 좀비 프로세스가 발생할 수 있으며, 이는 시스템 성능을 저하시킬 수 있습니다. 삭제를 진행하기 전에 이러한 위험을 충분히 이해했는지 확인하십시오.",
-    "execution-warn-title": "중요한 WARNING!",
-    "execution_deletion": {
-      "logs": "Logs 삭제",
-      "metrics": "메트릭 삭제",
-      "storage": "내부 저장소 파일 삭제"
-    },
-    "execution_failed": "실행 실패!",
-    "execution_guide": {
-      "get_started": {
-        "text": "Quickstart Guide를 따라 Kestra를 설치하고 첫 번째 workflow를 구축하세요.",
-        "title": "시작하기 ⚡"
-      },
-      "namespaces": {
-        "text": "namespace는 flow와 그 구성 요소의 논리적 그룹입니다.",
-        "title": "네임스페이스 정보"
-      },
-      "videos_tutorials": {
-        "text": "비디오 튜토리얼로 시작하세요.",
-        "title": "비디오 튜토리얼"
-      },
-      "workflow_components": {
-        "text": "Kestra workflow의 주요 오케스트레이션 구성 요소를 알아보세요.",
-        "title": "워크플로우 구성 요소"
-      }
-    },
-    "execution_started": "실행이 시작되었습니다!",
-    "execution_starts_progress": "실행이 시작되면, 여기에서 진행 상황 업데이트를 볼 수 있습니다.",
-    "execution_status": "실행 상태:",
-    "executions": "실행",
-    "executions deleted": "<code>{executionCount}</code> 개의 실행이 삭제되었습니다",
+    "stats": "통계",
+    "concurrency limits": "동시성 제한",
+    "system overview": "시스템 개요",
+    "usage": "사용량",
+    "namespaces": "Namespaces",
+    "tasks": "Tasks",
     "executions duration (in minutes)": "총 실행 시간 (분 단위)",
-    "executions force run": "<code>{executionCount}</code> 실행 강제 실행",
-    "executions killed": "<code>{executionCount}</code> 개의 실행이 강제 종료되었습니다",
-    "executions paused": "<code>{executionCount}</code> execution(s) PAUSED",
-    "executions replayed": "<code>{executionCount}</code> 개의 실행이 재실행되었습니다",
-    "executions restarted": "<code>{executionCount}</code> 개의 실행이 재시작되었습니다",
-    "executions resumed": "<code>{executionCount}</code> 개의 실행이 재개되었습니다",
-    "executions state changed": "<code>{executionCount}</code> 실행 상태가 변경되었습니다",
-    "executions unqueue": "<code>{executionCount}</code> 실행 대기열에서 제거됨",
-    "expand": "확장",
-    "expand all": "모두 확장",
-    "expand dependencies": "종속성 확장",
-    "expand error": "실패한 task만 확장",
-    "expand_by_default": "Expand structured logs by default",
-    "expiration": "만료",
-    "expiration date": "만료 날짜",
-    "export": "내보내기",
-    "export all flows": "모든 flow 내보내기",
-    "export all templates": "모든 템플릿 내보내기",
-    "export_as": ".{format}로 내보내기",
-    "export_csv": "CSV로 내보내기",
-    "exports": "내보내기 목록",
-    "failed to export plugin defaults": "플러그인 기본값 내보내기에 실패했습니다.",
-    "failed to import plugin defaults": "플러그인 기본값 가져오기에 실패했습니다",
-    "failed to render pdf": "PDF 미리보기를 렌더링하지 못했습니다",
-    "false": "False",
-    "feeds": {
-      "heading": "Kestra의 모든 것.",
-      "subheading": "최신 업데이트, 가이드 및 스토리",
-      "title": "Kestra의 새로운 기능"
+    "last 48 hours": "지난 48시간",
+    "configure basic auth": "기본 인증 구성",
+    "email": "이메일",
+    "password": "비밀번호",
+    "confirm password": "비밀번호 확인",
+    "email length constraint": "이메일은 256자를 초과할 수 없습니다.",
+    "password length constraint": "비밀번호는 256자를 초과할 수 없습니다.",
+    "password empty constraint": "잘못된 사용자 이름 또는 비밀번호",
+    "passwords do not match": "비밀번호가 일치하지 않습니다.",
+    "avg duration": "평균 실행 시간",
+    "neutral trend": "안정적",
+    "up trend": "증가 중",
+    "down trend": "감소 중",
+    "update aborted": "업데이트 중단됨",
+    "invalid flow": "잘못된 Flow",
+    "invalid yaml": "잘못된 YAML",
+    "inputs": "Inputs",
+    "no_inputs": "입력값이 없습니다.",
+    "input": "Input",
+    "variables": "변수",
+    "variable_explorer": {
+      "title": "입력/출력",
+      "search_placeholder": "Key 또는 value 검색...",
+      "tasks_outputs": "Tasks outputs",
+      "tree": "트리",
+      "raw_json": "Raw JSON",
+      "select_prompt": "value를 확인할 변수를 선택하세요.",
+      "empty": "이 실행에 사용할 수 있는 변수가 없습니다.",
+      "one_key": "\\{ 1 key \\}",
+      "n_keys": "\\{ {count} keys \\}",
+      "one_item": "[ 1개 항목 ]",
+      "n_items": "[ {count}개 항목 ]"
     },
-    "file preview truncated": "표시된 내용이 잘렸습니다",
-    "file unavailable": "파일을 사용할 수 없음",
-    "file unavailable description": "이 파일은 더 이상 사용할 수 없습니다 — 삭제되었거나 만료되었을 수 있습니다.",
-    "fileTypeNotAllowed": "허용되지 않는 파일 유형입니다. 허용되는 유형: {types}",
     "file_preview": {
       "big_file_warning": "이 파일의 크기는 {size}입니다. 브라우저가 차단될 수 있으니 로드하는 데 시간이 걸릴 수 있습니다. 그래도 로드하시겠습니까?",
       "load_anyway": "그래도 로드하기"
     },
-    "files": "파일",
-    "filter by log level": "Log 레벨로 필터링",
-    "filter by status": "{status} 상태로 실행 필터링",
-    "filter by this value": "Filter by this value",
-    "filter_for": "Filter for",
-    "filter_out": "Filter out",
-    "filters": {
-      "comparators": {
-        "between": "사이에",
-        "contains": "포함합니다",
-        "ends_with": "끝남",
-        "greater_than": "보다 큼",
-        "greater_than_or_equal_to": "크거나 같음",
-        "in": "안에",
-        "is": "입니다",
-        "is_not": "아님",
-        "is_one_of": "중 하나입니다.",
-        "less_than": "보다 작음",
-        "less_than_or_equal_to": "작거나 같음",
-        "not_contains": "포함하지 않음",
-        "not_in": "에 없음",
-        "starts_with": "로 시작합니다"
-      },
-      "empty": "데이터가 없습니다.",
-      "format": "'key:value'로 매개변수 입력",
-      "label": "필터 선택",
-      "options": {
-        "absolute_date": "절대 날짜",
-        "action": "동작",
-        "aggregation": "집계",
-        "child": "자식",
-        "details": "세부사항",
-        "endDate": "종료 날짜",
-        "flow": "플로우",
-        "labels": "레이블",
-        "level": "로그 레벨",
-        "metric": "메트릭",
-        "namespace": "네임스페이스",
-        "permission": "권한",
-        "relative_date": "상대 날짜",
-        "scope": "범위",
-        "service_type": "유형",
-        "startDate": "시작 날짜",
-        "state": "상태",
-        "status": "상태",
-        "task": "작업",
-        "text": "텍스트",
-        "type": "유형",
-        "user": "사용자"
-      },
-      "save": {
-        "dialog": {
-          "confirmation": "검색 기준 <code>{name}</code>",
-          "heading": "현재 검색 저장",
-          "hint": "이 검색 기준에 어떤 label을 지정하시겠습니까?",
-          "placeholder": "레이블"
-        },
-        "empty": "아직 검색을 저장하지 않았습니다.",
-        "label": "저장된 검색",
-        "name_already_used": "이미 사용 중인 label입니다.",
-        "remove": "제거",
-        "tooltip": "빈 검색 기준을 저장할 수 없습니다."
-      },
-      "settings": {
-        "label": "페이지 설정",
-        "show_chart": "주요 차트 표시"
-      },
-      "text_search": "이 텍스트 검색"
-    },
-    "fix_with_ai": "AI로 수정",
-    "flow": "Flow",
-    "flow already exists": "Flow가 이미 존재합니다",
-    "flow already exists message": "namespace <code>{namespace}</code>에 flow <code>{id}</code>가 이미 존재합니다. 새로운 리비전을 생성하시겠습니까?",
-    "flow creation": "Flow 생성",
-    "flow creation denied in namespace": "`{namespace}` namespace에서 flow를 생성할 권한이 없습니다.",
-    "flow delete": "<code>{flowCount}</code> 개의 flow를 삭제하시겠습니까?",
-    "flow deleted, you can restore it": "Flow가 삭제되었으며 읽기 전용 보기입니다. 여전히 복원할 수 있습니다.",
-    "flow disable": "<code>{flowCount}</code> 개의 flow를 비활성화하시겠습니까?",
-    "flow enable": "<code>{flowCount}</code> 개의 flow를 활성화하시겠습니까?",
-    "flow export": "<code>{flowCount}</code> 개의 flow를 내보내시겠습니까?",
-    "flow must have id and namespace": "Flow에는 id와 namespace가 있어야 합니다.",
-    "flow must not be empty": "flow는 비어 있을 수 없습니다",
-    "flow not imported": "일부 flow를 가져올 수 없습니다.",
-    "flow revision latest": "최신 flow 개정판",
-    "flow revision original": "원본 flow 개정",
-    "flow revision specific": "특정 flow 개정",
-    "flow source not found": "Flow source를 찾을 수 없음",
-    "flow-dependencies": "종속성",
-    "flow-no-dependencies": "귀하의 flow에는 종속성이 없습니다.",
-    "flow_editor_stats": {
-      "apps": {
-        "suffix": "앱(s)",
-        "tooltip": "이 flow를 사용하는 앱 보기"
-      },
-      "dependencies": {
-        "suffix": "종속성",
-        "tooltip": "flow 종속성 보기"
-      },
-      "errors": {
-        "label": "{count} 오류"
-      },
-      "revisions": {
-        "suffix": "리비전(s)",
-        "tooltip": "flow 수정 보기"
-      },
-      "tests": {
-        "suffix": "테스트",
-        "tooltip": "flow 테스트 보기"
-      }
-    },
-    "flow_export": "flow 내보내기",
-    "flow_only": "Flow 탭에서만 사용 가능합니다.",
-    "flow_outputs": "Flow Outputs",
-    "flows": "Flows",
-    "flows deleted": "<code>{count}</code> 개의 flow가 삭제되었습니다",
-    "flows disabled": "<code>{count}</code> 개의 flow가 비활성화되었습니다",
-    "flows enabled": "<code>{count}</code> 개의 flow가 활성화되었습니다",
-    "flows exported": "<code>{count}</code> Flow(s) 내보내기 완료",
-    "flows imported": "Flow가 가져왔습니다.",
-    "focus task": "문서를 보려면 요소를 클릭하세요.",
-    "fold_all_multi_lines": "모든 다중 라인 접기",
-    "font size": "Font size",
-    "for flow": "flow용",
-    "forbidden system labels": "system label로는 system.correlationId만 사용할 수 있습니다",
-    "force run": "강제 실행",
-    "force run confirm": "실행 <code>{id}</code>을(를) 강제로 실행하시겠습니까?<br/><br/>WARNING: 실행을 강제로 실행하는 것은 보장되지 않으며 중복된 task 실행을 생성할 수 있습니다.<br/><br/>다음 전환이 수행됩니다:<br/><ul><li>CREATED tasks는 RUNNING 상태로 이동합니다.</li><li>RUNNING tasks는 다시 제출됩니다.</li><li>QUEUED tasks는 대기열에서 제거됩니다.</li><li>PAUSED tasks는 재개됩니다.</li></ul>",
-    "force run done": "실행이 강제 실행됩니다.",
-    "force run title": "실행 <code>{id}</code> 강제 실행.",
-    "force run tooltip": "실행을 강제로 수행합니다. 이는 중복된 task 실행을 생성할 수 있으며, 가능하다면 다른 작업을 사용하십시오.",
-    "form": "양식",
-    "form error": "양식 오류",
-    "from": "시작",
-    "gantt": "간트",
-    "gantt_no_tasks_executed": "이 실행은 어떤 task도 실행하지 않고 종료되었습니다.  \n개요와 logs를 확인하여 이유를 알아보세요.",
-    "gantt_no_tasks_match_filters": "검색, 상태 또는 log-level 필터를 조정해 보세요.",
-    "gantt_no_tasks_match_filters_title": "선택한 필터와 일치하는 task가 없습니다.",
-    "healthcheck date": "HealthCheck 날짜",
-    "hide task documentation": "task 문서 숨기기",
-    "home": "홈",
-    "hostname": "호스트 이름",
-    "iam": "IAM",
-    "id": "Id",
-    "import": "가져오기",
-    "in-our-documentation": "우리의 문서에서.",
-    "informative notice": "노트(s)",
-    "input": "Input",
-    "inputs": "Inputs",
-    "instance": "인스턴스",
-    "invalid bulk delete": "실행을 삭제할 수 없습니다",
-    "invalid bulk force run": "실행을 강제로 실행할 수 없습니다.",
-    "invalid bulk kill": "실행을 강제 종료할 수 없습니다",
-    "invalid bulk pause": "실행을 PAUSED 상태로 전환할 수 없습니다.",
-    "invalid bulk replay": "실행을 재실행할 수 없습니다",
-    "invalid bulk restart": "실행을 재시작할 수 없습니다",
-    "invalid bulk resume": "실행을 재개할 수 없습니다",
-    "invalid bulk unqueue": "실행을 큐에서 제거할 수 없습니다.",
-    "invalid field": "잘못된 필드: {name}",
-    "invalid flow": "잘못된 Flow",
-    "invalid source": "잘못된 소스 코드",
-    "invalid yaml": "잘못된 YAML",
-    "is deprecated": "Deprecated 되었습니다",
-    "is required": "{field}는 필수 항목입니다.",
-    "item": "항목",
-    "items": "항목",
-    "join community": "커뮤니티에 참여하기",
-    "join_slack": "Slack 참여",
-    "jsonl": "JSONL",
-    "jump to...": "이동...",
-    "kestra": "Kestra",
-    "key": "Key",
-    "kill": "종료",
-    "kill only parents": "현재 것만 종료",
-    "kill parents and subflow": "현재 및 subflow 종료",
-    "killed confirm": "실행 <code>{id}</code>을(를) 종료하시겠습니까?",
-    "killed done": "종료 중입니다.",
-    "kv": {
-      "add": "생성",
-      "delete multiple": {
-        "confirm": "정말로 삭제하시겠습니까: <code>{name}</code> KV(s)?",
-        "warning": "해당 namespace에 대한 권한이 없으므로 생략됩니다: <code>{namespaces}</code>"
-      },
-      "duplicate": "이 키는 이미 존재합니다",
-      "inherited": "상속된 KV 쌍",
-      "name": "KV Store",
-      "type": "유형",
-      "update": "키 '{key}'의 값을 업데이트하세요"
-    },
-    "label": "Label",
-    "label filter placeholder": "'key:value'로 라벨 지정",
-    "labels": "라벨",
-    "last 48 hours": "지난 48시간",
-    "last X days count": "지난 {days}일 동안 {count}",
-    "last error was": "마지막 오류는",
-    "last evaluation date": "마지막 평가 날짜",
-    "last evaluation date tooltip": "When the trigger was last evaluated by the scheduler, regardless of whether it produced an execution.",
-    "last execution date": "마지막 실행 날짜",
-    "last execution state": "마지막 상태",
-    "last execution status": "마지막 실행 상태",
-    "last modified": "마지막 수정",
-    "last trigger date": "마지막 trigger 날짜",
-    "last trigger date tooltip": "트리거가 마지막으로 실행된 시점입니다. 백필을 실행할 때 과거일 수 있습니다.",
-    "latest_update": "최신 업데이트",
-    "launch execution": "실행",
-    "learn_more": "자세히 알아보기",
-    "leave page": "페이지 나가기",
-    "license": "라이선스",
-    "light_background": "밝은 배경에서 작업할 때 선호되는 옵션입니다.",
-    "light_version": "라이트 버전",
-    "line": "라인",
-    "line-by-line": "줄별로",
-    "loaded x dependencies": "{count} 개의 종속성이 로드되었습니다",
-    "loading": "로딩 중...",
-    "log expand setting": "기본 Log 표시",
-    "logExporters": "로그 Exporters",
-    "logs": "Logs",
-    "logs_copied": "Logs copied to your clipboard",
-    "logs_view": {
-      "compact": "기본 보기",
-      "compact_details": "각 task별로 그룹화된 간결한 보기로 task logs 표시",
-      "raw": "Temporal 보기",
-      "raw_details": "전체 task logs 및 flow logs를 원시 타임스탬프 순서로 표시"
-    },
-    "main_configuration": "주요 설정",
-    "manage labels": "label 관리",
-    "management port": "관리 포트",
-    "mark as": "<code>{status}</code>로 표시",
-    "max": "Max",
-    "mcp": {
-      "api_token": "API 토큰",
-      "auth_type": "인증",
-      "basic_auth": "기본 인증",
-      "bearer_token": "베어러 토큰 인증",
-      "client_setup": "클라이언트 설정",
-      "connect": "연결",
-      "connect_tab": {
-        "auth_api_token_hint": "클라이언트를 시작하기 전에 <code>KESTRA_TOKEN</code>을 환경 변수로 설정하세요.",
-        "auth_basic_hint": "클라이언트를 시작하기 전에 base64로 인코딩된 <code>username:password</code> 문자열을 포함하는 <code>KESTRA_BASIC_AUTH</code>를 환경 변수로 설정하세요.",
-        "auth_oauth_browser_hint": "첫 번째 연결 시 브라우저가 ID 공급자의 로그인 페이지를 엽니다.",
-        "auth_oauth_client_id_hint": "<code>&lt;client-id&gt;</code>를 OAuth 클라이언트 ID로 교체하고 해당 클라이언트에 유효한 리다이렉트 URI로 <code>http://localhost:7777</code>을 등록하세요.",
-        "claude_code": "Claude 코드",
-        "claude_code_hint": "터미널에서 다음 명령어를 실행하세요:",
-        "claude_desktop": "클로드 데스크톱",
-        "claude_desktop_hint": "다음 내용을 claude_desktop_config.json 파일에 추가하십시오:",
-        "claude_desktop_mac": "macOS: ~/Library/Application Support/Claude/claude_desktop_config.json",
-        "claude_desktop_win": "Windows: %APPDATA%\\Claude\\claude_desktop_config.json",
-        "client_picker_label": "AI 클라이언트 선택",
-        "codex": "Codex (OpenAI)",
-        "codex_hint": "귀하의 codex.json MCP 구성에 다음을 추가하십시오:",
-        "cursor": "커서",
-        "cursor_hint": "~/.cursor/mcp.json에 다음을 추가하십시오:",
-        "server_url": "서버 URL"
-      },
-      "copy_url": "URL 복사",
-      "create": "서버 생성",
-      "delete_confirm": "이 MCP 서버를 삭제하시겠습니까?",
-      "id_invalid": "ID는 소문자 또는 숫자로 시작해야 하며, 소문자, 숫자, 하이픈, 밑줄만 포함할 수 있습니다.",
-      "id_placeholder": "예: my-mcp-server",
-      "instructions": "지침",
-      "main_tenant": "메인",
-      "managed_by_kestra": "Kestra에서 관리",
-      "no_oauth_providers": "이 인스턴스에 구성된 OIDC 공급자가 없습니다",
-      "no_servers": "MCP 서버를 찾을 수 없습니다. 외부 AI 에이전트에 MCP Tool trigger를 노출하기 위해 첫 번째 서버를 생성하세요.",
-      "oauth": "OAuth",
-      "oauth_hint": "OIDC 공급자의 Bearer JWT",
-      "oauth_provider": "OAuth 공급자",
-      "oauth_provider_placeholder": "구성된 OIDC 공급자 선택",
-      "oauth_provider_required": "인증 유형이 OAuth인 경우 OAuth 공급자가 필요합니다",
-      "page_description": "Kestra flow를 MCP 호환 AI 에이전트의 도구로 노출하십시오.",
-      "private": "비공개",
-      "private_server": "프라이빗 서버",
-      "public": "공개",
-      "public_hint": "경고: 공개 서버는 인증이 필요하지 않습니다. URL을 아는 누구나 namespace 또는 권한 확인 없이 이 서버에 의해 노출된 모든 도구를 호출할 수 있습니다. 외부에 노출해도 안전한 서버에만 사용하십시오.",
-      "save": "변경 사항 저장",
-      "scopes_supported": "지원되는 scope",
-      "scopes_supported_hint": "이 서버의 Protected Resource Metadata 문서에 공개된 scope. 사양을 준수하는 MCP 클라이언트는 이 목록으로 인증 요청을 제한합니다. 필드를 생략하고 클라이언트가 IdP의 공개 scope로 대체할 수 있도록 비워 두세요.",
-      "scopes_supported_placeholder": "openid, profile, email",
-      "server": "MCP 서버",
-      "server_id": "서버 ID",
-      "server_type": "서버 유형",
-      "servers": "MCP 서버",
-      "servers_count": "{count} MCP 서버",
-      "tab_connect": "연결",
-      "tab_edit": "편집",
-      "tab_tool_flows": "도구 Flows",
-      "tab_tool_flows_placeholder": "도구 flow 관리가 곧 제공됩니다.",
-      "tools": {
-        "annotations": "어노테이션",
-        "create_tool_flow": "도구 flow 생성",
-        "description": "설명",
-        "destructive": "파괴적",
-        "flow": "flow",
-        "idempotent": "멱등",
-        "no_tools": "검색 조건에 맞는 tool flow가 없습니다.",
-        "open_world": "Open world",
-        "read_only": "읽기 전용",
-        "return_direct": "직접 반환",
-        "state": "상태",
-        "title": "제목",
-        "tool_name": "도구 이름",
-        "trigger_id": "Trigger ID",
-        "view_flow": "flow 열기"
-      },
-      "url_copied": "URL이 복사되었습니다!",
-      "username_password": "사용자 이름 & 비밀번호",
-      "your_servers": "내 서버"
-    },
-    "metric": "메트릭",
-    "metric choice": "이 flow에 대한 사용 가능한 메트릭이 없습니다.",
-    "metrics": "메트릭",
-    "min": "Min",
-    "missingSource": "소스 누락",
-    "modify inputs": "입력 수정",
-    "modify_inputs": "입력 수정",
-    "monogram": "모노그램",
-    "more actions": "추가 작업",
-    "more_actions": "추가 작업",
-    "multi_panel_editor": {
-      "close_all_panels": "모든 패널 닫기",
-      "close_all_tabs": "모든 탭 닫기",
-      "move_left": "왼쪽으로 이동",
-      "move_right": "오른쪽으로 이동"
-    },
-    "multiple saved done": "{name}이(가) 저장되었습니다.",
-    "name": "이름",
-    "namespace": "Namespace",
-    "namespace and id readonly": "`namespace`와 `id` 속성은 변경할 수 없습니다 — 초기 값으로 설정되었습니다. flow의 이름을 변경하거나 namespace를 변경하려면 새 flow를 만들고 기존 flow를 삭제하세요.",
-    "namespace files": {
-      "create": {
-        "file": "파일 생성",
-        "file_already_exists": "이 이름의 파일이 이미 존재합니다",
-        "file_conflicts_with_folder": "이 이름의 폴더가 이미 존재합니다",
-        "file_error": "파일 생성 중 오류 발생",
-        "folder": "폴더 생성",
-        "folder_already_exists": "이 이름의 폴더가 이미 존재합니다",
-        "folder_conflicts_with_file": "이 이름의 파일이 이미 존재합니다",
-        "folder_error": "폴더 생성 중 오류가 발생했습니다",
-        "label": "생성"
-      },
-      "delete": {
-        "file": "파일 삭제",
-        "files": "{count}개의 선택된 파일 삭제",
-        "folder": "폴더 삭제",
-        "folders": "{count}개의 선택된 폴더 삭제",
-        "label": "삭제"
-      },
-      "dialog": {
-        "deletion": {
-          "confirm": "확인",
-          "file_single": "파일 <code>{name}</code>을(를) 삭제하시겠습니까?",
-          "files": "<code>{count}</code>개의 파일을 삭제하시겠습니까?",
-          "folder_single": "폴더 <code>{name}</code> 및 모든 내용을 삭제하시겠습니까?",
-          "folders": "<code>{count}</code>개의 폴더와 모든 내용을 삭제하시겠습니까?",
-          "mixed": "<code>{folders}</code> 폴더와 <code>{files}</code> 파일을 삭제하시겠습니까?",
-          "title": "콘텐츠 삭제 확인"
-        },
-        "name": {
-          "file": "확장자를 포함한 이름:",
-          "folder": "폴더 이름:"
-        },
-        "parent_folder": "부모 폴더:"
-      },
-      "export": "namespace 파일 내보내기",
-      "export_single": "파일 내보내기",
-      "filter": "필터",
-      "import": {
-        "error": "파일을 가져오는 동안 오류가 발생했습니다",
-        "files": "파일 가져오기",
-        "folder": "폴더 가져오기",
-        "import": "가져오기",
-        "success": "파일이 성공적으로 가져와졌습니다"
-      },
-      "new_file": "새 파일",
-      "no_items": {
-        "heading": "아직 namespace에 파일이 없습니다.",
-        "paragraph": "파일을 생성하거나 가져와서 namespace 내의 flow 간에 코드를 공유하세요."
-      },
-      "no_selection": {
-        "description": "내용을 보려면 트리에서 파일을 선택하세요.",
-        "heading": "선택된 파일 없음"
-      },
-      "path": {
-        "copy": "경로 복사",
-        "error": "경로를 클립보드에 복사하는 동안 오류가 발생했습니다",
-        "success": "경로가 클립보드에 복사되었습니다"
-      },
-      "rename": {
-        "file": "파일 이름 변경",
-        "folder": "폴더 이름 변경",
-        "label": "이름 변경",
-        "new_file": "확장자를 포함한 새 이름:",
-        "new_folder": "새 폴더 이름:"
-      },
-      "revisions": {
-        "history": "수정 기록",
-        "restore": {
-          "success": "파일 수정이 성공적으로 복원되었습니다."
-        }
-      },
-      "toggle": {
-        "hide": "namespace 파일 숨기기",
-        "show": "namespace 파일 보기"
-      },
-      "tree": {
-        "collapse": "모든 폴더 축소",
-        "expand": "모든 폴더 확장"
-      }
-    },
-    "namespace not allowed": "Namespace가 허용되지 않습니다",
-    "namespace_editor": {
-      "close": {
-        "all": "모든 탭 닫기",
-        "other": "다른 탭 닫기",
-        "right": "오른쪽 닫기",
-        "tab": "탭 닫기"
-      },
-      "empty": {
-        "create_message": "namespace 파일을 생성하거나 가져올 수 있습니다.",
-        "title": "현재 열린 탭이 없습니다",
-        "video_message": "편집기 소개 비디오를 확인할 수 있습니다."
-      }
-    },
-    "namespaces": "Namespaces",
-    "neutral trend": "안정적",
-    "new": "새로 만들기",
-    "new version": "새 버전 {version} 사용 가능!",
-    "next": "다음",
-    "next evaluation date": "다음 평가 날짜",
-    "next evaluation date tooltip": "트리거가 다음으로 평가될 시점은 간격을 기준으로 합니다. 조건이 충족되지 않으면 다음 실행 날짜와 항상 같지 않을 수 있습니다.",
-    "next execution date": "다음 실행 날짜",
-    "next_execution": "다음 실행",
-    "no data current task": "현재 task에 대한 데이터가 없습니다.",
-    "no inputs": "이 flow에는 입력이 없습니다.",
-    "no metrics available": "이 task 실행에 대한 메트릭이 기록되지 않았습니다.",
-    "no outputs available": "이 task 실행에 대한 output이 없습니다.",
-    "no result": "결과가 없습니다.",
-    "no revisions": "리비전 없음",
-    "no revisions found": "이 flow에 대한 수정본이 하나만 존재합니다.",
-    "no-executions-view": {
-      "guidance_desc": "당신의 flow를 실행하는 데 도움이 필요하신가요?",
-      "guidance_sub_desc": "문서를 참조하여 필요한 모든 정보를 확인하세요.",
-      "namespace_guidance_desc": "네임스페이스를 관리하는 데 도움이 필요하신가요?",
-      "namespace_sub_title": "이 대시보드를 채우기 위해 이 namespace에서 하나 이상의 flow를 실행하십시오.",
-      "sub_title": "실행 버튼을 클릭하여 첫 번째 workflow 실행을 시작하세요.",
-      "title": "자동화를 시작하세요"
-    },
-    "no_code": {
-      "add_field": "{field} 추가",
-      "adding": "+ {what} 추가",
-      "adding_default": "+ 새 value 추가",
-      "clearSelection": "선택 해제",
-      "creation": {
-        "afterExecution": "실행 후 블록 추가",
-        "charts": "차트 추가",
-        "conditions": "조건 추가",
-        "default": "추가",
-        "errors": "오류 처리기 추가",
-        "finally": "마지막 블록 추가",
-        "inputs": "입력 필드 추가",
-        "numerator": "분자를 추가하세요",
-        "pluginDefaults": "플러그인 기본값 추가",
-        "tasks": "작업 추가",
-        "triggers": "트리거 추가",
-        "where": "데이터 필터링"
-      },
-      "fields": {
-        "general": {
-          "checks": "점검",
-          "concurrency": "병행성",
-          "disabled": "비활성화됨",
-          "labels": "레이블",
-          "listeners": "리스너",
-          "outputs": "출력",
-          "retry": "재시도",
-          "sla": "SLA",
-          "taskDefaults": "작업 기본값",
-          "updated": "업데이트됨",
-          "variables": "변수",
-          "workerGroup": "작업자 그룹",
-          "workerSelector": "워커 선택기"
-        },
-        "main": {
-          "description": "설명",
-          "id": "Flow ID",
-          "inputs": "입력",
-          "namespace": "네임스페이스"
-        }
-      },
-      "labels": {
-        "label": "레이블",
-        "no_code": "코드 없는 편집기",
-        "variable": "변수",
-        "yaml": "YAML 편집기"
-      },
-      "remove": {
-        "cases": "이 케이스를 제거하십시오",
-        "default": "이 항목 제거"
-      },
-      "sections": {
-        "afterExecution": "실행 후",
-        "deprecated": "사용되지 않는 속성",
-        "errors": "오류 처리기",
-        "finally": "마지막으로",
-        "pluginDefaults": "플러그인 기본값",
-        "tasks": "작업",
-        "triggers": "트리거"
-      },
-      "select": {
-        "afterExecution": "작업 선택",
-        "charts": "차트 유형 선택",
-        "conditions": "조건 선택",
-        "default": "유형 선택",
-        "errors": "작업 선택",
-        "finally": "작업 선택",
-        "inputs": "입력 필드 유형 선택",
-        "numerator": "분자를 선택하세요",
-        "pluginDefaults": "플러그인 선택",
-        "task": "작업 선택",
-        "tasks": "작업 선택",
-        "triggers": "트리거 선택",
-        "where": "필터 유형 선택"
-      },
-      "toggle_pebble": "Pebble 편집기 전환",
-      "unnamed": "이름 없음",
-      "version_oss_placeholder": "엔터프라이즈 에디션으로 플러그인 버전 관리 활성화"
-    },
-    "no_data": "여기에는 아직 아무것도 없는 것 같아요…<br/>필터를 조정하거나 다시 시도해 보세요!",
-    "no_file_choosen": "파일이 선택되지 않음",
-    "no_flow_outputs": "출력 없음.",
-    "no_history": "기록 없음",
-    "no_inputs": "입력값이 없습니다.",
-    "no_logs_data": "데이터 없음",
-    "no_logs_data_description": "필터를 조정하거나, 시간 범위를 변경하거나, flow가 최근에 실행되었는지 확인해 주세요.",
-    "no_logs_data_title": "선택한 필터에 대한 로그가 없습니다.",
-    "no_namespaces": "검색 기준에 맞는 namespace가 없습니다.",
-    "no_results": {
-      "assets": "자산을 찾을 수 없음",
-      "executions": "실행을 찾을 수 없음",
-      "flows": "flow를 찾을 수 없음",
-      "kv_pairs": "Key-Value 쌍을 찾을 수 없음",
-      "secrets": "비밀 없음",
-      "templates": "템플릿을 찾을 수 없음",
-      "triggers": "트리거를 찾을 수 없음"
-    },
-    "no_results_found": "결과를 찾을 수 없습니다",
-    "no_tasks_running": "아직 실행 중인 task가 없습니다.",
-    "no_trigger": "사용 가능한 trigger가 없습니다.",
     "no_variables": "사용 가능한 변수가 없습니다.",
-    "now": "지금",
-    "of": "의",
-    "ok": "확인",
-    "onboarding": {
-      "actions": {
-        "cancel_tutorial": "Cancel tutorial",
-        "complete": "Complete",
-        "edit_flow_to_continue": "Press Edit flow in the top bar (right).",
-        "execute_to_continue": "1. Press Execute in the top bar (right).\n2. Provide a value for <strong>name</strong>.\n3. Press Execute again in the modal.",
-        "finish_tutorial": "Finish tutorial",
-        "next": "Next",
-        "save_to_continue": "Press Save in the top bar (right)."
-      },
-      "cancel_modal": {
-        "confirm": "Cancel tutorial",
-        "description": "Do you want to cancel the First Flow tutorial?",
-        "keep": "Keep tutorial",
-        "title": "Cancel First Flow tutorial"
-      },
-      "editor_hints": {
-        "build_intro": "Build your first flow step by step.",
-        "step_1": "# 1) Add id",
-        "step_2": "# 2) Add namespace",
-        "step_3": "# 3) Add an input",
-        "step_4": "# 4) Add tasks and your first Python task",
-        "step_5": "# 5) Add a cron trigger"
-      },
-      "finish_actions": {
-        "create_flow": "Create Flow",
-        "explore_blueprints": "Explore Blueprints"
-      },
-      "steps": {
-        "add_cron_trigger": {
-          "description": "Triggers can start runs based on schedules or external events (for example webhooks or MQTT messages).<br><br>Now add a cron schedule trigger so this flow runs every 5 minutes.",
-          "title": "Add a cron trigger"
-        },
-        "add_id": {
-          "description": "The ID is the unique name of your flow, so you can find it, run it, and reference it consistently.<br><br>Now add <code>id</code> at the root level.",
-          "title": "Add flow id"
-        },
-        "add_input": {
-          "description": "Inputs are flow-level parameters that can be referenced inside tasks to dynamically control behavior at runtime.<br><br>Now add an input named <code>name</code> with type <code>STRING</code>.",
-          "title": "Add an input"
-        },
-        "add_input_default": {
-          "description": "When a flow is triggered automatically, inputs still need values at runtime.<br><br>The <code>name</code> input was already created in the previous step, so there’s no need to add it again. Just set a default value for the existing <code>name</code> input.",
-          "title": "Set a default input value"
-        },
-        "add_log_task": {
-          "description": "Tasks are the units of work your flow executes, defined as an ordered list of steps. Each task needs a unique <code>id</code> and a <code>type</code>. Kestra provides many task plugins for external systems; here we use a Python Script task.<br><br>The <code>&#123;&#123; ... &#125;&#125;</code> syntax is a Pebble expression, used to reference variables dynamically at runtime, like <code>&#123;&#123; inputs.name &#125;&#125;</code> from your flow inputs.<br><br>Now add the first task under <code>tasks</code> with <code>id</code>, <code>type</code>, and a <code>script</code> that prints a greeting.",
-          "title": "Add first task"
-        },
-        "add_namespace": {
-          "description": "The Namespace is the folder-like grouping that organizes flows by team, project, or environment.<br><br>Now add <code>namespace</code> at the root level.",
-          "title": "Add namespace"
-        },
-        "background_runs_info": {
-          "description": "This flow will now execute in the background every 5 minutes.<br><br>You can navigate to the Executions overview from the left menu to monitor scheduled runs.",
-          "title": "Scheduled runs"
-        },
-        "edit_flow_from_execution": {
-          "description": "You can jump directly from an execution back to the flow definition to iterate quickly.",
-          "title": "Return to Flow Editor"
-        },
-        "execute_flow": {
-          "description": "Executing starts a run of your flow with runtime input values.",
-          "title": "Execute flow"
-        },
-        "finish": {
-          "description": "Great start. You created, executed, parameterized, and scheduled a flow.<br><br>Choose what to do next ...",
-          "title": "You completed the First Flow tutorial"
-        },
-        "flow_basics": {
-          "description": "In Kestra, a <code>flow</code> is the core orchestration unit. You define it in YAML with metadata and ordered tasks.<br><br>Review the example structure below, then continue to build it step by step.",
-          "title": "Flow basics"
-        },
-        "save_flow": {
-          "description": "Saving persists your flow definition so it can be executed.",
-          "title": "Save flow"
-        },
-        "save_flow_again": {
-          "description": "Your flow now has a schedule and a default input value for automatic runs.",
-          "title": "Save flow"
-        },
-        "view_logs_status": {
-          "description": "Execution details show run status, timing, and task-level output logs.<br><br>Now open the execution details and click <code>greet</code> in the Gantt chart to see the logs.",
-          "title": "Check execution"
-        }
-      },
-      "validation": {
-        "add_cron_trigger_cron": "Add a cron expression, for example: `\"*/5 * * * *\"`.",
-        "add_cron_trigger_section": "Create a `triggers` section with a schedule trigger.",
-        "add_cron_trigger_type": "Set trigger type to `io.kestra.plugin.core.trigger.Schedule`.",
-        "add_id": "Add a flow ID at the top. Example: `id: hello_flow`.",
-        "add_input_default_defaults": "Add a default value for `name`, for example: `defaults: \"Kestra\"`.",
-        "add_input_default_id": "Keep the existing input ID as `name`.",
-        "add_input_default_section": "Go back to `inputs` and keep one existing input named `name` (do not add a second input).",
-        "add_input_id": "Inside `inputs`, add `id: name`.",
-        "add_input_section": "Create an `inputs` section with one input.",
-        "add_input_type": "Set the input type to `STRING`.",
-        "add_log_task_id": "Give the task an ID, for example: `id: greet`.",
-        "add_log_task_message": "Add a `script` field to the task.",
-        "add_log_task_pebble": "Use a Pebble expression in the script so it uses your input value (for example: `inputs.name`).",
-        "add_log_task_section": "Create a `tasks` section and add your first task.",
-        "add_log_task_type": "Set the task type to `io.kestra.plugin.scripts.python.Script`.",
-        "add_namespace": "Add a namespace at the top. Example: `namespace: company.team`.",
-        "complete_step": "You're close. Complete this step to continue.",
-        "edit_flow_from_execution": "Click `Edit flow` in the top bar to continue.",
-        "execute_flow": "Run the flow once to continue.",
-        "fix_yaml": "There is a small YAML formatting issue. Fix it, then continue.",
-        "save_flow": "Click Save to continue.",
-        "save_flow_again": "Click Save again to continue.",
-        "view_logs_status": "Open the execution details and check the logs for `greet`."
-      },
-      "welcome": {
-        "additional_help": "Additional help",
-        "badge": "Tutorial",
-        "blueprints": "Blueprints",
-        "docs": "Documentation",
-        "guided_description": "Learn how to create and run your first flow with guided steps.",
-        "guided_duration": "Recommended for most",
-        "guided_title": "Build your first flow",
-        "headline": "Build and run your first workflow in minutes",
-        "self_serve_description": "Go directly to the editor and build your own flow.",
-        "self_serve_note": "For experienced users",
-        "self_serve_title": "Create flow from scratch",
-        "slack": "Slack community",
-        "tutorial": "Tutorial"
-      }
+    "download": "다운로드",
+    "jsonl": "JSONL",
+    "concurrency_limit": {
+      "dialog_title": "동시성 제한",
+      "warning": "실행 중인 카운터를 변경하면 동시성이 손상되어 실행이 허용된 한도를 초과할 수 있습니다."
     },
-    "open": "열기",
-    "open full page": "전체 페이지 열기",
-    "open in new tab": "새 탭에서",
-    "open in same tab": "동일한 탭에서",
-    "open sidebar": "사이드바 열기",
-    "open source": "오픈 소스",
-    "open_page": "Open page",
-    "optional": "선택 사항",
-    "original execution": "원래 실행",
-    "originalCreatedDate": "원래 생성 날짜",
-    "outdated revision save confirmation": {
-      "confirm": "덮어쓰시겠습니까?",
-      "create": {
-        "description": "이 namespace에는 동일한 id를 가진 flow가 이미 존재합니다.",
-        "details": "덮어쓰기를 저장하고 새 버전을 생성합니다.",
-        "title": "Flow가 이미 존재합니다"
-      },
-      "update": {
-        "description": "현재 편집 중인 수정본이 구버전입니다.",
-        "details": "최신 수정본에 대한 자세한 내용은 수정본 탭을 확인하세요.",
-        "title": "구버전"
-      }
+    "documentation": {
+      "documentation": "문서",
+      "github": "GitHub 이슈 열기"
     },
-    "output": "Output",
-    "outputs": "Outputs",
-    "override": {
-      "details": "이전 flow는 Revisions 탭에서 복원할 수 있습니다.",
-      "title": "현재 Flow를 덮어쓸 예정입니다."
-    },
-    "overview": "개요",
-    "page": {
-      "next": "다음 페이지",
-      "previous": "이전 페이지"
-    },
-    "panel actions": "패널 작업",
-    "parent execution": "부모 실행",
-    "password": "비밀번호",
-    "password empty constraint": "잘못된 사용자 이름 또는 비밀번호",
-    "password length constraint": "비밀번호는 256자를 초과할 수 없습니다.",
-    "passwords do not match": "비밀번호가 일치하지 않습니다.",
-    "pause": "일시 중지",
-    "pause backfill": "backfill 일시 중지",
-    "pause backfills": "backfill 일시 중지",
-    "pause confirm": "실행 <code>{id}</code>을(를) 일시 중지하시겠습니까?",
-    "pause done": "실행이 PAUSED 상태입니다.",
-    "pause title": "실행 <code>{id}</code>을(를) 일시 중지합니다.<br/>현재 실행 중인 task는 계속 처리되며, 실행은 수동으로 다시 시작해야 합니다.",
-    "paused": "일시 중지됨",
-    "playground": {
-      "clear_history": "기록 지우기",
-      "confirm_create": "flow를 생성하는 동안에는 playground를 실행할 수 없습니다. playground 실행을 시작하면 flow가 생성됩니다.",
-      "history": "최근 10회 실행",
-      "play_icon_info": "또한 No-Code 또는 Topology 보기에서 Play 아이콘을 클릭할 수 있습니다.",
-      "run_all_tasks": "모든 Task 실행",
-      "run_task": "작업 실행",
-      "run_task_and_downstream": "Task 및 다운스트림 실행",
-      "run_task_info": "Flow Code 편집기에서 어떤 task 위에 마우스를 올리고 \"Run task\" 버튼을 클릭하여 task를 테스트하세요.",
-      "run_this_task": "이 task 실행",
-      "title": "플레이그라운드",
-      "toggle": "플레이그라운드",
-      "tooltip_persistence": "Playground를 끄고 다시 켜면, 페이지에 머무르는 동안 정보가 유지됩니다."
-    },
-    "playground actions": "플레이그라운드 작업",
-    "plugin defaults exported": "플러그인 기본값 내보내기 완료",
-    "plugin defaults imported": "플러그인 기본값이 가져왔습니다.",
-    "plugin defaults not imported": "일부 플러그인 기본값을 가져올 수 없습니다.",
-    "pluginDefaults": {
-      "add": "플러그인 기본값 추가",
-      "add_subtitle": "새 플러그인 기본값을 해당 속성으로 구성하십시오.",
-      "cancel": "취소",
-      "custom": "사용자 정의 플러그인",
-      "custom_configure": "사용자 정의 플러그인 유형 - YAML을 사용하여 구성",
-      "custom_placeholder": "플러그인 유형 입력",
-      "custom_type": "사용자 정의 플러그인 유형",
-      "edit": "플러그인 기본값 편집",
-      "edit_subtitle": "기존 플러그인 기본 설정 수정",
-      "form": "폼",
-      "predefined": "사전 정의된 플러그인",
-      "select_predefined": "미리 정의된 플러그인 선택",
-      "show_yaml": "YAML 보기",
-      "title": "플러그인 기본값",
-      "update": "플러그인 기본값 업데이트",
-      "use_custom": "사용자 정의 사용",
-      "yaml": "YAML",
-      "yaml_configuration": "YAML 구성"
-    },
-    "pluginPage": {
-      "elementType": {
-        "apps": "앱",
-        "charts": "차트",
-        "conditions": "조건",
-        "logExporters": "로그 익스포터",
-        "secrets": "비밀",
-        "taskRunners": "작업 실행기",
-        "tasks": "작업",
-        "triggers": "트리거"
-      },
-      "group": {
-        "blueprints": "블루프린트 ({count})",
-        "plugins": "플러그인 ({count})",
-        "tasks": "작업 ({count})"
-      },
+    "blueprints": {
+      "all": "모두",
+      "community": "커뮤니티",
+      "create": "블루프린트 생성",
+      "edit": "블루프린트 편집",
+      "title": "Blueprints",
+      "empty": "블루프린트가 없습니다.",
       "header": {
-        "back": "플러그인으로 돌아가기",
-        "certified": "인증됨",
-        "enterpriseEdition": "엔터프라이즈 에디션"
+        "catch phrase": {
+          "1": "첫 번째 단계가 항상 가장 어렵습니다.",
+          "2": "다음 {kind}을 시작하기 위해 blueprint를 탐색하세요."
+        },
+        "alt": "블루프린트 아이콘"
       },
-      "loadError": "플러그인을 로드할 수 없습니다. 다시 시도해 주세요.",
-      "noResults": "검색어와 일치하는 플러그인이 없습니다.",
-      "notFound": "이 플러그인을 찾을 수 없습니다.",
-      "overview": {
-        "createdBy": "작성자",
-        "latest": "최신",
-        "linksResources": "링크 및 리소스",
-        "managedBy": "관리자:",
-        "minKestraVersion": "호환 가능한 최소 Kestra 버전: {version}",
-        "minKestraVersionShort": "Kestra 최소 버전 {version}",
-        "pluginType": "플러그인 유형",
-        "previousVersions": "이전 버전",
-        "releaseNotes": "릴리스 노트",
-        "title": "개요",
-        "versions": "버전"
+      "custom": "사용자 정의 blueprints",
+      "flows": "플로우 Blueprints",
+      "apps": "앱 Blueprints",
+      "dashboards": "대시보드 Blueprints",
+      "detail": {
+        "category": "카테고리 유형",
+        "links": "링크 및 리소스",
+        "openInEditor": "편집 Flow에서 열기"
       },
-      "search": "{count}+ 플러그인 검색",
-      "searchTasks": "{count}개의 task 검색",
-      "sort": {
-        "mostUsed": "가장 많이 사용됨",
-        "nameAsc": "이름 A-Z",
-        "nameDesc": "이름 Z-A",
-        "newest": "최신순"
-      },
-      "sortBy": "정렬 기준"
+      "missingPlugins": {
+        "title": "누락된 plugin",
+        "description": "이 blueprint는 이 인스턴스에 설치되지 않은 plugin의 task를 사용합니다: {plugins}. 이 blueprint를 사용하려면 설치하세요.",
+        "card": "이 인스턴스에 설치되지 않은 plugin이 필요합니다: {plugins}",
+        "install": "plugin 설치"
+      }
     },
-    "plugin_default_already_exists": "<code>{type}</code>에 대한 플러그인 기본값이 이미 존재합니다.",
+    "use": "사용",
     "plugins": {
       "name": "플러그인",
       "names": "플러그인들",
       "please": "오른쪽에서 task를 선택하여 해당 문서를 확인하세요.",
       "release": "릴리스 노트"
     },
-    "port": "포트",
-    "prefill inputs": "미리 채우기",
-    "pretty_json": "Pretty JSON",
-    "prev_execution": "이전 실행",
-    "preview": {
-      "auto-view": "자동 보기",
-      "collapse": "접기",
-      "expand": "확장",
-      "force-editor": "편집기 보기 강제 적용",
-      "label": "미리보기",
-      "next": "다음",
-      "page_of": "{total} 중 {current} 페이지",
-      "pagination_info": "{total}개 중 {start}-{end} 행 표시 중.",
-      "previous": "이전",
-      "rows_truncated": "{total}개의 행 중 {shown}개를 표시 중입니다. 모든 데이터를 보려면 파일을 다운로드하세요.",
-      "showing_rows": "{total}개 중 {start}-{end} 행 표시",
-      "view": "보기"
+    "last execution date": "마지막 실행 날짜",
+    "last execution state": "마지막 상태",
+    "last X days count": "지난 {days}일 동안 {count}",
+    "date range count": "{startDate}와 {endDate} 사이에 {count}",
+    "date count": "{date}에 {count}",
+    "revisions": "수정본들",
+    "no revisions found": "이 flow에 대한 수정본이 하나만 존재합니다.",
+    "no revisions": "리비전 없음",
+    "see full revision": "전체 수정본 보기",
+    "side-by-side": "나란히",
+    "line-by-line": "줄별로",
+    "template": "템플릿",
+    "template creation": "템플릿 생성",
+    "templates": "템플릿들",
+    "templates deprecated": "템플릿은 사용 중지되었습니다. 대신 subflows를 사용하세요. 템플릿에서 subflows로 마이그레이션하는 방법을 설명하는 <a href=\"https://kestra.io/docs/migration-guide/0.11.0/templates?utm_source=app&utm_medium=referral&utm_campaign=template-inlinedoc\" target=\"_blank\">마이그레이션 섹션</a>을 참조하세요.",
+    "no result": "결과가 없습니다.",
+    "empty search": "검색 결과가 없습니다",
+    "trigger": "Trigger",
+    "no_trigger": "사용 가능한 trigger가 없습니다.",
+    "triggers": "Triggers",
+    "triggers_header_description": "트리거를 찾아보고 추가하고 관리하여 flow를 자동화하세요. flow를 AI 도구로 노출하거나, 스케줄링, webhook trigger 추가, 외부 앱의 변경 사항 폴링, 실시간 이벤트 리스너 중에서 선택하세요.",
+    "triggers_tabs_add": "추가",
+    "triggers_tabs_manage": "관리",
+    "triggers_add_search_placeholder": "트리거 검색...",
+    "triggers_add_filter_core": "코어",
+    "triggers_add_filter_realtime": "실시간",
+    "triggers_add_filter_all": "모두",
+    "triggers_add_filter_app": "앱",
+    "triggers_add_empty_title": "트리거를 찾을 수 없음",
+    "triggers_add_ee_tooltip": "이 trigger는 Enterprise Edition이 필요합니다.",
+    "triggers_add_category_empty": "이 카테고리에 trigger가 없습니다.",
+    "triggers_add_card_add_to_flow": "flow에 추가",
+    "triggers_add_card_add": "추가",
+    "triggers_add_modal_title": "{name}",
+    "triggers_add_modal_tab_form": "폼",
+    "triggers_add_modal_tab_source": "출처",
+    "triggers_add_modal_tab_documentation": "문서",
+    "triggers_add_modal_namespace_placeholder": "namespace 선택",
+    "triggers_add_modal_flow_placeholder": "flow 선택",
+    "triggers_add_modal_trigger_id": "트리거 ID",
+    "triggers_add_modal_trigger_id_placeholder": "이 trigger의 고유 식별자",
+    "triggers_add_modal_properties_hint": "트리거를 추가한 후 flow 편집기에서 트리거 속성을 구성합니다.",
+    "triggers_add_modal_ee_notice": "이 trigger는 Enterprise Edition이 필요합니다.",
+    "triggers_add_modal_add_button": "Flow에 Trigger 추가",
+    "trigger details": "Trigger 세부 정보",
+    "triggerflow disabled": "Flow 정의에서 trigger가 비활성화되었습니다.",
+    "last trigger date": "마지막 trigger 날짜",
+    "trigger_states": "상태",
+    "context updated date": "컨텍스트 업데이트 날짜",
+    "state updated date": "상태 업데이트 날짜",
+    "next evaluation date": "다음 평가 날짜",
+    "last evaluation date": "마지막 평가 날짜",
+    "last trigger date tooltip": "트리거가 마지막으로 실행된 시점입니다. 백필을 실행할 때 과거일 수 있습니다.",
+    "context updated date tooltip": "트리거의 컨텍스트가 마지막으로 업데이트된 시점입니다. 이는 실행이 트리거되거나, 완료되었을 때(잠금 해제), 또는 평가 후(실행이 발생하지 않더라도) 발생합니다.",
+    "next evaluation date tooltip": "트리거가 다음으로 평가될 시점은 간격을 기준으로 합니다. 조건이 충족되지 않으면 다음 실행 날짜와 항상 같지 않을 수 있습니다.",
+    "last evaluation date tooltip": "When the trigger was last evaluated by the scheduler, regardless of whether it produced an execution.",
+    "conditions": "조건",
+    "triggerId": "트리거 ID",
+    "tenantId": "테넌트 ID",
+    "codeDisabled": "Flow에서 비활성화됨",
+    "paused": "일시 중지됨",
+    "running": "실행 중",
+    "Fold auto": "편집기: 다중 라인 자동 접기",
+    "Hover description": "편집기: key 또는 value에 마우스를 올리면 필드 설명 표시",
+    "Fold content lines": "다중 라인 문자열 접기",
+    "Unfold content lines": "다중 라인 문자열 펼치기",
+    "Total": "총계",
+    "sub flow": "Subflow",
+    "execute": "실행",
+    "execute flow behaviour": "Flow 실행",
+    "open in same tab": "동일한 탭에서",
+    "open in new tab": "새 탭에서",
+    "execute the flow": "Flow <code>{id}</code> 실행",
+    "execute flow now ?": "이 flow를 실행하시겠습니까?",
+    "discard execution confirmation": "저장되지 않은 input이 있습니다. 이 실행을 취소하시겠습니까?",
+    "discard changes confirmation": "저장되지 않은 변경 사항이 있습니다. 정말로 취소하시겠습니까?",
+    "Default namespace": "기본 namespace",
+    "Default log level": "기본 log 레벨",
+    "unsaved changed ?": "저장되지 않은 변경 사항이 있습니다. 이 페이지를 떠나시겠습니까?",
+    "unsaved changes": "저장되지 않은 변경 사항",
+    "unsaved changes warning": "저장되지 않은 변경 사항이 있습니다. 이 페이지를 떠나면 변경 사항이 사라집니다.",
+    "leave page": "페이지 나가기",
+    "open full page": "전체 페이지 열기",
+    "drill down preview": "미리보기",
+    "Editor theme": "편집기 테마",
+    "Editor fontsize": "편집기 글꼴 크기",
+    "Editor fontfamily": "편집기 글꼴 패밀리",
+    "errors": {
+      "401": {
+        "title": "인증되지 않았습니다.",
+        "content": "이 페이지에 접근하려면 인증이 필요합니다."
+      },
+      "403": {
+        "title": "접근 거부됨",
+        "content": "이 페이지에 접근할 권한이 없습니다."
+      },
+      "404": {
+        "title": "페이지를 찾을 수 없음",
+        "content": "요청한 URL을 이 서버에서 찾을 수 없습니다.<br />알고 있는 전부입니다.",
+        "flow or execution": "찾고 있는 flow 또는 실행이 존재하지 않습니다."
+      }
     },
-    "pricing": "가격 책정",
-    "product_tour": "제품 둘러보기",
-    "properties": {
-      "hidden": "테이블에 숨김",
-      "hint": "열 표시 선택",
-      "label": "속성",
-      "shown": "표에 표시됨"
+    "back_to_dashboard": "대시보드로 돌아가기",
+    "copy all logs": "모든 Log 복사",
+    "copy logs": "Logs 복사",
+    "fix_with_ai": "AI로 수정",
+    "download logs": "Logs 다운로드",
+    "delete logs": "Logs 삭제",
+    "delete_all_logs": "모든 logs를 삭제하시겠습니까?",
+    "delete_log": "로그를 삭제하시겠습니까?",
+    "toggle fullscreen": "전체 화면 전환",
+    "copied": "복사됨",
+    "tags": "태그들",
+    "disabled flow title": "이 flow는 비활성화되었습니다.",
+    "disabled flow desc": "이 flow는 비활성화되어 있습니다. 실행하려면 활성화하세요.",
+    "label": "Label",
+    "labels": "라벨",
+    "label filter placeholder": "'key:value'로 라벨 지정",
+    "execution labels": "실행 라벨",
+    "wrong labels": "라벨에 빈 key 또는 value는 허용되지 않습니다",
+    "feeds": {
+      "title": "Kestra의 새로운 기능",
+      "heading": "Kestra의 모든 것.",
+      "subheading": "최신 업데이트, 가이드 및 스토리"
     },
-    "queued duration": "대기 중 지속 시간",
-    "quotas": "할당량",
-    "reach us": "문의하기",
-    "read-more": "자세히 알아보기",
-    "readonly property": "읽기 전용 속성",
-    "recent_executions": "최근 실행",
-    "refresh": "새로 고침",
-    "reject": "거부",
-    "relative": "상대적",
-    "relative end date": "상대적 종료 날짜",
-    "relative start date": "상대적 시작 날짜",
-    "remove label": "레이블 제거",
-    "remove this item": "이 항목 제거",
-    "remove_bookmark": "이 북마크를 제거하시겠습니까?",
-    "replay": "재실행",
-    "replay confirm": "재실행 하시겠습니까?",
-    "replay execution description": "선택한 실행을 기반으로 새 실행을 생성합니다.",
-    "replay execution title": "실행 다시 실행",
-    "replay from beginning tooltip": "처음부터 재실행",
-    "replay from task tooltip": "<code>{taskId}</code> Task에서 재실행",
-    "replay inputs": "입력",
-    "replay inputs new required": "이 수정본에는 input이 있습니다. 입력하라는 메시지가 표시됩니다.",
-    "replay latest revision": "최신 수정본을 사용하여 재실행",
-    "replay select taskrun": "어떤 task run을 재생할지 선택하십시오:",
-    "replay the execution": "flow <code>{flowId}</code>의 실행 <code>{executionId}</code>을(를) 다시 실행합니다.",
-    "replay using": "사용하여 재실행",
-    "replay with inputs": "입력과 함께 재실행",
-    "replayed": "실행이 재생되었습니다.",
-    "required field": "필수 필드",
-    "reset": "재시작",
-    "reset to defaults": "기본값으로 재설정",
-    "restart": "재시작",
-    "restart change revision": "선택하시는 수정본으로 재실행 할 수 있습니다.",
-    "restart confirm": "<code>{id}</code> 실행을 재시작하시겠습니까?",
-    "restart execution title": "실행 재시작",
-    "restart latest revision": "최신 수정본으로 재시작",
-    "restart tooltip": "<code>{state}</code> Task에서 실행을 재시작합니다.",
-    "restart trigger": {
-      "button": "Trigger 재시작",
-      "tooltip": "트리거 재시작"
-    },
-    "restarted": "실행이 재시작되었습니다.",
+    "delete execution running": "<div class=\"alert alert-warning mt-2 mb-0\">이 실행은 아직 RUNNING 상태입니다. 삭제해도 중지되지 않습니다.<br />실행을 중지하려면 실행을 강제 종료해야 합니다.</div>",
     "restore": "복원",
     "restore confirm": "리비전 <code>{revision}</code>을(를) 복원하시겠습니까?",
+    "bulk delete": "<code>{executionCount}</code> 개의 실행을 삭제하시겠습니까?",
+    "bulk replay": "<code>{executionCount}</code> 개의 실행을 재실행하시겠습니까?",
+    "bulk change state": "<code>{executionCount}</code> 실행의 상태를 변경하시겠습니까?",
+    "bulk resume": "<code>{executionCount}</code> 개의 실행을 재개하시겠습니까?",
+    "bulk pause": "<code>{executionCount}</code> 실행을 일시 중지하시겠습니까?",
+    "bulk unqueue": "<code>{executionCount}</code> 실행을 대기열에서 제거하시겠습니까?",
+    "bulk force run": "<code>{executionCount}</code> 실행을 강제로 실행하시겠습니까?<br/><br/>WARNING: 실행을 강제로 실행하는 것은 보장되지 않으며 중복된 task 실행을 생성할 수 있습니다.<br/><br/>다음 전환이 수행됩니다:<br/><ul><li>CREATED tasks는 RUNNING 상태로 이동됩니다.</li><li>RUNNING tasks는 다시 제출됩니다.</li><li>QUEUED tasks는 대기열에서 제거됩니다.</li><li>PAUSED tasks는 재개됩니다.</li></ul>",
+    "bulk restart": "<code>{executionCount}</code> 개의 실행을 재시작하시겠습니까?",
+    "bulk kill": "<code>{executionCount}</code> 개의 실행을 강제 종료하시겠습니까?",
+    "selection": {
+      "selected": "<strong>{count}</strong> 개 선택됨",
+      "all": "모두 선택 ({count})"
+    },
+    "cancel": "취소",
+    "errorLogs": "오류 logs",
+    "welcome_page": {
+      "welcome": "Kestra에 오신 것을 환영합니다",
+      "guide": "첫 번째 flow를 실행하는 데 도움이 필요하신가요?"
+    },
+    "product_tour": "제품 둘러보기",
+    "executions replayed": "<code>{executionCount}</code> 개의 실행이 재실행되었습니다",
+    "executions state changed": "<code>{executionCount}</code> 실행 상태가 변경되었습니다",
+    "executions resumed": "<code>{executionCount}</code> 개의 실행이 재개되었습니다",
+    "executions paused": "<code>{executionCount}</code> execution(s) PAUSED",
+    "executions unqueue": "<code>{executionCount}</code> 실행 대기열에서 제거됨",
+    "executions force run": "<code>{executionCount}</code> 실행 강제 실행",
+    "executions restarted": "<code>{executionCount}</code> 개의 실행이 재시작되었습니다",
+    "executions killed": "<code>{executionCount}</code> 개의 실행이 강제 종료되었습니다",
+    "executions deleted": "<code>{executionCount}</code> 개의 실행이 삭제되었습니다",
+    "invalid bulk replay": "실행을 재실행할 수 없습니다",
+    "invalid bulk resume": "실행을 재개할 수 없습니다",
+    "invalid bulk pause": "실행을 PAUSED 상태로 전환할 수 없습니다.",
+    "invalid bulk unqueue": "실행을 큐에서 제거할 수 없습니다.",
+    "invalid bulk force run": "실행을 강제로 실행할 수 없습니다.",
+    "invalid bulk restart": "실행을 재시작할 수 없습니다",
+    "invalid bulk kill": "실행을 강제 종료할 수 없습니다",
+    "invalid bulk delete": "실행을 삭제할 수 없습니다",
+    "execution not found": "{executionId} 실행을 찾을 수 없습니다.",
+    "execution not in state PAUSED": "실행 <code>{executionId}</code>이(가) PAUSED 상태가 아닙니다",
+    "execution not in state FAILED": "실행 <code>{executionId}</code>이(가) FAILED 상태가 아닙니다",
+    "execution already finished": "실행 <code>{executionId}</code>이(가) 이미 완료되었습니다",
     "restore revision": "리비전 <code>{revision}</code>을(를) 복원하시겠습니까?",
-    "resume": "재개",
-    "resume from breakpoint done": "실행이 중단점부터 재개되었습니다",
-    "resume from breakpoint title": "`{{id}}` 실행을 중단점에서 재개",
-    "resumed confirm": "실행 <code>{id}</code>을(를) 재개하시겠습니까?",
-    "resumed done": "실행이 재개되었습니다.",
-    "resumed title": "실행 <code>{id}</code> 재개",
-    "reuse original inputs": "원래 input 재사용",
-    "reuse_original_inputs": "원래 input 재사용",
-    "review your inputs": "입력 내용을 검토하세요",
-    "revision": "수정본",
-    "revision deleted": "{revision} 리비전이 성공적으로 삭제되었습니다.",
-    "revisions": "수정본들",
-    "row count": "행 수",
-    "run task in playground": "플레이그라운드에서 task 실행",
+    "seeing old revision": "이전 리비전을 보고 있습니다: {revision}",
+    "export": "내보내기",
+    "exports": "내보내기 목록",
+    "export_csv": "CSV로 내보내기",
+    "template export": "<code>{templateCount}</code> 개의 템플릿을 내보내시겠습니까?",
+    "templates exported": "템플릿이 내보내졌습니다",
+    "export all templates": "모든 템플릿 내보내기",
+    "flow_export": "flow 내보내기",
+    "flow export": "<code>{flowCount}</code> 개의 flow를 내보내시겠습니까?",
+    "flows exported": "<code>{count}</code> Flow(s) 내보내기 완료",
+    "export all flows": "모든 flow 내보내기",
+    "import": "가져오기",
+    "disable": "비활성화",
+    "enable": "활성화",
+    "enabled": "활성화됨",
+    "template delete": "<code>{templateCount}</code> 개의 템플릿을 삭제하시겠습니까?",
+    "flow delete": "<code>{flowCount}</code> 개의 flow를 삭제하시겠습니까?",
+    "templates deleted": "<code>{count}</code> 개의 템플릿이 삭제되었습니다",
+    "flows deleted": "<code>{count}</code> 개의 flow가 삭제되었습니다",
+    "flow disable": "<code>{flowCount}</code> 개의 flow를 비활성화하시겠습니까?",
+    "flow enable": "<code>{flowCount}</code> 개의 flow를 활성화하시겠습니까?",
+    "flows disabled": "<code>{count}</code> 개의 flow가 비활성화되었습니다",
+    "flows enabled": "<code>{count}</code> 개의 flow가 활성화되었습니다",
+    "flow-no-dependencies": "귀하의 flow에는 종속성이 없습니다.",
+    "flow-dependencies": "종속성",
+    "read-more": "자세히 알아보기",
+    "in-our-documentation": "우리의 문서에서.",
+    "dependencies": "종속성",
+    "see dependencies": "종속성 보기",
+    "see timeline": "타임라인 보기",
     "run timeline": "실행 타임라인",
-    "runners": "러너",
-    "running": "실행 중",
-    "running duration": "실행 중 지속 시간",
-    "save": "저장",
+    "dependencies missing acls": "이 flow에 대한 권한이 없습니다",
+    "dependencies delete flow": "이 flow는 종속성을 가지고 있습니다. 삭제하면 종속성이 실행되지 않습니다.<br /><br /> 영향을 받는 flow 목록은 다음과 같습니다:",
+    "expand dependencies": "종속성 확장",
+    "reset": "재시작",
+    "show task documentation": "task 문서 보기",
+    "hide task documentation": "task 문서 숨기기",
+    "show task documentation in editor": "편집기에서 task 문서 보기",
+    "show documentation": "문서 보기",
+    "focus task": "문서를 보려면 요소를 클릭하세요.",
+    "validate": "유효성 검사",
+    "add error handler": "오류 처리기 추가",
+    "taskDefaults": "Task 기본값",
+    "disabled": "비활성화됨",
+    "before": "이전",
+    "after": "이후",
+    "add at position": "{position} <code>{task}</code> 추가",
+    "create first task": "첫 번째 task 만들기",
+    "dynamic": "동적",
+    "choice": "선택",
+    "sequential": "순차적",
+    "can not delete": "삭제할 수 없음",
+    "can not have less than 1 task": "각 flow에는 최소한 하나의 task가 있어야 합니다.",
+    "task id already exists": "Task Id가 이미 존재합니다",
+    "Task Id already exist in the flow": "Task Id {taskId}가 flow에 이미 존재합니다.",
+    "task id": "Task ID",
+    "taskid column details": "마지막으로 실행된 task 및 시도 횟수.",
+    "flow already exists": "Flow가 이미 존재합니다",
+    "flow already exists message": "namespace <code>{namespace}</code>에 flow <code>{id}</code>가 이미 존재합니다. 새로운 리비전을 생성하시겠습니까?",
+    "plugin_default_already_exists": "<code>{type}</code>에 대한 플러그인 기본값이 이미 존재합니다.",
+    "namespace not allowed": "Namespace가 허용되지 않습니다",
+    "switch-view": "보기 전환",
+    "source and topology": "소스 및 토폴로지",
+    "source and doc": "소스 및 문서",
+    "source and blueprints": "소스 및 blueprints",
+    "editor": "편집기",
+    "error in editor": "편집기에서 오류가 발견되었습니다",
+    "delete task confirm": "task <code>{taskId}</code>을(를) 삭제하시겠습니까?",
+    "can not save": "저장할 수 없음",
+    "flow must not be empty": "flow는 비어 있을 수 없습니다",
+    "flow must have id and namespace": "Flow에는 id와 namespace가 있어야 합니다.",
+    "flow creation denied in namespace": "`{namespace}` namespace에서 flow를 생성할 권한이 없습니다.",
+    "readonly property": "읽기 전용 속성",
+    "namespace and id readonly": "`namespace`와 `id` 속성은 변경할 수 없습니다 — 초기 값으로 설정되었습니다. flow의 이름을 변경하거나 namespace를 변경하려면 새 flow를 만들고 기존 flow를 삭제하세요.",
+    "avg": "평균",
+    "sum": "합계",
+    "min": "Min",
+    "max": "Max",
+    "bar": "바",
+    "line": "라인",
+    "metric": "메트릭",
+    "aggregation": "집계",
+    "chart type": "차트 유형",
+    "metric choice": "이 flow에 대한 사용 가능한 메트릭이 없습니다.",
+    "of": "의",
+    "see_all_states": "모든 상태 보기",
     "save draft": {
       "message": "초안 저장됨",
       "retrieval": {
@@ -1680,164 +724,336 @@
         "existing": "<code>{flowFullName}</code> Flow 초안이 저장되었습니다. flow 편집을 계속하시겠습니까?"
       }
     },
-    "save task": "Task 저장",
-    "save_and_execute": "저장 및 실행",
-    "save_as_draft": "초안으로 저장",
-    "saved": "성공적으로 저장됨",
-    "saved as draft": "초안으로 저장되었습니다",
-    "saved as draft done": "<em>{name}</em>이(가) 초안으로 저장되었습니다",
-    "saved done": "<em>{name}</em>이(가) 성공적으로 저장되었습니다.",
-    "scheduleDate": "일정 날짜",
-    "scope_filter": {
-      "all": "모든 {label}",
-      "system": "시스템 {label}",
-      "system_description": "시스템 유지보수 {label}",
-      "user": "사용자 {label}",
-      "user_description": "일반 사용자에 의해 시작된 {label}"
+    "title": "제목",
+    "api": "API",
+    "more_actions": "추가 작업",
+    "expand error": "실패한 task만 확장",
+    "expand all": "모두 확장",
+    "collapse all": "모두 축소",
+    "expand": "확장",
+    "collapse": "축소",
+    "filter by this value": "Filter by this value",
+    "filter_for": "Filter for",
+    "filter_out": "Filter out",
+    "copy_value": "Copy value",
+    "open_page": "Open page",
+    "logs_copied": "Logs copied to your clipboard",
+    "expand_by_default": "Expand structured logs by default",
+    "show raw": "Show raw",
+    "similar lines": "similar lines",
+    "download_logs_description": "Choose which logs to export. Filters default to your current view.",
+    "display_settings": "Display settings",
+    "density": "Density",
+    "density_compact": "Compact",
+    "density_normal": "Normal",
+    "density_expanded": "Expanded",
+    "pretty_json": "Pretty JSON",
+    "body_line_clamp": "Limit line height",
+    "font size": "Font size",
+    "log expand setting": "기본 Log 표시",
+    "environment": "환경",
+    "environment name setting": "환경 이름",
+    "environment color setting": "환경 색상",
+    "slack support": "Slack을 통해 질문하기",
+    "join community": "커뮤니티에 참여하기",
+    "join_slack": "Slack 참여",
+    "kestra": "Kestra",
+    "reach us": "문의하기",
+    "new version": "새 버전 {version} 사용 가능!",
+    "error detected": "오류가 감지되었습니다.",
+    "warning detected": "경고 감지됨",
+    "informative notice": "노트(s)",
+    "cannot swap tasks": "task를 교환할 수 없음",
+    "open": "열기",
+    "dependency task": "Task {taskId}가 다른 task의 종속성입니다",
+    "administration": "관리",
+    "admin": "관리자",
+    "main_configuration": "주요 설정",
+    "commit_id": "커밋 id",
+    "evaluation lock date": "평가 잠금 날짜",
+    "unlock trigger": {
+      "tooltip": {
+        "execution": "이 trigger에 대한 실행이 진행 중입니다",
+        "evaluation": "trigger가 현재 평가 중입니다"
+      },
+      "confirmation": "trigger를 잠금 해제하시겠습니까?",
+      "warning": "이는 동일한 trigger에 대해 동시 실행을 초래할 수 있으며 최후의 수단으로 고려해야 합니다.",
+      "button": "trigger 잠금 해제",
+      "success": "Trigger가 잠금 해제되었습니다"
     },
-    "search": "검색",
-    "search blueprint": "Blueprints 검색",
-    "search filters": {
-      "filter name": "필터 이름",
-      "filters": "필터",
-      "manage": "검색 필터 관리",
-      "manage desc": "저장된 검색 필터 관리",
-      "save filter": "필터 저장",
-      "saved": "저장된 필터"
+    "restart trigger": {
+      "button": "Trigger 재시작",
+      "tooltip": "트리거 재시작"
     },
-    "search term in message": "메시지에서 검색어 찾기",
-    "search_docs": "검색",
-    "searching": "검색 중...",
-    "secret": {
-      "add": "생성",
-      "inherited": "상속된 비밀",
-      "isReadOnly": "비밀은 읽기 전용입니다",
-      "names": "비밀",
-      "update": "비밀 '{name}' 업데이트"
-    },
-    "security_advice": {
-      "content": "인스턴스를 보호하려면 기본 인증을 활성화하세요.",
-      "enable": "인증 활성화",
-      "switch_text": "다시 표시하지 않기",
-      "title": "인스턴스 보호"
-    },
-    "see dependencies": "종속성 보기",
-    "see full revision": "전체 수정본 보기",
-    "see timeline": "타임라인 보기",
-    "see_all_states": "모든 상태 보기",
-    "seeing old revision": "이전 리비전을 보고 있습니다: {revision}",
-    "select": "{{section}}을 선택하세요",
-    "select a state": "상태 선택",
-    "select datetime": "날짜 선택",
-    "select view": "보기 선택",
-    "selected": "선택됨",
-    "selection": {
-      "all": "모두 선택 ({count})",
-      "selected": "<strong>{count}</strong> 개 선택됨"
-    },
-    "sequential": "순차적",
-    "server type": "서버 유형",
+    "trigger disabled": "Flow 소스 내에서 Trigger가 비활성화되었습니다.",
+    "flow source not found": "Flow source를 찾을 수 없음",
+    "date format": "날짜 형식",
+    "timezone": "시간대",
+    "add task": "task 추가",
+    "unable to generate graph": "그래프 생성 중 문제가 발생하여 토폴로지를 표시할 수 없습니다.",
+    "attempts": "시도 횟수",
+    "flow deleted, you can restore it": "Flow가 삭제되었으며 읽기 전용 보기입니다. 여전히 복원할 수 있습니다.",
+    "workers": "Workers",
+    "worker group": "Worker 그룹",
+    "worker group key": "워크 그룹 key",
+    "worker group fallback": "작업자 그룹 대체",
+    "version": "버전",
     "services": "서비스",
+    "server type": "서버 유형",
+    "hostname": "호스트 이름",
+    "port": "포트",
+    "management port": "관리 포트",
+    "file preview truncated": "표시된 내용이 잘렸습니다",
+    "file unavailable": "파일을 사용할 수 없음",
+    "file unavailable description": "이 파일은 더 이상 사용할 수 없습니다 — 삭제되었거나 만료되었을 수 있습니다.",
+    "row count": "행 수",
+    "encoding": "인코딩",
+    "show": "보기",
+    "advanced configuration": "다른 속성",
+    "all executions": "모든 실행",
+    "trigger execution id": "Trigger Execution Id",
+    "execution_status": "실행 상태:",
+    "no_tasks_running": "아직 실행 중인 task가 없습니다.",
+    "execution_starts_progress": "실행이 시작되면, 여기에서 진행 상황 업데이트를 볼 수 있습니다.",
+    "triggers_state": {
+      "state": "상태",
+      "options": {
+        "enabled": "활성화됨",
+        "disabled": "비활성화됨"
+      }
+    },
+    "trigger filter": {
+      "title": "자식 실행 필터링",
+      "options": {
+        "ALL": "모든 실행",
+        "CHILD": "자식 실행",
+        "MAIN": "부모 실행"
+      }
+    },
+    "show chart": "차트 보기",
+    "namespace files": {
+      "toggle": {
+        "show": "namespace 파일 보기",
+        "hide": "namespace 파일 숨기기"
+      },
+      "filter": "필터",
+      "new_file": "새 파일",
+      "no_items": {
+        "heading": "아직 namespace에 파일이 없습니다.",
+        "paragraph": "파일을 생성하거나 가져와서 namespace 내의 flow 간에 코드를 공유하세요."
+      },
+      "no_selection": {
+        "heading": "선택된 파일 없음",
+        "description": "내용을 보려면 트리에서 파일을 선택하세요."
+      },
+      "tree": {
+        "expand": "모든 폴더 확장",
+        "collapse": "모든 폴더 축소"
+      },
+      "create": {
+        "label": "생성",
+        "file": "파일 생성",
+        "file_already_exists": "이 이름의 파일이 이미 존재합니다",
+        "file_conflicts_with_folder": "이 이름의 폴더가 이미 존재합니다",
+        "file_error": "파일 생성 중 오류 발생",
+        "folder": "폴더 생성",
+        "folder_already_exists": "이 이름의 폴더가 이미 존재합니다",
+        "folder_conflicts_with_file": "이 이름의 파일이 이미 존재합니다",
+        "folder_error": "폴더 생성 중 오류가 발생했습니다"
+      },
+      "rename": {
+        "label": "이름 변경",
+        "file": "파일 이름 변경",
+        "folder": "폴더 이름 변경",
+        "new_file": "확장자를 포함한 새 이름:",
+        "new_folder": "새 폴더 이름:"
+      },
+      "delete": {
+        "label": "삭제",
+        "file": "파일 삭제",
+        "folder": "폴더 삭제",
+        "files": "{count}개의 선택된 파일 삭제",
+        "folders": "{count}개의 선택된 폴더 삭제"
+      },
+      "import": {
+        "import": "가져오기",
+        "files": "파일 가져오기",
+        "folder": "폴더 가져오기",
+        "success": "파일이 성공적으로 가져와졌습니다",
+        "error": "파일을 가져오는 동안 오류가 발생했습니다"
+      },
+      "export": "namespace 파일 내보내기",
+      "export_single": "파일 내보내기",
+      "dialog": {
+        "name": {
+          "file": "확장자를 포함한 이름:",
+          "folder": "폴더 이름:"
+        },
+        "parent_folder": "부모 폴더:",
+        "deletion": {
+          "confirm": "확인",
+          "title": "콘텐츠 삭제 확인",
+          "files": "<code>{count}</code>개의 파일을 삭제하시겠습니까?",
+          "folders": "<code>{count}</code>개의 폴더와 모든 내용을 삭제하시겠습니까?",
+          "mixed": "<code>{folders}</code> 폴더와 <code>{files}</code> 파일을 삭제하시겠습니까?",
+          "file_single": "파일 <code>{name}</code>을(를) 삭제하시겠습니까?",
+          "folder_single": "폴더 <code>{name}</code> 및 모든 내용을 삭제하시겠습니까?"
+        }
+      },
+      "revisions": {
+        "history": "수정 기록",
+        "restore": {
+          "success": "파일 수정이 성공적으로 복원되었습니다."
+        }
+      },
+      "path": {
+        "copy": "경로 복사",
+        "success": "경로가 클립보드에 복사되었습니다",
+        "error": "경로를 클립보드에 복사하는 동안 오류가 발생했습니다"
+      }
+    },
+    "continue backfill": "backfill 계속",
+    "delete backfill": "backfill 삭제",
+    "pause backfill": "backfill 일시 중지",
+    "continue backfills": "backfill 계속",
+    "delete backfills": "backfill 삭제",
+    "pause backfills": "backfill 일시 중지",
+    "backfill executions": "backfill 실행",
+    "execute backfill": "backfill 실행",
+    "backfill paused": "백필 일시 중지됨",
+    "backfill running": "백필 실행 중",
+    "relative": "상대적",
+    "relative start date": "상대적 시작 날짜",
+    "relative end date": "상대적 종료 날짜",
+    "now": "지금",
+    "absolute": "절대적",
+    "backfill": "Backfill",
+    "Set labels tooltip": "실행에 라벨 설정",
+    "Set labels": "라벨 설정",
+    "manage labels": "label 관리",
+    "Set labels to execution": "실행 <code>{id}</code>의 라벨 추가 또는 업데이트",
+    "Set labels done": "실행의 라벨이 성공적으로 설정되었습니다",
+    "bulk set labels": "<code>{executionCount}</code> 개의 실행에 라벨을 설정하시겠습니까?",
+    "dependencies loaded": "종속성이 로드되었습니다",
+    "loaded x dependencies": "{count} 개의 종속성이 로드되었습니다",
+    "security_advice": {
+      "title": "인스턴스 보호",
+      "content": "인스턴스를 보호하려면 기본 인증을 활성화하세요.",
+      "switch_text": "다시 표시하지 않기",
+      "enable": "인증 활성화"
+    },
+    "true": "True",
+    "false": "False",
+    "undefined": "Undefined",
+    "execution-include-non-terminated": "종료되지 않은 실행을 포함하시겠습니까?",
+    "execution-warn-title": "중요한 WARNING!",
+    "execution-warn-deleting-still-running": "이 작업을 취소하고 진행 중인 실행을 먼저 중지할 것을 강력히 권장합니다. 종료되지 않은 실행을 삭제하면 concurrency 문제, flow 종속성 관리 불일치, 인스턴스에서의 좀비 프로세스가 발생할 수 있으며, 이는 시스템 성능을 저하시킬 수 있습니다. 삭제를 진행하기 전에 이러한 위험을 충분히 이해했는지 확인하십시오.",
+    "originalCreatedDate": "원래 생성 날짜",
+    "welcome": {
+      "menu": "Welcome",
+      "tour": {
+        "title": "제품 투어 시작하기",
+        "text": "사용 사례를 선택하고 단계별 가이드를 따라 Kestra의 기능과 역량을 배워보세요. ❤️"
+      },
+      "tutorial": {
+        "title": "튜토리얼",
+        "text": "* <a href=\"https://kestra.io/tutorial-videos/all?utm_source=app&utm_medium=referral&utm_campaign=welcome-tutorial\" target=\"_blank\">비디오 튜토리얼</a>  \n* <a href=\"https://kestra.io/docs?utm_source=app&utm_medium=referral&utm_campaign=welcome-tutorial\" target=\"_blank\">문서</a>  \n* <a href=\"https://kestra.io/blueprints?utm_source=app&utm_medium=referral&utm_campaign=welcome-tutorial\" target=\"_blank\">Blueprints</a>"
+      },
+      "help": {
+        "title": "도움이 필요하신가요?",
+        "text": "Slack 커뮤니티에서 질문을 하세요. 문제가 생기면 저희가 도와드리겠습니다. ✋"
+      }
+    },
+    "pluginPage": {
+      "search": "{count}+ 플러그인 검색",
+      "searchTasks": "{count}개의 task 검색",
+      "noResults": "검색어와 일치하는 플러그인이 없습니다.",
+      "loadError": "플러그인을 로드할 수 없습니다. 다시 시도해 주세요.",
+      "notFound": "이 플러그인을 찾을 수 없습니다.",
+      "elementType": {
+        "tasks": "작업",
+        "triggers": "트리거",
+        "conditions": "조건",
+        "taskRunners": "작업 실행기",
+        "charts": "차트",
+        "apps": "앱",
+        "logExporters": "로그 익스포터",
+        "secrets": "비밀"
+      },
+      "sortBy": "정렬 기준",
+      "sort": {
+        "nameAsc": "이름 A-Z",
+        "nameDesc": "이름 Z-A",
+        "newest": "최신순",
+        "mostUsed": "가장 많이 사용됨"
+      },
+      "group": {
+        "plugins": "플러그인 ({count})",
+        "tasks": "작업 ({count})",
+        "blueprints": "블루프린트 ({count})"
+      },
+      "overview": {
+        "title": "개요",
+        "versions": "버전",
+        "latest": "최신",
+        "releaseNotes": "릴리스 노트",
+        "previousVersions": "이전 버전",
+        "createdBy": "작성자",
+        "managedBy": "관리자:",
+        "pluginType": "플러그인 유형",
+        "linksResources": "링크 및 리소스",
+        "minKestraVersion": "호환 가능한 최소 Kestra 버전: {version}",
+        "minKestraVersionShort": "Kestra 최소 버전 {version}"
+      },
+      "header": {
+        "enterpriseEdition": "엔터프라이즈 에디션",
+        "certified": "인증됨",
+        "back": "플러그인으로 돌아가기"
+      }
+    },
+    "no inputs": "이 flow에는 입력이 없습니다.",
+    "admin_preferences": "Preferences",
     "settings": {
+      "label": "설정",
+      "updated": "{name} 업데이트됨",
       "blocks": {
         "configuration": {
-          "descriptions": {
-            "auto_refresh_interval": "목록 페이지에서 자동 데이터 새로 고침 간격(초).",
-            "default_namespace": "namespace 없이 새로운 flow를 생성할 때 사용됩니다.",
-            "editor_type": "flow를 처음 열 때 표시되는 편집기.",
-            "execute_default_tab": "실행으로 이동할 때 선택된 탭.",
-            "execute_flow": "실행 결과가 실행을 트리거한 후 열리는 위치.",
-            "flow_default_tab": "flow로 이동할 때 선택된 탭.",
-            "log_display": "실행을 열 때 로그가 표시되는 방식.",
-            "log_level": "실행 로그에 표시되는 최소 log level.",
-            "playground": "편집기 플레이그라운드에서 개별적으로 task 실행.",
-            "triggers_default_tab": "트리거 페이지로 이동할 때 선택된 탭."
-          },
+          "label": "기본 구성",
           "fields": {
-            "auto_refresh_interval": "자동 새로고침 간격",
-            "default_namespace": "기본 Namespace",
-            "editor_type": "기본 편집기 유형",
-            "execute_default_tab": "기본 실행 탭",
-            "execute_flow": "Flow 실행",
-            "flow_default_tab": "기본 Flow 탭",
             "language": "언어",
-            "log_display": "기본 Log 표시",
+            "default_namespace": "기본 Namespace",
             "log_level": "기본 Log 레벨",
+            "log_display": "기본 Log 표시",
+            "editor_type": "기본 편집기 유형",
+            "execute_flow": "Flow 실행",
+            "execute_default_tab": "기본 실행 탭",
             "multi_panel_editor": "멀티 패널 편집기",
+            "flow_default_tab": "기본 Flow 탭",
+            "triggers_default_tab": "기본 Trigger 탭",
             "playground": "플레이그라운드",
-            "triggers_default_tab": "기본 Trigger 탭"
+            "auto_refresh_interval": "자동 새로고침 간격"
           },
-          "label": "기본 구성"
-        },
-        "export": {
-          "fields": {
-            "flows": "모든 Flow 내보내기",
-            "templates": "모든 템플릿 내보내기"
-          },
-          "label": "내보내기"
-        },
-        "localization": {
           "descriptions": {
-            "date_format": "대시보드 전반에 걸쳐 날짜를 표시하는 데 사용되는 형식.",
-            "language": "메뉴 및 레이블의 인터페이스 언어.",
-            "time_zone": "실행 날짜와 예약된 trigger를 표시하는 데 사용됩니다."
-          },
-          "fields": {
-            "date_format": "날짜 형식",
-            "time_zone": "시간대"
-          },
-          "label": "언어 및 지역",
-          "note": "이 설정은 UI에서 날짜 및 시간 속성을 표시하는 데 사용됩니다. UTC와 다른 시간대에 flow를 예약하려면 flow 코드 또는 플러그인 기본값에서 Schedule trigger의 시간대 속성을 설정하세요."
-        },
-        "reset_section_to_defaults": "이 섹션의 기본 값을 복원",
-        "save": {
-          "discard": "버리기",
-          "label": "환경 설정 저장",
-          "unsaved_title": "저장되지 않은 변경 사항",
-          "unsaved_warning": "저장되지 않은 변경 사항이 있습니다. 나가기 전에 저장하시겠습니까?"
-        },
-        "sidebar": {
-          "descriptions": {
-            "items": "사이드바에서 항목을 표시, 숨기기 및 재정렬합니다."
-          },
-          "fields": {
-            "items": "네비게이션 항목"
-          },
-          "label": "사이드바"
+            "default_namespace": "namespace 없이 새로운 flow를 생성할 때 사용됩니다.",
+            "log_level": "실행 로그에 표시되는 최소 log level.",
+            "log_display": "실행을 열 때 로그가 표시되는 방식.",
+            "editor_type": "flow를 처음 열 때 표시되는 편집기.",
+            "execute_flow": "실행 결과가 실행을 트리거한 후 열리는 위치.",
+            "execute_default_tab": "실행으로 이동할 때 선택된 탭.",
+            "flow_default_tab": "flow로 이동할 때 선택된 탭.",
+            "triggers_default_tab": "트리거 페이지로 이동할 때 선택된 탭.",
+            "auto_refresh_interval": "목록 페이지에서 자동 데이터 새로 고침 간격(초).",
+            "playground": "편집기 플레이그라운드에서 개별적으로 task 실행."
+          }
         },
         "theme": {
-          "app_font_size_options": {
-            "large": "크게",
-            "medium": "보통",
-            "small": "작게"
-          },
-          "color_modes": {
-            "dark_1": "다크 1.0",
-            "dark_2": "다크 2.0",
-            "light": "라이트",
-            "sync": "시스템과 동기화"
-          },
-          "confirmations": {
-            "color_mode": "인터페이스가 이제 `{mode}` 테마를 사용합니다."
-          },
-          "descriptions": {
-            "app_font_size": "인터페이스의 모든 글꼴 크기에 적용되는 배율입니다.",
-            "color_mode": "선호하는 인터페이스 테마를 선택하세요.",
-            "color_mode_shortcut": "팁: 어디서나 <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>L</kbd>을 눌러 테마를 전환하세요.",
-            "editor_folding_stratgy": "flow를 열 때 긴 YAML 블록을 기본적으로 축소합니다.",
-            "editor_font_family": "YAML 편집기에서 사용되는 모노스페이스 글꼴.",
-            "editor_font_size": "YAML 및 no-code 편집기에서 사용되는 글꼴 크기.",
-            "editor_hover_description": "편집기에서 호버 시 속성 설명 표시.",
-            "environment_color": "현재 환경의 탐색에서 사용되는 강조 색상.",
-            "environment_name": "현재 환경의 표시 이름, 탐색에 표시됩니다.",
-            "logs_font_size": "로그 뷰어와 터미널에서 사용되는 글꼴 크기."
-          },
+          "label": "테마 설정",
           "fields": {
             "app_font_size": "앱 글꼴 크기",
             "chart_color_scheme": {
+              "label": "차트 색상 구성표",
               "classic": "클래식",
-              "kestra": "Kestra",
-              "label": "차트 색상 구성표"
+              "kestra": "Kestra"
             },
             "color_mode": "색상 모드",
             "editor_folding_stratgy": "편집기에서 자동 코드 접기",
@@ -1850,24 +1066,867 @@
             "logs_font_size": "로그 글꼴 크기",
             "theme": "테마"
           },
-          "label": "테마 설정"
+          "color_modes": {
+            "dark_2": "다크 2.0",
+            "dark_1": "다크 1.0",
+            "light": "라이트",
+            "sync": "시스템과 동기화"
+          },
+          "confirmations": {
+            "color_mode": "인터페이스가 이제 `{mode}` 테마를 사용합니다."
+          },
+          "descriptions": {
+            "color_mode": "선호하는 인터페이스 테마를 선택하세요.",
+            "color_mode_shortcut": "팁: 어디서나 <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>L</kbd>을 눌러 테마를 전환하세요.",
+            "logs_font_size": "로그 뷰어와 터미널에서 사용되는 글꼴 크기.",
+            "editor_font_family": "YAML 편집기에서 사용되는 모노스페이스 글꼴.",
+            "editor_font_size": "YAML 및 no-code 편집기에서 사용되는 글꼴 크기.",
+            "editor_folding_stratgy": "flow를 열 때 긴 YAML 블록을 기본적으로 축소합니다.",
+            "editor_hover_description": "편집기에서 호버 시 속성 설명 표시.",
+            "environment_name": "현재 환경의 표시 이름, 탐색에 표시됩니다.",
+            "environment_color": "현재 환경의 탐색에서 사용되는 강조 색상.",
+            "app_font_size": "인터페이스의 모든 글꼴 크기에 적용되는 배율입니다."
+          },
+          "app_font_size_options": {
+            "small": "작게",
+            "medium": "보통",
+            "large": "크게"
+          }
+        },
+        "localization": {
+          "label": "언어 및 지역",
+          "note": "이 설정은 UI에서 날짜 및 시간 속성을 표시하는 데 사용됩니다. UTC와 다른 시간대에 flow를 예약하려면 flow 코드 또는 플러그인 기본값에서 Schedule trigger의 시간대 속성을 설정하세요.",
+          "fields": {
+            "time_zone": "시간대",
+            "date_format": "날짜 형식"
+          },
+          "descriptions": {
+            "language": "메뉴 및 레이블의 인터페이스 언어.",
+            "time_zone": "실행 날짜와 예약된 trigger를 표시하는 데 사용됩니다.",
+            "date_format": "대시보드 전반에 걸쳐 날짜를 표시하는 데 사용되는 형식."
+          }
+        },
+        "export": {
+          "label": "내보내기",
+          "fields": {
+            "flows": "모든 Flow 내보내기",
+            "templates": "모든 템플릿 내보내기"
+          }
+        },
+        "save": {
+          "label": "환경 설정 저장",
+          "discard": "버리기",
+          "unsaved_title": "저장되지 않은 변경 사항",
+          "unsaved_warning": "저장되지 않은 변경 사항이 있습니다. 나가기 전에 저장하시겠습니까?"
+        },
+        "reset_section_to_defaults": "이 섹션의 기본 값을 복원",
+        "sidebar": {
+          "label": "사이드바",
+          "fields": {
+            "items": "네비게이션 항목"
+          },
+          "descriptions": {
+            "items": "사이드바에서 항목을 표시, 숨기기 및 재정렬합니다."
+          }
+        }
+      }
+    },
+    "apps": "앱",
+    "demos": {
+      "enterprise_edition": "엔터프라이즈 에디션",
+      "get_a_demo_button": "데모 받기",
+      "contact_sales": "영업팀에 문의하세요",
+      "watch_the_video": "비디오 보기",
+      "secrets": {
+        "title": "비밀 관리 업그레이드",
+        "message": "Enterprise Edition (EE)는 UI에서 비밀을 직접 추가, 편집 또는 삭제할 수 있게 해줍니다. 인스턴스를 재시작할 필요가 없습니다. 비밀을 namespace별로 세분화된 RBAC 권한으로 구성하고, 상위 namespace에서 하위 namespace로 상속할 수 있습니다. EE는 HashiCorp Vault, AWS Secrets Manager, Azure Key Vault, Google Secret Manager, Elasticsearch와 같은 비밀 관리자와 통합됩니다. namespace, tenant, 인스턴스별로 전용 백엔드를 설정하여 팀 간 비밀을 격리하거나 외부 vault에 저장된 읽기 전용 비밀을 활성화할 수 있습니다. 비밀은 저장 중 및 전송 중에 암호화된 상태로 유지됩니다. 선택적 캐싱은 API 호출을 줄이고, 감사 추적은 모든 접근을 log합니다.",
+        "detected_env": "다음은 인스턴스 시작 시 식별된 secret-type 환경 변수입니다:",
+        "empty_env": "아직 환경에 Secrets가 없습니다.",
+        "add_env": {
+          "intro": "새 Secret을 생성하려면:",
+          "first": "<a href=\"https://kestra.io/docs/how-to-guides/secrets?utm_source=app&utm_medium=referral&utm_campaign=secrets-inlinedoc#using-secrets-in-kestra\" target=\"_blank\">비밀 값</a>을 Base64로 인코딩하십시오.",
+          "second": "위의 값을 사용하여 '<strong>SECRET_{'{MY_SECRET_KEY}'}</strong>'라는 환경 변수를 추가하세요.",
+          "third": "Kestra 인스턴스를 재시작하십시오"
         }
       },
-      "label": "설정",
-      "updated": "{name} 업데이트됨"
+      "apps": {
+        "title": "Kestra로 맞춤형 앱 만들기",
+        "message": "Kestra Enterprise Edition의 앱은 플랫폼 외부에서 Kestra 워크플로와 상호작용하는 맞춤형 UI를 구축할 수 있게 해줍니다. 이 기능을 통해 워크플로를 맞춤형 애플리케이션의 백엔드로 사용할 수 있으며, 비기술적 사용자도 양식을 통해 데이터를 제출하거나 승인을 기다리는 PAUSED 워크플로를 재개할 수 있습니다."
+      },
+      "tests": {
+        "label": "테스트",
+        "header": "플로우에 대한 단위 테스트",
+        "title": "모든 변경 사항에 대한 신뢰성 보장",
+        "message": "플로우의 로직을 개별적으로 검증하고, 회귀를 조기에 감지하며, 자동화가 변화하고 성장함에 따라 신뢰를 유지하세요."
+      },
+      "assets": {
+        "label": "자산",
+        "header": "자산 메타데이터 및 관측 가능성",
+        "title": "모든 데이터셋, 서비스 및 종속성을 한눈에 확인하세요.",
+        "message": "자산은 관측 가능성, 계보, 소유권 메타데이터를 연결하여 플랫폼 팀이 더 빠르게 문제를 해결하고 자신 있게 배포할 수 있도록 합니다."
+      },
+      "IAM": {
+        "title": "IAM을 통해 SSO, SCIM 및 RBAC로 사용자 관리",
+        "message": "Kestra Enterprise Edition은 단일 사인온(SSO), SCIM 디렉토리 동기화, 역할 기반 접근 제어(RBAC)와 같은 IAM 기능을 내장하고 있으며, 여러 ID 공급자와 통합하여 사용자 및 서비스 계정에 대해 세분화된 권한을 할당할 수 있습니다."
+      },
+      "tenants": {
+        "title": "격리된 Tenant에서 Workflow 관리",
+        "message": "Kestra Enterprise Edition은 멀티-tenancy를 지원하여, 각기 다른 팀이나 프로젝트를 위한 완전히 분리된 환경을 제공합니다. 각 환경은 전용 worker 그룹, 비밀 정보 및 내부 저장소 백엔드와 같은 자체 리소스를 갖추고 있습니다."
+      },
+      "audit-logs": {
+        "title": "변경 사항 추적 - 감사 Log",
+        "message": "Kestra Enterprise Edition은 모든 활동을 강력하고 변경 불가능한 기록으로 로그하여 변경 사항을 추적하고, 규정을 준수하며, 문제를 해결하는 것을 쉽게 만듭니다."
+      },
+      "quotas": {
+        "title": "플로우에 실행 할당량 적용",
+        "message": "Kestra Enterprise Edition을 사용하면 플로우에 할당량을 정의하여 시간 창 내에서 동시 또는 총 실행 횟수를 제한할 수 있습니다. 할당량은 공유 인프라를 보호하고, SLA를 적용하며, 과도한 리소스를 소비하는 워크플로우를 방지하는 데 도움이 됩니다."
+      },
+      "instance": {
+        "title": "인스턴스 전반의 인프라 관리",
+        "message": "Kestra Enterprise Edition은 플랫폼의 상태를 관찰하고 Workers, Schedulers, Executors와 같은 모든 서비스의 가동 시간 지표를 추적할 수 있는 운영 대시보드를 제공합니다. 같은 페이지에서 계획된 다운타임에 대해 사용자에게 알리기 위한 공지를 생성할 수 있으며, 모든 서비스와 workflow 실행을 일시적으로 PAUSED 상태로 전환하여 업그레이드를 수행할 수 있는 유지보수 모드로 진입할 수 있습니다."
+      },
+      "blueprints": {
+        "title": "사용자 정의 Blueprints 추가",
+        "message": "Kestra Enterprise Edition에서는 조직에만 사용할 수 있는 맞춤형 Blueprints를 생성할 수 있습니다. 이를 모범 사례 템플릿으로 사용하여 팀 내에서 자주 사용하는 workflow를 공유하고, 중앙 집중화하고, 문서화할 수 있습니다."
+      },
+      "namespace": {
+        "edit": {
+          "title": "네임스페이스 관리 업그레이드",
+          "message": "Kestra Enterprise Edition에서는 namespace가 비밀, 변수 및 플러그인 기본값의 고급 격리 및 관리를 제공합니다. 관리자는 사용자 정의 비밀 관리자, 격리된 저장소 백엔드, 전용 worker 그룹 및 세부적인 권한을 namespace별로 구성할 수 있습니다. 이를 통해 비밀, 변수 및 플러그인 구성이 다양한 팀과 프로젝트 전반에 걸쳐 안전하고 쉽게 유지될 수 있습니다."
+        },
+        "secrets": {
+          "title": "비밀을 안전하게 관리하기",
+          "message": "Kestra Enterprise Edition에서는 namespace 수준에서 비밀을 저장하고 제어할 수 있어 위험을 최소화하고 각 팀의 자격 증명이 격리된 상태로 유지됩니다. 중첩된 계층 구조 덕분에 상위 namespace에서 자격 증명을 구성하면 모든 하위 namespace에서 이를 상속받을 수 있습니다. 전용 비밀 관리자 지원 및 세분화된 namespace 수준의 권한 설정은 보안과 규정을 더욱 강화합니다."
+        },
+        "assets": {
+          "title": "자산 관리 중앙화",
+          "message": "Kestra Enterprise Edition에서 Assets는 워크플로우가 상호작용하는 리소스의 실시간 인벤토리를 유지합니다. 이러한 리소스는 데이터베이스 테이블, 가상 머신, 파일 또는 사용 중인 외부 시스템일 수 있습니다."
+        },
+        "variables": {
+          "title": "변수를 중앙에서 관리하세요",
+          "message": "Kestra Enterprise Edition에서는 namespace 수준 변수들을 정의하고 관리하여 flow 전반에 걸친 반복적인 구성을 제거할 수 있습니다. 이러한 변수들은 일관성을 보장하고, 구성 업데이트를 간소화하며, 어떤 task나 trigger에서도 쉽게 참조할 수 있어 더 깔끔하고 유지보수하기 쉬운 워크플로우를 만듭니다."
+        },
+        "plugin-defaults": {
+          "title": "플러그인 기본값으로 구성 표준화",
+          "message": "Kestra Enterprise Edition에서는 각 flow에서 중복된 설정의 필요성을 줄이기 위해 namespace별 플러그인 기본값을 설정할 수 있습니다. 이 중앙 플러그인 관리 기능은 일관된 구성 설정을 강제하고, 비밀 정보나 변수를 안전하게 참조할 수 있게 하며, 워크플로우의 유지 관리를 간소화합니다."
+        },
+        "history": {
+          "title": "한 곳에서 수정 기록 관리",
+          "message": "Kestra Enterprise Edition에서는 namespace의 수정 이력을 관리할 수 있습니다."
+        },
+        "audit-logs": {
+          "title": "모든 변경 사항을 한 곳에서 추적하기",
+          "message": "Kestra Enterprise Edition에서는 namespace 수준의 감사 로그를 상세한 차이점과 함께 볼 수 있어, 모든 리소스에 걸쳐 누가 무엇을 언제 변경했는지에 대한 명확한 기록을 제공합니다."
+        }
+      }
+    },
+    "assets": {
+      "title": "자산"
+    },
+    "onboarding": {
+      "welcome": {
+        "headline": "Build and run your first workflow in minutes",
+        "guided_title": "Build your first flow",
+        "badge": "Tutorial",
+        "guided_description": "Learn how to create and run your first flow with guided steps.",
+        "guided_duration": "Recommended for most",
+        "self_serve_title": "Create flow from scratch",
+        "self_serve_description": "Go directly to the editor and build your own flow.",
+        "self_serve_note": "For experienced users",
+        "additional_help": "Additional help",
+        "docs": "Documentation",
+        "tutorial": "Tutorial",
+        "blueprints": "Blueprints",
+        "slack": "Slack community"
+      },
+      "steps": {
+        "flow_basics": {
+          "title": "Flow basics",
+          "description": "In Kestra, a <code>flow</code> is the core orchestration unit. You define it in YAML with metadata and ordered tasks.<br><br>Review the example structure below, then continue to build it step by step."
+        },
+        "add_id": {
+          "title": "Add flow id",
+          "description": "The ID is the unique name of your flow, so you can find it, run it, and reference it consistently.<br><br>Now add <code>id</code> at the root level."
+        },
+        "add_namespace": {
+          "title": "Add namespace",
+          "description": "The Namespace is the folder-like grouping that organizes flows by team, project, or environment.<br><br>Now add <code>namespace</code> at the root level."
+        },
+        "add_input": {
+          "title": "Add an input",
+          "description": "Inputs are flow-level parameters that can be referenced inside tasks to dynamically control behavior at runtime.<br><br>Now add an input named <code>name</code> with type <code>STRING</code>."
+        },
+        "add_log_task": {
+          "title": "Add first task",
+          "description": "Tasks are the units of work your flow executes, defined as an ordered list of steps. Each task needs a unique <code>id</code> and a <code>type</code>. Kestra provides many task plugins for external systems; here we use a Python Script task.<br><br>The <code>&#123;&#123; ... &#125;&#125;</code> syntax is a Pebble expression, used to reference variables dynamically at runtime, like <code>&#123;&#123; inputs.name &#125;&#125;</code> from your flow inputs.<br><br>Now add the first task under <code>tasks</code> with <code>id</code>, <code>type</code>, and a <code>script</code> that prints a greeting."
+        },
+        "save_flow": {
+          "title": "Save flow",
+          "description": "Saving persists your flow definition so it can be executed."
+        },
+        "execute_flow": {
+          "title": "Execute flow",
+          "description": "Executing starts a run of your flow with runtime input values."
+        },
+        "view_logs_status": {
+          "title": "Check execution",
+          "description": "Execution details show run status, timing, and task-level output logs.<br><br>Now open the execution details and click <code>greet</code> in the Gantt chart to see the logs."
+        },
+        "edit_flow_from_execution": {
+          "title": "Return to Flow Editor",
+          "description": "You can jump directly from an execution back to the flow definition to iterate quickly."
+        },
+        "add_cron_trigger": {
+          "title": "Add a cron trigger",
+          "description": "Triggers can start runs based on schedules or external events (for example webhooks or MQTT messages).<br><br>Now add a cron schedule trigger so this flow runs every 5 minutes."
+        },
+        "add_input_default": {
+          "title": "Set a default input value",
+          "description": "When a flow is triggered automatically, inputs still need values at runtime.<br><br>The <code>name</code> input was already created in the previous step, so there’s no need to add it again. Just set a default value for the existing <code>name</code> input."
+        },
+        "save_flow_again": {
+          "title": "Save flow",
+          "description": "Your flow now has a schedule and a default input value for automatic runs."
+        },
+        "background_runs_info": {
+          "title": "Scheduled runs",
+          "description": "This flow will now execute in the background every 5 minutes.<br><br>You can navigate to the Executions overview from the left menu to monitor scheduled runs."
+        },
+        "finish": {
+          "title": "You completed the First Flow tutorial",
+          "description": "Great start. You created, executed, parameterized, and scheduled a flow.<br><br>Choose what to do next ..."
+        }
+      },
+      "actions": {
+        "next": "Next",
+        "complete": "Complete",
+        "save_to_continue": "Press Save in the top bar (right).",
+        "execute_to_continue": "1. Press Execute in the top bar (right).\n2. Provide a value for <strong>name</strong>.\n3. Press Execute again in the modal.",
+        "edit_flow_to_continue": "Press Edit flow in the top bar (right).",
+        "cancel_tutorial": "Cancel tutorial",
+        "finish_tutorial": "Finish tutorial"
+      },
+      "finish_actions": {
+        "explore_blueprints": "Explore Blueprints",
+        "create_flow": "Create Flow"
+      },
+      "editor_hints": {
+        "build_intro": "Build your first flow step by step.",
+        "step_1": "# 1) Add id",
+        "step_2": "# 2) Add namespace",
+        "step_3": "# 3) Add an input",
+        "step_4": "# 4) Add tasks and your first Python task",
+        "step_5": "# 5) Add a cron trigger"
+      },
+      "cancel_modal": {
+        "title": "Cancel First Flow tutorial",
+        "description": "Do you want to cancel the First Flow tutorial?",
+        "confirm": "Cancel tutorial",
+        "keep": "Keep tutorial"
+      },
+      "validation": {
+        "complete_step": "You're close. Complete this step to continue.",
+        "fix_yaml": "There is a small YAML formatting issue. Fix it, then continue.",
+        "add_id": "Add a flow ID at the top. Example: `id: hello_flow`.",
+        "add_namespace": "Add a namespace at the top. Example: `namespace: company.team`.",
+        "add_input_section": "Create an `inputs` section with one input.",
+        "add_input_id": "Inside `inputs`, add `id: name`.",
+        "add_input_type": "Set the input type to `STRING`.",
+        "add_log_task_section": "Create a `tasks` section and add your first task.",
+        "add_log_task_id": "Give the task an ID, for example: `id: greet`.",
+        "add_log_task_type": "Set the task type to `io.kestra.plugin.scripts.python.Script`.",
+        "add_log_task_message": "Add a `script` field to the task.",
+        "add_log_task_pebble": "Use a Pebble expression in the script so it uses your input value (for example: `inputs.name`).",
+        "save_flow": "Click Save to continue.",
+        "execute_flow": "Run the flow once to continue.",
+        "view_logs_status": "Open the execution details and check the logs for `greet`.",
+        "edit_flow_from_execution": "Click `Edit flow` in the top bar to continue.",
+        "add_cron_trigger_section": "Create a `triggers` section with a schedule trigger.",
+        "add_cron_trigger_type": "Set trigger type to `io.kestra.plugin.core.trigger.Schedule`.",
+        "add_cron_trigger_cron": "Add a cron expression, for example: `\"*/5 * * * *\"`.",
+        "add_input_default_section": "Go back to `inputs` and keep one existing input named `name` (do not add a second input).",
+        "add_input_default_id": "Keep the existing input ID as `name`.",
+        "add_input_default_defaults": "Add a default value for `name`, for example: `defaults: \"Kestra\"`.",
+        "save_flow_again": "Click Save again to continue."
+      }
+    },
+    "enable concurrency": "동시성 활성화",
+    "auditlogs": "감사 Logs",
+    "quotas": "할당량",
+    "iam": "IAM",
+    "tenant": {
+      "name": "테넌트",
+      "names": "테넌트"
+    },
+    "ee-tooltip": {
+      "features-blocked": "이 기능은 Enterprise Edition이 필요합니다.",
+      "button": "문의하기"
+    },
+    "flow_only": "Flow 탭에서만 사용 가능합니다.",
+    "bulk action async warning": "잠시 시간이 걸릴 수 있습니다.",
+    "bulk unpause backfills": "{count} backfill 재개",
+    "bulk pause backfills": "{count} backfill 일시 중지",
+    "bulk delete backfills": "{count} backfill 삭제",
+    "bulk unlock": "{count} triggers 잠금 해제",
+    "bulk disabled status": {
+      "true": "{count} triggers 비활성화",
+      "false": "{count} triggers 활성화"
+    },
+    "unlock": "잠금 해제",
+    "bulk success unpause backfills": "{count} backfills 재개됨",
+    "bulk success pause backfills": "{count} backfills 일시 중지됨",
+    "bulk success delete backfills": "{count} backfills 삭제됨",
+    "bulk success unlock": "{count} triggers 잠금 해제됨",
+    "bulk success disabled status": {
+      "true": "{count} trigger(s) 비활성화됨",
+      "false": "{count} trigger(s) 활성화됨"
+    },
+    "no_namespaces": "검색 기준에 맞는 namespace가 없습니다.",
+    "system_namespace": "플랫폼을 시스템 flows로 점검하세요.",
+    "system_namespace_description": "유지 관리 작업을 자동화하세요, 실패 경고부터 자동 정리까지.",
+    "pluginDefaults": {
+      "title": "플러그인 기본값",
+      "add": "플러그인 기본값 추가",
+      "edit": "플러그인 기본값 편집",
+      "add_subtitle": "새 플러그인 기본값을 해당 속성으로 구성하십시오.",
+      "edit_subtitle": "기존 플러그인 기본 설정 수정",
+      "predefined": "사전 정의된 플러그인",
+      "custom": "사용자 정의 플러그인",
+      "form": "폼",
+      "yaml": "YAML",
+      "select_predefined": "미리 정의된 플러그인 선택",
+      "cancel": "취소",
+      "update": "플러그인 기본값 업데이트",
+      "custom_type": "사용자 정의 플러그인 유형",
+      "custom_placeholder": "플러그인 유형 입력",
+      "use_custom": "사용자 정의 사용",
+      "custom_configure": "사용자 정의 플러그인 유형 - YAML을 사용하여 구성",
+      "yaml_configuration": "YAML 구성",
+      "show_yaml": "YAML 보기"
+    },
+    "secret": {
+      "add": "생성",
+      "update": "비밀 '{name}' 업데이트",
+      "isReadOnly": "비밀은 읽기 전용입니다",
+      "names": "비밀",
+      "inherited": "상속된 비밀"
+    },
+    "workerId": "Worker Id",
+    "kv": {
+      "name": "KV Store",
+      "type": "유형",
+      "add": "생성",
+      "update": "키 '{key}'의 값을 업데이트하세요",
+      "duplicate": "이 키는 이미 존재합니다",
+      "delete multiple": {
+        "confirm": "정말로 삭제하시겠습니까: <code>{name}</code> KV(s)?",
+        "warning": "해당 namespace에 대한 권한이 없으므로 생략됩니다: <code>{namespaces}</code>"
+      },
+      "inherited": "상속된 KV 쌍"
+    },
+    "expiration": "만료",
+    "failed to render pdf": "PDF 미리보기를 렌더링하지 못했습니다",
+    "page": {
+      "previous": "이전 페이지",
+      "next": "다음 페이지"
+    },
+    "namespace_editor": {
+      "empty": {
+        "title": "현재 열린 탭이 없습니다",
+        "create_message": "namespace 파일을 생성하거나 가져올 수 있습니다.",
+        "video_message": "편집기 소개 비디오를 확인할 수 있습니다."
+      },
+      "close": {
+        "tab": "탭 닫기",
+        "all": "모든 탭 닫기",
+        "other": "다른 탭 닫기",
+        "right": "오른쪽 닫기"
+      }
+    },
+    "curl": {
+      "command": "cURL 명령어",
+      "note": "SECRET 및 FILE 입력 유형의 경우, 명령어는 실제 값에 맞게 조정되어야 합니다."
+    },
+    "webhook": {
+      "curl_command": "Webhook cURL 명령어",
+      "payload": "Webhook Payload (JSON)",
+      "curl_note": "이 cURL 명령어를 사용하여 사용자 정의 JSON 페이로드로 웹훅을 통해 flow를 trigger하십시오.",
+      "no_triggers": "이 flow에는 활성화된 webhook trigger가 없습니다.",
+      "copy_url": "웹훅 URL 복사"
+    },
+    "logs_view": {
+      "raw": "Temporal 보기",
+      "raw_details": "전체 task logs 및 flow logs를 원시 타임스탬프 순서로 표시",
+      "compact": "기본 보기",
+      "compact_details": "각 task별로 그룹화된 간결한 보기로 task logs 표시"
+    },
+    "execution_deletion": {
+      "logs": "Logs 삭제",
+      "metrics": "메트릭 삭제",
+      "storage": "내부 저장소 파일 삭제"
+    },
+    "scope_filter": {
+      "all": "모든 {label}",
+      "user": "사용자 {label}",
+      "system": "시스템 {label}",
+      "user_description": "일반 사용자에 의해 시작된 {label}",
+      "system_description": "시스템 유지보수 {label}"
+    },
+    "data": "데이터",
+    "webhook link copied": "웹훅 링크가 복사되었습니다.",
+    "copy url": "URL 복사",
+    "scheduleDate": "일정 날짜",
+    "warning": "경고",
+    "trigger_check_warning": "트리거 변수를 사용하는 것은 수동 flow 실행과 함께 작동하지 않습니다. 문제를 해결하려면 `??` 병합 연산자를 추가하세요. 예를 들어, `trigger.date` 대신 `trigger.date ?? execution.startDate`를 사용하세요.",
+    "docs": "문서",
+    "active-slots": "활성 슬롯",
+    "behavior": "동작",
+    "concurrency": "동시성",
+    "no-executions-view": {
+      "title": "자동화를 시작하세요",
+      "sub_title": "실행 버튼을 클릭하여 첫 번째 workflow 실행을 시작하세요.",
+      "namespace_sub_title": "이 대시보드를 채우기 위해 이 namespace에서 하나 이상의 flow를 실행하십시오.",
+      "guidance_desc": "당신의 flow를 실행하는 데 도움이 필요하신가요?",
+      "namespace_guidance_desc": "네임스페이스를 관리하는 데 도움이 필요하신가요?",
+      "guidance_sub_desc": "문서를 참조하여 필요한 모든 정보를 확인하세요."
+    },
+    "execution_guide": {
+      "get_started": {
+        "title": "시작하기 ⚡",
+        "text": "Quickstart Guide를 따라 Kestra를 설치하고 첫 번째 workflow를 구축하세요."
+      },
+      "namespaces": {
+        "title": "네임스페이스 정보",
+        "text": "namespace는 flow와 그 구성 요소의 논리적 그룹입니다."
+      },
+      "workflow_components": {
+        "title": "워크플로우 구성 요소",
+        "text": "Kestra workflow의 주요 오케스트레이션 구성 요소를 알아보세요."
+      },
+      "videos_tutorials": {
+        "title": "비디오 튜토리얼",
+        "text": "비디오 튜토리얼로 시작하세요."
+      }
+    },
+    "open sidebar": "사이드바 열기",
+    "close sidebar": "사이드바 닫기",
+    "customize sidebar": "사이드바 사용자 정의",
+    "reset to defaults": "기본값으로 재설정",
+    "drop items here": "여기에 항목을 드롭하세요",
+    "files": "파일",
+    "optional": "선택 사항",
+    "no_data": "여기에는 아직 아무것도 없는 것 같아요…<br/>필터를 조정하거나 다시 시도해 보세요!",
+    "bookmark": "북마크",
+    "remove_bookmark": "이 북마크를 제거하시겠습니까?",
+    "showLess": "덜 보기",
+    "showMore": "더 보기",
+    "documentationMenu": "문서 메뉴",
+    "item": "항목",
+    "items": "항목",
+    "cron": "크론",
+    "execution_started": "실행이 시작되었습니다!",
+    "execution_failed": "실행 실패!",
+    "last error was": "마지막 오류는",
+    "execution restarted": "이 실행은 {nbRestart}번 다시 시작되었습니다.",
+    "execution replay": "이 실행은 다음의 재실행입니다:",
+    "execution replayed": "이 실행은 재실행되었습니다.",
+    "task run id": "TaskRun ID",
+    "active": "활성화됨",
+    "flows imported": "Flow가 가져왔습니다.",
+    "flow not imported": "일부 flow를 가져올 수 없습니다.",
+    "plugin defaults exported": "플러그인 기본값 내보내기 완료",
+    "failed to export plugin defaults": "플러그인 기본값 내보내기에 실패했습니다.",
+    "plugin defaults imported": "플러그인 기본값이 가져왔습니다.",
+    "plugin defaults not imported": "일부 플러그인 기본값을 가져올 수 없습니다.",
+    "failed to import plugin defaults": "플러그인 기본값 가져오기에 실패했습니다",
+    "filters": {
+      "label": "필터 선택",
+      "empty": "데이터가 없습니다.",
+      "format": "'key:value'로 매개변수 입력",
+      "text_search": "이 텍스트 검색",
+      "options": {
+        "namespace": "네임스페이스",
+        "flow": "플로우",
+        "state": "상태",
+        "scope": "범위",
+        "child": "자식",
+        "level": "로그 레벨",
+        "task": "작업",
+        "metric": "메트릭",
+        "user": "사용자",
+        "type": "유형",
+        "service_type": "유형",
+        "permission": "권한",
+        "action": "동작",
+        "status": "상태",
+        "details": "세부사항",
+        "aggregation": "집계",
+        "relative_date": "상대 날짜",
+        "absolute_date": "절대 날짜",
+        "labels": "레이블",
+        "text": "텍스트",
+        "startDate": "시작 날짜",
+        "endDate": "종료 날짜"
+      },
+      "comparators": {
+        "is": "입니다",
+        "is_one_of": "중 하나입니다.",
+        "is_not": "아님",
+        "not_in": "에 없음",
+        "contains": "포함합니다",
+        "not_contains": "포함하지 않음",
+        "in": "안에",
+        "between": "사이에",
+        "starts_with": "로 시작합니다",
+        "greater_than": "보다 큼",
+        "greater_than_or_equal_to": "크거나 같음",
+        "less_than": "보다 작음",
+        "less_than_or_equal_to": "작거나 같음",
+        "ends_with": "끝남"
+      },
+      "save": {
+        "label": "저장된 검색",
+        "remove": "제거",
+        "empty": "아직 검색을 저장하지 않았습니다.",
+        "tooltip": "빈 검색 기준을 저장할 수 없습니다.",
+        "name_already_used": "이미 사용 중인 label입니다.",
+        "dialog": {
+          "heading": "현재 검색 저장",
+          "placeholder": "레이블",
+          "hint": "이 검색 기준에 어떤 label을 지정하시겠습니까?",
+          "confirmation": "검색 기준 <code>{name}</code>"
+        }
+      },
+      "settings": {
+        "label": "페이지 설정",
+        "show_chart": "주요 차트 표시"
+      }
+    },
+    "custom value": "사용자 정의 value",
+    "chart": "차트",
+    "chart preview": "차트 미리보기",
+    "no_code": {
+      "toggle_pebble": "Pebble 편집기 전환",
+      "version_oss_placeholder": "엔터프라이즈 에디션으로 플러그인 버전 관리 활성화",
+      "unnamed": "이름 없음",
+      "adding": "+ {what} 추가",
+      "adding_default": "+ 새 value 추가",
+      "add_field": "{field} 추가",
+      "clearSelection": "선택 해제",
+      "labels": {
+        "yaml": "YAML 편집기",
+        "no_code": "코드 없는 편집기",
+        "label": "레이블",
+        "variable": "변수"
+      },
+      "sections": {
+        "deprecated": "사용되지 않는 속성",
+        "tasks": "작업",
+        "triggers": "트리거",
+        "errors": "오류 처리기",
+        "afterExecution": "실행 후",
+        "finally": "마지막으로",
+        "pluginDefaults": "플러그인 기본값"
+      },
+      "fields": {
+        "main": {
+          "id": "Flow ID",
+          "namespace": "네임스페이스",
+          "description": "설명",
+          "inputs": "입력"
+        },
+        "general": {
+          "retry": "재시도",
+          "sla": "SLA",
+          "labels": "레이블",
+          "outputs": "출력",
+          "variables": "변수",
+          "concurrency": "병행성",
+          "disabled": "비활성화됨",
+          "listeners": "리스너",
+          "taskDefaults": "작업 기본값",
+          "workerGroup": "작업자 그룹",
+          "workerSelector": "워커 선택기",
+          "checks": "점검",
+          "updated": "업데이트됨"
+        }
+      },
+      "select": {
+        "default": "유형 선택",
+        "task": "작업 선택",
+        "tasks": "작업 선택",
+        "triggers": "트리거 선택",
+        "errors": "작업 선택",
+        "finally": "작업 선택",
+        "pluginDefaults": "플러그인 선택",
+        "afterExecution": "작업 선택",
+        "conditions": "조건 선택",
+        "inputs": "입력 필드 유형 선택",
+        "charts": "차트 유형 선택",
+        "where": "필터 유형 선택",
+        "numerator": "분자를 선택하세요"
+      },
+      "creation": {
+        "default": "추가",
+        "tasks": "작업 추가",
+        "triggers": "트리거 추가",
+        "errors": "오류 처리기 추가",
+        "finally": "마지막 블록 추가",
+        "pluginDefaults": "플러그인 기본값 추가",
+        "afterExecution": "실행 후 블록 추가",
+        "conditions": "조건 추가",
+        "inputs": "입력 필드 추가",
+        "charts": "차트 추가",
+        "where": "데이터 필터링",
+        "numerator": "분자를 추가하세요"
+      },
+      "remove": {
+        "default": "이 항목 제거",
+        "cases": "이 케이스를 제거하십시오"
+      }
+    },
+    "properties": {
+      "label": "속성",
+      "hint": "열 표시 선택",
+      "shown": "표에 표시됨",
+      "hidden": "테이블에 숨김"
+    },
+    "editor_shortcuts": {
+      "label": "키보드 단축키",
+      "trigger_autocompletion": "자동 완성 트리거",
+      "command_palette": "명령 팔레트 표시",
+      "save_flow": "Flow 저장",
+      "execute_flow": "flow 실행",
+      "toggle_ai_agent": "AI 에이전트 전환",
+      "move_line": "줄 이동",
+      "duplicate_cursor": "커서 복제",
+      "fold_unfold": "코드 접기/펼치기",
+      "comment_uncomment": "주석 처리/주석 해제",
+      "comment": "댓글",
+      "uncomment": "주석 해제",
+      "decrease_fontsize": "편집기 글꼴 크기 줄이기",
+      "increase_fontsize": "에디터 글꼴 크기 증가",
+      "reset_fontsize": "편집기 글꼴 크기 재설정"
+    },
+    "instance": "인스턴스",
+    "something_went_wrong": {
+      "loading_execution": "실행을 로드하는 중 문제가 발생했습니다.",
+      "connection_lost": {
+        "title": "연결이 중단되었습니다",
+        "message": "Kestra 인스턴스에 연결할 수 없습니다. 실행 중인지 확인한 후 페이지를 새로 고치세요."
+      }
+    },
+    "debug": "디버그",
+    "default": "기본값",
+    "data_not_protected": "귀하의 데이터는 보호되지 않습니다. 잃어버리지 마세요. <b>무료 보안 기능을 활성화하거나 유료 서비스를 시도해 보세요.</b>",
+    "activate_basic_auth": "기본 인증 활성화",
+    "dark_version": "다크 버전",
+    "use_dark_background": "어두운 배경에서 작업할 때는 이 버전을 사용하여 우리의 이름이 읽기 쉽게 유지되도록 하세요.",
+    "light_version": "라이트 버전",
+    "light_background": "밝은 배경에서 작업할 때 선호되는 옵션입니다.",
+    "monogram": "모노그램",
+    "wordmark_colors": "워드마크 색상은 배경에 따라 조정되며, 아이콘은 어두운 배경에 놓였을 때 배경 없이 유지됩니다.",
+    "download_logos": "로고 팩 다운로드",
+    "this_task_has": "이 task는",
+    "about_this_blueprint": "이 blueprint 정보",
+    "deleted_label": "삭제됨",
+    "fold_all_multi_lines": "모든 다중 라인 접기",
+    "task_id_exists": "Task ID가 이미 존재합니다.",
+    "task_id_message": "Flow에 Task Id ${existingTask}가 이미 존재합니다.",
+    "trigger_id_exists": "트리거 ID가 이미 존재합니다.",
+    "trigger_id_message": "Flow에 Trigger Id ${existingTrigger}가 이미 존재합니다.",
+    "watch": "시청",
+    "learn_more": "자세히 알아보기",
+    "watch_video": "비디오 보기",
+    "runners": "러너",
+    "select": "{{section}}을 선택하세요",
+    "for flow": "flow용",
+    "forbidden system labels": "system label로는 system.correlationId만 사용할 수 있습니다",
+    "confirm": "확인",
+    "taskRunners": "작업 실행기",
+    "additionalPlugins": "추가 플러그인",
+    "appBlocks": "앱 블록",
+    "charts": "차트",
+    "dataFilters": "데이터 필터",
+    "logExporters": "로그 Exporters",
+    "empty": {
+      "namespaceFiles": {
+        "title": "이 namespace에 아직 파일이 없습니다",
+        "content": "namespace 파일은 이 namespace의 프로젝트 폴더처럼 작동합니다. Python, SQL, dbt 또는 Terraform 코드를 저장한 다음, flow에서 다음을 사용하여 모든 파일을 참조하세요"
+      },
+      "announcements": {
+        "title": "아직 공지가 없습니다!",
+        "content": "공지사항을 통해 사용자에게 변경 사항을 알리거나 계획된 유지보수 중단에 대해 알릴 수 있습니다. 공지사항 유형을 선택하고, 표시할 날짜 범위를 설정한 후 공지사항 메시지를 작성하세요."
+      },
+      "kill_switches": {
+        "title": "아직 Kill Switch가 없습니다!",
+        "content": "킬 스위치 기능은 문제 있는 실행을 중지할 수 있는 UI 기반 메커니즘을 제공합니다. 이는 CLI 전용 <code>--skip-executions</code> 및 <code>--skip-flows</code> 명령을 포괄적인 관리 인터페이스로 대체합니다."
+      },
+      "apps": {
+        "title": "앱이 아직 없습니다!",
+        "content": "Kestra와 외부 세계를 상호작용하는 앱을 만들기 시작하세요."
+      },
+      "testSuites": {
+        "title": "아직 Test suite가 없습니다!",
+        "content": "테스트 스위트를 생성하여 flow를 테스트하기 시작하세요."
+      },
+      "assets": {
+        "title": "아직 자산이 없습니다!",
+        "content": "데이터 자산, 서비스 및 인프라를 추적하고 관리하기 위해 자산을 추가하세요."
+      },
+      "apiTokens": {
+        "title": "API 토큰 관리",
+        "content": "API 토큰은 Kestra API에 대한 프로그래매틱 접근을 허용하고자 할 때 사용됩니다."
+      },
+      "concurrency_executions": {
+        "title": "이 Flow에 대한 진행 중인 실행이 없습니다.",
+        "content": "자세한 내용은 <strong><a href=\"https://kestra.io/docs/workflow-components/execution?utm_source=app&utm_medium=referral&utm_campaign=concurrency-inlinedoc\" target=\"_blank\">Executions</a></strong>에 대한 문서를 참조하세요."
+      },
+      "concurrency_limit": {
+        "title": "이 Flow에 대한 제한이 설정되지 않았습니다.",
+        "content": "우리 문서에서 <strong><a href=\"https://kestra.io/docs/workflow-components/concurrency?utm_source=app&utm_medium=referral&utm_campaign=concurrency-inlinedoc\" target=\"_blank\">Concurrency Limits</a></strong>에 대해 더 읽어보세요."
+      },
+      "concurrency_limits": {
+        "title": "동시성 제한이 설정되지 않았습니다.",
+        "content": "우리 문서에서 <strong><a href=\"https://kestra.io/docs/workflow-components/concurrency?utm_source=app&utm_medium=referral&utm_campaign=concurrency-inlinedoc\" target=\"_blank\">동시성 제한</a></strong>에 대해 더 읽어보세요."
+      },
+      "pluginDefaults": {
+        "title": "아직 플러그인 기본값이 없습니다!",
+        "content": "플러그인 기본값을 사용하면 플러그인 구성을 중앙에서 관리하고 namespace의 모든 flow와 공유할 수 있습니다."
+      },
+      "variables": {
+        "title": "아직 변수가 없습니다",
+        "content": "flow 간의 구성을 공유하기 위해 key-value 쌍을 추가하세요. 하위 namespace는 이를 자동으로 상속하며, 모든 value를 참조할 수 있습니다."
+      },
+      "workerRegistrationTokens": {
+        "title": "아직 등록 토큰이 없습니다!",
+        "content": "등록 토큰은 원격 worker가 Kestra 인스턴스에 안전하게 인증하고 등록할 수 있도록 합니다. 토큰을 생성한 후 이를 사용하여 새로운 worker를 이 클러스터에 연결하세요."
+      },
+      "groups": {
+        "title": "아직 그룹이 없습니다!",
+        "content": "그룹은 사용자를 함께 묶어 권한 및 역할 바인딩을 테넌트 전체에서 집합적으로 관리할 수 있도록 합니다."
+      },
+      "dependencies": {
+        "FLOW": {
+          "title": "현재 종속성이 없습니다.",
+          "content": "<a href=\"https://kestra.io/docs/ui/flows?utm_source=app&utm_medium=referral&utm_campaign=dependencies-inlinedoc#dependencies\" target=\"_blank\">Flow Dependencies</a>에 대한 자세한 내용은 문서를 참조하세요."
+        },
+        "EXECUTION": {
+          "title": "현재 종속성이 없습니다.",
+          "content": "<a href=\"https://kestra.io/docs/ui/executions?utm_source=app&utm_medium=referral&utm_campaign=dependencies-inlinedoc#dependencies\" target=\"_blank\">실행 종속성</a>에 대한 자세한 내용은 문서를 참조하세요."
+        },
+        "NAMESPACE": {
+          "title": "현재 종속성이 없습니다.",
+          "content": "<a href=\"https://kestra.io/docs/ui/namespaces?utm_source=app&utm_medium=referral&utm_campaign=dependencies-inlinedoc#dependencies\" target=\"_blank\">Namespace Dependencies</a>에 대한 자세한 내용은 문서를 참조하세요."
+        },
+        "ASSET": {
+          "title": "현재 종속성이 없습니다.",
+          "content": "이 자산은 flow 또는 다른 자산과 상위 또는 하위 종속성이 없습니다."
+        }
+      },
+      "plugins": {
+        "title": "이 Namespace에 대한 플러그인 기본값이 설정되지 않았습니다.",
+        "content": "우리 문서에서 <strong><a href=\"https://kestra.io/docs/workflow-components/plugin-defaults?utm_source=app&utm_medium=referral&utm_campaign=plugin-default-inlinedoc\" target=\"_blank\">Concurrency Limits</a></strong>에 대해 더 읽어보세요."
+      },
+      "triggers": {
+        "title": "flow에 Triggers가 없습니다.",
+        "content": "<strong><a href=\"https://kestra.io/docs/workflow-components/triggers?utm_source=app&utm_medium=referral&utm_campaign=trigger-inlinedoc\" target=\"_blank\">Triggers</a></strong>에 대한 자세한 내용은 문서를 참조하세요."
+      },
+      "mcpToolFlows": {
+        "title": "이 서버에는 아직 등록된 tool flow가 없습니다.",
+        "content": "<code>McpToolTrigger</code>를 추가하여 flow를 MCP 도구로 노출합니다. <strong><a href=\"https://kestra.io/docs/workflow-components/triggers/mcp-tool-trigger?utm_source=app&utm_medium=referral&utm_campaign=mcp-tool-trigger-inlinedoc\" target=\"_blank\">MCP Tool Trigger</a></strong>에 대한 자세한 내용은 문서를 참조하세요."
+      },
+      "versionPlugin": {
+        "title": "아직 버전이 지정된 플러그인이 없습니다!",
+        "content": "여기에서 Kestra 인스턴스에 설치된 모든 플러그인을 관리할 수 있습니다. 새로 설치된 플러그인은 인스턴스의 구성에 따라 모든 Kestra 서비스에서 즉시 사용 가능하지 않을 수 있습니다."
+      },
+      "panels": {
+        "title": "패널이 열려 있지 않음",
+        "content": "모든 패널을 닫았습니다.  \n계속하려면 위의 탭을 선택하세요."
+      }
+    },
+    "toggle_word_wrap": "자동 줄 바꿈 토글",
+    "copied_logs_to_clipboard": "로그가 클립보드에 복사되었습니다.",
+    "multi_panel_editor": {
+      "move_right": "오른쪽으로 이동",
+      "move_left": "왼쪽으로 이동",
+      "close_all_tabs": "모든 탭 닫기",
+      "close_all_panels": "모든 패널 닫기"
+    },
+    "search_docs": "검색",
+    "no_results_found": "결과를 찾을 수 없습니다",
+    "searching": "검색 중...",
+    "worker information": "작업자 정보",
+    "test-badge-text": "테스트",
+    "test-badge-tooltip": "이 실행은 테스트에 의해 생성되었습니다.",
+    "total_executions": "총 실행 횟수",
+    "no_results": {
+      "executions": "실행을 찾을 수 없음",
+      "triggers": "트리거를 찾을 수 없음",
+      "flows": "flow를 찾을 수 없음",
+      "kv_pairs": "Key-Value 쌍을 찾을 수 없음",
+      "secrets": "비밀 없음",
+      "templates": "템플릿을 찾을 수 없음",
+      "assets": "자산을 찾을 수 없음"
+    },
+    "duplicate-pair": "{label} \"{key}\"가 중복되었습니다. 첫 번째 key는 무시됩니다.",
+    "dashboards": {
+      "labels": {
+        "singular": "대시보드",
+        "plural": "대시보드"
+      },
+      "default": "기본 대시보드",
+      "switch": "대시보드 전환",
+      "preview": "미리보기 대시보드",
+      "empty": "결과가 표시되지 않습니다.",
+      "creation": {
+        "label": "대시보드 생성",
+        "confirmation": "대시보드 <code>{title}</code>이(가) 생성되었습니다."
+      },
+      "edition": {
+        "label": "대시보드 편집",
+        "confirmation": "대시보드 <code>{title}</code>의 변경 사항이 저장되었습니다.",
+        "chart": "이 차트 편집",
+        "id readonly": "`id` 속성은 변경할 수 없습니다 — 현재 초기 값으로 설정되어 있습니다. 변경하려면 새 대시보드를 생성하고 기존 것을 제거할 수 있습니다."
+      },
+      "deletion": {
+        "confirmation": "<code>{title}</code> 대시보드를 삭제하시겠습니까?"
+      },
+      "no_description": "설명 없음",
+      "no_description_hint": "이 flow에 설명을 추가하여 무엇을 하는지 문서화하세요.<br>Markdown이 지원됩니다.",
+      "others": "기타",
+      "viewAll": "전체 보기",
+      "chart_preview": "차트 소스 코드를 클릭하여 미리보기를 확인하세요.",
+      "export": "CSV로 내보내기",
+      "quick_filters": {
+        "all": "전체",
+        "running": "실행 중",
+        "paused": "일시 중지됨",
+        "success": "성공",
+        "warning": "경고",
+        "failed": "실패"
+      }
     },
     "setup": {
-      "config": {
-        "basicauth": "기본 인증",
-        "queue": "큐",
-        "repository": "데이터베이스",
-        "storage": "내부 저장소"
+      "login": "로그인",
+      "login_title": "로그인",
+      "logout": "로그아웃",
+      "troubleshooting": "비밀번호를 잊으셨습니까?",
+      "steps": {
+        "user": "관리자 사용자 생성",
+        "config": "구성 유효성 검사",
+        "survey": "자세히 알려주세요",
+        "complete": "Kestra UI 시작"
       },
-      "confirm": {
-        "config_title": "구성이 유효한지 확인하십시오",
-        "confirm": "관리자 사용자 생성",
-        "not_valid": "아니요, 유효하지 않습니다",
-        "valid": "네, 유효합니다"
+      "titles": {
+        "user": "관리자 사용자 생성",
+        "survey": "Kestra OSS 개선에 도움을 주세요"
+      },
+      "subtitles": {
+        "user": "인스턴스를 보호하여 시작하세요.",
+        "config": "여기 귀하의 구성 세부 정보가 있습니다",
+        "survey": "죄송하지만 번역할 텍스트가 제공되지 않았습니다. 번역할 텍스트를 제공해 주시면 감사하겠습니다.",
+        "complete": "설정이 성공적으로 완료되었습니다!"
       },
       "form": {
         "email": "이메일",
@@ -1878,351 +1937,249 @@
         "username": "사용자 이름",
         "username_hint": "유효한 이메일 주소여야 합니다."
       },
-      "login": "로그인",
-      "login_title": "로그인",
-      "logout": "로그아웃",
-      "steps": {
-        "complete": "Kestra UI 시작",
-        "config": "구성 유효성 검사",
-        "survey": "자세히 알려주세요",
-        "user": "관리자 사용자 생성"
-      },
-      "subtitles": {
-        "complete": "설정이 성공적으로 완료되었습니다!",
-        "config": "여기 귀하의 구성 세부 정보가 있습니다",
-        "survey": "죄송하지만 번역할 텍스트가 제공되지 않았습니다. 번역할 텍스트를 제공해 주시면 감사하겠습니다.",
-        "user": "인스턴스를 보호하여 시작하세요."
-      },
-      "success": {
-        "subtitle": "모두 준비되었습니다!",
-        "title": "축하합니다!"
-      },
-      "survey": {
-        "company_11_50": "개인 프로젝트",
-        "company_1_10": "학습 / 탐색",
-        "company_250_plus": "프로덕션 배포",
-        "company_50_250": "우리 팀/회사 평가 중",
-        "company_personal": "기타",
-        "company_size": "Kestra를 사용하는 주요 목표는 무엇인가요?",
-        "continue": "계속",
-        "newsletter": "제품 업데이트를 이메일로 받으세요.",
-        "newsletter_heading": "항상 최신 정보를 받아보세요",
-        "skip": "건너뛰기",
-        "use_case": "무엇을 위해 사용할 계획입니까?",
-        "use_case_business": "비즈니스 워크플로우",
-        "use_case_data": "데이터 워크플로우",
-        "use_case_infrastructure": "인프라 자동화",
-        "use_case_ml": "ML 파이프라인",
-        "use_case_other": "기타",
-        "use_case_scheduling": "일정 및 반복 작업"
-      },
-      "titles": {
-        "survey": "Kestra OSS 개선에 도움을 주세요",
-        "user": "관리자 사용자 생성"
-      },
-      "troubleshooting": "비밀번호를 잊으셨습니까?",
       "validation": {
-        "config_message": "구성 설정을 업데이트하여 이 오류 메시지를 수정하십시오.",
-        "email_invalid": "유효하지 않은 이메일",
         "email_required": "이메일이 필요합니다",
+        "email_invalid": "유효하지 않은 이메일",
         "email_temporary_not_allowed": "임시 또는 일회용 이메일 주소는 허용되지 않습니다",
         "firstName_required": "이름이 필요합니다",
-        "incorrect_creds": "잘못된 사용자 이름 또는 비밀번호입니다. 자격 증명이 올바른지 확인하세요.",
         "lastName_required": "성을 입력해야 합니다",
         "password_invalid": "잘못된 비밀번호",
-        "password_required": "비밀번호는 필수입니다"
+        "password_required": "비밀번호는 필수입니다",
+        "incorrect_creds": "잘못된 사용자 이름 또는 비밀번호입니다. 자격 증명이 올바른지 확인하세요.",
+        "config_message": "구성 설정을 업데이트하여 이 오류 메시지를 수정하십시오."
+      },
+      "config": {
+        "repository": "데이터베이스",
+        "queue": "큐",
+        "storage": "내부 저장소",
+        "basicauth": "기본 인증"
+      },
+      "confirm": {
+        "confirm": "관리자 사용자 생성",
+        "config_title": "구성이 유효한지 확인하십시오",
+        "not_valid": "아니요, 유효하지 않습니다",
+        "valid": "네, 유효합니다"
+      },
+      "survey": {
+        "skip": "건너뛰기",
+        "company_size": "Kestra를 사용하는 주요 목표는 무엇인가요?",
+        "company_1_10": "학습 / 탐색",
+        "company_11_50": "개인 프로젝트",
+        "company_50_250": "우리 팀/회사 평가 중",
+        "company_250_plus": "프로덕션 배포",
+        "company_personal": "기타",
+        "use_case": "무엇을 위해 사용할 계획입니까?",
+        "use_case_infrastructure": "인프라 자동화",
+        "use_case_business": "비즈니스 워크플로우",
+        "use_case_data": "데이터 워크플로우",
+        "use_case_ml": "ML 파이프라인",
+        "use_case_scheduling": "일정 및 반복 작업",
+        "use_case_other": "기타",
+        "newsletter_heading": "항상 최신 정보를 받아보세요",
+        "newsletter": "제품 업데이트를 이메일로 받으세요.",
+        "continue": "계속"
+      },
+      "success": {
+        "title": "축하합니다!",
+        "subtitle": "모두 준비되었습니다!"
       }
     },
-    "show": "보기",
-    "show chart": "차트 보기",
-    "show description": "설명을 표시",
-    "show details": "세부 정보 표시",
-    "show documentation": "문서 보기",
-    "show more details": "자세한 정보 보기",
-    "show raw": "Show raw",
-    "show task condition": "작업 상태 표시",
-    "show task documentation": "task 문서 보기",
-    "show task documentation in editor": "편집기에서 task 문서 보기",
-    "show task logs": "Task Logs 보기",
-    "show task outputs": "Task Outputs 보기",
-    "show task source": "Task 소스 보기",
-    "showLess": "덜 보기",
-    "showMore": "더 보기",
-    "side-by-side": "나란히",
-    "similar lines": "similar lines",
-    "skipped": "건너뜀",
-    "slack support": "Slack을 통해 질문하기",
-    "something_went_wrong": {
-      "connection_lost": {
-        "message": "Kestra 인스턴스에 연결할 수 없습니다. 실행 중인지 확인한 후 페이지를 새로 고치세요.",
-        "title": "연결이 중단되었습니다"
+    "ai": {
+      "flow": {
+        "title": "AI 에이전트",
+        "prompt_placeholder": "Kestra flow를 생성하기 위한 지침을 입력하세요. 예시 프롬프트: 매주 월요일 오전 9시에 실행되는 flow를 생성하세요.",
+        "select_provider": "공급자 선택",
+        "generating": {
+          "flow": "Flow YAML을 생성 중입니다...",
+          "dashboard": "대시보드 YAML을 생성 중입니다...",
+          "app": "앱 YAML을 생성 중입니다...",
+          "test": "테스트 YAML을 생성 중입니다..."
+        },
+        "enable_instructions": {
+          "header": "<b>AI Copilot이 아직 구성되지 않았습니다.</b>\n\nAI Copilot을 활성화하려면, 다음 코드 조각을 Kestra 인스턴스 구성 파일(예: <code>application.yml</code>)에 추가하고 <code>geminiApiKey</code>를 실제 key로 교체하십시오:",
+          "footer": "참고: 현재 오픈 소스 에디션에서는 AI 제공자로 Gemini만 지원됩니다. 엔터프라이즈 에디션의 경우, 다른 모델 제공자 구성을 위해 AI Copilot 문서를 참조하십시오.\n\n구성을 저장한 후 Kestra 인스턴스를 재시작하십시오."
+        }
       },
-      "loading_execution": "실행을 로드하는 중 문제가 발생했습니다."
+      "dashboard": {
+        "prompt_placeholder": "데이터에 대해 질문하세요. 예시 프롬프트: 지난 7일 동안 내 flows의 성공률을 보여줘."
+      }
     },
-    "source": "소스",
-    "source and blueprints": "소스 및 blueprints",
-    "source and doc": "소스 및 문서",
-    "source and topology": "소스 및 토폴로지",
-    "source only": "소스 전용",
-    "source search": "소스 검색",
-    "source_search": {
-      "match_count": "{count}개 일치 | {count}개 일치",
-      "open_flow": "flow 열기",
-      "preview_empty": "미리 볼 결과를 선택하세요. 결과 목록에서 flow를 클릭하면 소스를 확인할 수 있습니다.",
-      "preview_error": "flow 소스를 불러오지 못했습니다"
+    "playground": {
+      "title": "플레이그라운드",
+      "run_task_info": "Flow Code 편집기에서 어떤 task 위에 마우스를 올리고 \"Run task\" 버튼을 클릭하여 task를 테스트하세요.",
+      "play_icon_info": "또한 No-Code 또는 Topology 보기에서 Play 아이콘을 클릭할 수 있습니다.",
+      "toggle": "플레이그라운드",
+      "run_task": "작업 실행",
+      "run_this_task": "이 task 실행",
+      "run_task_and_downstream": "Task 및 다운스트림 실행",
+      "run_all_tasks": "모든 Task 실행",
+      "history": "최근 10회 실행",
+      "clear_history": "기록 지우기",
+      "confirm_create": "flow를 생성하는 동안에는 playground를 실행할 수 없습니다. playground 실행을 시작하면 flow가 생성됩니다.",
+      "tooltip_persistence": "Playground를 끄고 다시 켜면, 페이지에 머무르는 동안 정보가 유지됩니다."
     },
-    "specific task": "특정 task",
-    "start date": "시작 날짜",
-    "start datetime": "시작 날짜 및 시간",
-    "started date": "시작 날짜",
-    "state": "상태",
-    "state updated date": "상태 업데이트 날짜",
-    "state_history": "상태 기록",
-    "stats": "통계",
-    "steps": "단계",
-    "stream": "스트림",
-    "sub flow": "Subflow",
     "submit": "제출",
-    "success": "성공",
-    "sum": "합계",
-    "switch-view": "보기 전환",
-    "system overview": "시스템 개요",
-    "system_namespace": "플랫폼을 시스템 flows로 점검하세요.",
-    "system_namespace_description": "유지 관리 작업을 자동화하세요, 실패 경고부터 자동 정리까지.",
-    "tags": "태그들",
-    "task": "Task",
-    "task failed": "작업 실패",
-    "task id": "Task ID",
-    "task id already exists": "Task Id가 이미 존재합니다",
-    "task is running": "Task가 RUNNING 중입니다.",
-    "task logs": "Task Logs",
-    "task run id": "TaskRun ID",
-    "task sent a warning": "Task에서 경고를 보냈습니다.",
-    "task was skipped": "Task가 건너뛰어졌습니다",
-    "task was successful": "Task가 성공했습니다",
-    "taskDefaults": "Task 기본값",
-    "taskRunners": "작업 실행기",
-    "task_id_exists": "Task ID가 이미 존재합니다.",
-    "task_id_message": "Flow에 Task Id ${existingTask}가 이미 존재합니다.",
-    "taskid column details": "마지막으로 실행된 task 및 시도 횟수.",
-    "tasks": "Tasks",
-    "template": "템플릿",
-    "template creation": "템플릿 생성",
-    "template delete": "<code>{templateCount}</code> 개의 템플릿을 삭제하시겠습니까?",
-    "template export": "<code>{templateCount}</code> 개의 템플릿을 내보내시겠습니까?",
-    "templates": "템플릿들",
-    "templates deleted": "<code>{count}</code> 개의 템플릿이 삭제되었습니다",
-    "templates deprecated": "템플릿은 사용 중지되었습니다. 대신 subflows를 사용하세요. 템플릿에서 subflows로 마이그레이션하는 방법을 설명하는 <a href=\"https://kestra.io/docs/migration-guide/0.11.0/templates?utm_source=app&utm_medium=referral&utm_campaign=template-inlinedoc\" target=\"_blank\">마이그레이션 섹션</a>을 참조하세요.",
-    "templates exported": "템플릿이 내보내졌습니다",
-    "tenant": {
-      "name": "테넌트",
-      "names": "테넌트"
-    },
-    "tenantId": "테넌트 ID",
-    "test-badge-text": "테스트",
-    "test-badge-tooltip": "이 실행은 테스트에 의해 생성되었습니다.",
-    "theme": "테마",
-    "this_task_has": "이 task는",
-    "timezone": "시간대",
-    "title": "제목",
-    "to": "종료",
     "to toggle": "전환하기",
-    "toggle fullscreen": "전체 화면 전환",
-    "toggle menu": "메뉴 전환",
-    "toggle output": "출력 전환",
-    "toggle output display": "출력 표시 전환",
-    "toggle periodic refresh each x seconds": "주기적인 새로 고침을 {interval}초마다 전환",
-    "toggle_word_wrap": "자동 줄 바꿈 토글",
-    "topology": "토폴로지",
-    "topology-graph": {
-      "graph-orientation": "그래프 방향",
-      "invalid": "그래프 오류",
-      "invalid_description": "그래프를 로드하는 중 오류가 발생했습니다. 소스 코드에서 오류를 확인하세요.",
-      "zoom-fit": "맞춤",
-      "zoom-in": "확대",
-      "zoom-out": "축소",
-      "zoom-reset": "확대/축소 재설정"
-    },
-    "total_duration": "총 지속 시간",
-    "total_executions": "총 실행 횟수",
-    "trigger": "Trigger",
-    "trigger details": "Trigger 세부 정보",
-    "trigger disabled": "Flow 소스 내에서 Trigger가 비활성화되었습니다.",
-    "trigger execution id": "Trigger Execution Id",
-    "trigger filter": {
-      "options": {
-        "ALL": "모든 실행",
-        "CHILD": "자식 실행",
-        "MAIN": "부모 실행"
+    "accept": "수락",
+    "reject": "거부",
+    "draft_available": "편집기에서 초안 변경을 사용할 수 있습니다.",
+    "last modified": "마지막 수정",
+    "run task in playground": "플레이그라운드에서 task 실행",
+    "task is running": "Task가 RUNNING 중입니다.",
+    "task was successful": "Task가 성공했습니다",
+    "task failed": "작업 실패",
+    "task was skipped": "Task가 건너뛰어졌습니다",
+    "task sent a warning": "Task에서 경고를 보냈습니다.",
+    "defaultsToNamespaceFile": "기본값은 namespace 파일: <code>{name}</code>",
+    "no_file_choosen": "파일이 선택되지 않음",
+    "dependency": {
+      "controls": {
+        "zoom_in": "확대하기",
+        "zoom_out": "축소",
+        "clear_selection": "선택 해제",
+        "fit_view": "화면에 맞추기"
       },
-      "title": "자식 실행 필터링"
-    },
-    "trigger refresh": "새로 고침 trigger",
-    "triggerId": "트리거 ID",
-    "trigger_check_warning": "트리거 변수를 사용하는 것은 수동 flow 실행과 함께 작동하지 않습니다. 문제를 해결하려면 `??` 병합 연산자를 추가하세요. 예를 들어, `trigger.date` 대신 `trigger.date ?? execution.startDate`를 사용하세요.",
-    "trigger_id_exists": "트리거 ID가 이미 존재합니다.",
-    "trigger_id_message": "Flow에 Trigger Id ${existingTrigger}가 이미 존재합니다.",
-    "trigger_states": "상태",
-    "triggered": "Trigger 실행",
-    "triggered done": "<em>{name}</em>이(가) 성공적으로 Trigger 되었습니다.",
-    "triggerflow disabled": "Flow 정의에서 trigger가 비활성화되었습니다.",
-    "triggers": "Triggers",
-    "triggers_add_card_add": "추가",
-    "triggers_add_card_add_to_flow": "flow에 추가",
-    "triggers_add_category_empty": "이 카테고리에 trigger가 없습니다.",
-    "triggers_add_ee_tooltip": "이 trigger는 Enterprise Edition이 필요합니다.",
-    "triggers_add_empty_title": "트리거를 찾을 수 없음",
-    "triggers_add_filter_all": "모두",
-    "triggers_add_filter_app": "앱",
-    "triggers_add_filter_core": "코어",
-    "triggers_add_filter_realtime": "실시간",
-    "triggers_add_modal_add_button": "Flow에 Trigger 추가",
-    "triggers_add_modal_ee_notice": "이 trigger는 Enterprise Edition이 필요합니다.",
-    "triggers_add_modal_flow_placeholder": "flow 선택",
-    "triggers_add_modal_namespace_placeholder": "namespace 선택",
-    "triggers_add_modal_properties_hint": "트리거를 추가한 후 flow 편집기에서 트리거 속성을 구성합니다.",
-    "triggers_add_modal_tab_documentation": "문서",
-    "triggers_add_modal_tab_form": "폼",
-    "triggers_add_modal_tab_source": "출처",
-    "triggers_add_modal_title": "{name}",
-    "triggers_add_modal_trigger_id": "트리거 ID",
-    "triggers_add_modal_trigger_id_placeholder": "이 trigger의 고유 식별자",
-    "triggers_add_search_placeholder": "트리거 검색...",
-    "triggers_header_description": "트리거를 찾아보고 추가하고 관리하여 flow를 자동화하세요. flow를 AI 도구로 노출하거나, 스케줄링, webhook trigger 추가, 외부 앱의 변경 사항 폴링, 실시간 이벤트 리스너 중에서 선택하세요.",
-    "triggers_state": {
-      "options": {
-        "disabled": "비활성화됨",
-        "enabled": "활성화됨"
-      },
-      "state": "상태"
-    },
-    "triggers_tabs_add": "추가",
-    "triggers_tabs_manage": "관리",
-    "true": "True",
-    "type": "유형",
-    "unable to generate graph": "그래프 생성 중 문제가 발생하여 토폴로지를 표시할 수 없습니다.",
-    "undefined": "Undefined",
-    "unlock": "잠금 해제",
-    "unlock trigger": {
-      "button": "trigger 잠금 해제",
-      "confirmation": "trigger를 잠금 해제하시겠습니까?",
-      "success": "Trigger가 잠금 해제되었습니다",
-      "tooltip": {
-        "evaluation": "trigger가 현재 평가 중입니다",
-        "execution": "이 trigger에 대한 실행이 진행 중입니다"
-      },
-      "warning": "이는 동일한 trigger에 대해 동시 실행을 초래할 수 있으며 최후의 수단으로 고려해야 합니다."
-    },
-    "unqueue": "대기열에서 제거",
-    "unqueue as": "<code>{status}</code>로 대기열에서 제거",
-    "unqueue confirm": "실행 <code>{id}</code>의 대기열을 해제하시겠습니까?",
-    "unqueue done": "실행이 대기열에서 제거되었습니다.",
-    "unqueue title": "실행 <code>{id}</code>을(를) 대기열에서 제거합니다.<br/>이 작업은 flow 동시성 제한을 따르지 않으므로 허용된 제한보다 더 많은 실행이 진행될 수 있습니다.",
-    "unqueue title multiple": "<code>{count}</code>개의 실행을 대기열에서 제거하시겠습니까?<br/><br/>이 작업은 flow 동시성 제한을 따르지 않으므로 허용된 제한보다 더 많은 실행이 진행될 수 있습니다.",
-    "unsaved changed ?": "저장되지 않은 변경 사항이 있습니다. 이 페이지를 떠나시겠습니까?",
-    "unsaved changes": "저장되지 않은 변경 사항",
-    "unsaved changes warning": "저장되지 않은 변경 사항이 있습니다. 이 페이지를 떠나면 변경 사항이 사라집니다.",
-    "up trend": "증가 중",
-    "update": "업데이트",
-    "update aborted": "업데이트 중단됨",
-    "update ok": "업데이트됨",
-    "updated date": "업데이트 날짜",
-    "usage": "사용량",
-    "use": "사용",
-    "use_dark_background": "어두운 배경에서 작업할 때는 이 버전을 사용하여 우리의 이름이 읽기 쉽게 유지되도록 하세요.",
-    "valid": "유효",
-    "validate": "유효성 검사",
-    "value": "Value",
-    "variable_explorer": {
-      "empty": "이 실행에 사용할 수 있는 변수가 없습니다.",
-      "n_items": "[ {count}개 항목 ]",
-      "n_keys": "\\{ {count} keys \\}",
-      "one_item": "[ 1개 항목 ]",
-      "one_key": "\\{ 1 key \\}",
-      "raw_json": "Raw JSON",
-      "search_placeholder": "Key 또는 value 검색...",
-      "select_prompt": "value를 확인할 변수를 선택하세요.",
-      "tasks_outputs": "Tasks outputs",
-      "title": "입력/출력",
-      "tree": "트리"
-    },
-    "variables": "변수",
-    "version": "버전",
-    "view metrics": "메트릭 보기",
-    "warning": "경고",
-    "warning detected": "경고 감지됨",
-    "warning flow with triggers": "이 flow는 triggers를 포함하고 있으며, 이 flow가 trigger expressions에 의존하는 경우 수동 실행이 실패합니다. 해당 Flow는 Trigger를 포함하고 있으며,  Trigger Expression을 의존하는 경우 수동 실행이 실패할 수 있습니다. ",
-    "watch": "시청",
-    "watch_video": "비디오 보기",
-    "webhook": {
-      "copy_url": "웹훅 URL 복사",
-      "curl_command": "Webhook cURL 명령어",
-      "curl_note": "이 cURL 명령어를 사용하여 사용자 정의 JSON 페이로드로 웹훅을 통해 flow를 trigger하십시오.",
-      "no_triggers": "이 flow에는 활성화된 webhook trigger가 없습니다.",
-      "payload": "Webhook Payload (JSON)"
-    },
-    "webhook link copied": "웹훅 링크가 복사되었습니다.",
-    "welcome": {
-      "help": {
-        "text": "Slack 커뮤니티에서 질문을 하세요. 문제가 생기면 저희가 도와드리겠습니다. ✋",
-        "title": "도움이 필요하신가요?"
-      },
-      "menu": "Welcome",
-      "tour": {
-        "text": "사용 사례를 선택하고 단계별 가이드를 따라 Kestra의 기능과 역량을 배워보세요. ❤️",
-        "title": "제품 투어 시작하기"
-      },
-      "tutorial": {
-        "text": "* <a href=\"https://kestra.io/tutorial-videos/all?utm_source=app&utm_medium=referral&utm_campaign=welcome-tutorial\" target=\"_blank\">비디오 튜토리얼</a>  \n* <a href=\"https://kestra.io/docs?utm_source=app&utm_medium=referral&utm_campaign=welcome-tutorial\" target=\"_blank\">문서</a>  \n* <a href=\"https://kestra.io/blueprints?utm_source=app&utm_medium=referral&utm_campaign=welcome-tutorial\" target=\"_blank\">Blueprints</a>",
-        "title": "튜토리얼"
+      "search": {
+        "placeholders": {
+          "default": "flow 또는 namespace로 검색...",
+          "asset": "자산, flow 또는 namespace로 검색..."
+        },
+        "namespace": {
+          "select": "namespace 선택",
+          "no_namespace": "namespace 없음"
+        },
+        "flow": {
+          "display": "flow 종속성 포함"
+        },
+        "no_results": "{term}에 대한 결과가 없습니다."
       }
     },
+    "preview": {
+      "label": "미리보기",
+      "force-editor": "편집기 보기 강제 적용",
+      "auto-view": "자동 보기",
+      "view": "보기",
+      "rows_truncated": "{total}개의 행 중 {shown}개를 표시 중입니다. 모든 데이터를 보려면 파일을 다운로드하세요.",
+      "pagination_info": "{total}개 중 {start}-{end} 행 표시 중.",
+      "showing_rows": "{total}개 중 {start}-{end} 행 표시",
+      "expand": "확장",
+      "collapse": "접기",
+      "previous": "이전",
+      "next": "다음",
+      "page_of": "{total} 중 {current} 페이지"
+    },
+    "delete trigger": "트리거 삭제",
+    "delete triggers": "트리거 삭제",
+    "bulk delete triggers": "{count}개의 trigger를 삭제하시겠습니까?",
+    "bulk success delete triggers": "{count} triggers가 성공적으로 삭제되었습니다",
+    "delete trigger confirmation": "트리거 {id}를 삭제하시겠습니까? WARNING: 트리거가 flow에서 여전히 활성 상태인 경우 삭제하면 중복 실행이 발생할 수 있습니다.",
+    "delete trigger success": "{id} 트리거가 성공적으로 삭제되었습니다",
+    "delete trigger error": "트리거 {id} 삭제 오류",
+    "revision deleted": "{revision} 리비전이 성공적으로 삭제되었습니다.",
+    "delete revision confirm": "{revision} 개정을 삭제하시겠습니까?",
+    "delete revision error": "{error} 오류로 인해 {revision} 수정본 삭제 오류 발생",
+    "no_history": "기록 없음",
+    "export_as": ".{format}로 내보내기",
+    "save_and_execute": "저장 및 실행",
     "welcome_copilot": {
       "button_cta": "새 flow 생성",
       "create_manually": {
-        "description": "편집기를 사용하여 처음부터 빌드하기",
-        "title": "수동으로 생성"
+        "title": "수동으로 생성",
+        "description": "편집기를 사용하여 처음부터 빌드하기"
       },
       "docs": {
-        "description": "공식 문서에서 자세히 알아보기",
-        "title": "문서 읽기"
+        "title": "문서 읽기",
+        "description": "공식 문서에서 자세히 알아보기"
       },
+      "title": "아이디어를 workflow로 전환하세요",
+      "need_help": "도움이 필요하신가요?",
+      "placeholder_prompt": "매일 오전 9시에 인사 메시지를 보내주세요.",
+      "show_more": "더 많은 프롬프트 보기",
+      "show_less": "더 적은 프롬프트 표시",
+      "remaining_quota": "{count}개의 AI 생성이 남아 있습니다. 제한은 매일 자정 UTC에 초기화됩니다.",
       "execute_hint": {
-        "description": "클릭하여 워크플로우를 저장하고 즉시 실행하세요.",
-        "title": "저장 및 flow 실행"
+        "title": "저장 및 flow 실행",
+        "description": "클릭하여 워크플로우를 저장하고 즉시 실행하세요."
+      },
+      "success_popup": {
+        "title": "축하합니다!",
+        "description": "첫 번째 flow를 성공적으로 실행했습니다! Kestra 전문가가 되는 길에 있습니다.",
+        "tutorial": "심층 튜토리얼",
+        "explore": "더 보기"
+      },
+      "success_page": {
+        "title": "모든 준비가 완료되었습니다!",
+        "description": "Kestra의 기본을 배웠습니다. 여정을 계속하는 데 도움이 될 몇 가지 리소스를 소개합니다.",
+        "restart": "튜토리얼 다시 시작",
+        "items": {
+          "tutorial": {
+            "title": "튜토리얼 시작",
+            "description": "Kestra 기능의 대화형 안내"
+          },
+          "blueprints": {
+            "title": "블루프린트",
+            "description": "일반적인 사용 사례를 위한 사전 구축된 워크플로우 템플릿"
+          },
+          "slack": {
+            "title": "슬랙 커뮤니티",
+            "description": "다른 사용자와 연결하고 커뮤니티로부터 도움 받기"
+          },
+          "videos": {
+            "title": "비디오 튜토리얼",
+            "description": "고급 기능을 위한 단계별 비디오 가이드"
+          },
+          "demo": {
+            "title": "데모 받기",
+            "description": "Kestra Enterprise Edition을 개인 맞춤형 데모로 탐색하세요."
+          }
+        }
+      },
+      "help": {
+        "tutorial": {
+          "title": "튜토리얼 시작",
+          "description": "가이드 단계와 함께 첫 번째 flow를 생성하고 실행하는 방법을 배우세요."
+        },
+        "blueprints": {
+          "title": "블루프린트",
+          "description": "일반적인 워크플로 패턴을 위한 사용 가능한 예제와 템플릿을 탐색하세요."
+        },
+        "slack": {
+          "title": "Slack 커뮤니티",
+          "description": "아이디어와 모범 사례를 공유하고, 기술적인 질문에 대한 도움을 받으세요."
+        }
       },
       "flows": {
-        "buildDbtPipeline": {
-          "label": "dbt 파이프라인 구축",
-          "prompt": "Kestra flow를 생성하여 dbt 프로젝트 저장소를 복제하고 DuckDB 프로필로 dbt build를 실행합니다."
-        },
-        "buildDockerImageAndRunIt": {
-          "label": "Docker 이미지를 빌드하고 실행하기",
-          "prompt": "인라인 Dockerfile에서 Docker 이미지를 빌드하고 결과 컨테이너를 실행하는 Kestra flow를 생성합니다."
-        },
-        "convertCsvToExcel": {
-          "label": "CSV를 Excel로 변환",
-          "prompt": "CSV 파일을 다운로드하고 Ion으로 변환한 후 결과를 Excel 파일로 내보내는 flow를 생성합니다."
-        },
-        "etlWorkflow": {
-          "label": "ETL 워크플로우",
-          "prompt": "JSON 데이터를 다운로드하고 Python으로 처리한 후 DuckDB로 변환된 결과를 쿼리하는 ETL flow를 생성합니다."
+        "jsonApiToDuckdb": {
+          "label": "DuckDB로의 JSON API",
+          "prompt": "공용 API에서 JSON 파일을 다운로드하고 Python 스크립트로 변환한 후 DuckDB Queries task로 처리하는 flow를 생성하세요."
         },
         "installNginxViaAnsible": {
           "label": "Ansible를 통해 Nginx 설치",
           "prompt": "Ansible을 사용하여 대상 머신에 Nginx를 설치하고 설치된 버전을 확인하는 Kestra flow를 생성합니다."
         },
-        "jsonApiToDuckdb": {
-          "label": "DuckDB로의 JSON API",
-          "prompt": "공용 API에서 JSON 파일을 다운로드하고 Python 스크립트로 변환한 후 DuckDB Queries task로 처리하는 flow를 생성하세요."
+        "buildDbtPipeline": {
+          "label": "dbt 파이프라인 구축",
+          "prompt": "Kestra flow를 생성하여 dbt 프로젝트 저장소를 복제하고 DuckDB 프로필로 dbt build를 실행합니다."
+        },
+        "etlWorkflow": {
+          "label": "ETL 워크플로우",
+          "prompt": "JSON 데이터를 다운로드하고 Python으로 처리한 후 DuckDB로 변환된 결과를 쿼리하는 ETL flow를 생성합니다."
+        },
+        "microservicesApis": {
+          "label": "마이크로서비스 & API",
+          "prompt": "웹사이트 API 응답을 확인하고 상태 코드가 성공적이지 않을 때 Slack 알림을 보내는 flow를 생성합니다."
+        },
+        "buildDockerImageAndRunIt": {
+          "label": "Docker 이미지를 빌드하고 실행하기",
+          "prompt": "인라인 Dockerfile에서 Docker 이미지를 빌드하고 결과 컨테이너를 실행하는 Kestra flow를 생성합니다."
         },
         "manualApproval": {
           "label": "수동 승인",
           "prompt": "승인 후 초기 처리 단계, 수동 승인 일시 중지, 최종 배포 단계가 포함된 flow를 생성합니다."
         },
-        "microservicesApis": {
-          "label": "마이크로서비스 & API",
-          "prompt": "웹사이트 API 응답을 확인하고 상태 코드가 성공적이지 않을 때 Slack 알림을 보내는 flow를 생성합니다."
+        "convertCsvToExcel": {
+          "label": "CSV를 Excel로 변환",
+          "prompt": "CSV 파일을 다운로드하고 Ion으로 변환한 후 결과를 Excel 파일로 내보내는 flow를 생성합니다."
         },
         "scheduledPdfReports": {
           "label": "예약된 PDF 보고서",
@@ -2232,73 +2189,116 @@
           "label": "주간 판매 KPI를 Slack으로 보내기",
           "prompt": "DuckDB를 사용하여 판매 KPI를 계산하고 요약을 Slack에 게시하는 주간 예약 flow를 생성합니다."
         }
-      },
-      "help": {
-        "blueprints": {
-          "description": "일반적인 워크플로 패턴을 위한 사용 가능한 예제와 템플릿을 탐색하세요.",
-          "title": "블루프린트"
-        },
-        "slack": {
-          "description": "아이디어와 모범 사례를 공유하고, 기술적인 질문에 대한 도움을 받으세요.",
-          "title": "Slack 커뮤니티"
-        },
-        "tutorial": {
-          "description": "가이드 단계와 함께 첫 번째 flow를 생성하고 실행하는 방법을 배우세요.",
-          "title": "튜토리얼 시작"
-        }
-      },
-      "need_help": "도움이 필요하신가요?",
-      "placeholder_prompt": "매일 오전 9시에 인사 메시지를 보내주세요.",
-      "remaining_quota": "{count}개의 AI 생성이 남아 있습니다. 제한은 매일 자정 UTC에 초기화됩니다.",
-      "show_less": "더 적은 프롬프트 표시",
-      "show_more": "더 많은 프롬프트 보기",
-      "success_page": {
-        "description": "Kestra의 기본을 배웠습니다. 여정을 계속하는 데 도움이 될 몇 가지 리소스를 소개합니다.",
-        "items": {
-          "blueprints": {
-            "description": "일반적인 사용 사례를 위한 사전 구축된 워크플로우 템플릿",
-            "title": "블루프린트"
-          },
-          "demo": {
-            "description": "Kestra Enterprise Edition을 개인 맞춤형 데모로 탐색하세요.",
-            "title": "데모 받기"
-          },
-          "slack": {
-            "description": "다른 사용자와 연결하고 커뮤니티로부터 도움 받기",
-            "title": "슬랙 커뮤니티"
-          },
-          "tutorial": {
-            "description": "Kestra 기능의 대화형 안내",
-            "title": "튜토리얼 시작"
-          },
-          "videos": {
-            "description": "고급 기능을 위한 단계별 비디오 가이드",
-            "title": "비디오 튜토리얼"
-          }
-        },
-        "restart": "튜토리얼 다시 시작",
-        "title": "모든 준비가 완료되었습니다!"
-      },
-      "success_popup": {
-        "description": "첫 번째 flow를 성공적으로 실행했습니다! Kestra 전문가가 되는 길에 있습니다.",
-        "explore": "더 보기",
-        "title": "축하합니다!",
-        "tutorial": "심층 튜토리얼"
-      },
-      "title": "아이디어를 workflow로 전환하세요"
+      }
     },
-    "welcome_page": {
-      "guide": "첫 번째 flow를 실행하는 데 도움이 필요하신가요?",
-      "welcome": "Kestra에 오신 것을 환영합니다"
+    "mcp": {
+      "your_servers": "내 서버",
+      "servers_count": "{count} MCP 서버",
+      "managed_by_kestra": "Kestra에서 관리",
+      "servers": "MCP 서버",
+      "server": "MCP 서버",
+      "client_setup": "클라이언트 설정",
+      "page_description": "Kestra flow를 MCP 호환 AI 에이전트의 도구로 노출하십시오.",
+      "create": "서버 생성",
+      "save": "변경 사항 저장",
+      "connect": "연결",
+      "copy_url": "URL 복사",
+      "url_copied": "URL이 복사되었습니다!",
+      "instructions": "지침",
+      "server_type": "서버 유형",
+      "auth_type": "인증",
+      "private": "비공개",
+      "private_server": "프라이빗 서버",
+      "public": "공개",
+      "public_hint": "경고: 공개 서버는 인증이 필요하지 않습니다. URL을 아는 누구나 namespace 또는 권한 확인 없이 이 서버에 의해 노출된 모든 도구를 호출할 수 있습니다. 외부에 노출해도 안전한 서버에만 사용하십시오.",
+      "basic_auth": "기본 인증",
+      "api_token": "API 토큰",
+      "oauth": "OAuth",
+      "username_password": "사용자 이름 & 비밀번호",
+      "bearer_token": "베어러 토큰 인증",
+      "oauth_hint": "OIDC 공급자의 Bearer JWT",
+      "oauth_provider": "OAuth 공급자",
+      "oauth_provider_placeholder": "구성된 OIDC 공급자 선택",
+      "oauth_provider_required": "인증 유형이 OAuth인 경우 OAuth 공급자가 필요합니다",
+      "scopes_supported": "지원되는 scope",
+      "scopes_supported_placeholder": "openid, profile, email",
+      "scopes_supported_hint": "이 서버의 Protected Resource Metadata 문서에 공개된 scope. 사양을 준수하는 MCP 클라이언트는 이 목록으로 인증 요청을 제한합니다. 필드를 생략하고 클라이언트가 IdP의 공개 scope로 대체할 수 있도록 비워 두세요.",
+      "no_oauth_providers": "이 인스턴스에 구성된 OIDC 공급자가 없습니다",
+      "delete_confirm": "이 MCP 서버를 삭제하시겠습니까?",
+      "no_servers": "MCP 서버를 찾을 수 없습니다. 외부 AI 에이전트에 MCP Tool trigger를 노출하기 위해 첫 번째 서버를 생성하세요.",
+      "server_id": "서버 ID",
+      "id_placeholder": "예: my-mcp-server",
+      "id_invalid": "ID는 소문자 또는 숫자로 시작해야 하며, 소문자, 숫자, 하이픈, 밑줄만 포함할 수 있습니다.",
+      "main_tenant": "메인",
+      "tab_edit": "편집",
+      "tab_connect": "연결",
+      "tab_tool_flows": "도구 Flows",
+      "tab_tool_flows_placeholder": "도구 flow 관리가 곧 제공됩니다.",
+      "tools": {
+        "no_tools": "검색 조건에 맞는 tool flow가 없습니다.",
+        "create_tool_flow": "도구 flow 생성",
+        "tool_name": "도구 이름",
+        "trigger_id": "Trigger ID",
+        "title": "제목",
+        "description": "설명",
+        "annotations": "어노테이션",
+        "flow": "flow",
+        "state": "상태",
+        "read_only": "읽기 전용",
+        "open_world": "Open world",
+        "destructive": "파괴적",
+        "idempotent": "멱등",
+        "return_direct": "직접 반환",
+        "view_flow": "flow 열기"
+      },
+      "connect_tab": {
+        "server_url": "서버 URL",
+        "client_picker_label": "AI 클라이언트 선택",
+        "claude_desktop": "클로드 데스크톱",
+        "claude_desktop_hint": "다음 내용을 claude_desktop_config.json 파일에 추가하십시오:",
+        "claude_desktop_mac": "macOS: ~/Library/Application Support/Claude/claude_desktop_config.json",
+        "claude_desktop_win": "Windows: %APPDATA%\\Claude\\claude_desktop_config.json",
+        "claude_code": "Claude 코드",
+        "claude_code_hint": "터미널에서 다음 명령어를 실행하세요:",
+        "cursor": "커서",
+        "cursor_hint": "~/.cursor/mcp.json에 다음을 추가하십시오:",
+        "codex": "Codex (OpenAI)",
+        "codex_hint": "귀하의 codex.json MCP 구성에 다음을 추가하십시오:",
+        "auth_basic_hint": "클라이언트를 시작하기 전에 base64로 인코딩된 <code>username:password</code> 문자열을 포함하는 <code>KESTRA_BASIC_AUTH</code>를 환경 변수로 설정하세요.",
+        "auth_api_token_hint": "클라이언트를 시작하기 전에 <code>KESTRA_TOKEN</code>을 환경 변수로 설정하세요.",
+        "auth_oauth_client_id_hint": "<code>&lt;client-id&gt;</code>를 OAuth 클라이언트 ID로 교체하고 해당 클라이언트에 유효한 리다이렉트 URI로 <code>http://localhost:7777</code>을 등록하세요.",
+        "auth_oauth_browser_hint": "첫 번째 연결 시 브라우저가 ID 공급자의 로그인 페이지를 엽니다."
+      }
     },
-    "wordmark_colors": "워드마크 색상은 배경에 따라 조정되며, 아이콘은 어두운 배경에 놓였을 때 배경 없이 유지됩니다.",
-    "worker group": "Worker 그룹",
-    "worker group fallback": "작업자 그룹 대체",
-    "worker group key": "워크 그룹 key",
-    "worker information": "작업자 정보",
-    "workerId": "Worker Id",
-    "workers": "Workers",
-    "wrong labels": "라벨에 빈 key 또는 value는 허용되지 않습니다",
-    "yes": "네"
+    "flow_editor_stats": {
+      "revisions": {
+        "suffix": "리비전(s)",
+        "tooltip": "flow 수정 보기"
+      },
+      "dependencies": {
+        "suffix": "종속성",
+        "tooltip": "flow 종속성 보기"
+      },
+      "apps": {
+        "suffix": "앱(s)",
+        "tooltip": "이 flow를 사용하는 앱 보기"
+      },
+      "tests": {
+        "suffix": "테스트",
+        "tooltip": "flow 테스트 보기"
+      },
+      "errors": {
+        "label": "{count} 오류"
+      }
+    },
+    "source_search": {
+      "match_count": "{count}개 일치 | {count}개 일치",
+      "open_flow": "flow 열기",
+      "preview_empty": "미리 볼 결과를 선택하세요. 결과 목록에서 flow를 클릭하면 소스를 확인할 수 있습니다.",
+      "preview_error": "flow 소스를 불러오지 못했습니다"
+    },
+    "open source": "오픈 소스",
+    "pricing": "가격 책정",
+    "license": "라이선스"
   }
 }

--- a/ui/src/translations/pl.json
+++ b/ui/src/translations/pl.json
@@ -1,1678 +1,722 @@
 {
   "pl": {
-    "Add flow": "Dodaj flow",
-    "Default log level": "Domyślny poziom log",
-    "Default namespace": "Domyślny namespace",
-    "Default page": "Domyślna strona",
-    "Editor fontfamily": "Rodzina czcionek edytora",
-    "Editor fontsize": "Rozmiar czcionki edytora",
-    "Editor theme": "Motyw edytora",
-    "Fold auto": "Edytor: automatyczne składanie wieloliniowych",
-    "Fold content lines": "Złóż wieloliniowe ciągi",
-    "Hover description": "Edytor: Pokaż opis pola po najechaniu na key lub value",
-    "Language": "Język",
-    "Per page": "na stronę",
-    "Set default page": "Ustaw domyślną stronę",
-    "Set labels": "Ustaw etykiety",
-    "Set labels done": "Pomyślnie ustawiono etykiety wykonania",
-    "Set labels to execution": "Dodaj lub zaktualizuj etykiety wykonania <code>{id}</code>",
-    "Set labels tooltip": "Ustaw etykiety dla wykonania",
-    "Task Id already exist in the flow": "Task Id {taskId} już istnieje w flow.",
-    "Total": "Całkowity",
-    "Unfold content lines": "Rozwiń wieloliniowe ciągi",
-    "about_this_blueprint": "O tym blueprint",
-    "absolute": "Absolutny",
-    "accept": "Zaakceptuj",
-    "actions": "Akcje",
-    "activate_basic_auth": "Aktywuj podstawowe uwierzytelnianie",
-    "active": "Aktywny",
-    "active-slots": "Aktywne sloty",
-    "actual state": "Aktualny stan",
-    "add": "Dodaj",
-    "add at position": "Dodaj {position} <code>{task}</code>",
-    "add error handler": "Dodaj handler błędów",
-    "add flow": "Dodaj flow",
+    "loading": "Ładowanie...",
+    "more actions": "Więcej akcji",
+    "toggle menu": "Przełącz menu",
+    "panel actions": "Akcje panelu",
+    "playground actions": "Akcje w Playground",
+    "bulk actions": "Akcje zbiorcze",
+    "view metrics": "Zobacz metryki",
+    "remove this item": "Usuń ten element",
     "add label": "Dodaj label",
-    "add task": "Dodaj task",
-    "add-trigger-in-editor": "Najpierw dodaj Trigger do swojego Flow",
-    "add_new_item": "Dodaj nowy element",
-    "additionalPlugins": "Dodatkowe Wtyczki",
-    "admin": "Administrator",
-    "admin_preferences": "Preferences",
-    "administration": "Administracja",
-    "advanced configuration": "Inne właściwości",
-    "after": "po",
-    "aggregation": "Agregacja",
-    "ai": {
-      "dashboard": {
-        "prompt_placeholder": "Zadaj pytanie dotyczące swoich danych. Przykładowa podpowiedź: Pokaż mi wskaźnik sukcesu moich flows z ostatnich 7 dni."
+    "remove label": "Usuń label",
+    "id": "Id",
+    "type": "Typ",
+    "ok": "OK",
+    "valid": "Prawidłowy",
+    "close": "Zamknij",
+    "namespace": "Namespace",
+    "description": "Opis",
+    "show description": "Pokaż opis",
+    "show details": "Pokaż szczegóły",
+    "show more details": "Pokaż więcej szczegółów",
+    "skipped": "Pominięto",
+    "revision": "Wersja",
+    "Language": "Język",
+    "Set default page": "Ustaw domyślną stronę",
+    "theme": "Motyw",
+    "flows": "Flows",
+    "flow": "Flow",
+    "invalid source": "Nieprawidłowy kod źródłowy",
+    "missingSource": "Brak źródła",
+    "update": "Aktualizuj",
+    "update ok": "jest zaktualizowany",
+    "delete ok": "jest usunięty",
+    "Default page": "Domyślna strona",
+    "confirmation": "Potwierdzenie",
+    "common": {
+      "back": "Wstecz"
+    },
+    "delete confirm": "Czy na pewno chcesz usunąć <code>{name}</code>?",
+    "outdated revision save confirmation": {
+      "confirm": "Czy chcesz to nadpisać?",
+      "update": {
+        "title": "Przestarzała wersja",
+        "description": "Wersja, którą edytujesz, jest przestarzała.",
+        "details": "Sprawdź zakładkę Wersje, aby uzyskać więcej informacji o najnowszej wersji."
       },
-      "flow": {
-        "enable_instructions": {
-          "footer": "Uwaga: Obecnie tylko Gemini jest obsługiwany jako dostawca AI dla Open Source Edition. W przypadku Enterprise Edition zapoznaj się z dokumentacją AI Copilot dotyczącą konfiguracji innych dostawców modeli.\n\nUruchom ponownie instancję Kestra po zapisaniu konfiguracji.",
-          "header": "<b>AI Copilot nie został jeszcze skonfigurowany.</b>\n\nAby włączyć AI Copilot, dodaj poniższy fragment do pliku konfiguracyjnego instancji Kestra (np. <code>application.yml</code>), zastępując <code>geminiApiKey</code> swoim rzeczywistym kluczem:"
-        },
-        "generating": {
-          "app": "Generowanie pliku YAML aplikacji dla Ciebie...",
-          "dashboard": "Generowanie Dashboard YAML dla Ciebie...",
-          "flow": "Generowanie YAML dla flow...",
-          "test": "Generowanie Test YAML dla Ciebie..."
-        },
-        "prompt_placeholder": "Wprowadź instrukcje, aby utworzyć swój flow w Kestra. Przykładowa podpowiedź: Utwórz flow, który uruchamia się w każdy poniedziałek o 9:00.",
-        "select_provider": "Wybierz dostawcę",
-        "title": "Agent AI"
+      "create": {
+        "title": "Flow już istnieje",
+        "description": "Flow z tym samym id już istnieje w tym namespace.",
+        "details": "Zapisz, aby nadpisać i utworzyć nową wersję."
       }
     },
-    "all executions": "Wszystkie wykonania",
-    "all tags": "Wszystkie tagi",
-    "api": "API",
-    "appBlocks": "Bloki aplikacji",
-    "apps": "Aplikacje",
-    "are you sure change state": "Czy na pewno chcesz zmienić stan?",
-    "assets": {
-      "title": "Zasoby"
+    "override": {
+      "title": "Zamierzasz nadpisać bieżący flow",
+      "details": "Poprzedni flow można przywrócić z karty Revisions."
     },
-    "attempt": "Próba",
-    "attempts": "Próba(y)",
-    "auditlogs": "Audit Logs",
-    "automatic refresh": "Automatyczne odświeżanie",
-    "avg": "Średnia",
-    "avg duration": "Średni czas trwania wykonania",
+    "is deprecated": "jest przestarzały",
+    "success": "Sukces",
+    "save": "Zapisz",
+    "save_as_draft": "Zapisz jako wersję roboczą",
+    "draft": "Wersja robocza",
+    "draft_flow_warning": "Ta rewizja flow jest wersją roboczą. Wykonanie zostanie uruchomione na tej roboczej rewizji i może natychmiast zakończyć się niepowodzeniem, jeśli definicja flow jest nieprawidłowa.",
+    "save task": "Zapisz Task",
+    "saved": "Pomyślnie zapisano",
+    "saved as draft": "Pomyślnie zapisano jako wersję roboczą",
+    "saved done": "<em>{name}</em> został pomyślnie zapisany",
+    "saved as draft done": "<em>{name}</em> został pomyślnie zapisany jako wersja robocza",
+    "multiple saved done": "{name} został zapisany",
+    "fileTypeNotAllowed": "Niedozwolony typ pliku. Akceptowane typy: {types}",
+    "delete": "Usuń",
+    "deleted": "Pomyślnie usunięto",
+    "deleted confirm": "<em>{name}</em> został pomyślnie usunięty!",
+    "Add flow": "Dodaj flow",
+    "add": "Dodaj",
+    "add_new_item": "Dodaj nowy element",
+    "copy": "Kopiuj",
+    "copy_to_clipboard": "Kopiuj do schowka",
+    "copy_and_close": "Skopiuj i zamknij",
+    "Per page": "na stronę",
+    "new": "Nowy",
+    "edit": "Edytuj",
     "back": "Wstecz",
-    "back_to_dashboard": "Powrót do pulpitu",
-    "backfill": "Backfill",
-    "backfill executions": "Backfill wykonania",
-    "backfill paused": "Wstrzymano backfill",
-    "backfill running": "Backfill uruchomiony",
-    "bar": "Bar",
-    "before": "przed",
-    "behavior": "Zachowanie",
-    "blueprints": {
-      "all": "Wszystkie",
-      "apps": "Szablony aplikacji",
-      "community": "Społeczność",
-      "create": "Utwórz blueprint",
-      "custom": "Niestandardowe blueprints",
-      "dashboards": "Dashboard Blueprinty",
-      "detail": {
-        "category": "Typ kategorii",
-        "links": "Linki i zasoby",
-        "openInEditor": "Otwórz w Edytuj Flow"
-      },
-      "edit": "Edytuj blueprint",
-      "empty": "Brak blueprintów do wyświetlenia.",
-      "flows": "Schematy Flow",
-      "header": {
-        "alt": "Ikona Blueprintów",
-        "catch phrase": {
-          "1": "Pierwszy krok jest zawsze najtrudniejszy.",
-          "2": "Eksploruj blueprints, aby rozpocząć swój następny {kind}."
-        }
-      },
-      "missingPlugins": {
-        "card": "Wymaga pluginów niezainstalowanych w tej instancji: {plugins}",
-        "description": "Ten blueprint używa tasków z pluginów, które nie są zainstalowane w tej instancji: {plugins}. Zainstaluj je, aby użyć tego blueprintu.",
-        "install": "Zainstaluj pluginy",
-        "title": "Brakujące pluginy"
-      },
-      "title": "Blueprints"
+    "next": "Dalej",
+    "done": "Gotowe",
+    "review your inputs": "Sprawdź swoje dane wejściowe",
+    "edit flow": "Edytuj flow",
+    "executions": "Wykonania",
+    "execution": "Wykonanie",
+    "execution id": "Id wykonania",
+    "recent_executions": "Ostatnie Wykonania",
+    "details": "Szczegóły",
+    "overview": "Przegląd",
+    "gantt": "Gantt",
+    "gantt_no_tasks_executed": "Ta wykonanie zakończyło się bez uruchomienia żadnego taska.\nSprawdź jego podsumowanie i logi, aby poznać przyczynę.",
+    "gantt_no_tasks_match_filters": "Spróbuj dostosować filtry wyszukiwania, stanu lub poziomu logów.",
+    "gantt_no_tasks_match_filters_title": "Brak zadań pasujących do wybranych filtrów.",
+    "logs": "Logs",
+    "no_logs_data": "Brak danych",
+    "no_logs_data_description": "Spróbuj dostosować filtry, zmienić zakres czasu lub sprawdź, czy flow został ostatnio wykonany.",
+    "no_logs_data_title": "Nie znaleziono logów dla wybranych filtrów.",
+    "duration": "Czas trwania",
+    "total_duration": "Całkowity czas trwania",
+    "running duration": "Czas trwania w trakcie działania",
+    "queued duration": "Czas trwania w kolejce",
+    "choose file": "Wybierz plik lub upuść go tutaj...",
+    "launch execution": "Wykonaj",
+    "warning flow with triggers": "Ten flow zawiera triggery i ręczne wykonanie zakończy się niepowodzeniem, jeśli ten flow zależy od wyrażeń trigger.",
+    "triggered": "Execution trigger",
+    "triggered done": "Wykonanie <em>{name}</em> zostało pomyślnie uruchomione",
+    "topology": "Topologia",
+    "date": "Data",
+    "prev_execution": "Poprzednia wykonanie",
+    "next_execution": "Następne wykonanie",
+    "datepicker": {
+      "leave empty for infinite": "Pozostaw puste dla nieskończonego czasu trwania lub wpisz czas trwania w formacie ISO 8601 (przykład: 'P1DT1H1M1S)'",
+      "duration example": "Przykład: 'P1DT1H1M1S'",
+      "error": "Nieprawidłowy format czasu trwania, musi być w formacie ISO 8601 (np. P1DT1H1M1S)",
+      "custom": "Niestandardowy",
+      "last5minutes": "Ostatnie 5 minut",
+      "last15minutes": "Ostatnie 15 minut",
+      "last1hour": "Ostatnia 1 godzina",
+      "last12hours": "Ostatnie 12 godzin",
+      "last24hours": "Ostatnie 24 godziny",
+      "last48hours": "Ostatnie 48 godzin",
+      "last7days": "Ostatnie 7 dni",
+      "last30days": "Ostatnie 30 dni",
+      "last365days": "Ostatnie 365 dni",
+      "next5minutes": "Następne 5 minut",
+      "next15minutes": "Następne 15 minut",
+      "next1hour": "Następna 1 godzina",
+      "next12hours": "Następne 12 godzin",
+      "next24hours": "Następne 24 godziny",
+      "next48hours": "Następne 48 godzin",
+      "next7days": "Następne 7 dni",
+      "next30days": "Następne 30 dni",
+      "next365days": "Następne 365 dni",
+      "5minutes": "5 minut",
+      "15minutes": "15 minut",
+      "1hour": "1 godzina",
+      "12hours": "12 godzin",
+      "24hours": "24 godziny",
+      "48hours": "48 godzin",
+      "7days": "7 dni",
+      "30days": "30 dni",
+      "365days": "365 dni",
+      "never": "Nigdy",
+      "today": "Dzisiaj",
+      "yesterday": "Wczoraj",
+      "dayBeforeYesterday": "Przedwczoraj",
+      "thisWeek": "Ten tydzień",
+      "thisWeekSoFar": "Ten tydzień do tej pory",
+      "previousWeek": "Poprzedni tydzień",
+      "thisMonth": "Ten miesiąc",
+      "thisMonthSoFar": "Ten miesiąc do tej pory",
+      "previousMonth": "Poprzedni miesiąc",
+      "thisYear": "Ten rok",
+      "thisYearSoFar": "Ten rok do tej pory",
+      "previousYear": "Poprzedni rok",
+      "short": {
+        "15m": "15 min",
+        "1h": "1h",
+        "12h": "12h",
+        "1d": "1d",
+        "7d": "7d"
+      }
     },
-    "body_line_clamp": "Limit line height",
-    "bookmark": "Zakładki",
-    "breakpoints": "Punkty przerwania",
-    "bulk action async warning": "To może zająć kilka chwil.",
-    "bulk actions": "Akcje zbiorcze",
-    "bulk change state": "Czy na pewno chcesz zmienić stan <code>{executionCount}</code> wykonania/wykonań?",
-    "bulk delete": "Czy na pewno chcesz usunąć <code>{executionCount}</code> wykonanie(a)?",
-    "bulk delete backfills": "Usuń {count} backfill",
-    "bulk delete triggers": "Czy na pewno chcesz usunąć {count} triggerów?",
-    "bulk disabled status": {
-      "false": "Włącz {count} triggers",
-      "true": "Wyłącz {count} triggers"
+    "created date": "Data utworzenia",
+    "latest_update": "Najnowsza aktualizacja",
+    "updated date": "Data aktualizacji",
+    "expiration date": "Data wygaśnięcia",
+    "started date": "Data rozpoczęcia",
+    "healthcheck date": "Data HealthCheck",
+    "next execution date": "Data następnego wykonania",
+    "last execution status": "Ostatni status wykonania",
+    "jump to...": "Przejdź do...",
+    "contextBar": {
+      "news": "Wiadomości",
+      "docs": "Dokumentacja",
+      "help": "Pomoc",
+      "issue": "Problem",
+      "demo": "Demo",
+      "star": "Oceń nas gwiazdkami"
     },
-    "bulk force run": "Czy na pewno chcesz wymusić uruchomienie <code>{executionCount}</code> wykonania/ń?<br/><br/>WARNING: wymuszenie uruchomienia wykonania nie jest gwarantowane i może spowodować duplikaty wykonania tasków.<br/><br/>Zostaną wykonane następujące przejścia:<br/><ul><li>Taski w stanie CREATED zostaną przeniesione do stanu RUNNING.</li><li>Taski w stanie RUNNING zostaną ponownie przesłane.</li><li>Taski w stanie QUEUED zostaną odkolejkowane.</li><li>Taski w stanie PAUSED zostaną wznowione.</li></ul>",
-    "bulk kill": "Czy na pewno chcesz zabić <code>{executionCount}</code> wykonanie(a)?",
-    "bulk pause": "Czy na pewno chcesz wstrzymać wykonanie <code>{executionCount}</code>?",
-    "bulk pause backfills": "Wstrzymaj {count} backfill",
-    "bulk replay": "Czy na pewno chcesz odtworzyć <code>{executionCount}</code> wykonanie(a)?",
-    "bulk restart": "Czy na pewno chcesz zrestartować <code>{executionCount}</code> wykonanie(a)?",
-    "bulk resume": "Czy na pewno chcesz wznowić <code>{executionCount}</code> wykonanie(a)?",
-    "bulk set labels": "Czy na pewno chcesz ustawić etykiety dla <code>{executionCount}</code> wykonanie(a)?",
-    "bulk success delete backfills": "{count} backfills usunięte",
-    "bulk success delete triggers": "Pomyślnie usunięto {count} triggerów",
-    "bulk success disabled status": {
-      "false": "{count} trigger(s) włączone",
-      "true": "{count} trigger(s) wyłączone"
+    "source": "Źródło",
+    "source only": "Tylko źródło",
+    "home": "Strona główna",
+    "create": "Utwórz",
+    "create_flow": "Utwórz Flow",
+    "add flow": "Dodaj flow",
+    "from": "Od",
+    "to": "Do",
+    "search filters": {
+      "saved": "Zapisane filtry",
+      "manage": "Zarządzaj filtrami wyszukiwania",
+      "manage desc": "Zarządzaj zapisanymi filtrami wyszukiwania",
+      "save filter": "Zapisz filtr",
+      "filter name": "Nazwa filtra",
+      "filters": "Filtry"
     },
-    "bulk success pause backfills": "{count} backfills wstrzymane",
-    "bulk success unlock": "{count} triggers odblokowane",
-    "bulk success unpause backfills": "{count} backfills wznowione",
-    "bulk unlock": "Odblokuj {count} triggers",
-    "bulk unpause backfills": "Wznów {count} backfill",
-    "bulk unqueue": "Czy na pewno chcesz usunąć z kolejki <code>{executionCount}</code> wykonanie(a)?",
-    "can not delete": "Nie można usunąć",
-    "can not have less than 1 task": "Każdy flow musi mieć przynajmniej jeden task.",
-    "can not save": "Nie można zapisać",
-    "cancel": "Anuluj",
+    "steps": "Kroki",
+    "state": "Stan",
+    "state_history": "Historia stanu",
+    "search term in message": "Wyszukaj termin w wiadomości",
+    "search": "Szukaj",
+    "search blueprint": "Wyszukaj blueprints",
+    "all tags": "Wszystkie tagi",
+    "source search": "Wyszukaj źródło",
+    "filter by log level": "Filtruj według poziomu log",
+    "selected": "Wybrane",
+    "task": "Task",
+    "task logs": "Task logs",
+    "display flow {id} executions": "Wyświetl wykonania flow {id}",
+    "actions": "Akcje",
+    "select datetime": "Wybierz datę",
+    "select view": "Wybierz widok",
+    "invalid field": "Nieprawidłowe pole: {name}",
+    "required field": "Wymagane pole",
+    "is required": "Pole {field} jest wymagane",
+    "error": "Błąd",
+    "form": "Formularz",
+    "form error": "Błąd formularza",
+    "display topology for flow": "Wyświetl topologię dla flow",
     "cannot create topology": "Nie można utworzyć topologii dla flow",
-    "cannot swap tasks": "Nie można zamienić tasks",
-    "change execution state confirm": "Czy na pewno chcesz zmienić stan wykonania <code>{id}</code>?",
-    "change execution state done": "Stan wykonania zaktualizowany",
-    "change queue confirm": "Czy na pewno chcesz zmienić stan kolejki dla wykonania <code>{id}</code>?<br/>",
+    "start date": "Data rozpoczęcia",
+    "end date": "Data zakończenia",
+    "creation": "Utworzenie",
+    "flow creation": "Utworzenie flow",
+    "start datetime": "Data i godzina rozpoczęcia",
+    "end datetime": "Data i godzina zakończenia",
+    "restart": "Uruchom ponownie",
+    "restart latest revision": "Uruchom ponownie najnowszą wersję",
+    "restart tooltip": "Uruchom ponownie wykonanie od task <code>{state}</code>",
+    "restarted": "Wykonanie zostało ponownie uruchomione",
+    "restart confirm": "Czy na pewno chcesz ponownie uruchomić wykonanie <code>{id}</code>?",
+    "restart change revision": "Możesz zmienić wersję, która będzie używana do nowego wykonania.",
+    "replay": "Odtwórz",
+    "replay from task tooltip": "Utwórz podobne wykonanie zaczynając od task <code>{taskId}</code>",
+    "replay from beginning tooltip": "Utwórz podobne wykonanie zaczynając od początku",
+    "replay latest revision": "Odtwórz używając najnowszej wersji",
+    "replayed": "Wykonanie jest odtwarzane",
+    "replay confirm": "Czy na pewno chcesz odtworzyć to wykonanie <code>{id}</code> i utworzyć nowe?",
+    "replay with inputs": "Odtwórz z inputami",
+    "reuse_original_inputs": "Ponownie użyj oryginalnych inputów",
+    "modify_inputs": "Modyfikuj inputy",
+    "replay the execution": "Odtwórz wykonanie <code>{executionId}</code> dla flow <code>{flowId}</code>",
+    "prefill inputs": "Wypełnij",
+    "current": "bieżący",
     "change state": "Zmień stan",
-    "change state confirm": "Czy na pewno chcesz zmienić stan uruchomienia task dla task <code>{task}</code> w wykonaniu <code>{id}</code>?",
-    "change state current state": "Aktualny status to:",
+    "actual state": "Aktualny stan",
+    "select a state": "Wybierz stan",
+    "are you sure change state": "Czy na pewno chcesz zmienić stan?",
+    "yes": "Tak",
     "change state done": "Stan task został zaktualizowany",
+    "change state confirm": "Czy na pewno chcesz zmienić stan uruchomienia task dla task <code>{task}</code> w wykonaniu <code>{id}</code>?",
+    "change queue confirm": "Czy na pewno chcesz zmienić stan kolejki dla wykonania <code>{id}</code>?<br/>",
+    "change state current state": "Aktualny status to:",
     "change state hint": {
+      "WARNING": [
+        "Flow zostanie oznaczony jako WARNING.",
+        "Następne taski zostaną wykonane.",
+        "Taski błędów zostaną wykonane."
+      ],
       "FAILED": [
         "Flow zostanie oznaczony jako FAILED.",
         "Żadne inne task nie będą wykonane.",
         "Task błędów będą wykonane."
-      ],
-      "RUNNING": [
-        "Flow zostanie ponownie uruchomiony i wykona wszystkie kolejne taski.",
-        "Wszystkie zablokowane taski zostaną wykonane."
       ],
       "SUCCESS": [
         "Flow zostanie uruchomiony ponownie, ponieważ ten task zakończył się sukcesem.",
         "Wszystkie zablokowane taski zostaną wykonane.",
         "Flow będzie w stanie SUCCESS, jeśli wszystkie uruchomienia tasków zakończą się sukcesem."
       ],
-      "WARNING": [
-        "Flow zostanie oznaczony jako WARNING.",
-        "Następne taski zostaną wykonane.",
-        "Taski błędów zostaną wykonane."
+      "RUNNING": [
+        "Flow zostanie ponownie uruchomiony i wykona wszystkie kolejne taski.",
+        "Wszystkie zablokowane taski zostaną wykonane."
       ]
     },
+    "replay execution title": "Ponowne wykonanie",
+    "restart execution title": "Uruchom ponownie wykonanie",
+    "replay execution description": "To utworzy nową wykonanie na podstawie wybranego wykonania.",
+    "replay using": "Odtwórz używając",
+    "flow revision original": "Oryginalna wersja flow",
+    "flow revision latest": "Najnowsza wersja flow",
+    "flow revision specific": "Specyficzna wersja flow",
+    "replay inputs": "Wejścia",
+    "reuse original inputs": "Ponownie użyj oryginalnych inputów",
+    "modify inputs": "Modyfikuj inputy",
+    "replay inputs new required": "Ta wersja ma inputy. Zostaniesz poproszony o ich wypełnienie.",
+    "replay select taskrun": "Wybierz uruchomienie task do ponownego odtworzenia z:",
     "change state tooltip": "Zmień stan wykonania",
-    "chart": "Wykres",
-    "chart preview": "Podgląd wykresu",
-    "chart type": "Typ wykresu",
-    "charts": "Wykresy",
-    "choice": "Wybór",
-    "choose file": "Wybierz plik lub upuść go tutaj...",
-    "close": "Zamknij",
-    "close sidebar": "zamknij pasek boczny",
-    "codeDisabled": "Wyłączone w flow",
-    "collapse": "Zwiń",
-    "collapse all": "Zwiń wszystko",
-    "commit_id": "Id commit",
-    "common": {
-      "back": "Wstecz"
-    },
-    "concurrency": "Współbieżność",
-    "concurrency limits": "Limity Równoczesności",
-    "concurrency_limit": {
-      "dialog_title": "Limity Równoczesności",
-      "warning": "Zmiana bieżącego licznika może uszkodzić współbieżność, co może spowodować przekroczenie dozwolonego limitu przez wykonania."
-    },
-    "conditions": "Warunki",
-    "configure basic auth": "Skonfiguruj podstawowe uwierzytelnianie",
-    "confirm": "Potwierdź",
-    "confirm password": "Potwierdź hasło",
-    "confirmation": "Potwierdzenie",
-    "context updated date": "Data aktualizacji kontekstu",
-    "context updated date tooltip": "Kiedy kontekst triggera został ostatnio zaktualizowany. Dzieje się to, gdy wykonanie jest uruchamiane, kończy się (blokada zwolniona) lub po ocenie (nawet jeśli nie dochodzi do wykonania).",
-    "contextBar": {
-      "demo": "Demo",
-      "docs": "Dokumentacja",
-      "help": "Pomoc",
-      "issue": "Problem",
-      "news": "Wiadomości",
-      "star": "Oceń nas gwiazdkami"
-    },
-    "continue backfill": "Kontynuuj backfill",
-    "continue backfills": "Kontynuuj backfills",
-    "copied": "Skopiowano",
-    "copied_logs_to_clipboard": "Skopiowano logi do schowka.",
-    "copy": "Kopiuj",
-    "copy all logs": "Skopiuj wszystkie Logi",
-    "copy logs": "Kopiuj logs",
-    "copy url": "Kopiuj URL",
-    "copy_and_close": "Skopiuj i zamknij",
-    "copy_to_clipboard": "Kopiuj do schowka",
-    "copy_value": "Copy value",
-    "create": "Utwórz",
-    "create first task": "Stwórz swój pierwszy task",
-    "create_flow": "Utwórz Flow",
-    "created date": "Data utworzenia",
-    "creation": "Utworzenie",
-    "cron": "Kron",
-    "curl": {
-      "command": "Komenda cURL",
-      "note": "Pamiętaj, że dla typu input SECRET i FILE, polecenie musi być dostosowane do rzeczywistych wartości."
-    },
-    "current": "bieżący",
-    "current execution": "Bieżące wykonanie",
-    "custom value": "Wartość niestandardowa",
-    "customize sidebar": "Dostosuj pasek boczny",
-    "dark_version": "Ciemna wersja",
-    "dashboards": {
-      "chart_preview": "Kliknij kod źródłowy wykresu, aby zobaczyć jego podgląd",
-      "creation": {
-        "confirmation": "Dashboard <code>{title}</code> został utworzony.",
-        "label": "Utwórz Dashboard"
-      },
-      "default": "Domyślny Dashboard",
-      "deletion": {
-        "confirmation": "Czy na pewno chcesz usunąć dashboard <code>{title}</code>?"
-      },
-      "edition": {
-        "chart": "Edytuj ten wykres",
-        "confirmation": "Zmiany w dashboardzie <code>{title}</code> zostały zapisane.",
-        "id readonly": "Właściwość `id` nie może być zmieniona — jest teraz ustawiona na swoje początkowe wartości. Jeśli chcesz ją zmienić, możesz utworzyć nowy dashboard i usunąć stary.",
-        "label": "Edytuj Dashboard"
-      },
-      "empty": "Brak wyników do wyświetlenia.",
-      "export": "Eksportuj do CSV",
-      "labels": {
-        "plural": "Dashboardy",
-        "singular": "Dashboard"
-      },
-      "no_description": "Brak opisu",
-      "no_description_hint": "Dodaj opis do tego flow, aby udokumentować, co robi.<br>Markdown jest obsługiwany.",
-      "others": "Inne",
-      "preview": "Podgląd Dashboardu",
-      "quick_filters": {
-        "all": "Wszystkie",
-        "failed": "Nieudane",
-        "paused": "Wstrzymano",
-        "running": "Uruchomione",
-        "success": "Sukces",
-        "warning": "Ostrzeżenie"
-      },
-      "switch": "Przełącz Dashboard",
-      "viewAll": "Pokaż wszystko"
-    },
-    "data": "Dane",
-    "dataFilters": "Filtry Danych",
-    "data_not_protected": "Twoje dane nie są chronione. Nie trać ich. <b>Włącz nasze darmowe funkcje zabezpieczeń lub wypróbuj naszą płatną ofertę.</b>",
-    "date": "Data",
-    "date count": "{count} w dniu {date}",
-    "date format": "Format daty",
-    "date range count": "{count} między {startDate} a {endDate}",
-    "datepicker": {
-      "12hours": "12 godzin",
-      "15minutes": "15 minut",
-      "1hour": "1 godzina",
-      "24hours": "24 godziny",
-      "30days": "30 dni",
-      "365days": "365 dni",
-      "48hours": "48 godzin",
-      "5minutes": "5 minut",
-      "7days": "7 dni",
-      "custom": "Niestandardowy",
-      "dayBeforeYesterday": "Przedwczoraj",
-      "duration example": "Przykład: 'P1DT1H1M1S'",
-      "error": "Nieprawidłowy format czasu trwania, musi być w formacie ISO 8601 (np. P1DT1H1M1S)",
-      "last12hours": "Ostatnie 12 godzin",
-      "last15minutes": "Ostatnie 15 minut",
-      "last1hour": "Ostatnia 1 godzina",
-      "last24hours": "Ostatnie 24 godziny",
-      "last30days": "Ostatnie 30 dni",
-      "last365days": "Ostatnie 365 dni",
-      "last48hours": "Ostatnie 48 godzin",
-      "last5minutes": "Ostatnie 5 minut",
-      "last7days": "Ostatnie 7 dni",
-      "leave empty for infinite": "Pozostaw puste dla nieskończonego czasu trwania lub wpisz czas trwania w formacie ISO 8601 (przykład: 'P1DT1H1M1S)'",
-      "never": "Nigdy",
-      "next12hours": "Następne 12 godzin",
-      "next15minutes": "Następne 15 minut",
-      "next1hour": "Następna 1 godzina",
-      "next24hours": "Następne 24 godziny",
-      "next30days": "Następne 30 dni",
-      "next365days": "Następne 365 dni",
-      "next48hours": "Następne 48 godzin",
-      "next5minutes": "Następne 5 minut",
-      "next7days": "Następne 7 dni",
-      "previousMonth": "Poprzedni miesiąc",
-      "previousWeek": "Poprzedni tydzień",
-      "previousYear": "Poprzedni rok",
-      "short": {
-        "12h": "12h",
-        "15m": "15 min",
-        "1d": "1d",
-        "1h": "1h",
-        "7d": "7d"
-      },
-      "thisMonth": "Ten miesiąc",
-      "thisMonthSoFar": "Ten miesiąc do tej pory",
-      "thisWeek": "Ten tydzień",
-      "thisWeekSoFar": "Ten tydzień do tej pory",
-      "thisYear": "Ten rok",
-      "thisYearSoFar": "Ten rok do tej pory",
-      "today": "Dzisiaj",
-      "yesterday": "Wczoraj"
-    },
-    "debug": "Debugowanie",
-    "default": "Domyślny",
-    "defaultsToNamespaceFile": "Domyślnie do pliku namespace: <code>{name}</code>",
-    "delete": "Usuń",
-    "delete backfill": "Usuń backfill",
-    "delete backfills": "Usuń backfills",
-    "delete confirm": "Czy na pewno chcesz usunąć <code>{name}</code>?",
-    "delete execution running": "<div class=\"alert alert-warning mt-2 mb-0\">To wykonanie jest nadal w trakcie, usunięcie go nie zatrzyma procesu.<br />Musisz zabić wykonanie, aby je zatrzymać.</div>",
-    "delete logs": "Usuń logs",
-    "delete ok": "jest usunięty",
-    "delete revision confirm": "Czy na pewno chcesz usunąć wersję {revision}?",
-    "delete revision error": "Błąd usuwania wersji {revision} z błędem {error}",
-    "delete task confirm": "Czy chcesz usunąć task <code>{taskId}</code>?",
-    "delete trigger": "Usuń trigger",
-    "delete trigger confirmation": "Czy na pewno chcesz usunąć trigger {id}? WARNING: usunięcie triggera może prowadzić do zduplikowanych wykonania, jeśli trigger jest nadal aktywny w flow.",
-    "delete trigger error": "Błąd podczas usuwania triggera {id}",
-    "delete trigger success": "Trigger {id} został pomyślnie usunięty",
-    "delete triggers": "Usuń triggery",
-    "delete_all_logs": "Czy na pewno chcesz usunąć wszystkie logs?",
-    "delete_log": "Czy na pewno chcesz usunąć log?",
-    "deleted": "Pomyślnie usunięto",
-    "deleted confirm": "<em>{name}</em> został pomyślnie usunięty!",
-    "deleted_label": "Usunięto",
-    "demos": {
-      "IAM": {
-        "message": "Kestra Enterprise Edition ma wbudowane funkcje IAM z jednokrotnym logowaniem (SSO), synchronizacją katalogu SCIM i kontrolą dostępu opartą na rolach (RBAC), integrując się z wieloma dostawcami tożsamości i pozwalając na przypisywanie szczegółowych uprawnień dla użytkowników i kont usługowych.",
-        "title": "Zarządzaj użytkownikami przez IAM z SSO, SCIM i RBAC"
-      },
-      "apps": {
-        "message": "Aplikacje w Kestra Enterprise Edition umożliwiają tworzenie niestandardowych interfejsów użytkownika, które współdziałają z workflowami Kestra spoza platformy. Ta funkcja pozwala używać workflowów jako backendu dla niestandardowych aplikacji, umożliwiając użytkownikom nietechnicznym przesyłanie danych za pomocą formularzy lub wznawianie PAUSED workflowów oczekujących na zatwierdzenie.",
-        "title": "Twórz własne aplikacje z Kestra"
-      },
-      "assets": {
-        "header": "Metadane zasobów i obserwowalność",
-        "label": "Zasoby",
-        "message": "Zasoby łączą metadane dotyczące obserwowalności, pochodzenia i własności, aby zespoły platformowe mogły szybciej rozwiązywać problemy i wdrażać z pewnością.",
-        "title": "Przenieś każdy zestaw danych, usługę i zależność do widoku."
-      },
-      "audit-logs": {
-        "message": "Kestra Enterprise Edition rejestruje każdą aktywność za pomocą solidnych, niezmiennych zapisów, co ułatwia śledzenie zmian, utrzymanie zgodności oraz rozwiązywanie problemów.",
-        "title": "Śledź zmiany za pomocą Audit Logs"
-      },
-      "blueprints": {
-        "message": "W Kestra Enterprise Edition możesz tworzyć niestandardowe Blueprints dostępne tylko dla Twojej organizacji. Możesz ich używać jako szablonów najlepszych praktyk do udostępniania, centralizowania i dokumentowania często używanych workflow w Twoim zespole.",
-        "title": "Dodaj niestandardowe Blueprints"
-      },
-      "contact_sales": "Skontaktuj się z działem sprzedaży",
-      "enterprise_edition": "Enterprise Edition",
-      "get_a_demo_button": "Uzyskaj Demo",
-      "instance": {
-        "message": "Kestra Enterprise Edition zapewnia operacyjny dashboard, który pomaga obserwować stan zdrowia Twojej platformy i śledzić metryki dostępności wszystkich usług, takich jak m.in. Workers, Schedulers i Executors. Z tej samej strony możesz również tworzyć Ogłoszenia, aby powiadomić użytkowników o planowanych przerwach, a także możesz wprowadzić tryb konserwacji, który tymczasowo wprowadza wszystkie usługi i wykonania workflow w stan PAUSED, aby przeprowadzić aktualizację.",
-        "title": "Zarządzaj infrastrukturą w całej swojej instancji"
-      },
-      "namespace": {
-        "assets": {
-          "message": "W Kestra Enterprise Edition, Assets prowadzi bieżący inwentarz zasobów, z którymi współpracują Twoje workflow. Te zasoby mogą być tabelami baz danych, maszynami wirtualnymi, plikami lub dowolnym zewnętrznym systemem, z którym pracujesz.",
-          "title": "Centralizacja zarządzania zasobami"
-        },
-        "audit-logs": {
-          "message": "W Kestra Enterprise Edition możesz przeglądać dzienniki audytu na poziomie namespace z szczegółowymi różnicami, co daje jasną historię, kto, co i kiedy zmienił we wszystkich zasobach.",
-          "title": "Śledź wszystkie zmiany w jednym miejscu"
-        },
-        "edit": {
-          "message": "W Kestra Enterprise Edition, namespaces zapewniają zaawansowaną izolację i zarządzanie tajemnicami, zmiennymi oraz domyślnymi ustawieniami pluginów na dużą skalę. Administratorzy mogą konfigurować niestandardowych menedżerów tajemnic, izolowane zaplecza pamięci, dedykowane grupy workerów oraz szczegółowe uprawnienia na poziomie namespace. To zapewnia, że tajemnice, zmienne i konfiguracje pluginów pozostają bezpieczne i łatwe do utrzymania w różnych zespołach i projektach.",
-          "title": "Ulepsz zarządzanie Namespace"
-        },
-        "history": {
-          "message": "W Kestra Enterprise Edition możesz zarządzać historią wersji swoich namespace.",
-          "title": "Zarządzaj historią wersji w jednym miejscu"
-        },
-        "plugin-defaults": {
-          "message": "W Kestra Enterprise Edition możesz ustawić domyślne wtyczki specyficzne dla namespace, co zmniejsza potrzebę powielania konfiguracji w każdym flow. To centralne zarządzanie wtyczkami zapewnia spójne konfiguracje, umożliwia bezpieczne odwoływanie się do sekretów lub zmiennych oraz upraszcza utrzymanie twoich workflow.",
-          "title": "Standaryzuj konfigurację za pomocą domyślnych ustawień Pluginów"
-        },
-        "secrets": {
-          "message": "W Kestra Enterprise Edition możesz przechowywać i kontrolować tajemnice na poziomie namespace, minimalizując ryzyko i zapewniając izolację danych uwierzytelniających każdego zespołu. Dzięki zagnieżdżonej hierarchii możesz również skonfigurować dane uwierzytelniające w nadrzędnym namespace, a zostaną one odziedziczone przez wszystkie podrzędne namespaces. Wsparcie dla dedykowanych menedżerów tajemnic oraz szczegółowe ustawienia uprawnień na poziomie namespace dodatkowo wzmacniają bezpieczeństwo i zgodność.",
-          "title": "Zarządzaj sekretami w bezpieczny sposób"
-        },
-        "variables": {
-          "message": "W Kestra Enterprise Edition możesz definiować i zarządzać zmiennymi na poziomie namespace, aby wyeliminować powtarzające się konfiguracje w różnych flow. Te zmienne zapewniają spójność, upraszczają aktualizacje konfiguracji i mogą być łatwo odwoływane przez dowolny task lub trigger, co prowadzi do czystszych i łatwiejszych w utrzymaniu workflow.",
-          "title": "Centralnie Zarządzaj Swoimi Zmiennymi"
-        }
-      },
-      "quotas": {
-        "message": "Kestra Enterprise Edition umożliwia definiowanie kwot dla flows w celu ograniczenia liczby równoczesnych lub łącznych wykonań w danym oknie czasowym. Kwoty pomagają chronić współdzieloną infrastrukturę, egzekwować SLA i zapobiegać nadmiernemu zużyciu zasobów przez niekontrolowane workflows.",
-        "title": "Egzekwowanie kwot wykonania dla flows"
-      },
-      "secrets": {
-        "add_env": {
-          "first": "Zakoduj <a href=\"https://kestra.io/docs/how-to-guides/secrets?utm_source=app&utm_medium=referral&utm_campaign=secrets-inlinedoc#using-secrets-in-kestra\" target=\"_blank\">wartość secret w Base64</a>",
-          "intro": "Aby utworzyć nowy Secret:",
-          "second": "Dodaj zmienną środowiskową o nazwie '<strong>SECRET_{'{MY_SECRET_KEY}'}</strong>' z powyższą wartością",
-          "third": "Uruchom ponownie instancję Kestra"
-        },
-        "detected_env": "Oto zmienne środowiskowe typu secret zidentyfikowane podczas uruchamiania instancji:",
-        "empty_env": "Nie masz jeszcze żadnych Secrets w swoim środowisku.",
-        "message": "Edycja Enterprise (EE) pozwala na dodawanie, edytowanie lub usuwanie sekretów bezpośrednio w UI — bez potrzeby ponownego uruchamiania instancji. Organizuj sekrety według namespace z precyzyjnymi uprawnieniami RBAC i dziedzicz je z namespace nadrzędnych do podrzędnych. EE integruje się z menedżerami sekretów, takimi jak HashiCorp Vault, AWS Secrets Manager, Azure Key Vault, Google Secret Manager i Elasticsearch. Skonfiguruj dedykowane backendy dla każdego namespace, mandanta lub instancji, aby izolować sekrety w zespołach, lub włącz sekrety tylko do odczytu przechowywane w zewnętrznych vaultach. Sekrety pozostają zaszyfrowane w spoczynku i podczas przesyłania. Opcjonalne buforowanie zmniejsza liczbę wywołań API, a ścieżki audytu logują cały dostęp.",
-        "title": "Ulepsz swoje zarządzanie Secrets Management"
-      },
-      "tenants": {
-        "message": "Kestra Enterprise Edition obsługuje multi-tenancy, zapewniając w pełni izolowane środowiska dla różnych zespołów lub projektów, z własnymi zasobami, takimi jak dedykowane grupy workerów, sekrety i wewnętrzne magazyny danych.",
-        "title": "Zarządzaj przepływami pracy w izolowanych tenantach"
-      },
-      "tests": {
-        "header": "Testy jednostkowe dla flowów",
-        "label": "Testy",
-        "message": "Zweryfikuj logikę swoich flow w izolacji, wcześnie wykrywaj regresje i utrzymuj pewność w swoich automatyzacjach, gdy się zmieniają i rozwijają.",
-        "title": "Zapewnij niezawodność przy każdej zmianie"
-      },
-      "watch_the_video": "Obejrzyj wideo"
-    },
-    "density": "Density",
-    "density_compact": "Compact",
-    "density_expanded": "Expanded",
-    "density_normal": "Normal",
-    "dependencies": "Zależności",
-    "dependencies delete flow": "Ten flow ma zależności. Usunięcie go uniemożliwi wykonanie ich zależności.<br /><br /> Oto lista dotkniętych flows:",
-    "dependencies loaded": "Zależności załadowane",
-    "dependencies missing acls": "Brak uprawnień do tego flow",
-    "dependency": {
-      "controls": {
-        "clear_selection": "Wyczyść zaznaczenie",
-        "fit_view": "Dopasuj do ekranu",
-        "zoom_in": "Powiększ",
-        "zoom_out": "Oddal"
-      },
-      "search": {
-        "flow": {
-          "display": "Uwzględnij zależności flow"
-        },
-        "namespace": {
-          "no_namespace": "Bez namespace",
-          "select": "Wybierz namespace"
-        },
-        "no_results": "Nie znaleziono wyników dla {term}",
-        "placeholders": {
-          "asset": "Szukaj według asset, flow lub namespace...",
-          "default": "Szukaj według flow lub namespace..."
-        }
-      }
-    },
-    "dependency task": "Task {taskId} jest zależnością innego task",
-    "description": "Opis",
-    "details": "Szczegóły",
-    "disable": "Wyłącz",
-    "disabled": "Wyłączone",
-    "disabled flow desc": "Ten flow jest wyłączony, proszę włączyć go, aby go wykonać.",
-    "disabled flow title": "Ten flow jest wyłączony",
-    "discard changes confirmation": "Masz niezapisane zmiany. Czy na pewno chcesz je odrzucić?",
-    "discard execution confirmation": "Masz niezapisane inputy. Czy na pewno chcesz odrzucić tę wykonanie?",
-    "display direct sub tasks count": "Wyświetl bezpośrednią liczbę subtask",
-    "display flow {id} executions": "Wyświetl wykonania flow {id}",
-    "display metric for specific task": "Wyświetl metrykę dla specyficznego task",
-    "display output for specific task": "Wyświetl wyjście dla specyficznego task",
-    "display topology for flow": "Wyświetl topologię dla flow",
-    "display_settings": "Display settings",
-    "docs": "Dokumentacja",
-    "documentation": {
-      "documentation": "Dokumentacja",
-      "github": "Otwórz problem na GitHub"
-    },
-    "documentationMenu": "Menu dokumentacji",
-    "done": "Gotowe",
-    "down trend": "Malejący",
-    "download": "Pobierz",
-    "download logs": "Pobierz logs",
-    "download_logos": "Pobierz Pakiet Logo",
-    "download_logs_description": "Choose which logs to export. Filters default to your current view.",
-    "draft": "Wersja robocza",
-    "draft_available": "Szkic zmiany jest dostępny w edytorze",
-    "draft_flow_warning": "Ta rewizja flow jest wersją roboczą. Wykonanie zostanie uruchomione na tej roboczej rewizji i może natychmiast zakończyć się niepowodzeniem, jeśli definicja flow jest nieprawidłowa.",
-    "drill down preview": "Podgląd",
-    "drop items here": "Upuść elementy tutaj",
-    "duplicate-pair": "{label} \"{key}\" jest zduplikowany, pierwszy klucz zignorowany.",
-    "duration": "Czas trwania",
-    "dynamic": "Dynamiczny",
-    "each value": "Wartość iteracji",
-    "edit": "Edytuj",
-    "edit flow": "Edytuj flow",
-    "editor": "Edytor",
-    "editor_shortcuts": {
-      "command_palette": "Pokaż paletę poleceń",
-      "comment": "Komentarz",
-      "comment_uncomment": "Komentarz/Odkomentuj",
-      "decrease_fontsize": "Zmniejsz rozmiar czcionki edytora",
-      "duplicate_cursor": "Duplikuj kursor",
-      "execute_flow": "Uruchom flow",
-      "fold_unfold": "Zwiń/Rozwiń kod",
-      "increase_fontsize": "Zwiększ rozmiar czcionki edytora",
-      "label": "Skróty klawiaturowe",
-      "move_line": "Przenieś linię",
-      "reset_fontsize": "Zresetuj rozmiar czcionki edytora",
-      "save_flow": "Zapisz flow",
-      "toggle_ai_agent": "Przełącz agenta AI",
-      "trigger_autocompletion": "Wyzwól autouzupełnianie",
-      "uncomment": "Odkomentuj"
-    },
-    "ee-tooltip": {
-      "button": "Porozmawiaj z nami",
-      "features-blocked": "Ta funkcja wymaga Enterprise Edition."
-    },
-    "email": "Email",
-    "email length constraint": "Email nie może przekraczać 256 znaków",
-    "empty": {
-      "announcements": {
-        "content": "Ogłoszenia pozwalają powiadomić użytkowników o wszelkich zmianach lub poinformować ich o planowanej przerwie konserwacyjnej. Wystarczy wybrać typ ogłoszenia, zakres dat, w którym ma być wyświetlane, i napisać treść ogłoszenia.",
-        "title": "Nie masz jeszcze ogłoszeń!"
-      },
-      "apiTokens": {
-        "content": "Tokeny API są używane za każdym razem, gdy chcesz przyznać programowy dostęp do API Kestra.",
-        "title": "Zarządzaj swoimi tokenami API"
-      },
-      "apps": {
-        "content": "Rozpocznij tworzenie aplikacji do interakcji z Kestra ze świata zewnętrznego.",
-        "title": "Nie masz jeszcze aplikacji!"
-      },
-      "assets": {
-        "content": "Dodaj zasoby, aby śledzić i zarządzać swoimi zasobami danych, usługami i infrastrukturą.",
-        "title": "Nie masz jeszcze zasobów!"
-      },
-      "concurrency_executions": {
-        "content": "Przeczytaj więcej o <strong><a href=\"https://kestra.io/docs/workflow-components/execution?utm_source=app&utm_medium=referral&utm_campaign=concurrency-inlinedoc\" target=\"_blank\">Executions</a></strong> w naszej dokumentacji.",
-        "title": "Brak trwających Executions dla tego flow."
-      },
-      "concurrency_limit": {
-        "content": "Przeczytaj więcej o <strong><a href=\"https://kestra.io/docs/workflow-components/concurrency?utm_source=app&utm_medium=referral&utm_campaign=concurrency-inlinedoc\" target=\"_blank\">Limitach Nebenläufigkeit</a></strong> w naszej dokumentacji.",
-        "title": "Dla tego flow nie ustawiono żadnych limitów."
-      },
-      "concurrency_limits": {
-        "content": "Przeczytaj więcej o <strong><a href=\"https://kestra.io/docs/workflow-components/concurrency?utm_source=app&utm_medium=referral&utm_campaign=concurrency-inlinedoc\" target=\"_blank\">Limitach Równoczesności</a></strong> w naszej dokumentacji.",
-        "title": "Nie ustawiono limitów współbieżności."
-      },
-      "dependencies": {
-        "ASSET": {
-          "content": "Ten zasób nie ma zależności w górę ani w dół z flow lub innymi zasobami.",
-          "title": "Obecnie brak zależności."
-        },
-        "EXECUTION": {
-          "content": "Przeczytaj więcej o <a href=\"https://kestra.io/docs/ui/executions?utm_source=app&utm_medium=referral&utm_campaign=dependencies-inlinedoc#dependencies\" target=\"_blank\">zależnościach wykonania</a> w naszej dokumentacji.",
-          "title": "Obecnie brak zależności."
-        },
-        "FLOW": {
-          "content": "Dowiedz się więcej o <a href=\"https://kestra.io/docs/ui/flows?utm_source=app&utm_medium=referral&utm_campaign=dependencies-inlinedoc#dependencies\" target=\"_blank\">Flow Dependencies</a> w naszej dokumentacji.",
-          "title": "Obecnie brak zależności."
-        },
-        "NAMESPACE": {
-          "content": "Dowiedz się więcej o <a href=\"https://kestra.io/docs/ui/namespaces?utm_source=app&utm_medium=referral&utm_campaign=dependencies-inlinedoc#dependencies\" target=\"_blank\">zależnościach Namespace</a> w naszej dokumentacji.",
-          "title": "Obecnie nie ma zależności."
-        }
-      },
-      "groups": {
-        "content": "Grupy pozwalają na łączenie użytkowników, aby można było zarządzać uprawnieniami i przypisaniami ról zbiorczo w całym Twoim mandancie.",
-        "title": "Nie masz jeszcze grup!"
-      },
-      "kill_switches": {
-        "content": "Funkcja Kill Switch zapewnia mechanizm w interfejsie użytkownika do zatrzymywania problematycznych wykonania. Zastępuje polecenia CLI <code>--skip-executions</code> i <code>--skip-flows</code> kompleksowym interfejsem administracyjnym.",
-        "title": "Nie masz jeszcze Kill Switches!"
-      },
-      "mcpToolFlows": {
-        "content": "Udostępnij flow jako narzędzie MCP, dodając do niego <code>McpToolTrigger</code>. Przeczytaj więcej o <strong><a href=\"https://kestra.io/docs/workflow-components/triggers/mcp-tool-trigger?utm_source=app&utm_medium=referral&utm_campaign=mcp-tool-trigger-inlinedoc\" target=\"_blank\">MCP Tool Trigger</a></strong> w naszej dokumentacji.",
-        "title": "Na tym serwerze nie zarejestrowano jeszcze żadnych flow narzędzi."
-      },
-      "namespaceFiles": {
-        "content": "Pliki namespace działają jak folder projektu dla tego namespace. Przechowuj kod Python, SQL, dbt lub Terraform, a następnie odwołuj się do dowolnego pliku w swoich flows za pomocą",
-        "title": "Brak plików w tym namespace"
-      },
-      "panels": {
-        "content": "Zamknąłeś wszystkie panele.  \nWybierz kartę powyżej, aby kontynuować.",
-        "title": "Brak otwartego panelu"
-      },
-      "pluginDefaults": {
-        "content": "Domyślne ustawienia Pluginów pozwalają centralnie zarządzać konfiguracją pluginów i udostępniać ją wszystkim flow w twoim namespace.",
-        "title": "Nie masz jeszcze domyślnych pluginów!"
-      },
-      "plugins": {
-        "content": "Przeczytaj więcej o <strong><a href=\"https://kestra.io/docs/workflow-components/plugin-defaults?utm_source=app&utm_medium=referral&utm_campaign=plugin-default-inlinedoc\" target=\"_blank\">Limitach Concurrency</a></strong> w naszej dokumentacji.",
-        "title": "Dla tego namespace nie ustawiono domyślnych pluginów."
-      },
-      "testSuites": {
-        "content": "Rozpocznij tworzenie zestawów testowych do testowania swoich flow.",
-        "title": "Nie masz jeszcze żadnych Test suites!"
-      },
-      "triggers": {
-        "content": "Przeczytaj więcej o <strong><a href=\"https://kestra.io/docs/workflow-components/triggers?utm_source=app&utm_medium=referral&utm_campaign=trigger-inlinedoc\" target=\"_blank\">Triggers</a></strong> w naszej dokumentacji.",
-        "title": "Twój flow nie ma żadnych Triggerów."
-      },
-      "variables": {
-        "content": "Dodaj pary klucz-wartość, aby udostępniać konfigurację między flow. Podrzędne namespace dziedziczą je automatycznie, a każdą wartość można odwołać za pomocą",
-        "title": "Jeszcze brak zmiennych"
-      },
-      "versionPlugin": {
-        "content": "Tutaj możesz zarządzać wszystkimi pluginami zainstalowanymi na Twojej instancji Kestra. Nowo zainstalowane pluginy mogą nie być od razu dostępne we wszystkich usługach Kestra, w zależności od konfiguracji Twojej instancji.",
-        "title": "Nie masz jeszcze wersjonowanego pluginu!"
-      },
-      "workerRegistrationTokens": {
-        "content": "Tokeny rejestracyjne pozwalają zdalnym workerom na bezpieczne uwierzytelnianie i rejestrowanie się w Twojej instancji Kestra. Utwórz token, a następnie użyj go, aby połączyć nowych workerów z tym klastrem.",
-        "title": "Nie masz jeszcze tokenów rejestracyjnych!"
-      }
-    },
-    "empty search": "Wyniki wyszukiwania są puste",
-    "enable": "Włącz",
-    "enable concurrency": "Włącz concurrency",
-    "enabled": "Włączone",
-    "encoding": "Kodowanie",
-    "end date": "Data zakończenia",
-    "end datetime": "Data i godzina zakończenia",
-    "environment": "Środowisko",
-    "environment color setting": "Kolor środowiska",
-    "environment name setting": "Nazwa środowiska",
-    "error": "Błąd",
-    "error detected": "Wykryto błąd(y).",
-    "error in editor": "Znaleziono błąd w edytorze",
-    "errorLogs": "Logi błędów",
-    "errors": {
-      "401": {
-        "content": "Musisz być uwierzytelniony, aby uzyskać dostęp do tej strony.",
-        "title": "Nieautoryzowany"
-      },
-      "403": {
-        "content": "Nie masz wymaganych uprawnień, aby uzyskać dostęp do tej strony.",
-        "title": "Dostęp zabroniony"
-      },
-      "404": {
-        "content": "Żądany URL nie został znaleziony na tym serwerze.<br />To wszystko, co wiemy.",
-        "flow or execution": "Flow lub wykonanie, którego szukasz, nie istnieje.",
-        "title": "Strona nie znaleziona"
-      }
-    },
+    "change execution state confirm": "Czy na pewno chcesz zmienić stan wykonania <code>{id}</code>?",
+    "change execution state done": "Stan wykonania zaktualizowany",
+    "mark as": "Oznacz jako <code>{status}</code>",
+    "unqueue as": "Usuń z kolejki jako <code>{status}</code>",
+    "kill": "Zakończ",
+    "kill parents and subflow": "Zatrzymaj bieżący flow i subflow",
+    "kill only parents": "Zabij tylko bieżący",
+    "killed confirm": "Czy na pewno chcesz zakończyć wykonanie <code>{id}</code>?",
+    "killed done": "Wykonanie jest w kolejce do zakończenia",
+    "resume": "Wznów",
+    "resumed title": "Wznów wykonanie <code>{id}</code>",
+    "resumed confirm": "Czy na pewno chcesz wznowić wykonanie <code>{id}</code>?",
+    "resumed done": "Wykonanie zostało wznowione",
+    "resume from breakpoint title": "Wznów wykonanie <code>{id}</code> z punktu przerwania",
+    "resume from breakpoint done": "Wykonanie zostało wznowione od punktu przerwania",
+    "breakpoints": "Punkty przerwania",
+    "pause": "Wstrzymaj",
+    "pause title": "Wstrzymaj wykonanie <code>{id}</code>.<br/>Zauważ, że aktualnie uruchomione taski nadal będą przetwarzane, a wykonanie będzie musiało zostać wznowione ręcznie.",
+    "pause confirm": "Czy na pewno chcesz wstrzymać wykonanie <code>{id}</code>?",
+    "pause done": "Wykonanie jest PAUSED",
+    "unqueue": "Usuń z kolejki",
+    "unqueue title": "Usuń z kolejki wykonanie <code>{id}</code>.<br/>Zwróć uwagę, że nie będzie to przestrzegać limitu współbieżności flow, więc może być uruchomionych więcej wykonań niż dozwolony limit.",
+    "unqueue title multiple": "Czy na pewno chcesz usunąć z kolejki <code>{count}</code> wykonania?<br/><br/>Zauważ, że nie będzie to przestrzegać limitu współbieżności flow, więc może być uruchomionych więcej wykonań niż dozwolony limit.",
+    "unqueue confirm": "Czy na pewno chcesz usunąć z kolejki wykonanie <code>{id}</code>?",
+    "unqueue done": "Wykonanie jest odkolejkowane",
+    "force run": "Wymuś uruchomienie",
+    "force run title": "Wymuś uruchomienie wykonania <code>{id}</code>.",
+    "force run tooltip": "Wymuś wykonanie. Może to spowodować duplikaty wykonania task, jeśli to możliwe, użyj innej akcji.",
+    "force run confirm": "Czy na pewno chcesz wymusić uruchomienie wykonania <code>{id}</code>?<br/><br/>WARNING: wymuszenie uruchomienia wykonania nie jest gwarantowane i może spowodować duplikaty wykonania tasków.<br/><br/>Następujące przejścia zostaną wykonane:<br/><ul><li>Taski w stanie CREATED zostaną przeniesione do stanu RUNNING.</li><li>Taski w stanie RUNNING zostaną ponownie przesłane.</li><li>Taski w stanie QUEUED zostaną odkolejkowane.</li><li>Taski w stanie PAUSED zostaną wznowione.</li></ul>",
+    "force run done": "Wymuszone uruchomienie Execution",
+    "toggle output": "Przełącz wyjścia",
+    "metrics": "Metryki",
+    "no data current task": "Brak dostępnych danych dla bieżącego taska",
+    "no metrics available": "Brak zarejestrowanych metryk dla tego uruchomienia task.",
+    "no outputs available": "Brak dostępnych outputów dla tego uruchomienia task.",
+    "outputs": "Wyjścia",
+    "flow_outputs": "Wyjścia Flow",
+    "no_flow_outputs": "Brak dostępnych outputów.",
+    "output": "Wyjście",
     "eval": {
-      "expression": "Wyrażenie",
-      "preview": "Podgląd",
-      "render": "Renderuj Wyrażenie",
       "title": "Debugowanie Wyrażenia",
-      "tooltip": "Renderuj dowolne wyrażenie Pebble i sprawdź kontekst wykonania."
+      "render": "Renderuj Wyrażenie",
+      "tooltip": "Renderuj dowolne wyrażenie Pebble i sprawdź kontekst wykonania.",
+      "preview": "Podgląd",
+      "expression": "Wyrażenie"
     },
-    "evaluation lock date": "Data blokady oceny",
-    "execute": "Wykonaj",
-    "execute backfill": "Wykonaj backfill",
-    "execute flow behaviour": "Wykonaj flow",
-    "execute flow now ?": "Czy chcesz wykonać ten flow?",
-    "execute the flow": "Wykonaj flow <code>{id}</code>",
-    "execution": "Wykonanie",
-    "execution already finished": "Wykonanie <code>{executionId}</code> już zakończone",
-    "execution id": "Id wykonania",
-    "execution labels": "Etykiety wykonania",
-    "execution not found": "Wykonanie {executionId} nie zostało znalezione.",
-    "execution not in state FAILED": "Wykonanie <code>{executionId}</code> nie jest w stanie FAILED",
-    "execution not in state PAUSED": "Wykonanie <code>{executionId}</code> nie jest w stanie PAUSED",
-    "execution replay": "To wykonanie jest powtórką z",
-    "execution replayed": "To wykonanie zostało odtworzone.",
-    "execution restarted": "Ta wykonanie zostało ponownie uruchomione {nbRestart} raz(y).",
+    "attempt": "Próba",
+    "toggle output display": "Przełącz wyświetlanie wyjścia",
+    "name": "Nazwa",
+    "key": "Klucz",
+    "value": "Wartość",
+    "each value": "Wartość iteracji",
+    "current execution": "Bieżące wykonanie",
+    "parent execution": "Wykonanie rodzica",
+    "original execution": "Oryginalne wykonanie",
+    "automatic refresh": "Automatyczne odświeżanie",
+    "toggle periodic refresh each x seconds": "Przełącz okresowe odświeżanie co {interval} sekund",
+    "trigger refresh": "Odśwież",
+    "add-trigger-in-editor": "Najpierw dodaj Trigger do swojego Flow",
+    "refresh": "Odśwież",
+    "filter by status": "Filtruj wykonania według statusu {status}",
+    "topology-graph": {
+      "graph-orientation": "Orientacja grafu",
+      "zoom-in": "Powiększ",
+      "zoom-out": "Pomniejsz",
+      "zoom-reset": "Zresetuj powiększenie",
+      "zoom-fit": "Dopasuj",
+      "invalid": "Błąd grafu",
+      "invalid_description": "Wystąpił błąd podczas ładowania grafu. Proszę sprawdzić kod źródłowy pod kątem błędów."
+    },
+    "show task logs": "Pokaż task logs",
+    "show task condition": "Pokaż warunek taska",
+    "show task outputs": "Pokaż task outputs",
+    "show task source": "Pokaż źródło task",
+    "specific task": "Specyficzny task",
+    "display output for specific task": "Wyświetl wyjście dla specyficznego task",
+    "display metric for specific task": "Wyświetl metrykę dla specyficznego task",
+    "display direct sub tasks count": "Wyświetl bezpośrednią liczbę subtask",
+    "stream": "Strumień",
     "execution statistics": "Statystyki wykonania",
-    "execution-include-non-terminated": "Uwzględnić nieukończone wykonania?",
-    "execution-warn-deleting-still-running": "Zalecamy anulowanie tej akcji i zakończenie wszystkich trwających executions. Usunięcie nieukończonych executions może prowadzić do problemów z concurrency, niespójności w zarządzaniu zależnościami flow oraz procesów zombie na Twojej instancji, co może pogorszyć wydajność systemu. Upewnij się, że w pełni rozumiesz te ryzyka przed kontynuowaniem usuwania.",
-    "execution-warn-title": "Ważne Ostrzeżenie!",
-    "execution_deletion": {
-      "logs": "Usuń logs",
-      "metrics": "Usuń metrics",
-      "storage": "Usuń wewnętrzne pliki storage"
-    },
-    "execution_failed": "Wykonanie nie powiodło się!",
-    "execution_guide": {
-      "get_started": {
-        "text": "Postępuj zgodnie z Przewodnikiem Szybkiego Startu, aby zainstalować Kestra i rozpocząć tworzenie swoich pierwszych workflowów.",
-        "title": "Zacznij ⚡"
-      },
-      "namespaces": {
-        "text": "Namespace to logiczne grupowanie flow i ich komponentów.",
-        "title": "O Namespace'ach"
-      },
-      "videos_tutorials": {
-        "text": "Rozpocznij korzystanie z naszych samouczków wideo.",
-        "title": "Samouczki wideo"
-      },
-      "workflow_components": {
-        "text": "Poznaj główne komponenty orkiestracji w workflow Kestra.",
-        "title": "Komponenty Workflow"
-      }
-    },
-    "execution_started": "Rozpoczęto wykonanie!",
-    "execution_starts_progress": "Gdy tylko rozpocznie się wykonanie, zobaczysz tutaj aktualizacje postępu.",
-    "execution_status": "Wykonanie jest:",
-    "executions": "Wykonania",
-    "executions deleted": "<code>{executionCount}</code> wykonanie(a) usunięte",
+    "stats": "Statystyki",
+    "concurrency limits": "Limity Równoczesności",
+    "system overview": "Przegląd Systemu",
+    "usage": "Użycie",
+    "namespaces": "Namespaces",
+    "tasks": "Tasks",
     "executions duration (in minutes)": "Całkowity czas trwania wykonania (w minutach)",
-    "executions force run": "<code>{executionCount}</code> wykonanie(a) wymuszone uruchomienie",
-    "executions killed": "<code>{executionCount}</code> wykonanie(a) zabite",
-    "executions paused": "<code>{executionCount}</code> wykonanie(a) wstrzymane",
-    "executions replayed": "<code>{executionCount}</code> wykonanie(a) odtworzone",
-    "executions restarted": "<code>{executionCount}</code> wykonanie(a) zrestartowane",
-    "executions resumed": "<code>{executionCount}</code> wykonanie(a) wznowione",
-    "executions state changed": "Stan wykonania <code>{executionCount}</code> został zmieniony",
-    "executions unqueue": "<code>{executionCount}</code> wykonanie(a) w kolejce",
-    "expand": "Rozwiń",
-    "expand all": "Rozwiń wszystko",
-    "expand dependencies": "Rozwiń zależności",
-    "expand error": "Rozwiń tylko nieudane tasks",
-    "expand_by_default": "Expand structured logs by default",
-    "expiration": "Wygaśnięcie",
-    "expiration date": "Data wygaśnięcia",
-    "export": "Eksportuj",
-    "export all flows": "Eksportuj wszystkie flows",
-    "export all templates": "Eksportuj wszystkie szablony",
-    "export_as": "Eksportuj jako .{format}",
-    "export_csv": "Eksportuj jako CSV",
-    "exports": "Eksporty",
-    "failed to export plugin defaults": "Nie udało się wyeksportować domyślnych ustawień wtyczki",
-    "failed to import plugin defaults": "Nie udało się zaimportować domyślnych ustawień wtyczki",
-    "failed to render pdf": "Nie udało się wygenerować podglądu PDF",
-    "false": "Fałsz",
-    "feeds": {
-      "heading": "Wszystko o Kestra.",
-      "subheading": "Najnowsze aktualizacje, przewodniki i historie",
-      "title": "Co nowego w Kestra"
+    "last 48 hours": "ostatnie 48 godzin",
+    "configure basic auth": "Skonfiguruj podstawowe uwierzytelnianie",
+    "email": "Email",
+    "password": "Hasło",
+    "confirm password": "Potwierdź hasło",
+    "email length constraint": "Email nie może przekraczać 256 znaków",
+    "password length constraint": "Hasło nie może przekraczać 256 znaków",
+    "password empty constraint": "Nieprawidłowa nazwa użytkownika lub hasło",
+    "passwords do not match": "Hasła nie pasują do siebie",
+    "avg duration": "Średni czas trwania wykonania",
+    "neutral trend": "Stabilny",
+    "up trend": "Rosnący",
+    "down trend": "Malejący",
+    "update aborted": "aktualizacja przerwana",
+    "invalid flow": "Nieprawidłowy flow",
+    "invalid yaml": "Nieprawidłowy YAML",
+    "inputs": "Inputs",
+    "no_inputs": "Brak dostępnych inputów.",
+    "input": "Input",
+    "variables": "Zmienne",
+    "variable_explorer": {
+      "title": "Wejście/Wyjście",
+      "search_placeholder": "Szukaj Key lub value...",
+      "tasks_outputs": "Tasks outputs",
+      "tree": "Drzewo",
+      "raw_json": "Raw JSON",
+      "select_prompt": "Wybierz zmienną, aby sprawdzić jej value.",
+      "empty": "Brak zmiennych dostępnych dla tego wykonania.",
+      "one_key": "\\{ 1 key \\}",
+      "n_keys": "\\{ {count} keys \\}",
+      "one_item": "[ 1 element ]",
+      "n_items": "[ {count} elementów ]"
     },
-    "file preview truncated": "Wyświetlana zawartość została skrócona",
-    "file unavailable": "Plik niedostępny",
-    "file unavailable description": "Ten plik nie jest już dostępny — mógł zostać usunięty lub wygasł.",
-    "fileTypeNotAllowed": "Niedozwolony typ pliku. Akceptowane typy: {types}",
     "file_preview": {
       "big_file_warning": "Ten plik ma rozmiar {size}. Może to chwilę potrwać, blokując przeglądarkę. Czy chcesz go mimo to załadować?",
       "load_anyway": "Załaduj mimo to"
     },
-    "files": "Pliki",
-    "filter by log level": "Filtruj według poziomu log",
-    "filter by status": "Filtruj wykonania według statusu {status}",
-    "filter by this value": "Filter by this value",
-    "filter_for": "Filter for",
-    "filter_out": "Filter out",
-    "filters": {
-      "comparators": {
-        "between": "pomiędzy",
-        "contains": "zawiera",
-        "ends_with": "kończy się na",
-        "greater_than": "większe niż",
-        "greater_than_or_equal_to": "większe lub równe",
-        "in": "w",
-        "is": "jest",
-        "is_not": "nie jest",
-        "is_one_of": "jest jednym z",
-        "less_than": "mniej niż",
-        "less_than_or_equal_to": "mniejsze lub równe",
-        "not_contains": "nie zawiera",
-        "not_in": "nie w",
-        "starts_with": "zaczyna się od"
-      },
-      "empty": "Brak danych.",
-      "format": "Wpisz parametr jako 'key:value'",
-      "label": "Wybierz filtry",
-      "options": {
-        "absolute_date": "Data bezwzględna",
-        "action": "Akcja",
-        "aggregation": "Agregacja",
-        "child": "Dziecko",
-        "details": "Szczegóły",
-        "endDate": "Data zakończenia",
-        "flow": "Flow",
-        "labels": "Etykiety",
-        "level": "Poziom logowania",
-        "metric": "Metryka",
-        "namespace": "Namespace",
-        "permission": "Uprawnienie",
-        "relative_date": "Data względna",
-        "scope": "Zakres",
-        "service_type": "Typ",
-        "startDate": "Data rozpoczęcia",
-        "state": "Stan",
-        "status": "Status",
-        "task": "Zadanie",
-        "text": "tekst",
-        "type": "Typ",
-        "user": "Użytkownik"
-      },
-      "save": {
-        "dialog": {
-          "confirmation": "Kryteria wyszukiwania <code>{name}</code>",
-          "heading": "Zapisz bieżące wyszukiwanie",
-          "hint": "Jak chcesz oznaczyć te kryteria wyszukiwania?",
-          "placeholder": "Etykieta"
-        },
-        "empty": "Nie zapisałeś jeszcze żadnego wyszukiwania.",
-        "label": "Zapisane wyszukiwania",
-        "name_already_used": "Szukana label już używana.",
-        "remove": "Usuń",
-        "tooltip": "Nie można zapisać pustych kryteriów wyszukiwania."
-      },
-      "settings": {
-        "label": "Ustawienia strony",
-        "show_chart": "Pokaż główny wykres"
-      },
-      "text_search": "Wyszukaj ten tekst"
-    },
-    "fix_with_ai": "Napraw za pomocą AI",
-    "flow": "Flow",
-    "flow already exists": "Flow już istnieje",
-    "flow already exists message": "Flow <code>{id}</code> już istnieje w namespace <code>{namespace}</code>. Czy chcesz utworzyć nową wersję?",
-    "flow creation": "Utworzenie flow",
-    "flow creation denied in namespace": "Nie masz uprawnień do tworzenia flow w namespace `{namespace}`.",
-    "flow delete": "Czy na pewno chcesz usunąć <code>{flowCount}</code> flow(s)?",
-    "flow deleted, you can restore it": "Flow został usunięty i jest to widok tylko do odczytu. Nadal możesz go przywrócić.",
-    "flow disable": "Czy na pewno chcesz wyłączyć <code>{flowCount}</code> flow(s)?",
-    "flow enable": "Czy na pewno chcesz włączyć <code>{flowCount}</code> flow(s)?",
-    "flow export": "Czy na pewno chcesz wyeksportować <code>{flowCount}</code> flow(s)?",
-    "flow must have id and namespace": "Flow musi mieć id i namespace.",
-    "flow must not be empty": "Flow nie może być pusty",
-    "flow not imported": "Niektóre flow nie mogły zostać zaimportowane",
-    "flow revision latest": "Najnowsza wersja flow",
-    "flow revision original": "Oryginalna wersja flow",
-    "flow revision specific": "Specyficzna wersja flow",
-    "flow source not found": "Źródło flow nie znalezione",
-    "flow-dependencies": "zależności",
-    "flow-no-dependencies": "Twój flow nie ma żadnych zależności",
-    "flow_editor_stats": {
-      "apps": {
-        "suffix": "Aplikacja(e)",
-        "tooltip": "Zobacz aplikacje używające tego flow"
-      },
-      "dependencies": {
-        "suffix": "Zależności",
-        "tooltip": "Zobacz zależności flow"
-      },
-      "errors": {
-        "label": "{count} Błąd(y)"
-      },
-      "revisions": {
-        "suffix": "Rewizja(e)",
-        "tooltip": "Zobacz rewizje flow"
-      },
-      "tests": {
-        "suffix": "Test(y)",
-        "tooltip": "Zobacz testy flow"
-      }
-    },
-    "flow_export": "Eksportuj flow",
-    "flow_only": "Dostępne tylko na zakładce Flow.",
-    "flow_outputs": "Wyjścia Flow",
-    "flows": "Flows",
-    "flows deleted": "<code>{count}</code> Flow(s) usunięte",
-    "flows disabled": "<code>{count}</code> Flow(s) wyłączone",
-    "flows enabled": "<code>{count}</code> Flow(s) włączone",
-    "flows exported": "<code>{count}</code> Flow(s) wyeksportowane",
-    "flows imported": "Zaimportowane flows",
-    "focus task": "Kliknij na dowolny element, aby zobaczyć jego dokumentację.",
-    "fold_all_multi_lines": "Zwiń wszystkie linie wielokrotne",
-    "font size": "Font size",
-    "for flow": "dla flow",
-    "forbidden system labels": "Tylko system.correlationId może być użyty jako system label",
-    "force run": "Wymuś uruchomienie",
-    "force run confirm": "Czy na pewno chcesz wymusić uruchomienie wykonania <code>{id}</code>?<br/><br/>WARNING: wymuszenie uruchomienia wykonania nie jest gwarantowane i może spowodować duplikaty wykonania tasków.<br/><br/>Następujące przejścia zostaną wykonane:<br/><ul><li>Taski w stanie CREATED zostaną przeniesione do stanu RUNNING.</li><li>Taski w stanie RUNNING zostaną ponownie przesłane.</li><li>Taski w stanie QUEUED zostaną odkolejkowane.</li><li>Taski w stanie PAUSED zostaną wznowione.</li></ul>",
-    "force run done": "Wymuszone uruchomienie Execution",
-    "force run title": "Wymuś uruchomienie wykonania <code>{id}</code>.",
-    "force run tooltip": "Wymuś wykonanie. Może to spowodować duplikaty wykonania task, jeśli to możliwe, użyj innej akcji.",
-    "form": "Formularz",
-    "form error": "Błąd formularza",
-    "from": "Od",
-    "gantt": "Gantt",
-    "gantt_no_tasks_executed": "Ta wykonanie zakończyło się bez uruchomienia żadnego taska.\nSprawdź jego podsumowanie i logi, aby poznać przyczynę.",
-    "gantt_no_tasks_match_filters": "Spróbuj dostosować filtry wyszukiwania, stanu lub poziomu logów.",
-    "gantt_no_tasks_match_filters_title": "Brak zadań pasujących do wybranych filtrów.",
-    "healthcheck date": "Data HealthCheck",
-    "hide task documentation": "Ukryj dokumentację task",
-    "home": "Strona główna",
-    "hostname": "Nazwa hosta",
-    "iam": "IAM",
-    "id": "Id",
-    "import": "Importuj",
-    "in-our-documentation": "w naszej dokumentacji.",
-    "informative notice": "Notatka(i)",
-    "input": "Input",
-    "inputs": "Inputs",
-    "instance": "Instancja",
-    "invalid bulk delete": "Nie można usunąć wykonań",
-    "invalid bulk force run": "Nie można wymusić uruchomienia wykonania",
-    "invalid bulk kill": "Nie można zabić wykonań",
-    "invalid bulk pause": "Nie można wstrzymać wykonania",
-    "invalid bulk replay": "Nie można odtworzyć wykonań",
-    "invalid bulk restart": "Nie można zrestartować wykonań",
-    "invalid bulk resume": "Nie można wznowić wykonań",
-    "invalid bulk unqueue": "Nie można usunąć z kolejki wykonania",
-    "invalid field": "Nieprawidłowe pole: {name}",
-    "invalid flow": "Nieprawidłowy flow",
-    "invalid source": "Nieprawidłowy kod źródłowy",
-    "invalid yaml": "Nieprawidłowy YAML",
-    "is deprecated": "jest przestarzały",
-    "is required": "Pole {field} jest wymagane",
-    "item": "element",
-    "items": "elementy",
-    "join community": "Dołącz Community",
-    "join_slack": "Dołącz do Slacka",
-    "jsonl": "JSONL",
-    "jump to...": "Przejdź do...",
-    "kestra": "Kestra",
-    "key": "Klucz",
-    "kill": "Zakończ",
-    "kill only parents": "Zabij tylko bieżący",
-    "kill parents and subflow": "Zatrzymaj bieżący flow i subflow",
-    "killed confirm": "Czy na pewno chcesz zakończyć wykonanie <code>{id}</code>?",
-    "killed done": "Wykonanie jest w kolejce do zakończenia",
-    "kv": {
-      "add": "Utwórz",
-      "delete multiple": {
-        "confirm": "Czy na pewno chcesz usunąć: <code>{name}</code> kv?",
-        "warning": "Nie masz uprawnień do tych namespace, więc zostaną pominięte: <code>{namespaces}</code>"
-      },
-      "duplicate": "Ten key już istnieje",
-      "inherited": "Odziedziczone pary KV",
-      "name": "KV Store",
-      "type": "Typ",
-      "update": "Zaktualizuj value dla key '{key}'"
-    },
-    "label": "Label",
-    "label filter placeholder": "Etykieta jako 'key:value'",
-    "labels": "Etykiety",
-    "last 48 hours": "ostatnie 48 godzin",
-    "last X days count": "{count} w ostatnich {days} dniach",
-    "last error was": "Ostatni błąd to",
-    "last evaluation date": "Data ostatniej oceny",
-    "last evaluation date tooltip": "When the trigger was last evaluated by the scheduler, regardless of whether it produced an execution.",
-    "last execution date": "Data ostatniego wykonania",
-    "last execution state": "Ostatni stan",
-    "last execution status": "Ostatni status wykonania",
-    "last modified": "Ostatnia modyfikacja",
-    "last trigger date": "Data ostatniego triggera",
-    "last trigger date tooltip": "Kiedy trigger został ostatnio wykonany. Może być w przeszłości podczas uruchamiania backfill.",
-    "latest_update": "Najnowsza aktualizacja",
-    "launch execution": "Wykonaj",
-    "learn_more": "Dowiedz się więcej",
-    "leave page": "Opuść stronę",
-    "license": "Licencja",
-    "light_background": "To jest preferowana opcja podczas pracy z jasnym tłem.",
-    "light_version": "Wersja jasna",
-    "line": "Linia",
-    "line-by-line": "linia po linii",
-    "loaded x dependencies": "{count} zależności załadowane",
-    "loading": "Ładowanie...",
-    "log expand setting": "Domyślne wyświetlanie Logs",
-    "logExporters": "Eksporterzy Logów",
-    "logs": "Logs",
-    "logs_copied": "Logs copied to your clipboard",
-    "logs_view": {
-      "compact": "Widok domyślny",
-      "compact_details": "Pokaż task logs w kompaktowym widoku pogrupowanym według każdego task",
-      "raw": "Widok czasowy",
-      "raw_details": "Pokaż pełne task logs i flow logs w surowym formacie uporządkowanym według znaczników czasu"
-    },
-    "main_configuration": "Główna konfiguracja",
-    "manage labels": "Zarządzaj label",
-    "management port": "Port zarządzania",
-    "mark as": "Oznacz jako <code>{status}</code>",
-    "max": "Max",
-    "mcp": {
-      "api_token": "Token API",
-      "auth_type": "Uwierzytelnianie",
-      "basic_auth": "Podstawowe uwierzytelnianie",
-      "bearer_token": "Uwierzytelnianie za pomocą tokenu Bearer",
-      "client_setup": "Konfiguracja klienta",
-      "connect": "Połącz",
-      "connect_tab": {
-        "auth_api_token_hint": "Przed uruchomieniem klienta ustaw <code>KESTRA_TOKEN</code> jako zmienną środowiskową.",
-        "auth_basic_hint": "Przed uruchomieniem klienta ustaw <code>KESTRA_BASIC_AUTH</code> jako zmienną środowiskową zawierającą zakodowany w base64 ciąg <code>username:password</code>.",
-        "auth_oauth_browser_hint": "Przy pierwszym połączeniu przeglądarka otworzy stronę logowania dostawcy tożsamości.",
-        "auth_oauth_client_id_hint": "Zastąp <code>&lt;client-id&gt;</code> identyfikatorem klienta OAuth i zarejestruj <code>http://localhost:7777</code> jako prawidłowy URI przekierowania na tym kliencie.",
-        "claude_code": "Claude Code",
-        "claude_code_hint": "Uruchom następujące polecenie w terminalu:",
-        "claude_desktop": "Claude Desktop",
-        "claude_desktop_hint": "Dodaj następujące elementy do pliku claude_desktop_config.json:",
-        "claude_desktop_mac": "macOS: ~/Library/Application Support/Claude/claude_desktop_config.json",
-        "claude_desktop_win": "Windows: %APPDATA%\\Claude\\claude_desktop_config.json",
-        "client_picker_label": "Wybierz klienta AI",
-        "codex": "Codex (OpenAI)",
-        "codex_hint": "Dodaj następujące elementy do konfiguracji MCP w pliku codex.json:",
-        "cursor": "Kursor",
-        "cursor_hint": "Dodaj następujące do ~/.cursor/mcp.json:",
-        "server_url": "URL serwera"
-      },
-      "copy_url": "Skopiuj URL",
-      "create": "Utwórz Serwer",
-      "delete_confirm": "Czy na pewno chcesz usunąć ten serwer MCP?",
-      "id_invalid": "ID musi zaczynać się od małej litery lub cyfry i zawierać tylko małe litery, cyfry, myślniki lub podkreślenia",
-      "id_placeholder": "np. my-mcp-server",
-      "instructions": "Instrukcje",
-      "main_tenant": "main",
-      "managed_by_kestra": "Zarządzane przez Kestra",
-      "no_oauth_providers": "Brak skonfigurowanych dostawców OIDC w tej instancji",
-      "no_servers": "Nie znaleziono serwerów MCP. Utwórz swój pierwszy serwer, aby udostępnić wyzwalacze MCP Tool zewnętrznym agentom AI.",
-      "oauth": "OAuth",
-      "oauth_hint": "Bearer JWT od dostawcy OIDC",
-      "oauth_provider": "Dostawca OAuth",
-      "oauth_provider_placeholder": "Wybierz skonfigurowanego dostawcę OIDC",
-      "oauth_provider_required": "Dostawca OAuth jest wymagany, gdy typ uwierzytelniania to OAuth",
-      "page_description": "Udostępnij swoje flow Kestra jako narzędzia dla agentów AI zgodnych z MCP",
-      "private": "Prywatne",
-      "private_server": "Serwer prywatny",
-      "public": "Publiczny",
-      "public_hint": "Ostrzeżenie: Publiczne serwery nie wymagają uwierzytelniania. Każdy, kto ma URL, może wywołać każde narzędzie udostępnione przez ten serwer, bez sprawdzania namespace'u ani uprawnień. Używaj tylko dla serwerów, które można bezpiecznie udostępniać zewnętrznie.",
-      "save": "Zapisz zmiany",
-      "scopes_supported": "Obsługiwane zakresy",
-      "scopes_supported_hint": "Zakresy reklamowane w dokumencie Protected Resource Metadata tego serwera. Zgodne ze specyfikacją klienty MCP ograniczają swoje żądanie autoryzacji do tej listy. Pozostaw puste, aby pominąć pole i pozwolić klientom korzystać z zakresów reklamowanych przez IdP.",
-      "scopes_supported_placeholder": "openid, profile, email",
-      "server": "Serwer MCP",
-      "server_id": "ID serwera",
-      "server_type": "Typ serwera",
-      "servers": "Serwery MCP",
-      "servers_count": "{{count}} Serwerów MCP",
-      "tab_connect": "Połącz",
-      "tab_edit": "Edytuj",
-      "tab_tool_flows": "Narzędzia Flow",
-      "tab_tool_flows_placeholder": "Zarządzanie flow narzędziami wkrótce dostępne.",
-      "tools": {
-        "annotations": "Adnotacje",
-        "create_tool_flow": "Utwórz flow narzędzia",
-        "description": "Opis",
-        "destructive": "Destrukcyjny",
-        "flow": "flow",
-        "idempotent": "Idempotentny",
-        "no_tools": "Żadne flow narzędzi nie pasują do Twojego wyszukiwania.",
-        "open_world": "Open world",
-        "read_only": "Tylko do odczytu",
-        "return_direct": "Zwrot bezpośredni",
-        "state": "Stan",
-        "title": "Tytuł",
-        "tool_name": "Nazwa narzędzia",
-        "trigger_id": "ID triggera",
-        "view_flow": "Otwórz flow"
-      },
-      "url_copied": "URL skopiowany!",
-      "username_password": "Nazwa użytkownika i hasło",
-      "your_servers": "Twoje Serwery"
-    },
-    "metric": "Metryka",
-    "metric choice": "Brak dostępnych metryk dla tego flow",
-    "metrics": "Metryki",
-    "min": "Min",
-    "missingSource": "Brak źródła",
-    "modify inputs": "Modyfikuj inputy",
-    "modify_inputs": "Modyfikuj inputy",
-    "monogram": "Monogram",
-    "more actions": "Więcej akcji",
-    "more_actions": "Więcej akcji",
-    "multi_panel_editor": {
-      "close_all_panels": "Zamknij wszystkie panele",
-      "close_all_tabs": "Zamknij wszystkie karty",
-      "move_left": "Przesuń w lewo",
-      "move_right": "Przesuń w prawo"
-    },
-    "multiple saved done": "{name} został zapisany",
-    "name": "Nazwa",
-    "namespace": "Namespace",
-    "namespace and id readonly": "Właściwości `namespace` i `id` nie mogą być zmienione — są teraz ustawione na ich początkowe wartości. Jeśli chcesz zmienić nazwę flow lub zmienić jego namespace, możesz stworzyć nowy flow i usunąć stary.",
-    "namespace files": {
-      "create": {
-        "file": "Stwórz plik",
-        "file_already_exists": "Plik o tej nazwie już istnieje",
-        "file_conflicts_with_folder": "Folder o tej nazwie już istnieje",
-        "file_error": "Wystąpił błąd podczas tworzenia pliku",
-        "folder": "Stwórz folder",
-        "folder_already_exists": "Folder o tej nazwie już istnieje",
-        "folder_conflicts_with_file": "Plik o tej nazwie już istnieje",
-        "folder_error": "Wystąpił błąd podczas tworzenia folderu",
-        "label": "Stwórz"
-      },
-      "delete": {
-        "file": "Usuń plik",
-        "files": "Usuń {count} wybrane pliki",
-        "folder": "Usuń folder",
-        "folders": "Usuń {count} wybrane foldery",
-        "label": "Usuń"
-      },
-      "dialog": {
-        "deletion": {
-          "confirm": "Potwierdź",
-          "file_single": "Czy na pewno chcesz usunąć plik <code>{name}</code>?",
-          "files": "Czy na pewno chcesz usunąć <code>{count}</code> plik(ów)?",
-          "folder_single": "Czy na pewno chcesz usunąć folder <code>{name}</code> i całą jego zawartość?",
-          "folders": "Czy na pewno chcesz usunąć <code>{count}</code> folder(y) i całą jego zawartość?",
-          "mixed": "Czy na pewno chcesz usunąć folder(y) <code>{folders}</code> i plik(i) <code>{files}</code>?",
-          "title": "Potwierdź usunięcie zawartości"
-        },
-        "name": {
-          "file": "Nazwa z rozszerzeniem:",
-          "folder": "Nazwa folderu:"
-        },
-        "parent_folder": "Folder nadrzędny:"
-      },
-      "export": "Eksportuj pliki namespace",
-      "export_single": "Eksportuj plik",
-      "filter": "Filtr",
-      "import": {
-        "error": "Wystąpiły błędy podczas importowania pliku(ów)",
-        "files": "Importuj pliki",
-        "folder": "Importuj folder",
-        "import": "Importuj",
-        "success": "Plik(i) pomyślnie zaimportowane"
-      },
-      "new_file": "Nowy plik",
-      "no_items": {
-        "heading": "Nie znaleziono jeszcze plików w twoim namespace.",
-        "paragraph": "Utwórz lub zaimportuj pliki, aby udostępniać kod między flow w twoim namespace."
-      },
-      "no_selection": {
-        "description": "Wybierz plik z drzewa, aby wyświetlić jego zawartość.",
-        "heading": "Nie wybrano plików"
-      },
-      "path": {
-        "copy": "Skopiuj ścieżkę",
-        "error": "Wystąpiły błędy podczas kopiowania ścieżki do schowka",
-        "success": "Ścieżka skopiowana do schowka"
-      },
-      "rename": {
-        "file": "Zmień nazwę pliku",
-        "folder": "Zmień nazwę folderu",
-        "label": "Zmień nazwę",
-        "new_file": "Nowa nazwa z rozszerzeniem:",
-        "new_folder": "Nowa nazwa folderu:"
-      },
-      "revisions": {
-        "history": "Historia wersji",
-        "restore": {
-          "success": "Przywrócenie wersji pliku zakończone sukcesem"
-        }
-      },
-      "toggle": {
-        "hide": "Ukryj pliki namespace",
-        "show": "Pokaż pliki namespace"
-      },
-      "tree": {
-        "collapse": "Zwiń wszystkie foldery",
-        "expand": "Rozwiń wszystkie foldery"
-      }
-    },
-    "namespace not allowed": "Namespace niedozwolony",
-    "namespace_editor": {
-      "close": {
-        "all": "Zamknij wszystkie karty",
-        "other": "Zamknij inne karty",
-        "right": "Zamknij po prawej",
-        "tab": "Zamknij kartę"
-      },
-      "empty": {
-        "create_message": "Możesz tworzyć lub importować pliki namespace.",
-        "title": "Obecnie brak otwartych zakładek",
-        "video_message": "Możesz obejrzeć Wideo Wprowadzające do naszego Edytora."
-      }
-    },
-    "namespaces": "Namespaces",
-    "neutral trend": "Stabilny",
-    "new": "Nowy",
-    "new version": "Nowa wersja {version} dostępna!",
-    "next": "Dalej",
-    "next evaluation date": "Data następnej oceny",
-    "next evaluation date tooltip": "Gdy trigger zostanie ponownie oceniony, na podstawie jego interwału. Nie zawsze jest to samo co następna data wykonania, jeśli warunki nie są spełnione.",
-    "next execution date": "Data następnego wykonania",
-    "next_execution": "Następne wykonanie",
-    "no data current task": "Brak dostępnych danych dla bieżącego taska",
-    "no inputs": "Ten flow nie ma inputs.",
-    "no metrics available": "Brak zarejestrowanych metryk dla tego uruchomienia task.",
-    "no outputs available": "Brak dostępnych outputów dla tego uruchomienia task.",
-    "no result": "Nie ma wyników do wyświetlenia.",
-    "no revisions": "Brak rewizji",
-    "no revisions found": "Istnieje tylko jedna wersja dla tego flow",
-    "no-executions-view": {
-      "guidance_desc": "Potrzebujesz wskazówek, jak wykonać swój flow?",
-      "guidance_sub_desc": "Postępuj zgodnie z dokumentacją, aby uzyskać wszystkie potrzebne informacje.",
-      "namespace_guidance_desc": "Potrzebujesz wskazówek, jak zarządzać swoim Namespace?",
-      "namespace_sub_title": "Wykonaj jeden lub więcej flow z tego namespace, aby wypełnić ten dashboard.",
-      "sub_title": "Kliknij przycisk Wykonaj, aby rozpocząć pierwsze wykonanie workflow.",
-      "title": "Zacznij automatyzację z"
-    },
-    "no_code": {
-      "add_field": "Dodaj {field}",
-      "adding": "+ Dodaj {what}",
-      "adding_default": "+ Dodaj nową wartość",
-      "clearSelection": "Wyczyść zaznaczenie",
-      "creation": {
-        "afterExecution": "Dodaj blok po wykonaniu",
-        "charts": "Dodaj wykres",
-        "conditions": "Dodaj warunek",
-        "default": "Dodaj",
-        "errors": "Dodaj obsługę błędów",
-        "finally": "Dodaj blok finally",
-        "inputs": "Dodaj pole input",
-        "numerator": "Dodaj licznik",
-        "pluginDefaults": "Dodaj domyślny plugin",
-        "tasks": "Dodaj task",
-        "triggers": "Dodaj trigger",
-        "where": "Filtruj swoje dane"
-      },
-      "fields": {
-        "general": {
-          "checks": "Kontrole",
-          "concurrency": "Współbieżność",
-          "disabled": "Wyłączony",
-          "labels": "Etykiety",
-          "listeners": "Słuchacze",
-          "outputs": "Wyjścia",
-          "retry": "Ponów próbę",
-          "sla": "SLA",
-          "taskDefaults": "Domyślne ustawienia Task",
-          "updated": "Zaktualizowano",
-          "variables": "Zmienne",
-          "workerGroup": "Grupa Worker",
-          "workerSelector": "Selektor Worker"
-        },
-        "main": {
-          "description": "Opis",
-          "id": "Flow ID",
-          "inputs": "Wejścia",
-          "namespace": "Namespace"
-        }
-      },
-      "labels": {
-        "label": "Etykieta",
-        "no_code": "Edytor No Code",
-        "variable": "Zmienna",
-        "yaml": "Edytor YAML"
-      },
-      "remove": {
-        "cases": "Usuń ten przypadek",
-        "default": "Usuń ten wpis"
-      },
-      "sections": {
-        "afterExecution": "Po wykonaniu",
-        "deprecated": "Właściwości przestarzałe",
-        "errors": "Obsługa błędów",
-        "finally": "Na koniec",
-        "pluginDefaults": "Domyślne ustawienia Pluginów",
-        "tasks": "Zadania",
-        "triggers": "Triggery"
-      },
-      "select": {
-        "afterExecution": "Wybierz task",
-        "charts": "Wybierz typ wykresu",
-        "conditions": "Wybierz warunek",
-        "default": "Wybierz typ",
-        "errors": "Wybierz task",
-        "finally": "Wybierz task",
-        "inputs": "Wybierz typ pola input",
-        "numerator": "Wybierz licznik",
-        "pluginDefaults": "Wybierz plugin",
-        "task": "Wybierz task",
-        "tasks": "Wybierz task",
-        "triggers": "Wybierz trigger",
-        "where": "Wybierz typ filtra"
-      },
-      "toggle_pebble": "Przełącz edytor Pebble",
-      "unnamed": "Brak Nazwy",
-      "version_oss_placeholder": "Odblokuj wersjonowanie pluginów z Enterprise Edition"
-    },
-    "no_data": "Wygląda na to, że nic tu nie ma... jeszcze!<br/>Dostosuj swoje filtry lub spróbuj ponownie!",
-    "no_file_choosen": "Nie wybrano pliku",
-    "no_flow_outputs": "Brak dostępnych outputów.",
-    "no_history": "Brak dostępnej historii",
-    "no_inputs": "Brak dostępnych inputów.",
-    "no_logs_data": "Brak danych",
-    "no_logs_data_description": "Spróbuj dostosować filtry, zmienić zakres czasu lub sprawdź, czy flow został ostatnio wykonany.",
-    "no_logs_data_title": "Nie znaleziono logów dla wybranych filtrów.",
-    "no_namespaces": "Zero namespaces spełnia kryteria wyszukiwania.",
-    "no_results": {
-      "assets": "Nie znaleziono zasobów",
-      "executions": "Nie znaleziono wykonania",
-      "flows": "Nie znaleziono flowów",
-      "kv_pairs": "Nie znaleziono par klucz-wartość",
-      "secrets": "Nie znaleziono sekretów",
-      "templates": "Nie znaleziono szablonów",
-      "triggers": "Nie znaleziono Triggerów"
-    },
-    "no_results_found": "Nie znaleziono wyników",
-    "no_tasks_running": "Jeszcze nie ma uruchomionych tasków.",
-    "no_trigger": "Brak dostępnego triggera.",
     "no_variables": "Brak dostępnych zmiennych.",
-    "now": "Teraz",
-    "of": "z",
-    "ok": "OK",
-    "onboarding": {
-      "actions": {
-        "cancel_tutorial": "Anuluj samouczek",
-        "complete": "Zakończ",
-        "edit_flow_to_continue": "Kliknij Edytuj flow w górnym pasku (po prawej).",
-        "execute_to_continue": "1. Kliknij Uruchom w górnym pasku (po prawej).\n2. Podaj wartość dla <strong>name</strong>.\n3. Kliknij ponownie Uruchom w oknie modalnym.",
-        "finish_tutorial": "Zakończ samouczek",
-        "next": "Dalej",
-        "save_to_continue": "Kliknij Zapisz w górnym pasku (po prawej)."
-      },
-      "cancel_modal": {
-        "confirm": "Anuluj samouczek",
-        "description": "Czy chcesz anulować samouczek Pierwszy Flow?",
-        "keep": "Kontynuuj samouczek",
-        "title": "Anuluj samouczek Pierwszy Flow"
-      },
-      "editor_hints": {
-        "build_intro": "Zbuduj swój pierwszy flow krok po kroku.",
-        "step_1": "# 1) Dodaj id",
-        "step_2": "# 2) Dodaj namespace",
-        "step_3": "# 3) Dodaj input",
-        "step_4": "# 4) Dodaj tasks i pierwsze zadanie Python",
-        "step_5": "# 5) Dodaj wyzwalacz cron"
-      },
-      "finish_actions": {
-        "create_flow": "Utwórz flow",
-        "explore_blueprints": "Przeglądaj Blueprinty"
-      },
-      "steps": {
-        "add_cron_trigger": {
-          "description": "Triggers mogą uruchamiać wykonania na podstawie harmonogramu lub zdarzeń zewnętrznych (np. webhooków lub wiadomości MQTT).<br><br>Dodaj teraz wyzwalacz cron, aby ten flow uruchamiał się co 5 minut.",
-          "title": "Dodaj wyzwalacz cron"
-        },
-        "add_id": {
-          "description": "ID to unikalna nazwa Twojego flow, dzięki której możesz go znaleźć, uruchomić i spójnie do niego się odwoływać.<br><br>Teraz dodaj <code>id</code> na poziomie głównym.",
-          "title": "Dodaj ID flow"
-        },
-        "add_input": {
-          "description": "Inputs to parametry na poziomie flow, które można wykorzystywać w zadaniach, aby dynamicznie kontrolować zachowanie w czasie wykonywania.<br><br>Dodaj teraz input o nazwie <code>name</code> z typem <code>STRING</code>.",
-          "title": "Dodaj input"
-        },
-        "add_input_default": {
-          "description": "Gdy flow jest wyzwalany automatycznie, inputy nadal wymagają wartości w czasie wykonywania.<br><br>Input <code>name</code> został już utworzony w poprzednim kroku, więc nie musisz dodawać go ponownie. Ustaw tylko domyślną wartość dla istniejącego inputu <code>name</code>.",
-          "title": "Ustaw domyślną wartość inputu"
-        },
-        "add_log_task": {
-          "description": "Tasks to jednostki pracy wykonywane przez flow, zdefiniowane jako uporządkowana lista kroków. Każde zadanie wymaga unikalnego <code>id</code> oraz <code>type</code>. Kestra udostępnia wiele wtyczek zadań dla systemów zewnętrznych; tutaj użyjemy zadania Python Script.<br><br>Składnia <code>&#123;&#123; ... &#125;&#125;</code> to wyrażenie Pebble, używane do dynamicznego odwoływania się do zmiennych w czasie wykonywania, np. <code>&#123;&#123; inputs.name &#125;&#125;</code> z inputów flow.<br><br>Dodaj teraz pierwsze zadanie w sekcji <code>tasks</code> z <code>id</code>, <code>type</code> oraz <code>script</code>, który wypisze powitanie.",
-          "title": "Dodaj pierwsze zadanie"
-        },
-        "add_namespace": {
-          "description": "Namespace to grupowanie podobne do folderu, które organizuje flow według zespołu, projektu lub środowiska.<br><br>Teraz dodaj <code>namespace</code> na poziomie głównym.",
-          "title": "Dodaj namespace"
-        },
-        "background_runs_info": {
-          "description": "Ten flow będzie teraz wykonywany w tle co 5 minut.<br><br>Możesz przejść do przeglądu Executions z menu po lewej stronie, aby monitorować zaplanowane uruchomienia.",
-          "title": "Zaplanowane uruchomienia"
-        },
-        "edit_flow_from_execution": {
-          "description": "Możesz bezpośrednio przejść z widoku wykonania do definicji flow, aby szybko wprowadzać zmiany.",
-          "title": "Wróć do edytora flow"
-        },
-        "execute_flow": {
-          "description": "Uruchomienie rozpoczyna wykonanie flow z wartościami inputów podanymi w czasie wykonywania.",
-          "title": "Uruchom flow"
-        },
-        "finish": {
-          "description": "Świetny początek. Utworzyłeś, uruchomiłeś, sparametryzowałeś i zaplanowałeś flow.<br><br>Wybierz, co chcesz zrobić dalej ...",
-          "title": "Ukończyłeś samouczek Pierwszy Flow"
-        },
-        "flow_basics": {
-          "description": "W Kestra <code>flow</code> jest główną jednostką orkiestracji. Definiujesz go w YAML z metadanymi i uporządkowanymi zadaniami.<br><br>Przejrzyj poniższą przykładową strukturę, a następnie buduj ją krok po kroku.",
-          "title": "Podstawy flow"
-        },
-        "save_flow": {
-          "description": "Zapisanie utrwala definicję flow, aby można było ją uruchomić.",
-          "title": "Zapisz flow"
-        },
-        "save_flow_again": {
-          "description": "Twój flow ma teraz harmonogram oraz domyślną wartość inputu dla automatycznych uruchomień.",
-          "title": "Zapisz flow"
-        },
-        "view_logs_status": {
-          "description": "Szczegóły wykonania pokazują status, czas trwania oraz logi wyjściowe na poziomie zadań.<br><br>Otwórz teraz szczegóły wykonania i kliknij <code>greet</code> na wykresie Gantta, aby zobaczyć logi.",
-          "title": "Sprawdź wykonanie"
-        }
-      },
-      "validation": {
-        "add_cron_trigger_cron": "Dodaj wyrażenie cron, np.: `\"*/5 * * * *\"`.",
-        "add_cron_trigger_section": "Utwórz sekcję `triggers` z wyzwalaczem harmonogramu.",
-        "add_cron_trigger_type": "Ustaw typ wyzwalacza na `io.kestra.plugin.core.trigger.Schedule`.",
-        "add_id": "Dodaj ID flow na górze. Przykład: `id: hello_flow`.",
-        "add_input_default_defaults": "Dodaj domyślną wartość dla `name`, np.: `defaults: \"Kestra\"`.",
-        "add_input_default_id": "Pozostaw istniejące ID inputu jako `name`.",
-        "add_input_default_section": "Wróć do `inputs` i pozostaw jeden istniejący input o nazwie `name` (nie dodawaj drugiego inputu).",
-        "add_input_id": "W sekcji `inputs` dodaj `id: name`.",
-        "add_input_section": "Utwórz sekcję `inputs` z jednym inputem.",
-        "add_input_type": "Ustaw typ inputu na `STRING`.",
-        "add_log_task_id": "Nadaj zadaniu ID, np.: `id: greet`.",
-        "add_log_task_message": "Dodaj pole `script` do zadania.",
-        "add_log_task_pebble": "Użyj wyrażenia Pebble w skrypcie, aby wykorzystać wartość inputu (np.: `inputs.name`).",
-        "add_log_task_section": "Utwórz sekcję `tasks` i dodaj pierwsze zadanie.",
-        "add_log_task_type": "Ustaw typ zadania na `io.kestra.plugin.scripts.python.Script`.",
-        "add_namespace": "Dodaj namespace na górze. Przykład: `namespace: company.team`.",
-        "complete_step": "Już prawie gotowe. Ukończ ten krok, aby kontynuować.",
-        "edit_flow_from_execution": "Kliknij `Edytuj flow` w górnym pasku, aby kontynuować.",
-        "execute_flow": "Uruchom flow raz, aby kontynuować.",
-        "fix_yaml": "Wystąpił drobny problem z formatowaniem YAML. Popraw go, a następnie kontynuuj.",
-        "save_flow": "Kliknij Zapisz, aby kontynuować.",
-        "save_flow_again": "Kliknij ponownie Zapisz, aby kontynuować.",
-        "view_logs_status": "Otwórz szczegóły wykonania i sprawdź logi dla `greet`."
-      },
-      "welcome": {
-        "additional_help": "Dodatkowa pomoc",
-        "badge": "Samouczek",
-        "blueprints": "Blueprinty",
-        "docs": "Dokumentacja",
-        "guided_description": "Dowiedz się, jak utworzyć i uruchomić swój pierwszy flow dzięki instrukcjom krok po kroku.",
-        "guided_duration": "Polecane dla większości użytkowników",
-        "guided_title": "Zbuduj swój pierwszy flow",
-        "headline": "Zbuduj i uruchom swój pierwszy workflow w kilka minut",
-        "self_serve_description": "Przejdź bezpośrednio do edytora i zbuduj własny flow.",
-        "self_serve_note": "Dla zaawansowanych użytkowników",
-        "self_serve_title": "Utwórz flow od podstaw",
-        "slack": "Społeczność Slack",
-        "tutorial": "Samouczek"
-      }
+    "download": "Pobierz",
+    "jsonl": "JSONL",
+    "concurrency_limit": {
+      "dialog_title": "Limity Równoczesności",
+      "warning": "Zmiana bieżącego licznika może uszkodzić współbieżność, co może spowodować przekroczenie dozwolonego limitu przez wykonania."
     },
-    "open": "Otwórz",
-    "open full page": "Otwórz pełną stronę",
-    "open in new tab": "W nowej zakładce",
-    "open in same tab": "W tej samej zakładce",
-    "open sidebar": "otwórz pasek boczny",
-    "open source": "Otwarte Źródło",
-    "open_page": "Open page",
-    "optional": "Opcjonalne",
-    "original execution": "Oryginalne wykonanie",
-    "originalCreatedDate": "Oryginalna data utworzenia",
-    "outdated revision save confirmation": {
-      "confirm": "Czy chcesz to nadpisać?",
-      "create": {
-        "description": "Flow z tym samym id już istnieje w tym namespace.",
-        "details": "Zapisz, aby nadpisać i utworzyć nową wersję.",
-        "title": "Flow już istnieje"
-      },
-      "update": {
-        "description": "Wersja, którą edytujesz, jest przestarzała.",
-        "details": "Sprawdź zakładkę Wersje, aby uzyskać więcej informacji o najnowszej wersji.",
-        "title": "Przestarzała wersja"
-      }
+    "documentation": {
+      "documentation": "Dokumentacja",
+      "github": "Otwórz problem na GitHub"
     },
-    "output": "Wyjście",
-    "outputs": "Wyjścia",
-    "override": {
-      "details": "Poprzedni flow można przywrócić z karty Revisions.",
-      "title": "Zamierzasz nadpisać bieżący flow"
-    },
-    "overview": "Przegląd",
-    "page": {
-      "next": "Następna strona",
-      "previous": "Poprzednia strona"
-    },
-    "panel actions": "Akcje panelu",
-    "parent execution": "Wykonanie rodzica",
-    "password": "Hasło",
-    "password empty constraint": "Nieprawidłowa nazwa użytkownika lub hasło",
-    "password length constraint": "Hasło nie może przekraczać 256 znaków",
-    "passwords do not match": "Hasła nie pasują do siebie",
-    "pause": "Wstrzymaj",
-    "pause backfill": "Wstrzymaj backfill",
-    "pause backfills": "Wstrzymaj backfills",
-    "pause confirm": "Czy na pewno chcesz wstrzymać wykonanie <code>{id}</code>?",
-    "pause done": "Wykonanie jest PAUSED",
-    "pause title": "Wstrzymaj wykonanie <code>{id}</code>.<br/>Zauważ, że aktualnie uruchomione taski nadal będą przetwarzane, a wykonanie będzie musiało zostać wznowione ręcznie.",
-    "paused": "Wstrzymano",
-    "playground": {
-      "clear_history": "Wyczyść historię",
-      "confirm_create": "Nie można uruchomić playground podczas tworzenia flow. Uruchomienie playground run utworzy flow.",
-      "history": "Ostatnie 10 uruchomień",
-      "play_icon_info": "Możesz również kliknąć ikonę Play w widokach No-Code lub Topology.",
-      "run_all_tasks": "Uruchom Wszystkie Taski",
-      "run_task": "Uruchom Task",
-      "run_task_and_downstream": "Uruchom task i downstream",
-      "run_task_info": "Najedź kursorem na dowolne zadanie w edytorze Flow Code i kliknij przycisk \"Run task\", aby przetestować swoje zadanie.",
-      "run_this_task": "Uruchom ten task",
-      "title": "Plac zabaw",
-      "toggle": "Plac zabaw",
-      "tooltip_persistence": "Jeśli wyłączysz i ponownie włączysz Playground, informacje pozostaną, dopóki pozostaniesz na stronie."
-    },
-    "playground actions": "Akcje w Playground",
-    "plugin defaults exported": "Domyślne ustawienia pluginu wyeksportowane",
-    "plugin defaults imported": "Domyślne ustawienia wtyczki zaimportowane",
-    "plugin defaults not imported": "Niektóre domyślne ustawienia pluginów nie mogły zostać zaimportowane",
-    "pluginDefaults": {
-      "add": "Dodaj Domyślną Wtyczkę",
-      "add_subtitle": "Skonfiguruj nową domyślną wtyczkę z jej właściwościami",
-      "cancel": "Anuluj",
-      "custom": "Wtyczka niestandardowa",
-      "custom_configure": "Niestandardowy typ wtyczki - konfiguruj za pomocą YAML",
-      "custom_placeholder": "Wprowadź typ pluginu",
-      "custom_type": "Niestandardowy typ wtyczki",
-      "edit": "Edytuj domyślny plugin",
-      "edit_subtitle": "Zmodyfikuj domyślną konfigurację istniejącej wtyczki",
-      "form": "Formularz",
-      "predefined": "Wstępnie zdefiniowana wtyczka",
-      "select_predefined": "Wybierz Wstępnie Zdefiniowaną Wtyczkę",
-      "show_yaml": "Pokaż YAML",
-      "title": "Domyślne ustawienia wtyczki",
-      "update": "Aktualizuj domyślną wtyczkę",
-      "use_custom": "Użyj niestandardowego",
-      "yaml": "YAML",
-      "yaml_configuration": "Konfiguracja YAML"
-    },
-    "pluginPage": {
-      "elementType": {
-        "apps": "Aplikacja",
-        "charts": "Wykres",
-        "conditions": "Warunek",
-        "logExporters": "Eksporter logów",
-        "secrets": "Sekret",
-        "taskRunners": "Uruchamianie tasków",
-        "tasks": "Zadanie",
-        "triggers": "Trigger"
-      },
-      "group": {
-        "blueprints": "Blueprinty ({count})",
-        "plugins": "Wtyczki ({count})",
-        "tasks": "Zadania ({count})"
-      },
+    "blueprints": {
+      "all": "Wszystkie",
+      "community": "Społeczność",
+      "create": "Utwórz blueprint",
+      "edit": "Edytuj blueprint",
+      "title": "Blueprints",
+      "empty": "Brak blueprintów do wyświetlenia.",
       "header": {
-        "back": "Wróć do pluginów",
-        "certified": "Certyfikowany",
-        "enterpriseEdition": "Edycja Enterprise"
+        "catch phrase": {
+          "1": "Pierwszy krok jest zawsze najtrudniejszy.",
+          "2": "Eksploruj blueprints, aby rozpocząć swój następny {kind}."
+        },
+        "alt": "Ikona Blueprintów"
       },
-      "loadError": "Nie można załadować wtyczek. Proszę spróbować ponownie.",
-      "noResults": "Brak wtyczek pasujących do wyszukiwania.",
-      "notFound": "Nie znaleziono tego pluginu.",
-      "overview": {
-        "createdBy": "Utworzone przez",
-        "latest": "Najnowsze",
-        "linksResources": "Linki i zasoby",
-        "managedBy": "Zarządzane przez",
-        "minKestraVersion": "Minimalna kompatybilna wersja Kestra: {version}",
-        "minKestraVersionShort": "Minimalna wersja Kestra {version}",
-        "pluginType": "Typ wtyczki",
-        "previousVersions": "Poprzednie wersje",
-        "releaseNotes": "Informacje o wydaniu",
-        "title": "Przegląd",
-        "versions": "Wersje"
+      "custom": "Niestandardowe blueprints",
+      "flows": "Schematy Flow",
+      "apps": "Szablony aplikacji",
+      "dashboards": "Dashboard Blueprinty",
+      "detail": {
+        "category": "Typ kategorii",
+        "links": "Linki i zasoby",
+        "openInEditor": "Otwórz w Edytuj Flow"
       },
-      "search": "Wyszukaj wśród {count}+ wtyczek",
-      "searchTasks": "Wyszukaj {count} tasków",
-      "sort": {
-        "mostUsed": "Najczęściej używane",
-        "nameAsc": "Nazwa A-Z",
-        "nameDesc": "Nazwa Z-A",
-        "newest": "Najnowsze"
-      },
-      "sortBy": "Sortuj według"
+      "missingPlugins": {
+        "title": "Brakujące pluginy",
+        "description": "Ten blueprint używa tasków z pluginów, które nie są zainstalowane w tej instancji: {plugins}. Zainstaluj je, aby użyć tego blueprintu.",
+        "card": "Wymaga pluginów niezainstalowanych w tej instancji: {plugins}",
+        "install": "Zainstaluj pluginy"
+      }
     },
-    "plugin_default_already_exists": "Domyślna wtyczka dla <code>{type}</code> już istnieje.",
+    "use": "Użyj",
     "plugins": {
       "name": "Plugin",
       "names": "Plugins",
       "please": "Proszę wybrać task po prawej, aby zobaczyć jego dokumentację",
       "release": "Informacje o wydaniu"
     },
-    "port": "Port",
-    "prefill inputs": "Wypełnij",
-    "pretty_json": "Pretty JSON",
-    "prev_execution": "Poprzednia wykonanie",
-    "preview": {
-      "auto-view": "Widok automatyczny",
-      "collapse": "Zwiń",
-      "expand": "Rozwiń",
-      "force-editor": "Wymuś widok edytora",
-      "label": "Podgląd",
-      "next": "Dalej",
-      "page_of": "Strona {current} z {total}",
-      "pagination_info": "Wyświetlanie wierszy {start}-{end} z {total}.",
-      "previous": "Poprzedni",
-      "rows_truncated": "Wyświetlanie {shown} z {total} wierszy. Pobierz plik, aby zobaczyć wszystkie dane.",
-      "showing_rows": "Wyświetlanie wierszy {start}-{end} z {total}",
-      "view": "Zobacz"
+    "last execution date": "Data ostatniego wykonania",
+    "last execution state": "Ostatni stan",
+    "last X days count": "{count} w ostatnich {days} dniach",
+    "date range count": "{count} między {startDate} a {endDate}",
+    "date count": "{count} w dniu {date}",
+    "revisions": "Wersje",
+    "no revisions found": "Istnieje tylko jedna wersja dla tego flow",
+    "no revisions": "Brak rewizji",
+    "see full revision": "Zobacz pełną wersję",
+    "side-by-side": "obok siebie",
+    "line-by-line": "linia po linii",
+    "template": "Szablon",
+    "template creation": "Utworzenie szablonu",
+    "templates": "Szablony",
+    "templates deprecated": "Szablony są przestarzałe. Proszę używać subflows. Zobacz <a href=\"https://kestra.io/docs/migration-guide/0.11.0/templates?utm_source=app&utm_medium=referral&utm_campaign=template-inlinedoc\" target=\"_blank\">sekcję migracji</a>, aby dowiedzieć się, jak migrować z szablonów do subflows.",
+    "no result": "Nie ma wyników do wyświetlenia.",
+    "empty search": "Wyniki wyszukiwania są puste",
+    "trigger": "Trigger",
+    "no_trigger": "Brak dostępnego triggera.",
+    "triggers": "Triggers",
+    "triggers_header_description": "Przeglądaj, dodawaj i zarządzaj triggerami, aby automatyzować swoje flows. Wybierz spośród udostępniania swojego flow jako narzędzie AI, planowania, dodawania webhook trigger, sondowania zmian w zewnętrznych aplikacjach lub słuchaczy zdarzeń w czasie rzeczywistym.",
+    "triggers_tabs_add": "Dodaj",
+    "triggers_tabs_manage": "Zarządzaj",
+    "triggers_add_search_placeholder": "Szukaj triggerów...",
+    "triggers_add_filter_core": "Rdzeń",
+    "triggers_add_filter_realtime": "Rzeczywisty czas",
+    "triggers_add_filter_all": "Wszystko",
+    "triggers_add_filter_app": "Aplikacja",
+    "triggers_add_empty_title": "Nie znaleziono triggerów",
+    "triggers_add_ee_tooltip": "Ten trigger wymaga Enterprise Edition.",
+    "triggers_add_category_empty": "Brak triggerów w tej kategorii.",
+    "triggers_add_card_add_to_flow": "Dodaj do flow",
+    "triggers_add_card_add": "Dodaj",
+    "triggers_add_modal_title": "{name}",
+    "triggers_add_modal_tab_form": "Formularz",
+    "triggers_add_modal_tab_source": "Źródło",
+    "triggers_add_modal_tab_documentation": "Dokumentacja",
+    "triggers_add_modal_namespace_placeholder": "Wybierz namespace",
+    "triggers_add_modal_flow_placeholder": "Wybierz flow",
+    "triggers_add_modal_trigger_id": "ID triggera",
+    "triggers_add_modal_trigger_id_placeholder": "Unikalny identyfikator dla tego triggera",
+    "triggers_add_modal_properties_hint": "Skonfiguruj właściwości triggera w edytorze flow po dodaniu triggera.",
+    "triggers_add_modal_ee_notice": "Ten trigger wymaga Enterprise Edition.",
+    "triggers_add_modal_add_button": "Dodaj Trigger do Flow",
+    "trigger details": "Szczegóły trigger",
+    "triggerflow disabled": "Trigger jest wyłączony w definicji flow",
+    "last trigger date": "Data ostatniego triggera",
+    "trigger_states": "Stany",
+    "context updated date": "Data aktualizacji kontekstu",
+    "state updated date": "Data aktualizacji stanu",
+    "next evaluation date": "Data następnej oceny",
+    "last evaluation date": "Data ostatniej oceny",
+    "last trigger date tooltip": "Kiedy trigger został ostatnio wykonany. Może być w przeszłości podczas uruchamiania backfill.",
+    "context updated date tooltip": "Kiedy kontekst triggera został ostatnio zaktualizowany. Dzieje się to, gdy wykonanie jest uruchamiane, kończy się (blokada zwolniona) lub po ocenie (nawet jeśli nie dochodzi do wykonania).",
+    "next evaluation date tooltip": "Gdy trigger zostanie ponownie oceniony, na podstawie jego interwału. Nie zawsze jest to samo co następna data wykonania, jeśli warunki nie są spełnione.",
+    "last evaluation date tooltip": "When the trigger was last evaluated by the scheduler, regardless of whether it produced an execution.",
+    "conditions": "Warunki",
+    "triggerId": "Identyfikator Trigger",
+    "tenantId": "Identyfikator Mandanta",
+    "codeDisabled": "Wyłączone w flow",
+    "paused": "Wstrzymano",
+    "running": "RUNNING",
+    "Fold auto": "Edytor: automatyczne składanie wieloliniowych",
+    "Hover description": "Edytor: Pokaż opis pola po najechaniu na key lub value",
+    "Fold content lines": "Złóż wieloliniowe ciągi",
+    "Unfold content lines": "Rozwiń wieloliniowe ciągi",
+    "Total": "Całkowity",
+    "sub flow": "Subflow",
+    "execute": "Wykonaj",
+    "execute flow behaviour": "Wykonaj flow",
+    "open in same tab": "W tej samej zakładce",
+    "open in new tab": "W nowej zakładce",
+    "execute the flow": "Wykonaj flow <code>{id}</code>",
+    "execute flow now ?": "Czy chcesz wykonać ten flow?",
+    "discard execution confirmation": "Masz niezapisane inputy. Czy na pewno chcesz odrzucić tę wykonanie?",
+    "discard changes confirmation": "Masz niezapisane zmiany. Czy na pewno chcesz je odrzucić?",
+    "Default namespace": "Domyślny namespace",
+    "Default log level": "Domyślny poziom log",
+    "unsaved changed ?": "Masz niezapisane zmiany, czy chcesz opuścić tę stronę?",
+    "unsaved changes": "Niezapisane zmiany",
+    "unsaved changes warning": "Masz niezapisane zmiany. Jeśli opuścisz tę stronę, twoje zmiany zostaną utracone.",
+    "leave page": "Opuść stronę",
+    "open full page": "Otwórz pełną stronę",
+    "drill down preview": "Podgląd",
+    "Editor theme": "Motyw edytora",
+    "Editor fontsize": "Rozmiar czcionki edytora",
+    "Editor fontfamily": "Rodzina czcionek edytora",
+    "errors": {
+      "401": {
+        "title": "Nieautoryzowany",
+        "content": "Musisz być uwierzytelniony, aby uzyskać dostęp do tej strony."
+      },
+      "403": {
+        "title": "Dostęp zabroniony",
+        "content": "Nie masz wymaganych uprawnień, aby uzyskać dostęp do tej strony."
+      },
+      "404": {
+        "title": "Strona nie znaleziona",
+        "content": "Żądany URL nie został znaleziony na tym serwerze.<br />To wszystko, co wiemy.",
+        "flow or execution": "Flow lub wykonanie, którego szukasz, nie istnieje."
+      }
     },
-    "pricing": "Cennik",
-    "product_tour": "Przewodnik po produkcie",
-    "properties": {
-      "hidden": "Ukryte w tabeli",
-      "hint": "Wybierz widoczne kolumny",
-      "label": "Właściwości",
-      "shown": "Wyświetlane w tabeli"
+    "back_to_dashboard": "Powrót do pulpitu",
+    "copy all logs": "Skopiuj wszystkie Logi",
+    "copy logs": "Kopiuj logs",
+    "fix_with_ai": "Napraw za pomocą AI",
+    "download logs": "Pobierz logs",
+    "delete logs": "Usuń logs",
+    "delete_all_logs": "Czy na pewno chcesz usunąć wszystkie logs?",
+    "delete_log": "Czy na pewno chcesz usunąć log?",
+    "toggle fullscreen": "Przełącz pełny ekran",
+    "copied": "Skopiowano",
+    "tags": "Tagi",
+    "disabled flow title": "Ten flow jest wyłączony",
+    "disabled flow desc": "Ten flow jest wyłączony, proszę włączyć go, aby go wykonać.",
+    "label": "Label",
+    "labels": "Etykiety",
+    "label filter placeholder": "Etykieta jako 'key:value'",
+    "execution labels": "Etykiety wykonania",
+    "wrong labels": "Pusta wartość lub key nie jest dozwolona w etykietach",
+    "feeds": {
+      "title": "Co nowego w Kestra",
+      "heading": "Wszystko o Kestra.",
+      "subheading": "Najnowsze aktualizacje, przewodniki i historie"
     },
-    "queued duration": "Czas trwania w kolejce",
-    "quotas": "Kwoty",
-    "reach us": "Porozmawiaj z nami",
-    "read-more": "Czytaj więcej o",
-    "readonly property": "Właściwość tylko do odczytu",
-    "recent_executions": "Ostatnie Wykonania",
-    "refresh": "Odśwież",
-    "reject": "Odrzuć",
-    "relative": "Względny",
-    "relative end date": "Względna data zakończenia",
-    "relative start date": "Względna data rozpoczęcia",
-    "remove label": "Usuń label",
-    "remove this item": "Usuń ten element",
-    "remove_bookmark": "Czy na pewno chcesz usunąć tę zakładkę?",
-    "replay": "Odtwórz",
-    "replay confirm": "Czy na pewno chcesz odtworzyć to wykonanie <code>{id}</code> i utworzyć nowe?",
-    "replay execution description": "To utworzy nową wykonanie na podstawie wybranego wykonania.",
-    "replay execution title": "Ponowne wykonanie",
-    "replay from beginning tooltip": "Utwórz podobne wykonanie zaczynając od początku",
-    "replay from task tooltip": "Utwórz podobne wykonanie zaczynając od task <code>{taskId}</code>",
-    "replay inputs": "Wejścia",
-    "replay inputs new required": "Ta wersja ma inputy. Zostaniesz poproszony o ich wypełnienie.",
-    "replay latest revision": "Odtwórz używając najnowszej wersji",
-    "replay select taskrun": "Wybierz uruchomienie task do ponownego odtworzenia z:",
-    "replay the execution": "Odtwórz wykonanie <code>{executionId}</code> dla flow <code>{flowId}</code>",
-    "replay using": "Odtwórz używając",
-    "replay with inputs": "Odtwórz z inputami",
-    "replayed": "Wykonanie jest odtwarzane",
-    "required field": "Wymagane pole",
-    "reset": "Restartuj",
-    "reset to defaults": "Resetuj do ustawień domyślnych",
-    "restart": "Uruchom ponownie",
-    "restart change revision": "Możesz zmienić wersję, która będzie używana do nowego wykonania.",
-    "restart confirm": "Czy na pewno chcesz ponownie uruchomić wykonanie <code>{id}</code>?",
-    "restart execution title": "Uruchom ponownie wykonanie",
-    "restart latest revision": "Uruchom ponownie najnowszą wersję",
-    "restart tooltip": "Uruchom ponownie wykonanie od task <code>{state}</code>",
-    "restart trigger": {
-      "button": "Restartuj trigger",
-      "tooltip": "Uruchom ponownie trigger"
-    },
-    "restarted": "Wykonanie zostało ponownie uruchomione",
+    "delete execution running": "<div class=\"alert alert-warning mt-2 mb-0\">To wykonanie jest nadal w trakcie, usunięcie go nie zatrzyma procesu.<br />Musisz zabić wykonanie, aby je zatrzymać.</div>",
     "restore": "Przywróć",
     "restore confirm": "Czy na pewno chcesz przywrócić wersję <code>{revision}</code>?",
+    "bulk delete": "Czy na pewno chcesz usunąć <code>{executionCount}</code> wykonanie(a)?",
+    "bulk replay": "Czy na pewno chcesz odtworzyć <code>{executionCount}</code> wykonanie(a)?",
+    "bulk change state": "Czy na pewno chcesz zmienić stan <code>{executionCount}</code> wykonania/wykonań?",
+    "bulk resume": "Czy na pewno chcesz wznowić <code>{executionCount}</code> wykonanie(a)?",
+    "bulk pause": "Czy na pewno chcesz wstrzymać wykonanie <code>{executionCount}</code>?",
+    "bulk unqueue": "Czy na pewno chcesz usunąć z kolejki <code>{executionCount}</code> wykonanie(a)?",
+    "bulk force run": "Czy na pewno chcesz wymusić uruchomienie <code>{executionCount}</code> wykonania/ń?<br/><br/>WARNING: wymuszenie uruchomienia wykonania nie jest gwarantowane i może spowodować duplikaty wykonania tasków.<br/><br/>Zostaną wykonane następujące przejścia:<br/><ul><li>Taski w stanie CREATED zostaną przeniesione do stanu RUNNING.</li><li>Taski w stanie RUNNING zostaną ponownie przesłane.</li><li>Taski w stanie QUEUED zostaną odkolejkowane.</li><li>Taski w stanie PAUSED zostaną wznowione.</li></ul>",
+    "bulk restart": "Czy na pewno chcesz zrestartować <code>{executionCount}</code> wykonanie(a)?",
+    "bulk kill": "Czy na pewno chcesz zabić <code>{executionCount}</code> wykonanie(a)?",
+    "selection": {
+      "selected": "<strong>{count}</strong> wybrano",
+      "all": "Wybierz wszystkie ({count})"
+    },
+    "cancel": "Anuluj",
+    "errorLogs": "Logi błędów",
+    "welcome_page": {
+      "welcome": "Witamy w Kestra",
+      "guide": "Potrzebujesz wskazówek, jak uruchomić swój pierwszy flow?"
+    },
+    "product_tour": "Przewodnik po produkcie",
+    "executions replayed": "<code>{executionCount}</code> wykonanie(a) odtworzone",
+    "executions state changed": "Stan wykonania <code>{executionCount}</code> został zmieniony",
+    "executions resumed": "<code>{executionCount}</code> wykonanie(a) wznowione",
+    "executions paused": "<code>{executionCount}</code> wykonanie(a) wstrzymane",
+    "executions unqueue": "<code>{executionCount}</code> wykonanie(a) w kolejce",
+    "executions force run": "<code>{executionCount}</code> wykonanie(a) wymuszone uruchomienie",
+    "executions restarted": "<code>{executionCount}</code> wykonanie(a) zrestartowane",
+    "executions killed": "<code>{executionCount}</code> wykonanie(a) zabite",
+    "executions deleted": "<code>{executionCount}</code> wykonanie(a) usunięte",
+    "invalid bulk replay": "Nie można odtworzyć wykonań",
+    "invalid bulk resume": "Nie można wznowić wykonań",
+    "invalid bulk pause": "Nie można wstrzymać wykonania",
+    "invalid bulk unqueue": "Nie można usunąć z kolejki wykonania",
+    "invalid bulk force run": "Nie można wymusić uruchomienia wykonania",
+    "invalid bulk restart": "Nie można zrestartować wykonań",
+    "invalid bulk kill": "Nie można zabić wykonań",
+    "invalid bulk delete": "Nie można usunąć wykonań",
+    "execution not found": "Wykonanie {executionId} nie zostało znalezione.",
+    "execution not in state PAUSED": "Wykonanie <code>{executionId}</code> nie jest w stanie PAUSED",
+    "execution not in state FAILED": "Wykonanie <code>{executionId}</code> nie jest w stanie FAILED",
+    "execution already finished": "Wykonanie <code>{executionId}</code> już zakończone",
     "restore revision": "Czy na pewno chcesz przywrócić wersję <code>{revision}</code>?",
-    "resume": "Wznów",
-    "resume from breakpoint done": "Wykonanie zostało wznowione od punktu przerwania",
-    "resume from breakpoint title": "Wznów wykonanie <code>{id}</code> z punktu przerwania",
-    "resumed confirm": "Czy na pewno chcesz wznowić wykonanie <code>{id}</code>?",
-    "resumed done": "Wykonanie zostało wznowione",
-    "resumed title": "Wznów wykonanie <code>{id}</code>",
-    "reuse original inputs": "Ponownie użyj oryginalnych inputów",
-    "reuse_original_inputs": "Ponownie użyj oryginalnych inputów",
-    "review your inputs": "Sprawdź swoje dane wejściowe",
-    "revision": "Wersja",
-    "revision deleted": "Revision {revision} został pomyślnie usunięty",
-    "revisions": "Wersje",
-    "row count": "Liczba wierszy",
-    "run task in playground": "Uruchom task w playgroundzie",
+    "seeing old revision": "Widzisz starą wersję: {revision}",
+    "export": "Eksportuj",
+    "exports": "Eksporty",
+    "export_csv": "Eksportuj jako CSV",
+    "template export": "Czy na pewno chcesz wyeksportować <code>{templateCount}</code> szablon(y)?",
+    "templates exported": "Szablony wyeksportowane",
+    "export all templates": "Eksportuj wszystkie szablony",
+    "flow_export": "Eksportuj flow",
+    "flow export": "Czy na pewno chcesz wyeksportować <code>{flowCount}</code> flow(s)?",
+    "flows exported": "<code>{count}</code> Flow(s) wyeksportowane",
+    "export all flows": "Eksportuj wszystkie flows",
+    "import": "Importuj",
+    "disable": "Wyłącz",
+    "enable": "Włącz",
+    "enabled": "Włączone",
+    "template delete": "Czy na pewno chcesz usunąć <code>{templateCount}</code> szablon(y)?",
+    "flow delete": "Czy na pewno chcesz usunąć <code>{flowCount}</code> flow(s)?",
+    "templates deleted": "<code>{count}</code> Szablon(y) usunięte",
+    "flows deleted": "<code>{count}</code> Flow(s) usunięte",
+    "flow disable": "Czy na pewno chcesz wyłączyć <code>{flowCount}</code> flow(s)?",
+    "flow enable": "Czy na pewno chcesz włączyć <code>{flowCount}</code> flow(s)?",
+    "flows disabled": "<code>{count}</code> Flow(s) wyłączone",
+    "flows enabled": "<code>{count}</code> Flow(s) włączone",
+    "flow-no-dependencies": "Twój flow nie ma żadnych zależności",
+    "flow-dependencies": "zależności",
+    "read-more": "Czytaj więcej o",
+    "in-our-documentation": "w naszej dokumentacji.",
+    "dependencies": "Zależności",
+    "see dependencies": "Zobacz zależności",
+    "see timeline": "Zobacz oś czasu",
     "run timeline": "Uruchom oś czasu",
-    "runners": "Biegacze",
-    "running": "RUNNING",
-    "running duration": "Czas trwania w trakcie działania",
-    "save": "Zapisz",
+    "dependencies missing acls": "Brak uprawnień do tego flow",
+    "dependencies delete flow": "Ten flow ma zależności. Usunięcie go uniemożliwi wykonanie ich zależności.<br /><br /> Oto lista dotkniętych flows:",
+    "expand dependencies": "Rozwiń zależności",
+    "reset": "Restartuj",
+    "show task documentation": "Pokaż dokumentację task",
+    "hide task documentation": "Ukryj dokumentację task",
+    "show task documentation in editor": "Pokaż dokumentację task w edytorze",
+    "show documentation": "Pokaż dokumentację",
+    "focus task": "Kliknij na dowolny element, aby zobaczyć jego dokumentację.",
+    "validate": "Zatwierdź",
+    "add error handler": "Dodaj handler błędów",
+    "taskDefaults": "Domyślne ustawienia task",
+    "disabled": "Wyłączone",
+    "before": "przed",
+    "after": "po",
+    "add at position": "Dodaj {position} <code>{task}</code>",
+    "create first task": "Stwórz swój pierwszy task",
+    "dynamic": "Dynamiczny",
+    "choice": "Wybór",
+    "sequential": "Sekwencyjny",
+    "can not delete": "Nie można usunąć",
+    "can not have less than 1 task": "Każdy flow musi mieć przynajmniej jeden task.",
+    "task id already exists": "Task Id już istnieje",
+    "Task Id already exist in the flow": "Task Id {taskId} już istnieje w flow.",
+    "task id": "Task ID",
+    "taskid column details": "Ostatni task wykonywany i liczba jego prób.",
+    "flow already exists": "Flow już istnieje",
+    "flow already exists message": "Flow <code>{id}</code> już istnieje w namespace <code>{namespace}</code>. Czy chcesz utworzyć nową wersję?",
+    "plugin_default_already_exists": "Domyślna wtyczka dla <code>{type}</code> już istnieje.",
+    "namespace not allowed": "Namespace niedozwolony",
+    "switch-view": "Przełącz widok",
+    "source and topology": "Źródło i topologia",
+    "source and doc": "Źródło i dokumentacja",
+    "source and blueprints": "Źródło i blueprints",
+    "editor": "Edytor",
+    "error in editor": "Znaleziono błąd w edytorze",
+    "delete task confirm": "Czy chcesz usunąć task <code>{taskId}</code>?",
+    "can not save": "Nie można zapisać",
+    "flow must not be empty": "Flow nie może być pusty",
+    "flow must have id and namespace": "Flow musi mieć id i namespace.",
+    "flow creation denied in namespace": "Nie masz uprawnień do tworzenia flow w namespace `{namespace}`.",
+    "readonly property": "Właściwość tylko do odczytu",
+    "namespace and id readonly": "Właściwości `namespace` i `id` nie mogą być zmienione — są teraz ustawione na ich początkowe wartości. Jeśli chcesz zmienić nazwę flow lub zmienić jego namespace, możesz stworzyć nowy flow i usunąć stary.",
+    "avg": "Średnia",
+    "sum": "Suma",
+    "min": "Min",
+    "max": "Max",
+    "bar": "Bar",
+    "line": "Linia",
+    "metric": "Metryka",
+    "aggregation": "Agregacja",
+    "chart type": "Typ wykresu",
+    "metric choice": "Brak dostępnych metryk dla tego flow",
+    "of": "z",
+    "see_all_states": "Zobacz wszystkie stany",
     "save draft": {
       "message": "Szkic zapisany",
       "retrieval": {
@@ -1680,164 +724,336 @@
         "existing": "Szkic Flow <code>{flowFullName}</code> został zapisany, czy chcesz kontynuować edycję flow?"
       }
     },
-    "save task": "Zapisz Task",
-    "save_and_execute": "Zapisz i Wykonaj",
-    "save_as_draft": "Zapisz jako wersję roboczą",
-    "saved": "Pomyślnie zapisano",
-    "saved as draft": "Pomyślnie zapisano jako wersję roboczą",
-    "saved as draft done": "<em>{name}</em> został pomyślnie zapisany jako wersja robocza",
-    "saved done": "<em>{name}</em> został pomyślnie zapisany",
-    "scheduleDate": "Data harmonogramu",
-    "scope_filter": {
-      "all": "Wszystkie {label}",
-      "system": "System {label}",
-      "system_description": "System konserwacji {label}",
-      "user": "Użytkownik {label}",
-      "user_description": "Zwykły użytkownik zainicjował {label}"
+    "title": "Tytuł",
+    "api": "API",
+    "more_actions": "Więcej akcji",
+    "expand error": "Rozwiń tylko nieudane tasks",
+    "expand all": "Rozwiń wszystko",
+    "collapse all": "Zwiń wszystko",
+    "expand": "Rozwiń",
+    "collapse": "Zwiń",
+    "filter by this value": "Filter by this value",
+    "filter_for": "Filter for",
+    "filter_out": "Filter out",
+    "copy_value": "Copy value",
+    "open_page": "Open page",
+    "logs_copied": "Logs copied to your clipboard",
+    "expand_by_default": "Expand structured logs by default",
+    "show raw": "Show raw",
+    "similar lines": "similar lines",
+    "download_logs_description": "Choose which logs to export. Filters default to your current view.",
+    "display_settings": "Display settings",
+    "density": "Density",
+    "density_compact": "Compact",
+    "density_normal": "Normal",
+    "density_expanded": "Expanded",
+    "pretty_json": "Pretty JSON",
+    "body_line_clamp": "Limit line height",
+    "font size": "Font size",
+    "log expand setting": "Domyślne wyświetlanie Logs",
+    "environment": "Środowisko",
+    "environment name setting": "Nazwa środowiska",
+    "environment color setting": "Kolor środowiska",
+    "slack support": "Zadaj pytanie przez Slack",
+    "join community": "Dołącz Community",
+    "join_slack": "Dołącz do Slacka",
+    "kestra": "Kestra",
+    "reach us": "Porozmawiaj z nami",
+    "new version": "Nowa wersja {version} dostępna!",
+    "error detected": "Wykryto błąd(y).",
+    "warning detected": "Wykryto ostrzeżenie(a)",
+    "informative notice": "Notatka(i)",
+    "cannot swap tasks": "Nie można zamienić tasks",
+    "open": "Otwórz",
+    "dependency task": "Task {taskId} jest zależnością innego task",
+    "administration": "Administracja",
+    "admin": "Administrator",
+    "main_configuration": "Główna konfiguracja",
+    "commit_id": "Id commit",
+    "evaluation lock date": "Data blokady oceny",
+    "unlock trigger": {
+      "tooltip": {
+        "execution": "Trwa wykonanie dla tego trigger",
+        "evaluation": "Trigger jest obecnie w ocenie"
+      },
+      "confirmation": "Czy na pewno chcesz odblokować trigger?",
+      "warning": "Może to prowadzić do równoczesnych wykonań dla tego samego trigger i powinno być traktowane jako ostateczność.",
+      "button": "Odblokuj trigger",
+      "success": "Trigger odblokowany"
     },
-    "search": "Szukaj",
-    "search blueprint": "Wyszukaj blueprints",
-    "search filters": {
-      "filter name": "Nazwa filtra",
-      "filters": "Filtry",
-      "manage": "Zarządzaj filtrami wyszukiwania",
-      "manage desc": "Zarządzaj zapisanymi filtrami wyszukiwania",
-      "save filter": "Zapisz filtr",
-      "saved": "Zapisane filtry"
+    "restart trigger": {
+      "button": "Restartuj trigger",
+      "tooltip": "Uruchom ponownie trigger"
     },
-    "search term in message": "Wyszukaj termin w wiadomości",
-    "search_docs": "Szukaj",
-    "searching": "Szukanie...",
-    "secret": {
-      "add": "Utwórz",
-      "inherited": "Dziedziczone secrets",
-      "isReadOnly": "Sekret jest tylko do odczytu",
-      "names": "Secrets",
-      "update": "Aktualizuj sekret '{name}'"
-    },
-    "security_advice": {
-      "content": "Włącz podstawowe uwierzytelnianie, aby chronić swoją instancję.",
-      "enable": "Włącz uwierzytelnianie",
-      "switch_text": "Nie pokazuj ponownie",
-      "title": "Chroń swoją instancję"
-    },
-    "see dependencies": "Zobacz zależności",
-    "see full revision": "Zobacz pełną wersję",
-    "see timeline": "Zobacz oś czasu",
-    "see_all_states": "Zobacz wszystkie stany",
-    "seeing old revision": "Widzisz starą wersję: {revision}",
-    "select": "Wybierz swoją {{section}}",
-    "select a state": "Wybierz stan",
-    "select datetime": "Wybierz datę",
-    "select view": "Wybierz widok",
-    "selected": "Wybrane",
-    "selection": {
-      "all": "Wybierz wszystkie ({count})",
-      "selected": "<strong>{count}</strong> wybrano"
-    },
-    "sequential": "Sekwencyjny",
-    "server type": "Typ serwera",
+    "trigger disabled": "Trigger jest wyłączony w źródle Flow",
+    "flow source not found": "Źródło flow nie znalezione",
+    "date format": "Format daty",
+    "timezone": "Strefa czasowa",
+    "add task": "Dodaj task",
+    "unable to generate graph": "Wystąpił problem podczas generowania grafu, co uniemożliwia wyświetlenie topologii.",
+    "attempts": "Próba(y)",
+    "flow deleted, you can restore it": "Flow został usunięty i jest to widok tylko do odczytu. Nadal możesz go przywrócić.",
+    "workers": "Workers",
+    "worker group": "Grupa Worker",
+    "worker group key": "Klucz grupy Worker",
+    "worker group fallback": "Grupa Workerów awaryjna",
+    "version": "Wersja",
     "services": "Usługi",
+    "server type": "Typ serwera",
+    "hostname": "Nazwa hosta",
+    "port": "Port",
+    "management port": "Port zarządzania",
+    "file preview truncated": "Wyświetlana zawartość została skrócona",
+    "file unavailable": "Plik niedostępny",
+    "file unavailable description": "Ten plik nie jest już dostępny — mógł zostać usunięty lub wygasł.",
+    "row count": "Liczba wierszy",
+    "encoding": "Kodowanie",
+    "show": "Pokaż",
+    "advanced configuration": "Inne właściwości",
+    "all executions": "Wszystkie wykonania",
+    "trigger execution id": "Trigger Execution Id",
+    "execution_status": "Wykonanie jest:",
+    "no_tasks_running": "Jeszcze nie ma uruchomionych tasków.",
+    "execution_starts_progress": "Gdy tylko rozpocznie się wykonanie, zobaczysz tutaj aktualizacje postępu.",
+    "triggers_state": {
+      "state": "Stan",
+      "options": {
+        "enabled": "Włączone",
+        "disabled": "Wyłączone"
+      }
+    },
+    "trigger filter": {
+      "title": "Filtruj wykonania dzieci",
+      "options": {
+        "ALL": "Wszystkie wykonania",
+        "CHILD": "Wykonania dzieci",
+        "MAIN": "Wykonania rodziców"
+      }
+    },
+    "show chart": "Pokaż Wykres",
+    "namespace files": {
+      "toggle": {
+        "show": "Pokaż pliki namespace",
+        "hide": "Ukryj pliki namespace"
+      },
+      "filter": "Filtr",
+      "new_file": "Nowy plik",
+      "no_items": {
+        "heading": "Nie znaleziono jeszcze plików w twoim namespace.",
+        "paragraph": "Utwórz lub zaimportuj pliki, aby udostępniać kod między flow w twoim namespace."
+      },
+      "no_selection": {
+        "heading": "Nie wybrano plików",
+        "description": "Wybierz plik z drzewa, aby wyświetlić jego zawartość."
+      },
+      "tree": {
+        "expand": "Rozwiń wszystkie foldery",
+        "collapse": "Zwiń wszystkie foldery"
+      },
+      "create": {
+        "label": "Stwórz",
+        "file": "Stwórz plik",
+        "file_already_exists": "Plik o tej nazwie już istnieje",
+        "file_conflicts_with_folder": "Folder o tej nazwie już istnieje",
+        "file_error": "Wystąpił błąd podczas tworzenia pliku",
+        "folder": "Stwórz folder",
+        "folder_already_exists": "Folder o tej nazwie już istnieje",
+        "folder_conflicts_with_file": "Plik o tej nazwie już istnieje",
+        "folder_error": "Wystąpił błąd podczas tworzenia folderu"
+      },
+      "rename": {
+        "label": "Zmień nazwę",
+        "file": "Zmień nazwę pliku",
+        "folder": "Zmień nazwę folderu",
+        "new_file": "Nowa nazwa z rozszerzeniem:",
+        "new_folder": "Nowa nazwa folderu:"
+      },
+      "delete": {
+        "label": "Usuń",
+        "file": "Usuń plik",
+        "folder": "Usuń folder",
+        "files": "Usuń {count} wybrane pliki",
+        "folders": "Usuń {count} wybrane foldery"
+      },
+      "import": {
+        "import": "Importuj",
+        "files": "Importuj pliki",
+        "folder": "Importuj folder",
+        "success": "Plik(i) pomyślnie zaimportowane",
+        "error": "Wystąpiły błędy podczas importowania pliku(ów)"
+      },
+      "export": "Eksportuj pliki namespace",
+      "export_single": "Eksportuj plik",
+      "dialog": {
+        "name": {
+          "file": "Nazwa z rozszerzeniem:",
+          "folder": "Nazwa folderu:"
+        },
+        "parent_folder": "Folder nadrzędny:",
+        "deletion": {
+          "confirm": "Potwierdź",
+          "title": "Potwierdź usunięcie zawartości",
+          "files": "Czy na pewno chcesz usunąć <code>{count}</code> plik(ów)?",
+          "folders": "Czy na pewno chcesz usunąć <code>{count}</code> folder(y) i całą jego zawartość?",
+          "mixed": "Czy na pewno chcesz usunąć folder(y) <code>{folders}</code> i plik(i) <code>{files}</code>?",
+          "file_single": "Czy na pewno chcesz usunąć plik <code>{name}</code>?",
+          "folder_single": "Czy na pewno chcesz usunąć folder <code>{name}</code> i całą jego zawartość?"
+        }
+      },
+      "revisions": {
+        "history": "Historia wersji",
+        "restore": {
+          "success": "Przywrócenie wersji pliku zakończone sukcesem"
+        }
+      },
+      "path": {
+        "copy": "Skopiuj ścieżkę",
+        "success": "Ścieżka skopiowana do schowka",
+        "error": "Wystąpiły błędy podczas kopiowania ścieżki do schowka"
+      }
+    },
+    "continue backfill": "Kontynuuj backfill",
+    "delete backfill": "Usuń backfill",
+    "pause backfill": "Wstrzymaj backfill",
+    "continue backfills": "Kontynuuj backfills",
+    "delete backfills": "Usuń backfills",
+    "pause backfills": "Wstrzymaj backfills",
+    "backfill executions": "Backfill wykonania",
+    "execute backfill": "Wykonaj backfill",
+    "backfill paused": "Wstrzymano backfill",
+    "backfill running": "Backfill uruchomiony",
+    "relative": "Względny",
+    "relative start date": "Względna data rozpoczęcia",
+    "relative end date": "Względna data zakończenia",
+    "now": "Teraz",
+    "absolute": "Absolutny",
+    "backfill": "Backfill",
+    "Set labels tooltip": "Ustaw etykiety dla wykonania",
+    "Set labels": "Ustaw etykiety",
+    "manage labels": "Zarządzaj label",
+    "Set labels to execution": "Dodaj lub zaktualizuj etykiety wykonania <code>{id}</code>",
+    "Set labels done": "Pomyślnie ustawiono etykiety wykonania",
+    "bulk set labels": "Czy na pewno chcesz ustawić etykiety dla <code>{executionCount}</code> wykonanie(a)?",
+    "dependencies loaded": "Zależności załadowane",
+    "loaded x dependencies": "{count} zależności załadowane",
+    "security_advice": {
+      "title": "Chroń swoją instancję",
+      "content": "Włącz podstawowe uwierzytelnianie, aby chronić swoją instancję.",
+      "switch_text": "Nie pokazuj ponownie",
+      "enable": "Włącz uwierzytelnianie"
+    },
+    "true": "Prawda",
+    "false": "Fałsz",
+    "undefined": "Niezdefiniowane",
+    "execution-include-non-terminated": "Uwzględnić nieukończone wykonania?",
+    "execution-warn-title": "Ważne Ostrzeżenie!",
+    "execution-warn-deleting-still-running": "Zalecamy anulowanie tej akcji i zakończenie wszystkich trwających executions. Usunięcie nieukończonych executions może prowadzić do problemów z concurrency, niespójności w zarządzaniu zależnościami flow oraz procesów zombie na Twojej instancji, co może pogorszyć wydajność systemu. Upewnij się, że w pełni rozumiesz te ryzyka przed kontynuowaniem usuwania.",
+    "originalCreatedDate": "Oryginalna data utworzenia",
+    "welcome": {
+      "menu": "Welcome",
+      "tour": {
+        "title": "Rozpocznij wycieczkę po produkcie",
+        "text": "Wybierz swój przypadek użycia i postępuj zgodnie z przewodnikiem krok po kroku, aby poznać funkcje i możliwości Kestra. ❤️"
+      },
+      "tutorial": {
+        "title": "Samouczek",
+        "text": "* <a href=\"https://kestra.io/tutorial-videos/all?utm_source=app&utm_medium=referral&utm_campaign=welcome-tutorial\" target=\"_blank\">Samouczki wideo</a>  \n* <a href=\"https://kestra.io/docs?utm_source=app&utm_medium=referral&utm_campaign=welcome-tutorial\" target=\"_blank\">Dokumentacja</a>  \n* <a href=\"https://kestra.io/blueprints?utm_source=app&utm_medium=referral&utm_campaign=welcome-tutorial\" target=\"_blank\">Blueprinty</a>"
+      },
+      "help": {
+        "title": "Potrzebujesz pomocy?",
+        "text": "Zadaj dowolne pytanie w naszej społeczności Slack. Jeśli utkniesz, jesteśmy tutaj, aby Ci pomóc. ✋"
+      }
+    },
+    "pluginPage": {
+      "search": "Wyszukaj wśród {count}+ wtyczek",
+      "searchTasks": "Wyszukaj {count} tasków",
+      "noResults": "Brak wtyczek pasujących do wyszukiwania.",
+      "loadError": "Nie można załadować wtyczek. Proszę spróbować ponownie.",
+      "notFound": "Nie znaleziono tego pluginu.",
+      "elementType": {
+        "tasks": "Zadanie",
+        "triggers": "Trigger",
+        "conditions": "Warunek",
+        "taskRunners": "Uruchamianie tasków",
+        "charts": "Wykres",
+        "apps": "Aplikacja",
+        "logExporters": "Eksporter logów",
+        "secrets": "Sekret"
+      },
+      "sortBy": "Sortuj według",
+      "sort": {
+        "nameAsc": "Nazwa A-Z",
+        "nameDesc": "Nazwa Z-A",
+        "newest": "Najnowsze",
+        "mostUsed": "Najczęściej używane"
+      },
+      "group": {
+        "plugins": "Wtyczki ({count})",
+        "tasks": "Zadania ({count})",
+        "blueprints": "Blueprinty ({count})"
+      },
+      "overview": {
+        "title": "Przegląd",
+        "versions": "Wersje",
+        "latest": "Najnowsze",
+        "releaseNotes": "Informacje o wydaniu",
+        "previousVersions": "Poprzednie wersje",
+        "createdBy": "Utworzone przez",
+        "managedBy": "Zarządzane przez",
+        "pluginType": "Typ wtyczki",
+        "linksResources": "Linki i zasoby",
+        "minKestraVersion": "Minimalna kompatybilna wersja Kestra: {version}",
+        "minKestraVersionShort": "Minimalna wersja Kestra {version}"
+      },
+      "header": {
+        "enterpriseEdition": "Edycja Enterprise",
+        "certified": "Certyfikowany",
+        "back": "Wróć do pluginów"
+      }
+    },
+    "no inputs": "Ten flow nie ma inputs.",
+    "admin_preferences": "Preferences",
     "settings": {
+      "label": "Ustawienia",
+      "updated": "{name} zaktualizowano",
       "blocks": {
         "configuration": {
-          "descriptions": {
-            "auto_refresh_interval": "Sekundy między automatycznymi odświeżeniami danych na stronach list.",
-            "default_namespace": "Używane podczas tworzenia nowych flow bez namespace.",
-            "editor_type": "Edytor wyświetlany przy otwieraniu flow po raz pierwszy.",
-            "execute_default_tab": "Karta wybrana podczas nawigacji do wykonania.",
-            "execute_flow": "Gdzie wyniki wykonania otwierają się po uruchomieniu trigger.",
-            "flow_default_tab": "Karta wybrana podczas nawigacji do flow.",
-            "log_display": "Jak logi są prezentowane podczas otwierania wykonania.",
-            "log_level": "Minimalny poziom logów wyświetlany w logach wykonania.",
-            "playground": "Uruchom taski indywidualnie w edytorze playground.",
-            "triggers_default_tab": "Karta wybrana podczas nawigacji do strony triggerów."
-          },
+          "label": "Główna konfiguracja",
           "fields": {
-            "auto_refresh_interval": "Interwał automatycznego odświeżania",
-            "default_namespace": "Domyślny Namespace",
-            "editor_type": "Domyślny typ edytora",
-            "execute_default_tab": "Domyślna karta Execution",
-            "execute_flow": "Wykonaj Flow",
-            "flow_default_tab": "Domyślna karta Flow",
             "language": "Język",
-            "log_display": "Domyślne Wyświetlanie Log",
+            "default_namespace": "Domyślny Namespace",
             "log_level": "Domyślna Poziom Logs",
+            "log_display": "Domyślne Wyświetlanie Log",
+            "editor_type": "Domyślny typ edytora",
+            "execute_flow": "Wykonaj Flow",
+            "execute_default_tab": "Domyślna karta Execution",
             "multi_panel_editor": "Edytor Wielopanelowy",
+            "flow_default_tab": "Domyślna karta Flow",
+            "triggers_default_tab": "Domyślna karta Triggers",
             "playground": "Plac zabaw",
-            "triggers_default_tab": "Domyślna karta Triggers"
+            "auto_refresh_interval": "Interwał automatycznego odświeżania"
           },
-          "label": "Główna konfiguracja"
-        },
-        "export": {
-          "fields": {
-            "flows": "Eksportuj Wszystkie Flows",
-            "templates": "Eksportuj Wszystkie Szablony"
-          },
-          "label": "Eksportuj"
-        },
-        "localization": {
           "descriptions": {
-            "date_format": "Format używany do wyświetlania dat w całym dashboardzie.",
-            "language": "Język interfejsu dla menu i etykiet.",
-            "time_zone": "Używane do wyświetlania dat wykonania i zaplanowanych triggerów."
-          },
-          "fields": {
-            "date_format": "Format Daty",
-            "time_zone": "Strefa Czasowa"
-          },
-          "label": "Język i region",
-          "note": "Zauważ, że to ustawienie jest używane do wyświetlania właściwości daty i czasu w UI. Aby zaplanować swoje flows w strefie czasowej innej niż UTC, upewnij się, że ustawisz właściwość strefy czasowej w trigger harmonogramu w kodzie flow lub w domyślnych ustawieniach pluginów."
-        },
-        "reset_section_to_defaults": "Przywróć domyślne wartości tej sekcji",
-        "save": {
-          "discard": "Odrzuć",
-          "label": "Zapisz preferencje",
-          "unsaved_title": "Niezapisane zmiany",
-          "unsaved_warning": "Masz niezapisane zmiany. Czy chcesz je zapisać przed opuszczeniem?"
-        },
-        "sidebar": {
-          "descriptions": {
-            "items": "Pokaż, ukryj i zmień kolejność elementów w pasku bocznym."
-          },
-          "fields": {
-            "items": "Elementy nawigacyjne"
-          },
-          "label": "Pasek boczny"
+            "default_namespace": "Używane podczas tworzenia nowych flow bez namespace.",
+            "log_level": "Minimalny poziom logów wyświetlany w logach wykonania.",
+            "log_display": "Jak logi są prezentowane podczas otwierania wykonania.",
+            "editor_type": "Edytor wyświetlany przy otwieraniu flow po raz pierwszy.",
+            "execute_flow": "Gdzie wyniki wykonania otwierają się po uruchomieniu trigger.",
+            "execute_default_tab": "Karta wybrana podczas nawigacji do wykonania.",
+            "flow_default_tab": "Karta wybrana podczas nawigacji do flow.",
+            "triggers_default_tab": "Karta wybrana podczas nawigacji do strony triggerów.",
+            "auto_refresh_interval": "Sekundy między automatycznymi odświeżeniami danych na stronach list.",
+            "playground": "Uruchom taski indywidualnie w edytorze playground."
+          }
         },
         "theme": {
-          "app_font_size_options": {
-            "large": "Duży",
-            "medium": "Średni",
-            "small": "Mały"
-          },
-          "color_modes": {
-            "dark_1": "Dark 1.0",
-            "dark_2": "Dark 2.0",
-            "light": "Jasny",
-            "sync": "Synchronizuj z systemem"
-          },
-          "confirmations": {
-            "color_mode": "Twój interfejs używa teraz motywu `{mode}`."
-          },
-          "descriptions": {
-            "app_font_size": "Współczynnik skalowania stosowany do wszystkich rozmiarów czcionek interfejsu.",
-            "color_mode": "Wybierz preferowany motyw interfejsu.",
-            "color_mode_shortcut": "Wskazówka: naciśnij <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>L</kbd>, aby zmieniać motywy z dowolnego miejsca.",
-            "editor_folding_stratgy": "Domyślnie zwijaj długie bloki YAML podczas otwierania flow.",
-            "editor_font_family": "Czcionka monospace używana w edytorze YAML.",
-            "editor_font_size": "Rozmiar czcionki używany w edytorach YAML i no-code.",
-            "editor_hover_description": "Pokaż opisy właściwości po najechaniu kursorem w edytorze.",
-            "environment_color": "Kolor akcentu używany dla bieżącego środowiska w nawigacji.",
-            "environment_name": "Nazwa wyświetlana dla bieżącego środowiska, pokazywana w nawigacji.",
-            "logs_font_size": "Rozmiar czcionki używany w przeglądarkach logów i terminalach."
-          },
+          "label": "Preferencje Motywu",
           "fields": {
             "app_font_size": "Rozmiar czcionki aplikacji",
             "chart_color_scheme": {
+              "label": "Schemat kolorów wykresu",
               "classic": "Klasyczny",
-              "kestra": "Kestra",
-              "label": "Schemat kolorów wykresu"
+              "kestra": "Kestra"
             },
             "color_mode": "Tryb kolorów",
             "editor_folding_stratgy": "Automatyczne Zwijanie Kodu w Edytorze",
@@ -1850,24 +1066,867 @@
             "logs_font_size": "Rozmiar czcionki logów",
             "theme": "Motyw"
           },
-          "label": "Preferencje Motywu"
+          "color_modes": {
+            "dark_2": "Dark 2.0",
+            "dark_1": "Dark 1.0",
+            "light": "Jasny",
+            "sync": "Synchronizuj z systemem"
+          },
+          "confirmations": {
+            "color_mode": "Twój interfejs używa teraz motywu `{mode}`."
+          },
+          "descriptions": {
+            "color_mode": "Wybierz preferowany motyw interfejsu.",
+            "color_mode_shortcut": "Wskazówka: naciśnij <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>L</kbd>, aby zmieniać motywy z dowolnego miejsca.",
+            "logs_font_size": "Rozmiar czcionki używany w przeglądarkach logów i terminalach.",
+            "editor_font_family": "Czcionka monospace używana w edytorze YAML.",
+            "editor_font_size": "Rozmiar czcionki używany w edytorach YAML i no-code.",
+            "editor_folding_stratgy": "Domyślnie zwijaj długie bloki YAML podczas otwierania flow.",
+            "editor_hover_description": "Pokaż opisy właściwości po najechaniu kursorem w edytorze.",
+            "environment_name": "Nazwa wyświetlana dla bieżącego środowiska, pokazywana w nawigacji.",
+            "environment_color": "Kolor akcentu używany dla bieżącego środowiska w nawigacji.",
+            "app_font_size": "Współczynnik skalowania stosowany do wszystkich rozmiarów czcionek interfejsu."
+          },
+          "app_font_size_options": {
+            "small": "Mały",
+            "medium": "Średni",
+            "large": "Duży"
+          }
+        },
+        "localization": {
+          "label": "Język i region",
+          "note": "Zauważ, że to ustawienie jest używane do wyświetlania właściwości daty i czasu w UI. Aby zaplanować swoje flows w strefie czasowej innej niż UTC, upewnij się, że ustawisz właściwość strefy czasowej w trigger harmonogramu w kodzie flow lub w domyślnych ustawieniach pluginów.",
+          "fields": {
+            "time_zone": "Strefa Czasowa",
+            "date_format": "Format Daty"
+          },
+          "descriptions": {
+            "language": "Język interfejsu dla menu i etykiet.",
+            "time_zone": "Używane do wyświetlania dat wykonania i zaplanowanych triggerów.",
+            "date_format": "Format używany do wyświetlania dat w całym dashboardzie."
+          }
+        },
+        "export": {
+          "label": "Eksportuj",
+          "fields": {
+            "flows": "Eksportuj Wszystkie Flows",
+            "templates": "Eksportuj Wszystkie Szablony"
+          }
+        },
+        "save": {
+          "label": "Zapisz preferencje",
+          "discard": "Odrzuć",
+          "unsaved_title": "Niezapisane zmiany",
+          "unsaved_warning": "Masz niezapisane zmiany. Czy chcesz je zapisać przed opuszczeniem?"
+        },
+        "reset_section_to_defaults": "Przywróć domyślne wartości tej sekcji",
+        "sidebar": {
+          "label": "Pasek boczny",
+          "fields": {
+            "items": "Elementy nawigacyjne"
+          },
+          "descriptions": {
+            "items": "Pokaż, ukryj i zmień kolejność elementów w pasku bocznym."
+          }
+        }
+      }
+    },
+    "apps": "Aplikacje",
+    "demos": {
+      "enterprise_edition": "Enterprise Edition",
+      "get_a_demo_button": "Uzyskaj Demo",
+      "contact_sales": "Skontaktuj się z działem sprzedaży",
+      "watch_the_video": "Obejrzyj wideo",
+      "secrets": {
+        "title": "Ulepsz swoje zarządzanie Secrets Management",
+        "message": "Edycja Enterprise (EE) pozwala na dodawanie, edytowanie lub usuwanie sekretów bezpośrednio w UI — bez potrzeby ponownego uruchamiania instancji. Organizuj sekrety według namespace z precyzyjnymi uprawnieniami RBAC i dziedzicz je z namespace nadrzędnych do podrzędnych. EE integruje się z menedżerami sekretów, takimi jak HashiCorp Vault, AWS Secrets Manager, Azure Key Vault, Google Secret Manager i Elasticsearch. Skonfiguruj dedykowane backendy dla każdego namespace, mandanta lub instancji, aby izolować sekrety w zespołach, lub włącz sekrety tylko do odczytu przechowywane w zewnętrznych vaultach. Sekrety pozostają zaszyfrowane w spoczynku i podczas przesyłania. Opcjonalne buforowanie zmniejsza liczbę wywołań API, a ścieżki audytu logują cały dostęp.",
+        "detected_env": "Oto zmienne środowiskowe typu secret zidentyfikowane podczas uruchamiania instancji:",
+        "empty_env": "Nie masz jeszcze żadnych Secrets w swoim środowisku.",
+        "add_env": {
+          "intro": "Aby utworzyć nowy Secret:",
+          "first": "Zakoduj <a href=\"https://kestra.io/docs/how-to-guides/secrets?utm_source=app&utm_medium=referral&utm_campaign=secrets-inlinedoc#using-secrets-in-kestra\" target=\"_blank\">wartość secret w Base64</a>",
+          "second": "Dodaj zmienną środowiskową o nazwie '<strong>SECRET_{'{MY_SECRET_KEY}'}</strong>' z powyższą wartością",
+          "third": "Uruchom ponownie instancję Kestra"
         }
       },
-      "label": "Ustawienia",
-      "updated": "{name} zaktualizowano"
+      "apps": {
+        "title": "Twórz własne aplikacje z Kestra",
+        "message": "Aplikacje w Kestra Enterprise Edition umożliwiają tworzenie niestandardowych interfejsów użytkownika, które współdziałają z workflowami Kestra spoza platformy. Ta funkcja pozwala używać workflowów jako backendu dla niestandardowych aplikacji, umożliwiając użytkownikom nietechnicznym przesyłanie danych za pomocą formularzy lub wznawianie PAUSED workflowów oczekujących na zatwierdzenie."
+      },
+      "tests": {
+        "label": "Testy",
+        "header": "Testy jednostkowe dla flowów",
+        "title": "Zapewnij niezawodność przy każdej zmianie",
+        "message": "Zweryfikuj logikę swoich flow w izolacji, wcześnie wykrywaj regresje i utrzymuj pewność w swoich automatyzacjach, gdy się zmieniają i rozwijają."
+      },
+      "assets": {
+        "label": "Zasoby",
+        "header": "Metadane zasobów i obserwowalność",
+        "title": "Przenieś każdy zestaw danych, usługę i zależność do widoku.",
+        "message": "Zasoby łączą metadane dotyczące obserwowalności, pochodzenia i własności, aby zespoły platformowe mogły szybciej rozwiązywać problemy i wdrażać z pewnością."
+      },
+      "IAM": {
+        "title": "Zarządzaj użytkownikami przez IAM z SSO, SCIM i RBAC",
+        "message": "Kestra Enterprise Edition ma wbudowane funkcje IAM z jednokrotnym logowaniem (SSO), synchronizacją katalogu SCIM i kontrolą dostępu opartą na rolach (RBAC), integrując się z wieloma dostawcami tożsamości i pozwalając na przypisywanie szczegółowych uprawnień dla użytkowników i kont usługowych."
+      },
+      "tenants": {
+        "title": "Zarządzaj przepływami pracy w izolowanych tenantach",
+        "message": "Kestra Enterprise Edition obsługuje multi-tenancy, zapewniając w pełni izolowane środowiska dla różnych zespołów lub projektów, z własnymi zasobami, takimi jak dedykowane grupy workerów, sekrety i wewnętrzne magazyny danych."
+      },
+      "audit-logs": {
+        "title": "Śledź zmiany za pomocą Audit Logs",
+        "message": "Kestra Enterprise Edition rejestruje każdą aktywność za pomocą solidnych, niezmiennych zapisów, co ułatwia śledzenie zmian, utrzymanie zgodności oraz rozwiązywanie problemów."
+      },
+      "quotas": {
+        "title": "Egzekwowanie kwot wykonania dla flows",
+        "message": "Kestra Enterprise Edition umożliwia definiowanie kwot dla flows w celu ograniczenia liczby równoczesnych lub łącznych wykonań w danym oknie czasowym. Kwoty pomagają chronić współdzieloną infrastrukturę, egzekwować SLA i zapobiegać nadmiernemu zużyciu zasobów przez niekontrolowane workflows."
+      },
+      "instance": {
+        "title": "Zarządzaj infrastrukturą w całej swojej instancji",
+        "message": "Kestra Enterprise Edition zapewnia operacyjny dashboard, który pomaga obserwować stan zdrowia Twojej platformy i śledzić metryki dostępności wszystkich usług, takich jak m.in. Workers, Schedulers i Executors. Z tej samej strony możesz również tworzyć Ogłoszenia, aby powiadomić użytkowników o planowanych przerwach, a także możesz wprowadzić tryb konserwacji, który tymczasowo wprowadza wszystkie usługi i wykonania workflow w stan PAUSED, aby przeprowadzić aktualizację."
+      },
+      "blueprints": {
+        "title": "Dodaj niestandardowe Blueprints",
+        "message": "W Kestra Enterprise Edition możesz tworzyć niestandardowe Blueprints dostępne tylko dla Twojej organizacji. Możesz ich używać jako szablonów najlepszych praktyk do udostępniania, centralizowania i dokumentowania często używanych workflow w Twoim zespole."
+      },
+      "namespace": {
+        "edit": {
+          "title": "Ulepsz zarządzanie Namespace",
+          "message": "W Kestra Enterprise Edition, namespaces zapewniają zaawansowaną izolację i zarządzanie tajemnicami, zmiennymi oraz domyślnymi ustawieniami pluginów na dużą skalę. Administratorzy mogą konfigurować niestandardowych menedżerów tajemnic, izolowane zaplecza pamięci, dedykowane grupy workerów oraz szczegółowe uprawnienia na poziomie namespace. To zapewnia, że tajemnice, zmienne i konfiguracje pluginów pozostają bezpieczne i łatwe do utrzymania w różnych zespołach i projektach."
+        },
+        "secrets": {
+          "title": "Zarządzaj sekretami w bezpieczny sposób",
+          "message": "W Kestra Enterprise Edition możesz przechowywać i kontrolować tajemnice na poziomie namespace, minimalizując ryzyko i zapewniając izolację danych uwierzytelniających każdego zespołu. Dzięki zagnieżdżonej hierarchii możesz również skonfigurować dane uwierzytelniające w nadrzędnym namespace, a zostaną one odziedziczone przez wszystkie podrzędne namespaces. Wsparcie dla dedykowanych menedżerów tajemnic oraz szczegółowe ustawienia uprawnień na poziomie namespace dodatkowo wzmacniają bezpieczeństwo i zgodność."
+        },
+        "assets": {
+          "title": "Centralizacja zarządzania zasobami",
+          "message": "W Kestra Enterprise Edition, Assets prowadzi bieżący inwentarz zasobów, z którymi współpracują Twoje workflow. Te zasoby mogą być tabelami baz danych, maszynami wirtualnymi, plikami lub dowolnym zewnętrznym systemem, z którym pracujesz."
+        },
+        "variables": {
+          "title": "Centralnie Zarządzaj Swoimi Zmiennymi",
+          "message": "W Kestra Enterprise Edition możesz definiować i zarządzać zmiennymi na poziomie namespace, aby wyeliminować powtarzające się konfiguracje w różnych flow. Te zmienne zapewniają spójność, upraszczają aktualizacje konfiguracji i mogą być łatwo odwoływane przez dowolny task lub trigger, co prowadzi do czystszych i łatwiejszych w utrzymaniu workflow."
+        },
+        "plugin-defaults": {
+          "title": "Standaryzuj konfigurację za pomocą domyślnych ustawień Pluginów",
+          "message": "W Kestra Enterprise Edition możesz ustawić domyślne wtyczki specyficzne dla namespace, co zmniejsza potrzebę powielania konfiguracji w każdym flow. To centralne zarządzanie wtyczkami zapewnia spójne konfiguracje, umożliwia bezpieczne odwoływanie się do sekretów lub zmiennych oraz upraszcza utrzymanie twoich workflow."
+        },
+        "history": {
+          "title": "Zarządzaj historią wersji w jednym miejscu",
+          "message": "W Kestra Enterprise Edition możesz zarządzać historią wersji swoich namespace."
+        },
+        "audit-logs": {
+          "title": "Śledź wszystkie zmiany w jednym miejscu",
+          "message": "W Kestra Enterprise Edition możesz przeglądać dzienniki audytu na poziomie namespace z szczegółowymi różnicami, co daje jasną historię, kto, co i kiedy zmienił we wszystkich zasobach."
+        }
+      }
+    },
+    "assets": {
+      "title": "Zasoby"
+    },
+    "onboarding": {
+      "welcome": {
+        "headline": "Zbuduj i uruchom swój pierwszy workflow w kilka minut",
+        "guided_title": "Zbuduj swój pierwszy flow",
+        "badge": "Samouczek",
+        "guided_description": "Dowiedz się, jak utworzyć i uruchomić swój pierwszy flow dzięki instrukcjom krok po kroku.",
+        "guided_duration": "Polecane dla większości użytkowników",
+        "self_serve_title": "Utwórz flow od podstaw",
+        "self_serve_description": "Przejdź bezpośrednio do edytora i zbuduj własny flow.",
+        "self_serve_note": "Dla zaawansowanych użytkowników",
+        "additional_help": "Dodatkowa pomoc",
+        "docs": "Dokumentacja",
+        "tutorial": "Samouczek",
+        "blueprints": "Blueprinty",
+        "slack": "Społeczność Slack"
+      },
+      "steps": {
+        "flow_basics": {
+          "title": "Podstawy flow",
+          "description": "W Kestra <code>flow</code> jest główną jednostką orkiestracji. Definiujesz go w YAML z metadanymi i uporządkowanymi zadaniami.<br><br>Przejrzyj poniższą przykładową strukturę, a następnie buduj ją krok po kroku."
+        },
+        "add_id": {
+          "title": "Dodaj ID flow",
+          "description": "ID to unikalna nazwa Twojego flow, dzięki której możesz go znaleźć, uruchomić i spójnie do niego się odwoływać.<br><br>Teraz dodaj <code>id</code> na poziomie głównym."
+        },
+        "add_namespace": {
+          "title": "Dodaj namespace",
+          "description": "Namespace to grupowanie podobne do folderu, które organizuje flow według zespołu, projektu lub środowiska.<br><br>Teraz dodaj <code>namespace</code> na poziomie głównym."
+        },
+        "add_input": {
+          "title": "Dodaj input",
+          "description": "Inputs to parametry na poziomie flow, które można wykorzystywać w zadaniach, aby dynamicznie kontrolować zachowanie w czasie wykonywania.<br><br>Dodaj teraz input o nazwie <code>name</code> z typem <code>STRING</code>."
+        },
+        "add_log_task": {
+          "title": "Dodaj pierwsze zadanie",
+          "description": "Tasks to jednostki pracy wykonywane przez flow, zdefiniowane jako uporządkowana lista kroków. Każde zadanie wymaga unikalnego <code>id</code> oraz <code>type</code>. Kestra udostępnia wiele wtyczek zadań dla systemów zewnętrznych; tutaj użyjemy zadania Python Script.<br><br>Składnia <code>&#123;&#123; ... &#125;&#125;</code> to wyrażenie Pebble, używane do dynamicznego odwoływania się do zmiennych w czasie wykonywania, np. <code>&#123;&#123; inputs.name &#125;&#125;</code> z inputów flow.<br><br>Dodaj teraz pierwsze zadanie w sekcji <code>tasks</code> z <code>id</code>, <code>type</code> oraz <code>script</code>, który wypisze powitanie."
+        },
+        "save_flow": {
+          "title": "Zapisz flow",
+          "description": "Zapisanie utrwala definicję flow, aby można było ją uruchomić."
+        },
+        "execute_flow": {
+          "title": "Uruchom flow",
+          "description": "Uruchomienie rozpoczyna wykonanie flow z wartościami inputów podanymi w czasie wykonywania."
+        },
+        "view_logs_status": {
+          "title": "Sprawdź wykonanie",
+          "description": "Szczegóły wykonania pokazują status, czas trwania oraz logi wyjściowe na poziomie zadań.<br><br>Otwórz teraz szczegóły wykonania i kliknij <code>greet</code> na wykresie Gantta, aby zobaczyć logi."
+        },
+        "edit_flow_from_execution": {
+          "title": "Wróć do edytora flow",
+          "description": "Możesz bezpośrednio przejść z widoku wykonania do definicji flow, aby szybko wprowadzać zmiany."
+        },
+        "add_cron_trigger": {
+          "title": "Dodaj wyzwalacz cron",
+          "description": "Triggers mogą uruchamiać wykonania na podstawie harmonogramu lub zdarzeń zewnętrznych (np. webhooków lub wiadomości MQTT).<br><br>Dodaj teraz wyzwalacz cron, aby ten flow uruchamiał się co 5 minut."
+        },
+        "add_input_default": {
+          "title": "Ustaw domyślną wartość inputu",
+          "description": "Gdy flow jest wyzwalany automatycznie, inputy nadal wymagają wartości w czasie wykonywania.<br><br>Input <code>name</code> został już utworzony w poprzednim kroku, więc nie musisz dodawać go ponownie. Ustaw tylko domyślną wartość dla istniejącego inputu <code>name</code>."
+        },
+        "save_flow_again": {
+          "title": "Zapisz flow",
+          "description": "Twój flow ma teraz harmonogram oraz domyślną wartość inputu dla automatycznych uruchomień."
+        },
+        "background_runs_info": {
+          "title": "Zaplanowane uruchomienia",
+          "description": "Ten flow będzie teraz wykonywany w tle co 5 minut.<br><br>Możesz przejść do przeglądu Executions z menu po lewej stronie, aby monitorować zaplanowane uruchomienia."
+        },
+        "finish": {
+          "title": "Ukończyłeś samouczek Pierwszy Flow",
+          "description": "Świetny początek. Utworzyłeś, uruchomiłeś, sparametryzowałeś i zaplanowałeś flow.<br><br>Wybierz, co chcesz zrobić dalej ..."
+        }
+      },
+      "actions": {
+        "next": "Dalej",
+        "complete": "Zakończ",
+        "save_to_continue": "Kliknij Zapisz w górnym pasku (po prawej).",
+        "execute_to_continue": "1. Kliknij Uruchom w górnym pasku (po prawej).\n2. Podaj wartość dla <strong>name</strong>.\n3. Kliknij ponownie Uruchom w oknie modalnym.",
+        "edit_flow_to_continue": "Kliknij Edytuj flow w górnym pasku (po prawej).",
+        "cancel_tutorial": "Anuluj samouczek",
+        "finish_tutorial": "Zakończ samouczek"
+      },
+      "finish_actions": {
+        "explore_blueprints": "Przeglądaj Blueprinty",
+        "create_flow": "Utwórz flow"
+      },
+      "editor_hints": {
+        "build_intro": "Zbuduj swój pierwszy flow krok po kroku.",
+        "step_1": "# 1) Dodaj id",
+        "step_2": "# 2) Dodaj namespace",
+        "step_3": "# 3) Dodaj input",
+        "step_4": "# 4) Dodaj tasks i pierwsze zadanie Python",
+        "step_5": "# 5) Dodaj wyzwalacz cron"
+      },
+      "cancel_modal": {
+        "title": "Anuluj samouczek Pierwszy Flow",
+        "description": "Czy chcesz anulować samouczek Pierwszy Flow?",
+        "confirm": "Anuluj samouczek",
+        "keep": "Kontynuuj samouczek"
+      },
+      "validation": {
+        "complete_step": "Już prawie gotowe. Ukończ ten krok, aby kontynuować.",
+        "fix_yaml": "Wystąpił drobny problem z formatowaniem YAML. Popraw go, a następnie kontynuuj.",
+        "add_id": "Dodaj ID flow na górze. Przykład: `id: hello_flow`.",
+        "add_namespace": "Dodaj namespace na górze. Przykład: `namespace: company.team`.",
+        "add_input_section": "Utwórz sekcję `inputs` z jednym inputem.",
+        "add_input_id": "W sekcji `inputs` dodaj `id: name`.",
+        "add_input_type": "Ustaw typ inputu na `STRING`.",
+        "add_log_task_section": "Utwórz sekcję `tasks` i dodaj pierwsze zadanie.",
+        "add_log_task_id": "Nadaj zadaniu ID, np.: `id: greet`.",
+        "add_log_task_type": "Ustaw typ zadania na `io.kestra.plugin.scripts.python.Script`.",
+        "add_log_task_message": "Dodaj pole `script` do zadania.",
+        "add_log_task_pebble": "Użyj wyrażenia Pebble w skrypcie, aby wykorzystać wartość inputu (np.: `inputs.name`).",
+        "save_flow": "Kliknij Zapisz, aby kontynuować.",
+        "execute_flow": "Uruchom flow raz, aby kontynuować.",
+        "view_logs_status": "Otwórz szczegóły wykonania i sprawdź logi dla `greet`.",
+        "edit_flow_from_execution": "Kliknij `Edytuj flow` w górnym pasku, aby kontynuować.",
+        "add_cron_trigger_section": "Utwórz sekcję `triggers` z wyzwalaczem harmonogramu.",
+        "add_cron_trigger_type": "Ustaw typ wyzwalacza na `io.kestra.plugin.core.trigger.Schedule`.",
+        "add_cron_trigger_cron": "Dodaj wyrażenie cron, np.: `\"*/5 * * * *\"`.",
+        "add_input_default_section": "Wróć do `inputs` i pozostaw jeden istniejący input o nazwie `name` (nie dodawaj drugiego inputu).",
+        "add_input_default_id": "Pozostaw istniejące ID inputu jako `name`.",
+        "add_input_default_defaults": "Dodaj domyślną wartość dla `name`, np.: `defaults: \"Kestra\"`.",
+        "save_flow_again": "Kliknij ponownie Zapisz, aby kontynuować."
+      }
+    },
+    "enable concurrency": "Włącz concurrency",
+    "auditlogs": "Audit Logs",
+    "quotas": "Kwoty",
+    "iam": "IAM",
+    "tenant": {
+      "name": "Mandant",
+      "names": "Najemcy"
+    },
+    "ee-tooltip": {
+      "features-blocked": "Ta funkcja wymaga Enterprise Edition.",
+      "button": "Porozmawiaj z nami"
+    },
+    "flow_only": "Dostępne tylko na zakładce Flow.",
+    "bulk action async warning": "To może zająć kilka chwil.",
+    "bulk unpause backfills": "Wznów {count} backfill",
+    "bulk pause backfills": "Wstrzymaj {count} backfill",
+    "bulk delete backfills": "Usuń {count} backfill",
+    "bulk unlock": "Odblokuj {count} triggers",
+    "bulk disabled status": {
+      "true": "Wyłącz {count} triggers",
+      "false": "Włącz {count} triggers"
+    },
+    "unlock": "Odblokuj",
+    "bulk success unpause backfills": "{count} backfills wznowione",
+    "bulk success pause backfills": "{count} backfills wstrzymane",
+    "bulk success delete backfills": "{count} backfills usunięte",
+    "bulk success unlock": "{count} triggers odblokowane",
+    "bulk success disabled status": {
+      "true": "{count} trigger(s) wyłączone",
+      "false": "{count} trigger(s) włączone"
+    },
+    "no_namespaces": "Zero namespaces spełnia kryteria wyszukiwania.",
+    "system_namespace": "Zachowaj kontrolę nad swoją platformą dzięki systemowym flows.",
+    "system_namespace_description": "Automatyzuj zadania konserwacyjne, od alertów o awariach po automatyczne czyszczenie.",
+    "pluginDefaults": {
+      "title": "Domyślne ustawienia wtyczki",
+      "add": "Dodaj Domyślną Wtyczkę",
+      "edit": "Edytuj domyślny plugin",
+      "add_subtitle": "Skonfiguruj nową domyślną wtyczkę z jej właściwościami",
+      "edit_subtitle": "Zmodyfikuj domyślną konfigurację istniejącej wtyczki",
+      "predefined": "Wstępnie zdefiniowana wtyczka",
+      "custom": "Wtyczka niestandardowa",
+      "form": "Formularz",
+      "yaml": "YAML",
+      "select_predefined": "Wybierz Wstępnie Zdefiniowaną Wtyczkę",
+      "cancel": "Anuluj",
+      "update": "Aktualizuj domyślną wtyczkę",
+      "custom_type": "Niestandardowy typ wtyczki",
+      "custom_placeholder": "Wprowadź typ pluginu",
+      "use_custom": "Użyj niestandardowego",
+      "custom_configure": "Niestandardowy typ wtyczki - konfiguruj za pomocą YAML",
+      "yaml_configuration": "Konfiguracja YAML",
+      "show_yaml": "Pokaż YAML"
+    },
+    "secret": {
+      "add": "Utwórz",
+      "update": "Aktualizuj sekret '{name}'",
+      "isReadOnly": "Sekret jest tylko do odczytu",
+      "names": "Secrets",
+      "inherited": "Dziedziczone secrets"
+    },
+    "workerId": "Worker Id",
+    "kv": {
+      "name": "KV Store",
+      "type": "Typ",
+      "add": "Utwórz",
+      "update": "Zaktualizuj value dla key '{key}'",
+      "duplicate": "Ten key już istnieje",
+      "delete multiple": {
+        "confirm": "Czy na pewno chcesz usunąć: <code>{name}</code> kv?",
+        "warning": "Nie masz uprawnień do tych namespace, więc zostaną pominięte: <code>{namespaces}</code>"
+      },
+      "inherited": "Odziedziczone pary KV"
+    },
+    "expiration": "Wygaśnięcie",
+    "failed to render pdf": "Nie udało się wygenerować podglądu PDF",
+    "page": {
+      "previous": "Poprzednia strona",
+      "next": "Następna strona"
+    },
+    "namespace_editor": {
+      "empty": {
+        "title": "Obecnie brak otwartych zakładek",
+        "create_message": "Możesz tworzyć lub importować pliki namespace.",
+        "video_message": "Możesz obejrzeć Wideo Wprowadzające do naszego Edytora."
+      },
+      "close": {
+        "tab": "Zamknij kartę",
+        "all": "Zamknij wszystkie karty",
+        "other": "Zamknij inne karty",
+        "right": "Zamknij po prawej"
+      }
+    },
+    "curl": {
+      "command": "Komenda cURL",
+      "note": "Pamiętaj, że dla typu input SECRET i FILE, polecenie musi być dostosowane do rzeczywistych wartości."
+    },
+    "webhook": {
+      "curl_command": "Polecenie cURL Webhook",
+      "payload": "Payload Webhook (JSON)",
+      "curl_note": "Użyj tej komendy cURL, aby triggerować flow za pomocą webhook z niestandardowym ładunkiem JSON.",
+      "no_triggers": "Ten flow nie ma włączonych webhook triggerów",
+      "copy_url": "Skopiuj URL webhooka"
+    },
+    "logs_view": {
+      "raw": "Widok czasowy",
+      "raw_details": "Pokaż pełne task logs i flow logs w surowym formacie uporządkowanym według znaczników czasu",
+      "compact": "Widok domyślny",
+      "compact_details": "Pokaż task logs w kompaktowym widoku pogrupowanym według każdego task"
+    },
+    "execution_deletion": {
+      "logs": "Usuń logs",
+      "metrics": "Usuń metrics",
+      "storage": "Usuń wewnętrzne pliki storage"
+    },
+    "scope_filter": {
+      "all": "Wszystkie {label}",
+      "user": "Użytkownik {label}",
+      "system": "System {label}",
+      "user_description": "Zwykły użytkownik zainicjował {label}",
+      "system_description": "System konserwacji {label}"
+    },
+    "data": "Dane",
+    "webhook link copied": "Link Webhook skopiowany.",
+    "copy url": "Kopiuj URL",
+    "scheduleDate": "Data harmonogramu",
+    "warning": "Ostrzeżenie",
+    "trigger_check_warning": "Używanie zmiennych trigger nie zadziała przy ręcznym wykonaniu flow. Dodaj operator koalescencji `??`, aby rozwiązać problem. Na przykład, zamiast `trigger.date`, użyj `trigger.date ?? execution.startDate`.",
+    "docs": "Dokumentacja",
+    "active-slots": "Aktywne sloty",
+    "behavior": "Zachowanie",
+    "concurrency": "Współbieżność",
+    "no-executions-view": {
+      "title": "Zacznij automatyzację z",
+      "sub_title": "Kliknij przycisk Wykonaj, aby rozpocząć pierwsze wykonanie workflow.",
+      "namespace_sub_title": "Wykonaj jeden lub więcej flow z tego namespace, aby wypełnić ten dashboard.",
+      "guidance_desc": "Potrzebujesz wskazówek, jak wykonać swój flow?",
+      "namespace_guidance_desc": "Potrzebujesz wskazówek, jak zarządzać swoim Namespace?",
+      "guidance_sub_desc": "Postępuj zgodnie z dokumentacją, aby uzyskać wszystkie potrzebne informacje."
+    },
+    "execution_guide": {
+      "get_started": {
+        "title": "Zacznij ⚡",
+        "text": "Postępuj zgodnie z Przewodnikiem Szybkiego Startu, aby zainstalować Kestra i rozpocząć tworzenie swoich pierwszych workflowów."
+      },
+      "namespaces": {
+        "title": "O Namespace'ach",
+        "text": "Namespace to logiczne grupowanie flow i ich komponentów."
+      },
+      "workflow_components": {
+        "title": "Komponenty Workflow",
+        "text": "Poznaj główne komponenty orkiestracji w workflow Kestra."
+      },
+      "videos_tutorials": {
+        "title": "Samouczki wideo",
+        "text": "Rozpocznij korzystanie z naszych samouczków wideo."
+      }
+    },
+    "open sidebar": "otwórz pasek boczny",
+    "close sidebar": "zamknij pasek boczny",
+    "customize sidebar": "Dostosuj pasek boczny",
+    "reset to defaults": "Resetuj do ustawień domyślnych",
+    "drop items here": "Upuść elementy tutaj",
+    "files": "Pliki",
+    "optional": "Opcjonalne",
+    "no_data": "Wygląda na to, że nic tu nie ma... jeszcze!<br/>Dostosuj swoje filtry lub spróbuj ponownie!",
+    "bookmark": "Zakładki",
+    "remove_bookmark": "Czy na pewno chcesz usunąć tę zakładkę?",
+    "showLess": "Pokaż mniej",
+    "showMore": "Pokaż więcej",
+    "documentationMenu": "Menu dokumentacji",
+    "item": "element",
+    "items": "elementy",
+    "cron": "Kron",
+    "execution_started": "Rozpoczęto wykonanie!",
+    "execution_failed": "Wykonanie nie powiodło się!",
+    "last error was": "Ostatni błąd to",
+    "execution restarted": "Ta wykonanie zostało ponownie uruchomione {nbRestart} raz(y).",
+    "execution replay": "To wykonanie jest powtórką z",
+    "execution replayed": "To wykonanie zostało odtworzone.",
+    "task run id": "ID TaskRun",
+    "active": "Aktywny",
+    "flows imported": "Zaimportowane flows",
+    "flow not imported": "Niektóre flow nie mogły zostać zaimportowane",
+    "plugin defaults exported": "Domyślne ustawienia pluginu wyeksportowane",
+    "failed to export plugin defaults": "Nie udało się wyeksportować domyślnych ustawień wtyczki",
+    "plugin defaults imported": "Domyślne ustawienia wtyczki zaimportowane",
+    "plugin defaults not imported": "Niektóre domyślne ustawienia pluginów nie mogły zostać zaimportowane",
+    "failed to import plugin defaults": "Nie udało się zaimportować domyślnych ustawień wtyczki",
+    "filters": {
+      "label": "Wybierz filtry",
+      "empty": "Brak danych.",
+      "format": "Wpisz parametr jako 'key:value'",
+      "text_search": "Wyszukaj ten tekst",
+      "options": {
+        "namespace": "Namespace",
+        "flow": "Flow",
+        "state": "Stan",
+        "scope": "Zakres",
+        "child": "Dziecko",
+        "level": "Poziom logowania",
+        "task": "Zadanie",
+        "metric": "Metryka",
+        "user": "Użytkownik",
+        "type": "Typ",
+        "service_type": "Typ",
+        "permission": "Uprawnienie",
+        "action": "Akcja",
+        "status": "Status",
+        "details": "Szczegóły",
+        "aggregation": "Agregacja",
+        "relative_date": "Data względna",
+        "absolute_date": "Data bezwzględna",
+        "labels": "Etykiety",
+        "text": "tekst",
+        "startDate": "Data rozpoczęcia",
+        "endDate": "Data zakończenia"
+      },
+      "comparators": {
+        "is": "jest",
+        "is_one_of": "jest jednym z",
+        "is_not": "nie jest",
+        "not_in": "nie w",
+        "contains": "zawiera",
+        "not_contains": "nie zawiera",
+        "in": "w",
+        "between": "pomiędzy",
+        "starts_with": "zaczyna się od",
+        "greater_than": "większe niż",
+        "greater_than_or_equal_to": "większe lub równe",
+        "less_than": "mniej niż",
+        "less_than_or_equal_to": "mniejsze lub równe",
+        "ends_with": "kończy się na"
+      },
+      "save": {
+        "label": "Zapisane wyszukiwania",
+        "remove": "Usuń",
+        "empty": "Nie zapisałeś jeszcze żadnego wyszukiwania.",
+        "tooltip": "Nie można zapisać pustych kryteriów wyszukiwania.",
+        "name_already_used": "Szukana label już używana.",
+        "dialog": {
+          "heading": "Zapisz bieżące wyszukiwanie",
+          "placeholder": "Etykieta",
+          "hint": "Jak chcesz oznaczyć te kryteria wyszukiwania?",
+          "confirmation": "Kryteria wyszukiwania <code>{name}</code>"
+        }
+      },
+      "settings": {
+        "label": "Ustawienia strony",
+        "show_chart": "Pokaż główny wykres"
+      }
+    },
+    "custom value": "Wartość niestandardowa",
+    "chart": "Wykres",
+    "chart preview": "Podgląd wykresu",
+    "no_code": {
+      "toggle_pebble": "Przełącz edytor Pebble",
+      "version_oss_placeholder": "Odblokuj wersjonowanie pluginów z Enterprise Edition",
+      "unnamed": "Brak Nazwy",
+      "adding": "+ Dodaj {what}",
+      "adding_default": "+ Dodaj nową wartość",
+      "add_field": "Dodaj {field}",
+      "clearSelection": "Wyczyść zaznaczenie",
+      "labels": {
+        "yaml": "Edytor YAML",
+        "no_code": "Edytor No Code",
+        "label": "Etykieta",
+        "variable": "Zmienna"
+      },
+      "sections": {
+        "deprecated": "Właściwości przestarzałe",
+        "tasks": "Zadania",
+        "triggers": "Triggery",
+        "errors": "Obsługa błędów",
+        "afterExecution": "Po wykonaniu",
+        "finally": "Na koniec",
+        "pluginDefaults": "Domyślne ustawienia Pluginów"
+      },
+      "fields": {
+        "main": {
+          "id": "Flow ID",
+          "namespace": "Namespace",
+          "description": "Opis",
+          "inputs": "Wejścia"
+        },
+        "general": {
+          "retry": "Ponów próbę",
+          "sla": "SLA",
+          "labels": "Etykiety",
+          "outputs": "Wyjścia",
+          "variables": "Zmienne",
+          "concurrency": "Współbieżność",
+          "disabled": "Wyłączony",
+          "listeners": "Słuchacze",
+          "taskDefaults": "Domyślne ustawienia Task",
+          "workerGroup": "Grupa Worker",
+          "workerSelector": "Selektor Worker",
+          "checks": "Kontrole",
+          "updated": "Zaktualizowano"
+        }
+      },
+      "select": {
+        "default": "Wybierz typ",
+        "task": "Wybierz task",
+        "tasks": "Wybierz task",
+        "triggers": "Wybierz trigger",
+        "errors": "Wybierz task",
+        "finally": "Wybierz task",
+        "pluginDefaults": "Wybierz plugin",
+        "afterExecution": "Wybierz task",
+        "conditions": "Wybierz warunek",
+        "inputs": "Wybierz typ pola input",
+        "charts": "Wybierz typ wykresu",
+        "where": "Wybierz typ filtra",
+        "numerator": "Wybierz licznik"
+      },
+      "creation": {
+        "default": "Dodaj",
+        "tasks": "Dodaj task",
+        "triggers": "Dodaj trigger",
+        "errors": "Dodaj obsługę błędów",
+        "finally": "Dodaj blok finally",
+        "pluginDefaults": "Dodaj domyślny plugin",
+        "afterExecution": "Dodaj blok po wykonaniu",
+        "conditions": "Dodaj warunek",
+        "inputs": "Dodaj pole input",
+        "charts": "Dodaj wykres",
+        "where": "Filtruj swoje dane",
+        "numerator": "Dodaj licznik"
+      },
+      "remove": {
+        "default": "Usuń ten wpis",
+        "cases": "Usuń ten przypadek"
+      }
+    },
+    "properties": {
+      "label": "Właściwości",
+      "hint": "Wybierz widoczne kolumny",
+      "shown": "Wyświetlane w tabeli",
+      "hidden": "Ukryte w tabeli"
+    },
+    "editor_shortcuts": {
+      "label": "Skróty klawiaturowe",
+      "trigger_autocompletion": "Wyzwól autouzupełnianie",
+      "command_palette": "Pokaż paletę poleceń",
+      "save_flow": "Zapisz flow",
+      "execute_flow": "Uruchom flow",
+      "toggle_ai_agent": "Przełącz agenta AI",
+      "move_line": "Przenieś linię",
+      "duplicate_cursor": "Duplikuj kursor",
+      "fold_unfold": "Zwiń/Rozwiń kod",
+      "comment_uncomment": "Komentarz/Odkomentuj",
+      "comment": "Komentarz",
+      "uncomment": "Odkomentuj",
+      "decrease_fontsize": "Zmniejsz rozmiar czcionki edytora",
+      "increase_fontsize": "Zwiększ rozmiar czcionki edytora",
+      "reset_fontsize": "Zresetuj rozmiar czcionki edytora"
+    },
+    "instance": "Instancja",
+    "something_went_wrong": {
+      "loading_execution": "Wystąpił problem podczas ładowania wykonania",
+      "connection_lost": {
+        "title": "Połączenie przerwane",
+        "message": "Nie udało nam się połączyć z instancją Kestra. Upewnij się, że jest uruchomiona, a następnie odśwież stronę."
+      }
+    },
+    "debug": "Debugowanie",
+    "default": "Domyślny",
+    "data_not_protected": "Twoje dane nie są chronione. Nie trać ich. <b>Włącz nasze darmowe funkcje zabezpieczeń lub wypróbuj naszą płatną ofertę.</b>",
+    "activate_basic_auth": "Aktywuj podstawowe uwierzytelnianie",
+    "dark_version": "Ciemna wersja",
+    "use_dark_background": "Użyj tej wersji podczas pracy na ciemnym tle, aby zapewnić, że nasza nazwa pozostanie czytelna.",
+    "light_version": "Wersja jasna",
+    "light_background": "To jest preferowana opcja podczas pracy z jasnym tłem.",
+    "monogram": "Monogram",
+    "wordmark_colors": "Kolory znaku słownego dostosowują się w zależności od tła, podczas gdy ikona pozostaje bez tła, gdy jest umieszczona na ciemnym tle.",
+    "download_logos": "Pobierz Pakiet Logo",
+    "this_task_has": "To zadanie ma",
+    "about_this_blueprint": "O tym blueprint",
+    "deleted_label": "Usunięto",
+    "fold_all_multi_lines": "Zwiń wszystkie linie wielokrotne",
+    "task_id_exists": "Id zadania już istnieje",
+    "task_id_message": "Identyfikator Task ${existingTask} już istnieje w flow.",
+    "trigger_id_exists": "Id triggera już istnieje",
+    "trigger_id_message": "Identyfikator Trigger ${existingTrigger} już istnieje w flow.",
+    "watch": "Oglądaj",
+    "learn_more": "Dowiedz się więcej",
+    "watch_video": "Obejrzyj wideo",
+    "runners": "Biegacze",
+    "select": "Wybierz swoją {{section}}",
+    "for flow": "dla flow",
+    "forbidden system labels": "Tylko system.correlationId może być użyty jako system label",
+    "confirm": "Potwierdź",
+    "taskRunners": "Task Runners",
+    "additionalPlugins": "Dodatkowe Wtyczki",
+    "appBlocks": "Bloki aplikacji",
+    "charts": "Wykresy",
+    "dataFilters": "Filtry Danych",
+    "logExporters": "Eksporterzy Logów",
+    "empty": {
+      "namespaceFiles": {
+        "title": "Brak plików w tym namespace",
+        "content": "Pliki namespace działają jak folder projektu dla tego namespace. Przechowuj kod Python, SQL, dbt lub Terraform, a następnie odwołuj się do dowolnego pliku w swoich flows za pomocą"
+      },
+      "announcements": {
+        "title": "Nie masz jeszcze ogłoszeń!",
+        "content": "Ogłoszenia pozwalają powiadomić użytkowników o wszelkich zmianach lub poinformować ich o planowanej przerwie konserwacyjnej. Wystarczy wybrać typ ogłoszenia, zakres dat, w którym ma być wyświetlane, i napisać treść ogłoszenia."
+      },
+      "kill_switches": {
+        "title": "Nie masz jeszcze Kill Switches!",
+        "content": "Funkcja Kill Switch zapewnia mechanizm w interfejsie użytkownika do zatrzymywania problematycznych wykonania. Zastępuje polecenia CLI <code>--skip-executions</code> i <code>--skip-flows</code> kompleksowym interfejsem administracyjnym."
+      },
+      "apps": {
+        "title": "Nie masz jeszcze aplikacji!",
+        "content": "Rozpocznij tworzenie aplikacji do interakcji z Kestra ze świata zewnętrznego."
+      },
+      "testSuites": {
+        "title": "Nie masz jeszcze żadnych Test suites!",
+        "content": "Rozpocznij tworzenie zestawów testowych do testowania swoich flow."
+      },
+      "assets": {
+        "title": "Nie masz jeszcze zasobów!",
+        "content": "Dodaj zasoby, aby śledzić i zarządzać swoimi zasobami danych, usługami i infrastrukturą."
+      },
+      "apiTokens": {
+        "title": "Zarządzaj swoimi tokenami API",
+        "content": "Tokeny API są używane za każdym razem, gdy chcesz przyznać programowy dostęp do API Kestra."
+      },
+      "concurrency_executions": {
+        "title": "Brak trwających Executions dla tego flow.",
+        "content": "Przeczytaj więcej o <strong><a href=\"https://kestra.io/docs/workflow-components/execution?utm_source=app&utm_medium=referral&utm_campaign=concurrency-inlinedoc\" target=\"_blank\">Executions</a></strong> w naszej dokumentacji."
+      },
+      "concurrency_limit": {
+        "title": "Dla tego flow nie ustawiono żadnych limitów.",
+        "content": "Przeczytaj więcej o <strong><a href=\"https://kestra.io/docs/workflow-components/concurrency?utm_source=app&utm_medium=referral&utm_campaign=concurrency-inlinedoc\" target=\"_blank\">Limitach Nebenläufigkeit</a></strong> w naszej dokumentacji."
+      },
+      "concurrency_limits": {
+        "title": "Nie ustawiono limitów współbieżności.",
+        "content": "Przeczytaj więcej o <strong><a href=\"https://kestra.io/docs/workflow-components/concurrency?utm_source=app&utm_medium=referral&utm_campaign=concurrency-inlinedoc\" target=\"_blank\">Limitach Równoczesności</a></strong> w naszej dokumentacji."
+      },
+      "pluginDefaults": {
+        "title": "Nie masz jeszcze domyślnych pluginów!",
+        "content": "Domyślne ustawienia Pluginów pozwalają centralnie zarządzać konfiguracją pluginów i udostępniać ją wszystkim flow w twoim namespace."
+      },
+      "variables": {
+        "title": "Jeszcze brak zmiennych",
+        "content": "Dodaj pary klucz-wartość, aby udostępniać konfigurację między flow. Podrzędne namespace dziedziczą je automatycznie, a każdą wartość można odwołać za pomocą"
+      },
+      "workerRegistrationTokens": {
+        "title": "Nie masz jeszcze tokenów rejestracyjnych!",
+        "content": "Tokeny rejestracyjne pozwalają zdalnym workerom na bezpieczne uwierzytelnianie i rejestrowanie się w Twojej instancji Kestra. Utwórz token, a następnie użyj go, aby połączyć nowych workerów z tym klastrem."
+      },
+      "groups": {
+        "title": "Nie masz jeszcze grup!",
+        "content": "Grupy pozwalają na łączenie użytkowników, aby można było zarządzać uprawnieniami i przypisaniami ról zbiorczo w całym Twoim mandancie."
+      },
+      "dependencies": {
+        "FLOW": {
+          "title": "Obecnie brak zależności.",
+          "content": "Dowiedz się więcej o <a href=\"https://kestra.io/docs/ui/flows?utm_source=app&utm_medium=referral&utm_campaign=dependencies-inlinedoc#dependencies\" target=\"_blank\">Flow Dependencies</a> w naszej dokumentacji."
+        },
+        "EXECUTION": {
+          "title": "Obecnie brak zależności.",
+          "content": "Przeczytaj więcej o <a href=\"https://kestra.io/docs/ui/executions?utm_source=app&utm_medium=referral&utm_campaign=dependencies-inlinedoc#dependencies\" target=\"_blank\">zależnościach wykonania</a> w naszej dokumentacji."
+        },
+        "NAMESPACE": {
+          "title": "Obecnie nie ma zależności.",
+          "content": "Dowiedz się więcej o <a href=\"https://kestra.io/docs/ui/namespaces?utm_source=app&utm_medium=referral&utm_campaign=dependencies-inlinedoc#dependencies\" target=\"_blank\">zależnościach Namespace</a> w naszej dokumentacji."
+        },
+        "ASSET": {
+          "title": "Obecnie brak zależności.",
+          "content": "Ten zasób nie ma zależności w górę ani w dół z flow lub innymi zasobami."
+        }
+      },
+      "plugins": {
+        "title": "Dla tego namespace nie ustawiono domyślnych pluginów.",
+        "content": "Przeczytaj więcej o <strong><a href=\"https://kestra.io/docs/workflow-components/plugin-defaults?utm_source=app&utm_medium=referral&utm_campaign=plugin-default-inlinedoc\" target=\"_blank\">Limitach Concurrency</a></strong> w naszej dokumentacji."
+      },
+      "triggers": {
+        "title": "Twój flow nie ma żadnych Triggerów.",
+        "content": "Przeczytaj więcej o <strong><a href=\"https://kestra.io/docs/workflow-components/triggers?utm_source=app&utm_medium=referral&utm_campaign=trigger-inlinedoc\" target=\"_blank\">Triggers</a></strong> w naszej dokumentacji."
+      },
+      "mcpToolFlows": {
+        "title": "Na tym serwerze nie zarejestrowano jeszcze żadnych flow narzędzi.",
+        "content": "Udostępnij flow jako narzędzie MCP, dodając do niego <code>McpToolTrigger</code>. Przeczytaj więcej o <strong><a href=\"https://kestra.io/docs/workflow-components/triggers/mcp-tool-trigger?utm_source=app&utm_medium=referral&utm_campaign=mcp-tool-trigger-inlinedoc\" target=\"_blank\">MCP Tool Trigger</a></strong> w naszej dokumentacji."
+      },
+      "versionPlugin": {
+        "title": "Nie masz jeszcze wersjonowanego pluginu!",
+        "content": "Tutaj możesz zarządzać wszystkimi pluginami zainstalowanymi na Twojej instancji Kestra. Nowo zainstalowane pluginy mogą nie być od razu dostępne we wszystkich usługach Kestra, w zależności od konfiguracji Twojej instancji."
+      },
+      "panels": {
+        "title": "Brak otwartego panelu",
+        "content": "Zamknąłeś wszystkie panele.  \nWybierz kartę powyżej, aby kontynuować."
+      }
+    },
+    "toggle_word_wrap": "Przełącz zawijanie wierszy",
+    "copied_logs_to_clipboard": "Skopiowano logi do schowka.",
+    "multi_panel_editor": {
+      "move_right": "Przesuń w prawo",
+      "move_left": "Przesuń w lewo",
+      "close_all_tabs": "Zamknij wszystkie karty",
+      "close_all_panels": "Zamknij wszystkie panele"
+    },
+    "search_docs": "Szukaj",
+    "no_results_found": "Nie znaleziono wyników",
+    "searching": "Szukanie...",
+    "worker information": "Informacje o Workerze",
+    "test-badge-text": "Test",
+    "test-badge-tooltip": "To wykonanie zostało utworzone przez Test.",
+    "total_executions": "Całkowita liczba wykonanych",
+    "no_results": {
+      "executions": "Nie znaleziono wykonania",
+      "triggers": "Nie znaleziono Triggerów",
+      "flows": "Nie znaleziono flowów",
+      "kv_pairs": "Nie znaleziono par klucz-wartość",
+      "secrets": "Nie znaleziono sekretów",
+      "templates": "Nie znaleziono szablonów",
+      "assets": "Nie znaleziono zasobów"
+    },
+    "duplicate-pair": "{label} \"{key}\" jest zduplikowany, pierwszy klucz zignorowany.",
+    "dashboards": {
+      "labels": {
+        "singular": "Dashboard",
+        "plural": "Dashboardy"
+      },
+      "default": "Domyślny Dashboard",
+      "switch": "Przełącz Dashboard",
+      "preview": "Podgląd Dashboardu",
+      "empty": "Brak wyników do wyświetlenia.",
+      "creation": {
+        "label": "Utwórz Dashboard",
+        "confirmation": "Dashboard <code>{title}</code> został utworzony."
+      },
+      "edition": {
+        "label": "Edytuj Dashboard",
+        "confirmation": "Zmiany w dashboardzie <code>{title}</code> zostały zapisane.",
+        "chart": "Edytuj ten wykres",
+        "id readonly": "Właściwość `id` nie może być zmieniona — jest teraz ustawiona na swoje początkowe wartości. Jeśli chcesz ją zmienić, możesz utworzyć nowy dashboard i usunąć stary."
+      },
+      "deletion": {
+        "confirmation": "Czy na pewno chcesz usunąć dashboard <code>{title}</code>?"
+      },
+      "no_description": "Brak opisu",
+      "no_description_hint": "Dodaj opis do tego flow, aby udokumentować, co robi.<br>Markdown jest obsługiwany.",
+      "others": "Inne",
+      "viewAll": "Pokaż wszystko",
+      "chart_preview": "Kliknij kod źródłowy wykresu, aby zobaczyć jego podgląd",
+      "export": "Eksportuj do CSV",
+      "quick_filters": {
+        "all": "Wszystkie",
+        "running": "Uruchomione",
+        "paused": "Wstrzymano",
+        "success": "Sukces",
+        "warning": "Ostrzeżenie",
+        "failed": "Nieudane"
+      }
     },
     "setup": {
-      "config": {
-        "basicauth": "Podstawowe uwierzytelnianie",
-        "queue": "Kolejka",
-        "repository": "Baza danych",
-        "storage": "Magazyn Wewnętrzny"
+      "login": "Zaloguj się",
+      "login_title": "Zaloguj się",
+      "logout": "Wyloguj się",
+      "troubleshooting": "Zapomniałeś hasła?",
+      "steps": {
+        "user": "Utwórz użytkownika admina",
+        "config": "Sprawdź Konfigurację",
+        "survey": "Powiedz nam więcej",
+        "complete": "Uruchom Kestra UI"
       },
-      "confirm": {
-        "config_title": "Potwierdź, że konfiguracja jest prawidłowa",
-        "confirm": "Utwórz użytkownika admin",
-        "not_valid": "Nie, to nie jest prawidłowe",
-        "valid": "Tak, jest prawidłowy"
+      "titles": {
+        "user": "Utwórz użytkownika admin",
+        "survey": "Pomóż nam ulepszyć Kestra OSS"
+      },
+      "subtitles": {
+        "user": "Zabezpiecz swoją instancję, aby rozpocząć.",
+        "config": "Oto szczegóły Twojej konfiguracji",
+        "survey": "Przepraszam, ale nie dostarczyłeś tekstu do przetłumaczenia. Proszę podać tekst, który chcesz przetłumaczyć.",
+        "complete": "Konfiguracja zakończona sukcesem!"
       },
       "form": {
         "email": "Email",
@@ -1878,351 +1937,249 @@
         "username": "Użytkownik",
         "username_hint": "Musi być prawidłowym adresem e-mail."
       },
-      "login": "Zaloguj się",
-      "login_title": "Zaloguj się",
-      "logout": "Wyloguj się",
-      "steps": {
-        "complete": "Uruchom Kestra UI",
-        "config": "Sprawdź Konfigurację",
-        "survey": "Powiedz nam więcej",
-        "user": "Utwórz użytkownika admina"
-      },
-      "subtitles": {
-        "complete": "Konfiguracja zakończona sukcesem!",
-        "config": "Oto szczegóły Twojej konfiguracji",
-        "survey": "Przepraszam, ale nie dostarczyłeś tekstu do przetłumaczenia. Proszę podać tekst, który chcesz przetłumaczyć.",
-        "user": "Zabezpiecz swoją instancję, aby rozpocząć."
-      },
-      "success": {
-        "subtitle": "Jesteś gotowy!",
-        "title": "Gratulacje!"
-      },
-      "survey": {
-        "company_11_50": "Projekt osobisty",
-        "company_1_10": "Nauka / eksploracja",
-        "company_250_plus": "Wdrożenie produkcyjne",
-        "company_50_250": "Ocena dla mojego zespołu/firmy",
-        "company_personal": "Inne",
-        "company_size": "Jaki jest Twój główny cel korzystania z Kestra?",
-        "continue": "Kontynuuj",
-        "newsletter": "Otrzymuj aktualizacje produktów przez e-mail.",
-        "newsletter_heading": "Bądź na bieżąco",
-        "skip": "Pomiń",
-        "use_case": "Do czego planujesz to używać?",
-        "use_case_business": "Przepływy pracy biznesowej",
-        "use_case_data": "Przepływy danych",
-        "use_case_infrastructure": "Automatyzacja infrastruktury",
-        "use_case_ml": "Potoki ML",
-        "use_case_other": "Inne",
-        "use_case_scheduling": "Planowanie i cykliczne zadania"
-      },
-      "titles": {
-        "survey": "Pomóż nam ulepszyć Kestra OSS",
-        "user": "Utwórz użytkownika admin"
-      },
-      "troubleshooting": "Zapomniałeś hasła?",
       "validation": {
-        "config_message": "Upewnij się, że zaktualizowałeś swoją konfigurację, aby naprawić ten komunikat o błędzie.",
-        "email_invalid": "Nieprawidłowy email",
         "email_required": "Email jest wymagany",
+        "email_invalid": "Nieprawidłowy email",
         "email_temporary_not_allowed": "Tymczasowe lub jednorazowe adresy e-mail nie są dozwolone",
         "firstName_required": "Imię jest wymagane",
-        "incorrect_creds": "Nieprawidłowa nazwa użytkownika lub hasło. Upewnij się, że Twoje dane uwierzytelniające są poprawne.",
         "lastName_required": "Wymagane nazwisko",
         "password_invalid": "Nieprawidłowe hasło",
-        "password_required": "Hasło jest wymagane"
+        "password_required": "Hasło jest wymagane",
+        "incorrect_creds": "Nieprawidłowa nazwa użytkownika lub hasło. Upewnij się, że Twoje dane uwierzytelniające są poprawne.",
+        "config_message": "Upewnij się, że zaktualizowałeś swoją konfigurację, aby naprawić ten komunikat o błędzie."
+      },
+      "config": {
+        "repository": "Baza danych",
+        "queue": "Kolejka",
+        "storage": "Magazyn Wewnętrzny",
+        "basicauth": "Podstawowe uwierzytelnianie"
+      },
+      "confirm": {
+        "confirm": "Utwórz użytkownika admin",
+        "config_title": "Potwierdź, że konfiguracja jest prawidłowa",
+        "not_valid": "Nie, to nie jest prawidłowe",
+        "valid": "Tak, jest prawidłowy"
+      },
+      "survey": {
+        "skip": "Pomiń",
+        "company_size": "Jaki jest Twój główny cel korzystania z Kestra?",
+        "company_1_10": "Nauka / eksploracja",
+        "company_11_50": "Projekt osobisty",
+        "company_50_250": "Ocena dla mojego zespołu/firmy",
+        "company_250_plus": "Wdrożenie produkcyjne",
+        "company_personal": "Inne",
+        "use_case": "Do czego planujesz to używać?",
+        "use_case_infrastructure": "Automatyzacja infrastruktury",
+        "use_case_business": "Przepływy pracy biznesowej",
+        "use_case_data": "Przepływy danych",
+        "use_case_ml": "Potoki ML",
+        "use_case_scheduling": "Planowanie i cykliczne zadania",
+        "use_case_other": "Inne",
+        "newsletter_heading": "Bądź na bieżąco",
+        "newsletter": "Otrzymuj aktualizacje produktów przez e-mail.",
+        "continue": "Kontynuuj"
+      },
+      "success": {
+        "title": "Gratulacje!",
+        "subtitle": "Jesteś gotowy!"
       }
     },
-    "show": "Pokaż",
-    "show chart": "Pokaż Wykres",
-    "show description": "Pokaż opis",
-    "show details": "Pokaż szczegóły",
-    "show documentation": "Pokaż dokumentację",
-    "show more details": "Pokaż więcej szczegółów",
-    "show raw": "Show raw",
-    "show task condition": "Pokaż warunek taska",
-    "show task documentation": "Pokaż dokumentację task",
-    "show task documentation in editor": "Pokaż dokumentację task w edytorze",
-    "show task logs": "Pokaż task logs",
-    "show task outputs": "Pokaż task outputs",
-    "show task source": "Pokaż źródło task",
-    "showLess": "Pokaż mniej",
-    "showMore": "Pokaż więcej",
-    "side-by-side": "obok siebie",
-    "similar lines": "similar lines",
-    "skipped": "Pominięto",
-    "slack support": "Zadaj pytanie przez Slack",
-    "something_went_wrong": {
-      "connection_lost": {
-        "message": "Nie udało nam się połączyć z instancją Kestra. Upewnij się, że jest uruchomiona, a następnie odśwież stronę.",
-        "title": "Połączenie przerwane"
+    "ai": {
+      "flow": {
+        "title": "Agent AI",
+        "prompt_placeholder": "Wprowadź instrukcje, aby utworzyć swój flow w Kestra. Przykładowa podpowiedź: Utwórz flow, który uruchamia się w każdy poniedziałek o 9:00.",
+        "select_provider": "Wybierz dostawcę",
+        "generating": {
+          "flow": "Generowanie YAML dla flow...",
+          "dashboard": "Generowanie Dashboard YAML dla Ciebie...",
+          "app": "Generowanie pliku YAML aplikacji dla Ciebie...",
+          "test": "Generowanie Test YAML dla Ciebie..."
+        },
+        "enable_instructions": {
+          "header": "<b>AI Copilot nie został jeszcze skonfigurowany.</b>\n\nAby włączyć AI Copilot, dodaj poniższy fragment do pliku konfiguracyjnego instancji Kestra (np. <code>application.yml</code>), zastępując <code>geminiApiKey</code> swoim rzeczywistym kluczem:",
+          "footer": "Uwaga: Obecnie tylko Gemini jest obsługiwany jako dostawca AI dla Open Source Edition. W przypadku Enterprise Edition zapoznaj się z dokumentacją AI Copilot dotyczącą konfiguracji innych dostawców modeli.\n\nUruchom ponownie instancję Kestra po zapisaniu konfiguracji."
+        }
       },
-      "loading_execution": "Wystąpił problem podczas ładowania wykonania"
+      "dashboard": {
+        "prompt_placeholder": "Zadaj pytanie dotyczące swoich danych. Przykładowa podpowiedź: Pokaż mi wskaźnik sukcesu moich flows z ostatnich 7 dni."
+      }
     },
-    "source": "Źródło",
-    "source and blueprints": "Źródło i blueprints",
-    "source and doc": "Źródło i dokumentacja",
-    "source and topology": "Źródło i topologia",
-    "source only": "Tylko źródło",
-    "source search": "Wyszukaj źródło",
-    "source_search": {
-      "match_count": "{count} wynik | {count} wyniki",
-      "open_flow": "Otwórz flow",
-      "preview_empty": "Wybierz wynik, aby wyświetlić podgląd. Kliknij flow na liście wyników, aby zobaczyć jego źródło.",
-      "preview_error": "Nie udało się załadować źródła flow"
+    "playground": {
+      "title": "Plac zabaw",
+      "run_task_info": "Najedź kursorem na dowolne zadanie w edytorze Flow Code i kliknij przycisk \"Run task\", aby przetestować swoje zadanie.",
+      "play_icon_info": "Możesz również kliknąć ikonę Play w widokach No-Code lub Topology.",
+      "toggle": "Plac zabaw",
+      "run_task": "Uruchom Task",
+      "run_this_task": "Uruchom ten task",
+      "run_task_and_downstream": "Uruchom task i downstream",
+      "run_all_tasks": "Uruchom Wszystkie Taski",
+      "history": "Ostatnie 10 uruchomień",
+      "clear_history": "Wyczyść historię",
+      "confirm_create": "Nie można uruchomić playground podczas tworzenia flow. Uruchomienie playground run utworzy flow.",
+      "tooltip_persistence": "Jeśli wyłączysz i ponownie włączysz Playground, informacje pozostaną, dopóki pozostaniesz na stronie."
     },
-    "specific task": "Specyficzny task",
-    "start date": "Data rozpoczęcia",
-    "start datetime": "Data i godzina rozpoczęcia",
-    "started date": "Data rozpoczęcia",
-    "state": "Stan",
-    "state updated date": "Data aktualizacji stanu",
-    "state_history": "Historia stanu",
-    "stats": "Statystyki",
-    "steps": "Kroki",
-    "stream": "Strumień",
-    "sub flow": "Subflow",
     "submit": "Wyślij",
-    "success": "Sukces",
-    "sum": "Suma",
-    "switch-view": "Przełącz widok",
-    "system overview": "Przegląd Systemu",
-    "system_namespace": "Zachowaj kontrolę nad swoją platformą dzięki systemowym flows.",
-    "system_namespace_description": "Automatyzuj zadania konserwacyjne, od alertów o awariach po automatyczne czyszczenie.",
-    "tags": "Tagi",
-    "task": "Task",
-    "task failed": "Task failed",
-    "task id": "Task ID",
-    "task id already exists": "Task Id już istnieje",
-    "task is running": "Task jest w trakcie RUNNING",
-    "task logs": "Task logs",
-    "task run id": "ID TaskRun",
-    "task sent a warning": "Task wysłał ostrzeżenie",
-    "task was skipped": "Pominięto task",
-    "task was successful": "Zadanie zakończyło się sukcesem",
-    "taskDefaults": "Domyślne ustawienia task",
-    "taskRunners": "Task Runners",
-    "task_id_exists": "Id zadania już istnieje",
-    "task_id_message": "Identyfikator Task ${existingTask} już istnieje w flow.",
-    "taskid column details": "Ostatni task wykonywany i liczba jego prób.",
-    "tasks": "Tasks",
-    "template": "Szablon",
-    "template creation": "Utworzenie szablonu",
-    "template delete": "Czy na pewno chcesz usunąć <code>{templateCount}</code> szablon(y)?",
-    "template export": "Czy na pewno chcesz wyeksportować <code>{templateCount}</code> szablon(y)?",
-    "templates": "Szablony",
-    "templates deleted": "<code>{count}</code> Szablon(y) usunięte",
-    "templates deprecated": "Szablony są przestarzałe. Proszę używać subflows. Zobacz <a href=\"https://kestra.io/docs/migration-guide/0.11.0/templates?utm_source=app&utm_medium=referral&utm_campaign=template-inlinedoc\" target=\"_blank\">sekcję migracji</a>, aby dowiedzieć się, jak migrować z szablonów do subflows.",
-    "templates exported": "Szablony wyeksportowane",
-    "tenant": {
-      "name": "Mandant",
-      "names": "Najemcy"
-    },
-    "tenantId": "Identyfikator Mandanta",
-    "test-badge-text": "Test",
-    "test-badge-tooltip": "To wykonanie zostało utworzone przez Test.",
-    "theme": "Motyw",
-    "this_task_has": "To zadanie ma",
-    "timezone": "Strefa czasowa",
-    "title": "Tytuł",
-    "to": "Do",
     "to toggle": "przełącz",
-    "toggle fullscreen": "Przełącz pełny ekran",
-    "toggle menu": "Przełącz menu",
-    "toggle output": "Przełącz wyjścia",
-    "toggle output display": "Przełącz wyświetlanie wyjścia",
-    "toggle periodic refresh each x seconds": "Przełącz okresowe odświeżanie co {interval} sekund",
-    "toggle_word_wrap": "Przełącz zawijanie wierszy",
-    "topology": "Topologia",
-    "topology-graph": {
-      "graph-orientation": "Orientacja grafu",
-      "invalid": "Błąd grafu",
-      "invalid_description": "Wystąpił błąd podczas ładowania grafu. Proszę sprawdzić kod źródłowy pod kątem błędów.",
-      "zoom-fit": "Dopasuj",
-      "zoom-in": "Powiększ",
-      "zoom-out": "Pomniejsz",
-      "zoom-reset": "Zresetuj powiększenie"
-    },
-    "total_duration": "Całkowity czas trwania",
-    "total_executions": "Całkowita liczba wykonanych",
-    "trigger": "Trigger",
-    "trigger details": "Szczegóły trigger",
-    "trigger disabled": "Trigger jest wyłączony w źródle Flow",
-    "trigger execution id": "Trigger Execution Id",
-    "trigger filter": {
-      "options": {
-        "ALL": "Wszystkie wykonania",
-        "CHILD": "Wykonania dzieci",
-        "MAIN": "Wykonania rodziców"
+    "accept": "Zaakceptuj",
+    "reject": "Odrzuć",
+    "draft_available": "Szkic zmiany jest dostępny w edytorze",
+    "last modified": "Ostatnia modyfikacja",
+    "run task in playground": "Uruchom task w playgroundzie",
+    "task is running": "Task jest w trakcie RUNNING",
+    "task was successful": "Zadanie zakończyło się sukcesem",
+    "task failed": "Task failed",
+    "task was skipped": "Pominięto task",
+    "task sent a warning": "Task wysłał ostrzeżenie",
+    "defaultsToNamespaceFile": "Domyślnie do pliku namespace: <code>{name}</code>",
+    "no_file_choosen": "Nie wybrano pliku",
+    "dependency": {
+      "controls": {
+        "zoom_in": "Powiększ",
+        "zoom_out": "Oddal",
+        "clear_selection": "Wyczyść zaznaczenie",
+        "fit_view": "Dopasuj do ekranu"
       },
-      "title": "Filtruj wykonania dzieci"
-    },
-    "trigger refresh": "Odśwież",
-    "triggerId": "Identyfikator Trigger",
-    "trigger_check_warning": "Używanie zmiennych trigger nie zadziała przy ręcznym wykonaniu flow. Dodaj operator koalescencji `??`, aby rozwiązać problem. Na przykład, zamiast `trigger.date`, użyj `trigger.date ?? execution.startDate`.",
-    "trigger_id_exists": "Id triggera już istnieje",
-    "trigger_id_message": "Identyfikator Trigger ${existingTrigger} już istnieje w flow.",
-    "trigger_states": "Stany",
-    "triggered": "Execution trigger",
-    "triggered done": "Wykonanie <em>{name}</em> zostało pomyślnie uruchomione",
-    "triggerflow disabled": "Trigger jest wyłączony w definicji flow",
-    "triggers": "Triggers",
-    "triggers_add_card_add": "Dodaj",
-    "triggers_add_card_add_to_flow": "Dodaj do flow",
-    "triggers_add_category_empty": "Brak triggerów w tej kategorii.",
-    "triggers_add_ee_tooltip": "Ten trigger wymaga Enterprise Edition.",
-    "triggers_add_empty_title": "Nie znaleziono triggerów",
-    "triggers_add_filter_all": "Wszystko",
-    "triggers_add_filter_app": "Aplikacja",
-    "triggers_add_filter_core": "Rdzeń",
-    "triggers_add_filter_realtime": "Rzeczywisty czas",
-    "triggers_add_modal_add_button": "Dodaj Trigger do Flow",
-    "triggers_add_modal_ee_notice": "Ten trigger wymaga Enterprise Edition.",
-    "triggers_add_modal_flow_placeholder": "Wybierz flow",
-    "triggers_add_modal_namespace_placeholder": "Wybierz namespace",
-    "triggers_add_modal_properties_hint": "Skonfiguruj właściwości triggera w edytorze flow po dodaniu triggera.",
-    "triggers_add_modal_tab_documentation": "Dokumentacja",
-    "triggers_add_modal_tab_form": "Formularz",
-    "triggers_add_modal_tab_source": "Źródło",
-    "triggers_add_modal_title": "{name}",
-    "triggers_add_modal_trigger_id": "ID triggera",
-    "triggers_add_modal_trigger_id_placeholder": "Unikalny identyfikator dla tego triggera",
-    "triggers_add_search_placeholder": "Szukaj triggerów...",
-    "triggers_header_description": "Przeglądaj, dodawaj i zarządzaj triggerami, aby automatyzować swoje flows. Wybierz spośród udostępniania swojego flow jako narzędzie AI, planowania, dodawania webhook trigger, sondowania zmian w zewnętrznych aplikacjach lub słuchaczy zdarzeń w czasie rzeczywistym.",
-    "triggers_state": {
-      "options": {
-        "disabled": "Wyłączone",
-        "enabled": "Włączone"
-      },
-      "state": "Stan"
-    },
-    "triggers_tabs_add": "Dodaj",
-    "triggers_tabs_manage": "Zarządzaj",
-    "true": "Prawda",
-    "type": "Typ",
-    "unable to generate graph": "Wystąpił problem podczas generowania grafu, co uniemożliwia wyświetlenie topologii.",
-    "undefined": "Niezdefiniowane",
-    "unlock": "Odblokuj",
-    "unlock trigger": {
-      "button": "Odblokuj trigger",
-      "confirmation": "Czy na pewno chcesz odblokować trigger?",
-      "success": "Trigger odblokowany",
-      "tooltip": {
-        "evaluation": "Trigger jest obecnie w ocenie",
-        "execution": "Trwa wykonanie dla tego trigger"
-      },
-      "warning": "Może to prowadzić do równoczesnych wykonań dla tego samego trigger i powinno być traktowane jako ostateczność."
-    },
-    "unqueue": "Usuń z kolejki",
-    "unqueue as": "Usuń z kolejki jako <code>{status}</code>",
-    "unqueue confirm": "Czy na pewno chcesz usunąć z kolejki wykonanie <code>{id}</code>?",
-    "unqueue done": "Wykonanie jest odkolejkowane",
-    "unqueue title": "Usuń z kolejki wykonanie <code>{id}</code>.<br/>Zwróć uwagę, że nie będzie to przestrzegać limitu współbieżności flow, więc może być uruchomionych więcej wykonań niż dozwolony limit.",
-    "unqueue title multiple": "Czy na pewno chcesz usunąć z kolejki <code>{count}</code> wykonania?<br/><br/>Zauważ, że nie będzie to przestrzegać limitu współbieżności flow, więc może być uruchomionych więcej wykonań niż dozwolony limit.",
-    "unsaved changed ?": "Masz niezapisane zmiany, czy chcesz opuścić tę stronę?",
-    "unsaved changes": "Niezapisane zmiany",
-    "unsaved changes warning": "Masz niezapisane zmiany. Jeśli opuścisz tę stronę, twoje zmiany zostaną utracone.",
-    "up trend": "Rosnący",
-    "update": "Aktualizuj",
-    "update aborted": "aktualizacja przerwana",
-    "update ok": "jest zaktualizowany",
-    "updated date": "Data aktualizacji",
-    "usage": "Użycie",
-    "use": "Użyj",
-    "use_dark_background": "Użyj tej wersji podczas pracy na ciemnym tle, aby zapewnić, że nasza nazwa pozostanie czytelna.",
-    "valid": "Prawidłowy",
-    "validate": "Zatwierdź",
-    "value": "Wartość",
-    "variable_explorer": {
-      "empty": "Brak zmiennych dostępnych dla tego wykonania.",
-      "n_items": "[ {count} elementów ]",
-      "n_keys": "\\{ {count} keys \\}",
-      "one_item": "[ 1 element ]",
-      "one_key": "\\{ 1 key \\}",
-      "raw_json": "Raw JSON",
-      "search_placeholder": "Szukaj Key lub value...",
-      "select_prompt": "Wybierz zmienną, aby sprawdzić jej value.",
-      "tasks_outputs": "Tasks outputs",
-      "title": "Wejście/Wyjście",
-      "tree": "Drzewo"
-    },
-    "variables": "Zmienne",
-    "version": "Wersja",
-    "view metrics": "Zobacz metryki",
-    "warning": "Ostrzeżenie",
-    "warning detected": "Wykryto ostrzeżenie(a)",
-    "warning flow with triggers": "Ten flow zawiera triggery i ręczne wykonanie zakończy się niepowodzeniem, jeśli ten flow zależy od wyrażeń trigger.",
-    "watch": "Oglądaj",
-    "watch_video": "Obejrzyj wideo",
-    "webhook": {
-      "copy_url": "Skopiuj URL webhooka",
-      "curl_command": "Polecenie cURL Webhook",
-      "curl_note": "Użyj tej komendy cURL, aby triggerować flow za pomocą webhook z niestandardowym ładunkiem JSON.",
-      "no_triggers": "Ten flow nie ma włączonych webhook triggerów",
-      "payload": "Payload Webhook (JSON)"
-    },
-    "webhook link copied": "Link Webhook skopiowany.",
-    "welcome": {
-      "help": {
-        "text": "Zadaj dowolne pytanie w naszej społeczności Slack. Jeśli utkniesz, jesteśmy tutaj, aby Ci pomóc. ✋",
-        "title": "Potrzebujesz pomocy?"
-      },
-      "menu": "Welcome",
-      "tour": {
-        "text": "Wybierz swój przypadek użycia i postępuj zgodnie z przewodnikiem krok po kroku, aby poznać funkcje i możliwości Kestra. ❤️",
-        "title": "Rozpocznij wycieczkę po produkcie"
-      },
-      "tutorial": {
-        "text": "* <a href=\"https://kestra.io/tutorial-videos/all?utm_source=app&utm_medium=referral&utm_campaign=welcome-tutorial\" target=\"_blank\">Samouczki wideo</a>  \n* <a href=\"https://kestra.io/docs?utm_source=app&utm_medium=referral&utm_campaign=welcome-tutorial\" target=\"_blank\">Dokumentacja</a>  \n* <a href=\"https://kestra.io/blueprints?utm_source=app&utm_medium=referral&utm_campaign=welcome-tutorial\" target=\"_blank\">Blueprinty</a>",
-        "title": "Samouczek"
+      "search": {
+        "placeholders": {
+          "default": "Szukaj według flow lub namespace...",
+          "asset": "Szukaj według asset, flow lub namespace..."
+        },
+        "namespace": {
+          "select": "Wybierz namespace",
+          "no_namespace": "Bez namespace"
+        },
+        "flow": {
+          "display": "Uwzględnij zależności flow"
+        },
+        "no_results": "Nie znaleziono wyników dla {term}"
       }
     },
+    "preview": {
+      "label": "Podgląd",
+      "force-editor": "Wymuś widok edytora",
+      "auto-view": "Widok automatyczny",
+      "view": "Zobacz",
+      "rows_truncated": "Wyświetlanie {shown} z {total} wierszy. Pobierz plik, aby zobaczyć wszystkie dane.",
+      "pagination_info": "Wyświetlanie wierszy {start}-{end} z {total}.",
+      "showing_rows": "Wyświetlanie wierszy {start}-{end} z {total}",
+      "expand": "Rozwiń",
+      "collapse": "Zwiń",
+      "previous": "Poprzedni",
+      "next": "Dalej",
+      "page_of": "Strona {current} z {total}"
+    },
+    "delete trigger": "Usuń trigger",
+    "delete triggers": "Usuń triggery",
+    "bulk delete triggers": "Czy na pewno chcesz usunąć {count} triggerów?",
+    "bulk success delete triggers": "Pomyślnie usunięto {count} triggerów",
+    "delete trigger confirmation": "Czy na pewno chcesz usunąć trigger {id}? WARNING: usunięcie triggera może prowadzić do zduplikowanych wykonania, jeśli trigger jest nadal aktywny w flow.",
+    "delete trigger success": "Trigger {id} został pomyślnie usunięty",
+    "delete trigger error": "Błąd podczas usuwania triggera {id}",
+    "revision deleted": "Revision {revision} został pomyślnie usunięty",
+    "delete revision confirm": "Czy na pewno chcesz usunąć wersję {revision}?",
+    "delete revision error": "Błąd usuwania wersji {revision} z błędem {error}",
+    "no_history": "Brak dostępnej historii",
+    "export_as": "Eksportuj jako .{format}",
+    "save_and_execute": "Zapisz i Wykonaj",
     "welcome_copilot": {
       "button_cta": "Utwórz flow od podstaw",
       "create_manually": {
-        "description": "Zbuduj od podstaw za pomocą edytora",
-        "title": "Utwórz ręcznie"
+        "title": "Utwórz ręcznie",
+        "description": "Zbuduj od podstaw za pomocą edytora"
       },
       "docs": {
-        "description": "Dowiedz się więcej w oficjalnej dokumentacji",
-        "title": "Przeczytaj dokumentację"
+        "title": "Przeczytaj dokumentację",
+        "description": "Dowiedz się więcej w oficjalnej dokumentacji"
       },
+      "title": "Zamień swój pomysł na workflow",
+      "need_help": "Potrzebujesz pomocy?",
+      "placeholder_prompt": "Wyślij mi codzienną wiadomość powitalną o 9 rano.",
+      "show_more": "Pokaż więcej podpowiedzi",
+      "show_less": "Pokaż mniej podpowiedzi",
+      "remaining_quota": "Pozostało Ci {count} generacji AI. Limit resetuje się codziennie o północy UTC.",
       "execute_hint": {
-        "description": "Kliknij, aby zapisać swój workflow i uruchomić go natychmiast.",
-        "title": "Zapisz i wykonaj swój flow"
+        "title": "Zapisz i wykonaj swój flow",
+        "description": "Kliknij, aby zapisać swój workflow i uruchomić go natychmiast."
+      },
+      "success_popup": {
+        "title": "Gratulacje!",
+        "description": "Pomyślnie wykonałeś swój pierwszy flow! Jesteś na dobrej drodze do zostania ekspertem Kestra.",
+        "tutorial": "Samouczek dogłębny",
+        "explore": "Odkryj więcej"
+      },
+      "success_page": {
+        "title": "Wszystko gotowe!",
+        "description": "Poznałeś podstawy Kestra. Oto kilka zasobów, które pomogą Ci kontynuować podróż.",
+        "restart": "Uruchom ponownie samouczek",
+        "items": {
+          "tutorial": {
+            "title": "Rozpocznij samouczek",
+            "description": "Interaktywny przewodnik po wszystkich funkcjach Kestra"
+          },
+          "blueprints": {
+            "title": "Blueprinty",
+            "description": "Szablony przepływów pracy dla typowych przypadków użycia"
+          },
+          "slack": {
+            "title": "Społeczność Slack",
+            "description": "Połącz się z innymi użytkownikami i uzyskaj pomoc od społeczności"
+          },
+          "videos": {
+            "title": "Samouczki wideo",
+            "description": "Przewodniki wideo krok po kroku dla zaawansowanych funkcji"
+          },
+          "demo": {
+            "title": "Uzyskaj demo",
+            "description": "Eksploruj Kestra Enterprise Edition z spersonalizowaną demonstracją"
+          }
+        }
+      },
+      "help": {
+        "tutorial": {
+          "title": "Rozpocznij samouczek",
+          "description": "Dowiedz się, jak utworzyć i uruchomić swój pierwszy flow z przewodnikiem krok po kroku."
+        },
+        "blueprints": {
+          "title": "Blueprinty",
+          "description": "Odkryj gotowe do użycia przykłady i szablony dla typowych wzorców workflow."
+        },
+        "slack": {
+          "title": "Społeczność Slack",
+          "description": "Dołącz do nas, aby dzielić się pomysłami i najlepszymi praktykami oraz uzyskać pomoc w kwestiach technicznych."
+        }
       },
       "flows": {
-        "buildDbtPipeline": {
-          "label": "Zbuduj pipeline dbt",
-          "prompt": "Utwórz flow Kestra, który klonuje repozytorium projektu dbt i uruchamia dbt build z profilem DuckDB."
-        },
-        "buildDockerImageAndRunIt": {
-          "label": "Zbuduj obraz Docker i uruchom go",
-          "prompt": "Utwórz flow Kestra, który buduje obraz Docker z wbudowanego Dockerfile i uruchamia wynikowy kontener."
-        },
-        "convertCsvToExcel": {
-          "label": "Konwertuj CSV na Excel",
-          "prompt": "Utwórz flow, który pobiera plik CSV, konwertuje go na Ion i eksportuje wynik jako plik Excel."
-        },
-        "etlWorkflow": {
-          "label": "Przepływ pracy ETL",
-          "prompt": "Utwórz flow ETL, który pobiera dane JSON, przetwarza je za pomocą Pythona i zapytuje przekształcony wynik za pomocą DuckDB."
+        "jsonApiToDuckdb": {
+          "label": "JSON API do DuckDB",
+          "prompt": "Utwórz flow, który pobiera plik JSON z publicznego API, przekształca go za pomocą skryptu Python, a następnie przetwarza za pomocą zadania DuckDB Queries."
         },
         "installNginxViaAnsible": {
           "label": "Zainstaluj Nginx za pomocą Ansible",
           "prompt": "Utwórz flow Kestra, który instaluje Nginx na docelowej maszynie za pomocą Ansible i weryfikuje zainstalowaną wersję."
         },
-        "jsonApiToDuckdb": {
-          "label": "JSON API do DuckDB",
-          "prompt": "Utwórz flow, który pobiera plik JSON z publicznego API, przekształca go za pomocą skryptu Python, a następnie przetwarza za pomocą zadania DuckDB Queries."
+        "buildDbtPipeline": {
+          "label": "Zbuduj pipeline dbt",
+          "prompt": "Utwórz flow Kestra, który klonuje repozytorium projektu dbt i uruchamia dbt build z profilem DuckDB."
+        },
+        "etlWorkflow": {
+          "label": "Przepływ pracy ETL",
+          "prompt": "Utwórz flow ETL, który pobiera dane JSON, przetwarza je za pomocą Pythona i zapytuje przekształcony wynik za pomocą DuckDB."
+        },
+        "microservicesApis": {
+          "label": "Mikrousługi i API",
+          "prompt": "Utwórz flow, który sprawdza odpowiedź API strony internetowej i wysyła alert Slack, gdy kod statusu nie jest sukcesem."
+        },
+        "buildDockerImageAndRunIt": {
+          "label": "Zbuduj obraz Docker i uruchom go",
+          "prompt": "Utwórz flow Kestra, który buduje obraz Docker z wbudowanego Dockerfile i uruchamia wynikowy kontener."
         },
         "manualApproval": {
           "label": "Ręczna akceptacja",
           "prompt": "Utwórz flow z początkowym krokiem przetwarzania, przerwą na ręczne zatwierdzenie i końcowym krokiem wdrożenia po zatwierdzeniu."
         },
-        "microservicesApis": {
-          "label": "Mikrousługi i API",
-          "prompt": "Utwórz flow, który sprawdza odpowiedź API strony internetowej i wysyła alert Slack, gdy kod statusu nie jest sukcesem."
+        "convertCsvToExcel": {
+          "label": "Konwertuj CSV na Excel",
+          "prompt": "Utwórz flow, który pobiera plik CSV, konwertuje go na Ion i eksportuje wynik jako plik Excel."
         },
         "scheduledPdfReports": {
           "label": "Zaplanowane raporty PDF",
@@ -2232,73 +2189,116 @@
           "label": "Tygodniowe KPI sprzedaży do Slack",
           "prompt": "Utwórz cotygodniowy zaplanowany flow, który oblicza KPI sprzedaży za pomocą DuckDB i publikuje podsumowanie na Slack."
         }
-      },
-      "help": {
-        "blueprints": {
-          "description": "Odkryj gotowe do użycia przykłady i szablony dla typowych wzorców workflow.",
-          "title": "Blueprinty"
-        },
-        "slack": {
-          "description": "Dołącz do nas, aby dzielić się pomysłami i najlepszymi praktykami oraz uzyskać pomoc w kwestiach technicznych.",
-          "title": "Społeczność Slack"
-        },
-        "tutorial": {
-          "description": "Dowiedz się, jak utworzyć i uruchomić swój pierwszy flow z przewodnikiem krok po kroku.",
-          "title": "Rozpocznij samouczek"
-        }
-      },
-      "need_help": "Potrzebujesz pomocy?",
-      "placeholder_prompt": "Wyślij mi codzienną wiadomość powitalną o 9 rano.",
-      "remaining_quota": "Pozostało Ci {count} generacji AI. Limit resetuje się codziennie o północy UTC.",
-      "show_less": "Pokaż mniej podpowiedzi",
-      "show_more": "Pokaż więcej podpowiedzi",
-      "success_page": {
-        "description": "Poznałeś podstawy Kestra. Oto kilka zasobów, które pomogą Ci kontynuować podróż.",
-        "items": {
-          "blueprints": {
-            "description": "Szablony przepływów pracy dla typowych przypadków użycia",
-            "title": "Blueprinty"
-          },
-          "demo": {
-            "description": "Eksploruj Kestra Enterprise Edition z spersonalizowaną demonstracją",
-            "title": "Uzyskaj demo"
-          },
-          "slack": {
-            "description": "Połącz się z innymi użytkownikami i uzyskaj pomoc od społeczności",
-            "title": "Społeczność Slack"
-          },
-          "tutorial": {
-            "description": "Interaktywny przewodnik po wszystkich funkcjach Kestra",
-            "title": "Rozpocznij samouczek"
-          },
-          "videos": {
-            "description": "Przewodniki wideo krok po kroku dla zaawansowanych funkcji",
-            "title": "Samouczki wideo"
-          }
-        },
-        "restart": "Uruchom ponownie samouczek",
-        "title": "Wszystko gotowe!"
-      },
-      "success_popup": {
-        "description": "Pomyślnie wykonałeś swój pierwszy flow! Jesteś na dobrej drodze do zostania ekspertem Kestra.",
-        "explore": "Odkryj więcej",
-        "title": "Gratulacje!",
-        "tutorial": "Samouczek dogłębny"
-      },
-      "title": "Zamień swój pomysł na workflow"
+      }
     },
-    "welcome_page": {
-      "guide": "Potrzebujesz wskazówek, jak uruchomić swój pierwszy flow?",
-      "welcome": "Witamy w Kestra"
+    "mcp": {
+      "your_servers": "Twoje Serwery",
+      "servers_count": "{{count}} Serwerów MCP",
+      "managed_by_kestra": "Zarządzane przez Kestra",
+      "servers": "Serwery MCP",
+      "server": "Serwer MCP",
+      "client_setup": "Konfiguracja klienta",
+      "page_description": "Udostępnij swoje flow Kestra jako narzędzia dla agentów AI zgodnych z MCP",
+      "create": "Utwórz Serwer",
+      "save": "Zapisz zmiany",
+      "connect": "Połącz",
+      "copy_url": "Skopiuj URL",
+      "url_copied": "URL skopiowany!",
+      "instructions": "Instrukcje",
+      "server_type": "Typ serwera",
+      "auth_type": "Uwierzytelnianie",
+      "private": "Prywatne",
+      "private_server": "Serwer prywatny",
+      "public": "Publiczny",
+      "public_hint": "Ostrzeżenie: Publiczne serwery nie wymagają uwierzytelniania. Każdy, kto ma URL, może wywołać każde narzędzie udostępnione przez ten serwer, bez sprawdzania namespace'u ani uprawnień. Używaj tylko dla serwerów, które można bezpiecznie udostępniać zewnętrznie.",
+      "basic_auth": "Podstawowe uwierzytelnianie",
+      "api_token": "Token API",
+      "oauth": "OAuth",
+      "username_password": "Nazwa użytkownika i hasło",
+      "bearer_token": "Uwierzytelnianie za pomocą tokenu Bearer",
+      "oauth_hint": "Bearer JWT od dostawcy OIDC",
+      "oauth_provider": "Dostawca OAuth",
+      "oauth_provider_placeholder": "Wybierz skonfigurowanego dostawcę OIDC",
+      "oauth_provider_required": "Dostawca OAuth jest wymagany, gdy typ uwierzytelniania to OAuth",
+      "scopes_supported": "Obsługiwane zakresy",
+      "scopes_supported_placeholder": "openid, profile, email",
+      "scopes_supported_hint": "Zakresy reklamowane w dokumencie Protected Resource Metadata tego serwera. Zgodne ze specyfikacją klienty MCP ograniczają swoje żądanie autoryzacji do tej listy. Pozostaw puste, aby pominąć pole i pozwolić klientom korzystać z zakresów reklamowanych przez IdP.",
+      "no_oauth_providers": "Brak skonfigurowanych dostawców OIDC w tej instancji",
+      "delete_confirm": "Czy na pewno chcesz usunąć ten serwer MCP?",
+      "no_servers": "Nie znaleziono serwerów MCP. Utwórz swój pierwszy serwer, aby udostępnić wyzwalacze MCP Tool zewnętrznym agentom AI.",
+      "server_id": "ID serwera",
+      "id_placeholder": "np. my-mcp-server",
+      "id_invalid": "ID musi zaczynać się od małej litery lub cyfry i zawierać tylko małe litery, cyfry, myślniki lub podkreślenia",
+      "main_tenant": "main",
+      "tab_edit": "Edytuj",
+      "tab_connect": "Połącz",
+      "tab_tool_flows": "Narzędzia Flow",
+      "tab_tool_flows_placeholder": "Zarządzanie flow narzędziami wkrótce dostępne.",
+      "tools": {
+        "no_tools": "Żadne flow narzędzi nie pasują do Twojego wyszukiwania.",
+        "create_tool_flow": "Utwórz flow narzędzia",
+        "tool_name": "Nazwa narzędzia",
+        "trigger_id": "ID triggera",
+        "title": "Tytuł",
+        "description": "Opis",
+        "annotations": "Adnotacje",
+        "flow": "flow",
+        "state": "Stan",
+        "read_only": "Tylko do odczytu",
+        "open_world": "Open world",
+        "destructive": "Destrukcyjny",
+        "idempotent": "Idempotentny",
+        "return_direct": "Zwrot bezpośredni",
+        "view_flow": "Otwórz flow"
+      },
+      "connect_tab": {
+        "server_url": "URL serwera",
+        "client_picker_label": "Wybierz klienta AI",
+        "claude_desktop": "Claude Desktop",
+        "claude_desktop_hint": "Dodaj następujące elementy do pliku claude_desktop_config.json:",
+        "claude_desktop_mac": "macOS: ~/Library/Application Support/Claude/claude_desktop_config.json",
+        "claude_desktop_win": "Windows: %APPDATA%\\Claude\\claude_desktop_config.json",
+        "claude_code": "Claude Code",
+        "claude_code_hint": "Uruchom następujące polecenie w terminalu:",
+        "cursor": "Kursor",
+        "cursor_hint": "Dodaj następujące do ~/.cursor/mcp.json:",
+        "codex": "Codex (OpenAI)",
+        "codex_hint": "Dodaj następujące elementy do konfiguracji MCP w pliku codex.json:",
+        "auth_basic_hint": "Przed uruchomieniem klienta ustaw <code>KESTRA_BASIC_AUTH</code> jako zmienną środowiskową zawierającą zakodowany w base64 ciąg <code>username:password</code>.",
+        "auth_api_token_hint": "Przed uruchomieniem klienta ustaw <code>KESTRA_TOKEN</code> jako zmienną środowiskową.",
+        "auth_oauth_client_id_hint": "Zastąp <code>&lt;client-id&gt;</code> identyfikatorem klienta OAuth i zarejestruj <code>http://localhost:7777</code> jako prawidłowy URI przekierowania na tym kliencie.",
+        "auth_oauth_browser_hint": "Przy pierwszym połączeniu przeglądarka otworzy stronę logowania dostawcy tożsamości."
+      }
     },
-    "wordmark_colors": "Kolory znaku słownego dostosowują się w zależności od tła, podczas gdy ikona pozostaje bez tła, gdy jest umieszczona na ciemnym tle.",
-    "worker group": "Grupa Worker",
-    "worker group fallback": "Grupa Workerów awaryjna",
-    "worker group key": "Klucz grupy Worker",
-    "worker information": "Informacje o Workerze",
-    "workerId": "Worker Id",
-    "workers": "Workers",
-    "wrong labels": "Pusta wartość lub key nie jest dozwolona w etykietach",
-    "yes": "Tak"
+    "flow_editor_stats": {
+      "revisions": {
+        "suffix": "Rewizja(e)",
+        "tooltip": "Zobacz rewizje flow"
+      },
+      "dependencies": {
+        "suffix": "Zależności",
+        "tooltip": "Zobacz zależności flow"
+      },
+      "apps": {
+        "suffix": "Aplikacja(e)",
+        "tooltip": "Zobacz aplikacje używające tego flow"
+      },
+      "tests": {
+        "suffix": "Test(y)",
+        "tooltip": "Zobacz testy flow"
+      },
+      "errors": {
+        "label": "{count} Błąd(y)"
+      }
+    },
+    "source_search": {
+      "match_count": "{count} wynik | {count} wyniki",
+      "open_flow": "Otwórz flow",
+      "preview_empty": "Wybierz wynik, aby wyświetlić podgląd. Kliknij flow na liście wyników, aby zobaczyć jego źródło.",
+      "preview_error": "Nie udało się załadować źródła flow"
+    },
+    "open source": "Otwarte Źródło",
+    "pricing": "Cennik",
+    "license": "Licencja"
   }
 }

--- a/ui/src/translations/pt.json
+++ b/ui/src/translations/pt.json
@@ -1,1678 +1,722 @@
 {
   "pt": {
-    "Add flow": "Adicionar flow",
-    "Default log level": "Nível de log padrão",
-    "Default namespace": "Namespace padrão",
-    "Default page": "Página padrão",
-    "Editor fontfamily": "Família de fontes do editor",
-    "Editor fontsize": "Tamanho da fonte do editor",
-    "Editor theme": "Tema do editor",
-    "Fold auto": "Editor: dobra automática de multilinhas",
-    "Fold content lines": "Dobrar strings multilinhas",
-    "Hover description": "Editor: Mostrar descrição do campo ao passar o mouse sobre o key ou value",
-    "Language": "Idioma",
-    "Per page": "por página",
-    "Set default page": "Definir página padrão",
-    "Set labels": "Definir labels",
-    "Set labels done": "Labels da execução definidos com sucesso",
-    "Set labels to execution": "Adicionar ou atualizar os labels da execução <code>{id}</code>",
-    "Set labels tooltip": "Definir labels para a execução",
-    "Task Id already exist in the flow": "Task Id {taskId} já existe no flow.",
-    "Total": "Total",
-    "Unfold content lines": "Desdobrar strings multilinhas",
-    "about_this_blueprint": "Sobre este blueprint",
-    "absolute": "Absoluto",
-    "accept": "Aceitar",
-    "actions": "Ações",
-    "activate_basic_auth": "Ativar Autenticação Básica",
-    "active": "Ativo",
-    "active-slots": "Slots ativos",
-    "actual state": "Estado atual",
-    "add": "Adicionar",
-    "add at position": "Adicionar {position} <code>{task}</code>",
-    "add error handler": "Adicionar um manipulador de erro",
-    "add flow": "Adicionar flow",
+    "loading": "A carregar...",
+    "more actions": "Mais ações",
+    "toggle menu": "Alternar menu",
+    "panel actions": "Ações do painel",
+    "playground actions": "Ações do Playground",
+    "bulk actions": "Ações em massa",
+    "view metrics": "Ver métricas",
+    "remove this item": "Remover este item",
     "add label": "Adicionar label",
-    "add task": "Adicionar uma task",
-    "add-trigger-in-editor": "Adicione um Trigger ao seu Flow primeiro",
-    "add_new_item": "Adicionar novo item",
-    "additionalPlugins": "Plugins Adicionais",
-    "admin": "Administração",
-    "admin_preferences": "Preferences",
-    "administration": "Administração",
-    "advanced configuration": "Outras propriedades",
-    "after": "depois",
-    "aggregation": "Agregação",
-    "ai": {
-      "dashboard": {
-        "prompt_placeholder": "Faça uma pergunta sobre seus dados. Exemplo de prompt: Mostre-me a taxa de sucesso dos meus flows nos últimos 7 dias."
+    "remove label": "Remover label",
+    "id": "Id",
+    "type": "Tipo",
+    "ok": "OK",
+    "valid": "Válido",
+    "close": "Fechar",
+    "namespace": "Namespace",
+    "description": "Descrição",
+    "show description": "Mostrar uma descrição",
+    "show details": "Mostrar detalhes",
+    "show more details": "Mostrar mais detalhes",
+    "skipped": "Pulado",
+    "revision": "Revisão",
+    "Language": "Idioma",
+    "Set default page": "Definir página padrão",
+    "theme": "Tema",
+    "flows": "Flows",
+    "flow": "Flow",
+    "invalid source": "Código fonte inválido",
+    "missingSource": "Fonte ausente",
+    "update": "Atualizar",
+    "update ok": "está atualizado",
+    "delete ok": "está deletado",
+    "Default page": "Página padrão",
+    "confirmation": "Confirmação",
+    "common": {
+      "back": "Voltar"
+    },
+    "delete confirm": "Tem certeza de que deseja deletar <code>{name}</code>?",
+    "outdated revision save confirmation": {
+      "confirm": "Deseja sobrescrever?",
+      "update": {
+        "title": "Revisão desatualizada",
+        "description": "A revisão que você está editando está desatualizada.",
+        "details": "Verifique a aba de Revisões para mais detalhes sobre a última versão."
       },
-      "flow": {
-        "enable_instructions": {
-          "footer": "Nota: Neste momento, apenas o Gemini é suportado como provedor de IA para a Open Source Edition. Para a Enterprise Edition, consulte a documentação do AI Copilot para a configuração de outros provedores de modelo.\n\nReinicie sua instância do Kestra após salvar a configuração.",
-          "header": "<b>AI Copilot ainda não foi configurado.</b>\n\nPara habilitar o AI Copilot, adicione o seguinte trecho ao arquivo de configuração da sua instância Kestra (por exemplo, <code>application.yml</code>), substituindo <code>geminiApiKey</code> pela sua chave real:"
-        },
-        "generating": {
-          "app": "Gerando YAML do App para você...",
-          "dashboard": "Gerando YAML do Dashboard para você...",
-          "flow": "Gerando YAML do flow para você...",
-          "test": "Gerando YAML de teste para você..."
-        },
-        "prompt_placeholder": "Insira instruções para criar seu flow Kestra. Exemplo de prompt: Crie um flow que execute toda segunda-feira às 9h.",
-        "select_provider": "Selecionar um provedor",
-        "title": "Agente de IA"
+      "create": {
+        "title": "Flow já existe",
+        "description": "Um flow com o mesmo id já existe neste namespace.",
+        "details": "Salvar para substituir e criar uma nova revisão."
       }
     },
-    "all executions": "Todas as execuções",
-    "all tags": "Todas as tags",
-    "api": "API",
-    "appBlocks": "Blocos do App",
-    "apps": "Aplicativos",
-    "are you sure change state": "Tem certeza de que deseja alterar o estado?",
-    "assets": {
-      "title": "Ativos"
+    "override": {
+      "title": "Você está prestes a sobrescrever o flow atual",
+      "details": "O flow anterior pode ser restaurado na aba Revisions."
     },
-    "attempt": "Tentativa",
-    "attempts": "Tentativa(s)",
-    "auditlogs": "Audit Logs",
-    "automatic refresh": "Atualização automática",
-    "avg": "Média",
-    "avg duration": "Duração média da execução",
+    "is deprecated": "está obsoleto",
+    "success": "Sucesso",
+    "save": "Salvar",
+    "save_as_draft": "Guardar como rascunho",
+    "draft": "Rascunho",
+    "draft_flow_warning": "Esta revisão do flow é um rascunho. A execução será feita sobre esta revisão de rascunho e pode falhar imediatamente se a definição do flow for inválida.",
+    "save task": "Salvar Task",
+    "saved": "Salvo com sucesso",
+    "saved as draft": "Guardado como rascunho com sucesso",
+    "saved done": "<em>{name}</em> foi salvo com sucesso",
+    "saved as draft done": "<em>{name}</em> foi guardado com sucesso como rascunho",
+    "multiple saved done": "{name} foi salvo",
+    "fileTypeNotAllowed": "Tipo de arquivo não permitido. Tipos aceitos: {types}",
+    "delete": "Deletar",
+    "deleted": "Deletado com sucesso",
+    "deleted confirm": "<em>{name}</em> foi deletado com sucesso!",
+    "Add flow": "Adicionar flow",
+    "add": "Adicionar",
+    "add_new_item": "Adicionar novo item",
+    "copy": "Copiar",
+    "copy_to_clipboard": "Copiar para a área de transferência",
+    "copy_and_close": "Copiar e fechar",
+    "Per page": "por página",
+    "new": "Novo",
+    "edit": "Editar",
     "back": "Voltar",
-    "back_to_dashboard": "Voltar ao dashboard",
-    "backfill": "Backfill",
-    "backfill executions": "Execuções de backfill",
-    "backfill paused": "Preenchimento retroativo pausado",
-    "backfill running": "Backfill em execução",
-    "bar": "Bar",
-    "before": "antes",
-    "behavior": "Comportamento",
-    "blueprints": {
-      "all": "Todos",
-      "apps": "Blueprints do Aplicativo",
-      "community": "Comunidade",
-      "create": "Criar um blueprint",
-      "custom": "Blueprints personalizados",
-      "dashboards": "Blueprints do Dashboard",
-      "detail": {
-        "category": "Tipo de categoria",
-        "links": "Link & Recursos",
-        "openInEditor": "Abrir em Edit Flow"
-      },
-      "edit": "Editar um blueprint",
-      "empty": "Nenhum blueprint para mostrar.",
-      "flows": "Blueprints de Flow",
-      "header": {
-        "alt": "Ícone de Blueprints",
-        "catch phrase": {
-          "1": "O primeiro passo é sempre o mais difícil.",
-          "2": "Explore blueprints para iniciar seu próximo {kind}."
-        }
-      },
-      "missingPlugins": {
-        "card": "Requer plugin(s) não instalados nesta instância: {plugins}",
-        "description": "Este blueprint usa tasks de plugin(s) que não estão instalados nesta instância: {plugins}. Instale-os para usar este blueprint.",
-        "install": "Instalar plugins",
-        "title": "Plugins ausentes"
-      },
-      "title": "Blueprints"
+    "next": "Próximo",
+    "done": "Concluído",
+    "review your inputs": "Reveja as suas entradas",
+    "edit flow": "Editar flow",
+    "executions": "Execuções",
+    "execution": "Execução",
+    "execution id": "Id de Execução",
+    "recent_executions": "Execuções Recentes",
+    "details": "Detalhes",
+    "overview": "Visão geral",
+    "gantt": "Gantt",
+    "gantt_no_tasks_executed": "Esta execução terminou sem executar nenhuma task.  \nVerifique sua visão geral e logs para encontrar o motivo.",
+    "gantt_no_tasks_match_filters": "Tente ajustar os filtros de busca, estado ou nível de log.",
+    "gantt_no_tasks_match_filters_title": "Nenhuma task corresponde aos filtros selecionados.",
+    "logs": "Logs",
+    "no_logs_data": "Sem Dados",
+    "no_logs_data_description": "Por favor, tente ajustar seus filtros, alterar o intervalo de tempo ou verifique se o flow foi executado recentemente.",
+    "no_logs_data_title": "Nenhum log encontrado para os filtros selecionados.",
+    "duration": "Duração",
+    "total_duration": "Duração total",
+    "running duration": "Duração em execução",
+    "queued duration": "Duração na fila",
+    "choose file": "Escolha um arquivo ou solte-o aqui...",
+    "launch execution": "Executar",
+    "warning flow with triggers": "Este flow contém triggers e uma execução manual falhará se este flow depender de expressões de trigger.",
+    "triggered": "Trigger de execução",
+    "triggered done": "Execução <em>{name}</em> foi acionada com sucesso",
+    "topology": "Topologia",
+    "date": "Data",
+    "prev_execution": "Execução anterior",
+    "next_execution": "Próxima execução",
+    "datepicker": {
+      "leave empty for infinite": "Deixe vazio para duração infinita ou digite uma duração ISO 8601 (exemplo: 'P1DT1H1M1S)'",
+      "duration example": "Exemplo: 'P1DT1H1M1S'",
+      "error": "Formato de duração inválido, deve ser uma duração ISO 8601 (P1DT1H1M1S por ex.)",
+      "custom": "Personalizado",
+      "last5minutes": "Últimos 5 minutos",
+      "last15minutes": "Últimos 15 minutos",
+      "last1hour": "Última 1 hora",
+      "last12hours": "Últimas 12 horas",
+      "last24hours": "Últimas 24 horas",
+      "last48hours": "Últimas 48 horas",
+      "last7days": "Últimos 7 dias",
+      "last30days": "Últimos 30 dias",
+      "last365days": "Últimos 365 dias",
+      "next5minutes": "Próximos 5 minutos",
+      "next15minutes": "Próximos 15 minutos",
+      "next1hour": "Próxima 1 hora",
+      "next12hours": "Próximas 12 horas",
+      "next24hours": "Próximas 24 horas",
+      "next48hours": "Próximas 48 horas",
+      "next7days": "Próximos 7 dias",
+      "next30days": "Próximos 30 dias",
+      "next365days": "Próximos 365 dias",
+      "5minutes": "5 minutos",
+      "15minutes": "15 minutos",
+      "1hour": "1 hora",
+      "12hours": "12 horas",
+      "24hours": "24 horas",
+      "48hours": "48 horas",
+      "7days": "7 dias",
+      "30days": "30 dias",
+      "365days": "365 dias",
+      "never": "Nunca",
+      "today": "Hoje",
+      "yesterday": "Ontem",
+      "dayBeforeYesterday": "Anteontem",
+      "thisWeek": "Esta semana",
+      "thisWeekSoFar": "Esta semana até agora",
+      "previousWeek": "Semana anterior",
+      "thisMonth": "Este mês",
+      "thisMonthSoFar": "Este mês até agora",
+      "previousMonth": "Mês anterior",
+      "thisYear": "Este ano",
+      "thisYearSoFar": "Este ano até agora",
+      "previousYear": "Ano anterior",
+      "short": {
+        "15m": "15min",
+        "1h": "1h",
+        "12h": "12h",
+        "1d": "1d",
+        "7d": "7d"
+      }
     },
-    "body_line_clamp": "Limit line height",
-    "bookmark": "Favoritos",
-    "breakpoints": "Pontos de interrupção",
-    "bulk action async warning": "Isso pode levar alguns instantes.",
-    "bulk actions": "Ações em massa",
-    "bulk change state": "Tem certeza de que deseja alterar o estado de <code>{executionCount}</code> execução(ões)?",
-    "bulk delete": "Tem certeza de que deseja deletar <code>{executionCount}</code> execução(ões)?",
-    "bulk delete backfills": "Excluir {count} backfill",
-    "bulk delete triggers": "Tem certeza de que deseja excluir {count} triggers?",
-    "bulk disabled status": {
-      "false": "Ativar {count} triggers",
-      "true": "Desativar {count} triggers"
+    "created date": "Data de criação",
+    "latest_update": "Última atualização",
+    "updated date": "Data de atualização",
+    "expiration date": "Data de expiração",
+    "started date": "Data de início",
+    "healthcheck date": "Data do HealthCheck",
+    "next execution date": "Próxima data de execução",
+    "last execution status": "Último status de execução",
+    "jump to...": "Ir para...",
+    "contextBar": {
+      "news": "Notícias",
+      "docs": "Documentos",
+      "help": "Ajuda",
+      "issue": "Problema",
+      "demo": "Demonstração",
+      "star": "Nos avalie com uma estrela"
     },
-    "bulk force run": "Tem certeza de que deseja forçar a execução de <code>{executionCount}</code> execução(ões)?<br/><br/>AVISO: forçar a execução de uma execução não é garantido e pode criar execuções de tarefas duplicadas.<br/><br/>As seguintes transições serão realizadas:<br/><ul><li>Tarefas CREATED serão movidas para o estado RUNNING.</li><li>Tarefas RUNNING serão re-submetidas.</li><li>Tarefas QUEUED serão removidas da fila.</li><li>Tarefas PAUSED serão retomadas.</li></ul>",
-    "bulk kill": "Tem certeza de que deseja matar <code>{executionCount}</code> execução(ões)?",
-    "bulk pause": "Tem certeza de que deseja pausar a(s) execução(ões) <code>{executionCount}</code>?",
-    "bulk pause backfills": "Pausar {count} backfill",
-    "bulk replay": "Tem certeza de que deseja reproduzir <code>{executionCount}</code> execução(ões)?",
-    "bulk restart": "Tem certeza de que deseja reiniciar <code>{executionCount}</code> execução(ões)?",
-    "bulk resume": "Tem certeza de que deseja retomar <code>{executionCount}</code> execução(ões)?",
-    "bulk set labels": "Tem certeza de que deseja definir labels para <code>{executionCount}</code> execução(ões)?",
-    "bulk success delete backfills": "{count} backfills excluídos",
-    "bulk success delete triggers": "{count} triggers foram excluídos com sucesso",
-    "bulk success disabled status": {
-      "false": "{count} trigger(s) ativado(s)",
-      "true": "{count} trigger(s) desativado(s)"
+    "source": "Fonte",
+    "source only": "Somente fonte",
+    "home": "Início",
+    "create": "Criar",
+    "create_flow": "Criar Flow",
+    "add flow": "Adicionar flow",
+    "from": "De",
+    "to": "Para",
+    "search filters": {
+      "saved": "Filtros salvos",
+      "manage": "Gerenciar filtros de busca",
+      "manage desc": "Gerenciar filtros de busca salvos",
+      "save filter": "Salvar filtro",
+      "filter name": "Nome do filtro",
+      "filters": "Filtros"
     },
-    "bulk success pause backfills": "{count} backfills pausados",
-    "bulk success unlock": "{count} triggers desbloqueados",
-    "bulk success unpause backfills": "{count} backfills despausados",
-    "bulk unlock": "Desbloquear {count} triggers",
-    "bulk unpause backfills": "Despausar {count} backfill",
-    "bulk unqueue": "Tem certeza de que deseja remover da fila <code>{executionCount}</code> execução(ões)?",
-    "can not delete": "Não pode deletar",
-    "can not have less than 1 task": "Cada flow deve ter pelo menos uma task.",
-    "can not save": "Não pode salvar",
-    "cancel": "Cancelar",
+    "steps": "Passos",
+    "state": "Estado",
+    "state_history": "Histórico de estado",
+    "search term in message": "Termo de busca na mensagem",
+    "search": "Buscar",
+    "search blueprint": "Buscar blueprints",
+    "all tags": "Todas as tags",
+    "source search": "Busca de fonte",
+    "filter by log level": "Filtrar por nível de log",
+    "selected": "Selecionado",
+    "task": "Task",
+    "task logs": "Task logs",
+    "display flow {id} executions": "Exibir execuções do flow {id}",
+    "actions": "Ações",
+    "select datetime": "Selecione uma data",
+    "select view": "Selecionar visualização",
+    "invalid field": "Campo inválido: {name}",
+    "required field": "Campo obrigatório",
+    "is required": "{field} é obrigatório",
+    "error": "Erro",
+    "form": "Formulário",
+    "form error": "Erro no formulário",
+    "display topology for flow": "Exibir topologia do flow",
     "cannot create topology": "Não foi possível criar topologia para o flow",
-    "cannot swap tasks": "Não é possível trocar as tasks",
-    "change execution state confirm": "Tem certeza de que deseja alterar o estado da execução <code>{id}</code>?",
-    "change execution state done": "Estado de execução atualizado",
-    "change queue confirm": "Tem certeza de que deseja alterar o estado da fila para a execução <code>{id}</code>?<br/>",
+    "start date": "Data de início",
+    "end date": "Data de término",
+    "creation": "Criação",
+    "flow creation": "Criação de flow",
+    "start datetime": "Data e hora de início",
+    "end datetime": "Data e hora de término",
+    "restart": "Reiniciar",
+    "restart latest revision": "Reiniciar última revisão",
+    "restart tooltip": "Reiniciar a execução a partir da task <code>{state}</code>",
+    "restarted": "A Execução é Reiniciada",
+    "restart confirm": "Tem certeza de que deseja reiniciar a execução <code>{id}</code>?",
+    "restart change revision": "Você pode alterar a revisão que será usada para a nova execução.",
+    "replay": "Repetir",
+    "replay from task tooltip": "Criar uma execução similar começando da task <code>{taskId}</code>",
+    "replay from beginning tooltip": "Criar uma execução similar começando do início",
+    "replay latest revision": "Repetir usando a última revisão",
+    "replayed": "A execução é Reproduzida",
+    "replay confirm": "Tem certeza de que deseja repetir esta execução <code>{id}</code> e criar uma nova?",
+    "replay with inputs": "Repetir com inputs",
+    "reuse_original_inputs": "Reutilizar inputs originais",
+    "modify_inputs": "Modificar inputs",
+    "replay the execution": "Reproduzir a execução <code>{executionId}</code> para o flow <code>{flowId}</code>",
+    "prefill inputs": "Preencher automaticamente",
+    "current": "atual",
     "change state": "Alterar estado",
-    "change state confirm": "Tem certeza de que deseja alterar o estado de execução da task <code>{task}</code> na execução <code>{id}</code>?",
-    "change state current state": "Status atual é:",
+    "actual state": "Estado atual",
+    "select a state": "Selecione um estado",
+    "are you sure change state": "Tem certeza de que deseja alterar o estado?",
+    "yes": "Sim",
     "change state done": "O estado da task foi atualizado",
+    "change state confirm": "Tem certeza de que deseja alterar o estado de execução da task <code>{task}</code> na execução <code>{id}</code>?",
+    "change queue confirm": "Tem certeza de que deseja alterar o estado da fila para a execução <code>{id}</code>?<br/>",
+    "change state current state": "Status atual é:",
     "change state hint": {
+      "WARNING": [
+        "O flow será marcado como WARNING.",
+        "As próximas tasks serão executadas.",
+        "As tasks de erro serão executadas."
+      ],
       "FAILED": [
         "O flow será marcado como FAILED.",
         "Nenhuma outra task será executada.",
         "As tasks de erro serão executadas."
-      ],
-      "RUNNING": [
-        "O flow será reiniciado e executará todas as próximas tasks.",
-        "Todas as tasks bloqueadas serão executadas."
       ],
       "SUCCESS": [
         "O flow será reiniciado pois esta task foi bem-sucedida.",
         "Todas as tasks bloqueadas serão executadas.",
         "O flow estará em estado de SUCCESS se todas as execuções das tasks forem bem-sucedidas."
       ],
-      "WARNING": [
-        "O flow será marcado como WARNING.",
-        "As próximas tasks serão executadas.",
-        "As tasks de erro serão executadas."
+      "RUNNING": [
+        "O flow será reiniciado e executará todas as próximas tasks.",
+        "Todas as tasks bloqueadas serão executadas."
       ]
     },
+    "replay execution title": "Repetir execução",
+    "restart execution title": "Reiniciar execução",
+    "replay execution description": "Isso criará uma nova execução com base na execução selecionada.",
+    "replay using": "Repetir usando",
+    "flow revision original": "Revisão original do flow",
+    "flow revision latest": "Última revisão do flow",
+    "flow revision specific": "Revisão específica do flow",
+    "replay inputs": "Entradas",
+    "reuse original inputs": "Reutilizar inputs originais",
+    "modify inputs": "Modificar inputs",
+    "replay inputs new required": "Esta revisão possui inputs. Você será solicitado a preenchê-los.",
+    "replay select taskrun": "Selecione a execução da task para reproduzir a partir de:",
     "change state tooltip": "Alterar o estado de execução",
-    "chart": "Gráfico",
-    "chart preview": "Pré-visualização do gráfico",
-    "chart type": "Tipo de gráfico",
-    "charts": "Gráficos",
-    "choice": "Escolha",
-    "choose file": "Escolha um arquivo ou solte-o aqui...",
-    "close": "Fechar",
-    "close sidebar": "fechar barra lateral",
-    "codeDisabled": "Desativado no Flow",
-    "collapse": "Colapsar",
-    "collapse all": "Colapsar tudo",
-    "commit_id": "ID do commit",
-    "common": {
-      "back": "Voltar"
-    },
-    "concurrency": "Concorrência",
-    "concurrency limits": "Limites de Concurrency",
-    "concurrency_limit": {
-      "dialog_title": "Limites de Concurrency",
-      "warning": "Alterar o contador em execução pode corromper a concorrência, fazendo com que as execuções excedam o limite permitido."
-    },
-    "conditions": "Condições",
-    "configure basic auth": "Configurar Autenticação Básica",
-    "confirm": "Confirmar",
-    "confirm password": "Confirmar senha",
-    "confirmation": "Confirmação",
-    "context updated date": "Data de atualização do contexto",
-    "context updated date tooltip": "Quando o contexto do trigger foi atualizado pela última vez. Isso ocorre quando a execução é acionada, termina (bloqueio liberado) ou após uma avaliação (mesmo que nenhuma execução ocorra).",
-    "contextBar": {
-      "demo": "Demonstração",
-      "docs": "Documentos",
-      "help": "Ajuda",
-      "issue": "Problema",
-      "news": "Notícias",
-      "star": "Nos avalie com uma estrela"
-    },
-    "continue backfill": "Continuar o backfill",
-    "continue backfills": "Continuar backfills",
-    "copied": "Copiado",
-    "copied_logs_to_clipboard": "Logs copiados para a área de transferência.",
-    "copy": "Copiar",
-    "copy all logs": "Copiar Todos os Logs",
-    "copy logs": "Copiar logs",
-    "copy url": "Copiar URL",
-    "copy_and_close": "Copiar e fechar",
-    "copy_to_clipboard": "Copiar para a área de transferência",
-    "copy_value": "Copy value",
-    "create": "Criar",
-    "create first task": "Crie sua primeira task",
-    "create_flow": "Criar Flow",
-    "created date": "Data de criação",
-    "creation": "Criação",
-    "cron": "Cron",
-    "curl": {
-      "command": "Comando cURL",
-      "note": "Observe que, para o tipo de input SECRET e FILE, o comando deve ser ajustado para corresponder aos valores reais."
-    },
-    "current": "atual",
-    "current execution": "Execução atual",
-    "custom value": "Valor personalizado",
-    "customize sidebar": "Personalizar barra lateral",
-    "dark_version": "Versão escura",
-    "dashboards": {
-      "chart_preview": "Clique no código-fonte de um gráfico para ver sua pré-visualização",
-      "creation": {
-        "confirmation": "O Dashboard <code>{title}</code> foi criado.",
-        "label": "Criar Dashboard"
-      },
-      "default": "Dashboard Padrão",
-      "deletion": {
-        "confirmation": "Tem certeza de que deseja excluir o dashboard <code>{title}</code>?"
-      },
-      "edition": {
-        "chart": "Edite este gráfico",
-        "confirmation": "As alterações no dashboard <code>{title}</code> foram salvas.",
-        "id readonly": "A propriedade `id` não pode ser alterada — agora está definida para seus valores iniciais. Se você quiser alterá-la, pode criar um novo dashboard e remover o antigo.",
-        "label": "Editar Dashboard"
-      },
-      "empty": "Não há resultados para serem exibidos.",
-      "export": "Exportar para CSV",
-      "labels": {
-        "plural": "Dashboards",
-        "singular": "Dashboard"
-      },
-      "no_description": "Sem descrição",
-      "no_description_hint": "Adicione uma descrição a este flow para documentar o que ele faz.<br>Markdown é suportado.",
-      "others": "Outros",
-      "preview": "Visualizar Dashboard",
-      "quick_filters": {
-        "all": "Todos",
-        "failed": "Falhou",
-        "paused": "Pausado",
-        "running": "Em execução",
-        "success": "Sucesso",
-        "warning": "Aviso"
-      },
-      "switch": "Alternar Dashboard",
-      "viewAll": "Ver tudo"
-    },
-    "data": "Dados",
-    "dataFilters": "Filtros de Dados",
-    "data_not_protected": "Seus dados não estão protegidos. Não os perca. <b>Ative nossos recursos de segurança gratuitos ou experimente nossa oferta paga.</b>",
-    "date": "Data",
-    "date count": "{count} em {date}",
-    "date format": "Formato de data",
-    "date range count": "{count} entre {startDate} e {endDate}",
-    "datepicker": {
-      "12hours": "12 horas",
-      "15minutes": "15 minutos",
-      "1hour": "1 hora",
-      "24hours": "24 horas",
-      "30days": "30 dias",
-      "365days": "365 dias",
-      "48hours": "48 horas",
-      "5minutes": "5 minutos",
-      "7days": "7 dias",
-      "custom": "Personalizado",
-      "dayBeforeYesterday": "Anteontem",
-      "duration example": "Exemplo: 'P1DT1H1M1S'",
-      "error": "Formato de duração inválido, deve ser uma duração ISO 8601 (P1DT1H1M1S por ex.)",
-      "last12hours": "Últimas 12 horas",
-      "last15minutes": "Últimos 15 minutos",
-      "last1hour": "Última 1 hora",
-      "last24hours": "Últimas 24 horas",
-      "last30days": "Últimos 30 dias",
-      "last365days": "Últimos 365 dias",
-      "last48hours": "Últimas 48 horas",
-      "last5minutes": "Últimos 5 minutos",
-      "last7days": "Últimos 7 dias",
-      "leave empty for infinite": "Deixe vazio para duração infinita ou digite uma duração ISO 8601 (exemplo: 'P1DT1H1M1S)'",
-      "never": "Nunca",
-      "next12hours": "Próximas 12 horas",
-      "next15minutes": "Próximos 15 minutos",
-      "next1hour": "Próxima 1 hora",
-      "next24hours": "Próximas 24 horas",
-      "next30days": "Próximos 30 dias",
-      "next365days": "Próximos 365 dias",
-      "next48hours": "Próximas 48 horas",
-      "next5minutes": "Próximos 5 minutos",
-      "next7days": "Próximos 7 dias",
-      "previousMonth": "Mês anterior",
-      "previousWeek": "Semana anterior",
-      "previousYear": "Ano anterior",
-      "short": {
-        "12h": "12h",
-        "15m": "15min",
-        "1d": "1d",
-        "1h": "1h",
-        "7d": "7d"
-      },
-      "thisMonth": "Este mês",
-      "thisMonthSoFar": "Este mês até agora",
-      "thisWeek": "Esta semana",
-      "thisWeekSoFar": "Esta semana até agora",
-      "thisYear": "Este ano",
-      "thisYearSoFar": "Este ano até agora",
-      "today": "Hoje",
-      "yesterday": "Ontem"
-    },
-    "debug": "Depurar",
-    "default": "Padrão",
-    "defaultsToNamespaceFile": "Padrões para arquivo de namespace: <code>{name}</code>",
-    "delete": "Deletar",
-    "delete backfill": "Deletar o backfill",
-    "delete backfills": "Deletar backfills",
-    "delete confirm": "Tem certeza de que deseja deletar <code>{name}</code>?",
-    "delete execution running": "<div class=\"alert alert-warning mt-2 mb-0\">Esta execução ainda está RUNNING, deletá-la não irá pará-la.<br />Você precisa matar a execução para pará-la.</div>",
-    "delete logs": "Deletar logs",
-    "delete ok": "está deletado",
-    "delete revision confirm": "Tem certeza de que deseja excluir a revisão {revision}?",
-    "delete revision error": "Erro ao excluir a revisão {revision} com erro {error}",
-    "delete task confirm": "Deseja deletar a task <code>{taskId}</code>?",
-    "delete trigger": "Excluir trigger",
-    "delete trigger confirmation": "Tem certeza de que deseja excluir o trigger {id}? WARNING: excluir um trigger pode levar a execuções duplicadas se o trigger ainda estiver ativo em um flow.",
-    "delete trigger error": "Erro ao excluir trigger {id}",
-    "delete trigger success": "O Trigger {id} foi excluído com sucesso",
-    "delete triggers": "Excluir triggers",
-    "delete_all_logs": "Tem certeza de que deseja deletar todos os logs?",
-    "delete_log": "Tem certeza de que deseja excluir o log?",
-    "deleted": "Deletado com sucesso",
-    "deleted confirm": "<em>{name}</em> foi deletado com sucesso!",
-    "deleted_label": "Deletado",
-    "demos": {
-      "IAM": {
-        "message": "A Kestra Enterprise Edition possui capacidades IAM integradas com single sign-on (SSO), sincronização de diretório SCIM e controle de acesso baseado em funções (RBAC), integrando-se com vários provedores de identidade e permitindo que você atribua permissões detalhadas para usuários e contas de serviço.",
-        "title": "Gerencie Usuários através do IAM com SSO, SCIM e RBAC"
-      },
-      "apps": {
-        "message": "As aplicações na Kestra Enterprise Edition permitem que você construa interfaces personalizadas que interagem com os workflows do Kestra fora da plataforma. Este recurso permite usar seus workflows como um backend para aplicações personalizadas, possibilitando que usuários não técnicos enviem dados através de formulários ou retomem workflows PAUSED aguardando aprovação.",
-        "title": "Crie Apps personalizadas com Kestra"
-      },
-      "assets": {
-        "header": "Metadados e Observabilidade de Assets",
-        "label": "Ativos",
-        "message": "Os assets conectam observabilidade, linhagem e metadados de propriedade para que as equipes da plataforma possam solucionar problemas mais rapidamente e implantar com confiança.",
-        "title": "Traga todos os datasets, serviços e dependências para a visualização."
-      },
-      "audit-logs": {
-        "message": "A Kestra Enterprise Edition registra todas as atividades com registros robustos e imutáveis, facilitando o acompanhamento de alterações, a manutenção da conformidade e a resolução de problemas.",
-        "title": "Acompanhe Alterações com Audit Logs"
-      },
-      "blueprints": {
-        "message": "Na Kestra Enterprise Edition, você pode criar Blueprints personalizados disponíveis apenas para sua organização. Você pode usá-los como modelos de melhores práticas para compartilhar, centralizar e documentar fluxos de trabalho comumente usados em sua equipe.",
-        "title": "Adicionar Blueprints Personalizados"
-      },
-      "contact_sales": "Contatar Vendas",
-      "enterprise_edition": "Edição Enterprise",
-      "get_a_demo_button": "Obter uma Demonstração",
-      "instance": {
-        "message": "A Kestra Enterprise Edition fornece um painel operacional para ajudar você a observar a saúde da sua plataforma e acompanhar as métricas de tempo de atividade de todos os serviços, como, por exemplo, Workers, Schedulers e Executors. Na mesma página, você também pode criar Anúncios para notificar seus usuários sobre interrupções planejadas, e pode entrar em um modo de manutenção que coloca temporariamente todos os serviços e execuções de workflow em um estado PAUSED para realizar uma atualização.",
-        "title": "Gerencie a Infraestrutura em Toda a Sua Instância"
-      },
-      "namespace": {
-        "assets": {
-          "message": "Na Kestra Enterprise Edition, Assets mantém um inventário ativo de recursos com os quais seus workflows interagem. Esses recursos podem ser tabelas de banco de dados, máquinas virtuais, arquivos ou qualquer sistema externo com o qual você trabalhe.",
-          "title": "Centralizar Gestão de Ativos"
-        },
-        "audit-logs": {
-          "message": "Na Kestra Enterprise Edition, você pode visualizar logs de auditoria no nível do namespace com diferenças detalhadas, fornecendo um histórico claro de quem alterou o quê e quando em todos os recursos.",
-          "title": "Acompanhe Todas as Alterações em Um Só Lugar"
-        },
-        "edit": {
-          "message": "Na Kestra Enterprise Edition, os namespaces oferecem isolamento avançado e governança de segredos, variáveis e padrões de plugins em escala. Os administradores podem configurar gerenciadores de segredos personalizados, backends de armazenamento isolados, grupos de worker dedicados e permissões detalhadas por namespace. Isso garante que segredos, variáveis e configurações de plugins permaneçam seguros e fáceis de manter em diferentes equipes e projetos.",
-          "title": "Atualize o Gerenciamento do seu Namespace"
-        },
-        "history": {
-          "message": "Na Kestra Enterprise Edition, você pode gerenciar o histórico de revisões dos seus Namespaces",
-          "title": "Gerenciar Histórico de Revisões em Um Só Lugar"
-        },
-        "plugin-defaults": {
-          "message": "Na Kestra Enterprise Edition, você pode definir padrões de plugin específicos para cada namespace, reduzindo a necessidade de configuração duplicada em cada flow. Esta governança central de plugins impõe configurações consistentes, permite a referência segura de segredos ou variáveis e simplifica a manutenção dos seus workflows.",
-          "title": "Padronizar Configuração com Padrões de Plugin"
-        },
-        "secrets": {
-          "message": "Na Kestra Enterprise Edition, você pode armazenar e controlar segredos no nível de namespace, minimizando riscos e garantindo que as credenciais de cada equipe permaneçam isoladas. Graças à hierarquia aninhada, você também pode configurar credenciais em um namespace pai e elas serão herdadas por todos os namespaces filhos. O suporte para gerenciadores de segredos dedicados e configurações de permissão detalhadas no nível de namespace fortalece ainda mais a segurança e a conformidade.",
-          "title": "Gerenciar Segredos de Forma Segura"
-        },
-        "variables": {
-          "message": "Na Kestra Enterprise Edition, você pode definir e gerenciar variáveis no nível do namespace para eliminar configurações repetitivas em flows. Essas variáveis garantem consistência, simplificam atualizações de configuração e podem ser facilmente referenciadas por qualquer task ou trigger para workflows mais limpos e fáceis de manter.",
-          "title": "Governe Centralmente Suas Variáveis"
-        }
-      },
-      "quotas": {
-        "message": "A Kestra Enterprise Edition permite definir cotas em flows para limitar o número de execuções simultâneas ou totais dentro de uma janela de tempo. As cotas ajudam a proteger a infraestrutura partilhada, aplicar SLAs e impedir que workflows descontrolados consumam recursos excessivos.",
-        "title": "Aplicar cotas de execução em flows"
-      },
-      "secrets": {
-        "add_env": {
-          "first": "Codifique o <a href=\"https://kestra.io/docs/how-to-guides/secrets?utm_source=app&utm_medium=referral&utm_campaign=secrets-inlinedoc#using-secrets-in-kestra\" target=\"_blank\">valor secreto em Base64</a>",
-          "intro": "Para criar um novo Secret:",
-          "second": "Adicione uma variável de ambiente chamada '<strong>SECRET_{'{MY_SECRET_KEY}'}</strong>' com o valor acima",
-          "third": "Reinicie sua instância do Kestra"
-        },
-        "detected_env": "Aqui estão as variáveis de ambiente do tipo secreto identificadas no momento de inicialização da instância:",
-        "empty_env": "Você ainda não tem nenhum Secret no seu ambiente.",
-        "message": "A Enterprise Edition (EE) permite adicionar, editar ou excluir segredos diretamente na UI—sem necessidade de reiniciar a instância. Organize segredos por namespace com permissões RBAC granulares e herde-os de namespaces pai para filho. A EE integra-se com gerenciadores de segredos como HashiCorp Vault, AWS Secrets Manager, Azure Key Vault, Google Secret Manager e Elasticsearch. Configure backends dedicados por namespace, tenant ou instância para isolar segredos entre equipes, ou habilite segredos somente leitura armazenados em cofres externos. Os segredos permanecem criptografados em repouso e em trânsito. O cache opcional reduz chamadas de API, e trilhas de auditoria registram todo o acesso.",
-        "title": "Atualize seu Gerenciamento de Secrets"
-      },
-      "tenants": {
-        "message": "A Kestra Enterprise Edition suporta multi-tenancy, proporcionando ambientes totalmente isolados para diferentes equipes ou projetos, cada um com seus próprios recursos, como grupos de worker dedicados ou segredos e backends de armazenamento interno.",
-        "title": "Gerenciar Fluxos de Trabalho em Tenants Isolados"
-      },
-      "tests": {
-        "header": "Testes Unitários para Flows",
-        "label": "Testes",
-        "message": "Verifique a lógica dos seus flows isoladamente, detecte regressões cedo e mantenha a confiança nas suas automações à medida que elas mudam e crescem.",
-        "title": "Garanta a Confiabilidade com Cada Alteração"
-      },
-      "watch_the_video": "Assista ao vídeo"
-    },
-    "density": "Density",
-    "density_compact": "Compact",
-    "density_expanded": "Expanded",
-    "density_normal": "Normal",
-    "dependencies": "Dependências",
-    "dependencies delete flow": "Este flow tem dependências. Deletá-lo impedirá que suas dependências sejam executadas.<br /><br /> Aqui está a lista de flows afetados:",
-    "dependencies loaded": "Dependências carregadas",
-    "dependencies missing acls": "Sem permissões neste flow",
-    "dependency": {
-      "controls": {
-        "clear_selection": "Limpar seleção",
-        "fit_view": "Ajustar à tela",
-        "zoom_in": "Aumentar",
-        "zoom_out": "Reduzir zoom"
-      },
-      "search": {
-        "flow": {
-          "display": "Incluir dependências do flow"
-        },
-        "namespace": {
-          "no_namespace": "Sem namespace",
-          "select": "Selecione um namespace"
-        },
-        "no_results": "Nenhum resultado encontrado para {term}",
-        "placeholders": {
-          "asset": "Pesquisar por asset, flow ou namespace...",
-          "default": "Pesquisar por flow ou namespace..."
-        }
-      }
-    },
-    "dependency task": "Task {taskId} é uma dependência de outra task",
-    "description": "Descrição",
-    "details": "Detalhes",
-    "disable": "Desativar",
-    "disabled": "Desativado",
-    "disabled flow desc": "Este flow está desativado, por favor, ative-o para executá-lo.",
-    "disabled flow title": "Este flow está desativado",
-    "discard changes confirmation": "Você tem alterações não salvas. Tem certeza de que deseja descartá-las?",
-    "discard execution confirmation": "Você tem inputs não salvos. Tem certeza de que deseja descartar esta execução?",
-    "display direct sub tasks count": "Exibir contagem direta de subtasks",
-    "display flow {id} executions": "Exibir execuções do flow {id}",
-    "display metric for specific task": "Exibir métrica para uma task específica",
-    "display output for specific task": "Exibir output para uma task específica",
-    "display topology for flow": "Exibir topologia do flow",
-    "display_settings": "Display settings",
-    "docs": "Documentos",
-    "documentation": {
-      "documentation": "Documentação",
-      "github": "Abrir um issue no GitHub"
-    },
-    "documentationMenu": "Menu de documentação",
-    "done": "Concluído",
-    "down trend": "Diminuindo",
-    "download": "Baixar",
-    "download logs": "Baixar logs",
-    "download_logos": "Baixar Pacote de Logos",
-    "download_logs_description": "Choose which logs to export. Filters default to your current view.",
-    "draft": "Rascunho",
-    "draft_available": "Alteração de rascunho disponível no editor",
-    "draft_flow_warning": "Esta revisão do flow é um rascunho. A execução será feita sobre esta revisão de rascunho e pode falhar imediatamente se a definição do flow for inválida.",
-    "drill down preview": "Pré-visualização",
-    "drop items here": "Solte os itens aqui",
-    "duplicate-pair": "O {label} \"{key}\" está duplicado, a primeira chave foi ignorada.",
-    "duration": "Duração",
-    "dynamic": "Dinâmico",
-    "each value": "Valor da iteração",
-    "edit": "Editar",
-    "edit flow": "Editar flow",
-    "editor": "Editor",
-    "editor_shortcuts": {
-      "command_palette": "Mostrar paleta de comandos",
-      "comment": "Comentário",
-      "comment_uncomment": "Comentar/Descomentar",
-      "decrease_fontsize": "Diminuir tamanho da fonte do editor",
-      "duplicate_cursor": "Duplicar cursor",
-      "execute_flow": "Executar flow",
-      "fold_unfold": "Dobra/Desdobra código",
-      "increase_fontsize": "Aumentar o tamanho da fonte do editor",
-      "label": "Atalhos de teclado",
-      "move_line": "Mover linha",
-      "reset_fontsize": "Redefinir tamanho da fonte do editor",
-      "save_flow": "Salvar flow",
-      "toggle_ai_agent": "Alternar agente de IA",
-      "trigger_autocompletion": "Acionar autocompletar",
-      "uncomment": "Descomentar"
-    },
-    "ee-tooltip": {
-      "button": "Fale conosco",
-      "features-blocked": "Este recurso requer a Enterprise Edition."
-    },
-    "email": "Email",
-    "email length constraint": "Email não deve exceder 256 caracteres",
-    "empty": {
-      "announcements": {
-        "content": "Os anúncios permitem que você notifique seus usuários sobre quaisquer alterações ou informe-os sobre o tempo de inatividade planejado para manutenção. Basta selecionar o tipo de anúncio, o intervalo de datas em que ele deve ser exibido e escrever a mensagem do anúncio.",
-        "title": "Você ainda não tem anúncios!"
-      },
-      "apiTokens": {
-        "content": "Tokens de API são usados sempre que você deseja conceder acesso programático à API do Kestra.",
-        "title": "Gerencie seus Tokens de API"
-      },
-      "apps": {
-        "content": "Comece a criar Apps para interagir com o Kestra a partir do mundo externo.",
-        "title": "Você ainda não tem apps!"
-      },
-      "assets": {
-        "content": "Adicione assets para rastrear e gerenciar seus data assets, serviços e infraestrutura.",
-        "title": "Você ainda não tem Assets!"
-      },
-      "concurrency_executions": {
-        "content": "Leia mais sobre <strong><a href=\"https://kestra.io/docs/workflow-components/execution?utm_source=app&utm_medium=referral&utm_campaign=concurrency-inlinedoc\" target=\"_blank\">Execuções</a></strong> em nossa documentação.",
-        "title": "Nenhuma Execução em andamento para este Flow."
-      },
-      "concurrency_limit": {
-        "content": "Leia mais sobre <strong><a href=\"https://kestra.io/docs/workflow-components/concurrency?utm_source=app&utm_medium=referral&utm_campaign=concurrency-inlinedoc\" target=\"_blank\">Limites de Concurrency</a></strong> em nossa documentação.",
-        "title": "Nenhum limite está definido para este Flow."
-      },
-      "concurrency_limits": {
-        "content": "Leia mais sobre os <strong><a href=\"https://kestra.io/docs/workflow-components/concurrency?utm_source=app&utm_medium=referral&utm_campaign=concurrency-inlinedoc\" target=\"_blank\">Limites de Concurrency</a></strong> em nossa documentação.",
-        "title": "Nenhum limite de concorrência está definido."
-      },
-      "dependencies": {
-        "ASSET": {
-          "content": "Este ativo não possui dependências upstream ou downstream com flows ou outros ativos.",
-          "title": "Atualmente, não há dependências."
-        },
-        "EXECUTION": {
-          "content": "Leia mais sobre <a href=\"https://kestra.io/docs/ui/executions?utm_source=app&utm_medium=referral&utm_campaign=dependencies-inlinedoc#dependencies\" target=\"_blank\">Dependências de Execução</a> na nossa documentação.",
-          "title": "Atualmente, não há dependências."
-        },
-        "FLOW": {
-          "content": "Leia mais sobre <a href=\"https://kestra.io/docs/ui/flows?utm_source=app&utm_medium=referral&utm_campaign=dependencies-inlinedoc#dependencies\" target=\"_blank\">Dependências de Flow</a> na nossa documentação.",
-          "title": "Atualmente, não há dependências."
-        },
-        "NAMESPACE": {
-          "content": "Leia mais sobre <a href=\"https://kestra.io/docs/ui/namespaces?utm_source=app&utm_medium=referral&utm_campaign=dependencies-inlinedoc#dependencies\" target=\"_blank\">Dependências de Namespace</a> em nossa documentação.",
-          "title": "Atualmente, não há dependências."
-        }
-      },
-      "groups": {
-        "content": "Grupos permitem que você agrupe usuários para gerenciar permissões e vinculações de funções coletivamente em todo o seu mandante.",
-        "title": "Você ainda não tem grupos!"
-      },
-      "kill_switches": {
-        "content": "O recurso Kill Switch fornece um mecanismo baseado em UI para interromper execuções problemáticas. Ele substitui os comandos <code>--skip-executions</code> e <code>--skip-flows</code> disponíveis apenas no CLI por uma interface de administração abrangente.",
-        "title": "Você ainda não tem Kill Switches!"
-      },
-      "mcpToolFlows": {
-        "content": "Exponha um flow como uma ferramenta MCP adicionando um <code>McpToolTrigger</code> a ele. Leia mais sobre o <strong><a href=\"https://kestra.io/docs/workflow-components/triggers/mcp-tool-trigger?utm_source=app&utm_medium=referral&utm_campaign=mcp-tool-trigger-inlinedoc\" target=\"_blank\">MCP Tool Trigger</a></strong> em nossa documentação.",
-        "title": "Ainda não há flows de ferramenta registrados neste servidor."
-      },
-      "namespaceFiles": {
-        "content": "Os ficheiros do namespace funcionam como uma pasta de projeto para este namespace. Armazene código Python, SQL, dbt ou Terraform e, em seguida, referencie qualquer ficheiro nos seus flows com",
-        "title": "Ainda não há ficheiros neste namespace"
-      },
-      "panels": {
-        "content": "Você fechou todos os painéis.  \nEscolha uma aba acima para continuar.",
-        "title": "Nenhum painel aberto"
-      },
-      "pluginDefaults": {
-        "content": "Padrões de Plugin permitem que você governe centralmente a configuração do seu plugin e a compartilhe com todos os flows no seu namespace.",
-        "title": "Você ainda não tem padrões de plugin!"
-      },
-      "plugins": {
-        "content": "Leia mais sobre <strong><a href=\"https://kestra.io/docs/workflow-components/plugin-defaults?utm_source=app&utm_medium=referral&utm_campaign=plugin-default-inlinedoc\" target=\"_blank\">Limites de Concurrency</a></strong> em nossa documentação.",
-        "title": "Nenhum padrão de plugin está definido para este Namespace."
-      },
-      "testSuites": {
-        "content": "Comece a criar suítes de Teste para testar seus Flows.",
-        "title": "Você ainda não tem Test suites!"
-      },
-      "triggers": {
-        "content": "Leia mais sobre <strong><a href=\"https://kestra.io/docs/workflow-components/triggers?utm_source=app&utm_medium=referral&utm_campaign=trigger-inlinedoc\" target=\"_blank\">Triggers</a></strong> em nossa documentação.",
-        "title": "Seu flow não possui nenhum trigger."
-      },
-      "variables": {
-        "content": "Adicione pares de key-value para compartilhar configurações entre flows. Namespaces filhos os herdam automaticamente, e você pode referenciar qualquer value com",
-        "title": "Ainda não há variáveis"
-      },
-      "versionPlugin": {
-        "content": "Aqui você pode gerenciar todos os plugins instalados na sua instância do Kestra. Plugins recém-instalados podem não estar imediatamente disponíveis em todos os serviços do Kestra, dependendo da configuração da sua instância.",
-        "title": "Você ainda não tem um plugin versionado!"
-      },
-      "workerRegistrationTokens": {
-        "content": "Tokens de registro permitem que workers remotos autentiquem-se e registrem-se com segurança na sua instância do Kestra. Crie um token e use-o para conectar novos workers a este cluster.",
-        "title": "Você ainda não tem tokens de registro!"
-      }
-    },
-    "empty search": "Resultados da pesquisa estão vazios",
-    "enable": "Ativar",
-    "enable concurrency": "Habilitar concorrência",
-    "enabled": "Ativado",
-    "encoding": "Codificação",
-    "end date": "Data de término",
-    "end datetime": "Data e hora de término",
-    "environment": "Ambiente",
-    "environment color setting": "Cor do ambiente",
-    "environment name setting": "Nome do ambiente",
-    "error": "Erro",
-    "error detected": "Erro(s) detectado(s).",
-    "error in editor": "Um erro foi encontrado no editor",
-    "errorLogs": "Logs de erros",
-    "errors": {
-      "401": {
-        "content": "Você precisa estar autenticado para acessar esta página.",
-        "title": "Não autorizado"
-      },
-      "403": {
-        "content": "Você não tem as permissões necessárias para acessar esta página.",
-        "title": "Acesso negado"
-      },
-      "404": {
-        "content": "A URL solicitada não foi encontrada neste servidor.<br />Isso é tudo que sabemos.",
-        "flow or execution": "O flow ou execução que você está procurando não existe.",
-        "title": "Página não encontrada"
-      }
-    },
+    "change execution state confirm": "Tem certeza de que deseja alterar o estado da execução <code>{id}</code>?",
+    "change execution state done": "Estado de execução atualizado",
+    "mark as": "Marcar como <code>{status}</code>",
+    "unqueue as": "Desenfileirar como <code>{status}</code>",
+    "kill": "Matar",
+    "kill parents and subflow": "Matar o flow atual e subflows",
+    "kill only parents": "Matar apenas o atual",
+    "killed confirm": "Tem certeza de que deseja matar a execução <code>{id}</code>?",
+    "killed done": "Execução está na fila para ser morta",
+    "resume": "Retomar",
+    "resumed title": "Retomar execução <code>{id}</code>",
+    "resumed confirm": "Tem certeza de que deseja retomar a execução <code>{id}</code>?",
+    "resumed done": "Execução foi retomada",
+    "resume from breakpoint title": "Retomar execução `<code>{id}</code>` de breakpoint",
+    "resume from breakpoint done": "Execução é retomada do breakpoint",
+    "breakpoints": "Pontos de interrupção",
+    "pause": "Pausar",
+    "pause title": "Pausar execução <code>{id}</code>.<br/>Note que as tasks atualmente em execução ainda serão processadas, e a execução terá que ser retomada manualmente.",
+    "pause confirm": "Tem certeza de que deseja pausar a execução <code>{id}</code>?",
+    "pause done": "A execução está PAUSED",
+    "unqueue": "Desenfileirar",
+    "unqueue title": "Desenfileirar execução <code>{id}</code>.<br/>Observe que isso não obedecerá ao limite de concorrência do flow, portanto, mais execuções podem estar em execução do que o limite permitido.",
+    "unqueue title multiple": "Tem certeza de que deseja Desenfileirar <code>{count}</code> execuções?<br/><br/>Observe que isso não obedecerá ao limite de concorrência do flow, portanto, mais execuções podem estar em execução do que o limite permitido.",
+    "unqueue confirm": "Tem certeza de que deseja desagendar a execução <code>{id}</code>?",
+    "unqueue done": "A execução está fora da fila",
+    "force run": "Executar forçadamente",
+    "force run title": "Forçar a execução da execução <code>{id}</code>.",
+    "force run tooltip": "Forçar a execução a correr. Pode criar execuções de task duplicadas; se possível, use outra ação.",
+    "force run confirm": "Tem certeza de que deseja forçar a execução <code>{id}</code>?<br/><br/>AVISO: forçar a execução de uma execução não é garantido e pode criar execuções de tarefa duplicadas.<br/><br/>As seguintes transições serão feitas:<br/><ul><li>Tarefas CREATED serão movidas para o estado RUNNING.</li><li>Tarefas RUNNING serão re-submetidas.</li><li>Tarefas QUEUED serão removidas da fila.</li><li>Tarefas PAUSED serão retomadas.</li></ul>",
+    "force run done": "A execução é forçada a correr",
+    "toggle output": "Alternar outputs",
+    "metrics": "Métricas",
+    "no data current task": "Não há dados disponíveis para a tarefa atual",
+    "no metrics available": "Nenhuma métrica registrada para esta execução de task.",
+    "no outputs available": "Nenhuma saída disponível para esta execução de task.",
+    "outputs": "Outputs",
+    "flow_outputs": "Saídas do Flow",
+    "no_flow_outputs": "Nenhum output disponível.",
+    "output": "Output",
     "eval": {
-      "expression": "Expressão",
-      "preview": "Pré-visualização",
-      "render": "Expressão de Renderização",
       "title": "Expressão de Depuração",
-      "tooltip": "Renderizar qualquer expressão Pebble e inspecionar o contexto da Execução."
+      "render": "Expressão de Renderização",
+      "tooltip": "Renderizar qualquer expressão Pebble e inspecionar o contexto da Execução.",
+      "preview": "Pré-visualização",
+      "expression": "Expressão"
     },
-    "evaluation lock date": "Data de bloqueio da avaliação",
-    "execute": "Executar",
-    "execute backfill": "Executar backfill",
-    "execute flow behaviour": "Executar o flow",
-    "execute flow now ?": "Deseja executar este flow?",
-    "execute the flow": "Executar o flow <code>{id}</code>",
-    "execution": "Execução",
-    "execution already finished": "Execução <code>{executionId}</code> já finalizada",
-    "execution id": "Id de Execução",
-    "execution labels": "Labels de execução",
-    "execution not found": "A execução {executionId} não foi encontrada.",
-    "execution not in state FAILED": "Execução <code>{executionId}</code> não está no estado FAILED",
-    "execution not in state PAUSED": "Execução <code>{executionId}</code> não está no estado PAUSED",
-    "execution replay": "Esta execução é uma repetição de",
-    "execution replayed": "Esta execução foi reproduzida.",
-    "execution restarted": "Esta execução foi reiniciada {nbRestart} vez(es).",
+    "attempt": "Tentativa",
+    "toggle output display": "Alternar exibição de output",
+    "name": "Nome",
+    "key": "Key",
+    "value": "Value",
+    "each value": "Valor da iteração",
+    "current execution": "Execução atual",
+    "parent execution": "Execução pai",
+    "original execution": "Execução original",
+    "automatic refresh": "Atualização automática",
+    "toggle periodic refresh each x seconds": "Alternar atualização periódica a cada {interval} segundos",
+    "trigger refresh": "Atualizar trigger",
+    "add-trigger-in-editor": "Adicione um Trigger ao seu Flow primeiro",
+    "refresh": "Atualizar",
+    "filter by status": "Filtrar execuções pelo status {status}",
+    "topology-graph": {
+      "graph-orientation": "Orientação do gráfico",
+      "zoom-in": "Aumentar zoom",
+      "zoom-out": "Diminuir zoom",
+      "zoom-reset": "Redefinir zoom",
+      "zoom-fit": "Ajustar",
+      "invalid": "Erro no gráfico",
+      "invalid_description": "Ocorreu um erro ao carregar o gráfico. Por favor, verifique o código-fonte para erros."
+    },
+    "show task logs": "Mostrar task logs",
+    "show task condition": "Exibir condição da task",
+    "show task outputs": "Mostrar outputs da task",
+    "show task source": "Mostrar fonte da task",
+    "specific task": "Task específica",
+    "display output for specific task": "Exibir output para uma task específica",
+    "display metric for specific task": "Exibir métrica para uma task específica",
+    "display direct sub tasks count": "Exibir contagem direta de subtasks",
+    "stream": "Stream",
     "execution statistics": "Estatísticas de execução",
-    "execution-include-non-terminated": "Incluir execuções não terminadas?",
-    "execution-warn-deleting-still-running": "Recomendamos fortemente que você cancele esta ação e encerre qualquer execução em andamento primeiro. Excluir execuções não terminadas pode levar a problemas de concorrência, inconsistências na gestão de dependências de flow e processos zumbis na sua instância, o que pode degradar o desempenho do sistema. Certifique-se de entender completamente esses riscos antes de prosseguir com a exclusão.",
-    "execution-warn-title": "Aviso Importante!",
-    "execution_deletion": {
-      "logs": "Excluir logs",
-      "metrics": "Excluir métricas",
-      "storage": "Excluir arquivos de armazenamento interno"
-    },
-    "execution_failed": "Execução FAILED!",
-    "execution_guide": {
-      "get_started": {
-        "text": "Siga o Guia de Início Rápido para instalar o Kestra e começar a criar seus primeiros workflows.",
-        "title": "Começar ⚡"
-      },
-      "namespaces": {
-        "text": "Namespaces são agrupamentos lógicos de flows e seus componentes.",
-        "title": "Sobre Namespaces"
-      },
-      "videos_tutorials": {
-        "text": "Comece com nossos tutoriais em vídeo.",
-        "title": "Tutoriais em Vídeo"
-      },
-      "workflow_components": {
-        "text": "Conheça os principais componentes de orquestração de um workflow Kestra.",
-        "title": "Componentes do Workflow"
-      }
-    },
-    "execution_started": "A execução foi iniciada!",
-    "execution_starts_progress": "Assim que a execução começar, você verá atualizações de progresso aqui.",
-    "execution_status": "A execução é:",
-    "executions": "Execuções",
-    "executions deleted": "<code>{executionCount}</code> execução(ões) deletada(s)",
+    "stats": "Estatísticas",
+    "concurrency limits": "Limites de Concurrency",
+    "system overview": "Visão Geral do Sistema",
+    "usage": "Uso",
+    "namespaces": "Namespaces",
+    "tasks": "Tasks",
     "executions duration (in minutes)": "Duração total das execuções (em minutos)",
-    "executions force run": "<code>{executionCount}</code> execução(ões) forçada(s) em execução",
-    "executions killed": "<code>{executionCount}</code> execução(ões) morta(s)",
-    "executions paused": "<code>{executionCount}</code> execução(ões) PAUSED",
-    "executions replayed": "<code>{executionCount}</code> execução(ões) reproduzida(s)",
-    "executions restarted": "<code>{executionCount}</code> execução(ões) reiniciada(s)",
-    "executions resumed": "<code>{executionCount}</code> execução(ões) retomada(s)",
-    "executions state changed": "O estado de <code>{executionCount}</code> execução(ões) foi alterado",
-    "executions unqueue": "<code>{executionCount}</code> execução(ões) na fila",
-    "expand": "Expandir",
-    "expand all": "Expandir tudo",
-    "expand dependencies": "Expandir dependências",
-    "expand error": "Expandir apenas tasks falhadas",
-    "expand_by_default": "Expand structured logs by default",
-    "expiration": "Expiração",
-    "expiration date": "Data de expiração",
-    "export": "Exportar",
-    "export all flows": "Exportar todos os flows",
-    "export all templates": "Exportar todos os templates",
-    "export_as": "Exportar como .{format}",
-    "export_csv": "Exportar como CSV",
-    "exports": "Exportações",
-    "failed to export plugin defaults": "Falha ao exportar padrões do plugin",
-    "failed to import plugin defaults": "Falha ao importar os padrões do plugin",
-    "failed to render pdf": "Falha ao renderizar a pré-visualização do PDF",
-    "false": "Falso",
-    "feeds": {
-      "heading": "Tudo sobre Kestra.",
-      "subheading": "As últimas atualizações, guias e histórias",
-      "title": "Novidades no Kestra"
+    "last 48 hours": "últimas 48 horas",
+    "configure basic auth": "Configurar Autenticação Básica",
+    "email": "Email",
+    "password": "Senha",
+    "confirm password": "Confirmar senha",
+    "email length constraint": "Email não deve exceder 256 caracteres",
+    "password length constraint": "Senha não deve exceder 256 caracteres",
+    "password empty constraint": "Nome de utilizador ou palavra-passe incorretos",
+    "passwords do not match": "Senhas não coincidem",
+    "avg duration": "Duração média da execução",
+    "neutral trend": "Estável",
+    "up trend": "Aumentando",
+    "down trend": "Diminuindo",
+    "update aborted": "atualização abortada",
+    "invalid flow": "Flow inválido",
+    "invalid yaml": "YAML inválido",
+    "inputs": "Inputs",
+    "no_inputs": "Nenhum input disponível.",
+    "input": "Input",
+    "variables": "Variáveis",
+    "variable_explorer": {
+      "title": "Entrada/Saída",
+      "search_placeholder": "Pesquisar Key ou value...",
+      "tasks_outputs": "Tasks outputs",
+      "tree": "Árvore",
+      "raw_json": "Raw JSON",
+      "select_prompt": "Selecione uma variável para inspecionar o seu value.",
+      "empty": "Não há variáveis disponíveis para esta execução.",
+      "one_key": "\\{ 1 key \\}",
+      "n_keys": "\\{ {count} keys \\}",
+      "one_item": "[ 1 item ]",
+      "n_items": "[ {count} itens ]"
     },
-    "file preview truncated": "Conteúdo exibido foi truncado",
-    "file unavailable": "Arquivo indisponível",
-    "file unavailable description": "Este arquivo não está mais disponível — pode ter sido removido ou expirado.",
-    "fileTypeNotAllowed": "Tipo de arquivo não permitido. Tipos aceitos: {types}",
     "file_preview": {
       "big_file_warning": "Este arquivo tem {size}. Pode demorar um pouco para carregar, bloqueando seu navegador. Deseja carregá-lo mesmo assim?",
       "load_anyway": "Carregar mesmo assim"
     },
-    "files": "Arquivos",
-    "filter by log level": "Filtrar por nível de log",
-    "filter by status": "Filtrar execuções pelo status {status}",
-    "filter by this value": "Filter by this value",
-    "filter_for": "Filter for",
-    "filter_out": "Filter out",
-    "filters": {
-      "comparators": {
-        "between": "entre",
-        "contains": "contém",
-        "ends_with": "termina com",
-        "greater_than": "maior que",
-        "greater_than_or_equal_to": "maior ou igual a",
-        "in": "em",
-        "is": "é",
-        "is_not": "não é",
-        "is_one_of": "é um dos",
-        "less_than": "menor que",
-        "less_than_or_equal_to": "menor ou igual a",
-        "not_contains": "não contém",
-        "not_in": "não em",
-        "starts_with": "começa com"
-      },
-      "empty": "Sem dados.",
-      "format": "Digite o parâmetro como 'key:value'",
-      "label": "Escolher filtros",
-      "options": {
-        "absolute_date": "Data absoluta",
-        "action": "Ação",
-        "aggregation": "Agregação",
-        "child": "Filho",
-        "details": "Detalhes",
-        "endDate": "Data de término",
-        "flow": "Fluxo",
-        "labels": "Etiquetas",
-        "level": "Nível de Log",
-        "metric": "Métrica",
-        "namespace": "Namespace",
-        "permission": "Permissão",
-        "relative_date": "Data relativa",
-        "scope": "Escopo",
-        "service_type": "Tipo",
-        "startDate": "Data de início",
-        "state": "Estado",
-        "status": "Status",
-        "task": "Tarefa",
-        "text": "Parece que você não forneceu nenhum texto para tradução. Por favor, forneça o texto que deseja que eu traduza para o português.",
-        "type": "Tipo",
-        "user": "Usuário"
-      },
-      "save": {
-        "dialog": {
-          "confirmation": "Critérios de pesquisa <code>{name}</code>",
-          "heading": "Salvar pesquisa atual",
-          "hint": "Como você deseja rotular este critério de busca?",
-          "placeholder": "Etiqueta"
-        },
-        "empty": "Você ainda não salvou nenhuma pesquisa.",
-        "label": "Pesquisas salvas",
-        "name_already_used": "A etiqueta de pesquisa já está em uso.",
-        "remove": "Remover",
-        "tooltip": "Você não pode salvar critérios de pesquisa vazios."
-      },
-      "settings": {
-        "label": "Configurações da página",
-        "show_chart": "Exibir gráfico principal"
-      },
-      "text_search": "Pesquisar por este texto"
-    },
-    "fix_with_ai": "Corrigir com AI",
-    "flow": "Flow",
-    "flow already exists": "Flow já existe",
-    "flow already exists message": "O flow <code>{id}</code> já existe no namespace <code>{namespace}</code>. Deseja criar uma nova revisão?",
-    "flow creation": "Criação de flow",
-    "flow creation denied in namespace": "Você não tem permissão para criar flows no namespace `{namespace}`.",
-    "flow delete": "Tem certeza de que deseja deletar <code>{flowCount}</code> flow(s)?",
-    "flow deleted, you can restore it": "O flow foi deletado e esta é uma visualização somente leitura. Você ainda pode restaurá-lo.",
-    "flow disable": "Tem certeza de que deseja desativar <code>{flowCount}</code> flow(s)?",
-    "flow enable": "Tem certeza de que deseja ativar <code>{flowCount}</code> flow(s)?",
-    "flow export": "Tem certeza de que deseja exportar <code>{flowCount}</code> flow(s)?",
-    "flow must have id and namespace": "Flow deve ter um id e um namespace.",
-    "flow must not be empty": "O flow não deve estar vazio",
-    "flow not imported": "Algum flow não pôde ser importado",
-    "flow revision latest": "Última revisão do flow",
-    "flow revision original": "Revisão original do flow",
-    "flow revision specific": "Revisão específica do flow",
-    "flow source not found": "Fonte do flow não encontrada",
-    "flow-dependencies": "dependências",
-    "flow-no-dependencies": "Seu flow não possui dependências",
-    "flow_editor_stats": {
-      "apps": {
-        "suffix": "App(s)",
-        "tooltip": "Visualizar aplicativos usando este flow"
-      },
-      "dependencies": {
-        "suffix": "Dependências",
-        "tooltip": "Ver dependências do flow"
-      },
-      "errors": {
-        "label": "{count} Erro(s)"
-      },
-      "revisions": {
-        "suffix": "Revisão(ões)",
-        "tooltip": "Ver revisões do flow"
-      },
-      "tests": {
-        "suffix": "Teste(s)",
-        "tooltip": "Ver testes de flow"
-      }
-    },
-    "flow_export": "Exportar flow",
-    "flow_only": "Disponível apenas na aba Flow.",
-    "flow_outputs": "Saídas do Flow",
-    "flows": "Flows",
-    "flows deleted": "<code>{count}</code> Flow(s) deletado(s)",
-    "flows disabled": "<code>{count}</code> Flow(s) desativado(s)",
-    "flows enabled": "<code>{count}</code> Flow(s) ativado(s)",
-    "flows exported": "<code>{count}</code> Flow(s) exportado(s)",
-    "flows imported": "Fluxos importados",
-    "focus task": "Clique em qualquer elemento para ver sua documentação.",
-    "fold_all_multi_lines": "Recolher Todas as Linhas Múltiplas",
-    "font size": "Font size",
-    "for flow": "para flow",
-    "forbidden system labels": "Apenas system.correlationId pode ser usado como label do sistema",
-    "force run": "Executar forçadamente",
-    "force run confirm": "Tem certeza de que deseja forçar a execução <code>{id}</code>?<br/><br/>AVISO: forçar a execução de uma execução não é garantido e pode criar execuções de tarefa duplicadas.<br/><br/>As seguintes transições serão feitas:<br/><ul><li>Tarefas CREATED serão movidas para o estado RUNNING.</li><li>Tarefas RUNNING serão re-submetidas.</li><li>Tarefas QUEUED serão removidas da fila.</li><li>Tarefas PAUSED serão retomadas.</li></ul>",
-    "force run done": "A execução é forçada a correr",
-    "force run title": "Forçar a execução da execução <code>{id}</code>.",
-    "force run tooltip": "Forçar a execução a correr. Pode criar execuções de task duplicadas; se possível, use outra ação.",
-    "form": "Formulário",
-    "form error": "Erro no formulário",
-    "from": "De",
-    "gantt": "Gantt",
-    "gantt_no_tasks_executed": "Esta execução terminou sem executar nenhuma task.  \nVerifique sua visão geral e logs para encontrar o motivo.",
-    "gantt_no_tasks_match_filters": "Tente ajustar os filtros de busca, estado ou nível de log.",
-    "gantt_no_tasks_match_filters_title": "Nenhuma task corresponde aos filtros selecionados.",
-    "healthcheck date": "Data do HealthCheck",
-    "hide task documentation": "Ocultar documentação da task",
-    "home": "Início",
-    "hostname": "Nome do host",
-    "iam": "IAM",
-    "id": "Id",
-    "import": "Importar",
-    "in-our-documentation": "na nossa documentação.",
-    "informative notice": "Nota(s)",
-    "input": "Input",
-    "inputs": "Inputs",
-    "instance": "Instância",
-    "invalid bulk delete": "Não foi possível deletar execuções",
-    "invalid bulk force run": "Não foi possível forçar a execução das execuções",
-    "invalid bulk kill": "Não foi possível matar execuções",
-    "invalid bulk pause": "Não foi possível pausar as execuções",
-    "invalid bulk replay": "Não foi possível reproduzir execuções",
-    "invalid bulk restart": "Não foi possível reiniciar execuções",
-    "invalid bulk resume": "Não foi possível retomar execuções",
-    "invalid bulk unqueue": "Não foi possível remover as execuções da fila",
-    "invalid field": "Campo inválido: {name}",
-    "invalid flow": "Flow inválido",
-    "invalid source": "Código fonte inválido",
-    "invalid yaml": "YAML inválido",
-    "is deprecated": "está obsoleto",
-    "is required": "{field} é obrigatório",
-    "item": "item",
-    "items": "itens",
-    "join community": "Junte-se à Comunidade",
-    "join_slack": "Participar do Slack",
-    "jsonl": "JSONL",
-    "jump to...": "Ir para...",
-    "kestra": "Kestra",
-    "key": "Key",
-    "kill": "Matar",
-    "kill only parents": "Matar apenas o atual",
-    "kill parents and subflow": "Matar o flow atual e subflows",
-    "killed confirm": "Tem certeza de que deseja matar a execução <code>{id}</code>?",
-    "killed done": "Execução está na fila para ser morta",
-    "kv": {
-      "add": "Criar",
-      "delete multiple": {
-        "confirm": "Tem certeza de que deseja excluir: <code>{name}</code> KV(s)?",
-        "warning": "Você não tem permissões para esses namespaces, então eles serão omitidos: <code>{namespaces}</code>"
-      },
-      "duplicate": "Esta key já existe",
-      "inherited": "Pares KV herdados",
-      "name": "KV Store",
-      "type": "Tipo",
-      "update": "Atualizar valor para a key '{key}'"
-    },
-    "label": "Label",
-    "label filter placeholder": "Label como 'key:value'",
-    "labels": "Labels",
-    "last 48 hours": "últimas 48 horas",
-    "last X days count": "{count} nos últimos {days} dias",
-    "last error was": "O último erro foi",
-    "last evaluation date": "Data da última avaliação",
-    "last evaluation date tooltip": "When the trigger was last evaluated by the scheduler, regardless of whether it produced an execution.",
-    "last execution date": "Data da última execução",
-    "last execution state": "Último estado",
-    "last execution status": "Último status de execução",
-    "last modified": "Última modificação",
-    "last trigger date": "Data da última trigger",
-    "last trigger date tooltip": "Quando o trigger foi executado pela última vez. Pode estar no passado ao executar um backfill.",
-    "latest_update": "Última atualização",
-    "launch execution": "Executar",
-    "learn_more": "Saiba mais",
-    "leave page": "Sair da Página",
-    "license": "Licença",
-    "light_background": "Esta é a opção preferida ao trabalhar com um fundo claro.",
-    "light_version": "Versão clara",
-    "line": "Linha",
-    "line-by-line": "linha por linha",
-    "loaded x dependencies": "{count} dependências carregadas",
-    "loading": "A carregar...",
-    "log expand setting": "Exibição padrão do Log",
-    "logExporters": "Exportadores de Log",
-    "logs": "Logs",
-    "logs_copied": "Logs copied to your clipboard",
-    "logs_view": {
-      "compact": "Visualização padrão",
-      "compact_details": "Mostrar logs de task em uma visualização compacta agrupada por cada task",
-      "raw": "Visualização temporal",
-      "raw_details": "Mostrar logs completos de task e flow em formato bruto ordenado por timestamp"
-    },
-    "main_configuration": "Configuração Principal",
-    "manage labels": "Gerenciar labels",
-    "management port": "Port de gerenciamento",
-    "mark as": "Marcar como <code>{status}</code>",
-    "max": "Max",
-    "mcp": {
-      "api_token": "Token da API",
-      "auth_type": "Autenticação",
-      "basic_auth": "Autenticação Básica",
-      "bearer_token": "Autenticação por token Bearer",
-      "client_setup": "Configuração do Cliente",
-      "connect": "Conectar",
-      "connect_tab": {
-        "auth_api_token_hint": "Defina <code>KESTRA_TOKEN</code> como uma variável de ambiente antes de iniciar o cliente.",
-        "auth_basic_hint": "Defina <code>KESTRA_BASIC_AUTH</code> como uma variável de ambiente contendo uma string <code>username:password</code> codificada em base64 antes de iniciar o cliente.",
-        "auth_oauth_browser_hint": "O seu navegador abrirá a página de login do fornecedor de identidade na primeira ligação.",
-        "auth_oauth_client_id_hint": "Substitua <code>&lt;client-id&gt;</code> pelo ID de cliente OAuth e registe <code>http://localhost:7777</code> como URI de redirecionamento válido nesse cliente.",
-        "claude_code": "Claude Code",
-        "claude_code_hint": "Execute o seguinte comando no seu terminal:",
-        "claude_desktop": "Claude Desktop",
-        "claude_desktop_hint": "Adicione o seguinte ao seu arquivo claude_desktop_config.json:",
-        "claude_desktop_mac": "macOS: ~/Library/Application Support/Claude/claude_desktop_config.json",
-        "claude_desktop_win": "Windows: %APPDATA%\\Claude\\claude_desktop_config.json",
-        "client_picker_label": "Escolha o seu cliente de IA",
-        "codex": "Codex (OpenAI)",
-        "codex_hint": "Adicione o seguinte à sua configuração MCP no codex.json:",
-        "cursor": "Cursor",
-        "cursor_hint": "Adicione o seguinte a ~/.cursor/mcp.json:",
-        "server_url": "URL do Servidor"
-      },
-      "copy_url": "Copiar URL",
-      "create": "Criar Servidor",
-      "delete_confirm": "Tem certeza de que deseja excluir este servidor MCP?",
-      "id_invalid": "O ID deve começar com uma letra minúscula ou dígito, e conter apenas letras minúsculas, dígitos, hífens ou underscores",
-      "id_placeholder": "por exemplo, my-mcp-server",
-      "instructions": "Instruções",
-      "main_tenant": "principal",
-      "managed_by_kestra": "Gerenciado por Kestra",
-      "no_oauth_providers": "Nenhum provedor OIDC configurado nesta instância",
-      "no_servers": "Nenhum servidor MCP encontrado. Crie seu primeiro servidor para expor triggers da ferramenta MCP a agentes de IA externos.",
-      "oauth": "OAuth",
-      "oauth_hint": "Bearer JWT do seu provedor OIDC",
-      "oauth_provider": "Provedor OAuth",
-      "oauth_provider_placeholder": "Selecione um provedor OIDC configurado",
-      "oauth_provider_required": "O provedor OAuth é obrigatório quando o tipo de autenticação é OAuth",
-      "page_description": "Exponha seus flows do Kestra como ferramentas para agentes de IA compatíveis com MCP",
-      "private": "Privado",
-      "private_server": "Servidor privado",
-      "public": "Público",
-      "public_hint": "Aviso: Servidores públicos não exigem autenticação. Qualquer pessoa com o URL pode chamar todas as ferramentas expostas por este servidor, sem verificações de namespace ou permissão. Use apenas para servidores seguros para expor externamente.",
-      "save": "Salvar Alterações",
-      "scopes_supported": "Scopes suportados",
-      "scopes_supported_hint": "Scopes anunciados no documento Protected Resource Metadata deste servidor. Clientes MCP conformes com a especificação restringem o pedido de autorização a esta lista. Deixe vazio para omitir o campo e deixar os clientes recorrerem aos scopes anunciados pelo IdP.",
-      "scopes_supported_placeholder": "openid, profile, email",
-      "server": "Servidor MCP",
-      "server_id": "ID do servidor",
-      "server_type": "Tipo de Servidor",
-      "servers": "Servidores MCP",
-      "servers_count": "{{count}} Servidores MCP",
-      "tab_connect": "Conectar",
-      "tab_edit": "Editar",
-      "tab_tool_flows": "Fluxos de Ferramentas",
-      "tab_tool_flows_placeholder": "O gerenciamento de flows de ferramentas estará disponível em breve.",
-      "tools": {
-        "annotations": "Anotações",
-        "create_tool_flow": "Criar um flow de ferramenta",
-        "description": "Descrição",
-        "destructive": "Destrutivo",
-        "flow": "flow",
-        "idempotent": "Idempotente",
-        "no_tools": "Nenhum flow de ferramenta corresponde à sua pesquisa.",
-        "open_world": "Open world",
-        "read_only": "Somente leitura",
-        "return_direct": "Retorno direto",
-        "state": "Estado",
-        "title": "Título",
-        "tool_name": "Nome da ferramenta",
-        "trigger_id": "ID do trigger",
-        "view_flow": "Abrir flow"
-      },
-      "url_copied": "URL copiado!",
-      "username_password": "Nome de usuário & senha",
-      "your_servers": "Seus Servidores"
-    },
-    "metric": "Métrica",
-    "metric choice": "Nenhuma métrica disponível para este flow",
-    "metrics": "Métricas",
-    "min": "Min",
-    "missingSource": "Fonte ausente",
-    "modify inputs": "Modificar inputs",
-    "modify_inputs": "Modificar inputs",
-    "monogram": "Monograma",
-    "more actions": "Mais ações",
-    "more_actions": "Mais Ações",
-    "multi_panel_editor": {
-      "close_all_panels": "Fechar todos os painéis",
-      "close_all_tabs": "Fechar todas as abas",
-      "move_left": "Mover para a esquerda",
-      "move_right": "Mover para a direita"
-    },
-    "multiple saved done": "{name} foi salvo",
-    "name": "Nome",
-    "namespace": "Namespace",
-    "namespace and id readonly": "As propriedades `namespace` e `id` não podem ser alteradas — elas estão definidas para seus valores iniciais. Se você quiser renomear um flow ou alterar seu namespace, você pode criar um novo flow e remover o antigo.",
-    "namespace files": {
-      "create": {
-        "file": "Criar arquivo",
-        "file_already_exists": "Um arquivo com este nome já existe",
-        "file_conflicts_with_folder": "Uma pasta com este nome já existe",
-        "file_error": "Ocorreu um erro ao criar o arquivo",
-        "folder": "Criar pasta",
-        "folder_already_exists": "Uma pasta com este nome já existe",
-        "folder_conflicts_with_file": "Um arquivo com este nome já existe",
-        "folder_error": "Ocorreu um erro ao criar a pasta",
-        "label": "Criar"
-      },
-      "delete": {
-        "file": "Deletar arquivo",
-        "files": "Excluir {count} arquivos selecionados",
-        "folder": "Deletar pasta",
-        "folders": "Excluir {count} pastas selecionadas",
-        "label": "Deletar"
-      },
-      "dialog": {
-        "deletion": {
-          "confirm": "Confirmar",
-          "file_single": "Tem certeza de que deseja excluir o arquivo <code>{name}</code>?",
-          "files": "Tem certeza de que deseja excluir <code>{count}</code> arquivo(s)?",
-          "folder_single": "Tem certeza de que deseja excluir a pasta <code>{name}</code> e todo o seu conteúdo?",
-          "folders": "Tem certeza de que deseja excluir <code>{count}</code> pasta(s) e todo o seu conteúdo?",
-          "mixed": "Tem certeza de que deseja excluir a(s) pasta(s) <code>{folders}</code> e o(s) arquivo(s) <code>{files}</code>?",
-          "title": "Confirmar exclusão de conteúdo"
-        },
-        "name": {
-          "file": "Nome com extensão:",
-          "folder": "Nome da pasta:"
-        },
-        "parent_folder": "Pasta pai:"
-      },
-      "export": "Exportar arquivos do namespace",
-      "export_single": "Exportar arquivo",
-      "filter": "Filtro",
-      "import": {
-        "error": "Ocorreu(ram) erro(s) ao importar o(s) arquivo(s)",
-        "files": "Importar arquivos",
-        "folder": "Importar pasta",
-        "import": "Importar",
-        "success": "Arquivo(s) importado(s) com sucesso"
-      },
-      "new_file": "Novo ficheiro",
-      "no_items": {
-        "heading": "Nenhum arquivo encontrado no seu namespace ainda.",
-        "paragraph": "Crie ou importe arquivos para compartilhar código entre flows no seu namespace."
-      },
-      "no_selection": {
-        "description": "Selecione um ficheiro da árvore para ver o seu conteúdo.",
-        "heading": "Nenhum ficheiro selecionado"
-      },
-      "path": {
-        "copy": "Copiar caminho",
-        "error": "Ocorreu(ram) erro(s) ao copiar o caminho para a área de transferência",
-        "success": "Caminho copiado para a área de transferência"
-      },
-      "rename": {
-        "file": "Renomear arquivo",
-        "folder": "Renomear pasta",
-        "label": "Renomear",
-        "new_file": "Novo nome com extensão:",
-        "new_folder": "Novo nome da pasta:"
-      },
-      "revisions": {
-        "history": "Histórico de revisões",
-        "restore": {
-          "success": "Revisão do arquivo restaurada com sucesso"
-        }
-      },
-      "toggle": {
-        "hide": "Ocultar arquivos do namespace",
-        "show": "Mostrar arquivos do namespace"
-      },
-      "tree": {
-        "collapse": "Colapsar todas as pastas",
-        "expand": "Expandir todas as pastas"
-      }
-    },
-    "namespace not allowed": "Namespace não permitido",
-    "namespace_editor": {
-      "close": {
-        "all": "Fechar todas as abas",
-        "other": "Fechar outras abas",
-        "right": "Fechar à direita",
-        "tab": "Fechar aba"
-      },
-      "empty": {
-        "create_message": "Você pode criar ou importar arquivos de namespace.",
-        "title": "Nenhuma aba aberta no momento",
-        "video_message": "Você pode assistir ao Vídeo de Introdução para o nosso Editor."
-      }
-    },
-    "namespaces": "Namespaces",
-    "neutral trend": "Estável",
-    "new": "Novo",
-    "new version": "Nova versão {version} disponível!",
-    "next": "Próximo",
-    "next evaluation date": "Próxima data de avaliação",
-    "next evaluation date tooltip": "Quando o trigger será avaliado novamente, com base em seu intervalo. Nem sempre é o mesmo que a próxima data de execução se as condições não forem atendidas.",
-    "next execution date": "Próxima data de execução",
-    "next_execution": "Próxima execução",
-    "no data current task": "Não há dados disponíveis para a tarefa atual",
-    "no inputs": "Este flow não tem inputs.",
-    "no metrics available": "Nenhuma métrica registrada para esta execução de task.",
-    "no outputs available": "Nenhuma saída disponível para esta execução de task.",
-    "no result": "Não há resultados para serem exibidos.",
-    "no revisions": "Sem revisões",
-    "no revisions found": "Existe apenas uma revisão para este flow",
-    "no-executions-view": {
-      "guidance_desc": "Precisa de orientação para executar o seu flow?",
-      "guidance_sub_desc": "Siga a documentação para todas as informações que você precisa.",
-      "namespace_guidance_desc": "Precisa de orientação para gerenciar seu Namespace?",
-      "namespace_sub_title": "Execute um ou mais flows deste namespace para preencher este dashboard.",
-      "sub_title": "Clique no botão Executar para iniciar a execução do seu primeiro fluxo de trabalho.",
-      "title": "Comece a automatizar com"
-    },
-    "no_code": {
-      "add_field": "Adicionar {field}",
-      "adding": "+ Adicionar um {what}",
-      "adding_default": "+ Adicionar um novo value",
-      "clearSelection": "Limpar seleção",
-      "creation": {
-        "afterExecution": "Adicionar um bloco após a execução",
-        "charts": "Adicionar um gráfico",
-        "conditions": "Adicionar uma condição",
-        "default": "Adicionar",
-        "errors": "Adicionar um manipulador de erro",
-        "finally": "Adicionar um bloco finally",
-        "inputs": "Adicionar um campo de input",
-        "numerator": "Adicionar um numerador",
-        "pluginDefaults": "Adicionar um padrão de plugin",
-        "tasks": "Adicionar uma task",
-        "triggers": "Adicionar um trigger",
-        "where": "Filtrar seus dados"
-      },
-      "fields": {
-        "general": {
-          "checks": "Verificações",
-          "concurrency": "Concorrência",
-          "disabled": "Desativado",
-          "labels": "Etiquetas",
-          "listeners": "Ouvintes",
-          "outputs": "Saídas",
-          "retry": "Repetir",
-          "sla": "SLA",
-          "taskDefaults": "Padrões de Task",
-          "updated": "Atualizado",
-          "variables": "Variáveis",
-          "workerGroup": "Grupo de Worker",
-          "workerSelector": "Seletor de Worker"
-        },
-        "main": {
-          "description": "Descrição",
-          "id": "ID do Flow",
-          "inputs": "Entradas",
-          "namespace": "Namespace"
-        }
-      },
-      "labels": {
-        "label": "Etiqueta",
-        "no_code": "Editor Sem Código",
-        "variable": "Variável",
-        "yaml": "Editor YAML"
-      },
-      "remove": {
-        "cases": "Remover este caso",
-        "default": "Remover esta entrada"
-      },
-      "sections": {
-        "afterExecution": "Após a Execução",
-        "deprecated": "Propriedades obsoletas",
-        "errors": "Manipuladores de Erro",
-        "finally": "Finalmente",
-        "pluginDefaults": "Padrões de Plugin",
-        "tasks": "Tarefas",
-        "triggers": "Triggers"
-      },
-      "select": {
-        "afterExecution": "Selecione uma task",
-        "charts": "Selecione um tipo de gráfico",
-        "conditions": "Selecione uma condição",
-        "default": "Selecione um tipo",
-        "errors": "Selecione uma task",
-        "finally": "Selecione uma task",
-        "inputs": "Selecione um tipo de campo de input",
-        "numerator": "Selecione um numerador",
-        "pluginDefaults": "Selecione um plugin",
-        "task": "Selecione uma task",
-        "tasks": "Selecione uma task",
-        "triggers": "Selecione um trigger",
-        "where": "Selecione um tipo de filtro"
-      },
-      "toggle_pebble": "Alternar editor Pebble",
-      "unnamed": "Sem Nome",
-      "version_oss_placeholder": "Desbloqueie a Versionamento de Plugin com a Enterprise Edition"
-    },
-    "no_data": "Parece que não há nada aqui... ainda!<br/>Ajuste seus filtros ou tente novamente!",
-    "no_file_choosen": "Nenhum arquivo selecionado",
-    "no_flow_outputs": "Nenhum output disponível.",
-    "no_history": "Sem histórico disponível",
-    "no_inputs": "Nenhum input disponível.",
-    "no_logs_data": "Sem Dados",
-    "no_logs_data_description": "Por favor, tente ajustar seus filtros, alterar o intervalo de tempo ou verifique se o flow foi executado recentemente.",
-    "no_logs_data_title": "Nenhum log encontrado para os filtros selecionados.",
-    "no_namespaces": "Nenhum namespace corresponde aos critérios de busca.",
-    "no_results": {
-      "assets": "Nenhum Asset Encontrado",
-      "executions": "Nenhuma Execução Encontrada",
-      "flows": "Nenhum Flow Encontrado",
-      "kv_pairs": "Nenhum par de Key-Value encontrado",
-      "secrets": "Nenhum Secret Encontrado",
-      "templates": "Nenhum Template Encontrado",
-      "triggers": "Nenhum Trigger Encontrado"
-    },
-    "no_results_found": "Nenhum resultado encontrado",
-    "no_tasks_running": "Ainda não há tasks em execução.",
-    "no_trigger": "Nenhum trigger disponível.",
     "no_variables": "Nenhuma variável disponível.",
-    "now": "Agora",
-    "of": "de",
-    "ok": "OK",
-    "onboarding": {
-      "actions": {
-        "cancel_tutorial": "Cancelar tutorial",
-        "complete": "Concluir",
-        "edit_flow_to_continue": "Clique em Editar flow na barra superior (à direita).",
-        "execute_to_continue": "1. Clique em Executar na barra superior (à direita).\n2. Forneça um valor para <strong>name</strong>.\n3. Clique em Executar novamente na janela modal.",
-        "finish_tutorial": "Finalizar tutorial",
-        "next": "Próximo",
-        "save_to_continue": "Clique em Guardar na barra superior (à direita)."
-      },
-      "cancel_modal": {
-        "confirm": "Cancelar tutorial",
-        "description": "Você quer cancelar o tutorial do Primeiro Flow?",
-        "keep": "Manter tutorial",
-        "title": "Cancelar o tutorial do Primeiro Flow"
-      },
-      "editor_hints": {
-        "build_intro": "Crie o seu primeiro flow passo a passo.",
-        "step_1": "# 1) Adicionar id",
-        "step_2": "# 2) Adicionar namespace",
-        "step_3": "# 3) Adicionar um input",
-        "step_4": "# 4) Adicionar tasks e a sua primeira task Python",
-        "step_5": "# 5) Adicionar um trigger cron"
-      },
-      "finish_actions": {
-        "create_flow": "Criar flow",
-        "explore_blueprints": "Explorar Blueprints"
-      },
-      "steps": {
-        "add_cron_trigger": {
-          "description": "Triggers podem iniciar execuções com base em agendas ou eventos externos (por exemplo, webhooks ou mensagens MQTT).<br><br>Agora adicione um trigger de agenda cron para que este flow seja executado a cada 5 minutos.",
-          "title": "Adicionar um trigger cron"
-        },
-        "add_id": {
-          "description": "O ID é o nome único do seu flow, para que você possa encontrá-lo, executá-lo e referenciá-lo de forma consistente.<br><br>Agora adicione <code>id</code> no nível raiz.",
-          "title": "Adicionar ID do flow"
-        },
-        "add_input": {
-          "description": "Inputs são parâmetros a nível de flow que podem ser referenciados dentro das tarefas para controlar dinamicamente o comportamento em tempo de execução.<br><br>Agora adicione um input chamado <code>name</code> com o tipo <code>STRING</code>.",
-          "title": "Adicionar um input"
-        },
-        "add_input_default": {
-          "description": "Quando um flow é acionado automaticamente, os inputs ainda precisam de valores em tempo de execução.<br><br>O input <code>name</code> já foi criado no passo anterior, então não é necessário adicioná-lo novamente. Apenas defina um valor padrão para o input existente <code>name</code>.",
-          "title": "Definir um valor padrão para o input"
-        },
-        "add_log_task": {
-          "description": "Tasks são as unidades de trabalho que o seu flow executa, definidas como uma lista ordenada de passos. Cada task precisa de um <code>id</code> único e um <code>type</code>. O Kestra fornece muitos plugins de tasks para sistemas externos; aqui usamos uma task de Python Script.<br><br>A sintaxe <code>&#123;&#123; ... &#125;&#125;</code> é uma expressão Pebble, usada para referenciar variáveis dinamicamente em tempo de execução, como <code>&#123;&#123; inputs.name &#125;&#125;</code> a partir dos inputs do flow.<br><br>Agora adicione a primeira task em <code>tasks</code> com <code>id</code>, <code>type</code> e um <code>script</code> que imprima uma saudação.",
-          "title": "Adicionar a primeira tarefa"
-        },
-        "add_namespace": {
-          "description": "O Namespace é um agrupamento semelhante a uma pasta que organiza flows por equipa, projeto ou ambiente.<br><br>Agora adicione <code>namespace</code> no nível raiz.",
-          "title": "Adicionar namespace"
-        },
-        "background_runs_info": {
-          "description": "Este flow agora será executado em segundo plano a cada 5 minutos.<br><br>Você pode navegar para a visão geral de Execuções no menu à esquerda para monitorar execuções agendadas.",
-          "title": "Execuções agendadas"
-        },
-        "edit_flow_from_execution": {
-          "description": "Você pode saltar diretamente de uma execução para a definição do flow para iterar rapidamente.",
-          "title": "Voltar ao Editor de Flow"
-        },
-        "execute_flow": {
-          "description": "Executar inicia uma execução do seu flow com valores de input em tempo de execução.",
-          "title": "Executar flow"
-        },
-        "finish": {
-          "description": "Ótimo começo. Você criou, executou, parametrizou e agendou um flow.<br><br>Escolha o que fazer a seguir ...",
-          "title": "Você concluiu o tutorial do Primeiro Flow"
-        },
-        "flow_basics": {
-          "description": "No Kestra, um <code>flow</code> é a unidade central de orquestração. Você o define em YAML com metadados e tarefas ordenadas.<br><br>Revise a estrutura de exemplo abaixo e depois continue a construí-la passo a passo.",
-          "title": "Noções básicas de flow"
-        },
-        "save_flow": {
-          "description": "Guardar preserva a definição do seu flow para que ele possa ser executado.",
-          "title": "Guardar flow"
-        },
-        "save_flow_again": {
-          "description": "O seu flow agora tem uma agenda e um valor padrão de input para execuções automáticas.",
-          "title": "Guardar flow"
-        },
-        "view_logs_status": {
-          "description": "Os detalhes de execução mostram o estado da execução, tempos e logs de saída ao nível das tasks.<br><br>Agora abra os detalhes da execução e clique em <code>greet</code> no gráfico de Gantt para ver os logs.",
-          "title": "Verificar execução"
-        }
-      },
-      "validation": {
-        "add_cron_trigger_cron": "Adicione uma expressão cron, por exemplo: `\"*/5 * * * *\"`.",
-        "add_cron_trigger_section": "Crie uma seção `triggers` com um trigger de agenda.",
-        "add_cron_trigger_type": "Defina o tipo do trigger como `io.kestra.plugin.core.trigger.Schedule`.",
-        "add_id": "Adicione um ID de flow no topo. Exemplo: `id: hello_flow`.",
-        "add_input_default_defaults": "Adicione um valor padrão para `name`, por exemplo: `defaults: \"Kestra\"`.",
-        "add_input_default_id": "Mantenha o ID do input existente como `name`.",
-        "add_input_default_section": "Volte para `inputs` e mantenha um input existente chamado `name` (não adicione um segundo input).",
-        "add_input_id": "Dentro de `inputs`, adicione `id: name`.",
-        "add_input_section": "Crie uma seção `inputs` com um input.",
-        "add_input_type": "Defina o tipo do input como `STRING`.",
-        "add_log_task_id": "Dê um ID à task, por exemplo: `id: greet`.",
-        "add_log_task_message": "Adicione um campo `script` à task.",
-        "add_log_task_pebble": "Use uma expressão Pebble no script para que ele use o valor do seu input (por exemplo: `inputs.name`).",
-        "add_log_task_section": "Crie uma seção `tasks` e adicione a sua primeira task.",
-        "add_log_task_type": "Defina o tipo da task como `io.kestra.plugin.scripts.python.Script`.",
-        "add_namespace": "Adicione um namespace no topo. Exemplo: `namespace: company.team`.",
-        "complete_step": "Você está quase lá. Conclua este passo para continuar.",
-        "edit_flow_from_execution": "Clique em `Editar flow` na barra superior para continuar.",
-        "execute_flow": "Execute o flow uma vez para continuar.",
-        "fix_yaml": "Há um pequeno problema de formatação YAML. Corrija-o e depois continue.",
-        "save_flow": "Clique em Guardar para continuar.",
-        "save_flow_again": "Clique em Guardar novamente para continuar.",
-        "view_logs_status": "Abra os detalhes da execução e verifique os logs de `greet`."
-      },
-      "welcome": {
-        "additional_help": "Ajuda adicional",
-        "badge": "Tutorial",
-        "blueprints": "Blueprints",
-        "docs": "Documentação",
-        "guided_description": "Aprenda como criar e executar o seu primeiro flow com passos guiados.",
-        "guided_duration": "Recomendado para a maioria",
-        "guided_title": "Crie o seu primeiro flow",
-        "headline": "Crie e execute o seu primeiro workflow em minutos",
-        "self_serve_description": "Vá diretamente para o editor e crie o seu próprio flow.",
-        "self_serve_note": "Para utilizadores experientes",
-        "self_serve_title": "Criar flow do zero",
-        "slack": "Comunidade Slack",
-        "tutorial": "Tutorial"
-      }
+    "download": "Baixar",
+    "jsonl": "JSONL",
+    "concurrency_limit": {
+      "dialog_title": "Limites de Concurrency",
+      "warning": "Alterar o contador em execução pode corromper a concorrência, fazendo com que as execuções excedam o limite permitido."
     },
-    "open": "Abrir",
-    "open full page": "Abrir Página Completa",
-    "open in new tab": "Em uma nova aba",
-    "open in same tab": "Na mesma aba",
-    "open sidebar": "abrir barra lateral",
-    "open source": "Código Aberto",
-    "open_page": "Open page",
-    "optional": "Opcional",
-    "original execution": "Execução original",
-    "originalCreatedDate": "Data de criação original",
-    "outdated revision save confirmation": {
-      "confirm": "Deseja sobrescrever?",
-      "create": {
-        "description": "Um flow com o mesmo id já existe neste namespace.",
-        "details": "Salvar para substituir e criar uma nova revisão.",
-        "title": "Flow já existe"
-      },
-      "update": {
-        "description": "A revisão que você está editando está desatualizada.",
-        "details": "Verifique a aba de Revisões para mais detalhes sobre a última versão.",
-        "title": "Revisão desatualizada"
-      }
+    "documentation": {
+      "documentation": "Documentação",
+      "github": "Abrir um issue no GitHub"
     },
-    "output": "Output",
-    "outputs": "Outputs",
-    "override": {
-      "details": "O flow anterior pode ser restaurado na aba Revisions.",
-      "title": "Você está prestes a sobrescrever o flow atual"
-    },
-    "overview": "Visão geral",
-    "page": {
-      "next": "Próxima página",
-      "previous": "Página anterior"
-    },
-    "panel actions": "Ações do painel",
-    "parent execution": "Execução pai",
-    "password": "Senha",
-    "password empty constraint": "Nome de utilizador ou palavra-passe incorretos",
-    "password length constraint": "Senha não deve exceder 256 caracteres",
-    "passwords do not match": "Senhas não coincidem",
-    "pause": "Pausar",
-    "pause backfill": "Pausar o backfill",
-    "pause backfills": "Pausar backfills",
-    "pause confirm": "Tem certeza de que deseja pausar a execução <code>{id}</code>?",
-    "pause done": "A execução está PAUSED",
-    "pause title": "Pausar execução <code>{id}</code>.<br/>Note que as tasks atualmente em execução ainda serão processadas, e a execução terá que ser retomada manualmente.",
-    "paused": "PAUSED",
-    "playground": {
-      "clear_history": "Limpar histórico",
-      "confirm_create": "Você não pode executar o playground enquanto cria um flow. Iniciar uma execução do playground criará o flow.",
-      "history": "Últimas 10 execuções",
-      "play_icon_info": "Você também pode clicar no ícone de Play nas visualizações No-Code ou Topology.",
-      "run_all_tasks": "Executar Todas as Tasks",
-      "run_task": "Executar Task",
-      "run_task_and_downstream": "Executar task & downstream",
-      "run_task_info": "Passe o cursor sobre qualquer task no editor de Flow Code e clique no botão \"Run task\" para testar sua task.",
-      "run_this_task": "Execute esta task",
-      "title": "Playground",
-      "toggle": "Playground",
-      "tooltip_persistence": "Se você desligar e ligar o Playground novamente, as informações permanecem enquanto você estiver na página."
-    },
-    "playground actions": "Ações do Playground",
-    "plugin defaults exported": "Padrões do plugin exportados",
-    "plugin defaults imported": "Padrões de plugin importados",
-    "plugin defaults not imported": "Alguns padrões de plugin não puderam ser importados",
-    "pluginDefaults": {
-      "add": "Adicionar Plugin Padrão",
-      "add_subtitle": "Configurar um novo plugin padrão com suas propriedades",
-      "cancel": "Cancelar",
-      "custom": "Plugin Personalizado",
-      "custom_configure": "Tipo de plugin personalizado - configurar usando YAML",
-      "custom_placeholder": "Insira o tipo de plugin",
-      "custom_type": "Tipo de plugin personalizado",
-      "edit": "Editar Padrão do Plugin",
-      "edit_subtitle": "Modificar a configuração padrão do plugin existente",
-      "form": "Formulário",
-      "predefined": "Plugin Predefinido",
-      "select_predefined": "Selecionar Plugin Predefinido",
-      "show_yaml": "Mostrar YAML",
-      "title": "Padrões do Plugin",
-      "update": "Atualizar Plugin Padrão",
-      "use_custom": "Usar Personalizado",
-      "yaml": "YAML",
-      "yaml_configuration": "Configuração YAML"
-    },
-    "pluginPage": {
-      "elementType": {
-        "apps": "Aplicativo",
-        "charts": "Gráfico",
-        "conditions": "Condição",
-        "logExporters": "Exportador de Log",
-        "secrets": "Secreto",
-        "taskRunners": "Executor de task",
-        "tasks": "Tarefa",
-        "triggers": "Trigger"
-      },
-      "group": {
-        "blueprints": "Blueprints ({count})",
-        "plugins": "Plugins ({count})",
-        "tasks": "Tarefas ({count})"
-      },
+    "blueprints": {
+      "all": "Todos",
+      "community": "Comunidade",
+      "create": "Criar um blueprint",
+      "edit": "Editar um blueprint",
+      "title": "Blueprints",
+      "empty": "Nenhum blueprint para mostrar.",
       "header": {
-        "back": "Voltar para plugins",
-        "certified": "Certificado",
-        "enterpriseEdition": "Edição Enterprise"
+        "catch phrase": {
+          "1": "O primeiro passo é sempre o mais difícil.",
+          "2": "Explore blueprints para iniciar seu próximo {kind}."
+        },
+        "alt": "Ícone de Blueprints"
       },
-      "loadError": "Não foi possível carregar os plugins. Por favor, tente novamente.",
-      "noResults": "Nenhum plugin corresponde à sua pesquisa.",
-      "notFound": "Este plugin não pôde ser encontrado.",
-      "overview": {
-        "createdBy": "Criado por",
-        "latest": "Mais Recente",
-        "linksResources": "Links e Recursos",
-        "managedBy": "Gerenciado por",
-        "minKestraVersion": "Versão mínima compatível do Kestra: {version}",
-        "minKestraVersionShort": "Versão mínima do Kestra {version}",
-        "pluginType": "Tipo de plugin",
-        "previousVersions": "Versões anteriores",
-        "releaseNotes": "Notas de lançamento",
-        "title": "Visão Geral",
-        "versions": "Versões"
+      "custom": "Blueprints personalizados",
+      "flows": "Blueprints de Flow",
+      "apps": "Blueprints do Aplicativo",
+      "dashboards": "Blueprints do Dashboard",
+      "detail": {
+        "category": "Tipo de categoria",
+        "links": "Link & Recursos",
+        "openInEditor": "Abrir em Edit Flow"
       },
-      "search": "Pesquisar em mais de {count} plugins",
-      "searchTasks": "Pesquisar {count} tasks",
-      "sort": {
-        "mostUsed": "Mais usados",
-        "nameAsc": "Nome A-Z",
-        "nameDesc": "Nome Z-A",
-        "newest": "Mais recente"
-      },
-      "sortBy": "Ordenar por"
+      "missingPlugins": {
+        "title": "Plugins ausentes",
+        "description": "Este blueprint usa tasks de plugin(s) que não estão instalados nesta instância: {plugins}. Instale-os para usar este blueprint.",
+        "card": "Requer plugin(s) não instalados nesta instância: {plugins}",
+        "install": "Instalar plugins"
+      }
     },
-    "plugin_default_already_exists": "O padrão do plugin para <code>{type}</code> já existe.",
+    "use": "Usar",
     "plugins": {
       "name": "Plugin",
       "names": "Plugins",
       "please": "Por favor, escolha uma task à direita para ver sua documentação",
       "release": "Notas de lançamento"
     },
-    "port": "Port",
-    "prefill inputs": "Preencher automaticamente",
-    "pretty_json": "Pretty JSON",
-    "prev_execution": "Execução anterior",
-    "preview": {
-      "auto-view": "Visualização automática",
-      "collapse": "Recolher",
-      "expand": "Expandir",
-      "force-editor": "Forçar visualização do editor",
-      "label": "Visualizar",
-      "next": "Próximo",
-      "page_of": "Página {current} de {total}",
-      "pagination_info": "Exibindo linhas {start}-{end} de {total}.",
-      "previous": "Anterior",
-      "rows_truncated": "Mostrando {shown} de {total} linhas. Baixe o arquivo para ver todos os dados.",
-      "showing_rows": "Mostrando linhas {start}-{end} de {total}",
-      "view": "Visualizar"
+    "last execution date": "Data da última execução",
+    "last execution state": "Último estado",
+    "last X days count": "{count} nos últimos {days} dias",
+    "date range count": "{count} entre {startDate} e {endDate}",
+    "date count": "{count} em {date}",
+    "revisions": "Revisões",
+    "no revisions found": "Existe apenas uma revisão para este flow",
+    "no revisions": "Sem revisões",
+    "see full revision": "Ver revisão completa",
+    "side-by-side": "lado a lado",
+    "line-by-line": "linha por linha",
+    "template": "Template",
+    "template creation": "Criação de template",
+    "templates": "Templates",
+    "templates deprecated": "Templates estão obsoletos. Por favor, use subflows. Veja a <a href=\"https://kestra.io/docs/migration-guide/0.11.0/templates?utm_source=app&utm_medium=referral&utm_campaign=template-inlinedoc\" target=\"_blank\">Seção de Migrações</a> explicando como você pode migrar de templates para subflows.",
+    "no result": "Não há resultados para serem exibidos.",
+    "empty search": "Resultados da pesquisa estão vazios",
+    "trigger": "Trigger",
+    "no_trigger": "Nenhum trigger disponível.",
+    "triggers": "Triggers",
+    "triggers_header_description": "Navegue, adicione e gerencie triggers para automatizar seus flows. Escolha entre expor seu flow como uma ferramenta de IA, agendar, adicionar um webhook trigger, verificar mudanças em aplicativos externos ou ouvintes de eventos em tempo real.",
+    "triggers_tabs_add": "Adicionar",
+    "triggers_tabs_manage": "Gerenciar",
+    "triggers_add_search_placeholder": "Procurar triggers...",
+    "triggers_add_filter_core": "Núcleo",
+    "triggers_add_filter_realtime": "Tempo real",
+    "triggers_add_filter_all": "Todos",
+    "triggers_add_filter_app": "Aplicativo",
+    "triggers_add_empty_title": "Nenhum trigger encontrado",
+    "triggers_add_ee_tooltip": "Este trigger requer a Enterprise Edition.",
+    "triggers_add_category_empty": "Sem triggers nesta categoria.",
+    "triggers_add_card_add_to_flow": "Adicionar ao flow",
+    "triggers_add_card_add": "Adicionar",
+    "triggers_add_modal_title": "{name}",
+    "triggers_add_modal_tab_form": "Formulário",
+    "triggers_add_modal_tab_source": "Fonte",
+    "triggers_add_modal_tab_documentation": "Documentação",
+    "triggers_add_modal_namespace_placeholder": "Selecione um namespace",
+    "triggers_add_modal_flow_placeholder": "Selecione um flow",
+    "triggers_add_modal_trigger_id": "ID do Trigger",
+    "triggers_add_modal_trigger_id_placeholder": "Identificador único para este trigger",
+    "triggers_add_modal_properties_hint": "Configure as propriedades do trigger no editor de flow após adicionar o trigger.",
+    "triggers_add_modal_ee_notice": "Este trigger requer a Enterprise Edition.",
+    "triggers_add_modal_add_button": "Adicionar Trigger ao Flow",
+    "trigger details": "Detalhes do trigger",
+    "triggerflow disabled": "Trigger está desativado na definição do flow",
+    "last trigger date": "Data da última trigger",
+    "trigger_states": "Estados",
+    "context updated date": "Data de atualização do contexto",
+    "state updated date": "Data de atualização do estado",
+    "next evaluation date": "Próxima data de avaliação",
+    "last evaluation date": "Data da última avaliação",
+    "last trigger date tooltip": "Quando o trigger foi executado pela última vez. Pode estar no passado ao executar um backfill.",
+    "context updated date tooltip": "Quando o contexto do trigger foi atualizado pela última vez. Isso ocorre quando a execução é acionada, termina (bloqueio liberado) ou após uma avaliação (mesmo que nenhuma execução ocorra).",
+    "next evaluation date tooltip": "Quando o trigger será avaliado novamente, com base em seu intervalo. Nem sempre é o mesmo que a próxima data de execução se as condições não forem atendidas.",
+    "last evaluation date tooltip": "When the trigger was last evaluated by the scheduler, regardless of whether it produced an execution.",
+    "conditions": "Condições",
+    "triggerId": "ID do Trigger",
+    "tenantId": "ID do Mandante",
+    "codeDisabled": "Desativado no Flow",
+    "paused": "PAUSED",
+    "running": "RUNNING",
+    "Fold auto": "Editor: dobra automática de multilinhas",
+    "Hover description": "Editor: Mostrar descrição do campo ao passar o mouse sobre o key ou value",
+    "Fold content lines": "Dobrar strings multilinhas",
+    "Unfold content lines": "Desdobrar strings multilinhas",
+    "Total": "Total",
+    "sub flow": "Subflow",
+    "execute": "Executar",
+    "execute flow behaviour": "Executar o flow",
+    "open in same tab": "Na mesma aba",
+    "open in new tab": "Em uma nova aba",
+    "execute the flow": "Executar o flow <code>{id}</code>",
+    "execute flow now ?": "Deseja executar este flow?",
+    "discard execution confirmation": "Você tem inputs não salvos. Tem certeza de que deseja descartar esta execução?",
+    "discard changes confirmation": "Você tem alterações não salvas. Tem certeza de que deseja descartá-las?",
+    "Default namespace": "Namespace padrão",
+    "Default log level": "Nível de log padrão",
+    "unsaved changed ?": "Você tem alterações não salvas, deseja sair desta página?",
+    "unsaved changes": "Alterações Não Salvas",
+    "unsaved changes warning": "Você tem alterações não salvas. Se você sair desta página, suas alterações serão perdidas.",
+    "leave page": "Sair da Página",
+    "open full page": "Abrir Página Completa",
+    "drill down preview": "Pré-visualização",
+    "Editor theme": "Tema do editor",
+    "Editor fontsize": "Tamanho da fonte do editor",
+    "Editor fontfamily": "Família de fontes do editor",
+    "errors": {
+      "401": {
+        "title": "Não autorizado",
+        "content": "Você precisa estar autenticado para acessar esta página."
+      },
+      "403": {
+        "title": "Acesso negado",
+        "content": "Você não tem as permissões necessárias para acessar esta página."
+      },
+      "404": {
+        "title": "Página não encontrada",
+        "content": "A URL solicitada não foi encontrada neste servidor.<br />Isso é tudo que sabemos.",
+        "flow or execution": "O flow ou execução que você está procurando não existe."
+      }
     },
-    "pricing": "Preços",
-    "product_tour": "Passeio pelo Produto",
-    "properties": {
-      "hidden": "Oculto na Tabela",
-      "hint": "Escolher Colunas Visíveis",
-      "label": "Propriedades",
-      "shown": "Exibido na Tabela"
+    "back_to_dashboard": "Voltar ao dashboard",
+    "copy all logs": "Copiar Todos os Logs",
+    "copy logs": "Copiar logs",
+    "fix_with_ai": "Corrigir com AI",
+    "download logs": "Baixar logs",
+    "delete logs": "Deletar logs",
+    "delete_all_logs": "Tem certeza de que deseja deletar todos os logs?",
+    "delete_log": "Tem certeza de que deseja excluir o log?",
+    "toggle fullscreen": "Alternar tela cheia",
+    "copied": "Copiado",
+    "tags": "Tags",
+    "disabled flow title": "Este flow está desativado",
+    "disabled flow desc": "Este flow está desativado, por favor, ative-o para executá-lo.",
+    "label": "Label",
+    "labels": "Labels",
+    "label filter placeholder": "Label como 'key:value'",
+    "execution labels": "Labels de execução",
+    "wrong labels": "Chave ou valor vazio não é permitido em labels",
+    "feeds": {
+      "title": "Novidades no Kestra",
+      "heading": "Tudo sobre Kestra.",
+      "subheading": "As últimas atualizações, guias e histórias"
     },
-    "queued duration": "Duração na fila",
-    "quotas": "Cotas",
-    "reach us": "Fale conosco",
-    "read-more": "Leia mais sobre",
-    "readonly property": "Propriedade somente leitura",
-    "recent_executions": "Execuções Recentes",
-    "refresh": "Atualizar",
-    "reject": "Rejeitar",
-    "relative": "Relativo",
-    "relative end date": "Data de término relativa",
-    "relative start date": "Data de início relativa",
-    "remove label": "Remover label",
-    "remove this item": "Remover este item",
-    "remove_bookmark": "Tem certeza de que deseja remover este marcador?",
-    "replay": "Repetir",
-    "replay confirm": "Tem certeza de que deseja repetir esta execução <code>{id}</code> e criar uma nova?",
-    "replay execution description": "Isso criará uma nova execução com base na execução selecionada.",
-    "replay execution title": "Repetir execução",
-    "replay from beginning tooltip": "Criar uma execução similar começando do início",
-    "replay from task tooltip": "Criar uma execução similar começando da task <code>{taskId}</code>",
-    "replay inputs": "Entradas",
-    "replay inputs new required": "Esta revisão possui inputs. Você será solicitado a preenchê-los.",
-    "replay latest revision": "Repetir usando a última revisão",
-    "replay select taskrun": "Selecione a execução da task para reproduzir a partir de:",
-    "replay the execution": "Reproduzir a execução <code>{executionId}</code> para o flow <code>{flowId}</code>",
-    "replay using": "Repetir usando",
-    "replay with inputs": "Repetir com inputs",
-    "replayed": "A execução é Reproduzida",
-    "required field": "Campo obrigatório",
-    "reset": "Reiniciar",
-    "reset to defaults": "Redefinir para padrões",
-    "restart": "Reiniciar",
-    "restart change revision": "Você pode alterar a revisão que será usada para a nova execução.",
-    "restart confirm": "Tem certeza de que deseja reiniciar a execução <code>{id}</code>?",
-    "restart execution title": "Reiniciar execução",
-    "restart latest revision": "Reiniciar última revisão",
-    "restart tooltip": "Reiniciar a execução a partir da task <code>{state}</code>",
-    "restart trigger": {
-      "button": "Reiniciar trigger",
-      "tooltip": "Reiniciar o trigger"
-    },
-    "restarted": "A Execução é Reiniciada",
+    "delete execution running": "<div class=\"alert alert-warning mt-2 mb-0\">Esta execução ainda está RUNNING, deletá-la não irá pará-la.<br />Você precisa matar a execução para pará-la.</div>",
     "restore": "Restaurar",
     "restore confirm": "Tem certeza de que deseja restaurar a revisão <code>{revision}</code>?",
+    "bulk delete": "Tem certeza de que deseja deletar <code>{executionCount}</code> execução(ões)?",
+    "bulk replay": "Tem certeza de que deseja reproduzir <code>{executionCount}</code> execução(ões)?",
+    "bulk change state": "Tem certeza de que deseja alterar o estado de <code>{executionCount}</code> execução(ões)?",
+    "bulk resume": "Tem certeza de que deseja retomar <code>{executionCount}</code> execução(ões)?",
+    "bulk pause": "Tem certeza de que deseja pausar a(s) execução(ões) <code>{executionCount}</code>?",
+    "bulk unqueue": "Tem certeza de que deseja remover da fila <code>{executionCount}</code> execução(ões)?",
+    "bulk force run": "Tem certeza de que deseja forçar a execução de <code>{executionCount}</code> execução(ões)?<br/><br/>AVISO: forçar a execução de uma execução não é garantido e pode criar execuções de tarefas duplicadas.<br/><br/>As seguintes transições serão realizadas:<br/><ul><li>Tarefas CREATED serão movidas para o estado RUNNING.</li><li>Tarefas RUNNING serão re-submetidas.</li><li>Tarefas QUEUED serão removidas da fila.</li><li>Tarefas PAUSED serão retomadas.</li></ul>",
+    "bulk restart": "Tem certeza de que deseja reiniciar <code>{executionCount}</code> execução(ões)?",
+    "bulk kill": "Tem certeza de que deseja matar <code>{executionCount}</code> execução(ões)?",
+    "selection": {
+      "selected": "<strong>{count}</strong> selecionado(s)",
+      "all": "Selecionar todos ({count})"
+    },
+    "cancel": "Cancelar",
+    "errorLogs": "Logs de erros",
+    "welcome_page": {
+      "welcome": "Bem-vindo ao Kestra",
+      "guide": "Precisa de orientação para executar seu primeiro flow?"
+    },
+    "product_tour": "Passeio pelo Produto",
+    "executions replayed": "<code>{executionCount}</code> execução(ões) reproduzida(s)",
+    "executions state changed": "O estado de <code>{executionCount}</code> execução(ões) foi alterado",
+    "executions resumed": "<code>{executionCount}</code> execução(ões) retomada(s)",
+    "executions paused": "<code>{executionCount}</code> execução(ões) PAUSED",
+    "executions unqueue": "<code>{executionCount}</code> execução(ões) na fila",
+    "executions force run": "<code>{executionCount}</code> execução(ões) forçada(s) em execução",
+    "executions restarted": "<code>{executionCount}</code> execução(ões) reiniciada(s)",
+    "executions killed": "<code>{executionCount}</code> execução(ões) morta(s)",
+    "executions deleted": "<code>{executionCount}</code> execução(ões) deletada(s)",
+    "invalid bulk replay": "Não foi possível reproduzir execuções",
+    "invalid bulk resume": "Não foi possível retomar execuções",
+    "invalid bulk pause": "Não foi possível pausar as execuções",
+    "invalid bulk unqueue": "Não foi possível remover as execuções da fila",
+    "invalid bulk force run": "Não foi possível forçar a execução das execuções",
+    "invalid bulk restart": "Não foi possível reiniciar execuções",
+    "invalid bulk kill": "Não foi possível matar execuções",
+    "invalid bulk delete": "Não foi possível deletar execuções",
+    "execution not found": "A execução {executionId} não foi encontrada.",
+    "execution not in state PAUSED": "Execução <code>{executionId}</code> não está no estado PAUSED",
+    "execution not in state FAILED": "Execução <code>{executionId}</code> não está no estado FAILED",
+    "execution already finished": "Execução <code>{executionId}</code> já finalizada",
     "restore revision": "Tem certeza de que deseja restaurar a revisão <code>{revision}</code>?",
-    "resume": "Retomar",
-    "resume from breakpoint done": "Execução é retomada do breakpoint",
-    "resume from breakpoint title": "Retomar execução `<code>{id}</code>` de breakpoint",
-    "resumed confirm": "Tem certeza de que deseja retomar a execução <code>{id}</code>?",
-    "resumed done": "Execução foi retomada",
-    "resumed title": "Retomar execução <code>{id}</code>",
-    "reuse original inputs": "Reutilizar inputs originais",
-    "reuse_original_inputs": "Reutilizar inputs originais",
-    "review your inputs": "Reveja as suas entradas",
-    "revision": "Revisão",
-    "revision deleted": "A revisão {revision} foi excluída com sucesso",
-    "revisions": "Revisões",
-    "row count": "Contagem de linhas",
-    "run task in playground": "Executar task no playground",
+    "seeing old revision": "Você está vendo uma revisão antiga: {revision}",
+    "export": "Exportar",
+    "exports": "Exportações",
+    "export_csv": "Exportar como CSV",
+    "template export": "Tem certeza de que deseja exportar <code>{templateCount}</code> template(s)?",
+    "templates exported": "Templates exportados",
+    "export all templates": "Exportar todos os templates",
+    "flow_export": "Exportar flow",
+    "flow export": "Tem certeza de que deseja exportar <code>{flowCount}</code> flow(s)?",
+    "flows exported": "<code>{count}</code> Flow(s) exportado(s)",
+    "export all flows": "Exportar todos os flows",
+    "import": "Importar",
+    "disable": "Desativar",
+    "enable": "Ativar",
+    "enabled": "Ativado",
+    "template delete": "Tem certeza de que deseja deletar <code>{templateCount}</code> template(s)?",
+    "flow delete": "Tem certeza de que deseja deletar <code>{flowCount}</code> flow(s)?",
+    "templates deleted": "<code>{count}</code> Template(s) deletado(s)",
+    "flows deleted": "<code>{count}</code> Flow(s) deletado(s)",
+    "flow disable": "Tem certeza de que deseja desativar <code>{flowCount}</code> flow(s)?",
+    "flow enable": "Tem certeza de que deseja ativar <code>{flowCount}</code> flow(s)?",
+    "flows disabled": "<code>{count}</code> Flow(s) desativado(s)",
+    "flows enabled": "<code>{count}</code> Flow(s) ativado(s)",
+    "flow-no-dependencies": "Seu flow não possui dependências",
+    "flow-dependencies": "dependências",
+    "read-more": "Leia mais sobre",
+    "in-our-documentation": "na nossa documentação.",
+    "dependencies": "Dependências",
+    "see dependencies": "Ver dependências",
+    "see timeline": "Ver linha do tempo",
     "run timeline": "Linha do Tempo de Execução",
-    "runners": "Corredores",
-    "running": "RUNNING",
-    "running duration": "Duração em execução",
-    "save": "Salvar",
+    "dependencies missing acls": "Sem permissões neste flow",
+    "dependencies delete flow": "Este flow tem dependências. Deletá-lo impedirá que suas dependências sejam executadas.<br /><br /> Aqui está a lista de flows afetados:",
+    "expand dependencies": "Expandir dependências",
+    "reset": "Reiniciar",
+    "show task documentation": "Mostrar documentação da task",
+    "hide task documentation": "Ocultar documentação da task",
+    "show task documentation in editor": "Mostrar documentação da task no editor",
+    "show documentation": "Mostrar documentação",
+    "focus task": "Clique em qualquer elemento para ver sua documentação.",
+    "validate": "Validar",
+    "add error handler": "Adicionar um manipulador de erro",
+    "taskDefaults": "Padrões da Task",
+    "disabled": "Desativado",
+    "before": "antes",
+    "after": "depois",
+    "add at position": "Adicionar {position} <code>{task}</code>",
+    "create first task": "Crie sua primeira task",
+    "dynamic": "Dinâmico",
+    "choice": "Escolha",
+    "sequential": "Sequencial",
+    "can not delete": "Não pode deletar",
+    "can not have less than 1 task": "Cada flow deve ter pelo menos uma task.",
+    "task id already exists": "Task Id já existe",
+    "Task Id already exist in the flow": "Task Id {taskId} já existe no flow.",
+    "task id": "Task ID",
+    "taskid column details": "Última task sendo executada e seu número de tentativas.",
+    "flow already exists": "Flow já existe",
+    "flow already exists message": "O flow <code>{id}</code> já existe no namespace <code>{namespace}</code>. Deseja criar uma nova revisão?",
+    "plugin_default_already_exists": "O padrão do plugin para <code>{type}</code> já existe.",
+    "namespace not allowed": "Namespace não permitido",
+    "switch-view": "Alternar visualização",
+    "source and topology": "Fonte e topologia",
+    "source and doc": "Fonte e documentação",
+    "source and blueprints": "Fonte e blueprints",
+    "editor": "Editor",
+    "error in editor": "Um erro foi encontrado no editor",
+    "delete task confirm": "Deseja deletar a task <code>{taskId}</code>?",
+    "can not save": "Não pode salvar",
+    "flow must not be empty": "O flow não deve estar vazio",
+    "flow must have id and namespace": "Flow deve ter um id e um namespace.",
+    "flow creation denied in namespace": "Você não tem permissão para criar flows no namespace `{namespace}`.",
+    "readonly property": "Propriedade somente leitura",
+    "namespace and id readonly": "As propriedades `namespace` e `id` não podem ser alteradas — elas estão definidas para seus valores iniciais. Se você quiser renomear um flow ou alterar seu namespace, você pode criar um novo flow e remover o antigo.",
+    "avg": "Média",
+    "sum": "Soma",
+    "min": "Min",
+    "max": "Max",
+    "bar": "Bar",
+    "line": "Linha",
+    "metric": "Métrica",
+    "aggregation": "Agregação",
+    "chart type": "Tipo de gráfico",
+    "metric choice": "Nenhuma métrica disponível para este flow",
+    "of": "de",
+    "see_all_states": "Ver todos os estados",
     "save draft": {
       "message": "Rascunho salvo",
       "retrieval": {
@@ -1680,164 +724,336 @@
         "existing": "Um rascunho do Flow <code>{flowFullName}</code> foi salvo, deseja continuar editando o flow?"
       }
     },
-    "save task": "Salvar Task",
-    "save_and_execute": "Salvar e Executar",
-    "save_as_draft": "Guardar como rascunho",
-    "saved": "Salvo com sucesso",
-    "saved as draft": "Guardado como rascunho com sucesso",
-    "saved as draft done": "<em>{name}</em> foi guardado com sucesso como rascunho",
-    "saved done": "<em>{name}</em> foi salvo com sucesso",
-    "scheduleDate": "Data de agendamento",
-    "scope_filter": {
-      "all": "Todos os {label}",
-      "system": "Sistema {label}",
-      "system_description": "Manutenção do sistema {label}",
-      "user": "Usuário {label}",
-      "user_description": "Usuário regular iniciou {label}"
+    "title": "Título",
+    "api": "API",
+    "more_actions": "Mais Ações",
+    "expand error": "Expandir apenas tasks falhadas",
+    "expand all": "Expandir tudo",
+    "collapse all": "Colapsar tudo",
+    "expand": "Expandir",
+    "collapse": "Colapsar",
+    "filter by this value": "Filter by this value",
+    "filter_for": "Filter for",
+    "filter_out": "Filter out",
+    "copy_value": "Copy value",
+    "open_page": "Open page",
+    "logs_copied": "Logs copied to your clipboard",
+    "expand_by_default": "Expand structured logs by default",
+    "show raw": "Show raw",
+    "similar lines": "similar lines",
+    "download_logs_description": "Choose which logs to export. Filters default to your current view.",
+    "display_settings": "Display settings",
+    "density": "Density",
+    "density_compact": "Compact",
+    "density_normal": "Normal",
+    "density_expanded": "Expanded",
+    "pretty_json": "Pretty JSON",
+    "body_line_clamp": "Limit line height",
+    "font size": "Font size",
+    "log expand setting": "Exibição padrão do Log",
+    "environment": "Ambiente",
+    "environment name setting": "Nome do ambiente",
+    "environment color setting": "Cor do ambiente",
+    "slack support": "Faça qualquer pergunta via Slack",
+    "join community": "Junte-se à Comunidade",
+    "join_slack": "Participar do Slack",
+    "kestra": "Kestra",
+    "reach us": "Fale conosco",
+    "new version": "Nova versão {version} disponível!",
+    "error detected": "Erro(s) detectado(s).",
+    "warning detected": "Aviso(s) detectado(s)",
+    "informative notice": "Nota(s)",
+    "cannot swap tasks": "Não é possível trocar as tasks",
+    "open": "Abrir",
+    "dependency task": "Task {taskId} é uma dependência de outra task",
+    "administration": "Administração",
+    "admin": "Administração",
+    "main_configuration": "Configuração Principal",
+    "commit_id": "ID do commit",
+    "evaluation lock date": "Data de bloqueio da avaliação",
+    "unlock trigger": {
+      "tooltip": {
+        "execution": "Há uma execução em andamento para este trigger",
+        "evaluation": "O trigger está atualmente em avaliação"
+      },
+      "confirmation": "Tem certeza de que deseja desbloquear o trigger?",
+      "warning": "Isso pode levar a execuções concorrentes para o mesmo trigger e deve ser considerado como uma última opção.",
+      "button": "Desbloquear trigger",
+      "success": "Trigger desbloqueado"
     },
-    "search": "Buscar",
-    "search blueprint": "Buscar blueprints",
-    "search filters": {
-      "filter name": "Nome do filtro",
-      "filters": "Filtros",
-      "manage": "Gerenciar filtros de busca",
-      "manage desc": "Gerenciar filtros de busca salvos",
-      "save filter": "Salvar filtro",
-      "saved": "Filtros salvos"
+    "restart trigger": {
+      "button": "Reiniciar trigger",
+      "tooltip": "Reiniciar o trigger"
     },
-    "search term in message": "Termo de busca na mensagem",
-    "search_docs": "Pesquisar",
-    "searching": "Procurando...",
-    "secret": {
-      "add": "Criar",
-      "inherited": "Segredos herdados",
-      "isReadOnly": "O segredo é somente leitura",
-      "names": "Segredos",
-      "update": "Atualizar segredo '{name}'"
-    },
-    "security_advice": {
-      "content": "Ative a autenticação básica para proteger sua instância.",
-      "enable": "Ativar autenticação",
-      "switch_text": "Não mostrar novamente",
-      "title": "Proteja sua instância"
-    },
-    "see dependencies": "Ver dependências",
-    "see full revision": "Ver revisão completa",
-    "see timeline": "Ver linha do tempo",
-    "see_all_states": "Ver todos os estados",
-    "seeing old revision": "Você está vendo uma revisão antiga: {revision}",
-    "select": "Selecione sua {{section}}",
-    "select a state": "Selecione um estado",
-    "select datetime": "Selecione uma data",
-    "select view": "Selecionar visualização",
-    "selected": "Selecionado",
-    "selection": {
-      "all": "Selecionar todos ({count})",
-      "selected": "<strong>{count}</strong> selecionado(s)"
-    },
-    "sequential": "Sequencial",
-    "server type": "Tipo de servidor",
+    "trigger disabled": "O Trigger está desativado na fonte do Flow",
+    "flow source not found": "Fonte do flow não encontrada",
+    "date format": "Formato de data",
+    "timezone": "Fuso horário",
+    "add task": "Adicionar uma task",
+    "unable to generate graph": "Ocorreu um problema ao gerar o gráfico, o que impede a exibição da topologia.",
+    "attempts": "Tentativa(s)",
+    "flow deleted, you can restore it": "O flow foi deletado e esta é uma visualização somente leitura. Você ainda pode restaurá-lo.",
+    "workers": "Workers",
+    "worker group": "Grupo de Workers",
+    "worker group key": "Grupo de Worker key",
+    "worker group fallback": "Grupo de Worker de reserva",
+    "version": "Versão",
     "services": "Serviços",
+    "server type": "Tipo de servidor",
+    "hostname": "Nome do host",
+    "port": "Port",
+    "management port": "Port de gerenciamento",
+    "file preview truncated": "Conteúdo exibido foi truncado",
+    "file unavailable": "Arquivo indisponível",
+    "file unavailable description": "Este arquivo não está mais disponível — pode ter sido removido ou expirado.",
+    "row count": "Contagem de linhas",
+    "encoding": "Codificação",
+    "show": "Mostrar",
+    "advanced configuration": "Outras propriedades",
+    "all executions": "Todas as execuções",
+    "trigger execution id": "Trigger Execution Id",
+    "execution_status": "A execução é:",
+    "no_tasks_running": "Ainda não há tasks em execução.",
+    "execution_starts_progress": "Assim que a execução começar, você verá atualizações de progresso aqui.",
+    "triggers_state": {
+      "state": "Estado",
+      "options": {
+        "enabled": "Ativado",
+        "disabled": "Desativado"
+      }
+    },
+    "trigger filter": {
+      "title": "Filtrar execuções filhas",
+      "options": {
+        "ALL": "Todas as Execuções",
+        "CHILD": "Execuções Filhas",
+        "MAIN": "Execuções Pais"
+      }
+    },
+    "show chart": "Mostrar Gráfico",
+    "namespace files": {
+      "toggle": {
+        "show": "Mostrar arquivos do namespace",
+        "hide": "Ocultar arquivos do namespace"
+      },
+      "filter": "Filtro",
+      "new_file": "Novo ficheiro",
+      "no_items": {
+        "heading": "Nenhum arquivo encontrado no seu namespace ainda.",
+        "paragraph": "Crie ou importe arquivos para compartilhar código entre flows no seu namespace."
+      },
+      "no_selection": {
+        "heading": "Nenhum ficheiro selecionado",
+        "description": "Selecione um ficheiro da árvore para ver o seu conteúdo."
+      },
+      "tree": {
+        "expand": "Expandir todas as pastas",
+        "collapse": "Colapsar todas as pastas"
+      },
+      "create": {
+        "label": "Criar",
+        "file": "Criar arquivo",
+        "file_already_exists": "Um arquivo com este nome já existe",
+        "file_conflicts_with_folder": "Uma pasta com este nome já existe",
+        "file_error": "Ocorreu um erro ao criar o arquivo",
+        "folder": "Criar pasta",
+        "folder_already_exists": "Uma pasta com este nome já existe",
+        "folder_conflicts_with_file": "Um arquivo com este nome já existe",
+        "folder_error": "Ocorreu um erro ao criar a pasta"
+      },
+      "rename": {
+        "label": "Renomear",
+        "file": "Renomear arquivo",
+        "folder": "Renomear pasta",
+        "new_file": "Novo nome com extensão:",
+        "new_folder": "Novo nome da pasta:"
+      },
+      "delete": {
+        "label": "Deletar",
+        "file": "Deletar arquivo",
+        "folder": "Deletar pasta",
+        "files": "Excluir {count} arquivos selecionados",
+        "folders": "Excluir {count} pastas selecionadas"
+      },
+      "import": {
+        "import": "Importar",
+        "files": "Importar arquivos",
+        "folder": "Importar pasta",
+        "success": "Arquivo(s) importado(s) com sucesso",
+        "error": "Ocorreu(ram) erro(s) ao importar o(s) arquivo(s)"
+      },
+      "export": "Exportar arquivos do namespace",
+      "export_single": "Exportar arquivo",
+      "dialog": {
+        "name": {
+          "file": "Nome com extensão:",
+          "folder": "Nome da pasta:"
+        },
+        "parent_folder": "Pasta pai:",
+        "deletion": {
+          "confirm": "Confirmar",
+          "title": "Confirmar exclusão de conteúdo",
+          "files": "Tem certeza de que deseja excluir <code>{count}</code> arquivo(s)?",
+          "folders": "Tem certeza de que deseja excluir <code>{count}</code> pasta(s) e todo o seu conteúdo?",
+          "mixed": "Tem certeza de que deseja excluir a(s) pasta(s) <code>{folders}</code> e o(s) arquivo(s) <code>{files}</code>?",
+          "file_single": "Tem certeza de que deseja excluir o arquivo <code>{name}</code>?",
+          "folder_single": "Tem certeza de que deseja excluir a pasta <code>{name}</code> e todo o seu conteúdo?"
+        }
+      },
+      "revisions": {
+        "history": "Histórico de revisões",
+        "restore": {
+          "success": "Revisão do arquivo restaurada com sucesso"
+        }
+      },
+      "path": {
+        "copy": "Copiar caminho",
+        "success": "Caminho copiado para a área de transferência",
+        "error": "Ocorreu(ram) erro(s) ao copiar o caminho para a área de transferência"
+      }
+    },
+    "continue backfill": "Continuar o backfill",
+    "delete backfill": "Deletar o backfill",
+    "pause backfill": "Pausar o backfill",
+    "continue backfills": "Continuar backfills",
+    "delete backfills": "Deletar backfills",
+    "pause backfills": "Pausar backfills",
+    "backfill executions": "Execuções de backfill",
+    "execute backfill": "Executar backfill",
+    "backfill paused": "Preenchimento retroativo pausado",
+    "backfill running": "Backfill em execução",
+    "relative": "Relativo",
+    "relative start date": "Data de início relativa",
+    "relative end date": "Data de término relativa",
+    "now": "Agora",
+    "absolute": "Absoluto",
+    "backfill": "Backfill",
+    "Set labels tooltip": "Definir labels para a execução",
+    "Set labels": "Definir labels",
+    "manage labels": "Gerenciar labels",
+    "Set labels to execution": "Adicionar ou atualizar os labels da execução <code>{id}</code>",
+    "Set labels done": "Labels da execução definidos com sucesso",
+    "bulk set labels": "Tem certeza de que deseja definir labels para <code>{executionCount}</code> execução(ões)?",
+    "dependencies loaded": "Dependências carregadas",
+    "loaded x dependencies": "{count} dependências carregadas",
+    "security_advice": {
+      "title": "Proteja sua instância",
+      "content": "Ative a autenticação básica para proteger sua instância.",
+      "switch_text": "Não mostrar novamente",
+      "enable": "Ativar autenticação"
+    },
+    "true": "Verdadeiro",
+    "false": "Falso",
+    "undefined": "Indefinido",
+    "execution-include-non-terminated": "Incluir execuções não terminadas?",
+    "execution-warn-title": "Aviso Importante!",
+    "execution-warn-deleting-still-running": "Recomendamos fortemente que você cancele esta ação e encerre qualquer execução em andamento primeiro. Excluir execuções não terminadas pode levar a problemas de concorrência, inconsistências na gestão de dependências de flow e processos zumbis na sua instância, o que pode degradar o desempenho do sistema. Certifique-se de entender completamente esses riscos antes de prosseguir com a exclusão.",
+    "originalCreatedDate": "Data de criação original",
+    "welcome": {
+      "menu": "Welcome",
+      "tour": {
+        "title": "Faça um tour pelo produto",
+        "text": "Escolha seu caso de uso e siga um guia passo a passo para aprender os recursos e capacidades do Kestra. ❤️"
+      },
+      "tutorial": {
+        "title": "Tutorial",
+        "text": "* <a href=\"https://kestra.io/tutorial-videos/all?utm_source=app&utm_medium=referral&utm_campaign=welcome-tutorial\" target=\"_blank\">Tutoriais em Vídeo</a>  \n* <a href=\"https://kestra.io/docs?utm_source=app&utm_medium=referral&utm_campaign=welcome-tutorial\" target=\"_blank\">Documentação</a>  \n* <a href=\"https://kestra.io/blueprints?utm_source=app&utm_medium=referral&utm_campaign=welcome-tutorial\" target=\"_blank\">Blueprints</a>"
+      },
+      "help": {
+        "title": "Precisa de ajuda?",
+        "text": "Faça qualquer pergunta em nossa comunidade no Slack. Se você estiver com dificuldades, estamos aqui para ajudar você. ✋"
+      }
+    },
+    "pluginPage": {
+      "search": "Pesquisar em mais de {count} plugins",
+      "searchTasks": "Pesquisar {count} tasks",
+      "noResults": "Nenhum plugin corresponde à sua pesquisa.",
+      "loadError": "Não foi possível carregar os plugins. Por favor, tente novamente.",
+      "notFound": "Este plugin não pôde ser encontrado.",
+      "elementType": {
+        "tasks": "Tarefa",
+        "triggers": "Trigger",
+        "conditions": "Condição",
+        "taskRunners": "Executor de task",
+        "charts": "Gráfico",
+        "apps": "Aplicativo",
+        "logExporters": "Exportador de Log",
+        "secrets": "Secreto"
+      },
+      "sortBy": "Ordenar por",
+      "sort": {
+        "nameAsc": "Nome A-Z",
+        "nameDesc": "Nome Z-A",
+        "newest": "Mais recente",
+        "mostUsed": "Mais usados"
+      },
+      "group": {
+        "plugins": "Plugins ({count})",
+        "tasks": "Tarefas ({count})",
+        "blueprints": "Blueprints ({count})"
+      },
+      "overview": {
+        "title": "Visão Geral",
+        "versions": "Versões",
+        "latest": "Mais Recente",
+        "releaseNotes": "Notas de lançamento",
+        "previousVersions": "Versões anteriores",
+        "createdBy": "Criado por",
+        "managedBy": "Gerenciado por",
+        "pluginType": "Tipo de plugin",
+        "linksResources": "Links e Recursos",
+        "minKestraVersion": "Versão mínima compatível do Kestra: {version}",
+        "minKestraVersionShort": "Versão mínima do Kestra {version}"
+      },
+      "header": {
+        "enterpriseEdition": "Edição Enterprise",
+        "certified": "Certificado",
+        "back": "Voltar para plugins"
+      }
+    },
+    "no inputs": "Este flow não tem inputs.",
+    "admin_preferences": "Preferences",
     "settings": {
+      "label": "Configurações",
+      "updated": "{name} atualizado",
       "blocks": {
         "configuration": {
-          "descriptions": {
-            "auto_refresh_interval": "Segundos entre atualizações automáticas de dados nas páginas de lista.",
-            "default_namespace": "Usado ao criar novos flows sem um namespace.",
-            "editor_type": "Editor mostrado ao abrir um flow pela primeira vez.",
-            "execute_default_tab": "Aba selecionada ao navegar para uma execução.",
-            "execute_flow": "Onde os resultados da execução abrem após acionar uma execução.",
-            "flow_default_tab": "Aba selecionada ao navegar para um flow.",
-            "log_display": "Como os logs são apresentados ao abrir uma execução.",
-            "log_level": "Nível mínimo de log mostrado nos logs de execução.",
-            "playground": "Execute tasks individualmente no editor playground.",
-            "triggers_default_tab": "Aba selecionada ao navegar para a página de triggers."
-          },
+          "label": "Configuração Principal",
           "fields": {
-            "auto_refresh_interval": "Intervalo de Atualização Automática",
-            "default_namespace": "Namespace Padrão",
-            "editor_type": "Tipo de Editor Padrão",
-            "execute_default_tab": "Aba de Execução Padrão",
-            "execute_flow": "Executar o Flow",
-            "flow_default_tab": "Aba Padrão do Flow",
             "language": "Idioma",
-            "log_display": "Exibição de Log Padrão",
+            "default_namespace": "Namespace Padrão",
             "log_level": "Nível de Log Padrão",
+            "log_display": "Exibição de Log Padrão",
+            "editor_type": "Tipo de Editor Padrão",
+            "execute_flow": "Executar o Flow",
+            "execute_default_tab": "Aba de Execução Padrão",
             "multi_panel_editor": "Editor de Painel Múltiplo",
+            "flow_default_tab": "Aba Padrão do Flow",
+            "triggers_default_tab": "Aba de Triggers Padrão",
             "playground": "Playground",
-            "triggers_default_tab": "Aba de Triggers Padrão"
+            "auto_refresh_interval": "Intervalo de Atualização Automática"
           },
-          "label": "Configuração Principal"
-        },
-        "export": {
-          "fields": {
-            "flows": "Exportar Todos os Flows",
-            "templates": "Exportar Todos os Templates"
-          },
-          "label": "Exportar"
-        },
-        "localization": {
           "descriptions": {
-            "date_format": "Formato usado para exibir datas em todo o dashboard.",
-            "language": "Idioma da interface para menus e labels.",
-            "time_zone": "Usado para exibir datas de execução e triggers agendados."
-          },
-          "fields": {
-            "date_format": "Formato de Data",
-            "time_zone": "Fuso Horário"
-          },
-          "label": "Idioma e Região",
-          "note": "Note que esta configuração é usada para exibir propriedades de data e hora na UI. Para agendar seus flows em um fuso horário diferente de UTC, certifique-se de definir a propriedade de fuso horário no trigger de Schedule no seu código de flow ou nos padrões do seu plugin."
-        },
-        "reset_section_to_defaults": "Restaurar os valores padrão desta seção",
-        "save": {
-          "discard": "Descartar",
-          "label": "Salvar Preferências",
-          "unsaved_title": "Alterações Não Salvas",
-          "unsaved_warning": "Você tem alterações não salvas. Deseja salvá-las antes de sair?"
-        },
-        "sidebar": {
-          "descriptions": {
-            "items": "Mostrar, ocultar e reordenar itens na barra lateral."
-          },
-          "fields": {
-            "items": "Itens de Navegação"
-          },
-          "label": "Barra Lateral"
+            "default_namespace": "Usado ao criar novos flows sem um namespace.",
+            "log_level": "Nível mínimo de log mostrado nos logs de execução.",
+            "log_display": "Como os logs são apresentados ao abrir uma execução.",
+            "editor_type": "Editor mostrado ao abrir um flow pela primeira vez.",
+            "execute_flow": "Onde os resultados da execução abrem após acionar uma execução.",
+            "execute_default_tab": "Aba selecionada ao navegar para uma execução.",
+            "flow_default_tab": "Aba selecionada ao navegar para um flow.",
+            "triggers_default_tab": "Aba selecionada ao navegar para a página de triggers.",
+            "auto_refresh_interval": "Segundos entre atualizações automáticas de dados nas páginas de lista.",
+            "playground": "Execute tasks individualmente no editor playground."
+          }
         },
         "theme": {
-          "app_font_size_options": {
-            "large": "Grande",
-            "medium": "Médio",
-            "small": "Pequeno"
-          },
-          "color_modes": {
-            "dark_1": "Dark 1.0",
-            "dark_2": "Escuro 2.0",
-            "light": "Claro",
-            "sync": "Sincronizar com o sistema"
-          },
-          "confirmations": {
-            "color_mode": "Sua interface agora usa o tema `{mode}`."
-          },
-          "descriptions": {
-            "app_font_size": "Fator de escala aplicado a todos os tamanhos de fonte da interface.",
-            "color_mode": "Escolha o tema de interface preferido.",
-            "color_mode_shortcut": "Dica: prima <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>L</kbd> para alternar temas a partir de qualquer lugar.",
-            "editor_folding_stratgy": "Recolher blocos longos de YAML por padrão ao abrir um flow.",
-            "editor_font_family": "Fonte monoespaçada usada no editor YAML.",
-            "editor_font_size": "Tamanho da fonte usado nos editores YAML e no-code.",
-            "editor_hover_description": "Mostrar descrições de propriedades ao passar o mouse no editor.",
-            "environment_color": "Cor de destaque usada para o ambiente atual na navegação.",
-            "environment_name": "Nome de exibição para o ambiente atual, mostrado na navegação.",
-            "logs_font_size": "Tamanho da fonte usado em visualizadores de log e terminais."
-          },
+          "label": "Preferências de Tema",
           "fields": {
             "app_font_size": "Tamanho da fonte da aplicação",
             "chart_color_scheme": {
+              "label": "Esquema de Cores do Gráfico",
               "classic": "Clássico",
-              "kestra": "Kestra",
-              "label": "Esquema de Cores do Gráfico"
+              "kestra": "Kestra"
             },
             "color_mode": "Modo de cor",
             "editor_folding_stratgy": "Dobramento Automático de Código no Editor",
@@ -1850,24 +1066,867 @@
             "logs_font_size": "Tamanho da Fonte dos Logs",
             "theme": "Tema"
           },
-          "label": "Preferências de Tema"
+          "color_modes": {
+            "dark_2": "Escuro 2.0",
+            "dark_1": "Dark 1.0",
+            "light": "Claro",
+            "sync": "Sincronizar com o sistema"
+          },
+          "confirmations": {
+            "color_mode": "Sua interface agora usa o tema `{mode}`."
+          },
+          "descriptions": {
+            "color_mode": "Escolha o tema de interface preferido.",
+            "color_mode_shortcut": "Dica: prima <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>L</kbd> para alternar temas a partir de qualquer lugar.",
+            "logs_font_size": "Tamanho da fonte usado em visualizadores de log e terminais.",
+            "editor_font_family": "Fonte monoespaçada usada no editor YAML.",
+            "editor_font_size": "Tamanho da fonte usado nos editores YAML e no-code.",
+            "editor_folding_stratgy": "Recolher blocos longos de YAML por padrão ao abrir um flow.",
+            "editor_hover_description": "Mostrar descrições de propriedades ao passar o mouse no editor.",
+            "environment_name": "Nome de exibição para o ambiente atual, mostrado na navegação.",
+            "environment_color": "Cor de destaque usada para o ambiente atual na navegação.",
+            "app_font_size": "Fator de escala aplicado a todos os tamanhos de fonte da interface."
+          },
+          "app_font_size_options": {
+            "small": "Pequeno",
+            "medium": "Médio",
+            "large": "Grande"
+          }
+        },
+        "localization": {
+          "label": "Idioma e Região",
+          "note": "Note que esta configuração é usada para exibir propriedades de data e hora na UI. Para agendar seus flows em um fuso horário diferente de UTC, certifique-se de definir a propriedade de fuso horário no trigger de Schedule no seu código de flow ou nos padrões do seu plugin.",
+          "fields": {
+            "time_zone": "Fuso Horário",
+            "date_format": "Formato de Data"
+          },
+          "descriptions": {
+            "language": "Idioma da interface para menus e labels.",
+            "time_zone": "Usado para exibir datas de execução e triggers agendados.",
+            "date_format": "Formato usado para exibir datas em todo o dashboard."
+          }
+        },
+        "export": {
+          "label": "Exportar",
+          "fields": {
+            "flows": "Exportar Todos os Flows",
+            "templates": "Exportar Todos os Templates"
+          }
+        },
+        "save": {
+          "label": "Salvar Preferências",
+          "discard": "Descartar",
+          "unsaved_title": "Alterações Não Salvas",
+          "unsaved_warning": "Você tem alterações não salvas. Deseja salvá-las antes de sair?"
+        },
+        "reset_section_to_defaults": "Restaurar os valores padrão desta seção",
+        "sidebar": {
+          "label": "Barra Lateral",
+          "fields": {
+            "items": "Itens de Navegação"
+          },
+          "descriptions": {
+            "items": "Mostrar, ocultar e reordenar itens na barra lateral."
+          }
+        }
+      }
+    },
+    "apps": "Aplicativos",
+    "demos": {
+      "enterprise_edition": "Edição Enterprise",
+      "get_a_demo_button": "Obter uma Demonstração",
+      "contact_sales": "Contatar Vendas",
+      "watch_the_video": "Assista ao vídeo",
+      "secrets": {
+        "title": "Atualize seu Gerenciamento de Secrets",
+        "message": "A Enterprise Edition (EE) permite adicionar, editar ou excluir segredos diretamente na UI—sem necessidade de reiniciar a instância. Organize segredos por namespace com permissões RBAC granulares e herde-os de namespaces pai para filho. A EE integra-se com gerenciadores de segredos como HashiCorp Vault, AWS Secrets Manager, Azure Key Vault, Google Secret Manager e Elasticsearch. Configure backends dedicados por namespace, tenant ou instância para isolar segredos entre equipes, ou habilite segredos somente leitura armazenados em cofres externos. Os segredos permanecem criptografados em repouso e em trânsito. O cache opcional reduz chamadas de API, e trilhas de auditoria registram todo o acesso.",
+        "detected_env": "Aqui estão as variáveis de ambiente do tipo secreto identificadas no momento de inicialização da instância:",
+        "empty_env": "Você ainda não tem nenhum Secret no seu ambiente.",
+        "add_env": {
+          "intro": "Para criar um novo Secret:",
+          "first": "Codifique o <a href=\"https://kestra.io/docs/how-to-guides/secrets?utm_source=app&utm_medium=referral&utm_campaign=secrets-inlinedoc#using-secrets-in-kestra\" target=\"_blank\">valor secreto em Base64</a>",
+          "second": "Adicione uma variável de ambiente chamada '<strong>SECRET_{'{MY_SECRET_KEY}'}</strong>' com o valor acima",
+          "third": "Reinicie sua instância do Kestra"
         }
       },
-      "label": "Configurações",
-      "updated": "{name} atualizado"
+      "apps": {
+        "title": "Crie Apps personalizadas com Kestra",
+        "message": "As aplicações na Kestra Enterprise Edition permitem que você construa interfaces personalizadas que interagem com os workflows do Kestra fora da plataforma. Este recurso permite usar seus workflows como um backend para aplicações personalizadas, possibilitando que usuários não técnicos enviem dados através de formulários ou retomem workflows PAUSED aguardando aprovação."
+      },
+      "tests": {
+        "label": "Testes",
+        "header": "Testes Unitários para Flows",
+        "title": "Garanta a Confiabilidade com Cada Alteração",
+        "message": "Verifique a lógica dos seus flows isoladamente, detecte regressões cedo e mantenha a confiança nas suas automações à medida que elas mudam e crescem."
+      },
+      "assets": {
+        "label": "Ativos",
+        "header": "Metadados e Observabilidade de Assets",
+        "title": "Traga todos os datasets, serviços e dependências para a visualização.",
+        "message": "Os assets conectam observabilidade, linhagem e metadados de propriedade para que as equipes da plataforma possam solucionar problemas mais rapidamente e implantar com confiança."
+      },
+      "IAM": {
+        "title": "Gerencie Usuários através do IAM com SSO, SCIM e RBAC",
+        "message": "A Kestra Enterprise Edition possui capacidades IAM integradas com single sign-on (SSO), sincronização de diretório SCIM e controle de acesso baseado em funções (RBAC), integrando-se com vários provedores de identidade e permitindo que você atribua permissões detalhadas para usuários e contas de serviço."
+      },
+      "tenants": {
+        "title": "Gerenciar Fluxos de Trabalho em Tenants Isolados",
+        "message": "A Kestra Enterprise Edition suporta multi-tenancy, proporcionando ambientes totalmente isolados para diferentes equipes ou projetos, cada um com seus próprios recursos, como grupos de worker dedicados ou segredos e backends de armazenamento interno."
+      },
+      "audit-logs": {
+        "title": "Acompanhe Alterações com Audit Logs",
+        "message": "A Kestra Enterprise Edition registra todas as atividades com registros robustos e imutáveis, facilitando o acompanhamento de alterações, a manutenção da conformidade e a resolução de problemas."
+      },
+      "quotas": {
+        "title": "Aplicar cotas de execução em flows",
+        "message": "A Kestra Enterprise Edition permite definir cotas em flows para limitar o número de execuções simultâneas ou totais dentro de uma janela de tempo. As cotas ajudam a proteger a infraestrutura partilhada, aplicar SLAs e impedir que workflows descontrolados consumam recursos excessivos."
+      },
+      "instance": {
+        "title": "Gerencie a Infraestrutura em Toda a Sua Instância",
+        "message": "A Kestra Enterprise Edition fornece um painel operacional para ajudar você a observar a saúde da sua plataforma e acompanhar as métricas de tempo de atividade de todos os serviços, como, por exemplo, Workers, Schedulers e Executors. Na mesma página, você também pode criar Anúncios para notificar seus usuários sobre interrupções planejadas, e pode entrar em um modo de manutenção que coloca temporariamente todos os serviços e execuções de workflow em um estado PAUSED para realizar uma atualização."
+      },
+      "blueprints": {
+        "title": "Adicionar Blueprints Personalizados",
+        "message": "Na Kestra Enterprise Edition, você pode criar Blueprints personalizados disponíveis apenas para sua organização. Você pode usá-los como modelos de melhores práticas para compartilhar, centralizar e documentar fluxos de trabalho comumente usados em sua equipe."
+      },
+      "namespace": {
+        "edit": {
+          "title": "Atualize o Gerenciamento do seu Namespace",
+          "message": "Na Kestra Enterprise Edition, os namespaces oferecem isolamento avançado e governança de segredos, variáveis e padrões de plugins em escala. Os administradores podem configurar gerenciadores de segredos personalizados, backends de armazenamento isolados, grupos de worker dedicados e permissões detalhadas por namespace. Isso garante que segredos, variáveis e configurações de plugins permaneçam seguros e fáceis de manter em diferentes equipes e projetos."
+        },
+        "secrets": {
+          "title": "Gerenciar Segredos de Forma Segura",
+          "message": "Na Kestra Enterprise Edition, você pode armazenar e controlar segredos no nível de namespace, minimizando riscos e garantindo que as credenciais de cada equipe permaneçam isoladas. Graças à hierarquia aninhada, você também pode configurar credenciais em um namespace pai e elas serão herdadas por todos os namespaces filhos. O suporte para gerenciadores de segredos dedicados e configurações de permissão detalhadas no nível de namespace fortalece ainda mais a segurança e a conformidade."
+        },
+        "assets": {
+          "title": "Centralizar Gestão de Ativos",
+          "message": "Na Kestra Enterprise Edition, Assets mantém um inventário ativo de recursos com os quais seus workflows interagem. Esses recursos podem ser tabelas de banco de dados, máquinas virtuais, arquivos ou qualquer sistema externo com o qual você trabalhe."
+        },
+        "variables": {
+          "title": "Governe Centralmente Suas Variáveis",
+          "message": "Na Kestra Enterprise Edition, você pode definir e gerenciar variáveis no nível do namespace para eliminar configurações repetitivas em flows. Essas variáveis garantem consistência, simplificam atualizações de configuração e podem ser facilmente referenciadas por qualquer task ou trigger para workflows mais limpos e fáceis de manter."
+        },
+        "plugin-defaults": {
+          "title": "Padronizar Configuração com Padrões de Plugin",
+          "message": "Na Kestra Enterprise Edition, você pode definir padrões de plugin específicos para cada namespace, reduzindo a necessidade de configuração duplicada em cada flow. Esta governança central de plugins impõe configurações consistentes, permite a referência segura de segredos ou variáveis e simplifica a manutenção dos seus workflows."
+        },
+        "history": {
+          "title": "Gerenciar Histórico de Revisões em Um Só Lugar",
+          "message": "Na Kestra Enterprise Edition, você pode gerenciar o histórico de revisões dos seus Namespaces"
+        },
+        "audit-logs": {
+          "title": "Acompanhe Todas as Alterações em Um Só Lugar",
+          "message": "Na Kestra Enterprise Edition, você pode visualizar logs de auditoria no nível do namespace com diferenças detalhadas, fornecendo um histórico claro de quem alterou o quê e quando em todos os recursos."
+        }
+      }
+    },
+    "assets": {
+      "title": "Ativos"
+    },
+    "onboarding": {
+      "welcome": {
+        "headline": "Crie e execute o seu primeiro workflow em minutos",
+        "guided_title": "Crie o seu primeiro flow",
+        "badge": "Tutorial",
+        "guided_description": "Aprenda como criar e executar o seu primeiro flow com passos guiados.",
+        "guided_duration": "Recomendado para a maioria",
+        "self_serve_title": "Criar flow do zero",
+        "self_serve_description": "Vá diretamente para o editor e crie o seu próprio flow.",
+        "self_serve_note": "Para utilizadores experientes",
+        "additional_help": "Ajuda adicional",
+        "docs": "Documentação",
+        "tutorial": "Tutorial",
+        "blueprints": "Blueprints",
+        "slack": "Comunidade Slack"
+      },
+      "steps": {
+        "flow_basics": {
+          "title": "Noções básicas de flow",
+          "description": "No Kestra, um <code>flow</code> é a unidade central de orquestração. Você o define em YAML com metadados e tarefas ordenadas.<br><br>Revise a estrutura de exemplo abaixo e depois continue a construí-la passo a passo."
+        },
+        "add_id": {
+          "title": "Adicionar ID do flow",
+          "description": "O ID é o nome único do seu flow, para que você possa encontrá-lo, executá-lo e referenciá-lo de forma consistente.<br><br>Agora adicione <code>id</code> no nível raiz."
+        },
+        "add_namespace": {
+          "title": "Adicionar namespace",
+          "description": "O Namespace é um agrupamento semelhante a uma pasta que organiza flows por equipa, projeto ou ambiente.<br><br>Agora adicione <code>namespace</code> no nível raiz."
+        },
+        "add_input": {
+          "title": "Adicionar um input",
+          "description": "Inputs são parâmetros a nível de flow que podem ser referenciados dentro das tarefas para controlar dinamicamente o comportamento em tempo de execução.<br><br>Agora adicione um input chamado <code>name</code> com o tipo <code>STRING</code>."
+        },
+        "add_log_task": {
+          "title": "Adicionar a primeira tarefa",
+          "description": "Tasks são as unidades de trabalho que o seu flow executa, definidas como uma lista ordenada de passos. Cada task precisa de um <code>id</code> único e um <code>type</code>. O Kestra fornece muitos plugins de tasks para sistemas externos; aqui usamos uma task de Python Script.<br><br>A sintaxe <code>&#123;&#123; ... &#125;&#125;</code> é uma expressão Pebble, usada para referenciar variáveis dinamicamente em tempo de execução, como <code>&#123;&#123; inputs.name &#125;&#125;</code> a partir dos inputs do flow.<br><br>Agora adicione a primeira task em <code>tasks</code> com <code>id</code>, <code>type</code> e um <code>script</code> que imprima uma saudação."
+        },
+        "save_flow": {
+          "title": "Guardar flow",
+          "description": "Guardar preserva a definição do seu flow para que ele possa ser executado."
+        },
+        "execute_flow": {
+          "title": "Executar flow",
+          "description": "Executar inicia uma execução do seu flow com valores de input em tempo de execução."
+        },
+        "view_logs_status": {
+          "title": "Verificar execução",
+          "description": "Os detalhes de execução mostram o estado da execução, tempos e logs de saída ao nível das tasks.<br><br>Agora abra os detalhes da execução e clique em <code>greet</code> no gráfico de Gantt para ver os logs."
+        },
+        "edit_flow_from_execution": {
+          "title": "Voltar ao Editor de Flow",
+          "description": "Você pode saltar diretamente de uma execução para a definição do flow para iterar rapidamente."
+        },
+        "add_cron_trigger": {
+          "title": "Adicionar um trigger cron",
+          "description": "Triggers podem iniciar execuções com base em agendas ou eventos externos (por exemplo, webhooks ou mensagens MQTT).<br><br>Agora adicione um trigger de agenda cron para que este flow seja executado a cada 5 minutos."
+        },
+        "add_input_default": {
+          "title": "Definir um valor padrão para o input",
+          "description": "Quando um flow é acionado automaticamente, os inputs ainda precisam de valores em tempo de execução.<br><br>O input <code>name</code> já foi criado no passo anterior, então não é necessário adicioná-lo novamente. Apenas defina um valor padrão para o input existente <code>name</code>."
+        },
+        "save_flow_again": {
+          "title": "Guardar flow",
+          "description": "O seu flow agora tem uma agenda e um valor padrão de input para execuções automáticas."
+        },
+        "background_runs_info": {
+          "title": "Execuções agendadas",
+          "description": "Este flow agora será executado em segundo plano a cada 5 minutos.<br><br>Você pode navegar para a visão geral de Execuções no menu à esquerda para monitorar execuções agendadas."
+        },
+        "finish": {
+          "title": "Você concluiu o tutorial do Primeiro Flow",
+          "description": "Ótimo começo. Você criou, executou, parametrizou e agendou um flow.<br><br>Escolha o que fazer a seguir ..."
+        }
+      },
+      "actions": {
+        "next": "Próximo",
+        "complete": "Concluir",
+        "save_to_continue": "Clique em Guardar na barra superior (à direita).",
+        "execute_to_continue": "1. Clique em Executar na barra superior (à direita).\n2. Forneça um valor para <strong>name</strong>.\n3. Clique em Executar novamente na janela modal.",
+        "edit_flow_to_continue": "Clique em Editar flow na barra superior (à direita).",
+        "cancel_tutorial": "Cancelar tutorial",
+        "finish_tutorial": "Finalizar tutorial"
+      },
+      "finish_actions": {
+        "explore_blueprints": "Explorar Blueprints",
+        "create_flow": "Criar flow"
+      },
+      "editor_hints": {
+        "build_intro": "Crie o seu primeiro flow passo a passo.",
+        "step_1": "# 1) Adicionar id",
+        "step_2": "# 2) Adicionar namespace",
+        "step_3": "# 3) Adicionar um input",
+        "step_4": "# 4) Adicionar tasks e a sua primeira task Python",
+        "step_5": "# 5) Adicionar um trigger cron"
+      },
+      "cancel_modal": {
+        "title": "Cancelar o tutorial do Primeiro Flow",
+        "description": "Você quer cancelar o tutorial do Primeiro Flow?",
+        "confirm": "Cancelar tutorial",
+        "keep": "Manter tutorial"
+      },
+      "validation": {
+        "complete_step": "Você está quase lá. Conclua este passo para continuar.",
+        "fix_yaml": "Há um pequeno problema de formatação YAML. Corrija-o e depois continue.",
+        "add_id": "Adicione um ID de flow no topo. Exemplo: `id: hello_flow`.",
+        "add_namespace": "Adicione um namespace no topo. Exemplo: `namespace: company.team`.",
+        "add_input_section": "Crie uma seção `inputs` com um input.",
+        "add_input_id": "Dentro de `inputs`, adicione `id: name`.",
+        "add_input_type": "Defina o tipo do input como `STRING`.",
+        "add_log_task_section": "Crie uma seção `tasks` e adicione a sua primeira task.",
+        "add_log_task_id": "Dê um ID à task, por exemplo: `id: greet`.",
+        "add_log_task_type": "Defina o tipo da task como `io.kestra.plugin.scripts.python.Script`.",
+        "add_log_task_message": "Adicione um campo `script` à task.",
+        "add_log_task_pebble": "Use uma expressão Pebble no script para que ele use o valor do seu input (por exemplo: `inputs.name`).",
+        "save_flow": "Clique em Guardar para continuar.",
+        "execute_flow": "Execute o flow uma vez para continuar.",
+        "view_logs_status": "Abra os detalhes da execução e verifique os logs de `greet`.",
+        "edit_flow_from_execution": "Clique em `Editar flow` na barra superior para continuar.",
+        "add_cron_trigger_section": "Crie uma seção `triggers` com um trigger de agenda.",
+        "add_cron_trigger_type": "Defina o tipo do trigger como `io.kestra.plugin.core.trigger.Schedule`.",
+        "add_cron_trigger_cron": "Adicione uma expressão cron, por exemplo: `\"*/5 * * * *\"`.",
+        "add_input_default_section": "Volte para `inputs` e mantenha um input existente chamado `name` (não adicione um segundo input).",
+        "add_input_default_id": "Mantenha o ID do input existente como `name`.",
+        "add_input_default_defaults": "Adicione um valor padrão para `name`, por exemplo: `defaults: \"Kestra\"`.",
+        "save_flow_again": "Clique em Guardar novamente para continuar."
+      }
+    },
+    "enable concurrency": "Habilitar concorrência",
+    "auditlogs": "Audit Logs",
+    "quotas": "Cotas",
+    "iam": "IAM",
+    "tenant": {
+      "name": "Mandante",
+      "names": "Mandantes"
+    },
+    "ee-tooltip": {
+      "features-blocked": "Este recurso requer a Enterprise Edition.",
+      "button": "Fale conosco"
+    },
+    "flow_only": "Disponível apenas na aba Flow.",
+    "bulk action async warning": "Isso pode levar alguns instantes.",
+    "bulk unpause backfills": "Despausar {count} backfill",
+    "bulk pause backfills": "Pausar {count} backfill",
+    "bulk delete backfills": "Excluir {count} backfill",
+    "bulk unlock": "Desbloquear {count} triggers",
+    "bulk disabled status": {
+      "true": "Desativar {count} triggers",
+      "false": "Ativar {count} triggers"
+    },
+    "unlock": "Desbloquear",
+    "bulk success unpause backfills": "{count} backfills despausados",
+    "bulk success pause backfills": "{count} backfills pausados",
+    "bulk success delete backfills": "{count} backfills excluídos",
+    "bulk success unlock": "{count} triggers desbloqueados",
+    "bulk success disabled status": {
+      "true": "{count} trigger(s) desativado(s)",
+      "false": "{count} trigger(s) ativado(s)"
+    },
+    "no_namespaces": "Nenhum namespace corresponde aos critérios de busca.",
+    "system_namespace": "Mantenha sua plataforma sob controle com system flows.",
+    "system_namespace_description": "Automatize tarefas de manutenção, desde alertas de falha até limpezas automatizadas.",
+    "pluginDefaults": {
+      "title": "Padrões do Plugin",
+      "add": "Adicionar Plugin Padrão",
+      "edit": "Editar Padrão do Plugin",
+      "add_subtitle": "Configurar um novo plugin padrão com suas propriedades",
+      "edit_subtitle": "Modificar a configuração padrão do plugin existente",
+      "predefined": "Plugin Predefinido",
+      "custom": "Plugin Personalizado",
+      "form": "Formulário",
+      "yaml": "YAML",
+      "select_predefined": "Selecionar Plugin Predefinido",
+      "cancel": "Cancelar",
+      "update": "Atualizar Plugin Padrão",
+      "custom_type": "Tipo de plugin personalizado",
+      "custom_placeholder": "Insira o tipo de plugin",
+      "use_custom": "Usar Personalizado",
+      "custom_configure": "Tipo de plugin personalizado - configurar usando YAML",
+      "yaml_configuration": "Configuração YAML",
+      "show_yaml": "Mostrar YAML"
+    },
+    "secret": {
+      "add": "Criar",
+      "update": "Atualizar segredo '{name}'",
+      "isReadOnly": "O segredo é somente leitura",
+      "names": "Segredos",
+      "inherited": "Segredos herdados"
+    },
+    "workerId": "Worker Id",
+    "kv": {
+      "name": "KV Store",
+      "type": "Tipo",
+      "add": "Criar",
+      "update": "Atualizar valor para a key '{key}'",
+      "duplicate": "Esta key já existe",
+      "delete multiple": {
+        "confirm": "Tem certeza de que deseja excluir: <code>{name}</code> KV(s)?",
+        "warning": "Você não tem permissões para esses namespaces, então eles serão omitidos: <code>{namespaces}</code>"
+      },
+      "inherited": "Pares KV herdados"
+    },
+    "expiration": "Expiração",
+    "failed to render pdf": "Falha ao renderizar a pré-visualização do PDF",
+    "page": {
+      "previous": "Página anterior",
+      "next": "Próxima página"
+    },
+    "namespace_editor": {
+      "empty": {
+        "title": "Nenhuma aba aberta no momento",
+        "create_message": "Você pode criar ou importar arquivos de namespace.",
+        "video_message": "Você pode assistir ao Vídeo de Introdução para o nosso Editor."
+      },
+      "close": {
+        "tab": "Fechar aba",
+        "all": "Fechar todas as abas",
+        "other": "Fechar outras abas",
+        "right": "Fechar à direita"
+      }
+    },
+    "curl": {
+      "command": "Comando cURL",
+      "note": "Observe que, para o tipo de input SECRET e FILE, o comando deve ser ajustado para corresponder aos valores reais."
+    },
+    "webhook": {
+      "curl_command": "Comando cURL do Webhook",
+      "payload": "Payload do Webhook (JSON)",
+      "curl_note": "Use este comando cURL para acionar o flow via webhook com carga útil JSON personalizada",
+      "no_triggers": "Este flow não possui triggers de webhook habilitados",
+      "copy_url": "Copiar URL do webhook"
+    },
+    "logs_view": {
+      "raw": "Visualização temporal",
+      "raw_details": "Mostrar logs completos de task e flow em formato bruto ordenado por timestamp",
+      "compact": "Visualização padrão",
+      "compact_details": "Mostrar logs de task em uma visualização compacta agrupada por cada task"
+    },
+    "execution_deletion": {
+      "logs": "Excluir logs",
+      "metrics": "Excluir métricas",
+      "storage": "Excluir arquivos de armazenamento interno"
+    },
+    "scope_filter": {
+      "all": "Todos os {label}",
+      "user": "Usuário {label}",
+      "system": "Sistema {label}",
+      "user_description": "Usuário regular iniciou {label}",
+      "system_description": "Manutenção do sistema {label}"
+    },
+    "data": "Dados",
+    "webhook link copied": "Link do Webhook copiado.",
+    "copy url": "Copiar URL",
+    "scheduleDate": "Data de agendamento",
+    "warning": "Aviso",
+    "trigger_check_warning": "Usar variáveis de trigger não funcionará com a execução manual de flow. Adicione o operador de coalescência `??` para resolver o problema. Por exemplo, em vez de `trigger.date`, use `trigger.date ?? execution.startDate`.",
+    "docs": "Documentos",
+    "active-slots": "Slots ativos",
+    "behavior": "Comportamento",
+    "concurrency": "Concorrência",
+    "no-executions-view": {
+      "title": "Comece a automatizar com",
+      "sub_title": "Clique no botão Executar para iniciar a execução do seu primeiro fluxo de trabalho.",
+      "namespace_sub_title": "Execute um ou mais flows deste namespace para preencher este dashboard.",
+      "guidance_desc": "Precisa de orientação para executar o seu flow?",
+      "namespace_guidance_desc": "Precisa de orientação para gerenciar seu Namespace?",
+      "guidance_sub_desc": "Siga a documentação para todas as informações que você precisa."
+    },
+    "execution_guide": {
+      "get_started": {
+        "title": "Começar ⚡",
+        "text": "Siga o Guia de Início Rápido para instalar o Kestra e começar a criar seus primeiros workflows."
+      },
+      "namespaces": {
+        "title": "Sobre Namespaces",
+        "text": "Namespaces são agrupamentos lógicos de flows e seus componentes."
+      },
+      "workflow_components": {
+        "title": "Componentes do Workflow",
+        "text": "Conheça os principais componentes de orquestração de um workflow Kestra."
+      },
+      "videos_tutorials": {
+        "title": "Tutoriais em Vídeo",
+        "text": "Comece com nossos tutoriais em vídeo."
+      }
+    },
+    "open sidebar": "abrir barra lateral",
+    "close sidebar": "fechar barra lateral",
+    "customize sidebar": "Personalizar barra lateral",
+    "reset to defaults": "Redefinir para padrões",
+    "drop items here": "Solte os itens aqui",
+    "files": "Arquivos",
+    "optional": "Opcional",
+    "no_data": "Parece que não há nada aqui... ainda!<br/>Ajuste seus filtros ou tente novamente!",
+    "bookmark": "Favoritos",
+    "remove_bookmark": "Tem certeza de que deseja remover este marcador?",
+    "showLess": "Mostrar menos",
+    "showMore": "Mostrar mais",
+    "documentationMenu": "Menu de documentação",
+    "item": "item",
+    "items": "itens",
+    "cron": "Cron",
+    "execution_started": "A execução foi iniciada!",
+    "execution_failed": "Execução FAILED!",
+    "last error was": "O último erro foi",
+    "execution restarted": "Esta execução foi reiniciada {nbRestart} vez(es).",
+    "execution replay": "Esta execução é uma repetição de",
+    "execution replayed": "Esta execução foi reproduzida.",
+    "task run id": "ID do TaskRun",
+    "active": "Ativo",
+    "flows imported": "Fluxos importados",
+    "flow not imported": "Algum flow não pôde ser importado",
+    "plugin defaults exported": "Padrões do plugin exportados",
+    "failed to export plugin defaults": "Falha ao exportar padrões do plugin",
+    "plugin defaults imported": "Padrões de plugin importados",
+    "plugin defaults not imported": "Alguns padrões de plugin não puderam ser importados",
+    "failed to import plugin defaults": "Falha ao importar os padrões do plugin",
+    "filters": {
+      "label": "Escolher filtros",
+      "empty": "Sem dados.",
+      "format": "Digite o parâmetro como 'key:value'",
+      "text_search": "Pesquisar por este texto",
+      "options": {
+        "namespace": "Namespace",
+        "flow": "Fluxo",
+        "state": "Estado",
+        "scope": "Escopo",
+        "child": "Filho",
+        "level": "Nível de Log",
+        "task": "Tarefa",
+        "metric": "Métrica",
+        "user": "Usuário",
+        "type": "Tipo",
+        "service_type": "Tipo",
+        "permission": "Permissão",
+        "action": "Ação",
+        "status": "Status",
+        "details": "Detalhes",
+        "aggregation": "Agregação",
+        "relative_date": "Data relativa",
+        "absolute_date": "Data absoluta",
+        "labels": "Etiquetas",
+        "text": "Parece que você não forneceu nenhum texto para tradução. Por favor, forneça o texto que deseja que eu traduza para o português.",
+        "startDate": "Data de início",
+        "endDate": "Data de término"
+      },
+      "comparators": {
+        "is": "é",
+        "is_one_of": "é um dos",
+        "is_not": "não é",
+        "not_in": "não em",
+        "contains": "contém",
+        "not_contains": "não contém",
+        "in": "em",
+        "between": "entre",
+        "starts_with": "começa com",
+        "greater_than": "maior que",
+        "greater_than_or_equal_to": "maior ou igual a",
+        "less_than": "menor que",
+        "less_than_or_equal_to": "menor ou igual a",
+        "ends_with": "termina com"
+      },
+      "save": {
+        "label": "Pesquisas salvas",
+        "remove": "Remover",
+        "empty": "Você ainda não salvou nenhuma pesquisa.",
+        "tooltip": "Você não pode salvar critérios de pesquisa vazios.",
+        "name_already_used": "A etiqueta de pesquisa já está em uso.",
+        "dialog": {
+          "heading": "Salvar pesquisa atual",
+          "placeholder": "Etiqueta",
+          "hint": "Como você deseja rotular este critério de busca?",
+          "confirmation": "Critérios de pesquisa <code>{name}</code>"
+        }
+      },
+      "settings": {
+        "label": "Configurações da página",
+        "show_chart": "Exibir gráfico principal"
+      }
+    },
+    "custom value": "Valor personalizado",
+    "chart": "Gráfico",
+    "chart preview": "Pré-visualização do gráfico",
+    "no_code": {
+      "toggle_pebble": "Alternar editor Pebble",
+      "version_oss_placeholder": "Desbloqueie a Versionamento de Plugin com a Enterprise Edition",
+      "unnamed": "Sem Nome",
+      "adding": "+ Adicionar um {what}",
+      "adding_default": "+ Adicionar um novo value",
+      "add_field": "Adicionar {field}",
+      "clearSelection": "Limpar seleção",
+      "labels": {
+        "yaml": "Editor YAML",
+        "no_code": "Editor Sem Código",
+        "label": "Etiqueta",
+        "variable": "Variável"
+      },
+      "sections": {
+        "deprecated": "Propriedades obsoletas",
+        "tasks": "Tarefas",
+        "triggers": "Triggers",
+        "errors": "Manipuladores de Erro",
+        "afterExecution": "Após a Execução",
+        "finally": "Finalmente",
+        "pluginDefaults": "Padrões de Plugin"
+      },
+      "fields": {
+        "main": {
+          "id": "ID do Flow",
+          "namespace": "Namespace",
+          "description": "Descrição",
+          "inputs": "Entradas"
+        },
+        "general": {
+          "retry": "Repetir",
+          "sla": "SLA",
+          "labels": "Etiquetas",
+          "outputs": "Saídas",
+          "variables": "Variáveis",
+          "concurrency": "Concorrência",
+          "disabled": "Desativado",
+          "listeners": "Ouvintes",
+          "taskDefaults": "Padrões de Task",
+          "workerGroup": "Grupo de Worker",
+          "workerSelector": "Seletor de Worker",
+          "checks": "Verificações",
+          "updated": "Atualizado"
+        }
+      },
+      "select": {
+        "default": "Selecione um tipo",
+        "task": "Selecione uma task",
+        "tasks": "Selecione uma task",
+        "triggers": "Selecione um trigger",
+        "errors": "Selecione uma task",
+        "finally": "Selecione uma task",
+        "pluginDefaults": "Selecione um plugin",
+        "afterExecution": "Selecione uma task",
+        "conditions": "Selecione uma condição",
+        "inputs": "Selecione um tipo de campo de input",
+        "charts": "Selecione um tipo de gráfico",
+        "where": "Selecione um tipo de filtro",
+        "numerator": "Selecione um numerador"
+      },
+      "creation": {
+        "default": "Adicionar",
+        "tasks": "Adicionar uma task",
+        "triggers": "Adicionar um trigger",
+        "errors": "Adicionar um manipulador de erro",
+        "finally": "Adicionar um bloco finally",
+        "pluginDefaults": "Adicionar um padrão de plugin",
+        "afterExecution": "Adicionar um bloco após a execução",
+        "conditions": "Adicionar uma condição",
+        "inputs": "Adicionar um campo de input",
+        "charts": "Adicionar um gráfico",
+        "where": "Filtrar seus dados",
+        "numerator": "Adicionar um numerador"
+      },
+      "remove": {
+        "default": "Remover esta entrada",
+        "cases": "Remover este caso"
+      }
+    },
+    "properties": {
+      "label": "Propriedades",
+      "hint": "Escolher Colunas Visíveis",
+      "shown": "Exibido na Tabela",
+      "hidden": "Oculto na Tabela"
+    },
+    "editor_shortcuts": {
+      "label": "Atalhos de teclado",
+      "trigger_autocompletion": "Acionar autocompletar",
+      "command_palette": "Mostrar paleta de comandos",
+      "save_flow": "Salvar flow",
+      "execute_flow": "Executar flow",
+      "toggle_ai_agent": "Alternar agente de IA",
+      "move_line": "Mover linha",
+      "duplicate_cursor": "Duplicar cursor",
+      "fold_unfold": "Dobra/Desdobra código",
+      "comment_uncomment": "Comentar/Descomentar",
+      "comment": "Comentário",
+      "uncomment": "Descomentar",
+      "decrease_fontsize": "Diminuir tamanho da fonte do editor",
+      "increase_fontsize": "Aumentar o tamanho da fonte do editor",
+      "reset_fontsize": "Redefinir tamanho da fonte do editor"
+    },
+    "instance": "Instância",
+    "something_went_wrong": {
+      "loading_execution": "Algo deu errado ao carregar a execução",
+      "connection_lost": {
+        "title": "Conexão interrompida",
+        "message": "Não conseguimos acessar sua instância do Kestra. Certifique-se de que está em execução e, em seguida, atualize a página."
+      }
+    },
+    "debug": "Depurar",
+    "default": "Padrão",
+    "data_not_protected": "Seus dados não estão protegidos. Não os perca. <b>Ative nossos recursos de segurança gratuitos ou experimente nossa oferta paga.</b>",
+    "activate_basic_auth": "Ativar Autenticação Básica",
+    "dark_version": "Versão escura",
+    "use_dark_background": "Use esta versão ao trabalhar em um fundo escuro para garantir que nosso nome permaneça legível.",
+    "light_version": "Versão clara",
+    "light_background": "Esta é a opção preferida ao trabalhar com um fundo claro.",
+    "monogram": "Monograma",
+    "wordmark_colors": "As cores da marca adaptam-se com base no fundo, enquanto o ícone permanece sem fundo quando colocado em um fundo escuro.",
+    "download_logos": "Baixar Pacote de Logos",
+    "this_task_has": "Esta task tem",
+    "about_this_blueprint": "Sobre este blueprint",
+    "deleted_label": "Deletado",
+    "fold_all_multi_lines": "Recolher Todas as Linhas Múltiplas",
+    "task_id_exists": "Id da Task já existe",
+    "task_id_message": "O Task Id ${existingTask} já existe no flow.",
+    "trigger_id_exists": "Id de Trigger já existe",
+    "trigger_id_message": "O Trigger Id ${existingTrigger} já existe no flow.",
+    "watch": "Assistir",
+    "learn_more": "Saiba mais",
+    "watch_video": "Assistir Vídeo",
+    "runners": "Corredores",
+    "select": "Selecione sua {{section}}",
+    "for flow": "para flow",
+    "forbidden system labels": "Apenas system.correlationId pode ser usado como label do sistema",
+    "confirm": "Confirmar",
+    "taskRunners": "Executores de Task",
+    "additionalPlugins": "Plugins Adicionais",
+    "appBlocks": "Blocos do App",
+    "charts": "Gráficos",
+    "dataFilters": "Filtros de Dados",
+    "logExporters": "Exportadores de Log",
+    "empty": {
+      "namespaceFiles": {
+        "title": "Ainda não há ficheiros neste namespace",
+        "content": "Os ficheiros do namespace funcionam como uma pasta de projeto para este namespace. Armazene código Python, SQL, dbt ou Terraform e, em seguida, referencie qualquer ficheiro nos seus flows com"
+      },
+      "announcements": {
+        "title": "Você ainda não tem anúncios!",
+        "content": "Os anúncios permitem que você notifique seus usuários sobre quaisquer alterações ou informe-os sobre o tempo de inatividade planejado para manutenção. Basta selecionar o tipo de anúncio, o intervalo de datas em que ele deve ser exibido e escrever a mensagem do anúncio."
+      },
+      "kill_switches": {
+        "title": "Você ainda não tem Kill Switches!",
+        "content": "O recurso Kill Switch fornece um mecanismo baseado em UI para interromper execuções problemáticas. Ele substitui os comandos <code>--skip-executions</code> e <code>--skip-flows</code> disponíveis apenas no CLI por uma interface de administração abrangente."
+      },
+      "apps": {
+        "title": "Você ainda não tem apps!",
+        "content": "Comece a criar Apps para interagir com o Kestra a partir do mundo externo."
+      },
+      "testSuites": {
+        "title": "Você ainda não tem Test suites!",
+        "content": "Comece a criar suítes de Teste para testar seus Flows."
+      },
+      "assets": {
+        "title": "Você ainda não tem Assets!",
+        "content": "Adicione assets para rastrear e gerenciar seus data assets, serviços e infraestrutura."
+      },
+      "apiTokens": {
+        "title": "Gerencie seus Tokens de API",
+        "content": "Tokens de API são usados sempre que você deseja conceder acesso programático à API do Kestra."
+      },
+      "concurrency_executions": {
+        "title": "Nenhuma Execução em andamento para este Flow.",
+        "content": "Leia mais sobre <strong><a href=\"https://kestra.io/docs/workflow-components/execution?utm_source=app&utm_medium=referral&utm_campaign=concurrency-inlinedoc\" target=\"_blank\">Execuções</a></strong> em nossa documentação."
+      },
+      "concurrency_limit": {
+        "title": "Nenhum limite está definido para este Flow.",
+        "content": "Leia mais sobre <strong><a href=\"https://kestra.io/docs/workflow-components/concurrency?utm_source=app&utm_medium=referral&utm_campaign=concurrency-inlinedoc\" target=\"_blank\">Limites de Concurrency</a></strong> em nossa documentação."
+      },
+      "concurrency_limits": {
+        "title": "Nenhum limite de concorrência está definido.",
+        "content": "Leia mais sobre os <strong><a href=\"https://kestra.io/docs/workflow-components/concurrency?utm_source=app&utm_medium=referral&utm_campaign=concurrency-inlinedoc\" target=\"_blank\">Limites de Concurrency</a></strong> em nossa documentação."
+      },
+      "pluginDefaults": {
+        "title": "Você ainda não tem padrões de plugin!",
+        "content": "Padrões de Plugin permitem que você governe centralmente a configuração do seu plugin e a compartilhe com todos os flows no seu namespace."
+      },
+      "variables": {
+        "title": "Ainda não há variáveis",
+        "content": "Adicione pares de key-value para compartilhar configurações entre flows. Namespaces filhos os herdam automaticamente, e você pode referenciar qualquer value com"
+      },
+      "workerRegistrationTokens": {
+        "title": "Você ainda não tem tokens de registro!",
+        "content": "Tokens de registro permitem que workers remotos autentiquem-se e registrem-se com segurança na sua instância do Kestra. Crie um token e use-o para conectar novos workers a este cluster."
+      },
+      "groups": {
+        "title": "Você ainda não tem grupos!",
+        "content": "Grupos permitem que você agrupe usuários para gerenciar permissões e vinculações de funções coletivamente em todo o seu mandante."
+      },
+      "dependencies": {
+        "FLOW": {
+          "title": "Atualmente, não há dependências.",
+          "content": "Leia mais sobre <a href=\"https://kestra.io/docs/ui/flows?utm_source=app&utm_medium=referral&utm_campaign=dependencies-inlinedoc#dependencies\" target=\"_blank\">Dependências de Flow</a> na nossa documentação."
+        },
+        "EXECUTION": {
+          "title": "Atualmente, não há dependências.",
+          "content": "Leia mais sobre <a href=\"https://kestra.io/docs/ui/executions?utm_source=app&utm_medium=referral&utm_campaign=dependencies-inlinedoc#dependencies\" target=\"_blank\">Dependências de Execução</a> na nossa documentação."
+        },
+        "NAMESPACE": {
+          "title": "Atualmente, não há dependências.",
+          "content": "Leia mais sobre <a href=\"https://kestra.io/docs/ui/namespaces?utm_source=app&utm_medium=referral&utm_campaign=dependencies-inlinedoc#dependencies\" target=\"_blank\">Dependências de Namespace</a> em nossa documentação."
+        },
+        "ASSET": {
+          "title": "Atualmente, não há dependências.",
+          "content": "Este ativo não possui dependências upstream ou downstream com flows ou outros ativos."
+        }
+      },
+      "plugins": {
+        "title": "Nenhum padrão de plugin está definido para este Namespace.",
+        "content": "Leia mais sobre <strong><a href=\"https://kestra.io/docs/workflow-components/plugin-defaults?utm_source=app&utm_medium=referral&utm_campaign=plugin-default-inlinedoc\" target=\"_blank\">Limites de Concurrency</a></strong> em nossa documentação."
+      },
+      "triggers": {
+        "title": "Seu flow não possui nenhum trigger.",
+        "content": "Leia mais sobre <strong><a href=\"https://kestra.io/docs/workflow-components/triggers?utm_source=app&utm_medium=referral&utm_campaign=trigger-inlinedoc\" target=\"_blank\">Triggers</a></strong> em nossa documentação."
+      },
+      "mcpToolFlows": {
+        "title": "Ainda não há flows de ferramenta registrados neste servidor.",
+        "content": "Exponha um flow como uma ferramenta MCP adicionando um <code>McpToolTrigger</code> a ele. Leia mais sobre o <strong><a href=\"https://kestra.io/docs/workflow-components/triggers/mcp-tool-trigger?utm_source=app&utm_medium=referral&utm_campaign=mcp-tool-trigger-inlinedoc\" target=\"_blank\">MCP Tool Trigger</a></strong> em nossa documentação."
+      },
+      "versionPlugin": {
+        "title": "Você ainda não tem um plugin versionado!",
+        "content": "Aqui você pode gerenciar todos os plugins instalados na sua instância do Kestra. Plugins recém-instalados podem não estar imediatamente disponíveis em todos os serviços do Kestra, dependendo da configuração da sua instância."
+      },
+      "panels": {
+        "title": "Nenhum painel aberto",
+        "content": "Você fechou todos os painéis.  \nEscolha uma aba acima para continuar."
+      }
+    },
+    "toggle_word_wrap": "Alternar Quebra de Linha",
+    "copied_logs_to_clipboard": "Logs copiados para a área de transferência.",
+    "multi_panel_editor": {
+      "move_right": "Mover para a direita",
+      "move_left": "Mover para a esquerda",
+      "close_all_tabs": "Fechar todas as abas",
+      "close_all_panels": "Fechar todos os painéis"
+    },
+    "search_docs": "Pesquisar",
+    "no_results_found": "Nenhum resultado encontrado",
+    "searching": "Procurando...",
+    "worker information": "Informações do Worker",
+    "test-badge-text": "Teste",
+    "test-badge-tooltip": "Esta execução foi criada por um Teste",
+    "total_executions": "Total de Execuções",
+    "no_results": {
+      "executions": "Nenhuma Execução Encontrada",
+      "triggers": "Nenhum Trigger Encontrado",
+      "flows": "Nenhum Flow Encontrado",
+      "kv_pairs": "Nenhum par de Key-Value encontrado",
+      "secrets": "Nenhum Secret Encontrado",
+      "templates": "Nenhum Template Encontrado",
+      "assets": "Nenhum Asset Encontrado"
+    },
+    "duplicate-pair": "O {label} \"{key}\" está duplicado, a primeira chave foi ignorada.",
+    "dashboards": {
+      "labels": {
+        "singular": "Dashboard",
+        "plural": "Dashboards"
+      },
+      "default": "Dashboard Padrão",
+      "switch": "Alternar Dashboard",
+      "preview": "Visualizar Dashboard",
+      "empty": "Não há resultados para serem exibidos.",
+      "creation": {
+        "label": "Criar Dashboard",
+        "confirmation": "O Dashboard <code>{title}</code> foi criado."
+      },
+      "edition": {
+        "label": "Editar Dashboard",
+        "confirmation": "As alterações no dashboard <code>{title}</code> foram salvas.",
+        "chart": "Edite este gráfico",
+        "id readonly": "A propriedade `id` não pode ser alterada — agora está definida para seus valores iniciais. Se você quiser alterá-la, pode criar um novo dashboard e remover o antigo."
+      },
+      "deletion": {
+        "confirmation": "Tem certeza de que deseja excluir o dashboard <code>{title}</code>?"
+      },
+      "no_description": "Sem descrição",
+      "no_description_hint": "Adicione uma descrição a este flow para documentar o que ele faz.<br>Markdown é suportado.",
+      "others": "Outros",
+      "viewAll": "Ver tudo",
+      "chart_preview": "Clique no código-fonte de um gráfico para ver sua pré-visualização",
+      "export": "Exportar para CSV",
+      "quick_filters": {
+        "all": "Todos",
+        "running": "Em execução",
+        "paused": "Pausado",
+        "success": "Sucesso",
+        "warning": "Aviso",
+        "failed": "Falhou"
+      }
     },
     "setup": {
-      "config": {
-        "basicauth": "Autenticação básica",
-        "queue": "Fila",
-        "repository": "Banco de Dados",
-        "storage": "Armazenamento Interno"
+      "login": "Login",
+      "login_title": "Entrar",
+      "logout": "Sair",
+      "troubleshooting": "Esqueceu a Senha?",
+      "steps": {
+        "user": "Criar usuário admin",
+        "config": "Validar Configuração",
+        "survey": "Conte-nos mais",
+        "complete": "Iniciar Kestra UI"
       },
-      "confirm": {
-        "config_title": "Confirme que a configuração é válida",
-        "confirm": "Criar usuário admin",
-        "not_valid": "Não, não é válido",
-        "valid": "Sim, é válido"
+      "titles": {
+        "user": "Criar um usuário admin",
+        "survey": "Ajude-nos a melhorar o Kestra OSS"
+      },
+      "subtitles": {
+        "user": "Proteja sua instância para começar.",
+        "config": "Aqui estão os detalhes da sua configuração",
+        "survey": "I'm sorry, but it seems there is no text provided after the \"----------\" for translation. Could you please provide the text you would like translated into Portuguese?",
+        "complete": "Configuração concluída com sucesso!"
       },
       "form": {
         "email": "Email",
@@ -1878,351 +1937,249 @@
         "username": "Nome de Usuário",
         "username_hint": "Deve ser um endereço de e-mail válido."
       },
-      "login": "Login",
-      "login_title": "Entrar",
-      "logout": "Sair",
-      "steps": {
-        "complete": "Iniciar Kestra UI",
-        "config": "Validar Configuração",
-        "survey": "Conte-nos mais",
-        "user": "Criar usuário admin"
-      },
-      "subtitles": {
-        "complete": "Configuração concluída com sucesso!",
-        "config": "Aqui estão os detalhes da sua configuração",
-        "survey": "I'm sorry, but it seems there is no text provided after the \"----------\" for translation. Could you please provide the text you would like translated into Portuguese?",
-        "user": "Proteja sua instância para começar."
-      },
-      "success": {
-        "subtitle": "Você está pronto!",
-        "title": "Parabéns!"
-      },
-      "survey": {
-        "company_11_50": "Projeto pessoal",
-        "company_1_10": "Aprendendo / explorando",
-        "company_250_plus": "Implantação de produção",
-        "company_50_250": "Avaliando para minha equipe/empresa",
-        "company_personal": "Outros",
-        "company_size": "Qual é o seu principal objetivo com o Kestra?",
-        "continue": "Continuar",
-        "newsletter": "Receba atualizações de produtos por email.",
-        "newsletter_heading": "Mantenha-se informado",
-        "skip": "Pular",
-        "use_case": "Para que você planeja usá-lo?",
-        "use_case_business": "Fluxos de trabalho empresariais",
-        "use_case_data": "Fluxos de trabalho de dados",
-        "use_case_infrastructure": "Automação de infraestrutura",
-        "use_case_ml": "Pipelines de ML",
-        "use_case_other": "Outros",
-        "use_case_scheduling": "Agendamento e trabalhos recorrentes"
-      },
-      "titles": {
-        "survey": "Ajude-nos a melhorar o Kestra OSS",
-        "user": "Criar um usuário admin"
-      },
-      "troubleshooting": "Esqueceu a Senha?",
       "validation": {
-        "config_message": "Certifique-se de atualizar sua configuração para corrigir esta mensagem de erro",
-        "email_invalid": "E-mail inválido",
         "email_required": "O e-mail é obrigatório",
+        "email_invalid": "E-mail inválido",
         "email_temporary_not_allowed": "Endereços de e-mail temporários ou descartáveis não são permitidos",
         "firstName_required": "Nome é obrigatório",
-        "incorrect_creds": "Nome de usuário ou senha inválidos. Certifique-se de que suas credenciais estão corretas.",
         "lastName_required": "Sobrenome obrigatório",
         "password_invalid": "Senha inválida",
-        "password_required": "A palavra-passe é obrigatória"
+        "password_required": "A palavra-passe é obrigatória",
+        "incorrect_creds": "Nome de usuário ou senha inválidos. Certifique-se de que suas credenciais estão corretas.",
+        "config_message": "Certifique-se de atualizar sua configuração para corrigir esta mensagem de erro"
+      },
+      "config": {
+        "repository": "Banco de Dados",
+        "queue": "Fila",
+        "storage": "Armazenamento Interno",
+        "basicauth": "Autenticação básica"
+      },
+      "confirm": {
+        "confirm": "Criar usuário admin",
+        "config_title": "Confirme que a configuração é válida",
+        "not_valid": "Não, não é válido",
+        "valid": "Sim, é válido"
+      },
+      "survey": {
+        "skip": "Pular",
+        "company_size": "Qual é o seu principal objetivo com o Kestra?",
+        "company_1_10": "Aprendendo / explorando",
+        "company_11_50": "Projeto pessoal",
+        "company_50_250": "Avaliando para minha equipe/empresa",
+        "company_250_plus": "Implantação de produção",
+        "company_personal": "Outros",
+        "use_case": "Para que você planeja usá-lo?",
+        "use_case_infrastructure": "Automação de infraestrutura",
+        "use_case_business": "Fluxos de trabalho empresariais",
+        "use_case_data": "Fluxos de trabalho de dados",
+        "use_case_ml": "Pipelines de ML",
+        "use_case_scheduling": "Agendamento e trabalhos recorrentes",
+        "use_case_other": "Outros",
+        "newsletter_heading": "Mantenha-se informado",
+        "newsletter": "Receba atualizações de produtos por email.",
+        "continue": "Continuar"
+      },
+      "success": {
+        "title": "Parabéns!",
+        "subtitle": "Você está pronto!"
       }
     },
-    "show": "Mostrar",
-    "show chart": "Mostrar Gráfico",
-    "show description": "Mostrar uma descrição",
-    "show details": "Mostrar detalhes",
-    "show documentation": "Mostrar documentação",
-    "show more details": "Mostrar mais detalhes",
-    "show raw": "Show raw",
-    "show task condition": "Exibir condição da task",
-    "show task documentation": "Mostrar documentação da task",
-    "show task documentation in editor": "Mostrar documentação da task no editor",
-    "show task logs": "Mostrar task logs",
-    "show task outputs": "Mostrar outputs da task",
-    "show task source": "Mostrar fonte da task",
-    "showLess": "Mostrar menos",
-    "showMore": "Mostrar mais",
-    "side-by-side": "lado a lado",
-    "similar lines": "similar lines",
-    "skipped": "Pulado",
-    "slack support": "Faça qualquer pergunta via Slack",
-    "something_went_wrong": {
-      "connection_lost": {
-        "message": "Não conseguimos acessar sua instância do Kestra. Certifique-se de que está em execução e, em seguida, atualize a página.",
-        "title": "Conexão interrompida"
+    "ai": {
+      "flow": {
+        "title": "Agente de IA",
+        "prompt_placeholder": "Insira instruções para criar seu flow Kestra. Exemplo de prompt: Crie um flow que execute toda segunda-feira às 9h.",
+        "select_provider": "Selecionar um provedor",
+        "generating": {
+          "flow": "Gerando YAML do flow para você...",
+          "dashboard": "Gerando YAML do Dashboard para você...",
+          "app": "Gerando YAML do App para você...",
+          "test": "Gerando YAML de teste para você..."
+        },
+        "enable_instructions": {
+          "header": "<b>AI Copilot ainda não foi configurado.</b>\n\nPara habilitar o AI Copilot, adicione o seguinte trecho ao arquivo de configuração da sua instância Kestra (por exemplo, <code>application.yml</code>), substituindo <code>geminiApiKey</code> pela sua chave real:",
+          "footer": "Nota: Neste momento, apenas o Gemini é suportado como provedor de IA para a Open Source Edition. Para a Enterprise Edition, consulte a documentação do AI Copilot para a configuração de outros provedores de modelo.\n\nReinicie sua instância do Kestra após salvar a configuração."
+        }
       },
-      "loading_execution": "Algo deu errado ao carregar a execução"
+      "dashboard": {
+        "prompt_placeholder": "Faça uma pergunta sobre seus dados. Exemplo de prompt: Mostre-me a taxa de sucesso dos meus flows nos últimos 7 dias."
+      }
     },
-    "source": "Fonte",
-    "source and blueprints": "Fonte e blueprints",
-    "source and doc": "Fonte e documentação",
-    "source and topology": "Fonte e topologia",
-    "source only": "Somente fonte",
-    "source search": "Busca de fonte",
-    "source_search": {
-      "match_count": "{count} correspondência | {count} correspondências",
-      "open_flow": "Abrir flow",
-      "preview_empty": "Selecione um resultado para pré-visualizar. Clique num flow na lista de resultados para ver a sua fonte.",
-      "preview_error": "Falha ao carregar a fonte do flow"
+    "playground": {
+      "title": "Playground",
+      "run_task_info": "Passe o cursor sobre qualquer task no editor de Flow Code e clique no botão \"Run task\" para testar sua task.",
+      "play_icon_info": "Você também pode clicar no ícone de Play nas visualizações No-Code ou Topology.",
+      "toggle": "Playground",
+      "run_task": "Executar Task",
+      "run_this_task": "Execute esta task",
+      "run_task_and_downstream": "Executar task & downstream",
+      "run_all_tasks": "Executar Todas as Tasks",
+      "history": "Últimas 10 execuções",
+      "clear_history": "Limpar histórico",
+      "confirm_create": "Você não pode executar o playground enquanto cria um flow. Iniciar uma execução do playground criará o flow.",
+      "tooltip_persistence": "Se você desligar e ligar o Playground novamente, as informações permanecem enquanto você estiver na página."
     },
-    "specific task": "Task específica",
-    "start date": "Data de início",
-    "start datetime": "Data e hora de início",
-    "started date": "Data de início",
-    "state": "Estado",
-    "state updated date": "Data de atualização do estado",
-    "state_history": "Histórico de estado",
-    "stats": "Estatísticas",
-    "steps": "Passos",
-    "stream": "Stream",
-    "sub flow": "Subflow",
     "submit": "Enviar",
-    "success": "Sucesso",
-    "sum": "Soma",
-    "switch-view": "Alternar visualização",
-    "system overview": "Visão Geral do Sistema",
-    "system_namespace": "Mantenha sua plataforma sob controle com system flows.",
-    "system_namespace_description": "Automatize tarefas de manutenção, desde alertas de falha até limpezas automatizadas.",
-    "tags": "Tags",
-    "task": "Task",
-    "task failed": "Tarefa falhou",
-    "task id": "Task ID",
-    "task id already exists": "Task Id já existe",
-    "task is running": "A task está RUNNING",
-    "task logs": "Task logs",
-    "task run id": "ID do TaskRun",
-    "task sent a warning": "A tarefa enviou um WARNING",
-    "task was skipped": "A tarefa foi ignorada",
-    "task was successful": "A tarefa foi bem-sucedida",
-    "taskDefaults": "Padrões da Task",
-    "taskRunners": "Executores de Task",
-    "task_id_exists": "Id da Task já existe",
-    "task_id_message": "O Task Id ${existingTask} já existe no flow.",
-    "taskid column details": "Última task sendo executada e seu número de tentativas.",
-    "tasks": "Tasks",
-    "template": "Template",
-    "template creation": "Criação de template",
-    "template delete": "Tem certeza de que deseja deletar <code>{templateCount}</code> template(s)?",
-    "template export": "Tem certeza de que deseja exportar <code>{templateCount}</code> template(s)?",
-    "templates": "Templates",
-    "templates deleted": "<code>{count}</code> Template(s) deletado(s)",
-    "templates deprecated": "Templates estão obsoletos. Por favor, use subflows. Veja a <a href=\"https://kestra.io/docs/migration-guide/0.11.0/templates?utm_source=app&utm_medium=referral&utm_campaign=template-inlinedoc\" target=\"_blank\">Seção de Migrações</a> explicando como você pode migrar de templates para subflows.",
-    "templates exported": "Templates exportados",
-    "tenant": {
-      "name": "Mandante",
-      "names": "Mandantes"
-    },
-    "tenantId": "ID do Mandante",
-    "test-badge-text": "Teste",
-    "test-badge-tooltip": "Esta execução foi criada por um Teste",
-    "theme": "Tema",
-    "this_task_has": "Esta task tem",
-    "timezone": "Fuso horário",
-    "title": "Título",
-    "to": "Para",
     "to toggle": "alternar",
-    "toggle fullscreen": "Alternar tela cheia",
-    "toggle menu": "Alternar menu",
-    "toggle output": "Alternar outputs",
-    "toggle output display": "Alternar exibição de output",
-    "toggle periodic refresh each x seconds": "Alternar atualização periódica a cada {interval} segundos",
-    "toggle_word_wrap": "Alternar Quebra de Linha",
-    "topology": "Topologia",
-    "topology-graph": {
-      "graph-orientation": "Orientação do gráfico",
-      "invalid": "Erro no gráfico",
-      "invalid_description": "Ocorreu um erro ao carregar o gráfico. Por favor, verifique o código-fonte para erros.",
-      "zoom-fit": "Ajustar",
-      "zoom-in": "Aumentar zoom",
-      "zoom-out": "Diminuir zoom",
-      "zoom-reset": "Redefinir zoom"
-    },
-    "total_duration": "Duração total",
-    "total_executions": "Total de Execuções",
-    "trigger": "Trigger",
-    "trigger details": "Detalhes do trigger",
-    "trigger disabled": "O Trigger está desativado na fonte do Flow",
-    "trigger execution id": "Trigger Execution Id",
-    "trigger filter": {
-      "options": {
-        "ALL": "Todas as Execuções",
-        "CHILD": "Execuções Filhas",
-        "MAIN": "Execuções Pais"
+    "accept": "Aceitar",
+    "reject": "Rejeitar",
+    "draft_available": "Alteração de rascunho disponível no editor",
+    "last modified": "Última modificação",
+    "run task in playground": "Executar task no playground",
+    "task is running": "A task está RUNNING",
+    "task was successful": "A tarefa foi bem-sucedida",
+    "task failed": "Tarefa falhou",
+    "task was skipped": "A tarefa foi ignorada",
+    "task sent a warning": "A tarefa enviou um WARNING",
+    "defaultsToNamespaceFile": "Padrões para arquivo de namespace: <code>{name}</code>",
+    "no_file_choosen": "Nenhum arquivo selecionado",
+    "dependency": {
+      "controls": {
+        "zoom_in": "Aumentar",
+        "zoom_out": "Reduzir zoom",
+        "clear_selection": "Limpar seleção",
+        "fit_view": "Ajustar à tela"
       },
-      "title": "Filtrar execuções filhas"
-    },
-    "trigger refresh": "Atualizar trigger",
-    "triggerId": "ID do Trigger",
-    "trigger_check_warning": "Usar variáveis de trigger não funcionará com a execução manual de flow. Adicione o operador de coalescência `??` para resolver o problema. Por exemplo, em vez de `trigger.date`, use `trigger.date ?? execution.startDate`.",
-    "trigger_id_exists": "Id de Trigger já existe",
-    "trigger_id_message": "O Trigger Id ${existingTrigger} já existe no flow.",
-    "trigger_states": "Estados",
-    "triggered": "Trigger de execução",
-    "triggered done": "Execução <em>{name}</em> foi acionada com sucesso",
-    "triggerflow disabled": "Trigger está desativado na definição do flow",
-    "triggers": "Triggers",
-    "triggers_add_card_add": "Adicionar",
-    "triggers_add_card_add_to_flow": "Adicionar ao flow",
-    "triggers_add_category_empty": "Sem triggers nesta categoria.",
-    "triggers_add_ee_tooltip": "Este trigger requer a Enterprise Edition.",
-    "triggers_add_empty_title": "Nenhum trigger encontrado",
-    "triggers_add_filter_all": "Todos",
-    "triggers_add_filter_app": "Aplicativo",
-    "triggers_add_filter_core": "Núcleo",
-    "triggers_add_filter_realtime": "Tempo real",
-    "triggers_add_modal_add_button": "Adicionar Trigger ao Flow",
-    "triggers_add_modal_ee_notice": "Este trigger requer a Enterprise Edition.",
-    "triggers_add_modal_flow_placeholder": "Selecione um flow",
-    "triggers_add_modal_namespace_placeholder": "Selecione um namespace",
-    "triggers_add_modal_properties_hint": "Configure as propriedades do trigger no editor de flow após adicionar o trigger.",
-    "triggers_add_modal_tab_documentation": "Documentação",
-    "triggers_add_modal_tab_form": "Formulário",
-    "triggers_add_modal_tab_source": "Fonte",
-    "triggers_add_modal_title": "{name}",
-    "triggers_add_modal_trigger_id": "ID do Trigger",
-    "triggers_add_modal_trigger_id_placeholder": "Identificador único para este trigger",
-    "triggers_add_search_placeholder": "Procurar triggers...",
-    "triggers_header_description": "Navegue, adicione e gerencie triggers para automatizar seus flows. Escolha entre expor seu flow como uma ferramenta de IA, agendar, adicionar um webhook trigger, verificar mudanças em aplicativos externos ou ouvintes de eventos em tempo real.",
-    "triggers_state": {
-      "options": {
-        "disabled": "Desativado",
-        "enabled": "Ativado"
-      },
-      "state": "Estado"
-    },
-    "triggers_tabs_add": "Adicionar",
-    "triggers_tabs_manage": "Gerenciar",
-    "true": "Verdadeiro",
-    "type": "Tipo",
-    "unable to generate graph": "Ocorreu um problema ao gerar o gráfico, o que impede a exibição da topologia.",
-    "undefined": "Indefinido",
-    "unlock": "Desbloquear",
-    "unlock trigger": {
-      "button": "Desbloquear trigger",
-      "confirmation": "Tem certeza de que deseja desbloquear o trigger?",
-      "success": "Trigger desbloqueado",
-      "tooltip": {
-        "evaluation": "O trigger está atualmente em avaliação",
-        "execution": "Há uma execução em andamento para este trigger"
-      },
-      "warning": "Isso pode levar a execuções concorrentes para o mesmo trigger e deve ser considerado como uma última opção."
-    },
-    "unqueue": "Desenfileirar",
-    "unqueue as": "Desenfileirar como <code>{status}</code>",
-    "unqueue confirm": "Tem certeza de que deseja desagendar a execução <code>{id}</code>?",
-    "unqueue done": "A execução está fora da fila",
-    "unqueue title": "Desenfileirar execução <code>{id}</code>.<br/>Observe que isso não obedecerá ao limite de concorrência do flow, portanto, mais execuções podem estar em execução do que o limite permitido.",
-    "unqueue title multiple": "Tem certeza de que deseja Desenfileirar <code>{count}</code> execuções?<br/><br/>Observe que isso não obedecerá ao limite de concorrência do flow, portanto, mais execuções podem estar em execução do que o limite permitido.",
-    "unsaved changed ?": "Você tem alterações não salvas, deseja sair desta página?",
-    "unsaved changes": "Alterações Não Salvas",
-    "unsaved changes warning": "Você tem alterações não salvas. Se você sair desta página, suas alterações serão perdidas.",
-    "up trend": "Aumentando",
-    "update": "Atualizar",
-    "update aborted": "atualização abortada",
-    "update ok": "está atualizado",
-    "updated date": "Data de atualização",
-    "usage": "Uso",
-    "use": "Usar",
-    "use_dark_background": "Use esta versão ao trabalhar em um fundo escuro para garantir que nosso nome permaneça legível.",
-    "valid": "Válido",
-    "validate": "Validar",
-    "value": "Value",
-    "variable_explorer": {
-      "empty": "Não há variáveis disponíveis para esta execução.",
-      "n_items": "[ {count} itens ]",
-      "n_keys": "\\{ {count} keys \\}",
-      "one_item": "[ 1 item ]",
-      "one_key": "\\{ 1 key \\}",
-      "raw_json": "Raw JSON",
-      "search_placeholder": "Pesquisar Key ou value...",
-      "select_prompt": "Selecione uma variável para inspecionar o seu value.",
-      "tasks_outputs": "Tasks outputs",
-      "title": "Entrada/Saída",
-      "tree": "Árvore"
-    },
-    "variables": "Variáveis",
-    "version": "Versão",
-    "view metrics": "Ver métricas",
-    "warning": "Aviso",
-    "warning detected": "Aviso(s) detectado(s)",
-    "warning flow with triggers": "Este flow contém triggers e uma execução manual falhará se este flow depender de expressões de trigger.",
-    "watch": "Assistir",
-    "watch_video": "Assistir Vídeo",
-    "webhook": {
-      "copy_url": "Copiar URL do webhook",
-      "curl_command": "Comando cURL do Webhook",
-      "curl_note": "Use este comando cURL para acionar o flow via webhook com carga útil JSON personalizada",
-      "no_triggers": "Este flow não possui triggers de webhook habilitados",
-      "payload": "Payload do Webhook (JSON)"
-    },
-    "webhook link copied": "Link do Webhook copiado.",
-    "welcome": {
-      "help": {
-        "text": "Faça qualquer pergunta em nossa comunidade no Slack. Se você estiver com dificuldades, estamos aqui para ajudar você. ✋",
-        "title": "Precisa de ajuda?"
-      },
-      "menu": "Welcome",
-      "tour": {
-        "text": "Escolha seu caso de uso e siga um guia passo a passo para aprender os recursos e capacidades do Kestra. ❤️",
-        "title": "Faça um tour pelo produto"
-      },
-      "tutorial": {
-        "text": "* <a href=\"https://kestra.io/tutorial-videos/all?utm_source=app&utm_medium=referral&utm_campaign=welcome-tutorial\" target=\"_blank\">Tutoriais em Vídeo</a>  \n* <a href=\"https://kestra.io/docs?utm_source=app&utm_medium=referral&utm_campaign=welcome-tutorial\" target=\"_blank\">Documentação</a>  \n* <a href=\"https://kestra.io/blueprints?utm_source=app&utm_medium=referral&utm_campaign=welcome-tutorial\" target=\"_blank\">Blueprints</a>",
-        "title": "Tutorial"
+      "search": {
+        "placeholders": {
+          "default": "Pesquisar por flow ou namespace...",
+          "asset": "Pesquisar por asset, flow ou namespace..."
+        },
+        "namespace": {
+          "select": "Selecione um namespace",
+          "no_namespace": "Sem namespace"
+        },
+        "flow": {
+          "display": "Incluir dependências do flow"
+        },
+        "no_results": "Nenhum resultado encontrado para {term}"
       }
     },
+    "preview": {
+      "label": "Visualizar",
+      "force-editor": "Forçar visualização do editor",
+      "auto-view": "Visualização automática",
+      "view": "Visualizar",
+      "rows_truncated": "Mostrando {shown} de {total} linhas. Baixe o arquivo para ver todos os dados.",
+      "pagination_info": "Exibindo linhas {start}-{end} de {total}.",
+      "showing_rows": "Mostrando linhas {start}-{end} de {total}",
+      "expand": "Expandir",
+      "collapse": "Recolher",
+      "previous": "Anterior",
+      "next": "Próximo",
+      "page_of": "Página {current} de {total}"
+    },
+    "delete trigger": "Excluir trigger",
+    "delete triggers": "Excluir triggers",
+    "bulk delete triggers": "Tem certeza de que deseja excluir {count} triggers?",
+    "bulk success delete triggers": "{count} triggers foram excluídos com sucesso",
+    "delete trigger confirmation": "Tem certeza de que deseja excluir o trigger {id}? WARNING: excluir um trigger pode levar a execuções duplicadas se o trigger ainda estiver ativo em um flow.",
+    "delete trigger success": "O Trigger {id} foi excluído com sucesso",
+    "delete trigger error": "Erro ao excluir trigger {id}",
+    "revision deleted": "A revisão {revision} foi excluída com sucesso",
+    "delete revision confirm": "Tem certeza de que deseja excluir a revisão {revision}?",
+    "delete revision error": "Erro ao excluir a revisão {revision} com erro {error}",
+    "no_history": "Sem histórico disponível",
+    "export_as": "Exportar como .{format}",
+    "save_and_execute": "Salvar e Executar",
     "welcome_copilot": {
       "button_cta": "Criar flow do zero",
       "create_manually": {
-        "description": "Construa do zero usando o editor",
-        "title": "Criar manualmente"
+        "title": "Criar manualmente",
+        "description": "Construa do zero usando o editor"
       },
       "docs": {
-        "description": "Saiba mais na documentação oficial",
-        "title": "Leia a documentação"
+        "title": "Leia a documentação",
+        "description": "Saiba mais na documentação oficial"
       },
+      "title": "Transforme sua ideia em um workflow",
+      "need_help": "Precisa de Ajuda?",
+      "placeholder_prompt": "Envie-me uma mensagem de saudação diária às 9h.",
+      "show_more": "Mostrar mais prompts",
+      "show_less": "Mostrar menos prompts",
+      "remaining_quota": "Você tem {count} gerações de IA restantes. O limite é redefinido diariamente à meia-noite UTC.",
       "execute_hint": {
-        "description": "Clique para salvar seu workflow e executá-lo imediatamente.",
-        "title": "Salvar & Executar seu flow"
+        "title": "Salvar & Executar seu flow",
+        "description": "Clique para salvar seu workflow e executá-lo imediatamente."
+      },
+      "success_popup": {
+        "title": "Parabéns!",
+        "description": "Você executou com sucesso seu primeiro flow! Você está a caminho de se tornar um especialista em Kestra.",
+        "tutorial": "Tutorial de Imersão",
+        "explore": "Explore Mais"
+      },
+      "success_page": {
+        "title": "Tudo pronto!",
+        "description": "Você aprendeu o básico do Kestra. Aqui estão alguns recursos para ajudar você a continuar sua jornada.",
+        "restart": "Reiniciar Tutorial",
+        "items": {
+          "tutorial": {
+            "title": "Iniciar um Tutorial",
+            "description": "Passeio interativo por todos os recursos do Kestra"
+          },
+          "blueprints": {
+            "title": "Blueprints",
+            "description": "Modelos de workflow pré-construídos para casos de uso comuns"
+          },
+          "slack": {
+            "title": "Comunidade Slack",
+            "description": "Conecte-se com outros usuários e obtenha ajuda da comunidade"
+          },
+          "videos": {
+            "title": "Tutoriais em Vídeo",
+            "description": "Guias em vídeo passo a passo para recursos avançados"
+          },
+          "demo": {
+            "title": "Solicitar uma Demonstração",
+            "description": "Explore o Kestra Enterprise Edition com uma demonstração personalizada"
+          }
+        }
+      },
+      "help": {
+        "tutorial": {
+          "title": "Iniciar um Tutorial",
+          "description": "Aprenda a criar e executar seu primeiro flow com etapas guiadas."
+        },
+        "blueprints": {
+          "title": "Blueprints",
+          "description": "Explore exemplos e templates prontos para padrões comuns de workflow."
+        },
+        "slack": {
+          "title": "Comunidade Slack",
+          "description": "Junte-se a nós para compartilhar ideias e melhores práticas, e obter ajuda com questões técnicas."
+        }
       },
       "flows": {
-        "buildDbtPipeline": {
-          "label": "Crie um pipeline dbt",
-          "prompt": "Crie um flow do Kestra que clona um repositório de projeto dbt e executa dbt build com um perfil DuckDB."
-        },
-        "buildDockerImageAndRunIt": {
-          "label": "Crie uma imagem Docker e execute-a",
-          "prompt": "Crie um flow do Kestra que construa uma imagem Docker a partir de um Dockerfile inline e execute o container resultante."
-        },
-        "convertCsvToExcel": {
-          "label": "Converter um CSV para Excel",
-          "prompt": "Crie um flow que faça o download de um arquivo CSV, converta-o para Ion e exporte o resultado como um arquivo Excel."
-        },
-        "etlWorkflow": {
-          "label": "Fluxo de Trabalho ETL",
-          "prompt": "Crie um flow ETL que faça o download de dados JSON, processe-os com Python e consulte o resultado transformado com DuckDB."
+        "jsonApiToDuckdb": {
+          "label": "API JSON para DuckDB",
+          "prompt": "Crie um flow que baixe um arquivo JSON de uma API pública, transforme-o com um script Python e processe-o com uma task DuckDB Queries."
         },
         "installNginxViaAnsible": {
           "label": "Instalar Nginx via Ansible",
           "prompt": "Crie um flow do Kestra que instala o Nginx em uma máquina alvo com Ansible e verifica a versão instalada."
         },
-        "jsonApiToDuckdb": {
-          "label": "API JSON para DuckDB",
-          "prompt": "Crie um flow que baixe um arquivo JSON de uma API pública, transforme-o com um script Python e processe-o com uma task DuckDB Queries."
+        "buildDbtPipeline": {
+          "label": "Crie um pipeline dbt",
+          "prompt": "Crie um flow do Kestra que clona um repositório de projeto dbt e executa dbt build com um perfil DuckDB."
+        },
+        "etlWorkflow": {
+          "label": "Fluxo de Trabalho ETL",
+          "prompt": "Crie um flow ETL que faça o download de dados JSON, processe-os com Python e consulte o resultado transformado com DuckDB."
+        },
+        "microservicesApis": {
+          "label": "Microservices & APIs",
+          "prompt": "Crie um flow que verifica a resposta da API de um site e envia um alerta no Slack quando o código de status não for bem-sucedido."
+        },
+        "buildDockerImageAndRunIt": {
+          "label": "Crie uma imagem Docker e execute-a",
+          "prompt": "Crie um flow do Kestra que construa uma imagem Docker a partir de um Dockerfile inline e execute o container resultante."
         },
         "manualApproval": {
           "label": "Aprovação manual",
           "prompt": "Crie um flow com uma etapa inicial de processamento, uma pausa para aprovação manual e uma etapa final de implantação após a aprovação."
         },
-        "microservicesApis": {
-          "label": "Microservices & APIs",
-          "prompt": "Crie um flow que verifica a resposta da API de um site e envia um alerta no Slack quando o código de status não for bem-sucedido."
+        "convertCsvToExcel": {
+          "label": "Converter um CSV para Excel",
+          "prompt": "Crie um flow que faça o download de um arquivo CSV, converta-o para Ion e exporte o resultado como um arquivo Excel."
         },
         "scheduledPdfReports": {
           "label": "Relatórios PDF agendados",
@@ -2232,73 +2189,116 @@
           "label": "KPIs de Vendas Semanais para Slack",
           "prompt": "Crie um flow agendado semanalmente que calcula KPIs de vendas com DuckDB e publica o resumo no Slack."
         }
-      },
-      "help": {
-        "blueprints": {
-          "description": "Explore exemplos e templates prontos para padrões comuns de workflow.",
-          "title": "Blueprints"
-        },
-        "slack": {
-          "description": "Junte-se a nós para compartilhar ideias e melhores práticas, e obter ajuda com questões técnicas.",
-          "title": "Comunidade Slack"
-        },
-        "tutorial": {
-          "description": "Aprenda a criar e executar seu primeiro flow com etapas guiadas.",
-          "title": "Iniciar um Tutorial"
-        }
-      },
-      "need_help": "Precisa de Ajuda?",
-      "placeholder_prompt": "Envie-me uma mensagem de saudação diária às 9h.",
-      "remaining_quota": "Você tem {count} gerações de IA restantes. O limite é redefinido diariamente à meia-noite UTC.",
-      "show_less": "Mostrar menos prompts",
-      "show_more": "Mostrar mais prompts",
-      "success_page": {
-        "description": "Você aprendeu o básico do Kestra. Aqui estão alguns recursos para ajudar você a continuar sua jornada.",
-        "items": {
-          "blueprints": {
-            "description": "Modelos de workflow pré-construídos para casos de uso comuns",
-            "title": "Blueprints"
-          },
-          "demo": {
-            "description": "Explore o Kestra Enterprise Edition com uma demonstração personalizada",
-            "title": "Solicitar uma Demonstração"
-          },
-          "slack": {
-            "description": "Conecte-se com outros usuários e obtenha ajuda da comunidade",
-            "title": "Comunidade Slack"
-          },
-          "tutorial": {
-            "description": "Passeio interativo por todos os recursos do Kestra",
-            "title": "Iniciar um Tutorial"
-          },
-          "videos": {
-            "description": "Guias em vídeo passo a passo para recursos avançados",
-            "title": "Tutoriais em Vídeo"
-          }
-        },
-        "restart": "Reiniciar Tutorial",
-        "title": "Tudo pronto!"
-      },
-      "success_popup": {
-        "description": "Você executou com sucesso seu primeiro flow! Você está a caminho de se tornar um especialista em Kestra.",
-        "explore": "Explore Mais",
-        "title": "Parabéns!",
-        "tutorial": "Tutorial de Imersão"
-      },
-      "title": "Transforme sua ideia em um workflow"
+      }
     },
-    "welcome_page": {
-      "guide": "Precisa de orientação para executar seu primeiro flow?",
-      "welcome": "Bem-vindo ao Kestra"
+    "mcp": {
+      "your_servers": "Seus Servidores",
+      "servers_count": "{{count}} Servidores MCP",
+      "managed_by_kestra": "Gerenciado por Kestra",
+      "servers": "Servidores MCP",
+      "server": "Servidor MCP",
+      "client_setup": "Configuração do Cliente",
+      "page_description": "Exponha seus flows do Kestra como ferramentas para agentes de IA compatíveis com MCP",
+      "create": "Criar Servidor",
+      "save": "Salvar Alterações",
+      "connect": "Conectar",
+      "copy_url": "Copiar URL",
+      "url_copied": "URL copiado!",
+      "instructions": "Instruções",
+      "server_type": "Tipo de Servidor",
+      "auth_type": "Autenticação",
+      "private": "Privado",
+      "private_server": "Servidor privado",
+      "public": "Público",
+      "public_hint": "Aviso: Servidores públicos não exigem autenticação. Qualquer pessoa com o URL pode chamar todas as ferramentas expostas por este servidor, sem verificações de namespace ou permissão. Use apenas para servidores seguros para expor externamente.",
+      "basic_auth": "Autenticação Básica",
+      "api_token": "Token da API",
+      "oauth": "OAuth",
+      "username_password": "Nome de usuário & senha",
+      "bearer_token": "Autenticação por token Bearer",
+      "oauth_hint": "Bearer JWT do seu provedor OIDC",
+      "oauth_provider": "Provedor OAuth",
+      "oauth_provider_placeholder": "Selecione um provedor OIDC configurado",
+      "oauth_provider_required": "O provedor OAuth é obrigatório quando o tipo de autenticação é OAuth",
+      "scopes_supported": "Scopes suportados",
+      "scopes_supported_placeholder": "openid, profile, email",
+      "scopes_supported_hint": "Scopes anunciados no documento Protected Resource Metadata deste servidor. Clientes MCP conformes com a especificação restringem o pedido de autorização a esta lista. Deixe vazio para omitir o campo e deixar os clientes recorrerem aos scopes anunciados pelo IdP.",
+      "no_oauth_providers": "Nenhum provedor OIDC configurado nesta instância",
+      "delete_confirm": "Tem certeza de que deseja excluir este servidor MCP?",
+      "no_servers": "Nenhum servidor MCP encontrado. Crie seu primeiro servidor para expor triggers da ferramenta MCP a agentes de IA externos.",
+      "server_id": "ID do servidor",
+      "id_placeholder": "por exemplo, my-mcp-server",
+      "id_invalid": "O ID deve começar com uma letra minúscula ou dígito, e conter apenas letras minúsculas, dígitos, hífens ou underscores",
+      "main_tenant": "principal",
+      "tab_edit": "Editar",
+      "tab_connect": "Conectar",
+      "tab_tool_flows": "Fluxos de Ferramentas",
+      "tab_tool_flows_placeholder": "O gerenciamento de flows de ferramentas estará disponível em breve.",
+      "tools": {
+        "no_tools": "Nenhum flow de ferramenta corresponde à sua pesquisa.",
+        "create_tool_flow": "Criar um flow de ferramenta",
+        "tool_name": "Nome da ferramenta",
+        "trigger_id": "ID do trigger",
+        "title": "Título",
+        "description": "Descrição",
+        "annotations": "Anotações",
+        "flow": "flow",
+        "state": "Estado",
+        "read_only": "Somente leitura",
+        "open_world": "Open world",
+        "destructive": "Destrutivo",
+        "idempotent": "Idempotente",
+        "return_direct": "Retorno direto",
+        "view_flow": "Abrir flow"
+      },
+      "connect_tab": {
+        "server_url": "URL do Servidor",
+        "client_picker_label": "Escolha o seu cliente de IA",
+        "claude_desktop": "Claude Desktop",
+        "claude_desktop_hint": "Adicione o seguinte ao seu arquivo claude_desktop_config.json:",
+        "claude_desktop_mac": "macOS: ~/Library/Application Support/Claude/claude_desktop_config.json",
+        "claude_desktop_win": "Windows: %APPDATA%\\Claude\\claude_desktop_config.json",
+        "claude_code": "Claude Code",
+        "claude_code_hint": "Execute o seguinte comando no seu terminal:",
+        "cursor": "Cursor",
+        "cursor_hint": "Adicione o seguinte a ~/.cursor/mcp.json:",
+        "codex": "Codex (OpenAI)",
+        "codex_hint": "Adicione o seguinte à sua configuração MCP no codex.json:",
+        "auth_basic_hint": "Defina <code>KESTRA_BASIC_AUTH</code> como uma variável de ambiente contendo uma string <code>username:password</code> codificada em base64 antes de iniciar o cliente.",
+        "auth_api_token_hint": "Defina <code>KESTRA_TOKEN</code> como uma variável de ambiente antes de iniciar o cliente.",
+        "auth_oauth_client_id_hint": "Substitua <code>&lt;client-id&gt;</code> pelo ID de cliente OAuth e registe <code>http://localhost:7777</code> como URI de redirecionamento válido nesse cliente.",
+        "auth_oauth_browser_hint": "O seu navegador abrirá a página de login do fornecedor de identidade na primeira ligação."
+      }
     },
-    "wordmark_colors": "As cores da marca adaptam-se com base no fundo, enquanto o ícone permanece sem fundo quando colocado em um fundo escuro.",
-    "worker group": "Grupo de Workers",
-    "worker group fallback": "Grupo de Worker de reserva",
-    "worker group key": "Grupo de Worker key",
-    "worker information": "Informações do Worker",
-    "workerId": "Worker Id",
-    "workers": "Workers",
-    "wrong labels": "Chave ou valor vazio não é permitido em labels",
-    "yes": "Sim"
+    "flow_editor_stats": {
+      "revisions": {
+        "suffix": "Revisão(ões)",
+        "tooltip": "Ver revisões do flow"
+      },
+      "dependencies": {
+        "suffix": "Dependências",
+        "tooltip": "Ver dependências do flow"
+      },
+      "apps": {
+        "suffix": "App(s)",
+        "tooltip": "Visualizar aplicativos usando este flow"
+      },
+      "tests": {
+        "suffix": "Teste(s)",
+        "tooltip": "Ver testes de flow"
+      },
+      "errors": {
+        "label": "{count} Erro(s)"
+      }
+    },
+    "source_search": {
+      "match_count": "{count} correspondência | {count} correspondências",
+      "open_flow": "Abrir flow",
+      "preview_empty": "Selecione um resultado para pré-visualizar. Clique num flow na lista de resultados para ver a sua fonte.",
+      "preview_error": "Falha ao carregar a fonte do flow"
+    },
+    "open source": "Código Aberto",
+    "pricing": "Preços",
+    "license": "Licença"
   }
 }

--- a/ui/src/translations/pt_BR.json
+++ b/ui/src/translations/pt_BR.json
@@ -1,1678 +1,722 @@
 {
   "pt_BR": {
-    "Add flow": "Adicionar flow",
-    "Default log level": "Nível de log padrão",
-    "Default namespace": "Namespace padrão",
-    "Default page": "Página padrão",
-    "Editor fontfamily": "Família de fontes do editor",
-    "Editor fontsize": "Tamanho da fonte do editor",
-    "Editor theme": "Tema do editor",
-    "Fold auto": "Editor: dobra automática de multilinhas",
-    "Fold content lines": "Dobrar strings multilinhas",
-    "Hover description": "Editor: Mostrar descrição do campo ao passar o mouse sobre o key ou value",
-    "Language": "Idioma",
-    "Per page": "por página",
-    "Set default page": "Definir página padrão",
-    "Set labels": "Definir labels",
-    "Set labels done": "Labels da execução definidos com sucesso",
-    "Set labels to execution": "Adicionar ou atualizar os labels da execução <code>{id}</code>",
-    "Set labels tooltip": "Definir labels para a execução",
-    "Task Id already exist in the flow": "Task Id {taskId} já existe no flow.",
-    "Total": "Total",
-    "Unfold content lines": "Desdobrar strings multilinhas",
-    "about_this_blueprint": "Sobre este blueprint",
-    "absolute": "Absoluto",
-    "accept": "Aceitar",
-    "actions": "Ações",
-    "activate_basic_auth": "Ativar Autenticação Básica",
-    "active": "Ativo",
-    "active-slots": "Slots ativos",
-    "actual state": "Estado atual",
-    "add": "Adicionar",
-    "add at position": "Adicionar {position} <code>{task}</code>",
-    "add error handler": "Adicionar um manipulador de erro",
-    "add flow": "Adicionar flow",
+    "loading": "Carregando...",
+    "more actions": "Mais ações",
+    "toggle menu": "Alternar menu",
+    "panel actions": "Ações do painel",
+    "playground actions": "Ações do Playground",
+    "bulk actions": "Ações em massa",
+    "view metrics": "Ver métricas",
+    "remove this item": "Remover este item",
     "add label": "Adicionar label",
-    "add task": "Adicionar uma task",
-    "add-trigger-in-editor": "Adicione um Trigger ao seu Flow primeiro",
-    "add_new_item": "Adicionar novo item",
-    "additionalPlugins": "Plugins Adicionais",
-    "admin": "Administração",
-    "admin_preferences": "Preferences",
-    "administration": "Administração",
-    "advanced configuration": "Outras propriedades",
-    "after": "depois",
-    "aggregation": "Agregação",
-    "ai": {
-      "dashboard": {
-        "prompt_placeholder": "Faça uma pergunta sobre seus dados. Exemplo de prompt: Mostre-me a taxa de sucesso dos meus flows nos últimos 7 dias."
+    "remove label": "Remover label",
+    "id": "Id",
+    "type": "Tipo",
+    "ok": "OK",
+    "valid": "Válido",
+    "close": "Fechar",
+    "namespace": "Namespace",
+    "description": "Descrição",
+    "show description": "Mostrar uma descrição",
+    "show details": "Mostrar detalhes",
+    "show more details": "Mostrar mais detalhes",
+    "skipped": "Pulado",
+    "revision": "Revisão",
+    "Language": "Idioma",
+    "Set default page": "Definir página padrão",
+    "theme": "Tema",
+    "flows": "Flows",
+    "flow": "Flow",
+    "invalid source": "Código fonte inválido",
+    "missingSource": "Fonte ausente",
+    "update": "Atualizar",
+    "update ok": "está atualizado",
+    "delete ok": "está deletado",
+    "Default page": "Página padrão",
+    "confirmation": "Confirmação",
+    "common": {
+      "back": "Voltar"
+    },
+    "delete confirm": "Tem certeza de que deseja excluir <code>{name}</code>?",
+    "outdated revision save confirmation": {
+      "confirm": "Deseja sobrescrever?",
+      "update": {
+        "title": "Revisão desatualizada",
+        "description": "A revisão que você está editando está desatualizada.",
+        "details": "Verifique a aba de Revisões para mais detalhes sobre a última versão."
       },
-      "flow": {
-        "enable_instructions": {
-          "footer": "Nota: Neste momento, apenas o Gemini é suportado como provedor de IA para a Open Source Edition. Para a Enterprise Edition, consulte a documentação do AI Copilot para a configuração de outros provedores de modelo.\n\nReinicie sua instância do Kestra após salvar a configuração.",
-          "header": "<b>AI Copilot ainda não foi configurado.</b>\n\nPara habilitar o AI Copilot, adicione o seguinte trecho ao arquivo de configuração da sua instância Kestra (por exemplo, <code>application.yml</code>), substituindo <code>geminiApiKey</code> pela sua chave real:"
-        },
-        "generating": {
-          "app": "Gerando YAML do App para você...",
-          "dashboard": "Gerando YAML do Dashboard para você...",
-          "flow": "Gerando YAML do flow para você...",
-          "test": "Gerando YAML de teste para você..."
-        },
-        "prompt_placeholder": "Insira instruções para criar seu flow Kestra. Exemplo de prompt: Crie um flow que execute toda segunda-feira às 9h.",
-        "select_provider": "Selecionar um provedor",
-        "title": "Agente de IA"
+      "create": {
+        "title": "Flow já existe",
+        "description": "Um flow com o mesmo id já existe neste namespace.",
+        "details": "Salvar para substituir e criar uma nova revisão."
       }
     },
-    "all executions": "Todas as execuções",
-    "all tags": "Todas as tags",
-    "api": "API",
-    "appBlocks": "Blocos do App",
-    "apps": "Aplicativos",
-    "are you sure change state": "Tem certeza de que deseja alterar o estado?",
-    "assets": {
-      "title": "Ativos"
+    "override": {
+      "title": "Você está prestes a sobrescrever o flow atual",
+      "details": "O flow anterior pode ser restaurado na aba Revisions."
     },
-    "attempt": "Tentativa",
-    "attempts": "Tentativa(s)",
-    "auditlogs": "Audit Logs",
-    "automatic refresh": "Atualização automática",
-    "avg": "Média",
-    "avg duration": "Duração média da execução",
+    "is deprecated": "está obsoleto",
+    "success": "Sucesso",
+    "save": "Salvar",
+    "save_as_draft": "Salvar como rascunho",
+    "draft": "Rascunho",
+    "draft_flow_warning": "Esta revisão do flow é um rascunho. A execução será feita nesta revisão de rascunho e pode falhar imediatamente se a definição do flow for inválida.",
+    "save task": "Salvar Task",
+    "saved": "Salvo com sucesso",
+    "saved as draft": "Salvo como rascunho com sucesso",
+    "saved done": "<em>{name}</em> foi salvo com sucesso",
+    "saved as draft done": "<em>{name}</em> foi salvo com sucesso como rascunho",
+    "multiple saved done": "{name} foi salvo",
+    "fileTypeNotAllowed": "Tipo de arquivo não permitido. Tipos aceitos: {types}",
+    "delete": "Excluir",
+    "deleted": "Deletado com sucesso",
+    "deleted confirm": "<em>{name}</em> foi deletado com sucesso!",
+    "Add flow": "Adicionar flow",
+    "add": "Adicionar",
+    "add_new_item": "Adicionar novo item",
+    "copy": "Copiar",
+    "copy_to_clipboard": "Copiar para a área de transferência",
+    "copy_and_close": "Copiar e fechar",
+    "Per page": "por página",
+    "new": "Novo",
+    "edit": "Editar",
     "back": "Voltar",
-    "back_to_dashboard": "Voltar ao dashboard",
-    "backfill": "Backfill",
-    "backfill executions": "Execuções de backfill",
-    "backfill paused": "Preenchimento retroativo pausado",
-    "backfill running": "Backfill em execução",
-    "bar": "Bar",
-    "before": "antes",
-    "behavior": "Comportamento",
-    "blueprints": {
-      "all": "Todos",
-      "apps": "Blueprints do Aplicativo",
-      "community": "Comunidade",
-      "create": "Criar um blueprint",
-      "custom": "Blueprints personalizados",
-      "dashboards": "Blueprints do Dashboard",
-      "detail": {
-        "category": "Tipo de categoria",
-        "links": "Link & Recursos",
-        "openInEditor": "Abrir em Edit Flow"
-      },
-      "edit": "Editar um blueprint",
-      "empty": "Nenhum blueprint para mostrar.",
-      "flows": "Blueprints de Flow",
-      "header": {
-        "alt": "Ícone de Blueprints",
-        "catch phrase": {
-          "1": "O primeiro passo é sempre o mais difícil.",
-          "2": "Explore blueprints para iniciar seu próximo {kind}."
-        }
-      },
-      "missingPlugins": {
-        "card": "Requer plugin(s) não instalados nesta instância: {plugins}",
-        "description": "Este blueprint usa tasks de plugin(s) que não estão instalados nesta instância: {plugins}. Instale-os para usar este blueprint.",
-        "install": "Instalar plugins",
-        "title": "Plugins ausentes"
-      },
-      "title": "Blueprints"
+    "next": "Próximo",
+    "done": "Concluído",
+    "review your inputs": "Revise suas entradas",
+    "edit flow": "Editar flow",
+    "executions": "Execuções",
+    "execution": "Execução",
+    "execution id": "Id de Execução",
+    "recent_executions": "Execuções Recentes",
+    "details": "Detalhes",
+    "overview": "Visão geral",
+    "gantt": "Gantt",
+    "gantt_no_tasks_executed": "Esta execução terminou sem executar nenhuma task.  \nVerifique sua visão geral e logs para encontrar o motivo.",
+    "gantt_no_tasks_match_filters": "Tente ajustar os filtros de busca, estado ou nível de log.",
+    "gantt_no_tasks_match_filters_title": "Nenhuma task corresponde aos filtros selecionados.",
+    "logs": "Logs",
+    "no_logs_data": "Sem Dados",
+    "no_logs_data_description": "Tente ajustar seus filtros, alterar o intervalo de tempo ou verificar se o flow foi executado recentemente.",
+    "no_logs_data_title": "Nenhum log encontrado para os filtros selecionados.",
+    "duration": "Duração",
+    "total_duration": "Duração total",
+    "running duration": "Duração em execução",
+    "queued duration": "Duração na fila",
+    "choose file": "Escolha um arquivo ou solte-o aqui...",
+    "launch execution": "Executar",
+    "warning flow with triggers": "Este flow contém triggers e uma execução manual falhará se este flow depender de expressões de trigger.",
+    "triggered": "Trigger de execução",
+    "triggered done": "Execução <em>{name}</em> foi acionada com sucesso",
+    "topology": "Topologia",
+    "date": "Data",
+    "prev_execution": "Execução anterior",
+    "next_execution": "Próxima execução",
+    "datepicker": {
+      "leave empty for infinite": "Deixe vazio para duração infinita ou digite uma duração ISO 8601 (exemplo: 'P1DT1H1M1S)'",
+      "duration example": "Exemplo: 'P1DT1H1M1S'",
+      "error": "Formato de duração inválido, deve ser uma duração ISO 8601 (P1DT1H1M1S por ex.)",
+      "custom": "Personalizado",
+      "last5minutes": "Últimos 5 minutos",
+      "last15minutes": "Últimos 15 minutos",
+      "last1hour": "Última 1 hora",
+      "last12hours": "Últimas 12 horas",
+      "last24hours": "Últimas 24 horas",
+      "last48hours": "Últimas 48 horas",
+      "last7days": "Últimos 7 dias",
+      "last30days": "Últimos 30 dias",
+      "last365days": "Últimos 365 dias",
+      "next5minutes": "Próximos 5 minutos",
+      "next15minutes": "Próximos 15 minutos",
+      "next1hour": "Próxima 1 hora",
+      "next12hours": "Próximas 12 horas",
+      "next24hours": "Próximas 24 horas",
+      "next48hours": "Próximas 48 horas",
+      "next7days": "Próximos 7 dias",
+      "next30days": "Próximos 30 dias",
+      "next365days": "Próximos 365 dias",
+      "5minutes": "5 minutos",
+      "15minutes": "15 minutos",
+      "1hour": "1 hora",
+      "12hours": "12 horas",
+      "24hours": "24 horas",
+      "48hours": "48 horas",
+      "7days": "7 dias",
+      "30days": "30 dias",
+      "365days": "365 dias",
+      "never": "Nunca",
+      "today": "Hoje",
+      "yesterday": "Ontem",
+      "dayBeforeYesterday": "Anteontem",
+      "thisWeek": "Esta semana",
+      "thisWeekSoFar": "Esta semana até agora",
+      "previousWeek": "Semana anterior",
+      "thisMonth": "Este mês",
+      "thisMonthSoFar": "Este mês até agora",
+      "previousMonth": "Mês anterior",
+      "thisYear": "Este ano",
+      "thisYearSoFar": "Este ano até agora",
+      "previousYear": "Ano anterior",
+      "short": {
+        "15m": "15min",
+        "1h": "1h",
+        "12h": "12h",
+        "1d": "1d",
+        "7d": "7d"
+      }
     },
-    "body_line_clamp": "Limit line height",
-    "bookmark": "Favoritos",
-    "breakpoints": "Pontos de interrupção",
-    "bulk action async warning": "Isso pode levar alguns instantes.",
-    "bulk actions": "Ações em massa",
-    "bulk change state": "Tem certeza de que deseja alterar o estado de <code>{executionCount}</code> execução(ões)?",
-    "bulk delete": "Tem certeza de que deseja excluir <code>{executionCount}</code> execução(ões)?",
-    "bulk delete backfills": "Excluir {count} backfill",
-    "bulk delete triggers": "Tem certeza de que deseja excluir {count} triggers?",
-    "bulk disabled status": {
-      "false": "Ativar {count} triggers",
-      "true": "Desativar {count} triggers"
+    "created date": "Data de criação",
+    "latest_update": "Última atualização",
+    "updated date": "Data de atualização",
+    "expiration date": "Data de expiração",
+    "started date": "Data de início",
+    "healthcheck date": "Data do HealthCheck",
+    "next execution date": "Próxima data de execução",
+    "last execution status": "Último status de execução",
+    "jump to...": "Ir para...",
+    "contextBar": {
+      "news": "Notícias",
+      "docs": "Documentos",
+      "help": "Ajuda",
+      "issue": "Problema",
+      "demo": "Demonstração",
+      "star": "Nos avalie com uma estrela"
     },
-    "bulk force run": "Tem certeza de que deseja forçar a execução de <code>{executionCount}</code> execução(ões)?<br/><br/>AVISO: forçar a execução de uma execução não é garantido e pode criar execuções de tarefas duplicadas.<br/><br/>As seguintes transições serão realizadas:<br/><ul><li>Tarefas CREATED serão movidas para o estado RUNNING.</li><li>Tarefas RUNNING serão re-submetidas.</li><li>Tarefas QUEUED serão removidas da fila.</li><li>Tarefas PAUSED serão retomadas.</li></ul>",
-    "bulk kill": "Tem certeza de que deseja matar <code>{executionCount}</code> execução(ões)?",
-    "bulk pause": "Tem certeza de que deseja pausar a(s) execução(ões) <code>{executionCount}</code>?",
-    "bulk pause backfills": "Pausar {count} backfill",
-    "bulk replay": "Tem certeza de que deseja reproduzir <code>{executionCount}</code> execução(ões)?",
-    "bulk restart": "Tem certeza de que deseja reiniciar <code>{executionCount}</code> execução(ões)?",
-    "bulk resume": "Tem certeza de que deseja retomar <code>{executionCount}</code> execução(ões)?",
-    "bulk set labels": "Tem certeza de que deseja definir labels para <code>{executionCount}</code> execução(ões)?",
-    "bulk success delete backfills": "{count} backfills excluídos",
-    "bulk success delete triggers": "{count} triggers foram excluídos com sucesso",
-    "bulk success disabled status": {
-      "false": "{count} trigger(s) ativado(s)",
-      "true": "{count} trigger(s) desativado(s)"
+    "source": "Fonte",
+    "source only": "Somente fonte",
+    "home": "Início",
+    "create": "Criar",
+    "create_flow": "Criar Flow",
+    "add flow": "Adicionar flow",
+    "from": "De",
+    "to": "Para",
+    "search filters": {
+      "saved": "Filtros salvos",
+      "manage": "Gerenciar filtros de busca",
+      "manage desc": "Gerenciar filtros de busca salvos",
+      "save filter": "Salvar filtro",
+      "filter name": "Nome do filtro",
+      "filters": "Filtros"
     },
-    "bulk success pause backfills": "{count} backfills pausados",
-    "bulk success unlock": "{count} triggers desbloqueados",
-    "bulk success unpause backfills": "{count} backfills despausados",
-    "bulk unlock": "Desbloquear {count} triggers",
-    "bulk unpause backfills": "Despausar {count} backfill",
-    "bulk unqueue": "Tem certeza de que deseja remover da fila <code>{executionCount}</code> execução(ões)?",
-    "can not delete": "Não pode excluir",
-    "can not have less than 1 task": "Cada flow deve ter pelo menos uma task.",
-    "can not save": "Não pode salvar",
-    "cancel": "Cancelar",
+    "steps": "Passos",
+    "state": "Estado",
+    "state_history": "Histórico de estado",
+    "search term in message": "Termo de busca na mensagem",
+    "search": "Buscar",
+    "search blueprint": "Buscar blueprints",
+    "all tags": "Todas as tags",
+    "source search": "Busca de fonte",
+    "filter by log level": "Filtrar por nível de log",
+    "selected": "Selecionado",
+    "task": "Task",
+    "task logs": "Task logs",
+    "display flow {id} executions": "Exibir execuções do flow {id}",
+    "actions": "Ações",
+    "select datetime": "Selecione uma data",
+    "select view": "Selecionar visualização",
+    "invalid field": "Campo inválido: {name}",
+    "required field": "Campo obrigatório",
+    "is required": "{field} é obrigatório",
+    "error": "Erro",
+    "form": "Formulário",
+    "form error": "Erro no formulário",
+    "display topology for flow": "Exibir topologia do flow",
     "cannot create topology": "Não foi possível criar topologia para o flow",
-    "cannot swap tasks": "Não é possível trocar as tasks",
-    "change execution state confirm": "Tem certeza de que deseja alterar o estado da execução <code>{id}</code>?",
-    "change execution state done": "Estado de execução atualizado",
-    "change queue confirm": "Tem certeza de que deseja alterar o estado da fila para a execução <code>{id}</code>?<br/>",
+    "start date": "Data de início",
+    "end date": "Data de término",
+    "creation": "Criação",
+    "flow creation": "Criação de flow",
+    "start datetime": "Data e hora de início",
+    "end datetime": "Data e hora de término",
+    "restart": "Reiniciar",
+    "restart latest revision": "Reiniciar última revisão",
+    "restart tooltip": "Reiniciar a execução a partir da task <code>{state}</code>",
+    "restarted": "A execução foi reiniciada",
+    "restart confirm": "Tem certeza de que deseja reiniciar a execução <code>{id}</code>?",
+    "restart change revision": "Você pode alterar a revisão que será usada para a nova execução.",
+    "replay": "Repetir",
+    "replay from task tooltip": "Criar uma execução similar começando da task <code>{taskId}</code>",
+    "replay from beginning tooltip": "Criar uma execução similar começando do início",
+    "replay latest revision": "Repetir usando a última revisão",
+    "replayed": "A execução é Reexecutada",
+    "replay confirm": "Tem certeza de que deseja repetir esta execução <code>{id}</code> e criar uma nova?",
+    "replay with inputs": "Repetir com inputs",
+    "reuse_original_inputs": "Reutilizar inputs originais",
+    "modify_inputs": "Modificar inputs",
+    "replay the execution": "Reproduzir a execução <code>{executionId}</code> para o flow <code>{flowId}</code>",
+    "prefill inputs": "Preencher automaticamente",
+    "current": "atual",
     "change state": "Alterar estado",
-    "change state confirm": "Tem certeza de que deseja alterar o estado de execução da task <code>{task}</code> na execução <code>{id}</code>?",
-    "change state current state": "Status atual é:",
+    "actual state": "Estado atual",
+    "select a state": "Selecione um estado",
+    "are you sure change state": "Tem certeza de que deseja alterar o estado?",
+    "yes": "Sim",
     "change state done": "O estado da task foi atualizado",
+    "change state confirm": "Tem certeza de que deseja alterar o estado de execução da task <code>{task}</code> na execução <code>{id}</code>?",
+    "change queue confirm": "Tem certeza de que deseja alterar o estado da fila para a execução <code>{id}</code>?<br/>",
+    "change state current state": "Status atual é:",
     "change state hint": {
+      "WARNING": [
+        "O flow será marcado como WARNING.",
+        "As próximas tasks serão executadas.",
+        "As tasks de erro serão executadas."
+      ],
       "FAILED": [
         "O flow será marcado como FAILED.",
         "Nenhuma outra task será executada.",
         "As tasks de erro serão executadas."
-      ],
-      "RUNNING": [
-        "O flow será reiniciado e executará todas as próximas tasks.",
-        "Todas as tasks bloqueadas serão executadas."
       ],
       "SUCCESS": [
         "O flow será reiniciado pois esta task foi bem-sucedida.",
         "Todas as tasks bloqueadas serão executadas.",
         "O flow estará em estado de SUCCESS se todas as execuções das tasks forem bem-sucedidas."
       ],
-      "WARNING": [
-        "O flow será marcado como WARNING.",
-        "As próximas tasks serão executadas.",
-        "As tasks de erro serão executadas."
+      "RUNNING": [
+        "O flow será reiniciado e executará todas as próximas tasks.",
+        "Todas as tasks bloqueadas serão executadas."
       ]
     },
+    "replay execution title": "Reexecutar execução",
+    "restart execution title": "Reiniciar execução",
+    "replay execution description": "Isso criará uma nova execução com base na execução selecionada.",
+    "replay using": "Repetir usando",
+    "flow revision original": "Revisão original do flow",
+    "flow revision latest": "Última revisão do flow",
+    "flow revision specific": "Revisão específica do flow",
+    "replay inputs": "Entradas",
+    "reuse original inputs": "Reutilizar inputs originais",
+    "modify inputs": "Modificar inputs",
+    "replay inputs new required": "Esta revisão possui inputs. Você será solicitado a preenchê-los.",
+    "replay select taskrun": "Selecione o task run para reproduzir a partir de:",
     "change state tooltip": "Alterar o estado de execução",
-    "chart": "Gráfico",
-    "chart preview": "Prévia do gráfico",
-    "chart type": "Tipo de gráfico",
-    "charts": "Gráficos",
-    "choice": "Escolha",
-    "choose file": "Escolha um arquivo ou solte-o aqui...",
-    "close": "Fechar",
-    "close sidebar": "fechar barra lateral",
-    "codeDisabled": "Desativado no Flow",
-    "collapse": "Recolher",
-    "collapse all": "Recolher tudo",
-    "commit_id": "ID do commit",
-    "common": {
-      "back": "Voltar"
-    },
-    "concurrency": "Concorrência",
-    "concurrency limits": "Limites de Concurrency",
-    "concurrency_limit": {
-      "dialog_title": "Limites de Concurrency",
-      "warning": "Alterar o contador em execução pode corromper a concorrência, fazendo com que as execuções excedam o limite permitido."
-    },
-    "conditions": "Condições",
-    "configure basic auth": "Configurar Autenticação Básica",
-    "confirm": "Confirmar",
-    "confirm password": "Confirmar senha",
-    "confirmation": "Confirmação",
-    "context updated date": "Data de atualização do contexto",
-    "context updated date tooltip": "Quando o contexto do trigger foi atualizado pela última vez. Isso ocorre quando a execução é acionada, termina (bloqueio liberado) ou após uma avaliação (mesmo que nenhuma execução ocorra).",
-    "contextBar": {
-      "demo": "Demonstração",
-      "docs": "Documentos",
-      "help": "Ajuda",
-      "issue": "Problema",
-      "news": "Notícias",
-      "star": "Nos avalie com uma estrela"
-    },
-    "continue backfill": "Continuar o backfill",
-    "continue backfills": "Continuar backfills",
-    "copied": "Copiado",
-    "copied_logs_to_clipboard": "Logs copiados para a área de transferência.",
-    "copy": "Copiar",
-    "copy all logs": "Copiar Todos os Logs",
-    "copy logs": "Copiar logs",
-    "copy url": "Copiar URL",
-    "copy_and_close": "Copiar e fechar",
-    "copy_to_clipboard": "Copiar para a área de transferência",
-    "copy_value": "Copy value",
-    "create": "Criar",
-    "create first task": "Crie sua primeira task",
-    "create_flow": "Criar Flow",
-    "created date": "Data de criação",
-    "creation": "Criação",
-    "cron": "Cron",
-    "curl": {
-      "command": "Comando cURL",
-      "note": "Observe que, para o tipo de input SECRET e FILE, o comando deve ser ajustado para corresponder aos valores reais."
-    },
-    "current": "atual",
-    "current execution": "Execução atual",
-    "custom value": "Valor personalizado",
-    "customize sidebar": "Personalizar barra lateral",
-    "dark_version": "Versão escura",
-    "dashboards": {
-      "chart_preview": "Clique no código-fonte de um gráfico para ver sua pré-visualização",
-      "creation": {
-        "confirmation": "O Dashboard <code>{title}</code> foi criado.",
-        "label": "Criar Dashboard"
-      },
-      "default": "Dashboard Padrão",
-      "deletion": {
-        "confirmation": "Tem certeza de que deseja excluir o dashboard <code>{title}</code>?"
-      },
-      "edition": {
-        "chart": "Edite este gráfico",
-        "confirmation": "As alterações no dashboard <code>{title}</code> foram salvas.",
-        "id readonly": "A propriedade `id` não pode ser alterada — agora está definida para seus valores iniciais. Se você quiser alterá-la, pode criar um novo dashboard e remover o antigo.",
-        "label": "Editar Dashboard"
-      },
-      "empty": "Não há resultados para serem exibidos.",
-      "export": "Exportar para CSV",
-      "labels": {
-        "plural": "Dashboards",
-        "singular": "Dashboard"
-      },
-      "no_description": "Sem descrição",
-      "no_description_hint": "Adicione uma descrição a este flow para documentar o que ele faz.<br>Markdown é suportado.",
-      "others": "Outros",
-      "preview": "Visualizar Dashboard",
-      "quick_filters": {
-        "all": "Todos",
-        "failed": "Falhou",
-        "paused": "Pausado",
-        "running": "Em execução",
-        "success": "Sucesso",
-        "warning": "Aviso"
-      },
-      "switch": "Alternar Dashboard",
-      "viewAll": "Ver tudo"
-    },
-    "data": "Dados",
-    "dataFilters": "Filtros de Dados",
-    "data_not_protected": "Seus dados não estão protegidos. Não os perca. <b>Ative nossos recursos de segurança gratuitos ou experimente nossa oferta paga.</b>",
-    "date": "Data",
-    "date count": "{count} em {date}",
-    "date format": "Formato de data",
-    "date range count": "{count} entre {startDate} e {endDate}",
-    "datepicker": {
-      "12hours": "12 horas",
-      "15minutes": "15 minutos",
-      "1hour": "1 hora",
-      "24hours": "24 horas",
-      "30days": "30 dias",
-      "365days": "365 dias",
-      "48hours": "48 horas",
-      "5minutes": "5 minutos",
-      "7days": "7 dias",
-      "custom": "Personalizado",
-      "dayBeforeYesterday": "Anteontem",
-      "duration example": "Exemplo: 'P1DT1H1M1S'",
-      "error": "Formato de duração inválido, deve ser uma duração ISO 8601 (P1DT1H1M1S por ex.)",
-      "last12hours": "Últimas 12 horas",
-      "last15minutes": "Últimos 15 minutos",
-      "last1hour": "Última 1 hora",
-      "last24hours": "Últimas 24 horas",
-      "last30days": "Últimos 30 dias",
-      "last365days": "Últimos 365 dias",
-      "last48hours": "Últimas 48 horas",
-      "last5minutes": "Últimos 5 minutos",
-      "last7days": "Últimos 7 dias",
-      "leave empty for infinite": "Deixe vazio para duração infinita ou digite uma duração ISO 8601 (exemplo: 'P1DT1H1M1S)'",
-      "never": "Nunca",
-      "next12hours": "Próximas 12 horas",
-      "next15minutes": "Próximos 15 minutos",
-      "next1hour": "Próxima 1 hora",
-      "next24hours": "Próximas 24 horas",
-      "next30days": "Próximos 30 dias",
-      "next365days": "Próximos 365 dias",
-      "next48hours": "Próximas 48 horas",
-      "next5minutes": "Próximos 5 minutos",
-      "next7days": "Próximos 7 dias",
-      "previousMonth": "Mês anterior",
-      "previousWeek": "Semana anterior",
-      "previousYear": "Ano anterior",
-      "short": {
-        "12h": "12h",
-        "15m": "15min",
-        "1d": "1d",
-        "1h": "1h",
-        "7d": "7d"
-      },
-      "thisMonth": "Este mês",
-      "thisMonthSoFar": "Este mês até agora",
-      "thisWeek": "Esta semana",
-      "thisWeekSoFar": "Esta semana até agora",
-      "thisYear": "Este ano",
-      "thisYearSoFar": "Este ano até agora",
-      "today": "Hoje",
-      "yesterday": "Ontem"
-    },
-    "debug": "Depurar",
-    "default": "Padrão",
-    "defaultsToNamespaceFile": "Padrões para arquivo de namespace: <code>{name}</code>",
-    "delete": "Excluir",
-    "delete backfill": "Excluir o backfill",
-    "delete backfills": "Excluir backfills",
-    "delete confirm": "Tem certeza de que deseja excluir <code>{name}</code>?",
-    "delete execution running": "<div class=\"alert alert-warning mt-2 mb-0\">Esta execução ainda está RUNNING, deletá-la não irá pará-la.<br />Você precisa matar a execução para pará-la.</div>",
-    "delete logs": "Excluir logs",
-    "delete ok": "está deletado",
-    "delete revision confirm": "Tem certeza de que deseja excluir a revisão {revision}?",
-    "delete revision error": "Erro ao excluir a revisão {revision} com erro {error}",
-    "delete task confirm": "Deseja Excluir a task <code>{taskId}</code>?",
-    "delete trigger": "Excluir trigger",
-    "delete trigger confirmation": "Tem certeza de que deseja excluir o trigger {id}? WARNING: excluir um trigger pode levar a execuções duplicadas se o trigger ainda estiver ativo em um flow.",
-    "delete trigger error": "Erro ao excluir trigger {id}",
-    "delete trigger success": "O Trigger {id} foi excluído com sucesso",
-    "delete triggers": "Excluir triggers",
-    "delete_all_logs": "Tem certeza de que deseja excluir todos os logs?",
-    "delete_log": "Tem certeza de que deseja excluir o log?",
-    "deleted": "Deletado com sucesso",
-    "deleted confirm": "<em>{name}</em> foi deletado com sucesso!",
-    "deleted_label": "Deletado",
-    "demos": {
-      "IAM": {
-        "message": "A Kestra Enterprise Edition possui capacidades IAM integradas com single sign-on (SSO), sincronização de diretório SCIM e controle de acesso baseado em funções (RBAC), integrando-se com vários provedores de identidade e permitindo que você atribua permissões detalhadas para usuários e contas de serviço.",
-        "title": "Gerencie Usuários através do IAM com SSO, SCIM e RBAC"
-      },
-      "apps": {
-        "message": "As aplicações na Kestra Enterprise Edition permitem que você construa interfaces personalizadas que interagem com os workflows do Kestra fora da plataforma. Este recurso permite usar seus workflows como um backend para aplicações personalizadas, possibilitando que usuários não técnicos enviem dados através de formulários ou retomem workflows PAUSED aguardando aprovação.",
-        "title": "Crie Apps personalizadas com Kestra"
-      },
-      "assets": {
-        "header": "Metadados e Observabilidade de Assets",
-        "label": "Ativos",
-        "message": "Ativos conectam metadados de observabilidade, linhagem e propriedade para que as equipes da plataforma possam solucionar problemas mais rapidamente e implantar com confiança.",
-        "title": "Traga todos os datasets, serviços e dependências para a visualização."
-      },
-      "audit-logs": {
-        "message": "A Kestra Enterprise Edition registra todas as atividades com registros robustos e imutáveis, facilitando o acompanhamento de alterações, a manutenção da conformidade e a resolução de problemas.",
-        "title": "Acompanhe Alterações com Audit Logs"
-      },
-      "blueprints": {
-        "message": "Na Kestra Enterprise Edition, você pode criar Blueprints personalizados disponíveis apenas para sua organização. Você pode usá-los como modelos de melhores práticas para compartilhar, centralizar e documentar fluxos de trabalho comumente usados em sua equipe.",
-        "title": "Adicionar Blueprints Personalizados"
-      },
-      "contact_sales": "Entre em Contato com Vendas",
-      "enterprise_edition": "Edição Enterprise",
-      "get_a_demo_button": "Obter uma Demonstração",
-      "instance": {
-        "message": "A Kestra Enterprise Edition fornece um painel operacional para ajudar você a observar a saúde da sua plataforma e acompanhar as métricas de tempo de atividade de todos os serviços, como, por exemplo, Workers, Schedulers e Executors. Na mesma página, você também pode criar Anúncios para notificar seus usuários sobre interrupções planejadas, e pode entrar em um modo de manutenção que coloca temporariamente todos os serviços e execuções de workflow em um estado PAUSED para realizar uma atualização.",
-        "title": "Gerencie a Infraestrutura em Toda a Sua Instância"
-      },
-      "namespace": {
-        "assets": {
-          "message": "Na Kestra Enterprise Edition, Assets mantém um inventário ao vivo de recursos com os quais seus workflows interagem. Esses recursos podem ser tabelas de banco de dados, máquinas virtuais, arquivos ou qualquer sistema externo com o qual você trabalhe.",
-          "title": "Centralizar Gerenciamento de Ativos"
-        },
-        "audit-logs": {
-          "message": "Na Kestra Enterprise Edition, você pode visualizar logs de auditoria no nível do namespace com diferenças detalhadas, fornecendo um histórico claro de quem alterou o quê e quando em todos os recursos.",
-          "title": "Acompanhe Todas as Alterações em Um Só Lugar"
-        },
-        "edit": {
-          "message": "Na Kestra Enterprise Edition, os namespaces oferecem isolamento avançado e governança de segredos, variáveis e padrões de plugins em escala. Os administradores podem configurar gerenciadores de segredos personalizados, backends de armazenamento isolados, grupos de worker dedicados e permissões detalhadas por namespace. Isso garante que segredos, variáveis e configurações de plugins permaneçam seguros e fáceis de manter em diferentes equipes e projetos.",
-          "title": "Atualize o Gerenciamento do seu Namespace"
-        },
-        "history": {
-          "message": "Na Kestra Enterprise Edition, você pode gerenciar o histórico de revisões dos seus Namespaces",
-          "title": "Gerenciar Histórico de Revisões em Um Só Lugar"
-        },
-        "plugin-defaults": {
-          "message": "Na Kestra Enterprise Edition, você pode definir padrões de plugin específicos para cada namespace, reduzindo a necessidade de configuração duplicada em cada flow. Esta governança central de plugins impõe configurações consistentes, permite a referência segura de segredos ou variáveis e simplifica a manutenção dos seus workflows.",
-          "title": "Padronizar Configuração com Padrões de Plugin"
-        },
-        "secrets": {
-          "message": "Na Kestra Enterprise Edition, você pode armazenar e controlar segredos no nível de namespace, minimizando riscos e garantindo que as credenciais de cada equipe permaneçam isoladas. Graças à hierarquia aninhada, você também pode configurar credenciais em um namespace pai e elas serão herdadas por todos os namespaces filhos. O suporte para gerenciadores de segredos dedicados e configurações de permissão detalhadas no nível de namespace fortalece ainda mais a segurança e a conformidade.",
-          "title": "Gerenciar Segredos de Forma Segura"
-        },
-        "variables": {
-          "message": "Na Kestra Enterprise Edition, você pode definir e gerenciar variáveis no nível do namespace para eliminar configurações repetitivas em flows. Essas variáveis garantem consistência, simplificam atualizações de configuração e podem ser facilmente referenciadas por qualquer task ou trigger para workflows mais limpos e fáceis de manter.",
-          "title": "Governe Centralmente Suas Variáveis"
-        }
-      },
-      "quotas": {
-        "message": "O Kestra Enterprise Edition permite definir cotas em flows para limitar o número de execuções simultâneas ou totais dentro de uma janela de tempo. As cotas ajudam a proteger a infraestrutura compartilhada, aplicar SLAs e impedir que workflows descontrolados consumam recursos excessivos.",
-        "title": "Aplicar cotas de execução em flows"
-      },
-      "secrets": {
-        "add_env": {
-          "first": "Codifique o <a href=\"https://kestra.io/docs/how-to-guides/secrets?utm_source=app&utm_medium=referral&utm_campaign=secrets-inlinedoc#using-secrets-in-kestra\" target=\"_blank\">valor secreto em Base64</a>",
-          "intro": "Para criar um novo Secret:",
-          "second": "Adicione uma variável de ambiente chamada '<strong>SECRET_{'{MY_SECRET_KEY}'}</strong>' com o valor acima",
-          "third": "Reinicie sua instância do Kestra"
-        },
-        "detected_env": "Aqui estão as variáveis de ambiente do tipo secreto identificadas no momento de inicialização da instância:",
-        "empty_env": "Você ainda não tem nenhum Secret no seu ambiente.",
-        "message": "A Enterprise Edition (EE) permite adicionar, editar ou excluir segredos diretamente na UI—sem necessidade de reiniciar a instância. Organize segredos por namespace com permissões RBAC granulares e herde-os de namespaces pai para filho. A EE integra-se com gerenciadores de segredos como HashiCorp Vault, AWS Secrets Manager, Azure Key Vault, Google Secret Manager e Elasticsearch. Configure backends dedicados por namespace, tenant ou instância para isolar segredos entre equipes, ou habilite segredos somente leitura armazenados em cofres externos. Os segredos permanecem criptografados em repouso e em trânsito. O cache opcional reduz chamadas de API, e trilhas de auditoria registram todo o acesso.",
-        "title": "Atualize seu Gerenciamento de Secrets"
-      },
-      "tenants": {
-        "message": "A Kestra Enterprise Edition suporta multi-tenancy, proporcionando ambientes totalmente isolados para diferentes equipes ou projetos, cada um com seus próprios recursos, como grupos de worker dedicados ou segredos e backends de armazenamento interno.",
-        "title": "Gerenciar Fluxos de Trabalho em Tenants Isolados"
-      },
-      "tests": {
-        "header": "Testes Unitários para Flows",
-        "label": "Testes",
-        "message": "Verifique a lógica dos seus flows isoladamente, detecte regressões cedo e mantenha a confiança nas suas automações à medida que elas mudam e crescem.",
-        "title": "Garanta a Confiabilidade com Cada Alteração"
-      },
-      "watch_the_video": "Assista ao vídeo"
-    },
-    "density": "Density",
-    "density_compact": "Compact",
-    "density_expanded": "Expanded",
-    "density_normal": "Normal",
-    "dependencies": "Dependências",
-    "dependencies delete flow": "Este flow tem dependências. Deletá-lo impedirá que suas dependências sejam executadas.<br /><br /> Aqui está a lista de flows afetados:",
-    "dependencies loaded": "Dependências carregadas",
-    "dependencies missing acls": "Sem permissões neste flow",
-    "dependency": {
-      "controls": {
-        "clear_selection": "Limpar seleção",
-        "fit_view": "Ajustar à tela",
-        "zoom_in": "Aumentar",
-        "zoom_out": "Reduzir zoom"
-      },
-      "search": {
-        "flow": {
-          "display": "Incluir dependências do flow"
-        },
-        "namespace": {
-          "no_namespace": "Sem namespace",
-          "select": "Selecione um namespace"
-        },
-        "no_results": "Nenhum resultado encontrado para {term}",
-        "placeholders": {
-          "asset": "Pesquisar por asset, flow ou namespace...",
-          "default": "Pesquisar por flow ou namespace..."
-        }
-      }
-    },
-    "dependency task": "Task {taskId} é uma dependência de outra task",
-    "description": "Descrição",
-    "details": "Detalhes",
-    "disable": "Desativar",
-    "disabled": "Desativado",
-    "disabled flow desc": "Este flow está desativado, por favor, ative-o para executá-lo.",
-    "disabled flow title": "Este flow está desativado",
-    "discard changes confirmation": "Você tem alterações não salvas. Tem certeza de que deseja descartá-las?",
-    "discard execution confirmation": "Você tem inputs não salvos. Tem certeza de que deseja descartar esta execução?",
-    "display direct sub tasks count": "Exibir contagem direta de subtasks",
-    "display flow {id} executions": "Exibir execuções do flow {id}",
-    "display metric for specific task": "Exibir métrica para uma task específica",
-    "display output for specific task": "Exibir output para uma task específica",
-    "display topology for flow": "Exibir topologia do flow",
-    "display_settings": "Display settings",
-    "docs": "Documentos",
-    "documentation": {
-      "documentation": "Documentação",
-      "github": "Abrir um issue no GitHub"
-    },
-    "documentationMenu": "Menu de documentação",
-    "done": "Concluído",
-    "down trend": "Diminuindo",
-    "download": "Baixar",
-    "download logs": "Baixar logs",
-    "download_logos": "Baixar Pacote de Logos",
-    "download_logs_description": "Choose which logs to export. Filters default to your current view.",
-    "draft": "Rascunho",
-    "draft_available": "Mudança de rascunho disponível no editor",
-    "draft_flow_warning": "Esta revisão do flow é um rascunho. A execução será feita nesta revisão de rascunho e pode falhar imediatamente se a definição do flow for inválida.",
-    "drill down preview": "Pré-visualização",
-    "drop items here": "Solte os itens aqui",
-    "duplicate-pair": "O {label} \"{key}\" está duplicado, a primeira chave foi ignorada.",
-    "duration": "Duração",
-    "dynamic": "Dinâmico",
-    "each value": "Valor da iteração",
-    "edit": "Editar",
-    "edit flow": "Editar flow",
-    "editor": "Editor",
-    "editor_shortcuts": {
-      "command_palette": "Mostrar paleta de comandos",
-      "comment": "Comentário",
-      "comment_uncomment": "Comentar/Descomentar",
-      "decrease_fontsize": "Diminuir tamanho da fonte do editor",
-      "duplicate_cursor": "Duplicar cursor",
-      "execute_flow": "Executar flow",
-      "fold_unfold": "Dobra/Desdobra código",
-      "increase_fontsize": "Aumentar o tamanho da fonte do editor",
-      "label": "Atalhos de teclado",
-      "move_line": "Mover linha",
-      "reset_fontsize": "Redefinir tamanho da fonte do editor",
-      "save_flow": "Salvar flow",
-      "toggle_ai_agent": "Alternar agente de IA",
-      "trigger_autocompletion": "Acionar autocompletar",
-      "uncomment": "Descomentar"
-    },
-    "ee-tooltip": {
-      "button": "Fale conosco",
-      "features-blocked": "Este recurso requer a Enterprise Edition."
-    },
-    "email": "Email",
-    "email length constraint": "Email não deve exceder 256 caracteres",
-    "empty": {
-      "announcements": {
-        "content": "Os anúncios permitem que você notifique seus usuários sobre quaisquer alterações ou informe-os sobre o tempo de inatividade planejado para manutenção. Basta selecionar o tipo de anúncio, o intervalo de datas em que ele deve ser exibido e escrever a mensagem do anúncio.",
-        "title": "Você ainda não tem anúncios!"
-      },
-      "apiTokens": {
-        "content": "Tokens de API são usados sempre que você deseja conceder acesso programático à API do Kestra.",
-        "title": "Gerencie seus Tokens de API"
-      },
-      "apps": {
-        "content": "Comece a criar Apps para interagir com o Kestra a partir do mundo externo.",
-        "title": "Você ainda não tem apps!"
-      },
-      "assets": {
-        "content": "Adicione assets para rastrear e gerenciar seus assets de dados, serviços e infraestrutura.",
-        "title": "Você ainda não tem Assets!"
-      },
-      "concurrency_executions": {
-        "content": "Leia mais sobre <strong><a href=\"https://kestra.io/docs/workflow-components/execution?utm_source=app&utm_medium=referral&utm_campaign=concurrency-inlinedoc\" target=\"_blank\">Execuções</a></strong> em nossa documentação.",
-        "title": "Nenhuma Execução em andamento para este Flow."
-      },
-      "concurrency_limit": {
-        "content": "Leia mais sobre <strong><a href=\"https://kestra.io/docs/workflow-components/concurrency?utm_source=app&utm_medium=referral&utm_campaign=concurrency-inlinedoc\" target=\"_blank\">Limites de Concurrency</a></strong> em nossa documentação.",
-        "title": "Nenhum limite está definido para este Flow."
-      },
-      "concurrency_limits": {
-        "content": "Leia mais sobre <strong><a href=\"https://kestra.io/docs/workflow-components/concurrency?utm_source=app&utm_medium=referral&utm_campaign=concurrency-inlinedoc\" target=\"_blank\">Limites de Concurrency</a></strong> em nossa documentação.",
-        "title": "Nenhum limite de concorrência está definido."
-      },
-      "dependencies": {
-        "ASSET": {
-          "content": "Este ativo não possui dependências upstream ou downstream com flows ou outros ativos.",
-          "title": "Atualmente, não há dependências."
-        },
-        "EXECUTION": {
-          "content": "Leia mais sobre <a href=\"https://kestra.io/docs/ui/executions?utm_source=app&utm_medium=referral&utm_campaign=dependencies-inlinedoc#dependencies\" target=\"_blank\">Dependências de Execução</a> na nossa documentação.",
-          "title": "Atualmente, não há dependências."
-        },
-        "FLOW": {
-          "content": "Leia mais sobre <a href=\"https://kestra.io/docs/ui/flows?utm_source=app&utm_medium=referral&utm_campaign=dependencies-inlinedoc#dependencies\" target=\"_blank\">Dependências de Flow</a> na nossa documentação.",
-          "title": "Atualmente, não há dependências."
-        },
-        "NAMESPACE": {
-          "content": "Leia mais sobre <a href=\"https://kestra.io/docs/ui/namespaces?utm_source=app&utm_medium=referral&utm_campaign=dependencies-inlinedoc#dependencies\" target=\"_blank\">Dependências de Namespace</a> em nossa documentação.",
-          "title": "Atualmente, não há dependências."
-        }
-      },
-      "groups": {
-        "content": "Grupos permitem que você agrupe usuários para gerenciar permissões e vinculações de funções coletivamente em todo o seu tenant.",
-        "title": "Você ainda não tem grupos!"
-      },
-      "kill_switches": {
-        "content": "O recurso Kill Switch fornece um mecanismo baseado em UI para interromper execuções problemáticas. Ele substitui os comandos <code>--skip-executions</code> e <code>--skip-flows</code> disponíveis apenas no CLI por uma interface de administração abrangente.",
-        "title": "Você ainda não tem Kill Switches!"
-      },
-      "mcpToolFlows": {
-        "content": "Exponha um flow como uma ferramenta MCP adicionando um <code>McpToolTrigger</code> a ele. Leia mais sobre o <strong><a href=\"https://kestra.io/docs/workflow-components/triggers/mcp-tool-trigger?utm_source=app&utm_medium=referral&utm_campaign=mcp-tool-trigger-inlinedoc\" target=\"_blank\">MCP Tool Trigger</a></strong> em nossa documentação.",
-        "title": "Ainda não há flows de ferramenta registrados neste servidor."
-      },
-      "namespaceFiles": {
-        "content": "Os arquivos do namespace funcionam como uma pasta de projeto para este namespace. Armazene código Python, SQL, dbt ou Terraform e, em seguida, referencie qualquer arquivo nos seus flows com",
-        "title": "Ainda não há arquivos neste namespace"
-      },
-      "panels": {
-        "content": "Você fechou todos os painéis.  \nEscolha uma aba acima para continuar.",
-        "title": "Nenhum painel aberto"
-      },
-      "pluginDefaults": {
-        "content": "Os Padrões de Plugin permitem que você governe centralmente a configuração do seu plugin e a compartilhe com todos os flows no seu namespace.",
-        "title": "Você ainda não tem padrões de plugin!"
-      },
-      "plugins": {
-        "content": "Leia mais sobre <strong><a href=\"https://kestra.io/docs/workflow-components/plugin-defaults?utm_source=app&utm_medium=referral&utm_campaign=plugin-default-inlinedoc\" target=\"_blank\">Limites de Concurrency</a></strong> em nossa documentação.",
-        "title": "Nenhum padrão de plugin está definido para este Namespace."
-      },
-      "testSuites": {
-        "content": "Comece a criar suítes de Teste para testar seus Flows.",
-        "title": "Você ainda não tem Test suites!"
-      },
-      "triggers": {
-        "content": "Leia mais sobre <strong><a href=\"https://kestra.io/docs/workflow-components/triggers?utm_source=app&utm_medium=referral&utm_campaign=trigger-inlinedoc\" target=\"_blank\">Triggers</a></strong> em nossa documentação.",
-        "title": "Seu flow não possui nenhum trigger."
-      },
-      "variables": {
-        "content": "Adicione pares de key-value para compartilhar configurações entre flows. Namespaces filhos os herdam automaticamente, e você pode referenciar qualquer value com",
-        "title": "Ainda não há variáveis"
-      },
-      "versionPlugin": {
-        "content": "Aqui você pode gerenciar todos os plugins instalados na sua instância do Kestra. Plugins recém-instalados podem não estar imediatamente disponíveis em todos os serviços do Kestra, dependendo da configuração da sua instância.",
-        "title": "Você ainda não tem um plugin versionado!"
-      },
-      "workerRegistrationTokens": {
-        "content": "Tokens de registro permitem que workers remotos autentiquem-se e registrem-se com segurança na sua instância do Kestra. Crie um token e use-o para conectar novos workers a este cluster.",
-        "title": "Você ainda não tem tokens de registro!"
-      }
-    },
-    "empty search": "Resultados da pesquisa estão vazios",
-    "enable": "Ativar",
-    "enable concurrency": "Habilitar concorrência",
-    "enabled": "Ativado",
-    "encoding": "Codificação",
-    "end date": "Data de término",
-    "end datetime": "Data e hora de término",
-    "environment": "Ambiente",
-    "environment color setting": "Cor do ambiente",
-    "environment name setting": "Nome do ambiente",
-    "error": "Erro",
-    "error detected": "Erro(s) detectado(s).",
-    "error in editor": "Um erro foi encontrado no editor",
-    "errorLogs": "Logs de erros",
-    "errors": {
-      "401": {
-        "content": "Você precisa estar autenticado para acessar esta página.",
-        "title": "Não autorizado"
-      },
-      "403": {
-        "content": "Você não tem as permissões necessárias para acessar esta página.",
-        "title": "Acesso negado"
-      },
-      "404": {
-        "content": "A URL solicitada não foi encontrada neste servidor.<br />Isso é tudo que sabemos.",
-        "flow or execution": "O flow ou execução que você está procurando não existe.",
-        "title": "Página não encontrada"
-      }
-    },
+    "change execution state confirm": "Tem certeza de que deseja alterar o estado da execução <code>{id}</code>?",
+    "change execution state done": "Estado de execução atualizado",
+    "mark as": "Marcar como <code>{status}</code>",
+    "unqueue as": "Desenfileirar como <code>{status}</code>",
+    "kill": "Matar",
+    "kill parents and subflow": "Matar o flow atual e subflows",
+    "kill only parents": "Matar apenas o atual",
+    "killed confirm": "Tem certeza de que deseja matar a execução <code>{id}</code>?",
+    "killed done": "Execução está na fila para ser morta",
+    "resume": "Retomar",
+    "resumed title": "Retomar execução <code>{id}</code>",
+    "resumed confirm": "Tem certeza de que deseja retomar a execução <code>{id}</code>?",
+    "resumed done": "Execução foi retomada",
+    "resume from breakpoint title": "Retomar execução <code>{id}</code> a partir do ponto de interrupção",
+    "resume from breakpoint done": "A execução é retomada a partir do ponto de interrupção",
+    "breakpoints": "Pontos de interrupção",
+    "pause": "Pausar",
+    "pause title": "Pausar execução <code>{id}</code>.<br/>Note que as tasks atualmente em execução ainda serão processadas, e a execução terá que ser retomada manualmente.",
+    "pause confirm": "Tem certeza de que deseja pausar a execução <code>{id}</code>?",
+    "pause done": "A execução está PAUSED",
+    "unqueue": "Desenfileirar",
+    "unqueue title": "Desenfileirar execução <code>{id}</code>.<br/>Observe que isso não obedecerá ao limite de concorrência do flow, portanto, mais execuções podem estar em execução do que o limite permitido.",
+    "unqueue title multiple": "Tem certeza de que deseja Desenfileirar <code>{count}</code> execuções?<br/><br/>Observe que isso não obedecerá ao limite de concorrência do flow, portanto, mais execuções podem estar em execução do que o limite permitido.",
+    "unqueue confirm": "Tem certeza de que deseja desagendar a execução <code>{id}</code>?",
+    "unqueue done": "A execução está fora da fila",
+    "force run": "Forçar execução",
+    "force run title": "Forçar a execução da execução <code>{id}</code>.",
+    "force run tooltip": "Forçar a execução a rodar. Pode criar execuções de tarefas duplicadas; se possível, use outra ação.",
+    "force run confirm": "Tem certeza de que deseja forçar a execução <code>{id}</code>?<br/><br/>AVISO: forçar a execução de uma execução não é garantido e pode criar execuções de tarefa duplicadas.<br/><br/>As seguintes transições serão feitas:<br/><ul><li>Tarefas CREATED serão movidas para o estado RUNNING.</li><li>Tarefas RUNNING serão re-submetidas.</li><li>Tarefas QUEUED serão removidas da fila.</li><li>Tarefas PAUSED serão retomadas.</li></ul>",
+    "force run done": "A execução foi forçada a rodar",
+    "toggle output": "Alternar outputs",
+    "metrics": "Métricas",
+    "no data current task": "Não há dados disponíveis para a tarefa atual",
+    "no metrics available": "Nenhuma métrica registrada para esta execução de task.",
+    "no outputs available": "Nenhuma saída disponível para esta execução de task.",
+    "outputs": "Outputs",
+    "flow_outputs": "Saídas do Flow",
+    "no_flow_outputs": "Sem outputs disponíveis.",
+    "output": "Output",
     "eval": {
-      "expression": "Expressão",
-      "preview": "Visualizar",
-      "render": "Expressão de Renderização",
       "title": "Expressão de Depuração",
-      "tooltip": "Renderizar qualquer expressão Pebble e inspecionar o contexto da Execução."
+      "render": "Expressão de Renderização",
+      "tooltip": "Renderizar qualquer expressão Pebble e inspecionar o contexto da Execução.",
+      "preview": "Visualizar",
+      "expression": "Expressão"
     },
-    "evaluation lock date": "Data de bloqueio da avaliação",
-    "execute": "Executar",
-    "execute backfill": "Executar backfill",
-    "execute flow behaviour": "Executar o flow",
-    "execute flow now ?": "Deseja executar este flow?",
-    "execute the flow": "Executar o flow <code>{id}</code>",
-    "execution": "Execução",
-    "execution already finished": "Execução <code>{executionId}</code> já finalizada",
-    "execution id": "Id de Execução",
-    "execution labels": "Labels de execução",
-    "execution not found": "Execução {executionId} não encontrada.",
-    "execution not in state FAILED": "Execução <code>{executionId}</code> não está no estado FAILED",
-    "execution not in state PAUSED": "Execução <code>{executionId}</code> não está no estado PAUSED",
-    "execution replay": "Esta execução é uma repetição de",
-    "execution replayed": "Esta execução foi reproduzida.",
-    "execution restarted": "Esta execução foi reiniciada {nbRestart} vez(es).",
+    "attempt": "Tentativa",
+    "toggle output display": "Alternar exibição de output",
+    "name": "Nome",
+    "key": "Key",
+    "value": "Value",
+    "each value": "Valor da iteração",
+    "current execution": "Execução atual",
+    "parent execution": "Execução pai",
+    "original execution": "Execução original",
+    "automatic refresh": "Atualização automática",
+    "toggle periodic refresh each x seconds": "Alternar atualização periódica a cada {interval} segundos",
+    "trigger refresh": "Atualizar trigger",
+    "add-trigger-in-editor": "Adicione um Trigger ao seu Flow primeiro",
+    "refresh": "Atualizar",
+    "filter by status": "Filtrar execuções pelo status {status}",
+    "topology-graph": {
+      "graph-orientation": "Orientação do gráfico",
+      "zoom-in": "Aumentar zoom",
+      "zoom-out": "Diminuir zoom",
+      "zoom-reset": "Redefinir zoom",
+      "zoom-fit": "Ajustar",
+      "invalid": "Erro no gráfico",
+      "invalid_description": "Ocorreu um erro ao carregar o gráfico. Por favor, verifique o código-fonte para erros."
+    },
+    "show task logs": "Mostrar task logs",
+    "show task condition": "Exibir condição da task",
+    "show task outputs": "Mostrar outputs da task",
+    "show task source": "Mostrar fonte da task",
+    "specific task": "Task específica",
+    "display output for specific task": "Exibir output para uma task específica",
+    "display metric for specific task": "Exibir métrica para uma task específica",
+    "display direct sub tasks count": "Exibir contagem direta de subtasks",
+    "stream": "Stream",
     "execution statistics": "Estatísticas de execução",
-    "execution-include-non-terminated": "Incluir execuções não terminadas?",
-    "execution-warn-deleting-still-running": "Recomendamos fortemente que você cancele esta ação e encerre qualquer execução em andamento primeiro. Excluir execuções não terminadas pode levar a problemas de concorrência, inconsistências na gestão de dependências de flow e processos zumbis na sua instância, o que pode degradar o desempenho do sistema. Certifique-se de entender completamente esses riscos antes de prosseguir com a exclusão.",
-    "execution-warn-title": "Aviso Importante!",
-    "execution_deletion": {
-      "logs": "Excluir logs",
-      "metrics": "Excluir métricas",
-      "storage": "Excluir arquivos de armazenamento interno"
-    },
-    "execution_failed": "Execução falhou!",
-    "execution_guide": {
-      "get_started": {
-        "text": "Siga o Guia de Início Rápido para instalar o Kestra e começar a criar seus primeiros workflows.",
-        "title": "Começar ⚡"
-      },
-      "namespaces": {
-        "text": "Namespaces são agrupamentos lógicos de flows e seus componentes.",
-        "title": "Sobre Namespaces"
-      },
-      "videos_tutorials": {
-        "text": "Comece com nossos tutoriais em vídeo.",
-        "title": "Tutoriais em Vídeo"
-      },
-      "workflow_components": {
-        "text": "Conheça os principais componentes de orquestração de um workflow Kestra.",
-        "title": "Componentes do Workflow"
-      }
-    },
-    "execution_started": "A execução foi iniciada!",
-    "execution_starts_progress": "Assim que a execução começar, você verá atualizações de progresso aqui.",
-    "execution_status": "A execução é:",
-    "executions": "Execuções",
-    "executions deleted": "<code>{executionCount}</code> execução(ões) deletada(s)",
+    "stats": "Estatísticas",
+    "concurrency limits": "Limites de Concurrency",
+    "system overview": "Visão Geral do Sistema",
+    "usage": "Uso",
+    "namespaces": "Namespaces",
+    "tasks": "Tasks",
     "executions duration (in minutes)": "Duração total das execuções (em minutos)",
-    "executions force run": "<code>{executionCount}</code> execução(ões) forçada(s) em execução",
-    "executions killed": "<code>{executionCount}</code> execução(ões) morta(s)",
-    "executions paused": "<code>{executionCount}</code> execução(ões) PAUSED",
-    "executions replayed": "<code>{executionCount}</code> execução(ões) reproduzida(s)",
-    "executions restarted": "<code>{executionCount}</code> execução(ões) reiniciada(s)",
-    "executions resumed": "<code>{executionCount}</code> execução(ões) retomada(s)",
-    "executions state changed": "O estado de <code>{executionCount}</code> execução(ões) foi alterado",
-    "executions unqueue": "<code>{executionCount}</code> execução(ões) na fila",
-    "expand": "Expandir",
-    "expand all": "Expandir tudo",
-    "expand dependencies": "Expandir dependências",
-    "expand error": "Expandir apenas tasks falhadas",
-    "expand_by_default": "Expand structured logs by default",
-    "expiration": "Expiração",
-    "expiration date": "Data de expiração",
-    "export": "Exportar",
-    "export all flows": "Exportar todos os flows",
-    "export all templates": "Exportar todos os templates",
-    "export_as": "Exportar como .{format}",
-    "export_csv": "Exportar como CSV",
-    "exports": "Exportações",
-    "failed to export plugin defaults": "Falha ao exportar padrões do plugin",
-    "failed to import plugin defaults": "Falha ao importar padrões do plugin",
-    "failed to render pdf": "Falha ao renderizar a pré-visualização do PDF",
-    "false": "Falso",
-    "feeds": {
-      "heading": "Tudo sobre Kestra.",
-      "subheading": "As últimas atualizações, guias e histórias",
-      "title": "Novidades no Kestra"
+    "last 48 hours": "últimas 48 horas",
+    "configure basic auth": "Configurar Autenticação Básica",
+    "email": "Email",
+    "password": "Senha",
+    "confirm password": "Confirmar senha",
+    "email length constraint": "Email não deve exceder 256 caracteres",
+    "password length constraint": "Senha não deve exceder 256 caracteres",
+    "password empty constraint": "Nome de usuário ou senha incorretos",
+    "passwords do not match": "Senhas não coincidem",
+    "avg duration": "Duração média da execução",
+    "neutral trend": "Estável",
+    "up trend": "Aumentando",
+    "down trend": "Diminuindo",
+    "update aborted": "atualização abortada",
+    "invalid flow": "Flow inválido",
+    "invalid yaml": "YAML inválido",
+    "inputs": "Inputs",
+    "no_inputs": "Nenhum input disponível.",
+    "input": "Input",
+    "variables": "Variáveis",
+    "variable_explorer": {
+      "title": "Entrada/Saída",
+      "search_placeholder": "Pesquisar Key ou value...",
+      "tasks_outputs": "Tasks outputs",
+      "tree": "Árvore",
+      "raw_json": "Raw JSON",
+      "select_prompt": "Selecione uma variável para inspecionar seu value.",
+      "empty": "Nenhuma variável disponível para esta execução.",
+      "one_key": "\\{ 1 key \\}",
+      "n_keys": "\\{ {count} keys \\}",
+      "one_item": "[ 1 item ]",
+      "n_items": "[ {count} itens ]"
     },
-    "file preview truncated": "Conteúdo exibido foi truncado",
-    "file unavailable": "Arquivo indisponível",
-    "file unavailable description": "Este arquivo não está mais disponível — pode ter sido removido ou expirado.",
-    "fileTypeNotAllowed": "Tipo de arquivo não permitido. Tipos aceitos: {types}",
     "file_preview": {
       "big_file_warning": "Este arquivo tem {size}. Pode demorar um pouco para carregar, bloqueando seu navegador. Deseja carregá-lo mesmo assim?",
       "load_anyway": "Carregar mesmo assim"
     },
-    "files": "Arquivos",
-    "filter by log level": "Filtrar por nível de log",
-    "filter by status": "Filtrar execuções pelo status {status}",
-    "filter by this value": "Filter by this value",
-    "filter_for": "Filter for",
-    "filter_out": "Filter out",
-    "filters": {
-      "comparators": {
-        "between": "entre",
-        "contains": "contém",
-        "ends_with": "termina com",
-        "greater_than": "maior que",
-        "greater_than_or_equal_to": "maior ou igual a",
-        "in": "em",
-        "is": "é",
-        "is_not": "não é",
-        "is_one_of": "é um dos",
-        "less_than": "menor que",
-        "less_than_or_equal_to": "menor ou igual a",
-        "not_contains": "não contém",
-        "not_in": "não em",
-        "starts_with": "começa com"
-      },
-      "empty": "Sem dados.",
-      "format": "Digite o parâmetro como 'key:value'",
-      "label": "Escolher filtros",
-      "options": {
-        "absolute_date": "Data absoluta",
-        "action": "Ação",
-        "aggregation": "Agregação",
-        "child": "Filho",
-        "details": "Detalhes",
-        "endDate": "Data de término",
-        "flow": "Fluxo",
-        "labels": "Etiquetas",
-        "level": "Nível de Log",
-        "metric": "Métrica",
-        "namespace": "Namespace",
-        "permission": "Permissão",
-        "relative_date": "Data relativa",
-        "scope": "Escopo",
-        "service_type": "Tipo",
-        "startDate": "Data de início",
-        "state": "Estado",
-        "status": "Status",
-        "task": "Tarefa",
-        "text": "Parece que você não forneceu nenhum texto para tradução. Por favor, forneça o texto que deseja que eu traduza para o português.",
-        "type": "Tipo",
-        "user": "Usuário"
-      },
-      "save": {
-        "dialog": {
-          "confirmation": "Critérios de pesquisa <code>{name}</code>",
-          "heading": "Salvar pesquisa atual",
-          "hint": "Como você deseja rotular este critério de busca?",
-          "placeholder": "Etiqueta"
-        },
-        "empty": "Você ainda não salvou nenhuma pesquisa.",
-        "label": "Pesquisas salvas",
-        "name_already_used": "A etiqueta de pesquisa já está em uso.",
-        "remove": "Remover",
-        "tooltip": "Você não pode salvar critérios de pesquisa vazios."
-      },
-      "settings": {
-        "label": "Configurações da página",
-        "show_chart": "Exibir gráfico principal"
-      },
-      "text_search": "Pesquisar por este texto"
-    },
-    "fix_with_ai": "Corrigir com AI",
-    "flow": "Flow",
-    "flow already exists": "Flow já existe",
-    "flow already exists message": "Flow <code>{id}</code> já existe no namespace <code>{namespace}</code>. Deseja criar uma nova revisão?",
-    "flow creation": "Criação de flow",
-    "flow creation denied in namespace": "Você não tem permissão para criar flows no namespace `{namespace}`.",
-    "flow delete": "Tem certeza de que deseja excluir <code>{flowCount}</code> flow(s)?",
-    "flow deleted, you can restore it": "O flow foi deletado e esta é uma visualização somente leitura. Você ainda pode restaurá-lo.",
-    "flow disable": "Tem certeza de que deseja desativar <code>{flowCount}</code> flow(s)?",
-    "flow enable": "Tem certeza de que deseja ativar <code>{flowCount}</code> flow(s)?",
-    "flow export": "Tem certeza de que deseja exportar <code>{flowCount}</code> flow(s)?",
-    "flow must have id and namespace": "Flow deve ter um id e um namespace.",
-    "flow must not be empty": "O flow não deve estar vazio",
-    "flow not imported": "Algum flow não pôde ser importado",
-    "flow revision latest": "Última revisão do flow",
-    "flow revision original": "Revisão original do flow",
-    "flow revision specific": "Revisão específica do flow",
-    "flow source not found": "Fonte do flow não encontrada",
-    "flow-dependencies": "dependências",
-    "flow-no-dependencies": "Seu flow não possui dependências",
-    "flow_editor_stats": {
-      "apps": {
-        "suffix": "Aplicativo(s)",
-        "tooltip": "Ver aplicativos usando este flow"
-      },
-      "dependencies": {
-        "suffix": "Dependências",
-        "tooltip": "Visualizar dependências do flow"
-      },
-      "errors": {
-        "label": "{count} Erro(s)"
-      },
-      "revisions": {
-        "suffix": "Revisão(ões)",
-        "tooltip": "Visualizar revisões do flow"
-      },
-      "tests": {
-        "suffix": "Testes",
-        "tooltip": "Visualizar testes de flow"
-      }
-    },
-    "flow_export": "Exportar flow",
-    "flow_only": "Disponível apenas na aba Flow.",
-    "flow_outputs": "Saídas do Flow",
-    "flows": "Flows",
-    "flows deleted": "<code>{count}</code> Flow(s) deletado(s)",
-    "flows disabled": "<code>{count}</code> Flow(s) desativado(s)",
-    "flows enabled": "<code>{count}</code> Flow(s) ativado(s)",
-    "flows exported": "<code>{count}</code> Flow(s) exportado(s)",
-    "flows imported": "Fluxos importados",
-    "focus task": "Clique em qualquer elemento para ver sua documentação.",
-    "fold_all_multi_lines": "Recolher Todas as Linhas Múltiplas",
-    "font size": "Font size",
-    "for flow": "para flow",
-    "forbidden system labels": "Apenas system.correlationId pode ser usado como label do sistema",
-    "force run": "Forçar execução",
-    "force run confirm": "Tem certeza de que deseja forçar a execução <code>{id}</code>?<br/><br/>AVISO: forçar a execução de uma execução não é garantido e pode criar execuções de tarefa duplicadas.<br/><br/>As seguintes transições serão feitas:<br/><ul><li>Tarefas CREATED serão movidas para o estado RUNNING.</li><li>Tarefas RUNNING serão re-submetidas.</li><li>Tarefas QUEUED serão removidas da fila.</li><li>Tarefas PAUSED serão retomadas.</li></ul>",
-    "force run done": "A execução foi forçada a rodar",
-    "force run title": "Forçar a execução da execução <code>{id}</code>.",
-    "force run tooltip": "Forçar a execução a rodar. Pode criar execuções de tarefas duplicadas; se possível, use outra ação.",
-    "form": "Formulário",
-    "form error": "Erro no formulário",
-    "from": "De",
-    "gantt": "Gantt",
-    "gantt_no_tasks_executed": "Esta execução terminou sem executar nenhuma task.  \nVerifique sua visão geral e logs para encontrar o motivo.",
-    "gantt_no_tasks_match_filters": "Tente ajustar os filtros de busca, estado ou nível de log.",
-    "gantt_no_tasks_match_filters_title": "Nenhuma task corresponde aos filtros selecionados.",
-    "healthcheck date": "Data do HealthCheck",
-    "hide task documentation": "Ocultar documentação da task",
-    "home": "Início",
-    "hostname": "Nome do host",
-    "iam": "IAM",
-    "id": "Id",
-    "import": "Importar",
-    "in-our-documentation": "na nossa documentação.",
-    "informative notice": "Nota(s)",
-    "input": "Input",
-    "inputs": "Inputs",
-    "instance": "Instância",
-    "invalid bulk delete": "Não foi possível excluir execuções",
-    "invalid bulk force run": "Não foi possível forçar a execução das execuções",
-    "invalid bulk kill": "Não foi possível matar execuções",
-    "invalid bulk pause": "Não foi possível pausar as execuções",
-    "invalid bulk replay": "Não foi possível reproduzir execuções",
-    "invalid bulk restart": "Não foi possível reiniciar execuções",
-    "invalid bulk resume": "Não foi possível retomar execuções",
-    "invalid bulk unqueue": "Não foi possível remover as execuções da fila",
-    "invalid field": "Campo inválido: {name}",
-    "invalid flow": "Flow inválido",
-    "invalid source": "Código fonte inválido",
-    "invalid yaml": "YAML inválido",
-    "is deprecated": "está obsoleto",
-    "is required": "{field} é obrigatório",
-    "item": "item",
-    "items": "itens",
-    "join community": "Junte-se à Comunidade",
-    "join_slack": "Participar do Slack",
-    "jsonl": "JSONL",
-    "jump to...": "Ir para...",
-    "kestra": "Kestra",
-    "key": "Key",
-    "kill": "Matar",
-    "kill only parents": "Matar apenas o atual",
-    "kill parents and subflow": "Matar o flow atual e subflows",
-    "killed confirm": "Tem certeza de que deseja matar a execução <code>{id}</code>?",
-    "killed done": "Execução está na fila para ser morta",
-    "kv": {
-      "add": "Criar",
-      "delete multiple": {
-        "confirm": "Tem certeza de que deseja excluir: <code>{name}</code> KV(s)?",
-        "warning": "Você não tem permissões para esses namespaces, então eles serão omitidos: <code>{namespaces}</code>"
-      },
-      "duplicate": "Esta key já existe",
-      "inherited": "Pares KV herdados",
-      "name": "KV Store",
-      "type": "Tipo",
-      "update": "Atualizar valor para a key '{key}'"
-    },
-    "label": "Label",
-    "label filter placeholder": "Label como 'key:value'",
-    "labels": "Labels",
-    "last 48 hours": "últimas 48 horas",
-    "last X days count": "{count} nos últimos {days} dias",
-    "last error was": "O último erro foi",
-    "last evaluation date": "Data da última avaliação",
-    "last evaluation date tooltip": "When the trigger was last evaluated by the scheduler, regardless of whether it produced an execution.",
-    "last execution date": "Data da última execução",
-    "last execution state": "Último estado",
-    "last execution status": "Último status de execução",
-    "last modified": "Última modificação",
-    "last trigger date": "Data da última trigger",
-    "last trigger date tooltip": "Quando o trigger foi executado pela última vez. Pode estar no passado ao executar um backfill.",
-    "latest_update": "Última atualização",
-    "launch execution": "Executar",
-    "learn_more": "Saiba mais",
-    "leave page": "Sair da Página",
-    "license": "Licença",
-    "light_background": "Esta é a opção preferida ao trabalhar com um fundo claro.",
-    "light_version": "Versão clara",
-    "line": "Linha",
-    "line-by-line": "linha por linha",
-    "loaded x dependencies": "{count} dependências carregadas",
-    "loading": "Carregando...",
-    "log expand setting": "Exibição padrão do Log",
-    "logExporters": "Exportadores de Log",
-    "logs": "Logs",
-    "logs_copied": "Logs copied to your clipboard",
-    "logs_view": {
-      "compact": "Visualização padrão",
-      "compact_details": "Mostrar logs de task em uma visualização compacta agrupada por cada task",
-      "raw": "Visualização temporal",
-      "raw_details": "Mostrar logs completos de task e flow em formato bruto ordenado por timestamp"
-    },
-    "main_configuration": "Configuração Principal",
-    "manage labels": "Gerenciar labels",
-    "management port": "Port de gerenciamento",
-    "mark as": "Marcar como <code>{status}</code>",
-    "max": "Max",
-    "mcp": {
-      "api_token": "Token da API",
-      "auth_type": "Autenticação",
-      "basic_auth": "Autenticação Básica",
-      "bearer_token": "Autenticação por token Bearer",
-      "client_setup": "Configuração do cliente",
-      "connect": "Conectar",
-      "connect_tab": {
-        "auth_api_token_hint": "Defina <code>KESTRA_TOKEN</code> como variável de ambiente antes de iniciar o cliente.",
-        "auth_basic_hint": "Defina <code>KESTRA_BASIC_AUTH</code> como variável de ambiente contendo uma string <code>username:password</code> codificada em base64 antes de iniciar o cliente.",
-        "auth_oauth_browser_hint": "Seu navegador abrirá a página de login do provedor de identidade na primeira conexão.",
-        "auth_oauth_client_id_hint": "Substitua <code>&lt;client-id&gt;</code> pelo ID do cliente OAuth e registre <code>http://localhost:7777</code> como URI de redirecionamento válido nesse cliente.",
-        "claude_code": "Código Claude",
-        "claude_code_hint": "Execute o seguinte comando no seu terminal:",
-        "claude_desktop": "Claude Desktop",
-        "claude_desktop_hint": "Adicione o seguinte ao seu arquivo claude_desktop_config.json:",
-        "claude_desktop_mac": "macOS: ~/Library/Application Support/Claude/claude_desktop_config.json",
-        "claude_desktop_win": "Windows: %APPDATA%\\Claude\\claude_desktop_config.json",
-        "client_picker_label": "Escolha seu cliente de IA",
-        "codex": "Codex (OpenAI)",
-        "codex_hint": "Adicione o seguinte ao seu arquivo de configuração codex.json MCP:",
-        "cursor": "Cursor",
-        "cursor_hint": "Adicione o seguinte a ~/.cursor/mcp.json:",
-        "server_url": "URL do Servidor"
-      },
-      "copy_url": "Copiar URL",
-      "create": "Criar Servidor",
-      "delete_confirm": "Tem certeza de que deseja excluir este servidor MCP?",
-      "id_invalid": "O ID deve começar com uma letra minúscula ou dígito, e conter apenas letras minúsculas, dígitos, hífens ou underscores",
-      "id_placeholder": "por exemplo, meu-servidor-mcp",
-      "instructions": "Instruções",
-      "main_tenant": "principal",
-      "managed_by_kestra": "Gerenciado por Kestra",
-      "no_oauth_providers": "Nenhum provedor OIDC configurado nesta instância",
-      "no_servers": "Nenhum servidor MCP encontrado. Crie seu primeiro servidor para expor triggers da ferramenta MCP a agentes de IA externos.",
-      "oauth": "OAuth",
-      "oauth_hint": "Bearer JWT do seu provedor OIDC",
-      "oauth_provider": "Provedor OAuth",
-      "oauth_provider_placeholder": "Selecione um provedor OIDC configurado",
-      "oauth_provider_required": "O provedor OAuth é obrigatório quando o tipo de autenticação é OAuth",
-      "page_description": "Exponha seus flows do Kestra como ferramentas para agentes de IA compatíveis com MCP",
-      "private": "Privado",
-      "private_server": "Servidor privado",
-      "public": "Público",
-      "public_hint": "Aviso: Servidores públicos não exigem autenticação. Qualquer pessoa com a URL pode chamar todas as ferramentas expostas por este servidor, sem verificações de namespace ou permissão. Use apenas para servidores seguros para expor externamente.",
-      "save": "Salvar Alterações",
-      "scopes_supported": "Scopes suportados",
-      "scopes_supported_hint": "Scopes divulgados no documento Protected Resource Metadata deste servidor. Clientes MCP em conformidade com a especificação restringem sua solicitação de autorização a esta lista. Deixe vazio para omitir o campo e deixar os clientes recorrerem aos scopes divulgados pelo IdP.",
-      "scopes_supported_placeholder": "openid, profile, email",
-      "server": "Servidor MCP",
-      "server_id": "ID do servidor",
-      "server_type": "Tipo de Servidor",
-      "servers": "Servidores MCP",
-      "servers_count": "{count} Servidores MCP",
-      "tab_connect": "Conectar",
-      "tab_edit": "Editar",
-      "tab_tool_flows": "Fluxos de Ferramentas",
-      "tab_tool_flows_placeholder": "A gestão de tool flows estará disponível em breve.",
-      "tools": {
-        "annotations": "Anotações",
-        "create_tool_flow": "Criar um flow de ferramenta",
-        "description": "Descrição",
-        "destructive": "Destrutivo",
-        "flow": "flow",
-        "idempotent": "Idempotente",
-        "no_tools": "Nenhum flow de ferramenta corresponde à sua pesquisa.",
-        "open_world": "Open world",
-        "read_only": "Somente leitura",
-        "return_direct": "Retorno direto",
-        "state": "Estado",
-        "title": "Título",
-        "tool_name": "Nome da ferramenta",
-        "trigger_id": "ID do trigger",
-        "view_flow": "Abrir flow"
-      },
-      "url_copied": "URL copiado!",
-      "username_password": "Nome de usuário & senha",
-      "your_servers": "Seus Servidores"
-    },
-    "metric": "Métrica",
-    "metric choice": "Nenhuma métrica disponível para este flow",
-    "metrics": "Métricas",
-    "min": "Min",
-    "missingSource": "Fonte ausente",
-    "modify inputs": "Modificar inputs",
-    "modify_inputs": "Modificar inputs",
-    "monogram": "Monograma",
-    "more actions": "Mais ações",
-    "more_actions": "Mais Ações",
-    "multi_panel_editor": {
-      "close_all_panels": "Fechar todos os painéis",
-      "close_all_tabs": "Fechar todas as abas",
-      "move_left": "Mover para a esquerda",
-      "move_right": "Mover para a direita"
-    },
-    "multiple saved done": "{name} foi salvo",
-    "name": "Nome",
-    "namespace": "Namespace",
-    "namespace and id readonly": "As propriedades `namespace` e `id` não podem ser alteradas — elas estão definidas para seus valores iniciais. Se você quiser renomear um flow ou alterar seu namespace, você pode criar um novo flow e remover o antigo.",
-    "namespace files": {
-      "create": {
-        "file": "Criar arquivo",
-        "file_already_exists": "Um arquivo com este nome já existe",
-        "file_conflicts_with_folder": "Uma pasta com este nome já existe",
-        "file_error": "Ocorreu um erro ao criar o arquivo",
-        "folder": "Criar pasta",
-        "folder_already_exists": "Uma pasta com este nome já existe",
-        "folder_conflicts_with_file": "Um arquivo com este nome já existe",
-        "folder_error": "Ocorreu um erro ao criar a pasta",
-        "label": "Criar"
-      },
-      "delete": {
-        "file": "Excluir arquivo",
-        "files": "Excluir {count} arquivos selecionados",
-        "folder": "Excluir pasta",
-        "folders": "Excluir {count} pastas selecionadas",
-        "label": "Excluir"
-      },
-      "dialog": {
-        "deletion": {
-          "confirm": "Confirmar",
-          "file_single": "Tem certeza de que deseja excluir o arquivo <code>{name}</code>?",
-          "files": "Tem certeza de que deseja excluir <code>{count}</code> arquivo(s)?",
-          "folder_single": "Tem certeza de que deseja excluir a pasta <code>{name}</code> e todo o seu conteúdo?",
-          "folders": "Tem certeza de que deseja excluir <code>{count}</code> pasta(s) e todo o seu conteúdo?",
-          "mixed": "Tem certeza de que deseja excluir a(s) pasta(s) <code>{folders}</code> e o(s) arquivo(s) <code>{files}</code>?",
-          "title": "Confirmar exclusão de conteúdo"
-        },
-        "name": {
-          "file": "Nome com extensão:",
-          "folder": "Nome da pasta:"
-        },
-        "parent_folder": "Pasta pai:"
-      },
-      "export": "Exportar arquivos do namespace",
-      "export_single": "Exportar arquivo",
-      "filter": "Filtro",
-      "import": {
-        "error": "Ocorreu(ram) erro(s) ao importar o(s) arquivo(s)",
-        "files": "Importar arquivos",
-        "folder": "Importar pasta",
-        "import": "Importar",
-        "success": "Arquivo(s) importado(s) com sucesso"
-      },
-      "new_file": "Novo arquivo",
-      "no_items": {
-        "heading": "Nenhum arquivo encontrado no seu namespace ainda.",
-        "paragraph": "Crie ou importe arquivos para compartilhar código entre flows no seu namespace."
-      },
-      "no_selection": {
-        "description": "Selecione um arquivo da árvore para ver seu conteúdo.",
-        "heading": "Nenhum arquivo selecionado"
-      },
-      "path": {
-        "copy": "Copiar caminho",
-        "error": "Ocorreu(ram) erro(s) ao copiar o caminho para a área de transferência",
-        "success": "Caminho copiado para a área de transferência"
-      },
-      "rename": {
-        "file": "Renomear arquivo",
-        "folder": "Renomear pasta",
-        "label": "Renomear",
-        "new_file": "Novo nome com extensão:",
-        "new_folder": "Novo nome da pasta:"
-      },
-      "revisions": {
-        "history": "Histórico de revisões",
-        "restore": {
-          "success": "Revisão do arquivo restaurada com sucesso"
-        }
-      },
-      "toggle": {
-        "hide": "Ocultar arquivos do namespace",
-        "show": "Mostrar arquivos do namespace"
-      },
-      "tree": {
-        "collapse": "Colapsar todas as pastas",
-        "expand": "Expandir todas as pastas"
-      }
-    },
-    "namespace not allowed": "Namespace não permitido",
-    "namespace_editor": {
-      "close": {
-        "all": "Fechar todas as abas",
-        "other": "Fechar outras abas",
-        "right": "Fechar à direita",
-        "tab": "Fechar aba"
-      },
-      "empty": {
-        "create_message": "Você pode criar ou importar arquivos de namespace.",
-        "title": "Nenhuma aba aberta no momento",
-        "video_message": "Você pode assistir ao Vídeo de Introdução para o nosso Editor."
-      }
-    },
-    "namespaces": "Namespaces",
-    "neutral trend": "Estável",
-    "new": "Novo",
-    "new version": "Nova versão {version} disponível!",
-    "next": "Próximo",
-    "next evaluation date": "Próxima data de avaliação",
-    "next evaluation date tooltip": "Quando o trigger será avaliado novamente, com base em seu intervalo. Nem sempre é o mesmo que a próxima data de execução se as condições não forem atendidas.",
-    "next execution date": "Próxima data de execução",
-    "next_execution": "Próxima execução",
-    "no data current task": "Não há dados disponíveis para a tarefa atual",
-    "no inputs": "Este flow não tem inputs.",
-    "no metrics available": "Nenhuma métrica registrada para esta execução de task.",
-    "no outputs available": "Nenhuma saída disponível para esta execução de task.",
-    "no result": "Não há resultados para serem exibidos.",
-    "no revisions": "Sem revisões",
-    "no revisions found": "Existe apenas uma revisão para este flow",
-    "no-executions-view": {
-      "guidance_desc": "Precisa de orientação para executar o seu flow?",
-      "guidance_sub_desc": "Siga a documentação para todas as informações que você precisa.",
-      "namespace_guidance_desc": "Precisa de orientação para gerenciar seu Namespace?",
-      "namespace_sub_title": "Execute um ou mais flows deste namespace para preencher este dashboard.",
-      "sub_title": "Clique no botão Executar para iniciar a execução do seu primeiro fluxo de trabalho.",
-      "title": "Comece a automatizar com"
-    },
-    "no_code": {
-      "add_field": "Adicionar {field}",
-      "adding": "+ Adicionar um {what}",
-      "adding_default": "+ Adicionar um novo value",
-      "clearSelection": "Limpar seleção",
-      "creation": {
-        "afterExecution": "Adicionar um bloco após a execução",
-        "charts": "Adicionar um gráfico",
-        "conditions": "Adicionar uma condição",
-        "default": "Adicionar",
-        "errors": "Adicionar um manipulador de erro",
-        "finally": "Adicionar um bloco finally",
-        "inputs": "Adicionar um campo de input",
-        "numerator": "Adicionar um numerador",
-        "pluginDefaults": "Adicionar um padrão de plugin",
-        "tasks": "Adicionar uma task",
-        "triggers": "Adicionar um trigger",
-        "where": "Filtrar seus dados"
-      },
-      "fields": {
-        "general": {
-          "checks": "Verificações",
-          "concurrency": "Concorrência",
-          "disabled": "Desativado",
-          "labels": "Etiquetas",
-          "listeners": "Ouvintes",
-          "outputs": "Saídas",
-          "retry": "Repetir",
-          "sla": "SLA",
-          "taskDefaults": "Padrões de Task",
-          "updated": "Atualizado",
-          "variables": "Variáveis",
-          "workerGroup": "Grupo de Worker",
-          "workerSelector": "Seletor de Worker"
-        },
-        "main": {
-          "description": "Descrição",
-          "id": "ID do Flow",
-          "inputs": "Entradas",
-          "namespace": "Namespace"
-        }
-      },
-      "labels": {
-        "label": "Etiqueta",
-        "no_code": "Editor Sem Código",
-        "variable": "Variável",
-        "yaml": "Editor YAML"
-      },
-      "remove": {
-        "cases": "Remover este caso",
-        "default": "Remover esta entrada"
-      },
-      "sections": {
-        "afterExecution": "Após a Execução",
-        "deprecated": "Propriedades obsoletas",
-        "errors": "Manipuladores de Erro",
-        "finally": "Finalmente",
-        "pluginDefaults": "Padrões de Plugin",
-        "tasks": "Tarefas",
-        "triggers": "Triggers"
-      },
-      "select": {
-        "afterExecution": "Selecione uma task",
-        "charts": "Selecione um tipo de gráfico",
-        "conditions": "Selecione uma condição",
-        "default": "Selecione um tipo",
-        "errors": "Selecione uma task",
-        "finally": "Selecione uma task",
-        "inputs": "Selecione um tipo de campo de input",
-        "numerator": "Selecione um numerador",
-        "pluginDefaults": "Selecione um plugin",
-        "task": "Selecione uma task",
-        "tasks": "Selecione uma task",
-        "triggers": "Selecione um trigger",
-        "where": "Selecione um tipo de filtro"
-      },
-      "toggle_pebble": "Alternar editor Pebble",
-      "unnamed": "Sem Nome",
-      "version_oss_placeholder": "Desbloqueie a Versionamento de Plugin com a Enterprise Edition"
-    },
-    "no_data": "Parece que não há nada aqui... ainda!<br/>Ajuste seus filtros ou tente novamente!",
-    "no_file_choosen": "Nenhum arquivo selecionado",
-    "no_flow_outputs": "Sem outputs disponíveis.",
-    "no_history": "Sem histórico disponível",
-    "no_inputs": "Nenhum input disponível.",
-    "no_logs_data": "Sem Dados",
-    "no_logs_data_description": "Tente ajustar seus filtros, alterar o intervalo de tempo ou verificar se o flow foi executado recentemente.",
-    "no_logs_data_title": "Nenhum log encontrado para os filtros selecionados.",
-    "no_namespaces": "Nenhum namespace corresponde aos critérios de busca.",
-    "no_results": {
-      "assets": "Nenhum Asset Encontrado",
-      "executions": "Nenhuma Execução Encontrada",
-      "flows": "Nenhum Flow Encontrado",
-      "kv_pairs": "Nenhum par de Key-Value encontrado",
-      "secrets": "Nenhum Secret Encontrado",
-      "templates": "Nenhum Template Encontrado",
-      "triggers": "Nenhum Trigger Encontrado"
-    },
-    "no_results_found": "Nenhum resultado encontrado",
-    "no_tasks_running": "Ainda não há tasks em execução.",
-    "no_trigger": "Nenhum trigger disponível.",
     "no_variables": "Nenhuma variável disponível.",
-    "now": "Agora",
-    "of": "de",
-    "ok": "OK",
-    "onboarding": {
-      "actions": {
-        "cancel_tutorial": "Cancelar tutorial",
-        "complete": "Concluir",
-        "edit_flow_to_continue": "Clique em Editar flow na barra superior (à direita).",
-        "execute_to_continue": "1. Clique em Executar na barra superior (à direita).\n2. Forneça um valor para <strong>name</strong>.\n3. Clique em Executar novamente no modal.",
-        "finish_tutorial": "Finalizar tutorial",
-        "next": "Próximo",
-        "save_to_continue": "Clique em Salvar na barra superior (à direita)."
-      },
-      "cancel_modal": {
-        "confirm": "Cancelar tutorial",
-        "description": "Você deseja cancelar o tutorial Primeiro Flow?",
-        "keep": "Manter tutorial",
-        "title": "Cancelar o tutorial Primeiro Flow"
-      },
-      "editor_hints": {
-        "build_intro": "Crie seu primeiro flow passo a passo.",
-        "step_1": "# 1) Adicionar id",
-        "step_2": "# 2) Adicionar namespace",
-        "step_3": "# 3) Adicionar um input",
-        "step_4": "# 4) Adicionar tasks e sua primeira task Python",
-        "step_5": "# 5) Adicionar um gatilho cron"
-      },
-      "finish_actions": {
-        "create_flow": "Criar flow",
-        "explore_blueprints": "Explorar Blueprints"
-      },
-      "steps": {
-        "add_cron_trigger": {
-          "description": "Triggers podem iniciar execuções com base em agendamentos ou eventos externos (por exemplo, webhooks ou mensagens MQTT).<br><br>Agora adicione um gatilho de agendamento cron para que este flow seja executado a cada 5 minutos.",
-          "title": "Adicionar um gatilho cron"
-        },
-        "add_id": {
-          "description": "O ID é o nome único do seu flow, para que você possa encontrá-lo, executá-lo e referenciá-lo de forma consistente.<br><br>Agora adicione <code>id</code> no nível raiz.",
-          "title": "Adicionar ID do flow"
-        },
-        "add_input": {
-          "description": "Inputs são parâmetros em nível de flow que podem ser referenciados dentro das tarefas para controlar dinamicamente o comportamento em tempo de execução.<br><br>Agora adicione um input chamado <code>name</code> com o tipo <code>STRING</code>.",
-          "title": "Adicionar um input"
-        },
-        "add_input_default": {
-          "description": "Quando um flow é acionado automaticamente, os inputs ainda precisam de valores em tempo de execução.<br><br>O input <code>name</code> já foi criado na etapa anterior, então não é necessário adicioná-lo novamente. Basta definir um valor padrão para o input existente <code>name</code>.",
-          "title": "Definir um valor padrão para o input"
-        },
-        "add_log_task": {
-          "description": "Tasks são as unidades de trabalho que seu flow executa, definidas como uma lista ordenada de etapas. Cada task precisa de um <code>id</code> único e um <code>type</code>. O Kestra fornece muitos plugins de tasks para sistemas externos; aqui usamos uma task de Python Script.<br><br>A sintaxe <code>&#123;&#123; ... &#125;&#125;</code> é uma expressão Pebble, usada para referenciar variáveis dinamicamente em tempo de execução, como <code>&#123;&#123; inputs.name &#125;&#125;</code> a partir dos inputs do flow.<br><br>Agora adicione a primeira task em <code>tasks</code> com <code>id</code>, <code>type</code> e um <code>script</code> que imprima uma saudação.",
-          "title": "Adicionar a primeira tarefa"
-        },
-        "add_namespace": {
-          "description": "O Namespace é um agrupamento semelhante a uma pasta que organiza flows por equipe, projeto ou ambiente.<br><br>Agora adicione <code>namespace</code> no nível raiz.",
-          "title": "Adicionar namespace"
-        },
-        "background_runs_info": {
-          "description": "Este flow agora será executado em segundo plano a cada 5 minutos.<br><br>Você pode navegar até a visão geral de Execuções no menu à esquerda para monitorar as execuções agendadas.",
-          "title": "Execuções agendadas"
-        },
-        "edit_flow_from_execution": {
-          "description": "Você pode ir diretamente de uma execução para a definição do flow para iterar rapidamente.",
-          "title": "Voltar ao Editor de Flow"
-        },
-        "execute_flow": {
-          "description": "Executar inicia uma execução do seu flow com valores de input em tempo de execução.",
-          "title": "Executar flow"
-        },
-        "finish": {
-          "description": "Ótimo começo. Você criou, executou, parametrizou e agendou um flow.<br><br>Escolha o que fazer a seguir ...",
-          "title": "Você concluiu o tutorial Primeiro Flow"
-        },
-        "flow_basics": {
-          "description": "No Kestra, um <code>flow</code> é a unidade central de orquestração. Você o define em YAML com metadados e tarefas ordenadas.<br><br>Revise a estrutura de exemplo abaixo e depois continue a construí-la passo a passo.",
-          "title": "Noções básicas de flow"
-        },
-        "save_flow": {
-          "description": "Salvar persiste a definição do seu flow para que ele possa ser executado.",
-          "title": "Salvar flow"
-        },
-        "save_flow_again": {
-          "description": "Seu flow agora tem um agendamento e um valor padrão de input para execuções automáticas.",
-          "title": "Salvar flow"
-        },
-        "view_logs_status": {
-          "description": "Os detalhes da execução mostram o status, o tempo e os logs de saída em nível de task.<br><br>Agora abra os detalhes da execução e clique em <code>greet</code> no gráfico de Gantt para ver os logs.",
-          "title": "Verificar execução"
-        }
-      },
-      "validation": {
-        "add_cron_trigger_cron": "Adicione uma expressão cron, por exemplo: `\"*/5 * * * *\"`.",
-        "add_cron_trigger_section": "Crie uma seção `triggers` com um gatilho de agendamento.",
-        "add_cron_trigger_type": "Defina o tipo do gatilho como `io.kestra.plugin.core.trigger.Schedule`.",
-        "add_id": "Adicione um ID de flow no topo. Exemplo: `id: hello_flow`.",
-        "add_input_default_defaults": "Adicione um valor padrão para `name`, por exemplo: `defaults: \"Kestra\"`.",
-        "add_input_default_id": "Mantenha o ID do input existente como `name`.",
-        "add_input_default_section": "Volte para `inputs` e mantenha um input existente chamado `name` (não adicione um segundo input).",
-        "add_input_id": "Dentro de `inputs`, adicione `id: name`.",
-        "add_input_section": "Crie uma seção `inputs` com um input.",
-        "add_input_type": "Defina o tipo do input como `STRING`.",
-        "add_log_task_id": "Dê um ID à task, por exemplo: `id: greet`.",
-        "add_log_task_message": "Adicione um campo `script` à task.",
-        "add_log_task_pebble": "Use uma expressão Pebble no script para que ele utilize o valor do seu input (por exemplo: `inputs.name`).",
-        "add_log_task_section": "Crie uma seção `tasks` e adicione sua primeira task.",
-        "add_log_task_type": "Defina o tipo da task como `io.kestra.plugin.scripts.python.Script`.",
-        "add_namespace": "Adicione um namespace no topo. Exemplo: `namespace: company.team`.",
-        "complete_step": "Você está quase lá. Conclua esta etapa para continuar.",
-        "edit_flow_from_execution": "Clique em `Editar flow` na barra superior para continuar.",
-        "execute_flow": "Execute o flow uma vez para continuar.",
-        "fix_yaml": "Há um pequeno problema de formatação YAML. Corrija-o e depois continue.",
-        "save_flow": "Clique em Salvar para continuar.",
-        "save_flow_again": "Clique em Salvar novamente para continuar.",
-        "view_logs_status": "Abra os detalhes da execução e verifique os logs de `greet`."
-      },
-      "welcome": {
-        "additional_help": "Ajuda adicional",
-        "badge": "Tutorial",
-        "blueprints": "Blueprints",
-        "docs": "Documentação",
-        "guided_description": "Aprenda a criar e executar seu primeiro flow com passos guiados.",
-        "guided_duration": "Recomendado para a maioria dos usuários",
-        "guided_title": "Crie seu primeiro flow",
-        "headline": "Crie e execute seu primeiro workflow em minutos",
-        "self_serve_description": "Vá direto para o editor e crie seu próprio flow.",
-        "self_serve_note": "Para usuários experientes",
-        "self_serve_title": "Criar flow do zero",
-        "slack": "Comunidade no Slack",
-        "tutorial": "Tutorial"
-      }
+    "download": "Baixar",
+    "jsonl": "JSONL",
+    "concurrency_limit": {
+      "dialog_title": "Limites de Concurrency",
+      "warning": "Alterar o contador em execução pode corromper a concorrência, fazendo com que as execuções excedam o limite permitido."
     },
-    "open": "Abrir",
-    "open full page": "Abrir Página Completa",
-    "open in new tab": "Em uma nova aba",
-    "open in same tab": "Na mesma aba",
-    "open sidebar": "abrir barra lateral",
-    "open source": "Código Aberto",
-    "open_page": "Open page",
-    "optional": "Opcional",
-    "original execution": "Execução original",
-    "originalCreatedDate": "Data de criação original",
-    "outdated revision save confirmation": {
-      "confirm": "Deseja sobrescrever?",
-      "create": {
-        "description": "Um flow com o mesmo id já existe neste namespace.",
-        "details": "Salvar para substituir e criar uma nova revisão.",
-        "title": "Flow já existe"
-      },
-      "update": {
-        "description": "A revisão que você está editando está desatualizada.",
-        "details": "Verifique a aba de Revisões para mais detalhes sobre a última versão.",
-        "title": "Revisão desatualizada"
-      }
+    "documentation": {
+      "documentation": "Documentação",
+      "github": "Abrir um issue no GitHub"
     },
-    "output": "Output",
-    "outputs": "Outputs",
-    "override": {
-      "details": "O flow anterior pode ser restaurado na aba Revisions.",
-      "title": "Você está prestes a sobrescrever o flow atual"
-    },
-    "overview": "Visão geral",
-    "page": {
-      "next": "Próxima página",
-      "previous": "Página anterior"
-    },
-    "panel actions": "Ações do painel",
-    "parent execution": "Execução pai",
-    "password": "Senha",
-    "password empty constraint": "Nome de usuário ou senha incorretos",
-    "password length constraint": "Senha não deve exceder 256 caracteres",
-    "passwords do not match": "Senhas não coincidem",
-    "pause": "Pausar",
-    "pause backfill": "Pausar o backfill",
-    "pause backfills": "Pausar backfills",
-    "pause confirm": "Tem certeza de que deseja pausar a execução <code>{id}</code>?",
-    "pause done": "A execução está PAUSED",
-    "pause title": "Pausar execução <code>{id}</code>.<br/>Note que as tasks atualmente em execução ainda serão processadas, e a execução terá que ser retomada manualmente.",
-    "paused": "PAUSED",
-    "playground": {
-      "clear_history": "Limpar histórico",
-      "confirm_create": "Você não pode executar o playground enquanto cria um flow. Iniciar uma execução do playground criará o flow.",
-      "history": "Últimas 10 execuções",
-      "play_icon_info": "Você também pode clicar no ícone de Play nas visualizações No-Code ou Topology.",
-      "run_all_tasks": "Executar Todas as Tasks",
-      "run_task": "Executar Task",
-      "run_task_and_downstream": "Executar task & downstream",
-      "run_task_info": "Passe o cursor sobre qualquer task no editor de Flow Code e clique no botão \"Run task\" para testar sua task.",
-      "run_this_task": "Execute esta task",
-      "title": "Playground",
-      "toggle": "Playground",
-      "tooltip_persistence": "Se você desligar e ligar o Playground novamente, as informações permanecem enquanto você estiver na página."
-    },
-    "playground actions": "Ações do Playground",
-    "plugin defaults exported": "Padrões do plugin exportados",
-    "plugin defaults imported": "Padrões de plugin importados",
-    "plugin defaults not imported": "Alguns padrões de plugin não puderam ser importados",
-    "pluginDefaults": {
-      "add": "Adicionar Plugin Padrão",
-      "add_subtitle": "Configurar um novo plugin padrão com suas propriedades",
-      "cancel": "Cancelar",
-      "custom": "Plugin Personalizado",
-      "custom_configure": "Tipo de plugin personalizado - configure usando YAML",
-      "custom_placeholder": "Insira o tipo de plugin",
-      "custom_type": "Tipo de plugin personalizado",
-      "edit": "Editar Padrão do Plugin",
-      "edit_subtitle": "Modificar a configuração padrão do plugin existente",
-      "form": "Formulário",
-      "predefined": "Plugin Predefinido",
-      "select_predefined": "Selecionar Plugin Predefinido",
-      "show_yaml": "Mostrar YAML",
-      "title": "Padrões do Plugin",
-      "update": "Atualizar Plugin Padrão",
-      "use_custom": "Usar Personalizado",
-      "yaml": "YAML",
-      "yaml_configuration": "Configuração YAML"
-    },
-    "pluginPage": {
-      "elementType": {
-        "apps": "Aplicativo",
-        "charts": "Gráfico",
-        "conditions": "Condição",
-        "logExporters": "Exportador de log",
-        "secrets": "Secreto",
-        "taskRunners": "Executor de task",
-        "tasks": "Tarefa",
-        "triggers": "Trigger"
-      },
-      "group": {
-        "blueprints": "Blueprints ({count})",
-        "plugins": "Plugins ({count})",
-        "tasks": "Tarefas ({count})"
-      },
+    "blueprints": {
+      "all": "Todos",
+      "community": "Comunidade",
+      "create": "Criar um blueprint",
+      "edit": "Editar um blueprint",
+      "title": "Blueprints",
+      "empty": "Nenhum blueprint para mostrar.",
       "header": {
-        "back": "Voltar para plugins",
-        "certified": "Certificado",
-        "enterpriseEdition": "Edição Enterprise"
+        "catch phrase": {
+          "1": "O primeiro passo é sempre o mais difícil.",
+          "2": "Explore blueprints para iniciar seu próximo {kind}."
+        },
+        "alt": "Ícone de Blueprints"
       },
-      "loadError": "Não foi possível carregar os plugins. Por favor, tente novamente.",
-      "noResults": "Nenhum plugin corresponde à sua pesquisa.",
-      "notFound": "Este plugin não pôde ser encontrado.",
-      "overview": {
-        "createdBy": "Criado por",
-        "latest": "Mais recente",
-        "linksResources": "Links e Recursos",
-        "managedBy": "Gerenciado por",
-        "minKestraVersion": "Versão mínima compatível do Kestra: {version}",
-        "minKestraVersionShort": "Versão mínima do Kestra {version}",
-        "pluginType": "Tipo de plugin",
-        "previousVersions": "Versões anteriores",
-        "releaseNotes": "Notas de versão",
-        "title": "Visão Geral",
-        "versions": "Versões"
+      "custom": "Blueprints personalizados",
+      "flows": "Blueprints de Flow",
+      "apps": "Blueprints do Aplicativo",
+      "dashboards": "Blueprints do Dashboard",
+      "detail": {
+        "category": "Tipo de categoria",
+        "links": "Link & Recursos",
+        "openInEditor": "Abrir em Edit Flow"
       },
-      "search": "Pesquisar em mais de {count} plugins",
-      "searchTasks": "Pesquisar {count} tasks",
-      "sort": {
-        "mostUsed": "Mais usados",
-        "nameAsc": "Nome A-Z",
-        "nameDesc": "Nome Z-A",
-        "newest": "Mais recente"
-      },
-      "sortBy": "Ordenar por"
+      "missingPlugins": {
+        "title": "Plugins ausentes",
+        "description": "Este blueprint usa tasks de plugin(s) que não estão instalados nesta instância: {plugins}. Instale-os para usar este blueprint.",
+        "card": "Requer plugin(s) não instalados nesta instância: {plugins}",
+        "install": "Instalar plugins"
+      }
     },
-    "plugin_default_already_exists": "O padrão do plugin para <code>{type}</code> já existe.",
+    "use": "Usar",
     "plugins": {
       "name": "Plugin",
       "names": "Plugins",
       "please": "Por favor, escolha uma task à direita para ver sua documentação",
       "release": "Notas de lançamento"
     },
-    "port": "Port",
-    "prefill inputs": "Preencher automaticamente",
-    "pretty_json": "Pretty JSON",
-    "prev_execution": "Execução anterior",
-    "preview": {
-      "auto-view": "Visualização automática",
-      "collapse": "Recolher",
-      "expand": "Expandir",
-      "force-editor": "Forçar visualização do editor",
-      "label": "Visualizar",
-      "next": "Próximo",
-      "page_of": "Página {current} de {total}",
-      "pagination_info": "Exibindo linhas {start}-{end} de {total}.",
-      "previous": "Anterior",
-      "rows_truncated": "Mostrando {shown} de {total} linhas. Baixe o arquivo para ver todos os dados.",
-      "showing_rows": "Mostrando linhas {start}-{end} de {total}",
-      "view": "Visualizar"
+    "last execution date": "Data da última execução",
+    "last execution state": "Último estado",
+    "last X days count": "{count} nos últimos {days} dias",
+    "date range count": "{count} entre {startDate} e {endDate}",
+    "date count": "{count} em {date}",
+    "revisions": "Revisões",
+    "no revisions found": "Existe apenas uma revisão para este flow",
+    "no revisions": "Sem revisões",
+    "see full revision": "Ver revisão completa",
+    "side-by-side": "lado a lado",
+    "line-by-line": "linha por linha",
+    "template": "Template",
+    "template creation": "Criação de template",
+    "templates": "Templates",
+    "templates deprecated": "Templates estão obsoletos. Por favor, use subflows. Veja a <a href=\"https://kestra.io/docs/migration-guide/0.11.0/templates?utm_source=app&utm_medium=referral&utm_campaign=template-inlinedoc\" target=\"_blank\">Seção de Migrações</a> explicando como você pode migrar de templates para subflows.",
+    "no result": "Não há resultados para serem exibidos.",
+    "empty search": "Resultados da pesquisa estão vazios",
+    "trigger": "Trigger",
+    "no_trigger": "Nenhum trigger disponível.",
+    "triggers": "Triggers",
+    "triggers_header_description": "Navegue, adicione e gerencie triggers para automatizar seus flows. Escolha entre expor seu flow como uma ferramenta de IA, agendar, adicionar um webhook trigger, verificar mudanças em aplicativos externos ou ouvintes de eventos em tempo real.",
+    "triggers_tabs_add": "Adicionar",
+    "triggers_tabs_manage": "Gerenciar",
+    "triggers_add_search_placeholder": "Procurar triggers...",
+    "triggers_add_filter_core": "Núcleo",
+    "triggers_add_filter_realtime": "Tempo real",
+    "triggers_add_filter_all": "Todos",
+    "triggers_add_filter_app": "Aplicativo",
+    "triggers_add_empty_title": "Nenhum trigger encontrado",
+    "triggers_add_ee_tooltip": "Este trigger requer a Enterprise Edition.",
+    "triggers_add_category_empty": "Nenhum trigger nesta categoria.",
+    "triggers_add_card_add_to_flow": "Adicionar ao flow",
+    "triggers_add_card_add": "Adicionar",
+    "triggers_add_modal_title": "{name}",
+    "triggers_add_modal_tab_form": "Formulário",
+    "triggers_add_modal_tab_source": "Fonte",
+    "triggers_add_modal_tab_documentation": "Documentação",
+    "triggers_add_modal_namespace_placeholder": "Selecione um namespace",
+    "triggers_add_modal_flow_placeholder": "Selecione um flow",
+    "triggers_add_modal_trigger_id": "ID do Trigger",
+    "triggers_add_modal_trigger_id_placeholder": "Identificador único para este trigger",
+    "triggers_add_modal_properties_hint": "Configure as propriedades do trigger no editor de flow após adicionar o trigger.",
+    "triggers_add_modal_ee_notice": "Este trigger requer a Enterprise Edition.",
+    "triggers_add_modal_add_button": "Adicionar Trigger ao Flow",
+    "trigger details": "Detalhes do trigger",
+    "triggerflow disabled": "Trigger está desativado na definição do flow",
+    "last trigger date": "Data da última trigger",
+    "trigger_states": "Estados",
+    "context updated date": "Data de atualização do contexto",
+    "state updated date": "Data de atualização do estado",
+    "next evaluation date": "Próxima data de avaliação",
+    "last evaluation date": "Data da última avaliação",
+    "last trigger date tooltip": "Quando o trigger foi executado pela última vez. Pode estar no passado ao executar um backfill.",
+    "context updated date tooltip": "Quando o contexto do trigger foi atualizado pela última vez. Isso ocorre quando a execução é acionada, termina (bloqueio liberado) ou após uma avaliação (mesmo que nenhuma execução ocorra).",
+    "next evaluation date tooltip": "Quando o trigger será avaliado novamente, com base em seu intervalo. Nem sempre é o mesmo que a próxima data de execução se as condições não forem atendidas.",
+    "last evaluation date tooltip": "When the trigger was last evaluated by the scheduler, regardless of whether it produced an execution.",
+    "conditions": "Condições",
+    "triggerId": "ID do Trigger",
+    "tenantId": "ID do Cliente",
+    "codeDisabled": "Desativado no Flow",
+    "paused": "PAUSED",
+    "running": "Executando",
+    "Fold auto": "Editor: dobra automática de multilinhas",
+    "Hover description": "Editor: Mostrar descrição do campo ao passar o mouse sobre o key ou value",
+    "Fold content lines": "Dobrar strings multilinhas",
+    "Unfold content lines": "Desdobrar strings multilinhas",
+    "Total": "Total",
+    "sub flow": "Subflow",
+    "execute": "Executar",
+    "execute flow behaviour": "Executar o flow",
+    "open in same tab": "Na mesma aba",
+    "open in new tab": "Em uma nova aba",
+    "execute the flow": "Executar o flow <code>{id}</code>",
+    "execute flow now ?": "Deseja executar este flow?",
+    "discard execution confirmation": "Você tem inputs não salvos. Tem certeza de que deseja descartar esta execução?",
+    "discard changes confirmation": "Você tem alterações não salvas. Tem certeza de que deseja descartá-las?",
+    "Default namespace": "Namespace padrão",
+    "Default log level": "Nível de log padrão",
+    "unsaved changed ?": "Você tem alterações não salvas, deseja sair desta página?",
+    "unsaved changes": "Alterações Não Salvas",
+    "unsaved changes warning": "Você tem alterações não salvas. Se você sair desta página, suas alterações serão perdidas.",
+    "leave page": "Sair da Página",
+    "open full page": "Abrir Página Completa",
+    "drill down preview": "Pré-visualização",
+    "Editor theme": "Tema do editor",
+    "Editor fontsize": "Tamanho da fonte do editor",
+    "Editor fontfamily": "Família de fontes do editor",
+    "errors": {
+      "401": {
+        "title": "Não autorizado",
+        "content": "Você precisa estar autenticado para acessar esta página."
+      },
+      "403": {
+        "title": "Acesso negado",
+        "content": "Você não tem as permissões necessárias para acessar esta página."
+      },
+      "404": {
+        "title": "Página não encontrada",
+        "content": "A URL solicitada não foi encontrada neste servidor.<br />Isso é tudo que sabemos.",
+        "flow or execution": "O flow ou execução que você está procurando não existe."
+      }
     },
-    "pricing": "Preços",
-    "product_tour": "Tour do Produto",
-    "properties": {
-      "hidden": "Oculto na Tabela",
-      "hint": "Escolher Colunas Visíveis",
-      "label": "Propriedades",
-      "shown": "Exibido na Tabela"
+    "back_to_dashboard": "Voltar ao dashboard",
+    "copy all logs": "Copiar Todos os Logs",
+    "copy logs": "Copiar logs",
+    "fix_with_ai": "Corrigir com AI",
+    "download logs": "Baixar logs",
+    "delete logs": "Excluir logs",
+    "delete_all_logs": "Tem certeza de que deseja excluir todos os logs?",
+    "delete_log": "Tem certeza de que deseja excluir o log?",
+    "toggle fullscreen": "Alternar tela cheia",
+    "copied": "Copiado",
+    "tags": "Tags",
+    "disabled flow title": "Este flow está desativado",
+    "disabled flow desc": "Este flow está desativado, por favor, ative-o para executá-lo.",
+    "label": "Label",
+    "labels": "Labels",
+    "label filter placeholder": "Label como 'key:value'",
+    "execution labels": "Labels de execução",
+    "wrong labels": "Chave ou valor vazio não é permitido em labels",
+    "feeds": {
+      "title": "Novidades no Kestra",
+      "heading": "Tudo sobre Kestra.",
+      "subheading": "As últimas atualizações, guias e histórias"
     },
-    "queued duration": "Duração na fila",
-    "quotas": "Cotas",
-    "reach us": "Fale conosco",
-    "read-more": "Leia mais sobre",
-    "readonly property": "Propriedade somente leitura",
-    "recent_executions": "Execuções Recentes",
-    "refresh": "Atualizar",
-    "reject": "Rejeitar",
-    "relative": "Relativo",
-    "relative end date": "Data de término relativa",
-    "relative start date": "Data de início relativa",
-    "remove label": "Remover label",
-    "remove this item": "Remover este item",
-    "remove_bookmark": "Tem certeza de que deseja remover este marcador?",
-    "replay": "Repetir",
-    "replay confirm": "Tem certeza de que deseja repetir esta execução <code>{id}</code> e criar uma nova?",
-    "replay execution description": "Isso criará uma nova execução com base na execução selecionada.",
-    "replay execution title": "Reexecutar execução",
-    "replay from beginning tooltip": "Criar uma execução similar começando do início",
-    "replay from task tooltip": "Criar uma execução similar começando da task <code>{taskId}</code>",
-    "replay inputs": "Entradas",
-    "replay inputs new required": "Esta revisão possui inputs. Você será solicitado a preenchê-los.",
-    "replay latest revision": "Repetir usando a última revisão",
-    "replay select taskrun": "Selecione o task run para reproduzir a partir de:",
-    "replay the execution": "Reproduzir a execução <code>{executionId}</code> para o flow <code>{flowId}</code>",
-    "replay using": "Repetir usando",
-    "replay with inputs": "Repetir com inputs",
-    "replayed": "A execução é Reexecutada",
-    "required field": "Campo obrigatório",
-    "reset": "Reiniciar",
-    "reset to defaults": "Redefinir para padrões",
-    "restart": "Reiniciar",
-    "restart change revision": "Você pode alterar a revisão que será usada para a nova execução.",
-    "restart confirm": "Tem certeza de que deseja reiniciar a execução <code>{id}</code>?",
-    "restart execution title": "Reiniciar execução",
-    "restart latest revision": "Reiniciar última revisão",
-    "restart tooltip": "Reiniciar a execução a partir da task <code>{state}</code>",
-    "restart trigger": {
-      "button": "Reiniciar trigger",
-      "tooltip": "Reiniciar o trigger"
-    },
-    "restarted": "A execução foi reiniciada",
+    "delete execution running": "<div class=\"alert alert-warning mt-2 mb-0\">Esta execução ainda está RUNNING, deletá-la não irá pará-la.<br />Você precisa matar a execução para pará-la.</div>",
     "restore": "Restaurar",
     "restore confirm": "Tem certeza de que deseja restaurar a revisão <code>{revision}</code>?",
+    "bulk delete": "Tem certeza de que deseja excluir <code>{executionCount}</code> execução(ões)?",
+    "bulk replay": "Tem certeza de que deseja reproduzir <code>{executionCount}</code> execução(ões)?",
+    "bulk change state": "Tem certeza de que deseja alterar o estado de <code>{executionCount}</code> execução(ões)?",
+    "bulk resume": "Tem certeza de que deseja retomar <code>{executionCount}</code> execução(ões)?",
+    "bulk pause": "Tem certeza de que deseja pausar a(s) execução(ões) <code>{executionCount}</code>?",
+    "bulk unqueue": "Tem certeza de que deseja remover da fila <code>{executionCount}</code> execução(ões)?",
+    "bulk force run": "Tem certeza de que deseja forçar a execução de <code>{executionCount}</code> execução(ões)?<br/><br/>AVISO: forçar a execução de uma execução não é garantido e pode criar execuções de tarefas duplicadas.<br/><br/>As seguintes transições serão realizadas:<br/><ul><li>Tarefas CREATED serão movidas para o estado RUNNING.</li><li>Tarefas RUNNING serão re-submetidas.</li><li>Tarefas QUEUED serão removidas da fila.</li><li>Tarefas PAUSED serão retomadas.</li></ul>",
+    "bulk restart": "Tem certeza de que deseja reiniciar <code>{executionCount}</code> execução(ões)?",
+    "bulk kill": "Tem certeza de que deseja matar <code>{executionCount}</code> execução(ões)?",
+    "selection": {
+      "selected": "<strong>{count}</strong> selecionado(s)",
+      "all": "Selecionar todos ({count})"
+    },
+    "cancel": "Cancelar",
+    "errorLogs": "Logs de erros",
+    "welcome_page": {
+      "welcome": "Bem-vindo ao Kestra",
+      "guide": "Precisa de orientação para executar seu primeiro flow?"
+    },
+    "product_tour": "Tour do Produto",
+    "executions replayed": "<code>{executionCount}</code> execução(ões) reproduzida(s)",
+    "executions state changed": "O estado de <code>{executionCount}</code> execução(ões) foi alterado",
+    "executions resumed": "<code>{executionCount}</code> execução(ões) retomada(s)",
+    "executions paused": "<code>{executionCount}</code> execução(ões) PAUSED",
+    "executions unqueue": "<code>{executionCount}</code> execução(ões) na fila",
+    "executions force run": "<code>{executionCount}</code> execução(ões) forçada(s) em execução",
+    "executions restarted": "<code>{executionCount}</code> execução(ões) reiniciada(s)",
+    "executions killed": "<code>{executionCount}</code> execução(ões) morta(s)",
+    "executions deleted": "<code>{executionCount}</code> execução(ões) deletada(s)",
+    "invalid bulk replay": "Não foi possível reproduzir execuções",
+    "invalid bulk resume": "Não foi possível retomar execuções",
+    "invalid bulk pause": "Não foi possível pausar as execuções",
+    "invalid bulk unqueue": "Não foi possível remover as execuções da fila",
+    "invalid bulk force run": "Não foi possível forçar a execução das execuções",
+    "invalid bulk restart": "Não foi possível reiniciar execuções",
+    "invalid bulk kill": "Não foi possível matar execuções",
+    "invalid bulk delete": "Não foi possível excluir execuções",
+    "execution not found": "Execução {executionId} não encontrada.",
+    "execution not in state PAUSED": "Execução <code>{executionId}</code> não está no estado PAUSED",
+    "execution not in state FAILED": "Execução <code>{executionId}</code> não está no estado FAILED",
+    "execution already finished": "Execução <code>{executionId}</code> já finalizada",
     "restore revision": "Tem certeza de que deseja restaurar a revisão <code>{revision}</code>?",
-    "resume": "Retomar",
-    "resume from breakpoint done": "A execução é retomada a partir do ponto de interrupção",
-    "resume from breakpoint title": "Retomar execução <code>{id}</code> a partir do ponto de interrupção",
-    "resumed confirm": "Tem certeza de que deseja retomar a execução <code>{id}</code>?",
-    "resumed done": "Execução foi retomada",
-    "resumed title": "Retomar execução <code>{id}</code>",
-    "reuse original inputs": "Reutilizar inputs originais",
-    "reuse_original_inputs": "Reutilizar inputs originais",
-    "review your inputs": "Revise suas entradas",
-    "revision": "Revisão",
-    "revision deleted": "A revisão {revision} foi excluída com sucesso",
-    "revisions": "Revisões",
-    "row count": "Contagem de linhas",
-    "run task in playground": "Executar task no playground",
+    "seeing old revision": "Você está vendo uma revisão antiga: {revision}",
+    "export": "Exportar",
+    "exports": "Exportações",
+    "export_csv": "Exportar como CSV",
+    "template export": "Tem certeza de que deseja exportar <code>{templateCount}</code> template(s)?",
+    "templates exported": "Templates exportados",
+    "export all templates": "Exportar todos os templates",
+    "flow_export": "Exportar flow",
+    "flow export": "Tem certeza de que deseja exportar <code>{flowCount}</code> flow(s)?",
+    "flows exported": "<code>{count}</code> Flow(s) exportado(s)",
+    "export all flows": "Exportar todos os flows",
+    "import": "Importar",
+    "disable": "Desativar",
+    "enable": "Ativar",
+    "enabled": "Ativado",
+    "template delete": "Tem certeza de que deseja excluir <code>{templateCount}</code> template(s)?",
+    "flow delete": "Tem certeza de que deseja excluir <code>{flowCount}</code> flow(s)?",
+    "templates deleted": "<code>{count}</code> Template(s) deletado(s)",
+    "flows deleted": "<code>{count}</code> Flow(s) deletado(s)",
+    "flow disable": "Tem certeza de que deseja desativar <code>{flowCount}</code> flow(s)?",
+    "flow enable": "Tem certeza de que deseja ativar <code>{flowCount}</code> flow(s)?",
+    "flows disabled": "<code>{count}</code> Flow(s) desativado(s)",
+    "flows enabled": "<code>{count}</code> Flow(s) ativado(s)",
+    "flow-no-dependencies": "Seu flow não possui dependências",
+    "flow-dependencies": "dependências",
+    "read-more": "Leia mais sobre",
+    "in-our-documentation": "na nossa documentação.",
+    "dependencies": "Dependências",
+    "see dependencies": "Ver dependências",
+    "see timeline": "Ver linha do tempo",
     "run timeline": "Linha do Tempo de Execução",
-    "runners": "Corredores",
-    "running": "Executando",
-    "running duration": "Duração em execução",
-    "save": "Salvar",
+    "dependencies missing acls": "Sem permissões neste flow",
+    "dependencies delete flow": "Este flow tem dependências. Deletá-lo impedirá que suas dependências sejam executadas.<br /><br /> Aqui está a lista de flows afetados:",
+    "expand dependencies": "Expandir dependências",
+    "reset": "Reiniciar",
+    "show task documentation": "Mostrar documentação da task",
+    "hide task documentation": "Ocultar documentação da task",
+    "show task documentation in editor": "Mostrar documentação da task no editor",
+    "show documentation": "Mostrar documentação",
+    "focus task": "Clique em qualquer elemento para ver sua documentação.",
+    "validate": "Validar",
+    "add error handler": "Adicionar um manipulador de erro",
+    "taskDefaults": "Padrões da Task",
+    "disabled": "Desativado",
+    "before": "antes",
+    "after": "depois",
+    "add at position": "Adicionar {position} <code>{task}</code>",
+    "create first task": "Crie sua primeira task",
+    "dynamic": "Dinâmico",
+    "choice": "Escolha",
+    "sequential": "Sequencial",
+    "can not delete": "Não pode excluir",
+    "can not have less than 1 task": "Cada flow deve ter pelo menos uma task.",
+    "task id already exists": "Task Id já existe",
+    "Task Id already exist in the flow": "Task Id {taskId} já existe no flow.",
+    "task id": "Task ID",
+    "taskid column details": "Última task sendo executada e seu número de tentativas.",
+    "flow already exists": "Flow já existe",
+    "flow already exists message": "Flow <code>{id}</code> já existe no namespace <code>{namespace}</code>. Deseja criar uma nova revisão?",
+    "plugin_default_already_exists": "O padrão do plugin para <code>{type}</code> já existe.",
+    "namespace not allowed": "Namespace não permitido",
+    "switch-view": "Alternar visualização",
+    "source and topology": "Fonte e topologia",
+    "source and doc": "Fonte e documentação",
+    "source and blueprints": "Fonte e blueprints",
+    "editor": "Editor",
+    "error in editor": "Um erro foi encontrado no editor",
+    "delete task confirm": "Deseja Excluir a task <code>{taskId}</code>?",
+    "can not save": "Não pode salvar",
+    "flow must not be empty": "O flow não deve estar vazio",
+    "flow must have id and namespace": "Flow deve ter um id e um namespace.",
+    "flow creation denied in namespace": "Você não tem permissão para criar flows no namespace `{namespace}`.",
+    "readonly property": "Propriedade somente leitura",
+    "namespace and id readonly": "As propriedades `namespace` e `id` não podem ser alteradas — elas estão definidas para seus valores iniciais. Se você quiser renomear um flow ou alterar seu namespace, você pode criar um novo flow e remover o antigo.",
+    "avg": "Média",
+    "sum": "Soma",
+    "min": "Min",
+    "max": "Max",
+    "bar": "Bar",
+    "line": "Linha",
+    "metric": "Métrica",
+    "aggregation": "Agregação",
+    "chart type": "Tipo de gráfico",
+    "metric choice": "Nenhuma métrica disponível para este flow",
+    "of": "de",
+    "see_all_states": "Ver todos os estados",
     "save draft": {
       "message": "Rascunho salvo",
       "retrieval": {
@@ -1680,164 +724,336 @@
         "existing": "Um rascunho do Flow <code>{flowFullName}</code> foi salvo, deseja continuar editando o flow?"
       }
     },
-    "save task": "Salvar Task",
-    "save_and_execute": "Salvar & Executar",
-    "save_as_draft": "Salvar como rascunho",
-    "saved": "Salvo com sucesso",
-    "saved as draft": "Salvo como rascunho com sucesso",
-    "saved as draft done": "<em>{name}</em> foi salvo com sucesso como rascunho",
-    "saved done": "<em>{name}</em> foi salvo com sucesso",
-    "scheduleDate": "Data de agendamento",
-    "scope_filter": {
-      "all": "Todos os {label}",
-      "system": "Sistema {label}",
-      "system_description": "Manutenção do sistema {label}",
-      "user": "Usuário {label}",
-      "user_description": "Usuário regular iniciou {label}"
+    "title": "Título",
+    "api": "API",
+    "more_actions": "Mais Ações",
+    "expand error": "Expandir apenas tasks falhadas",
+    "expand all": "Expandir tudo",
+    "collapse all": "Recolher tudo",
+    "expand": "Expandir",
+    "collapse": "Recolher",
+    "filter by this value": "Filter by this value",
+    "filter_for": "Filter for",
+    "filter_out": "Filter out",
+    "copy_value": "Copy value",
+    "open_page": "Open page",
+    "logs_copied": "Logs copied to your clipboard",
+    "expand_by_default": "Expand structured logs by default",
+    "show raw": "Show raw",
+    "similar lines": "similar lines",
+    "download_logs_description": "Choose which logs to export. Filters default to your current view.",
+    "display_settings": "Display settings",
+    "density": "Density",
+    "density_compact": "Compact",
+    "density_normal": "Normal",
+    "density_expanded": "Expanded",
+    "pretty_json": "Pretty JSON",
+    "body_line_clamp": "Limit line height",
+    "font size": "Font size",
+    "log expand setting": "Exibição padrão do Log",
+    "environment": "Ambiente",
+    "environment name setting": "Nome do ambiente",
+    "environment color setting": "Cor do ambiente",
+    "slack support": "Faça qualquer pergunta via Slack",
+    "join community": "Junte-se à Comunidade",
+    "join_slack": "Participar do Slack",
+    "kestra": "Kestra",
+    "reach us": "Fale conosco",
+    "new version": "Nova versão {version} disponível!",
+    "error detected": "Erro(s) detectado(s).",
+    "warning detected": "Aviso(s) detectado(s)",
+    "informative notice": "Nota(s)",
+    "cannot swap tasks": "Não é possível trocar as tasks",
+    "open": "Abrir",
+    "dependency task": "Task {taskId} é uma dependência de outra task",
+    "administration": "Administração",
+    "admin": "Administração",
+    "main_configuration": "Configuração Principal",
+    "commit_id": "ID do commit",
+    "evaluation lock date": "Data de bloqueio da avaliação",
+    "unlock trigger": {
+      "tooltip": {
+        "execution": "Há uma execução em andamento para este trigger",
+        "evaluation": "O trigger está atualmente em avaliação"
+      },
+      "confirmation": "Tem certeza de que deseja desbloquear o trigger?",
+      "warning": "Isso pode levar a execuções concorrentes para o mesmo trigger e deve ser considerado como uma última opção.",
+      "button": "Desbloquear trigger",
+      "success": "Trigger desbloqueado"
     },
-    "search": "Buscar",
-    "search blueprint": "Buscar blueprints",
-    "search filters": {
-      "filter name": "Nome do filtro",
-      "filters": "Filtros",
-      "manage": "Gerenciar filtros de busca",
-      "manage desc": "Gerenciar filtros de busca salvos",
-      "save filter": "Salvar filtro",
-      "saved": "Filtros salvos"
+    "restart trigger": {
+      "button": "Reiniciar trigger",
+      "tooltip": "Reiniciar o trigger"
     },
-    "search term in message": "Termo de busca na mensagem",
-    "search_docs": "Pesquisar",
-    "searching": "Procurando...",
-    "secret": {
-      "add": "Criar",
-      "inherited": "Segredos herdados",
-      "isReadOnly": "O segredo é somente leitura",
-      "names": "Segredos",
-      "update": "Atualizar segredo '{name}'"
-    },
-    "security_advice": {
-      "content": "Ative a autenticação básica para proteger sua instância.",
-      "enable": "Ativar autenticação",
-      "switch_text": "Não mostrar novamente",
-      "title": "Proteja sua instância"
-    },
-    "see dependencies": "Ver dependências",
-    "see full revision": "Ver revisão completa",
-    "see timeline": "Ver linha do tempo",
-    "see_all_states": "Ver todos os estados",
-    "seeing old revision": "Você está vendo uma revisão antiga: {revision}",
-    "select": "Selecione sua {{section}}",
-    "select a state": "Selecione um estado",
-    "select datetime": "Selecione uma data",
-    "select view": "Selecionar visualização",
-    "selected": "Selecionado",
-    "selection": {
-      "all": "Selecionar todos ({count})",
-      "selected": "<strong>{count}</strong> selecionado(s)"
-    },
-    "sequential": "Sequencial",
-    "server type": "Tipo de servidor",
+    "trigger disabled": "O Trigger está desativado na fonte do Flow",
+    "flow source not found": "Fonte do flow não encontrada",
+    "date format": "Formato de data",
+    "timezone": "Fuso horário",
+    "add task": "Adicionar uma task",
+    "unable to generate graph": "Ocorreu um problema ao gerar o gráfico, o que impede a exibição da topologia.",
+    "attempts": "Tentativa(s)",
+    "flow deleted, you can restore it": "O flow foi deletado e esta é uma visualização somente leitura. Você ainda pode restaurá-lo.",
+    "workers": "Workers",
+    "worker group": "Grupo de Workers",
+    "worker group key": "Grupo de Worker key",
+    "worker group fallback": "Grupo de Worker de reserva",
+    "version": "Versão",
     "services": "Serviços",
+    "server type": "Tipo de servidor",
+    "hostname": "Nome do host",
+    "port": "Port",
+    "management port": "Port de gerenciamento",
+    "file preview truncated": "Conteúdo exibido foi truncado",
+    "file unavailable": "Arquivo indisponível",
+    "file unavailable description": "Este arquivo não está mais disponível — pode ter sido removido ou expirado.",
+    "row count": "Contagem de linhas",
+    "encoding": "Codificação",
+    "show": "Mostrar",
+    "advanced configuration": "Outras propriedades",
+    "all executions": "Todas as execuções",
+    "trigger execution id": "Trigger Execution Id",
+    "execution_status": "A execução é:",
+    "no_tasks_running": "Ainda não há tasks em execução.",
+    "execution_starts_progress": "Assim que a execução começar, você verá atualizações de progresso aqui.",
+    "triggers_state": {
+      "state": "Estado",
+      "options": {
+        "enabled": "Ativado",
+        "disabled": "Desativado"
+      }
+    },
+    "trigger filter": {
+      "title": "Filtrar execuções filhas",
+      "options": {
+        "ALL": "Todas as Execuções",
+        "CHILD": "Execuções Filhas",
+        "MAIN": "Execuções Pais"
+      }
+    },
+    "show chart": "Mostrar Gráfico",
+    "namespace files": {
+      "toggle": {
+        "show": "Mostrar arquivos do namespace",
+        "hide": "Ocultar arquivos do namespace"
+      },
+      "filter": "Filtro",
+      "new_file": "Novo arquivo",
+      "no_items": {
+        "heading": "Nenhum arquivo encontrado no seu namespace ainda.",
+        "paragraph": "Crie ou importe arquivos para compartilhar código entre flows no seu namespace."
+      },
+      "no_selection": {
+        "heading": "Nenhum arquivo selecionado",
+        "description": "Selecione um arquivo da árvore para ver seu conteúdo."
+      },
+      "tree": {
+        "expand": "Expandir todas as pastas",
+        "collapse": "Colapsar todas as pastas"
+      },
+      "create": {
+        "label": "Criar",
+        "file": "Criar arquivo",
+        "file_already_exists": "Um arquivo com este nome já existe",
+        "file_conflicts_with_folder": "Uma pasta com este nome já existe",
+        "file_error": "Ocorreu um erro ao criar o arquivo",
+        "folder": "Criar pasta",
+        "folder_already_exists": "Uma pasta com este nome já existe",
+        "folder_conflicts_with_file": "Um arquivo com este nome já existe",
+        "folder_error": "Ocorreu um erro ao criar a pasta"
+      },
+      "rename": {
+        "label": "Renomear",
+        "file": "Renomear arquivo",
+        "folder": "Renomear pasta",
+        "new_file": "Novo nome com extensão:",
+        "new_folder": "Novo nome da pasta:"
+      },
+      "delete": {
+        "label": "Excluir",
+        "file": "Excluir arquivo",
+        "folder": "Excluir pasta",
+        "files": "Excluir {count} arquivos selecionados",
+        "folders": "Excluir {count} pastas selecionadas"
+      },
+      "import": {
+        "import": "Importar",
+        "files": "Importar arquivos",
+        "folder": "Importar pasta",
+        "success": "Arquivo(s) importado(s) com sucesso",
+        "error": "Ocorreu(ram) erro(s) ao importar o(s) arquivo(s)"
+      },
+      "export": "Exportar arquivos do namespace",
+      "export_single": "Exportar arquivo",
+      "dialog": {
+        "name": {
+          "file": "Nome com extensão:",
+          "folder": "Nome da pasta:"
+        },
+        "parent_folder": "Pasta pai:",
+        "deletion": {
+          "confirm": "Confirmar",
+          "title": "Confirmar exclusão de conteúdo",
+          "files": "Tem certeza de que deseja excluir <code>{count}</code> arquivo(s)?",
+          "folders": "Tem certeza de que deseja excluir <code>{count}</code> pasta(s) e todo o seu conteúdo?",
+          "mixed": "Tem certeza de que deseja excluir a(s) pasta(s) <code>{folders}</code> e o(s) arquivo(s) <code>{files}</code>?",
+          "file_single": "Tem certeza de que deseja excluir o arquivo <code>{name}</code>?",
+          "folder_single": "Tem certeza de que deseja excluir a pasta <code>{name}</code> e todo o seu conteúdo?"
+        }
+      },
+      "revisions": {
+        "history": "Histórico de revisões",
+        "restore": {
+          "success": "Revisão do arquivo restaurada com sucesso"
+        }
+      },
+      "path": {
+        "copy": "Copiar caminho",
+        "success": "Caminho copiado para a área de transferência",
+        "error": "Ocorreu(ram) erro(s) ao copiar o caminho para a área de transferência"
+      }
+    },
+    "continue backfill": "Continuar o backfill",
+    "delete backfill": "Excluir o backfill",
+    "pause backfill": "Pausar o backfill",
+    "continue backfills": "Continuar backfills",
+    "delete backfills": "Excluir backfills",
+    "pause backfills": "Pausar backfills",
+    "backfill executions": "Execuções de backfill",
+    "execute backfill": "Executar backfill",
+    "backfill paused": "Preenchimento retroativo pausado",
+    "backfill running": "Backfill em execução",
+    "relative": "Relativo",
+    "relative start date": "Data de início relativa",
+    "relative end date": "Data de término relativa",
+    "now": "Agora",
+    "absolute": "Absoluto",
+    "backfill": "Backfill",
+    "Set labels tooltip": "Definir labels para a execução",
+    "Set labels": "Definir labels",
+    "manage labels": "Gerenciar labels",
+    "Set labels to execution": "Adicionar ou atualizar os labels da execução <code>{id}</code>",
+    "Set labels done": "Labels da execução definidos com sucesso",
+    "bulk set labels": "Tem certeza de que deseja definir labels para <code>{executionCount}</code> execução(ões)?",
+    "dependencies loaded": "Dependências carregadas",
+    "loaded x dependencies": "{count} dependências carregadas",
+    "security_advice": {
+      "title": "Proteja sua instância",
+      "content": "Ative a autenticação básica para proteger sua instância.",
+      "switch_text": "Não mostrar novamente",
+      "enable": "Ativar autenticação"
+    },
+    "true": "Verdadeiro",
+    "false": "Falso",
+    "undefined": "Indefinido",
+    "execution-include-non-terminated": "Incluir execuções não terminadas?",
+    "execution-warn-title": "Aviso Importante!",
+    "execution-warn-deleting-still-running": "Recomendamos fortemente que você cancele esta ação e encerre qualquer execução em andamento primeiro. Excluir execuções não terminadas pode levar a problemas de concorrência, inconsistências na gestão de dependências de flow e processos zumbis na sua instância, o que pode degradar o desempenho do sistema. Certifique-se de entender completamente esses riscos antes de prosseguir com a exclusão.",
+    "originalCreatedDate": "Data de criação original",
+    "welcome": {
+      "menu": "Welcome",
+      "tour": {
+        "title": "Faça um tour pelo produto",
+        "text": "Escolha seu caso de uso e siga um guia passo a passo para aprender os recursos e capacidades do Kestra. ❤️"
+      },
+      "tutorial": {
+        "title": "Tutorial",
+        "text": "* <a href=\"https://kestra.io/tutorial-videos/all?utm_source=app&utm_medium=referral&utm_campaign=welcome-tutorial\" target=\"_blank\">Tutoriais em Vídeo</a>  \n* <a href=\"https://kestra.io/docs?utm_source=app&utm_medium=referral&utm_campaign=welcome-tutorial\" target=\"_blank\">Documentação</a>  \n* <a href=\"https://kestra.io/blueprints?utm_source=app&utm_medium=referral&utm_campaign=welcome-tutorial\" target=\"_blank\">Blueprints</a>"
+      },
+      "help": {
+        "title": "Precisa de ajuda?",
+        "text": "Faça qualquer pergunta em nossa comunidade no Slack. Se você estiver com dificuldades, estamos aqui para ajudar você. ✋"
+      }
+    },
+    "pluginPage": {
+      "search": "Pesquisar em mais de {count} plugins",
+      "searchTasks": "Pesquisar {count} tasks",
+      "noResults": "Nenhum plugin corresponde à sua pesquisa.",
+      "loadError": "Não foi possível carregar os plugins. Por favor, tente novamente.",
+      "notFound": "Este plugin não pôde ser encontrado.",
+      "elementType": {
+        "tasks": "Tarefa",
+        "triggers": "Trigger",
+        "conditions": "Condição",
+        "taskRunners": "Executor de task",
+        "charts": "Gráfico",
+        "apps": "Aplicativo",
+        "logExporters": "Exportador de log",
+        "secrets": "Secreto"
+      },
+      "sortBy": "Ordenar por",
+      "sort": {
+        "nameAsc": "Nome A-Z",
+        "nameDesc": "Nome Z-A",
+        "newest": "Mais recente",
+        "mostUsed": "Mais usados"
+      },
+      "group": {
+        "plugins": "Plugins ({count})",
+        "tasks": "Tarefas ({count})",
+        "blueprints": "Blueprints ({count})"
+      },
+      "overview": {
+        "title": "Visão Geral",
+        "versions": "Versões",
+        "latest": "Mais recente",
+        "releaseNotes": "Notas de versão",
+        "previousVersions": "Versões anteriores",
+        "createdBy": "Criado por",
+        "managedBy": "Gerenciado por",
+        "pluginType": "Tipo de plugin",
+        "linksResources": "Links e Recursos",
+        "minKestraVersion": "Versão mínima compatível do Kestra: {version}",
+        "minKestraVersionShort": "Versão mínima do Kestra {version}"
+      },
+      "header": {
+        "enterpriseEdition": "Edição Enterprise",
+        "certified": "Certificado",
+        "back": "Voltar para plugins"
+      }
+    },
+    "no inputs": "Este flow não tem inputs.",
+    "admin_preferences": "Preferences",
     "settings": {
+      "label": "Configurações",
+      "updated": "{name} atualizado",
       "blocks": {
         "configuration": {
-          "descriptions": {
-            "auto_refresh_interval": "Segundos entre atualizações automáticas de dados nas páginas de lista.",
-            "default_namespace": "Usado ao criar novos flows sem um namespace.",
-            "editor_type": "Editor exibido ao abrir um flow pela primeira vez.",
-            "execute_default_tab": "Aba selecionada ao navegar para uma execução.",
-            "execute_flow": "Onde os resultados da execução abrem após acionar uma execução.",
-            "flow_default_tab": "Aba selecionada ao navegar para um flow.",
-            "log_display": "Como os logs são apresentados ao abrir uma execução.",
-            "log_level": "Nível mínimo de log mostrado nos logs de execução.",
-            "playground": "Execute tasks individualmente no playground do editor.",
-            "triggers_default_tab": "Aba selecionada ao navegar para a página de triggers."
-          },
+          "label": "Configuração Principal",
           "fields": {
-            "auto_refresh_interval": "Intervalo de Atualização Automática",
-            "default_namespace": "Namespace Padrão",
-            "editor_type": "Tipo de Editor Padrão",
-            "execute_default_tab": "Aba de Execução Padrão",
-            "execute_flow": "Executar o Flow",
-            "flow_default_tab": "Aba Padrão do Flow",
             "language": "Idioma",
-            "log_display": "Exibição de Log Padrão",
+            "default_namespace": "Namespace Padrão",
             "log_level": "Nível de Log Padrão",
+            "log_display": "Exibição de Log Padrão",
+            "editor_type": "Tipo de Editor Padrão",
+            "execute_flow": "Executar o Flow",
+            "execute_default_tab": "Aba de Execução Padrão",
             "multi_panel_editor": "Editor de Painel Múltiplo",
+            "flow_default_tab": "Aba Padrão do Flow",
+            "triggers_default_tab": "Aba de Triggers Padrão",
             "playground": "Playground",
-            "triggers_default_tab": "Aba de Triggers Padrão"
+            "auto_refresh_interval": "Intervalo de Atualização Automática"
           },
-          "label": "Configuração Principal"
-        },
-        "export": {
-          "fields": {
-            "flows": "Exportar Todos os Flows",
-            "templates": "Exportar Todos os Templates"
-          },
-          "label": "Exportar"
-        },
-        "localization": {
           "descriptions": {
-            "date_format": "Formato usado para exibir datas em todo o dashboard.",
-            "language": "Idioma da interface para menus e labels.",
-            "time_zone": "Usado para exibir datas de execução e triggers agendados."
-          },
-          "fields": {
-            "date_format": "Formato de Data",
-            "time_zone": "Fuso Horário"
-          },
-          "label": "Idioma e Região",
-          "note": "Observe que esta configuração é usada para exibir propriedades de data e hora na UI. Para agendar seus flows em um fuso horário diferente de UTC, certifique-se de definir a propriedade de fuso horário no trigger de Schedule no seu código de flow ou nos padrões do seu plugin."
-        },
-        "reset_section_to_defaults": "Restaurar os valores padrão desta seção",
-        "save": {
-          "discard": "Descartar",
-          "label": "Salvar Preferências",
-          "unsaved_title": "Alterações Não Salvas",
-          "unsaved_warning": "Você tem alterações não salvas. Deseja salvá-las antes de sair?"
-        },
-        "sidebar": {
-          "descriptions": {
-            "items": "Mostrar, ocultar e reordenar itens na barra lateral."
-          },
-          "fields": {
-            "items": "Itens de Navegação"
-          },
-          "label": "Barra Lateral"
+            "default_namespace": "Usado ao criar novos flows sem um namespace.",
+            "log_level": "Nível mínimo de log mostrado nos logs de execução.",
+            "log_display": "Como os logs são apresentados ao abrir uma execução.",
+            "editor_type": "Editor exibido ao abrir um flow pela primeira vez.",
+            "execute_flow": "Onde os resultados da execução abrem após acionar uma execução.",
+            "execute_default_tab": "Aba selecionada ao navegar para uma execução.",
+            "flow_default_tab": "Aba selecionada ao navegar para um flow.",
+            "triggers_default_tab": "Aba selecionada ao navegar para a página de triggers.",
+            "auto_refresh_interval": "Segundos entre atualizações automáticas de dados nas páginas de lista.",
+            "playground": "Execute tasks individualmente no playground do editor."
+          }
         },
         "theme": {
-          "app_font_size_options": {
-            "large": "Grande",
-            "medium": "Médio",
-            "small": "Pequeno"
-          },
-          "color_modes": {
-            "dark_1": "Dark 1.0",
-            "dark_2": "Dark 2.0",
-            "light": "Claro",
-            "sync": "Sincronizar com o sistema"
-          },
-          "confirmations": {
-            "color_mode": "Sua interface agora usa o tema `{mode}`."
-          },
-          "descriptions": {
-            "app_font_size": "Fator de escala aplicado a todos os tamanhos de fonte da interface.",
-            "color_mode": "Escolha o tema de interface preferido.",
-            "color_mode_shortcut": "Dica: pressione <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>L</kbd> para alternar temas de qualquer lugar.",
-            "editor_folding_stratgy": "Recolher blocos longos de YAML por padrão ao abrir um flow.",
-            "editor_font_family": "Fonte monoespaçada usada no editor YAML.",
-            "editor_font_size": "Tamanho da fonte usado nos editores YAML e no-code.",
-            "editor_hover_description": "Mostrar descrições de propriedades ao passar o mouse no editor.",
-            "environment_color": "Cor de destaque usada para o ambiente atual na navegação.",
-            "environment_name": "Nome de exibição para o ambiente atual, mostrado na navegação.",
-            "logs_font_size": "Tamanho da fonte usado em visualizadores de log e terminais."
-          },
+          "label": "Preferências de Tema",
           "fields": {
             "app_font_size": "Tamanho de fonte do aplicativo",
             "chart_color_scheme": {
+              "label": "Esquema de Cores do Gráfico",
               "classic": "Clássico",
-              "kestra": "Kestra",
-              "label": "Esquema de Cores do Gráfico"
+              "kestra": "Kestra"
             },
             "color_mode": "Modo de cor",
             "editor_folding_stratgy": "Dobramento Automático de Código no Editor",
@@ -1850,24 +1066,867 @@
             "logs_font_size": "Tamanho da Fonte dos Logs",
             "theme": "Tema"
           },
-          "label": "Preferências de Tema"
+          "color_modes": {
+            "dark_2": "Dark 2.0",
+            "dark_1": "Dark 1.0",
+            "light": "Claro",
+            "sync": "Sincronizar com o sistema"
+          },
+          "confirmations": {
+            "color_mode": "Sua interface agora usa o tema `{mode}`."
+          },
+          "descriptions": {
+            "color_mode": "Escolha o tema de interface preferido.",
+            "color_mode_shortcut": "Dica: pressione <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>L</kbd> para alternar temas de qualquer lugar.",
+            "logs_font_size": "Tamanho da fonte usado em visualizadores de log e terminais.",
+            "editor_font_family": "Fonte monoespaçada usada no editor YAML.",
+            "editor_font_size": "Tamanho da fonte usado nos editores YAML e no-code.",
+            "editor_folding_stratgy": "Recolher blocos longos de YAML por padrão ao abrir um flow.",
+            "editor_hover_description": "Mostrar descrições de propriedades ao passar o mouse no editor.",
+            "environment_name": "Nome de exibição para o ambiente atual, mostrado na navegação.",
+            "environment_color": "Cor de destaque usada para o ambiente atual na navegação.",
+            "app_font_size": "Fator de escala aplicado a todos os tamanhos de fonte da interface."
+          },
+          "app_font_size_options": {
+            "small": "Pequeno",
+            "medium": "Médio",
+            "large": "Grande"
+          }
+        },
+        "localization": {
+          "label": "Idioma e Região",
+          "note": "Observe que esta configuração é usada para exibir propriedades de data e hora na UI. Para agendar seus flows em um fuso horário diferente de UTC, certifique-se de definir a propriedade de fuso horário no trigger de Schedule no seu código de flow ou nos padrões do seu plugin.",
+          "fields": {
+            "time_zone": "Fuso Horário",
+            "date_format": "Formato de Data"
+          },
+          "descriptions": {
+            "language": "Idioma da interface para menus e labels.",
+            "time_zone": "Usado para exibir datas de execução e triggers agendados.",
+            "date_format": "Formato usado para exibir datas em todo o dashboard."
+          }
+        },
+        "export": {
+          "label": "Exportar",
+          "fields": {
+            "flows": "Exportar Todos os Flows",
+            "templates": "Exportar Todos os Templates"
+          }
+        },
+        "save": {
+          "label": "Salvar Preferências",
+          "discard": "Descartar",
+          "unsaved_title": "Alterações Não Salvas",
+          "unsaved_warning": "Você tem alterações não salvas. Deseja salvá-las antes de sair?"
+        },
+        "reset_section_to_defaults": "Restaurar os valores padrão desta seção",
+        "sidebar": {
+          "label": "Barra Lateral",
+          "fields": {
+            "items": "Itens de Navegação"
+          },
+          "descriptions": {
+            "items": "Mostrar, ocultar e reordenar itens na barra lateral."
+          }
+        }
+      }
+    },
+    "apps": "Aplicativos",
+    "demos": {
+      "enterprise_edition": "Edição Enterprise",
+      "get_a_demo_button": "Obter uma Demonstração",
+      "contact_sales": "Entre em Contato com Vendas",
+      "watch_the_video": "Assista ao vídeo",
+      "secrets": {
+        "title": "Atualize seu Gerenciamento de Secrets",
+        "message": "A Enterprise Edition (EE) permite adicionar, editar ou excluir segredos diretamente na UI—sem necessidade de reiniciar a instância. Organize segredos por namespace com permissões RBAC granulares e herde-os de namespaces pai para filho. A EE integra-se com gerenciadores de segredos como HashiCorp Vault, AWS Secrets Manager, Azure Key Vault, Google Secret Manager e Elasticsearch. Configure backends dedicados por namespace, tenant ou instância para isolar segredos entre equipes, ou habilite segredos somente leitura armazenados em cofres externos. Os segredos permanecem criptografados em repouso e em trânsito. O cache opcional reduz chamadas de API, e trilhas de auditoria registram todo o acesso.",
+        "detected_env": "Aqui estão as variáveis de ambiente do tipo secreto identificadas no momento de inicialização da instância:",
+        "empty_env": "Você ainda não tem nenhum Secret no seu ambiente.",
+        "add_env": {
+          "intro": "Para criar um novo Secret:",
+          "first": "Codifique o <a href=\"https://kestra.io/docs/how-to-guides/secrets?utm_source=app&utm_medium=referral&utm_campaign=secrets-inlinedoc#using-secrets-in-kestra\" target=\"_blank\">valor secreto em Base64</a>",
+          "second": "Adicione uma variável de ambiente chamada '<strong>SECRET_{'{MY_SECRET_KEY}'}</strong>' com o valor acima",
+          "third": "Reinicie sua instância do Kestra"
         }
       },
-      "label": "Configurações",
-      "updated": "{name} atualizado"
+      "apps": {
+        "title": "Crie Apps personalizadas com Kestra",
+        "message": "As aplicações na Kestra Enterprise Edition permitem que você construa interfaces personalizadas que interagem com os workflows do Kestra fora da plataforma. Este recurso permite usar seus workflows como um backend para aplicações personalizadas, possibilitando que usuários não técnicos enviem dados através de formulários ou retomem workflows PAUSED aguardando aprovação."
+      },
+      "tests": {
+        "label": "Testes",
+        "header": "Testes Unitários para Flows",
+        "title": "Garanta a Confiabilidade com Cada Alteração",
+        "message": "Verifique a lógica dos seus flows isoladamente, detecte regressões cedo e mantenha a confiança nas suas automações à medida que elas mudam e crescem."
+      },
+      "assets": {
+        "label": "Ativos",
+        "header": "Metadados e Observabilidade de Assets",
+        "title": "Traga todos os datasets, serviços e dependências para a visualização.",
+        "message": "Ativos conectam metadados de observabilidade, linhagem e propriedade para que as equipes da plataforma possam solucionar problemas mais rapidamente e implantar com confiança."
+      },
+      "IAM": {
+        "title": "Gerencie Usuários através do IAM com SSO, SCIM e RBAC",
+        "message": "A Kestra Enterprise Edition possui capacidades IAM integradas com single sign-on (SSO), sincronização de diretório SCIM e controle de acesso baseado em funções (RBAC), integrando-se com vários provedores de identidade e permitindo que você atribua permissões detalhadas para usuários e contas de serviço."
+      },
+      "tenants": {
+        "title": "Gerenciar Fluxos de Trabalho em Tenants Isolados",
+        "message": "A Kestra Enterprise Edition suporta multi-tenancy, proporcionando ambientes totalmente isolados para diferentes equipes ou projetos, cada um com seus próprios recursos, como grupos de worker dedicados ou segredos e backends de armazenamento interno."
+      },
+      "audit-logs": {
+        "title": "Acompanhe Alterações com Audit Logs",
+        "message": "A Kestra Enterprise Edition registra todas as atividades com registros robustos e imutáveis, facilitando o acompanhamento de alterações, a manutenção da conformidade e a resolução de problemas."
+      },
+      "quotas": {
+        "title": "Aplicar cotas de execução em flows",
+        "message": "O Kestra Enterprise Edition permite definir cotas em flows para limitar o número de execuções simultâneas ou totais dentro de uma janela de tempo. As cotas ajudam a proteger a infraestrutura compartilhada, aplicar SLAs e impedir que workflows descontrolados consumam recursos excessivos."
+      },
+      "instance": {
+        "title": "Gerencie a Infraestrutura em Toda a Sua Instância",
+        "message": "A Kestra Enterprise Edition fornece um painel operacional para ajudar você a observar a saúde da sua plataforma e acompanhar as métricas de tempo de atividade de todos os serviços, como, por exemplo, Workers, Schedulers e Executors. Na mesma página, você também pode criar Anúncios para notificar seus usuários sobre interrupções planejadas, e pode entrar em um modo de manutenção que coloca temporariamente todos os serviços e execuções de workflow em um estado PAUSED para realizar uma atualização."
+      },
+      "blueprints": {
+        "title": "Adicionar Blueprints Personalizados",
+        "message": "Na Kestra Enterprise Edition, você pode criar Blueprints personalizados disponíveis apenas para sua organização. Você pode usá-los como modelos de melhores práticas para compartilhar, centralizar e documentar fluxos de trabalho comumente usados em sua equipe."
+      },
+      "namespace": {
+        "edit": {
+          "title": "Atualize o Gerenciamento do seu Namespace",
+          "message": "Na Kestra Enterprise Edition, os namespaces oferecem isolamento avançado e governança de segredos, variáveis e padrões de plugins em escala. Os administradores podem configurar gerenciadores de segredos personalizados, backends de armazenamento isolados, grupos de worker dedicados e permissões detalhadas por namespace. Isso garante que segredos, variáveis e configurações de plugins permaneçam seguros e fáceis de manter em diferentes equipes e projetos."
+        },
+        "secrets": {
+          "title": "Gerenciar Segredos de Forma Segura",
+          "message": "Na Kestra Enterprise Edition, você pode armazenar e controlar segredos no nível de namespace, minimizando riscos e garantindo que as credenciais de cada equipe permaneçam isoladas. Graças à hierarquia aninhada, você também pode configurar credenciais em um namespace pai e elas serão herdadas por todos os namespaces filhos. O suporte para gerenciadores de segredos dedicados e configurações de permissão detalhadas no nível de namespace fortalece ainda mais a segurança e a conformidade."
+        },
+        "assets": {
+          "title": "Centralizar Gerenciamento de Ativos",
+          "message": "Na Kestra Enterprise Edition, Assets mantém um inventário ao vivo de recursos com os quais seus workflows interagem. Esses recursos podem ser tabelas de banco de dados, máquinas virtuais, arquivos ou qualquer sistema externo com o qual você trabalhe."
+        },
+        "variables": {
+          "title": "Governe Centralmente Suas Variáveis",
+          "message": "Na Kestra Enterprise Edition, você pode definir e gerenciar variáveis no nível do namespace para eliminar configurações repetitivas em flows. Essas variáveis garantem consistência, simplificam atualizações de configuração e podem ser facilmente referenciadas por qualquer task ou trigger para workflows mais limpos e fáceis de manter."
+        },
+        "plugin-defaults": {
+          "title": "Padronizar Configuração com Padrões de Plugin",
+          "message": "Na Kestra Enterprise Edition, você pode definir padrões de plugin específicos para cada namespace, reduzindo a necessidade de configuração duplicada em cada flow. Esta governança central de plugins impõe configurações consistentes, permite a referência segura de segredos ou variáveis e simplifica a manutenção dos seus workflows."
+        },
+        "history": {
+          "title": "Gerenciar Histórico de Revisões em Um Só Lugar",
+          "message": "Na Kestra Enterprise Edition, você pode gerenciar o histórico de revisões dos seus Namespaces"
+        },
+        "audit-logs": {
+          "title": "Acompanhe Todas as Alterações em Um Só Lugar",
+          "message": "Na Kestra Enterprise Edition, você pode visualizar logs de auditoria no nível do namespace com diferenças detalhadas, fornecendo um histórico claro de quem alterou o quê e quando em todos os recursos."
+        }
+      }
+    },
+    "assets": {
+      "title": "Ativos"
+    },
+    "onboarding": {
+      "welcome": {
+        "headline": "Crie e execute seu primeiro workflow em minutos",
+        "guided_title": "Crie seu primeiro flow",
+        "badge": "Tutorial",
+        "guided_description": "Aprenda a criar e executar seu primeiro flow com passos guiados.",
+        "guided_duration": "Recomendado para a maioria dos usuários",
+        "self_serve_title": "Criar flow do zero",
+        "self_serve_description": "Vá direto para o editor e crie seu próprio flow.",
+        "self_serve_note": "Para usuários experientes",
+        "additional_help": "Ajuda adicional",
+        "docs": "Documentação",
+        "tutorial": "Tutorial",
+        "blueprints": "Blueprints",
+        "slack": "Comunidade no Slack"
+      },
+      "steps": {
+        "flow_basics": {
+          "title": "Noções básicas de flow",
+          "description": "No Kestra, um <code>flow</code> é a unidade central de orquestração. Você o define em YAML com metadados e tarefas ordenadas.<br><br>Revise a estrutura de exemplo abaixo e depois continue a construí-la passo a passo."
+        },
+        "add_id": {
+          "title": "Adicionar ID do flow",
+          "description": "O ID é o nome único do seu flow, para que você possa encontrá-lo, executá-lo e referenciá-lo de forma consistente.<br><br>Agora adicione <code>id</code> no nível raiz."
+        },
+        "add_namespace": {
+          "title": "Adicionar namespace",
+          "description": "O Namespace é um agrupamento semelhante a uma pasta que organiza flows por equipe, projeto ou ambiente.<br><br>Agora adicione <code>namespace</code> no nível raiz."
+        },
+        "add_input": {
+          "title": "Adicionar um input",
+          "description": "Inputs são parâmetros em nível de flow que podem ser referenciados dentro das tarefas para controlar dinamicamente o comportamento em tempo de execução.<br><br>Agora adicione um input chamado <code>name</code> com o tipo <code>STRING</code>."
+        },
+        "add_log_task": {
+          "title": "Adicionar a primeira tarefa",
+          "description": "Tasks são as unidades de trabalho que seu flow executa, definidas como uma lista ordenada de etapas. Cada task precisa de um <code>id</code> único e um <code>type</code>. O Kestra fornece muitos plugins de tasks para sistemas externos; aqui usamos uma task de Python Script.<br><br>A sintaxe <code>&#123;&#123; ... &#125;&#125;</code> é uma expressão Pebble, usada para referenciar variáveis dinamicamente em tempo de execução, como <code>&#123;&#123; inputs.name &#125;&#125;</code> a partir dos inputs do flow.<br><br>Agora adicione a primeira task em <code>tasks</code> com <code>id</code>, <code>type</code> e um <code>script</code> que imprima uma saudação."
+        },
+        "save_flow": {
+          "title": "Salvar flow",
+          "description": "Salvar persiste a definição do seu flow para que ele possa ser executado."
+        },
+        "execute_flow": {
+          "title": "Executar flow",
+          "description": "Executar inicia uma execução do seu flow com valores de input em tempo de execução."
+        },
+        "view_logs_status": {
+          "title": "Verificar execução",
+          "description": "Os detalhes da execução mostram o status, o tempo e os logs de saída em nível de task.<br><br>Agora abra os detalhes da execução e clique em <code>greet</code> no gráfico de Gantt para ver os logs."
+        },
+        "edit_flow_from_execution": {
+          "title": "Voltar ao Editor de Flow",
+          "description": "Você pode ir diretamente de uma execução para a definição do flow para iterar rapidamente."
+        },
+        "add_cron_trigger": {
+          "title": "Adicionar um gatilho cron",
+          "description": "Triggers podem iniciar execuções com base em agendamentos ou eventos externos (por exemplo, webhooks ou mensagens MQTT).<br><br>Agora adicione um gatilho de agendamento cron para que este flow seja executado a cada 5 minutos."
+        },
+        "add_input_default": {
+          "title": "Definir um valor padrão para o input",
+          "description": "Quando um flow é acionado automaticamente, os inputs ainda precisam de valores em tempo de execução.<br><br>O input <code>name</code> já foi criado na etapa anterior, então não é necessário adicioná-lo novamente. Basta definir um valor padrão para o input existente <code>name</code>."
+        },
+        "save_flow_again": {
+          "title": "Salvar flow",
+          "description": "Seu flow agora tem um agendamento e um valor padrão de input para execuções automáticas."
+        },
+        "background_runs_info": {
+          "title": "Execuções agendadas",
+          "description": "Este flow agora será executado em segundo plano a cada 5 minutos.<br><br>Você pode navegar até a visão geral de Execuções no menu à esquerda para monitorar as execuções agendadas."
+        },
+        "finish": {
+          "title": "Você concluiu o tutorial Primeiro Flow",
+          "description": "Ótimo começo. Você criou, executou, parametrizou e agendou um flow.<br><br>Escolha o que fazer a seguir ..."
+        }
+      },
+      "actions": {
+        "next": "Próximo",
+        "complete": "Concluir",
+        "save_to_continue": "Clique em Salvar na barra superior (à direita).",
+        "execute_to_continue": "1. Clique em Executar na barra superior (à direita).\n2. Forneça um valor para <strong>name</strong>.\n3. Clique em Executar novamente no modal.",
+        "edit_flow_to_continue": "Clique em Editar flow na barra superior (à direita).",
+        "cancel_tutorial": "Cancelar tutorial",
+        "finish_tutorial": "Finalizar tutorial"
+      },
+      "finish_actions": {
+        "explore_blueprints": "Explorar Blueprints",
+        "create_flow": "Criar flow"
+      },
+      "editor_hints": {
+        "build_intro": "Crie seu primeiro flow passo a passo.",
+        "step_1": "# 1) Adicionar id",
+        "step_2": "# 2) Adicionar namespace",
+        "step_3": "# 3) Adicionar um input",
+        "step_4": "# 4) Adicionar tasks e sua primeira task Python",
+        "step_5": "# 5) Adicionar um gatilho cron"
+      },
+      "cancel_modal": {
+        "title": "Cancelar o tutorial Primeiro Flow",
+        "description": "Você deseja cancelar o tutorial Primeiro Flow?",
+        "confirm": "Cancelar tutorial",
+        "keep": "Manter tutorial"
+      },
+      "validation": {
+        "complete_step": "Você está quase lá. Conclua esta etapa para continuar.",
+        "fix_yaml": "Há um pequeno problema de formatação YAML. Corrija-o e depois continue.",
+        "add_id": "Adicione um ID de flow no topo. Exemplo: `id: hello_flow`.",
+        "add_namespace": "Adicione um namespace no topo. Exemplo: `namespace: company.team`.",
+        "add_input_section": "Crie uma seção `inputs` com um input.",
+        "add_input_id": "Dentro de `inputs`, adicione `id: name`.",
+        "add_input_type": "Defina o tipo do input como `STRING`.",
+        "add_log_task_section": "Crie uma seção `tasks` e adicione sua primeira task.",
+        "add_log_task_id": "Dê um ID à task, por exemplo: `id: greet`.",
+        "add_log_task_type": "Defina o tipo da task como `io.kestra.plugin.scripts.python.Script`.",
+        "add_log_task_message": "Adicione um campo `script` à task.",
+        "add_log_task_pebble": "Use uma expressão Pebble no script para que ele utilize o valor do seu input (por exemplo: `inputs.name`).",
+        "save_flow": "Clique em Salvar para continuar.",
+        "execute_flow": "Execute o flow uma vez para continuar.",
+        "view_logs_status": "Abra os detalhes da execução e verifique os logs de `greet`.",
+        "edit_flow_from_execution": "Clique em `Editar flow` na barra superior para continuar.",
+        "add_cron_trigger_section": "Crie uma seção `triggers` com um gatilho de agendamento.",
+        "add_cron_trigger_type": "Defina o tipo do gatilho como `io.kestra.plugin.core.trigger.Schedule`.",
+        "add_cron_trigger_cron": "Adicione uma expressão cron, por exemplo: `\"*/5 * * * *\"`.",
+        "add_input_default_section": "Volte para `inputs` e mantenha um input existente chamado `name` (não adicione um segundo input).",
+        "add_input_default_id": "Mantenha o ID do input existente como `name`.",
+        "add_input_default_defaults": "Adicione um valor padrão para `name`, por exemplo: `defaults: \"Kestra\"`.",
+        "save_flow_again": "Clique em Salvar novamente para continuar."
+      }
+    },
+    "enable concurrency": "Habilitar concorrência",
+    "auditlogs": "Audit Logs",
+    "quotas": "Cotas",
+    "iam": "IAM",
+    "tenant": {
+      "name": "Cliente",
+      "names": "Clientes"
+    },
+    "ee-tooltip": {
+      "features-blocked": "Este recurso requer a Enterprise Edition.",
+      "button": "Fale conosco"
+    },
+    "flow_only": "Disponível apenas na aba Flow.",
+    "bulk action async warning": "Isso pode levar alguns instantes.",
+    "bulk unpause backfills": "Despausar {count} backfill",
+    "bulk pause backfills": "Pausar {count} backfill",
+    "bulk delete backfills": "Excluir {count} backfill",
+    "bulk unlock": "Desbloquear {count} triggers",
+    "bulk disabled status": {
+      "true": "Desativar {count} triggers",
+      "false": "Ativar {count} triggers"
+    },
+    "unlock": "Desbloquear",
+    "bulk success unpause backfills": "{count} backfills despausados",
+    "bulk success pause backfills": "{count} backfills pausados",
+    "bulk success delete backfills": "{count} backfills excluídos",
+    "bulk success unlock": "{count} triggers desbloqueados",
+    "bulk success disabled status": {
+      "true": "{count} trigger(s) desativado(s)",
+      "false": "{count} trigger(s) ativado(s)"
+    },
+    "no_namespaces": "Nenhum namespace corresponde aos critérios de busca.",
+    "system_namespace": "Mantenha sua plataforma sob controle com system flows.",
+    "system_namespace_description": "Automatize tarefas de manutenção, desde alertas de falha até limpezas automatizadas.",
+    "pluginDefaults": {
+      "title": "Padrões do Plugin",
+      "add": "Adicionar Plugin Padrão",
+      "edit": "Editar Padrão do Plugin",
+      "add_subtitle": "Configurar um novo plugin padrão com suas propriedades",
+      "edit_subtitle": "Modificar a configuração padrão do plugin existente",
+      "predefined": "Plugin Predefinido",
+      "custom": "Plugin Personalizado",
+      "form": "Formulário",
+      "yaml": "YAML",
+      "select_predefined": "Selecionar Plugin Predefinido",
+      "cancel": "Cancelar",
+      "update": "Atualizar Plugin Padrão",
+      "custom_type": "Tipo de plugin personalizado",
+      "custom_placeholder": "Insira o tipo de plugin",
+      "use_custom": "Usar Personalizado",
+      "custom_configure": "Tipo de plugin personalizado - configure usando YAML",
+      "yaml_configuration": "Configuração YAML",
+      "show_yaml": "Mostrar YAML"
+    },
+    "secret": {
+      "add": "Criar",
+      "update": "Atualizar segredo '{name}'",
+      "isReadOnly": "O segredo é somente leitura",
+      "names": "Segredos",
+      "inherited": "Segredos herdados"
+    },
+    "workerId": "Worker Id",
+    "kv": {
+      "name": "KV Store",
+      "type": "Tipo",
+      "add": "Criar",
+      "update": "Atualizar valor para a key '{key}'",
+      "duplicate": "Esta key já existe",
+      "delete multiple": {
+        "confirm": "Tem certeza de que deseja excluir: <code>{name}</code> KV(s)?",
+        "warning": "Você não tem permissões para esses namespaces, então eles serão omitidos: <code>{namespaces}</code>"
+      },
+      "inherited": "Pares KV herdados"
+    },
+    "expiration": "Expiração",
+    "failed to render pdf": "Falha ao renderizar a pré-visualização do PDF",
+    "page": {
+      "previous": "Página anterior",
+      "next": "Próxima página"
+    },
+    "namespace_editor": {
+      "empty": {
+        "title": "Nenhuma aba aberta no momento",
+        "create_message": "Você pode criar ou importar arquivos de namespace.",
+        "video_message": "Você pode assistir ao Vídeo de Introdução para o nosso Editor."
+      },
+      "close": {
+        "tab": "Fechar aba",
+        "all": "Fechar todas as abas",
+        "other": "Fechar outras abas",
+        "right": "Fechar à direita"
+      }
+    },
+    "curl": {
+      "command": "Comando cURL",
+      "note": "Observe que, para o tipo de input SECRET e FILE, o comando deve ser ajustado para corresponder aos valores reais."
+    },
+    "webhook": {
+      "curl_command": "Comando cURL do Webhook",
+      "payload": "Payload do Webhook (JSON)",
+      "curl_note": "Use este comando cURL para acionar o flow via webhook com carga útil JSON personalizada",
+      "no_triggers": "Este flow não possui triggers de webhook habilitados",
+      "copy_url": "Copiar URL do webhook"
+    },
+    "logs_view": {
+      "raw": "Visualização temporal",
+      "raw_details": "Mostrar logs completos de task e flow em formato bruto ordenado por timestamp",
+      "compact": "Visualização padrão",
+      "compact_details": "Mostrar logs de task em uma visualização compacta agrupada por cada task"
+    },
+    "execution_deletion": {
+      "logs": "Excluir logs",
+      "metrics": "Excluir métricas",
+      "storage": "Excluir arquivos de armazenamento interno"
+    },
+    "scope_filter": {
+      "all": "Todos os {label}",
+      "user": "Usuário {label}",
+      "system": "Sistema {label}",
+      "user_description": "Usuário regular iniciou {label}",
+      "system_description": "Manutenção do sistema {label}"
+    },
+    "data": "Dados",
+    "webhook link copied": "Link do Webhook copiado.",
+    "copy url": "Copiar URL",
+    "scheduleDate": "Data de agendamento",
+    "warning": "Aviso",
+    "trigger_check_warning": "Usar variáveis de trigger não funcionará com a execução manual de flow. Adicione o operador de coalescência `??` para resolver o problema. Por exemplo, em vez de `trigger.date`, use `trigger.date ?? execution.startDate`.",
+    "docs": "Documentos",
+    "active-slots": "Slots ativos",
+    "behavior": "Comportamento",
+    "concurrency": "Concorrência",
+    "no-executions-view": {
+      "title": "Comece a automatizar com",
+      "sub_title": "Clique no botão Executar para iniciar a execução do seu primeiro fluxo de trabalho.",
+      "namespace_sub_title": "Execute um ou mais flows deste namespace para preencher este dashboard.",
+      "guidance_desc": "Precisa de orientação para executar o seu flow?",
+      "namespace_guidance_desc": "Precisa de orientação para gerenciar seu Namespace?",
+      "guidance_sub_desc": "Siga a documentação para todas as informações que você precisa."
+    },
+    "execution_guide": {
+      "get_started": {
+        "title": "Começar ⚡",
+        "text": "Siga o Guia de Início Rápido para instalar o Kestra e começar a criar seus primeiros workflows."
+      },
+      "namespaces": {
+        "title": "Sobre Namespaces",
+        "text": "Namespaces são agrupamentos lógicos de flows e seus componentes."
+      },
+      "workflow_components": {
+        "title": "Componentes do Workflow",
+        "text": "Conheça os principais componentes de orquestração de um workflow Kestra."
+      },
+      "videos_tutorials": {
+        "title": "Tutoriais em Vídeo",
+        "text": "Comece com nossos tutoriais em vídeo."
+      }
+    },
+    "open sidebar": "abrir barra lateral",
+    "close sidebar": "fechar barra lateral",
+    "customize sidebar": "Personalizar barra lateral",
+    "reset to defaults": "Redefinir para padrões",
+    "drop items here": "Solte os itens aqui",
+    "files": "Arquivos",
+    "optional": "Opcional",
+    "no_data": "Parece que não há nada aqui... ainda!<br/>Ajuste seus filtros ou tente novamente!",
+    "bookmark": "Favoritos",
+    "remove_bookmark": "Tem certeza de que deseja remover este marcador?",
+    "showLess": "Mostrar menos",
+    "showMore": "Mostrar mais",
+    "documentationMenu": "Menu de documentação",
+    "item": "item",
+    "items": "itens",
+    "cron": "Cron",
+    "execution_started": "A execução foi iniciada!",
+    "execution_failed": "Execução falhou!",
+    "last error was": "O último erro foi",
+    "execution restarted": "Esta execução foi reiniciada {nbRestart} vez(es).",
+    "execution replay": "Esta execução é uma repetição de",
+    "execution replayed": "Esta execução foi reproduzida.",
+    "task run id": "ID do TaskRun",
+    "active": "Ativo",
+    "flows imported": "Fluxos importados",
+    "flow not imported": "Algum flow não pôde ser importado",
+    "plugin defaults exported": "Padrões do plugin exportados",
+    "failed to export plugin defaults": "Falha ao exportar padrões do plugin",
+    "plugin defaults imported": "Padrões de plugin importados",
+    "plugin defaults not imported": "Alguns padrões de plugin não puderam ser importados",
+    "failed to import plugin defaults": "Falha ao importar padrões do plugin",
+    "filters": {
+      "label": "Escolher filtros",
+      "empty": "Sem dados.",
+      "format": "Digite o parâmetro como 'key:value'",
+      "text_search": "Pesquisar por este texto",
+      "options": {
+        "namespace": "Namespace",
+        "flow": "Fluxo",
+        "state": "Estado",
+        "scope": "Escopo",
+        "child": "Filho",
+        "level": "Nível de Log",
+        "task": "Tarefa",
+        "metric": "Métrica",
+        "user": "Usuário",
+        "type": "Tipo",
+        "service_type": "Tipo",
+        "permission": "Permissão",
+        "action": "Ação",
+        "status": "Status",
+        "details": "Detalhes",
+        "aggregation": "Agregação",
+        "relative_date": "Data relativa",
+        "absolute_date": "Data absoluta",
+        "labels": "Etiquetas",
+        "text": "Parece que você não forneceu nenhum texto para tradução. Por favor, forneça o texto que deseja que eu traduza para o português.",
+        "startDate": "Data de início",
+        "endDate": "Data de término"
+      },
+      "comparators": {
+        "is": "é",
+        "is_one_of": "é um dos",
+        "is_not": "não é",
+        "not_in": "não em",
+        "contains": "contém",
+        "not_contains": "não contém",
+        "in": "em",
+        "between": "entre",
+        "starts_with": "começa com",
+        "greater_than": "maior que",
+        "greater_than_or_equal_to": "maior ou igual a",
+        "less_than": "menor que",
+        "less_than_or_equal_to": "menor ou igual a",
+        "ends_with": "termina com"
+      },
+      "save": {
+        "label": "Pesquisas salvas",
+        "remove": "Remover",
+        "empty": "Você ainda não salvou nenhuma pesquisa.",
+        "tooltip": "Você não pode salvar critérios de pesquisa vazios.",
+        "name_already_used": "A etiqueta de pesquisa já está em uso.",
+        "dialog": {
+          "heading": "Salvar pesquisa atual",
+          "placeholder": "Etiqueta",
+          "hint": "Como você deseja rotular este critério de busca?",
+          "confirmation": "Critérios de pesquisa <code>{name}</code>"
+        }
+      },
+      "settings": {
+        "label": "Configurações da página",
+        "show_chart": "Exibir gráfico principal"
+      }
+    },
+    "custom value": "Valor personalizado",
+    "chart": "Gráfico",
+    "chart preview": "Prévia do gráfico",
+    "no_code": {
+      "toggle_pebble": "Alternar editor Pebble",
+      "version_oss_placeholder": "Desbloqueie a Versionamento de Plugin com a Enterprise Edition",
+      "unnamed": "Sem Nome",
+      "adding": "+ Adicionar um {what}",
+      "adding_default": "+ Adicionar um novo value",
+      "add_field": "Adicionar {field}",
+      "clearSelection": "Limpar seleção",
+      "labels": {
+        "yaml": "Editor YAML",
+        "no_code": "Editor Sem Código",
+        "label": "Etiqueta",
+        "variable": "Variável"
+      },
+      "sections": {
+        "deprecated": "Propriedades obsoletas",
+        "tasks": "Tarefas",
+        "triggers": "Triggers",
+        "errors": "Manipuladores de Erro",
+        "afterExecution": "Após a Execução",
+        "finally": "Finalmente",
+        "pluginDefaults": "Padrões de Plugin"
+      },
+      "fields": {
+        "main": {
+          "id": "ID do Flow",
+          "namespace": "Namespace",
+          "description": "Descrição",
+          "inputs": "Entradas"
+        },
+        "general": {
+          "retry": "Repetir",
+          "sla": "SLA",
+          "labels": "Etiquetas",
+          "outputs": "Saídas",
+          "variables": "Variáveis",
+          "concurrency": "Concorrência",
+          "disabled": "Desativado",
+          "listeners": "Ouvintes",
+          "taskDefaults": "Padrões de Task",
+          "workerGroup": "Grupo de Worker",
+          "workerSelector": "Seletor de Worker",
+          "checks": "Verificações",
+          "updated": "Atualizado"
+        }
+      },
+      "select": {
+        "default": "Selecione um tipo",
+        "task": "Selecione uma task",
+        "tasks": "Selecione uma task",
+        "triggers": "Selecione um trigger",
+        "errors": "Selecione uma task",
+        "finally": "Selecione uma task",
+        "pluginDefaults": "Selecione um plugin",
+        "afterExecution": "Selecione uma task",
+        "conditions": "Selecione uma condição",
+        "inputs": "Selecione um tipo de campo de input",
+        "charts": "Selecione um tipo de gráfico",
+        "where": "Selecione um tipo de filtro",
+        "numerator": "Selecione um numerador"
+      },
+      "creation": {
+        "default": "Adicionar",
+        "tasks": "Adicionar uma task",
+        "triggers": "Adicionar um trigger",
+        "errors": "Adicionar um manipulador de erro",
+        "finally": "Adicionar um bloco finally",
+        "pluginDefaults": "Adicionar um padrão de plugin",
+        "afterExecution": "Adicionar um bloco após a execução",
+        "conditions": "Adicionar uma condição",
+        "inputs": "Adicionar um campo de input",
+        "charts": "Adicionar um gráfico",
+        "where": "Filtrar seus dados",
+        "numerator": "Adicionar um numerador"
+      },
+      "remove": {
+        "default": "Remover esta entrada",
+        "cases": "Remover este caso"
+      }
+    },
+    "properties": {
+      "label": "Propriedades",
+      "hint": "Escolher Colunas Visíveis",
+      "shown": "Exibido na Tabela",
+      "hidden": "Oculto na Tabela"
+    },
+    "editor_shortcuts": {
+      "label": "Atalhos de teclado",
+      "trigger_autocompletion": "Acionar autocompletar",
+      "command_palette": "Mostrar paleta de comandos",
+      "save_flow": "Salvar flow",
+      "execute_flow": "Executar flow",
+      "toggle_ai_agent": "Alternar agente de IA",
+      "move_line": "Mover linha",
+      "duplicate_cursor": "Duplicar cursor",
+      "fold_unfold": "Dobra/Desdobra código",
+      "comment_uncomment": "Comentar/Descomentar",
+      "comment": "Comentário",
+      "uncomment": "Descomentar",
+      "decrease_fontsize": "Diminuir tamanho da fonte do editor",
+      "increase_fontsize": "Aumentar o tamanho da fonte do editor",
+      "reset_fontsize": "Redefinir tamanho da fonte do editor"
+    },
+    "instance": "Instância",
+    "something_went_wrong": {
+      "loading_execution": "Algo deu errado ao carregar a execução",
+      "connection_lost": {
+        "title": "Conexão interrompida",
+        "message": "Não conseguimos acessar sua instância do Kestra. Certifique-se de que está em execução e atualize a página."
+      }
+    },
+    "debug": "Depurar",
+    "default": "Padrão",
+    "data_not_protected": "Seus dados não estão protegidos. Não os perca. <b>Ative nossos recursos de segurança gratuitos ou experimente nossa oferta paga.</b>",
+    "activate_basic_auth": "Ativar Autenticação Básica",
+    "dark_version": "Versão escura",
+    "use_dark_background": "Use esta versão ao trabalhar em um fundo escuro para garantir que nosso nome permaneça legível.",
+    "light_version": "Versão clara",
+    "light_background": "Esta é a opção preferida ao trabalhar com um fundo claro.",
+    "monogram": "Monograma",
+    "wordmark_colors": "As cores da marca adaptam-se com base no fundo, enquanto o ícone permanece sem fundo quando colocado em um fundo escuro.",
+    "download_logos": "Baixar Pacote de Logos",
+    "this_task_has": "Esta task tem",
+    "about_this_blueprint": "Sobre este blueprint",
+    "deleted_label": "Deletado",
+    "fold_all_multi_lines": "Recolher Todas as Linhas Múltiplas",
+    "task_id_exists": "Id da Task já existe",
+    "task_id_message": "O Task Id ${existingTask} já existe no flow.",
+    "trigger_id_exists": "Id de Trigger já existe",
+    "trigger_id_message": "O Trigger Id ${existingTrigger} já existe no flow.",
+    "watch": "Assistir",
+    "learn_more": "Saiba mais",
+    "watch_video": "Assistir Vídeo",
+    "runners": "Corredores",
+    "select": "Selecione sua {{section}}",
+    "for flow": "para flow",
+    "forbidden system labels": "Apenas system.correlationId pode ser usado como label do sistema",
+    "confirm": "Confirmar",
+    "taskRunners": "Executores de Task",
+    "additionalPlugins": "Plugins Adicionais",
+    "appBlocks": "Blocos do App",
+    "charts": "Gráficos",
+    "dataFilters": "Filtros de Dados",
+    "logExporters": "Exportadores de Log",
+    "empty": {
+      "namespaceFiles": {
+        "title": "Ainda não há arquivos neste namespace",
+        "content": "Os arquivos do namespace funcionam como uma pasta de projeto para este namespace. Armazene código Python, SQL, dbt ou Terraform e, em seguida, referencie qualquer arquivo nos seus flows com"
+      },
+      "announcements": {
+        "title": "Você ainda não tem anúncios!",
+        "content": "Os anúncios permitem que você notifique seus usuários sobre quaisquer alterações ou informe-os sobre o tempo de inatividade planejado para manutenção. Basta selecionar o tipo de anúncio, o intervalo de datas em que ele deve ser exibido e escrever a mensagem do anúncio."
+      },
+      "kill_switches": {
+        "title": "Você ainda não tem Kill Switches!",
+        "content": "O recurso Kill Switch fornece um mecanismo baseado em UI para interromper execuções problemáticas. Ele substitui os comandos <code>--skip-executions</code> e <code>--skip-flows</code> disponíveis apenas no CLI por uma interface de administração abrangente."
+      },
+      "apps": {
+        "title": "Você ainda não tem apps!",
+        "content": "Comece a criar Apps para interagir com o Kestra a partir do mundo externo."
+      },
+      "testSuites": {
+        "title": "Você ainda não tem Test suites!",
+        "content": "Comece a criar suítes de Teste para testar seus Flows."
+      },
+      "assets": {
+        "title": "Você ainda não tem Assets!",
+        "content": "Adicione assets para rastrear e gerenciar seus assets de dados, serviços e infraestrutura."
+      },
+      "apiTokens": {
+        "title": "Gerencie seus Tokens de API",
+        "content": "Tokens de API são usados sempre que você deseja conceder acesso programático à API do Kestra."
+      },
+      "concurrency_executions": {
+        "title": "Nenhuma Execução em andamento para este Flow.",
+        "content": "Leia mais sobre <strong><a href=\"https://kestra.io/docs/workflow-components/execution?utm_source=app&utm_medium=referral&utm_campaign=concurrency-inlinedoc\" target=\"_blank\">Execuções</a></strong> em nossa documentação."
+      },
+      "concurrency_limit": {
+        "title": "Nenhum limite está definido para este Flow.",
+        "content": "Leia mais sobre <strong><a href=\"https://kestra.io/docs/workflow-components/concurrency?utm_source=app&utm_medium=referral&utm_campaign=concurrency-inlinedoc\" target=\"_blank\">Limites de Concurrency</a></strong> em nossa documentação."
+      },
+      "concurrency_limits": {
+        "title": "Nenhum limite de concorrência está definido.",
+        "content": "Leia mais sobre <strong><a href=\"https://kestra.io/docs/workflow-components/concurrency?utm_source=app&utm_medium=referral&utm_campaign=concurrency-inlinedoc\" target=\"_blank\">Limites de Concurrency</a></strong> em nossa documentação."
+      },
+      "pluginDefaults": {
+        "title": "Você ainda não tem padrões de plugin!",
+        "content": "Os Padrões de Plugin permitem que você governe centralmente a configuração do seu plugin e a compartilhe com todos os flows no seu namespace."
+      },
+      "variables": {
+        "title": "Ainda não há variáveis",
+        "content": "Adicione pares de key-value para compartilhar configurações entre flows. Namespaces filhos os herdam automaticamente, e você pode referenciar qualquer value com"
+      },
+      "workerRegistrationTokens": {
+        "title": "Você ainda não tem tokens de registro!",
+        "content": "Tokens de registro permitem que workers remotos autentiquem-se e registrem-se com segurança na sua instância do Kestra. Crie um token e use-o para conectar novos workers a este cluster."
+      },
+      "groups": {
+        "title": "Você ainda não tem grupos!",
+        "content": "Grupos permitem que você agrupe usuários para gerenciar permissões e vinculações de funções coletivamente em todo o seu tenant."
+      },
+      "dependencies": {
+        "FLOW": {
+          "title": "Atualmente, não há dependências.",
+          "content": "Leia mais sobre <a href=\"https://kestra.io/docs/ui/flows?utm_source=app&utm_medium=referral&utm_campaign=dependencies-inlinedoc#dependencies\" target=\"_blank\">Dependências de Flow</a> na nossa documentação."
+        },
+        "EXECUTION": {
+          "title": "Atualmente, não há dependências.",
+          "content": "Leia mais sobre <a href=\"https://kestra.io/docs/ui/executions?utm_source=app&utm_medium=referral&utm_campaign=dependencies-inlinedoc#dependencies\" target=\"_blank\">Dependências de Execução</a> na nossa documentação."
+        },
+        "NAMESPACE": {
+          "title": "Atualmente, não há dependências.",
+          "content": "Leia mais sobre <a href=\"https://kestra.io/docs/ui/namespaces?utm_source=app&utm_medium=referral&utm_campaign=dependencies-inlinedoc#dependencies\" target=\"_blank\">Dependências de Namespace</a> em nossa documentação."
+        },
+        "ASSET": {
+          "title": "Atualmente, não há dependências.",
+          "content": "Este ativo não possui dependências upstream ou downstream com flows ou outros ativos."
+        }
+      },
+      "plugins": {
+        "title": "Nenhum padrão de plugin está definido para este Namespace.",
+        "content": "Leia mais sobre <strong><a href=\"https://kestra.io/docs/workflow-components/plugin-defaults?utm_source=app&utm_medium=referral&utm_campaign=plugin-default-inlinedoc\" target=\"_blank\">Limites de Concurrency</a></strong> em nossa documentação."
+      },
+      "triggers": {
+        "title": "Seu flow não possui nenhum trigger.",
+        "content": "Leia mais sobre <strong><a href=\"https://kestra.io/docs/workflow-components/triggers?utm_source=app&utm_medium=referral&utm_campaign=trigger-inlinedoc\" target=\"_blank\">Triggers</a></strong> em nossa documentação."
+      },
+      "mcpToolFlows": {
+        "title": "Ainda não há flows de ferramenta registrados neste servidor.",
+        "content": "Exponha um flow como uma ferramenta MCP adicionando um <code>McpToolTrigger</code> a ele. Leia mais sobre o <strong><a href=\"https://kestra.io/docs/workflow-components/triggers/mcp-tool-trigger?utm_source=app&utm_medium=referral&utm_campaign=mcp-tool-trigger-inlinedoc\" target=\"_blank\">MCP Tool Trigger</a></strong> em nossa documentação."
+      },
+      "versionPlugin": {
+        "title": "Você ainda não tem um plugin versionado!",
+        "content": "Aqui você pode gerenciar todos os plugins instalados na sua instância do Kestra. Plugins recém-instalados podem não estar imediatamente disponíveis em todos os serviços do Kestra, dependendo da configuração da sua instância."
+      },
+      "panels": {
+        "title": "Nenhum painel aberto",
+        "content": "Você fechou todos os painéis.  \nEscolha uma aba acima para continuar."
+      }
+    },
+    "toggle_word_wrap": "Alternar Quebra de Linha",
+    "copied_logs_to_clipboard": "Logs copiados para a área de transferência.",
+    "multi_panel_editor": {
+      "move_right": "Mover para a direita",
+      "move_left": "Mover para a esquerda",
+      "close_all_tabs": "Fechar todas as abas",
+      "close_all_panels": "Fechar todos os painéis"
+    },
+    "search_docs": "Pesquisar",
+    "no_results_found": "Nenhum resultado encontrado",
+    "searching": "Procurando...",
+    "worker information": "Informações do Worker",
+    "test-badge-text": "Teste",
+    "test-badge-tooltip": "Esta execução foi criada por um Teste",
+    "total_executions": "Total de Execuções",
+    "no_results": {
+      "executions": "Nenhuma Execução Encontrada",
+      "triggers": "Nenhum Trigger Encontrado",
+      "flows": "Nenhum Flow Encontrado",
+      "kv_pairs": "Nenhum par de Key-Value encontrado",
+      "secrets": "Nenhum Secret Encontrado",
+      "templates": "Nenhum Template Encontrado",
+      "assets": "Nenhum Asset Encontrado"
+    },
+    "duplicate-pair": "O {label} \"{key}\" está duplicado, a primeira chave foi ignorada.",
+    "dashboards": {
+      "labels": {
+        "singular": "Dashboard",
+        "plural": "Dashboards"
+      },
+      "default": "Dashboard Padrão",
+      "switch": "Alternar Dashboard",
+      "preview": "Visualizar Dashboard",
+      "empty": "Não há resultados para serem exibidos.",
+      "creation": {
+        "label": "Criar Dashboard",
+        "confirmation": "O Dashboard <code>{title}</code> foi criado."
+      },
+      "edition": {
+        "label": "Editar Dashboard",
+        "confirmation": "As alterações no dashboard <code>{title}</code> foram salvas.",
+        "chart": "Edite este gráfico",
+        "id readonly": "A propriedade `id` não pode ser alterada — agora está definida para seus valores iniciais. Se você quiser alterá-la, pode criar um novo dashboard e remover o antigo."
+      },
+      "deletion": {
+        "confirmation": "Tem certeza de que deseja excluir o dashboard <code>{title}</code>?"
+      },
+      "no_description": "Sem descrição",
+      "no_description_hint": "Adicione uma descrição a este flow para documentar o que ele faz.<br>Markdown é suportado.",
+      "others": "Outros",
+      "viewAll": "Ver tudo",
+      "chart_preview": "Clique no código-fonte de um gráfico para ver sua pré-visualização",
+      "export": "Exportar para CSV",
+      "quick_filters": {
+        "all": "Todos",
+        "running": "Em execução",
+        "paused": "Pausado",
+        "success": "Sucesso",
+        "warning": "Aviso",
+        "failed": "Falhou"
+      }
     },
     "setup": {
-      "config": {
-        "basicauth": "Autenticação básica",
-        "queue": "Fila",
-        "repository": "Banco de Dados",
-        "storage": "Armazenamento Interno"
+      "login": "Login",
+      "login_title": "Entrar",
+      "logout": "Sair",
+      "troubleshooting": "Esqueceu a Senha?",
+      "steps": {
+        "user": "Criar usuário admin",
+        "config": "Validar Configuração",
+        "survey": "Conte-nos mais",
+        "complete": "Iniciar Kestra UI"
       },
-      "confirm": {
-        "config_title": "Confirme que a configuração é válida",
-        "confirm": "Criar usuário admin",
-        "not_valid": "Não, não é válido",
-        "valid": "Sim, é válido"
+      "titles": {
+        "user": "Criar um usuário admin",
+        "survey": "Ajude-nos a melhorar o Kestra OSS"
+      },
+      "subtitles": {
+        "user": "Proteja sua instância para começar.",
+        "config": "Aqui estão os detalhes da sua configuração",
+        "survey": "I'm sorry, but it seems there is no text provided after the \"----------\" for translation. Could you please provide the text you would like translated?",
+        "complete": "Configuração concluída com sucesso!"
       },
       "form": {
         "email": "Email",
@@ -1878,351 +1937,249 @@
         "username": "Nome de Usuário",
         "username_hint": "Deve ser um endereço de e-mail válido."
       },
-      "login": "Login",
-      "login_title": "Entrar",
-      "logout": "Sair",
-      "steps": {
-        "complete": "Iniciar Kestra UI",
-        "config": "Validar Configuração",
-        "survey": "Conte-nos mais",
-        "user": "Criar usuário admin"
-      },
-      "subtitles": {
-        "complete": "Configuração concluída com sucesso!",
-        "config": "Aqui estão os detalhes da sua configuração",
-        "survey": "I'm sorry, but it seems there is no text provided after the \"----------\" for translation. Could you please provide the text you would like translated?",
-        "user": "Proteja sua instância para começar."
-      },
-      "success": {
-        "subtitle": "Você está pronto!",
-        "title": "Parabéns!"
-      },
-      "survey": {
-        "company_11_50": "Projeto pessoal",
-        "company_1_10": "Aprendendo / explorando",
-        "company_250_plus": "Implantação de produção",
-        "company_50_250": "Avaliando para minha equipe/empresa",
-        "company_personal": "Outros",
-        "company_size": "Qual é o seu principal objetivo com o Kestra?",
-        "continue": "Continuar",
-        "newsletter": "Receba atualizações de produtos por email.",
-        "newsletter_heading": "Mantenha-se informado",
-        "skip": "Pular",
-        "use_case": "Para que você planeja usá-lo?",
-        "use_case_business": "Fluxos de trabalho empresariais",
-        "use_case_data": "Fluxos de trabalho de dados",
-        "use_case_infrastructure": "Automação de infraestrutura",
-        "use_case_ml": "Pipelines de ML",
-        "use_case_other": "Outros",
-        "use_case_scheduling": "Agendamento e trabalhos recorrentes"
-      },
-      "titles": {
-        "survey": "Ajude-nos a melhorar o Kestra OSS",
-        "user": "Criar um usuário admin"
-      },
-      "troubleshooting": "Esqueceu a Senha?",
       "validation": {
-        "config_message": "Certifique-se de atualizar sua configuração para corrigir esta mensagem de erro",
-        "email_invalid": "E-mail inválido",
         "email_required": "O e-mail é obrigatório",
+        "email_invalid": "E-mail inválido",
         "email_temporary_not_allowed": "Endereços de e-mail temporários ou descartáveis não são permitidos",
         "firstName_required": "Nome é obrigatório",
-        "incorrect_creds": "Nome de usuário ou senha inválidos. Certifique-se de que suas credenciais estão corretas.",
         "lastName_required": "Sobrenome obrigatório",
         "password_invalid": "Senha inválida",
-        "password_required": "A senha é obrigatória"
+        "password_required": "A senha é obrigatória",
+        "incorrect_creds": "Nome de usuário ou senha inválidos. Certifique-se de que suas credenciais estão corretas.",
+        "config_message": "Certifique-se de atualizar sua configuração para corrigir esta mensagem de erro"
+      },
+      "config": {
+        "repository": "Banco de Dados",
+        "queue": "Fila",
+        "storage": "Armazenamento Interno",
+        "basicauth": "Autenticação básica"
+      },
+      "confirm": {
+        "confirm": "Criar usuário admin",
+        "config_title": "Confirme que a configuração é válida",
+        "not_valid": "Não, não é válido",
+        "valid": "Sim, é válido"
+      },
+      "survey": {
+        "skip": "Pular",
+        "company_size": "Qual é o seu principal objetivo com o Kestra?",
+        "company_1_10": "Aprendendo / explorando",
+        "company_11_50": "Projeto pessoal",
+        "company_50_250": "Avaliando para minha equipe/empresa",
+        "company_250_plus": "Implantação de produção",
+        "company_personal": "Outros",
+        "use_case": "Para que você planeja usá-lo?",
+        "use_case_infrastructure": "Automação de infraestrutura",
+        "use_case_business": "Fluxos de trabalho empresariais",
+        "use_case_data": "Fluxos de trabalho de dados",
+        "use_case_ml": "Pipelines de ML",
+        "use_case_scheduling": "Agendamento e trabalhos recorrentes",
+        "use_case_other": "Outros",
+        "newsletter_heading": "Mantenha-se informado",
+        "newsletter": "Receba atualizações de produtos por email.",
+        "continue": "Continuar"
+      },
+      "success": {
+        "title": "Parabéns!",
+        "subtitle": "Você está pronto!"
       }
     },
-    "show": "Mostrar",
-    "show chart": "Mostrar Gráfico",
-    "show description": "Mostrar uma descrição",
-    "show details": "Mostrar detalhes",
-    "show documentation": "Mostrar documentação",
-    "show more details": "Mostrar mais detalhes",
-    "show raw": "Show raw",
-    "show task condition": "Exibir condição da task",
-    "show task documentation": "Mostrar documentação da task",
-    "show task documentation in editor": "Mostrar documentação da task no editor",
-    "show task logs": "Mostrar task logs",
-    "show task outputs": "Mostrar outputs da task",
-    "show task source": "Mostrar fonte da task",
-    "showLess": "Mostrar menos",
-    "showMore": "Mostrar mais",
-    "side-by-side": "lado a lado",
-    "similar lines": "similar lines",
-    "skipped": "Pulado",
-    "slack support": "Faça qualquer pergunta via Slack",
-    "something_went_wrong": {
-      "connection_lost": {
-        "message": "Não conseguimos acessar sua instância do Kestra. Certifique-se de que está em execução e atualize a página.",
-        "title": "Conexão interrompida"
+    "ai": {
+      "flow": {
+        "title": "Agente de IA",
+        "prompt_placeholder": "Insira instruções para criar seu flow Kestra. Exemplo de prompt: Crie um flow que execute toda segunda-feira às 9h.",
+        "select_provider": "Selecionar um provedor",
+        "generating": {
+          "flow": "Gerando YAML do flow para você...",
+          "dashboard": "Gerando YAML do Dashboard para você...",
+          "app": "Gerando YAML do App para você...",
+          "test": "Gerando YAML de teste para você..."
+        },
+        "enable_instructions": {
+          "header": "<b>AI Copilot ainda não foi configurado.</b>\n\nPara habilitar o AI Copilot, adicione o seguinte trecho ao arquivo de configuração da sua instância Kestra (por exemplo, <code>application.yml</code>), substituindo <code>geminiApiKey</code> pela sua chave real:",
+          "footer": "Nota: Neste momento, apenas o Gemini é suportado como provedor de IA para a Open Source Edition. Para a Enterprise Edition, consulte a documentação do AI Copilot para a configuração de outros provedores de modelo.\n\nReinicie sua instância do Kestra após salvar a configuração."
+        }
       },
-      "loading_execution": "Algo deu errado ao carregar a execução"
+      "dashboard": {
+        "prompt_placeholder": "Faça uma pergunta sobre seus dados. Exemplo de prompt: Mostre-me a taxa de sucesso dos meus flows nos últimos 7 dias."
+      }
     },
-    "source": "Fonte",
-    "source and blueprints": "Fonte e blueprints",
-    "source and doc": "Fonte e documentação",
-    "source and topology": "Fonte e topologia",
-    "source only": "Somente fonte",
-    "source search": "Busca de fonte",
-    "source_search": {
-      "match_count": "{count} correspondência | {count} correspondências",
-      "open_flow": "Abrir flow",
-      "preview_empty": "Selecione um resultado para pré-visualizar. Clique em um flow na lista de resultados para ver seu código-fonte.",
-      "preview_error": "Falha ao carregar o código-fonte do flow"
+    "playground": {
+      "title": "Playground",
+      "run_task_info": "Passe o cursor sobre qualquer task no editor de Flow Code e clique no botão \"Run task\" para testar sua task.",
+      "play_icon_info": "Você também pode clicar no ícone de Play nas visualizações No-Code ou Topology.",
+      "toggle": "Playground",
+      "run_task": "Executar Task",
+      "run_this_task": "Execute esta task",
+      "run_task_and_downstream": "Executar task & downstream",
+      "run_all_tasks": "Executar Todas as Tasks",
+      "history": "Últimas 10 execuções",
+      "clear_history": "Limpar histórico",
+      "confirm_create": "Você não pode executar o playground enquanto cria um flow. Iniciar uma execução do playground criará o flow.",
+      "tooltip_persistence": "Se você desligar e ligar o Playground novamente, as informações permanecem enquanto você estiver na página."
     },
-    "specific task": "Task específica",
-    "start date": "Data de início",
-    "start datetime": "Data e hora de início",
-    "started date": "Data de início",
-    "state": "Estado",
-    "state updated date": "Data de atualização do estado",
-    "state_history": "Histórico de estado",
-    "stats": "Estatísticas",
-    "steps": "Passos",
-    "stream": "Stream",
-    "sub flow": "Subflow",
     "submit": "Enviar",
-    "success": "Sucesso",
-    "sum": "Soma",
-    "switch-view": "Alternar visualização",
-    "system overview": "Visão Geral do Sistema",
-    "system_namespace": "Mantenha sua plataforma sob controle com system flows.",
-    "system_namespace_description": "Automatize tarefas de manutenção, desde alertas de falha até limpezas automatizadas.",
-    "tags": "Tags",
-    "task": "Task",
-    "task failed": "Tarefa falhou",
-    "task id": "Task ID",
-    "task id already exists": "Task Id já existe",
-    "task is running": "A task está RUNNING",
-    "task logs": "Task logs",
-    "task run id": "ID do TaskRun",
-    "task sent a warning": "A tarefa enviou um WARNING",
-    "task was skipped": "A tarefa foi ignorada",
-    "task was successful": "A tarefa foi bem-sucedida",
-    "taskDefaults": "Padrões da Task",
-    "taskRunners": "Executores de Task",
-    "task_id_exists": "Id da Task já existe",
-    "task_id_message": "O Task Id ${existingTask} já existe no flow.",
-    "taskid column details": "Última task sendo executada e seu número de tentativas.",
-    "tasks": "Tasks",
-    "template": "Template",
-    "template creation": "Criação de template",
-    "template delete": "Tem certeza de que deseja excluir <code>{templateCount}</code> template(s)?",
-    "template export": "Tem certeza de que deseja exportar <code>{templateCount}</code> template(s)?",
-    "templates": "Templates",
-    "templates deleted": "<code>{count}</code> Template(s) deletado(s)",
-    "templates deprecated": "Templates estão obsoletos. Por favor, use subflows. Veja a <a href=\"https://kestra.io/docs/migration-guide/0.11.0/templates?utm_source=app&utm_medium=referral&utm_campaign=template-inlinedoc\" target=\"_blank\">Seção de Migrações</a> explicando como você pode migrar de templates para subflows.",
-    "templates exported": "Templates exportados",
-    "tenant": {
-      "name": "Cliente",
-      "names": "Clientes"
-    },
-    "tenantId": "ID do Cliente",
-    "test-badge-text": "Teste",
-    "test-badge-tooltip": "Esta execução foi criada por um Teste",
-    "theme": "Tema",
-    "this_task_has": "Esta task tem",
-    "timezone": "Fuso horário",
-    "title": "Título",
-    "to": "Para",
     "to toggle": "alternar",
-    "toggle fullscreen": "Alternar tela cheia",
-    "toggle menu": "Alternar menu",
-    "toggle output": "Alternar outputs",
-    "toggle output display": "Alternar exibição de output",
-    "toggle periodic refresh each x seconds": "Alternar atualização periódica a cada {interval} segundos",
-    "toggle_word_wrap": "Alternar Quebra de Linha",
-    "topology": "Topologia",
-    "topology-graph": {
-      "graph-orientation": "Orientação do gráfico",
-      "invalid": "Erro no gráfico",
-      "invalid_description": "Ocorreu um erro ao carregar o gráfico. Por favor, verifique o código-fonte para erros.",
-      "zoom-fit": "Ajustar",
-      "zoom-in": "Aumentar zoom",
-      "zoom-out": "Diminuir zoom",
-      "zoom-reset": "Redefinir zoom"
-    },
-    "total_duration": "Duração total",
-    "total_executions": "Total de Execuções",
-    "trigger": "Trigger",
-    "trigger details": "Detalhes do trigger",
-    "trigger disabled": "O Trigger está desativado na fonte do Flow",
-    "trigger execution id": "Trigger Execution Id",
-    "trigger filter": {
-      "options": {
-        "ALL": "Todas as Execuções",
-        "CHILD": "Execuções Filhas",
-        "MAIN": "Execuções Pais"
+    "accept": "Aceitar",
+    "reject": "Rejeitar",
+    "draft_available": "Mudança de rascunho disponível no editor",
+    "last modified": "Última modificação",
+    "run task in playground": "Executar task no playground",
+    "task is running": "A task está RUNNING",
+    "task was successful": "A tarefa foi bem-sucedida",
+    "task failed": "Tarefa falhou",
+    "task was skipped": "A tarefa foi ignorada",
+    "task sent a warning": "A tarefa enviou um WARNING",
+    "defaultsToNamespaceFile": "Padrões para arquivo de namespace: <code>{name}</code>",
+    "no_file_choosen": "Nenhum arquivo selecionado",
+    "dependency": {
+      "controls": {
+        "zoom_in": "Aumentar",
+        "zoom_out": "Reduzir zoom",
+        "clear_selection": "Limpar seleção",
+        "fit_view": "Ajustar à tela"
       },
-      "title": "Filtrar execuções filhas"
-    },
-    "trigger refresh": "Atualizar trigger",
-    "triggerId": "ID do Trigger",
-    "trigger_check_warning": "Usar variáveis de trigger não funcionará com a execução manual de flow. Adicione o operador de coalescência `??` para resolver o problema. Por exemplo, em vez de `trigger.date`, use `trigger.date ?? execution.startDate`.",
-    "trigger_id_exists": "Id de Trigger já existe",
-    "trigger_id_message": "O Trigger Id ${existingTrigger} já existe no flow.",
-    "trigger_states": "Estados",
-    "triggered": "Trigger de execução",
-    "triggered done": "Execução <em>{name}</em> foi acionada com sucesso",
-    "triggerflow disabled": "Trigger está desativado na definição do flow",
-    "triggers": "Triggers",
-    "triggers_add_card_add": "Adicionar",
-    "triggers_add_card_add_to_flow": "Adicionar ao flow",
-    "triggers_add_category_empty": "Nenhum trigger nesta categoria.",
-    "triggers_add_ee_tooltip": "Este trigger requer a Enterprise Edition.",
-    "triggers_add_empty_title": "Nenhum trigger encontrado",
-    "triggers_add_filter_all": "Todos",
-    "triggers_add_filter_app": "Aplicativo",
-    "triggers_add_filter_core": "Núcleo",
-    "triggers_add_filter_realtime": "Tempo real",
-    "triggers_add_modal_add_button": "Adicionar Trigger ao Flow",
-    "triggers_add_modal_ee_notice": "Este trigger requer a Enterprise Edition.",
-    "triggers_add_modal_flow_placeholder": "Selecione um flow",
-    "triggers_add_modal_namespace_placeholder": "Selecione um namespace",
-    "triggers_add_modal_properties_hint": "Configure as propriedades do trigger no editor de flow após adicionar o trigger.",
-    "triggers_add_modal_tab_documentation": "Documentação",
-    "triggers_add_modal_tab_form": "Formulário",
-    "triggers_add_modal_tab_source": "Fonte",
-    "triggers_add_modal_title": "{name}",
-    "triggers_add_modal_trigger_id": "ID do Trigger",
-    "triggers_add_modal_trigger_id_placeholder": "Identificador único para este trigger",
-    "triggers_add_search_placeholder": "Procurar triggers...",
-    "triggers_header_description": "Navegue, adicione e gerencie triggers para automatizar seus flows. Escolha entre expor seu flow como uma ferramenta de IA, agendar, adicionar um webhook trigger, verificar mudanças em aplicativos externos ou ouvintes de eventos em tempo real.",
-    "triggers_state": {
-      "options": {
-        "disabled": "Desativado",
-        "enabled": "Ativado"
-      },
-      "state": "Estado"
-    },
-    "triggers_tabs_add": "Adicionar",
-    "triggers_tabs_manage": "Gerenciar",
-    "true": "Verdadeiro",
-    "type": "Tipo",
-    "unable to generate graph": "Ocorreu um problema ao gerar o gráfico, o que impede a exibição da topologia.",
-    "undefined": "Indefinido",
-    "unlock": "Desbloquear",
-    "unlock trigger": {
-      "button": "Desbloquear trigger",
-      "confirmation": "Tem certeza de que deseja desbloquear o trigger?",
-      "success": "Trigger desbloqueado",
-      "tooltip": {
-        "evaluation": "O trigger está atualmente em avaliação",
-        "execution": "Há uma execução em andamento para este trigger"
-      },
-      "warning": "Isso pode levar a execuções concorrentes para o mesmo trigger e deve ser considerado como uma última opção."
-    },
-    "unqueue": "Desenfileirar",
-    "unqueue as": "Desenfileirar como <code>{status}</code>",
-    "unqueue confirm": "Tem certeza de que deseja desagendar a execução <code>{id}</code>?",
-    "unqueue done": "A execução está fora da fila",
-    "unqueue title": "Desenfileirar execução <code>{id}</code>.<br/>Observe que isso não obedecerá ao limite de concorrência do flow, portanto, mais execuções podem estar em execução do que o limite permitido.",
-    "unqueue title multiple": "Tem certeza de que deseja Desenfileirar <code>{count}</code> execuções?<br/><br/>Observe que isso não obedecerá ao limite de concorrência do flow, portanto, mais execuções podem estar em execução do que o limite permitido.",
-    "unsaved changed ?": "Você tem alterações não salvas, deseja sair desta página?",
-    "unsaved changes": "Alterações Não Salvas",
-    "unsaved changes warning": "Você tem alterações não salvas. Se você sair desta página, suas alterações serão perdidas.",
-    "up trend": "Aumentando",
-    "update": "Atualizar",
-    "update aborted": "atualização abortada",
-    "update ok": "está atualizado",
-    "updated date": "Data de atualização",
-    "usage": "Uso",
-    "use": "Usar",
-    "use_dark_background": "Use esta versão ao trabalhar em um fundo escuro para garantir que nosso nome permaneça legível.",
-    "valid": "Válido",
-    "validate": "Validar",
-    "value": "Value",
-    "variable_explorer": {
-      "empty": "Nenhuma variável disponível para esta execução.",
-      "n_items": "[ {count} itens ]",
-      "n_keys": "\\{ {count} keys \\}",
-      "one_item": "[ 1 item ]",
-      "one_key": "\\{ 1 key \\}",
-      "raw_json": "Raw JSON",
-      "search_placeholder": "Pesquisar Key ou value...",
-      "select_prompt": "Selecione uma variável para inspecionar seu value.",
-      "tasks_outputs": "Tasks outputs",
-      "title": "Entrada/Saída",
-      "tree": "Árvore"
-    },
-    "variables": "Variáveis",
-    "version": "Versão",
-    "view metrics": "Ver métricas",
-    "warning": "Aviso",
-    "warning detected": "Aviso(s) detectado(s)",
-    "warning flow with triggers": "Este flow contém triggers e uma execução manual falhará se este flow depender de expressões de trigger.",
-    "watch": "Assistir",
-    "watch_video": "Assistir Vídeo",
-    "webhook": {
-      "copy_url": "Copiar URL do webhook",
-      "curl_command": "Comando cURL do Webhook",
-      "curl_note": "Use este comando cURL para acionar o flow via webhook com carga útil JSON personalizada",
-      "no_triggers": "Este flow não possui triggers de webhook habilitados",
-      "payload": "Payload do Webhook (JSON)"
-    },
-    "webhook link copied": "Link do Webhook copiado.",
-    "welcome": {
-      "help": {
-        "text": "Faça qualquer pergunta em nossa comunidade no Slack. Se você estiver com dificuldades, estamos aqui para ajudar você. ✋",
-        "title": "Precisa de ajuda?"
-      },
-      "menu": "Welcome",
-      "tour": {
-        "text": "Escolha seu caso de uso e siga um guia passo a passo para aprender os recursos e capacidades do Kestra. ❤️",
-        "title": "Faça um tour pelo produto"
-      },
-      "tutorial": {
-        "text": "* <a href=\"https://kestra.io/tutorial-videos/all?utm_source=app&utm_medium=referral&utm_campaign=welcome-tutorial\" target=\"_blank\">Tutoriais em Vídeo</a>  \n* <a href=\"https://kestra.io/docs?utm_source=app&utm_medium=referral&utm_campaign=welcome-tutorial\" target=\"_blank\">Documentação</a>  \n* <a href=\"https://kestra.io/blueprints?utm_source=app&utm_medium=referral&utm_campaign=welcome-tutorial\" target=\"_blank\">Blueprints</a>",
-        "title": "Tutorial"
+      "search": {
+        "placeholders": {
+          "default": "Pesquisar por flow ou namespace...",
+          "asset": "Pesquisar por asset, flow ou namespace..."
+        },
+        "namespace": {
+          "select": "Selecione um namespace",
+          "no_namespace": "Sem namespace"
+        },
+        "flow": {
+          "display": "Incluir dependências do flow"
+        },
+        "no_results": "Nenhum resultado encontrado para {term}"
       }
     },
+    "preview": {
+      "label": "Visualizar",
+      "force-editor": "Forçar visualização do editor",
+      "auto-view": "Visualização automática",
+      "view": "Visualizar",
+      "rows_truncated": "Mostrando {shown} de {total} linhas. Baixe o arquivo para ver todos os dados.",
+      "pagination_info": "Exibindo linhas {start}-{end} de {total}.",
+      "showing_rows": "Mostrando linhas {start}-{end} de {total}",
+      "expand": "Expandir",
+      "collapse": "Recolher",
+      "previous": "Anterior",
+      "next": "Próximo",
+      "page_of": "Página {current} de {total}"
+    },
+    "delete trigger": "Excluir trigger",
+    "delete triggers": "Excluir triggers",
+    "bulk delete triggers": "Tem certeza de que deseja excluir {count} triggers?",
+    "bulk success delete triggers": "{count} triggers foram excluídos com sucesso",
+    "delete trigger confirmation": "Tem certeza de que deseja excluir o trigger {id}? WARNING: excluir um trigger pode levar a execuções duplicadas se o trigger ainda estiver ativo em um flow.",
+    "delete trigger success": "O Trigger {id} foi excluído com sucesso",
+    "delete trigger error": "Erro ao excluir trigger {id}",
+    "revision deleted": "A revisão {revision} foi excluída com sucesso",
+    "delete revision confirm": "Tem certeza de que deseja excluir a revisão {revision}?",
+    "delete revision error": "Erro ao excluir a revisão {revision} com erro {error}",
+    "no_history": "Sem histórico disponível",
+    "export_as": "Exportar como .{format}",
+    "save_and_execute": "Salvar & Executar",
     "welcome_copilot": {
       "button_cta": "Criar flow do zero",
       "create_manually": {
-        "description": "Construir do zero usando o editor",
-        "title": "Criar manualmente"
+        "title": "Criar manualmente",
+        "description": "Construir do zero usando o editor"
       },
       "docs": {
-        "description": "Saiba mais na documentação oficial",
-        "title": "Leia a documentação"
+        "title": "Leia a documentação",
+        "description": "Saiba mais na documentação oficial"
       },
+      "title": "Transforme sua ideia em um workflow",
+      "need_help": "Precisa de Ajuda?",
+      "placeholder_prompt": "Envie-me uma mensagem de saudação diária às 9h.",
+      "show_more": "Mostrar mais prompts",
+      "show_less": "Mostrar menos prompts",
+      "remaining_quota": "Você tem {count} gerações de IA restantes. O limite é redefinido diariamente à meia-noite UTC.",
       "execute_hint": {
-        "description": "Clique para salvar seu workflow e executá-lo imediatamente.",
-        "title": "Salve e Execute seu flow"
+        "title": "Salve e Execute seu flow",
+        "description": "Clique para salvar seu workflow e executá-lo imediatamente."
+      },
+      "success_popup": {
+        "title": "Parabéns!",
+        "description": "Você executou com sucesso seu primeiro flow! Você está a caminho de se tornar um especialista em Kestra.",
+        "tutorial": "Tutorial Detalhado",
+        "explore": "Explore Mais"
+      },
+      "success_page": {
+        "title": "Você está pronto!",
+        "description": "Você aprendeu o básico do Kestra. Aqui estão alguns recursos para ajudar você a continuar sua jornada.",
+        "restart": "Reiniciar Tutorial",
+        "items": {
+          "tutorial": {
+            "title": "Iniciar um Tutorial",
+            "description": "Passeio interativo de todos os recursos do Kestra"
+          },
+          "blueprints": {
+            "title": "Blueprints",
+            "description": "Modelos de workflow pré-construídos para casos de uso comuns"
+          },
+          "slack": {
+            "title": "Comunidade Slack",
+            "description": "Conecte-se com outros usuários e obtenha ajuda da comunidade"
+          },
+          "videos": {
+            "title": "Tutoriais em Vídeo",
+            "description": "Guias em vídeo passo a passo para recursos avançados"
+          },
+          "demo": {
+            "title": "Obter uma Demonstração",
+            "description": "Explore a Kestra Enterprise Edition com uma demonstração personalizada"
+          }
+        }
+      },
+      "help": {
+        "tutorial": {
+          "title": "Iniciar um Tutorial",
+          "description": "Aprenda como criar e executar seu primeiro flow com etapas guiadas."
+        },
+        "blueprints": {
+          "title": "Blueprints",
+          "description": "Explore exemplos e modelos prontos para padrões comuns de workflow."
+        },
+        "slack": {
+          "title": "Comunidade Slack",
+          "description": "Junte-se a nós para compartilhar ideias e melhores práticas, e obter ajuda com questões técnicas."
+        }
       },
       "flows": {
-        "buildDbtPipeline": {
-          "label": "Crie um pipeline dbt",
-          "prompt": "Crie um flow do Kestra que clona um repositório de projeto dbt e executa dbt build com um perfil DuckDB."
-        },
-        "buildDockerImageAndRunIt": {
-          "label": "Crie uma imagem Docker e execute-a",
-          "prompt": "Crie um flow do Kestra que construa uma imagem Docker a partir de um Dockerfile inline e execute o container resultante."
-        },
-        "convertCsvToExcel": {
-          "label": "Converter um CSV para Excel",
-          "prompt": "Crie um flow que faça o download de um arquivo CSV, converta-o para Ion e exporte o resultado como um arquivo Excel."
-        },
-        "etlWorkflow": {
-          "label": "Fluxo de Trabalho ETL",
-          "prompt": "Crie um flow de ETL que baixe dados JSON, processe-os com Python e consulte o resultado transformado com DuckDB."
+        "jsonApiToDuckdb": {
+          "label": "API JSON para DuckDB",
+          "prompt": "Crie um flow que baixa um arquivo JSON de uma API pública, transforma-o com um script Python e o processa com uma task de DuckDB Queries."
         },
         "installNginxViaAnsible": {
           "label": "Instalar Nginx via Ansible",
           "prompt": "Crie um flow do Kestra que instala o Nginx em uma máquina alvo com Ansible e verifica a versão instalada."
         },
-        "jsonApiToDuckdb": {
-          "label": "API JSON para DuckDB",
-          "prompt": "Crie um flow que baixa um arquivo JSON de uma API pública, transforma-o com um script Python e o processa com uma task de DuckDB Queries."
+        "buildDbtPipeline": {
+          "label": "Crie um pipeline dbt",
+          "prompt": "Crie um flow do Kestra que clona um repositório de projeto dbt e executa dbt build com um perfil DuckDB."
+        },
+        "etlWorkflow": {
+          "label": "Fluxo de Trabalho ETL",
+          "prompt": "Crie um flow de ETL que baixe dados JSON, processe-os com Python e consulte o resultado transformado com DuckDB."
+        },
+        "microservicesApis": {
+          "label": "Microservices & APIs",
+          "prompt": "Crie um flow que verifica a resposta da API de um site e envia um alerta no Slack quando o código de status não for bem-sucedido."
+        },
+        "buildDockerImageAndRunIt": {
+          "label": "Crie uma imagem Docker e execute-a",
+          "prompt": "Crie um flow do Kestra que construa uma imagem Docker a partir de um Dockerfile inline e execute o container resultante."
         },
         "manualApproval": {
           "label": "Aprovação manual",
           "prompt": "Crie um flow com uma etapa inicial de processamento, uma pausa para aprovação manual e uma etapa final de implantação após a aprovação."
         },
-        "microservicesApis": {
-          "label": "Microservices & APIs",
-          "prompt": "Crie um flow que verifica a resposta da API de um site e envia um alerta no Slack quando o código de status não for bem-sucedido."
+        "convertCsvToExcel": {
+          "label": "Converter um CSV para Excel",
+          "prompt": "Crie um flow que faça o download de um arquivo CSV, converta-o para Ion e exporte o resultado como um arquivo Excel."
         },
         "scheduledPdfReports": {
           "label": "Relatórios PDF agendados",
@@ -2232,73 +2189,116 @@
           "label": "KPIs de Vendas Semanais para o Slack",
           "prompt": "Crie um flow agendado semanalmente que calcula KPIs de vendas com DuckDB e publica o resumo no Slack."
         }
-      },
-      "help": {
-        "blueprints": {
-          "description": "Explore exemplos e modelos prontos para padrões comuns de workflow.",
-          "title": "Blueprints"
-        },
-        "slack": {
-          "description": "Junte-se a nós para compartilhar ideias e melhores práticas, e obter ajuda com questões técnicas.",
-          "title": "Comunidade Slack"
-        },
-        "tutorial": {
-          "description": "Aprenda como criar e executar seu primeiro flow com etapas guiadas.",
-          "title": "Iniciar um Tutorial"
-        }
-      },
-      "need_help": "Precisa de Ajuda?",
-      "placeholder_prompt": "Envie-me uma mensagem de saudação diária às 9h.",
-      "remaining_quota": "Você tem {count} gerações de IA restantes. O limite é redefinido diariamente à meia-noite UTC.",
-      "show_less": "Mostrar menos prompts",
-      "show_more": "Mostrar mais prompts",
-      "success_page": {
-        "description": "Você aprendeu o básico do Kestra. Aqui estão alguns recursos para ajudar você a continuar sua jornada.",
-        "items": {
-          "blueprints": {
-            "description": "Modelos de workflow pré-construídos para casos de uso comuns",
-            "title": "Blueprints"
-          },
-          "demo": {
-            "description": "Explore a Kestra Enterprise Edition com uma demonstração personalizada",
-            "title": "Obter uma Demonstração"
-          },
-          "slack": {
-            "description": "Conecte-se com outros usuários e obtenha ajuda da comunidade",
-            "title": "Comunidade Slack"
-          },
-          "tutorial": {
-            "description": "Passeio interativo de todos os recursos do Kestra",
-            "title": "Iniciar um Tutorial"
-          },
-          "videos": {
-            "description": "Guias em vídeo passo a passo para recursos avançados",
-            "title": "Tutoriais em Vídeo"
-          }
-        },
-        "restart": "Reiniciar Tutorial",
-        "title": "Você está pronto!"
-      },
-      "success_popup": {
-        "description": "Você executou com sucesso seu primeiro flow! Você está a caminho de se tornar um especialista em Kestra.",
-        "explore": "Explore Mais",
-        "title": "Parabéns!",
-        "tutorial": "Tutorial Detalhado"
-      },
-      "title": "Transforme sua ideia em um workflow"
+      }
     },
-    "welcome_page": {
-      "guide": "Precisa de orientação para executar seu primeiro flow?",
-      "welcome": "Bem-vindo ao Kestra"
+    "mcp": {
+      "your_servers": "Seus Servidores",
+      "servers_count": "{count} Servidores MCP",
+      "managed_by_kestra": "Gerenciado por Kestra",
+      "servers": "Servidores MCP",
+      "server": "Servidor MCP",
+      "client_setup": "Configuração do cliente",
+      "page_description": "Exponha seus flows do Kestra como ferramentas para agentes de IA compatíveis com MCP",
+      "create": "Criar Servidor",
+      "save": "Salvar Alterações",
+      "connect": "Conectar",
+      "copy_url": "Copiar URL",
+      "url_copied": "URL copiado!",
+      "instructions": "Instruções",
+      "server_type": "Tipo de Servidor",
+      "auth_type": "Autenticação",
+      "private": "Privado",
+      "private_server": "Servidor privado",
+      "public": "Público",
+      "public_hint": "Aviso: Servidores públicos não exigem autenticação. Qualquer pessoa com a URL pode chamar todas as ferramentas expostas por este servidor, sem verificações de namespace ou permissão. Use apenas para servidores seguros para expor externamente.",
+      "basic_auth": "Autenticação Básica",
+      "api_token": "Token da API",
+      "oauth": "OAuth",
+      "username_password": "Nome de usuário & senha",
+      "bearer_token": "Autenticação por token Bearer",
+      "oauth_hint": "Bearer JWT do seu provedor OIDC",
+      "oauth_provider": "Provedor OAuth",
+      "oauth_provider_placeholder": "Selecione um provedor OIDC configurado",
+      "oauth_provider_required": "O provedor OAuth é obrigatório quando o tipo de autenticação é OAuth",
+      "scopes_supported": "Scopes suportados",
+      "scopes_supported_placeholder": "openid, profile, email",
+      "scopes_supported_hint": "Scopes divulgados no documento Protected Resource Metadata deste servidor. Clientes MCP em conformidade com a especificação restringem sua solicitação de autorização a esta lista. Deixe vazio para omitir o campo e deixar os clientes recorrerem aos scopes divulgados pelo IdP.",
+      "no_oauth_providers": "Nenhum provedor OIDC configurado nesta instância",
+      "delete_confirm": "Tem certeza de que deseja excluir este servidor MCP?",
+      "no_servers": "Nenhum servidor MCP encontrado. Crie seu primeiro servidor para expor triggers da ferramenta MCP a agentes de IA externos.",
+      "server_id": "ID do servidor",
+      "id_placeholder": "por exemplo, meu-servidor-mcp",
+      "id_invalid": "O ID deve começar com uma letra minúscula ou dígito, e conter apenas letras minúsculas, dígitos, hífens ou underscores",
+      "main_tenant": "principal",
+      "tab_edit": "Editar",
+      "tab_connect": "Conectar",
+      "tab_tool_flows": "Fluxos de Ferramentas",
+      "tab_tool_flows_placeholder": "A gestão de tool flows estará disponível em breve.",
+      "tools": {
+        "no_tools": "Nenhum flow de ferramenta corresponde à sua pesquisa.",
+        "create_tool_flow": "Criar um flow de ferramenta",
+        "tool_name": "Nome da ferramenta",
+        "trigger_id": "ID do trigger",
+        "title": "Título",
+        "description": "Descrição",
+        "annotations": "Anotações",
+        "flow": "flow",
+        "state": "Estado",
+        "read_only": "Somente leitura",
+        "open_world": "Open world",
+        "destructive": "Destrutivo",
+        "idempotent": "Idempotente",
+        "return_direct": "Retorno direto",
+        "view_flow": "Abrir flow"
+      },
+      "connect_tab": {
+        "server_url": "URL do Servidor",
+        "client_picker_label": "Escolha seu cliente de IA",
+        "claude_desktop": "Claude Desktop",
+        "claude_desktop_hint": "Adicione o seguinte ao seu arquivo claude_desktop_config.json:",
+        "claude_desktop_mac": "macOS: ~/Library/Application Support/Claude/claude_desktop_config.json",
+        "claude_desktop_win": "Windows: %APPDATA%\\Claude\\claude_desktop_config.json",
+        "claude_code": "Código Claude",
+        "claude_code_hint": "Execute o seguinte comando no seu terminal:",
+        "cursor": "Cursor",
+        "cursor_hint": "Adicione o seguinte a ~/.cursor/mcp.json:",
+        "codex": "Codex (OpenAI)",
+        "codex_hint": "Adicione o seguinte ao seu arquivo de configuração codex.json MCP:",
+        "auth_basic_hint": "Defina <code>KESTRA_BASIC_AUTH</code> como variável de ambiente contendo uma string <code>username:password</code> codificada em base64 antes de iniciar o cliente.",
+        "auth_api_token_hint": "Defina <code>KESTRA_TOKEN</code> como variável de ambiente antes de iniciar o cliente.",
+        "auth_oauth_client_id_hint": "Substitua <code>&lt;client-id&gt;</code> pelo ID do cliente OAuth e registre <code>http://localhost:7777</code> como URI de redirecionamento válido nesse cliente.",
+        "auth_oauth_browser_hint": "Seu navegador abrirá a página de login do provedor de identidade na primeira conexão."
+      }
     },
-    "wordmark_colors": "As cores da marca adaptam-se com base no fundo, enquanto o ícone permanece sem fundo quando colocado em um fundo escuro.",
-    "worker group": "Grupo de Workers",
-    "worker group fallback": "Grupo de Worker de reserva",
-    "worker group key": "Grupo de Worker key",
-    "worker information": "Informações do Worker",
-    "workerId": "Worker Id",
-    "workers": "Workers",
-    "wrong labels": "Chave ou valor vazio não é permitido em labels",
-    "yes": "Sim"
+    "flow_editor_stats": {
+      "revisions": {
+        "suffix": "Revisão(ões)",
+        "tooltip": "Visualizar revisões do flow"
+      },
+      "dependencies": {
+        "suffix": "Dependências",
+        "tooltip": "Visualizar dependências do flow"
+      },
+      "apps": {
+        "suffix": "Aplicativo(s)",
+        "tooltip": "Ver aplicativos usando este flow"
+      },
+      "tests": {
+        "suffix": "Testes",
+        "tooltip": "Visualizar testes de flow"
+      },
+      "errors": {
+        "label": "{count} Erro(s)"
+      }
+    },
+    "source_search": {
+      "match_count": "{count} correspondência | {count} correspondências",
+      "open_flow": "Abrir flow",
+      "preview_empty": "Selecione um resultado para pré-visualizar. Clique em um flow na lista de resultados para ver seu código-fonte.",
+      "preview_error": "Falha ao carregar o código-fonte do flow"
+    },
+    "open source": "Código Aberto",
+    "pricing": "Preços",
+    "license": "Licença"
   }
 }

--- a/ui/src/translations/ru.json
+++ b/ui/src/translations/ru.json
@@ -1,1678 +1,722 @@
 {
   "ru": {
-    "Add flow": "Добавить flow",
-    "Default log level": "Уровень log по умолчанию",
-    "Default namespace": "Namespace по умолчанию",
-    "Default page": "Страница по умолчанию",
-    "Editor fontfamily": "Шрифт редактора",
-    "Editor fontsize": "Размер шрифта редактора",
-    "Editor theme": "Тема редактора",
-    "Fold auto": "Редактор: автоматическое сворачивание многострочных строк",
-    "Fold content lines": "Свернуть многострочные строки",
-    "Hover description": "Редактор: Показать описание поля при наведении на key или value",
-    "Language": "Язык",
-    "Per page": "на страницу",
-    "Set default page": "Установить страницу по умолчанию",
-    "Set labels": "Установить метки",
-    "Set labels done": "Метки выполнения успешно установлены",
-    "Set labels to execution": "Добавить или обновить метки выполнения <code>{id}</code>",
-    "Set labels tooltip": "Установить метки для выполнения",
-    "Task Id already exist in the flow": "Task Id {taskId} уже существует в flow.",
-    "Total": "Всего",
-    "Unfold content lines": "Развернуть многострочные строки",
-    "about_this_blueprint": "О данном blueprint",
-    "absolute": "Абсолютный",
-    "accept": "Принять",
-    "actions": "Действия",
-    "activate_basic_auth": "Активировать Basic Authentication",
-    "active": "Активно",
-    "active-slots": "Активные слоты",
-    "actual state": "Фактическое состояние",
-    "add": "Добавить",
-    "add at position": "Добавить {position} <code>{task}</code>",
-    "add error handler": "Добавить обработчик ошибок",
-    "add flow": "Добавить flow",
+    "loading": "Загрузка...",
+    "more actions": "Дополнительные действия",
+    "toggle menu": "Переключить меню",
+    "panel actions": "Действия панели",
+    "playground actions": "Действия Playground",
+    "bulk actions": "Массовые действия",
+    "view metrics": "Просмотр метрик",
+    "remove this item": "Удалить этот элемент",
     "add label": "Добавить label",
-    "add task": "Добавить задачу",
-    "add-trigger-in-editor": "Сначала добавьте Trigger в ваш Flow",
-    "add_new_item": "Добавить новый элемент",
-    "additionalPlugins": "Дополнительные плагины",
-    "admin": "Администратор",
-    "admin_preferences": "Preferences",
-    "administration": "Администрирование",
-    "advanced configuration": "Другие свойства",
-    "after": "после",
-    "aggregation": "Агрегация",
-    "ai": {
-      "dashboard": {
-        "prompt_placeholder": "Задайте вопрос о ваших данных. Пример запроса: Покажите мне уровень успеха моих flows за последние 7 дней."
+    "remove label": "Удалить label",
+    "id": "Id",
+    "type": "Тип",
+    "ok": "ОК",
+    "valid": "Действительный",
+    "close": "Закрыть",
+    "namespace": "Namespace",
+    "description": "Описание",
+    "show description": "Показать описание",
+    "show details": "Показать детали",
+    "show more details": "Показать больше деталей",
+    "skipped": "Пропущено",
+    "revision": "Редакция",
+    "Language": "Язык",
+    "Set default page": "Установить страницу по умолчанию",
+    "theme": "Тема",
+    "flows": "Flows",
+    "flow": "Flow",
+    "invalid source": "Неверный исходный код",
+    "missingSource": "Отсутствует источник",
+    "update": "Обновить",
+    "update ok": "обновлено",
+    "delete ok": "удалено",
+    "Default page": "Страница по умолчанию",
+    "confirmation": "Подтверждение",
+    "common": {
+      "back": "Назад"
+    },
+    "delete confirm": "Вы уверены, что хотите удалить <code>{name}</code>?",
+    "outdated revision save confirmation": {
+      "confirm": "Вы хотите перезаписать это?",
+      "update": {
+        "title": "Устаревшая редакция",
+        "description": "Редакция, которую вы редактируете, устарела.",
+        "details": "Проверьте вкладку Revisions для получения более подробной информации о последней версии."
       },
-      "flow": {
-        "enable_instructions": {
-          "footer": "Примечание: В настоящее время только Gemini поддерживается в качестве AI-провайдера для Open Source Edition. Для Enterprise Edition, пожалуйста, обратитесь к документации AI Copilot для настройки других провайдеров моделей.\n\nПерезапустите ваш Kestra instance после сохранения конфигурации.",
-          "header": "<b>AI Copilot еще не настроен.</b>\n\nЧтобы включить AI Copilot, добавьте следующий фрагмент в файл конфигурации вашего экземпляра Kestra (например, <code>application.yml</code>), заменив <code>geminiApiKey</code> на ваш фактический ключ:"
-        },
-        "generating": {
-          "app": "Генерация YAML для приложения...",
-          "dashboard": "Генерация Dashboard YAML для вас...",
-          "flow": "Генерация Flow YAML для вас...",
-          "test": "Генерация тестового YAML для вас..."
-        },
-        "prompt_placeholder": "Введите инструкции для создания вашего Kestra flow. Пример запроса: Создайте flow, который запускается каждый понедельник в 9 утра.",
-        "select_provider": "Выберите провайдера",
-        "title": "AI Агент"
+      "create": {
+        "title": "Flow уже существует",
+        "description": "В этом namespace уже существует flow с таким же id.",
+        "details": "Сохранить для переопределения и создания новой ревизии."
       }
     },
-    "all executions": "Все выполнения",
-    "all tags": "Все теги",
-    "api": "API",
-    "appBlocks": "Блоки приложения",
-    "apps": "Приложения",
-    "are you sure change state": "Вы уверены, что хотите изменить состояние?",
-    "assets": {
-      "title": "Активы"
+    "override": {
+      "title": "Вы собираетесь перезаписать текущий flow",
+      "details": "Предыдущий flow можно восстановить на вкладке Revisions."
     },
-    "attempt": "Попытка",
-    "attempts": "Попытка(и)",
-    "auditlogs": "Аудиторские логи",
-    "automatic refresh": "Автоматическое обновление",
-    "avg": "Среднее",
-    "avg duration": "Средняя длительность выполнения",
+    "is deprecated": "устарело",
+    "success": "Успех",
+    "save": "Сохранить",
+    "save_as_draft": "Сохранить как черновик",
+    "draft": "Черновик",
+    "draft_flow_warning": "Эта ревизия flow является черновиком. Выполнение будет запущено для этой черновой ревизии и может сразу завершиться ошибкой, если определение flow некорректно.",
+    "save task": "Сохранить задачу",
+    "saved": "Успешно сохранено",
+    "saved as draft": "Успешно сохранено как черновик",
+    "saved done": "<em>{name}</em> успешно сохранен",
+    "saved as draft done": "<em>{name}</em> успешно сохранён как черновик",
+    "multiple saved done": "{name} был сохранен",
+    "fileTypeNotAllowed": "Недопустимый тип файла. Допустимые типы: {types}",
+    "delete": "Удалить",
+    "deleted": "Успешно удалено",
+    "deleted confirm": "<em>{name}</em> успешно удален!",
+    "Add flow": "Добавить flow",
+    "add": "Добавить",
+    "add_new_item": "Добавить новый элемент",
+    "copy": "Копировать",
+    "copy_to_clipboard": "Копировать в буфер обмена",
+    "copy_and_close": "Копировать и закрыть",
+    "Per page": "на страницу",
+    "new": "Новый",
+    "edit": "Редактировать",
     "back": "Назад",
-    "back_to_dashboard": "Вернуться на панель управления",
-    "backfill": "Заполнение",
-    "backfill executions": "Выполнения заполнение",
-    "backfill paused": "Заполнение приостановлено",
-    "backfill running": "Запуск Backfill",
-    "bar": "Бар",
-    "before": "до",
-    "behavior": "Поведение",
-    "blueprints": {
-      "all": "Все",
-      "apps": "Черновики приложений",
-      "community": "Сообщество",
-      "create": "Создать blueprint",
-      "custom": "Пользовательские blueprints",
-      "dashboards": "Панель управления Blueprints",
-      "detail": {
-        "category": "Тип категории",
-        "links": "Ссылка и ресурсы",
-        "openInEditor": "Открыть в Edit Flow"
-      },
-      "edit": "Редактировать blueprint",
-      "empty": "Нет blueprints для отображения.",
-      "flows": "Черновики Flow",
-      "header": {
-        "alt": "Иконка Blueprints",
-        "catch phrase": {
-          "1": "Первый шаг всегда самый трудный.",
-          "2": "Исследуйте blueprints, чтобы начать ваш следующий {kind}."
-        }
-      },
-      "missingPlugins": {
-        "card": "Требуются plugin(s), не установленные в этом экземпляре: {plugins}",
-        "description": "Этот blueprint использует tasks из plugin(s), которые не установлены в этом экземпляре: {plugins}. Установите их, чтобы использовать этот blueprint.",
-        "install": "Установить plugins",
-        "title": "Отсутствующие plugins"
-      },
-      "title": "Blueprints"
+    "next": "Далее",
+    "done": "Готово",
+    "review your inputs": "Проверьте введённые данные",
+    "edit flow": "Редактировать flow",
+    "executions": "Выполнения",
+    "execution": "Выполнение",
+    "execution id": "Идентификатор выполнения",
+    "recent_executions": "Недавние выполнения",
+    "details": "Детали",
+    "overview": "Обзор",
+    "gantt": "Гантт",
+    "gantt_no_tasks_executed": "Это выполнение завершилось без запуска каких-либо task. Проверьте его обзор и логи, чтобы узнать причину.",
+    "gantt_no_tasks_match_filters": "Попробуйте изменить фильтры поиска, состояния или уровня Log.",
+    "gantt_no_tasks_match_filters_title": "Нет задач, соответствующих выбранным фильтрам.",
+    "logs": "Логи",
+    "no_logs_data": "Нет данных",
+    "no_logs_data_description": "Попробуйте изменить фильтры, изменить временной диапазон или проверьте, выполнялся ли flow недавно.",
+    "no_logs_data_title": "Для выбранных фильтров логи не найдены.",
+    "duration": "Длительность",
+    "total_duration": "Общая продолжительность",
+    "running duration": "Время выполнения",
+    "queued duration": "Время в очереди",
+    "choose file": "Выберите файл или перетащите его сюда...",
+    "launch execution": "Выполнить",
+    "warning flow with triggers": "Этот flow содержит triggers, и ручное выполнение завершится неудачей, если этот flow зависит от trigger выражений.",
+    "triggered": "Активирован trigger",
+    "triggered done": "Выполнение <em>{name}</em> успешно запущено",
+    "topology": "Топология",
+    "date": "Дата",
+    "prev_execution": "Предыдущее выполнение",
+    "next_execution": "Следующее выполнение",
+    "datepicker": {
+      "leave empty for infinite": "Оставьте пустым для бесконечной длительности или введите длительность в формате ISO 8601 (пример: 'P1DT1H1M1S)'",
+      "duration example": "Пример: 'P1DT1H1M1S'",
+      "error": "Неверный формат длительности, должен быть в формате ISO 8601 (например, P1DT1H1M1S)",
+      "custom": "Пользовательский",
+      "last5minutes": "Последние 5 минут",
+      "last15minutes": "Последние 15 минут",
+      "last1hour": "Последний час",
+      "last12hours": "Последние 12 часов",
+      "last24hours": "Последние 24 часа",
+      "last48hours": "Последние 48 часов",
+      "last7days": "Последние 7 дней",
+      "last30days": "Последние 30 дней",
+      "last365days": "Последние 365 дней",
+      "next5minutes": "Следующие 5 мин",
+      "next15minutes": "Следующие 15 минут",
+      "next1hour": "Следующий 1 час",
+      "next12hours": "Следующие 12 часов",
+      "next24hours": "Следующие 24 часа",
+      "next48hours": "Следующие 48 часов",
+      "next7days": "Следующие 7 дней",
+      "next30days": "Следующие 30 дней",
+      "next365days": "Следующие 365 дней",
+      "5minutes": "5 минут",
+      "15minutes": "15 минут",
+      "1hour": "1 час",
+      "12hours": "12 часов",
+      "24hours": "24 часа",
+      "48hours": "48 часов",
+      "7days": "7 дней",
+      "30days": "30 дней",
+      "365days": "365 дней",
+      "never": "Никогда",
+      "today": "Сегодня",
+      "yesterday": "Вчера",
+      "dayBeforeYesterday": "Позавчера",
+      "thisWeek": "Эта неделя",
+      "thisWeekSoFar": "На этой неделе",
+      "previousWeek": "Прошлая неделя",
+      "thisMonth": "Этот месяц",
+      "thisMonthSoFar": "В этом месяце",
+      "previousMonth": "Прошлый месяц",
+      "thisYear": "Этот год",
+      "thisYearSoFar": "В этом году",
+      "previousYear": "Прошлый год",
+      "short": {
+        "15m": "15м",
+        "1h": "1ч",
+        "12h": "12ч",
+        "1d": "1д",
+        "7d": "7д"
+      }
     },
-    "body_line_clamp": "Limit line height",
-    "bookmark": "Закладки",
-    "breakpoints": "Точки останова",
-    "bulk action async warning": "Это может занять несколько минут.",
-    "bulk actions": "Массовые действия",
-    "bulk change state": "Вы уверены, что хотите изменить состояние выполнения <code>{executionCount}</code>?",
-    "bulk delete": "Вы уверены, что хотите удалить <code>{executionCount}</code> выполнение(я)?",
-    "bulk delete backfills": "Удалить {count} заполнение",
-    "bulk delete triggers": "Вы уверены, что хотите удалить {count} triggers?",
-    "bulk disabled status": {
-      "false": "Включить {count} triggers",
-      "true": "Отключить {count} triggers"
+    "created date": "Дата создания",
+    "latest_update": "Последнее обновление",
+    "updated date": "Дата обновления",
+    "expiration date": "Дата истечения",
+    "started date": "Дата начала",
+    "healthcheck date": "HealthCheck Дата",
+    "next execution date": "Дата следующего выполнения",
+    "last execution status": "Последний статус выполнения",
+    "jump to...": "Перейти к...",
+    "contextBar": {
+      "news": "Новости",
+      "docs": "Документация",
+      "help": "Помощь",
+      "issue": "Проблема",
+      "demo": "Демо",
+      "star": "Добавьте нас в избранное"
     },
-    "bulk force run": "Вы уверены, что хотите принудительно запустить выполнение <code>{executionCount}</code>?<br/><br/>WARNING: принудительный запуск выполнения не гарантирован и может создать дублирующие выполнения задач.<br/><br/>Будут выполнены следующие переходы:<br/><ul><li>CREATED задачи будут переведены в состояние RUNNING.</li><li>RUNNING задачи будут повторно отправлены.</li><li>QUEUED задачи будут извлечены из очереди.</li><li>PAUSED задачи будут возобновлены.</li></ul>",
-    "bulk kill": "Вы уверены, что хотите убить <code>{executionCount}</code> выполнение(я)?",
-    "bulk pause": "Вы уверены, что хотите приостановить выполнение <code>{executionCount}</code>?",
-    "bulk pause backfills": "Приостановить {count} заполнение",
-    "bulk replay": "Вы уверены, что хотите воспроизвести <code>{executionCount}</code> выполнение(я)?",
-    "bulk restart": "Вы уверены, что хотите перезапустить <code>{executionCount}</code> выполнение(я)?",
-    "bulk resume": "Вы уверены, что хотите возобновить <code>{executionCount}</code> выполнение(я)?",
-    "bulk set labels": "Вы уверены, что хотите установить метки для <code>{executionCount}</code> выполнения(й)?",
-    "bulk success delete backfills": "{count} backfills заполнения",
-    "bulk success delete triggers": "{count} триггеры были успешно удалены",
-    "bulk success disabled status": {
-      "false": "{count} trigger(s) включены",
-      "true": "{count} trigger(s) отключены"
+    "source": "Источник",
+    "source only": "Источник только",
+    "home": "Домой",
+    "create": "Создать",
+    "create_flow": "Создать Flow",
+    "add flow": "Добавить flow",
+    "from": "От",
+    "to": "До",
+    "search filters": {
+      "saved": "Сохраненные фильтры",
+      "manage": "Управление поисковыми фильтрами",
+      "manage desc": "Управление сохраненными поисковыми фильтрами",
+      "save filter": "Сохранить фильтр",
+      "filter name": "Имя фильтра",
+      "filters": "Фильтры"
     },
-    "bulk success pause backfills": "{count} заполнения приостановлены",
-    "bulk success unlock": "{count} triggers разблокированы",
-    "bulk success unpause backfills": "{count} заполнения возобновлены",
-    "bulk unlock": "Разблокировать {count} triggers",
-    "bulk unpause backfills": "Возобновить {count} заполнение",
-    "bulk unqueue": "Вы уверены, что хотите удалить из очереди выполнение(я) <code>{executionCount}</code>?",
-    "can not delete": "Невозможно удалить",
-    "can not have less than 1 task": "Не может быть менее одного задания",
-    "can not save": "Невозможно сохранить",
-    "cancel": "Отмена",
+    "steps": "Шаги",
+    "state": "Состояние",
+    "state_history": "История состояния",
+    "search term in message": "Поиск по термину в сообщении",
+    "search": "Поиск",
+    "search blueprint": "Поиск чертежей",
+    "all tags": "Все теги",
+    "source search": "Поиск по источнику",
+    "filter by log level": "Фильтр по уровню log",
+    "selected": "Выбрано",
+    "task": "Задача",
+    "task logs": "Журналы задач",
+    "display flow {id} executions": "Показать выполнения flow {id}",
+    "actions": "Действия",
+    "select datetime": "Выберите дату",
+    "select view": "Выберите вид",
+    "invalid field": "Неверное поле: {name}",
+    "required field": "Обязательное поле",
+    "is required": "{field} обязателен для заполнения",
+    "error": "Ошибка",
+    "form": "Форма",
+    "form error": "Ошибка формы",
+    "display topology for flow": "Показать топологию для flow",
     "cannot create topology": "Не удалось создать топологию для flow",
-    "cannot swap tasks": "Невозможно поменять местами tasks",
-    "change execution state confirm": "Вы уверены, что хотите изменить состояние выполнения <code>{id}</code>?",
-    "change execution state done": "Состояние выполнения обновлено",
-    "change queue confirm": "Вы уверены, что хотите изменить состояние очереди для выполнения <code>{id}</code>?<br/>",
+    "start date": "Дата начала",
+    "end date": "Дата окончания",
+    "creation": "Создание",
+    "flow creation": "Создание flow",
+    "start datetime": "Дата и время начала",
+    "end datetime": "Дата и время окончания",
+    "restart": "Перезапуск",
+    "restart latest revision": "Перезапустить последнюю редакцию",
+    "restart tooltip": "Перезапустить выполнение с <code>{state}</code> task",
+    "restarted": "Выполнение перезапущено",
+    "restart confirm": "Вы уверены, что хотите перезапустить выполнение <code>{id}</code>?",
+    "restart change revision": "Вы можете изменить редакцию, которая будет использоваться для нового выполнения.",
+    "replay": "Повтор",
+    "replay from task tooltip": "Создать аналогичное выполнение, начиная с задачи <code>{taskId}</code>",
+    "replay from beginning tooltip": "Создать аналогичное выполнение, начиная с начала",
+    "replay latest revision": "Повтор с использованием последней редакции",
+    "replayed": "Выполнение воспроизведено",
+    "replay confirm": "Вы уверены, что хотите повторить это выполнение <code>{id}</code> и создать новое?",
+    "replay with inputs": "Воспроизвести с inputами",
+    "reuse_original_inputs": "Повторно использовать оригинальные inputы",
+    "modify_inputs": "Изменить inputs",
+    "replay the execution": "Повторить выполнение <code>{executionId}</code> для flow <code>{flowId}</code>",
+    "prefill inputs": "Предзаполнение",
+    "current": "текущий",
     "change state": "Изменить состояние",
-    "change state confirm": "Вы уверены, что хотите изменить состояние выполнения задачи <code>{task}</code> в исполнении <code>{id}</code>?",
-    "change state current state": "Текущий статус:",
+    "actual state": "Фактическое состояние",
+    "select a state": "Выберите состояние",
+    "are you sure change state": "Вы уверены, что хотите изменить состояние?",
+    "yes": "Да",
     "change state done": "Состояние task было обновлено",
+    "change state confirm": "Вы уверены, что хотите изменить состояние выполнения задачи <code>{task}</code> в исполнении <code>{id}</code>?",
+    "change queue confirm": "Вы уверены, что хотите изменить состояние очереди для выполнения <code>{id}</code>?<br/>",
+    "change state current state": "Текущий статус:",
     "change state hint": {
+      "WARNING": [
+        "Flow будет помечен как WARNING.",
+        "Следующие tasks будут выполнены.",
+        "Ошибка tasks будет выполнена."
+      ],
       "FAILED": [
         "Flow будет помечен как FAILED.",
         "Никакие другие task не будут выполнены.",
         "Ошибочные tasks будут выполнены."
-      ],
-      "RUNNING": [
-        "Flow будет перезапущен и выполнит все следующие tasks.",
-        "Все заблокированные tasks будут выполнены."
       ],
       "SUCCESS": [
         "Flow будет перезапущен, так как этот task был успешным.",
         "Все заблокированные tasks будут выполнены.",
         "Flow будет в состоянии SUCCESS, если все запуски tasks будут успешными."
       ],
-      "WARNING": [
-        "Flow будет помечен как WARNING.",
-        "Следующие tasks будут выполнены.",
-        "Ошибка tasks будет выполнена."
+      "RUNNING": [
+        "Flow будет перезапущен и выполнит все следующие tasks.",
+        "Все заблокированные tasks будут выполнены."
       ]
     },
+    "replay execution title": "Повторное выполнение",
+    "restart execution title": "Перезапустить выполнение",
+    "replay execution description": "Это создаст новое выполнение на основе выбранного выполнения.",
+    "replay using": "Повторное воспроизведение с использованием",
+    "flow revision original": "Оригинальная ревизия flow",
+    "flow revision latest": "Последняя версия flow",
+    "flow revision specific": "Конкретная ревизия flow",
+    "replay inputs": "Входные данные",
+    "reuse original inputs": "Повторное использование оригинальных input",
+    "modify inputs": "Изменить inputs",
+    "replay inputs new required": "Эта редакция имеет inputs. Вам будет предложено их заполнить.",
+    "replay select taskrun": "Выберите выполнение task для повторного воспроизведения из:",
     "change state tooltip": "Изменить состояние выполнения",
-    "chart": "График",
-    "chart preview": "Предварительный просмотр диаграммы",
-    "chart type": "Тип диаграммы",
-    "charts": "Графики",
-    "choice": "Выбор",
-    "choose file": "Выберите файл или перетащите его сюда...",
-    "close": "Закрыть",
-    "close sidebar": "закрыть боковую панель",
-    "codeDisabled": "Отключено в flow",
-    "collapse": "Свернуть",
-    "collapse all": "Свернуть все",
-    "commit_id": "Идентификатор коммита",
-    "common": {
-      "back": "Назад"
-    },
-    "concurrency": "Конкурентность",
-    "concurrency limits": "Ограничения на параллелизм",
-    "concurrency_limit": {
-      "dialog_title": "Ограничения на параллельность",
-      "warning": "Изменение счетчика выполнения может нарушить параллелизм, поэтому выполнения могут превысить допустимый лимит."
-    },
-    "conditions": "Условия",
-    "configure basic auth": "Настроить базовую аутентификацию",
-    "confirm": "Подтвердить",
-    "confirm password": "Подтвердить пароль",
-    "confirmation": "Подтверждение",
-    "context updated date": "Дата обновления контекста",
-    "context updated date tooltip": "Когда контекст trigger был обновлен в последний раз. Это происходит, когда выполняется execution, завершается (блокировка снята) или после оценки (даже если execution не происходит).",
-    "contextBar": {
-      "demo": "Демо",
-      "docs": "Документация",
-      "help": "Помощь",
-      "issue": "Проблема",
-      "news": "Новости",
-      "star": "Добавьте нас в избранное"
-    },
-    "continue backfill": "Продолжить заполнение",
-    "continue backfills": "Продолжить заполнения",
-    "copied": "Скопировано",
-    "copied_logs_to_clipboard": "Скопированные logs в буфер обмена.",
-    "copy": "Копировать",
-    "copy all logs": "Скопировать все Logs",
-    "copy logs": "Копировать логи",
-    "copy url": "Скопировать URL",
-    "copy_and_close": "Копировать и закрыть",
-    "copy_to_clipboard": "Копировать в буфер обмена",
-    "copy_value": "Copy value",
-    "create": "Создать",
-    "create first task": "Создайте свою первую задачу",
-    "create_flow": "Создать Flow",
-    "created date": "Дата создания",
-    "creation": "Создание",
-    "cron": "Крон",
-    "curl": {
-      "command": "Команда cURL",
-      "note": "Обратите внимание, что для типов ввода SECRET и FILE команда должна быть адаптирована, чтобы соответствовать реальным значениям."
-    },
-    "current": "текущий",
-    "current execution": "Текущее выполнение",
-    "custom value": "Пользовательское значение",
-    "customize sidebar": "Настроить боковую панель",
-    "dark_version": "Темная версия",
-    "dashboards": {
-      "chart_preview": "Нажмите на исходный код диаграммы, чтобы увидеть его предварительный просмотр",
-      "creation": {
-        "confirmation": "Панель <code>{title}</code> создана.",
-        "label": "Создать Dashboard"
-      },
-      "default": "Панель по умолчанию",
-      "deletion": {
-        "confirmation": "Вы уверены, что хотите удалить панель <code>{title}</code>?"
-      },
-      "edition": {
-        "chart": "Редактировать этот график",
-        "confirmation": "Изменения в панели <code>{title}</code> сохранены.",
-        "id readonly": "Свойство `id` не может быть изменено — оно установлено на начальные значения. Если вы хотите его изменить, вы можете создать новую панель и удалить старую.",
-        "label": "Редактировать Dashboard"
-      },
-      "empty": "Нет результатов для отображения.",
-      "export": "Экспорт в CSV",
-      "labels": {
-        "plural": "Панели управления",
-        "singular": "Панель управления"
-      },
-      "no_description": "Нет описания",
-      "no_description_hint": "Добавьте описание к этому flow, чтобы задокументировать его назначение.<br>Поддерживается Markdown.",
-      "others": "Другие",
-      "preview": "Предварительный просмотр Dashboard",
-      "quick_filters": {
-        "all": "Все",
-        "failed": "Ошибка",
-        "paused": "Приостановлено",
-        "running": "Выполняется",
-        "success": "Успешно",
-        "warning": "Предупреждение"
-      },
-      "switch": "Переключить Панель управления",
-      "viewAll": "Показать все"
-    },
-    "data": "Данные",
-    "dataFilters": "Фильтры данных",
-    "data_not_protected": "Ваши данные не защищены. Не потеряйте их. <b>Включите наши бесплатные функции безопасности или попробуйте платную версию.</b>",
-    "date": "Дата",
-    "date count": "{count} на {date}",
-    "date format": "Формат даты",
-    "date range count": "{count} между {startDate} и {endDate}",
-    "datepicker": {
-      "12hours": "12 часов",
-      "15minutes": "15 минут",
-      "1hour": "1 час",
-      "24hours": "24 часа",
-      "30days": "30 дней",
-      "365days": "365 дней",
-      "48hours": "48 часов",
-      "5minutes": "5 минут",
-      "7days": "7 дней",
-      "custom": "Пользовательский",
-      "dayBeforeYesterday": "Позавчера",
-      "duration example": "Пример: 'P1DT1H1M1S'",
-      "error": "Неверный формат длительности, должен быть в формате ISO 8601 (например, P1DT1H1M1S)",
-      "last12hours": "Последние 12 часов",
-      "last15minutes": "Последние 15 минут",
-      "last1hour": "Последний час",
-      "last24hours": "Последние 24 часа",
-      "last30days": "Последние 30 дней",
-      "last365days": "Последние 365 дней",
-      "last48hours": "Последние 48 часов",
-      "last5minutes": "Последние 5 минут",
-      "last7days": "Последние 7 дней",
-      "leave empty for infinite": "Оставьте пустым для бесконечной длительности или введите длительность в формате ISO 8601 (пример: 'P1DT1H1M1S)'",
-      "never": "Никогда",
-      "next12hours": "Следующие 12 часов",
-      "next15minutes": "Следующие 15 минут",
-      "next1hour": "Следующий 1 час",
-      "next24hours": "Следующие 24 часа",
-      "next30days": "Следующие 30 дней",
-      "next365days": "Следующие 365 дней",
-      "next48hours": "Следующие 48 часов",
-      "next5minutes": "Следующие 5 мин",
-      "next7days": "Следующие 7 дней",
-      "previousMonth": "Прошлый месяц",
-      "previousWeek": "Прошлая неделя",
-      "previousYear": "Прошлый год",
-      "short": {
-        "12h": "12ч",
-        "15m": "15м",
-        "1d": "1д",
-        "1h": "1ч",
-        "7d": "7д"
-      },
-      "thisMonth": "Этот месяц",
-      "thisMonthSoFar": "В этом месяце",
-      "thisWeek": "Эта неделя",
-      "thisWeekSoFar": "На этой неделе",
-      "thisYear": "Этот год",
-      "thisYearSoFar": "В этом году",
-      "today": "Сегодня",
-      "yesterday": "Вчера"
-    },
-    "debug": "Отладка",
-    "default": "По умолчанию",
-    "defaultsToNamespaceFile": "По умолчанию для файла namespace: <code>{name}</code>",
-    "delete": "Удалить",
-    "delete backfill": "Удалить backfill",
-    "delete backfills": "Удалить заполнения",
-    "delete confirm": "Вы уверены, что хотите удалить <code>{name}</code>?",
-    "delete execution running": "<div class=\"alert alert-warning mt-2 mb-0\">Это выполнение все еще выполняется, удаление его не остановит.<br />Вам нужно убить выполнение, чтобы остановить его.</div>",
-    "delete logs": "Удалить логи",
-    "delete ok": "удалено",
-    "delete revision confirm": "Вы уверены, что хотите удалить ревизию {revision}?",
-    "delete revision error": "Ошибка при удалении ревизии {revision} с ошибкой {error}",
-    "delete task confirm": "Вы хотите удалить task <code>{taskId}</code>?",
-    "delete trigger": "Удалить trigger",
-    "delete trigger confirmation": "Вы уверены, что хотите удалить trigger {id}? WARNING: удаление trigger может привести к дублированию выполнений, если trigger все еще активен в flow.",
-    "delete trigger error": "Ошибка при удалении trigger {id}",
-    "delete trigger success": "Триггер {id} был успешно удален",
-    "delete triggers": "Удалить triggers",
-    "delete_all_logs": "Вы уверены, что хотите удалить все логи?",
-    "delete_log": "Вы уверены, что хотите удалить log?",
-    "deleted": "Успешно удалено",
-    "deleted confirm": "<em>{name}</em> успешно удален!",
-    "deleted_label": "Удалено",
-    "demos": {
-      "IAM": {
-        "message": "Kestra Enterprise Edition имеет встроенные возможности IAM с поддержкой единого входа (SSO), синхронизацией каталога SCIM и управлением доступом на основе ролей (RBAC), интегрируясь с несколькими поставщиками идентификации и позволяя назначать детализированные разрешения для пользователей и учетных записей сервисов.",
-        "title": "Управление пользователями через IAM с SSO, SCIM и RBAC"
-      },
-      "apps": {
-        "message": "Приложения в Kestra Enterprise Edition позволяют создавать пользовательские интерфейсы, которые взаимодействуют с Kestra workflows вне платформы. Эта функция позволяет использовать ваши workflows в качестве backend для пользовательских приложений, что дает возможность нетехническим пользователям отправлять данные через формы или возобновлять PAUSED workflows, ожидающие одобрения.",
-        "title": "Создавайте пользовательские приложения с Kestra"
-      },
-      "assets": {
-        "header": "Метаданные и наблюдаемость активов",
-        "label": "Активы",
-        "message": "Активы связывают метаданные наблюдаемости, происхождения и владения, чтобы команды платформы могли быстрее устранять неполадки и развертывать с уверенностью.",
-        "title": "Приведите каждый набор данных, сервис и зависимость в поле зрения."
-      },
-      "audit-logs": {
-        "message": "Kestra Enterprise Edition записывает каждую активность с надежными, неизменяемыми записями, что упрощает отслеживание изменений, поддержание соответствия и устранение неполадок.",
-        "title": "Отслеживание изменений с помощью Audit Logs"
-      },
-      "blueprints": {
-        "message": "В Kestra Enterprise Edition вы можете создавать пользовательские Blueprints, доступные только вашей организации. Вы можете использовать их в качестве шаблонов лучших практик для обмена, централизации и документирования часто используемых рабочих процессов в вашей команде.",
-        "title": "Добавить пользовательские Blueprints"
-      },
-      "contact_sales": "Связаться с отделом продаж",
-      "enterprise_edition": "Enterprise Edition (Корпоративная версия)",
-      "get_a_demo_button": "Получить демо-версию",
-      "instance": {
-        "message": "Kestra Enterprise Edition предоставляет операционную панель, которая помогает вам наблюдать за состоянием вашей платформы и отслеживать метрики времени безотказной работы всех сервисов, таких как, например, Workers, Schedulers и Executors. С той же страницы вы также можете создавать объявления, чтобы уведомлять пользователей о планируемом времени простоя, и вы можете войти в режим обслуживания, который временно переводит все сервисы и выполнения workflow в состояние PAUSED для выполнения обновления.",
-        "title": "Управление инфраструктурой в вашем экземпляре"
-      },
-      "namespace": {
-        "assets": {
-          "message": "В Kestra Enterprise Edition, Assets ведет актуальный учет ресурсов, с которыми взаимодействуют ваши workflows. Эти ресурсы могут быть таблицами баз данных, виртуальными машинами, файлами или любой внешней системой, с которой вы работаете.",
-          "title": "Централизованное управление активами"
-        },
-        "audit-logs": {
-          "message": "В Kestra Enterprise Edition вы можете просматривать audit logs на уровне namespace с подробными различиями, что дает вам четкую историю того, кто, что и когда изменил во всех ресурсах.",
-          "title": "Отслеживайте все изменения в одном месте"
-        },
-        "edit": {
-          "message": "В Kestra Enterprise Edition, namespaces обеспечивают продвинутую изоляцию и управление секретами, переменными и настройками плагинов в масштабе. Администраторы могут настраивать пользовательские менеджеры секретов, изолированные хранилища, выделенные группы worker и детализированные разрешения на уровне каждого namespace. Это гарантирует, что секреты, переменные и конфигурации плагинов остаются безопасными и легкими в обслуживании для разных команд и проектов.",
-          "title": "Обновите управление вашим Namespace"
-        },
-        "history": {
-          "message": "В Kestra Enterprise Edition вы можете управлять историей ревизий ваших Namespaces.",
-          "title": "Управляйте Историей Ревизий в Одном Месте"
-        },
-        "plugin-defaults": {
-          "message": "В Kestra Enterprise Edition вы можете установить специфичные для namespace значения по умолчанию для плагинов, что уменьшает необходимость дублирования настроек в каждом flow. Это централизованное управление плагинами обеспечивает согласованность конфигураций, позволяет безопасно ссылаться на секреты или переменные и упрощает обслуживание ваших workflows.",
-          "title": "Стандартизация конфигурации с помощью значений по умолчанию плагина"
-        },
-        "secrets": {
-          "message": "В Kestra Enterprise Edition вы можете хранить и контролировать секреты на уровне namespace, минимизируя риски и обеспечивая изоляцию учетных данных каждой команды. Благодаря вложенной иерархии, вы также можете настроить учетные данные в родительском namespace, и они будут унаследованы всеми дочерними namespaces. Поддержка специализированных менеджеров секретов и детализированных настроек разрешений на уровне namespace дополнительно укрепляет безопасность и соответствие требованиям.",
-          "title": "Управление секретами безопасным способом"
-        },
-        "variables": {
-          "message": "В Kestra Enterprise Edition вы можете определять и управлять переменными на уровне namespace, чтобы устранить повторяющиеся конфигурации в различных flows. Эти переменные обеспечивают согласованность, упрощают обновление конфигураций и могут быть легко использованы в любом task или trigger для более чистых и удобных в обслуживании рабочих процессов.",
-          "title": "Централизованно управляйте вашими переменными"
-        }
-      },
-      "quotas": {
-        "message": "Kestra Enterprise Edition позволяет определять квоты для потоков, ограничивая количество одновременных или суммарных выполнений в заданном временном окне. Квоты помогают защитить общую инфраструктуру, обеспечить соблюдение SLA и предотвратить избыточное потребление ресурсов неконтролируемыми рабочими процессами.",
-        "title": "Применение квот выполнения к потокам"
-      },
-      "secrets": {
-        "add_env": {
-          "first": "Закодируйте <a href=\"https://kestra.io/docs/how-to-guides/secrets?utm_source=app&utm_medium=referral&utm_campaign=secrets-inlinedoc#using-secrets-in-kestra\" target=\"_blank\">секретное значение в Base64</a>",
-          "intro": "Чтобы создать новый Secret:",
-          "second": "Добавьте переменную окружения с именем '<strong>SECRET_{'{MY_SECRET_KEY}'}</strong>' с указанным выше значением",
-          "third": "Перезапустите ваш экземпляр Kestra"
-        },
-        "detected_env": "Вот переменные окружения типа secret, определенные при запуске экземпляра:",
-        "empty_env": "У вас еще нет Secrets в вашей среде.",
-        "message": "Enterprise Edition (EE) позволяет добавлять, редактировать или удалять секреты непосредственно в UI — без необходимости перезапуска экземпляра. Организуйте секреты по namespace с детализированными RBAC-разрешениями и наследуйте их от родительских к дочерним namespace. EE интегрируется с менеджерами секретов, такими как HashiCorp Vault, AWS Secrets Manager, Azure Key Vault, Google Secret Manager и Elasticsearch. Настройте выделенные бэкенды для каждого namespace, арендатора или экземпляра, чтобы изолировать секреты между командами, или включите только для чтения секреты, хранящиеся во внешних хранилищах. Секреты остаются зашифрованными в состоянии покоя и при передаче. Опциональное кэширование уменьшает количество API-запросов, а аудиторские следы фиксируют весь доступ.",
-        "title": "Обновите управление Secrets"
-      },
-      "tenants": {
-        "message": "Kestra Enterprise Edition поддерживает мультиаренду, предоставляя полностью изолированные среды для различных команд или проектов, каждая из которых имеет собственные ресурсы, такие как выделенные группы worker или секреты и внутренние хранилища.",
-        "title": "Управление Workflows в изолированных tenants"
-      },
-      "tests": {
-        "header": "Юнит-тесты для Flows",
-        "label": "Тесты",
-        "message": "Проверьте логику ваших flow в изоляции, обнаруживайте регрессии на ранних стадиях и поддерживайте уверенность в ваших автоматизациях по мере их изменения и роста.",
-        "title": "Обеспечьте надежность с каждым изменением"
-      },
-      "watch_the_video": "Смотреть видео"
-    },
-    "density": "Density",
-    "density_compact": "Compact",
-    "density_expanded": "Expanded",
-    "density_normal": "Normal",
-    "dependencies": "Зависимости",
-    "dependencies delete flow": "Этот flow имеет зависимости. Удаление его предотвратит выполнение их зависимостей.<br /><br /> Вот список затронутых flows:",
-    "dependencies loaded": "Зависимости загружены",
-    "dependencies missing acls": "Нет разрешений на этот flow",
-    "dependency": {
-      "controls": {
-        "clear_selection": "Очистить выбор",
-        "fit_view": "По размеру экрана",
-        "zoom_in": "Увеличить",
-        "zoom_out": "Уменьшить масштаб"
-      },
-      "search": {
-        "flow": {
-          "display": "Включить зависимости flow"
-        },
-        "namespace": {
-          "no_namespace": "Без namespace",
-          "select": "Выберите namespace"
-        },
-        "no_results": "Результаты для {term} не найдены",
-        "placeholders": {
-          "asset": "Поиск по asset, flow или namespace...",
-          "default": "Поиск по flow или namespace..."
-        }
-      }
-    },
-    "dependency task": "Задача {taskId} является зависимостью другого задачи",
-    "description": "Описание",
-    "details": "Детали",
-    "disable": "Отключить",
-    "disabled": "Отключено",
-    "disabled flow desc": "Этот flow отключен, пожалуйста, включите его для выполнения.",
-    "disabled flow title": "Этот flow отключен",
-    "discard changes confirmation": "У вас есть несохраненные изменения. Вы уверены, что хотите их отменить?",
-    "discard execution confirmation": "У вас есть несохраненные input. Вы уверены, что хотите отменить эту execution?",
-    "display direct sub tasks count": "Показать количество прямых подзадач",
-    "display flow {id} executions": "Показать выполнения flow {id}",
-    "display metric for specific task": "Показать метрику для конкретной задачи",
-    "display output for specific task": "Показать вывод для конкретной задачи",
-    "display topology for flow": "Показать топологию для flow",
-    "display_settings": "Display settings",
-    "docs": "Документы",
-    "documentation": {
-      "documentation": "Документация",
-      "github": "Открыть проблему на GitHub"
-    },
-    "documentationMenu": "Меню документации",
-    "done": "Готово",
-    "down trend": "Уменьшается",
-    "download": "Скачать",
-    "download logs": "Скачать логи",
-    "download_logos": "Скачать пакет логотипов",
-    "download_logs_description": "Choose which logs to export. Filters default to your current view.",
-    "draft": "Черновик",
-    "draft_available": "Черновик изменений доступен в редакторе",
-    "draft_flow_warning": "Эта ревизия flow является черновиком. Выполнение будет запущено для этой черновой ревизии и может сразу завершиться ошибкой, если определение flow некорректно.",
-    "drill down preview": "Предпросмотр",
-    "drop items here": "Перетащите элементы сюда",
-    "duplicate-pair": "{label} \"{key}\" дублируется, первый ключ игнорируется.",
-    "duration": "Длительность",
-    "dynamic": "Динамический",
-    "each value": "Значение итерации",
-    "edit": "Редактировать",
-    "edit flow": "Редактировать flow",
-    "editor": "Редактор",
-    "editor_shortcuts": {
-      "command_palette": "Показать палитру команд",
-      "comment": "Комментарий",
-      "comment_uncomment": "Комментарий/Раскомментировать",
-      "decrease_fontsize": "Уменьшить размер шрифта редактора",
-      "duplicate_cursor": "Дублировать курсор",
-      "execute_flow": "Запустить flow",
-      "fold_unfold": "Свернуть/Развернуть код",
-      "increase_fontsize": "Увеличить размер шрифта редактора",
-      "label": "Горячие клавиши",
-      "move_line": "Переместить строку",
-      "reset_fontsize": "Сбросить размер шрифта редактора",
-      "save_flow": "Сохранить flow",
-      "toggle_ai_agent": "Переключить AI agent",
-      "trigger_autocompletion": "Запустить автозаполнение",
-      "uncomment": "Раскомментировать"
-    },
-    "ee-tooltip": {
-      "button": "Свяжитесь с нами",
-      "features-blocked": "Эта функция требует Enterprise Edition."
-    },
-    "email": "Email",
-    "email length constraint": "Email не должен превышать 256 символов",
-    "empty": {
-      "announcements": {
-        "content": "Объявления позволяют уведомлять ваших пользователей о любых изменениях или информировать их о запланированном времени простоя для обслуживания. Просто выберите тип объявления, диапазон дат, в течение которого оно должно отображаться, и напишите сообщение объявления.",
-        "title": "У вас пока нет объявлений!"
-      },
-      "apiTokens": {
-        "content": "Токены API используются всякий раз, когда вы хотите предоставить программный доступ к API Kestra.",
-        "title": "Управление вашими API Tokens"
-      },
-      "apps": {
-        "content": "Начните создавать приложения для взаимодействия с Kestra из внешнего мира.",
-        "title": "У вас пока нет приложений!"
-      },
-      "assets": {
-        "content": "Добавьте assets, чтобы отслеживать и управлять вашими данными, сервисами и инфраструктурой.",
-        "title": "У вас еще нет Assets!"
-      },
-      "concurrency_executions": {
-        "content": "Узнайте больше о <strong><a href=\"https://kestra.io/docs/workflow-components/execution?utm_source=app&utm_medium=referral&utm_campaign=concurrency-inlinedoc\" target=\"_blank\">Executions</a></strong> в нашей документации.",
-        "title": "Нет текущих выполнений для этого flow."
-      },
-      "concurrency_limit": {
-        "content": "Узнайте больше о <strong><a href=\"https://kestra.io/docs/workflow-components/concurrency?utm_source=app&utm_medium=referral&utm_campaign=concurrency-inlinedoc\" target=\"_blank\">ограничениях на Concurrency</a></strong> в нашей документации.",
-        "title": "Для этого flow не установлены ограничения."
-      },
-      "concurrency_limits": {
-        "content": "Узнайте больше о <strong><a href=\"https://kestra.io/docs/workflow-components/concurrency?utm_source=app&utm_medium=referral&utm_campaign=concurrency-inlinedoc\" target=\"_blank\">ограничениях на Concurrency</a></strong> в нашей документации.",
-        "title": "Пределы на параллельность не установлены."
-      },
-      "dependencies": {
-        "ASSET": {
-          "content": "Этот ресурс не имеет зависимостей вверх или вниз по потоку с flow или другими ресурсами.",
-          "title": "В настоящее время зависимости отсутствуют."
-        },
-        "EXECUTION": {
-          "content": "Узнайте больше о <a href=\"https://kestra.io/docs/ui/executions?utm_source=app&utm_medium=referral&utm_campaign=dependencies-inlinedoc#dependencies\" target=\"_blank\">зависимостях выполнения</a> в нашей документации.",
-          "title": "В настоящее время зависимости отсутствуют."
-        },
-        "FLOW": {
-          "content": "Узнайте больше о <a href=\"https://kestra.io/docs/ui/flows?utm_source=app&utm_medium=referral&utm_campaign=dependencies-inlinedoc#dependencies\" target=\"_blank\">Flow Dependencies</a> в нашей документации.",
-          "title": "В настоящее время зависимости отсутствуют."
-        },
-        "NAMESPACE": {
-          "content": "Узнайте больше о <a href=\"https://kestra.io/docs/ui/namespaces?utm_source=app&utm_medium=referral&utm_campaign=dependencies-inlinedoc#dependencies\" target=\"_blank\">Namespace Dependencies</a> в нашей документации.",
-          "title": "В настоящее время зависимости отсутствуют."
-        }
-      },
-      "groups": {
-        "content": "Группы позволяют объединять пользователей, чтобы вы могли управлять разрешениями и привязками ролей коллективно в рамках вашего арендатора.",
-        "title": "У вас еще нет групп!"
-      },
-      "kill_switches": {
-        "content": "Функция Kill Switch предоставляет механизм на основе UI для остановки проблемных выполнений. Она заменяет команды CLI <code>--skip-executions</code> и <code>--skip-flows</code> на комплексный административный интерфейс.",
-        "title": "У вас еще нет Kill Switches!"
-      },
-      "mcpToolFlows": {
-        "content": "Представьте flow как инструмент MCP, добавив в него <code>McpToolTrigger</code>. Подробнее о <strong><a href=\"https://kestra.io/docs/workflow-components/triggers/mcp-tool-trigger?utm_source=app&utm_medium=referral&utm_campaign=mcp-tool-trigger-inlinedoc\" target=\"_blank\">MCP Tool Trigger</a></strong> читайте в нашей документации.",
-        "title": "На этом сервере еще не зарегистрированы tool flows."
-      },
-      "namespaceFiles": {
-        "content": "Файлы namespace работают как папка проекта для этого namespace. Храните код Python, SQL, dbt или Terraform, а затем ссылайтесь на любой файл в своих flows с помощью",
-        "title": "В этом namespace пока нет файлов"
-      },
-      "panels": {
-        "content": "Вы закрыли все панели.  \nВыберите вкладку выше, чтобы продолжить.",
-        "title": "Нет открытой панели"
-      },
-      "pluginDefaults": {
-        "content": "Параметры плагина по умолчанию позволяют централизованно управлять конфигурацией вашего плагина и делиться ею со всеми flow в вашем namespace.",
-        "title": "У вас еще нет стандартных настроек плагина!"
-      },
-      "plugins": {
-        "content": "Узнайте больше о <strong><a href=\"https://kestra.io/docs/workflow-components/plugin-defaults?utm_source=app&utm_medium=referral&utm_campaign=plugin-default-inlinedoc\" target=\"_blank\">Concurrency Limits</a></strong> в нашей документации.",
-        "title": "Для этого namespace не установлены значения по умолчанию для плагинов."
-      },
-      "testSuites": {
-        "content": "Начните создавать тестовые наборы для проверки ваших Flows.",
-        "title": "У вас еще нет Test suites!"
-      },
-      "triggers": {
-        "content": "Узнайте больше о <strong><a href=\"https://kestra.io/docs/workflow-components/triggers?utm_source=app&utm_medium=referral&utm_campaign=trigger-inlinedoc\" target=\"_blank\">Triggers</a></strong> в нашей документации.",
-        "title": "Ваш flow не имеет никаких Triggers."
-      },
-      "variables": {
-        "content": "Добавьте пары ключ-значение для совместного использования конфигурации между flows. Дочерние namespaces автоматически наследуют их, и вы можете ссылаться на любое значение с помощью",
-        "title": "Пока нет переменных"
-      },
-      "versionPlugin": {
-        "content": "Здесь вы можете управлять всеми плагинами, установленными на вашем экземпляре Kestra. Недавно установленные плагины могут быть не сразу доступны во всех службах Kestra в зависимости от конфигурации вашего экземпляра.",
-        "title": "У вас еще нет версионированного плагина!"
-      },
-      "workerRegistrationTokens": {
-        "content": "Токены регистрации позволяют удаленным worker безопасно аутентифицироваться и регистрироваться в вашем экземпляре Kestra. Создайте токен, затем используйте его для подключения новых worker к этому кластеру.",
-        "title": "У вас еще нет токенов регистрации!"
-      }
-    },
-    "empty search": "Результаты поиска пусты",
-    "enable": "Включить",
-    "enable concurrency": "Включить concurrency",
-    "enabled": "Включено",
-    "encoding": "Кодировка",
-    "end date": "Дата окончания",
-    "end datetime": "Дата и время окончания",
-    "environment": "Окружение",
-    "environment color setting": "Цвет окружения",
-    "environment name setting": "Имя окружения",
-    "error": "Ошибка",
-    "error detected": "Обнаружена ошибка(и).",
-    "error in editor": "В редакторе найдена ошибка",
-    "errorLogs": "Логи ошибок",
-    "errors": {
-      "401": {
-        "content": "Вам нужно пройти аутентификацию для доступа к этой странице.",
-        "title": "Неавторизован"
-      },
-      "403": {
-        "content": "У вас нет необходимых прав для доступа к этой странице.",
-        "title": "Доступ запрещен"
-      },
-      "404": {
-        "content": "Запрашиваемый URL не найден на этом сервере.<br />Это все, что мы знаем.",
-        "flow or execution": "Flow или выполнение, которое вы ищете, не существует.",
-        "title": "Страница не найдена"
-      }
-    },
+    "change execution state confirm": "Вы уверены, что хотите изменить состояние выполнения <code>{id}</code>?",
+    "change execution state done": "Состояние выполнения обновлено",
+    "mark as": "Пометить как <code>{status}</code>",
+    "unqueue as": "Очередь снята как <code>{status}</code>",
+    "kill": "Убить",
+    "kill parents and subflow": "Прервать текущий и subflows",
+    "kill only parents": "Убить только текущий",
+    "killed confirm": "Вы уверены, что хотите убить выполнение <code>{id}</code>?",
+    "killed done": "Выполнение поставлено в очередь на убийство",
+    "resume": "Возобновить",
+    "resumed title": "Возобновить выполнение <code>{id}</code>",
+    "resumed confirm": "Вы уверены, что хотите возобновить выполнение <code>{id}</code>?",
+    "resumed done": "Выполнение возобновлено",
+    "resume from breakpoint title": "Возобновить выполнение <code>{id}</code> с точки останова",
+    "resume from breakpoint done": "Выполнение возобновлено с точки останова",
+    "breakpoints": "Точки останова",
+    "pause": "Пауза",
+    "pause title": "Приостановить выполнение <code>{id}</code>.<br/>Обратите внимание, что текущие RUNNING задачи все равно будут обрабатываться, и выполнение придется возобновить вручную.",
+    "pause confirm": "Вы уверены, что хотите приостановить выполнение <code>{id}</code>?",
+    "pause done": "Выполнение приостановлено",
+    "unqueue": "Из очереди",
+    "unqueue title": "Извлечь выполнение <code>{id}</code> из очереди.<br/>Обратите внимание, что это не будет учитывать ограничение на параллельность flow, поэтому может выполняться больше процессов, чем разрешено.",
+    "unqueue title multiple": "Вы уверены, что хотите удалить из очереди <code>{count}</code> выполнений?<br/><br/>Обратите внимание, что это не будет учитывать ограничение на параллельность flow, поэтому может выполняться больше выполнений, чем разрешено.",
+    "unqueue confirm": "Вы уверены, что хотите отменить выполнение <code>{id}</code>?",
+    "unqueue done": "Выполнение находится вне очереди",
+    "force run": "Принудительный запуск",
+    "force run title": "Принудительный запуск выполнения <code>{id}</code>.",
+    "force run tooltip": "Принудительно запустить выполнение. Это может создать дублирующие выполнения задач, если возможно, используйте другое действие.",
+    "force run confirm": "Вы уверены, что хотите принудительно запустить выполнение <code>{id}</code>?<br/><br/>WARNING: принудительный запуск выполнения не гарантирован и может создать дублирующие выполнения task.<br/><br/>Будут выполнены следующие переходы:<br/><ul><li>CREATED tasks будут переведены в состояние RUNNING.</li><li>RUNNING tasks будут повторно отправлены.</li><li>QUEUED tasks будут извлечены из очереди.</li><li>PAUSED tasks будут возобновлены.</li></ul>",
+    "force run done": "Выполнение принудительного запуска",
+    "toggle output": "Переключить выводы",
+    "metrics": "Метрики",
+    "no data current task": "Для текущего task нет доступных данных",
+    "no metrics available": "Для этого выполнения task метрики не записаны.",
+    "no outputs available": "Для этого выполнения task нет доступных outputs.",
+    "outputs": "Выводы",
+    "flow_outputs": "Выходы Flow",
+    "no_flow_outputs": "Нет доступных output.",
+    "output": "Вывод",
     "eval": {
-      "expression": "Выражение",
-      "preview": "Предварительный просмотр",
-      "render": "Отобразить выражение",
       "title": "Отладка выражения",
-      "tooltip": "Выполните любое выражение Pebble и проверьте контекст выполнения."
+      "render": "Отобразить выражение",
+      "tooltip": "Выполните любое выражение Pebble и проверьте контекст выполнения.",
+      "preview": "Предварительный просмотр",
+      "expression": "Выражение"
     },
-    "evaluation lock date": "Дата блокировки оценки",
-    "execute": "Выполнить",
-    "execute backfill": "Выполнить заполнение",
-    "execute flow behaviour": "Выполнить flow",
-    "execute flow now ?": "Вы хотите выполнить этот flow?",
-    "execute the flow": "Выполнить flow <code>{id}</code>",
-    "execution": "Выполнение",
-    "execution already finished": "Выполнение <code>{executionId}</code> уже завершено",
-    "execution id": "Идентификатор выполнения",
-    "execution labels": "Метки выполнения",
-    "execution not found": "Выполнение {executionId} не найдено.",
-    "execution not in state FAILED": "Выполнение <code>{executionId}</code> не в состоянии FAILED",
-    "execution not in state PAUSED": "Выполнение <code>{executionId}</code> не в состоянии PAUSED",
-    "execution replay": "Это выполнение является повтором",
-    "execution replayed": "Это выполнение было воспроизведено.",
-    "execution restarted": "Это выполнение было перезапущено {nbRestart} раз(а).",
+    "attempt": "Попытка",
+    "toggle output display": "Переключить отображение вывода",
+    "name": "Имя",
+    "key": "Ключ",
+    "value": "Значение",
+    "each value": "Значение итерации",
+    "current execution": "Текущее выполнение",
+    "parent execution": "Родительское выполнение",
+    "original execution": "Оригинальное выполнение",
+    "automatic refresh": "Автоматическое обновление",
+    "toggle periodic refresh each x seconds": "Переключить периодическое обновление каждые {interval} секунд",
+    "trigger refresh": "Обновить",
+    "add-trigger-in-editor": "Сначала добавьте Trigger в ваш Flow",
+    "refresh": "Обновить",
+    "filter by status": "Фильтровать выполнения по статусу {status}",
+    "topology-graph": {
+      "graph-orientation": "Ориентация графика",
+      "zoom-in": "Увеличить",
+      "zoom-out": "Уменьшить",
+      "zoom-reset": "Сбросить масштаб",
+      "zoom-fit": "Подогнать",
+      "invalid": "Ошибка графа",
+      "invalid_description": "Произошла ошибка при загрузке графа. Пожалуйста, проверьте исходный код на наличие ошибок."
+    },
+    "show task logs": "Показать логи задачи",
+    "show task condition": "Показать условие task",
+    "show task outputs": "Показать выводы задачи",
+    "show task source": "Показать исходный код задачи",
+    "specific task": "Конкретная задача",
+    "display output for specific task": "Показать вывод для конкретной задачи",
+    "display metric for specific task": "Показать метрику для конкретной задачи",
+    "display direct sub tasks count": "Показать количество прямых подзадач",
+    "stream": "Поток",
     "execution statistics": "Статистика выполнения",
-    "execution-include-non-terminated": "Включить незавершенные выполнения?",
-    "execution-warn-deleting-still-running": "Мы настоятельно рекомендуем отменить это действие и сначала завершить все текущие executions. Удаление незавершенных executions может привести к проблемам с concurrency, несоответствиям в управлении зависимостями flow и появлению \"зомби\"-процессов на вашем экземпляре, что может ухудшить производительность системы. Убедитесь, что вы полностью понимаете эти риски, прежде чем продолжить удаление.",
-    "execution-warn-title": "Важное предупреждение!",
-    "execution_deletion": {
-      "logs": "Удалить логи",
-      "metrics": "Удалить метрики",
-      "storage": "Удалить внутренние файлы хранения"
-    },
-    "execution_failed": "Выполнение не удалось!",
-    "execution_guide": {
-      "get_started": {
-        "text": "Следуйте Руководству по быстрому старту, чтобы установить Kestra и начать создавать свои первые workflows.",
-        "title": "Начать ⚡"
-      },
-      "namespaces": {
-        "text": "Пространства имен — это логические группы flow и их компонентов.",
-        "title": "О namespace"
-      },
-      "videos_tutorials": {
-        "text": "Начните с наших видеоуроков.",
-        "title": "Видеоуроки"
-      },
-      "workflow_components": {
-        "text": "Познакомьтесь с основными компонентами оркестрации в workflow Kestra.",
-        "title": "Компоненты Workflow"
-      }
-    },
-    "execution_started": "Выполнение началось!",
-    "execution_starts_progress": "Как только начнется выполнение, вы увидите здесь обновления о ходе выполнения.",
-    "execution_status": "Выполнение:",
-    "executions": "Выполнения",
-    "executions deleted": "<code>{executionCount}</code> выполнение(я) удалено",
+    "stats": "Статистика",
+    "concurrency limits": "Ограничения на параллелизм",
+    "system overview": "Обзор системы",
+    "usage": "Использование",
+    "namespaces": "Namespaces",
+    "tasks": "Задачи",
     "executions duration (in minutes)": "Общая длительность выполнения (в минутах)",
-    "executions force run": "<code>{executionCount}</code> выполнение(я) принудительный запуск",
-    "executions killed": "<code>{executionCount}</code> выполнение(я) убито",
-    "executions paused": "<code>{executionCount}</code> выполнение(я) PAUSED",
-    "executions replayed": "<code>{executionCount}</code> выполнение(я) воспроизведено",
-    "executions restarted": "<code>{executionCount}</code> выполнение(я) перезапущено",
-    "executions resumed": "<code>{executionCount}</code> выполнение(я) возобновлено",
-    "executions state changed": "Состояние выполнения <code>{executionCount}</code> было изменено",
-    "executions unqueue": "<code>{executionCount}</code> выполнение(я) в очереди",
-    "expand": "Развернуть",
-    "expand all": "Развернуть все",
-    "expand dependencies": "Развернуть зависимости",
-    "expand error": "Развернуть только неудачные tasks",
-    "expand_by_default": "Expand structured logs by default",
-    "expiration": "Срок действия",
-    "expiration date": "Дата истечения",
-    "export": "Экспорт",
-    "export all flows": "Экспортировать все flows",
-    "export all templates": "Экспортировать все шаблоны",
-    "export_as": "Экспортировать как .{format}",
-    "export_csv": "Экспортировать как CSV",
-    "exports": "Экспорты",
-    "failed to export plugin defaults": "Не удалось экспортировать значения по умолчанию плагина",
-    "failed to import plugin defaults": "Не удалось импортировать значения по умолчанию плагина",
-    "failed to render pdf": "Не удалось отобразить предварительный просмотр PDF",
-    "false": "Ложь",
-    "feeds": {
-      "heading": "Все о Kestra.",
-      "subheading": "Последние обновления, руководства и истории",
-      "title": "Что нового в Kestra"
+    "last 48 hours": "последние 48 часов",
+    "configure basic auth": "Настроить базовую аутентификацию",
+    "email": "Email",
+    "password": "Пароль",
+    "confirm password": "Подтвердить пароль",
+    "email length constraint": "Email не должен превышать 256 символов",
+    "password length constraint": "Пароль не должен превышать 256 символов",
+    "password empty constraint": "Неверное имя пользователя или пароль",
+    "passwords do not match": "Пароли не совпадают",
+    "avg duration": "Средняя длительность выполнения",
+    "neutral trend": "Стабильно",
+    "up trend": "Увеличивается",
+    "down trend": "Уменьшается",
+    "update aborted": "обновление прервано",
+    "invalid flow": "Неверный flow",
+    "invalid yaml": "Неверный YAML",
+    "inputs": "Входные данные",
+    "no_inputs": "Нет доступных input.",
+    "input": "Ввод",
+    "variables": "Переменные",
+    "variable_explorer": {
+      "title": "Ввод/Вывод",
+      "search_placeholder": "Поиск по Key или value...",
+      "tasks_outputs": "Tasks outputs",
+      "tree": "Дерево",
+      "raw_json": "Raw JSON",
+      "select_prompt": "Выберите переменную, чтобы просмотреть её value.",
+      "empty": "Нет переменных, доступных для этого выполнения.",
+      "one_key": "\\{ 1 key \\}",
+      "n_keys": "\\{ {count} keys \\}",
+      "one_item": "[ 1 элемент ]",
+      "n_items": "[ {count} элементов ]"
     },
-    "file preview truncated": "Отображаемое содержимое было усечено",
-    "file unavailable": "Файл недоступен",
-    "file unavailable description": "Этот файл больше недоступен — возможно, он был удален или срок его действия истек.",
-    "fileTypeNotAllowed": "Недопустимый тип файла. Допустимые типы: {types}",
     "file_preview": {
       "big_file_warning": "Этот файл имеет размер {size}. Загрузка может занять некоторое время и заблокировать ваш браузер. Вы все равно хотите его загрузить?",
       "load_anyway": "Загрузить в любом случае"
     },
-    "files": "Файлы",
-    "filter by log level": "Фильтр по уровню log",
-    "filter by status": "Фильтровать выполнения по статусу {status}",
-    "filter by this value": "Filter by this value",
-    "filter_for": "Filter for",
-    "filter_out": "Filter out",
-    "filters": {
-      "comparators": {
-        "between": "между",
-        "contains": "содержит",
-        "ends_with": "заканчивается на",
-        "greater_than": "больше чем",
-        "greater_than_or_equal_to": "больше или равно",
-        "in": "в",
-        "is": "является",
-        "is_not": "не является",
-        "is_one_of": "является одним из",
-        "less_than": "меньше чем",
-        "less_than_or_equal_to": "меньше или равно",
-        "not_contains": "не содержит",
-        "not_in": "не является одним из",
-        "starts_with": "начинается с"
-      },
-      "empty": "Нет данных.",
-      "format": "Введите параметр в формате 'key:value'",
-      "label": "Выберите фильтры",
-      "options": {
-        "absolute_date": "Абсолютная дата",
-        "action": "Действие",
-        "aggregation": "Агрегация",
-        "child": "Дочерний элемент",
-        "details": "Детали",
-        "endDate": "Дата окончания",
-        "flow": "Поток",
-        "labels": "Метки",
-        "level": "Уровень Log",
-        "metric": "Метрика",
-        "namespace": "Namespace",
-        "permission": "Разрешение",
-        "relative_date": "Относительная дата",
-        "scope": "Область применения",
-        "service_type": "Тип",
-        "startDate": "Дата начала",
-        "state": "Состояние",
-        "status": "Статус",
-        "task": "Задача",
-        "text": "I'm sorry, but it seems that the text you want me to translate is missing. Could you please provide the text that needs to be translated?",
-        "type": "Тип",
-        "user": "Пользователь"
-      },
-      "save": {
-        "dialog": {
-          "confirmation": "Критерии поиска <code>{name}</code>",
-          "heading": "Сохранить текущий поиск",
-          "hint": "Как вы хотите обозначить этот критерий поиска?",
-          "placeholder": "Ярлык"
-        },
-        "empty": "Вы еще не сохранили ни одного поиска.",
-        "label": "Сохранённые поиски",
-        "name_already_used": "Поиск label уже используется.",
-        "remove": "Удалить",
-        "tooltip": "Вы не можете сохранить пустые критерии поиска."
-      },
-      "settings": {
-        "label": "Настройки страницы",
-        "show_chart": "Показать основную диаграмму"
-      },
-      "text_search": "Искать этот текст"
-    },
-    "fix_with_ai": "Исправить с помощью AI",
-    "flow": "Flow",
-    "flow already exists": "Flow уже существует",
-    "flow already exists message": "Поток <code>{id}</code> уже существует в namespace <code>{namespace}</code>. Хотите создать новую ревизию?",
-    "flow creation": "Создание flow",
-    "flow creation denied in namespace": "У вас нет разрешения на создание flows в namespace `{namespace}`.",
-    "flow delete": "Вы уверены, что хотите удалить <code>{flowCount}</code> flow(ы)?",
-    "flow deleted, you can restore it": "Flow был удален, и это представление только для чтения. Вы все еще можете его восстановить.",
-    "flow disable": "Вы уверены, что хотите отключить <code>{flowCount}</code> flow(ы)?",
-    "flow enable": "Вы уверены, что хотите включить <code>{flowCount}</code> flow(ы)?",
-    "flow export": "Вы уверены, что хотите экспортировать <code>{flowCount}</code> flow(ы)?",
-    "flow must have id and namespace": "Flow должен иметь id и namespace.",
-    "flow must not be empty": "Flow не должен быть пустым",
-    "flow not imported": "Некоторые flow не удалось импортировать",
-    "flow revision latest": "Последняя версия flow",
-    "flow revision original": "Оригинальная ревизия flow",
-    "flow revision specific": "Конкретная ревизия flow",
-    "flow source not found": "Источник flow не найден",
-    "flow-dependencies": "зависимости",
-    "flow-no-dependencies": "Ваш flow не имеет зависимостей",
-    "flow_editor_stats": {
-      "apps": {
-        "suffix": "Приложение(я)",
-        "tooltip": "Просмотр приложений, использующих этот flow"
-      },
-      "dependencies": {
-        "suffix": "Зависимости",
-        "tooltip": "Просмотр зависимостей flow"
-      },
-      "errors": {
-        "label": "{count} Ошибка(и)"
-      },
-      "revisions": {
-        "suffix": "Ревизия(и)",
-        "tooltip": "Просмотр версий flow"
-      },
-      "tests": {
-        "suffix": "Тест(ы)",
-        "tooltip": "Просмотр тестов flow"
-      }
-    },
-    "flow_export": "Экспорт flow",
-    "flow_only": "Доступно только на вкладке Flow.",
-    "flow_outputs": "Выходы Flow",
-    "flows": "Flows",
-    "flows deleted": "<code>{count}</code> Flow(ы) удалены",
-    "flows disabled": "<code>{count}</code> Flow(ы) отключены",
-    "flows enabled": "<code>{count}</code> Flow(ы) включены",
-    "flows exported": "<code>{count}</code> Flow(s) экспортировано",
-    "flows imported": "Потоки импортированы",
-    "focus task": "Нажмите на любой элемент, чтобы увидеть его документацию.",
-    "fold_all_multi_lines": "Свернуть все многострочные строки",
-    "font size": "Font size",
-    "for flow": "для flow",
-    "forbidden system labels": "Только system.correlationId можно использовать как system label",
-    "force run": "Принудительный запуск",
-    "force run confirm": "Вы уверены, что хотите принудительно запустить выполнение <code>{id}</code>?<br/><br/>WARNING: принудительный запуск выполнения не гарантирован и может создать дублирующие выполнения task.<br/><br/>Будут выполнены следующие переходы:<br/><ul><li>CREATED tasks будут переведены в состояние RUNNING.</li><li>RUNNING tasks будут повторно отправлены.</li><li>QUEUED tasks будут извлечены из очереди.</li><li>PAUSED tasks будут возобновлены.</li></ul>",
-    "force run done": "Выполнение принудительного запуска",
-    "force run title": "Принудительный запуск выполнения <code>{id}</code>.",
-    "force run tooltip": "Принудительно запустить выполнение. Это может создать дублирующие выполнения задач, если возможно, используйте другое действие.",
-    "form": "Форма",
-    "form error": "Ошибка формы",
-    "from": "От",
-    "gantt": "Гантт",
-    "gantt_no_tasks_executed": "Это выполнение завершилось без запуска каких-либо task. Проверьте его обзор и логи, чтобы узнать причину.",
-    "gantt_no_tasks_match_filters": "Попробуйте изменить фильтры поиска, состояния или уровня Log.",
-    "gantt_no_tasks_match_filters_title": "Нет задач, соответствующих выбранным фильтрам.",
-    "healthcheck date": "HealthCheck Дата",
-    "hide task documentation": "Скрыть документацию задачи",
-    "home": "Домой",
-    "hostname": "Имя хоста",
-    "iam": "IAM",
-    "id": "Id",
-    "import": "Импорт",
-    "in-our-documentation": "в нашей документации.",
-    "informative notice": "Примечание(я)",
-    "input": "Ввод",
-    "inputs": "Входные данные",
-    "instance": "Экземпляр",
-    "invalid bulk delete": "Не удалось удалить выполнения",
-    "invalid bulk force run": "Не удалось принудительно запустить executions",
-    "invalid bulk kill": "Не удалось убить выполнения",
-    "invalid bulk pause": "Не удалось приостановить выполнения",
-    "invalid bulk replay": "Не удалось воспроизвести выполнения",
-    "invalid bulk restart": "Не удалось перезапустить выполнения",
-    "invalid bulk resume": "Не удалось возобновить выполнения",
-    "invalid bulk unqueue": "Не удалось удалить выполнения из очереди",
-    "invalid field": "Неверное поле: {name}",
-    "invalid flow": "Неверный flow",
-    "invalid source": "Неверный исходный код",
-    "invalid yaml": "Неверный YAML",
-    "is deprecated": "устарело",
-    "is required": "{field} обязателен для заполнения",
-    "item": "элемент",
-    "items": "элементы",
-    "join community": "Присоединяйтесь к сообществу",
-    "join_slack": "Присоединиться к Slack",
-    "jsonl": "JSONL",
-    "jump to...": "Перейти к...",
-    "kestra": "Kestra",
-    "key": "Ключ",
-    "kill": "Убить",
-    "kill only parents": "Убить только текущий",
-    "kill parents and subflow": "Прервать текущий и subflows",
-    "killed confirm": "Вы уверены, что хотите убить выполнение <code>{id}</code>?",
-    "killed done": "Выполнение поставлено в очередь на убийство",
-    "kv": {
-      "add": "Создать",
-      "delete multiple": {
-        "confirm": "Вы уверены, что хотите удалить: <code>{name}</code> kv store?",
-        "warning": "У вас нет разрешений для этих namespaces, поэтому они будут пропущены: <code>{namespaces}</code>"
-      },
-      "duplicate": "Этот key уже существует",
-      "inherited": "Наследуемые KV пары",
-      "name": "KV Store",
-      "type": "Тип",
-      "update": "Обновить значение для key '{key}'"
-    },
-    "label": "Метка",
-    "label filter placeholder": "Метка как 'key:value'",
-    "labels": "Метки",
-    "last 48 hours": "последние 48 часов",
-    "last X days count": "{count} за последние {days} дней",
-    "last error was": "Последняя ошибка была",
-    "last evaluation date": "Дата последней оценки",
-    "last evaluation date tooltip": "When the trigger was last evaluated by the scheduler, regardless of whether it produced an execution.",
-    "last execution date": "Дата последнего выполнения",
-    "last execution state": "Последнее состояние",
-    "last execution status": "Последний статус выполнения",
-    "last modified": "Последнее изменение",
-    "last trigger date": "Дата последнего срабатывания",
-    "last trigger date tooltip": "Когда trigger выполнялся в последний раз. Может быть в прошлом при запуске backfill.",
-    "latest_update": "Последнее обновление",
-    "launch execution": "Выполнить",
-    "learn_more": "Узнать больше",
-    "leave page": "Покинуть страницу",
-    "license": "Лицензия",
-    "light_background": "Это предпочтительный вариант при работе со светлым фоном.",
-    "light_version": "Легкая версия",
-    "line": "Линия",
-    "line-by-line": "построчно",
-    "loaded x dependencies": "{count} зависимости загружены",
-    "loading": "Загрузка...",
-    "log expand setting": "Отображение logs по умолчанию",
-    "logExporters": "Экспортеры Log",
-    "logs": "Логи",
-    "logs_copied": "Logs copied to your clipboard",
-    "logs_view": {
-      "compact": "Вид по умолчанию",
-      "compact_details": "Показать task логи в компактном виде, сгруппированном по каждой задаче",
-      "raw": "Временной вид",
-      "raw_details": "Показать полные task logs и flow логи в формате необработанных временных меток"
-    },
-    "main_configuration": "Основная конфигурация",
-    "manage labels": "Управление labels",
-    "management port": "Порт управления",
-    "mark as": "Пометить как <code>{status}</code>",
-    "max": "Макс",
-    "mcp": {
-      "api_token": "Токен API",
-      "auth_type": "Аутентификация",
-      "basic_auth": "Базовая аутентификация",
-      "bearer_token": "Аутентификация с использованием Bearer token",
-      "client_setup": "Настройка клиента",
-      "connect": "Подключить",
-      "connect_tab": {
-        "auth_api_token_hint": "Перед запуском клиента установите <code>KESTRA_TOKEN</code> как переменную окружения.",
-        "auth_basic_hint": "Перед запуском клиента установите <code>KESTRA_BASIC_AUTH</code> как переменную окружения, содержащую строку <code>username:password</code>, закодированную в base64.",
-        "auth_oauth_browser_hint": "При первом подключении браузер откроет страницу входа провайдера идентификации.",
-        "auth_oauth_client_id_hint": "Замените <code>&lt;client-id&gt;</code> на ID OAuth-клиента и зарегистрируйте <code>http://localhost:7777</code> как действительный URI перенаправления на этом клиенте.",
-        "claude_code": "Код Claude",
-        "claude_code_hint": "Выполните следующую команду в вашем терминале:",
-        "claude_desktop": "Клод Десктоп",
-        "claude_desktop_hint": "Добавьте следующее в ваш файл claude_desktop_config.json:",
-        "claude_desktop_mac": "macOS: ~/Library/Application Support/Claude/claude_desktop_config.json",
-        "claude_desktop_win": "Windows: %APPDATA%\\Claude\\claude_desktop_config.json",
-        "client_picker_label": "Выберите ваш AI-клиент",
-        "codex": "Codex (OpenAI)",
-        "codex_hint": "Добавьте следующее в вашу конфигурацию codex.json MCP:",
-        "cursor": "Курсор",
-        "cursor_hint": "Добавьте следующее в ~/.cursor/mcp.json:",
-        "server_url": "URL сервера"
-      },
-      "copy_url": "Скопировать URL",
-      "create": "Создать сервер",
-      "delete_confirm": "Вы уверены, что хотите удалить этот MCP сервер?",
-      "id_invalid": "ID должен начинаться с строчной буквы или цифры и содержать только строчные буквы, цифры, дефисы или подчеркивания",
-      "id_placeholder": "например, my-mcp-server",
-      "instructions": "Инструкции",
-      "main_tenant": "главная",
-      "managed_by_kestra": "Управляется Kestra",
-      "no_oauth_providers": "В этом экземпляре не настроены OIDC-провайдеры",
-      "no_servers": "Серверы MCP не найдены. Создайте первый сервер, чтобы предоставить триггеры MCP Tool внешним AI-агентам.",
-      "oauth": "OAuth",
-      "oauth_hint": "Bearer JWT от вашего OIDC-провайдера",
-      "oauth_provider": "Провайдер OAuth",
-      "oauth_provider_placeholder": "Выберите настроенный OIDC-провайдер",
-      "oauth_provider_required": "Провайдер OAuth обязателен, когда тип аутентификации — OAuth",
-      "page_description": "Предоставьте ваши Kestra flows как инструменты для MCP-совместимых AI агентов",
-      "private": "Частный",
-      "private_server": "Частный сервер",
-      "public": "Публичный",
-      "public_hint": "Внимание: Публичные серверы не требуют аутентификации. Любой, у кого есть URL-адрес, может вызывать любой инструмент, предоставляемый этим сервером, без проверок namespace или разрешений. Используйте только для серверов, которые безопасно предоставлять внешне.",
-      "save": "Сохранить изменения",
-      "scopes_supported": "Поддерживаемые scopes",
-      "scopes_supported_hint": "Scopes, объявленные в документе Protected Resource Metadata этого сервера. MCP-клиенты, соответствующие спецификации, ограничивают запрос авторизации этим списком. Оставьте пустым, чтобы пропустить поле и позволить клиентам использовать scopes, объявленные IdP.",
-      "scopes_supported_placeholder": "openid, profile, email",
-      "server": "Сервер MCP",
-      "server_id": "ID сервера",
-      "server_type": "Тип сервера",
-      "servers": "Серверы MCP",
-      "servers_count": "{count} MCP Серверов",
-      "tab_connect": "Подключиться",
-      "tab_edit": "Редактировать",
-      "tab_tool_flows": "Инструменты Flow",
-      "tab_tool_flows_placeholder": "Управление flow инструментами скоро появится.",
-      "tools": {
-        "annotations": "Аннотации",
-        "create_tool_flow": "Создать flow инструмента",
-        "description": "Описание",
-        "destructive": "Деструктивный",
-        "flow": "flow",
-        "idempotent": "Идемпотентный",
-        "no_tools": "Нет flow, соответствующих вашему запросу.",
-        "open_world": "Open world",
-        "read_only": "Только чтение",
-        "return_direct": "Прямой возврат",
-        "state": "Состояние",
-        "title": "Заголовок",
-        "tool_name": "Название инструмента",
-        "trigger_id": "ID trigger",
-        "view_flow": "Открыть flow"
-      },
-      "url_copied": "URL скопирован!",
-      "username_password": "Имя пользователя и пароль",
-      "your_servers": "Ваши серверы"
-    },
-    "metric": "Метрика",
-    "metric choice": "Для этого flow метрики недоступны",
-    "metrics": "Метрики",
-    "min": "Мин",
-    "missingSource": "Отсутствует источник",
-    "modify inputs": "Изменить inputs",
-    "modify_inputs": "Изменить inputs",
-    "monogram": "Монограмма",
-    "more actions": "Дополнительные действия",
-    "more_actions": "Больше действий",
-    "multi_panel_editor": {
-      "close_all_panels": "Закрыть все панели",
-      "close_all_tabs": "Закрыть все вкладки",
-      "move_left": "Переместить влево",
-      "move_right": "Переместить вправо"
-    },
-    "multiple saved done": "{name} был сохранен",
-    "name": "Имя",
-    "namespace": "Namespace",
-    "namespace and id readonly": "Свойства `namespace` и `id` не могут быть изменены — они установлены на начальные значения. Если вы хотите переименовать flow или изменить его namespace, вы можете создать новый flow и удалить старый.",
-    "namespace files": {
-      "create": {
-        "file": "Создать файл",
-        "file_already_exists": "Файл с таким именем уже существует",
-        "file_conflicts_with_folder": "Папка с таким именем уже существует",
-        "file_error": "Произошла ошибка при создании файла",
-        "folder": "Создать папку",
-        "folder_already_exists": "Папка с таким именем уже существует",
-        "folder_conflicts_with_file": "Файл с таким именем уже существует",
-        "folder_error": "Произошла ошибка при создании папки",
-        "label": "Создать"
-      },
-      "delete": {
-        "file": "Удалить файл",
-        "files": "Удалить {count} выбранных файлов",
-        "folder": "Удалить папку",
-        "folders": "Удалить {count} выбранных папок",
-        "label": "Удалить"
-      },
-      "dialog": {
-        "deletion": {
-          "confirm": "Подтвердить",
-          "file_single": "Вы уверены, что хотите удалить файл <code>{name}</code>?",
-          "files": "Вы уверены, что хотите удалить <code>{count}</code> файл(ы)?",
-          "folder_single": "Вы уверены, что хотите удалить папку <code>{name}</code> и все её содержимое?",
-          "folders": "Вы уверены, что хотите удалить <code>{count}</code> папку(и) и все её содержимое?",
-          "mixed": "Вы уверены, что хотите удалить папку(и) <code>{folders}</code> и файл(ы) <code>{files}</code>?",
-          "title": "Подтвердите удаление содержимого"
-        },
-        "name": {
-          "file": "Имя с расширением:",
-          "folder": "Имя папки:"
-        },
-        "parent_folder": "Родительская папка:"
-      },
-      "export": "Экспортировать файлы namespace",
-      "export_single": "Экспортировать файл",
-      "filter": "Фильтр",
-      "import": {
-        "error": "Произошли ошибки при импорте файла(ов)",
-        "files": "Импортировать файлы",
-        "folder": "Импортировать папку",
-        "import": "Импортировать",
-        "success": "Файл(ы) успешно импортированы"
-      },
-      "new_file": "Новый файл",
-      "no_items": {
-        "heading": "В вашем namespace пока нет файлов.",
-        "paragraph": "Создайте или импортируйте файлы для обмена кодом между flows в вашем namespace."
-      },
-      "no_selection": {
-        "description": "Выберите файл из дерева, чтобы просмотреть его содержимое.",
-        "heading": "Файлы не выбраны"
-      },
-      "path": {
-        "copy": "Скопировать путь",
-        "error": "Произошли ошибки при копировании пути в буфер обмена",
-        "success": "Путь скопирован в буфер обмена"
-      },
-      "rename": {
-        "file": "Переименовать файл",
-        "folder": "Переименовать папку",
-        "label": "Переименовать",
-        "new_file": "Новое имя с расширением:",
-        "new_folder": "Новое имя папки:"
-      },
-      "revisions": {
-        "history": "История изменений",
-        "restore": {
-          "success": "Файл успешно восстановлен до предыдущей версии"
-        }
-      },
-      "toggle": {
-        "hide": "Скрыть файлы namespace",
-        "show": "Показать файлы namespace"
-      },
-      "tree": {
-        "collapse": "Свернуть все папки",
-        "expand": "Развернуть все папки"
-      }
-    },
-    "namespace not allowed": "Namespace не разрешен",
-    "namespace_editor": {
-      "close": {
-        "all": "Закрыть все вкладки",
-        "other": "Закрыть другие вкладки",
-        "right": "Закрыть справа",
-        "tab": "Закрыть вкладку"
-      },
-      "empty": {
-        "create_message": "Вы можете создать или импортировать файлы namespace.",
-        "title": "В настоящее время вкладки не открыты",
-        "video_message": "Вы можете посмотреть Вводное Видео для нашего Editor."
-      }
-    },
-    "namespaces": "Namespaces",
-    "neutral trend": "Стабильно",
-    "new": "Новый",
-    "new version": "Доступна новая версия {version}!",
-    "next": "Далее",
-    "next evaluation date": "Следующая дата оценки",
-    "next evaluation date tooltip": "Когда trigger будет оцениваться в следующий раз, на основе его интервала. Не всегда совпадает с датой следующей Ausführung, если условия не выполнены.",
-    "next execution date": "Дата следующего выполнения",
-    "next_execution": "Следующее выполнение",
-    "no data current task": "Для текущего task нет доступных данных",
-    "no inputs": "Этот flow не имеет входных данных.",
-    "no metrics available": "Для этого выполнения task метрики не записаны.",
-    "no outputs available": "Для этого выполнения task нет доступных outputs.",
-    "no result": "Нет результатов для отображения.",
-    "no revisions": "Нет ревизий",
-    "no revisions found": "Для этого flow существует только одна редакция",
-    "no-executions-view": {
-      "guidance_desc": "Нужна помощь для выполнения вашего flow?",
-      "guidance_sub_desc": "Следуйте документации для получения всей необходимой информации.",
-      "namespace_guidance_desc": "Нужна помощь в управлении вашим Namespace?",
-      "namespace_sub_title": "Выполните один или несколько flow из этого namespace, чтобы заполнить эту панель.",
-      "sub_title": "Нажмите на кнопку Execute, чтобы начать выполнение вашего первого workflow.",
-      "title": "Начните автоматизацию с"
-    },
-    "no_code": {
-      "add_field": "Добавить {field}",
-      "adding": "+ Добавить {what}",
-      "adding_default": "+ Добавить новое value",
-      "clearSelection": "Очистить выбор",
-      "creation": {
-        "afterExecution": "Добавить блок после выполнения",
-        "charts": "Добавить диаграмму",
-        "conditions": "Добавить условие",
-        "default": "Добавить",
-        "errors": "Добавить обработчик ошибок",
-        "finally": "Добавить блок finally",
-        "inputs": "Добавить поле input",
-        "numerator": "Добавить числитель",
-        "pluginDefaults": "Добавить плагин по умолчанию",
-        "tasks": "Добавить task",
-        "triggers": "Добавить trigger",
-        "where": "Фильтруйте ваши данные"
-      },
-      "fields": {
-        "general": {
-          "checks": "Проверки",
-          "concurrency": "Конкурентность",
-          "disabled": "Отключено",
-          "labels": "Метки",
-          "listeners": "Слушатели",
-          "outputs": "Выходы",
-          "retry": "Повторить попытку",
-          "sla": "SLA",
-          "taskDefaults": "Значения по умолчанию для Task",
-          "updated": "Обновлено",
-          "variables": "Переменные",
-          "workerGroup": "Группа Worker",
-          "workerSelector": "Селектор Worker"
-        },
-        "main": {
-          "description": "Описание",
-          "id": "ID flow",
-          "inputs": "Входные данные",
-          "namespace": "Namespace"
-        }
-      },
-      "labels": {
-        "label": "Метка",
-        "no_code": "Редактор No Code",
-        "variable": "Переменная",
-        "yaml": "Редактор YAML"
-      },
-      "remove": {
-        "cases": "Удалить этот кейс",
-        "default": "Удалить эту запись"
-      },
-      "sections": {
-        "afterExecution": "После выполнения",
-        "deprecated": "Устаревшие свойства",
-        "errors": "Обработчики ошибок",
-        "finally": "Наконец",
-        "pluginDefaults": "Настройки плагина по умолчанию",
-        "tasks": "Задачи",
-        "triggers": "Триггеры"
-      },
-      "select": {
-        "afterExecution": "Выберите task",
-        "charts": "Выберите тип диаграммы",
-        "conditions": "Выберите условие",
-        "default": "Выберите тип",
-        "errors": "Выберите task",
-        "finally": "Выберите task",
-        "inputs": "Выберите тип поля input",
-        "numerator": "Выберите числитель",
-        "pluginDefaults": "Выберите плагин",
-        "task": "Выберите task",
-        "tasks": "Выберите task",
-        "triggers": "Выберите trigger",
-        "where": "Выберите тип фильтра"
-      },
-      "toggle_pebble": "Переключить редактор Pebble",
-      "unnamed": "Без имени",
-      "version_oss_placeholder": "Разблокируйте Версионирование Плагинов с Enterprise Edition"
-    },
-    "no_data": "Похоже, здесь пока ничего нет…<br/>Измените фильтры или попробуйте снова!",
-    "no_file_choosen": "Файл не выбран",
-    "no_flow_outputs": "Нет доступных output.",
-    "no_history": "История недоступна",
-    "no_inputs": "Нет доступных input.",
-    "no_logs_data": "Нет данных",
-    "no_logs_data_description": "Попробуйте изменить фильтры, изменить временной диапазон или проверьте, выполнялся ли flow недавно.",
-    "no_logs_data_title": "Для выбранных фильтров логи не найдены.",
-    "no_namespaces": "Ни один namespace не соответствует критериям поиска.",
-    "no_results": {
-      "assets": "Активы не найдены",
-      "executions": "Исполнения не найдены",
-      "flows": "Потоки не найдены",
-      "kv_pairs": "Пары kv store не найдены",
-      "secrets": "Секреты не найдены",
-      "templates": "Шаблоны не найдены",
-      "triggers": "Триггеры не найдены"
-    },
-    "no_results_found": "Результаты не найдены",
-    "no_tasks_running": "Ещё нет запущенных tasks.",
-    "no_trigger": "Триггер недоступен.",
     "no_variables": "Переменные недоступны.",
-    "now": "Сейчас",
-    "of": "из",
-    "ok": "ОК",
-    "onboarding": {
-      "actions": {
-        "cancel_tutorial": "Отменить руководство",
-        "complete": "Завершить",
-        "edit_flow_to_continue": "Нажмите Edit flow в верхней панели (справа).",
-        "execute_to_continue": "1. Нажмите Execute в верхней панели (справа).\n2. Укажите значение для <strong>name</strong>.\n3. Нажмите Execute ещё раз в модальном окне.",
-        "finish_tutorial": "Завершить руководство",
-        "next": "Далее",
-        "save_to_continue": "Нажмите Save в верхней панели (справа)."
-      },
-      "cancel_modal": {
-        "confirm": "Отменить руководство",
-        "description": "Вы хотите отменить руководство «Первый Flow»?",
-        "keep": "Продолжить руководство",
-        "title": "Отменить руководство «Первый Flow»"
-      },
-      "editor_hints": {
-        "build_intro": "Создайте свой первый flow шаг за шагом.",
-        "step_1": "# 1) Добавьте id",
-        "step_2": "# 2) Добавьте namespace",
-        "step_3": "# 3) Добавьте input",
-        "step_4": "# 4) Добавьте tasks и вашу первую Python-задачу",
-        "step_5": "# 5) Добавьте cron-триггер"
-      },
-      "finish_actions": {
-        "create_flow": "Создать flow",
-        "explore_blueprints": "Посмотреть шаблоны"
-      },
-      "steps": {
-        "add_cron_trigger": {
-          "description": "Triggers могут запускать выполнения по расписанию или по внешним событиям (например, webhooks или MQTT-сообщения).<br><br>Теперь добавьте cron-триггер расписания, чтобы этот flow запускался каждые 5 минут.",
-          "title": "Добавьте cron-триггер"
-        },
-        "add_id": {
-          "description": "ID — это уникальное имя вашего flow, чтобы вы могли находить его, запускать и последовательно ссылаться на него.<br><br>Теперь добавьте <code>id</code> на корневом уровне.",
-          "title": "Добавьте ID flow"
-        },
-        "add_input": {
-          "description": "Inputs — это параметры на уровне flow, которые можно использовать внутри задач, чтобы динамически управлять поведением во время выполнения.<br><br>Теперь добавьте input с именем <code>name</code> и типом <code>STRING</code>.",
-          "title": "Добавьте input"
-        },
-        "add_input_default": {
-          "description": "Когда flow запускается автоматически, inputs всё равно нуждаются в значениях во время выполнения.<br><br>Input <code>name</code> уже был создан на предыдущем шаге, поэтому добавлять его снова не нужно. Просто задайте значение по умолчанию для существующего input <code>name</code>.",
-          "title": "Задайте значение input по умолчанию"
-        },
-        "add_log_task": {
-          "description": "Tasks — это единицы работы, которые выполняет ваш flow, определённые как упорядоченный список шагов. Каждой задаче нужен уникальный <code>id</code> и <code>type</code>. Kestra предоставляет множество плагинов задач для внешних систем; здесь мы используем задачу Python Script.<br><br>Синтаксис <code>&#123;&#123; ... &#125;&#125;</code> — это выражение Pebble, используемое для динамического обращения к переменным во время выполнения, например <code>&#123;&#123; inputs.name &#125;&#125;</code> из inputs flow.<br><br>Теперь добавьте первую задачу под <code>tasks</code> с <code>id</code>, <code>type</code> и <code>script</code>, который выводит приветствие.",
-          "title": "Добавьте первую задачу"
-        },
-        "add_namespace": {
-          "description": "Namespace — это группировка, похожая на папку, которая организует flow по команде, проекту или окружению.<br><br>Теперь добавьте <code>namespace</code> на корневом уровне.",
-          "title": "Добавьте namespace"
-        },
-        "background_runs_info": {
-          "description": "Этот flow теперь будет выполняться в фоне каждые 5 минут.<br><br>Вы можете перейти к обзору Executions в левом меню, чтобы отслеживать запуски по расписанию.",
-          "title": "Запуски по расписанию"
-        },
-        "edit_flow_from_execution": {
-          "description": "Вы можете перейти напрямую из выполнения обратно к определению flow, чтобы быстро вносить изменения.",
-          "title": "Вернитесь в редактор flow"
-        },
-        "execute_flow": {
-          "description": "Запуск начинает выполнение flow с входными значениями, заданными во время выполнения.",
-          "title": "Запустите flow"
-        },
-        "finish": {
-          "description": "Отличное начало. Вы создали flow, запустили его, добавили параметры и расписание.<br><br>Выберите, что делать дальше ...",
-          "title": "Вы завершили руководство «Первый Flow»"
-        },
-        "flow_basics": {
-          "description": "В Kestra <code>flow</code> — это основная единица оркестрации. Вы определяете его в YAML с метаданными и упорядоченными задачами.<br><br>Просмотрите пример структуры ниже, затем продолжайте создавать её шаг за шагом.",
-          "title": "Основы flow"
-        },
-        "save_flow": {
-          "description": "Сохранение фиксирует определение вашего flow, чтобы его можно было выполнить.",
-          "title": "Сохраните flow"
-        },
-        "save_flow_again": {
-          "description": "Теперь у вашего flow есть расписание и значение input по умолчанию для автоматических запусков.",
-          "title": "Сохраните flow"
-        },
-        "view_logs_status": {
-          "description": "Детали выполнения показывают статус запуска, тайминги и выходные логи на уровне задач.<br><br>Теперь откройте детали выполнения и нажмите <code>greet</code> на диаграмме Ганта, чтобы посмотреть логи.",
-          "title": "Проверьте выполнение"
-        }
-      },
-      "validation": {
-        "add_cron_trigger_cron": "Добавьте cron-выражение, например: `\"*/5 * * * *\"`.",
-        "add_cron_trigger_section": "Создайте секцию `triggers` с триггером расписания.",
-        "add_cron_trigger_type": "Установите тип триггера в `io.kestra.plugin.core.trigger.Schedule`.",
-        "add_id": "Добавьте ID flow вверху. Пример: `id: hello_flow`.",
-        "add_input_default_defaults": "Добавьте значение по умолчанию для `name`, например: `defaults: \"Kestra\"`.",
-        "add_input_default_id": "Оставьте существующий ID input как `name`.",
-        "add_input_default_section": "Вернитесь в `inputs` и оставьте один существующий input с именем `name` (не добавляйте второй input).",
-        "add_input_id": "Внутри `inputs` добавьте `id: name`.",
-        "add_input_section": "Создайте секцию `inputs` с одним input.",
-        "add_input_type": "Установите тип input в `STRING`.",
-        "add_log_task_id": "Дайте задаче ID, например: `id: greet`.",
-        "add_log_task_message": "Добавьте поле `script` в задачу.",
-        "add_log_task_pebble": "Используйте выражение Pebble в скрипте, чтобы оно использовало значение input (например: `inputs.name`).",
-        "add_log_task_section": "Создайте секцию `tasks` и добавьте первую задачу.",
-        "add_log_task_type": "Установите тип задачи в `io.kestra.plugin.scripts.python.Script`.",
-        "add_namespace": "Добавьте namespace вверху. Пример: `namespace: company.team`.",
-        "complete_step": "Вы почти у цели. Завершите этот шаг, чтобы продолжить.",
-        "edit_flow_from_execution": "Нажмите `Edit flow` в верхней панели, чтобы продолжить.",
-        "execute_flow": "Запустите flow один раз, чтобы продолжить.",
-        "fix_yaml": "Есть небольшая проблема с форматированием YAML. Исправьте её, затем продолжайте.",
-        "save_flow": "Нажмите Save, чтобы продолжить.",
-        "save_flow_again": "Нажмите Save ещё раз, чтобы продолжить.",
-        "view_logs_status": "Откройте детали выполнения и проверьте логи для `greet`."
-      },
-      "welcome": {
-        "additional_help": "Дополнительная помощь",
-        "badge": "Руководство",
-        "blueprints": "Шаблоны",
-        "docs": "Документация",
-        "guided_description": "Узнайте, как создать и запустить свой первый flow с помощью пошаговых инструкций.",
-        "guided_duration": "Рекомендуется большинству пользователей",
-        "guided_title": "Создайте свой первый flow",
-        "headline": "Создайте и запустите свой первый workflow за несколько минут",
-        "self_serve_description": "Перейдите прямо в редактор и создайте свой flow.",
-        "self_serve_note": "Для опытных пользователей",
-        "self_serve_title": "Создать flow с нуля",
-        "slack": "Сообщество Slack",
-        "tutorial": "Руководство"
-      }
+    "download": "Скачать",
+    "jsonl": "JSONL",
+    "concurrency_limit": {
+      "dialog_title": "Ограничения на параллельность",
+      "warning": "Изменение счетчика выполнения может нарушить параллелизм, поэтому выполнения могут превысить допустимый лимит."
     },
-    "open": "Открыть",
-    "open full page": "Открыть страницу полностью",
-    "open in new tab": "В новой вкладке",
-    "open in same tab": "В той же вкладке",
-    "open sidebar": "открыть боковую панель",
-    "open source": "Открытый исходный код",
-    "open_page": "Open page",
-    "optional": "Опционально",
-    "original execution": "Оригинальное выполнение",
-    "originalCreatedDate": "Оригинальная дата создания",
-    "outdated revision save confirmation": {
-      "confirm": "Вы хотите перезаписать это?",
-      "create": {
-        "description": "В этом namespace уже существует flow с таким же id.",
-        "details": "Сохранить для переопределения и создания новой ревизии.",
-        "title": "Flow уже существует"
-      },
-      "update": {
-        "description": "Редакция, которую вы редактируете, устарела.",
-        "details": "Проверьте вкладку Revisions для получения более подробной информации о последней версии.",
-        "title": "Устаревшая редакция"
-      }
+    "documentation": {
+      "documentation": "Документация",
+      "github": "Открыть проблему на GitHub"
     },
-    "output": "Вывод",
-    "outputs": "Выводы",
-    "override": {
-      "details": "Предыдущий flow можно восстановить на вкладке Revisions.",
-      "title": "Вы собираетесь перезаписать текущий flow"
-    },
-    "overview": "Обзор",
-    "page": {
-      "next": "Следующая страница",
-      "previous": "Предыдущая страница"
-    },
-    "panel actions": "Действия панели",
-    "parent execution": "Родительское выполнение",
-    "password": "Пароль",
-    "password empty constraint": "Неверное имя пользователя или пароль",
-    "password length constraint": "Пароль не должен превышать 256 символов",
-    "passwords do not match": "Пароли не совпадают",
-    "pause": "Пауза",
-    "pause backfill": "Приостановить заполнение",
-    "pause backfills": "Приостановить заполнения",
-    "pause confirm": "Вы уверены, что хотите приостановить выполнение <code>{id}</code>?",
-    "pause done": "Выполнение приостановлено",
-    "pause title": "Приостановить выполнение <code>{id}</code>.<br/>Обратите внимание, что текущие RUNNING задачи все равно будут обрабатываться, и выполнение придется возобновить вручную.",
-    "paused": "Пауза",
-    "playground": {
-      "clear_history": "Очистить историю",
-      "confirm_create": "Вы не можете запустить playground во время создания flow. Запуск playground создаст flow.",
-      "history": "Последние 10 запусков",
-      "play_icon_info": "Вы также можете нажать на значок Play в представлениях No-Code или Topology.",
-      "run_all_tasks": "Запустить все Tasks",
-      "run_task": "Запустить Task",
-      "run_task_and_downstream": "Запустить task и downstream",
-      "run_task_info": "Наведите курсор на любую task в редакторе Flow Code и нажмите кнопку \"Run task\", чтобы протестировать вашу task.",
-      "run_this_task": "Запустить этот task",
-      "title": "Песочница",
-      "toggle": "Песочница",
-      "tooltip_persistence": "Если вы выключите и снова включите Playground, информация останется, пока вы находитесь на странице."
-    },
-    "playground actions": "Действия Playground",
-    "plugin defaults exported": "Экспортированы значения по умолчанию плагина",
-    "plugin defaults imported": "Параметры плагина по умолчанию импортированы",
-    "plugin defaults not imported": "Некоторые значения по умолчанию для плагинов не удалось импортировать",
-    "pluginDefaults": {
-      "add": "Добавить плагин по умолчанию",
-      "add_subtitle": "Настройте новый плагин по умолчанию с его свойствами",
-      "cancel": "Отменить",
-      "custom": "Пользовательский плагин",
-      "custom_configure": "Пользовательский тип плагина - настройка с использованием YAML",
-      "custom_placeholder": "Введите тип плагина",
-      "custom_type": "Пользовательский тип плагина",
-      "edit": "Редактировать значение по умолчанию для плагина",
-      "edit_subtitle": "Изменить существующую конфигурацию плагина по умолчанию",
-      "form": "Форма",
-      "predefined": "Предопределенный плагин",
-      "select_predefined": "Выберите Предопределенный Плагин",
-      "show_yaml": "Показать YAML",
-      "title": "Настройки плагина по умолчанию",
-      "update": "Обновить плагин по умолчанию",
-      "use_custom": "Использовать пользовательский",
-      "yaml": "YAML",
-      "yaml_configuration": "Конфигурация YAML"
-    },
-    "pluginPage": {
-      "elementType": {
-        "apps": "Приложение",
-        "charts": "График",
-        "conditions": "Условие",
-        "logExporters": "Экспортер логов",
-        "secrets": "Секрет",
-        "taskRunners": "Запуск задачи",
-        "tasks": "Задача",
-        "triggers": "Триггер"
-      },
-      "group": {
-        "blueprints": "Чертежи ({count})",
-        "plugins": "Плагины ({count})",
-        "tasks": "Задачи ({count})"
-      },
+    "blueprints": {
+      "all": "Все",
+      "community": "Сообщество",
+      "create": "Создать blueprint",
+      "edit": "Редактировать blueprint",
+      "title": "Blueprints",
+      "empty": "Нет blueprints для отображения.",
       "header": {
-        "back": "Назад к плагинам",
-        "certified": "Сертифицированный",
-        "enterpriseEdition": "Энтерпрайз-версия"
+        "catch phrase": {
+          "1": "Первый шаг всегда самый трудный.",
+          "2": "Исследуйте blueprints, чтобы начать ваш следующий {kind}."
+        },
+        "alt": "Иконка Blueprints"
       },
-      "loadError": "Не удалось загрузить плагины. Пожалуйста, попробуйте снова.",
-      "noResults": "Нет плагинов, соответствующих вашему запросу.",
-      "notFound": "Этот плагин не найден.",
-      "overview": {
-        "createdBy": "Создано пользователем",
-        "latest": "Последние",
-        "linksResources": "Ссылки и ресурсы",
-        "managedBy": "Управляется",
-        "minKestraVersion": "Минимальная совместимая версия Kestra: {version}",
-        "minKestraVersionShort": "Минимальная версия Kestra {version}",
-        "pluginType": "Тип плагина",
-        "previousVersions": "Предыдущие версии",
-        "releaseNotes": "Примечания к выпуску",
-        "title": "Обзор",
-        "versions": "Версии"
+      "custom": "Пользовательские blueprints",
+      "flows": "Черновики Flow",
+      "apps": "Черновики приложений",
+      "dashboards": "Панель управления Blueprints",
+      "detail": {
+        "category": "Тип категории",
+        "links": "Ссылка и ресурсы",
+        "openInEditor": "Открыть в Edit Flow"
       },
-      "search": "Поиск среди {count}+ плагинов",
-      "searchTasks": "Искать {count} tasks",
-      "sort": {
-        "mostUsed": "Наиболее используемые",
-        "nameAsc": "Имя A-Я",
-        "nameDesc": "Имя Я-А",
-        "newest": "Новейшие"
-      },
-      "sortBy": "Сортировать по"
+      "missingPlugins": {
+        "title": "Отсутствующие plugins",
+        "description": "Этот blueprint использует tasks из plugin(s), которые не установлены в этом экземпляре: {plugins}. Установите их, чтобы использовать этот blueprint.",
+        "card": "Требуются plugin(s), не установленные в этом экземпляре: {plugins}",
+        "install": "Установить plugins"
+      }
     },
-    "plugin_default_already_exists": "Плагин по умолчанию для <code>{type}</code> уже существует.",
+    "use": "Использовать",
     "plugins": {
       "name": "Плагин",
       "names": "Плагины",
       "please": "Пожалуйста, выберите task справа, чтобы увидеть его документацию",
       "release": "Заметки о выпуске"
     },
-    "port": "Порт",
-    "prefill inputs": "Предзаполнение",
-    "pretty_json": "Pretty JSON",
-    "prev_execution": "Предыдущее выполнение",
-    "preview": {
-      "auto-view": "Автоматический просмотр",
-      "collapse": "Свернуть",
-      "expand": "Развернуть",
-      "force-editor": "Принудительный просмотр редактора",
-      "label": "Предварительный просмотр",
-      "next": "Далее",
-      "page_of": "Страница {current} из {total}",
-      "pagination_info": "Показаны строки {start}-{end} из {total}.",
-      "previous": "Предыдущий",
-      "rows_truncated": "Показано {shown} из {total} строк. Загрузите файл, чтобы просмотреть все данные.",
-      "showing_rows": "Показаны строки {start}-{end} из {total}",
-      "view": "Просмотр"
+    "last execution date": "Дата последнего выполнения",
+    "last execution state": "Последнее состояние",
+    "last X days count": "{count} за последние {days} дней",
+    "date range count": "{count} между {startDate} и {endDate}",
+    "date count": "{count} на {date}",
+    "revisions": "Редакции",
+    "no revisions found": "Для этого flow существует только одна редакция",
+    "no revisions": "Нет ревизий",
+    "see full revision": "Посмотреть полную редакцию",
+    "side-by-side": "бок о бок",
+    "line-by-line": "построчно",
+    "template": "Шаблон",
+    "template creation": "Создание шаблона",
+    "templates": "Шаблоны",
+    "templates deprecated": "Шаблоны устарели. Пожалуйста, используйте subflows вместо них. См. <a href=\"https://kestra.io/docs/migration-guide/0.11.0/templates?utm_source=app&utm_medium=referral&utm_campaign=template-inlinedoc\" target=\"_blank\">раздел миграции</a>, объясняющий, как можно мигрировать с шаблонов на subflows.",
+    "no result": "Нет результатов для отображения.",
+    "empty search": "Результаты поиска пусты",
+    "trigger": "Trigger",
+    "no_trigger": "Триггер недоступен.",
+    "triggers": "Triggers",
+    "triggers_header_description": "Просматривайте, добавляйте и управляйте triggers для автоматизации ваших flows. Выберите из вариантов: сделать ваш flow инструментом AI, запланировать, добавить webhook trigger, опрос изменений во внешних приложениях или слушатели событий в реальном времени.",
+    "triggers_tabs_add": "Добавить",
+    "triggers_tabs_manage": "Управление",
+    "triggers_add_search_placeholder": "Поиск triggers...",
+    "triggers_add_filter_core": "Ядро",
+    "triggers_add_filter_realtime": "Реальное время",
+    "triggers_add_filter_all": "Все",
+    "triggers_add_filter_app": "Приложение",
+    "triggers_add_empty_title": "Триггеры не найдены",
+    "triggers_add_ee_tooltip": "Этот trigger требует Enterprise Edition.",
+    "triggers_add_category_empty": "В этой категории нет triggers.",
+    "triggers_add_card_add_to_flow": "Добавить в flow",
+    "triggers_add_card_add": "Добавить",
+    "triggers_add_modal_title": "{name}",
+    "triggers_add_modal_tab_form": "Форма",
+    "triggers_add_modal_tab_source": "Источник",
+    "triggers_add_modal_tab_documentation": "Документация",
+    "triggers_add_modal_namespace_placeholder": "Выберите namespace",
+    "triggers_add_modal_flow_placeholder": "Выберите flow",
+    "triggers_add_modal_trigger_id": "Идентификатор Trigger",
+    "triggers_add_modal_trigger_id_placeholder": "Уникальный идентификатор для этого trigger",
+    "triggers_add_modal_properties_hint": "Настройте свойства trigger в редакторе flow после добавления trigger.",
+    "triggers_add_modal_ee_notice": "Этот trigger требует Enterprise Edition.",
+    "triggers_add_modal_add_button": "Добавить Trigger в Flow",
+    "trigger details": "Подробности trigger",
+    "triggerflow disabled": "Trigger отключен в определении flow",
+    "last trigger date": "Дата последнего срабатывания",
+    "trigger_states": "Состояния",
+    "context updated date": "Дата обновления контекста",
+    "state updated date": "Дата обновления состояния",
+    "next evaluation date": "Следующая дата оценки",
+    "last evaluation date": "Дата последней оценки",
+    "last trigger date tooltip": "Когда trigger выполнялся в последний раз. Может быть в прошлом при запуске backfill.",
+    "context updated date tooltip": "Когда контекст trigger был обновлен в последний раз. Это происходит, когда выполняется execution, завершается (блокировка снята) или после оценки (даже если execution не происходит).",
+    "next evaluation date tooltip": "Когда trigger будет оцениваться в следующий раз, на основе его интервала. Не всегда совпадает с датой следующей Ausführung, если условия не выполнены.",
+    "last evaluation date tooltip": "When the trigger was last evaluated by the scheduler, regardless of whether it produced an execution.",
+    "conditions": "Условия",
+    "triggerId": "Идентификатор Trigger",
+    "tenantId": "ID арендатора",
+    "codeDisabled": "Отключено в flow",
+    "paused": "Пауза",
+    "running": "RUNNING",
+    "Fold auto": "Редактор: автоматическое сворачивание многострочных строк",
+    "Hover description": "Редактор: Показать описание поля при наведении на key или value",
+    "Fold content lines": "Свернуть многострочные строки",
+    "Unfold content lines": "Развернуть многострочные строки",
+    "Total": "Всего",
+    "sub flow": "Подпроцесс",
+    "execute": "Выполнить",
+    "execute flow behaviour": "Выполнить flow",
+    "open in same tab": "В той же вкладке",
+    "open in new tab": "В новой вкладке",
+    "execute the flow": "Выполнить flow <code>{id}</code>",
+    "execute flow now ?": "Вы хотите выполнить этот flow?",
+    "discard execution confirmation": "У вас есть несохраненные input. Вы уверены, что хотите отменить эту execution?",
+    "discard changes confirmation": "У вас есть несохраненные изменения. Вы уверены, что хотите их отменить?",
+    "Default namespace": "Namespace по умолчанию",
+    "Default log level": "Уровень log по умолчанию",
+    "unsaved changed ?": "У вас есть несохраненные изменения, вы хотите покинуть эту страницу?",
+    "unsaved changes": "Несохраненные изменения",
+    "unsaved changes warning": "У вас есть несохраненные изменения. Если вы покинете эту страницу, ваши изменения будут потеряны.",
+    "leave page": "Покинуть страницу",
+    "open full page": "Открыть страницу полностью",
+    "drill down preview": "Предпросмотр",
+    "Editor theme": "Тема редактора",
+    "Editor fontsize": "Размер шрифта редактора",
+    "Editor fontfamily": "Шрифт редактора",
+    "errors": {
+      "401": {
+        "title": "Неавторизован",
+        "content": "Вам нужно пройти аутентификацию для доступа к этой странице."
+      },
+      "403": {
+        "title": "Доступ запрещен",
+        "content": "У вас нет необходимых прав для доступа к этой странице."
+      },
+      "404": {
+        "title": "Страница не найдена",
+        "content": "Запрашиваемый URL не найден на этом сервере.<br />Это все, что мы знаем.",
+        "flow or execution": "Flow или выполнение, которое вы ищете, не существует."
+      }
     },
-    "pricing": "Цены",
-    "product_tour": "Тур по продукту",
-    "properties": {
-      "hidden": "Скрыто в таблице",
-      "hint": "Выберите видимые столбцы",
-      "label": "Свойства",
-      "shown": "Показано в таблице"
+    "back_to_dashboard": "Вернуться на панель управления",
+    "copy all logs": "Скопировать все Logs",
+    "copy logs": "Копировать логи",
+    "fix_with_ai": "Исправить с помощью AI",
+    "download logs": "Скачать логи",
+    "delete logs": "Удалить логи",
+    "delete_all_logs": "Вы уверены, что хотите удалить все логи?",
+    "delete_log": "Вы уверены, что хотите удалить log?",
+    "toggle fullscreen": "Переключить полноэкранный режим",
+    "copied": "Скопировано",
+    "tags": "Теги",
+    "disabled flow title": "Этот flow отключен",
+    "disabled flow desc": "Этот flow отключен, пожалуйста, включите его для выполнения.",
+    "label": "Метка",
+    "labels": "Метки",
+    "label filter placeholder": "Метка как 'key:value'",
+    "execution labels": "Метки выполнения",
+    "wrong labels": "Пустой key или value не допускается в метках",
+    "feeds": {
+      "title": "Что нового в Kestra",
+      "heading": "Все о Kestra.",
+      "subheading": "Последние обновления, руководства и истории"
     },
-    "queued duration": "Время в очереди",
-    "quotas": "Квоты",
-    "reach us": "Свяжитесь с нами",
-    "read-more": "Узнать больше о",
-    "readonly property": "Свойство только для чтения",
-    "recent_executions": "Недавние выполнения",
-    "refresh": "Обновить",
-    "reject": "Отклонить",
-    "relative": "Относительный",
-    "relative end date": "Относительная дата окончания",
-    "relative start date": "Относительная дата начала",
-    "remove label": "Удалить label",
-    "remove this item": "Удалить этот элемент",
-    "remove_bookmark": "Вы уверены, что хотите удалить эту закладку?",
-    "replay": "Повтор",
-    "replay confirm": "Вы уверены, что хотите повторить это выполнение <code>{id}</code> и создать новое?",
-    "replay execution description": "Это создаст новое выполнение на основе выбранного выполнения.",
-    "replay execution title": "Повторное выполнение",
-    "replay from beginning tooltip": "Создать аналогичное выполнение, начиная с начала",
-    "replay from task tooltip": "Создать аналогичное выполнение, начиная с задачи <code>{taskId}</code>",
-    "replay inputs": "Входные данные",
-    "replay inputs new required": "Эта редакция имеет inputs. Вам будет предложено их заполнить.",
-    "replay latest revision": "Повтор с использованием последней редакции",
-    "replay select taskrun": "Выберите выполнение task для повторного воспроизведения из:",
-    "replay the execution": "Повторить выполнение <code>{executionId}</code> для flow <code>{flowId}</code>",
-    "replay using": "Повторное воспроизведение с использованием",
-    "replay with inputs": "Воспроизвести с inputами",
-    "replayed": "Выполнение воспроизведено",
-    "required field": "Обязательное поле",
-    "reset": "Перезапустить",
-    "reset to defaults": "Сбросить настройки по умолчанию",
-    "restart": "Перезапуск",
-    "restart change revision": "Вы можете изменить редакцию, которая будет использоваться для нового выполнения.",
-    "restart confirm": "Вы уверены, что хотите перезапустить выполнение <code>{id}</code>?",
-    "restart execution title": "Перезапустить выполнение",
-    "restart latest revision": "Перезапустить последнюю редакцию",
-    "restart tooltip": "Перезапустить выполнение с <code>{state}</code> task",
-    "restart trigger": {
-      "button": "Перезапустить trigger",
-      "tooltip": "Перезапустить trigger"
-    },
-    "restarted": "Выполнение перезапущено",
+    "delete execution running": "<div class=\"alert alert-warning mt-2 mb-0\">Это выполнение все еще выполняется, удаление его не остановит.<br />Вам нужно убить выполнение, чтобы остановить его.</div>",
     "restore": "Восстановить",
     "restore confirm": "Вы уверены, что хотите восстановить ревизию <code>{revision}</code>?",
+    "bulk delete": "Вы уверены, что хотите удалить <code>{executionCount}</code> выполнение(я)?",
+    "bulk replay": "Вы уверены, что хотите воспроизвести <code>{executionCount}</code> выполнение(я)?",
+    "bulk change state": "Вы уверены, что хотите изменить состояние выполнения <code>{executionCount}</code>?",
+    "bulk resume": "Вы уверены, что хотите возобновить <code>{executionCount}</code> выполнение(я)?",
+    "bulk pause": "Вы уверены, что хотите приостановить выполнение <code>{executionCount}</code>?",
+    "bulk unqueue": "Вы уверены, что хотите удалить из очереди выполнение(я) <code>{executionCount}</code>?",
+    "bulk force run": "Вы уверены, что хотите принудительно запустить выполнение <code>{executionCount}</code>?<br/><br/>WARNING: принудительный запуск выполнения не гарантирован и может создать дублирующие выполнения задач.<br/><br/>Будут выполнены следующие переходы:<br/><ul><li>CREATED задачи будут переведены в состояние RUNNING.</li><li>RUNNING задачи будут повторно отправлены.</li><li>QUEUED задачи будут извлечены из очереди.</li><li>PAUSED задачи будут возобновлены.</li></ul>",
+    "bulk restart": "Вы уверены, что хотите перезапустить <code>{executionCount}</code> выполнение(я)?",
+    "bulk kill": "Вы уверены, что хотите убить <code>{executionCount}</code> выполнение(я)?",
+    "selection": {
+      "selected": "<strong>{count}</strong> выбрано",
+      "all": "Выбрать все ({count})"
+    },
+    "cancel": "Отмена",
+    "errorLogs": "Логи ошибок",
+    "welcome_page": {
+      "welcome": "Добро пожаловать в Kestra",
+      "guide": "Нужна помощь в выполнении вашего первого flow?"
+    },
+    "product_tour": "Тур по продукту",
+    "executions replayed": "<code>{executionCount}</code> выполнение(я) воспроизведено",
+    "executions state changed": "Состояние выполнения <code>{executionCount}</code> было изменено",
+    "executions resumed": "<code>{executionCount}</code> выполнение(я) возобновлено",
+    "executions paused": "<code>{executionCount}</code> выполнение(я) PAUSED",
+    "executions unqueue": "<code>{executionCount}</code> выполнение(я) в очереди",
+    "executions force run": "<code>{executionCount}</code> выполнение(я) принудительный запуск",
+    "executions restarted": "<code>{executionCount}</code> выполнение(я) перезапущено",
+    "executions killed": "<code>{executionCount}</code> выполнение(я) убито",
+    "executions deleted": "<code>{executionCount}</code> выполнение(я) удалено",
+    "invalid bulk replay": "Не удалось воспроизвести выполнения",
+    "invalid bulk resume": "Не удалось возобновить выполнения",
+    "invalid bulk pause": "Не удалось приостановить выполнения",
+    "invalid bulk unqueue": "Не удалось удалить выполнения из очереди",
+    "invalid bulk force run": "Не удалось принудительно запустить executions",
+    "invalid bulk restart": "Не удалось перезапустить выполнения",
+    "invalid bulk kill": "Не удалось убить выполнения",
+    "invalid bulk delete": "Не удалось удалить выполнения",
+    "execution not found": "Выполнение {executionId} не найдено.",
+    "execution not in state PAUSED": "Выполнение <code>{executionId}</code> не в состоянии PAUSED",
+    "execution not in state FAILED": "Выполнение <code>{executionId}</code> не в состоянии FAILED",
+    "execution already finished": "Выполнение <code>{executionId}</code> уже завершено",
     "restore revision": "Вы уверены, что хотите восстановить ревизию <code>{revision}</code>?",
-    "resume": "Возобновить",
-    "resume from breakpoint done": "Выполнение возобновлено с точки останова",
-    "resume from breakpoint title": "Возобновить выполнение <code>{id}</code> с точки останова",
-    "resumed confirm": "Вы уверены, что хотите возобновить выполнение <code>{id}</code>?",
-    "resumed done": "Выполнение возобновлено",
-    "resumed title": "Возобновить выполнение <code>{id}</code>",
-    "reuse original inputs": "Повторное использование оригинальных input",
-    "reuse_original_inputs": "Повторно использовать оригинальные inputы",
-    "review your inputs": "Проверьте введённые данные",
-    "revision": "Редакция",
-    "revision deleted": "Ревизия {revision} была успешно удалена",
-    "revisions": "Редакции",
-    "row count": "Количество строк",
-    "run task in playground": "Запустить task в playground",
+    "seeing old revision": "Вы просматриваете старую ревизию: {revision}",
+    "export": "Экспорт",
+    "exports": "Экспорты",
+    "export_csv": "Экспортировать как CSV",
+    "template export": "Вы уверены, что хотите экспортировать <code>{templateCount}</code> шаблон(ы)?",
+    "templates exported": "Шаблоны экспортированы",
+    "export all templates": "Экспортировать все шаблоны",
+    "flow_export": "Экспорт flow",
+    "flow export": "Вы уверены, что хотите экспортировать <code>{flowCount}</code> flow(ы)?",
+    "flows exported": "<code>{count}</code> Flow(s) экспортировано",
+    "export all flows": "Экспортировать все flows",
+    "import": "Импорт",
+    "disable": "Отключить",
+    "enable": "Включить",
+    "enabled": "Включено",
+    "template delete": "Вы уверены, что хотите удалить <code>{templateCount}</code> шаблон(ы)?",
+    "flow delete": "Вы уверены, что хотите удалить <code>{flowCount}</code> flow(ы)?",
+    "templates deleted": "<code>{count}</code> Шаблон(ы) удалены",
+    "flows deleted": "<code>{count}</code> Flow(ы) удалены",
+    "flow disable": "Вы уверены, что хотите отключить <code>{flowCount}</code> flow(ы)?",
+    "flow enable": "Вы уверены, что хотите включить <code>{flowCount}</code> flow(ы)?",
+    "flows disabled": "<code>{count}</code> Flow(ы) отключены",
+    "flows enabled": "<code>{count}</code> Flow(ы) включены",
+    "flow-no-dependencies": "Ваш flow не имеет зависимостей",
+    "flow-dependencies": "зависимости",
+    "read-more": "Узнать больше о",
+    "in-our-documentation": "в нашей документации.",
+    "dependencies": "Зависимости",
+    "see dependencies": "Просмотреть зависимости",
+    "see timeline": "Просмотреть временную шкалу",
     "run timeline": "Хронология выполнения",
-    "runners": "Запуски",
-    "running": "RUNNING",
-    "running duration": "Время выполнения",
-    "save": "Сохранить",
+    "dependencies missing acls": "Нет разрешений на этот flow",
+    "dependencies delete flow": "Этот flow имеет зависимости. Удаление его предотвратит выполнение их зависимостей.<br /><br /> Вот список затронутых flows:",
+    "expand dependencies": "Развернуть зависимости",
+    "reset": "Перезапустить",
+    "show task documentation": "Показать документацию задачи",
+    "hide task documentation": "Скрыть документацию задачи",
+    "show task documentation in editor": "Показать документацию задачи в редакторе",
+    "show documentation": "Показать документацию",
+    "focus task": "Нажмите на любой элемент, чтобы увидеть его документацию.",
+    "validate": "Проверить",
+    "add error handler": "Добавить обработчик ошибок",
+    "taskDefaults": "Задача по умолчанию",
+    "disabled": "Отключено",
+    "before": "до",
+    "after": "после",
+    "add at position": "Добавить {position} <code>{task}</code>",
+    "create first task": "Создайте свою первую задачу",
+    "dynamic": "Динамический",
+    "choice": "Выбор",
+    "sequential": "Последовательный",
+    "can not delete": "Невозможно удалить",
+    "can not have less than 1 task": "Не может быть менее одного задания",
+    "task id already exists": "ID задачи уже существует",
+    "Task Id already exist in the flow": "Task Id {taskId} уже существует в flow.",
+    "task id": "ID задачи",
+    "taskid column details": "Последний task выполняется и количество его попыток.",
+    "flow already exists": "Flow уже существует",
+    "flow already exists message": "Поток <code>{id}</code> уже существует в namespace <code>{namespace}</code>. Хотите создать новую ревизию?",
+    "plugin_default_already_exists": "Плагин по умолчанию для <code>{type}</code> уже существует.",
+    "namespace not allowed": "Namespace не разрешен",
+    "switch-view": "Переключить вид",
+    "source and topology": "Источник и топология",
+    "source and doc": "Источник и документация",
+    "source and blueprints": "Источник и blueprints",
+    "editor": "Редактор",
+    "error in editor": "В редакторе найдена ошибка",
+    "delete task confirm": "Вы хотите удалить task <code>{taskId}</code>?",
+    "can not save": "Невозможно сохранить",
+    "flow must not be empty": "Flow не должен быть пустым",
+    "flow must have id and namespace": "Flow должен иметь id и namespace.",
+    "flow creation denied in namespace": "У вас нет разрешения на создание flows в namespace `{namespace}`.",
+    "readonly property": "Свойство только для чтения",
+    "namespace and id readonly": "Свойства `namespace` и `id` не могут быть изменены — они установлены на начальные значения. Если вы хотите переименовать flow или изменить его namespace, вы можете создать новый flow и удалить старый.",
+    "avg": "Среднее",
+    "sum": "Сумма",
+    "min": "Мин",
+    "max": "Макс",
+    "bar": "Бар",
+    "line": "Линия",
+    "metric": "Метрика",
+    "aggregation": "Агрегация",
+    "chart type": "Тип диаграммы",
+    "metric choice": "Для этого flow метрики недоступны",
+    "of": "из",
+    "see_all_states": "Просмотреть все состояния",
     "save draft": {
       "message": "Черновик сохранен",
       "retrieval": {
@@ -1680,164 +724,336 @@
         "existing": "Черновик Flow <code>{flowFullName}</code> сохранен, хотите продолжить редактирование flow?"
       }
     },
-    "save task": "Сохранить задачу",
-    "save_and_execute": "Сохранить и выполнить",
-    "save_as_draft": "Сохранить как черновик",
-    "saved": "Успешно сохранено",
-    "saved as draft": "Успешно сохранено как черновик",
-    "saved as draft done": "<em>{name}</em> успешно сохранён как черновик",
-    "saved done": "<em>{name}</em> успешно сохранен",
-    "scheduleDate": "Дата расписания",
-    "scope_filter": {
-      "all": "Все {label}",
-      "system": "Система {label}",
-      "system_description": "Системное обслуживание {label}",
-      "user": "Пользователь {label}",
-      "user_description": "Обычный пользователь инициировал {label}"
+    "title": "Заголовок",
+    "api": "API",
+    "more_actions": "Больше действий",
+    "expand error": "Развернуть только неудачные tasks",
+    "expand all": "Развернуть все",
+    "collapse all": "Свернуть все",
+    "expand": "Развернуть",
+    "collapse": "Свернуть",
+    "filter by this value": "Filter by this value",
+    "filter_for": "Filter for",
+    "filter_out": "Filter out",
+    "copy_value": "Copy value",
+    "open_page": "Open page",
+    "logs_copied": "Logs copied to your clipboard",
+    "expand_by_default": "Expand structured logs by default",
+    "show raw": "Show raw",
+    "similar lines": "similar lines",
+    "download_logs_description": "Choose which logs to export. Filters default to your current view.",
+    "display_settings": "Display settings",
+    "density": "Density",
+    "density_compact": "Compact",
+    "density_normal": "Normal",
+    "density_expanded": "Expanded",
+    "pretty_json": "Pretty JSON",
+    "body_line_clamp": "Limit line height",
+    "font size": "Font size",
+    "log expand setting": "Отображение logs по умолчанию",
+    "environment": "Окружение",
+    "environment name setting": "Имя окружения",
+    "environment color setting": "Цвет окружения",
+    "slack support": "Задайте любой вопрос через Slack",
+    "join community": "Присоединяйтесь к сообществу",
+    "join_slack": "Присоединиться к Slack",
+    "kestra": "Kestra",
+    "reach us": "Свяжитесь с нами",
+    "new version": "Доступна новая версия {version}!",
+    "error detected": "Обнаружена ошибка(и).",
+    "warning detected": "Обнаружены предупреждения",
+    "informative notice": "Примечание(я)",
+    "cannot swap tasks": "Невозможно поменять местами tasks",
+    "open": "Открыть",
+    "dependency task": "Задача {taskId} является зависимостью другого задачи",
+    "administration": "Администрирование",
+    "admin": "Администратор",
+    "main_configuration": "Основная конфигурация",
+    "commit_id": "Идентификатор коммита",
+    "evaluation lock date": "Дата блокировки оценки",
+    "unlock trigger": {
+      "tooltip": {
+        "execution": "Выполнение запущено для этого trigger",
+        "evaluation": "Trigger в настоящее время оценивается"
+      },
+      "confirmation": "Вы уверены, что хотите разблокировать trigger?",
+      "warning": "Это может привести к параллельным выполнениям для одного и того же trigger и должно рассматриваться как крайняя мера.",
+      "button": "Разблокировать trigger",
+      "success": "Trigger разблокирован"
     },
-    "search": "Поиск",
-    "search blueprint": "Поиск чертежей",
-    "search filters": {
-      "filter name": "Имя фильтра",
-      "filters": "Фильтры",
-      "manage": "Управление поисковыми фильтрами",
-      "manage desc": "Управление сохраненными поисковыми фильтрами",
-      "save filter": "Сохранить фильтр",
-      "saved": "Сохраненные фильтры"
+    "restart trigger": {
+      "button": "Перезапустить trigger",
+      "tooltip": "Перезапустить trigger"
     },
-    "search term in message": "Поиск по термину в сообщении",
-    "search_docs": "Поиск",
-    "searching": "Поиск...",
-    "secret": {
-      "add": "Создать",
-      "inherited": "Унаследованные секреты",
-      "isReadOnly": "Секрет доступен только для чтения",
-      "names": "Cекреты",
-      "update": "Обновить секрет '{name}'"
-    },
-    "security_advice": {
-      "content": "Включите базовую аутентификацию для защиты вашего экземпляра.",
-      "enable": "Включить аутентификацию",
-      "switch_text": "Больше не показывать",
-      "title": "Защитите ваш экземпляр"
-    },
-    "see dependencies": "Просмотреть зависимости",
-    "see full revision": "Посмотреть полную редакцию",
-    "see timeline": "Просмотреть временную шкалу",
-    "see_all_states": "Просмотреть все состояния",
-    "seeing old revision": "Вы просматриваете старую ревизию: {revision}",
-    "select": "Выберите ваш {{section}}",
-    "select a state": "Выберите состояние",
-    "select datetime": "Выберите дату",
-    "select view": "Выберите вид",
-    "selected": "Выбрано",
-    "selection": {
-      "all": "Выбрать все ({count})",
-      "selected": "<strong>{count}</strong> выбрано"
-    },
-    "sequential": "Последовательный",
-    "server type": "Тип сервера",
+    "trigger disabled": "Триггер отключен в источнике Flow",
+    "flow source not found": "Источник flow не найден",
+    "date format": "Формат даты",
+    "timezone": "Часовой пояс",
+    "add task": "Добавить задачу",
+    "unable to generate graph": "Произошла ошибка при генерации графа, что препятствует отображению топологии.",
+    "attempts": "Попытка(и)",
+    "flow deleted, you can restore it": "Flow был удален, и это представление только для чтения. Вы все еще можете его восстановить.",
+    "workers": "Workers",
+    "worker group": "Группа workers",
+    "worker group key": "Ключ группы Worker",
+    "worker group fallback": "Группа Worker резервный вариант",
+    "version": "Версия",
     "services": "Сервисы",
+    "server type": "Тип сервера",
+    "hostname": "Имя хоста",
+    "port": "Порт",
+    "management port": "Порт управления",
+    "file preview truncated": "Отображаемое содержимое было усечено",
+    "file unavailable": "Файл недоступен",
+    "file unavailable description": "Этот файл больше недоступен — возможно, он был удален или срок его действия истек.",
+    "row count": "Количество строк",
+    "encoding": "Кодировка",
+    "show": "Показать",
+    "advanced configuration": "Другие свойства",
+    "all executions": "Все выполнения",
+    "trigger execution id": "Trigger Execution Id",
+    "execution_status": "Выполнение:",
+    "no_tasks_running": "Ещё нет запущенных tasks.",
+    "execution_starts_progress": "Как только начнется выполнение, вы увидите здесь обновления о ходе выполнения.",
+    "triggers_state": {
+      "state": "Состояние",
+      "options": {
+        "enabled": "Включено",
+        "disabled": "Отключено"
+      }
+    },
+    "trigger filter": {
+      "title": "Фильтровать дочерние выполнения",
+      "options": {
+        "ALL": "Все выполнения",
+        "CHILD": "Дочерние выполнения",
+        "MAIN": "Родительские выполнения"
+      }
+    },
+    "show chart": "Показать диаграмму",
+    "namespace files": {
+      "toggle": {
+        "show": "Показать файлы namespace",
+        "hide": "Скрыть файлы namespace"
+      },
+      "filter": "Фильтр",
+      "new_file": "Новый файл",
+      "no_items": {
+        "heading": "В вашем namespace пока нет файлов.",
+        "paragraph": "Создайте или импортируйте файлы для обмена кодом между flows в вашем namespace."
+      },
+      "no_selection": {
+        "heading": "Файлы не выбраны",
+        "description": "Выберите файл из дерева, чтобы просмотреть его содержимое."
+      },
+      "tree": {
+        "expand": "Развернуть все папки",
+        "collapse": "Свернуть все папки"
+      },
+      "create": {
+        "label": "Создать",
+        "file": "Создать файл",
+        "file_already_exists": "Файл с таким именем уже существует",
+        "file_conflicts_with_folder": "Папка с таким именем уже существует",
+        "file_error": "Произошла ошибка при создании файла",
+        "folder": "Создать папку",
+        "folder_already_exists": "Папка с таким именем уже существует",
+        "folder_conflicts_with_file": "Файл с таким именем уже существует",
+        "folder_error": "Произошла ошибка при создании папки"
+      },
+      "rename": {
+        "label": "Переименовать",
+        "file": "Переименовать файл",
+        "folder": "Переименовать папку",
+        "new_file": "Новое имя с расширением:",
+        "new_folder": "Новое имя папки:"
+      },
+      "delete": {
+        "label": "Удалить",
+        "file": "Удалить файл",
+        "folder": "Удалить папку",
+        "files": "Удалить {count} выбранных файлов",
+        "folders": "Удалить {count} выбранных папок"
+      },
+      "import": {
+        "import": "Импортировать",
+        "files": "Импортировать файлы",
+        "folder": "Импортировать папку",
+        "success": "Файл(ы) успешно импортированы",
+        "error": "Произошли ошибки при импорте файла(ов)"
+      },
+      "export": "Экспортировать файлы namespace",
+      "export_single": "Экспортировать файл",
+      "dialog": {
+        "name": {
+          "file": "Имя с расширением:",
+          "folder": "Имя папки:"
+        },
+        "parent_folder": "Родительская папка:",
+        "deletion": {
+          "confirm": "Подтвердить",
+          "title": "Подтвердите удаление содержимого",
+          "files": "Вы уверены, что хотите удалить <code>{count}</code> файл(ы)?",
+          "folders": "Вы уверены, что хотите удалить <code>{count}</code> папку(и) и все её содержимое?",
+          "mixed": "Вы уверены, что хотите удалить папку(и) <code>{folders}</code> и файл(ы) <code>{files}</code>?",
+          "file_single": "Вы уверены, что хотите удалить файл <code>{name}</code>?",
+          "folder_single": "Вы уверены, что хотите удалить папку <code>{name}</code> и все её содержимое?"
+        }
+      },
+      "revisions": {
+        "history": "История изменений",
+        "restore": {
+          "success": "Файл успешно восстановлен до предыдущей версии"
+        }
+      },
+      "path": {
+        "copy": "Скопировать путь",
+        "success": "Путь скопирован в буфер обмена",
+        "error": "Произошли ошибки при копировании пути в буфер обмена"
+      }
+    },
+    "continue backfill": "Продолжить заполнение",
+    "delete backfill": "Удалить backfill",
+    "pause backfill": "Приостановить заполнение",
+    "continue backfills": "Продолжить заполнения",
+    "delete backfills": "Удалить заполнения",
+    "pause backfills": "Приостановить заполнения",
+    "backfill executions": "Выполнения заполнение",
+    "execute backfill": "Выполнить заполнение",
+    "backfill paused": "Заполнение приостановлено",
+    "backfill running": "Запуск Backfill",
+    "relative": "Относительный",
+    "relative start date": "Относительная дата начала",
+    "relative end date": "Относительная дата окончания",
+    "now": "Сейчас",
+    "absolute": "Абсолютный",
+    "backfill": "Заполнение",
+    "Set labels tooltip": "Установить метки для выполнения",
+    "Set labels": "Установить метки",
+    "manage labels": "Управление labels",
+    "Set labels to execution": "Добавить или обновить метки выполнения <code>{id}</code>",
+    "Set labels done": "Метки выполнения успешно установлены",
+    "bulk set labels": "Вы уверены, что хотите установить метки для <code>{executionCount}</code> выполнения(й)?",
+    "dependencies loaded": "Зависимости загружены",
+    "loaded x dependencies": "{count} зависимости загружены",
+    "security_advice": {
+      "title": "Защитите ваш экземпляр",
+      "content": "Включите базовую аутентификацию для защиты вашего экземпляра.",
+      "switch_text": "Больше не показывать",
+      "enable": "Включить аутентификацию"
+    },
+    "true": "Истина",
+    "false": "Ложь",
+    "undefined": "Неопределено",
+    "execution-include-non-terminated": "Включить незавершенные выполнения?",
+    "execution-warn-title": "Важное предупреждение!",
+    "execution-warn-deleting-still-running": "Мы настоятельно рекомендуем отменить это действие и сначала завершить все текущие executions. Удаление незавершенных executions может привести к проблемам с concurrency, несоответствиям в управлении зависимостями flow и появлению \"зомби\"-процессов на вашем экземпляре, что может ухудшить производительность системы. Убедитесь, что вы полностью понимаете эти риски, прежде чем продолжить удаление.",
+    "originalCreatedDate": "Оригинальная дата создания",
+    "welcome": {
+      "menu": "Welcome",
+      "tour": {
+        "title": "Пройдите экскурсию по продукту",
+        "text": "Выберите ваш сценарий использования и следуйте пошаговому руководству, чтобы изучить возможности и функции Kestra. ❤️"
+      },
+      "tutorial": {
+        "title": "Учебник",
+        "text": "* <a href=\"https://kestra.io/tutorial-videos/all?utm_source=app&utm_medium=referral&utm_campaign=welcome-tutorial\" target=\"_blank\">Видеоуроки</a>  \n* <a href=\"https://kestra.io/docs?utm_source=app&utm_medium=referral&utm_campaign=welcome-tutorial\" target=\"_blank\">Документация</a>  \n* <a href=\"https://kestra.io/blueprints?utm_source=app&utm_medium=referral&utm_campaign=welcome-tutorial\" target=\"_blank\">Blueprints</a>"
+      },
+      "help": {
+        "title": "Нужна помощь?",
+        "text": "Задайте любой вопрос в нашем сообществе Slack. Если вы застряли, мы здесь, чтобы помочь вам. ✋"
+      }
+    },
+    "pluginPage": {
+      "search": "Поиск среди {count}+ плагинов",
+      "searchTasks": "Искать {count} tasks",
+      "noResults": "Нет плагинов, соответствующих вашему запросу.",
+      "loadError": "Не удалось загрузить плагины. Пожалуйста, попробуйте снова.",
+      "notFound": "Этот плагин не найден.",
+      "elementType": {
+        "tasks": "Задача",
+        "triggers": "Триггер",
+        "conditions": "Условие",
+        "taskRunners": "Запуск задачи",
+        "charts": "График",
+        "apps": "Приложение",
+        "logExporters": "Экспортер логов",
+        "secrets": "Секрет"
+      },
+      "sortBy": "Сортировать по",
+      "sort": {
+        "nameAsc": "Имя A-Я",
+        "nameDesc": "Имя Я-А",
+        "newest": "Новейшие",
+        "mostUsed": "Наиболее используемые"
+      },
+      "group": {
+        "plugins": "Плагины ({count})",
+        "tasks": "Задачи ({count})",
+        "blueprints": "Чертежи ({count})"
+      },
+      "overview": {
+        "title": "Обзор",
+        "versions": "Версии",
+        "latest": "Последние",
+        "releaseNotes": "Примечания к выпуску",
+        "previousVersions": "Предыдущие версии",
+        "createdBy": "Создано пользователем",
+        "managedBy": "Управляется",
+        "pluginType": "Тип плагина",
+        "linksResources": "Ссылки и ресурсы",
+        "minKestraVersion": "Минимальная совместимая версия Kestra: {version}",
+        "minKestraVersionShort": "Минимальная версия Kestra {version}"
+      },
+      "header": {
+        "enterpriseEdition": "Энтерпрайз-версия",
+        "certified": "Сертифицированный",
+        "back": "Назад к плагинам"
+      }
+    },
+    "no inputs": "Этот flow не имеет входных данных.",
+    "admin_preferences": "Preferences",
     "settings": {
+      "label": "Настройки",
+      "updated": "{name} обновлено",
       "blocks": {
         "configuration": {
-          "descriptions": {
-            "auto_refresh_interval": "Секунды между автоматическими обновлениями данных на страницах списков.",
-            "default_namespace": "Используется при создании новых flow без namespace.",
-            "editor_type": "Редактор, отображаемый при открытии flow в первый раз.",
-            "execute_default_tab": "Вкладка выбрана при переходе к выполнению.",
-            "execute_flow": "Где результаты выполнения открываются после запуска.",
-            "flow_default_tab": "Вкладка выбрана при переходе к flow.",
-            "log_display": "Как отображаются логи при открытии выполнения.",
-            "log_level": "Минимальный уровень log, отображаемый в execution logs.",
-            "playground": "Запускайте задачи по отдельности в редакторе playground.",
-            "triggers_default_tab": "Вкладка выбрана при переходе на страницу триггеров."
-          },
+          "label": "Основная конфигурация",
           "fields": {
-            "auto_refresh_interval": "Интервал автоматического обновления",
-            "default_namespace": "Namespace по умолчанию",
-            "editor_type": "Тип редактора по умолчанию",
-            "execute_default_tab": "Вкладка выполнения по умолчанию",
-            "execute_flow": "Выполнить Flow",
-            "flow_default_tab": "Вкладка Flow по умолчанию",
             "language": "Язык",
-            "log_display": "Отображение логов по умолчанию",
+            "default_namespace": "Namespace по умолчанию",
             "log_level": "Уровень логов по умолчанию",
+            "log_display": "Отображение логов по умолчанию",
+            "editor_type": "Тип редактора по умолчанию",
+            "execute_flow": "Выполнить Flow",
+            "execute_default_tab": "Вкладка выполнения по умолчанию",
             "multi_panel_editor": "Многооконный редактор",
+            "flow_default_tab": "Вкладка Flow по умолчанию",
+            "triggers_default_tab": "Вкладка по умолчанию Triggers",
             "playground": "Песочница",
-            "triggers_default_tab": "Вкладка по умолчанию Triggers"
+            "auto_refresh_interval": "Интервал автоматического обновления"
           },
-          "label": "Основная конфигурация"
-        },
-        "export": {
-          "fields": {
-            "flows": "Экспортировать все flows",
-            "templates": "Экспортировать все шаблоны"
-          },
-          "label": "Экспорт"
-        },
-        "localization": {
           "descriptions": {
-            "date_format": "Формат, используемый для отображения дат на панели управления.",
-            "language": "Язык интерфейса для меню и меток.",
-            "time_zone": "Используется для отображения дат выполнения и запланированных trigger."
-          },
-          "fields": {
-            "date_format": "Формат даты",
-            "time_zone": "Часовой пояс"
-          },
-          "label": "Язык и регион",
-          "note": "Обратите внимание, что эта настройка используется для отображения свойств даты и времени в интерфейсе. Чтобы запланировать ваши flows в часовом поясе, отличном от UTC, убедитесь, что вы установили свойство timezone в trigger расписания в вашем коде flow или в настройках плагина по умолчанию."
-        },
-        "reset_section_to_defaults": "Восстановить значения по умолчанию для этого раздела",
-        "save": {
-          "discard": "Отменить",
-          "label": "Сохранить настройки",
-          "unsaved_title": "Несохраненные изменения",
-          "unsaved_warning": "У вас есть несохраненные изменения. Хотите сохранить их перед выходом?"
-        },
-        "sidebar": {
-          "descriptions": {
-            "items": "Показать, скрыть и изменить порядок элементов в боковой панели."
-          },
-          "fields": {
-            "items": "Элементы навигации"
-          },
-          "label": "Боковая панель"
+            "default_namespace": "Используется при создании новых flow без namespace.",
+            "log_level": "Минимальный уровень log, отображаемый в execution logs.",
+            "log_display": "Как отображаются логи при открытии выполнения.",
+            "editor_type": "Редактор, отображаемый при открытии flow в первый раз.",
+            "execute_flow": "Где результаты выполнения открываются после запуска.",
+            "execute_default_tab": "Вкладка выбрана при переходе к выполнению.",
+            "flow_default_tab": "Вкладка выбрана при переходе к flow.",
+            "triggers_default_tab": "Вкладка выбрана при переходе на страницу триггеров.",
+            "auto_refresh_interval": "Секунды между автоматическими обновлениями данных на страницах списков.",
+            "playground": "Запускайте задачи по отдельности в редакторе playground."
+          }
         },
         "theme": {
-          "app_font_size_options": {
-            "large": "Большой",
-            "medium": "Средний",
-            "small": "Маленький"
-          },
-          "color_modes": {
-            "dark_1": "Темный 1.0",
-            "dark_2": "Темный 2.0",
-            "light": "Светлый",
-            "sync": "Синхронизировать с системой"
-          },
-          "confirmations": {
-            "color_mode": "Ваш интерфейс теперь использует тему `{mode}`."
-          },
-          "descriptions": {
-            "app_font_size": "Коэффициент масштабирования, применяемый ко всем размерам шрифта интерфейса.",
-            "color_mode": "Выберите предпочитаемый интерфейсный модус.",
-            "color_mode_shortcut": "Совет: нажмите <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>L</kbd>, чтобы переключать темы из любого места.",
-            "editor_folding_stratgy": "Сворачивать длинные блоки YAML по умолчанию при открытии flow.",
-            "editor_font_family": "Моноширинный шрифт, используемый в редакторе YAML.",
-            "editor_font_size": "Размер шрифта, используемый в редакторах YAML и no-code.",
-            "editor_hover_description": "Показывать описания свойств при наведении в редакторе.",
-            "environment_color": "Цвет акцента, используемый для текущей среды в навигации.",
-            "environment_name": "Отображаемое имя для текущей среды, показанное в навигации.",
-            "logs_font_size": "Размер шрифта, используемый в Log Viewer и терминалах."
-          },
+          "label": "Настройки темы",
           "fields": {
             "app_font_size": "Размер шрифта приложения",
             "chart_color_scheme": {
+              "label": "Цветовая схема диаграммы",
               "classic": "Классический",
-              "kestra": "Kestra",
-              "label": "Цветовая схема диаграммы"
+              "kestra": "Kestra"
             },
             "color_mode": "Режим цвета",
             "editor_folding_stratgy": "Автоматическое сворачивание кода в редакторе",
@@ -1850,24 +1066,867 @@
             "logs_font_size": "Размер шрифта Logs",
             "theme": "Тема"
           },
-          "label": "Настройки темы"
+          "color_modes": {
+            "dark_2": "Темный 2.0",
+            "dark_1": "Темный 1.0",
+            "light": "Светлый",
+            "sync": "Синхронизировать с системой"
+          },
+          "confirmations": {
+            "color_mode": "Ваш интерфейс теперь использует тему `{mode}`."
+          },
+          "descriptions": {
+            "color_mode": "Выберите предпочитаемый интерфейсный модус.",
+            "color_mode_shortcut": "Совет: нажмите <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>L</kbd>, чтобы переключать темы из любого места.",
+            "logs_font_size": "Размер шрифта, используемый в Log Viewer и терминалах.",
+            "editor_font_family": "Моноширинный шрифт, используемый в редакторе YAML.",
+            "editor_font_size": "Размер шрифта, используемый в редакторах YAML и no-code.",
+            "editor_folding_stratgy": "Сворачивать длинные блоки YAML по умолчанию при открытии flow.",
+            "editor_hover_description": "Показывать описания свойств при наведении в редакторе.",
+            "environment_name": "Отображаемое имя для текущей среды, показанное в навигации.",
+            "environment_color": "Цвет акцента, используемый для текущей среды в навигации.",
+            "app_font_size": "Коэффициент масштабирования, применяемый ко всем размерам шрифта интерфейса."
+          },
+          "app_font_size_options": {
+            "small": "Маленький",
+            "medium": "Средний",
+            "large": "Большой"
+          }
+        },
+        "localization": {
+          "label": "Язык и регион",
+          "note": "Обратите внимание, что эта настройка используется для отображения свойств даты и времени в интерфейсе. Чтобы запланировать ваши flows в часовом поясе, отличном от UTC, убедитесь, что вы установили свойство timezone в trigger расписания в вашем коде flow или в настройках плагина по умолчанию.",
+          "fields": {
+            "time_zone": "Часовой пояс",
+            "date_format": "Формат даты"
+          },
+          "descriptions": {
+            "language": "Язык интерфейса для меню и меток.",
+            "time_zone": "Используется для отображения дат выполнения и запланированных trigger.",
+            "date_format": "Формат, используемый для отображения дат на панели управления."
+          }
+        },
+        "export": {
+          "label": "Экспорт",
+          "fields": {
+            "flows": "Экспортировать все flows",
+            "templates": "Экспортировать все шаблоны"
+          }
+        },
+        "save": {
+          "label": "Сохранить настройки",
+          "discard": "Отменить",
+          "unsaved_title": "Несохраненные изменения",
+          "unsaved_warning": "У вас есть несохраненные изменения. Хотите сохранить их перед выходом?"
+        },
+        "reset_section_to_defaults": "Восстановить значения по умолчанию для этого раздела",
+        "sidebar": {
+          "label": "Боковая панель",
+          "fields": {
+            "items": "Элементы навигации"
+          },
+          "descriptions": {
+            "items": "Показать, скрыть и изменить порядок элементов в боковой панели."
+          }
+        }
+      }
+    },
+    "apps": "Приложения",
+    "demos": {
+      "enterprise_edition": "Enterprise Edition (Корпоративная версия)",
+      "get_a_demo_button": "Получить демо-версию",
+      "contact_sales": "Связаться с отделом продаж",
+      "watch_the_video": "Смотреть видео",
+      "secrets": {
+        "title": "Обновите управление Secrets",
+        "message": "Enterprise Edition (EE) позволяет добавлять, редактировать или удалять секреты непосредственно в UI — без необходимости перезапуска экземпляра. Организуйте секреты по namespace с детализированными RBAC-разрешениями и наследуйте их от родительских к дочерним namespace. EE интегрируется с менеджерами секретов, такими как HashiCorp Vault, AWS Secrets Manager, Azure Key Vault, Google Secret Manager и Elasticsearch. Настройте выделенные бэкенды для каждого namespace, арендатора или экземпляра, чтобы изолировать секреты между командами, или включите только для чтения секреты, хранящиеся во внешних хранилищах. Секреты остаются зашифрованными в состоянии покоя и при передаче. Опциональное кэширование уменьшает количество API-запросов, а аудиторские следы фиксируют весь доступ.",
+        "detected_env": "Вот переменные окружения типа secret, определенные при запуске экземпляра:",
+        "empty_env": "У вас еще нет Secrets в вашей среде.",
+        "add_env": {
+          "intro": "Чтобы создать новый Secret:",
+          "first": "Закодируйте <a href=\"https://kestra.io/docs/how-to-guides/secrets?utm_source=app&utm_medium=referral&utm_campaign=secrets-inlinedoc#using-secrets-in-kestra\" target=\"_blank\">секретное значение в Base64</a>",
+          "second": "Добавьте переменную окружения с именем '<strong>SECRET_{'{MY_SECRET_KEY}'}</strong>' с указанным выше значением",
+          "third": "Перезапустите ваш экземпляр Kestra"
         }
       },
-      "label": "Настройки",
-      "updated": "{name} обновлено"
+      "apps": {
+        "title": "Создавайте пользовательские приложения с Kestra",
+        "message": "Приложения в Kestra Enterprise Edition позволяют создавать пользовательские интерфейсы, которые взаимодействуют с Kestra workflows вне платформы. Эта функция позволяет использовать ваши workflows в качестве backend для пользовательских приложений, что дает возможность нетехническим пользователям отправлять данные через формы или возобновлять PAUSED workflows, ожидающие одобрения."
+      },
+      "tests": {
+        "label": "Тесты",
+        "header": "Юнит-тесты для Flows",
+        "title": "Обеспечьте надежность с каждым изменением",
+        "message": "Проверьте логику ваших flow в изоляции, обнаруживайте регрессии на ранних стадиях и поддерживайте уверенность в ваших автоматизациях по мере их изменения и роста."
+      },
+      "assets": {
+        "label": "Активы",
+        "header": "Метаданные и наблюдаемость активов",
+        "title": "Приведите каждый набор данных, сервис и зависимость в поле зрения.",
+        "message": "Активы связывают метаданные наблюдаемости, происхождения и владения, чтобы команды платформы могли быстрее устранять неполадки и развертывать с уверенностью."
+      },
+      "IAM": {
+        "title": "Управление пользователями через IAM с SSO, SCIM и RBAC",
+        "message": "Kestra Enterprise Edition имеет встроенные возможности IAM с поддержкой единого входа (SSO), синхронизацией каталога SCIM и управлением доступом на основе ролей (RBAC), интегрируясь с несколькими поставщиками идентификации и позволяя назначать детализированные разрешения для пользователей и учетных записей сервисов."
+      },
+      "tenants": {
+        "title": "Управление Workflows в изолированных tenants",
+        "message": "Kestra Enterprise Edition поддерживает мультиаренду, предоставляя полностью изолированные среды для различных команд или проектов, каждая из которых имеет собственные ресурсы, такие как выделенные группы worker или секреты и внутренние хранилища."
+      },
+      "audit-logs": {
+        "title": "Отслеживание изменений с помощью Audit Logs",
+        "message": "Kestra Enterprise Edition записывает каждую активность с надежными, неизменяемыми записями, что упрощает отслеживание изменений, поддержание соответствия и устранение неполадок."
+      },
+      "quotas": {
+        "title": "Применение квот выполнения к потокам",
+        "message": "Kestra Enterprise Edition позволяет определять квоты для потоков, ограничивая количество одновременных или суммарных выполнений в заданном временном окне. Квоты помогают защитить общую инфраструктуру, обеспечить соблюдение SLA и предотвратить избыточное потребление ресурсов неконтролируемыми рабочими процессами."
+      },
+      "instance": {
+        "title": "Управление инфраструктурой в вашем экземпляре",
+        "message": "Kestra Enterprise Edition предоставляет операционную панель, которая помогает вам наблюдать за состоянием вашей платформы и отслеживать метрики времени безотказной работы всех сервисов, таких как, например, Workers, Schedulers и Executors. С той же страницы вы также можете создавать объявления, чтобы уведомлять пользователей о планируемом времени простоя, и вы можете войти в режим обслуживания, который временно переводит все сервисы и выполнения workflow в состояние PAUSED для выполнения обновления."
+      },
+      "blueprints": {
+        "title": "Добавить пользовательские Blueprints",
+        "message": "В Kestra Enterprise Edition вы можете создавать пользовательские Blueprints, доступные только вашей организации. Вы можете использовать их в качестве шаблонов лучших практик для обмена, централизации и документирования часто используемых рабочих процессов в вашей команде."
+      },
+      "namespace": {
+        "edit": {
+          "title": "Обновите управление вашим Namespace",
+          "message": "В Kestra Enterprise Edition, namespaces обеспечивают продвинутую изоляцию и управление секретами, переменными и настройками плагинов в масштабе. Администраторы могут настраивать пользовательские менеджеры секретов, изолированные хранилища, выделенные группы worker и детализированные разрешения на уровне каждого namespace. Это гарантирует, что секреты, переменные и конфигурации плагинов остаются безопасными и легкими в обслуживании для разных команд и проектов."
+        },
+        "secrets": {
+          "title": "Управление секретами безопасным способом",
+          "message": "В Kestra Enterprise Edition вы можете хранить и контролировать секреты на уровне namespace, минимизируя риски и обеспечивая изоляцию учетных данных каждой команды. Благодаря вложенной иерархии, вы также можете настроить учетные данные в родительском namespace, и они будут унаследованы всеми дочерними namespaces. Поддержка специализированных менеджеров секретов и детализированных настроек разрешений на уровне namespace дополнительно укрепляет безопасность и соответствие требованиям."
+        },
+        "assets": {
+          "title": "Централизованное управление активами",
+          "message": "В Kestra Enterprise Edition, Assets ведет актуальный учет ресурсов, с которыми взаимодействуют ваши workflows. Эти ресурсы могут быть таблицами баз данных, виртуальными машинами, файлами или любой внешней системой, с которой вы работаете."
+        },
+        "variables": {
+          "title": "Централизованно управляйте вашими переменными",
+          "message": "В Kestra Enterprise Edition вы можете определять и управлять переменными на уровне namespace, чтобы устранить повторяющиеся конфигурации в различных flows. Эти переменные обеспечивают согласованность, упрощают обновление конфигураций и могут быть легко использованы в любом task или trigger для более чистых и удобных в обслуживании рабочих процессов."
+        },
+        "plugin-defaults": {
+          "title": "Стандартизация конфигурации с помощью значений по умолчанию плагина",
+          "message": "В Kestra Enterprise Edition вы можете установить специфичные для namespace значения по умолчанию для плагинов, что уменьшает необходимость дублирования настроек в каждом flow. Это централизованное управление плагинами обеспечивает согласованность конфигураций, позволяет безопасно ссылаться на секреты или переменные и упрощает обслуживание ваших workflows."
+        },
+        "history": {
+          "title": "Управляйте Историей Ревизий в Одном Месте",
+          "message": "В Kestra Enterprise Edition вы можете управлять историей ревизий ваших Namespaces."
+        },
+        "audit-logs": {
+          "title": "Отслеживайте все изменения в одном месте",
+          "message": "В Kestra Enterprise Edition вы можете просматривать audit logs на уровне namespace с подробными различиями, что дает вам четкую историю того, кто, что и когда изменил во всех ресурсах."
+        }
+      }
+    },
+    "assets": {
+      "title": "Активы"
+    },
+    "onboarding": {
+      "welcome": {
+        "headline": "Создайте и запустите свой первый workflow за несколько минут",
+        "guided_title": "Создайте свой первый flow",
+        "badge": "Руководство",
+        "guided_description": "Узнайте, как создать и запустить свой первый flow с помощью пошаговых инструкций.",
+        "guided_duration": "Рекомендуется большинству пользователей",
+        "self_serve_title": "Создать flow с нуля",
+        "self_serve_description": "Перейдите прямо в редактор и создайте свой flow.",
+        "self_serve_note": "Для опытных пользователей",
+        "additional_help": "Дополнительная помощь",
+        "docs": "Документация",
+        "tutorial": "Руководство",
+        "blueprints": "Шаблоны",
+        "slack": "Сообщество Slack"
+      },
+      "steps": {
+        "flow_basics": {
+          "title": "Основы flow",
+          "description": "В Kestra <code>flow</code> — это основная единица оркестрации. Вы определяете его в YAML с метаданными и упорядоченными задачами.<br><br>Просмотрите пример структуры ниже, затем продолжайте создавать её шаг за шагом."
+        },
+        "add_id": {
+          "title": "Добавьте ID flow",
+          "description": "ID — это уникальное имя вашего flow, чтобы вы могли находить его, запускать и последовательно ссылаться на него.<br><br>Теперь добавьте <code>id</code> на корневом уровне."
+        },
+        "add_namespace": {
+          "title": "Добавьте namespace",
+          "description": "Namespace — это группировка, похожая на папку, которая организует flow по команде, проекту или окружению.<br><br>Теперь добавьте <code>namespace</code> на корневом уровне."
+        },
+        "add_input": {
+          "title": "Добавьте input",
+          "description": "Inputs — это параметры на уровне flow, которые можно использовать внутри задач, чтобы динамически управлять поведением во время выполнения.<br><br>Теперь добавьте input с именем <code>name</code> и типом <code>STRING</code>."
+        },
+        "add_log_task": {
+          "title": "Добавьте первую задачу",
+          "description": "Tasks — это единицы работы, которые выполняет ваш flow, определённые как упорядоченный список шагов. Каждой задаче нужен уникальный <code>id</code> и <code>type</code>. Kestra предоставляет множество плагинов задач для внешних систем; здесь мы используем задачу Python Script.<br><br>Синтаксис <code>&#123;&#123; ... &#125;&#125;</code> — это выражение Pebble, используемое для динамического обращения к переменным во время выполнения, например <code>&#123;&#123; inputs.name &#125;&#125;</code> из inputs flow.<br><br>Теперь добавьте первую задачу под <code>tasks</code> с <code>id</code>, <code>type</code> и <code>script</code>, который выводит приветствие."
+        },
+        "save_flow": {
+          "title": "Сохраните flow",
+          "description": "Сохранение фиксирует определение вашего flow, чтобы его можно было выполнить."
+        },
+        "execute_flow": {
+          "title": "Запустите flow",
+          "description": "Запуск начинает выполнение flow с входными значениями, заданными во время выполнения."
+        },
+        "view_logs_status": {
+          "title": "Проверьте выполнение",
+          "description": "Детали выполнения показывают статус запуска, тайминги и выходные логи на уровне задач.<br><br>Теперь откройте детали выполнения и нажмите <code>greet</code> на диаграмме Ганта, чтобы посмотреть логи."
+        },
+        "edit_flow_from_execution": {
+          "title": "Вернитесь в редактор flow",
+          "description": "Вы можете перейти напрямую из выполнения обратно к определению flow, чтобы быстро вносить изменения."
+        },
+        "add_cron_trigger": {
+          "title": "Добавьте cron-триггер",
+          "description": "Triggers могут запускать выполнения по расписанию или по внешним событиям (например, webhooks или MQTT-сообщения).<br><br>Теперь добавьте cron-триггер расписания, чтобы этот flow запускался каждые 5 минут."
+        },
+        "add_input_default": {
+          "title": "Задайте значение input по умолчанию",
+          "description": "Когда flow запускается автоматически, inputs всё равно нуждаются в значениях во время выполнения.<br><br>Input <code>name</code> уже был создан на предыдущем шаге, поэтому добавлять его снова не нужно. Просто задайте значение по умолчанию для существующего input <code>name</code>."
+        },
+        "save_flow_again": {
+          "title": "Сохраните flow",
+          "description": "Теперь у вашего flow есть расписание и значение input по умолчанию для автоматических запусков."
+        },
+        "background_runs_info": {
+          "title": "Запуски по расписанию",
+          "description": "Этот flow теперь будет выполняться в фоне каждые 5 минут.<br><br>Вы можете перейти к обзору Executions в левом меню, чтобы отслеживать запуски по расписанию."
+        },
+        "finish": {
+          "title": "Вы завершили руководство «Первый Flow»",
+          "description": "Отличное начало. Вы создали flow, запустили его, добавили параметры и расписание.<br><br>Выберите, что делать дальше ..."
+        }
+      },
+      "actions": {
+        "next": "Далее",
+        "complete": "Завершить",
+        "save_to_continue": "Нажмите Save в верхней панели (справа).",
+        "execute_to_continue": "1. Нажмите Execute в верхней панели (справа).\n2. Укажите значение для <strong>name</strong>.\n3. Нажмите Execute ещё раз в модальном окне.",
+        "edit_flow_to_continue": "Нажмите Edit flow в верхней панели (справа).",
+        "cancel_tutorial": "Отменить руководство",
+        "finish_tutorial": "Завершить руководство"
+      },
+      "finish_actions": {
+        "explore_blueprints": "Посмотреть шаблоны",
+        "create_flow": "Создать flow"
+      },
+      "editor_hints": {
+        "build_intro": "Создайте свой первый flow шаг за шагом.",
+        "step_1": "# 1) Добавьте id",
+        "step_2": "# 2) Добавьте namespace",
+        "step_3": "# 3) Добавьте input",
+        "step_4": "# 4) Добавьте tasks и вашу первую Python-задачу",
+        "step_5": "# 5) Добавьте cron-триггер"
+      },
+      "cancel_modal": {
+        "title": "Отменить руководство «Первый Flow»",
+        "description": "Вы хотите отменить руководство «Первый Flow»?",
+        "confirm": "Отменить руководство",
+        "keep": "Продолжить руководство"
+      },
+      "validation": {
+        "complete_step": "Вы почти у цели. Завершите этот шаг, чтобы продолжить.",
+        "fix_yaml": "Есть небольшая проблема с форматированием YAML. Исправьте её, затем продолжайте.",
+        "add_id": "Добавьте ID flow вверху. Пример: `id: hello_flow`.",
+        "add_namespace": "Добавьте namespace вверху. Пример: `namespace: company.team`.",
+        "add_input_section": "Создайте секцию `inputs` с одним input.",
+        "add_input_id": "Внутри `inputs` добавьте `id: name`.",
+        "add_input_type": "Установите тип input в `STRING`.",
+        "add_log_task_section": "Создайте секцию `tasks` и добавьте первую задачу.",
+        "add_log_task_id": "Дайте задаче ID, например: `id: greet`.",
+        "add_log_task_type": "Установите тип задачи в `io.kestra.plugin.scripts.python.Script`.",
+        "add_log_task_message": "Добавьте поле `script` в задачу.",
+        "add_log_task_pebble": "Используйте выражение Pebble в скрипте, чтобы оно использовало значение input (например: `inputs.name`).",
+        "save_flow": "Нажмите Save, чтобы продолжить.",
+        "execute_flow": "Запустите flow один раз, чтобы продолжить.",
+        "view_logs_status": "Откройте детали выполнения и проверьте логи для `greet`.",
+        "edit_flow_from_execution": "Нажмите `Edit flow` в верхней панели, чтобы продолжить.",
+        "add_cron_trigger_section": "Создайте секцию `triggers` с триггером расписания.",
+        "add_cron_trigger_type": "Установите тип триггера в `io.kestra.plugin.core.trigger.Schedule`.",
+        "add_cron_trigger_cron": "Добавьте cron-выражение, например: `\"*/5 * * * *\"`.",
+        "add_input_default_section": "Вернитесь в `inputs` и оставьте один существующий input с именем `name` (не добавляйте второй input).",
+        "add_input_default_id": "Оставьте существующий ID input как `name`.",
+        "add_input_default_defaults": "Добавьте значение по умолчанию для `name`, например: `defaults: \"Kestra\"`.",
+        "save_flow_again": "Нажмите Save ещё раз, чтобы продолжить."
+      }
+    },
+    "enable concurrency": "Включить concurrency",
+    "auditlogs": "Аудиторские логи",
+    "quotas": "Квоты",
+    "iam": "IAM",
+    "tenant": {
+      "name": "Мандант",
+      "names": "Арендаторы"
+    },
+    "ee-tooltip": {
+      "features-blocked": "Эта функция требует Enterprise Edition.",
+      "button": "Свяжитесь с нами"
+    },
+    "flow_only": "Доступно только на вкладке Flow.",
+    "bulk action async warning": "Это может занять несколько минут.",
+    "bulk unpause backfills": "Возобновить {count} заполнение",
+    "bulk pause backfills": "Приостановить {count} заполнение",
+    "bulk delete backfills": "Удалить {count} заполнение",
+    "bulk unlock": "Разблокировать {count} triggers",
+    "bulk disabled status": {
+      "true": "Отключить {count} triggers",
+      "false": "Включить {count} triggers"
+    },
+    "unlock": "Разблокировать",
+    "bulk success unpause backfills": "{count} заполнения возобновлены",
+    "bulk success pause backfills": "{count} заполнения приостановлены",
+    "bulk success delete backfills": "{count} backfills заполнения",
+    "bulk success unlock": "{count} triggers разблокированы",
+    "bulk success disabled status": {
+      "true": "{count} trigger(s) отключены",
+      "false": "{count} trigger(s) включены"
+    },
+    "no_namespaces": "Ни один namespace не соответствует критериям поиска.",
+    "system_namespace": "Держите вашу платформу под контролем с помощью system flows.",
+    "system_namespace_description": "Автоматизируйте задачи обслуживания, от предупреждений о сбоях до автоматической очистки.",
+    "pluginDefaults": {
+      "title": "Настройки плагина по умолчанию",
+      "add": "Добавить плагин по умолчанию",
+      "edit": "Редактировать значение по умолчанию для плагина",
+      "add_subtitle": "Настройте новый плагин по умолчанию с его свойствами",
+      "edit_subtitle": "Изменить существующую конфигурацию плагина по умолчанию",
+      "predefined": "Предопределенный плагин",
+      "custom": "Пользовательский плагин",
+      "form": "Форма",
+      "yaml": "YAML",
+      "select_predefined": "Выберите Предопределенный Плагин",
+      "cancel": "Отменить",
+      "update": "Обновить плагин по умолчанию",
+      "custom_type": "Пользовательский тип плагина",
+      "custom_placeholder": "Введите тип плагина",
+      "use_custom": "Использовать пользовательский",
+      "custom_configure": "Пользовательский тип плагина - настройка с использованием YAML",
+      "yaml_configuration": "Конфигурация YAML",
+      "show_yaml": "Показать YAML"
+    },
+    "secret": {
+      "add": "Создать",
+      "update": "Обновить секрет '{name}'",
+      "isReadOnly": "Секрет доступен только для чтения",
+      "names": "Cекреты",
+      "inherited": "Унаследованные секреты"
+    },
+    "workerId": "Worker Id",
+    "kv": {
+      "name": "KV Store",
+      "type": "Тип",
+      "add": "Создать",
+      "update": "Обновить значение для key '{key}'",
+      "duplicate": "Этот key уже существует",
+      "delete multiple": {
+        "confirm": "Вы уверены, что хотите удалить: <code>{name}</code> kv store?",
+        "warning": "У вас нет разрешений для этих namespaces, поэтому они будут пропущены: <code>{namespaces}</code>"
+      },
+      "inherited": "Наследуемые KV пары"
+    },
+    "expiration": "Срок действия",
+    "failed to render pdf": "Не удалось отобразить предварительный просмотр PDF",
+    "page": {
+      "previous": "Предыдущая страница",
+      "next": "Следующая страница"
+    },
+    "namespace_editor": {
+      "empty": {
+        "title": "В настоящее время вкладки не открыты",
+        "create_message": "Вы можете создать или импортировать файлы namespace.",
+        "video_message": "Вы можете посмотреть Вводное Видео для нашего Editor."
+      },
+      "close": {
+        "tab": "Закрыть вкладку",
+        "all": "Закрыть все вкладки",
+        "other": "Закрыть другие вкладки",
+        "right": "Закрыть справа"
+      }
+    },
+    "curl": {
+      "command": "Команда cURL",
+      "note": "Обратите внимание, что для типов ввода SECRET и FILE команда должна быть адаптирована, чтобы соответствовать реальным значениям."
+    },
+    "webhook": {
+      "curl_command": "Команда cURL для Webhook",
+      "payload": "Payload Webhook (JSON)",
+      "curl_note": "Используйте эту команду cURL, чтобы trigger flow через webhook с пользовательским JSON payload",
+      "no_triggers": "Этот flow не имеет включенных webhook trigger",
+      "copy_url": "Скопировать URL вебхука"
+    },
+    "logs_view": {
+      "raw": "Временной вид",
+      "raw_details": "Показать полные task logs и flow логи в формате необработанных временных меток",
+      "compact": "Вид по умолчанию",
+      "compact_details": "Показать task логи в компактном виде, сгруппированном по каждой задаче"
+    },
+    "execution_deletion": {
+      "logs": "Удалить логи",
+      "metrics": "Удалить метрики",
+      "storage": "Удалить внутренние файлы хранения"
+    },
+    "scope_filter": {
+      "all": "Все {label}",
+      "user": "Пользователь {label}",
+      "system": "Система {label}",
+      "user_description": "Обычный пользователь инициировал {label}",
+      "system_description": "Системное обслуживание {label}"
+    },
+    "data": "Данные",
+    "webhook link copied": "Ссылка на Webhook скопирована.",
+    "copy url": "Скопировать URL",
+    "scheduleDate": "Дата расписания",
+    "warning": "Предупреждение",
+    "trigger_check_warning": "Использование переменных trigger не будет работать с ручным выполнением flow. Добавьте оператор объединения `??`, чтобы решить проблему. Например, вместо `trigger.date` используйте `trigger.date ?? execution.startDate`.",
+    "docs": "Документы",
+    "active-slots": "Активные слоты",
+    "behavior": "Поведение",
+    "concurrency": "Конкурентность",
+    "no-executions-view": {
+      "title": "Начните автоматизацию с",
+      "sub_title": "Нажмите на кнопку Execute, чтобы начать выполнение вашего первого workflow.",
+      "namespace_sub_title": "Выполните один или несколько flow из этого namespace, чтобы заполнить эту панель.",
+      "guidance_desc": "Нужна помощь для выполнения вашего flow?",
+      "namespace_guidance_desc": "Нужна помощь в управлении вашим Namespace?",
+      "guidance_sub_desc": "Следуйте документации для получения всей необходимой информации."
+    },
+    "execution_guide": {
+      "get_started": {
+        "title": "Начать ⚡",
+        "text": "Следуйте Руководству по быстрому старту, чтобы установить Kestra и начать создавать свои первые workflows."
+      },
+      "namespaces": {
+        "title": "О namespace",
+        "text": "Пространства имен — это логические группы flow и их компонентов."
+      },
+      "workflow_components": {
+        "title": "Компоненты Workflow",
+        "text": "Познакомьтесь с основными компонентами оркестрации в workflow Kestra."
+      },
+      "videos_tutorials": {
+        "title": "Видеоуроки",
+        "text": "Начните с наших видеоуроков."
+      }
+    },
+    "open sidebar": "открыть боковую панель",
+    "close sidebar": "закрыть боковую панель",
+    "customize sidebar": "Настроить боковую панель",
+    "reset to defaults": "Сбросить настройки по умолчанию",
+    "drop items here": "Перетащите элементы сюда",
+    "files": "Файлы",
+    "optional": "Опционально",
+    "no_data": "Похоже, здесь пока ничего нет…<br/>Измените фильтры или попробуйте снова!",
+    "bookmark": "Закладки",
+    "remove_bookmark": "Вы уверены, что хотите удалить эту закладку?",
+    "showLess": "Показать меньше",
+    "showMore": "Показать больше",
+    "documentationMenu": "Меню документации",
+    "item": "элемент",
+    "items": "элементы",
+    "cron": "Крон",
+    "execution_started": "Выполнение началось!",
+    "execution_failed": "Выполнение не удалось!",
+    "last error was": "Последняя ошибка была",
+    "execution restarted": "Это выполнение было перезапущено {nbRestart} раз(а).",
+    "execution replay": "Это выполнение является повтором",
+    "execution replayed": "Это выполнение было воспроизведено.",
+    "task run id": "ID выполнения задачи",
+    "active": "Активно",
+    "flows imported": "Потоки импортированы",
+    "flow not imported": "Некоторые flow не удалось импортировать",
+    "plugin defaults exported": "Экспортированы значения по умолчанию плагина",
+    "failed to export plugin defaults": "Не удалось экспортировать значения по умолчанию плагина",
+    "plugin defaults imported": "Параметры плагина по умолчанию импортированы",
+    "plugin defaults not imported": "Некоторые значения по умолчанию для плагинов не удалось импортировать",
+    "failed to import plugin defaults": "Не удалось импортировать значения по умолчанию плагина",
+    "filters": {
+      "label": "Выберите фильтры",
+      "empty": "Нет данных.",
+      "format": "Введите параметр в формате 'key:value'",
+      "text_search": "Искать этот текст",
+      "options": {
+        "namespace": "Namespace",
+        "flow": "Поток",
+        "state": "Состояние",
+        "scope": "Область применения",
+        "child": "Дочерний элемент",
+        "level": "Уровень Log",
+        "task": "Задача",
+        "metric": "Метрика",
+        "user": "Пользователь",
+        "type": "Тип",
+        "service_type": "Тип",
+        "permission": "Разрешение",
+        "action": "Действие",
+        "status": "Статус",
+        "details": "Детали",
+        "aggregation": "Агрегация",
+        "relative_date": "Относительная дата",
+        "absolute_date": "Абсолютная дата",
+        "labels": "Метки",
+        "text": "I'm sorry, but it seems that the text you want me to translate is missing. Could you please provide the text that needs to be translated?",
+        "startDate": "Дата начала",
+        "endDate": "Дата окончания"
+      },
+      "comparators": {
+        "is": "является",
+        "is_one_of": "является одним из",
+        "is_not": "не является",
+        "not_in": "не является одним из",
+        "contains": "содержит",
+        "not_contains": "не содержит",
+        "in": "в",
+        "between": "между",
+        "starts_with": "начинается с",
+        "greater_than": "больше чем",
+        "greater_than_or_equal_to": "больше или равно",
+        "less_than": "меньше чем",
+        "less_than_or_equal_to": "меньше или равно",
+        "ends_with": "заканчивается на"
+      },
+      "save": {
+        "label": "Сохранённые поиски",
+        "remove": "Удалить",
+        "empty": "Вы еще не сохранили ни одного поиска.",
+        "tooltip": "Вы не можете сохранить пустые критерии поиска.",
+        "name_already_used": "Поиск label уже используется.",
+        "dialog": {
+          "heading": "Сохранить текущий поиск",
+          "placeholder": "Ярлык",
+          "hint": "Как вы хотите обозначить этот критерий поиска?",
+          "confirmation": "Критерии поиска <code>{name}</code>"
+        }
+      },
+      "settings": {
+        "label": "Настройки страницы",
+        "show_chart": "Показать основную диаграмму"
+      }
+    },
+    "custom value": "Пользовательское значение",
+    "chart": "График",
+    "chart preview": "Предварительный просмотр диаграммы",
+    "no_code": {
+      "toggle_pebble": "Переключить редактор Pebble",
+      "version_oss_placeholder": "Разблокируйте Версионирование Плагинов с Enterprise Edition",
+      "unnamed": "Без имени",
+      "adding": "+ Добавить {what}",
+      "adding_default": "+ Добавить новое value",
+      "add_field": "Добавить {field}",
+      "clearSelection": "Очистить выбор",
+      "labels": {
+        "yaml": "Редактор YAML",
+        "no_code": "Редактор No Code",
+        "label": "Метка",
+        "variable": "Переменная"
+      },
+      "sections": {
+        "deprecated": "Устаревшие свойства",
+        "tasks": "Задачи",
+        "triggers": "Триггеры",
+        "errors": "Обработчики ошибок",
+        "afterExecution": "После выполнения",
+        "finally": "Наконец",
+        "pluginDefaults": "Настройки плагина по умолчанию"
+      },
+      "fields": {
+        "main": {
+          "id": "ID flow",
+          "namespace": "Namespace",
+          "description": "Описание",
+          "inputs": "Входные данные"
+        },
+        "general": {
+          "retry": "Повторить попытку",
+          "sla": "SLA",
+          "labels": "Метки",
+          "outputs": "Выходы",
+          "variables": "Переменные",
+          "concurrency": "Конкурентность",
+          "disabled": "Отключено",
+          "listeners": "Слушатели",
+          "taskDefaults": "Значения по умолчанию для Task",
+          "workerGroup": "Группа Worker",
+          "workerSelector": "Селектор Worker",
+          "checks": "Проверки",
+          "updated": "Обновлено"
+        }
+      },
+      "select": {
+        "default": "Выберите тип",
+        "task": "Выберите task",
+        "tasks": "Выберите task",
+        "triggers": "Выберите trigger",
+        "errors": "Выберите task",
+        "finally": "Выберите task",
+        "pluginDefaults": "Выберите плагин",
+        "afterExecution": "Выберите task",
+        "conditions": "Выберите условие",
+        "inputs": "Выберите тип поля input",
+        "charts": "Выберите тип диаграммы",
+        "where": "Выберите тип фильтра",
+        "numerator": "Выберите числитель"
+      },
+      "creation": {
+        "default": "Добавить",
+        "tasks": "Добавить task",
+        "triggers": "Добавить trigger",
+        "errors": "Добавить обработчик ошибок",
+        "finally": "Добавить блок finally",
+        "pluginDefaults": "Добавить плагин по умолчанию",
+        "afterExecution": "Добавить блок после выполнения",
+        "conditions": "Добавить условие",
+        "inputs": "Добавить поле input",
+        "charts": "Добавить диаграмму",
+        "where": "Фильтруйте ваши данные",
+        "numerator": "Добавить числитель"
+      },
+      "remove": {
+        "default": "Удалить эту запись",
+        "cases": "Удалить этот кейс"
+      }
+    },
+    "properties": {
+      "label": "Свойства",
+      "hint": "Выберите видимые столбцы",
+      "shown": "Показано в таблице",
+      "hidden": "Скрыто в таблице"
+    },
+    "editor_shortcuts": {
+      "label": "Горячие клавиши",
+      "trigger_autocompletion": "Запустить автозаполнение",
+      "command_palette": "Показать палитру команд",
+      "save_flow": "Сохранить flow",
+      "execute_flow": "Запустить flow",
+      "toggle_ai_agent": "Переключить AI agent",
+      "move_line": "Переместить строку",
+      "duplicate_cursor": "Дублировать курсор",
+      "fold_unfold": "Свернуть/Развернуть код",
+      "comment_uncomment": "Комментарий/Раскомментировать",
+      "comment": "Комментарий",
+      "uncomment": "Раскомментировать",
+      "decrease_fontsize": "Уменьшить размер шрифта редактора",
+      "increase_fontsize": "Увеличить размер шрифта редактора",
+      "reset_fontsize": "Сбросить размер шрифта редактора"
+    },
+    "instance": "Экземпляр",
+    "something_went_wrong": {
+      "loading_execution": "Произошла ошибка при загрузке выполнения",
+      "connection_lost": {
+        "title": "Соединение прервано",
+        "message": "Мы не смогли подключиться к вашей Kestra instance. Убедитесь, что она запущена, затем обновите страницу."
+      }
+    },
+    "debug": "Отладка",
+    "default": "По умолчанию",
+    "data_not_protected": "Ваши данные не защищены. Не потеряйте их. <b>Включите наши бесплатные функции безопасности или попробуйте платную версию.</b>",
+    "activate_basic_auth": "Активировать Basic Authentication",
+    "dark_version": "Темная версия",
+    "use_dark_background": "Используйте эту версию при работе на темном фоне, чтобы наше имя оставалось читаемым.",
+    "light_version": "Легкая версия",
+    "light_background": "Это предпочтительный вариант при работе со светлым фоном.",
+    "monogram": "Монограмма",
+    "wordmark_colors": "Цвета логотипа адаптируются в зависимости от фона, в то время как иконка остается без фона, когда размещена на темном фоне.",
+    "download_logos": "Скачать пакет логотипов",
+    "this_task_has": "Эта задача имеет",
+    "about_this_blueprint": "О данном blueprint",
+    "deleted_label": "Удалено",
+    "fold_all_multi_lines": "Свернуть все многострочные строки",
+    "task_id_exists": "Id задачи уже существует",
+    "task_id_message": "Id задачи ${existingTask} уже существует в flow.",
+    "trigger_id_exists": "Идентификатор Trigger уже существует",
+    "trigger_id_message": "Идентификатор Trigger ${existingTrigger} уже существует в flow.",
+    "watch": "Наблюдение",
+    "learn_more": "Узнать больше",
+    "watch_video": "Смотреть видео",
+    "runners": "Запуски",
+    "select": "Выберите ваш {{section}}",
+    "for flow": "для flow",
+    "forbidden system labels": "Только system.correlationId можно использовать как system label",
+    "confirm": "Подтвердить",
+    "taskRunners": "Запускатели Task",
+    "additionalPlugins": "Дополнительные плагины",
+    "appBlocks": "Блоки приложения",
+    "charts": "Графики",
+    "dataFilters": "Фильтры данных",
+    "logExporters": "Экспортеры Log",
+    "empty": {
+      "namespaceFiles": {
+        "title": "В этом namespace пока нет файлов",
+        "content": "Файлы namespace работают как папка проекта для этого namespace. Храните код Python, SQL, dbt или Terraform, а затем ссылайтесь на любой файл в своих flows с помощью"
+      },
+      "announcements": {
+        "title": "У вас пока нет объявлений!",
+        "content": "Объявления позволяют уведомлять ваших пользователей о любых изменениях или информировать их о запланированном времени простоя для обслуживания. Просто выберите тип объявления, диапазон дат, в течение которого оно должно отображаться, и напишите сообщение объявления."
+      },
+      "kill_switches": {
+        "title": "У вас еще нет Kill Switches!",
+        "content": "Функция Kill Switch предоставляет механизм на основе UI для остановки проблемных выполнений. Она заменяет команды CLI <code>--skip-executions</code> и <code>--skip-flows</code> на комплексный административный интерфейс."
+      },
+      "apps": {
+        "title": "У вас пока нет приложений!",
+        "content": "Начните создавать приложения для взаимодействия с Kestra из внешнего мира."
+      },
+      "testSuites": {
+        "title": "У вас еще нет Test suites!",
+        "content": "Начните создавать тестовые наборы для проверки ваших Flows."
+      },
+      "assets": {
+        "title": "У вас еще нет Assets!",
+        "content": "Добавьте assets, чтобы отслеживать и управлять вашими данными, сервисами и инфраструктурой."
+      },
+      "apiTokens": {
+        "title": "Управление вашими API Tokens",
+        "content": "Токены API используются всякий раз, когда вы хотите предоставить программный доступ к API Kestra."
+      },
+      "concurrency_executions": {
+        "title": "Нет текущих выполнений для этого flow.",
+        "content": "Узнайте больше о <strong><a href=\"https://kestra.io/docs/workflow-components/execution?utm_source=app&utm_medium=referral&utm_campaign=concurrency-inlinedoc\" target=\"_blank\">Executions</a></strong> в нашей документации."
+      },
+      "concurrency_limit": {
+        "title": "Для этого flow не установлены ограничения.",
+        "content": "Узнайте больше о <strong><a href=\"https://kestra.io/docs/workflow-components/concurrency?utm_source=app&utm_medium=referral&utm_campaign=concurrency-inlinedoc\" target=\"_blank\">ограничениях на Concurrency</a></strong> в нашей документации."
+      },
+      "concurrency_limits": {
+        "title": "Пределы на параллельность не установлены.",
+        "content": "Узнайте больше о <strong><a href=\"https://kestra.io/docs/workflow-components/concurrency?utm_source=app&utm_medium=referral&utm_campaign=concurrency-inlinedoc\" target=\"_blank\">ограничениях на Concurrency</a></strong> в нашей документации."
+      },
+      "pluginDefaults": {
+        "title": "У вас еще нет стандартных настроек плагина!",
+        "content": "Параметры плагина по умолчанию позволяют централизованно управлять конфигурацией вашего плагина и делиться ею со всеми flow в вашем namespace."
+      },
+      "variables": {
+        "title": "Пока нет переменных",
+        "content": "Добавьте пары ключ-значение для совместного использования конфигурации между flows. Дочерние namespaces автоматически наследуют их, и вы можете ссылаться на любое значение с помощью"
+      },
+      "workerRegistrationTokens": {
+        "title": "У вас еще нет токенов регистрации!",
+        "content": "Токены регистрации позволяют удаленным worker безопасно аутентифицироваться и регистрироваться в вашем экземпляре Kestra. Создайте токен, затем используйте его для подключения новых worker к этому кластеру."
+      },
+      "groups": {
+        "title": "У вас еще нет групп!",
+        "content": "Группы позволяют объединять пользователей, чтобы вы могли управлять разрешениями и привязками ролей коллективно в рамках вашего арендатора."
+      },
+      "dependencies": {
+        "FLOW": {
+          "title": "В настоящее время зависимости отсутствуют.",
+          "content": "Узнайте больше о <a href=\"https://kestra.io/docs/ui/flows?utm_source=app&utm_medium=referral&utm_campaign=dependencies-inlinedoc#dependencies\" target=\"_blank\">Flow Dependencies</a> в нашей документации."
+        },
+        "EXECUTION": {
+          "title": "В настоящее время зависимости отсутствуют.",
+          "content": "Узнайте больше о <a href=\"https://kestra.io/docs/ui/executions?utm_source=app&utm_medium=referral&utm_campaign=dependencies-inlinedoc#dependencies\" target=\"_blank\">зависимостях выполнения</a> в нашей документации."
+        },
+        "NAMESPACE": {
+          "title": "В настоящее время зависимости отсутствуют.",
+          "content": "Узнайте больше о <a href=\"https://kestra.io/docs/ui/namespaces?utm_source=app&utm_medium=referral&utm_campaign=dependencies-inlinedoc#dependencies\" target=\"_blank\">Namespace Dependencies</a> в нашей документации."
+        },
+        "ASSET": {
+          "title": "В настоящее время зависимости отсутствуют.",
+          "content": "Этот ресурс не имеет зависимостей вверх или вниз по потоку с flow или другими ресурсами."
+        }
+      },
+      "plugins": {
+        "title": "Для этого namespace не установлены значения по умолчанию для плагинов.",
+        "content": "Узнайте больше о <strong><a href=\"https://kestra.io/docs/workflow-components/plugin-defaults?utm_source=app&utm_medium=referral&utm_campaign=plugin-default-inlinedoc\" target=\"_blank\">Concurrency Limits</a></strong> в нашей документации."
+      },
+      "triggers": {
+        "title": "Ваш flow не имеет никаких Triggers.",
+        "content": "Узнайте больше о <strong><a href=\"https://kestra.io/docs/workflow-components/triggers?utm_source=app&utm_medium=referral&utm_campaign=trigger-inlinedoc\" target=\"_blank\">Triggers</a></strong> в нашей документации."
+      },
+      "mcpToolFlows": {
+        "title": "На этом сервере еще не зарегистрированы tool flows.",
+        "content": "Представьте flow как инструмент MCP, добавив в него <code>McpToolTrigger</code>. Подробнее о <strong><a href=\"https://kestra.io/docs/workflow-components/triggers/mcp-tool-trigger?utm_source=app&utm_medium=referral&utm_campaign=mcp-tool-trigger-inlinedoc\" target=\"_blank\">MCP Tool Trigger</a></strong> читайте в нашей документации."
+      },
+      "versionPlugin": {
+        "title": "У вас еще нет версионированного плагина!",
+        "content": "Здесь вы можете управлять всеми плагинами, установленными на вашем экземпляре Kestra. Недавно установленные плагины могут быть не сразу доступны во всех службах Kestra в зависимости от конфигурации вашего экземпляра."
+      },
+      "panels": {
+        "title": "Нет открытой панели",
+        "content": "Вы закрыли все панели.  \nВыберите вкладку выше, чтобы продолжить."
+      }
+    },
+    "toggle_word_wrap": "Переключить перенос слов",
+    "copied_logs_to_clipboard": "Скопированные logs в буфер обмена.",
+    "multi_panel_editor": {
+      "move_right": "Переместить вправо",
+      "move_left": "Переместить влево",
+      "close_all_tabs": "Закрыть все вкладки",
+      "close_all_panels": "Закрыть все панели"
+    },
+    "search_docs": "Поиск",
+    "no_results_found": "Результаты не найдены",
+    "searching": "Поиск...",
+    "worker information": "Информация о Worker",
+    "test-badge-text": "Тест",
+    "test-badge-tooltip": "Это выполнение было создано тестом",
+    "total_executions": "Общее количество выполнений",
+    "no_results": {
+      "executions": "Исполнения не найдены",
+      "triggers": "Триггеры не найдены",
+      "flows": "Потоки не найдены",
+      "kv_pairs": "Пары kv store не найдены",
+      "secrets": "Секреты не найдены",
+      "templates": "Шаблоны не найдены",
+      "assets": "Активы не найдены"
+    },
+    "duplicate-pair": "{label} \"{key}\" дублируется, первый ключ игнорируется.",
+    "dashboards": {
+      "labels": {
+        "singular": "Панель управления",
+        "plural": "Панели управления"
+      },
+      "default": "Панель по умолчанию",
+      "switch": "Переключить Панель управления",
+      "preview": "Предварительный просмотр Dashboard",
+      "empty": "Нет результатов для отображения.",
+      "creation": {
+        "label": "Создать Dashboard",
+        "confirmation": "Панель <code>{title}</code> создана."
+      },
+      "edition": {
+        "label": "Редактировать Dashboard",
+        "confirmation": "Изменения в панели <code>{title}</code> сохранены.",
+        "chart": "Редактировать этот график",
+        "id readonly": "Свойство `id` не может быть изменено — оно установлено на начальные значения. Если вы хотите его изменить, вы можете создать новую панель и удалить старую."
+      },
+      "deletion": {
+        "confirmation": "Вы уверены, что хотите удалить панель <code>{title}</code>?"
+      },
+      "no_description": "Нет описания",
+      "no_description_hint": "Добавьте описание к этому flow, чтобы задокументировать его назначение.<br>Поддерживается Markdown.",
+      "others": "Другие",
+      "viewAll": "Показать все",
+      "chart_preview": "Нажмите на исходный код диаграммы, чтобы увидеть его предварительный просмотр",
+      "export": "Экспорт в CSV",
+      "quick_filters": {
+        "all": "Все",
+        "running": "Выполняется",
+        "paused": "Приостановлено",
+        "success": "Успешно",
+        "warning": "Предупреждение",
+        "failed": "Ошибка"
+      }
     },
     "setup": {
-      "config": {
-        "basicauth": "Базовая аутентификация",
-        "queue": "Очередь",
-        "repository": "База данных",
-        "storage": "Внутреннее хранилище"
+      "login": "Войти",
+      "login_title": "Войти",
+      "logout": "Выход",
+      "troubleshooting": "Забыли пароль?",
+      "steps": {
+        "user": "Создать администратора",
+        "config": "Проверить конфигурацию",
+        "survey": "Расскажите нам больше",
+        "complete": "Запустить Kestra UI"
       },
-      "confirm": {
-        "config_title": "Подтвердите, что конфигурация действительна",
-        "confirm": "Создать администратора",
-        "not_valid": "Нет, это недействительно",
-        "valid": "Да, это допустимо"
+      "titles": {
+        "user": "Создать администратора",
+        "survey": "Помогите нам улучшить Kestra OSS"
+      },
+      "subtitles": {
+        "user": "Защитите ваш экземпляр, чтобы начать.",
+        "config": "Вот детали вашей конфигурации",
+        "survey": "Извините, но я не вижу текст, который нужно перевести. Пожалуйста, предоставьте текст после \"----------\", чтобы я мог помочь с переводом.",
+        "complete": "Настройка успешно завершена!"
       },
       "form": {
         "email": "Электронная почта",
@@ -1878,351 +1937,249 @@
         "username": "Имя пользователя",
         "username_hint": "Должен быть действительный адрес электронной почты."
       },
-      "login": "Войти",
-      "login_title": "Войти",
-      "logout": "Выход",
-      "steps": {
-        "complete": "Запустить Kestra UI",
-        "config": "Проверить конфигурацию",
-        "survey": "Расскажите нам больше",
-        "user": "Создать администратора"
-      },
-      "subtitles": {
-        "complete": "Настройка успешно завершена!",
-        "config": "Вот детали вашей конфигурации",
-        "survey": "Извините, но я не вижу текст, который нужно перевести. Пожалуйста, предоставьте текст после \"----------\", чтобы я мог помочь с переводом.",
-        "user": "Защитите ваш экземпляр, чтобы начать."
-      },
-      "success": {
-        "subtitle": "Вы готовы!",
-        "title": "Поздравляем!"
-      },
-      "survey": {
-        "company_11_50": "Личный проект",
-        "company_1_10": "Обучение / исследование",
-        "company_250_plus": "Развертывание в производственной среде",
-        "company_50_250": "Оценка для моей команды/компании",
-        "company_personal": "Другое",
-        "company_size": "Какова ваша основная цель с Kestra?",
-        "continue": "Продолжить",
-        "newsletter": "Получайте обновления о продукте по электронной почте.",
-        "newsletter_heading": "Будьте в курсе",
-        "skip": "Пропустить",
-        "use_case": "Для чего вы планируете это использовать?",
-        "use_case_business": "Бизнес-процессы",
-        "use_case_data": "Рабочие процессы данных",
-        "use_case_infrastructure": "Автоматизация инфраструктуры",
-        "use_case_ml": "ML конвейеры",
-        "use_case_other": "Другое",
-        "use_case_scheduling": "Планирование и повторяющиеся задания"
-      },
-      "titles": {
-        "survey": "Помогите нам улучшить Kestra OSS",
-        "user": "Создать администратора"
-      },
-      "troubleshooting": "Забыли пароль?",
       "validation": {
-        "config_message": "Убедитесь, что обновили вашу конфигурацию, чтобы исправить это сообщение об ошибке.",
-        "email_invalid": "Недействительный email",
         "email_required": "Требуется Email",
+        "email_invalid": "Недействительный email",
         "email_temporary_not_allowed": "Временные или одноразовые адреса электронной почты не разрешены",
         "firstName_required": "Имя обязательно",
-        "incorrect_creds": "Неверное имя пользователя или пароль. Убедитесь, что ваши учетные данные верны.",
         "lastName_required": "Требуется фамилия",
         "password_invalid": "Неверный пароль",
-        "password_required": "Пароль обязателен"
+        "password_required": "Пароль обязателен",
+        "incorrect_creds": "Неверное имя пользователя или пароль. Убедитесь, что ваши учетные данные верны.",
+        "config_message": "Убедитесь, что обновили вашу конфигурацию, чтобы исправить это сообщение об ошибке."
+      },
+      "config": {
+        "repository": "База данных",
+        "queue": "Очередь",
+        "storage": "Внутреннее хранилище",
+        "basicauth": "Базовая аутентификация"
+      },
+      "confirm": {
+        "confirm": "Создать администратора",
+        "config_title": "Подтвердите, что конфигурация действительна",
+        "not_valid": "Нет, это недействительно",
+        "valid": "Да, это допустимо"
+      },
+      "survey": {
+        "skip": "Пропустить",
+        "company_size": "Какова ваша основная цель с Kestra?",
+        "company_1_10": "Обучение / исследование",
+        "company_11_50": "Личный проект",
+        "company_50_250": "Оценка для моей команды/компании",
+        "company_250_plus": "Развертывание в производственной среде",
+        "company_personal": "Другое",
+        "use_case": "Для чего вы планируете это использовать?",
+        "use_case_infrastructure": "Автоматизация инфраструктуры",
+        "use_case_business": "Бизнес-процессы",
+        "use_case_data": "Рабочие процессы данных",
+        "use_case_ml": "ML конвейеры",
+        "use_case_scheduling": "Планирование и повторяющиеся задания",
+        "use_case_other": "Другое",
+        "newsletter_heading": "Будьте в курсе",
+        "newsletter": "Получайте обновления о продукте по электронной почте.",
+        "continue": "Продолжить"
+      },
+      "success": {
+        "title": "Поздравляем!",
+        "subtitle": "Вы готовы!"
       }
     },
-    "show": "Показать",
-    "show chart": "Показать диаграмму",
-    "show description": "Показать описание",
-    "show details": "Показать детали",
-    "show documentation": "Показать документацию",
-    "show more details": "Показать больше деталей",
-    "show raw": "Show raw",
-    "show task condition": "Показать условие task",
-    "show task documentation": "Показать документацию задачи",
-    "show task documentation in editor": "Показать документацию задачи в редакторе",
-    "show task logs": "Показать логи задачи",
-    "show task outputs": "Показать выводы задачи",
-    "show task source": "Показать исходный код задачи",
-    "showLess": "Показать меньше",
-    "showMore": "Показать больше",
-    "side-by-side": "бок о бок",
-    "similar lines": "similar lines",
-    "skipped": "Пропущено",
-    "slack support": "Задайте любой вопрос через Slack",
-    "something_went_wrong": {
-      "connection_lost": {
-        "message": "Мы не смогли подключиться к вашей Kestra instance. Убедитесь, что она запущена, затем обновите страницу.",
-        "title": "Соединение прервано"
+    "ai": {
+      "flow": {
+        "title": "AI Агент",
+        "prompt_placeholder": "Введите инструкции для создания вашего Kestra flow. Пример запроса: Создайте flow, который запускается каждый понедельник в 9 утра.",
+        "select_provider": "Выберите провайдера",
+        "generating": {
+          "flow": "Генерация Flow YAML для вас...",
+          "dashboard": "Генерация Dashboard YAML для вас...",
+          "app": "Генерация YAML для приложения...",
+          "test": "Генерация тестового YAML для вас..."
+        },
+        "enable_instructions": {
+          "header": "<b>AI Copilot еще не настроен.</b>\n\nЧтобы включить AI Copilot, добавьте следующий фрагмент в файл конфигурации вашего экземпляра Kestra (например, <code>application.yml</code>), заменив <code>geminiApiKey</code> на ваш фактический ключ:",
+          "footer": "Примечание: В настоящее время только Gemini поддерживается в качестве AI-провайдера для Open Source Edition. Для Enterprise Edition, пожалуйста, обратитесь к документации AI Copilot для настройки других провайдеров моделей.\n\nПерезапустите ваш Kestra instance после сохранения конфигурации."
+        }
       },
-      "loading_execution": "Произошла ошибка при загрузке выполнения"
+      "dashboard": {
+        "prompt_placeholder": "Задайте вопрос о ваших данных. Пример запроса: Покажите мне уровень успеха моих flows за последние 7 дней."
+      }
     },
-    "source": "Источник",
-    "source and blueprints": "Источник и blueprints",
-    "source and doc": "Источник и документация",
-    "source and topology": "Источник и топология",
-    "source only": "Источник только",
-    "source search": "Поиск по источнику",
-    "source_search": {
-      "match_count": "{count} совпадение | {count} совпадения",
-      "open_flow": "Открыть flow",
-      "preview_empty": "Выберите результат для предпросмотра. Нажмите на flow в списке результатов, чтобы увидеть его исходный код.",
-      "preview_error": "Не удалось загрузить исходный код flow"
+    "playground": {
+      "title": "Песочница",
+      "run_task_info": "Наведите курсор на любую task в редакторе Flow Code и нажмите кнопку \"Run task\", чтобы протестировать вашу task.",
+      "play_icon_info": "Вы также можете нажать на значок Play в представлениях No-Code или Topology.",
+      "toggle": "Песочница",
+      "run_task": "Запустить Task",
+      "run_this_task": "Запустить этот task",
+      "run_task_and_downstream": "Запустить task и downstream",
+      "run_all_tasks": "Запустить все Tasks",
+      "history": "Последние 10 запусков",
+      "clear_history": "Очистить историю",
+      "confirm_create": "Вы не можете запустить playground во время создания flow. Запуск playground создаст flow.",
+      "tooltip_persistence": "Если вы выключите и снова включите Playground, информация останется, пока вы находитесь на странице."
     },
-    "specific task": "Конкретная задача",
-    "start date": "Дата начала",
-    "start datetime": "Дата и время начала",
-    "started date": "Дата начала",
-    "state": "Состояние",
-    "state updated date": "Дата обновления состояния",
-    "state_history": "История состояния",
-    "stats": "Статистика",
-    "steps": "Шаги",
-    "stream": "Поток",
-    "sub flow": "Подпроцесс",
     "submit": "Отправить",
-    "success": "Успех",
-    "sum": "Сумма",
-    "switch-view": "Переключить вид",
-    "system overview": "Обзор системы",
-    "system_namespace": "Держите вашу платформу под контролем с помощью system flows.",
-    "system_namespace_description": "Автоматизируйте задачи обслуживания, от предупреждений о сбоях до автоматической очистки.",
-    "tags": "Теги",
-    "task": "Задача",
-    "task failed": "Задача FAILED",
-    "task id": "ID задачи",
-    "task id already exists": "ID задачи уже существует",
-    "task is running": "Задача RUNNING",
-    "task logs": "Журналы задач",
-    "task run id": "ID выполнения задачи",
-    "task sent a warning": "Задача отправила предупреждение",
-    "task was skipped": "Задача была пропущена",
-    "task was successful": "Задача была успешной",
-    "taskDefaults": "Задача по умолчанию",
-    "taskRunners": "Запускатели Task",
-    "task_id_exists": "Id задачи уже существует",
-    "task_id_message": "Id задачи ${existingTask} уже существует в flow.",
-    "taskid column details": "Последний task выполняется и количество его попыток.",
-    "tasks": "Задачи",
-    "template": "Шаблон",
-    "template creation": "Создание шаблона",
-    "template delete": "Вы уверены, что хотите удалить <code>{templateCount}</code> шаблон(ы)?",
-    "template export": "Вы уверены, что хотите экспортировать <code>{templateCount}</code> шаблон(ы)?",
-    "templates": "Шаблоны",
-    "templates deleted": "<code>{count}</code> Шаблон(ы) удалены",
-    "templates deprecated": "Шаблоны устарели. Пожалуйста, используйте subflows вместо них. См. <a href=\"https://kestra.io/docs/migration-guide/0.11.0/templates?utm_source=app&utm_medium=referral&utm_campaign=template-inlinedoc\" target=\"_blank\">раздел миграции</a>, объясняющий, как можно мигрировать с шаблонов на subflows.",
-    "templates exported": "Шаблоны экспортированы",
-    "tenant": {
-      "name": "Мандант",
-      "names": "Арендаторы"
-    },
-    "tenantId": "ID арендатора",
-    "test-badge-text": "Тест",
-    "test-badge-tooltip": "Это выполнение было создано тестом",
-    "theme": "Тема",
-    "this_task_has": "Эта задача имеет",
-    "timezone": "Часовой пояс",
-    "title": "Заголовок",
-    "to": "До",
     "to toggle": "переключить",
-    "toggle fullscreen": "Переключить полноэкранный режим",
-    "toggle menu": "Переключить меню",
-    "toggle output": "Переключить выводы",
-    "toggle output display": "Переключить отображение вывода",
-    "toggle periodic refresh each x seconds": "Переключить периодическое обновление каждые {interval} секунд",
-    "toggle_word_wrap": "Переключить перенос слов",
-    "topology": "Топология",
-    "topology-graph": {
-      "graph-orientation": "Ориентация графика",
-      "invalid": "Ошибка графа",
-      "invalid_description": "Произошла ошибка при загрузке графа. Пожалуйста, проверьте исходный код на наличие ошибок.",
-      "zoom-fit": "Подогнать",
-      "zoom-in": "Увеличить",
-      "zoom-out": "Уменьшить",
-      "zoom-reset": "Сбросить масштаб"
-    },
-    "total_duration": "Общая продолжительность",
-    "total_executions": "Общее количество выполнений",
-    "trigger": "Trigger",
-    "trigger details": "Подробности trigger",
-    "trigger disabled": "Триггер отключен в источнике Flow",
-    "trigger execution id": "Trigger Execution Id",
-    "trigger filter": {
-      "options": {
-        "ALL": "Все выполнения",
-        "CHILD": "Дочерние выполнения",
-        "MAIN": "Родительские выполнения"
+    "accept": "Принять",
+    "reject": "Отклонить",
+    "draft_available": "Черновик изменений доступен в редакторе",
+    "last modified": "Последнее изменение",
+    "run task in playground": "Запустить task в playground",
+    "task is running": "Задача RUNNING",
+    "task was successful": "Задача была успешной",
+    "task failed": "Задача FAILED",
+    "task was skipped": "Задача была пропущена",
+    "task sent a warning": "Задача отправила предупреждение",
+    "defaultsToNamespaceFile": "По умолчанию для файла namespace: <code>{name}</code>",
+    "no_file_choosen": "Файл не выбран",
+    "dependency": {
+      "controls": {
+        "zoom_in": "Увеличить",
+        "zoom_out": "Уменьшить масштаб",
+        "clear_selection": "Очистить выбор",
+        "fit_view": "По размеру экрана"
       },
-      "title": "Фильтровать дочерние выполнения"
-    },
-    "trigger refresh": "Обновить",
-    "triggerId": "Идентификатор Trigger",
-    "trigger_check_warning": "Использование переменных trigger не будет работать с ручным выполнением flow. Добавьте оператор объединения `??`, чтобы решить проблему. Например, вместо `trigger.date` используйте `trigger.date ?? execution.startDate`.",
-    "trigger_id_exists": "Идентификатор Trigger уже существует",
-    "trigger_id_message": "Идентификатор Trigger ${existingTrigger} уже существует в flow.",
-    "trigger_states": "Состояния",
-    "triggered": "Активирован trigger",
-    "triggered done": "Выполнение <em>{name}</em> успешно запущено",
-    "triggerflow disabled": "Trigger отключен в определении flow",
-    "triggers": "Triggers",
-    "triggers_add_card_add": "Добавить",
-    "triggers_add_card_add_to_flow": "Добавить в flow",
-    "triggers_add_category_empty": "В этой категории нет triggers.",
-    "triggers_add_ee_tooltip": "Этот trigger требует Enterprise Edition.",
-    "triggers_add_empty_title": "Триггеры не найдены",
-    "triggers_add_filter_all": "Все",
-    "triggers_add_filter_app": "Приложение",
-    "triggers_add_filter_core": "Ядро",
-    "triggers_add_filter_realtime": "Реальное время",
-    "triggers_add_modal_add_button": "Добавить Trigger в Flow",
-    "triggers_add_modal_ee_notice": "Этот trigger требует Enterprise Edition.",
-    "triggers_add_modal_flow_placeholder": "Выберите flow",
-    "triggers_add_modal_namespace_placeholder": "Выберите namespace",
-    "triggers_add_modal_properties_hint": "Настройте свойства trigger в редакторе flow после добавления trigger.",
-    "triggers_add_modal_tab_documentation": "Документация",
-    "triggers_add_modal_tab_form": "Форма",
-    "triggers_add_modal_tab_source": "Источник",
-    "triggers_add_modal_title": "{name}",
-    "triggers_add_modal_trigger_id": "Идентификатор Trigger",
-    "triggers_add_modal_trigger_id_placeholder": "Уникальный идентификатор для этого trigger",
-    "triggers_add_search_placeholder": "Поиск triggers...",
-    "triggers_header_description": "Просматривайте, добавляйте и управляйте triggers для автоматизации ваших flows. Выберите из вариантов: сделать ваш flow инструментом AI, запланировать, добавить webhook trigger, опрос изменений во внешних приложениях или слушатели событий в реальном времени.",
-    "triggers_state": {
-      "options": {
-        "disabled": "Отключено",
-        "enabled": "Включено"
-      },
-      "state": "Состояние"
-    },
-    "triggers_tabs_add": "Добавить",
-    "triggers_tabs_manage": "Управление",
-    "true": "Истина",
-    "type": "Тип",
-    "unable to generate graph": "Произошла ошибка при генерации графа, что препятствует отображению топологии.",
-    "undefined": "Неопределено",
-    "unlock": "Разблокировать",
-    "unlock trigger": {
-      "button": "Разблокировать trigger",
-      "confirmation": "Вы уверены, что хотите разблокировать trigger?",
-      "success": "Trigger разблокирован",
-      "tooltip": {
-        "evaluation": "Trigger в настоящее время оценивается",
-        "execution": "Выполнение запущено для этого trigger"
-      },
-      "warning": "Это может привести к параллельным выполнениям для одного и того же trigger и должно рассматриваться как крайняя мера."
-    },
-    "unqueue": "Из очереди",
-    "unqueue as": "Очередь снята как <code>{status}</code>",
-    "unqueue confirm": "Вы уверены, что хотите отменить выполнение <code>{id}</code>?",
-    "unqueue done": "Выполнение находится вне очереди",
-    "unqueue title": "Извлечь выполнение <code>{id}</code> из очереди.<br/>Обратите внимание, что это не будет учитывать ограничение на параллельность flow, поэтому может выполняться больше процессов, чем разрешено.",
-    "unqueue title multiple": "Вы уверены, что хотите удалить из очереди <code>{count}</code> выполнений?<br/><br/>Обратите внимание, что это не будет учитывать ограничение на параллельность flow, поэтому может выполняться больше выполнений, чем разрешено.",
-    "unsaved changed ?": "У вас есть несохраненные изменения, вы хотите покинуть эту страницу?",
-    "unsaved changes": "Несохраненные изменения",
-    "unsaved changes warning": "У вас есть несохраненные изменения. Если вы покинете эту страницу, ваши изменения будут потеряны.",
-    "up trend": "Увеличивается",
-    "update": "Обновить",
-    "update aborted": "обновление прервано",
-    "update ok": "обновлено",
-    "updated date": "Дата обновления",
-    "usage": "Использование",
-    "use": "Использовать",
-    "use_dark_background": "Используйте эту версию при работе на темном фоне, чтобы наше имя оставалось читаемым.",
-    "valid": "Действительный",
-    "validate": "Проверить",
-    "value": "Значение",
-    "variable_explorer": {
-      "empty": "Нет переменных, доступных для этого выполнения.",
-      "n_items": "[ {count} элементов ]",
-      "n_keys": "\\{ {count} keys \\}",
-      "one_item": "[ 1 элемент ]",
-      "one_key": "\\{ 1 key \\}",
-      "raw_json": "Raw JSON",
-      "search_placeholder": "Поиск по Key или value...",
-      "select_prompt": "Выберите переменную, чтобы просмотреть её value.",
-      "tasks_outputs": "Tasks outputs",
-      "title": "Ввод/Вывод",
-      "tree": "Дерево"
-    },
-    "variables": "Переменные",
-    "version": "Версия",
-    "view metrics": "Просмотр метрик",
-    "warning": "Предупреждение",
-    "warning detected": "Обнаружены предупреждения",
-    "warning flow with triggers": "Этот flow содержит triggers, и ручное выполнение завершится неудачей, если этот flow зависит от trigger выражений.",
-    "watch": "Наблюдение",
-    "watch_video": "Смотреть видео",
-    "webhook": {
-      "copy_url": "Скопировать URL вебхука",
-      "curl_command": "Команда cURL для Webhook",
-      "curl_note": "Используйте эту команду cURL, чтобы trigger flow через webhook с пользовательским JSON payload",
-      "no_triggers": "Этот flow не имеет включенных webhook trigger",
-      "payload": "Payload Webhook (JSON)"
-    },
-    "webhook link copied": "Ссылка на Webhook скопирована.",
-    "welcome": {
-      "help": {
-        "text": "Задайте любой вопрос в нашем сообществе Slack. Если вы застряли, мы здесь, чтобы помочь вам. ✋",
-        "title": "Нужна помощь?"
-      },
-      "menu": "Welcome",
-      "tour": {
-        "text": "Выберите ваш сценарий использования и следуйте пошаговому руководству, чтобы изучить возможности и функции Kestra. ❤️",
-        "title": "Пройдите экскурсию по продукту"
-      },
-      "tutorial": {
-        "text": "* <a href=\"https://kestra.io/tutorial-videos/all?utm_source=app&utm_medium=referral&utm_campaign=welcome-tutorial\" target=\"_blank\">Видеоуроки</a>  \n* <a href=\"https://kestra.io/docs?utm_source=app&utm_medium=referral&utm_campaign=welcome-tutorial\" target=\"_blank\">Документация</a>  \n* <a href=\"https://kestra.io/blueprints?utm_source=app&utm_medium=referral&utm_campaign=welcome-tutorial\" target=\"_blank\">Blueprints</a>",
-        "title": "Учебник"
+      "search": {
+        "placeholders": {
+          "default": "Поиск по flow или namespace...",
+          "asset": "Поиск по asset, flow или namespace..."
+        },
+        "namespace": {
+          "select": "Выберите namespace",
+          "no_namespace": "Без namespace"
+        },
+        "flow": {
+          "display": "Включить зависимости flow"
+        },
+        "no_results": "Результаты для {term} не найдены"
       }
     },
+    "preview": {
+      "label": "Предварительный просмотр",
+      "force-editor": "Принудительный просмотр редактора",
+      "auto-view": "Автоматический просмотр",
+      "view": "Просмотр",
+      "rows_truncated": "Показано {shown} из {total} строк. Загрузите файл, чтобы просмотреть все данные.",
+      "pagination_info": "Показаны строки {start}-{end} из {total}.",
+      "showing_rows": "Показаны строки {start}-{end} из {total}",
+      "expand": "Развернуть",
+      "collapse": "Свернуть",
+      "previous": "Предыдущий",
+      "next": "Далее",
+      "page_of": "Страница {current} из {total}"
+    },
+    "delete trigger": "Удалить trigger",
+    "delete triggers": "Удалить triggers",
+    "bulk delete triggers": "Вы уверены, что хотите удалить {count} triggers?",
+    "bulk success delete triggers": "{count} триггеры были успешно удалены",
+    "delete trigger confirmation": "Вы уверены, что хотите удалить trigger {id}? WARNING: удаление trigger может привести к дублированию выполнений, если trigger все еще активен в flow.",
+    "delete trigger success": "Триггер {id} был успешно удален",
+    "delete trigger error": "Ошибка при удалении trigger {id}",
+    "revision deleted": "Ревизия {revision} была успешно удалена",
+    "delete revision confirm": "Вы уверены, что хотите удалить ревизию {revision}?",
+    "delete revision error": "Ошибка при удалении ревизии {revision} с ошибкой {error}",
+    "no_history": "История недоступна",
+    "export_as": "Экспортировать как .{format}",
+    "save_and_execute": "Сохранить и выполнить",
     "welcome_copilot": {
       "button_cta": "Создать flow с нуля",
       "create_manually": {
-        "description": "Создать с нуля, используя редактор",
-        "title": "Создать вручную"
+        "title": "Создать вручную",
+        "description": "Создать с нуля, используя редактор"
       },
       "docs": {
-        "description": "Узнайте больше в официальной документации",
-        "title": "Читать документацию"
+        "title": "Читать документацию",
+        "description": "Узнайте больше в официальной документации"
       },
+      "title": "Превратите вашу идею в workflow",
+      "need_help": "Нужна помощь?",
+      "placeholder_prompt": "Отправляйте мне ежедневное приветственное сообщение в 9 утра.",
+      "show_more": "Показать больше подсказок",
+      "show_less": "Показать меньше подсказок",
+      "remaining_quota": "У вас осталось {count} AI generations. Лимит сбрасывается ежедневно в полночь UTC.",
       "execute_hint": {
-        "description": "Нажмите, чтобы сохранить ваш workflow и запустить его немедленно.",
-        "title": "Сохранить и выполнить ваш flow"
+        "title": "Сохранить и выполнить ваш flow",
+        "description": "Нажмите, чтобы сохранить ваш workflow и запустить его немедленно."
+      },
+      "success_popup": {
+        "title": "Поздравляем!",
+        "description": "Вы успешно выполнили свой первый flow! Вы на пути к тому, чтобы стать профессионалом в Kestra.",
+        "tutorial": "Углубленный учебник",
+        "explore": "Исследовать больше"
+      },
+      "success_page": {
+        "title": "Вы готовы!",
+        "description": "Вы изучили основы Kestra. Вот некоторые ресурсы, которые помогут вам продолжить ваше путешествие.",
+        "restart": "Перезапустить учебник",
+        "items": {
+          "tutorial": {
+            "title": "Начать учебное пособие",
+            "description": "Интерактивное руководство по всем функциям Kestra"
+          },
+          "blueprints": {
+            "title": "Черновики",
+            "description": "Готовые шаблоны workflow для общих случаев использования"
+          },
+          "slack": {
+            "title": "Сообщество Slack",
+            "description": "Подключитесь к другим пользователям и получите помощь от сообщества"
+          },
+          "videos": {
+            "title": "Видеоуроки",
+            "description": "Пошаговые видеоинструкции по продвинутым функциям"
+          },
+          "demo": {
+            "title": "Получить демо",
+            "description": "Исследуйте Kestra Enterprise Edition с персонализированной демонстрацией"
+          }
+        }
+      },
+      "help": {
+        "tutorial": {
+          "title": "Начать учебное пособие",
+          "description": "Узнайте, как создать и запустить ваш первый flow с пошаговыми инструкциями."
+        },
+        "blueprints": {
+          "title": "Чертежи",
+          "description": "Исследуйте готовые примеры и шаблоны для общих паттернов workflow."
+        },
+        "slack": {
+          "title": "Сообщество Slack",
+          "description": "Присоединяйтесь к нам, чтобы делиться идеями и лучшими практиками, а также получать помощь с техническими вопросами."
+        }
       },
       "flows": {
-        "buildDbtPipeline": {
-          "label": "Создать dbt pipeline",
-          "prompt": "Создайте flow в Kestra, который клонирует репозиторий проекта dbt и запускает dbt build с профилем DuckDB."
-        },
-        "buildDockerImageAndRunIt": {
-          "label": "Создайте Docker image и запустите его",
-          "prompt": "Создайте flow в Kestra, который собирает Docker-образ из встроенного Dockerfile и запускает полученный контейнер."
-        },
-        "convertCsvToExcel": {
-          "label": "Преобразовать CSV в Excel",
-          "prompt": "Создайте flow, который загружает CSV файл, преобразует его в Ion и экспортирует результат как Excel файл."
-        },
-        "etlWorkflow": {
-          "label": "ETL Workflow",
-          "prompt": "Создайте ETL flow, который загружает данные в формате JSON, обрабатывает их с помощью Python и выполняет запросы к преобразованному результату с помощью DuckDB."
+        "jsonApiToDuckdb": {
+          "label": "JSON API в DuckDB",
+          "prompt": "Создайте flow, который загружает JSON файл из публичного API, преобразует его с помощью Python скрипта и обрабатывает с помощью DuckDB Queries task."
         },
         "installNginxViaAnsible": {
           "label": "Установить Nginx через Ansible",
           "prompt": "Создайте flow Kestra, который устанавливает Nginx на целевой машине с помощью Ansible и проверяет установленную версию."
         },
-        "jsonApiToDuckdb": {
-          "label": "JSON API в DuckDB",
-          "prompt": "Создайте flow, который загружает JSON файл из публичного API, преобразует его с помощью Python скрипта и обрабатывает с помощью DuckDB Queries task."
+        "buildDbtPipeline": {
+          "label": "Создать dbt pipeline",
+          "prompt": "Создайте flow в Kestra, который клонирует репозиторий проекта dbt и запускает dbt build с профилем DuckDB."
+        },
+        "etlWorkflow": {
+          "label": "ETL Workflow",
+          "prompt": "Создайте ETL flow, который загружает данные в формате JSON, обрабатывает их с помощью Python и выполняет запросы к преобразованному результату с помощью DuckDB."
+        },
+        "microservicesApis": {
+          "label": "Микросервисы и API",
+          "prompt": "Создайте flow, который проверяет ответ API веб-сайта и отправляет уведомление в Slack, если код состояния не успешен."
+        },
+        "buildDockerImageAndRunIt": {
+          "label": "Создайте Docker image и запустите его",
+          "prompt": "Создайте flow в Kestra, который собирает Docker-образ из встроенного Dockerfile и запускает полученный контейнер."
         },
         "manualApproval": {
           "label": "Ручное одобрение",
           "prompt": "Создайте flow с начальным этапом обработки, паузой для ручного утверждения и финальным этапом развертывания после утверждения."
         },
-        "microservicesApis": {
-          "label": "Микросервисы и API",
-          "prompt": "Создайте flow, который проверяет ответ API веб-сайта и отправляет уведомление в Slack, если код состояния не успешен."
+        "convertCsvToExcel": {
+          "label": "Преобразовать CSV в Excel",
+          "prompt": "Создайте flow, который загружает CSV файл, преобразует его в Ion и экспортирует результат как Excel файл."
         },
         "scheduledPdfReports": {
           "label": "Запланированные PDF отчеты",
@@ -2232,73 +2189,116 @@
           "label": "Еженедельные KPI продаж в Slack",
           "prompt": "Создайте еженедельный запланированный flow, который вычисляет KPI продаж с помощью DuckDB и отправляет сводку в Slack."
         }
-      },
-      "help": {
-        "blueprints": {
-          "description": "Исследуйте готовые примеры и шаблоны для общих паттернов workflow.",
-          "title": "Чертежи"
-        },
-        "slack": {
-          "description": "Присоединяйтесь к нам, чтобы делиться идеями и лучшими практиками, а также получать помощь с техническими вопросами.",
-          "title": "Сообщество Slack"
-        },
-        "tutorial": {
-          "description": "Узнайте, как создать и запустить ваш первый flow с пошаговыми инструкциями.",
-          "title": "Начать учебное пособие"
-        }
-      },
-      "need_help": "Нужна помощь?",
-      "placeholder_prompt": "Отправляйте мне ежедневное приветственное сообщение в 9 утра.",
-      "remaining_quota": "У вас осталось {count} AI generations. Лимит сбрасывается ежедневно в полночь UTC.",
-      "show_less": "Показать меньше подсказок",
-      "show_more": "Показать больше подсказок",
-      "success_page": {
-        "description": "Вы изучили основы Kestra. Вот некоторые ресурсы, которые помогут вам продолжить ваше путешествие.",
-        "items": {
-          "blueprints": {
-            "description": "Готовые шаблоны workflow для общих случаев использования",
-            "title": "Черновики"
-          },
-          "demo": {
-            "description": "Исследуйте Kestra Enterprise Edition с персонализированной демонстрацией",
-            "title": "Получить демо"
-          },
-          "slack": {
-            "description": "Подключитесь к другим пользователям и получите помощь от сообщества",
-            "title": "Сообщество Slack"
-          },
-          "tutorial": {
-            "description": "Интерактивное руководство по всем функциям Kestra",
-            "title": "Начать учебное пособие"
-          },
-          "videos": {
-            "description": "Пошаговые видеоинструкции по продвинутым функциям",
-            "title": "Видеоуроки"
-          }
-        },
-        "restart": "Перезапустить учебник",
-        "title": "Вы готовы!"
-      },
-      "success_popup": {
-        "description": "Вы успешно выполнили свой первый flow! Вы на пути к тому, чтобы стать профессионалом в Kestra.",
-        "explore": "Исследовать больше",
-        "title": "Поздравляем!",
-        "tutorial": "Углубленный учебник"
-      },
-      "title": "Превратите вашу идею в workflow"
+      }
     },
-    "welcome_page": {
-      "guide": "Нужна помощь в выполнении вашего первого flow?",
-      "welcome": "Добро пожаловать в Kestra"
+    "mcp": {
+      "your_servers": "Ваши серверы",
+      "servers_count": "{count} MCP Серверов",
+      "managed_by_kestra": "Управляется Kestra",
+      "servers": "Серверы MCP",
+      "server": "Сервер MCP",
+      "client_setup": "Настройка клиента",
+      "page_description": "Предоставьте ваши Kestra flows как инструменты для MCP-совместимых AI агентов",
+      "create": "Создать сервер",
+      "save": "Сохранить изменения",
+      "connect": "Подключить",
+      "copy_url": "Скопировать URL",
+      "url_copied": "URL скопирован!",
+      "instructions": "Инструкции",
+      "server_type": "Тип сервера",
+      "auth_type": "Аутентификация",
+      "private": "Частный",
+      "private_server": "Частный сервер",
+      "public": "Публичный",
+      "public_hint": "Внимание: Публичные серверы не требуют аутентификации. Любой, у кого есть URL-адрес, может вызывать любой инструмент, предоставляемый этим сервером, без проверок namespace или разрешений. Используйте только для серверов, которые безопасно предоставлять внешне.",
+      "basic_auth": "Базовая аутентификация",
+      "api_token": "Токен API",
+      "oauth": "OAuth",
+      "username_password": "Имя пользователя и пароль",
+      "bearer_token": "Аутентификация с использованием Bearer token",
+      "oauth_hint": "Bearer JWT от вашего OIDC-провайдера",
+      "oauth_provider": "Провайдер OAuth",
+      "oauth_provider_placeholder": "Выберите настроенный OIDC-провайдер",
+      "oauth_provider_required": "Провайдер OAuth обязателен, когда тип аутентификации — OAuth",
+      "scopes_supported": "Поддерживаемые scopes",
+      "scopes_supported_placeholder": "openid, profile, email",
+      "scopes_supported_hint": "Scopes, объявленные в документе Protected Resource Metadata этого сервера. MCP-клиенты, соответствующие спецификации, ограничивают запрос авторизации этим списком. Оставьте пустым, чтобы пропустить поле и позволить клиентам использовать scopes, объявленные IdP.",
+      "no_oauth_providers": "В этом экземпляре не настроены OIDC-провайдеры",
+      "delete_confirm": "Вы уверены, что хотите удалить этот MCP сервер?",
+      "no_servers": "Серверы MCP не найдены. Создайте первый сервер, чтобы предоставить триггеры MCP Tool внешним AI-агентам.",
+      "server_id": "ID сервера",
+      "id_placeholder": "например, my-mcp-server",
+      "id_invalid": "ID должен начинаться с строчной буквы или цифры и содержать только строчные буквы, цифры, дефисы или подчеркивания",
+      "main_tenant": "главная",
+      "tab_edit": "Редактировать",
+      "tab_connect": "Подключиться",
+      "tab_tool_flows": "Инструменты Flow",
+      "tab_tool_flows_placeholder": "Управление flow инструментами скоро появится.",
+      "tools": {
+        "no_tools": "Нет flow, соответствующих вашему запросу.",
+        "create_tool_flow": "Создать flow инструмента",
+        "tool_name": "Название инструмента",
+        "trigger_id": "ID trigger",
+        "title": "Заголовок",
+        "description": "Описание",
+        "annotations": "Аннотации",
+        "flow": "flow",
+        "state": "Состояние",
+        "read_only": "Только чтение",
+        "open_world": "Open world",
+        "destructive": "Деструктивный",
+        "idempotent": "Идемпотентный",
+        "return_direct": "Прямой возврат",
+        "view_flow": "Открыть flow"
+      },
+      "connect_tab": {
+        "server_url": "URL сервера",
+        "client_picker_label": "Выберите ваш AI-клиент",
+        "claude_desktop": "Клод Десктоп",
+        "claude_desktop_hint": "Добавьте следующее в ваш файл claude_desktop_config.json:",
+        "claude_desktop_mac": "macOS: ~/Library/Application Support/Claude/claude_desktop_config.json",
+        "claude_desktop_win": "Windows: %APPDATA%\\Claude\\claude_desktop_config.json",
+        "claude_code": "Код Claude",
+        "claude_code_hint": "Выполните следующую команду в вашем терминале:",
+        "cursor": "Курсор",
+        "cursor_hint": "Добавьте следующее в ~/.cursor/mcp.json:",
+        "codex": "Codex (OpenAI)",
+        "codex_hint": "Добавьте следующее в вашу конфигурацию codex.json MCP:",
+        "auth_basic_hint": "Перед запуском клиента установите <code>KESTRA_BASIC_AUTH</code> как переменную окружения, содержащую строку <code>username:password</code>, закодированную в base64.",
+        "auth_api_token_hint": "Перед запуском клиента установите <code>KESTRA_TOKEN</code> как переменную окружения.",
+        "auth_oauth_client_id_hint": "Замените <code>&lt;client-id&gt;</code> на ID OAuth-клиента и зарегистрируйте <code>http://localhost:7777</code> как действительный URI перенаправления на этом клиенте.",
+        "auth_oauth_browser_hint": "При первом подключении браузер откроет страницу входа провайдера идентификации."
+      }
     },
-    "wordmark_colors": "Цвета логотипа адаптируются в зависимости от фона, в то время как иконка остается без фона, когда размещена на темном фоне.",
-    "worker group": "Группа workers",
-    "worker group fallback": "Группа Worker резервный вариант",
-    "worker group key": "Ключ группы Worker",
-    "worker information": "Информация о Worker",
-    "workerId": "Worker Id",
-    "workers": "Workers",
-    "wrong labels": "Пустой key или value не допускается в метках",
-    "yes": "Да"
+    "flow_editor_stats": {
+      "revisions": {
+        "suffix": "Ревизия(и)",
+        "tooltip": "Просмотр версий flow"
+      },
+      "dependencies": {
+        "suffix": "Зависимости",
+        "tooltip": "Просмотр зависимостей flow"
+      },
+      "apps": {
+        "suffix": "Приложение(я)",
+        "tooltip": "Просмотр приложений, использующих этот flow"
+      },
+      "tests": {
+        "suffix": "Тест(ы)",
+        "tooltip": "Просмотр тестов flow"
+      },
+      "errors": {
+        "label": "{count} Ошибка(и)"
+      }
+    },
+    "source_search": {
+      "match_count": "{count} совпадение | {count} совпадения",
+      "open_flow": "Открыть flow",
+      "preview_empty": "Выберите результат для предпросмотра. Нажмите на flow в списке результатов, чтобы увидеть его исходный код.",
+      "preview_error": "Не удалось загрузить исходный код flow"
+    },
+    "open source": "Открытый исходный код",
+    "pricing": "Цены",
+    "license": "Лицензия"
   }
 }

--- a/ui/src/translations/zh_CN.json
+++ b/ui/src/translations/zh_CN.json
@@ -1,1678 +1,722 @@
 {
   "zh_CN": {
-    "Add flow": "添加流程",
-    "Default log level": "默认日志级别",
-    "Default namespace": "默认命名空间",
-    "Default page": "默认页面",
-    "Editor fontfamily": "编辑器字体家族",
-    "Editor fontsize": "编辑器字体大小",
-    "Editor theme": "编辑器主题",
-    "Fold auto": "编辑器：自动折叠多行",
-    "Fold content lines": "折叠多行字符串",
-    "Hover description": "编辑器：当鼠标悬停在key或value上时显示字段描述",
-    "Language": "语言",
-    "Per page": "每页",
-    "Set default page": "设置默认页面",
-    "Set labels": "设置标签",
-    "Set labels done": "标签设置成功",
-    "Set labels to execution": "为执行 <code>{id}</code> 添加或更新标签",
-    "Set labels tooltip": "设置执行标签",
-    "Task Id already exist in the flow": "流程中已存在任务ID {taskId}。",
-    "Total": "总计",
-    "Unfold content lines": "展开多行字符串",
-    "about_this_blueprint": "关于此blueprint",
-    "absolute": "绝对",
-    "accept": "接受",
-    "actions": "操作",
-    "activate_basic_auth": "启用基本身份验证",
-    "active": "活动",
-    "active-slots": "活动槽位",
-    "actual state": "实际状态",
-    "add": "添加",
-    "add at position": "在 {position} <code>{task}</code> 添加",
-    "add error handler": "添加错误处理程序",
-    "add flow": "添加流程",
+    "loading": "加载中...",
+    "more actions": "更多操作",
+    "toggle menu": "切换菜单",
+    "panel actions": "面板操作",
+    "playground actions": "游乐场操作",
+    "bulk actions": "批量操作",
+    "view metrics": "查看指标",
+    "remove this item": "移除此项",
     "add label": "添加label",
-    "add task": "添加任务",
-    "add-trigger-in-editor": "首先为您的Flow添加一个Trigger",
-    "add_new_item": "添加新项目",
-    "additionalPlugins": "附加插件",
-    "admin": "管理员",
-    "admin_preferences": "Preferences",
-    "administration": "管理",
-    "advanced configuration": "其他属性",
-    "after": "之后",
-    "aggregation": "聚合",
-    "ai": {
-      "dashboard": {
-        "prompt_placeholder": "询问有关您数据的问题。示例提示：显示我过去7天内的flow成功率。"
+    "remove label": "移除标签",
+    "id": "ID",
+    "type": "类型",
+    "ok": "确定",
+    "valid": "有效",
+    "close": "关闭",
+    "namespace": "命名空间",
+    "description": "描述",
+    "show description": "显示描述",
+    "show details": "显示详情",
+    "show more details": "显示更多详情",
+    "skipped": "跳过",
+    "revision": "修订版",
+    "Language": "语言",
+    "Set default page": "设置默认页面",
+    "theme": "主题",
+    "flows": "流程",
+    "flow": "流程",
+    "invalid source": "无效的源代码",
+    "missingSource": "缺少源",
+    "update": "更新",
+    "update ok": "已更新",
+    "delete ok": "已删除",
+    "Default page": "默认页面",
+    "confirmation": "确认",
+    "common": {
+      "back": "返回"
+    },
+    "delete confirm": "确定要删除 <code>{name}</code> 吗？",
+    "outdated revision save confirmation": {
+      "confirm": "你想覆盖它吗？",
+      "update": {
+        "title": "修订版过时",
+        "description": "你正在编辑的修订版已过时。",
+        "details": "查看修订标签以了解最新版本的详细信息。"
       },
-      "flow": {
-        "enable_instructions": {
-          "footer": "注意：目前，开源版仅支持Gemini作为AI提供商。对于企业版，请参阅AI Copilot文档以获取其他模型提供商的配置。\n\n保存配置后，重新启动您的Kestra实例。",
-          "header": "<b>AI Copilot 尚未配置。</b>\n\n要启用 AI Copilot，请将以下代码片段添加到您的 Kestra 实例配置文件中（例如 <code>application.yml</code>），并将 <code>geminiApiKey</code> 替换为您的实际 key："
-        },
-        "generating": {
-          "app": "正在为您生成应用程序 YAML...",
-          "dashboard": "正在为您生成Dashboard YAML...",
-          "flow": "正在为您生成Flow YAML...",
-          "test": "正在为您生成测试 YAML..."
-        },
-        "prompt_placeholder": "输入指令以创建您的Kestra flow。示例提示：创建一个每周一上午9点运行的flow。",
-        "select_provider": "选择提供商",
-        "title": "AI代理"
+      "create": {
+        "title": "流程已存在",
+        "description": "在此namespace中已存在具有相同id的flow。",
+        "details": "保存以覆盖并创建新版本。"
       }
     },
-    "all executions": "所有执行",
-    "all tags": "所有标签",
-    "api": "API",
-    "appBlocks": "应用模块",
-    "apps": "应用程序",
-    "are you sure change state": "您确定要更改状态吗？",
-    "assets": {
-      "title": "资产"
+    "override": {
+      "title": "你将覆盖当前流程",
+      "details": "先前的flow可以从Revisions标签页恢复。"
     },
-    "attempt": "尝试",
-    "attempts": "尝试",
-    "auditlogs": "审计日志",
-    "automatic refresh": "自动刷新",
-    "avg": "平均",
-    "avg duration": "平均执行时间",
+    "is deprecated": "已弃用",
+    "success": "成功",
+    "save": "保存",
+    "save_as_draft": "保存为草稿",
+    "draft": "草稿",
+    "draft_flow_warning": "此 flow 修订版本为草稿。执行将基于此草稿修订版本运行，如果 flow 定义无效，可能会立即失败。",
+    "save task": "保存任务",
+    "saved": "保存成功",
+    "saved as draft": "已成功保存为草稿",
+    "saved done": "<em>{name}</em> 成功保存",
+    "saved as draft done": "<em>{name}</em> 已成功保存为草稿",
+    "multiple saved done": "{name} 已保存",
+    "fileTypeNotAllowed": "不允许的文件类型。接受的类型：{types}",
+    "delete": "删除",
+    "deleted": "删除成功",
+    "deleted confirm": "<em>{name}</em> 成功删除！",
+    "Add flow": "添加流程",
+    "add": "添加",
+    "add_new_item": "添加新项目",
+    "copy": "复制",
+    "copy_to_clipboard": "复制到剪贴板",
+    "copy_and_close": "复制并关闭",
+    "Per page": "每页",
+    "new": "新建",
+    "edit": "编辑",
     "back": "返回",
-    "back_to_dashboard": "返回仪表板",
-    "backfill": "回填",
-    "backfill executions": "回填执行",
-    "backfill paused": "补数据已暂停",
-    "backfill running": "正在运行Backfill",
-    "bar": "酒吧",
-    "before": "之前",
-    "behavior": "行为",
-    "blueprints": {
-      "all": "全部",
-      "apps": "应用蓝图",
-      "community": "社区",
-      "create": "创建一个blueprint",
-      "custom": "自定义blueprints",
-      "dashboards": "仪表板 Blueprints",
-      "detail": {
-        "category": "类别类型",
-        "links": "链接与资源",
-        "openInEditor": "在编辑 Flow 中打开"
-      },
-      "edit": "编辑蓝图",
-      "empty": "没有可显示的blueprints。",
-      "flows": "流程蓝图",
-      "header": {
-        "alt": "蓝图图标",
-        "catch phrase": {
-          "1": "第一步总是最难的。",
-          "2": "探索蓝图以启动您的下一个{kind}。"
-        }
-      },
-      "missingPlugins": {
-        "card": "需要此实例上未安装的 plugin：{plugins}",
-        "description": "此 blueprint 使用了此实例上未安装的 plugin 的 task：{plugins}。请安装它们以使用此 blueprint。",
-        "install": "安装 plugin",
-        "title": "缺少 plugin"
-      },
-      "title": "蓝图"
+    "next": "下一步",
+    "done": "完成",
+    "review your inputs": "检查您的输入",
+    "edit flow": "编辑流程",
+    "executions": "执行",
+    "execution": "执行",
+    "execution id": "执行 Id",
+    "recent_executions": "最近执行",
+    "details": "详情",
+    "overview": "概览",
+    "gantt": "甘特图",
+    "gantt_no_tasks_executed": "此执行结束时未运行任何task。  \n请检查其概览和logs以了解原因。",
+    "gantt_no_tasks_match_filters": "尝试调整搜索、状态或log-level过滤器。",
+    "gantt_no_tasks_match_filters_title": "没有任务符合所选过滤器。",
+    "logs": "日志",
+    "no_logs_data": "无数据",
+    "no_logs_data_description": "请尝试调整过滤器、更改时间范围，或检查flow最近是否已执行。",
+    "no_logs_data_title": "未找到所选过滤器的日志。",
+    "duration": "持续时间",
+    "total_duration": "总持续时间",
+    "running duration": "运行时间",
+    "queued duration": "排队时间",
+    "choose file": "选择文件或拖放到此处...",
+    "launch execution": "执行",
+    "warning flow with triggers": "此流程包含触发器，如果此流程依赖触发表达式，则手动执行将失败。",
+    "triggered": "执行触发器",
+    "triggered done": "执行 <em>{name}</em> 成功触发",
+    "topology": "拓扑",
+    "date": "日期",
+    "prev_execution": "先前执行",
+    "next_execution": "下一次执行",
+    "datepicker": {
+      "leave empty for infinite": "留空表示无限持续时间或输入ISO 8601持续时间（例如：'P1DT1H1M1S'）",
+      "duration example": "例如：'P1DT1H1M1S'",
+      "error": "无效的持续时间格式，必须为ISO 8601持续时间（例如：'P1DT1H1M1S'）",
+      "custom": "自定义",
+      "last5minutes": "最近5分钟",
+      "last15minutes": "最近15分钟",
+      "last1hour": "最近1小时",
+      "last12hours": "最近12小时",
+      "last24hours": "最近24小时",
+      "last48hours": "最近48小时",
+      "last7days": "最近7天",
+      "last30days": "最近30天",
+      "last365days": "最近365天",
+      "next5minutes": "接下来的5分钟",
+      "next15minutes": "接下来的15分钟",
+      "next1hour": "接下来1小时",
+      "next12hours": "接下来的12小时",
+      "next24hours": "接下来的24小时",
+      "next48hours": "接下来的48小时",
+      "next7days": "接下来的7天",
+      "next30days": "接下来的30天",
+      "next365days": "接下来365天",
+      "5minutes": "5分钟",
+      "15minutes": "15分钟",
+      "1hour": "1小时",
+      "12hours": "12小时",
+      "24hours": "24小时",
+      "48hours": "48小时",
+      "7days": "7天",
+      "30days": "30天",
+      "365days": "365天",
+      "never": "从不",
+      "today": "今天",
+      "yesterday": "昨天",
+      "dayBeforeYesterday": "前天",
+      "thisWeek": "本周",
+      "thisWeekSoFar": "截至本周",
+      "previousWeek": "上周",
+      "thisMonth": "本月",
+      "thisMonthSoFar": "截至本月",
+      "previousMonth": "上月",
+      "thisYear": "今年",
+      "thisYearSoFar": "截至今年",
+      "previousYear": "去年",
+      "short": {
+        "15m": "15分钟",
+        "1h": "1小时",
+        "12h": "12小时",
+        "1d": "1天",
+        "7d": "7天"
+      }
     },
-    "body_line_clamp": "Limit line height",
-    "bookmark": "书签",
-    "breakpoints": "断点",
-    "bulk action async warning": "这可能需要一些时间。",
-    "bulk actions": "批量操作",
-    "bulk change state": "您确定要更改<code>{executionCount}</code>次执行的状态吗？",
-    "bulk delete": "确定要删除 <code>{executionCount}</code> 个执行吗？",
-    "bulk delete backfills": "删除 {count} 回填",
-    "bulk delete triggers": "您确定要删除 {count} 个 triggers 吗？",
-    "bulk disabled status": {
-      "false": "启用 {count} 触发器",
-      "true": "禁用 {count} 触发器"
+    "created date": "创建日期",
+    "latest_update": "最新更新",
+    "updated date": "更新日期",
+    "expiration date": "过期日期",
+    "started date": "开始日期",
+    "healthcheck date": "健康检查日期",
+    "next execution date": "下次执行日期",
+    "last execution status": "上次执行状态",
+    "jump to...": "跳转到...",
+    "contextBar": {
+      "news": "新闻",
+      "docs": "文档",
+      "help": "帮助",
+      "issue": "问题",
+      "demo": "演示",
+      "star": "点赞我们"
     },
-    "bulk force run": "您确定要强制运行<code>{executionCount}</code>次执行吗？<br/><br/>WARNING: 强制运行执行不保证成功，并且可能会创建重复的task执行。<br/><br/>将进行以下转换：<br/><ul><li>CREATED的tasks将被移动到RUNNING状态。</li><li>RUNNING的tasks将被重新提交。</li><li>QUEUED的tasks将被取消排队。</li><li>PAUSED的tasks将被恢复。</li></ul>",
-    "bulk kill": "确定要终止 <code>{executionCount}</code> 个执行吗？",
-    "bulk pause": "您确定要暂停 <code>{executionCount}</code> 次执行吗？",
-    "bulk pause backfills": "暂停 {count} 回填",
-    "bulk replay": "确定要重放 <code>{executionCount}</code> 个执行吗？",
-    "bulk restart": "确定要重新开始 <code>{executionCount}</code> 个执行吗？",
-    "bulk resume": "确定要恢复 <code>{executionCount}</code> 个执行吗？",
-    "bulk set labels": "确定要为 <code>{executionCount}</code> 个执行设置标签吗？",
-    "bulk success delete backfills": "{count} 回填已删除",
-    "bulk success delete triggers": "{count} 个 trigger 已成功删除",
-    "bulk success disabled status": {
-      "false": "{count} 个触发器已启用",
-      "true": "{count} 个触发器已禁用"
+    "source": "来源",
+    "source only": "仅限来源",
+    "home": "首页",
+    "create": "创建",
+    "create_flow": "创建Flow",
+    "add flow": "添加流程",
+    "from": "从",
+    "to": "到",
+    "search filters": {
+      "saved": "已保存的过滤器",
+      "manage": "管理搜索过滤器",
+      "manage desc": "管理已保存的搜索过滤器",
+      "save filter": "保存过滤器",
+      "filter name": "过滤器名称",
+      "filters": "过滤器"
     },
-    "bulk success pause backfills": "{count} 回填已暂停",
-    "bulk success unlock": "{count} 触发器已解锁",
-    "bulk success unpause backfills": "{count} 回填已取消暂停",
-    "bulk unlock": "解锁 {count} 触发器",
-    "bulk unpause backfills": "取消暂停 {count} 回填",
-    "bulk unqueue": "您确定要取消排队 <code>{executionCount}</code> 个执行吗？",
-    "can not delete": "无法删除",
-    "can not have less than 1 task": "每个流程必须至少有一个任务。",
-    "can not save": "无法保存",
-    "cancel": "取消",
+    "steps": "步骤",
+    "state": "状态",
+    "state_history": "状态历史",
+    "search term in message": "在消息中搜索术语",
+    "search": "搜索",
+    "search blueprint": "搜索蓝图",
+    "all tags": "所有标签",
+    "source search": "源搜索",
+    "filter by log level": "按日志级别过滤",
+    "selected": "已选择",
+    "task": "任务",
+    "task logs": "任务日志",
+    "display flow {id} executions": "显示流程 {id} 的执行",
+    "actions": "操作",
+    "select datetime": "选择日期",
+    "select view": "选择视图",
+    "invalid field": "无效字段：{name}",
+    "required field": "必填字段",
+    "is required": "{field}是必需的",
+    "error": "错误",
+    "form": "表单",
+    "form error": "表单错误",
+    "display topology for flow": "显示流程的拓扑",
     "cannot create topology": "无法为流程创建拓扑",
-    "cannot swap tasks": "无法交换任务",
-    "change execution state confirm": "您确定要更改执行<code>{id}</code>的状态吗？",
-    "change execution state done": "执行状态已更新",
-    "change queue confirm": "您确定要更改执行 <code>{id}</code> 的队列状态吗？<br/>",
+    "start date": "开始日期",
+    "end date": "结束日期",
+    "creation": "创建",
+    "flow creation": "流程创建",
+    "start datetime": "开始日期时间",
+    "end datetime": "结束日期时间",
+    "restart": "重新开始",
+    "restart latest revision": "重新开始最新修订版",
+    "restart tooltip": "从 <code>{state}</code> 任务重新开始执行",
+    "restarted": "执行已重启",
+    "restart confirm": "确定要重新开始执行 <code>{id}</code> 吗？",
+    "restart change revision": "你可以更改用于新执行的修订版。",
+    "replay": "重放",
+    "replay from task tooltip": "从任务 <code>{taskId}</code> 创建相似的执行",
+    "replay from beginning tooltip": "从头开始创建相似的执行",
+    "replay latest revision": "使用最新修订版重放",
+    "replayed": "执行已重放",
+    "replay confirm": "确定要重放此执行 <code>{id}</code> 并创建一个新的吗？",
+    "replay with inputs": "使用输入重放",
+    "reuse_original_inputs": "重用原始input",
+    "modify_inputs": "修改输入",
+    "replay the execution": "重放 flow <code>{flowId}</code> 的执行 <code>{executionId}</code>",
+    "prefill inputs": "预填",
+    "current": "当前",
     "change state": "更改状态",
-    "change state confirm": "您确定要更改执行 <code>{id}</code> 中 <code>{task}</code> 任务的任务运行状态吗？",
-    "change state current state": "当前状态是：",
+    "actual state": "实际状态",
+    "select a state": "选择状态",
+    "are you sure change state": "您确定要更改状态吗？",
+    "yes": "是",
     "change state done": "任务状态已更新",
+    "change state confirm": "您确定要更改执行 <code>{id}</code> 中 <code>{task}</code> 任务的任务运行状态吗？",
+    "change queue confirm": "您确定要更改执行 <code>{id}</code> 的队列状态吗？<br/>",
+    "change state current state": "当前状态是：",
     "change state hint": {
+      "WARNING": [
+        "流程将被标记为WARNING。",
+        "接下来的tasks将被执行。",
+        "错误的tasks将被执行。"
+      ],
       "FAILED": [
         "该flow将被标记为FAILED。",
         "不会执行其他task。",
         "将执行错误tasks。"
-      ],
-      "RUNNING": [
-        "flow将重新启动，并将执行所有后续task。",
-        "所有被阻止的task将被执行。"
       ],
       "SUCCESS": [
         "由于此任务成功，flow 将重新启动。",
         "所有被阻止的任务将被执行。",
         "如果所有任务运行都成功，flow 将处于 SUCCESS 状态。"
       ],
-      "WARNING": [
-        "流程将被标记为WARNING。",
-        "接下来的tasks将被执行。",
-        "错误的tasks将被执行。"
+      "RUNNING": [
+        "flow将重新启动，并将执行所有后续task。",
+        "所有被阻止的task将被执行。"
       ]
     },
+    "replay execution title": "重放执行",
+    "restart execution title": "重新启动执行",
+    "replay execution description": "这将基于所选的执行创建一个新的执行。",
+    "replay using": "使用重播",
+    "flow revision original": "原始flow修订版",
+    "flow revision latest": "最新的flow修订版",
+    "flow revision specific": "特定flow修订版",
+    "replay inputs": "输入",
+    "reuse original inputs": "重用原始input",
+    "modify inputs": "修改inputs",
+    "replay inputs new required": "此修订版有inputs。系统将提示您填写它们。",
+    "replay select taskrun": "选择要重放的task运行：",
     "change state tooltip": "更改执行状态",
-    "chart": "图表",
-    "chart preview": "图表预览",
-    "chart type": "图表类型",
-    "charts": "图表",
-    "choice": "选择",
-    "choose file": "选择文件或拖放到此处...",
-    "close": "关闭",
-    "close sidebar": "关闭侧边栏",
-    "codeDisabled": "在Flow中禁用",
-    "collapse": "折叠",
-    "collapse all": "折叠所有",
-    "commit_id": "提交 id",
-    "common": {
-      "back": "返回"
-    },
-    "concurrency": "并发",
-    "concurrency limits": "并发限制",
-    "concurrency_limit": {
-      "dialog_title": "并发限制",
-      "warning": "更改运行计数器可能会破坏并发性，因此执行可能会超出允许的限制。"
-    },
-    "conditions": "条件",
-    "configure basic auth": "配置基本认证",
-    "confirm": "确认",
-    "confirm password": "确认密码",
-    "confirmation": "确认",
-    "context updated date": "上下文更新日期",
-    "context updated date tooltip": "触发器的上下文上次更新的时间。这发生在执行被触发、完成（锁释放）或评估后（即使没有执行发生）。",
-    "contextBar": {
-      "demo": "演示",
-      "docs": "文档",
-      "help": "帮助",
-      "issue": "问题",
-      "news": "新闻",
-      "star": "点赞我们"
-    },
-    "continue backfill": "继续回填",
-    "continue backfills": "继续回填",
-    "copied": "已复制",
-    "copied_logs_to_clipboard": "已将日志复制到剪贴板。",
-    "copy": "复制",
-    "copy all logs": "复制所有日志",
-    "copy logs": "复制日志",
-    "copy url": "复制 URL",
-    "copy_and_close": "复制并关闭",
-    "copy_to_clipboard": "复制到剪贴板",
-    "copy_value": "Copy value",
-    "create": "创建",
-    "create first task": "创建你的第一个任务",
-    "create_flow": "创建Flow",
-    "created date": "创建日期",
-    "creation": "创建",
-    "cron": "定时任务",
-    "curl": {
-      "command": "cURL命令",
-      "note": "请注意，对于SECRET和FILE类型的input，命令必须调整以匹配实际值。"
-    },
-    "current": "当前",
-    "current execution": "当前执行",
-    "custom value": "自定义值",
-    "customize sidebar": "自定义侧边栏",
-    "dark_version": "深色版本",
-    "dashboards": {
-      "chart_preview": "单击图表源代码以查看其预览",
-      "creation": {
-        "confirmation": "仪表板 <code>{title}</code> 已创建。",
-        "label": "创建仪表板"
-      },
-      "default": "默认仪表板",
-      "deletion": {
-        "confirmation": "您确定要删除<code>{title}</code>仪表板吗？"
-      },
-      "edition": {
-        "chart": "编辑此图表",
-        "confirmation": "仪表板<code>{title}</code>中的更改已保存。",
-        "id readonly": "属性 `id` 不能更改——它现在设置为初始值。如果您想更改它，可以创建一个新的仪表板并删除旧的。",
-        "label": "编辑仪表板"
-      },
-      "empty": "没有结果显示。",
-      "export": "导出为CSV",
-      "labels": {
-        "plural": "仪表板",
-        "singular": "仪表板"
-      },
-      "no_description": "无描述",
-      "no_description_hint": "为此 flow 添加描述以记录其功能。<br>支持 Markdown。",
-      "others": "其他",
-      "preview": "预览仪表板",
-      "quick_filters": {
-        "all": "全部",
-        "failed": "失败",
-        "paused": "已暂停",
-        "running": "运行中",
-        "success": "成功",
-        "warning": "警告"
-      },
-      "switch": "切换仪表板",
-      "viewAll": "查看全部"
-    },
-    "data": "数据",
-    "dataFilters": "数据过滤器",
-    "data_not_protected": "您的数据未受保护。不要丢失它。<b>启用我们的免费安全功能或试用我们的付费服务。</b>",
-    "date": "日期",
-    "date count": "{date}的{count}",
-    "date format": "日期格式",
-    "date range count": "{startDate}到{endDate}之间的{count}",
-    "datepicker": {
-      "12hours": "12小时",
-      "15minutes": "15分钟",
-      "1hour": "1小时",
-      "24hours": "24小时",
-      "30days": "30天",
-      "365days": "365天",
-      "48hours": "48小时",
-      "5minutes": "5分钟",
-      "7days": "7天",
-      "custom": "自定义",
-      "dayBeforeYesterday": "前天",
-      "duration example": "例如：'P1DT1H1M1S'",
-      "error": "无效的持续时间格式，必须为ISO 8601持续时间（例如：'P1DT1H1M1S'）",
-      "last12hours": "最近12小时",
-      "last15minutes": "最近15分钟",
-      "last1hour": "最近1小时",
-      "last24hours": "最近24小时",
-      "last30days": "最近30天",
-      "last365days": "最近365天",
-      "last48hours": "最近48小时",
-      "last5minutes": "最近5分钟",
-      "last7days": "最近7天",
-      "leave empty for infinite": "留空表示无限持续时间或输入ISO 8601持续时间（例如：'P1DT1H1M1S'）",
-      "never": "从不",
-      "next12hours": "接下来的12小时",
-      "next15minutes": "接下来的15分钟",
-      "next1hour": "接下来1小时",
-      "next24hours": "接下来的24小时",
-      "next30days": "接下来的30天",
-      "next365days": "接下来365天",
-      "next48hours": "接下来的48小时",
-      "next5minutes": "接下来的5分钟",
-      "next7days": "接下来的7天",
-      "previousMonth": "上月",
-      "previousWeek": "上周",
-      "previousYear": "去年",
-      "short": {
-        "12h": "12小时",
-        "15m": "15分钟",
-        "1d": "1天",
-        "1h": "1小时",
-        "7d": "7天"
-      },
-      "thisMonth": "本月",
-      "thisMonthSoFar": "截至本月",
-      "thisWeek": "本周",
-      "thisWeekSoFar": "截至本周",
-      "thisYear": "今年",
-      "thisYearSoFar": "截至今年",
-      "today": "今天",
-      "yesterday": "昨天"
-    },
-    "debug": "调试",
-    "default": "默认值",
-    "defaultsToNamespaceFile": "默认为 namespace 文件：<code>{name}</code>",
-    "delete": "删除",
-    "delete backfill": "删除回填",
-    "delete backfills": "删除回填",
-    "delete confirm": "确定要删除 <code>{name}</code> 吗？",
-    "delete execution running": "<div class=\"alert alert-warning mt-2 mb-0\">此执行仍在运行，删除它不会停止它。<br />你需要终止执行以停止它。</div>",
-    "delete logs": "删除日志",
-    "delete ok": "已删除",
-    "delete revision confirm": "您确定要删除修订版 {revision} 吗？",
-    "delete revision error": "删除修订版 {revision} 时出错，错误信息 {error}",
-    "delete task confirm": "确定要删除任务 <code>{taskId}</code> 吗？",
-    "delete trigger": "删除 trigger",
-    "delete trigger confirmation": "您确定要删除trigger {id}吗？WARNING: 如果trigger仍在flow中激活，删除trigger可能会导致重复执行。",
-    "delete trigger error": "删除触发器 {id} 时出错",
-    "delete trigger success": "触发器 {id} 已成功删除",
-    "delete triggers": "删除 triggers",
-    "delete_all_logs": "确定要删除所有日志吗？",
-    "delete_log": "您确定要删除这个log吗？",
-    "deleted": "删除成功",
-    "deleted confirm": "<em>{name}</em> 成功删除！",
-    "deleted_label": "已删除",
-    "demos": {
-      "IAM": {
-        "message": "Kestra 企业版具有内置的 IAM 功能，包括单点登录 (SSO)、SCIM 目录同步和基于角色的访问控制 (RBAC)，可以与多个身份提供商集成，并允许您为用户和服务帐户分配细粒度的权限。",
-        "title": "通过IAM使用SSO、SCIM和RBAC管理用户"
-      },
-      "apps": {
-        "message": "在 Kestra 企业版中，应用程序允许您构建自定义 UI，以便从平台外部与 Kestra 工作流进行交互。此功能使您可以将工作流用作自定义应用程序的后端，允许非技术用户通过表单提交数据或恢复等待批准的暂停工作流。",
-        "title": "使用 Kestra 构建自定义应用程序"
-      },
-      "assets": {
-        "header": "资产元数据和可观测性",
-        "label": "资产",
-        "message": "资产连接可观测性、血缘关系和所有权元数据，使平台团队能够更快地排查问题并自信地部署。",
-        "title": "将每个数据集、服务和依赖项展示出来。"
-      },
-      "audit-logs": {
-        "message": "Kestra Enterprise Edition记录每个活动，提供强大且不可更改的记录，使得跟踪更改、保持合规性和解决问题变得容易。",
-        "title": "使用审计日志跟踪更改"
-      },
-      "blueprints": {
-        "message": "在 Kestra 企业版中，您可以创建仅供您的组织使用的自定义 Blueprints。您可以将它们用作最佳实践模板，以便在团队中共享、集中和记录常用的工作流。",
-        "title": "添加自定义蓝图"
-      },
-      "contact_sales": "联系我们的销售团队",
-      "enterprise_edition": "企业版",
-      "get_a_demo_button": "获取演示",
-      "instance": {
-        "message": "Kestra Enterprise Edition 提供一个操作仪表板，帮助您观察平台的健康状况并跟踪所有服务（如 Workers、Schedulers 和 Executors）的正常运行时间指标。在同一页面，您还可以创建公告以通知用户计划中的停机时间，并且可以进入维护模式，将所有服务和工作流执行暂时置于 PAUSED 状态以进行升级。",
-        "title": "管理您的实例中的基础设施"
-      },
-      "namespace": {
-        "assets": {
-          "message": "在 Kestra 企业版中，Assets 保持着与您的工作流交互的资源的实时清单。这些资源可以是数据库表、虚拟机、文件或您使用的任何外部系统。",
-          "title": "集中资产管理"
-        },
-        "audit-logs": {
-          "message": "在 Kestra 企业版中，您可以查看 namespace 级别的审计日志，包含详细的差异，提供所有资源的更改历史，清晰地显示是谁在何时更改了什么。",
-          "title": "在一个地方跟踪所有更改"
-        },
-        "edit": {
-          "message": "在 Kestra 企业版中，namespace 提供了高级的隔离和治理功能，用于管理大规模的密钥、变量和插件默认值。管理员可以为每个 namespace 配置自定义密钥管理器、隔离存储后端、专用 worker 组以及细粒度权限。这确保了密钥、变量和插件配置在不同团队和项目中保持安全且易于维护。",
-          "title": "升级您的Namespace管理"
-        },
-        "history": {
-          "message": "在 Kestra Enterprise Edition 中，您可以管理 Namespace 的修订历史记录。",
-          "title": "在一个地方管理修订历史"
-        },
-        "plugin-defaults": {
-          "message": "在 Kestra Enterprise Edition 中，您可以设置特定于 namespace 的插件默认值，从而减少每个 flow 中重复设置的需求。这种集中的插件管理强制执行一致的配置，允许安全引用机密或变量，并简化工作流的维护。",
-          "title": "使用插件默认值标准化配置"
-        },
-        "secrets": {
-          "message": "在 Kestra Enterprise Edition 中，您可以在 namespace 级别存储和控制机密，从而最大限度地降低风险并确保每个团队的凭据保持隔离。得益于嵌套层次结构，您还可以在父 namespace 中配置凭据，并且它们将被所有子 namespace 继承。对专用机密管理器和细粒度的 namespace 级别权限设置的支持进一步增强了安全性和合规性。",
-          "title": "以安全方式管理Secrets"
-        },
-        "variables": {
-          "message": "在 Kestra 企业版中，您可以定义和管理 namespace 级别的变量，以消除跨 flow 的重复配置。这些变量确保了一致性，简化了配置更新，并且可以被任何 task 或 trigger 轻松引用，从而实现更简洁、更易维护的工作流。",
-          "title": "集中管理您的变量"
-        }
-      },
-      "quotas": {
-        "message": "Kestra 企业版允许您为工作流定义配额，以限制在时间窗口内的并发或总执行次数。配额有助于保护共享基础设施、执行 SLA，并防止失控的工作流消耗过多资源。",
-        "title": "为工作流设置执行配额"
-      },
-      "secrets": {
-        "add_env": {
-          "first": "将<a href=\"https://kestra.io/docs/how-to-guides/secrets?utm_source=app&utm_medium=referral&utm_campaign=secrets-inlinedoc#using-secrets-in-kestra\" target=\"_blank\">secret value编码为Base64</a>",
-          "intro": "创建新Secret：",
-          "second": "添加一个名为 '<strong>SECRET_{'{MY_SECRET_KEY}'}</strong>' 的环境变量，并使用上述值",
-          "third": "重新启动您的Kestra实例"
-        },
-        "detected_env": "以下是在实例启动时识别的secret-type环境变量：",
-        "empty_env": "您还没有在您的环境中添加任何Secrets。",
-        "message": "企业版 (EE) 允许您直接在UI中添加、编辑或删除秘密，无需重启实例。通过细粒度的RBAC权限按namespace组织秘密，并从父namespace继承到子namespace。EE与HashiCorp Vault、AWS Secrets Manager、Azure Key Vault、Google Secret Manager和Elasticsearch等秘密管理器集成。为每个namespace、tenant或实例设置专用后端，以隔离团队之间的秘密，或启用存储在外部vault中的只读秘密。秘密在静态和传输中保持加密。可选的缓存减少API调用，并且审计跟踪记录所有访问。",
-        "title": "升级您的Secrets管理"
-      },
-      "tenants": {
-        "message": "Kestra 企业版支持多租户，为不同的团队或项目提供完全隔离的环境，每个环境都有自己的资源，如专用的worker组、密钥和内部存储后端。",
-        "title": "在独立的tenant中管理工作流"
-      },
-      "tests": {
-        "header": "Flows的单元测试",
-        "label": "测试",
-        "message": "验证您的flow逻辑是否独立，及早检测回归，并在自动化变更和增长时保持信心。",
-        "title": "确保每次更改的可靠性"
-      },
-      "watch_the_video": "观看视频"
-    },
-    "density": "Density",
-    "density_compact": "Compact",
-    "density_expanded": "Expanded",
-    "density_normal": "Normal",
-    "dependencies": "依赖关系",
-    "dependencies delete flow": "此流程有依赖关系。删除它将阻止其依赖关系的执行。<br /><br /> 受影响的流程列表如下：",
-    "dependencies loaded": "依赖项已加载",
-    "dependencies missing acls": "此流程没有权限",
-    "dependency": {
-      "controls": {
-        "clear_selection": "清除选择",
-        "fit_view": "适合屏幕",
-        "zoom_in": "放大",
-        "zoom_out": "缩小视图"
-      },
-      "search": {
-        "flow": {
-          "display": "包含flow依赖项"
-        },
-        "namespace": {
-          "no_namespace": "没有namespace",
-          "select": "选择一个namespace"
-        },
-        "no_results": "未找到与 {term} 相关的结果",
-        "placeholders": {
-          "asset": "按资产、flow或namespace搜索...",
-          "default": "按flow或namespace搜索..."
-        }
-      }
-    },
-    "dependency task": "任务 {taskId} 是另一个任务的依赖",
-    "description": "描述",
-    "details": "详情",
-    "disable": "禁用",
-    "disabled": "禁用",
-    "disabled flow desc": "此流程已禁用，请启用以执行。",
-    "disabled flow title": "此流程已禁用",
-    "discard changes confirmation": "您有未保存的更改。您确定要放弃它们吗？",
-    "discard execution confirmation": "您有未保存的输入。您确定要放弃此执行吗？",
-    "display direct sub tasks count": "显示直接子任务数量",
-    "display flow {id} executions": "显示流程 {id} 的执行",
-    "display metric for specific task": "显示特定任务的指标",
-    "display output for specific task": "显示特定任务的输出",
-    "display topology for flow": "显示流程的拓扑",
-    "display_settings": "Display settings",
-    "docs": "文档",
-    "documentation": {
-      "documentation": "文档",
-      "github": "打开一个GitHub问题"
-    },
-    "documentationMenu": "文档菜单",
-    "done": "完成",
-    "down trend": "减少",
-    "download": "下载",
-    "download logs": "下载日志",
-    "download_logos": "下载 Logo 包",
-    "download_logs_description": "Choose which logs to export. Filters default to your current view.",
-    "draft": "草稿",
-    "draft_available": "编辑器中有可用的草稿更改",
-    "draft_flow_warning": "此 flow 修订版本为草稿。执行将基于此草稿修订版本运行，如果 flow 定义无效，可能会立即失败。",
-    "drill down preview": "预览",
-    "drop items here": "将项目拖放到此处",
-    "duplicate-pair": "{label} \"{key}\" 是重复的，第一个 key 被忽略。",
-    "duration": "持续时间",
-    "dynamic": "动态",
-    "each value": "迭代值",
-    "edit": "编辑",
-    "edit flow": "编辑流程",
-    "editor": "编辑器",
-    "editor_shortcuts": {
-      "command_palette": "显示命令面板",
-      "comment": "评论",
-      "comment_uncomment": "注释/取消注释",
-      "decrease_fontsize": "减小编辑器字体大小",
-      "duplicate_cursor": "复制光标",
-      "execute_flow": "执行 flow",
-      "fold_unfold": "折叠/展开代码",
-      "increase_fontsize": "增加编辑器字体大小",
-      "label": "键盘快捷键",
-      "move_line": "移动行",
-      "reset_fontsize": "重置编辑器字体大小",
-      "save_flow": "保存flow",
-      "toggle_ai_agent": "切换AI代理",
-      "trigger_autocompletion": "触发自动完成",
-      "uncomment": "取消注释"
-    },
-    "ee-tooltip": {
-      "button": "联系我们",
-      "features-blocked": "此功能需要企业版。"
-    },
-    "email": "电子邮件",
-    "email length constraint": "电子邮件不得超过256个字符",
-    "empty": {
-      "announcements": {
-        "content": "公告允许您通知用户任何更改或告知他们计划的维护停机时间。只需选择公告类型、显示的日期范围，并撰写公告消息。",
-        "title": "您还没有公告！"
-      },
-      "apiTokens": {
-        "content": "API令牌用于在您希望授予程序化访问Kestra API时使用。",
-        "title": "管理您的API Tokens"
-      },
-      "apps": {
-        "content": "开始构建应用程序，以便与外部世界的Kestra进行交互。",
-        "title": "您还没有应用程序！"
-      },
-      "assets": {
-        "content": "添加资产以跟踪和管理您的数据资产、服务和基础设施。",
-        "title": "您还没有资产！"
-      },
-      "concurrency_executions": {
-        "content": "在我们的文档中阅读更多关于<strong><a href=\"https://kestra.io/docs/workflow-components/execution?utm_source=app&utm_medium=referral&utm_campaign=concurrency-inlinedoc\" target=\"_blank\">Executions</a></strong>的信息。",
-        "title": "此 Flow 没有正在进行的 Executions。"
-      },
-      "concurrency_limit": {
-        "content": "在我们的文档中阅读更多关于<strong><a href=\"https://kestra.io/docs/workflow-components/concurrency?utm_source=app&utm_medium=referral&utm_campaign=concurrency-inlinedoc\" target=\"_blank\">Concurrency Limits</a></strong>的信息。",
-        "title": "此Flow未设置限制。"
-      },
-      "concurrency_limits": {
-        "content": "在我们的文档中阅读更多关于<strong><a href=\"https://kestra.io/docs/workflow-components/concurrency?utm_source=app&utm_medium=referral&utm_campaign=concurrency-inlinedoc\" target=\"_blank\">并发限制</a></strong>的信息。",
-        "title": "未设置并发限制。"
-      },
-      "dependencies": {
-        "ASSET": {
-          "content": "此资产与flow或其他资产没有上游或下游依赖关系。",
-          "title": "当前没有依赖项。"
-        },
-        "EXECUTION": {
-          "content": "了解更多关于<a href=\"https://kestra.io/docs/ui/executions?utm_source=app&utm_medium=referral&utm_campaign=dependencies-inlinedoc#dependencies\" target=\"_blank\">执行依赖关系</a>的信息，请参阅我们的文档。",
-          "title": "当前没有依赖项。"
-        },
-        "FLOW": {
-          "content": "在我们的文档中阅读更多关于<a href=\"https://kestra.io/docs/ui/flows?utm_source=app&utm_medium=referral&utm_campaign=dependencies-inlinedoc#dependencies\" target=\"_blank\">Flow Dependencies</a>的信息。",
-          "title": "当前没有依赖项。"
-        },
-        "NAMESPACE": {
-          "content": "了解更多关于<a href=\"https://kestra.io/docs/ui/namespaces?utm_source=app&utm_medium=referral&utm_campaign=dependencies-inlinedoc#dependencies\" target=\"_blank\">Namespace Dependencies</a>的信息，请参阅我们的文档。",
-          "title": "当前没有依赖项。"
-        }
-      },
-      "groups": {
-        "content": "组允许您将用户捆绑在一起，以便您可以在整个租户中集体管理权限和角色绑定。",
-        "title": "您还没有群组！"
-      },
-      "kill_switches": {
-        "content": "Kill Switch 功能提供了一种基于UI的机制来停止有问题的执行。它用一个全面的管理界面替代了仅限CLI的<code>--skip-executions</code>和<code>--skip-flows</code>命令。",
-        "title": "您还没有 Kill Switches！"
-      },
-      "mcpToolFlows": {
-        "content": "通过向flow添加<code>McpToolTrigger</code>，将flow公开为MCP工具。请在我们的文档中阅读更多关于<strong><a href=\"https://kestra.io/docs/workflow-components/triggers/mcp-tool-trigger?utm_source=app&utm_medium=referral&utm_campaign=mcp-tool-trigger-inlinedoc\" target=\"_blank\">MCP Tool Trigger</a></strong>的信息。",
-        "title": "此服务器上尚未注册任何工具flow。"
-      },
-      "namespaceFiles": {
-        "content": "命名空间文件的作用类似于此命名空间的项目文件夹。存储 Python、SQL、dbt 或 Terraform 代码，然后在您的 flow 中引用任何文件，使用",
-        "title": "此命名空间中尚无文件"
-      },
-      "panels": {
-        "content": "您已关闭所有面板。  \n请选择上面的选项卡以继续。",
-        "title": "没有面板打开"
-      },
-      "pluginDefaults": {
-        "content": "插件默认设置允许您集中管理插件配置，并与namespace中的所有flow共享。",
-        "title": "您还没有插件默认值！"
-      },
-      "plugins": {
-        "content": "在我们的文档中阅读更多关于<strong><a href=\"https://kestra.io/docs/workflow-components/plugin-defaults?utm_source=app&utm_medium=referral&utm_campaign=plugin-default-inlinedoc\" target=\"_blank\">Concurrency Limits</a></strong>的信息。",
-        "title": "此Namespace未设置插件默认值。"
-      },
-      "testSuites": {
-        "content": "开始创建测试套件以测试您的Flows。",
-        "title": "您还没有测试套件！"
-      },
-      "triggers": {
-        "content": "在我们的文档中阅读更多关于<strong><a href=\"https://kestra.io/docs/workflow-components/triggers?utm_source=app&utm_medium=referral&utm_campaign=trigger-inlinedoc\" target=\"_blank\">Triggers</a></strong>的信息。",
-        "title": "您的 flow 没有任何 Triggers。"
-      },
-      "variables": {
-        "content": "添加kv store以在不同的flow之间共享配置。子namespace会自动继承这些配置，您可以引用任何value。",
-        "title": "尚无变量"
-      },
-      "versionPlugin": {
-        "content": "在这里，您可以管理安装在您的 Kestra 实例上的所有插件。新安装的插件可能不会立即在所有 Kestra 服务中可用，这取决于您的实例配置。",
-        "title": "您还没有版本化的插件！"
-      },
-      "workerRegistrationTokens": {
-        "content": "注册令牌允许远程worker安全地进行身份验证并注册到您的Kestra实例。创建一个令牌，然后使用它将新worker连接到此集群。",
-        "title": "您还没有注册令牌！"
-      }
-    },
-    "empty search": "搜索结果为空",
-    "enable": "启用",
-    "enable concurrency": "启用并发",
-    "enabled": "已启用",
-    "encoding": "编码",
-    "end date": "结束日期",
-    "end datetime": "结束日期时间",
-    "environment": "环境",
-    "environment color setting": "环境颜色",
-    "environment name setting": "环境名称",
-    "error": "错误",
-    "error detected": "检测到错误。",
-    "error in editor": "在编辑器中发现错误",
-    "errorLogs": "错误日志",
-    "errors": {
-      "401": {
-        "content": "你需要认证才能访问此页面。",
-        "title": "未授权"
-      },
-      "403": {
-        "content": "你没有访问此页面所需的权限。",
-        "title": "访问被拒绝"
-      },
-      "404": {
-        "content": "请求的URL未在此服务器上找到。<br />这就是我们所知道的。",
-        "flow or execution": "你正在寻找的流程或执行不存在。",
-        "title": "页面未找到"
-      }
-    },
+    "change execution state confirm": "您确定要更改执行<code>{id}</code>的状态吗？",
+    "change execution state done": "执行状态已更新",
+    "mark as": "标记为 <code>{status}</code>",
+    "unqueue as": "取消排队为<code>{status}</code>",
+    "kill": "终止",
+    "kill parents and subflow": "终止当前和subflows",
+    "kill only parents": "仅终止当前",
+    "killed confirm": "确定要终止执行 <code>{id}</code> 吗？",
+    "killed done": "执行已排队终止",
+    "resume": "恢复",
+    "resumed title": "恢复执行 <code>{id}</code>",
+    "resumed confirm": "确定要恢复执行 <code>{id}</code> 吗？",
+    "resumed done": "执行已恢复",
+    "resume from breakpoint title": "从断点恢复执行 `{{id}}`",
+    "resume from breakpoint done": "执行已从断点恢复",
+    "breakpoints": "断点",
+    "pause": "暂停",
+    "pause title": "暂停执行<code>{id}</code>。<br/>请注意，当前正在运行的task仍将被处理，并且执行需要手动恢复。",
+    "pause confirm": "您确定要暂停执行<code>{id}</code>吗？",
+    "pause done": "执行已PAUSED",
+    "unqueue": "出队列",
+    "unqueue title": "取消执行 <code>{id}</code>。<br/>请注意，它将不遵循 flow 并发限制，因此可能会有超过允许限制的执行正在运行。",
+    "unqueue title multiple": "您确定要取消排队 <code>{count}</code> 个执行吗？<br/><br/>请注意，这将不遵循flow的并发限制，因此可能会有超过允许限制的执行正在运行。",
+    "unqueue confirm": "您确定要取消排队执行<code>{id}</code>吗？",
+    "unqueue done": "执行已出队列",
+    "force run": "强制运行",
+    "force run title": "强制运行执行 <code>{id}</code>。",
+    "force run tooltip": "强制执行运行。这可能会创建重复的task执行，如果可能，请使用其他操作。",
+    "force run confirm": "您确定要强制运行执行 <code>{id}</code> 吗？<br/><br/>WARNING: 强制运行执行不保证成功，并且可能会创建重复的任务执行。<br/><br/>将进行以下转换：<br/><ul><li>CREATED 任务将被移动到 RUNNING 状态。</li><li>RUNNING 任务将被重新提交。</li><li>QUEUED 任务将被取消排队。</li><li>PAUSED 任务将被恢复。</li></ul>",
+    "force run done": "执行被强制运行",
+    "toggle output": "切换输出",
+    "metrics": "指标",
+    "no data current task": "当前task没有可用数据",
+    "no metrics available": "此task运行没有记录任何指标。",
+    "no outputs available": "此任务运行没有可用的输出。",
+    "outputs": "输出",
+    "flow_outputs": "Flow Outputs",
+    "no_flow_outputs": "没有可用的output。",
+    "output": "输出",
     "eval": {
-      "expression": "表达式",
-      "preview": "预览",
-      "render": "渲染表达式",
       "title": "调试表达式",
-      "tooltip": "渲染任何Pebble表达式并检查执行上下文。"
+      "render": "渲染表达式",
+      "tooltip": "渲染任何Pebble表达式并检查执行上下文。",
+      "preview": "预览",
+      "expression": "表达式"
     },
-    "evaluation lock date": "评估锁定日期",
-    "execute": "执行",
-    "execute backfill": "执行回填",
-    "execute flow behaviour": "执行流程",
-    "execute flow now ?": "是否要执行此流程？",
-    "execute the flow": "执行流程 <code>{id}</code>",
-    "execution": "执行",
-    "execution already finished": "执行 <code>{executionId}</code> 已完成",
-    "execution id": "执行 Id",
-    "execution labels": "执行标签",
-    "execution not found": "执行 {executionId} 未找到。",
-    "execution not in state FAILED": "执行 <code>{executionId}</code> 未处于失败状态",
-    "execution not in state PAUSED": "执行 <code>{executionId}</code> 未处于暂停状态",
-    "execution replay": "此执行是以下内容的重放",
-    "execution replayed": "此执行已被重放。",
-    "execution restarted": "此执行已重新启动{nbRestart}次。",
+    "attempt": "尝试",
+    "toggle output display": "切换输出显示",
+    "name": "名称",
+    "key": "键",
+    "value": "值",
+    "each value": "迭代值",
+    "current execution": "当前执行",
+    "parent execution": "父执行",
+    "original execution": "原始执行",
+    "automatic refresh": "自动刷新",
+    "toggle periodic refresh each x seconds": "切换每隔 {interval} 秒的定期刷新",
+    "trigger refresh": "触发刷新",
+    "add-trigger-in-editor": "首先为您的Flow添加一个Trigger",
+    "refresh": "刷新",
+    "filter by status": "按{status}状态筛选执行",
+    "topology-graph": {
+      "graph-orientation": "图表方向",
+      "zoom-in": "放大",
+      "zoom-out": "缩小",
+      "zoom-reset": "重置缩放",
+      "zoom-fit": "适应屏幕",
+      "invalid": "图形错误",
+      "invalid_description": "加载图表时发生错误。请检查源代码中的错误。"
+    },
+    "show task logs": "显示任务日志",
+    "show task condition": "显示任务条件",
+    "show task outputs": "显示任务输出",
+    "show task source": "显示任务源代码",
+    "specific task": "特定任务",
+    "display output for specific task": "显示特定任务的输出",
+    "display metric for specific task": "显示特定任务的指标",
+    "display direct sub tasks count": "显示直接子任务数量",
+    "stream": "流",
     "execution statistics": "执行统计",
-    "execution-include-non-terminated": "包括未终止的执行？",
-    "execution-warn-deleting-still-running": "我们强烈建议您取消此操作，并首先终止任何正在进行的执行。删除未终止的执行可能导致并发性问题、flow依赖管理不一致以及实例上的僵尸进程，这些都会降低系统性能。在继续删除之前，请确保您完全了解这些风险。",
-    "execution-warn-title": "重要警告！",
-    "execution_deletion": {
-      "logs": "删除日志",
-      "metrics": "删除指标",
-      "storage": "删除内部存储文件"
-    },
-    "execution_failed": "执行失败！",
-    "execution_guide": {
-      "get_started": {
-        "text": "请按照快速入门指南安装Kestra并开始构建您的第一个工作流。",
-        "title": "开始使用 ⚡"
-      },
-      "namespaces": {
-        "text": "namespace 是 flow 及其组件的逻辑分组。",
-        "title": "关于Namespaces"
-      },
-      "videos_tutorials": {
-        "text": "开始观看我们的视频教程。",
-        "title": "视频教程"
-      },
-      "workflow_components": {
-        "text": "了解 Kestra 工作流的主要编排组件。",
-        "title": "工作流组件"
-      }
-    },
-    "execution_started": "执行已开始！",
-    "execution_starts_progress": "一旦执行开始，您将在此处看到进度更新。",
-    "execution_status": "执行状态是：",
-    "executions": "执行",
-    "executions deleted": "<code>{executionCount}</code> 个执行已删除",
+    "stats": "统计",
+    "concurrency limits": "并发限制",
+    "system overview": "系统概览",
+    "usage": "使用情况",
+    "namespaces": "命名空间",
+    "tasks": "任务",
     "executions duration (in minutes)": "总执行持续时间（分钟）",
-    "executions force run": "<code>{executionCount}</code> 次执行被强制运行",
-    "executions killed": "<code>{executionCount}</code> 个执行已终止",
-    "executions paused": "<code>{executionCount}</code> 次执行已暂停",
-    "executions replayed": "<code>{executionCount}</code> 个执行已重放",
-    "executions restarted": "<code>{executionCount}</code> 个执行已重新开始",
-    "executions resumed": "<code>{executionCount}</code> 个执行已恢复",
-    "executions state changed": "<code>{executionCount}</code> 次执行的状态已更改",
-    "executions unqueue": "<code>{executionCount}</code> 次执行未排队",
-    "expand": "展开",
-    "expand all": "展开所有",
-    "expand dependencies": "展开依赖关系",
-    "expand error": "仅展开失败的任务",
-    "expand_by_default": "Expand structured logs by default",
-    "expiration": "过期",
-    "expiration date": "过期日期",
-    "export": "导出",
-    "export all flows": "导出所有流程",
-    "export all templates": "导出所有模板",
-    "export_as": "导出为.{format}",
-    "export_csv": "导出为CSV",
-    "exports": "导出",
-    "failed to export plugin defaults": "无法导出插件默认值",
-    "failed to import plugin defaults": "无法导入插件默认值",
-    "failed to render pdf": "渲染PDF预览失败",
-    "false": "假",
-    "feeds": {
-      "heading": "所有关于Kestra的内容。",
-      "subheading": "最新更新、指南和故事",
-      "title": "Kestra的最新动态"
+    "last 48 hours": "最近48小时",
+    "configure basic auth": "配置基本认证",
+    "email": "电子邮件",
+    "password": "密码",
+    "confirm password": "确认密码",
+    "email length constraint": "电子邮件不得超过256个字符",
+    "password length constraint": "密码不得超过256个字符",
+    "password empty constraint": "用户名或密码不正确",
+    "passwords do not match": "密码不匹配",
+    "avg duration": "平均执行时间",
+    "neutral trend": "稳定",
+    "up trend": "增加",
+    "down trend": "减少",
+    "update aborted": "更新中止",
+    "invalid flow": "无效流程",
+    "invalid yaml": "无效的 YAML",
+    "inputs": "输入",
+    "no_inputs": "没有可用的input。",
+    "input": "输入",
+    "variables": "变量",
+    "variable_explorer": {
+      "title": "输入/输出",
+      "search_placeholder": "搜索 Key 或 value...",
+      "tasks_outputs": "Tasks outputs",
+      "tree": "树",
+      "raw_json": "Raw JSON",
+      "select_prompt": "选择一个变量以查看其 value。",
+      "empty": "此执行没有可用的变量。",
+      "one_key": "\\{ 1 key \\}",
+      "n_keys": "\\{ {count} keys \\}",
+      "one_item": "[ 1 项 ]",
+      "n_items": "[ {count} 项 ]"
     },
-    "file preview truncated": "显示的内容已被截断",
-    "file unavailable": "文件不可用",
-    "file unavailable description": "该文件不再可用——可能已被清除或过期。",
-    "fileTypeNotAllowed": "不允许的文件类型。接受的类型：{types}",
     "file_preview": {
       "big_file_warning": "此文件大小为{size}。加载可能需要一些时间，并可能阻塞您的浏览器。您是否仍然要加载它？",
       "load_anyway": "仍然加载"
     },
-    "files": "文件",
-    "filter by log level": "按日志级别过滤",
-    "filter by status": "按{status}状态筛选执行",
-    "filter by this value": "Filter by this value",
-    "filter_for": "Filter for",
-    "filter_out": "Filter out",
-    "filters": {
-      "comparators": {
-        "between": "之间",
-        "contains": "包含",
-        "ends_with": "以...结束",
-        "greater_than": "大于",
-        "greater_than_or_equal_to": "大于或等于",
-        "in": "在",
-        "is": "是",
-        "is_not": "不是",
-        "is_one_of": "是其中之一",
-        "less_than": "小于",
-        "less_than_or_equal_to": "小于或等于",
-        "not_contains": "不包含",
-        "not_in": "不在",
-        "starts_with": "以...开始"
-      },
-      "empty": "无数据。",
-      "format": "将参数输入为 'key:value'",
-      "label": "选择过滤器",
-      "options": {
-        "absolute_date": "绝对日期",
-        "action": "操作",
-        "aggregation": "聚合",
-        "child": "子节点",
-        "details": "详情",
-        "endDate": "结束日期",
-        "flow": "流程",
-        "labels": "标签",
-        "level": "日志级别",
-        "metric": "指标",
-        "namespace": "命名空间",
-        "permission": "权限",
-        "relative_date": "相对日期",
-        "scope": "范围",
-        "service_type": "类型",
-        "startDate": "开始日期",
-        "state": "状态",
-        "status": "状态",
-        "task": "任务",
-        "text": "文本",
-        "type": "类型",
-        "user": "用户"
-      },
-      "save": {
-        "dialog": {
-          "confirmation": "搜索条件 <code>{name}</code>",
-          "heading": "保存当前搜索",
-          "hint": "您想如何标记此搜索条件？",
-          "placeholder": "标签"
-        },
-        "empty": "您还没有保存任何搜索。",
-        "label": "已保存的搜索",
-        "name_already_used": "搜索标签已被使用。",
-        "remove": "移除",
-        "tooltip": "您不能保存空的搜索条件。"
-      },
-      "settings": {
-        "label": "页面设置",
-        "show_chart": "显示主图表"
-      },
-      "text_search": "搜索此文本"
-    },
-    "fix_with_ai": "使用 AI 修复",
-    "flow": "流程",
-    "flow already exists": "流程已存在",
-    "flow already exists message": "flow <code>{id}</code> 已存在于 namespace <code>{namespace}</code>。您要创建一个新的修订版本吗？",
-    "flow creation": "流程创建",
-    "flow creation denied in namespace": "您没有权限在namespace `{namespace}`中创建flows。",
-    "flow delete": "确定要删除 <code>{flowCount}</code> 个流程吗？",
-    "flow deleted, you can restore it": "流程已删除，这是只读视图。你仍然可以恢复它。",
-    "flow disable": "确定要禁用 <code>{flowCount}</code> 个流程吗？",
-    "flow enable": "确定要启用 <code>{flowCount}</code> 个流程吗？",
-    "flow export": "确定要导出 <code>{flowCount}</code> 个流程吗？",
-    "flow must have id and namespace": "流程必须有ID和命名空间。",
-    "flow must not be empty": "flow不能为空",
-    "flow not imported": "某些flow无法导入",
-    "flow revision latest": "最新的flow修订版",
-    "flow revision original": "原始flow修订版",
-    "flow revision specific": "特定flow修订版",
-    "flow source not found": "未找到flow源",
-    "flow-dependencies": "依赖项",
-    "flow-no-dependencies": "您的flow没有任何依赖项",
-    "flow_editor_stats": {
-      "apps": {
-        "suffix": "应用程序",
-        "tooltip": "查看使用此flow的应用程序"
-      },
-      "dependencies": {
-        "suffix": "依赖项",
-        "tooltip": "查看flow依赖关系"
-      },
-      "errors": {
-        "label": "{count} 错误"
-      },
-      "revisions": {
-        "suffix": "版本",
-        "tooltip": "查看flow修订版本"
-      },
-      "tests": {
-        "suffix": "测试",
-        "tooltip": "查看flow测试"
-      }
-    },
-    "flow_export": "导出flow",
-    "flow_only": "仅在流程标签中可用。",
-    "flow_outputs": "Flow Outputs",
-    "flows": "流程",
-    "flows deleted": "<code>{count}</code> 个流程已删除",
-    "flows disabled": "<code>{count}</code> 个流程已禁用",
-    "flows enabled": "<code>{count}</code> 个流程已启用",
-    "flows exported": "<code>{count}</code> 个 flow 已导出",
-    "flows imported": "Flow已导入",
-    "focus task": "点击任何元素以查看其文档。",
-    "fold_all_multi_lines": "折叠所有多行",
-    "font size": "Font size",
-    "for flow": "用于 flow",
-    "forbidden system labels": "只有 system.correlationId 可以用作系统 label",
-    "force run": "强制运行",
-    "force run confirm": "您确定要强制运行执行 <code>{id}</code> 吗？<br/><br/>WARNING: 强制运行执行不保证成功，并且可能会创建重复的任务执行。<br/><br/>将进行以下转换：<br/><ul><li>CREATED 任务将被移动到 RUNNING 状态。</li><li>RUNNING 任务将被重新提交。</li><li>QUEUED 任务将被取消排队。</li><li>PAUSED 任务将被恢复。</li></ul>",
-    "force run done": "执行被强制运行",
-    "force run title": "强制运行执行 <code>{id}</code>。",
-    "force run tooltip": "强制执行运行。这可能会创建重复的task执行，如果可能，请使用其他操作。",
-    "form": "表单",
-    "form error": "表单错误",
-    "from": "从",
-    "gantt": "甘特图",
-    "gantt_no_tasks_executed": "此执行结束时未运行任何task。  \n请检查其概览和logs以了解原因。",
-    "gantt_no_tasks_match_filters": "尝试调整搜索、状态或log-level过滤器。",
-    "gantt_no_tasks_match_filters_title": "没有任务符合所选过滤器。",
-    "healthcheck date": "健康检查日期",
-    "hide task documentation": "隐藏任务文档",
-    "home": "首页",
-    "hostname": "主机名",
-    "iam": "IAM",
-    "id": "ID",
-    "import": "导入",
-    "in-our-documentation": "在我们的文档中。",
-    "informative notice": "注意事项",
-    "input": "输入",
-    "inputs": "输入",
-    "instance": "实例",
-    "invalid bulk delete": "无法删除执行",
-    "invalid bulk force run": "无法强制运行执行",
-    "invalid bulk kill": "无法终止执行",
-    "invalid bulk pause": "无法暂停执行",
-    "invalid bulk replay": "无法重放执行",
-    "invalid bulk restart": "无法重新开始执行",
-    "invalid bulk resume": "无法恢复执行",
-    "invalid bulk unqueue": "无法取消排队的执行",
-    "invalid field": "无效字段：{name}",
-    "invalid flow": "无效流程",
-    "invalid source": "无效的源代码",
-    "invalid yaml": "无效的 YAML",
-    "is deprecated": "已弃用",
-    "is required": "{field}是必需的",
-    "item": "项目",
-    "items": "项目",
-    "join community": "加入社区",
-    "join_slack": "加入 Slack",
-    "jsonl": "JSONL",
-    "jump to...": "跳转到...",
-    "kestra": "Kestra",
-    "key": "键",
-    "kill": "终止",
-    "kill only parents": "仅终止当前",
-    "kill parents and subflow": "终止当前和subflows",
-    "killed confirm": "确定要终止执行 <code>{id}</code> 吗？",
-    "killed done": "执行已排队终止",
-    "kv": {
-      "add": "创建",
-      "delete multiple": {
-        "confirm": "您确定要删除：<code>{name}</code> kv 吗？",
-        "warning": "您没有这些namespace的权限，因此它们将被省略：<code>{namespaces}</code>"
-      },
-      "duplicate": "此键已存在",
-      "inherited": "继承的KV对",
-      "name": "键值存储",
-      "type": "类型",
-      "update": "更新键 '{key}' 的值"
-    },
-    "label": "标签",
-    "label filter placeholder": "标签为 '键:值'",
-    "labels": "标签",
-    "last 48 hours": "最近48小时",
-    "last X days count": "{days}天内的{count}",
-    "last error was": "上次错误是",
-    "last evaluation date": "上次评估日期",
-    "last evaluation date tooltip": "When the trigger was last evaluated by the scheduler, regardless of whether it produced an execution.",
-    "last execution date": "最后执行日期",
-    "last execution state": "上一次状态",
-    "last execution status": "上次执行状态",
-    "last modified": "上次修改",
-    "last trigger date": "上次触发日期",
-    "last trigger date tooltip": "触发器上次执行的时间。在运行backfill时可能是过去的时间。",
-    "latest_update": "最新更新",
-    "launch execution": "执行",
-    "learn_more": "了解更多",
-    "leave page": "离开页面",
-    "license": "许可证",
-    "light_background": "这是在使用浅色背景时的首选选项。",
-    "light_version": "轻量版本",
-    "line": "行",
-    "line-by-line": "逐行",
-    "loaded x dependencies": "已加载 {count} 个依赖项",
-    "loading": "加载中...",
-    "log expand setting": "日志默认显示",
-    "logExporters": "日志导出器",
-    "logs": "日志",
-    "logs_copied": "Logs copied to your clipboard",
-    "logs_view": {
-      "compact": "默认视图",
-      "compact_details": "按任务分组显示任务日志",
-      "raw": "时间视图",
-      "raw_details": "以原始时间顺序显示完整任务日志和流程日志"
-    },
-    "main_configuration": "主配置",
-    "manage labels": "管理labels",
-    "management port": "管理端口",
-    "mark as": "标记为 <code>{status}</code>",
-    "max": "最大",
-    "mcp": {
-      "api_token": "API Token",
-      "auth_type": "身份验证",
-      "basic_auth": "基本认证",
-      "bearer_token": "Bearer token 身份验证",
-      "client_setup": "客户端设置",
-      "connect": "连接",
-      "connect_tab": {
-        "auth_api_token_hint": "在启动客户端之前，将 <code>KESTRA_TOKEN</code> 设置为环境变量。",
-        "auth_basic_hint": "在启动客户端之前，将 <code>KESTRA_BASIC_AUTH</code> 设置为包含 base64 编码的 <code>username:password</code> 字符串的环境变量。",
-        "auth_oauth_browser_hint": "首次连接时，您的浏览器将打开身份提供商的登录页面。",
-        "auth_oauth_client_id_hint": "将 <code>&lt;client-id&gt;</code> 替换为 OAuth 客户端 ID，并在该客户端上将 <code>http://localhost:7777</code> 注册为有效的重定向 URI。",
-        "claude_code": "Claude代码",
-        "claude_code_hint": "在终端中运行以下命令：",
-        "claude_desktop": "Claude 桌面版",
-        "claude_desktop_hint": "请将以下内容添加到您的 claude_desktop_config.json 文件中：",
-        "claude_desktop_mac": "macOS: ~/Library/Application Support/Claude/claude_desktop_config.json",
-        "claude_desktop_win": "Windows: %APPDATA%\\Claude\\claude_desktop_config.json",
-        "client_picker_label": "选择您的 AI 客户端",
-        "codex": "Codex (OpenAI)",
-        "codex_hint": "将以下内容添加到您的codex.json MCP配置中：",
-        "cursor": "光标",
-        "cursor_hint": "将以下内容添加到 ~/.cursor/mcp.json：",
-        "server_url": "服务器 URL"
-      },
-      "copy_url": "复制 URL",
-      "create": "创建服务器",
-      "delete_confirm": "您确定要删除此MCP服务器吗？",
-      "id_invalid": "ID必须以小写字母或数字开头，并且只能包含小写字母、数字、连字符或下划线。",
-      "id_placeholder": "例如 my-mcp-server",
-      "instructions": "说明",
-      "main_tenant": "main",
-      "managed_by_kestra": "由 Kestra 管理",
-      "no_oauth_providers": "此实例中未配置 OIDC 提供商",
-      "no_servers": "未找到MCP服务器。创建您的第一个服务器以向外部AI代理公开MCP Tool triggers。",
-      "oauth": "OAuth",
-      "oauth_hint": "来自您的 OIDC 提供商的 Bearer JWT",
-      "oauth_provider": "OAuth 提供商",
-      "oauth_provider_placeholder": "选择已配置的 OIDC 提供商",
-      "oauth_provider_required": "当认证类型为 OAuth 时，OAuth 提供商为必填项",
-      "page_description": "将您的Kestra flow公开为MCP兼容AI代理的工具",
-      "private": "私有",
-      "private_server": "私有服务器",
-      "public": "公开",
-      "public_hint": "警告：公共服务器无需身份验证。任何拥有此 URL 的人都可以调用此服务器公开的所有工具，无需 namespace 或权限检查。仅用于可以安全地对外公开的服务器。",
-      "save": "保存更改",
-      "scopes_supported": "支持的 scope",
-      "scopes_supported_hint": "此服务器 Protected Resource Metadata 文档中公告的 scope。符合规范的 MCP 客户端将其授权请求限制为此列表。留空以省略该字段，让客户端回退到 IdP 公告的 scope。",
-      "scopes_supported_placeholder": "openid, profile, email",
-      "server": "MCP 服务器",
-      "server_id": "服务器 ID",
-      "server_type": "服务器类型",
-      "servers": "MCP 服务器",
-      "servers_count": "{count} MCP 服务器",
-      "tab_connect": "连接",
-      "tab_edit": "编辑",
-      "tab_tool_flows": "工具Flows",
-      "tab_tool_flows_placeholder": "工具flow管理即将推出。",
-      "tools": {
-        "annotations": "注释",
-        "create_tool_flow": "创建工具flow",
-        "description": "描述",
-        "destructive": "破坏性",
-        "flow": "flow",
-        "idempotent": "幂等",
-        "no_tools": "没有符合您搜索的工具flow。",
-        "open_world": "Open world",
-        "read_only": "只读",
-        "return_direct": "直接返回",
-        "state": "状态",
-        "title": "标题",
-        "tool_name": "工具名称",
-        "trigger_id": "Trigger ID",
-        "view_flow": "打开 flow"
-      },
-      "url_copied": "URL 已复制！",
-      "username_password": "用户名和密码",
-      "your_servers": "您的服务器"
-    },
-    "metric": "指标",
-    "metric choice": "此flow没有可用的指标",
-    "metrics": "指标",
-    "min": "最小",
-    "missingSource": "缺少源",
-    "modify inputs": "修改inputs",
-    "modify_inputs": "修改输入",
-    "monogram": "字母组合",
-    "more actions": "更多操作",
-    "more_actions": "更多操作",
-    "multi_panel_editor": {
-      "close_all_panels": "关闭所有面板",
-      "close_all_tabs": "关闭所有标签页",
-      "move_left": "向左移动",
-      "move_right": "向右移动"
-    },
-    "multiple saved done": "{name} 已保存",
-    "name": "名称",
-    "namespace": "命名空间",
-    "namespace and id readonly": "属性 `namespace` 和 `id` 不能更改——它们现在被设置为初始值。如果你想重命名一个流程或更改其命名空间，可以创建一个新流程并删除旧的。",
-    "namespace files": {
-      "create": {
-        "file": "创建文件",
-        "file_already_exists": "已存在同名文件",
-        "file_conflicts_with_folder": "已存在同名文件夹",
-        "file_error": "创建文件时发生错误",
-        "folder": "创建文件夹",
-        "folder_already_exists": "已存在同名文件夹",
-        "folder_conflicts_with_file": "已存在同名文件",
-        "folder_error": "创建文件夹时发生错误",
-        "label": "创建"
-      },
-      "delete": {
-        "file": "删除文件",
-        "files": "删除 {count} 个已选择的文件",
-        "folder": "删除文件夹",
-        "folders": "删除 {count} 个已选文件夹",
-        "label": "删除"
-      },
-      "dialog": {
-        "deletion": {
-          "confirm": "确认",
-          "file_single": "您确定要删除文件<code>{name}</code>吗？",
-          "files": "您确定要删除 <code>{count}</code> 个文件吗？",
-          "folder_single": "您确定要删除文件夹<code>{name}</code>及其所有内容吗？",
-          "folders": "您确定要删除 <code>{count}</code> 个文件夹及其所有内容吗？",
-          "mixed": "您确定要删除 <code>{folders}</code> 个文件夹和 <code>{files}</code> 个文件吗？",
-          "title": "确认删除内容"
-        },
-        "name": {
-          "file": "文件名（带扩展名）：",
-          "folder": "文件夹名："
-        },
-        "parent_folder": "父文件夹："
-      },
-      "export": "导出命名空间文件",
-      "export_single": "导出文件",
-      "filter": "过滤",
-      "import": {
-        "error": "导入文件时出错",
-        "files": "导入文件",
-        "folder": "导入文件夹",
-        "import": "导入",
-        "success": "文件成功导入"
-      },
-      "new_file": "新建文件",
-      "no_items": {
-        "heading": "尚未在您的namespace中找到文件。",
-        "paragraph": "创建或导入文件以在您的namespace中跨flow共享代码。"
-      },
-      "no_selection": {
-        "description": "从树中选择一个文件以查看其内容。",
-        "heading": "未选择文件"
-      },
-      "path": {
-        "copy": "复制路径",
-        "error": "复制路径到剪贴板时出错",
-        "success": "路径已复制到剪贴板"
-      },
-      "rename": {
-        "file": "重命名文件",
-        "folder": "重命名文件夹",
-        "label": "重命名",
-        "new_file": "新的文件名（带扩展名）：",
-        "new_folder": "新的文件夹名："
-      },
-      "revisions": {
-        "history": "修订历史",
-        "restore": {
-          "success": "文件修订已成功恢复"
-        }
-      },
-      "toggle": {
-        "hide": "隐藏命名空间文件",
-        "show": "显示命名空间文件"
-      },
-      "tree": {
-        "collapse": "折叠所有文件夹",
-        "expand": "展开所有文件夹"
-      }
-    },
-    "namespace not allowed": "不允许的命名空间",
-    "namespace_editor": {
-      "close": {
-        "all": "关闭所有标签页",
-        "other": "关闭其他标签页",
-        "right": "关闭右侧",
-        "tab": "关闭标签页"
-      },
-      "empty": {
-        "create_message": "您可以创建或导入namespace文件。",
-        "title": "当前没有打开的标签",
-        "video_message": "您可以查看我们编辑器的介绍视频。"
-      }
-    },
-    "namespaces": "命名空间",
-    "neutral trend": "稳定",
-    "new": "新建",
-    "new version": "新版本 {version} 可用！",
-    "next": "下一步",
-    "next evaluation date": "下次评估日期",
-    "next evaluation date tooltip": "根据其间隔，下一次评估trigger的时间。如果条件不满足，可能与下一次执行日期不同。",
-    "next execution date": "下次执行日期",
-    "next_execution": "下一次执行",
-    "no data current task": "当前task没有可用数据",
-    "no inputs": "此流程没有输入。",
-    "no metrics available": "此task运行没有记录任何指标。",
-    "no outputs available": "此任务运行没有可用的输出。",
-    "no result": "没有结果显示。",
-    "no revisions": "无修订",
-    "no revisions found": "此流程只有一个修订版",
-    "no-executions-view": {
-      "guidance_desc": "需要指导来执行您的flow吗？",
-      "guidance_sub_desc": "请查阅文档以获取您所需的所有信息。",
-      "namespace_guidance_desc": "需要指导来管理您的Namespace吗？",
-      "namespace_sub_title": "从此namespace执行一个或多个flow以填充此仪表板。",
-      "sub_title": "单击Execute按钮以开始您的第一个工作流执行。",
-      "title": "开始自动化使用"
-    },
-    "no_code": {
-      "add_field": "添加{field}",
-      "adding": "+ 添加{what}",
-      "adding_default": "+ 添加新value",
-      "clearSelection": "清除选择",
-      "creation": {
-        "afterExecution": "添加执行后块",
-        "charts": "添加图表",
-        "conditions": "添加条件",
-        "default": "添加",
-        "errors": "添加错误处理程序",
-        "finally": "添加一个finally块",
-        "inputs": "添加一个input字段",
-        "numerator": "添加分子",
-        "pluginDefaults": "添加插件默认值",
-        "tasks": "添加任务",
-        "triggers": "添加一个trigger",
-        "where": "筛选您的数据"
-      },
-      "fields": {
-        "general": {
-          "checks": "检查",
-          "concurrency": "并发性",
-          "disabled": "禁用",
-          "labels": "标签",
-          "listeners": "监听器",
-          "outputs": "输出",
-          "retry": "重试",
-          "sla": "SLA",
-          "taskDefaults": "任务默认值",
-          "updated": "已更新",
-          "variables": "变量",
-          "workerGroup": "工作组",
-          "workerSelector": "Worker 选择器"
-        },
-        "main": {
-          "description": "描述",
-          "id": "Flow ID",
-          "inputs": "输入",
-          "namespace": "命名空间"
-        }
-      },
-      "labels": {
-        "label": "标签",
-        "no_code": "无代码编辑器",
-        "variable": "变量",
-        "yaml": "YAML编辑器"
-      },
-      "remove": {
-        "cases": "删除此案例",
-        "default": "删除此条目"
-      },
-      "sections": {
-        "afterExecution": "执行后",
-        "deprecated": "不推荐使用的属性",
-        "errors": "错误处理程序",
-        "finally": "最后",
-        "pluginDefaults": "插件默认值",
-        "tasks": "任务",
-        "triggers": "触发器"
-      },
-      "select": {
-        "afterExecution": "选择一个task",
-        "charts": "选择图表类型",
-        "conditions": "选择条件",
-        "default": "选择类型",
-        "errors": "选择一个task",
-        "finally": "选择一个task",
-        "inputs": "选择一个input字段类型",
-        "numerator": "选择一个分子",
-        "pluginDefaults": "选择插件",
-        "task": "选择一个task",
-        "tasks": "选择一个task",
-        "triggers": "选择一个trigger",
-        "where": "选择筛选器类型"
-      },
-      "toggle_pebble": "切换Pebble编辑器",
-      "unnamed": "无名称",
-      "version_oss_placeholder": "解锁企业版插件版本控制"
-    },
-    "no_data": "看起来这里还没有内容……<br/>调整您的过滤器，或者再试一次！",
-    "no_file_choosen": "未选择文件",
-    "no_flow_outputs": "没有可用的output。",
-    "no_history": "无可用历史记录",
-    "no_inputs": "没有可用的input。",
-    "no_logs_data": "无数据",
-    "no_logs_data_description": "请尝试调整过滤器、更改时间范围，或检查flow最近是否已执行。",
-    "no_logs_data_title": "未找到所选过滤器的日志。",
-    "no_namespaces": "没有符合搜索条件的命名空间。",
-    "no_results": {
-      "assets": "未找到资产",
-      "executions": "未找到执行",
-      "flows": "未找到Flows",
-      "kv_pairs": "未找到Key-Value对",
-      "secrets": "未找到Secrets",
-      "templates": "未找到模板",
-      "triggers": "未找到Triggers"
-    },
-    "no_results_found": "未找到结果",
-    "no_tasks_running": "尚无任务正在运行。",
-    "no_trigger": "没有可用的trigger。",
     "no_variables": "没有可用的变量。",
-    "now": "现在",
-    "of": "的",
-    "ok": "确定",
-    "onboarding": {
-      "actions": {
-        "cancel_tutorial": "取消教程",
-        "complete": "完成",
-        "edit_flow_to_continue": "请在顶部右侧点击“Edit flow”。",
-        "execute_to_continue": "1. 在顶部右侧点击“Execute”。\n2. 为 <strong>name</strong> 提供一个值。\n3. 在弹窗中再次点击“Execute”。",
-        "finish_tutorial": "完成教程",
-        "next": "下一步",
-        "save_to_continue": "请在顶部右侧点击“Save”。"
-      },
-      "cancel_modal": {
-        "confirm": "取消教程",
-        "description": "您确定要取消“第一个 Flow”教程吗？",
-        "keep": "继续教程",
-        "title": "取消“第一个 Flow”教程"
-      },
-      "editor_hints": {
-        "build_intro": "逐步构建您的第一个 Flow。",
-        "step_1": "# 1) 添加 id",
-        "step_2": "# 2) 添加 namespace",
-        "step_3": "# 3) 添加输入参数",
-        "step_4": "# 4) 添加 tasks 并创建第一个 Python 任务",
-        "step_5": "# 5) 添加 Cron 触发器"
-      },
-      "finish_actions": {
-        "create_flow": "创建 Flow",
-        "explore_blueprints": "浏览蓝图"
-      },
-      "steps": {
-        "add_cron_trigger": {
-          "description": "Triggers 可以根据计划或外部事件（例如 Webhook 或 MQTT 消息）启动运行。<br><br>现在添加一个 Cron 计划触发器，使该 Flow 每 5 分钟运行一次。",
-          "title": "添加 Cron 触发器"
-        },
-        "add_id": {
-          "description": "ID 是您的 Flow 的唯一名称，方便您查找、运行和一致地引用它。<br><br>现在在根级别添加 <code>id</code>。",
-          "title": "添加 Flow ID"
-        },
-        "add_input": {
-          "description": "Inputs 是 Flow 级别的参数，可在任务中引用，以在运行时动态控制行为。<br><br>现在添加一个名为 <code>name</code> 且类型为 <code>STRING</code> 的输入参数。",
-          "title": "添加输入参数"
-        },
-        "add_input_default": {
-          "description": "当 Flow 被自动触发时，输入参数仍然需要在运行时提供值。<br><br><code>name</code> 输入已在上一步创建，无需再次添加。只需为现有的 <code>name</code> 输入设置默认值。",
-          "title": "设置输入的默认值"
-        },
-        "add_log_task": {
-          "description": "Tasks 是 Flow 执行的工作单元，定义为按顺序排列的步骤列表。每个任务都需要唯一的 <code>id</code> 和 <code>type</code>。Kestra 提供了许多用于外部系统的任务插件；这里我们使用一个 Python Script 任务。<br><br><code>&#123;&#123; ... &#125;&#125;</code> 语法是 Pebble 表达式，用于在运行时动态引用变量，例如来自 Flow 输入的 <code>&#123;&#123; inputs.name &#125;&#125;</code>。<br><br>现在在 <code>tasks</code> 下添加第一个任务，包括 <code>id</code>、<code>type</code> 和一个输出问候语的 <code>script</code>。",
-          "title": "添加第一个任务"
-        },
-        "add_namespace": {
-          "description": "Namespace 是类似文件夹的分组，用于按团队、项目或环境组织 Flow。<br><br>现在在根级别添加 <code>namespace</code>。",
-          "title": "添加命名空间"
-        },
-        "background_runs_info": {
-          "description": "此 Flow 现在将每 5 分钟在后台执行一次。<br><br>您可以通过左侧菜单进入“Executions”概览页面以监控计划运行。",
-          "title": "计划运行"
-        },
-        "edit_flow_from_execution": {
-          "description": "您可以直接从执行页面跳转回 Flow 定义，以便快速迭代。",
-          "title": "返回 Flow 编辑器"
-        },
-        "execute_flow": {
-          "description": "执行将使用运行时输入值启动一次 Flow 运行。",
-          "title": "执行 Flow"
-        },
-        "finish": {
-          "description": "很好的开始。您已创建、执行、参数化并安排了一个 Flow。<br><br>请选择接下来要执行的操作 ...",
-          "title": "您已完成“第一个 Flow”教程"
-        },
-        "flow_basics": {
-          "description": "在 Kestra 中，<code>flow</code> 是核心的编排单元。您使用 YAML 定义它，包括元数据和按顺序排列的任务。<br><br>请查看下面的示例结构，然后逐步构建它。",
-          "title": "Flow 基础"
-        },
-        "save_flow": {
-          "description": "保存后，您的 Flow 定义将被持久化，以便执行。",
-          "title": "保存 Flow"
-        },
-        "save_flow_again": {
-          "description": "现在您的 Flow 已包含计划任务和自动运行所需的默认输入值。",
-          "title": "保存 Flow"
-        },
-        "view_logs_status": {
-          "description": "执行详情会显示运行状态、耗时以及任务级输出日志。<br><br>现在打开执行详情，并在甘特图中点击 <code>greet</code> 查看日志。",
-          "title": "查看执行情况"
-        }
-      },
-      "validation": {
-        "add_cron_trigger_cron": "添加一个 Cron 表达式，例如：`\"*/5 * * * *\"`。",
-        "add_cron_trigger_section": "创建一个包含计划触发器的 `triggers` 部分。",
-        "add_cron_trigger_type": "将触发器类型设置为 `io.kestra.plugin.core.trigger.Schedule`。",
-        "add_id": "请在顶部添加一个 Flow ID。例如：`id: hello_flow`。",
-        "add_input_default_defaults": "为 `name` 添加默认值，例如：`defaults: \"Kestra\"`。",
-        "add_input_default_id": "保持现有输入 ID 为 `name`。",
-        "add_input_default_section": "返回 `inputs`，保留一个名为 `name` 的现有输入（不要添加第二个输入）。",
-        "add_input_id": "在 `inputs` 中添加 `id: name`。",
-        "add_input_section": "请创建一个包含一个输入参数的 `inputs` 部分。",
-        "add_input_type": "将输入类型设置为 `STRING`。",
-        "add_log_task_id": "为任务设置一个 ID，例如：`id: greet`。",
-        "add_log_task_message": "为任务添加一个 `script` 字段。",
-        "add_log_task_pebble": "在脚本中使用 Pebble 表达式以使用输入值（例如：`inputs.name`）。",
-        "add_log_task_section": "请创建一个 `tasks` 部分并添加第一个任务。",
-        "add_log_task_type": "将任务类型设置为 `io.kestra.plugin.scripts.python.Script`。",
-        "add_namespace": "请在顶部添加一个 namespace。例如：`namespace: company.team`。",
-        "complete_step": "快完成了。请完成此步骤以继续。",
-        "edit_flow_from_execution": "点击顶部栏中的“Edit flow”以继续。",
-        "execute_flow": "请运行一次 Flow 以继续。",
-        "fix_yaml": "YAML 格式存在小问题。请修复后继续。",
-        "save_flow": "点击“Save”以继续。",
-        "save_flow_again": "再次点击“Save”以继续。",
-        "view_logs_status": "打开执行详情并检查 `greet` 的日志。"
-      },
-      "welcome": {
-        "additional_help": "更多帮助",
-        "badge": "教程",
-        "blueprints": "蓝图",
-        "docs": "文档",
-        "guided_description": "通过引导步骤学习如何创建并运行您的第一个 Flow。",
-        "guided_duration": "推荐大多数用户使用",
-        "guided_title": "构建您的第一个 Flow",
-        "headline": "几分钟内构建并运行您的第一个工作流",
-        "self_serve_description": "直接进入编辑器并创建您自己的 Flow。",
-        "self_serve_note": "适合有经验的用户",
-        "self_serve_title": "从零开始创建 Flow",
-        "slack": "Slack 社区",
-        "tutorial": "教程"
-      }
+    "download": "下载",
+    "jsonl": "JSONL",
+    "concurrency_limit": {
+      "dialog_title": "并发限制",
+      "warning": "更改运行计数器可能会破坏并发性，因此执行可能会超出允许的限制。"
     },
-    "open": "打开",
-    "open full page": "打开完整页面",
-    "open in new tab": "在新标签页打开",
-    "open in same tab": "在同一标签页打开",
-    "open sidebar": "打开侧边栏",
-    "open source": "开源",
-    "open_page": "Open page",
-    "optional": "可选",
-    "original execution": "原始执行",
-    "originalCreatedDate": "原始创建日期",
-    "outdated revision save confirmation": {
-      "confirm": "你想覆盖它吗？",
-      "create": {
-        "description": "在此namespace中已存在具有相同id的flow。",
-        "details": "保存以覆盖并创建新版本。",
-        "title": "流程已存在"
-      },
-      "update": {
-        "description": "你正在编辑的修订版已过时。",
-        "details": "查看修订标签以了解最新版本的详细信息。",
-        "title": "修订版过时"
-      }
+    "documentation": {
+      "documentation": "文档",
+      "github": "打开一个GitHub问题"
     },
-    "output": "输出",
-    "outputs": "输出",
-    "override": {
-      "details": "先前的flow可以从Revisions标签页恢复。",
-      "title": "你将覆盖当前流程"
-    },
-    "overview": "概览",
-    "page": {
-      "next": "下一页",
-      "previous": "上一页"
-    },
-    "panel actions": "面板操作",
-    "parent execution": "父执行",
-    "password": "密码",
-    "password empty constraint": "用户名或密码不正确",
-    "password length constraint": "密码不得超过256个字符",
-    "passwords do not match": "密码不匹配",
-    "pause": "暂停",
-    "pause backfill": "暂停回填",
-    "pause backfills": "暂停回填",
-    "pause confirm": "您确定要暂停执行<code>{id}</code>吗？",
-    "pause done": "执行已PAUSED",
-    "pause title": "暂停执行<code>{id}</code>。<br/>请注意，当前正在运行的task仍将被处理，并且执行需要手动恢复。",
-    "paused": "暂停",
-    "playground": {
-      "clear_history": "清除历史记录",
-      "confirm_create": "在创建flow时无法运行playground。启动playground运行将创建flow。",
-      "history": "最近10次运行",
-      "play_icon_info": "您还可以在无代码或拓扑视图中点击播放图标。",
-      "run_all_tasks": "运行所有Tasks",
-      "run_task": "运行Task",
-      "run_task_and_downstream": "运行 task 和下游",
-      "run_task_info": "将鼠标悬停在Flow Code编辑器中的任何task上，然后点击“Run task”按钮以测试您的task。",
-      "run_this_task": "运行此task",
-      "title": "游乐场",
-      "toggle": "游乐场",
-      "tooltip_persistence": "如果您关闭并重新打开Playground，只要您停留在页面上，信息将保持不变。"
-    },
-    "playground actions": "游乐场操作",
-    "plugin defaults exported": "插件默认值已导出",
-    "plugin defaults imported": "插件默认值已导入",
-    "plugin defaults not imported": "某些插件默认设置无法导入",
-    "pluginDefaults": {
-      "add": "添加插件默认值",
-      "add_subtitle": "配置新插件默认值及其属性",
-      "cancel": "取消",
-      "custom": "自定义插件",
-      "custom_configure": "自定义插件类型 - 使用 YAML 配置",
-      "custom_placeholder": "输入插件类型",
-      "custom_type": "自定义插件类型",
-      "edit": "编辑插件默认值",
-      "edit_subtitle": "修改现有插件默认配置",
-      "form": "表单",
-      "predefined": "预定义插件",
-      "select_predefined": "选择预定义插件",
-      "show_yaml": "显示 YAML",
-      "title": "插件默认值",
-      "update": "更新插件默认值",
-      "use_custom": "使用自定义",
-      "yaml": "YAML",
-      "yaml_configuration": "YAML 配置"
-    },
-    "pluginPage": {
-      "elementType": {
-        "apps": "应用程序",
-        "charts": "图表",
-        "conditions": "条件",
-        "logExporters": "日志导出器",
-        "secrets": "秘密",
-        "taskRunners": "任务运行器",
-        "tasks": "任务",
-        "triggers": "触发器"
-      },
-      "group": {
-        "blueprints": "蓝图 ({count})",
-        "plugins": "插件 ({count})",
-        "tasks": "任务 ({count})"
-      },
+    "blueprints": {
+      "all": "全部",
+      "community": "社区",
+      "create": "创建一个blueprint",
+      "edit": "编辑蓝图",
+      "title": "蓝图",
+      "empty": "没有可显示的blueprints。",
       "header": {
-        "back": "返回插件",
-        "certified": "认证",
-        "enterpriseEdition": "企业版"
+        "catch phrase": {
+          "1": "第一步总是最难的。",
+          "2": "探索蓝图以启动您的下一个{kind}。"
+        },
+        "alt": "蓝图图标"
       },
-      "loadError": "无法加载插件。请重试。",
-      "noResults": "没有插件符合您的搜索。",
-      "notFound": "未找到此插件。",
-      "overview": {
-        "createdBy": "由...创建",
-        "latest": "最新",
-        "linksResources": "链接和资源",
-        "managedBy": "由...管理",
-        "minKestraVersion": "与Kestra兼容的最低版本：{version}",
-        "minKestraVersionShort": "最低 Kestra 版本 {version}",
-        "pluginType": "插件类型",
-        "previousVersions": "先前版本",
-        "releaseNotes": "发行说明",
-        "title": "概览",
-        "versions": "版本"
+      "custom": "自定义blueprints",
+      "flows": "流程蓝图",
+      "apps": "应用蓝图",
+      "dashboards": "仪表板 Blueprints",
+      "detail": {
+        "category": "类别类型",
+        "links": "链接与资源",
+        "openInEditor": "在编辑 Flow 中打开"
       },
-      "search": "在{count}+个插件中搜索",
-      "searchTasks": "搜索 {count} 个 task",
-      "sort": {
-        "mostUsed": "最常使用",
-        "nameAsc": "名称 A-Z",
-        "nameDesc": "名称 Z-A",
-        "newest": "最新"
-      },
-      "sortBy": "排序依据"
+      "missingPlugins": {
+        "title": "缺少 plugin",
+        "description": "此 blueprint 使用了此实例上未安装的 plugin 的 task：{plugins}。请安装它们以使用此 blueprint。",
+        "card": "需要此实例上未安装的 plugin：{plugins}",
+        "install": "安装 plugin"
+      }
     },
-    "plugin_default_already_exists": "<code>{type}</code>的插件默认值已存在。",
+    "use": "使用",
     "plugins": {
       "name": "插件",
       "names": "插件",
       "please": "请选择右侧的一个任务以查看其文档",
       "release": "发行说明"
     },
-    "port": "端口",
-    "prefill inputs": "预填",
-    "pretty_json": "Pretty JSON",
-    "prev_execution": "先前执行",
-    "preview": {
-      "auto-view": "自动视图",
-      "collapse": "折叠",
-      "expand": "展开",
-      "force-editor": "强制编辑器视图",
-      "label": "预览",
-      "next": "下一步",
-      "page_of": "第 {current} 页，共 {total} 页",
-      "pagination_info": "显示第 {start}-{end} 行，共 {total} 行。",
-      "previous": "上一步",
-      "rows_truncated": "显示 {shown} 行，共 {total} 行。下载文件以查看所有数据。",
-      "showing_rows": "显示第 {start}-{end} 行，共 {total} 行",
-      "view": "查看"
+    "last execution date": "最后执行日期",
+    "last execution state": "上一次状态",
+    "last X days count": "{days}天内的{count}",
+    "date range count": "{startDate}到{endDate}之间的{count}",
+    "date count": "{date}的{count}",
+    "revisions": "修订版",
+    "no revisions found": "此流程只有一个修订版",
+    "no revisions": "无修订",
+    "see full revision": "查看完整修订版",
+    "side-by-side": "并排",
+    "line-by-line": "逐行",
+    "template": "模板",
+    "template creation": "模板创建",
+    "templates": "模板",
+    "templates deprecated": "模板已弃用。请使用子流程代替。查看 <a href=\"https://kestra.io/docs/migration-guide/0.11.0/templates?utm_source=app&utm_medium=referral&utm_campaign=template-inlinedoc\" target=\"_blank\">迁移部分</a> 了解如何从模板迁移到子流程。",
+    "no result": "没有结果显示。",
+    "empty search": "搜索结果为空",
+    "trigger": "触发器",
+    "no_trigger": "没有可用的trigger。",
+    "triggers": "触发器",
+    "triggers_header_description": "浏览、添加和管理触发器以自动化您的flows。您可以选择将flow公开为AI工具、进行调度、添加webhook trigger、轮询外部应用程序中的更改或实时事件监听器。",
+    "triggers_tabs_add": "添加",
+    "triggers_tabs_manage": "管理",
+    "triggers_add_search_placeholder": "搜索 triggers...",
+    "triggers_add_filter_core": "核心",
+    "triggers_add_filter_realtime": "实时",
+    "triggers_add_filter_all": "全部",
+    "triggers_add_filter_app": "应用程序",
+    "triggers_add_empty_title": "未找到trigger",
+    "triggers_add_ee_tooltip": "此trigger需要企业版。",
+    "triggers_add_category_empty": "此类别中没有trigger。",
+    "triggers_add_card_add_to_flow": "添加到flow",
+    "triggers_add_card_add": "添加",
+    "triggers_add_modal_title": "{name}",
+    "triggers_add_modal_tab_form": "表单",
+    "triggers_add_modal_tab_source": "来源",
+    "triggers_add_modal_tab_documentation": "文档",
+    "triggers_add_modal_namespace_placeholder": "选择一个namespace",
+    "triggers_add_modal_flow_placeholder": "选择一个flow",
+    "triggers_add_modal_trigger_id": "触发器ID",
+    "triggers_add_modal_trigger_id_placeholder": "此trigger的唯一标识符",
+    "triggers_add_modal_properties_hint": "在添加trigger后，在flow编辑器中配置trigger属性。",
+    "triggers_add_modal_ee_notice": "此trigger需要企业版。",
+    "triggers_add_modal_add_button": "将 Trigger 添加到 Flow",
+    "trigger details": "触发器详情",
+    "triggerflow disabled": "触发器在流程定义中被禁用",
+    "last trigger date": "上次触发日期",
+    "trigger_states": "状态",
+    "context updated date": "上下文更新日期",
+    "state updated date": "状态更新日期",
+    "next evaluation date": "下次评估日期",
+    "last evaluation date": "上次评估日期",
+    "last trigger date tooltip": "触发器上次执行的时间。在运行backfill时可能是过去的时间。",
+    "context updated date tooltip": "触发器的上下文上次更新的时间。这发生在执行被触发、完成（锁释放）或评估后（即使没有执行发生）。",
+    "next evaluation date tooltip": "根据其间隔，下一次评估trigger的时间。如果条件不满足，可能与下一次执行日期不同。",
+    "last evaluation date tooltip": "When the trigger was last evaluated by the scheduler, regardless of whether it produced an execution.",
+    "conditions": "条件",
+    "triggerId": "触发器 ID",
+    "tenantId": "租户 ID",
+    "codeDisabled": "在Flow中禁用",
+    "paused": "暂停",
+    "running": "运行",
+    "Fold auto": "编辑器：自动折叠多行",
+    "Hover description": "编辑器：当鼠标悬停在key或value上时显示字段描述",
+    "Fold content lines": "折叠多行字符串",
+    "Unfold content lines": "展开多行字符串",
+    "Total": "总计",
+    "sub flow": "子流程",
+    "execute": "执行",
+    "execute flow behaviour": "执行流程",
+    "open in same tab": "在同一标签页打开",
+    "open in new tab": "在新标签页打开",
+    "execute the flow": "执行流程 <code>{id}</code>",
+    "execute flow now ?": "是否要执行此流程？",
+    "discard execution confirmation": "您有未保存的输入。您确定要放弃此执行吗？",
+    "discard changes confirmation": "您有未保存的更改。您确定要放弃它们吗？",
+    "Default namespace": "默认命名空间",
+    "Default log level": "默认日志级别",
+    "unsaved changed ?": "你有未保存的更改，是否要离开此页面？",
+    "unsaved changes": "未保存的更改",
+    "unsaved changes warning": "您有未保存的更改。如果您离开此页面，您的更改将会丢失。",
+    "leave page": "离开页面",
+    "open full page": "打开完整页面",
+    "drill down preview": "预览",
+    "Editor theme": "编辑器主题",
+    "Editor fontsize": "编辑器字体大小",
+    "Editor fontfamily": "编辑器字体家族",
+    "errors": {
+      "401": {
+        "title": "未授权",
+        "content": "你需要认证才能访问此页面。"
+      },
+      "403": {
+        "title": "访问被拒绝",
+        "content": "你没有访问此页面所需的权限。"
+      },
+      "404": {
+        "title": "页面未找到",
+        "content": "请求的URL未在此服务器上找到。<br />这就是我们所知道的。",
+        "flow or execution": "你正在寻找的流程或执行不存在。"
+      }
     },
-    "pricing": "定价",
-    "product_tour": "产品导览",
-    "properties": {
-      "hidden": "隐藏在表格中",
-      "hint": "选择可见列",
-      "label": "属性",
-      "shown": "显示在表格中"
+    "back_to_dashboard": "返回仪表板",
+    "copy all logs": "复制所有日志",
+    "copy logs": "复制日志",
+    "fix_with_ai": "使用 AI 修复",
+    "download logs": "下载日志",
+    "delete logs": "删除日志",
+    "delete_all_logs": "确定要删除所有日志吗？",
+    "delete_log": "您确定要删除这个log吗？",
+    "toggle fullscreen": "切换全屏",
+    "copied": "已复制",
+    "tags": "标签",
+    "disabled flow title": "此流程已禁用",
+    "disabled flow desc": "此流程已禁用，请启用以执行。",
+    "label": "标签",
+    "labels": "标签",
+    "label filter placeholder": "标签为 '键:值'",
+    "execution labels": "执行标签",
+    "wrong labels": "标签中不允许空键或值",
+    "feeds": {
+      "title": "Kestra的最新动态",
+      "heading": "所有关于Kestra的内容。",
+      "subheading": "最新更新、指南和故事"
     },
-    "queued duration": "排队时间",
-    "quotas": "配额",
-    "reach us": "联系我们",
-    "read-more": "了解更多关于",
-    "readonly property": "只读属性",
-    "recent_executions": "最近执行",
-    "refresh": "刷新",
-    "reject": "拒绝",
-    "relative": "相对",
-    "relative end date": "相对结束日期",
-    "relative start date": "相对开始日期",
-    "remove label": "移除标签",
-    "remove this item": "移除此项",
-    "remove_bookmark": "您确定要删除此书签吗？",
-    "replay": "重放",
-    "replay confirm": "确定要重放此执行 <code>{id}</code> 并创建一个新的吗？",
-    "replay execution description": "这将基于所选的执行创建一个新的执行。",
-    "replay execution title": "重放执行",
-    "replay from beginning tooltip": "从头开始创建相似的执行",
-    "replay from task tooltip": "从任务 <code>{taskId}</code> 创建相似的执行",
-    "replay inputs": "输入",
-    "replay inputs new required": "此修订版有inputs。系统将提示您填写它们。",
-    "replay latest revision": "使用最新修订版重放",
-    "replay select taskrun": "选择要重放的task运行：",
-    "replay the execution": "重放 flow <code>{flowId}</code> 的执行 <code>{executionId}</code>",
-    "replay using": "使用重播",
-    "replay with inputs": "使用输入重放",
-    "replayed": "执行已重放",
-    "required field": "必填字段",
-    "reset": "重置",
-    "reset to defaults": "重置为默认值",
-    "restart": "重新开始",
-    "restart change revision": "你可以更改用于新执行的修订版。",
-    "restart confirm": "确定要重新开始执行 <code>{id}</code> 吗？",
-    "restart execution title": "重新启动执行",
-    "restart latest revision": "重新开始最新修订版",
-    "restart tooltip": "从 <code>{state}</code> 任务重新开始执行",
-    "restart trigger": {
-      "button": "重新启动触发器",
-      "tooltip": "重新启动trigger"
-    },
-    "restarted": "执行已重启",
+    "delete execution running": "<div class=\"alert alert-warning mt-2 mb-0\">此执行仍在运行，删除它不会停止它。<br />你需要终止执行以停止它。</div>",
     "restore": "恢复",
     "restore confirm": "确定要恢复修订版 <code>{revision}</code> 吗？",
+    "bulk delete": "确定要删除 <code>{executionCount}</code> 个执行吗？",
+    "bulk replay": "确定要重放 <code>{executionCount}</code> 个执行吗？",
+    "bulk change state": "您确定要更改<code>{executionCount}</code>次执行的状态吗？",
+    "bulk resume": "确定要恢复 <code>{executionCount}</code> 个执行吗？",
+    "bulk pause": "您确定要暂停 <code>{executionCount}</code> 次执行吗？",
+    "bulk unqueue": "您确定要取消排队 <code>{executionCount}</code> 个执行吗？",
+    "bulk force run": "您确定要强制运行<code>{executionCount}</code>次执行吗？<br/><br/>WARNING: 强制运行执行不保证成功，并且可能会创建重复的task执行。<br/><br/>将进行以下转换：<br/><ul><li>CREATED的tasks将被移动到RUNNING状态。</li><li>RUNNING的tasks将被重新提交。</li><li>QUEUED的tasks将被取消排队。</li><li>PAUSED的tasks将被恢复。</li></ul>",
+    "bulk restart": "确定要重新开始 <code>{executionCount}</code> 个执行吗？",
+    "bulk kill": "确定要终止 <code>{executionCount}</code> 个执行吗？",
+    "selection": {
+      "selected": "<strong>{count}</strong> 个已选择",
+      "all": "选择所有 ({count})"
+    },
+    "cancel": "取消",
+    "errorLogs": "错误日志",
+    "welcome_page": {
+      "welcome": "欢迎使用 Kestra",
+      "guide": "需要指导来执行您的第一个flow吗？"
+    },
+    "product_tour": "产品导览",
+    "executions replayed": "<code>{executionCount}</code> 个执行已重放",
+    "executions state changed": "<code>{executionCount}</code> 次执行的状态已更改",
+    "executions resumed": "<code>{executionCount}</code> 个执行已恢复",
+    "executions paused": "<code>{executionCount}</code> 次执行已暂停",
+    "executions unqueue": "<code>{executionCount}</code> 次执行未排队",
+    "executions force run": "<code>{executionCount}</code> 次执行被强制运行",
+    "executions restarted": "<code>{executionCount}</code> 个执行已重新开始",
+    "executions killed": "<code>{executionCount}</code> 个执行已终止",
+    "executions deleted": "<code>{executionCount}</code> 个执行已删除",
+    "invalid bulk replay": "无法重放执行",
+    "invalid bulk resume": "无法恢复执行",
+    "invalid bulk pause": "无法暂停执行",
+    "invalid bulk unqueue": "无法取消排队的执行",
+    "invalid bulk force run": "无法强制运行执行",
+    "invalid bulk restart": "无法重新开始执行",
+    "invalid bulk kill": "无法终止执行",
+    "invalid bulk delete": "无法删除执行",
+    "execution not found": "执行 {executionId} 未找到。",
+    "execution not in state PAUSED": "执行 <code>{executionId}</code> 未处于暂停状态",
+    "execution not in state FAILED": "执行 <code>{executionId}</code> 未处于失败状态",
+    "execution already finished": "执行 <code>{executionId}</code> 已完成",
     "restore revision": "确定要恢复修订版 <code>{revision}</code> 吗？",
-    "resume": "恢复",
-    "resume from breakpoint done": "执行已从断点恢复",
-    "resume from breakpoint title": "从断点恢复执行 `{{id}}`",
-    "resumed confirm": "确定要恢复执行 <code>{id}</code> 吗？",
-    "resumed done": "执行已恢复",
-    "resumed title": "恢复执行 <code>{id}</code>",
-    "reuse original inputs": "重用原始input",
-    "reuse_original_inputs": "重用原始input",
-    "review your inputs": "检查您的输入",
-    "revision": "修订版",
-    "revision deleted": "修订版 {revision} 已成功删除",
-    "revisions": "修订版",
-    "row count": "行数",
-    "run task in playground": "在playground中运行task",
+    "seeing old revision": "你正在查看旧修订版：{revision}",
+    "export": "导出",
+    "exports": "导出",
+    "export_csv": "导出为CSV",
+    "template export": "确定要导出 <code>{templateCount}</code> 个模板吗？",
+    "templates exported": "模板已导出",
+    "export all templates": "导出所有模板",
+    "flow_export": "导出flow",
+    "flow export": "确定要导出 <code>{flowCount}</code> 个流程吗？",
+    "flows exported": "<code>{count}</code> 个 flow 已导出",
+    "export all flows": "导出所有流程",
+    "import": "导入",
+    "disable": "禁用",
+    "enable": "启用",
+    "enabled": "已启用",
+    "template delete": "确定要删除 <code>{templateCount}</code> 个模板吗？",
+    "flow delete": "确定要删除 <code>{flowCount}</code> 个流程吗？",
+    "templates deleted": "<code>{count}</code> 个模板已删除",
+    "flows deleted": "<code>{count}</code> 个流程已删除",
+    "flow disable": "确定要禁用 <code>{flowCount}</code> 个流程吗？",
+    "flow enable": "确定要启用 <code>{flowCount}</code> 个流程吗？",
+    "flows disabled": "<code>{count}</code> 个流程已禁用",
+    "flows enabled": "<code>{count}</code> 个流程已启用",
+    "flow-no-dependencies": "您的flow没有任何依赖项",
+    "flow-dependencies": "依赖项",
+    "read-more": "了解更多关于",
+    "in-our-documentation": "在我们的文档中。",
+    "dependencies": "依赖关系",
+    "see dependencies": "查看依赖关系",
+    "see timeline": "查看时间线",
     "run timeline": "运行时间线",
-    "runners": "运行者",
-    "running": "运行",
-    "running duration": "运行时间",
-    "save": "保存",
+    "dependencies missing acls": "此流程没有权限",
+    "dependencies delete flow": "此流程有依赖关系。删除它将阻止其依赖关系的执行。<br /><br /> 受影响的流程列表如下：",
+    "expand dependencies": "展开依赖关系",
+    "reset": "重置",
+    "show task documentation": "显示任务文档",
+    "hide task documentation": "隐藏任务文档",
+    "show task documentation in editor": "在编辑器中显示任务文档",
+    "show documentation": "显示文档",
+    "focus task": "点击任何元素以查看其文档。",
+    "validate": "验证",
+    "add error handler": "添加错误处理程序",
+    "taskDefaults": "任务默认值",
+    "disabled": "禁用",
+    "before": "之前",
+    "after": "之后",
+    "add at position": "在 {position} <code>{task}</code> 添加",
+    "create first task": "创建你的第一个任务",
+    "dynamic": "动态",
+    "choice": "选择",
+    "sequential": "顺序",
+    "can not delete": "无法删除",
+    "can not have less than 1 task": "每个流程必须至少有一个任务。",
+    "task id already exists": "任务ID已存在",
+    "Task Id already exist in the flow": "流程中已存在任务ID {taskId}。",
+    "task id": "任务ID",
+    "taskid column details": "最后执行的任务及其尝试次数。",
+    "flow already exists": "流程已存在",
+    "flow already exists message": "flow <code>{id}</code> 已存在于 namespace <code>{namespace}</code>。您要创建一个新的修订版本吗？",
+    "plugin_default_already_exists": "<code>{type}</code>的插件默认值已存在。",
+    "namespace not allowed": "不允许的命名空间",
+    "switch-view": "切换视图",
+    "source and topology": "源代码和拓扑",
+    "source and doc": "源代码和文档",
+    "source and blueprints": "源代码和蓝图",
+    "editor": "编辑器",
+    "error in editor": "在编辑器中发现错误",
+    "delete task confirm": "确定要删除任务 <code>{taskId}</code> 吗？",
+    "can not save": "无法保存",
+    "flow must not be empty": "flow不能为空",
+    "flow must have id and namespace": "流程必须有ID和命名空间。",
+    "flow creation denied in namespace": "您没有权限在namespace `{namespace}`中创建flows。",
+    "readonly property": "只读属性",
+    "namespace and id readonly": "属性 `namespace` 和 `id` 不能更改——它们现在被设置为初始值。如果你想重命名一个流程或更改其命名空间，可以创建一个新流程并删除旧的。",
+    "avg": "平均",
+    "sum": "总计",
+    "min": "最小",
+    "max": "最大",
+    "bar": "酒吧",
+    "line": "行",
+    "metric": "指标",
+    "aggregation": "聚合",
+    "chart type": "图表类型",
+    "metric choice": "此flow没有可用的指标",
+    "of": "的",
+    "see_all_states": "查看所有状态",
     "save draft": {
       "message": "草稿已保存",
       "retrieval": {
@@ -1680,164 +724,336 @@
         "existing": "已保存一个 <code>{flowFullName}</code> 流程草稿，你想继续编辑流程吗？"
       }
     },
-    "save task": "保存任务",
-    "save_and_execute": "保存并执行",
-    "save_as_draft": "保存为草稿",
-    "saved": "保存成功",
-    "saved as draft": "已成功保存为草稿",
-    "saved as draft done": "<em>{name}</em> 已成功保存为草稿",
-    "saved done": "<em>{name}</em> 成功保存",
-    "scheduleDate": "计划日期",
-    "scope_filter": {
-      "all": "所有 {label}",
-      "system": "系统 {label}",
-      "system_description": "系统维护 {label}",
-      "user": "用户 {label}",
-      "user_description": "普通用户启动了{label}"
+    "title": "标题",
+    "api": "API",
+    "more_actions": "更多操作",
+    "expand error": "仅展开失败的任务",
+    "expand all": "展开所有",
+    "collapse all": "折叠所有",
+    "expand": "展开",
+    "collapse": "折叠",
+    "filter by this value": "Filter by this value",
+    "filter_for": "Filter for",
+    "filter_out": "Filter out",
+    "copy_value": "Copy value",
+    "open_page": "Open page",
+    "logs_copied": "Logs copied to your clipboard",
+    "expand_by_default": "Expand structured logs by default",
+    "show raw": "Show raw",
+    "similar lines": "similar lines",
+    "download_logs_description": "Choose which logs to export. Filters default to your current view.",
+    "display_settings": "Display settings",
+    "density": "Density",
+    "density_compact": "Compact",
+    "density_normal": "Normal",
+    "density_expanded": "Expanded",
+    "pretty_json": "Pretty JSON",
+    "body_line_clamp": "Limit line height",
+    "font size": "Font size",
+    "log expand setting": "日志默认显示",
+    "environment": "环境",
+    "environment name setting": "环境名称",
+    "environment color setting": "环境颜色",
+    "slack support": "通过Slack提问",
+    "join community": "加入社区",
+    "join_slack": "加入 Slack",
+    "kestra": "Kestra",
+    "reach us": "联系我们",
+    "new version": "新版本 {version} 可用！",
+    "error detected": "检测到错误。",
+    "warning detected": "检测到警告",
+    "informative notice": "注意事项",
+    "cannot swap tasks": "无法交换任务",
+    "open": "打开",
+    "dependency task": "任务 {taskId} 是另一个任务的依赖",
+    "administration": "管理",
+    "admin": "管理员",
+    "main_configuration": "主配置",
+    "commit_id": "提交 id",
+    "evaluation lock date": "评估锁定日期",
+    "unlock trigger": {
+      "tooltip": {
+        "execution": "此触发器正在执行",
+        "evaluation": "此触发器当前正在评估"
+      },
+      "confirmation": "确定要解锁触发器吗？",
+      "warning": "这可能会导致同一触发器的并发执行，应作为最后的选择。",
+      "button": "解锁触发器",
+      "success": "触发器已解锁"
     },
-    "search": "搜索",
-    "search blueprint": "搜索蓝图",
-    "search filters": {
-      "filter name": "过滤器名称",
-      "filters": "过滤器",
-      "manage": "管理搜索过滤器",
-      "manage desc": "管理已保存的搜索过滤器",
-      "save filter": "保存过滤器",
-      "saved": "已保存的过滤器"
+    "restart trigger": {
+      "button": "重新启动触发器",
+      "tooltip": "重新启动trigger"
     },
-    "search term in message": "在消息中搜索术语",
-    "search_docs": "搜索",
-    "searching": "搜索中...",
-    "secret": {
-      "add": "创建",
-      "inherited": "继承的秘密",
-      "isReadOnly": "Secret 是只读的",
-      "names": "秘密",
-      "update": "更新密钥 '{name}'"
-    },
-    "security_advice": {
-      "content": "启用基本认证来保护你的实例。",
-      "enable": "启用认证",
-      "switch_text": "不要再显示",
-      "title": "保护你的实例"
-    },
-    "see dependencies": "查看依赖关系",
-    "see full revision": "查看完整修订版",
-    "see timeline": "查看时间线",
-    "see_all_states": "查看所有状态",
-    "seeing old revision": "你正在查看旧修订版：{revision}",
-    "select": "选择您的{{section}}",
-    "select a state": "选择状态",
-    "select datetime": "选择日期",
-    "select view": "选择视图",
-    "selected": "已选择",
-    "selection": {
-      "all": "选择所有 ({count})",
-      "selected": "<strong>{count}</strong> 个已选择"
-    },
-    "sequential": "顺序",
-    "server type": "服务器类型",
+    "trigger disabled": "在Flow源中触发器已禁用",
+    "flow source not found": "未找到flow源",
+    "date format": "日期格式",
+    "timezone": "时区",
+    "add task": "添加任务",
+    "unable to generate graph": "生成图表时发生问题，无法显示拓扑。",
+    "attempts": "尝试",
+    "flow deleted, you can restore it": "流程已删除，这是只读视图。你仍然可以恢复它。",
+    "workers": "工作者",
+    "worker group": "工作组",
+    "worker group key": "工作组 key",
+    "worker group fallback": "工作组回退",
+    "version": "版本",
     "services": "服务",
+    "server type": "服务器类型",
+    "hostname": "主机名",
+    "port": "端口",
+    "management port": "管理端口",
+    "file preview truncated": "显示的内容已被截断",
+    "file unavailable": "文件不可用",
+    "file unavailable description": "该文件不再可用——可能已被清除或过期。",
+    "row count": "行数",
+    "encoding": "编码",
+    "show": "显示",
+    "advanced configuration": "其他属性",
+    "all executions": "所有执行",
+    "trigger execution id": "触发执行ID",
+    "execution_status": "执行状态是：",
+    "no_tasks_running": "尚无任务正在运行。",
+    "execution_starts_progress": "一旦执行开始，您将在此处看到进度更新。",
+    "triggers_state": {
+      "state": "状态",
+      "options": {
+        "enabled": "启用",
+        "disabled": "禁用"
+      }
+    },
+    "trigger filter": {
+      "title": "过滤子执行",
+      "options": {
+        "ALL": "所有执行",
+        "CHILD": "子执行",
+        "MAIN": "父执行"
+      }
+    },
+    "show chart": "显示图表",
+    "namespace files": {
+      "toggle": {
+        "show": "显示命名空间文件",
+        "hide": "隐藏命名空间文件"
+      },
+      "filter": "过滤",
+      "new_file": "新建文件",
+      "no_items": {
+        "heading": "尚未在您的namespace中找到文件。",
+        "paragraph": "创建或导入文件以在您的namespace中跨flow共享代码。"
+      },
+      "no_selection": {
+        "heading": "未选择文件",
+        "description": "从树中选择一个文件以查看其内容。"
+      },
+      "tree": {
+        "expand": "展开所有文件夹",
+        "collapse": "折叠所有文件夹"
+      },
+      "create": {
+        "label": "创建",
+        "file": "创建文件",
+        "file_already_exists": "已存在同名文件",
+        "file_conflicts_with_folder": "已存在同名文件夹",
+        "file_error": "创建文件时发生错误",
+        "folder": "创建文件夹",
+        "folder_already_exists": "已存在同名文件夹",
+        "folder_conflicts_with_file": "已存在同名文件",
+        "folder_error": "创建文件夹时发生错误"
+      },
+      "rename": {
+        "label": "重命名",
+        "file": "重命名文件",
+        "folder": "重命名文件夹",
+        "new_file": "新的文件名（带扩展名）：",
+        "new_folder": "新的文件夹名："
+      },
+      "delete": {
+        "label": "删除",
+        "file": "删除文件",
+        "folder": "删除文件夹",
+        "files": "删除 {count} 个已选择的文件",
+        "folders": "删除 {count} 个已选文件夹"
+      },
+      "import": {
+        "import": "导入",
+        "files": "导入文件",
+        "folder": "导入文件夹",
+        "success": "文件成功导入",
+        "error": "导入文件时出错"
+      },
+      "export": "导出命名空间文件",
+      "export_single": "导出文件",
+      "dialog": {
+        "name": {
+          "file": "文件名（带扩展名）：",
+          "folder": "文件夹名："
+        },
+        "parent_folder": "父文件夹：",
+        "deletion": {
+          "confirm": "确认",
+          "title": "确认删除内容",
+          "files": "您确定要删除 <code>{count}</code> 个文件吗？",
+          "folders": "您确定要删除 <code>{count}</code> 个文件夹及其所有内容吗？",
+          "mixed": "您确定要删除 <code>{folders}</code> 个文件夹和 <code>{files}</code> 个文件吗？",
+          "file_single": "您确定要删除文件<code>{name}</code>吗？",
+          "folder_single": "您确定要删除文件夹<code>{name}</code>及其所有内容吗？"
+        }
+      },
+      "revisions": {
+        "history": "修订历史",
+        "restore": {
+          "success": "文件修订已成功恢复"
+        }
+      },
+      "path": {
+        "copy": "复制路径",
+        "success": "路径已复制到剪贴板",
+        "error": "复制路径到剪贴板时出错"
+      }
+    },
+    "continue backfill": "继续回填",
+    "delete backfill": "删除回填",
+    "pause backfill": "暂停回填",
+    "continue backfills": "继续回填",
+    "delete backfills": "删除回填",
+    "pause backfills": "暂停回填",
+    "backfill executions": "回填执行",
+    "execute backfill": "执行回填",
+    "backfill paused": "补数据已暂停",
+    "backfill running": "正在运行Backfill",
+    "relative": "相对",
+    "relative start date": "相对开始日期",
+    "relative end date": "相对结束日期",
+    "now": "现在",
+    "absolute": "绝对",
+    "backfill": "回填",
+    "Set labels tooltip": "设置执行标签",
+    "Set labels": "设置标签",
+    "manage labels": "管理labels",
+    "Set labels to execution": "为执行 <code>{id}</code> 添加或更新标签",
+    "Set labels done": "标签设置成功",
+    "bulk set labels": "确定要为 <code>{executionCount}</code> 个执行设置标签吗？",
+    "dependencies loaded": "依赖项已加载",
+    "loaded x dependencies": "已加载 {count} 个依赖项",
+    "security_advice": {
+      "title": "保护你的实例",
+      "content": "启用基本认证来保护你的实例。",
+      "switch_text": "不要再显示",
+      "enable": "启用认证"
+    },
+    "true": "真",
+    "false": "假",
+    "undefined": "未定义",
+    "execution-include-non-terminated": "包括未终止的执行？",
+    "execution-warn-title": "重要警告！",
+    "execution-warn-deleting-still-running": "我们强烈建议您取消此操作，并首先终止任何正在进行的执行。删除未终止的执行可能导致并发性问题、flow依赖管理不一致以及实例上的僵尸进程，这些都会降低系统性能。在继续删除之前，请确保您完全了解这些风险。",
+    "originalCreatedDate": "原始创建日期",
+    "welcome": {
+      "menu": "Welcome",
+      "tour": {
+        "title": "开始产品导览",
+        "text": "选择您的用例，并按照分步指南学习 Kestra 的功能和能力。❤️"
+      },
+      "tutorial": {
+        "title": "教程",
+        "text": "* <a href=\"https://kestra.io/tutorial-videos/all?utm_source=app&utm_medium=referral&utm_campaign=welcome-tutorial\" target=\"_blank\">视频教程</a>  \n* <a href=\"https://kestra.io/docs?utm_source=app&utm_medium=referral&utm_campaign=welcome-tutorial\" target=\"_blank\">文档</a>  \n* <a href=\"https://kestra.io/blueprints?utm_source=app&utm_medium=referral&utm_campaign=welcome-tutorial\" target=\"_blank\">Blueprints</a>"
+      },
+      "help": {
+        "title": "需要帮助吗？",
+        "text": "在我们的Slack社区中提问。如果您遇到困难，我们会帮助您。✋"
+      }
+    },
+    "pluginPage": {
+      "search": "在{count}+个插件中搜索",
+      "searchTasks": "搜索 {count} 个 task",
+      "noResults": "没有插件符合您的搜索。",
+      "loadError": "无法加载插件。请重试。",
+      "notFound": "未找到此插件。",
+      "elementType": {
+        "tasks": "任务",
+        "triggers": "触发器",
+        "conditions": "条件",
+        "taskRunners": "任务运行器",
+        "charts": "图表",
+        "apps": "应用程序",
+        "logExporters": "日志导出器",
+        "secrets": "秘密"
+      },
+      "sortBy": "排序依据",
+      "sort": {
+        "nameAsc": "名称 A-Z",
+        "nameDesc": "名称 Z-A",
+        "newest": "最新",
+        "mostUsed": "最常使用"
+      },
+      "group": {
+        "plugins": "插件 ({count})",
+        "tasks": "任务 ({count})",
+        "blueprints": "蓝图 ({count})"
+      },
+      "overview": {
+        "title": "概览",
+        "versions": "版本",
+        "latest": "最新",
+        "releaseNotes": "发行说明",
+        "previousVersions": "先前版本",
+        "createdBy": "由...创建",
+        "managedBy": "由...管理",
+        "pluginType": "插件类型",
+        "linksResources": "链接和资源",
+        "minKestraVersion": "与Kestra兼容的最低版本：{version}",
+        "minKestraVersionShort": "最低 Kestra 版本 {version}"
+      },
+      "header": {
+        "enterpriseEdition": "企业版",
+        "certified": "认证",
+        "back": "返回插件"
+      }
+    },
+    "no inputs": "此流程没有输入。",
+    "admin_preferences": "Preferences",
     "settings": {
+      "label": "设置",
+      "updated": "{name} 已更新",
       "blocks": {
         "configuration": {
-          "descriptions": {
-            "auto_refresh_interval": "列表页面上自动数据刷新的秒数。",
-            "default_namespace": "用于在没有namespace的情况下创建新flow。",
-            "editor_type": "首次打开flow时显示的编辑器。",
-            "execute_default_tab": "导航到执行时选择的选项卡。",
-            "execute_flow": "触发运行后执行结果打开的位置。",
-            "flow_default_tab": "导航到flow时选择的选项卡。",
-            "log_display": "打开执行时日志的呈现方式。",
-            "log_level": "执行日志中显示的最低日志级别。",
-            "playground": "在编辑器游乐场中单独运行任务。",
-            "triggers_default_tab": "导航到 triggers 页面时选择的选项卡。"
-          },
+          "label": "主要配置",
           "fields": {
-            "auto_refresh_interval": "自动刷新间隔",
-            "default_namespace": "默认命名空间",
-            "editor_type": "默认编辑器类型",
-            "execute_default_tab": "默认执行选项卡",
-            "execute_flow": "执行流程",
-            "flow_default_tab": "默认 Flow 标签页",
             "language": "语言",
-            "log_display": "默认日志显示",
+            "default_namespace": "默认命名空间",
             "log_level": "默认日志级别",
+            "log_display": "默认日志显示",
+            "editor_type": "默认编辑器类型",
+            "execute_flow": "执行流程",
+            "execute_default_tab": "默认执行选项卡",
             "multi_panel_editor": "多面板编辑器",
+            "flow_default_tab": "默认 Flow 标签页",
+            "triggers_default_tab": "默认 Trigger 标签页",
             "playground": "游乐场",
-            "triggers_default_tab": "默认 Trigger 标签页"
+            "auto_refresh_interval": "自动刷新间隔"
           },
-          "label": "主要配置"
-        },
-        "export": {
-          "fields": {
-            "flows": "导出所有流程",
-            "templates": "导出所有模板"
-          },
-          "label": "导出"
-        },
-        "localization": {
           "descriptions": {
-            "date_format": "用于在仪表板中显示日期的格式。",
-            "language": "菜单和标签的界面语言。",
-            "time_zone": "用于显示执行日期和计划触发器。"
-          },
-          "fields": {
-            "date_format": "日期格式",
-            "time_zone": "时区"
-          },
-          "label": "语言和地区",
-          "note": "请注意，此设置用于在UI中显示日期和时间属性。要在UTC以外的时区安排你的流程，请确保在流程代码或插件默认值中的Schedule触发器上设置时区属性。"
-        },
-        "reset_section_to_defaults": "恢复此部分的默认值",
-        "save": {
-          "discard": "丢弃",
-          "label": "保存偏好设置",
-          "unsaved_title": "未保存的更改",
-          "unsaved_warning": "您有未保存的更改。您想在离开之前保存它们吗？"
-        },
-        "sidebar": {
-          "descriptions": {
-            "items": "在侧边栏中显示、隐藏和重新排序项目。"
-          },
-          "fields": {
-            "items": "导航项"
-          },
-          "label": "侧边栏"
+            "default_namespace": "用于在没有namespace的情况下创建新flow。",
+            "log_level": "执行日志中显示的最低日志级别。",
+            "log_display": "打开执行时日志的呈现方式。",
+            "editor_type": "首次打开flow时显示的编辑器。",
+            "execute_flow": "触发运行后执行结果打开的位置。",
+            "execute_default_tab": "导航到执行时选择的选项卡。",
+            "flow_default_tab": "导航到flow时选择的选项卡。",
+            "triggers_default_tab": "导航到 triggers 页面时选择的选项卡。",
+            "auto_refresh_interval": "列表页面上自动数据刷新的秒数。",
+            "playground": "在编辑器游乐场中单独运行任务。"
+          }
         },
         "theme": {
-          "app_font_size_options": {
-            "large": "大",
-            "medium": "中",
-            "small": "小"
-          },
-          "color_modes": {
-            "dark_1": "Dark 1.0",
-            "dark_2": "深色模式 2.0",
-            "light": "浅色模式",
-            "sync": "与系统同步"
-          },
-          "confirmations": {
-            "color_mode": "您的界面现在使用 `{mode}` 主题。"
-          },
-          "descriptions": {
-            "app_font_size": "应用于所有界面字体大小的缩放系数。",
-            "color_mode": "选择您偏好的界面主题。",
-            "color_mode_shortcut": "提示：在任意位置按 <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>L</kbd> 即可循环切换主题。",
-            "editor_folding_stratgy": "默认情况下，打开flow时折叠长YAML块。",
-            "editor_font_family": "YAML编辑器中使用的等宽字体。",
-            "editor_font_size": "YAML和无代码编辑器中使用的字体大小。",
-            "editor_hover_description": "在编辑器中悬停时显示属性描述。",
-            "environment_color": "用于导航中当前环境的强调颜色。",
-            "environment_name": "当前环境的显示名称，显示在导航中。",
-            "logs_font_size": "日志查看器和终端中使用的字体大小。"
-          },
+          "label": "主题偏好",
           "fields": {
             "app_font_size": "应用字体大小",
             "chart_color_scheme": {
+              "label": "图表配色方案",
               "classic": "经典",
-              "kestra": "Kestra",
-              "label": "图表配色方案"
+              "kestra": "Kestra"
             },
             "color_mode": "颜色模式",
             "editor_folding_stratgy": "编辑器中的自动代码折叠",
@@ -1850,24 +1066,867 @@
             "logs_font_size": "日志字体大小",
             "theme": "主题"
           },
-          "label": "主题偏好"
+          "color_modes": {
+            "dark_2": "深色模式 2.0",
+            "dark_1": "Dark 1.0",
+            "light": "浅色模式",
+            "sync": "与系统同步"
+          },
+          "confirmations": {
+            "color_mode": "您的界面现在使用 `{mode}` 主题。"
+          },
+          "descriptions": {
+            "color_mode": "选择您偏好的界面主题。",
+            "color_mode_shortcut": "提示：在任意位置按 <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>L</kbd> 即可循环切换主题。",
+            "logs_font_size": "日志查看器和终端中使用的字体大小。",
+            "editor_font_family": "YAML编辑器中使用的等宽字体。",
+            "editor_font_size": "YAML和无代码编辑器中使用的字体大小。",
+            "editor_folding_stratgy": "默认情况下，打开flow时折叠长YAML块。",
+            "editor_hover_description": "在编辑器中悬停时显示属性描述。",
+            "environment_name": "当前环境的显示名称，显示在导航中。",
+            "environment_color": "用于导航中当前环境的强调颜色。",
+            "app_font_size": "应用于所有界面字体大小的缩放系数。"
+          },
+          "app_font_size_options": {
+            "small": "小",
+            "medium": "中",
+            "large": "大"
+          }
+        },
+        "localization": {
+          "label": "语言和地区",
+          "note": "请注意，此设置用于在UI中显示日期和时间属性。要在UTC以外的时区安排你的流程，请确保在流程代码或插件默认值中的Schedule触发器上设置时区属性。",
+          "fields": {
+            "time_zone": "时区",
+            "date_format": "日期格式"
+          },
+          "descriptions": {
+            "language": "菜单和标签的界面语言。",
+            "time_zone": "用于显示执行日期和计划触发器。",
+            "date_format": "用于在仪表板中显示日期的格式。"
+          }
+        },
+        "export": {
+          "label": "导出",
+          "fields": {
+            "flows": "导出所有流程",
+            "templates": "导出所有模板"
+          }
+        },
+        "save": {
+          "label": "保存偏好设置",
+          "discard": "丢弃",
+          "unsaved_title": "未保存的更改",
+          "unsaved_warning": "您有未保存的更改。您想在离开之前保存它们吗？"
+        },
+        "reset_section_to_defaults": "恢复此部分的默认值",
+        "sidebar": {
+          "label": "侧边栏",
+          "fields": {
+            "items": "导航项"
+          },
+          "descriptions": {
+            "items": "在侧边栏中显示、隐藏和重新排序项目。"
+          }
+        }
+      }
+    },
+    "apps": "应用程序",
+    "demos": {
+      "enterprise_edition": "企业版",
+      "get_a_demo_button": "获取演示",
+      "contact_sales": "联系我们的销售团队",
+      "watch_the_video": "观看视频",
+      "secrets": {
+        "title": "升级您的Secrets管理",
+        "message": "企业版 (EE) 允许您直接在UI中添加、编辑或删除秘密，无需重启实例。通过细粒度的RBAC权限按namespace组织秘密，并从父namespace继承到子namespace。EE与HashiCorp Vault、AWS Secrets Manager、Azure Key Vault、Google Secret Manager和Elasticsearch等秘密管理器集成。为每个namespace、tenant或实例设置专用后端，以隔离团队之间的秘密，或启用存储在外部vault中的只读秘密。秘密在静态和传输中保持加密。可选的缓存减少API调用，并且审计跟踪记录所有访问。",
+        "detected_env": "以下是在实例启动时识别的secret-type环境变量：",
+        "empty_env": "您还没有在您的环境中添加任何Secrets。",
+        "add_env": {
+          "intro": "创建新Secret：",
+          "first": "将<a href=\"https://kestra.io/docs/how-to-guides/secrets?utm_source=app&utm_medium=referral&utm_campaign=secrets-inlinedoc#using-secrets-in-kestra\" target=\"_blank\">secret value编码为Base64</a>",
+          "second": "添加一个名为 '<strong>SECRET_{'{MY_SECRET_KEY}'}</strong>' 的环境变量，并使用上述值",
+          "third": "重新启动您的Kestra实例"
         }
       },
-      "label": "设置",
-      "updated": "{name} 已更新"
+      "apps": {
+        "title": "使用 Kestra 构建自定义应用程序",
+        "message": "在 Kestra 企业版中，应用程序允许您构建自定义 UI，以便从平台外部与 Kestra 工作流进行交互。此功能使您可以将工作流用作自定义应用程序的后端，允许非技术用户通过表单提交数据或恢复等待批准的暂停工作流。"
+      },
+      "tests": {
+        "label": "测试",
+        "header": "Flows的单元测试",
+        "title": "确保每次更改的可靠性",
+        "message": "验证您的flow逻辑是否独立，及早检测回归，并在自动化变更和增长时保持信心。"
+      },
+      "assets": {
+        "label": "资产",
+        "header": "资产元数据和可观测性",
+        "title": "将每个数据集、服务和依赖项展示出来。",
+        "message": "资产连接可观测性、血缘关系和所有权元数据，使平台团队能够更快地排查问题并自信地部署。"
+      },
+      "IAM": {
+        "title": "通过IAM使用SSO、SCIM和RBAC管理用户",
+        "message": "Kestra 企业版具有内置的 IAM 功能，包括单点登录 (SSO)、SCIM 目录同步和基于角色的访问控制 (RBAC)，可以与多个身份提供商集成，并允许您为用户和服务帐户分配细粒度的权限。"
+      },
+      "tenants": {
+        "title": "在独立的tenant中管理工作流",
+        "message": "Kestra 企业版支持多租户，为不同的团队或项目提供完全隔离的环境，每个环境都有自己的资源，如专用的worker组、密钥和内部存储后端。"
+      },
+      "audit-logs": {
+        "title": "使用审计日志跟踪更改",
+        "message": "Kestra Enterprise Edition记录每个活动，提供强大且不可更改的记录，使得跟踪更改、保持合规性和解决问题变得容易。"
+      },
+      "quotas": {
+        "title": "为工作流设置执行配额",
+        "message": "Kestra 企业版允许您为工作流定义配额，以限制在时间窗口内的并发或总执行次数。配额有助于保护共享基础设施、执行 SLA，并防止失控的工作流消耗过多资源。"
+      },
+      "instance": {
+        "title": "管理您的实例中的基础设施",
+        "message": "Kestra Enterprise Edition 提供一个操作仪表板，帮助您观察平台的健康状况并跟踪所有服务（如 Workers、Schedulers 和 Executors）的正常运行时间指标。在同一页面，您还可以创建公告以通知用户计划中的停机时间，并且可以进入维护模式，将所有服务和工作流执行暂时置于 PAUSED 状态以进行升级。"
+      },
+      "blueprints": {
+        "title": "添加自定义蓝图",
+        "message": "在 Kestra 企业版中，您可以创建仅供您的组织使用的自定义 Blueprints。您可以将它们用作最佳实践模板，以便在团队中共享、集中和记录常用的工作流。"
+      },
+      "namespace": {
+        "edit": {
+          "title": "升级您的Namespace管理",
+          "message": "在 Kestra 企业版中，namespace 提供了高级的隔离和治理功能，用于管理大规模的密钥、变量和插件默认值。管理员可以为每个 namespace 配置自定义密钥管理器、隔离存储后端、专用 worker 组以及细粒度权限。这确保了密钥、变量和插件配置在不同团队和项目中保持安全且易于维护。"
+        },
+        "secrets": {
+          "title": "以安全方式管理Secrets",
+          "message": "在 Kestra Enterprise Edition 中，您可以在 namespace 级别存储和控制机密，从而最大限度地降低风险并确保每个团队的凭据保持隔离。得益于嵌套层次结构，您还可以在父 namespace 中配置凭据，并且它们将被所有子 namespace 继承。对专用机密管理器和细粒度的 namespace 级别权限设置的支持进一步增强了安全性和合规性。"
+        },
+        "assets": {
+          "title": "集中资产管理",
+          "message": "在 Kestra 企业版中，Assets 保持着与您的工作流交互的资源的实时清单。这些资源可以是数据库表、虚拟机、文件或您使用的任何外部系统。"
+        },
+        "variables": {
+          "title": "集中管理您的变量",
+          "message": "在 Kestra 企业版中，您可以定义和管理 namespace 级别的变量，以消除跨 flow 的重复配置。这些变量确保了一致性，简化了配置更新，并且可以被任何 task 或 trigger 轻松引用，从而实现更简洁、更易维护的工作流。"
+        },
+        "plugin-defaults": {
+          "title": "使用插件默认值标准化配置",
+          "message": "在 Kestra Enterprise Edition 中，您可以设置特定于 namespace 的插件默认值，从而减少每个 flow 中重复设置的需求。这种集中的插件管理强制执行一致的配置，允许安全引用机密或变量，并简化工作流的维护。"
+        },
+        "history": {
+          "title": "在一个地方管理修订历史",
+          "message": "在 Kestra Enterprise Edition 中，您可以管理 Namespace 的修订历史记录。"
+        },
+        "audit-logs": {
+          "title": "在一个地方跟踪所有更改",
+          "message": "在 Kestra 企业版中，您可以查看 namespace 级别的审计日志，包含详细的差异，提供所有资源的更改历史，清晰地显示是谁在何时更改了什么。"
+        }
+      }
+    },
+    "assets": {
+      "title": "资产"
+    },
+    "onboarding": {
+      "welcome": {
+        "headline": "几分钟内构建并运行您的第一个工作流",
+        "guided_title": "构建您的第一个 Flow",
+        "badge": "教程",
+        "guided_description": "通过引导步骤学习如何创建并运行您的第一个 Flow。",
+        "guided_duration": "推荐大多数用户使用",
+        "self_serve_title": "从零开始创建 Flow",
+        "self_serve_description": "直接进入编辑器并创建您自己的 Flow。",
+        "self_serve_note": "适合有经验的用户",
+        "additional_help": "更多帮助",
+        "docs": "文档",
+        "tutorial": "教程",
+        "blueprints": "蓝图",
+        "slack": "Slack 社区"
+      },
+      "steps": {
+        "flow_basics": {
+          "title": "Flow 基础",
+          "description": "在 Kestra 中，<code>flow</code> 是核心的编排单元。您使用 YAML 定义它，包括元数据和按顺序排列的任务。<br><br>请查看下面的示例结构，然后逐步构建它。"
+        },
+        "add_id": {
+          "title": "添加 Flow ID",
+          "description": "ID 是您的 Flow 的唯一名称，方便您查找、运行和一致地引用它。<br><br>现在在根级别添加 <code>id</code>。"
+        },
+        "add_namespace": {
+          "title": "添加命名空间",
+          "description": "Namespace 是类似文件夹的分组，用于按团队、项目或环境组织 Flow。<br><br>现在在根级别添加 <code>namespace</code>。"
+        },
+        "add_input": {
+          "title": "添加输入参数",
+          "description": "Inputs 是 Flow 级别的参数，可在任务中引用，以在运行时动态控制行为。<br><br>现在添加一个名为 <code>name</code> 且类型为 <code>STRING</code> 的输入参数。"
+        },
+        "add_log_task": {
+          "title": "添加第一个任务",
+          "description": "Tasks 是 Flow 执行的工作单元，定义为按顺序排列的步骤列表。每个任务都需要唯一的 <code>id</code> 和 <code>type</code>。Kestra 提供了许多用于外部系统的任务插件；这里我们使用一个 Python Script 任务。<br><br><code>&#123;&#123; ... &#125;&#125;</code> 语法是 Pebble 表达式，用于在运行时动态引用变量，例如来自 Flow 输入的 <code>&#123;&#123; inputs.name &#125;&#125;</code>。<br><br>现在在 <code>tasks</code> 下添加第一个任务，包括 <code>id</code>、<code>type</code> 和一个输出问候语的 <code>script</code>。"
+        },
+        "save_flow": {
+          "title": "保存 Flow",
+          "description": "保存后，您的 Flow 定义将被持久化，以便执行。"
+        },
+        "execute_flow": {
+          "title": "执行 Flow",
+          "description": "执行将使用运行时输入值启动一次 Flow 运行。"
+        },
+        "view_logs_status": {
+          "title": "查看执行情况",
+          "description": "执行详情会显示运行状态、耗时以及任务级输出日志。<br><br>现在打开执行详情，并在甘特图中点击 <code>greet</code> 查看日志。"
+        },
+        "edit_flow_from_execution": {
+          "title": "返回 Flow 编辑器",
+          "description": "您可以直接从执行页面跳转回 Flow 定义，以便快速迭代。"
+        },
+        "add_cron_trigger": {
+          "title": "添加 Cron 触发器",
+          "description": "Triggers 可以根据计划或外部事件（例如 Webhook 或 MQTT 消息）启动运行。<br><br>现在添加一个 Cron 计划触发器，使该 Flow 每 5 分钟运行一次。"
+        },
+        "add_input_default": {
+          "title": "设置输入的默认值",
+          "description": "当 Flow 被自动触发时，输入参数仍然需要在运行时提供值。<br><br><code>name</code> 输入已在上一步创建，无需再次添加。只需为现有的 <code>name</code> 输入设置默认值。"
+        },
+        "save_flow_again": {
+          "title": "保存 Flow",
+          "description": "现在您的 Flow 已包含计划任务和自动运行所需的默认输入值。"
+        },
+        "background_runs_info": {
+          "title": "计划运行",
+          "description": "此 Flow 现在将每 5 分钟在后台执行一次。<br><br>您可以通过左侧菜单进入“Executions”概览页面以监控计划运行。"
+        },
+        "finish": {
+          "title": "您已完成“第一个 Flow”教程",
+          "description": "很好的开始。您已创建、执行、参数化并安排了一个 Flow。<br><br>请选择接下来要执行的操作 ..."
+        }
+      },
+      "actions": {
+        "next": "下一步",
+        "complete": "完成",
+        "save_to_continue": "请在顶部右侧点击“Save”。",
+        "execute_to_continue": "1. 在顶部右侧点击“Execute”。\n2. 为 <strong>name</strong> 提供一个值。\n3. 在弹窗中再次点击“Execute”。",
+        "edit_flow_to_continue": "请在顶部右侧点击“Edit flow”。",
+        "cancel_tutorial": "取消教程",
+        "finish_tutorial": "完成教程"
+      },
+      "finish_actions": {
+        "explore_blueprints": "浏览蓝图",
+        "create_flow": "创建 Flow"
+      },
+      "editor_hints": {
+        "build_intro": "逐步构建您的第一个 Flow。",
+        "step_1": "# 1) 添加 id",
+        "step_2": "# 2) 添加 namespace",
+        "step_3": "# 3) 添加输入参数",
+        "step_4": "# 4) 添加 tasks 并创建第一个 Python 任务",
+        "step_5": "# 5) 添加 Cron 触发器"
+      },
+      "cancel_modal": {
+        "title": "取消“第一个 Flow”教程",
+        "description": "您确定要取消“第一个 Flow”教程吗？",
+        "confirm": "取消教程",
+        "keep": "继续教程"
+      },
+      "validation": {
+        "complete_step": "快完成了。请完成此步骤以继续。",
+        "fix_yaml": "YAML 格式存在小问题。请修复后继续。",
+        "add_id": "请在顶部添加一个 Flow ID。例如：`id: hello_flow`。",
+        "add_namespace": "请在顶部添加一个 namespace。例如：`namespace: company.team`。",
+        "add_input_section": "请创建一个包含一个输入参数的 `inputs` 部分。",
+        "add_input_id": "在 `inputs` 中添加 `id: name`。",
+        "add_input_type": "将输入类型设置为 `STRING`。",
+        "add_log_task_section": "请创建一个 `tasks` 部分并添加第一个任务。",
+        "add_log_task_id": "为任务设置一个 ID，例如：`id: greet`。",
+        "add_log_task_type": "将任务类型设置为 `io.kestra.plugin.scripts.python.Script`。",
+        "add_log_task_message": "为任务添加一个 `script` 字段。",
+        "add_log_task_pebble": "在脚本中使用 Pebble 表达式以使用输入值（例如：`inputs.name`）。",
+        "save_flow": "点击“Save”以继续。",
+        "execute_flow": "请运行一次 Flow 以继续。",
+        "view_logs_status": "打开执行详情并检查 `greet` 的日志。",
+        "edit_flow_from_execution": "点击顶部栏中的“Edit flow”以继续。",
+        "add_cron_trigger_section": "创建一个包含计划触发器的 `triggers` 部分。",
+        "add_cron_trigger_type": "将触发器类型设置为 `io.kestra.plugin.core.trigger.Schedule`。",
+        "add_cron_trigger_cron": "添加一个 Cron 表达式，例如：`\"*/5 * * * *\"`。",
+        "add_input_default_section": "返回 `inputs`，保留一个名为 `name` 的现有输入（不要添加第二个输入）。",
+        "add_input_default_id": "保持现有输入 ID 为 `name`。",
+        "add_input_default_defaults": "为 `name` 添加默认值，例如：`defaults: \"Kestra\"`。",
+        "save_flow_again": "再次点击“Save”以继续。"
+      }
+    },
+    "enable concurrency": "启用并发",
+    "auditlogs": "审计日志",
+    "quotas": "配额",
+    "iam": "IAM",
+    "tenant": {
+      "name": "租户",
+      "names": "租户"
+    },
+    "ee-tooltip": {
+      "features-blocked": "此功能需要企业版。",
+      "button": "联系我们"
+    },
+    "flow_only": "仅在流程标签中可用。",
+    "bulk action async warning": "这可能需要一些时间。",
+    "bulk unpause backfills": "取消暂停 {count} 回填",
+    "bulk pause backfills": "暂停 {count} 回填",
+    "bulk delete backfills": "删除 {count} 回填",
+    "bulk unlock": "解锁 {count} 触发器",
+    "bulk disabled status": {
+      "true": "禁用 {count} 触发器",
+      "false": "启用 {count} 触发器"
+    },
+    "unlock": "解锁",
+    "bulk success unpause backfills": "{count} 回填已取消暂停",
+    "bulk success pause backfills": "{count} 回填已暂停",
+    "bulk success delete backfills": "{count} 回填已删除",
+    "bulk success unlock": "{count} 触发器已解锁",
+    "bulk success disabled status": {
+      "true": "{count} 个触发器已禁用",
+      "false": "{count} 个触发器已启用"
+    },
+    "no_namespaces": "没有符合搜索条件的命名空间。",
+    "system_namespace": "保持您的平台通过系统flows进行检查。",
+    "system_namespace_description": "自动化维护任务，从故障警报到自动清理。",
+    "pluginDefaults": {
+      "title": "插件默认值",
+      "add": "添加插件默认值",
+      "edit": "编辑插件默认值",
+      "add_subtitle": "配置新插件默认值及其属性",
+      "edit_subtitle": "修改现有插件默认配置",
+      "predefined": "预定义插件",
+      "custom": "自定义插件",
+      "form": "表单",
+      "yaml": "YAML",
+      "select_predefined": "选择预定义插件",
+      "cancel": "取消",
+      "update": "更新插件默认值",
+      "custom_type": "自定义插件类型",
+      "custom_placeholder": "输入插件类型",
+      "use_custom": "使用自定义",
+      "custom_configure": "自定义插件类型 - 使用 YAML 配置",
+      "yaml_configuration": "YAML 配置",
+      "show_yaml": "显示 YAML"
+    },
+    "secret": {
+      "add": "创建",
+      "update": "更新密钥 '{name}'",
+      "isReadOnly": "Secret 是只读的",
+      "names": "秘密",
+      "inherited": "继承的秘密"
+    },
+    "workerId": "工作者ID",
+    "kv": {
+      "name": "键值存储",
+      "type": "类型",
+      "add": "创建",
+      "update": "更新键 '{key}' 的值",
+      "duplicate": "此键已存在",
+      "delete multiple": {
+        "confirm": "您确定要删除：<code>{name}</code> kv 吗？",
+        "warning": "您没有这些namespace的权限，因此它们将被省略：<code>{namespaces}</code>"
+      },
+      "inherited": "继承的KV对"
+    },
+    "expiration": "过期",
+    "failed to render pdf": "渲染PDF预览失败",
+    "page": {
+      "previous": "上一页",
+      "next": "下一页"
+    },
+    "namespace_editor": {
+      "empty": {
+        "title": "当前没有打开的标签",
+        "create_message": "您可以创建或导入namespace文件。",
+        "video_message": "您可以查看我们编辑器的介绍视频。"
+      },
+      "close": {
+        "tab": "关闭标签页",
+        "all": "关闭所有标签页",
+        "other": "关闭其他标签页",
+        "right": "关闭右侧"
+      }
+    },
+    "curl": {
+      "command": "cURL命令",
+      "note": "请注意，对于SECRET和FILE类型的input，命令必须调整以匹配实际值。"
+    },
+    "webhook": {
+      "curl_command": "Webhook cURL 命令",
+      "payload": "Webhook Payload (JSON)",
+      "curl_note": "使用此 cURL 命令通过 webhook 触发 flow，并使用自定义 JSON 负载",
+      "no_triggers": "此flow没有启用的webhook triggers",
+      "copy_url": "复制 webhook URL"
+    },
+    "logs_view": {
+      "raw": "时间视图",
+      "raw_details": "以原始时间顺序显示完整任务日志和流程日志",
+      "compact": "默认视图",
+      "compact_details": "按任务分组显示任务日志"
+    },
+    "execution_deletion": {
+      "logs": "删除日志",
+      "metrics": "删除指标",
+      "storage": "删除内部存储文件"
+    },
+    "scope_filter": {
+      "all": "所有 {label}",
+      "user": "用户 {label}",
+      "system": "系统 {label}",
+      "user_description": "普通用户启动了{label}",
+      "system_description": "系统维护 {label}"
+    },
+    "data": "数据",
+    "webhook link copied": "Webhook链接已复制。",
+    "copy url": "复制 URL",
+    "scheduleDate": "计划日期",
+    "warning": "警告",
+    "trigger_check_warning": "使用 trigger 变量无法与手动 flow 执行一起工作。添加 `??` 合并运算符来解决此问题。例如，不要使用 `trigger.date`，而是使用 `trigger.date ?? execution.startDate`。",
+    "docs": "文档",
+    "active-slots": "活动槽位",
+    "behavior": "行为",
+    "concurrency": "并发",
+    "no-executions-view": {
+      "title": "开始自动化使用",
+      "sub_title": "单击Execute按钮以开始您的第一个工作流执行。",
+      "namespace_sub_title": "从此namespace执行一个或多个flow以填充此仪表板。",
+      "guidance_desc": "需要指导来执行您的flow吗？",
+      "namespace_guidance_desc": "需要指导来管理您的Namespace吗？",
+      "guidance_sub_desc": "请查阅文档以获取您所需的所有信息。"
+    },
+    "execution_guide": {
+      "get_started": {
+        "title": "开始使用 ⚡",
+        "text": "请按照快速入门指南安装Kestra并开始构建您的第一个工作流。"
+      },
+      "namespaces": {
+        "title": "关于Namespaces",
+        "text": "namespace 是 flow 及其组件的逻辑分组。"
+      },
+      "workflow_components": {
+        "title": "工作流组件",
+        "text": "了解 Kestra 工作流的主要编排组件。"
+      },
+      "videos_tutorials": {
+        "title": "视频教程",
+        "text": "开始观看我们的视频教程。"
+      }
+    },
+    "open sidebar": "打开侧边栏",
+    "close sidebar": "关闭侧边栏",
+    "customize sidebar": "自定义侧边栏",
+    "reset to defaults": "重置为默认值",
+    "drop items here": "将项目拖放到此处",
+    "files": "文件",
+    "optional": "可选",
+    "no_data": "看起来这里还没有内容……<br/>调整您的过滤器，或者再试一次！",
+    "bookmark": "书签",
+    "remove_bookmark": "您确定要删除此书签吗？",
+    "showLess": "显示较少",
+    "showMore": "显示更多",
+    "documentationMenu": "文档菜单",
+    "item": "项目",
+    "items": "项目",
+    "cron": "定时任务",
+    "execution_started": "执行已开始！",
+    "execution_failed": "执行失败！",
+    "last error was": "上次错误是",
+    "execution restarted": "此执行已重新启动{nbRestart}次。",
+    "execution replay": "此执行是以下内容的重放",
+    "execution replayed": "此执行已被重放。",
+    "task run id": "任务运行 ID",
+    "active": "活动",
+    "flows imported": "Flow已导入",
+    "flow not imported": "某些flow无法导入",
+    "plugin defaults exported": "插件默认值已导出",
+    "failed to export plugin defaults": "无法导出插件默认值",
+    "plugin defaults imported": "插件默认值已导入",
+    "plugin defaults not imported": "某些插件默认设置无法导入",
+    "failed to import plugin defaults": "无法导入插件默认值",
+    "filters": {
+      "label": "选择过滤器",
+      "empty": "无数据。",
+      "format": "将参数输入为 'key:value'",
+      "text_search": "搜索此文本",
+      "options": {
+        "namespace": "命名空间",
+        "flow": "流程",
+        "state": "状态",
+        "scope": "范围",
+        "child": "子节点",
+        "level": "日志级别",
+        "task": "任务",
+        "metric": "指标",
+        "user": "用户",
+        "type": "类型",
+        "service_type": "类型",
+        "permission": "权限",
+        "action": "操作",
+        "status": "状态",
+        "details": "详情",
+        "aggregation": "聚合",
+        "relative_date": "相对日期",
+        "absolute_date": "绝对日期",
+        "labels": "标签",
+        "text": "文本",
+        "startDate": "开始日期",
+        "endDate": "结束日期"
+      },
+      "comparators": {
+        "is": "是",
+        "is_one_of": "是其中之一",
+        "is_not": "不是",
+        "not_in": "不在",
+        "contains": "包含",
+        "not_contains": "不包含",
+        "in": "在",
+        "between": "之间",
+        "starts_with": "以...开始",
+        "greater_than": "大于",
+        "greater_than_or_equal_to": "大于或等于",
+        "less_than": "小于",
+        "less_than_or_equal_to": "小于或等于",
+        "ends_with": "以...结束"
+      },
+      "save": {
+        "label": "已保存的搜索",
+        "remove": "移除",
+        "empty": "您还没有保存任何搜索。",
+        "tooltip": "您不能保存空的搜索条件。",
+        "name_already_used": "搜索标签已被使用。",
+        "dialog": {
+          "heading": "保存当前搜索",
+          "placeholder": "标签",
+          "hint": "您想如何标记此搜索条件？",
+          "confirmation": "搜索条件 <code>{name}</code>"
+        }
+      },
+      "settings": {
+        "label": "页面设置",
+        "show_chart": "显示主图表"
+      }
+    },
+    "custom value": "自定义值",
+    "chart": "图表",
+    "chart preview": "图表预览",
+    "no_code": {
+      "toggle_pebble": "切换Pebble编辑器",
+      "version_oss_placeholder": "解锁企业版插件版本控制",
+      "unnamed": "无名称",
+      "adding": "+ 添加{what}",
+      "adding_default": "+ 添加新value",
+      "add_field": "添加{field}",
+      "clearSelection": "清除选择",
+      "labels": {
+        "yaml": "YAML编辑器",
+        "no_code": "无代码编辑器",
+        "label": "标签",
+        "variable": "变量"
+      },
+      "sections": {
+        "deprecated": "不推荐使用的属性",
+        "tasks": "任务",
+        "triggers": "触发器",
+        "errors": "错误处理程序",
+        "afterExecution": "执行后",
+        "finally": "最后",
+        "pluginDefaults": "插件默认值"
+      },
+      "fields": {
+        "main": {
+          "id": "Flow ID",
+          "namespace": "命名空间",
+          "description": "描述",
+          "inputs": "输入"
+        },
+        "general": {
+          "retry": "重试",
+          "sla": "SLA",
+          "labels": "标签",
+          "outputs": "输出",
+          "variables": "变量",
+          "concurrency": "并发性",
+          "disabled": "禁用",
+          "listeners": "监听器",
+          "taskDefaults": "任务默认值",
+          "workerGroup": "工作组",
+          "workerSelector": "Worker 选择器",
+          "checks": "检查",
+          "updated": "已更新"
+        }
+      },
+      "select": {
+        "default": "选择类型",
+        "task": "选择一个task",
+        "tasks": "选择一个task",
+        "triggers": "选择一个trigger",
+        "errors": "选择一个task",
+        "finally": "选择一个task",
+        "pluginDefaults": "选择插件",
+        "afterExecution": "选择一个task",
+        "conditions": "选择条件",
+        "inputs": "选择一个input字段类型",
+        "charts": "选择图表类型",
+        "where": "选择筛选器类型",
+        "numerator": "选择一个分子"
+      },
+      "creation": {
+        "default": "添加",
+        "tasks": "添加任务",
+        "triggers": "添加一个trigger",
+        "errors": "添加错误处理程序",
+        "finally": "添加一个finally块",
+        "pluginDefaults": "添加插件默认值",
+        "afterExecution": "添加执行后块",
+        "conditions": "添加条件",
+        "inputs": "添加一个input字段",
+        "charts": "添加图表",
+        "where": "筛选您的数据",
+        "numerator": "添加分子"
+      },
+      "remove": {
+        "default": "删除此条目",
+        "cases": "删除此案例"
+      }
+    },
+    "properties": {
+      "label": "属性",
+      "hint": "选择可见列",
+      "shown": "显示在表格中",
+      "hidden": "隐藏在表格中"
+    },
+    "editor_shortcuts": {
+      "label": "键盘快捷键",
+      "trigger_autocompletion": "触发自动完成",
+      "command_palette": "显示命令面板",
+      "save_flow": "保存flow",
+      "execute_flow": "执行 flow",
+      "toggle_ai_agent": "切换AI代理",
+      "move_line": "移动行",
+      "duplicate_cursor": "复制光标",
+      "fold_unfold": "折叠/展开代码",
+      "comment_uncomment": "注释/取消注释",
+      "comment": "评论",
+      "uncomment": "取消注释",
+      "decrease_fontsize": "减小编辑器字体大小",
+      "increase_fontsize": "增加编辑器字体大小",
+      "reset_fontsize": "重置编辑器字体大小"
+    },
+    "instance": "实例",
+    "something_went_wrong": {
+      "loading_execution": "加载执行时出现问题",
+      "connection_lost": {
+        "title": "连接中断",
+        "message": "无法连接到您的Kestra实例。请确保它正在运行，然后刷新页面。"
+      }
+    },
+    "debug": "调试",
+    "default": "默认值",
+    "data_not_protected": "您的数据未受保护。不要丢失它。<b>启用我们的免费安全功能或试用我们的付费服务。</b>",
+    "activate_basic_auth": "启用基本身份验证",
+    "dark_version": "深色版本",
+    "use_dark_background": "在深色背景上工作时使用此版本，以确保我们的名称保持可读。",
+    "light_version": "轻量版本",
+    "light_background": "这是在使用浅色背景时的首选选项。",
+    "monogram": "字母组合",
+    "wordmark_colors": "字标的颜色会根据背景进行调整，而图标在深色背景上时则保持无背景。",
+    "download_logos": "下载 Logo 包",
+    "this_task_has": "此task已",
+    "about_this_blueprint": "关于此blueprint",
+    "deleted_label": "已删除",
+    "fold_all_multi_lines": "折叠所有多行",
+    "task_id_exists": "任务ID已存在",
+    "task_id_message": "任务ID ${existingTask} 已经存在于flow中。",
+    "trigger_id_exists": "Trigger Id 已经存在",
+    "trigger_id_message": "触发器 Id ${existingTrigger} 已经存在于 flow 中。",
+    "watch": "监视",
+    "learn_more": "了解更多",
+    "watch_video": "观看视频",
+    "runners": "运行者",
+    "select": "选择您的{{section}}",
+    "for flow": "用于 flow",
+    "forbidden system labels": "只有 system.correlationId 可以用作系统 label",
+    "confirm": "确认",
+    "taskRunners": "任务 Runners",
+    "additionalPlugins": "附加插件",
+    "appBlocks": "应用模块",
+    "charts": "图表",
+    "dataFilters": "数据过滤器",
+    "logExporters": "日志导出器",
+    "empty": {
+      "namespaceFiles": {
+        "title": "此命名空间中尚无文件",
+        "content": "命名空间文件的作用类似于此命名空间的项目文件夹。存储 Python、SQL、dbt 或 Terraform 代码，然后在您的 flow 中引用任何文件，使用"
+      },
+      "announcements": {
+        "title": "您还没有公告！",
+        "content": "公告允许您通知用户任何更改或告知他们计划的维护停机时间。只需选择公告类型、显示的日期范围，并撰写公告消息。"
+      },
+      "kill_switches": {
+        "title": "您还没有 Kill Switches！",
+        "content": "Kill Switch 功能提供了一种基于UI的机制来停止有问题的执行。它用一个全面的管理界面替代了仅限CLI的<code>--skip-executions</code>和<code>--skip-flows</code>命令。"
+      },
+      "apps": {
+        "title": "您还没有应用程序！",
+        "content": "开始构建应用程序，以便与外部世界的Kestra进行交互。"
+      },
+      "testSuites": {
+        "title": "您还没有测试套件！",
+        "content": "开始创建测试套件以测试您的Flows。"
+      },
+      "assets": {
+        "title": "您还没有资产！",
+        "content": "添加资产以跟踪和管理您的数据资产、服务和基础设施。"
+      },
+      "apiTokens": {
+        "title": "管理您的API Tokens",
+        "content": "API令牌用于在您希望授予程序化访问Kestra API时使用。"
+      },
+      "concurrency_executions": {
+        "title": "此 Flow 没有正在进行的 Executions。",
+        "content": "在我们的文档中阅读更多关于<strong><a href=\"https://kestra.io/docs/workflow-components/execution?utm_source=app&utm_medium=referral&utm_campaign=concurrency-inlinedoc\" target=\"_blank\">Executions</a></strong>的信息。"
+      },
+      "concurrency_limit": {
+        "title": "此Flow未设置限制。",
+        "content": "在我们的文档中阅读更多关于<strong><a href=\"https://kestra.io/docs/workflow-components/concurrency?utm_source=app&utm_medium=referral&utm_campaign=concurrency-inlinedoc\" target=\"_blank\">Concurrency Limits</a></strong>的信息。"
+      },
+      "concurrency_limits": {
+        "title": "未设置并发限制。",
+        "content": "在我们的文档中阅读更多关于<strong><a href=\"https://kestra.io/docs/workflow-components/concurrency?utm_source=app&utm_medium=referral&utm_campaign=concurrency-inlinedoc\" target=\"_blank\">并发限制</a></strong>的信息。"
+      },
+      "pluginDefaults": {
+        "title": "您还没有插件默认值！",
+        "content": "插件默认设置允许您集中管理插件配置，并与namespace中的所有flow共享。"
+      },
+      "variables": {
+        "title": "尚无变量",
+        "content": "添加kv store以在不同的flow之间共享配置。子namespace会自动继承这些配置，您可以引用任何value。"
+      },
+      "workerRegistrationTokens": {
+        "title": "您还没有注册令牌！",
+        "content": "注册令牌允许远程worker安全地进行身份验证并注册到您的Kestra实例。创建一个令牌，然后使用它将新worker连接到此集群。"
+      },
+      "groups": {
+        "title": "您还没有群组！",
+        "content": "组允许您将用户捆绑在一起，以便您可以在整个租户中集体管理权限和角色绑定。"
+      },
+      "dependencies": {
+        "FLOW": {
+          "title": "当前没有依赖项。",
+          "content": "在我们的文档中阅读更多关于<a href=\"https://kestra.io/docs/ui/flows?utm_source=app&utm_medium=referral&utm_campaign=dependencies-inlinedoc#dependencies\" target=\"_blank\">Flow Dependencies</a>的信息。"
+        },
+        "EXECUTION": {
+          "title": "当前没有依赖项。",
+          "content": "了解更多关于<a href=\"https://kestra.io/docs/ui/executions?utm_source=app&utm_medium=referral&utm_campaign=dependencies-inlinedoc#dependencies\" target=\"_blank\">执行依赖关系</a>的信息，请参阅我们的文档。"
+        },
+        "NAMESPACE": {
+          "title": "当前没有依赖项。",
+          "content": "了解更多关于<a href=\"https://kestra.io/docs/ui/namespaces?utm_source=app&utm_medium=referral&utm_campaign=dependencies-inlinedoc#dependencies\" target=\"_blank\">Namespace Dependencies</a>的信息，请参阅我们的文档。"
+        },
+        "ASSET": {
+          "title": "当前没有依赖项。",
+          "content": "此资产与flow或其他资产没有上游或下游依赖关系。"
+        }
+      },
+      "plugins": {
+        "title": "此Namespace未设置插件默认值。",
+        "content": "在我们的文档中阅读更多关于<strong><a href=\"https://kestra.io/docs/workflow-components/plugin-defaults?utm_source=app&utm_medium=referral&utm_campaign=plugin-default-inlinedoc\" target=\"_blank\">Concurrency Limits</a></strong>的信息。"
+      },
+      "triggers": {
+        "title": "您的 flow 没有任何 Triggers。",
+        "content": "在我们的文档中阅读更多关于<strong><a href=\"https://kestra.io/docs/workflow-components/triggers?utm_source=app&utm_medium=referral&utm_campaign=trigger-inlinedoc\" target=\"_blank\">Triggers</a></strong>的信息。"
+      },
+      "mcpToolFlows": {
+        "title": "此服务器上尚未注册任何工具flow。",
+        "content": "通过向flow添加<code>McpToolTrigger</code>，将flow公开为MCP工具。请在我们的文档中阅读更多关于<strong><a href=\"https://kestra.io/docs/workflow-components/triggers/mcp-tool-trigger?utm_source=app&utm_medium=referral&utm_campaign=mcp-tool-trigger-inlinedoc\" target=\"_blank\">MCP Tool Trigger</a></strong>的信息。"
+      },
+      "versionPlugin": {
+        "title": "您还没有版本化的插件！",
+        "content": "在这里，您可以管理安装在您的 Kestra 实例上的所有插件。新安装的插件可能不会立即在所有 Kestra 服务中可用，这取决于您的实例配置。"
+      },
+      "panels": {
+        "title": "没有面板打开",
+        "content": "您已关闭所有面板。  \n请选择上面的选项卡以继续。"
+      }
+    },
+    "toggle_word_wrap": "切换自动换行",
+    "copied_logs_to_clipboard": "已将日志复制到剪贴板。",
+    "multi_panel_editor": {
+      "move_right": "向右移动",
+      "move_left": "向左移动",
+      "close_all_tabs": "关闭所有标签页",
+      "close_all_panels": "关闭所有面板"
+    },
+    "search_docs": "搜索",
+    "no_results_found": "未找到结果",
+    "searching": "搜索中...",
+    "worker information": "工作者信息",
+    "test-badge-text": "测试",
+    "test-badge-tooltip": "此执行由测试创建",
+    "total_executions": "总执行次数",
+    "no_results": {
+      "executions": "未找到执行",
+      "triggers": "未找到Triggers",
+      "flows": "未找到Flows",
+      "kv_pairs": "未找到Key-Value对",
+      "secrets": "未找到Secrets",
+      "templates": "未找到模板",
+      "assets": "未找到资产"
+    },
+    "duplicate-pair": "{label} \"{key}\" 是重复的，第一个 key 被忽略。",
+    "dashboards": {
+      "labels": {
+        "singular": "仪表板",
+        "plural": "仪表板"
+      },
+      "default": "默认仪表板",
+      "switch": "切换仪表板",
+      "preview": "预览仪表板",
+      "empty": "没有结果显示。",
+      "creation": {
+        "label": "创建仪表板",
+        "confirmation": "仪表板 <code>{title}</code> 已创建。"
+      },
+      "edition": {
+        "label": "编辑仪表板",
+        "confirmation": "仪表板<code>{title}</code>中的更改已保存。",
+        "chart": "编辑此图表",
+        "id readonly": "属性 `id` 不能更改——它现在设置为初始值。如果您想更改它，可以创建一个新的仪表板并删除旧的。"
+      },
+      "deletion": {
+        "confirmation": "您确定要删除<code>{title}</code>仪表板吗？"
+      },
+      "no_description": "无描述",
+      "no_description_hint": "为此 flow 添加描述以记录其功能。<br>支持 Markdown。",
+      "others": "其他",
+      "viewAll": "查看全部",
+      "chart_preview": "单击图表源代码以查看其预览",
+      "export": "导出为CSV",
+      "quick_filters": {
+        "all": "全部",
+        "running": "运行中",
+        "paused": "已暂停",
+        "success": "成功",
+        "warning": "警告",
+        "failed": "失败"
+      }
     },
     "setup": {
-      "config": {
-        "basicauth": "基本认证",
-        "queue": "队列",
-        "repository": "数据库",
-        "storage": "内部存储"
+      "login": "登录",
+      "login_title": "登录",
+      "logout": "注销",
+      "troubleshooting": "忘记密码？",
+      "steps": {
+        "user": "创建管理员用户",
+        "config": "验证配置",
+        "survey": "请告诉我们更多信息",
+        "complete": "启动 Kestra UI"
       },
-      "confirm": {
-        "config_title": "确认配置有效",
-        "confirm": "创建管理员用户",
-        "not_valid": "不，这无效",
-        "valid": "是的，它是有效的"
+      "titles": {
+        "user": "创建管理员用户",
+        "survey": "帮助我们改进 Kestra OSS"
+      },
+      "subtitles": {
+        "user": "保护您的实例以开始使用。",
+        "config": "以下是您的配置详情",
+        "survey": "I'm sorry, but it seems there is no text provided after the \"----------\" for translation. Could you please provide the text you would like translated?",
+        "complete": "设置成功完成！"
       },
       "form": {
         "email": "电子邮件",
@@ -1878,351 +1937,249 @@
         "username": "用户名",
         "username_hint": "必须是有效的电子邮件地址。"
       },
-      "login": "登录",
-      "login_title": "登录",
-      "logout": "注销",
-      "steps": {
-        "complete": "启动 Kestra UI",
-        "config": "验证配置",
-        "survey": "请告诉我们更多信息",
-        "user": "创建管理员用户"
-      },
-      "subtitles": {
-        "complete": "设置成功完成！",
-        "config": "以下是您的配置详情",
-        "survey": "I'm sorry, but it seems there is no text provided after the \"----------\" for translation. Could you please provide the text you would like translated?",
-        "user": "保护您的实例以开始使用。"
-      },
-      "success": {
-        "subtitle": "一切准备就绪！",
-        "title": "恭喜！"
-      },
-      "survey": {
-        "company_11_50": "个人项目",
-        "company_1_10": "学习 / 探索",
-        "company_250_plus": "生产部署",
-        "company_50_250": "为我的团队/公司评估",
-        "company_personal": "其他",
-        "company_size": "您使用 Kestra 的主要目标是什么？",
-        "continue": "继续",
-        "newsletter": "通过电子邮件获取产品更新。",
-        "newsletter_heading": "保持关注",
-        "skip": "跳过",
-        "use_case": "你计划用它来做什么？",
-        "use_case_business": "业务工作流",
-        "use_case_data": "数据工作流",
-        "use_case_infrastructure": "基础设施自动化",
-        "use_case_ml": "ML 管道",
-        "use_case_other": "其他",
-        "use_case_scheduling": "调度和重复作业"
-      },
-      "titles": {
-        "survey": "帮助我们改进 Kestra OSS",
-        "user": "创建管理员用户"
-      },
-      "troubleshooting": "忘记密码？",
       "validation": {
-        "config_message": "请确保更新您的配置以修复此错误消息",
-        "email_invalid": "无效的电子邮件",
         "email_required": "需要提供电子邮件",
+        "email_invalid": "无效的电子邮件",
         "email_temporary_not_allowed": "不允许使用临时或一次性邮箱地址",
         "firstName_required": "名字为必填项",
-        "incorrect_creds": "用户名或密码无效。请确保您的凭据正确。",
         "lastName_required": "姓氏为必填项",
         "password_invalid": "密码无效",
-        "password_required": "密码为必填项"
+        "password_required": "密码为必填项",
+        "incorrect_creds": "用户名或密码无效。请确保您的凭据正确。",
+        "config_message": "请确保更新您的配置以修复此错误消息"
+      },
+      "config": {
+        "repository": "数据库",
+        "queue": "队列",
+        "storage": "内部存储",
+        "basicauth": "基本认证"
+      },
+      "confirm": {
+        "confirm": "创建管理员用户",
+        "config_title": "确认配置有效",
+        "not_valid": "不，这无效",
+        "valid": "是的，它是有效的"
+      },
+      "survey": {
+        "skip": "跳过",
+        "company_size": "您使用 Kestra 的主要目标是什么？",
+        "company_1_10": "学习 / 探索",
+        "company_11_50": "个人项目",
+        "company_50_250": "为我的团队/公司评估",
+        "company_250_plus": "生产部署",
+        "company_personal": "其他",
+        "use_case": "你计划用它来做什么？",
+        "use_case_infrastructure": "基础设施自动化",
+        "use_case_business": "业务工作流",
+        "use_case_data": "数据工作流",
+        "use_case_ml": "ML 管道",
+        "use_case_scheduling": "调度和重复作业",
+        "use_case_other": "其他",
+        "newsletter_heading": "保持关注",
+        "newsletter": "通过电子邮件获取产品更新。",
+        "continue": "继续"
+      },
+      "success": {
+        "title": "恭喜！",
+        "subtitle": "一切准备就绪！"
       }
     },
-    "show": "显示",
-    "show chart": "显示图表",
-    "show description": "显示描述",
-    "show details": "显示详情",
-    "show documentation": "显示文档",
-    "show more details": "显示更多详情",
-    "show raw": "Show raw",
-    "show task condition": "显示任务条件",
-    "show task documentation": "显示任务文档",
-    "show task documentation in editor": "在编辑器中显示任务文档",
-    "show task logs": "显示任务日志",
-    "show task outputs": "显示任务输出",
-    "show task source": "显示任务源代码",
-    "showLess": "显示较少",
-    "showMore": "显示更多",
-    "side-by-side": "并排",
-    "similar lines": "similar lines",
-    "skipped": "跳过",
-    "slack support": "通过Slack提问",
-    "something_went_wrong": {
-      "connection_lost": {
-        "message": "无法连接到您的Kestra实例。请确保它正在运行，然后刷新页面。",
-        "title": "连接中断"
+    "ai": {
+      "flow": {
+        "title": "AI代理",
+        "prompt_placeholder": "输入指令以创建您的Kestra flow。示例提示：创建一个每周一上午9点运行的flow。",
+        "select_provider": "选择提供商",
+        "generating": {
+          "flow": "正在为您生成Flow YAML...",
+          "dashboard": "正在为您生成Dashboard YAML...",
+          "app": "正在为您生成应用程序 YAML...",
+          "test": "正在为您生成测试 YAML..."
+        },
+        "enable_instructions": {
+          "header": "<b>AI Copilot 尚未配置。</b>\n\n要启用 AI Copilot，请将以下代码片段添加到您的 Kestra 实例配置文件中（例如 <code>application.yml</code>），并将 <code>geminiApiKey</code> 替换为您的实际 key：",
+          "footer": "注意：目前，开源版仅支持Gemini作为AI提供商。对于企业版，请参阅AI Copilot文档以获取其他模型提供商的配置。\n\n保存配置后，重新启动您的Kestra实例。"
+        }
       },
-      "loading_execution": "加载执行时出现问题"
+      "dashboard": {
+        "prompt_placeholder": "询问有关您数据的问题。示例提示：显示我过去7天内的flow成功率。"
+      }
     },
-    "source": "来源",
-    "source and blueprints": "源代码和蓝图",
-    "source and doc": "源代码和文档",
-    "source and topology": "源代码和拓扑",
-    "source only": "仅限来源",
-    "source search": "源搜索",
-    "source_search": {
-      "match_count": "{count} 个匹配 | {count} 个匹配",
-      "open_flow": "打开 flow",
-      "preview_empty": "选择一个结果进行预览。点击结果列表中的 flow 查看其源码。",
-      "preview_error": "加载 flow 源码失败"
+    "playground": {
+      "title": "游乐场",
+      "run_task_info": "将鼠标悬停在Flow Code编辑器中的任何task上，然后点击“Run task”按钮以测试您的task。",
+      "play_icon_info": "您还可以在无代码或拓扑视图中点击播放图标。",
+      "toggle": "游乐场",
+      "run_task": "运行Task",
+      "run_this_task": "运行此task",
+      "run_task_and_downstream": "运行 task 和下游",
+      "run_all_tasks": "运行所有Tasks",
+      "history": "最近10次运行",
+      "clear_history": "清除历史记录",
+      "confirm_create": "在创建flow时无法运行playground。启动playground运行将创建flow。",
+      "tooltip_persistence": "如果您关闭并重新打开Playground，只要您停留在页面上，信息将保持不变。"
     },
-    "specific task": "特定任务",
-    "start date": "开始日期",
-    "start datetime": "开始日期时间",
-    "started date": "开始日期",
-    "state": "状态",
-    "state updated date": "状态更新日期",
-    "state_history": "状态历史",
-    "stats": "统计",
-    "steps": "步骤",
-    "stream": "流",
-    "sub flow": "子流程",
     "submit": "提交",
-    "success": "成功",
-    "sum": "总计",
-    "switch-view": "切换视图",
-    "system overview": "系统概览",
-    "system_namespace": "保持您的平台通过系统flows进行检查。",
-    "system_namespace_description": "自动化维护任务，从故障警报到自动清理。",
-    "tags": "标签",
-    "task": "任务",
-    "task failed": "任务失败",
-    "task id": "任务ID",
-    "task id already exists": "任务ID已存在",
-    "task is running": "任务正在运行",
-    "task logs": "任务日志",
-    "task run id": "任务运行 ID",
-    "task sent a warning": "任务发送了警告",
-    "task was skipped": "任务被跳过",
-    "task was successful": "任务成功",
-    "taskDefaults": "任务默认值",
-    "taskRunners": "任务 Runners",
-    "task_id_exists": "任务ID已存在",
-    "task_id_message": "任务ID ${existingTask} 已经存在于flow中。",
-    "taskid column details": "最后执行的任务及其尝试次数。",
-    "tasks": "任务",
-    "template": "模板",
-    "template creation": "模板创建",
-    "template delete": "确定要删除 <code>{templateCount}</code> 个模板吗？",
-    "template export": "确定要导出 <code>{templateCount}</code> 个模板吗？",
-    "templates": "模板",
-    "templates deleted": "<code>{count}</code> 个模板已删除",
-    "templates deprecated": "模板已弃用。请使用子流程代替。查看 <a href=\"https://kestra.io/docs/migration-guide/0.11.0/templates?utm_source=app&utm_medium=referral&utm_campaign=template-inlinedoc\" target=\"_blank\">迁移部分</a> 了解如何从模板迁移到子流程。",
-    "templates exported": "模板已导出",
-    "tenant": {
-      "name": "租户",
-      "names": "租户"
-    },
-    "tenantId": "租户 ID",
-    "test-badge-text": "测试",
-    "test-badge-tooltip": "此执行由测试创建",
-    "theme": "主题",
-    "this_task_has": "此task已",
-    "timezone": "时区",
-    "title": "标题",
-    "to": "到",
     "to toggle": "切换",
-    "toggle fullscreen": "切换全屏",
-    "toggle menu": "切换菜单",
-    "toggle output": "切换输出",
-    "toggle output display": "切换输出显示",
-    "toggle periodic refresh each x seconds": "切换每隔 {interval} 秒的定期刷新",
-    "toggle_word_wrap": "切换自动换行",
-    "topology": "拓扑",
-    "topology-graph": {
-      "graph-orientation": "图表方向",
-      "invalid": "图形错误",
-      "invalid_description": "加载图表时发生错误。请检查源代码中的错误。",
-      "zoom-fit": "适应屏幕",
-      "zoom-in": "放大",
-      "zoom-out": "缩小",
-      "zoom-reset": "重置缩放"
-    },
-    "total_duration": "总持续时间",
-    "total_executions": "总执行次数",
-    "trigger": "触发器",
-    "trigger details": "触发器详情",
-    "trigger disabled": "在Flow源中触发器已禁用",
-    "trigger execution id": "触发执行ID",
-    "trigger filter": {
-      "options": {
-        "ALL": "所有执行",
-        "CHILD": "子执行",
-        "MAIN": "父执行"
+    "accept": "接受",
+    "reject": "拒绝",
+    "draft_available": "编辑器中有可用的草稿更改",
+    "last modified": "上次修改",
+    "run task in playground": "在playground中运行task",
+    "task is running": "任务正在运行",
+    "task was successful": "任务成功",
+    "task failed": "任务失败",
+    "task was skipped": "任务被跳过",
+    "task sent a warning": "任务发送了警告",
+    "defaultsToNamespaceFile": "默认为 namespace 文件：<code>{name}</code>",
+    "no_file_choosen": "未选择文件",
+    "dependency": {
+      "controls": {
+        "zoom_in": "放大",
+        "zoom_out": "缩小视图",
+        "clear_selection": "清除选择",
+        "fit_view": "适合屏幕"
       },
-      "title": "过滤子执行"
-    },
-    "trigger refresh": "触发刷新",
-    "triggerId": "触发器 ID",
-    "trigger_check_warning": "使用 trigger 变量无法与手动 flow 执行一起工作。添加 `??` 合并运算符来解决此问题。例如，不要使用 `trigger.date`，而是使用 `trigger.date ?? execution.startDate`。",
-    "trigger_id_exists": "Trigger Id 已经存在",
-    "trigger_id_message": "触发器 Id ${existingTrigger} 已经存在于 flow 中。",
-    "trigger_states": "状态",
-    "triggered": "执行触发器",
-    "triggered done": "执行 <em>{name}</em> 成功触发",
-    "triggerflow disabled": "触发器在流程定义中被禁用",
-    "triggers": "触发器",
-    "triggers_add_card_add": "添加",
-    "triggers_add_card_add_to_flow": "添加到flow",
-    "triggers_add_category_empty": "此类别中没有trigger。",
-    "triggers_add_ee_tooltip": "此trigger需要企业版。",
-    "triggers_add_empty_title": "未找到trigger",
-    "triggers_add_filter_all": "全部",
-    "triggers_add_filter_app": "应用程序",
-    "triggers_add_filter_core": "核心",
-    "triggers_add_filter_realtime": "实时",
-    "triggers_add_modal_add_button": "将 Trigger 添加到 Flow",
-    "triggers_add_modal_ee_notice": "此trigger需要企业版。",
-    "triggers_add_modal_flow_placeholder": "选择一个flow",
-    "triggers_add_modal_namespace_placeholder": "选择一个namespace",
-    "triggers_add_modal_properties_hint": "在添加trigger后，在flow编辑器中配置trigger属性。",
-    "triggers_add_modal_tab_documentation": "文档",
-    "triggers_add_modal_tab_form": "表单",
-    "triggers_add_modal_tab_source": "来源",
-    "triggers_add_modal_title": "{name}",
-    "triggers_add_modal_trigger_id": "触发器ID",
-    "triggers_add_modal_trigger_id_placeholder": "此trigger的唯一标识符",
-    "triggers_add_search_placeholder": "搜索 triggers...",
-    "triggers_header_description": "浏览、添加和管理触发器以自动化您的flows。您可以选择将flow公开为AI工具、进行调度、添加webhook trigger、轮询外部应用程序中的更改或实时事件监听器。",
-    "triggers_state": {
-      "options": {
-        "disabled": "禁用",
-        "enabled": "启用"
-      },
-      "state": "状态"
-    },
-    "triggers_tabs_add": "添加",
-    "triggers_tabs_manage": "管理",
-    "true": "真",
-    "type": "类型",
-    "unable to generate graph": "生成图表时发生问题，无法显示拓扑。",
-    "undefined": "未定义",
-    "unlock": "解锁",
-    "unlock trigger": {
-      "button": "解锁触发器",
-      "confirmation": "确定要解锁触发器吗？",
-      "success": "触发器已解锁",
-      "tooltip": {
-        "evaluation": "此触发器当前正在评估",
-        "execution": "此触发器正在执行"
-      },
-      "warning": "这可能会导致同一触发器的并发执行，应作为最后的选择。"
-    },
-    "unqueue": "出队列",
-    "unqueue as": "取消排队为<code>{status}</code>",
-    "unqueue confirm": "您确定要取消排队执行<code>{id}</code>吗？",
-    "unqueue done": "执行已出队列",
-    "unqueue title": "取消执行 <code>{id}</code>。<br/>请注意，它将不遵循 flow 并发限制，因此可能会有超过允许限制的执行正在运行。",
-    "unqueue title multiple": "您确定要取消排队 <code>{count}</code> 个执行吗？<br/><br/>请注意，这将不遵循flow的并发限制，因此可能会有超过允许限制的执行正在运行。",
-    "unsaved changed ?": "你有未保存的更改，是否要离开此页面？",
-    "unsaved changes": "未保存的更改",
-    "unsaved changes warning": "您有未保存的更改。如果您离开此页面，您的更改将会丢失。",
-    "up trend": "增加",
-    "update": "更新",
-    "update aborted": "更新中止",
-    "update ok": "已更新",
-    "updated date": "更新日期",
-    "usage": "使用情况",
-    "use": "使用",
-    "use_dark_background": "在深色背景上工作时使用此版本，以确保我们的名称保持可读。",
-    "valid": "有效",
-    "validate": "验证",
-    "value": "值",
-    "variable_explorer": {
-      "empty": "此执行没有可用的变量。",
-      "n_items": "[ {count} 项 ]",
-      "n_keys": "\\{ {count} keys \\}",
-      "one_item": "[ 1 项 ]",
-      "one_key": "\\{ 1 key \\}",
-      "raw_json": "Raw JSON",
-      "search_placeholder": "搜索 Key 或 value...",
-      "select_prompt": "选择一个变量以查看其 value。",
-      "tasks_outputs": "Tasks outputs",
-      "title": "输入/输出",
-      "tree": "树"
-    },
-    "variables": "变量",
-    "version": "版本",
-    "view metrics": "查看指标",
-    "warning": "警告",
-    "warning detected": "检测到警告",
-    "warning flow with triggers": "此流程包含触发器，如果此流程依赖触发表达式，则手动执行将失败。",
-    "watch": "监视",
-    "watch_video": "观看视频",
-    "webhook": {
-      "copy_url": "复制 webhook URL",
-      "curl_command": "Webhook cURL 命令",
-      "curl_note": "使用此 cURL 命令通过 webhook 触发 flow，并使用自定义 JSON 负载",
-      "no_triggers": "此flow没有启用的webhook triggers",
-      "payload": "Webhook Payload (JSON)"
-    },
-    "webhook link copied": "Webhook链接已复制。",
-    "welcome": {
-      "help": {
-        "text": "在我们的Slack社区中提问。如果您遇到困难，我们会帮助您。✋",
-        "title": "需要帮助吗？"
-      },
-      "menu": "Welcome",
-      "tour": {
-        "text": "选择您的用例，并按照分步指南学习 Kestra 的功能和能力。❤️",
-        "title": "开始产品导览"
-      },
-      "tutorial": {
-        "text": "* <a href=\"https://kestra.io/tutorial-videos/all?utm_source=app&utm_medium=referral&utm_campaign=welcome-tutorial\" target=\"_blank\">视频教程</a>  \n* <a href=\"https://kestra.io/docs?utm_source=app&utm_medium=referral&utm_campaign=welcome-tutorial\" target=\"_blank\">文档</a>  \n* <a href=\"https://kestra.io/blueprints?utm_source=app&utm_medium=referral&utm_campaign=welcome-tutorial\" target=\"_blank\">Blueprints</a>",
-        "title": "教程"
+      "search": {
+        "placeholders": {
+          "default": "按flow或namespace搜索...",
+          "asset": "按资产、flow或namespace搜索..."
+        },
+        "namespace": {
+          "select": "选择一个namespace",
+          "no_namespace": "没有namespace"
+        },
+        "flow": {
+          "display": "包含flow依赖项"
+        },
+        "no_results": "未找到与 {term} 相关的结果"
       }
     },
+    "preview": {
+      "label": "预览",
+      "force-editor": "强制编辑器视图",
+      "auto-view": "自动视图",
+      "view": "查看",
+      "rows_truncated": "显示 {shown} 行，共 {total} 行。下载文件以查看所有数据。",
+      "pagination_info": "显示第 {start}-{end} 行，共 {total} 行。",
+      "showing_rows": "显示第 {start}-{end} 行，共 {total} 行",
+      "expand": "展开",
+      "collapse": "折叠",
+      "previous": "上一步",
+      "next": "下一步",
+      "page_of": "第 {current} 页，共 {total} 页"
+    },
+    "delete trigger": "删除 trigger",
+    "delete triggers": "删除 triggers",
+    "bulk delete triggers": "您确定要删除 {count} 个 triggers 吗？",
+    "bulk success delete triggers": "{count} 个 trigger 已成功删除",
+    "delete trigger confirmation": "您确定要删除trigger {id}吗？WARNING: 如果trigger仍在flow中激活，删除trigger可能会导致重复执行。",
+    "delete trigger success": "触发器 {id} 已成功删除",
+    "delete trigger error": "删除触发器 {id} 时出错",
+    "revision deleted": "修订版 {revision} 已成功删除",
+    "delete revision confirm": "您确定要删除修订版 {revision} 吗？",
+    "delete revision error": "删除修订版 {revision} 时出错，错误信息 {error}",
+    "no_history": "无可用历史记录",
+    "export_as": "导出为.{format}",
+    "save_and_execute": "保存并执行",
     "welcome_copilot": {
       "button_cta": "从头创建flow",
       "create_manually": {
-        "description": "使用编辑器从头开始构建",
-        "title": "手动创建"
+        "title": "手动创建",
+        "description": "使用编辑器从头开始构建"
       },
       "docs": {
-        "description": "在官方文档中了解更多信息",
-        "title": "阅读文档"
+        "title": "阅读文档",
+        "description": "在官方文档中了解更多信息"
       },
+      "title": "将您的想法转化为workflow",
+      "need_help": "需要帮助？",
+      "placeholder_prompt": "每天早上9点发送问候消息给我。",
+      "show_more": "显示更多提示",
+      "show_less": "显示更少提示",
+      "remaining_quota": "您还有 {count} 次AI生成机会。限制将在每天的UTC午夜重置。",
       "execute_hint": {
-        "description": "单击以保存您的工作流并立即运行。",
-        "title": "保存并执行您的flow"
+        "title": "保存并执行您的flow",
+        "description": "单击以保存您的工作流并立即运行。"
+      },
+      "success_popup": {
+        "title": "恭喜！",
+        "description": "您已成功执行了您的第一个flow！您正在迈向成为Kestra专家的道路上。",
+        "tutorial": "深入教程",
+        "explore": "探索更多"
+      },
+      "success_page": {
+        "title": "一切准备就绪！",
+        "description": "您已经了解了Kestra的基础知识。以下是一些资源，帮助您继续您的旅程。",
+        "restart": "重新启动教程",
+        "items": {
+          "tutorial": {
+            "title": "开始教程",
+            "description": "Kestra所有功能的互动演练"
+          },
+          "blueprints": {
+            "title": "蓝图",
+            "description": "预构建工作流模板用于常见用例"
+          },
+          "slack": {
+            "title": "Slack 社区",
+            "description": "与其他用户联系并从社区获得帮助"
+          },
+          "videos": {
+            "title": "视频教程",
+            "description": "高级功能的逐步视频指南"
+          },
+          "demo": {
+            "title": "获取演示",
+            "description": "通过个性化演示探索 Kestra Enterprise Edition"
+          }
+        }
+      },
+      "help": {
+        "tutorial": {
+          "title": "开始教程",
+          "description": "了解如何通过指南步骤创建并运行您的第一个flow。"
+        },
+        "blueprints": {
+          "title": "蓝图",
+          "description": "探索可直接使用的示例和模板，以适应常见的工作流模式。"
+        },
+        "slack": {
+          "title": "Slack 社区",
+          "description": "加入我们，分享想法和最佳实践，并获得技术问题的帮助。"
+        }
       },
       "flows": {
-        "buildDbtPipeline": {
-          "label": "构建一个 dbt pipeline",
-          "prompt": "创建一个Kestra flow，克隆一个dbt项目仓库，并使用DuckDB配置文件运行dbt build。"
-        },
-        "buildDockerImageAndRunIt": {
-          "label": "构建一个Docker镜像并运行它",
-          "prompt": "创建一个 Kestra flow，从内联 Dockerfile 构建 Docker 镜像并运行生成的容器。"
-        },
-        "convertCsvToExcel": {
-          "label": "将CSV转换为Excel",
-          "prompt": "创建一个flow，下载CSV文件，将其转换为Ion，并将结果导出为Excel文件。"
-        },
-        "etlWorkflow": {
-          "label": "ETL 工作流",
-          "prompt": "创建一个ETL flow，下载JSON数据，用Python处理，并使用DuckDB查询转换后的结果。"
+        "jsonApiToDuckdb": {
+          "label": "DuckDB 的 JSON API",
+          "prompt": "创建一个flow，从公共API下载JSON文件，使用Python脚本进行转换，并通过DuckDB Queries task进行处理。"
         },
         "installNginxViaAnsible": {
           "label": "通过Ansible安装Nginx",
           "prompt": "创建一个Kestra flow，使用Ansible在目标机器上安装Nginx并验证已安装的版本。"
         },
-        "jsonApiToDuckdb": {
-          "label": "DuckDB 的 JSON API",
-          "prompt": "创建一个flow，从公共API下载JSON文件，使用Python脚本进行转换，并通过DuckDB Queries task进行处理。"
+        "buildDbtPipeline": {
+          "label": "构建一个 dbt pipeline",
+          "prompt": "创建一个Kestra flow，克隆一个dbt项目仓库，并使用DuckDB配置文件运行dbt build。"
+        },
+        "etlWorkflow": {
+          "label": "ETL 工作流",
+          "prompt": "创建一个ETL flow，下载JSON数据，用Python处理，并使用DuckDB查询转换后的结果。"
+        },
+        "microservicesApis": {
+          "label": "微服务和API",
+          "prompt": "创建一个flow，用于检查网站API响应，并在状态码不成功时发送Slack警报。"
+        },
+        "buildDockerImageAndRunIt": {
+          "label": "构建一个Docker镜像并运行它",
+          "prompt": "创建一个 Kestra flow，从内联 Dockerfile 构建 Docker 镜像并运行生成的容器。"
         },
         "manualApproval": {
           "label": "人工审批",
           "prompt": "创建一个flow，包含初始处理步骤、手动审批暂停，以及审批后的最终部署步骤。"
         },
-        "microservicesApis": {
-          "label": "微服务和API",
-          "prompt": "创建一个flow，用于检查网站API响应，并在状态码不成功时发送Slack警报。"
+        "convertCsvToExcel": {
+          "label": "将CSV转换为Excel",
+          "prompt": "创建一个flow，下载CSV文件，将其转换为Ion，并将结果导出为Excel文件。"
         },
         "scheduledPdfReports": {
           "label": "计划的PDF报告",
@@ -2232,73 +2189,116 @@
           "label": "每周销售KPI发送到Slack",
           "prompt": "创建一个每周定时的flow，使用DuckDB计算销售KPI，并将摘要发布到Slack。"
         }
-      },
-      "help": {
-        "blueprints": {
-          "description": "探索可直接使用的示例和模板，以适应常见的工作流模式。",
-          "title": "蓝图"
-        },
-        "slack": {
-          "description": "加入我们，分享想法和最佳实践，并获得技术问题的帮助。",
-          "title": "Slack 社区"
-        },
-        "tutorial": {
-          "description": "了解如何通过指南步骤创建并运行您的第一个flow。",
-          "title": "开始教程"
-        }
-      },
-      "need_help": "需要帮助？",
-      "placeholder_prompt": "每天早上9点发送问候消息给我。",
-      "remaining_quota": "您还有 {count} 次AI生成机会。限制将在每天的UTC午夜重置。",
-      "show_less": "显示更少提示",
-      "show_more": "显示更多提示",
-      "success_page": {
-        "description": "您已经了解了Kestra的基础知识。以下是一些资源，帮助您继续您的旅程。",
-        "items": {
-          "blueprints": {
-            "description": "预构建工作流模板用于常见用例",
-            "title": "蓝图"
-          },
-          "demo": {
-            "description": "通过个性化演示探索 Kestra Enterprise Edition",
-            "title": "获取演示"
-          },
-          "slack": {
-            "description": "与其他用户联系并从社区获得帮助",
-            "title": "Slack 社区"
-          },
-          "tutorial": {
-            "description": "Kestra所有功能的互动演练",
-            "title": "开始教程"
-          },
-          "videos": {
-            "description": "高级功能的逐步视频指南",
-            "title": "视频教程"
-          }
-        },
-        "restart": "重新启动教程",
-        "title": "一切准备就绪！"
-      },
-      "success_popup": {
-        "description": "您已成功执行了您的第一个flow！您正在迈向成为Kestra专家的道路上。",
-        "explore": "探索更多",
-        "title": "恭喜！",
-        "tutorial": "深入教程"
-      },
-      "title": "将您的想法转化为workflow"
+      }
     },
-    "welcome_page": {
-      "guide": "需要指导来执行您的第一个flow吗？",
-      "welcome": "欢迎使用 Kestra"
+    "mcp": {
+      "your_servers": "您的服务器",
+      "servers_count": "{count} MCP 服务器",
+      "managed_by_kestra": "由 Kestra 管理",
+      "servers": "MCP 服务器",
+      "server": "MCP 服务器",
+      "client_setup": "客户端设置",
+      "page_description": "将您的Kestra flow公开为MCP兼容AI代理的工具",
+      "create": "创建服务器",
+      "save": "保存更改",
+      "connect": "连接",
+      "copy_url": "复制 URL",
+      "url_copied": "URL 已复制！",
+      "instructions": "说明",
+      "server_type": "服务器类型",
+      "auth_type": "身份验证",
+      "private": "私有",
+      "private_server": "私有服务器",
+      "public": "公开",
+      "public_hint": "警告：公共服务器无需身份验证。任何拥有此 URL 的人都可以调用此服务器公开的所有工具，无需 namespace 或权限检查。仅用于可以安全地对外公开的服务器。",
+      "basic_auth": "基本认证",
+      "api_token": "API Token",
+      "oauth": "OAuth",
+      "username_password": "用户名和密码",
+      "bearer_token": "Bearer token 身份验证",
+      "oauth_hint": "来自您的 OIDC 提供商的 Bearer JWT",
+      "oauth_provider": "OAuth 提供商",
+      "oauth_provider_placeholder": "选择已配置的 OIDC 提供商",
+      "oauth_provider_required": "当认证类型为 OAuth 时，OAuth 提供商为必填项",
+      "scopes_supported": "支持的 scope",
+      "scopes_supported_placeholder": "openid, profile, email",
+      "scopes_supported_hint": "此服务器 Protected Resource Metadata 文档中公告的 scope。符合规范的 MCP 客户端将其授权请求限制为此列表。留空以省略该字段，让客户端回退到 IdP 公告的 scope。",
+      "no_oauth_providers": "此实例中未配置 OIDC 提供商",
+      "delete_confirm": "您确定要删除此MCP服务器吗？",
+      "no_servers": "未找到MCP服务器。创建您的第一个服务器以向外部AI代理公开MCP Tool triggers。",
+      "server_id": "服务器 ID",
+      "id_placeholder": "例如 my-mcp-server",
+      "id_invalid": "ID必须以小写字母或数字开头，并且只能包含小写字母、数字、连字符或下划线。",
+      "main_tenant": "main",
+      "tab_edit": "编辑",
+      "tab_connect": "连接",
+      "tab_tool_flows": "工具Flows",
+      "tab_tool_flows_placeholder": "工具flow管理即将推出。",
+      "tools": {
+        "no_tools": "没有符合您搜索的工具flow。",
+        "create_tool_flow": "创建工具flow",
+        "tool_name": "工具名称",
+        "trigger_id": "Trigger ID",
+        "title": "标题",
+        "description": "描述",
+        "annotations": "注释",
+        "flow": "flow",
+        "state": "状态",
+        "read_only": "只读",
+        "open_world": "Open world",
+        "destructive": "破坏性",
+        "idempotent": "幂等",
+        "return_direct": "直接返回",
+        "view_flow": "打开 flow"
+      },
+      "connect_tab": {
+        "server_url": "服务器 URL",
+        "client_picker_label": "选择您的 AI 客户端",
+        "claude_desktop": "Claude 桌面版",
+        "claude_desktop_hint": "请将以下内容添加到您的 claude_desktop_config.json 文件中：",
+        "claude_desktop_mac": "macOS: ~/Library/Application Support/Claude/claude_desktop_config.json",
+        "claude_desktop_win": "Windows: %APPDATA%\\Claude\\claude_desktop_config.json",
+        "claude_code": "Claude代码",
+        "claude_code_hint": "在终端中运行以下命令：",
+        "cursor": "光标",
+        "cursor_hint": "将以下内容添加到 ~/.cursor/mcp.json：",
+        "codex": "Codex (OpenAI)",
+        "codex_hint": "将以下内容添加到您的codex.json MCP配置中：",
+        "auth_basic_hint": "在启动客户端之前，将 <code>KESTRA_BASIC_AUTH</code> 设置为包含 base64 编码的 <code>username:password</code> 字符串的环境变量。",
+        "auth_api_token_hint": "在启动客户端之前，将 <code>KESTRA_TOKEN</code> 设置为环境变量。",
+        "auth_oauth_client_id_hint": "将 <code>&lt;client-id&gt;</code> 替换为 OAuth 客户端 ID，并在该客户端上将 <code>http://localhost:7777</code> 注册为有效的重定向 URI。",
+        "auth_oauth_browser_hint": "首次连接时，您的浏览器将打开身份提供商的登录页面。"
+      }
     },
-    "wordmark_colors": "字标的颜色会根据背景进行调整，而图标在深色背景上时则保持无背景。",
-    "worker group": "工作组",
-    "worker group fallback": "工作组回退",
-    "worker group key": "工作组 key",
-    "worker information": "工作者信息",
-    "workerId": "工作者ID",
-    "workers": "工作者",
-    "wrong labels": "标签中不允许空键或值",
-    "yes": "是"
+    "flow_editor_stats": {
+      "revisions": {
+        "suffix": "版本",
+        "tooltip": "查看flow修订版本"
+      },
+      "dependencies": {
+        "suffix": "依赖项",
+        "tooltip": "查看flow依赖关系"
+      },
+      "apps": {
+        "suffix": "应用程序",
+        "tooltip": "查看使用此flow的应用程序"
+      },
+      "tests": {
+        "suffix": "测试",
+        "tooltip": "查看flow测试"
+      },
+      "errors": {
+        "label": "{count} 错误"
+      }
+    },
+    "source_search": {
+      "match_count": "{count} 个匹配 | {count} 个匹配",
+      "open_flow": "打开 flow",
+      "preview_empty": "选择一个结果进行预览。点击结果列表中的 flow 查看其源码。",
+      "preview_error": "加载 flow 源码失败"
+    },
+    "open source": "开源",
+    "pricing": "定价",
+    "license": "许可证"
   }
 }


### PR DESCRIPTION
Generates and stores UI translation files in en.json key order (instead of alphabetically) so regeneration no longer opens reorder-only PRs.