### PR TITLE
fix(plugins): disambiguate assertThat(HttpStatus) in PluginControllerTest

### DIFF
--- a/webserver/src/test/java/io/kestra/webserver/controllers/api/PluginControllerTest.java
+++ b/webserver/src/test/java/io/kestra/webserver/controllers/api/PluginControllerTest.java
@@ -132,7 +132,7 @@ class PluginControllerTest {
             PluginController.PluginIconResponse.class
         );
 
-        assertThat(response.getStatus()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getStatus().getCode()).isEqualTo(HttpStatus.OK.getCode());
         assertThat(response.body().icon()).isNull();
     }
 


### PR DESCRIPTION
## What
`develop` currently fails to build: `:webserver:compileTestJava` errors with a single ambiguous-`assertThat` compile error, which means the whole webserver test suite never runs and no test report is produced.

```
PluginControllerTest.java:135: error: reference to assertThat is ambiguous
  both method <T>assertThat(T) in Assertions and method assertThat(CharSequence) in Assertions match
1 error
> Task :webserver:compileTestJava FAILED
```

## Why
`assertThat(response.getStatus())` where `getStatus()` returns `io.micronaut.http.HttpStatus` is ambiguous under the current AssertJ + Micronaut versions (the `<T extends Comparable>assertThat(T)` and `assertThat(CharSequence)` overloads both match). This was introduced by #17219 (`iconByClassNotFound`), which compiled when written but became ambiguous once combined with the current dependency set on develop — so it only surfaced after both landed.

## Fix
Assert on the status **code**, matching the convention already used throughout this same test class (e.g. line 489, and `assertThatObject(...)` elsewhere):

```java
assertThat(response.getStatus().getCode()).isEqualTo(HttpStatus.OK.getCode());
```

This is the only compile error in the module, so it unblocks `:webserver:compileTestJava` → `:webserver:test` → the test report.