### PR TITLE
fix(core): pin brotli4j native artifacts to fix UnsatisfiedLinkError

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -44,6 +44,23 @@ dependencies {
     implementation 'com.github.ksuid:ksuid:1.1.4'
     api 'org.apache.httpcomponents.client5:httpclient5'
 
+    // httpclient5's content-compression support (DecompressingEntity) detects brotli4j
+    // reflectively whenever it's on the classpath (pulled in by any module/plugin) and turns on
+    // Brotli negotiation for every HTTP request. Without a matching native artifact,
+    // DecoderJNI.nativeCreate throws UnsatisfiedLinkError as soon as a server actually replies
+    // with Content-Encoding: br. Pin base+native to the same version so Brotli either works
+    // end-to-end or isn't silently half-wired.
+    constraints {
+        implementation('com.aayushatharva.brotli4j:brotli4j') {
+            version { strictly '1.23.0' }
+        }
+    }
+    runtimeOnly 'com.aayushatharva.brotli4j:brotli4j:1.23.0'
+    runtimeOnly 'com.aayushatharva.brotli4j:native-linux-x86_64:1.23.0'
+    runtimeOnly 'com.aayushatharva.brotli4j:native-linux-aarch64:1.23.0'
+    runtimeOnly 'com.aayushatharva.brotli4j:native-osx-x86_64:1.23.0'
+    runtimeOnly 'com.aayushatharva.brotli4j:native-osx-aarch64:1.23.0'
+
     // plugins
     implementation 'org.apache.maven.resolver:maven-resolver-impl'
     implementation 'org.apache.maven.resolver:maven-resolver-supplier-mvn3'


### PR DESCRIPTION
## Summary
- `io.kestra.plugin.core.http.Request` crashes with `UnsatisfiedLinkError` (`DecoderJNI.nativeCreate`) whenever the remote server replies with `Content-Encoding: br` (e.g. dummyjson.com behind Cloudflare).
- httpclient5's `DecompressingEntity`/`ContentCompressionExec` reflectively detects `brotli4j` on the classpath (pulled in transitively by any module or installed plugin, not declared by httpclient5 itself) and enables Brotli negotiation for every HTTP request made through `HttpClient`. When only the pure-Java `brotli4j` base jar ends up resolved without the matching native platform artifact, decoding blows up at runtime instead of failing to resolve at build time.
- Fix: explicitly declare `brotli4j` + native artifacts for linux/osx (x86_64/aarch64) in `core/build.gradle`, pinned to the same version via a `strictly` constraint so base and native jars can never drift apart and cause a version mismatch.
- Verified `:core:dependencyInsight --dependency brotli4j` resolves all native artifacts + base + `service` module at a single consistent version, and `:core:compileJava` is unaffected.

Repro flow (fails today on `develop`/`1.3.13`):
```yaml
id: request
namespace: sanitychecks

tasks:
  - id: request
    type: io.kestra.plugin.core.http.Request
    uri: https://dummyjson.com/products
```

## Test plan
- [x] `./gradlew :core:dependencyInsight --dependency brotli4j --configuration runtimeClasspath` shows base + native (linux-x86_64/aarch64, osx-x86_64/aarch64) + service all at `1.23.0`
- [x] `./gradlew :core:compileJava` succeeds
- [ ] Re-run the sanity-check flow above against a build with this change and confirm no `UnsatisfiedLinkError`