### PR TITLE
docs(core): fix RegexConfiguration timeout default in Javadoc (10s, not 30s)

### DIFF
--- a/core/src/main/java/io/kestra/core/utils/RegexConfiguration.java
+++ b/core/src/main/java/io/kestra/core/utils/RegexConfiguration.java
@@ -18,7 +18,7 @@ public class RegexConfiguration {
 
     /**
      * Maximum duration for a single regex operation before it is aborted.
-     * Defaults to 30 seconds.
+     * Defaults to 10 seconds.
      */
     private Duration timeout = Duration.ofSeconds(10);
 

--- a/core/src/test/java/io/kestra/core/utils/RegexUtilsTest.java
+++ b/core/src/test/java/io/kestra/core/utils/RegexUtilsTest.java
@@ -150,4 +150,9 @@ class RegexUtilsTest {
         // Then it must be rejected
         assertThat(RegexUtils.isSafeUserRegex(null)).isFalse();
     }
+
+    @Test
+    void shouldDefaultConfigurationTimeoutToTenSeconds() {
+        assertThat(new RegexConfiguration().getTimeout()).isEqualTo(Duration.ofSeconds(10));
+    }
 }


### PR DESCRIPTION


The Javadoc on `RegexConfiguration.timeout` documents the wrong default for the
ReDoS abort timeout. It says the field "Defaults to 30 seconds", but the field is
initialized to `Duration.ofSeconds(10)`:

```java
/**
 * Maximum duration for a single regex operation before it is aborted.
 * Defaults to 30 seconds.   // <- doc says 30s
 */
private Duration timeout = Duration.ofSeconds(10);   // <- value is 10s
```

`RegexUtils.DEFAULT_TIMEOUT` is also `Duration.ofSeconds(10)`, and there is no
`kestra.regex.*` override in the shipped configuration, so the effective default
is 10 seconds. The 30s in the Javadoc is the only place that disagrees, and it has
been inaccurate since `RegexConfiguration` was introduced.

This changes the Javadoc to say 10 seconds so it matches the actual value, and
adds a small unit test asserting `new RegexConfiguration().getTimeout()` equals
`Duration.ofSeconds(10)`, so the documented default and the real one cannot
silently drift apart again. No behavior change: the timeout value is untouched.

### Related Issue

No existing issue; this is a documentation-vs-code correctness fix for a
security-relevant setting (the ReDoS backtracking guard applied to user-supplied
regex operations).

### Backend Checklist

- [x] Code compiles successfully and passes all checks
- [x] All unit and integration tests pass

### Additional Notes

Verified with `./gradlew :core:test --tests "io.kestra.core.utils.RegexUtilsTest"`
(10/10 passing, including the new `shouldDefaultConfigurationTimeoutToTenSeconds`).

If you would rather keep the 30s wording and change the value instead, let me know
and I will flip the direction; I aligned the doc to the code because two
independent sites (the field initializer and `RegexUtils.DEFAULT_TIMEOUT`) already
agree on 10 seconds.
