### PR TITLE
Fixed : Unable to show an ION output inside the execution page

### DIFF
--- a/core/src/main/java/io/kestra/plugin/core/preview/ImageFileRenderer.java
+++ b/core/src/main/java/io/kestra/plugin/core/preview/ImageFileRenderer.java
@@ -2,6 +2,7 @@ package io.kestra.plugin.core.preview;
 
 import java.util.Set;
 
+import io.kestra.core.models.annotations.Plugin;
 import io.kestra.core.preview.FilePreview;
 
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -20,6 +21,7 @@ import lombok.experimental.SuperBuilder;
     title = "Image file renderer",
     description = "Preview image files inside the Kestra UI, supported extensions: png, jpg, jpeg, svg, gif, bmp, webp."
 )
+@Plugin
 public class ImageFileRenderer extends AbstractBase64FileRenderer {
     private static final Set<String> SUPPORTED_EXTENSIONS = Set.of("png", "jpg", "jpeg", "svg", "gif", "bmp", "webp");
 

--- a/core/src/main/java/io/kestra/plugin/core/preview/IonFileRenderer.java
+++ b/core/src/main/java/io/kestra/plugin/core/preview/IonFileRenderer.java
@@ -8,6 +8,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
+import io.kestra.core.models.annotations.Plugin;
 import io.kestra.core.preview.FilePreview;
 import io.kestra.core.preview.FileRenderer;
 import io.kestra.core.serializers.FileSerde;
@@ -30,6 +31,7 @@ import static io.kestra.core.utils.Rethrow.throwConsumer;
     title = "ION file renderer",
     description = "Preview ION files inside the Kestra UI."
 )
+@Plugin
 public class IonFileRenderer implements FileRenderer {
     @Override
     public boolean supports(String extension) {

--- a/core/src/main/java/io/kestra/plugin/core/preview/PdfFileRenderer.java
+++ b/core/src/main/java/io/kestra/plugin/core/preview/PdfFileRenderer.java
@@ -1,5 +1,6 @@
 package io.kestra.plugin.core.preview;
 
+import io.kestra.core.models.annotations.Plugin;
 import io.kestra.core.preview.FilePreview;
 
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -18,6 +19,7 @@ import lombok.experimental.SuperBuilder;
     title = "PDF file renderer",
     description = "Preview PDF files inside the Kestra UI."
 )
+@Plugin
 public class PdfFileRenderer extends AbstractBase64FileRenderer {
     @Override
     protected FilePreview.Type getPreviewType() {

--- a/core/src/main/java/io/kestra/plugin/core/preview/TextFileRenderer.java
+++ b/core/src/main/java/io/kestra/plugin/core/preview/TextFileRenderer.java
@@ -7,7 +7,7 @@ import java.io.InputStreamReader;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.Optional;
-
+import io.kestra.core.models.annotations.Plugin;
 import io.kestra.core.preview.FilePreview;
 import io.kestra.core.preview.FileRenderer;
 import io.kestra.core.serializers.FileSerde;
@@ -28,6 +28,7 @@ import lombok.experimental.SuperBuilder;
     title = "Text file renderer",
     description = "Preview text files inside the Kestra UI, supported extensions: txt, md."
 )
+@Plugin
 public class TextFileRenderer implements FileRenderer {
     private static final int MAX_SIZE_IN_BYTES = 2_097_152; // 2 MB
 

--- a/core/src/test/java/io/kestra/plugin/core/preview/IonFileRendererTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/preview/IonFileRendererTest.java
@@ -1,12 +1,12 @@
 package io.kestra.plugin.core.preview;
 
 import java.io.*;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
-
 import io.kestra.core.preview.FilePreview;
 import io.kestra.core.serializers.FileSerde;
 
@@ -18,7 +18,7 @@ class IonFileRendererTest {
     void testTruncatedByLineCount(int lineCount, boolean truncated) throws IOException {
         File tempFile = File.createTempFile("unit", ".ion");
 
-        try (OutputStream output = new FileOutputStream(tempFile);) {
+        try (OutputStream output = new FileOutputStream(tempFile)) {
             for (int i = 0; i < lineCount; i++) {
                 FileSerde.write(output, Map.of(1, 2));
             }
@@ -29,5 +29,36 @@ class IonFileRendererTest {
         FilePreview rendered = renderer.render("ion", is, Optional.empty(), 100);
 
         assertThat(rendered.isTruncated()).isEqualTo(truncated);
+        assertThat(rendered.getType()).isEqualTo(FilePreview.Type.LIST);
+        List<?> content = (List<?>) rendered.getContent();
+        assertThat(content).hasSize(Math.min(lineCount, 100));
+    }
+
+    @ParameterizedTest
+    @CsvSource({ "1, true", "2, false" })
+    void shouldPreviewBinaryIonRows(int maxRows, boolean truncated) throws IOException {
+        File tempFile = File.createTempFile("unit", ".ion");
+
+        try (OutputStream output = new FileOutputStream(tempFile)) {
+            FileSerde.write(output, Map.of("order_id", "1", "customer_name", "Sagar Khandagre"));
+            FileSerde.write(output, Map.of("order_id", "2", "customer_name", "Miguel Moore"));
+        }
+
+        try (InputStream inputStream = new DataInputStream(new FileInputStream(tempFile))) {
+            IonFileRenderer renderer = new IonFileRenderer();
+
+            FilePreview rendered = renderer.render("ion", inputStream, Optional.empty(), maxRows);
+
+            assertThat(rendered.getExtension()).isEqualTo("ion");
+            assertThat(rendered.getType()).isEqualTo(FilePreview.Type.LIST);
+            assertThat(rendered.isTruncated()).isEqualTo(truncated);
+            assertThat(rendered.getContent())
+                .isEqualTo(
+                    List.of(
+                        Map.of("order_id", "1", "customer_name", "Sagar Khandagre"),
+                        Map.of("order_id", "2", "customer_name", "Miguel Moore")
+                    ).subList(0, maxRows)
+                );
+        }
     }
 }


### PR DESCRIPTION
**Closes #17092** 

**Root cause found:** backend was returning raw binary Ion as TEXT because built-in file renderers were not registered in the plugin service descriptor.

  So ExecutionController.previewFileFromExecution() fell back to TextFileRenderer instead of using IonFileRenderer.

  **Fixed:**

  - Added @Plugin to built-in file renderers:
      - IonFileRenderer
      - TextFileRenderer - ImageFileRenderer - PdfFileRenderer

  - Added regression coverage in IonFileRendererTest to assert binary Ion returns FilePreview.Type.LIST with row content.
  
  
  
[Screencast from 2026-07-04 20-20-29.webm](https://github.com/user-attachments/assets/6ab50829-7af0-4558-a27d-f81fe7a18931)
