### PR TITLE
fix(logs): widen logs/metrics task_id column to 256 to match Task.id max size

### DIFF
--- a/core/src/test/java/io/kestra/core/repositories/AbstractLogRepositoryTest.java
+++ b/core/src/test/java/io/kestra/core/repositories/AbstractLogRepositoryTest.java
@@ -417,6 +417,21 @@ public abstract class AbstractLogRepositoryTest {
     }
 
     @Test
+    void shouldPersistTaskIdLongerThan150Chars() {
+        // A plugin-generated taskId (e.g. Ansible "<host> | <play> : <task>") can exceed the legacy
+        // VARCHAR(150) task_id column and crash-loop the indexer; the column now allows up to 256.
+        String tenant = TestsUtils.randomTenant(this.getClass().getSimpleName());
+        String longTaskId = "a".repeat(200);
+        LogEntry log = logEntry(tenant, Level.INFO, "execLongTaskId").taskId(longTaskId).build();
+
+        LogEntry saved = logRepository.save(log);
+
+        List<LogEntry> found = logRepository.findByExecutionIdAndTaskId(tenant, saved.getExecutionId(), longTaskId, null);
+        assertThat(found).hasSize(1);
+        assertThat(found.getFirst().getTaskId()).isEqualTo(longTaskId);
+    }
+
+    @Test
     void purge() {
         String tenant = TestsUtils.randomTenant(this.getClass().getSimpleName());
         logRepository.save(logEntry(tenant, Level.INFO, "execution1").build());

--- a/core/src/test/java/io/kestra/core/repositories/AbstractMetricRepositoryTest.java
+++ b/core/src/test/java/io/kestra/core/repositories/AbstractMetricRepositoryTest.java
@@ -190,6 +190,22 @@ public abstract class AbstractMetricRepositoryTest {
         assertThat(results).isEqualTo(1.0);
     }
 
+    @Test
+    void shouldPersistTaskIdLongerThan150Chars() {
+        // A plugin-generated taskId (e.g. Ansible "<host> | <play> : <task>") can exceed the legacy
+        // VARCHAR(150) task_id column and crash-loop the indexer; the column now allows up to 256.
+        String tenant = TestsUtils.randomTenant(this.getClass().getSimpleName());
+        String executionId = FriendlyId.createFriendlyId();
+        String longTaskId = "a".repeat(200);
+        MetricEntry counter = MetricEntry.of(taskRun(tenant, executionId, longTaskId), counter("counter"), null);
+
+        metricRepository.save(counter);
+
+        List<MetricEntry> results = metricRepository.findByExecutionIdAndTaskId(tenant, executionId, longTaskId, Pageable.from(1, 10));
+        assertThat(results.size()).isEqualTo(1);
+        assertThat(results.getFirst().getTaskId()).isEqualTo(longTaskId);
+    }
+
     private Counter counter(String metricName) {
         return Counter.of(metricName, 1);
     }

--- a/jdbc-h2/src/main/resources/migrations/h2/V1_56__widen_task_id.sql
+++ b/jdbc-h2/src/main/resources/migrations/h2/V1_56__widen_task_id.sql
@@ -1,0 +1,5 @@
+-- Widen the generated task_id column from 150 to 256 to match Task.id's @Size(max = 256).
+-- Plugin-generated taskIds (e.g. Ansible "<host> | <play> : <task>") can exceed 150 chars and
+-- overflow the VARCHAR(150) column, crashing the JDBC indexer. H2 restates the generation expression.
+ALTER TABLE logs ALTER COLUMN "task_id" VARCHAR(256) GENERATED ALWAYS AS (JQ_STRING("value", '.taskId'));
+ALTER TABLE metrics ALTER COLUMN "task_id" VARCHAR(256) GENERATED ALWAYS AS (JQ_STRING("value", '.taskId'));

--- a/jdbc-mysql/src/main/resources/migrations/mysql/V1_57__widen_task_id.sql
+++ b/jdbc-mysql/src/main/resources/migrations/mysql/V1_57__widen_task_id.sql
@@ -1,0 +1,6 @@
+-- Widen the generated task_id column from 150 to 256 to match Task.id's @Size(max = 256).
+-- Plugin-generated taskIds (e.g. Ansible "<host> | <play> : <task>") can exceed 150 chars and
+-- overflow the VARCHAR(150) column, crashing the JDBC indexer. MySQL requires restating the full
+-- generation expression; modifying a STORED generated column rebuilds the table (ALGORITHM=COPY).
+ALTER TABLE logs MODIFY COLUMN `task_id` VARCHAR(256) GENERATED ALWAYS AS (value ->> '$.taskId') STORED;
+ALTER TABLE metrics MODIFY COLUMN `task_id` VARCHAR(256) GENERATED ALWAYS AS (value ->> '$.taskId') STORED;

--- a/jdbc-postgres/src/main/resources/migrations/postgres/V1_57__widen_task_id.sql
+++ b/jdbc-postgres/src/main/resources/migrations/postgres/V1_57__widen_task_id.sql
@@ -1,0 +1,6 @@
+-- Widen the generated task_id column from 150 to 256 to match Task.id's @Size(max = 256).
+-- Plugin-generated taskIds (e.g. Ansible "<host> | <play> : <task>") can exceed 150 chars and
+-- overflow the VARCHAR(150) column, crashing the JDBC indexer. In Postgres this is a metadata-only
+-- change (no table rewrite). NOT NULL on metrics.task_id is preserved by ALTER ... TYPE.
+ALTER TABLE logs ALTER COLUMN task_id TYPE VARCHAR(256);
+ALTER TABLE metrics ALTER COLUMN task_id TYPE VARCHAR(256);


### PR DESCRIPTION
## What

Widen the generated `task_id` column from `VARCHAR(150)` → `VARCHAR(256)` on the `logs` and `metrics` tables (Postgres, MySQL, H2), to match `Task.id`'s `@Size(max = 256)`.

## Why

Closes #17328. A `taskId` longer than 150 chars (e.g. a plugin-synthesized Ansible label `<host> | <play> : <task name>`) overflows the `VARCHAR(150)` generated column. The JDBC indexer treats the SQL error as fatal and calls `KestraContext.shutdown()`; the un-acked message is redelivered on restart, crash-looping the instance.

## How

- 3 Flyway migrations (`V1_57` pg/mysql, `V1_56` h2) using the in-place `ALTER`/`MODIFY` pattern — preserves indexes and the generated-projection design. No Java change, no data loss (the full taskId lives in the JSON `value`).
- Regression tests in the shared abstract bases (`AbstractLogRepositoryTest`, `AbstractMetricRepositoryTest`) persisting a 200-char taskId; confirmed red before the migration, green after.

### Migration cost
- **Postgres / H2**: metadata-only / instant.
- **MySQL**: modifying a `STORED GENERATED` column rebuilds the table (`ALGORITHM=COPY`, no online path). Large MySQL `logs` tables may see a blocking rebuild at startup — can be run via gh-ost / pt-osc beforehand.

## Companion PR

EE H2 asset-table parity (`asset_usages`, `asset_lineage_events` → 256): kestra-io/kestra-ee (linked below once opened).

## Residual (follow-up)

`taskId` is unvalidated on the dynamic-taskrun path, so a value >256 would still overflow — a separate follow-up to bound/validate `TaskRun.taskId` / `LogEntry.taskId`.
