### PR TITLE
fix(kv): translate duplicate-key and duration validator errors

### DIFF
--- a/ui/src/components/kv/KVTable.vue
+++ b/ui/src/components/kv/KVTable.vue
@@ -551,7 +551,7 @@
 
     function durationValidator(_rule: any, value: string, callback: (error?: Error) => void) {
         if (value !== undefined && !value.match(/^P(?=[^T]|T.)(?:\d*D)?(?:T(?=.)(?:\d*H)?(?:\d*M)?(?:\d*S)?)?$/)) {
-            callback(new Error("datepicker.error"))
+            callback(new Error(t("datepicker.error")))
         } else {
             callback()
         }

--- a/ui/src/components/kv/KVTable.vue
+++ b/ui/src/components/kv/KVTable.vue
@@ -561,7 +561,7 @@
 
     function kvKeyDuplicate(_rule: any, value: string, callback: (error?: Error) => void) {
         if (kv.value.update === undefined && kvs.value && kvs.value.find(r => r.namespace === kv.value.namespace && r.key === value)) {
-            return callback(new Error("kv.duplicate"))
+            return callback(new Error(t("kv.duplicate")))
         } else {
             callback()
         }


### PR DESCRIPTION
- The KV Store create/edit form's duplicate-key and invalid-duration validators returned raw i18n keys (`kv.duplicate`, `datepicker.error`) instead of translated messages — both now go through `t()`, matching the other validators in the same file.