### PR TITLE
fix(triggers): bound polling trigger evaluation with a timeout to prevent silent lock leaks

### DIFF
--- a/scheduler/src/main/java/io/kestra/scheduler/AbstractScheduler.java
+++ b/scheduler/src/main/java/io/kestra/scheduler/AbstractScheduler.java
@@ -743,8 +743,9 @@ public abstract class AbstractScheduler implements Scheduler {
                                 Trigger triggerRunning = Trigger.of(f.getTriggerContext(), now);
                                 var flowWithTrigger = f.toBuilder().triggerContext(triggerRunning).build();
                                 try {
-                                    this.triggerState.save(triggerRunning, scheduleContext, "/kestra/services/scheduler/handle/save/on-eval-true/polling");
-                                    this.sendWorkerTriggerToWorker(flowWithTrigger);
+                                    if (this.sendWorkerTriggerToWorker(flowWithTrigger)) {
+                                        this.triggerState.save(triggerRunning, scheduleContext, "/kestra/services/scheduler/handle/save/on-eval-true/polling");
+                                    }
                                 } catch (InternalException e) {
                                     Logs.logTrigger(
                                         f.getTriggerContext(),
@@ -1113,7 +1114,15 @@ public abstract class AbstractScheduler implements Scheduler {
         );
     }
 
-    private void sendWorkerTriggerToWorker(FlowWithWorkerTrigger flowWithTrigger) throws InternalException {
+    /**
+     * Sends a worker trigger evaluation job to a worker.
+     *
+     * @return {@code true} if the job was actually dispatched to a worker, {@code false} for every
+     *         no-dispatch outcome (no worker group for the key, FAIL/CANCEL fallback when no worker is
+     *         available, or a queue emission error). The caller must only take the trigger evaluation
+     *         lock when this returns {@code true}, otherwise the trigger would stay locked forever.
+     */
+    private boolean sendWorkerTriggerToWorker(FlowWithWorkerTrigger flowWithTrigger) throws InternalException {
         if (log.isDebugEnabled()) {
             Logs.logTrigger(
                 flowWithTrigger.getTriggerContext(),
@@ -1138,32 +1147,44 @@ public abstract class AbstractScheduler implements Scheduler {
                 String workerGroupKey = runContext.render(workerGroup.get().getKey());
                 if (WorkerGroup.isDefault(workerGroupKey)) {
                     this.workerJobQueue.emit(workerTrigger);
+                    return true;
                 } else if (workerGroupExecutorInterface.isWorkerGroupExistForKey(workerGroupKey, tenantId)) {
                     // Check whether at-least one worker is available
                     if (workerGroupExecutorInterface.isWorkerGroupAvailableForKey(workerGroupKey)) {
                         this.workerJobQueue.emit(workerGroupKey, workerTrigger);
+                        return true;
                     } else {
                         WorkerGroup.Fallback fallback = workerGroup.map(WorkerGroup::getFallback).orElse(WorkerGroup.Fallback.WAIT);
-                        switch (fallback) {
-                            case FAIL -> runContext.logger()
-                                .error("No workers are available for worker group '{}', ignoring the trigger.", workerGroupKey);
-                            case CANCEL -> runContext.logger()
-                                .warn("No workers are available for worker group '{}', ignoring the trigger.", workerGroupKey);
+                        return switch (fallback) {
+                            case FAIL -> {
+                                runContext.logger()
+                                    .error("No workers are available for worker group '{}', ignoring the trigger.", workerGroupKey);
+                                yield false;
+                            }
+                            case CANCEL -> {
+                                runContext.logger()
+                                    .warn("No workers are available for worker group '{}', ignoring the trigger.", workerGroupKey);
+                                yield false;
+                            }
                             case WAIT -> {
                                 runContext.logger()
                                     .info("No workers are available for worker group '{}', waiting for one to be available.", workerGroupKey);
                                 this.workerJobQueue.emit(workerGroupKey, workerTrigger);
+                                yield true;
                             }
-                        }
+                        };
                     }
                 } else {
                     runContext.logger().error("No worker group exist for key '{}', ignoring the trigger.", workerGroupKey);
+                    return false;
                 }
             } else {
                 this.workerJobQueue.emit(workerTrigger);
+                return true;
             }
         } catch (QueueException e) {
             log.error("Unable to emit the Worker Trigger job", e);
+            return false;
         }
     }
 

--- a/scheduler/src/test/java/io/kestra/scheduler/SchedulerTriggerDispatchLockTest.java
+++ b/scheduler/src/test/java/io/kestra/scheduler/SchedulerTriggerDispatchLockTest.java
@@ -1,0 +1,98 @@
+package io.kestra.scheduler;
+
+import java.time.Duration;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+
+import io.kestra.core.models.flows.Flow;
+import io.kestra.core.models.tasks.WorkerGroup;
+import io.kestra.core.models.triggers.Trigger;
+import io.kestra.core.runners.FlowListeners;
+import io.kestra.core.runners.SchedulerTriggerStateInterface;
+import io.kestra.core.runners.WorkerGroupExecutorInterface;
+import io.kestra.core.services.WorkerGroupService;
+import io.kestra.core.tasks.test.PollingTrigger;
+import io.kestra.core.utils.Await;
+import io.kestra.jdbc.runner.JdbcScheduler;
+
+import io.micronaut.context.ApplicationContext;
+import io.micronaut.test.annotation.MockBean;
+import jakarta.inject.Inject;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+
+/**
+ * Verifies that the scheduler only takes a polling trigger's evaluation lock when the worker job was
+ * actually dispatched. When dispatch is a no-op (here: the resolved worker group does not exist), the
+ * trigger must stay unlocked (evaluateRunningDate == null) so it remains eligible for scheduling
+ * instead of being silently stuck forever.
+ */
+public class SchedulerTriggerDispatchLockTest extends AbstractSchedulerTest {
+    @Inject
+    protected ApplicationContext applicationContext;
+
+    @Inject
+    private FlowListeners flowListenersService;
+
+    @Inject
+    private SchedulerTriggerStateInterface schedulerTriggerState;
+
+    @MockBean(WorkerGroupService.class)
+    WorkerGroupService workerGroupService() {
+        WorkerGroupService mockService = mock(WorkerGroupService.class);
+        when(mockService.resolveGroupFromJob(any(), any())).thenReturn(Optional.of(new WorkerGroup("missing-group", null)));
+        when(mockService.resolveGroupFromKey(any())).thenReturn(null);
+        return mockService;
+    }
+
+    @MockBean(WorkerGroupExecutorInterface.class)
+    WorkerGroupExecutorInterface workerGroupExecutorInterface() {
+        WorkerGroupExecutorInterface mockExecutor = mock(WorkerGroupExecutorInterface.class);
+        // the resolved worker group does not exist -> the scheduler cannot dispatch the trigger job
+        when(mockExecutor.isWorkerGroupExistForKey(any(), any())).thenReturn(false);
+        when(mockExecutor.isWorkerGroupAvailableForKey(any())).thenReturn(false);
+        when(mockExecutor.listAllWorkerGroupKeys()).thenReturn(Set.of());
+        return mockExecutor;
+    }
+
+    @Test
+    void shouldNotLockTriggerWhenWorkerJobNotDispatched() throws Exception {
+        FlowListeners flowListenersServiceSpy = spy(this.flowListenersService);
+        PollingTrigger pollingTrigger = PollingTrigger.builder()
+            .id("polling-trigger")
+            .type(PollingTrigger.class.getName())
+            .duration(500L)
+            .build();
+        Flow flow = createFlow(Collections.singletonList(pollingTrigger));
+        doReturn(List.of(flow)).when(flowListenersServiceSpy).flows();
+
+        try (AbstractScheduler scheduler = new JdbcScheduler(applicationContext, flowListenersServiceSpy)) {
+            scheduler.run();
+
+            Trigger trigger = Trigger.of(flow, pollingTrigger);
+
+            // wait until the scheduler has created & started evaluating the trigger
+            Await.until(() -> schedulerTriggerState.findLast(trigger).isPresent(), Duration.ofMillis(100), Duration.ofSeconds(10));
+
+            // Across several evaluation ticks the trigger must never acquire the evaluation lock, because
+            // the worker job is never dispatched. Before the fix, the lock was persisted on the first tick
+            // and never released, silently stalling the schedule.
+            for (int i = 0; i < 15; i++) {
+                assertThat(schedulerTriggerState.findLast(trigger))
+                    .get()
+                    .extracting(Trigger::getEvaluateRunningDate)
+                    .isNull();
+                Thread.sleep(200);
+            }
+        }
+    }
+}

--- a/worker/src/main/java/io/kestra/worker/DefaultWorker.java
+++ b/worker/src/main/java/io/kestra/worker/DefaultWorker.java
@@ -37,6 +37,7 @@ import com.google.common.collect.ImmutableList;
 
 import io.kestra.core.exceptions.DeserializationException;
 import io.kestra.core.exceptions.IllegalVariableEvaluationException;
+import io.kestra.core.exceptions.TimeoutExceededException;
 import io.kestra.core.metrics.MetricRegistry;
 import io.kestra.core.models.Label;
 import io.kestra.core.models.assets.Asset;
@@ -121,6 +122,9 @@ public class DefaultWorker implements Worker {
 
     @Inject
     private ServerConfig serverConfig;
+
+    @Inject
+    private WorkerConfig workerConfig;
 
     @Inject
     private RunContextInitializer runContextInitializer;
@@ -615,10 +619,15 @@ public class DefaultWorker implements Worker {
                     );
 
                     if (workerTrigger.getTrigger() instanceof PollingTriggerInterface pollingTrigger) {
-                        WorkerTriggerCallable workerCallable = new WorkerTriggerCallable(runContext, workerTrigger, pollingTrigger);
+                        WorkerTriggerCallable workerCallable = new WorkerTriggerCallable(runContext, workerTrigger, pollingTrigger, workerConfig.triggerEvaluationTimeout());
                         io.kestra.core.models.flows.State.Type state = callJob(workerCallable);
 
                         if (workerCallable.getException() != null || !state.equals(SUCCESS)) {
+                            if (workerCallable.getException() instanceof TimeoutExceededException) {
+                                metricRegistry
+                                    .counter(MetricRegistry.METRIC_WORKER_TIMEOUT_COUNT, MetricRegistry.METRIC_WORKER_TIMEOUT_COUNT_DESCRIPTION, metricRegistry.tags(workerTrigger, workerGroup))
+                                    .increment();
+                            }
                             this.handleTriggerError(workerTrigger, workerCallable.getException());
                         }
 

--- a/worker/src/main/java/io/kestra/worker/DefaultWorker.java
+++ b/worker/src/main/java/io/kestra/worker/DefaultWorker.java
@@ -619,7 +619,7 @@ public class DefaultWorker implements Worker {
                     );
 
                     if (workerTrigger.getTrigger() instanceof PollingTriggerInterface pollingTrigger) {
-                        WorkerTriggerCallable workerCallable = new WorkerTriggerCallable(runContext, workerTrigger, pollingTrigger, workerConfig.triggerEvaluationTimeout());
+                        WorkerTriggerCallable workerCallable = new WorkerTriggerCallable(runContext, workerTrigger, pollingTrigger, workerConfig.pollingTriggerTimeout());
                         io.kestra.core.models.flows.State.Type state = callJob(workerCallable);
 
                         if (workerCallable.getException() != null || !state.equals(SUCCESS)) {

--- a/worker/src/main/java/io/kestra/worker/WorkerConfig.java
+++ b/worker/src/main/java/io/kestra/worker/WorkerConfig.java
@@ -1,0 +1,26 @@
+package io.kestra.worker;
+
+import java.time.Duration;
+
+import io.micronaut.context.annotation.ConfigurationProperties;
+import io.micronaut.core.annotation.Nullable;
+import io.micronaut.core.bind.annotation.Bindable;
+
+/**
+ * Worker configuration.
+ *
+ * @param triggerEvaluationTimeout The maximum time a polling trigger evaluation is allowed to run on
+ *        a worker before it is interrupted. This bounds evaluations that would otherwise block
+ *        forever (e.g. a stuck {@code KafkaConsumer.poll()} during a consumer-group rebalance): on
+ *        timeout the worker thread is freed and an error result is emitted so the scheduler releases
+ *        the trigger evaluation lock instead of leaving the trigger silently stuck. Applies to
+ *        polling triggers only (realtime triggers run for their whole lifetime by design). The
+ *        default is deliberately generous so that legitimate long evaluations are never interrupted;
+ *        lower it if faster recovery from hangs is desired.
+ */
+@ConfigurationProperties("kestra.worker")
+public record WorkerConfig(
+    @Bindable(defaultValue = "10m")
+    @Nullable Duration triggerEvaluationTimeout
+) {
+}

--- a/worker/src/main/java/io/kestra/worker/WorkerConfig.java
+++ b/worker/src/main/java/io/kestra/worker/WorkerConfig.java
@@ -9,7 +9,7 @@ import io.micronaut.core.bind.annotation.Bindable;
 /**
  * Worker configuration.
  *
- * @param triggerEvaluationTimeout The maximum time a polling trigger evaluation is allowed to run on
+ * @param pollingTriggerTimeout The maximum time a polling trigger evaluation is allowed to run on
  *        a worker before it is interrupted. This bounds evaluations that would otherwise block
  *        forever (e.g. a stuck {@code KafkaConsumer.poll()} during a consumer-group rebalance): on
  *        timeout the worker thread is freed and an error result is emitted so the scheduler releases
@@ -21,6 +21,6 @@ import io.micronaut.core.bind.annotation.Bindable;
 @ConfigurationProperties("kestra.worker")
 public record WorkerConfig(
     @Bindable(defaultValue = "10m")
-    @Nullable Duration triggerEvaluationTimeout
+    @Nullable Duration pollingTriggerTimeout
 ) {
 }

--- a/worker/src/main/java/io/kestra/worker/WorkerTriggerCallable.java
+++ b/worker/src/main/java/io/kestra/worker/WorkerTriggerCallable.java
@@ -1,13 +1,17 @@
 package io.kestra.worker;
 
+import java.time.Duration;
 import java.util.Optional;
 
+import io.kestra.core.exceptions.TimeoutExceededException;
 import io.kestra.core.models.executions.Execution;
 import io.kestra.core.models.flows.State;
 import io.kestra.core.models.triggers.PollingTriggerInterface;
 import io.kestra.core.runners.RunContext;
 import io.kestra.core.runners.WorkerTrigger;
 
+import dev.failsafe.Failsafe;
+import dev.failsafe.Timeout;
 import lombok.Getter;
 
 import static io.kestra.core.models.flows.State.Type.SUCCESS;
@@ -15,20 +19,58 @@ import static io.kestra.core.models.flows.State.Type.SUCCESS;
 public class WorkerTriggerCallable extends AbstractWorkerTriggerCallable {
     PollingTriggerInterface pollingTrigger;
 
+    // Maximum time the evaluation is allowed to run before being interrupted; null disables the timeout.
+    private final Duration triggerEvaluationTimeout;
+
     @Getter
     Optional<Execution> evaluate;
 
     WorkerTriggerCallable(RunContext runContext, WorkerTrigger workerTrigger, PollingTriggerInterface pollingTrigger) {
+        this(runContext, workerTrigger, pollingTrigger, null);
+    }
+
+    WorkerTriggerCallable(RunContext runContext, WorkerTrigger workerTrigger, PollingTriggerInterface pollingTrigger, Duration triggerEvaluationTimeout) {
         super(runContext, pollingTrigger.getClass().getName(), workerTrigger);
         this.pollingTrigger = pollingTrigger;
+        this.triggerEvaluationTimeout = triggerEvaluationTimeout;
     }
 
     @Override
     public State.Type doCall() throws Exception {
-        this.evaluate = this.pollingTrigger.evaluate(
+        if (triggerEvaluationTimeout == null) {
+            this.evaluate = this.evaluateTrigger();
+            return SUCCESS;
+        }
+
+        Timeout<Object> timeout = Timeout
+            .builder(triggerEvaluationTimeout)
+            .withInterrupt() // use to awake blocking evaluations, e.g. a stuck KafkaConsumer.poll().
+            .build();
+        try {
+            Failsafe.with(timeout).run(() -> this.evaluate = this.evaluateTrigger());
+            return SUCCESS;
+        } catch (dev.failsafe.TimeoutExceededException e) {
+            // Interrupt the (potentially blocked) evaluation and free the worker thread.
+            // Setting the exception (killed stays false) makes the caller emit an error trigger result,
+            // which releases the scheduler's evaluation lock instead of leaving the trigger stuck.
+            kill(false);
+            // Clear the interrupt flag set by Failsafe's withInterrupt() so it doesn't leak
+            // to the caller (e.g., queue emission after timeout).
+            Thread.interrupted();
+            return this.exceptionHandler(new TimeoutExceededException(triggerEvaluationTimeout));
+        } catch (dev.failsafe.FailsafeException e) {
+            // Failsafe wraps evaluation exceptions; unwrap so they are handled like a normal evaluation failure.
+            if (e.getCause() instanceof Exception cause) {
+                throw cause;
+            }
+            throw e;
+        }
+    }
+
+    private Optional<Execution> evaluateTrigger() throws Exception {
+        return this.pollingTrigger.evaluate(
             workerTrigger.getConditionContext().withRunContext(runContext),
             workerTrigger.getTriggerContext()
         );
-        return SUCCESS;
     }
 }

--- a/worker/src/test/java/io/kestra/worker/WorkerTriggerCallableTest.java
+++ b/worker/src/test/java/io/kestra/worker/WorkerTriggerCallableTest.java
@@ -1,0 +1,103 @@
+package io.kestra.worker;
+
+import java.time.Duration;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+
+import io.kestra.core.exceptions.TimeoutExceededException;
+import io.kestra.core.junit.annotations.KestraTest;
+import io.kestra.core.models.conditions.ConditionContext;
+import io.kestra.core.models.flows.Flow;
+import io.kestra.core.models.flows.State;
+import io.kestra.core.models.triggers.AbstractTrigger;
+import io.kestra.core.models.triggers.PollingTriggerInterface;
+import io.kestra.core.models.triggers.Trigger;
+import io.kestra.core.runners.DefaultRunContext;
+import io.kestra.core.runners.RunContext;
+import io.kestra.core.runners.RunContextFactory;
+import io.kestra.core.runners.RunContextInitializer;
+import io.kestra.core.runners.WorkerTrigger;
+import io.kestra.core.tasks.test.SleepTrigger;
+import io.kestra.core.utils.IdUtils;
+
+import jakarta.inject.Inject;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@KestraTest
+class WorkerTriggerCallableTest {
+    @Inject
+    RunContextFactory runContextFactory;
+
+    @Inject
+    RunContextInitializer runContextInitializer;
+
+    @Test
+    void shouldInterruptAndFailWhenEvaluationExceedsTimeout() {
+        // Given: a polling trigger whose evaluation blocks far longer than the timeout
+        SleepTrigger trigger = SleepTrigger.builder()
+            .id("sleep")
+            .type(SleepTrigger.class.getName())
+            .duration(Duration.ofMinutes(5).toMillis())
+            .build();
+        WorkerTriggerCallable callable = callable(trigger, Duration.ofMillis(300));
+
+        // When
+        State.Type state = callable.call();
+
+        // Then: the evaluation is interrupted, marked failed, and carries a TimeoutExceededException
+        // (the caller emits an error trigger result on this, which releases the scheduler lock)
+        // The FAILED state makes handleTrigger route to handleTriggerError (which releases the lock)
+        // and skip publishTriggerExecution, so any partial getEvaluate() value is irrelevant here.
+        assertThat(state).isEqualTo(State.Type.FAILED);
+        assertThat(callable.getException()).isInstanceOf(TimeoutExceededException.class);
+    }
+
+    @Test
+    void shouldSucceedWhenEvaluationCompletesWithinTimeout() {
+        // Given: a fast evaluation with a generous timeout
+        SleepTrigger trigger = SleepTrigger.builder()
+            .id("sleep")
+            .type(SleepTrigger.class.getName())
+            .duration(1L)
+            .build();
+        WorkerTriggerCallable callable = callable(trigger, Duration.ofSeconds(30));
+
+        // When
+        State.Type state = callable.call();
+
+        // Then
+        assertThat(state).isEqualTo(State.Type.SUCCESS);
+        assertThat(callable.getException()).isNull();
+        assertThat(callable.getEvaluate()).isEqualTo(Optional.empty());
+    }
+
+    private WorkerTriggerCallable callable(AbstractTrigger trigger, Duration timeout) {
+        Flow flow = Flow.builder()
+            .id(IdUtils.create())
+            .namespace("io.kestra.tests")
+            .build();
+
+        Trigger triggerContext = Trigger.builder()
+            .namespace(flow.getNamespace())
+            .flowId(flow.getId())
+            .triggerId(trigger.getId())
+            .build();
+
+        RunContext runContext = runContextInitializer.forScheduler((DefaultRunContext) runContextFactory.of(), triggerContext, trigger);
+
+        ConditionContext conditionContext = ConditionContext.builder()
+            .runContext(runContext)
+            .flow(flow)
+            .build();
+
+        WorkerTrigger workerTrigger = WorkerTrigger.builder()
+            .trigger(trigger)
+            .triggerContext(triggerContext)
+            .conditionContext(conditionContext)
+            .build();
+
+        return new WorkerTriggerCallable(runContext, workerTrigger, (PollingTriggerInterface) trigger, timeout);
+    }
+}


### PR DESCRIPTION
### What does this PR do?

Fixes a bug where a **polling trigger** on the JDBC backend could get **silently stuck** — its *Next execution date* freezes and never advances, with no error and nothing in the flow logs — until an operator manually clicks **Unlock** (after which it eventually gets stuck again).

Closes #17445

### Root cause

The polling trigger's evaluation lock (`Trigger.evaluateRunningDate`) leaks whenever the worker produces **no result** (as opposed to throwing — thrown exceptions are already handled and release the lock):

1. **Evaluation hangs.** `DefaultWorker.callJob` runs `evaluate()` synchronously with **no timeout**, so a blocking evaluation (e.g. a stuck `KafkaConsumer.poll()` during a consumer-group rebalance) wedges the worker thread forever and never emits a result.
2. **No-dispatch swallowed.** `AbstractScheduler.sendWorkerTriggerToWorker` persisted the lock *before* dispatching, then swallowed no-dispatch outcomes (no worker group for the key, `FAIL`/`CANCEL` fallback, queue emission error), locking the trigger with no job ever running.

There was no automatic recovery — only a scheduler restart or manual Unlock.

### Changes

- **Worker-level trigger-evaluation timeout** (`kestra.worker.trigger-evaluation-timeout`, default `PT10M`): `WorkerTriggerCallable` now bounds `evaluate()` with a Failsafe `Timeout.withInterrupt()`, mirroring `WorkerTaskCallable`. On timeout the evaluation is interrupted (freeing the worker thread) and an error result is emitted, which releases the scheduler's evaluation lock. Applies to polling triggers only; realtime triggers are unaffected. The default is deliberately generous so legitimate long evaluations are never cut — lower it for faster recovery from hangs.
- **Lock only on actual dispatch**: `sendWorkerTriggerToWorker` now returns whether the job was really dispatched, and `handle()` persists `evaluateRunningDate` only when it was.

### How was it tested?

- `WorkerTriggerCallableTest` — a blocking evaluation is interrupted and reported as `FAILED` with a `TimeoutExceededException`; a fast evaluation returns `SUCCESS`.
- `SchedulerTriggerDispatchLockTest` — a no-dispatch outcome leaves the trigger unlocked (verified to fail if the fix is reverted).
- Full `:worker:test` and `:scheduler:test` suites pass (existing `SchedulerPollingTriggerTest` still green — normal dispatch is unaffected).

### Notes

- Targets `releases/v1.3.x`. All changes are in OSS; Enterprise inherits them (EE does not override `DefaultWorker` or the scheduler).
- Trigger evaluation has no timeout on `develop` either (the locking model was reworked separately there); a forward-port will follow.
