### PR TITLE
fix(ai): compile the copilot execution-logs tool against the renamed log repository

### DIFF
--- a/webserver/src/main/java/io/kestra/webserver/services/ai/agent/tool/ReadExecutionLogsTool.java
+++ b/webserver/src/main/java/io/kestra/webserver/services/ai/agent/tool/ReadExecutionLogsTool.java
@@ -6,7 +6,7 @@ import java.util.stream.Collectors;
 
 import io.kestra.core.models.QueryFilter;
 import io.kestra.core.models.executions.LogEntry;
-import io.kestra.core.repositories.LogRepositoryInterface;
+import io.kestra.core.repositories.LogDataStoreInterface;
 import io.kestra.webserver.converters.QueryFilterFormat;
 import io.kestra.webserver.services.ai.agent.AgentCallContext;
 import io.kestra.webserver.services.ai.agent.domain.AgentToolFamily;
@@ -22,10 +22,10 @@ import jakarta.inject.Singleton;
 public class ReadExecutionLogsTool implements AiPlatformTool {
     private static final int MAX_LOGS = 500;
 
-    private final LogRepositoryInterface logRepository;
+    private final LogDataStoreInterface logRepository;
 
     @Inject
-    public ReadExecutionLogsTool(final LogRepositoryInterface logRepository) {
+    public ReadExecutionLogsTool(final LogDataStoreInterface logRepository) {
         this.logRepository = logRepository;
     }
 


### PR DESCRIPTION
## Problem

`webserver:compileJava` fails on `feat/ai-copilot-v2-agentic-loop`:

```
ReadExecutionLogsTool.java:9: error: cannot find symbol
import io.kestra.core.repositories.LogRepositoryInterface;
```

The recent `develop` merge into this branch brought in #17212 (pluggable log
repository), which renamed `LogRepositoryInterface` → `LogDataStoreInterface`.
`ReadExecutionLogsTool` (added by the "sub agents and tools" work) still
referenced the old type, so the branch no longer compiles.

## Fix

Pure type swap — `LogDataStoreInterface` exposes the same
`find(Pageable, tenantId, List<QueryFilter>)` method the tool already calls, and
its `ArrayListTotal<LogEntry>` return is a `List<LogEntry>`, so no call-site
changes are needed. This mirrors how `LogController` now consumes the repository.

`:core` + `:webserver` compile clean after the change.

Targets `feat/ai-copilot-v2-agentic-loop`.
