### PR TITLE
fix(core): guard null input in startsWith/endsWith Pebble filters

### DIFF
--- a/core/src/main/java/io/kestra/core/runners/pebble/filters/EndsWithFilter.java
+++ b/core/src/main/java/io/kestra/core/runners/pebble/filters/EndsWithFilter.java
@@ -1,5 +1,6 @@
 package io.kestra.core.runners.pebble.filters;
 
+import java.text.MessageFormat;
 import java.util.List;
 import java.util.Map;
 
@@ -23,6 +24,19 @@ public class EndsWithFilter implements Filter {
 
     @Override
     public Object apply(Object input, Map<String, Object> args, PebbleTemplate self, EvaluationContext context, int lineNumber) throws PebbleException {
+        if (input == null) {
+            return false;
+        }
+
+        if (args.get(ARGUMENT_VALUE) == null) {
+            throw new PebbleException(
+                null,
+                MessageFormat.format("The argument ''{0}'' is required.", ARGUMENT_VALUE),
+                lineNumber,
+                self.getName()
+            );
+        }
+
         String data = input.toString();
 
         return data.endsWith(args.get(ARGUMENT_VALUE).toString());

--- a/core/src/main/java/io/kestra/core/runners/pebble/filters/StartsWithFilter.java
+++ b/core/src/main/java/io/kestra/core/runners/pebble/filters/StartsWithFilter.java
@@ -1,5 +1,6 @@
 package io.kestra.core.runners.pebble.filters;
 
+import java.text.MessageFormat;
 import java.util.List;
 import java.util.Map;
 
@@ -23,6 +24,19 @@ public class StartsWithFilter implements Filter {
 
     @Override
     public Object apply(Object input, Map<String, Object> args, PebbleTemplate self, EvaluationContext context, int lineNumber) throws PebbleException {
+        if (input == null) {
+            return false;
+        }
+
+        if (args.get(ARGUMENT_VALUE) == null) {
+            throw new PebbleException(
+                null,
+                MessageFormat.format("The argument ''{0}'' is required.", ARGUMENT_VALUE),
+                lineNumber,
+                self.getName()
+            );
+        }
+
         String data = input.toString();
 
         return data.startsWith(args.get(ARGUMENT_VALUE).toString());

--- a/core/src/test/java/io/kestra/core/runners/pebble/filters/EndsWithFilterTest.java
+++ b/core/src/test/java/io/kestra/core/runners/pebble/filters/EndsWithFilterTest.java
@@ -11,6 +11,7 @@ import io.kestra.core.runners.VariableRenderer;
 import jakarta.inject.Inject;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @KestraTest
 class EndsWithFilterTest {
@@ -24,5 +25,22 @@ class EndsWithFilterTest {
         );
 
         assertThat(render).isTrue();
+    }
+
+    @Test
+    void shouldReturnFalseWhenInputIsNull() throws IllegalVariableEvaluationException {
+        // Given / When
+        String render = variableRenderer.render("{{ null | endsWith('x') }}", Map.of());
+
+        // Then
+        assertThat(render).isEqualTo("false");
+    }
+
+    @Test
+    void shouldThrowWhenValueArgumentIsNull() {
+        // Given / When / Then
+        assertThatThrownBy(() -> variableRenderer.render("{{ 'abc' | endsWith(value=null) }}", Map.of()))
+            .isInstanceOf(IllegalVariableEvaluationException.class)
+            .hasMessageContaining("The argument 'value' is required");
     }
 }

--- a/core/src/test/java/io/kestra/core/runners/pebble/filters/StartsWithFilterTest.java
+++ b/core/src/test/java/io/kestra/core/runners/pebble/filters/StartsWithFilterTest.java
@@ -11,6 +11,7 @@ import io.kestra.core.runners.VariableRenderer;
 import jakarta.inject.Inject;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @KestraTest
 class StartsWithFilterTest {
@@ -24,5 +25,22 @@ class StartsWithFilterTest {
         );
 
         assertThat(render).isTrue();
+    }
+
+    @Test
+    void shouldReturnFalseWhenInputIsNull() throws IllegalVariableEvaluationException {
+        // Given / When
+        String render = variableRenderer.render("{{ null | startsWith('x') }}", Map.of());
+
+        // Then
+        assertThat(render).isEqualTo("false");
+    }
+
+    @Test
+    void shouldThrowWhenValueArgumentIsNull() {
+        // Given / When / Then
+        assertThatThrownBy(() -> variableRenderer.render("{{ 'abc' | startsWith(value=null) }}", Map.of()))
+            .isInstanceOf(IllegalVariableEvaluationException.class)
+            .hasMessageContaining("The argument 'value' is required");
     }
 }


### PR DESCRIPTION


The `startsWith` and `endsWith` Pebble filters dereferenced both the piped input
and the `value` argument with no null handling:

```java
String data = input.toString();
return data.startsWith(args.get("value").toString());
```

So rendering a template where either side is null failed with an opaque
`NullPointerException` (surfaced to users as `IllegalVariableEvaluationException`):

- `{{ null | startsWith('x') }}` -> NPE on `input.toString()`
- `{{ 'abc' | startsWith(value=null) }}` -> NPE on `args.get("value").toString()`

(`endsWith` behaved identically.) In practice this bites any template that pipes a
possibly-unset variable through the filter, e.g. `{{ outputs.x.uri | startsWith('/') }}`
when `outputs.x` is absent.

Every other string filter in `io.kestra.core.runners.pebble.filters` already guards
null input first (`RegexMatchFilter`, `RegexReplaceFilter`, `RegexExtractFilter`,
`SubstringBeforeFilter`, `ReplaceFilter`, `SlugifyFilter`, ...). `startsWith` and
`endsWith` were the only two that did not.

This PR aligns both filters with the existing contract, mirroring the sibling
boolean filter `RegexMatchFilter` exactly:

- return `false` when the input is null;
- throw a `PebbleException` reporting the required `'value'` argument when it is
  missing or null.

Returning `false` (rather than `null`) matches how the other boolean-returning
filter in the package (`regexMatch`) behaves, so `startsWith`/`endsWith` stay
consistent with it while the string-transform filters keep returning `null`.

### Related Issue

No existing issue; this is a small robustness fix found while reading the filter
package. Happy to open a tracking issue first if the maintainers prefer.

### Backend Checklist

- [x] Code compiles successfully and passes all checks
- [x] All unit and integration tests pass

`./gradlew :core:test --tests "io.kestra.core.runners.pebble.filters.StartsWithFilterTest" --tests "io.kestra.core.runners.pebble.filters.EndsWithFilterTest"`
-> 6 tests passed, BUILD SUCCESSFUL. The two new tests fail on the current code
with the exact NPE and pass with the fix.

### Additional Notes

Scope is intentionally minimal: only the two filters that lacked the guard, plus a
regression test each. No behavior change for non-null inputs.

---

## Changed files

- `core/src/main/java/io/kestra/core/runners/pebble/filters/StartsWithFilter.java` (+14)
- `core/src/main/java/io/kestra/core/runners/pebble/filters/EndsWithFilter.java` (+14)
- `core/src/test/java/io/kestra/core/runners/pebble/filters/StartsWithFilterTest.java` (+18)
- `core/src/test/java/io/kestra/core/runners/pebble/filters/EndsWithFilterTest.java` (+18)
