### PR TITLE
build: run backend check serially with --rerun-tasks (CI experiment — do not merge)

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -115,19 +115,67 @@ jobs:
     secrets:
       GITHUB_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+  # EXPERIMENT (do not merge): inlined from
+  # kestra-io/actions/.github/workflows/kestra-oss-backend-tests.yml@main to run the
+  # Gradle check serially with every task forced to re-run.
+  # - `needs`/`if` on file-changes are intentionally dropped: the backend filter
+  #   excludes `.github/**`, so this workflow-only PR would otherwise skip the job.
+  # - `--no-parallel` is required on top of dropping `--parallel`: gradle.properties
+  #   sets `org.gradle.parallel=true`, which would silently re-enable parallelism.
+  # - `--rerun-tasks` defeats up-to-date checks and the build cache so all tests run.
   backend:
     name: Backend - Tests
-    needs: file-changes
-    if: "needs.file-changes.outputs.backend == 'true'"
-    uses: kestra-io/actions/.github/workflows/kestra-oss-backend-tests.yml@main
-    secrets:
-      GITHUB_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-      SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 300
+    permissions:
+      contents: write
+      checks: write
+      actions: read
+      pull-requests: write
+    env:
       GOOGLE_SERVICE_ACCOUNT: ${{ secrets.GOOGLE_SERVICE_ACCOUNT }}
+      SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
       DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
-    with:
-      java-version: 25
+    steps:
+      - uses: actions/checkout@v5
+        name: Checkout - Current ref
+        with:
+          fetch-depth: 0
+
+      - uses: kestra-io/actions/composite/setup-build@main
+        name: Setup - Build
+        with:
+          java-enabled: true
+          node-enabled: true
+          python-enabled: true
+          java-version: 25
+
+      - name: Setup - Start docker compose
+        shell: bash
+        run: docker compose -f docker-compose-ci.yml up -d
+
+      - name: Gradle - check (serial, rerun all tasks)
+        shell: bash
+        run: |
+          ./gradlew check --rerun-tasks --no-parallel
+
+      - name: comment PR with test report
+        if: ${{ !cancelled() }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: npx --yes @kestra-io/kestra-devtools generateTestReportSummary --only-errors --ci $(pwd)
+
+      - name: generate test report in logs and fail if any failed tests
+        if: ${{ !cancelled() }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: npx --yes @kestra-io/kestra-devtools generateTestReportSummary --only-errors --fail-on-error $(pwd)
+
+      - name: Report - Java
+        uses: kestra-io/actions/composite/report-java@main
+        if: ${{ !cancelled() }}
+        with:
+          secrets: ${{ toJSON(secrets) }}
 
   e2e-tests:
     name: E2E - Tests

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -116,13 +116,11 @@ jobs:
       GITHUB_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   # EXPERIMENT (do not merge): inlined from
-  # kestra-io/actions/.github/workflows/kestra-oss-backend-tests.yml@main to run the
-  # Gradle check serially with every task forced to re-run.
+  # kestra-io/actions/.github/workflows/kestra-oss-backend-tests.yml@main.
+  # Phase 2: the usual parallel setup, still with `--rerun-tasks` so the workload is
+  # identical to the serial phase-1 run (all tests execute, nothing from cache).
   # - `needs`/`if` on file-changes are intentionally dropped: the backend filter
   #   excludes `.github/**`, so this workflow-only PR would otherwise skip the job.
-  # - `--no-parallel` is required on top of dropping `--parallel`: gradle.properties
-  #   sets `org.gradle.parallel=true`, which would silently re-enable parallelism.
-  # - `--rerun-tasks` defeats up-to-date checks and the build cache so all tests run.
   backend:
     name: Backend - Tests
     runs-on: ubuntu-latest
@@ -154,10 +152,10 @@ jobs:
         shell: bash
         run: docker compose -f docker-compose-ci.yml up -d
 
-      - name: Gradle - check (serial, rerun all tasks)
+      - name: Gradle - check (parallel, rerun all tasks)
         shell: bash
         run: |
-          ./gradlew check --rerun-tasks --no-parallel
+          ./gradlew check --rerun-tasks --parallel
 
       - name: comment PR with test report
         if: ${{ !cancelled() }}


### PR DESCRIPTION
## ⚠️ CI experiment — do not merge

Overrides the `backend` job (normally the reusable `kestra-oss-backend-tests.yml`) with an inline copy whose Gradle step runs:

```bash
./gradlew check --rerun-tasks --no-parallel
```

instead of `./gradlew check javadoc --parallel`, to observe how the test suite behaves with **zero Gradle parallelism** and **every test forced to run**.

### Notes
- `--no-parallel` is needed on top of dropping `--parallel`: `gradle.properties` sets `org.gradle.parallel=true`, so the plain command would still parallelize.
- `--rerun-tasks` defeats up-to-date checks and the build cache, so no test task can be skipped.
- The `file-changes` gate is dropped for this job because the backend paths-filter excludes `.github/**` — this PR would otherwise skip the backend job entirely.
- `timeout-minutes` raised 90 → 300 since the serial run will be much slower.

Companion EE PR: kestra-io/kestra-ee#9215 (the EE branch was pushed first, so the `trigger-ee` dispatch here is skipped in favor of the EE PR's own CI).