### PR TITLE
test(triggers): fix flaky shouldUnlockTriggerWhenLocked orphan-GC race

### DIFF
--- a/webserver/src/test/java/io/kestra/webserver/controllers/api/TriggerControllerTest.java
+++ b/webserver/src/test/java/io/kestra/webserver/controllers/api/TriggerControllerTest.java
@@ -177,7 +177,7 @@ class TriggerControllerTest {
     @Test
     void shouldUnlockTriggerWhenLocked() {
         // GIVEN
-        TriggerState trigger = createTriggerWith(IdUtils.create(), IdUtils.create(), TENANT_ID).locked(Clock.systemDefaultZone(), true);
+        TriggerState trigger = newRandomTriggerState().locked(Clock.systemDefaultZone(), true);
         jdbcTriggerRepository.save(trigger);
 
         // WHEN
@@ -673,17 +673,6 @@ class TriggerControllerTest {
                         .build()
                 )
             )
-            .build();
-    }
-
-    private TriggerState createTriggerWith(String flow, String namespace, String triggerId) {
-        return TriggerState.builder()
-            .tenantId(TENANT_ID)
-            .flowId(flow)
-            .namespace(namespace)
-            .triggerId(triggerId)
-            .evaluatedAt(Instant.now())
-            .vnode(VNodes.computeVNodeFromFlow(FlowId.of(TENANT_ID, namespace, flow, null), schedulerConfiguration.vnodes()))
             .build();
     }
 


### PR DESCRIPTION
## What
Build the fixture in `TriggerControllerTest.shouldUnlockTriggerWhenLocked()` with `newRandomTriggerState()` instead of `createTriggerWith(...)`, and drop the now-unused `createTriggerWith` helper.

## Why (flake root cause)
The test created a locked trigger with **no backing flow** and **no far-future `nextEvaluationDate`**. On unlock the trigger becomes schedule-eligible, and the scheduler's periodic `DefaultSchedulableTriggerFetcher.getSchedulableTriggers()` **deletes any trigger whose flow doesn't exist**. If that orphan-GC tick fires between the unlock ack and the post-unlock re-read (`TriggerStateService.refresh()`), `findById` returns empty → `NoSuchElementException: Trigger disappeared after unlock` → 404. Seen intermittently on CI (e.g. run 29504353982 on `v2.0.0-rc5`, and `develop` earlier).

Every other non-flaky lock/unlock/reset test in this class uses `newRandomTriggerState()`, which sets a far-future `nextEvaluationDate` specifically so the scheduler never treats the flow-less trigger as eligible and never GCs it. This test was the only one using the guard-less helper.

## Scope
Test-only. The orphan-GC is correct in production, where an unlocked trigger always has a backing flow, so the race can't occur there.

## Test
`./gradlew :webserver:test --tests "io.kestra.webserver.controllers.api.TriggerControllerTest"` — green across 8 consecutive clean reruns locally.