### PR TITLE
fix(build): repair Translations CI check + stabilize flowTriggerWithPause

### DIFF
--- a/.github/workflows/auto-translate-ui-keys.yml
+++ b/.github/workflows/auto-translate-ui-keys.yml
@@ -60,4 +60,5 @@ jobs:
             gh pr create --title "Translations from en.json" --body $'This PR was created automatically by a GitHub Action.\n\nSomeone from the @kestra-io/frontend team needs to review and merge.' --base ${{ github.ref_name }} --head $BRANCH_NAME
 
         - name: Check keys matching
-          run: node ui/src/translations/check.js
+          run: npm run translations:check
+          working-directory: ui

--- a/core/src/test/java/io/kestra/core/runners/AbstractRunnerTest.java
+++ b/core/src/test/java/io/kestra/core/runners/AbstractRunnerTest.java
@@ -225,11 +225,12 @@ public abstract class AbstractRunnerTest {
 
     @Test
     @LoadFlows(
-        { "flows/valids/trigger-flow-listener-with-pause.yaml",
-            "flows/valids/trigger-flow-with-pause.yaml" }
+        value = { "flows/valids/trigger-flow-listener-with-pause.yaml",
+            "flows/valids/trigger-flow-with-pause.yaml" },
+        tenantId = "pause-tenant"
     )
     void flowTriggerWithPause() throws Exception {
-        flowTriggerCaseTest.triggerWithPause();
+        flowTriggerCaseTest.triggerWithPause("pause-tenant");
     }
 
     @Test

--- a/core/src/test/java/io/kestra/core/runners/FlowTriggerCaseTest.java
+++ b/core/src/test/java/io/kestra/core/runners/FlowTriggerCaseTest.java
@@ -88,17 +88,18 @@ public class FlowTriggerCaseTest {
             );
     }
 
-    public void triggerWithPause() throws TimeoutException, QueueException {
-        Execution execution = runnerUtils.runOne(MAIN_TENANT, "io.kestra.tests.trigger.pause", "trigger-flow-with-pause");
+    public void triggerWithPause(String tenantId) throws TimeoutException, QueueException {
+        Execution execution = runnerUtils.runOne(tenantId, "io.kestra.tests.trigger.pause", "trigger-flow-with-pause");
 
         assertThat(execution.getTaskRunList().size()).isEqualTo(3);
         assertThat(execution.getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
 
         List<Execution> triggeredExec = runnerUtils.awaitFlowExecutionNumber(
             4,
-            MAIN_TENANT,
+            tenantId,
             "io.kestra.tests.trigger.pause",
-            "trigger-flow-listener-with-pause"
+            "trigger-flow-listener-with-pause",
+            Duration.ofSeconds(60)
         );
 
         assertThat(triggeredExec.size()).isEqualTo(4);


### PR DESCRIPTION
## What
Two independent CI fixes surfaced while triaging a red `develop` run ([run 28941381052](https://github.com/kestra-io/kestra/actions/runs/28941381052)).

### 1. Translations workflow — real breakage (deterministic)
`auto-translate-ui-keys.yml` ran `node ui/src/translations/check.js`, but that script was migrated to TypeScript (`check.ts`) and the `.js` was deleted → `Cannot find module` → the step fails on **every** run. Now uses the maintained `npm run translations:check` (`npx tsx check.ts`).

### 2. `flowTriggerWithPause` — flaky test (timing)
The parent flow transitions RUNNING → PAUSED (`PT1S`) → RUNNING → SUCCESS, firing the Flow-trigger listener 4 times. On a loaded runner the 4th execution didn't terminate within the default **20s** await → intermittent `3 Execution found … but 4 where awaited`.
- Bump the `awaitFlowExecutionNumber` timeout to **60s** (already the pattern in `FlowConcurrencyCaseTest`).
- Move the case off `MAIN_TENANT` onto a dedicated `pause-tenant` to avoid cross-test state leakage, matching the sibling trigger cases (`listener-tenant`, `trigger-tenant`).

## Verification
- `cd ui && npm run translations:check` → exit 0 (no missing/extra keys).
- `./gradlew :jdbc-h2:test --tests "io.kestra.runner.h2.H2RunnerTest.flowTriggerWithPause"` → SUCCESS.

Test-only + workflow change; no production code touched.