### PR TITLE
fix(storage): surface a descriptive error when local storage cannot create parent directories

### DIFF
--- a/storage-local/src/main/java/io/kestra/storage/local/LocalStorage.java
+++ b/storage-local/src/main/java/io/kestra/storage/local/LocalStorage.java
@@ -209,10 +209,11 @@ public class LocalStorage implements StorageInterface {
     }
 
     private static URI putFile(URI uri, StorageObject storageObject, File file) throws IOException {
-        File parent = file.getParentFile();
-        if (!parent.exists()) {
-            parent.mkdirs();
-        }
+        // Files.createDirectories throws a descriptive exception (e.g. AccessDeniedException,
+        // FileAlreadyExistsException) when the parent hierarchy cannot be created, unlike
+        // File#mkdirs whose boolean result was previously ignored and let the subsequent
+        // FileOutputStream fail with a misleading FileNotFoundException.
+        Files.createDirectories(file.toPath().getParent());
 
         try (InputStream data = storageObject.inputStream(); OutputStream outStream = new FileOutputStream(file)) {
             byte[] buffer = new byte[8 * 1024];

--- a/storage-local/src/test/java/io/kestra/storage/local/LocalStorageTest.java
+++ b/storage-local/src/test/java/io/kestra/storage/local/LocalStorageTest.java
@@ -4,6 +4,7 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.nio.file.FileAlreadyExistsException;
 
 import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.jupiter.api.Test;
@@ -61,5 +62,34 @@ class LocalStorageTest extends StorageTestSuite {
             IllegalArgumentException.class,
             () -> storageInterface.get(IdUtils.create(), null, traversal)
         );
+    }
+
+    // When the parent directory hierarchy cannot be created (here: a regular file occupies a
+    // path segment), put must fail with a descriptive exception naming the offending path —
+    // not the misleading FileNotFoundException that surfaced while File#mkdirs' boolean
+    // result was ignored (see issue #17093).
+    @Test
+    void shouldFailWithDescriptiveErrorWhenParentDirectoryCannotBeCreated() throws URISyntaxException, IOException {
+        // Given: a regular file at the path where the parent directory would be created
+        String tenantId = IdUtils.create();
+        storageInterface.put(
+            tenantId,
+            null,
+            new URI("/parent-conflict/blocking"),
+            new ByteArrayInputStream("i am a file, not a directory".getBytes())
+        );
+
+        // When: putting an object whose parent path traverses that regular file
+        // Then: the failure names the conflicting path instead of a misleading "not found"
+        FileAlreadyExistsException exception = assertThrows(
+            FileAlreadyExistsException.class,
+            () -> storageInterface.put(
+                tenantId,
+                null,
+                new URI("/parent-conflict/blocking/child.ion"),
+                new ByteArrayInputStream("Hello World".getBytes())
+            )
+        );
+        assertTrue(exception.getMessage().contains("blocking"));
     }
 }


### PR DESCRIPTION
### ✨ Description

`LocalStorage.putFile()` ignored the boolean result of `File#mkdirs`, so any failure to create the parent directory hierarchy surfaced later as a misleading `FileNotFoundException (No such file or directory)` from `FileOutputStream` pointing users at a path problem when the real cause was something else entirely.

This PR replaces the ignored `mkdirs()` call with `Files.createDirectories()`, which throws a descriptive exception naming the offending path:
- `AccessDeniedException` when the process lacks permission on an existing parent
- `FileAlreadyExistsException` when a regular file occupies a path segment


### 🔗 Related Issue

Relates to https://github.com/kestra-io/kestra/issues/17093 (diagnosability half; the UID regression itself was resolved by the base-image pin in v1.3.27).

### 🛠️ Backend Checklist

- [x] Code compiles successfully and passes all checks
- [x] All unit and integration tests pass `./gradlew :storage-local:test` (67 tests, includes the inherited `StorageTestSuite` contract)

### 📝 Additional Notes

- The new test (`shouldFailWithDescriptiveErrorWhenParentDirectoryCannotBeCreated`) was verified red against the previous implementation (fails with `FileNotFoundException`) and green with the fix it deterministically forces the failure by placing a regular file where a parent directory must be created, so it doesn't depend on permission bits (which would be bypassed when CI runs as root).
- `createDirectoryFromPath()` already checks its `mkdirs()` result and throws; left untouched.
- Developed with AI assistance (Claude Code), reviewed and driven by a human. As requested by the template, a cat joke: why did the cat get assigned the storage bug? Because it's an expert at putting things in boxes. 🐱

