### PR TITLE
feat(executions): namespace and tenant concurrency limits — executor engine (kestra-ee#8660)

### DIFF
--- a/core/src/main/java/io/kestra/core/runners/ScopedConcurrencyLimit.java
+++ b/core/src/main/java/io/kestra/core/runners/ScopedConcurrencyLimit.java
@@ -1,0 +1,72 @@
+package io.kestra.core.runners;
+
+import java.util.Objects;
+
+import io.kestra.core.models.HasUID;
+import io.kestra.core.models.flows.Concurrency;
+import io.kestra.core.models.flows.FlowInterface;
+
+import jakarta.annotation.Nullable;
+import jakarta.validation.constraints.NotNull;
+
+/**
+ * A concurrency limit definition together with the scope it applies to.
+ * <p>
+ * A flow-scoped limit comes from the flow's own {@code concurrency} property; namespace and
+ * tenant scoped limits are an EE feature. The running counter of a scope is keyed by
+ * {@link #uid()}: for the {@link Scope#FLOW} scope it matches {@link ConcurrencyLimit#uid()},
+ * for broader scopes the absent parts are kept empty.
+ *
+ * @param scope the level this limit applies to
+ * @param tenantId the tenant, never null
+ * @param namespace the namespace the limit applies to, null for a tenant-scoped limit
+ * @param flowId the flow the limit applies to, null unless the scope is {@link Scope#FLOW}
+ * @param concurrency the limit and its behavior
+ */
+public record ScopedConcurrencyLimit(
+    @NotNull Scope scope,
+    @NotNull String tenantId,
+    @Nullable String namespace,
+    @Nullable String flowId,
+    @NotNull Concurrency concurrency) implements HasUID {
+
+    public enum Scope {
+        FLOW,
+        NAMESPACE,
+        TENANT
+    }
+
+    public static ScopedConcurrencyLimit ofFlow(FlowInterface flow) {
+        return new ScopedConcurrencyLimit(Scope.FLOW, flow.getTenantId(), flow.getNamespace(), flow.getId(), flow.getConcurrency());
+    }
+
+    public static ScopedConcurrencyLimit ofNamespace(String tenantId, String namespace, Concurrency concurrency) {
+        return new ScopedConcurrencyLimit(Scope.NAMESPACE, tenantId, namespace, null, concurrency);
+    }
+
+    public static ScopedConcurrencyLimit ofTenant(String tenantId, Concurrency concurrency) {
+        return new ScopedConcurrencyLimit(Scope.TENANT, tenantId, null, null, concurrency);
+    }
+
+    /**
+     * Whether the given execution coordinates fall inside this scope: the flow itself for a
+     * flow scope, the namespace or any descendant for a namespace scope, the whole tenant for
+     * a tenant scope.
+     */
+    public boolean covers(String tenantId, String namespace, String flowId) {
+        if (!Objects.equals(this.tenantId, tenantId)) {
+            return false;
+        }
+        return switch (this.scope) {
+            case FLOW -> Objects.equals(this.namespace, namespace) && Objects.equals(this.flowId, flowId);
+            case NAMESPACE -> Objects.equals(this.namespace, namespace) || (namespace != null && namespace.startsWith(this.namespace + "."));
+            case TENANT -> true;
+        };
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public String uid() {
+        return this.tenantId + "|" + Objects.requireNonNullElse(this.namespace, "") + "|" + Objects.requireNonNullElse(this.flowId, "");
+    }
+}

--- a/core/src/main/java/io/kestra/core/services/ConcurrencyLimitResolver.java
+++ b/core/src/main/java/io/kestra/core/services/ConcurrencyLimitResolver.java
@@ -1,0 +1,30 @@
+package io.kestra.core.services;
+
+import java.util.List;
+
+import io.kestra.core.models.flows.FlowInterface;
+import io.kestra.core.runners.ScopedConcurrencyLimit;
+
+import jakarta.inject.Singleton;
+
+/**
+ * Resolves the concurrency limits applying to the executions of a flow.
+ * <p>
+ * Limits are returned in evaluation order — flow, namespace, parent namespaces (innermost
+ * first), tenant — and the first limit reached defines the behavior. An execution that runs
+ * claims one slot in <b>every</b> returned scope.
+ * <p>
+ * Namespace and tenant level limits are an EE feature: this OSS implementation only resolves
+ * the flow's own {@code concurrency} property.
+ */
+@Singleton
+public class ConcurrencyLimitResolver {
+    /**
+     * All concurrency limits applying to executions of the given flow, in evaluation order.
+     *
+     * @return an empty list when no limit applies
+     */
+    public List<ScopedConcurrencyLimit> resolveLimits(FlowInterface flow) {
+        return flow.getConcurrency() == null ? List.of() : List.of(ScopedConcurrencyLimit.ofFlow(flow));
+    }
+}

--- a/executor/src/main/java/io/kestra/executor/ConcurrencyLimitStateStore.java
+++ b/executor/src/main/java/io/kestra/executor/ConcurrencyLimitStateStore.java
@@ -1,21 +1,31 @@
 package io.kestra.executor;
 
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
+import java.util.function.Function;
 
 import org.apache.commons.lang3.tuple.Pair;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import io.kestra.core.models.executions.Execution;
+import io.kestra.core.models.flows.Concurrency;
 import io.kestra.core.models.flows.FlowInterface;
 import io.kestra.core.runners.ConcurrencyLimit;
 import io.kestra.core.runners.ExecutionQueuedStateStore;
 import io.kestra.core.runners.ExecutionRunning;
+import io.kestra.core.runners.ScopedConcurrencyLimit;
 import io.kestra.core.runners.TransactionContext;
 
 /**
  * This state store is used by the {@link io.kestra.core.runners.Executor} to handle flow concurrency limit.
  */
 public interface ConcurrencyLimitStateStore {
+    Logger LOG = LoggerFactory.getLogger(ConcurrencyLimitStateStore.class);
+
     /**
      * Count running executions, then process the concurrency limit with the provided consumer.
      *
@@ -48,4 +58,78 @@ public interface ConcurrencyLimitStateStore {
      * @param consumer the consumer to call with the popped execution (only called if pop succeeds and limit allows)
      */
     void decrementAndPop(FlowInterface flow, ExecutionQueuedStateStore executionQueuedStateStore, BiConsumer<TransactionContext, Execution> consumer);
+
+    /**
+     * Atomically read the running counter of every given scope, hand the counts (in scope
+     * order) to the decision function, and — when it asks to claim — increment every scope
+     * counter within the same transaction. The consumer receives the transaction context so it
+     * can attach related writes (e.g. saving a queued execution) to the same transaction.
+     * <p>
+     * The default implementation only supports the single flow-scoped limit case (the OSS
+     * semantics) and delegates to {@link #countThenProcess(FlowInterface, BiFunction)};
+     * implementors must override it to support namespace or tenant scoped limits.
+     *
+     * @param flow the flow whose execution is evaluated
+     * @param limits the applicable limits in evaluation order, never empty
+     * @param consumer decides from the running counts; returns the processed execution and
+     *        whether to claim one slot in every scope
+     */
+    default ExecutionRunning countThenProcess(FlowInterface flow, List<ScopedConcurrencyLimit> limits,
+        BiFunction<TransactionContext, List<Integer>, Pair<ExecutionRunning, Boolean>> consumer) {
+        if (limits.size() == 1 && limits.getFirst().scope() == ScopedConcurrencyLimit.Scope.FLOW) {
+            return countThenProcess(flow, (txContext, concurrencyLimit) ->
+            {
+                int running = concurrencyLimit.getRunning() == null ? 0 : concurrencyLimit.getRunning();
+                Pair<ExecutionRunning, Boolean> result = consumer.apply(txContext, List.of(running));
+                return Pair.of(result.getLeft(), Boolean.TRUE.equals(result.getRight()) ? concurrencyLimit.withRunning(running + 1) : concurrencyLimit);
+            });
+        }
+        throw new UnsupportedOperationException("This state store only supports flow-scoped concurrency limits");
+    }
+
+    /**
+     * Atomically release the slots a terminated execution holds — decrement the counter of
+     * every given scope — then pop the oldest queued execution that fits <b>all</b> of its own
+     * scopes, skipping candidates that do not fit yet. The popped execution's scope counters
+     * are incremented in the same transaction and the mapped execution is returned; the caller
+     * must emit it only after this method returns, never from inside the transaction.
+     * <p>
+     * The default implementation only supports the single flow-scoped limit case (the OSS
+     * semantics): for the {@link Concurrency.Behavior#QUEUE} behavior it delegates to
+     * {@link #decrementAndPop(FlowInterface, ExecutionQueuedStateStore, BiConsumer)}, otherwise
+     * to {@link #decrement(FlowInterface)}. Implementors must override it to support namespace
+     * or tenant scoped limits.
+     *
+     * @param flow the flow of the terminated execution
+     * @param limits the limits applying to the terminated execution, in evaluation order, never empty
+     * @param executionQueuedStateStore the store queued candidates are popped from
+     * @param candidateLimits resolves the limits applying to a queued candidate (its flow may
+     *        differ from {@code flow} when namespace or tenant scopes are involved)
+     * @param consumer maps the popped execution to the execution to run (e.g. marks it RUNNING)
+     * @return the mapped popped execution, when one was popped
+     */
+    default Optional<Execution> releaseThenPop(
+        FlowInterface flow,
+        List<ScopedConcurrencyLimit> limits,
+        ExecutionQueuedStateStore executionQueuedStateStore,
+        Function<Execution, List<ScopedConcurrencyLimit>> candidateLimits,
+        BiFunction<TransactionContext, Execution, Execution> consumer) {
+        if (limits.size() == 1 && limits.getFirst().scope() == ScopedConcurrencyLimit.Scope.FLOW) {
+            if (limits.getFirst().concurrency().getBehavior() == Concurrency.Behavior.QUEUE) {
+                AtomicReference<Execution> popped = new AtomicReference<>();
+                decrementAndPop(flow, executionQueuedStateStore, (txContext, queued) -> popped.set(consumer.apply(txContext, queued)));
+                return Optional.ofNullable(popped.get());
+            }
+
+            int newLimit = decrement(flow);
+            if (newLimit >= limits.getFirst().concurrency().getLimit()) {
+                LOG.error(
+                    "Concurrency limit reached for flow {}.{} after decrementing the execution running count due to a terminated execution. This should not happen.",
+                    flow.getNamespace(), flow.getId()
+                );
+            }
+            return Optional.empty();
+        }
+        throw new UnsupportedOperationException("This state store only supports flow-scoped concurrency limits");
+    }
 }

--- a/executor/src/main/java/io/kestra/executor/ConcurrencySlotReleaseProcessor.java
+++ b/executor/src/main/java/io/kestra/executor/ConcurrencySlotReleaseProcessor.java
@@ -1,23 +1,26 @@
 package io.kestra.executor;
 
+import java.util.List;
 import java.util.Optional;
-import java.util.concurrent.atomic.AtomicReference;
 
 import io.kestra.core.metrics.MetricRegistry;
 import io.kestra.core.models.executions.Execution;
 import io.kestra.core.models.flows.Concurrency;
 import io.kestra.core.models.flows.State;
 import io.kestra.core.runners.ExecutionQueuedStateStore;
+import io.kestra.core.runners.FlowMetaStoreInterface;
+import io.kestra.core.runners.ScopedConcurrencyLimit;
+import io.kestra.core.services.ConcurrencyLimitResolver;
 
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
-import lombok.extern.slf4j.Slf4j;
 
 /**
- * Releases a terminated execution's concurrency slot and, for the QUEUE behavior, pops the next
- * queued execution — returning it to the caller instead of emitting it.
+ * Releases a terminated execution's concurrency slots — one per applicable scope: flow,
+ * namespace, tenant — and pops the next queued execution that fits all of its own scopes,
+ * returning it to the caller instead of emitting it.
  * <p>
- * IMPORTANT — transactional outbox: {@link ConcurrencyLimitStateStore#decrementAndPop} runs its
+ * IMPORTANT — transactional outbox: {@link ConcurrencyLimitStateStore#releaseThenPop} runs its
  * consumer inside the concurrency-limit store's transaction. Queue messages must never be emitted
  * from inside that transaction: on brokers with their own transactionality (e.g. Kafka), a
  * consumer can observe the message before the state-store transaction commits and act on state
@@ -26,29 +29,40 @@ import lombok.extern.slf4j.Slf4j;
  * i.e. after the transaction has committed. Same rule as {@link ExecutionDelayProcessor}.
  */
 @Singleton
-@Slf4j
 public class ConcurrencySlotReleaseProcessor {
     private final ConcurrencyLimitStateStore concurrencyLimitStateStore;
+    private final ConcurrencyLimitResolver concurrencyLimitResolver;
     private final ExecutionQueuedStateStore executionQueuedStateStore;
+    private final FlowMetaStoreInterface flowMetaStore;
     private final MetricRegistry metricRegistry;
 
     @Inject
     public ConcurrencySlotReleaseProcessor(
         ConcurrencyLimitStateStore concurrencyLimitStateStore,
+        ConcurrencyLimitResolver concurrencyLimitResolver,
         ExecutionQueuedStateStore executionQueuedStateStore,
+        FlowMetaStoreInterface flowMetaStore,
         MetricRegistry metricRegistry) {
         this.concurrencyLimitStateStore = concurrencyLimitStateStore;
+        this.concurrencyLimitResolver = concurrencyLimitResolver;
         this.executionQueuedStateStore = executionQueuedStateStore;
+        this.flowMetaStore = flowMetaStore;
         this.metricRegistry = metricRegistry;
     }
 
     /**
-     * Releases the slot held by the terminated execution of {@code executor} (whose flow must
-     * have a concurrency limit) and returns the next queued execution, already marked RUNNING,
-     * when one was popped. The caller must emit the returned execution only after this method
-     * returns — never from inside the state-store transaction (see the class Javadoc).
+     * Releases the slots held by the terminated execution of {@code executor} in every
+     * applicable concurrency scope — a no-op when no limit applies to its flow — and returns
+     * the next queued execution, already marked RUNNING, when one was popped. The caller must
+     * emit the returned execution only after this method returns — never from inside the
+     * state-store transaction (see the class Javadoc).
      */
     public Optional<Execution> release(ExecutorContext executor) {
+        List<ScopedConcurrencyLimit> limits = concurrencyLimitResolver.resolveLimits(executor.getFlow());
+        if (limits.isEmpty()) {
+            return Optional.empty();
+        }
+
         Execution execution = executor.getExecution();
 
         // if an execution was queued but never running, it would have never been counted inside the concurrency limit and should not lead to popping a new queued execution
@@ -61,35 +75,25 @@ public class ConcurrencySlotReleaseProcessor {
         // as we may receive multiple time killed execution (one when we kill it, then one for each running worker task), we limit to the first we receive: when the state transitioned from KILLING to KILLED
         boolean killingThenKilled = execution.getState().getCurrent().isKilled() && executor.getOriginalState() == State.Type.KILLING;
         if (!queuedThenKilled && !concurrencyShortCircuitState && (!execution.getState().getCurrent().isKilled() || killingThenKilled)) {
-            if (executor.getFlow().getConcurrency().getBehavior() == Concurrency.Behavior.QUEUE) {
-                AtomicReference<Execution> popped = new AtomicReference<>();
-
-                // Pop the next queued execution atomically with decrement/increment to avoid race conditions
-                // that could leave executions stuck in the queue indefinitely (see issue #13785)
-                concurrencyLimitStateStore.decrementAndPop(
-                    executor.getFlow(),
-                    executionQueuedStateStore,
-                    (txContext, queued) ->
-                    {
-                        var newExecution = queued.withState(State.Type.RUNNING);
-                        metricRegistry.counter(
-                            MetricRegistry.METRIC_EXECUTOR_EXECUTION_POPPED_COUNT, MetricRegistry.METRIC_EXECUTOR_EXECUTION_POPPED_COUNT_DESCRIPTION,
-                            metricRegistry.tags(newExecution)
-                        ).increment();
-                        popped.set(newExecution);
-                    }
-                );
-
-                return Optional.ofNullable(popped.get());
-            } else {
-                int newLimit = concurrencyLimitStateStore.decrement(executor.getFlow());
-                if (newLimit >= executor.getFlow().getConcurrency().getLimit()) {
-                    log.error(
-                        "Concurrency limit reached for flow {}.{} after decrementing the execution running count due to the terminated execution {}. This should not happen.",
-                        executor.getFlow().getNamespace(), executor.getFlow().getId(), executor.getExecution().getId()
-                    );
+            // Pop the next queued execution atomically with the decrements/increment to avoid race conditions
+            // that could leave executions stuck in the queue indefinitely (see issue #13785)
+            return concurrencyLimitStateStore.releaseThenPop(
+                executor.getFlow(),
+                limits,
+                executionQueuedStateStore,
+                candidate -> flowMetaStore.findByExecution(candidate)
+                    .map(concurrencyLimitResolver::resolveLimits)
+                    .orElse(List.of()),
+                (txContext, queued) ->
+                {
+                    var newExecution = queued.withState(State.Type.RUNNING);
+                    metricRegistry.counter(
+                        MetricRegistry.METRIC_EXECUTOR_EXECUTION_POPPED_COUNT, MetricRegistry.METRIC_EXECUTOR_EXECUTION_POPPED_COUNT_DESCRIPTION,
+                        metricRegistry.tags(newExecution)
+                    ).increment();
+                    return newExecution;
                 }
-            }
+            );
         }
 
         return Optional.empty();

--- a/executor/src/main/java/io/kestra/executor/DefaultExecutor.java
+++ b/executor/src/main/java/io/kestra/executor/DefaultExecutor.java
@@ -626,18 +626,17 @@ public class DefaultExecutor extends AbstractService implements Executor {
                     slaMonitorStateStore.purge(executor.getExecution().getId());
                 }
 
-                // check if there exists a queued execution and submit it to the execution queue
-                if (executor.getFlow().getConcurrency() != null) {
-                    // Transactional outbox: the processor pops inside the concurrency-limit
-                    // store's transaction and only returns the execution; it is emitted here,
-                    // after decrementAndPop() has committed (same rule as executionDelayLoop).
-                    Optional<Execution> popped = concurrencySlotReleaseProcessor.release(executor);
-                    if (popped.isPresent()) {
-                        executionQueue.emit(popped.get());
+                // release the concurrency slots (a no-op when no limit applies to the flow),
+                // then check if there exists a queued execution and submit it to the execution queue.
+                // Transactional outbox: the processor pops inside the concurrency-limit
+                // store's transaction and only returns the execution; it is emitted here,
+                // after releaseThenPop() has committed (same rule as executionDelayLoop).
+                Optional<Execution> popped = concurrencySlotReleaseProcessor.release(executor);
+                if (popped.isPresent()) {
+                    executionQueue.emit(popped.get());
 
-                        // process flow triggers to allow listening on RUNNING state after a QUEUED state
-                        processFlowTriggers(popped.get());
-                    }
+                    // process flow triggers to allow listening on RUNNING state after a QUEUED state
+                    processFlowTriggers(popped.get());
                 }
 
                 // purge the trigger: reset scheduler trigger at end

--- a/executor/src/main/java/io/kestra/executor/ExecutorService.java
+++ b/executor/src/main/java/io/kestra/executor/ExecutorService.java
@@ -99,13 +99,32 @@ public class ExecutorService {
 
     public ExecutionRunning processExecutionRunning(FlowInterface flow, int runningCount, ExecutionRunning executionRunning) {
         // if concurrency was removed, it can be null as we always get the latest flow definition
-        if (flow.getConcurrency() != null && runningCount >= flow.getConcurrency().getLimit()) {
-            return switch (flow.getConcurrency().getBehavior()) {
+        if (flow.getConcurrency() == null) {
+            return runExecutionRunning(executionRunning);
+        }
+
+        return processExecutionRunning(List.of(ScopedConcurrencyLimit.ofFlow(flow)), List.of(runningCount), executionRunning);
+    }
+
+    /**
+     * Evaluate the scoped concurrency limits in order against their running counts: the first
+     * limit reached defines the behavior applied to the execution; when none is reached the
+     * execution runs.
+     */
+    public ExecutionRunning processExecutionRunning(List<ScopedConcurrencyLimit> limits, List<Integer> runningCounts, ExecutionRunning executionRunning) {
+        for (int i = 0; i < limits.size(); i++) {
+            ScopedConcurrencyLimit limit = limits.get(i);
+            int runningCount = runningCounts.get(i);
+            if (runningCount < limit.concurrency().getLimit()) {
+                continue;
+            }
+
+            return switch (limit.concurrency().getBehavior()) {
                 case QUEUE -> {
                     Logs.logExecution(
                         executionRunning.getExecution(),
                         Level.INFO,
-                        "Execution is queued due to concurrency limit exceeded, {} running(s)",
+                        "Execution is queued due to " + scopeDescription(limit) + "concurrency limit exceeded, {} running(s)",
                         runningCount
                     );
                     var newExecution = executionRunning.getExecution().withState(State.Type.QUEUED);
@@ -120,7 +139,8 @@ public class ExecutorService {
                     .withExecution(executionRunning.getExecution().withState(State.Type.CANCELLED))
                     .withConcurrencyState(ExecutionRunning.ConcurrencyState.CANCELLED);
                 case FAIL -> {
-                    var failedExecution = executionRunning.getExecution().failedExecutionFromExecutor(new IllegalStateException("Execution is FAILED due to concurrency limit exceeded"));
+                    var failedExecution = executionRunning.getExecution()
+                        .failedExecutionFromExecutor(new IllegalStateException("Execution is FAILED due to " + scopeDescription(limit) + "concurrency limit exceeded"));
                     var logger = runContextLoggerFactory.create(executionRunning.getExecution());
                     logger.emitLogs(failedExecution.logs());
                     yield executionRunning
@@ -131,10 +151,22 @@ public class ExecutorService {
             };
         }
 
-        // if under the limit, run it!
+        // if under every limit, run it!
+        return runExecutionRunning(executionRunning);
+    }
+
+    private static ExecutionRunning runExecutionRunning(ExecutionRunning executionRunning) {
         return executionRunning
             .withExecution(executionRunning.getExecution().withState(State.Type.RUNNING))
             .withConcurrencyState(ExecutionRunning.ConcurrencyState.RUNNING);
+    }
+
+    private static String scopeDescription(ScopedConcurrencyLimit limit) {
+        return switch (limit.scope()) {
+            case FLOW -> "";
+            case NAMESPACE -> "namespace '" + limit.namespace() + "' ";
+            case TENANT -> "tenant ";
+        };
     }
 
     public ExecutorContext process(ExecutorContext executor) {

--- a/executor/src/main/java/io/kestra/executor/handler/ExecutionEventMessageHandler.java
+++ b/executor/src/main/java/io/kestra/executor/handler/ExecutionEventMessageHandler.java
@@ -25,6 +25,7 @@ import io.kestra.core.queues.DispatchQueueInterface;
 import io.kestra.core.queues.KeyedDispatchQueueInterface;
 import io.kestra.core.queues.QueueException;
 import io.kestra.core.runners.*;
+import io.kestra.core.services.ConcurrencyLimitResolver;
 import io.kestra.core.services.QuotaService;
 import io.kestra.core.services.WorkerQueueService;
 import io.kestra.core.trace.Tracer;
@@ -52,6 +53,7 @@ public class ExecutionEventMessageHandler implements ExecutorMessageHandler<Exec
     private final ExecutionDelayStateStore executionDelayStateStore;
     private final SLAMonitorStateStore slaMonitorStateStore;
     private final ConcurrencyLimitStateStore concurrencyLimitStateStore;
+    private final ConcurrencyLimitResolver concurrencyLimitResolver;
     private final ExecutorService executorService;
     private final WorkerQueueService workerGroupService;
     private final QuotaService quotaService;
@@ -72,6 +74,7 @@ public class ExecutionEventMessageHandler implements ExecutorMessageHandler<Exec
         ExecutionDelayStateStore executionDelayStateStore,
         SLAMonitorStateStore slaMonitorStateStore,
         ConcurrencyLimitStateStore concurrencyLimitStateStore,
+        ConcurrencyLimitResolver concurrencyLimitResolver,
         ExecutorService executorService,
         WorkerQueueService workerGroupService,
         QuotaService quotaService,
@@ -89,6 +92,7 @@ public class ExecutionEventMessageHandler implements ExecutorMessageHandler<Exec
         this.executionDelayStateStore = executionDelayStateStore;
         this.slaMonitorStateStore = slaMonitorStateStore;
         this.concurrencyLimitStateStore = concurrencyLimitStateStore;
+        this.concurrencyLimitResolver = concurrencyLimitResolver;
         this.executorService = executorService;
         this.workerGroupService = workerGroupService;
         this.quotaService = quotaService;
@@ -178,8 +182,10 @@ public class ExecutionEventMessageHandler implements ExecutorMessageHandler<Exec
                                 return executor.withExecution(newExecution, "processQuotas");
                             }
 
-                            // handle concurrency limit
-                            if (flow.getConcurrency() != null) {
+                            // handle concurrency limits — flow, namespace and tenant scoped; an execution that
+                            // runs claims one slot in every scope, the first limit reached defines the behavior
+                            List<ScopedConcurrencyLimit> concurrencyLimits = concurrencyLimitResolver.resolveLimits(flow);
+                            if (!concurrencyLimits.isEmpty()) {
                                 ExecutionRunning executionRunning = ExecutionRunning.builder()
                                     .tenantId(executor.getFlow().getTenantId())
                                     .namespace(executor.getFlow().getNamespace())
@@ -188,15 +194,15 @@ public class ExecutionEventMessageHandler implements ExecutorMessageHandler<Exec
                                     .concurrencyState(ExecutionRunning.ConcurrencyState.CREATED)
                                     .build();
 
-                                ExecutionRunning processed = concurrencyLimitStateStore.countThenProcess(flow, (txContext, concurrencyLimit) ->
+                                ExecutionRunning processed = concurrencyLimitStateStore.countThenProcess(flow, concurrencyLimits, (txContext, runningCounts) ->
                                 {
-                                    ExecutionRunning computed = executorService.processExecutionRunning(flow, concurrencyLimit.getRunning(), executionRunning.withExecution(execution)); // be sure that the execution running contains the latest value of the execution
+                                    ExecutionRunning computed = executorService.processExecutionRunning(concurrencyLimits, runningCounts, executionRunning.withExecution(execution)); // be sure that the execution running contains the latest value of the execution
                                     if (computed.getConcurrencyState() == ExecutionRunning.ConcurrencyState.RUNNING && !computed.getExecution().getState().isTerminated()) {
-                                        return Pair.of(computed, concurrencyLimit.withRunning(concurrencyLimit.getRunning() + 1));
+                                        return Pair.of(computed, true);
                                     } else if (computed.getConcurrencyState() == ExecutionRunning.ConcurrencyState.QUEUED) {
                                         executionQueuedStateStore.save(txContext, ExecutionQueued.fromExecutionRunning(computed));
                                     }
-                                    return Pair.of(computed, concurrencyLimit);
+                                    return Pair.of(computed, false);
                                 });
 
                                 // if the execution is queued or terminated due to concurrency limit, we stop here

--- a/executor/src/test/java/io/kestra/executor/ConcurrencyLimitStateStoreContract.java
+++ b/executor/src/test/java/io/kestra/executor/ConcurrencyLimitStateStoreContract.java
@@ -3,6 +3,7 @@ package io.kestra.executor;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.apache.commons.lang3.tuple.Pair;
@@ -13,6 +14,7 @@ import io.kestra.core.models.flows.Concurrency;
 import io.kestra.core.models.flows.Flow;
 import io.kestra.core.runners.ExecutionQueued;
 import io.kestra.core.runners.ExecutionQueuedStateStore;
+import io.kestra.core.runners.ScopedConcurrencyLimit;
 import io.kestra.core.utils.IdUtils;
 import io.kestra.plugin.core.log.Log;
 
@@ -35,12 +37,16 @@ public abstract class ConcurrencyLimitStateStoreContract {
     protected abstract ExecutionQueuedStateStore queuedStore();
 
     protected static Flow flow(int limit) {
+        return flow(limit, Concurrency.Behavior.QUEUE);
+    }
+
+    protected static Flow flow(int limit, Concurrency.Behavior behavior) {
         return Flow.builder()
             .tenantId("main")
             .namespace("io.kestra.unittest")
             .id(IdUtils.create())
             .revision(1)
-            .concurrency(Concurrency.builder().behavior(Concurrency.Behavior.QUEUE).limit(limit).build())
+            .concurrency(Concurrency.builder().behavior(behavior).limit(limit).build())
             .tasks(List.of(Log.builder().id("log").type(Log.class.getName()).message("test").build()))
             .build();
     }
@@ -129,6 +135,103 @@ public abstract class ConcurrencyLimitStateStoreContract {
         store().decrementAndPop(flow, queuedStore(), (txContext, execution) -> popped.add(execution));
         assertThat(popped).extracting(Execution::getId).containsExactly(waiting.getId());
         assertThat(currentCount(flow)).isEqualTo(1);
+    }
+
+    // --- scoped operations, single flow scope: the semantics every store gets from the
+    // default adapter methods and that scoped-capable implementations must reproduce
+
+    @Test
+    void shouldClaimSlotThroughScopedGateOnlyWhenConsumerClaims() {
+        // Given
+        Flow flow = flow(2);
+        List<ScopedConcurrencyLimit> limits = List.of(ScopedConcurrencyLimit.ofFlow(flow));
+
+        // When: a first evaluation claims, a second declines
+        List<List<Integer>> seen = new ArrayList<>();
+        store().countThenProcess(flow, limits, (txContext, counts) ->
+        {
+            seen.add(counts);
+            return Pair.of(null, true);
+        });
+        store().countThenProcess(flow, limits, (txContext, counts) ->
+        {
+            seen.add(counts);
+            return Pair.of(null, false);
+        });
+
+        // Then: the consumer saw the running counts in scope order, only the claim incremented
+        assertThat(seen).containsExactly(List.of(0), List.of(1));
+        assertThat(currentCount(flow)).isEqualTo(1);
+    }
+
+    @Test
+    void shouldPopOldestQueuedThroughScopedReleaseAndHandItTheFreedSlot() {
+        // Given: one running execution at the limit, two queued behind it (older first)
+        Flow flow = flow(1);
+        List<ScopedConcurrencyLimit> limits = List.of(ScopedConcurrencyLimit.ofFlow(flow));
+        Execution first = Execution.newExecution(flow, List.of());
+        Execution second = Execution.newExecution(flow, List.of());
+        Instant now = Instant.now();
+        store().countThenProcess(flow, (txContext, limit) ->
+        {
+            queuedStore().save(txContext, queued(flow, first, now.minusSeconds(60)));
+            queuedStore().save(txContext, queued(flow, second, now));
+            return Pair.of(null, limit.withRunning(1));
+        });
+
+        // When: the running execution terminates and frees its slot
+        Optional<Execution> popped = store().releaseThenPop(
+            flow, limits, queuedStore(),
+            candidate -> limits,
+            (txContext, queued) -> queued
+        );
+
+        // Then: FIFO by date, and the popped execution took over the freed slot
+        assertThat(popped).map(Execution::getId).contains(first.getId());
+        assertThat(currentCount(flow)).isEqualTo(1);
+    }
+
+    @Test
+    void shouldOnlyReleaseSlotThroughScopedReleaseWhenBehaviorIsNotQueue() {
+        // Given: a CANCEL-behavior flow holding one slot (nothing can be queued under CANCEL)
+        Flow flow = flow(1, Concurrency.Behavior.CANCEL);
+        List<ScopedConcurrencyLimit> limits = List.of(ScopedConcurrencyLimit.ofFlow(flow));
+        store().countThenProcess(flow, (txContext, limit) -> Pair.of(null, limit.withRunning(1)));
+
+        // When
+        Optional<Execution> popped = store().releaseThenPop(
+            flow, limits, queuedStore(),
+            candidate -> limits,
+            (txContext, queued) -> queued
+        );
+
+        // Then: the slot is released and nothing is popped
+        assertThat(popped).isEmpty();
+        assertThat(currentCount(flow)).isZero();
+    }
+
+    @Test
+    void shouldNotPopThroughScopedReleaseWhenCounterRemainsAtLimit() {
+        // Given: the counter was inflated above the limit (over-limit race aftermath), one queued
+        Flow flow = flow(1);
+        List<ScopedConcurrencyLimit> limits = List.of(ScopedConcurrencyLimit.ofFlow(flow));
+        Execution waiting = Execution.newExecution(flow, List.of());
+        store().countThenProcess(flow, (txContext, limit) ->
+        {
+            queuedStore().save(txContext, queued(flow, waiting, Instant.now()));
+            return Pair.of(null, limit.withRunning(3));
+        });
+
+        // When: a termination decrements 3 -> 2, still >= limit
+        Optional<Execution> popped = store().releaseThenPop(
+            flow, limits, queuedStore(),
+            candidate -> limits,
+            (txContext, queued) -> queued
+        );
+
+        // Then: nothing is dequeued (the queued-protection guard)
+        assertThat(popped).isEmpty();
+        assertThat(currentCount(flow)).isEqualTo(2);
     }
 
     private int currentCount(Flow flow) {

--- a/executor/src/test/java/io/kestra/executor/statemachine/ScopedConcurrencyLifecycleTest.java
+++ b/executor/src/test/java/io/kestra/executor/statemachine/ScopedConcurrencyLifecycleTest.java
@@ -1,0 +1,411 @@
+package io.kestra.executor.statemachine;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import io.kestra.core.models.executions.Execution;
+import io.kestra.core.models.flows.Concurrency;
+import io.kestra.core.models.flows.FlowWithSource;
+import io.kestra.core.models.flows.State;
+import io.kestra.core.runners.ExecutionEvent;
+import io.kestra.core.runners.ExecutionEventType;
+import io.kestra.core.runners.ScopedConcurrencyLimit;
+import io.kestra.core.services.ConcurrencyLimitResolver;
+import io.kestra.executor.ExecutorContext;
+import io.kestra.executor.testkit.Executions;
+import io.kestra.executor.testkit.ExecutorTestHarness;
+import io.kestra.executor.testkit.Flows;
+import io.kestra.plugin.core.log.Log;
+
+import static io.kestra.executor.testkit.ExecutorContextAssert.assertThat;
+
+/**
+ * Layer-1 sagas of namespace and tenant scoped concurrency limits (kestra-ee#8660) through the
+ * real {@code ExecutionEventMessageHandler} and {@code ConcurrencySlotReleaseProcessor}: the
+ * flow → namespace → parent namespaces → tenant evaluation order where the first limit reached
+ * defines the behavior, the claim-one-slot-per-scope accounting, multi-scope release, and the
+ * cross-flow pop of queued executions when a shared scope frees a slot — no Micronaut, no
+ * database. Namespace/tenant limit <b>definitions</b> are an EE feature: the sagas stub the
+ * {@link ConcurrencyLimitResolver} spy the way the EE resolver will answer, while
+ * {@code ConcurrencyLifecycleTest} keeps pinning the OSS flow-scope-only behavior.
+ */
+class ScopedConcurrencyLifecycleTest {
+
+    private static final String TENANT = Flows.TENANT;
+
+    private final ExecutorTestHarness harness = ExecutorTestHarness.create();
+
+    // --- the resolver seam
+
+    @Test
+    void shouldResolveOnlyTheFlowScopeInOss() {
+        // Given: the real OSS resolver
+        ConcurrencyLimitResolver resolver = new ConcurrencyLimitResolver();
+        FlowWithSource unlimited = Flows.of(logTask());
+        FlowWithSource limited = flowInNamespace("io.kestra.tests", "limited", queue(3));
+
+        // When / Then: no limit without flow concurrency, a single FLOW scope with it
+        Assertions.assertThat(resolver.resolveLimits(unlimited)).isEmpty();
+        Assertions.assertThat(resolver.resolveLimits(limited)).satisfiesExactly(scope ->
+        {
+            Assertions.assertThat(scope.scope()).isEqualTo(ScopedConcurrencyLimit.Scope.FLOW);
+            Assertions.assertThat(scope.uid()).isEqualTo(TENANT + "|io.kestra.tests|" + limited.getId());
+            Assertions.assertThat(scope.concurrency().getLimit()).isEqualTo(3);
+        });
+    }
+
+    // --- evaluation order: flow, namespace, parent namespaces, tenant — first limit reached wins
+
+    @Test
+    void shouldApplyTheFirstReachedLimitAcrossNamespaces() {
+        // Given: the exact example of kestra-ee#8660 — flow A limits 5 (QUEUE), namespace
+        // io.kestra.example1 limits 100 (QUEUE), namespace io.kestra limits 10 (FAIL),
+        // flow B defines nothing
+        ScopedConcurrencyLimit example1Scope = ScopedConcurrencyLimit.ofNamespace(TENANT, "io.kestra.example1", queue(100));
+        ScopedConcurrencyLimit ioKestraScope = ScopedConcurrencyLimit.ofNamespace(TENANT, "io.kestra", limit(10, Concurrency.Behavior.FAIL));
+
+        FlowWithSource flowA = flowInNamespace("io.kestra.example1", "a", queue(5));
+        FlowWithSource flowB = flowInNamespace("io.kestra.example2", "b", null);
+        harness.registerFlow(flowA);
+        harness.registerFlow(flowB);
+        stubLimits(flowA, ScopedConcurrencyLimit.ofFlow(flowA), example1Scope, ioKestraScope);
+        stubLimits(flowB, ioKestraScope);
+
+        // Given: 9 running flow B and 1 running flow A
+        for (int i = 0; i < 9; i++) {
+            startExecution(flowB);
+        }
+        startExecution(flowA);
+        Assertions.assertThat(harness.concurrencyLimitStateStore().running(ioKestraScope)).isEqualTo(10);
+
+        // When: running another flow A
+        Execution another = Executions.created(flowA);
+        harness.executionStateStore().save(another);
+        ExecutorContext context = handleEvent(another);
+
+        // Then: the io.kestra namespace limit is the first one reached, so the execution FAILs —
+        // the flow (1 < 5) and io.kestra.example1 (1 < 100) limits pass and claim nothing
+        assertThat(context).executionInState(State.Type.FAILED).updatedFrom("handleConcurrencyLimit");
+        Assertions.assertThat(harness.concurrencyLimitStateStore().running(flowA)).isEqualTo(1);
+        Assertions.assertThat(harness.concurrencyLimitStateStore().running(ioKestraScope)).isEqualTo(10);
+        Assertions.assertThat(harness.executionQueuedStateStore().queued()).isEmpty();
+    }
+
+    @Test
+    void shouldApplyTheFlowBehaviorWhenFlowAndNamespaceLimitsAreBothReached() {
+        // Given: a flow limit (QUEUE) and a namespace limit (FAIL), both of 1
+        FlowWithSource flow = flowInNamespace("io.kestra.tests", "a", queue(1));
+        ScopedConcurrencyLimit namespaceScope = ScopedConcurrencyLimit.ofNamespace(TENANT, "io.kestra.tests", limit(1, Concurrency.Behavior.FAIL));
+        harness.registerFlow(flow);
+        stubLimits(flow, ScopedConcurrencyLimit.ofFlow(flow), namespaceScope);
+        startExecution(flow);
+
+        // When: a second execution arrives while both limits are reached
+        Execution second = Executions.created(flow);
+        harness.executionStateStore().save(second);
+        ExecutorContext context = handleEvent(second);
+
+        // Then: the flow limit is evaluated first, so its QUEUE behavior wins over FAIL
+        assertThat(context).executionInState(State.Type.QUEUED).updatedFrom("handleConcurrencyLimit");
+        Assertions.assertThat(harness.executionQueuedStateStore().queued())
+            .singleElement()
+            .satisfies(queued -> Assertions.assertThat(queued.getExecution().getId()).isEqualTo(second.getId()));
+    }
+
+    @Test
+    void shouldApplyTheInnermostNamespaceBehaviorBeforeItsParent() {
+        // Given: no flow limit; the innermost namespace CANCELs, its parent FAILs, both at 1
+        FlowWithSource flow = flowInNamespace("io.kestra.team.a", "a", null);
+        ScopedConcurrencyLimit childScope = ScopedConcurrencyLimit.ofNamespace(TENANT, "io.kestra.team.a", limit(1, Concurrency.Behavior.CANCEL));
+        ScopedConcurrencyLimit parentScope = ScopedConcurrencyLimit.ofNamespace(TENANT, "io.kestra", limit(1, Concurrency.Behavior.FAIL));
+        harness.registerFlow(flow);
+        stubLimits(flow, childScope, parentScope);
+        startExecution(flow);
+
+        // When
+        Execution second = Executions.created(flow);
+        harness.executionStateStore().save(second);
+        ExecutorContext context = handleEvent(second);
+
+        // Then: innermost first — CANCELLED, not FAILED
+        assertThat(context).executionInState(State.Type.CANCELLED).updatedFrom("handleConcurrencyLimit");
+    }
+
+    @Test
+    void shouldApplyTheTenantLimitWhenEveryNamespaceHasCapacity() {
+        // Given: a generous namespace limit and a tenant limit of 1 (FAIL)
+        FlowWithSource flow = flowInNamespace("io.kestra.tests", "a", null);
+        ScopedConcurrencyLimit namespaceScope = ScopedConcurrencyLimit.ofNamespace(TENANT, "io.kestra.tests", queue(10));
+        ScopedConcurrencyLimit tenantScope = ScopedConcurrencyLimit.ofTenant(TENANT, limit(1, Concurrency.Behavior.FAIL));
+        harness.registerFlow(flow);
+        stubLimits(flow, namespaceScope, tenantScope);
+        startExecution(flow);
+
+        // When
+        Execution second = Executions.created(flow);
+        harness.executionStateStore().save(second);
+        ExecutorContext context = handleEvent(second);
+
+        // Then: the tenant limit, last in the evaluation order, defines the behavior
+        assertThat(context).executionInState(State.Type.FAILED).updatedFrom("handleConcurrencyLimit");
+        Assertions.assertThat(harness.concurrencyLimitStateStore().running(tenantScope)).isEqualTo(1);
+    }
+
+    // --- slot accounting: a running execution claims one slot in every scope, none otherwise
+
+    @Test
+    void shouldClaimOneSlotInEveryScopeWhenRunning() {
+        // Given: flow, namespace, parent namespace and tenant limits
+        FlowWithSource flow = flowInNamespace("io.kestra.team.a", "a", queue(5));
+        ScopedConcurrencyLimit childScope = ScopedConcurrencyLimit.ofNamespace(TENANT, "io.kestra.team.a", queue(5));
+        ScopedConcurrencyLimit parentScope = ScopedConcurrencyLimit.ofNamespace(TENANT, "io.kestra", queue(5));
+        ScopedConcurrencyLimit tenantScope = ScopedConcurrencyLimit.ofTenant(TENANT, queue(5));
+        harness.registerFlow(flow);
+        stubLimits(flow, ScopedConcurrencyLimit.ofFlow(flow), childScope, parentScope, tenantScope);
+
+        // When
+        ExecutorContext started = startExecution(flow);
+
+        // Then: one slot claimed per scope
+        Assertions.assertThat(started.getExecution().getState().getCurrent()).isEqualTo(State.Type.RUNNING);
+        Assertions.assertThat(harness.concurrencyLimitStateStore().running(flow)).isEqualTo(1);
+        Assertions.assertThat(harness.concurrencyLimitStateStore().running(childScope)).isEqualTo(1);
+        Assertions.assertThat(harness.concurrencyLimitStateStore().running(parentScope)).isEqualTo(1);
+        Assertions.assertThat(harness.concurrencyLimitStateStore().running(tenantScope)).isEqualTo(1);
+    }
+
+    @Test
+    void shouldCountExecutionsOfFlowsWithoutOwnLimitTowardTheNamespaceLimit() {
+        // Given: a flow without flow-level concurrency, in a namespace limited to 2
+        FlowWithSource flow = flowInNamespace("io.kestra.tests", "b", null);
+        ScopedConcurrencyLimit namespaceScope = ScopedConcurrencyLimit.ofNamespace(TENANT, "io.kestra.tests", queue(2));
+        harness.registerFlow(flow);
+        stubLimits(flow, namespaceScope);
+
+        // When: two executions fill the namespace, a third arrives
+        startExecution(flow);
+        startExecution(flow);
+        Execution third = Executions.created(flow);
+        harness.executionStateStore().save(third);
+        ExecutorContext context = handleEvent(third);
+
+        // Then: the third queues on the namespace limit; no flow-scoped counter ever moved
+        assertThat(context).executionInState(State.Type.QUEUED).updatedFrom("handleConcurrencyLimit");
+        Assertions.assertThat(harness.concurrencyLimitStateStore().running(namespaceScope)).isEqualTo(2);
+        Assertions.assertThat(harness.concurrencyLimitStateStore().running(flow)).isZero();
+    }
+
+    // --- release: termination frees every scope, then the queue drains across flows
+
+    @Test
+    void shouldReleaseEveryScopeOnTermination() {
+        // Given: a running execution holding flow + namespace + tenant slots
+        FlowWithSource flow = flowInNamespace("io.kestra.tests", "a", queue(5));
+        ScopedConcurrencyLimit namespaceScope = ScopedConcurrencyLimit.ofNamespace(TENANT, "io.kestra.tests", queue(5));
+        ScopedConcurrencyLimit tenantScope = ScopedConcurrencyLimit.ofTenant(TENANT, queue(5));
+        harness.registerFlow(flow);
+        stubLimits(flow, ScopedConcurrencyLimit.ofFlow(flow), namespaceScope, tenantScope);
+        ExecutorContext started = startExecution(flow);
+
+        // When: it terminates
+        Optional<Execution> popped = release(terminated(flow, started.getExecution()));
+
+        // Then: every scope counter is back to zero, nothing to pop
+        Assertions.assertThat(popped).isEmpty();
+        Assertions.assertThat(harness.concurrencyLimitStateStore().running(flow)).isZero();
+        Assertions.assertThat(harness.concurrencyLimitStateStore().running(namespaceScope)).isZero();
+        Assertions.assertThat(harness.concurrencyLimitStateStore().running(tenantScope)).isZero();
+    }
+
+    @Test
+    void shouldPopQueuedExecutionOfAnotherFlowWhenTheSharedNamespaceSlotFrees() {
+        // Given: two flows sharing a namespace limited to 1, no flow-level limits
+        ScopedConcurrencyLimit namespaceScope = ScopedConcurrencyLimit.ofNamespace(TENANT, "io.kestra.tests", queue(1));
+        FlowWithSource flowA = flowInNamespace("io.kestra.tests", "a", null);
+        FlowWithSource flowB = flowInNamespace("io.kestra.tests", "b", null);
+        harness.registerFlow(flowA);
+        harness.registerFlow(flowB);
+        stubLimits(flowA, namespaceScope);
+        stubLimits(flowB, namespaceScope);
+
+        // Given: A holds the namespace slot, B is queued behind it
+        ExecutorContext runningA = startExecution(flowA);
+        Execution waitingB = Executions.created(flowB);
+        harness.executionStateStore().save(waitingB);
+        assertThat(handleEvent(waitingB)).executionInState(State.Type.QUEUED);
+
+        // When: A terminates
+        Optional<Execution> popped = release(terminated(flowA, runningA.getExecution()));
+
+        // Then: B — an execution of a different flow — takes over the namespace slot
+        Assertions.assertThat(popped)
+            .hasValueSatisfying(execution ->
+            {
+                Assertions.assertThat(execution.getId()).isEqualTo(waitingB.getId());
+                Assertions.assertThat(execution.getState().getCurrent()).isEqualTo(State.Type.RUNNING);
+            });
+        Assertions.assertThat(harness.concurrencyLimitStateStore().running(namespaceScope)).isEqualTo(1);
+        Assertions.assertThat(harness.executionQueuedStateStore().queued()).isEmpty();
+    }
+
+    @Test
+    void shouldSkipCandidateBlockedByItsOwnFlowLimitAndPopTheNextFit() {
+        // Given: a namespace limited to 2; flow A additionally limited to 1; flow B unlimited
+        ScopedConcurrencyLimit namespaceScope = ScopedConcurrencyLimit.ofNamespace(TENANT, "io.kestra.tests", queue(2));
+        FlowWithSource flowA = flowInNamespace("io.kestra.tests", "a", queue(1));
+        FlowWithSource flowB = flowInNamespace("io.kestra.tests", "b", null);
+        FlowWithSource flowC = flowInNamespace("io.kestra.tests", "c", null);
+        harness.registerFlow(flowA);
+        harness.registerFlow(flowB);
+        harness.registerFlow(flowC);
+        stubLimits(flowA, ScopedConcurrencyLimit.ofFlow(flowA), namespaceScope);
+        stubLimits(flowB, namespaceScope);
+        stubLimits(flowC, namespaceScope);
+
+        // Given: A1 and C fill the namespace; A2 queues on its flow limit, then B queues on the namespace
+        ExecutorContext runningA1 = startExecution(flowA);
+        ExecutorContext runningC = startExecution(flowC);
+        Execution waitingA2 = Executions.created(flowA);
+        harness.executionStateStore().save(waitingA2);
+        assertThat(handleEvent(waitingA2)).executionInState(State.Type.QUEUED);
+        Execution waitingB = Executions.created(flowB);
+        harness.executionStateStore().save(waitingB);
+        assertThat(handleEvent(waitingB)).executionInState(State.Type.QUEUED);
+
+        // When: C terminates, freeing one namespace slot
+        Optional<Execution> popped = release(terminated(flowC, runningC.getExecution()));
+
+        // Then: A2 — the oldest candidate — is still blocked by its own flow limit (A1 runs),
+        // so it is skipped and B pops instead of starving behind it
+        Assertions.assertThat(popped).map(Execution::getId).contains(waitingB.getId());
+        Assertions.assertThat(harness.executionQueuedStateStore().queued())
+            .singleElement()
+            .satisfies(queued -> Assertions.assertThat(queued.getExecution().getId()).isEqualTo(waitingA2.getId()));
+
+        // When: A1 terminates, freeing the flow A slot and a namespace slot
+        Optional<Execution> reconsidered = release(terminated(flowA, runningA1.getExecution()));
+
+        // Then: the skipped A2 is reconsidered and finally pops
+        Assertions.assertThat(reconsidered).map(Execution::getId).contains(waitingA2.getId());
+        Assertions.assertThat(harness.executionQueuedStateStore().queued()).isEmpty();
+        Assertions.assertThat(harness.concurrencyLimitStateStore().running(flowA)).isEqualTo(1);
+        Assertions.assertThat(harness.concurrencyLimitStateStore().running(namespaceScope)).isEqualTo(2);
+    }
+
+    @Test
+    void shouldNotPopCandidateOutsideTheFreedScopes() {
+        // Given: two namespaces, each limited to 1, each with one running and one queued execution
+        ScopedConcurrencyLimit namespace1Scope = ScopedConcurrencyLimit.ofNamespace(TENANT, "io.kestra.ns1", queue(1));
+        ScopedConcurrencyLimit namespace2Scope = ScopedConcurrencyLimit.ofNamespace(TENANT, "io.kestra.ns2", queue(1));
+        FlowWithSource flowA = flowInNamespace("io.kestra.ns1", "a", null);
+        FlowWithSource flowB = flowInNamespace("io.kestra.ns2", "b", null);
+        harness.registerFlow(flowA);
+        harness.registerFlow(flowB);
+        stubLimits(flowA, namespace1Scope);
+        stubLimits(flowB, namespace2Scope);
+
+        ExecutorContext runningA = startExecution(flowA);
+        startExecution(flowB);
+        // B2 queues first: it is the oldest queued execution overall
+        Execution waitingB2 = Executions.created(flowB);
+        harness.executionStateStore().save(waitingB2);
+        assertThat(handleEvent(waitingB2)).executionInState(State.Type.QUEUED);
+        Execution waitingA2 = Executions.created(flowA);
+        harness.executionStateStore().save(waitingA2);
+        assertThat(handleEvent(waitingA2)).executionInState(State.Type.QUEUED);
+
+        // When: A terminates, freeing only the ns1 slot
+        Optional<Execution> popped = release(terminated(flowA, runningA.getExecution()));
+
+        // Then: A2 pops even though B2 queued earlier — B2 shares no scope with the freed slot
+        Assertions.assertThat(popped).map(Execution::getId).contains(waitingA2.getId());
+        Assertions.assertThat(harness.executionQueuedStateStore().queued())
+            .singleElement()
+            .satisfies(queued -> Assertions.assertThat(queued.getExecution().getId()).isEqualTo(waitingB2.getId()));
+    }
+
+    @Test
+    void shouldNotReleaseScopesWhenExecutionWasShortCircuited() {
+        // Given: a namespace limit of 1 with the CANCEL behavior, its slot taken
+        FlowWithSource flow = flowInNamespace("io.kestra.tests", "a", null);
+        ScopedConcurrencyLimit namespaceScope = ScopedConcurrencyLimit.ofNamespace(TENANT, "io.kestra.tests", limit(1, Concurrency.Behavior.CANCEL));
+        harness.registerFlow(flow);
+        stubLimits(flow, namespaceScope);
+        startExecution(flow);
+
+        // Given: a second execution short-circuited CANCELLED at the gate — it never claimed a slot
+        Execution second = Executions.created(flow);
+        harness.executionStateStore().save(second);
+        ExecutorContext cancelled = handleEvent(second);
+        assertThat(cancelled).executionInState(State.Type.CANCELLED);
+
+        // When: its termination reaches the release processor (as DefaultExecutor#toExecution does)
+        Optional<Execution> popped = release(cancelled);
+
+        // Then: the short-circuit guard holds — no decrement, no pop
+        Assertions.assertThat(popped).isEmpty();
+        Assertions.assertThat(harness.concurrencyLimitStateStore().running(namespaceScope)).isEqualTo(1);
+    }
+
+    // --- fixtures
+
+    /**
+     * Create the execution, persist it, and run its CREATED event through the real handler —
+     * the exact path a webserver/scheduler submission takes.
+     */
+    private ExecutorContext startExecution(FlowWithSource flow) {
+        Execution execution = Executions.created(flow);
+        harness.executionStateStore().save(execution);
+        return handleEvent(execution);
+    }
+
+    private ExecutorContext handleEvent(Execution execution) {
+        return harness.executionEventMessageHandler()
+            .handle(new ExecutionEvent(execution, ExecutionEventType.CREATED))
+            .orElseThrow();
+    }
+
+    private Optional<Execution> release(ExecutorContext terminated) {
+        return harness.concurrencySlotReleaseProcessor().release(terminated);
+    }
+
+    private static ExecutorContext terminated(FlowWithSource flow, Execution running) {
+        return new ExecutorContext(running, flow).withExecution(running.withState(State.Type.SUCCESS), "test");
+    }
+
+    /**
+     * Stub the harness resolver spy the way the EE resolver will answer for this flow: its
+     * scoped limits in evaluation order.
+     */
+    private void stubLimits(FlowWithSource flow, ScopedConcurrencyLimit... limits) {
+        Mockito.doReturn(List.of(limits))
+            .when(harness.concurrencyLimitResolver())
+            .resolveLimits(Mockito.argThat(candidate -> candidate != null && flow.getId().equals(candidate.getId())));
+    }
+
+    private static FlowWithSource flowInNamespace(String namespace, String id, Concurrency concurrency) {
+        return Flows.of(
+            Flows.builder(logTask())
+                .namespace(namespace)
+                .id(id)
+                .concurrency(concurrency)
+                .build()
+        );
+    }
+
+    private static Concurrency queue(int limit) {
+        return limit(limit, Concurrency.Behavior.QUEUE);
+    }
+
+    private static Concurrency limit(int limit, Concurrency.Behavior behavior) {
+        return Concurrency.builder().behavior(behavior).limit(limit).build();
+    }
+
+    private static Log logTask() {
+        return Log.builder().id("log").type(Log.class.getName()).message("hello").build();
+    }
+}

--- a/executor/src/test/java/io/kestra/executor/testkit/ExecutorTestHarness.java
+++ b/executor/src/test/java/io/kestra/executor/testkit/ExecutorTestHarness.java
@@ -33,6 +33,7 @@ import io.kestra.core.runners.WorkerTaskResult;
 import io.kestra.core.runners.configuration.LoggingConfiguration;
 import io.kestra.core.runners.configuration.VariableConfiguration;
 import io.kestra.core.runners.pebble.PebbleEngineFactory;
+import io.kestra.core.services.ConcurrencyLimitResolver;
 import io.kestra.core.services.ExecutionService;
 import io.kestra.core.services.QuotaService;
 import io.kestra.core.services.TaskOutputService;
@@ -76,6 +77,7 @@ import jakarta.validation.Validator;
  * <p>
  * Cross-cutting collaborators without executor logic ({@link KillSwitchService} — stubbed to
  * PASS, {@link QuotaService}, {@link AsyncOperationService}, {@link FlowTriggerService},
+ * {@link ConcurrencyLimitResolver} — a spy over the real flow-scope-only resolver,
  * {@link KillSwitchActionService}) are Mockito mocks exposed for per-test stubbing.
  */
 public final class ExecutorTestHarness {
@@ -116,6 +118,7 @@ public final class ExecutorTestHarness {
     private final KillSwitchService killSwitchService;
     private final KillSwitchActionService killSwitchActionService;
     private final QuotaService quotaService;
+    private final ConcurrencyLimitResolver concurrencyLimitResolver;
     private final AsyncOperationService asyncOperationService;
     private final FlowTriggerService flowTriggerService;
     private final MultipleConditionStateStore multipleConditionStateStore;
@@ -210,6 +213,8 @@ public final class ExecutorTestHarness {
         );
         this.killSwitchActionService = Mockito.mock(KillSwitchActionService.class);
         this.quotaService = Mockito.mock(QuotaService.class);
+        // a spy: the real OSS resolver (flow scope only) unless a test stubs namespace/tenant limits
+        this.concurrencyLimitResolver = Mockito.spy(new ConcurrencyLimitResolver());
         this.asyncOperationService = Mockito.mock(AsyncOperationService.class);
         this.flowTriggerService = Mockito.mock(FlowTriggerService.class);
         this.multipleConditionStateStore = Mockito.mock(MultipleConditionStateStore.class);
@@ -236,6 +241,7 @@ public final class ExecutorTestHarness {
             executionDelayStateStore,
             slaMonitorStateStore,
             concurrencyLimitStateStore,
+            concurrencyLimitResolver,
             executorService,
             workerQueueService,
             quotaService,
@@ -319,7 +325,9 @@ public final class ExecutorTestHarness {
         );
         this.concurrencySlotReleaseProcessor = new ConcurrencySlotReleaseProcessor(
             concurrencyLimitStateStore,
+            concurrencyLimitResolver,
             executionQueuedStateStore,
+            flowMetaStore,
             metricRegistry
         );
         this.slaMonitorProcessor = new SLAMonitorProcessor(
@@ -524,6 +532,10 @@ public final class ExecutorTestHarness {
 
     public QuotaService quotaService() {
         return quotaService;
+    }
+
+    public ConcurrencyLimitResolver concurrencyLimitResolver() {
+        return concurrencyLimitResolver;
     }
 
     public AsyncOperationService asyncOperationService() {

--- a/executor/src/test/java/io/kestra/executor/testkit/InMemoryConcurrencyLimitStateStore.java
+++ b/executor/src/test/java/io/kestra/executor/testkit/InMemoryConcurrencyLimitStateStore.java
@@ -1,22 +1,32 @@
 package io.kestra.executor.testkit;
 
+import java.util.Comparator;
+import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
+import java.util.function.Function;
 
 import org.apache.commons.lang3.tuple.Pair;
 
 import io.kestra.core.models.executions.Execution;
 import io.kestra.core.models.flows.FlowInterface;
 import io.kestra.core.runners.ConcurrencyLimit;
+import io.kestra.core.runners.ExecutionQueued;
 import io.kestra.core.runners.ExecutionQueuedStateStore;
 import io.kestra.core.runners.ExecutionRunning;
+import io.kestra.core.runners.ScopedConcurrencyLimit;
 import io.kestra.core.runners.TransactionContext;
 import io.kestra.executor.ConcurrencyLimitStateStore;
 
 /**
- * Map-backed {@link ConcurrencyLimitStateStore}: a running counter per flow uid.
+ * Map-backed {@link ConcurrencyLimitStateStore}: a running counter per scope uid — the flow uid
+ * for flow-scoped limits, {@code tenant|namespace|} / {@code tenant||} for namespace and tenant
+ * scoped ones. Unlike the JDBC/ES stores it fully implements the scoped operations, including
+ * the widest-scope FIFO pop with per-candidate fit check.
  */
 public class InMemoryConcurrencyLimitStateStore implements ConcurrencyLimitStateStore {
     private final Map<String, ConcurrencyLimit> limits = new ConcurrentHashMap<>();
@@ -66,11 +76,95 @@ public class InMemoryConcurrencyLimitStateStore implements ConcurrencyLimitState
         }
     }
 
+    @Override
+    public synchronized ExecutionRunning countThenProcess(FlowInterface flow, List<ScopedConcurrencyLimit> scopes,
+        BiFunction<TransactionContext, List<Integer>, Pair<ExecutionRunning, Boolean>> consumer) {
+        List<Integer> counts = scopes.stream()
+            .map(scope -> running(limits.computeIfAbsent(scope.uid(), key -> emptyLimit(scope))))
+            .toList();
+        Pair<ExecutionRunning, Boolean> result = consumer.apply(NoopTransactionContext.INSTANCE, counts);
+        if (Boolean.TRUE.equals(result.getRight())) {
+            scopes.forEach(this::increment);
+        }
+        return result.getLeft();
+    }
+
+    @Override
+    public synchronized Optional<Execution> releaseThenPop(
+        FlowInterface flow,
+        List<ScopedConcurrencyLimit> scopes,
+        ExecutionQueuedStateStore executionQueuedStateStore,
+        Function<Execution, List<ScopedConcurrencyLimit>> candidateLimits,
+        BiFunction<TransactionContext, Execution, Execution> consumer) {
+        scopes.forEach(this::decrement);
+
+        // Scan the queued candidates FIFO within the widest freed scope: candidates outside it
+        // share no counter with the released execution, so their fit cannot have changed. The
+        // fake needs the whole queued list, hence the kit queued store (a production
+        // implementation would add a scan operation to its own queued storage instead).
+        InMemoryExecutionQueuedStateStore queuedStore = (InMemoryExecutionQueuedStateStore) executionQueuedStateStore;
+        ScopedConcurrencyLimit widest = widestScope(scopes);
+        List<ExecutionQueued> candidates = queuedStore.queued().stream()
+            .filter(queued -> widest.covers(queued.getTenantId(), queued.getNamespace(), queued.getFlowId()))
+            .sorted(Comparator.comparing(ExecutionQueued::getDate))
+            .toList();
+
+        for (ExecutionQueued candidate : candidates) {
+            List<ScopedConcurrencyLimit> candidateScopes = candidateLimits.apply(candidate.getExecution());
+            boolean fits = candidateScopes.stream().allMatch(scope -> running(scope) < scope.concurrency().getLimit());
+            if (fits) {
+                candidateScopes.forEach(this::increment);
+                queuedStore.remove(candidate.getExecution());
+                return Optional.of(consumer.apply(NoopTransactionContext.INSTANCE, candidate.getExecution()));
+            }
+            // a blocked candidate is skipped, not head-of-line blocking: it is reconsidered
+            // whenever one of its own scopes frees a slot
+        }
+
+        return Optional.empty();
+    }
+
     /**
      * The current running count for a flow (0 if never incremented).
      */
     public int running(FlowInterface flow) {
         return running(limits.get(uid(flow)));
+    }
+
+    /**
+     * The current running count for a scope (0 if never incremented).
+     */
+    public int running(ScopedConcurrencyLimit scope) {
+        return running(limits.get(scope.uid()));
+    }
+
+    private synchronized void increment(ScopedConcurrencyLimit scope) {
+        limits.compute(
+            scope.uid(),
+            (key, limit) -> (limit == null ? emptyLimit(scope) : limit).withRunning(running(limit) + 1)
+        );
+    }
+
+    private synchronized void decrement(ScopedConcurrencyLimit scope) {
+        limits.compute(
+            scope.uid(),
+            (key, limit) -> (limit == null ? emptyLimit(scope) : limit).withRunning(Math.max(0, running(limit) - 1))
+        );
+    }
+
+    private static ScopedConcurrencyLimit widestScope(List<ScopedConcurrencyLimit> scopes) {
+        Optional<ScopedConcurrencyLimit> tenant = scopes.stream()
+            .filter(scope -> scope.scope() == ScopedConcurrencyLimit.Scope.TENANT)
+            .findFirst();
+        if (tenant.isPresent()) {
+            return tenant.get();
+        }
+
+        // namespace scopes are ancestors of the same flow namespace: the shortest is the widest
+        return scopes.stream()
+            .filter(scope -> scope.scope() == ScopedConcurrencyLimit.Scope.NAMESPACE)
+            .min(Comparator.comparingInt(scope -> scope.namespace().length()))
+            .orElse(scopes.getFirst());
     }
 
     private static int running(ConcurrencyLimit limit) {
@@ -82,6 +176,15 @@ public class InMemoryConcurrencyLimitStateStore implements ConcurrencyLimitState
             .tenantId(flow.getTenantId())
             .namespace(flow.getNamespace())
             .flowId(flow.getId())
+            .running(0)
+            .build();
+    }
+
+    private static ConcurrencyLimit emptyLimit(ScopedConcurrencyLimit scope) {
+        return ConcurrencyLimit.builder()
+            .tenantId(scope.tenantId())
+            .namespace(Objects.requireNonNullElse(scope.namespace(), ""))
+            .flowId(Objects.requireNonNullElse(scope.flowId(), ""))
             .running(0)
             .build();
     }


### PR DESCRIPTION
## What

Implements the executor-side engine for kestra-io/kestra-ee#8660 — **concurrency limits at the namespace or tenant level** — behind an OSS seam, proven with the executor testkit. Stacked on #17264 (only the last two commits are new).

Spec implemented (from the issue):

- Evaluation order **flow → namespace → parent namespaces (innermost first) → tenant**; the **first limit reached defines the behavior** (QUEUE / CANCEL / FAIL).
- An execution that runs claims **one slot in every applicable scope**; executions of flows *without* their own `concurrency` property count toward their namespace/tenant limits.
- On termination every scope is released, and the **oldest queued execution that fits all of its own scopes** is popped — including executions of *other flows* sharing a freed namespace/tenant scope. Candidates blocked by one of their own scopes are skipped (no head-of-line starvation) and reconsidered when one of their scopes frees.

The issue's worked example (9 running `example2.B` + 1 running `example1.A`, namespace `io.kestra` limited to 10 with FAIL → the next `A` fails even though its own limit of 5 has capacity) is pinned verbatim in `ScopedConcurrencyLifecycleTest#shouldApplyTheFirstReachedLimitAcrossNamespaces`.

## How — the seam (`feat` commit)

- **`ScopedConcurrencyLimit`** (core): a `Concurrency` plus the scope it applies to (FLOW / NAMESPACE / TENANT); scope counters are keyed by its uid (`tenant|namespace|flowId`, blank parts for the broader scopes — the FLOW uid matches today's `ConcurrencyLimit` key).
- **`ConcurrencyLimitResolver`** (core): resolves the ordered limit list for a flow. The OSS implementation returns the flow's own `concurrency` only — **namespace/tenant limit definitions are the EE part** (Limits tab on Namespace/Tenant + an `@Replaces` resolver walking the namespace tree), out of scope here.
- **`ConcurrencyLimitStateStore`** gains two scoped operations as **default methods**: a multi-counter `countThenProcess` (read all scope counters, decide, claim-all atomically) and `releaseThenPop` (decrement all scopes, widest-scope FIFO pop with per-candidate fit check). The defaults handle the single-flow-scope case by delegating to the existing flow-keyed methods — so **JDBC and EE Elasticsearch stores keep working unchanged**, and multi-scope throws `UnsupportedOperationException` until an implementation opts in (that's the EE-coordinated extraction PR's job, together with a queued-store scan operation).
- `ExecutionEventMessageHandler` gate and `ConcurrencySlotReleaseProcessor` now go through the resolver + scoped store API (single code path); `ExecutorService#processExecutionRunning` generalizes to an ordered-limits overload (flow-scope messages unchanged); `DefaultExecutor#toExecution` no longer guards on `flow.getConcurrency() != null` — the release processor no-ops when no limit applies.

Net effect in OSS today: behavior is byte-for-byte the flow-level semantics (the resolver only ever returns the flow scope); the scoped path only activates when a resolver provides namespace/tenant limits.

## Tests (`test` commit)

- **`ScopedConcurrencyLifecycleTest`** (12 sagas through the real handler + release processor, no Micronaut/DB): the issue's example, first-reached-wins across flow/namespace/parent/tenant, claim-one-slot-per-scope accounting, flows-without-own-limit counting toward namespace limits, multi-scope release, **cross-flow pop** when a shared namespace slot frees, blocked-candidate skip + reconsideration, scope-filtered popping, and the short-circuit release guard. EE resolver behavior is simulated by stubbing the harness's `ConcurrencyLimitResolver` spy.
- **`ConcurrencyLimitStateStoreContract`** +4 scenarios pinning the scoped API in the single-flow-scope case — they run against **H2 (via the default adapters over real JDBC transactions)** and the in-memory fake (via its real multi-scope override), keeping both provably equivalent where they overlap.
- `InMemoryConcurrencyLimitStateStore` implements the full multi-scope semantics (claim-all, widest-scope FIFO pop with fit check).

## Testing

- `:executor:test`: 281 passing, 0 failures
- `H2ConcurrencyLimitStateStoreTest` (contract on H2): 9/9
- `H2RunnerTest`: green (executor production change — AGENTS.md rule)
- kestra-ee: `jdbc-ee:compileJava` + `repository-elasticsearch-ee:compileTestJava` compile clean

## Next (not this PR)

The minimal production extraction once the approach is validated: this PR's `feat` commit, plus EE — limit definitions on Namespace/Tenant (Limits tab), an `@Replaces` resolver, scoped implementations for the JDBC + Elasticsearch stores (incl. a queued-store scan operation), and the runner-level twins.
