### PR TITLE
fix: fetch task run outputs from dedicated endpoints

### DIFF
--- a/ui/src/components/executions/Outputs.vue
+++ b/ui/src/components/executions/Outputs.vue
@@ -4,25 +4,34 @@
     </KsDropdownItem>
 
     <KsDrawer v-if="isOpen" v-model="isOpen" :title="$t('outputs')">
-        <Vars
-            :execution="props.execution"
-            class="table-unrounded mt-1"
-            :data="props.outputs"
-        />
+        <div v-ks-loading="isLoading">
+            <Vars
+                :execution="props.execution"
+                class="table-unrounded mt-1"
+                :data="outputs"
+            />
+        </div>
     </KsDrawer>
 </template>
 
 <script setup lang="ts">
-    import {computed, ref, type PropType} from "vue"
+    import {computed, ref, watch, type PropType} from "vue"
+    import {vKsLoading} from "@kestra-io/design-system"
 
     import Vars from "../executions/Vars.vue"
+
+    import {useHasTaskRunOutputs, loadTaskRunOutputs} from "../../composables/useTaskRunOutputs"
 
     import LocationExit from "vue-material-design-icons/LocationExit.vue"
 
     const props = defineProps({
-        outputs: {
-            type: Object as PropType<object>,
-            default: () => ({}),
+        taskRun: {
+            type: Object as PropType<{id: string; state: {current: string}}>,
+            required: true,
+        },
+        executionId: {
+            type: String,
+            required: true,
         },
         execution: {
             type: Object as PropType<object>,
@@ -31,6 +40,26 @@
     })
 
     const isOpen = ref(false)
+    const outputs = ref<Record<string, unknown>>({})
+    const isLoading = ref(false)
 
-    const disabled = computed(() => !props.outputs || Object.keys(props.outputs).length === 0)
+    const hasOutputs = useHasTaskRunOutputs(
+        computed(() => props.executionId),
+        computed(() => props.taskRun.id),
+        computed(() => props.taskRun.state?.current),
+    )
+
+    const disabled = computed(() => !hasOutputs.value)
+
+    watch(isOpen, async (open) => {
+        if (!open || Object.keys(outputs.value).length > 0) {
+            return
+        }
+        isLoading.value = true
+        try {
+            outputs.value = await loadTaskRunOutputs(props.executionId, props.taskRun.id)
+        } finally {
+            isLoading.value = false
+        }
+    })
 </script>

--- a/ui/src/components/executions/TaskRunActions.vue
+++ b/ui/src/components/executions/TaskRunActions.vue
@@ -24,7 +24,8 @@
                 <Metrics :taskRun="taskRun" :execution="execution" />
 
                 <Outputs
-                    :outputs="taskRun.outputs"
+                    :taskRun="taskRun"
+                    :executionId="execution.id"
                     :execution="execution"
                 />
 

--- a/ui/src/components/inputs/LowCodeEditor.vue
+++ b/ui/src/components/inputs/LowCodeEditor.vue
@@ -108,16 +108,24 @@
                 </KsTabPane>
                 <KsTabPane :label="$t('outputs')" name="outputs">
                     <div class="tab-body outputs-view">
-                        <section v-for="taskRun in selectedTask.taskRuns" :key="taskRun.id" class="taskrun-card">
+                        <section
+                            v-for="taskRun in selectedTask.taskRuns"
+                            :key="taskRun.id"
+                            class="taskrun-card"
+                            v-ks-loading="isLoadingTaskRunOutputs(taskRun.id)"
+                        >
                             <div v-if="selectedTask.taskRuns.length > 1" class="taskrun-card__header">
                                 <KsExecutionStatus size="small" :status="taskRun.state.current" />
                                 <code class="taskrun-card__value">{{ taskRun.value ?? taskRun.id }}</code>
                             </div>
                             <Vars
-                                v-if="taskRun.outputs && Object.keys(taskRun.outputs).length > 0"
-                                :data="taskRun.outputs"
+                                v-if="taskRunOutputsById[taskRun.id] && Object.keys(taskRunOutputsById[taskRun.id]).length > 0"
+                                :data="taskRunOutputsById[taskRun.id]"
                             />
-                            <span v-else class="taskrun-card__empty">{{ $t("no outputs available") }}</span>
+                            <span
+                                v-else-if="!isLoadingTaskRunOutputs(taskRun.id)"
+                                class="taskrun-card__empty"
+                            >{{ $t("no outputs available") }}</span>
                         </section>
                     </div>
                 </KsTabPane>
@@ -218,10 +226,11 @@
     import PlayBoxMultiple from "vue-material-design-icons/PlayBoxMultiple.vue"
 
     import {Topology} from "@kestra-io/topology"
-    import {SECTIONS, State, KsMarkdown, KsEditor, KsDialog} from "@kestra-io/design-system"
+    import {SECTIONS, State, KsMarkdown, KsEditor, KsDialog, vKsLoading} from "@kestra-io/design-system"
     import {Execution} from "@kestra-io/kestra-sdk"
     import {flowYamlUtils as YAML_UTILS} from "@kestra-io/topology"
     import {useEditorBindings} from "../../composables/useEditorBindings"
+    import {loadTaskRunOutputs} from "../../composables/useTaskRunOutputs"
 
     import {TOPOLOGY_CLICK_INJECTION_KEY} from "../no-code/injectionKeys"
     import {useAuthStore} from "override/stores/auth"
@@ -502,6 +511,8 @@
     const inspectTab = ref<"logs" | "outputs" | "metrics">("logs")
     const isReplayPickerOpen = ref(false)
     const selectedTask = ref()
+    const taskRunOutputsById = ref<Record<string, Record<string, unknown>>>({})
+    const loadingOutputsTaskRunIds = ref<Set<string>>(new Set())
     const replayExecution = ref()
     const replayTaskRun = ref()
     const replayRef = ref<InstanceType<typeof Restart>>()
@@ -672,6 +683,42 @@
     const showLogs = (event: string) => openInspect(event, "logs")
 
     const showOutputs = (event: unknown) => openInspect(event, "outputs")
+
+    function isLoadingTaskRunOutputs(taskRunId: string): boolean {
+        return loadingOutputsTaskRunIds.value.has(taskRunId)
+    }
+
+    async function fetchTaskRunOutputs(executionId: string, taskRunId: string) {
+        if (taskRunOutputsById.value[taskRunId] || loadingOutputsTaskRunIds.value.has(taskRunId)) {
+            return
+        }
+        loadingOutputsTaskRunIds.value.add(taskRunId)
+        try {
+            taskRunOutputsById.value = {
+                ...taskRunOutputsById.value,
+                [taskRunId]: await loadTaskRunOutputs(executionId, taskRunId),
+            }
+        } finally {
+            loadingOutputsTaskRunIds.value.delete(taskRunId)
+        }
+    }
+
+    // Task run outputs live behind a dedicated endpoint since Kestra 2.0 (they are no
+    // longer embedded on the taskRun objects in selectedTask.taskRuns) — fetch them
+    // lazily once the outputs tab is actually shown.
+    watch(
+        [selectedTask, inspectTab, isInspectOpen],
+        ([task, tab, open]) => {
+            const executionId = task?.execution?.id
+            if (!open || tab !== "outputs" || !executionId) {
+                return
+            }
+            for (const taskRun of task.taskRuns ?? []) {
+                fetchTaskRunOutputs(executionId, taskRun.id)
+            }
+        },
+        {immediate: true},
+    )
 
     const openReplayDialog = (taskExecution: unknown, taskRun: unknown) => {
         replayExecution.value = taskExecution

--- a/ui/src/composables/useTaskRunOutputs.ts
+++ b/ui/src/composables/useTaskRunOutputs.ts
@@ -1,0 +1,69 @@
+import {ref, watch, type ComputedRef, type Ref} from "vue"
+import * as OutputsAPI from "@kestra-io/kestra-sdk/outputs"
+
+// Since Kestra 2.0, task run outputs are no longer embedded on the Execution
+// payload (`taskRun.outputs` is a deprecated pre-2.0 compatibility field) — they
+// live behind the dedicated /outputs endpoints. This module fetches "which task
+// runs have outputs" once per execution and shares the result across every
+// caller asking about that execution, instead of one request per row.
+const taskRunIdsWithOutputsCache = new Map<string, Promise<Set<string>>>()
+
+function fetchTaskRunIdsWithOutputs(executionId: string, forceRefresh: boolean): Promise<Set<string>> {
+    if (!forceRefresh) {
+        const cached = taskRunIdsWithOutputsCache.get(executionId)
+        if (cached) {
+            return cached
+        }
+    }
+
+    const pending = OutputsAPI.taskOutputsInformation(
+        {executionId},
+        {validateStatus: (status: number) => status === 200 || status === 404},
+    ).then((data: any) => new Set<string>((data ?? []).map((task: any) => task.taskRunId).filter(Boolean)))
+
+    taskRunIdsWithOutputsCache.set(executionId, pending)
+    return pending
+}
+
+/**
+ * Whether a given task run has outputs, per the dedicated outputs endpoint.
+ * Bypasses the cache whenever the task run's own state changes, so a still-running
+ * task correctly flips to "has outputs" once it finishes.
+ */
+export function useHasTaskRunOutputs(
+    executionId: ComputedRef<string | undefined> | Ref<string | undefined>,
+    taskRunId: ComputedRef<string | undefined> | Ref<string | undefined>,
+    taskRunState: ComputedRef<string | undefined> | Ref<string | undefined>,
+) {
+    const hasOutputs = ref(false)
+    let hasRunOnce = false
+
+    watch(
+        [executionId, taskRunId, taskRunState],
+        async ([execId, runId]) => {
+            if (!execId || !runId) {
+                hasOutputs.value = false
+                return
+            }
+            // Bypass the cache on any re-run after the first (e.g. the task run's own
+            // state just changed) so a still-running task correctly flips to "has
+            // outputs" once it finishes, instead of being stuck with a stale answer.
+            const forceRefresh = hasRunOnce
+            hasRunOnce = true
+            const taskRunIds = await fetchTaskRunIdsWithOutputs(execId, forceRefresh)
+            hasOutputs.value = taskRunIds.has(runId)
+        },
+        {immediate: true},
+    )
+
+    return hasOutputs
+}
+
+/** Fetches a single task run's output values. Returns an empty object when there are none. */
+export async function loadTaskRunOutputs(executionId: string, taskRunId: string): Promise<Record<string, unknown>> {
+    const data = await OutputsAPI.taskRunOutputs(
+        {executionId, taskRunId},
+        {validateStatus: (status: number) => status === 200 || status === 404},
+    )
+    return data ?? {}
+}

--- a/ui/tests/unit/composables/useTaskRunOutputs.spec.ts
+++ b/ui/tests/unit/composables/useTaskRunOutputs.spec.ts
@@ -1,0 +1,86 @@
+import {describe, test, expect, vi, beforeEach} from "vitest"
+import {ref} from "vue"
+import {flushPromises} from "@vue/test-utils"
+
+const taskOutputsInformationMock = vi.fn()
+const taskRunOutputsMock = vi.fn()
+
+vi.mock("@kestra-io/kestra-sdk/outputs", () => ({
+    taskOutputsInformation: (...args: unknown[]) => taskOutputsInformationMock(...args),
+    taskRunOutputs: (...args: unknown[]) => taskRunOutputsMock(...args),
+}))
+
+import {useHasTaskRunOutputs, loadTaskRunOutputs} from "../../../src/composables/useTaskRunOutputs"
+
+describe("useTaskRunOutputs", () => {
+    beforeEach(() => {
+        taskOutputsInformationMock.mockReset()
+        taskRunOutputsMock.mockReset()
+    })
+
+    test("resolves true for a task run present in taskOutputsInformation", async () => {
+        taskOutputsInformationMock.mockResolvedValue([{taskRunId: "tr-1"}, {taskRunId: "tr-2"}])
+
+        const hasOutputs = useHasTaskRunOutputs(ref("exec-1"), ref("tr-1"), ref("SUCCESS"))
+        await flushPromises()
+
+        expect(hasOutputs.value).toBe(true)
+    })
+
+    test("resolves false for a task run absent from taskOutputsInformation", async () => {
+        taskOutputsInformationMock.mockResolvedValue([{taskRunId: "tr-1"}])
+
+        const hasOutputs = useHasTaskRunOutputs(ref("exec-2"), ref("tr-unknown"), ref("SUCCESS"))
+        await flushPromises()
+
+        expect(hasOutputs.value).toBe(false)
+    })
+
+    test("shares a single taskOutputsInformation request across task runs of the same execution", async () => {
+        taskOutputsInformationMock.mockResolvedValue([{taskRunId: "tr-a"}])
+
+        const executionId = ref("exec-shared")
+        useHasTaskRunOutputs(executionId, ref("tr-a"), ref("SUCCESS"))
+        useHasTaskRunOutputs(executionId, ref("tr-b"), ref("SUCCESS"))
+        await flushPromises()
+
+        expect(taskOutputsInformationMock).toHaveBeenCalledTimes(1)
+    })
+
+    test("bypasses the cache and re-checks when the task run's own state changes", async () => {
+        taskOutputsInformationMock
+            .mockResolvedValueOnce([])
+            .mockResolvedValueOnce([{taskRunId: "tr-running"}])
+
+        const taskRunState = ref("RUNNING")
+        const hasOutputs = useHasTaskRunOutputs(ref("exec-live"), ref("tr-running"), taskRunState)
+        await flushPromises()
+        expect(hasOutputs.value).toBe(false)
+
+        taskRunState.value = "SUCCESS"
+        await flushPromises()
+
+        expect(hasOutputs.value).toBe(true)
+        expect(taskOutputsInformationMock).toHaveBeenCalledTimes(2)
+    })
+
+    test("loadTaskRunOutputs returns the fetched outputs", async () => {
+        taskRunOutputsMock.mockResolvedValue({body: {id: 1}})
+
+        const outputs = await loadTaskRunOutputs("exec-1", "tr-1")
+
+        expect(outputs).toEqual({body: {id: 1}})
+        expect(taskRunOutputsMock).toHaveBeenCalledWith(
+            {executionId: "exec-1", taskRunId: "tr-1"},
+            expect.objectContaining({validateStatus: expect.any(Function)}),
+        )
+    })
+
+    test("loadTaskRunOutputs returns an empty object when there are none", async () => {
+        taskRunOutputsMock.mockResolvedValue(null)
+
+        const outputs = await loadTaskRunOutputs("exec-1", "tr-2")
+
+        expect(outputs).toEqual({})
+    })
+})


### PR DESCRIPTION
Fetches task run outputs from the dedicated `/outputs` endpoints instead of the deprecated `taskRun.outputs` field, which the Execution API no longer populates since Kestra 2.0. This was leaving Gantt's "Outputs" menu item permanently disabled and Topology's "Show task outputs" drawer always empty, even when a task produced outputs. Both views now fetch outputs lazily and show a loading state while doing so.

- Adds a shared `useTaskRunOutputs` composable with per-execution caching to avoid duplicate requests
- Adds unit tests for the new composable

Closes kestra-io/kestra-ee#9087