### PR TITLE
fix: add OpenAPI response documentation for trigger export endpoint

### DIFF
--- a/webserver/src/main/java/io/kestra/webserver/controllers/api/TriggerController.java
+++ b/webserver/src/main/java/io/kestra/webserver/controllers/api/TriggerController.java
@@ -413,6 +413,7 @@ public class TriggerController {
     @Get(uri = "/export/by-query/csv", produces = MediaType.TEXT_CSV)
     @ExecuteOn(TaskExecutors.IO)
     @Operation(tags = { "Triggers" }, summary = "Export all triggers as a streamed CSV file")
+    @ApiResponse(responseCode = "200", content = { @Content(mediaType = MediaType.TEXT_CSV, schema = @Schema(type = "string")) })
     @SuppressWarnings("unchecked")
     public MutableHttpResponse<Flux<String>> exportTriggers(
         @Parameter(description = "Filters. PHP-style nested query is used - examples: `filters[flowId][EQUALS]=hello-world`, `filters[namespace][CONTAINS]=test`", in = ParameterIn.QUERY)


### PR DESCRIPTION
### ✨ Description

Adds OpenAPI/Swagger documentation for the HTTP response of the `exportTriggers` endpoint by including an `@ApiResponse` annotation. This improves API documentation by explicitly declaring that the endpoint returns a 200 status code with CSV content.

### 🔗 Related Issue

No related issue.

### 🛠️ Backend Checklist

- [x] Code compiles successfully and passes all checks
- [x] All unit and integration tests pass

### 📝 Additional Notes

This is a documentation-only change that adds OpenAPI metadata to the trigger export endpoint. The annotation specifies:
- Response code: 200
- Content type: text/csv
- Schema type: string

This helps API consumers and documentation generators understand the expected response format without affecting runtime behavior.

### 🤖 AI Authors

Why don't cats play poker in the jungle? Too many cheetahs! 🐱

https://claude.ai/code/session_01TVyzi9iY8k6PuyUwN5oJHn