### PR TITLE
modify: updated v-if state of the deselect button to function correct…

### DIFF
--- a/ui/packages/design-system/src/components/Data/KsDataTable/filter/layout/FilterMultiSelect.vue
+++ b/ui/packages/design-system/src/components/Data/KsDataTable/filter/layout/FilterMultiSelect.vue
@@ -30,7 +30,7 @@
                     </KsCheckbox>
                 </button>
                 <button
-                    v-if="modelValue.length > 0"
+                    v-if="isPartiallySelected || allSelected"
                     type="button"
                     class="clear-btn"
                     @click="handleDeselectAll"


### PR DESCRIPTION
✨ Description
Fixes visually inconsistent state in grouped multi-select filters after using "Deselect All". Previously, category rows could appear both selected and deselected at the same time in the popover, making it unclear whether the filter was active, cleared, or partially selected. This was caused by [name the actual root cause you fixed — e.g. "the parent checkbox's visual state not being recalculated from the tri-state logic after a bulk deselect"]. Now the checkbox state (checked / unchecked / indeterminate) is derived consistently from the selected children, so the UI always reflects a single, unambiguous state after any deselect action.

🔗 Related Issue
Closes #17349 

https://github.com/user-attachments/assets/ae754d6d-937d-4042-a039-c44523f8144a


https://github.com/kestra-io/kestra/issues/17349

🎨 Frontend Checklist
- [x] Code builds without errors (`npm run build`)
- [x] All existing E2E tests pass (`npm run test:e2e`)
- [x] Screenshots or video recordings attached showing the `UI` changes

📝 Additional Notes
- Reproduced against Kestra 1.3.27 by selecting category values, clicking Deselect All, and observing category rows appear selected and deselected simultaneously in the filter popover.
- [Optional: mention if you also disabled/changed "Deselect All" when there's nothing to deselect, per the issue's suggested expected behavior.]
- Tested manually by repeating the repro steps from the issue and confirming category state is now visually unambiguous after deselection.