### PR TITLE
fix: non-forced plugin defaults in a parent > child relationship now compose in a single pass

### DIFF
--- a/core/src/main/java/io/kestra/core/services/PluginDefaultService.java
+++ b/core/src/main/java/io/kestra/core/services/PluginDefaultService.java
@@ -61,10 +61,10 @@ import lombok.extern.slf4j.Slf4j;
  * Defaults come from three levels, ordered most-important-first: <b>flow</b> &gt; <b>namespace</b> (EE, closest
  * namespace first) &gt; <b>global</b> (configuration). Each default is either:
  * <ul>
- *   <li><b>type-matched</b> — applied to every plugin whose {@code type} equals or is prefixed by the default's
- *       {@code type}; or</li>
- *   <li><b>named</b> — carries a {@code ref} id and is applied <i>only</i> to plugins that opt in with
- *       {@code pluginDefaultsRef: <id>}, never by type matching.</li>
+ * <li><b>type-matched</b> — applied to every plugin whose {@code type} equals or is prefixed by the default's
+ * {@code type}; or</li>
+ * <li><b>named</b> — carries a {@code ref} id and is applied <i>only</i> to plugins that opt in with
+ * {@code pluginDefaultsRef: <id>}, never by type matching.</li>
  * </ul>
  *
  * <h2>{@code forced}</h2>
@@ -76,11 +76,11 @@ import lombok.extern.slf4j.Slf4j;
  *
  * <h2>How a single plugin is resolved</h2>
  * <ol>
- *   <li><b>No {@code pluginDefaultsRef}:</b> non-forced then forced type-matched defaults are applied (forced last,
- *       so it wins).</li>
- *   <li><b>With {@code pluginDefaultsRef: id}:</b> non-forced type-matched defaults are skipped. If a <i>forced</i>
- *       type-matched default also applies, <b>it takes over entirely and the referenced default is ignored</b>
- *       (no stacking) — enforcement always wins. Otherwise the referenced default is applied.</li>
+ * <li><b>No {@code pluginDefaultsRef}:</b> non-forced then forced type-matched defaults are applied (forced last,
+ * so it wins).</li>
+ * <li><b>With {@code pluginDefaultsRef: id}:</b> non-forced type-matched defaults are skipped. If a <i>forced</i>
+ * type-matched default also applies, <b>it takes over entirely and the referenced default is ignored</b>
+ * (no stacking) — enforcement always wins. Otherwise the referenced default is applied.</li>
  * </ol>
  *
  * <h2>Resolving a {@code ref}</h2>
@@ -657,22 +657,27 @@ public class PluginDefaultService {
 
     Object recursiveDefaults(Object object, Map<String, List<PluginDefault>> defaults, boolean forcedPass) {
         if (object instanceof Map<?, ?> value) {
-            value = value
-                .entrySet()
-                .stream()
-                .map(
-                    e -> new AbstractMap.SimpleEntry<>(
-                        e.getKey(),
-                        recursiveDefaults(e.getValue(), defaults, forcedPass)
-                    )
-                )
-                .collect(HashMap::new, (m, v) -> m.put(v.getKey(), v.getValue()), HashMap::putAll);
+            // 1. descend into existing children first (post-order), with the full default set
+            Map<String, Object> result = mapChildrenDefaults(value, defaults, forcedPass);
 
-            if (value.containsKey("type")) {
-                value = defaults(value, defaults, forcedPass);
+            if (result.containsKey("type")) {
+                // 2. apply the defaults matching this node
+                DefaultsResult applied = defaults(result, defaults, forcedPass);
+                result = applied.value();
+
+                // 3. a matching default may have injected a new typed child (e.g. a broad `io.kestra`
+                //    default adding a `taskRunner`) that a more specific default should decorate. Re-descend
+                //    to reach it, but drop the defaults already applied here: a default must not recurse into
+                //    the subtree it produced, otherwise a catch-all self-injector would loop forever.
+                if (!applied.applied().isEmpty()) {
+                    Map<String, List<PluginDefault>> remaining = withoutApplied(defaults, applied.applied());
+                    if (!remaining.isEmpty()) {
+                        result = mapChildrenDefaults(result, remaining, forcedPass);
+                    }
+                }
             }
 
-            return value;
+            return result;
         } else if (object instanceof Collection<?> value) {
             return value
                 .stream()
@@ -684,18 +689,47 @@ public class PluginDefaultService {
     }
 
     @SuppressWarnings("unchecked")
-    private Map<?, ?> defaults(Map<?, ?> plugin, Map<String, List<PluginDefault>> defaults, boolean forcedPass) {
+    private Map<String, Object> mapChildrenDefaults(Map<?, ?> value, Map<String, List<PluginDefault>> defaults, boolean forcedPass) {
+        return value
+            .entrySet()
+            .stream()
+            .map(
+                e -> new AbstractMap.SimpleEntry<>(
+                    (String) e.getKey(),
+                    recursiveDefaults(e.getValue(), defaults, forcedPass)
+                )
+            )
+            .collect(HashMap::new, (m, v) -> m.put(v.getKey(), v.getValue()), HashMap::putAll);
+    }
+
+    /** Rebuilds the default map without the given instances, compared by identity (the exact ones just applied). */
+    private Map<String, List<PluginDefault>> withoutApplied(Map<String, List<PluginDefault>> all, List<PluginDefault> applied) {
+        Map<String, List<PluginDefault>> remaining = new HashMap<>();
+        all.forEach((key, list) ->
+        {
+            List<PluginDefault> kept = list.stream()
+                .filter(pd -> applied.stream().noneMatch(a -> a == pd))
+                .toList();
+            if (!kept.isEmpty()) {
+                remaining.put(key, kept);
+            }
+        });
+        return remaining;
+    }
+
+    @SuppressWarnings("unchecked")
+    private DefaultsResult defaults(Map<?, ?> plugin, Map<String, List<PluginDefault>> defaults, boolean forcedPass) {
         boolean hasRef = plugin.containsKey(PLUGIN_DEFAULTS_REF_FIELD);
 
         // a plugin opting into a named (ref) default ('pluginDefaultsRef') ignores non-forced type-matched defaults;
         // forced (admin-enforced) defaults are always applied regardless, see below.
         if (hasRef && !forcedPass) {
-            return plugin;
+            return new DefaultsResult((Map<String, Object>) plugin, List.of());
         }
 
         Object type = plugin.get("type");
         if (!(type instanceof String pluginType)) {
-            return plugin;
+            return new DefaultsResult((Map<String, Object>) plugin, List.of());
         }
 
         List<PluginDefault> matching = defaults.entrySet()
@@ -705,7 +739,7 @@ public class PluginDefaultService {
             .toList();
 
         if (matching.isEmpty()) {
-            return plugin;
+            return new DefaultsResult((Map<String, Object>) plugin, List.of());
         }
 
         if (hasRef) {
@@ -736,7 +770,11 @@ public class PluginDefaultService {
             }
         }
 
-        return result;
+        return new DefaultsResult(result, matching);
+    }
+
+    /** Result of applying defaults to a single node: the merged value and the exact default instances applied. */
+    private record DefaultsResult(Map<String, Object> value, List<PluginDefault> applied) {
     }
 
     /**

--- a/core/src/test/java/io/kestra/core/services/PluginDefaultServiceTest.java
+++ b/core/src/test/java/io/kestra/core/services/PluginDefaultServiceTest.java
@@ -11,9 +11,6 @@ import org.junit.jupiter.api.Test;
 import org.slf4j.LoggerFactory;
 import org.slf4j.event.Level;
 
-import ch.qos.logback.classic.Logger;
-import ch.qos.logback.classic.spi.ILoggingEvent;
-import ch.qos.logback.core.AppenderBase;
 import com.fasterxml.jackson.core.JsonProcessingException;
 
 import io.kestra.core.exceptions.FlowProcessingException;
@@ -38,6 +35,9 @@ import io.kestra.plugin.core.condition.Expression;
 import io.kestra.plugin.core.log.Log;
 import io.kestra.plugin.core.trigger.Schedule;
 
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.AppenderBase;
 import jakarta.inject.Inject;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
@@ -132,6 +132,172 @@ class PluginDefaultServiceTest {
                         "id", "my-task",
                         "type", "io.kestra.test",
                         "default-key", "default-value"
+                    )
+                )
+            ), result
+        );
+    }
+
+    @Test
+    void shouldComposeNonForcedParentAndChildDefaults() {
+        // Given: a broad default injects a taskRunner, a specific default decorates it — both non-forced.
+        // This is the reported bug: without the re-descent fix, the specific default is never applied.
+        Map<String, List<PluginDefault>> defaults = Map.of(
+            "io.kestra",
+            List.of(new PluginDefault("io.kestra", false, Map.of("taskRunner", Map.of("type", "io.kestra.plugin.ee.kubernetes.runner.Kubernetes")))),
+            "io.kestra.plugin.ee.kubernetes.runner.Kubernetes",
+            List.of(new PluginDefault("io.kestra.plugin.ee.kubernetes.runner.Kubernetes", false, Map.of("namespace", "the-namespace")))
+        );
+
+        Map<String, Object> flow = Map.of(
+            "id", "test",
+            "namespace", "type",
+            "tasks", List.of(Map.of("id", "my-task", "type", "io.kestra.plugin.scripts.python.Commands"))
+        );
+
+        // When
+        Object result = pluginDefaultService.recursiveDefaults(flow, defaults);
+
+        // Then: the created taskRunner carries both its type (from the broad default) and the params (from the specific one)
+        Assertions.assertEquals(
+            Map.of(
+                "id", "test",
+                "namespace", "type",
+                "tasks", List.of(
+                    Map.of(
+                        "id", "my-task",
+                        "type", "io.kestra.plugin.scripts.python.Commands",
+                        "taskRunner", Map.of(
+                            "type", "io.kestra.plugin.ee.kubernetes.runner.Kubernetes",
+                            "namespace", "the-namespace"
+                        )
+                    )
+                )
+            ), result
+        );
+    }
+
+    @Test
+    void shouldComposeNonForcedParentWithForcedChildDefault() {
+        // Given: broad default (non-forced) injects a taskRunner, specific default (forced) decorates it
+        Map<String, List<PluginDefault>> defaults = Map.of(
+            "io.kestra",
+            List.of(new PluginDefault("io.kestra", false, Map.of("taskRunner", Map.of("type", "io.kestra.plugin.ee.kubernetes.runner.Kubernetes")))),
+            "io.kestra.plugin.ee.kubernetes.runner.Kubernetes",
+            List.of(new PluginDefault("io.kestra.plugin.ee.kubernetes.runner.Kubernetes", true, Map.of("namespace", "forced-namespace")))
+        );
+
+        Map<String, Object> flow = Map.of(
+            "id", "test",
+            "namespace", "type",
+            "tasks", List.of(Map.of("id", "my-task", "type", "io.kestra.plugin.scripts.python.Commands"))
+        );
+
+        // When
+        Object result = pluginDefaultService.recursiveDefaults(flow, defaults);
+
+        // Then
+        Assertions.assertEquals(
+            Map.of(
+                "id", "test",
+                "namespace", "type",
+                "tasks", List.of(
+                    Map.of(
+                        "id", "my-task",
+                        "type", "io.kestra.plugin.scripts.python.Commands",
+                        "taskRunner", Map.of(
+                            "type", "io.kestra.plugin.ee.kubernetes.runner.Kubernetes",
+                            "namespace", "forced-namespace"
+                        )
+                    )
+                )
+            ), result
+        );
+    }
+
+    @Test
+    void shouldApplyForcedDefaultToExistingNestedNode() {
+        // Mirrors the forced pass of innerInjectDefault: the taskRunner already exists (created by the
+        // non-forced pass) and a forced default overrides the user-provided value on it.
+        Map<String, List<PluginDefault>> forced = Map.of(
+            "io.kestra.plugin.ee.kubernetes.runner.Kubernetes",
+            List.of(new PluginDefault("io.kestra.plugin.ee.kubernetes.runner.Kubernetes", true, Map.of("namespace", "forced-namespace")))
+        );
+
+        Map<String, Object> flow = Map.of(
+            "id", "test",
+            "namespace", "type",
+            "tasks", List.of(
+                Map.of(
+                    "id", "my-task",
+                    "type", "io.kestra.plugin.scripts.python.Commands",
+                    "taskRunner", Map.of("type", "io.kestra.plugin.ee.kubernetes.runner.Kubernetes", "namespace", "user-namespace")
+                )
+            )
+        );
+
+        // When
+        Object result = pluginDefaultService.recursiveDefaults(flow, forced);
+
+        // Then: forced wins over the user value
+        Assertions.assertEquals(
+            Map.of(
+                "id", "test",
+                "namespace", "type",
+                "tasks", List.of(
+                    Map.of(
+                        "id", "my-task",
+                        "type", "io.kestra.plugin.scripts.python.Commands",
+                        "taskRunner", Map.of(
+                            "type", "io.kestra.plugin.ee.kubernetes.runner.Kubernetes",
+                            "namespace", "forced-namespace"
+                        )
+                    )
+                )
+            ), result
+        );
+    }
+
+    @Test
+    void shouldComposeMultiLevelInjectedDefaultsAndTerminate() {
+        // Three non-forced defaults chaining injected nodes. Child types stay under the `io.kestra` prefix,
+        // so the broad D1 could re-match them — the exclusion must keep it out of the subtrees it produced
+        // (otherwise this would inject forever / not terminate).
+        Map<String, List<PluginDefault>> defaults = Map.of(
+            "io.kestra",
+            List.of(new PluginDefault("io.kestra", false, Map.of("childRunner", Map.of("type", "io.kestra.runner.Level2")))),
+            "io.kestra.runner.Level2",
+            List.of(new PluginDefault("io.kestra.runner.Level2", false, Map.of("p2", "v2", "grandRunner", Map.of("type", "io.kestra.runner.Level3")))),
+            "io.kestra.runner.Level3",
+            List.of(new PluginDefault("io.kestra.runner.Level3", false, Map.of("p3", "v3")))
+        );
+
+        Map<String, Object> flow = Map.of(
+            "id", "test",
+            "namespace", "type",
+            "tasks", List.of(Map.of("id", "my-task", "type", "io.kestra.plugin.scripts.python.Commands"))
+        );
+
+        // When
+        Object result = pluginDefaultService.recursiveDefaults(flow, defaults);
+
+        // Then
+        Assertions.assertEquals(
+            Map.of(
+                "id", "test",
+                "namespace", "type",
+                "tasks", List.of(
+                    Map.of(
+                        "id", "my-task",
+                        "type", "io.kestra.plugin.scripts.python.Commands",
+                        "childRunner", Map.of(
+                            "type", "io.kestra.runner.Level2",
+                            "p2", "v2",
+                            "grandRunner", Map.of(
+                                "type", "io.kestra.runner.Level3",
+                                "p3", "v3"
+                            )
+                        )
                     )
                 )
             ), result


### PR DESCRIPTION
Given two plugin defaults where one injects a node the other decorates:

```yaml
pluginDefaults:
  # creates a taskRunner on every task
  - type: io.kestra
    values:
      taskRunner:
        type: io.kestra.plugin.ee.kubernetes.runner.Kubernetes
  # decorates the Kubernetes runner
  - type: io.kestra.plugin.ee.kubernetes.runner.Kubernetes
    values:
      namespace: my-namespace
```

This only worked when the second default was `forced: true`. Forced defaults are applied in a separate second traversal that rediscovers the `taskRunner` created by the first pass, so the `namespace` got merged. With both non-forced they land in the same traversal, and since `recursiveDefaults` is post-order the just-created `taskRunner` was never revisited — the `namespace` was silently dropped and the resulting runner was left incomplete:

```diff
 taskRunner:
   type: io.kestra.plugin.ee.kubernetes.runner.Kubernetes
+  namespace: my-namespace   # dropped before, applied now
```

`recursiveDefaults` now re-descends into a node's children after applying its defaults, using only the defaults that did *not* match the node. A more specific default can decorate a child that a broader one injected, while a default can't recurse into the subtree it produced — which keeps termination and preserves the existing self-injection guard.

Also fixes the same latent bug when both defaults are `forced`. No change to `MapUtils.deepMerge` or the forced/non-forced two-pass wiring; EE inherits the fix.
