### PR TITLE
fix(apps): make typed buttons visible on light theme

### DIFF
--- a/ui/src/styles/layout/element-plus-overload.scss
+++ b/ui/src/styles/layout/element-plus-overload.scss
@@ -9,7 +9,12 @@
 // button
 .el-button {
 
-    &:not(.el-button--primary):not(.el-button--success):not(.el-button--warning):not(.el-button--danger):not(.el-button--error):not(.el-button--info):not(.el-button--playground), &--default {
+    // NB: match only by the *absence* of a type modifier — do NOT add `&--default` here.
+    // Element Plus reuses `.el-button--default` for the default *size* too, so a typed button
+    // (e.g. `el-button--danger`) rendered at default size also carries `.el-button--default`.
+    // Matching `&--default` would then clobber its background to the secondary colour while the
+    // type keeps its own (white) text, producing invisible text — see Apps' Cancel button.
+    &:not(.el-button--primary):not(.el-button--success):not(.el-button--warning):not(.el-button--danger):not(.el-button--error):not(.el-button--info):not(.el-button--playground) {
         --el-button-hover-text-color: var(--ks-content-primary);
         --el-button-hover-border-color: var(--ks-border-primary);
         --el-button-bg-color: var(--ks-button-background-secondary);


### PR DESCRIPTION
## What

Typed Apps buttons (e.g. the **Cancel Execution** danger button) rendered their label **invisible on the light theme** — white text on a white background with only a coloured border, readable only on hover.

| Before (light theme) | After |
|---|---|
| white text on white bg, red border → invisible | text visible on the button's own colour |

## Why

Element Plus reuses the `.el-button--default` class for the default **size** as well as the default **type**. The Apps buttons always pass a size, so a danger button ends up with `el-button--danger el-button--default`.

The secondary-button rule in `ui/src/styles/layout/element-plus-overload.scss` matched `&--default`, so that typed-but-default-size button had its **background overridden to the secondary (white) colour** while the Element Plus `danger` variant kept its **white text** → invisible label; hover then set `--ks-content-primary`, which is why it only showed when highlighted.

## Fix

Drop `&--default` from the selector. Default-**type** buttons are already covered by the `:not(...)` type chain, so this removes no intended styling — it only stops typed buttons (danger/warning/error/info) at default size from getting the secondary-background clobber, letting them render with their own colours.

## Verification

Compiled the actual v1.3.x style pipeline (`element-plus-overload.scss` + `root.scss` + ui-libs `0.0.303` tokens + Element Plus) and rendered the exact markup:

- **Before:** Cancel button computed `text=#fff, bg=#fff, border=#f56c6c` — reproduced the reported bug.
- **After:** Cancel → visible on solid red; success/primary/warning unchanged; **default-type and no-type buttons still render as secondary** (dark on white) — no regression.

Note: on `develop` this class of bug does not occur because the Apps buttons were migrated to the design-system `<KsButton>`.

Closes https://github.com/kestra-io/kestra-ee/issues/9146.