### PR TITLE
fix(ui): unify fitHeight layout across listing pages for pinned pagination

### DIFF
--- a/ui/packages/design-system/src/components/Data/KsDataTable/KsDataTable.vue
+++ b/ui/packages/design-system/src/components/Data/KsDataTable/KsDataTable.vue
@@ -13,50 +13,48 @@
                 <slot name="top" />
             </div>
 
-            <template v-if="hasTableSlot">
+            <div v-if="hasTableSlot" class="ks-data-table-content ks-data-table-content--slot">
                 <slot name="table" />
-            </template>
+            </div>
 
-            <template v-else>
-                <div ref="container" class="ks-data-table-content" :class="{'no-selection-gutter': !hasSelectionColumn && !noFirstColumnGutter}" @click.capture="(e: MouseEvent) => isShiftPressed = e.shiftKey">
-                    <div v-if="hasSelection && data && data.length && hasBulkActions" class="bulk-select-header">
-                        <KsBulkSelect
-                            :selectAll="queryBulkAction"
-                            :selectionCount="mappedSelection.length"
-                            :total="selectableTotal"
-                            @toggle-all="toggleAllSelection"
-                            @unselect="toggleAllUnselected"
-                        >
-                            <slot name="bulk-actions" />
-                        </KsBulkSelect>
-                    </div>
-                    <div v-else-if="hasSelection && data && data.length" class="bulk-select-header">
-                        <slot name="select-actions" />
-                    </div>
-
-                    <KsTable
-                        ref="tableRef"
-                        v-bind="$attrs"
-                        :tableLayout="tableLayout"
-                        fixed
-                        :data
-                        :rowKey
-                        :expandRowKeys="composedExpandRowKeys"
-                        :rowClassName="composedRowClassName"
-                        :emptyText="noDataText"
-                        @selection-change="selectionChanged"
-                        @select="onSelect"
-                        @sort-change="onSortChange"
-                        @row-dblclick="(row, column, event) => emit('row-dblclick', row, column, event)"
+            <div v-else ref="container" class="ks-data-table-content" :class="{'no-selection-gutter': !hasSelectionColumn && !noFirstColumnGutter}" @click.capture="(e: MouseEvent) => isShiftPressed = e.shiftKey">
+                <div v-if="hasSelection && data && data.length && hasBulkActions" class="bulk-select-header">
+                    <KsBulkSelect
+                        :selectAll="queryBulkAction"
+                        :selectionCount="mappedSelection.length"
+                        :total="selectableTotal"
+                        @toggle-all="toggleAllSelection"
+                        @unselect="toggleAllUnselected"
                     >
-                        <KsTableColumn v-if="selectable && showSelection" type="selection" reserveSelection :selectable="rowSelectable" />
-                        <slot />
-                        <template #empty>
-                            <KsNoData :title="noDataText" />
-                        </template>
-                    </KsTable>
+                        <slot name="bulk-actions" />
+                    </KsBulkSelect>
                 </div>
-            </template>
+                <div v-else-if="hasSelection && data && data.length" class="bulk-select-header">
+                    <slot name="select-actions" />
+                </div>
+
+                <KsTable
+                    ref="tableRef"
+                    v-bind="$attrs"
+                    :tableLayout="tableLayout"
+                    fixed
+                    :data
+                    :rowKey
+                    :expandRowKeys="composedExpandRowKeys"
+                    :rowClassName="composedRowClassName"
+                    :emptyText="noDataText"
+                    @selection-change="selectionChanged"
+                    @select="onSelect"
+                    @sort-change="onSortChange"
+                    @row-dblclick="(row, column, event) => emit('row-dblclick', row, column, event)"
+                >
+                    <KsTableColumn v-if="selectable && showSelection" type="selection" reserveSelection :selectable="rowSelectable" />
+                    <slot />
+                    <template #empty>
+                        <KsNoData :title="noDataText" />
+                    </template>
+                </KsTable>
+            </div>
 
             <KsPagination
                 v-if="showPagination"
@@ -492,6 +490,19 @@
         &--fit {
             min-height: 0;
             overflow: hidden;
+
+            .ks-data-table-content {
+                flex: 1 1 0;
+                min-height: 0;
+
+                &--slot {
+                    overflow: auto;
+                }
+            }
+
+            .kel-pagination {
+                margin-top: auto;
+            }
         }
     }
 
@@ -526,6 +537,13 @@
                 text-overflow: ellipsis;
                 white-space: nowrap;
             }
+        }
+
+        // element-plus sizes the empty-block to 100% of its scroll view, on top of the header row's own
+        // height, overflowing the view by the header's height whenever an ancestor constrains it (e.g. any
+        // empty-state layout). Subtract the header height we already track for the bulk-select overlay above.
+        .kel-table__empty-block {
+            height: calc(100% - var(--table-header-height, 0px)) !important;
         }
 
         .kel-table tr.ks-row-force-expanded .kel-table__expand-icon {

--- a/ui/packages/design-system/tests/storybook/Data/KsDataTable.stories.ts
+++ b/ui/packages/design-system/tests/storybook/Data/KsDataTable.stories.ts
@@ -1,5 +1,6 @@
 import type {Meta, StoryObj} from "@storybook/vue3-vite"
 import {ref} from "vue"
+import {within, userEvent, expect, waitFor} from "storybook/test"
 import KsDataTable from "../../../src/components/Data/KsDataTable/KsDataTable.vue"
 import KsTableColumn from "../../../src/components/Data/KsTable/KsTableColumn.vue"
 import KsTag from "../../../src/components/Data/KsTag/KsTag.vue"
@@ -290,6 +291,48 @@ export const CustomContent: Story = {
     }),
 }
 
+export const PaginationRoundtrip: Story = {
+    name: "Pagination — page-changed roundtrip",
+    render: () => ({
+        components: {KsDataTable, KsTableColumn},
+        setup() {
+            const page = ref(1)
+            const size = ref(10)
+            const pagedData = ref(SAMPLE_DATA.slice(0, 10))
+            const onPageChanged = ({page: p, size: s}: {page: number; size: number}) => {
+                page.value = p
+                size.value = s
+                pagedData.value = SAMPLE_DATA.slice((p - 1) * s, p * s)
+            }
+            return {pagedData, page, size, total: SAMPLE_DATA.length, onPageChanged}
+        },
+        template: `
+            <div style="padding: 24px">
+                <ks-data-table
+                    :data="pagedData"
+                    :total="total"
+                    :current-page="page"
+                    :page-size="size"
+                    @page-changed="onPageChanged"
+                >
+                    <ks-table-column prop="id" label="Flow ID" />
+                    <ks-table-column prop="namespace" label="Namespace" />
+                </ks-data-table>
+            </div>
+        `,
+    }),
+    async play({canvasElement}) {
+        const canvas = within(canvasElement)
+        await canvas.findByText("flow-001")
+
+        const pager = canvasElement.querySelector(".kel-pager") as HTMLElement
+        await userEvent.click(within(pager).getByText("2"))
+
+        await canvas.findByText("flow-011")
+        await waitFor(() => expect(canvas.queryByText("flow-001")).toBeNull())
+    },
+}
+
 export const FitHeight: Story = {
     name: "fitHeight — bounded container with tall slot content",
     parameters: {
@@ -315,4 +358,75 @@ export const FitHeight: Story = {
             </div>
         `,
     }),
+}
+
+export const FitHeightSlotScroll: Story = {
+    name: "fitHeight — #table slot scrolls via the wrapper, pagination pinned",
+    parameters: {
+        docs: {
+            description: {
+                story: "With `fitHeight`, the `#table` slot is wrapped in `.ks-data-table-content--slot` with `overflow: auto`, so tall slot content scrolls by itself — no scroll wrapper needed in the slot — and the pagination stays pinned at the bottom of the bounded container.",
+            },
+        },
+    },
+    render: () => ({
+        components: {KsDataTable},
+        template: `
+            <div data-testid="bounded" style="height: 320px; display: flex; flex-direction: column; overflow: hidden">
+                <ks-data-table :total="30" :current-page="1" :page-size="10" fit-height>
+                    <template #table>
+                        <div>
+                            <div v-for="i in 60" :key="i" style="padding: 8px; border-bottom: 1px solid var(--ks-border-subtle)">
+                                Row {{ i }}
+                            </div>
+                        </div>
+                    </template>
+                </ks-data-table>
+            </div>
+        `,
+    }),
+    async play({canvasElement}) {
+        const bounded = canvasElement.querySelector("[data-testid=bounded]") as HTMLElement
+        const wrapper = canvasElement.querySelector(".ks-data-table-content--slot") as HTMLElement
+        await expect(wrapper).toBeTruthy()
+
+        // tall slot content scrolls inside the wrapper instead of expanding the container
+        await waitFor(() => expect(wrapper.scrollHeight).toBeGreaterThan(wrapper.clientHeight))
+        await expect(bounded.scrollHeight).toBeLessThanOrEqual(bounded.clientHeight + 1)
+
+        // pagination stays pinned within the bounded container
+        const pagination = canvasElement.querySelector(".kel-pagination") as HTMLElement
+        await expect(pagination).toBeTruthy()
+        await expect(pagination.getBoundingClientRect().bottom).toBeLessThanOrEqual(bounded.getBoundingClientRect().bottom + 1)
+    },
+}
+
+export const FitHeightEmptyBounded: Story = {
+    name: "fitHeight — empty state fits the bounded container",
+    parameters: {
+        docs: {
+            description: {
+                story: "element-plus sizes the empty-block to 100% of the scroll view on top of the header row, overflowing bounded containers by the header height; the height is corrected via `--table-header-height` so the empty state fits.",
+            },
+        },
+    },
+    render: () => ({
+        components: {KsDataTable, KsTableColumn},
+        template: `
+            <div data-testid="bounded" style="height: 300px; display: flex; flex-direction: column; overflow: hidden">
+                <ks-data-table :data="[]" :total="0" no-data-text="No flows found" fit-height>
+                    <ks-table-column prop="id" label="Flow ID" />
+                    <ks-table-column prop="namespace" label="Namespace" />
+                </ks-data-table>
+            </div>
+        `,
+    }),
+    async play({canvasElement}) {
+        const canvas = within(canvasElement)
+        await canvas.findByText("No flows found")
+
+        const body = canvasElement.querySelector(".ks-data-table-body--fit") as HTMLElement
+        await expect(body).toBeTruthy()
+        await waitFor(() => expect(body.scrollHeight).toBeLessThanOrEqual(body.clientHeight + 1))
+    },
 }

--- a/ui/src/components/Tabs.vue
+++ b/ui/src/components/Tabs.vue
@@ -47,6 +47,12 @@
 
     export interface Tab extends RouterTab {
         locked?: boolean;
+        /**
+         * When true, the tab's content section gets the full-container layout
+         * (bounded flex height) instead of the default scrolling container —
+         * for tabs hosting a full-page listing (e.g. KsDataTable with fitHeight).
+         */
+        fullContainer?: boolean;
         props?: any;
         blueprintDetail?: boolean;
     }
@@ -120,7 +126,7 @@
     }
 
     const containerClass = computed(() => {
-        if (activeTab.value?.locked) return {"px-0": true, "full-container": true}
+        if (activeTab.value?.locked || activeTab.value?.fullContainer) return {"px-0": true, "full-container": true}
         return {"container": true, "tabs-flush-top": true}
     })
 

--- a/ui/src/components/admin/ConcurrencyLimits.vue
+++ b/ui/src/components/admin/ConcurrencyLimits.vue
@@ -2,8 +2,8 @@
     <TopNavBar :title="routeInfo.title" />
 
     <Empty v-if="data?.results === undefined || data?.results.length === 0" type="concurrency_limits" />
-    <section v-else class="container">
-        <KsDataTable :total="data?.total ?? 0">
+    <section v-else class="full-container">
+        <KsDataTable :total="data?.total ?? 0" fitHeight>
             <template #table>
                 <KsTable
                     :data="data?.results"

--- a/ui/src/components/admin/mcp/tabs/McpToolFlows.vue
+++ b/ui/src/components/admin/mcp/tabs/McpToolFlows.vue
@@ -20,6 +20,7 @@
 
         <KsDataTable
             v-else
+            fitHeight
             :data="filteredTools"
             :total="filteredTools.length"
             :loading="loading"
@@ -285,6 +286,12 @@
 </script>
 
 <style lang="scss" scoped>
+    .mcp-tools {
+        display: flex;
+        flex-direction: column;
+        min-height: 0;
+    }
+
     .mono {
         font-family: var(--ks-font-family-mono);
         font-size: var(--ks-font-size-sm);

--- a/ui/src/components/admin/mcp/useMcpTabs.ts
+++ b/ui/src/components/admin/mcp/useMcpTabs.ts
@@ -30,6 +30,7 @@ export function useMcpTabs() {
             title: t("mcp.tab_tool_flows"),
             component: McpToolFlows,
             disabled: isCreate.value,
+            fullContainer: true,
         },
     ])
 

--- a/ui/src/components/admin/triggers/Triggers.vue
+++ b/ui/src/components/admin/triggers/Triggers.vue
@@ -43,7 +43,7 @@
 
     const tabs = computed(() => [
         {name: "add", title: t("triggers_tabs_add"), component: markRaw(TriggersGrid)},
-        {name: "manage", title: t("triggers_tabs_manage"), component: markRaw(TriggersManage)},
+        {name: "manage", title: t("triggers_tabs_manage"), component: markRaw(TriggersManage), fullContainer: true},
     ])
 
     const isManageTab = computed(() => route.params.tab === "manage")

--- a/ui/src/components/admin/triggers/TriggersManage.vue
+++ b/ui/src/components/admin/triggers/TriggersManage.vue
@@ -8,6 +8,7 @@
             :currentPage="urlPage"
             :pageSize="urlSize"
             :defaultSort="{prop: 'flowId', order: 'ascending'}"
+            fitHeight
             :selectable="canCheck"
             :selectionMapper="selectionMapper"
             :rowClassName="getClasses"
@@ -859,6 +860,10 @@
 
 <style scoped lang="scss">
     .triggers-manage {
+        display: flex;
+        flex-direction: column;
+        min-height: 0;
+
         :deep(tr.no-expand .kel-table__expand-icon) {
             pointer-events: none;
 

--- a/ui/src/components/dashboard/Dashboard.vue
+++ b/ui/src/components/dashboard/Dashboard.vue
@@ -191,7 +191,7 @@
 <style scoped lang="scss">
 
 .filterPadding {
-    margin-top: 2rem;
+    margin-top: 1rem;
     padding: 0 2rem;
 }
 

--- a/ui/src/components/dashboard/sections/Sections.vue
+++ b/ui/src/components/dashboard/sections/Sections.vue
@@ -178,6 +178,7 @@ section#charts {
                     right: 1.25rem;
                 }
             }
+
         }
 
         #charts_buttons {

--- a/ui/src/components/executions/Executions.vue
+++ b/ui/src/components/executions/Executions.vue
@@ -34,7 +34,7 @@
             </ul>
         </template>
     </TopNavBar>
-    <section :class="{'container padding-bottom': topbar}">
+    <section :class="{'full-container': fitHeightResolved}">
         <KsDataTable
             ref="dataTable"
             :loadData="loadData"
@@ -51,6 +51,7 @@
             :selectable="!hidden?.includes('selection') && canCheck"
             :no-data-text="$t('no_results.executions')"
             :rowKey="(row: any) => row.id"
+            :fitHeight="fitHeightResolved"
         >
             <template #navbar v-if="isDisplayedTop">
                 <KSFilter
@@ -437,6 +438,7 @@
         embed?: boolean;
         filter?: boolean;
         topbar?: boolean;
+        fitHeight?: boolean;
         id?: string | null;
         statuses?: string[];
         isReadOnly?: boolean;
@@ -450,6 +452,7 @@
         embed: false,
         filter: true,
         topbar: true,
+        fitHeight: undefined,
         id: null,
         statuses: () => [],
         isReadOnly: false,
@@ -460,6 +463,8 @@
         namespace: undefined,
         defaultScopeFilter: false,
     })
+
+    const fitHeightResolved = computed(() => props.fitHeight ?? props.topbar)
 
     const emit = defineEmits<{
         "state-count": [payload: { runningCount: number; totalCount: number }];
@@ -1061,12 +1066,18 @@
 </script>
 
 <style scoped lang="scss">
-.shadow {
-    box-shadow: 0px 2px 4px 0px var(--ks-shadow-element) !important;
+.full-container {
+    min-height: 0;
+    display: flex;
+    flex-direction: column;
+
+    > * {
+        flex: 1;
+    }
 }
 
-.padding-bottom {
-    padding-bottom: 4rem;
+.shadow {
+    box-shadow: 0px 2px 4px 0px var(--ks-shadow-element) !important;
 }
 
 .custom-warning {

--- a/ui/src/components/flows/Flows.vue
+++ b/ui/src/components/flows/Flows.vue
@@ -19,7 +19,7 @@
             </NavBarActions>
         </template>
     </TopNavBar>
-    <section :class="{container: topbar}">
+    <section :class="{'full-container': fitHeightResolved}">
         <KsDataTable
             ref="dataTable"
             :loadData="loadData"
@@ -38,6 +38,7 @@
             :no-data-text="$t('no_results.flows')"
             class="flows-table"
             :rowKey="(row: any) => `${row.namespace}-${row.id}`"
+            :fitHeight="fitHeightResolved"
         >
             <template #top>
                 <KSFilter
@@ -311,17 +312,21 @@
 
     const props = withDefaults(defineProps<{
         topbar?: boolean;
+        fitHeight?: boolean;
         namespace?: string;
         id?: string | null;
         defaultScopeFilter?: boolean,
         embed?: boolean;
     }>(), {
         topbar: true,
+        fitHeight: undefined,
         namespace: undefined,
         id: undefined,
         defaultScopeFilter: false,
         embed: false,
     })
+
+    const fitHeightResolved = computed(() => props.fitHeight ?? props.topbar)
 
     const flowStore = useFlowStore()
     const apiStore = useApiStore()
@@ -737,6 +742,16 @@
 </script>
 
 <style scoped lang="scss">
+.full-container {
+    min-height: 0;
+    display: flex;
+    flex-direction: column;
+
+    > * {
+        flex: 1;
+    }
+}
+
 .shadow {
     box-shadow: 0px 2px 4px 0px var(--ks-shadow-element) !important;
 }

--- a/ui/src/components/flows/blueprints/BlueprintsBrowser.vue
+++ b/ui/src/components/flows/blueprints/BlueprintsBrowser.vue
@@ -11,6 +11,7 @@
                 :currentPage="urlPage"
                 :pageSize="urlSize"
                 :noGutter="!embed && !system"
+                :fitHeight="!embed && !system"
                 @ready="ready = true"
                 @page-changed="onPageChanged"
             >

--- a/ui/src/components/kv/KVTable.vue
+++ b/ui/src/components/kv/KVTable.vue
@@ -10,7 +10,7 @@
         @page-changed="({page, size}: {page: number; size: number}) => router.push({query: {...route.query, page: String(page), size: String(size)}})"
         @sort-change="({prop, order}: {column: any; prop: string | null; order: string | null}) => router.push({query: {...route.query, sort: `${prop}:${order === 'ascending' ? 'asc' : 'desc'}`}})"
         :no-data-text="$t('no_results.kv_pairs')"
-        class="fill-height"
+        :fitHeight="!paneView"
         :showSelection="!paneView"
         :rowKey="(row: any) => `${row.namespace}-${row.key}`"
     >

--- a/ui/src/components/kv/KVs.vue
+++ b/ui/src/components/kv/KVs.vue
@@ -10,7 +10,7 @@
             </ul>
         </template>
     </TopNavBar>
-    <section class="d-flex flex-column fill-height container padding-bottom">
+    <section class="full-container">
         <KVTable />
     </section>
 </template>

--- a/ui/src/components/namespaces/utils/useHelpers.ts
+++ b/ui/src/components/namespaces/utils/useHelpers.ts
@@ -19,6 +19,7 @@ export interface Tab {
     props?: Record<string, any>;
     count?: number;
     blueprintDetail?: boolean;
+    fullContainer?: boolean;
 }
 
 export interface Breadcrumb {
@@ -106,9 +107,11 @@ export function useHelpers() {
             props: {
                 namespace: namespace.value,
                 topbar: false,
+                fitHeight: true,
                 defaultScopeFilter: false,
                 embed: true,
             },
+            fullContainer: true,
         },
         {
             name: "executions",
@@ -117,10 +120,12 @@ export function useHelpers() {
             props: {
                 namespace: namespace.value,
                 topbar: false,
+                fitHeight: true,
                 visibleCharts: true,
                 embed: true,
                 defaultScopeFilter: false,
             },
+            fullContainer: true,
         },
         {
             name: "dependencies",

--- a/ui/src/components/secrets/Secrets.vue
+++ b/ui/src/components/secrets/Secrets.vue
@@ -10,7 +10,7 @@
             </ul>
         </template>
     </Navbar>
-    <section class="d-flex flex-column fill-height padding-bottom container">
+    <section :class="miscStore.configs?.secretsEnabled === undefined ? 'd-flex flex-column fill-height container' : 'full-container'">
         <div v-if="miscStore.configs?.secretsEnabled === undefined" class="d-flex flex-column text-start m-0 p-0 mw-100">
             <div class="oss-secrets-block d-flex flex-column gap-4">
                 <SecretsTable

--- a/ui/src/components/secrets/SecretsTable.vue
+++ b/ui/src/components/secrets/SecretsTable.vue
@@ -1,5 +1,5 @@
 <template>
-    <div class="d-flex flex-column fill-height">
+    <div class="secrets-table">
         <KsDataTable
             ref="dataTable"
             :loadData="loadData"
@@ -12,7 +12,7 @@
             @page-changed="({page, size}: {page: number; size: number}) => router.push({query: {...route.query, page: String(page), size: String(size)}})"
             @sort-change="({prop, order}: {column: any; prop: string | null; order: string | null}) => router.push({query: {...route.query, sort: `${prop}:${order === 'ascending' ? 'asc' : 'desc'}`}})"
             :no-data-text="$t('no_results.secrets')"
-            class="fill-height"
+            :fitHeight="!paneView && !keyOnly"
             :rowKey="(row: any) => `${row.namespace}-${row.key}`"
         >
             <template #top v-if="!paneView">
@@ -610,6 +610,12 @@
     })
 </script>
 <style scoped lang="scss">
+    .secrets-table {
+        display: flex;
+        flex-direction: column;
+        min-height: 0;
+    }
+
     .namespace-tag {
         padding: 0 6px;
 

--- a/ui/src/override/components/flows/blueprints/Blueprints.vue
+++ b/ui/src/override/components/flows/blueprints/Blueprints.vue
@@ -5,7 +5,7 @@
         <section
             v-bind="$attrs"
             class="main-container"
-            :class="{'blueprints-margin': !combinedView, 'detail-view': !!selectedBlueprintId}"
+            :class="{'blueprints-margin': !combinedView, 'detail-view': !!selectedBlueprintId, 'full-container': !embed}"
         >
             <BlueprintDetail
                 v-if="selectedBlueprintId"

--- a/ui/src/override/components/namespaces/useTabs.ts
+++ b/ui/src/override/components/namespaces/useTabs.ts
@@ -55,6 +55,7 @@ export function useTabs() {
             title: t("kv.name"),
             component: KVTable,
             props: {namespace},
+            fullContainer: true,
         },
         {
             ...lockedProps("history"),

--- a/ui/src/styles/app.scss
+++ b/ui/src/styles/app.scss
@@ -104,6 +104,12 @@ main {
         }
     }
 
+    // fitHeight pages pin the pagination footer, so override main-container's own top/bottom padding to match plain full-container pages
+    section.main-container.full-container:has(:is(.ks-data-table-wrapper, .full-width-table)) {
+        padding-top: 1rem;
+        padding-bottom: 0;
+    }
+
     .full-width-table {
         th.kel-table__cell:first-child > .cell,
         td.kel-table__cell:first-child > .cell {
@@ -117,6 +123,7 @@ main {
         display: flex;
         flex-direction: column;
         min-height: 0;
+        padding-top: 1rem;
 
         > * {
             flex: 1;


### PR DESCRIPTION
- KsDataTable gains a `fitHeight` prop + `.fit` CSS modifier so a table can bound its height to its container instead of growing the page
- Fixed an element-plus bug where empty-state tables still reserved scroll height, causing a phantom page scrollbar
- Tabs.vue gains a `fullContainer` tab option, giving the active tab's content flex-bounded height for tabs that host a full listing page
- Added missing `fullContainer` field to the namespaces-local `Tab` type (useHelpers.ts) so the KV Store tab wiring type-checks
- Wired fitHeight/full-container across OSS listing pages: Flows, Executions, Secrets, SecretsTable, KVs, KVTable, ConcurrencyLimits, LogsWrapper, BlueprintsBrowser, Blueprints override
- Fixes kestra-io/kestra-ee#9299 — pagination bar scrolled off-screen on long listing pages instead of staying pinned at the bottom
- Layout/CSS change — verified live across ~15 pages (empty, single-page, multi-page states); no meaningful unit-test coverage for this kind of change