### PR TITLE
fix(plugins): return empty array when listTriggers response has no results

### DIFF
--- a/ui/src/stores/plugins.ts
+++ b/ui/src/stores/plugins.ts
@@ -300,7 +300,7 @@ export const usePluginsStore = defineStore("plugins", () => {
 
     async function listTriggers() {
         const response = await PluginsAPI.listTriggerPlugins() as unknown as {results: TriggerPluginDto[]; total: number}
-        return response.results
+        return response?.results ?? []
     }
 
     async function listWithSubgroup(_options?: Record<string, any>) {


### PR DESCRIPTION
Fixes the `Unhandled error during execution of app errorHandler` warning in the Triggers Storybook CI test: `listTriggers()` forwarded `response.results` unchecked, so a non-`{results,total}` payload made `TriggersGrid`'s computed call `.filter()` on `undefined`. Now defaults to `[]`, honoring the declared `TriggerPluginDto[]` return type. 🐱 The cat always lands on its feet — never on `undefined`.