### PR TITLE
build(core): exclude translation node scripts from browser type-check

### DIFF
--- a/ui/tsconfig.app.json
+++ b/ui/tsconfig.app.json
@@ -16,5 +16,10 @@
     "src/**/*.tsx",
     "src/**/*.vue",
     "src/**/*.json",
+  ],
+  "exclude": [
+    // Node scripts (use fs/path/url) — type-checked via tsconfig.test.json, not the browser app build.
+    "src/translations/check.ts",
+    "src/translations/compareTranslations.ts",
   ]
 }

--- a/ui/tsconfig.test.json
+++ b/ui/tsconfig.test.json
@@ -11,7 +11,9 @@
   ],
   "include": [
     ".storybook/preview.*",
-    "scripts/**/*.ts",  
+    "scripts/**/*.ts",
+    "src/translations/check.ts",
+    "src/translations/compareTranslations.ts",
     "tests/fixtures/**/*.ts",
     "tests/unit/**/*.ts",
     "tests/unit/**/*.tsx",


### PR DESCRIPTION
## What
The Node scripts `src/translations/check.ts` and `src/translations/compareTranslations.ts` use Node built-ins (`fs`, `path`, `url`). Because they live under `src/`, they were picked up by `tsconfig.app.json` — the browser app build, which sets `types: []` — and `vue-tsc --build tsconfig.app.json` failed with:

```
error TS2307: Cannot find module 'path' or its corresponding type declarations.
error TS2307: Cannot find module 'url' or its corresponding type declarations.
error TS2307: Cannot find module 'fs' or its corresponding type declarations.
```

## Fix
Exclude the two Node scripts from the browser app build and type-check them via `tsconfig.test.json` instead (which has Node types available), matching how `scripts/generate_translations.ts` is already handled.

## Context
Follow-up to https://github.com/kestra-io/kestra/pull/17249, which converted `check.js` → `check.ts` and introduced the shared `compareTranslations.ts`.

`npm run check:types` now passes all three steps (design-system, app, test).