### PR TITLE
fix(namespaces): surface authorization errors when uploading namespace files

### DIFF
--- a/ui/src/stores/fileExplorer.ts
+++ b/ui/src/stores/fileExplorer.ts
@@ -347,7 +347,7 @@ export const useFileExplorerStore = defineStore("fileExplorer", () => {
                 const fileName = pathParts[pathParts.length - 1];
                 const [name, extension] = getFileNameWithExtension(fileName);
                 const content = await readFile(file);
-                namespacesStore.importFileDirectory({
+                await namespacesStore.importFileDirectory({
                     namespace: namespaceId.value,
                     content,
                     path: `${folderPath}/${fileName}`,
@@ -362,12 +362,12 @@ export const useFileExplorerStore = defineStore("fileExplorer", () => {
             } else {
                 const content = await readFile(file);
                 const [name, extension] = getFileNameWithExtension(file.name);
-                namespacesStore.importFileDirectory({
+                await namespacesStore.importFileDirectory({
                     namespace: namespaceId.value,
                     content,
                     path: file.name,
                 });
-                
+
                 fileTree.value.push({
                     id: Utils.uid(),
                     fileName: `${name}${extension ? `.${extension}` : ""}`,


### PR DESCRIPTION
### What this fixes

Reported in kestra-ee#9205: a user with **read-only** access to Namespaces (and Flows) is blocked from *creating* a namespace file (correct), but *uploading* a file appears to succeed.

### Root cause

Both "create" and "upload" hit the exact same backend endpoint (`POST /namespaces/{namespace}/files`), guarded by the same permission, so the backend correctly rejects **both** for a read-only user — the upload is **not** actually written to storage.

The discrepancy is purely client-side, in `importFiles` (`ui/src/stores/fileExplorer.ts`):

- **Create** (`saveOrCreateFile`) is `await`ed, so a rejection propagates (the global error handler surfaces the unauthorized toast) and the optimistic tree push is skipped.
- **Upload** (`importFileDirectory`) was **fire-and-forget** — not awaited, no error handling — and the file node was pushed into the tree **unconditionally**. So the rejected request was silently swallowed and the file *appeared* uploaded (it would vanish on refresh).

### The fix

`await` the `importFileDirectory` calls so a failed upload propagates the error (surfacing the authorization toast) and the optimistic tree update is skipped — mirroring the create-file path.

### Notes

- Not a privilege escalation: no file was ever written server-side; this only corrects the misleading UI + swallowed error.
- The same fire-and-forget pattern exists on `develop`; a matching change should be applied there (this PR targets `releases/v1.3.x` per the reported version v1.3.26).

Closes https://github.com/kestra-io/kestra-ee/issues/9205.