### PR TITLE
fix(inputs): strip null when optional input is cleared before execution

### DIFF
--- a/ui/src/utils/submitTask.js
+++ b/ui/src/utils/submitTask.js
@@ -7,7 +7,7 @@ export const inputsToFormData = (submitor, inputsList, values) => {
     let inputValuesCloned = _cloneDeep(values)
 
     for (const input of inputsList || []) {
-        if (inputValuesCloned[input.id] === undefined || inputValuesCloned[input.id] === "") {
+        if (inputValuesCloned[input.id] === undefined || inputValuesCloned[input.id] === null || inputValuesCloned[input.id] === "") {
             delete inputValuesCloned[input.id];
         }
 


### PR DESCRIPTION

All PRs submitted by external contributors that do not follow this template (including proper description, related issue, and checklist sections) **may be automatically closed**.

As a general practice, if you plan to work on a specific issue, comment on the issue first and wait to be assigned before starting any actual work. This avoids duplicated work and ensures a smooth contribution process - otherwise, the PR **may be automatically closed**.

---

### ✨ Description
When a user fills an optional INT input and then clears it before submitting, the component emits null (not undefined). The null value was not being stripped from the form data before submission, causing it to be sent to the backend as the string "null", which fails integer parsing and returns a validation error.

What does this PR change?  
This fix adds a null check alongside the existing undefined and "" checks in inputsToFormData.

### 🔗 Related Issue

Closes https://github.com/kestra-io/kestra/issues/17410

### 🎨 Frontend Checklist

_If this PR does not include any frontend changes, delete this entire section._

- [x] Code builds without errors (`npm run build`)
- [ ] All existing E2E tests pass (`npm run test:e2e`)
- [x] Screenshots or video recordings attached showing the `UI` changes



### 📝 Additional Notes

This bug was already fixed on develop as a side effect of the JavaScript → TypeScript migration (submitTask.ts already includes the null check). This PR backports the fix to releases/v1.3.x where the original .js file still had the gap.

[Screencast from 2026-07-16 23-05-06.webm](https://github.com/user-attachments/assets/e0544647-dc6b-4e7c-aba6-4d132b1506c5)

