### PR TITLE
fix(topology): adjust case label positioning based on target position

### DIFF
--- a/ui/packages/topology/src/nodes/EdgeNode.vue
+++ b/ui/packages/topology/src/nodes/EdgeNode.vue
@@ -68,11 +68,11 @@
 
     const labelAnchor = computed(() => {
         switch (props.targetPosition) {
-            case "left": return "translate(-100%, -50%)"
-            case "right": return "translate(0, -50%)"
-            case "top": return "translate(-50%, -100%)"
-            case "bottom": return "translate(-50%, 0)"
-            default: return "translate(-50%, -50%)"
+        case "left": return "translate(-100%, -50%)"
+        case "right": return "translate(0, -50%)"
+        case "top": return "translate(-50%, -100%)"
+        case "bottom": return "translate(-50%, 0)"
+        default: return "translate(-50%, -50%)"
         }
     })
 

--- a/ui/packages/topology/src/nodes/EdgeNode.vue
+++ b/ui/packages/topology/src/nodes/EdgeNode.vue
@@ -11,7 +11,7 @@
         <div
             class="edge-case-label"
             :style="{
-                transform: `translate(-50%, -50%) translate(${caseLabelX}px, ${caseLabelY}px)`,
+                transform: `${labelAnchor} translate(${caseLabelX}px, ${caseLabelY}px)`,
             }"
         >
             {{ data.value }}
@@ -64,6 +64,16 @@
         if (props.targetPosition === "top") return ty - CASE_LABEL_GAP
         if (props.targetPosition === "bottom") return ty + CASE_LABEL_GAP
         return ty
+    })
+
+    const labelAnchor = computed(() => {
+        switch (props.targetPosition) {
+            case "left": return "translate(-100%, -50%)"
+            case "right": return "translate(0, -50%)"
+            case "top": return "translate(-50%, -100%)"
+            case "bottom": return "translate(-50%, 0)"
+            default: return "translate(-50%, -50%)"
+        }
     })
 
     defineOptions({inheritAttrs: false})


### PR DESCRIPTION
closes https://github.com/kestra-io/kestra-ee/issues/8906

**Edge label positioning improvements:**

* Added a computed property `labelAnchor` that returns the correct CSS `translate` value based on the `targetPosition` prop, ensuring the label is anchored appropriately for each edge direction.
* Updated the inline style for the label to use the new `labelAnchor` value, improving label placement for left, right, top, and bottom edge cases.

<img width="834" height="679" alt="Capture d’écran 2026-07-16 à 16 18 11" src="https://github.com/user-attachments/assets/a552c292-1a95-4cd6-a32d-6504b074a660" />
<img width="840" height="419" alt="Capture d’écran 2026-07-16 à 16 18 24" src="https://github.com/user-attachments/assets/611e5480-9456-4cad-90be-240ad506e19a" />
