### PR TITLE
fix(system): pin kestra-base to Ubuntu 24.04 (noble) to fix base-image CI

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -1,5 +1,10 @@
 ARG JRE_VERSION="25"
-FROM eclipse-temurin:${JRE_VERSION}-jre
+# Pin the Ubuntu release explicitly. The unsuffixed `-jre` tag floats to the
+# latest Ubuntu, which silently drifted to 26.04 (Python 3.14) and broke the
+# build: `amazon-ion` (a `kestra` pip dep) has no cp314 wheel, so pip falls back
+# to a source build that needs cmake/gcc. 24.04 LTS ships Python 3.12, for which
+# a wheel exists. Pinning also keeps the base OS (and its UID layout) stable.
+FROM eclipse-temurin:${JRE_VERSION}-jre-noble
 
 ARG UV_VERSION="0.6.17"
 ARG WITH_PYTHON="false"


### PR DESCRIPTION
## What

Pins `Dockerfile.base` to `eclipse-temurin:${JRE_VERSION}-jre-noble` (Ubuntu 24.04 LTS) instead of the unsuffixed, floating `-jre` tag.

## Why — the daily base-image publish has been red since 2026-07-03

[`global-push-base-image.yml`](https://github.com/kestra-io/kestra/actions/workflows/global-push-base-image.yml) fails on the `WITH_PYTHON=true` variants (`latest`, `latest-jre21`). The final step `uv pip install kestra` can't build `amazon-ion`:

```
× Failed to build `amazon-ion==0.14.6`
CMake Error: CMAKE_C_COMPILER not set / unable to find a build program
```

**Root cause:** the unsuffixed `eclipse-temurin:${JRE_VERSION}-jre` tag floats to the latest Ubuntu and silently drifted to **26.04**, which ships **Python 3.14**. `amazon-ion` (a `kestra` pip dependency) publishes wheels only up to **cp313** — no cp314 — so pip falls back to the source sdist, whose `py_build_cmake` backend needs cmake + a C/C++ compiler that the base image doesn't carry. Nothing in the repo changed on 2026-07-03; the base OS moved under us.

This is the **same floating-tag drift** that caused the UID 1000→1001 regression fixed in #17236 / kestra-io/kestra-ee#9184.

**Impact — it blocks that UID fix too.** The matrix runs with the default `fail-fast: true`, so when the `WITH_PYTHON` job fails (~10s in) the still-running multi-arch `-no-plugins` builds are **cancelled before they push**. No base variant — including `latest-no-plugins`, which every runtime image and the UID fix depend on — has published since 2026-07-02.

## Fix

Pin to 24.04 LTS → **Python 3.12**, for which a prebuilt `amazon-ion` wheel exists. Pinning also stops the base OS (and its UID layout) from drifting again unnoticed.

## Validation

Built `Dockerfile.base` with `--build-arg WITH_PYTHON=true` on the noble pin:
- `+ amazon-ion==0.14.6` … `Installed 11 packages in 30ms` — from a **wheel**, no cmake
- `python3 --version` → `Python 3.12.3`
- `import amazon.ion` → OK
- `id kestra` → `uid=1000(kestra) gid=1000(kestra)` (the #17236 UID pin still holds on noble)

## Notes

- Complements #17236 (UID pin). Together they make the base image deterministic; that PR handles the UID, this one handles the OS/Python drift that broke publishing.
- I did **not** touch the matrix `fail-fast` (left as-is per request). Worth a follow-up: adding `fail-fast: false` would stop a future `WITH_PYTHON` break from blocking the `-no-plugins` base that runtime images depend on.