### PR TITLE
fix(tests): stop ReducedLogDataStore leaking as a duplicate 'h2' log-store plugin

### DIFF
--- a/jdbc-h2/src/test/java/io/kestra/repository/h2/ReducedLogDataStore.java
+++ b/jdbc-h2/src/test/java/io/kestra/repository/h2/ReducedLogDataStore.java
@@ -10,6 +10,7 @@ import io.kestra.core.repositories.PaginationType;
 import io.micronaut.data.model.CursoredPage;
 import io.micronaut.data.model.Page;
 import io.micronaut.data.model.Pageable;
+import io.swagger.v3.oas.annotations.Hidden;
 
 /**
  * Test-only log store with a reduced capability set, mirroring a cloud log store such as GCP Cloud
@@ -26,6 +27,12 @@ import io.micronaut.data.model.Pageable;
  * Wired via {@code @MockBean(LogDataStoreInterface.class)} in the tests (with {@code kestra.logs.type} unset so it
  * falls back to the H2 repository — which keeps the log-table migrations, e.g. the {@code task_id} widen, running).
  */
+// @Plugin and @Plugin.Id are @Inherited, so without @Hidden this test double would be registered as a
+// SECOND log-store plugin under the inherited id "h2". LogDataStoreInterfaceFactory.resolve("h2") then does
+// a findFirst() over all types with that id and non-deterministically instantiates H2LogDataStore OR this
+// reduced store (canPurge()==false) in unrelated suites — e.g. H2ExecutionServiceTest.purge() intermittently
+// deleting 0 logs. @Hidden makes the plugin scanner skip it, so it is only ever wired via the @MockBean below.
+@Hidden
 public class ReducedLogDataStore extends H2LogDataStore {
 
     @Override


### PR DESCRIPTION
## Problem

`io.kestra.repository.h2.H2ExecutionServiceTest > purge()` fails intermittently on `develop` (e.g. [this run](https://github.com/kestra-io/kestra/actions/runs/29484332770/job/87575215270)):

```
org.opentest4j.AssertionFailedError:
expected: 10
 but was: 0
    at io.kestra.core.repositories.AbstractExecutionServiceTest.purge(AbstractExecutionServiceTest.java:126)
```

Line 126 is the `logsCount` assertion: the purge reports **0** logs deleted where **10** were expected (the `executionsCount` assertion on the line above passes).

## Root cause

`ReducedLogDataStore` (a test-only reduced-capability log store) `extends H2LogDataStore`, which is annotated `@Plugin @Plugin.Id("h2")`. Both `@Plugin` and `@Plugin.Id` are **`@Inherited`**, so the test double is silently registered as a **second log-store plugin under id `"h2"`**.

`LogDataStoreInterfaceFactory.resolve("h2")` selects the first type whose id matches (`findFirst()` in `AbstractPluginInterfaceFactory`), so it **non-deterministically** instantiates `H2LogDataStore` *or* `ReducedLogDataStore` in unrelated suites. When it resolves to the reduced store — whose `canPurge()` is `false` — `AbstractJdbcLogDataStore.purge(...)` short-circuits to `return 0`. The logs are still written (so `findByExecutionId` sees 10), but purge deletes nothing → `expected 10 but was 0`. The order-dependence is why it's flaky on CI.

This is unrelated to the `@MockBean` wiring in `ReducedLogDataStoreTest`, async log persistence, or transaction visibility — all ruled out while debugging (runtime logging confirmed `purge(List) via ...ReducedLogDataStore canPurge=false`).

## Fix

Mark `ReducedLogDataStore` `@Hidden` so the plugin scanner skips it (`PluginScanner` ignores `@Hidden` plugins). It is then only ever wired directly via the `@MockBean` in `ReducedLogDataStoreTest`, and `resolve("h2")` reliably returns `H2LogDataStore` everywhere else. Test-only change, +7 lines.

## Verification

- Before: `H2ExecutionServiceTest.purge()` failed deterministically locally (17/17 reproduction runs).
- After: passes consistently. Ran `H2ExecutionServiceTest`, `ReducedLogDataStoreTest`, `H2LogDataStoreTest`, `H2LogDataStoreDedicatedTest`, and `LogDataStoreInterfaceFactoryTest` together 3× — all green — confirming `@Hidden` doesn't break real plugin discovery and the reduced-store contract test still runs.

## Follow-up (not in this PR)

A test subclass inheriting a real `@Plugin.Id` and quietly becoming a duplicate plugin is an easy trap. Worth considering: have plugin id resolution fail loudly (or warn) on duplicate ids for a type instead of silently `findFirst()`-ing one. Left out here because it touches shared resolution used by every plugin factory and deserves its own change.