### PR TITLE
fix(tasks): don't validate Content-Length for content-encoded HTTP downloads

### DIFF
--- a/core/src/main/java/io/kestra/plugin/core/http/Download.java
+++ b/core/src/main/java/io/kestra/plugin/core/http/Download.java
@@ -98,7 +98,14 @@ public class Download extends AbstractHttp implements RunnableTask<Download.Outp
                         size.set(0L);
                     }
 
-                    if (r.getBody() != null) {
+                    // Content-Length describes the size of the transferred (encoded) body, while `size` counts the
+                    // bytes actually written after any content-coding has been transparently decoded (e.g. gzip).
+                    // The two only match for identity encoding, so skip the check when the response is content-encoded.
+                    boolean contentEncoded = r.getHeaders().firstValue("Content-Encoding")
+                        .map(encoding -> !encoding.isBlank() && !"identity".equalsIgnoreCase(encoding))
+                        .orElse(false);
+
+                    if (r.getBody() != null && !contentEncoded) {
                         r.getHeaders().firstValue("Content-Length").ifPresent(header ->
                         {
                             long length = Long.parseLong(header);

--- a/core/src/test/java/io/kestra/plugin/core/http/DownloadTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/http/DownloadTest.java
@@ -1,8 +1,10 @@
 package io.kestra.plugin.core.http;
 
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
+import java.util.zip.GZIPOutputStream;
 
 import org.apache.commons.io.IOUtils;
 import org.junit.jupiter.api.Test;
@@ -36,6 +38,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 @KestraTest
 class DownloadTest {
     private static final String CSV_CONTENT = "id,name,value\n1,foo,100\n2,bar,200\n3,baz,300\n";
+    private static final String GZIP_CONTENT = "the quick brown fox jumps over the lazy dog\n".repeat(64);
 
     @Inject
     private TestRunContextFactory runContextFactory;
@@ -145,6 +148,27 @@ class DownloadTest {
         Download.Output output = task.run(runContext);
 
         assertThat(this.storageInterface.get(MAIN_TENANT, null, output.getUri()).readAllBytes().length).isEqualTo(10000 * 12);
+    }
+
+    @Test
+    void gzip() throws Exception {
+        EmbeddedServer embeddedServer = applicationContext.getBean(EmbeddedServer.class);
+        embeddedServer.start();
+
+        Download task = Download.builder()
+            .id(DownloadTest.class.getSimpleName())
+            .type(DownloadTest.class.getName())
+            .uri(Property.ofValue(embeddedServer.getURI() + "/gzip"))
+            .build();
+
+        RunContext runContext = TestsUtils.mockRunContext(this.runContextFactory, task, ImmutableMap.of());
+
+        // A gzip-encoded response advertises a Content-Length equal to the compressed size, which differs from the
+        // decoded bytes written to storage. The task must not fail with "Invalid size" and must store the full content.
+        Download.Output output = assertDoesNotThrow(() -> task.run(runContext));
+
+        assertThat(IOUtils.toString(this.storageInterface.get(MAIN_TENANT, null, output.getUri()), StandardCharsets.UTF_8))
+            .isEqualTo(GZIP_CONTENT);
     }
 
     @Test
@@ -283,6 +307,20 @@ class DownloadTest {
         public HttpResponse<byte[]> csv() {
             return HttpResponse.ok(CSV_CONTENT.getBytes(StandardCharsets.UTF_8))
                 .contentType(io.micronaut.http.MediaType.TEXT_CSV_TYPE);
+        }
+
+        @Get("gzip")
+        public HttpResponse<byte[]> gzip() throws IOException {
+            ByteArrayOutputStream compressed = new ByteArrayOutputStream();
+            try (GZIPOutputStream gzipStream = new GZIPOutputStream(compressed)) {
+                gzipStream.write(GZIP_CONTENT.getBytes(StandardCharsets.UTF_8));
+            }
+
+            // Return already-compressed bytes with an explicit Content-Encoding so the framework does not re-encode;
+            // the byte[] body makes the server emit a Content-Length equal to the compressed size.
+            return HttpResponse.ok(compressed.toByteArray())
+                .header(HttpHeaders.CONTENT_ENCODING, "gzip")
+                .contentType(io.micronaut.http.MediaType.TEXT_PLAIN_TYPE);
         }
 
         @Get("500")


### PR DESCRIPTION
## What

The `Download` HTTP task fails with `IllegalStateException: Invalid size` whenever the server returns a **content-encoded** (e.g. `Content-Encoding: gzip`) response.

## Root cause

`Download.run()` compares the number of bytes written to storage against the response's `Content-Length` header. For a gzip response, `Content-Length` is the **compressed** transfer size, while the Apache HTTP client transparently **decompresses** the body — so the bytes written are the **decoded** size. The two never match, so the task throws.

Per [RFC 9110 §8.6](https://www.rfc-editor.org/rfc/rfc9110#section-8.6), `Content-Length` describes the encoded message body, so the check is only meaningful for identity encoding.

## How this was found

It surfaced as a **consistent** (non-flaky) failure of `core > io.kestra.core.tasks.test.SanityCheckTest > qaNamespaceFiles`. Its first task downloads a file from `raw.githubusercontent.com`, which is now served gzip-encoded:

```
Invalid size, got 383, expected 245   # decoded 383 bytes vs compressed Content-Length 245
```

→ `download` task FAILED → execution never reached SUCCESS → `hasSize(8)` assertion failed. Reproduced locally on the first run (deterministic, not a timeout).

## Fix

Skip the `Content-Length` size check when a non-identity `Content-Encoding` header is present.

## Tests

Adds `DownloadTest.gzip`, an embedded-server regression test that serves a gzip-encoded body (compressed Content-Length ≠ decoded size). Verified it **fails without** this change (`Invalid size, got 2816, expected 83`) and **passes with** it.

- `SanityCheckTest.qaNamespaceFiles` → green
- `DownloadTest` → 13/13 passing