### PR TITLE
ci: add synchronous EE compile gate to main build via webhook

### DIFF
--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -22,11 +22,12 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  # When an OSS ci start, we trigger an EE one
+  # On develop push: fire the full EE CI cross-check async (oss-updated) AND run a
+  # synchronous EE compile gate via the Kestra webhook.
   trigger-ee:
     runs-on: ubuntu-latest
     steps:
-      # Targeting develop branch from develop
+      # Targeting develop branch from develop — async, fire-and-forget full EE CI
       - name: Trigger EE Workflow (develop push, no payload)
         if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/develop' }}
         uses: kestra-io/actions/composite/repository-dispatch@main
@@ -36,6 +37,21 @@ jobs:
           repository: kestra-io/kestra-ee
           event-type: "oss-updated"
           client-payload: '{"ref": "${{ github.ref }}", "commit_sha": "${{ github.sha }}"}'
+
+      - name: Checkout  # required to resolve the local composite action below
+        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/develop' }}
+        uses: actions/checkout@v4
+
+      # Synchronous EE compileJava gate: fails this job (and the run) on compile
+      # failure and posts a compile status on the develop commit.
+      - name: EE compile check (via Kestra webhook)
+        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/develop' }}
+        uses: ./.github/actions/ee-compile-check
+        with:
+          webhook-url: ${{ secrets.KESTRA_CI_EEBUILD_WEBHOOK_URL }}
+          ref: ${{ github.ref_name }}
+          commit-sha: ${{ github.sha }}
+          pr-repo: ${{ github.repository }}
 
   backend-tests:
     name: Backend tests


### PR DESCRIPTION
Wires the Kestra webhook EE compile-check (from #17115, currently PR-only) into the **main build** (`main-build.yml`) as well.

### Behavior on a develop push

The `trigger-ee` job now does **both**:

1. **Full EE CI cross-check — async, fire-and-forget** (unchanged): still fires the `oss-updated` `repository_dispatch` at kestra-ee. Runs compile + tests, doesn't block the OSS build, and its `EE CI results` commit status stays **suppressed** on main builds (kestra-io/kestra-ee#9352).
2. **EE compile gate — synchronous** (new): runs `./.github/actions/ee-compile-check` against the pushed ref via the Kestra webhook. It **blocks**, fails the run on an EE compile break, and posts a compile status on the develop commit.

Net: the heavy/flaky full EE CI still runs for signal but is quiet on the OSS build, while the fast, reliable compile-check becomes the visible gate.

### Notes

- Adds a `Checkout` step so the local composite action resolves (the `oss-updated` dispatch action is remote and needs no checkout).
- `commit-sha`/`pr-repo` are passed so the flow posts the compile status on the develop commit; no `pr-number` (not a PR).
- Scoped to `develop` pushes only, matching the existing `oss-updated` trigger condition.
- `end` (Slack) job `needs` are left unchanged — a compile break fails the `trigger-ee` job and the run, and posts a failing commit status, but does not add a Slack ping. Say the word if you want develop EE-compile breaks to also notify Slack.

Companion to kestra-io/kestra-ee#9352.