### PR TITLE
fix(jdbc): bound the H2 compiled jq-expression cache

### DIFF
--- a/jdbc-h2/build.gradle
+++ b/jdbc-h2/build.gradle
@@ -12,6 +12,7 @@ dependencies {
     implementation project(":queue-jdbc")
 
     implementation("io.micronaut.sql:micronaut-jooq")
+    implementation("com.github.ben-manes.caffeine:caffeine")
     runtimeOnly("com.h2database:h2")
 
     testAnnotationProcessor project(":processor")

--- a/jdbc-h2/src/main/java/io/kestra/runner/h2/H2Functions.java
+++ b/jdbc-h2/src/main/java/io/kestra/runner/h2/H2Functions.java
@@ -2,13 +2,14 @@ package io.kestra.runner.h2;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
 import java.util.stream.StreamSupport;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.NullNode;
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
 
 import io.kestra.core.serializers.JacksonMapper;
 
@@ -24,7 +25,17 @@ public final class H2Functions {
     }
 
     private static final Scope scope = Scope.newEmptyScope();
-    private static final ConcurrentHashMap<String, JsonQuery> QUERY_CACHE = new ConcurrentHashMap<>();
+
+    /**
+     * Caches compiled jq expressions to avoid recompiling on every row. The set of expressions is
+     * unbounded in practice because some are built from user-supplied label keys (see the
+     * {@code JQ_STRING(... CONCAT('... select(.key == "', {key}, '") ...'))} filters in the H2
+     * repository services), so the cache is size-bounded to keep memory usage stable.
+     */
+    private static final Cache<String, JsonQuery> QUERY_CACHE = Caffeine.newBuilder()
+        .maximumSize(1000)
+        .recordStats()
+        .build();
 
     static {
         BuiltinFunctionLoader.getInstance().loadFunctions(Versions.JQ_1_6, scope);
@@ -94,7 +105,7 @@ public final class H2Functions {
 
     @SneakyThrows
     private static List<JsonNode> jq(String value, String expression) {
-        JsonQuery q = QUERY_CACHE.computeIfAbsent(expression, H2Functions::compileQuery);
+        JsonQuery q = QUERY_CACHE.get(expression, H2Functions::compileQuery);
 
         final List<JsonNode> out = new ArrayList<>();
         JsonNode in = JacksonMapper.ofJson().readTree(value);

--- a/jdbc-h2/src/test/java/io/kestra/runner/h2/H2FunctionsTest.java
+++ b/jdbc-h2/src/test/java/io/kestra/runner/h2/H2FunctionsTest.java
@@ -1,8 +1,11 @@
 package io.kestra.runner.h2;
 
+import java.lang.reflect.Field;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
+
+import com.github.benmanes.caffeine.cache.Cache;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -103,5 +106,30 @@ class H2FunctionsTest {
 
         // Then — no match (injection neutralised), no exception
         assertThat(result).isNull();
+    }
+
+    @Test
+    void shouldBoundCacheSizeWhenManyDistinctExpressionsAreEvaluated() throws Exception {
+        // Given a payload and many distinct jq expressions, mimicking a user filtering by an
+        // unbounded number of distinct label keys (each distinct key yields a distinct expression).
+        String json = "{\"labels\":[{\"key\":\"safe\",\"value\":\"v\"}]}";
+        long maximumSize = 1000L;
+        int distinctExpressions = (int) (maximumSize * 5);
+
+        // When each distinct expression is compiled and cached
+        for (int i = 0; i < distinctExpressions; i++) {
+            H2Functions.jqString(json, ".labels[]? | select(.key == \"k" + i + "\") | .value");
+        }
+
+        // Then the compiled-query cache stays bounded instead of growing without limit
+        Cache<?, ?> queryCache = queryCache();
+        queryCache.cleanUp();
+        assertThat(queryCache.estimatedSize()).isLessThanOrEqualTo(maximumSize);
+    }
+
+    private static Cache<?, ?> queryCache() throws Exception {
+        Field field = H2Functions.class.getDeclaredField("QUERY_CACHE");
+        field.setAccessible(true);
+        return (Cache<?, ?>) field.get(null);
     }
 }


### PR DESCRIPTION

<!-- This is the only text meant to go upstream. It follows the repo PR template:
     Description, Related Issue, Backend Checklist, Additional Notes. The Frontend
     section is deleted because there are no frontend changes. -->


`H2Functions.QUERY_CACHE` was an unbounded `ConcurrentHashMap<String, JsonQuery>`
that is only ever populated (via `computeIfAbsent`) and never evicted. Its cache
key is the jq expression string, and some of those expressions are built from
user-supplied label keys: the H2 execution and flow repository filters emit
`JQ_STRING("value", CONCAT('.labels[]? | select(.key == "', <key>, '") | .value'))`,
so the runtime expression contains the label key the caller filtered on.

On the default H2 backend, an authenticated user who lists or searches executions
or flows while filtering by an increasing number of distinct label keys adds one
permanent map entry plus one retained compiled `JsonQuery` per distinct key, for
the JVM lifetime. Over time this grows the static map without bound and can
exhaust memory.

This replaces the unbounded map with a size-bounded Caffeine cache
(`maximumSize(1000)`), which keeps the recompilation-avoidance benefit that the
cache was introduced for while capping its memory footprint. `computeIfAbsent`
becomes `Cache#get(key, mappingFunction)`, which has the same "compile once, then
reuse" semantics for these always-valid, code-constructed expressions. The bound
mirrors the existing bounded-cache pattern already used elsewhere in the codebase
(for example `FlowWithDefaultCache`), so the size and `recordStats()` choices are
consistent with the rest of the project.

### Related Issue

No existing issue. This is a robustness fix for an unbounded cache on the default
H2 backend. Happy to open a tracking issue first if the maintainers prefer.

### Backend Checklist

- [x] Code compiles successfully and passes all checks
- [x] All unit and integration tests pass

### Additional Notes

- Scope is limited to `jdbc-h2`. The Postgres and MySQL backends do not use this
  helper, so no equivalent change is needed there.
- A regression test was added to the existing `H2FunctionsTest`: it evaluates many
  more distinct expressions than the cap and asserts the cache stays bounded.
- `com.github.ben-manes.caffeine:caffeine` is added to `jdbc-h2` as an
  `implementation` dependency, versionless, resolved through the enforced platform
  BOM exactly like the other modules that use Caffeine (scheduler, worker,
  webserver, core).

---

## Files changed

- `jdbc-h2/src/main/java/io/kestra/runner/h2/H2Functions.java` - swap the
  unbounded `ConcurrentHashMap` for a bounded Caffeine `Cache`
  (`maximumSize(1000).recordStats()`); `computeIfAbsent` -> `get(key, fn)`; update
  imports; add a Javadoc explaining why the cache must be bounded.
- `jdbc-h2/build.gradle` - add the versionless `caffeine` implementation
  dependency (pinned by the platform BOM).
- `jdbc-h2/src/test/java/io/kestra/runner/h2/H2FunctionsTest.java` - add one
  regression test (`shouldBoundCacheSizeWhenManyDistinctExpressionsAreEvaluated`)
  plus a small reflection helper; the existing tests are untouched.
