### PR TITLE
feat(ai): apply an AI-drafted flow from the copilot

### DIFF
--- a/ui/src/components/ai/copilot/CopilotArtefactDraft.vue
+++ b/ui/src/components/ai/copilot/CopilotArtefactDraft.vue
@@ -23,9 +23,24 @@
         </KsAlert>
 
         <!-- The drafted YAML — read-only, syntax-highlighted preview (nothing is saved).
-             KsMarkdown provides its own copy-to-clipboard control, so no separate copy button.
-             A one-click "apply" (load into the flow editor) arrives with the flow-editor cutover. -->
+             KsMarkdown provides its own copy-to-clipboard control, so no separate copy button. -->
         <KsMarkdown class="copilot-draft-yaml" data-test="copilot-draft-yaml" :content="yamlBlock" />
+
+        <!-- Apply actions (flow drafts only): review in the editor, or save it directly. -->
+        <div v-if="draft.kind === 'FLOW'" class="copilot-draft-footer">
+            <KsButton size="small" data-test="copilot-draft-open" @click="openInEditor(draft)">
+                {{ t("ai.copilot.draft.openInEditor") }}
+            </KsButton>
+            <KsButton
+                size="small"
+                type="primary"
+                :disabled="!draft.valid || applying"
+                data-test="copilot-draft-apply"
+                @click="apply(draft)"
+            >
+                {{ t("ai.copilot.draft.apply") }}
+            </KsButton>
+        </div>
     </div>
 </template>
 
@@ -33,11 +48,13 @@
     import {computed} from "vue"
     import {useI18n} from "vue-i18n"
     import FileDocumentOutline from "vue-material-design-icons/FileDocumentOutline.vue"
+    import {useApplyDraft} from "./useApplyDraft"
     import type {ArtefactDraftEvent} from "./types"
 
     const props = defineProps<{draft: ArtefactDraftEvent}>()
 
     const {t} = useI18n()
+    const {applying, openInEditor, apply} = useApplyDraft()
 
     // Render the YAML as a fenced code block so KsMarkdown syntax-highlights it (matching the
     // assistant transcript), rather than showing it as flat monospace text.
@@ -80,5 +97,13 @@
         overflow: auto;
         padding: var(--ks-spacing-3);
         font-size: var(--ks-font-size-sm);
+    }
+
+    .copilot-draft-footer {
+        display: flex;
+        justify-content: flex-end;
+        gap: var(--ks-spacing-2);
+        padding: var(--ks-spacing-2) var(--ks-spacing-3);
+        background: var(--ks-bg-elevated);
     }
 </style>

--- a/ui/src/components/ai/copilot/useApplyDraft.ts
+++ b/ui/src/components/ai/copilot/useApplyDraft.ts
@@ -1,0 +1,99 @@
+import {ref} from "vue"
+import {useRoute, useRouter} from "vue-router"
+import {useI18n} from "vue-i18n"
+import {KsMessageBox} from "@kestra-io/design-system"
+import {flowYamlUtils as YAML_UTILS} from "@kestra-io/topology"
+import * as FlowsAPI from "@kestra-io/kestra-sdk/flows"
+import type {ArtefactDraftEvent} from "./types"
+
+/**
+ * Actions for an AI-drafted artefact:
+ *   - `openInEditor` — hand the drafted YAML to the flow-creation editor to review + save there.
+ *   - `apply` — create (or update) the flow directly, behind a confirm.
+ *
+ * Flow-only for now: apps have no OSS editor and dashboards use a separate store (future work).
+ */
+export function useApplyDraft() {
+    const route = useRoute()
+    const router = useRouter()
+    const {t} = useI18n()
+
+    /** True while a direct apply is in flight (disables the button). */
+    const applying = ref(false)
+
+    /**
+     * (A) Open the drafted YAML in the flow-creation editor. Reuses the same `blueprintSourceYaml`
+     * handoff the "Use blueprint" / MCP-tool flows use — FlowCreate.vue seeds the editor from it.
+     */
+    function openInEditor(draft: ArtefactDraftEvent): void {
+        router.push({
+            name: "flows/create",
+            query: {blueprintId: "copilot-draft", blueprintSourceYaml: draft.yaml},
+            ...(route.params.tenant ? {params: {tenant: route.params.tenant}} : {}),
+        })
+    }
+
+    /** (B) Create or update the flow directly. Confirms first; wording depends on whether it exists. */
+    async function apply(draft: ArtefactDraftEvent): Promise<void> {
+        const {namespace, id} = parseFlowId(draft.yaml)
+        if (!namespace || !id) {
+            await KsMessageBox.alert(t("ai.copilot.draft.applyNoTarget"), t("ai.copilot.draft.applyTitle"), {type: "error"})
+            return
+        }
+
+        const confirmed = await KsMessageBox.confirm(
+            t("ai.copilot.draft.applyConfirm", {namespace, id}),
+            t("ai.copilot.draft.applyTitle"),
+            {type: "warning", confirmButtonText: t("ai.copilot.draft.apply"), cancelButtonText: t("cancel")},
+        ).then(() => true).catch(() => false)
+        if (!confirmed) return
+
+        applying.value = true
+        try {
+            // Try to create; if the flow already exists, update it instead. We deliberately don't
+            // probe with a GET first — a 404 on a not-yet-existing flow trips the global error page.
+            try {
+                await FlowsAPI.createFlow(
+                    {body: draft.yaml, draft: false, showMessageOnError: false} as Parameters<typeof FlowsAPI.createFlow>[0],
+                )
+            } catch (e) {
+                if (!isAlreadyExists(e)) throw e
+                await FlowsAPI.updateFlow(
+                    {namespace, id, body: draft.yaml, showMessageOnError: false} as Parameters<typeof FlowsAPI.updateFlow>[0],
+                )
+            }
+            // Land on the applied flow so the result is visible.
+            router.push({
+                name: "flows/update",
+                params: {namespace, id, ...(route.params.tenant ? {tenant: route.params.tenant} : {})},
+            })
+        } catch (e) {
+            const err = e as {response?: {data?: {message?: string}}; message?: string}
+            await KsMessageBox.alert(
+                err?.response?.data?.message ?? err?.message ?? t("ai.copilot.draft.applyError"),
+                t("ai.copilot.draft.applyTitle"),
+                {type: "error"},
+            )
+        } finally {
+            applying.value = false
+        }
+    }
+
+    /** Parse the flow's namespace + id out of its YAML; empty strings when it can't be read. */
+    function parseFlowId(yaml: string): {namespace: string; id: string} {
+        try {
+            const parsed = YAML_UTILS.parse(yaml)
+            return {namespace: parsed?.namespace ?? "", id: parsed?.id ?? ""}
+        } catch {
+            return {namespace: "", id: ""}
+        }
+    }
+
+    /** A create failed because the flow already exists (→ update instead), mirroring the flow store. */
+    function isAlreadyExists(e: unknown): boolean {
+        const err = e as {response?: {status?: number; data?: {message?: string}}}
+        return err?.response?.status === 422 && !!err?.response?.data?.message?.includes("Flow id already exists")
+    }
+
+    return {applying, openInEditor, apply}
+}

--- a/ui/src/translations/de.json
+++ b/ui/src/translations/de.json
@@ -2099,6 +2099,12 @@
         "recents": "Recents",
         "recentsEmpty": "No recent conversations yet",
         "draft": {
+          "openInEditor": "Im Editor öffnen",
+          "apply": "Anwenden",
+          "applyTitle": "Flow anwenden",
+          "applyConfirm": "Den flow {namespace}.{id} anwenden? Er wird erstellt oder überschrieben, falls er bereits existiert.",
+          "applyError": "Der flow konnte nicht angewendet werden. Bitte versuchen Sie es erneut.",
+          "applyNoTarget": "Dieser Entwurf hat keinen namespace oder keine id zum Anwenden.",
           "title": {
             "flow": "Proposed flow",
             "dashboard": "Proposed dashboard",

--- a/ui/src/translations/en.json
+++ b/ui/src/translations/en.json
@@ -2099,6 +2099,12 @@
         "recents": "Recents",
         "recentsEmpty": "No recent conversations yet",
         "draft": {
+          "openInEditor": "Open in editor",
+          "apply": "Apply",
+          "applyTitle": "Apply flow",
+          "applyConfirm": "Apply the flow {namespace}.{id}? It will be created, or overwritten if it already exists.",
+          "applyError": "Couldn't apply the flow. Please try again.",
+          "applyNoTarget": "This draft has no namespace or id to apply.",
           "title": {
             "flow": "Proposed flow",
             "dashboard": "Proposed dashboard",

--- a/ui/src/translations/es.json
+++ b/ui/src/translations/es.json
@@ -2099,6 +2099,12 @@
         "recents": "Recents",
         "recentsEmpty": "No recent conversations yet",
         "draft": {
+          "openInEditor": "Abrir en el editor",
+          "apply": "Aplicar",
+          "applyTitle": "Aplicar flow",
+          "applyConfirm": "¿Aplicar el flow {namespace}.{id}? Se creará, o se sobrescribirá si ya existe.",
+          "applyError": "No se pudo aplicar el flow. Inténtalo de nuevo.",
+          "applyNoTarget": "Este borrador no tiene namespace ni id para aplicar.",
           "title": {
             "flow": "Proposed flow",
             "dashboard": "Proposed dashboard",

--- a/ui/src/translations/fr.json
+++ b/ui/src/translations/fr.json
@@ -2099,6 +2099,12 @@
         "recents": "Recents",
         "recentsEmpty": "No recent conversations yet",
         "draft": {
+          "openInEditor": "Ouvrir dans l'éditeur",
+          "apply": "Appliquer",
+          "applyTitle": "Appliquer le flow",
+          "applyConfirm": "Appliquer le flow {namespace}.{id} ? Il sera créé, ou écrasé s'il existe déjà.",
+          "applyError": "Impossible d'appliquer le flow. Veuillez réessayer.",
+          "applyNoTarget": "Ce brouillon n'a pas de namespace ni d'id à appliquer.",
           "title": {
             "flow": "Proposed flow",
             "dashboard": "Proposed dashboard",

--- a/ui/src/translations/hi.json
+++ b/ui/src/translations/hi.json
@@ -2099,6 +2099,12 @@
         "recents": "Recents",
         "recentsEmpty": "No recent conversations yet",
         "draft": {
+          "openInEditor": "एडिटर में खोलें",
+          "apply": "लागू करें",
+          "applyTitle": "flow लागू करें",
+          "applyConfirm": "flow {namespace}.{id} लागू करें? यह बनाया जाएगा, या यदि यह पहले से मौजूद है तो अधिलेखित किया जाएगा।",
+          "applyError": "flow लागू नहीं किया जा सका। कृपया पुनः प्रयास करें।",
+          "applyNoTarget": "इस ड्राफ्ट में लागू करने के लिए कोई namespace या id नहीं है।",
           "title": {
             "flow": "Proposed flow",
             "dashboard": "Proposed dashboard",

--- a/ui/src/translations/it.json
+++ b/ui/src/translations/it.json
@@ -2099,6 +2099,12 @@
         "recents": "Recents",
         "recentsEmpty": "No recent conversations yet",
         "draft": {
+          "openInEditor": "Apri nell'editor",
+          "apply": "Applica",
+          "applyTitle": "Applica flow",
+          "applyConfirm": "Applicare il flow {namespace}.{id}? Verrà creato oppure sovrascritto se esiste già.",
+          "applyError": "Impossibile applicare il flow. Riprova.",
+          "applyNoTarget": "Questa bozza non ha namespace o id da applicare.",
           "title": {
             "flow": "Proposed flow",
             "dashboard": "Proposed dashboard",

--- a/ui/src/translations/ja.json
+++ b/ui/src/translations/ja.json
@@ -2099,6 +2099,12 @@
         "recents": "Recents",
         "recentsEmpty": "No recent conversations yet",
         "draft": {
+          "openInEditor": "エディターで開く",
+          "apply": "適用",
+          "applyTitle": "flow を適用",
+          "applyConfirm": "flow {namespace}.{id} を適用しますか？作成されます。既に存在する場合は上書きされます。",
+          "applyError": "flow を適用できませんでした。もう一度お試しください。",
+          "applyNoTarget": "この下書きには適用する namespace または id がありません。",
           "title": {
             "flow": "Proposed flow",
             "dashboard": "Proposed dashboard",

--- a/ui/src/translations/ko.json
+++ b/ui/src/translations/ko.json
@@ -2099,6 +2099,12 @@
         "recents": "Recents",
         "recentsEmpty": "No recent conversations yet",
         "draft": {
+          "openInEditor": "편집기에서 열기",
+          "apply": "적용",
+          "applyTitle": "flow 적용",
+          "applyConfirm": "{namespace}.{id} flow를 적용하시겠습니까? 생성되며, 이미 존재하는 경우 덮어씁니다.",
+          "applyError": "flow를 적용할 수 없습니다. 다시 시도해 주세요.",
+          "applyNoTarget": "이 초안에는 적용할 namespace 또는 id가 없습니다.",
           "title": {
             "flow": "Proposed flow",
             "dashboard": "Proposed dashboard",

--- a/ui/src/translations/pl.json
+++ b/ui/src/translations/pl.json
@@ -2099,6 +2099,12 @@
         "recents": "Recents",
         "recentsEmpty": "No recent conversations yet",
         "draft": {
+          "openInEditor": "Otwórz w edytorze",
+          "apply": "Zastosuj",
+          "applyTitle": "Zastosuj flow",
+          "applyConfirm": "Zastosować flow {namespace}.{id}? Zostanie utworzony lub nadpisany, jeśli już istnieje.",
+          "applyError": "Nie udało się zastosować flow. Spróbuj ponownie.",
+          "applyNoTarget": "Ten szkic nie ma namespace ani id do zastosowania.",
           "title": {
             "flow": "Proposed flow",
             "dashboard": "Proposed dashboard",

--- a/ui/src/translations/pt.json
+++ b/ui/src/translations/pt.json
@@ -2099,6 +2099,12 @@
         "recents": "Recents",
         "recentsEmpty": "No recent conversations yet",
         "draft": {
+          "openInEditor": "Abrir no editor",
+          "apply": "Aplicar",
+          "applyTitle": "Aplicar flow",
+          "applyConfirm": "Aplicar o flow {namespace}.{id}? Ele será criado ou substituído se já existir.",
+          "applyError": "Não foi possível aplicar o flow. Tente novamente.",
+          "applyNoTarget": "Este rascunho não tem namespace nem id para aplicar.",
           "title": {
             "flow": "Proposed flow",
             "dashboard": "Proposed dashboard",

--- a/ui/src/translations/pt_BR.json
+++ b/ui/src/translations/pt_BR.json
@@ -2099,6 +2099,12 @@
         "recents": "Recents",
         "recentsEmpty": "No recent conversations yet",
         "draft": {
+          "openInEditor": "Abrir no editor",
+          "apply": "Aplicar",
+          "applyTitle": "Aplicar flow",
+          "applyConfirm": "Aplicar o flow {namespace}.{id}? Ele será criado ou substituído se já existir.",
+          "applyError": "Não foi possível aplicar o flow. Tente novamente.",
+          "applyNoTarget": "Este rascunho não tem namespace nem id para aplicar.",
           "title": {
             "flow": "Proposed flow",
             "dashboard": "Proposed dashboard",

--- a/ui/src/translations/ru.json
+++ b/ui/src/translations/ru.json
@@ -2099,6 +2099,12 @@
         "recents": "Recents",
         "recentsEmpty": "No recent conversations yet",
         "draft": {
+          "openInEditor": "Открыть в редакторе",
+          "apply": "Применить",
+          "applyTitle": "Применить flow",
+          "applyConfirm": "Применить flow {namespace}.{id}? Он будет создан или перезаписан, если уже существует.",
+          "applyError": "Не удалось применить flow. Пожалуйста, попробуйте снова.",
+          "applyNoTarget": "В этом черновике нет namespace или id для применения.",
           "title": {
             "flow": "Proposed flow",
             "dashboard": "Proposed dashboard",

--- a/ui/src/translations/zh_CN.json
+++ b/ui/src/translations/zh_CN.json
@@ -2099,6 +2099,12 @@
         "recents": "Recents",
         "recentsEmpty": "No recent conversations yet",
         "draft": {
+          "openInEditor": "在编辑器中打开",
+          "apply": "应用",
+          "applyTitle": "应用 flow",
+          "applyConfirm": "应用 flow {namespace}.{id} 吗？将创建它；如果已存在则覆盖。",
+          "applyError": "无法应用 flow。请重试。",
+          "applyNoTarget": "此草稿没有可应用的 namespace 或 id。",
           "title": {
             "flow": "Proposed flow",
             "dashboard": "Proposed dashboard",

--- a/ui/tests/unit/components/ai/copilot/CopilotArtefactDraft.spec.ts
+++ b/ui/tests/unit/components/ai/copilot/CopilotArtefactDraft.spec.ts
@@ -1,5 +1,14 @@
-import {describe, it, expect} from "vitest"
+import {describe, it, expect, vi} from "vitest"
 import {mount} from "@vue/test-utils"
+import {ref} from "vue"
+
+// Stub the apply composable (it pulls in the router + flows SDK); assert wiring only.
+const openInEditor = vi.fn()
+const apply = vi.fn()
+vi.mock("../../../../../src/components/ai/copilot/useApplyDraft", () => ({
+    useApplyDraft: () => ({applying: ref(false), openInEditor, apply}),
+}))
+
 import CopilotArtefactDraft from "../../../../../src/components/ai/copilot/CopilotArtefactDraft.vue"
 import {mountGlobal} from "./_helpers"
 import type {ArtefactDraftEvent} from "../../../../../src/components/ai/copilot/types"
@@ -32,5 +41,27 @@ describe("CopilotArtefactDraft", () => {
         const w = mountDraft({draftId: "d3", kind: "APP", yaml: "id: my-app", valid: true, constraints: null})
         expect(w.find("[data-test=\"copilot-draft-copy\"]").exists()).toBe(false)
         expect(w.find("[data-test=\"copilot-draft-yaml\"]").text()).toContain("id: my-app")
+    })
+
+    it("offers Open-in-editor + Apply for a valid flow draft and wires them", async () => {
+        const w = mountDraft({draftId: "d4", kind: "FLOW", yaml: "id: f", valid: true, constraints: null})
+        await w.find("[data-test=\"copilot-draft-open\"]").trigger("click")
+        expect(openInEditor).toHaveBeenCalled()
+        const applyBtn = w.find("[data-test=\"copilot-draft-apply\"]")
+        expect(applyBtn.attributes("disabled")).toBeUndefined()
+        await applyBtn.trigger("click")
+        expect(apply).toHaveBeenCalled()
+    })
+
+    it("disables Apply for an invalid flow draft (Open-in-editor stays available)", () => {
+        const w = mountDraft({draftId: "d5", kind: "FLOW", yaml: "id: f", valid: false, constraints: "bad"})
+        expect(w.find("[data-test=\"copilot-draft-apply\"]").attributes("disabled")).toBeDefined()
+        expect(w.find("[data-test=\"copilot-draft-open\"]").exists()).toBe(true)
+    })
+
+    it("shows no apply actions for non-flow drafts (dashboard/app)", () => {
+        const w = mountDraft({draftId: "d6", kind: "DASHBOARD", yaml: "x: 1", valid: true, constraints: null})
+        expect(w.find("[data-test=\"copilot-draft-open\"]").exists()).toBe(false)
+        expect(w.find("[data-test=\"copilot-draft-apply\"]").exists()).toBe(false)
     })
 })

--- a/ui/tests/unit/components/ai/copilot/useApplyDraft.spec.ts
+++ b/ui/tests/unit/components/ai/copilot/useApplyDraft.spec.ts
@@ -1,0 +1,95 @@
+import {describe, it, expect, vi, beforeEach} from "vitest"
+
+// --- mocks (hoisted) ---
+const push = vi.fn()
+let routeParams: Record<string, any> = {}
+vi.mock("vue-router", () => ({
+    useRouter: () => ({push}),
+    useRoute: () => ({params: routeParams}),
+}))
+vi.mock("vue-i18n", () => ({useI18n: () => ({t: (k: string) => k})}))
+
+const confirm = vi.fn()
+const alert = vi.fn().mockResolvedValue(undefined)
+vi.mock("@kestra-io/design-system", () => ({KsMessageBox: {confirm: (...a: unknown[]) => confirm(...a), alert: (...a: unknown[]) => alert(...a)}}))
+
+let parsed: {namespace?: string; id?: string} = {}
+vi.mock("@kestra-io/topology", () => ({flowYamlUtils: {parse: () => parsed}}))
+
+const createFlow = vi.fn().mockResolvedValue({})
+const updateFlow = vi.fn().mockResolvedValue({})
+vi.mock("@kestra-io/kestra-sdk/flows", () => ({
+    createFlow: (...a: unknown[]) => createFlow(...a),
+    updateFlow: (...a: unknown[]) => updateFlow(...a),
+}))
+
+// A create rejection shaped like the backend's "already exists" 422.
+const alreadyExists = {response: {status: 422, data: {message: "Flow id already exists: my-flow"}}}
+
+import {useApplyDraft} from "../../../../../src/components/ai/copilot/useApplyDraft"
+
+const draft = (over = {}) => ({draftId: "d1", kind: "FLOW" as const, yaml: "id: my-flow\nnamespace: company.team", valid: true, constraints: null, ...over})
+
+describe("useApplyDraft", () => {
+    beforeEach(() => {
+        vi.clearAllMocks()
+        routeParams = {tenant: "main"}
+        parsed = {namespace: "company.team", id: "my-flow"}
+        alert.mockResolvedValue(undefined)
+        createFlow.mockResolvedValue({})
+        updateFlow.mockResolvedValue({})
+    })
+
+    it("openInEditor pushes flows/create with the drafted YAML as blueprintSourceYaml", () => {
+        useApplyDraft().openInEditor(draft())
+        expect(push).toHaveBeenCalledWith(expect.objectContaining({
+            name: "flows/create",
+            query: {blueprintId: "copilot-draft", blueprintSourceYaml: "id: my-flow\nnamespace: company.team"},
+            params: {tenant: "main"},
+        }))
+    })
+
+    it("apply CREATES the flow, then navigates to it", async () => {
+        confirm.mockResolvedValueOnce(undefined) // user confirms
+        await useApplyDraft().apply(draft())
+        expect(createFlow).toHaveBeenCalledWith(expect.objectContaining({body: "id: my-flow\nnamespace: company.team"}))
+        expect(updateFlow).not.toHaveBeenCalled()
+        // On success it navigates to the applied flow.
+        expect(push).toHaveBeenCalledWith(expect.objectContaining({
+            name: "flows/update",
+            params: {namespace: "company.team", id: "my-flow", tenant: "main"},
+        }))
+    })
+
+    it("apply UPDATES the flow when create reports it already exists", async () => {
+        confirm.mockResolvedValueOnce(undefined)
+        createFlow.mockRejectedValueOnce(alreadyExists) // create → 422 already exists → fall back to update
+        await useApplyDraft().apply(draft())
+        expect(updateFlow).toHaveBeenCalledWith(expect.objectContaining({namespace: "company.team", id: "my-flow", body: "id: my-flow\nnamespace: company.team"}))
+        expect(push).toHaveBeenCalledWith(expect.objectContaining({name: "flows/update"}))
+    })
+
+    it("apply surfaces an error (no update) when create fails for another reason", async () => {
+        confirm.mockResolvedValueOnce(undefined)
+        createFlow.mockRejectedValueOnce({response: {status: 422, data: {message: "invalid flow: bad task"}}})
+        await useApplyDraft().apply(draft())
+        expect(updateFlow).not.toHaveBeenCalled()
+        expect(alert).toHaveBeenCalled()
+        expect(push).not.toHaveBeenCalled()
+    })
+
+    it("apply does nothing when the confirm is cancelled", async () => {
+        confirm.mockRejectedValueOnce(new Error("cancel")) // user cancels
+        await useApplyDraft().apply(draft())
+        expect(createFlow).not.toHaveBeenCalled()
+        expect(updateFlow).not.toHaveBeenCalled()
+    })
+
+    it("apply alerts and skips confirm when the draft has no namespace/id", async () => {
+        parsed = {} // no namespace/id parsed from the YAML
+        await useApplyDraft().apply(draft({yaml: "not: a-flow"}))
+        expect(alert).toHaveBeenCalled()
+        expect(confirm).not.toHaveBeenCalled()
+        expect(createFlow).not.toHaveBeenCalled()
+    })
+})


### PR DESCRIPTION
## What

The flow artefact-draft card was preview-only. It now offers two ways to act on a drafted flow:

- **Open in editor** — hands the drafted YAML to the flow-creation editor (reuses the same `blueprintSourceYaml` handoff as "Use blueprint" / MCP-tool creation), so you review + save it there. Available even for invalid drafts.
- **Apply** — creates the flow directly, behind a `KsMessageBox` confirm. If a flow with that id already exists, it updates it instead. On success it navigates to the flow. **Disabled for invalid drafts.**

## Notes / decisions
- **No existence probe.** A `GET /flows/{ns}/{id}` for a not-yet-existing flow returns 404, and the global axios handler ([`kestraAxios.ts`](kestra/ui/src/utils/kestraAxios.ts)) routes *any* 404 to the error page (no per-request opt-out) — which caused a brief 404 flash. So Apply tries `createFlow` and falls back to `updateFlow` on the backend's **422 "Flow id already exists"** (same detection the flow store uses). `createFlow`/`updateFlow` run with `showMessageOnError: false`, so failures surface only through the card's own alert.
- **Flow-only** for now: apps have no OSS editor; dashboards use a separate store (follow-up).
- Logic lives in a `useApplyDraft` composable; the card stays presentational.

## Tests
- `useApplyDraft.spec` — create→navigate, create→422→update, other-error→alert, cancel, no-namespace/id.
- `CopilotArtefactDraft.spec` — footer shows for FLOW only, Apply disabled when invalid, both buttons wired.
- 106/106 copilot unit tests pass; lint + type-check + `translations:check` clean. New `ai.copilot.draft.*` keys in all 13 locales ("flow"/"namespace"/"id" kept English per the reserved-terms rule).

## ⚠️ Worth a live smoke
Apply writes to the instance (create/update). The 404-flash is resolved by construction, but a manual smoke once a dev server is up is worth it.

## Scope
Frontend-only. Shared with EE via the `kestra` alias, so no EE changes needed.