### PR TITLE
fix(scripts): clean up leaked Docker container on interrupt during setup

### DIFF
--- a/script/src/main/java/io/kestra/plugin/scripts/runner/docker/Docker.java
+++ b/script/src/main/java/io/kestra/plugin/scripts/runner/docker/Docker.java
@@ -417,123 +417,133 @@ public class Docker extends TaskRunner<Docker.DockerTaskRunnerDetailResult> {
             String filesVolumeName = null;
             var strategy = runContext.render(this.fileHandlingStrategy).as(FileHandlingStrategy.class).orElse(null);
 
-            // pull image only if we will create a new container
-            if (containerId == null) {
-                var renderedPolicy = runContext.render(this.getPullPolicy()).as(PullPolicy.class).orElseThrow();
-                if (!PullPolicy.NEVER.equals(renderedPolicy)) {
-                    pullImage(dockerClient, image, renderedPolicy, logger);
-                }
+            // Everything below that can leave a container behind (create or resume) must clean it up if it
+            // throws — e.g. a raw Thread.interrupt() landing on a blocking Docker HTTP call here would otherwise
+            // leak the container, since the attach/wait phase's cleanup finally hasn't been entered yet.
+            try {
+                // pull image only if we will create a new container
+                if (containerId == null) {
+                    var renderedPolicy = runContext.render(this.getPullPolicy()).as(PullPolicy.class).orElseThrow();
+                    if (!PullPolicy.NEVER.equals(renderedPolicy)) {
+                        pullImage(dockerClient, image, renderedPolicy, logger);
+                    }
 
-                // we check, if killed during image pull.
-                checkKilled("Execution was killed during image pull.");
+                    // we check, if killed during image pull.
+                    checkKilled("Execution was killed during image pull.");
 
-                // create container
-                CreateContainerCmd container = configure(taskCommands, dockerClient, runContext, additionalVars);
-                CreateContainerResponse exec = container.exec();
-                containerId = exec.getId();
-                containerIdRef.set(containerId);
+                    // create container
+                    CreateContainerCmd container = configure(taskCommands, dockerClient, runContext, additionalVars);
+                    CreateContainerResponse exec = container.exec();
+                    containerId = exec.getId();
+                    containerIdRef.set(containerId);
 
-                if (logger.isTraceEnabled()) {
-                    logger.trace("Container created: {}", containerId);
-                }
-
-                // create a volume if we need to handle files
-                if (needVolume && FileHandlingStrategy.VOLUME.equals(strategy)) {
-                    CreateVolumeCmd files = dockerClient.createVolumeCmd()
-                        .withLabels(labels);
-                    filesVolumeName = files.exec().getName();
                     if (logger.isTraceEnabled()) {
-                        logger.trace("Volume created: {}", filesVolumeName);
+                        logger.trace("Container created: {}", containerId);
                     }
 
-                    String remotePath = windowsToUnixPath(taskCommands.getWorkingDirectory().toString());
-
-                    // first, create an archive
-                    Path fileArchive = runContext.workingDir().createFile("inputFiles.tar");
-                    try (
-                        FileOutputStream fos = new FileOutputStream(fileArchive.toString());
-                        TarArchiveOutputStream out = new TarArchiveOutputStream(fos)
-                    ) {
-                        out.setLongFileMode(TarArchiveOutputStream.LONGFILE_POSIX); // allow long file name
-                        out.setBigNumberMode(TarArchiveOutputStream.BIGNUMBER_POSIX); // allow large archive name
-
-                        for (Path file : relativeWorkingDirectoryFilesPaths) {
-                            Path resolvedFile = runContext.workingDir().resolve(file);
-                            TarArchiveEntry entry = out.createArchiveEntry(resolvedFile.toFile(), file.toString());
-                            // Preserve POSIX permissions if supported
-                            try {
-                                Set<PosixFilePermission> perms = Files.getPosixFilePermissions(resolvedFile);
-                                entry.setMode(UnixModeToPosixFilePermissions.fromPosixFilePermissions(perms));
-                            } catch (UnsupportedOperationException | IOException ignore) {
-                                // Skipping unix file permission
-                            }
-                            out.putArchiveEntry(entry);
-                            if (!Files.isDirectory(resolvedFile)) {
-                                try (InputStream fis = Files.newInputStream(resolvedFile)) {
-                                    IOUtils.copy(fis, out);
-                                }
-                            }
-                            out.closeArchiveEntry();
+                    // create a volume if we need to handle files
+                    if (needVolume && FileHandlingStrategy.VOLUME.equals(strategy)) {
+                        CreateVolumeCmd files = dockerClient.createVolumeCmd()
+                            .withLabels(labels);
+                        filesVolumeName = files.exec().getName();
+                        if (logger.isTraceEnabled()) {
+                            logger.trace("Volume created: {}", filesVolumeName);
                         }
-                        out.finish();
+
+                        String remotePath = windowsToUnixPath(taskCommands.getWorkingDirectory().toString());
+
+                        // first, create an archive
+                        Path fileArchive = runContext.workingDir().createFile("inputFiles.tar");
+                        try (
+                            FileOutputStream fos = new FileOutputStream(fileArchive.toString());
+                            TarArchiveOutputStream out = new TarArchiveOutputStream(fos)
+                        ) {
+                            out.setLongFileMode(TarArchiveOutputStream.LONGFILE_POSIX); // allow long file name
+                            out.setBigNumberMode(TarArchiveOutputStream.BIGNUMBER_POSIX); // allow large archive name
+
+                            for (Path file : relativeWorkingDirectoryFilesPaths) {
+                                Path resolvedFile = runContext.workingDir().resolve(file);
+                                TarArchiveEntry entry = out.createArchiveEntry(resolvedFile.toFile(), file.toString());
+                                // Preserve POSIX permissions if supported
+                                try {
+                                    Set<PosixFilePermission> perms = Files.getPosixFilePermissions(resolvedFile);
+                                    entry.setMode(UnixModeToPosixFilePermissions.fromPosixFilePermissions(perms));
+                                } catch (UnsupportedOperationException | IOException ignore) {
+                                    // Skipping unix file permission
+                                }
+                                out.putArchiveEntry(entry);
+                                if (!Files.isDirectory(resolvedFile)) {
+                                    try (InputStream fis = Files.newInputStream(resolvedFile)) {
+                                        IOUtils.copy(fis, out);
+                                    }
+                                }
+                                out.closeArchiveEntry();
+                            }
+                            out.finish();
+                        }
+
+                        // then send it to the container
+                        try (InputStream is = new FileInputStream(fileArchive.toString())) {
+                            CopyArchiveToContainerCmd copyArchiveToContainerCmd = dockerClient.copyArchiveToContainerCmd(containerId)
+                                .withTarInputStream(is)
+                                .withRemotePath(remotePath);
+                            copyArchiveToContainerCmd.exec();
+                        }
+
+                        Files.delete(fileArchive);
+
+                        // create the outputDir if needed
+                        if (taskCommands.outputDirectoryEnabled()) {
+                            CopyArchiveToContainerCmd copyArchiveToContainerCmd = dockerClient.copyArchiveToContainerCmd(containerId)
+                                .withHostResource(taskCommands.getOutputDirectory().toString())
+                                .withRemotePath(remotePath);
+                            copyArchiveToContainerCmd.exec();
+                        }
                     }
 
-                    // then send it to the container
-                    try (InputStream is = new FileInputStream(fileArchive.toString())) {
-                        CopyArchiveToContainerCmd copyArchiveToContainerCmd = dockerClient.copyArchiveToContainerCmd(containerId)
-                            .withTarInputStream(is)
-                            .withRemotePath(remotePath);
-                        copyArchiveToContainerCmd.exec();
+                    // we check, if killed before container start
+                    checkKilled("Execution was killed before starting the container.");
+
+                    // start container
+                    dockerClient.startContainerCmd(containerId).exec();
+
+                    List<String> renderedCommands = runContext.render(taskCommands.getCommands()).asList(String.class);
+
+                    if (logger.isDebugEnabled()) {
+                        logger.debug(
+                            "Starting command with container id {} [{}]",
+                            containerId,
+                            String.join(" ", renderedCommands)
+                        );
+                    }
+                } else {
+                    // resumed path: do not re-create or start the container, just attach and wait
+                    if (logger.isDebugEnabled()) {
+                        logger.debug("Attaching to logs of container {}", containerId);
+                    }
+                    if (needVolume && FileHandlingStrategy.VOLUME.equals(strategy)) {
+                        List<String> labelsList = labels.entrySet()
+                            .stream()
+                            .map(entry -> String.join("=", entry.getKey(), entry.getValue()))
+                            .toList();
+                        var volumes = dockerClient.listVolumesCmd()
+                            .withFilter("label", labelsList).exec();
+                        if (volumes.getVolumes() == null || volumes.getVolumes().isEmpty()) {
+                            logger.error("No volume found for resumed container {}", containerId);
+                            throw new TaskException(1, defaultLogConsumer);
+                        } else {
+                            var volume = volumes.getVolumes().get(0);
+                            filesVolumeName = volume.getName();
+                            logger.debug("Volume found with name {} for resumed container {}", filesVolumeName, containerId);
+                        }
                     }
 
-                    Files.delete(fileArchive);
-
-                    // create the outputDir if needed
-                    if (taskCommands.outputDirectoryEnabled()) {
-                        CopyArchiveToContainerCmd copyArchiveToContainerCmd = dockerClient.copyArchiveToContainerCmd(containerId)
-                            .withHostResource(taskCommands.getOutputDirectory().toString())
-                            .withRemotePath(remotePath);
-                        copyArchiveToContainerCmd.exec();
-                    }
                 }
-
-                // we check, if killed before container start
-                checkKilled("Execution was killed before starting the container.");
-
-                // start container
-                dockerClient.startContainerCmd(containerId).exec();
-
-                List<String> renderedCommands = runContext.render(taskCommands.getCommands()).asList(String.class);
-
-                if (logger.isDebugEnabled()) {
-                    logger.debug(
-                        "Starting command with container id {} [{}]",
-                        containerId,
-                        String.join(" ", renderedCommands)
-                    );
+            } catch (Exception e) {
+                if (containerId != null) {
+                    cleanupContainer(dockerClient, containerId, needVolume, strategy, filesVolumeName, renderedDelete, logger);
                 }
-            } else {
-                // resumed path: do not re-create or start the container, just attach and wait
-                if (logger.isDebugEnabled()) {
-                    logger.debug("Attaching to logs of container {}", containerId);
-                }
-                if (needVolume && FileHandlingStrategy.VOLUME.equals(strategy)) {
-                    List<String> labelsList = labels.entrySet()
-                        .stream()
-                        .map(entry -> String.join("=", entry.getKey(), entry.getValue()))
-                        .toList();
-                    var volumes = dockerClient.listVolumesCmd()
-                        .withFilter("label", labelsList).exec();
-                    if (volumes.getVolumes() == null || volumes.getVolumes().isEmpty()) {
-                        logger.error("No volume found for resumed container {}", containerId);
-                        throw new TaskException(1, defaultLogConsumer);
-                    } else {
-                        var volume = volumes.getVolumes().get(0);
-                        filesVolumeName = volume.getName();
-                        logger.debug("Volume found with name {} for resumed container {}", filesVolumeName, containerId);
-                    }
-                }
-
+                throw e;
             }
 
             final String runContainerId = containerId;
@@ -631,32 +641,7 @@ public class Docker extends TaskRunner<Docker.DockerTaskRunnerDetailResult> {
                     .details(DockerTaskRunnerDetailResult.builder().containerId(runContainerId).build())
                     .build();
             } finally {
-                // Clear the interrupted flag so Docker HTTP cleanup calls are not rejected.
-                boolean wasInterrupted = Thread.interrupted();
-                try {
-                    kill();
-
-                    if (Boolean.TRUE.equals(renderedDelete)) {
-                        dockerClient.removeContainerCmd(runContainerId).exec();
-                        if (logger.isTraceEnabled()) {
-                            logger.trace("Container deleted: {}", runContainerId);
-                        }
-
-                        if (needVolume && FileHandlingStrategy.VOLUME.equals(strategy) && filesVolumeName != null) {
-                            dockerClient.removeVolumeCmd(filesVolumeName).exec();
-
-                            if (logger.isTraceEnabled()) {
-                                logger.trace("Volume deleted: {}", filesVolumeName);
-                            }
-                        }
-                    }
-                } catch (Exception ignored) {
-
-                } finally {
-                    if (wasInterrupted) {
-                        Thread.currentThread().interrupt();
-                    }
-                }
+                cleanupContainer(dockerClient, runContainerId, needVolume, strategy, filesVolumeName, renderedDelete, logger);
             }
         } catch (RuntimeException e) {
             if (isDockerSocketAccessError(e)) {
@@ -666,6 +651,45 @@ public class Docker extends TaskRunner<Docker.DockerTaskRunnerDetailResult> {
                 );
             }
             throw e;
+        }
+    }
+
+    /**
+     * Kills the running container (via the registered {@code onKill} runnable) and, if {@code renderedDelete}
+     * is true, removes the container and its files volume. Clears the thread's interrupted flag beforehand so
+     * these cleanup HTTP calls are not themselves rejected by a lingering interrupt, then restores it afterward.
+     * <p>
+     * Called both when the run is interrupted before reaching the attach/wait phase (setup-phase catch) and
+     * during normal completion cleanup (attach/wait phase finally), so a container is never leaked regardless
+     * of where in {@link #run} the interruption or failure occurs.
+     */
+    private void cleanupContainer(DockerClient dockerClient, String containerId, boolean needVolume, FileHandlingStrategy strategy, String filesVolumeName, Boolean renderedDelete,
+        Logger logger) {
+        // Clear the interrupted flag so Docker HTTP cleanup calls are not rejected.
+        boolean wasInterrupted = Thread.interrupted();
+        try {
+            kill();
+
+            if (Boolean.TRUE.equals(renderedDelete)) {
+                dockerClient.removeContainerCmd(containerId).exec();
+                if (logger.isTraceEnabled()) {
+                    logger.trace("Container deleted: {}", containerId);
+                }
+
+                if (needVolume && FileHandlingStrategy.VOLUME.equals(strategy) && filesVolumeName != null) {
+                    dockerClient.removeVolumeCmd(filesVolumeName).exec();
+
+                    if (logger.isTraceEnabled()) {
+                        logger.trace("Volume deleted: {}", filesVolumeName);
+                    }
+                }
+            }
+        } catch (Exception ignored) {
+
+        } finally {
+            if (wasInterrupted) {
+                Thread.currentThread().interrupt();
+            }
         }
     }
 

--- a/script/src/test/java/io/kestra/plugin/scripts/runner/docker/DockerTest.java
+++ b/script/src/test/java/io/kestra/plugin/scripts/runner/docker/DockerTest.java
@@ -18,7 +18,6 @@ import org.mockito.Mockito;
 
 import com.github.dockerjava.api.model.Container;
 
-import io.kestra.core.junit.annotations.FlakyTest;
 import io.kestra.core.models.executions.LogEntry;
 import io.kestra.core.models.property.Property;
 import io.kestra.core.models.tasks.runners.AbstractTaskRunnerTest;
@@ -231,7 +230,6 @@ class DockerTest extends AbstractTaskRunnerTest {
     }
 
     @Test
-    @FlakyTest(description = "Docker container lifecycle timing varies across CI environments")
     void interruptAfterResume() throws Exception {
         var taskRunId = IdUtils.create();
 


### PR DESCRIPTION
## Summary

`io.kestra.plugin.scripts.runner.docker.DockerTest.interruptAfterResume()` has been `@FlakyTest`-quarantined and fails often in CI — e.g. on [PR #17485](https://github.com/kestra-io/kestra/pull/17485), with `AssertionError: Expected: is <true> but: was <false>` on the test's final "no leftover containers" assertion.

**Root cause:** `Docker.run()` only guaranteed container/volume cleanup (kill + optional delete) via a `try/finally` wrapping the attach-and-wait phase. Everything before that — resume-container lookup, image pull, container creation, volume/file handling, container start, and the resumed-path's volume lookup (`listVolumesCmd()`) — had no cleanup safety net. If the executing thread was raw-interrupted (`Thread.interrupt()`, as opposed to the graceful `TaskRunner.kill()` API) while blocked on a Docker HTTP call in that window, the resulting exception propagated straight out of `run()`, leaking the container. This explains why the sibling test `killAfterResume()` (same file, never flaky) is reliable: it calls the graceful `.kill()` API instead of raw `Thread.interrupt()`, so it never exercised this gap.

## Changes

- `Docker.java`: extracted the cleanup logic into a shared `cleanupContainer(...)` helper, and wrapped the container-resolution/pre-attach setup phase in a `try/catch(Exception)` that runs the same cleanup on any exception before rethrowing — mirroring the existing `finally` used for the attach/wait phase. This closes the leak for both the create path (image pull / create / volume-populate / start) and the resume path (volume lookup), all previously unprotected.
- `DockerTest.java`: removed `@FlakyTest` from `interruptAfterResume()` now that cleanup is deterministic regardless of where the interrupt lands.

## Test plan

- [x] `:script:compileJava` / `:script:compileTestJava` — clean
- [x] `:script:test --tests ...DockerTest.interruptAfterResume` — run 5x against a real Docker daemon (previously flaky) — all pass
- [x] `:script:test --tests ...DockerTest` (full class, 10 tests) — all pass, including `killAfterResume()` (no regression)
- [x] Verified no containers leaked by any test run (`docker ps -a` before/after)
- [x] Code-reviewed; one indentation nit found and fixed via `spotlessApply`