### PR TITLE
feat(ai): rename the copilot "Build" mode label to "Edit"

### DIFF
--- a/ui/src/components/ai/copilot/CopilotComposer.vue
+++ b/ui/src/components/ai/copilot/CopilotComposer.vue
@@ -122,7 +122,7 @@
     import Microphone from "vue-material-design-icons/Microphone.vue"
     import Check from "vue-material-design-icons/Check.vue"
     import Close from "vue-material-design-icons/Close.vue"
-    // Per-mode icons taken from the UI-2.0 Figma: Build → wrench ("build"), Plan → map.
+    // Per-mode icons taken from the UI-2.0 Figma: Edit → wrench, Plan → map.
     // Ask isn't shown in that file, so we use a Q&A chat icon to match its read-only intent.
     import ChatQuestionOutline from "vue-material-design-icons/ChatQuestionOutline.vue"
     import Wrench from "vue-material-design-icons/Wrench.vue"
@@ -155,8 +155,7 @@
     const draft = defineModel<string>({default: ""})
     const textareaEl = ref<HTMLTextAreaElement>()
 
-    // Values are the backend Mode enum; labels follow the Figma wording
-    // (EDIT is surfaced as "Build"); icons match the Figma mode pills.
+    // Values are the backend Mode enum; icons match the Figma mode pills.
     const modeOptions = computed<{label: string; value: Mode; icon: Component}[]>(() => [
         {label: t("ai.copilot.mode.ask"), value: "ASK", icon: ChatQuestionOutline},
         {label: t("ai.copilot.mode.edit"), value: "EDIT", icon: Wrench},

--- a/ui/src/components/ai/copilot/types.ts
+++ b/ui/src/components/ai/copilot/types.ts
@@ -10,7 +10,7 @@
  * for the shapes the frontend exchanges with `…/ai/threads`.
  */
 
-/** Conversation mode. NOTE: the Figma design labels EDIT as "Build". */
+/** Conversation mode. */
 export type Mode = "ASK" | "EDIT" | "PLAN"
 
 /** The resting/working state of a thread — the single source of truth for what the UI may do next. */

--- a/ui/src/translations/de.json
+++ b/ui/src/translations/de.json
@@ -2014,7 +2014,7 @@
         "send": "Send",
         "mode": {
           "ask": "Ask",
-          "edit": "Build",
+          "edit": "Edit",
           "plan": "Plan"
         },
         "empty": {

--- a/ui/src/translations/en.json
+++ b/ui/src/translations/en.json
@@ -2014,7 +2014,7 @@
         "send": "Send",
         "mode": {
           "ask": "Ask",
-          "edit": "Build",
+          "edit": "Edit",
           "plan": "Plan"
         },
         "empty": {

--- a/ui/src/translations/es.json
+++ b/ui/src/translations/es.json
@@ -2014,7 +2014,7 @@
         "send": "Send",
         "mode": {
           "ask": "Ask",
-          "edit": "Build",
+          "edit": "Edit",
           "plan": "Plan"
         },
         "empty": {

--- a/ui/src/translations/fr.json
+++ b/ui/src/translations/fr.json
@@ -2014,7 +2014,7 @@
         "send": "Send",
         "mode": {
           "ask": "Ask",
-          "edit": "Build",
+          "edit": "Edit",
           "plan": "Plan"
         },
         "empty": {

--- a/ui/src/translations/hi.json
+++ b/ui/src/translations/hi.json
@@ -2014,7 +2014,7 @@
         "send": "Send",
         "mode": {
           "ask": "Ask",
-          "edit": "Build",
+          "edit": "Edit",
           "plan": "Plan"
         },
         "empty": {

--- a/ui/src/translations/it.json
+++ b/ui/src/translations/it.json
@@ -2014,7 +2014,7 @@
         "send": "Send",
         "mode": {
           "ask": "Ask",
-          "edit": "Build",
+          "edit": "Edit",
           "plan": "Plan"
         },
         "empty": {

--- a/ui/src/translations/ja.json
+++ b/ui/src/translations/ja.json
@@ -2014,7 +2014,7 @@
         "send": "Send",
         "mode": {
           "ask": "Ask",
-          "edit": "Build",
+          "edit": "Edit",
           "plan": "Plan"
         },
         "empty": {

--- a/ui/src/translations/ko.json
+++ b/ui/src/translations/ko.json
@@ -2014,7 +2014,7 @@
         "send": "Send",
         "mode": {
           "ask": "Ask",
-          "edit": "Build",
+          "edit": "Edit",
           "plan": "Plan"
         },
         "empty": {

--- a/ui/src/translations/pl.json
+++ b/ui/src/translations/pl.json
@@ -2014,7 +2014,7 @@
         "send": "Send",
         "mode": {
           "ask": "Ask",
-          "edit": "Build",
+          "edit": "Edit",
           "plan": "Plan"
         },
         "empty": {

--- a/ui/src/translations/pt.json
+++ b/ui/src/translations/pt.json
@@ -2014,7 +2014,7 @@
         "send": "Send",
         "mode": {
           "ask": "Ask",
-          "edit": "Build",
+          "edit": "Edit",
           "plan": "Plan"
         },
         "empty": {

--- a/ui/src/translations/pt_BR.json
+++ b/ui/src/translations/pt_BR.json
@@ -2014,7 +2014,7 @@
         "send": "Send",
         "mode": {
           "ask": "Ask",
-          "edit": "Build",
+          "edit": "Edit",
           "plan": "Plan"
         },
         "empty": {

--- a/ui/src/translations/ru.json
+++ b/ui/src/translations/ru.json
@@ -2014,7 +2014,7 @@
         "send": "Send",
         "mode": {
           "ask": "Ask",
-          "edit": "Build",
+          "edit": "Edit",
           "plan": "Plan"
         },
         "empty": {

--- a/ui/src/translations/zh_CN.json
+++ b/ui/src/translations/zh_CN.json
@@ -2014,7 +2014,7 @@
         "send": "Send",
         "mode": {
           "ask": "Ask",
-          "edit": "Build",
+          "edit": "Edit",
           "plan": "Plan"
         },
         "empty": {

--- a/ui/tests/e2e/ai-copilot.spec.ts
+++ b/ui/tests/e2e/ai-copilot.spec.ts
@@ -107,7 +107,7 @@ test.describe("AI Copilot", () => {
             })
         })
 
-        // Default mode is already Build (EDIT); the stub returns a proposal regardless of mode.
+        // Default mode is already Edit (EDIT); the stub returns a proposal regardless of mode.
         await page.locator(D.input).fill("restart my failed execution")
         await page.locator(D.send).click()
 

--- a/ui/tests/unit/components/ai/copilot/CopilotComposer.spec.ts
+++ b/ui/tests/unit/components/ai/copilot/CopilotComposer.spec.ts
@@ -10,9 +10,9 @@ const input = (w: ReturnType<typeof mountComposer>) => w.find("[data-test=\"copi
 const sendBtn = (w: ReturnType<typeof mountComposer>) => w.find("[data-test=\"copilot-send\"]")
 
 describe("CopilotComposer", () => {
-    it("offers the three modes with Figma labels (Build == EDIT)", () => {
+    it("offers the three modes (Ask / Edit / Plan)", () => {
         const labels = mountComposer().findAll(".ks-dropdown-item").map((b) => b.text())
-        expect(labels).toEqual(["Ask", "Build", "Plan"])
+        expect(labels).toEqual(["Ask", "Edit", "Plan"])
     })
 
     it("disables send until there is non-whitespace input", async () => {
@@ -48,7 +48,7 @@ describe("CopilotComposer", () => {
 
     it("relays mode changes from the dropdown via update:mode", async () => {
         const w = mountComposer()
-        // The dropdown items are Ask / Build / Plan; clicking "Plan" emits PLAN.
+        // The dropdown items are Ask / Edit / Plan; clicking "Plan" emits PLAN.
         await w.findAll(".ks-dropdown-item")[2].trigger("click")
         expect(w.emitted("update:mode")?.[0]).toEqual(["PLAN"])
     })


### PR DESCRIPTION
## What

The EDIT conversation mode was surfaced in the composer's mode selector as **"Build"** (the Figma wording). This renames the label to **"Edit"** so it matches the mode name.

- `ai.copilot.mode.edit`: `"Build"` → `"Edit"` in **all 13 locales** (kept English, consistent with the sibling `Ask` / `Plan` labels).
- Dropped the now-stale "EDIT is surfaced as Build" comments in `CopilotComposer.vue` and `types.ts`, and updated the test/comment references.

The composer placeholder copy ("Tell me what to build…") is intentionally left unchanged — it's a call-to-action sentence, not the mode label.

## Tests
- `CopilotComposer.spec` asserts the three mode labels are now `Ask` / `Edit` / `Plan`.
- 9/9 composer tests pass; lint + `translations:check` clean.

## Scope
Frontend-only. Shared with EE via the `kestra` alias, so no EE changes needed.