### PR TITLE
feat(ai): show a context chip and structured tool results in copilot

### DIFF
--- a/ui/src/components/ai/copilot/CopilotChat.vue
+++ b/ui/src/components/ai/copilot/CopilotChat.vue
@@ -38,6 +38,7 @@
                     <img :src="logo" alt="" class="copilot-artwork-img" >
                 </div>
                 <KsText size="large" class="copilot-empty-title">{{ t("ai.copilot.empty.title") }}</KsText>
+                <CopilotContextChip v-if="activeScope" :scope="activeScope" @clear="scopeDismissed = true" />
                 <CopilotComposer
                     ref="emptyComposer"
                     v-model="composerText"
@@ -92,6 +93,7 @@
             </KsAlert>
 
             <div class="copilot-footer">
+                <CopilotContextChip v-if="activeScope" :scope="activeScope" @clear="scopeDismissed = true" />
                 <CopilotComposer
                     ref="footerComposer"
                     v-model="composerText"
@@ -120,6 +122,7 @@
     import CopilotComposer from "./CopilotComposer.vue"
     import CopilotThinking from "./CopilotThinking.vue"
     import ProposedActionCard from "./ProposedActionCard.vue"
+    import CopilotContextChip from "./CopilotContextChip.vue"
     import {useAiChat} from "./useAiChat"
     import {scopeFromRoute} from "./routeScope"
     import type {Mode, ScopeBinding} from "./types"
@@ -142,6 +145,15 @@
     // page as `inFocus` so the agent knows what the user is looking at. An explicit `inFocus` prop
     // (if a parent ever passes one) still wins. Recomputed as the route changes while the drawer is open.
     const routeInFocus = computed<ScopeBinding | null>(() => props.inFocus ?? scopeFromRoute(route))
+
+    // The user can dismiss the context chip to run a turn without the current page's scope. Dismissal
+    // is re-armed whenever the focused resource changes (navigating to a new page re-attaches scope).
+    const scopeDismissed = ref(false)
+    const activeScope = computed<ScopeBinding | null>(() => (scopeDismissed.value ? null : routeInFocus.value))
+    watch(
+        () => JSON.stringify(routeInFocus.value),
+        () => (scopeDismissed.value = false),
+    )
 
     // Shared composer text (both the empty-state and footer composers bind it), so an external
     // entry point can seed a prompt via the misc store (see consumeSeededPrompt).
@@ -194,7 +206,7 @@
     })
 
     function onSubmit(prompt: string): void {
-        sendChat({prompt, mode: mode.value, inFocus: routeInFocus.value, providerId: selectedProvider.value})
+        sendChat({prompt, mode: mode.value, inFocus: activeScope.value, providerId: selectedProvider.value})
     }
 
     // Keep the transcript pinned to the bottom as content arrives: new messages, streamed

--- a/ui/src/components/ai/copilot/CopilotContextChip.vue
+++ b/ui/src/components/ai/copilot/CopilotContextChip.vue
@@ -1,0 +1,52 @@
+<template>
+    <!-- Shows the page the copilot is focused on (sent as `inFocus`). Dismissible to drop the scope. -->
+    <div class="copilot-context" data-test="copilot-context-chip">
+        <KsTag closable size="small" :icon="icon" @close="emit('clear')">
+            {{ label }}
+        </KsTag>
+    </div>
+</template>
+
+<script setup lang="ts">
+    import {computed} from "vue"
+    import {useI18n} from "vue-i18n"
+    import FileDocumentOutline from "vue-material-design-icons/FileDocumentOutline.vue"
+    import PlayCircleOutline from "vue-material-design-icons/PlayCircleOutline.vue"
+    import FolderOutline from "vue-material-design-icons/FolderOutline.vue"
+    import type {ScopeBinding} from "./types"
+
+    const props = defineProps<{scope: ScopeBinding}>()
+    const emit = defineEmits<{clear: []}>()
+
+    const {t} = useI18n()
+
+    const icon = computed(() => {
+        switch (props.scope.kind) {
+        case "EXECUTION":
+            return PlayCircleOutline
+        case "NAMESPACE":
+            return FolderOutline
+        default:
+            return FileDocumentOutline
+        }
+    })
+
+    // A short, human label for the focused resource. Falls back gracefully if a field is missing.
+    const label = computed(() => {
+        switch (props.scope.kind) {
+        case "EXECUTION":
+            return t("ai.copilot.context.execution", {id: props.scope.executionId ?? ""})
+        case "NAMESPACE":
+            return t("ai.copilot.context.namespace", {namespace: props.scope.namespace ?? ""})
+        default:
+            return t("ai.copilot.context.flow", {flow: props.scope.flowId ?? ""})
+        }
+    })
+</script>
+
+<style scoped>
+    .copilot-context {
+        display: flex;
+        margin-bottom: var(--ks-spacing-2);
+    }
+</style>

--- a/ui/src/components/ai/copilot/CopilotMessage.vue
+++ b/ui/src/components/ai/copilot/CopilotMessage.vue
@@ -30,13 +30,26 @@
     </div>
 
     <div v-else-if="message.type === 'TOOL_RESULT'" class="copilot-msg copilot-tool-result" data-test="copilot-tool-result">
-        <KsIcon class="copilot-tool-result-icon" :class="isOk ? 'is-ok' : 'is-error'">
-            <CheckCircleOutline v-if="isOk" />
-            <CloseCircleOutline v-else />
-        </KsIcon>
-        <KsText size="small" class="copilot-tool-label">
-            {{ t(`ai.copilot.toolResult.${outcome}`, {tool: toolName}) }}
-        </KsText>
+        <div class="copilot-tool-result-row">
+            <KsIcon class="copilot-tool-result-icon" :class="isOk ? 'is-ok' : 'is-error'">
+                <CheckCircleOutline v-if="isOk" />
+                <CloseCircleOutline v-else />
+            </KsIcon>
+            <KsText size="small" class="copilot-tool-label">
+                {{ t(`ai.copilot.toolResult.${outcome}`, {tool: toolName}) }}
+            </KsText>
+        </div>
+
+        <!-- Result payload / error / rejection reason — present on thread reload (the live stream
+             carries only the outcome). Collapsed by default, like the tool-call args. -->
+        <KsCollapse v-if="resultDetail" v-model="expandedResult" data-test="copilot-tool-result-detail">
+            <KsCollapseItem name="result">
+                <template #title>
+                    <KsText size="small" class="copilot-tool-label">{{ t("ai.copilot.toolResult.detail") }}</KsText>
+                </template>
+                <pre class="copilot-tool-args">{{ resultDetail }}</pre>
+            </KsCollapseItem>
+        </KsCollapse>
     </div>
 
     <!-- Artefact draft — a non-mutating flow/dashboard/app the agent generated -->
@@ -58,9 +71,12 @@
     const {t} = useI18n()
 
     const expanded = ref<string[]>([])
+    const expandedResult = ref<string[]>([])
 
     const argsJson = computed(() => JSON.stringify(props.message.toolCall?.arguments ?? {}, null, 2))
-    const toolName = computed(() => props.message.toolResult?.tool ?? "")
+    // On reload the tool name lives on the paired toolCall (the persisted result map has no `tool`);
+    // on the live stream it's on the result event itself.
+    const toolName = computed(() => props.message.toolResult?.tool ?? props.message.toolCall?.tool ?? "")
     // Backend outcomes: "ok" (tool ran), "error" (tool threw, turn continues), "rejected" (user declined).
     // Anything unexpected falls back to "rejected" so we never render a raw/missing label.
     const outcome = computed(() => {
@@ -68,6 +84,20 @@
         return value === "ok" || value === "error" ? value : "rejected"
     })
     const isOk = computed(() => outcome.value === "ok")
+
+    // The detail to show under a tool result: the returned payload on success, the message on an
+    // error, the reason on a rejection. Null when there's nothing extra (e.g. a live turn, which
+    // streams only the outcome) so the collapsible is hidden.
+    const resultDetail = computed<string | null>(() => {
+        const toolResult = props.message.toolResult
+        if (!toolResult) return null
+        if (outcome.value === "error") return toolResult.error ?? null
+        if (outcome.value === "rejected") return toolResult.reason ?? null
+        if (toolResult.result == null) return null
+        return typeof toolResult.result === "string"
+            ? toolResult.result
+            : JSON.stringify(toolResult.result, null, 2)
+    })
 </script>
 
 <style scoped>
@@ -127,7 +157,7 @@
         --kel-text-color: var(--ks-text-secondary);
     }
 
-    .copilot-tool-result {
+    .copilot-tool-result-row {
         display: flex;
         align-items: center;
         gap: var(--ks-spacing-1);

--- a/ui/src/components/ai/copilot/types.ts
+++ b/ui/src/components/ai/copilot/types.ts
@@ -151,6 +151,14 @@ export interface ToolResultEvent {
     tool: string
     /** "ok", "error" (the tool threw; the turn continues), or "rejected". */
     outcome: string
+    /**
+     * Detail persisted with the result — present on thread reload, not on the live stream (the SSE
+     * tool_result event carries only `tool` + `outcome`). `result` on success, `error` on a thrown
+     * tool, `reason` on a user rejection.
+     */
+    result?: unknown
+    error?: string | null
+    reason?: string | null
 }
 
 /** A single step of a Plan-mode plan card. */

--- a/ui/src/translations/de.json
+++ b/ui/src/translations/de.json
@@ -2021,7 +2021,13 @@
           "title": "Turn your idea into a workflow"
         },
         "toolCall": "Running {tool}",
+        "context": {
+          "execution": "Ausführung: {id}",
+          "flow": "Flow: {flow}",
+          "namespace": "Namespace: {namespace}"
+        },
         "toolResult": {
+          "detail": "Details",
           "error": "{tool} fehlgeschlagen",
           "ok": "{tool} completed",
           "rejected": "{tool} rejected"

--- a/ui/src/translations/en.json
+++ b/ui/src/translations/en.json
@@ -2021,7 +2021,13 @@
           "title": "Turn your idea into a workflow"
         },
         "toolCall": "Running {tool}",
+        "context": {
+          "execution": "Execution: {id}",
+          "flow": "Flow: {flow}",
+          "namespace": "Namespace: {namespace}"
+        },
         "toolResult": {
+          "detail": "Details",
           "error": "{tool} failed",
           "ok": "{tool} completed",
           "rejected": "{tool} rejected"

--- a/ui/src/translations/es.json
+++ b/ui/src/translations/es.json
@@ -2021,7 +2021,13 @@
           "title": "Turn your idea into a workflow"
         },
         "toolCall": "Running {tool}",
+        "context": {
+          "execution": "Ejecución: {id}",
+          "flow": "Flow: {flow}",
+          "namespace": "Namespace: {namespace}"
+        },
         "toolResult": {
+          "detail": "Detalles",
           "error": "{tool} falló",
           "ok": "{tool} completed",
           "rejected": "{tool} rejected"

--- a/ui/src/translations/fr.json
+++ b/ui/src/translations/fr.json
@@ -2021,7 +2021,13 @@
           "title": "Turn your idea into a workflow"
         },
         "toolCall": "Running {tool}",
+        "context": {
+          "execution": "Exécution: {id}",
+          "flow": "Flow: {flow}",
+          "namespace": "Namespace: {namespace}"
+        },
         "toolResult": {
+          "detail": "Détails",
           "error": "{tool} a échoué",
           "ok": "{tool} completed",
           "rejected": "{tool} rejected"

--- a/ui/src/translations/hi.json
+++ b/ui/src/translations/hi.json
@@ -2021,7 +2021,13 @@
           "title": "Turn your idea into a workflow"
         },
         "toolCall": "Running {tool}",
+        "context": {
+          "execution": "निष्पादन: {id}",
+          "flow": "Flow: {flow}",
+          "namespace": "Namespace: {namespace}"
+        },
         "toolResult": {
+          "detail": "विवरण",
           "error": "{tool} विफल रहा",
           "ok": "{tool} completed",
           "rejected": "{tool} rejected"

--- a/ui/src/translations/it.json
+++ b/ui/src/translations/it.json
@@ -2021,7 +2021,13 @@
           "title": "Turn your idea into a workflow"
         },
         "toolCall": "Running {tool}",
+        "context": {
+          "execution": "Esecuzione: {id}",
+          "flow": "Flow: {flow}",
+          "namespace": "Namespace: {namespace}"
+        },
         "toolResult": {
+          "detail": "Dettagli",
           "error": "{tool} non riuscito",
           "ok": "{tool} completed",
           "rejected": "{tool} rejected"

--- a/ui/src/translations/ja.json
+++ b/ui/src/translations/ja.json
@@ -2021,7 +2021,13 @@
           "title": "Turn your idea into a workflow"
         },
         "toolCall": "Running {tool}",
+        "context": {
+          "execution": "実行: {id}",
+          "flow": "Flow: {flow}",
+          "namespace": "Namespace: {namespace}"
+        },
         "toolResult": {
+          "detail": "詳細",
           "error": "{tool} が失敗しました",
           "ok": "{tool} completed",
           "rejected": "{tool} rejected"

--- a/ui/src/translations/ko.json
+++ b/ui/src/translations/ko.json
@@ -2021,7 +2021,13 @@
           "title": "Turn your idea into a workflow"
         },
         "toolCall": "Running {tool}",
+        "context": {
+          "execution": "실행: {id}",
+          "flow": "Flow: {flow}",
+          "namespace": "Namespace: {namespace}"
+        },
         "toolResult": {
+          "detail": "세부 정보",
           "error": "{tool} 실패",
           "ok": "{tool} completed",
           "rejected": "{tool} rejected"

--- a/ui/src/translations/pl.json
+++ b/ui/src/translations/pl.json
@@ -2021,7 +2021,13 @@
           "title": "Turn your idea into a workflow"
         },
         "toolCall": "Running {tool}",
+        "context": {
+          "execution": "Wykonanie: {id}",
+          "flow": "Flow: {flow}",
+          "namespace": "Namespace: {namespace}"
+        },
         "toolResult": {
+          "detail": "Szczegóły",
           "error": "{tool} nie powiodło się",
           "ok": "{tool} completed",
           "rejected": "{tool} rejected"

--- a/ui/src/translations/pt.json
+++ b/ui/src/translations/pt.json
@@ -2021,7 +2021,13 @@
           "title": "Turn your idea into a workflow"
         },
         "toolCall": "Running {tool}",
+        "context": {
+          "execution": "Execução: {id}",
+          "flow": "Flow: {flow}",
+          "namespace": "Namespace: {namespace}"
+        },
         "toolResult": {
+          "detail": "Detalhes",
           "error": "{tool} falhou",
           "ok": "{tool} completed",
           "rejected": "{tool} rejected"

--- a/ui/src/translations/pt_BR.json
+++ b/ui/src/translations/pt_BR.json
@@ -2021,7 +2021,13 @@
           "title": "Turn your idea into a workflow"
         },
         "toolCall": "Running {tool}",
+        "context": {
+          "execution": "Execução: {id}",
+          "flow": "Flow: {flow}",
+          "namespace": "Namespace: {namespace}"
+        },
         "toolResult": {
+          "detail": "Detalhes",
           "error": "{tool} falhou",
           "ok": "{tool} completed",
           "rejected": "{tool} rejected"

--- a/ui/src/translations/ru.json
+++ b/ui/src/translations/ru.json
@@ -2021,7 +2021,13 @@
           "title": "Turn your idea into a workflow"
         },
         "toolCall": "Running {tool}",
+        "context": {
+          "execution": "Выполнение: {id}",
+          "flow": "Flow: {flow}",
+          "namespace": "Namespace: {namespace}"
+        },
         "toolResult": {
+          "detail": "Подробности",
           "error": "{tool} не удалось",
           "ok": "{tool} completed",
           "rejected": "{tool} rejected"

--- a/ui/src/translations/zh_CN.json
+++ b/ui/src/translations/zh_CN.json
@@ -2021,7 +2021,13 @@
           "title": "Turn your idea into a workflow"
         },
         "toolCall": "Running {tool}",
+        "context": {
+          "execution": "执行: {id}",
+          "flow": "Flow: {flow}",
+          "namespace": "Namespace: {namespace}"
+        },
         "toolResult": {
+          "detail": "详情",
           "error": "{tool} 失败",
           "ok": "{tool} completed",
           "rejected": "{tool} rejected"

--- a/ui/tests/e2e/ai-copilot.spec.ts
+++ b/ui/tests/e2e/ai-copilot.spec.ts
@@ -120,4 +120,39 @@ test.describe("AI Copilot", () => {
         await expect(page.locator(D.chat)).toContainText("Done — it's running again.")
         await expect(card).toBeHidden()
     })
+
+    test("surfaces a notice when a turn returns no output", async ({page}) => {
+        // The stream closes with only `done` — no tokens, tools, or proposal.
+        await page.route("**/ai/threads/*/chat", async (route) => {
+            await route.fulfill({
+                status: 200,
+                contentType: "text/event-stream",
+                body: sse([["done", {status: "IDLE"}]]),
+            })
+        })
+
+        await page.locator(D.input).fill("hello?")
+        await page.locator(D.send).click()
+
+        await expect(page.locator("[data-test=\"copilot-notice\"]")).toBeVisible()
+    })
+
+    test("carries the current page as a context chip on a detail route", async ({page}) => {
+        // Open a flow detail route (the flow need not exist — the chip is derived from the route name
+        // + params). Re-open the AI dock on the new page, then assert the context chip reflects it.
+        const tenant = new URL(page.url()).pathname.split("/")[2] || "main"
+        await page.goto(`/ui/${tenant}/flows/edit/company.team/e2e-context-flow`, {waitUntil: "domcontentloaded"})
+
+        const chat = page.locator(D.chat)
+        if (!(await chat.isVisible().catch(() => false))) {
+            await page.getByRole("button", {name: "Toggle panel"}).click().catch(() => {})
+            await page.waitForTimeout(500)
+            await page.getByRole("tab", {name: "AI"}).click().catch(() => {})
+        }
+        await expect(chat).toBeVisible({timeout: 15000})
+
+        const chip = page.locator("[data-test=\"copilot-context-chip\"]")
+        await expect(chip).toBeVisible()
+        await expect(chip).toContainText("e2e-context-flow")
+    })
 })

--- a/ui/tests/unit/components/ai/copilot/CopilotChat.spec.ts
+++ b/ui/tests/unit/components/ai/copilot/CopilotChat.spec.ts
@@ -104,6 +104,29 @@ describe("CopilotChat", () => {
         }))
     })
 
+    it("shows the context chip on a detail route and hides it on a plain route", async () => {
+        routeStub = {name: "flows/update", params: {namespace: "company.team", id: "my-flow"}}
+        expect(mountChat().findComponent({name: "CopilotContextChip"}).exists()).toBe(true)
+
+        routeStub = {name: "flows/list", params: {}}
+        expect(mountChat().findComponent({name: "CopilotContextChip"}).exists()).toBe(false)
+    })
+
+    it("drops the scope from the turn after the context chip is dismissed", async () => {
+        routeStub = {name: "flows/update", params: {namespace: "company.team", id: "my-flow"}}
+        const w = mountChat()
+        const chip = w.findComponent({name: "CopilotContextChip"})
+        expect(chip.exists()).toBe(true)
+
+        chip.vm.$emit("clear")
+        await flushPromises()
+        expect(w.findComponent({name: "CopilotContextChip"}).exists()).toBe(false)
+
+        w.findComponent({name: "CopilotComposer"}).vm.$emit("submit", "no scope please")
+        await flushPromises()
+        expect(state.sendChat).toHaveBeenCalledWith(expect.objectContaining({prompt: "no scope please", inFocus: null}))
+    })
+
     it("surfaces a warning notice when a turn yields no output", () => {
         state.notice.value = "emptyTurn"
         const w = mountChat()

--- a/ui/tests/unit/components/ai/copilot/CopilotContextChip.spec.ts
+++ b/ui/tests/unit/components/ai/copilot/CopilotContextChip.spec.ts
@@ -1,0 +1,39 @@
+import {describe, it, expect} from "vitest"
+import {mount} from "@vue/test-utils"
+import {i18n} from "./_helpers"
+import CopilotContextChip from "../../../../../src/components/ai/copilot/CopilotContextChip.vue"
+
+// KsTag stub with a working close button so we can assert the clear emit.
+const KsTag = {
+    name: "KsTag",
+    // `closable` must be typed Boolean so the valueless `<KsTag closable>` attribute resolves to true
+    // (an untyped array prop would make it "" — falsy — and hide the close button).
+    props: {closable: Boolean, icon: {type: [Object, Function], default: undefined}, size: {type: String, default: undefined}},
+    emits: ["close"],
+    template: "<span class=\"ks-tag\"><slot /><button v-if=\"closable\" class=\"close\" @click=\"$emit('close')\">x</button></span>",
+}
+const KsIcon = {name: "KsIcon", template: "<i><slot /></i>"}
+
+const mountChip = (scope: any) =>
+    mount(CopilotContextChip, {props: {scope}, global: {plugins: [i18n], stubs: {KsTag, KsIcon}}})
+
+describe("CopilotContextChip", () => {
+    it("labels a flow scope", () => {
+        expect(mountChip({kind: "FLOW", namespace: "company.team", flowId: "my-flow"}).text()).toContain("Flow: my-flow")
+    })
+
+    it("labels an execution scope", () => {
+        expect(mountChip({kind: "EXECUTION", namespace: "company.team", flowId: "my-flow", executionId: "exec-1"}).text())
+            .toContain("Execution: exec-1")
+    })
+
+    it("labels a namespace scope", () => {
+        expect(mountChip({kind: "NAMESPACE", namespace: "company.team"}).text()).toContain("Namespace: company.team")
+    })
+
+    it("emits clear when the chip is dismissed", async () => {
+        const w = mountChip({kind: "FLOW", flowId: "my-flow"})
+        await w.find(".close").trigger("click")
+        expect(w.emitted("clear")).toHaveLength(1)
+    })
+})

--- a/ui/tests/unit/components/ai/copilot/CopilotMessage.spec.ts
+++ b/ui/tests/unit/components/ai/copilot/CopilotMessage.spec.ts
@@ -58,6 +58,36 @@ describe("CopilotMessage", () => {
         expect(w.text()).not.toContain("completed")
     })
 
+    it("shows the result payload detail on a reloaded ok tool_result", () => {
+        const w = mountMessage({
+            id: "5c", role: "TOOL", type: "TOOL_RESULT",
+            toolResult: {outcome: "ok", result: {executionId: "exec-1", state: "SUCCESS"}},
+            toolCall: {tool: "read-execution", kind: "PLATFORM", family: "READ", arguments: {}},
+        })
+        // Tool name resolves from the paired toolCall when the persisted result map has no `tool`.
+        expect(w.text()).toContain("read-execution")
+        expect(w.find("[data-test=\"copilot-tool-result-detail\"]").exists()).toBe(true)
+        expect(w.text()).toContain("exec-1")
+        expect(w.text()).toContain("SUCCESS")
+    })
+
+    it("shows the error message as detail on an errored tool_result", () => {
+        const w = mountMessage({
+            id: "5d", role: "TOOL", type: "TOOL_RESULT",
+            toolResult: {tool: "read-flow", outcome: "error", error: "Flow not found: x"},
+        })
+        expect(w.find("[data-test=\"copilot-tool-result-detail\"]").exists()).toBe(true)
+        expect(w.text()).toContain("Flow not found: x")
+    })
+
+    it("has no detail collapsible on a live tool_result carrying only the outcome", () => {
+        const w = mountMessage({
+            id: "5e", role: "TOOL", type: "TOOL_RESULT",
+            toolResult: {tool: "list-flows", outcome: "ok"},
+        })
+        expect(w.find("[data-test=\"copilot-tool-result-detail\"]").exists()).toBe(false)
+    })
+
     it("renders an artefact_draft message as a draft card", () => {
         const w = mountMessage({
             id: "6", role: "ASSISTANT", type: "ARTEFACT_DRAFT",


### PR DESCRIPTION
## What

Two frontend improvements to the Copilot v2 agentic loop, both pure-FE and OSS-only.

### 1. Context chip (`inFocus`)
The copilot derives `inFocus` from the current route, but the user had **no visual cue** of what the agent was focused on. This adds a dismissible chip above the composer (both empty-state and footer) showing the focused resource:

- `Flow: my-flow` / `Execution: exec-1` / `Namespace: company.team` (new `CopilotContextChip.vue`).
- **Dismiss** drops the scope from the next turn; it **re-arms** when the focused resource changes (navigating to a new page).
- "Flow"/"Namespace" stay English (reserved terms); "Execution" is translated.

### 2. Structured tool results
The BE now returns typed result records, but the transcript only showed *"{tool} completed"*. A tool result now has a collapsible **Details** panel:

- the returned payload on success, the error message on a thrown tool, the rejection reason on a user decline.
- This detail is present **on thread reload** — the live SSE stream carries only `tool` + `outcome` (documented in the type). The tool name now also falls back to the paired tool-call on reload (the persisted result map has no `tool`).

## Tests
- **Unit:** `CopilotContextChip.spec` (labels + clear), `CopilotMessage.spec` (+4 result-detail cases + reload tool-name), `CopilotChat.spec` (+2 chip wiring cases) — **93/93 copilot unit tests pass**.
- **E2E** (`ai-copilot.spec.ts`): the empty-turn notice, and the context chip on a detail route.

> ⚠️ The two e2e tests were **not run locally** (no app up). The empty-turn one follows the existing stubbed pattern; the context-chip one navigates to a `flows/edit` route (the chip is derived from the route name, so the flow need not exist) — worth confirming on the first CI run.

## Gates
Type-check adds **0 new errors**; lint clean; `translations:check` clean (new keys across all 13 locales).

## Scope
Frontend-only, OSS-only — the copilot components are shared with EE via the `kestra` alias, so no EE changes are needed.