### PR TITLE
feat(ai): make copilot context-aware and notify on empty turns

### DIFF
--- a/ui/src/components/ai/copilot/CopilotChat.vue
+++ b/ui/src/components/ai/copilot/CopilotChat.vue
@@ -87,6 +87,10 @@
                 {{ t(`ai.copilot.error.${error}`) }}
             </KsAlert>
 
+            <KsAlert v-else-if="notice" type="warning" class="copilot-error" data-test="copilot-notice">
+                {{ t(`ai.copilot.notice.${notice}`) }}
+            </KsAlert>
+
             <div class="copilot-footer">
                 <CopilotComposer
                     ref="footerComposer"
@@ -104,6 +108,7 @@
 
 <script setup lang="ts">
     import {ref, computed, nextTick, watch, onBeforeUnmount, onMounted} from "vue"
+    import {useRoute} from "vue-router"
     import {useI18n} from "vue-i18n"
     import Plus from "vue-material-design-icons/Plus.vue"
     import ChevronDown from "vue-material-design-icons/ChevronDown.vue"
@@ -116,6 +121,7 @@
     import CopilotThinking from "./CopilotThinking.vue"
     import ProposedActionCard from "./ProposedActionCard.vue"
     import {useAiChat} from "./useAiChat"
+    import {scopeFromRoute} from "./routeScope"
     import type {Mode, ScopeBinding} from "./types"
     import {useMiscStore} from "override/stores/misc"
 
@@ -127,9 +133,15 @@
     }>()
 
     const {t} = useI18n()
+    const route = useRoute()
     const miscStore = useMiscStore()
 
     const mode = ref<Mode>(props.initialMode ?? "EDIT")
+
+    // Context-awareness: when the copilot opens on a flow / execution / namespace page, send that
+    // page as `inFocus` so the agent knows what the user is looking at. An explicit `inFocus` prop
+    // (if a parent ever passes one) still wins. Recomputed as the route changes while the drawer is open.
+    const routeInFocus = computed<ScopeBinding | null>(() => props.inFocus ?? scopeFromRoute(route))
 
     // Shared composer text (both the empty-state and footer composers bind it), so an external
     // entry point can seed a prompt via the misc store (see consumeSeededPrompt).
@@ -159,14 +171,14 @@
         t("ai.copilot.suggestions.dbt"),
     ])
 
-    const {messages, status, streaming, error, pendingConfirmation, unavailable, canSend, sendChat, confirm, cancel, reset, retry} = useAiChat()
+    const {messages, status, streaming, error, notice, pendingConfirmation, unavailable, canSend, sendChat, confirm, cancel, reset, retry} = useAiChat()
 
     // `status` gates the composer via `canSend`; keep the lints happy that we read it.
     void status
 
     // Empty state shows until the first turn produces a message, a proposal, or an error.
     const isEmpty = computed(
-        () => messages.value.length === 0 && !pendingConfirmation.value && !error.value,
+        () => messages.value.length === 0 && !pendingConfirmation.value && !error.value && !notice.value,
     )
 
     // "Thinking…" placeholder while the model is working but hasn't produced its next output
@@ -182,7 +194,7 @@
     })
 
     function onSubmit(prompt: string): void {
-        sendChat({prompt, mode: mode.value, inFocus: props.inFocus, providerId: selectedProvider.value})
+        sendChat({prompt, mode: mode.value, inFocus: routeInFocus.value, providerId: selectedProvider.value})
     }
 
     // Keep the transcript pinned to the bottom as content arrives: new messages, streamed

--- a/ui/src/components/ai/copilot/routeScope.ts
+++ b/ui/src/components/ai/copilot/routeScope.ts
@@ -1,0 +1,45 @@
+import type {ScopeBinding} from "./types"
+
+/** The subset of the current route the scope mapping reads. */
+interface RouteLike {
+    name?: string | symbol | null
+    params?: Record<string, string | string[]>
+}
+
+/** First value of a route param (params can be string | string[]); undefined when absent/empty. */
+function param(params: RouteLike["params"], key: string): string | undefined {
+    const value = params?.[key]
+    const first = Array.isArray(value) ? value[0] : value
+    return first || undefined
+}
+
+/**
+ * Derives the Copilot `inFocus` scope from the current route, so a turn started on a
+ * flow / execution / namespace detail page carries that context to the agent. Returns
+ * null on routes with no meaningful scope (list pages, home, settings, …).
+ *
+ * Route shapes (see `routes.ts`):
+ *   - executions/update → /:tenant?/executions/:namespace/:flowId/:id
+ *   - flows/update      → /:tenant?/flows/edit/:namespace/:id
+ *   - namespaces/update → /:tenant?/namespaces/edit/:id
+ */
+export function scopeFromRoute(route: RouteLike | undefined | null): ScopeBinding | null {
+    const name = typeof route?.name === "string" ? route.name : ""
+    const params = route?.params
+
+    switch (name) {
+        case "executions/update":
+            return {
+                kind: "EXECUTION",
+                namespace: param(params, "namespace"),
+                flowId: param(params, "flowId"),
+                executionId: param(params, "id"),
+            }
+        case "flows/update":
+            return {kind: "FLOW", namespace: param(params, "namespace"), flowId: param(params, "id")}
+        case "namespaces/update":
+            return {kind: "NAMESPACE", namespace: param(params, "id")}
+        default:
+            return null
+    }
+}

--- a/ui/src/components/ai/copilot/useAiChat.ts
+++ b/ui/src/components/ai/copilot/useAiChat.ts
@@ -38,6 +38,9 @@ import {
 /** Locale-agnostic error identifier; the component maps it to `ai.copilot.error.<code>`. */
 export type ErrorCode = "turnInProgress" | "request" | "generic"
 
+/** Locale-agnostic non-error notice identifier; the component maps it to `ai.copilot.notice.<code>`. */
+export type NoticeCode = "emptyTurn"
+
 /** A message as rendered in the chat transcript (a superset of the wire MessageView). */
 export interface ChatMessage {
     /** Local, stable key for v-for. */
@@ -62,6 +65,8 @@ export function useAiChat() {
     const streaming = ref(false)
     /** A translation-key suffix under `ai.copilot.error.*`, or null. Kept locale-agnostic. */
     const error = ref<ErrorCode | null>(null)
+    /** A non-error notice (e.g. a turn that produced no output) under `ai.copilot.notice.*`, or null. */
+    const notice = ref<NoticeCode | null>(null)
     /** The proposal awaiting a confirm/reject decision, if any. */
     const pendingConfirmation = ref<ProposedActionEvent | null>(null)
     /** True when the backend reports no AI provider is configured (503) — render an "unavailable" state. */
@@ -129,6 +134,7 @@ export function useAiChat() {
         }
 
         error.value = null
+        notice.value = null
         pendingConfirmation.value = null
         push({id: uid(), role: "USER", type: "TEXT", content: request.prompt})
         await runStream(`${base()}/${active.uid}/chat`, request)
@@ -138,6 +144,7 @@ export function useAiChat() {
     function retry(): void {
         unavailable.value = false
         error.value = null
+        notice.value = null
     }
 
     /**
@@ -167,6 +174,7 @@ export function useAiChat() {
         status.value = "IDLE"
         streaming.value = false
         error.value = null
+        notice.value = null
         pendingConfirmation.value = null
         unavailable.value = false
         activeAssistant = null
@@ -176,11 +184,19 @@ export function useAiChat() {
     async function runStream(url: string, body: unknown): Promise<void> {
         streaming.value = true
         status.value = "RUNNING"
+        notice.value = null
         activeAssistant = null
         abort = new AbortController()
+        const countBefore = messages.value.length
 
         try {
             await streamSse({url, body, signal: abort.signal, onFrame: reduce})
+            // The stream closed cleanly but added nothing to the transcript and left no proposal —
+            // e.g. a transient provider hiccup returned only `done`. Surface a notice rather than
+            // leaving the panel silent, so the user knows to retry.
+            if (messages.value.length === countBefore && !pendingConfirmation.value && !error.value) {
+                notice.value = "emptyTurn"
+            }
         } catch (e) {
             if ((e as Error)?.name === "AbortError") return
             // 503 mid-stream (provider removed) → the unavailable state; otherwise a generic error.
@@ -266,6 +282,7 @@ export function useAiChat() {
         status,
         streaming,
         error,
+        notice,
         pendingConfirmation,
         unavailable,
         canSend,

--- a/ui/src/translations/de.json
+++ b/ui/src/translations/de.json
@@ -2036,6 +2036,9 @@
           "pending": "Pending approval",
           "revise": "Reply to revise"
         },
+        "notice": {
+          "emptyTurn": "Der Assistent hat keine Antwort zurückgegeben. Bitte versuche es erneut."
+        },
         "error": {
           "turnInProgress": "A turn is already in progress.",
           "request": "The request failed. Please try again.",

--- a/ui/src/translations/en.json
+++ b/ui/src/translations/en.json
@@ -2036,6 +2036,9 @@
           "pending": "Pending approval",
           "revise": "Reply to revise"
         },
+        "notice": {
+          "emptyTurn": "The assistant didn't return a response. Please try again."
+        },
         "error": {
           "turnInProgress": "A turn is already in progress.",
           "request": "The request failed. Please try again.",

--- a/ui/src/translations/es.json
+++ b/ui/src/translations/es.json
@@ -2036,6 +2036,9 @@
           "pending": "Pending approval",
           "revise": "Reply to revise"
         },
+        "notice": {
+          "emptyTurn": "El asistente no devolvió una respuesta. Inténtalo de nuevo."
+        },
         "error": {
           "turnInProgress": "A turn is already in progress.",
           "request": "The request failed. Please try again.",

--- a/ui/src/translations/fr.json
+++ b/ui/src/translations/fr.json
@@ -2036,6 +2036,9 @@
           "pending": "Pending approval",
           "revise": "Reply to revise"
         },
+        "notice": {
+          "emptyTurn": "L'assistant n'a renvoyé aucune réponse. Veuillez réessayer."
+        },
         "error": {
           "turnInProgress": "A turn is already in progress.",
           "request": "The request failed. Please try again.",

--- a/ui/src/translations/hi.json
+++ b/ui/src/translations/hi.json
@@ -2036,6 +2036,9 @@
           "pending": "Pending approval",
           "revise": "Reply to revise"
         },
+        "notice": {
+          "emptyTurn": "सहायक ने कोई प्रतिक्रिया नहीं दी। कृपया पुनः प्रयास करें।"
+        },
         "error": {
           "turnInProgress": "A turn is already in progress.",
           "request": "The request failed. Please try again.",

--- a/ui/src/translations/it.json
+++ b/ui/src/translations/it.json
@@ -2036,6 +2036,9 @@
           "pending": "Pending approval",
           "revise": "Reply to revise"
         },
+        "notice": {
+          "emptyTurn": "L'assistente non ha restituito una risposta. Riprova."
+        },
         "error": {
           "turnInProgress": "A turn is already in progress.",
           "request": "The request failed. Please try again.",

--- a/ui/src/translations/ja.json
+++ b/ui/src/translations/ja.json
@@ -2036,6 +2036,9 @@
           "pending": "Pending approval",
           "revise": "Reply to revise"
         },
+        "notice": {
+          "emptyTurn": "アシスタントから応答がありませんでした。もう一度お試しください。"
+        },
         "error": {
           "turnInProgress": "A turn is already in progress.",
           "request": "The request failed. Please try again.",

--- a/ui/src/translations/ko.json
+++ b/ui/src/translations/ko.json
@@ -2036,6 +2036,9 @@
           "pending": "Pending approval",
           "revise": "Reply to revise"
         },
+        "notice": {
+          "emptyTurn": "어시스턴트가 응답을 반환하지 않았습니다. 다시 시도해 주세요."
+        },
         "error": {
           "turnInProgress": "A turn is already in progress.",
           "request": "The request failed. Please try again.",

--- a/ui/src/translations/pl.json
+++ b/ui/src/translations/pl.json
@@ -2036,6 +2036,9 @@
           "pending": "Pending approval",
           "revise": "Reply to revise"
         },
+        "notice": {
+          "emptyTurn": "Asystent nie zwrócił odpowiedzi. Spróbuj ponownie."
+        },
         "error": {
           "turnInProgress": "A turn is already in progress.",
           "request": "The request failed. Please try again.",

--- a/ui/src/translations/pt.json
+++ b/ui/src/translations/pt.json
@@ -2036,6 +2036,9 @@
           "pending": "Pending approval",
           "revise": "Reply to revise"
         },
+        "notice": {
+          "emptyTurn": "O assistente não retornou uma resposta. Tente novamente."
+        },
         "error": {
           "turnInProgress": "A turn is already in progress.",
           "request": "The request failed. Please try again.",

--- a/ui/src/translations/pt_BR.json
+++ b/ui/src/translations/pt_BR.json
@@ -2036,6 +2036,9 @@
           "pending": "Pending approval",
           "revise": "Reply to revise"
         },
+        "notice": {
+          "emptyTurn": "O assistente não retornou uma resposta. Tente novamente."
+        },
         "error": {
           "turnInProgress": "A turn is already in progress.",
           "request": "The request failed. Please try again.",

--- a/ui/src/translations/ru.json
+++ b/ui/src/translations/ru.json
@@ -2036,6 +2036,9 @@
           "pending": "Pending approval",
           "revise": "Reply to revise"
         },
+        "notice": {
+          "emptyTurn": "Ассистент не вернул ответ. Пожалуйста, попробуйте снова."
+        },
         "error": {
           "turnInProgress": "A turn is already in progress.",
           "request": "The request failed. Please try again.",

--- a/ui/src/translations/zh_CN.json
+++ b/ui/src/translations/zh_CN.json
@@ -2036,6 +2036,9 @@
           "pending": "Pending approval",
           "revise": "Reply to revise"
         },
+        "notice": {
+          "emptyTurn": "助手未返回响应。请重试。"
+        },
         "error": {
           "turnInProgress": "A turn is already in progress.",
           "request": "The request failed. Please try again.",

--- a/ui/tests/unit/components/ai/copilot/CopilotChat.spec.ts
+++ b/ui/tests/unit/components/ai/copilot/CopilotChat.spec.ts
@@ -11,6 +11,7 @@ const state = {
     status: ref("IDLE"),
     streaming: ref(false),
     error: ref<string | null>(null),
+    notice: ref<string | null>(null),
     pendingConfirmation: ref<any>(null),
     unavailable: ref(false),
     canSend: ref(true),
@@ -21,6 +22,9 @@ const state = {
     retry: vi.fn(),
 }
 vi.mock("../../../../../src/components/ai/copilot/useAiChat", () => ({useAiChat: () => state}))
+// CopilotChat derives `inFocus` from the current route — mock a mutable route so tests control it.
+let routeStub: {name?: string; params: Record<string, any>} = {name: undefined, params: {}}
+vi.mock("vue-router", () => ({useRoute: () => routeStub}))
 // The provider list is fetched on mount — stub the SDK so no real request fires.
 vi.mock("@kestra-io/kestra-sdk/ai", () => ({providers: vi.fn().mockResolvedValue([])}))
 // CopilotChat reads a seeded prompt from the misc store on mount. Shared mutable stub so a
@@ -37,10 +41,12 @@ describe("CopilotChat", () => {
     beforeEach(() => {
         state.messages.value = []
         state.error.value = null
+        state.notice.value = null
         state.pendingConfirmation.value = null
         state.unavailable.value = false
         state.canSend.value = true
         state.streaming.value = false
+        routeStub = {name: undefined, params: {}}
         state.sendChat.mockReset()
         state.confirm.mockReset()
         state.reset.mockReset()
@@ -80,11 +86,30 @@ describe("CopilotChat", () => {
         expect(miscStore.copilotPrompt).toBeNull()
     })
 
-    it("forwards a composer submit to sendChat with the current mode", async () => {
+    it("forwards a composer submit to sendChat with the current mode (no scope off a plain route)", async () => {
         const w = mountChat({initialMode: "PLAN"})
         w.findComponent({name: "CopilotComposer"}).vm.$emit("submit", "do it")
         await flushPromises()
-        expect(state.sendChat).toHaveBeenCalledWith({prompt: "do it", mode: "PLAN", inFocus: undefined})
+        expect(state.sendChat).toHaveBeenCalledWith({prompt: "do it", mode: "PLAN", inFocus: null, providerId: undefined})
+    })
+
+    it("sends the current page as inFocus when on a detail route (context-awareness)", async () => {
+        routeStub = {name: "executions/update", params: {namespace: "company.team", flowId: "my-flow", id: "exec-1"}}
+        const w = mountChat()
+        w.findComponent({name: "CopilotComposer"}).vm.$emit("submit", "why did this fail?")
+        await flushPromises()
+        expect(state.sendChat).toHaveBeenCalledWith(expect.objectContaining({
+            prompt: "why did this fail?",
+            inFocus: {kind: "EXECUTION", namespace: "company.team", flowId: "my-flow", executionId: "exec-1"},
+        }))
+    })
+
+    it("surfaces a warning notice when a turn yields no output", () => {
+        state.notice.value = "emptyTurn"
+        const w = mountChat()
+        const alert = w.find("[data-test=\"copilot-notice\"]")
+        expect(alert.exists()).toBe(true)
+        expect(alert.text()).toBe("The assistant didn't return a response. Please try again.")
     })
 
     it("renders the proposed-action card and confirms on approve, forwarding the selected provider", async () => {

--- a/ui/tests/unit/components/ai/copilot/routeScope.spec.ts
+++ b/ui/tests/unit/components/ai/copilot/routeScope.spec.ts
@@ -1,0 +1,39 @@
+import {describe, it, expect} from "vitest"
+import {scopeFromRoute} from "../../../../../src/components/ai/copilot/routeScope"
+
+describe("scopeFromRoute", () => {
+    it("maps an execution detail route to an EXECUTION scope", () => {
+        expect(scopeFromRoute({name: "executions/update", params: {namespace: "company.team", flowId: "my-flow", id: "exec-1"}}))
+            .toEqual({kind: "EXECUTION", namespace: "company.team", flowId: "my-flow", executionId: "exec-1"})
+    })
+
+    it("maps a flow detail route to a FLOW scope (id is the flow id)", () => {
+        expect(scopeFromRoute({name: "flows/update", params: {namespace: "company.team", id: "my-flow"}}))
+            .toEqual({kind: "FLOW", namespace: "company.team", flowId: "my-flow"})
+    })
+
+    it("maps a namespace detail route to a NAMESPACE scope (id is the namespace)", () => {
+        expect(scopeFromRoute({name: "namespaces/update", params: {id: "company.team"}}))
+            .toEqual({kind: "NAMESPACE", namespace: "company.team"})
+    })
+
+    it("returns null for routes with no meaningful scope", () => {
+        expect(scopeFromRoute({name: "flows/list", params: {}})).toBeNull()
+        expect(scopeFromRoute({name: "home", params: {}})).toBeNull()
+    })
+
+    it("is defensive about missing/oddly-typed route input", () => {
+        expect(scopeFromRoute(undefined)).toBeNull()
+        expect(scopeFromRoute(null)).toBeNull()
+        expect(scopeFromRoute({params: {}})).toBeNull()
+        // A symbol name (Vue Router allows it) is not one of ours → null.
+        expect(scopeFromRoute({name: Symbol("x"), params: {}})).toBeNull()
+    })
+
+    it("takes the first value when a param is an array and treats empty as absent", () => {
+        expect(scopeFromRoute({name: "flows/update", params: {namespace: ["a", "b"], id: "f"}}))
+            .toEqual({kind: "FLOW", namespace: "a", flowId: "f"})
+        expect(scopeFromRoute({name: "namespaces/update", params: {id: ""}}))
+            .toEqual({kind: "NAMESPACE", namespace: undefined})
+    })
+})

--- a/ui/tests/unit/components/ai/copilot/useAiChat.spec.ts
+++ b/ui/tests/unit/components/ai/copilot/useAiChat.spec.ts
@@ -168,6 +168,48 @@ describe("useAiChat", () => {
         expect(chat.error.value).toBe("generic")
     })
 
+    it("surfaces the emptyTurn notice when a turn streams only done (no output)", async () => {
+        const chat = useAiChat()
+        nextFrames = [{event: "done", data: {status: "IDLE"}}]
+        await chat.sendChat({prompt: "hi"})
+        expect(chat.notice.value).toBe("emptyTurn")
+        expect(chat.status.value).toBe("IDLE")
+    })
+
+    it("does not set the emptyTurn notice when the turn produced output", async () => {
+        const chat = useAiChat()
+        nextFrames = [
+            {event: "token", data: {text: "Hi there"}},
+            {event: "done", data: {status: "IDLE"}},
+        ]
+        await chat.sendChat({prompt: "hi"})
+        expect(chat.notice.value).toBeNull()
+    })
+
+    it("does not set the emptyTurn notice when the turn suspends on a proposal", async () => {
+        const chat = useAiChat()
+        nextFrames = [
+            {event: "proposed_action", data: {confirmationId: "c1", tool: "restart-execution", family: "MUTATE", summary: "Restart"}},
+            {event: "done", data: {status: "AWAITING_CONFIRMATION"}},
+        ]
+        await chat.sendChat({prompt: "restart it", mode: "EDIT"})
+        expect(chat.notice.value).toBeNull()
+    })
+
+    it("clears a prior emptyTurn notice when a new turn starts", async () => {
+        const chat = useAiChat()
+        nextFrames = [{event: "done", data: {status: "IDLE"}}]
+        await chat.sendChat({prompt: "first"})
+        expect(chat.notice.value).toBe("emptyTurn")
+
+        nextFrames = [
+            {event: "token", data: {text: "now I answer"}},
+            {event: "done", data: {status: "IDLE"}},
+        ]
+        await chat.sendChat({prompt: "second"})
+        expect(chat.notice.value).toBeNull()
+    })
+
     it("rehydrates a thread transcript sorted by uid", async () => {
         const chat = useAiChat()
         get.mockResolvedValue({data: {


### PR DESCRIPTION
## What

Two frontend improvements to the Copilot v2 agentic loop.

### 1. Context-awareness (`inFocus`)
The copilot mounts in the context drawer with no props, so `inFocus` was **always `undefined`** — the agent never knew which page the user was on. This derives `inFocus` from the current route: opening the copilot on a **flow / execution / namespace** detail page now sends that page as the turn's `inFocus` scope.

- A pure `scopeFromRoute()` maps the detail routes (`executions/update` → `EXECUTION`, `flows/update` → `FLOW`, `namespaces/update` → `NAMESPACE`), returning `null` on list/other pages.
- An explicit `inFocus` prop (should a parent ever pass one) still wins.
- Recomputed reactively, so it tracks route changes while the drawer stays open.

### 2. Empty-turn UX
When a turn closed cleanly but produced **no output and no proposal** (e.g. the transient provider hiccup that returns only a `done` event — the "empty turn" we hit under rate-limiting), the panel just sat silent. It now surfaces a **warning notice** so the user knows to retry. The notice clears on the next turn, or as soon as output / a proposal arrives.

## Tests
- `routeScope.spec` — the route→scope mapping, incl. array params and defensive/undefined input
- `CopilotChat.spec` — a detail route forwards the derived `inFocus`; a plain route forwards `null`; the notice renders as a warning alert
- `useAiChat.spec` — `emptyTurn` is set on a no-output turn, and **not** set when the turn produced tokens or suspended on a proposal; cleared on the next turn

Added `ai.copilot.notice.emptyTurn` to **all 13 locales**; `translations:check` clean. 84/84 copilot unit tests pass; type-check adds no new errors.

## Scope
Frontend-only, OSS-only — the copilot components are shared with EE via the `kestra` alias, so no EE changes are needed.