### PR TITLE
test: fix two flaky/broken tests surfaced by PR #17465's CI run

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -264,16 +264,6 @@ subprojects {subProj ->
             t.environment 'SECRET_PASSWORD', "cGFzc3dvcmQ="
             t.environment 'ENV_TEST1', "true"
             t.environment 'ENV_TEST2', "Pass by env"
-
-
-            // these modules tests were battle tested by @nkwiatkowski so we can allow to try to enable parallel testing on them
-            if (subProj.name == 'jdbc-h2' || subProj.name == 'jdbc-mysql' || subProj.name == 'jdbc-postgres') {
-                // JUnit 5 parallel settings
-                t.systemProperty 'junit.jupiter.execution.parallel.enabled', 'true'
-                t.systemProperty 'junit.jupiter.execution.parallel.mode.default', 'concurrent'
-                t.systemProperty 'junit.jupiter.execution.parallel.mode.classes.default', 'same_thread'
-                t.systemProperty 'junit.jupiter.execution.parallel.config.strategy', 'dynamic'
-            }
         }
 
         tasks.register('integrationTest', Test) { Test t ->

--- a/webserver/src/test/java/io/kestra/webserver/controllers/api/MiscControllerTest.java
+++ b/webserver/src/test/java/io/kestra/webserver/controllers/api/MiscControllerTest.java
@@ -11,6 +11,7 @@ import io.kestra.core.models.flows.FlowWithSource;
 import io.kestra.core.repositories.SettingRepositoryInterface;
 import io.kestra.core.runners.pebble.PebbleFunction;
 import io.kestra.core.utils.IdUtils;
+import io.kestra.webserver.filter.TestAuthFilter;
 import io.kestra.webserver.services.BasicAuthCredentials;
 import io.kestra.webserver.services.BasicAuthService;
 import io.kestra.webserver.services.BasicAuthService.BasicAuthConfiguration;
@@ -257,16 +258,22 @@ class MiscControllerTest {
         }
     }
 
-    @FlakyTest(description = "BasicAuth state from other tests leaks; needs full security lifecycle isolation")
     @Test
     void logout_shouldRequireAuthentication() {
         // unlike /login, /logout must not bypass AuthenticationFilter: an unauthenticated caller has
         // no session to clear, so the request is rejected rather than silently accepted.
-        assertThatThrownBy(
-            () -> client.toBlocking().exchange(HttpRequest.POST("/api/v1/logout", null))
-        ).isInstanceOfSatisfying(
-            HttpClientResponseException.class, ex -> assertThat((CharSequence) ex.getStatus()).isEqualTo(HttpStatus.UNAUTHORIZED)
-        );
+        // TestAuthFilter transparently attaches a valid Authorization header to every outgoing test
+        // request unless disabled, so it must be turned off to genuinely exercise the unauthenticated path.
+        TestAuthFilter.ENABLED = false;
+        try {
+            assertThatThrownBy(
+                () -> client.toBlocking().exchange(HttpRequest.POST("/api/v1/logout", null))
+            ).isInstanceOfSatisfying(
+                HttpClientResponseException.class, ex -> assertThat((CharSequence) ex.getStatus()).isEqualTo(HttpStatus.UNAUTHORIZED)
+            );
+        } finally {
+            TestAuthFilter.ENABLED = true;
+        }
     }
 
     @Test


### PR DESCRIPTION
## Summary

PR #17465 merged cleanly, but its CI run ([run 29580468850](https://github.com/kestra-io/kestra/actions/runs/29580468850)) turned red on two tests unrelated to that PR's own change. This is a follow-up fixing both.

- **`MysqlExecutionStatisticsCompactorTest` (build-breaking)** — `ConcurrentModificationException`. Root cause: `jdbc-h2`/`jdbc-mysql`/`jdbc-postgres` ran test methods **concurrently** within a class; `AbstractExecutionStatisticsCompactorTest` has a method-level `@Property` on one test, and Micronaut's per-method environment refresh (`DefaultEnvironment.refreshAndDiff`) raced across ForkJoinPool workers sharing one `@MicronautTest` context. Fix: disable JUnit parallel execution for these three modules (rather than a narrower per-class `@Execution(SAME_THREAD)`), eliminating this and any other latent intra-class method race for them, at the cost of some CI runtime.
- **`MiscControllerTest.logout_shouldRequireAuthentication()` (already `@FlakyTest`-quarantined, so not build-breaking)** — `TestAuthFilter` is a global test-only client filter that auto-attaches a valid default-admin `Authorization` header to every outgoing test call lacking one, so the "bare unauthenticated" logout call was never actually unauthenticated — it flaked whenever persisted basic-auth credentials matched the auto-attached default. Fix: toggle `TestAuthFilter.ENABLED = false` around the assertion (restored in `finally`), matching the existing pattern in `AuthenticationFilterTest`/`McpServerAuthenticationFilterTest`, and drop the now-unwarranted `@FlakyTest`.

## Test plan
- [x] `:jdbc-mysql:test --tests MysqlExecutionStatisticsCompactorTest` — 5/5 pass (ran twice, incl. `--rerun-tasks`)
- [x] `:jdbc-h2:test --tests H2ExecutionStatisticsCompactorTest` — pass
- [x] `:jdbc-postgres:test --tests PostgresExecutionStatisticsCompactorTest` — pass
- [x] `:jdbc-mysql:unitTest` (full suite, 746 tests) — all pass sequentially, no regression from disabling parallelism
- [x] `:webserver:test --tests MiscControllerTest` — all 9 methods pass, including the fixed `logout_shouldRequireAuthentication` alongside its still-`@FlakyTest`-tagged siblings