### PR TITLE
fix(executor): emit delayed executions after the transaction commits

### DIFF
--- a/executor/src/main/java/io/kestra/executor/DefaultExecutor.java
+++ b/executor/src/main/java/io/kestra/executor/DefaultExecutor.java
@@ -434,6 +434,13 @@ public class DefaultExecutor extends AbstractService implements Executor {
 
         executionDelayLoopTimer.record(() ->
         {
+            // Collect the resulting executors during the transaction and emit them only AFTER
+            // processExpired() commits. Emitting inside the transaction races the queue consumer:
+            // on a non-transactional queue (Kafka) a new execution created by replay
+            // (CREATE_NEW_EXECUTION / RESTART_FAILED_FLOW) can be consumed before its INSERT is
+            // visible, so the executor's lock finds no row, silently skips it ("not ready for now"),
+            // and the new execution is dropped — the retry chain never runs.
+            List<ExecutorContext> toEmit = new ArrayList<>();
             executionDelayStateStore.processExpired(Instant.now(), executionDelay ->
             {
                 Optional<ExecutorContext> maybeExecutor = executionStateStore.lock(executionDelay.getExecutionId(), execution ->
@@ -500,8 +507,12 @@ public class DefaultExecutor extends AbstractService implements Executor {
                     return executor;
                 });
 
-                maybeExecutor.ifPresent(this::toExecution);
+                maybeExecutor.ifPresent(toEmit::add);
             });
+
+            // Transaction has committed here: the new/updated executions are now durably visible,
+            // so emitting their events cannot be consumed before the state store can see them.
+            toEmit.forEach(this::toExecution);
         });
     }
 


### PR DESCRIPTION
## What

`executionDelayLoop()` published each delayed execution's queue event from **inside** `AbstractJdbcExecutionDelayStateStore.processExpired()`'s JDBC transaction. This change collects the resulting executors during the transaction and emits their events only **after** it commits (transactional-outbox ordering).

## Why

`CREATE_NEW_EXECUTION` retries were silently dropped on the **Kafka** runner, making the four `KafkaRunnerRetryTest.retryNewExecution{Task,Flow}{Attempts,Duration}` tests time out after 30s (consistently — reproduced locally on the first try).

Traced end-to-end:

1. A task with `CREATE_NEW_EXECUTION` retry fails → the executor marks the original execution `RETRIED` and schedules a `RESTART_FAILED_FLOW` `ExecutionDelay`.
2. `executionDelayLoop()` processes the matured delay. `processExpired()` wraps the whole callback in **one** JDBC transaction.
3. Inside that transaction, `executionStateStore.lock(originalId, …)` calls `executionService.replay(...)`, minting a **new** execution (state `CREATED`) and `INSERT`ing it (`AbstractJdbcExecutionRepository`: *"different execution ID … for replay, we must INSERT"*).
4. Still inside the **uncommitted** transaction, `toExecution(...)` publishes the new execution's `ExecutionEvent` to the Kafka `execution_event` topic. The Kafka producer transaction commits immediately, so the message is instantly visible.
5. The executor's own consumer receives the event ~200ms later, but the outer JDBC transaction hasn't committed, so `executionStateStore.lock(newId)` finds no row and returns empty (*"not ready for now, skip and wait for a first state"*).
6. The Kafka offset is committed regardless → the new execution is dropped, and the retry chain never runs → the test's `Await` for a FAILED execution times out.

JDBC/H2/Postgres/MySQL are immune because their queue is a table in the **same** database, so the queue message and the new execution row commit atomically in one transaction — a consumer can never observe the event before the row.

## Testing

- The four `CREATE_NEW_EXECUTION` variants **fail on `develop`** (30s `TimeoutException`) and **pass reliably with this change** (~4-6s, matching the JDBC/ES backends) across repeated runs (solo, whole-class, and isolated).
- `H2RunnerRetryTest` stays green (20 passing) — no regression on the JDBC path.

## Notes

`@FlakyTest` on `KafkaRunnerRetryTest` is intentionally **left in place**: the class has a separate, non-deterministic classloader/metaspace flake when all 21 heavy runner tests share one JVM, unrelated to this fix. It can be removed in a follow-up once CI confirms whole-class stability.