### PR TITLE
ci: reuse EE compile-check webhook in main workflow

### DIFF
--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -22,13 +22,39 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  # When an OSS ci start, we trigger an EE one
+  # When develop lands a push, run the kestra-ee compile check for the ref (via a
+  # Kestra webhook) and surface the result inline. Replaces the async
+  # "oss-updated" repository_dispatch round-trip.
   trigger-ee:
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout  # required so the local composite action below can resolve
+        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/develop' }}
+        uses: actions/checkout@v4
+
+      # Run the EE compileJava check for the pushed ref on a Kestra instance and
+      # surface the result inline. The flow resolves the matching kestra-ee ref
+      # itself (same-name branch, else develop). commit-sha posts a commit-status
+      # callback on the develop HEAD so EE-compile health is visible on develop.
+      - name: EE compile check (via Kestra webhook)
+        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/develop' }}
+        uses: ./.github/actions/ee-compile-check
+        with:
+          webhook-url: ${{ secrets.KESTRA_CI_EEBUILD_WEBHOOK_URL }}
+          ref: ${{ github.ref_name }}
+          commit-sha: ${{ github.sha }}
+          pr-repo: ${{ github.repository }}
+
+      # ------------------------------------------------------------------------
+      # LEGACY (DISABLED): the develop push used to trigger the full kestra-ee
+      # workflow asynchronously via an "oss-updated" repository dispatch. It is
+      # superseded by the synchronous "EE compile check (via Kestra webhook)"
+      # step above. Kept here, guarded by `false &&`, for quick rollback — drop
+      # the `false &&` (and disable the webhook step above) to re-enable.
+      # ------------------------------------------------------------------------
       # Targeting develop branch from develop
       - name: Trigger EE Workflow (develop push, no payload)
-        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/develop' }}
+        if: ${{ false && (github.event_name == 'push' && github.ref == 'refs/heads/develop') }}
         uses: kestra-io/actions/composite/repository-dispatch@main
         with:
           gh-app-id: ${{ secrets.GH_BOT_APP_ID }}

--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -22,20 +22,14 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  # When develop lands a push, run the kestra-ee compile check for the ref (via a
-  # Kestra webhook) and surface the result inline. Replaces the async
-  # "oss-updated" repository_dispatch round-trip.
+  # On develop push, run the kestra-ee compile check for the ref via a Kestra webhook.
   trigger-ee:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout  # required so the local composite action below can resolve
+      - name: Checkout  # required to resolve the local composite action below
         if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/develop' }}
         uses: actions/checkout@v4
 
-      # Run the EE compileJava check for the pushed ref on a Kestra instance and
-      # surface the result inline. The flow resolves the matching kestra-ee ref
-      # itself (same-name branch, else develop). commit-sha posts a commit-status
-      # callback on the develop HEAD so EE-compile health is visible on develop.
       - name: EE compile check (via Kestra webhook)
         if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/develop' }}
         uses: ./.github/actions/ee-compile-check
@@ -45,14 +39,8 @@ jobs:
           commit-sha: ${{ github.sha }}
           pr-repo: ${{ github.repository }}
 
-      # ------------------------------------------------------------------------
-      # LEGACY (DISABLED): the develop push used to trigger the full kestra-ee
-      # workflow asynchronously via an "oss-updated" repository dispatch. It is
-      # superseded by the synchronous "EE compile check (via Kestra webhook)"
-      # step above. Kept here, guarded by `false &&`, for quick rollback — drop
-      # the `false &&` (and disable the webhook step above) to re-enable.
-      # ------------------------------------------------------------------------
-      # Targeting develop branch from develop
+      # LEGACY (DISABLED): superseded by the webhook step above; kept behind
+      # `false &&` for quick rollback.
       - name: Trigger EE Workflow (develop push, no payload)
         if: ${{ false && (github.event_name == 'push' && github.ref == 'refs/heads/develop') }}
         uses: kestra-io/actions/composite/repository-dispatch@main


### PR DESCRIPTION
Reuses the synchronous webhook-based EE compile check introduced in #17115 (which wired it into `pull-request.yml`) inside the main-branch CI (`main-build.yml`).

## What changed

The `trigger-ee` job in `main-build.yml` previously fired an async `oss-updated` `repository_dispatch` at kestra-ee on every `develop` push and forgot about it. It now instead calls the shared composite action `./.github/actions/ee-compile-check` — the same one `pull-request.yml` uses — to run the kestra-ee `compileJava` check for the pushed ref via the Kestra webhook and surface the result inline.

- **`ref`**: `github.ref_name` (the flow resolves the matching kestra-ee ref — same-name branch, else `develop`).
- **`commit-sha`**: `github.sha`, so the flow posts a commit-status callback on the `develop` HEAD — EE-compile health is visible directly on develop.
- **`pr-repo`**: `github.repository` for that callback.
- Requires a `checkout` step (added) so the local composite action can resolve.

The legacy `oss-updated` `repository_dispatch` is **kept but disabled** behind `false &&`, mirroring the rollback pattern in `pull-request.yml` — drop the `false &&` (and disable the webhook step) to revert.

Consumes the existing `KESTRA_CI_EEBUILD_WEBHOOK_URL` repo secret introduced by #17115.

## Notes / open question

Behavior is scoped to `develop` pushes only, exactly as the previous trigger was. The `end` (Slack) job's `needs` were left unchanged, so an EE-compile failure on develop fails the `trigger-ee` job (visible in the Actions UI + as a commit status) but does not currently trigger the Slack failure notification. Happy to wire `trigger-ee` into the `end` job if you'd like develop-breaking EE-compile failures to also ping Slack — left it out to keep scope tight and avoid noise from transient webhook/infra failures.