### PR TITLE
fix(design-system): stop uppercasing QueryFilter field names in routeQueryToQueryFilters

### DIFF
--- a/ui/packages/design-system/src/components/Data/KsDataTable/filter/utils/helpers.ts
+++ b/ui/packages/design-system/src/components/Data/KsDataTable/filter/utils/helpers.ts
@@ -72,18 +72,6 @@ export interface QueryFilter {
 }
 
 /**
- * `QueryFilter.Field`'s wire value (`@JsonValue`) is the camelCase form of its enum name for every
- * field except these two irregular ones — see the `Field` enum in `QueryFilter.java`.
- */
-const FIELD_VALUE_OVERRIDES: Record<string, string> = {
-    q: "QUERY",
-    groupList: "GROUP",
-}
-
-const fieldToEnumName = (field: string): string =>
-    FIELD_VALUE_OVERRIDES[field] ?? field.replace(/([A-Z])/g, "_$1").toUpperCase()
-
-/**
  * Builds one logical position in the filter tree, mirroring the backend's
  * `QueryFilterFormatBinder.NodeBuilder`: direct leaves land here directly, LABELS leaves sharing an
  * operation are merged into one filter with a map value, and nested `[and|or][N]` segments descend
@@ -103,17 +91,16 @@ class FilterNodeBuilder {
     }
 
     addLeaf(field: string, operation: string, subKey: string | undefined, value: string | string[]) {
-        const enumField = fieldToEnumName(field)
         const scalarValue = Array.isArray(value) ? value[0] : value
 
-        if (enumField === "LABELS" && subKey) {
+        if (field === "labels" && subKey) {
             const map = this.labelsByOp.get(operation) ?? {}
             map[subKey] = scalarValue
             this.labelsByOp.set(operation, map)
             return
         }
 
-        this.directLeaves.push({field: enumField, operation, value})
+        this.directLeaves.push({field, operation, value})
     }
 
     build(): QueryFilter[] {
@@ -121,7 +108,7 @@ class FilterNodeBuilder {
 
         this.labelsByOp.forEach((map, operation) => {
             if (Object.keys(map).length > 0) {
-                items.push({field: "LABELS", operation, value: map})
+                items.push({field: "labels", operation, value: map})
             }
         })
 

--- a/ui/src/stores/logs.ts
+++ b/ui/src/stores/logs.ts
@@ -68,7 +68,7 @@ export const useLogsStore = defineStore("logs", () => {
 
     async function levelCounts(baseParams: Record<string, any>): Promise<Record<string, number>> {
         const baseFilters = (routeQueryToQueryFilters(baseParams) as QueryFilter[])
-            .filter((f) => f.field !== "LEVEL")
+            .filter((f) => f.field !== "level")
 
         const cumulative = await Promise.all(LEVELS_ASC.map((logLevel) => {
             const filters = [...baseFilters, {field: "level", operation: "GREATER_THAN_OR_EQUAL_TO", value: logLevel}]

--- a/ui/tests/unit/filter/utils/helpers.spec.ts
+++ b/ui/tests/unit/filter/utils/helpers.spec.ts
@@ -75,22 +75,22 @@ describe("Filter Helpers", () => {
     describe("routeQueryToQueryFilters", () => {
         it("builds a simple leaf filter", () => {
             expect(routeQueryToQueryFilters({"filters[namespace][EQUALS]": "io.kestra"})).toEqual([
-                {field: "NAMESPACE", operation: "EQUALS", value: "io.kestra"},
+                {field: "namespace", operation: "EQUALS", value: "io.kestra"},
             ])
         })
 
-        it("maps the irregular q/groupList field values", () => {
+        it("keeps the irregular q/groupList field values as-is (already the wire form)", () => {
             expect(routeQueryToQueryFilters({"filters[q][EQUALS]": "hello"})).toEqual([
-                {field: "QUERY", operation: "EQUALS", value: "hello"},
+                {field: "q", operation: "EQUALS", value: "hello"},
             ])
             expect(routeQueryToQueryFilters({"filters[groupList][EQUALS]": "team"})).toEqual([
-                {field: "GROUP", operation: "EQUALS", value: "team"},
+                {field: "groupList", operation: "EQUALS", value: "team"},
             ])
         })
 
         it("keeps a comma-joined IN/NOT_IN value as a plain string", () => {
             expect(routeQueryToQueryFilters({"filters[namespace][IN]": "a,b,c"})).toEqual([
-                {field: "NAMESPACE", operation: "IN", value: "a,b,c"},
+                {field: "namespace", operation: "IN", value: "a,b,c"},
             ])
         })
 
@@ -99,7 +99,7 @@ describe("Filter Helpers", () => {
                 "filters[labels][EQUALS][env]": "prod",
                 "filters[labels][EQUALS][team]": "backend",
             })).toEqual([
-                {field: "LABELS", operation: "EQUALS", value: {env: "prod", team: "backend"}},
+                {field: "labels", operation: "EQUALS", value: {env: "prod", team: "backend"}},
             ])
         })
 
@@ -111,8 +111,8 @@ describe("Filter Helpers", () => {
                 {
                     field: "", operation: "", logical: "OR",
                     children: [
-                        {field: "STATE", operation: "EQUALS", value: "RUNNING"},
-                        {field: "STATE", operation: "EQUALS", value: "FAILED"},
+                        {field: "state", operation: "EQUALS", value: "RUNNING"},
+                        {field: "state", operation: "EQUALS", value: "FAILED"},
                     ],
                 },
             ])
@@ -120,7 +120,7 @@ describe("Filter Helpers", () => {
 
         it("flattens a single-branch AND group back to a plain leaf", () => {
             expect(routeQueryToQueryFilters({"filters[and][0][state][EQUALS]": "RUNNING"})).toEqual([
-                {field: "STATE", operation: "EQUALS", value: "RUNNING"},
+                {field: "state", operation: "EQUALS", value: "RUNNING"},
             ])
         })
 
@@ -136,11 +136,11 @@ describe("Filter Helpers", () => {
                         {
                             field: "", operation: "", logical: "AND",
                             children: [
-                                {field: "NAMESPACE", operation: "EQUALS", value: "io.kestra"},
-                                {field: "STATE", operation: "EQUALS", value: "RUNNING"},
+                                {field: "namespace", operation: "EQUALS", value: "io.kestra"},
+                                {field: "state", operation: "EQUALS", value: "RUNNING"},
                             ],
                         },
-                        {field: "STATE", operation: "EQUALS", value: "FAILED"},
+                        {field: "state", operation: "EQUALS", value: "FAILED"},
                     ],
                 },
             ])
@@ -151,8 +151,8 @@ describe("Filter Helpers", () => {
                 "filters[startDate][GREATER_THAN_OR_EQUAL_TO]": "2023-01-01T00:00:00.000Z",
                 "filters[endDate][LESS_THAN_OR_EQUAL_TO]": "2023-01-31T23:59:59.000Z",
             })).toEqual([
-                {field: "START_DATE", operation: "GREATER_THAN_OR_EQUAL_TO", value: "2023-01-01T00:00:00.000Z"},
-                {field: "END_DATE", operation: "LESS_THAN_OR_EQUAL_TO", value: "2023-01-31T23:59:59.000Z"},
+                {field: "startDate", operation: "GREATER_THAN_OR_EQUAL_TO", value: "2023-01-01T00:00:00.000Z"},
+                {field: "endDate", operation: "LESS_THAN_OR_EQUAL_TO", value: "2023-01-31T23:59:59.000Z"},
             ])
         })
 


### PR DESCRIPTION
Closes kestra-io/kestra-ee#9353.
closes #17450
closes #17455

`routeQueryToQueryFilters()` kept uppercasing field names to match the SDK's old, buggy enum-name casing. #17412/#17411 fixed the backend/SDK to the real lowercase wire form but missed this shared URL-filter decoder, so any URL-driven filter still sent the stale uppercase casing and got rejected.

**The snake_case flip-flop:** installing the then-buggy `kestra-sdk` exposed `QueryFilter` fields as `SCREAMING_SNAKE_CASE` enum names instead of their real lowercase wire form, so #17227 hardcoded call sites to match that casing. Once #17412 fixed the backend/SDK to emit the correct lowercase wire form, #17411 flipped those call sites back — but missed this shared decoder, leaving it stuck on the pre-fix casing while the backend now expects the post-fix one.

---
_Generated by [Claude Code](https://claude.ai/code/session_016fsUTeA8xxS1RdWce9auui)_