### PR TITLE
test(executions): fix flaky ConcurrentModificationException in compactor test

### DIFF
--- a/jdbc/src/test/java/io/kestra/jdbc/repository/AbstractExecutionStatisticsCompactorTest.java
+++ b/jdbc/src/test/java/io/kestra/jdbc/repository/AbstractExecutionStatisticsCompactorTest.java
@@ -24,6 +24,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @MicronautTest
 @Property(name = "kestra.server-type", value = "STANDALONE")
+// The compactor is a live @Scheduled singleton here; without disabling the schedule a background
+// tick can call compact() concurrently with the test's manual compact(), and both hit the shared
+// singleton jOOQ Configuration from two threads -> ConcurrentModificationException. Push the
+// schedule far past any test run so only the manual calls exercise compact().
+@Property(name = "kestra.jdbc.execution-statistics.compactor.initial-delay", value = "999d")
+@Property(name = "kestra.jdbc.execution-statistics.compactor.fixed-delay", value = "999d")
 public abstract class AbstractExecutionStatisticsCompactorTest {
     @Inject
     protected ExecutionStatisticsRepositoryInterface executionStatisticsRepository;

--- a/jdbc/src/test/java/io/kestra/jdbc/repository/AbstractExecutionStatisticsCompactorTest.java
+++ b/jdbc/src/test/java/io/kestra/jdbc/repository/AbstractExecutionStatisticsCompactorTest.java
@@ -13,6 +13,7 @@ import io.kestra.core.models.executions.statistics.DailyExecutionStatistics;
 import io.kestra.core.models.executions.statistics.ExecutionStatistic;
 import io.kestra.core.models.flows.State;
 import io.kestra.core.repositories.ExecutionStatisticsRepositoryInterface;
+import io.kestra.core.utils.Await;
 import io.kestra.core.utils.DateUtils;
 import io.kestra.core.utils.TestsUtils;
 
@@ -68,6 +69,11 @@ public abstract class AbstractExecutionStatisticsCompactorTest {
     void shouldNotCompactTheCurrentOpenBucket() {
         // Given: a raw row in the current (not yet closed) minute
         String tenant = TestsUtils.randomTenant(this.getClass().getSimpleName());
+        // The compactor derives closedBefore = Instant.now().truncatedTo(MINUTES) inside compact(); if a
+        // minute rollover lands between the bucket built here and that sampling, this still-open bucket
+        // would look closed and get compacted (count 2). Start early in a fresh minute so save + compact()
+        // can't straddle a rollover.
+        Await.until(() -> Instant.now().toEpochMilli() % 60_000 < 55_000);
         Instant bucket = Instant.now().truncatedTo(ChronoUnit.MINUTES);
         String executionId = FriendlyId.createFriendlyId();
         executionStatisticsRepository.save(raw(tenant, bucket, State.Type.SUCCESS, executionId, 1000));


### PR DESCRIPTION
## What
Disable the `@Scheduled` compactor tick inside `AbstractExecutionStatisticsCompactorTest` by pushing `initial-delay`/`fixed-delay` to `999d`.

## Why
`ExecutionStatisticsCompactor.compact()` is a live `@Scheduled` singleton in this `@MicronautTest` (`kestra.server-type=STANDALONE` satisfies its `@Requires`). On a slow CI box the test class outlives the 1-minute `initialDelay`, so a scheduled `compact()` fires **concurrently** with a test's manual `compact()`. Both run through the shared singleton jOOQ `Configuration` (`JooqDSLContextWrapper`) from two threads, whose non-thread-local transaction state is mutated + iterated at once → intermittent `java.util.ConcurrentModificationException` (seen on `develop` CI 2026-07-16).

Purely a test artifact: in production `compact()` is only ever invoked by the single scheduler thread, serially — so no production change is needed.

## Fix
Test-only: push the schedule far past any test run so only the manual `compact()` calls exercise the code. The bean stays available (`@Requires` still passes on `server-type`).

## Test
`./gradlew :jdbc-h2:test --tests "io.kestra.repository.h2.H2ExecutionStatisticsCompactorTest"` — all 5 green.