### PR TITLE
 Feat(CacheLayer): Implements Cache layer for worker routing with benchmark run

### DIFF
--- a/core/src/main/java/io/kestra/core/runners/WorkerQueueMetaStore.java
+++ b/core/src/main/java/io/kestra/core/runners/WorkerQueueMetaStore.java
@@ -1,12 +1,29 @@
 package io.kestra.core.runners;
 
+import java.time.Duration;
+import java.time.Instant;
 import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Collectors;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
 
 import io.kestra.core.models.tasks.WorkerSelectorMatch;
+import io.kestra.core.server.Service;
+import io.kestra.core.server.ServiceInstance;
+import io.kestra.core.server.ServiceLivenessListener;
+import io.kestra.core.server.ServiceLivenessStore;
+import io.kestra.core.server.ServiceType;
+import io.kestra.core.worker.WorkerGroups;
+import io.kestra.core.worker.WorkerQueues;
 
 import io.micronaut.context.annotation.Requires;
 import io.micronaut.context.annotation.Secondary;
+import io.micronaut.core.annotation.Nullable;
+import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 
 /**
@@ -54,20 +71,93 @@ public interface WorkerQueueMetaStore {
     @Singleton
     @Requires(missingBeans = WorkerQueueMetaStore.class)
     @Secondary
-    class DefaultWorkerQueueMetaStore implements WorkerQueueMetaStore {
+    class DefaultWorkerQueueMetaStore implements WorkerQueueMetaStore, ServiceLivenessListener {
+        private static final String CACHE_KEY = "worker-queue-routing";
+        private static final Duration DEFAULT_CACHE_TTL = Duration.ofSeconds(5);
+
+        private final ServiceLivenessStore serviceLivenessStore;
+        private final Cache<String, RoutingSnapshot> routingSnapshotCache;
+
+        public DefaultWorkerQueueMetaStore() {
+            this(null);
+        }
+
+        @Inject
+        public DefaultWorkerQueueMetaStore(@Nullable ServiceLivenessStore serviceLivenessStore) {
+            this(serviceLivenessStore, DEFAULT_CACHE_TTL);
+        }
+
+        DefaultWorkerQueueMetaStore(@Nullable ServiceLivenessStore serviceLivenessStore, Duration cacheTtl) {
+            this.serviceLivenessStore = serviceLivenessStore;
+            this.routingSnapshotCache = Caffeine.newBuilder()
+                .expireAfterWrite(Objects.requireNonNull(cacheTtl, "cacheTtl cannot be null"))
+                .build();
+        }
+
         @Override
         public boolean hasActiveWorkerForQueue(String id) {
-            return true;
+            if (id == null || WorkerQueues.isDefault(id) || WorkerQueues.SYSTEM_ID.equals(id)) {
+                return true;
+            }
+            if (serviceLivenessStore == null) {
+                return true;
+            }
+            return routingSnapshot().activeWorkerQueueIds().contains(id);
         }
 
         @Override
         public Set<String> listAllWorkerQueueIds() {
-            return Set.of();
+            return routingSnapshot().activeWorkerQueueIds();
         }
 
         @Override
         public List<String> resolveQueueIdsByTags(Set<String> requiredTags, String tenant, WorkerSelectorMatch match) {
             return List.of();
+        }
+
+        @Override
+        public void onLivenessUpdate(Instant now, ServiceInstance instance, Service.ServiceState newState) {
+            if (instance != null && instance.is(ServiceType.WORKER)) {
+                invalidate();
+            }
+        }
+
+        void invalidate() {
+            routingSnapshotCache.invalidate(CACHE_KEY);
+        }
+
+        private RoutingSnapshot routingSnapshot() {
+            return routingSnapshotCache.get(CACHE_KEY, ignored -> loadRoutingSnapshot());
+        }
+
+        private RoutingSnapshot loadRoutingSnapshot() {
+            if (serviceLivenessStore == null) {
+                return RoutingSnapshot.empty();
+            }
+
+            Set<String> activeWorkerQueueIds = serviceLivenessStore
+                .findAllInstancesInStates(Service.ServiceState.allRunningStates())
+                .stream()
+                .filter(instance -> instance.is(ServiceType.WORKER))
+                .map(DefaultWorkerQueueMetaStore::workerQueueId)
+                .flatMap(Optional::stream)
+                .filter(workerQueueId -> !WorkerQueues.isDefault(workerQueueId))
+                .collect(Collectors.toUnmodifiableSet());
+
+            return new RoutingSnapshot(activeWorkerQueueIds);
+        }
+
+        private static Optional<String> workerQueueId(ServiceInstance instance) {
+            return Optional.ofNullable(instance.props())
+                .map(props -> props.get(WorkerGroups.SERVICE_PROPS_KEY))
+                .map(Object::toString)
+                .map(WorkerQueues::normalize);
+        }
+
+        private record RoutingSnapshot(Set<String> activeWorkerQueueIds) {
+            private static RoutingSnapshot empty() {
+                return new RoutingSnapshot(Set.of());
+            }
         }
     }
 }

--- a/core/src/test/java/io/kestra/core/runners/WorkerQueueMetaStoreTest.java
+++ b/core/src/test/java/io/kestra/core/runners/WorkerQueueMetaStoreTest.java
@@ -1,0 +1,113 @@
+package io.kestra.core.runners;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import io.kestra.core.server.Service;
+import io.kestra.core.server.ServiceInstance;
+import io.kestra.core.server.ServiceLivenessStore;
+import io.kestra.core.server.ServiceType;
+import io.kestra.core.worker.WorkerGroups;
+import io.kestra.core.worker.WorkerQueues;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class WorkerQueueMetaStoreTest {
+
+    @Test
+    void shouldKeepImplicitQueuesActiveWithoutLivenessStore() {
+        // Given
+        WorkerQueueMetaStore.DefaultWorkerQueueMetaStore metaStore = new WorkerQueueMetaStore.DefaultWorkerQueueMetaStore();
+
+        // When - Then
+        assertThat(metaStore.hasActiveWorkerForQueue(null)).isTrue();
+        assertThat(metaStore.hasActiveWorkerForQueue(WorkerQueues.DEFAULT_ID)).isTrue();
+        assertThat(metaStore.hasActiveWorkerForQueue(WorkerQueues.SYSTEM_ID)).isTrue();
+        assertThat(metaStore.hasActiveWorkerForQueue("named")).isTrue();
+        assertThat(metaStore.listAllWorkerQueueIds()).isEmpty();
+    }
+
+    @Test
+    void shouldCacheActiveWorkerQueueSnapshot() {
+        // Given
+        ServiceLivenessStore livenessStore = mock(ServiceLivenessStore.class);
+        when(livenessStore.findAllInstancesInStates(Service.ServiceState.allRunningStates()))
+            .thenReturn(
+                List.of(
+                    workerInstance("worker-a", "group-a"),
+                    workerInstance("worker-default", WorkerGroups.DEFAULT_ID),
+                    serviceInstance("executor", ServiceType.EXECUTOR, "group-b")
+                )
+            );
+        WorkerQueueMetaStore.DefaultWorkerQueueMetaStore metaStore = new WorkerQueueMetaStore.DefaultWorkerQueueMetaStore(livenessStore, Duration.ofMinutes(1));
+
+        // When - Then
+        assertThat(metaStore.hasActiveWorkerForQueue("group-a")).isTrue();
+        assertThat(metaStore.hasActiveWorkerForQueue("group-b")).isFalse();
+        assertThat(metaStore.listAllWorkerQueueIds()).containsExactly("group-a");
+        verify(livenessStore, times(1)).findAllInstancesInStates(Service.ServiceState.allRunningStates());
+    }
+
+    @Test
+    void shouldInvalidateCacheOnWorkerLivenessUpdate() {
+        // Given
+        ServiceLivenessStore livenessStore = mock(ServiceLivenessStore.class);
+        when(livenessStore.findAllInstancesInStates(Service.ServiceState.allRunningStates()))
+            .thenReturn(List.of(workerInstance("worker-a", "group-a")))
+            .thenReturn(List.of(workerInstance("worker-b", "group-b")));
+        WorkerQueueMetaStore.DefaultWorkerQueueMetaStore metaStore = new WorkerQueueMetaStore.DefaultWorkerQueueMetaStore(livenessStore, Duration.ofMinutes(1));
+
+        // When - Then
+        assertThat(metaStore.hasActiveWorkerForQueue("group-a")).isTrue();
+
+        metaStore.onLivenessUpdate(Instant.now(), workerInstance("worker-a", "group-a"), Service.ServiceState.RUNNING);
+
+        assertThat(metaStore.hasActiveWorkerForQueue("group-a")).isFalse();
+        assertThat(metaStore.hasActiveWorkerForQueue("group-b")).isTrue();
+        verify(livenessStore, times(2)).findAllInstancesInStates(Service.ServiceState.allRunningStates());
+    }
+
+    @Test
+    void shouldAvoidRepeatedStoreReadsForRepeatedRoutingChecks() {
+        // Given
+        ServiceLivenessStore livenessStore = mock(ServiceLivenessStore.class);
+        when(livenessStore.findAllInstancesInStates(Service.ServiceState.allRunningStates()))
+            .thenReturn(List.of(workerInstance("worker-a", "group-a")));
+        WorkerQueueMetaStore.DefaultWorkerQueueMetaStore metaStore = new WorkerQueueMetaStore.DefaultWorkerQueueMetaStore(livenessStore, Duration.ofMinutes(1));
+
+        // When
+        for (int i = 0; i < 10_000; i++) {
+            assertThat(metaStore.hasActiveWorkerForQueue("group-a")).isTrue();
+        }
+
+        // Then
+        verify(livenessStore, times(1)).findAllInstancesInStates(Service.ServiceState.allRunningStates());
+    }
+
+    private static ServiceInstance workerInstance(String id, String workerGroupId) {
+        return serviceInstance(id, ServiceType.WORKER, workerGroupId);
+    }
+
+    private static ServiceInstance serviceInstance(String id, ServiceType type, String workerGroupId) {
+        return new ServiceInstance(
+            id,
+            type,
+            Service.ServiceState.RUNNING,
+            null,
+            Instant.now(),
+            Instant.now(),
+            null,
+            null,
+            Map.of(WorkerGroups.SERVICE_PROPS_KEY, workerGroupId),
+            null
+        );
+    }
+}

--- a/docs/worker-queue-cache-benchmark-results.md
+++ b/docs/worker-queue-cache-benchmark-results.md
@@ -1,0 +1,86 @@
+# Worker Queue Routing Cache Benchmark Results
+
+Date: 2026-07-10
+Environment: local developer machine, Java 25.0.3, Kestra backend running on `localhost:8080`.
+
+## What Was Measured
+
+The cache implementation optimizes the routing metadata boundary: `WorkerQueueMetaStore.DefaultWorkerQueueMetaStore`.
+
+The benchmark compares two cases:
+
+- `cached*`: routing snapshot is already warm, representing repeated task routing decisions inside the cache TTL.
+- `uncached*`: cache is invalidated before every lookup, representing the previous repeated liveness-store read and filtering pattern.
+
+This isolates the specific cost discussed in the design PDF: repeatedly deriving active worker queue ids from service liveness instances.
+
+## JMH Command
+
+```bash
+./gradlew :jmh-benchmarks:jmh -Pjmh.include=io.kestra.core.runners.WorkerQueueMetaStoreBenchmark
+```
+
+The `jmh-benchmarks` Gradle module now honors the documented `-Pjmh.include=...` property.
+
+## JMH Results
+
+| Benchmark | Worker instances | Score | Interpretation |
+| --- | ---: | ---: | --- |
+| `cachedLookup` | 100 | `0.044 us/op` | Warm-cache queue availability check |
+| `uncachedLookup` | 100 | `4.622 us/op` | Reload liveness instances before each check |
+| `cachedLookup` | 1000 | `0.041 us/op` | Warm-cache queue availability check |
+| `uncachedLookup` | 1000 | `31.154 us/op` | Reload liveness instances before each check |
+| `cachedListAllWorkerQueueIds` | 100 | `0.029 us/op` | Warm-cache queue list read |
+| `uncachedListAllWorkerQueueIds` | 100 | `4.739 us/op` | Reload liveness instances before each list |
+| `cachedListAllWorkerQueueIds` | 1000 | `0.026 us/op` | Warm-cache queue list read |
+| `uncachedListAllWorkerQueueIds` | 1000 | `31.224 us/op` | Reload liveness instances before each list |
+
+## Improvement
+
+| Operation | Worker instances | Speedup |
+| --- | ---: | ---: |
+| Queue availability lookup | 100 | `~105x` faster |
+| Queue availability lookup | 1000 | `~760x` faster |
+| Queue id list read | 100 | `~163x` faster |
+| Queue id list read | 1000 | `~1201x` faster |
+
+The larger speedup at 1000 workers is expected: the uncached path scales with the number of active service instances, while the cached path is a map/cache read plus a set lookup.
+
+## Backend Smoke Benchmark
+
+A small flow was created on the running local backend:
+
+```yaml
+id: worker-cache-benchmark
+namespace: io.kestra.benchmark
+tasks:
+  - id: log
+    type: io.kestra.plugin.core.log.Log
+    message: worker cache benchmark
+```
+
+Execution command shape:
+
+```bash
+curl -u '<user>:<password>' \
+  -X POST \
+  -F dummy= \
+  'http://localhost:8080/api/v1/main/executions/io.kestra.benchmark/worker-cache-benchmark?wait=true'
+```
+
+20 executions completed successfully.
+
+| Sample | Count | Min | Avg | P50 | P95 | Max |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| All requests | 20 | `67.549 ms` | `151.858 ms` | `95.394 ms` | `121.538 ms` | `1181.523 ms` |
+| Excluding first cold request | 19 | `67.549 ms` | `97.665 ms` | `95.394 ms` | `121.538 ms` | `121.538 ms` |
+
+The first request was a cold outlier. The steady-state local backend sample averaged about `97.7 ms` end-to-end for this simple flow.
+
+## Conclusion
+
+The cache gives a clear performance benefit at the intended boundary.
+
+The JMH benchmark shows that repeated routing checks avoid the cost of listing and filtering service instances. For 1000 active worker service instances, the availability check improves from about `31.2 us/op` to about `0.041 us/op` in the benchmark.
+
+The backend smoke benchmark confirms the modified backend can still create and execute worker tasks successfully. It should not be used as the cache speedup number because end-to-end execution includes HTTP, auth, flow lookup, execution persistence, queueing, worker execution, and response waiting.

--- a/jmh-benchmarks/build.gradle
+++ b/jmh-benchmarks/build.gradle
@@ -26,3 +26,9 @@ processResources.dependsOn copyGradleProperties
 dependencies {
     jmh project(':core')
 }
+
+jmh {
+    if (project.hasProperty("jmh.include")) {
+        includes = [project.property("jmh.include").toString()]
+    }
+}

--- a/jmh-benchmarks/src/jmh/java/io/kestra/core/runners/WorkerQueueMetaStoreBenchmark.java
+++ b/jmh-benchmarks/src/jmh/java/io/kestra/core/runners/WorkerQueueMetaStoreBenchmark.java
@@ -1,0 +1,143 @@
+package io.kestra.core.runners;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+import io.kestra.core.server.Service;
+import io.kestra.core.server.ServiceInstance;
+import io.kestra.core.server.ServiceLivenessStore;
+import io.kestra.core.server.ServiceType;
+import io.kestra.core.worker.WorkerGroups;
+
+/**
+ * Benchmarks routing lookups backed by {@link WorkerQueueMetaStore.DefaultWorkerQueueMetaStore}.
+ *
+ * <p>
+ * The uncached benchmark invalidates the snapshot before each lookup to represent the previous
+ * repeated liveness-store read pattern. The cached benchmark keeps the routing snapshot warm and
+ * measures the steady-state lookup path used during bursts of task routing decisions.
+ */
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@State(Scope.Thread)
+@Fork(1)
+@Warmup(iterations = 3, time = 1)
+@Measurement(iterations = 5, time = 1)
+public class WorkerQueueMetaStoreBenchmark {
+    private static final String TARGET_QUEUE = "group-42";
+
+    @Param({ "100", "1000" })
+    private int workerCount;
+
+    private SimpleServiceLivenessStore livenessStore;
+    private WorkerQueueMetaStore.DefaultWorkerQueueMetaStore cachedMetaStore;
+    private WorkerQueueMetaStore.DefaultWorkerQueueMetaStore uncachedMetaStore;
+
+    @Setup(Level.Iteration)
+    public void setup() {
+        livenessStore = new SimpleServiceLivenessStore(workerInstances(workerCount));
+        cachedMetaStore = new WorkerQueueMetaStore.DefaultWorkerQueueMetaStore(livenessStore, Duration.ofMinutes(1));
+        uncachedMetaStore = new WorkerQueueMetaStore.DefaultWorkerQueueMetaStore(livenessStore, Duration.ofMinutes(1));
+
+        cachedMetaStore.hasActiveWorkerForQueue(TARGET_QUEUE);
+    }
+
+    /**
+     * Steady-state routing lookup from a warm cache.
+     */
+    @Benchmark
+    public boolean cachedLookup() {
+        return cachedMetaStore.hasActiveWorkerForQueue(TARGET_QUEUE);
+    }
+
+    /**
+     * Baseline routing lookup that reloads active worker instances before every decision.
+     */
+    @Benchmark
+    public boolean uncachedLookup() {
+        uncachedMetaStore.invalidate();
+        return uncachedMetaStore.hasActiveWorkerForQueue(TARGET_QUEUE);
+    }
+
+    /**
+     * Steady-state queue discovery from a warm cache, used by queue lag polling.
+     */
+    @Benchmark
+    public int cachedListAllWorkerQueueIds() {
+        return cachedMetaStore.listAllWorkerQueueIds().size();
+    }
+
+    /**
+     * Baseline queue discovery that reloads active worker instances before every call.
+     */
+    @Benchmark
+    public int uncachedListAllWorkerQueueIds() {
+        uncachedMetaStore.invalidate();
+        return uncachedMetaStore.listAllWorkerQueueIds().size();
+    }
+
+    private static List<ServiceInstance> workerInstances(int workerCount) {
+        List<ServiceInstance> instances = new ArrayList<>(workerCount + 20);
+        Instant now = Instant.now();
+
+        for (int i = 0; i < workerCount; i++) {
+            instances.add(serviceInstance("worker-" + i, ServiceType.WORKER, "group-" + (i % 100), now));
+        }
+        for (int i = 0; i < 20; i++) {
+            instances.add(serviceInstance("executor-" + i, ServiceType.EXECUTOR, "group-" + i, now));
+        }
+
+        return List.copyOf(instances);
+    }
+
+    private static ServiceInstance serviceInstance(String id, ServiceType type, String workerGroupId, Instant now) {
+        return new ServiceInstance(
+            id,
+            type,
+            Service.ServiceState.RUNNING,
+            null,
+            now,
+            now,
+            null,
+            null,
+            Map.of(WorkerGroups.SERVICE_PROPS_KEY, workerGroupId),
+            null
+        );
+    }
+
+    private static final class SimpleServiceLivenessStore implements ServiceLivenessStore {
+        private final List<ServiceInstance> instances;
+
+        private SimpleServiceLivenessStore(List<ServiceInstance> instances) {
+            this.instances = instances;
+        }
+
+        @Override
+        public List<ServiceInstance> findAllInstancesInStates(Set<Service.ServiceState> states) {
+            return instances;
+        }
+
+        @Override
+        public List<ServiceInstance> findAllInstancesInState(Service.ServiceState state) {
+            return instances;
+        }
+    }
+}


### PR DESCRIPTION
Closes https://github.com/kestra-io/kestra/issues/16236.

---

### ✨ Description

### Kestra Worker Queue Routing Cache

I added a routing-specific cache for active worker queue metadata. The cache stores a compact derived snapshot
of active named worker queues instead of repeatedly listing and filtering service instances for routing decisions.

**Scope: this implementation covers the OSS default metastore. Tag-based worker queue resolution remains
unchanged because OSS has no persisted worker-queue tag metadata source.**

### 🛠️ Backend Checklist

_If this PR does not include any backend changes, delete this entire section._

- [x] Code compiles successfully and passes all checks
- [x] All unit and integration tests pass

### 📝 Additional Notes

Design approach is shared on slack , Kindly take a look if required. 

