### PR TITLE
fix(system): widden too small columns and limit trigger.id to 256

### DIFF
--- a/core/src/main/java/io/kestra/core/models/triggers/AbstractTrigger.java
+++ b/core/src/main/java/io/kestra/core/models/triggers/AbstractTrigger.java
@@ -22,6 +22,7 @@ import io.kestra.core.validations.NoSystemLabelValidation;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -33,6 +34,7 @@ import lombok.experimental.SuperBuilder;
 @NoArgsConstructor
 @JsonInclude(JsonInclude.Include.NON_DEFAULT)
 abstract public class AbstractTrigger implements TriggerInterface {
+    @Size(max = 256, message = "Trigger id must be at most 256 characters")
     protected String id;
 
     protected String type;

--- a/core/src/test/java/io/kestra/core/validations/FlowValidationTest.java
+++ b/core/src/test/java/io/kestra/core/validations/FlowValidationTest.java
@@ -660,6 +660,49 @@ class FlowValidationTest {
         assertThat(modelValidator.isValid(flow)).isEmpty();
     }
 
+    @Test
+    void triggerIdExceedingMaxSize_failValidation() {
+        // A trigger id longer than 256 chars must fail validation early, before it can overflow the
+        // VARCHAR(256) trigger_id DB columns and crash-loop the indexer (see kestra-ee #9268).
+        String longId = "a".repeat(257);
+        Flow flow = YamlParser.parse("""
+            id: test
+            namespace: unittest
+            tasks:
+              - id: hello
+                type: io.kestra.plugin.core.log.Log
+                message: hi
+            triggers:
+              - id: %s
+                type: io.kestra.plugin.core.trigger.Schedule
+                cron: "*/1 * * * *"
+            """.formatted(longId), Flow.class);
+
+        Optional<ConstraintViolationException> validate = modelValidator.isValid(flow);
+        assertThat(validate).isPresent();
+        assertThat(validate.get().getMessage()).contains("Trigger id must be at most 256 characters");
+    }
+
+    @Test
+    void triggerIdAtMaxSize_succeeds() {
+        // A 256-char trigger id is the maximum the trigger_id columns can hold, so it must pass validation.
+        String maxId = "a".repeat(256);
+        Flow flow = YamlParser.parse("""
+            id: test
+            namespace: unittest
+            tasks:
+              - id: hello
+                type: io.kestra.plugin.core.log.Log
+                message: hi
+            triggers:
+              - id: %s
+                type: io.kestra.plugin.core.trigger.Schedule
+                cron: "*/1 * * * *"
+            """.formatted(maxId), Flow.class);
+
+        assertThat(modelValidator.isValid(flow)).isEmpty();
+    }
+
     private Flow parse(String path) {
         URL resource = TestsUtils.class.getClassLoader().getResource(path);
         assert resource != null;

--- a/jdbc-h2/src/main/java/io/kestra/repository/h2/migration/V2_0_17WidenIdentifierColumnsMigration.java
+++ b/jdbc-h2/src/main/java/io/kestra/repository/h2/migration/V2_0_17WidenIdentifierColumnsMigration.java
@@ -1,0 +1,36 @@
+package io.kestra.repository.h2.migration;
+
+import java.util.List;
+
+import javax.sql.DataSource;
+
+import io.kestra.jdbc.migration.AbstractV2_0_17WidenIdentifierColumnsMigration;
+
+import io.micronaut.context.annotation.Requires;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+
+/**
+ * OSS H2 primary-datasource identifier-column widening migration.
+ */
+@Singleton
+@Requires(property = "kestra.repository.type", pattern = "h2|memory")
+public class V2_0_17WidenIdentifierColumnsMigration extends AbstractV2_0_17WidenIdentifierColumnsMigration {
+
+    private final DataSource dataSource;
+
+    @Inject
+    public V2_0_17WidenIdentifierColumnsMigration(final DataSource dataSource) {
+        this.dataSource = dataSource;
+    }
+
+    @Override
+    protected DataSource dataSource() {
+        return dataSource;
+    }
+
+    @Override
+    public List<String> sqlResources() {
+        return List.of("/migrations/2.0.17-widen-identifier-columns-h2.sql");
+    }
+}

--- a/jdbc-h2/src/main/java/io/kestra/repository/h2/migration/V2_0_17WidenLogsTriggerIdMigration.java
+++ b/jdbc-h2/src/main/java/io/kestra/repository/h2/migration/V2_0_17WidenLogsTriggerIdMigration.java
@@ -1,0 +1,76 @@
+package io.kestra.repository.h2.migration;
+
+import java.util.List;
+import java.util.Map;
+
+import javax.sql.DataSource;
+
+import io.kestra.jdbc.LogJdbcDataSourceProvider;
+import io.kestra.jdbc.migration.AbstractSQLMigrationScript;
+import io.kestra.jdbc.migration.LogStoreTypeResolver;
+
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.context.condition.Condition;
+import io.micronaut.context.condition.ConditionContext;
+import jakarta.inject.Singleton;
+
+/**
+ * H2 log-store trigger_id widening migration.
+ *
+ * <p>
+ * Widens the generated {@code trigger_id} column to {@code VARCHAR(256)} on the log-store table resolved
+ * by {@link LogJdbcDataSourceProvider} (a dedicated database when {@code kestra.logs.h2.url} is set,
+ * otherwise the primary datasource), matching {@code Trigger.id}'s {@code @Size(max = 256)}. Mirrors
+ * {@code V2_0_16WidenLogsTaskIdMigration}: the scriptId encodes the backend ("-h2") and a non-default
+ * table name, so switching the log-repo backend re-applies it.
+ *
+ * <p>
+ * Runs whenever the effective log-store dialect is H2 — a configured {@code kestra.logs.type=h2|memory}
+ * or the fallback to an H2 {@code kestra.repository.type} (logs kept in the main database).
+ */
+@Singleton
+@Requires(condition = V2_0_17WidenLogsTriggerIdMigration.H2LogStoreEnabled.class)
+public class V2_0_17WidenLogsTriggerIdMigration extends AbstractSQLMigrationScript {
+
+    public static final class H2LogStoreEnabled implements Condition {
+        @Override
+        public boolean matches(final ConditionContext context) {
+            return LogStoreTypeResolver.matches(context, "h2");
+        }
+    }
+
+    private static final String SCRIPT_ID = "2.0.17-widen-logs-trigger-id-h2";
+    private static final String SQL_RESOURCE = "/migrations/2.0.17-widen-logs-trigger-id-h2.sql";
+
+    private final LogJdbcDataSourceProvider logDataSourceProvider;
+
+    public V2_0_17WidenLogsTriggerIdMigration(final LogJdbcDataSourceProvider logDataSourceProvider) {
+        this.logDataSourceProvider = logDataSourceProvider;
+    }
+
+    @Override
+    public String scriptId() {
+        String table = logDataSourceProvider.table();
+        return "logs".equals(table) ? SCRIPT_ID : SCRIPT_ID + "-" + table;
+    }
+
+    @Override
+    public String description() {
+        return "H2 dedicated log store: widen trigger_id to VARCHAR(256)";
+    }
+
+    @Override
+    public List<String> sqlResources() {
+        return List.of(SQL_RESOURCE);
+    }
+
+    @Override
+    protected DataSource dataSource() {
+        return logDataSourceProvider.dataSource();
+    }
+
+    @Override
+    public void migrate() throws Exception {
+        executeSqlScript(dataSource(), SQL_RESOURCE, Map.of("table", logDataSourceProvider.table()));
+    }
+}

--- a/jdbc-h2/src/main/resources/migrations/2.0.17-widen-identifier-columns-h2.sql
+++ b/jdbc-h2/src/main/resources/migrations/2.0.17-widen-identifier-columns-h2.sql
@@ -1,0 +1,7 @@
+-- 2.0.17: widen every primary-datasource generated column that holds a Trigger.id to VARCHAR(256) to match
+-- Trigger.id's @Size(max = 256), and normalize executions.trigger_execution_id to VARCHAR(150) so all
+-- dialects match. See kestra-ee #9268. H2 restates the generation expression when altering a generated
+-- column; all changes here are index-safe (widenings, plus a narrowing of the ULID-only trigger_execution_id).
+ALTER TABLE triggers ALTER COLUMN "trigger_id" VARCHAR(256) NOT NULL GENERATED ALWAYS AS (JQ_STRING("value", '.triggerId'));
+ALTER TABLE executions ALTER COLUMN "trigger_id" VARCHAR(256) GENERATED ALWAYS AS (JQ_STRING("value", '.trigger.id'));
+ALTER TABLE executions ALTER COLUMN "trigger_execution_id" VARCHAR(150) GENERATED ALWAYS AS (JQ_STRING("value", '.trigger.variables.executionId'));

--- a/jdbc-h2/src/main/resources/migrations/2.0.17-widen-logs-trigger-id-h2.sql
+++ b/jdbc-h2/src/main/resources/migrations/2.0.17-widen-logs-trigger-id-h2.sql
@@ -1,0 +1,3 @@
+-- Widen the dedicated log-store table's generated trigger_id column to VARCHAR(256) to match Trigger.id's @Size(max = 256).
+-- H2 restates the generation expression when altering a generated column. ${table} is the log table.
+ALTER TABLE ${table} ALTER COLUMN "trigger_id" VARCHAR(256) GENERATED ALWAYS AS (JQ_STRING("value", '.triggerId'));

--- a/jdbc-mysql/src/main/java/io/kestra/repository/mysql/migration/V2_0_17WidenIdentifierColumnsMigration.java
+++ b/jdbc-mysql/src/main/java/io/kestra/repository/mysql/migration/V2_0_17WidenIdentifierColumnsMigration.java
@@ -1,0 +1,40 @@
+package io.kestra.repository.mysql.migration;
+
+import java.util.List;
+
+import javax.sql.DataSource;
+
+import io.kestra.jdbc.migration.AbstractV2_0_17WidenIdentifierColumnsMigration;
+import io.kestra.repository.mysql.MysqlRepositoryEnabled;
+
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+
+/**
+ * OSS MySQL primary-datasource identifier-column widening migration.
+ *
+ * <p>
+ * Guarded on MySQL: modifying a {@code STORED GENERATED} column rebuilds the table
+ * ({@code ALGORITHM=COPY}), so each ALTER widens only when the column is still below its target width.
+ */
+@Singleton
+@MysqlRepositoryEnabled
+public class V2_0_17WidenIdentifierColumnsMigration extends AbstractV2_0_17WidenIdentifierColumnsMigration {
+
+    private final DataSource dataSource;
+
+    @Inject
+    public V2_0_17WidenIdentifierColumnsMigration(final DataSource dataSource) {
+        this.dataSource = dataSource;
+    }
+
+    @Override
+    protected DataSource dataSource() {
+        return dataSource;
+    }
+
+    @Override
+    public List<String> sqlResources() {
+        return List.of("/migrations/2.0.17-widen-identifier-columns-mysql.sql");
+    }
+}

--- a/jdbc-mysql/src/main/java/io/kestra/repository/mysql/migration/V2_0_17WidenLogsTriggerIdMigration.java
+++ b/jdbc-mysql/src/main/java/io/kestra/repository/mysql/migration/V2_0_17WidenLogsTriggerIdMigration.java
@@ -1,0 +1,76 @@
+package io.kestra.repository.mysql.migration;
+
+import java.util.List;
+import java.util.Map;
+
+import javax.sql.DataSource;
+
+import io.kestra.jdbc.LogJdbcDataSourceProvider;
+import io.kestra.jdbc.migration.AbstractSQLMigrationScript;
+import io.kestra.jdbc.migration.LogStoreTypeResolver;
+
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.context.condition.Condition;
+import io.micronaut.context.condition.ConditionContext;
+import jakarta.inject.Singleton;
+
+/**
+ * MySQL log-store trigger_id widening migration.
+ *
+ * <p>
+ * Widens the generated {@code trigger_id} column to {@code VARCHAR(256)} on the log-store table resolved
+ * by {@link LogJdbcDataSourceProvider}, matching {@code Trigger.id}'s {@code @Size(max = 256)}. Guarded
+ * by an information_schema length check because modifying a {@code STORED GENERATED} column rebuilds the
+ * table ({@code ALGORITHM=COPY}). Mirrors {@code V2_0_16WidenLogsTaskIdMigration}: the scriptId encodes
+ * the backend ("-mysql") and a non-default table name, so switching the log-repo backend re-applies it.
+ *
+ * <p>
+ * Runs whenever the effective log-store dialect is MySQL — a configured {@code kestra.logs.type=mysql}
+ * or the fallback to a MySQL {@code kestra.repository.type} (logs kept in the main database).
+ */
+@Singleton
+@Requires(condition = V2_0_17WidenLogsTriggerIdMigration.MysqlLogStoreEnabled.class)
+public class V2_0_17WidenLogsTriggerIdMigration extends AbstractSQLMigrationScript {
+
+    public static final class MysqlLogStoreEnabled implements Condition {
+        @Override
+        public boolean matches(final ConditionContext context) {
+            return LogStoreTypeResolver.matches(context, "mysql");
+        }
+    }
+
+    private static final String SCRIPT_ID = "2.0.17-widen-logs-trigger-id-mysql";
+    private static final String SQL_RESOURCE = "/migrations/2.0.17-widen-logs-trigger-id-mysql.sql";
+
+    private final LogJdbcDataSourceProvider logDataSourceProvider;
+
+    public V2_0_17WidenLogsTriggerIdMigration(final LogJdbcDataSourceProvider logDataSourceProvider) {
+        this.logDataSourceProvider = logDataSourceProvider;
+    }
+
+    @Override
+    public String scriptId() {
+        String table = logDataSourceProvider.table();
+        return "logs".equals(table) ? SCRIPT_ID : SCRIPT_ID + "-" + table;
+    }
+
+    @Override
+    public String description() {
+        return "MySQL dedicated log store: widen trigger_id to VARCHAR(256)";
+    }
+
+    @Override
+    public List<String> sqlResources() {
+        return List.of(SQL_RESOURCE);
+    }
+
+    @Override
+    protected DataSource dataSource() {
+        return logDataSourceProvider.dataSource();
+    }
+
+    @Override
+    public void migrate() throws Exception {
+        executeSqlScript(dataSource(), SQL_RESOURCE, Map.of("table", logDataSourceProvider.table()));
+    }
+}

--- a/jdbc-mysql/src/main/resources/migrations/2.0.17-widen-identifier-columns-mysql.sql
+++ b/jdbc-mysql/src/main/resources/migrations/2.0.17-widen-identifier-columns-mysql.sql
@@ -1,0 +1,20 @@
+-- 2.0.17: widen every primary-datasource generated column that holds a Trigger.id to VARCHAR(256) to match
+-- Trigger.id's @Size(max = 256), and normalize executions.trigger_execution_id to VARCHAR(150) so all
+-- dialects match. See kestra-ee #9268. Modifying a STORED GENERATED column rebuilds the table
+-- (ALGORITHM=COPY), so each ALTER is guarded by an information_schema length check and runs only when the
+-- column is still below its target width.
+SET @len = (SELECT CHARACTER_MAXIMUM_LENGTH FROM information_schema.columns WHERE table_schema = DATABASE() AND table_name = 'triggers' AND column_name = 'trigger_id');
+SET @sql = IF(@len IS NOT NULL AND @len < 256, 'ALTER TABLE triggers MODIFY COLUMN `trigger_id` VARCHAR(256) GENERATED ALWAYS AS (value ->> ''$.triggerId'') STORED NOT NULL', 'SELECT 1');
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+SET @len = (SELECT CHARACTER_MAXIMUM_LENGTH FROM information_schema.columns WHERE table_schema = DATABASE() AND table_name = 'executions' AND column_name = 'trigger_id');
+SET @sql = IF(@len IS NOT NULL AND @len < 256, 'ALTER TABLE executions MODIFY COLUMN `trigger_id` VARCHAR(256) GENERATED ALWAYS AS (value ->> ''$.trigger.id'') STORED', 'SELECT 1');
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+SET @len = (SELECT CHARACTER_MAXIMUM_LENGTH FROM information_schema.columns WHERE table_schema = DATABASE() AND table_name = 'executions' AND column_name = 'trigger_execution_id');
+SET @sql = IF(@len IS NOT NULL AND @len < 150, 'ALTER TABLE executions MODIFY COLUMN `trigger_execution_id` VARCHAR(150) GENERATED ALWAYS AS (value ->> ''$.trigger.variables.executionId'') STORED', 'SELECT 1');
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;

--- a/jdbc-mysql/src/main/resources/migrations/2.0.17-widen-logs-trigger-id-mysql.sql
+++ b/jdbc-mysql/src/main/resources/migrations/2.0.17-widen-logs-trigger-id-mysql.sql
@@ -1,0 +1,8 @@
+-- Widen the dedicated log-store table's generated trigger_id column to VARCHAR(256) to match Trigger.id's @Size(max = 256).
+-- Guarded: modifying a STORED GENERATED column rebuilds the table (ALGORITHM=COPY), so widen only
+-- when still shorter than 256. ${table} is substituted with the configured log table name.
+SET @len = (SELECT CHARACTER_MAXIMUM_LENGTH FROM information_schema.columns WHERE table_schema = DATABASE() AND table_name = '${table}' AND column_name = 'trigger_id');
+SET @sql = IF(@len IS NOT NULL AND @len < 256, 'ALTER TABLE ${table} MODIFY COLUMN `trigger_id` VARCHAR(256) GENERATED ALWAYS AS (value ->> ''$.triggerId'') STORED', 'SELECT 1');
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;

--- a/jdbc-postgres/src/main/java/io/kestra/repository/postgres/migration/V2_0_17WidenIdentifierColumnsMigration.java
+++ b/jdbc-postgres/src/main/java/io/kestra/repository/postgres/migration/V2_0_17WidenIdentifierColumnsMigration.java
@@ -1,0 +1,36 @@
+package io.kestra.repository.postgres.migration;
+
+import java.util.List;
+
+import javax.sql.DataSource;
+
+import io.kestra.jdbc.migration.AbstractV2_0_17WidenIdentifierColumnsMigration;
+import io.kestra.repository.postgres.PostgresRepositoryEnabled;
+
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+
+/**
+ * OSS Postgres primary-datasource identifier-column widening migration.
+ */
+@Singleton
+@PostgresRepositoryEnabled
+public class V2_0_17WidenIdentifierColumnsMigration extends AbstractV2_0_17WidenIdentifierColumnsMigration {
+
+    private final DataSource dataSource;
+
+    @Inject
+    public V2_0_17WidenIdentifierColumnsMigration(final DataSource dataSource) {
+        this.dataSource = dataSource;
+    }
+
+    @Override
+    protected DataSource dataSource() {
+        return dataSource;
+    }
+
+    @Override
+    public List<String> sqlResources() {
+        return List.of("/migrations/2.0.17-widen-identifier-columns-postgres.sql");
+    }
+}

--- a/jdbc-postgres/src/main/java/io/kestra/repository/postgres/migration/V2_0_17WidenLogsTriggerIdMigration.java
+++ b/jdbc-postgres/src/main/java/io/kestra/repository/postgres/migration/V2_0_17WidenLogsTriggerIdMigration.java
@@ -1,0 +1,76 @@
+package io.kestra.repository.postgres.migration;
+
+import java.util.List;
+import java.util.Map;
+
+import javax.sql.DataSource;
+
+import io.kestra.jdbc.LogJdbcDataSourceProvider;
+import io.kestra.jdbc.migration.AbstractSQLMigrationScript;
+import io.kestra.jdbc.migration.LogStoreTypeResolver;
+
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.context.condition.Condition;
+import io.micronaut.context.condition.ConditionContext;
+import jakarta.inject.Singleton;
+
+/**
+ * Postgres log-store trigger_id widening migration.
+ *
+ * <p>
+ * Widens the generated {@code trigger_id} column to {@code VARCHAR(256)} on the log-store table resolved
+ * by {@link LogJdbcDataSourceProvider} (a dedicated database when {@code kestra.logs.postgres.url} is
+ * set, otherwise the primary datasource), matching {@code Trigger.id}'s {@code @Size(max = 256)}. Mirrors
+ * {@code V2_0_16WidenLogsTaskIdMigration}: the scriptId encodes the backend ("-postgres") and a
+ * non-default table name, so switching the log-repo backend re-applies it.
+ *
+ * <p>
+ * Runs whenever the effective log-store dialect is Postgres — a configured {@code kestra.logs.type=postgres}
+ * or the fallback to a Postgres {@code kestra.repository.type} (logs kept in the main database).
+ */
+@Singleton
+@Requires(condition = V2_0_17WidenLogsTriggerIdMigration.PostgresLogStoreEnabled.class)
+public class V2_0_17WidenLogsTriggerIdMigration extends AbstractSQLMigrationScript {
+
+    public static final class PostgresLogStoreEnabled implements Condition {
+        @Override
+        public boolean matches(final ConditionContext context) {
+            return LogStoreTypeResolver.matches(context, "postgres");
+        }
+    }
+
+    private static final String SCRIPT_ID = "2.0.17-widen-logs-trigger-id-postgres";
+    private static final String SQL_RESOURCE = "/migrations/2.0.17-widen-logs-trigger-id-postgres.sql";
+
+    private final LogJdbcDataSourceProvider logDataSourceProvider;
+
+    public V2_0_17WidenLogsTriggerIdMigration(final LogJdbcDataSourceProvider logDataSourceProvider) {
+        this.logDataSourceProvider = logDataSourceProvider;
+    }
+
+    @Override
+    public String scriptId() {
+        String table = logDataSourceProvider.table();
+        return "logs".equals(table) ? SCRIPT_ID : SCRIPT_ID + "-" + table;
+    }
+
+    @Override
+    public String description() {
+        return "Postgres dedicated log store: widen trigger_id to VARCHAR(256)";
+    }
+
+    @Override
+    public List<String> sqlResources() {
+        return List.of(SQL_RESOURCE);
+    }
+
+    @Override
+    protected DataSource dataSource() {
+        return logDataSourceProvider.dataSource();
+    }
+
+    @Override
+    public void migrate() throws Exception {
+        executeSqlScript(dataSource(), SQL_RESOURCE, Map.of("table", logDataSourceProvider.table()));
+    }
+}

--- a/jdbc-postgres/src/main/resources/migrations/2.0.17-widen-identifier-columns-postgres.sql
+++ b/jdbc-postgres/src/main/resources/migrations/2.0.17-widen-identifier-columns-postgres.sql
@@ -1,0 +1,5 @@
+-- 2.0.17: widen every primary-datasource generated column that holds a Trigger.id to VARCHAR(256) to match
+-- Trigger.id's @Size(max = 256). See kestra-ee #9268. Metadata-only on Postgres (no table rewrite); NOT NULL
+-- is preserved. trigger_execution_id is already VARCHAR(150) on Postgres, so it is left as-is.
+ALTER TABLE triggers ALTER COLUMN trigger_id TYPE VARCHAR(256);
+ALTER TABLE executions ALTER COLUMN trigger_id TYPE VARCHAR(256);

--- a/jdbc-postgres/src/main/resources/migrations/2.0.17-widen-logs-trigger-id-postgres.sql
+++ b/jdbc-postgres/src/main/resources/migrations/2.0.17-widen-logs-trigger-id-postgres.sql
@@ -1,0 +1,3 @@
+-- Widen the dedicated log-store table's generated trigger_id column to VARCHAR(256) to match Trigger.id's @Size(max = 256).
+-- Metadata-only on Postgres (no table rewrite). ${table} is substituted with the configured log table.
+ALTER TABLE ${table} ALTER COLUMN trigger_id TYPE VARCHAR(256);

--- a/jdbc/src/main/java/io/kestra/jdbc/migration/AbstractV2_0_17WidenIdentifierColumnsMigration.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/migration/AbstractV2_0_17WidenIdentifierColumnsMigration.java
@@ -1,0 +1,32 @@
+package io.kestra.jdbc.migration;
+
+/**
+ * Abstract base for the 2.0.17 primary-datasource identifier-column migration.
+ *
+ * <p>
+ * Widens every generated column on the primary datasource that holds a {@code Trigger.id} —
+ * {@code triggers.trigger_id} and {@code executions.trigger_id} (the latter added by
+ * {@code 2.0.01-upgrade}, extracting {@code .trigger.id}) — from {@code VARCHAR(150)} to
+ * {@code VARCHAR(256)} to match {@code Trigger.id}'s {@code @Size(max = 256)}. A trigger id longer than
+ * 150 chars would otherwise overflow the column and crash-loop the JDBC indexer (see kestra-ee #9268).
+ * On H2/MySQL it also normalizes {@code executions.trigger_execution_id} from {@code VARCHAR(100)} to
+ * {@code VARCHAR(150)} so all dialects match (Postgres already declares it at 150).
+ *
+ * <p>
+ * The log-store table's {@code trigger_id} is widened separately by the
+ * {@code 2.0.17-widen-logs-trigger-id-<dialect>} migration, which runs against the (possibly dedicated)
+ * log datasource. Concrete subclasses provide the per-dialect SQL resource and the primary
+ * {@link javax.sql.DataSource}.
+ */
+public abstract class AbstractV2_0_17WidenIdentifierColumnsMigration extends AbstractSQLMigrationScript {
+
+    @Override
+    public String scriptId() {
+        return "2.0.17-widen-identifier-columns";
+    }
+
+    @Override
+    public String description() {
+        return "Widen trigger_id identifier columns to VARCHAR(256) and normalize trigger_execution_id";
+    }
+}

--- a/webserver/src/main/java/io/kestra/webserver/controllers/api/TriggerPluginCategory.java
+++ b/webserver/src/main/java/io/kestra/webserver/controllers/api/TriggerPluginCategory.java
@@ -4,12 +4,12 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonValue;
 
-import io.swagger.v3.oas.annotations.media.Schema;
-
 import io.kestra.core.models.triggers.PollingTriggerInterface;
 import io.kestra.core.models.triggers.RealtimeTriggerInterface;
 import io.kestra.core.plugins.RegisteredPlugin;
 import io.kestra.core.utils.Enums;
+
+import io.swagger.v3.oas.annotations.media.Schema;
 
 /**
  * Category bucket for the "Add Trigger" catalog in the UI.


### PR DESCRIPTION
Add validation for Trigger.id for maximum of 256 char as Task.id.
Widden columns to match the maximum size defined in the code.

This would prevent future issues as https://github.com/kestra-io/kestra/issues/17328