### PR TITLE
refactor/type converter

### DIFF
--- a/cli/src/main/java/io/kestra/cli/commands/namespaces/kv/KvUpdateCommand.java
+++ b/cli/src/main/java/io/kestra/cli/commands/namespaces/kv/KvUpdateCommand.java
@@ -10,6 +10,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.kestra.cli.AbstractApiCommand;
 import io.kestra.cli.services.TenantIdSelectorService;
 import io.kestra.core.serializers.JacksonMapper;
+import io.kestra.core.utils.TypeConverter;
 
 import io.micronaut.http.HttpRequest;
 import io.micronaut.http.MediaType;
@@ -66,7 +67,7 @@ public class KvUpdateCommand extends AbstractApiCommand {
             value = wrapAsJsonLiteral(value);
         }
 
-        Duration ttl = expiration == null ? null : Duration.parse(expiration);
+        Duration ttl = TypeConverter.toDuration(expiration);
         MutableHttpRequest<String> request = HttpRequest
             .PUT(apiUri("/namespaces/", tenantService.getTenantId(tenantId)) + namespace + "/kv/" + key, value)
             .contentType(MediaType.TEXT_PLAIN);

--- a/core/src/main/java/io/kestra/core/exceptions/TypeConversionException.java
+++ b/core/src/main/java/io/kestra/core/exceptions/TypeConversionException.java
@@ -1,0 +1,21 @@
+package io.kestra.core.exceptions;
+
+import io.kestra.core.utils.TypeConverter;
+
+/**
+ * Exception thrown by {@link TypeConverter} when a value cannot be converted to the target type.
+ *
+ * <p>Extends {@link IllegalArgumentException} so that existing {@code IllegalArgumentException}
+ * handling (e.g. the webserver's HTTP 400 mapping and repository filter wrapping) applies to
+ * conversion failures without additional wiring. The original parse failure is preserved as the cause.
+ */
+public class TypeConversionException extends IllegalArgumentException {
+
+    public TypeConversionException(String message) {
+        super(message);
+    }
+
+    public TypeConversionException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/core/src/main/java/io/kestra/core/plugins/notifications/ExecutionService.java
+++ b/core/src/main/java/io/kestra/core/plugins/notifications/ExecutionService.java
@@ -10,6 +10,7 @@ import io.kestra.core.exceptions.IllegalVariableEvaluationException;
 import io.kestra.core.runners.DefaultRunContext;
 import io.kestra.core.runners.RunContext;
 import io.kestra.core.serializers.JacksonMapper;
+import io.kestra.core.utils.TypeConverter;
 import io.kestra.core.utils.UriProvider;
 
 public final class ExecutionService {
@@ -123,7 +124,7 @@ public final class ExecutionService {
 
     private record ExecutionContextState(String current, String startDate, String endDate) {
         public String humanDuration() {
-            Duration duration = Duration.between(Instant.parse(startDate), Optional.ofNullable(endDate).map(d -> Instant.parse(d)).orElse(Instant.now()));
+            Duration duration = Duration.between(TypeConverter.toInstant(startDate), Optional.ofNullable(endDate).map(TypeConverter::toInstant).orElse(Instant.now()));
             return DurationFormatUtils.formatDurationHMS(duration.toMillis());
         }
     }

--- a/core/src/main/java/io/kestra/core/runners/FlowInputOutput.java
+++ b/core/src/main/java/io/kestra/core/runners/FlowInputOutput.java
@@ -37,6 +37,7 @@ import io.kestra.core.storages.StorageContext;
 import io.kestra.core.storages.StorageInterface;
 import io.kestra.core.utils.ListUtils;
 import io.kestra.core.utils.MapUtils;
+import io.kestra.core.utils.TypeConverter;
 
 import io.micronaut.core.annotation.Nullable;
 import io.micronaut.http.multipart.CompletedFileUpload;
@@ -547,14 +548,14 @@ public class FlowInputOutput {
                     String encrypted = EncryptionService.encrypt(secretKey.get(), current.toString());
                     yield EncryptedString.from(encrypted);
                 }
-                case INT -> current instanceof Integer ? current : Integer.valueOf(current.toString());
+                case INT -> TypeConverter.toInteger(current);
                 // Assuming that after the render we must have a double/int, so we can safely use its toString representation
-                case FLOAT -> current instanceof Float ? current : Float.valueOf(current.toString());
-                case BOOL -> current instanceof Boolean ? current : Boolean.valueOf(current.toString());
-                case DATETIME -> current instanceof Instant ? current : Instant.parse(current.toString());
-                case DATE -> current instanceof LocalDate ? current : LocalDate.parse(current.toString());
-                case TIME -> current instanceof LocalTime ? current : LocalTime.parse(current.toString());
-                case DURATION -> current instanceof Duration ? current : Duration.parse(current.toString());
+                case FLOAT -> TypeConverter.toFloat(current);
+                case BOOL -> TypeConverter.toBoolean(current);
+                case DATETIME -> TypeConverter.toInstant(current);
+                case DATE -> TypeConverter.toLocalDate(current);
+                case TIME -> TypeConverter.toLocalTime(current);
+                case DURATION -> TypeConverter.toDuration(current);
                 case FILE -> {
                     URI uri = URI.create(current.toString().replace(File.separator, "/"));
 

--- a/core/src/main/java/io/kestra/core/test/flow/Assertion.java
+++ b/core/src/main/java/io/kestra/core/test/flow/Assertion.java
@@ -8,9 +8,11 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.core.JsonProcessingException;
 
 import io.kestra.core.exceptions.IllegalVariableEvaluationException;
+import io.kestra.core.exceptions.TypeConversionException;
 import io.kestra.core.models.property.Property;
 import io.kestra.core.runners.RunContext;
 import io.kestra.core.serializers.JacksonMapper;
+import io.kestra.core.utils.TypeConverter;
 import io.kestra.core.validations.TestSuiteAssertionValidation;
 
 import jakarta.validation.constraints.NotNull;
@@ -387,14 +389,10 @@ public class Assertion {
     }
 
     private Double tryToParseDouble(Object x) throws IllegalVariableEvaluationException {
-        if (x instanceof Double) {
-            return (Double) x;
-        } else {
-            try {
-                return Double.parseDouble(x.toString());
-            } catch (NumberFormatException e) {
-                throw new IllegalVariableEvaluationException("Could not parse value as a Double");
-            }
+        try {
+            return TypeConverter.toDouble(x);
+        } catch (TypeConversionException e) {
+            throw new IllegalVariableEvaluationException("Could not parse value as a Double");
         }
     }
 

--- a/core/src/main/java/io/kestra/core/utils/DateUtils.java
+++ b/core/src/main/java/io/kestra/core/utils/DateUtils.java
@@ -8,6 +8,11 @@ import io.kestra.core.exceptions.InternalException;
 import io.kestra.core.models.QueryFilter;
 
 public class DateUtils {
+    /**
+     * @deprecated use {@link TypeConverter#toZonedDateTime(Object)} instead — same strict
+     * ISO-8601 parsing, but throws an unchecked {@code TypeConversionException}.
+     */
+    @Deprecated(since = "2.0", forRemoval = true)
     public static ZonedDateTime parseZonedDateTime(String render) throws InternalException {
         ZonedDateTime currentDate;
         try {
@@ -16,16 +21,6 @@ public class DateUtils {
             throw new InternalException(e);
         }
         return currentDate;
-    }
-
-    public static OffsetTime parseOffsetTime(String render) throws InternalException {
-        OffsetTime currentTime;
-        try {
-            currentTime = OffsetTime.parse(render);
-        } catch (DateTimeException e) {
-            throw new InternalException(e);
-        }
-        return currentTime;
     }
 
     public static LocalDate parseLocalDate(String render) throws InternalException {
@@ -37,29 +32,6 @@ public class DateUtils {
             } catch (DateTimeException e2) {
                 try {
                     return LocalDateTime.parse(render).toLocalDate();
-                } catch (DateTimeException e3) {
-                    throw new InternalException(e3);
-                }
-            }
-        }
-    }
-
-    /**
-     * Parses an ISO 8601 date or datetime string to an {@link Instant}.
-     *
-     * <p>
-     * Parsing order: {@link ZonedDateTime} → {@link LocalDateTime} (treated as UTC) →
-     * {@link LocalDate} (treated as midnight UTC). Throws {@link InternalException} if none match.
-     */
-    public static Instant parseInstant(String render) throws InternalException {
-        try {
-            return ZonedDateTime.parse(render).toInstant();
-        } catch (DateTimeException e1) {
-            try {
-                return LocalDateTime.parse(render).toInstant(ZoneOffset.UTC);
-            } catch (DateTimeException e2) {
-                try {
-                    return LocalDate.parse(render).atStartOfDay(ZoneOffset.UTC).toInstant();
                 } catch (DateTimeException e3) {
                     throw new InternalException(e3);
                 }
@@ -126,20 +98,12 @@ public class DateUtils {
         ZonedDateTime endDate = null;
         for (QueryFilter filter : filters) {
             if (isStartDateFilter(filter)) {
-                startDate = parse(filter.value());
+                startDate = TypeConverter.toZonedDateTime(filter.value());
             } else if (isEndDateFilter(filter)) {
-                endDate = parse(filter.value());
+                endDate = TypeConverter.toZonedDateTime(filter.value());
             }
         }
         validateTimeline(startDate, endDate);
-    }
-
-    private static ZonedDateTime parse(Object o) {
-        if (o instanceof ZonedDateTime) {
-            return (ZonedDateTime) o;
-        } else {
-            return ZonedDateTime.parse(o.toString());
-        }
     }
 
     private static boolean isEndDateFilter(QueryFilter filter) {

--- a/core/src/main/java/io/kestra/core/utils/TypeConverter.java
+++ b/core/src/main/java/io/kestra/core/utils/TypeConverter.java
@@ -1,0 +1,237 @@
+package io.kestra.core.utils;
+
+import io.kestra.core.exceptions.TypeConversionException;
+import jakarta.annotation.Nullable;
+import jakarta.validation.constraints.NotNull;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.time.ZonedDateTime;
+import java.util.Arrays;
+import java.util.List;
+import java.util.function.Function;
+
+/**
+ * Utility methods for converting raw values (typically {@link Object} or {@link String}) into typed values.
+ *
+ * <p>General contract for all methods:
+ * <ul>
+ *     <li>{@code null} in, {@code null} out.</li>
+ *     <li>A value already of the target type is returned as-is (passthrough).</li>
+ *     <li>Any other value is strictly parsed from its {@code toString()} representation — no trimming,
+ *     no locale handling, no lenient formats.</li>
+ *     <li>Conversion failures throw {@link TypeConversionException} (an {@link IllegalArgumentException})
+ *     carrying the original parse failure as cause.</li>
+ * </ul>
+ */
+public final class TypeConverter {
+
+    /**
+     * Converts the given value to a {@link Boolean}.
+     *
+     * <p>Uses {@link Boolean#parseBoolean(String)} semantics: only the literal {@code "true"}
+     * (case-insensitive) is {@code true}; everything else — including {@code "1"} and {@code "yes"} —
+     * is {@code false}. Do NOT use for flow-condition truthiness; use {@link TruthUtils} instead.
+     *
+     * @param value the value to convert.
+     * @return the converted value, or {@code null} if the value is {@code null}.
+     */
+    public static Boolean toBoolean(final @Nullable Object value) {
+        return switch (value) {
+            case null -> null;
+            case Boolean b -> b;
+            default -> Boolean.parseBoolean(value.toString());
+        };
+    }
+
+    /**
+     * Converts the given value to an {@link Integer}.
+     *
+     * @param value the value to convert.
+     * @return the converted value, or {@code null} if the value is {@code null}.
+     * @throws TypeConversionException if the value cannot be parsed as an integer.
+     */
+    public static Integer toInteger(final @Nullable Object value) {
+        return switch (value) {
+            case null -> null;
+            case Integer i -> i;
+            default -> convert(value, Integer.class, v -> Integer.valueOf(v.toString()));
+        };
+    }
+
+    /**
+     * Converts the given value to a {@link Long}.
+     *
+     * @param value the value to convert.
+     * @return the converted value, or {@code null} if the value is {@code null}.
+     * @throws TypeConversionException if the value cannot be parsed as a long.
+     */
+    public static Long toLong(final @Nullable Object value) {
+        return switch (value) {
+            case null -> null;
+            case Long l -> l;
+            default -> convert(value, Long.class, v -> Long.valueOf(v.toString()));
+        };
+    }
+
+    /**
+     * Converts the given value to a {@link Float}.
+     *
+     * @param value the value to convert.
+     * @return the converted value, or {@code null} if the value is {@code null}.
+     * @throws TypeConversionException if the value cannot be parsed as a float.
+     */
+    public static Float toFloat(final @Nullable Object value) {
+        return switch (value) {
+            case null -> null;
+            case Float f -> f;
+            default -> convert(value, Float.class, v -> Float.valueOf(v.toString()));
+        };
+    }
+
+    /**
+     * Converts the given value to a {@link Double}.
+     *
+     * @param value the value to convert.
+     * @return the converted value, or {@code null} if the value is {@code null}.
+     * @throws TypeConversionException if the value cannot be parsed as a double.
+     */
+    public static Double toDouble(final @Nullable Object value) {
+        return switch (value) {
+            case null -> null;
+            case Double d -> d;
+            default -> convert(value, Double.class, v -> Double.valueOf(v.toString()));
+        };
+    }
+
+    /**
+     * Converts the given value to a {@link Duration} using strict ISO-8601 parsing (e.g. {@code "PT1H"}).
+     *
+     * @param value the value to convert.
+     * @return the converted value, or {@code null} if the value is {@code null}.
+     * @throws TypeConversionException if the value cannot be parsed as a duration.
+     */
+    public static Duration toDuration(final @Nullable Object value) {
+        return switch (value) {
+            case null -> null;
+            case Duration d -> d;
+            default -> convert(value, Duration.class, v -> Duration.parse(v.toString()));
+        };
+    }
+
+    /**
+     * Converts the given value to an {@link Instant} using strict ISO-8601 instant parsing
+     * (e.g. {@code "2023-05-02T01:02:03Z"}). For lenient multi-format fallback parsing, use {@link DateUtils}.
+     *
+     * @param value the value to convert.
+     * @return the converted value, or {@code null} if the value is {@code null}.
+     * @throws TypeConversionException if the value cannot be parsed as an instant.
+     */
+    public static Instant toInstant(final @Nullable Object value) {
+        return switch (value) {
+            case null -> null;
+            case Instant i -> i;
+            default -> convert(value, Instant.class, v -> Instant.parse(v.toString()));
+        };
+    }
+
+    /**
+     * Converts the given value to a {@link LocalDate} using strict ISO-8601 date parsing (e.g. {@code "2023-05-02"}).
+     * For lenient multi-format fallback parsing, use {@link DateUtils}.
+     *
+     * @param value the value to convert.
+     * @return the converted value, or {@code null} if the value is {@code null}.
+     * @throws TypeConversionException if the value cannot be parsed as a date.
+     */
+    public static LocalDate toLocalDate(final @Nullable Object value) {
+        return switch (value) {
+            case null -> null;
+            case LocalDate d -> d;
+            default -> convert(value, LocalDate.class, v -> LocalDate.parse(v.toString()));
+        };
+    }
+
+    /**
+     * Converts the given value to a {@link LocalTime} using strict ISO-8601 time parsing (e.g. {@code "01:02:03"}).
+     *
+     * @param value the value to convert.
+     * @return the converted value, or {@code null} if the value is {@code null}.
+     * @throws TypeConversionException if the value cannot be parsed as a time.
+     */
+    public static LocalTime toLocalTime(final @Nullable Object value) {
+        return switch (value) {
+            case null -> null;
+            case LocalTime t -> t;
+            default -> convert(value, LocalTime.class, v -> LocalTime.parse(v.toString()));
+        };
+    }
+
+    /**
+     * Converts the given value to a {@link ZonedDateTime} using strict ISO-8601 parsing
+     * (e.g. {@code "2023-05-02T01:02:03+02:00[Europe/Paris]"}). For lenient multi-format fallback parsing,
+     * use {@link DateUtils}.
+     *
+     * @param value the value to convert.
+     * @return the converted value, or {@code null} if the value is {@code null}.
+     * @throws TypeConversionException if the value cannot be parsed as a zoned date-time.
+     */
+    public static ZonedDateTime toZonedDateTime(final @Nullable Object value) {
+        return switch (value) {
+            case null -> null;
+            case ZonedDateTime z -> z;
+            default -> convert(value, ZonedDateTime.class, v -> ZonedDateTime.parse(v.toString()));
+        };
+    }
+
+    /**
+     * Converts the given value to an enum of the given type, matching names case-insensitively
+     * via {@link Enums#getForNameIgnoreCase(String, Class)}.
+     *
+     * @param value the value to convert.
+     * @param enumType the enum class type.
+     * @param <T> the enum type.
+     * @return the converted value, or {@code null} if the value is {@code null}.
+     * @throws TypeConversionException if no enum constant matches the value.
+     */
+    public static <T extends Enum<T>> T toEnum(final @Nullable Object value, final @NotNull Class<T> enumType) {
+        if (value == null) {
+            return null;
+        }
+        if (enumType.isInstance(value)) {
+            return enumType.cast(value);
+        }
+        return convert(value, enumType, v -> Enums.getForNameIgnoreCase(v.toString(), enumType));
+    }
+
+    /**
+     * Converts the given value to a list of strings. A {@link String} is split on commas (tokens are
+     * not trimmed); any other value is converted via {@link ListUtils#convertToListString(Object)}.
+     *
+     * @param value the value to convert.
+     * @return the converted value, or {@code null} if the value is {@code null}.
+     */
+    public static List<String> toListOfString(final @Nullable Object value) {
+        return switch (value) {
+            case null -> null;
+            case String csv -> Arrays.asList(csv.split(","));
+            default -> ListUtils.convertToListString(value);
+        };
+    }
+
+    private static <T> T convert(final Object value, final Class<T> targetType, final Function<Object, T> parser) {
+        try {
+            return parser.apply(value);
+        } catch (RuntimeException e) {
+            throw new TypeConversionException(conversionErrorMessage(value, targetType), e);
+        }
+    }
+
+    private static String conversionErrorMessage(final Object value, final Class<?> targetType) {
+        return "Cannot convert value '" + value + "' to " + targetType.getSimpleName();
+    }
+
+    private TypeConverter() {
+    }
+}

--- a/core/src/main/java/io/kestra/plugin/core/flow/LoopUntil.java
+++ b/core/src/main/java/io/kestra/plugin/core/flow/LoopUntil.java
@@ -25,6 +25,7 @@ import io.kestra.core.runners.RunContext;
 import io.kestra.core.utils.GraphUtils;
 import io.kestra.core.utils.MapUtils;
 import io.kestra.core.utils.TruthUtils;
+import io.kestra.core.utils.TypeConverter;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
@@ -228,7 +229,7 @@ public class LoopUntil extends AbstractBranch<LoopUntil.Output> {
         );
 
         return Output.builder()
-            .iterationCount(Integer.parseInt(value) + 1)
+            .iterationCount(TypeConverter.toInteger(value) + 1)
             .build();
     }
 

--- a/core/src/main/java/io/kestra/plugin/core/http/Download.java
+++ b/core/src/main/java/io/kestra/plugin/core/http/Download.java
@@ -23,6 +23,7 @@ import io.kestra.core.models.annotations.Plugin;
 import io.kestra.core.models.property.Property;
 import io.kestra.core.models.tasks.RunnableTask;
 import io.kestra.core.runners.RunContext;
+import io.kestra.core.utils.TypeConverter;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
@@ -108,7 +109,7 @@ public class Download extends AbstractHttp implements RunnableTask<Download.Outp
                     if (r.getBody() != null && !contentEncoded) {
                         r.getHeaders().firstValue("Content-Length").ifPresent(header ->
                         {
-                            long length = Long.parseLong(header);
+                            long length = TypeConverter.toLong(header);
 
                             if (length != size.get()) {
                                 throw new IllegalStateException("Invalid size, got " + size + ", expected " + length);

--- a/core/src/main/java/io/kestra/plugin/core/kv/Set.java
+++ b/core/src/main/java/io/kestra/plugin/core/kv/Set.java
@@ -18,6 +18,7 @@ import io.kestra.core.serializers.JacksonMapper;
 import io.kestra.core.storages.kv.KVMetadata;
 import io.kestra.core.storages.kv.KVStore;
 import io.kestra.core.storages.kv.KVValueAndMetadata;
+import io.kestra.core.utils.TypeConverter;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
@@ -116,12 +117,12 @@ public class Set extends Task implements RunnableTask<VoidOutput> {
             if (renderedValue instanceof String renderedValueStr) {
                 renderedValue = switch (renderedKvType) {
                     case NUMBER -> JacksonMapper.ofJson().readValue(renderedValueStr, Number.class);
-                    case BOOLEAN -> Boolean.parseBoolean((String) renderedValue);
-                    case DATETIME -> Instant.parse(renderedValueStr);
+                    case BOOLEAN -> TypeConverter.toBoolean(renderedValueStr);
+                    case DATETIME -> TypeConverter.toInstant(renderedValueStr);
                     case DATE -> parseDate(renderedValueStr);
                     // We parse duration to make sure it's valid but we store it as a raw duration string
                     case DURATION -> {
-                        Duration.parse(renderedValueStr);
+                        TypeConverter.toDuration(renderedValueStr);
                         yield renderedValueStr;
                     }
                     case JSON -> JacksonMapper.toObject(renderedValueStr);

--- a/core/src/main/java/io/kestra/plugin/core/kv/Version.java
+++ b/core/src/main/java/io/kestra/plugin/core/kv/Version.java
@@ -12,6 +12,7 @@ import io.kestra.core.models.FetchVersion;
 import io.kestra.core.models.QueryFilter;
 import io.kestra.core.services.KVStoreService;
 import io.kestra.core.storages.kv.KVEntry;
+import io.kestra.core.utils.TypeConverter;
 import io.kestra.core.validations.KvVersionBehaviorValidation;
 
 import io.micronaut.data.model.Pageable;
@@ -53,7 +54,7 @@ public class Version extends KvPurgeBehavior {
             namespace,
             before == null
                 ? Collections.emptyList()
-                : List.of(QueryFilter.builder().field(QueryFilter.Field.UPDATED).operation(QueryFilter.Op.LESS_THAN_OR_EQUAL_TO).value(ZonedDateTime.parse(before)).build()),
+                : List.of(QueryFilter.builder().field(QueryFilter.Field.UPDATED).operation(QueryFilter.Op.LESS_THAN_OR_EQUAL_TO).value(TypeConverter.toZonedDateTime(before)).build()),
             true,
             true,
             before == null ? FetchVersion.ALL : FetchVersion.OLD

--- a/core/src/main/java/io/kestra/plugin/core/log/PurgeLogs.java
+++ b/core/src/main/java/io/kestra/plugin/core/log/PurgeLogs.java
@@ -14,6 +14,7 @@ import io.kestra.core.models.tasks.Task;
 import io.kestra.core.runners.DefaultRunContext;
 import io.kestra.core.runners.RunContext;
 import io.kestra.core.services.ExecutionLogService;
+import io.kestra.core.utils.TypeConverter;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
@@ -151,8 +152,8 @@ public class PurgeLogs extends Task implements RunnableTask<PurgeLogs.Output>, S
             runContext.render(flowId).as(String.class).orElse(null),
             runContext.render(executionId).as(String.class).orElse(null),
             logLevelsRendered.isEmpty() ? null : logLevelsRendered,
-            renderedDate != null ? ZonedDateTime.parse(renderedDate) : null,
-            ZonedDateTime.parse(runContext.render(endDate).as(String.class).orElseThrow()),
+            TypeConverter.toZonedDateTime(renderedDate),
+            TypeConverter.toZonedDateTime(runContext.render(endDate).as(String.class).orElseThrow()),
             execLogs,
             nonExecLogs,
             runContext.render(this.batchSize).as(Integer.class).orElse(null)

--- a/core/src/main/java/io/kestra/plugin/core/namespace/Version.java
+++ b/core/src/main/java/io/kestra/plugin/core/namespace/Version.java
@@ -11,6 +11,7 @@ import io.kestra.core.models.FetchVersion;
 import io.kestra.core.models.QueryFilter;
 import io.kestra.core.namespace.NamespaceFileService;
 import io.kestra.core.storages.NamespaceFile;
+import io.kestra.core.utils.TypeConverter;
 import io.kestra.core.validations.FilesVersionBehaviorValidation;
 
 import io.micronaut.data.model.Pageable;
@@ -52,7 +53,7 @@ public class Version extends FilesPurgeBehavior {
             namespace,
             before == null
                 ? Collections.emptyList()
-                : List.of(QueryFilter.builder().field(QueryFilter.Field.UPDATED).operation(QueryFilter.Op.LESS_THAN_OR_EQUAL_TO).value(ZonedDateTime.parse(before)).build()),
+                : List.of(QueryFilter.builder().field(QueryFilter.Field.UPDATED).operation(QueryFilter.Op.LESS_THAN_OR_EQUAL_TO).value(TypeConverter.toZonedDateTime(before)).build()),
             true,
             before == null ? FetchVersion.ALL : FetchVersion.OLD
         );

--- a/core/src/main/java/io/kestra/plugin/core/storage/PurgeStorage.java
+++ b/core/src/main/java/io/kestra/plugin/core/storage/PurgeStorage.java
@@ -14,6 +14,7 @@ import io.kestra.core.models.tasks.Task;
 import io.kestra.core.runners.DefaultRunContext;
 import io.kestra.core.runners.RunContext;
 import io.kestra.core.services.StoragePurgeService;
+import io.kestra.core.utils.TypeConverter;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
@@ -113,7 +114,7 @@ public class PurgeStorage extends Task implements RunnableTask<PurgeStorage.Outp
         String rNamespace = runContext.render(this.namespace).as(String.class).orElse(null);
         String rFlowId = runContext.render(this.flowId).as(String.class).orElse(null);
         ZonedDateTime rStartDate = runContext.render(this.startDate).as(String.class).map(ZonedDateTime::parse).orElse(null);
-        ZonedDateTime rEndDate = ZonedDateTime.parse(runContext.render(this.endDate).as(String.class).orElseThrow());
+        ZonedDateTime rEndDate = TypeConverter.toZonedDateTime(runContext.render(this.endDate).as(String.class).orElseThrow());
         boolean rDryRun = runContext.render(this.dryRun).as(Boolean.class).orElseThrow();
 
         // Reject before the ACL check so the user sees the actual mistake, not an "all namespaces" denial.

--- a/core/src/test/java/io/kestra/core/utils/TypeConverterTest.java
+++ b/core/src/test/java/io/kestra/core/utils/TypeConverterTest.java
@@ -1,0 +1,137 @@
+package io.kestra.core.utils;
+
+import io.kestra.core.exceptions.TypeConversionException;
+import org.junit.jupiter.api.Named;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeParseException;
+import java.util.List;
+import java.util.function.Function;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class TypeConverterTest {
+
+    private enum TestEnum {
+        FIRST, SECOND
+    }
+
+    private static final Function<Object, TestEnum> TO_TEST_ENUM = value -> TypeConverter.toEnum(value, TestEnum.class);
+
+    @ParameterizedTest
+    @MethodSource("converters")
+    void shouldReturnNullWhenInputIsNull(Function<Object, ?> converter) {
+        assertThat(converter.apply(null)).isNull();
+    }
+
+    private static Stream<Arguments> converters() {
+        return Stream.of(
+            arguments("toBoolean", TypeConverter::toBoolean),
+            arguments("toInteger", TypeConverter::toInteger),
+            arguments("toLong", TypeConverter::toLong),
+            arguments("toFloat", TypeConverter::toFloat),
+            arguments("toDouble", TypeConverter::toDouble),
+            arguments("toDuration", TypeConverter::toDuration),
+            arguments("toInstant", TypeConverter::toInstant),
+            arguments("toLocalDate", TypeConverter::toLocalDate),
+            arguments("toLocalTime", TypeConverter::toLocalTime),
+            arguments("toZonedDateTime", TypeConverter::toZonedDateTime),
+            arguments("toEnum", TO_TEST_ENUM),
+            arguments("toListOfString", TypeConverter::toListOfString)
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("passthroughValues")
+    void shouldReturnSameInstanceWhenAlreadyTargetType(Function<Object, ?> converter, Object value) {
+        assertThat(converter.apply(value)).isSameAs(value);
+    }
+
+    private static Stream<Arguments> passthroughValues() {
+        return Stream.of(
+            arguments("toBoolean", TypeConverter::toBoolean, Boolean.TRUE),
+            arguments("toInteger", TypeConverter::toInteger, Integer.valueOf(42)),
+            arguments("toLong", TypeConverter::toLong, Long.valueOf(42L)),
+            arguments("toFloat", TypeConverter::toFloat, Float.valueOf(1.5f)),
+            arguments("toDouble", TypeConverter::toDouble, Double.valueOf(1.5d)),
+            arguments("toDuration", TypeConverter::toDuration, Duration.ofHours(1)),
+            arguments("toInstant", TypeConverter::toInstant, Instant.parse("2023-05-02T01:02:03Z")),
+            arguments("toLocalDate", TypeConverter::toLocalDate, LocalDate.of(2023, 5, 2)),
+            arguments("toLocalTime", TypeConverter::toLocalTime, LocalTime.of(1, 2, 3)),
+            arguments("toZonedDateTime", TypeConverter::toZonedDateTime, ZonedDateTime.parse("2023-05-02T01:02:03+02:00[Europe/Paris]")),
+            arguments("toEnum", TO_TEST_ENUM, TestEnum.FIRST)
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("validConversions")
+    void shouldConvertWhenValidInput(Function<Object, ?> converter, Object input, Object expected) {
+        assertThat(converter.apply(input)).isEqualTo(expected);
+    }
+
+    private static Stream<Arguments> validConversions() {
+        return Stream.of(
+            arguments("toBoolean", TypeConverter::toBoolean, "true", true),
+            arguments("toBoolean", TypeConverter::toBoolean, "TrUe", true),
+            arguments("toBoolean", TypeConverter::toBoolean, "false", false),
+            // only the literal "true" is true — "1", "yes" and non-boolean objects are false, never an error
+            arguments("toBoolean", TypeConverter::toBoolean, "1", false),
+            arguments("toBoolean", TypeConverter::toBoolean, "yes", false),
+            arguments("toBoolean", TypeConverter::toBoolean, 1, false),
+            arguments("toInteger", TypeConverter::toInteger, "42", 42),
+            arguments("toInteger", TypeConverter::toInteger, 42L, 42),
+            arguments("toLong", TypeConverter::toLong, "3000000000", 3_000_000_000L),
+            arguments("toLong", TypeConverter::toLong, 42, 42L),
+            arguments("toFloat", TypeConverter::toFloat, "1.5", 1.5f),
+            arguments("toDouble", TypeConverter::toDouble, "1.5", 1.5d),
+            arguments("toDuration", TypeConverter::toDuration, "PT24H", Duration.ofHours(24)),
+            arguments("toInstant", TypeConverter::toInstant, "2023-05-02T01:02:03Z", Instant.parse("2023-05-02T01:02:03Z")),
+            arguments("toLocalDate", TypeConverter::toLocalDate, "2023-05-02", LocalDate.of(2023, 5, 2)),
+            arguments("toLocalTime", TypeConverter::toLocalTime, "01:02:03", LocalTime.of(1, 2, 3)),
+            arguments("toZonedDateTime", TypeConverter::toZonedDateTime, "2023-05-02T01:02:03+02:00[Europe/Paris]", ZonedDateTime.parse("2023-05-02T01:02:03+02:00[Europe/Paris]")),
+            arguments("toEnum", TO_TEST_ENUM, "first", TestEnum.FIRST),
+            arguments("toEnum", TO_TEST_ENUM, "SECOND", TestEnum.SECOND),
+            arguments("toListOfString", TypeConverter::toListOfString, "a,b,c", List.of("a", "b", "c")),
+            // tokens are not trimmed
+            arguments("toListOfString", TypeConverter::toListOfString, "a, b", List.of("a", " b")),
+            arguments("toListOfString", TypeConverter::toListOfString, "a", List.of("a")),
+            arguments("toListOfString", TypeConverter::toListOfString, List.of(1, 2), List.of("1", "2"))
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("invalidConversions")
+    void shouldThrowTypeConversionExceptionWhenInvalidInput(Function<Object, ?> converter, Object input, Class<? extends Throwable> causeType) {
+        assertThatThrownBy(() -> converter.apply(input))
+            .isInstanceOf(TypeConversionException.class)
+            .hasCauseInstanceOf(causeType);
+    }
+
+    private static Stream<Arguments> invalidConversions() {
+        return Stream.of(
+            arguments("toInteger", TypeConverter::toInteger, "not-a-number", NumberFormatException.class),
+            arguments("toInteger", TypeConverter::toInteger, 3_000_000_000L, NumberFormatException.class),
+            arguments("toLong", TypeConverter::toLong, "1.5", NumberFormatException.class),
+            arguments("toFloat", TypeConverter::toFloat, "abc", NumberFormatException.class),
+            arguments("toDuration", TypeConverter::toDuration, "24h", DateTimeParseException.class),
+            // documents the strictness relied on by callers: only ISO instants, no zoned formats
+            arguments("toInstant", TypeConverter::toInstant, "2023-05-02T01:02:03+02:00[Europe/Paris]", DateTimeParseException.class),
+            arguments("toLocalDate", TypeConverter::toLocalDate, "02/05/2023", DateTimeParseException.class),
+            arguments("toZonedDateTime", TypeConverter::toZonedDateTime, "2023-05-02", DateTimeParseException.class),
+            arguments("toEnum", TO_TEST_ENUM, "THIRD", IllegalArgumentException.class)
+        );
+    }
+
+    private static Arguments arguments(String name, Function<Object, ?> converter, Object... rest) {
+        return Arguments.of(Stream.concat(Stream.of(Named.of(name, converter)), Stream.of(rest)).toArray());
+    }
+}

--- a/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcRepository.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcRepository.java
@@ -30,6 +30,7 @@ import io.kestra.core.utils.DateUtils;
 import io.kestra.core.utils.Either;
 import io.kestra.core.utils.Enums;
 import io.kestra.core.utils.ListUtils;
+import io.kestra.core.utils.TypeConverter;
 import io.kestra.jdbc.services.JdbcFilterService;
 
 import io.micronaut.core.annotation.Nullable;
@@ -487,9 +488,7 @@ public abstract class AbstractJdbcRepository {
     }
 
     private Condition getDateCondition(Object value, Op operation, String dateColumn) {
-        OffsetDateTime dateTime = (value instanceof ZonedDateTime)
-            ? ((ZonedDateTime) value).toOffsetDateTime()
-            : ZonedDateTime.parse(value.toString()).toOffsetDateTime();
+        OffsetDateTime dateTime = TypeConverter.toZonedDateTime(value).toOffsetDateTime();
         return applyDateCondition(dateTime, operation, dateColumn);
     }
 
@@ -648,8 +647,8 @@ public abstract class AbstractJdbcRepository {
     protected Condition handleAttemptNumberField(Object value, QueryFilter.Op operation) {
         Name columnName = getColumnName(QueryFilter.Field.ATTEMPT_NUMBER);
         return switch (operation) {
-            case EQUALS -> DSL.field(columnName).eq(toInteger(value));
-            case NOT_EQUALS -> DSL.field(columnName).ne(toInteger(value));
+            case EQUALS -> DSL.field(columnName).eq(TypeConverter.toInteger(value));
+            case NOT_EQUALS -> DSL.field(columnName).ne(TypeConverter.toInteger(value));
             case IN -> DSL.field(columnName).in(toIntegerList(value));
             case NOT_IN -> DSL.field(columnName).notIn(toIntegerList(value));
             default -> throw new InvalidQueryFiltersException(
@@ -658,22 +657,11 @@ public abstract class AbstractJdbcRepository {
         };
     }
 
-    // ToDo: We should create reusable classes for type conversion
-    private static Integer toInteger(Object value) {
-        if (value == null) {
-            return null;
-        }
-        if (value instanceof Number n) {
-            return n.intValue();
-        }
-        return Integer.parseInt(value.toString());
-    }
-
     private static List<Integer> toIntegerList(Object value) {
         if (value instanceof List<?> list) {
-            return list.stream().map(AbstractJdbcRepository::toInteger).toList();
+            return list.stream().map(TypeConverter::toInteger).toList();
         }
-        return List.of(toInteger(value));
+        return List.of(TypeConverter.toInteger(value));
     }
 
     Condition applyDateCondition(OffsetDateTime dateTime, QueryFilter.Op operation, String fieldName) {

--- a/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcServiceInstanceRepository.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcServiceInstanceRepository.java
@@ -3,7 +3,6 @@ package io.kestra.jdbc.repository;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.ZonedDateTime;
-import java.time.format.DateTimeParseException;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -23,6 +22,7 @@ import org.jooq.SelectConditionStep;
 import org.jooq.Table;
 import org.jooq.impl.DSL;
 
+import io.kestra.core.exceptions.TypeConversionException;
 import io.kestra.core.models.QueryFilter;
 import io.kestra.core.repositories.ArrayListTotal;
 import io.kestra.core.repositories.ServiceInstanceRepositoryInterface;
@@ -32,6 +32,7 @@ import io.kestra.core.server.ServiceInstance;
 import io.kestra.core.server.ServiceLivenessStore;
 import io.kestra.core.server.ServiceStateTransition;
 import io.kestra.core.server.ServiceType;
+import io.kestra.core.utils.TypeConverter;
 import io.kestra.jdbc.runner.JdbcTransactionContext;
 
 import io.micronaut.data.model.Pageable;
@@ -279,10 +280,10 @@ public abstract class AbstractJdbcServiceInstanceRepository extends AbstractJdbc
         // Accept ISO-8601 durations (e.g. PT5M) as a "now minus duration" threshold;
         // the supplied operation is applied against that threshold.
         try {
-            Duration duration = value instanceof Duration d ? d : Duration.parse(value.toString());
+            Duration duration = TypeConverter.toDuration(value);
             ZonedDateTime threshold = ZonedDateTime.now().minus(duration);
             return applyDateCondition(threshold.toOffsetDateTime(), operation, column);
-        } catch (DateTimeParseException ignored) {
+        } catch (TypeConversionException ignored) {
             // Not a duration — fall through to absolute date parsing
         }
         return super.createdCondition(value, operation, column);

--- a/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcTriggerRepository.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcTriggerRepository.java
@@ -3,7 +3,6 @@ package io.kestra.jdbc.repository;
 import java.time.Duration;
 import java.time.OffsetDateTime;
 import java.time.ZonedDateTime;
-import java.time.format.DateTimeParseException;
 import java.util.*;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -13,6 +12,7 @@ import org.jooq.Record;
 import org.jooq.impl.DSL;
 
 import io.kestra.core.exceptions.InvalidQueryFiltersException;
+import io.kestra.core.exceptions.TypeConversionException;
 import io.kestra.core.models.QueryFilter;
 import io.kestra.core.models.QueryFilter.Resource;
 import io.kestra.core.models.dashboards.ColumnDescriptor;
@@ -26,6 +26,7 @@ import io.kestra.core.scheduler.model.TriggerState;
 import io.kestra.core.scheduler.store.TriggerStateStore;
 import io.kestra.core.utils.DateUtils;
 import io.kestra.core.utils.ListUtils;
+import io.kestra.core.utils.TypeConverter;
 import io.kestra.jdbc.services.JdbcFilterService;
 import io.kestra.plugin.core.dashboard.data.ITriggers;
 import io.kestra.plugin.core.dashboard.data.Triggers;
@@ -344,7 +345,7 @@ public abstract class AbstractJdbcTriggerRepository extends AbstractJdbcCrudRepo
 
     @Override
     protected Condition lockedCondition(Object value, QueryFilter.Op operation) {
-        boolean lockedValue = value instanceof Boolean b ? b : Boolean.parseBoolean(value.toString());
+        boolean lockedValue = TypeConverter.toBoolean(value);
         return switch (operation) {
             case EQUALS -> DSL.field(DSL.quotedName("locked")).eq(lockedValue);
             default -> throw new InvalidQueryFiltersException("Unsupported operation for LOCKED: " + operation);
@@ -364,18 +365,16 @@ public abstract class AbstractJdbcTriggerRepository extends AbstractJdbcCrudRepo
     private Condition triggerDateFieldCondition(Object value, QueryFilter.Op operation, String column, QueryFilter.Field field) {
         // Accept ISO-8601 durations (e.g. PT24H) as "last N hours" — same semantics as TIME_RANGE
         try {
-            Duration duration = value instanceof Duration d ? d : Duration.parse(value.toString());
+            Duration duration = TypeConverter.toDuration(value);
             ZonedDateTime threshold = ZonedDateTime.now().minus(duration);
             return applyDateCondition(threshold.toOffsetDateTime(), QueryFilter.Op.GREATER_THAN_OR_EQUAL_TO, column);
-        } catch (DateTimeParseException ignored) {
+        } catch (TypeConversionException ignored) {
             // Not a duration — fall through to absolute date parsing
         }
         try {
-            OffsetDateTime dateTime = (value instanceof ZonedDateTime zdt)
-                ? zdt.toOffsetDateTime()
-                : ZonedDateTime.parse(value.toString()).toOffsetDateTime();
+            OffsetDateTime dateTime = TypeConverter.toZonedDateTime(value).toOffsetDateTime();
             return applyDateCondition(dateTime, operation, column);
-        } catch (DateTimeParseException e) {
+        } catch (TypeConversionException e) {
             throw new InvalidQueryFiltersException("Invalid date or duration value for " + field + ": " + value);
         }
     }

--- a/scheduler/src/main/java/io/kestra/scheduler/TriggerScheduler.java
+++ b/scheduler/src/main/java/io/kestra/scheduler/TriggerScheduler.java
@@ -50,6 +50,7 @@ import io.kestra.core.services.PluginDefaultService;
 import io.kestra.core.utils.IdUtils;
 import io.kestra.core.utils.Logs;
 import io.kestra.core.utils.TruthUtils;
+import io.kestra.core.utils.TypeConverter;
 import io.kestra.scheduler.internals.DefaultSchedulableTriggerFetcher;
 import io.kestra.scheduler.internals.NextEvaluationDate;
 import io.kestra.scheduler.internals.SchedulableEvaluator;
@@ -445,7 +446,7 @@ public class TriggerScheduler {
         ) {
             Object nextVariable = evaluationResult.trigger().getVariables().get("next");
 
-            ZonedDateTime next = (nextVariable != null) ? ZonedDateTime.parse((CharSequence) nextVariable) : null;
+            ZonedDateTime next = TypeConverter.toZonedDateTime(nextVariable);
 
             // Exclude backfills
             // FIXME : "late" are not excluded and can increase delay value (false positive)

--- a/webserver/src/main/java/io/kestra/webserver/controllers/api/KVController.java
+++ b/webserver/src/main/java/io/kestra/webserver/controllers/api/KVController.java
@@ -17,6 +17,7 @@ import io.kestra.core.serializers.JacksonMapper;
 import io.kestra.core.services.KVStoreService;
 import io.kestra.core.storages.kv.*;
 import io.kestra.core.tenant.TenantService;
+import io.kestra.core.utils.TypeConverter;
 import io.kestra.webserver.converters.QueryFilterFormat;
 import io.kestra.webserver.responses.PagedResults;
 import io.kestra.webserver.utils.PageableUtils;
@@ -129,7 +130,7 @@ public class KVController {
         @RequestBody(description = "The value of the key") @Body String value) throws IOException {
         String description = httpHeaders.get("description");
         String ttl = httpHeaders.get("ttl");
-        KVMetadata metadata = new KVMetadata(description, ttl == null ? null : Duration.parse(ttl));
+        KVMetadata metadata = new KVMetadata(description, TypeConverter.toDuration(ttl));
         try {
             // use ION mapper to properly handle timestamp
             JsonNode jsonNode = JacksonMapper.ofIon().readTree(value);

--- a/webserver/src/main/java/io/kestra/webserver/services/SearchableFactory.java
+++ b/webserver/src/main/java/io/kestra/webserver/services/SearchableFactory.java
@@ -1,7 +1,6 @@
 package io.kestra.webserver.services;
 
 import java.time.Instant;
-import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Stream;
@@ -17,6 +16,7 @@ import io.kestra.core.models.flows.FlowScope;
 import io.kestra.core.models.namespaces.Namespace;
 import io.kestra.core.runners.FollowLogEvent;
 import io.kestra.core.services.FollowLogEventMatcher;
+import io.kestra.core.utils.TypeConverter;
 import io.kestra.webserver.utils.Searchable;
 
 import io.micronaut.context.annotation.Factory;
@@ -257,9 +257,9 @@ public class SearchableFactory {
         if (event.timestamp() == null) {
             return -1;
         }
-        Instant target = queryValue instanceof Instant i ? i
-            : queryValue instanceof ZonedDateTime zdt ? zdt.toInstant()
-                : ZonedDateTime.parse(queryValue.toString()).toInstant();
+        Instant target = queryValue instanceof Instant i
+            ? i
+            : TypeConverter.toZonedDateTime(queryValue).toInstant();
         return event.timestamp().compareTo(target);
     }
 

--- a/webserver/src/main/java/io/kestra/webserver/utils/RequestUtils.java
+++ b/webserver/src/main/java/io/kestra/webserver/utils/RequestUtils.java
@@ -5,6 +5,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import io.kestra.core.models.flows.FlowScope;
+import io.kestra.core.utils.TypeConverter;
 
 import io.micronaut.http.HttpStatus;
 import io.micronaut.http.exceptions.HttpStatusException;
@@ -58,7 +59,7 @@ public class RequestUtils {
             .map(valueStr ->
             {
                 try {
-                    return FlowScope.valueOf(valueStr.toUpperCase());
+                    return TypeConverter.toEnum(valueStr, FlowScope.class);
                 } catch (IllegalArgumentException e) {
                     throw new IllegalArgumentException("Invalid FlowScope value: " + valueStr, e);
                 }

--- a/webserver/src/main/java/io/kestra/webserver/utils/TimeLineSearch.java
+++ b/webserver/src/main/java/io/kestra/webserver/utils/TimeLineSearch.java
@@ -2,10 +2,10 @@ package io.kestra.webserver.utils;
 
 import java.time.Duration;
 import java.time.ZonedDateTime;
-import java.time.format.DateTimeParseException;
 import java.util.List;
 
 import io.kestra.core.models.QueryFilter;
+import io.kestra.core.utils.TypeConverter;
 
 import lombok.Builder;
 import lombok.Data;
@@ -37,9 +37,9 @@ public class TimeLineSearch {
                 continue;
             }
             switch (filter.field()) {
-                case START_DATE -> startDate = ZonedDateTime.parse(filter.value().toString());
-                case END_DATE -> endDate = ZonedDateTime.parse(filter.value().toString());
-                case TIME_RANGE -> timeRange = parseDuration(filter.value().toString());
+                case START_DATE -> startDate = TypeConverter.toZonedDateTime(filter.value());
+                case END_DATE -> endDate = TypeConverter.toZonedDateTime(filter.value());
+                case TIME_RANGE -> timeRange = TypeConverter.toDuration(filter.value());
             }
         }
 
@@ -57,14 +57,6 @@ public class TimeLineSearch {
         }
 
         return new TimeLineSearch(startDate, endDate, timeRange);
-    }
-
-    private static Duration parseDuration(String duration) {
-        try {
-            return Duration.parse(duration);
-        } catch (DateTimeParseException e) {
-            throw new IllegalArgumentException("Invalid duration: " + duration);
-        }
     }
 
 }

--- a/webserver/src/test/java/io/kestra/webserver/utils/TimeLineSearchTest.java
+++ b/webserver/src/test/java/io/kestra/webserver/utils/TimeLineSearchTest.java
@@ -104,7 +104,7 @@ class TimeLineSearchTest {
         // WHEN
         Exception exception = assertThrows(IllegalArgumentException.class, () -> TimeLineSearch.extractFrom(filters));
         // THEN
-        assertThat(exception.getMessage()).contains("Invalid duration");
+        assertThat(exception.getMessage()).contains("Cannot convert value 'invalid-duration' to Duration");
     }
 
     @Test


### PR DESCRIPTION
Consolidates duplicated ad-hoc parsing (boolean/number/date/duration/enum/
list) into io.kestra.core.utils.TypeConverter: null-safe, passthrough when
already typed, strict toString() parse otherwise. Failures throw
TypeConversionException, which extends IllegalArgumentException on purpose
so the existing HTTP 400 mapping and repository filter wrapping apply as-is.

Migrated call sites: flow input parsing, KV, JDBC/webserver filter coercion,
purge/version tasks, scheduler, CLI. Conversion errors now surface as
consistent 400s instead of raw parse exceptions (500) on some paths.

Part-of: https://github.com/kestra-io/kestra-ee/pull/9216