### PR TITLE
refactor(stores): migrate remaining Pinia stores to setup syntax

### DIFF
--- a/ui/src/stores/api.ts
+++ b/ui/src/stores/api.ts
@@ -1,6 +1,7 @@
 import axios from "axios"
 import cloneDeep from "lodash/cloneDeep"
 import {defineStore} from "pinia"
+import {ref} from "vue"
 import {useMiscStore} from "override/stores/misc"
 import {capturePosthogEvent, disablePosthog} from "../utils/posthog"
 import {ensureUid} from "../utils/uid"
@@ -41,12 +42,6 @@ interface EventsOptions {
 
 type Configs = Record<string, any>;
 
-interface State {
-    feeds: Feed[];
-    version: string | undefined;
-    apiConfig: any;
-}
-
 let counter = 0
 
 const pendingEvents = new PendingEventsBuffer<EventData, EventsOptions>({
@@ -83,146 +78,155 @@ function buildEventPayload(data: EventData, configs: Configs, uid: string) {
     return {mergeData, backendData}
 }
 
-export const useApiStore = defineStore("api", {
-    state: (): State => ({
-        feeds: [],
-        version: undefined,
-        apiConfig: undefined,
-    }),
+export const useApiStore = defineStore("api", () => {
+    const feeds = ref<Feed[]>([])
+    const version = ref<string | undefined>(undefined)
+    const apiConfig = ref<any>(undefined)
 
-    actions: {
-        async loadFeeds(options: { iid: string; uid: string; version: string }) {
-            const response = await axios.get<FeedResponse>(`${API_URL}/v1/feeds`, {
-                withCredentials: true,
-                params: {
-                    iid: options.iid,
-                    uid: options.uid,
-                    version: options.version,
-                },
-            })
+    async function loadFeeds(options: { iid: string; uid: string; version: string }) {
+        const response = await axios.get<FeedResponse>(`${API_URL}/v1/feeds`, {
+            withCredentials: true,
+            params: {
+                iid: options.iid,
+                uid: options.uid,
+                version: options.version,
+            },
+        })
 
-            this.feeds = response.data.feeds
-            this.version = response.data.version
+        feeds.value = response.data.feeds
+        version.value = response.data.version
 
-            return response.data
-        },
+        return response.data
+    }
 
-        async loadConfig() {
-            const response = await axios.get(`${API_URL}/v1/config`, {
-                withCredentials: true,
-            })
+    async function loadConfig() {
+        const response = await axios.get(`${API_URL}/v1/config`, {
+            withCredentials: true,
+        })
 
-            this.apiConfig = response.data
-            return response.data
-        },
+        apiConfig.value = response.data
+        return response.data
+    }
 
-        async flushQueuedEvents() {
-            const miscStore = useMiscStore()
-            const configs = miscStore.configs
+    async function flushQueuedEvents() {
+        const miscStore = useMiscStore()
+        const configs = miscStore.configs
 
-            // Can't decide yet.
-            if (configs === undefined) return
+        // Can't decide yet.
+        if (configs === undefined) return
 
-            // Analytics disabled: drop queued events.
-            if (analyticsDisabled(configs)) {
-                pendingEvents.clear()
-                return
+        // Analytics disabled: drop queued events.
+        if (analyticsDisabled(configs)) {
+            pendingEvents.clear()
+            return
+        }
+
+        // Ensure uid exists now that we know analytics is enabled.
+        const uid = ensureUid()
+
+        const toFlush = pendingEvents.drain()
+        for (const item of toFlush) {
+            try {
+                await sendEventNow(item.data, item.options, configs, uid)
+            } catch {
+                // Best-effort flush: keep draining even if a send fails.
             }
+        }
+    }
 
-            // Ensure uid exists now that we know analytics is enabled.
-            const uid = ensureUid()
+    async function events(data: EventData, options: EventsOptions = {}) {
+        const miscStore = useMiscStore()
+        const configs = miscStore.configs
 
-            const toFlush = pendingEvents.drain()
-            for (const item of toFlush) {
+        // If configs aren't ready yet, buffer and replay later.
+        if (configs === undefined) {
+            pendingEvents.enqueue(data, options)
+            return
+        }
+
+        if (analyticsDisabled(configs)) {
+            pendingEvents.clear()
+            return
+        }
+
+        const uid = ensureUid()
+
+        return sendEventNow(data, options, configs, uid)
+    }
+
+    async function sendEventNow(data: EventData, options: EventsOptions, configs: Configs, uid: string) {
+        const {mergeData, backendData} = buildEventPayload(data, configs, uid)
+
+        if (options.posthog !== false) {
+            posthogEvents(mergeData)
+        }
+
+        // Configs are loaded: flush any buffered events best-effort.
+        if (pendingEvents.length > 0) {
+            void flushQueuedEvents()
+        }
+
+        return axios.post(`${API_URL}/v1/reports/events`, backendData, {
+            withCredentials: true,
+        })
+    }
+
+    function posthogEvents(data: EventData & { date?: string; counter?: number }) {
+        const miscStore = useMiscStore()
+        const configs = miscStore.configs
+        if (configs?.isUiAnonymousUsageEnabled === false) {
+            disablePosthog()
+            return
+        }
+
+        const type = data.type
+        const finalData: Partial<EventData> = cloneDeep(data)
+
+        delete finalData.type
+        delete finalData.date
+        delete finalData.counter
+
+        const eventName = type === "PAGE" ? "$pageview" : data.type.toLowerCase()
+
+        if (type === "PAGE") {
+            const origin = data.page?.origin ?? window.location.origin
+            const path = data.page?.path ?? window.location.pathname
+            const host = (() => {
                 try {
-                    await this.sendEventNow(item.data, item.options, configs, uid)
+                    return new URL(origin).host
                 } catch {
-                    // Best-effort flush: keep draining even if a send fails.
+                    return window.location.host
                 }
-            }
-        },
+            })()
+            const fullPath = data.page?.fullPath
+            const currentUrl = fullPath ? `${origin}${fullPath}` : `${origin}${path}`;
 
-        async events(data: EventData, options: EventsOptions = {}) {
-            const miscStore = useMiscStore()
-            const configs = miscStore.configs
+            (finalData as any).$current_url = currentUrl;
+            (finalData as any).$pathname = path;
+            (finalData as any).$host = host;
+            (finalData as any).$title = document.title
+        }
 
-            // If configs aren't ready yet, buffer and replay later.
-            if (configs === undefined) {
-                pendingEvents.enqueue(data, options)
-                return
-            }
+        capturePosthogEvent(configs, eventName, finalData as Record<string, any>)
+    }
 
-            if (analyticsDisabled(configs)) {
-                pendingEvents.clear()
-                return
-            }
+    async function pluginsInformation() {
+        return axios.get<{byPlugin: Record<string, {lastReleasedAt?: string; usageCount?: number}>}>(
+            `${API_URL}/v1/plugins/pluginsInformation?icons=false`,
+            {withCredentials: true},
+        )
+    }
 
-            const uid = ensureUid()
-
-            return this.sendEventNow(data, options, configs, uid)
-        },
-
-        async sendEventNow(data: EventData, options: EventsOptions, configs: Configs, uid: string) {
-            const {mergeData, backendData} = buildEventPayload(data, configs, uid)
-
-            if (options.posthog !== false) {
-                this.posthogEvents(mergeData)
-            }
-
-            // Configs are loaded: flush any buffered events best-effort.
-            if (pendingEvents.length > 0) {
-                void this.flushQueuedEvents()
-            }
-
-            return axios.post(`${API_URL}/v1/reports/events`, backendData, {
-                withCredentials: true,
-            })
-        },
-
-        posthogEvents(data: EventData & { date?: string; counter?: number }) {
-            const miscStore = useMiscStore()
-            const configs = miscStore.configs
-            if (configs?.isUiAnonymousUsageEnabled === false) {
-                disablePosthog()
-                return
-            }
-
-            const type = data.type
-            const finalData: Partial<EventData> = cloneDeep(data)
-
-            delete finalData.type
-            delete finalData.date
-            delete finalData.counter
-
-            const eventName = type === "PAGE" ? "$pageview" : data.type.toLowerCase()
-
-            if (type === "PAGE") {
-                const origin = data.page?.origin ?? window.location.origin
-                const path = data.page?.path ?? window.location.pathname
-                const host = (() => {
-                    try {
-                        return new URL(origin).host
-                    } catch {
-                        return window.location.host
-                    }
-                })()
-                const fullPath = data.page?.fullPath
-                const currentUrl = fullPath ? `${origin}${fullPath}` : `${origin}${path}`;
-
-                (finalData as any).$current_url = currentUrl;
-                (finalData as any).$pathname = path;
-                (finalData as any).$host = host;
-                (finalData as any).$title = document.title
-            }
-
-            capturePosthogEvent(configs, eventName, finalData as Record<string, any>)
-        },
-
-        async pluginsInformation() {
-            return axios.get<{byPlugin: Record<string, {lastReleasedAt?: string; usageCount?: number}>}>(
-                `${API_URL}/v1/plugins/pluginsInformation?icons=false`,
-                {withCredentials: true},
-            )
-        },
-    },
+    return {
+        feeds,
+        version,
+        apiConfig,
+        loadFeeds,
+        loadConfig,
+        flushQueuedEvents,
+        events,
+        sendEventNow,
+        posthogEvents,
+        pluginsInformation,
+    }
 })

--- a/ui/src/stores/bookmarks.ts
+++ b/ui/src/stores/bookmarks.ts
@@ -1,4 +1,5 @@
 import {defineStore} from "pinia"
+import {ref} from "vue"
 
 const LOCAL_STORAGE_KEY = "starred.bookmarks"
 
@@ -8,46 +9,46 @@ interface Page {
     label?: string;
 }
 
-interface State {
-    pages: Array<Page>;
-}
+export const useBookmarksStore = defineStore("bookmarks", () => {
+    const pages = ref<Page[]>(JSON.parse(initialPages))
 
-export const useBookmarksStore = defineStore("bookmarks", {
-    state: (): State => ({
-        pages: JSON.parse(initialPages),
-    }),
+    function add(page: Page ) {
+        const currentPages = pages.value
+        if (!currentPages.find(p => p.path === page.path)) {
+            currentPages.push(page)
+            updateAll(currentPages)
+        }
+    }
+    function remove(page: Page) {
+        const currentPages = pages.value
+        const index = currentPages.findIndex(p => p.path === page.path)
+        if (index > -1) {
+            currentPages.splice(index, 1)
+            updateAll(currentPages)
+        }
+    }
+    function rename(page: Page) {
+        const currentPages = pages.value
+        const index = currentPages.findIndex(p => p.path === page.path)
+        if (index > -1) {
+            currentPages.splice(index, 1, {
+                ...currentPages[index],
+                label: page.label,
+            })
+            updateAll(currentPages)
+        }
 
-    actions: {
-        add(page: Page ) {
-            const pages = this.pages
-            if (!pages.find(p => p.path === page.path)) {
-                pages.push(page)
-                this.updateAll(pages)
-            }
-        },
-        remove(page: Page) {
-            const pages = this.pages
-            const index = pages.findIndex(p => p.path === page.path)
-            if (index > -1) {
-                pages.splice(index, 1)
-                this.updateAll(pages)
-            }
-        },
-        rename(page: Page) {
-            const pages = this.pages
-            const index = pages.findIndex(p => p.path === page.path)
-            if (index > -1) {
-                pages.splice(index, 1, {
-                    ...pages[index],
-                    label: page.label,
-                })
-                this.updateAll(pages)
-            }
+    }
+    function updateAll(newPages: Array<Page>) {
+        pages.value = newPages
+        localStorage.setItem(LOCAL_STORAGE_KEY, JSON.stringify(newPages))
+    }
 
-        },
-        updateAll(pages: Array<Page>) {
-            this.pages = pages
-            localStorage.setItem(LOCAL_STORAGE_KEY, JSON.stringify(pages))
-        },
-    },
+    return {
+        pages,
+        add,
+        remove,
+        rename,
+        updateAll,
+    }
 })

--- a/ui/src/stores/doc.ts
+++ b/ui/src/stores/doc.ts
@@ -1,5 +1,6 @@
 import axios from "axios"
 import {defineStore} from "pinia"
+import {computed, ref} from "vue"
 import {API_URL} from "./api"
 
 const PATH_PLACEHOLDER = "{path}"
@@ -19,107 +20,107 @@ interface SearchResult {
     preview: string;
 }
 
-interface State {
-    pageMetadata: DocMetadata | undefined;
-    resourceUrlTemplate: string | undefined;
-    appResourceUrlTemplate: string | undefined;
-    docPath: string | undefined;
-    docId: string | undefined;
-}
+export const useDocStore = defineStore("doc", () => {
+    const pageMetadata = ref<DocMetadata | undefined>(undefined)
+    const resourceUrlTemplate = ref<string | undefined>(undefined)
+    const appResourceUrlTemplate = ref<string | undefined>(undefined)
+    const docPath = ref<string | undefined>(undefined)
+    const docId = ref<string | undefined>(undefined)
 
-export const useDocStore = defineStore("doc", {
-    state: (): State => ({
-        pageMetadata: undefined,
-        resourceUrlTemplate: undefined,
-        appResourceUrlTemplate: undefined,
-        docPath: undefined,
-        docId: undefined,
-    }),
-
-    getters: {
-        resourceUrl: (state) => (path?: string, domain: string = "/docs"): string | undefined => {
-            if (state.resourceUrlTemplate) {
-                let resourcePath = ""
-                if (path !== undefined) {
-                    resourcePath = path.startsWith("/") ? path : `/${path}`
-                }
-                if (!domain.startsWith("/")) {
-                    domain = "/" + domain
-                }
-                return state.resourceUrlTemplate.replace(PATH_PLACEHOLDER, domain + resourcePath)
+    const resourceUrl = computed(() => (path?: string, domain: string = "/docs"): string | undefined => {
+        if (resourceUrlTemplate.value) {
+            let resourcePath = ""
+            if (path !== undefined) {
+                resourcePath = path.startsWith("/") ? path : `/${path}`
             }
-            return undefined
-        },
-    },
+            if (!domain.startsWith("/")) {
+                domain = "/" + domain
+            }
+            return resourceUrlTemplate.value.replace(PATH_PLACEHOLDER, domain + resourcePath)
+        }
+        return undefined
+    })
 
-    actions: {
-        async children(prefix?: string): Promise<any> {
-            const url = this.resourceUrl(prefix)
+    async function children(prefix?: string): Promise<any> {
+        const url = resourceUrl.value(prefix)
+        if (!url) throw new Error("Resource URL template not initialized")
+
+        const response = await axios.get(url + "/children")
+        return response.data
+    }
+
+    async function fetchResource(path: string): Promise<FetchResourceResponse> {
+        const url = resourceUrl.value(path)
+        if (!url) throw new Error("Resource URL template not initialized")
+
+        const response = await axios.get(url)
+
+        let metadata = response.headers["x-kestra-metadata"]
+        if (metadata !== undefined) {
+            metadata = JSON.parse(metadata)
+        }
+
+        return {
+            content: response.data,
+            metadata,
+        }
+    }
+
+    async function fetchDocId(id: string): Promise<FetchResourceResponse> {
+        const url = resourceUrl.value()
+        if (!url) throw new Error("Resource URL template not initialized")
+
+        const response = await axios.get(`${url}/doc/${id}`)
+
+        let metadata = response.headers["x-kestra-metadata"]
+        if (metadata !== undefined) {
+            metadata = JSON.parse(metadata)
+        }
+
+        docPath.value = metadata.parsedUrl
+
+        return {
+            content: response.data,
+            metadata,
+        }
+    }
+
+    async function search({q, scoredSearch = false}: {q: string; scoredSearch?: boolean}): Promise<any> {
+        if (scoredSearch) {
+            const url = resourceUrl.value(undefined, "search")
             if (!url) throw new Error("Resource URL template not initialized")
 
-            const response = await axios.get(url + "/children")
-            return response.data
-        },
+            const response = await axios.get(`${url}?q=${q}&type=DOCS`)
+            return response.data.results.map(({url: itemUrl, title, highlights}: {url: string; title: string; highlights?: string[]}): SearchResult => ({
+                parsedUrl: itemUrl,
+                title,
+                // highlights are HTML snippets (with <mark>/<br/> tags); strip them for a plain-text preview
+                preview: (highlights?.[0] ?? "").replace(/<br\s*\/?>/gi, " ").replace(/<[^>]+>/g, "").replace(/\s+/g, " ").trim(),
+            }))
+        }
 
-        async fetchResource(path: string): Promise<FetchResourceResponse> {
-            const url = this.resourceUrl(path)
-            if (!url) throw new Error("Resource URL template not initialized")
+        const url = resourceUrl.value()
+        if (!url) throw new Error("Resource URL template not initialized")
 
-            const response = await axios.get(url)
+        const response = await axios.get(`${url}/search?q=${q}`)
+        return response.data
+    }
 
-            let metadata = response.headers["x-kestra-metadata"]
-            if (metadata !== undefined) {
-                metadata = JSON.parse(metadata)
-            }
+    function initResourceUrlTemplate(version: string) {
+        resourceUrlTemplate.value = `${API_URL}/v1${PATH_PLACEHOLDER}/versions/${version}`
+    }
 
-            return {
-                content: response.data,
-                metadata,
-            }
-        },
-
-        async fetchDocId(docId: string): Promise<FetchResourceResponse> {
-            const url = this.resourceUrl()
-            if (!url) throw new Error("Resource URL template not initialized")
-
-            const response = await axios.get(`${url}/doc/${docId}`)
-
-            let metadata = response.headers["x-kestra-metadata"]
-            if (metadata !== undefined) {
-                metadata = JSON.parse(metadata)
-            }
-
-            this.docPath = metadata.parsedUrl
-
-            return {
-                content: response.data,
-                metadata,
-            }
-        },
-
-        async search({q, scoredSearch = false}: {q: string; scoredSearch?: boolean}): Promise<any> {
-            if (scoredSearch) {
-                const url = this.resourceUrl(undefined, "search")
-                if (!url) throw new Error("Resource URL template not initialized")
-
-                const response = await axios.get(`${url}?q=${q}&type=DOCS`)
-                return response.data.results.map(({url: itemUrl, title, highlights}: {url: string; title: string; highlights?: string[]}): SearchResult => ({
-                    parsedUrl: itemUrl,
-                    title,
-                    // highlights are HTML snippets (with <mark>/<br/> tags); strip them for a plain-text preview
-                    preview: (highlights?.[0] ?? "").replace(/<br\s*\/?>/gi, " ").replace(/<[^>]+>/g, "").replace(/\s+/g, " ").trim(),
-                }))
-            }
-
-            const url = this.resourceUrl()
-            if (!url) throw new Error("Resource URL template not initialized")
-
-            const response = await axios.get(`${url}/search?q=${q}`)
-            return response.data
-        },
-
-        initResourceUrlTemplate(version: string) {
-            this.resourceUrlTemplate = `${API_URL}/v1${PATH_PLACEHOLDER}/versions/${version}`
-        },
-    },
+    return {
+        pageMetadata,
+        resourceUrlTemplate,
+        appResourceUrlTemplate,
+        docPath,
+        docId,
+        resourceUrl,
+        children,
+        fetchResource,
+        fetchDocId,
+        search,
+        initResourceUrlTemplate,
+    }
 })

--- a/ui/src/stores/featureSpotlight.ts
+++ b/ui/src/stores/featureSpotlight.ts
@@ -1,4 +1,5 @@
 import {defineStore} from "pinia"
+import {computed, ref} from "vue"
 
 export type FeatureSpotlight = {
     navItemId: string;
@@ -19,30 +20,25 @@ function loadSeenIds(): string[] {
     }
 }
 
-interface State {
-    seenIds: string[];
-}
+export const useFeatureSpotlightStore = defineStore("featureSpotlight", () => {
+    const seenIds = ref<string[]>(loadSeenIds())
 
-export const useFeatureSpotlightStore = defineStore("featureSpotlight", {
-    state: (): State => ({
-        seenIds: loadSeenIds(),
-    }),
-    getters: {
-        unseenSpotlights(state): FeatureSpotlight[] {
-            return FEATURE_SPOTLIGHTS.filter((spotlight) => !state.seenIds.includes(spotlight.navItemId))
-        },
-        hasUnseenForId(): (navItemId?: string) => boolean {
-            return (navItemId) =>
-                Boolean(navItemId && this.unseenSpotlights.some((spotlight) => spotlight.navItemId === navItemId))
-        },
-    },
-    actions: {
-        markSeenById(navItemId?: string) {
-            if (!navItemId || this.seenIds.includes(navItemId)) return
-            if (!FEATURE_SPOTLIGHTS.some((spotlight) => spotlight.navItemId === navItemId)) return
+    const unseenSpotlights = computed((): FeatureSpotlight[] => FEATURE_SPOTLIGHTS.filter((spotlight) => !seenIds.value.includes(spotlight.navItemId)))
+    const hasUnseenForId = computed(() => (navItemId?: string): boolean =>
+        Boolean(navItemId && unseenSpotlights.value.some((spotlight) => spotlight.navItemId === navItemId)))
 
-            this.seenIds = [...this.seenIds, navItemId]
-            localStorage.setItem(SEEN_STORAGE_KEY, JSON.stringify(this.seenIds))
-        },
-    },
+    function markSeenById(navItemId?: string) {
+        if (!navItemId || seenIds.value.includes(navItemId)) return
+        if (!FEATURE_SPOTLIGHTS.some((spotlight) => spotlight.navItemId === navItemId)) return
+
+        seenIds.value = [...seenIds.value, navItemId]
+        localStorage.setItem(SEEN_STORAGE_KEY, JSON.stringify(seenIds.value))
+    }
+
+    return {
+        seenIds,
+        unseenSpotlights,
+        hasUnseenForId,
+        markSeenById,
+    }
 })

--- a/ui/src/stores/layout.ts
+++ b/ui/src/stores/layout.ts
@@ -1,14 +1,5 @@
 import {defineStore} from "pinia"
-
-interface State {
-    topNavbar: any | undefined;
-    envName: string | undefined;
-    envColor: string | undefined;
-    sideMenuCollapsed: boolean;
-    menuSectionsCollapsed: Record<string, boolean>;
-    menuItemVisibility: Record<string, boolean>;
-    menuItemOrder: Record<string, string[]>;
-}
+import {ref} from "vue"
 
 const MENU_SECTIONS_COLLAPSED_KEY = "menuSectionsCollapsed"
 const MENU_ITEM_VISIBILITY_KEY = "menuItemVisibility"
@@ -23,75 +14,89 @@ function readObject<T>(key: string): T {
     }
 }
 
-export const useLayoutStore = defineStore("layout", {
-    state: (): State => ({
-        topNavbar: undefined,
-        envName: localStorage.getItem("envName") || undefined,
-        envColor: localStorage.getItem("envColor") || undefined,
-        sideMenuCollapsed: (() => {
-            if (typeof window === "undefined") {
-                return false
-            }
+export const useLayoutStore = defineStore("layout", () => {
+    const topNavbar = ref<any | undefined>(undefined)
+    const envName = ref<string | undefined>(localStorage.getItem("envName") || undefined)
+    const envColor = ref<string | undefined>(localStorage.getItem("envColor") || undefined)
+    const sideMenuCollapsed = ref<boolean>((() => {
+        if (typeof window === "undefined") {
+            return false
+        }
 
-            return localStorage.getItem("menuCollapsed") === "true" || window.matchMedia("(max-width: 768px)").matches
-        })(),
-        menuSectionsCollapsed: readObject<Record<string, boolean>>(MENU_SECTIONS_COLLAPSED_KEY),
-        menuItemVisibility: readObject<Record<string, boolean>>(MENU_ITEM_VISIBILITY_KEY),
-        menuItemOrder: readObject<Record<string, string[]>>(MENU_ITEM_ORDER_KEY),
-    }),
-    getters: {},
-    actions: {
-        setTopNavbar(value: any) {
-            this.topNavbar = value
-        },
+        return localStorage.getItem("menuCollapsed") === "true" || window.matchMedia("(max-width: 768px)").matches
+    })())
+    const menuSectionsCollapsed = ref<Record<string, boolean>>(readObject<Record<string, boolean>>(MENU_SECTIONS_COLLAPSED_KEY))
+    const menuItemVisibility = ref<Record<string, boolean>>(readObject<Record<string, boolean>>(MENU_ITEM_VISIBILITY_KEY))
+    const menuItemOrder = ref<Record<string, string[]>>(readObject<Record<string, string[]>>(MENU_ITEM_ORDER_KEY))
 
-        setEnvName(value: string | undefined) {
-            if (value) {
-                localStorage.setItem("envName", value)
-            } else {
-                localStorage.removeItem("envName")
-            }
-            this.envName = value
-        },
+    function setTopNavbar(value: any) {
+        topNavbar.value = value
+    }
 
-        setEnvColor(value: string | undefined) {
-            if (value) {
-                localStorage.setItem("envColor", value)
-            } else {
-                localStorage.removeItem("envColor")
-            }
-            this.envColor = value
-        },
+    function setEnvName(value: string | undefined) {
+        if (value) {
+            localStorage.setItem("envName", value)
+        } else {
+            localStorage.removeItem("envName")
+        }
+        envName.value = value
+    }
 
-        setSideMenuCollapsed(value: boolean) {
-            this.sideMenuCollapsed = value
-            localStorage.setItem("menuCollapsed", value ? "true" : "false")
+    function setEnvColor(value: string | undefined) {
+        if (value) {
+            localStorage.setItem("envColor", value)
+        } else {
+            localStorage.removeItem("envColor")
+        }
+        envColor.value = value
+    }
 
-            const htmlElement = document.documentElement
-            htmlElement.classList.toggle("menu-collapsed", value)
-            htmlElement.classList.toggle("menu-not-collapsed", !value)
-        },
+    function setSideMenuCollapsed(value: boolean) {
+        sideMenuCollapsed.value = value
+        localStorage.setItem("menuCollapsed", value ? "true" : "false")
 
-        setMenuSectionCollapsed(id: string, collapsed: boolean) {
-            this.menuSectionsCollapsed = {...this.menuSectionsCollapsed, [id]: collapsed}
-            localStorage.setItem(MENU_SECTIONS_COLLAPSED_KEY, JSON.stringify(this.menuSectionsCollapsed))
-        },
+        const htmlElement = document.documentElement
+        htmlElement.classList.toggle("menu-collapsed", value)
+        htmlElement.classList.toggle("menu-not-collapsed", !value)
+    }
 
-        setMenuItemVisibility(id: string, visible: boolean) {
-            this.menuItemVisibility = {...this.menuItemVisibility, [id]: visible}
-            localStorage.setItem(MENU_ITEM_VISIBILITY_KEY, JSON.stringify(this.menuItemVisibility))
-        },
+    function setMenuSectionCollapsed(id: string, collapsed: boolean) {
+        menuSectionsCollapsed.value = {...menuSectionsCollapsed.value, [id]: collapsed}
+        localStorage.setItem(MENU_SECTIONS_COLLAPSED_KEY, JSON.stringify(menuSectionsCollapsed.value))
+    }
 
-        setMenuItemOrder(sectionId: string, orderedIds: string[]) {
-            this.menuItemOrder = {...this.menuItemOrder, [sectionId]: orderedIds}
-            localStorage.setItem(MENU_ITEM_ORDER_KEY, JSON.stringify(this.menuItemOrder))
-        },
+    function setMenuItemVisibility(id: string, visible: boolean) {
+        menuItemVisibility.value = {...menuItemVisibility.value, [id]: visible}
+        localStorage.setItem(MENU_ITEM_VISIBILITY_KEY, JSON.stringify(menuItemVisibility.value))
+    }
 
-        resetMenuCustomization() {
-            this.menuItemVisibility = {}
-            this.menuItemOrder = {}
-            localStorage.removeItem(MENU_ITEM_VISIBILITY_KEY)
-            localStorage.removeItem(MENU_ITEM_ORDER_KEY)
-        },
-    },
+    function setMenuItemOrder(sectionId: string, orderedIds: string[]) {
+        menuItemOrder.value = {...menuItemOrder.value, [sectionId]: orderedIds}
+        localStorage.setItem(MENU_ITEM_ORDER_KEY, JSON.stringify(menuItemOrder.value))
+    }
+
+    function resetMenuCustomization() {
+        menuItemVisibility.value = {}
+        menuItemOrder.value = {}
+        localStorage.removeItem(MENU_ITEM_VISIBILITY_KEY)
+        localStorage.removeItem(MENU_ITEM_ORDER_KEY)
+    }
+
+    return {
+        topNavbar,
+        envName,
+        envColor,
+        sideMenuCollapsed,
+        menuSectionsCollapsed,
+        menuItemVisibility,
+        menuItemOrder,
+        setTopNavbar,
+        setEnvName,
+        setEnvColor,
+        setSideMenuCollapsed,
+        setMenuSectionCollapsed,
+        setMenuItemVisibility,
+        setMenuItemOrder,
+        resetMenuCustomization,
+    }
 })

--- a/ui/src/stores/routeTabs.ts
+++ b/ui/src/stores/routeTabs.ts
@@ -1,5 +1,5 @@
 import {defineStore} from "pinia"
-import {markRaw} from "vue"
+import {computed, markRaw, ref, shallowRef} from "vue"
 import type {Component} from "vue"
 import type {RouteLocationRaw, RouteLocationNormalizedLoaded, Router} from "vue-router"
 
@@ -84,42 +84,42 @@ interface SetTabsPayload {
     displayMode?: RouteTabsDisplayMode;
 }
 
-interface State {
-    tabs: RouteTab[];
-    routeName: string;
-    embedActiveTab: string | undefined;
-    ownerId: symbol | null;
-    displayMode: RouteTabsDisplayMode;
-}
+export const useRouteTabsStore = defineStore("routeTabs", () => {
+    const tabs = ref<RouteTab[]>([])
+    const routeName = ref<string>("")
+    const embedActiveTab = ref<string | undefined>(undefined)
+    const ownerId = shallowRef<symbol | null>(null)
+    const displayMode = ref<RouteTabsDisplayMode>("sidebar")
 
-export const useRouteTabsStore = defineStore("routeTabs", {
-    state: (): State => ({
-        tabs: [],
-        routeName: "",
-        embedActiveTab: undefined,
-        ownerId: null,
-        displayMode: "sidebar",
-    }),
-    getters: {
-        hasTabs: (state): boolean => state.tabs.length > 0,
-        visibleTabs: (state): RouteTab[] => state.tabs.filter(t => !t.hidden),
-    },
-    actions: {
-        setTabs(payload: SetTabsPayload) {
-            this.tabs = payload.tabs.map(t => (t.component ? {...t, component: markRaw(t.component)} : t))
-            this.routeName = payload.routeName ?? ""
-            this.embedActiveTab = payload.embedActiveTab
-            this.ownerId = payload.ownerId
-            this.displayMode = payload.displayMode ?? "sidebar"
-        },
-        clearTabsIfOwner(ownerId: symbol) {
-            if (this.ownerId === ownerId) {
-                this.tabs = []
-                this.routeName = ""
-                this.embedActiveTab = undefined
-                this.ownerId = null
-                this.displayMode = "sidebar"
-            }
-        },
-    },
+    const hasTabs = computed((): boolean => tabs.value.length > 0)
+    const visibleTabs = computed((): RouteTab[] => tabs.value.filter(t => !t.hidden))
+
+    function setTabs(payload: SetTabsPayload) {
+        tabs.value = payload.tabs.map(t => (t.component ? {...t, component: markRaw(t.component)} : t))
+        routeName.value = payload.routeName ?? ""
+        embedActiveTab.value = payload.embedActiveTab
+        ownerId.value = payload.ownerId
+        displayMode.value = payload.displayMode ?? "sidebar"
+    }
+    function clearTabsIfOwner(owner: symbol) {
+        if (ownerId.value === owner) {
+            tabs.value = []
+            routeName.value = ""
+            embedActiveTab.value = undefined
+            ownerId.value = null
+            displayMode.value = "sidebar"
+        }
+    }
+
+    return {
+        tabs,
+        routeName,
+        embedActiveTab,
+        ownerId,
+        displayMode,
+        hasTabs,
+        visibleTabs,
+        setTabs,
+        clearTabsIfOwner,
+    }
 })

--- a/ui/src/stores/service.ts
+++ b/ui/src/stores/service.ts
@@ -1,21 +1,19 @@
 import {defineStore} from "pinia"
+import {ref} from "vue"
 import * as ServicesAPI from "@kestra-io/kestra-sdk/services"
 import type {ServiceInstance} from "@kestra-io/kestra-sdk"
 
-interface State {
-    service: ServiceInstance | undefined;
-}
+export const useServiceStore = defineStore("service", () => {
+    const service = ref<ServiceInstance | undefined>(undefined)
 
-export const useServiceStore = defineStore("service", {
-    state: (): State => ({
-        service: undefined,
-    }),
+    async function findServiceById(options: {id: string}): Promise<ServiceInstance> {
+        const result = await ServicesAPI.service(options)
+        service.value = result
+        return result
+    }
 
-    actions: {
-        async findServiceById(options: {id: string}): Promise<ServiceInstance> {
-            const service = await ServicesAPI.service(options)
-            this.service = service
-            return service
-        },
-    },
+    return {
+        service,
+        findServiceById,
+    }
 })


### PR DESCRIPTION
### ✨ Description

Continues the Options API → Composition API migration by converting the last 7 Pinia stores in `ui/src/stores/` from Options API object syntax (`state`/`getters`/`actions`) to setup-function syntax (`defineStore(id, () => {...})`), matching the style already used by `trigger.ts`, `ai.ts`, `flow.ts`, `core.ts`, etc.

Stores converted: `api.ts`, `bookmarks.ts`, `doc.ts`, `featureSpotlight.ts`, `layout.ts`, `routeTabs.ts`, `service.ts`.

All Vue components in `ui/` already use `<script setup>` (enforced by the `vue/component-api-style` ESLint rule), so no component changes were needed for this migration.

Behavior-preserving refactor only — no functional changes. External consumers (`store.foo`) are unaffected since Pinia exposes the same public shape regardless of Options vs setup syntax. Verified no callers rely on Options-API-specific internals (`$patch`, `$reset`, `$subscribe`).

### 🔗 Related Issue

N/A

### 🎨 Frontend Checklist

- [x] Code builds without errors (`npm run check:types` passes)
- [x] Lint passes (`npm run test:lint`)
- [x] Existing unit tests covering these stores pass (`ui/tests/unit/stores/*`, plus consumers)

### 📝 Additional Notes

Split into 2 commits for reviewability:
1. `api`, `doc`, `service` stores
2. `bookmarks`, `featureSpotlight`, `layout`, `routeTabs` stores

### 🤖 AI Authors

Why did the Pinia store refuse `this`? Because after the migration, it finally learned to stand on its own `ref`s. 🐱


---
_Generated by [Claude Code](https://claude.ai/code/session_01APrHqCyRFRDdLv2XLUSFei)_