### PR TITLE
fix(flows): stop flagging pluginDefaults-supplied required properties in the editor

### DIFF
--- a/core/src/main/java/io/kestra/core/services/PluginDefaultService.java
+++ b/core/src/main/java/io/kestra/core/services/PluginDefaultService.java
@@ -95,6 +95,24 @@ public class PluginDefaultService {
     }
 
     /**
+     * Resolves the effective plugin defaults (flow-level, namespace-level, and global) that apply to a flow.
+     * <p>
+     * Public entry point over {@link #getAllDefaults(String, String, Map)} so callers such as the webserver can
+     * expose the effective defaults without injecting them into a flow. Relies on virtual dispatch: the Enterprise
+     * override of {@code getAllDefaults} contributes namespace-level defaults.
+     *
+     * @param tenantId the tenant
+     * @param namespace the flow namespace, used to resolve namespace-level defaults
+     * @param flow the flow as a map (its {@code pluginDefaults} section provides flow-level defaults); may be empty
+     * @return list of {@code PluginDefault} ordered by most important first
+     */
+    public List<PluginDefault> resolveEffectiveDefaults(final String tenantId,
+        final String namespace,
+        final Map<String, Object> flow) {
+        return getAllDefaults(tenantId, namespace, flow);
+    }
+
+    /**
      * Gets all the defaults values for the given flow.
      *
      * @param flow the flow to extract default

--- a/ui/src/composables/monaco/languages/languagesConfigurator.ts
+++ b/ui/src/composables/monaco/languages/languagesConfigurator.ts
@@ -31,7 +31,7 @@ export default async function configure(
         } else {
             yamlAutocompletion = new YamlAutoCompletion()
         }
-        await new YamlLanguageConfigurator(yamlAutocompletion, router, flowStore).configure(pluginsStore, t, editorInstance)
+        await new YamlLanguageConfigurator(yamlAutocompletion, router, flowStore, namespacesStore).configure(pluginsStore, t, editorInstance)
     } else if(language.endsWith("-pebble")) {
         const autoCompletion = new FlowAutoCompletion(flowStore, pluginsStore, namespacesStore, mcpStore, computed(() => flowStore.flowYaml))
         await new PebbleLanguageConfigurator(language, autoCompletion, computed(() => flowStore.flowYaml))

--- a/ui/src/composables/monaco/languages/pluginDefaultsMarkers.ts
+++ b/ui/src/composables/monaco/languages/pluginDefaultsMarkers.ts
@@ -1,0 +1,121 @@
+import {flowYamlUtils as YAML_UTILS} from "@kestra-io/topology"
+
+/**
+ * A plugin default entry, as declared in a flow's `pluginDefaults` block or
+ * inherited from the namespace / global configuration. `values` holds the
+ * properties the default supplies for tasks/triggers matching `type`.
+ */
+export interface EffectiveDefault {
+    type?: string;
+    values?: Record<string, unknown> | null;
+}
+
+/**
+ * Minimal shape of a Monaco marker this filter reasons about. Kept structural
+ * (not tied to `monaco.editor.IMarkerData`) so the helper stays pure and
+ * unit-testable without Monaco.
+ */
+export interface MarkerLike {
+    message: string;
+    startLineNumber: number;
+    startColumn: number;
+}
+
+// monaco-yaml emits missing-required-property diagnostics as: Missing property "x".
+const MISSING_PROPERTY_MESSAGE = /^Missing property "(.+)"\.$/
+
+interface TypedMap {
+    type?: unknown;
+    range: [number, number, number];
+}
+
+/**
+ * Convert a 1-based Monaco `(line, column)` position into a 0-based offset in
+ * `source`, so it can be matched against YAML node ranges.
+ */
+function positionToOffset(source: string, lineNumber: number, column: number): number {
+    const lines = source.split("\n")
+    let offset = 0
+    for (let i = 0; i < lineNumber - 1 && i < lines.length; i++) {
+        offset += lines[i].length + 1 // +1 for the newline
+    }
+    return offset + (column - 1)
+}
+
+/**
+ * Resolve the `type` of the task/trigger mapping enclosing the given source
+ * offset. Uses {@link YAML_UTILS.extractFieldFromMaps} to collect every mapping
+ * carrying a `type` field with its full node range, then returns the innermost
+ * one containing the offset (largest start still enclosing it). Returns
+ * undefined when no typed mapping encloses the offset.
+ */
+function findEnclosingTaskType(source: string, offset: number): string | undefined {
+    try {
+        const typed = YAML_UTILS.extractFieldFromMaps(source, "type") as TypedMap[]
+        const enclosing = typed
+            .filter((entry) => entry.range[0] <= offset && offset <= entry.range[2])
+            .sort((a, b) => b.range[0] - a.range[0])[0]
+        return typeof enclosing?.type === "string" ? enclosing.type : undefined
+    } catch {
+        return undefined
+    }
+}
+
+/**
+ * A default covers a task when its `type` matches the task `type` either
+ * exactly or by prefix — the same semantics as the backend
+ * `PluginDefaultService.defaults()` matcher.
+ */
+function defaultMatchesType(defaultType: string, taskType: string): boolean {
+    return defaultType === taskType || taskType.startsWith(defaultType)
+}
+
+/**
+ * True when at least one effective default that matches `taskType` supplies
+ * `property` in its `values`.
+ */
+export function isPropertyCoveredByDefaults(
+    property: string,
+    taskType: string,
+    defaults: EffectiveDefault[],
+): boolean {
+    return defaults.some((def) => {
+        if (!def?.type || !defaultMatchesType(def.type, taskType)) {
+            return false
+        }
+        return !!def.values && Object.prototype.hasOwnProperty.call(def.values, property)
+    })
+}
+
+/**
+ * Remove `Missing property "x"` markers that are false positives because an
+ * effective plugin default (flow-level, namespace-level, or global) supplies
+ * `x` for the enclosing task's `type`. All other markers are preserved.
+ *
+ * Pure and idempotent: re-running it on its own output removes nothing, which
+ * the configurator relies on to avoid a re-publish loop.
+ */
+export function filterDefaultsCoveredMarkers<T extends MarkerLike>(
+    markers: T[],
+    source: string,
+    defaults: EffectiveDefault[],
+): T[] {
+    if (!markers.length || !defaults.length || !source.length) {
+        return markers
+    }
+
+    return markers.filter((marker) => {
+        const match = MISSING_PROPERTY_MESSAGE.exec(marker.message)
+        if (!match) {
+            return true
+        }
+        const property = match[1]
+        const offset = positionToOffset(source, marker.startLineNumber, marker.startColumn)
+        const taskType = findEnclosingTaskType(source, offset)
+        if (!taskType) {
+            return true
+        }
+        // Drop the marker only when a default actually covers the property.
+        return !isPropertyCoveredByDefaults(property, taskType, defaults)
+    })
+}

--- a/ui/src/composables/monaco/languages/yamlLanguageConfigurator.ts
+++ b/ui/src/composables/monaco/languages/yamlLanguageConfigurator.ts
@@ -33,6 +33,7 @@ import {
     filterExistingSubflowLinks,
     SUBFLOW_LINK_SCHEME,
 } from "./subflowLinkProvider"
+import {filterDefaultsCoveredMarkers, type EffectiveDefault} from "./pluginDefaultsMarkers"
 import IPosition = monaco.IPosition;
 import IDisposable = monaco.IDisposable;
 import IModel = monaco.editor.IModel;
@@ -118,12 +119,23 @@ export class YamlLanguageConfigurator extends AbstractLanguageConfigurator {
     protected readonly yamlAutoCompletionObject: YamlAutoCompletion
     protected readonly router?: Router
     protected readonly flowStore?: ReturnType<typeof useFlowStore>
+    protected readonly namespacesStore?: {loadEffectivePluginDefaults: (payload: {id: string}) => Promise<EffectiveDefault[]>}
 
-    constructor(yamlAutoCompletion: YamlAutoCompletion, router?: Router, flowStore?: ReturnType<typeof useFlowStore>) {
+    // Session cache of effective namespace + global plugin defaults, keyed by namespace.
+    private readonly inheritedDefaultsCache = new Map<string, EffectiveDefault[]>()
+    private readonly inheritedDefaultsPending = new Set<string>()
+
+    constructor(
+        yamlAutoCompletion: YamlAutoCompletion,
+        router?: Router,
+        flowStore?: ReturnType<typeof useFlowStore>,
+        namespacesStore?: {loadEffectivePluginDefaults: (payload: {id: string}) => Promise<EffectiveDefault[]>},
+    ) {
         super("yaml")
         this.yamlAutoCompletionObject = yamlAutoCompletion
         this.router = router
         this.flowStore = flowStore
+        this.namespacesStore = namespacesStore
     }
 
     async configureLanguage(pluginsStore: ReturnType<typeof usePluginsStore>) {
@@ -637,9 +649,109 @@ export class YamlLanguageConfigurator extends AbstractLanguageConfigurator {
         )
 
         this.registerSubflowLinks(autoCompletionProviders)
+        this.registerPluginDefaultsMarkerFilter(autoCompletionProviders)
         this.registerEditionProviders(autoCompletionProviders, t)
 
         return autoCompletionProviders
+    }
+
+    /**
+     * Effective namespace-level and global plugin defaults for a namespace, from
+     * a session cache. On a cache miss, kicks off a fetch (deduplicated) and
+     * re-filters the given model once it resolves; a failed fetch (e.g. 403 for a
+     * user without namespace read access) caches `[]` so the editor degrades to
+     * showing the warning. Flow-level defaults are read from the buffer, not here.
+     */
+    private inheritedPluginDefaults(namespace: string | undefined, resource: monaco.Uri): EffectiveDefault[] {
+        if (!namespace) {
+            return []
+        }
+        const cached = this.inheritedDefaultsCache.get(namespace)
+        if (cached !== undefined) {
+            return cached
+        }
+        const store = this.namespacesStore
+        if (store && !this.inheritedDefaultsPending.has(namespace)) {
+            this.inheritedDefaultsPending.add(namespace)
+            store
+                .loadEffectivePluginDefaults({id: namespace})
+                .then((defaults) => this.inheritedDefaultsCache.set(namespace, defaults ?? []))
+                .catch(() => this.inheritedDefaultsCache.set(namespace, []))
+                .finally(() => {
+                    this.inheritedDefaultsPending.delete(namespace)
+                    this.filterModelMarkers(resource)
+                })
+        }
+        return []
+    }
+
+    /**
+     * Suppress `Missing property "x"` warnings that monaco-yaml raises for
+     * required task properties actually supplied by a plugin default. monaco-yaml
+     * validates the raw buffer against a static JSON schema and cannot know about
+     * `pluginDefaults`, so we post-filter its markers (issue #14471).
+     *
+     * Registered once (the listener is global); it inspects every changed flow
+     * model. The filter is idempotent, so re-publishing the filtered set does not
+     * loop — a re-run removes nothing more and we skip the redundant write.
+     */
+    private registerPluginDefaultsMarkerFilter(disposables: IDisposable[]) {
+        disposables.push(
+            monaco.editor.onDidChangeMarkers((resources) => {
+                for (const resource of resources) {
+                    this.filterModelMarkers(resource)
+                }
+            }),
+        )
+    }
+
+    private filterModelMarkers(resource: monaco.Uri) {
+        const YAML_MARKER_OWNER = "yaml"
+
+        if (!resource.path.includes("flow-")) {
+            return
+        }
+        const model = monaco.editor.getModel(resource)
+        if (!model || model.isDisposed()) {
+            return
+        }
+
+        const markers = monaco.editor.getModelMarkers({
+            owner: YAML_MARKER_OWNER,
+            resource,
+        })
+        if (!markers.length) {
+            return
+        }
+
+        const source = model.getValue()
+        let flowDefaults: EffectiveDefault[] = []
+        let namespace: string | undefined
+        try {
+            const parsed = YAML_UTILS.parse(source, false) as {
+                namespace?: string;
+                pluginDefaults?: EffectiveDefault[];
+            }
+            namespace = parsed?.namespace
+            flowDefaults = Array.isArray(parsed?.pluginDefaults) ? parsed.pluginDefaults : []
+        } catch {
+            return
+        }
+
+        const effectiveDefaults = [
+            ...flowDefaults,
+            ...this.inheritedPluginDefaults(namespace, resource),
+        ]
+        if (!effectiveDefaults.length) {
+            return
+        }
+
+        const filtered = filterDefaultsCoveredMarkers(markers, source, effectiveDefaults)
+        // Only rewrite when we actually removed something — avoids a needless
+        // re-publish (and the change event it would trigger).
+        if (filtered.length !== markers.length) {
+            monaco.editor.setModelMarkers(model, YAML_MARKER_OWNER, filtered)
+        }
     }
 
     /**

--- a/ui/src/composables/useBaseNamespaces.ts
+++ b/ui/src/composables/useBaseNamespaces.ts
@@ -187,10 +187,6 @@ export const useBaseNamespacesStore = () => {
         // NOOP IN OSS
     }
 
-    // Effective plugin defaults (namespace-level + global) applicable to a namespace.
-    // Used by the flow editor to avoid flagging required properties supplied by a plugin default.
-    // Returns [] on any non-200 (e.g. 403 when the user lacks namespace read access), so the
-    // editor degrades gracefully to showing the warning.
     async function loadEffectivePluginDefaults({id}: {id: string}): Promise<EffectiveDefault[]> {
         try {
             const response = await axios.get(`${apiUrl()}/namespaces/${id}/effective-plugindefaults`, VALIDATE)

--- a/ui/src/composables/useBaseNamespaces.ts
+++ b/ui/src/composables/useBaseNamespaces.ts
@@ -1,5 +1,6 @@
 import {ref} from "vue"
 import {apiUrl} from "override/utils/route"
+import type {EffectiveDefault} from "./monaco/languages/pluginDefaultsMarkers"
 import * as Utils from "../utils/utils"
 import {useClient, type PagedResultsNamespace} from "@kestra-io/kestra-sdk"
 import * as NamespaceAPI from "@kestra-io/kestra-sdk/namespaces"
@@ -186,6 +187,22 @@ export const useBaseNamespacesStore = () => {
         // NOOP IN OSS
     }
 
+    // Effective plugin defaults (namespace-level + global) applicable to a namespace.
+    // Used by the flow editor to avoid flagging required properties supplied by a plugin default.
+    // Returns [] on any non-200 (e.g. 403 when the user lacks namespace read access), so the
+    // editor degrades gracefully to showing the warning.
+    async function loadEffectivePluginDefaults({id}: {id: string}): Promise<EffectiveDefault[]> {
+        try {
+            const response = await axios.get(`${apiUrl()}/namespaces/${id}/effective-plugindefaults`, VALIDATE)
+            if (response.status !== 200) {
+                return []
+            }
+            return response.data?.pluginDefaults ?? []
+        } catch {
+            return []
+        }
+    }
+
     async function createDirectory(payload: {namespace: string; path: string}) {
         const URL = `${base(payload.namespace)}/files/directory?path=${slashPrefix(payload.path)}`
         await axios.post(URL)
@@ -319,6 +336,7 @@ export const useBaseNamespacesStore = () => {
         deleteSecrets,
         loadInheritedVariables,
         loadInheritedPluginDefaults,
+        loadEffectivePluginDefaults,
         createDirectory,
         readDirectory,
         saveOrCreateFile: createFile,

--- a/ui/tests/unit/composables/pluginDefaultsMarkers.spec.ts
+++ b/ui/tests/unit/composables/pluginDefaultsMarkers.spec.ts
@@ -1,0 +1,101 @@
+import {describe, it, expect} from "vitest"
+import {
+    filterDefaultsCoveredMarkers,
+    isPropertyCoveredByDefaults,
+    type EffectiveDefault,
+    type MarkerLike,
+} from "../../../src/composables/monaco/languages/pluginDefaultsMarkers"
+
+// A flow whose Download task omits the required `uri`, supplied via flow-level pluginDefaults.
+const FLOW = `id: test
+namespace: io.kestra.unittest
+tasks:
+  - id: download
+    type: io.kestra.plugin.core.http.Download
+pluginDefaults:
+  - type: io.kestra.plugin.core.http.Download
+    values:
+      uri: https://kestra.io
+`
+
+// Marker positioned on the download task's `type:` line (line 5), as monaco-yaml
+// reports missing-required diagnostics against the enclosing mapping.
+function missingUriMarker(): MarkerLike {
+    return {message: "Missing property \"uri\".", startLineNumber: 5, startColumn: 5}
+}
+
+describe("isPropertyCoveredByDefaults", () => {
+    const defaults: EffectiveDefault[] = [
+        {type: "io.kestra.plugin.core.http.Download", values: {uri: "https://kestra.io"}},
+    ]
+
+    it("covers exact type match with the property present", () => {
+        expect(isPropertyCoveredByDefaults("uri", "io.kestra.plugin.core.http.Download", defaults)).toBe(true)
+    })
+
+    it("does not cover a property the default does not supply", () => {
+        expect(isPropertyCoveredByDefaults("method", "io.kestra.plugin.core.http.Download", defaults)).toBe(false)
+    })
+
+    it("matches by type prefix (backend semantics)", () => {
+        const prefixDefaults: EffectiveDefault[] = [{type: "io.kestra.plugin.core.http", values: {uri: "x"}}]
+        expect(isPropertyCoveredByDefaults("uri", "io.kestra.plugin.core.http.Download", prefixDefaults)).toBe(true)
+    })
+
+    it("does not match an unrelated type", () => {
+        expect(isPropertyCoveredByDefaults("uri", "io.kestra.plugin.core.log.Log", defaults)).toBe(false)
+    })
+
+    it("ignores defaults without a values map", () => {
+        expect(isPropertyCoveredByDefaults("uri", "io.kestra.plugin.core.http.Download", [{type: "io.kestra.plugin.core.http.Download"}])).toBe(false)
+    })
+})
+
+describe("filterDefaultsCoveredMarkers", () => {
+    it("drops a missing-property marker covered by a flow-level default", () => {
+        const defaults: EffectiveDefault[] = [
+            {type: "io.kestra.plugin.core.http.Download", values: {uri: "https://kestra.io"}},
+        ]
+        const result = filterDefaultsCoveredMarkers([missingUriMarker()], FLOW, defaults)
+        expect(result).toHaveLength(0)
+    })
+
+    it("keeps a missing-property marker when no default supplies it", () => {
+        const defaults: EffectiveDefault[] = [
+            {type: "io.kestra.plugin.core.http.Download", values: {method: "GET"}},
+        ]
+        const result = filterDefaultsCoveredMarkers([missingUriMarker()], FLOW, defaults)
+        expect(result).toHaveLength(1)
+    })
+
+    it("keeps a missing-property marker for a different task type", () => {
+        const defaults: EffectiveDefault[] = [
+            {type: "io.kestra.plugin.core.log.Log", values: {uri: "x"}},
+        ]
+        const result = filterDefaultsCoveredMarkers([missingUriMarker()], FLOW, defaults)
+        expect(result).toHaveLength(1)
+    })
+
+    it("preserves non missing-property markers untouched", () => {
+        const other: MarkerLike = {message: "Incorrect type. Expected \"string\".", startLineNumber: 5, startColumn: 5}
+        const defaults: EffectiveDefault[] = [
+            {type: "io.kestra.plugin.core.http.Download", values: {uri: "https://kestra.io"}},
+        ]
+        const result = filterDefaultsCoveredMarkers([other, missingUriMarker()], FLOW, defaults)
+        expect(result).toEqual([other])
+    })
+
+    it("is idempotent — re-running on its own output removes nothing", () => {
+        const defaults: EffectiveDefault[] = [
+            {type: "io.kestra.plugin.core.http.Download", values: {uri: "https://kestra.io"}},
+        ]
+        const once = filterDefaultsCoveredMarkers([missingUriMarker()], FLOW, defaults)
+        const twice = filterDefaultsCoveredMarkers(once, FLOW, defaults)
+        expect(twice).toEqual(once)
+    })
+
+    it("returns markers unchanged when there are no defaults", () => {
+        const markers = [missingUriMarker()]
+        expect(filterDefaultsCoveredMarkers(markers, FLOW, [])).toBe(markers)
+    })
+})

--- a/webserver/src/main/java/io/kestra/webserver/controllers/api/NamespaceController.java
+++ b/webserver/src/main/java/io/kestra/webserver/controllers/api/NamespaceController.java
@@ -8,11 +8,13 @@ import org.apache.commons.lang3.Strings;
 
 import io.kestra.core.contexts.configuration.SystemFlowsConfiguration;
 import io.kestra.core.models.QueryFilter;
+import io.kestra.core.models.flows.PluginDefault;
 import io.kestra.core.models.namespaces.Namespace;
 import io.kestra.core.models.namespaces.NamespaceInterface;
 import io.kestra.core.models.topologies.FlowTopologyGraph;
 import io.kestra.core.repositories.ArrayListTotal;
 import io.kestra.core.repositories.FlowRepositoryInterface;
+import io.kestra.core.services.PluginDefaultService;
 import io.kestra.core.tenant.TenantService;
 import io.kestra.core.topologies.FlowTopologyService;
 import io.kestra.webserver.converters.QueryFilterFormat;
@@ -53,6 +55,9 @@ public class NamespaceController<N extends Namespace> {
 
     @Inject
     private Searchable<Namespace> namespaceSearchable;
+
+    @Inject
+    protected PluginDefaultService pluginDefaultService;
 
     protected Comparator<String> sorter(Pageable pageable) {
         return Optional.of(pageable.getSort().getOrderBy())
@@ -158,5 +163,29 @@ public class NamespaceController<N extends Namespace> {
         @Parameter(description = "The flow namespace") @PathVariable String namespace,
         @Parameter(description = "if true, list only destination dependencies, otherwise list also source dependencies") @QueryValue(defaultValue = "false") boolean destinationOnly) {
         return flowTopologyService.namespaceGraph(tenantService.resolveTenant(), namespace);
+    }
+
+    @Get(uri = "{id}/effective-plugindefaults")
+    @ExecuteOn(TaskExecutors.IO)
+    @Operation(
+        tags = { "Namespaces" },
+        summary = "Get the effective plugin defaults applicable to a namespace",
+        description = "Returns the namespace-level and global plugin defaults that apply to flows in this namespace. " +
+            "Used by the flow editor to avoid flagging required properties that are actually supplied by a plugin default."
+    )
+    public EffectivePluginDefaultsResponse effectivePluginDefaults(
+        @Parameter(description = "The namespace id") @PathVariable String id) {
+        List<PluginDefault> defaults = pluginDefaultService.resolveEffectiveDefaults(
+            tenantService.resolveTenant(),
+            id,
+            Collections.emptyMap()
+        );
+        return new EffectivePluginDefaultsResponse(defaults);
+    }
+
+    /**
+     * Wraps the effective plugin defaults in a JSON object so the response stays backwards-compatibly evolvable.
+     */
+    public record EffectivePluginDefaultsResponse(List<PluginDefault> pluginDefaults) {
     }
 }

--- a/webserver/src/test/java/io/kestra/webserver/controllers/api/NamespaceControllerTest.java
+++ b/webserver/src/test/java/io/kestra/webserver/controllers/api/NamespaceControllerTest.java
@@ -60,6 +60,16 @@ public class NamespaceControllerTest {
         assertThat(namespace.getId()).isEqualTo("my.ns");
     }
 
+    @Test
+    void effectivePluginDefaultsReturnsWrappedList() {
+        NamespaceController.EffectivePluginDefaultsResponse response = client.toBlocking().retrieve(
+            HttpRequest.GET("/api/v1/main/namespaces/my.ns/effective-plugindefaults"),
+            NamespaceController.EffectivePluginDefaultsResponse.class
+        );
+
+        assertThat(response.pluginDefaults()).isEmpty();
+    }
+
     @SuppressWarnings("unchecked")
     @Test
     void list() {


### PR DESCRIPTION
## What

The flow **code editor** shows yellow "missing property" warnings for required task properties that are actually provided by `pluginDefaults`.

### Why the previous fix didn't work

PR #16366 injected plugin defaults before computing warnings in `FlowService.validate`. But that path can't produce this symptom:
- `FlowService.warnings(...)` only emits subflow / trigger-`dependsOn` / timeout / plaintext-secret warnings — **never** "missing property".
- Those warnings feed the `FlowEditorStats` banner, not the editor gutter.
- The yellow underline is produced **client-side** by `monaco-yaml`, validating the raw buffer against the static, type-only JSON schema from `GET /plugins/schemas/flow`. It has no knowledge of `pluginDefaults`.

### Approach

Post-filter monaco-yaml's markers: drop a `Missing property "x"` warning when an effective plugin default supplies `x` for the enclosing task's `type` (exact/prefix match, mirroring `PluginDefaultService`).

- **Flow-level** defaults are read from the editor buffer (live, no network).
- **Namespace-level + global** defaults come from a new `GET namespaces/{id}/effective-plugindefaults` endpoint, fetched and cached per namespace. A failed/forbidden fetch degrades gracefully — the warning stays.

`monaco-yaml`'s `validate` is all-or-nothing, so disabling client validation isn't an option (it would drop legitimate type/enum/unknown-property diagnostics) — hence the marker post-filter.

## Changes

- `pluginDefaultsMarkers.ts` — pure, unit-tested helper (`filterDefaultsCoveredMarkers`, `isPropertyCoveredByDefaults`).
- `yamlLanguageConfigurator.ts` — global `onDidChangeMarkers` filter gated to `flow-*` models; idempotent (no re-publish loop).
- `useBaseNamespaces.ts` — `loadEffectivePluginDefaults` store action.
- `PluginDefaultService.resolveEffectiveDefaults(...)` public wrapper + `GET namespaces/{id}/effective-plugindefaults` on `NamespaceController` (wrapped DTO).

## Security

The new endpoint is public in OSS (OSS has no per-namespace RBAC). The EE companion PR **overrides it with a `NAMESPACE:VIEW` check** — see kestra-io/kestra-ee#9261.

## Tests

- Vitest: 11 cases for the marker filter.
- `NamespaceControllerTest`: endpoint returns the wrapped shape.
- `check:types` + eslint clean.

Fixes #14471
