### PR TITLE
fix(triggers): fix orphan-GC race in unlock and restart, validate flow exists first

### DIFF
--- a/webserver/src/main/java/io/kestra/webserver/services/TriggerStateService.java
+++ b/webserver/src/main/java/io/kestra/webserver/services/TriggerStateService.java
@@ -75,7 +75,7 @@ public class TriggerStateService {
      *
      * @param trigger the trigger identifier.
      * @return the refreshed trigger state.
-     * @throws NotFoundException if the trigger does not exist.
+     * @throws NotFoundException if the trigger, its flow, or the trigger definition within that flow does not exist.
      * @throws ConflictException if the trigger is already unlocked, is a realtime trigger, or the reset failed.
      */
     public TriggerState unlockTriggerById(final TriggerId trigger) throws NotFoundException, ConflictException {
@@ -88,6 +88,9 @@ public class TriggerStateService {
             // scheduler submit a second instance while the first is still running on a worker.
             throw new ConflictException("trigger %s is a realtime trigger, reset it to kill and restart it".formatted(trigger));
         }
+        // Fail fast if the trigger is orphaned otherwise the reset would race the scheduler's orphan-GC.
+        validateToggleable(trigger);
+
         awaitBlockingAction(
             trigger.uid(),
             operationId -> triggerEventQueue.send(new ResetTrigger(trigger).withOperationId(operationId)),
@@ -97,8 +100,8 @@ public class TriggerStateService {
     }
 
     /**
-     * Unlocks all locked triggers among the given identifiers. Non-existing, already-unlocked
-     * and realtime triggers are silently skipped.
+     * Unlocks all locked triggers among the given identifiers. Non-existing, already-unlocked,
+     * realtime, and orphaned (flow or trigger definition missing) triggers are silently skipped.
      *
      * @param triggers the trigger identifiers.
      * @return an async-operation response with the count of unlock events emitted.
@@ -106,6 +109,7 @@ public class TriggerStateService {
     public ApiAsyncOperationResponse unlockAllByIds(List<TriggerId> triggers) {
         List<TriggerId> lockedIds = triggers.stream()
             .filter(id -> triggerRepository.findById(id).map(TriggerStateService::isUnlockable).orElse(false))
+            .filter(this::isFlowBackedTrigger)
             .toList();
         return submitBatch(
             lockedIds, (id, operationId) -> triggerEventQueue.send(new ResetTrigger(id).withOperationId(operationId))
@@ -113,7 +117,8 @@ public class TriggerStateService {
     }
 
     /**
-     * Unlocks all locked triggers matching the given filters. Realtime triggers are silently skipped.
+     * Unlocks all locked triggers matching the given filters. Realtime and orphaned (flow or
+     * trigger definition missing) triggers are silently skipped.
      *
      * @param tenant the tenant identifier.
      * @param filters the query filters.
@@ -123,6 +128,7 @@ public class TriggerStateService {
         List<TriggerId> lockedIds = triggerRepository.find(tenant, filters)
             .filter(TriggerStateService::isUnlockable)
             .map(TriggerId::of)
+            .filter(this::isFlowBackedTrigger)
             .collectList()
             .blockOptional()
             .orElse(List.of());
@@ -137,12 +143,15 @@ public class TriggerStateService {
      *
      * @param triggerId the trigger identifier.
      * @return the refreshed trigger state.
-     * @throws NotFoundException if the trigger does not exist.
+     * @throws NotFoundException if the trigger, its flow, or the trigger definition within that flow does not exist.
      * @throws QueueException if the execution-killed event cannot be emitted.
      * @throws ConflictException if the reset failed.
      */
     public TriggerState resetTrigger(final TriggerId triggerId) throws NotFoundException, QueueException, ConflictException {
         getTriggerState(triggerId);
+        // Fail fast if the trigger is orphaned otherwise the reset would race the scheduler's orphan-GC.
+        validateToggleable(triggerId);
+
         executionKilledQueue.emit(
             ExecutionKilledTrigger.builder()
                 // Trigger kills are not processed by the Executor: emit them directly in the
@@ -378,6 +387,18 @@ public class TriggerStateService {
             .filter(t -> t.getId().equals(triggerId.getTriggerId()))
             .findFirst()
             .orElseThrow(() -> new NotFoundException("Trigger not found: %s".formatted(triggerId)));
+    }
+
+    /**
+     * Same check as {@link #validateToggleable(TriggerId)}, as a boolean predicate for stream filtering.
+     */
+    private boolean isFlowBackedTrigger(TriggerId triggerId) {
+        try {
+            validateToggleable(triggerId);
+            return true;
+        } catch (NotFoundException e) {
+            return false;
+        }
     }
 
     private ApiAsyncOperationResponse submitExistingBatch(List<TriggerId> triggers, java.util.function.BiConsumer<TriggerId, String> emit) {

--- a/webserver/src/test/java/io/kestra/webserver/controllers/api/TriggerControllerTest.java
+++ b/webserver/src/test/java/io/kestra/webserver/controllers/api/TriggerControllerTest.java
@@ -175,10 +175,9 @@ class TriggerControllerTest {
     }
 
     @Test
-    void shouldUnlockTriggerWhenLocked() {
+    void shouldUnlockTriggerWhenLocked() throws FlowProcessingException, QueueException {
         // GIVEN
-        TriggerState trigger = newRandomTriggerState().locked(Clock.systemDefaultZone(), true);
-        jdbcTriggerRepository.save(trigger);
+        TriggerState trigger = newLockedFlowBackedTrigger();
 
         // WHEN
         HttpResponse<ApiTriggerState> exchange = client.toBlocking().exchange(
@@ -273,27 +272,40 @@ class TriggerControllerTest {
     }
 
     @Test
+    void shouldReturnNotFoundWhenUnlockingOrphanedTrigger() {
+        // GIVEN — a locked trigger row whose flow doesn't exist (e.g. deleted after the trigger was
+        // locked, before orphan-GC caught up). Unlocking it must fail fast instead of racing that GC.
+        TriggerState trigger = newRandomTriggerState().locked(Clock.systemDefaultZone(), true);
+        jdbcTriggerRepository.save(trigger);
+
+        // WHEN
+        HttpClientResponseException e = assertThrows(
+            HttpClientResponseException.class, () -> client.toBlocking().exchange(
+                HttpRequest.POST(
+                    (TRIGGER_PATH + "/%s/%s/%s/unlock").formatted(
+                        trigger.getNamespace(),
+                        trigger.getFlowId(),
+                        trigger.getTriggerId()
+                    ), null
+                )
+            )
+        );
+
+        // THEN
+        assertThat(e.getStatus().getCode()).isEqualTo(HttpStatus.NOT_FOUND.getCode());
+    }
+
+    @Test
     void shouldRestartTriggerWhenExists() throws FlowProcessingException, QueueException {
-        // GIVEN
-        Flow flow = generateFlow();
-        flowService.create(GenericFlow.of(flow));
-
-        TriggerState trigger = TriggerState.builder()
-            .flowId(flow.getId())
-            .namespace(flow.getNamespace())
-            .tenantId(TENANT_ID)
-            .triggerId("trigger-to-restart")
-            .locked(true)
-            .disabled(true)
-            .build();
-
-        jdbcTriggerRepository.create(trigger);
+        // GIVEN — a real, flow-backed trigger: restarting a flow-less trigger would race the
+        // scheduler's orphan-GC the same way unlocking one does (see newLockedFlowBackedTrigger javadoc).
+        TriggerState trigger = newLockedFlowBackedTrigger();
 
         // WHEN
         HttpResponse<ApiTriggerState> restarted = client.toBlocking().exchange(
             HttpRequest.POST(
                 (TRIGGER_PATH
-                    + "/%s/%s/%s/restart".formatted(flow.getNamespace(), flow.getId(), trigger.getTriggerId())),
+                    + "/%s/%s/%s/restart".formatted(trigger.getNamespace(), trigger.getFlowId(), trigger.getTriggerId())),
                 null
             ),
             ApiTriggerState.class
@@ -312,6 +324,30 @@ class TriggerControllerTest {
         );
 
         assertThat(exception.getStatus().getCode()).isEqualTo(HttpStatus.NOT_FOUND.getCode());
+    }
+
+    @Test
+    void shouldReturnNotFoundWhenRestartingOrphanedTrigger() {
+        // GIVEN — a locked trigger row whose flow doesn't exist (e.g. deleted after the trigger was
+        // locked, before orphan-GC caught up). Restarting it must fail fast instead of racing that GC.
+        TriggerState trigger = newRandomTriggerState().locked(Clock.systemDefaultZone(), true);
+        jdbcTriggerRepository.save(trigger);
+
+        // WHEN
+        HttpClientResponseException e = assertThrows(
+            HttpClientResponseException.class, () -> client.toBlocking().exchange(
+                HttpRequest.POST(
+                    (TRIGGER_PATH + "/%s/%s/%s/restart").formatted(
+                        trigger.getNamespace(),
+                        trigger.getFlowId(),
+                        trigger.getTriggerId()
+                    ), null
+                )
+            )
+        );
+
+        // THEN
+        assertThat(e.getStatus().getCode()).isEqualTo(HttpStatus.NOT_FOUND.getCode());
     }
 
     @Test
@@ -360,11 +396,9 @@ class TriggerControllerTest {
     }
 
     @Test
-    void shouldAcceptUnlockByIdsWhenLocked() {
+    void shouldAcceptUnlockByIdsWhenLocked() throws FlowProcessingException, QueueException {
         // GIVEN
-        TriggerState state = newRandomTriggerState().locked(Clock.systemDefaultZone(), true);
-
-        jdbcTriggerRepository.save(state);
+        TriggerState state = newLockedFlowBackedTrigger();
 
         // WHEN
         List<TriggerController.ApiTriggerId> triggers = List.of(new TriggerController.ApiTriggerId(state.getNamespace(), state.getFlowId(), state.getTriggerId()));
@@ -417,11 +451,9 @@ class TriggerControllerTest {
     }
 
     @Test
-    void shouldAcceptUnlockByQueryWhenLocked() {
+    void shouldAcceptUnlockByQueryWhenLocked() throws FlowProcessingException, QueueException {
         // GIVEN
-        TriggerState state = newRandomTriggerState().locked(Clock.systemDefaultZone(), true);
-
-        jdbcTriggerRepository.save(state);
+        TriggerState state = newLockedFlowBackedTrigger();
 
         // WHEN
         HttpResponse<ApiAsyncOperationResponse> response = client.toBlocking().exchange(
@@ -648,6 +680,21 @@ class TriggerControllerTest {
             .type(type)
             .vnode(VNodes.computeVNodeFromFlow(FlowId.of(TENANT_ID, random, random, null), schedulerConfiguration.vnodes()))
             .build();
+    }
+
+    private TriggerState newLockedFlowBackedTrigger() throws FlowProcessingException, QueueException {
+        Flow flow = generateFlowWithTrigger(IdUtils.create().toLowerCase());
+        TriggerState fixture = createTriggerFromFlow(flow, false);
+        flowService.create(GenericFlow.of(flow));
+
+        // The flow's own trigger creation asynchronously seeds a TriggerState row; wait for it
+        // instead of racing it with our own save(), then lock that row.
+        Awaitility.await().atMost(Duration.ofSeconds(30)).pollInterval(Duration.ofMillis(100))
+            .until(() -> jdbcTriggerRepository.findById(fixture).isPresent());
+        TriggerState trigger = jdbcTriggerRepository.findById(fixture).orElseThrow()
+            .locked(Clock.systemDefaultZone(), true);
+        jdbcTriggerRepository.save(trigger);
+        return trigger;
     }
 
     private Flow generateFlowWithTrigger(String namespace) {


### PR DESCRIPTION
## Summary

`TriggerControllerTest.shouldUnlockTriggerWhenLocked()` failed often in CI — e.g. on [PR #17495](https://github.com/kestra-io/kestra/pull/17495) — with:
```
io.micronaut.http.client.exceptions.HttpClientResponseException: Not Found: Trigger disappeared after unlock: [tenant=main, namespace=..., flow=..., trigger=...]
```
A prior fix attempt ([#17473](https://github.com/kestra-io/kestra/pull/17473)) tried seeding the test's flow-less trigger with a far-future `nextEvaluationDate`, but it didn't close the race — here's why.

**Root cause:** `TriggerStateService.unlockTriggerById` sends a `ResetTrigger` event, then re-reads the trigger. The scheduler's `onResetTrigger` handler calls `state.reset(clock)`, which *unconditionally* nulls `nextEvaluationDate`, and only recomputes a real date `if` the trigger's flow/definition is found. For a flow-less trigger that recompute is skipped, leaving `nextEvaluationDate=null` the instant it's unlocked — regardless of whatever date the fixture originally seeded (that's why the prior fix didn't help: unlocking itself wipes it). The scheduler's eligibility query treats `NULL` as "eligible now", so the very next poll picks up the now-eligible, still-flow-less trigger, finds no backing flow, and deletes it as an orphan — racing the webserver's own re-read.

## Changes

1. **Test fix** — give the trigger fixture a real backing flow (mirroring the established `shouldDeleteTriggerWhenExists` pattern: create the flow, await the scheduler's own async auto-creation of the matching `TriggerState` row, then lock it). With a real flow, `onResetTrigger` properly recomputes `nextEvaluationDate` from the trigger's own schedule instead of leaving it null — closing the race entirely, not just narrowing it.
2. **Production hardening** — `unlockTriggerById` now validates the flow/trigger-definition still exists (`validateToggleable`) before sending the reset, failing fast with 404 for a genuinely orphaned trigger instead of racing the orphan-GC. Extended the same guard to the batch `unlockAllByIds`/`unlockAllMatching` endpoints for parity (their existing sibling endpoints, `toggleAllByIds`/`toggleAllMatching`, already had this guard). Added a dedicated test for the new 404 behavior.
3. **Restart endpoint parity** — `TriggerStateService.resetTrigger` (the `/restart` endpoint) sends the same `ResetTrigger` event through the identical scheduler handler, so it shares the exact same race and had no guard either. Added the same `validateToggleable` fail-fast check before the kill event is emitted. Fixed `shouldRestartTriggerWhenExists`, whose fixture trigger id didn't correspond to any real trigger definition in its flow (and would now correctly 404 under the guard), to use the flow-backed fixture helper, and added a dedicated test for the new 404 behavior.

Two of the batch-unlock tests used flow-less fixtures expecting a successful unlock count — updated them to use a real flow too, since a flow-less trigger is now correctly recognized as orphaned rather than silently accepted.

## Test plan

- [x] `:webserver:compileJava` / `:webserver:compileTestJava` — clean
- [x] `:webserver:test --tests ...TriggerControllerTest.shouldUnlockTriggerWhenLocked` — run 5x (previously flaky) — all pass
- [x] `:webserver:test --tests ...TriggerControllerTest` (full class, 23 tests) — all pass, including the unlock and restart orphan-404 tests and the fixed batch/restart tests, no regressions
