### PR TITLE
fix(ui): add missing translation for invalid duration format

### DIFF
--- a/ui/src/translations/en.json
+++ b/ui/src/translations/en.json
@@ -28,6 +28,7 @@
     "flows": "Flows",
     "flow": "Flow",
     "invalid source": "Invalid source code",
+    "invalid duration": "Invalid duration format. Please use ISO 8601 (e.g., PT30M, P1D).",
     "missingSource": "Missing source",
     "update": "Update",
     "update ok": "is updated",


### PR DESCRIPTION
### ✨ Description

What does this PR change?  

As @Pradumnasaraf mentioned in https://github.com/kestra-io/kestra/issues/17354#issuecomment-4965794922, the component was looking for the translation key "invalid duration", which wasn't defined in en.json, causing the fallback raw string to display. I have now added the correct translation mapping so that the message "Invalid duration format. Please use ISO 8601 (e.g., PT30M, P1D)." renders correctly during input validation.

### 🔗 Related Issue

Which issue does this PR resolve?

Fixes #17399 

### 🎨 Frontend Checklist

- [x] Code builds without errors (`npm run build`)
- [x] All existing E2E tests pass (`npm run test:e2e`)
- [x] Screenshots or video recordings attached showing the `UI` changes

<img width="1470" height="837" alt="Screenshot 2026-07-14 at 3 28 39 PM" src="https://github.com/user-attachments/assets/5748a70e-7a96-4ca0-b9a5-e814fc10b460" />



