### PR TITLE
chore(logs): apply spotless formatting to external log data store files

### DIFF
--- a/core/src/main/java/io/kestra/core/models/AccessScope.java
+++ b/core/src/main/java/io/kestra/core/models/AccessScope.java
@@ -10,12 +10,12 @@ import java.util.List;
  * can be reused by any namespace-scoped resource (logs, audit logs, secrets, KV, …).
  *
  * <ul>
- *     <li>{@link Kind#GLOBAL} — no restriction (the caller may read every namespace);</li>
- *     <li>{@link Kind#NAMESPACES} — restrict to the given namespaces (and their children);</li>
- *     <li>{@link Kind#DENY_ALL} — no access, the query must return nothing.</li>
+ * <li>{@link Kind#GLOBAL} — no restriction (the caller may read every namespace);</li>
+ * <li>{@link Kind#NAMESPACES} — restrict to the given namespaces (and their children);</li>
+ * <li>{@link Kind#DENY_ALL} — no access, the query must return nothing.</li>
  * </ul>
  *
- * @param kind       the kind of restriction.
+ * @param kind the kind of restriction.
  * @param namespaces the allowed namespaces (only meaningful for {@link Kind#NAMESPACES}).
  */
 public record AccessScope(Kind kind, List<String> namespaces) {

--- a/core/src/main/java/io/kestra/core/plugins/AbstractPluginInterfaceFactory.java
+++ b/core/src/main/java/io/kestra/core/plugins/AbstractPluginInterfaceFactory.java
@@ -1,14 +1,5 @@
 package io.kestra.core.plugins;
 
-import io.kestra.core.exceptions.KestraRuntimeException;
-import io.kestra.core.models.Plugin;
-import io.kestra.core.serializers.JacksonMapper;
-
-import jakarta.validation.ConstraintViolation;
-import jakarta.validation.ConstraintViolationException;
-import jakarta.validation.Validator;
-import org.apache.commons.lang3.tuple.Pair;
-
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -16,6 +7,16 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+
+import org.apache.commons.lang3.tuple.Pair;
+
+import io.kestra.core.exceptions.KestraRuntimeException;
+import io.kestra.core.models.Plugin;
+import io.kestra.core.serializers.JacksonMapper;
+
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.ConstraintViolationException;
+import jakarta.validation.Validator;
 
 /**
  * Base class for factories that construct a plugin instance selected by a {@code type} configuration
@@ -66,7 +67,7 @@ public abstract class AbstractPluginInterfaceFactory<T> {
      * The returned instance is <b>not</b> initialized — concrete factories perform any init /
      * decoration in their own {@code make(...)}.
      *
-     * @param identifier          the plugin identifier, optionally in the form {@code <id>:<version>}.
+     * @param identifier the plugin identifier, optionally in the form {@code <id>:<version>}.
      * @param pluginConfiguration the plugin configuration. May be {@code null}.
      * @return the validated, uninitialized plugin instance.
      * @throws KestraRuntimeException if no plugin can be found, or the configuration is invalid.

--- a/core/src/main/java/io/kestra/core/plugins/PluginScanner.java
+++ b/core/src/main/java/io/kestra/core/plugins/PluginScanner.java
@@ -33,9 +33,9 @@ import io.kestra.core.models.tasks.runners.TaskRunner;
 import io.kestra.core.models.triggers.AbstractTrigger;
 import io.kestra.core.models.ui.PluginUiModule;
 import io.kestra.core.preview.FileRenderer;
+import io.kestra.core.repositories.LogDataStoreInterface;
 import io.kestra.core.secret.SecretPluginInterface;
 import io.kestra.core.serializers.JacksonMapper;
-import io.kestra.core.repositories.LogDataStoreInterface;
 import io.kestra.core.storages.StorageInterface;
 
 import io.swagger.v3.oas.annotations.Hidden;

--- a/core/src/main/java/io/kestra/core/repositories/log/LogDataStoreInterfaceFactory.java
+++ b/core/src/main/java/io/kestra/core/repositories/log/LogDataStoreInterfaceFactory.java
@@ -1,5 +1,8 @@
 package io.kestra.core.repositories.log;
 
+import java.util.List;
+import java.util.Map;
+
 import io.kestra.core.plugins.AbstractPluginInterfaceFactory;
 import io.kestra.core.plugins.ApplicationContextInitializable;
 import io.kestra.core.plugins.PluginRegistry;
@@ -8,9 +11,6 @@ import io.kestra.core.repositories.LogDataStoreInterface;
 
 import io.micronaut.context.ApplicationContext;
 import jakarta.validation.Validator;
-
-import java.util.List;
-import java.util.Map;
 
 /**
  * Factory for constructing {@link LogDataStoreInterface} objects from configuration.
@@ -35,7 +35,7 @@ public class LogDataStoreInterfaceFactory extends AbstractPluginInterfaceFactory
      * Constructs and validates a new {@link LogDataStoreInterface} of the given type with the given
      * configuration.
      *
-     * @param identifier          the ID of the log store, optionally in the form {@code <id>:<version>}.
+     * @param identifier the ID of the log store, optionally in the form {@code <id>:<version>}.
      * @param pluginConfiguration the configuration of the log store. May be {@code null}.
      * @return a new, initialized {@link LogDataStoreInterface}.
      */

--- a/jdbc/src/main/java/io/kestra/jdbc/LogJdbcDataSourceProvider.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/LogJdbcDataSourceProvider.java
@@ -26,9 +26,9 @@ import jakarta.inject.Singleton;
  * A single resolution shared by the log store and the log-table migration so a dedicated log
  * database is described in one place (rather than a separate {@code datasources.logs} block):
  * <ul>
- *     <li>if {@code kestra.logs.<type>.url} is set → build (and own) a dedicated HikariCP
- *         {@link DataSource} + {@link JooqDSLContextWrapper} for it (e.g. Postgres main + MySQL logs);</li>
- *     <li>otherwise → fall back to the primary {@link DataSource} (logs in the main database).</li>
+ * <li>if {@code kestra.logs.<type>.url} is set → build (and own) a dedicated HikariCP
+ * {@link DataSource} + {@link JooqDSLContextWrapper} for it (e.g. Postgres main + MySQL logs);</li>
+ * <li>otherwise → fall back to the primary {@link DataSource} (logs in the main database).</li>
  * </ul>
  * The dedicated pool is built lazily and closed on shutdown.
  */

--- a/jdbc/src/main/java/io/kestra/jdbc/migration/AbstractSQLMigrationScript.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/migration/AbstractSQLMigrationScript.java
@@ -137,7 +137,7 @@ public abstract class AbstractSQLMigrationScript implements MigrationScript {
      * placeholders in the SQL with the given replacements before executing. Used e.g. to inject a
      * configurable table name into a log-store migration script.
      *
-     * @param dataSource   the data source to obtain a connection from
+     * @param dataSource the data source to obtain a connection from
      * @param resourcePath classpath resource path to the SQL file
      * @param replacements placeholder key → value substitutions (key {@code x} replaces {@code ${x}})
      * @throws IOException if the resource cannot be read

--- a/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcLogDataStore.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcLogDataStore.java
@@ -2,6 +2,7 @@ package io.kestra.jdbc.repository;
 
 import java.time.ZonedDateTime;
 import java.util.*;
+import java.util.function.BiFunction;
 import java.util.stream.Collectors;
 
 import org.jooq.*;
@@ -37,8 +38,6 @@ import jakarta.annotation.Nullable;
 import lombok.Getter;
 import reactor.core.publisher.Flux;
 
-import java.util.function.BiFunction;
-
 public abstract class AbstractJdbcLogDataStore extends AbstractJdbcCrudRepository<LogEntry> implements LogDataStoreInterface {
 
     private static final Condition NORMAL_KIND_CONDITION = field("execution_kind").isNull().or(field("execution_kind").eq(ExecutionKind.NORMAL.name()));
@@ -66,7 +65,7 @@ public abstract class AbstractJdbcLogDataStore extends AbstractJdbcCrudRepositor
      * repository bound to the dedicated log datasource (when {@code kestra.logs.<type>.url} is set),
      * or the shared {@code @Named("logs")} repository (the primary datasource) otherwise.
      *
-     * @param applicationContext      the application context to resolve beans from.
+     * @param applicationContext the application context to resolve beans from.
      * @param dedicatedRepositoryFactory builds the dialect-specific repository for the dedicated
      *        datasource (e.g. {@code (config, wrapper) -> new H2Repository<>(config, wrapper)}).
      */


### PR DESCRIPTION
## What
Applies spotless formatting to the files introduced/modified by #17212 (`feat(logs): pluggable log repository selected by kestra.logs.type`).

## Why
That work predated the repo-wide spotless config and was squash-merged into `develop` **after** the spotless commit (#17273). Because the kestra spotless-conventions plugin sets `enforceCheck = false` (spotless is not part of `build`/`check`), CI never flagged the unformatted code, so these files landed unformatted.

## Scope
Ran `spotlessApply`, then kept **only** the files touched by #17212 (7 files actually needed formatting; the rest already conformed). No reformatting of any unrelated file.

Pure formatting only — import grouping/ordering, unused-import removal, whitespace, line-wrapping, javadoc alignment. No logic changes; modules compile clean.

Companion PR: kestra-io/kestra-ee#(EE spotless PR) for #9172.