### PR TITLE
refactor(tests): move log data store test suite into :tests module

### DIFF
--- a/jdbc-h2/src/test/java/io/kestra/core/repositories/log/LogDataStoreInterfaceFactoryTest.java
+++ b/jdbc-h2/src/test/java/io/kestra/core/repositories/log/LogDataStoreInterfaceFactoryTest.java
@@ -18,7 +18,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
  * <p>
  * Lives in the {@code jdbc-h2} module so at least one log store ({@code H2LogDataStore}) is on the
  * classpath and discoverable via the plugin registry. It exercises the factory, not the store —
- * the store's behavior is covered by {@code H2LogRepositoryTest} (the shared repository suite).
+ * the store's behavior is covered by {@code H2LogDataStoreTest} (the shared log data store suite).
  */
 @MicronautTest
 class LogDataStoreInterfaceFactoryTest {

--- a/jdbc-h2/src/test/java/io/kestra/repository/h2/H2LogDataStoreTest.java
+++ b/jdbc-h2/src/test/java/io/kestra/repository/h2/H2LogDataStoreTest.java
@@ -1,0 +1,7 @@
+package io.kestra.repository.h2;
+
+import io.kestra.core.repositories.AbstractLogDataStoreTest;
+
+public class H2LogDataStoreTest extends AbstractLogDataStoreTest {
+
+}

--- a/jdbc-h2/src/test/java/io/kestra/repository/h2/H2LogRepositoryTest.java
+++ b/jdbc-h2/src/test/java/io/kestra/repository/h2/H2LogRepositoryTest.java
@@ -1,7 +1,0 @@
-package io.kestra.repository.h2;
-
-import io.kestra.core.repositories.AbstractLogRepositoryTest;
-
-public class H2LogRepositoryTest extends AbstractLogRepositoryTest {
-
-}

--- a/jdbc-mysql/src/test/java/io/kestra/repository/mysql/MysqlLogDataStoreTest.java
+++ b/jdbc-mysql/src/test/java/io/kestra/repository/mysql/MysqlLogDataStoreTest.java
@@ -1,0 +1,7 @@
+package io.kestra.repository.mysql;
+
+import io.kestra.core.repositories.AbstractLogDataStoreTest;
+
+public class MysqlLogDataStoreTest extends AbstractLogDataStoreTest {
+
+}

--- a/jdbc-mysql/src/test/java/io/kestra/repository/mysql/MysqlLogRepositoryTest.java
+++ b/jdbc-mysql/src/test/java/io/kestra/repository/mysql/MysqlLogRepositoryTest.java
@@ -1,7 +1,0 @@
-package io.kestra.repository.mysql;
-
-import io.kestra.core.repositories.AbstractLogRepositoryTest;
-
-public class MysqlLogRepositoryTest extends AbstractLogRepositoryTest {
-
-}

--- a/jdbc-postgres/src/test/java/io/kestra/repository/postgres/PostgresLogDataStoreTest.java
+++ b/jdbc-postgres/src/test/java/io/kestra/repository/postgres/PostgresLogDataStoreTest.java
@@ -1,0 +1,7 @@
+package io.kestra.repository.postgres;
+
+import io.kestra.core.repositories.AbstractLogDataStoreTest;
+
+public class PostgresLogDataStoreTest extends AbstractLogDataStoreTest {
+
+}

--- a/jdbc-postgres/src/test/java/io/kestra/repository/postgres/PostgresLogRepositoryTest.java
+++ b/jdbc-postgres/src/test/java/io/kestra/repository/postgres/PostgresLogRepositoryTest.java
@@ -1,7 +1,0 @@
-package io.kestra.repository.postgres;
-
-import io.kestra.core.repositories.AbstractLogRepositoryTest;
-
-public class PostgresLogRepositoryTest extends AbstractLogRepositoryTest {
-
-}

--- a/tests/build.gradle
+++ b/tests/build.gradle
@@ -10,7 +10,7 @@ dependencies {
     implementation "io.micronaut.test:micronaut-test-junit5"
 
     implementation "org.junit.jupiter:junit-jupiter-engine"
-    implementation "org.junit.jupiter:junit-jupiter-engine"
+    implementation "org.junit.jupiter:junit-jupiter-params"
 
     api 'org.hamcrest:hamcrest:3.0'
     api 'org.hamcrest:hamcrest-library:3.0'

--- a/tests/src/main/java/io/kestra/core/repositories/AbstractLogDataStoreTest.java
+++ b/tests/src/main/java/io/kestra/core/repositories/AbstractLogDataStoreTest.java
@@ -42,7 +42,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @MicronautTest(transactional = false)
-public abstract class AbstractLogRepositoryTest {
+public abstract class AbstractLogDataStoreTest {
     @Inject
     protected LogDataStoreInterface logRepository;
 


### PR DESCRIPTION
## Why
Groundwork for the first external log-repository plugin. Plugin test-support base classes must be reachable by **external plugin repositories**, which can only consume a published *main* artifact — not another module's `sourceSets.test.output`. `AbstractLogRepositoryTest` lived in `core/src/test`, so consumers reached it via the in-build-only `project(':core').sourceSets.test.output` hack. This moves it into the shared `:tests` module (`src/main`), the same pattern `StorageTestSuite` already follows (published as `io.kestra:tests`).

## What
- Move `core/src/test/.../repositories/AbstractLogRepositoryTest.java` → `tests/src/main/.../repositories/AbstractLogDataStoreTest.java` (rename for consistency with the earlier `*LogRepository → *LogDataStore` rename; package unchanged).
- Rename the 3 empty JDBC subclasses to `H2/Mysql/PostgresLogDataStoreTest`.
- Add `junit-jupiter-params` to `:tests` main (the suite uses `@ParameterizedTest`/`@MethodSource`/`@FieldSource`).

## Verification
`:tests` compiles; `H2LogDataStoreTest` runs green (242 tests). Faithful move — no logic/annotation changes.

## Notes
Companion EE PR: kestra-io/kestra-ee#PENDING renames the sole EE consumer (`ElasticSearchLogRepositoryTest → ElasticSearchLogDataStoreTest`); **merge this OSS PR first**.

Part of the external-log-repository groundwork (kestra-io/kestra-ee#7054).