### PR TITLE
fix(ci): use a test artifact for dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -189,6 +189,18 @@ subprojects {subProj ->
 
         configurations {
             mockitoAgent
+            // Exposes this project's compiled test classes/resources to other projects, replacing the
+            // Gradle 9.5-incompatible `project(':x').sourceSets.test.output` cross-project script access.
+            testArtifacts {
+                canBeConsumed = true
+                canBeResolved = false
+            }
+        }
+
+        artifacts {
+            sourceSets.test.output.files.each { dir ->
+                testArtifacts(dir) { builtBy tasks.named('testClasses') }
+            }
         }
 
         dependencies {

--- a/executor/build.gradle
+++ b/executor/build.gradle
@@ -8,7 +8,7 @@ dependencies {
 
     // test
     testAnnotationProcessor project(':processor')
-    testImplementation project(':core').sourceSets.test.output
+    testImplementation project(path: ':core', configuration: 'testArtifacts')
     testImplementation project(':storage-local')
     testImplementation project(':worker')
 

--- a/indexer/build.gradle
+++ b/indexer/build.gradle
@@ -8,7 +8,7 @@ dependencies {
 
     // test
     testAnnotationProcessor project(':processor')
-    testImplementation project(':core').sourceSets.test.output
+    testImplementation project(path: ':core', configuration: 'testArtifacts')
     testImplementation project(':storage-local')
     testImplementation project(':worker')
 

--- a/jdbc-h2/build.gradle
+++ b/jdbc-h2/build.gradle
@@ -15,11 +15,11 @@ dependencies {
     runtimeOnly("com.h2database:h2")
 
     testAnnotationProcessor project(":processor")
-    testImplementation project(':core').sourceSets.test.output
-    testImplementation project(':jdbc').sourceSets.test.output
-    testImplementation project(':executor').sourceSets.test.output
+    testImplementation project(path: ':core', configuration: 'testArtifacts')
+    testImplementation project(path: ':jdbc', configuration: 'testArtifacts')
+    testImplementation project(path: ':executor', configuration: 'testArtifacts')
     testImplementation project(':storage-local')
     testImplementation project(':indexer')
     testImplementation project(':tests')
-    testImplementation project(':queue').sourceSets.test.output
+    testImplementation project(path: ':queue', configuration: 'testArtifacts')
 }

--- a/jdbc-mysql/build.gradle
+++ b/jdbc-mysql/build.gradle
@@ -15,13 +15,13 @@ dependencies {
     runtimeOnly("com.mysql:mysql-connector-j")
 
     testAnnotationProcessor project(":processor")
-    testImplementation project(':core').sourceSets.test.output
-    testImplementation project(':jdbc').sourceSets.test.output
-    testImplementation project(':executor').sourceSets.test.output
-    testImplementation project(':scheduler').sourceSets.test.output
+    testImplementation project(path: ':core', configuration: 'testArtifacts')
+    testImplementation project(path: ':jdbc', configuration: 'testArtifacts')
+    testImplementation project(path: ':executor', configuration: 'testArtifacts')
+    testImplementation project(path: ':scheduler', configuration: 'testArtifacts')
     testImplementation project(':storage-local')
     testImplementation project(':indexer')
     testImplementation project(':tests')
-    testImplementation project(':queue').sourceSets.test.output
+    testImplementation project(path: ':queue', configuration: 'testArtifacts')
     testImplementation("io.micronaut.validation:micronaut-validation") // MysqlServiceLivenessCoordinatorTest fail to init without that
 }

--- a/jdbc-postgres/build.gradle
+++ b/jdbc-postgres/build.gradle
@@ -15,12 +15,12 @@ dependencies {
     runtimeOnly("org.postgresql:postgresql")
 
     testAnnotationProcessor project(":processor")
-    testImplementation project(':core').sourceSets.test.output
-    testImplementation project(':jdbc').sourceSets.test.output
-    testImplementation project(':executor').sourceSets.test.output
+    testImplementation project(path: ':core', configuration: 'testArtifacts')
+    testImplementation project(path: ':jdbc', configuration: 'testArtifacts')
+    testImplementation project(path: ':executor', configuration: 'testArtifacts')
     testImplementation project(':storage-local')
     testImplementation project(':indexer')
     testImplementation project(':tests')
-    testImplementation project(':queue').sourceSets.test.output
+    testImplementation project(path: ':queue', configuration: 'testArtifacts')
     testImplementation("io.micronaut.validation:micronaut-validation") // PostgresServiceLivenessCoordinatorTest fail to init without that
 }

--- a/jdbc/build.gradle
+++ b/jdbc/build.gradle
@@ -18,7 +18,7 @@ dependencies {
     testImplementation project(':tests')
     testImplementation project(':queue')
     testImplementation project(':queue-jdbc')
-    testImplementation project(':core').sourceSets.test.output
-    testImplementation project(':executor').sourceSets.test.output
-    testImplementation project(":queue").sourceSets.test.output
+    testImplementation project(path: ':core', configuration: 'testArtifacts')
+    testImplementation project(path: ':executor', configuration: 'testArtifacts')
+    testImplementation project(path: ':queue', configuration: 'testArtifacts')
 }

--- a/scheduler/build.gradle
+++ b/scheduler/build.gradle
@@ -9,13 +9,13 @@ dependencies {
 
     // test
     testAnnotationProcessor project(':processor')
-    testImplementation project(':core').sourceSets.test.output
+    testImplementation project(path: ':core', configuration: 'testArtifacts')
     testImplementation project(':storage-local')
     testImplementation project(':worker')
 
     testImplementation project(':tests')
     testImplementation project(':jdbc')
-    testImplementation project(':jdbc').sourceSets.test.output
+    testImplementation project(path: ':jdbc', configuration: 'testArtifacts')
     testImplementation project(':jdbc-h2')
     testImplementation("io.micronaut.sql:micronaut-jooq")
 }

--- a/script/build.gradle
+++ b/script/build.gradle
@@ -12,7 +12,7 @@ dependencies {
     }
     implementation 'com.github.docker-java:docker-java-transport-httpclient5'
 
-    testImplementation project(':core').sourceSets.test.output
+    testImplementation project(path: ':core', configuration: 'testArtifacts')
     testImplementation project(':tests')
     testImplementation project(':storage-local')
     testImplementation project(':repository-memory')

--- a/webserver/build.gradle
+++ b/webserver/build.gradle
@@ -41,7 +41,7 @@ dependencies {
 
     // test
     testAnnotationProcessor project(':processor')
-    testImplementation project(':core').sourceSets.test.output
+    testImplementation project(path: ':core', configuration: 'testArtifacts')
     testImplementation project(':storage-local')
     testImplementation project(':worker')
     testImplementation project(':indexer')
@@ -51,8 +51,8 @@ dependencies {
 
     testImplementation project(':tests')
     testImplementation project(':jdbc')
-    testImplementation project(':jdbc').sourceSets.test.output
-    testImplementation project(':queue').sourceSets.test.output
+    testImplementation project(path: ':jdbc', configuration: 'testArtifacts')
+    testImplementation project(path: ':queue', configuration: 'testArtifacts')
     testImplementation project(':jdbc-h2')
     testImplementation("io.micronaut.sql:micronaut-jooq")
 }

--- a/worker-controller/build.gradle
+++ b/worker-controller/build.gradle
@@ -22,12 +22,12 @@ dependencies {
 
     // test
     testAnnotationProcessor project(':processor')
-    testImplementation project(':core').sourceSets.test.output
+    testImplementation project(path: ':core', configuration: 'testArtifacts')
     testImplementation project(':storage-local')
 
     testImplementation project(':tests')
     testImplementation project(':jdbc')
-    testImplementation project(':jdbc').sourceSets.test.output
+    testImplementation project(path: ':jdbc', configuration: 'testArtifacts')
     testImplementation project(':jdbc-h2')
     testImplementation("io.micronaut.sql:micronaut-jooq")
 

--- a/worker/build.gradle
+++ b/worker/build.gradle
@@ -14,13 +14,13 @@ dependencies {
 
     // test
     testAnnotationProcessor project(':processor')
-    testImplementation project(':core').sourceSets.test.output
+    testImplementation project(path: ':core', configuration: 'testArtifacts')
     testImplementation project(':storage-local')
 
     testImplementation project(':tests')
     testImplementation project(':jdbc')
-    testImplementation project(':jdbc').sourceSets.test.output
-    testImplementation project(':queue').sourceSets.test.output
+    testImplementation project(path: ':jdbc', configuration: 'testArtifacts')
+    testImplementation project(path: ':queue', configuration: 'testArtifacts')
 
     testImplementation project(':jdbc-h2')
     testImplementation("io.micronaut.sql:micronaut-jooq")


### PR DESCRIPTION
The old way was not compatible with Gradle 9.5.