### PR TITLE
feat(design-system): add square prop to KsButton

### DIFF
--- a/ui/packages/design-system/src/components/Basic/KsButton/KsButton.vue
+++ b/ui/packages/design-system/src/components/Basic/KsButton/KsButton.vue
@@ -7,6 +7,7 @@
         <ElButton
             :aria-label="tooltip"
             v-bind="({...filteredProps(), ...$attrs} as any)"
+            :class="{'is-square': square}"
             @click="emit('click', $event)"
             plain
         >
@@ -24,6 +25,7 @@
     <ElButton
         v-else
         v-bind="({...filteredProps(), ...$attrs} as any)"
+        :class="{'is-square': square}"
         @click="emit('click', $event)"
         plain
     >
@@ -62,6 +64,7 @@
         autofocus?: boolean
         round?: boolean
         circle?: boolean
+        square?: boolean
         color?: string
         tag?: string | Component
         tooltip?: string
@@ -78,7 +81,7 @@
         icon?(): unknown
     }>()
 
-    const filteredProps = useFilteredProps(props, ["tooltip", "tooltipPlacement"])
+    const filteredProps = useFilteredProps(props, ["tooltip", "tooltipPlacement", "square"])
 </script>
 
 <style lang="scss">
@@ -125,6 +128,12 @@
 
         &.kel-button--small {
             border-radius: var(--kel-border-radius-small);
+        }
+
+        &.is-square {
+            aspect-ratio: 1;
+            padding-left: 0;
+            padding-right: 0;
         }
 
         &.is-plain:not(.is-text) {

--- a/ui/packages/design-system/tests/storybook/Basic/KsButton.stories.ts
+++ b/ui/packages/design-system/tests/storybook/Basic/KsButton.stories.ts
@@ -24,6 +24,7 @@ const meta: Meta<typeof KsButton> = {
         plain: {control: "boolean"},
         round: {control: "boolean"},
         circle: {control: "boolean"},
+        square: {control: "boolean"},
         text: {control: "boolean"},
         link: {control: "boolean"},
         bg: {control: "boolean"},
@@ -136,6 +137,33 @@ export const RoundAndCircle: Story = {
             </div>
         `,
     }),
+}
+
+export const Square: Story = {
+    render: () => ({
+        components: {KsButton},
+        setup() {
+            return {DownloadIcon}
+        },
+        template: `
+            <div style="padding:24px;display:flex;gap:12px;align-items:center">
+                <ks-button square :icon="DownloadIcon" size="small" aria-label="Download" />
+                <ks-button square :icon="DownloadIcon" aria-label="Download" />
+                <ks-button square :icon="DownloadIcon" size="large" aria-label="Download" />
+                <ks-button square :icon="DownloadIcon" type="primary" aria-label="Download" />
+            </div>
+        `,
+    }),
+    parameters: {
+        docs: {
+            description: {
+                story: "`square` is an icon-only modifier (the counterpart of `circle`): the width tracks the button height for a true square, independent of the glyph. Don't pair it with a text label.",
+            },
+        },
+    },
+    async play({canvasElement}) {
+        await expect(canvasElement.querySelector(".kel-button.is-square")).toBeTruthy()
+    },
 }
 
 /** Disabled state */

--- a/ui/packages/design-system/tests/units/Basic/KsButton.test.ts
+++ b/ui/packages/design-system/tests/units/Basic/KsButton.test.ts
@@ -71,6 +71,29 @@ describe("KsButton", () => {
         expect(wrapper.find(".kel-button.is-circle").exists()).toBe(true)
     })
 
+    test("square applies is-square class", () => {
+        const wrapper = mount(KsButton, {
+            props: {square: true},
+            global: globalConfig,
+        })
+        expect(wrapper.find(".kel-button.is-square").exists()).toBe(true)
+    })
+
+    test("square is not forwarded as a DOM attribute", () => {
+        const wrapper = mount(KsButton, {
+            props: {square: true},
+            global: globalConfig,
+        })
+        expect(wrapper.find(".kel-button").attributes("square")).toBeUndefined()
+    })
+
+    test("no is-square class without the square prop", () => {
+        const wrapper = mount(KsButton, {
+            global: globalConfig,
+        })
+        expect(wrapper.find(".is-square").exists()).toBe(false)
+    })
+
     test("emits click event when clicked", async () => {
         const wrapper = mount(KsButton, {
             slots: {default: "Click"},

--- a/ui/src/components/executions/Logs.vue
+++ b/ui/src/components/executions/Logs.vue
@@ -35,9 +35,9 @@
             <div class="logs-toolbar__actions">
                 <Restart v-if="executionsStore.execution" :execution="executionsStore.execution" @follow="emit('follow', $event)" />
                 <LogDisplaySettings />
-                <KsButton type="default" size="default" class="logs-toolbar__btn" :icon="Download" :aria-label="t('download logs')" :tooltip="t('download logs')" @click="downloadContent()" />
-                <KsButton type="default" size="default" class="logs-toolbar__btn" :icon="ContentCopy" :aria-label="t('copy logs')" :tooltip="t('copy logs')" @click="copyAllLogs()" />
-                <KsButton type="default" size="default" class="logs-toolbar__btn" :icon="Refresh" :aria-label="t('refresh')" :tooltip="t('refresh')" @click="loadLogs()" />
+                <KsButton square type="default" size="default" :icon="Download" :aria-label="t('download logs')" :tooltip="t('download logs')" @click="downloadContent()" />
+                <KsButton square type="default" size="default" :icon="ContentCopy" :aria-label="t('copy logs')" :tooltip="t('copy logs')" @click="copyAllLogs()" />
+                <KsButton square type="default" size="default" :icon="Refresh" :aria-label="t('refresh')" :tooltip="t('refresh')" @click="loadLogs()" />
             </div>
         </div>
 
@@ -544,11 +544,6 @@
       align-items: center;
       gap: var(--ks-spacing-2);
       margin-left: auto;
-    }
-
-    &__btn {
-      padding: var(--ks-spacing-2);
-      border-radius: var(--ks-radius-base);
     }
 
     &__text-btn {

--- a/ui/src/components/logs/LogDisplaySettings.vue
+++ b/ui/src/components/logs/LogDisplaySettings.vue
@@ -1,7 +1,7 @@
 <template>
     <KsPopover placement="bottom-end" trigger="click" :title="t('display_settings')" width="300">
         <template #reference>
-            <KsButton type="default" size="default" class="display-settings-btn" :icon="Cog" :aria-label="t('display_settings')" />
+            <KsButton square type="default" size="default" :icon="Cog" :aria-label="t('display_settings')" />
         </template>
         <template #default>
             <div class="log-display-settings">
@@ -64,12 +64,6 @@
 </script>
 
 <style scoped lang="scss">
-    .display-settings-btn {
-        margin: 0;
-        padding: var(--ks-spacing-2);
-        border-radius: var(--ks-radius-base);
-    }
-
     .log-display-settings {
         display: flex;
         flex-direction: column;

--- a/ui/src/components/logs/LogsWrapper.vue
+++ b/ui/src/components/logs/LogsWrapper.vue
@@ -44,8 +44,8 @@
                             </div>
                             <div class="logs-toolbar__actions">
                                 <LogDisplaySettings />
-                                <KsButton type="default" size="default" class="logs-toolbar__btn" :icon="Download" :aria-label="t('download logs')" :tooltip="t('download logs')" @click="openDownload" />
-                                <KsButton type="default" size="default" class="logs-toolbar__btn" :icon="ContentCopy" :aria-label="t('copy logs')" :tooltip="t('copy logs')" @click="copyAllLogs" />
+                                <KsButton square type="default" size="default" :icon="Download" :aria-label="t('download logs')" :tooltip="t('download logs')" @click="openDownload" />
+                                <KsButton square type="default" size="default" :icon="ContentCopy" :aria-label="t('copy logs')" :tooltip="t('copy logs')" @click="copyAllLogs" />
                             </div>
                         </div>
                         <div v-if="logsStore.logs !== undefined && logsStore.logs?.length > 0" class="logs-wrapper">
@@ -468,11 +468,6 @@
             align-items: center;
             margin-left: auto;
             gap: var(--ks-spacing-2);
-        }
-
-        &__btn {
-            padding: var(--ks-spacing-2);
-            border-radius: var(--ks-radius-base);
         }
 
         :deep(.kel-button) {


### PR DESCRIPTION
closes https://github.com/kestra-io/kestra-ee/issues/8958

<img width="551" height="524" alt="Capture d’écran 2026-07-16 à 17 54 38" src="https://github.com/user-attachments/assets/df425396-545f-43cc-8a38-938cd23b9a0a" />

This pull request adds a new `square` prop to the `KsButton` component, allowing for true square, icon-only buttons. The change updates the component, its styles, and its usage throughout the UI to improve consistency and visual alignment for icon buttons. Storybook stories and unit tests are also added to demonstrate and verify the new functionality.

**Component Enhancements:**

* Added a `square` prop to `KsButton`, which applies an `.is-square` class for a true square aspect ratio and removes horizontal padding, intended for icon-only buttons. The prop is filtered out from being passed to the DOM. (`ui/packages/design-system/src/components/Basic/KsButton/KsButton.vue` [[1]](diffhunk://#diff-913cf7109cc801d2498523e7a9855ea362012dbf57f7ce1c211786bfe979e904R67) [[2]](diffhunk://#diff-913cf7109cc801d2498523e7a9855ea362012dbf57f7ce1c211786bfe979e904R10) [[3]](diffhunk://#diff-913cf7109cc801d2498523e7a9855ea362012dbf57f7ce1c211786bfe979e904R28) [[4]](diffhunk://#diff-913cf7109cc801d2498523e7a9855ea362012dbf57f7ce1c211786bfe979e904R133-R138) [[5]](diffhunk://#diff-913cf7109cc801d2498523e7a9855ea362012dbf57f7ce1c211786bfe979e904L81-R84)

**Storybook and Testing:**

* Added Storybook controls and a new `Square` story for `KsButton` to showcase the `square` prop, with documentation and visual tests. (`ui/packages/design-system/tests/storybook/Basic/KsButton.stories.ts` [[1]](diffhunk://#diff-42f837708d8e1202b4d4dd0195e1a91faec6ae5f9325158ebeb55792980695afR27) [[2]](diffhunk://#diff-42f837708d8e1202b4d4dd0195e1a91faec6ae5f9325158ebeb55792980695afR142-R168)
* Added unit tests to verify `.is-square` class application, DOM attribute filtering, and default behavior. (`ui/packages/design-system/tests/units/Basic/KsButton.test.ts` [ui/packages/design-system/tests/units/Basic/KsButton.test.tsR74-R96](diffhunk://#diff-7d28a06e1bd8b63456f888e9b0509e48280fa9600ebdd848f890086f3d1d135eR74-R96))

**UI Usage Updates:**

* Updated all icon-only `KsButton` usages in logs toolbars and display settings to use the new `square` prop for consistent appearance. (`ui/src/components/executions/Logs.vue` [[1]](diffhunk://#diff-55ef8503a9532e766cfd7df8fd1fae8d3e921198b3b6cba6262cba31dfd78066L38-R40) `ui/src/components/logs/LogsWrapper.vue` [[2]](diffhunk://#diff-68c58759f65939b62ace87f5a812867efcb6e8fc1af9c1a4f051e5932545aa40L47-R48) `ui/src/components/logs/LogDisplaySettings.vue` [[3]](diffhunk://#diff-3b3a328d70ded94cd465909bb411aeda5fca6c3fa5a2f65eac01450d138a70b4L4-R4)

**Style Cleanup:**

* Removed now-unnecessary custom padding and border-radius styles for button wrappers in logs components, since these are handled by the `square` prop. (`ui/src/components/executions/Logs.vue` [[1]](diffhunk://#diff-55ef8503a9532e766cfd7df8fd1fae8d3e921198b3b6cba6262cba31dfd78066L549-L553) `ui/src/components/logs/LogsWrapper.vue` [[2]](diffhunk://#diff-68c58759f65939b62ace87f5a812867efcb6e8fc1af9c1a4f051e5932545aa40L473-L477) `ui/src/components/logs/LogDisplaySettings.vue` [[3]](diffhunk://#diff-3b3a328d70ded94cd465909bb411aeda5fca6c3fa5a2f65eac01450d138a70b4L67-L72)