### PR TITLE
fix(executor): honor parent task logLevel for the subflow creation log

### DIFF
--- a/core/src/main/java/io/kestra/core/runners/RunContextLogger.java
+++ b/core/src/main/java/io/kestra/core/runners/RunContextLogger.java
@@ -224,6 +224,27 @@ public class RunContextLogger implements Supplier<org.slf4j.Logger> {
     }
 
     /**
+     * Emit the given log entry only when its level is enabled for this context's configured
+     * log level. Prefer this over {@link #emitLog(LogEntry)} for manually built entries:
+     * direct emission bypasses the regular logging pipeline, so the configured level filter
+     * (e.g. a task's {@code logLevel} property) must be applied explicitly.
+     *
+     * @see #emitLog(LogEntry)
+     */
+    public void emitLogIfEnabled(LogEntry logEntry) {
+        if (logEntry.getLevel() == null || isLogLevelEnabled(logEntry.getLevel())) {
+            this.emitLog(logEntry);
+        }
+    }
+
+    /**
+     * Returns true when the given level is enabled for this context's configured log level.
+     */
+    public boolean isLogLevelEnabled(org.slf4j.event.Level level) {
+        return this.loglevel == null || Level.toLevel(level.toString()).isGreaterOrEqual(this.loglevel);
+    }
+
+    /**
      * Emit the log lines attached to a dynamically-generated taskrun through the regular logging
      * pipeline, so the standard appender behaviour (secret masking, long-message splitting, level
      * filtering, forwarding to the server log, file vs queue routing) applies natively — the only

--- a/core/src/test/java/io/kestra/core/runners/RunContextLoggerTest.java
+++ b/core/src/test/java/io/kestra/core/runners/RunContextLoggerTest.java
@@ -495,6 +495,32 @@ class RunContextLoggerTest {
             .contains(org.assertj.core.groups.Tuple.tuple(RunContextLogger.PROGRESS_KEY, "pod.created"));
     }
 
+    @Test
+    void shouldFilterDirectlyEmittedLogEntriesWhenLevelIsBelowConfiguredLogLevel() {
+        // Given: a logger whose configured level filter is WARN
+        List<LogEntry> logs = new CopyOnWriteArrayList<>();
+        logQueue.addListener(log -> logs.add(log));
+
+        Flow flow = TestsUtils.mockFlow();
+        Execution execution = TestsUtils.mockExecution(flow, Map.of());
+
+        RunContextLogger runContextLogger = new RunContextLogger(
+            logEntryEmitter,
+            LogEntry.of(execution),
+            Level.WARN,
+            false
+        );
+
+        // When: directly emitting one entry below and one entry at the configured level
+        runContextLogger.emitLogIfEnabled(LogEntry.of(execution).toBuilder().level(Level.INFO).message("suppressed info message").build());
+        runContextLogger.emitLogIfEnabled(LogEntry.of(execution).toBuilder().level(Level.WARN).message("emitted warn message").build());
+
+        // Then: only the entry at the configured level reaches the queue
+        await().atMost(Duration.ofSeconds(5)).until(() -> logs.stream()
+            .anyMatch(logEntry -> "emitted warn message".equals(logEntry.getMessage())));
+        assertThat(logs).noneMatch(logEntry -> "suppressed info message".equals(logEntry.getMessage()));
+    }
+
     /**
      * Exposes the protected {@link RunContextLogger.BaseAppender#transform} for the test.
      */

--- a/executor/src/main/java/io/kestra/executor/handler/ExecutionEventMessageHandler.java
+++ b/executor/src/main/java/io/kestra/executor/handler/ExecutionEventMessageHandler.java
@@ -356,22 +356,21 @@ public class ExecutionEventMessageHandler implements ExecutorMessageHandler<Exec
 
                                 log.info(msg);
 
-                                // Respect the parent task's configured logLevel (e.g. plugin defaults setting
-                                // logLevel: WARN): emitLog bypasses the regular logging pipeline, so without this
-                                // check the INFO creation log is persisted regardless of configuration (#16238).
+                                // Bind the logger to the parent task so its configured logLevel (e.g. plugin
+                                // defaults setting logLevel: WARN) applies to the creation log, which is emitted
+                                // directly and therefore bypasses the regular logging pipeline (#16238).
                                 Task parentTask = flow.findTaskByTaskIdOrNull(subflowExecution.getParentTaskRun().getTaskId());
-                                Level minLevel = parentTask != null ? parentTask.getLogLevel() : null;
-                                if (minLevel == null || Level.INFO.toInt() >= minLevel.toInt()) {
-                                    var logger = runContextLoggerFactory.create(execution);
-                                    logger.emitLog(
-                                        LogEntry.of(subflowExecution.getParentTaskRun(), subflowExecution.getExecution().getKind()).toBuilder()
-                                            .level(Level.INFO)
-                                            .message(msg)
-                                            .timestamp(subflowExecution.getParentTaskRun().getState().getStartDate())
-                                            .thread(Thread.currentThread().getName())
-                                            .build()
-                                    );
-                                }
+                                var logger = parentTask != null
+                                    ? runContextLoggerFactory.create(subflowExecution.getParentTaskRun(), parentTask, subflowExecution.getExecution().getKind())
+                                    : runContextLoggerFactory.create(execution);
+                                logger.emitLogIfEnabled(
+                                    LogEntry.of(subflowExecution.getParentTaskRun(), subflowExecution.getExecution().getKind()).toBuilder()
+                                        .level(Level.INFO)
+                                        .message(msg)
+                                        .timestamp(subflowExecution.getParentTaskRun().getState().getStartDate())
+                                        .thread(Thread.currentThread().getName())
+                                        .build()
+                                );
 
                                 executionQueue.emit(subflowExecution.getExecution());
                             }));

--- a/executor/src/main/java/io/kestra/executor/handler/ExecutionEventMessageHandler.java
+++ b/executor/src/main/java/io/kestra/executor/handler/ExecutionEventMessageHandler.java
@@ -22,6 +22,7 @@ import io.kestra.core.models.flows.quota.Quota;
 import io.kestra.core.models.flows.sla.ExecutionMonitoringSLA;
 import io.kestra.core.models.flows.sla.SLA;
 import io.kestra.core.models.flows.sla.SLAMonitor;
+import io.kestra.core.models.tasks.Task;
 import io.kestra.core.queues.DispatchQueueInterface;
 import io.kestra.core.queues.KeyedDispatchQueueInterface;
 import io.kestra.core.queues.QueueException;
@@ -355,15 +356,22 @@ public class ExecutionEventMessageHandler implements ExecutorMessageHandler<Exec
 
                                 log.info(msg);
 
-                                var logger = runContextLoggerFactory.create(execution);
-                                logger.emitLog(
-                                    LogEntry.of(subflowExecution.getParentTaskRun(), subflowExecution.getExecution().getKind()).toBuilder()
-                                        .level(Level.INFO)
-                                        .message(msg)
-                                        .timestamp(subflowExecution.getParentTaskRun().getState().getStartDate())
-                                        .thread(Thread.currentThread().getName())
-                                        .build()
-                                );
+                                // Respect the parent task's configured logLevel (e.g. plugin defaults setting
+                                // logLevel: WARN): emitLog bypasses the regular logging pipeline, so without this
+                                // check the INFO creation log is persisted regardless of configuration (#16238).
+                                Task parentTask = flow.findTaskByTaskIdOrNull(subflowExecution.getParentTaskRun().getTaskId());
+                                Level minLevel = parentTask != null ? parentTask.getLogLevel() : null;
+                                if (minLevel == null || Level.INFO.toInt() >= minLevel.toInt()) {
+                                    var logger = runContextLoggerFactory.create(execution);
+                                    logger.emitLog(
+                                        LogEntry.of(subflowExecution.getParentTaskRun(), subflowExecution.getExecution().getKind()).toBuilder()
+                                            .level(Level.INFO)
+                                            .message(msg)
+                                            .timestamp(subflowExecution.getParentTaskRun().getState().getStartDate())
+                                            .thread(Thread.currentThread().getName())
+                                            .build()
+                                    );
+                                }
 
                                 executionQueue.emit(subflowExecution.getExecution());
                             }));

--- a/executor/src/test/java/io/kestra/executor/handler/ExecutionEventMessageHandlerSubflowLogTest.java
+++ b/executor/src/test/java/io/kestra/executor/handler/ExecutionEventMessageHandlerSubflowLogTest.java
@@ -1,0 +1,151 @@
+package io.kestra.executor.handler;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.slf4j.event.Level;
+
+import io.kestra.core.junit.annotations.KestraTest;
+import io.kestra.core.killswitch.EvaluationType;
+import io.kestra.core.killswitch.KillSwitchService;
+import io.kestra.core.models.executions.Execution;
+import io.kestra.core.models.executions.LogEntry;
+import io.kestra.core.models.flows.Flow;
+import io.kestra.core.models.flows.GenericFlow;
+import io.kestra.core.repositories.ExecutionRepositoryInterface;
+import io.kestra.core.repositories.FlowRepositoryInterface;
+import io.kestra.core.runners.ExecutionEvent;
+import io.kestra.core.runners.ExecutionEventType;
+import io.kestra.core.runners.LogEntryEmitter;
+import io.kestra.core.utils.IdUtils;
+import io.kestra.plugin.core.flow.Subflow;
+import io.kestra.plugin.core.log.Log;
+
+import io.micronaut.test.annotation.MockBean;
+import jakarta.inject.Inject;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.atLeast;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+// The subflow creation log is emitted through LogEntryEmitter directly (bypassing the regular
+// logging pipeline), so it must honor the parent task's configured logLevel explicitly — e.g.
+// plugin defaults setting logLevel: WARN must suppress the INFO creation log (#16238).
+@KestraTest
+class ExecutionEventMessageHandlerSubflowLogTest {
+    private static final String CREATION_LOG_PREFIX = "Created new execution";
+    private static final int MAX_EXECUTOR_PASSES = 5;
+
+    @Inject
+    private ExecutionEventMessageHandler executionEventMessageHandler;
+
+    @Inject
+    private ExecutionRepositoryInterface executionRepository;
+
+    @Inject
+    private FlowRepositoryInterface flowRepository;
+
+    @Inject
+    KillSwitchService killSwitchService;
+
+    @Inject
+    LogEntryEmitter logEntryEmitter;
+
+    @MockBean(KillSwitchService.class)
+    KillSwitchService killSwitchService() {
+        return mock(KillSwitchService.class);
+    }
+
+    @MockBean(LogEntryEmitter.class)
+    LogEntryEmitter logEntryEmitter() {
+        return mock(LogEntryEmitter.class);
+    }
+
+    @BeforeEach
+    void setUp() {
+        when(killSwitchService.evaluate(any(ExecutionEvent.class))).thenReturn(EvaluationType.PASS);
+        when(logEntryEmitter.emits(any(LogEntry.class))).thenReturn(CompletableFuture.completedFuture(null));
+        when(logEntryEmitter.emits(anyList())).thenReturn(CompletableFuture.completedFuture(null));
+    }
+
+    @Test
+    void shouldEmitSubflowCreationLogByDefault() {
+        // Given: a parent flow whose Subflow task has no configured logLevel
+        var subflowExecutions = runParentFlowWithSubflowTask(null);
+
+        // Then: the subflow execution was created and the INFO creation log was emitted
+        assertThat(subflowExecutions).isTrue();
+        assertThat(capturedCreationLogs()).isNotEmpty();
+    }
+
+    @Test
+    void shouldNotEmitSubflowCreationLogWhenParentTaskLogLevelIsAboveInfo() {
+        // Given: a parent flow whose Subflow task is configured with logLevel WARN
+        var subflowExecutions = runParentFlowWithSubflowTask(Level.WARN);
+
+        // Then: the subflow execution was created but the INFO creation log was suppressed
+        assertThat(subflowExecutions).isTrue();
+        assertThat(capturedCreationLogs()).isEmpty();
+    }
+
+    /**
+     * Creates a child flow and a parent flow holding a single Subflow task with the given logLevel,
+     * then drives the handler until the subflow execution is produced.
+     *
+     * @return true when a subflow execution was produced within the allotted executor passes
+     */
+    private boolean runParentFlowWithSubflowTask(Level subflowTaskLogLevel) {
+        var childFlow = flowRepository.create(GenericFlow.of(Flow.builder()
+            .tenantId("tenant")
+            .namespace("namespace")
+            .id(IdUtils.create())
+            .tasks(List.of(Log.builder().id("log").type(Log.class.getName()).message("Hello from child").build()))
+            .build()));
+
+        var parentFlow = flowRepository.create(GenericFlow.of(Flow.builder()
+            .tenantId("tenant")
+            .namespace("namespace")
+            .id(IdUtils.create())
+            .tasks(List.of(Subflow.builder()
+                .id("subflow")
+                .type(Subflow.class.getName())
+                .namespace(childFlow.getNamespace())
+                .flowId(childFlow.getId())
+                .logLevel(subflowTaskLogLevel)
+                .build()))
+            .build()));
+
+        var execution = Execution.newExecution(parentFlow, Collections.emptyList());
+        executionRepository.save(execution);
+
+        var maybeExecutor = executionEventMessageHandler.handle(new ExecutionEvent(execution, ExecutionEventType.CREATED));
+
+        // The subflow execution is produced once the executor processes the executable task; the
+        // number of passes is an executor implementation detail, so re-handle until it shows up.
+        for (int pass = 0; pass < MAX_EXECUTOR_PASSES && maybeExecutor.isPresent(); pass++) {
+            if (!maybeExecutor.get().getSubflowExecutions().isEmpty()) {
+                return true;
+            }
+            var current = maybeExecutor.get().getExecution();
+            executionRepository.save(current);
+            maybeExecutor = executionEventMessageHandler.handle(new ExecutionEvent(current, ExecutionEventType.UPDATED));
+        }
+        return maybeExecutor.map(executor -> !executor.getSubflowExecutions().isEmpty()).orElse(false);
+    }
+
+    private List<LogEntry> capturedCreationLogs() {
+        ArgumentCaptor<LogEntry> captor = ArgumentCaptor.forClass(LogEntry.class);
+        verify(logEntryEmitter, atLeast(0)).emits(captor.capture());
+        return captor.getAllValues().stream()
+            .filter(logEntry -> logEntry.getMessage() != null && logEntry.getMessage().startsWith(CREATION_LOG_PREFIX))
+            .toList();
+    }
+}


### PR DESCRIPTION
### ✨ Description

When a subflow execution is created, the executor emits a `Created new execution [[link ...]]` log entry through `LogEntryEmitter` with a hardcoded `Level.INFO` bypassing the regular logging pipeline and therefore any configured level filtering. Users who set plugin defaults like:

```yaml
plugins:
  defaults:
    - type: io.kestra.plugin
      forced: true
      values:
        logLevel: WARN
```

to keep the `logs` table lean still get this INFO entry persisted for every single subflow execution.

The fix looks up the parent task on the flow (which `findByExecutionThenInjectDefaults` has already enriched with plugin defaults, so `logLevel: WARN` from configuration is visible) and skips the emit when INFO is below the configured level. Behavior is unchanged when no `logLevel` is configured, and the server log line (`log.info`) is untouched only the persisted LogEntry respects the filter.

### 🔗 Related Issue

Closes https://github.com/kestra-io/kestra/issues/16238.

### 🛠️ Backend Checklist

- [x] Code compiles successfully and passes all checks
- [x] All unit and integration tests pass `:executor:test --tests ExecutionEventMessageHandlerSubflowLogTest` (new, 2 tests) and `:jdbc-h2:test --tests H2RunnerTest` per the executor-change guideline (100 tests)

### 📝 Additional Notes

- The new test drives the real handler with a parent flow holding a `Subflow` task: with no `logLevel` the creation log is emitted (guards against regressing the default behavior); with `logLevel: WARN` it is suppressed. Verified red without the fix, green with it.
- While running `H2RunnerTest` three times I observed one-off failures in `flowTriggerWithPause` and `flowTriggerAnyMode` (await-timeout style, a different test each run, all passing on other runs, including a fully green run on clean `develop`). They look like pre-existing timing flakiness in the multiple-condition trigger tests rather than anything related to this change flagging in case it's useful signal.
- Developed with AI assistance (Claude Code), reviewed and driven by a human. Template cat joke: the subflow log was like a cat announcing every door it walks through now it only meows when you've asked to hear it. 🐱

