### PR TITLE
fix(core): validate REGEX filter patterns to prevent catastrophic backtracking (ReDoS)

### DIFF
--- a/core/src/main/java/io/kestra/core/models/QueryFilter.java
+++ b/core/src/main/java/io/kestra/core/models/QueryFilter.java
@@ -14,6 +14,7 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import io.kestra.core.exceptions.InvalidQueryFiltersException;
 import io.kestra.core.models.dashboards.filters.*;
 import io.kestra.core.utils.Enums;
+import io.kestra.core.utils.RegexUtils;
 
 import lombok.Builder;
 
@@ -776,6 +777,15 @@ public record QueryFilter(
                     filter.field().name(), resource.name(),
                     resource.supportedField().stream().map(Field::name).collect(Collectors.joining(", "))
                 )
+            );
+        }
+        if (
+            filter.operation() == Op.REGEX
+                && filter.value() instanceof String pattern
+                && !RegexUtils.isSafeUserRegex(pattern)
+        ) {
+            errors.add(
+                "REGEX pattern for field %s is too long or prone to catastrophic backtracking".formatted(filter.field().name())
             );
         }
     }

--- a/core/src/main/java/io/kestra/core/models/dashboards/filters/Regex.java
+++ b/core/src/main/java/io/kestra/core/models/dashboards/filters/Regex.java
@@ -2,6 +2,8 @@ package io.kestra.core.models.dashboards.filters;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 
+import io.kestra.core.validations.SafeRegexValidation;
+
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import lombok.Builder;
@@ -22,5 +24,6 @@ public class Regex<F extends Enum<F>> extends AbstractFilter<F> {
     protected FilterType type = FilterType.REGEX;
 
     @NotNull
+    @SafeRegexValidation
     private String value;
 }

--- a/core/src/main/java/io/kestra/core/utils/RegexUtils.java
+++ b/core/src/main/java/io/kestra/core/utils/RegexUtils.java
@@ -22,6 +22,12 @@ public final class RegexUtils {
     private static final Duration DEFAULT_TIMEOUT = Duration.ofSeconds(10);
     private static final AtomicBoolean initialized = new AtomicBoolean(false);
 
+    /**
+     * Maximum length allowed for a user-supplied regex pattern that is executed by the database engine.
+     * Longer patterns are rejected without evaluation.
+     */
+    public static final int MAX_USER_REGEX_LENGTH = 250;
+
     private static volatile Duration timeout = DEFAULT_TIMEOUT;
 
     private RegexUtils() {
@@ -156,6 +162,59 @@ public final class RegexUtils {
     public static String replaceAll(String input, String regex, String replacement, Duration timeout) {
         Pattern pattern = Pattern.compile(regex);
         return matcher(pattern, input, timeout).replaceAll(replacement);
+    }
+
+    /**
+     * A repetition quantifier: {@code +}, {@code *}, {@code ?} (unescaped — a backslash-escaped
+     * {@code \+}/{@code \*}/{@code \?} is a literal character, not a quantifier), or a curly-brace
+     * count ({@code {n}}, {@code {n,}}, {@code {n,m}}).
+     */
+    private static final String QUANTIFIER = "(?:(?<!\\\\)[+*?]|\\{\\d+(?:,\\d*)?})";
+
+    /**
+     * A group containing a quantifier (including {@code ?}, e.g. {@code (a?)}) that is itself
+     * followed by another quantifier, e.g. {@code (a+)+}, {@code (a*)*}, {@code (a?){25}}. Nesting an
+     * optional/unbounded quantifier inside a repeated group is the classic signature of catastrophic
+     * backtracking (ReDoS), whether the outer repetition is unbounded ({@code +}/{@code *}) or a large
+     * bounded count ({@code {25}}).
+     */
+    private static final Pattern NESTED_QUANTIFIER = Pattern.compile(
+        "\\([^()]*" + QUANTIFIER + "[^()]*\\)\\s*" + QUANTIFIER
+    );
+
+    /**
+     * A group containing a top-level alternation ({@code |}) that is itself followed by a
+     * quantifier, e.g. {@code (a|a)+}, {@code (a|ab)*}. Ambiguous alternation combined with
+     * repetition is another classic catastrophic-backtracking shape, distinct from a nested
+     * quantifier.
+     */
+    private static final Pattern ALTERNATION_WITH_REPETITION = Pattern.compile(
+        "\\([^()|]*\\|[^()]*\\)\\s*" + QUANTIFIER
+    );
+
+    /**
+     * Checks whether a user-supplied regex pattern is safe to execute against a database engine
+     * (e.g. via Postgres {@code ~} or MySQL {@code REGEXP}), which offer no backtracking timeout of
+     * their own.
+     *
+     * <p>
+     * This is a heuristic, not a full ReDoS analysis: it rejects patterns that are too long, and
+     * patterns containing a group with a nested quantifier (e.g. {@code (a+)+}, {@code (a?){25}}) or a
+     * repeated ambiguous alternation (e.g. {@code (a|a)+}) — the two most common causes of
+     * catastrophic backtracking. Other shapes (e.g. backreference-based ambiguity, or blowup spread
+     * across multiple sibling groups) are not covered.
+     * </p>
+     *
+     * @param pattern the user-supplied regex pattern.
+     * @return {@code true} if the pattern is within the length limit and contains neither a nested
+     *         quantifier nor a repeated alternation.
+     */
+    public static boolean isSafeUserRegex(String pattern) {
+        if (pattern == null || pattern.length() > MAX_USER_REGEX_LENGTH) {
+            return false;
+        }
+        return !NESTED_QUANTIFIER.matcher(pattern).find()
+            && !ALTERNATION_WITH_REPETITION.matcher(pattern).find();
     }
 
     /**

--- a/core/src/main/java/io/kestra/core/validations/SafeRegexValidation.java
+++ b/core/src/main/java/io/kestra/core/validations/SafeRegexValidation.java
@@ -1,0 +1,22 @@
+package io.kestra.core.validations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import io.kestra.core.validations.validator.SafeRegexValidator;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = SafeRegexValidator.class)
+@Target({ ElementType.FIELD, ElementType.PARAMETER, ElementType.TYPE_USE })
+public @interface SafeRegexValidation {
+    String message() default "regex pattern is too long or prone to catastrophic backtracking";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+}

--- a/core/src/main/java/io/kestra/core/validations/validator/SafeRegexValidator.java
+++ b/core/src/main/java/io/kestra/core/validations/validator/SafeRegexValidator.java
@@ -1,0 +1,19 @@
+package io.kestra.core.validations.validator;
+
+import io.kestra.core.utils.RegexUtils;
+import io.kestra.core.validations.SafeRegexValidation;
+
+import io.micronaut.core.annotation.AnnotationValue;
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.core.annotation.Nullable;
+import io.micronaut.validation.validator.constraints.ConstraintValidator;
+import io.micronaut.validation.validator.constraints.ConstraintValidatorContext;
+import jakarta.inject.Singleton;
+
+@Singleton
+public class SafeRegexValidator implements ConstraintValidator<SafeRegexValidation, String> {
+    @Override
+    public boolean isValid(@Nullable String value, @NonNull AnnotationValue<SafeRegexValidation> annotationMetadata, @NonNull ConstraintValidatorContext context) {
+        return value == null || RegexUtils.isSafeUserRegex(value);
+    }
+}

--- a/core/src/test/java/io/kestra/core/models/QueryFilterTest.java
+++ b/core/src/test/java/io/kestra/core/models/QueryFilterTest.java
@@ -789,6 +789,36 @@ public class QueryFilterTest {
     }
 
     @Test
+    void shouldThrowExceptionWhenRegexIsCatastrophic() {
+        // Given a REGEX filter prone to catastrophic backtracking
+        QueryFilter filter = QueryFilter.builder()
+            .field(Field.NAMESPACE)
+            .operation(Op.REGEX)
+            .value("(a+)+")
+            .build();
+
+        // When / Then — it must be rejected before reaching any repository backend
+        InvalidQueryFiltersException e = assertThrows(
+            InvalidQueryFiltersException.class,
+            () -> QueryFilter.validateQueryFilters(List.of(filter), Resource.EXECUTION)
+        );
+        assertThat(e.getMessage()).contains("catastrophic backtracking");
+    }
+
+    @Test
+    void shouldNotThrowExceptionWhenRegexIsSafe() {
+        // Given a safe REGEX filter
+        QueryFilter filter = QueryFilter.builder()
+            .field(Field.NAMESPACE)
+            .operation(Op.REGEX)
+            .value("io\\.kestra\\..*")
+            .build();
+
+        // When / Then
+        assertDoesNotThrow(() -> QueryFilter.validateQueryFilters(List.of(filter), Resource.EXECUTION));
+    }
+
+    @Test
     void shouldReturnPrefixFilterWhenOperationIsPrefix() {
         QueryFilter filter = QueryFilter.builder()
             .field(Field.NAMESPACE)

--- a/core/src/test/java/io/kestra/core/utils/RegexUtilsTest.java
+++ b/core/src/test/java/io/kestra/core/utils/RegexUtilsTest.java
@@ -3,8 +3,12 @@ package io.kestra.core.utils;
 import java.time.Duration;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Stream;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -89,5 +93,61 @@ class RegexUtilsTest {
         } finally {
             RegexUtils.resetInit();
         }
+    }
+
+    static Stream<Arguments> unsafeUserRegex() {
+        return Stream.of(
+            // Nested unbounded quantifiers
+            Arguments.of("(a+)+b"),
+            Arguments.of("(a*)*"),
+            Arguments.of("(.*)*"),
+            Arguments.of("(a+)*"),
+            Arguments.of("(a{1,})+"),
+            // Ambiguous alternation under repetition
+            Arguments.of("(a|a)+$"),
+            // Bounded-but-large nested quantifier ("Zalgo" shape) — no unbounded quantifier character at all
+            Arguments.of("(a?){25}b"),
+            Arguments.of("a".repeat(RegexUtils.MAX_USER_REGEX_LENGTH + 1))
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("unsafeUserRegex")
+    void shouldRejectUnsafeUserRegex(String pattern) {
+        // Given a pattern prone to catastrophic backtracking (or too long to evaluate)
+        // When checking whether it is safe to run against a database engine
+        // Then it must be rejected
+        assertThat(RegexUtils.isSafeUserRegex(pattern)).isFalse();
+    }
+
+    static Stream<Arguments> safeUserRegex() {
+        return Stream.of(
+            Arguments.of("[a-z]+"),
+            Arguments.of("hello.*world"),
+            Arguments.of("(abc)+"),
+            Arguments.of("flow_\\d+"),
+            Arguments.of("io\\.kestra\\..*"),
+            // A single quantifier on an escaped literal '+' — no ambiguity, must not be mistaken for
+            // a nested unbounded quantifier
+            Arguments.of("(a\\+)+"),
+            Arguments.of("")
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("safeUserRegex")
+    void shouldAcceptSafeUserRegex(String pattern) {
+        // Given a pattern with no catastrophic-backtracking risk
+        // When checking whether it is safe to run against a database engine
+        // Then it must be accepted
+        assertThat(RegexUtils.isSafeUserRegex(pattern)).isTrue();
+    }
+
+    @Test
+    void shouldRejectNullUserRegex() {
+        // Given a null pattern
+        // When checking whether it is safe to run against a database engine
+        // Then it must be rejected
+        assertThat(RegexUtils.isSafeUserRegex(null)).isFalse();
     }
 }

--- a/core/src/test/java/io/kestra/core/validations/SafeRegexValidationTest.java
+++ b/core/src/test/java/io/kestra/core/validations/SafeRegexValidationTest.java
@@ -1,0 +1,55 @@
+package io.kestra.core.validations;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+
+import io.kestra.core.junit.annotations.KestraTest;
+import io.kestra.core.models.dashboards.filters.Regex;
+import io.kestra.core.models.validations.ModelValidator;
+
+import jakarta.inject.Inject;
+import jakarta.validation.ConstraintViolationException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@KestraTest
+class SafeRegexValidationTest {
+    @Inject
+    private ModelValidator modelValidator;
+
+    enum TestField {
+        NAMESPACE
+    }
+
+    @Test
+    void shouldValidateSafeRegex() {
+        // Given
+        Regex<TestField> filter = Regex.<TestField> builder()
+            .field(TestField.NAMESPACE)
+            .value("io\\.kestra\\..*")
+            .build();
+
+        // When
+        Optional<ConstraintViolationException> valid = modelValidator.isValid(filter);
+
+        // Then
+        assertThat(valid.isEmpty()).isTrue();
+    }
+
+    @Test
+    void shouldNotValidateCatastrophicRegex() {
+        // Given
+        Regex<TestField> filter = Regex.<TestField> builder()
+            .field(TestField.NAMESPACE)
+            .value("(a+)+")
+            .build();
+
+        // When
+        Optional<ConstraintViolationException> valid = modelValidator.isValid(filter);
+
+        // Then
+        assertThat(valid.isPresent()).isTrue();
+        assertThat(valid.get().getMessage()).contains("catastrophic backtracking");
+    }
+}

--- a/jdbc/src/test/java/io/kestra/jdbc/repository/AbstractSQLInjectionTest.java
+++ b/jdbc/src/test/java/io/kestra/jdbc/repository/AbstractSQLInjectionTest.java
@@ -5,6 +5,7 @@ import java.util.Map;
 
 import org.junit.jupiter.api.Test;
 
+import io.kestra.core.exceptions.InvalidQueryFiltersException;
 import io.kestra.core.models.Label;
 import io.kestra.core.models.QueryFilter;
 import io.kestra.core.models.flows.Flow;
@@ -21,6 +22,7 @@ import jakarta.inject.Inject;
 
 import static io.kestra.core.repositories.AbstractExecutionRepositoryTest.builder;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @MicronautTest
 public abstract class AbstractSQLInjectionTest {
@@ -219,6 +221,36 @@ public abstract class AbstractSQLInjectionTest {
         } finally {
             deleteFlow(flow);
         }
+    }
+
+    private static final String CATASTROPHIC_REGEX_PATTERN = "(a+)+$";
+
+    private QueryFilter catastrophicRegexFilter() {
+        return QueryFilter.builder()
+            .field(QueryFilter.Field.NAMESPACE)
+            .operation(QueryFilter.Op.REGEX)
+            .value(CATASTROPHIC_REGEX_PATTERN)
+            .build();
+    }
+
+    @Test
+    void flowRegexFilterShouldRejectCatastrophicBacktrackingPattern() {
+        String tenant = TestsUtils.randomTenant(this.getClass().getSimpleName());
+
+        // A REGEX filter prone to catastrophic backtracking must be rejected before reaching the DB engine
+        assertThatThrownBy(() -> flowRepository.find(Pageable.UNPAGED, tenant, List.of(catastrophicRegexFilter())))
+            .as("REGEX with a catastrophic-backtracking pattern should be rejected")
+            .isInstanceOf(InvalidQueryFiltersException.class);
+    }
+
+    @Test
+    void executionRegexFilterShouldRejectCatastrophicBacktrackingPattern() {
+        var tenant = TestsUtils.randomTenant(this.getClass().getSimpleName());
+
+        // Same guard on the execution repository's QueryFilter path
+        assertThatThrownBy(() -> executionRepository.find(Pageable.from(1, 10), tenant, List.of(catastrophicRegexFilter())))
+            .as("REGEX with a catastrophic-backtracking pattern should be rejected")
+            .isInstanceOf(InvalidQueryFiltersException.class);
     }
 
     private void deleteFlow(Flow flow) {

--- a/webserver/src/main/java/io/kestra/webserver/controllers/api/DashboardController.java
+++ b/webserver/src/main/java/io/kestra/webserver/controllers/api/DashboardController.java
@@ -347,6 +347,7 @@ public class DashboardController {
     private FetchChartDataQuery buildChartPreviewDataQuery(PreviewRequest previewRequest) {
         String tenantId = tenantService.resolveTenant();
         Chart<?> chart = YamlParser.parse(previewRequest.chart(), Chart.class);
+        modelValidator.validate(chart);
         ChartFiltersOverrides globalFilter = previewRequest.globalFilter();
 
         List<QueryFilter> filters = globalFilter != null ? globalFilter.getFilters() : null;

--- a/webserver/src/test/java/io/kestra/webserver/controllers/api/DashboardControllerTest.java
+++ b/webserver/src/test/java/io/kestra/webserver/controllers/api/DashboardControllerTest.java
@@ -750,4 +750,35 @@ class DashboardControllerTest {
         assertThat(chartData.getTotal()).isEqualTo(1);
         assertThat(chartData.getResults().get(0).get("execution_id")).isEqualTo(idForLabelAC);
     }
+
+    @Test
+    void previewShouldRejectCatastrophicRegexInWhereClause() {
+        // A REGEX filter embedded directly in an ad-hoc (non-persisted) chart definition must be
+        // rejected before it ever reaches a repository backend — this endpoint bypasses the normal
+        // dashboard create/update validation, so the chart itself must still be validated.
+        String chartYaml = """
+            id: table_executions_chart_id
+            type: io.kestra.plugin.core.dashboard.chart.Table
+            data:
+              type: io.kestra.plugin.core.dashboard.data.Executions
+              columns:
+                execution_id:
+                  field: ID
+              where:
+                - field: NAMESPACE
+                  type: REGEX
+                  value: "(a+)+"
+            """;
+
+        var previewRequest = new DashboardController.PreviewRequest(chartYaml, null);
+
+        HttpClientResponseException httpClientResponseException = Assertions.assertThrows(
+            HttpClientResponseException.class, () -> client.toBlocking().retrieve(
+                POST(DASHBOARD_PATH + "/charts/preview", previewRequest),
+                PagedResults.class
+            )
+        );
+        assertThat(httpClientResponseException.getStatus().getCode()).isEqualTo(422);
+        assertThat(httpClientResponseException.getMessage()).contains("catastrophic backtracking");
+    }
 }


### PR DESCRIPTION
## Summary

- A user-supplied `REGEX` filter pattern was passed unvalidated to the database engine's regex evaluator (JDBC `likeRegex`, Elasticsearch `regexp` in the EE codebase), so a crafted pattern with catastrophic backtracking could lock a DB thread for an extended period (ReDoS).
- `QueryFilter.validateQueryFilters` now rejects unsafe `REGEX` values via `RegexUtils.isSafeUserRegex`. It is already called by `AbstractJdbcRepository.filter()` (and, in the EE codebase, the Elasticsearch repository's `findQueryFilter()` gateways), so this single change protects every JDBC-backed and Elasticsearch-backed resource without duplicating the check per repository.
- Added a `@SafeRegexValidation` Bean Validation constraint on `Regex.value` (the dashboard/`AbstractFilter` filter model), which fires wherever `ModelValidator.validate(...)` cascades through a chart's `where` clause — covering `JdbcFilterService` and the EE `ElasticSearchFilterService` the same way.
- Found and fixed a related gap while investigating: the `/charts/preview` and `/charts/export/to-csv` endpoints parsed ad-hoc chart YAML but never called model validation at all, so they bypassed all Bean Validation constraints, not just this one.
- `RegexUtils.isSafeUserRegex` is a heuristic (documented as such): it flags nested quantifiers (`(a+)+`, `(a?){25}`) and repeated ambiguous alternation (`(a|a)+`), the two most common catastrophic-backtracking shapes, while correctly leaving safe patterns like escaped literals (`(a\+)+`) alone.

Fixes https://github.com/kestra-io/kestra-ee/issues/8001
Fixes https://github.com/kestra-io/kestra-ee/issues/9028

## Test plan

- [x] `core:test` — `QueryFilterTest`, `RegexUtilsTest`, `SafeRegexValidationTest` (new unit tests for the heuristic and both validation entry points)
- [x] `jdbc-h2:test` — `H2SQLInjectionTest` (end-to-end: a catastrophic REGEX filter is rejected before reaching H2 via both the flow and execution repositories)
- [x] `webserver:test` — `DashboardControllerTest` (end-to-end: `/charts/preview` now rejects a catastrophic REGEX embedded in an ad-hoc chart's `where` clause with a 422)
- [x] Verified against a real Elasticsearch instance in the EE codebase (companion PR) that the same centralized check protects the ES-backed repository with no EE-side code changes needed — see kestra-io/kestra-ee#<PR>