### PR TITLE
fix(namespaces): make namespace_file_metadata case-sensitive on MySQL (v1.3.x backport)

### DIFF
--- a/core/src/test/java/io/kestra/core/repositories/AbstractNamespaceFileMetadataRepositoryTest.java
+++ b/core/src/test/java/io/kestra/core/repositories/AbstractNamespaceFileMetadataRepositoryTest.java
@@ -60,6 +60,45 @@ public abstract class AbstractNamespaceFileMetadataRepositoryTest {
     }
 
     @Test
+    void findByPathIsCaseSensitive() throws IOException {
+        // Given: two namespace files whose paths differ only by case.
+        // Paths map 1:1 to case-sensitive storage URIs, so they are two distinct files.
+        String tenantId = TestsUtils.randomTenant();
+        String namespace = TestsUtils.randomNamespace();
+
+        NamespaceFileMetadata upperCase = NamespaceFileMetadata.builder()
+            .tenantId(tenantId)
+            .namespace(namespace)
+            .path("/MyFile.sql")
+            .size(1L)
+            .build();
+        NamespaceFileMetadata lowerCase = NamespaceFileMetadata.builder()
+            .tenantId(tenantId)
+            .namespace(namespace)
+            .path("/myfile.sql")
+            .size(1L)
+            .build();
+
+        // When: both are saved
+        namespaceFileMetadataRepositoryInterface.save(upperCase);
+        namespaceFileMetadataRepositoryInterface.save(lowerCase);
+
+        // Then: each is stored as its own version-1 file and lookups are case-sensitive.
+        // On MySQL with a case-insensitive collation this fails: saving the second one is treated
+        // as a new version of the first, and findByPath returns the wrong row (see Pylon #2018).
+        Optional<NamespaceFileMetadata> foundUpper = namespaceFileMetadataRepositoryInterface.findByPath(tenantId, namespace, "/MyFile.sql");
+        Optional<NamespaceFileMetadata> foundLower = namespaceFileMetadataRepositoryInterface.findByPath(tenantId, namespace, "/myfile.sql");
+
+        assertThat(foundUpper).isPresent();
+        assertThat(foundUpper.get().getPath()).isEqualTo("/MyFile.sql");
+        assertThat(foundUpper.get().getVersion()).isEqualTo(1);
+
+        assertThat(foundLower).isPresent();
+        assertThat(foundLower.get().getPath()).isEqualTo("/myfile.sql");
+        assertThat(foundLower.get().getVersion()).isEqualTo(1);
+    }
+
+    @Test
     void deleteMetadata() throws IOException {
         String tenantId = TestsUtils.randomTenant();
         String namespace = TestsUtils.randomNamespace();

--- a/jdbc-mysql/src/main/resources/migrations/mysql/V1_57__namespace_file_metadata_case_sensitive.sql
+++ b/jdbc-mysql/src/main/resources/migrations/mysql/V1_57__namespace_file_metadata_case_sensitive.sql
@@ -1,0 +1,15 @@
+-- Namespace file paths are case-sensitive: they map 1:1 to case-sensitive storage URIs, and the
+-- primary key `key` of namespace_file_metadata embeds the path (tenantId_namespace_path_version).
+-- The table was created with the case-insensitive collation utf8mb4_unicode_ci, so on MySQL two
+-- files whose paths differ only by case (e.g. MyFile.sql vs myfile.sql) collide: the primary key
+-- collides on insert and path lookups return the wrong row. See Pylon #2018.
+-- Switch `key`, `path` and `parent_path` to the case-sensitive utf8mb4_bin collation.
+
+ALTER TABLE namespace_file_metadata
+    MODIFY COLUMN `key` VARCHAR(768) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL;
+
+ALTER TABLE namespace_file_metadata
+    MODIFY COLUMN `path` VARCHAR(350) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin GENERATED ALWAYS AS (value ->> '$.path') STORED NOT NULL;
+
+ALTER TABLE namespace_file_metadata
+    MODIFY COLUMN `parent_path` VARCHAR(350) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin GENERATED ALWAYS AS (value ->> '$.parentPath') STORED;


### PR DESCRIPTION
Backport of #17305 to `releases/v1.3.x`.

### What this does

On **MySQL**, namespace files whose paths differ only by **case** (e.g. `MyFile.sql` vs `myfile.sql`) are treated as the **same file**, corrupting `namespace_file_metadata` and breaking `SyncNamespaceFiles` / `PurgeFiles` / any `putFile` for the affected namespace. Postgres and H2 are unaffected.

### Root cause

`namespace_file_metadata` is created with the case-insensitive collation `utf8mb4_unicode_ci` (`V1_51__ns_files_metadata.sql`). Namespace file paths are case-sensitive — they map 1:1 to storage URIs. On MySQL this causes:

1. **PK collision** — the PK `key` is the file UID and embeds the path (`NamespaceFileMetadata.uid()`); `..._/MyFile.sql_1` and `..._/myfile.sql_1` collide under a case-insensitive PK → `Duplicate entry ... for key PRIMARY`.
2. **Wrong lookups** — `findByPath` (`field("path").in(...)`) matches a differently-cased row, so `save()`/`putFile()` overwrite the wrong record.

### Fix

Switch `key`, `path` and `parent_path` to the case-sensitive `utf8mb4_bin` collation via migration `V1_57__namespace_file_metadata_case_sensitive.sql`. Purely schema-level; no Java production change.

> Note: the `FULLTEXT(path)` index used for the namespace-file *search* filter becomes case-sensitive as a side effect — acceptable given identity correctness is the priority.

### Testing

- Reproduced the collision at the DB level on MySQL 9.7 (duplicate-key on insert + lowercase lookup returning the mixed-case row).
- Verified the migration converts `ci`→`bin`, preserves rows, keeps the `FULLTEXT` index.
- `AbstractNamespaceFileMetadataRepositoryTest` — **20 passing** on H2 and MySQL (including the new `findByPathIsCaseSensitive`).

### Related

Backport of #17305 · fixes kestra-io/kestra-ee#9254.
