### PR TITLE
fix(ui): make document title reactive to route changes

### DIFF
--- a/ui/packages/design-system/src/components/Data/KsMarkdown/KsMarkdown.vue
+++ b/ui/packages/design-system/src/components/Data/KsMarkdown/KsMarkdown.vue
@@ -79,6 +79,19 @@
         return result
     }
 
+    // Raw HTML video embeds in docs are YouTube-only; restrict `iframe src` to YouTube's
+    // own embed hosts so the shared xss whitelist below can't be used to embed arbitrary sites.
+    const IFRAME_ALLOWED_HOSTS = ["www.youtube.com", "www.youtube-nocookie.com"]
+
+    function isAllowedIframeSrc(value: string): boolean {
+        try {
+            const url = new URL(value)
+            return url.protocol === "https:" && IFRAME_ALLOWED_HOSTS.includes(url.hostname)
+        } catch {
+            return false
+        }
+    }
+
     function htmlEscape(content: string): string {
         return xss(content, {
             whiteList: {
@@ -95,6 +108,7 @@
                 h1: ["id", "class"], h2: ["id", "class"], h3: ["id", "class"],
                 h4: ["id", "class"], h5: ["id", "class"], h6: ["id", "class"],
                 hr: [],
+                iframe: ["src", "title", "width", "height", "allow", "allowfullscreen", "referrerpolicy", "frameborder", "class"],
                 img: ["src", "alt", "title", "width", "height", "class"],
                 kbd: [],
                 li: ["class"], ol: ["start", "class"], ul: ["class"],
@@ -114,6 +128,12 @@
                 button: ["type", "class", "aria-label"],
             },
             stripIgnoreTag: true,
+            onTagAttr: function (tag: string, name: string, value: string) {
+                if (tag === "iframe" && name === "src" && !isAllowedIframeSrc(value)) {
+                    return ""
+                }
+                return undefined
+            },
             onIgnoreTagAttr: function (_tag: string, name: string, value: string) {
                 if (name.startsWith("data-")) {
                     return name + "=\"" + escapeAttrValue(value) + "\""

--- a/ui/packages/design-system/tests/units/Data/KsMarkdown/KsMarkdown.test.ts
+++ b/ui/packages/design-system/tests/units/Data/KsMarkdown/KsMarkdown.test.ts
@@ -451,6 +451,46 @@ describe("KsMarkdown", () => {
         expect(wrapper.html()).not.toContain("onerror")
     })
 
+    test("renders iframe with a YouTube embed src", () => {
+        const wrapper = mount(KsMarkdown, {
+            props: {content: "<div class=\"video-container\">\n<iframe src=\"https://www.youtube.com/embed/abc123\" title=\"YouTube video player\" allowfullscreen></iframe>\n</div>"},
+            global: globalConfig,
+        })
+        const iframe = wrapper.find("iframe")
+        expect(iframe.exists()).toBe(true)
+        expect(iframe.attributes("src")).toBe("https://www.youtube.com/embed/abc123")
+    })
+
+    test("strips src from an iframe pointing at a non-YouTube host", () => {
+        const wrapper = mount(KsMarkdown, {
+            props: {content: "<iframe src=\"https://evil.example.com/phish\"></iframe>"},
+            global: globalConfig,
+        })
+        const iframe = wrapper.find("iframe")
+        expect(iframe.exists()).toBe(true)
+        expect(iframe.attributes("src")).toBeUndefined()
+    })
+
+    test("renders iframe with a youtube-nocookie.com embed src", () => {
+        const wrapper = mount(KsMarkdown, {
+            props: {content: "<iframe src=\"https://www.youtube-nocookie.com/embed/abc123\"></iframe>"},
+            global: globalConfig,
+        })
+        const iframe = wrapper.find("iframe")
+        expect(iframe.exists()).toBe(true)
+        expect(iframe.attributes("src")).toBe("https://www.youtube-nocookie.com/embed/abc123")
+    })
+
+    test("strips src from an iframe using http instead of https", () => {
+        const wrapper = mount(KsMarkdown, {
+            props: {content: "<iframe src=\"http://www.youtube.com/embed/abc123\"></iframe>"},
+            global: globalConfig,
+        })
+        const iframe = wrapper.find("iframe")
+        expect(iframe.exists()).toBe(true)
+        expect(iframe.attributes("src")).toBeUndefined()
+    })
+
     test("injects custom-component inner HTML verbatim when xssProtection is disabled", () => {
         // markRaw prevents Vue's reactive() from wrapping the component definition
         // when it flows through @vue/test-utils' reactive props bag — without it, mounting

--- a/ui/src/components/ContextInfoContent.vue
+++ b/ui/src/components/ContextInfoContent.vue
@@ -1,8 +1,9 @@
 <template>
     <div class="wrapper">
-        <div v-if="title || $slots['back-button']" class="title">
+        <div v-if="title || $slots['back-button'] || $slots['header']" class="title">
             <slot name="back-button" />
             <h2 v-if="title">{{ title }}</h2>
+            <slot name="header" />
         </div>
         <div class="content" ref="contentRef">
             <slot />
@@ -49,7 +50,8 @@
             overflow: hidden;
             margin-bottom: 0;
             margin-top: 0;
-            width: 100%;
+            flex: 1;
+            min-width: 0;
             line-height: 1.2;
             font-weight: var(--ks-font-weight-semibold);
         }

--- a/ui/src/components/dashboard/components/Header.vue
+++ b/ui/src/components/dashboard/components/Header.vue
@@ -85,7 +85,7 @@
         ALLOWED_CREATION_ROUTES.includes(String(route.name)) && isAllowedDashboard.value,
     )
 
-    const routeInfo = computed(() => ({title: props.dashboard?.title ?? t("overview")}))
+    const routeInfo = computed(() => ({title: props.dashboard?.title || t("overview")}))
 
     import useRouteContext from "../../../composables/useRouteContext"
     useRouteContext(routeInfo)

--- a/ui/src/components/docs/ContextDocs.vue
+++ b/ui/src/components/docs/ContextDocs.vue
@@ -59,6 +59,7 @@
     import ContextDocsSearch from "./ContextDocsSearch.vue"
     import ContextInfoContent from "../ContextInfoContent.vue"
     import ContextChildTableOfContents from "./ContextChildTableOfContents.vue"
+    import {removeMDXImports, extractMultilineJSXComponents, replaceSelfClosingTagsWithOpenClose} from "./docsUtils"
 
     import {useI18n} from "vue-i18n"
     const {t} = useI18n({useScope: "global"})
@@ -134,92 +135,6 @@
         if (!canGoBack.value) return
         currentHistoryIndex.value--
         docStore.docPath = docHistory.value[currentHistoryIndex.value]
-    }
-
-    function removeMDXImports(content: string): string {
-        // we want to only remove lines that are not in a code block
-        // so we isolate code blocks first
-        const contentArray = content.split("```")
-        for(let i = 0; i < contentArray.length; i++){
-            // if the index is even, it's outside a code block
-            if(i % 2 === 0){
-                // remove lines that start with `import`
-                // to keep compatibility with mdx files
-                // without splitting and rejoining since it would
-                // create huge arrays just to destroy them right after
-                contentArray[i] = contentArray[i].replaceAll(/import [\s\S]+? from ['"][\s\S]+?['"];?/g, "")
-            }
-        }
-        return contentArray.join("```")
-    }
-
-    function extractMultilineJSXComponents(content: string) {
-        // first, find every line that start with < and a capital letter, and that doesn't end with />
-        const lines = content.split("\n")
-        const linesToRemove: number[] = []
-        const removedComponents: Record<number, string> = {}
-        let startOfBlockLine = -1
-        let componentName = ""
-        let insideCodeBlock = false
-        let currentBlockLines: number[] = []
-
-        for(let i = 0; i < lines.length; i++){
-            if(insideCodeBlock){
-                if(lines[i].match(/^```/)){
-                    insideCodeBlock = false
-                }
-                continue
-            } else {
-                if(lines[i].match(/^```/)){
-                    insideCodeBlock = true
-                    continue
-                }
-            }
-
-            if(startOfBlockLine > -1){
-                // if an empty line appears, MDX will consider it a stop in the JSX
-                if(lines[i].trim() === ""){
-                    startOfBlockLine = -1
-                    componentName = ""
-                    currentBlockLines = []
-                    continue
-                }
-
-                currentBlockLines.push(i)
-
-                // if we have started a block, let's check if this line is the end of it.
-                // if so, we remove it and stop the next iterations until we find a new block
-                if(lines[i].match(/^\/>/)){
-                    removedComponents[startOfBlockLine] = lines.slice(startOfBlockLine, i).join("\n") + `\n></${componentName}>`
-                    startOfBlockLine = -1
-                    componentName = ""
-                    // and only once we are sure the block is closed,
-                    // do we add the lines to remove
-                    linesToRemove.push(...currentBlockLines)
-                    currentBlockLines = []
-                }
-            }
-
-            if(lines[i].match(/^<([A-Z][\w]*)\b(?![^>]*\/>).*$/)){
-                componentName = lines[i].match(/^<([A-Z][\w]*)/)?.[1] ?? ""
-                startOfBlockLine = i
-            }
-        }
-
-        // in place of each removed block, we add a placeholder with the component name to keep track of where it was in the doc
-        for(const lineIndex in removedComponents){
-            lines[lineIndex] = `<!-- ${removedComponents[lineIndex]} -->`
-        }
-        return {
-            content: lines.filter((_, i) => !linesToRemove.includes(i)).join("\n"),
-            removedComponents: removedComponents,
-        }
-    }
-
-    function replaceSelfClosingTagsWithOpenClose(content: string): string {
-        // we want to replace every self closing tag with an open and close tag
-        // to keep compatibility with mdx files that use self closing tags for custom components
-        return content.replaceAll(/<([A-Z][\w]*)\b([^>]*)\/>/g, "<$1$2></$1>\n")
     }
 
     async function setDocPageFromResponse(response: {metadata?: any, content:string}) {

--- a/ui/src/components/docs/Docs.vue
+++ b/ui/src/components/docs/Docs.vue
@@ -15,6 +15,7 @@
 <script setup lang="ts">
     import {computed,ref,watch} from "vue"
     import TopNavBar from "../layout/TopNavBar.vue"
+    import useRouteContext from "../../composables/useRouteContext"
     import {useDocStore} from "../../stores/doc"
     import DocsLayout from "./DocsLayout.vue"
     import Toc from "./Toc.vue"
@@ -67,6 +68,8 @@
     const routeInfo = computed(() => ({
         title: docStore.pageMetadata?.title ?? t("docs"),
     }))
+
+    useRouteContext(routeInfo)
 
     watch(
         () => route.params.path,

--- a/ui/src/components/docs/Docs.vue
+++ b/ui/src/components/docs/Docs.vue
@@ -5,9 +5,7 @@
             <Toc />
         </template>
         <template #content>
-            <template>
-                <KsMarkdown class="markdown" :content="markdownContent" :components="markdownComponents" />
-            </template>
+            <KsMarkdown class="markdown" :content="markdownContent" :components="markdownComponents" />
         </template>
     </DocsLayout>
 </template>
@@ -36,6 +34,7 @@
     import ProseA from "../content/ProseA.vue"
     import ChildTableOfContents from "../content/ChildTableOfContents.vue"
     import ChildCard from "../content/ChildCard.vue"
+    import {removeMDXImports, extractMultilineJSXComponents, replaceSelfClosingTagsWithOpenClose} from "./docsUtils"
 
     const markdownComponents = {
         a: ProseA,
@@ -72,15 +71,20 @@
     useRouteContext(routeInfo)
 
     watch(
-        () => route.params.path,
-        async () => {
-            const response = await docStore.fetchResource(path.value ? `/${path.value}` : "")
+        [() => route.params.path, () => docStore.resourceUrlTemplate],
+        async ([, resourceUrlTemplate]) => {
+            if (!resourceUrlTemplate) return
+
+            // the route already consumes the "docs" path segment, so it must be added back here for the API lookup
+            const response = await docStore.fetchResource(path.value ? `/docs/${path.value}` : "/docs")
             docStore.pageMetadata = response.metadata
             let content = response.content
             if (!("canShare" in navigator)) {
                 content = content.replaceAll(/\s*web-share\s*/g, "")
             }
-            markdownContent.value = content
+            content = removeMDXImports(content)
+            const {content: cleanedContent} = extractMultilineJSXComponents(content)
+            markdownContent.value = replaceSelfClosingTagsWithOpenClose(cleanedContent)
         },
         {immediate: true},
     )

--- a/ui/src/components/docs/Toc.vue
+++ b/ui/src/components/docs/Toc.vue
@@ -31,7 +31,7 @@
 </template>
 
 <script setup lang="ts">
-    import {ref, computed, onMounted} from "vue"
+    import {ref, computed, watch} from "vue"
     import {useDocStore} from "../../stores/doc"
     import RecursiveToc from "./RecursiveToc.vue"
     import ArrowRight from "vue-material-design-icons/ArrowRight.vue"
@@ -120,9 +120,14 @@
         ])
     })
 
-    onMounted(async () => {
-        rawStructure.value = await docStore.children()
-    })
+    watch(
+        () => docStore.resourceUrlTemplate,
+        async (resourceUrlTemplate) => {
+            if (!resourceUrlTemplate) return
+            rawStructure.value = await docStore.children()
+        },
+        {immediate: true},
+    )
 
     const search = async (q: string, cb: (results: SearchResult[]) => void) => {
         cb(await docStore.search({q}))

--- a/ui/src/components/docs/docsUtils.ts
+++ b/ui/src/components/docs/docsUtils.ts
@@ -41,3 +41,89 @@ export const DISABLED_PAGES = [
     "docs/terraform/guides",
     "docs/terraform/resources",
 ]
+
+export function removeMDXImports(content: string): string {
+    // we want to only remove lines that are not in a code block
+    // so we isolate code blocks first
+    const contentArray = content.split("```")
+    for(let i = 0; i < contentArray.length; i++){
+        // if the index is even, it's outside a code block
+        if(i % 2 === 0){
+            // remove lines that start with `import`
+            // to keep compatibility with mdx files
+            // without splitting and rejoining since it would
+            // create huge arrays just to destroy them right after
+            contentArray[i] = contentArray[i].replaceAll(/import [\s\S]+? from ['"][\s\S]+?['"];?/g, "")
+        }
+    }
+    return contentArray.join("```")
+}
+
+export function extractMultilineJSXComponents(content: string) {
+    // first, find every line that start with < and a capital letter, and that doesn't end with />
+    const lines = content.split("\n")
+    const linesToRemove: number[] = []
+    const removedComponents: Record<number, string> = {}
+    let startOfBlockLine = -1
+    let componentName = ""
+    let insideCodeBlock = false
+    let currentBlockLines: number[] = []
+
+    for(let i = 0; i < lines.length; i++){
+        if(insideCodeBlock){
+            if(lines[i].match(/^```/)){
+                insideCodeBlock = false
+            }
+            continue
+        } else {
+            if(lines[i].match(/^```/)){
+                insideCodeBlock = true
+                continue
+            }
+        }
+
+        if(startOfBlockLine > -1){
+            // if an empty line appears, MDX will consider it a stop in the JSX
+            if(lines[i].trim() === ""){
+                startOfBlockLine = -1
+                componentName = ""
+                currentBlockLines = []
+                continue
+            }
+
+            currentBlockLines.push(i)
+
+            // if we have started a block, let's check if this line is the end of it.
+            // if so, we remove it and stop the next iterations until we find a new block
+            if(lines[i].match(/^\/>/)){
+                removedComponents[startOfBlockLine] = lines.slice(startOfBlockLine, i).join("\n") + `\n></${componentName}>`
+                startOfBlockLine = -1
+                componentName = ""
+                // and only once we are sure the block is closed,
+                // do we add the lines to remove
+                linesToRemove.push(...currentBlockLines)
+                currentBlockLines = []
+            }
+        }
+
+        if(lines[i].match(/^<([A-Z][\w]*)\b(?![^>]*\/>).*$/)){
+            componentName = lines[i].match(/^<([A-Z][\w]*)/)?.[1] ?? ""
+            startOfBlockLine = i
+        }
+    }
+
+    // in place of each removed block, we add a placeholder with the component name to keep track of where it was in the doc
+    for(const lineIndex in removedComponents){
+        lines[lineIndex] = `<!-- ${removedComponents[lineIndex]} -->`
+    }
+    return {
+        content: lines.filter((_, i) => !linesToRemove.includes(i)).join("\n"),
+        removedComponents: removedComponents,
+    }
+}
+
+export function replaceSelfClosingTagsWithOpenClose(content: string): string {
+    // we want to replace every self closing tag with an open and close tag
+    // to keep compatibility with mdx files that use self closing tags for custom components
+    return content.replaceAll(/<([A-Z][\w]*)\b([^>]*)\/>/g, "<$1$2></$1>\n")
+}

--- a/ui/src/components/flows/FlowExecutions.vue
+++ b/ui/src/components/flows/FlowExecutions.vue
@@ -4,6 +4,7 @@
         :flowId="flowStore.flow?.id"
         :topbar="false"
         :defaultScopeFilter="false"
+        :embed="embed"
         filter
     />
 </template>
@@ -13,6 +14,10 @@
 
     import {useFlowStore} from "../../stores/flow"
     const flowStore = useFlowStore()
+
+    defineProps<{
+        embed?: boolean;
+    }>()
 
     defineOptions({inheritAttrs: false})
 </script>

--- a/ui/src/components/flows/FlowRoot.vue
+++ b/ui/src/components/flows/FlowRoot.vue
@@ -35,9 +35,10 @@
     import DemoAuditLogs from "../demo/AuditLogs.vue"
     import {useAuthStore} from "override/stores/auth"
     import {useMiscStore} from "override/stores/misc"
-    import {computed, onBeforeUnmount, onMounted, onUnmounted, ref, watch} from "vue"
+    import {computed, onBeforeUnmount, onUnmounted, ref, watch} from "vue"
     import {useRoute, useRouter} from "vue-router"
     import {useI18n} from "vue-i18n"
+    import useRouteContext from "../../composables/useRouteContext"
 
     export interface Tab {
         name: string
@@ -106,6 +107,7 @@
                     name: "executions",
                     component: FlowExecutions,
                     title: t("executions"),
+                    props: {embed: true},
                 })
             }
 
@@ -232,18 +234,7 @@
 
         const ready = computed(() => user.value && flowStore.flow)
 
-        // RouteContext mixin: update document title on route change
-        function handleTitle() {
-            let baseTitle: string
-            if (document.title.lastIndexOf("|") > 0) {
-                baseTitle = document.title.substring(document.title.lastIndexOf("|") + 1)
-            } else {
-                baseTitle = document.title
-            }
-            document.title = routeInfo.value.title + " | " + baseTitle
-        }
-
-        watch(() => route.fullPath, () => handleTitle())
+        useRouteContext(routeInfo)
 
         watch(tabs, () => syncTabsToStore(), {immediate: true, deep: true})
 
@@ -291,8 +282,6 @@
         // NOTE: Flow creation component is ./FlowCreate.vue
         flowStore.isCreating = false
         load()
-
-        onMounted(() => handleTitle())
 
         onBeforeUnmount(() => {
             routeTabsStore.clearTabsIfOwner(tabsOwnerId)

--- a/ui/src/components/flows/Flows.vue
+++ b/ui/src/components/flows/Flows.vue
@@ -314,11 +314,13 @@
         namespace?: string;
         id?: string | null;
         defaultScopeFilter?: boolean,
+        embed?: boolean;
     }>(), {
         topbar: true,
         namespace: undefined,
         id: undefined,
         defaultScopeFilter: false,
+        embed: false,
     })
 
     const flowStore = useFlowStore()
@@ -398,7 +400,7 @@
 
     const routeInfo = computed(() => ({title: t("flows")}))
 
-    useRouteContext(routeInfo)
+    useRouteContext(routeInfo, props.embed)
 
     const dataTable = useTemplateRef("dataTable")
 

--- a/ui/src/components/namespaces/utils/useHelpers.ts
+++ b/ui/src/components/namespaces/utils/useHelpers.ts
@@ -107,6 +107,7 @@ export function useHelpers() {
                 namespace: namespace.value,
                 topbar: false,
                 defaultScopeFilter: false,
+                embed: true,
             },
         },
         {
@@ -117,7 +118,7 @@ export function useHelpers() {
                 namespace: namespace.value,
                 topbar: false,
                 visibleCharts: true,
-                embed: false,
+                embed: true,
                 defaultScopeFilter: false,
             },
         },

--- a/ui/src/composables/useRouteContext.ts
+++ b/ui/src/composables/useRouteContext.ts
@@ -1,24 +1,19 @@
 import {Ref, watch} from "vue"
-import {useRoute} from "vue-router"
 
 export default function useRouteContext(routeInfo: Ref<{title: string}>, embed: boolean = false) {
-    const route = useRoute()
-
     function handleTitle(){
         if(!embed) {
             let baseTitle
 
-            if (document.title.lastIndexOf("|") > 0) {
-                baseTitle = document.title.substring(document.title.lastIndexOf("|") + 1)
+            if (document.title.lastIndexOf("|") >= 0) {
+                baseTitle = document.title.substring(document.title.lastIndexOf("|") + 1).trim()
             } else {
                 baseTitle = document.title
             }
 
-            document.title = routeInfo.value?.title + " | " + baseTitle
+            document.title = (routeInfo.value?.title ?? "") + " | " + baseTitle
         }
     }
 
-    watch(() => route, () => {
-        handleTitle()
-    }, {immediate: true})
+    watch(() => routeInfo.value?.title, handleTitle, {immediate: true})
 }

--- a/ui/src/translations/de.json
+++ b/ui/src/translations/de.json
@@ -36,7 +36,8 @@
     "Default page": "Standardseite",
     "confirmation": "Bestätigung",
     "common": {
-      "back": "Zurück"
+      "back": "Zurück",
+      "openInNewTab": "In neuer Registerkarte öffnen"
     },
     "delete confirm": "Sind Sie sicher, dass Sie <code>{name}</code> löschen möchten?",
     "outdated revision save confirmation": {

--- a/ui/src/translations/en.json
+++ b/ui/src/translations/en.json
@@ -36,7 +36,8 @@
     "Default page": "Default page",
     "confirmation": "Confirmation",
     "common": {
-      "back": "Back"
+      "back": "Back",
+      "openInNewTab": "Open in new tab"
     },
     "delete confirm": "Are you sure you want to delete <code>{name}</code>?",
     "outdated revision save confirmation": {

--- a/ui/src/translations/es.json
+++ b/ui/src/translations/es.json
@@ -36,7 +36,8 @@
     "Default page": "Página predeterminada",
     "confirmation": "Confirmación",
     "common": {
-      "back": "Atrás"
+      "back": "Atrás",
+      "openInNewTab": "Abrir en nueva pestaña"
     },
     "delete confirm": "¿Estás seguro de eliminar <code>{name}</code>?",
     "outdated revision save confirmation": {

--- a/ui/src/translations/fr.json
+++ b/ui/src/translations/fr.json
@@ -36,7 +36,8 @@
     "Default page": "Page par défaut",
     "confirmation": "Confirmation",
     "common": {
-      "back": "Retour"
+      "back": "Retour",
+      "openInNewTab": "Ouvrir dans un nouvel onglet"
     },
     "delete confirm": "Êtes-vous sur de vouloir effacer <code>{name}</code> ?",
     "outdated revision save confirmation": {

--- a/ui/src/translations/hi.json
+++ b/ui/src/translations/hi.json
@@ -36,7 +36,8 @@
     "Default page": "पूर्व-निर्धारित पृष्ठ",
     "confirmation": "पुष्टि",
     "common": {
-      "back": "वापस"
+      "back": "वापस",
+      "openInNewTab": "नए टैब में खोलें"
     },
     "delete confirm": "क्या आप वाकई <code>{name}</code> को हटाना चाहते हैं?",
     "outdated revision save confirmation": {

--- a/ui/src/translations/it.json
+++ b/ui/src/translations/it.json
@@ -36,7 +36,8 @@
     "Default page": "Pagina predefinita",
     "confirmation": "Conferma",
     "common": {
-      "back": "Indietro"
+      "back": "Indietro",
+      "openInNewTab": "Apri in una nuova scheda"
     },
     "delete confirm": "Sei sicuro di voler eliminare <code>{name}</code>?",
     "outdated revision save confirmation": {

--- a/ui/src/translations/ja.json
+++ b/ui/src/translations/ja.json
@@ -36,7 +36,8 @@
     "Default page": "デフォルトページ",
     "confirmation": "確認",
     "common": {
-      "back": "戻る"
+      "back": "戻る",
+      "openInNewTab": "新しいタブで開く"
     },
     "delete confirm": "<code>{name}</code>を削除してもよろしいですか？",
     "outdated revision save confirmation": {

--- a/ui/src/translations/ko.json
+++ b/ui/src/translations/ko.json
@@ -36,7 +36,8 @@
     "Default page": "기본 페이지",
     "confirmation": "확인",
     "common": {
-      "back": "뒤로"
+      "back": "뒤로",
+      "openInNewTab": "새 탭에서 열기"
     },
     "delete confirm": "<code>{name}</code>을(를) 삭제하시겠습니까?",
     "outdated revision save confirmation": {

--- a/ui/src/translations/pl.json
+++ b/ui/src/translations/pl.json
@@ -36,7 +36,8 @@
     "Default page": "Domyślna strona",
     "confirmation": "Potwierdzenie",
     "common": {
-      "back": "Wstecz"
+      "back": "Wstecz",
+      "openInNewTab": "Otwórz w nowej karcie"
     },
     "delete confirm": "Czy na pewno chcesz usunąć <code>{name}</code>?",
     "outdated revision save confirmation": {

--- a/ui/src/translations/pt.json
+++ b/ui/src/translations/pt.json
@@ -36,7 +36,8 @@
     "Default page": "Página padrão",
     "confirmation": "Confirmação",
     "common": {
-      "back": "Voltar"
+      "back": "Voltar",
+      "openInNewTab": "Abrir em nova aba"
     },
     "delete confirm": "Tem certeza de que deseja deletar <code>{name}</code>?",
     "outdated revision save confirmation": {

--- a/ui/src/translations/pt_BR.json
+++ b/ui/src/translations/pt_BR.json
@@ -36,7 +36,8 @@
     "Default page": "Página padrão",
     "confirmation": "Confirmação",
     "common": {
-      "back": "Voltar"
+      "back": "Voltar",
+      "openInNewTab": "Abrir em nova aba"
     },
     "delete confirm": "Tem certeza de que deseja excluir <code>{name}</code>?",
     "outdated revision save confirmation": {

--- a/ui/src/translations/ru.json
+++ b/ui/src/translations/ru.json
@@ -36,7 +36,8 @@
     "Default page": "Страница по умолчанию",
     "confirmation": "Подтверждение",
     "common": {
-      "back": "Назад"
+      "back": "Назад",
+      "openInNewTab": "Открыть в новой вкладке"
     },
     "delete confirm": "Вы уверены, что хотите удалить <code>{name}</code>?",
     "outdated revision save confirmation": {

--- a/ui/src/translations/zh_CN.json
+++ b/ui/src/translations/zh_CN.json
@@ -36,7 +36,8 @@
     "Default page": "默认页面",
     "confirmation": "确认",
     "common": {
-      "back": "返回"
+      "back": "返回",
+      "openInNewTab": "在新标签页中打开"
     },
     "delete confirm": "确定要删除 <code>{name}</code> 吗？",
     "outdated revision save confirmation": {

--- a/ui/tests/unit/components/dashboard/Header.spec.ts
+++ b/ui/tests/unit/components/dashboard/Header.spec.ts
@@ -1,0 +1,39 @@
+import {describe, it, expect, beforeEach, vi} from "vitest"
+import {createI18n} from "vue-i18n"
+import {shallowMount} from "@vue/test-utils"
+
+vi.mock("vue-router", () => ({
+    useRoute: () => ({name: "home"}),
+}))
+
+vi.mock("override/stores/auth", () => ({
+    useAuthStore: () => ({user: {isAllowed: () => false}}),
+}))
+
+import Header from "../../../../src/components/dashboard/components/Header.vue"
+
+const i18n = createI18n({legacy: false, locale: "en", messages: {en: {overview: "Overview"}}, missingWarn: false, fallbackWarn: false})
+
+function mountHeader(dashboard: any) {
+    return shallowMount(Header, {props: {dashboard}, global: {plugins: [i18n]}})
+}
+
+describe("dashboard Header.vue — browser tab title", () => {
+    beforeEach(() => {
+        document.title = "Kestra EE"
+    })
+
+    it("falls back to 'Overview' when the dashboard title is an empty string (not just undefined)", () => {
+        const wrapper = mountHeader({id: "default", title: "", deleted: false, charts: []})
+
+        expect(document.title).toBe("Overview | Kestra EE")
+        wrapper.unmount()
+    })
+
+    it("uses the dashboard's title once it is set", () => {
+        const wrapper = mountHeader({id: "default", title: "Default Dashboard", deleted: false, charts: []})
+
+        expect(document.title).toBe("Default Dashboard | Kestra EE")
+        wrapper.unmount()
+    })
+})

--- a/ui/tests/unit/components/docs/Docs.spec.ts
+++ b/ui/tests/unit/components/docs/Docs.spec.ts
@@ -1,0 +1,120 @@
+import {describe, it, expect, vi, beforeEach, afterEach} from "vitest"
+import {nextTick, reactive} from "vue"
+import {createI18n} from "vue-i18n"
+import {shallowMount, flushPromises, VueWrapper} from "@vue/test-utils"
+
+// On a fresh browser-tab boot (e.g. the docs pop-out link's target="_blank" nav),
+// Docs.vue can mount before App.vue's async loadGeneralResources() has initialized
+// docStore.resourceUrlTemplate. Fetching before that races and throws
+// "Resource URL template not initialized" (see stores/doc.ts), leaving the page
+// permanently empty. The fix: gate the fetch on resourceUrlTemplate and re-fire once
+// it becomes available.
+const routeParams: {path?: string} = {}
+vi.mock("vue-router", () => ({
+    // path/fullPath/name are only exercised by DocsLayout (used un-stubbed in the
+    // MDX-cleanup test below) — the other tests only read params.path.
+    useRoute: () => ({params: routeParams, path: "/main/docs", fullPath: "/main/docs", name: "docs/view"}),
+}))
+
+const fetchResource = vi.fn().mockResolvedValue({metadata: {title: "Outputs"}, content: "doc content"})
+const docStoreState = reactive<{resourceUrlTemplate?: string, pageMetadata?: any}>({
+    resourceUrlTemplate: undefined,
+    pageMetadata: undefined,
+})
+vi.mock("../../../../src/stores/doc", () => ({
+    useDocStore: () => Object.assign(docStoreState, {fetchResource}),
+}))
+
+import Docs from "../../../../src/components/docs/Docs.vue"
+
+const i18n = createI18n({legacy: false, locale: "en", messages: {en: {docs: "Docs"}}, missingWarn: false, fallbackWarn: false})
+
+let wrapper: VueWrapper
+
+function mountDocs() {
+    wrapper = shallowMount(Docs, {global: {plugins: [i18n]}})
+    return wrapper
+}
+
+describe("Docs.vue — fetch gated on resourceUrlTemplate", () => {
+    beforeEach(() => {
+        routeParams.path = undefined
+        docStoreState.resourceUrlTemplate = undefined
+        docStoreState.pageMetadata = undefined
+        fetchResource.mockClear()
+    })
+
+    afterEach(() => {
+        wrapper?.unmount()
+    })
+
+    it("does not fetch the doc resource while the resource URL template is not yet initialized", () => {
+        mountDocs()
+        expect(fetchResource).not.toHaveBeenCalled()
+    })
+
+    it("fetches the doc resource once the resource URL template becomes available", async () => {
+        mountDocs()
+        expect(fetchResource).not.toHaveBeenCalled()
+
+        docStoreState.resourceUrlTemplate = "http://localhost/api/v1{path}/versions/1.0.0"
+        await nextTick()
+
+        expect(fetchResource).toHaveBeenCalledTimes(1)
+    })
+
+    it("fetches immediately when the resource URL template is already set at mount", () => {
+        docStoreState.resourceUrlTemplate = "http://localhost/api/v1{path}/versions/1.0.0"
+        mountDocs()
+
+        expect(fetchResource).toHaveBeenCalledTimes(1)
+    })
+
+    // The remote docs API keys every resource under its own "docs/" segment
+    // (e.g. "docs/installation"), but the route "/docs/:path" already consumes
+    // one "docs" segment for pretty URLs, so route.params.path never carries it.
+    // fetchResource must re-add the "docs/" prefix or every lookup 404s.
+    it("re-adds the docs/ prefix stripped by the route when fetching a sub-page", () => {
+        routeParams.path = "installation"
+        docStoreState.resourceUrlTemplate = "http://localhost/api/v1{path}/versions/1.0.0"
+        mountDocs()
+
+        expect(fetchResource).toHaveBeenCalledWith("/docs/installation")
+    })
+
+    it("fetches the docs/ root resource when there is no route path", () => {
+        docStoreState.resourceUrlTemplate = "http://localhost/api/v1{path}/versions/1.0.0"
+        mountDocs()
+
+        expect(fetchResource).toHaveBeenCalledWith("/docs")
+    })
+
+    // A bare <template> with no v-if/v-for/v-slot directive is not stripped by the
+    // Vue compiler and renders as a literal, inert HTML <template> element (never
+    // laid out or painted), silently hiding KsMarkdown's content in the browser.
+    it("does not wrap the markdown content in a bare template element", () => {
+        docStoreState.resourceUrlTemplate = "http://localhost/api/v1{path}/versions/1.0.0"
+        mountDocs()
+
+        expect(wrapper.html()).not.toContain("<template")
+    })
+
+    // The remote MDX source files carry a leftover `import ChildCard from "...astro"`
+    // line meant for the Astro-based docs site, not for KsMarkdown; ContextDocs.vue
+    // (the embedded "?" panel) already strips it, Docs.vue (the standalone page) must too.
+    it("strips leftover MDX import lines from fetched content before rendering", async () => {
+        fetchResource.mockResolvedValueOnce({
+            metadata: {title: "Installation"},
+            content: "import ChildCard from \"~/components/docs/ChildCard.astro\"\n\nHello world",
+        })
+        docStoreState.resourceUrlTemplate = "http://localhost/api/v1{path}/versions/1.0.0"
+        // DocsLayout renders its #content slot directly (no v-if guard), so unstubbing
+        // just it lets KsMarkdown's stub (still shallow) receive the real content prop.
+        wrapper = shallowMount(Docs, {global: {plugins: [i18n], stubs: {DocsLayout: false}}})
+        await flushPromises()
+
+        const markdown = wrapper.find("[content]")
+        expect(markdown.attributes("content")).not.toContain("ChildCard.astro")
+        expect(markdown.attributes("content")).toContain("Hello world")
+    })
+})

--- a/ui/tests/unit/components/docs/Toc.spec.ts
+++ b/ui/tests/unit/components/docs/Toc.spec.ts
@@ -1,0 +1,57 @@
+import {describe, it, expect, vi, beforeEach, afterEach} from "vitest"
+import {nextTick, reactive} from "vue"
+import {createI18n} from "vue-i18n"
+import {shallowMount, VueWrapper} from "@vue/test-utils"
+
+// Same fresh-tab-boot race as Docs.vue: Toc.vue used to fetch its sidebar structure
+// onMounted, which can fire before docStore.resourceUrlTemplate is initialized and
+// throw "Resource URL template not initialized". Gate on the template instead.
+const children = vi.fn().mockResolvedValue({})
+const docStoreState = reactive<{resourceUrlTemplate?: string}>({resourceUrlTemplate: undefined})
+vi.mock("../../../../src/stores/doc", () => ({
+    useDocStore: () => Object.assign(docStoreState, {children, search: vi.fn()}),
+}))
+
+import Toc from "../../../../src/components/docs/Toc.vue"
+
+const i18n = createI18n({legacy: false, locale: "en", messages: {en: {search: "Search"}}, missingWarn: false, fallbackWarn: false})
+
+let wrapper: VueWrapper
+
+function mountToc() {
+    wrapper = shallowMount(Toc, {global: {plugins: [i18n], stubs: {KsAutocomplete: true}}})
+    return wrapper
+}
+
+describe("Toc.vue — children fetch gated on resourceUrlTemplate", () => {
+    beforeEach(() => {
+        docStoreState.resourceUrlTemplate = undefined
+        children.mockClear()
+    })
+
+    afterEach(() => {
+        wrapper?.unmount()
+    })
+
+    it("does not fetch the doc tree while the resource URL template is not yet initialized", () => {
+        mountToc()
+        expect(children).not.toHaveBeenCalled()
+    })
+
+    it("fetches the doc tree once the resource URL template becomes available", async () => {
+        mountToc()
+        expect(children).not.toHaveBeenCalled()
+
+        docStoreState.resourceUrlTemplate = "http://localhost/api/v1{path}/versions/1.0.0"
+        await nextTick()
+
+        expect(children).toHaveBeenCalledTimes(1)
+    })
+
+    it("fetches immediately when the resource URL template is already set at mount", () => {
+        docStoreState.resourceUrlTemplate = "http://localhost/api/v1{path}/versions/1.0.0"
+        mountToc()
+
+        expect(children).toHaveBeenCalledTimes(1)
+    })
+})

--- a/ui/tests/unit/components/flows/FlowExecutions.spec.ts
+++ b/ui/tests/unit/components/flows/FlowExecutions.spec.ts
@@ -1,0 +1,27 @@
+import {describe, it, expect, vi} from "vitest"
+import {shallowMount} from "@vue/test-utils"
+
+vi.mock("../../../../src/stores/flow", () => ({
+    useFlowStore: () => ({flow: {id: "my_flow", namespace: "company.team"}}),
+}))
+
+import FlowExecutions from "../../../../src/components/flows/FlowExecutions.vue"
+import Executions from "../../../../src/components/executions/Executions.vue"
+
+function mountFlowExecutions(embed?: boolean) {
+    return shallowMount(FlowExecutions, {
+        props: embed === undefined ? {} : {embed},
+    })
+}
+
+describe("FlowExecutions.vue — embed prop forwarding", () => {
+    it("forwards embed:true to Executions so it doesn't clobber the flow's title", () => {
+        const wrapper = mountFlowExecutions(true)
+        expect(wrapper.findComponent(Executions).props("embed")).toBe(true)
+    })
+
+    it("forwards embed:false/undefined to Executions (standalone behavior unchanged)", () => {
+        const wrapper = mountFlowExecutions()
+        expect(wrapper.findComponent(Executions).props("embed")).toBeFalsy()
+    })
+})

--- a/ui/tests/unit/components/namespaces/useHelpers.spec.ts
+++ b/ui/tests/unit/components/namespaces/useHelpers.spec.ts
@@ -1,0 +1,38 @@
+import {describe, it, expect, vi} from "vitest"
+import {defineComponent, h} from "vue"
+import {mount} from "@vue/test-utils"
+import {createI18n} from "vue-i18n"
+
+vi.mock("vue-router", () => ({
+    useRoute: () => ({params: {id: "company.team"}}),
+}))
+
+import {useHelpers} from "../../../../src/components/namespaces/utils/useHelpers"
+
+const i18n = createI18n({legacy: false, locale: "en", messages: {en: {}}, missingWarn: false, fallbackWarn: false})
+
+function mountHelpers() {
+    let captured: ReturnType<typeof useHelpers>
+    const wrapper = mount(defineComponent({
+        setup() {
+            captured = useHelpers()
+            return () => h("div")
+        },
+    }), {global: {plugins: [i18n]}})
+    wrapper.unmount()
+    return captured!
+}
+
+describe("namespaces useHelpers — embedded tab title suppression", () => {
+    it("flows tab forwards embed:true so Flows.vue doesn't clobber the namespace title", () => {
+        const {tabs} = mountHelpers()
+        const flowsTab = tabs.find((tab) => tab.name === "flows")
+        expect(flowsTab?.props?.embed).toBe(true)
+    })
+
+    it("executions tab forwards embed:true so Executions.vue doesn't clobber the namespace title", () => {
+        const {tabs} = mountHelpers()
+        const executionsTab = tabs.find((tab) => tab.name === "executions")
+        expect(executionsTab?.props?.embed).toBe(true)
+    })
+})

--- a/ui/tests/unit/composables/useRouteContext.spec.ts
+++ b/ui/tests/unit/composables/useRouteContext.spec.ts
@@ -1,0 +1,65 @@
+import {beforeEach, afterEach, describe, expect, it} from "vitest"
+import {defineComponent, h, nextTick, ref, type Ref} from "vue"
+import {mount, VueWrapper} from "@vue/test-utils"
+import useRouteContext from "../../../src/composables/useRouteContext"
+
+function mountRouteContext(routeInfo: Ref<{title: string}>, embed = false) {
+    return mount(defineComponent({
+        setup() {
+            useRouteContext(routeInfo, embed)
+        },
+        render: () => h("div"),
+    }))
+}
+
+describe("useRouteContext", () => {
+    let wrapper: VueWrapper
+
+    beforeEach(() => {
+        document.title = "Kestra EE"
+    })
+
+    afterEach(() => {
+        wrapper?.unmount()
+    })
+
+    it("sets the title on mount", () => {
+        wrapper = mountRouteContext(ref({title: "Initial"}))
+        expect(document.title).toBe("Initial | Kestra EE")
+    })
+
+    it("updates the title when routeInfo.title changes after mount (async-loaded entity name)", async () => {
+        const routeInfo = ref({title: "Loading"})
+        wrapper = mountRouteContext(routeInfo)
+
+        routeInfo.value = {title: "Loaded Entity"}
+        await nextTick()
+
+        expect(document.title).toBe("Loaded Entity | Kestra EE")
+    })
+
+    it("does not accumulate whitespace across repeated title changes", async () => {
+        const routeInfo = ref({title: "First"})
+        wrapper = mountRouteContext(routeInfo)
+
+        routeInfo.value = {title: "Second"}
+        await nextTick()
+        routeInfo.value = {title: "Third"}
+        await nextTick()
+
+        expect(document.title).toBe("Third | Kestra EE")
+    })
+
+    it("does not touch document.title when embed is true", () => {
+        wrapper = mountRouteContext(ref({title: "Ignored"}), true)
+        expect(document.title).toBe("Kestra EE")
+    })
+
+    it("does not double the pipe when the base title starts with '|' (browser-trimmed leading space)", async () => {
+        document.title = "| Kestra EE"
+        const routeInfo = ref({title: "Default Dashboard"})
+        wrapper = mountRouteContext(routeInfo)
+
+        expect(document.title).toBe("Default Dashboard | Kestra EE")
+    })
+})

--- a/ui/tests/unit/setup.ts
+++ b/ui/tests/unit/setup.ts
@@ -40,6 +40,11 @@ if (typeof document !== "undefined" && typeof document.queryCommandSupported !==
 if (typeof document !== "undefined" && typeof document.execCommand !== "function") {
     (document as any).execCommand = () => false
 }
+// pdfjs-dist (pulled in transitively via PdfPreview.vue) constructs a DOMMatrix
+// at module load time, which jsdom doesn't provide.
+if (typeof globalThis.DOMMatrix === "undefined") {
+    (globalThis as any).DOMMatrix = class DOMMatrix {}
+}
 if (typeof window !== "undefined" && typeof window.matchMedia !== "function") {
     (window as any).matchMedia = (query: string) => ({
         matches: false,


### PR DESCRIPTION
- `useRouteContext` watched a non-reactive `route` ref, so its watch fired once at mount only: async-loaded entity names latched to a placeholder, and same-component param navigation (e.g. asset A -> B) never updated the tab title. Now watches `routeInfo.value?.title` reactively.
- Base-title parsing kept a leading space after `|`, so repeated title writes accumulated whitespace. Now trims before recomposing.
- Consolidate `FlowRoot`'s duplicate hand-rolled title logic onto `useRouteContext` instead of a second divergent mechanism.
- Thread an `embed` prop through `Flows`/`FlowExecutions` (and mark two namespace tab configs `embed: true`) so a component rendered as a nested tab doesn't clobber its parent's title.
- Add the missing `useRouteContext` call to `Docs.vue`.
- Dashboard `Header.vue`: fall back to the "Overview" label when the dashboard title is an empty string, not just null/undefined.

Companion PR: kestra-io/kestra-ee#9313 fix.