### PR TITLE
feat(ai): polish the copilot empty-turn notice and artefact draft

### DIFF
--- a/ui/packages/design-system/src/components/Data/KsMarkdown/KsMarkdown.vue
+++ b/ui/packages/design-system/src/components/Data/KsMarkdown/KsMarkdown.vue
@@ -13,7 +13,7 @@
     import remarkDirective from "remark-directive"
     import type {Root, RootContent} from "mdast"
     import ContentCopy from "vue-material-design-icons/ContentCopy.vue"
-    import CheckCircleOutline from "vue-material-design-icons/CheckCircleOutline.vue"
+    import Check from "vue-material-design-icons/Check.vue"
     import xss, {escapeAttrValue} from "xss"
     import KsAlert from "../../Feedback/KsAlert.vue"
     import KsTable from "../KsTable/KsTable.vue"
@@ -202,13 +202,12 @@
                         onClick: (e: MouseEvent) => {
                             const btn = e.currentTarget as HTMLButtonElement
                             navigator.clipboard.writeText(value).then(() => {
-                                btn.querySelector(".ks-markdown__copy-btn-ok")?.classList.add("opacity-100")
-                                setTimeout(() => {
-                                    btn.querySelector(".ks-markdown__copy-btn-ok")?.classList.remove("opacity-100")
-                                }, 2000)
+                                // Swap the copy glyph for the check (not overlay it) for the confirm window.
+                                btn.classList.add("is-copied")
+                                setTimeout(() => btn.classList.remove("is-copied"), 2000)
                             }).catch(() => { /* clipboard unavailable */ })
                         },
-                    }, [h(CheckCircleOutline, {class: "ks-markdown__copy-btn-ok"}), h(ContentCopy)]),
+                    }, [h(Check, {class: "ks-markdown__copy-btn-ok"}), h(ContentCopy, {class: "ks-markdown__copy-btn-icon"})]),
                 ]),
                 highlightedHtml
                     ? h("div", {class: "ks-markdown__code-shiki", innerHTML: highlightedHtml})
@@ -538,15 +537,26 @@
                         color: var(--kel-text-color-primary);
                     }
 
+                    /* The copy glyph and the confirm check occupy the same cell; only one is
+                       visible at a time (swapped via the .is-copied state), never overlaid. */
                     > * {
                         grid-area: 1 / 1;
+                        transition: opacity 0.15s ease;
                     }
 
                     .ks-markdown__copy-btn-ok {
-                        transition: opacity 0.15s ease;
-                        background: var(--ks-bg-base);
                         color: var(--ks-text-success);
                         opacity: 0;
+                    }
+
+                    &.is-copied {
+                        .ks-markdown__copy-btn-icon {
+                            opacity: 0;
+                        }
+
+                        .ks-markdown__copy-btn-ok {
+                            opacity: 1;
+                        }
                     }
                 }
             }

--- a/ui/src/components/ai/copilot/CopilotArtefactDraft.vue
+++ b/ui/src/components/ai/copilot/CopilotArtefactDraft.vue
@@ -22,23 +22,15 @@
             {{ draft.constraints }}
         </KsAlert>
 
-        <!-- The drafted YAML — read-only preview, nothing is saved -->
-        <pre class="copilot-draft-yaml" data-test="copilot-draft-yaml">{{ draft.yaml }}</pre>
-
-        <div class="copilot-draft-footer">
-            <KsButton
-                type="default"
-                data-test="copilot-draft-copy"
-                @click="copy"
-            >
-                {{ copied ? t("ai.copilot.draft.copied") : t("ai.copilot.draft.copy") }}
-            </KsButton>
-        </div>
+        <!-- The drafted YAML — read-only, syntax-highlighted preview (nothing is saved).
+             KsMarkdown provides its own copy-to-clipboard control, so no separate copy button.
+             A one-click "apply" (load into the flow editor) arrives with the flow-editor cutover. -->
+        <KsMarkdown class="copilot-draft-yaml" data-test="copilot-draft-yaml" :content="yamlBlock" />
     </div>
 </template>
 
 <script setup lang="ts">
-    import {ref} from "vue"
+    import {computed} from "vue"
     import {useI18n} from "vue-i18n"
     import FileDocumentOutline from "vue-material-design-icons/FileDocumentOutline.vue"
     import type {ArtefactDraftEvent} from "./types"
@@ -47,23 +39,9 @@
 
     const {t} = useI18n()
 
-    const copied = ref(false)
-    let resetTimer: ReturnType<typeof setTimeout> | undefined
-
-    // Dock fallback for "accept": there is no editor mounted alongside the global
-    // copilot yet (that arrives with the flow-editor cutover), so the useful action
-    // today is to hand the user the YAML to paste. Loading it into an in-place editor
-    // will be wired when the copilot is embedded in the editor.
-    async function copy(): Promise<void> {
-        try {
-            await navigator.clipboard?.writeText(props.draft.yaml)
-        } catch {
-            return
-        }
-        copied.value = true
-        clearTimeout(resetTimer)
-        resetTimer = setTimeout(() => (copied.value = false), 2000)
-    }
+    // Render the YAML as a fenced code block so KsMarkdown syntax-highlights it (matching the
+    // assistant transcript), rather than showing it as flat monospace text.
+    const yamlBlock = computed(() => "```yaml\n" + props.draft.yaml + "\n```")
 </script>
 
 <style scoped>
@@ -95,21 +73,12 @@
         margin: var(--ks-spacing-2) var(--ks-spacing-3) 0;
     }
 
+    /* Constrain + scroll the highlighted block; KsMarkdown styles the code itself. */
     .copilot-draft-yaml {
         margin: 0;
         max-height: 18rem;
         overflow: auto;
         padding: var(--ks-spacing-3);
-        font-family: monospace;
         font-size: var(--ks-font-size-sm);
-        white-space: pre;
-        color: var(--ks-text-secondary);
-    }
-
-    .copilot-draft-footer {
-        display: flex;
-        justify-content: flex-end;
-        padding: var(--ks-spacing-2) var(--ks-spacing-3);
-        background: var(--ks-bg-elevated);
     }
 </style>

--- a/ui/src/components/ai/copilot/CopilotChat.vue
+++ b/ui/src/components/ai/copilot/CopilotChat.vue
@@ -91,7 +91,12 @@
                     {{ t(`ai.copilot.error.${error}`) }}
                 </KsAlert>
                 <KsAlert v-else-if="notice" type="warning" data-test="copilot-notice">
-                    {{ t(`ai.copilot.notice.${notice}`) }}
+                    <div class="copilot-notice-body">
+                        <span>{{ t(`ai.copilot.notice.${notice}`) }}</span>
+                        <KsButton size="small" data-test="copilot-notice-retry" @click="retryLastTurn">
+                            {{ t("ai.copilot.notice.retry") }}
+                        </KsButton>
+                    </div>
                 </KsAlert>
             </div>
 
@@ -186,7 +191,7 @@
         t("ai.copilot.suggestions.dbt"),
     ])
 
-    const {messages, status, streaming, error, notice, pendingConfirmation, unavailable, canSend, sendChat, confirm, cancel, reset, retry} = useAiChat()
+    const {messages, status, streaming, error, notice, pendingConfirmation, unavailable, canSend, sendChat, confirm, cancel, reset, retry, retryLastTurn} = useAiChat()
 
     // `status` gates the composer via `canSend`; keep the lints happy that we read it.
     void status
@@ -380,6 +385,23 @@
 
     .copilot-banner {
         padding: 0 var(--ks-spacing-5);
+    }
+
+    /* Notice text + its retry action share a row; the button is pinned to the right. */
+    .copilot-notice-body {
+        display: flex;
+        width: 100%;
+        align-items: center;
+        gap: var(--ks-spacing-3);
+    }
+
+    .copilot-notice-body > span {
+        flex: 1;
+    }
+
+    .copilot-notice-body > :last-child {
+        flex-shrink: 0;
+        margin-left: auto;
     }
 
     .copilot-footer {

--- a/ui/src/components/ai/copilot/useAiChat.ts
+++ b/ui/src/components/ai/copilot/useAiChat.ts
@@ -75,6 +75,8 @@ export function useAiChat() {
     /** Reference to the assistant bubble currently being streamed into. */
     let activeAssistant: ChatMessage | null = null
     let abort: AbortController | null = null
+    /** The last chat/confirm request, so an empty/failed turn can be retried without retyping. */
+    let lastTurn: {url: string; body: unknown} | null = null
 
     /** True when a new chat turn may be sent. */
     const canSend = computed(() => status.value === "IDLE" && !streaming.value)
@@ -147,6 +149,12 @@ export function useAiChat() {
         notice.value = null
     }
 
+    /** Re-runs the last chat/confirm turn — used by the empty-turn notice to retry without retyping. */
+    async function retryLastTurn(): Promise<void> {
+        if (!lastTurn || streaming.value) return
+        await runStream(lastTurn.url, lastTurn.body)
+    }
+
     /**
      * Resolves a pending proposal. APPROVE resumes & dispatches; REJECT records rejection.
      * The resumed turn runs a fresh model call, so it needs the same `providerId` the chat turn used.
@@ -178,6 +186,7 @@ export function useAiChat() {
         pendingConfirmation.value = null
         unavailable.value = false
         activeAssistant = null
+        lastTurn = null
     }
 
     /** Shared streaming driver for both chat and confirm turns. */
@@ -187,6 +196,7 @@ export function useAiChat() {
         notice.value = null
         activeAssistant = null
         abort = new AbortController()
+        lastTurn = {url, body}
         const countBefore = messages.value.length
 
         try {
@@ -294,6 +304,7 @@ export function useAiChat() {
         cancel,
         reset,
         retry,
+        retryLastTurn,
     }
 }
 

--- a/ui/src/translations/de.json
+++ b/ui/src/translations/de.json
@@ -2043,7 +2043,8 @@
           "revise": "Reply to revise"
         },
         "notice": {
-          "emptyTurn": "Der Assistent hat keine Antwort zurückgegeben. Bitte versuche es erneut."
+          "emptyTurn": "Der Assistent hat keine Antwort zurückgegeben. Bitte versuche es erneut.",
+          "retry": "Erneut versuchen"
         },
         "error": {
           "turnInProgress": "A turn is already in progress.",

--- a/ui/src/translations/en.json
+++ b/ui/src/translations/en.json
@@ -2043,7 +2043,8 @@
           "revise": "Reply to revise"
         },
         "notice": {
-          "emptyTurn": "The assistant didn't return a response. Please try again."
+          "emptyTurn": "The assistant didn't return a response. Please try again.",
+          "retry": "Retry"
         },
         "error": {
           "turnInProgress": "A turn is already in progress.",

--- a/ui/src/translations/es.json
+++ b/ui/src/translations/es.json
@@ -2043,7 +2043,8 @@
           "revise": "Reply to revise"
         },
         "notice": {
-          "emptyTurn": "El asistente no devolvió una respuesta. Inténtalo de nuevo."
+          "emptyTurn": "El asistente no devolvió una respuesta. Inténtalo de nuevo.",
+          "retry": "Reintentar"
         },
         "error": {
           "turnInProgress": "A turn is already in progress.",

--- a/ui/src/translations/fr.json
+++ b/ui/src/translations/fr.json
@@ -2043,7 +2043,8 @@
           "revise": "Reply to revise"
         },
         "notice": {
-          "emptyTurn": "L'assistant n'a renvoyé aucune réponse. Veuillez réessayer."
+          "emptyTurn": "L'assistant n'a renvoyé aucune réponse. Veuillez réessayer.",
+          "retry": "Réessayer"
         },
         "error": {
           "turnInProgress": "A turn is already in progress.",

--- a/ui/src/translations/hi.json
+++ b/ui/src/translations/hi.json
@@ -2043,7 +2043,8 @@
           "revise": "Reply to revise"
         },
         "notice": {
-          "emptyTurn": "सहायक ने कोई प्रतिक्रिया नहीं दी। कृपया पुनः प्रयास करें।"
+          "emptyTurn": "सहायक ने कोई प्रतिक्रिया नहीं दी। कृपया पुनः प्रयास करें।",
+          "retry": "पुनः प्रयास करें"
         },
         "error": {
           "turnInProgress": "A turn is already in progress.",

--- a/ui/src/translations/it.json
+++ b/ui/src/translations/it.json
@@ -2043,7 +2043,8 @@
           "revise": "Reply to revise"
         },
         "notice": {
-          "emptyTurn": "L'assistente non ha restituito una risposta. Riprova."
+          "emptyTurn": "L'assistente non ha restituito una risposta. Riprova.",
+          "retry": "Riprova"
         },
         "error": {
           "turnInProgress": "A turn is already in progress.",

--- a/ui/src/translations/ja.json
+++ b/ui/src/translations/ja.json
@@ -2043,7 +2043,8 @@
           "revise": "Reply to revise"
         },
         "notice": {
-          "emptyTurn": "アシスタントから応答がありませんでした。もう一度お試しください。"
+          "emptyTurn": "アシスタントから応答がありませんでした。もう一度お試しください。",
+          "retry": "再試行"
         },
         "error": {
           "turnInProgress": "A turn is already in progress.",

--- a/ui/src/translations/ko.json
+++ b/ui/src/translations/ko.json
@@ -2043,7 +2043,8 @@
           "revise": "Reply to revise"
         },
         "notice": {
-          "emptyTurn": "어시스턴트가 응답을 반환하지 않았습니다. 다시 시도해 주세요."
+          "emptyTurn": "어시스턴트가 응답을 반환하지 않았습니다. 다시 시도해 주세요.",
+          "retry": "다시 시도"
         },
         "error": {
           "turnInProgress": "A turn is already in progress.",

--- a/ui/src/translations/pl.json
+++ b/ui/src/translations/pl.json
@@ -2043,7 +2043,8 @@
           "revise": "Reply to revise"
         },
         "notice": {
-          "emptyTurn": "Asystent nie zwrócił odpowiedzi. Spróbuj ponownie."
+          "emptyTurn": "Asystent nie zwrócił odpowiedzi. Spróbuj ponownie.",
+          "retry": "Ponów"
         },
         "error": {
           "turnInProgress": "A turn is already in progress.",

--- a/ui/src/translations/pt.json
+++ b/ui/src/translations/pt.json
@@ -2043,7 +2043,8 @@
           "revise": "Reply to revise"
         },
         "notice": {
-          "emptyTurn": "O assistente não retornou uma resposta. Tente novamente."
+          "emptyTurn": "O assistente não retornou uma resposta. Tente novamente.",
+          "retry": "Tentar novamente"
         },
         "error": {
           "turnInProgress": "A turn is already in progress.",

--- a/ui/src/translations/pt_BR.json
+++ b/ui/src/translations/pt_BR.json
@@ -2043,7 +2043,8 @@
           "revise": "Reply to revise"
         },
         "notice": {
-          "emptyTurn": "O assistente não retornou uma resposta. Tente novamente."
+          "emptyTurn": "O assistente não retornou uma resposta. Tente novamente.",
+          "retry": "Tentar novamente"
         },
         "error": {
           "turnInProgress": "A turn is already in progress.",

--- a/ui/src/translations/ru.json
+++ b/ui/src/translations/ru.json
@@ -2043,7 +2043,8 @@
           "revise": "Reply to revise"
         },
         "notice": {
-          "emptyTurn": "Ассистент не вернул ответ. Пожалуйста, попробуйте снова."
+          "emptyTurn": "Ассистент не вернул ответ. Пожалуйста, попробуйте снова.",
+          "retry": "Повторить"
         },
         "error": {
           "turnInProgress": "A turn is already in progress.",

--- a/ui/src/translations/zh_CN.json
+++ b/ui/src/translations/zh_CN.json
@@ -2043,7 +2043,8 @@
           "revise": "Reply to revise"
         },
         "notice": {
-          "emptyTurn": "助手未返回响应。请重试。"
+          "emptyTurn": "助手未返回响应。请重试。",
+          "retry": "重试"
         },
         "error": {
           "turnInProgress": "A turn is already in progress.",

--- a/ui/tests/unit/components/ai/copilot/CopilotArtefactDraft.spec.ts
+++ b/ui/tests/unit/components/ai/copilot/CopilotArtefactDraft.spec.ts
@@ -1,4 +1,4 @@
-import {describe, it, expect, vi, beforeEach} from "vitest"
+import {describe, it, expect} from "vitest"
 import {mount} from "@vue/test-utils"
 import CopilotArtefactDraft from "../../../../../src/components/ai/copilot/CopilotArtefactDraft.vue"
 import {mountGlobal} from "./_helpers"
@@ -7,19 +7,13 @@ import type {ArtefactDraftEvent} from "../../../../../src/components/ai/copilot/
 const mountDraft = (draft: ArtefactDraftEvent) =>
     mount(CopilotArtefactDraft, {props: {draft}, global: mountGlobal})
 
-const writeText = vi.fn().mockResolvedValue(undefined)
-
 describe("CopilotArtefactDraft", () => {
-    beforeEach(() => {
-        writeText.mockClear()
-        vi.stubGlobal("navigator", {clipboard: {writeText}})
-    })
-
     it("renders the kind title, a valid badge and the YAML", () => {
         const w = mountDraft({draftId: "d1", kind: "FLOW", yaml: "id: demo", valid: true, constraints: null})
         expect(w.text()).toContain("Proposed flow")
         expect(w.find(".ks-code-status").attributes("data-status")).toBe("valid")
-        expect(w.find("[data-test=\"copilot-draft-yaml\"]").text()).toBe("id: demo")
+        // Rendered via KsMarkdown as a highlighted yaml fence, so assert the YAML is present.
+        expect(w.find("[data-test=\"copilot-draft-yaml\"]").text()).toContain("id: demo")
         // A valid draft shows no constraints alert.
         expect(w.find(".ks-alert").exists()).toBe(false)
     })
@@ -33,13 +27,10 @@ describe("CopilotArtefactDraft", () => {
         expect(alert.text()).toContain("charts is required")
     })
 
-    it("copies the YAML to the clipboard and flips the button label", async () => {
+    it("renders the YAML via KsMarkdown and exposes no separate copy button", () => {
+        // Copy is handled by KsMarkdown's built-in control, so the card has no copy button of its own.
         const w = mountDraft({draftId: "d3", kind: "APP", yaml: "id: my-app", valid: true, constraints: null})
-        const button = w.find("[data-test=\"copilot-draft-copy\"]")
-        expect(button.text()).toBe("Copy YAML")
-        await button.trigger("click")
-        await w.vm.$nextTick()
-        expect(writeText).toHaveBeenCalledWith("id: my-app")
-        expect(button.text()).toBe("Copied")
+        expect(w.find("[data-test=\"copilot-draft-copy\"]").exists()).toBe(false)
+        expect(w.find("[data-test=\"copilot-draft-yaml\"]").text()).toContain("id: my-app")
     })
 })

--- a/ui/tests/unit/components/ai/copilot/CopilotChat.spec.ts
+++ b/ui/tests/unit/components/ai/copilot/CopilotChat.spec.ts
@@ -20,6 +20,7 @@ const state = {
     cancel: vi.fn(),
     reset: vi.fn(),
     retry: vi.fn(),
+    retryLastTurn: vi.fn(),
 }
 vi.mock("../../../../../src/components/ai/copilot/useAiChat", () => ({useAiChat: () => state}))
 // CopilotChat derives `inFocus` from the current route — mock a mutable route so tests control it.
@@ -51,6 +52,7 @@ describe("CopilotChat", () => {
         state.confirm.mockReset()
         state.reset.mockReset()
         state.retry.mockReset()
+        state.retryLastTurn.mockReset()
         miscStore.copilotPrompt = null
     })
 
@@ -132,7 +134,14 @@ describe("CopilotChat", () => {
         const w = mountChat()
         const alert = w.find("[data-test=\"copilot-notice\"]")
         expect(alert.exists()).toBe(true)
-        expect(alert.text()).toBe("The assistant didn't return a response. Please try again.")
+        expect(alert.text()).toContain("The assistant didn't return a response. Please try again.")
+    })
+
+    it("retries the last turn from the empty-turn notice", async () => {
+        state.notice.value = "emptyTurn"
+        const w = mountChat()
+        await w.find("[data-test=\"copilot-notice-retry\"]").trigger("click")
+        expect(state.retryLastTurn).toHaveBeenCalled()
     })
 
     it("renders the proposed-action card and confirms on approve, forwarding the selected provider", async () => {

--- a/ui/tests/unit/components/ai/copilot/useAiChat.spec.ts
+++ b/ui/tests/unit/components/ai/copilot/useAiChat.spec.ts
@@ -196,6 +196,30 @@ describe("useAiChat", () => {
         expect(chat.notice.value).toBeNull()
     })
 
+    it("retryLastTurn re-runs the last turn and clears the notice when output arrives", async () => {
+        const chat = useAiChat()
+        nextFrames = [{event: "done", data: {status: "IDLE"}}]
+        await chat.sendChat({prompt: "hi", providerId: "gemini-legacy"})
+        expect(chat.notice.value).toBe("emptyTurn")
+
+        nextFrames = [
+            {event: "token", data: {text: "now answered"}},
+            {event: "done", data: {status: "IDLE"}},
+        ]
+        await chat.retryLastTurn()
+        // Same request body was replayed, and the successful turn cleared the notice.
+        expect(lastBody).toMatchObject({prompt: "hi", providerId: "gemini-legacy"})
+        expect(chat.notice.value).toBeNull()
+        expect(chat.messages.value.some((m) => m.role === "ASSISTANT" && m.content === "now answered")).toBe(true)
+    })
+
+    it("retryLastTurn is a no-op before any turn has run", async () => {
+        const chat = useAiChat()
+        await chat.retryLastTurn()
+        expect(chat.streaming.value).toBe(false)
+        expect(chat.messages.value).toHaveLength(0)
+    })
+
     it("clears a prior emptyTurn notice when a new turn starts", async () => {
         const chat = useAiChat()
         nextFrames = [{event: "done", data: {status: "IDLE"}}]


### PR DESCRIPTION
## What

A batch of UX polish on the Copilot v2 surfaces (two scope-clean commits).

### `ai` — copilot notice + artefact draft
- **Notice banner overflow fixed** — the empty-turn/error banner was `margin`-inset on a `width:100%` alert, so it spilled ~24px past the panel's right edge. Now inset via a padded wrapper; it lines up exactly with the composer.
- **Retry button on the empty-turn notice** — replays the last chat/confirm turn (`retryLastTurn`), so a blank response can be retried in one click instead of retyping.
- **Drafted YAML is syntax-highlighted** — the proposed-artefact card renders the YAML through `KsMarkdown` (same highlighter as the transcript) instead of flat monospace, and the now-redundant **"Copy YAML"** button is removed (the code block has its own copy control).

### `design-system` — markdown copy confirmation
- The code-block copy button confirmed with a **check-in-a-circle overlaid on the copy glyph** (read as a stray "selected circle"). Now it uses a **plain check** and **swaps** it in for the copy glyph (one hidden, one shown) rather than stacking them — a clean confirmation. Applies to every markdown code block app-wide.

## Tests
- `useAiChat.spec` — `retryLastTurn` replays the last turn and clears the notice on success (+ no-op before any turn).
- `CopilotChat.spec` — the notice renders a right-aligned retry button that calls `retryLastTurn`.
- `CopilotArtefactDraft.spec` — YAML renders via KsMarkdown; no separate copy button.
- 96/96 copilot unit tests pass; lint + type-check + `translations:check` clean. New key `ai.copilot.notice.retry` in all 13 locales.

## Scope
Frontend-only. The copilot components are shared with EE via the `kestra` alias, so no EE changes needed.