### PR TITLE
feat(ai): resume the last copilot conversation on reload

### DIFF
--- a/ui/src/components/ai/copilot/CopilotChat.vue
+++ b/ui/src/components/ai/copilot/CopilotChat.vue
@@ -1,22 +1,13 @@
 <template>
     <div class="copilot-chat" data-test="copilot-chat">
-        <!-- Thread controls: start a new chat, browse recents (recents is a BE-pending placeholder). -->
+        <!-- Thread controls: start a new chat; the Recents list (switch / rename / delete) is EE-only,
+             rendered by the CopilotThreadControls override (a no-op in OSS). -->
         <div class="copilot-topbar">
             <KsButton size="small" class="copilot-topbar-pill" data-test="copilot-new-chat" @click="reset">
                 {{ t("ai.copilot.newChat") }}
                 <Plus :size="16" />
             </KsButton>
-            <KsDropdown trigger="click" data-test="copilot-recents">
-                <KsButton size="small" class="copilot-topbar-pill">
-                    {{ t("ai.copilot.recents") }}
-                    <ChevronDown :size="16" />
-                </KsButton>
-                <template #dropdown>
-                    <KsDropdownMenu>
-                        <KsDropdownItem disabled>{{ t("ai.copilot.recentsEmpty") }}</KsDropdownItem>
-                    </KsDropdownMenu>
-                </template>
-            </KsDropdown>
+            <CopilotThreadControls :activeId="thread?.uid" @select="onSelectThread" />
         </div>
 
         <!-- AI unavailable: the backend has no configured provider (503). -->
@@ -121,7 +112,6 @@
     import {useRoute} from "vue-router"
     import {useI18n} from "vue-i18n"
     import Plus from "vue-material-design-icons/Plus.vue"
-    import ChevronDown from "vue-material-design-icons/ChevronDown.vue"
     import RobotOffOutline from "vue-material-design-icons/RobotOffOutline.vue"
     import * as AiApi from "@kestra-io/kestra-sdk/ai"
     import type {AiControllerAiProviderResponse} from "@kestra-io/kestra-sdk"
@@ -131,6 +121,7 @@
     import CopilotThinking from "./CopilotThinking.vue"
     import ProposedActionCard from "./ProposedActionCard.vue"
     import CopilotContextChip from "./CopilotContextChip.vue"
+    import CopilotThreadControls from "override/components/ai/copilot/CopilotThreadControls.vue"
     import {useAiChat} from "./useAiChat"
     import {scopeFromRoute} from "./routeScope"
     import type {Mode, ScopeBinding} from "./types"
@@ -191,7 +182,15 @@
         t("ai.copilot.suggestions.dbt"),
     ])
 
-    const {messages, status, streaming, error, notice, pendingConfirmation, unavailable, canSend, sendChat, confirm, cancel, reset, retry, retryLastTurn} = useAiChat()
+    const {thread, messages, status, streaming, error, notice, pendingConfirmation, unavailable, canSend, sendChat, confirm, cancel, reset, retry, retryLastTurn, loadThread, restoreThread} = useAiChat()
+
+    // Restore the last conversation on open (threads are persisted server-side); harmless no-op if none.
+    onMounted(() => { restoreThread() })
+
+    /** Switch to a thread picked from the (EE) Recents list — rehydrates its transcript + pending action. */
+    function onSelectThread(threadId: string): void {
+        loadThread(threadId)
+    }
 
     // `status` gates the composer via `canSend`; keep the lints happy that we read it.
     void status

--- a/ui/src/components/ai/copilot/CopilotMessage.vue
+++ b/ui/src/components/ai/copilot/CopilotMessage.vue
@@ -56,6 +56,11 @@
     <div v-else-if="message.type === 'ARTEFACT_DRAFT' && message.draft" class="copilot-msg copilot-msg-assistant">
         <CopilotArtefactDraft :draft="message.draft" />
     </div>
+
+    <!-- Cancelled turn — a subtle, centered system marker in the transcript (reload only). -->
+    <div v-else-if="message.type === 'CANCELLED'" class="copilot-msg copilot-msg-cancelled" data-test="copilot-cancelled">
+        <KsText size="small" class="copilot-cancelled-label">{{ t("ai.copilot.cancelled") }}</KsText>
+    </div>
 </template>
 
 <script setup lang="ts">
@@ -113,6 +118,16 @@
     .copilot-msg-assistant {
         display: flex;
         justify-content: flex-start;
+    }
+
+    .copilot-msg-cancelled {
+        display: flex;
+        justify-content: center;
+    }
+
+    .copilot-cancelled-label {
+        --kel-text-color: var(--ks-text-muted);
+        font-style: italic;
     }
 
     .copilot-bubble-user {

--- a/ui/src/components/ai/copilot/types.ts
+++ b/ui/src/components/ai/copilot/types.ts
@@ -18,7 +18,7 @@ export type ThreadStatus = "IDLE" | "RUNNING" | "AWAITING_CONFIRMATION"
 
 export type MessageRole = "USER" | "ASSISTANT" | "TOOL" | "SYSTEM"
 
-export type MessageType = "TEXT" | "TOOL_CALL" | "TOOL_RESULT" | "PROPOSED_ACTION" | "ARTEFACT_DRAFT"
+export type MessageType = "TEXT" | "TOOL_CALL" | "TOOL_RESULT" | "PROPOSED_ACTION" | "ARTEFACT_DRAFT" | "CANCELLED"
 
 export type ToolFamily = "READ" | "MUTATE" | "ACT"
 
@@ -99,6 +99,8 @@ export interface ThreadDetail {
     mode: Mode
     scope?: ScopeBinding | null
     status: ThreadStatus
+    /** Set only when status is AWAITING_CONFIRMATION — lets a reload resume the suspended turn. */
+    pendingConfirmationId?: string | null
     messages: MessageView[]
 }
 

--- a/ui/src/components/ai/copilot/types.ts
+++ b/ui/src/components/ai/copilot/types.ts
@@ -150,7 +150,9 @@ export interface ArtefactDraftEvent {
 }
 
 export interface ToolResultEvent {
-    tool: string
+    /** Present on the live stream; absent on thread reload (the persisted map has no `tool` — the
+     *  name comes from the paired tool-call instead). */
+    tool?: string
     /** "ok", "error" (the tool threw; the turn continues), or "rejected". */
     outcome: string
     /**

--- a/ui/src/components/ai/copilot/useAiChat.ts
+++ b/ui/src/components/ai/copilot/useAiChat.ts
@@ -36,7 +36,7 @@ import {
 } from "./types"
 
 /** Locale-agnostic error identifier; the component maps it to `ai.copilot.error.<code>`. */
-export type ErrorCode = "turnInProgress" | "request" | "generic"
+export type ErrorCode = "turnInProgress" | "turnCap" | "request" | "generic"
 
 /** Locale-agnostic non-error notice identifier; the component maps it to `ai.copilot.notice.<code>`. */
 export type NoticeCode = "emptyTurn"
@@ -46,7 +46,7 @@ export interface ChatMessage {
     /** Local, stable key for v-for. */
     id: string
     role: "USER" | "ASSISTANT" | "TOOL" | "SYSTEM"
-    type: "TEXT" | "TOOL_CALL" | "TOOL_RESULT" | "PROPOSED_ACTION" | "ARTEFACT_DRAFT"
+    type: "TEXT" | "TOOL_CALL" | "TOOL_RESULT" | "PROPOSED_ACTION" | "ARTEFACT_DRAFT" | "CANCELLED"
     /** Assistant text; appended to as `token` events arrive. */
     content?: string
     toolCall?: ToolCallEvent
@@ -83,13 +83,46 @@ export function useAiChat() {
 
     const base = () => `${apiUrl()}/ai/threads`
 
+    // The active thread uid is remembered client-side so the conversation survives a reload
+    // (threads are persisted + user-scoped server-side). A stale/foreign uid just 404s → cleared.
+    const THREAD_STORAGE_KEY = "kestra.copilot.activeThread"
+    const rememberThread = (uid: string) => {
+        try {
+            localStorage.setItem(THREAD_STORAGE_KEY, uid)
+        } catch { /* storage unavailable (private mode) — resume simply won't persist */ }
+    }
+    const forgetThread = () => {
+        try {
+            localStorage.removeItem(THREAD_STORAGE_KEY)
+        } catch { /* ignore */ }
+    }
+
     /** Creates the thread once and reuses its uid for the rest of the session. */
     async function ensureThread(request: CreateThreadRequest = {}): Promise<ThreadSummary> {
         if (thread.value) return thread.value
         const {data} = await client.post<ThreadSummary>(base(), request)
         thread.value = data
         status.value = data.status
+        rememberThread(data.uid)
         return data
+    }
+
+    /**
+     * Restores the last conversation on mount from the remembered uid. A cleared / other-user /
+     * other-tenant thread 404s → we forget it and start empty. No-op if a thread is already active.
+     */
+    async function restoreThread(): Promise<void> {
+        if (thread.value) return
+        let storedId: string | null = null
+        try {
+            storedId = localStorage.getItem(THREAD_STORAGE_KEY)
+        } catch { /* storage unavailable */ }
+        if (!storedId) return
+        try {
+            await loadThread(storedId)
+        } catch {
+            forgetThread()
+        }
     }
 
     /** Rehydrates an existing thread's transcript on reload. Sorts messages by uid. */
@@ -105,6 +138,9 @@ export function useAiChat() {
             updatedAt: "",
         }
         status.value = data.status
+        error.value = null
+        notice.value = null
+        activeAssistant = null
         messages.value = [...data.messages]
             .sort((a, b) => a.uid.localeCompare(b.uid))
             .map((m) => ({
@@ -118,6 +154,27 @@ export function useAiChat() {
                 toolResult: (m.toolResult as unknown as ToolResultEvent) ?? undefined,
                 draft: m.draft ?? undefined,
             }))
+
+        // Resume a suspended turn: reconstruct the pending proposal so its confirm card renders again.
+        // The backend gives only `pendingConfirmationId`; the summary/held-tool come from the last
+        // PROPOSED_ACTION message in the transcript.
+        pendingConfirmation.value = data.status === "AWAITING_CONFIRMATION" && data.pendingConfirmationId
+            ? proposalFromTranscript(data.pendingConfirmationId)
+            : null
+
+        rememberThread(data.uid)
+    }
+
+    /** Rebuild a ProposedActionEvent from the persisted PROPOSED_ACTION message + the pending id. */
+    function proposalFromTranscript(confirmationId: string): ProposedActionEvent {
+        const last = [...messages.value].reverse().find((m) => m.type === "PROPOSED_ACTION")
+        return {
+            confirmationId,
+            summary: last?.content ?? "",
+            tool: last?.toolCall?.tool ?? null,
+            family: last?.toolCall?.family ?? null,
+            arguments: last?.toolCall?.arguments ?? null,
+        }
     }
 
     /** Sends a user turn and streams the response. Creates the thread if needed. */
@@ -187,6 +244,7 @@ export function useAiChat() {
         unavailable.value = false
         activeAssistant = null
         lastTurn = null
+        forgetThread()
     }
 
     /** Shared streaming driver for both chat and confirm turns. */
@@ -272,7 +330,9 @@ export function useAiChat() {
 
     function toErrorCode(e: unknown): ErrorCode {
         if (e instanceof SseHttpError) {
-            return e.status === 409 ? "turnInProgress" : "request"
+            if (e.status === 409) return "turnInProgress"
+            if (e.status === 429) return "turnCap" // thread hit its turn limit — start a new chat
+            return "request"
         }
         return "generic"
     }
@@ -299,6 +359,7 @@ export function useAiChat() {
         // actions
         ensureThread,
         loadThread,
+        restoreThread,
         sendChat,
         confirm,
         cancel,

--- a/ui/src/override/components/ai/copilot/CopilotThreadControls.vue
+++ b/ui/src/override/components/ai/copilot/CopilotThreadControls.vue
@@ -1,0 +1,14 @@
+<template>
+    <!--
+        OSS no-op: thread management (Recents list / switch / rename / delete) is an EE-only
+        feature — the Enterprise build shadows this via its own `override/` with the real controls.
+        OSS runs a single implicit session, so it shows no Recents surface.
+    -->
+</template>
+
+<script setup lang="ts">
+    // Props/emits mirror the EE implementation so CopilotChat binds the same contract in both
+    // editions; OSS simply renders nothing and never emits.
+    defineProps<{activeId?: string | null}>()
+    defineEmits<{(e: "select", threadId: string): void}>()
+</script>

--- a/ui/src/translations/de.json
+++ b/ui/src/translations/de.json
@@ -2046,7 +2046,9 @@
           "emptyTurn": "Der Assistent hat keine Antwort zurückgegeben. Bitte versuche es erneut.",
           "retry": "Erneut versuchen"
         },
+        "cancelled": "Vorgang abgebrochen",
         "error": {
+          "turnCap": "Diese Unterhaltung hat ihr Limit erreicht — starten Sie einen neuen Chat.",
           "turnInProgress": "A turn is already in progress.",
           "request": "The request failed. Please try again.",
           "generic": "Something went wrong. Please try again."

--- a/ui/src/translations/en.json
+++ b/ui/src/translations/en.json
@@ -2046,7 +2046,9 @@
           "emptyTurn": "The assistant didn't return a response. Please try again.",
           "retry": "Retry"
         },
+        "cancelled": "Turn cancelled",
         "error": {
+          "turnCap": "This conversation reached its limit — start a new chat.",
           "turnInProgress": "A turn is already in progress.",
           "request": "The request failed. Please try again.",
           "generic": "Something went wrong. Please try again."

--- a/ui/src/translations/es.json
+++ b/ui/src/translations/es.json
@@ -2046,7 +2046,9 @@
           "emptyTurn": "El asistente no devolvió una respuesta. Inténtalo de nuevo.",
           "retry": "Reintentar"
         },
+        "cancelled": "Turno cancelado",
         "error": {
+          "turnCap": "Esta conversación alcanzó su límite: inicia un nuevo chat.",
           "turnInProgress": "A turn is already in progress.",
           "request": "The request failed. Please try again.",
           "generic": "Something went wrong. Please try again."

--- a/ui/src/translations/fr.json
+++ b/ui/src/translations/fr.json
@@ -2046,7 +2046,9 @@
           "emptyTurn": "L'assistant n'a renvoyé aucune réponse. Veuillez réessayer.",
           "retry": "Réessayer"
         },
+        "cancelled": "Tour annulé",
         "error": {
+          "turnCap": "Cette conversation a atteint sa limite — démarrez une nouvelle discussion.",
           "turnInProgress": "A turn is already in progress.",
           "request": "The request failed. Please try again.",
           "generic": "Something went wrong. Please try again."

--- a/ui/src/translations/hi.json
+++ b/ui/src/translations/hi.json
@@ -2046,7 +2046,9 @@
           "emptyTurn": "सहायक ने कोई प्रतिक्रिया नहीं दी। कृपया पुनः प्रयास करें।",
           "retry": "पुनः प्रयास करें"
         },
+        "cancelled": "टर्न रद्द किया गया",
         "error": {
+          "turnCap": "यह बातचीत अपनी सीमा तक पहुँच गई — नई चैट शुरू करें।",
           "turnInProgress": "A turn is already in progress.",
           "request": "The request failed. Please try again.",
           "generic": "Something went wrong. Please try again."

--- a/ui/src/translations/it.json
+++ b/ui/src/translations/it.json
@@ -2046,7 +2046,9 @@
           "emptyTurn": "L'assistente non ha restituito una risposta. Riprova.",
           "retry": "Riprova"
         },
+        "cancelled": "Turno annullato",
         "error": {
+          "turnCap": "Questa conversazione ha raggiunto il limite — avvia una nuova chat.",
           "turnInProgress": "A turn is already in progress.",
           "request": "The request failed. Please try again.",
           "generic": "Something went wrong. Please try again."

--- a/ui/src/translations/ja.json
+++ b/ui/src/translations/ja.json
@@ -2046,7 +2046,9 @@
           "emptyTurn": "アシスタントから応答がありませんでした。もう一度お試しください。",
           "retry": "再試行"
         },
+        "cancelled": "ターンをキャンセルしました",
         "error": {
+          "turnCap": "この会話は上限に達しました。新しいチャットを開始してください。",
           "turnInProgress": "A turn is already in progress.",
           "request": "The request failed. Please try again.",
           "generic": "Something went wrong. Please try again."

--- a/ui/src/translations/ko.json
+++ b/ui/src/translations/ko.json
@@ -2046,7 +2046,9 @@
           "emptyTurn": "어시스턴트가 응답을 반환하지 않았습니다. 다시 시도해 주세요.",
           "retry": "다시 시도"
         },
+        "cancelled": "턴이 취소됨",
         "error": {
+          "turnCap": "이 대화가 한도에 도달했습니다. 새 채팅을 시작하세요.",
           "turnInProgress": "A turn is already in progress.",
           "request": "The request failed. Please try again.",
           "generic": "Something went wrong. Please try again."

--- a/ui/src/translations/pl.json
+++ b/ui/src/translations/pl.json
@@ -2046,7 +2046,9 @@
           "emptyTurn": "Asystent nie zwrócił odpowiedzi. Spróbuj ponownie.",
           "retry": "Ponów"
         },
+        "cancelled": "Tura anulowana",
         "error": {
+          "turnCap": "Ta rozmowa osiągnęła limit — rozpocznij nowy czat.",
           "turnInProgress": "A turn is already in progress.",
           "request": "The request failed. Please try again.",
           "generic": "Something went wrong. Please try again."

--- a/ui/src/translations/pt.json
+++ b/ui/src/translations/pt.json
@@ -2046,7 +2046,9 @@
           "emptyTurn": "O assistente não retornou uma resposta. Tente novamente.",
           "retry": "Tentar novamente"
         },
+        "cancelled": "Turno cancelado",
         "error": {
+          "turnCap": "Esta conversa atingiu o limite — inicie um novo chat.",
           "turnInProgress": "A turn is already in progress.",
           "request": "The request failed. Please try again.",
           "generic": "Something went wrong. Please try again."

--- a/ui/src/translations/pt_BR.json
+++ b/ui/src/translations/pt_BR.json
@@ -2046,7 +2046,9 @@
           "emptyTurn": "O assistente não retornou uma resposta. Tente novamente.",
           "retry": "Tentar novamente"
         },
+        "cancelled": "Turno cancelado",
         "error": {
+          "turnCap": "Esta conversa atingiu o limite — inicie um novo chat.",
           "turnInProgress": "A turn is already in progress.",
           "request": "The request failed. Please try again.",
           "generic": "Something went wrong. Please try again."

--- a/ui/src/translations/ru.json
+++ b/ui/src/translations/ru.json
@@ -2046,7 +2046,9 @@
           "emptyTurn": "Ассистент не вернул ответ. Пожалуйста, попробуйте снова.",
           "retry": "Повторить"
         },
+        "cancelled": "Ход отменён",
         "error": {
+          "turnCap": "Этот разговор достиг лимита — начните новый чат.",
           "turnInProgress": "A turn is already in progress.",
           "request": "The request failed. Please try again.",
           "generic": "Something went wrong. Please try again."

--- a/ui/src/translations/zh_CN.json
+++ b/ui/src/translations/zh_CN.json
@@ -2046,7 +2046,9 @@
           "emptyTurn": "助手未返回响应。请重试。",
           "retry": "重试"
         },
+        "cancelled": "已取消本轮",
         "error": {
+          "turnCap": "此对话已达到上限——请开始新的聊天。",
           "turnInProgress": "A turn is already in progress.",
           "request": "The request failed. Please try again.",
           "generic": "Something went wrong. Please try again."

--- a/ui/tests/unit/components/ai/copilot/CopilotChat.spec.ts
+++ b/ui/tests/unit/components/ai/copilot/CopilotChat.spec.ts
@@ -21,6 +21,8 @@ const state = {
     reset: vi.fn(),
     retry: vi.fn(),
     retryLastTurn: vi.fn(),
+    loadThread: vi.fn(),
+    restoreThread: vi.fn(),
 }
 vi.mock("../../../../../src/components/ai/copilot/useAiChat", () => ({useAiChat: () => state}))
 // CopilotChat derives `inFocus` from the current route — mock a mutable route so tests control it.
@@ -34,6 +36,7 @@ const miscStore = {copilotPrompt: null as string | null, openCopilot: vi.fn(), p
 vi.mock("override/stores/misc", () => ({useMiscStore: () => miscStore}))
 
 import CopilotChat from "../../../../../src/components/ai/copilot/CopilotChat.vue"
+import CopilotThreadControls from "override/components/ai/copilot/CopilotThreadControls.vue"
 import {providers as providersMock} from "@kestra-io/kestra-sdk/ai"
 
 const mountChat = (props = {}) => mount(CopilotChat, {props, global: mountGlobal})
@@ -53,6 +56,9 @@ describe("CopilotChat", () => {
         state.reset.mockReset()
         state.retry.mockReset()
         state.retryLastTurn.mockReset()
+        state.loadThread.mockReset()
+        state.restoreThread.mockReset()
+        state.thread.value = null
         miscStore.copilotPrompt = null
     })
 
@@ -137,6 +143,24 @@ describe("CopilotChat", () => {
         expect(alert.text()).toContain("The assistant didn't return a response. Please try again.")
     })
 
+    it("restores the last conversation on mount", () => {
+        mountChat()
+        expect(state.restoreThread).toHaveBeenCalled()
+    })
+
+    it("surfaces the turn-cap error with a start-a-new-chat message", () => {
+        state.error.value = "turnCap"
+        const w = mountChat()
+        expect(w.find(".ks-alert").text()).toContain("start a new chat")
+    })
+
+    it("switches thread when the thread controls emit select", async () => {
+        const w = mountChat()
+        w.findComponent(CopilotThreadControls).vm.$emit("select", "t-42")
+        await flushPromises()
+        expect(state.loadThread).toHaveBeenCalledWith("t-42")
+    })
+
     it("retries the last turn from the empty-turn notice", async () => {
         state.notice.value = "emptyTurn"
         const w = mountChat()
@@ -189,8 +213,8 @@ describe("CopilotChat", () => {
         expect(state.reset).toHaveBeenCalled()
     })
 
-    it("shows the recents placeholder control", () => {
-        expect(mountChat().find("[data-test=\"copilot-recents\"]").exists()).toBe(true)
+    it("mounts the thread controls (EE-only Recents; a no-op in OSS)", () => {
+        expect(mountChat().findComponent(CopilotThreadControls).exists()).toBe(true)
     })
 
     it("shows the AI-unavailable state (and no composer) when unavailable", () => {

--- a/ui/tests/unit/components/ai/copilot/CopilotMessage.spec.ts
+++ b/ui/tests/unit/components/ai/copilot/CopilotMessage.spec.ts
@@ -96,4 +96,11 @@ describe("CopilotMessage", () => {
         expect(w.find(".copilot-draft").exists()).toBe(true)
         expect(w.find("[data-test=\"copilot-draft-yaml\"]").text()).toContain("id: demo")
     })
+
+    it("renders a CANCELLED message as a subtle system marker", () => {
+        const w = mountMessage({id: "7", role: "SYSTEM", type: "CANCELLED"})
+        const marker = w.find("[data-test=\"copilot-cancelled\"]")
+        expect(marker.exists()).toBe(true)
+        expect(marker.text()).toBe("Turn cancelled")
+    })
 })

--- a/ui/tests/unit/components/ai/copilot/useAiChat.spec.ts
+++ b/ui/tests/unit/components/ai/copilot/useAiChat.spec.ts
@@ -39,6 +39,7 @@ describe("useAiChat", () => {
         nextFrames = []
         nextError = null
         lastBody = null
+        localStorage.clear()
         post.mockResolvedValue(idleThread())
     })
 
@@ -287,5 +288,69 @@ describe("useAiChat", () => {
         expect(chat.thread.value).toBeNull()
         expect(chat.status.value).toBe("IDLE")
         expect(chat.pendingConfirmation.value).toBeNull()
+    })
+
+    it("maps a 429 to the turnCap error code", async () => {
+        const chat = useAiChat()
+        nextError = new SseHttpError(429, "")
+        await chat.sendChat({prompt: "hi"})
+        expect(chat.error.value).toBe("turnCap")
+        expect(chat.status.value).toBe("IDLE")
+    })
+
+    it("remembers the thread uid and restoreThread() rehydrates it on reload", async () => {
+        // First session: create a thread (persists its uid to localStorage).
+        const first = useAiChat()
+        nextFrames = [{event: "done", data: {status: "IDLE"}}]
+        await first.sendChat({prompt: "hi"})
+        expect(localStorage.getItem("kestra.copilot.activeThread")).toBe("t1")
+
+        // Second session (reload): restoreThread loads the remembered thread's transcript.
+        get.mockResolvedValue({data: {
+            uid: "t1", mode: "ASK", status: "IDLE",
+            messages: [{uid: "a", role: "USER", type: "TEXT", content: "hi"}],
+        }})
+        const reloaded = useAiChat()
+        await reloaded.restoreThread()
+        expect(get).toHaveBeenCalledWith("http://localhost/api/v1/main/ai/threads/t1")
+        expect(reloaded.thread.value?.uid).toBe("t1")
+        expect(reloaded.messages.value.some((m) => m.content === "hi")).toBe(true)
+    })
+
+    it("restoreThread() forgets a stored thread that no longer exists (404) and stays empty", async () => {
+        localStorage.setItem("kestra.copilot.activeThread", "gone")
+        get.mockRejectedValue({status: 404})
+        const chat = useAiChat()
+        await chat.restoreThread()
+        expect(chat.thread.value).toBeNull()
+        expect(localStorage.getItem("kestra.copilot.activeThread")).toBeNull()
+    })
+
+    it("loadThread reconstructs a pending proposal from pendingConfirmationId + the transcript", async () => {
+        get.mockResolvedValue({data: {
+            uid: "t2", mode: "EDIT", status: "AWAITING_CONFIRMATION", pendingConfirmationId: "cf-9",
+            messages: [
+                {uid: "a", role: "USER", type: "TEXT", content: "restart it"},
+                {uid: "b", role: "ASSISTANT", type: "PROPOSED_ACTION", content: "Run restart-execution on exec-1",
+                 toolCall: {tool: "restart-execution", kind: "PLATFORM", family: "MUTATE", arguments: {id: "exec-1"}}},
+            ],
+        }})
+        const chat = useAiChat()
+        await chat.loadThread("t2")
+        expect(chat.status.value).toBe("AWAITING_CONFIRMATION")
+        expect(chat.pendingConfirmation.value).toMatchObject({
+            confirmationId: "cf-9",
+            summary: "Run restart-execution on exec-1",
+            tool: "restart-execution",
+        })
+    })
+
+    it("reset() forgets the remembered thread", async () => {
+        const chat = useAiChat()
+        nextFrames = [{event: "done", data: {status: "IDLE"}}]
+        await chat.sendChat({prompt: "hi"})
+        expect(localStorage.getItem("kestra.copilot.activeThread")).toBe("t1")
+        chat.reset()
+        expect(localStorage.getItem("kestra.copilot.activeThread")).toBeNull()
     })
 })


### PR DESCRIPTION
## What

The backend now persists threads and scopes them per-user, and the guardrails commit added `pendingConfirmationId` on `GET /{id}`. This wires the FE up to actually use it — the copilot previously forgot everything on refresh (`loadThread` existed but was never called).

- **Resume on reload:** remember the active thread uid in `localStorage`; on mount restore it via `loadThread` (a cleared / other-user / other-tenant thread 404s → forget it, start empty). "New chat" clears it.
- **Rehydrate a suspended turn:** on an `AWAITING_CONFIRMATION` thread, reconstruct the pending proposal from `pendingConfirmationId` + the last `PROPOSED_ACTION` message (which persists the summary as `content` and the held tool as `toolCall`), so the confirm card renders and approve/reject still works after reload.
- **`CANCELLED` message type:** rendered as a subtle, centered system marker.
- **429 turn-cap:** mapped to a dedicated "this conversation reached its limit — start a new chat" error.
- **Thread-controls scaffold:** a no-op `CopilotThreadControls` override + a mount point in `CopilotChat` (`@select → loadThread`). OSS renders nothing (single session); **EE will shadow it with the real Recents list / switch / rename / delete** in a follow-up.

## Tests
- `useAiChat.spec` — remember/restore uid, 404 forgets it, pending-proposal reconstruction, 429→turnCap, reset forgets.
- `CopilotChat.spec` — restore on mount, turn-cap error renders, thread-controls mounted + `select`→`loadThread`.
- `CopilotMessage.spec` — `CANCELLED` marker.
- **115/115 copilot unit tests pass**; lint + type-check + `translations:check` clean. New keys `error.turnCap` + `cancelled` in all 13 locales.

## Relationship to the existing thread PRs
This supersedes the OSS resume portion of #17375 (which was built against the pre-guardrails contract — it read `data.pendingConfirmation` as a full object; the backend ships `pendingConfirmationId` as a string). The **EE thread-management UI** (the real `CopilotThreadControls`) follows in a companion EE PR that builds on this scaffold.

## Scope
Frontend-only; shared with EE via the `kestra` alias.