### PR TITLE
fix: revision history for a namespace file returns "Not found"

### DIFF
--- a/core/src/main/java/io/kestra/core/namespace/NamespaceFileService.java
+++ b/core/src/main/java/io/kestra/core/namespace/NamespaceFileService.java
@@ -1,6 +1,7 @@
 package io.kestra.core.namespace;
 
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -126,7 +127,7 @@ public class NamespaceFileService {
         return getRepository().find(
             Pageable.UNPAGED, tenantId, List.of(
                 QueryFilter.builder().field(QueryFilter.Field.NAMESPACE).operation(QueryFilter.Op.EQUALS).value(namespace).build(),
-                QueryFilter.builder().field(QueryFilter.Field.PATH).operation(QueryFilter.Op.EQUALS).value(path).build()
+                QueryFilter.builder().field(QueryFilter.Field.PATH).operation(QueryFilter.Op.EQUALS).value(NamespaceFile.normalize(Path.of(path)).toString()).build()
             ), true, FetchVersion.ALL
         );
     }

--- a/webserver/src/test/java/io/kestra/webserver/controllers/api/NamespaceFileControllerTest.java
+++ b/webserver/src/test/java/io/kestra/webserver/controllers/api/NamespaceFileControllerTest.java
@@ -139,6 +139,19 @@ class NamespaceFileControllerTest {
     }
 
     @Test
+    void getRevisionsWithoutLeadingSlash() throws IOException, URISyntaxException {
+        // The UI's file explorer builds paths without a leading slash (e.g. "test.txt" for a root-level file),
+        // while namespace file metadata is always stored with a normalized leading slash ("/test.txt").
+        String namespace = TestsUtils.randomNamespace();
+        Namespace namespaceStorage = namespaceFactory.of(TENANT_ID, namespace, storageInterface);
+        namespaceStorage.putFile(Path.of("/test.txt"), new ByteArrayInputStream("Hello World".getBytes()));
+
+        List<NamespaceFileRevision> res = client.toBlocking()
+            .retrieve(HttpRequest.GET("/api/v1/main/namespaces/" + namespace + "/files/revisions?path=test.txt"), Argument.of(List.class, NamespaceFileRevision.class));
+        assertThat(res).containsExactlyInAnyOrder(new NamespaceFileRevision(1));
+    }
+
+    @Test
     void namespaceRootGetFileMetadatasWithoutPreCreation() {
         String namespace = TestsUtils.randomNamespace();
         FileAttributes res = client.toBlocking().retrieve(HttpRequest.GET("/api/v1/main/namespaces/" + namespace + "/files/stats"), TestFileAttributes.class);


### PR DESCRIPTION
- The revision history endpoint queried namespace file metadata with the raw path, while every other read path (get, exists, delete, move) normalizes it to always include a leading slash.
- Root-level namespace files are referenced without a leading slash from the UI's file explorer, so their revision history never matched any stored metadata row and returned a 404.
- Fixed by normalizing the path in `NamespaceFileService.findRevisions` before querying, consistent with the rest of the namespace file read paths.
- Added a regression test covering a root-level file requested without a leading slash.
- Fixes kestra-io/kestra-ee#9382