### PR TITLE
perf(core): load @types/node and Monaco typings registration lazily

### DIFF
--- a/ui/packages/design-system/src/components/Form/KsEditor.vue
+++ b/ui/packages/design-system/src/components/Form/KsEditor.vue
@@ -201,6 +201,7 @@
     import "monaco-editor/esm/vs/editor/standalone/browser/iPadShowKeyboard/iPadShowKeyboard"
     import "monaco-editor/esm/vs/editor/standalone/browser/quickAccess/standaloneCommandsQuickAccess"
     import "monaco-editor/esm/vs/language/json/monaco.contribution"
+    import "monaco-editor/esm/vs/language/typescript/monaco.contribution"
     import "monaco-editor/esm/vs/basic-languages/monaco.contribution"
 
     import type {VNode} from "vue"

--- a/ui/src/main.ts
+++ b/ui/src/main.ts
@@ -3,20 +3,6 @@ import type {Router} from "vue-router"
 
 import "./utils/monacoEnvironment"
 
-const NodeTypesRaw = import.meta.glob("/node_modules/@types/node/**/*.d.ts", {eager: true, query: "?raw", import: "default"}) as Record<string, string>
-function loadNodeTypes(tries = 0) {
-    import("monaco-editor/esm/vs/editor/editor.api").then(({languages}) => {
-        if (languages.typescript) {
-            for (const path in NodeTypesRaw) {
-                languages.typescript.typescriptDefaults.addExtraLib(NodeTypesRaw[path], `file://${path}`)
-            }
-        } else if (tries <= 15) {
-            setTimeout(() => loadNodeTypes(tries + 1), (tries + 1) * 100)
-        }
-    })
-}
-loadNodeTypes()
-
 import App from "./App.vue"
 import initApp from "./utils/init"
 import {setupKestraHttp} from "./utils/kestraHttp"

--- a/ui/src/utils/monacoEnvironment.ts
+++ b/ui/src/utils/monacoEnvironment.ts
@@ -3,23 +3,18 @@ import JsonWorker from "monaco-editor/esm/vs/language/json/json.worker?worker"
 import TypeScriptWorker from "monaco-editor/esm/vs/language/typescript/ts.worker?worker"
 import YamlWorker from "../components/inputs/yaml.worker.js?worker"
 
-const nodeTypesRaw = import.meta.glob("/node_modules/@types/node/**/*.d.ts", {query: "?raw", import: "default"}) as Record<string, () => Promise<string>>
-
 let nodeTypesRequested = false
 
-// Registers @types/node into Monaco's TS service on first JS/TS worker request — both
-// the types and the TS language contribution are multi-MB payloads that must not load
-// at boot. Importing the contribution is what populates `languages.typescript` (Monaco's
-// ESM build leaves it undefined otherwise).
+// Lazily registers @types/node on first JS/TS worker request. The TS contribution import
+// is what populates `languages.typescript` (Monaco's ESM build leaves it undefined otherwise).
 function loadNodeTypes() {
     Promise.all([
         import("monaco-editor/esm/vs/language/typescript/monaco.contribution"),
         import("monaco-editor/esm/vs/editor/editor.api"),
-    ]).then(([, {languages}]) => {
-        for (const path in nodeTypesRaw) {
-            nodeTypesRaw[path]().then((content) => {
-                languages.typescript.typescriptDefaults.addExtraLib(content, `file://${path}`)
-            })
+        import("./monacoNodeTypes"),
+    ]).then(([, {languages}, {default: nodeTypes}]) => {
+        for (const path in nodeTypes) {
+            languages.typescript.typescriptDefaults.addExtraLib(nodeTypes[path], `file://${path}`)
         }
     })
 }

--- a/ui/src/utils/monacoEnvironment.ts
+++ b/ui/src/utils/monacoEnvironment.ts
@@ -3,6 +3,28 @@ import JsonWorker from "monaco-editor/esm/vs/language/json/json.worker?worker"
 import TypeScriptWorker from "monaco-editor/esm/vs/language/typescript/ts.worker?worker"
 import YamlWorker from "../components/inputs/yaml.worker.js?worker"
 
+let nodeTypesRequested = false
+
+// Registers @types/node into Monaco's TypeScript language service the first
+// time a JS/TS worker is requested. Both Monaco and the raw typings are
+// multi-megabyte payloads that must not load at boot; extra libs added after
+// worker creation still propagate to open models. The retry loop waits for
+// the typescript language contribution to finish registering.
+function loadNodeTypes(tries = 0) {
+    Promise.all([
+        import("monaco-editor/esm/vs/editor/editor.api"),
+        import("./nodeTypes"),
+    ]).then(([{languages}, {default: nodeTypesRaw}]) => {
+        if (languages.typescript) {
+            for (const path in nodeTypesRaw) {
+                languages.typescript.typescriptDefaults.addExtraLib(nodeTypesRaw[path], `file://${path}`)
+            }
+        } else if (tries <= 15) {
+            setTimeout(() => loadNodeTypes(tries + 1), (tries + 1) * 100)
+        }
+    })
+}
+
 window.MonacoEnvironment = {
     getWorker(_moduleId, label) {
         switch (label) {
@@ -14,6 +36,10 @@ window.MonacoEnvironment = {
             return new JsonWorker()
         case "javascript":
         case "typescript":
+            if (!nodeTypesRequested) {
+                nodeTypesRequested = true
+                loadNodeTypes()
+            }
             return new TypeScriptWorker()
         default:
             throw new Error(`Unknown label ${label}`)

--- a/ui/src/utils/monacoEnvironment.ts
+++ b/ui/src/utils/monacoEnvironment.ts
@@ -8,18 +8,18 @@ const nodeTypesRaw = import.meta.glob("/node_modules/@types/node/**/*.d.ts", {qu
 let nodeTypesRequested = false
 
 // Registers @types/node into Monaco's TS service on first JS/TS worker request — both
-// are multi-MB payloads that must not load at boot. Retries until languages.typescript exists.
-function loadNodeTypes(tries = 0) {
-    import("monaco-editor/esm/vs/editor/editor.api").then(({languages}) => {
-        const typescript = languages.typescript
-        if (typescript) {
-            for (const path in nodeTypesRaw) {
-                nodeTypesRaw[path]().then((content) => {
-                    typescript.typescriptDefaults.addExtraLib(content, `file://${path}`)
-                })
-            }
-        } else if (tries <= 15) {
-            setTimeout(() => loadNodeTypes(tries + 1), (tries + 1) * 100)
+// the types and the TS language contribution are multi-MB payloads that must not load
+// at boot. Importing the contribution is what populates `languages.typescript` (Monaco's
+// ESM build leaves it undefined otherwise).
+function loadNodeTypes() {
+    Promise.all([
+        import("monaco-editor/esm/vs/language/typescript/monaco.contribution"),
+        import("monaco-editor/esm/vs/editor/editor.api"),
+    ]).then(([, {languages}]) => {
+        for (const path in nodeTypesRaw) {
+            nodeTypesRaw[path]().then((content) => {
+                languages.typescript.typescriptDefaults.addExtraLib(content, `file://${path}`)
+            })
         }
     })
 }

--- a/ui/src/utils/monacoEnvironment.ts
+++ b/ui/src/utils/monacoEnvironment.ts
@@ -5,11 +5,8 @@ import YamlWorker from "../components/inputs/yaml.worker.js?worker"
 
 let nodeTypesRequested = false
 
-// Registers @types/node into Monaco's TypeScript language service the first
-// time a JS/TS worker is requested. Both Monaco and the raw typings are
-// multi-megabyte payloads that must not load at boot; extra libs added after
-// worker creation still propagate to open models. The retry loop waits for
-// the typescript language contribution to finish registering.
+// Registers @types/node into Monaco's TS service on first JS/TS worker request — both
+// are multi-MB payloads that must not load at boot. Retries until languages.typescript exists.
 function loadNodeTypes(tries = 0) {
     Promise.all([
         import("monaco-editor/esm/vs/editor/editor.api"),

--- a/ui/src/utils/monacoEnvironment.ts
+++ b/ui/src/utils/monacoEnvironment.ts
@@ -3,18 +3,20 @@ import JsonWorker from "monaco-editor/esm/vs/language/json/json.worker?worker"
 import TypeScriptWorker from "monaco-editor/esm/vs/language/typescript/ts.worker?worker"
 import YamlWorker from "../components/inputs/yaml.worker.js?worker"
 
+const nodeTypesRaw = import.meta.glob("/node_modules/@types/node/**/*.d.ts", {query: "?raw", import: "default"}) as Record<string, () => Promise<string>>
+
 let nodeTypesRequested = false
 
 // Registers @types/node into Monaco's TS service on first JS/TS worker request — both
 // are multi-MB payloads that must not load at boot. Retries until languages.typescript exists.
 function loadNodeTypes(tries = 0) {
-    Promise.all([
-        import("monaco-editor/esm/vs/editor/editor.api"),
-        import("./nodeTypes"),
-    ]).then(([{languages}, {default: nodeTypesRaw}]) => {
-        if (languages.typescript) {
+    import("monaco-editor/esm/vs/editor/editor.api").then(({languages}) => {
+        const typescript = languages.typescript
+        if (typescript) {
             for (const path in nodeTypesRaw) {
-                languages.typescript.typescriptDefaults.addExtraLib(nodeTypesRaw[path], `file://${path}`)
+                nodeTypesRaw[path]().then((content) => {
+                    typescript.typescriptDefaults.addExtraLib(content, `file://${path}`)
+                })
             }
         } else if (tries <= 15) {
             setTimeout(() => loadNodeTypes(tries + 1), (tries + 1) * 100)

--- a/ui/src/utils/monacoNodeTypes.ts
+++ b/ui/src/utils/monacoNodeTypes.ts
@@ -1,0 +1,5 @@
+// Eager `?raw` glob inlines every @types/node .d.ts here; reached only via dynamic import()
+// from monacoEnvironment, so the whole tree is one lazy chunk, off the boot critical path.
+const nodeTypes = import.meta.glob("/node_modules/@types/node/**/*.d.ts", {eager: true, query: "?raw", import: "default"}) as Record<string, string>
+
+export default nodeTypes

--- a/ui/src/utils/nodeTypes.ts
+++ b/ui/src/utils/nodeTypes.ts
@@ -1,4 +1,0 @@
-// Several megabytes of raw @types/node typings for the Monaco TypeScript
-// language service. Only ever import this module dynamically — a static
-// import would inline the whole payload into the importer's chunk.
-export default import.meta.glob("/node_modules/@types/node/**/*.d.ts", {eager: true, query: "?raw", import: "default"}) as Record<string, string>

--- a/ui/src/utils/nodeTypes.ts
+++ b/ui/src/utils/nodeTypes.ts
@@ -1,0 +1,4 @@
+// Several megabytes of raw @types/node typings for the Monaco TypeScript
+// language service. Only ever import this module dynamically — a static
+// import would inline the whole payload into the importer's chunk.
+export default import.meta.glob("/node_modules/@types/node/**/*.d.ts", {eager: true, query: "?raw", import: "default"}) as Record<string, string>


### PR DESCRIPTION
### ✨ Description

`main.ts` eagerly inlined the entire `@types/node` tree as raw strings (`import.meta.glob` with `eager: true`) and kicked off a Monaco import at boot for every user, editor page or not. The typings alone accounted for **2.4 MB of the 2.65 MB entry chunk** (~444 KB gzipped on the critical path).

This PR (updated per review):
- moves the typings glob into a dedicated `monacoNodeTypes.ts` module (eager `?raw` glob) that is **dynamically imported** from `monacoEnvironment.ts`, so Vite bundles the whole `@types/node` tree into a **single lazy chunk** — off the boot critical path, and one request instead of ~60 separate chunks;
- registers the extra libs from `MonacoEnvironment.getWorker` the first time a `javascript`/`typescript` worker is requested — the earliest point a user actually needs node typings;
- **imports the Monaco TypeScript language contribution** (`monaco-editor/esm/vs/language/typescript/monaco.contribution`) in both the lazy loader and `KsEditor`. Monaco 0.52's ESM build leaves `languages.typescript` undefined until this module is imported — without it the typings registration (and `KsEditor`'s `setCompilerOptions`) silently no-op'd. This fixes a **regression** in ambient-type completions introduced by the Monaco update.

**Measured (production build):**

| | before | after |
|---|---|---|
| entry chunk (`index-*.js`) | 2,648 KB (gzip 518 KB) | **~249 KB (gzip ~74 KB)** |
| `@types/node` payload | in entry chunk, fetched at boot | **1 lazy chunk** (`monacoNodeTypes-*.js`, 2,468 KB / gzip 441 KB), fetched on first JS/TS editor use, not preloaded |

### 🔗 Related Issue

None — follows up on an internal frontend performance audit.

### 🎨 Frontend Checklist

- [x] Code builds without errors (`npm run build`)
- [ ] All existing E2E tests pass (`npm run test:e2e`)
- [ ] Screenshots or video recordings attached showing the `UI` changes — no visual changes; verified nothing typings-related appears in `index.html` preloads

### 📝 Additional Notes

- The single-chunk approach keeps the typings off the boot path while collapsing ~60 network requests into one; the chunk only loads when a JS/TS editor is first used.
- The `editor.api` chunk itself is still `modulepreload`ed because app code (`KsEditor`, the monaco language-configurator composables) imports it statically — untangling that is a separate, larger refactor worth its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014kPcgZ5tmBYQFfZJ69e5Mj