### PR TITLE
fix(webserver): capture OTel context before reactive chain in createExecution

### DIFF
--- a/webserver/src/main/java/io/kestra/webserver/controllers/api/ExecutionController.java
+++ b/webserver/src/main/java/io/kestra/webserver/controllers/api/ExecutionController.java
@@ -772,6 +772,10 @@ public class ExecutionController {
         }
 
         var executionId = IdUtils.create();
+        // Capture the OTel context on the current thread before entering the reactive chain.
+        // flatMap() may execute on a different thread (e.g. boundedElastic), where Context.current()
+        // would return an empty root context since OTel Context is thread-local.
+        final Context otelContext = Context.current();
         return flowInputOutput.readExecutionInputs(flow, executionId, inputs)
             .flatMap(executionInputs ->
             {
@@ -800,13 +804,13 @@ public class ExecutionController {
                     createCommand = createCommand.withStateType(State.Type.FAILED);
                 }
 
-                // inject the traceparent from the current OTel context into the command so it's propagated to the execution
+                // inject the traceparent from the captured OTel context into the command so it's propagated to the execution
                 // TODO see if we can replicate ExecutionTextMapSetter logic
                 Map<String, String> traceCarrier = new HashMap<>();
                 openTelemetry
                     .map(OpenTelemetry::getPropagators)
                     .map(ContextPropagators::getTextMapPropagator)
-                    .ifPresent(propagator -> propagator.inject(Context.current(), traceCarrier, Map::put));
+                    .ifPresent(propagator -> propagator.inject(otelContext, traceCarrier, Map::put));
                 if (traceCarrier.containsKey("traceparent")) {
                     createCommand = createCommand.withTraceParent(traceCarrier.get("traceparent"));
                 }


### PR DESCRIPTION
## Summary

`Context.current()` is thread-local. In `ExecutionController.createExecution()`, it was called inside a reactive `.flatMap()` callback which may execute on a different thread (e.g., `boundedElastic`). On that thread, the original HTTP request's OTel context is not available, resulting in an empty or new `traceParent` being injected into the Execution — breaking trace propagation between the webserver and downstream services (executor, worker).

**Fix**: Capture `Context.current()` before entering the reactive chain and use the captured reference inside `flatMap()`.

## Root Cause

```java
// Before (bug): Context.current() called after thread switch
return flowInputOutput.readExecutionInputs(...)
    .flatMap(executionInputs -> {
        // Now on boundedElastic thread — Context.current() returns empty root context
        propagator.inject(Context.current(), traceCarrier, Map::put);
    });

// After (fix): capture context on original thread
final Context otelContext = Context.current();  // still on IO thread with HTTP span
return flowInputOutput.readExecutionInputs(...)
    .flatMap(executionInputs -> {
        propagator.inject(otelContext, traceCarrier, Map::put);  // correct context
    });
```

## Test Plan

- [x] Verified that after the fix, the `traceParent` field in the created Execution contains the same traceId as the HTTP request span
- [x] Confirmed executor and worker spans correctly chain under the webserver's HTTP span in the trace viewer
- [x] Compilation passes (`./gradlew :webserver:compileJava`)