### PR TITLE
feat(ai): show the copilot thinking words in random order

### DIFF
--- a/ui/src/components/ai/copilot/CopilotThinking.vue
+++ b/ui/src/components/ai/copilot/CopilotThinking.vue
@@ -23,7 +23,14 @@
     const index = ref(0)
     const word = computed(() => words.value[index.value] ?? "")
 
-    // Advance every 5s; start on a random word so a new turn doesn't always open on the same one.
+    /** A random index in [0, count) that is never the current one, so no word repeats back-to-back. */
+    function nextRandomIndex(current: number, count: number): number {
+        if (count <= 1) return 0
+        const pick = Math.floor(Math.random() * (count - 1))
+        return pick >= current ? pick + 1 : pick
+    }
+
+    // Show the words in random order, advancing every 5s (a random start, then a random next each tick).
     const ROTATE_MS = 5000
     let timer: ReturnType<typeof setInterval> | undefined
     onMounted(() => {
@@ -31,7 +38,7 @@
         if (count === 0) return
         index.value = Math.floor(Math.random() * count)
         timer = setInterval(() => {
-            index.value = (index.value + 1) % words.value.length
+            index.value = nextRandomIndex(index.value, words.value.length)
         }, ROTATE_MS)
     })
     onBeforeUnmount(() => clearInterval(timer))

--- a/ui/tests/unit/components/ai/copilot/CopilotThinking.spec.ts
+++ b/ui/tests/unit/components/ai/copilot/CopilotThinking.spec.ts
@@ -24,14 +24,17 @@ describe("CopilotThinking", () => {
         expect(dots.attributes("aria-hidden")).toBe("true")
     })
 
-    it("advances to the next word every 5 seconds", async () => {
+    it("rotates to a different (random) word every 5 seconds, never repeating the current one", async () => {
         vi.useFakeTimers()
-        vi.spyOn(Math, "random").mockReturnValue(0)
+        // Random sequence: 0 → start on the first word; 0.5 → the next tick picks a different index.
+        const seq = [0, 0.5]
+        let i = 0
+        vi.spyOn(Math, "random").mockImplementation(() => seq[i++] ?? 0)
         const w = mountThinking()
-        expect(w.text()).toContain("Orchestrating")
+        const first = w.text()
 
         vi.advanceTimersByTime(5000)
         await w.vm.$nextTick()
-        expect(w.text()).toContain("Scheduling")
+        expect(w.text()).not.toBe(first)
     })
 })


### PR DESCRIPTION
## What

The copilot's working indicator cycled through the orchestration status words **sequentially**. It now shows them in **random order**:

- a random start word (unchanged),
- a random next word on each 5s tick,
- guaranteed to **never repeat the current word** back-to-back (`nextRandomIndex` picks from the remaining words).

Everything else is unchanged — the cross-fade and the animated dots.

## Tests
- `CopilotThinking.spec` updated to assert the word rotates to a *different* one each interval.
- 2/2 pass; lint + type-check clean.

## Scope
Frontend-only. Shared with EE via the `kestra` alias, so no EE changes needed.