### PR TITLE
fix(system): stabilise kestra-base image — pin Ubuntu 24.04 + UID/GID 1000

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -4,8 +4,13 @@ FROM eclipse-temurin:${JRE_VERSION}-jre
 ARG UV_VERSION="0.6.17"
 ARG WITH_PYTHON="false"
 
-RUN groupadd kestra && \
-    useradd -m -g kestra kestra
+# Ubuntu 24.04+ bases (eclipse-temurin:*-jre) ship a default `ubuntu` user on
+# UID/GID 1000, which would push our `useradd` to 1001. Pin kestra to 1000 so
+# deployments that assume it (Helm rootless DinD socket group, fsGroup, existing
+# PVC ownership) keep working.
+RUN userdel -r ubuntu 2>/dev/null || true; \
+    groupadd -g 1000 kestra && \
+    useradd -u 1000 -g 1000 -m kestra
 
 WORKDIR /app
 


### PR DESCRIPTION
## What

Pins the `kestra` user/group in `Dockerfile.base` back to **UID/GID 1000**.

## Root cause

`kestra-base` is built `FROM eclipse-temurin:${JRE_VERSION}-jre` — the **unsuffixed** tag, which floats to the latest Ubuntu LTS. The runtime image on 1.3.23 used the pinned `eclipse-temurin:25-jre-jammy` (Ubuntu 22.04). Between those two Ubuntu releases, the base started shipping a baked-in `ubuntu` user squatting on **UID/GID 1000**, so the *unchanged* `useradd kestra` now lands on **1001**:

| FROM tag | Ubuntu | Default user | `useradd kestra` → |
|---|---|---|---|
| `eclipse-temurin:25-jre-jammy` (1.3.23) | 22.04 | none | **1000** |
| `eclipse-temurin:25-jre` (current base) | 26.04 | `ubuntu` at 1000 | **1001** |

The migration to `kestra-base` was only the *vehicle* — `Dockerfile.base` was created with the unsuffixed tag, so it inherited the OS bump. Verified by building the **old** local-`useradd` Dockerfile (identical to 1.3.23) but on `eclipse-temurin:25-jre`: it also produces UID 1001. So dropping `-jammy` alone reproduces the regression; `kestra-base` is incidental.

It is **not** a docker-java/httpclient5 change — `docker-java` (3.6.0) and `httpclient5` (5.5.1) are byte-identical across the affected tags. The only difference is the base-image UID.

## Impact

A silent breaking change for anything that assumes the worker runs as 1000. Most visibly, the Helm chart's **rootless DinD sidecar** creates the docker socket group-owned by GID 1000 (`--group=1000`, `runAsGroup: 1000` in `charts/kestra/values.yaml`). A worker at GID 1001 loses access to the socket and the first `docker-java` call fails with:

```
java.net.BindException: Permission denied
  at com.github.dockerjava.core.exec.ListContainersCmdExec.execute(...)
  at io.kestra.plugin.scripts.runner.docker.Docker.run(Docker.java:404)
```

…before any container is created. It also silently mismatches `fsGroup: 1000` in the starter chart and file ownership on existing persistent volumes.

## Fix

Free UID/GID 1000 (the default `ubuntu` user) and recreate `kestra` pinned to 1000, so the UID is stable regardless of which Ubuntu the base floats to:

```dockerfile
RUN userdel -r ubuntu 2>/dev/null || true; \
    groupadd -g 1000 kestra && \
    useradd -u 1000 -g 1000 -m kestra
```

`userdel` is guarded so it's a no-op on bases without an `ubuntu` user; if a future base squats 1000 under a different name, `groupadd -g 1000` fails the build **loudly** rather than silently regressing to 1001.

## Scope

`Dockerfile.base` lives only on `develop` and publishes the shared moving tags `ghcr.io/kestra-io/kestra-base:latest-*` (rebuilt nightly by `global-push-base-image.yml`). Both `develop` and the release lines (`v1.0.x`–`v1.3.x`) consume those tags via `FROM …kestra-base:latest…`, so **this single change fixes every affected branch** on the next base-image rebuild + patch release — no per-branch Dockerfile backport needed.

## Validation

Built `Dockerfile.base` locally before/after (Ubuntu 26.04 base):
- before → `uid=1001(kestra) gid=1001(kestra)`, `ubuntu:x:1000:1000` present
- after  → `uid=1000(kestra) gid=1000(kestra) groups=1000(kestra)`

## Alternative considered

Bumping the Helm chart's rootless DinD to `--group=1001` / `runAsGroup: 1001` would fix the reported symptom but leave the other 1000-assumptions (`fsGroup: 1000`, existing PVC ownership) mismatched and would break users still on the UID-1000 base. Fixing at the source restores the long-standing contract with the smallest blast radius. A rename approach (`usermod -l kestra ubuntu`) was rejected because `kestra` would inherit `ubuntu`'s supplementary groups, including `sudo`.

Fixes https://github.com/kestra-io/kestra-ee/issues/9184