### PR TITLE
test(triggers): stop runner in TriggerControllerFilterTest to fix flaky QUEUES lock

### DIFF
--- a/webserver/src/test/java/io/kestra/webserver/controllers/api/TriggerControllerFilterTest.java
+++ b/webserver/src/test/java/io/kestra/webserver/controllers/api/TriggerControllerFilterTest.java
@@ -42,11 +42,16 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * Parameterized tests that exercise the {@code /search} trigger endpoint against the full surface
  * of supported filter fields (including the controller-level
- * {@code dateFilter}/{@code startDate}/{@code endDate} rewrite). The scheduler is deliberately
- * disabled so trigger state fixtures (especially {@code nextEvaluationDate} and
- * {@code lastTriggeredDate}) are not mutated under the test.
+ * {@code dateFilter}/{@code startDate}/{@code endDate} rewrite). Neither the runner nor the
+ * scheduler is started: the test only persists fixtures (flows synchronously via
+ * {@code FlowService}, trigger states directly via the repository) and reads them back through
+ * {@code /search}, so no background component is required. Keeping them off also avoids a concurrent
+ * {@code QUEUES} poller racing the per-test {@code drop()} (which caused intermittent
+ * {@code Timeout trying to lock table "QUEUES"} failures), and guarantees trigger state fixtures
+ * (especially {@code nextEvaluationDate} and {@code lastTriggeredDate}) are not mutated under the
+ * test.
  */
-@KestraTest(startRunner = true, startScheduler = false)
+@KestraTest(startRunner = false, startScheduler = false)
 class TriggerControllerFilterTest {
 
     public static final String TENANT_ID = "main";


### PR DESCRIPTION
The per-test @BeforeEach runs the deprecated JdbcTestUtils.drop(), which issues a bulk 'delete from QUEUES'. With startRunner=true the JDBC queue poller threads hold locks on QUEUES, so drop() intermittently failed with 'Timeout trying to lock table "QUEUES" [50200]'; the resulting context teardown then cascaded into 'Client is closed' / 'No bean MeterRegistry' on later parameterized cases.

The test never needs the runner: FlowService.create() persists flows synchronously, trigger states are saved directly via the repository, and /search only reads. Disabling the runner removes the only concurrent QUEUES accessor so drop() gets a clean table lock.