### PR TITLE
fix(ui): update KsId tooltip placement to support dynamic positioning

### DIFF
--- a/ui/packages/design-system/src/components/Data/KsId.vue
+++ b/ui/packages/design-system/src/components/Data/KsId.vue
@@ -20,6 +20,7 @@
         value?: string
         shrink?: boolean
         size?: number
+        /** Tooltip placement. Defaults to "top". */
         placement?: string
     }>(), {
         value: undefined,

--- a/ui/packages/design-system/src/components/Data/KsId.vue
+++ b/ui/packages/design-system/src/components/Data/KsId.vue
@@ -1,5 +1,5 @@
 <template>
-    <KsTooltip v-if="hasTooltip" placement="top">
+    <KsTooltip v-if="hasTooltip" :placement>
         <template #content>
             <code>{{ value }}</code>
         </template>
@@ -20,10 +20,12 @@
         value?: string
         shrink?: boolean
         size?: number
+        placement?: string
     }>(), {
         value: undefined,
         shrink: true,
         size: undefined,
+        placement: "top",
     })
 
     const emit = defineEmits<{

--- a/ui/src/components/executions/Executions.vue
+++ b/ui/src/components/executions/Executions.vue
@@ -162,7 +162,7 @@
                         }"
                         class="execution-id"
                     >
-                        <KsId :value="scope.row?.id" :shrink="true" />
+                        <KsId :value="scope.row?.id" :shrink="true" placement="right" />
                     </RouterLink>
                 </template>
             </KsTableColumn>


### PR DESCRIPTION
closes https://github.com/kestra-io/kestra-ee/issues/8963

This pull request introduces a minor enhancement to the `KsId` component, allowing the tooltip placement to be customized. The default placement is set to "top," but components using `KsId` can now override this. The only usage update in this PR sets the placement to "right" for execution IDs in the executions table.

Component improvements:

* [`ui/packages/design-system/src/components/Data/KsId.vue`](diffhunk://#diff-b27f3b80cee8c85393b45ee3909e1288f42ca255df9edd033313d110a7035943R23-R28): Added a `placement` prop to `KsId`, defaulting to "top", and passed it to the underlying `KsTooltip` for flexible tooltip positioning. [[1]](diffhunk://#diff-b27f3b80cee8c85393b45ee3909e1288f42ca255df9edd033313d110a7035943R23-R28) [[2]](diffhunk://#diff-b27f3b80cee8c85393b45ee3909e1288f42ca255df9edd033313d110a7035943L2-R2)

Usage update:

* [`ui/src/components/executions/Executions.vue`](diffhunk://#diff-22681d716f6b3d243636a73069e9798a16cd1ac7fd929a771d5607937afb3177L165-R165): Updated the executions table to display the execution ID tooltip on the right side by setting `placement="right"` on `KsId`.