### PR TITLE
fix(logs): widen logs/metrics task_id to 256 (v2 / MigrationRunner)

### DIFF
--- a/core/src/test/java/io/kestra/core/repositories/AbstractMetricRepositoryTest.java
+++ b/core/src/test/java/io/kestra/core/repositories/AbstractMetricRepositoryTest.java
@@ -198,6 +198,22 @@ public abstract class AbstractMetricRepositoryTest {
         assertThat(results).isEqualTo(1.0);
     }
 
+    @Test
+    void shouldPersistTaskIdLongerThan150Chars() {
+        // A plugin-generated taskId (e.g. Ansible "<host> | <play> : <task>") can exceed the legacy
+        // VARCHAR(150) task_id column and crash-loop the indexer; the column now allows up to 256.
+        String tenant = TestsUtils.randomTenant(this.getClass().getSimpleName());
+        String executionId = FriendlyId.createFriendlyId();
+        String longTaskId = "a".repeat(200);
+        MetricEntry counter = MetricEntry.of(taskRun(tenant, executionId, longTaskId), counter("counter"), null);
+
+        metricRepository.save(counter);
+
+        List<MetricEntry> results = metricRepository.findByExecutionIdAndTaskId(tenant, executionId, longTaskId, Pageable.from(1, 10));
+        assertThat(results.size()).isEqualTo(1);
+        assertThat(results.getFirst().getTaskId()).isEqualTo(longTaskId);
+    }
+
     private Counter counter(String metricName) {
         return Counter.of(metricName, 1);
     }

--- a/jdbc-h2/src/main/java/io/kestra/repository/h2/migration/V2_0_16WidenLogsTaskIdMigration.java
+++ b/jdbc-h2/src/main/java/io/kestra/repository/h2/migration/V2_0_16WidenLogsTaskIdMigration.java
@@ -1,0 +1,76 @@
+package io.kestra.repository.h2.migration;
+
+import java.util.List;
+import java.util.Map;
+
+import javax.sql.DataSource;
+
+import io.kestra.jdbc.LogJdbcDataSourceProvider;
+import io.kestra.jdbc.migration.AbstractSQLMigrationScript;
+import io.kestra.jdbc.migration.LogStoreTypeResolver;
+
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.context.condition.Condition;
+import io.micronaut.context.condition.ConditionContext;
+import jakarta.inject.Singleton;
+
+/**
+ * H2 log-store task_id widening migration.
+ *
+ * <p>
+ * Widens the generated {@code task_id} column to {@code VARCHAR(256)} on the log-store table resolved
+ * by {@link LogJdbcDataSourceProvider} (a dedicated database when {@code kestra.logs.h2.url} is set,
+ * otherwise the primary datasource). Mirrors {@code V2_0_14LogsMigration}: the scriptId encodes the
+ * backend ("-h2") and a non-default table name, so switching the log-repo backend re-applies it.
+ *
+ * <p>
+ * Runs whenever the effective log-store dialect is H2 — a configured {@code kestra.logs.type=h2|memory}
+ * or the fallback to an H2 {@code kestra.repository.type} (logs kept in the main database).
+ */
+@Singleton
+@Requires(condition = V2_0_16WidenLogsTaskIdMigration.H2LogStoreEnabled.class)
+public class V2_0_16WidenLogsTaskIdMigration extends AbstractSQLMigrationScript {
+
+    public static final class H2LogStoreEnabled implements Condition {
+        @Override
+        public boolean matches(final ConditionContext context) {
+            return LogStoreTypeResolver.matches(context, "h2");
+        }
+    }
+
+
+    private static final String SCRIPT_ID = "2.0.16-widen-logs-task-id-h2";
+    private static final String SQL_RESOURCE = "/migrations/2.0.16-widen-logs-task-id-h2.sql";
+
+    private final LogJdbcDataSourceProvider logDataSourceProvider;
+
+    public V2_0_16WidenLogsTaskIdMigration(final LogJdbcDataSourceProvider logDataSourceProvider) {
+        this.logDataSourceProvider = logDataSourceProvider;
+    }
+
+    @Override
+    public String scriptId() {
+        String table = logDataSourceProvider.table();
+        return "logs".equals(table) ? SCRIPT_ID : SCRIPT_ID + "-" + table;
+    }
+
+    @Override
+    public String description() {
+        return "H2 dedicated log store: widen task_id to VARCHAR(256)";
+    }
+
+    @Override
+    public List<String> sqlResources() {
+        return List.of(SQL_RESOURCE);
+    }
+
+    @Override
+    protected DataSource dataSource() {
+        return logDataSourceProvider.dataSource();
+    }
+
+    @Override
+    public void migrate() throws Exception {
+        executeSqlScript(dataSource(), SQL_RESOURCE, Map.of("table", logDataSourceProvider.table()));
+    }
+}

--- a/jdbc-h2/src/main/java/io/kestra/repository/h2/migration/V2_0_16WidenMetricsTaskIdMigration.java
+++ b/jdbc-h2/src/main/java/io/kestra/repository/h2/migration/V2_0_16WidenMetricsTaskIdMigration.java
@@ -1,0 +1,36 @@
+package io.kestra.repository.h2.migration;
+
+import java.util.List;
+
+import javax.sql.DataSource;
+
+import io.kestra.jdbc.migration.AbstractV2_0_16WidenMetricsTaskIdMigration;
+
+import io.micronaut.context.annotation.Requires;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+
+/**
+ * OSS H2 metrics task_id widening migration (primary datasource).
+ */
+@Singleton
+@Requires(property = "kestra.repository.type", pattern = "h2|memory")
+public class V2_0_16WidenMetricsTaskIdMigration extends AbstractV2_0_16WidenMetricsTaskIdMigration {
+
+    private final DataSource dataSource;
+
+    @Inject
+    public V2_0_16WidenMetricsTaskIdMigration(final DataSource dataSource) {
+        this.dataSource = dataSource;
+    }
+
+    @Override
+    protected DataSource dataSource() {
+        return dataSource;
+    }
+
+    @Override
+    public List<String> sqlResources() {
+        return List.of("/migrations/2.0.16-widen-metrics-task-id-h2.sql");
+    }
+}

--- a/jdbc-h2/src/main/resources/migrations/2.0.16-widen-logs-task-id-h2.sql
+++ b/jdbc-h2/src/main/resources/migrations/2.0.16-widen-logs-task-id-h2.sql
@@ -1,0 +1,3 @@
+-- Widen the dedicated log-store table's generated task_id column to VARCHAR(256).
+-- H2 restates the generation expression when altering a generated column. ${table} is the log table.
+ALTER TABLE ${table} ALTER COLUMN "task_id" VARCHAR(256) GENERATED ALWAYS AS (JQ_STRING("value", '.taskId'));

--- a/jdbc-h2/src/main/resources/migrations/2.0.16-widen-metrics-task-id-h2.sql
+++ b/jdbc-h2/src/main/resources/migrations/2.0.16-widen-metrics-task-id-h2.sql
@@ -1,0 +1,3 @@
+-- Widen the metrics.task_id generated column from 150 to 256 to match Task.id's @Size(max = 256).
+-- H2 restates the generation expression when altering a generated column.
+ALTER TABLE metrics ALTER COLUMN "task_id" VARCHAR(256) GENERATED ALWAYS AS (JQ_STRING("value", '.taskId'));

--- a/jdbc-h2/src/test/java/io/kestra/repository/h2/H2LogDataStoreDedicatedTest.java
+++ b/jdbc-h2/src/test/java/io/kestra/repository/h2/H2LogDataStoreDedicatedTest.java
@@ -26,6 +26,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 @MicronautTest
 @Property(name = "kestra.logs.type", value = "h2")
 @Property(name = "kestra.logs.h2.url", value = "jdbc:h2:mem:logs_dedicated;TIME ZONE=UTC;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=TRUE")
+// Use an isolated primary datasource so this test's migration history (which records the log-table
+// migrations applied to the dedicated log database) does not leak into the shared in-memory "public"
+// database used by the other repository tests in the same JVM.
+@Property(name = "datasources.h2.url", value = "jdbc:h2:mem:logs_dedicated_primary;LOCK_TIMEOUT=30000;TIME ZONE=UTC;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE")
 class H2LogDataStoreDedicatedTest {
 
     @Inject

--- a/jdbc-mysql/src/main/java/io/kestra/repository/mysql/migration/V2_0_16WidenLogsTaskIdMigration.java
+++ b/jdbc-mysql/src/main/java/io/kestra/repository/mysql/migration/V2_0_16WidenLogsTaskIdMigration.java
@@ -1,0 +1,77 @@
+package io.kestra.repository.mysql.migration;
+
+import java.util.List;
+import java.util.Map;
+
+import javax.sql.DataSource;
+
+import io.kestra.jdbc.LogJdbcDataSourceProvider;
+import io.kestra.jdbc.migration.AbstractSQLMigrationScript;
+import io.kestra.jdbc.migration.LogStoreTypeResolver;
+
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.context.condition.Condition;
+import io.micronaut.context.condition.ConditionContext;
+import jakarta.inject.Singleton;
+
+/**
+ * MySQL log-store task_id widening migration.
+ *
+ * <p>
+ * Widens the generated {@code task_id} column to {@code VARCHAR(256)} on the log-store table resolved
+ * by {@link LogJdbcDataSourceProvider}. Guarded by an information_schema length check because
+ * modifying a {@code STORED GENERATED} column rebuilds the table ({@code ALGORITHM=COPY}). Mirrors
+ * {@code V2_0_14LogsMigration}: the scriptId encodes the backend ("-mysql") and a non-default table
+ * name, so switching the log-repo backend re-applies it.
+ *
+ * <p>
+ * Runs whenever the effective log-store dialect is MySQL — a configured {@code kestra.logs.type=mysql}
+ * or the fallback to a MySQL {@code kestra.repository.type} (logs kept in the main database).
+ */
+@Singleton
+@Requires(condition = V2_0_16WidenLogsTaskIdMigration.MysqlLogStoreEnabled.class)
+public class V2_0_16WidenLogsTaskIdMigration extends AbstractSQLMigrationScript {
+
+    public static final class MysqlLogStoreEnabled implements Condition {
+        @Override
+        public boolean matches(final ConditionContext context) {
+            return LogStoreTypeResolver.matches(context, "mysql");
+        }
+    }
+
+
+    private static final String SCRIPT_ID = "2.0.16-widen-logs-task-id-mysql";
+    private static final String SQL_RESOURCE = "/migrations/2.0.16-widen-logs-task-id-mysql.sql";
+
+    private final LogJdbcDataSourceProvider logDataSourceProvider;
+
+    public V2_0_16WidenLogsTaskIdMigration(final LogJdbcDataSourceProvider logDataSourceProvider) {
+        this.logDataSourceProvider = logDataSourceProvider;
+    }
+
+    @Override
+    public String scriptId() {
+        String table = logDataSourceProvider.table();
+        return "logs".equals(table) ? SCRIPT_ID : SCRIPT_ID + "-" + table;
+    }
+
+    @Override
+    public String description() {
+        return "MySQL dedicated log store: widen task_id to VARCHAR(256)";
+    }
+
+    @Override
+    public List<String> sqlResources() {
+        return List.of(SQL_RESOURCE);
+    }
+
+    @Override
+    protected DataSource dataSource() {
+        return logDataSourceProvider.dataSource();
+    }
+
+    @Override
+    public void migrate() throws Exception {
+        executeSqlScript(dataSource(), SQL_RESOURCE, Map.of("table", logDataSourceProvider.table()));
+    }
+}

--- a/jdbc-mysql/src/main/java/io/kestra/repository/mysql/migration/V2_0_16WidenMetricsTaskIdMigration.java
+++ b/jdbc-mysql/src/main/java/io/kestra/repository/mysql/migration/V2_0_16WidenMetricsTaskIdMigration.java
@@ -1,0 +1,41 @@
+package io.kestra.repository.mysql.migration;
+
+import java.util.List;
+
+import javax.sql.DataSource;
+
+import io.kestra.jdbc.migration.AbstractV2_0_16WidenMetricsTaskIdMigration;
+import io.kestra.repository.mysql.MysqlRepositoryEnabled;
+
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+
+/**
+ * OSS MySQL metrics task_id widening migration (primary datasource).
+ *
+ * <p>
+ * Guarded on MySQL: modifying a {@code STORED GENERATED} column rebuilds the table
+ * ({@code ALGORITHM=COPY}), so the SQL widens only when the column is still shorter than 256,
+ * skipping the rebuild for installs already at 256 (e.g. arriving from Kestra 1.3.x).
+ */
+@Singleton
+@MysqlRepositoryEnabled
+public class V2_0_16WidenMetricsTaskIdMigration extends AbstractV2_0_16WidenMetricsTaskIdMigration {
+
+    private final DataSource dataSource;
+
+    @Inject
+    public V2_0_16WidenMetricsTaskIdMigration(final DataSource dataSource) {
+        this.dataSource = dataSource;
+    }
+
+    @Override
+    protected DataSource dataSource() {
+        return dataSource;
+    }
+
+    @Override
+    public List<String> sqlResources() {
+        return List.of("/migrations/2.0.16-widen-metrics-task-id-mysql.sql");
+    }
+}

--- a/jdbc-mysql/src/main/resources/migrations/2.0.16-widen-logs-task-id-mysql.sql
+++ b/jdbc-mysql/src/main/resources/migrations/2.0.16-widen-logs-task-id-mysql.sql
@@ -1,0 +1,8 @@
+-- Widen the dedicated log-store table's generated task_id column to VARCHAR(256).
+-- Guarded: modifying a STORED GENERATED column rebuilds the table (ALGORITHM=COPY), so widen only
+-- when still shorter than 256. ${table} is substituted with the configured log table name.
+SET @len = (SELECT CHARACTER_MAXIMUM_LENGTH FROM information_schema.columns WHERE table_schema = DATABASE() AND table_name = '${table}' AND column_name = 'task_id');
+SET @sql = IF(@len IS NOT NULL AND @len < 256, 'ALTER TABLE ${table} MODIFY COLUMN `task_id` VARCHAR(256) GENERATED ALWAYS AS (value ->> ''$.taskId'') STORED', 'SELECT 1');
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;

--- a/jdbc-mysql/src/main/resources/migrations/2.0.16-widen-metrics-task-id-mysql.sql
+++ b/jdbc-mysql/src/main/resources/migrations/2.0.16-widen-metrics-task-id-mysql.sql
@@ -1,0 +1,9 @@
+-- Widen the metrics.task_id generated column from 150 to 256 to match Task.id's @Size(max = 256).
+-- Modifying a STORED GENERATED column rebuilds the table (ALGORITHM=COPY), so the ALTER is guarded by
+-- an information_schema length check and runs only when the column is still shorter than 256 —
+-- skipping the rebuild for installs already at 256 (e.g. arriving from Kestra 1.3.x).
+SET @len = (SELECT CHARACTER_MAXIMUM_LENGTH FROM information_schema.columns WHERE table_schema = DATABASE() AND table_name = 'metrics' AND column_name = 'task_id');
+SET @sql = IF(@len IS NOT NULL AND @len < 256, 'ALTER TABLE metrics MODIFY COLUMN `task_id` VARCHAR(256) GENERATED ALWAYS AS (value ->> ''$.taskId'') STORED', 'SELECT 1');
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;

--- a/jdbc-postgres/src/main/java/io/kestra/repository/postgres/migration/V2_0_16WidenLogsTaskIdMigration.java
+++ b/jdbc-postgres/src/main/java/io/kestra/repository/postgres/migration/V2_0_16WidenLogsTaskIdMigration.java
@@ -1,0 +1,76 @@
+package io.kestra.repository.postgres.migration;
+
+import java.util.List;
+import java.util.Map;
+
+import javax.sql.DataSource;
+
+import io.kestra.jdbc.LogJdbcDataSourceProvider;
+import io.kestra.jdbc.migration.AbstractSQLMigrationScript;
+import io.kestra.jdbc.migration.LogStoreTypeResolver;
+
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.context.condition.Condition;
+import io.micronaut.context.condition.ConditionContext;
+import jakarta.inject.Singleton;
+
+/**
+ * Postgres log-store task_id widening migration.
+ *
+ * <p>
+ * Widens the generated {@code task_id} column to {@code VARCHAR(256)} on the log-store table resolved
+ * by {@link LogJdbcDataSourceProvider} (a dedicated database when {@code kestra.logs.postgres.url} is
+ * set, otherwise the primary datasource). Mirrors {@code V2_0_14LogsMigration}: the scriptId encodes
+ * the backend ("-postgres") and a non-default table name, so switching the log-repo backend re-applies it.
+ *
+ * <p>
+ * Runs whenever the effective log-store dialect is Postgres — a configured {@code kestra.logs.type=postgres}
+ * or the fallback to a Postgres {@code kestra.repository.type} (logs kept in the main database).
+ */
+@Singleton
+@Requires(condition = V2_0_16WidenLogsTaskIdMigration.PostgresLogStoreEnabled.class)
+public class V2_0_16WidenLogsTaskIdMigration extends AbstractSQLMigrationScript {
+
+    public static final class PostgresLogStoreEnabled implements Condition {
+        @Override
+        public boolean matches(final ConditionContext context) {
+            return LogStoreTypeResolver.matches(context, "postgres");
+        }
+    }
+
+
+    private static final String SCRIPT_ID = "2.0.16-widen-logs-task-id-postgres";
+    private static final String SQL_RESOURCE = "/migrations/2.0.16-widen-logs-task-id-postgres.sql";
+
+    private final LogJdbcDataSourceProvider logDataSourceProvider;
+
+    public V2_0_16WidenLogsTaskIdMigration(final LogJdbcDataSourceProvider logDataSourceProvider) {
+        this.logDataSourceProvider = logDataSourceProvider;
+    }
+
+    @Override
+    public String scriptId() {
+        String table = logDataSourceProvider.table();
+        return "logs".equals(table) ? SCRIPT_ID : SCRIPT_ID + "-" + table;
+    }
+
+    @Override
+    public String description() {
+        return "Postgres dedicated log store: widen task_id to VARCHAR(256)";
+    }
+
+    @Override
+    public List<String> sqlResources() {
+        return List.of(SQL_RESOURCE);
+    }
+
+    @Override
+    protected DataSource dataSource() {
+        return logDataSourceProvider.dataSource();
+    }
+
+    @Override
+    public void migrate() throws Exception {
+        executeSqlScript(dataSource(), SQL_RESOURCE, Map.of("table", logDataSourceProvider.table()));
+    }
+}

--- a/jdbc-postgres/src/main/java/io/kestra/repository/postgres/migration/V2_0_16WidenMetricsTaskIdMigration.java
+++ b/jdbc-postgres/src/main/java/io/kestra/repository/postgres/migration/V2_0_16WidenMetricsTaskIdMigration.java
@@ -1,0 +1,36 @@
+package io.kestra.repository.postgres.migration;
+
+import java.util.List;
+
+import javax.sql.DataSource;
+
+import io.kestra.jdbc.migration.AbstractV2_0_16WidenMetricsTaskIdMigration;
+import io.kestra.repository.postgres.PostgresRepositoryEnabled;
+
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+
+/**
+ * OSS Postgres metrics task_id widening migration (primary datasource).
+ */
+@Singleton
+@PostgresRepositoryEnabled
+public class V2_0_16WidenMetricsTaskIdMigration extends AbstractV2_0_16WidenMetricsTaskIdMigration {
+
+    private final DataSource dataSource;
+
+    @Inject
+    public V2_0_16WidenMetricsTaskIdMigration(final DataSource dataSource) {
+        this.dataSource = dataSource;
+    }
+
+    @Override
+    protected DataSource dataSource() {
+        return dataSource;
+    }
+
+    @Override
+    public List<String> sqlResources() {
+        return List.of("/migrations/2.0.16-widen-metrics-task-id-postgres.sql");
+    }
+}

--- a/jdbc-postgres/src/main/resources/migrations/2.0.16-widen-logs-task-id-postgres.sql
+++ b/jdbc-postgres/src/main/resources/migrations/2.0.16-widen-logs-task-id-postgres.sql
@@ -1,0 +1,3 @@
+-- Widen the dedicated log-store table's generated task_id column to VARCHAR(256).
+-- Metadata-only on Postgres (no table rewrite). ${table} is substituted with the configured log table.
+ALTER TABLE ${table} ALTER COLUMN task_id TYPE VARCHAR(256);

--- a/jdbc-postgres/src/main/resources/migrations/2.0.16-widen-metrics-task-id-postgres.sql
+++ b/jdbc-postgres/src/main/resources/migrations/2.0.16-widen-metrics-task-id-postgres.sql
@@ -1,0 +1,3 @@
+-- Widen the metrics.task_id generated column from 150 to 256 to match Task.id's @Size(max = 256).
+-- Metadata-only on Postgres (no table rewrite); NOT NULL is preserved.
+ALTER TABLE metrics ALTER COLUMN task_id TYPE VARCHAR(256);

--- a/jdbc/src/main/java/io/kestra/jdbc/migration/AbstractV2_0_16WidenMetricsTaskIdMigration.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/migration/AbstractV2_0_16WidenMetricsTaskIdMigration.java
@@ -1,0 +1,28 @@
+package io.kestra.jdbc.migration;
+
+/**
+ * Abstract base for the 2.0.16 metrics task_id widening migration (main/primary datasource).
+ *
+ * <p>
+ * Widens the generated {@code task_id} column of the {@code metrics} table from {@code VARCHAR(150)}
+ * to {@code VARCHAR(256)} to match {@code Task.id}'s {@code @Size(max = 256)}. A plugin-generated
+ * {@code taskId} (e.g. Ansible {@code "<host> | <play> : <task>"}) can exceed 150 chars and overflow
+ * the column, crash-looping the JDBC indexer. Concrete subclasses provide the per-dialect SQL resource
+ * and the primary {@link javax.sql.DataSource}.
+ *
+ * <p>
+ * This migration targets the {@code metrics} table only; the log table's {@code task_id} is widened
+ * separately by the {@code 2.0.16-widen-logs-task-id-<dialect>} migration against the log datasource.
+ */
+public abstract class AbstractV2_0_16WidenMetricsTaskIdMigration extends AbstractSQLMigrationScript {
+
+    @Override
+    public String scriptId() {
+        return "2.0.16-widen-metrics-task-id";
+    }
+
+    @Override
+    public String description() {
+        return "Widen the metrics task_id column to VARCHAR(256) to match Task.id max size";
+    }
+}

--- a/jdbc/src/main/java/io/kestra/jdbc/migration/LogStoreTypeResolver.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/migration/LogStoreTypeResolver.java
@@ -1,0 +1,45 @@
+package io.kestra.jdbc.migration;
+
+import java.util.Optional;
+
+import io.micronaut.context.condition.ConditionContext;
+
+/**
+ * Resolves the effective JDBC log-store dialect for migration gating.
+ *
+ * <p>
+ * The log store type is {@code kestra.logs.type} when set, otherwise it falls back to
+ * {@code kestra.repository.type} (logs stored in the main database) — mirroring
+ * {@code KestraBeansFactory.getLogDataStorePluginId}. {@code memory} maps to {@code h2}.
+ *
+ * <p>
+ * Used by the log-table widening migrations so they run for the dialect that actually backs the log
+ * store, whether a dedicated log repository is configured or logs use the current repository backend.
+ */
+public final class LogStoreTypeResolver {
+
+    private LogStoreTypeResolver() {
+    }
+
+    /**
+     * @return the effective log-store dialect ({@code kestra.logs.type ?? kestra.repository.type},
+     *         {@code memory} → {@code h2}), or empty when neither property is set.
+     */
+    public static Optional<String> effectiveType(final ConditionContext<?> context) {
+        String type = context.getProperty("kestra.logs.type", String.class)
+            .orElseGet(() -> context.getProperty("kestra.repository.type", String.class).orElse(null));
+
+        if (type == null) {
+            return Optional.empty();
+        }
+
+        return Optional.of(type.equalsIgnoreCase("memory") ? "h2" : type.toLowerCase());
+    }
+
+    /**
+     * @return {@code true} when the effective log-store dialect equals the given dialect.
+     */
+    public static boolean matches(final ConditionContext<?> context, final String dialect) {
+        return effectiveType(context).map(type -> type.equalsIgnoreCase(dialect)).orElse(false);
+    }
+}

--- a/tests/src/main/java/io/kestra/core/repositories/AbstractLogDataStoreTest.java
+++ b/tests/src/main/java/io/kestra/core/repositories/AbstractLogDataStoreTest.java
@@ -181,6 +181,21 @@ public abstract class AbstractLogDataStoreTest {
     }
 
     @Test
+    void shouldPersistTaskIdLongerThan150Chars() {
+        // A plugin-generated taskId (e.g. Ansible "<host> | <play> : <task>") can exceed the legacy
+        // VARCHAR(150) task_id column and crash-loop the indexer; the column now allows up to 256.
+        String tenant = TestsUtils.randomTenant(this.getClass().getSimpleName());
+        String longTaskId = "a".repeat(200);
+        LogEntry log = logEntry(tenant, Level.INFO, "execLongTaskId").taskId(longTaskId).build();
+
+        LogEntry saved = logRepository.save(log);
+
+        List<LogEntry> found = logRepository.findByExecutionIdAndTaskId(tenant, saved.getExecutionId(), longTaskId, null);
+        assertThat(found).hasSize(1);
+        assertThat(found.getFirst().getTaskId()).isEqualTo(longTaskId);
+    }
+
+    @Test
     void all() {
         String tenant = TestsUtils.randomTenant(this.getClass().getSimpleName());
         LogEntry.LogEntryBuilder builder = logEntry(tenant, Level.INFO);


### PR DESCRIPTION
## What

Widen the generated `task_id` column from `VARCHAR(150)` → `VARCHAR(256)` on the `logs` and `metrics` tables for Kestra v2, via `MigrationRunner` increments.

## Why

The v2 counterpart of #17329. Root issue #17328: a `taskId` longer than 150 chars (e.g. a plugin-synthesized Ansible label `<host> | <play> : <task>`) overflows the generated `VARCHAR(150)` `task_id` column; the JDBC indexer treats the SQL error as fatal and shuts the server down, crash-looping the instance.

## How

Two increments (both `task_id`→256, guarded on MySQL):
- **`2.0.16-widen-task-id`** (repository-type gated, primary datasource): widens `metrics` and the main-DB `logs` table — covers the default/co-located log store (Kestra enforces a co-located store matches the repository dialect).
- **`2.0.16-widen-logs-task-id-<dialect>`** (`kestra.logs.type` gated, `LogJdbcDataSourceProvider`): widens a **dedicated** external log DB. Mirrors `V2_0_14LogsMigration`; its **scriptId encodes the datasource** (`-<dialect>[-<table>]`) so switching the log-repo backend re-applies it.

**MySQL guard:** modifying a `STORED GENERATED` column rebuilds the table (`ALGORITHM=COPY`). Each ALTER is guarded by an `information_schema.CHARACTER_MAXIMUM_LENGTH < 256` check so it skips the rebuild for installs already at 256 (e.g. upgraded from Kestra 1.3.x, which widened it via Flyway). Postgres/H2 are metadata-only.

## Tests

TDD regression tests added to `AbstractMetricRepositoryTest` and `AbstractLogDataStoreTest` (persist a 200-char taskId); red before the migrations, green after. Full H2 log + metric suites pass.

## Companion / residual

- EE companion (H2 asset-table parity): kestra-io/kestra-ee (linked in a comment).
- Residual: a pure back-compat install with **no `kestra.logs.type`** keeps logs in the baseline main-DB `logs` table — covered by the primary-DS migration above. A `taskId` >256 is still out of range (unvalidated dynamic-taskrun path) — separate follow-up.
