### PR TITLE
fix(core): bound the plugin documentation cache to stop unbounded heap growth

### DIFF
--- a/core/src/main/java/io/kestra/core/docs/ClassPluginDocumentation.java
+++ b/core/src/main/java/io/kestra/core/docs/ClassPluginDocumentation.java
@@ -1,9 +1,12 @@
 package io.kestra.core.docs;
 
+import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
-import java.util.concurrent.ConcurrentHashMap;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
 
 import io.kestra.core.plugins.PluginClassAndMetadata;
 
@@ -16,7 +19,14 @@ import lombok.ToString;
 @EqualsAndHashCode
 @ToString
 public class ClassPluginDocumentation<T> extends AbstractClassDocumentation<T> {
-    private static final Map<PluginDocIdentifier, ClassPluginDocumentation<?>> CACHE = new ConcurrentHashMap<>();
+    // Bounded: the keyspace (class name + version + allProperties) is effectively unbounded in EE
+    // where multiple plugin versions can be installed, and the generated documentation values are
+    // large (JSON schemas, $defs, outputs). An unbounded map here grows the heap for the whole JVM
+    // lifetime as users browse plugins/versions (see #16983).
+    private static final Cache<PluginDocIdentifier, ClassPluginDocumentation<?>> CACHE = Caffeine.newBuilder()
+        .maximumSize(1_000)
+        .expireAfterAccess(Duration.ofHours(1))
+        .build();
     private String icon;
     private String group;
     protected String docLicense;
@@ -87,7 +97,7 @@ public class ClassPluginDocumentation<T> extends AbstractClassDocumentation<T> {
 
     public static <T> ClassPluginDocumentation<T> of(JsonSchemaGenerator jsonSchemaGenerator, PluginClassAndMetadata<T> plugin, String version, boolean allProperties) {
         //noinspection unchecked
-        return (ClassPluginDocumentation<T>) CACHE.computeIfAbsent(
+        return (ClassPluginDocumentation<T>) CACHE.get(
             new PluginDocIdentifier(plugin.type(), version, allProperties),
             (key) -> new ClassPluginDocumentation<>(jsonSchemaGenerator, plugin, allProperties)
         );

--- a/core/src/main/java/io/kestra/core/docs/ClassPluginDocumentation.java
+++ b/core/src/main/java/io/kestra/core/docs/ClassPluginDocumentation.java
@@ -20,7 +20,7 @@ import lombok.ToString;
 @ToString
 public class ClassPluginDocumentation<T> extends AbstractClassDocumentation<T> {
     private static final int CACHE_MAXIMUM_SIZE = 1_000;
-    private static final Duration CACHE_EXPIRE_AFTER_ACCESS = Duration.ofHours(1);
+    private static final Duration CACHE_EXPIRE_AFTER_ACCESS = Duration.ofDays(1);
 
     // Bounded: the keyspace (class name + version + allProperties) is effectively unbounded in EE
     // where multiple plugin versions can be installed, and the generated documentation values are

--- a/core/src/main/java/io/kestra/core/docs/ClassPluginDocumentation.java
+++ b/core/src/main/java/io/kestra/core/docs/ClassPluginDocumentation.java
@@ -19,13 +19,16 @@ import lombok.ToString;
 @EqualsAndHashCode
 @ToString
 public class ClassPluginDocumentation<T> extends AbstractClassDocumentation<T> {
+    private static final int CACHE_MAXIMUM_SIZE = 1_000;
+    private static final Duration CACHE_EXPIRE_AFTER_ACCESS = Duration.ofHours(1);
+
     // Bounded: the keyspace (class name + version + allProperties) is effectively unbounded in EE
     // where multiple plugin versions can be installed, and the generated documentation values are
     // large (JSON schemas, $defs, outputs). An unbounded map here grows the heap for the whole JVM
     // lifetime as users browse plugins/versions (see #16983).
     private static final Cache<PluginDocIdentifier, ClassPluginDocumentation<?>> CACHE = Caffeine.newBuilder()
-        .maximumSize(1_000)
-        .expireAfterAccess(Duration.ofHours(1))
+        .maximumSize(CACHE_MAXIMUM_SIZE)
+        .expireAfterAccess(CACHE_EXPIRE_AFTER_ACCESS)
         .build();
     private String icon;
     private String group;

--- a/core/src/test/java/io/kestra/core/docs/ClassPluginDocumentationTest.java
+++ b/core/src/test/java/io/kestra/core/docs/ClassPluginDocumentationTest.java
@@ -174,4 +174,32 @@ class ClassPluginDocumentationTest {
             assertThat((Boolean) withDefault.get("$dynamic")).isTrue();
         }));
     }
+
+    // The cache key is (class + version + allProperties): same key must return the cached
+    // instance, while a different version must generate a distinct documentation object.
+    // Bounding/eviction itself is Caffeine's contract (see #16983) and is not re-tested here.
+    @Test
+    void shouldCachePerClassVersionAndAllProperties() throws URISyntaxException {
+        Helpers.runApplicationContext(throwConsumer((applicationContext) ->
+        {
+            // Given
+            JsonSchemaGenerator jsonSchemaGenerator = applicationContext.getBean(JsonSchemaGenerator.class);
+
+            PluginScanner pluginScanner = new PluginScanner(ClassPluginDocumentationTest.class.getClassLoader());
+            RegisteredPlugin scan = pluginScanner.scan();
+
+            PluginClassAndMetadata<DynamicPropertyExampleTask> metadata = PluginClassAndMetadata.create(scan, DynamicPropertyExampleTask.class, DynamicPropertyExampleTask.class, null);
+
+            // When
+            ClassPluginDocumentation<? extends DynamicPropertyExampleTask> first = ClassPluginDocumentation.of(jsonSchemaGenerator, metadata, "1.0.0", true);
+            ClassPluginDocumentation<? extends DynamicPropertyExampleTask> sameKey = ClassPluginDocumentation.of(jsonSchemaGenerator, metadata, "1.0.0", true);
+            ClassPluginDocumentation<? extends DynamicPropertyExampleTask> otherVersion = ClassPluginDocumentation.of(jsonSchemaGenerator, metadata, "2.0.0", true);
+            ClassPluginDocumentation<? extends DynamicPropertyExampleTask> otherProperties = ClassPluginDocumentation.of(jsonSchemaGenerator, metadata, "1.0.0", false);
+
+            // Then
+            assertThat(sameKey).isSameAs(first);
+            assertThat(otherVersion).isNotSameAs(first);
+            assertThat(otherProperties).isNotSameAs(first);
+        }));
+    }
 }


### PR DESCRIPTION
### ✨ Description

`ClassPluginDocumentation` declared a process-lifetime static cache with no bound:

```java
private static final Map<PluginDocIdentifier, ClassPluginDocumentation<?>> CACHE = new ConcurrentHashMap<>();
```

The key includes plugin class name + **version** + `allProperties`, and the values are large generated documentation objects (JSON schemas, `$defs`, outputs, metrics). The plugin-docs endpoints populate it every time a user opens a task in the editor, and with multiple plugin versions installed the keyspace is effectively unbounded, so heap grows for the entire JVM lifetime.

This PR replaces the raw `ConcurrentHashMap` with a Caffeine cache bounded by `maximumSize(1_000)` + `expireAfterAccess(1h)`, consistent with the existing bounded caches in core (`FlowWithDefaultCache`, `QueueLagPoller`). Caffeine is already a `core` dependency; the `of()` call switches from `computeIfAbsent` to the equivalent `Cache#get(key, mappingFunction)`, so caching semantics for callers are unchanged.

### 🔗 Related Issue

Closes https://github.com/kestra-io/kestra/issues/16983.

### 🛠️ Backend Checklist

- [x] Code compiles successfully and passes all checks
- [x] All unit and integration tests pass `./gradlew :core:test --tests ClassPluginDocumentationTest` (5 tests) and `--tests DocumentationGeneratorTest` (8 tests, the other consumer of this class)

### 📝 Additional Notes

- Added `shouldCachePerClassVersionAndAllProperties` covering the caching contract we own: same key returns the cached instance; a different version or `allProperties` flag generates a distinct object. Eviction/bounding itself is Caffeine's contract and is deliberately not re-tested (size-based eviction is async and would make the test flaky).
- Sizing rationale: OSS installs typically have hundreds of plugin classes, so 1,000 entries comfortably covers the hot set; `expireAfterAccess` reclaims memory on idle instances either way.
- Developed with AI assistance (Claude Code), reviewed and driven by a human. Template-mandated cat joke: this cache used to hoard like a cat with cardboard boxes, now it only keeps the 1,000 boxes it actually sits in. 🐱

