### PR TITLE
feat(execution): support dynamic label values in triggers

### DIFF
--- a/core/src/main/java/io/kestra/core/models/triggers/AbstractTrigger.java
+++ b/core/src/main/java/io/kestra/core/models/triggers/AbstractTrigger.java
@@ -69,11 +69,12 @@ abstract public class AbstractTrigger implements TriggerInterface {
 
     @Schema(
         title = "The labels to pass to the execution created.",
+        description = "Label values are dynamic and can reference trigger variables.",
         implementation = Object.class, oneOf = { List.class, Map.class }
     )
     @JsonSerialize(using = ListOrMapOfLabelSerializer.class)
     @JsonDeserialize(using = ListOrMapOfLabelDeserializer.class)
-    @PluginProperty(hidden = true, group = "advanced")
+    @PluginProperty(hidden = true, group = "advanced", dynamic = true)
     private List<@NoSystemLabelValidation Label> labels;
 
     @PluginProperty(group = "reliability")

--- a/core/src/main/java/io/kestra/core/models/triggers/TriggerService.java
+++ b/core/src/main/java/io/kestra/core/models/triggers/TriggerService.java
@@ -59,7 +59,7 @@ public abstract class TriggerService {
         AbstractTrigger trigger,
         ExecutionTrigger executionTrigger,
         ConditionContext conditionContext) {
-        List<Label> labels = buildLabels(id, trigger, conditionContext);
+        List<Label> labels = buildLabels(id, trigger, conditionContext, executionTrigger.getVariables());
 
         return new TriggerEvaluationResult(
             id,
@@ -123,7 +123,7 @@ public abstract class TriggerService {
         TriggerContext context,
         ExecutionTrigger executionTrigger,
         ConditionContext conditionContext) {
-        List<Label> executionLabels = buildLabels(id, trigger, conditionContext);
+        List<Label> executionLabels = buildLabels(id, trigger, conditionContext, executionTrigger.getVariables());
         return Execution.builder()
             .id(id)
             .namespace(context.getNamespace())
@@ -137,8 +137,8 @@ public abstract class TriggerService {
             .build();
     }
 
-    private static List<Label> buildLabels(String id, AbstractTrigger trigger, ConditionContext conditionContext) {
-        List<Label> labels = new ArrayList<>(ListUtils.emptyOnNull(trigger.getLabels()));
+    private static List<Label> buildLabels(String id, AbstractTrigger trigger, ConditionContext conditionContext, Map<String, Object> variables) {
+        List<Label> labels = LabelService.fromTrigger(conditionContext.getRunContext(), conditionContext.getFlow(), trigger, Map.of("trigger", variables));
         labels.add(new Label(Label.FROM, "trigger"));
         if (labels.stream().noneMatch(label -> Label.CORRELATION_ID.equals(label.key()))) {
             labels.add(new Label(Label.CORRELATION_ID, id));

--- a/core/src/main/java/io/kestra/core/services/LabelService.java
+++ b/core/src/main/java/io/kestra/core/services/LabelService.java
@@ -33,14 +33,14 @@ public final class LabelService {
      * Trigger labels will be rendered via the run context but not flow labels.
      * In case rendering is not possible, the label will be omitted.
      */
-    public static List<Label> fromTrigger(RunContext runContext, FlowInterface flow, AbstractTrigger trigger) {
+    public static List<Label> fromTrigger(RunContext runContext, FlowInterface flow, AbstractTrigger trigger, Map<String, Object> variables) {
 
         final List<Label> labels = new ArrayList<>(labelsExcludingSystem(flow.getLabels())); // no need for rendering
 
         // It is better to remove system labels before rendering
         List<Label> triggerLabels = labelsExcludingSystem(trigger.getLabels());
         for (Label label : triggerLabels) {
-            final var value = renderLabelValue(runContext, label);
+            final var value = renderLabelValue(runContext, label, variables);
             if (value != null) {
                 labels.add(new Label(label.key(), value));
             }
@@ -49,9 +49,9 @@ public final class LabelService {
         return labels;
     }
 
-    private static String renderLabelValue(RunContext runContext, Label label) {
+    private static String renderLabelValue(RunContext runContext, Label label, Map<String, Object> variables) {
         try {
-            String value = runContext.render(label.value());
+            String value = runContext.render(label.value(), variables);
             return (value != null && !value.isEmpty()) ? value : null;
         } catch (IllegalVariableEvaluationException e) {
             runContext.logger().warn("Failed to render label '{}', it will be omitted", label.key(), e);

--- a/core/src/main/java/io/kestra/plugin/core/trigger/Flow.java
+++ b/core/src/main/java/io/kestra/plugin/core/trigger/Flow.java
@@ -307,7 +307,24 @@ public class Flow extends AbstractTrigger implements TriggerOutput<Flow.Output> 
             outputs = MapUtils.deepMerge(outputs, multipleConditionWindow.get().getOutputs());
         }
 
-        List<Label> labels = LabelService.fromTrigger(runContext, flow, this);
+        var executionTrigger = ExecutionTrigger.of(
+            this,
+            Output.builder()
+                .executionId(current.getId())
+                .executionLabels(Label.toNestedMap(current.getLabels().stream().filter(label -> !label.key().equals(Label.CORRELATION_ID)).collect(Collectors.toList())))
+                .namespace(current.getNamespace())
+                .flowId(current.getFlowId())
+                .flowRevision(current.getFlowRevision())
+                .state(current.getState().getCurrent())
+                .startDate(current.getState().getStartDate())
+                .endDate(current.getState().getEndDate().orElse(null))
+                .firstFailedTaskId(ListUtils.emptyOnNull(current.getTaskRunList()).stream().filter(t -> t.getState().getCurrent().isFailed()).map(TaskRun::getTaskId).findFirst().orElse(null))
+                .lastTaskId(ListUtils.emptyOnNull(current.getTaskRunList()).reversed().stream().map(TaskRun::getTaskId).findFirst().orElse(null))
+                .outputs(outputs)
+                .build()
+        );
+
+        List<Label> labels = LabelService.fromTrigger(runContext, flow, this, Map.of("trigger", executionTrigger.getVariables()));
         Streams.of(current.getLabels())
             .filter(label -> label.key().equals(Label.CORRELATION_ID))
             .findFirst()
@@ -321,24 +338,7 @@ public class Flow extends AbstractTrigger implements TriggerOutput<Flow.Output> 
             .flowRevision(flow.getRevision())
             .labels(labels)
             .state(new State())
-            .trigger(
-                ExecutionTrigger.of(
-                    this,
-                    Output.builder()
-                        .executionId(current.getId())
-                        .executionLabels(Label.toNestedMap(current.getLabels().stream().filter(label -> !label.key().equals(Label.CORRELATION_ID)).collect(Collectors.toList())))
-                        .namespace(current.getNamespace())
-                        .flowId(current.getFlowId())
-                        .flowRevision(current.getFlowRevision())
-                        .state(current.getState().getCurrent())
-                        .startDate(current.getState().getStartDate())
-                        .endDate(current.getState().getEndDate().orElse(null))
-                        .firstFailedTaskId(ListUtils.emptyOnNull(current.getTaskRunList()).stream().filter(t -> t.getState().getCurrent().isFailed()).map(TaskRun::getTaskId).findFirst().orElse(null))
-                        .lastTaskId(ListUtils.emptyOnNull(current.getTaskRunList()).reversed().stream().map(TaskRun::getTaskId).findFirst().orElse(null))
-                        .outputs(outputs)
-                        .build()
-                )
-            );
+            .trigger(executionTrigger);
 
         try {
             if (this.inputs != null) {

--- a/core/src/main/java/io/kestra/plugin/core/trigger/SchedulableExecutionFactory.java
+++ b/core/src/main/java/io/kestra/plugin/core/trigger/SchedulableExecutionFactory.java
@@ -34,7 +34,7 @@ final class SchedulableExecutionFactory {
         RunContext runContext = conditionContext.getRunContext();
         ExecutionTrigger executionTrigger = ExecutionTrigger.of((AbstractTrigger) trigger, variables);
 
-        List<Label> labels = getLabels(trigger, runContext, triggerContext.getBackfill(), conditionContext.getFlow());
+        List<Label> labels = getLabels(trigger, runContext, triggerContext.getBackfill(), conditionContext.getFlow(), variables);
 
         List<Label> executionLabels = new ArrayList<>(ListUtils.emptyOnNull(labels));
         executionLabels.add(new Label(Label.FROM, "trigger"));
@@ -87,8 +87,8 @@ final class SchedulableExecutionFactory {
         return inputs;
     }
 
-    private static List<Label> getLabels(Schedulable trigger, RunContext runContext, Backfill backfill, FlowInterface flow) throws IllegalVariableEvaluationException {
-        List<Label> labels = LabelService.fromTrigger(runContext, flow, (AbstractTrigger) trigger);
+    private static List<Label> getLabels(Schedulable trigger, RunContext runContext, Backfill backfill, FlowInterface flow, Map<String, Object> variables) throws IllegalVariableEvaluationException {
+        List<Label> labels = LabelService.fromTrigger(runContext, flow, (AbstractTrigger) trigger, Map.of("trigger", variables));
 
         if (backfill != null) {
             // It is better to remove system labels before rendering

--- a/core/src/test/java/io/kestra/core/services/LabelServiceTest.java
+++ b/core/src/test/java/io/kestra/core/services/LabelServiceTest.java
@@ -51,7 +51,7 @@ class LabelServiceTest {
             .labels(List.of(new Label("scheduleLabel", "scheduleValue"), new Label("variable", "{{variable}}")))
             .build();
 
-        List<Label> labels = LabelService.fromTrigger(runContext, flow, trigger);
+        List<Label> labels = LabelService.fromTrigger(runContext, flow, trigger, Collections.emptyMap());
 
         assertThat(labels).hasSize(3);
         assertThat(labels).contains(new Label("key", "value"), new Label("scheduleLabel", "scheduleValue"), new Label("variable", "variableValue"));
@@ -67,10 +67,26 @@ class LabelServiceTest {
             .labels(List.of(new Label("scheduleLabel", "scheduleValue"), new Label("variable", "{{variable}}")))
             .build();
 
-        List<Label> labels = LabelService.fromTrigger(runContext, flow, trigger);
+        List<Label> labels = LabelService.fromTrigger(runContext, flow, trigger, Collections.emptyMap());
 
         assertThat(labels).hasSize(2);
         assertThat(labels).contains(new Label("key", "value"), new Label("scheduleLabel", "scheduleValue"));
+    }
+
+    @Test
+    void shouldRenderLabelValueUsingProvidedVariables() {
+        RunContext runContext = runContextFactory.of();
+        Flow flow = Flow.builder()
+            .labels(List.of(new Label("key", "value")))
+            .build();
+        AbstractTrigger trigger = Schedule.builder()
+            .labels(List.of(new Label("dynamicLabel", "{{ trigger.executionId }}")))
+            .build();
+
+        List<Label> labels = LabelService.fromTrigger(runContext, flow, trigger, Map.of("trigger", Map.of("executionId", "exec-123")));
+
+        assertThat(labels).hasSize(2);
+        assertThat(labels).contains(new Label("key", "value"), new Label("dynamicLabel", "exec-123"));
     }
 
     @Test

--- a/core/src/test/java/io/kestra/plugin/core/trigger/FlowTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/trigger/FlowTest.java
@@ -200,4 +200,100 @@ class FlowTest {
         assertThat(evaluate.get().getTrigger()).extracting(ExecutionTrigger::getVariables).hasFieldOrProperty("executionLabels");
         assertThat(evaluate.get().getTrigger().getVariables().get("executionLabels")).isEqualTo(Map.of("execution-label", "execution"));
     }
+
+    @Test
+    void success_withDynamicLabels() {
+        var flow = io.kestra.core.models.flows.Flow.builder()
+            .id("flow-with-flow-trigger")
+            .namespace("io.kestra.unittest")
+            .revision(1)
+            .tasks(
+                Collections.singletonList(
+                    Return.builder()
+                        .id("test")
+                        .type(Return.class.getName())
+                        .format(Property.ofValue("test"))
+                        .build()
+                )
+            )
+            .build();
+        var triggeringExecution = Execution.builder()
+            .id(IdUtils.create())
+            .namespace("io.kestra.unittest.upstream")
+            .flowId("upstream-flow")
+            .flowRevision(1)
+            .state(new State().withState(State.Type.RUNNING))
+            .build();
+        var flowTrigger = Flow.builder()
+            .id("flow")
+            .type(Flow.class.getName())
+            .labels(
+                List.of(
+                    new Label("triggering-execution-id", "{{ trigger.executionId }}"),
+                    new Label("triggering-namespace", "{{ trigger.namespace }}"),
+                    new Label("triggering-flow-id", "{{ trigger.flowId }}")
+                )
+            )
+            .build();
+
+        Optional<Execution> evaluate = flowTrigger.evaluate(
+            Optional.empty(),
+            runContextFactory.of(),
+            flow,
+            triggeringExecution
+        );
+
+        assertThat(evaluate.isPresent()).isTrue();
+        assertThat(evaluate.get().getLabels()).hasSize(3);
+        assertThat(evaluate.get().getLabels()).contains(new Label("triggering-execution-id", triggeringExecution.getId()));
+        assertThat(evaluate.get().getLabels()).contains(new Label("triggering-namespace", "io.kestra.unittest.upstream"));
+        assertThat(evaluate.get().getLabels()).contains(new Label("triggering-flow-id", "upstream-flow"));
+    }
+
+    @Test
+    void success_withInvalidDynamicLabel() {
+        var flow = io.kestra.core.models.flows.Flow.builder()
+            .id("flow-with-flow-trigger")
+            .namespace("io.kestra.unittest")
+            .revision(1)
+            .tasks(
+                Collections.singletonList(
+                    Return.builder()
+                        .id("test")
+                        .type(Return.class.getName())
+                        .format(Property.ofValue("test"))
+                        .build()
+                )
+            )
+            .build();
+        var triggeringExecution = Execution.builder()
+            .id(IdUtils.create())
+            .namespace("io.kestra.unittest.upstream")
+            .flowId("upstream-flow")
+            .flowRevision(1)
+            .state(new State().withState(State.Type.RUNNING))
+            .build();
+        var flowTrigger = Flow.builder()
+            .id("flow")
+            .type(Flow.class.getName())
+            .labels(
+                List.of(
+                    new Label("triggering-execution-id", "{{ trigger.executionId }}"),
+                    new Label("unknown-trigger-field", "{{ trigger.doesNotExist }}") // should be omitted, not fail the evaluation
+                )
+            )
+            .build();
+
+        Optional<Execution> evaluate = flowTrigger.evaluate(
+            Optional.empty(),
+            runContextFactory.of(),
+            flow,
+            triggeringExecution
+        );
+
+        assertThat(evaluate.isPresent()).isTrue();
+        assertThat(evaluate.get().getLabels()).hasSize(1);
+        assertThat(evaluate.get().getLabels()).contains(new Label("triggering-execution-id", triggeringExecution.getId()));
+        assertThat(evaluate.get().getLabels()).noneMatch(label -> label.key().equals("unknown-trigger-field"));
+    }
 }


### PR DESCRIPTION
Trigger labels can now use expressions to access filter/functions or trigger variables.

Closes #3876

Example 1: using a Pebble function

```yaml
id: schedule
namespace: company.team

triggers:
  - id: shedule
    type: io.kestra.plugin.core.trigger.Schedule
    cron: "* * * * *"
    labels: 
      test: year-{{now(format='YYYY')}}

tasks:
  - id: hello
    type: io.kestra.plugin.core.log.Log
    message: Hello World! 🚀
```

Example 2: using a trigger variable

```yaml
id: schedule
namespace: company.team

triggers:
  - id: shedule
    type: io.kestra.plugin.core.trigger.Schedule
    cron: "* * * * *"
    labels: 
      test: year-{{trigger.previous}}

tasks:
  - id: hello
    type: io.kestra.plugin.core.log.Log
    message: Hello World! 🚀
```