### PR TITLE
feat(core): add 'sys purge-queue' CLI command and fix queue purge lock timeout

### DIFF
--- a/cli/src/main/java/io/kestra/cli/commands/sys/PurgeQueueCommand.java
+++ b/cli/src/main/java/io/kestra/cli/commands/sys/PurgeQueueCommand.java
@@ -1,0 +1,59 @@
+package io.kestra.cli.commands.sys;
+
+import java.time.Duration;
+import java.util.Optional;
+
+import io.kestra.cli.AbstractCommand;
+import io.kestra.jdbc.runner.JdbcQueueCleaner;
+
+import io.micronaut.context.ApplicationContext;
+import jakarta.inject.Inject;
+import lombok.extern.slf4j.Slf4j;
+import picocli.CommandLine;
+
+@CommandLine.Command(
+    name = "purge-queue",
+    description = { "Purge expired messages from the JDBC 'queues' table",
+        "Deletes records older than the configured 'kestra.jdbc.cleaner' retention. This command does not start any server component, so it can be run to recover an instance whose executor can no longer purge the queue on its own. Deletes are committed in batches to avoid lock contention on large tables."
+    },
+    mixinStandardHelpOptions = true
+)
+@Slf4j
+public class PurgeQueueCommand extends AbstractCommand {
+    @Inject
+    private ApplicationContext applicationContext;
+
+    @CommandLine.Option(
+        names = { "--retention" },
+        description = "Override the global retention for this run (ISO-8601 duration, e.g. PT1H). Per-type retentions from the configuration are always applied. Defaults to the configured 'kestra.jdbc.cleaner.retention'."
+    )
+    private Duration retention;
+
+    @Override
+    public Integer call() throws Exception {
+        super.call();
+
+        Optional<String> queueType = applicationContext.getProperty("kestra.queue.type", String.class);
+        if (queueType.isEmpty()) {
+            stdOut("Unable to purge the queue, the 'kestra.queue.type' configuration is not set");
+            return 0;
+        }
+
+        switch (queueType.get()) {
+            case "postgres", "mysql", "h2" -> {
+                JdbcQueueCleaner queueCleaner = applicationContext.getBean(JdbcQueueCleaner.class);
+                long purged = retention != null ? queueCleaner.purge(retention) : queueCleaner.purge();
+                stdOut("Successfully purged {0} messages from the queues table", purged);
+                return 0;
+            }
+            case "kafka" -> {
+                stdOut("Unable to purge the queue, the 'kestra.queue.type' configuration is set to 'kafka' which does not use the 'queues' table");
+                return 1;
+            }
+            default -> {
+                stdOut("Unable to purge the queue, the 'kestra.queue.type' '{0}' does not use a purgeable 'queues' table", queueType.get());
+                return 0;
+            }
+        }
+    }
+}

--- a/cli/src/main/java/io/kestra/cli/commands/sys/SysCommand.java
+++ b/cli/src/main/java/io/kestra/cli/commands/sys/SysCommand.java
@@ -16,6 +16,7 @@ import picocli.CommandLine;
         ReindexCommand.class,
         DatabaseCommand.class,
         SubmitQueuedCommand.class,
+        PurgeQueueCommand.class,
         StateStoreCommand.class
     }
 )

--- a/cli/src/test/java/io/kestra/cli/commands/sys/PurgeQueueCommandTest.java
+++ b/cli/src/test/java/io/kestra/cli/commands/sys/PurgeQueueCommandTest.java
@@ -1,0 +1,53 @@
+package io.kestra.cli.commands.sys;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+
+import org.junit.jupiter.api.Test;
+
+import io.kestra.jdbc.runner.JdbcQueueCleaner;
+
+import io.micronaut.configuration.picocli.PicocliRunner;
+import io.micronaut.context.ApplicationContext;
+import io.micronaut.context.env.Environment;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class PurgeQueueCommandTest {
+    @Test
+    void shouldReportUnpurgeableQueueTypeAndNotStartServerForMemory() {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        System.setOut(new PrintStream(out));
+
+        // The default CLI test environment uses the in-memory queue, which has no 'queues' table to purge.
+        // The command must handle it gracefully (exit 0) without booting any server component.
+        try (ApplicationContext ctx = ApplicationContext.run(Environment.CLI, Environment.TEST)) {
+            Integer call = PicocliRunner.call(PurgeQueueCommand.class, ctx, new String[]{});
+
+            assertThat(call).isZero();
+            assertThat(out.toString()).contains("does not use a purgeable");
+            // no server component should have been started
+            assertThat(ctx.getProperty("kestra.server-type", String.class)).isEmpty();
+        }
+    }
+
+    @Test
+    void shouldPurgeOnJdbcWithoutStartingServer() {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        System.setOut(new PrintStream(out));
+
+        // 'purge-queue-h2' sets up a real JDBC (h2) backend WITHOUT a server-type. This is the crux of the
+        // feature: the command must resolve JdbcQueueCleaner (whose scheduled sibling JdbcCleaner is gated to
+        // EXECUTOR/STANDALONE) and purge the queue even though no executor/worker/scheduler is running.
+        // Deletion correctness across dialects is covered by AbstractJdbcCleanerTest (H2/MySQL/Postgres).
+        try (ApplicationContext ctx = ApplicationContext.run(Environment.CLI, "purge-queue-h2")) {
+            assertThat(ctx.getProperty("kestra.server-type", String.class)).isEmpty();
+            assertThat(ctx.getBean(JdbcQueueCleaner.class)).isNotNull();
+
+            Integer call = PicocliRunner.call(PurgeQueueCommand.class, ctx, new String[]{});
+
+            assertThat(call).isZero();
+            assertThat(out.toString()).contains("Successfully purged");
+        }
+    }
+}

--- a/cli/src/test/resources/application-purge-queue-h2.yml
+++ b/cli/src/test/resources/application-purge-queue-h2.yml
@@ -1,0 +1,32 @@
+datasources:
+  h2:
+    url: jdbc:h2:mem:purge-queue;TIME ZONE=UTC;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+    username: sa
+    password: ""
+    driverClassName: org.h2.Driver
+
+flyway:
+  datasources:
+    h2:
+      enabled: true
+      locations:
+        - classpath:migrations/h2
+      ignore-migration-patterns: "*:missing,*:future"
+      out-of-order: true
+
+kestra:
+  # NB: no server-type is set on purpose — this proves the purge command works in a CLI context
+  # that does not start any server component (the whole point of the feature).
+  queue:
+    type: h2
+  repository:
+    type: h2
+  storage:
+    type: local
+    local:
+      base-path: /tmp/unittest
+  jdbc:
+    cleaner:
+      initial-delay: 1h
+      fixed-delay: 1h
+      retention: 24h

--- a/jdbc/src/main/java/io/kestra/jdbc/runner/JdbcCleaner.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/runner/JdbcCleaner.java
@@ -1,127 +1,34 @@
 package io.kestra.jdbc.runner;
 
-import java.time.Duration;
-import java.time.ZonedDateTime;
-import java.time.temporal.Temporal;
-import java.util.List;
-import java.util.concurrent.atomic.LongAdder;
+import java.util.Objects;
 
-import org.jooq.*;
-import org.jooq.Record;
-import org.jooq.impl.DSL;
-
-import io.kestra.core.utils.ListUtils;
-import io.kestra.jdbc.JdbcTableConfig;
-import io.kestra.jdbc.JooqDSLContextWrapper;
-import io.kestra.jdbc.repository.AbstractJdbcRepository;
-
-import io.micronaut.context.annotation.ConfigurationProperties;
-import io.micronaut.context.annotation.EachProperty;
 import io.micronaut.context.annotation.Requires;
 import io.micronaut.scheduling.annotation.Scheduled;
 import jakarta.inject.Inject;
-import jakarta.inject.Named;
 import jakarta.inject.Singleton;
-import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 
+/**
+ * Scheduled trigger that periodically purges the <code>queues</code> table on the executor.
+ * <p>
+ * The purge logic lives in {@link JdbcQueueCleaner} so it can be shared with the
+ * <code>sys purge-queue</code> CLI command; this class only owns the schedule and the server-type gate.
+ */
 @Singleton
 @JdbcRunnerEnabled
 @Slf4j
 @Requires(property = "kestra.jdbc.cleaner")
 @Requires(property = "kestra.server-type", pattern = "(EXECUTOR|STANDALONE)")
 public class JdbcCleaner {
-    private static final Field<Object> UPDATED_FIELD = AbstractJdbcRepository.field("updated");
-    private static final int MYSQL_BATCH_SIZE = 10_000;
-
-    private final JooqDSLContextWrapper dslContextWrapper;
-    private final Configuration configuration;
-    private final JdbcCleanerService jdbcCleanerService;
-    private final Table<Record> queueTable;
+    private final JdbcQueueCleaner queueCleaner;
 
     @Inject
-    public JdbcCleaner(@Named("queues") JdbcTableConfig jdbcTableConfig,
-        JooqDSLContextWrapper dslContextWrapper,
-        Configuration configuration,
-        JdbcCleanerService jdbcCleanerService) {
-        this.dslContextWrapper = dslContextWrapper;
-        this.configuration = configuration;
-        this.jdbcCleanerService = jdbcCleanerService;
-
-        this.queueTable = DSL.table(jdbcTableConfig.table());
+    public JdbcCleaner(JdbcQueueCleaner queueCleaner) {
+        this.queueCleaner = Objects.requireNonNull(queueCleaner, "queueCleaner must not be null");
     }
 
     @Scheduled(initialDelay = "${kestra.jdbc.cleaner.initial-delay}", fixedDelay = "${kestra.jdbc.cleaner.fixed-delay}")
     public long deleteQueue() {
-        LongAdder totalDeleted = new LongAdder();
-        // first, delete types that are configured more specifically
-        ListUtils.emptyOnNull(configuration.getTypes()).forEach(type ->
-        {
-            dslContextWrapper.transaction(configuration ->
-            {
-                var condition = UPDATED_FIELD.lessOrEqual(period(configuration, type.getRetention()))
-                    .and(jdbcCleanerService.buildTypeCondition(type.getType()));
-                int deleted = delete(configuration, condition);
-                log.info("Cleaned {} records from {} for type {}", deleted, this.queueTable.getName(), type.getType());
-                totalDeleted.add(deleted);
-            });
-        });
-
-        // then, delete all other records
-        dslContextWrapper.transaction(configuration ->
-        {
-            var condition = UPDATED_FIELD.lessOrEqual(period(configuration, this.configuration.getRetention()));
-            int deleted = delete(configuration, condition);
-            log.info("Cleaned {} records from {}", deleted, this.queueTable.getName());
-            totalDeleted.add(deleted);
-        });
-
-        return totalDeleted.longValue();
-    }
-
-    private int delete(org.jooq.Configuration configuration, Condition condition) {
-        if (configuration.dialect().family() == SQLDialect.MYSQL) {
-            // MySQL struggle with large transactions so we need to execute them in batch
-            int totalDeleted = 0;
-            int subDeleted;
-            do {
-                subDeleted = DSL
-                    .using(configuration)
-                    .delete(this.queueTable)
-                    .where(condition)
-                    .limit(MYSQL_BATCH_SIZE)
-                    .execute();
-                totalDeleted += subDeleted;
-            } while (subDeleted > 0);
-            return totalDeleted;
-        } else {
-            return DSL
-                .using(configuration)
-                .delete(this.queueTable)
-                .where(condition)
-                .execute();
-        }
-    }
-
-    private Temporal period(org.jooq.Configuration configuration, Duration retention) {
-        if (configuration.dialect().family() == SQLDialect.MYSQL) {
-            // 'date' column in the table is in local time for MySQL
-            return ZonedDateTime.now().minus(retention).toLocalDateTime();
-        }
-        return ZonedDateTime.now().minus(retention).toOffsetDateTime();
-    }
-
-    @ConfigurationProperties("kestra.jdbc.cleaner")
-    @Getter
-    public static class Configuration {
-        Duration retention;
-        List<TypeConfiguration> types;
-
-        @Getter
-        @EachProperty(value = "types", list = true)
-        public static class TypeConfiguration {
-            String type;
-            Duration retention;
-        }
+        return queueCleaner.purge();
     }
 }

--- a/jdbc/src/main/java/io/kestra/jdbc/runner/JdbcQueueCleaner.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/runner/JdbcQueueCleaner.java
@@ -1,0 +1,155 @@
+package io.kestra.jdbc.runner;
+
+import java.time.Duration;
+import java.time.ZonedDateTime;
+import java.time.temporal.Temporal;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.atomic.LongAdder;
+
+import org.jooq.*;
+import org.jooq.Record;
+import org.jooq.impl.DSL;
+
+import io.kestra.core.utils.ListUtils;
+import io.kestra.jdbc.JdbcTableConfig;
+import io.kestra.jdbc.JooqDSLContextWrapper;
+import io.kestra.jdbc.repository.AbstractJdbcRepository;
+
+import io.micronaut.context.annotation.ConfigurationProperties;
+import io.micronaut.context.annotation.EachProperty;
+import io.micronaut.context.annotation.Requires;
+import jakarta.inject.Inject;
+import jakarta.inject.Named;
+import jakarta.inject.Singleton;
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Purges expired records from the <code>queues</code> table based on the configured retention.
+ * <p>
+ * This bean is intentionally <b>not</b> gated by <code>kestra.server-type</code> so the purge logic can
+ * be reused both by the scheduled {@link JdbcCleaner} (running on the executor) and by the
+ * <code>sys purge-queue</code> CLI command, which does not start any server component.
+ * <p>
+ * For MySQL the delete is executed in batches, each committed in its own transaction. Committing per
+ * batch is what allows the purge to grind through millions of rows: a single large transaction holds
+ * row locks on every deleted row until it commits, which trips <code>innodb_lock_wait_timeout</code> on
+ * big tables.
+ */
+@Singleton
+@JdbcRunnerEnabled
+@Slf4j
+@Requires(property = "kestra.jdbc.cleaner")
+public class JdbcQueueCleaner {
+    private static final Field<Object> UPDATED_FIELD = AbstractJdbcRepository.field("updated");
+    private static final int MYSQL_BATCH_SIZE = 10_000;
+
+    private final JooqDSLContextWrapper dslContextWrapper;
+    private final Configuration configuration;
+    private final JdbcCleanerService jdbcCleanerService;
+    private final Table<Record> queueTable;
+
+    @Inject
+    public JdbcQueueCleaner(@Named("queues") JdbcTableConfig jdbcTableConfig,
+        JooqDSLContextWrapper dslContextWrapper,
+        Configuration configuration,
+        JdbcCleanerService jdbcCleanerService) {
+        this.dslContextWrapper = Objects.requireNonNull(dslContextWrapper, "dslContextWrapper must not be null");
+        this.configuration = Objects.requireNonNull(configuration, "configuration must not be null");
+        this.jdbcCleanerService = Objects.requireNonNull(jdbcCleanerService, "jdbcCleanerService must not be null");
+
+        this.queueTable = DSL.table(jdbcTableConfig.table());
+    }
+
+    /**
+     * Purge the queues table using the configured retention (global and per-type).
+     *
+     * @return the number of purged records
+     */
+    public long purge() {
+        return purge(null);
+    }
+
+    /**
+     * Purge the queues table. Per-type retentions always come from the configuration; the global
+     * retention can be overridden for a one-off cleanup.
+     *
+     * @param globalRetentionOverride the retention to use for the global catch-all phase, or
+     *                                <code>null</code> to use the configured global retention
+     * @return the number of purged records
+     */
+    public long purge(Duration globalRetentionOverride) {
+        LongAdder totalDeleted = new LongAdder();
+
+        // first, delete types that are configured more specifically
+        ListUtils.emptyOnNull(configuration.getTypes()).forEach(type -> {
+            int deleted = delete(type.getRetention(), jdbcCleanerService.buildTypeCondition(type.getType()));
+            log.info("Purged {} records from {} for type {}", deleted, this.queueTable.getName(), type.getType());
+            totalDeleted.add(deleted);
+        });
+
+        // then, delete all other records using the (possibly overridden) global retention
+        Duration globalRetention = globalRetentionOverride != null ? globalRetentionOverride : configuration.getRetention();
+        int deleted = delete(globalRetention, null);
+        log.info("Purged {} records from {}", deleted, this.queueTable.getName());
+        totalDeleted.add(deleted);
+
+        return totalDeleted.longValue();
+    }
+
+    private int delete(Duration retention, Condition extraCondition) {
+        // MySQL struggles with large transactions so we delete in batches, each batch committed in its own
+        // transaction to avoid holding row locks until the whole purge completes. Other dialects delete in a
+        // single statement (the loop then simply runs once). Committing per batch is what lets the purge grind
+        // through millions of rows without tripping innodb_lock_wait_timeout.
+        int totalDeleted = 0;
+        int subDeleted;
+        do {
+            subDeleted = dslContextWrapper.transactionResult(configuration -> {
+                var delete = DSL.using(configuration)
+                    .delete(this.queueTable)
+                    .where(condition(configuration, retention, extraCondition));
+
+                if (configuration.dialect().family() == SQLDialect.MYSQL) {
+                    return delete.limit(MYSQL_BATCH_SIZE).execute();
+                }
+                return delete.execute();
+            });
+            totalDeleted += subDeleted;
+            if (subDeleted > 0) {
+                log.debug("Purged a batch of {} records from {} ({} so far)", subDeleted, this.queueTable.getName(), totalDeleted);
+            }
+            // Only MySQL is batched: a full batch means there may be more, so keep going.
+        } while (subDeleted == MYSQL_BATCH_SIZE);
+
+        return totalDeleted;
+    }
+
+    private Condition condition(org.jooq.Configuration configuration, Duration retention, Condition extraCondition) {
+        Condition condition = UPDATED_FIELD.lessOrEqual(period(configuration, retention));
+        return extraCondition != null ? condition.and(extraCondition) : condition;
+    }
+
+    private Temporal period(org.jooq.Configuration configuration, Duration retention) {
+        if (configuration.dialect().family() == SQLDialect.MYSQL) {
+            // 'updated' column in the table is in local time for MySQL
+            return ZonedDateTime.now().minus(retention).toLocalDateTime();
+        }
+        return ZonedDateTime.now().minus(retention).toOffsetDateTime();
+    }
+
+    @ConfigurationProperties("kestra.jdbc.cleaner")
+    @Getter
+    public static class Configuration {
+        Duration retention;
+        List<TypeConfiguration> types;
+
+        @Getter
+        @EachProperty(value = "types", list = true)
+        public static class TypeConfiguration {
+            String type;
+            Duration retention;
+        }
+    }
+}


### PR DESCRIPTION
## Context

A customer's `queues` table (MySQL) grew to ~8.6M rows and the executor's scheduled cleaner could no longer purge it — it hit `Lock wait timeout exceeded` and the uncaught-exception handler shut the server down. Because **the executor is the component that runs the purge**, once it can't boot it can never clean up. Operators were reduced to running manual `DELETE ... LIMIT` scripts against the DB.

## Root cause

`JdbcCleaner` batches MySQL deletes (`.limit(10_000)`) but ran the **entire batch loop inside a single `dslContextWrapper.transaction(...)`**. All batch-DELETEs accumulate row locks in one uncommitted transaction until the loop finishes, so on millions of rows it always trips `innodb_lock_wait_timeout`. Statement-level batching doesn't help when locks are held until commit — which is exactly why a manual script that **commits between batches** works.

## Changes

- **`JdbcQueueCleaner`** (new) — server-type-agnostic bean holding the purge logic. The MySQL branch now **commits per batch** (each `.limit(10_000)` delete in its own transaction), so the purge can grind through millions of rows without holding locks. Exposes `purge()` (configured retention) and `purge(Duration)` (global override).
- **`JdbcCleaner`** — reduced to a thin `@Scheduled` delegate; the executor's scheduled purge inherits the per-batch-commit fix.
- **`sys purge-queue`** CLI command — purges the `queues` table **without starting any server component**, so an instance whose executor can't boot can still be recovered. Uses the configured `kestra.jdbc.cleaner` retention, with an optional `--retention` override. Guards on `kestra.queue.type` (h2/mysql/postgres).

Usage: stop the components, then `kestra sys purge-queue -c <config>`.

## Tests

- `AbstractJdbcCleanerTest` passes on **H2, MySQL, and Postgres** (covers the refactored `purge()` incl. the MySQL per-batch path).
- New `PurgeQueueCommandTest`: the command resolves `JdbcQueueCleaner` and runs to success in a **no-server-type** context (the crux of the feature), plus graceful handling of non-JDBC queue types.
- Full `cli sys` command package still green.