### PR TITLE
fix(tasks): stop HTTP client from negotiating Brotli

### DIFF
--- a/core/src/main/java/io/kestra/core/http/client/HttpClient.java
+++ b/core/src/main/java/io/kestra/core/http/client/HttpClient.java
@@ -33,6 +33,7 @@ import org.apache.hc.client5.http.ssl.NoopHostnameVerifier;
 import org.apache.hc.client5.http.ssl.SSLConnectionSocketFactory;
 import org.apache.hc.core5.http.ContentType;
 import org.apache.hc.core5.http.HttpEntity;
+import org.apache.hc.core5.http.HttpHeaders;
 import org.apache.hc.core5.http.ParseException;
 import org.apache.hc.core5.http.io.HttpClientResponseHandler;
 import org.apache.hc.core5.http.io.SocketConfig;
@@ -91,6 +92,14 @@ public class HttpClient implements Closeable {
         org.apache.hc.client5.http.impl.classic.HttpClientBuilder builder = HttpClients.custom()
             .disableDefaultUserAgent()
             .setUserAgent("Kestra");
+
+        // Advertise only gzip/deflate so the client never negotiates Brotli (Accept-Encoding: br).
+        // HttpClient5 auto-detects brotli4j on the classpath (e.g. brought in by a plugin) and would
+        // otherwise offer `br`, then fail with UnsatisfiedLinkError when the matching native artifact
+        // is missing. Setting the header explicitly wins: ContentCompressionExec only adds its own
+        // Accept-Encoding when the request has none, so gzip/deflate responses are still auto-decoded.
+        builder.addRequestInterceptorFirst((request, entity, context) ->
+            request.setHeader(HttpHeaders.ACCEPT_ENCODING, "gzip, x-gzip, deflate"));
 
         if (observationRegistry != null) {
             // micrometer, must be placed before the retry strategy (see https://docs.micrometer.io/micrometer/reference/reference/httpcomponents.html#_retry_strategy_considerations)

--- a/core/src/test/java/io/kestra/core/http/client/HttpClientTest.java
+++ b/core/src/test/java/io/kestra/core/http/client/HttpClientTest.java
@@ -173,6 +173,23 @@ class HttpClientTest {
     }
 
     @Test
+    void shouldOfferGzipButNeverBrotli() throws IllegalVariableEvaluationException, HttpClientException, IOException {
+        // Given / When: the client advertises its accepted encodings to the server
+        try (HttpClient client = client()) {
+            HttpResponse<String> response = client.request(
+                HttpRequest.of(URI.create(embeddedServerUri + "/http/accept-encoding")),
+                String.class
+            );
+
+            // Then: gzip/deflate are offered (compression preserved) but Brotli (br) is never negotiated,
+            // so httpclient5 never invokes brotli4j and cannot throw UnsatisfiedLinkError.
+            assertThat(response.getStatus().getCode()).isEqualTo(200);
+            assertThat(response.getBody()).contains("gzip");
+            assertThat(response.getBody()).doesNotContain("br");
+        }
+    }
+
+    @Test
     void getJsonMap() throws IllegalVariableEvaluationException, HttpClientException, IOException {
         try (HttpClient client = client()) {
             HttpResponse<Map<String, String>> response = client.request(
@@ -543,6 +560,13 @@ class HttpClientTest {
         @Produces(MediaType.TEXT_PLAIN)
         public io.micronaut.http.HttpResponse<String> contentType(io.micronaut.http.HttpRequest<?> request) {
             return io.micronaut.http.HttpResponse.ok(request.getContentType().orElseThrow().toString());
+        }
+
+        @Get("accept-encoding")
+        @Produces(MediaType.TEXT_PLAIN)
+        public io.micronaut.http.HttpResponse<String> acceptEncoding(io.micronaut.http.HttpRequest<?> request) {
+            String encoding = request.getHeaders().get(HttpHeaders.ACCEPT_ENCODING);
+            return io.micronaut.http.HttpResponse.ok(encoding == null ? "" : encoding);
         }
 
         @Get("json")


### PR DESCRIPTION
## What
The HTTP tasks (`io.kestra.plugin.core.http.*`) wrap Apache HttpClient5, which keeps content compression enabled by default and **reflectively detects `brotli4j` on the classpath**. When `brotli4j` is present it advertises `Accept-Encoding: br` and registers a Brotli decoder. If the base jar is present but its **native artifact is missing or version-mismatched**, decoding a `Content-Encoding: br` response (e.g. from a Cloudflare-fronted server like `dummyjson.com`) crashes with `UnsatisfiedLinkError`.

This forces `Accept-Encoding: gzip, x-gzip, deflate` via a request interceptor in `HttpClient.createClient()`, so Brotli is never negotiated — while gzip/deflate responses stay transparently decoded (no bandwidth regression).

## Why this approach
`brotli4j` is **not** a dependency of core (`httpclient5` declares it `optional`); in the failing scenario it reaches the classpath from a **loaded plugin jar**. Fixing it in our own client is therefore more robust than pinning `brotli4j` + native artifacts in `core/build.gradle` (cf. #17275), which:
- doesn't cover Windows (only linux/osx natives),
- ships several MB of native binaries to every deployment,
- needs re-pinning on every httpclient5 upgrade,
- may not even govern the plugin classloader that actually crashes.

HttpClient5's `ContentCompressionExec` only adds its own `Accept-Encoding` when the request has none (verified in the 5.6.2 bytecode), so the explicit header wins.

## Tests
Added `shouldOfferGzipButNeverBrotli` in `HttpClientTest` (plus an `/http/accept-encoding` echo endpoint) asserting the outgoing header offers `gzip` and never `br`. Verified with `./gradlew :core:test --tests "io.kestra.core.http.client.HttpClientTest"`.

Alternative to #17275.