### PR TITLE
feat(executions): filter LOOP-kind executions by their originating taskId

### DIFF
--- a/core/src/main/java/io/kestra/core/models/QueryFilter.java
+++ b/core/src/main/java/io/kestra/core/models/QueryFilter.java
@@ -561,7 +561,7 @@ public record QueryFilter(
                 return List.of(
                     Field.QUERY, Field.SCOPE, Field.FLOW_ID, Field.START_DATE, Field.END_DATE,
                     Field.STATE, Field.LABELS, Field.TRIGGER_EXECUTION_ID, Field.CHILD_FILTER,
-                    Field.NAMESPACE, Field.KIND, Field.PARENT_ID
+                    Field.NAMESPACE, Field.KIND, Field.PARENT_ID, Field.TASK_ID
                 );
             }
         },

--- a/core/src/main/java/io/kestra/core/repositories/ExecutionRepositoryInterface.java
+++ b/core/src/main/java/io/kestra/core/repositories/ExecutionRepositoryInterface.java
@@ -1,6 +1,7 @@
 package io.kestra.core.repositories;
 
 import java.time.ZonedDateTime;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -155,23 +156,38 @@ public interface ExecutionRepositoryInterface extends QueryBuilderInterface<Exec
         String tenantId,
         @Nullable List<FlowFilter> flows);
 
-    /** Returns the loop sub-executions for the given parent execution, sorted by iteration index. */
-    default List<Execution> findLoopSubExecutions(String tenantId, String parentExecutionId) {
-        return find(
-            Pageable.from(Sort.of(Sort.Order.asc("loopRunIndex"))),
-            tenantId,
-            List.of(
-                QueryFilter.builder()
-                    .field(QueryFilter.Field.PARENT_ID)
-                    .operation(QueryFilter.Op.EQUALS)
-                    .value(parentExecutionId)
-                    .build(),
-                QueryFilter.builder()
-                    .field(QueryFilter.Field.KIND)
-                    .operation(QueryFilter.Op.EQUALS)
-                    .value(ExecutionKind.LOOP)
-                    .build()
-            )
+    /**
+     * Returns the loop sub-executions for the given parent execution, sorted by iteration index.
+     *
+     * @param taskId if non-null, scopes the result to the iterations of that single Loop task
+     *        (matched against {@code loopRun.taskId}); if null, returns iterations for
+     *        every Loop task under the parent execution.
+     */
+    default List<Execution> findLoopSubExecutions(String tenantId, String parentExecutionId, @Nullable String taskId) {
+        List<QueryFilter> filters = new ArrayList<>();
+        filters.add(
+            QueryFilter.builder()
+                .field(QueryFilter.Field.PARENT_ID)
+                .operation(QueryFilter.Op.EQUALS)
+                .value(parentExecutionId)
+                .build()
         );
+        filters.add(
+            QueryFilter.builder()
+                .field(QueryFilter.Field.KIND)
+                .operation(QueryFilter.Op.EQUALS)
+                .value(ExecutionKind.LOOP)
+                .build()
+        );
+        if (taskId != null) {
+            filters.add(
+                QueryFilter.builder()
+                    .field(QueryFilter.Field.TASK_ID)
+                    .operation(QueryFilter.Op.EQUALS)
+                    .value(taskId)
+                    .build()
+            );
+        }
+        return find(Pageable.from(Sort.of(Sort.Order.asc("loopRunIndex"))), tenantId, filters);
     }
 }

--- a/core/src/main/java/io/kestra/core/services/ExecutionService.java
+++ b/core/src/main/java/io/kestra/core/services/ExecutionService.java
@@ -575,8 +575,9 @@ public class ExecutionService {
             return Optional.of(new ExecutionWithTaskRun(execution, maybeTaskRun.get()));
         }
 
-        // Recursively search loop sub-executions to support nested loops
-        return executionRepository.findLoopSubExecutions(execution.getTenantId(), execution.getId()).stream()
+        // Recursively search loop sub-executions to support nested loops; span every loop task, we don't
+        // know upfront which one the taskRunId belongs to
+        return executionRepository.findLoopSubExecutions(execution.getTenantId(), execution.getId(), null).stream()
             .map(sub -> findExecutionWithTaskRun(sub, taskRunId))
             .filter(Optional::isPresent)
             .map(Optional::get)
@@ -961,7 +962,7 @@ public class ExecutionService {
      * @return a list of zero or more {@link ExecutionKilledExecution}.
      */
     public List<ExecutionKilledExecution> killLoopSubExecutions(final String tenantId, final String executionId) {
-        return executionRepository.findLoopSubExecutions(tenantId, executionId)
+        return executionRepository.findLoopSubExecutions(tenantId, executionId, null)
             .stream()
             .filter(subExecution -> subExecution.getState().isRunning() || subExecution.getState().isPaused())
             .map(
@@ -984,7 +985,7 @@ public class ExecutionService {
      * @return the last restartable sub-execution for that loop task run, if any
      */
     public Optional<Execution> findLastFailingLoopSubExecution(Execution execution, TaskRun loopTaskRun) {
-        return executionRepository.findLoopSubExecutions(execution.getTenantId(), execution.getId())
+        return executionRepository.findLoopSubExecutions(execution.getTenantId(), execution.getId(), loopTaskRun.getTaskId())
             .stream()
             .filter(sub -> sub.getLoopRun() != null && sub.getLoopRun().taskRunId().equals(loopTaskRun.getId()))
             .filter(sub -> sub.getState().canBeRestarted())

--- a/core/src/test/java/io/kestra/core/repositories/AbstractExecutionRepositoryTest.java
+++ b/core/src/test/java/io/kestra/core/repositories/AbstractExecutionRepositoryTest.java
@@ -1004,6 +1004,44 @@ public abstract class AbstractExecutionRepositoryTest {
     }
 
     @Test
+    protected void shouldFindLoopSubExecutionsScopedByTaskId() {
+        // Given a parent execution with iterations from two distinct Loop tasks
+        var tenant = TestsUtils.randomTenant(this.getClass().getSimpleName());
+        Execution parent = executionRepository.save(builder(tenant, State.Type.SUCCESS, null).build());
+
+        TaskRun loop1TaskRun = TaskRun.of(
+            parent, ResolvedTask.of(
+                Return.builder().id("loop1").type(Return.class.getName()).format(Property.ofValue("test")).build()
+            )
+        );
+        TaskRun loop2TaskRun = TaskRun.of(
+            parent, ResolvedTask.of(
+                Return.builder().id("loop2").type(Return.class.getName()).format(Property.ofValue("test")).build()
+            )
+        );
+
+        for (int i = 0; i < 2; i++) {
+            executionRepository.save(parent.loopExecution(loop1TaskRun, i, null, "value" + i));
+        }
+        for (int i = 0; i < 3; i++) {
+            executionRepository.save(parent.loopExecution(loop2TaskRun, i, null, "value" + i));
+        }
+
+        // When / Then: scoping to a single loop task returns only that task's iterations
+        List<Execution> loop1Subs = executionRepository.findLoopSubExecutions(tenant, parent.getId(), "loop1");
+        assertThat(loop1Subs).hasSize(2)
+            .allMatch(e -> "loop1".equals(e.getLoopRun().taskId()));
+
+        List<Execution> loop2Subs = executionRepository.findLoopSubExecutions(tenant, parent.getId(), "loop2");
+        assertThat(loop2Subs).hasSize(3)
+            .allMatch(e -> "loop2".equals(e.getLoopRun().taskId()));
+
+        // A null taskId returns every loop task's iterations
+        List<Execution> allSubs = executionRepository.findLoopSubExecutions(tenant, parent.getId(), null);
+        assertThat(allSubs).hasSize(5);
+    }
+
+    @Test
     protected void shouldFindByLabel() {
         var tenant = TestsUtils.randomTenant(this.getClass().getSimpleName());
         var exec1 = executionRepository.save(

--- a/core/src/test/java/io/kestra/core/runners/DisabledTest.java
+++ b/core/src/test/java/io/kestra/core/runners/DisabledTest.java
@@ -35,7 +35,7 @@ public class DisabledTest {
     void flowable(Execution execution) {
         assertThat(execution.getTaskRunList()).hasSize(7);
 
-        var subExecutions = executionRepository.findLoopSubExecutions(execution.getTenantId(), execution.getId());
+        var subExecutions = executionRepository.findLoopSubExecutions(execution.getTenantId(), execution.getId(), null);
         assertThat(subExecutions).hasSize(3);
         assertThat(subExecutions.stream().map(Execution::getTaskRunList).mapToLong(List::size).sum()).isEqualTo(3);
     }

--- a/core/src/test/java/io/kestra/core/runners/ExecutionServiceTest.java
+++ b/core/src/test/java/io/kestra/core/runners/ExecutionServiceTest.java
@@ -150,7 +150,7 @@ class ExecutionServiceTest {
         assertThat(restart.getTaskRunList()).hasSize(1);
         assertThat(restart.getTaskRunList().getFirst().getState().getCurrent()).isEqualTo(State.Type.RESTARTED);
         assertThat(restart.getLabels()).contains(new Label(Label.RESTARTED, "true"));
-        var subExecutions = executionRepository.findLoopSubExecutions(restart.getTenantId(), restart.getId());
+        var subExecutions = executionRepository.findLoopSubExecutions(restart.getTenantId(), restart.getId(), null);
         assertThat(subExecutions).hasSize(3);
     }
 
@@ -219,7 +219,7 @@ class ExecutionServiceTest {
         // Given: with the Loop task, parent has only 2 task runs (1_each + 2_end); loop iterations are sub-executions
         assertThat(execution.getTaskRunList()).hasSize(2);
         assertThat(execution.getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
-        var subExecutions = executionRepository.findLoopSubExecutions(execution.getTenantId(), execution.getId());
+        var subExecutions = executionRepository.findLoopSubExecutions(execution.getTenantId(), execution.getId(), null);
         assertThat(subExecutions).hasSize(3);
 
         // When: replay from the task that comes after the Loop (still in the parent execution)
@@ -297,9 +297,9 @@ class ExecutionServiceTest {
         assertThat(execution.getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
 
         // Navigate to a level-3 sub-execution to find the item task run
-        List<Execution> loop1Subs = executionRepository.findLoopSubExecutions(TENANT_2, execution.getId());
-        List<Execution> loop2Subs = executionRepository.findLoopSubExecutions(TENANT_2, loop1Subs.getFirst().getId());
-        List<Execution> loop3Subs = executionRepository.findLoopSubExecutions(TENANT_2, loop2Subs.getFirst().getId());
+        List<Execution> loop1Subs = executionRepository.findLoopSubExecutions(TENANT_2, execution.getId(), null);
+        List<Execution> loop2Subs = executionRepository.findLoopSubExecutions(TENANT_2, loop1Subs.getFirst().getId(), null);
+        List<Execution> loop3Subs = executionRepository.findLoopSubExecutions(TENANT_2, loop2Subs.getFirst().getId(), null);
         TaskRun itemTaskRun = loop3Subs.getFirst().findTaskRunsByTaskId("item").getFirst();
 
         // When: replay from item in the deepest sub-execution
@@ -322,9 +322,9 @@ class ExecutionServiceTest {
         assertThat(execution.getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
 
         // Navigate to a level-3 sub-execution to find the parents task run
-        List<Execution> loop1Subs = executionRepository.findLoopSubExecutions(TENANT_1, execution.getId());
-        List<Execution> loop2Subs = executionRepository.findLoopSubExecutions(TENANT_1, loop1Subs.getFirst().getId());
-        List<Execution> loop3Subs = executionRepository.findLoopSubExecutions(TENANT_1, loop2Subs.getFirst().getId());
+        List<Execution> loop1Subs = executionRepository.findLoopSubExecutions(TENANT_1, execution.getId(), null);
+        List<Execution> loop2Subs = executionRepository.findLoopSubExecutions(TENANT_1, loop1Subs.getFirst().getId(), null);
+        List<Execution> loop3Subs = executionRepository.findLoopSubExecutions(TENANT_1, loop2Subs.getFirst().getId(), null);
         TaskRun parentsTaskRun = loop3Subs.getFirst().findTaskRunsByTaskId("parents").getFirst();
 
         // When: replay from parents — item and parent are predecessors and should be kept
@@ -370,7 +370,7 @@ class ExecutionServiceTest {
         assertThat(execution.getTaskRunList()).hasSize(1);
         assertThat(execution.getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
 
-        List<Execution> subExecutions = executionRepository.findLoopSubExecutions(MAIN_TENANT, execution.getId());
+        List<Execution> subExecutions = executionRepository.findLoopSubExecutions(MAIN_TENANT, execution.getId(), null);
         assertThat(subExecutions).hasSize(3);
         TaskRun itemTaskRun = subExecutions.getFirst().findTaskRunsByTaskId("item").getFirst();
 
@@ -426,7 +426,7 @@ class ExecutionServiceTest {
         assertThat(execution.getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
 
         // child task runs live in loop sub-executions, not in the parent
-        List<Execution> subExecutions = executionRepository.findLoopSubExecutions(TENANT_1, execution.getId());
+        List<Execution> subExecutions = executionRepository.findLoopSubExecutions(TENANT_1, execution.getId(), null);
         assertThat(subExecutions).hasSize(3);
         TaskRun itemTaskRun = subExecutions.getFirst().findTaskRunsByTaskId("item").getFirst();
 

--- a/core/src/test/java/io/kestra/core/runners/InputsTest.java
+++ b/core/src/test/java/io/kestra/core/runners/InputsTest.java
@@ -228,7 +228,7 @@ public class InputsTest {
 
         assertThat(execution.getTaskRunList()).hasSize(13);
         assertThat(execution.getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
-        var subExecutions = executionRepository.findLoopSubExecutions(execution.getTenantId(), execution.getId());
+        var subExecutions = executionRepository.findLoopSubExecutions(execution.getTenantId(), execution.getId(), null);
         assertThat(subExecutions).hasSize(3);
 
         assertThat((String) taskOutputService.getOutputs(execution.findTaskRunsByTaskId("file").getFirst()).get("value"))
@@ -396,7 +396,7 @@ public class InputsTest {
 
         assertThat(execution.getTaskRunList()).hasSize(13);
         assertThat(execution.getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
-        var subExecutions = executionRepository.findLoopSubExecutions(execution.getTenantId(), execution.getId());
+        var subExecutions = executionRepository.findLoopSubExecutions(execution.getTenantId(), execution.getId(), null);
         assertThat(subExecutions).hasSize(3);
 
         assertThat(execution.getInputs().get("json1")).isInstanceOf(Map.class);

--- a/core/src/test/java/io/kestra/core/runners/RestartCaseTest.java
+++ b/core/src/test/java/io/kestra/core/runners/RestartCaseTest.java
@@ -227,7 +227,7 @@ public class RestartCaseTest {
         Execution firstExecution = runnerUtils.runOne(MAIN_TENANT, flow.getNamespace(), flow.getId(), Duration.ofSeconds(60));
 
         assertThat(firstExecution.getState().getCurrent()).isEqualTo(Type.FAILED);
-        var subExecutions = executionRepository.findLoopSubExecutions(firstExecution.getTenantId(), firstExecution.getId());
+        var subExecutions = executionRepository.findLoopSubExecutions(firstExecution.getTenantId(), firstExecution.getId(), null);
         assertThat(subExecutions).hasSize(1);
 
         // first restart: index=0 sub-execution is restarted and succeeds, then index=1 is created and fails
@@ -255,7 +255,7 @@ public class RestartCaseTest {
         assertThat(finishedRestarted1.getId()).isEqualTo(firstExecution.getId());
         assertThat(finishedRestarted1.getState().getCurrent()).isEqualTo(Type.FAILED);
 
-        subExecutions = executionRepository.findLoopSubExecutions(firstExecution.getTenantId(), firstExecution.getId());
+        subExecutions = executionRepository.findLoopSubExecutions(firstExecution.getTenantId(), firstExecution.getId(), null);
         assertThat(subExecutions).hasSize(2);
 
         // second restart: index=1 sub-execution is restarted and succeeds, then index=2 is created and fails
@@ -280,7 +280,7 @@ public class RestartCaseTest {
         assertThat(finishedRestarted2.getId()).isEqualTo(firstExecution.getId());
         assertThat(finishedRestarted2.getState().getCurrent()).isEqualTo(Type.FAILED);
 
-        subExecutions = executionRepository.findLoopSubExecutions(firstExecution.getTenantId(), firstExecution.getId());
+        subExecutions = executionRepository.findLoopSubExecutions(firstExecution.getTenantId(), firstExecution.getId(), null);
         assertThat(subExecutions).hasSize(3);
 
         // third restart: index=2 sub-execution is restarted and succeeds; all 3 iterations done
@@ -306,7 +306,7 @@ public class RestartCaseTest {
         assertThat(finishedRestarted3.getState().getCurrent()).isEqualTo(Type.SUCCESS);
 
         // we must have 3 loop sub-executions at the end — one per iteration, each restarted in place
-        subExecutions = executionRepository.findLoopSubExecutions(firstExecution.getTenantId(), firstExecution.getId());
+        subExecutions = executionRepository.findLoopSubExecutions(firstExecution.getTenantId(), firstExecution.getId(), null);
         assertThat(subExecutions).hasSize(3);
     }
 

--- a/core/src/test/java/io/kestra/core/runners/RunContextTest.java
+++ b/core/src/test/java/io/kestra/core/runners/RunContextTest.java
@@ -152,7 +152,7 @@ class RunContextTest {
         assertThat(execution.getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
         assertThat(execution.getTaskRunList().getFirst().getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
 
-        var subExecutions = executionRepository.findLoopSubExecutions(execution.getTenantId(), execution.getId());
+        var subExecutions = executionRepository.findLoopSubExecutions(execution.getTenantId(), execution.getId(), null);
         assertThat(subExecutions.size()).isEqualTo(9);
     }
 
@@ -344,7 +344,7 @@ class RunContextTest {
         assertThat(execution.getState().getCurrent()).isEqualTo(State.Type.FAILED);
         assertThat(execution.getTaskRunList().size()).isEqualTo(1);
 
-        var subExecutions = executionRepository.findLoopSubExecutions(execution.getTenantId(), execution.getId());
+        var subExecutions = executionRepository.findLoopSubExecutions(execution.getTenantId(), execution.getId(), null);
         assertThat(subExecutions.size()).isEqualTo(2);
         TaskRun taskRun = subExecutions.stream()
             .flatMap(e -> e.getTaskRunList().stream())

--- a/core/src/test/java/io/kestra/core/services/TaskOutputServiceTest.java
+++ b/core/src/test/java/io/kestra/core/services/TaskOutputServiceTest.java
@@ -41,7 +41,7 @@ class TaskOutputServiceTest {
         assertThat(execution.getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
         assertThat(execution.getTaskRunList()).hasSize(3);
 
-        var subExecutions = executionRepository.findLoopSubExecutions(execution.getTenantId(), execution.getId());
+        var subExecutions = executionRepository.findLoopSubExecutions(execution.getTenantId(), execution.getId(), null);
         assertThat(subExecutions.size()).isEqualTo(2);
 
         Map<String, Object> outputs = taskOutputService.computeOutputs(subExecutions.getFirst());
@@ -66,7 +66,7 @@ class TaskOutputServiceTest {
         assertThat(execution.getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
         assertThat(execution.getTaskRunList()).hasSize(2);
 
-        var subExecutions = executionRepository.findLoopSubExecutions(execution.getTenantId(), execution.getId());
+        var subExecutions = executionRepository.findLoopSubExecutions(execution.getTenantId(), execution.getId(), null);
         assertThat(subExecutions.size()).isEqualTo(3);
 
         Map<String, Object> outputs = taskOutputService.computeOutputs(subExecutions.getFirst());
@@ -88,7 +88,7 @@ class TaskOutputServiceTest {
         assertThat(execution.getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
         assertThat(execution.getTaskRunList()).hasSize(1);
 
-        var subExecutions = executionRepository.findLoopSubExecutions(execution.getTenantId(), execution.getId());
+        var subExecutions = executionRepository.findLoopSubExecutions(execution.getTenantId(), execution.getId(), null);
         assertThat(subExecutions.size()).isEqualTo(3);
 
         Map<String, Object> outputs = taskOutputService.computeOutputs(subExecutions.getFirst());

--- a/core/src/test/java/io/kestra/plugin/core/flow/BadFlowableTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/flow/BadFlowableTest.java
@@ -40,11 +40,11 @@ public class BadFlowableTest {
         // The parent terminates when the first sub-execution fails, but concurrent sub-executions
         // may still be running. Wait for all to reach a terminal state before asserting.
         Await.until(
-            () -> executionRepository.findLoopSubExecutions(execution.getTenantId(), execution.getId()).stream().allMatch(e -> e.getState().isTerminated()),
+            () -> executionRepository.findLoopSubExecutions(execution.getTenantId(), execution.getId(), null).stream().allMatch(e -> e.getState().isTerminated()),
             Duration.ofMillis(100),
             Duration.ofSeconds(30)
         );
-        var subExecutions = executionRepository.findLoopSubExecutions(execution.getTenantId(), execution.getId());
+        var subExecutions = executionRepository.findLoopSubExecutions(execution.getTenantId(), execution.getId(), null);
         assertThat(subExecutions).hasSize(2);
         assertThat(subExecutions).extracting("state.current").containsOnly(State.Type.FAILED);
     }

--- a/core/src/test/java/io/kestra/plugin/core/flow/FinallyTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/flow/FinallyTest.java
@@ -200,7 +200,7 @@ class FinallyTest {
         assertThat(execution.getTaskRunList()).hasSize(1);
         assertThat(execution.getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
 
-        var subExecutions = executionRepository.findLoopSubExecutions(execution.getTenantId(), execution.getId());
+        var subExecutions = executionRepository.findLoopSubExecutions(execution.getTenantId(), execution.getId(), null);
         assertThat(subExecutions.size()).isEqualTo(3);
         assertThat(subExecutions.getFirst().findTaskRunsByTaskId("ok").getFirst().getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
         assertThat(subExecutions.getFirst().findTaskRunsByTaskId("a1").getFirst().getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
@@ -224,11 +224,11 @@ class FinallyTest {
         // but other sub-executions continue running their errors/finally tasks in parallel.
         // Wait for all sub-executions to reach terminal state before asserting.
         Await.until(
-            () -> executionRepository.findLoopSubExecutions(execution.getTenantId(), execution.getId()).stream().allMatch(e -> e.getState().isTerminated()),
+            () -> executionRepository.findLoopSubExecutions(execution.getTenantId(), execution.getId(), null).stream().allMatch(e -> e.getState().isTerminated()),
             Duration.ofMillis(100),
             Duration.ofSeconds(30)
         );
-        var subExecutions = executionRepository.findLoopSubExecutions(execution.getTenantId(), execution.getId());
+        var subExecutions = executionRepository.findLoopSubExecutions(execution.getTenantId(), execution.getId(), null);
         assertThat(subExecutions.size()).isEqualTo(3);
         assertThat(subExecutions.getFirst().findTaskRunsByTaskId("ko").getFirst().getState().getCurrent()).isEqualTo(State.Type.FAILED);
         assertThat(subExecutions.getFirst().findTaskRunsByTaskId("a1").getFirst().getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
@@ -250,7 +250,7 @@ class FinallyTest {
         assertThat(execution.getTaskRunList()).hasSize(1);
         assertThat(execution.getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
 
-        var subExecutions = executionRepository.findLoopSubExecutions(execution.getTenantId(), execution.getId());
+        var subExecutions = executionRepository.findLoopSubExecutions(execution.getTenantId(), execution.getId(), null);
         assertThat(subExecutions.size()).isEqualTo(3);
         assertThat(subExecutions.getFirst().findTaskRunsByTaskId("ok").getFirst().getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
         assertThat(subExecutions.getFirst().findTaskRunsByTaskId("a1").getFirst().getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
@@ -274,11 +274,11 @@ class FinallyTest {
         // but other sub-executions continue running their errors/finally tasks in parallel.
         // Wait for all sub-executions to reach terminal state before asserting.
         Await.until(
-            () -> executionRepository.findLoopSubExecutions(execution.getTenantId(), execution.getId()).stream().allMatch(e -> e.getState().isTerminated()),
+            () -> executionRepository.findLoopSubExecutions(execution.getTenantId(), execution.getId(), null).stream().allMatch(e -> e.getState().isTerminated()),
             Duration.ofMillis(100),
             Duration.ofSeconds(30)
         );
-        var subExecutions = executionRepository.findLoopSubExecutions(execution.getTenantId(), execution.getId());
+        var subExecutions = executionRepository.findLoopSubExecutions(execution.getTenantId(), execution.getId(), null);
         assertThat(subExecutions.size()).isEqualTo(3);
 
         assertThat(subExecutions.getFirst().findTaskRunsByTaskId("ko").getFirst().getState().getCurrent()).isEqualTo(State.Type.FAILED);

--- a/core/src/test/java/io/kestra/plugin/core/flow/IfTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/flow/IfTest.java
@@ -138,7 +138,7 @@ class IfTest {
 
         assertThat(execution.getTaskRunList()).hasSize(1);
 
-        var subExecutions = executionRepository.findLoopSubExecutions(execution.getTenantId(), execution.getId());
+        var subExecutions = executionRepository.findLoopSubExecutions(execution.getTenantId(), execution.getId(), null);
         assertThat(subExecutions.size()).isEqualTo(3);
         assertThat(subExecutions.get(1).findTaskRunsByTaskId("after_if").getFirst().getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
         assertThat(subExecutions.getFirst().getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
@@ -158,7 +158,7 @@ class IfTest {
         assertThat(execution.getTaskRunList()).hasSize(2);
         assertThat(execution.getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
 
-        var subExecutions = executionRepository.findLoopSubExecutions(execution.getTenantId(), execution.getId());
+        var subExecutions = executionRepository.findLoopSubExecutions(execution.getTenantId(), execution.getId(), null);
         assertThat(subExecutions.size()).isEqualTo(3);
     }
 

--- a/core/src/test/java/io/kestra/plugin/core/flow/LoopCaseTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/flow/LoopCaseTest.java
@@ -58,7 +58,7 @@ public class LoopCaseTest {
             .containsEntry(Loop.TERMINATED_ITERATIONS_OUTPUT, Map.of("SUCCESS", 3));
 
         // 3 loop sub-executions, one per iteration, all with SUCCESS
-        List<Execution> subExecutions = executionRepository.findLoopSubExecutions(execution.getTenantId(), execution.getId());
+        List<Execution> subExecutions = executionRepository.findLoopSubExecutions(execution.getTenantId(), execution.getId(), null);
         assertThat(subExecutions).hasSize(3);
         assertThat(subExecutions).allMatch(sub -> sub.getState().getCurrent() == State.Type.SUCCESS);
         assertThat(subExecutions).allMatch(throwPredicate(sub ->
@@ -79,7 +79,7 @@ public class LoopCaseTest {
             .containsEntry(Loop.TERMINATED_ITERATIONS_OUTPUT, Map.of("SUCCESS", 2));
 
         // 2 loop sub-executions, one per iteration, each running 2 child tasks
-        List<Execution> subExecutions = executionRepository.findLoopSubExecutions(execution.getTenantId(), execution.getId());
+        List<Execution> subExecutions = executionRepository.findLoopSubExecutions(execution.getTenantId(), execution.getId(), null);
         assertThat(subExecutions).hasSize(2);
         assertThat(subExecutions).allMatch(sub -> sub.getState().getCurrent() == State.Type.SUCCESS);
         assertThat(subExecutions).allMatch(sub -> sub.getTaskRunList().size() == 2);
@@ -92,7 +92,7 @@ public class LoopCaseTest {
         assertThat(execution.getTaskRunList().getFirst().getState().getCurrent()).isEqualTo(State.Type.FAILED);
 
         // Only one sub-execution ran before the loop was terminated
-        List<Execution> subExecutions = executionRepository.findLoopSubExecutions(execution.getTenantId(), execution.getId());
+        List<Execution> subExecutions = executionRepository.findLoopSubExecutions(execution.getTenantId(), execution.getId(), null);
         assertThat(subExecutions).hasSize(1);
         assertThat(subExecutions.getFirst().getState().getCurrent()).isEqualTo(State.Type.FAILED);
     }
@@ -108,7 +108,7 @@ public class LoopCaseTest {
             .containsEntry(Loop.TERMINATED_ITERATIONS_OUTPUT, Map.of("FAILED", 3));
 
         // All 3 sub-executions ran and each failed individually (failure not propagated to the loop)
-        List<Execution> subExecutions = executionRepository.findLoopSubExecutions(execution.getTenantId(), execution.getId());
+        List<Execution> subExecutions = executionRepository.findLoopSubExecutions(execution.getTenantId(), execution.getId(), null);
         assertThat(subExecutions).hasSize(3);
         assertThat(subExecutions).allMatch(sub -> sub.getState().getCurrent() == State.Type.FAILED);
     }
@@ -123,7 +123,7 @@ public class LoopCaseTest {
             .containsEntry(Loop.ITERATION_COUNT_OUTPUT, 3)
             .containsEntry(Loop.TERMINATED_ITERATIONS_OUTPUT, Map.of("SUCCESS", 3));
 
-        List<Execution> subExecutions = executionRepository.findLoopSubExecutions(execution.getTenantId(), execution.getId());
+        List<Execution> subExecutions = executionRepository.findLoopSubExecutions(execution.getTenantId(), execution.getId(), null);
         assertThat(subExecutions).hasSize(3);
         assertThat(subExecutions).allMatch(sub -> sub.getState().getCurrent() == State.Type.SUCCESS);
         assertThat(subExecutions).allMatch(throwPredicate(sub ->
@@ -143,7 +143,7 @@ public class LoopCaseTest {
             .containsEntry(Loop.ITERATION_COUNT_OUTPUT, 3)
             .containsEntry(Loop.TERMINATED_ITERATIONS_OUTPUT, Map.of("SUCCESS", 3));
 
-        List<Execution> subExecutions = executionRepository.findLoopSubExecutions(execution.getTenantId(), execution.getId());
+        List<Execution> subExecutions = executionRepository.findLoopSubExecutions(execution.getTenantId(), execution.getId(), null);
         assertThat(subExecutions).hasSize(3);
         assertThat(subExecutions).allMatch(sub -> sub.getState().getCurrent() == State.Type.SUCCESS);
         assertThat(subExecutions).allMatch(throwPredicate(sub ->
@@ -163,7 +163,7 @@ public class LoopCaseTest {
             .containsEntry(Loop.ITERATION_COUNT_OUTPUT, 3)
             .containsEntry(Loop.TERMINATED_ITERATIONS_OUTPUT, Map.of("SUCCESS", 3));
 
-        List<Execution> subExecutions = executionRepository.findLoopSubExecutions(execution.getTenantId(), execution.getId());
+        List<Execution> subExecutions = executionRepository.findLoopSubExecutions(execution.getTenantId(), execution.getId(), null);
         assertThat(subExecutions).hasSize(3);
         assertThat(subExecutions).allMatch(sub -> sub.getState().getCurrent() == State.Type.SUCCESS);
         assertThat(subExecutions).allMatch(throwPredicate(sub ->
@@ -183,7 +183,7 @@ public class LoopCaseTest {
             .containsEntry(Loop.ITERATION_COUNT_OUTPUT, 4)
             .containsEntry(Loop.TERMINATED_ITERATIONS_OUTPUT, Map.of("SUCCESS", 4));
 
-        List<Execution> subExecutions = executionRepository.findLoopSubExecutions(execution.getTenantId(), execution.getId());
+        List<Execution> subExecutions = executionRepository.findLoopSubExecutions(execution.getTenantId(), execution.getId(), null);
         assertThat(subExecutions).hasSize(4);
         assertThat(subExecutions).allMatch(sub -> sub.getState().getCurrent() == State.Type.SUCCESS);
         assertThat(subExecutions).allMatch(throwPredicate(sub ->
@@ -204,7 +204,7 @@ public class LoopCaseTest {
             .containsEntry(Loop.TERMINATED_ITERATIONS_OUTPUT, Map.of("SUCCESS", 3));
 
         // 3 loop sub-executions, one per iteration, all with SUCCESS
-        List<Execution> subExecutions = executionRepository.findLoopSubExecutions(execution.getTenantId(), execution.getId());
+        List<Execution> subExecutions = executionRepository.findLoopSubExecutions(execution.getTenantId(), execution.getId(), null);
         assertThat(subExecutions).hasSize(3);
         assertThat(subExecutions).allMatch(sub -> sub.getState().getCurrent() == State.Type.SUCCESS);
     }
@@ -221,7 +221,7 @@ public class LoopCaseTest {
         }
 
         // 6 loop sub-executions total (3 per loop task), all with SUCCESS
-        List<Execution> subExecutions = executionRepository.findLoopSubExecutions(execution.getTenantId(), execution.getId());
+        List<Execution> subExecutions = executionRepository.findLoopSubExecutions(execution.getTenantId(), execution.getId(), null);
         assertThat(subExecutions).hasSize(6);
         assertThat(subExecutions).allMatch(sub -> sub.getState().getCurrent() == State.Type.SUCCESS);
         assertThat(subExecutions).allMatch(throwPredicate(sub ->
@@ -229,6 +229,13 @@ public class LoopCaseTest {
             String expectedValue = sub.getLoopRun().index() + " - " + sub.getLoopRun().value();
             return expectedValue.equals(taskOutputService.getOutputs(sub.getTaskRunList().getFirst()).get("value"));
         }));
+
+        // Scoping by taskId returns only that loop task's 3 iterations, not the other loop's
+        for (TaskRun loopTaskRun : execution.getTaskRunList()) {
+            List<Execution> loopSubExecutions = executionRepository.findLoopSubExecutions(execution.getTenantId(), execution.getId(), loopTaskRun.getTaskId());
+            assertThat(loopSubExecutions).hasSize(3);
+            assertThat(loopSubExecutions).allMatch(sub -> loopTaskRun.getTaskId().equals(sub.getLoopRun().taskId()));
+        }
     }
 
     public void loopNested(Execution execution) throws InternalException {
@@ -242,7 +249,7 @@ public class LoopCaseTest {
             .containsEntry(Loop.TERMINATED_ITERATIONS_OUTPUT, Map.of("SUCCESS", 3));
 
         // 3 loop sub-executions, one per iteration, all with SUCCESS
-        List<Execution> subExecutions = executionRepository.findLoopSubExecutions(execution.getTenantId(), execution.getId());
+        List<Execution> subExecutions = executionRepository.findLoopSubExecutions(execution.getTenantId(), execution.getId(), null);
         assertThat(subExecutions).hasSize(3);
         assertThat(subExecutions).allMatch(sub -> sub.getState().getCurrent() == State.Type.SUCCESS);
         assertThat(subExecutions).allMatch(throwPredicate(sub ->
@@ -256,7 +263,7 @@ public class LoopCaseTest {
 
         // each loop1 sub-execution should have 3 loop2 sub-executions, each running loop3
         for (Execution loop1SubExec : subExecutions) {
-            List<Execution> loop2SubExecutions = executionRepository.findLoopSubExecutions(loop1SubExec.getTenantId(), loop1SubExec.getId());
+            List<Execution> loop2SubExecutions = executionRepository.findLoopSubExecutions(loop1SubExec.getTenantId(), loop1SubExec.getId(), null);
             assertThat(loop2SubExecutions).hasSize(3);
             assertThat(loop2SubExecutions).allMatch(sub -> sub.getState().getCurrent() == State.Type.SUCCESS);
             assertThat(loop2SubExecutions).allMatch(throwPredicate(sub ->
@@ -269,7 +276,7 @@ public class LoopCaseTest {
             }));
             // each loop2 sub-execution should have 3 loop3 sub-executions with Return task outputs
             for (Execution loop2SubExec : loop2SubExecutions) {
-                List<Execution> loop3SubExecutions = executionRepository.findLoopSubExecutions(loop2SubExec.getTenantId(), loop2SubExec.getId());
+                List<Execution> loop3SubExecutions = executionRepository.findLoopSubExecutions(loop2SubExec.getTenantId(), loop2SubExec.getId(), null);
                 assertThat(loop3SubExecutions).hasSize(3);
                 assertThat(loop3SubExecutions).allMatch(sub -> sub.getState().getCurrent() == State.Type.SUCCESS);
                 for (Execution loop3SubExec : loop3SubExecutions) {
@@ -310,7 +317,7 @@ public class LoopCaseTest {
             .containsEntry(Loop.TERMINATED_ITERATIONS_OUTPUT, Map.of("SUCCESS", 3));
 
         // 3 loop sub-executions, one per map entry, all with SUCCESS
-        List<Execution> subExecutions = executionRepository.findLoopSubExecutions(execution.getTenantId(), execution.getId());
+        List<Execution> subExecutions = executionRepository.findLoopSubExecutions(execution.getTenantId(), execution.getId(), null);
         assertThat(subExecutions).hasSize(3);
         assertThat(subExecutions).allMatch(sub -> sub.getState().getCurrent() == State.Type.SUCCESS);
         // each iteration must carry a non-null key
@@ -334,7 +341,7 @@ public class LoopCaseTest {
             .containsEntry(Loop.TERMINATED_ITERATIONS_OUTPUT, Map.of("SUCCESS", 3));
 
         // 3 loop sub-executions, one per ION value, all with SUCCESS
-        List<Execution> subExecutions = executionRepository.findLoopSubExecutions(execution.getTenantId(), execution.getId());
+        List<Execution> subExecutions = executionRepository.findLoopSubExecutions(execution.getTenantId(), execution.getId(), null);
         assertThat(subExecutions).hasSize(3);
         assertThat(subExecutions).allMatch(sub -> sub.getState().getCurrent() == State.Type.SUCCESS);
         assertThat(subExecutions).allMatch(throwPredicate(sub ->
@@ -349,7 +356,7 @@ public class LoopCaseTest {
         assertThat(execution.getTaskRunList()).hasSize(2);
 
         // 3 loop sub-executions, all with SUCCESS
-        List<Execution> subExecutions = executionRepository.findLoopSubExecutions(execution.getTenantId(), execution.getId());
+        List<Execution> subExecutions = executionRepository.findLoopSubExecutions(execution.getTenantId(), execution.getId(), null);
         assertThat(subExecutions).hasSize(3);
         assertThat(subExecutions).allMatch(sub -> sub.getState().getCurrent() == State.Type.SUCCESS);
         assertThat(subExecutions).allMatch(sub -> sub.getTaskRunList().size() == 2);
@@ -363,7 +370,7 @@ public class LoopCaseTest {
         assertThat(execution.getTaskRunList()).hasSize(2);
 
         // 3 loop sub-executions, all with SUCCESS
-        List<Execution> subExecutions = executionRepository.findLoopSubExecutions(execution.getTenantId(), execution.getId());
+        List<Execution> subExecutions = executionRepository.findLoopSubExecutions(execution.getTenantId(), execution.getId(), null);
         assertThat(subExecutions).hasSize(3);
         assertThat(subExecutions).allMatch(sub -> sub.getState().getCurrent() == State.Type.SUCCESS);
         assertThat(subExecutions).allMatch(sub -> sub.getTaskRunList().size() == 1);
@@ -382,7 +389,7 @@ public class LoopCaseTest {
         assertThat(execution.getTaskRunList()).hasSize(2);
 
         // 3 loop sub-executions, all with SUCCESS
-        List<Execution> subExecutions = executionRepository.findLoopSubExecutions(execution.getTenantId(), execution.getId());
+        List<Execution> subExecutions = executionRepository.findLoopSubExecutions(execution.getTenantId(), execution.getId(), null);
         assertThat(subExecutions).hasSize(3);
         assertThat(subExecutions).allMatch(sub -> sub.getState().getCurrent() == State.Type.SUCCESS);
         assertThat(subExecutions).allMatch(sub -> sub.getTaskRunList().size() == 1);
@@ -427,7 +434,7 @@ public class LoopCaseTest {
 
         // Only one sub-execution ran before the loop was terminated (transmitFailed=true by default).
         // The sub-execution itself is FAILED (output rendering failed), but its inner tasks succeeded.
-        List<Execution> subExecutions = executionRepository.findLoopSubExecutions(execution.getTenantId(), execution.getId());
+        List<Execution> subExecutions = executionRepository.findLoopSubExecutions(execution.getTenantId(), execution.getId(), null);
         assertThat(subExecutions).hasSize(1);
         Execution subExecution = subExecutions.getFirst();
         assertThat(subExecution.getState().getCurrent()).isEqualTo(State.Type.FAILED);
@@ -439,7 +446,7 @@ public class LoopCaseTest {
         assertThat(execution.getTaskRunList()).hasSize(3);
 
         // 3 loop sub-executions, all with SUCCESS
-        List<Execution> subExecutions = executionRepository.findLoopSubExecutions(execution.getTenantId(), execution.getId());
+        List<Execution> subExecutions = executionRepository.findLoopSubExecutions(execution.getTenantId(), execution.getId(), null);
         assertThat(subExecutions).hasSize(3);
         assertThat(subExecutions).allMatch(sub -> sub.getState().getCurrent() == State.Type.SUCCESS);
         assertThat(subExecutions).allMatch(sub -> sub.getTaskRunList().size() == 1);
@@ -493,7 +500,7 @@ public class LoopCaseTest {
         assertThat(execution.getTaskRunList()).hasSize(2);
         assertThat(execution.getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
 
-        List<Execution> subExecutions = executionRepository.findLoopSubExecutions(execution.getTenantId(), execution.getId());
+        List<Execution> subExecutions = executionRepository.findLoopSubExecutions(execution.getTenantId(), execution.getId(), null);
         assertThat(subExecutions).hasSize(3);
         assertThat((String) taskOutputService.getOutputs(subExecutions.get(2).getTaskRunList().get(1)).get("value")).contains("json > JSON > [\"my-complex\"]");
     }
@@ -502,7 +509,7 @@ public class LoopCaseTest {
         assertThat(execution.getTaskRunList()).hasSize(2);
         assertThat(execution.getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
 
-        List<Execution> subExecutions = executionRepository.findLoopSubExecutions(execution.getTenantId(), execution.getId());
+        List<Execution> subExecutions = executionRepository.findLoopSubExecutions(execution.getTenantId(), execution.getId(), null);
         assertThat(subExecutions).hasSize(3);
         assertThat((String) taskOutputService.getOutputs(subExecutions.get(2).getTaskRunList().get(1)).get("value")).contains("json > JSON > [\"my-complex\"]");
     }
@@ -511,15 +518,15 @@ public class LoopCaseTest {
         assertThat(execution.getTaskRunList()).hasSize(3);
         assertThat(execution.getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
 
-        List<Execution> subExecutions = executionRepository.findLoopSubExecutions(execution.getTenantId(), execution.getId());
+        List<Execution> subExecutions = executionRepository.findLoopSubExecutions(execution.getTenantId(), execution.getId(), null);
         assertThat(subExecutions).hasSize(2);
 
-        List<Execution> subSubExecutions = executionRepository.findLoopSubExecutions(subExecutions.get(1).getTenantId(), subExecutions.get(1).getId());
+        List<Execution> subSubExecutions = executionRepository.findLoopSubExecutions(subExecutions.get(1).getTenantId(), subExecutions.get(1).getId(), null);
         assertThat(subSubExecutions).hasSize(2);
         TaskRun switchNumber1 = subSubExecutions.getFirst().findTaskRunsByTaskId("2-1-1_switch-number-1").getFirst();
         assertThat((String) taskOutputService.getOutputs(switchNumber1).get("value")).isEqualTo("1");
 
-        subSubExecutions = executionRepository.findLoopSubExecutions(subExecutions.get(1).getTenantId(), subExecutions.get(1).getId());
+        subSubExecutions = executionRepository.findLoopSubExecutions(subExecutions.get(1).getTenantId(), subExecutions.get(1).getId(), null);
         assertThat(subSubExecutions).hasSize(2);
         TaskRun switchNumber2 = subSubExecutions.get(1).findTaskRunsByTaskId("2-1-1_switch-number-2").getFirst();
         assertThat((String) taskOutputService.getOutputs(switchNumber2).get("value")).isEqualTo("2 b");
@@ -529,7 +536,7 @@ public class LoopCaseTest {
         assertThat(execution.getTaskRunList()).hasSize(1);
         assertThat(execution.getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
 
-        var subExecutions = executionRepository.findLoopSubExecutions(execution.getTenantId(), execution.getId());
+        var subExecutions = executionRepository.findLoopSubExecutions(execution.getTenantId(), execution.getId(), null);
         assertThat(subExecutions).hasSize(2);
 
         // for each sub-execution, check their subflow

--- a/core/src/test/java/io/kestra/plugin/core/flow/RetryCaseTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/flow/RetryCaseTest.java
@@ -169,7 +169,7 @@ public class RetryCaseTest {
         assertThat(execution.getTaskRunList().getFirst().attemptNumber()).isEqualTo(1);
 
         // At least one sub-execution must have retried its child task
-        var subExecutions = executionRepository.findLoopSubExecutions(execution.getTenantId(), execution.getId());
+        var subExecutions = executionRepository.findLoopSubExecutions(execution.getTenantId(), execution.getId(), null);
         assertThat(subExecutions).hasSize(2);
         boolean anyChildRetried = subExecutions.stream()
             .flatMap(sub -> sub.getTaskRunList().stream())

--- a/core/src/test/java/io/kestra/plugin/core/flow/SwitchTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/flow/SwitchTest.java
@@ -119,7 +119,7 @@ class SwitchTest {
         assertThat(execution.getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
         assertThat(execution.getTaskRunList()).hasSize(1);
 
-        var subExecutions = executionRepository.findLoopSubExecutions(execution.getTenantId(), execution.getId());
+        var subExecutions = executionRepository.findLoopSubExecutions(execution.getTenantId(), execution.getId(), null);
         assertThat(subExecutions.size()).isEqualTo(2);
 
         // we check that OOMCRM_EB_DD_000 and OOMCRM_EB_DD_001 have been processed once across all sub-executions

--- a/core/src/test/java/io/kestra/plugin/core/flow/WorkingDirectoryTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/flow/WorkingDirectoryTest.java
@@ -180,13 +180,13 @@ public class WorkingDirectoryTest {
             assertThat(execution.getTaskRunList()).hasSize(2);
             assertThat(execution.getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
 
-            List<Execution> subExecutions = executionRepository.findLoopSubExecutions(execution.getTenantId(), execution.getId());
+            List<Execution> subExecutions = executionRepository.findLoopSubExecutions(execution.getTenantId(), execution.getId(), null);
             assertThat(subExecutions).hasSize(1);
 
-            List<Execution> subSubExecutions = executionRepository.findLoopSubExecutions(subExecutions.getFirst().getTenantId(), subExecutions.getFirst().getId());
+            List<Execution> subSubExecutions = executionRepository.findLoopSubExecutions(subExecutions.getFirst().getTenantId(), subExecutions.getFirst().getId(), null);
             assertThat(subExecutions).hasSize(1);
 
-            List<Execution> subSubSubExecutions = executionRepository.findLoopSubExecutions(subSubExecutions.getFirst().getTenantId(), subSubExecutions.getFirst().getId());
+            List<Execution> subSubSubExecutions = executionRepository.findLoopSubExecutions(subSubExecutions.getFirst().getTenantId(), subSubExecutions.getFirst().getId(), null);
             assertThat(subSubSubExecutions).hasSize(1);
 
             assertThat((String) taskOutputService.getOutputs(execution.findTaskRunsByTaskId("2_end").getFirst()).get("value")).startsWith("kestra://");
@@ -306,7 +306,7 @@ public class WorkingDirectoryTest {
             assertThat(execution.getTaskRunList()).hasSize(1);
             assertThat(execution.getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
 
-            var subExecutions = executionRepository.findLoopSubExecutions(execution.getTenantId(), execution.getId());
+            var subExecutions = executionRepository.findLoopSubExecutions(execution.getTenantId(), execution.getId(), null);
             assertThat(subExecutions.size()).isEqualTo(1);
             assertThat(((String) taskOutputService.getOutputs(subExecutions.getFirst().findTaskRunsByTaskId("log-taskrun").getFirst()).get("value"))).contains("1");
         }
@@ -317,7 +317,7 @@ public class WorkingDirectoryTest {
             assertThat(execution.getTaskRunList()).hasSize(1);
             assertThat(execution.getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
 
-            var subExecutions = executionRepository.findLoopSubExecutions(execution.getTenantId(), execution.getId());
+            var subExecutions = executionRepository.findLoopSubExecutions(execution.getTenantId(), execution.getId(), null);
             assertThat(subExecutions.size()).isEqualTo(1);
             assertThat(((String) taskOutputService.getOutputs(subExecutions.getFirst().findTaskRunsByTaskId("log-workerparent").getFirst()).get("value")))
                 .contains("{\"task\":{\"id\":\"seq\"}}");

--- a/jdbc-h2/src/main/java/io/kestra/repository/h2/migration/V2_0_18ExecutionsLoopRunTaskIdMigration.java
+++ b/jdbc-h2/src/main/java/io/kestra/repository/h2/migration/V2_0_18ExecutionsLoopRunTaskIdMigration.java
@@ -1,0 +1,36 @@
+package io.kestra.repository.h2.migration;
+
+import java.util.List;
+
+import javax.sql.DataSource;
+
+import io.kestra.jdbc.migration.AbstractV2_0_18ExecutionsLoopRunTaskIdMigration;
+
+import io.micronaut.context.annotation.Requires;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+
+/**
+ * OSS H2 executions loop-run-task-id migration.
+ */
+@Singleton
+@Requires(property = "kestra.repository.type", pattern = "h2|memory")
+public class V2_0_18ExecutionsLoopRunTaskIdMigration extends AbstractV2_0_18ExecutionsLoopRunTaskIdMigration {
+
+    private final DataSource dataSource;
+
+    @Inject
+    public V2_0_18ExecutionsLoopRunTaskIdMigration(final DataSource dataSource) {
+        this.dataSource = dataSource;
+    }
+
+    @Override
+    protected DataSource dataSource() {
+        return dataSource;
+    }
+
+    @Override
+    public List<String> sqlResources() {
+        return List.of("/migrations/2.0.18-executions-loop-run-task-id-h2.sql");
+    }
+}

--- a/jdbc-h2/src/main/resources/migrations/2.0.18-executions-loop-run-task-id-h2.sql
+++ b/jdbc-h2/src/main/resources/migrations/2.0.18-executions-loop-run-task-id-h2.sql
@@ -1,0 +1,3 @@
+-- 2.0.18: expose the originating Loop task id (loopRun.taskId) as a queryable generated column on
+-- executions, so LOOP-kind iteration executions can be filtered per loop task.
+ALTER TABLE executions ADD COLUMN IF NOT EXISTS "loop_run_task_id" VARCHAR(256) GENERATED ALWAYS AS (JQ_STRING("value", '.loopRun.taskId'));

--- a/jdbc-h2/src/test/java/io/kestra/repository/h2/H2ExecutionRepositoryTest.java
+++ b/jdbc-h2/src/test/java/io/kestra/repository/h2/H2ExecutionRepositoryTest.java
@@ -1,13 +1,6 @@
 package io.kestra.repository.h2;
 
-import org.junit.jupiter.api.Test;
-
 import io.kestra.core.repositories.AbstractExecutionRepositoryTest;
 
 public class H2ExecutionRepositoryTest extends AbstractExecutionRepositoryTest {
-    @Test
-    @Override
-    protected void mappingConflict() {
-
-    }
 }

--- a/jdbc-mysql/src/main/java/io/kestra/repository/mysql/migration/V2_0_18ExecutionsLoopRunTaskIdMigration.java
+++ b/jdbc-mysql/src/main/java/io/kestra/repository/mysql/migration/V2_0_18ExecutionsLoopRunTaskIdMigration.java
@@ -1,0 +1,36 @@
+package io.kestra.repository.mysql.migration;
+
+import java.util.List;
+
+import javax.sql.DataSource;
+
+import io.kestra.jdbc.migration.AbstractV2_0_18ExecutionsLoopRunTaskIdMigration;
+import io.kestra.repository.mysql.MysqlRepositoryEnabled;
+
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+
+/**
+ * OSS MySQL executions loop-run-task-id migration.
+ */
+@Singleton
+@MysqlRepositoryEnabled
+public class V2_0_18ExecutionsLoopRunTaskIdMigration extends AbstractV2_0_18ExecutionsLoopRunTaskIdMigration {
+
+    private final DataSource dataSource;
+
+    @Inject
+    public V2_0_18ExecutionsLoopRunTaskIdMigration(final DataSource dataSource) {
+        this.dataSource = dataSource;
+    }
+
+    @Override
+    protected DataSource dataSource() {
+        return dataSource;
+    }
+
+    @Override
+    public List<String> sqlResources() {
+        return List.of("/migrations/2.0.18-executions-loop-run-task-id-mysql.sql");
+    }
+}

--- a/jdbc-mysql/src/main/resources/migrations/2.0.18-executions-loop-run-task-id-mysql.sql
+++ b/jdbc-mysql/src/main/resources/migrations/2.0.18-executions-loop-run-task-id-mysql.sql
@@ -1,0 +1,7 @@
+-- 2.0.18: expose the originating Loop task id (loopRun.taskId) as a queryable generated column on
+-- executions, so LOOP-kind iteration executions can be filtered per loop task. Mirrors loop_run_index.
+SET @col_exists = (SELECT COUNT(*) FROM information_schema.columns WHERE table_schema = DATABASE() AND table_name = 'executions' AND column_name = 'loop_run_task_id');
+SET @sql = IF(@col_exists = 0, 'ALTER TABLE executions ADD COLUMN loop_run_task_id VARCHAR(256) GENERATED ALWAYS AS (value ->> ''$.loopRun.taskId'') STORED', 'SELECT 1');
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;

--- a/jdbc-postgres/src/main/java/io/kestra/repository/postgres/migration/V2_0_18ExecutionsLoopRunTaskIdMigration.java
+++ b/jdbc-postgres/src/main/java/io/kestra/repository/postgres/migration/V2_0_18ExecutionsLoopRunTaskIdMigration.java
@@ -1,0 +1,36 @@
+package io.kestra.repository.postgres.migration;
+
+import java.util.List;
+
+import javax.sql.DataSource;
+
+import io.kestra.jdbc.migration.AbstractV2_0_18ExecutionsLoopRunTaskIdMigration;
+import io.kestra.repository.postgres.PostgresRepositoryEnabled;
+
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+
+/**
+ * OSS PostgreSQL executions loop-run-task-id migration.
+ */
+@Singleton
+@PostgresRepositoryEnabled
+public class V2_0_18ExecutionsLoopRunTaskIdMigration extends AbstractV2_0_18ExecutionsLoopRunTaskIdMigration {
+
+    private final DataSource dataSource;
+
+    @Inject
+    public V2_0_18ExecutionsLoopRunTaskIdMigration(final DataSource dataSource) {
+        this.dataSource = dataSource;
+    }
+
+    @Override
+    protected DataSource dataSource() {
+        return dataSource;
+    }
+
+    @Override
+    public List<String> sqlResources() {
+        return List.of("/migrations/2.0.18-executions-loop-run-task-id-postgres.sql");
+    }
+}

--- a/jdbc-postgres/src/main/resources/migrations/2.0.18-executions-loop-run-task-id-postgres.sql
+++ b/jdbc-postgres/src/main/resources/migrations/2.0.18-executions-loop-run-task-id-postgres.sql
@@ -1,0 +1,3 @@
+-- 2.0.18: expose the originating Loop task id (loopRun.taskId) as a queryable generated column on
+-- executions, so LOOP-kind iteration executions can be filtered per loop task. Mirrors loop_run_index.
+ALTER TABLE executions ADD COLUMN IF NOT EXISTS "loop_run_task_id" VARCHAR(256) GENERATED ALWAYS AS (value #>> '{loopRun,taskId}') STORED;

--- a/jdbc/src/main/java/io/kestra/jdbc/migration/AbstractV2_0_18ExecutionsLoopRunTaskIdMigration.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/migration/AbstractV2_0_18ExecutionsLoopRunTaskIdMigration.java
@@ -1,0 +1,21 @@
+package io.kestra.jdbc.migration;
+
+/**
+ * Abstract base for the 2.0.18 executions loop-run-task-id migration.
+ *
+ * <p>
+ * Adds a generated {@code loop_run_task_id} column on the {@code executions} table (derived from
+ * {@code loopRun.taskId}), so LOOP-kind iteration executions can be filtered per originating Loop task.
+ */
+public abstract class AbstractV2_0_18ExecutionsLoopRunTaskIdMigration extends AbstractSQLMigrationScript {
+
+    @Override
+    public String scriptId() {
+        return "2.0.18-executions-loop-run-task-id";
+    }
+
+    @Override
+    public String description() {
+        return "Executions: add generated loop_run_task_id column";
+    }
+}

--- a/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcExecutionRepository.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcExecutionRepository.java
@@ -240,6 +240,14 @@ public abstract class AbstractJdbcExecutionRepository extends AbstractJdbcCrudRe
         return filter.children().stream().anyMatch(AbstractJdbcExecutionRepository::containsLeafForKind);
     }
 
+    @Override
+    protected Name getColumnName(QueryFilter.Field field) {
+        if (field == QueryFilter.Field.TASK_ID) {
+            return DSL.quotedName("loop_run_task_id");
+        }
+        return super.getColumnName(field);
+    }
+
     private Condition buildDateFilterCondition(@Nullable List<QueryFilter> filters, @Nullable DateFilter dateFilter) {
         if (dateFilter == DateFilter.START_OR_END_DATE && filters != null) {
             List<QueryFilter> dateBoundaryFilters = filters.stream()

--- a/ui/src/components/logs/TaskRunDetails.vue
+++ b/ui/src/components/logs/TaskRunDetails.vue
@@ -243,6 +243,7 @@
                             query: {
                                 'filters[parentId][EQUALS]': asTaskRun(currentTaskRun).executionId,
                                 'filters[kind][EQUALS]': 'LOOP',
+                                'filters[taskId][EQUALS]': asTaskRun(currentTaskRun).taskId,
                             }
                         }"
                         size="small"
@@ -253,6 +254,7 @@
                         :currentTaskRunId="asTaskRun(currentTaskRun).id"
                         :loopOutputsByTaskRunId="loopOutputsByTaskRunId"
                         :executionId="asTaskRun(currentTaskRun).executionId"
+                        :taskId="asTaskRun(currentTaskRun).taskId"
                     />
                 </div>
             </DynamicScrollerItem>

--- a/ui/src/components/logs/TaskRunLoopProgress.vue
+++ b/ui/src/components/logs/TaskRunLoopProgress.vue
@@ -14,11 +14,12 @@
                 :key="loopTerminatedSegment.state" 
                 size="small"
                 :to="{
-                    // execution list filtered by Parent execution and state
+                    // execution list filtered by Parent execution, Loop task and state
                     name: 'executions/list',
                     query: {
                         'filters[parentId][EQUALS]': executionId,
                         'filters[kind][EQUALS]': 'LOOP',
+                        'filters[taskId][EQUALS]': taskId,
                         'filters[state][EQUALS]': loopTerminatedSegment.state
                     }
                 }"
@@ -41,6 +42,7 @@
     const props = defineProps<{
         executionId: string;
         currentTaskRunId: string;
+        taskId: string;
         loopOutputsByTaskRunId: Record<string, { iterationCount: number; terminatedIterations: Record<string, number> }>;
     }>()
 

--- a/webserver/src/test/java/io/kestra/webserver/controllers/api/ExecutionControllerRunnerTest.java
+++ b/webserver/src/test/java/io/kestra/webserver/controllers/api/ExecutionControllerRunnerTest.java
@@ -409,7 +409,7 @@ class ExecutionControllerRunnerTest {
         assertThat(result.getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
         assertThat(result.getTaskRunList().size()).isEqualTo(13);
 
-        var subExecutions = executionRepositoryInterface.findLoopSubExecutions(result.getTenantId(), result.getId());
+        var subExecutions = executionRepositoryInterface.findLoopSubExecutions(result.getTenantId(), result.getId(), null);
         assertThat(subExecutions).hasSize(3);
     }
 
@@ -506,6 +506,31 @@ class ExecutionControllerRunnerTest {
         assertThat(result.getResult()).isNull();
         assertThat(result.getError()).contains("Unable to find `missing` used in the expression `{{ missing }}` at line 1");
         assertThat(result.getStackTrace()).contains("Unable to find `missing` used in the expression `{{ missing }}` at line 1");
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    @LoadFlows({ "flows/valids/loop-multiple.yaml" })
+    void searchExecutionsShouldFilterLoopByTaskId() throws TimeoutException, QueueException {
+        // Given a flow with two Loop tasks (loop1 + loop2), each producing 3 iterations
+        Execution execution = runnerUtils.runOne(TENANT_ID, TESTS_FLOW_NS, "loop-multiple");
+        assertThat(execution.getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
+
+        // When searching LOOP-kind executions scoped to a single loop task's taskId
+        PagedResults<Execution> loop1Results = client.toBlocking().retrieve(
+            GET("/api/v1/%s/executions/search?filters[parentId][EQUALS]=%s&filters[kind][EQUALS]=LOOP&filters[taskId][EQUALS]=loop1".formatted(TENANT_ID, execution.getId())),
+            Argument.of(PagedResults.class, Execution.class)
+        );
+        PagedResults<Execution> loop2Results = client.toBlocking().retrieve(
+            GET("/api/v1/%s/executions/search?filters[parentId][EQUALS]=%s&filters[kind][EQUALS]=LOOP&filters[taskId][EQUALS]=loop2".formatted(TENANT_ID, execution.getId())),
+            Argument.of(PagedResults.class, Execution.class)
+        );
+
+        // Then each loop task's iterations are returned in isolation from the other loop's
+        assertThat(loop1Results.getTotal()).isEqualTo(3L);
+        assertThat(loop1Results.getResults()).allMatch(e -> "loop1".equals(e.getLoopRun().taskId()));
+        assertThat(loop2Results.getTotal()).isEqualTo(3L);
+        assertThat(loop2Results.getResults()).allMatch(e -> "loop2".equals(e.getLoopRun().taskId()));
     }
 
     @Test
@@ -832,7 +857,7 @@ class ExecutionControllerRunnerTest {
         assertThat(restarted.getId()).isNotEqualTo(parentExecution.getId());
 
         // 1_each (Loop) is kept as SUCCESS and not re-run, so no new sub-executions are created for the restarted execution
-        var subExecutions = executionRepositoryInterface.findLoopSubExecutions(restarted.getTenantId(), restarted.getId());
+        var subExecutions = executionRepositoryInterface.findLoopSubExecutions(restarted.getTenantId(), restarted.getId(), null);
         assertThat(subExecutions).hasSize(0);
     }
 

--- a/webserver/src/test/java/io/kestra/webserver/controllers/api/ExecutionControllerTest.java
+++ b/webserver/src/test/java/io/kestra/webserver/controllers/api/ExecutionControllerTest.java
@@ -364,7 +364,7 @@ class ExecutionControllerTest {
         );
         assertThat(exception.getStatus().getCode()).isEqualTo(HttpStatus.BAD_REQUEST.getCode());
         assertThat(exception.getMessage()).isEqualTo(
-            "Invalid query filters: Provided query filters are invalid: Field TRIGGER_ID is not supported for resource EXECUTION. Supported fields are QUERY, SCOPE, FLOW_ID, START_DATE, END_DATE, STATE, LABELS, TRIGGER_EXECUTION_ID, CHILD_FILTER, NAMESPACE, KIND, PARENT_ID"
+            "Invalid query filters: Provided query filters are invalid: Field TRIGGER_ID is not supported for resource EXECUTION. Supported fields are QUERY, SCOPE, FLOW_ID, START_DATE, END_DATE, STATE, LABELS, TRIGGER_EXECUTION_ID, CHILD_FILTER, NAMESPACE, KIND, PARENT_ID, TASK_ID"
         );
 
         exception = assertThrows(


### PR DESCRIPTION
## Summary
- Adds a generated `loop_run_task_id` column on `executions` (H2/Postgres/MySQL) derived from `loopRun.taskId`, so LOOP-kind iteration executions can be scoped to the single Loop task that produced them.
- Exposes it via the existing `QueryFilter.Field.TASK_ID` on the `/executions/search` API (`filters[taskId][EQUALS]=...`).
- Fixes `ExecutionRepositoryInterface.findLoopSubExecutions`, which previously always returned every Loop task's iterations under a parent execution regardless of caller intent — it now accepts an optional `taskId` scope.
- Scopes the Gantt/topology "iterations" links (`TaskRunDetails.vue`, `TaskRunLoopProgress.vue`) to the specific Loop task, so a flow with multiple Loop tasks (as in the issue's sample flow) shows each loop's iterations independently.

Fixes #17364

## Test plan
- [x] `H2ExecutionRepositoryTest` (incl. new `shouldFindLoopSubExecutionsScopedByTaskId`, covering both taskId-scoped and bare-taskId-without-kind queries)
- [x] `H2RunnerTest` full suite (incl. extended `LoopCaseTest.loopMultiple` against the real two-Loop-task `loop-multiple.yaml` fixture)
- [x] New `ExecutionControllerRunnerTest.searchExecutionsShouldFilterLoopByTaskId` (end-to-end `/executions/search` API test)
- [x] UI: `npm run check:types` and `eslint` on the two changed components