### PR TITLE
fix(ai): send provider on copilot confirm and show failed tool calls

### DIFF
--- a/ui/src/components/ai/copilot/CopilotChat.vue
+++ b/ui/src/components/ai/copilot/CopilotChat.vue
@@ -75,7 +75,7 @@
                     v-if="pendingConfirmation"
                     :action="pendingConfirmation"
                     :disabled="streaming"
-                    @approve="confirm('APPROVE')"
+                    @approve="confirm('APPROVE', undefined, selectedProvider)"
                     @reject="onReject"
                 />
 
@@ -203,7 +203,7 @@
     const footerComposer = ref<InstanceType<typeof CopilotComposer> | null>(null)
 
     async function onReject(): Promise<void> {
-        await confirm("REJECT")
+        await confirm("REJECT", undefined, selectedProvider.value)
         await nextTick()
         footerComposer.value?.focus()
     }

--- a/ui/src/components/ai/copilot/CopilotMessage.vue
+++ b/ui/src/components/ai/copilot/CopilotMessage.vue
@@ -35,7 +35,7 @@
             <CloseCircleOutline v-else />
         </KsIcon>
         <KsText size="small" class="copilot-tool-label">
-            {{ isOk ? t("ai.copilot.toolResult.ok", {tool: toolName}) : t("ai.copilot.toolResult.rejected", {tool: toolName}) }}
+            {{ t(`ai.copilot.toolResult.${outcome}`, {tool: toolName}) }}
         </KsText>
     </div>
 
@@ -61,7 +61,13 @@
 
     const argsJson = computed(() => JSON.stringify(props.message.toolCall?.arguments ?? {}, null, 2))
     const toolName = computed(() => props.message.toolResult?.tool ?? "")
-    const isOk = computed(() => props.message.toolResult?.outcome === "ok")
+    // Backend outcomes: "ok" (tool ran), "error" (tool threw, turn continues), "rejected" (user declined).
+    // Anything unexpected falls back to "rejected" so we never render a raw/missing label.
+    const outcome = computed(() => {
+        const value = props.message.toolResult?.outcome
+        return value === "ok" || value === "error" ? value : "rejected"
+    })
+    const isOk = computed(() => outcome.value === "ok")
 </script>
 
 <style scoped>

--- a/ui/src/components/ai/copilot/types.ts
+++ b/ui/src/components/ai/copilot/types.ts
@@ -63,6 +63,7 @@ export interface ConfirmActionRequest {
     confirmationId: string
     decision: Decision
     reason?: string | null
+    providerId?: string | null
 }
 
 /* ------------------------------------------------------------------ *
@@ -148,7 +149,7 @@ export interface ArtefactDraftEvent {
 
 export interface ToolResultEvent {
     tool: string
-    /** "ok" or "rejected". */
+    /** "ok", "error" (the tool threw; the turn continues), or "rejected". */
     outcome: string
 }
 

--- a/ui/src/components/ai/copilot/useAiChat.ts
+++ b/ui/src/components/ai/copilot/useAiChat.ts
@@ -140,13 +140,16 @@ export function useAiChat() {
         error.value = null
     }
 
-    /** Resolves a pending proposal. APPROVE resumes & dispatches; REJECT records rejection. */
-    async function confirm(decision: Decision, reason?: string): Promise<void> {
+    /**
+     * Resolves a pending proposal. APPROVE resumes & dispatches; REJECT records rejection.
+     * The resumed turn runs a fresh model call, so it needs the same `providerId` the chat turn used.
+     */
+    async function confirm(decision: Decision, reason?: string, providerId?: string): Promise<void> {
         const active = thread.value
         const proposal = pendingConfirmation.value
         if (!active || !proposal) return
 
-        const request: ConfirmActionRequest = {confirmationId: proposal.confirmationId, decision, reason}
+        const request: ConfirmActionRequest = {confirmationId: proposal.confirmationId, decision, reason, providerId}
         pendingConfirmation.value = null
         await runStream(`${base()}/${active.uid}/confirm`, request)
     }

--- a/ui/src/translations/de.json
+++ b/ui/src/translations/de.json
@@ -2022,6 +2022,7 @@
         },
         "toolCall": "Running {tool}",
         "toolResult": {
+          "error": "{tool} fehlgeschlagen",
           "ok": "{tool} completed",
           "rejected": "{tool} rejected"
         },

--- a/ui/src/translations/en.json
+++ b/ui/src/translations/en.json
@@ -2022,6 +2022,7 @@
         },
         "toolCall": "Running {tool}",
         "toolResult": {
+          "error": "{tool} failed",
           "ok": "{tool} completed",
           "rejected": "{tool} rejected"
         },

--- a/ui/src/translations/es.json
+++ b/ui/src/translations/es.json
@@ -2022,6 +2022,7 @@
         },
         "toolCall": "Running {tool}",
         "toolResult": {
+          "error": "{tool} falló",
           "ok": "{tool} completed",
           "rejected": "{tool} rejected"
         },

--- a/ui/src/translations/fr.json
+++ b/ui/src/translations/fr.json
@@ -2022,6 +2022,7 @@
         },
         "toolCall": "Running {tool}",
         "toolResult": {
+          "error": "{tool} a échoué",
           "ok": "{tool} completed",
           "rejected": "{tool} rejected"
         },

--- a/ui/src/translations/hi.json
+++ b/ui/src/translations/hi.json
@@ -2022,6 +2022,7 @@
         },
         "toolCall": "Running {tool}",
         "toolResult": {
+          "error": "{tool} विफल रहा",
           "ok": "{tool} completed",
           "rejected": "{tool} rejected"
         },

--- a/ui/src/translations/it.json
+++ b/ui/src/translations/it.json
@@ -2022,6 +2022,7 @@
         },
         "toolCall": "Running {tool}",
         "toolResult": {
+          "error": "{tool} non riuscito",
           "ok": "{tool} completed",
           "rejected": "{tool} rejected"
         },

--- a/ui/src/translations/ja.json
+++ b/ui/src/translations/ja.json
@@ -2022,6 +2022,7 @@
         },
         "toolCall": "Running {tool}",
         "toolResult": {
+          "error": "{tool} が失敗しました",
           "ok": "{tool} completed",
           "rejected": "{tool} rejected"
         },

--- a/ui/src/translations/ko.json
+++ b/ui/src/translations/ko.json
@@ -2022,6 +2022,7 @@
         },
         "toolCall": "Running {tool}",
         "toolResult": {
+          "error": "{tool} 실패",
           "ok": "{tool} completed",
           "rejected": "{tool} rejected"
         },

--- a/ui/src/translations/pl.json
+++ b/ui/src/translations/pl.json
@@ -2022,6 +2022,7 @@
         },
         "toolCall": "Running {tool}",
         "toolResult": {
+          "error": "{tool} nie powiodło się",
           "ok": "{tool} completed",
           "rejected": "{tool} rejected"
         },

--- a/ui/src/translations/pt.json
+++ b/ui/src/translations/pt.json
@@ -2022,6 +2022,7 @@
         },
         "toolCall": "Running {tool}",
         "toolResult": {
+          "error": "{tool} falhou",
           "ok": "{tool} completed",
           "rejected": "{tool} rejected"
         },

--- a/ui/src/translations/pt_BR.json
+++ b/ui/src/translations/pt_BR.json
@@ -2022,6 +2022,7 @@
         },
         "toolCall": "Running {tool}",
         "toolResult": {
+          "error": "{tool} falhou",
           "ok": "{tool} completed",
           "rejected": "{tool} rejected"
         },

--- a/ui/src/translations/ru.json
+++ b/ui/src/translations/ru.json
@@ -2022,6 +2022,7 @@
         },
         "toolCall": "Running {tool}",
         "toolResult": {
+          "error": "{tool} не удалось",
           "ok": "{tool} completed",
           "rejected": "{tool} rejected"
         },

--- a/ui/src/translations/zh_CN.json
+++ b/ui/src/translations/zh_CN.json
@@ -2022,6 +2022,7 @@
         },
         "toolCall": "Running {tool}",
         "toolResult": {
+          "error": "{tool} 失败",
           "ok": "{tool} completed",
           "rejected": "{tool} rejected"
         },

--- a/ui/tests/unit/components/ai/copilot/CopilotChat.spec.ts
+++ b/ui/tests/unit/components/ai/copilot/CopilotChat.spec.ts
@@ -29,6 +29,7 @@ const miscStore = {copilotPrompt: null as string | null, openCopilot: vi.fn(), p
 vi.mock("override/stores/misc", () => ({useMiscStore: () => miscStore}))
 
 import CopilotChat from "../../../../../src/components/ai/copilot/CopilotChat.vue"
+import {providers as providersMock} from "@kestra-io/kestra-sdk/ai"
 
 const mountChat = (props = {}) => mount(CopilotChat, {props, global: mountGlobal})
 
@@ -86,14 +87,17 @@ describe("CopilotChat", () => {
         expect(state.sendChat).toHaveBeenCalledWith({prompt: "do it", mode: "PLAN", inFocus: undefined})
     })
 
-    it("renders the proposed-action card and confirms on approve", async () => {
+    it("renders the proposed-action card and confirms on approve, forwarding the selected provider", async () => {
+        // The resumed turn needs the same provider as the chat turn, so approve must pass it through.
+        ;(providersMock as any).mockResolvedValueOnce([{id: "gemini-legacy", isDefault: true}])
         state.pendingConfirmation.value = {confirmationId: "c1", tool: "restart-execution", family: "MUTATE", summary: "Restart"}
         const w = mountChat()
+        await flushPromises() // let the provider list resolve so selectedProvider is set
         const card = w.findComponent({name: "ProposedActionCard"})
         expect(card.exists()).toBe(true)
         card.vm.$emit("approve")
         await flushPromises()
-        expect(state.confirm).toHaveBeenCalledWith("APPROVE")
+        expect(state.confirm).toHaveBeenCalledWith("APPROVE", undefined, "gemini-legacy")
     })
 
     it("rejects via the proposed-action card", async () => {
@@ -101,7 +105,7 @@ describe("CopilotChat", () => {
         const w = mountChat()
         w.findComponent({name: "ProposedActionCard"}).vm.$emit("reject")
         await flushPromises()
-        expect(state.confirm).toHaveBeenCalledWith("REJECT")
+        expect(state.confirm).toHaveBeenCalledWith("REJECT", undefined, undefined)
     })
 
     it("disables the composer when a turn cannot be sent", () => {

--- a/ui/tests/unit/components/ai/copilot/CopilotMessage.spec.ts
+++ b/ui/tests/unit/components/ai/copilot/CopilotMessage.spec.ts
@@ -48,6 +48,16 @@ describe("CopilotMessage", () => {
         expect(w.text()).toContain("rejected")
     })
 
+    it("renders an errored tool_result with the failed message", () => {
+        const w = mountMessage({
+            id: "5b", role: "TOOL", type: "TOOL_RESULT",
+            toolResult: {tool: "read-execution", outcome: "error"},
+        })
+        expect(w.text()).toContain("failed")
+        // An error is not a success — it must not render as ok.
+        expect(w.text()).not.toContain("completed")
+    })
+
     it("renders an artefact_draft message as a draft card", () => {
         const w = mountMessage({
             id: "6", role: "ASSISTANT", type: "ARTEFACT_DRAFT",

--- a/ui/tests/unit/components/ai/copilot/useAiChat.spec.ts
+++ b/ui/tests/unit/components/ai/copilot/useAiChat.spec.ts
@@ -9,11 +9,14 @@ vi.mock("@kestra-io/kestra-sdk", () => ({useClient: () => ({post, get})}))
 
 let nextFrames: AiSseFrame[] = []
 let nextError: Error | null = null
+/** Records the JSON body of the most recent stream (chat/confirm) so tests can assert what was sent. */
+let lastBody: Record<string, unknown> | null = null
 vi.mock("../../../../../src/components/ai/copilot/streamSse", async (importOriginal) => {
     const actual = await importOriginal<typeof import("../../../../../src/components/ai/copilot/streamSse")>()
     return {
         ...actual,
-        streamSse: vi.fn(async ({onFrame}: {onFrame: (f: AiSseFrame) => void}) => {
+        streamSse: vi.fn(async ({onFrame, body}: {onFrame: (f: AiSseFrame) => void; body: Record<string, unknown>}) => {
+            lastBody = body
             if (nextError) throw nextError
             for (const f of nextFrames) onFrame(f)
         }),
@@ -35,6 +38,7 @@ describe("useAiChat", () => {
         get.mockReset()
         nextFrames = []
         nextError = null
+        lastBody = null
         post.mockResolvedValue(idleThread())
     })
 
@@ -86,7 +90,9 @@ describe("useAiChat", () => {
             {event: "tool_result", data: {tool: "restart-execution", outcome: "ok"}},
             {event: "done", data: {status: "IDLE"}},
         ]
-        await chat.confirm("APPROVE")
+        // The resumed turn runs a fresh model call, so confirm must forward the provider it was given.
+        await chat.confirm("APPROVE", undefined, "gemini-legacy")
+        expect(lastBody).toMatchObject({confirmationId: "c1", decision: "APPROVE", providerId: "gemini-legacy"})
         expect(chat.pendingConfirmation.value).toBeNull()
         expect(chat.status.value).toBe("IDLE")
         expect(chat.messages.value.some((m) => m.type === "TOOL_RESULT" && m.toolResult?.outcome === "ok")).toBe(true)


### PR DESCRIPTION
## What

Aligns the Copilot v2 frontend with the latest changes on the agentic-loop backend (OSS `0b95c5cd0`, EE `1a1cb8d0a`). Two FE-facing contract changes landed there; this catches the FE up to both.

### 1. `confirm` now sends `providerId`
The backend replaced the in-memory suspended-turn registry with confirmation state persisted on the thread. As part of that, `POST …/{threadId}/confirm` now takes a `providerId`, and `AgentOrchestrator.resume(...)` uses it for the resumed turn's model call — the provider is no longer captured from the suspended turn.

The FE `confirm()` wasn't sending it, so approve/reject would fail to resolve a provider mid-stream (a real regression with a non-default provider). We now thread the selected provider through `confirm()` from both the approve and reject call sites.

### 2. New `tool_result` outcome: `"error"`
A `@Tool` that throws no longer aborts the whole turn — the backend emits `tool_result` with `outcome: "error"` (and continues the loop). The FE previously treated any non-`ok` outcome as `"rejected"`, mislabelling genuine tool failures. `CopilotMessage` now renders three outcomes (`ok` / `error` / `rejected`), with unknown values falling back to `rejected`.

## Tests
- `useAiChat.spec` — asserts `confirm` forwards `providerId` in the request body
- `CopilotChat.spec` — approve forwards the selected provider; reject covers the no-provider case
- `CopilotMessage.spec` — an errored tool-result renders "failed", not "completed"
- Added `ai.copilot.toolResult.error` to **all 13 locales**; `translations:check` clean

72/72 copilot unit tests pass. Type-check adds no new errors.

## Scope
Frontend-only, and OSS-only — the copilot components are shared with EE via the `kestra` alias, so no EE changes are needed.