### PR TITLE
test(ai): frontend coverage for the v2 copilot tool catalog

### DIFF
--- a/ui/src/components/ai/copilot/CopilotArtefactDraft.vue
+++ b/ui/src/components/ai/copilot/CopilotArtefactDraft.vue
@@ -1,5 +1,5 @@
 <template>
-    <div class="copilot-draft">
+    <div class="copilot-draft" data-test="copilot-draft">
         <!-- Header band: what was drafted + whether it validates -->
         <div class="copilot-draft-header">
             <KsText size="small" class="copilot-draft-title">

--- a/ui/src/components/ai/copilot/CopilotMessage.vue
+++ b/ui/src/components/ai/copilot/CopilotMessage.vue
@@ -14,7 +14,7 @@
     </div>
 
     <!-- Tool call / tool result — collapsible technical detail -->
-    <div v-else-if="message.type === 'TOOL_CALL'" class="copilot-msg copilot-tool">
+    <div v-else-if="message.type === 'TOOL_CALL'" class="copilot-msg copilot-tool" data-test="copilot-tool-call">
         <KsCollapse v-model="expanded">
             <KsCollapseItem name="tool">
                 <!-- Title via slot so it renders at the same small/secondary treatment as the
@@ -29,7 +29,7 @@
         </KsCollapse>
     </div>
 
-    <div v-else-if="message.type === 'TOOL_RESULT'" class="copilot-msg copilot-tool-result">
+    <div v-else-if="message.type === 'TOOL_RESULT'" class="copilot-msg copilot-tool-result" data-test="copilot-tool-result">
         <KsIcon class="copilot-tool-result-icon" :class="isOk ? 'is-ok' : 'is-error'">
             <CheckCircleOutline v-if="isOk" />
             <CloseCircleOutline v-else />

--- a/ui/tests/e2e/ai-copilot-tools.spec.ts
+++ b/ui/tests/e2e/ai-copilot-tools.spec.ts
@@ -1,0 +1,138 @@
+import {expect, test} from "@playwright/test"
+import {shared} from "./fixtures/shared"
+
+/**
+ * Per-tool end-to-end coverage for the AI Copilot v2 tool catalog.
+ *
+ * The `…/chat` SSE stream is stubbed via `page.route` so each tool is exercised
+ * deterministically, without a configured LLM provider — this asserts the *frontend*
+ * renders each tool's activity (tool_call / tool_result / artefact_draft) end-to-end
+ * through the real app shell. A companion unit spec (copilotToolCatalog.spec.ts) covers
+ * the same catalog at the reducer/component level.
+ *
+ * When the backend adds a tool, add it to PLATFORM_TOOLS / AUTHORING_TOOLS below.
+ */
+
+const sse = (events: [string, unknown][]) =>
+    events.map(([event, data]) => `event: ${event}\ndata: ${JSON.stringify(data)}\n\n`).join("")
+
+const THREAD = {uid: "e2e-thread", mode: "EDIT", status: "IDLE", createdAt: "", updatedAt: ""}
+
+const D = {
+    chat: "[data-test=\"copilot-chat\"]",
+    input: "[data-test=\"copilot-composer-input\"]",
+    send: "[data-test=\"copilot-send\"]",
+    toolCall: "[data-test=\"copilot-tool-call\"]",
+    toolResult: "[data-test=\"copilot-tool-result\"]",
+    draft: "[data-test=\"copilot-draft\"]",
+}
+
+const PLATFORM_TOOLS = [
+    {tool: "read-execution", family: "READ"},
+    {tool: "list-executions", family: "READ"},
+    {tool: "read-execution-logs", family: "READ"},
+    {tool: "read-flow", family: "READ"},
+    {tool: "list-flows", family: "READ"},
+    {tool: "search-plugins", family: "READ"},
+    {tool: "get-plugin-schema", family: "READ"},
+    {tool: "validate-flow", family: "READ"},
+    {tool: "restart-execution", family: "ACT"},
+]
+
+const AUTHORING_TOOLS = [
+    {tool: "author-flow", kind: "FLOW", title: "Proposed flow"},
+    {tool: "author-dashboard", kind: "DASHBOARD", title: "Proposed dashboard"},
+    {tool: "author-app", kind: "APP", title: "Proposed app"},
+]
+
+test.describe("AI Copilot v2 — tool catalog", () => {
+    test.beforeEach(async ({page}) => {
+        await page.route("**/api/v1/*/ai/threads", async (route) => {
+            if (route.request().method() === "POST") {
+                await route.fulfill({status: 200, contentType: "application/json", body: JSON.stringify(THREAD)})
+            } else {
+                await route.continue()
+            }
+        })
+
+        await test.step("login", async () => {
+            await page.goto("/ui")
+            await page.getByRole("textbox", {name: "Email"}).fill(shared.username)
+            await page.getByRole("textbox", {name: "Password"}).fill(shared.password)
+            await page.getByRole("button", {name: "Login"}).click()
+            await page.waitForTimeout(2000)
+            for (let i = 0; i < 3; i++) {
+                try { await page.goto("/ui", {waitUntil: "domcontentloaded"}); break } catch { await page.waitForTimeout(1000) }
+            }
+            await expect(page.getByRole("heading", {name: "Default Dashboard"})).toBeVisible({timeout: 25000})
+        })
+
+        await test.step("open the AI copilot dock tab", async () => {
+            const chat = page.locator(D.chat)
+            if (!(await chat.isVisible().catch(() => false))) {
+                await page.getByRole("button", {name: "Toggle panel"}).click().catch(() => {})
+                await page.waitForTimeout(500)
+            }
+            await page.getByRole("tab", {name: "AI"}).click().catch(() => {})
+            await expect(chat).toBeVisible({timeout: 15000})
+        })
+    })
+
+    // Stub the next chat turn's SSE stream, then send a prompt.
+    async function runTurn(page: import("@playwright/test").Page, events: [string, unknown][], prompt: string) {
+        await page.route("**/ai/threads/*/chat", async (route) => {
+            await route.fulfill({status: 200, contentType: "text/event-stream", body: sse(events)})
+        })
+        await page.locator(D.input).fill(prompt)
+        await page.locator(D.send).click()
+    }
+
+    for (const {tool, family} of PLATFORM_TOOLS) {
+        test(`renders the "${tool}" tool activity`, async ({page}) => {
+            await runTurn(page, [
+                ["tool_call", {tool, kind: "PLATFORM", family, arguments: {}}],
+                ["tool_result", {tool, outcome: "ok"}],
+                ["token", {text: "Done."}],
+                ["done", {status: "IDLE"}],
+            ], `use the ${tool} tool`)
+
+            await expect(page.locator(D.toolCall).filter({hasText: tool})).toBeVisible({timeout: 15000})
+            await expect(page.locator(D.toolResult).filter({hasText: tool})).toBeVisible({timeout: 15000})
+        })
+    }
+
+    for (const {tool, kind, title} of AUTHORING_TOOLS) {
+        test(`renders the "${tool}" authoring draft (${kind})`, async ({page}) => {
+            await runTurn(page, [
+                ["tool_call", {tool, kind: "AUTHORING", arguments: {}}],
+                ["artefact_draft", {draftId: tool, kind, yaml: `id: ${tool}`, valid: true, constraints: null}],
+                ["tool_result", {tool, outcome: "ok"}],
+                ["done", {status: "IDLE"}],
+            ], `use the ${tool} tool`)
+
+            const draft = page.locator(D.draft)
+            await expect(draft).toBeVisible({timeout: 15000})
+            await expect(draft).toContainText(title)
+            await expect(draft).toContainText(`id: ${tool}`)
+        })
+    }
+
+    test("renders every tool in a single multi-tool turn", async ({page}) => {
+        const events: [string, unknown][] = []
+        for (const {tool, family} of PLATFORM_TOOLS) {
+            events.push(["tool_call", {tool, kind: "PLATFORM", family, arguments: {}}])
+            events.push(["tool_result", {tool, outcome: "ok"}])
+        }
+        for (const {tool, kind} of AUTHORING_TOOLS) {
+            events.push(["tool_call", {tool, kind: "AUTHORING", arguments: {}}])
+            events.push(["artefact_draft", {draftId: tool, kind, yaml: `id: ${tool}`, valid: true, constraints: null}])
+            events.push(["tool_result", {tool, outcome: "ok"}])
+        }
+        events.push(["done", {status: "IDLE"}])
+
+        await runTurn(page, events, "exercise every tool")
+
+        await expect(page.locator(D.toolCall)).toHaveCount(PLATFORM_TOOLS.length + AUTHORING_TOOLS.length, {timeout: 15000})
+        await expect(page.locator(D.draft)).toHaveCount(AUTHORING_TOOLS.length)
+    })
+})

--- a/ui/tests/unit/components/ai/copilot/copilotToolCatalog.spec.ts
+++ b/ui/tests/unit/components/ai/copilot/copilotToolCatalog.spec.ts
@@ -1,0 +1,141 @@
+import {describe, it, expect, vi, beforeEach} from "vitest"
+import {mount} from "@vue/test-utils"
+import type {AiSseFrame} from "../../../../../src/components/ai/copilot/types"
+import {mountGlobal} from "./_helpers"
+
+// Mock the axios client (thread create) and the SSE reader so we can drive frames
+// deterministically without a backend — same harness as useAiChat.spec.
+const post = vi.fn()
+const get = vi.fn()
+vi.mock("@kestra-io/kestra-sdk", () => ({useClient: () => ({post, get})}))
+
+let nextFrames: AiSseFrame[] = []
+vi.mock("../../../../../src/components/ai/copilot/streamSse", async (importOriginal) => {
+    const actual = await importOriginal<typeof import("../../../../../src/components/ai/copilot/streamSse")>()
+    return {
+        ...actual,
+        streamSse: vi.fn(async ({onFrame}: {onFrame: (f: AiSseFrame) => void}) => {
+            for (const f of nextFrames) onFrame(f)
+        }),
+    }
+})
+vi.mock("override/utils/route", () => ({apiUrl: () => "http://localhost/api/v1/main"}))
+
+import {useAiChat} from "../../../../../src/components/ai/copilot/useAiChat"
+import CopilotMessage from "../../../../../src/components/ai/copilot/CopilotMessage.vue"
+
+// The AI Copilot v2 tool catalog, mirrored from the backend agent tools. This is the single
+// place the FE test suite enumerates every tool; add new tools here when the backend adds them.
+const PLATFORM_TOOLS = [
+    {tool: "read-execution", family: "READ"},
+    {tool: "list-executions", family: "READ"},
+    {tool: "read-execution-logs", family: "READ"},
+    {tool: "read-flow", family: "READ"},
+    {tool: "list-flows", family: "READ"},
+    {tool: "search-plugins", family: "READ"},
+    {tool: "get-plugin-schema", family: "READ"},
+    {tool: "validate-flow", family: "READ"},
+    {tool: "restart-execution", family: "ACT"},
+] as const
+
+const AUTHORING_TOOLS = [
+    {tool: "author-flow", kind: "FLOW", title: "Proposed flow"},
+    {tool: "author-dashboard", kind: "DASHBOARD", title: "Proposed dashboard"},
+    {tool: "author-app", kind: "APP", title: "Proposed app"},
+] as const
+
+/** A stream that exercises every tool: each platform tool calls + returns; each authoring tool
+ *  calls, emits a draft, then returns. */
+function catalogFrames(): AiSseFrame[] {
+    const frames: AiSseFrame[] = []
+    for (const t of PLATFORM_TOOLS) {
+        frames.push({event: "tool_call", data: {tool: t.tool, kind: "PLATFORM", family: t.family, arguments: {}}})
+        frames.push({event: "tool_result", data: {tool: t.tool, outcome: "ok"}})
+    }
+    for (const t of AUTHORING_TOOLS) {
+        frames.push({event: "tool_call", data: {tool: t.tool, kind: "AUTHORING", arguments: {}}})
+        frames.push({event: "artefact_draft", data: {draftId: t.tool, kind: t.kind, yaml: `id: ${t.tool}`, valid: true, constraints: null}})
+        frames.push({event: "tool_result", data: {tool: t.tool, outcome: "ok"}})
+    }
+    frames.push({event: "done", data: {status: "IDLE"}})
+    return frames
+}
+
+const mountMessage = (message: any) => mount(CopilotMessage, {props: {message}, global: mountGlobal})
+
+describe("AI Copilot v2 — full tool catalog", () => {
+    beforeEach(() => {
+        post.mockReset()
+        get.mockReset()
+        nextFrames = []
+        post.mockResolvedValue({data: {uid: "t1", mode: "EDIT", status: "IDLE", createdAt: "", updatedAt: ""}})
+    })
+
+    it("reduces a stream that exercises every tool into the expected transcript", async () => {
+        const chat = useAiChat()
+        nextFrames = catalogFrames()
+        await chat.sendChat({prompt: "exercise every tool", mode: "EDIT"})
+
+        // Every tool produced a tool_call carrying its name.
+        const calledTools = chat.messages.value.filter((m) => m.type === "TOOL_CALL").map((m) => m.toolCall?.tool)
+        for (const {tool} of [...PLATFORM_TOOLS, ...AUTHORING_TOOLS]) {
+            expect(calledTools).toContain(tool)
+        }
+
+        // Every tool produced an "ok" tool_result.
+        const okResults = chat.messages.value.filter((m) => m.type === "TOOL_RESULT" && m.toolResult?.outcome === "ok")
+        expect(okResults).toHaveLength(PLATFORM_TOOLS.length + AUTHORING_TOOLS.length)
+
+        // Authoring tools each produced an artefact draft of the right kind.
+        const draftKinds = chat.messages.value.filter((m) => m.type === "ARTEFACT_DRAFT").map((m) => m.draft?.kind)
+        expect(draftKinds).toEqual(AUTHORING_TOOLS.map((t) => t.kind))
+
+        expect(chat.status.value).toBe("IDLE")
+    })
+
+    it("preserves the tool_call → tool_result family/kind on the reduced messages", async () => {
+        const chat = useAiChat()
+        nextFrames = catalogFrames()
+        await chat.sendChat({prompt: "exercise every tool", mode: "EDIT"})
+
+        for (const {tool, family} of PLATFORM_TOOLS) {
+            const call = chat.messages.value.find((m) => m.type === "TOOL_CALL" && m.toolCall?.tool === tool)
+            expect(call?.toolCall?.family).toBe(family)
+            expect(call?.toolCall?.kind).toBe("PLATFORM")
+        }
+        for (const {tool} of AUTHORING_TOOLS) {
+            const call = chat.messages.value.find((m) => m.type === "TOOL_CALL" && m.toolCall?.tool === tool)
+            expect(call?.toolCall?.kind).toBe("AUTHORING")
+        }
+    })
+
+    it("renders a tool_call row showing the tool name for every platform tool", () => {
+        for (const {tool, family} of PLATFORM_TOOLS) {
+            const w = mountMessage({id: tool, role: "TOOL", type: "TOOL_CALL", toolCall: {tool, family, arguments: {}}})
+            expect(w.find(".copilot-tool-label").text()).toContain(tool)
+        }
+    })
+
+    it("renders an ok and a rejected tool_result for every platform tool", () => {
+        for (const {tool} of PLATFORM_TOOLS) {
+            const ok = mountMessage({id: `${tool}-ok`, role: "TOOL", type: "TOOL_RESULT", toolResult: {tool, outcome: "ok"}})
+            expect(ok.text()).toContain(tool)
+            expect(ok.text()).toContain("completed")
+
+            const rejected = mountMessage({id: `${tool}-x`, role: "TOOL", type: "TOOL_RESULT", toolResult: {tool, outcome: "rejected"}})
+            expect(rejected.text()).toContain("rejected")
+        }
+    })
+
+    it("renders an artefact-draft card for every authoring tool kind", () => {
+        for (const {tool, kind, title} of AUTHORING_TOOLS) {
+            const w = mountMessage({
+                id: tool, role: "ASSISTANT", type: "ARTEFACT_DRAFT",
+                draft: {draftId: tool, kind, yaml: `id: ${tool}`, valid: true, constraints: null},
+            })
+            expect(w.find(".copilot-draft").exists()).toBe(true)
+            expect(w.text()).toContain(title)
+            expect(w.find("[data-test=\"copilot-draft-yaml\"]").text()).toContain(`id: ${tool}`)
+        }
+    })
+})


### PR DESCRIPTION
## What

Frontend test coverage for the **AI Copilot v2 tool catalog**. The FE renders tools generically (no bespoke per-tool UI), so coverage is split into two layers:

### 1. All tools at once — unit (`copilotToolCatalog.spec.ts`), deterministic
- Drives the real `useAiChat` reducer with a stream that exercises **every** tool: `tool_call` + `tool_result` for each platform tool, and `tool_call` → `artefact_draft` → `tool_result` for each authoring tool.
- Asserts the reduced transcript (every tool called, every result `ok`, each authoring draft's kind) and that `tool_call.family`/`kind` are preserved.
- Mounts `CopilotMessage` for each tool to assert rendering (tool name row, ok/rejected result, and the draft card per kind FLOW/DASHBOARD/APP).

### 2. Each tool individually — e2e (`ai-copilot-tools.spec.ts`), deterministic
- One case per tool: stubs the `…/chat` SSE with that tool's frames (via `page.route`, no live provider) and asserts the real app shell renders its activity; plus a multi-tool turn that asserts all render.
- Follows the existing `ai-copilot.spec.ts` stubbed pattern → CI-friendly.

### Enabling change
- Added `data-test` anchors: `copilot-tool-call`, `copilot-tool-result`, `copilot-draft` (repo convention prefers `data-test` over class selectors for e2e).

**Catalog** (single source of truth in both specs): read/act tools `read-execution`, `list-executions`, `read-execution-logs`, `read-flow`, `list-flows`, `search-plugins`, `get-plugin-schema`, `validate-flow`, `restart-execution`; authoring `author-flow`, `author-dashboard`, `author-app`. Add new tools there when the backend adds them.

Unit suite green (72 tests), lint clean. Backend tool tests (`services/ai/agent/**`) also pass on this branch.
