### PR TITLE
test(scheduler): assert nextEvaluationDate in shouldRecoverMissingScheduleGivenLAST

### DIFF
--- a/scheduler/src/test/java/io/kestra/scheduler/TriggerSchedulerTest.java
+++ b/scheduler/src/test/java/io/kestra/scheduler/TriggerSchedulerTest.java
@@ -449,7 +449,7 @@ class TriggerSchedulerTest {
                 assertThat(currentTriggerState.isLocked()).isTrue();
                 assertThat(currentTriggerState.getEvaluatedAt()).isEqualTo(expectedNextEvaluationNDate.minusMinutes(15).toInstant());
                 assertThat(currentTriggerState.getUpdatedAt()).isEqualTo(SchedulerClock.now().toInstant());
-                assertThat(expectedNextEvaluationNDate);
+                assertThat(currentTriggerState.getNextEvaluationDate()).isEqualTo(expectedNextEvaluationNDate.toInstant());
 
                 // Assert NO Execution
                 assertThat(triggerExecutionPublisher.executions().size()).isEqualTo(1);


### PR DESCRIPTION


`TriggerSchedulerTest.shouldRecoverMissingScheduleGivenLAST` asserts the trigger
state after each `onSchedule`. In the first-call block, the check on the
recovered next-evaluation date was written as:

```java
assertThat(expectedNextEvaluationNDate);
```

That is an AssertJ `assertThat(...)` with no terminal matcher: it builds an
`AbstractZonedDateTimeAssert` and discards it, so it asserts nothing. Under
`RecoverMissedSchedules.LAST`, the `nextEvaluationDate` set after the first
recovery was therefore never verified, giving false coverage.

This restores the intended assertion, matching the pattern already used by the
second-call block of the same test and by `shouldRecoverMissingScheduleGivenNONE`:

```java
assertThat(currentTriggerState.getNextEvaluationDate())
    .isEqualTo(expectedNextEvaluationNDate.toInstant());
```

The now-live assertion passes, so the LAST-recovery next-evaluation date was
already correct; this simply makes the test actually cover it. No production code
changes.

### Related Issue

No tracked issue. This is a self-contained test-correctness fix (a dropped
AssertJ terminal matcher) found while reading the scheduler tests.

### Backend Checklist

- [x] Code compiles successfully and passes all checks
- [x] All unit and integration tests pass

### Additional Notes

Verified red -> green: temporarily changing the expected value to
`expectedNextEvaluationNDate.plusHours(999)` makes the previously-dead assertion
fail (`expected: ...T04:30:00Z but was: ...T13:30:00Z`), confirming it now
executes and validates a real value; reverted afterwards. Ran with
`--rerun-tasks` so the result is a genuine execution, not a cached one:

```
./gradlew :scheduler:test \
  --tests "io.kestra.scheduler.TriggerSchedulerTest.shouldRecoverMissingScheduleGivenLAST" \
  --tests "io.kestra.scheduler.TriggerSchedulerTest.shouldRecoverMissingScheduleGivenNONE"
```

Both tests pass.
