### PR TITLE
build: remove husky, use gradle-managed git hook

### DIFF
--- a/ui/.husky/pre-commit
+++ b/ui/.husky/pre-commit
@@ -1,1 +1,0 @@
-cd ui && npx lint-staged

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -60,7 +60,6 @@
                 "eslint": "^9.39.4",
                 "eslint-plugin-vue": "^9.33.0",
                 "globals": "^17.6.0",
-                "husky": "^9.1.7",
                 "jsdom": "^29.1.1",
                 "lint-staged": "^16.4.0",
                 "lodash": "^4.18.1",
@@ -3597,6 +3596,7 @@
             "os": [
                 "android"
             ],
+            "peer": true,
             "engines": {
                 "node": ">= 10.0.0"
             },
@@ -3617,6 +3617,7 @@
             "os": [
                 "darwin"
             ],
+            "peer": true,
             "engines": {
                 "node": ">= 10.0.0"
             },
@@ -3637,6 +3638,7 @@
             "os": [
                 "darwin"
             ],
+            "peer": true,
             "engines": {
                 "node": ">= 10.0.0"
             },
@@ -3657,6 +3659,7 @@
             "os": [
                 "freebsd"
             ],
+            "peer": true,
             "engines": {
                 "node": ">= 10.0.0"
             },
@@ -3677,6 +3680,7 @@
             "os": [
                 "linux"
             ],
+            "peer": true,
             "engines": {
                 "node": ">= 10.0.0"
             },
@@ -3697,6 +3701,7 @@
             "os": [
                 "linux"
             ],
+            "peer": true,
             "engines": {
                 "node": ">= 10.0.0"
             },
@@ -3717,6 +3722,7 @@
             "os": [
                 "linux"
             ],
+            "peer": true,
             "engines": {
                 "node": ">= 10.0.0"
             },
@@ -3737,6 +3743,7 @@
             "os": [
                 "linux"
             ],
+            "peer": true,
             "engines": {
                 "node": ">= 10.0.0"
             },
@@ -3757,6 +3764,7 @@
             "os": [
                 "linux"
             ],
+            "peer": true,
             "engines": {
                 "node": ">= 10.0.0"
             },
@@ -3777,6 +3785,7 @@
             "os": [
                 "linux"
             ],
+            "peer": true,
             "engines": {
                 "node": ">= 10.0.0"
             },
@@ -3797,6 +3806,7 @@
             "os": [
                 "win32"
             ],
+            "peer": true,
             "engines": {
                 "node": ">= 10.0.0"
             },
@@ -3817,6 +3827,7 @@
             "os": [
                 "win32"
             ],
+            "peer": true,
             "engines": {
                 "node": ">= 10.0.0"
             },
@@ -3837,6 +3848,7 @@
             "os": [
                 "win32"
             ],
+            "peer": true,
             "engines": {
                 "node": ">= 10.0.0"
             },
@@ -10589,21 +10601,6 @@
                 "url": "https://github.com/sponsors/EvanHahn"
             }
         },
-        "node_modules/husky": {
-            "version": "9.1.7",
-            "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.7.tgz",
-            "integrity": "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==",
-            "license": "MIT",
-            "bin": {
-                "husky": "bin.js"
-            },
-            "engines": {
-                "node": ">=18"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/typicode"
-            }
-        },
         "node_modules/iconv-lite": {
             "version": "0.6.3",
             "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
@@ -15127,6 +15124,7 @@
             ],
             "license": "MIT",
             "optional": true,
+            "peer": true,
             "dependencies": {
                 "sass": "1.100.0"
             }
@@ -15137,6 +15135,7 @@
             "integrity": "sha512-B5j0rYMlinhhOo9tjQebMVVn0TfyXAF+wB3b2ggZUuJ/is/Y+7+JGjirAMxHZ9Z3hIP98NPfamlAkBHa1lAaXQ==",
             "license": "MIT",
             "optional": true,
+            "peer": true,
             "dependencies": {
                 "chokidar": "^5.0.0",
                 "immutable": "^5.1.5",
@@ -15164,6 +15163,7 @@
             "os": [
                 "android"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=14.0.0"
             }
@@ -15180,6 +15180,7 @@
             "os": [
                 "android"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=14.0.0"
             }
@@ -15196,6 +15197,7 @@
             "os": [
                 "android"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=14.0.0"
             }
@@ -15212,6 +15214,7 @@
             "os": [
                 "android"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=14.0.0"
             }
@@ -15228,6 +15231,7 @@
             "os": [
                 "darwin"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=14.0.0"
             }
@@ -15244,6 +15248,7 @@
             "os": [
                 "darwin"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=14.0.0"
             }
@@ -15260,6 +15265,7 @@
             "os": [
                 "linux"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=14.0.0"
             }
@@ -15276,6 +15282,7 @@
             "os": [
                 "linux"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=14.0.0"
             }
@@ -15292,6 +15299,7 @@
             "os": [
                 "linux"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=14.0.0"
             }
@@ -15308,6 +15316,7 @@
             "os": [
                 "linux"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=14.0.0"
             }
@@ -15324,6 +15333,7 @@
             "os": [
                 "linux"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=14.0.0"
             }
@@ -15340,6 +15350,7 @@
             "os": [
                 "linux"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=14.0.0"
             }
@@ -15356,6 +15367,7 @@
             "os": [
                 "linux"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=14.0.0"
             }
@@ -15372,6 +15384,7 @@
             "os": [
                 "linux"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=14.0.0"
             }
@@ -15388,6 +15401,7 @@
                 "!linux",
                 "!win32"
             ],
+            "peer": true,
             "dependencies": {
                 "sass": "1.100.0"
             }
@@ -15398,6 +15412,7 @@
             "integrity": "sha512-B5j0rYMlinhhOo9tjQebMVVn0TfyXAF+wB3b2ggZUuJ/is/Y+7+JGjirAMxHZ9Z3hIP98NPfamlAkBHa1lAaXQ==",
             "license": "MIT",
             "optional": true,
+            "peer": true,
             "dependencies": {
                 "chokidar": "^5.0.0",
                 "immutable": "^5.1.5",
@@ -15425,6 +15440,7 @@
             "os": [
                 "win32"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=14.0.0"
             }
@@ -15441,6 +15457,7 @@
             "os": [
                 "win32"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=14.0.0"
             }

--- a/ui/package.json
+++ b/ui/package.json
@@ -24,7 +24,6 @@
         "lint": "oxlint --fix src packages && eslint --fix",
         "storybook": "storybook dev -p 6006",
         "build-storybook": "storybook build",
-        "prepare": "cd .. && husky ui/.husky && ([ -d .git ] && rimraf .git/hooks) || true",
         "postinstall": "npx patch-package"
     },
     "dependencies": {
@@ -76,7 +75,6 @@
         "eslint": "^9.39.4",
         "eslint-plugin-vue": "^9.33.0",
         "globals": "^17.6.0",
-        "husky": "^9.1.7",
         "jsdom": "^29.1.1",
         "lint-staged": "^16.4.0",
         "lodash": "^4.18.1",


### PR DESCRIPTION
Removes Husky from the UI package; the Gradle `spotless-conventions` plugin now owns the git hook.

Husky and the plugin both set `core.hooksPath`, and Husky's `prepare` script re-pointed it to `ui/.husky/_` on every `npm i`, overriding the Gradle hook — and Husky's pre-commit only ran frontend `lint-staged`, so `spotlessApply` on staged Java files was skipped. This is the cause of the recurring Java formatting drift. The Gradle hook already runs `lint-staged` for the UI, so no coverage is lost.

After merging, existing clones must re-point their hook once: `./gradlew clean build` (or `git config core.hooksPath .github/.hooks`).

EE companion: kestra-io/kestra-ee#9208