### PR TITLE
feat(execution): Execution statistics

### DIFF
--- a/core/src/main/java/io/kestra/core/metrics/MetricRegistry.java
+++ b/core/src/main/java/io/kestra/core/metrics/MetricRegistry.java
@@ -214,6 +214,9 @@ public class MetricRegistry {
     public static final String METRIC_JDBC_QUERY_DURATION = "jdbc.query.duration";
     public static final String METRIC_JDBC_QUERY_DURATION_DESCRIPTION = "Duration of database queries";
 
+    public static final String METRIC_JDBC_EXECUTION_STATISTICS_COMPACTOR_DURATION = "jdbc.execution-statistics.compactor.duration";
+    public static final String METRIC_JDBC_EXECUTION_STATISTICS_COMPACTOR_DURATION_DESCRIPTION = "Duration of a single execution statistics compaction run";
+
     public static final String METRIC_QUEUE_MESSAGE_BIG_TOTAL = "queue.message.big.total";
     public static final String METRIC_QUEUE_MESSAGE_BIG_TOTAL_DESCRIPTION = "Total number of big messages";
     public static final String METRIC_QUEUE_MESSAGE_EMITTED_TOTAL = "queue.message.emitted.total";

--- a/core/src/main/java/io/kestra/core/models/executions/statistics/DailyExecutionStatistics.java
+++ b/core/src/main/java/io/kestra/core/models/executions/statistics/DailyExecutionStatistics.java
@@ -23,6 +23,8 @@ public class DailyExecutionStatistics {
     @NotNull
     private Duration duration;
 
+    private Duration taskRunsDuration;
+
     @Builder.Default
     @JsonInclude
     private Map<State.Type, Long> executionCounts = new HashMap<>(

--- a/core/src/main/java/io/kestra/core/models/executions/statistics/ExecutionStatistic.java
+++ b/core/src/main/java/io/kestra/core/models/executions/statistics/ExecutionStatistic.java
@@ -1,0 +1,95 @@
+package io.kestra.core.models.executions.statistics;
+
+import java.time.Instant;
+
+import io.kestra.core.models.HasUID;
+import io.kestra.core.models.executions.Execution;
+import io.kestra.core.models.flows.State;
+import io.kestra.core.queues.event.DispatchEvent;
+import io.kestra.core.utils.IdUtils;
+import io.kestra.core.utils.ListUtils;
+
+import jakarta.annotation.Nullable;
+
+/**
+ * A lightweight execution-statistic row, emitted asynchronously by the executor on execution
+ * termination and consumed by the indexer.
+ * <p>
+ * Two flavors share this same shape so that reading a range of buckets is a uniform aggregation
+ * regardless of whether the periodic compaction job has already run on a given bucket:
+ * <ul>
+ * <li><b>Raw row</b>: emitted directly for a terminated execution, {@code count = 1},
+ * {@code executionId} set. Its {@link #uid()} is the execution id, which makes ingestion
+ * idempotent under at-least-once queue delivery: a redelivered record overwrites the same row
+ * instead of being double-counted.</li>
+ * <li><b>Aggregate row</b>: written by the periodic compaction job by merging the raw rows of a
+ * closed minute bucket, {@code count = N}, {@code executionId} is {@code null}. Its
+ * {@link #uid()} is a deterministic hash of the bucket key so re-compaction overwrites the same
+ * row instead of creating duplicates.</li>
+ * </ul>
+ */
+public record ExecutionStatistic(
+    String tenantId,
+    String namespace,
+    String flowId,
+    Instant date,
+    State.Type state,
+    long count,
+    long durationSumMs,
+    long durationMinMs,
+    long durationMaxMs,
+    long taskRunCount,
+    long taskRunsDurationSumMs,
+    // Nullable (unlike durationMinMs/MaxMs, which always have a value): an execution can have zero
+    // task runs, in which case there is no task-run duration to report, not a zero one.
+    @Nullable Long taskRunsDurationMinMs,
+    @Nullable Long taskRunsDurationMaxMs,
+    @Nullable String executionId) implements HasUID, DispatchEvent {
+    /**
+     * Builds a raw statistic row ({@code count = 1}) for a terminated execution.
+     *
+     * @param execution the terminated execution.
+     * @param bucket the minute bucket this execution is recorded under (the executor buckets by
+     *        the execution's end date, falling back to the current time if not yet set).
+     */
+    public ExecutionStatistic(Execution execution, Instant bucket) {
+        this(
+            execution.getTenantId(),
+            execution.getNamespace(),
+            execution.getFlowId(),
+            bucket,
+            execution.getState().getCurrent(),
+            1,
+            execution.getState().getDurationOrComputeIt().toMillis(),
+            execution.getState().getDurationOrComputeIt().toMillis(),
+            execution.getState().getDurationOrComputeIt().toMillis(),
+            ListUtils.emptyOnNull(execution.getTaskRunList()).size(),
+            ListUtils.emptyOnNull(execution.getTaskRunList()).stream()
+                .mapToLong(taskRun -> taskRun.getState().getDurationOrComputeIt().toMillis())
+                .sum(),
+            ListUtils.emptyOnNull(execution.getTaskRunList()).stream()
+                .mapToLong(taskRun -> taskRun.getState().getDurationOrComputeIt().toMillis())
+                .min()
+                .stream().boxed().findFirst().orElse(null),
+            ListUtils.emptyOnNull(execution.getTaskRunList()).stream()
+                .mapToLong(taskRun -> taskRun.getState().getDurationOrComputeIt().toMillis())
+                .max()
+                .stream().boxed().findFirst().orElse(null),
+            execution.getId()
+        );
+    }
+
+    /** {@inheritDoc} **/
+    @Override
+    public String uid() {
+        return executionId != null
+            ? executionId
+            : IdUtils.from(IdUtils.fromParts(tenantId, namespace, flowId, date.toString(), state.name()));
+    }
+
+    /** {@inheritDoc} **/
+    @Override
+    public String key() {
+        return uid();
+    }
+}

--- a/core/src/main/java/io/kestra/core/repositories/ExecutionStatisticsRepositoryInterface.java
+++ b/core/src/main/java/io/kestra/core/repositories/ExecutionStatisticsRepositoryInterface.java
@@ -1,0 +1,43 @@
+package io.kestra.core.repositories;
+
+import java.time.Instant;
+import java.util.List;
+
+import io.kestra.core.models.executions.statistics.DailyExecutionStatistics;
+import io.kestra.core.models.executions.statistics.ExecutionStatistic;
+import io.kestra.core.runners.IndexingRepository;
+import io.kestra.core.utils.DateUtils;
+
+import io.micronaut.core.annotation.Nullable;
+
+/**
+ * Repository for the pre-aggregated execution-statistics table (see {@link ExecutionStatistic}).
+ * <p>
+ * Only {@link IndexingRepository#saveBatch} is used by the indexer to persist incoming raw rows.
+ * {@link #statistics} exposes the aggregated read path that consumers (dashboards, SLA tracking,
+ * execution progress) should use instead of querying the {@code executions} table directly.
+ */
+public interface ExecutionStatisticsRepositoryInterface extends IndexingRepository<ExecutionStatistic> {
+    /**
+     * Aggregates execution statistics over a date range, bucketed by {@code groupBy}.
+     * <p>
+     * Transparently sums both raw rows (not yet compacted) and already-compacted aggregate rows
+     * of the same bucket, so results are correct regardless of whether the periodic compaction job
+     * has already processed that bucket.
+     *
+     * @param tenantId the tenant id.
+     * @param namespace an optional namespace filter.
+     * @param flowId an optional flow id filter (requires {@code namespace} to be set).
+     * @param startDate the inclusive range start.
+     * @param endDate the inclusive range end.
+     * @param groupBy the bucket size to group results by.
+     * @return one {@link DailyExecutionStatistics} entry per bucket in the range.
+     */
+    List<DailyExecutionStatistics> statistics(
+        String tenantId,
+        @Nullable String namespace,
+        @Nullable String flowId,
+        Instant startDate,
+        Instant endDate,
+        DateUtils.GroupType groupBy);
+}

--- a/core/src/main/java/io/kestra/plugin/core/preview/TextFileRenderer.java
+++ b/core/src/main/java/io/kestra/plugin/core/preview/TextFileRenderer.java
@@ -7,6 +7,7 @@ import java.io.InputStreamReader;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.Optional;
+
 import io.kestra.core.models.annotations.Plugin;
 import io.kestra.core.preview.FilePreview;
 import io.kestra.core.preview.FileRenderer;

--- a/core/src/test/java/io/kestra/core/repositories/AbstractExecutionStatisticsRepositoryTest.java
+++ b/core/src/test/java/io/kestra/core/repositories/AbstractExecutionStatisticsRepositoryTest.java
@@ -1,0 +1,187 @@
+package io.kestra.core.repositories;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import com.devskiller.friendly_id.FriendlyId;
+
+import io.kestra.core.models.executions.statistics.DailyExecutionStatistics;
+import io.kestra.core.models.executions.statistics.ExecutionStatistic;
+import io.kestra.core.models.flows.State;
+import io.kestra.core.utils.DateUtils;
+import io.kestra.core.utils.TestsUtils;
+
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import jakarta.inject.Inject;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@MicronautTest
+public abstract class AbstractExecutionStatisticsRepositoryTest {
+    @Inject
+    protected ExecutionStatisticsRepositoryInterface executionStatisticsRepository;
+
+    /**
+     * Hook for Elasticsearch impl to be able to refresh the index before querying
+     */
+    protected void refresh() {
+    }
+
+    @Test
+    void shouldBeIdempotentOnRedelivery() {
+        // Given: the same raw row (same executionId) delivered twice, simulating an
+        // at-least-once queue redelivery
+        String tenant = TestsUtils.randomTenant(this.getClass().getSimpleName());
+        Instant bucket = Instant.now().truncatedTo(ChronoUnit.MINUTES);
+        String executionId = FriendlyId.createFriendlyId();
+        ExecutionStatistic raw = raw(tenant, "namespace", "flow", bucket, State.Type.SUCCESS, executionId, 1000);
+
+        // When
+        executionStatisticsRepository.save(raw);
+        executionStatisticsRepository.save(raw);
+
+        // Then: redelivery overwrote the same row instead of being double-counted
+        DailyExecutionStatistics stats = statisticsFor(tenant, "namespace", "flow", bucket);
+        assertThat(stats.getExecutionCounts().get(State.Type.SUCCESS)).isEqualTo(1L);
+        assertThat(stats.getDuration().getSum().toMillis()).isEqualTo(1000L);
+    }
+
+    @Test
+    void shouldSumMultipleRawRowsInTheSameBucket() {
+        // Given
+        String tenant = TestsUtils.randomTenant(this.getClass().getSimpleName());
+        Instant bucket = Instant.now().truncatedTo(ChronoUnit.MINUTES);
+
+        executionStatisticsRepository.saveBatch(
+            List.of(
+                raw(tenant, "namespace", "flow", bucket, State.Type.SUCCESS, FriendlyId.createFriendlyId(), 1000),
+                raw(tenant, "namespace", "flow", bucket, State.Type.SUCCESS, FriendlyId.createFriendlyId(), 2000),
+                raw(tenant, "namespace", "flow", bucket, State.Type.SUCCESS, FriendlyId.createFriendlyId(), 3000)
+            )
+        );
+
+        // When
+        DailyExecutionStatistics stats = statisticsFor(tenant, "namespace", "flow", bucket);
+
+        // Then
+        assertThat(stats.getExecutionCounts().get(State.Type.SUCCESS)).isEqualTo(3L);
+        assertThat(stats.getDuration().getSum().toMillis()).isEqualTo(6000L);
+        assertThat(stats.getDuration().getMin().toMillis()).isEqualTo(1000L);
+        assertThat(stats.getDuration().getMax().toMillis()).isEqualTo(3000L);
+        assertThat(stats.getDuration().getAvg().toMillis()).isEqualTo(2000L);
+        assertThat(stats.getTaskRunsDuration().getSum().toMillis()).isEqualTo(6000L);
+        assertThat(stats.getTaskRunsDuration().getMin().toMillis()).isEqualTo(1000L);
+        assertThat(stats.getTaskRunsDuration().getMax().toMillis()).isEqualTo(3000L);
+        assertThat(stats.getTaskRunsDuration().getAvg().toMillis()).isEqualTo(2000L);
+    }
+
+    @Test
+    void shouldNotLetExecutionsWithoutTaskRunsCorruptTaskRunDurationMinMax() {
+        // Given: one execution with a single 500ms task run, and one that never ran any task
+        // (e.g. failed validation before starting) so it has no task-run duration to contribute
+        String tenant = TestsUtils.randomTenant(this.getClass().getSimpleName());
+        Instant bucket = Instant.now().truncatedTo(ChronoUnit.MINUTES);
+
+        executionStatisticsRepository.saveBatch(
+            List.of(
+                raw(tenant, "namespace", "flow", bucket, State.Type.SUCCESS, FriendlyId.createFriendlyId(), 500),
+                rawWithoutTaskRuns(tenant, "namespace", "flow", bucket, State.Type.FAILED, FriendlyId.createFriendlyId(), 200)
+            )
+        );
+
+        // When
+        DailyExecutionStatistics stats = statisticsFor(tenant, "namespace", "flow", bucket);
+
+        // Then: the task-less execution must not drag the min down to 0
+        assertThat(stats.getTaskRunsDuration().getCount()).isEqualTo(1L);
+        assertThat(stats.getTaskRunsDuration().getSum().toMillis()).isEqualTo(500L);
+        assertThat(stats.getTaskRunsDuration().getMin().toMillis()).isEqualTo(500L);
+        assertThat(stats.getTaskRunsDuration().getMax().toMillis()).isEqualTo(500L);
+    }
+
+    @Test
+    void shouldReportNoTaskRunDurationWhenNoExecutionInTheBucketHadTaskRuns() {
+        // Given: every execution in the bucket failed before running any task
+        String tenant = TestsUtils.randomTenant(this.getClass().getSimpleName());
+        Instant bucket = Instant.now().truncatedTo(ChronoUnit.MINUTES);
+
+        executionStatisticsRepository.saveBatch(
+            List.of(
+                rawWithoutTaskRuns(tenant, "namespace", "flow", bucket, State.Type.FAILED, FriendlyId.createFriendlyId(), 100),
+                rawWithoutTaskRuns(tenant, "namespace", "flow", bucket, State.Type.FAILED, FriendlyId.createFriendlyId(), 200)
+            )
+        );
+
+        // When
+        DailyExecutionStatistics stats = statisticsFor(tenant, "namespace", "flow", bucket);
+
+        // Then: no task-run data point exists, so min/max must be null, not a false 0
+        assertThat(stats.getTaskRunsDuration().getCount()).isEqualTo(0L);
+        assertThat(stats.getTaskRunsDuration().getSum().toMillis()).isEqualTo(0L);
+        assertThat(stats.getTaskRunsDuration().getMin()).isNull();
+        assertThat(stats.getTaskRunsDuration().getMax()).isNull();
+    }
+
+    @Test
+    void shouldAggregateAcrossRawAndAlreadyCompactedRows() {
+        // Given: one already-compacted aggregate row (as the periodic compaction job would
+        // produce, executionId == null) plus one raw row landing late in the same bucket
+        String tenant = TestsUtils.randomTenant(this.getClass().getSimpleName());
+        Instant bucket = Instant.now().truncatedTo(ChronoUnit.MINUTES);
+
+        ExecutionStatistic compacted = new ExecutionStatistic(tenant, "namespace", "flow", bucket, State.Type.SUCCESS, 5, 5000, 500, 1500, 10, 5000, 100L, 900L, null);
+        ExecutionStatistic lateRaw = raw(tenant, "namespace", "flow", bucket, State.Type.SUCCESS, FriendlyId.createFriendlyId(), 2000);
+        executionStatisticsRepository.saveBatch(List.of(compacted, lateRaw));
+
+        // When
+        DailyExecutionStatistics stats = statisticsFor(tenant, "namespace", "flow", bucket);
+
+        // Then: the read is correct whether or not the compaction job has already processed this bucket
+        assertThat(stats.getExecutionCounts().get(State.Type.SUCCESS)).isEqualTo(6L);
+        assertThat(stats.getDuration().getSum().toMillis()).isEqualTo(7000L);
+        assertThat(stats.getDuration().getMax().toMillis()).isEqualTo(2000L);
+    }
+
+    @Test
+    void shouldScopeStatisticsToNamespaceAndFlow() {
+        // Given
+        String tenant = TestsUtils.randomTenant(this.getClass().getSimpleName());
+        Instant bucket = Instant.now().truncatedTo(ChronoUnit.MINUTES);
+
+        executionStatisticsRepository.saveBatch(
+            List.of(
+                raw(tenant, "namespace", "flow", bucket, State.Type.SUCCESS, FriendlyId.createFriendlyId(), 1000),
+                raw(tenant, "namespace", "other-flow", bucket, State.Type.SUCCESS, FriendlyId.createFriendlyId(), 1000),
+                raw(tenant, "other-namespace", "flow", bucket, State.Type.SUCCESS, FriendlyId.createFriendlyId(), 1000)
+            )
+        );
+
+        // When
+        DailyExecutionStatistics stats = statisticsFor(tenant, "namespace", "flow", bucket);
+
+        // Then
+        assertThat(stats.getExecutionCounts().get(State.Type.SUCCESS)).isEqualTo(1L);
+    }
+
+    private DailyExecutionStatistics statisticsFor(String tenant, String namespace, String flowId, Instant bucket) {
+        // refresh before querying
+        this.refresh();
+
+        List<DailyExecutionStatistics> stats = executionStatisticsRepository.statistics(
+            tenant, namespace, flowId, bucket, bucket, DateUtils.GroupType.MINUTE
+        );
+        assertThat(stats).hasSize(1);
+        return stats.getFirst();
+    }
+
+    private ExecutionStatistic raw(String tenant, String namespace, String flowId, Instant bucket, State.Type state, String executionId, long durationMs) {
+        return new ExecutionStatistic(tenant, namespace, flowId, bucket, state, 1, durationMs, durationMs, durationMs, 1, durationMs, durationMs, durationMs, executionId);
+    }
+
+    private ExecutionStatistic rawWithoutTaskRuns(String tenant, String namespace, String flowId, Instant bucket, State.Type state, String executionId, long durationMs) {
+        return new ExecutionStatistic(tenant, namespace, flowId, bucket, state, 1, durationMs, durationMs, durationMs, 0, 0, null, null, executionId);
+    }
+}

--- a/core/src/test/java/io/kestra/plugin/core/preview/IonFileRendererTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/preview/IonFileRendererTest.java
@@ -7,6 +7,7 @@ import java.util.Optional;
 
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
+
 import io.kestra.core.preview.FilePreview;
 import io.kestra.core.serializers.FileSerde;
 

--- a/executor/src/main/java/io/kestra/executor/DefaultExecutor.java
+++ b/executor/src/main/java/io/kestra/executor/DefaultExecutor.java
@@ -2,6 +2,7 @@ package io.kestra.executor;
 
 import java.time.Duration;
 import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.*;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -19,6 +20,7 @@ import io.kestra.core.killswitch.EvaluationType;
 import io.kestra.core.killswitch.KillSwitchService;
 import io.kestra.core.metrics.MetricRegistry;
 import io.kestra.core.models.executions.*;
+import io.kestra.core.models.executions.statistics.ExecutionStatistic;
 import io.kestra.core.models.flows.Concurrency;
 import io.kestra.core.models.flows.FlowInterface;
 import io.kestra.core.models.flows.FlowWithSource;
@@ -75,6 +77,8 @@ public class DefaultExecutor extends AbstractService implements Executor {
     private final DispatchQueueInterface<SubflowExecutionEnd> subflowExecutionEndQueue;
     private final DispatchQueueInterface<MultipleConditionEvent> multipleConditionEventQueue;
     private final DispatchQueueInterface<LoopExecutionEvent> loopExecutionEventQueue;
+    private final DispatchQueueInterface<ExecutionStatistic> executionStatisticQueue;
+
     private final ExecutorService executorService;
     private final ExecutionService executionService;
     private final FlowTriggerService flowTriggerService;
@@ -142,6 +146,7 @@ public class DefaultExecutor extends AbstractService implements Executor {
         DispatchQueueInterface<SubflowExecutionEnd> subflowExecutionEndQueue,
         DispatchQueueInterface<MultipleConditionEvent> multipleConditionEventQueue,
         DispatchQueueInterface<LoopExecutionEvent> loopExecutionEventQueue,
+        DispatchQueueInterface<ExecutionStatistic> executionStatisticQueue,
         ExecutorService executorService,
         ExecutionService executionService,
         FlowTriggerService flowTriggerService,
@@ -179,6 +184,7 @@ public class DefaultExecutor extends AbstractService implements Executor {
         this.subflowExecutionEndQueue = subflowExecutionEndQueue;
         this.multipleConditionEventQueue = multipleConditionEventQueue;
         this.loopExecutionEventQueue = loopExecutionEventQueue;
+        this.executionStatisticQueue = executionStatisticQueue;
         this.executorService = executorService;
         this.executionService = executionService;
         this.flowTriggerService = flowTriggerService;
@@ -676,6 +682,7 @@ public class DefaultExecutor extends AbstractService implements Executor {
                 if (execution.getTrigger() != null && execution.getState().isFailed() && ListUtils.isEmpty(execution.getTaskRunList())) {
                     sendTriggerExecutionTerminated(execution);
                     this.followExecutionEventQueue.emit(new FollowExecutionEvent(execution, ExecutionEventType.TERMINATED));
+                    emitExecutionStatistic(execution);
                 }
 
                 return;
@@ -812,6 +819,8 @@ public class DefaultExecutor extends AbstractService implements Executor {
                 // Note that we must use 'emit' here and not emitAsync as we need to emit it inside the same transaction to avoid races,
                 // and transactions are bound to a thread. This is true for all emission of the follow execution event inside an execution lock.
                 this.followExecutionEventQueue.emit(new FollowExecutionEvent(executor.getExecution(), ExecutionEventType.TERMINATED));
+
+                emitExecutionStatistic(execution);
             } else {
                 ExecutionEvent event = new ExecutionEvent(executor.getExecution(), ExecutionEventType.UPDATED);
                 this.executionEventQueue.emit(event);
@@ -839,11 +848,24 @@ public class DefaultExecutor extends AbstractService implements Executor {
 
                         // update all execution followers
                         this.followExecutionEventQueue.emit(new FollowExecutionEvent(failedExecution, ExecutionEventType.TERMINATED));
+
+                        emitExecutionStatistic(failedExecution);
                     } catch (QueueException ex) {
                         log.error("Unable to emit the execution {}", failedExecution.getId(), ex);
                     }
                 }
             }
+        }
+    }
+
+    /**
+     * Asynchronously emits a raw execution-statistic row for the indexer to persist for every terminal NORMAL-kind execution.
+     */
+    private void emitExecutionStatistic(Execution execution) {
+        if (execution.getKind() == null || ExecutionKind.NORMAL == execution.getKind()) {
+            // An end date should always be set, but use the current date as a safety belt
+            Instant bucket = execution.getState().getEndDate().orElse(Instant.now()).truncatedTo(ChronoUnit.MINUTES);
+            this.executionStatisticQueue.emitAsync(new ExecutionStatistic(execution, bucket));
         }
     }
 

--- a/indexer/src/main/java/io/kestra/indexer/DefaultIndexer.java
+++ b/indexer/src/main/java/io/kestra/indexer/DefaultIndexer.java
@@ -6,8 +6,10 @@ import java.util.concurrent.CopyOnWriteArrayList;
 import io.kestra.core.metrics.MetricRegistry;
 import io.kestra.core.models.executions.LogEntry;
 import io.kestra.core.models.executions.MetricEntry;
+import io.kestra.core.models.executions.statistics.ExecutionStatistic;
 import io.kestra.core.queues.*;
 import io.kestra.core.queues.event.DispatchEvent;
+import io.kestra.core.repositories.ExecutionStatisticsRepositoryInterface;
 import io.kestra.core.repositories.LogDataStoreInterface;
 import io.kestra.core.repositories.MetricRepositoryInterface;
 import io.kestra.core.runners.Indexer;
@@ -36,6 +38,10 @@ public class DefaultIndexer extends AbstractService implements Indexer {
 
     private final MetricRepositoryInterface metricRepository;
     private final DispatchQueueInterface<MetricEntry> metricQueue;
+
+    private final ExecutionStatisticsRepositoryInterface executionStatisticsRepository;
+    private final DispatchQueueInterface<ExecutionStatistic> executionStatisticQueue;
+
     private final MetricRegistry metricRegistry;
     // Thread-safe: populated by run() but iterated from doStop() on the context-close thread.
     private final List<QueueSubscriber<?>> subscribers = new CopyOnWriteArrayList<>();
@@ -49,6 +55,8 @@ public class DefaultIndexer extends AbstractService implements Indexer {
         DispatchQueueInterface<LogEntry> logQueue,
         MetricRepositoryInterface metricRepositor,
         DispatchQueueInterface<MetricEntry> metricQueue,
+        ExecutionStatisticsRepositoryInterface executionStatisticsRepository,
+        DispatchQueueInterface<ExecutionStatistic> executionStatisticQueue,
         MetricRegistry metricRegistry,
         ApplicationEventPublisher<ServiceStateChangeEvent> eventPublisher,
         IgnoreExecutionService ignoreExecutionService,
@@ -59,6 +67,8 @@ public class DefaultIndexer extends AbstractService implements Indexer {
         this.logQueue = logQueue;
         this.metricRepository = metricRepositor;
         this.metricQueue = metricQueue;
+        this.executionStatisticsRepository = executionStatisticsRepository;
+        this.executionStatisticQueue = executionStatisticQueue;
         this.metricRegistry = metricRegistry;
         this.ignoreExecutionService = ignoreExecutionService;
         this.queueService = queueService;
@@ -82,6 +92,7 @@ public class DefaultIndexer extends AbstractService implements Indexer {
     protected void startQueues() {
         this.sendBatch(logQueue, logRepository);
         this.sendBatch(metricQueue, metricRepository);
+        this.sendBatch(executionStatisticQueue, executionStatisticsRepository);
     }
 
     protected <T extends DispatchEvent> void sendBatch(DispatchQueueInterface<T> queueInterface, IndexingRepository<T> indexingRepository) {

--- a/indexer/src/test/java/io/kestra/indexer/DefaultIndexerTest.java
+++ b/indexer/src/test/java/io/kestra/indexer/DefaultIndexerTest.java
@@ -1,0 +1,141 @@
+package io.kestra.indexer;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.slf4j.event.Level;
+
+import com.devskiller.friendly_id.FriendlyId;
+
+import io.kestra.core.junit.annotations.KestraTest;
+import io.kestra.core.models.executions.LogEntry;
+import io.kestra.core.models.executions.MetricEntry;
+import io.kestra.core.models.executions.TaskRun;
+import io.kestra.core.models.executions.metrics.Counter;
+import io.kestra.core.models.executions.statistics.DailyExecutionStatistics;
+import io.kestra.core.models.executions.statistics.ExecutionStatistic;
+import io.kestra.core.models.flows.State;
+import io.kestra.core.queues.DispatchQueueInterface;
+import io.kestra.core.repositories.*;
+import io.kestra.core.utils.DateUtils;
+import io.kestra.core.utils.TestsUtils;
+
+import io.micronaut.data.model.Pageable;
+import jakarta.inject.Inject;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+@KestraTest
+class DefaultIndexerTest {
+    @Inject
+    private DefaultIndexer indexer;
+
+    @Inject
+    private DispatchQueueInterface<ExecutionStatistic> executionStatisticQueue;
+
+    @Inject
+    private ExecutionStatisticsRepositoryInterface executionStatisticsRepository;
+
+    @Inject
+    private DispatchQueueInterface<LogEntry> logQueue;
+
+    @Inject
+    private LogDataStoreInterface logDataStore;
+
+    @Inject
+    private DispatchQueueInterface<MetricEntry> metricQueue;
+
+    @Inject
+    private MetricRepositoryInterface metricRepository;
+
+    @Test
+    void shouldPersistExecutionStatisticsConsumedFromTheQueue() throws Exception {
+        // Given
+        indexer.startQueues();
+
+        String tenant = TestsUtils.randomTenant(this.getClass().getSimpleName());
+        Instant bucket = Instant.now().truncatedTo(ChronoUnit.MINUTES);
+        ExecutionStatistic statistic = new ExecutionStatistic(
+            tenant, "namespace", "flow", bucket, State.Type.SUCCESS, 1, 1000, 1000, 1000, 1, 1000, 1000L, 1000L, FriendlyId.createFriendlyId()
+        );
+
+        // When
+        executionStatisticQueue.emit(statistic);
+
+        // Then: the indexer batch-consumes the queue asynchronously and persists it via saveBatch
+        await().atMost(Duration.ofSeconds(10)).untilAsserted(() ->
+        {
+            List<DailyExecutionStatistics> stats = executionStatisticsRepository.statistics(
+                tenant, "namespace", "flow", bucket, bucket, DateUtils.GroupType.MINUTE
+            );
+            assertThat(stats).hasSize(1);
+            assertThat(stats.getFirst().getExecutionCounts().get(State.Type.SUCCESS)).isEqualTo(1L);
+        });
+    }
+
+    @Test
+    void shouldPersistLogsConsumedFromTheQueue() throws Exception {
+        // Given
+        indexer.startQueues();
+
+        String tenant = TestsUtils.randomTenant(this.getClass().getSimpleName());
+        String executionId = FriendlyId.createFriendlyId();
+        LogEntry logEntry = LogEntry.builder()
+            .tenantId(tenant)
+            .namespace("namespace")
+            .flowId("flow")
+            .taskId("task")
+            .executionId(executionId)
+            .taskRunId(FriendlyId.createFriendlyId())
+            .attemptNumber(0)
+            .timestamp(Instant.now())
+            .level(Level.INFO)
+            .thread("")
+            .message("hello from the indexer test")
+            .build();
+
+        // When
+        logQueue.emit(logEntry);
+
+        // Then
+        await().atMost(Duration.ofSeconds(10)).untilAsserted(() ->
+        {
+            List<LogEntry> logs = logDataStore.findByExecutionIdWithoutAcl(tenant, executionId, Level.INFO);
+            assertThat(logs).hasSize(1);
+            assertThat(logs.getFirst().getMessage()).isEqualTo("hello from the indexer test");
+        });
+    }
+
+    @Test
+    void shouldPersistMetricsConsumedFromTheQueue() throws Exception {
+        // Given
+        indexer.startQueues();
+
+        String tenant = TestsUtils.randomTenant(this.getClass().getSimpleName());
+        String executionId = FriendlyId.createFriendlyId();
+        TaskRun taskRun = TaskRun.builder()
+            .tenantId(tenant)
+            .namespace("namespace")
+            .flowId("flow")
+            .executionId(executionId)
+            .taskId("task")
+            .id(FriendlyId.createFriendlyId())
+            .build();
+        MetricEntry metricEntry = MetricEntry.of(taskRun, Counter.of("counter", 1), null);
+
+        // When
+        metricQueue.emit(metricEntry);
+
+        // Then
+        await().atMost(Duration.ofSeconds(10)).untilAsserted(() ->
+        {
+            ArrayListTotal<MetricEntry> metrics = metricRepository.findByExecutionId(tenant, executionId, Pageable.from(1, 10));
+            assertThat(metrics).hasSize(1);
+            assertThat(metrics.getFirst().getName()).isEqualTo("counter");
+        });
+    }
+}

--- a/jdbc-h2/src/main/java/io/kestra/repository/h2/H2ExecutionStatisticsRepository.java
+++ b/jdbc-h2/src/main/java/io/kestra/repository/h2/H2ExecutionStatisticsRepository.java
@@ -1,0 +1,17 @@
+package io.kestra.repository.h2;
+
+import io.kestra.core.models.executions.statistics.ExecutionStatistic;
+import io.kestra.core.repositories.RepositoryBean;
+import io.kestra.jdbc.repository.AbstractJdbcExecutionStatisticsRepository;
+
+import jakarta.inject.Inject;
+import jakarta.inject.Named;
+
+@RepositoryBean
+@H2RepositoryEnabled
+public class H2ExecutionStatisticsRepository extends AbstractJdbcExecutionStatisticsRepository {
+    @Inject
+    public H2ExecutionStatisticsRepository(@Named("executionstatistics") H2Repository<ExecutionStatistic> repository) {
+        super(repository);
+    }
+}

--- a/jdbc-h2/src/main/java/io/kestra/repository/h2/migration/V2_0_14ExecutionStatisticsMigration.java
+++ b/jdbc-h2/src/main/java/io/kestra/repository/h2/migration/V2_0_14ExecutionStatisticsMigration.java
@@ -1,0 +1,51 @@
+package io.kestra.repository.h2.migration;
+
+import javax.sql.DataSource;
+
+import io.kestra.core.migration.MigrationScript;
+import io.kestra.jdbc.migration.AbstractSQLMigrationScript;
+import io.kestra.repository.h2.H2RepositoryEnabled;
+
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+
+/**
+ * OSS H2 execution-statistics migration script.
+ *
+ * <p>
+ * Adds the {@code execution_statistics} table, used to store per-execution (raw) and periodically
+ * compacted (aggregate) execution-statistic rows, aggregated to the minute (see issue #16524).
+ */
+@Singleton
+@H2RepositoryEnabled
+public class V2_0_14ExecutionStatisticsMigration extends AbstractSQLMigrationScript {
+
+    private static final String SCRIPT_ID = "2.0.14-execution-statistics";
+
+    private final DataSource dataSource;
+
+    @Inject
+    public V2_0_14ExecutionStatisticsMigration(final DataSource dataSource) {
+        this.dataSource = dataSource;
+    }
+
+    @Override
+    public String scriptId() {
+        return SCRIPT_ID;
+    }
+
+    @Override
+    public String description() {
+        return "OSS H2: add the execution_statistics table";
+    }
+
+    @Override
+    public String checksum() {
+        return MigrationScript.checksumOfResources("/migrations/2.0.14-execution-statistics-h2.sql");
+    }
+
+    @Override
+    public void migrate() throws Exception {
+        executeSqlResource(dataSource, "/migrations/2.0.14-execution-statistics-h2.sql");
+    }
+}

--- a/jdbc-h2/src/main/resources/migrations/2.0.14-execution-statistics-h2.sql
+++ b/jdbc-h2/src/main/resources/migrations/2.0.14-execution-statistics-h2.sql
@@ -1,0 +1,17 @@
+-- Adds the execution_statistics table, used to store per-execution (raw) and periodically
+-- compacted (aggregate) execution-statistic rows, aggregated to the minute (see issue #16524).
+CREATE TABLE IF NOT EXISTS execution_statistics (
+    "key" VARCHAR(250) NOT NULL PRIMARY KEY,
+    "value" TEXT NOT NULL,
+    "tenant_id" VARCHAR(250) GENERATED ALWAYS AS (JQ_STRING("value", '.tenantId')),
+    "namespace" VARCHAR(150) NOT NULL GENERATED ALWAYS AS (JQ_STRING("value", '.namespace')),
+    "flow_id" VARCHAR(150) NOT NULL GENERATED ALWAYS AS (JQ_STRING("value", '.flowId')),
+    "state" VARCHAR(50) NOT NULL GENERATED ALWAYS AS (JQ_STRING("value", '.state')),
+    "date" TIMESTAMP NOT NULL GENERATED ALWAYS AS (PARSEDATETIME(LEFT(JQ_STRING("value", '.date'), 23) || '+00:00', 'yyyy-MM-dd''T''HH:mm:ss.SSSXXX')),
+    "execution_id" VARCHAR(150) GENERATED ALWAYS AS (JQ_STRING("value", '.executionId'))
+);
+
+CREATE INDEX IF NOT EXISTS execution_statistics_tenant_id__date ON execution_statistics ("tenant_id", "date");
+CREATE INDEX IF NOT EXISTS execution_statistics_tenant_id__namespace__flow_id__date ON execution_statistics ("tenant_id", "namespace", "flow_id", "date");
+-- Index used for the compaction mechanism for fast retrieval of NOT NULL execution_id values ordered by date
+CREATE INDEX IF NOT EXISTS execution_statistics_execution_id__date ON execution_statistics ("execution_id", "date");

--- a/jdbc-h2/src/test/java/io/kestra/repository/h2/H2ExecutionStatisticsCompactorTest.java
+++ b/jdbc-h2/src/test/java/io/kestra/repository/h2/H2ExecutionStatisticsCompactorTest.java
@@ -1,0 +1,6 @@
+package io.kestra.repository.h2;
+
+import io.kestra.jdbc.repository.AbstractExecutionStatisticsCompactorTest;
+
+public class H2ExecutionStatisticsCompactorTest extends AbstractExecutionStatisticsCompactorTest {
+}

--- a/jdbc-h2/src/test/java/io/kestra/repository/h2/H2ExecutionStatisticsRepositoryTest.java
+++ b/jdbc-h2/src/test/java/io/kestra/repository/h2/H2ExecutionStatisticsRepositoryTest.java
@@ -1,0 +1,6 @@
+package io.kestra.repository.h2;
+
+import io.kestra.core.repositories.AbstractExecutionStatisticsRepositoryTest;
+
+public class H2ExecutionStatisticsRepositoryTest extends AbstractExecutionStatisticsRepositoryTest {
+}

--- a/jdbc-mysql/src/main/java/io/kestra/repository/mysql/MysqlExecutionStatisticsRepository.java
+++ b/jdbc-mysql/src/main/java/io/kestra/repository/mysql/MysqlExecutionStatisticsRepository.java
@@ -1,0 +1,17 @@
+package io.kestra.repository.mysql;
+
+import io.kestra.core.models.executions.statistics.ExecutionStatistic;
+import io.kestra.core.repositories.RepositoryBean;
+import io.kestra.jdbc.repository.AbstractJdbcExecutionStatisticsRepository;
+
+import jakarta.inject.Inject;
+import jakarta.inject.Named;
+
+@RepositoryBean
+@MysqlRepositoryEnabled
+public class MysqlExecutionStatisticsRepository extends AbstractJdbcExecutionStatisticsRepository {
+    @Inject
+    public MysqlExecutionStatisticsRepository(@Named("executionstatistics") MysqlRepository<ExecutionStatistic> repository) {
+        super(repository);
+    }
+}

--- a/jdbc-mysql/src/main/java/io/kestra/repository/mysql/migration/V2_0_14ExecutionStatisticsMigration.java
+++ b/jdbc-mysql/src/main/java/io/kestra/repository/mysql/migration/V2_0_14ExecutionStatisticsMigration.java
@@ -1,0 +1,51 @@
+package io.kestra.repository.mysql.migration;
+
+import javax.sql.DataSource;
+
+import io.kestra.core.migration.MigrationScript;
+import io.kestra.jdbc.migration.AbstractSQLMigrationScript;
+import io.kestra.repository.mysql.MysqlRepositoryEnabled;
+
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+
+/**
+ * OSS MySQL execution-statistics migration script.
+ *
+ * <p>
+ * Adds the {@code execution_statistics} table, used to store per-execution (raw) and periodically
+ * compacted (aggregate) execution-statistic rows, aggregated to the minute (see issue #16524).
+ */
+@Singleton
+@MysqlRepositoryEnabled
+public class V2_0_14ExecutionStatisticsMigration extends AbstractSQLMigrationScript {
+
+    private static final String SCRIPT_ID = "2.0.14-execution-statistics";
+
+    private final DataSource dataSource;
+
+    @Inject
+    public V2_0_14ExecutionStatisticsMigration(final DataSource dataSource) {
+        this.dataSource = dataSource;
+    }
+
+    @Override
+    public String scriptId() {
+        return SCRIPT_ID;
+    }
+
+    @Override
+    public String description() {
+        return "OSS MySQL: add the execution_statistics table";
+    }
+
+    @Override
+    public String checksum() {
+        return MigrationScript.checksumOfResources("/migrations/2.0.14-execution-statistics-mysql.sql");
+    }
+
+    @Override
+    public void migrate() throws Exception {
+        executeSqlResource(dataSource, "/migrations/2.0.14-execution-statistics-mysql.sql");
+    }
+}

--- a/jdbc-mysql/src/main/resources/migrations/2.0.14-execution-statistics-mysql.sql
+++ b/jdbc-mysql/src/main/resources/migrations/2.0.14-execution-statistics-mysql.sql
@@ -1,0 +1,16 @@
+-- Adds the execution_statistics table, used to store per-execution (raw) and periodically
+-- compacted (aggregate) execution-statistic rows, aggregated to the minute (see issue #16524).
+CREATE TABLE IF NOT EXISTS execution_statistics (
+    `key` VARCHAR(250) NOT NULL PRIMARY KEY,
+    `value` JSON NOT NULL,
+    `tenant_id` VARCHAR(250) GENERATED ALWAYS AS (value ->> '$.tenantId') STORED,
+    `namespace` VARCHAR(150) GENERATED ALWAYS AS (value ->> '$.namespace') STORED NOT NULL,
+    `flow_id` VARCHAR(150) GENERATED ALWAYS AS (value ->> '$.flowId') STORED NOT NULL,
+    `state` VARCHAR(50) GENERATED ALWAYS AS (value ->> '$.state') STORED NOT NULL,
+    `date` DATETIME(6) GENERATED ALWAYS AS (STR_TO_DATE(value ->> '$.date' , '%Y-%m-%dT%H:%i:%s.%fZ')) STORED NOT NULL,
+    `execution_id` VARCHAR(150) GENERATED ALWAYS AS (value ->> '$.executionId') STORED,
+    INDEX ix_execution_statistics_tenant_id__date (tenant_id, `date`),
+    INDEX ix_execution_statistics_tenant_id__namespace__flow_id__date (tenant_id, namespace, flow_id, `date`),
+    -- Index used for the compaction mechanism for fast retrieval of NOT NULL execution_id values ordered by date
+    INDEX ix_execution_statistics_execution_id__date (execution_id, `date`)
+) ENGINE INNODB CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;

--- a/jdbc-mysql/src/test/java/io/kestra/repository/mysql/MysqlExecutionStatisticsCompactorTest.java
+++ b/jdbc-mysql/src/test/java/io/kestra/repository/mysql/MysqlExecutionStatisticsCompactorTest.java
@@ -1,0 +1,6 @@
+package io.kestra.repository.mysql;
+
+import io.kestra.jdbc.repository.AbstractExecutionStatisticsCompactorTest;
+
+public class MysqlExecutionStatisticsCompactorTest extends AbstractExecutionStatisticsCompactorTest {
+}

--- a/jdbc-mysql/src/test/java/io/kestra/repository/mysql/MysqlExecutionStatisticsRepositoryTest.java
+++ b/jdbc-mysql/src/test/java/io/kestra/repository/mysql/MysqlExecutionStatisticsRepositoryTest.java
@@ -1,0 +1,6 @@
+package io.kestra.repository.mysql;
+
+import io.kestra.core.repositories.AbstractExecutionStatisticsRepositoryTest;
+
+public class MysqlExecutionStatisticsRepositoryTest extends AbstractExecutionStatisticsRepositoryTest {
+}

--- a/jdbc-postgres/src/main/java/io/kestra/repository/postgres/PostgresExecutionStatisticsRepository.java
+++ b/jdbc-postgres/src/main/java/io/kestra/repository/postgres/PostgresExecutionStatisticsRepository.java
@@ -1,0 +1,17 @@
+package io.kestra.repository.postgres;
+
+import io.kestra.core.models.executions.statistics.ExecutionStatistic;
+import io.kestra.core.repositories.RepositoryBean;
+import io.kestra.jdbc.repository.AbstractJdbcExecutionStatisticsRepository;
+
+import jakarta.inject.Inject;
+import jakarta.inject.Named;
+
+@RepositoryBean
+@PostgresRepositoryEnabled
+public class PostgresExecutionStatisticsRepository extends AbstractJdbcExecutionStatisticsRepository {
+    @Inject
+    public PostgresExecutionStatisticsRepository(@Named("executionstatistics") PostgresRepository<ExecutionStatistic> repository) {
+        super(repository);
+    }
+}

--- a/jdbc-postgres/src/main/java/io/kestra/repository/postgres/migration/V2_0_14ExecutionStatisticsMigration.java
+++ b/jdbc-postgres/src/main/java/io/kestra/repository/postgres/migration/V2_0_14ExecutionStatisticsMigration.java
@@ -1,0 +1,51 @@
+package io.kestra.repository.postgres.migration;
+
+import javax.sql.DataSource;
+
+import io.kestra.core.migration.MigrationScript;
+import io.kestra.jdbc.migration.AbstractSQLMigrationScript;
+import io.kestra.repository.postgres.PostgresRepositoryEnabled;
+
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+
+/**
+ * OSS PostgreSQL execution-statistics migration script.
+ *
+ * <p>
+ * Adds the {@code execution_statistics} table, used to store per-execution (raw) and periodically
+ * compacted (aggregate) execution-statistic rows, aggregated to the minute (see issue #16524).
+ */
+@Singleton
+@PostgresRepositoryEnabled
+public class V2_0_14ExecutionStatisticsMigration extends AbstractSQLMigrationScript {
+
+    private static final String SCRIPT_ID = "2.0.14-execution-statistics";
+
+    private final DataSource dataSource;
+
+    @Inject
+    public V2_0_14ExecutionStatisticsMigration(final DataSource dataSource) {
+        this.dataSource = dataSource;
+    }
+
+    @Override
+    public String scriptId() {
+        return SCRIPT_ID;
+    }
+
+    @Override
+    public String description() {
+        return "OSS PostgreSQL: add the execution_statistics table";
+    }
+
+    @Override
+    public String checksum() {
+        return MigrationScript.checksumOfResources("/migrations/2.0.14-execution-statistics-postgres.sql");
+    }
+
+    @Override
+    public void migrate() throws Exception {
+        executeSqlResource(dataSource, "/migrations/2.0.14-execution-statistics-postgres.sql");
+    }
+}

--- a/jdbc-postgres/src/main/resources/migrations/2.0.14-execution-statistics-postgres.sql
+++ b/jdbc-postgres/src/main/resources/migrations/2.0.14-execution-statistics-postgres.sql
@@ -1,0 +1,17 @@
+-- Adds the execution_statistics table, used to store per-execution (raw) and periodically
+-- compacted (aggregate) execution-statistic rows, aggregated to the minute (see issue #16524).
+CREATE TABLE IF NOT EXISTS execution_statistics (
+    key VARCHAR(250) NOT NULL PRIMARY KEY,
+    value JSONB NOT NULL,
+    tenant_id VARCHAR(250) GENERATED ALWAYS AS (value ->> 'tenantId') STORED,
+    namespace VARCHAR(150) NOT NULL GENERATED ALWAYS AS (value ->> 'namespace') STORED,
+    flow_id VARCHAR(150) NOT NULL GENERATED ALWAYS AS (value ->> 'flowId') STORED,
+    state VARCHAR(50) NOT NULL GENERATED ALWAYS AS (value ->> 'state') STORED,
+    date TIMESTAMPTZ NOT NULL GENERATED ALWAYS AS (PARSE_ISO8601_DATETIME(value ->> 'date')) STORED,
+    execution_id VARCHAR(150) GENERATED ALWAYS AS (value ->> 'executionId') STORED
+);
+
+CREATE INDEX IF NOT EXISTS execution_statistics_tenant_id__date ON execution_statistics (tenant_id, date);
+CREATE INDEX IF NOT EXISTS execution_statistics_tenant_id__namespace__flow_id__date ON execution_statistics (tenant_id, namespace, flow_id, date);
+-- Index used for the compaction mechanism for fast retrieval of NOT NULL execution_id values ordered by date
+CREATE INDEX IF NOT EXISTS execution_statistics_execution_id__date ON execution_statistics (execution_id, date);

--- a/jdbc-postgres/src/test/java/io/kestra/repository/postgres/PostgresExecutionStatisticsCompactorTest.java
+++ b/jdbc-postgres/src/test/java/io/kestra/repository/postgres/PostgresExecutionStatisticsCompactorTest.java
@@ -1,0 +1,6 @@
+package io.kestra.repository.postgres;
+
+import io.kestra.jdbc.repository.AbstractExecutionStatisticsCompactorTest;
+
+public class PostgresExecutionStatisticsCompactorTest extends AbstractExecutionStatisticsCompactorTest {
+}

--- a/jdbc-postgres/src/test/java/io/kestra/repository/postgres/PostgresExecutionStatisticsRepositoryTest.java
+++ b/jdbc-postgres/src/test/java/io/kestra/repository/postgres/PostgresExecutionStatisticsRepositoryTest.java
@@ -1,0 +1,6 @@
+package io.kestra.repository.postgres;
+
+import io.kestra.core.repositories.AbstractExecutionStatisticsRepositoryTest;
+
+public class PostgresExecutionStatisticsRepositoryTest extends AbstractExecutionStatisticsRepositoryTest {
+}

--- a/jdbc/src/main/java/io/kestra/jdbc/JdbcTableConfigsFactory.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/JdbcTableConfigsFactory.java
@@ -9,6 +9,7 @@ import io.kestra.core.models.executions.Execution;
 import io.kestra.core.models.executions.LogEntry;
 import io.kestra.core.models.executions.MetricEntry;
 import io.kestra.core.models.executions.TaskOutput;
+import io.kestra.core.models.executions.statistics.ExecutionStatistic;
 import io.kestra.core.models.flows.FlowInterface;
 import io.kestra.core.models.flows.sla.SLAMonitor;
 import io.kestra.core.models.kv.PersistedKvMetadata;
@@ -69,6 +70,12 @@ public class JdbcTableConfigsFactory {
     @Named("multipleconditions")
     public InstantiableJdbcTableConfig multipleConditions() {
         return new InstantiableJdbcTableConfig("multipleconditions", MultipleConditionWindow.class, "multipleconditions");
+    }
+
+    @Bean
+    @Named("executionstatistics")
+    public InstantiableJdbcTableConfig executionStatistics() {
+        return new InstantiableJdbcTableConfig("executionstatistics", ExecutionStatistic.class, "execution_statistics");
     }
 
     @Bean

--- a/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcExecutionRepository.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcExecutionRepository.java
@@ -614,6 +614,11 @@ public abstract class AbstractJdbcExecutionRepository extends AbstractJdbcCrudRe
         }
     }
 
+    // NOTE: anchored to ZoneId.systemDefault(), matching this class's getDate()-based bucket-key
+    // extraction (also system-default-zone), so results are internally consistent but their
+    // absolute bucket labels are off by the server's UTC offset on non-UTC hosts. See
+    // AbstractJdbcExecutionStatisticsRepository#fillDate for the UTC-correct pattern; not applied
+    // here since it also requires fixing the shared getDate(), out of scope for now.
     private static List<DailyExecutionStatistics> fillDate(
         List<DailyExecutionStatistics> results,
         ZonedDateTime startDate,
@@ -661,7 +666,7 @@ public abstract class AbstractJdbcExecutionRepository extends AbstractJdbcCrudRe
             .groupBy(groupByType)
             .duration(
                 DailyExecutionStatistics.Duration.builder()
-                    .avg(Duration.ofMillis(durationSum / count))
+                    .avg(Duration.ofMillis(count == 0 ? 0 : durationSum / count))
                     .min(result.stream().map(ExecutionStatistics::getDurationMin).map(x -> x != null ? x : 0).min(Long::compare).map(Duration::ofMillis).orElse(null))
                     .max(result.stream().map(ExecutionStatistics::getDurationMax).map(x -> x != null ? x : 0).max(Long::compare).map(Duration::ofMillis).orElse(null))
                     .sum(Duration.ofMillis(durationSum))

--- a/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcExecutionStatisticsRepository.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcExecutionStatisticsRepository.java
@@ -1,0 +1,246 @@
+package io.kestra.jdbc.repository;
+
+import java.time.DayOfWeek;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.time.temporal.ChronoUnit;
+import java.time.temporal.TemporalAdjusters;
+import java.util.ArrayList;
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.jooq.Condition;
+import org.jooq.DSLContext;
+import org.jooq.Field;
+import org.jooq.SQLDialect;
+import org.jooq.SelectConditionStep;
+import org.jooq.impl.DSL;
+
+import io.kestra.core.models.executions.statistics.DailyExecutionStatistics;
+import io.kestra.core.models.executions.statistics.ExecutionStatistic;
+import io.kestra.core.models.flows.State;
+import io.kestra.core.repositories.ExecutionStatisticsRepositoryInterface;
+import io.kestra.core.utils.DateUtils;
+
+import io.micronaut.core.annotation.Nullable;
+
+/**
+ * Base JDBC repository for the pre-aggregated {@code execution_statistics} table.
+ * <p>
+ * The table mixes raw rows (one per terminated execution, {@code count = 1}) with rows already
+ * merged by the periodic compaction job ({@code count = N}); see {@link ExecutionStatistic} for
+ * why this makes {@link #statistics} a uniform aggregation regardless of compaction state.
+ * <p>
+ */
+public abstract class AbstractJdbcExecutionStatisticsRepository extends AbstractJdbcCrudRepository<ExecutionStatistic> implements ExecutionStatisticsRepositoryInterface {
+    // Package-private: referenced by ExecutionStatisticsCompactor, which shares this table but isn't part of this class's hierarchy.
+    static final Field<String> NAMESPACE_FIELD = field("namespace", String.class);
+    static final Field<String> FLOW_ID_FIELD = field("flow_id", String.class);
+    static final Field<Object> DATE_FIELD = field("date");
+
+    public AbstractJdbcExecutionStatisticsRepository(io.kestra.jdbc.AbstractJdbcRepository<ExecutionStatistic> jdbcRepository) {
+        super(jdbcRepository);
+    }
+
+    /** {@inheritDoc} **/
+    @Override
+    protected Condition defaultFilter(String tenantId) {
+        return tenantCondition(tenantId);
+    }
+
+    /** {@inheritDoc} **/
+    @Override
+    protected Condition defaultFilter() {
+        return DSL.trueCondition();
+    }
+
+    /** {@inheritDoc} **/
+    @Override
+    public List<DailyExecutionStatistics> statistics(
+        String tenantId,
+        @Nullable String namespace,
+        @Nullable String flowId,
+        Instant startDate,
+        Instant endDate,
+        DateUtils.GroupType groupBy) {
+        DateUtils.GroupType groupByType = groupBy != null ? groupBy : DateUtils.groupByType(Duration.between(startDate, endDate));
+
+        List<ExecutionStatistic> rows = this.jdbcRepository
+            .getDslContextWrapper()
+            .transactionResult(configuration ->
+            {
+                DSLContext context = DSL.using(configuration);
+
+                SelectConditionStep<?> select = context
+                    .select(VALUE_FIELD)
+                    .from(this.jdbcRepository.getTable())
+                    .where(this.defaultFilter(tenantId))
+                    .and(DATE_FIELD.greaterOrEqual(bindableDate(configuration.dialect(), startDate)))
+                    .and(DATE_FIELD.lessOrEqual(bindableDate(configuration.dialect(), endDate)));
+
+                if (namespace != null) {
+                    select = select.and(NAMESPACE_FIELD.eq(namespace));
+                }
+
+                if (flowId != null) {
+                    select = select.and(FLOW_ID_FIELD.eq(flowId));
+                }
+
+                return this.jdbcRepository.fetch(select);
+            });
+
+        Map<Instant, List<ExecutionStatistic>> byBucket = rows.stream()
+            .collect(Collectors.groupingBy(row -> truncateToBucket(row.date(), groupByType)));
+
+        List<DailyExecutionStatistics> results = byBucket.entrySet().stream()
+            .map(entry -> dailyExecutionStatisticsMap(entry.getKey(), entry.getValue(), groupByType.val()))
+            .toList();
+
+        return fillDate(results, truncateToBucket(startDate, groupByType), truncateToBucket(endDate, groupByType), groupByType);
+    }
+
+    /**
+     * Converts an absolute instant to the value type comparable with the {@code date} generated
+     * column. MySQL's {@code DATETIME} generated column is populated via {@code STR_TO_DATE} on
+     * the ISO-8601 string, which discards the 'Z' and stores the UTC wall-clock digits as a naive
+     * (timezone-less) value; H2/PostgreSQL parse the same string into a timestamp that retains the
+     * absolute instant, so an {@link java.time.OffsetDateTime} compares correctly there.
+     */
+    static Object bindableDate(SQLDialect dialect, Instant instant) {
+        return dialect.family() == SQLDialect.MYSQL
+            ? LocalDateTime.ofInstant(instant, ZoneOffset.UTC)
+            : instant.atOffset(ZoneOffset.UTC);
+    }
+
+    /**
+     * Tenant-null-safe equality condition on {@code tenant_id}.
+     */
+    static Condition tenantCondition(String tenantId) {
+        return tenantId == null ? TENANT_ID_FIELD.isNull() : TENANT_ID_FIELD.eq(tenantId);
+    }
+
+    /**
+     * Truncates an instant to the start of its bucket for the given group type. Operates directly
+     * on the real (deserialized) {@link Instant}, in UTC — no SQL-side date-part extraction is
+     * involved, so there is no risk of the system-default-zone reconstruction bug that a
+     * digit-extraction approach (year/month/day/hour/minute columns) would be exposed to.
+     */
+    private static Instant truncateToBucket(Instant instant, DateUtils.GroupType groupType) {
+        return switch (groupType) {
+            case MINUTE -> instant.truncatedTo(ChronoUnit.MINUTES);
+            case HOUR -> instant.truncatedTo(ChronoUnit.HOURS);
+            case DAY -> instant.truncatedTo(ChronoUnit.DAYS);
+            case WEEK -> instant.truncatedTo(ChronoUnit.DAYS)
+                .atZone(ZoneOffset.UTC)
+                .with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY))
+                .toInstant();
+            case MONTH -> instant.atZone(ZoneOffset.UTC).withDayOfMonth(1).truncatedTo(ChronoUnit.DAYS).toInstant();
+        };
+    }
+
+    /**
+     * Fills gaps in {@code results} so every bucket in {@code [startDate, endDate]} is present,
+     * even when it has no matching rows.
+     * <p>
+     * {@link AbstractJdbcExecutionRepository#fillDate} and {@link AbstractJdbcMetricRepository}'s
+     * private {@code fillDate} reimplement the same gap-filling idea, but anchor to
+     * {@code ZoneId.systemDefault()} instead of UTC — self-consistent with their own
+     * {@code AbstractJdbcRepository#getDate} bucket-key extraction (which has the same
+     * system-default-zone bug), but wrong in absolute terms on non-UTC hosts. Not consolidated
+     * here: fixing it properly means fixing {@code getDate()} too, which is shared by those two
+     * already-shipped read paths and out of scope for this feature.
+     */
+    private static List<DailyExecutionStatistics> fillDate(List<DailyExecutionStatistics> results, Instant startDate, Instant endDate, DateUtils.GroupType groupByType) {
+        ChronoUnit unit = switch (groupByType) {
+            case MONTH -> ChronoUnit.MONTHS;
+            case WEEK -> ChronoUnit.WEEKS;
+            case DAY -> ChronoUnit.DAYS;
+            case HOUR -> ChronoUnit.HOURS;
+            case MINUTE -> ChronoUnit.MINUTES;
+        };
+
+        Map<Instant, DailyExecutionStatistics> byBucket = results.stream()
+            .collect(Collectors.toMap(DailyExecutionStatistics::getStartDate, r -> r));
+
+        List<DailyExecutionStatistics> filledResult = new ArrayList<>();
+        // MONTH/WEEK are calendar (not fixed-duration) units, so advancing requires a zoned
+        // representation; Instant.plus(...) only supports fixed-duration units.
+        ZonedDateTime current = startDate.atZone(ZoneOffset.UTC);
+        ZonedDateTime boundary = endDate.atZone(ZoneOffset.UTC).plus(1, unit);
+
+        while (current.isBefore(boundary)) {
+            Instant bucket = current.toInstant();
+            filledResult.add(
+                byBucket.getOrDefault(
+                    bucket, DailyExecutionStatistics.builder()
+                        .startDate(bucket)
+                        .groupBy(groupByType.val())
+                        .duration(DailyExecutionStatistics.Duration.builder().build())
+                        .taskRunsDuration(DailyExecutionStatistics.Duration.builder().build())
+                        .build()
+                )
+            );
+            current = current.plus(1, unit);
+        }
+
+        return filledResult;
+    }
+
+    private static DailyExecutionStatistics dailyExecutionStatisticsMap(Instant bucket, List<ExecutionStatistic> rows, String groupByType) {
+        long count = 0;
+        long durationSum = 0;
+        long durationMin = Long.MAX_VALUE;
+        long durationMax = 0;
+        long taskRunCount = 0;
+        long taskRunsDurationSum = 0;
+        Long taskRunsDurationMin = null;
+        Long taskRunsDurationMax = null;
+        Map<State.Type, Long> countsByState = new EnumMap<>(State.Type.class);
+
+        // rows is never empty: it's a group from Collectors.groupingBy over the non-empty rows
+        // fetched by statistics(), so durationMin/durationMax always get a real value below.
+        for (ExecutionStatistic row : rows) {
+            count += row.count();
+            durationSum += row.durationSumMs();
+            durationMin = Math.min(durationMin, row.durationMinMs());
+            durationMax = Math.max(durationMax, row.durationMaxMs());
+            taskRunCount += row.taskRunCount();
+            taskRunsDurationSum += row.taskRunsDurationSumMs();
+            taskRunsDurationMin = ExecutionStatisticsCompactor.minOf(taskRunsDurationMin, row.taskRunsDurationMinMs());
+            taskRunsDurationMax = ExecutionStatisticsCompactor.maxOf(taskRunsDurationMax, row.taskRunsDurationMaxMs());
+            countsByState.merge(row.state(), row.count(), Long::sum);
+        }
+
+        DailyExecutionStatistics build = DailyExecutionStatistics.builder()
+            .startDate(bucket)
+            .groupBy(groupByType)
+            .duration(
+                DailyExecutionStatistics.Duration.builder()
+                    .avg(Duration.ofMillis(count == 0 ? 0 : durationSum / count))
+                    .min(Duration.ofMillis(durationMin))
+                    .max(Duration.ofMillis(durationMax))
+                    .sum(Duration.ofMillis(durationSum))
+                    .count(count)
+                    .build()
+            )
+            .taskRunsDuration(
+                DailyExecutionStatistics.Duration.builder()
+                    .avg(Duration.ofMillis(taskRunCount == 0 ? 0 : taskRunsDurationSum / taskRunCount))
+                    .min(taskRunsDurationMin == null ? null : Duration.ofMillis(taskRunsDurationMin))
+                    .max(taskRunsDurationMax == null ? null : Duration.ofMillis(taskRunsDurationMax))
+                    .sum(Duration.ofMillis(taskRunsDurationSum))
+                    .count(taskRunCount)
+                    .build()
+            )
+            .build();
+
+        build.getExecutionCounts().putAll(countsByState);
+
+        return build;
+    }
+}

--- a/jdbc/src/main/java/io/kestra/jdbc/repository/ExecutionStatisticCompactorConfig.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/repository/ExecutionStatisticCompactorConfig.java
@@ -1,0 +1,21 @@
+package io.kestra.jdbc.repository;
+
+import java.time.Duration;
+
+import io.micronaut.context.annotation.ConfigurationProperties;
+import io.micronaut.core.bind.annotation.Bindable;
+
+/**
+ * Configuration for {@link ExecutionStatisticsCompactor}.
+ *
+ * @param initialDelay delay before the first compaction run after startup.
+ * @param fixedDelay delay between the end of one compaction run and the start of the next.
+ * @param maxKeysPerRun maximum number of distinct {@code (tenant, namespace, flow, state)} keys
+ *        compacted per run, bounding the work of a single tick.
+ */
+@ConfigurationProperties("kestra.jdbc.execution-statistics.compactor")
+public record ExecutionStatisticCompactorConfig(
+    @Bindable(defaultValue = "1m") Duration initialDelay, // kept here for documentation, used inside the {@link ExecutionStatisticsCompactor}'s @Scheduled annotation
+    @Bindable(defaultValue = "1m") Duration fixedDelay, // kept here for documentation, used inside the {@link ExecutionStatisticsCompactor}'s @Scheduled annotation
+    @Bindable(defaultValue = "1000") Integer maxKeysPerRun) {
+}

--- a/jdbc/src/main/java/io/kestra/jdbc/repository/ExecutionStatisticsCompactor.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/repository/ExecutionStatisticsCompactor.java
@@ -1,0 +1,275 @@
+package io.kestra.jdbc.repository;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.jooq.DSLContext;
+import org.jooq.Field;
+import org.jooq.impl.DSL;
+
+import io.kestra.core.metrics.MetricRegistry;
+import io.kestra.core.models.executions.statistics.ExecutionStatistic;
+import io.kestra.core.models.flows.State;
+import io.kestra.jdbc.JooqDSLContextWrapper;
+import io.kestra.jdbc.runner.JdbcRepositoryEnabled;
+
+import io.micrometer.core.instrument.Timer;
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.core.annotation.Nullable;
+import io.micronaut.scheduling.annotation.Scheduled;
+import jakarta.inject.Inject;
+import jakarta.inject.Named;
+import jakarta.inject.Singleton;
+import lombok.extern.slf4j.Slf4j;
+
+import static io.kestra.jdbc.repository.AbstractJdbcExecutionStatisticsRepository.DATE_FIELD;
+import static io.kestra.jdbc.repository.AbstractJdbcExecutionStatisticsRepository.FLOW_ID_FIELD;
+import static io.kestra.jdbc.repository.AbstractJdbcExecutionStatisticsRepository.NAMESPACE_FIELD;
+import static io.kestra.jdbc.repository.AbstractJdbcExecutionStatisticsRepository.bindableDate;
+import static io.kestra.jdbc.repository.AbstractJdbcExecutionStatisticsRepository.tenantCondition;
+import static io.kestra.jdbc.repository.AbstractJdbcRepository.KEY_FIELD;
+import static io.kestra.jdbc.repository.AbstractJdbcRepository.TENANT_ID_FIELD;
+import static io.kestra.jdbc.repository.AbstractJdbcRepository.VALUE_FIELD;
+import static io.kestra.jdbc.repository.AbstractJdbcRepository.field;
+
+/**
+ * Periodically compacts the {@code execution_statistics} table.
+ * <p>
+ * The table mixes raw per-execution rows ({@code count = 1}) with rows already merged by a
+ * previous run ({@code count = N}); see {@link ExecutionStatistic} for why every read is a
+ * uniform aggregation regardless of compaction state. This job bounds row growth: for every
+ * closed minute bucket that still holds raw rows, it merges them into the bucket's aggregate row
+ * and deletes the raw rows.
+ * <p>
+ * It is only used in JDBC backends, Elasticsearch didn't compact and always aggregate on the fly when querying.
+ */
+@Singleton
+@JdbcRepositoryEnabled
+@Requires(property = "kestra.server-type", pattern = "(STANDALONE|WEBSERVER|INDEXER)")
+@Slf4j
+public class ExecutionStatisticsCompactor {
+    // Safety cap on the number of findKeysWithRawRows() batches drained within a single tick, so
+    // that a key which can never be compacted (e.g. a persistently corrupt row) can't keep the
+    // batch full forever and block this thread indefinitely; the remainder is simply picked up on
+    // the next tick. Not user-configurable: it exists purely to bound worst-case behavior, not to
+    // be tuned.
+    private static final int MAX_BATCHES_PER_TICK = 50;
+
+    private static final Field<String> STATE_FIELD = field("state", String.class);
+    private static final Field<String> EXECUTION_ID_FIELD = field("execution_id", String.class);
+
+    private final io.kestra.jdbc.AbstractJdbcRepository<ExecutionStatistic> jdbcRepository;
+    private final JooqDSLContextWrapper dslContextWrapper;
+    private final int maxKeysPerRun;
+    private final Timer compactionDurationTimer;
+
+    @Inject
+    public ExecutionStatisticsCompactor(
+        @Named("executionstatistics") io.kestra.jdbc.AbstractJdbcRepository<ExecutionStatistic> jdbcRepository,
+        ExecutionStatisticCompactorConfig config,
+        MetricRegistry metricRegistry) {
+        this.jdbcRepository = jdbcRepository;
+        this.dslContextWrapper = jdbcRepository.getDslContextWrapper();
+        this.maxKeysPerRun = config.maxKeysPerRun();
+        this.compactionDurationTimer = metricRegistry.timer(
+            MetricRegistry.METRIC_JDBC_EXECUTION_STATISTICS_COMPACTOR_DURATION,
+            MetricRegistry.METRIC_JDBC_EXECUTION_STATISTICS_COMPACTOR_DURATION_DESCRIPTION
+        );
+    }
+
+    // @Scheduled requires compile-time constant placeholder strings, so initialDelay/fixedDelay
+    // can't be read from the injected ExecutionStatisticCompactorConfig directly; the property
+    // keys and defaults here must stay in sync with that config's prefix (same pattern as
+    // io.kestra.core.storages.kv.KVPurgeCleaner + KVPurgeConfiguration).
+    @Scheduled(
+        initialDelay = "${kestra.jdbc.execution-statistics.compactor.initial-delay:1m}",
+        fixedDelay = "${kestra.jdbc.execution-statistics.compactor.fixed-delay:1m}"
+    )
+    public void compact() {
+        compactionDurationTimer.record(this::drainBacklog);
+    }
+
+    private void drainBacklog() {
+        Instant closedBefore = Instant.now().truncatedTo(ChronoUnit.MINUTES);
+
+        int batches = 0;
+        List<BucketGroupKey> keys;
+        do {
+            keys = findKeysWithRawRows(closedBefore);
+
+            for (BucketGroupKey key : keys) {
+                try {
+                    compactKey(key, closedBefore);
+                } catch (Exception e) {
+                    // one key failing (e.g. a transient deadlock) must not prevent the others from being compacted;
+                    // the row(s) will simply be retried on the next tick.
+                    log.warn("Unable to compact execution statistics for {}: {}", key, e.getMessage(), e);
+                }
+            }
+
+            batches++;
+            // a full batch means there may be more keys waiting: keep draining within this tick
+            // instead of waiting for the next fixedDelay, so a burst of activity doesn't push
+            // compaction further and further behind.
+        } while (keys.size() == maxKeysPerRun && batches < MAX_BATCHES_PER_TICK);
+
+        if (keys.size() == maxKeysPerRun) {
+            log.warn(
+                "Execution statistics compaction hit its per-tick safety cap ({} batches of {} keys); the remaining backlog will be processed on the next tick.",
+                MAX_BATCHES_PER_TICK, maxKeysPerRun
+            );
+        }
+    }
+
+    private List<BucketGroupKey> findKeysWithRawRows(Instant closedBefore) {
+        return dslContextWrapper.transactionResult(
+            configuration -> DSL
+                .using(configuration)
+                .selectDistinct(TENANT_ID_FIELD, NAMESPACE_FIELD, FLOW_ID_FIELD, STATE_FIELD)
+                .from(jdbcRepository.getTable())
+                .where(EXECUTION_ID_FIELD.isNotNull())
+                .and(DATE_FIELD.lessThan(bindableDate(configuration.dialect(), closedBefore)))
+                .limit(maxKeysPerRun)
+                .fetch(
+                    record -> new BucketGroupKey(
+                        record.get(TENANT_ID_FIELD),
+                        record.get(NAMESPACE_FIELD),
+                        record.get(FLOW_ID_FIELD),
+                        record.get(STATE_FIELD)
+                    )
+                )
+        );
+    }
+
+    private void compactKey(BucketGroupKey key, Instant closedBefore) {
+        dslContextWrapper.transaction(configuration ->
+        {
+            DSLContext context = DSL.using(configuration);
+
+            List<ExecutionStatistic> rawRows = jdbcRepository.fetch(
+                context.select(VALUE_FIELD)
+                    .from(jdbcRepository.getTable())
+                    .where(tenantCondition(key.tenantId()))
+                    .and(NAMESPACE_FIELD.eq(key.namespace()))
+                    .and(FLOW_ID_FIELD.eq(key.flowId()))
+                    .and(STATE_FIELD.eq(key.state()))
+                    .and(EXECUTION_ID_FIELD.isNotNull())
+                    .and(DATE_FIELD.lessThan(bindableDate(configuration.dialect(), closedBefore)))
+                    .forUpdate()
+                    .skipLocked()
+            );
+
+            if (rawRows.isEmpty()) {
+                // either nothing left, or another compactor instance already claimed these rows
+                return;
+            }
+
+            Map<Instant, List<ExecutionStatistic>> byBucket = rawRows.stream()
+                .collect(Collectors.groupingBy(ExecutionStatistic::date));
+
+            byBucket.forEach((bucketDate, bucketRows) -> mergeBucket(context, key, bucketDate, bucketRows));
+
+            context.deleteFrom(jdbcRepository.getTable())
+                .where(KEY_FIELD.in(rawRows.stream().map(ExecutionStatistic::executionId).toList()))
+                .execute();
+
+            log.debug("Compacted {} execution statistics for {} into {} bucket(s)", rawRows.size(), key, byBucket.size());
+        });
+    }
+
+    /**
+     * Merges one closed bucket's raw rows into its aggregate row.
+     * <p>
+     * The aggregate row is fetched-or-created with {@link io.kestra.jdbc.AbstractJdbcRepository#getOrInsert}
+     * under a {@code FOR UPDATE} lock so a concurrent compactor merging the same bucket blocks
+     * instead of racing (a lost-update would otherwise be possible: both merges read the same
+     * pre-merge totals and the second write would silently overwrite the first).
+     */
+    private void mergeBucket(DSLContext context, BucketGroupKey key, Instant bucketDate, List<ExecutionStatistic> bucketRows) {
+        State.Type state = State.Type.valueOf(key.state());
+        ExecutionStatistic zero = new ExecutionStatistic(key.tenantId(), key.namespace(), key.flowId(), bucketDate, state, 0, 0, 0, 0, 0, 0, null, null, null);
+
+        ExecutionStatistic existing = jdbcRepository.getOrInsert(
+            context,
+            () -> jdbcRepository.fetchOne(
+                context.select(VALUE_FIELD)
+                    .from(jdbcRepository.getTable())
+                    .where(KEY_FIELD.eq(zero.uid()))
+                    .forUpdate()
+            ),
+            () -> zero
+        );
+
+        long count = 0;
+        long durationSum = 0;
+        long durationMin = Long.MAX_VALUE;
+        long durationMax = 0;
+        long taskRunCount = 0;
+        long taskRunsDurationSum = 0;
+        Long taskRunsDurationMin = null;
+        Long taskRunsDurationMax = null;
+        // bucketRows is never empty: it's a group from Collectors.groupingBy over the non-empty
+        // rawRows fetched in compactKey.
+        for (ExecutionStatistic row : bucketRows) {
+            count += row.count();
+            durationSum += row.durationSumMs();
+            durationMin = Math.min(durationMin, row.durationMinMs());
+            durationMax = Math.max(durationMax, row.durationMaxMs());
+            taskRunCount += row.taskRunCount();
+            taskRunsDurationSum += row.taskRunsDurationSumMs();
+            taskRunsDurationMin = minOf(taskRunsDurationMin, row.taskRunsDurationMinMs());
+            taskRunsDurationMax = maxOf(taskRunsDurationMax, row.taskRunsDurationMaxMs());
+        }
+
+        ExecutionStatistic merged = new ExecutionStatistic(
+            key.tenantId(),
+            key.namespace(),
+            key.flowId(),
+            bucketDate,
+            state,
+            existing.count() + count,
+            existing.durationSumMs() + durationSum,
+            existing.count() == 0 ? durationMin : Math.min(existing.durationMinMs(), durationMin),
+            existing.count() == 0 ? durationMax : Math.max(existing.durationMaxMs(), durationMax),
+            existing.taskRunCount() + taskRunCount,
+            existing.taskRunsDurationSumMs() + taskRunsDurationSum,
+            minOf(existing.taskRunsDurationMinMs(), taskRunsDurationMin),
+            maxOf(existing.taskRunsDurationMaxMs(), taskRunsDurationMax),
+            null
+        );
+
+        jdbcRepository.persist(merged, context, jdbcRepository.persistFields(merged));
+    }
+
+    /**
+     * Null-safe {@code min}: a null operand means "no task run contributed a value yet", not zero.
+     * Package-private: also used by {@link AbstractJdbcExecutionStatisticsRepository} for the same
+     * merge semantics on the read side, instead of a second hand-rolled copy.
+     */
+    static Long minOf(@Nullable Long a, @Nullable Long b) {
+        if (a == null)
+            return b;
+        if (b == null)
+            return a;
+        return Math.min(a, b);
+    }
+
+    /**
+     * Null-safe {@code max}: a null operand means "no task run contributed a value yet", not zero.
+     * Package-private: also used by {@link AbstractJdbcExecutionStatisticsRepository} for the same
+     * merge semantics on the read side, instead of a second hand-rolled copy.
+     */
+    static Long maxOf(@Nullable Long a, @Nullable Long b) {
+        if (a == null)
+            return b;
+        if (b == null)
+            return a;
+        return Math.max(a, b);
+    }
+
+    private record BucketGroupKey(String tenantId, String namespace, String flowId, String state) {
+    }
+}

--- a/jdbc/src/test/java/io/kestra/jdbc/repository/AbstractExecutionStatisticsCompactorTest.java
+++ b/jdbc/src/test/java/io/kestra/jdbc/repository/AbstractExecutionStatisticsCompactorTest.java
@@ -1,0 +1,178 @@
+package io.kestra.jdbc.repository;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import java.util.stream.IntStream;
+
+import org.junit.jupiter.api.Test;
+
+import com.devskiller.friendly_id.FriendlyId;
+
+import io.kestra.core.models.executions.statistics.DailyExecutionStatistics;
+import io.kestra.core.models.executions.statistics.ExecutionStatistic;
+import io.kestra.core.models.flows.State;
+import io.kestra.core.repositories.ExecutionStatisticsRepositoryInterface;
+import io.kestra.core.utils.DateUtils;
+import io.kestra.core.utils.TestsUtils;
+
+import io.micronaut.context.annotation.Property;
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import jakarta.inject.Inject;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@MicronautTest
+@Property(name = "kestra.server-type", value = "STANDALONE")
+public abstract class AbstractExecutionStatisticsCompactorTest {
+    @Inject
+    protected ExecutionStatisticsRepositoryInterface executionStatisticsRepository;
+
+    @Inject
+    protected ExecutionStatisticsCompactor executionStatisticsCompactor;
+
+    @Test
+    void shouldCompactClosedBucketWithoutChangingReadResult() {
+        // Given: 3 raw rows in a bucket from 5 minutes ago (closed relative to "now")
+        String tenant = TestsUtils.randomTenant(this.getClass().getSimpleName());
+        Instant bucket = Instant.now().minus(5, ChronoUnit.MINUTES).truncatedTo(ChronoUnit.MINUTES);
+
+        executionStatisticsRepository.saveBatch(
+            List.of(
+                raw(tenant, bucket, State.Type.SUCCESS, FriendlyId.createFriendlyId(), 1000),
+                raw(tenant, bucket, State.Type.SUCCESS, FriendlyId.createFriendlyId(), 2000),
+                raw(tenant, bucket, State.Type.SUCCESS, FriendlyId.createFriendlyId(), 3000)
+            )
+        );
+
+        DailyExecutionStatistics before = statisticsFor(tenant, bucket);
+
+        // When
+        executionStatisticsCompactor.compact();
+
+        // Then: the compaction is transparent to readers
+        DailyExecutionStatistics after = statisticsFor(tenant, bucket);
+        assertThat(after.getExecutionCounts()).isEqualTo(before.getExecutionCounts());
+        assertThat(after.getDuration().getSum()).isEqualTo(before.getDuration().getSum());
+        assertThat(after.getDuration().getMin()).isEqualTo(before.getDuration().getMin());
+        assertThat(after.getDuration().getMax()).isEqualTo(before.getDuration().getMax());
+    }
+
+    @Test
+    void shouldNotCompactTheCurrentOpenBucket() {
+        // Given: a raw row in the current (not yet closed) minute
+        String tenant = TestsUtils.randomTenant(this.getClass().getSimpleName());
+        Instant bucket = Instant.now().truncatedTo(ChronoUnit.MINUTES);
+        String executionId = FriendlyId.createFriendlyId();
+        executionStatisticsRepository.save(raw(tenant, bucket, State.Type.SUCCESS, executionId, 1000));
+
+        // When
+        executionStatisticsCompactor.compact();
+
+        // Then: the raw row was left untouched (not claimed/deleted), so re-saving the same
+        // executionId still overwrites it in place instead of adding a second (raw + aggregate) row
+        executionStatisticsRepository.save(raw(tenant, bucket, State.Type.SUCCESS, executionId, 1000));
+        DailyExecutionStatistics stats = statisticsFor(tenant, bucket);
+        assertThat(stats.getExecutionCounts().get(State.Type.SUCCESS)).isEqualTo(1L);
+    }
+
+    @Test
+    void shouldMergeLateRawRowsIntoAnExistingAggregate() {
+        // Given: a bucket already compacted (2 executions), then a late-arriving raw row for the same bucket
+        String tenant = TestsUtils.randomTenant(this.getClass().getSimpleName());
+        Instant bucket = Instant.now().minus(5, ChronoUnit.MINUTES).truncatedTo(ChronoUnit.MINUTES);
+
+        executionStatisticsRepository.saveBatch(
+            List.of(
+                raw(tenant, bucket, State.Type.SUCCESS, FriendlyId.createFriendlyId(), 1000),
+                raw(tenant, bucket, State.Type.SUCCESS, FriendlyId.createFriendlyId(), 2000)
+            )
+        );
+        executionStatisticsCompactor.compact();
+
+        executionStatisticsRepository.save(raw(tenant, bucket, State.Type.SUCCESS, FriendlyId.createFriendlyId(), 9000));
+
+        // When: compacting again must merge the late row into the existing aggregate, not overwrite it
+        executionStatisticsCompactor.compact();
+
+        // Then
+        DailyExecutionStatistics stats = statisticsFor(tenant, bucket);
+        assertThat(stats.getExecutionCounts().get(State.Type.SUCCESS)).isEqualTo(3L);
+        assertThat(stats.getDuration().getSum().toMillis()).isEqualTo(12000L);
+        assertThat(stats.getDuration().getMax().toMillis()).isEqualTo(9000L);
+        assertThat(stats.getTaskRunsDuration().getSum().toMillis()).isEqualTo(12000L);
+        assertThat(stats.getTaskRunsDuration().getMin().toMillis()).isEqualTo(1000L);
+        assertThat(stats.getTaskRunsDuration().getMax().toMillis()).isEqualTo(9000L);
+    }
+
+    @Test
+    void shouldNotLetLateExecutionsWithoutTaskRunsCorruptTheCompactedTaskRunDurationMinMax() {
+        // Given: a bucket already compacted from a single 500ms-task-run execution, then a
+        // late-arriving execution that never ran any task
+        String tenant = TestsUtils.randomTenant(this.getClass().getSimpleName());
+        Instant bucket = Instant.now().minus(5, ChronoUnit.MINUTES).truncatedTo(ChronoUnit.MINUTES);
+
+        executionStatisticsRepository.save(raw(tenant, bucket, State.Type.SUCCESS, FriendlyId.createFriendlyId(), 500));
+        executionStatisticsCompactor.compact();
+
+        ExecutionStatistic lateWithoutTaskRuns = new ExecutionStatistic(
+            tenant, "namespace", "flow", bucket, State.Type.FAILED, 1, 200, 200, 200, 0, 0, null, null, FriendlyId.createFriendlyId()
+        );
+        executionStatisticsRepository.save(lateWithoutTaskRuns);
+
+        // When: compacting again must merge the task-less execution without dragging the min to 0
+        executionStatisticsCompactor.compact();
+
+        // Then
+        DailyExecutionStatistics stats = statisticsFor(tenant, bucket);
+        assertThat(stats.getExecutionCounts().values().stream().mapToLong(Long::longValue).sum()).isEqualTo(2L);
+        assertThat(stats.getTaskRunsDuration().getCount()).isEqualTo(1L);
+        assertThat(stats.getTaskRunsDuration().getMin().toMillis()).isEqualTo(500L);
+        assertThat(stats.getTaskRunsDuration().getMax().toMillis()).isEqualTo(500L);
+    }
+
+    @Test
+    @Property(name = "kestra.jdbc.execution-statistics.compactor.max-keys-per-run", value = "2")
+    void shouldDrainMoreKeysThanTheBatchLimitWithinASingleTick() {
+        // Given: 5 distinct (namespace, flow, state) keys, more than the batch limit of 2 configured
+        // for this test — a single compact() call must not stop after the first batch, or a burst of
+        // activity spanning more distinct keys than the limit would fall further and further behind.
+        String tenant = TestsUtils.randomTenant(this.getClass().getSimpleName());
+        Instant bucket = Instant.now().minus(5, ChronoUnit.MINUTES).truncatedTo(ChronoUnit.MINUTES);
+
+        executionStatisticsRepository.saveBatch(
+            IntStream.range(0, 5)
+                .mapToObj(i -> raw(tenant, "flow-" + i, bucket, State.Type.SUCCESS, FriendlyId.createFriendlyId(), 1000))
+                .toList()
+        );
+
+        // When
+        executionStatisticsCompactor.compact();
+
+        // Then: every key was compacted in this single tick, not just the first 2
+        for (int i = 0; i < 5; i++) {
+            DailyExecutionStatistics stats = statisticsFor(tenant, "flow-" + i, bucket);
+            assertThat(stats.getExecutionCounts().get(State.Type.SUCCESS)).isEqualTo(1L);
+        }
+    }
+
+    private DailyExecutionStatistics statisticsFor(String tenant, Instant bucket) {
+        return statisticsFor(tenant, "flow", bucket);
+    }
+
+    private DailyExecutionStatistics statisticsFor(String tenant, String flowId, Instant bucket) {
+        List<DailyExecutionStatistics> stats = executionStatisticsRepository.statistics(
+            tenant, "namespace", flowId, bucket, bucket, DateUtils.GroupType.MINUTE
+        );
+        assertThat(stats).hasSize(1);
+        return stats.getFirst();
+    }
+
+    private ExecutionStatistic raw(String tenant, Instant bucket, State.Type state, String executionId, long durationMs) {
+        return raw(tenant, "flow", bucket, state, executionId, durationMs);
+    }
+
+    private ExecutionStatistic raw(String tenant, String flowId, Instant bucket, State.Type state, String executionId, long durationMs) {
+        return new ExecutionStatistic(tenant, "namespace", flowId, bucket, state, 1, durationMs, durationMs, durationMs, 1, durationMs, durationMs, durationMs, executionId);
+    }
+}

--- a/queue-jdbc/src/main/java/io/kestra/queue/jdbc/JdbcQueueFactory.java
+++ b/queue-jdbc/src/main/java/io/kestra/queue/jdbc/JdbcQueueFactory.java
@@ -8,6 +8,7 @@ import io.kestra.core.models.executions.Execution;
 import io.kestra.core.models.executions.ExecutionKilled;
 import io.kestra.core.models.executions.LogEntry;
 import io.kestra.core.models.executions.MetricEntry;
+import io.kestra.core.models.executions.statistics.ExecutionStatistic;
 import io.kestra.core.models.flows.FlowInterface;
 import io.kestra.core.queues.BroadcastQueueInterface;
 import io.kestra.core.queues.DispatchQueueInterface;
@@ -123,6 +124,15 @@ public class JdbcQueueFactory implements QueueFactoryInterface<JdbcDependencies>
     public DispatchQueueInterface<MetricEntry> metricQueue(JdbcDependencies dependencies) {
         return new JdbcDispatchQueue<>(
             MetricEntry.class, dependencies.queueService(), dependencies.jdbcQueueClient(), dependencies.executorsUtils(), dependencies.metricRegistry(), dependencies.ignoreExecutionService()
+        );
+    }
+
+    @QueueBean
+    @Override
+    public DispatchQueueInterface<ExecutionStatistic> executionStatisticQueue(JdbcDependencies dependencies) {
+        return new JdbcDispatchQueue<>(
+            ExecutionStatistic.class, dependencies.queueService(), dependencies.jdbcQueueClient(), dependencies.executorsUtils(), dependencies.metricRegistry(),
+            dependencies.ignoreExecutionService()
         );
     }
 

--- a/queue/src/main/java/io/kestra/queue/QueueFactoryInterface.java
+++ b/queue/src/main/java/io/kestra/queue/QueueFactoryInterface.java
@@ -4,6 +4,7 @@ import io.kestra.core.async.AsyncOperationProcessedEvent;
 import io.kestra.core.executor.command.ExecutionCommand;
 import io.kestra.core.mcp.models.McpSessionEvent;
 import io.kestra.core.models.executions.*;
+import io.kestra.core.models.executions.statistics.ExecutionStatistic;
 import io.kestra.core.models.flows.FlowInterface;
 import io.kestra.core.queues.BroadcastQueueInterface;
 import io.kestra.core.queues.DispatchQueueInterface;
@@ -40,6 +41,8 @@ public interface QueueFactoryInterface<D> {
     VNodeDispatchQueueInterface<TriggerEvent> triggerEventQueue(D dependencies);
 
     DispatchQueueInterface<MetricEntry> metricQueue(D dependencies);
+
+    DispatchQueueInterface<ExecutionStatistic> executionStatisticQueue(D dependencies);
 
     BroadcastQueueInterface<FollowExecutionEvent> followExecutionQueue(D dependencies);
 


### PR DESCRIPTION
Store execution statistics in a separate database for fast retrieval and long retention. In JDBC, aggregate at the minute (compact) the statistics to lower resource usage.

Closes #16524
