### PR TITLE
fix(core): lower-case Windows drive letter with Locale.ROOT in windowsToUnixPath

### DIFF
--- a/core/src/main/java/io/kestra/core/utils/WindowsUtils.java
+++ b/core/src/main/java/io/kestra/core/utils/WindowsUtils.java
@@ -1,13 +1,14 @@
 package io.kestra.core.utils;
 
 import java.net.URI;
+import java.util.Locale;
 import java.util.regex.Matcher;
 
 public class WindowsUtils {
 
     public static String windowsToUnixPath(String path, boolean startWithSlash) {
         Matcher matcher = java.util.regex.Pattern.compile("([A-Za-z]:)").matcher(path);
-        String unixPath = matcher.replaceAll(m -> m.group().toLowerCase());
+        String unixPath = matcher.replaceAll(m -> m.group().toLowerCase(Locale.ROOT));
 
         unixPath = unixPath
             .replace("\\", "/")

--- a/core/src/test/java/io/kestra/core/utils/WindowsUtilsTest.java
+++ b/core/src/test/java/io/kestra/core/utils/WindowsUtilsTest.java
@@ -1,0 +1,27 @@
+package io.kestra.core.utils;
+
+import java.util.Locale;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class WindowsUtilsTest {
+
+    @Test
+    void shouldLowerCaseDriveLetterUsingRootLocaleUnderTurkishLocale() {
+        // Given: a JVM whose default locale lower-cases ASCII 'I' to the dotless 'ı'
+        Locale previous = Locale.getDefault();
+        Locale.setDefault(Locale.of("tr", "TR"));
+
+        try {
+            // When: converting an I-drive Windows path
+            String unixPath = WindowsUtils.windowsToUnixPath("I:\\namespace\\file.txt");
+
+            // Then: the drive letter is the plain ASCII 'i', not the dotless 'ı' (U+0131)
+            assertThat(unixPath).isEqualTo("/i/namespace/file.txt");
+        } finally {
+            Locale.setDefault(previous);
+        }
+    }
+}


### PR DESCRIPTION


`WindowsUtils.windowsToUnixPath` lower-cases the matched drive letter with the
default locale (`m.group().toLowerCase()`). `String.toLowerCase()` without an
explicit locale uses the JVM default locale, and under a Turkish or Azeri locale
ASCII `I` maps to the dotless small `ı` (U+0131) instead of `i`. On a server
running with such a default locale, an `I:` drive path is therefore rewritten to
a segment containing the dotless character rather than `/i/`, which corrupts the
paths this method produces for namespace files, task runners and local storage
resolution (callers in `NamespaceFile`, `LocalStorage`, `TaskRunner` and the
Docker task runner).

This switches the drive-letter lower-casing to `Locale.ROOT`, which performs a
locale-independent ASCII case fold. That matches the locale-aware handling
already used elsewhere in the codebase (`Slugify` uses `Locale.ENGLISH`,
`DateUtils`/`Enums` use `Locale.ROOT`), and is in line with the recent locale
hardening in `chore(core): localize to languages other than english (#17138)`.

A regression test forces the Turkish locale, converts an `I:`-drive path and
asserts the result is `/i/...`, restoring the previous default locale in a
`finally` block. Reverting the one-line fix makes that test fail with
`expected "/i/namespace/file.txt" but was "/ı/namespace/file.txt"`.

The change is limited to the drive-letter case fold; no other behaviour of
`windowsToUnixPath` is modified.

### Related Issue

No existing issue; this is a small correctness fix found while reading the path
utilities. Happy to open a tracking issue first if the maintainers prefer that
before review.

### Backend Checklist

- [x] Relevant code compiles successfully
- [x] Relevant tests pass

### Additional Notes

- `Locale.of("tr","TR")` is used in the test rather than the Java-25-deprecated
  `new Locale(...)`.
- Verified locally with `./gradlew :core:test --tests
  "io.kestra.core.utils.WindowsUtilsTest"` (JDK 25 / Gradle 9.4.1). The existing
  `ScriptServiceTest` (which exercises `windowsToUnixPath` through
  `LocalStorage`) also stays green.
