### PR TITLE
feat(plugins): support kv() and secret() in task version field

### DIFF
--- a/core/src/main/java/io/kestra/core/services/PluginDefaultService.java
+++ b/core/src/main/java/io/kestra/core/services/PluginDefaultService.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.annotations.VisibleForTesting;
 
 import io.kestra.core.exceptions.FlowProcessingException;
+import io.kestra.core.exceptions.IllegalVariableEvaluationException;
 import io.kestra.core.exceptions.KestraRuntimeException;
 import io.kestra.core.models.Plugin;
 import io.kestra.core.models.executions.Execution;
@@ -33,12 +34,16 @@ import io.kestra.core.models.flows.FlowWithSource;
 import io.kestra.core.models.flows.PluginDefault;
 import io.kestra.core.models.flows.PluginDefaultSpec;
 import io.kestra.core.plugins.PluginRegistry;
+import io.kestra.core.runners.RunContextCache;
 import io.kestra.core.runners.RunContextLogger;
 import io.kestra.core.runners.RunContextLoggerFactory;
+import io.kestra.core.runners.RunVariables;
+import io.kestra.core.runners.VariableRenderer;
 import io.kestra.core.serializers.JacksonMapper;
 import io.kestra.core.serializers.YamlParser;
 import io.kestra.core.utils.Logs;
 import io.kestra.core.utils.MapUtils;
+import io.kestra.core.utils.PebbleUtil;
 
 import io.micronaut.core.annotation.Nullable;
 import jakarta.annotation.PostConstruct;
@@ -71,14 +76,22 @@ public class PluginDefaultService {
 
     protected final PluginRegistry pluginRegistry;
 
+    private final VariableRenderer variableRenderer;
+
+    private final RunContextCache runContextCache;
+
     @Inject
     public PluginDefaultService(
         @Nullable PluginGlobalDefaultConfiguration pluginGlobalDefault,
         RunContextLoggerFactory runContextLoggerFactory,
-        PluginRegistry pluginRegistry) {
+        PluginRegistry pluginRegistry,
+        VariableRenderer variableRenderer,
+        RunContextCache runContextCache) {
         this.pluginGlobalDefault = pluginGlobalDefault;
         this.runContextLoggerFactory = runContextLoggerFactory;
         this.pluginRegistry = pluginRegistry;
+        this.variableRenderer = variableRenderer;
+        this.runContextCache = runContextCache;
     }
 
     @PostConstruct
@@ -387,6 +400,7 @@ public class PluginDefaultService {
         revision = revision == null ? (Integer) mapFlow.get("revision") : revision;
 
         mapFlow = innerInjectDefault(tenant, namespace, mapFlow, onlyVersions);
+        mapFlow = renderPluginVersions(tenant, namespace, mapFlow);
 
         FlowWithSource withDefault = YamlParser.parse(mapFlow, FlowWithSource.class, strictParsing);
 
@@ -457,6 +471,61 @@ public class PluginDefaultService {
 
         return flowAsMap;
 
+    }
+
+    /**
+     * Renders Pebble expressions found in the {@code version} field of any plugin node (task, trigger, ...) in the
+     * given flow map, e.g. {@code version: "{{ kv('PLUGIN_VERSION') }}"}.
+     * <p>
+     * This runs once at flow parse/save time, before the plugin classloader is resolved from the raw
+     * {@code type:version} identifier, so no execution exists yet: only {@code kv()}, {@code secret()} and
+     * {@code env()} are resolvable (tenant/namespace-scoped, from the flow's own metadata). Referencing an
+     * execution-scoped variable (outputs, inputs, vars, ...) fails with a clear error rather than being ignored.
+     *
+     * @throws KestraRuntimeException if a {@code version} expression cannot be rendered
+     */
+    @SuppressWarnings("unchecked")
+    private Map<String, Object> renderPluginVersions(@Nullable final String tenantId, final String namespace, final Map<String, Object> flowAsMap) {
+        return (Map<String, Object>) recursiveRenderVersion(flowAsMap, tenantId, namespace, flowAsMap.get("id"));
+    }
+
+    @SuppressWarnings("unchecked")
+    private Object recursiveRenderVersion(final Object object, final String tenantId, final String namespace, final Object flowId) {
+        if (object instanceof Map<?, ?> value) {
+            Map<Object, Object> result = value
+                .entrySet()
+                .stream()
+                .map(e -> new AbstractMap.SimpleEntry<>(e.getKey(), recursiveRenderVersion(e.getValue(), tenantId, namespace, flowId)))
+                .collect(HashMap::new, (m, v) -> m.put(v.getKey(), v.getValue()), HashMap::putAll);
+
+            if (
+                result.get("type") instanceof String && result.get("version") instanceof String versionExpression
+                    && PebbleUtil.containsOpeningBlockDelimiter(versionExpression)
+            ) {
+                result.put("version", renderVersion(versionExpression, tenantId, namespace, flowId));
+            }
+
+            return result;
+        } else if (object instanceof Collection<?> value) {
+            return value.stream().map(item -> recursiveRenderVersion(item, tenantId, namespace, flowId)).toList();
+        }
+
+        return object;
+    }
+
+    private String renderVersion(final String versionExpression, final String tenantId, final String namespace, final Object flowId) {
+        Map<String, Object> flow = new HashMap<>();
+        flow.put("id", flowId);
+        flow.put("namespace", namespace);
+        flow.put("tenantId", tenantId);
+
+        Map<String, Object> renderVariables = Map.of("flow", flow, RunVariables.ENVS, runContextCache.getEnvVars());
+
+        try {
+            return variableRenderer.render(versionExpression, renderVariables);
+        } catch (IllegalVariableEvaluationException e) {
+            throw new KestraRuntimeException("Failed to render plugin 'version' expression '" + versionExpression + "': " + e.getMessage(), e);
+        }
     }
 
     /**

--- a/core/src/test/java/io/kestra/core/services/PluginDefaultServiceOverrideTest.java
+++ b/core/src/test/java/io/kestra/core/services/PluginDefaultServiceOverrideTest.java
@@ -20,7 +20,9 @@ import io.kestra.core.models.flows.Flow;
 import io.kestra.core.models.flows.FlowPluginDefault;
 import io.kestra.core.models.flows.PluginDefault;
 import io.kestra.core.plugins.PluginRegistry;
+import io.kestra.core.runners.RunContextCache;
 import io.kestra.core.runners.RunContextLoggerFactory;
+import io.kestra.core.runners.VariableRenderer;
 import io.kestra.core.services.PluginDefaultServiceTest.DefaultPrecedenceTester;
 import io.kestra.core.utils.TestsUtils;
 
@@ -41,6 +43,12 @@ class PluginDefaultServiceOverrideTest {
 
     @Inject
     private PluginRegistry pluginRegistry;
+
+    @Inject
+    private VariableRenderer variableRenderer;
+
+    @Inject
+    private RunContextCache runContextCache;
 
     /**
      * Tests that:
@@ -129,7 +137,7 @@ class PluginDefaultServiceOverrideTest {
         );
 
         // defaults are ordered most-important-first: flow, then namespace, then global
-        final PluginDefaultService service = new PluginDefaultService(null, runContextLoggerFactory, pluginRegistry) {
+        final PluginDefaultService service = new PluginDefaultService(null, runContextLoggerFactory, pluginRegistry, variableRenderer, runContextCache) {
             @Override
             protected List<PluginDefault> getAllDefaults(String tenantId, String namespace, Map<String, Object> flow) {
                 List<PluginDefault> defaults = new ArrayList<>(getFlowDefaults(flow));

--- a/core/src/test/java/io/kestra/core/services/PluginDefaultServiceTest.java
+++ b/core/src/test/java/io/kestra/core/services/PluginDefaultServiceTest.java
@@ -1,5 +1,6 @@
 package io.kestra.core.services;
 
+import java.io.IOException;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
@@ -12,6 +13,7 @@ import org.slf4j.LoggerFactory;
 import org.slf4j.event.Level;
 
 import io.kestra.core.exceptions.FlowProcessingException;
+import io.kestra.core.exceptions.KestraRuntimeException;
 import io.kestra.core.junit.annotations.KestraTest;
 import io.kestra.core.models.annotations.Plugin;
 import io.kestra.core.models.conditions.ConditionContext;
@@ -27,7 +29,12 @@ import io.kestra.core.models.triggers.AbstractTrigger;
 import io.kestra.core.models.triggers.PollingTriggerInterface;
 import io.kestra.core.models.triggers.TriggerContext;
 import io.kestra.core.models.triggers.TriggerOutput;
+import io.kestra.core.runners.KVMetadataStateStore;
 import io.kestra.core.runners.RunContext;
+import io.kestra.core.storages.StorageInterface;
+import io.kestra.core.storages.kv.InternalKVStore;
+import io.kestra.core.storages.kv.KVStore;
+import io.kestra.core.storages.kv.KVValueAndMetadata;
 import io.kestra.core.utils.TestsUtils;
 import io.kestra.plugin.core.log.Log;
 import io.kestra.plugin.core.trigger.Schedule;
@@ -66,6 +73,74 @@ class PluginDefaultServiceTest {
 
     @Inject
     private PluginDefaultService pluginDefaultService;
+
+    @Inject
+    private KVMetadataStateStore kvMetadataStateStore;
+
+    @Inject
+    private StorageInterface storageInterface;
+
+    @Test
+    void shouldRenderKvExpressionInTaskVersion() throws FlowProcessingException, IOException {
+        // Given
+        var tenant = TestsUtils.randomTenant(PluginDefaultServiceTest.class.getSimpleName());
+        var namespace = TestsUtils.randomNamespace();
+        KVStore kv = new InternalKVStore(tenant, namespace, storageInterface, kvMetadataStateStore);
+        kv.put("PLUGIN_VERSION", new KVValueAndMetadata(null, "1.2.3"));
+
+        String source = """
+            id: version-kv-test
+            namespace: %s
+            tasks:
+              - id: log
+                type: io.kestra.plugin.core.log.Log
+                version: "{{ kv('PLUGIN_VERSION') }}"
+                message: hello
+            """.formatted(namespace);
+
+        // When
+        FlowWithSource injected = pluginDefaultService.parseFlowWithAllDefaults(tenant, source, true);
+
+        // Then
+        assertThat(((Log) injected.getTasks().getFirst()).getVersion(), is("1.2.3"));
+    }
+
+    @Test
+    void shouldFailClearlyWhenVersionExpressionReferencesMissingKv() {
+        // Given
+        var tenant = TestsUtils.randomTenant(PluginDefaultServiceTest.class.getSimpleName());
+        var namespace = TestsUtils.randomNamespace();
+        String source = """
+            id: version-kv-missing-test
+            namespace: %s
+            tasks:
+              - id: log
+                type: io.kestra.plugin.core.log.Log
+                version: "{{ kv('MISSING_KEY') }}"
+                message: hello
+            """.formatted(namespace);
+
+        // When / Then
+        Assertions.assertThrows(KestraRuntimeException.class, () -> pluginDefaultService.parseFlowWithAllDefaults(tenant, source, true));
+    }
+
+    @Test
+    void shouldFailClearlyWhenVersionExpressionReferencesExecutionScopedVariable() {
+        // Given — no execution exists yet at flow parse time, so 'outputs' is not resolvable
+        var tenant = TestsUtils.randomTenant(PluginDefaultServiceTest.class.getSimpleName());
+        String source = """
+            id: version-outputs-test
+            namespace: io.kestra.unittest
+            tasks:
+              - id: log
+                type: io.kestra.plugin.core.log.Log
+                version: "{{ outputs.previousTask.version }}"
+                message: hello
+            """;
+
+        // When / Then
+        Assertions.assertThrows(KestraRuntimeException.class, () -> pluginDefaultService.parseFlowWithAllDefaults(tenant, source, true));
+    }
 
     @Test
     void shouldInjectGivenFlowWithNullSource() throws FlowProcessingException {

--- a/jmh-benchmarks/src/jmh/java/io/kestra/core/services/PluginDefaultServiceBenchmark.java
+++ b/jmh-benchmarks/src/jmh/java/io/kestra/core/services/PluginDefaultServiceBenchmark.java
@@ -47,7 +47,7 @@ public class PluginDefaultServiceBenchmark {
 
     @Setup(Level.Trial)
     public void setup() {
-        pluginDefaultService = new PluginDefaultService(null, null, DefaultPluginRegistry.getOrCreate());
+        pluginDefaultService = new PluginDefaultService(null, null, DefaultPluginRegistry.getOrCreate(), null, null);
 
         noDefaults = GenericFlow.fromYaml("main", flowSource(""));
         typeDefaults = GenericFlow.fromYaml("main", flowSource(typeDefaultEntries()));


### PR DESCRIPTION
## Summary

Allows a task's `version` field to be resolved via `kv()` / `secret()` / `env()` at flow parse/save time, e.g.:

```yaml
id: gcs_upload
type: io.kestra.plugin.gcp.gcs.Upload
version: "{{ kv('GCP_PLUGIN_VERSION') }}"
```

This lets teams pin plugin versions per namespace via the (self-service, namespace-scoped) KV store instead of the `kestra.plugins.defaults` `application.yml` workaround, which requires infra/admin access to change.

- `PluginDefaultService` now renders any `version` field containing a Pebble expression on the raw flow map, right after plugin-default injection and before `YamlParser.parse` triggers `PluginDeserializer` classloader resolution — so by the time the plugin identifier (`type:version`) is extracted, `version` is already a concrete literal.
- Only `flow` (tenant/namespace/id) and `envs` are exposed to the renderer, so `kv()`, `secret()`, and `env()` work, but `outputs`/`inputs`/task-run vars are not resolvable (no execution exists yet) — referencing them fails with a clear error instead of silently resolving to nothing, thanks to Pebble's `strictVariables` mode.
- Rendering only runs when a `version` string actually contains a Pebble delimiter (`PebbleUtil.containsOpeningBlockDelimiter`), so plain literal versions (the common case) pay no extra cost.
- A render failure (missing KV key, disallowed variable, etc.) throws `KestraRuntimeException`, so flow save/parse fails loudly rather than silently dropping the version.
- `type` is intentionally untouched, matching the scope called out in the issue.

Since this hooks into `PluginDefaultService.parseFlowWithAllDefaults`, it runs once at flow create/update and once on first execution warm-up (`DefaultFlowMetaStore.findByExecutionThenInjectDefaults`), then the parsed `FlowWithSource` is cached — it is **not** re-evaluated on every execution. If the underlying KV value changes, the flow must be re-saved for the new version to take effect.

Closes #17280

## Test plan

- [x] `PluginDefaultServiceTest#shouldRenderKvExpressionInTaskVersion` — `kv()` in `version` resolves to the stored value on a real task.
- [x] `PluginDefaultServiceTest#shouldFailClearlyWhenVersionExpressionReferencesMissingKv` — missing KV key fails flow parsing with a clear error.
- [x] `PluginDefaultServiceTest#shouldFailClearlyWhenVersionExpressionReferencesExecutionScopedVariable` — referencing `outputs.*` in `version` fails clearly instead of being silently ignored.
- [x] `./gradlew :core:test --tests "io.kestra.core.services.*"` and related suites (`YamlParserTest`, `PluginDeserializerTest`, pebble function tests, `DefaultFlowMetaStoreTest`) pass.
- [x] `./gradlew :jdbc-h2:test --tests "io.kestra.runner.h2.H2RunnerTest"` passes (executor constraint per contributing guidelines).