### PR TITLE
build(deps): upgrade the UI to TypeScript 7

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -36,6 +36,7 @@
                 "@types/path-browserify": "^1.0.3",
                 "@types/semver": "^7.7.1",
                 "@typescript-eslint/parser": "^8.59.2",
+                "@typescript/native-preview": "7.0.0-dev.20260615.1",
                 "@vitejs/plugin-vue": "^6.0.7",
                 "@vitejs/plugin-vue-jsx": "^5.1.5",
                 "@vitest/browser": "^4.1.7",
@@ -90,7 +91,8 @@
                 "storybook": "^10.3.3",
                 "storybook-vue3-router": "^7.0.0",
                 "ts-node": "^10.9.2",
-                "typescript": "^5.9.3",
+                "typescript": "^7.0.2",
+                "typescript6": "npm:typescript@^6.0.3",
                 "uuid": "^14.0.0",
                 "vite": "^8.0.14",
                 "vitest": "^4.1.5",
@@ -100,7 +102,7 @@
                 "vue-i18n": "^11.4.4",
                 "vue-material-design-icons": "^5.3.1",
                 "vue-router": "^5.0.6",
-                "vue-tsc": "^3.2.8",
+                "vue-tsgo": "^0.2.2",
                 "vue-virtual-scroller": "^3.0.4",
                 "xss": "^1.0.15",
                 "yaml": "^2.8.3"
@@ -722,6 +724,110 @@
             "resolved": "https://registry.npmjs.org/@chevrotain/types/-/types-11.1.2.tgz",
             "integrity": "sha512-U+HFai5+zmJCkK86QsaJtoITlboZHBqrVketcO2ROv865xfCMSFpELQoz1GkX5GzME8pTa+3kbKrZHQtI0gdbw==",
             "license": "Apache-2.0"
+        },
+        "node_modules/@clerc/core": {
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/@clerc/core/-/core-1.3.1.tgz",
+            "integrity": "sha512-8jowdURow2tXga2gUa4E7/j8/9tl5TLXAvtpbnsY3JK4PTcaKB3lyc6YrcfUTJfV06whBzBpPvr3jGcNja3Wtg==",
+            "license": "MIT",
+            "dependencies": {
+                "@clerc/parser": "1.3.1",
+                "@clerc/utils": "1.3.1",
+                "lite-emit": "^4.0.0"
+            }
+        },
+        "node_modules/@clerc/parser": {
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/@clerc/parser/-/parser-1.3.1.tgz",
+            "integrity": "sha512-e1rb82ENJNfZYjkf5tR7OcsmwNShINJumxfy7fS9SYypSZNRbQmzHj7k7miQ3u+Mfc08fpBtvpAGqeBWQKQxRQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@clerc/utils": "1.3.1"
+            }
+        },
+        "node_modules/@clerc/plugin-completions": {
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/@clerc/plugin-completions/-/plugin-completions-1.3.1.tgz",
+            "integrity": "sha512-zotC2qXVnDZLdwsFI6RPzhA90aNLkZSMuAeYsmrTEekknI3KMp2VFMKEBkQ+Zjsq3XCdaT8P4WEvPFkLJIMZjA==",
+            "license": "MIT",
+            "peerDependencies": {
+                "@clerc/core": "*"
+            }
+        },
+        "node_modules/@clerc/plugin-friendly-error": {
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/@clerc/plugin-friendly-error/-/plugin-friendly-error-1.3.1.tgz",
+            "integrity": "sha512-qef/3VbiEBDEWU3hiKBP0uUHPo0dxLd0WCLg1ZJNAMUjjZosNPMM+vsFAp1cRKFr/9wQCDzHF7nEPbrodogaqw==",
+            "license": "MIT",
+            "peerDependencies": {
+                "@clerc/core": "*"
+            }
+        },
+        "node_modules/@clerc/plugin-help": {
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/@clerc/plugin-help/-/plugin-help-1.3.1.tgz",
+            "integrity": "sha512-8cibdUMgZpUqv2kVfTK2HcbxeEz53NQnX+SR4Dh0V+oqB95MmRc0ihXUdXb2qR0J5h5zd7F9QC6yRiG9t00F/g==",
+            "license": "MIT",
+            "dependencies": {
+                "@clerc/utils": "1.3.1",
+                "@uttr/tint": "^0.1.3",
+                "fast-string-width": "^3.0.2",
+                "text-table": "^0.2.0"
+            },
+            "peerDependencies": {
+                "@clerc/core": "*"
+            }
+        },
+        "node_modules/@clerc/plugin-not-found": {
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/@clerc/plugin-not-found/-/plugin-not-found-1.3.1.tgz",
+            "integrity": "sha512-k52YK5wDjqdenVDzcOH0A9mZl40RXa+FKNrWiiFxHY/U/REc7dBfISCDEH4ilVPZEe9Op3MB6zjgujDXOSYW0w==",
+            "license": "MIT",
+            "dependencies": {
+                "@uttr/tint": "^0.1.3"
+            },
+            "peerDependencies": {
+                "@clerc/core": "*"
+            }
+        },
+        "node_modules/@clerc/plugin-strict-flags": {
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/@clerc/plugin-strict-flags/-/plugin-strict-flags-1.3.1.tgz",
+            "integrity": "sha512-sFys7qDIiaiBZ/DsHTpQd1jfQKIirK0hav+SPLZfp5696ZiGzZxuXw0L11q9Y/XEaJj3eXtEPTbTBeY1O2W/ew==",
+            "license": "MIT",
+            "dependencies": {
+                "@clerc/utils": "1.3.1"
+            },
+            "peerDependencies": {
+                "@clerc/core": "*"
+            }
+        },
+        "node_modules/@clerc/plugin-update-notifier": {
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/@clerc/plugin-update-notifier/-/plugin-update-notifier-1.3.1.tgz",
+            "integrity": "sha512-wUq9E3CBMzEDhL5uUwt08Gf7yUydUFIcAbWXijhEEnId924facRKQIbFmEDfD+bV5MIfGukBXmeTobDGAcvXIQ==",
+            "license": "MIT",
+            "peerDependencies": {
+                "@clerc/core": "*"
+            }
+        },
+        "node_modules/@clerc/plugin-version": {
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/@clerc/plugin-version/-/plugin-version-1.3.1.tgz",
+            "integrity": "sha512-g8bn+J/oX8dwNhFCwh8E1BGka9Z9PLCjQ+dgByMc7EA7RH0agxU9bWXgHqkL4JFMPhVWFG2w6sGxL6pN6tyq4Q==",
+            "license": "MIT",
+            "dependencies": {
+                "@clerc/utils": "1.3.1"
+            },
+            "peerDependencies": {
+                "@clerc/core": "*"
+            }
+        },
+        "node_modules/@clerc/utils": {
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/@clerc/utils/-/utils-1.3.1.tgz",
+            "integrity": "sha512-wkK6daYkmTQKnhSADMkunfDhNJI6rRCn2R++7cI2EoEBmOZWYqn7frkk5ac7zsxBi0Mc3UnMVaJiNFU+t6PPWQ==",
+            "license": "MIT"
         },
         "node_modules/@codecov/bundler-plugin-core": {
             "version": "2.0.1",
@@ -1456,9 +1562,9 @@
             "license": "MIT"
         },
         "node_modules/@eslint/config-array/node_modules/brace-expansion": {
-            "version": "1.1.15",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-            "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+            "version": "1.1.16",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+            "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
             "license": "MIT",
             "dependencies": {
                 "balanced-match": "^1.0.0",
@@ -1531,9 +1637,9 @@
             "license": "MIT"
         },
         "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-            "version": "1.1.15",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-            "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+            "version": "1.1.16",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+            "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
             "license": "MIT",
             "dependencies": {
                 "balanced-match": "^1.0.0",
@@ -1732,9 +1838,9 @@
             "license": "MIT"
         },
         "node_modules/@iconify/utils": {
-            "version": "3.1.3",
-            "resolved": "https://registry.npmjs.org/@iconify/utils/-/utils-3.1.3.tgz",
-            "integrity": "sha512-LPKOXPn/zV+zis1oOfGWogaXVpqUybF3ZS6SCZIsz8vg0ivVp9+fVqyYB7xq0aiST/VhUQYGO1qo6uoYSiEJqw==",
+            "version": "3.1.4",
+            "resolved": "https://registry.npmjs.org/@iconify/utils/-/utils-3.1.4.tgz",
+            "integrity": "sha512-b1S7B1k9ohZ+iNTi2ATxbRYG9fTrJmUT0rc46bvVnNxqNRGW7dyo/vRREwyniI5IRN2RSJHDcm+s3BjWrSAjHw==",
             "license": "MIT",
             "dependencies": {
                 "@antfu/install-pkg": "^1.1.0",
@@ -1876,9 +1982,9 @@
             "link": true
         },
         "node_modules/@kestra-io/kestra-sdk": {
-            "version": "2.0.0-kdevelop.17828135.30c54e76.93e9a466",
-            "resolved": "https://registry.npmjs.org/@kestra-io/kestra-sdk/-/kestra-sdk-2.0.0-kdevelop.17828135.30c54e76.93e9a466.tgz",
-            "integrity": "sha512-sgwdJ2dQ/GkbJLx0Goq/7TbX6QM9bEC87QziQSIcFAySPdr8DlsOpxskDu8UZxZLCutB9b9oqrN4b+X3W+P8nQ==",
+            "version": "2.0.0-kdevelop.17834137.52b4a415.9f8328d1",
+            "resolved": "https://registry.npmjs.org/@kestra-io/kestra-sdk/-/kestra-sdk-2.0.0-kdevelop.17834137.52b4a415.9f8328d1.tgz",
+            "integrity": "sha512-NPOD79dEBtFR3g4FLCbk9/aXei62OwKlISP1cyJDbmDCa3e/bIeUAZtVoatCo0/y2F62DOGN7e0ziThdhR9O2w==",
             "license": "Unlicense",
             "dependencies": {
                 "axios": "1.16.1",
@@ -1936,12 +2042,12 @@
             }
         },
         "node_modules/@module-federation/bridge-react-webpack-plugin": {
-            "version": "2.6.0",
-            "resolved": "https://registry.npmjs.org/@module-federation/bridge-react-webpack-plugin/-/bridge-react-webpack-plugin-2.6.0.tgz",
-            "integrity": "sha512-V+4+1PUmDgAozXPJA8evIa2G+dPJGYn1JzDoHS9wMFch2blko/DO2sMq6FGuZFnT1oyjxiWeiaWXluRElOU9rQ==",
+            "version": "2.7.0",
+            "resolved": "https://registry.npmjs.org/@module-federation/bridge-react-webpack-plugin/-/bridge-react-webpack-plugin-2.7.0.tgz",
+            "integrity": "sha512-+7eYeJnIaofQHha8CK+FxPAXMIigd2xwONHi9rlYpdGqpCBIggRKMqL0b1owyDDNiAPF2lWUbxeNm0oUfF7GbA==",
             "license": "MIT",
             "dependencies": {
-                "@module-federation/sdk": "2.6.0",
+                "@module-federation/sdk": "2.7.0",
                 "@types/semver": "7.5.8",
                 "semver": "7.6.3"
             }
@@ -1965,13 +2071,13 @@
             }
         },
         "node_modules/@module-federation/cli": {
-            "version": "2.6.0",
-            "resolved": "https://registry.npmjs.org/@module-federation/cli/-/cli-2.6.0.tgz",
-            "integrity": "sha512-CHBsi5f8Oe9sCN6rY4R0+P/oFApvuutnqfoYNtuORdMn6FHittFDkuLFCSYlrZN2QYw/Sqir2xgLcwmY77Z7PA==",
+            "version": "2.7.0",
+            "resolved": "https://registry.npmjs.org/@module-federation/cli/-/cli-2.7.0.tgz",
+            "integrity": "sha512-Nx5PQFmYqiiiIaU8uyzFcm9j8bNGb0SEo1GvbjI4ehfRJ5a92sUjNE++Q3o6zmVDI4wDXIhpGxioYdXi5QF40w==",
             "license": "MIT",
             "dependencies": {
-                "@module-federation/dts-plugin": "2.6.0",
-                "@module-federation/sdk": "2.6.0",
+                "@module-federation/dts-plugin": "2.7.0",
+                "@module-federation/sdk": "2.7.0",
                 "commander": "11.1.0",
                 "jiti": "2.4.2"
             },
@@ -1983,6 +2089,210 @@
             }
         },
         "node_modules/@module-federation/dts-plugin": {
+            "version": "2.7.0",
+            "resolved": "https://registry.npmjs.org/@module-federation/dts-plugin/-/dts-plugin-2.7.0.tgz",
+            "integrity": "sha512-mVKeGUf/7iqRMAFfikhsr2zXtA70WuzJdS1bPqqoeLQNRGXBLDjedcDG26RpIlsvuZcmIOqgN5Z6qw7Bh/HZUg==",
+            "license": "MIT",
+            "dependencies": {
+                "@module-federation/error-codes": "2.7.0",
+                "@module-federation/managers": "2.7.0",
+                "@module-federation/sdk": "2.7.0",
+                "@module-federation/third-party-dts-extractor": "2.7.0",
+                "adm-zip": "0.5.10",
+                "isomorphic-ws": "5.0.0",
+                "node-schedule": "2.1.1",
+                "undici": "7.28.0",
+                "ws": "8.21.0"
+            },
+            "peerDependencies": {
+                "typescript": "^4.9.0 || ^5.0.0 || ^6.0.0",
+                "vue-tsc": ">=1.0.24"
+            },
+            "peerDependenciesMeta": {
+                "vue-tsc": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@module-federation/dts-plugin/node_modules/undici": {
+            "version": "7.28.0",
+            "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+            "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=20.18.1"
+            }
+        },
+        "node_modules/@module-federation/enhanced": {
+            "version": "2.7.0",
+            "resolved": "https://registry.npmjs.org/@module-federation/enhanced/-/enhanced-2.7.0.tgz",
+            "integrity": "sha512-1ZaiFIsFdH68MLoU7jrYxwhDt4WbDqmuTcnVsRqp9QZhZsex9h2zkeNpZdctL2Q1BtGsuNJ4ngJCOmO84O+6CQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@module-federation/bridge-react-webpack-plugin": "2.7.0",
+                "@module-federation/cli": "2.7.0",
+                "@module-federation/dts-plugin": "2.7.0",
+                "@module-federation/error-codes": "2.7.0",
+                "@module-federation/inject-external-runtime-core-plugin": "2.7.0",
+                "@module-federation/managers": "2.7.0",
+                "@module-federation/manifest": "2.7.0",
+                "@module-federation/rspack": "2.7.0",
+                "@module-federation/runtime-tools": "2.7.0",
+                "@module-federation/sdk": "2.7.0",
+                "@module-federation/webpack-bundler-runtime": "2.7.0",
+                "schema-utils": "4.3.0",
+                "tapable": "2.3.0",
+                "upath": "2.0.1"
+            },
+            "bin": {
+                "mf": "bin/mf.js"
+            },
+            "peerDependencies": {
+                "typescript": "^4.9.0 || ^5.0.0 || ^6.0.0",
+                "vue-tsc": ">=1.0.24",
+                "webpack": "^5.0.0"
+            },
+            "peerDependenciesMeta": {
+                "typescript": {
+                    "optional": true
+                },
+                "vue-tsc": {
+                    "optional": true
+                },
+                "webpack": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@module-federation/error-codes": {
+            "version": "2.7.0",
+            "resolved": "https://registry.npmjs.org/@module-federation/error-codes/-/error-codes-2.7.0.tgz",
+            "integrity": "sha512-syToF3H77IbBhJ7auGMCIb5ZDmJ5tvaqSeEvncJrOCq7JBT96F4UDlQDyNh6kCVznvYqqHsPeEMrfI9b5/Omlg==",
+            "license": "MIT"
+        },
+        "node_modules/@module-federation/inject-external-runtime-core-plugin": {
+            "version": "2.7.0",
+            "resolved": "https://registry.npmjs.org/@module-federation/inject-external-runtime-core-plugin/-/inject-external-runtime-core-plugin-2.7.0.tgz",
+            "integrity": "sha512-8xHVUWsnlYd1vQPUjVEO+OPBhBjbdur+jp33QwqwkJkSUW/WOgnybCevVyfiA05aaiSyPo1PluQPT6uhImVb7A==",
+            "license": "MIT",
+            "peerDependencies": {
+                "@module-federation/runtime-tools": "2.7.0"
+            }
+        },
+        "node_modules/@module-federation/managers": {
+            "version": "2.7.0",
+            "resolved": "https://registry.npmjs.org/@module-federation/managers/-/managers-2.7.0.tgz",
+            "integrity": "sha512-cWohiUvSrY6dIfhwsRABmEWfvJiAD5u/gxU7XRk7bx5nYPj7qn5gvYWJtvLNWzenluHZR6sib+03QMlyo+MYKQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@module-federation/sdk": "2.7.0",
+                "empathic": "2.0.0"
+            }
+        },
+        "node_modules/@module-federation/manifest": {
+            "version": "2.7.0",
+            "resolved": "https://registry.npmjs.org/@module-federation/manifest/-/manifest-2.7.0.tgz",
+            "integrity": "sha512-phK5/pK/e0JyjMh7a2tvRXUFE0WCG9lxu4BtBQllZXNO0zjrroOHl2s/0sSUCdOq6NIL1HF9wTAudYiCKmNFjA==",
+            "license": "MIT",
+            "dependencies": {
+                "@module-federation/dts-plugin": "2.7.0",
+                "@module-federation/managers": "2.7.0",
+                "@module-federation/sdk": "2.7.0"
+            }
+        },
+        "node_modules/@module-federation/rspack": {
+            "version": "2.7.0",
+            "resolved": "https://registry.npmjs.org/@module-federation/rspack/-/rspack-2.7.0.tgz",
+            "integrity": "sha512-VbYc/5cpIze16ysBZJvmeXU7NN8tAs6Q/MdDsllIwO+Ir7JIEXgGrs5Bs+K7BuAu3HpxyRC8KanJTD+JB91+WA==",
+            "license": "MIT",
+            "dependencies": {
+                "@module-federation/bridge-react-webpack-plugin": "2.7.0",
+                "@module-federation/dts-plugin": "2.7.0",
+                "@module-federation/inject-external-runtime-core-plugin": "2.7.0",
+                "@module-federation/managers": "2.7.0",
+                "@module-federation/manifest": "2.7.0",
+                "@module-federation/runtime-tools": "2.7.0",
+                "@module-federation/sdk": "2.7.0"
+            },
+            "peerDependencies": {
+                "@rspack/core": "^0.7.0 || ^1.0.0 || ^2.0.0-0",
+                "typescript": "^4.9.0 || ^5.0.0 || ^6.0.0",
+                "vue-tsc": ">=1.0.24"
+            },
+            "peerDependenciesMeta": {
+                "typescript": {
+                    "optional": true
+                },
+                "vue-tsc": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@module-federation/runtime": {
+            "version": "2.7.0",
+            "resolved": "https://registry.npmjs.org/@module-federation/runtime/-/runtime-2.7.0.tgz",
+            "integrity": "sha512-UtLozKKNvhT0D1+F0MEWsAmddJ39ItKW15E22LVMAwXmYZRSnzIvJQ2Y6kQ4LwhWABsw/GRSpUDex5OfhpSQPw==",
+            "license": "MIT",
+            "dependencies": {
+                "@module-federation/error-codes": "2.7.0",
+                "@module-federation/runtime-core": "2.7.0",
+                "@module-federation/sdk": "2.7.0"
+            }
+        },
+        "node_modules/@module-federation/runtime-core": {
+            "version": "2.7.0",
+            "resolved": "https://registry.npmjs.org/@module-federation/runtime-core/-/runtime-core-2.7.0.tgz",
+            "integrity": "sha512-5ROZLVIeV9YnWO2RwCwSHcy6sh48yclErO/2GZ2Xe8lFubPrFirgU8pbwBjZw+All0ZzN44BGS4ECRMVFzVcpg==",
+            "license": "MIT",
+            "dependencies": {
+                "@module-federation/error-codes": "2.7.0",
+                "@module-federation/sdk": "2.7.0"
+            }
+        },
+        "node_modules/@module-federation/runtime-tools": {
+            "version": "2.7.0",
+            "resolved": "https://registry.npmjs.org/@module-federation/runtime-tools/-/runtime-tools-2.7.0.tgz",
+            "integrity": "sha512-AY61QeZ0jV0GywgR9j3Yd37KiXoY6gaSYABhjDF3q7XL9PNtb2Ezm1F/985wqaKJYX+qJvYv+PMH6hTvyHdPYQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@module-federation/runtime": "2.7.0",
+                "@module-federation/webpack-bundler-runtime": "2.7.0"
+            }
+        },
+        "node_modules/@module-federation/sdk": {
+            "version": "2.7.0",
+            "resolved": "https://registry.npmjs.org/@module-federation/sdk/-/sdk-2.7.0.tgz",
+            "integrity": "sha512-piiLEjaIdjbNq8E11Di6vsfryhcdN/+sBCH6NjG7gSU2VHHoHEayZQWWL7VVdS6rVjexF9McLhPTSrl0adUU+A==",
+            "license": "MIT"
+        },
+        "node_modules/@module-federation/third-party-dts-extractor": {
+            "version": "2.7.0",
+            "resolved": "https://registry.npmjs.org/@module-federation/third-party-dts-extractor/-/third-party-dts-extractor-2.7.0.tgz",
+            "integrity": "sha512-hZJKkngQ4hwe0U+vrT3KOsU11qoHCQK0wB4x1bXoTgpTfV9j5NSuddOyRmwbvXpir9bDWh3xy7ghqsx3mFf3kA==",
+            "license": "MIT",
+            "dependencies": {
+                "empathic": "2.0.0",
+                "exsolve": "1.0.8"
+            }
+        },
+        "node_modules/@module-federation/vite": {
+            "version": "1.16.13",
+            "resolved": "https://registry.npmjs.org/@module-federation/vite/-/vite-1.16.13.tgz",
+            "integrity": "sha512-jlA29Wwu/CW21hf2VyNQ/qrLfvk0RWVYA+rU4Ps0CEeMd0q+ss1gnwwvCV+Ot6TPLcu2z5pfxc3UZiBQdH9+rw==",
+            "license": "MIT",
+            "dependencies": {
+                "@module-federation/dts-plugin": "2.6.0",
+                "@module-federation/runtime": "2.6.0",
+                "@module-federation/sdk": "2.6.0"
+            },
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            },
+            "peerDependencies": {
+                "vite": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
+            }
+        },
+        "node_modules/@module-federation/vite/node_modules/@module-federation/dts-plugin": {
             "version": "2.6.0",
             "resolved": "https://registry.npmjs.org/@module-federation/dts-plugin/-/dts-plugin-2.6.0.tgz",
             "integrity": "sha512-0dMjLhU+2HNPyX5Txu6JqA2CAYxVLRv3c/bpRk58aNVwhDO/jqp66IdFztdMZ1XiHqOW9jB3pkOSuIpcl/yXpQ==",
@@ -2009,72 +2319,13 @@
                 }
             }
         },
-        "node_modules/@module-federation/dts-plugin/node_modules/undici": {
-            "version": "7.28.0",
-            "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
-            "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=20.18.1"
-            }
-        },
-        "node_modules/@module-federation/enhanced": {
-            "version": "2.6.0",
-            "resolved": "https://registry.npmjs.org/@module-federation/enhanced/-/enhanced-2.6.0.tgz",
-            "integrity": "sha512-pQ0V93FfeHtr67Nusr6ySTQO1qeOGs1x9MMjbeZ4ObOPbXdHNX1tH19xVP8mo5k3e8iIV2teMoSayTmHT+nD0g==",
-            "license": "MIT",
-            "dependencies": {
-                "@module-federation/bridge-react-webpack-plugin": "2.6.0",
-                "@module-federation/cli": "2.6.0",
-                "@module-federation/dts-plugin": "2.6.0",
-                "@module-federation/error-codes": "2.6.0",
-                "@module-federation/inject-external-runtime-core-plugin": "2.6.0",
-                "@module-federation/managers": "2.6.0",
-                "@module-federation/manifest": "2.6.0",
-                "@module-federation/rspack": "2.6.0",
-                "@module-federation/runtime-tools": "2.6.0",
-                "@module-federation/sdk": "2.6.0",
-                "@module-federation/webpack-bundler-runtime": "2.6.0",
-                "schema-utils": "4.3.0",
-                "tapable": "2.3.0",
-                "upath": "2.0.1"
-            },
-            "bin": {
-                "mf": "bin/mf.js"
-            },
-            "peerDependencies": {
-                "typescript": "^4.9.0 || ^5.0.0",
-                "vue-tsc": ">=1.0.24",
-                "webpack": "^5.0.0"
-            },
-            "peerDependenciesMeta": {
-                "typescript": {
-                    "optional": true
-                },
-                "vue-tsc": {
-                    "optional": true
-                },
-                "webpack": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/@module-federation/error-codes": {
+        "node_modules/@module-federation/vite/node_modules/@module-federation/error-codes": {
             "version": "2.6.0",
             "resolved": "https://registry.npmjs.org/@module-federation/error-codes/-/error-codes-2.6.0.tgz",
             "integrity": "sha512-J9opjWJJZ1JI/9EvNZF8Ps1VMHS9EsH/i0UjCkQQxFVYZxSDBX1CFunvc7awac4cY//LqJUfqBbfoQPhCfKKKw==",
             "license": "MIT"
         },
-        "node_modules/@module-federation/inject-external-runtime-core-plugin": {
-            "version": "2.6.0",
-            "resolved": "https://registry.npmjs.org/@module-federation/inject-external-runtime-core-plugin/-/inject-external-runtime-core-plugin-2.6.0.tgz",
-            "integrity": "sha512-x5SmH33U1nSEcBXG6YzvkwIQLoKcd/CNfrAx4IJ4qBzlQKI0NvY7U4JE83LpBnwahNTQLvp27ZVX+1f7kt4Vww==",
-            "license": "MIT",
-            "peerDependencies": {
-                "@module-federation/runtime-tools": "2.6.0"
-            }
-        },
-        "node_modules/@module-federation/managers": {
+        "node_modules/@module-federation/vite/node_modules/@module-federation/managers": {
             "version": "2.6.0",
             "resolved": "https://registry.npmjs.org/@module-federation/managers/-/managers-2.6.0.tgz",
             "integrity": "sha512-7Y4Ri6Lh10dCHoEJvNGFmK2Gg1JKy7oJ1TEZhuU3n3mgIpZ519fDNRvU4+tiO9C49p1xyK+mQ8ewxth83waKUA==",
@@ -2084,47 +2335,7 @@
                 "find-pkg": "2.0.0"
             }
         },
-        "node_modules/@module-federation/manifest": {
-            "version": "2.6.0",
-            "resolved": "https://registry.npmjs.org/@module-federation/manifest/-/manifest-2.6.0.tgz",
-            "integrity": "sha512-wIjI4wgFKBoq4l/iBOT2lva+i5sPv1+Ci1gOLOfjMAkygyGo97csUG5TaCWgLJpZzbYrpbFObCB2wZhqaLrQIw==",
-            "license": "MIT",
-            "dependencies": {
-                "@module-federation/dts-plugin": "2.6.0",
-                "@module-federation/managers": "2.6.0",
-                "@module-federation/sdk": "2.6.0",
-                "find-pkg": "2.0.0"
-            }
-        },
-        "node_modules/@module-federation/rspack": {
-            "version": "2.6.0",
-            "resolved": "https://registry.npmjs.org/@module-federation/rspack/-/rspack-2.6.0.tgz",
-            "integrity": "sha512-Ayh7WLxhLRMyfBfajDwEytR5StFfnqf8p4tPHq5ds+HzJMlGz/M+NIYEzdOpfOFdE5IqN9bY/mj2AFI5lCureQ==",
-            "license": "MIT",
-            "dependencies": {
-                "@module-federation/bridge-react-webpack-plugin": "2.6.0",
-                "@module-federation/dts-plugin": "2.6.0",
-                "@module-federation/inject-external-runtime-core-plugin": "2.6.0",
-                "@module-federation/managers": "2.6.0",
-                "@module-federation/manifest": "2.6.0",
-                "@module-federation/runtime-tools": "2.6.0",
-                "@module-federation/sdk": "2.6.0"
-            },
-            "peerDependencies": {
-                "@rspack/core": "^0.7.0 || ^1.0.0 || ^2.0.0-0",
-                "typescript": "^4.9.0 || ^5.0.0",
-                "vue-tsc": ">=1.0.24"
-            },
-            "peerDependenciesMeta": {
-                "typescript": {
-                    "optional": true
-                },
-                "vue-tsc": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/@module-federation/runtime": {
+        "node_modules/@module-federation/vite/node_modules/@module-federation/runtime": {
             "version": "2.6.0",
             "resolved": "https://registry.npmjs.org/@module-federation/runtime/-/runtime-2.6.0.tgz",
             "integrity": "sha512-Y8KgL70RDxD8cCtGWGlGkt+TSDleIjdGmS27gnllibQAIgG/vHhPD11r8kd92x44k4dqtMIntzreOphGICl92g==",
@@ -2135,7 +2346,7 @@
                 "@module-federation/sdk": "2.6.0"
             }
         },
-        "node_modules/@module-federation/runtime-core": {
+        "node_modules/@module-federation/vite/node_modules/@module-federation/runtime-core": {
             "version": "2.6.0",
             "resolved": "https://registry.npmjs.org/@module-federation/runtime-core/-/runtime-core-2.6.0.tgz",
             "integrity": "sha512-9sL7Yj3H3COZI9JpK/J4hmJUBkIJdmowkj6phHuFiy5Hm5bHiE5U+9WBbR9KqTdyNhAVSL9FeprBW5/Io6i59A==",
@@ -2145,17 +2356,7 @@
                 "@module-federation/sdk": "2.6.0"
             }
         },
-        "node_modules/@module-federation/runtime-tools": {
-            "version": "2.6.0",
-            "resolved": "https://registry.npmjs.org/@module-federation/runtime-tools/-/runtime-tools-2.6.0.tgz",
-            "integrity": "sha512-LfvihAhAWWNWlAL9zM+UDVDSSuLE2ZU0ATJ6dcbJuLstYbHYfUqq2e6IyU8TKLPXIib0VAWqPrT44TPam1VJ7g==",
-            "license": "MIT",
-            "dependencies": {
-                "@module-federation/runtime": "2.6.0",
-                "@module-federation/webpack-bundler-runtime": "2.6.0"
-            }
-        },
-        "node_modules/@module-federation/sdk": {
+        "node_modules/@module-federation/vite/node_modules/@module-federation/sdk": {
             "version": "2.6.0",
             "resolved": "https://registry.npmjs.org/@module-federation/sdk/-/sdk-2.6.0.tgz",
             "integrity": "sha512-Z3HT1uDciMrvz2at3sw6TJbAK9Fl7RmoC/8iqO35HDtQMQJ1qSsMIAjnsiCpAC0D4nAm6PIqgSqPWRO/WYgo0Q==",
@@ -2169,7 +2370,7 @@
                 }
             }
         },
-        "node_modules/@module-federation/third-party-dts-extractor": {
+        "node_modules/@module-federation/vite/node_modules/@module-federation/third-party-dts-extractor": {
             "version": "2.6.0",
             "resolved": "https://registry.npmjs.org/@module-federation/third-party-dts-extractor/-/third-party-dts-extractor-2.6.0.tgz",
             "integrity": "sha512-rEC1YRC3gTafoOcFm1Htz6cAwHRoWEMQNCm1LXR1HiuayJzUkViVpK/1Pp37UZfytOyQ0qIaP6Ag81PdGvDbmw==",
@@ -2179,32 +2380,41 @@
                 "resolve": "1.22.8"
             }
         },
-        "node_modules/@module-federation/vite": {
-            "version": "1.16.12",
-            "resolved": "https://registry.npmjs.org/@module-federation/vite/-/vite-1.16.12.tgz",
-            "integrity": "sha512-ydbUPYxA8kY1nopVyD6eks1j++rWAop/L8U3x44dnoCLffSx0rm1MldWO5l/ydfyCBneD+rL+eFroG9/JLOjdQ==",
+        "node_modules/@module-federation/vite/node_modules/resolve": {
+            "version": "1.22.8",
+            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
+            "integrity": "sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==",
             "license": "MIT",
             "dependencies": {
-                "@module-federation/dts-plugin": "2.6.0",
-                "@module-federation/runtime": "2.6.0",
-                "@module-federation/sdk": "2.6.0"
+                "is-core-module": "^2.13.0",
+                "path-parse": "^1.0.7",
+                "supports-preserve-symlinks-flag": "^1.0.0"
             },
+            "bin": {
+                "resolve": "bin/resolve"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/@module-federation/vite/node_modules/undici": {
+            "version": "7.28.0",
+            "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+            "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+            "license": "MIT",
             "engines": {
-                "node": "^20.19.0 || >=22.12.0"
-            },
-            "peerDependencies": {
-                "vite": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
+                "node": ">=20.18.1"
             }
         },
         "node_modules/@module-federation/webpack-bundler-runtime": {
-            "version": "2.6.0",
-            "resolved": "https://registry.npmjs.org/@module-federation/webpack-bundler-runtime/-/webpack-bundler-runtime-2.6.0.tgz",
-            "integrity": "sha512-JjuWOU3ktwDjBWhM4WCoeiErcUxcB5YwUnVjyTMfNJHC3+DMhG4m6ziCl5EJrCv+KaEQdcvXmxLliNZidBZGQg==",
+            "version": "2.7.0",
+            "resolved": "https://registry.npmjs.org/@module-federation/webpack-bundler-runtime/-/webpack-bundler-runtime-2.7.0.tgz",
+            "integrity": "sha512-3qLRIqcZVBNgJrZpiEzcTP8a6+mCdUV1QGk/XljawsQHyNieMVdLQtdLvkoF5Z5kRXNMovq+wv3vchKOMWyA8w==",
             "license": "MIT",
             "dependencies": {
-                "@module-federation/error-codes": "2.6.0",
-                "@module-federation/runtime": "2.6.0",
-                "@module-federation/sdk": "2.6.0"
+                "@module-federation/error-codes": "2.7.0",
+                "@module-federation/runtime": "2.7.0",
+                "@module-federation/sdk": "2.7.0"
             }
         },
         "node_modules/@napi-rs/canvas": {
@@ -2566,9 +2776,9 @@
             }
         },
         "node_modules/@octokit/request": {
-            "version": "10.0.10",
-            "resolved": "https://registry.npmjs.org/@octokit/request/-/request-10.0.10.tgz",
-            "integrity": "sha512-KxNC2pTqqhszMNrf12ZRd4PonRgyJdsM4F/jySiddQK+DsRcfBtUvqn8t7UsyZhnRJHvX46OohDt5N3VqIWC2w==",
+            "version": "10.0.11",
+            "resolved": "https://registry.npmjs.org/@octokit/request/-/request-10.0.11.tgz",
+            "integrity": "sha512-+s7HUxjfFqOMS9VlIwDffq0MikjSAK0gSpG73W+meAvVAvX4MBrHYTK5Bj3Uot55qFT4gzUtfzE4mGWY4Br8/Q==",
             "license": "MIT",
             "dependencies": {
                 "@octokit/endpoint": "^11.0.3",
@@ -2972,9 +3182,9 @@
             }
         },
         "node_modules/@oxc-resolver/binding-android-arm-eabi": {
-            "version": "11.21.3",
-            "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-android-arm-eabi/-/binding-android-arm-eabi-11.21.3.tgz",
-            "integrity": "sha512-eNU11A2WNizh04v3uyaJCootrHIaS0B9aHYXvAvVnPNk4xYSjMUjHnhQ6dewPN2MRYDskV85d1N0Aw0WNWhcyg==",
+            "version": "11.23.0",
+            "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-android-arm-eabi/-/binding-android-arm-eabi-11.23.0.tgz",
+            "integrity": "sha512-8IJyWRLVAyhTfe9/TIEbQqSQnl5rUqYJrUOS6Dkr+Mq9FGHMxDGeiEmwkBqCvDP5KckpPh/GYSgbag66O6JsCw==",
             "cpu": [
                 "arm"
             ],
@@ -2985,9 +3195,9 @@
             ]
         },
         "node_modules/@oxc-resolver/binding-android-arm64": {
-            "version": "11.21.3",
-            "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-android-arm64/-/binding-android-arm64-11.21.3.tgz",
-            "integrity": "sha512-8Q+ZjTLvn2dIcWsrmhdrEihm7q+ag/k+mkry7Z+t0QbbHaVxXQfvH9AewyVMh/WrpEKhQ3DDgx9fYbqeCpeOEw==",
+            "version": "11.23.0",
+            "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-android-arm64/-/binding-android-arm64-11.23.0.tgz",
+            "integrity": "sha512-pprVojnNhHxupwTT2gdeUlkxll6XEvWWBk3oVicOSNVWQC99OBnDhMQDoirqnzrE1bScQSMS2JgPpqdlrhz/Fg==",
             "cpu": [
                 "arm64"
             ],
@@ -2998,9 +3208,9 @@
             ]
         },
         "node_modules/@oxc-resolver/binding-darwin-arm64": {
-            "version": "11.21.3",
-            "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-darwin-arm64/-/binding-darwin-arm64-11.21.3.tgz",
-            "integrity": "sha512-wkh0qKZGHXVUDxFw3oA1TXnU2BDYY/r775oJflGeIr8uDPPoN2pk8gijQIzYRT6hoql/lg3+Tx/SaTn9e2/aGg==",
+            "version": "11.23.0",
+            "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-darwin-arm64/-/binding-darwin-arm64-11.23.0.tgz",
+            "integrity": "sha512-mbIrWIMAJeytyee36OyUP5XH92TP7FaKaQ2m5AjokKy7STgjrhRt7SMXqpqLjhGm6Xn721Xmsg6H3Rtd9YQETw==",
             "cpu": [
                 "arm64"
             ],
@@ -3011,9 +3221,9 @@
             ]
         },
         "node_modules/@oxc-resolver/binding-darwin-x64": {
-            "version": "11.21.3",
-            "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-darwin-x64/-/binding-darwin-x64-11.21.3.tgz",
-            "integrity": "sha512-HbNc23FAQYbuyDV2vBWMez4u4mrsm5RAkniGZAWqr6lYZ3N4beeqIb776jzwRl8qL2zRhHVXpUj97X0QgogVzg==",
+            "version": "11.23.0",
+            "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-darwin-x64/-/binding-darwin-x64-11.23.0.tgz",
+            "integrity": "sha512-UnIphmZ1LazUCr9DXWaKYWtKDefPMbgLsywaoYxRqVCNHhq4MM6d2q1Nz1i9Vzxt5i+cE2nRUYpAUHr/lijNYA==",
             "cpu": [
                 "x64"
             ],
@@ -3024,9 +3234,9 @@
             ]
         },
         "node_modules/@oxc-resolver/binding-freebsd-x64": {
-            "version": "11.21.3",
-            "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-freebsd-x64/-/binding-freebsd-x64-11.21.3.tgz",
-            "integrity": "sha512-K6xNsTUPEUdfrn0+kbMq5nOUB5w1C5pavPQngt4TM2FpN91lP0PBe2srSpamb4d69O7h86oAi/qWX/kZNRSjkw==",
+            "version": "11.23.0",
+            "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-freebsd-x64/-/binding-freebsd-x64-11.23.0.tgz",
+            "integrity": "sha512-aaZ/cSEYFkSxgS2hOrobT6RQcsWNviOX8dW6CEkVx2/UYkAf9MeHbjl3W0usWV53rVV//ndBdn2nb1y7jsu4lw==",
             "cpu": [
                 "x64"
             ],
@@ -3037,9 +3247,9 @@
             ]
         },
         "node_modules/@oxc-resolver/binding-linux-arm-gnueabihf": {
-            "version": "11.21.3",
-            "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-11.21.3.tgz",
-            "integrity": "sha512-VcFmOpcpWX1zoEy8M58tR2M9YxM+Z9RuQhqAx5q0CTmrruaP7Gveejg75hzd/5sg5nk9G3aLALEa3hE2FsmmTQ==",
+            "version": "11.23.0",
+            "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-11.23.0.tgz",
+            "integrity": "sha512-IoJLvO5SjLSVMaq83BNTrPCb1FppvoJc1IhZ5CoUVl3PykUBku7D+LK1j0GSurhJcIc6zfjghsvaZNpq5ev6Mg==",
             "cpu": [
                 "arm"
             ],
@@ -3050,9 +3260,9 @@
             ]
         },
         "node_modules/@oxc-resolver/binding-linux-arm-musleabihf": {
-            "version": "11.21.3",
-            "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-11.21.3.tgz",
-            "integrity": "sha512-quVoxFLBy43hWaQbbDtQNRwAX5vX76mv7n64icAtQcJ3eNgVeblqmkupF/hAneNthdqSlnd1sTjb3aQSaDPaCQ==",
+            "version": "11.23.0",
+            "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-11.23.0.tgz",
+            "integrity": "sha512-vskFpwg44T/LFsfjSCnVZ5ygcuqzPC1yUzVEiKa8BgHAQz0+QLQQW3EGWLPVi8EXFghzjR4EtgPBtOhCjU4jdw==",
             "cpu": [
                 "arm"
             ],
@@ -3063,9 +3273,9 @@
             ]
         },
         "node_modules/@oxc-resolver/binding-linux-arm64-gnu": {
-            "version": "11.21.3",
-            "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-11.21.3.tgz",
-            "integrity": "sha512-X0AqNZgcD07Q4V3RDK18/vYOj/HQT/FnmEFGYS2jTWqY7JO13ryE3TEs3eAIgUJhBnNkpEaiXqz3VK8M7qQhWQ==",
+            "version": "11.23.0",
+            "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-11.23.0.tgz",
+            "integrity": "sha512-//TcHVhrChyw5RYtgts6WO7KcWq9387c1Z5Zvhqpk/ktAbyaRYgBZrpSY1GDCFq50ASt6B6jhh+JxB1rB45IAg==",
             "cpu": [
                 "arm64"
             ],
@@ -3076,9 +3286,9 @@
             ]
         },
         "node_modules/@oxc-resolver/binding-linux-arm64-musl": {
-            "version": "11.21.3",
-            "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-arm64-musl/-/binding-linux-arm64-musl-11.21.3.tgz",
-            "integrity": "sha512-YkaQnaKYdbuaXvRt5Qd0GpbihzVnyfR6z1SpYfIUC6RTu4NF7lDKPjVkYb+jRI2gedVO2rVpN35Y6akG6ud4Lw==",
+            "version": "11.23.0",
+            "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-arm64-musl/-/binding-linux-arm64-musl-11.23.0.tgz",
+            "integrity": "sha512-ZFqlwiTf7CXLLSGyAR9tYiO33LiaeIEXW+xm42d8mnUGpDgPltyrCGYtQezyMMEXvjhOgCz1X+i7sbDTJEx+bg==",
             "cpu": [
                 "arm64"
             ],
@@ -3089,9 +3299,9 @@
             ]
         },
         "node_modules/@oxc-resolver/binding-linux-ppc64-gnu": {
-            "version": "11.21.3",
-            "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-11.21.3.tgz",
-            "integrity": "sha512-gB9HwhrPiFqUzDeEq+y/CgAijz1YdI6BnXz5GaH2Pa9cWdutchlkGFAiAuGb/PjVQpiK6NFKzFuztxrweoit7A==",
+            "version": "11.23.0",
+            "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-11.23.0.tgz",
+            "integrity": "sha512-oZ5LeN5+H1R19dRjTAxKrxQguH+AsemHcnthEfFxf4OjmBSty2doHLeSmMunKy3zpTHJQ3lh3Af+dNS+W6dYeA==",
             "cpu": [
                 "ppc64"
             ],
@@ -3102,9 +3312,9 @@
             ]
         },
         "node_modules/@oxc-resolver/binding-linux-riscv64-gnu": {
-            "version": "11.21.3",
-            "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-11.21.3.tgz",
-            "integrity": "sha512-zjDWBlYk8QGv0H8dsPUWqkfjYIIjG2TvspGkzXL0eImbgxtZorA/klKeHyolevoT3Kvbi+1iMr9Lhrh7jf54Og==",
+            "version": "11.23.0",
+            "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-11.23.0.tgz",
+            "integrity": "sha512-O4ciFDyX5ebQd0qkb1bjAIg8IEfiLT03GbSeylwlwlUMK9KwBWaALwrxSbc0Msaz4U6iPj+T9eRXpD5mxBfmvA==",
             "cpu": [
                 "riscv64"
             ],
@@ -3115,9 +3325,9 @@
             ]
         },
         "node_modules/@oxc-resolver/binding-linux-riscv64-musl": {
-            "version": "11.21.3",
-            "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-11.21.3.tgz",
-            "integrity": "sha512-4UfsQvacV388y1zpXL7C1x1FNYaV52JtuNRiuzrfQA2z1z6ElVrsidkGsrvQ5EgeSq1Pj7kaKqrgGkvFuxJ/tw==",
+            "version": "11.23.0",
+            "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-11.23.0.tgz",
+            "integrity": "sha512-P3o8Y9kISYjcxadmbO+94ThRwLhwGuDAbA7dcdd4+YLpfeF+mmobz8fXf4NmSdfSqjyRSkceJDBRZha9NVYkiQ==",
             "cpu": [
                 "riscv64"
             ],
@@ -3128,9 +3338,9 @@
             ]
         },
         "node_modules/@oxc-resolver/binding-linux-s390x-gnu": {
-            "version": "11.21.3",
-            "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-11.21.3.tgz",
-            "integrity": "sha512-b5uH+HKH0MP5mNBYaK75SKsJbw52URqrx2LavYdq6wb0l3ExAG5niYRP9DWUNHdKilpaBVM2bXk9HNWrH3ew7Q==",
+            "version": "11.23.0",
+            "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-11.23.0.tgz",
+            "integrity": "sha512-oj03m1E3RmTFczKhcKJDzHaEDKJnPIsDcQFVxBJsSdXGSuIPdt5TvcM332FfMQgzI6yDJqyl4InrnFfXrmUTKQ==",
             "cpu": [
                 "s390x"
             ],
@@ -3141,9 +3351,9 @@
             ]
         },
         "node_modules/@oxc-resolver/binding-linux-x64-gnu": {
-            "version": "11.21.3",
-            "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-x64-gnu/-/binding-linux-x64-gnu-11.21.3.tgz",
-            "integrity": "sha512-PjYlmilBpNRh2ntXNYAK3Am5w/nPfEpnU/96iNx7CI8EzAn12J4JRiec63wHJTH31nLoCNxBg/829pN+3CfG3Q==",
+            "version": "11.23.0",
+            "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-x64-gnu/-/binding-linux-x64-gnu-11.23.0.tgz",
+            "integrity": "sha512-BqJxbSC8FdP7mSuSpRePTGHm0hXWV+dfz//f7SjsteZncLaBgWTBmi/OZNv7sX6CyG/Pt/eJkPorP+DkMOhMwQ==",
             "cpu": [
                 "x64"
             ],
@@ -3154,9 +3364,9 @@
             ]
         },
         "node_modules/@oxc-resolver/binding-linux-x64-musl": {
-            "version": "11.21.3",
-            "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-x64-musl/-/binding-linux-x64-musl-11.21.3.tgz",
-            "integrity": "sha512-QTBAb7JuHlZ7JUEyM8UiQi2f7m/L4swBhP2TNpYIDc9Wp/wRw1G/8sl6i13aIzQAXH7LKIm294LeOHd0lQR8zA==",
+            "version": "11.23.0",
+            "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-x64-musl/-/binding-linux-x64-musl-11.23.0.tgz",
+            "integrity": "sha512-utmw+VmUrW4K8LI5/6jhg4aGYKJHOIjQ9syYOOA6pF3w7haKu4r4enTe2U0C04/HbUvkq/Zif43xFsKW1Pnq9w==",
             "cpu": [
                 "x64"
             ],
@@ -3167,9 +3377,9 @@
             ]
         },
         "node_modules/@oxc-resolver/binding-openharmony-arm64": {
-            "version": "11.21.3",
-            "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-openharmony-arm64/-/binding-openharmony-arm64-11.21.3.tgz",
-            "integrity": "sha512-4j1DFwjwv36ec9kds0jU/ucQ5Ha4ERO/H95BxR5JFf0kqUUAJ1kwII7XhTc1vZrkdJkvLGC9Q2MbpObpum8RBg==",
+            "version": "11.23.0",
+            "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-openharmony-arm64/-/binding-openharmony-arm64-11.23.0.tgz",
+            "integrity": "sha512-V6lbRrthHa4TbvsLjPtg+EkXT1tRY+s4I8rYLXUfiHlZzGx3sLv1EH9CEOOevjvUYHLsbe/gqCIc73XnQfPb9A==",
             "cpu": [
                 "arm64"
             ],
@@ -3180,48 +3390,27 @@
             ]
         },
         "node_modules/@oxc-resolver/binding-wasm32-wasi": {
-            "version": "11.21.3",
-            "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-wasm32-wasi/-/binding-wasm32-wasi-11.21.3.tgz",
-            "integrity": "sha512-i8oluoel5kru/j1WNrjmQSiA3GQ7wvIYVR1IwIoZtKogAhya2iub+ZKIeSIkcJOrnzQ18Tzl/F+kL3fYOxZLvA==",
+            "version": "11.23.0",
+            "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-wasm32-wasi/-/binding-wasm32-wasi-11.23.0.tgz",
+            "integrity": "sha512-gRoOxQPdnAmIAjxcuQNBxfihvx+wjTaQM/9/eP12xwnGNawOG/+Zz9RHN4WNSxT45b5CrscK4NB8aPh+oZQXAQ==",
             "cpu": [
                 "wasm32"
             ],
             "license": "MIT",
             "optional": true,
             "dependencies": {
-                "@emnapi/core": "1.11.0",
-                "@emnapi/runtime": "1.11.0",
-                "@napi-rs/wasm-runtime": "^1.1.5"
+                "@emnapi/core": "1.11.1",
+                "@emnapi/runtime": "1.11.1",
+                "@napi-rs/wasm-runtime": "^1.1.6"
             },
             "engines": {
                 "node": ">=14.0.0"
             }
         },
-        "node_modules/@oxc-resolver/binding-wasm32-wasi/node_modules/@emnapi/core": {
-            "version": "1.11.0",
-            "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.0.tgz",
-            "integrity": "sha512-l9Oo58x0HOP5znGzVhYW9U3e5wVuA4LAZU2AGezTmkhO1CgQRFDhDg4nneHsu/t3WniXg9QrG2nIXL/ZS8ln8Q==",
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "@emnapi/wasi-threads": "1.2.2",
-                "tslib": "^2.4.0"
-            }
-        },
-        "node_modules/@oxc-resolver/binding-wasm32-wasi/node_modules/@emnapi/runtime": {
-            "version": "1.11.0",
-            "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.0.tgz",
-            "integrity": "sha512-55coeOFKHv1ywEcUXJtWU5f+Jr/W5tZDvZig8DLKSwUN1JpROQ4rk/SNOQiFWmaR/VKF4zuFyW1B8JduOSv6Pg==",
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "tslib": "^2.4.0"
-            }
-        },
         "node_modules/@oxc-resolver/binding-win32-arm64-msvc": {
-            "version": "11.21.3",
-            "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-11.21.3.tgz",
-            "integrity": "sha512-M/8dw8dD6aOs+NlPJax401CZB9I7Aut84isQLgALGGwke4Afvw+/7yYhZb94yXf6t2sPLhQLmSmtSV+2FhsOWg==",
+            "version": "11.23.0",
+            "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-11.23.0.tgz",
+            "integrity": "sha512-CgTGMYsJVe1eUiCdJTpGw21svXw79ITsemN1h0hcNkiswasDbN5MoibSLY+gRMWP5syfEz5iffrjZnwEP8xeUA==",
             "cpu": [
                 "arm64"
             ],
@@ -3232,9 +3421,9 @@
             ]
         },
         "node_modules/@oxc-resolver/binding-win32-x64-msvc": {
-            "version": "11.21.3",
-            "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-win32-x64-msvc/-/binding-win32-x64-msvc-11.21.3.tgz",
-            "integrity": "sha512-H7BCt/VnS9hnmMp42eGhZ99izSCRvlnWwy/N71K1/J8QoExwY4262Z8QiEkMDtduRJrztayDxETTckmUuAVL9Q==",
+            "version": "11.23.0",
+            "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-win32-x64-msvc/-/binding-win32-x64-msvc-11.23.0.tgz",
+            "integrity": "sha512-gUGJpr+Rn6zMxm5juApV0K3U845i8t47o8k+rbO0BHbi4PoJIfSPeQmrE2dgohQm2g5k6iviNFyXCGqvmaYUpw==",
             "cpu": [
                 "x64"
             ],
@@ -3245,9 +3434,9 @@
             ]
         },
         "node_modules/@oxlint/binding-android-arm-eabi": {
-            "version": "1.71.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-android-arm-eabi/-/binding-android-arm-eabi-1.71.0.tgz",
-            "integrity": "sha512-ImGmd1njEg4FEJH03jhRnveEegtO3czCtfptvaHivKAZQIYATbVFBrrzbaYMYv0oJioTnxZAZVSyV+oL7W8S2g==",
+            "version": "1.73.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-android-arm-eabi/-/binding-android-arm-eabi-1.73.0.tgz",
+            "integrity": "sha512-HZQRN/UMBu+Ut+/9MiAChkbP4qZqrNOWBcNI45vOT40GVhbGR0JgHB87L48D4iAqFQIdVmeQYtV9RF89AjTKkg==",
             "cpu": [
                 "arm"
             ],
@@ -3261,9 +3450,9 @@
             }
         },
         "node_modules/@oxlint/binding-android-arm64": {
-            "version": "1.71.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-android-arm64/-/binding-android-arm64-1.71.0.tgz",
-            "integrity": "sha512-4A5BEexBrwY1YFF8Kiq/lp/wQPRG79G3BWIE1FuWaM5MvmpYSd+7ZySVcKkHdwo0UDzdQGddp6pD9mpctMqLnw==",
+            "version": "1.73.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-android-arm64/-/binding-android-arm64-1.73.0.tgz",
+            "integrity": "sha512-Gp+KJRylv2aW7thRpG5p1KTxZq4ZJFbWowrKzufNq9d3ssl3r3JviYV45/+p+7CN1Nv0zDd1e8Ex0b/HUDq4TQ==",
             "cpu": [
                 "arm64"
             ],
@@ -3277,9 +3466,9 @@
             }
         },
         "node_modules/@oxlint/binding-darwin-arm64": {
-            "version": "1.71.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-darwin-arm64/-/binding-darwin-arm64-1.71.0.tgz",
-            "integrity": "sha512-9wJA9GJulLwS2usU3CEisI/ESDO1n1z9eyTCvApMDrAkbJ1ve0mORgTMjcWWsKxkzkeZ2N/Gpra5IQE7x8tYgQ==",
+            "version": "1.73.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-darwin-arm64/-/binding-darwin-arm64-1.73.0.tgz",
+            "integrity": "sha512-3de96NdtXhxERMjIz7wsp2HYMY6pMQycGxFWac2mFecAx6VeARF/IqFb1QIaqiCRIdfzBwzTed+pCTCoiS+CYA==",
             "cpu": [
                 "arm64"
             ],
@@ -3293,9 +3482,9 @@
             }
         },
         "node_modules/@oxlint/binding-darwin-x64": {
-            "version": "1.71.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-darwin-x64/-/binding-darwin-x64-1.71.0.tgz",
-            "integrity": "sha512-PlLCjS06V0PeJMAJwzjrExw1sYNW9Gch3JtNlcwwZDXGlTYDuwHNN89zYH8LTXFfgkVtsYvs2nv0FqrzyuFDzg==",
+            "version": "1.73.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-darwin-x64/-/binding-darwin-x64-1.73.0.tgz",
+            "integrity": "sha512-5zx/uPW32TiaOeVY1dQ/H5iOf0K1HOdFKOJhLqGl4o63+i1fpzoqqu/mKtd7OFgFjNCdhlyTGgjVkQTZm1ELcg==",
             "cpu": [
                 "x64"
             ],
@@ -3309,9 +3498,9 @@
             }
         },
         "node_modules/@oxlint/binding-freebsd-x64": {
-            "version": "1.71.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-freebsd-x64/-/binding-freebsd-x64-1.71.0.tgz",
-            "integrity": "sha512-Lhil7bWre0ncxbUoDoxfS0JzpTz17BRQKW7iwoAUY8GJ66+WwJEfYPCFJ1P0WgVZR5/O/b3Q2pENlHOjeXLOGQ==",
+            "version": "1.73.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-freebsd-x64/-/binding-freebsd-x64-1.73.0.tgz",
+            "integrity": "sha512-qNe4gKHaGnLuZJ8toUg90JAa0S2vTVvDw+0bRi3q1avXZXDT4u5mMeECf3nD4HYrbdn1O7dXqWut4onY/yx/Xg==",
             "cpu": [
                 "x64"
             ],
@@ -3325,9 +3514,9 @@
             }
         },
         "node_modules/@oxlint/binding-linux-arm-gnueabihf": {
-            "version": "1.71.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.71.0.tgz",
-            "integrity": "sha512-Oo9/L58PYD3RC0x05d2upAPLllHytTjHQGsnC06P6Ynn7jKkp5mdImQxXdJ3+FnBaKspNpGogzgVsi6g872LiA==",
+            "version": "1.73.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.73.0.tgz",
+            "integrity": "sha512-cCehYh5hTbfShm/fxTD6wwrGUWIpvX+N5OxmAMhFhDeTGXvw+BeNj889tpxsFQ9ZLatQ6wImuY8tsKLZ+FMz7w==",
             "cpu": [
                 "arm"
             ],
@@ -3341,9 +3530,9 @@
             }
         },
         "node_modules/@oxlint/binding-linux-arm-musleabihf": {
-            "version": "1.71.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-1.71.0.tgz",
-            "integrity": "sha512-mSHfyfgJrEbyIR29ejaeS50BdPk+GoNPlC1dckpDiUZbJAIel68sjSMdOt4WY0/gva+ECC7FNITQkxMJU+vSBw==",
+            "version": "1.73.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-1.73.0.tgz",
+            "integrity": "sha512-d5j5GDU/2dMgjVhw7TQT9ITrsIr1Y02KEXKyVGIXUkD+KiaxE9TP65FS2ZdgTBemQvoRL+gSBdbrIm3cQIeacg==",
             "cpu": [
                 "arm"
             ],
@@ -3357,9 +3546,9 @@
             }
         },
         "node_modules/@oxlint/binding-linux-arm64-gnu": {
-            "version": "1.71.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.71.0.tgz",
-            "integrity": "sha512-n9yY4M2tiy3aij4AqtlnspzpfdpeT5JQfK2/w2d8oyp5W0FRwOb1dIeX99nORNcxGr08iD9bH8N5XFz3I2iy8w==",
+            "version": "1.73.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.73.0.tgz",
+            "integrity": "sha512-Eyf1SrP3+yR1DI3OJgOY2Pvrr9dWP9TK37xPaDYycwTtlGlI45erJAVIfH5/m/xosDt6BupJYEFi47bvbTuuyw==",
             "cpu": [
                 "arm64"
             ],
@@ -3373,9 +3562,9 @@
             }
         },
         "node_modules/@oxlint/binding-linux-arm64-musl": {
-            "version": "1.71.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.71.0.tgz",
-            "integrity": "sha512-fJZrs5sDZtTaPIOiemRQQmo82Ezy+vOGXemPc4Ok7iVVsYsFa7SlW6Z5XN819VfsqBHRm3NJ3rTdnR8+bJYJdQ==",
+            "version": "1.73.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.73.0.tgz",
+            "integrity": "sha512-IlT/OJApEDKaMmCooHuncgJZbbCe7T5QIWmTZBEtYscWvzPQuuEinVcid6kwQRVQOUdb7PUCz4jQHnaYXdfJXw==",
             "cpu": [
                 "arm64"
             ],
@@ -3389,9 +3578,9 @@
             }
         },
         "node_modules/@oxlint/binding-linux-ppc64-gnu": {
-            "version": "1.71.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.71.0.tgz",
-            "integrity": "sha512-cwl7VKGERIy9p+G+AvZdfy/06q0aHXaTt/mMRReC751iuNYJgqKjB7NydXSS30nBT9vtr2tunciOtrR4fD6FUA==",
+            "version": "1.73.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.73.0.tgz",
+            "integrity": "sha512-L+JYcb/vdg5fmcH08V6o0YYLU28cTH1SPNulwJdvK9NK49aXSkYy6oNpKBmddArVOXYqNepriDGiZ04G54kh1Q==",
             "cpu": [
                 "ppc64"
             ],
@@ -3405,9 +3594,9 @@
             }
         },
         "node_modules/@oxlint/binding-linux-riscv64-gnu": {
-            "version": "1.71.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-1.71.0.tgz",
-            "integrity": "sha512-eZ8ieVXvzGi8jr7+ybQGPK2STw3mldfxZlgA2738iflfB/rzA69sE6m5rDRpQaxC7dpm745Enlh1Tod0QAk9Gg==",
+            "version": "1.73.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-1.73.0.tgz",
+            "integrity": "sha512-Qtk0g3bKV6OwWjIm7R8kQN1uOZRKQt/MODK2a8QfkwhTpXBD53ozx5XLVWLGDQAVyp2otLW4D2wB98XfAfMPGA==",
             "cpu": [
                 "riscv64"
             ],
@@ -3421,9 +3610,9 @@
             }
         },
         "node_modules/@oxlint/binding-linux-riscv64-musl": {
-            "version": "1.71.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-1.71.0.tgz",
-            "integrity": "sha512-puMDbQYe6+NXwfMusojoA7CXGn2b3utukmd23PQqc1E3XhVCwyZ+FueSMzDYeNgDV2dUfIVXAAKZBcFDeCL6sA==",
+            "version": "1.73.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-1.73.0.tgz",
+            "integrity": "sha512-wX0NQKZVxltkAOVmzFcpOaMpdaUvsq1Eqpx9tkAfl71UdkTlSo1R4AdAnGccR1Fm2+TzFgZ22CyyGuZ41RDr/A==",
             "cpu": [
                 "riscv64"
             ],
@@ -3437,9 +3626,9 @@
             }
         },
         "node_modules/@oxlint/binding-linux-s390x-gnu": {
-            "version": "1.71.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.71.0.tgz",
-            "integrity": "sha512-4NJLxBs1ujISCt3L/1FcywLs73PWtJuw+piD6feK2V6h6OS6P7xu9/sWt1DTRLibe6QCzmfZzmM/2HPORoV/Lg==",
+            "version": "1.73.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.73.0.tgz",
+            "integrity": "sha512-vPe7UGBMWyiLTtnqS4xxgMQFSFGmtQwhwCxuiw6lXygaO6bVt0D8dFVg8Xv05eaiN3ybC0HXXHUAohFMFvqoCQ==",
             "cpu": [
                 "s390x"
             ],
@@ -3453,9 +3642,9 @@
             }
         },
         "node_modules/@oxlint/binding-linux-x64-gnu": {
-            "version": "1.71.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.71.0.tgz",
-            "integrity": "sha512-cFDaiR8L3430qp88tfZnvFlt3KotFhR/DlbIL0nHOMMYiG/9Wy4l+6f7t8G8pTa9bd8Lt8+M0y/qjRQ/xcB74g==",
+            "version": "1.73.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.73.0.tgz",
+            "integrity": "sha512-2CwIWr9cemFC/CbRBWZvuk5mffz6ObmfFkfcC/9rTQ7f+icNhYr2kOjf9Rt8lLvugvkdGDOmkoVoFFHh6ClCTw==",
             "cpu": [
                 "x64"
             ],
@@ -3469,9 +3658,9 @@
             }
         },
         "node_modules/@oxlint/binding-linux-x64-musl": {
-            "version": "1.71.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-x64-musl/-/binding-linux-x64-musl-1.71.0.tgz",
-            "integrity": "sha512-orfixdt76KlpNly9z0PkWBBNfwjKz+JFVLP/7wnVchlKNU9Dpt9InU/ZggeSej6fC7qwHmHNOGlhLnQXcYoGuA==",
+            "version": "1.73.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-x64-musl/-/binding-linux-x64-musl-1.73.0.tgz",
+            "integrity": "sha512-nDadfJgg7NBBxG0N560wOe7LLX5QiYp6qBaI7viuk5EUORFBktU/NfV0MbTqU3gTqQDCh4VyxKdo5VADxk9w8Q==",
             "cpu": [
                 "x64"
             ],
@@ -3485,9 +3674,9 @@
             }
         },
         "node_modules/@oxlint/binding-openharmony-arm64": {
-            "version": "1.71.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-openharmony-arm64/-/binding-openharmony-arm64-1.71.0.tgz",
-            "integrity": "sha512-9emQu2lAp6yhPB3XuI+++vR+l/o6JR1X+EpxwcumPdQXBWXEPAsquPGL7l158EqU8SebQMXTUa/S5zN98juyHw==",
+            "version": "1.73.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-openharmony-arm64/-/binding-openharmony-arm64-1.73.0.tgz",
+            "integrity": "sha512-wGjJC+NLH9xP+IKGn9RDW94ojJR/wPbg5WCnQjj/oReaOtCQthr8ws1zICe77JFmo4ouUdeTHHZL/ESGiF6Pmw==",
             "cpu": [
                 "arm64"
             ],
@@ -3501,9 +3690,9 @@
             }
         },
         "node_modules/@oxlint/binding-win32-arm64-msvc": {
-            "version": "1.71.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.71.0.tgz",
-            "integrity": "sha512-bd5kI8spYwTm3BILDtGhi73zoup5dw8MlPQNT8YB3BD5UIsjNe3K9/4ctrzQMX4SZMoK5HgzVLkLJzacEXB7fA==",
+            "version": "1.73.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.73.0.tgz",
+            "integrity": "sha512-I7X47GPGljw225YUQ5SbC/rb1Kkdrd0yQf0x+hYxeKS6DpfjMbo9ccQPQ6LNY6BoJQ1sHhgDUGuMn5Vg5gHT6w==",
             "cpu": [
                 "arm64"
             ],
@@ -3517,9 +3706,9 @@
             }
         },
         "node_modules/@oxlint/binding-win32-ia32-msvc": {
-            "version": "1.71.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-1.71.0.tgz",
-            "integrity": "sha512-W4HvOHGzVLHcrmFu+bMrJlho+/yrlX5ZNdJZqGe8MEldkQG+RHYhxxad9P4jvWAYFmIqUA5i9DQ8QsJqSU9GIw==",
+            "version": "1.73.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-1.73.0.tgz",
+            "integrity": "sha512-5lWj+3h+74Fm1jYOO9qkJA4xkAlZA099DkXppuXsk7UpnpZLttsefrZU469vChGaG6hcSqrkKXQOvMTZtbjeNg==",
             "cpu": [
                 "ia32"
             ],
@@ -3533,9 +3722,9 @@
             }
         },
         "node_modules/@oxlint/binding-win32-x64-msvc": {
-            "version": "1.71.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.71.0.tgz",
-            "integrity": "sha512-D2kyEIPHk/G/wiZLnwTVC/sVst+T/lKldVOjAFpgTIBUAOlry72e5OiapDbDBF4LfJLkN5ypJb/8Eu6yJzkveQ==",
+            "version": "1.73.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.73.0.tgz",
+            "integrity": "sha512-WaNRvh4f6zY9CvUQk2YoA1O90ieWrIklI84+HXFr9Isjz9CSESrdqo/RtIYt4Dll/cAchqGDMehfaZd0vqEFZw==",
             "cpu": [
                 "x64"
             ],
@@ -3900,18 +4089,18 @@
             }
         },
         "node_modules/@posthog/core": {
-            "version": "1.38.1",
-            "resolved": "https://registry.npmjs.org/@posthog/core/-/core-1.38.1.tgz",
-            "integrity": "sha512-tsJTugsKzx47eRMjNfG272/GFf0FF0LeI+gyJ/anibpbYAzdNuX5kr6enpmJrhdgLESqzJGH8QF0+I9075Xr1Q==",
+            "version": "1.39.6",
+            "resolved": "https://registry.npmjs.org/@posthog/core/-/core-1.39.6.tgz",
+            "integrity": "sha512-o6ajIwN5zXoNP0D4H/QPmOyibNTUkSyOR6ya7AG5U2ywXx4awo72L2KnCoiZPQM5x/bXv6jPBdimH8M18Ax0aw==",
             "license": "MIT",
             "dependencies": {
                 "@posthog/types": "^1.392.0"
             }
         },
         "node_modules/@posthog/types": {
-            "version": "1.392.0",
-            "resolved": "https://registry.npmjs.org/@posthog/types/-/types-1.392.0.tgz",
-            "integrity": "sha512-nctNujXL3FC1v99FktaTMSugSD9ZOZekEpahUSafkU2TSvW+XGKNkQZbokuJtiWvPBK208dwMJva8UfBkChqpw==",
+            "version": "1.392.1",
+            "resolved": "https://registry.npmjs.org/@posthog/types/-/types-1.392.1.tgz",
+            "integrity": "sha512-Qg6Gl7/1vlr8+gPtBi5gwnLgAgiyFoKOVmTvTtDcvya9cpTwZfna7rQmkGQ4B63CunUYNNbOlqcwiUwUDyTK6w==",
             "license": "MIT"
         },
         "node_modules/@protobufjs/aspromise": {
@@ -3966,9 +4155,9 @@
             "license": "BSD-3-Clause"
         },
         "node_modules/@protobufjs/utf8": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.1.tgz",
-            "integrity": "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==",
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.2.tgz",
+            "integrity": "sha512-b1UQwcEZ4yCnMCD8DAL1VlbvBJE9/IX4FTIp7BG1xYpf29SLazLSrqUkj4w7Y5y7cCVP6E5tcqqcI0xemPkHug==",
             "license": "BSD-3-Clause"
         },
         "node_modules/@quansync/fs": {
@@ -4002,9 +4191,9 @@
             "license": "MIT"
         },
         "node_modules/@rolldown/binding-android-arm64": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.4.tgz",
-            "integrity": "sha512-EZLpf/8y7GXkkra90ML47kzik/GMP3EMcE9bPyHmRfxLC6z9+aW5A8poCsoxjrT5GfEcNAAvWwUHjvP1pUQkfw==",
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.5.tgz",
+            "integrity": "sha512-lZg8fqIv2v7FF237bwMgzGZEJvGL79/s5knJ/i6FmsGF4XXlzccZ4jb+TrFIxtSSxFtIpdsgrPZeMk1I9AFcyQ==",
             "cpu": [
                 "arm64"
             ],
@@ -4018,9 +4207,9 @@
             }
         },
         "node_modules/@rolldown/binding-darwin-arm64": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.4.tgz",
-            "integrity": "sha512-aUi+HBvmYb7j8krl1+qJgkG8C17fO79gk3c+jPw4S8glRFc1DTija9S3EyaTSQUm5GJXYKDAsugBEhFHH2vYiQ==",
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.5.tgz",
+            "integrity": "sha512-51Bnx9pNiMRKSUNtBfySkNJ9vMU9Hh3I1ozDd6gyPPYzaXCfnptUcEZxXGYFn+ul2dtcMUiqGR1Yai2K10uoTw==",
             "cpu": [
                 "arm64"
             ],
@@ -4034,9 +4223,9 @@
             }
         },
         "node_modules/@rolldown/binding-darwin-x64": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.4.tgz",
-            "integrity": "sha512-F7hHC3gwY11+vByKPRWqwGbeXWVgKmL+pTGCinaEhdihzBV2aQ0fvZOch9cXYUOKuKKq429HeYXOqQLc7wFCEg==",
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.5.tgz",
+            "integrity": "sha512-Tm+gbfC0aHu1tBA/JvKQh32S0K6YgCHkiAF4/W6xX0K0RmNuc94VeK419dJoE65R5aRxmo+noZQSWrAMF6yb6g==",
             "cpu": [
                 "x64"
             ],
@@ -4050,9 +4239,9 @@
             }
         },
         "node_modules/@rolldown/binding-freebsd-x64": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.4.tgz",
-            "integrity": "sha512-sI5yw+7s92SK6odiEhD5lKCBlWcpjHS5qyqpVQbZAJ0fIzEUXrmbl3DH2ybR3PZogulNJF+COLtmA8hUfvkCCQ==",
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.5.tgz",
+            "integrity": "sha512-JMzDKCCXq93YccG5gz3hvOs1oXRKAf0XYpfOS88e+wZrC8Iugj6j68867vrYZkvpDDpKn/KoKORThmchMpF6TA==",
             "cpu": [
                 "x64"
             ],
@@ -4066,9 +4255,9 @@
             }
         },
         "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.4.tgz",
-            "integrity": "sha512-mCi0OKgEieFircrtVYmQAFGszRtMnZ6fpZAXrxanXAu7lqZcsK1E1RAaZNG0uKAnxox3B1f4EyQNnoyMfN1vAA==",
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.5.tgz",
+            "integrity": "sha512-uML21j2K5TfPGutKxub+M+nLjZIrWjXQ5Grx4lCe/nimTj9B4L63zHpjXLl4y0L3mcm2htEQIb06oCG/szerNw==",
             "cpu": [
                 "arm"
             ],
@@ -4082,9 +4271,9 @@
             }
         },
         "node_modules/@rolldown/binding-linux-arm64-gnu": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.4.tgz",
-            "integrity": "sha512-B9Ial3Kv5sh0SHnB1g/QWcUQCEvCF6QKGAl4zXypYj65mVI+B4AhFBwPtSN7pDrJeIx8Z7zdy4ntx+wQABom7w==",
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.5.tgz",
+            "integrity": "sha512-navSiuTMogvnQoZoM/v+l3ZWo50/NTwSHSzheABx/RCnmUPaKwq9qSo4Br2OYRs21+Fz8uFqITZM3H4opOB0/Q==",
             "cpu": [
                 "arm64"
             ],
@@ -4098,9 +4287,9 @@
             }
         },
         "node_modules/@rolldown/binding-linux-arm64-musl": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.4.tgz",
-            "integrity": "sha512-lZVym0PuHE1KZ22gmFTC15lAkrg9iTszR617oYRB/iPY1A56ywoJzVKOJBKaot5RiikCObmur6pogpse3gRcng==",
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.5.tgz",
+            "integrity": "sha512-lAryqH7IteztmCXQXk0etKj4wBQ7Gx5S6LjKhsgp9zb8I5bsuvU/2llH1hDQcjsFeqIsovMVN339/8pUDDBXxA==",
             "cpu": [
                 "arm64"
             ],
@@ -4114,9 +4303,9 @@
             }
         },
         "node_modules/@rolldown/binding-linux-ppc64-gnu": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.4.tgz",
-            "integrity": "sha512-t2DNiLJWNTbnEHyUzTumldML6ET4/g16467LZoDDJ3tSxGvguL5/NyC2lCsNKuyRycg9XeDQF5SSv+TNOhQEXg==",
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.5.tgz",
+            "integrity": "sha512-fsK/sNBnxzBlL4O1JNrZakVQxPspqpED5dLtNsZS9oOKmtSpdNIzxH2kkol5HYTWJN47sE20ztMJPxfZ89qGOg==",
             "cpu": [
                 "ppc64"
             ],
@@ -4130,9 +4319,9 @@
             }
         },
         "node_modules/@rolldown/binding-linux-s390x-gnu": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.4.tgz",
-            "integrity": "sha512-0WIRnL1Uw4BvTZRLQt+PVgo6ZKTJadlC2btP+/EOXv2f/DWbY0rEgl+y834mIVwP1FkTlWVTrGGJXf12lru7EQ==",
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.5.tgz",
+            "integrity": "sha512-gLYb4BIadlfTOYT5gO503n8zQjXflgzpD0FcyKh0Mzx3rqCZKnHoJWV9xe1KXUJ5lx2JfcSHr/mhzS0PC/McAA==",
             "cpu": [
                 "s390x"
             ],
@@ -4146,9 +4335,9 @@
             }
         },
         "node_modules/@rolldown/binding-linux-x64-gnu": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.4.tgz",
-            "integrity": "sha512-JWtGshGfX+oENAKonoNkqEJX+7hC8yfhi9GUyPX1VX4mdh1y5r+ZiJLR5XzAB0aoP6s/PcILsGjKq8O0mm24bw==",
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.5.tgz",
+            "integrity": "sha512-FjcpEKUyJygHgs1o50VYNvkt5+7Le/VEdYt0AkRpkL33MnyQfwr8l5mXwMmfmTbyMPr5vJLC+8/Gd9gXnwU1QQ==",
             "cpu": [
                 "x64"
             ],
@@ -4162,9 +4351,9 @@
             }
         },
         "node_modules/@rolldown/binding-linux-x64-musl": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.4.tgz",
-            "integrity": "sha512-rT6yQcxUuXs4CnbofqwHRRV0iem349rLMYpTjkgQGLjrY4ado/eDzwPZPTCgTOlF6Nkp8NEv70yLMTn6qkWxsQ==",
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.5.tgz",
+            "integrity": "sha512-Me+PfPI2TMeOQk0gYWfLQZtTktrmzbr8cDboqX83XKc7UrgAi55gF+2dUkWdxd19n55Essp2yeca+O9N5rBxHg==",
             "cpu": [
                 "x64"
             ],
@@ -4178,9 +4367,9 @@
             }
         },
         "node_modules/@rolldown/binding-openharmony-arm64": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.4.tgz",
-            "integrity": "sha512-KXMGoboq5cyaCQjDA4GLuRiOwBQ0EyFnJoVViLeZ45/3rFItRODEr+NdsBcVpll40hhNArlm/speWGRvj08LzA==",
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.5.tgz",
+            "integrity": "sha512-yc5WrLzXks6zCQfn9Oxr8pORKyl/pF+QjHmW/Qx3qu0oyrrNC+y2JLTU1E2rcWYAmzlnqngWXHQjy51VzW70Vw==",
             "cpu": [
                 "arm64"
             ],
@@ -4194,9 +4383,9 @@
             }
         },
         "node_modules/@rolldown/binding-wasm32-wasi": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.4.tgz",
-            "integrity": "sha512-5K83rb36oJiY7BCyE9zLZtGcPV4g5wvq+xwdO0XPIwDVZI8cyB/AUjkNXGb92/rnmezEkjMOpgY61rtwjQtFwg==",
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.5.tgz",
+            "integrity": "sha512-VbQGPX2b4r48TAMIM2cjgluIM1HYutm4pcTEJsle7iEP7sB1dFqtPLBVbdLAZCxy1txCcPxf4QFf4v8uvltPqA==",
             "cpu": [
                 "wasm32"
             ],
@@ -4212,9 +4401,9 @@
             }
         },
         "node_modules/@rolldown/binding-win32-arm64-msvc": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.4.tgz",
-            "integrity": "sha512-PnWBtw3TV5KOg69HQQDR0mnQuyCmSGR2pAB4DC1rPF808fgKeTUMj2EOEyKATpgiuxuR5APQmiDO7PDgEjTFSA==",
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.5.tgz",
+            "integrity": "sha512-gHv82k63z4qpV5+Q1y/12KrK0ltWBukVDI8nZcbT7Tt/ZlOIVwppazneq0F93oDxTo3IgAMEDIoQh3E2n6mVsw==",
             "cpu": [
                 "arm64"
             ],
@@ -4228,9 +4417,9 @@
             }
         },
         "node_modules/@rolldown/binding-win32-x64-msvc": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.4.tgz",
-            "integrity": "sha512-M1lpniBePobTfsa7Ks9a199e1akxsXn+GYBUKsEzv3YFzOm1HJAMNwKI3qr0Zq+mxwx9gOZoTdP1yXRYsZUocQ==",
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.5.tgz",
+            "integrity": "sha512-tTZuDBPw85tEN5PQi1pnEBzDy0Z49HtScLAbD5t6hyeU92A95pRWaSMw1GZZi/RwgSgUIl0xrSlXIT/9QzvYSA==",
             "cpu": [
                 "x64"
             ],
@@ -4593,13 +4782,13 @@
             "license": "Apache-2.0"
         },
         "node_modules/@shikijs/core": {
-            "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-4.3.0.tgz",
-            "integrity": "sha512-EooU3i9F6IAE8kEu+AnGf9DFZWkQBZ+hJn3tLVbsH+61mtQiva5biai66fAA6nvFPXkLgvrh7BrR7YcJU83xQQ==",
+            "version": "4.3.1",
+            "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-4.3.1.tgz",
+            "integrity": "sha512-ANMDxuaPsNMdDC1m4vfvhlDmJweMwkE5XitTwrq2rWHx5jM+dlm4MmHt2PP6t0uejfR77SuhrhJ0zEijIF/uhA==",
             "license": "MIT",
             "dependencies": {
-                "@shikijs/primitive": "4.3.0",
-                "@shikijs/types": "4.3.0",
+                "@shikijs/primitive": "4.3.1",
+                "@shikijs/types": "4.3.1",
                 "@shikijs/vscode-textmate": "^10.0.2",
                 "@types/hast": "^3.0.4",
                 "hast-util-to-html": "^9.0.5"
@@ -4609,12 +4798,12 @@
             }
         },
         "node_modules/@shikijs/engine-javascript": {
-            "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-4.3.0.tgz",
-            "integrity": "sha512-hTv/KiFf2tpiqlACPiztGGurEARWIutB8YUhcrA1pUC7VzzwKO+g5crUocrLztrZ5ro5Z4hbXg7bYclETn3gSQ==",
+            "version": "4.3.1",
+            "resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-4.3.1.tgz",
+            "integrity": "sha512-JBItcnPuYq7jVJdZo/vMj94r+szT7XEjHFX+mvFDGSEIbVAXAGyHAHzhbWzpGOwYidCZrErJLLgn2PVeiokHnQ==",
             "license": "MIT",
             "dependencies": {
-                "@shikijs/types": "4.3.0",
+                "@shikijs/types": "4.3.1",
                 "@shikijs/vscode-textmate": "^10.0.2",
                 "oniguruma-to-es": "^4.3.6"
             },
@@ -4623,12 +4812,12 @@
             }
         },
         "node_modules/@shikijs/engine-oniguruma": {
-            "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-4.3.0.tgz",
-            "integrity": "sha512-1vMdN3gHfnKfLYwecUI2ITJI4RhHt96xEaJumVn7Heb0IlJ8WQMIH0Voak+2j22BpSNKdnOfB/pCTPnPm2gq7A==",
+            "version": "4.3.1",
+            "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-4.3.1.tgz",
+            "integrity": "sha512-OXyNMzg0pews+msMj4cHeqT4xiYKKvbnn6VbdAXxfoFl3SSx4fJTc8FadECuc5/H9p3BzhNAoAUXKwAu9rWYhg==",
             "license": "MIT",
             "dependencies": {
-                "@shikijs/types": "4.3.0",
+                "@shikijs/types": "4.3.1",
                 "@shikijs/vscode-textmate": "^10.0.2"
             },
             "engines": {
@@ -4636,24 +4825,24 @@
             }
         },
         "node_modules/@shikijs/langs": {
-            "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-4.3.0.tgz",
-            "integrity": "sha512-rnlqFbBRSys9bT4gl/5rw9RnS0W/I84ZldXPkO7cvlEMoV85TyF/aU01N7/NbSR776RNLjrJKjfFUXJR6wN1Cg==",
+            "version": "4.3.1",
+            "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-4.3.1.tgz",
+            "integrity": "sha512-m0l9nsDqgBHvbZbk7A0/kXz/impK3uB/c6rAn6Gpg/uPtdZRQ+alsN/17MU5thb68XTj/4DxkZAotrM0GGSpDQ==",
             "license": "MIT",
             "dependencies": {
-                "@shikijs/types": "4.3.0"
+                "@shikijs/types": "4.3.1"
             },
             "engines": {
                 "node": ">=20"
             }
         },
         "node_modules/@shikijs/primitive": {
-            "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/@shikijs/primitive/-/primitive-4.3.0.tgz",
-            "integrity": "sha512-CPkz64PTa5diRW1ggzMZH9VM/du4RNChYgVtgqrFcgruvIybmCvySv8GkiHSczUHXYuuR8TdKEwFx+UnZMpgdg==",
+            "version": "4.3.1",
+            "resolved": "https://registry.npmjs.org/@shikijs/primitive/-/primitive-4.3.1.tgz",
+            "integrity": "sha512-CXQRQOYy1leqQ8ceTeJdmXv/bsUY++6QyLpXJ94LZAAYj5X2SKRdc5ipguv4NPyGVKItB2PPwUpRNe0Sjh5S1A==",
             "license": "MIT",
             "dependencies": {
-                "@shikijs/types": "4.3.0",
+                "@shikijs/types": "4.3.1",
                 "@shikijs/vscode-textmate": "^10.0.2",
                 "@types/hast": "^3.0.4"
             },
@@ -4662,21 +4851,21 @@
             }
         },
         "node_modules/@shikijs/themes": {
-            "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-4.3.0.tgz",
-            "integrity": "sha512-Avgt05YiT+Y3prjIc9lmQxhJzHBcCfR6cjiFW4OyaMBbt2A6trX5rfjUzx+Vj/mE9qpArYjatnqo9XPjQNW/AQ==",
+            "version": "4.3.1",
+            "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-4.3.1.tgz",
+            "integrity": "sha512-dgpoJ4WqNi2yTmizQHBJ5zcX6j2lE6icN/0yt4l1kkf16jrY/pwPLoTb1ETsWMz0OBLf9ZNvwmxft+cH+N9qSA==",
             "license": "MIT",
             "dependencies": {
-                "@shikijs/types": "4.3.0"
+                "@shikijs/types": "4.3.1"
             },
             "engines": {
                 "node": ">=20"
             }
         },
         "node_modules/@shikijs/types": {
-            "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-4.3.0.tgz",
-            "integrity": "sha512-oc8b9U2SYvofKZk8e/737nIX0qwf6eV2vHFATeObAu7r+mUVpLs8Re0BmVkIjAWAYgkmG/CzLNo7rzuBzRu/wQ==",
+            "version": "4.3.1",
+            "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-4.3.1.tgz",
+            "integrity": "sha512-CHFxE0jztBIZRHH6gxXE7DXUCFXjReEGxZ/j0rfSLGKZuwp2xBYycEP14875DSa9KLL/6700oxIq6oO6ef9K2g==",
             "license": "MIT",
             "dependencies": {
                 "@shikijs/vscode-textmate": "^10.0.2",
@@ -4697,6 +4886,53 @@
             "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
             "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
             "license": "MIT"
+        },
+        "node_modules/@storybook/addon-a11y": {
+            "version": "10.4.6",
+            "resolved": "https://registry.npmjs.org/@storybook/addon-a11y/-/addon-a11y-10.4.6.tgz",
+            "integrity": "sha512-XCJy+f0DFOiCgUU9knRDlLDxVFI+AAQ3/wE/NF85zB9iDPPS2DwkSN+mas3zDgHt66zhN8Cq3/UiyCDUweV9Zw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@storybook/global": "^5.0.0",
+                "axe-core": "^4.2.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/storybook"
+            },
+            "peerDependencies": {
+                "storybook": "^10.4.6"
+            }
+        },
+        "node_modules/@storybook/addon-docs": {
+            "version": "10.4.6",
+            "resolved": "https://registry.npmjs.org/@storybook/addon-docs/-/addon-docs-10.4.6.tgz",
+            "integrity": "sha512-aWAfP5JMiT5a3zBJizwroCRzOCqZwDTJmvsYvwMD3ilIEa/kT1vhf6Xrbk4XIPhDwbh8Hpb/Gfnka1xBYEISWg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@mdx-js/react": "^3.0.0",
+                "@storybook/csf-plugin": "10.4.6",
+                "@storybook/icons": "^2.0.2",
+                "@storybook/react-dom-shim": "10.4.6",
+                "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+                "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+                "ts-dedent": "^2.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/storybook"
+            },
+            "peerDependencies": {
+                "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+                "storybook": "^10.4.6"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                }
+            }
         },
         "node_modules/@storybook/addon-themes": {
             "version": "10.4.6",
@@ -4831,6 +5067,32 @@
                 "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
             }
         },
+        "node_modules/@storybook/react-dom-shim": {
+            "version": "10.4.6",
+            "resolved": "https://registry.npmjs.org/@storybook/react-dom-shim/-/react-dom-shim-10.4.6.tgz",
+            "integrity": "sha512-iGNmKzrq9vgl2PDrYAnZKI+yvac3Ym+lJXXuQaqlFRS23zA5MNm4EBX+rAG7WulqchoK6NaZ0KQOs2mAgEpTMg==",
+            "dev": true,
+            "license": "MIT",
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/storybook"
+            },
+            "peerDependencies": {
+                "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+                "@types/react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+                "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+                "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+                "storybook": "^10.4.6"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                },
+                "@types/react-dom": {
+                    "optional": true
+                }
+            }
+        },
         "node_modules/@storybook/vue3": {
             "version": "10.4.6",
             "resolved": "https://registry.npmjs.org/@storybook/vue3/-/vue3-10.4.6.tgz",
@@ -4870,6 +5132,19 @@
             "peerDependencies": {
                 "storybook": "^10.4.6",
                 "vite": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
+            }
+        },
+        "node_modules/@storybook/vue3-vite/node_modules/typescript": {
+            "version": "5.9.3",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+            "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+            "license": "Apache-2.0",
+            "bin": {
+                "tsc": "bin/tsc",
+                "tsserver": "bin/tsserver"
+            },
+            "engines": {
+                "node": ">=14.17"
             }
         },
         "node_modules/@swagger-api/apidom-ast": {
@@ -5900,9 +6175,9 @@
             "license": "MIT"
         },
         "node_modules/@types/d3-random": {
-            "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/@types/d3-random/-/d3-random-3.0.3.tgz",
-            "integrity": "sha512-Imagg1vJ3y76Y2ea0871wpabqp613+8/r0mCLEBfdtqC7xMSfj9idOnmBYyMoULfHePJyxMAw3nWhJxzc+LFwQ==",
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/@types/d3-random/-/d3-random-3.0.4.tgz",
+            "integrity": "sha512-UHYId5WTCx4L4YNel7NU00XUXXgvgpgZOvp10PuvsQENjMDXhh2RyFc0KBjO7B45ne4Ha1yVH7ii0vnzKkuzWA==",
             "license": "MIT"
         },
         "node_modules/@types/d3-scale": {
@@ -6087,9 +6362,9 @@
             "license": "MIT"
         },
         "node_modules/@types/node": {
-            "version": "25.9.4",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.4.tgz",
-            "integrity": "sha512-dszCsrKb5U7ZsVZBWiHFklTloVl0mSEnWH/iZXfZUlI4rzCUnsvGmgqfuVRHL54ugE7/wRuxEIXRa2iMZ+BG6g==",
+            "version": "25.9.5",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.5.tgz",
+            "integrity": "sha512-OScDchr2fwuUmWdf4kZ9h7PcJiYDVInhJizG/biAq3cAvqwYktuy/TYGGdZNMtNTFUP7rnb0NU4TUdm82kt4Rg==",
             "license": "MIT",
             "dependencies": {
                 "undici-types": ">=7.24.0 <7.24.7"
@@ -6175,15 +6450,15 @@
             }
         },
         "node_modules/@typescript-eslint/parser": {
-            "version": "8.62.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.62.0.tgz",
-            "integrity": "sha512-dzHeT2gySzZtLDsuqxU9AkYgIsQoHAHtRBpOqM+Ofzx1Bwrd2RcCjQJ+6iQbsHOIR6NS33bF2W1k3blN1zLDrA==",
+            "version": "8.63.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.63.0.tgz",
+            "integrity": "sha512-gwh4gvvlaVDKKxyfxMG+Gnu1u9X0OQBwyGLkbwB65dIzBKnxeRiJlNFqlI3zwVhNXJIs6qV7mlFCn/BIajlVig==",
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/scope-manager": "8.62.0",
-                "@typescript-eslint/types": "8.62.0",
-                "@typescript-eslint/typescript-estree": "8.62.0",
-                "@typescript-eslint/visitor-keys": "8.62.0",
+                "@typescript-eslint/scope-manager": "8.63.0",
+                "@typescript-eslint/types": "8.63.0",
+                "@typescript-eslint/typescript-estree": "8.63.0",
+                "@typescript-eslint/visitor-keys": "8.63.0",
                 "debug": "^4.4.3"
             },
             "engines": {
@@ -6199,13 +6474,13 @@
             }
         },
         "node_modules/@typescript-eslint/project-service": {
-            "version": "8.62.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.62.0.tgz",
-            "integrity": "sha512-wexnCqiTg7BOGtbLDftYpRWlmLq4xfoMd7BKFR6Y75sZS3QmRKLdN3yWLhmIYgqMmP/OXWpj3H8odkb5nGURCQ==",
+            "version": "8.63.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.63.0.tgz",
+            "integrity": "sha512-e5dh0/UI0ok53AlZ5wRkXCB32z/f2jUZqPR/ygAw5WYaSw8j9EoJWlS7wQjr/dmOaqWjnPIn2m+HhVPCMWGZVQ==",
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/tsconfig-utils": "^8.62.0",
-                "@typescript-eslint/types": "^8.62.0",
+                "@typescript-eslint/tsconfig-utils": "^8.63.0",
+                "@typescript-eslint/types": "^8.63.0",
                 "debug": "^4.4.3"
             },
             "engines": {
@@ -6220,13 +6495,13 @@
             }
         },
         "node_modules/@typescript-eslint/scope-manager": {
-            "version": "8.62.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.62.0.tgz",
-            "integrity": "sha512-1lX38kNxXIRb8mEc3lbq5mdHq1Pf2+U0nFU65KfT18mtPxxl0fvjuEE92mHuXPuCtElJhOrddOpyMlM3Z0umEA==",
+            "version": "8.63.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.63.0.tgz",
+            "integrity": "sha512-uUyfMWCnDSN8bCpcrY8nGP2BLkQ9Xn0GsipcONcpIDWhwhO4ZSyHvyS14U3X75mzxWxL3I2UZIrenTzdzcJO8A==",
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "8.62.0",
-                "@typescript-eslint/visitor-keys": "8.62.0"
+                "@typescript-eslint/types": "8.63.0",
+                "@typescript-eslint/visitor-keys": "8.63.0"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -6237,9 +6512,9 @@
             }
         },
         "node_modules/@typescript-eslint/tsconfig-utils": {
-            "version": "8.62.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.62.0.tgz",
-            "integrity": "sha512-y2GAdB6ykaXUvuspbYnizQc4oDDz0Tz/Yc7iWrXf9mx8vm/L/0vLHCe0tS2boG96Zy+DivnVDQ9ZUEWoHqqx1g==",
+            "version": "8.63.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.63.0.tgz",
+            "integrity": "sha512-sUAbkulqBAsncKnbRP3+7CtQFRKicexnj7ZwNC6ddCR7EmrXvjvdCYMJbUIqMd6lwoEriZjwLo08aS5tSjVMHg==",
             "license": "MIT",
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -6253,9 +6528,9 @@
             }
         },
         "node_modules/@typescript-eslint/types": {
-            "version": "8.62.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.62.0.tgz",
-            "integrity": "sha512-KvAclkktORPvM54TgLgA4z9HIV1M8zOgw9ZVNXl9f/8dLYfXYX1wkMXP7qmabpijQRV5bHJLOmoyGQbLMaUYeg==",
+            "version": "8.63.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.63.0.tgz",
+            "integrity": "sha512-xyLtl9DUBBFrcJS4x2pIqGLH68/tC2uOa4Z7pUteW09D3bXnnXUom4dyPikzWgB7llmIc1zoeI3aoUdC4rPK/Q==",
             "license": "MIT",
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -6266,15 +6541,15 @@
             }
         },
         "node_modules/@typescript-eslint/typescript-estree": {
-            "version": "8.62.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.62.0.tgz",
-            "integrity": "sha512-+hVbNxtW64pIcZWDPGbyaKF7vp2IBTVY5ma1blwwksrjdsbdqqEKvJWMGbBofei4F6Dovx1M0RJgoFeNu2279A==",
+            "version": "8.63.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.63.0.tgz",
+            "integrity": "sha512-ygBkU+B7ex5UI/gKhaqexWev79uISfIv7XQCRNYO/jmD8rGLPyWLAb3KMRT6nd8Gt9bmUBi9+iX6tBdYfOY81Q==",
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/project-service": "8.62.0",
-                "@typescript-eslint/tsconfig-utils": "8.62.0",
-                "@typescript-eslint/types": "8.62.0",
-                "@typescript-eslint/visitor-keys": "8.62.0",
+                "@typescript-eslint/project-service": "8.63.0",
+                "@typescript-eslint/tsconfig-utils": "8.63.0",
+                "@typescript-eslint/types": "8.63.0",
+                "@typescript-eslint/visitor-keys": "8.63.0",
                 "debug": "^4.4.3",
                 "minimatch": "^10.2.2",
                 "semver": "^7.7.3",
@@ -6293,12 +6568,12 @@
             }
         },
         "node_modules/@typescript-eslint/visitor-keys": {
-            "version": "8.62.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.62.0.tgz",
-            "integrity": "sha512-CY3uyFSRbcQv3nnSv8S0+lDftMVz6P963PoRlxrV7ew/Md564g9ut60PYzdLM5qW4jFn93GBF+Soi90ISAN+GQ==",
+            "version": "8.63.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.63.0.tgz",
+            "integrity": "sha512-UexrHGnGTpbuQHct2ExOc2ZcFbGUS9FOesCxxqdBGcpI1BxYu/LZ6U8Aq6/72XtF/qRBk9nhuGHFJIXXMhPMdw==",
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "8.62.0",
+                "@typescript-eslint/types": "8.63.0",
                 "eslint-visitor-keys": "^5.0.0"
             },
             "engines": {
@@ -6307,6 +6582,459 @@
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/typescript-eslint"
+            }
+        },
+        "node_modules/@typescript/native-preview": {
+            "version": "7.0.0-dev.20260615.1",
+            "resolved": "https://registry.npmjs.org/@typescript/native-preview/-/native-preview-7.0.0-dev.20260615.1.tgz",
+            "integrity": "sha512-JJ8X1l7H1GrnseK1k30qfQqB8Pz6jw3IALZVIj5oXQeRbUCe0Wx3ljkJEmOpunogdhEfA8IlOggskbUjVsXKBQ==",
+            "license": "Apache-2.0",
+            "bin": {
+                "tsgo": "bin/tsgo.js"
+            },
+            "engines": {
+                "node": ">=16.20.0"
+            },
+            "optionalDependencies": {
+                "@typescript/native-preview-darwin-arm64": "7.0.0-dev.20260615.1",
+                "@typescript/native-preview-darwin-x64": "7.0.0-dev.20260615.1",
+                "@typescript/native-preview-linux-arm": "7.0.0-dev.20260615.1",
+                "@typescript/native-preview-linux-arm64": "7.0.0-dev.20260615.1",
+                "@typescript/native-preview-linux-x64": "7.0.0-dev.20260615.1",
+                "@typescript/native-preview-win32-arm64": "7.0.0-dev.20260615.1",
+                "@typescript/native-preview-win32-x64": "7.0.0-dev.20260615.1"
+            }
+        },
+        "node_modules/@typescript/native-preview-darwin-arm64": {
+            "version": "7.0.0-dev.20260615.1",
+            "resolved": "https://registry.npmjs.org/@typescript/native-preview-darwin-arm64/-/native-preview-darwin-arm64-7.0.0-dev.20260615.1.tgz",
+            "integrity": "sha512-EHrtoVGEEhIhsnGe+b8w0FoM9JfIw5SkoPwO8ifaU0PrYm2UbyPbj2I2hOTxtk458t0irvGz2+8cshylBRbKng==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">=16.20.0"
+            }
+        },
+        "node_modules/@typescript/native-preview-darwin-x64": {
+            "version": "7.0.0-dev.20260615.1",
+            "resolved": "https://registry.npmjs.org/@typescript/native-preview-darwin-x64/-/native-preview-darwin-x64-7.0.0-dev.20260615.1.tgz",
+            "integrity": "sha512-BcDA56hkk6mrUpysaOVvrdACoX5d2SF1JTwHMoNjT1KysBicExS2wlH0eN0L01iDeqtB73XHl7A4zrKFmKzrBg==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">=16.20.0"
+            }
+        },
+        "node_modules/@typescript/native-preview-linux-arm": {
+            "version": "7.0.0-dev.20260615.1",
+            "resolved": "https://registry.npmjs.org/@typescript/native-preview-linux-arm/-/native-preview-linux-arm-7.0.0-dev.20260615.1.tgz",
+            "integrity": "sha512-YRXRS/7ZqrDKXBJhFQcZiOdnHRuRbWoL/QkggpoGfhIuSAh4HvTU0WEUnPM+jRnH2kUMfsSgd8EAnPvmuP7/VA==",
+            "cpu": [
+                "arm"
+            ],
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=16.20.0"
+            }
+        },
+        "node_modules/@typescript/native-preview-linux-arm64": {
+            "version": "7.0.0-dev.20260615.1",
+            "resolved": "https://registry.npmjs.org/@typescript/native-preview-linux-arm64/-/native-preview-linux-arm64-7.0.0-dev.20260615.1.tgz",
+            "integrity": "sha512-TDAlBpyYCF7Z+ELTH+1tabDE6W3shl+H+Z+nmzaQio1I8pFvbwt2iLlE0Rc9CpRdIeaqr0ppMEgXHoeV3fZFWA==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=16.20.0"
+            }
+        },
+        "node_modules/@typescript/native-preview-linux-x64": {
+            "version": "7.0.0-dev.20260615.1",
+            "resolved": "https://registry.npmjs.org/@typescript/native-preview-linux-x64/-/native-preview-linux-x64-7.0.0-dev.20260615.1.tgz",
+            "integrity": "sha512-/QDmRWt6abB7fw3yMchjlyDXej/7Dr8mYG4wvGGf6c1hc5Il5UpDQWNHejatdeKvAu+sszz8JhTuL8et47fTTg==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=16.20.0"
+            }
+        },
+        "node_modules/@typescript/native-preview-win32-arm64": {
+            "version": "7.0.0-dev.20260615.1",
+            "resolved": "https://registry.npmjs.org/@typescript/native-preview-win32-arm64/-/native-preview-win32-arm64-7.0.0-dev.20260615.1.tgz",
+            "integrity": "sha512-WTJOLoe2rxT0W1i8ndWk2MKrakxRFNki537JZxvKAmSTbyOZznHlW3O3dbryUtTBYA716DDqS3ci24kuIfvBdg==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=16.20.0"
+            }
+        },
+        "node_modules/@typescript/native-preview-win32-x64": {
+            "version": "7.0.0-dev.20260615.1",
+            "resolved": "https://registry.npmjs.org/@typescript/native-preview-win32-x64/-/native-preview-win32-x64-7.0.0-dev.20260615.1.tgz",
+            "integrity": "sha512-4cSCpXG7um18nwmLdU/SjoTv3OcO38/ufTiy1oWVccgGHLJqppiOP9/o+ElKIWhvrp78IaGy8+h3YqEjQ4/pcQ==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=16.20.0"
+            }
+        },
+        "node_modules/@typescript/typescript-aix-ppc64": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/@typescript/typescript-aix-ppc64/-/typescript-aix-ppc64-7.0.2.tgz",
+            "integrity": "sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ==",
+            "cpu": [
+                "ppc64"
+            ],
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "aix"
+            ],
+            "engines": {
+                "node": ">=16.20.0"
+            }
+        },
+        "node_modules/@typescript/typescript-darwin-arm64": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/@typescript/typescript-darwin-arm64/-/typescript-darwin-arm64-7.0.2.tgz",
+            "integrity": "sha512-gowzar9MwS/aRWp6f3a4KUqzRjAZjOsmGNCM6LcTgXum+dBfgsBVMN+AgvOCCbguXyick6LJhpBszxMebJ8syA==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">=16.20.0"
+            }
+        },
+        "node_modules/@typescript/typescript-darwin-x64": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/@typescript/typescript-darwin-x64/-/typescript-darwin-x64-7.0.2.tgz",
+            "integrity": "sha512-SZ9xZInqApNlNGc9s0W1VSsktYSOe9cFqNOIqmN1Gs8SmkjKZYFt017G4VwPxASInODuAdbTW7sXiFUf893RgA==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">=16.20.0"
+            }
+        },
+        "node_modules/@typescript/typescript-freebsd-arm64": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/@typescript/typescript-freebsd-arm64/-/typescript-freebsd-arm64-7.0.2.tgz",
+            "integrity": "sha512-W5NH4y/J0plIIS5b2xvTEkU7JFxyqdMAOgf+Ilhl0vHQXKO5dZoxd+C/jEtq56c4F3wk71RB4BMRQ2XdI+bwYQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": ">=16.20.0"
+            }
+        },
+        "node_modules/@typescript/typescript-freebsd-x64": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/@typescript/typescript-freebsd-x64/-/typescript-freebsd-x64-7.0.2.tgz",
+            "integrity": "sha512-UMGDx5sTpzNw3WiPebH7l90IWfJggEd+egHt/q6p7/Cm3zqoV7VxkGXt+3DxPIw8CcmvAB0j3sVVfbhX+M4Tpw==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": ">=16.20.0"
+            }
+        },
+        "node_modules/@typescript/typescript-linux-arm": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-arm/-/typescript-linux-arm-7.0.2.tgz",
+            "integrity": "sha512-gffT3xPz9sR7j/YJExkyPntrI0P2EP9XbOyWzth2/Gs0RstK+90RBcO0ncXoXy/beYll1SXw846Nf2zdnEz0QQ==",
+            "cpu": [
+                "arm"
+            ],
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=16.20.0"
+            }
+        },
+        "node_modules/@typescript/typescript-linux-arm64": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-arm64/-/typescript-linux-arm64-7.0.2.tgz",
+            "integrity": "sha512-Qh4eU4/y3yDjnfjjyPYihMj5/ODIlmt+Bzu17OI+fiSRDW57QmU5SiN63exPRNJPKUzcc1INa1NXdrJ+MqHjUQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=16.20.0"
+            }
+        },
+        "node_modules/@typescript/typescript-linux-loong64": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-loong64/-/typescript-linux-loong64-7.0.2.tgz",
+            "integrity": "sha512-uEHck9i8hoAzXPiYRib1O7miOnz23SxIeVl6F4LXox+qov1K35jHcEW6VHKvZI+pyvl7fZEP4MCU5LYvIq1GuQ==",
+            "cpu": [
+                "loong64"
+            ],
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=16.20.0"
+            }
+        },
+        "node_modules/@typescript/typescript-linux-mips64el": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-mips64el/-/typescript-linux-mips64el-7.0.2.tgz",
+            "integrity": "sha512-R4KvAMnE43W5Qeqb0Ly56O3mWMWIAgsMyz36DCaycd5nbg/9kzm0liw3JocfRqyJY0KPmzFjbswozXyW0DnIYA==",
+            "cpu": [
+                "mips64el"
+            ],
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=16.20.0"
+            }
+        },
+        "node_modules/@typescript/typescript-linux-ppc64": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-ppc64/-/typescript-linux-ppc64-7.0.2.tgz",
+            "integrity": "sha512-DORx5b3sd/4S7eayxm4FQv+A7CrkUIGRaHiwI8oiHTAI1fAPWhF4J0vAlkC8biAlHSVVwxMQ3tjZ2/DVbnQiiA==",
+            "cpu": [
+                "ppc64"
+            ],
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=16.20.0"
+            }
+        },
+        "node_modules/@typescript/typescript-linux-riscv64": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-riscv64/-/typescript-linux-riscv64-7.0.2.tgz",
+            "integrity": "sha512-wf0jqEDOjrPRnKwYRyyJDRo11KMbvMFrU+q4zqKyChODBzvlkbhNQfKvLxQCcwTpdDaXSHZTVuh0JoCrKCUMHQ==",
+            "cpu": [
+                "riscv64"
+            ],
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=16.20.0"
+            }
+        },
+        "node_modules/@typescript/typescript-linux-s390x": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-s390x/-/typescript-linux-s390x-7.0.2.tgz",
+            "integrity": "sha512-IkwJc3L7yhytWd/ewjyxNDfOmswCm9GWMJT/ue/dU4aZNbwZeYAetq42VyLmsmSjvoX7z74X6ZaYCtzAr0EuGw==",
+            "cpu": [
+                "s390x"
+            ],
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=16.20.0"
+            }
+        },
+        "node_modules/@typescript/typescript-linux-x64": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-x64/-/typescript-linux-x64-7.0.2.tgz",
+            "integrity": "sha512-EYdf2cNg7rgCWJnxCdJ+F3V39O8ihb37eHAu1LK8oAFizgTQbPOK7zHHXbPt8rX24COqODXeI3sIf0fCXG7H/A==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=16.20.0"
+            }
+        },
+        "node_modules/@typescript/typescript-netbsd-arm64": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/@typescript/typescript-netbsd-arm64/-/typescript-netbsd-arm64-7.0.2.tgz",
+            "integrity": "sha512-+polYF4MF04aPpO5FTkHran9yUQDSXqy5GiSDKpsll5jy3l3+g9QLhpf39T+ePtefhXLOGrLl0QIjkQP6VnelA==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "netbsd"
+            ],
+            "engines": {
+                "node": ">=16.20.0"
+            }
+        },
+        "node_modules/@typescript/typescript-netbsd-x64": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/@typescript/typescript-netbsd-x64/-/typescript-netbsd-x64-7.0.2.tgz",
+            "integrity": "sha512-8YIT0EHM/3dq10ZOVF/A7pc/YSMtbcecct4rWtexrnSCHOPcpC2KTLXfTCR6vDpnSiY12heNb1GiN/wu+T/FyA==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "netbsd"
+            ],
+            "engines": {
+                "node": ">=16.20.0"
+            }
+        },
+        "node_modules/@typescript/typescript-openbsd-arm64": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/@typescript/typescript-openbsd-arm64/-/typescript-openbsd-arm64-7.0.2.tgz",
+            "integrity": "sha512-APT8+ClYnuYm1u9+kgGXoMj2VzWzcymwh2gNSQVySHfkRDGOTVkoWLjCmOQSaO+PoqQ57B0flRp9SA+7GnnkzQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "openbsd"
+            ],
+            "engines": {
+                "node": ">=16.20.0"
+            }
+        },
+        "node_modules/@typescript/typescript-openbsd-x64": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/@typescript/typescript-openbsd-x64/-/typescript-openbsd-x64-7.0.2.tgz",
+            "integrity": "sha512-yX7s+Q0Dln0Dt9tEzZsAjXXR/+ytBM7AlglaqyeMPxQszJ1JhlJdZ6jLA+IzldHtflX81em7lDao1xXu+aRRkg==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "openbsd"
+            ],
+            "engines": {
+                "node": ">=16.20.0"
+            }
+        },
+        "node_modules/@typescript/typescript-sunos-x64": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/@typescript/typescript-sunos-x64/-/typescript-sunos-x64-7.0.2.tgz",
+            "integrity": "sha512-dLJDGaLZ1D4HPQn62u1n8mBDkJREwMsAkCdkwd4Ieqw+x3TUyTsqY0YiBCtE6H6OzzgGk3iuZ3vFWRS+E8/d1g==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "sunos"
+            ],
+            "engines": {
+                "node": ">=16.20.0"
+            }
+        },
+        "node_modules/@typescript/typescript-win32-arm64": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/@typescript/typescript-win32-arm64/-/typescript-win32-arm64-7.0.2.tgz",
+            "integrity": "sha512-Gyl1Vy6OsWesLzmq+EP0Fb7b4Nid5232AvcA2SFcdYreldpNtYFFofPjnt62y9hQy7VTaZp65ICJjuAQRaVcIQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=16.20.0"
+            }
+        },
+        "node_modules/@typescript/typescript-win32-x64": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/@typescript/typescript-win32-x64/-/typescript-win32-x64-7.0.2.tgz",
+            "integrity": "sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=16.20.0"
             }
         },
         "node_modules/@ungap/structured-clone": {
@@ -6324,6 +7052,12 @@
                 "d3-selection": "^3.0.0",
                 "d3-transition": "^3.0.1"
             }
+        },
+        "node_modules/@uttr/tint": {
+            "version": "0.1.3",
+            "resolved": "https://registry.npmjs.org/@uttr/tint/-/tint-0.1.3.tgz",
+            "integrity": "sha512-nQlAxBriuQ7NPxvMlxCXdw0n4alhEAIzsjFNNyU4CR7AitUwMFp1A5e/47JYQ7NMcooaI06OEQKylYhNhbpuIA==",
+            "license": "MIT"
         },
         "node_modules/@vitejs/plugin-vue": {
             "version": "6.0.7",
@@ -6362,14 +7096,14 @@
             }
         },
         "node_modules/@vitest/browser": {
-            "version": "4.1.9",
-            "resolved": "https://registry.npmjs.org/@vitest/browser/-/browser-4.1.9.tgz",
-            "integrity": "sha512-j1BKtWmPcqpMhmx/L9EPLgAJpCb0zKfwoWLmqBbxaogCXHjOwHFSEoHCBfnGtx93xKQwilZ26m+UOsHqHMkRNg==",
+            "version": "4.1.10",
+            "resolved": "https://registry.npmjs.org/@vitest/browser/-/browser-4.1.10.tgz",
+            "integrity": "sha512-UDwuWGwXj646CBx/bQHOaJSX7np0I8JL/UKQYa1e4QrVHH8VdWtx8eaOuf8sy0ShwDgR6NjJAsp5eF6vjF6qng==",
             "license": "MIT",
             "dependencies": {
                 "@blazediff/core": "1.9.1",
-                "@vitest/mocker": "4.1.9",
-                "@vitest/utils": "4.1.9",
+                "@vitest/mocker": "4.1.10",
+                "@vitest/utils": "4.1.10",
                 "magic-string": "^0.30.21",
                 "pngjs": "^7.0.0",
                 "sirv": "^3.0.2",
@@ -6380,17 +7114,17 @@
                 "url": "https://opencollective.com/vitest"
             },
             "peerDependencies": {
-                "vitest": "4.1.9"
+                "vitest": "4.1.10"
             }
         },
         "node_modules/@vitest/browser-playwright": {
-            "version": "4.1.9",
-            "resolved": "https://registry.npmjs.org/@vitest/browser-playwright/-/browser-playwright-4.1.9.tgz",
-            "integrity": "sha512-Bq1rOGf9waevzG3EOkO/dene6bvKTUsZMVg8S1i+WH3JcMjuXEjiahP9rAqZRELUqjBySOJsvvSWqK/B3wjKQw==",
+            "version": "4.1.10",
+            "resolved": "https://registry.npmjs.org/@vitest/browser-playwright/-/browser-playwright-4.1.10.tgz",
+            "integrity": "sha512-nMoXGEiRpT7m3W7NsbvrM2aKNwiNHZf+zEpUCvMteGjZFvfT96Q9fh7QyB98dvDWXiKvrLxA7bJ1mCOOv+JQPw==",
             "license": "MIT",
             "dependencies": {
-                "@vitest/browser": "4.1.9",
-                "@vitest/mocker": "4.1.9",
+                "@vitest/browser": "4.1.10",
+                "@vitest/mocker": "4.1.10",
                 "tinyrainbow": "^3.1.0"
             },
             "funding": {
@@ -6398,7 +7132,7 @@
             },
             "peerDependencies": {
                 "playwright": "*",
-                "vitest": "4.1.9"
+                "vitest": "4.1.10"
             },
             "peerDependenciesMeta": {
                 "playwright": {
@@ -6407,13 +7141,13 @@
             }
         },
         "node_modules/@vitest/coverage-v8": {
-            "version": "4.1.9",
-            "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.9.tgz",
-            "integrity": "sha512-G9/lgqibheLVBDRuya45EbsEXTYcWoSG+TLg7i2axuzx0Eq62eXn+aWXyaVdV5vKvFSWd6ywcX8hA7la9Pvu8g==",
+            "version": "4.1.10",
+            "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.10.tgz",
+            "integrity": "sha512-IM49HmthevbgAO4anp1hwtoT9wYe59w0LR00gr+eagHE+ZJ5lK4sLPeO0ubgoJcwLk6dehU3R24N+FbEEKDc8g==",
             "license": "MIT",
             "dependencies": {
                 "@bcoe/v8-coverage": "^1.0.2",
-                "@vitest/utils": "4.1.9",
+                "@vitest/utils": "4.1.10",
                 "ast-v8-to-istanbul": "^1.0.0",
                 "istanbul-lib-coverage": "^3.2.2",
                 "istanbul-lib-report": "^3.0.1",
@@ -6427,8 +7161,8 @@
                 "url": "https://opencollective.com/vitest"
             },
             "peerDependencies": {
-                "@vitest/browser": "4.1.9",
-                "vitest": "4.1.9"
+                "@vitest/browser": "4.1.10",
+                "vitest": "4.1.10"
             },
             "peerDependenciesMeta": {
                 "@vitest/browser": {
@@ -6500,12 +7234,12 @@
             }
         },
         "node_modules/@vitest/mocker": {
-            "version": "4.1.9",
-            "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.9.tgz",
-            "integrity": "sha512-EVkXzBjrPGM+cK8/ANWgBrkUCfJfb38/EfTSO8h7pWvKkyPkpWxvR7BkD2MyItMF62C97zAEoqdpUixwR/e+Rw==",
+            "version": "4.1.10",
+            "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
+            "integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
             "license": "MIT",
             "dependencies": {
-                "@vitest/spy": "4.1.9",
+                "@vitest/spy": "4.1.10",
                 "estree-walker": "^3.0.3",
                 "magic-string": "^0.30.21"
             },
@@ -6526,9 +7260,9 @@
             }
         },
         "node_modules/@vitest/pretty-format": {
-            "version": "4.1.9",
-            "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.9.tgz",
-            "integrity": "sha512-s0iufns3iIFitdgm+YR7g1whCAaGtXz459VS9/PqyKDEEFgYIhsHOQmXgIgDuYCt7DeQmiZT0Qe2OA2p4ZPu5A==",
+            "version": "4.1.10",
+            "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
+            "integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
             "license": "MIT",
             "dependencies": {
                 "tinyrainbow": "^3.1.0"
@@ -6538,12 +7272,12 @@
             }
         },
         "node_modules/@vitest/runner": {
-            "version": "4.1.9",
-            "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.9.tgz",
-            "integrity": "sha512-KXLMDtc7oe70+3mJfGrPUWPesswH+3sTxAMAMl8DG7I8IUQT4XW718dY5ID3vPUcmlu27CcKfY4P3h3I29SLJg==",
+            "version": "4.1.10",
+            "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.10.tgz",
+            "integrity": "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==",
             "license": "MIT",
             "dependencies": {
-                "@vitest/utils": "4.1.9",
+                "@vitest/utils": "4.1.10",
                 "pathe": "^2.0.3"
             },
             "funding": {
@@ -6551,13 +7285,13 @@
             }
         },
         "node_modules/@vitest/snapshot": {
-            "version": "4.1.9",
-            "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.9.tgz",
-            "integrity": "sha512-Jc7RKGNBo8Z28WYIm0Niej4xdSPByRf6mU58VpHQkd6Zh05rlnA+twjbK5HyeIGHxrzsc3mJgS43uM0CZKzaIA==",
+            "version": "4.1.10",
+            "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.10.tgz",
+            "integrity": "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==",
             "license": "MIT",
             "dependencies": {
-                "@vitest/pretty-format": "4.1.9",
-                "@vitest/utils": "4.1.9",
+                "@vitest/pretty-format": "4.1.10",
+                "@vitest/utils": "4.1.10",
                 "magic-string": "^0.30.21",
                 "pathe": "^2.0.3"
             },
@@ -6566,21 +7300,21 @@
             }
         },
         "node_modules/@vitest/spy": {
-            "version": "4.1.9",
-            "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.9.tgz",
-            "integrity": "sha512-fHpsS6mIi+PiEW+vcRVOMkX1oSaPKne3VOclSFICPcGOmfKgXPU5iAah+wcNcj2xPrCCmfq99IDGf+EojhhvhA==",
+            "version": "4.1.10",
+            "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.10.tgz",
+            "integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==",
             "license": "MIT",
             "funding": {
                 "url": "https://opencollective.com/vitest"
             }
         },
         "node_modules/@vitest/utils": {
-            "version": "4.1.9",
-            "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.9.tgz",
-            "integrity": "sha512-A51o8ymO5PpqlWNnBP9ZHPXDIpuMtTLlGSjN7la4US+LJzoUMyhwjA5QXlm39JexgwHKW4Xjs8Z2d3dLCXOeuA==",
+            "version": "4.1.10",
+            "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
+            "integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
             "license": "MIT",
             "dependencies": {
-                "@vitest/pretty-format": "4.1.9",
+                "@vitest/pretty-format": "4.1.10",
                 "convert-source-map": "^2.0.0",
                 "tinyrainbow": "^3.1.0"
             },
@@ -6963,9 +7697,9 @@
             "license": "MIT"
         },
         "node_modules/@vue/language-core/node_modules/brace-expansion": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
-            "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+            "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
             "license": "MIT",
             "dependencies": {
                 "balanced-match": "^1.0.0"
@@ -7318,6 +8052,16 @@
                 "url": "https://github.com/fb55/entities?sponsor=1"
             }
         },
+        "node_modules/ansis": {
+            "version": "4.3.1",
+            "resolved": "https://registry.npmjs.org/ansis/-/ansis-4.3.1.tgz",
+            "integrity": "sha512-BJ8/l4R5LRE7hW9WdSuGYrLSHi2ynxeFpDFbH0K/CgNeY/tyhk+vO6TYxXC5r5CpUhNVX310xzPsN/H9lCdfOA==",
+            "dev": true,
+            "license": "ISC",
+            "engines": {
+                "node": ">=14"
+            }
+        },
         "node_modules/apg-lite": {
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/apg-lite/-/apg-lite-1.0.5.tgz",
@@ -7523,9 +8267,9 @@
             "license": "MIT"
         },
         "node_modules/baseline-browser-mapping": {
-            "version": "2.10.40",
-            "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.40.tgz",
-            "integrity": "sha512-BSSLZ9/Cjjv7Gtj5B68ZzXcXUg8iOf3fme+FCuh8rC/Go+Kmh8cox7M3A8dolou16s64QjLPOSdngh7GxXvkSw==",
+            "version": "2.10.42",
+            "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.42.tgz",
+            "integrity": "sha512-c/jurFrDLyui7o1J86yLkRu4LMsTYcBohveus7/I2Hzdn9KIP2bdJPTue/lR1KH46enoPbD77GKeSYNdyPoD3Q==",
             "license": "Apache-2.0",
             "bin": {
                 "baseline-browser-mapping": "dist/cli.cjs"
@@ -7617,9 +8361,9 @@
             }
         },
         "node_modules/browserslist": {
-            "version": "4.28.4",
-            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.4.tgz",
-            "integrity": "sha512-MTc8i/x9jBQd1iMw2CFGS+rwMa07eYjLR0CCTLDACl9xhxy+nIs3KeML/biicXtk9JrZ6dnnTatmc7ErPXIxqw==",
+            "version": "4.28.5",
+            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.5.tgz",
+            "integrity": "sha512-Cu2E6QejHWzuDMTkuwgpABFgDfZrXLQq5V13YOACZx4mFAG4IwGTbTfHPMr4WtxlHoXSM8FIuRwYYCz5XiabaQ==",
             "funding": [
                 {
                     "type": "opencollective",
@@ -7636,10 +8380,10 @@
             ],
             "license": "MIT",
             "dependencies": {
-                "baseline-browser-mapping": "^2.10.38",
-                "caniuse-lite": "^1.0.30001799",
-                "electron-to-chromium": "^1.5.376",
-                "node-releases": "^2.0.48",
+                "baseline-browser-mapping": "^2.10.42",
+                "caniuse-lite": "^1.0.30001800",
+                "electron-to-chromium": "^1.5.387",
+                "node-releases": "^2.0.50",
                 "update-browserslist-db": "^1.2.3"
             },
             "bin": {
@@ -7774,9 +8518,9 @@
             }
         },
         "node_modules/caniuse-lite": {
-            "version": "1.0.30001799",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001799.tgz",
-            "integrity": "sha512-hG1bReV+OUU+MOqK4t/ZWI0tZOyz3rqS9XuhOUz1cIcbwBKjOyJEJuw9ER5JuNyqxNk8u/JUVbGibBOL1yrjFw==",
+            "version": "1.0.30001803",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001803.tgz",
+            "integrity": "sha512-g/uHREV2ZpK9qMalCsWaxmA6ol+DX8GYhuf3T40RKoP+oL7vhRJh8LNt73PCjpnR6l14FzfPrB5Yux4PKm2meg==",
             "funding": [
                 {
                     "type": "opencollective",
@@ -7936,6 +8680,22 @@
             "license": "MIT",
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/clerc": {
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/clerc/-/clerc-1.3.1.tgz",
+            "integrity": "sha512-FUgCFbvK40HPIvR5ty5Y1V8UkesgR+h64H6ybkc8ZOCWvO9Z5F1t3Fdw+DfX6n1kDlYg640Qp3HmqVOXtKtZPQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@clerc/core": "1.3.1",
+                "@clerc/plugin-completions": "1.3.1",
+                "@clerc/plugin-friendly-error": "1.3.1",
+                "@clerc/plugin-help": "1.3.1",
+                "@clerc/plugin-not-found": "1.3.1",
+                "@clerc/plugin-strict-flags": "1.3.1",
+                "@clerc/plugin-update-notifier": "1.3.1",
+                "@clerc/plugin-version": "1.3.1"
             }
         },
         "node_modules/cli-cursor": {
@@ -8177,9 +8937,9 @@
             }
         },
         "node_modules/cronstrue": {
-            "version": "3.23.0",
-            "resolved": "https://registry.npmjs.org/cronstrue/-/cronstrue-3.23.0.tgz",
-            "integrity": "sha512-sIBZcwhpwkarRxfAHctpqGU9RapM7aLg5IktORluDnnUNkaTIIxEfI6S5IQy1isBGyTmgbbz4X6xPqpUgK7l0A==",
+            "version": "3.24.0",
+            "resolved": "https://registry.npmjs.org/cronstrue/-/cronstrue-3.24.0.tgz",
+            "integrity": "sha512-t/Ji3Ur2c/pzhIAWNwC0ftl3JAE4dLfCjAdZoTZXmPDZwcispnS1PaMcMS4OmIIXyIVouAz+yw+mfQiE3hz5OQ==",
             "license": "MIT",
             "bin": {
                 "cronstrue": "bin/cli.js"
@@ -8821,6 +9581,15 @@
                 "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
             }
         },
+        "node_modules/data-urls/node_modules/whatwg-mimetype": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+            "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=20"
+            }
+        },
         "node_modules/dayjs": {
             "version": "1.11.21",
             "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.21.tgz",
@@ -9149,9 +9918,9 @@
             "license": "MIT"
         },
         "node_modules/editorconfig/node_modules/brace-expansion": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
-            "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+            "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
             "license": "MIT",
             "dependencies": {
                 "balanced-match": "^1.0.0"
@@ -9182,9 +9951,9 @@
             }
         },
         "node_modules/electron-to-chromium": {
-            "version": "1.5.381",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.381.tgz",
-            "integrity": "sha512-n9Wa6yB+vDsGuA8AKbl/0z7HbvWqt5jxIdvr1IUicd0ryPrk7/xzwqLv8D9AbbvZ6avVNtXYLTfmgFHkwkyelg==",
+            "version": "1.5.389",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.389.tgz",
+            "integrity": "sha512-cEto7aeOqBfU1D+c5py5pE+ooscKE75JifxLBdFUZsqAxRS6y7kebtxAZvICszSl05gPjYHDTjY+lXpyGvpJbg==",
             "license": "ISC"
         },
         "node_modules/element-plus": {
@@ -9218,6 +9987,15 @@
             "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
             "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
             "license": "MIT"
+        },
+        "node_modules/empathic": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/empathic/-/empathic-2.0.0.tgz",
+            "integrity": "sha512-i6UzDscO/XfAcNYD75CfICkmfLedpyPDdozrLMmQc5ORaQcdMoc21OnlEylMIqI7U8eniKrPMxxtj8k0vhmJhA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=14"
+            }
         },
         "node_modules/entities": {
             "version": "7.0.1",
@@ -9262,9 +10040,9 @@
             }
         },
         "node_modules/es-module-lexer": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.2.0.tgz",
-            "integrity": "sha512-3lGxdTXCLfe1MYfTz1y2ksAAUM4NAOP6rPEjxGJVKO7TZ5+tvHCaQWGpC4Y3IXvW3ece0Cz1cIP4FWBxOnGCTQ==",
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.0.tgz",
+            "integrity": "sha512-KLdwQm2NvGLDkQDCGvmiQrhkd0JbMzXthwQAUgWjQuQdBLFa3eiBP5arXZyA+f8x+x7OXgud6bq2rxjGtHV2tw==",
             "license": "MIT"
         },
         "node_modules/es-object-atoms": {
@@ -9549,9 +10327,9 @@
             "license": "MIT"
         },
         "node_modules/eslint/node_modules/brace-expansion": {
-            "version": "1.1.15",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-            "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+            "version": "1.1.16",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+            "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
             "license": "MIT",
             "dependencies": {
                 "balanced-match": "^1.0.0",
@@ -9734,9 +10512,9 @@
             }
         },
         "node_modules/exsolve": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/exsolve/-/exsolve-1.1.0.tgz",
-            "integrity": "sha512-D+42+T12DdIlJM3uepa55qGiL3sYdLBOxIl2ifQCzCHz4c7eiolaHsi3BIqEr7JxBzxv2pYZQX9kw16ziMcEmw==",
+            "version": "1.0.8",
+            "resolved": "https://registry.npmjs.org/exsolve/-/exsolve-1.0.8.tgz",
+            "integrity": "sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA==",
             "license": "MIT"
         },
         "node_modules/ext": {
@@ -9777,6 +10555,21 @@
             "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
             "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
             "license": "MIT"
+        },
+        "node_modules/fast-string-truncated-width": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/fast-string-truncated-width/-/fast-string-truncated-width-3.0.3.tgz",
+            "integrity": "sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g==",
+            "license": "MIT"
+        },
+        "node_modules/fast-string-width": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/fast-string-width/-/fast-string-width-3.0.2.tgz",
+            "integrity": "sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==",
+            "license": "MIT",
+            "dependencies": {
+                "fast-string-truncated-width": "^3.0.2"
+            }
         },
         "node_modules/fast-uri": {
             "version": "3.1.3",
@@ -10018,12 +10811,12 @@
             }
         },
         "node_modules/framer-motion": {
-            "version": "12.42.0",
-            "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.42.0.tgz",
-            "integrity": "sha512-wp7EJnfWaaEScVygKv3e20udoRz+LbtxScsuTkakAxfXmt+ReC6WyPW2nINRAGvd+hG9odwcjBLyOTPjH5pBRA==",
+            "version": "12.42.2",
+            "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.42.2.tgz",
+            "integrity": "sha512-5XY9luDiu0oHfHBjpDthFMh0ES+122w6p/papSJBweMkO8Sn+PW2QaEgRblQBpWFnuvZS5qvarpt/hO2pjGmnw==",
             "license": "MIT",
             "dependencies": {
-                "motion-dom": "^12.42.0",
+                "motion-dom": "^12.42.2",
                 "motion-utils": "^12.39.0",
                 "tslib": "^2.4.0"
             },
@@ -10082,9 +10875,9 @@
             }
         },
         "node_modules/gaxios": {
-            "version": "7.1.5",
-            "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.1.5.tgz",
-            "integrity": "sha512-5FZy72Rh8LhtjmvDrKkI+lVhrsQrVKVsItxMoDm5mNQE+xR0WVIIs+jzPSJgBvKVsLi24fZhXJIsNI0bihDzFg==",
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.2.0.tgz",
+            "integrity": "sha512-CUVb4wcYe+771XevyH6HtGmXFAGGKkIC3kswAP8Z1JCe0j80JMaTPZH930DWFrvo0atjh18Arc0pEyUCWa5bfg==",
             "license": "Apache-2.0",
             "dependencies": {
                 "extend": "^3.0.2",
@@ -10193,7 +10986,6 @@
             "version": "5.0.0-beta.5",
             "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-5.0.0-beta.5.tgz",
             "integrity": "sha512-/6gFNr0N04nob252sTQxyFLi3eKFRqIg1I87YcqAMT1i6SQrSF6KujUEQrtrjMV0H/eejTCltLdDSTEMzHbnsQ==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "resolve-pkg-maps": "^1.0.0"
@@ -10245,9 +11037,9 @@
             "license": "MIT"
         },
         "node_modules/glob/node_modules/brace-expansion": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
-            "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+            "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
             "license": "MIT",
             "dependencies": {
                 "balanced-match": "^1.0.0"
@@ -10398,16 +11190,6 @@
             },
             "engines": {
                 "node": ">=20.0.0"
-            }
-        },
-        "node_modules/happy-dom/node_modules/whatwg-mimetype": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
-            "integrity": "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==",
-            "devOptional": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=12"
             }
         },
         "node_modules/has-flag": {
@@ -10593,9 +11375,9 @@
             }
         },
         "node_modules/humanize-duration": {
-            "version": "3.33.2",
-            "resolved": "https://registry.npmjs.org/humanize-duration/-/humanize-duration-3.33.2.tgz",
-            "integrity": "sha512-K7Ny/ULO1hDm2nnhvAY+SJV1skxFb61fd073SG1IWJl+D44ULrruCuTyjHKjBVVcSuTlnY99DKtgEG39CM5QOQ==",
+            "version": "3.34.0",
+            "resolved": "https://registry.npmjs.org/humanize-duration/-/humanize-duration-3.34.0.tgz",
+            "integrity": "sha512-NDxhYxiiRzsST6xULIHuYWRvsCtviJXRdjarhyWyh78S4Ou+MWhM2k4HQ+y7iegdrzreXe11isd0au1N2PB/pQ==",
             "license": "Unlicense",
             "funding": {
                 "url": "https://github.com/sponsors/EvanHahn"
@@ -10643,9 +11425,9 @@
             }
         },
         "node_modules/immutable": {
-            "version": "5.1.8",
-            "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.8.tgz",
-            "integrity": "sha512-TM5YqrGeTsVIPPpILzeqZ8D2Zc2TvNgSDi88zPF2a4cyqQdWV/wVWBDRDbNzzrLeRWScrFcOX9lW2iX6GOtUDw==",
+            "version": "5.1.9",
+            "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.9.tgz",
+            "integrity": "sha512-m8nVez3rwrgmWxtLMt1ZYXB2Lv7OKYn/disyxAlSDYAlKSlFoPPfIAmAM/M5xqL4m4C/wAPw7S2/CNaUii1Hxg==",
             "license": "MIT"
         },
         "node_modules/import-fresh": {
@@ -11158,9 +11940,9 @@
             }
         },
         "node_modules/jsdom/node_modules/lru-cache": {
-            "version": "11.5.1",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
-            "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
+            "version": "11.5.2",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+            "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
             "license": "BlueOak-1.0.0",
             "engines": {
                 "node": "20 || >=22"
@@ -11173,6 +11955,15 @@
             "license": "MIT",
             "engines": {
                 "node": ">=20.18.1"
+            }
+        },
+        "node_modules/jsdom/node_modules/whatwg-mimetype": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+            "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=20"
             }
         },
         "node_modules/jsdom/node_modules/xml-name-validator": {
@@ -11786,6 +12577,12 @@
                 "@types/trusted-types": "^2.0.2"
             }
         },
+        "node_modules/lite-emit": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/lite-emit/-/lite-emit-4.0.0.tgz",
+            "integrity": "sha512-8krVeIZLS7JbkXz4R9xYziqHcxga6UgmomVWb45g21aB4M8qzDwr7FTEW3PJa80PTUASXeqbfipveKCB5YZdug==",
+            "license": "MIT"
+        },
         "node_modules/local-pkg": {
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/local-pkg/-/local-pkg-1.2.1.tgz",
@@ -11990,6 +12787,36 @@
                 "lz-string": "bin/bin.js"
             }
         },
+        "node_modules/magic-regexp": {
+            "version": "0.10.0",
+            "resolved": "https://registry.npmjs.org/magic-regexp/-/magic-regexp-0.10.0.tgz",
+            "integrity": "sha512-Uly1Bu4lO1hwHUW0CQeSWuRtzCMNO00CmXtS8N6fyvB3B979GOEEeAkiTUDsmbYLAbvpUS/Kt5c4ibosAzVyVg==",
+            "license": "MIT",
+            "dependencies": {
+                "estree-walker": "^3.0.3",
+                "magic-string": "^0.30.12",
+                "mlly": "^1.7.2",
+                "regexp-tree": "^0.1.27",
+                "type-level-regexp": "~0.1.17",
+                "ufo": "^1.5.4",
+                "unplugin": "^2.0.0"
+            }
+        },
+        "node_modules/magic-regexp/node_modules/unplugin": {
+            "version": "2.3.11",
+            "resolved": "https://registry.npmjs.org/unplugin/-/unplugin-2.3.11.tgz",
+            "integrity": "sha512-5uKD0nqiYVzlmCRs01Fhs2BdkEgBS3SAVP6ndrBsuK42iC2+JHyxM05Rm9G8+5mkmRtzMZGY8Ct5+mliZxU/Ww==",
+            "license": "MIT",
+            "dependencies": {
+                "@jridgewell/remapping": "^2.3.5",
+                "acorn": "^8.15.0",
+                "picomatch": "^4.0.3",
+                "webpack-virtual-modules": "^0.6.2"
+            },
+            "engines": {
+                "node": ">=18.12.0"
+            }
+        },
         "node_modules/magic-string": {
             "version": "0.30.21",
             "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -12066,15 +12893,15 @@
             }
         },
         "node_modules/marked": {
-            "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/marked/-/marked-4.3.0.tgz",
-            "integrity": "sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==",
+            "version": "16.4.2",
+            "resolved": "https://registry.npmjs.org/marked/-/marked-16.4.2.tgz",
+            "integrity": "sha512-TI3V8YYWvkVf3KJe1dRkpnjs68JUPyEa5vjKrp1XEEJUAOaQc+Qj+L1qWbPd0SJuAdQkFU0h73sXXqwDYxsiDA==",
             "license": "MIT",
             "bin": {
                 "marked": "bin/marked.js"
             },
             "engines": {
-                "node": ">= 12"
+                "node": ">= 20"
             }
         },
         "node_modules/material-file-icons": {
@@ -12415,18 +13242,6 @@
                 "stylis": "^4.3.6",
                 "ts-dedent": "^2.2.0",
                 "uuid": "^11.1.0 || ^12 || ^13 || ^14.0.0"
-            }
-        },
-        "node_modules/mermaid/node_modules/marked": {
-            "version": "16.4.2",
-            "resolved": "https://registry.npmjs.org/marked/-/marked-16.4.2.tgz",
-            "integrity": "sha512-TI3V8YYWvkVf3KJe1dRkpnjs68JUPyEa5vjKrp1XEEJUAOaQc+Qj+L1qWbPd0SJuAdQkFU0h73sXXqwDYxsiDA==",
-            "license": "MIT",
-            "bin": {
-                "marked": "bin/marked.js"
-            },
-            "engines": {
-                "node": ">= 20"
             }
         },
         "node_modules/micromark": {
@@ -13291,9 +14106,9 @@
             }
         },
         "node_modules/motion-dom": {
-            "version": "12.42.0",
-            "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.42.0.tgz",
-            "integrity": "sha512-M63h4n8R+quJdNhBwuLlgxM+OLYa9+I/T2pzDRboB9fLXRdbou+Gw7Zury+SkpaCyACP1JHSjHgZ1EgTkBr30w==",
+            "version": "12.42.2",
+            "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.42.2.tgz",
+            "integrity": "sha512-5gIMWLp/PycBtJRJWRgjxke5n8dlvkSn2DrYW+tr3XcqAZY1xZh6BJyooJXCM8wdfM7wfMjkBJNLge1CKPUIRA==",
             "license": "MIT",
             "dependencies": {
                 "motion-utils": "^12.39.0"
@@ -13664,39 +14479,51 @@
             }
         },
         "node_modules/oxc-resolver": {
-            "version": "11.21.3",
-            "resolved": "https://registry.npmjs.org/oxc-resolver/-/oxc-resolver-11.21.3.tgz",
-            "integrity": "sha512-2Mx3fKQz7+xgrBONjsxOgCGtMHOn38/HxMzW1I5efwXB5a4lRN0Vp40gYUJFBWJslcrvwoofTrqoTnLbwTd3pA==",
+            "version": "11.23.0",
+            "resolved": "https://registry.npmjs.org/oxc-resolver/-/oxc-resolver-11.23.0.tgz",
+            "integrity": "sha512-f0+l598CJMOLnYPXsXxttJALH0ljtivdRMKtvHhxRuWa5FYmw5+qODARl8oYjMC/brpzKcrpdORsOBrTqhBZ9A==",
             "license": "MIT",
             "funding": {
                 "url": "https://github.com/sponsors/Boshen"
             },
             "optionalDependencies": {
-                "@oxc-resolver/binding-android-arm-eabi": "11.21.3",
-                "@oxc-resolver/binding-android-arm64": "11.21.3",
-                "@oxc-resolver/binding-darwin-arm64": "11.21.3",
-                "@oxc-resolver/binding-darwin-x64": "11.21.3",
-                "@oxc-resolver/binding-freebsd-x64": "11.21.3",
-                "@oxc-resolver/binding-linux-arm-gnueabihf": "11.21.3",
-                "@oxc-resolver/binding-linux-arm-musleabihf": "11.21.3",
-                "@oxc-resolver/binding-linux-arm64-gnu": "11.21.3",
-                "@oxc-resolver/binding-linux-arm64-musl": "11.21.3",
-                "@oxc-resolver/binding-linux-ppc64-gnu": "11.21.3",
-                "@oxc-resolver/binding-linux-riscv64-gnu": "11.21.3",
-                "@oxc-resolver/binding-linux-riscv64-musl": "11.21.3",
-                "@oxc-resolver/binding-linux-s390x-gnu": "11.21.3",
-                "@oxc-resolver/binding-linux-x64-gnu": "11.21.3",
-                "@oxc-resolver/binding-linux-x64-musl": "11.21.3",
-                "@oxc-resolver/binding-openharmony-arm64": "11.21.3",
-                "@oxc-resolver/binding-wasm32-wasi": "11.21.3",
-                "@oxc-resolver/binding-win32-arm64-msvc": "11.21.3",
-                "@oxc-resolver/binding-win32-x64-msvc": "11.21.3"
+                "@oxc-resolver/binding-android-arm-eabi": "11.23.0",
+                "@oxc-resolver/binding-android-arm64": "11.23.0",
+                "@oxc-resolver/binding-darwin-arm64": "11.23.0",
+                "@oxc-resolver/binding-darwin-x64": "11.23.0",
+                "@oxc-resolver/binding-freebsd-x64": "11.23.0",
+                "@oxc-resolver/binding-linux-arm-gnueabihf": "11.23.0",
+                "@oxc-resolver/binding-linux-arm-musleabihf": "11.23.0",
+                "@oxc-resolver/binding-linux-arm64-gnu": "11.23.0",
+                "@oxc-resolver/binding-linux-arm64-musl": "11.23.0",
+                "@oxc-resolver/binding-linux-ppc64-gnu": "11.23.0",
+                "@oxc-resolver/binding-linux-riscv64-gnu": "11.23.0",
+                "@oxc-resolver/binding-linux-riscv64-musl": "11.23.0",
+                "@oxc-resolver/binding-linux-s390x-gnu": "11.23.0",
+                "@oxc-resolver/binding-linux-x64-gnu": "11.23.0",
+                "@oxc-resolver/binding-linux-x64-musl": "11.23.0",
+                "@oxc-resolver/binding-openharmony-arm64": "11.23.0",
+                "@oxc-resolver/binding-wasm32-wasi": "11.23.0",
+                "@oxc-resolver/binding-win32-arm64-msvc": "11.23.0",
+                "@oxc-resolver/binding-win32-x64-msvc": "11.23.0"
+            }
+        },
+        "node_modules/oxc-walker": {
+            "version": "0.7.0",
+            "resolved": "https://registry.npmjs.org/oxc-walker/-/oxc-walker-0.7.0.tgz",
+            "integrity": "sha512-54B4KUhrzbzc4sKvKwVYm7E2PgeROpGba0/2nlNZMqfDyca+yOor5IMb4WLGBatGDT0nkzYdYuzylg7n3YfB7A==",
+            "license": "MIT",
+            "dependencies": {
+                "magic-regexp": "^0.10.0"
+            },
+            "peerDependencies": {
+                "oxc-parser": ">=0.98.0"
             }
         },
         "node_modules/oxlint": {
-            "version": "1.71.0",
-            "resolved": "https://registry.npmjs.org/oxlint/-/oxlint-1.71.0.tgz",
-            "integrity": "sha512-U1m1X+C0vDj7DC1e13IoZULzEcPczE7UOMTs8VlZGHUEIUaSTZKo5qkPsQEfzpgnQ29Pea/w3Xntk62UCecxZw==",
+            "version": "1.73.0",
+            "resolved": "https://registry.npmjs.org/oxlint/-/oxlint-1.73.0.tgz",
+            "integrity": "sha512-u91G9TJzU6yqKWNZUYprQB07W7YvntZXaRxQ6CkoytepYhLWUXWsr1M8zUJ34VatNPuUAr3Z8GH+O2A331CluQ==",
             "license": "MIT",
             "bin": {
                 "oxlint": "bin/oxlint"
@@ -13708,28 +14535,28 @@
                 "url": "https://github.com/sponsors/Boshen"
             },
             "optionalDependencies": {
-                "@oxlint/binding-android-arm-eabi": "1.71.0",
-                "@oxlint/binding-android-arm64": "1.71.0",
-                "@oxlint/binding-darwin-arm64": "1.71.0",
-                "@oxlint/binding-darwin-x64": "1.71.0",
-                "@oxlint/binding-freebsd-x64": "1.71.0",
-                "@oxlint/binding-linux-arm-gnueabihf": "1.71.0",
-                "@oxlint/binding-linux-arm-musleabihf": "1.71.0",
-                "@oxlint/binding-linux-arm64-gnu": "1.71.0",
-                "@oxlint/binding-linux-arm64-musl": "1.71.0",
-                "@oxlint/binding-linux-ppc64-gnu": "1.71.0",
-                "@oxlint/binding-linux-riscv64-gnu": "1.71.0",
-                "@oxlint/binding-linux-riscv64-musl": "1.71.0",
-                "@oxlint/binding-linux-s390x-gnu": "1.71.0",
-                "@oxlint/binding-linux-x64-gnu": "1.71.0",
-                "@oxlint/binding-linux-x64-musl": "1.71.0",
-                "@oxlint/binding-openharmony-arm64": "1.71.0",
-                "@oxlint/binding-win32-arm64-msvc": "1.71.0",
-                "@oxlint/binding-win32-ia32-msvc": "1.71.0",
-                "@oxlint/binding-win32-x64-msvc": "1.71.0"
+                "@oxlint/binding-android-arm-eabi": "1.73.0",
+                "@oxlint/binding-android-arm64": "1.73.0",
+                "@oxlint/binding-darwin-arm64": "1.73.0",
+                "@oxlint/binding-darwin-x64": "1.73.0",
+                "@oxlint/binding-freebsd-x64": "1.73.0",
+                "@oxlint/binding-linux-arm-gnueabihf": "1.73.0",
+                "@oxlint/binding-linux-arm-musleabihf": "1.73.0",
+                "@oxlint/binding-linux-arm64-gnu": "1.73.0",
+                "@oxlint/binding-linux-arm64-musl": "1.73.0",
+                "@oxlint/binding-linux-ppc64-gnu": "1.73.0",
+                "@oxlint/binding-linux-riscv64-gnu": "1.73.0",
+                "@oxlint/binding-linux-riscv64-musl": "1.73.0",
+                "@oxlint/binding-linux-s390x-gnu": "1.73.0",
+                "@oxlint/binding-linux-x64-gnu": "1.73.0",
+                "@oxlint/binding-linux-x64-musl": "1.73.0",
+                "@oxlint/binding-openharmony-arm64": "1.73.0",
+                "@oxlint/binding-win32-arm64-msvc": "1.73.0",
+                "@oxlint/binding-win32-ia32-msvc": "1.73.0",
+                "@oxlint/binding-win32-x64-msvc": "1.73.0"
             },
             "peerDependencies": {
-                "oxlint-tsgolint": ">=0.22.1",
+                "oxlint-tsgolint": ">=0.24.0",
                 "vite-plus": "*"
             },
             "peerDependenciesMeta": {
@@ -13791,9 +14618,9 @@
             "license": "BlueOak-1.0.0"
         },
         "node_modules/package-manager-detector": {
-            "version": "1.6.0",
-            "resolved": "https://registry.npmjs.org/package-manager-detector/-/package-manager-detector-1.6.0.tgz",
-            "integrity": "sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA==",
+            "version": "1.7.0",
+            "resolved": "https://registry.npmjs.org/package-manager-detector/-/package-manager-detector-1.7.0.tgz",
+            "integrity": "sha512-xg1eHpwYL/D/HEdWw2goFZP6vV0FH7W+PZ5rFkGjdIDLtxq7EkzBUeT3m+lndYCt8wKbmofUu1MUdMCXkCk9ZQ==",
             "license": "MIT"
         },
         "node_modules/parent-module": {
@@ -13993,9 +14820,9 @@
             "license": "ISC"
         },
         "node_modules/picomatch": {
-            "version": "4.0.4",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-            "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+            "version": "4.0.5",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+            "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
             "license": "MIT",
             "engines": {
                 "node": ">=12"
@@ -14176,25 +15003,25 @@
             }
         },
         "node_modules/posthog-js": {
-            "version": "1.396.1",
-            "resolved": "https://registry.npmjs.org/posthog-js/-/posthog-js-1.396.1.tgz",
-            "integrity": "sha512-bwwTP15ZmE+TYkaEYQ9j1atHnafT/zJAsX2lqqiqZxaw0H2Ga4E6qh/nkR5rKf/GmQIAeGw5iYDeg7b3GVzMVg==",
-            "license": "SEE LICENSE IN LICENSE",
+            "version": "1.398.6",
+            "resolved": "https://registry.npmjs.org/posthog-js/-/posthog-js-1.398.6.tgz",
+            "integrity": "sha512-T86lyZ4Eqn0d0a1CJ9dTc+c1eVNw5qQb1JeomvTueYJ23JXYLEva4m9K/epFRoMtD3iqZ7tDD1jzRoaRH7wycA==",
+            "license": "(Apache-2.0 AND MIT)",
             "dependencies": {
-                "@posthog/core": "^1.38.1",
-                "@posthog/types": "^1.392.0",
-                "core-js": "^3.38.1",
+                "@posthog/core": "^1.39.6",
+                "@posthog/types": "^1.392.1",
+                "core-js": "^3.49.0",
                 "dompurify": "^3.3.2",
                 "fflate": "^0.4.8",
-                "preact": "^10.29.2",
+                "preact": "^10.29.3",
                 "query-selector-shadow-dom": "^1.0.1",
                 "web-vitals": "^5.3.0"
             }
         },
         "node_modules/preact": {
-            "version": "10.29.3",
-            "resolved": "https://registry.npmjs.org/preact/-/preact-10.29.3.tgz",
-            "integrity": "sha512-D9NL1GAnJZhc3RndVs4gDdxEeU9TcHgywMrhhOsnpdlvFjdbx0gAsLUnH6JEhlJH5giL7Tx5biWPUSEXE/HPzw==",
+            "version": "10.29.6",
+            "resolved": "https://registry.npmjs.org/preact/-/preact-10.29.6.tgz",
+            "integrity": "sha512-/UzLXnc1jrAS2uHi89XsSECqXVHYzV1VUL1L3esxrmPRmDvKFWtmbabE2a4QQ5a3bLgBivubRCEOt4GGmncPBQ==",
             "license": "MIT",
             "funding": {
                 "type": "opencollective",
@@ -14211,9 +15038,9 @@
             }
         },
         "node_modules/prettier": {
-            "version": "3.9.3",
-            "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.3.tgz",
-            "integrity": "sha512-HWmu+K+zvHNpaMfSnYeqdqrDbR16cuIXaPx8WoHaviQkDJh1/0BNtOZmHVQI5jc3wXv0H1yXc9wjvFdXh+n3hQ==",
+            "version": "3.9.4",
+            "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.4.tgz",
+            "integrity": "sha512-yWG/o/4oJfo036EKAfK6ACAoDOfHeRHx4tuxkfBZiauURiaSmYwlpOr5LQqKtIkRD2z1PLteme2WoxEnj4tHTg==",
             "license": "MIT",
             "bin": {
                 "prettier": "bin/prettier.cjs"
@@ -14288,9 +15115,9 @@
             "license": "ISC"
         },
         "node_modules/protobufjs": {
-            "version": "7.6.4",
-            "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.4.tgz",
-            "integrity": "sha512-RJJPTTpvFfHcWLkIa2JFWK4XvtSzS0yEWDmunqHXli1h3JlkbcQZXDZdcWxv+JK3Xsl5/UFDPZ0iGm7DAengYw==",
+            "version": "7.6.5",
+            "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.5.tgz",
+            "integrity": "sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==",
             "hasInstallScript": true,
             "license": "BSD-3-Clause",
             "dependencies": {
@@ -14541,6 +15368,18 @@
                 "node": ">=18.16.0"
             }
         },
+        "node_modules/rapidoc/node_modules/marked": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/marked/-/marked-4.3.0.tgz",
+            "integrity": "sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==",
+            "license": "MIT",
+            "bin": {
+                "marked": "bin/marked.js"
+            },
+            "engines": {
+                "node": ">= 12"
+            }
+        },
         "node_modules/react": {
             "version": "19.2.7",
             "resolved": "https://registry.npmjs.org/react/-/react-19.2.7.tgz",
@@ -14635,6 +15474,15 @@
             "resolved": "https://registry.npmjs.org/regex-utilities/-/regex-utilities-2.3.0.tgz",
             "integrity": "sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng==",
             "license": "MIT"
+        },
+        "node_modules/regexp-tree": {
+            "version": "0.1.27",
+            "resolved": "https://registry.npmjs.org/regexp-tree/-/regexp-tree-0.1.27.tgz",
+            "integrity": "sha512-iETxpjK6YoRWJG5o6hXLwvjYAoW+FEZn9os0PD/b6AP6xQwsa/Y7lCVgIixBbUPMfhu+i2LtdeAqVTgGlQarfA==",
+            "license": "MIT",
+            "bin": {
+                "regexp-tree": "bin/regexp-tree"
+            }
         },
         "node_modules/remark-directive": {
             "version": "4.0.0",
@@ -14736,17 +15584,21 @@
             }
         },
         "node_modules/resolve": {
-            "version": "1.22.8",
-            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
-            "integrity": "sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==",
+            "version": "1.22.12",
+            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
+            "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
             "license": "MIT",
             "dependencies": {
-                "is-core-module": "^2.13.0",
+                "es-errors": "^1.3.0",
+                "is-core-module": "^2.16.1",
                 "path-parse": "^1.0.7",
                 "supports-preserve-symlinks-flag": "^1.0.0"
             },
             "bin": {
                 "resolve": "bin/resolve"
+            },
+            "engines": {
+                "node": ">= 0.4"
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
@@ -14778,7 +15630,6 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
             "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
-            "dev": true,
             "license": "MIT",
             "funding": {
                 "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
@@ -14861,9 +15712,9 @@
             }
         },
         "node_modules/rimraf/node_modules/lru-cache": {
-            "version": "11.5.1",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
-            "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
+            "version": "11.5.2",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+            "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
             "license": "BlueOak-1.0.0",
             "engines": {
                 "node": "20 || >=22"
@@ -14892,12 +15743,12 @@
             "license": "Unlicense"
         },
         "node_modules/rolldown": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.4.tgz",
-            "integrity": "sha512-IjZYiLxZwpnhwhdBH2ugdTGVSdhCQUmLxLoqyjiL0JxYjyRst+5a0P3xfrTxJ5F638j4Mvvw5FAX5XE6eHpXbA==",
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.5.tgz",
+            "integrity": "sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA==",
             "license": "MIT",
             "dependencies": {
-                "@oxc-project/types": "=0.138.0",
+                "@oxc-project/types": "=0.139.0",
                 "@rolldown/pluginutils": "^1.0.0"
             },
             "bin": {
@@ -14907,27 +15758,27 @@
                 "node": "^20.19.0 || >=22.12.0"
             },
             "optionalDependencies": {
-                "@rolldown/binding-android-arm64": "1.1.4",
-                "@rolldown/binding-darwin-arm64": "1.1.4",
-                "@rolldown/binding-darwin-x64": "1.1.4",
-                "@rolldown/binding-freebsd-x64": "1.1.4",
-                "@rolldown/binding-linux-arm-gnueabihf": "1.1.4",
-                "@rolldown/binding-linux-arm64-gnu": "1.1.4",
-                "@rolldown/binding-linux-arm64-musl": "1.1.4",
-                "@rolldown/binding-linux-ppc64-gnu": "1.1.4",
-                "@rolldown/binding-linux-s390x-gnu": "1.1.4",
-                "@rolldown/binding-linux-x64-gnu": "1.1.4",
-                "@rolldown/binding-linux-x64-musl": "1.1.4",
-                "@rolldown/binding-openharmony-arm64": "1.1.4",
-                "@rolldown/binding-wasm32-wasi": "1.1.4",
-                "@rolldown/binding-win32-arm64-msvc": "1.1.4",
-                "@rolldown/binding-win32-x64-msvc": "1.1.4"
+                "@rolldown/binding-android-arm64": "1.1.5",
+                "@rolldown/binding-darwin-arm64": "1.1.5",
+                "@rolldown/binding-darwin-x64": "1.1.5",
+                "@rolldown/binding-freebsd-x64": "1.1.5",
+                "@rolldown/binding-linux-arm-gnueabihf": "1.1.5",
+                "@rolldown/binding-linux-arm64-gnu": "1.1.5",
+                "@rolldown/binding-linux-arm64-musl": "1.1.5",
+                "@rolldown/binding-linux-ppc64-gnu": "1.1.5",
+                "@rolldown/binding-linux-s390x-gnu": "1.1.5",
+                "@rolldown/binding-linux-x64-gnu": "1.1.5",
+                "@rolldown/binding-linux-x64-musl": "1.1.5",
+                "@rolldown/binding-openharmony-arm64": "1.1.5",
+                "@rolldown/binding-wasm32-wasi": "1.1.5",
+                "@rolldown/binding-win32-arm64-msvc": "1.1.5",
+                "@rolldown/binding-win32-x64-msvc": "1.1.5"
             }
         },
         "node_modules/rolldown/node_modules/@oxc-project/types": {
-            "version": "0.138.0",
-            "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.138.0.tgz",
-            "integrity": "sha512-1a7ZKmrRTCoN1XMZ4L0PyyqrMnrNlLyPuOkdSX2MZg7IiIGRUyurNhAm73ptDOraoBcIordsIGKNPKUzy3ZmfA==",
+            "version": "0.139.0",
+            "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.139.0.tgz",
+            "integrity": "sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw==",
             "license": "MIT",
             "funding": {
                 "url": "https://github.com/sponsors/Boshen"
@@ -15607,17 +16458,17 @@
             }
         },
         "node_modules/shiki": {
-            "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/shiki/-/shiki-4.3.0.tgz",
-            "integrity": "sha512-NKKjWzR6LIGL3sXBrWDw9sDS9cxx42/DkysaNqJEeOWE8Kix5gpak0bc00OfDVEO4oyXSyz8+aRaqKoBD1yo7A==",
+            "version": "4.3.1",
+            "resolved": "https://registry.npmjs.org/shiki/-/shiki-4.3.1.tgz",
+            "integrity": "sha512-oR+qDVi2OjX1tmDpyv+3KviX01KzO6Af+0NNnKnsp9491UEGz2YpxTuJboS/6VhYpTdqzmuJBuiTlrAWWJAssw==",
             "license": "MIT",
             "dependencies": {
-                "@shikijs/core": "4.3.0",
-                "@shikijs/engine-javascript": "4.3.0",
-                "@shikijs/engine-oniguruma": "4.3.0",
-                "@shikijs/langs": "4.3.0",
-                "@shikijs/themes": "4.3.0",
-                "@shikijs/types": "4.3.0",
+                "@shikijs/core": "4.3.1",
+                "@shikijs/engine-javascript": "4.3.1",
+                "@shikijs/engine-oniguruma": "4.3.1",
+                "@shikijs/langs": "4.3.1",
+                "@shikijs/themes": "4.3.1",
+                "@shikijs/types": "4.3.1",
                 "@shikijs/vscode-textmate": "^10.0.2",
                 "@types/hast": "^3.0.4"
             },
@@ -15761,9 +16612,9 @@
             "license": "MIT"
         },
         "node_modules/std-env": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
-            "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+            "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
             "license": "MIT"
         },
         "node_modules/storybook": {
@@ -16156,6 +17007,12 @@
                 "url": "https://opencollective.com/webpack"
             }
         },
+        "node_modules/text-table": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+            "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
+            "license": "MIT"
+        },
         "node_modules/tiny-invariant": {
             "version": "1.3.3",
             "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
@@ -16212,21 +17069,21 @@
             }
         },
         "node_modules/tldts": {
-            "version": "7.4.5",
-            "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.5.tgz",
-            "integrity": "sha512-RfEzKWcq5fHUOFq7J3rl3Oz6ylKGtcHqUznzj4EcXsxLSIjJcvpbXAQtWGeJQ0xKnimR5e0Cn+cn9TssfMzm+g==",
+            "version": "7.4.7",
+            "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.7.tgz",
+            "integrity": "sha512-56L0/9HELHSsG1bFCzay8UoLxzRL7kpFf7Wl5q/kSYwiSJGACvro61xnKzPNM+SadxllzdtXsKDSXE7HPeqIAw==",
             "license": "MIT",
             "dependencies": {
-                "tldts-core": "^7.4.5"
+                "tldts-core": "^7.4.7"
             },
             "bin": {
                 "tldts": "bin/cli.js"
             }
         },
         "node_modules/tldts-core": {
-            "version": "7.4.5",
-            "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.5.tgz",
-            "integrity": "sha512-pGrwzZDvPwKe+7NNUqAunb6rqTfynr0VOUhCMdqbu5xlvNiszsAJygRzwvpVycdzejlbpY+SWJOn+s75Og7FEA==",
+            "version": "7.4.7",
+            "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.7.tgz",
+            "integrity": "sha512-rNlAI8fKn/JckBMUSbNL/ES2kmDiurWaE49l+ikwEc9A6lFR7gMx9AhgQMQKBK4H5w4pKLH64JzZfB99uRsGNQ==",
             "license": "MIT"
         },
         "node_modules/tmp": {
@@ -16266,9 +17123,9 @@
             }
         },
         "node_modules/tough-cookie": {
-            "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
-            "integrity": "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==",
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.2.tgz",
+            "integrity": "sha512-exgYmnmL/sJpR3upZfXG5PoatXQii55xAiXGXzY+sROLZ/Y+SLcp9PgJNI9Vz37HpQ74WvDcLT8eqm+kV3FzrA==",
             "license": "BSD-3-Clause",
             "dependencies": {
                 "tldts": "^7.0.5"
@@ -16498,9 +17355,9 @@
             }
         },
         "node_modules/type-fest": {
-            "version": "5.7.0",
-            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.7.0.tgz",
-            "integrity": "sha512-1URUxUqfHFM1c+zfSPsa3gnkO7Aq21qyH75SIduNYz4SzY964rn1X2vCMQaHSHhktiw+0kPa2iyb6PUpXqB6Vg==",
+            "version": "5.8.0",
+            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.8.0.tgz",
+            "integrity": "sha512-YGYEVz3Fm5iy/AybuA0oyNFq7H4CgQNfRp/qfe8nurE1kuCeNm3/vfm9X4Mtl+qLyaKJUh5xrFZwogr41SMjYA==",
             "license": "(MIT OR CC0-1.0)",
             "dependencies": {
                 "tagged-tag": "^1.0.0"
@@ -16512,6 +17369,12 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/type-level-regexp": {
+            "version": "0.1.17",
+            "resolved": "https://registry.npmjs.org/type-level-regexp/-/type-level-regexp-0.1.17.tgz",
+            "integrity": "sha512-wTk4DH3cxwk196uGLK/E9pE45aLfeKJacKmcEgEOA/q5dnPGNxXt0cfYdFxb57L+sEpf1oJH4Dnx/pnRcku9jg==",
+            "license": "MIT"
+        },
         "node_modules/types-ramda": {
             "version": "0.30.1",
             "resolved": "https://registry.npmjs.org/types-ramda/-/types-ramda-0.30.1.tgz",
@@ -16522,9 +17385,44 @@
             }
         },
         "node_modules/typescript": {
-            "version": "5.9.3",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-            "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-7.0.2.tgz",
+            "integrity": "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA==",
+            "license": "Apache-2.0",
+            "bin": {
+                "tsc": "bin/tsc"
+            },
+            "engines": {
+                "node": ">=16.20.0"
+            },
+            "optionalDependencies": {
+                "@typescript/typescript-aix-ppc64": "7.0.2",
+                "@typescript/typescript-darwin-arm64": "7.0.2",
+                "@typescript/typescript-darwin-x64": "7.0.2",
+                "@typescript/typescript-freebsd-arm64": "7.0.2",
+                "@typescript/typescript-freebsd-x64": "7.0.2",
+                "@typescript/typescript-linux-arm": "7.0.2",
+                "@typescript/typescript-linux-arm64": "7.0.2",
+                "@typescript/typescript-linux-loong64": "7.0.2",
+                "@typescript/typescript-linux-mips64el": "7.0.2",
+                "@typescript/typescript-linux-ppc64": "7.0.2",
+                "@typescript/typescript-linux-riscv64": "7.0.2",
+                "@typescript/typescript-linux-s390x": "7.0.2",
+                "@typescript/typescript-linux-x64": "7.0.2",
+                "@typescript/typescript-netbsd-arm64": "7.0.2",
+                "@typescript/typescript-netbsd-x64": "7.0.2",
+                "@typescript/typescript-openbsd-arm64": "7.0.2",
+                "@typescript/typescript-openbsd-x64": "7.0.2",
+                "@typescript/typescript-sunos-x64": "7.0.2",
+                "@typescript/typescript-win32-arm64": "7.0.2",
+                "@typescript/typescript-win32-x64": "7.0.2"
+            }
+        },
+        "node_modules/typescript6": {
+            "name": "typescript",
+            "version": "6.0.3",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+            "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
             "license": "Apache-2.0",
             "bin": {
                 "tsc": "bin/tsc",
@@ -16702,13 +17600,13 @@
             }
         },
         "node_modules/unplugin-utils": {
-            "version": "0.3.1",
-            "resolved": "https://registry.npmjs.org/unplugin-utils/-/unplugin-utils-0.3.1.tgz",
-            "integrity": "sha512-5lWVjgi6vuHhJ526bI4nlCOmkCIF3nnfXkCMDeMJrtdvxTs6ZFCM8oNufGTsDbKv/tJ/xj8RpvXjRuPBZJuJog==",
+            "version": "0.3.2",
+            "resolved": "https://registry.npmjs.org/unplugin-utils/-/unplugin-utils-0.3.2.tgz",
+            "integrity": "sha512-xVToRh2CTmLk2HnEG7ac4rl1MJTT3RFkpS8B++/SnB0kXvuaavD+n3m/vrzyWQOdJNSZQACnbz01pnppbwV5BA==",
             "license": "MIT",
             "dependencies": {
                 "pathe": "^2.0.3",
-                "picomatch": "^4.0.3"
+                "picomatch": "^4.0.4"
             },
             "engines": {
                 "node": ">=20.19.0"
@@ -16973,6 +17871,33 @@
                 "vscode-uri": "^3.0.8"
             }
         },
+        "node_modules/vite-plugin-dts/node_modules/@vue/language-core": {
+            "version": "3.3.7",
+            "resolved": "https://registry.npmjs.org/@vue/language-core/-/language-core-3.3.7.tgz",
+            "integrity": "sha512-LzmkKinXAMMoh8Jfi/jMUSDUjuPdv8mynH5WJGKfXyZtDw3hQ6GBaoI6Bcnl/Xqlu32q/0Z6i/trp4VXykzyLw==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "@volar/language-core": "2.4.28",
+                "@vue/compiler-dom": "^3.5.0",
+                "@vue/shared": "^3.5.0",
+                "alien-signals": "^3.2.1",
+                "muggle-string": "^0.4.1",
+                "path-browserify": "^1.0.1",
+                "picomatch": "^4.0.4"
+            }
+        },
+        "node_modules/vite-plugin-dts/node_modules/alien-signals": {
+            "version": "3.2.1",
+            "resolved": "https://registry.npmjs.org/alien-signals/-/alien-signals-3.2.1.tgz",
+            "integrity": "sha512-I8FjmltrfnDFoZedi5CG8DghVYNhzb/Ijluz7tCSJH0xpd0484Kowhbb1XDYOxfJpU1p5wnM2X54dA+IfGyD1g==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "peer": true
+        },
         "node_modules/vite-plugin-dts/node_modules/unplugin": {
             "version": "2.3.11",
             "resolved": "https://registry.npmjs.org/unplugin/-/unplugin-2.3.11.tgz",
@@ -17058,18 +17983,18 @@
             }
         },
         "node_modules/vitest": {
-            "version": "4.1.9",
-            "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.9.tgz",
-            "integrity": "sha512-nE3/LEyc0z87uHYLZebqCUOaJr2hdtuPp7BQ4BosVFnfltxgAvMG08NyrSGlPpOUWvR27c5flSmYFTNr78L9GQ==",
+            "version": "4.1.10",
+            "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.10.tgz",
+            "integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
             "license": "MIT",
             "dependencies": {
-                "@vitest/expect": "4.1.9",
-                "@vitest/mocker": "4.1.9",
-                "@vitest/pretty-format": "4.1.9",
-                "@vitest/runner": "4.1.9",
-                "@vitest/snapshot": "4.1.9",
-                "@vitest/spy": "4.1.9",
-                "@vitest/utils": "4.1.9",
+                "@vitest/expect": "4.1.10",
+                "@vitest/mocker": "4.1.10",
+                "@vitest/pretty-format": "4.1.10",
+                "@vitest/runner": "4.1.10",
+                "@vitest/snapshot": "4.1.10",
+                "@vitest/spy": "4.1.10",
+                "@vitest/utils": "4.1.10",
                 "es-module-lexer": "^2.0.0",
                 "expect-type": "^1.3.0",
                 "magic-string": "^0.30.21",
@@ -17097,12 +18022,12 @@
                 "@edge-runtime/vm": "*",
                 "@opentelemetry/api": "^1.9.0",
                 "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
-                "@vitest/browser-playwright": "4.1.9",
-                "@vitest/browser-preview": "4.1.9",
-                "@vitest/browser-webdriverio": "4.1.9",
-                "@vitest/coverage-istanbul": "4.1.9",
-                "@vitest/coverage-v8": "4.1.9",
-                "@vitest/ui": "4.1.9",
+                "@vitest/browser-playwright": "4.1.10",
+                "@vitest/browser-preview": "4.1.10",
+                "@vitest/browser-webdriverio": "4.1.10",
+                "@vitest/coverage-istanbul": "4.1.10",
+                "@vitest/coverage-v8": "4.1.10",
+                "@vitest/ui": "4.1.10",
                 "happy-dom": "*",
                 "jsdom": "*",
                 "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
@@ -17164,15 +18089,15 @@
             }
         },
         "node_modules/vitest/node_modules/@vitest/expect": {
-            "version": "4.1.9",
-            "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.9.tgz",
-            "integrity": "sha512-vl/rYsUKcBr3SnQn166+XR5ZQcgMx3DQhFWdfli/cWpLnLUmbxZvyrJZotLFUryib+LtArYMSTJ5RbQ57ZqrlA==",
+            "version": "4.1.10",
+            "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
+            "integrity": "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==",
             "license": "MIT",
             "dependencies": {
                 "@standard-schema/spec": "^1.1.0",
                 "@types/chai": "^5.2.2",
-                "@vitest/spy": "4.1.9",
-                "@vitest/utils": "4.1.9",
+                "@vitest/spy": "4.1.10",
+                "@vitest/utils": "4.1.10",
                 "chai": "^6.2.2",
                 "tinyrainbow": "^3.1.0"
             },
@@ -17199,21 +18124,21 @@
             }
         },
         "node_modules/vscode-jsonrpc": {
-            "version": "9.0.0",
-            "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-9.0.0.tgz",
-            "integrity": "sha512-+VvMmQPJhtvJ+8O+zu2JKIRiLxXF8NW7krWgyMGeOHrp4Cn23T5hc0v2LknNeopDOB70wghHAds7mKtcZ0I4Sg==",
+            "version": "9.0.1",
+            "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-9.0.1.tgz",
+            "integrity": "sha512-rfuA6T75H6m5EkbhtEPzre9pT0HPcDI2MMy4+nPFIBks5J8JBAUHD4tRYSgaBOijIEC7SRkC1kKyXTLqbmh9jw==",
             "license": "MIT",
             "engines": {
                 "node": ">=14.0.0"
             }
         },
         "node_modules/vscode-languageserver-protocol": {
-            "version": "3.18.1",
-            "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.18.1.tgz",
-            "integrity": "sha512-RTiiVHdpxpYcJVI5sq6S5TLjQ4WDR/rBrIWru+kPXe6sGQ9PFQ3GamrTKLvPqbR4ylr1SoodhmcqbFII0WXVuw==",
+            "version": "3.18.2",
+            "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.18.2.tgz",
+            "integrity": "sha512-XRyDbT0Pp3sSNti3JmxVEUMySWCSi1hhM+/KUlCy1hV1zmrqpM1OwO12EAki8blhmLuIMpaJrYbo0OzGVfK2Qg==",
             "license": "MIT",
             "dependencies": {
-                "vscode-jsonrpc": "9.0.0",
+                "vscode-jsonrpc": "9.0.1",
                 "vscode-languageserver-types": "3.18.0"
             }
         },
@@ -17283,9 +18208,9 @@
             "license": "MIT"
         },
         "node_modules/vue-component-type-helpers": {
-            "version": "3.3.5",
-            "resolved": "https://registry.npmjs.org/vue-component-type-helpers/-/vue-component-type-helpers-3.3.5.tgz",
-            "integrity": "sha512-Fe1jyPJoUGpJOYKOri44jduR7My4yYINOMJISuMAbmrs+L5LbIDUc8NTWZYY3EJLK0yPLuCmcd5zoCsE4k2/KA==",
+            "version": "3.3.7",
+            "resolved": "https://registry.npmjs.org/vue-component-type-helpers/-/vue-component-type-helpers-3.3.7.tgz",
+            "integrity": "sha512-Skkhw9agYSgsWqv7bxSOGJZa9SaiJbZVGdXuFWnrzKaQYHnw9qbjD630rw6RyMqDbp54nfLCLw5SZA55if7JLg==",
             "license": "MIT"
         },
         "node_modules/vue-docgen-api": {
@@ -17656,13 +18581,14 @@
             }
         },
         "node_modules/vue-tsc": {
-            "version": "3.3.5",
-            "resolved": "https://registry.npmjs.org/vue-tsc/-/vue-tsc-3.3.5.tgz",
-            "integrity": "sha512-Rzh/G2MmNlMSAMTiQEjDrsb4dgB/jbtEM47rVN2NtidF1dfb/q4w4QvpQBtW5+y3y5H27Hjh7deVwk+YB02fNg==",
+            "version": "3.2.9",
+            "resolved": "https://registry.npmjs.org/vue-tsc/-/vue-tsc-3.2.9.tgz",
+            "integrity": "sha512-qm8/nbo+9eZc1SCndm9wT+gq23pM+wRIdHY0wjm83B3lIginHTwcdrLUyTrKjDWXbMVNjKegNrnymhpdqnCL3A==",
+            "devOptional": true,
             "license": "MIT",
             "dependencies": {
                 "@volar/typescript": "2.4.28",
-                "@vue/language-core": "3.3.5"
+                "@vue/language-core": "3.2.9"
             },
             "bin": {
                 "vue-tsc": "bin/vue-tsc.js"
@@ -17675,6 +18601,7 @@
             "version": "2.4.28",
             "resolved": "https://registry.npmjs.org/@volar/language-core/-/language-core-2.4.28.tgz",
             "integrity": "sha512-w4qhIJ8ZSitgLAkVay6AbcnC7gP3glYM3fYwKV3srj8m494E3xtrCv6E+bWviiK/8hs6e6t1ij1s2Endql7vzQ==",
+            "devOptional": true,
             "license": "MIT",
             "dependencies": {
                 "@volar/source-map": "2.4.28"
@@ -17684,12 +18611,14 @@
             "version": "2.4.28",
             "resolved": "https://registry.npmjs.org/@volar/source-map/-/source-map-2.4.28.tgz",
             "integrity": "sha512-yX2BDBqJkRXfKw8my8VarTyjv48QwxdJtvRgUpNE5erCsgEUdI2DsLbpa+rOQVAJYshY99szEcRDmyHbF10ggQ==",
+            "devOptional": true,
             "license": "MIT"
         },
         "node_modules/vue-tsc/node_modules/@volar/typescript": {
             "version": "2.4.28",
             "resolved": "https://registry.npmjs.org/@volar/typescript/-/typescript-2.4.28.tgz",
             "integrity": "sha512-Ja6yvWrbis2QtN4ClAKreeUZPVYMARDYZl9LMEv1iQ1QdepB6wn0jTRxA9MftYmYa4DQ4k/DaSZpFPUfxl8giw==",
+            "devOptional": true,
             "license": "MIT",
             "dependencies": {
                 "@volar/language-core": "2.4.28",
@@ -17698,9 +18627,10 @@
             }
         },
         "node_modules/vue-tsc/node_modules/@vue/language-core": {
-            "version": "3.3.5",
-            "resolved": "https://registry.npmjs.org/@vue/language-core/-/language-core-3.3.5.tgz",
-            "integrity": "sha512-UkKu5nhX89fg4VhlG/FOeI10G3cj/7radKT/cy9BT4Q9qJmJlSTAc/dP63Xqs29aypN4f39xUV6PsLNk/dcD6g==",
+            "version": "3.2.9",
+            "resolved": "https://registry.npmjs.org/@vue/language-core/-/language-core-3.2.9.tgz",
+            "integrity": "sha512-ie0ojt/0fU/GfIogh+zgHbaYRPlt9S+cLOxcWwF7nTSFh897BVgnFKL2byT4kpp1mlqYWZ2psGwSniyE2xsxYw==",
+            "devOptional": true,
             "license": "MIT",
             "dependencies": {
                 "@volar/language-core": "2.4.28",
@@ -17716,7 +18646,482 @@
             "version": "3.2.1",
             "resolved": "https://registry.npmjs.org/alien-signals/-/alien-signals-3.2.1.tgz",
             "integrity": "sha512-I8FjmltrfnDFoZedi5CG8DghVYNhzb/Ijluz7tCSJH0xpd0484Kowhbb1XDYOxfJpU1p5wnM2X54dA+IfGyD1g==",
+            "devOptional": true,
             "license": "MIT"
+        },
+        "node_modules/vue-tsgo": {
+            "version": "0.2.2",
+            "resolved": "https://registry.npmjs.org/vue-tsgo/-/vue-tsgo-0.2.2.tgz",
+            "integrity": "sha512-rdpWiVlJ462hjJGqUTkeYvJkMYUMdL0/j4JF/LqqTCDXeLRbhZB670t5agx6+ZMpzq116exxde26hxufNgkiPQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@vue/compiler-dom": "^3.5.33",
+                "@vue/language-core": "^3.2.8",
+                "@vue/shared": "^3.5.33",
+                "clerc": "^1.3.1",
+                "empathic": "^2.0.0",
+                "get-tsconfig": "5.0.0-beta.5",
+                "mlly": "^1.8.2",
+                "muggle-string": "^0.4.1",
+                "oxc-parser": "^0.129.0",
+                "oxc-resolver": "^11.19.1",
+                "oxc-walker": "^0.7.0",
+                "pathe": "^2.0.3",
+                "vscode-jsonrpc": "9.0.0-next.11"
+            },
+            "bin": {
+                "vue-tsgo": "dist/cli.mjs"
+            },
+            "engines": {
+                "node": ">=22.12.0"
+            },
+            "peerDependencies": {
+                "@typescript/native-preview": "*"
+            }
+        },
+        "node_modules/vue-tsgo/node_modules/@emnapi/core": {
+            "version": "1.10.0",
+            "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+            "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "@emnapi/wasi-threads": "1.2.1",
+                "tslib": "^2.4.0"
+            }
+        },
+        "node_modules/vue-tsgo/node_modules/@emnapi/runtime": {
+            "version": "1.10.0",
+            "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+            "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "tslib": "^2.4.0"
+            }
+        },
+        "node_modules/vue-tsgo/node_modules/@emnapi/wasi-threads": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+            "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "tslib": "^2.4.0"
+            }
+        },
+        "node_modules/vue-tsgo/node_modules/@oxc-parser/binding-android-arm-eabi": {
+            "version": "0.129.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-android-arm-eabi/-/binding-android-arm-eabi-0.129.0.tgz",
+            "integrity": "sha512-sG37CfXLlYXdDrggAFO/mKcO4w36piwf862xAZXIuf3nzKhWK1FvW4dqie+06++z+mDto2QeOQSvhyzBeK5jsQ==",
+            "cpu": [
+                "arm"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/vue-tsgo/node_modules/@oxc-parser/binding-android-arm64": {
+            "version": "0.129.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-android-arm64/-/binding-android-arm64-0.129.0.tgz",
+            "integrity": "sha512-DVyLFN2+S0VOhT6lm5++tFqlu3x2Njiby6y5DhTzjV5uRsZWpifsBn6+yjtwAxl105peEjs5BHE3ToBJuQjLTg==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/vue-tsgo/node_modules/@oxc-parser/binding-darwin-arm64": {
+            "version": "0.129.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-darwin-arm64/-/binding-darwin-arm64-0.129.0.tgz",
+            "integrity": "sha512-QeqThtB8qax4IL+NFBWgshudyKkj5c076L8vyd8PCEx7U1wHyIbH49MEQ5J5iURFhUW5jiFmdnLKEwyOo0GAJA==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/vue-tsgo/node_modules/@oxc-parser/binding-darwin-x64": {
+            "version": "0.129.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-darwin-x64/-/binding-darwin-x64-0.129.0.tgz",
+            "integrity": "sha512-zn5+7nv4DlK4uFgblmhKm6xRV0QUHXOHyIDkjmhxJ53xSA9ahkb3pHNiHesNPXn/nK/VWU+C+Z6JYHdatZBh7g==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/vue-tsgo/node_modules/@oxc-parser/binding-freebsd-x64": {
+            "version": "0.129.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-freebsd-x64/-/binding-freebsd-x64-0.129.0.tgz",
+            "integrity": "sha512-SPTcDBiHWlgRpWFC1jnoi0sBWqCw4DFR+4b8+dV+NAhUu2ONERWyIVIOCfcE9a8BlvZsDCuXf3l/x7wQUs1Rsw==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/vue-tsgo/node_modules/@oxc-parser/binding-linux-arm-gnueabihf": {
+            "version": "0.129.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-0.129.0.tgz",
+            "integrity": "sha512-Rgc9+WNKLbc+chyDTXyyJ7gbgLo+ve27CrRnmIwGgucGflrBZbutge5jdPPegcgf46RrR4dkBbMCp0/x16mdig==",
+            "cpu": [
+                "arm"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/vue-tsgo/node_modules/@oxc-parser/binding-linux-arm-musleabihf": {
+            "version": "0.129.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-0.129.0.tgz",
+            "integrity": "sha512-YtSsJ51VysXqlO8Cs2mWTyXvxBRemTHj4WDQjXwKl0SAxh+CVrEdXrdH+RnjxLj3JCUMFeYuHs5c+/DImfbKkg==",
+            "cpu": [
+                "arm"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/vue-tsgo/node_modules/@oxc-parser/binding-linux-arm64-gnu": {
+            "version": "0.129.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.129.0.tgz",
+            "integrity": "sha512-9oK8iQr9KtgI5JhaJ+5IwiQsXEo6NuasFgovtJGrdK/RxbA0bO4YKRvVY7M+8lozUCVz1U7XrFFODv3emIOPRA==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/vue-tsgo/node_modules/@oxc-parser/binding-linux-arm64-musl": {
+            "version": "0.129.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.129.0.tgz",
+            "integrity": "sha512-GghE/bf9ZqgqZFxLacgP0ImVD6UiLKQOpvpgUoIsqjopu2ms/+p1L0d0Dv2Sck+8p0FbKS2WE3IjqmIlLbxJgA==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/vue-tsgo/node_modules/@oxc-parser/binding-linux-ppc64-gnu": {
+            "version": "0.129.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-0.129.0.tgz",
+            "integrity": "sha512-A2PW0UbERzKGV6fKX1zoe2Tkc1zVcEJSSPW9IUSKbZAPuPe+M5/5hTA+6fQbWmevabe2B3IDky66a1lFGjpBKA==",
+            "cpu": [
+                "ppc64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/vue-tsgo/node_modules/@oxc-parser/binding-linux-riscv64-gnu": {
+            "version": "0.129.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-0.129.0.tgz",
+            "integrity": "sha512-omwxd9H+jrl1T72RI666k4ho7Eli2iHdELzf+dL0D+uXThNZXYJCbKjm5rK2hrHmDy4O+NWv7+khBrEkorLsgw==",
+            "cpu": [
+                "riscv64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/vue-tsgo/node_modules/@oxc-parser/binding-linux-riscv64-musl": {
+            "version": "0.129.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-0.129.0.tgz",
+            "integrity": "sha512-v2hi8id+M8C0uY8uuG2t2a5vr8H9XyHXiHL12yMdMNtgn04nnM/8hlOGuoJuxVc07PhClNiaoSaY2eXehSRa7w==",
+            "cpu": [
+                "riscv64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/vue-tsgo/node_modules/@oxc-parser/binding-linux-s390x-gnu": {
+            "version": "0.129.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-0.129.0.tgz",
+            "integrity": "sha512-UXrdDyLh1Obgj5X+IVVXWoo5/FJbFsU8/uLQ/M9lkVUwBUKpRFxNEhzwBNv21qqdKgAh+pr2CCVD8J1JfRPsIQ==",
+            "cpu": [
+                "s390x"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/vue-tsgo/node_modules/@oxc-parser/binding-linux-x64-gnu": {
+            "version": "0.129.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.129.0.tgz",
+            "integrity": "sha512-hsL/3/kdX9FGLqOj8DR3Eki4Y6zO1i3+ZHhiPwX0hDt4n+18abkfUzePCv3h8SShprwCmwdxPnlrebZ5+MZ+cw==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/vue-tsgo/node_modules/@oxc-parser/binding-linux-x64-musl": {
+            "version": "0.129.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-x64-musl/-/binding-linux-x64-musl-0.129.0.tgz",
+            "integrity": "sha512-kdXvJ4crOeRld3vWl0J0VU4nmnT4pZ3lKGA5tZ1y0UPWsBtElDYd+jsz4lE36tpAbCiWm0M0PG0laUNBSE+Wlw==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/vue-tsgo/node_modules/@oxc-parser/binding-openharmony-arm64": {
+            "version": "0.129.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-openharmony-arm64/-/binding-openharmony-arm64-0.129.0.tgz",
+            "integrity": "sha512-DusJfcK7EGwf9TEakB+z6SXCLdHGvDZ8U8882bzWb4oVrORHpbkFl9npS7cN3YC2axcVKoktbxZevS1nxVCKFw==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openharmony"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/vue-tsgo/node_modules/@oxc-parser/binding-wasm32-wasi": {
+            "version": "0.129.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-wasm32-wasi/-/binding-wasm32-wasi-0.129.0.tgz",
+            "integrity": "sha512-Iie9CcII+ELSinKFnxTR15xhI9qriVivEhbFh3driRNbzms/5ioDAU0fwe8Mf1FEaz3n2FtiUVX0h0nwKLYk0A==",
+            "cpu": [
+                "wasm32"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "@emnapi/core": "1.10.0",
+                "@emnapi/runtime": "1.10.0",
+                "@napi-rs/wasm-runtime": "^1.1.4"
+            },
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/vue-tsgo/node_modules/@oxc-parser/binding-win32-arm64-msvc": {
+            "version": "0.129.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.129.0.tgz",
+            "integrity": "sha512-99kH1udLyrts+wGm+u0VhPbogkb2wxc/6J1XMKOpS6Kx5DjBWGRZZfBjfCGI3xKSInpYbZn4TLWLX1Q1GURYwg==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/vue-tsgo/node_modules/@oxc-parser/binding-win32-ia32-msvc": {
+            "version": "0.129.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-0.129.0.tgz",
+            "integrity": "sha512-tmSBR1A4yH697qV291xKyDe4OAWFchJ+cXf2wuipx/vK3n5d5Ej9MVLRtXlIcZ38n8qAjsF0/AnskaYgxM151A==",
+            "cpu": [
+                "ia32"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/vue-tsgo/node_modules/@oxc-parser/binding-win32-x64-msvc": {
+            "version": "0.129.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.129.0.tgz",
+            "integrity": "sha512-Z1PbJvkPeLASIUxa3AnrQ5H+vv1K9zC0IGnQqoKfM0ZvsvCSe0d3u5m7d9iuy+HB7GrcElHuwKb0d0qFdtG0iA==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/vue-tsgo/node_modules/@oxc-project/types": {
+            "version": "0.129.0",
+            "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.129.0.tgz",
+            "integrity": "sha512-3oz8m3FGdr2nDXVqmFUw7jolKliC4MoyXYIG2c7gpjBnzUWQpUGIYcXYKxTdTi+N2jusvt610ckTMkxdwHkYEg==",
+            "license": "MIT",
+            "funding": {
+                "url": "https://github.com/sponsors/Boshen"
+            }
+        },
+        "node_modules/vue-tsgo/node_modules/@volar/language-core": {
+            "version": "2.4.28",
+            "resolved": "https://registry.npmjs.org/@volar/language-core/-/language-core-2.4.28.tgz",
+            "integrity": "sha512-w4qhIJ8ZSitgLAkVay6AbcnC7gP3glYM3fYwKV3srj8m494E3xtrCv6E+bWviiK/8hs6e6t1ij1s2Endql7vzQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@volar/source-map": "2.4.28"
+            }
+        },
+        "node_modules/vue-tsgo/node_modules/@volar/source-map": {
+            "version": "2.4.28",
+            "resolved": "https://registry.npmjs.org/@volar/source-map/-/source-map-2.4.28.tgz",
+            "integrity": "sha512-yX2BDBqJkRXfKw8my8VarTyjv48QwxdJtvRgUpNE5erCsgEUdI2DsLbpa+rOQVAJYshY99szEcRDmyHbF10ggQ==",
+            "license": "MIT"
+        },
+        "node_modules/vue-tsgo/node_modules/@vue/language-core": {
+            "version": "3.3.7",
+            "resolved": "https://registry.npmjs.org/@vue/language-core/-/language-core-3.3.7.tgz",
+            "integrity": "sha512-LzmkKinXAMMoh8Jfi/jMUSDUjuPdv8mynH5WJGKfXyZtDw3hQ6GBaoI6Bcnl/Xqlu32q/0Z6i/trp4VXykzyLw==",
+            "license": "MIT",
+            "dependencies": {
+                "@volar/language-core": "2.4.28",
+                "@vue/compiler-dom": "^3.5.0",
+                "@vue/shared": "^3.5.0",
+                "alien-signals": "^3.2.1",
+                "muggle-string": "^0.4.1",
+                "path-browserify": "^1.0.1",
+                "picomatch": "^4.0.4"
+            }
+        },
+        "node_modules/vue-tsgo/node_modules/alien-signals": {
+            "version": "3.2.1",
+            "resolved": "https://registry.npmjs.org/alien-signals/-/alien-signals-3.2.1.tgz",
+            "integrity": "sha512-I8FjmltrfnDFoZedi5CG8DghVYNhzb/Ijluz7tCSJH0xpd0484Kowhbb1XDYOxfJpU1p5wnM2X54dA+IfGyD1g==",
+            "license": "MIT"
+        },
+        "node_modules/vue-tsgo/node_modules/oxc-parser": {
+            "version": "0.129.0",
+            "resolved": "https://registry.npmjs.org/oxc-parser/-/oxc-parser-0.129.0.tgz",
+            "integrity": "sha512-S6eFI+VLkpyA+/Lf8z6qURjDV6Mgo74SLNznNopHTlQW3hedv2MB/z31kBRuBCCTqZN9HHdva0ojljEhPnBKFA==",
+            "license": "MIT",
+            "dependencies": {
+                "@oxc-project/types": "^0.129.0"
+            },
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/Boshen"
+            },
+            "optionalDependencies": {
+                "@oxc-parser/binding-android-arm-eabi": "0.129.0",
+                "@oxc-parser/binding-android-arm64": "0.129.0",
+                "@oxc-parser/binding-darwin-arm64": "0.129.0",
+                "@oxc-parser/binding-darwin-x64": "0.129.0",
+                "@oxc-parser/binding-freebsd-x64": "0.129.0",
+                "@oxc-parser/binding-linux-arm-gnueabihf": "0.129.0",
+                "@oxc-parser/binding-linux-arm-musleabihf": "0.129.0",
+                "@oxc-parser/binding-linux-arm64-gnu": "0.129.0",
+                "@oxc-parser/binding-linux-arm64-musl": "0.129.0",
+                "@oxc-parser/binding-linux-ppc64-gnu": "0.129.0",
+                "@oxc-parser/binding-linux-riscv64-gnu": "0.129.0",
+                "@oxc-parser/binding-linux-riscv64-musl": "0.129.0",
+                "@oxc-parser/binding-linux-s390x-gnu": "0.129.0",
+                "@oxc-parser/binding-linux-x64-gnu": "0.129.0",
+                "@oxc-parser/binding-linux-x64-musl": "0.129.0",
+                "@oxc-parser/binding-openharmony-arm64": "0.129.0",
+                "@oxc-parser/binding-wasm32-wasi": "0.129.0",
+                "@oxc-parser/binding-win32-arm64-msvc": "0.129.0",
+                "@oxc-parser/binding-win32-ia32-msvc": "0.129.0",
+                "@oxc-parser/binding-win32-x64-msvc": "0.129.0"
+            }
+        },
+        "node_modules/vue-tsgo/node_modules/vscode-jsonrpc": {
+            "version": "9.0.0-next.11",
+            "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-9.0.0-next.11.tgz",
+            "integrity": "sha512-u6LElQNbSiE9OugEEmrUKwH6+8BpPz2S5MDHvQUqHL//I4Q8GPikKLOUf856UnbLkZdhxaPrExac1lA3XwpIPA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=14.0.0"
+            }
         },
         "node_modules/vue-virtual-scroller": {
             "version": "3.0.4",
@@ -17786,12 +19191,13 @@
             "license": "MIT"
         },
         "node_modules/whatwg-mimetype": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
-            "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
+            "integrity": "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==",
+            "devOptional": true,
             "license": "MIT",
             "engines": {
-                "node": ">=20"
+                "node": ">=12"
             }
         },
         "node_modules/whatwg-url": {
@@ -18177,7 +19583,7 @@
                 "sass": "^1.100.0",
                 "sass-embedded": "^1.99.0",
                 "storybook": "^10.3.1",
-                "tsdown": "^0.22.1",
+                "tsdown": "0.22.1",
                 "typescript": "^6.0.3",
                 "vite": "^8.0.14",
                 "vite-plugin-dts": "^5.0.1",
@@ -18185,7 +19591,8 @@
                 "vitest-browser-vue": "^2.1.0",
                 "vue-material-design-icons": "^5.3.1",
                 "vue-router": "^5.0.6",
-                "vue-tsc": "^3.2.8",
+                "vue-tsc": "3.2.9",
+                "vue-tsgo": "^0.2.2",
                 "yaml": "^2.8.2"
             },
             "peerDependencies": {
@@ -18281,108 +19688,10 @@
                 "node": "^22.18.0 || >=24.11.0"
             }
         },
-        "packages/design-system/node_modules/@storybook/addon-a11y": {
-            "version": "10.4.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@storybook/global": "^5.0.0",
-                "axe-core": "^4.2.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/storybook"
-            },
-            "peerDependencies": {
-                "storybook": "^10.4.1"
-            }
-        },
-        "packages/design-system/node_modules/@storybook/addon-docs": {
-            "version": "10.4.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@mdx-js/react": "^3.0.0",
-                "@storybook/csf-plugin": "10.4.1",
-                "@storybook/icons": "^2.0.2",
-                "@storybook/react-dom-shim": "10.4.1",
-                "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
-                "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
-                "ts-dedent": "^2.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/storybook"
-            },
-            "peerDependencies": {
-                "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
-                "storybook": "^10.4.1"
-            },
-            "peerDependenciesMeta": {
-                "@types/react": {
-                    "optional": true
-                }
-            }
-        },
-        "packages/design-system/node_modules/@storybook/csf-plugin": {
-            "version": "10.4.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "unplugin": "^2.3.5"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/storybook"
-            },
-            "peerDependencies": {
-                "esbuild": "*",
-                "rollup": "*",
-                "storybook": "^10.4.1",
-                "vite": "*",
-                "webpack": "*"
-            },
-            "peerDependenciesMeta": {
-                "esbuild": {
-                    "optional": true
-                },
-                "rollup": {
-                    "optional": true
-                },
-                "vite": {
-                    "optional": true
-                },
-                "webpack": {
-                    "optional": true
-                }
-            }
-        },
-        "packages/design-system/node_modules/@storybook/react-dom-shim": {
-            "version": "10.4.1",
-            "dev": true,
-            "license": "MIT",
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/storybook"
-            },
-            "peerDependencies": {
-                "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
-                "@types/react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
-                "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
-                "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
-                "storybook": "^10.4.1"
-            },
-            "peerDependenciesMeta": {
-                "@types/react": {
-                    "optional": true
-                },
-                "@types/react-dom": {
-                    "optional": true
-                }
-            }
-        },
         "packages/design-system/node_modules/@tsdown/css": {
             "version": "0.22.1",
+            "resolved": "https://registry.npmjs.org/@tsdown/css/-/css-0.22.1.tgz",
+            "integrity": "sha512-svCG1LXBEQl4I0rFzAcgL7eZ/2hU/qcJ7uAe1OYO/iThq0DioUqrJq54z0bjG8IdbNEV441IpupC7XTxDGUT0Q==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -18420,66 +19729,6 @@
                 "sass-embedded": {
                     "optional": true
                 }
-            }
-        },
-        "packages/design-system/node_modules/@volar/language-core": {
-            "version": "2.4.28",
-            "resolved": "https://registry.npmjs.org/@volar/language-core/-/language-core-2.4.28.tgz",
-            "integrity": "sha512-w4qhIJ8ZSitgLAkVay6AbcnC7gP3glYM3fYwKV3srj8m494E3xtrCv6E+bWviiK/8hs6e6t1ij1s2Endql7vzQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@volar/source-map": "2.4.28"
-            }
-        },
-        "packages/design-system/node_modules/@volar/source-map": {
-            "version": "2.4.28",
-            "resolved": "https://registry.npmjs.org/@volar/source-map/-/source-map-2.4.28.tgz",
-            "integrity": "sha512-yX2BDBqJkRXfKw8my8VarTyjv48QwxdJtvRgUpNE5erCsgEUdI2DsLbpa+rOQVAJYshY99szEcRDmyHbF10ggQ==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "packages/design-system/node_modules/@volar/typescript": {
-            "version": "2.4.28",
-            "resolved": "https://registry.npmjs.org/@volar/typescript/-/typescript-2.4.28.tgz",
-            "integrity": "sha512-Ja6yvWrbis2QtN4ClAKreeUZPVYMARDYZl9LMEv1iQ1QdepB6wn0jTRxA9MftYmYa4DQ4k/DaSZpFPUfxl8giw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@volar/language-core": "2.4.28",
-                "path-browserify": "^1.0.1",
-                "vscode-uri": "^3.0.8"
-            }
-        },
-        "packages/design-system/node_modules/@vue/language-core": {
-            "version": "3.2.9",
-            "resolved": "https://registry.npmjs.org/@vue/language-core/-/language-core-3.2.9.tgz",
-            "integrity": "sha512-ie0ojt/0fU/GfIogh+zgHbaYRPlt9S+cLOxcWwF7nTSFh897BVgnFKL2byT4kpp1mlqYWZ2psGwSniyE2xsxYw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@volar/language-core": "2.4.28",
-                "@vue/compiler-dom": "^3.5.0",
-                "@vue/shared": "^3.5.0",
-                "alien-signals": "^3.2.0",
-                "muggle-string": "^0.4.1",
-                "path-browserify": "^1.0.1",
-                "picomatch": "^4.0.4"
-            }
-        },
-        "packages/design-system/node_modules/alien-signals": {
-            "version": "3.2.1",
-            "resolved": "https://registry.npmjs.org/alien-signals/-/alien-signals-3.2.1.tgz",
-            "integrity": "sha512-I8FjmltrfnDFoZedi5CG8DghVYNhzb/Ijluz7tCSJH0xpd0484Kowhbb1XDYOxfJpU1p5wnM2X54dA+IfGyD1g==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "packages/design-system/node_modules/ansis": {
-            "version": "4.3.0",
-            "dev": true,
-            "license": "ISC",
-            "engines": {
-                "node": ">=14"
             }
         },
         "packages/design-system/node_modules/ast-kit": {
@@ -18528,6 +19777,8 @@
         },
         "packages/design-system/node_modules/empathic": {
             "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/empathic/-/empathic-2.0.1.tgz",
+            "integrity": "sha512-YGRs8knHhKHVShLkFET/rWAU8kmHbOV5LwN938RHI0pljAJ1Gf6SzXsSmRaEzcXTtOOmVqJ5+WtQPL5uigY50Q==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -18536,6 +19787,8 @@
         },
         "packages/design-system/node_modules/hookable": {
             "version": "6.1.1",
+            "resolved": "https://registry.npmjs.org/hookable/-/hookable-6.1.1.tgz",
+            "integrity": "sha512-U9LYDy1CwhMCnprUfeAZWZGByVbhd54hwepegYTK7Pi5NvqEj63ifz5z+xukznehT7i6NIZRu89Ay1AZmRsLEQ==",
             "dev": true,
             "license": "MIT"
         },
@@ -18583,27 +19836,10 @@
                 }
             }
         },
-        "packages/design-system/node_modules/sass": {
-            "version": "1.100.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "chokidar": "^5.0.0",
-                "immutable": "^5.1.5",
-                "source-map-js": ">=0.6.2 <2.0.0"
-            },
-            "bin": {
-                "sass": "sass.js"
-            },
-            "engines": {
-                "node": ">=20.19.0"
-            },
-            "optionalDependencies": {
-                "@parcel/watcher": "^2.4.1"
-            }
-        },
         "packages/design-system/node_modules/tsdown": {
             "version": "0.22.1",
+            "resolved": "https://registry.npmjs.org/tsdown/-/tsdown-0.22.1.tgz",
+            "integrity": "sha512-Ldx1jLyDFEzsN/fMBi2TBVaZe4fuEJhIiHjQhX0pV7oa5uYz5Imdivs5mNzEXOrMEtFRR6C9BQ2YqLoroffB+Q==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -18675,6 +19911,8 @@
         },
         "packages/design-system/node_modules/typescript": {
             "version": "6.0.3",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+            "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
             "dev": true,
             "license": "Apache-2.0",
             "bin": {
@@ -18685,37 +19923,6 @@
                 "node": ">=14.17"
             }
         },
-        "packages/design-system/node_modules/unplugin": {
-            "version": "2.3.11",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@jridgewell/remapping": "^2.3.5",
-                "acorn": "^8.15.0",
-                "picomatch": "^4.0.3",
-                "webpack-virtual-modules": "^0.6.2"
-            },
-            "engines": {
-                "node": ">=18.12.0"
-            }
-        },
-        "packages/design-system/node_modules/vue-tsc": {
-            "version": "3.2.9",
-            "resolved": "https://registry.npmjs.org/vue-tsc/-/vue-tsc-3.2.9.tgz",
-            "integrity": "sha512-qm8/nbo+9eZc1SCndm9wT+gq23pM+wRIdHY0wjm83B3lIginHTwcdrLUyTrKjDWXbMVNjKegNrnymhpdqnCL3A==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@volar/typescript": "2.4.28",
-                "@vue/language-core": "3.2.9"
-            },
-            "bin": {
-                "vue-tsc": "bin/vue-tsc.js"
-            },
-            "peerDependencies": {
-                "typescript": ">=5.0.0"
-            }
-        },
         "packages/slot-contracts": {
             "name": "@kestra-io/slot-contracts",
             "version": "0.0.0-dev",
@@ -18724,7 +19931,7 @@
             },
             "devDependencies": {
                 "ts-morph": "^28.0.0",
-                "tsdown": "^0.22.1"
+                "tsdown": "0.22.1"
             },
             "peerDependencies": {
                 "@kestra-io/kestra-sdk": "*"
@@ -18808,14 +20015,6 @@
                 "node": "^22.18.0 || >=24.11.0"
             }
         },
-        "packages/slot-contracts/node_modules/ansis": {
-            "version": "4.3.0",
-            "dev": true,
-            "license": "ISC",
-            "engines": {
-                "node": ">=14"
-            }
-        },
         "packages/slot-contracts/node_modules/ast-kit": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/ast-kit/-/ast-kit-3.0.0.tgz",
@@ -18862,6 +20061,8 @@
         },
         "packages/slot-contracts/node_modules/empathic": {
             "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/empathic/-/empathic-2.0.1.tgz",
+            "integrity": "sha512-YGRs8knHhKHVShLkFET/rWAU8kmHbOV5LwN938RHI0pljAJ1Gf6SzXsSmRaEzcXTtOOmVqJ5+WtQPL5uigY50Q==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -18870,6 +20071,8 @@
         },
         "packages/slot-contracts/node_modules/hookable": {
             "version": "6.1.1",
+            "resolved": "https://registry.npmjs.org/hookable/-/hookable-6.1.1.tgz",
+            "integrity": "sha512-U9LYDy1CwhMCnprUfeAZWZGByVbhd54hwepegYTK7Pi5NvqEj63ifz5z+xukznehT7i6NIZRu89Ay1AZmRsLEQ==",
             "dev": true,
             "license": "MIT"
         },
@@ -18919,6 +20122,8 @@
         },
         "packages/slot-contracts/node_modules/tsdown": {
             "version": "0.22.1",
+            "resolved": "https://registry.npmjs.org/tsdown/-/tsdown-0.22.1.tgz",
+            "integrity": "sha512-Ldx1jLyDFEzsN/fMBi2TBVaZe4fuEJhIiHjQhX0pV7oa5uYz5Imdivs5mNzEXOrMEtFRR6C9BQ2YqLoroffB+Q==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -18988,6 +20193,22 @@
                 }
             }
         },
+        "packages/slot-contracts/node_modules/typescript": {
+            "version": "6.0.3",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+            "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "optional": true,
+            "peer": true,
+            "bin": {
+                "tsc": "bin/tsc",
+                "tsserver": "bin/tsserver"
+            },
+            "engines": {
+                "node": ">=14.17"
+            }
+        },
         "packages/topology": {
             "name": "@kestra-io/topology",
             "version": "0.0.0-dev",
@@ -19005,13 +20226,14 @@
                 "@types/node": "^25.9.1",
                 "@vitejs/plugin-vue": "^6.0.7",
                 "sass-embedded": "^1.99.0",
-                "tsdown": "^0.22.1",
+                "tsdown": "0.22.1",
                 "typescript": "^6.0.3",
                 "vite": "^8.0.14",
                 "vitest": "^4.1.0",
                 "vue": "^3.5.0",
                 "vue-i18n": "^11.4.4",
-                "vue-tsc": "^3.2.8"
+                "vue-tsc": "3.2.9",
+                "vue-tsgo": "^0.2.2"
             },
             "peerDependencies": {
                 "@kestra-io/design-system": "*",
@@ -19108,66 +20330,6 @@
                 "node": "^22.18.0 || >=24.11.0"
             }
         },
-        "packages/topology/node_modules/@volar/language-core": {
-            "version": "2.4.28",
-            "resolved": "https://registry.npmjs.org/@volar/language-core/-/language-core-2.4.28.tgz",
-            "integrity": "sha512-w4qhIJ8ZSitgLAkVay6AbcnC7gP3glYM3fYwKV3srj8m494E3xtrCv6E+bWviiK/8hs6e6t1ij1s2Endql7vzQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@volar/source-map": "2.4.28"
-            }
-        },
-        "packages/topology/node_modules/@volar/source-map": {
-            "version": "2.4.28",
-            "resolved": "https://registry.npmjs.org/@volar/source-map/-/source-map-2.4.28.tgz",
-            "integrity": "sha512-yX2BDBqJkRXfKw8my8VarTyjv48QwxdJtvRgUpNE5erCsgEUdI2DsLbpa+rOQVAJYshY99szEcRDmyHbF10ggQ==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "packages/topology/node_modules/@volar/typescript": {
-            "version": "2.4.28",
-            "resolved": "https://registry.npmjs.org/@volar/typescript/-/typescript-2.4.28.tgz",
-            "integrity": "sha512-Ja6yvWrbis2QtN4ClAKreeUZPVYMARDYZl9LMEv1iQ1QdepB6wn0jTRxA9MftYmYa4DQ4k/DaSZpFPUfxl8giw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@volar/language-core": "2.4.28",
-                "path-browserify": "^1.0.1",
-                "vscode-uri": "^3.0.8"
-            }
-        },
-        "packages/topology/node_modules/@vue/language-core": {
-            "version": "3.2.9",
-            "resolved": "https://registry.npmjs.org/@vue/language-core/-/language-core-3.2.9.tgz",
-            "integrity": "sha512-ie0ojt/0fU/GfIogh+zgHbaYRPlt9S+cLOxcWwF7nTSFh897BVgnFKL2byT4kpp1mlqYWZ2psGwSniyE2xsxYw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@volar/language-core": "2.4.28",
-                "@vue/compiler-dom": "^3.5.0",
-                "@vue/shared": "^3.5.0",
-                "alien-signals": "^3.2.0",
-                "muggle-string": "^0.4.1",
-                "path-browserify": "^1.0.1",
-                "picomatch": "^4.0.4"
-            }
-        },
-        "packages/topology/node_modules/alien-signals": {
-            "version": "3.2.1",
-            "resolved": "https://registry.npmjs.org/alien-signals/-/alien-signals-3.2.1.tgz",
-            "integrity": "sha512-I8FjmltrfnDFoZedi5CG8DghVYNhzb/Ijluz7tCSJH0xpd0484Kowhbb1XDYOxfJpU1p5wnM2X54dA+IfGyD1g==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "packages/topology/node_modules/ansis": {
-            "version": "4.3.0",
-            "dev": true,
-            "license": "ISC",
-            "engines": {
-                "node": ">=14"
-            }
-        },
         "packages/topology/node_modules/ast-kit": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/ast-kit/-/ast-kit-3.0.0.tgz",
@@ -19214,6 +20376,8 @@
         },
         "packages/topology/node_modules/empathic": {
             "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/empathic/-/empathic-2.0.1.tgz",
+            "integrity": "sha512-YGRs8knHhKHVShLkFET/rWAU8kmHbOV5LwN938RHI0pljAJ1Gf6SzXsSmRaEzcXTtOOmVqJ5+WtQPL5uigY50Q==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -19222,6 +20386,8 @@
         },
         "packages/topology/node_modules/hookable": {
             "version": "6.1.1",
+            "resolved": "https://registry.npmjs.org/hookable/-/hookable-6.1.1.tgz",
+            "integrity": "sha512-U9LYDy1CwhMCnprUfeAZWZGByVbhd54hwepegYTK7Pi5NvqEj63ifz5z+xukznehT7i6NIZRu89Ay1AZmRsLEQ==",
             "dev": true,
             "license": "MIT"
         },
@@ -19271,6 +20437,8 @@
         },
         "packages/topology/node_modules/tsdown": {
             "version": "0.22.1",
+            "resolved": "https://registry.npmjs.org/tsdown/-/tsdown-0.22.1.tgz",
+            "integrity": "sha512-Ldx1jLyDFEzsN/fMBi2TBVaZe4fuEJhIiHjQhX0pV7oa5uYz5Imdivs5mNzEXOrMEtFRR6C9BQ2YqLoroffB+Q==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -19342,6 +20510,8 @@
         },
         "packages/topology/node_modules/typescript": {
             "version": "6.0.3",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+            "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
             "dev": true,
             "license": "Apache-2.0",
             "bin": {
@@ -19350,23 +20520,6 @@
             },
             "engines": {
                 "node": ">=14.17"
-            }
-        },
-        "packages/topology/node_modules/vue-tsc": {
-            "version": "3.2.9",
-            "resolved": "https://registry.npmjs.org/vue-tsc/-/vue-tsc-3.2.9.tgz",
-            "integrity": "sha512-qm8/nbo+9eZc1SCndm9wT+gq23pM+wRIdHY0wjm83B3lIginHTwcdrLUyTrKjDWXbMVNjKegNrnymhpdqnCL3A==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@volar/typescript": "2.4.28",
-                "@vue/language-core": "3.2.9"
-            },
-            "bin": {
-                "vue-tsc": "bin/vue-tsc.js"
-            },
-            "peerDependencies": {
-                "typescript": ">=5.0.0"
             }
         }
     }

--- a/ui/package.json
+++ b/ui/package.json
@@ -13,7 +13,7 @@
         "build:design": "npm run build --workspace=@kestra-io/design-system",
         "build:topology": "npm run build --workspace=@kestra-io/topology",
         "preview": "vite preview",
-        "check:types": "vue-tsc --build packages/design-system/tsconfig.app.json && echo \"design-system compiled\" \\\n && vue-tsc --build tsconfig.app.json && echo \"app checked\" \\\n && vue-tsc --project tsconfig.test.json && echo \"test checked\"",
+        "check:types": "vue-tsgo --build packages/design-system/tsconfig.app.json && echo \"design-system compiled\" \\\n && vue-tsgo --build tsconfig.app.json && echo \"app checked\" \\\n && vue-tsgo --project tsconfig.test.json && echo \"test checked\"",
         "test:lint": "oxlint src packages && eslint",
         "test:all": "vitest run --coverage",
         "test:unit": "vitest run --project=unit",
@@ -24,7 +24,7 @@
         "lint": "oxlint --fix src packages && eslint --fix",
         "storybook": "storybook dev -p 6006",
         "build-storybook": "storybook build",
-        "postinstall": "npx patch-package"
+        "postinstall": "npx patch-package && node scripts/link-js-typescript.mjs"
     },
     "dependencies": {
         "@codecov/vite-plugin": "^2.0.1",
@@ -51,6 +51,7 @@
         "@types/path-browserify": "^1.0.3",
         "@types/semver": "^7.7.1",
         "@typescript-eslint/parser": "^8.59.2",
+        "@typescript/native-preview": "7.0.0-dev.20260615.1",
         "@vitejs/plugin-vue": "^6.0.7",
         "@vitejs/plugin-vue-jsx": "^5.1.5",
         "@vitest/browser": "^4.1.7",
@@ -105,7 +106,8 @@
         "storybook": "^10.3.3",
         "storybook-vue3-router": "^7.0.0",
         "ts-node": "^10.9.2",
-        "typescript": "^5.9.3",
+        "typescript": "^7.0.2",
+        "typescript6": "npm:typescript@^6.0.3",
         "uuid": "^14.0.0",
         "vite": "^8.0.14",
         "vitest": "^4.1.5",
@@ -115,7 +117,7 @@
         "vue-i18n": "^11.4.4",
         "vue-material-design-icons": "^5.3.1",
         "vue-router": "^5.0.6",
-        "vue-tsc": "^3.2.8",
+        "vue-tsgo": "^0.2.2",
         "vue-virtual-scroller": "^3.0.4",
         "xss": "^1.0.15",
         "yaml": "^2.8.3"
@@ -139,6 +141,27 @@
     },
     "overrides": {
         "axios": "1.16.1",
+        "@typescript-eslint/parser": {
+            "typescript": "$typescript"
+        },
+        "@typescript-eslint/typescript-estree": {
+            "typescript": "$typescript"
+        },
+        "@typescript-eslint/project-service": {
+            "typescript": "$typescript"
+        },
+        "@typescript-eslint/tsconfig-utils": {
+            "typescript": "$typescript"
+        },
+        "@typescript-eslint/utils": {
+            "typescript": "$typescript"
+        },
+        "@module-federation/enhanced": {
+            "typescript": "$typescript"
+        },
+        "@module-federation/dts-plugin": {
+            "typescript": "$typescript"
+        },
         "@popperjs/core": "npm:@sxzz/popperjs-es@^2.11.7",
         "@codecov/vite-plugin": {
             "vite": "$vite"

--- a/ui/packages/design-system/package.json
+++ b/ui/packages/design-system/package.json
@@ -27,7 +27,7 @@
     "build": "tsdown",
     "dev": "tsdown --watch",
     "play": "vite",
-    "typecheck": "vue-tsc --noEmit",
+    "typecheck": "vue-tsgo --build tsconfig.json",
     "prepublishOnly": "npm run build",
     "storybook": "storybook dev -p 6007 --no-open",
     "test": "npm run lint:test & npm run types:test & npm run unit:test & npm run storybook:test & wait",
@@ -38,7 +38,7 @@
     "storybook:build": "storybook build",
     "lint:fix": "oxlint --fix && eslint --fix",
     "lint:test": "oxlint && eslint",
-    "types:test": "vue-tsc --noEmit",
+    "types:test": "vue-tsgo --build tsconfig.json",
     "generate:palette": "node scripts/generate-palette.mjs"
   },
   "peerDependencies": {
@@ -105,7 +105,7 @@
     "sass": "^1.100.0",
     "sass-embedded": "^1.99.0",
     "storybook": "^10.3.1",
-    "tsdown": "^0.22.1",
+    "tsdown": "0.22.1",
     "typescript": "^6.0.3",
     "vite": "^8.0.14",
     "vite-plugin-dts": "^5.0.1",
@@ -113,7 +113,8 @@
     "vitest-browser-vue": "^2.1.0",
     "vue-material-design-icons": "^5.3.1",
     "vue-router": "^5.0.6",
-    "vue-tsc": "^3.2.8",
+    "vue-tsc": "3.2.9",
+    "vue-tsgo": "^0.2.2",
     "yaml": "^2.8.2"
   }
 }

--- a/ui/packages/design-system/src/components/Data/KsCarousel.vue
+++ b/ui/packages/design-system/src/components/Data/KsCarousel.vue
@@ -1,7 +1,7 @@
 <template>
     <ElCarousel
         v-bind="({...filteredProps(), ...$attrs} as any)"
-        @change="(current, prev) => emit('change', current, prev)"
+        @change="(current: number, prev: number) => emit('change', current, prev)"
     >
         <template v-if="$slots.default" #default>
             <slot />

--- a/ui/packages/design-system/src/components/Data/KsDataTable/KsDataTable.vue
+++ b/ui/packages/design-system/src/components/Data/KsDataTable/KsDataTable.vue
@@ -47,7 +47,7 @@
                         @selection-change="selectionChanged"
                         @select="onSelect"
                         @sort-change="onSortChange"
-                        @row-dblclick="(row, column, event) => emit('row-dblclick', row, column, event)"
+                        @row-dblclick="(row: any, column: any, event: Event) => emit('row-dblclick', row, column, event)"
                     >
                         <KsTableColumn v-if="selectable && showSelection" type="selection" reserveSelection />
                         <slot />

--- a/ui/packages/design-system/src/components/Data/KsDataTable/filter/MainFilter.vue
+++ b/ui/packages/design-system/src/components/Data/KsDataTable/filter/MainFilter.vue
@@ -49,7 +49,7 @@
         >
             <KsSearch
                 v-model="localSearchQuery"
-                @update:modelValue="(v) => debouncedUpdateSearch(v ?? '')"
+                @update:modelValue="(v: string | undefined) => debouncedUpdateSearch(v ?? '')"
                 :placeholder="filter.configuration?.value?.searchPlaceholder"
                 clearable
             />

--- a/ui/packages/design-system/src/components/Data/KsDataTable/filter/MobileFilter.vue
+++ b/ui/packages/design-system/src/components/Data/KsDataTable/filter/MobileFilter.vue
@@ -8,7 +8,7 @@
             >
                 <KsSearch
                     v-model="localSearchQuery"
-                    @update:modelValue="(v) => debouncedUpdateSearch(v ?? '')"
+                    @update:modelValue="(v: string | undefined) => debouncedUpdateSearch(v ?? '')"
                     :placeholder="filter.configuration?.value?.searchPlaceholder"
                     clearable
                 />
@@ -128,7 +128,7 @@
                             :editingFilter="filter.editingFilter?.value"
                             :savedFilters="filter.savedFilters?.value ?? []"
                             @save="onSaveFilter"
-                            @edit="(id, name, desc) => filter.updateSavedFilter(id, name, desc, filter.appliedFilters?.value ?? [])"
+                            @edit="(id: string, name: string, desc: string) => filter.updateSavedFilter(id, name, desc, filter.appliedFilters?.value ?? [])"
                             @close-edit="filter.closeEditFilter"
                         >
                             {{ $t("filter.save") }}

--- a/ui/packages/design-system/src/components/Data/KsTable/KsTable.vue
+++ b/ui/packages/design-system/src/components/Data/KsTable/KsTable.vue
@@ -2,11 +2,11 @@
     <ElTable
         ref="tableRef"
         v-bind="({...filteredProps(), ...$attrs} as any)"
-        @selection-change="(selection) => emit('selectionChange', selection)"
-        @select="(selection, row) => emit('select', selection, row)"
-        @sort-change="(e) => emit('sortChange', e)"
-        @row-click="(row, column, event) => emit('rowClick', row, column, event)"
-        @row-dblclick="(row, column, event) => emit('rowDblclick', row, column, event)"
+        @selection-change="(selection: any[]) => emit('selectionChange', selection)"
+        @select="(selection: any[], row: any) => emit('select', selection, row)"
+        @sort-change="(e: {column: any; prop: string | null; order: string | null}) => emit('sortChange', e)"
+        @row-click="(row: any, column: any, event: Event) => emit('rowClick', row, column, event)"
+        @row-dblclick="(row: any, column: any, event: Event) => emit('rowDblclick', row, column, event)"
     >
         <template v-if="$slots.default" #default>
             <slot />

--- a/ui/packages/design-system/src/components/Data/KsTree.vue
+++ b/ui/packages/design-system/src/components/Data/KsTree.vue
@@ -2,9 +2,9 @@
     <ElTree
         ref="treeRef"
         v-bind="({...filteredProps(), ...$attrs} as any)"
-        @node-drag-start="(node, event) => emit('nodeDragStart', node, event)"
-        @node-drop="(draggingNode, dropNode, dropType, event) => emit('nodeDrop', draggingNode, dropNode, dropType, event)"
-        @node-click="(data, node, el, event) => emit('nodeClick', data, node, el, event)"
+        @node-drag-start="(node: any, event: DragEvent) => emit('nodeDragStart', node, event)"
+        @node-drop="(draggingNode: any, dropNode: any, dropType: string, event: DragEvent) => emit('nodeDrop', draggingNode, dropNode, dropType, event)"
+        @node-click="(data: any, node: any, el: any, event: MouseEvent) => emit('nodeClick', data, node, el, event)"
     >
         <template v-if="$slots.default" #default="scope">
             <slot v-bind="scope" />

--- a/ui/packages/design-system/src/components/Navigation/KsMenu/KsMenu.vue
+++ b/ui/packages/design-system/src/components/Navigation/KsMenu/KsMenu.vue
@@ -1,7 +1,7 @@
 <template>
     <ElMenu
         v-bind="({...filteredProps(), ...$attrs} as any)"
-        @select="(index, indexPath) => emit('select', index, indexPath)"
+        @select="(index: string, indexPath: string[]) => emit('select', index, indexPath)"
     >
         <template v-if="$slots.default" #default>
             <slot />

--- a/ui/packages/design-system/src/components/Navigation/KsTopNavBar/KsTopNavBar.vue
+++ b/ui/packages/design-system/src/components/Navigation/KsTopNavBar/KsTopNavBar.vue
@@ -39,7 +39,7 @@
                     :modelValue="activeTab"
                     class="tab-select"
                     size="small"
-                    @change="(v) => $emit('tab-change', v as string)"
+                    @change="(v: unknown) => $emit('tab-change', v as string)"
                 >
                     <KsOption
                         v-for="tab in tabs"

--- a/ui/packages/design-system/src/components/Others/KsBacktop.vue
+++ b/ui/packages/design-system/src/components/Others/KsBacktop.vue
@@ -1,7 +1,7 @@
 <template>
     <ElBacktop
         v-bind="({...filteredProps(), ...$attrs} as any)"
-        @click="(evt) => emit('click', evt)"
+        @click="(evt: MouseEvent) => emit('click', evt)"
     >
         <template v-if="$slots.default" #default>
             <slot />

--- a/ui/packages/slot-contracts/package.json
+++ b/ui/packages/slot-contracts/package.json
@@ -23,14 +23,14 @@
     "scripts": {
         "build": "tsdown",
         "dev": "tsdown --watch",
-        "typecheck": "vue-tsc --noEmit",
+        "typecheck": "vue-tsgo --project tsconfig.json",
         "prepublishOnly": "npm run build"
     },
     "peerDependencies": {
         "@kestra-io/kestra-sdk": "*"
     },
     "devDependencies": {
-        "tsdown": "^0.22.1",
+        "tsdown": "0.22.1",
         "ts-morph": "^28.0.0"
     },
     "dependencies": {

--- a/ui/packages/topology/package.json
+++ b/ui/packages/topology/package.json
@@ -32,7 +32,7 @@
     "scripts": {
         "build": "tsdown",
         "dev": "tsdown --watch",
-        "typecheck": "vue-tsc --noEmit",
+        "typecheck": "vue-tsgo --project tsconfig.json",
         "test": "npm run unit:test",
         "unit:test": "vitest run --config vitest.unit.config.ts",
         "unit:watch": "vitest --config vitest.unit.config.ts",
@@ -70,12 +70,13 @@
         "@types/node": "^25.9.1",
         "@vitejs/plugin-vue": "^6.0.7",
         "sass-embedded": "^1.99.0",
-        "tsdown": "^0.22.1",
+        "tsdown": "0.22.1",
         "typescript": "^6.0.3",
         "vite": "^8.0.14",
         "vitest": "^4.1.0",
         "vue": "^3.5.0",
         "vue-i18n": "^11.4.4",
-        "vue-tsc": "^3.2.8"
+        "vue-tsc": "3.2.9",
+        "vue-tsgo": "^0.2.2"
     }
 }

--- a/ui/scripts/link-js-typescript.mjs
+++ b/ui/scripts/link-js-typescript.mjs
@@ -1,0 +1,51 @@
+/**
+ * typescript@7 ships only the native (Go) compiler — it no longer exposes the JS
+ * compiler API that several tools still load via `require("typescript")`:
+ *
+ * - @typescript-eslint (parsing TS sources for ESLint; peer range is still <7)
+ * - vue/compiler-sfc's register-ts.js (resolving imported types in defineProps<T>()
+ *   during the Vite build)
+ *
+ * Until those tools support TypeScript 7, we install typescript@6 under the alias
+ * "typescript6" and link it as `typescript` inside each consuming package, so
+ * `require("typescript")` resolves to the JS implementation there while the rest
+ * of the repo uses typescript@7.
+ *
+ * Runs from the package root via postinstall. Delete this script (and the
+ * "typescript6" dependency + the typescript overrides in package.json) once the
+ * consumers below are compatible with TypeScript 7.
+ */
+import {existsSync, mkdirSync, rmSync, symlinkSync} from "node:fs"
+import {dirname, join, relative} from "node:path"
+
+const root = process.cwd()
+const typescript6 = join(root, "node_modules", "typescript6")
+
+const consumers = [
+    "node_modules/@typescript-eslint/parser",
+    "node_modules/@typescript-eslint/typescript-estree",
+    "node_modules/@typescript-eslint/project-service",
+    "node_modules/@typescript-eslint/tsconfig-utils",
+    "node_modules/ts-api-utils",
+    "node_modules/vue",
+]
+
+if (!existsSync(typescript6)) {
+    console.error("link-js-typescript: node_modules/typescript6 not found — did npm install run?")
+    process.exit(1)
+}
+
+for (const consumer of consumers) {
+    const pkgDir = join(root, consumer)
+    if (!existsSync(pkgDir)) continue
+    const linkPath = join(pkgDir, "node_modules", "typescript")
+    mkdirSync(dirname(linkPath), {recursive: true})
+    rmSync(linkPath, {recursive: true, force: true})
+    const target = relative(dirname(linkPath), typescript6)
+    try {
+        symlinkSync(target, linkPath, "dir")
+    } catch {
+        // Windows without developer mode: junctions need no privilege but require absolute paths
+        symlinkSync(typescript6, linkPath, "junction")
+    }
+}

--- a/ui/src/components/executions/Logs.vue
+++ b/ui/src/components/executions/Logs.vue
@@ -52,7 +52,7 @@
             :logCursor="logCursor"
             @follow="emit('follow', $event)"
             @opened-taskruns-count="openedTaskrunsCount = $event"
-            @log-indices-by-level="Object.entries($event).forEach(([levelName, indices]) => logIndicesByLevel[levelName] = indices)"
+            @log-indices-by-level="Object.entries($event as Record<string, string[]>).forEach(([levelName, indices]) => logIndicesByLevel[levelName] = indices)"
             :targetFlow="executionsStore.flow"
             :showProgressBar="false"
         />

--- a/ui/src/components/executions/TaskRunActions.vue
+++ b/ui/src/components/executions/TaskRunActions.vue
@@ -158,7 +158,7 @@
     )
 
     const canReadFlow = computed(() =>
-        authStore.user?.isAllowed(resource.FLOW, action.VIEW, route.params.namespace),
+        authStore.user?.isAllowed(resource.FLOW, action.VIEW, route.params.namespace as string),
     )
 
     function downloadNameFor(currentTaskRunId: string): string {

--- a/ui/src/components/flows/FlowRun.vue
+++ b/ui/src/components/flows/FlowRun.vue
@@ -27,9 +27,9 @@
                         :executeClicked="executeClicked"
                         @confirm="onSubmit"
                         @ready="onInputsFormReady"
-                        @update:model-value-no-default="values => inputsNoDefaults=values"
+                        @update:model-value-no-default="(values: Record<string, unknown>) => inputsNoDefaults=values"
                         @update:checks="onChecksUpdate"
-                        @update:on-recap="value => inputsOnRecap = value"
+                        @update:on-recap="(value: boolean) => inputsOnRecap = value"
                     />
                     <KsText v-else type="info">
                         {{ $t('no inputs') }}

--- a/ui/src/components/inputs/FileExplorer.vue
+++ b/ui/src/components/inputs/FileExplorer.vue
@@ -138,7 +138,7 @@
                                 v-if="selectionMode"
                                 class="me-2"
                                 :modelValue="selectedNodes.includes(data.id)"
-                                @update-model-value="checked => toggleCheckboxSelection(checked, node)"
+                                @update-model-value="(checked: boolean) => toggleCheckboxSelection(checked, node)"
                                 @mousedown.stop
                                 @click.stop
                             />

--- a/ui/src/components/inputs/FlowFileEditorTab.vue
+++ b/ui/src/components/inputs/FlowFileEditorTab.vue
@@ -36,7 +36,7 @@
                 @cursor="updatePluginDocumentation"
                 @save="flow ? saveFlowYaml(): saveFileContent()"
                 @execute="execute"
-                @mouse-move="(e) => highlightHoveredTask(e.target?.position?.lineNumber)"
+                @mouse-move="(e: any) => highlightHoveredTask(e.target?.position?.lineNumber)"
                 @mouse-leave="() => highlightHoveredTask(-1)"
                 :original="hasDraft ? source : undefined"
             >

--- a/ui/src/components/no-code/NoCode.vue
+++ b/ui/src/components/no-code/NoCode.vue
@@ -19,7 +19,7 @@
                             <template #tasks>
                                 <TaskObjectField
                                     v-bind="v"
-                                    @update:model-value="(val) => onTaskUpdateField(v.fieldKey, val)"
+                                    @update:model-value="(val: any) => onTaskUpdateField(v.fieldKey, val)"
                                 />
                             </template>
                         </Wrapper>
@@ -30,7 +30,7 @@
                             <template #tasks>
                                 <TaskObjectField
                                     v-bind="v"
-                                    @update:model-value="(val) => onTaskUpdateField(v.fieldKey, val)"
+                                    @update:model-value="(val: any) => onTaskUpdateField(v.fieldKey, val)"
                                 />
                             </template>
                         </Wrapper>

--- a/ui/src/components/no-code/components/inputs/InputPair.vue
+++ b/ui/src/components/no-code/components/inputs/InputPair.vue
@@ -19,7 +19,7 @@
                 <InputText
                     :modelValue="pair[0]"
                     :placeholder="$t('key')"
-                    @update:model-value="(changed) => handleKeyInput(index, changed)"
+                    @update:model-value="(changed: string) => handleKeyInput(index, changed)"
                     :haveError="duplicatedKeys.includes(pair[0])"
                 />
             </KsCol>
@@ -28,7 +28,7 @@
                     <InputText
                         :modelValue="pair[1]"
                         :placeholder="$t('value')"
-                        @update:model-value="(changed) => updateValue(index, changed)"
+                        @update:model-value="(changed: string) => updateValue(index, changed)"
                         class="w-100 me-2"
                     />
                 </slot>

--- a/ui/src/components/no-code/components/tasks/TaskObject.vue
+++ b/ui/src/components/no-code/components/tasks/TaskObject.vue
@@ -40,7 +40,7 @@
             <TaskDict
                 :modelValue
                 @update:model-value="
-                    (value) => $emit('update:modelValue', value)
+                    (value: Record<string, any> | undefined) => $emit('update:modelValue', value)
                 "
                 :root
                 :schema="schema ?? {}"

--- a/ui/src/components/plugins/PluginList.vue
+++ b/ui/src/components/plugins/PluginList.vue
@@ -12,7 +12,7 @@
             v-if="navigationStack.length === 0"
             class="search-field"
             :router="false"
-            @search="value => searchQuery = value"
+            @search="(value: string) => searchQuery = value"
         />
     </div>
 

--- a/ui/src/components/plugins/plugin-default/TaskObjectListInline.vue
+++ b/ui/src/components/plugins/plugin-default/TaskObjectListInline.vue
@@ -23,7 +23,7 @@
                 :modelValue="modelValue?.[index]"
                 :parentPath="`${root}[${index}]`"
                 :blockSchemaPath="taskSchemaPath"
-                @update:model-value="val => update(index, val)"
+                @update:model-value="(val: any) => update(index, val)"
             />
         </div>
 

--- a/ui/src/utils/init.ts
+++ b/ui/src/utils/init.ts
@@ -140,7 +140,9 @@ export default async (
 
     // moment
     moment.locale(locale)
-    const momentExtended = extendMoment(moment)
+    // TypeScript 7 resolves moment-range's `typeof import("moment")` parameter with a
+    // `default` member that moment-timezone's namespace type does not carry
+    const momentExtended = extendMoment(moment as unknown as Parameters<typeof extendMoment>[0])
     app.config.globalProperties.$moment = momentExtended
     setMomentInstance(momentExtended)
     setDateFormatter(dateFilter as any) // FIXME: any - dateFilter signature differs from DateFormatterFn

--- a/ui/tests/storybook/components/no-code/components/tasks/TaskAnyOf.stories.tsx
+++ b/ui/tests/storybook/components/no-code/components/tasks/TaskAnyOf.stories.tsx
@@ -1,5 +1,8 @@
 import {computed, provide, ref} from "vue";
-import TaskAnyOf from "../../../../../../src/components/no-code/components/tasks/TaskAnyOf.vue";
+import TaskAnyOfVue from "../../../../../../src/components/no-code/components/tasks/TaskAnyOf.vue";
+// vue-tsgo (TypeScript 7) does not surface defineModel()-derived props on the
+// component type when it is consumed from TSX, so type the component loosely here.
+const TaskAnyOf = TaskAnyOfVue as unknown as import("vue").FunctionalComponent<Record<string, any>>;
 import {Meta, StoryObj} from "@storybook/vue3-vite";
 import {vueRouter} from "storybook-vue3-router";
 import {SCHEMA_DEFINITIONS_INJECTION_KEY} from "../../../../../../src/components/no-code/injectionKeys";
@@ -25,7 +28,7 @@ export const SimpleTypes: Story = {
                 <div style={{width: "500px"}}>
                     <TaskAnyOf
                         modelValue={model.value}
-                        onUpdate:modelValue={(val) => model.value = val}
+                        onUpdate:modelValue={(val: any) => model.value = val}
                         schema={args.schema}
                     />
                 </div>
@@ -54,7 +57,7 @@ export const ArrayVariants: Story = {
                 <div style={{width: "500px"}}>
                     <TaskAnyOf
                         modelValue={model.value}
-                        onUpdate:modelValue={(val) => model.value = val}
+                        onUpdate:modelValue={(val: any) => model.value = val}
                         schema={args.schema}
                     />
                 </div>

--- a/ui/tests/storybook/components/no-code/components/tasks/TaskArray.stories.tsx
+++ b/ui/tests/storybook/components/no-code/components/tasks/TaskArray.stories.tsx
@@ -1,5 +1,8 @@
 import {computed, provide, ref} from "vue";
-import TaskArray from "../../../../../../src/components/no-code/components/tasks/TaskArray.vue";
+import TaskArrayVue from "../../../../../../src/components/no-code/components/tasks/TaskArray.vue";
+// vue-tsgo (TypeScript 7) does not surface defineModel()-derived props on the
+// component type when it is consumed from TSX, so type the component loosely here.
+const TaskArray = TaskArrayVue as unknown as import("vue").FunctionalComponent<Record<string, any>>;
 import Wrapper from "../../../../../../src/components/no-code/components/tasks/Wrapper.vue";
 import {Meta, StoryObj} from "@storybook/vue3-vite";
 import {expect, within, fireEvent, waitFor} from "storybook/test";
@@ -29,7 +32,7 @@ export const StringArray: Story = {
                         {{
                             tasks: () => <TaskArray
                                 modelValue={model.value}
-                                onUpdate:modelValue={(val) => model.value = val}
+                                onUpdate:modelValue={(val: any) => model.value = val}
                                 schema={args.schema}
                                 root="items"
                             />
@@ -60,7 +63,7 @@ export const EmptyArray: Story = {
                         {{
                             tasks: () => <TaskArray
                                 modelValue={model.value}
-                                onUpdate:modelValue={(val) => model.value = val}
+                                onUpdate:modelValue={(val: any) => model.value = val}
                                 schema={args.schema}
                                 root="tags"
                             />
@@ -98,7 +101,7 @@ export const ObjectArray: Story = {
                         {{
                             tasks: () => <TaskArray
                                 modelValue={model.value}
-                                onUpdate:modelValue={(val) => model.value = val}
+                                onUpdate:modelValue={(val: any) => model.value = val}
                                 schema={args.schema}
                                 root="rows"
                             />

--- a/ui/tests/storybook/components/no-code/components/tasks/TaskConstant.stories.tsx
+++ b/ui/tests/storybook/components/no-code/components/tasks/TaskConstant.stories.tsx
@@ -1,5 +1,8 @@
 import {ref} from "vue";
-import TaskConstant from "../../../../../../src/components/no-code/components/tasks/TaskConstant.vue";
+import TaskConstantVue from "../../../../../../src/components/no-code/components/tasks/TaskConstant.vue";
+// vue-tsgo (TypeScript 7) does not surface defineModel()-derived props on the
+// component type when it is consumed from TSX, so type the component loosely here.
+const TaskConstant = TaskConstantVue as unknown as import("vue").FunctionalComponent<Record<string, any>>;
 import {Meta, StoryObj} from "@storybook/vue3-vite";
 import {expect, within} from "storybook/test";
 
@@ -19,7 +22,7 @@ const render: Story["render"] = (args) => ({
             <div style={{width: "400px"}}>
                 <TaskConstant
                     modelValue={model.value}
-                    onUpdate:modelValue={(val) => model.value = val}
+                    onUpdate:modelValue={(val: any) => model.value = val}
                     schema={args.schema}
                 />
             </div>

--- a/ui/tests/storybook/components/no-code/components/tasks/TaskDict.stories.tsx
+++ b/ui/tests/storybook/components/no-code/components/tasks/TaskDict.stories.tsx
@@ -1,5 +1,8 @@
 import {computed, provide, ref} from "vue";
-import TaskDict from "../../../../../../src/components/no-code/components/tasks/TaskDict.vue";
+import TaskDictVue from "../../../../../../src/components/no-code/components/tasks/TaskDict.vue";
+// vue-tsgo (TypeScript 7) does not surface defineModel()-derived props on the
+// component type when it is consumed from TSX, so type the component loosely here.
+const TaskDict = TaskDictVue as unknown as import("vue").FunctionalComponent<Record<string, any>>;
 import Wrapper from "../../../../../../src/components/no-code/components/tasks/Wrapper.vue";
 import {userEvent, waitFor, within, expect} from "storybook/test";
 import {Meta, StoryObj} from "@storybook/vue3-vite";
@@ -30,7 +33,7 @@ const render: Story["render"] = (args) => ({
         const model = ref(args.modelValue || {});
         provide(SCHEMA_DEFINITIONS_INJECTION_KEY, computed(() => ({})));
         return () => <>
-            <TaskDict modelValue={model.value} schema={{}} onUpdate:modelValue={val => model.value = val}/>
+            <TaskDict modelValue={model.value} schema={{}} onUpdate:modelValue={(val: any) => model.value = val}/>
             <pre data-testid="sb-meta-data-result">
                 {JSON.stringify(model.value, null, 2)}
             </pre>
@@ -124,7 +127,7 @@ export const ValuesAsObjects: Story = {
                                         }
                                     }
                                 }
-                            }} onUpdate:modelValue={val => model.value = val}/>
+                            }} onUpdate:modelValue={(val: any) => model.value = val}/>
                         }}
                     </Wrapper>
                     <pre data-testid="sb-meta-data-result" style={{background: "var(--ks-bg-surface)", padding: "10px", borderRadius: "4px", width: "100%"}}>
@@ -182,7 +185,7 @@ export const ValuesAsTaskLists: Story = {
                                         })),
                                     }
                                 }
-                            }} onUpdate:modelValue={val => model.value = val}/>
+                            }} onUpdate:modelValue={(val: any) => model.value = val}/>
                         }}
                     </Wrapper>
                     <pre data-testid="sb-meta-data-result" style={{background: "var(--ks-bg-surface)", padding: "10px", borderRadius: "4px", width: "100%"}}>

--- a/ui/tests/storybook/components/no-code/components/tasks/TaskExpression.stories.tsx
+++ b/ui/tests/storybook/components/no-code/components/tasks/TaskExpression.stories.tsx
@@ -1,5 +1,8 @@
 import {computed, provide, ref} from "vue";
-import TaskExpression from "../../../../../../src/components/no-code/components/tasks/TaskExpression.vue";
+import TaskExpressionVue from "../../../../../../src/components/no-code/components/tasks/TaskExpression.vue";
+// vue-tsgo (TypeScript 7) does not surface defineModel()-derived props on the
+// component type when it is consumed from TSX, so type the component loosely here.
+const TaskExpression = TaskExpressionVue as unknown as import("vue").FunctionalComponent<Record<string, any>>;
 import {Meta, StoryObj} from "@storybook/vue3-vite";
 import {vueRouter} from "storybook-vue3-router";
 import {SCHEMA_DEFINITIONS_INJECTION_KEY} from "../../../../../../src/components/no-code/injectionKeys";
@@ -24,7 +27,7 @@ const render: Story["render"] = (args) => ({
             <div style={{width: "500px"}}>
                 <TaskExpression
                     modelValue={model.value}
-                    onUpdate:modelValue={(val) => model.value = val}
+                    onUpdate:modelValue={(val: any) => model.value = val}
                     root={args.root}
                 />
             </div>

--- a/ui/tests/storybook/components/no-code/components/tasks/TaskList.stories.tsx
+++ b/ui/tests/storybook/components/no-code/components/tasks/TaskList.stories.tsx
@@ -7,7 +7,10 @@ vi.mock("../../../../../../src/stores/playground", () => ({
 }));
 
 import {computed, provide, ref} from "vue";
-import TaskList from "../../../../../../src/components/no-code/components/tasks/TaskList.vue";
+import TaskListVue from "../../../../../../src/components/no-code/components/tasks/TaskList.vue";
+// vue-tsgo (TypeScript 7) does not surface defineModel()-derived props on the
+// component type when it is consumed from TSX, so type the component loosely here.
+const TaskList = TaskListVue as unknown as import("vue").FunctionalComponent<Record<string, any>>;
 import {Meta, StoryObj} from "@storybook/vue3-vite";
 import {vueRouter} from "storybook-vue3-router";
 import {
@@ -60,7 +63,7 @@ export const Default: Story = {
             return () => <div style={{width: "600px"}}>
                 <TaskList
                     modelValue={model.value}
-                    onUpdate:modelValue={(val) => model.value = val}
+                    onUpdate:modelValue={(val: any) => model.value = val}
                     root="tasks"
                 />
             </div>
@@ -88,7 +91,7 @@ export const Merged: Story = {
             return () => <div style={{width: "600px"}}>
                 <TaskList
                     modelValue={model.value}
-                    onUpdate:modelValue={(val) => model.value = val}
+                    onUpdate:modelValue={(val: any) => model.value = val}
                     merge
                 />
             </div>

--- a/ui/tests/storybook/components/no-code/components/tasks/TaskTask.stories.tsx
+++ b/ui/tests/storybook/components/no-code/components/tasks/TaskTask.stories.tsx
@@ -1,5 +1,8 @@
 import {computed, provide, ref} from "vue";
-import TaskTask from "../../../../../../src/components/no-code/components/tasks/TaskTask.vue";
+import TaskTaskVue from "../../../../../../src/components/no-code/components/tasks/TaskTask.vue";
+// vue-tsgo (TypeScript 7) does not surface defineModel()-derived props on the
+// component type when it is consumed from TSX, so type the component loosely here.
+const TaskTask = TaskTaskVue as unknown as import("vue").FunctionalComponent<Record<string, any>>;
 import {Meta, StoryObj} from "@storybook/vue3-vite";
 import {vueRouter} from "storybook-vue3-router";
 import {

--- a/ui/tests/storybook/theme/ShowCase.vue
+++ b/ui/tests/storybook/theme/ShowCase.vue
@@ -188,7 +188,7 @@
             </el-select>
         </div>
 
-        <Tabs :tabs="tabs" :embedActiveTab="activeTab" @changed="(tab) => { if(tab.name) tabChanged({name:tab.name}) }" />
+        <Tabs :tabs="tabs" :embedActiveTab="activeTab" @changed="(tab: {name?: string}) => { if(tab.name) tabChanged({name:tab.name}) }" />
         <div>
             <div class="sub-title my-2 text-sm text-gray-600">
                 list suggestions when activated

--- a/ui/tsconfig.app.json
+++ b/ui/tsconfig.app.json
@@ -1,21 +1,23 @@
 {
   "extends": "./tsconfig.base.json",
   "compilerOptions": {
-    "composite": true,
-    "declaration": true,
-    "emitDeclarationOnly": true,
-    "outDir": "./node_modules/.tmp/types",
-    "tsBuildInfoFile": "./node_modules/.tmp/types/tsconfig.app.tsbuildinfo",
+    "noEmit": true,
     "types": []
   },
-  "references": [
-    {"path": "./packages/design-system/tsconfig.app.json"}
-  ],
   "include": [
     "src/**/*.ts",
     "src/**/*.tsx",
     "src/**/*.vue",
     "src/**/*.json",
+    // vue-tsgo (TypeScript 7) checks imported workspace package sources as part
+    // of this project instead of consuming declarations emitted by project
+    // references, so the package sources and their ambient declarations (env.d.ts)
+    // must be covered by this project too.
+    "packages/design-system/src/**/*.ts",
+    "packages/design-system/src/**/*.vue",
+    "packages/topology/src/**/*.ts",
+    "packages/topology/src/**/*.vue",
+    "packages/slot-contracts/src/**/*.ts",
   ],
   "exclude": [
     // Node scripts (use fs/path/url) — type-checked via tsconfig.test.json, not the browser app build.

--- a/ui/tsconfig.base.json
+++ b/ui/tsconfig.base.json
@@ -19,7 +19,15 @@
     "preserveSymlinks": true,
     "rootDir": ".",
     "paths": {
-      "override/*": ["./src/override/*"]
+      "override/*": ["./src/override/*"],
+      // Resolve the workspace packages to their sources: vue-tsgo (TypeScript 7)
+      // cannot type re-exports that go through the node_modules symlinks because
+      // the .vue files reached that way are not part of the checked project.
+      "@kestra-io/design-system": ["./packages/design-system/src/index.ts"],
+      "@kestra-io/design-system/components/*": ["./packages/design-system/src/components/*"],
+      "@kestra-io/slot-contracts": ["./packages/slot-contracts/src/index.ts"],
+      "@kestra-io/topology": ["./packages/topology/src/index.ts"],
+      "@kestra-io/topology/vue-flow-utils": ["./packages/topology/src/vue-flow-utils.ts"]
     }
   }
 }

--- a/ui/tsconfig.test.json
+++ b/ui/tsconfig.test.json
@@ -25,7 +25,17 @@
     "tests/storybook/**/*.vue",
     "src/utils/global.ts",
     "src/*.d.ts",
-    "packages/design-system/src/env.d.ts",
-    "packages/topology/src/env.d.ts"
+    // vue-tsgo (TypeScript 7) checks every file reachable through imports as part
+    // of this project, so the app and workspace package sources must be covered
+    // here for their ambient declarations and paths to apply to them.
+    "src/**/*.ts",
+    "src/**/*.tsx",
+    "src/**/*.vue",
+    "src/**/*.json",
+    "packages/design-system/src/**/*.ts",
+    "packages/design-system/src/**/*.vue",
+    "packages/topology/src/**/*.ts",
+    "packages/topology/src/**/*.vue",
+    "packages/slot-contracts/src/**/*.ts"
   ]
 }


### PR DESCRIPTION
### ✨ Description

Upgrades the frontend toolchain to **TypeScript 7** (`typescript@7.0.2`, the native Go compiler). Since TS 7 no longer ships the JS compiler API, several parts of the toolchain had to be adapted:

- **Type checking** now runs through [`vue-tsgo`](https://github.com/KazariEX/vue-tsgo) backed by `@typescript/native-preview` (tsgo). `vue-tsc` cannot run on TS 7 yet ([vuejs/language-tools#5381](https://github.com/vuejs/language-tools/issues/5381)); `@typescript/native-preview` is pinned to the last build whose binary layout `vue-tsgo` 0.2.2 supports.
- **Tools that still need the JS compiler API** keep working via a JS TypeScript 6 installed under the `typescript6` alias and linked into their `node_modules` by `ui/scripts/link-js-typescript.mjs` (postinstall): `@typescript-eslint` (its peer range is still `<7`) and `vue/compiler-sfc`'s `register-ts.js` (resolving imported types in `defineProps<T>()` during the Vite build). `package.json` `overrides` relax the corresponding `typescript` peer ranges.
- **`design-system`/`topology` keep `typescript@^6.0.3`** for their `tsdown`/`rolldown-plugin-dts` d.ts builds, which cannot run on the native compiler. Their `typecheck` scripts move to `vue-tsgo`. `tsdown`/`vue-tsc` are pinned to the exact versions the previous lockfile resolved.
- **tsconfig restructuring**: `vue-tsgo` checks imported workspace sources directly (LSP-based, no declaration emit, no project references), so `tsconfig.app.json`/`tsconfig.test.json` now cover the package sources + their ambient declarations, and `tsconfig.base.json` maps `@kestra-io/*` to their sources (the node_modules symlink route loses types for re-exports from `.vue` files under tsgo).
- **Type fixes surfaced by the stricter tsgo checking**: explicit parameter types in inline template handlers (tsgo does not infer emit parameter types through `v-bind="(... as any)"`), a moment interop cast in `init.ts`, and loosely-typed TSX aliases in the no-code storybook stories (tsgo does not surface `defineModel`-derived props in TSX).

Verified locally: `npm run check:types`, `npm run test:lint`, `npm run test:unit` (622 passed), `npm run build`, and a fresh `npm ci`.

⚠️ Note: `npm run build:design` (tsdown d.ts emit) fails identically on `develop` before this change — pre-existing breakage unrelated to TS 7 (`rolldown-plugin-dts: Unable to load file ... LogicalChooser.vue`).

Companion EE PR: kestra-io/kestra-ee — same branch name `claude/typescript-7-upgrade-4thn2z` so both CIs run against each other.

### 🔗 Related Issue

Internal toolchain upgrade — no linked issue.

### 🎨 Frontend Checklist

- [x] Code builds without errors (`npm run build`)
- [ ] All existing E2E tests pass (`npm run test:e2e`) — not run locally (requires a backend); unit tests and type checks pass
- [ ] Screenshots — no visual changes (toolchain + type-level changes only)

### 📝 Additional Notes

- The `typescript6` alias + link script + overrides are transitional: delete them once `@typescript-eslint` and `vue/compiler-sfc` support TypeScript 7.
- `@typescript/native-preview` must stay pinned until `vue-tsgo` supports the renamed `bin/tsgo` layout of newer builds.

### 🤖 AI Authors

Why did the cat sit on the CI runner? Because it wanted to keep an eye on the *type* of mice going through the pipeline. 🐱

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01523UhY9ompi2q9JEZhAXPm

---
_Generated by [Claude Code](https://claude.ai/code/session_01523UhY9ompi2q9JEZhAXPm)_