### PR TITLE
feat: purge-flow-revisions

### DIFF
--- a/core/src/main/java/io/kestra/plugin/core/flow/PurgeFlows.java
+++ b/core/src/main/java/io/kestra/plugin/core/flow/PurgeFlows.java
@@ -3,6 +3,7 @@ package io.kestra.plugin.core.flow;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicLong;
 
+import io.kestra.core.exceptions.ValidationErrorException;
 import io.kestra.core.models.annotations.Example;
 import io.kestra.core.models.annotations.Plugin;
 import io.kestra.core.models.flows.FlowWithSource;
@@ -12,7 +13,6 @@ import io.kestra.core.models.tasks.Task;
 import io.kestra.core.repositories.FlowRepositoryInterface;
 import io.kestra.core.runners.DefaultRunContext;
 import io.kestra.core.runners.RunContext;
-import io.kestra.plugin.core.purge.PurgeTask;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.Valid;
@@ -28,7 +28,7 @@ import lombok.experimental.SuperBuilder;
 @Schema(
     title = "Purge old flow revisions.",
     description = """
-        Deletes old flow revisions using a purge `behavior` (default keeps 1 latest revision), optional flow ID glob, and Namespace filters (`namespaces` list or `namespacePattern`). Child Namespaces are included by default.
+        Deletes old flow revisions using a purge `behavior` (default keeps 1 latest revision), with optional namespace prefix and flow ID filters.
 
         The latest revision of each flow is always kept."""
 )
@@ -44,35 +44,25 @@ import lombok.experimental.SuperBuilder;
                 tasks:
                   - id: purge_flows
                     type: io.kestra.plugin.core.flow.PurgeFlows
-                    namespaces:
-                      - company
-                    includeChildNamespaces: true
-                    flowPattern: "*_deprecated"
+                    namespace: company
                     behavior:
-                      type: version
                       keepAmount: 2
                 """
         )
     }
 )
-public class PurgeFlows extends Task implements PurgeTask<FlowWithSource>, RunnableTask<PurgeFlows.Output> {
+public class PurgeFlows extends Task implements RunnableTask<PurgeFlows.Output> {
     @Schema(
-        title = "Flow ID pattern, e.g. '*'",
-        description = "Delete only old revisions for flows whose ID matches the glob pattern."
+        title = "Namespace whose flows need to be purged, or namespace of the flow that needs to be purged",
+        description = "If `flowId` isn't provided, this is a namespace prefix, else the namespace of the flow."
     )
-    private Property<String> flowPattern;
+    private Property<String> namespace;
 
     @Schema(
-        title = "List of namespaces to delete old flow revisions from",
-        description = "If not set, all namespaces will be considered. Can't be used with `namespacePattern` - use one or the other."
+        title = "The flow ID whose old revisions should be purged",
+        description = "You need to provide the `namespace` property if you want to purge a flow."
     )
-    private Property<List<String>> namespaces;
-
-    @Schema(
-        title = "Glob pattern for the namespaces to delete old flow revisions from",
-        description = "If not set, all namespaces will be considered. Example: `company.*`. Can't be used with `namespaces` - use one or the other."
-    )
-    private Property<String> namespacePattern;
+    private Property<String> flowId;
 
     @Schema(
         title = "Purge behavior",
@@ -83,33 +73,28 @@ public class PurgeFlows extends Task implements PurgeTask<FlowWithSource>, Runna
     @NotNull
     private Property<Version> behavior = Property.ofValue(Version.builder().keepAmount(1).build());
 
-    @Schema(
-        title = "Delete old flow revisions from child namespaces",
-        description = "Defaults to true. This means that if you set `namespaces` to `company`, it will also delete old flow revisions from `company.team`, `company.data`, etc."
-    )
-    @Builder.Default
-    private Property<Boolean> includeChildNamespaces = Property.ofValue(true);
-
     @Override
     public Output run(RunContext runContext) throws Exception {
-        List<String> flowNamespaces = findNamespaces(runContext);
-        runContext.logger().info("purging old flow revisions from {} namespaces: {}", flowNamespaces.size(), flowNamespaces);
-
         AtomicLong count = new AtomicLong();
         Version renderedBehavior = runContext.render(behavior).as(Version.class).orElseThrow();
         String tenantId = runContext.flowInfo().tenantId();
         FlowRepositoryInterface flowRepository = ((DefaultRunContext) runContext).services().additionalService(FlowRepositoryInterface.class);
+        String renderedNamespace = runContext.render(this.namespace).as(String.class).orElse(null);
+        String renderedFlowId = runContext.render(this.flowId).as(String.class).orElse(null);
+        if (renderedNamespace == null && renderedFlowId != null) {
+            throw new ValidationErrorException(List.of("Property `namespace` is required when `flowId` is set."));
+        }
 
-        for (String namespace : flowNamespaces) {
-            List<FlowWithSource> latestFlows = filterItems(runContext, flowRepository.findByNamespaceWithSource(tenantId, namespace));
-            for (FlowWithSource flow : latestFlows) {
-                List<Integer> revisions = renderedBehavior.revisionsToPurge(tenantId, namespace, flow.getId(), flowRepository).stream()
-                    .map(FlowWithSource::getRevision)
-                    .toList();
-                if (!revisions.isEmpty()) {
-                    flowRepository.deleteRevisions(tenantId, namespace, flow.getId(), revisions);
-                    count.addAndGet(revisions.size());
-                }
+        List<FlowWithSource> flows = findFlows(runContext, flowRepository, tenantId, renderedNamespace, renderedFlowId);
+        runContext.logger().info("purging old revisions from {} flows", flows.size());
+
+        for (FlowWithSource flow : flows) {
+            List<Integer> revisions = renderedBehavior.revisionsToPurge(tenantId, flow.getNamespace(), flow.getId(), flowRepository).stream()
+                .map(FlowWithSource::getRevision)
+                .toList();
+            if (!revisions.isEmpty()) {
+                flowRepository.deleteRevisions(tenantId, flow.getNamespace(), flow.getId(), revisions);
+                count.addAndGet(revisions.size());
             }
         }
 
@@ -120,14 +105,26 @@ public class PurgeFlows extends Task implements PurgeTask<FlowWithSource>, Runna
             .build();
     }
 
-    @Override
-    public Property<String> filterPattern() {
-        return flowPattern;
-    }
+    private List<FlowWithSource> findFlows(
+        RunContext runContext,
+        FlowRepositoryInterface flowRepository,
+        String tenantId,
+        String renderedNamespace,
+        String renderedFlowId
+    ) {
+        if (renderedNamespace == null) {
+            runContext.acl().allowAllNamespaces().check();
+            return flowRepository.findAllWithSource(tenantId);
+        }
 
-    @Override
-    public String filterTargetExtractor(FlowWithSource item) {
-        return item.getId();
+        runContext.acl().allowNamespace(renderedNamespace).check();
+        if (renderedFlowId != null) {
+            return flowRepository.findByIdWithSource(tenantId, renderedNamespace, renderedFlowId)
+                .map(List::of)
+                .orElseGet(List::of);
+        }
+
+        return flowRepository.findByNamespacePrefixWithSource(tenantId, renderedNamespace);
     }
 
     @Builder

--- a/core/src/main/java/io/kestra/plugin/core/flow/PurgeFlows.java
+++ b/core/src/main/java/io/kestra/plugin/core/flow/PurgeFlows.java
@@ -83,7 +83,7 @@ public class PurgeFlows extends Task implements RunnableTask<PurgeFlows.Output>,
         String renderedNamespace = runContext.render(this.namespace).as(String.class).orElse(null);
         String renderedFlowId = runContext.render(this.flowId).as(String.class).orElse(null);
         if (renderedNamespace == null && renderedFlowId != null) {
-            throw new ValidationErrorException(List.of("Property `namespace` is required when `flowId` is set."));
+            throw new IllegalArgumentException("Property `namespace` is required when `flowId` is set.");
         }
 
         List<FlowWithSource> flows = findFlows(runContext, flowRepository, tenantId, renderedNamespace, renderedFlowId);

--- a/core/src/main/java/io/kestra/plugin/core/flow/PurgeFlows.java
+++ b/core/src/main/java/io/kestra/plugin/core/flow/PurgeFlows.java
@@ -1,0 +1,141 @@
+package io.kestra.plugin.core.flow;
+
+import java.util.List;
+import java.util.concurrent.atomic.AtomicLong;
+
+import io.kestra.core.models.annotations.Example;
+import io.kestra.core.models.annotations.Plugin;
+import io.kestra.core.models.flows.FlowWithSource;
+import io.kestra.core.models.property.Property;
+import io.kestra.core.models.tasks.RunnableTask;
+import io.kestra.core.models.tasks.Task;
+import io.kestra.core.repositories.FlowRepositoryInterface;
+import io.kestra.core.runners.DefaultRunContext;
+import io.kestra.core.runners.RunContext;
+import io.kestra.plugin.core.purge.PurgeTask;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+@SuperBuilder(toBuilder = true)
+@Getter
+@NoArgsConstructor
+@Schema(
+    title = "Purge old flow revisions.",
+    description = """
+        Deletes old flow revisions using a purge `behavior` (default keeps 1 latest revision), optional flow ID glob, and Namespace filters (`namespaces` list or `namespacePattern`). Child Namespaces are included by default.
+
+        The latest revision of each flow is always kept."""
+)
+@Plugin(
+    examples = {
+        @Example(
+            title = "Purge old flow revisions for a namespace tree.",
+            full = true,
+            code = """
+                id: purge_flow_revisions
+                namespace: system
+
+                tasks:
+                  - id: purge_flows
+                    type: io.kestra.plugin.core.flow.PurgeFlows
+                    namespaces:
+                      - company
+                    includeChildNamespaces: true
+                    flowPattern: "*_deprecated"
+                    behavior:
+                      type: version
+                      keepAmount: 2
+                """
+        )
+    }
+)
+public class PurgeFlows extends Task implements PurgeTask<FlowWithSource>, RunnableTask<PurgeFlows.Output> {
+    @Schema(
+        title = "Flow ID pattern, e.g. '*'",
+        description = "Delete only old revisions for flows whose ID matches the glob pattern."
+    )
+    private Property<String> flowPattern;
+
+    @Schema(
+        title = "List of namespaces to delete old flow revisions from",
+        description = "If not set, all namespaces will be considered. Can't be used with `namespacePattern` - use one or the other."
+    )
+    private Property<List<String>> namespaces;
+
+    @Schema(
+        title = "Glob pattern for the namespaces to delete old flow revisions from",
+        description = "If not set, all namespaces will be considered. Example: `company.*`. Can't be used with `namespaces` - use one or the other."
+    )
+    private Property<String> namespacePattern;
+
+    @Schema(
+        title = "Purge behavior",
+        description = "Defines how old flow revisions are purged."
+    )
+    @Builder.Default
+    @Valid
+    @NotNull
+    private Property<Version> behavior = Property.ofValue(Version.builder().keepAmount(1).build());
+
+    @Schema(
+        title = "Delete old flow revisions from child namespaces",
+        description = "Defaults to true. This means that if you set `namespaces` to `company`, it will also delete old flow revisions from `company.team`, `company.data`, etc."
+    )
+    @Builder.Default
+    private Property<Boolean> includeChildNamespaces = Property.ofValue(true);
+
+    @Override
+    public Output run(RunContext runContext) throws Exception {
+        List<String> flowNamespaces = findNamespaces(runContext);
+        runContext.logger().info("purging old flow revisions from {} namespaces: {}", flowNamespaces.size(), flowNamespaces);
+
+        AtomicLong count = new AtomicLong();
+        Version renderedBehavior = runContext.render(behavior).as(Version.class).orElseThrow();
+        String tenantId = runContext.flowInfo().tenantId();
+        FlowRepositoryInterface flowRepository = ((DefaultRunContext) runContext).services().additionalService(FlowRepositoryInterface.class);
+
+        for (String namespace : flowNamespaces) {
+            List<FlowWithSource> latestFlows = filterItems(runContext, flowRepository.findByNamespaceWithSource(tenantId, namespace));
+            for (FlowWithSource flow : latestFlows) {
+                List<Integer> revisions = renderedBehavior.revisionsToPurge(tenantId, namespace, flow.getId(), flowRepository).stream()
+                    .map(FlowWithSource::getRevision)
+                    .toList();
+                if (!revisions.isEmpty()) {
+                    flowRepository.deleteRevisions(tenantId, namespace, flow.getId(), revisions);
+                    count.addAndGet(revisions.size());
+                }
+            }
+        }
+
+        runContext.logger().info("purged {} flow revisions", count.get());
+
+        return Output.builder()
+            .size(count.get())
+            .build();
+    }
+
+    @Override
+    public Property<String> filterPattern() {
+        return flowPattern;
+    }
+
+    @Override
+    public String filterTargetExtractor(FlowWithSource item) {
+        return item.getId();
+    }
+
+    @Builder
+    @Getter
+    public static class Output implements io.kestra.core.models.tasks.Output {
+        @Schema(
+            title = "The number of purged flow revisions"
+        )
+        private Long size;
+    }
+}

--- a/core/src/main/java/io/kestra/plugin/core/flow/PurgeFlows.java
+++ b/core/src/main/java/io/kestra/plugin/core/flow/PurgeFlows.java
@@ -9,6 +9,7 @@ import io.kestra.core.models.annotations.Plugin;
 import io.kestra.core.models.flows.FlowWithSource;
 import io.kestra.core.models.property.Property;
 import io.kestra.core.models.tasks.RunnableTask;
+import io.kestra.core.models.tasks.SystemTask;
 import io.kestra.core.models.tasks.Task;
 import io.kestra.core.repositories.FlowRepositoryInterface;
 import io.kestra.core.runners.DefaultRunContext;
@@ -51,7 +52,7 @@ import lombok.experimental.SuperBuilder;
         )
     }
 )
-public class PurgeFlows extends Task implements RunnableTask<PurgeFlows.Output> {
+public class PurgeFlows extends Task implements RunnableTask<PurgeFlows.Output>, SystemTask {
     @Schema(
         title = "Namespace whose flows need to be purged, or namespace of the flow that needs to be purged",
         description = "If `flowId` isn't provided, this is a namespace prefix, else the namespace of the flow."

--- a/core/src/main/java/io/kestra/plugin/core/flow/Version.java
+++ b/core/src/main/java/io/kestra/plugin/core/flow/Version.java
@@ -4,16 +4,12 @@ import java.time.Instant;
 import java.util.Comparator;
 import java.util.List;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
-
 import io.kestra.core.models.flows.FlowWithSource;
 import io.kestra.core.repositories.FlowRepositoryInterface;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.AssertTrue;
 import jakarta.validation.constraints.Min;
-import jakarta.validation.constraints.NotNull;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
@@ -22,20 +18,15 @@ import lombok.experimental.SuperBuilder;
 @Getter
 @NoArgsConstructor
 public class Version {
-    @NotNull
-    @JsonInclude
-    @Builder.Default
-    protected String type = "version";
-
     @Schema(
         title = "The date before which revisions should be purged.",
-        description = "Must be an ISO-8601 instant, for example `2026-01-01T00:00:00Z`. Using this filter will never delete the latest revision of a flow to avoid accidental flow deletion."
+        description = "Must be an ISO-8601 instant, for example `2026-01-01T00:00:00Z`. Using this filter will never delete the latest revision or the latest non-draft revision of a flow to avoid accidental flow deletion."
     )
     private String before;
 
     @Schema(
         title = "How many revisions should be kept for each matching flow.",
-        description = "The latest revision is always kept."
+        description = "The latest revision and the latest non-draft revision are always kept."
     )
     @Min(1)
     private Integer keepAmount;
@@ -50,9 +41,15 @@ public class Version {
             .map(FlowWithSource::getRevision)
             .max(Integer::compareTo)
             .orElse(null);
+        Integer latestNonDraftRevision = revisions.stream()
+            .filter(revision -> !revision.isDraft())
+            .map(FlowWithSource::getRevision)
+            .max(Integer::compareTo)
+            .orElse(null);
 
         List<FlowWithSource> oldRevisions = revisions.stream()
             .filter(revision -> !revision.getRevision().equals(latestRevision))
+            .filter(revision -> !revision.getRevision().equals(latestNonDraftRevision))
             .toList();
 
         if (keepAmount != null) {
@@ -60,6 +57,7 @@ public class Version {
                 .sorted(Comparator.comparing(FlowWithSource::getRevision).reversed())
                 .skip(keepAmount)
                 .filter(revision -> !revision.getRevision().equals(latestRevision))
+                .filter(revision -> !revision.getRevision().equals(latestNonDraftRevision))
                 .toList();
         }
 

--- a/core/src/main/java/io/kestra/plugin/core/flow/Version.java
+++ b/core/src/main/java/io/kestra/plugin/core/flow/Version.java
@@ -1,0 +1,80 @@
+package io.kestra.plugin.core.flow;
+
+import java.time.Instant;
+import java.util.Comparator;
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import io.kestra.core.models.flows.FlowWithSource;
+import io.kestra.core.repositories.FlowRepositoryInterface;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.AssertTrue;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+@SuperBuilder
+@Getter
+@NoArgsConstructor
+public class Version {
+    @NotNull
+    @JsonInclude
+    @Builder.Default
+    protected String type = "version";
+
+    @Schema(
+        title = "The date before which revisions should be purged.",
+        description = "Must be an ISO-8601 instant, for example `2026-01-01T00:00:00Z`. Using this filter will never delete the latest revision of a flow to avoid accidental flow deletion."
+    )
+    private String before;
+
+    @Schema(
+        title = "How many revisions should be kept for each matching flow.",
+        description = "The latest revision is always kept."
+    )
+    @Min(1)
+    private Integer keepAmount;
+
+    List<FlowWithSource> revisionsToPurge(String tenantId, String namespace, String flowId, FlowRepositoryInterface flowRepository) {
+        List<FlowWithSource> revisions = flowRepository.findRevisions(tenantId, namespace, flowId, false);
+        if (revisions.size() <= 1) {
+            return List.of();
+        }
+
+        Integer latestRevision = revisions.stream()
+            .map(FlowWithSource::getRevision)
+            .max(Integer::compareTo)
+            .orElse(null);
+
+        List<FlowWithSource> oldRevisions = revisions.stream()
+            .filter(revision -> !revision.getRevision().equals(latestRevision))
+            .toList();
+
+        if (keepAmount != null) {
+            return revisions.stream()
+                .sorted(Comparator.comparing(FlowWithSource::getRevision).reversed())
+                .skip(keepAmount)
+                .filter(revision -> !revision.getRevision().equals(latestRevision))
+                .toList();
+        }
+
+        if (before != null) {
+            Instant beforeInstant = Instant.parse(before);
+            return oldRevisions.stream()
+                .filter(revision -> revision.getUpdated() != null && !revision.getUpdated().isAfter(beforeInstant))
+                .toList();
+        }
+
+        return oldRevisions;
+    }
+
+    @AssertTrue(message = "Cannot set both 'before' and 'keepAmount' properties")
+    boolean isValidPurgeConfiguration() {
+        return before == null || keepAmount == null;
+    }
+}

--- a/core/src/test/java/io/kestra/plugin/core/flow/PurgeFlowsTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/flow/PurgeFlowsTest.java
@@ -1,0 +1,151 @@
+package io.kestra.plugin.core.flow;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+
+import io.kestra.core.context.TestRunContextFactory;
+import io.kestra.core.junit.annotations.KestraTest;
+import io.kestra.core.models.flows.Flow;
+import io.kestra.core.models.flows.FlowWithSource;
+import io.kestra.core.models.flows.GenericFlow;
+import io.kestra.core.models.property.Property;
+import io.kestra.core.models.validations.ModelValidator;
+import io.kestra.core.repositories.FlowRepositoryInterface;
+import io.kestra.core.utils.IdUtils;
+import io.kestra.core.utils.TestsUtils;
+import io.kestra.plugin.core.debug.Return;
+
+import jakarta.inject.Inject;
+import jakarta.validation.ConstraintViolationException;
+
+import static io.kestra.core.tenant.TenantService.MAIN_TENANT;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Execution(ExecutionMode.SAME_THREAD)
+@KestraTest
+class PurgeFlowsTest {
+    @Inject
+    TestRunContextFactory runContextFactory;
+
+    @Inject
+    FlowRepositoryInterface flowRepository;
+
+    @Inject
+    ModelValidator modelValidator;
+
+    @BeforeEach
+    void setup() {
+        flowRepository.findAll(MAIN_TENANT).forEach(flow -> flowRepository.delete(flow));
+    }
+
+    @Test
+    void shouldPurgeOldRevisionsByKeepAmount() throws Exception {
+        String namespace = TestsUtils.randomNamespace();
+        String flowId = IdUtils.create();
+        FlowWithSource revision1 = flowRepository.create(testingFlow(namespace, flowId, "first"));
+        FlowWithSource revision2 = flowRepository.update(testingFlow(namespace, flowId, "second"), revision1);
+        flowRepository.update(testingFlow(namespace, flowId, "third"), revision2);
+
+        PurgeFlows purgeFlows = PurgeFlows.builder()
+            .type(PurgeFlows.class.getName())
+            .namespaces(Property.ofValue(List.of(namespace)))
+            .behavior(Property.ofValue(Version.builder().keepAmount(2).build()))
+            .build();
+
+        PurgeFlows.Output output = purgeFlows.run(runContextFactory.of(namespace));
+
+        assertThat(output.getSize()).isEqualTo(1L);
+        assertThat(flowRepository.findRevisions(MAIN_TENANT, namespace, flowId, false))
+            .extracting(FlowWithSource::getRevision)
+            .containsExactlyInAnyOrder(2, 3);
+    }
+
+    @Test
+    void shouldPurgeOldRevisionsByDateWithoutDeletingLatestRevision() throws Exception {
+        String namespace = TestsUtils.randomNamespace();
+        String flowId = IdUtils.create();
+        FlowWithSource revision1 = flowRepository.create(testingFlow(namespace, flowId, "first"));
+        Instant afterFirstRevision = Instant.now();
+        FlowWithSource revision2 = flowRepository.update(testingFlow(namespace, flowId, "second"), revision1);
+        flowRepository.update(testingFlow(namespace, flowId, "third"), revision2);
+
+        PurgeFlows purgeFlows = PurgeFlows.builder()
+            .type(PurgeFlows.class.getName())
+            .namespaces(Property.ofValue(List.of(namespace)))
+            .behavior(Property.ofValue(Version.builder().before(afterFirstRevision.toString()).build()))
+            .build();
+
+        PurgeFlows.Output output = purgeFlows.run(runContextFactory.of(namespace));
+
+        assertThat(output.getSize()).isEqualTo(1L);
+        assertThat(flowRepository.findRevisions(MAIN_TENANT, namespace, flowId, false))
+            .extracting(FlowWithSource::getRevision)
+            .containsExactlyInAnyOrder(2, 3);
+        assertThat(flowRepository.findById(MAIN_TENANT, namespace, flowId).isPresent()).isTrue();
+    }
+
+    @Test
+    void shouldPurgeOnlyFlowsMatchingPattern() throws Exception {
+        String namespace = TestsUtils.randomNamespace();
+        String matchingFlowId = "matching_" + IdUtils.create();
+        String otherFlowId = "other_" + IdUtils.create();
+        FlowWithSource matchingRevision1 = flowRepository.create(testingFlow(namespace, matchingFlowId, "first"));
+        flowRepository.update(testingFlow(namespace, matchingFlowId, "second"), matchingRevision1);
+        FlowWithSource otherRevision1 = flowRepository.create(testingFlow(namespace, otherFlowId, "first"));
+        flowRepository.update(testingFlow(namespace, otherFlowId, "second"), otherRevision1);
+
+        PurgeFlows purgeFlows = PurgeFlows.builder()
+            .type(PurgeFlows.class.getName())
+            .namespaces(Property.ofValue(List.of(namespace)))
+            .flowPattern(Property.ofValue("matching_*"))
+            .build();
+
+        PurgeFlows.Output output = purgeFlows.run(runContextFactory.of(namespace));
+
+        assertThat(output.getSize()).isEqualTo(1L);
+        assertThat(flowRepository.findRevisions(MAIN_TENANT, namespace, matchingFlowId, false))
+            .extracting(FlowWithSource::getRevision)
+            .containsExactly(2);
+        assertThat(flowRepository.findRevisions(MAIN_TENANT, namespace, otherFlowId, false))
+            .extracting(FlowWithSource::getRevision)
+            .containsExactlyInAnyOrder(1, 2);
+    }
+
+    @Test
+    void validation() {
+        PurgeFlows valid = PurgeFlows.builder()
+            .id(IdUtils.create())
+            .type(PurgeFlows.class.getName())
+            .behavior(Property.ofValue(Version.builder().keepAmount(2).build()))
+            .build();
+        PurgeFlows invalid = PurgeFlows.builder()
+            .id(IdUtils.create())
+            .type(PurgeFlows.class.getName())
+            .behavior(Property.ofValue(Version.builder().before(Instant.now().toString()).keepAmount(2).build()))
+            .build();
+
+        Optional<ConstraintViolationException> validException = modelValidator.isValid(valid);
+        Optional<ConstraintViolationException> invalidException = modelValidator.isValid(invalid);
+
+        assertThat(validException).isEmpty();
+        assertThat(invalidException).isPresent();
+        assertThat(invalidException.get().getMessage()).contains("behavior.validPurgeConfiguration: Cannot set both 'before' and 'keepAmount' properties");
+    }
+
+    private GenericFlow testingFlow(String namespace, String flowId, String message) {
+        return GenericFlow.of(
+            Flow.builder()
+                .tenantId(MAIN_TENANT)
+                .namespace(namespace)
+                .id(flowId)
+                .tasks(List.of(Return.builder().id("return").type(Return.class.getName()).format(Property.ofValue(message)).build()))
+                .build()
+        );
+    }
+}

--- a/core/src/test/java/io/kestra/plugin/core/flow/PurgeFlowsTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/flow/PurgeFlowsTest.java
@@ -54,7 +54,7 @@ class PurgeFlowsTest {
 
         PurgeFlows purgeFlows = PurgeFlows.builder()
             .type(PurgeFlows.class.getName())
-            .namespaces(Property.ofValue(List.of(namespace)))
+            .namespace(Property.ofValue(namespace))
             .behavior(Property.ofValue(Version.builder().keepAmount(2).build()))
             .build();
 
@@ -77,7 +77,7 @@ class PurgeFlowsTest {
 
         PurgeFlows purgeFlows = PurgeFlows.builder()
             .type(PurgeFlows.class.getName())
-            .namespaces(Property.ofValue(List.of(namespace)))
+            .namespace(Property.ofValue(namespace))
             .behavior(Property.ofValue(Version.builder().before(afterFirstRevision.toString()).build()))
             .build();
 
@@ -91,9 +91,9 @@ class PurgeFlowsTest {
     }
 
     @Test
-    void shouldPurgeOnlyFlowsMatchingPattern() throws Exception {
+    void shouldPurgeOnlyTargetedFlow() throws Exception {
         String namespace = TestsUtils.randomNamespace();
-        String matchingFlowId = "matching_" + IdUtils.create();
+        String matchingFlowId = IdUtils.create();
         String otherFlowId = "other_" + IdUtils.create();
         FlowWithSource matchingRevision1 = flowRepository.create(testingFlow(namespace, matchingFlowId, "first"));
         flowRepository.update(testingFlow(namespace, matchingFlowId, "second"), matchingRevision1);
@@ -102,8 +102,8 @@ class PurgeFlowsTest {
 
         PurgeFlows purgeFlows = PurgeFlows.builder()
             .type(PurgeFlows.class.getName())
-            .namespaces(Property.ofValue(List.of(namespace)))
-            .flowPattern(Property.ofValue("matching_*"))
+            .namespace(Property.ofValue(namespace))
+            .flowId(Property.ofValue(matchingFlowId))
             .build();
 
         PurgeFlows.Output output = purgeFlows.run(runContextFactory.of(namespace));
@@ -115,6 +115,60 @@ class PurgeFlowsTest {
         assertThat(flowRepository.findRevisions(MAIN_TENANT, namespace, otherFlowId, false))
             .extracting(FlowWithSource::getRevision)
             .containsExactlyInAnyOrder(1, 2);
+    }
+
+    @Test
+    void shouldPurgeFlowsFromNamespacePrefix() throws Exception {
+        String namespace = TestsUtils.randomNamespace();
+        String childNamespace = namespace + ".child";
+        String similarNamespace = namespace + "_similar";
+        String flowId = IdUtils.create();
+        FlowWithSource rootRevision1 = flowRepository.create(testingFlow(namespace, flowId, "first"));
+        flowRepository.update(testingFlow(namespace, flowId, "second"), rootRevision1);
+        FlowWithSource childRevision1 = flowRepository.create(testingFlow(childNamespace, flowId, "first"));
+        flowRepository.update(testingFlow(childNamespace, flowId, "second"), childRevision1);
+        FlowWithSource similarRevision1 = flowRepository.create(testingFlow(similarNamespace, flowId, "first"));
+        flowRepository.update(testingFlow(similarNamespace, flowId, "second"), similarRevision1);
+
+        PurgeFlows purgeFlows = PurgeFlows.builder()
+            .type(PurgeFlows.class.getName())
+            .namespace(Property.ofValue(namespace))
+            .build();
+
+        PurgeFlows.Output output = purgeFlows.run(runContextFactory.of(namespace));
+
+        assertThat(output.getSize()).isEqualTo(2L);
+        assertThat(flowRepository.findRevisions(MAIN_TENANT, namespace, flowId, false))
+            .extracting(FlowWithSource::getRevision)
+            .containsExactly(2);
+        assertThat(flowRepository.findRevisions(MAIN_TENANT, childNamespace, flowId, false))
+            .extracting(FlowWithSource::getRevision)
+            .containsExactly(2);
+        assertThat(flowRepository.findRevisions(MAIN_TENANT, similarNamespace, flowId, false))
+            .extracting(FlowWithSource::getRevision)
+            .containsExactlyInAnyOrder(1, 2);
+    }
+
+    @Test
+    void shouldKeepLatestNonDraftRevision() throws Exception {
+        String namespace = TestsUtils.randomNamespace();
+        String flowId = IdUtils.create();
+        FlowWithSource revision1 = flowRepository.create(testingFlow(namespace, flowId, "published", false));
+        FlowWithSource revision2 = flowRepository.update(testingFlow(namespace, flowId, "draft", true), revision1);
+        flowRepository.update(testingFlow(namespace, flowId, "draft again", true), revision2);
+
+        PurgeFlows purgeFlows = PurgeFlows.builder()
+            .type(PurgeFlows.class.getName())
+            .namespace(Property.ofValue(namespace))
+            .behavior(Property.ofValue(Version.builder().keepAmount(1).build()))
+            .build();
+
+        PurgeFlows.Output output = purgeFlows.run(runContextFactory.of(namespace));
+
+        assertThat(output.getSize()).isEqualTo(1L);
+        assertThat(flowRepository.findRevisions(MAIN_TENANT, namespace, flowId, false))
+            .extracting(FlowWithSource::getRevision)
+            .containsExactlyInAnyOrder(1, 3);
     }
 
     @Test
@@ -139,11 +193,16 @@ class PurgeFlowsTest {
     }
 
     private GenericFlow testingFlow(String namespace, String flowId, String message) {
+        return testingFlow(namespace, flowId, message, false);
+    }
+
+    private GenericFlow testingFlow(String namespace, String flowId, String message, boolean draft) {
         return GenericFlow.of(
             Flow.builder()
                 .tenantId(MAIN_TENANT)
                 .namespace(namespace)
                 .id(flowId)
+                .draft(draft)
                 .tasks(List.of(Return.builder().id("return").type(Return.class.getName()).format(Property.ofValue(message)).build()))
                 .build()
         );


### PR DESCRIPTION
closes: #17175 

---

### ✨ Description

What does this PR change?  

Adds `io.kestra.plugin.core.flow.PurgeFlows`, a core task that purges old flow revisions by namespace, optional flow ID pattern, and version retention behavior.

The task supports:
- `namespaces`
- `namespacePattern`
- `includeChildNamespaces`
- `flowPattern`
- `behavior.type: version`
- `behavior.keepAmount`
- `behavior.before`

By default, the task keeps the latest revision of each flow and purges older revisions.

## Why

Kestra already has `PurgeFiles` for old namespace file versions. This adds equivalent cleanup behavior for flow revisions.

## Testing

```bash
./gradlew :core:test --tests "io.kestra.plugin.core.flow.PurgeFlowsTest"
```

https://github.com/user-attachments/assets/18ffb99c-d65e-4ff5-b454-6fcb8e7aa51c



