### PR TITLE
docs(system): correct GrpcConfiguration maxInboundMessageSize default Javadoc

### DIFF
--- a/worker-controller/src/main/java/io/kestra/controller/config/GrpcConfiguration.java
+++ b/worker-controller/src/main/java/io/kestra/controller/config/GrpcConfiguration.java
@@ -10,7 +10,7 @@ import io.micronaut.core.bind.annotation.Bindable;
  *        Enabling reflection allows clients to query the server for available services and methods,
  *        which can be useful for debugging and development tools. Defaults to false.
  * @param maxInboundMessageSize Maximum inbound message size in bytes, applied to both the gRPC server and client channel.
- *        Defaults to {@link Integer#MAX_VALUE} (no limit).
+ *        Defaults to {@code 10485760} (10 MB).
  */
 @ConfigurationProperties("kestra.grpc")
 public record GrpcConfiguration(


### PR DESCRIPTION


The `@param` Javadoc for `maxInboundMessageSize` on `GrpcConfiguration`
(`kestra.grpc`) states the default is `Integer.MAX_VALUE` (no limit), but the
field is bound as `@Bindable(defaultValue = "10485760") // 10 MB`. The real
default is a hard 10 MB cap, not unlimited.

That value is applied verbatim to both the gRPC server and the worker client
channel (`DefaultController`, `GrpcChannelManager`, `WorkerJobFetcher` via
`grpcConfiguration.maxInboundMessageSize()`), and there is no
`kestra.grpc.max-inbound-message-size` override in the shipped resources, so
10 MB is the true effective default. The old Javadoc misled operators into
believing inbound gRPC messages (worker job payloads) are unbounded, which
matters for capacity planning and for diagnosing `RESOURCE_EXHAUSTED` failures.

This corrects the single Javadoc line to match the actual bound value and the
existing inline `// 10 MB` comment. Documentation only, no behavior change.

```diff
- *        Defaults to {@link Integer#MAX_VALUE} (no limit).
+ *        Defaults to {@code 10485760} (10 MB).
```

### Related Issue

No related issue: this is a small, self-found documentation fix where the
config Javadoc contradicts the bound default in the same file. Happy to open a
tracking issue first if you would prefer that for this change.

### Backend Checklist

- [x] Code compiles successfully and passes all checks
- [x] All unit and integration tests pass

### Additional Notes

The 10 MB default and the `Integer.MAX_VALUE` Javadoc were introduced together
in the same commit that added the inbound-size cap (`fix(worker): handle gRPC
RESOURCE_EXHAUSTED error for too large task outputs`); the inline `// 10 MB`
comment on the field confirms 10 MB is the intended value, so the Javadoc was
the part that was wrong. Verified with
`./gradlew :worker-controller:compileJava` (BUILD SUCCESSFUL); the `{@code}`
tag is used rather than `{@link}` because the default is a literal value, matching
the sibling `reflectionEnabled` parameter's style.
