### PR TITLE
feat(core): census input types by name in the anonymous usage report

### DIFF
--- a/core/src/main/java/io/kestra/core/models/collectors/FlowUsage.java
+++ b/core/src/main/java/io/kestra/core/models/collectors/FlowUsage.java
@@ -4,8 +4,11 @@ import java.lang.reflect.InvocationTargetException;
 import java.util.*;
 import java.util.concurrent.atomic.LongAdder;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import io.kestra.core.models.flows.Flow;
+import io.kestra.core.models.flows.Input;
+import io.kestra.core.models.flows.input.FormInput;
 import io.kestra.core.models.tasks.FlowableTask;
 import io.kestra.core.models.tasks.Task;
 import io.kestra.core.models.tasks.runners.TaskRunner;
@@ -18,7 +21,7 @@ import lombok.Getter;
 import lombok.experimental.SuperBuilder;
 import lombok.extern.jackson.Jacksonized;
 
-@SuperBuilder
+@SuperBuilder(toBuilder = true)
 @Getter
 @Jacksonized
 public class FlowUsage {
@@ -31,6 +34,7 @@ public class FlowUsage {
     private final Map<String, Long> taskTypeCount;
     private final Map<String, Long> triggerTypeCount;
     private final Map<String, Long> taskRunnerTypeCount;
+    private final Map<String, Long> inputTypeCount;
     private final Long hasInputsCount;
     private final Long hasOutputsCount;
     private final Long hasLabelsCount;
@@ -66,6 +70,9 @@ public class FlowUsage {
             .toList();
         List<AbstractTrigger> allTriggers = filtered.stream()
             .flatMap(flow -> ListUtils.emptyOnNull(flow.getTriggers()).stream())
+            .toList();
+        List<Input<?>> allInputs = filtered.stream()
+            .flatMap(flow -> ListUtils.emptyOnNull(flow.getInputs()).stream())
             .toList();
 
         LongAdder count = new LongAdder();
@@ -139,6 +146,7 @@ public class FlowUsage {
             .taskTypeCount(taskTypeCount(allTasks))
             .triggerTypeCount(triggerTypeCount(allTriggers))
             .taskRunnerTypeCount(taskRunnerTypeCount(allTasks))
+            .inputTypeCount(inputTypeCount(allInputs))
             .hasInputsCount(hasInputsCount.longValue())
             .hasOutputsCount(hasOutputsCount.longValue())
             .hasLabelsCount(hasLabelsCount.longValue())
@@ -177,6 +185,22 @@ public class FlowUsage {
         return allTriggers
             .stream()
             .collect(Collectors.groupingBy(f -> f.getType(), Collectors.counting()));
+    }
+
+    /**
+     * Groups {@code inputs} by {@link Input#getType()}, recursing into {@link FormInput#getInputs()}.
+     * Public so EE can reuse it for reusable-inputs block definitions (see {@code FeatureUsageReport}).
+     */
+    public static Map<String, Long> inputTypeCount(List<Input<?>> inputs) {
+        if (ListUtils.isEmpty(inputs)) {
+            return Map.of();
+        }
+
+        return inputs.stream()
+            .flatMap(input -> input instanceof FormInput form
+                ? Stream.concat(Stream.of(input.getType().name()), ListUtils.emptyOnNull(form.getInputs()).stream().map(i -> i.getType().name()))
+                : Stream.of(input.getType().name()))
+            .collect(Collectors.groupingBy(t -> t, Collectors.counting()));
     }
 
     private static Map<String, Long> taskRunnerTypeCount(List<Task> allTask) {

--- a/core/src/test/java/io/kestra/core/models/collectors/FlowUsageTest.java
+++ b/core/src/test/java/io/kestra/core/models/collectors/FlowUsageTest.java
@@ -1,0 +1,80 @@
+package io.kestra.core.models.collectors;
+
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import io.kestra.core.models.flows.Flow;
+import io.kestra.core.models.flows.Input;
+import io.kestra.core.models.flows.Type;
+import io.kestra.core.models.flows.input.BoolInput;
+import io.kestra.core.models.flows.input.FormInput;
+import io.kestra.core.models.flows.input.IntInput;
+import io.kestra.core.models.flows.input.ReusableInputsInput;
+import io.kestra.core.models.flows.input.StringInput;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class FlowUsageTest {
+
+    @Test
+    void shouldCountInputTypesRecursingIntoFormChildren() {
+        // Given
+        List<Input<?>> inputs = List.of(
+            StringInput.builder().id("in").type(Type.STRING).build(),
+            FormInput.builder().id("form").type(Type.FORM).inputs(List.of(
+                IntInput.builder().id("count").type(Type.INT).build(),
+                BoolInput.builder().id("flag").type(Type.BOOL).build()
+            )).build(),
+            ReusableInputsInput.builder().id("ref").type(Type.REUSABLE_INPUTS).ref("infra").build()
+        );
+
+        // When
+        Map<String, Long> inputTypeCount = FlowUsage.inputTypeCount(inputs);
+
+        // Then
+        assertThat(inputTypeCount).containsEntry("STRING", 1L);
+        assertThat(inputTypeCount).containsEntry("FORM", 1L);
+        assertThat(inputTypeCount).containsEntry("INT", 1L);
+        assertThat(inputTypeCount).containsEntry("BOOL", 1L);
+        assertThat(inputTypeCount).containsEntry("REUSABLE_INPUTS", 1L);
+    }
+
+    @Test
+    void shouldReturnEmptyMapForNoInputs() {
+        assertThat(FlowUsage.inputTypeCount(null)).isEmpty();
+        assertThat(FlowUsage.inputTypeCount(List.of())).isEmpty();
+    }
+
+    @Test
+    void shouldAggregateInputTypeCountAcrossFlows() {
+        // Given
+        Flow flowA = Flow.builder()
+            .id("a")
+            .namespace("io.kestra.unittest")
+            .inputs(List.of(StringInput.builder().id("in").type(Type.STRING).build()))
+            .build();
+        Flow flowB = Flow.builder()
+            .id("b")
+            .namespace("io.kestra.unittest")
+            .inputs(List.of(
+                StringInput.builder().id("in").type(Type.STRING).build(),
+                ReusableInputsInput.builder().id("ref").type(Type.REUSABLE_INPUTS).ref("infra").build()
+            ))
+            .build();
+        // excluded from the census: the 'tutorial' namespace is filtered out by FlowUsage.of(...)
+        Flow tutorialFlow = Flow.builder()
+            .id("c")
+            .namespace("tutorial")
+            .inputs(List.of(ReusableInputsInput.builder().id("ref").type(Type.REUSABLE_INPUTS).ref("infra").build()))
+            .build();
+
+        // When
+        FlowUsage flowUsage = FlowUsage.of(List.of(flowA, flowB, tutorialFlow));
+
+        // Then
+        assertThat(flowUsage.getInputTypeCount()).containsEntry("STRING", 2L);
+        assertThat(flowUsage.getInputTypeCount()).containsEntry("REUSABLE_INPUTS", 1L);
+    }
+}

--- a/core/src/test/java/io/kestra/core/reporter/reports/AbstractFeatureUsageReportTest.java
+++ b/core/src/test/java/io/kestra/core/reporter/reports/AbstractFeatureUsageReportTest.java
@@ -18,6 +18,8 @@ import io.kestra.core.models.flows.Output;
 import io.kestra.core.models.flows.State;
 import io.kestra.core.models.flows.Type;
 import io.kestra.core.models.flows.check.Check;
+import io.kestra.core.models.flows.input.FormInput;
+import io.kestra.core.models.flows.input.IntInput;
 import io.kestra.core.models.flows.input.StringInput;
 import io.kestra.core.models.flows.quota.Quota;
 import io.kestra.core.models.flows.sla.SLA;
@@ -80,7 +82,12 @@ public abstract class AbstractFeatureUsageReportTest {
             .id(IdUtils.create())
             .namespace(namespace)
             .labels(List.of(new Label("key", "value")))
-            .inputs(List.of(StringInput.builder().id("in").type(Type.STRING).build()))
+            .inputs(List.of(
+                StringInput.builder().id("in").type(Type.STRING).build(),
+                FormInput.builder().id("form").type(Type.FORM).inputs(List.of(
+                    IntInput.builder().id("count").type(Type.INT).build()
+                )).build()
+            ))
             .outputs(List.of(Output.builder().id("out").type(Type.STRING).value("value").build()))
             .variables(Map.of("var", "value"))
             .workerSelector(new WorkerSelector(List.of("tag"), null))
@@ -172,6 +179,9 @@ public abstract class AbstractFeatureUsageReportTest {
             assertThat(after.getFlows().getHasSlaCount()).isEqualTo(before.getFlows().getHasSlaCount() + 1);
             assertThat(after.getFlows().getHasChecksCount()).isEqualTo(before.getFlows().getHasChecksCount() + 1);
             assertThat(after.getFlows().getHasQuotasCount()).isEqualTo(before.getFlows().getHasQuotasCount() + 1);
+            assertThat(after.getFlows().getInputTypeCount().getOrDefault("STRING", 0L)).isEqualTo(before.getFlows().getInputTypeCount().getOrDefault("STRING", 0L) + 1);
+            assertThat(after.getFlows().getInputTypeCount().getOrDefault("FORM", 0L)).isEqualTo(before.getFlows().getInputTypeCount().getOrDefault("FORM", 0L) + 1);
+            assertThat(after.getFlows().getInputTypeCount().getOrDefault("INT", 0L)).isEqualTo(before.getFlows().getInputTypeCount().getOrDefault("INT", 0L) + 1);
 
             assertThat(after.getFlows().getTasks().getHasRetryCount()).isEqualTo(before.getFlows().getTasks().getHasRetryCount() + 1);
             assertThat(after.getFlows().getTasks().getHasTimeoutCount()).isEqualTo(before.getFlows().getTasks().getHasTimeoutCount() + 1);


### PR DESCRIPTION
- Add `inputTypeCount` to `FlowUsage`, grouping every flow's authored inputs by type (recursing into FORM children), mirroring `taskTypeCount`/`triggerTypeCount`.
- Gives visibility into adoption of newer input types (FORM, REUSABLE_INPUTS).