### PR TITLE
feat(system): add security response headers to every HTTP response

### DIFF
--- a/cli/src/main/resources/application.yml
+++ b/cli/src/main/resources/application.yml
@@ -148,6 +148,18 @@ kestra:
     # Automatically loads all tutorial flows at startup.
     enabled: true
 
+  webserver:
+    # Browser security response headers, added to every HTTP response (UI and API).
+    # Set a value to "" to disable that single header, or security-headers.enabled to false to disable the whole filter.
+    security-headers:
+      enabled: true
+      frame-options: SAMEORIGIN
+      content-type-options: nosniff
+      referrer-policy: strict-origin-when-cross-origin
+      # content-security-policy: "default-src 'self'; ..." # tune for the UI before enforcing
+      # content-security-policy-report-only: true # report-only intermediate step
+      # strict-transport-security: "max-age=31536000; includeSubDomains" # only sent when this server sees the request as HTTPS
+
   retries:
     attempts: 5
     multiplier: 2.0

--- a/webserver/src/main/java/io/kestra/webserver/configuration/SecurityHeadersConfiguration.java
+++ b/webserver/src/main/java/io/kestra/webserver/configuration/SecurityHeadersConfiguration.java
@@ -1,0 +1,33 @@
+package io.kestra.webserver.configuration;
+
+import io.micronaut.context.annotation.ConfigurationProperties;
+import io.micronaut.core.annotation.Nullable;
+import io.micronaut.core.bind.annotation.Bindable;
+
+/**
+ * Configuration for the browser security response headers emitted on every HTTP response by
+ * {@link io.kestra.webserver.filter.SecurityHeadersFilter}.
+ * <p>
+ * A blank value for any individual header disables that header, while {@code enabled: false} disables the
+ * whole filter (also read directly by a {@code @Requires} on the filter itself, so the filter bean isn't even
+ * created when disabled).
+ *
+ * @param enabled master toggle for the whole filter (default {@code true}).
+ * @param frameOptions value for {@code X-Frame-Options} (default {@code SAMEORIGIN}); blank to disable.
+ * @param contentTypeOptions value for {@code X-Content-Type-Options} (default {@code nosniff}); blank to disable.
+ * @param referrerPolicy value for {@code Referrer-Policy} (default {@code strict-origin-when-cross-origin}); blank to disable.
+ * @param contentSecurityPolicy value for {@code Content-Security-Policy}; opt-in, absent by default.
+ * @param contentSecurityPolicyReportOnly when {@code true}, the CSP is emitted under
+ *        {@code Content-Security-Policy-Report-Only} instead of enforcing it — a safe intermediate step.
+ * @param strictTransportSecurity value for {@code Strict-Transport-Security}; opt-in, and only emitted on HTTPS requests.
+ */
+@ConfigurationProperties("kestra.webserver.security-headers")
+public record SecurityHeadersConfiguration(
+    @Bindable(defaultValue = "true") boolean enabled,
+    @Bindable(defaultValue = "SAMEORIGIN") String frameOptions,
+    @Bindable(defaultValue = "nosniff") String contentTypeOptions,
+    @Bindable(defaultValue = "strict-origin-when-cross-origin") String referrerPolicy,
+    @Nullable String contentSecurityPolicy,
+    @Bindable(defaultValue = "false") boolean contentSecurityPolicyReportOnly,
+    @Nullable String strictTransportSecurity) {
+}

--- a/webserver/src/main/java/io/kestra/webserver/filter/SecurityHeadersFilter.java
+++ b/webserver/src/main/java/io/kestra/webserver/filter/SecurityHeadersFilter.java
@@ -1,0 +1,95 @@
+package io.kestra.webserver.filter;
+
+import java.util.Objects;
+
+import io.kestra.webserver.configuration.SecurityHeadersConfiguration;
+
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.core.annotation.Nullable;
+import io.micronaut.core.order.Ordered;
+import io.micronaut.core.util.StringUtils;
+import io.micronaut.http.HttpRequest;
+import io.micronaut.http.MutableHttpResponse;
+import io.micronaut.http.annotation.ResponseFilter;
+import io.micronaut.http.annotation.ServerFilter;
+import io.micronaut.http.filter.ServerFilterPhase;
+
+/**
+ * Adds browser security response headers to every HTTP response (UI and API), driven by
+ * {@link SecurityHeadersConfiguration}.
+ * <p>
+ * Runs at {@link ServerFilterPhase#FIRST}, i.e. as the outermost filter, so its response processing happens
+ * <em>last</em> on the way out — after every other filter, including ones that replace the response object
+ * wholesale (e.g. {@link io.kestra.webserver.controllers.api.StaticFilter} rebuilding the {@code index.html}
+ * response) or short-circuit the chain early with an error response (e.g. an authentication or CSRF filter
+ * returning 401/403 without proceeding). Any other phase would let such responses skip this filter entirely.
+ * Each configured, non-blank header is only set when it is not already present, so a controller or another
+ * filter can still override it. HSTS is emitted only on secure (HTTPS) requests, since it is meaningless — and
+ * potentially harmful — over plain HTTP. Note this only detects TLS terminated on this server directly; behind a
+ * TLS-terminating reverse proxy, configure the proxy to also set HSTS, since the request reaches this server as
+ * plain HTTP.
+ */
+@Requires(property = "kestra.webserver.security-headers.enabled", notEquals = "false", defaultValue = "true")
+@ServerFilter("/**")
+public class SecurityHeadersFilter implements Ordered {
+    private static final String X_FRAME_OPTIONS = "X-Frame-Options";
+    private static final String X_CONTENT_TYPE_OPTIONS = "X-Content-Type-Options";
+    private static final String REFERRER_POLICY = "Referrer-Policy";
+    private static final String CONTENT_SECURITY_POLICY = "Content-Security-Policy";
+    private static final String CONTENT_SECURITY_POLICY_REPORT_ONLY = "Content-Security-Policy-Report-Only";
+    private static final String STRICT_TRANSPORT_SECURITY = "Strict-Transport-Security";
+
+    @Nullable
+    private final String frameOptions;
+    @Nullable
+    private final String contentTypeOptions;
+    @Nullable
+    private final String referrerPolicy;
+    @Nullable
+    private final String contentSecurityPolicy;
+    private final String contentSecurityPolicyHeaderName;
+    @Nullable
+    private final String strictTransportSecurity;
+
+    public SecurityHeadersFilter(SecurityHeadersConfiguration configuration) {
+        Objects.requireNonNull(configuration);
+        this.frameOptions = blankToNull(configuration.frameOptions());
+        this.contentTypeOptions = blankToNull(configuration.contentTypeOptions());
+        this.referrerPolicy = blankToNull(configuration.referrerPolicy());
+        this.contentSecurityPolicy = blankToNull(configuration.contentSecurityPolicy());
+        this.contentSecurityPolicyHeaderName = configuration.contentSecurityPolicyReportOnly()
+            ? CONTENT_SECURITY_POLICY_REPORT_ONLY
+            : CONTENT_SECURITY_POLICY;
+        this.strictTransportSecurity = blankToNull(configuration.strictTransportSecurity());
+    }
+
+    @ResponseFilter
+    public void addSecurityHeaders(@NonNull HttpRequest<?> request, @NonNull MutableHttpResponse<?> response) {
+        setIfAbsent(response, X_FRAME_OPTIONS, frameOptions);
+        setIfAbsent(response, X_CONTENT_TYPE_OPTIONS, contentTypeOptions);
+        setIfAbsent(response, REFERRER_POLICY, referrerPolicy);
+        setIfAbsent(response, contentSecurityPolicyHeaderName, contentSecurityPolicy);
+
+        // HSTS is only meaningful over HTTPS; never advertise it on plain HTTP.
+        if (request.isSecure()) {
+            setIfAbsent(response, STRICT_TRANSPORT_SECURITY, strictTransportSecurity);
+        }
+    }
+
+    private static void setIfAbsent(MutableHttpResponse<?> response, String name, @Nullable String value) {
+        if (value != null && !response.getHeaders().contains(name)) {
+            response.getHeaders().set(name, value);
+        }
+    }
+
+    @Nullable
+    private static String blankToNull(@Nullable String value) {
+        return StringUtils.hasText(value) ? value : null;
+    }
+
+    @Override
+    public int getOrder() {
+        return ServerFilterPhase.FIRST.order();
+    }
+}

--- a/webserver/src/test/java/io/kestra/webserver/filter/SecurityHeadersFilterIntegrationTest.java
+++ b/webserver/src/test/java/io/kestra/webserver/filter/SecurityHeadersFilterIntegrationTest.java
@@ -1,0 +1,97 @@
+package io.kestra.webserver.filter;
+
+import java.util.Base64;
+
+import org.junit.jupiter.api.Test;
+
+import io.kestra.webserver.services.BasicAuthService;
+
+import io.micronaut.context.ApplicationContext;
+import io.micronaut.context.annotation.Property;
+import io.micronaut.http.HttpRequest;
+import io.micronaut.http.HttpResponse;
+import io.micronaut.http.MutableHttpRequest;
+import io.micronaut.http.client.annotation.Client;
+import io.micronaut.http.client.exceptions.HttpClientResponseException;
+import io.micronaut.http.cookie.Cookie;
+import io.micronaut.reactor.http.client.ReactorHttpClient;
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import jakarta.inject.Inject;
+
+import static io.micronaut.http.HttpRequest.GET;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * End-to-end wiring checks for {@link SecurityHeadersFilter}: confirms the {@code kestra.webserver.security-headers.*}
+ * configuration actually binds and the filter is applied to a real HTTP response. Header-value logic itself is
+ * covered by the plain unit tests in {@link SecurityHeadersFilterTest}.
+ */
+@MicronautTest(rebuildContext = true)
+class SecurityHeadersFilterIntegrationTest {
+    @Inject
+    @Client("/")
+    ReactorHttpClient client;
+
+    @Inject
+    ApplicationContext applicationContext;
+
+    @Inject
+    private BasicAuthService.BasicAuthConfiguration basicAuthConfiguration;
+
+    @Test
+    void shouldSetSafeDefaultHeadersOnARealResponse() {
+        // Given
+        assertThat(applicationContext.containsBean(SecurityHeadersFilter.class)).isTrue();
+
+        // When
+        var response = client.toBlocking().exchange(GET("/ping"));
+
+        // Then
+        assertThat(response.getHeaders().get("X-Frame-Options")).isEqualTo("SAMEORIGIN");
+        assertThat(response.getHeaders().get("X-Content-Type-Options")).isEqualTo("nosniff");
+        assertThat(response.getHeaders().get("Referrer-Policy")).isEqualTo("strict-origin-when-cross-origin");
+        assertThat(response.getHeaders().contains("Content-Security-Policy")).isFalse();
+    }
+
+    @Test
+    @Property(name = "kestra.webserver.security-headers.enabled", value = "false")
+    void shouldSetNoHeadersWhenFilterIsDisabled() {
+        // Given
+        assertThat(applicationContext.containsBean(SecurityHeadersFilter.class)).isFalse();
+
+        // When
+        var response = client.toBlocking().exchange(GET("/ping"));
+
+        // Then
+        assertThat(response.getHeaders().contains("X-Frame-Options")).isFalse();
+        assertThat(response.getHeaders().contains("X-Content-Type-Options")).isFalse();
+        assertThat(response.getHeaders().contains("Referrer-Policy")).isFalse();
+    }
+
+    @Test
+    void shouldSetHeadersOnAResponseThatShortCircuitsBeforeTheFilterChainCompletes() {
+        // Given - a CSRF-rejected request: CsrfTokenFilter returns 403 without proceeding down the chain,
+        // at ServerFilterPhase.SECURITY - if SecurityHeadersFilter ran at a later phase it would never be invoked.
+        String basicAuthCookieValue = Base64.getEncoder().encodeToString(
+            (basicAuthConfiguration.getUsername() + ":" + basicAuthConfiguration.getPassword()).getBytes()
+        );
+        MutableHttpRequest<?> request = HttpRequest.POST("/api/v1/main/executions/webhook/unit_test/webhook_test", "")
+            .cookie(Cookie.of(BasicAuthService.BASIC_AUTH_COOKIE_NAME, basicAuthCookieValue));
+
+        // When
+        HttpClientResponseException exception = null;
+        HttpResponse<?> response;
+        try {
+            response = client.toBlocking().exchange(request);
+        } catch (HttpClientResponseException e) {
+            exception = e;
+            response = e.getResponse();
+        }
+
+        // Then
+        assertThat(exception).isNotNull();
+        assertThat(response.getHeaders().get("X-Frame-Options")).isEqualTo("SAMEORIGIN");
+        assertThat(response.getHeaders().get("X-Content-Type-Options")).isEqualTo("nosniff");
+        assertThat(response.getHeaders().get("Referrer-Policy")).isEqualTo("strict-origin-when-cross-origin");
+    }
+}

--- a/webserver/src/test/java/io/kestra/webserver/filter/SecurityHeadersFilterTest.java
+++ b/webserver/src/test/java/io/kestra/webserver/filter/SecurityHeadersFilterTest.java
@@ -1,0 +1,126 @@
+package io.kestra.webserver.filter;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import io.kestra.webserver.configuration.SecurityHeadersConfiguration;
+
+import io.micronaut.http.HttpRequest;
+import io.micronaut.http.HttpResponse;
+import io.micronaut.http.MutableHttpResponse;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class SecurityHeadersFilterTest {
+    private static final SecurityHeadersConfiguration DEFAULT_CONFIGURATION = new SecurityHeadersConfiguration(
+        true, "SAMEORIGIN", "nosniff", "strict-origin-when-cross-origin", null, false, null
+    );
+
+    @Test
+    void shouldSetSafeDefaultHeaders() {
+        // Given
+        SecurityHeadersFilter filter = new SecurityHeadersFilter(DEFAULT_CONFIGURATION);
+        HttpRequest<?> request = request(false);
+        MutableHttpResponse<?> response = HttpResponse.ok();
+
+        // When
+        filter.addSecurityHeaders(request, response);
+
+        // Then
+        assertThat(response.getHeaders().get("X-Frame-Options")).isEqualTo("SAMEORIGIN");
+        assertThat(response.getHeaders().get("X-Content-Type-Options")).isEqualTo("nosniff");
+        assertThat(response.getHeaders().get("Referrer-Policy")).isEqualTo("strict-origin-when-cross-origin");
+        assertThat(response.getHeaders().contains("Content-Security-Policy")).isFalse();
+        assertThat(response.getHeaders().contains("Strict-Transport-Security")).isFalse();
+    }
+
+    @Test
+    void shouldNotOverrideAnAlreadySetHeader() {
+        // Given - a controller or another filter already set X-Frame-Options
+        SecurityHeadersFilter filter = new SecurityHeadersFilter(DEFAULT_CONFIGURATION);
+        HttpRequest<?> request = request(false);
+        MutableHttpResponse<?> response = HttpResponse.ok();
+        response.getHeaders().set("X-Frame-Options", "DENY");
+
+        // When
+        filter.addSecurityHeaders(request, response);
+
+        // Then
+        assertThat(response.getHeaders().get("X-Frame-Options")).isEqualTo("DENY");
+    }
+
+    @ParameterizedTest
+    @CsvSource(
+        {
+            "false, Content-Security-Policy, Content-Security-Policy-Report-Only",
+            "true, Content-Security-Policy-Report-Only, Content-Security-Policy"
+        }
+    )
+    void shouldSetContentSecurityPolicyUnderTheConfiguredHeaderName(boolean reportOnly, String expectedHeader, String unexpectedHeader) {
+        // Given
+        SecurityHeadersConfiguration configuration = new SecurityHeadersConfiguration(
+            true, "SAMEORIGIN", "nosniff", "strict-origin-when-cross-origin", "default-src 'self'", reportOnly, null
+        );
+        SecurityHeadersFilter filter = new SecurityHeadersFilter(configuration);
+        HttpRequest<?> request = request(false);
+        MutableHttpResponse<?> response = HttpResponse.ok();
+
+        // When
+        filter.addSecurityHeaders(request, response);
+
+        // Then
+        assertThat(response.getHeaders().get(expectedHeader)).isEqualTo("default-src 'self'");
+        assertThat(response.getHeaders().contains(unexpectedHeader)).isFalse();
+    }
+
+    @Test
+    void shouldSetStrictTransportSecurityOnlyOnSecureRequest() {
+        // Given
+        SecurityHeadersConfiguration configuration = new SecurityHeadersConfiguration(
+            true, "SAMEORIGIN", "nosniff", "strict-origin-when-cross-origin", null, false, "max-age=31536000; includeSubDomains"
+        );
+        SecurityHeadersFilter filter = new SecurityHeadersFilter(configuration);
+
+        // When - insecure (plain HTTP) request
+        MutableHttpResponse<?> insecureResponse = HttpResponse.ok();
+        filter.addSecurityHeaders(request(false), insecureResponse);
+
+        // Then - HSTS must not be advertised over plain HTTP
+        assertThat(insecureResponse.getHeaders().contains("Strict-Transport-Security")).isFalse();
+
+        // When - secure (HTTPS) request
+        MutableHttpResponse<?> secureResponse = HttpResponse.ok();
+        filter.addSecurityHeaders(request(true), secureResponse);
+
+        // Then
+        assertThat(secureResponse.getHeaders().get("Strict-Transport-Security")).isEqualTo("max-age=31536000; includeSubDomains");
+    }
+
+    @Test
+    void shouldSetNoHeadersWhenAllValuesAreBlank() {
+        // Given
+        SecurityHeadersConfiguration configuration = new SecurityHeadersConfiguration(
+            true, "", "", "", null, false, null
+        );
+        SecurityHeadersFilter filter = new SecurityHeadersFilter(configuration);
+        HttpRequest<?> request = request(false);
+        MutableHttpResponse<?> response = HttpResponse.ok();
+
+        // When
+        filter.addSecurityHeaders(request, response);
+
+        // Then
+        assertThat(response.getHeaders().contains("X-Frame-Options")).isFalse();
+        assertThat(response.getHeaders().contains("X-Content-Type-Options")).isFalse();
+        assertThat(response.getHeaders().contains("Referrer-Policy")).isFalse();
+    }
+
+    private static HttpRequest<?> request(boolean secure) {
+        HttpRequest<?> request = mock(HttpRequest.class);
+        when(request.isSecure()).thenReturn(secure);
+        return request;
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `X-Frame-Options`, `X-Content-Type-Options` and `Referrer-Policy` to every HTTP response (UI and API) with safe defaults, plus opt-in `Content-Security-Policy` (with a report-only mode) and `Strict-Transport-Security`, all configurable under `kestra.webserver.security-headers.*` (`SecurityHeadersConfiguration`).
- New `SecurityHeadersFilter` runs at `ServerFilterPhase.FIRST` (outermost) so it applies even to responses that short-circuit earlier in the chain (e.g. 401/403 from auth or CSRF filters) or get rebuilt by another filter (`StaticFilter`'s `index.html` rewrite) — verified with a dedicated regression test.
- Closes kestra-io/kestra-ee#9036.
- Closes https://github.com/kestra-io/kestra-ee/issues/6112

## Test plan
- [x] `SecurityHeadersFilterTest` — unit tests for default headers, override protection, CSP/report-only header selection, HSTS gated on HTTPS, all-blank disables everything
- [x] `SecurityHeadersFilterIntegrationTest` — real HTTP client checks: default headers on a normal response, filter fully disabled via config, headers still present on a short-circuited (CSRF-rejected) response
- [x] Ran full `webserver` filter/tenant test suites to confirm no regressions from the new global `/**` filter