### PR TITLE
fix(core): fix service start/stop lifecycle races behind the 'cannot start' CI failures

### DIFF
--- a/cli/src/main/java/io/kestra/cli/StandAloneRunner.java
+++ b/cli/src/main/java/io/kestra/cli/StandAloneRunner.java
@@ -74,6 +74,7 @@ public class StandAloneRunner implements Runnable, AutoCloseable {
 
         poolExecutor = executorsUtils.cachedThreadPool("standalone-runner");
         poolExecutor.execute(defaultExecutor);
+        servers.add(defaultExecutor);
 
         if (controllerEnabled) {
             Controller controller = controllerProvider.get();
@@ -105,16 +106,22 @@ public class StandAloneRunner implements Runnable, AutoCloseable {
         servers.add(systemWorker);
 
         try {
-            Await.await().atMost(getRunningTimeout()).until(
-                () -> servers.stream().allMatch(s -> Optional.ofNullable(s.getState()).orElse(Service.ServiceState.RUNNING).isRunning())
-            );
+            Await.await().atMost(getRunningTimeout()).until(() -> servers.stream().allMatch(StandAloneRunner::isStarted));
         } catch (ConditionTimeoutException e) {
             throw new RuntimeException(
-                servers.stream().filter(s -> !Optional.ofNullable(s.getState()).orElse(Service.ServiceState.RUNNING).isRunning())
-                    .map(Service::getClass)
+                servers.stream().filter(s -> !isStarted(s))
+                    .map(s -> s.getClass().getSimpleName() + " (state: " + s.getState() + ")")
                     .toList() + " not started in time"
             );
         }
+    }
+
+    /**
+     * A service is only considered started once it reached RUNNING (or MAINTENANCE).
+     */
+    private static boolean isStarted(Service service) {
+        Service.ServiceState state = service.getState();
+        return Service.ServiceState.RUNNING == state || Service.ServiceState.MAINTENANCE == state;
     }
 
     private Duration getRunningTimeout() {

--- a/core/src/main/java/io/kestra/core/contexts/KestraContext.java
+++ b/core/src/main/java/io/kestra/core/contexts/KestraContext.java
@@ -99,6 +99,9 @@ public abstract class KestraContext {
 
     /**
      * Shutdowns the Kestra application.
+     * WARNING: this method is not safe to be called from the global KestraContext static instance as in unit test,
+     * this instance may have already been replaced by a fresh one, so you might shut down the next test run!
+     * The safe pattern is to inject a KestraContext instance and call this method on it.
      */
     public void shutdown() {
         // noop

--- a/core/src/main/java/io/kestra/core/exceptions/TypeConversionException.java
+++ b/core/src/main/java/io/kestra/core/exceptions/TypeConversionException.java
@@ -5,7 +5,8 @@ import io.kestra.core.utils.TypeConverter;
 /**
  * Exception thrown by {@link TypeConverter} when a value cannot be converted to the target type.
  *
- * <p>Extends {@link IllegalArgumentException} so that existing {@code IllegalArgumentException}
+ * <p>
+ * Extends {@link IllegalArgumentException} so that existing {@code IllegalArgumentException}
  * handling (e.g. the webserver's HTTP 400 mapping and repository filter wrapping) applies to
  * conversion failures without additional wiring. The original parse failure is preserved as the cause.
  */

--- a/core/src/main/java/io/kestra/core/http/client/HttpClient.java
+++ b/core/src/main/java/io/kestra/core/http/client/HttpClient.java
@@ -98,8 +98,7 @@ public class HttpClient implements Closeable {
         // otherwise offer `br`, then fail with UnsatisfiedLinkError when the matching native artifact
         // is missing. Setting the header explicitly wins: ContentCompressionExec only adds its own
         // Accept-Encoding when the request has none, so gzip/deflate responses are still auto-decoded.
-        builder.addRequestInterceptorFirst((request, entity, context) ->
-            request.setHeader(HttpHeaders.ACCEPT_ENCODING, "gzip, x-gzip, deflate"));
+        builder.addRequestInterceptorFirst((request, entity, context) -> request.setHeader(HttpHeaders.ACCEPT_ENCODING, "gzip, x-gzip, deflate"));
 
         if (observationRegistry != null) {
             // micrometer, must be placed before the retry strategy (see https://docs.micrometer.io/micrometer/reference/reference/httpcomponents.html#_retry_strategy_considerations)

--- a/core/src/main/java/io/kestra/core/models/AccessScope.java
+++ b/core/src/main/java/io/kestra/core/models/AccessScope.java
@@ -10,12 +10,12 @@ import java.util.List;
  * can be reused by any namespace-scoped resource (logs, audit logs, secrets, KV, …).
  *
  * <ul>
- *     <li>{@link Kind#GLOBAL} — no restriction (the caller may read every namespace);</li>
- *     <li>{@link Kind#NAMESPACES} — restrict to the given namespaces (and their children);</li>
- *     <li>{@link Kind#DENY_ALL} — no access, the query must return nothing.</li>
+ * <li>{@link Kind#GLOBAL} — no restriction (the caller may read every namespace);</li>
+ * <li>{@link Kind#NAMESPACES} — restrict to the given namespaces (and their children);</li>
+ * <li>{@link Kind#DENY_ALL} — no access, the query must return nothing.</li>
  * </ul>
  *
- * @param kind       the kind of restriction.
+ * @param kind the kind of restriction.
  * @param namespaces the allowed namespaces (only meaningful for {@link Kind#NAMESPACES}).
  */
 public record AccessScope(Kind kind, List<String> namespaces) {

--- a/core/src/main/java/io/kestra/core/plugins/AbstractPluginInterfaceFactory.java
+++ b/core/src/main/java/io/kestra/core/plugins/AbstractPluginInterfaceFactory.java
@@ -1,14 +1,5 @@
 package io.kestra.core.plugins;
 
-import io.kestra.core.exceptions.KestraRuntimeException;
-import io.kestra.core.models.Plugin;
-import io.kestra.core.serializers.JacksonMapper;
-
-import jakarta.validation.ConstraintViolation;
-import jakarta.validation.ConstraintViolationException;
-import jakarta.validation.Validator;
-import org.apache.commons.lang3.tuple.Pair;
-
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -16,6 +7,16 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+
+import org.apache.commons.lang3.tuple.Pair;
+
+import io.kestra.core.exceptions.KestraRuntimeException;
+import io.kestra.core.models.Plugin;
+import io.kestra.core.serializers.JacksonMapper;
+
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.ConstraintViolationException;
+import jakarta.validation.Validator;
 
 /**
  * Base class for factories that construct a plugin instance selected by a {@code type} configuration
@@ -66,7 +67,7 @@ public abstract class AbstractPluginInterfaceFactory<T> {
      * The returned instance is <b>not</b> initialized — concrete factories perform any init /
      * decoration in their own {@code make(...)}.
      *
-     * @param identifier          the plugin identifier, optionally in the form {@code <id>:<version>}.
+     * @param identifier the plugin identifier, optionally in the form {@code <id>:<version>}.
      * @param pluginConfiguration the plugin configuration. May be {@code null}.
      * @return the validated, uninitialized plugin instance.
      * @throws KestraRuntimeException if no plugin can be found, or the configuration is invalid.

--- a/core/src/main/java/io/kestra/core/plugins/PluginScanner.java
+++ b/core/src/main/java/io/kestra/core/plugins/PluginScanner.java
@@ -33,9 +33,9 @@ import io.kestra.core.models.tasks.runners.TaskRunner;
 import io.kestra.core.models.triggers.AbstractTrigger;
 import io.kestra.core.models.ui.PluginUiModule;
 import io.kestra.core.preview.FileRenderer;
+import io.kestra.core.repositories.LogDataStoreInterface;
 import io.kestra.core.secret.SecretPluginInterface;
 import io.kestra.core.serializers.JacksonMapper;
-import io.kestra.core.repositories.LogDataStoreInterface;
 import io.kestra.core.storages.StorageInterface;
 
 import io.swagger.v3.oas.annotations.Hidden;

--- a/core/src/main/java/io/kestra/core/repositories/log/LogDataStoreInterfaceFactory.java
+++ b/core/src/main/java/io/kestra/core/repositories/log/LogDataStoreInterfaceFactory.java
@@ -1,5 +1,8 @@
 package io.kestra.core.repositories.log;
 
+import java.util.List;
+import java.util.Map;
+
 import io.kestra.core.plugins.AbstractPluginInterfaceFactory;
 import io.kestra.core.plugins.ApplicationContextInitializable;
 import io.kestra.core.plugins.PluginRegistry;
@@ -8,9 +11,6 @@ import io.kestra.core.repositories.LogDataStoreInterface;
 
 import io.micronaut.context.ApplicationContext;
 import jakarta.validation.Validator;
-
-import java.util.List;
-import java.util.Map;
 
 /**
  * Factory for constructing {@link LogDataStoreInterface} objects from configuration.
@@ -35,7 +35,7 @@ public class LogDataStoreInterfaceFactory extends AbstractPluginInterfaceFactory
      * Constructs and validates a new {@link LogDataStoreInterface} of the given type with the given
      * configuration.
      *
-     * @param identifier          the ID of the log store, optionally in the form {@code <id>:<version>}.
+     * @param identifier the ID of the log store, optionally in the form {@code <id>:<version>}.
      * @param pluginConfiguration the configuration of the log store. May be {@code null}.
      * @return a new, initialized {@link LogDataStoreInterface}.
      */

--- a/core/src/main/java/io/kestra/core/server/AbstractService.java
+++ b/core/src/main/java/io/kestra/core/server/AbstractService.java
@@ -1,6 +1,8 @@
 package io.kestra.core.server;
 
+import java.time.Duration;
 import java.util.Map;
+import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -13,12 +15,20 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class AbstractService implements Service {
 
+    /**
+     * How long {@link #stop()} waits for an in-flight startup to complete before proceeding with a
+     * best-effort teardown. Generous on purpose: a worker startup can legitimately block up to the
+     * gRPC connect deadline (30s by default) before creating its resources.
+     */
+    private static final Duration STARTUP_COMPLETION_TIMEOUT = Duration.ofMinutes(1);
+
     private final String id;
     private final ServiceType serviceType;
     private final ApplicationEventPublisher<ServiceStateChangeEvent> eventPublisher;
 
     private final AtomicReference<ServiceState> state = new AtomicReference<>();
     private final AtomicBoolean stopped = new AtomicBoolean(false);
+    private final ServiceLifecycleGuard lifecycleGuard = new ServiceLifecycleGuard();
 
     public AbstractService(ServiceType serviceType, ApplicationEventPublisher<ServiceStateChangeEvent> eventPublisher) {
         this.id = IdUtils.create();
@@ -27,8 +37,14 @@ public class AbstractService implements Service {
     }
 
     protected void setState(final ServiceState state) {
-        this.state.set(state);
-        this.eventPublisher.publishEvent(new ServiceStateChangeEvent(this, getProperties()));
+        // Once a stop began, drop startup-side transitions (CREATED/RUNNING/MAINTENANCE): a startup
+        // or maintenance-listener thread racing the stop could otherwise overwrite the terminal
+        // state, leaving a fully torn-down service published as RUNNING. updateAndGet re-evaluates
+        // on contention, so a concurrent stop's terminal write can never be clobbered.
+        ServiceState result = this.state.updateAndGet(current -> stopped.get() && state.isRunning() ? current : state);
+        if (result == state) {
+            this.eventPublisher.publishEvent(new ServiceStateChangeEvent(this, getProperties()));
+        }
     }
 
     @Override
@@ -51,6 +67,55 @@ public class AbstractService implements Service {
     }
 
     /**
+     * Runs the given startup body under the service lifecycle guard. Services started
+     * asynchronously (runner thread pool) MUST run their startup through this template:
+     * <ul>
+     * <li>when {@link #stop()} was already requested (e.g. the application context is closing),
+     * the startup is aborted and nothing is created;</li>
+     * <li>while the body runs, a concurrent {@link #stop()} waits (bounded) for it to complete, so
+     * the teardown can never miss a resource created by the startup;</li>
+     * <li>when the body completes and no stop was requested meanwhile, {@code onStarted} runs — it
+     * typically transitions the service to RUNNING (or MAINTENANCE) and logs the successful start;</li>
+     * <li>a pending stop is always unblocked, even when the body throws.</li>
+     * </ul>
+     *
+     * @param startup the startup body, creating the service resources.
+     * @param onStarted the effective-start hook, skipped when a stop is pending.
+     * @throws IllegalStateException if the service was already started.
+     */
+    protected final void guardedStart(final Runnable startup, final Runnable onStarted) {
+        final String serviceName = getClass().getSimpleName();
+        if (!lifecycleGuard.beginStart()) {
+            log.info("Service [{}] stop was requested before startup began, aborting startup", serviceName);
+            return;
+        }
+        try {
+            startup.run();
+            if (lifecycleGuard.endStart()) {
+                onStarted.run();
+            } else {
+                log.info("Service [{}] startup completed with a stop pending, terminating", serviceName);
+            }
+        } catch (RejectedExecutionException e) {
+            // A stop() gave up waiting for this startup (startup-completion timeout) and already
+            // tore the service's thread pools down; the late startup then submitting to them is the
+            // expected outcome of that best-effort teardown, not a fatal error, so we didn't let it propagate.
+            log.warn("Service [{}] startup aborted: a stop tore down its resources while the startup was still in flight", serviceName, e);
+        } finally {
+            // unblock a pending stop even when the startup fails
+            lifecycleGuard.endStart();
+        }
+    }
+
+    /**
+     * @return {@code true} once {@link #stop()} has been requested. Long startups can use it as a
+     *         cheap cooperative checkpoint to abort early.
+     */
+    protected boolean isStopRequested() {
+        return lifecycleGuard.isStopRequested();
+    }
+
+    /**
      * {@inheritDoc}
      */
     @Override
@@ -63,6 +128,10 @@ public class AbstractService implements Service {
         if (stopped.compareAndSet(false, true)) {
             setState(ServiceState.TERMINATING);
             log.info("Service [{}] is terminating", getClass().getSimpleName());
+            // Refuse any future startup and wait (bounded) for an in-flight one, so doStop() never
+            // races a half-done startup: it would miss the resources created right after and leave
+            // them running once the application context (and e.g. its datasource) is closed.
+            lifecycleGuard.beginStop(STARTUP_COMPLETION_TIMEOUT);
             try {
                 ServiceState serviceState = doStop();
                 setState(serviceState);

--- a/core/src/main/java/io/kestra/core/server/ServiceLifecycleGuard.java
+++ b/core/src/main/java/io/kestra/core/server/ServiceLifecycleGuard.java
@@ -1,0 +1,109 @@
+package io.kestra.core.server;
+
+import java.time.Duration;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Coordinates a service startup with its stop so they can never overlap.
+ * <p>
+ * Services are started asynchronously (e.g. by the standalone runner thread pool) while
+ * {@code stop()} is called from another thread (Micronaut {@code @PreDestroy} on context close).
+ * Without coordination, a stop racing a still-in-flight startup tears down a partially built
+ * service: it misses resources that the startup creates just after, and those resources (queue
+ * subscribers, scheduled loops, gRPC servers) then outlive the application context.
+ * <p>
+ * Every lifecycle decision is a CAS on a single phase:
+ * <ul>
+ * <li>stop before start: the startup is refused ({@link #beginStart()} returns {@code false}), nothing is ever created;</li>
+ * <li>stop during start: {@link #beginStop(Duration)} blocks — bounded — until the startup completes, so the teardown sees every created resource;</li>
+ * <li>stop after start: no waiting.</li>
+ * </ul>
+ * The service must call {@link #endStart()} when its startup completes (success or failure, so a
+ * failed startup cannot block a pending stop) and use its return value to decide whether it may
+ * transition to RUNNING: {@code false} means a stop was requested meanwhile and the service is
+ * terminating, not running.
+ * The best way to use this guard is via the {@link AbstractService#guardedStart(Runnable, Runnable)} method.
+ */
+@Slf4j
+final class ServiceLifecycleGuard {
+
+    enum Phase {
+        NEW,
+        STARTING,
+        STARTED,
+        STOPPED
+    }
+
+    private final AtomicReference<Phase> phase = new AtomicReference<>(Phase.NEW);
+    private final AtomicBoolean stopRequested = new AtomicBoolean(false);
+    private final CountDownLatch startupFinished = new CountDownLatch(1);
+
+    /**
+     * Marks the beginning of the service startup.
+     *
+     * @return {@code true} if the service can start, {@code false} if a stop was already requested — the service must not create any resource.
+     * @throws IllegalStateException if the service was already started.
+     */
+    boolean beginStart() {
+        if (phase.compareAndSet(Phase.NEW, Phase.STARTING)) {
+            return true;
+        }
+        if (Phase.STOPPED == phase.get()) {
+            return false;
+        }
+        throw new IllegalStateException("Service already started");
+    }
+
+    /**
+     * Marks the end of the service startup, unblocking a stop waiting on it. Idempotent, and must
+     * be called even when the startup fails.
+     *
+     * @return {@code true} if the service effectively started and may transition to RUNNING,
+     *         {@code false} if a stop was requested in the meantime.
+     */
+    boolean endStart() {
+        boolean started = phase.compareAndSet(Phase.STARTING, Phase.STARTED) && !stopRequested.get();
+        startupFinished.countDown();
+        return started;
+    }
+
+    /**
+     * Marks the beginning of the service stop. When a startup is in flight, blocks until it
+     * completes at most {@code startupCompletionTimeout}, after which the teardown proceeds
+     * best-effort so a hung startup (e.g. an unresponsive database call) cannot block the
+     * application shutdown forever.
+     */
+    void beginStop(Duration startupCompletionTimeout) {
+        stopRequested.set(true);
+
+        if (phase.compareAndSet(Phase.NEW, Phase.STOPPED)) {
+            // the service never started: a later beginStart() will now be refused
+            return;
+        }
+
+        if (Phase.STARTING == phase.get()) {
+            try {
+                if (!startupFinished.await(startupCompletionTimeout.toMillis(), TimeUnit.MILLISECONDS)) {
+                    log.warn("Startup did not complete within {}, proceeding with a best-effort teardown", startupCompletionTimeout);
+                }
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                log.warn("Interrupted while waiting for the startup to complete, proceeding with a best-effort teardown");
+            }
+        }
+
+        phase.set(Phase.STOPPED);
+    }
+
+    /**
+     * @return {@code true} once a stop has been requested, even if it is still waiting on an in-flight startup.
+     */
+    boolean isStopRequested() {
+        return stopRequested.get();
+    }
+}

--- a/core/src/main/java/io/kestra/core/server/ServiceLivenessManager.java
+++ b/core/src/main/java/io/kestra/core/server/ServiceLivenessManager.java
@@ -3,6 +3,7 @@ package io.kestra.core.server;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.locks.ReentrantLock;
 
@@ -49,8 +50,11 @@ public class ServiceLivenessManager extends AbstractServiceLivenessTask {
         final LocalServiceStateFactory localServiceStateFactory,
         final ServerInstanceFactory serverInstanceFactory,
         final ServiceLivenessUpdater serviceLivenessUpdater,
-        final List<ServiceLivenessListener> livenessListeners) {
-        this(configuration, serviceRegistry, localServiceStateFactory, serverInstanceFactory, serviceLivenessUpdater, new DefaultStateTransitionFailureCallback(), livenessListeners);
+        final List<ServiceLivenessListener> livenessListeners,
+        final KestraContext kestraContext) {
+        this(
+            configuration, serviceRegistry, localServiceStateFactory, serverInstanceFactory, serviceLivenessUpdater, new DefaultStateTransitionFailureCallback(kestraContext), livenessListeners
+        );
     }
 
     @VisibleForTesting
@@ -59,7 +63,10 @@ public class ServiceLivenessManager extends AbstractServiceLivenessTask {
         final LocalServiceStateFactory localServiceStateFactory,
         final ServerInstanceFactory serverInstanceFactory,
         final ServiceLivenessUpdater serviceLivenessUpdater) {
-        this(configuration, serviceRegistry, localServiceStateFactory, serverInstanceFactory, serviceLivenessUpdater, new DefaultStateTransitionFailureCallback(), List.of());
+        this(
+            configuration, serviceRegistry, localServiceStateFactory, serverInstanceFactory, serviceLivenessUpdater, new DefaultStateTransitionFailureCallback(KestraContext.getContext()),
+            List.of()
+        );
     }
 
     @VisibleForTesting
@@ -435,6 +442,15 @@ public class ServiceLivenessManager extends AbstractServiceLivenessTask {
 
     public static final class DefaultStateTransitionFailureCallback implements OnStateTransitionFailureCallback {
 
+        private final KestraContext kestraContext;
+
+        /**
+         * Creates a callback shutting down the given owning context on liveness failure.
+         */
+        public DefaultStateTransitionFailureCallback(final KestraContext kestraContext) {
+            this.kestraContext = Objects.requireNonNull(kestraContext, "kestraContext cannot be null");
+        }
+
         /**
          * {@inheritDoc}
          **/
@@ -468,7 +484,7 @@ public class ServiceLivenessManager extends AbstractServiceLivenessTask {
                 if (state.equals(Service.ServiceState.NOT_RUNNING) || state.equals(Service.ServiceState.INACTIVE)) {
                     service.skipGracefulTermination(true);
                 }
-                KestraContext.getContext().shutdown();
+                kestraContext.shutdown();
                 return Optional.empty();
             }
 

--- a/core/src/main/java/io/kestra/core/utils/DateUtils.java
+++ b/core/src/main/java/io/kestra/core/utils/DateUtils.java
@@ -10,7 +10,7 @@ import io.kestra.core.models.QueryFilter;
 public class DateUtils {
     /**
      * @deprecated use {@link TypeConverter#toZonedDateTime(Object)} instead — same strict
-     * ISO-8601 parsing, but throws an unchecked {@code TypeConversionException}.
+     *             ISO-8601 parsing, but throws an unchecked {@code TypeConversionException}.
      */
     @Deprecated(since = "2.0", forRemoval = true)
     public static ZonedDateTime parseZonedDateTime(String render) throws InternalException {

--- a/core/src/main/java/io/kestra/core/utils/ExecutorsUtils.java
+++ b/core/src/main/java/io/kestra/core/utils/ExecutorsUtils.java
@@ -44,7 +44,7 @@ public class ExecutorsUtils {
         return this.wrap(
             name,
             Executors.newCachedThreadPool(
-                Thread.ofVirtual().name(name + "_%d").factory()
+                Thread.ofVirtual().name(name + "_%d").uncaughtExceptionHandler(new ThreadUncaughtExceptionHandler()).factory()
             )
         );
     }
@@ -74,7 +74,7 @@ public class ExecutorsUtils {
             60L,
             TimeUnit.SECONDS,
             new LinkedBlockingQueue<>(),
-            Thread.ofVirtual().name(name + "_%d").factory()
+            Thread.ofVirtual().name(name + "_%d").uncaughtExceptionHandler(new ThreadUncaughtExceptionHandler()).factory()
         );
 
         threadPoolExecutor.allowCoreThreadTimeOut(true);

--- a/core/src/main/java/io/kestra/core/utils/ThreadMainFactoryBuilder.java
+++ b/core/src/main/java/io/kestra/core/utils/ThreadMainFactoryBuilder.java
@@ -13,7 +13,8 @@ public final class ThreadMainFactoryBuilder {
     public static ThreadFactory build(String name) {
         return new ThreadFactoryBuilder()
             .setNameFormat(name)
-            .setUncaughtExceptionHandler(ThreadUncaughtExceptionHandler.INSTANCE)
+            // a new handler per factory: it captures the KestraContext current at build time
+            .setUncaughtExceptionHandler(new ThreadUncaughtExceptionHandler())
             .build();
     }
 }

--- a/core/src/main/java/io/kestra/core/utils/ThreadUncaughtExceptionHandler.java
+++ b/core/src/main/java/io/kestra/core/utils/ThreadUncaughtExceptionHandler.java
@@ -1,6 +1,7 @@
 package io.kestra.core.utils;
 
 import java.lang.Thread.UncaughtExceptionHandler;
+import java.util.Objects;
 
 import io.kestra.core.contexts.KestraContext;
 
@@ -8,11 +9,48 @@ import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 public final class ThreadUncaughtExceptionHandler implements UncaughtExceptionHandler {
+    /**
+     * Shared instance created at class-load time, i.e. usually before any {@link KestraContext} is
+     * initialized: it then resolves the context at failure time. Prefer creating a new instance
+     * from the owning context (see {@link #ThreadUncaughtExceptionHandler()}) — the static context
+     * points to the newest context in the JVM, which at failure time can be a different, freshly
+     * started one when several contexts follow each other in the same JVM (tests).
+     */
     public static final UncaughtExceptionHandler INSTANCE = new ThreadUncaughtExceptionHandler();
+
+    private final KestraContext kestraContext;
+
+    /**
+     * Creates a handler bound to the {@link KestraContext} current at construction time, so the
+     * threads it is installed on shut down the context that created them.
+     * Falls back to failure-time resolution when no context is initialized yet.
+     * <p>
+     * Known limitation: the capture reads the same JVM-global static, so it is only correct when
+     * the constructing code runs while its owning context is the current one. When several
+     * application contexts genuinely coexist in one JVM (nested/embedded contexts), a thread pool
+     * built by context A after context B became current is permanently bound to B, and an uncaught
+     * exception in A's pool shuts B down. Thread pools are normally built during their context's
+     * bean construction — right after its own initializer became current — so this window is
+     * narrow; code needing a strict binding should use
+     * {@link #ThreadUncaughtExceptionHandler(KestraContext)} with an injected context instead.
+     */
+    public ThreadUncaughtExceptionHandler() {
+        this.kestraContext = currentContextOrNull();
+    }
+
+    /**
+     * Creates a handler that shuts down the given owning context on an uncaught exception.
+     *
+     * @param kestraContext the context owning the threads this handler is installed on.
+     */
+    public ThreadUncaughtExceptionHandler(KestraContext kestraContext) {
+        this.kestraContext = Objects.requireNonNull(kestraContext, "kestraContext cannot be null");
+    }
 
     @Override
     public void uncaughtException(Thread t, Throwable e) {
-        boolean isTest = KestraContext.getContext().getEnvironments().contains("test");
+        KestraContext context = kestraContext != null ? kestraContext : KestraContext.getContext();
+        boolean isTest = context.getEnvironments().contains("test");
 
         try {
             // cannot use FormattingLogger due to a dependency loop
@@ -23,11 +61,21 @@ public final class ThreadUncaughtExceptionHandler implements UncaughtExceptionHa
             System.err.println(e.getMessage());
             System.err.println(errorInLogging.getMessage());
         } finally {
-            KestraContext.getContext().shutdown();
+            context.shutdown();
 
             if (!isTest) {
                 Runtime.getRuntime().exit(1);
             }
+        }
+    }
+
+    private static KestraContext currentContextOrNull() {
+        try {
+            return KestraContext.getContext();
+        } catch (IllegalStateException e) {
+            // no context initialized yet (e.g. the INSTANCE created at class-load time):
+            // the context will be resolved at failure time instead
+            return null;
         }
     }
 }

--- a/core/src/main/java/io/kestra/core/utils/TypeConverter.java
+++ b/core/src/main/java/io/kestra/core/utils/TypeConverter.java
@@ -1,9 +1,5 @@
 package io.kestra.core.utils;
 
-import io.kestra.core.exceptions.TypeConversionException;
-import jakarta.annotation.Nullable;
-import jakarta.validation.constraints.NotNull;
-
 import java.time.Duration;
 import java.time.Instant;
 import java.time.LocalDate;
@@ -13,17 +9,23 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.function.Function;
 
+import io.kestra.core.exceptions.TypeConversionException;
+
+import jakarta.annotation.Nullable;
+import jakarta.validation.constraints.NotNull;
+
 /**
  * Utility methods for converting raw values (typically {@link Object} or {@link String}) into typed values.
  *
- * <p>General contract for all methods:
+ * <p>
+ * General contract for all methods:
  * <ul>
- *     <li>{@code null} in, {@code null} out.</li>
- *     <li>A value already of the target type is returned as-is (passthrough).</li>
- *     <li>Any other value is strictly parsed from its {@code toString()} representation — no trimming,
- *     no locale handling, no lenient formats.</li>
- *     <li>Conversion failures throw {@link TypeConversionException} (an {@link IllegalArgumentException})
- *     carrying the original parse failure as cause.</li>
+ * <li>{@code null} in, {@code null} out.</li>
+ * <li>A value already of the target type is returned as-is (passthrough).</li>
+ * <li>Any other value is strictly parsed from its {@code toString()} representation — no trimming,
+ * no locale handling, no lenient formats.</li>
+ * <li>Conversion failures throw {@link TypeConversionException} (an {@link IllegalArgumentException})
+ * carrying the original parse failure as cause.</li>
  * </ul>
  */
 public final class TypeConverter {
@@ -31,7 +33,8 @@ public final class TypeConverter {
     /**
      * Converts the given value to a {@link Boolean}.
      *
-     * <p>Uses {@link Boolean#parseBoolean(String)} semantics: only the literal {@code "true"}
+     * <p>
+     * Uses {@link Boolean#parseBoolean(String)} semantics: only the literal {@code "true"}
      * (case-insensitive) is {@code true}; everything else — including {@code "1"} and {@code "yes"} —
      * is {@code false}. Do NOT use for flow-condition truthiness; use {@link TruthUtils} instead.
      *

--- a/core/src/main/java/io/kestra/core/validations/AppConfigValidator.java
+++ b/core/src/main/java/io/kestra/core/validations/AppConfigValidator.java
@@ -43,7 +43,8 @@ public class AppConfigValidator {
     /**
      * Validates the application-wide configuration and returns the outcome of each check.
      *
-     * <p>This method is side-effect free (it neither logs nor throws) so the same checks can be
+     * <p>
+     * This method is side-effect free (it neither logs nor throws) so the same checks can be
      * reused for on-demand validation.
      *
      * @param environment the configuration environment to validate

--- a/core/src/main/java/io/kestra/core/validations/ConfigValidationResult.java
+++ b/core/src/main/java/io/kestra/core/validations/ConfigValidationResult.java
@@ -3,12 +3,13 @@ package io.kestra.core.validations;
 /**
  * Outcome of a single configuration validation check.
  *
- * <p>Instances are produced by the configuration validators (e.g. {@link AppConfigValidator},
+ * <p>
+ * Instances are produced by the configuration validators (e.g. {@link AppConfigValidator},
  * {@link ServerCommandValidator}) so that the same checks can be reused both at boot time and
  * for on-demand validation (e.g. the {@code configs validate} CLI command).
  *
- * @param key     the configuration property (or logical check name) that was validated
- * @param valid   whether the check passed
+ * @param key the configuration property (or logical check name) that was validated
+ * @param valid whether the check passed
  * @param message a human-readable explanation of the failure, {@code null} when the check passed
  */
 public record ConfigValidationResult(String key, boolean valid, String message) {

--- a/core/src/main/java/io/kestra/core/validations/ServerCommandValidator.java
+++ b/core/src/main/java/io/kestra/core/validations/ServerCommandValidator.java
@@ -54,20 +54,23 @@ public class ServerCommandValidator {
     /**
      * Validates that the properties required to start the given {@link ServerType} are defined.
      *
-     * <p>This method is side-effect free (it neither logs nor throws) so the same checks can be
+     * <p>
+     * This method is side-effect free (it neither logs nor throws) so the same checks can be
      * reused for on-demand validation.
      *
      * @param environment the configuration environment to validate
-     * @param serverType  the server type whose required properties must be present
+     * @param serverType the server type whose required properties must be present
      * @return the outcome of each required-property check, never {@code null}
      */
     public static List<ConfigValidationResult> validateServerConfiguration(final Environment environment, final ServerType serverType) {
         final Map<String, String> required = ServerType.WORKER.equals(serverType) ? WORKER_REQUIRED_PROPERTIES : ALL_REQUIRED_PROPERTIES;
 
         return required.entrySet().stream()
-            .map(property -> environment.containsProperty(property.getKey())
-                ? ConfigValidationResult.valid(property.getKey())
-                : ConfigValidationResult.invalid(property.getKey(), missingPropertyMessage(property.getKey(), property.getValue())))
+            .map(
+                property -> environment.containsProperty(property.getKey())
+                    ? ConfigValidationResult.valid(property.getKey())
+                    : ConfigValidationResult.invalid(property.getKey(), missingPropertyMessage(property.getKey(), property.getValue()))
+            )
             .toList();
     }
 

--- a/core/src/main/java/io/kestra/plugin/core/kv/Version.java
+++ b/core/src/main/java/io/kestra/plugin/core/kv/Version.java
@@ -1,7 +1,6 @@
 package io.kestra.plugin.core.kv;
 
 import java.io.IOException;
-import java.time.ZonedDateTime;
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;

--- a/core/src/main/java/io/kestra/plugin/core/log/PurgeLogs.java
+++ b/core/src/main/java/io/kestra/plugin/core/log/PurgeLogs.java
@@ -1,6 +1,5 @@
 package io.kestra.plugin.core.log;
 
-import java.time.ZonedDateTime;
 import java.util.List;
 
 import org.slf4j.event.Level;

--- a/core/src/main/java/io/kestra/plugin/core/namespace/Version.java
+++ b/core/src/main/java/io/kestra/plugin/core/namespace/Version.java
@@ -1,6 +1,5 @@
 package io.kestra.plugin.core.namespace;
 
-import java.time.ZonedDateTime;
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;

--- a/core/src/test/java/io/kestra/core/server/ServiceLifecycleGuardTest.java
+++ b/core/src/test/java/io/kestra/core/server/ServiceLifecycleGuardTest.java
@@ -1,0 +1,163 @@
+package io.kestra.core.server;
+
+import java.time.Duration;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class ServiceLifecycleGuardTest {
+
+    @Test
+    void shouldStartThenStopWithoutWaiting() {
+        // Given
+        var guard = new ServiceLifecycleGuard();
+
+        // When
+        boolean canStart = guard.beginStart();
+        boolean started = guard.endStart();
+        long before = System.nanoTime();
+        guard.beginStop(Duration.ofSeconds(10));
+        long elapsedMs = (System.nanoTime() - before) / 1_000_000;
+
+        // Then
+        assertThat(canStart).isTrue();
+        assertThat(started).isTrue();
+        assertThat(elapsedMs).isLessThan(1_000);
+    }
+
+    @Test
+    void shouldRefuseStartWhenStopWasRequestedFirst() {
+        // Given
+        var guard = new ServiceLifecycleGuard();
+
+        // When
+        guard.beginStop(Duration.ofSeconds(10));
+
+        // Then
+        assertThat(guard.beginStart()).isFalse();
+        assertThat(guard.isStopRequested()).isTrue();
+    }
+
+    @Test
+    void shouldThrowOnDoubleStart() {
+        // Given
+        var guard = new ServiceLifecycleGuard();
+        guard.beginStart();
+
+        // When/Then
+        assertThatThrownBy(guard::beginStart).isInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    void shouldBlockStopUntilStartupCompletes() throws InterruptedException {
+        // Given: a startup in flight
+        var guard = new ServiceLifecycleGuard();
+        guard.beginStart();
+
+        var stopReturned = new CountDownLatch(1);
+        Thread stopper = Thread.ofVirtual().start(() ->
+        {
+            guard.beginStop(Duration.ofSeconds(10));
+            stopReturned.countDown();
+        });
+
+        // wait until the stop request is effectively visible, so the assertions below cannot pass
+        // vacuously because the stopper thread was not scheduled yet
+        while (!guard.isStopRequested()) {
+            Thread.onSpinWait();
+        }
+
+        // Then: stop is blocked while the startup is in flight
+        assertThat(stopReturned.await(200, TimeUnit.MILLISECONDS)).isFalse();
+
+        // When: the startup completes
+        boolean started = guard.endStart();
+
+        // Then: stop unblocks, and the service must not transition to RUNNING
+        assertThat(stopReturned.await(2, TimeUnit.SECONDS)).isTrue();
+        assertThat(started).isFalse();
+        stopper.join(1000);
+    }
+
+    @Test
+    void shouldNotReportStartedWhenStartupCompletesAfterStopTimedOut() {
+        // Given: a startup that outlives the stop wait
+        var guard = new ServiceLifecycleGuard();
+        guard.beginStart();
+        guard.beginStop(Duration.ofMillis(50));
+
+        // When: the hung startup finally completes
+        boolean started = guard.endStart();
+
+        // Then
+        assertThat(started).isFalse();
+    }
+
+    @Test
+    void shouldProceedBestEffortWhenStartupHangs() {
+        // Given: a startup that never completes
+        var guard = new ServiceLifecycleGuard();
+        guard.beginStart();
+
+        // When
+        long before = System.nanoTime();
+        guard.beginStop(Duration.ofMillis(100));
+        long elapsedMs = (System.nanoTime() - before) / 1_000_000;
+
+        // Then: stop proceeded after the timeout instead of hanging
+        assertThat(elapsedMs).isGreaterThanOrEqualTo(100);
+        assertThat(elapsedMs).isLessThan(5_000);
+    }
+
+    @Test
+    void shouldReportEffectiveStartOnlyOnFirstEndStart() {
+        // Given
+        var guard = new ServiceLifecycleGuard();
+        guard.beginStart();
+
+        // When
+        boolean first = guard.endStart();
+        boolean second = guard.endStart();
+
+        // Then: only the first call reports an effective start
+        assertThat(first).isTrue();
+        assertThat(second).isFalse();
+    }
+
+    @Test
+    void shouldReportStopRequestedWhileWaitingOnStartup() throws InterruptedException {
+        // Given: a startup in flight that checks the cooperative flag
+        var guard = new ServiceLifecycleGuard();
+        guard.beginStart();
+
+        var observedWhileStarting = new AtomicBoolean(false);
+        var stopRequestedSeen = new CountDownLatch(1);
+        Thread starter = Thread.ofVirtual().start(() ->
+        {
+            try {
+                // simulate a long startup polling the cooperative checkpoint
+                while (!guard.isStopRequested()) {
+                    Thread.onSpinWait();
+                }
+                observedWhileStarting.set(true);
+                stopRequestedSeen.countDown();
+            } finally {
+                guard.endStart();
+            }
+        });
+
+        // When
+        Thread stopper = Thread.ofVirtual().start(() -> guard.beginStop(Duration.ofSeconds(10)));
+
+        // Then
+        assertThat(stopRequestedSeen.await(2, TimeUnit.SECONDS)).isTrue();
+        assertThat(observedWhileStarting).isTrue();
+        starter.join(1000);
+        stopper.join(1000);
+    }
+}

--- a/core/src/test/java/io/kestra/core/utils/ThreadUncaughtExceptionHandlerTest.java
+++ b/core/src/test/java/io/kestra/core/utils/ThreadUncaughtExceptionHandlerTest.java
@@ -1,0 +1,122 @@
+package io.kestra.core.utils;
+
+import java.util.Optional;
+import java.util.Set;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import io.kestra.core.contexts.KestraContext;
+import io.kestra.core.models.ServerType;
+import io.kestra.core.plugins.PluginRegistry;
+import io.kestra.core.storages.StorageInterface;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ThreadUncaughtExceptionHandlerTest {
+
+    private KestraContext previousContext;
+
+    @BeforeEach
+    void saveKestraContext() {
+        try {
+            previousContext = KestraContext.getContext();
+        } catch (IllegalStateException e) {
+            previousContext = null;
+        }
+    }
+
+    @AfterEach
+    void restoreKestraContext() {
+        // do not leak the recording stub into later tests of the same fork
+        KestraContext.setContext(previousContext);
+    }
+
+    @Test
+    void shouldShutdownTheBoundContextNotTheStaticOne() {
+        // Given: the JVM-global static points to another (newer) context
+        var boundContext = new RecordingContext();
+        var otherContext = new RecordingContext();
+        KestraContext.setContext(otherContext);
+
+        var handler = new ThreadUncaughtExceptionHandler(boundContext);
+
+        // When
+        handler.uncaughtException(Thread.currentThread(), new RuntimeException("boom"));
+
+        // Then
+        assertThat(boundContext.shutdownCalled).isTrue();
+        assertThat(otherContext.shutdownCalled).isFalse();
+    }
+
+    @Test
+    void shouldCaptureTheContextCurrentAtConstructionTime() {
+        // Given: a handler created while the static points to the owning context
+        var owningContext = new RecordingContext();
+        KestraContext.setContext(owningContext);
+        var handler = new ThreadUncaughtExceptionHandler();
+
+        // When: a newer context replaced the static before the failure happens
+        var newerContext = new RecordingContext();
+        KestraContext.setContext(newerContext);
+        handler.uncaughtException(Thread.currentThread(), new RuntimeException("boom"));
+
+        // Then
+        assertThat(owningContext.shutdownCalled).isTrue();
+        assertThat(newerContext.shutdownCalled).isFalse();
+    }
+
+    /**
+     * A recording {@link KestraContext} whose environments contain "test" so the handler never
+     * calls {@code Runtime.getRuntime().exit(1)}.
+     */
+    private static final class RecordingContext extends KestraContext {
+        private volatile boolean shutdownCalled = false;
+
+        @Override
+        public void shutdown() {
+            this.shutdownCalled = true;
+        }
+
+        @Override
+        public Set<String> getEnvironments() {
+            return Set.of("test");
+        }
+
+        @Override
+        public ServerType getServerType() {
+            return ServerType.STANDALONE;
+        }
+
+        @Override
+        public int getAllocatedCpuCores() {
+            return 1;
+        }
+
+        @Override
+        public Optional<Integer> getWorkerMaxNumThreads() {
+            return Optional.empty();
+        }
+
+        @Override
+        public void injectWorkerConfigs(Integer maxNumThreads) {
+            // no-op
+        }
+
+        @Override
+        public String getVersion() {
+            return null;
+        }
+
+        @Override
+        public PluginRegistry getPluginRegistry() {
+            return null;
+        }
+
+        @Override
+        public StorageInterface getStorageInterface() {
+            return null;
+        }
+    }
+}

--- a/core/src/test/java/io/kestra/core/utils/TypeConverterTest.java
+++ b/core/src/test/java/io/kestra/core/utils/TypeConverterTest.java
@@ -1,11 +1,5 @@
 package io.kestra.core.utils;
 
-import io.kestra.core.exceptions.TypeConversionException;
-import org.junit.jupiter.api.Named;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.MethodSource;
-
 import java.time.Duration;
 import java.time.Instant;
 import java.time.LocalDate;
@@ -16,13 +10,21 @@ import java.util.List;
 import java.util.function.Function;
 import java.util.stream.Stream;
 
+import org.junit.jupiter.api.Named;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import io.kestra.core.exceptions.TypeConversionException;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class TypeConverterTest {
 
     private enum TestEnum {
-        FIRST, SECOND
+        FIRST,
+        SECOND
     }
 
     private static final Function<Object, TestEnum> TO_TEST_ENUM = value -> TypeConverter.toEnum(value, TestEnum.class);

--- a/executor/src/main/java/io/kestra/executor/DefaultExecutor.java
+++ b/executor/src/main/java/io/kestra/executor/DefaultExecutor.java
@@ -115,7 +115,6 @@ public class DefaultExecutor extends AbstractService implements Executor {
     private final List<Runnable> receiveCancellations = new CopyOnWriteArrayList<>();
     private final List<QueueSubscriber<?>> queueSubscribers = new CopyOnWriteArrayList<>();
     private final AtomicBoolean isPaused = new AtomicBoolean(false);
-    private final AtomicBoolean shutdown = new AtomicBoolean(false);
 
     private final java.util.concurrent.ExecutorService workerTaskResultExecutorService;
     private final java.util.concurrent.ExecutorService executionExecutorService;
@@ -346,7 +345,7 @@ public class DefaultExecutor extends AbstractService implements Executor {
                 } catch (ExecutionException | InterruptedException e) {
                     // An exception during shutdown is teardown noise (e.g. closed datasource), not a reason to escalate.
                     // We avoid closing the Executor if the exception is a CannotCreateTransactionException as it may be transient
-                    if (!shutdown.get() && e.getCause() != null && !e.getCause().getClass().getSimpleName().equals("CannotCreateTransactionException")) {
+                    if (!isStopRequested() && e.getCause() != null && !e.getCause().getClass().getSimpleName().equals("CannotCreateTransactionException")) {
                         log.error("Executor fatal exception in the scheduledDelay thread", e);
                         close();
                         kestraContext.shutdown();
@@ -368,7 +367,7 @@ public class DefaultExecutor extends AbstractService implements Executor {
                 } catch (ExecutionException | InterruptedException e) {
                     // An exception during shutdown is teardown noise (e.g. closed datasource), not a reason to escalate.
                     // We avoid closing the Executor if the exception is a CannotCreateTransactionException as it may be transient
-                    if (!shutdown.get() && e.getCause() != null && !e.getCause().getClass().getSimpleName().equals("CannotCreateTransactionException")) {
+                    if (!isStopRequested() && e.getCause() != null && !e.getCause().getClass().getSimpleName().equals("CannotCreateTransactionException")) {
                         log.error("Executor fatal exception in the scheduledSLAMonitor thread", e);
                         close();
                         kestraContext.shutdown();
@@ -489,7 +488,7 @@ public class DefaultExecutor extends AbstractService implements Executor {
      * - Failed flow that will be retried after an interval
      **/
     private void executionDelayLoop() {
-        if (this.shutdown.get() || this.isPaused.get()) {
+        if (isStopRequested() || this.isPaused.get()) {
             return;
         }
 
@@ -584,7 +583,7 @@ public class DefaultExecutor extends AbstractService implements Executor {
     }
 
     private void executionSLAMonitorLoop() {
-        if (this.shutdown.get() || this.isPaused.get()) {
+        if (isStopRequested() || this.isPaused.get()) {
             return;
         }
 
@@ -899,9 +898,7 @@ public class DefaultExecutor extends AbstractService implements Executor {
     @Override
     protected ServiceState doStop() {
         // AbstractService.stop() already waited for any in-flight startup, so nothing can be
-        // created past this point. Signal the loops and watchers that exceptions from now on are
-        // teardown noise (e.g. closed datasource), not a reason to escalate.
-        this.shutdown.set(true);
+        // created past this point; the loops and watchers see the stop via isStopRequested().
         try {
             this.receiveCancellations.forEach(Runnable::run);
             this.queueSubscribers.forEach(QueueSubscriber::close);

--- a/executor/src/main/java/io/kestra/executor/DefaultExecutor.java
+++ b/executor/src/main/java/io/kestra/executor/DefaultExecutor.java
@@ -91,6 +91,11 @@ public class DefaultExecutor extends AbstractService implements Executor {
 
     private final MetricRegistry metricRegistry;
 
+    // The context captured at construction time.
+    // The static context returned by KestraContext.getContext() might change if the context is restarted inside the same JVM
+    // which can occur at least in tests.
+    private final KestraContext kestraContext;
+
     private final RunContextFactory runContextFactory;
 
     private final ExecutionCommandMessageHandler executionCommandMessageHandler;
@@ -124,6 +129,7 @@ public class DefaultExecutor extends AbstractService implements Executor {
         ApplicationEventPublisher<ServiceStateChangeEvent> eventPublisher,
         ExecutorsUtils executorsUtils,
         ExecutorConfiguration executorConfiguration,
+        KestraContext kestraContext,
         DispatchQueueInterface<Execution> executionQueue,
         DispatchQueueInterface<ExecutionCommand> executionCommandQueue,
         KillSwitchService killSwitchService,
@@ -160,6 +166,7 @@ public class DefaultExecutor extends AbstractService implements Executor {
         LoopExecutionEventMessageHandler loopExecutionEventMessageHandler) {
         super(ServiceType.EXECUTOR, eventPublisher);
 
+        this.kestraContext = kestraContext;
         this.executionQueue = executionQueue;
         this.executionCommandQueue = executionCommandQueue;
         this.killSwitchService = killSwitchService;
@@ -199,7 +206,7 @@ public class DefaultExecutor extends AbstractService implements Executor {
         // for the worker task result queue and the execution queue.
         // Other queues would not benefit from more consumers.
         int threadCount = executorConfiguration.threadCount() != null ? executorConfiguration.threadCount() : 0;
-        this.numberOfThreads = threadCount != 0 ? threadCount : Math.max(4, KestraContext.getContext().getAllocatedCpuCores());
+        this.numberOfThreads = threadCount != 0 ? threadCount : Math.max(4, kestraContext.getAllocatedCpuCores());
         this.workerTaskResultExecutorService = executorsUtils.maxCachedThreadPool(numberOfThreads, "executor-worker-task-result-executor");
         this.executionExecutorService = executorsUtils.maxCachedThreadPool(numberOfThreads, "executor-execution-event-executor");
 
@@ -318,11 +325,12 @@ public class DefaultExecutor extends AbstractService implements Executor {
                 } catch (CancellationException ignored) {
 
                 } catch (ExecutionException | InterruptedException e) {
+                    // An exception during shutdown is teardown noise (e.g. closed datasource), not a reason to escalate.
                     // We avoid closing the Executor if the exception is a CannotCreateTransactionException as it may be transient
-                    if (e.getCause() != null && !e.getCause().getClass().getSimpleName().equals("CannotCreateTransactionException")) {
+                    if (!shutdown.get() && e.getCause() != null && !e.getCause().getClass().getSimpleName().equals("CannotCreateTransactionException")) {
                         log.error("Executor fatal exception in the scheduledDelay thread", e);
                         close();
-                        KestraContext.getContext().shutdown();
+                        kestraContext.shutdown();
                     }
                 }
             }
@@ -339,11 +347,12 @@ public class DefaultExecutor extends AbstractService implements Executor {
                 } catch (CancellationException ignored) {
 
                 } catch (ExecutionException | InterruptedException e) {
+                    // An exception during shutdown is teardown noise (e.g. closed datasource), not a reason to escalate.
                     // We avoid closing the Executor if the exception is a CannotCreateTransactionException as it may be transient
-                    if (e.getCause() != null && !e.getCause().getClass().getSimpleName().equals("CannotCreateTransactionException")) {
+                    if (!shutdown.get() && e.getCause() != null && !e.getCause().getClass().getSimpleName().equals("CannotCreateTransactionException")) {
                         log.error("Executor fatal exception in the scheduledSLAMonitor thread", e);
                         close();
-                        KestraContext.getContext().shutdown();
+                        kestraContext.shutdown();
                     }
                 }
             }

--- a/executor/src/main/java/io/kestra/executor/DefaultExecutor.java
+++ b/executor/src/main/java/io/kestra/executor/DefaultExecutor.java
@@ -111,8 +111,9 @@ public class DefaultExecutor extends AbstractService implements Executor {
     private ScheduledFuture<?> executionDelayFuture;
     private ScheduledFuture<?> monitorSLAFuture;
 
-    private final List<Runnable> receiveCancellations = new ArrayList<>();
-    private final List<QueueSubscriber<?>> queueSubscribers = new ArrayList<>();
+    // Thread-safe: populated by run() but iterated from maintenance listener and shutdown threads.
+    private final List<Runnable> receiveCancellations = new CopyOnWriteArrayList<>();
+    private final List<QueueSubscriber<?>> queueSubscribers = new CopyOnWriteArrayList<>();
     private final AtomicBoolean isPaused = new AtomicBoolean(false);
     private final AtomicBoolean shutdown = new AtomicBoolean(false);
 
@@ -245,6 +246,18 @@ public class DefaultExecutor extends AbstractService implements Executor {
 
     @Override
     public void run() {
+        guardedStart(this::doRun, () ->
+        {
+            if (this.maintenanceService.isInMaintenanceMode()) {
+                enterMaintenance();
+            } else {
+                setState(ServiceState.RUNNING);
+            }
+            log.info("Executor started with {} thread(s)", numberOfThreads);
+        });
+    }
+
+    private void doRun() {
         // listen to executor related queues
         this.queueSubscribers.addFirst(this.executionQueue.subscriber().subscribe(this::executionQueue));
         this.queueSubscribers.addFirst(
@@ -299,6 +312,12 @@ public class DefaultExecutor extends AbstractService implements Executor {
                 DefaultExecutor.this.exitMaintenance();
             }
         })::dispose);
+
+        // A stop may have timed out waiting for this startup and already closed the scheduled
+        // pool — don't schedule the loops or start their watchers on it.
+        if (isStopRequested()) {
+            return;
+        }
 
         // Start delay and monitoring loops
         executionDelayFuture = scheduledExecutorService.scheduleAtFixedRate(
@@ -358,13 +377,6 @@ public class DefaultExecutor extends AbstractService implements Executor {
             }
         );
 
-        // init the service
-        if (this.maintenanceService.isInMaintenanceMode()) {
-            enterMaintenance();
-        } else {
-            setState(ServiceState.RUNNING);
-        }
-        log.info("Executor started with {} thread(s)", numberOfThreads);
     }
 
     private void executionQueue(Either<Execution, DeserializationException> either) {
@@ -886,9 +898,23 @@ public class DefaultExecutor extends AbstractService implements Executor {
 
     @Override
     protected ServiceState doStop() {
-        this.receiveCancellations.forEach(Runnable::run);
-        this.queueSubscribers.forEach(QueueSubscriber::close);
-        ExecutorsUtils.closeScheduledThreadPool(scheduledExecutorService, Duration.ofSeconds(5), List.of(executionDelayFuture, monitorSLAFuture));
+        // AbstractService.stop() already waited for any in-flight startup, so nothing can be
+        // created past this point. Signal the loops and watchers that exceptions from now on are
+        // teardown noise (e.g. closed datasource), not a reason to escalate.
+        this.shutdown.set(true);
+        try {
+            this.receiveCancellations.forEach(Runnable::run);
+            this.queueSubscribers.forEach(QueueSubscriber::close);
+        } finally {
+            // Always stop the scheduled loops: leaving them running after the context is closed makes
+            // them fail on the closed datasource and escalate to an application shutdown.
+            // The futures are null when stop ran before run() scheduled them.
+            ExecutorsUtils.closeScheduledThreadPool(
+                scheduledExecutorService,
+                Duration.ofSeconds(5),
+                Stream.of(executionDelayFuture, monitorSLAFuture).filter(Objects::nonNull).toList()
+            );
+        }
         return ServiceState.TERMINATED_GRACEFULLY;
     }
 }

--- a/indexer/src/main/java/io/kestra/indexer/DefaultIndexer.java
+++ b/indexer/src/main/java/io/kestra/indexer/DefaultIndexer.java
@@ -2,8 +2,6 @@ package io.kestra.indexer;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicReference;
 
 import io.kestra.core.metrics.MetricRegistry;
 import io.kestra.core.models.executions.LogEntry;
@@ -18,7 +16,6 @@ import io.kestra.core.server.AbstractService;
 import io.kestra.core.server.ServiceStateChangeEvent;
 import io.kestra.core.server.ServiceType;
 import io.kestra.core.services.IgnoreExecutionService;
-import io.kestra.core.utils.IdUtils;
 import io.kestra.core.utils.ListUtils;
 
 import io.micronaut.context.event.ApplicationEventPublisher;
@@ -42,12 +39,6 @@ public class DefaultIndexer extends AbstractService implements Indexer {
     private final MetricRegistry metricRegistry;
     private final List<QueueSubscriber<?>> subscribers = new ArrayList<>();
 
-    private final String id = IdUtils.create();
-    private final AtomicReference<ServiceState> state = new AtomicReference<>();
-    private final ApplicationEventPublisher<ServiceStateChangeEvent> eventPublisher;
-
-    private final AtomicBoolean closed = new AtomicBoolean(false);
-
     private final IgnoreExecutionService ignoreExecutionService;
     private final QueueService queueService;
 
@@ -68,7 +59,6 @@ public class DefaultIndexer extends AbstractService implements Indexer {
         this.metricRepository = metricRepositor;
         this.metricQueue = metricQueue;
         this.metricRegistry = metricRegistry;
-        this.eventPublisher = eventPublisher;
         this.ignoreExecutionService = ignoreExecutionService;
         this.queueService = queueService;
 
@@ -122,24 +112,6 @@ public class DefaultIndexer extends AbstractService implements Indexer {
                 });
             }
         }));
-    }
-
-    /** {@inheritDoc} **/
-    @Override
-    public String getId() {
-        return id;
-    }
-
-    /** {@inheritDoc} **/
-    @Override
-    public ServiceType getType() {
-        return ServiceType.INDEXER;
-    }
-
-    /** {@inheritDoc} **/
-    @Override
-    public ServiceState getState() {
-        return state.get();
     }
 
     @Override

--- a/indexer/src/main/java/io/kestra/indexer/DefaultIndexer.java
+++ b/indexer/src/main/java/io/kestra/indexer/DefaultIndexer.java
@@ -1,7 +1,7 @@
 package io.kestra.indexer;
 
-import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 import io.kestra.core.metrics.MetricRegistry;
 import io.kestra.core.models.executions.LogEntry;
@@ -37,7 +37,8 @@ public class DefaultIndexer extends AbstractService implements Indexer {
     private final MetricRepositoryInterface metricRepository;
     private final DispatchQueueInterface<MetricEntry> metricQueue;
     private final MetricRegistry metricRegistry;
-    private final List<QueueSubscriber<?>> subscribers = new ArrayList<>();
+    // Thread-safe: populated by run() but iterated from doStop() on the context-close thread.
+    private final List<QueueSubscriber<?>> subscribers = new CopyOnWriteArrayList<>();
 
     private final IgnoreExecutionService ignoreExecutionService;
     private final QueueService queueService;
@@ -67,10 +68,15 @@ public class DefaultIndexer extends AbstractService implements Indexer {
 
     @Override
     public void run() {
-        log.debug("Starting the indexer");
-        startQueues();
-        setState(ServiceState.RUNNING);
-        log.info("Indexer started");
+        guardedStart(() ->
+        {
+            log.debug("Starting the indexer");
+            startQueues();
+        }, () ->
+        {
+            setState(ServiceState.RUNNING);
+            log.info("Indexer started");
+        });
     }
 
     protected void startQueues() {

--- a/jdbc-h2/src/main/java/io/kestra/repository/h2/migration/V2_0_16WidenLogsTaskIdMigration.java
+++ b/jdbc-h2/src/main/java/io/kestra/repository/h2/migration/V2_0_16WidenLogsTaskIdMigration.java
@@ -38,7 +38,6 @@ public class V2_0_16WidenLogsTaskIdMigration extends AbstractSQLMigrationScript 
         }
     }
 
-
     private static final String SCRIPT_ID = "2.0.16-widen-logs-task-id-h2";
     private static final String SQL_RESOURCE = "/migrations/2.0.16-widen-logs-task-id-h2.sql";
 

--- a/jdbc-mysql/src/main/java/io/kestra/repository/mysql/migration/V2_0_16WidenLogsTaskIdMigration.java
+++ b/jdbc-mysql/src/main/java/io/kestra/repository/mysql/migration/V2_0_16WidenLogsTaskIdMigration.java
@@ -39,7 +39,6 @@ public class V2_0_16WidenLogsTaskIdMigration extends AbstractSQLMigrationScript 
         }
     }
 
-
     private static final String SCRIPT_ID = "2.0.16-widen-logs-task-id-mysql";
     private static final String SQL_RESOURCE = "/migrations/2.0.16-widen-logs-task-id-mysql.sql";
 

--- a/jdbc-postgres/src/main/java/io/kestra/repository/postgres/migration/V2_0_16WidenLogsTaskIdMigration.java
+++ b/jdbc-postgres/src/main/java/io/kestra/repository/postgres/migration/V2_0_16WidenLogsTaskIdMigration.java
@@ -38,7 +38,6 @@ public class V2_0_16WidenLogsTaskIdMigration extends AbstractSQLMigrationScript 
         }
     }
 
-
     private static final String SCRIPT_ID = "2.0.16-widen-logs-task-id-postgres";
     private static final String SQL_RESOURCE = "/migrations/2.0.16-widen-logs-task-id-postgres.sql";
 

--- a/jdbc/src/main/java/io/kestra/jdbc/DatasourcePoolSizeDefaulter.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/DatasourcePoolSizeDefaulter.java
@@ -6,7 +6,6 @@ import io.micronaut.configuration.jdbc.hikari.DatasourceConfiguration;
 import io.micronaut.context.env.Environment;
 import io.micronaut.context.event.BeanCreatedEvent;
 import io.micronaut.context.event.BeanCreatedEventListener;
-
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 

--- a/jdbc/src/main/java/io/kestra/jdbc/LogJdbcDataSourceProvider.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/LogJdbcDataSourceProvider.java
@@ -26,9 +26,9 @@ import jakarta.inject.Singleton;
  * A single resolution shared by the log store and the log-table migration so a dedicated log
  * database is described in one place (rather than a separate {@code datasources.logs} block):
  * <ul>
- *     <li>if {@code kestra.logs.<type>.url} is set → build (and own) a dedicated HikariCP
- *         {@link DataSource} + {@link JooqDSLContextWrapper} for it (e.g. Postgres main + MySQL logs);</li>
- *     <li>otherwise → fall back to the primary {@link DataSource} (logs in the main database).</li>
+ * <li>if {@code kestra.logs.<type>.url} is set → build (and own) a dedicated HikariCP
+ * {@link DataSource} + {@link JooqDSLContextWrapper} for it (e.g. Postgres main + MySQL logs);</li>
+ * <li>otherwise → fall back to the primary {@link DataSource} (logs in the main database).</li>
  * </ul>
  * The dedicated pool is built lazily and closed on shutdown.
  */

--- a/jdbc/src/main/java/io/kestra/jdbc/migration/AbstractSQLMigrationScript.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/migration/AbstractSQLMigrationScript.java
@@ -137,7 +137,7 @@ public abstract class AbstractSQLMigrationScript implements MigrationScript {
      * placeholders in the SQL with the given replacements before executing. Used e.g. to inject a
      * configurable table name into a log-store migration script.
      *
-     * @param dataSource   the data source to obtain a connection from
+     * @param dataSource the data source to obtain a connection from
      * @param resourcePath classpath resource path to the SQL file
      * @param replacements placeholder key → value substitutions (key {@code x} replaces {@code ${x}})
      * @throws IOException if the resource cannot be read

--- a/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcLogDataStore.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcLogDataStore.java
@@ -2,6 +2,7 @@ package io.kestra.jdbc.repository;
 
 import java.time.ZonedDateTime;
 import java.util.*;
+import java.util.function.BiFunction;
 import java.util.stream.Collectors;
 
 import org.jooq.*;
@@ -37,8 +38,6 @@ import jakarta.annotation.Nullable;
 import lombok.Getter;
 import reactor.core.publisher.Flux;
 
-import java.util.function.BiFunction;
-
 public abstract class AbstractJdbcLogDataStore extends AbstractJdbcCrudRepository<LogEntry> implements LogDataStoreInterface {
 
     private static final Condition NORMAL_KIND_CONDITION = field("execution_kind").isNull().or(field("execution_kind").eq(ExecutionKind.NORMAL.name()));
@@ -66,7 +65,7 @@ public abstract class AbstractJdbcLogDataStore extends AbstractJdbcCrudRepositor
      * repository bound to the dedicated log datasource (when {@code kestra.logs.<type>.url} is set),
      * or the shared {@code @Named("logs")} repository (the primary datasource) otherwise.
      *
-     * @param applicationContext      the application context to resolve beans from.
+     * @param applicationContext the application context to resolve beans from.
      * @param dedicatedRepositoryFactory builds the dialect-specific repository for the dedicated
      *        datasource (e.g. {@code (config, wrapper) -> new H2Repository<>(config, wrapper)}).
      */

--- a/queue/src/main/java/io/kestra/queue/AbstractPollingSubscriber.java
+++ b/queue/src/main/java/io/kestra/queue/AbstractPollingSubscriber.java
@@ -15,8 +15,6 @@ import io.kestra.queue.poller.QueuePollerConfiguration;
 
 import lombok.extern.slf4j.Slf4j;
 
-import static org.awaitility.Awaitility.await;
-
 /**
  * A subscriber that uses a polling mechanism.
  * It used the {@link QueuePoller} to periodically execute a poll query (whether on a database or a message broker)
@@ -94,8 +92,6 @@ public abstract class AbstractPollingSubscriber<T extends Event> extends Abstrac
                 this.markEnd();
             }
         });
-
-        await().until(this::isActive);
 
         return this;
     }

--- a/queue/src/main/java/io/kestra/queue/AbstractSubscriber.java
+++ b/queue/src/main/java/io/kestra/queue/AbstractSubscriber.java
@@ -8,7 +8,6 @@ import java.util.concurrent.locks.Condition;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Consumer;
 
-import io.kestra.core.contexts.KestraContext;
 import io.kestra.core.exceptions.DeserializationException;
 import io.kestra.core.metrics.MetricRegistry;
 import io.kestra.core.queues.QueueSubscriber;
@@ -249,7 +248,8 @@ public abstract class AbstractSubscriber<T extends Event> implements QueueSubscr
         log.error("{} fatal error while consuming messages. Initiating application shutdown.", logPrefix, cause);
         this.markEnd();
         try {
-            KestraContext.getContext().shutdown();
+            // shutdown the context owning this subscriber.
+            this.queueService.getKestraContext().shutdown();
         } catch (Exception e) {
             log.warn("{} failed to initiate shutdown.", logPrefix, e);
         }

--- a/queue/src/main/java/io/kestra/queue/QueueService.java
+++ b/queue/src/main/java/io/kestra/queue/QueueService.java
@@ -5,7 +5,9 @@ import java.util.concurrent.ExecutorService;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.annotations.VisibleForTesting;
 
+import io.kestra.core.contexts.KestraContext;
 import io.kestra.core.exceptions.DeserializationException;
 import io.kestra.core.metrics.MetricRegistry;
 import io.kestra.core.models.executions.Execution;
@@ -40,18 +42,33 @@ public class QueueService {
     @Getter
     protected final QueueConfiguration queueConfiguration;
 
+    // The context captured at construction time. Subscribers use it for emergency shutdowns instead of the static context
+    // returned by KestraContext.getContext() might change if the context is restarted inside the same JVM, which can occur at least in tests.
+    @Getter
+    private volatile KestraContext kestraContext; // volatile field as tests swap it
+
     @Inject
-    public QueueService(ExecutorsUtils executorsUtils, QueueConfiguration queueConfiguration, MetricRegistry metricRegistry, SchedulerConfiguration schedulerConfiguration) {
+    public QueueService(ExecutorsUtils executorsUtils, QueueConfiguration queueConfiguration, MetricRegistry metricRegistry, SchedulerConfiguration schedulerConfiguration,
+        KestraContext kestraContext) {
         // this executor service is used to execute subscribers, as subscribers can be CPU bound, it is not a good idea to use a virtual thread here
         this.subscriberExecutorService = executorsUtils.cachedThreadPool("queue-" + queueConfiguration.getType());
         this.queueConfiguration = queueConfiguration;
         this.metricRegistry = metricRegistry;
         this.vNodeCount = schedulerConfiguration.vnodes();
+        this.kestraContext = kestraContext;
     }
 
     @PreDestroy
     void close() {
         this.subscriberExecutorService.shutdown();
+    }
+
+    /**
+     * Allows tests to intercept the emergency shutdown triggered by subscribers on fatal errors.
+     */
+    @VisibleForTesting
+    void setKestraContext(KestraContext kestraContext) {
+        this.kestraContext = kestraContext;
     }
 
     public void execute(Runnable runnable) {

--- a/queue/src/test/java/io/kestra/queue/AbstractDispatchQueueTest.java
+++ b/queue/src/test/java/io/kestra/queue/AbstractDispatchQueueTest.java
@@ -43,6 +43,9 @@ public abstract class AbstractDispatchQueueTest extends AbstractQueueTest {
     @Inject
     private MetricRegistry metricRegistry;
 
+    @Inject
+    private QueueService queueService;
+
     private KestraContext realContext;
     protected NoOpShutdownContext noOpShutdownContext;
 
@@ -51,11 +54,14 @@ public abstract class AbstractDispatchQueueTest extends AbstractQueueTest {
         realContext = KestraContext.getContext();
         noOpShutdownContext = new NoOpShutdownContext(realContext, new AtomicBoolean(false));
         KestraContext.setContext(noOpShutdownContext);
+        // subscribers shut down the context captured by the QueueService, not the static one
+        queueService.setKestraContext(noOpShutdownContext);
     }
 
     @AfterEach
     void restoreKestraContext() {
         KestraContext.setContext(realContext);
+        queueService.setKestraContext(realContext);
     }
 
     @Test

--- a/queue/src/test/java/io/kestra/queue/AbstractPollingSubscriberTest.java
+++ b/queue/src/test/java/io/kestra/queue/AbstractPollingSubscriberTest.java
@@ -1,0 +1,107 @@
+package io.kestra.queue;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import io.kestra.core.metrics.MetricRegistry;
+import io.kestra.core.queues.event.Event;
+import io.kestra.core.services.IgnoreExecutionService;
+import io.kestra.queue.poller.QueuePollerConfiguration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class AbstractPollingSubscriberTest {
+
+    private QueueService queueService;
+    private MetricRegistry metricRegistry;
+    private IgnoreExecutionService ignoreExecutionService;
+
+    @BeforeEach
+    void setUp() {
+        queueService = mock(QueueService.class);
+        metricRegistry = mock(MetricRegistry.class);
+        ignoreExecutionService = mock(IgnoreExecutionService.class);
+        when(metricRegistry.timer(anyString(), anyString(), anyString(), anyString()))
+            .thenReturn(mock(io.micrometer.core.instrument.Timer.class));
+        // run the polling loop on a real thread, like the real QueueService does
+        doAnswer(invocation ->
+        {
+            Thread.ofVirtual().start((Runnable) invocation.getArgument(0));
+            return null;
+        }).when(queueService).execute(any());
+    }
+
+    @Test
+    void shouldNotStartThePollingLoopWhenSubscribingADeactivatedSubscriber() throws InterruptedException {
+        // Given: a subscriber that was NOT marked ready (e.g. closed while the component was subscribing)
+        var subscriber = new TestPollingSubscriber(queueService, metricRegistry, ignoreExecutionService);
+
+        // When
+        subscriber.subscribe(either ->
+        {
+        });
+
+        // Then: the loop exits without ever polling
+        assertThat(subscriber.polled.await(200, TimeUnit.MILLISECONDS)).isFalse();
+        assertThat(subscriber.isActive()).isFalse();
+    }
+
+    @Test
+    void shouldStartPollingLoopWhenReady() throws InterruptedException {
+        // Given
+        var subscriber = new TestPollingSubscriber(queueService, metricRegistry, ignoreExecutionService);
+        subscriber.markReady();
+
+        // When
+        subscriber.subscribe(either ->
+        {
+        });
+
+        // Then: the polling loop runs
+        assertThat(subscriber.polled.await(2, TimeUnit.SECONDS)).isTrue();
+        assertThat(subscriber.isActive()).isTrue();
+
+        subscriber.close();
+        assertThat(subscriber.isActive()).isFalse();
+    }
+
+    /**
+     * Minimal concrete implementation for testing AbstractPollingSubscriber.
+     */
+    static class TestPollingSubscriber extends AbstractPollingSubscriber<TestEvent> {
+        final CountDownLatch polled = new CountDownLatch(1);
+
+        TestPollingSubscriber(QueueService queueService, MetricRegistry metricRegistry, IgnoreExecutionService ignoreExecutionService) {
+            super(
+                TestEvent.class, "test-queue", queueService, metricRegistry, ignoreExecutionService,
+                new QueuePollerConfiguration(Duration.ofMillis(10), Duration.ofMillis(10), Duration.ofSeconds(1), 10, 1, false)
+            );
+        }
+
+        @Override
+        protected Integer poll(Consumer<byte[]> messageConsumer) {
+            polled.countDown();
+            return 0;
+        }
+
+        @Override
+        protected Integer pollBatch(Consumer<List<byte[]>> messageConsumer) {
+            polled.countDown();
+            return 0;
+        }
+    }
+
+    record TestEvent(String key) implements Event {
+    }
+}

--- a/queue/src/test/java/io/kestra/queue/AbstractSubscriberTest.java
+++ b/queue/src/test/java/io/kestra/queue/AbstractSubscriberTest.java
@@ -9,7 +9,6 @@ import java.util.function.Consumer;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import io.kestra.core.contexts.KestraContext;
 import io.kestra.core.exceptions.DeserializationException;
 import io.kestra.core.metrics.MetricRegistry;
 import io.kestra.core.queues.QueueSubscriber;
@@ -457,7 +456,7 @@ class AbstractSubscriberTest {
         var subscriber = createSubscriber();
         subscriber.markReady();
         var noOpContext = new NoOpShutdownContext(new AtomicBoolean(false));
-        KestraContext.setContext(noOpContext);
+        when(queueService.getKestraContext()).thenReturn(noOpContext);
 
         // When
         subscriber.markEnd(new RuntimeException("test error"));
@@ -472,7 +471,7 @@ class AbstractSubscriberTest {
         // Given
         var subscriber = createSubscriber();
         subscriber.markReady();
-        KestraContext.setContext(new NoOpShutdownContext(new AtomicBoolean(false)));
+        when(queueService.getKestraContext()).thenReturn(new NoOpShutdownContext(new AtomicBoolean(false)));
 
         // When
         subscriber.markEnd(new RuntimeException("test error"));
@@ -487,7 +486,7 @@ class AbstractSubscriberTest {
         var subscriber = createSubscriber();
         subscriber.markReady();
         var noOpContext = new NoOpShutdownContext(new AtomicBoolean(false));
-        KestraContext.setContext(noOpContext);
+        when(queueService.getKestraContext()).thenReturn(noOpContext);
 
         // When
         subscriber.markEnd(new RuntimeException("first"));

--- a/scheduler/src/main/java/io/kestra/scheduler/DefaultScheduler.java
+++ b/scheduler/src/main/java/io/kestra/scheduler/DefaultScheduler.java
@@ -2,15 +2,14 @@ package io.kestra.scheduler;
 
 import java.time.Clock;
 import java.time.Duration;
-import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
@@ -46,12 +45,12 @@ public class DefaultScheduler extends AbstractService implements Scheduler {
 
     private static final String EXECUTOR_NAME = "scheduler-scheduling-loop";
 
-    private final AtomicBoolean started = new AtomicBoolean(false);
     private final ExecutorsUtils executorsUtils;
     private final TriggerSchedulingLoopFactory schedulerEventLoopFactory;
 
     private ExecutorService executorService;
-    private List<TriggerSchedulingLoop> schedulingLoops;
+    // Thread-safe: mutated by the vNodes rebalance listener thread and iterated from doStop().
+    private final List<TriggerSchedulingLoop> schedulingLoops = new CopyOnWriteArrayList<>();
     private final VNodesAssigner vNodesAssigner;
     private final Clock clock;
 
@@ -67,7 +66,8 @@ public class DefaultScheduler extends AbstractService implements Scheduler {
     private final MaintenanceService maintenanceService;
 
     // Consumers
-    private final List<Disposable> consumerDisposables = new ArrayList<>();
+    // Thread-safe: mutated by the vNodes rebalance listener thread and iterated from doStop().
+    private final List<Disposable> consumerDisposables = new CopyOnWriteArrayList<>();
 
     private Disposable maintenanceListener;
 
@@ -132,15 +132,18 @@ public class DefaultScheduler extends AbstractService implements Scheduler {
      */
     @Override
     public void start(int maxThreads) {
-        if (!this.started.compareAndSet(false, true)) {
-            throw new IllegalStateException("Scheduler already started");
-        }
+        guardedStart(() -> doStart(maxThreads), () ->
+        {
+            setState(maintenanceService.isInMaintenanceMode() ? ServiceState.MAINTENANCE : ServiceState.RUNNING);
+            log.info("Scheduler started with {} thread(s) [timezone={}]", maxThreads, SchedulerClock.getClock().getZone());
+        });
+    }
+
+    private void doStart(int maxThreads) {
         this.metricRegistry.gauge(MetricRegistry.METRIC_SCHEDULER_EVENTLOOP_THREAD_MAX, MetricRegistry.METRIC_SCHEDULER_EVENTLOOP_THREAD_MAX_DESCRIPTION, maxThreads);
 
         // Create the scheduling loops
         this.executorService = executorsUtils.maxCachedThreadPool(maxThreads, EXECUTOR_NAME);
-
-        this.schedulingLoops = new ArrayList<>(maxThreads);
 
         final AtomicInteger metricAssignedVNodesCount = this.metricRegistry.gauge(
             MetricRegistry.METRIC_SCHEDULER_ASSIGNED_VNODES_COUNT,
@@ -205,8 +208,12 @@ public class DefaultScheduler extends AbstractService implements Scheduler {
         maintenanceListener = maintenanceService.listen(new MaintenanceService.MaintenanceListener() {
             @Override
             public void onMaintenanceModeEnter() {
+                if (!getState().isRunning()) {
+                    return; // scheduler is either terminating or already terminated.
+                }
+
                 // vNode assignments may change during maintenance mode (e.g., a scheduler leaves or joins the cluster).
-                // it's therefore more reliable to just stop scheduling in a similar way to vNodes revokation. 
+                // it's therefore more reliable to just stop scheduling in a similar way to vNodes revokation.
                 stopAllConsumers();
                 stopAllSchedulingLoop(false);
                 setState(ServiceState.MAINTENANCE);
@@ -214,18 +221,16 @@ public class DefaultScheduler extends AbstractService implements Scheduler {
 
             @Override
             public void onMaintenanceModeExit() {
+                if (!getState().isRunning()) {
+                    return; // scheduler is either terminating or already terminated.
+                }
+
                 // restart scheduling
                 startScheduling();
                 setState(ServiceState.RUNNING);
             }
         });
 
-        if (maintenanceService.isInMaintenanceMode()) {
-            setState(ServiceState.MAINTENANCE);
-        } else {
-            setState(ServiceState.RUNNING);
-        }
-        log.info("Scheduler started with {} thread(s) [timezone={}]", maxThreads, SchedulerClock.getClock().getZone());
     }
 
     private void startScheduling() {
@@ -327,10 +332,6 @@ public class DefaultScheduler extends AbstractService implements Scheduler {
      */
     @Override
     protected ServiceState doStop() {
-        if (!this.started.compareAndSet(true, false)) {
-            return ServiceState.TERMINATED_GRACEFULLY; // Already shut down or not started.
-        }
-
         if (rebalanceDisposable != null) {
             rebalanceDisposable.dispose();
         }
@@ -344,6 +345,11 @@ public class DefaultScheduler extends AbstractService implements Scheduler {
 
         // Stop all scheduling loops
         stopAllSchedulingLoop(true);
+
+        if (this.executorService == null) {
+            // the startup was aborted before the executor was created — nothing left to stop
+            return ServiceState.TERMINATED_GRACEFULLY;
+        }
 
         // Initiate graceful shutdown
         this.executorService.shutdown();

--- a/scheduler/src/main/java/io/kestra/scheduler/DefaultScheduler.java
+++ b/scheduler/src/main/java/io/kestra/scheduler/DefaultScheduler.java
@@ -332,16 +332,18 @@ public class DefaultScheduler extends AbstractService implements Scheduler {
      */
     @Override
     protected ServiceState doStop() {
+        // Dispose the listeners first: their isRunning() guards are check-then-act, so a callback
+        // that passed its guard just before we transitioned to TERMINATING could otherwise
+        // recreate consumers or resubmit scheduling loops concurrently with the teardown below.
+        if (this.maintenanceListener != null) {
+            this.maintenanceListener.dispose();
+        }
         if (rebalanceDisposable != null) {
             rebalanceDisposable.dispose();
         }
 
         // Stop all queues consumption
         stopAllConsumers();
-
-        if (this.maintenanceListener != null) {
-            this.maintenanceListener.dispose();
-        }
 
         // Stop all scheduling loops
         stopAllSchedulingLoop(true);

--- a/scheduler/src/test/java/io/kestra/scheduler/DefaultSchedulerTest.java
+++ b/scheduler/src/test/java/io/kestra/scheduler/DefaultSchedulerTest.java
@@ -147,7 +147,7 @@ class DefaultSchedulerTest {
             // WHEN - THEN
             assertThatThrownBy(() -> scheduler.start(2))
                 .isInstanceOf(IllegalStateException.class)
-                .hasMessage("Scheduler already started");
+                .hasMessage("Service already started");
         }
     }
 

--- a/scheduler/src/test/java/io/kestra/scheduler/TriggerSchedulerTest.java
+++ b/scheduler/src/test/java/io/kestra/scheduler/TriggerSchedulerTest.java
@@ -12,6 +12,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.IntStream;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -84,6 +85,14 @@ class TriggerSchedulerTest {
         SchedulerClock.setClock(initialSchedulerClock);
         triggerStateStore = new InMemoryTriggerStateStore();
         triggerExecutionPublisher = new CollectorTriggerExecutionPublisher();
+    }
+
+    @AfterEach
+    void restoreSchedulerClock() {
+        // SchedulerClock is a JVM-wide static: without a restore, the last fixed clock set by a
+        // test here leaks into every later test class of the fork, whose trigger dates are then
+        // computed against a frozen past instant.
+        SchedulerClock.setClock(Clock.systemDefaultZone());
     }
 
     @Test

--- a/tests/src/main/java/io/kestra/core/runners/TestRunner.java
+++ b/tests/src/main/java/io/kestra/core/runners/TestRunner.java
@@ -3,7 +3,6 @@ package io.kestra.core.runners;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -102,14 +101,22 @@ public class TestRunner implements Runnable, AutoCloseable {
         }
 
         try {
-            Await.await().atMost(getRunningTimeout()).until(() -> servers.stream().allMatch(s -> Optional.ofNullable(s.getState()).orElse(Service.ServiceState.RUNNING).isRunning()));
+            Await.await().atMost(getRunningTimeout()).until(() -> servers.stream().allMatch(TestRunner::isStarted));
         } catch (ConditionTimeoutException e) {
             throw new RuntimeException(
-                servers.stream().filter(s -> !Optional.ofNullable(s.getState()).orElse(Service.ServiceState.RUNNING).isRunning())
-                    .map(Service::getClass)
+                servers.stream().filter(s -> !isStarted(s))
+                    .map(s -> s.getClass().getSimpleName() + " (state: " + s.getState() + ")")
                     .toList() + " not started in time"
             );
         }
+    }
+
+    /**
+     * A service is only considered started once it reached RUNNING (or MAINTENANCE).
+     */
+    private static boolean isStarted(Service service) {
+        Service.ServiceState state = service.getState();
+        return Service.ServiceState.RUNNING == state || Service.ServiceState.MAINTENANCE == state;
     }
 
     private Duration getRunningTimeout() {

--- a/webserver/src/main/java/io/kestra/webserver/controllers/api/KVController.java
+++ b/webserver/src/main/java/io/kestra/webserver/controllers/api/KVController.java
@@ -1,7 +1,6 @@
 package io.kestra.webserver.controllers.api;
 
 import java.io.IOException;
-import java.time.Duration;
 import java.time.Instant;
 import java.util.*;
 

--- a/worker-controller/src/main/java/io/kestra/controller/DefaultController.java
+++ b/worker-controller/src/main/java/io/kestra/controller/DefaultController.java
@@ -105,10 +105,14 @@ public class DefaultController extends AbstractService implements Controller {
      */
     @Override
     public void start() {
-        if (getState() != ServiceState.CREATED) {
-            throw new IllegalStateException("Controller is already started or stopped");
-        }
+        guardedStart(this::doStart, () ->
+        {
+            setState(ServiceState.RUNNING);
+            LOG.info("Controller started, listening on {}", controllerConfiguration.port());
+        });
+    }
 
+    private void doStart() {
         LOG.info("Starting Controller");
         int port = controllerConfiguration.port();
         try {
@@ -119,8 +123,6 @@ public class DefaultController extends AbstractService implements Controller {
         } catch (IOException e) {
             throw new UncheckedIOException("Error while building gRPC server", e);
         }
-        LOG.info("Controller started, listening on {}", port);
-        setState(ServiceState.RUNNING);
     }
 
     /**

--- a/worker/src/main/java/io/kestra/worker/AbstractWorker.java
+++ b/worker/src/main/java/io/kestra/worker/AbstractWorker.java
@@ -180,6 +180,12 @@ public abstract class AbstractWorker extends AbstractService {
             jobFetcher.pause();
         }
 
+        // The controller dispatches jobs to any connected stream regardless of the worker's state.
+        // Don't start fetching when a stop is already pending.
+        if (isStopRequested()) {
+            log.info("Worker stop is pending, not starting the job fetcher");
+            return;
+        }
         jobFetcher.init(workerContext);
         workerIOThreadsExecutor.submit(jobFetcher);
     }

--- a/worker/src/main/java/io/kestra/worker/AbstractWorker.java
+++ b/worker/src/main/java/io/kestra/worker/AbstractWorker.java
@@ -3,12 +3,12 @@ package io.kestra.worker;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
@@ -68,10 +68,10 @@ public abstract class AbstractWorker extends AbstractService {
     protected final List<WorkerIOSender> workerIOSenders;
     protected final ExecutorService workerIOThreadsExecutor;
 
-    protected final AtomicBoolean initialized = new AtomicBoolean(false);
     protected final AtomicBoolean skipGracefulTermination = new AtomicBoolean(false);
 
-    protected final List<Disposable> disposables = new ArrayList<>();
+    // Thread-safe: populated by start() but iterated from doStop()/stopNow() on other threads.
+    protected final List<Disposable> disposables = new CopyOnWriteArrayList<>();
 
     protected String workerGroupId;
 
@@ -117,10 +117,17 @@ public abstract class AbstractWorker extends AbstractService {
      * Starts the worker.
      */
     public void start(int numThreads) {
-        if (!this.initialized.compareAndSet(false, true)) {
-            throw new IllegalStateException("Worker already started");
-        }
+        guardedStart(() -> doStart(numThreads), () ->
+        {
+            setState(maintenanceService.isInMaintenanceMode() ? ServiceState.MAINTENANCE : ServiceState.RUNNING);
+            log.info("Worker started with {} thread(s)", numThreads);
+        });
+    }
 
+    private void doStart(int numThreads) {
+        // May block for a while: WorkerAgent performs a gRPC handshake with the controller here.
+        // A stop() requested during that window waits (bounded) for this method to complete, then
+        // tears down everything it created.
         this.workerGroupId = resolveWorkerGroupId();
 
         this.setState(ServiceState.CREATED);
@@ -173,12 +180,8 @@ public abstract class AbstractWorker extends AbstractService {
             jobFetcher.pause();
         }
 
-        setState(inMaintenanceMode ? ServiceState.MAINTENANCE : ServiceState.RUNNING);
-
         jobFetcher.init(workerContext);
         workerIOThreadsExecutor.submit(jobFetcher);
-
-        log.info("Worker started with {} thread(s)", numThreads);
     }
 
     private void enterMaintenance() {


### PR DESCRIPTION
## Context

CI sometimes fails with Kestra unable to start: `[DefaultExecutor] not started in time`, `[WorkerAgent] not started in time`, or the cryptic `Condition with Lambda expression in io.kestra.queue.AbstractPollingSubscriber was not fulfilled within 10 seconds`. Digging into the CI logs of a failed run showed this was not just an overloaded CI server: a chain of real races caused **one test class to shut down the application context of the next test class while it was still starting**, cascading into `initializationError` for every subsequent class in the fork.

The chain, in short: a test finished so fast that its context began closing while the executor was still starting → the executor's `doStop()` crashed halfway (concurrent list modification) and never cancelled its scheduled background loops → those orphaned loops kept running after the context (and its datasource) was closed, failed, and called `KestraContext.getContext().shutdown()` — but that static pointer already referenced the **next** test's freshly started context, which got killed mid-startup. Repeat.

This PR fixes each link of that chain, plus the same class of bugs found in the other services by auditing everything that extends `AbstractService`.

## The races and their fixes

**1. The runners reported "ready" before services actually started** — `TestRunner` and `StandAloneRunner` counted a service as started as soon as it was *created* (or even when it had no state at all). Tests could therefore start — and finish, and tear down — while a service was still in the middle of its startup. Both runners now wait until every service has actually reached `RUNNING` (or `MAINTENANCE`), and the timeout error names the service that lagged along with its actual state. This also unmasks real failures: a worker whose connection to the controller failed used to be silently reported as started.

**2. Stopping a service could race its own in-flight startup** — every service (executor, worker, scheduler, controller, indexer) starts asynchronously on a runner thread pool, while `stop()` runs on the context-close thread. When the two overlapped, `stop()` tore down a half-built service: it missed resources created moments later (queue subscribers, scheduled loops, a gRPC server), which then leaked past the context's death. `AbstractService` now owns a small **lifecycle guard** used by all services through a single `guardedStart()` template:
- a stop that arrives *before* startup simply cancels it — nothing is ever created;
- a stop that arrives *during* startup waits for it to finish (bounded by a timeout, so a startup hung on a dead database can never block shutdown forever), then tears everything down;
- a service whose startup finished while a stop was pending no longer advertises itself as `RUNNING`.

**3. Emergency shutdowns could target the wrong application** — several failure paths called `KestraContext.getContext().shutdown()`. That static always points to the *newest* context in the JVM, so a leftover thread from a closed test context would shut down the next test's healthy context. All these paths (executor watchers, queue subscribers, thread-pool uncaught-exception handlers, liveness callback — and the license checker in EE) now hold a reference to **their own** context, captured when they are created: at worst a stale thread now shuts down a context that is already closed, a no-op.

**4. A hidden 10-second wait with an unreadable failure** — queue subscribers ended their subscription with a bare Awaitility wait whose only possible outcome, when it fired, was the cryptic 10-second `ConditionTimeoutException` seen on CI. The wait was a no-op on the happy path and is removed; a subscriber deactivated by a concurrent shutdown now simply doesn't start its polling loop.

**5. `DefaultIndexer` never reported its state** — it shadowed its parent's `state` field, so `getState()` returned `null` forever. Harmless under the old lax readiness check, fatal under the fixed one; the shadowed fields are removed.

**6. A stopping worker could still take work** — the controller dispatches jobs to any connected stream without checking the worker's state, so a worker whose stop was already pending could fetch a job seconds before being killed, causing a duplicate partial run. The worker no longer starts its job fetcher when a stop is pending.

**7. Smaller windows of the same family** — the scheduler now unsubscribes its maintenance/rebalance listeners *before* tearing down (a listener firing at the wrong moment could re-create consumers mid-teardown); the executor's background-loop watchers now learn about a stop at its very beginning instead of halfway through (no more spurious "Executor fatal exception" logs during clean shutdowns); and two JVM-wide statics leaked by tests (`SchedulerClock` frozen at a 2025 date, and a stub `KestraContext`) are now restored after the tests that set them — the frozen clock was itself a source of order-dependent failures.

Fixes #16969

## Validation

- Unit tests for the new lifecycle guard, the subscriber behavior, and the context-bound exception handler.
- `H2RunnerTest` (100 tests) plus the `core`/`queue`/`executor`/`worker`/`scheduler`/`indexer`/`worker-controller` suites all green.
- CI signatures to watch after merge — these should disappear: `not started in time`, `AbstractPollingSubscriber was not fulfilled within 10 seconds`, and `Kestra server - Shutdown initiated` from `*-exception-watcher` threads during teardown.

## Notes for reviewers

- One deliberate behavior decision: a Kestra that cannot reach its database during **normal operation** still shuts down, as before — the fixes only stop *teardown noise* (errors caused by the shutdown itself) from being treated as fatal.
- EE compiles against this branch unchanged (audited: no EE code constructs or overrides the touched classes); a small companion EE branch applies the same owning-context fix to the license checker.
- `kestra server standalone` now genuinely waits for all services before reporting ready — startup may appear marginally slower, but "ready" now means ready.
