### PR TITLE
fix(namespaces): make namespace_file_metadata case-sensitive on MySQL

### DIFF
--- a/core/src/test/java/io/kestra/core/repositories/AbstractNamespaceFileMetadataRepositoryTest.java
+++ b/core/src/test/java/io/kestra/core/repositories/AbstractNamespaceFileMetadataRepositoryTest.java
@@ -60,6 +60,45 @@ public abstract class AbstractNamespaceFileMetadataRepositoryTest {
     }
 
     @Test
+    void findByPathIsCaseSensitive() throws IOException {
+        // Given: two namespace files whose paths differ only by case.
+        // Paths map 1:1 to case-sensitive storage URIs, so they are two distinct files.
+        String tenantId = TestsUtils.randomTenant();
+        String namespace = TestsUtils.randomNamespace();
+
+        NamespaceFileMetadata upperCase = NamespaceFileMetadata.builder()
+            .tenantId(tenantId)
+            .namespace(namespace)
+            .path("/MyFile.sql")
+            .size(1L)
+            .build();
+        NamespaceFileMetadata lowerCase = NamespaceFileMetadata.builder()
+            .tenantId(tenantId)
+            .namespace(namespace)
+            .path("/myfile.sql")
+            .size(1L)
+            .build();
+
+        // When: both are saved
+        namespaceFileMetadataRepositoryInterface.save(upperCase);
+        namespaceFileMetadataRepositoryInterface.save(lowerCase);
+
+        // Then: each is stored as its own revision-1 file and lookups are case-sensitive.
+        // On MySQL with a case-insensitive collation this fails: saving the second one is treated
+        // as a new revision of the first, and findByPath returns the wrong row (see Pylon #2018).
+        Optional<NamespaceFileMetadata> foundUpper = namespaceFileMetadataRepositoryInterface.findByPath(tenantId, namespace, "/MyFile.sql");
+        Optional<NamespaceFileMetadata> foundLower = namespaceFileMetadataRepositoryInterface.findByPath(tenantId, namespace, "/myfile.sql");
+
+        assertThat(foundUpper).isPresent();
+        assertThat(foundUpper.get().getPath()).isEqualTo("/MyFile.sql");
+        assertThat(foundUpper.get().getRevision()).isEqualTo(1);
+
+        assertThat(foundLower).isPresent();
+        assertThat(foundLower.get().getPath()).isEqualTo("/myfile.sql");
+        assertThat(foundLower.get().getRevision()).isEqualTo(1);
+    }
+
+    @Test
     void deleteMetadata() throws IOException {
         String tenantId = TestsUtils.randomTenant();
         String namespace = TestsUtils.randomNamespace();

--- a/jdbc-mysql/src/main/java/io/kestra/repository/mysql/migration/V2_0_15NamespaceFileMetadataCaseSensitiveMigration.java
+++ b/jdbc-mysql/src/main/java/io/kestra/repository/mysql/migration/V2_0_15NamespaceFileMetadataCaseSensitiveMigration.java
@@ -1,0 +1,54 @@
+package io.kestra.repository.mysql.migration;
+
+import javax.sql.DataSource;
+
+import io.kestra.core.migration.MigrationScript;
+import io.kestra.jdbc.migration.AbstractSQLMigrationScript;
+import io.kestra.repository.mysql.MysqlRepositoryEnabled;
+
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+
+/**
+ * OSS MySQL namespace_file_metadata case-sensitivity migration script.
+ *
+ * <p>
+ * Switches the {@code key}, {@code path} and {@code parent_path} columns of
+ * {@code namespace_file_metadata} to the case-sensitive {@code utf8mb4_bin} collation. Namespace
+ * file paths map 1:1 to case-sensitive storage URIs and the primary key {@code key} embeds the
+ * path, so the default case-insensitive collation made files that differ only by case collide.
+ */
+@Singleton
+@MysqlRepositoryEnabled
+public class V2_0_15NamespaceFileMetadataCaseSensitiveMigration extends AbstractSQLMigrationScript {
+
+    private static final String SCRIPT_ID = "2.0.15-namespace-file-metadata-case-sensitive";
+    private static final String RESOURCE = "/migrations/2.0.15-namespace-file-metadata-case-sensitive-mysql.sql";
+
+    private final DataSource dataSource;
+
+    @Inject
+    public V2_0_15NamespaceFileMetadataCaseSensitiveMigration(final DataSource dataSource) {
+        this.dataSource = dataSource;
+    }
+
+    @Override
+    public String scriptId() {
+        return SCRIPT_ID;
+    }
+
+    @Override
+    public String description() {
+        return "OSS MySQL namespace_file_metadata: make key/path/parent_path case-sensitive";
+    }
+
+    @Override
+    public String checksum() {
+        return MigrationScript.checksumOfResources(RESOURCE);
+    }
+
+    @Override
+    public void migrate() throws Exception {
+        executeSqlResource(dataSource, RESOURCE);
+    }
+}

--- a/jdbc-mysql/src/main/resources/migrations/2.0.15-namespace-file-metadata-case-sensitive-mysql.sql
+++ b/jdbc-mysql/src/main/resources/migrations/2.0.15-namespace-file-metadata-case-sensitive-mysql.sql
@@ -1,0 +1,28 @@
+-- Namespace file paths are case-sensitive: they map 1:1 to case-sensitive storage URIs, and the
+-- primary key `key` of namespace_file_metadata embeds the path (tenantId_namespace_path_revision).
+-- The table was created with the case-insensitive collation utf8mb4_unicode_ci, so on MySQL two
+-- files whose paths differ only by case (e.g. MyFile.sql vs myfile.sql) collide: the second one is
+-- treated as the same file, and path lookups return the wrong row. See Pylon #2018.
+-- Switch `key`, `path` and `parent_path` to the case-sensitive utf8mb4_bin collation.
+-- Each ALTER is guarded so the migration is idempotent.
+
+-- `key` (primary key, regular column)
+SET @col_key = (SELECT COLLATION_NAME FROM information_schema.columns WHERE table_schema = DATABASE() AND table_name = 'namespace_file_metadata' AND column_name = 'key');
+SET @sql = IF(@col_key IS NOT NULL AND @col_key <> 'utf8mb4_bin', 'ALTER TABLE namespace_file_metadata MODIFY COLUMN `key` VARCHAR(768) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL', 'SELECT 1');
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+-- `path` (generated STORED column; also backs the FULLTEXT index and the composite indexes)
+SET @col_path = (SELECT COLLATION_NAME FROM information_schema.columns WHERE table_schema = DATABASE() AND table_name = 'namespace_file_metadata' AND column_name = 'path');
+SET @sql = IF(@col_path IS NOT NULL AND @col_path <> 'utf8mb4_bin', 'ALTER TABLE namespace_file_metadata MODIFY COLUMN `path` VARCHAR(350) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin GENERATED ALWAYS AS (value ->> ''$.path'') STORED NOT NULL', 'SELECT 1');
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+-- `parent_path` (generated STORED column)
+SET @col_parent = (SELECT COLLATION_NAME FROM information_schema.columns WHERE table_schema = DATABASE() AND table_name = 'namespace_file_metadata' AND column_name = 'parent_path');
+SET @sql = IF(@col_parent IS NOT NULL AND @col_parent <> 'utf8mb4_bin', 'ALTER TABLE namespace_file_metadata MODIFY COLUMN `parent_path` VARCHAR(350) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin GENERATED ALWAYS AS (value ->> ''$.parentPath'') STORED', 'SELECT 1');
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;


### PR DESCRIPTION
### What this does

On **MySQL**, namespace files whose paths differ only by **case** (e.g. `MyFile.sql` vs `myfile.sql`) are treated as the **same file**. This corrupts `namespace_file_metadata` and breaks `SyncNamespaceFiles` / `PurgeFiles` / any `putFile` for the affected namespace. Postgres and H2 are unaffected.

### Root cause

`namespace_file_metadata` is created with the case-insensitive collation `utf8mb4_unicode_ci` (`jdbc-mysql/.../baseline-mysql.sql`). Namespace file paths are semantically case-sensitive — they map 1:1 to storage URIs, which are case-sensitive on virtually every backend. On MySQL this causes:

1. **Primary-key collision** — the PK `key` is the file UID and embeds the path (`tenantId_namespace_path_revision`, see `NamespaceFileMetadata.uid()` / `IdUtils.fromParts`). `..._/MyFile.sql_1` and `..._/myfile.sql_1` collide under a case-insensitive PK → inserting the second fails with `Duplicate entry ... for key PRIMARY`.
2. **Wrong lookups** — `AbstractJdbcNamespaceFileMetadataRepository.findByPath` filters with `field("path").in(...)`; on MySQL it matches a differently-cased row, so `save()`/`putFile()` (`InternalNamespace`) believe the file already exists and take the overwrite/version-bump branch against the wrong record; `fetchOne`(→`fetchAny`) returns the wrong file's metadata.

Postgres/H2 compare case-sensitively by default → **MySQL-only**.

### Fix

Switch the identity/lookup columns of `namespace_file_metadata` — the primary key `key` and the `path` / `parent_path` generated columns — to the case-sensitive `utf8mb4_bin` collation. Purely schema-level; no Java production code change.

- New migration `2.0.15-namespace-file-metadata-case-sensitive-mysql.sql` + bean `V2_0_15NamespaceFileMetadataCaseSensitiveMigration` (idempotent — guarded per-column, safe to re-run; converts existing installs).
- Regression test `AbstractNamespaceFileMetadataRepositoryTest.findByPathIsCaseSensitive` — runs on H2 / Postgres / MySQL.

> Note: the `FULLTEXT(path)` index used for the namespace-file *search* filter becomes case-sensitive as a side effect. Acceptable given file identity correctness is the priority.

### Testing

- Reproduced the collision at the DB level on MySQL 9.7 (duplicate-key on insert + lowercase lookup returning the mixed-case row).
- Verified the migration converts `ci`→`bin`, preserves existing rows, keeps the `FULLTEXT` index, and is idempotent.
- `AbstractNamespaceFileMetadataRepositoryTest` — **20 passing** on each of H2, Postgres, MySQL (including the new test).

### Related

Fixes kestra-io/kestra-ee#9254 (from an internal support ticket).
