### PR TITLE
fix(tests): eliminate the paired "not started in time" CI flake

### DIFF
--- a/cli/src/test/resources/application-test.yml
+++ b/cli/src/test/resources/application-test.yml
@@ -26,7 +26,7 @@ kestra:
     maxRetryAttempts: 1
     shutdownTimeout: 3s
   controller:
-    port: ${random.port}
+    port: ${random.int[20000,32000]} # keep out of the ephemeral port range (32768-60999): an outbound socket could steal a random.port between config resolution and the controller bind
   worker:
     controllers:
       type: STATIC

--- a/core/src/test/resources/application-test.yml
+++ b/core/src/test/resources/application-test.yml
@@ -95,7 +95,7 @@ kestra:
     maxRetryAttempts: 1
     shutdownTimeout: 3s
   controller:
-    port: ${random.port}
+    port: ${random.int[20000,32000]} # keep out of the ephemeral port range (32768-60999): an outbound socket could steal a random.port between config resolution and the controller bind
     maxConnectionAgeGrace: 0s
   worker:
     controllers:

--- a/core/src/test/resources/application-testssl.yml
+++ b/core/src/test/resources/application-testssl.yml
@@ -3,5 +3,5 @@ micronaut:
     ssl:
       enabled: true
       build-self-signed: true
-      port: "${random.port}"
+      port: "${random.int[20000,32000]}" # keep out of the ephemeral port range (32768-60999): an outbound socket could steal a random.port between config resolution and the server bind
     dual-protocol : true

--- a/executor/src/test/resources/application-test.yml
+++ b/executor/src/test/resources/application-test.yml
@@ -68,7 +68,7 @@ kestra:
     maxRetryAttempts: 1
     shutdownTimeout: 3s
   controller:
-    port: ${random.port}
+    port: ${random.int[20000,32000]} # keep out of the ephemeral port range (32768-60999): an outbound socket could steal a random.port between config resolution and the controller bind
     maxConnectionAgeGrace: 0s
   worker:
     controllers:

--- a/jdbc-h2/src/test/resources/application-test.yml
+++ b/jdbc-h2/src/test/resources/application-test.yml
@@ -38,7 +38,7 @@ kestra:
     maxRetryAttempts: 1
     shutdownTimeout: 3s
   controller:
-    port: ${random.port}
+    port: ${random.int[20000,32000]} # keep out of the ephemeral port range (32768-60999): an outbound socket could steal a random.port between config resolution and the controller bind
   worker:
     controllers:
       type: STATIC

--- a/jdbc-mysql/src/test/resources/application-test.yml
+++ b/jdbc-mysql/src/test/resources/application-test.yml
@@ -44,7 +44,7 @@ kestra:
     shutdownTimeout: 3s
 
   controller:
-    port: ${random.port}
+    port: ${random.int[20000,32000]} # keep out of the ephemeral port range (32768-60999): an outbound socket could steal a random.port between config resolution and the controller bind
   worker:
     controllers:
       type: STATIC

--- a/jdbc-postgres/src/test/resources/application-test.yml
+++ b/jdbc-postgres/src/test/resources/application-test.yml
@@ -40,7 +40,7 @@ kestra:
     maxRetryAttempts: 1
     shutdownTimeout: 3s
   controller:
-    port: ${random.port}
+    port: ${random.int[20000,32000]} # keep out of the ephemeral port range (32768-60999): an outbound socket could steal a random.port between config resolution and the controller bind
   worker:
     controllers:
       type: STATIC

--- a/tests/src/main/java/io/kestra/core/runners/TestRunner.java
+++ b/tests/src/main/java/io/kestra/core/runners/TestRunner.java
@@ -101,12 +101,23 @@ public class TestRunner implements Runnable, AutoCloseable {
         }
 
         try {
-            Await.await().atMost(getRunningTimeout()).until(() -> servers.stream().allMatch(TestRunner::isStarted));
+            Await.await().atMost(getRunningTimeout()).until(
+                () -> servers.stream().allMatch(TestRunner::isStarted) || servers.stream().anyMatch(TestRunner::hasFailedToStart)
+            );
         } catch (ConditionTimeoutException e) {
             throw new RuntimeException(
                 servers.stream().filter(s -> !isStarted(s))
                     .map(s -> s.getClass().getSimpleName() + " (state: " + s.getState() + ")")
                     .toList() + " not started in time"
+            );
+        }
+
+        List<Service> failed = servers.stream().filter(TestRunner::hasFailedToStart).toList();
+        if (!failed.isEmpty()) {
+            throw new RuntimeException(
+                failed.stream()
+                    .map(s -> s.getClass().getSimpleName() + " (state: " + s.getState() + ")")
+                    .toList() + " terminated during startup: the context was most likely shut down by an uncaught exception, check the logs above for the root cause"
             );
         }
     }
@@ -117,6 +128,21 @@ public class TestRunner implements Runnable, AutoCloseable {
     private static boolean isStarted(Service service) {
         Service.ServiceState state = service.getState();
         return Service.ServiceState.RUNNING == state || Service.ServiceState.MAINTENANCE == state;
+    }
+
+    /**
+     * A service can never (re)reach RUNNING once it left the CREATED, RUNNING and MAINTENANCE
+     * states: seeing any other state during startup means the service — usually the whole
+     * context — was shut down underneath us, so keeping on waiting would only time out and
+     * hide the root cause. A {@code null} state means the service has not registered yet and
+     * is still starting.
+     */
+    private static boolean hasFailedToStart(Service service) {
+        Service.ServiceState state = service.getState();
+        return state != null
+            && Service.ServiceState.CREATED != state
+            && Service.ServiceState.RUNNING != state
+            && Service.ServiceState.MAINTENANCE != state;
     }
 
     private Duration getRunningTimeout() {

--- a/webserver/src/test/resources/application-test.yml
+++ b/webserver/src/test/resources/application-test.yml
@@ -41,7 +41,7 @@ kestra:
     maxRetryAttempts: 1
     shutdownTimeout: 3s
   controller:
-    port: ${random.port}
+    port: ${random.int[20000,32000]} # keep out of the ephemeral port range (32768-60999): an outbound socket could steal a random.port between config resolution and the controller bind
     maxConnectionAgeGrace: 0s
   worker:
     controllers:

--- a/worker-controller/src/main/java/io/kestra/controller/GrpcChannelManager.java
+++ b/worker-controller/src/main/java/io/kestra/controller/GrpcChannelManager.java
@@ -67,9 +67,11 @@ public class GrpcChannelManager {
 
     private static final ObjectMapper MAPPER = JacksonMapper.ofJson();
 
-    private static final AtomicBoolean STATIC_RESOLVER_REGISTERED = new AtomicBoolean(false);
-    // Reference to the registered resolver provider for cleanup
-    private static final AtomicReference<StaticNameResolverProvider> REGISTERED_STATIC_RESOLVER_PROVIDER = new AtomicReference<>();
+    // The static name resolver is stateless (endpoints are encoded in each channel's target URI),
+    // so a single instance is registered once per JVM at class-load time and never deregistered.
+    static {
+        NameResolverRegistry.getDefaultRegistry().register(new StaticNameResolverProvider());
+    }
 
     private static final AtomicBoolean STORAGE_RESOLVER_REGISTERED = new AtomicBoolean(false);
     private static final AtomicReference<StorageNameResolverProvider> REGISTERED_STORAGE_RESOLVER_PROVIDER = new AtomicReference<>();
@@ -177,23 +179,17 @@ public class GrpcChannelManager {
             throw new IllegalStateException("Static configuration requires at least one endpoint");
         }
 
-        List<EquivalentAddressGroup> addresses = staticConfig.endpoints().stream()
+        List<InetSocketAddress> endpoints = staticConfig.endpoints().stream()
             .map(e ->
             {
                 log.debug("Adding static controller endpoint: {}:{}", e.host(), e.port());
-                return new EquivalentAddressGroup(new InetSocketAddress(e.host(), e.port()));
+                return InetSocketAddress.createUnresolved(e.host(), e.port());
             })
             .toList();
 
-        log.info("Configuring static discovery with {} controller endpoint(s)", addresses.size());
+        log.info("Configuring static discovery with {} controller endpoint(s)", endpoints.size());
 
-        // Register the static name resolver provider only once, store reference for cleanup
-        if (STATIC_RESOLVER_REGISTERED.compareAndSet(false, true)) {
-            StaticNameResolverProvider resolverProvider = new StaticNameResolverProvider(addresses);
-            NameResolverRegistry.getDefaultRegistry().register(resolverProvider);
-            REGISTERED_STATIC_RESOLVER_PROVIDER.set(resolverProvider);
-        }
-        return Grpc.newChannelBuilder("static:///controllers", createChannelCredentials());
+        return Grpc.newChannelBuilder(StaticNameResolverProvider.targetFor(endpoints), createChannelCredentials());
     }
 
     /**
@@ -363,15 +359,6 @@ public class GrpcChannelManager {
                     Thread.currentThread().interrupt();
                 }
             }
-        }
-
-        // Unregister the static name resolver provider to prevent memory leaks
-        // and allow clean re-initialization in tests.
-        // Use getAndSet to atomically retrieve and clear, preventing double-deregister races.
-        StaticNameResolverProvider staticProvider = REGISTERED_STATIC_RESOLVER_PROVIDER.getAndSet(null);
-        if (staticProvider != null) {
-            STATIC_RESOLVER_REGISTERED.set(false);
-            deregisterSilently(staticProvider, "static");
         }
 
         StorageNameResolverProvider storageProvider = REGISTERED_STORAGE_RESOLVER_PROVIDER.getAndSet(null);

--- a/worker-controller/src/main/java/io/kestra/controller/grpc/resolver/StaticNameResolverProvider.java
+++ b/worker-controller/src/main/java/io/kestra/controller/grpc/resolver/StaticNameResolverProvider.java
@@ -1,22 +1,26 @@
 package io.kestra.controller.grpc.resolver;
 
+import java.net.InetSocketAddress;
 import java.net.URI;
 import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import io.grpc.EquivalentAddressGroup;
 import io.grpc.NameResolver;
 import io.grpc.NameResolverProvider;
 
 /**
- * A gRPC NameResolverProvider that provides static list of controller endpoints.
+ * A gRPC NameResolverProvider that resolves a static list of controller endpoints
+ * encoded in the channel target URI.
  * <p>
- * This provider uses the "static" scheme and allows configuring a fixed list
- * of controller addresses for load balancing.
+ * This provider uses the "static" scheme and is fully stateless: the endpoints are
+ * carried by each channel's target (e.g. {@code static:///host1:9096,host2:9097}).
  * <p>
  * Usage:
- * 
+ *
  * <pre>
- * ManagedChannelBuilder.forTarget("static:///controllers")
+ * ManagedChannelBuilder.forTarget(StaticNameResolverProvider.targetFor(endpoints))
  * </pre>
  */
 public class StaticNameResolverProvider extends NameResolverProvider {
@@ -24,15 +28,24 @@ public class StaticNameResolverProvider extends NameResolverProvider {
     private static final String SCHEME = "static";
     private static final int PRIORITY = 5;
 
-    private final List<EquivalentAddressGroup> addresses;
-
     /**
-     * Creates a new StaticNameResolverProvider with the given addresses.
+     * Builds the channel target URI encoding the given endpoints.
+     * <p>
+     * Addresses may be unresolved ({@link InetSocketAddress#createUnresolved(String, int)});
+     * only their host string and port are encoded.
      *
-     * @param addresses the list of controller addresses to resolve to
+     * @param endpoints the controller endpoints, in {@code host:port} form once encoded
+     * @return the channel target, e.g. {@code static:///host1:9096,host2:9097}
      */
-    public StaticNameResolverProvider(List<EquivalentAddressGroup> addresses) {
-        this.addresses = addresses;
+    public static String targetFor(List<InetSocketAddress> endpoints) {
+        if (endpoints == null || endpoints.isEmpty()) {
+            throw new IllegalArgumentException("At least one controller endpoint is required");
+        }
+        return SCHEME + ":///" + endpoints.stream()
+            // strip the brackets of a bracketed IPv6 literal ("[::1]"): "[" is not a valid URI
+            // path character, and parseAddresses() splits host from port on the last colon anyway
+            .map(e -> e.getHostString().replace("[", "").replace("]", "") + ":" + e.getPort())
+            .collect(Collectors.joining(","));
     }
 
     @Override
@@ -40,7 +53,38 @@ public class StaticNameResolverProvider extends NameResolverProvider {
         if (!SCHEME.equals(targetUri.getScheme())) {
             return null;
         }
-        return new StaticNameResolver(addresses);
+        return new StaticNameResolver(parseAddresses(targetUri));
+    }
+
+    /**
+     * Parses the {@code host:port} list encoded in the target URI path by {@link #targetFor(List)}.
+     *
+     * @param targetUri the channel target URI, e.g. {@code static:///host1:9096,host2:9097}
+     * @return the decoded addresses
+     * @throws IllegalArgumentException if the URI does not encode a valid endpoint list
+     */
+    static List<EquivalentAddressGroup> parseAddresses(URI targetUri) {
+        String path = targetUri.getPath();
+        if (path == null || path.length() <= 1) {
+            throw new IllegalArgumentException("No controller endpoint encoded in target URI: " + targetUri);
+        }
+        return Stream.of(path.substring(1).split(","))
+            .map(endpoint ->
+            {
+                int separator = endpoint.lastIndexOf(':');
+                if (separator <= 0 || separator == endpoint.length() - 1) {
+                    throw new IllegalArgumentException("Invalid controller endpoint '" + endpoint + "' in target URI: " + targetUri);
+                }
+                String host = endpoint.substring(0, separator);
+                int port;
+                try {
+                    port = Integer.parseInt(endpoint.substring(separator + 1));
+                } catch (NumberFormatException e) {
+                    throw new IllegalArgumentException("Invalid controller endpoint port in '" + endpoint + "' from target URI: " + targetUri, e);
+                }
+                return new EquivalentAddressGroup(new InetSocketAddress(host, port));
+            })
+            .toList();
     }
 
     @Override

--- a/worker-controller/src/test/java/io/kestra/controller/GrpcChannelManagerTest.java
+++ b/worker-controller/src/test/java/io/kestra/controller/GrpcChannelManagerTest.java
@@ -398,29 +398,40 @@ class GrpcChannelManagerTest {
     }
 
     @Test
-    void shouldUnregisterResolverOnClose() {
-        // Given - create two channel managers with static config
-        WorkerControllersConfiguration config = createStaticConfig(
-            List.of(new Endpoint("localhost", 9096))
-        );
+    void shouldSupportManagersWithOverlappingLifetimesAndDifferentEndpoints() {
+        // Given - two channel managers with static configs pointing at different controllers,
+        // alive at the same time in the same JVM (as happens with successive test contexts).
+        // The shared, stateless name resolver must serve both channels from their own target URI.
         GrpcChannelConfiguration channelConfig = createDefaultChannelConfig();
+        GrpcChannelManager manager1 = new GrpcChannelManager(
+            channelConfig, createDefaultGrpcConfig(),
+            createStaticConfig(List.of(new Endpoint("localhost", 9096))), null
+        );
+        GrpcChannelManager manager2 = new GrpcChannelManager(
+            channelConfig, createDefaultGrpcConfig(),
+            createStaticConfig(List.of(new Endpoint("localhost", 9097))), null
+        );
 
-        // First manager registers the resolver
-        GrpcChannelManager manager1 = new GrpcChannelManager(channelConfig, createDefaultGrpcConfig(), config, null);
+        // When - both initialize, then the first one closes
         manager1.init();
-
-        // Close first manager - should unregister resolver
+        manager2.init();
         manager1.close();
 
-        // Second manager should be able to register a new resolver
-        GrpcChannelManager manager2 = new GrpcChannelManager(channelConfig, createDefaultGrpcConfig(), config, null);
-        manager2.init();
-
-        // Then - both should work without conflict
+        // Then - the surviving manager's channel is unaffected by the other's lifecycle
         assertThat(manager2.getDefaultChannel()).isNotNull();
+        assertThat(((ManagedChannel) manager2.getDefaultChannel()).isShutdown()).isFalse();
+
+        // And a manager created after a close still works (the resolver stays registered JVM-wide)
+        GrpcChannelManager manager3 = new GrpcChannelManager(
+            channelConfig, createDefaultGrpcConfig(),
+            createStaticConfig(List.of(new Endpoint("localhost", 9098))), null
+        );
+        manager3.init();
+        assertThat(manager3.getDefaultChannel()).isNotNull();
 
         // Cleanup
         manager2.close();
+        manager3.close();
     }
 
     // Helper methods

--- a/worker-controller/src/test/java/io/kestra/controller/resolver/StaticNameResolverTest.java
+++ b/worker-controller/src/test/java/io/kestra/controller/resolver/StaticNameResolverTest.java
@@ -14,6 +14,7 @@ import io.grpc.EquivalentAddressGroup;
 import io.grpc.NameResolver;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class StaticNameResolverTest {
 
@@ -61,23 +62,79 @@ class StaticNameResolverTest {
     }
 
     @Test
-    void providerShouldCreateResolver() {
-        List<EquivalentAddressGroup> addresses = List.of(
-            new EquivalentAddressGroup(new InetSocketAddress("localhost", 9096))
-        );
-
-        StaticNameResolverProvider provider = new StaticNameResolverProvider(addresses);
+    void providerShouldCreateResolverFromEndpointsEncodedInTargetUri() {
+        StaticNameResolverProvider provider = new StaticNameResolverProvider();
 
         assertThat(provider.getDefaultScheme()).isEqualTo("static");
 
-        NameResolver resolver = provider.newNameResolver(URI.create("static:///controllers"), null);
+        NameResolver resolver = provider.newNameResolver(URI.create("static:///localhost:9096"), null);
         assertThat(resolver).isNotNull();
         assertThat(resolver).isInstanceOf(StaticNameResolver.class);
+
+        AtomicReference<NameResolver.ResolutionResult> result = new AtomicReference<>();
+        resolver.start(new TestListener(result));
+        assertThat(result.get().getAddresses()).containsExactly(
+            new EquivalentAddressGroup(new InetSocketAddress("localhost", 9096))
+        );
+    }
+
+    @Test
+    void providerShouldRoundTripEndpointsThroughTargetUri() {
+        // Given
+        List<InetSocketAddress> endpoints = List.of(
+            InetSocketAddress.createUnresolved("controller-1.example.com", 9096),
+            InetSocketAddress.createUnresolved("controller-2.example.com", 9097)
+        );
+
+        // When
+        String target = StaticNameResolverProvider.targetFor(endpoints);
+
+        // Then
+        assertThat(target).isEqualTo("static:///controller-1.example.com:9096,controller-2.example.com:9097");
+
+        NameResolver resolver = new StaticNameResolverProvider().newNameResolver(URI.create(target), null);
+        AtomicReference<NameResolver.ResolutionResult> result = new AtomicReference<>();
+        resolver.start(new TestListener(result));
+        assertThat(result.get().getAddresses()).containsExactly(
+            new EquivalentAddressGroup(new InetSocketAddress("controller-1.example.com", 9096)),
+            new EquivalentAddressGroup(new InetSocketAddress("controller-2.example.com", 9097))
+        );
+    }
+
+    @Test
+    void providerShouldRoundTripBracketedIpv6Endpoints() {
+        // Given
+        String target = StaticNameResolverProvider.targetFor(List.of(InetSocketAddress.createUnresolved("[::1]", 9096)));
+
+        // Then - brackets are stripped so the target stays a valid URI
+        assertThat(target).isEqualTo("static:///::1:9096");
+
+        NameResolver resolver = new StaticNameResolverProvider().newNameResolver(URI.create(target), null);
+        AtomicReference<NameResolver.ResolutionResult> result = new AtomicReference<>();
+        resolver.start(new TestListener(result));
+        assertThat(result.get().getAddresses()).containsExactly(
+            new EquivalentAddressGroup(new InetSocketAddress("::1", 9096))
+        );
+    }
+
+    @Test
+    void providerShouldRejectTargetUriWithoutEndpoints() {
+        StaticNameResolverProvider provider = new StaticNameResolverProvider();
+
+        assertThatThrownBy(() -> provider.newNameResolver(URI.create("static:///"), null))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("No controller endpoint");
+        assertThatThrownBy(() -> provider.newNameResolver(URI.create("static:///localhost"), null))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("Invalid controller endpoint");
+        assertThatThrownBy(() -> provider.newNameResolver(URI.create("static:///localhost:abc"), null))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("Invalid controller endpoint");
     }
 
     @Test
     void providerShouldReturnNullForWrongScheme() {
-        StaticNameResolverProvider provider = new StaticNameResolverProvider(List.of());
+        StaticNameResolverProvider provider = new StaticNameResolverProvider();
 
         NameResolver resolver = provider.newNameResolver(URI.create("dns:///localhost"), null);
         assertThat(resolver).isNull();

--- a/worker-controller/src/test/resources/application-test.yml
+++ b/worker-controller/src/test/resources/application-test.yml
@@ -68,7 +68,7 @@ kestra:
     maxRetryAttempts: 1
     shutdownTimeout: 3s
   controller:
-    port: ${random.port}
+    port: ${random.int[20000,32000]} # keep out of the ephemeral port range (32768-60999): an outbound socket could steal a random.port between config resolution and the controller bind
   worker:
     controllers:
       type: STATIC

--- a/worker/src/test/resources/application-test.yml
+++ b/worker/src/test/resources/application-test.yml
@@ -68,7 +68,7 @@ kestra:
     maxRetryAttempts: 1
     shutdownTimeout: 3s
   controller:
-    port: ${random.port}
+    port: ${random.int[20000,32000]} # keep out of the ephemeral port range (32768-60999): an outbound socket could steal a random.port between config resolution and the controller bind
   worker:
     controllers:
       type: STATIC


### PR DESCRIPTION
## Context

Follow-up to #17340. CI still failed intermittently with:

```
java.lang.RuntimeException: [DefaultExecutor (state: TERMINATED_GRACEFULLY), ...] not started in time
    at io.kestra.core.runners.TestRunner.run(TestRunner.java:109)
```

Log analysis (e.g. run 29075777252, `jdbc-mysql`) shows these failures always come in **pairs of test classes** and are caused by two compounding bugs:

1. **Trigger** — `kestra.controller.port: ${random.port}` picks a free port at config-resolution time but does not reserve it. When the draw lands in the Linux ephemeral range (32768–60999), the kernel can hand the same port to any outbound connection before the controller binds it, failing `DefaultController.doStart` with `BindException: Address already in use`. The uncaught exception shuts the whole context down while `TestRunner` keeps waiting, producing the misleading "not started in time" a full timeout later.
2. **Amplifier** — the crashed context died mid-`@PostConstruct` of `GrpcChannelManager`, so its `@PreDestroy` never ran and its `StaticNameResolverProvider` (holding the dead port) stayed registered in gRPC's JVM-global `NameResolverRegistry`. The **next** test class CAS-skipped registration, silently resolved `static:///controllers` through the stale provider, dialed the dead port for 30s, and was shut down in turn by the resulting uncaught `WorkerConnectionFailedException` — the second failure of the pair. (Observed directly: a context whose controller bound 29235 had its worker dialing the previous context's 54532.)

## Changes

- **`fix(worker)`**: `StaticNameResolverProvider` is now stateless — endpoints ride in each channel's target URI (`static:///host1:port1,host2:port2`); a single provider is registered once per JVM in a static initializer and never deregistered. No per-context state can leak between application contexts coexisting in one JVM.
- **`fix(tests)`**: `TestRunner` aborts the startup await as soon as any service enters a state from which RUNNING is unreachable, failing immediately with an explicit "terminated during startup" message instead of a misleading timeout.
- **`fix(tests)`**: test configs use `${random.int[20000,32000]}` instead of `${random.port}` for the controller port (and the SSL webserver test port), keeping drawn ports out of the ephemeral range.

## Tests

- New unit tests: URI encode/parse round-trip (incl. IPv6 and malformed input) and overlapping-lifetime channel managers with different endpoints.
- `worker-controller` tests 29/29, `H2RunnerTest` green (single unrelated pre-existing flaky passes on rerun), `RequestTest` (testssl) 28/28.

Companion EE PR aligns the EE test configs.