### PR TITLE
feat: new WorkerTaskResultListener listener

### DIFF
--- a/core/src/main/java/io/kestra/core/models/flows/State.java
+++ b/core/src/main/java/io/kestra/core/models/flows/State.java
@@ -107,6 +107,26 @@ public class State {
         return this.getDuration().orElseGet(() -> Duration.between(this.getStartDate(), Instant.now()));
     }
 
+    /**
+     * Duration from the most recent {@link Type#RUNNING} transition to the terminal date — how long the last
+     * attempt actually ran. Empty if it never entered RUNNING or hasn't ended. Unlike {@link #getDuration()}
+     * (start → end), this excludes pre-RUNNING time and earlier retry attempts.
+     */
+    @JsonIgnore
+    public Optional<Duration> lastRunningDuration() {
+        Optional<Instant> end = this.getEndDate();
+        if (end.isEmpty()) {
+            return Optional.empty();
+        }
+        Instant runningAt = null;
+        for (History history : this.histories) {
+            if (history.getState() == Type.RUNNING) {
+                runningAt = history.getDate();
+            }
+        }
+        return runningAt == null ? Optional.empty() : Optional.of(Duration.between(runningAt, end.get()));
+    }
+
     @JsonProperty(access = JsonProperty.Access.READ_ONLY)
     public Instant getStartDate() {
         return this.histories.getFirst().getDate();

--- a/core/src/test/java/io/kestra/core/models/flows/StateTest.java
+++ b/core/src/test/java/io/kestra/core/models/flows/StateTest.java
@@ -101,6 +101,45 @@ class StateTest {
     }
 
     @Test
+    void shouldGetLastRunningDurationFromTheLastRunningTransition() {
+        // a retry appends attempts; the window must be the last RUNNING → end, not the first
+        Instant firstRunning = Instant.parse("2024-01-01T00:00:00Z");
+        Instant lastRunning = Instant.parse("2024-01-01T00:10:00Z");
+        Instant end = Instant.parse("2024-01-01T00:10:03Z");
+        State state = new State(
+            State.Type.SUCCESS, List.of(
+                new State.History(State.Type.CREATED, firstRunning.minusSeconds(1)),
+                new State.History(State.Type.RUNNING, firstRunning),
+                new State.History(State.Type.FAILED, firstRunning.plusSeconds(4)),
+                new State.History(State.Type.RETRYING, lastRunning.minusSeconds(1)),
+                new State.History(State.Type.RUNNING, lastRunning),
+                new State.History(State.Type.SUCCESS, end)
+            )
+        );
+
+        assertThat(state.lastRunningDuration()).contains(Duration.between(lastRunning, end));
+    }
+
+    @Test
+    void shouldGetEmptyLastRunningDurationWhenNeverRunning() {
+        State state = new State(
+            State.Type.FAILED, List.of(
+                new State.History(State.Type.CREATED, START),
+                new State.History(State.Type.FAILED, END)
+            )
+        );
+
+        assertThat(state.lastRunningDuration()).isEmpty();
+    }
+
+    @Test
+    void shouldGetEmptyLastRunningDurationWhenNotEnded() {
+        State state = new State(State.Type.RUNNING, List.of(new State.History(State.Type.RUNNING, START)));
+
+        assertThat(state.lastRunningDuration()).isEmpty();
+    }
+
+    @Test
     void shouldFormatHumanDurationAsHoursMinutesSeconds() {
         // Given / When / Then
         assertThat(terminatedState().humanDuration()).isEqualTo("01:01:01.000");

--- a/executor/src/main/java/io/kestra/executor/handler/WorkerTaskResultListener.java
+++ b/executor/src/main/java/io/kestra/executor/handler/WorkerTaskResultListener.java
@@ -1,0 +1,18 @@
+package io.kestra.executor.handler;
+
+import io.kestra.core.models.executions.Execution;
+import io.kestra.core.runners.WorkerTaskResult;
+
+/**
+ * Extension point notified after the executor has processed a {@link WorkerTaskResult} for its execution —
+ * either joining the result or failing the execution from the executor-side fallback paths. {@code execution}
+ * is the post-join execution, so a listener can resolve the flow/task when the result alone isn't enough.
+ * <p>
+ * A plain redelivery of an already-joined taskrun is not notified; killswitched results are not notified
+ * either. Listeners run synchronously on whichever executor thread handled the message, so they may be
+ * called concurrently and must be thread-safe — keep them cheap and non-blocking. A listener throwing
+ * does not fail execution processing and does not stop the remaining listeners.
+ */
+public interface WorkerTaskResultListener {
+    void onJoined(WorkerTaskResult workerTaskResult, Execution execution);
+}

--- a/executor/src/main/java/io/kestra/executor/handler/WorkerTaskResultMessageHandler.java
+++ b/executor/src/main/java/io/kestra/executor/handler/WorkerTaskResultMessageHandler.java
@@ -1,11 +1,13 @@
 package io.kestra.executor.handler;
 
+import java.util.List;
 import java.util.Optional;
 
 import io.kestra.core.exceptions.FlowNotFoundException;
 import io.kestra.core.exceptions.InternalException;
 import io.kestra.core.killswitch.EvaluationType;
 import io.kestra.core.killswitch.KillSwitchService;
+import io.kestra.core.models.executions.Execution;
 import io.kestra.core.runners.FlowMetaStoreInterface;
 import io.kestra.core.runners.WorkerTaskResult;
 import io.kestra.executor.ExecutionStateStore;
@@ -30,18 +32,22 @@ public class WorkerTaskResultMessageHandler implements ExecutorMessageHandler<Wo
     private final KillSwitchService killSwitchService;
     private final KillSwitchActionService killSwitchActionService;
 
+    private final List<WorkerTaskResultListener> workerTaskResultListeners;
+
     @Inject
     public WorkerTaskResultMessageHandler(
         ExecutionStateStore executionStateStore,
         ExecutorService executorService,
         FlowMetaStoreInterface flowMetaStore,
         KillSwitchService killSwitchService,
-        KillSwitchActionService killSwitchActionService) {
+        KillSwitchActionService killSwitchActionService,
+        List<WorkerTaskResultListener> workerTaskResultListeners) {
         this.executionStateStore = executionStateStore;
         this.executorService = executorService;
         this.flowMetaStore = flowMetaStore;
         this.killSwitchService = killSwitchService;
         this.killSwitchActionService = killSwitchActionService;
+        this.workerTaskResultListeners = workerTaskResultListeners;
     }
 
     @Override
@@ -59,7 +65,7 @@ public class WorkerTaskResultMessageHandler implements ExecutorMessageHandler<Wo
             executorService.log(log, true, message);
         }
 
-        return executionStateStore.lock(message.getTaskRun().getExecutionId(), execution ->
+        Optional<ExecutorContext> result = executionStateStore.lock(message.getTaskRun().getExecutionId(), execution ->
         {
             ExecutorContext current = new ExecutorContext(execution);
 
@@ -85,5 +91,22 @@ public class WorkerTaskResultMessageHandler implements ExecutorMessageHandler<Wo
 
             return null;
         });
+
+        // a present result means the taskrun was joined here (redeliveries come back empty): notify listeners once
+        if (result.isPresent()) {
+            notifyJoined(message, result.get().getExecution());
+        }
+
+        return result;
+    }
+
+    private void notifyJoined(WorkerTaskResult message, Execution execution) {
+        for (WorkerTaskResultListener listener : workerTaskResultListeners) {
+            try {
+                listener.onJoined(message, execution);
+            } catch (Exception e) {
+                log.error("Worker task result listener {} failed", listener.getClass().getName(), e);
+            }
+        }
     }
 }

--- a/executor/src/test/java/io/kestra/executor/handler/WorkerTaskResultMessageHandlerTest.java
+++ b/executor/src/test/java/io/kestra/executor/handler/WorkerTaskResultMessageHandlerTest.java
@@ -24,8 +24,11 @@ import jakarta.inject.Inject;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -46,6 +49,9 @@ class WorkerTaskResultMessageHandlerTest {
     @Inject
     KillSwitchActionService killSwitchActionService;
 
+    @Inject
+    WorkerTaskResultListener workerTaskResultListener;
+
     @MockBean(KillSwitchService.class)
     KillSwitchService killSwitchService() {
         return mock(KillSwitchService.class);
@@ -54,6 +60,11 @@ class WorkerTaskResultMessageHandlerTest {
     @MockBean(KillSwitchActionService.class)
     KillSwitchActionService killSwitchActionService() {
         return mock(KillSwitchActionService.class);
+    }
+
+    @MockBean(WorkerTaskResultListener.class)
+    WorkerTaskResultListener workerTaskResultListener() {
+        return mock(WorkerTaskResultListener.class);
     }
 
     @BeforeEach
@@ -100,6 +111,70 @@ class WorkerTaskResultMessageHandlerTest {
 
         assertThat(maybeExecutor).isPresent();
         assertThat(maybeExecutor.get().getExecution().getTaskRunList().getFirst().getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
+        verify(workerTaskResultListener).onJoined(eq(workerTaskResult), any());
+    }
+
+    @Test
+    void shouldNotNotifyListenersWhenNotJoined() {
+        var workerTaskResult = WorkerTaskResult.builder()
+            .taskRun(TaskRun.builder().executionId("execution").id("taskrun").taskId("task").build())
+            .build();
+
+        var maybeExecutor = workerTaskResultMessageHandler.handle(workerTaskResult);
+
+        assertThat(maybeExecutor).isEmpty();
+        verify(workerTaskResultListener, never()).onJoined(any(), any());
+    }
+
+    @Test
+    void shouldNotifyListenerOnlyOnceOnRedelivery() {
+        var flow = Fixtures.flow();
+        flowRepository.create(GenericFlow.of(flow));
+        var execution = Execution.newExecution(flow, Collections.emptyList());
+        var taskRun = TaskRun.builder()
+            .executionId(execution.getId())
+            .namespace(execution.getNamespace())
+            .flowId(execution.getFlowId())
+            .id("taskrun")
+            .taskId(flow.getTasks().getFirst().getId())
+            .state(new State().withState(State.Type.SUBMITTED))
+            .build();
+        executionRepository.save(execution.withTaskRunList(Collections.singletonList(taskRun)));
+        var workerTaskResult = WorkerTaskResult.builder()
+            .taskRun(taskRun.withState(State.Type.SUCCESS))
+            .build();
+
+        workerTaskResultMessageHandler.handle(workerTaskResult);
+        var redelivered = workerTaskResultMessageHandler.handle(workerTaskResult);
+
+        // a redelivery of the already-joined result comes back empty and must not be billed again
+        assertThat(redelivered).isEmpty();
+        verify(workerTaskResultListener, times(1)).onJoined(eq(workerTaskResult), any());
+    }
+
+    @Test
+    void shouldKeepProcessingWhenListenerThrows() {
+        doThrow(new RuntimeException("boom")).when(workerTaskResultListener).onJoined(any(), any());
+        var flow = Fixtures.flow();
+        flowRepository.create(GenericFlow.of(flow));
+        var execution = Execution.newExecution(flow, Collections.emptyList());
+        var taskRun = TaskRun.builder()
+            .executionId(execution.getId())
+            .namespace(execution.getNamespace())
+            .flowId(execution.getFlowId())
+            .id("taskrun")
+            .taskId(flow.getTasks().getFirst().getId())
+            .state(new State().withState(State.Type.SUBMITTED))
+            .build();
+        executionRepository.save(execution.withTaskRunList(Collections.singletonList(taskRun)));
+        var workerTaskResult = WorkerTaskResult.builder()
+            .taskRun(taskRun.withState(State.Type.SUCCESS))
+            .build();
+
+        var maybeExecutor = workerTaskResultMessageHandler.handle(workerTaskResult);
+
+        // a throwing listener must not fail execution processing
+        assertThat(maybeExecutor).isPresent();
     }
 
     @Test
@@ -149,6 +224,7 @@ class WorkerTaskResultMessageHandlerTest {
 
         assertThat(result).isEmpty();
         verify(killSwitchActionService).handle(EvaluationType.IGNORE, execution.getTenantId(), execution.getId());
+        verify(workerTaskResultListener, never()).onJoined(any(), any());
     }
 
     @Test


### PR DESCRIPTION
  Add a WorkerTaskResultListener extension point so anything can react to joined worker task results without replacing the executor.

  - WorkerTaskResultMessageHandler now notifies registered WorkerTaskResultListener beans when a result is joined (present result); listener exceptions are logged and never fail execution processing.
  - No behavior change for OSS