### PR TITLE
chore: remove sourcemap warning

### DIFF
--- a/ui/patches/monaco-editor+0.52.2.patch
+++ b/ui/patches/monaco-editor+0.52.2.patch
@@ -1,0 +1,10 @@
+diff --git a/node_modules/monaco-editor/esm/vs/base/common/marked/marked.js b/node_modules/monaco-editor/esm/vs/base/common/marked/marked.js
+index 56333ff..d743087 100644
+--- a/node_modules/monaco-editor/esm/vs/base/common/marked/marked.js
++++ b/node_modules/monaco-editor/esm/vs/base/common/marked/marked.js
+@@ -2534,5 +2534,3 @@ export var setOptions = (__marked_exports.setOptions || exports.setOptions);
+ export var use = (__marked_exports.use || exports.use);
+ export var walkTokens = (__marked_exports.walkTokens || exports.walkTokens);
+ // ESM-uncomment-end
+-
+-//# sourceMappingURL=marked.umd.js.map

--- a/ui/vitest.config.js
+++ b/ui/vitest.config.js
@@ -13,36 +13,16 @@ const dirname =
         ? __dirname
         : path.dirname(fileURLToPath(import.meta.url))
 
-// `vitest run --merge-reports` never executes tests — it only reads the blob
-// files written by the sharded runs and regenerates a combined report. But
-// merely loading the full "storybook" project config still boots a Vite dev
-// server, and its esbuild dependency optimizer segfaults during the
-// "scanning dependencies" step (confirmed both in CI and locally) even though
-// no test ever actually runs in this mode.
-//
-// Swapping in a lighter project definition for merge mode (tried twice: bare
-// name only, then bare name + a matching `include` glob) avoids the crash but
-// breaks the merge in a different way: each blob records the `pool` the
-// original shard ran under (`"browser"`), and `mergeReports()` recreates each
-// specification against the *current* project using that exact pool
-// (`createSpecification(file.filepath, void 0, file.pool)`). A project
-// without a matching `browser` config can't back a "browser" pool spec, so
-// nothing ends up registered as a test module even though the raw per-file
-// results still print — and the default reporter's `onTestRunEnd` treats a
-// zero-length module list as "No test files found", regardless of how much
-// output was already printed.
-//
-// So the project identity/pool shape must stay exactly the same between the
-// sharded runs and the merge. Instead, target the actual crash directly:
-// disable Vite's automatic dependency *scan* (`optimizeDeps.noDiscovery`)
-// only during merge, since nothing is ever served or executed in this mode
-// and the scan has nothing legitimate to do anyway.
+// `--merge-reports` only recombines existing report blobs; it runs no tests.
+// But loading the config still boots a Vite dev server whose dependency scan
+// segfaults (CI and locally). We can't swap in a lighter project to dodge it:
+// the merge recreates each spec using the pool recorded in its blob ("browser"),
+// so the project's pool shape must match the sharded runs exactly.
+// Instead, disable the scan during merge only — nothing is served here anyway.
 const isMergeReports = process.argv.includes("--merge-reports")
 
 const resolvedViteConfig = typeof viteConfig === "function" ? viteConfig({mode: "test"}) : viteConfig
 
-// No backend is available during tests — clear the API proxy so Vite doesn't
-// emit "[vite] http proxy error" for every story that fires an /api request.
 if (resolvedViteConfig.server) {
     resolvedViteConfig.server.proxy = {}
 }

--- a/ui/vitest.config.unit.js
+++ b/ui/vitest.config.unit.js
@@ -25,11 +25,7 @@ export default defineProject({
             "tests/e2e/**",
             "node_modules/**",
             "tests/unit/**/translation.spec.js",
-            // Design system has its own dedicated CI job (Frontend - Design System
-            // tests) running its own vitest config/setup from within that package.
-            // Without this exclude, this project's default include glob picks up
-            // those same test files too, re-running them a second time here under
-            // the wrong setup file (missing the design-system-specific mocks).
+            // Design system runs in its own CI job with its own config/setup; no more double run.
             "packages/design-system/**",
         ],
     },


### PR DESCRIPTION
When running the dev env we sometimes get irrelevant warnings from vite:

```log
11:28:50 AM [vite] (client) Failed to load source map for kestra/ui/node_modules/monaco-editor/esm/vs/base/common/marked/marked.js.
Error: An error occurred while trying to read the map file at marked.umd.js.map
Error: ENOENT: no such file or directory, open 'kestra/ui/node_modules/monaco-editor/esm/vs/base/common/marked/marked.umd.js.map'
```

This change fixes it while removing some useless comments.