### PR TITLE
fix(plugins): fall back to plain type resolution instead of excluding plugin types from schema

### DIFF
--- a/core/src/main/java/io/kestra/core/docs/JsonSchemaGenerator.java
+++ b/core/src/main/java/io/kestra/core/docs/JsonSchemaGenerator.java
@@ -987,13 +987,15 @@ public class JsonSchemaGenerator {
     protected static Optional<ResolvedType> safelyResolveSubtype(ResolvedType declaredType, Class<?> clz, TypeContext typeContext) {
         try {
             return Optional.ofNullable(typeContext.resolveSubtype(declaredType, clz));
-        } catch (Throwable e) {
+        } catch (Exception | LinkageError e) {
             // resolveSubtype() walks the full generic hierarchy against declaredType and can throw
             // (e.g. java.lang.TypeNotPresentException on a non-backward-compatible plugin, or a
             // classloading conflict such as NoClassDefFoundError/LinkageError from a plugin jar).
             // Fall back to a plain resolve(), the same call every other plugin category (TaskRunner,
             // Chart, Asset, ...) already relies on, so the type still appears in the schema/autocompletion
             // even if some generic-derived detail is missing, instead of silently disappearing.
+            // Deliberately not catch(Throwable): VirtualMachineError (OutOfMemoryError, StackOverflowError)
+            // must propagate rather than be logged and swallowed here.
             try {
                 ResolvedType fallback = typeContext.resolve(clz);
                 log.warn(
@@ -1004,7 +1006,7 @@ public class JsonSchemaGenerator {
                     e.getMessage()
                 );
                 return Optional.of(fallback);
-            } catch (Throwable fallbackException) {
+            } catch (Exception | LinkageError fallbackException) {
                 log.warn(
                     "Unable to resolve subtype '{}' of '{}' for schema generation, it will be excluded from autocompletion. Cause: [{}] {}",
                     clz.getName(),

--- a/core/src/main/java/io/kestra/core/docs/JsonSchemaGenerator.java
+++ b/core/src/main/java/io/kestra/core/docs/JsonSchemaGenerator.java
@@ -987,9 +987,18 @@ public class JsonSchemaGenerator {
     protected static Optional<ResolvedType> safelyResolveSubtype(ResolvedType declaredType, Class<?> clz, TypeContext typeContext) {
         try {
             return Optional.ofNullable(typeContext.resolveSubtype(declaredType, clz));
-        } catch (Exception e) {
-            // exception can be thrown when resolving a plugin-type depending on
-            // a non-backward compatible kestra (e.g., java.lang.TypeNotPresentException).
+        } catch (Throwable e) {
+            // Can be thrown when resolving a plugin-type depending on a non-backward compatible kestra
+            // (e.g., java.lang.TypeNotPresentException), or a plugin jar with a classloading conflict
+            // (e.g., NoClassDefFoundError/LinkageError). Log so the excluded type is not silently missing
+            // from the schema used for editor autocompletion.
+            log.warn(
+                "Unable to resolve subtype '{}' of '{}' for schema generation, it will be excluded from autocompletion. Cause: [{}] {}",
+                clz.getName(),
+                declaredType.getErasedType().getName(),
+                e.getClass().getSimpleName(),
+                e.getMessage()
+            );
             return Optional.empty();
         }
     }

--- a/core/src/main/java/io/kestra/core/docs/JsonSchemaGenerator.java
+++ b/core/src/main/java/io/kestra/core/docs/JsonSchemaGenerator.java
@@ -988,18 +988,32 @@ public class JsonSchemaGenerator {
         try {
             return Optional.ofNullable(typeContext.resolveSubtype(declaredType, clz));
         } catch (Throwable e) {
-            // Can be thrown when resolving a plugin-type depending on a non-backward compatible kestra
-            // (e.g., java.lang.TypeNotPresentException), or a plugin jar with a classloading conflict
-            // (e.g., NoClassDefFoundError/LinkageError). Log so the excluded type is not silently missing
-            // from the schema used for editor autocompletion.
-            log.warn(
-                "Unable to resolve subtype '{}' of '{}' for schema generation, it will be excluded from autocompletion. Cause: [{}] {}",
-                clz.getName(),
-                declaredType.getErasedType().getName(),
-                e.getClass().getSimpleName(),
-                e.getMessage()
-            );
-            return Optional.empty();
+            // resolveSubtype() walks the full generic hierarchy against declaredType and can throw
+            // (e.g. java.lang.TypeNotPresentException on a non-backward-compatible plugin, or a
+            // classloading conflict such as NoClassDefFoundError/LinkageError from a plugin jar).
+            // Fall back to a plain resolve(), the same call every other plugin category (TaskRunner,
+            // Chart, Asset, ...) already relies on, so the type still appears in the schema/autocompletion
+            // even if some generic-derived detail is missing, instead of silently disappearing.
+            try {
+                ResolvedType fallback = typeContext.resolve(clz);
+                log.warn(
+                    "Unable to fully resolve subtype '{}' of '{}' for schema generation, falling back to a plain type resolution. Cause: [{}] {}",
+                    clz.getName(),
+                    declaredType.getErasedType().getName(),
+                    e.getClass().getSimpleName(),
+                    e.getMessage()
+                );
+                return Optional.of(fallback);
+            } catch (Throwable fallbackException) {
+                log.warn(
+                    "Unable to resolve subtype '{}' of '{}' for schema generation, it will be excluded from autocompletion. Cause: [{}] {}",
+                    clz.getName(),
+                    declaredType.getErasedType().getName(),
+                    fallbackException.getClass().getSimpleName(),
+                    fallbackException.getMessage()
+                );
+                return Optional.empty();
+            }
         }
     }
 

--- a/core/src/main/java/io/kestra/core/docs/JsonSchemaGenerator.java
+++ b/core/src/main/java/io/kestra/core/docs/JsonSchemaGenerator.java
@@ -92,6 +92,20 @@ public class JsonSchemaGenerator {
 
     private final PluginRegistry pluginRegistry;
 
+    /**
+     * Per-invocation isolation state for {@link #subtypeResolver}, used only when a first schema-generation attempt
+     * failed because of one broken plugin (see {@link #generateRootSchemaIsolatingFailures}). Held in a
+     * {@link ThreadLocal} rather than passed through the (overridable) {@code build}/{@code subtypeResolver}
+     * signatures so Enterprise overrides keep working, and so the happy path — which never sets it — is unchanged.
+     * {@code probing} disables subtype expansion so a single type can be schema-generated cheaply and without
+     * recursion; {@code excluded} lists the plugin types to drop from the anyOf on a retry.
+     */
+    private record IsolationContext(boolean probing, Set<String> excluded) {
+        private static final IsolationContext NONE = new IsolationContext(false, Set.of());
+    }
+
+    private final ThreadLocal<IsolationContext> isolation = ThreadLocal.withInitial(() -> IsolationContext.NONE);
+
     @Inject
     public JsonSchemaGenerator(final PluginRegistry pluginRegistry) {
         this.pluginRegistry = pluginRegistry;
@@ -121,30 +135,109 @@ public class JsonSchemaGenerator {
     }
 
     public <T> Map<String, Object> schemas(Class<? extends T> cls, boolean arrayOf, List<String> allowedPluginTypes, boolean withOutputs) {
-        SchemaGeneratorConfigBuilder builder = new SchemaGeneratorConfigBuilder(
-            SchemaVersion.DRAFT_7,
-            OptionPreset.PLAIN_JSON
-        );
-
-        this.build(builder, true, allowedPluginTypes, withOutputs);
-
-        SchemaGeneratorConfig schemaGeneratorConfig = builder.build();
-
-        SchemaGenerator generator = new SchemaGenerator(schemaGeneratorConfig);
         try {
-            ObjectNode objectNode = generator.generateSchema(cls);
+            ObjectNode objectNode = generateRootSchemaIsolatingFailures(cls, allowedPluginTypes, withOutputs);
             if (arrayOf) {
                 objectNode.put("type", "array");
             }
             replaceOneOfWithAnyOf(objectNode);
             pullDocumentationAndDefaultFromAnyOf(objectNode);
             removeRequiredOnPropsWithDefaults(objectNode);
+            injectUnresolvedPluginTypes(objectNode, allowedPluginTypes);
 
             Map<String, Object> schema = MAPPER.convertValue(objectNode, MAP_TYPE_REFERENCE);
             stripEditionRestrictedInputTypes(schema);
             return schema;
         } catch (Exception e) {
             throw new IllegalArgumentException("Unable to generate jsonschema for '" + cls.getName() + "'", e);
+        }
+    }
+
+    // package-private for testing
+    ObjectNode generateRootSchema(Class<?> cls, List<String> allowedPluginTypes, boolean withOutputs) {
+        SchemaGeneratorConfigBuilder builder = new SchemaGeneratorConfigBuilder(
+            SchemaVersion.DRAFT_7,
+            OptionPreset.PLAIN_JSON
+        );
+        this.build(builder, true, allowedPluginTypes, withOutputs);
+        return new SchemaGenerator(builder.build()).generateSchema(cls);
+    }
+
+    /**
+     * Generate the root schema, isolating the failure of any single plugin. victools' {@code generateSchema} is
+     * atomic: if one registered task/trigger cannot be schema-generated (e.g. it was built against an incompatible
+     * Kestra version and a drifted type surfaces via a property or a Swagger {@code @Schema(implementation=...)}),
+     * the whole flow schema aborts and autocompletion breaks for EVERY plugin, not just the offending one (#12102).
+     * On such a failure, probe each eligible task/trigger in isolation, drop the ones that cannot be generated, and
+     * regenerate. The dropped types are re-added as permissive placeholders by {@link #injectUnresolvedPluginTypes},
+     * so they keep autocompleting and validating. The happy path (nothing broken) never probes and is unchanged.
+     */
+    private ObjectNode generateRootSchemaIsolatingFailures(Class<?> cls, List<String> allowedPluginTypes, boolean withOutputs) {
+        try {
+            return generateRootSchema(cls, allowedPluginTypes, withOutputs);
+        } catch (Exception | LinkageError firstFailure) {
+            Set<String> unresolvable = probeUnresolvablePluginTypes(allowedPluginTypes);
+            if (unresolvable.isEmpty()) {
+                // Not a per-plugin isolation problem we can recover from — surface the original failure.
+                throw firstFailure instanceof RuntimeException runtimeException
+                    ? runtimeException
+                    : new IllegalStateException(firstFailure);
+            }
+            log.warn(
+                "Flow schema generation failed; regenerating without {} plugin type(s) that cannot be schema-generated "
+                    + "(they will appear with a permissive placeholder): {}",
+                unresolvable.size(),
+                unresolvable
+            );
+            isolation.set(new IsolationContext(false, unresolvable));
+            try {
+                return generateRootSchema(cls, allowedPluginTypes, withOutputs);
+            } finally {
+                isolation.remove();
+            }
+        }
+    }
+
+    /**
+     * Probe every eligible task/trigger by generating its schema in isolation (with subtype expansion disabled, so
+     * each probe is cheap and cannot recurse through {@code List<Task>}-style properties) and return the names of
+     * those that throw. Called only after a full generation already failed, so its cost is paid only when a broken
+     * plugin is actually present.
+     */
+    // package-private for testing
+    Set<String> probeUnresolvablePluginTypes(List<String> allowedPluginTypes) {
+        isolation.set(new IsolationContext(true, Set.of()));
+        try {
+            SchemaGeneratorConfigBuilder builder = new SchemaGeneratorConfigBuilder(
+                SchemaVersion.DRAFT_7,
+                OptionPreset.PLAIN_JSON
+            );
+            this.build(builder, true, allowedPluginTypes, false);
+            SchemaGenerator probe = new SchemaGenerator(builder.build());
+
+            Set<String> unresolvable = new HashSet<>();
+            Stream.concat(
+                    getRegisteredPlugins().stream().flatMap(registeredPlugin -> registeredPlugin.getTasks().stream()),
+                    getRegisteredPlugins().stream().flatMap(registeredPlugin -> registeredPlugin.getTriggers().stream())
+                )
+                .filter(clz -> isSchemaEligiblePlugin(clz, allowedPluginTypes))
+                .distinct()
+                .forEach(clz -> {
+                    try {
+                        probe.generateSchema(clz);
+                    } catch (Exception | LinkageError e) {
+                        unresolvable.add(clz.getName());
+                        log.warn(
+                            "Plugin type '{}' cannot be schema-generated and will be shown with a permissive placeholder. Cause: [{}] {}",
+                            clz.getName(),
+                            e.getClass().getSimpleName(),
+                            e.getMessage()
+                        );
+                    }
+                });
+            return unresolvable;
+        } finally {
+            isolation.remove();
         }
     }
 
@@ -847,20 +940,27 @@ public class JsonSchemaGenerator {
     }
 
     protected List<ResolvedType> subtypeResolver(ResolvedType declaredType, TypeContext typeContext, List<String> allowedPluginTypes) {
+        IsolationContext isolationContext = isolation.get();
         if (declaredType.getErasedType() == Task.class) {
+            if (isolationContext.probing()) {
+                return null; // probing a single type: skip subtype expansion (cheap, non-recursive)
+            }
             return getRegisteredPlugins()
                 .stream()
                 .flatMap(registeredPlugin -> registeredPlugin.getTasks().stream())
-                .filter(p -> allowedPluginTypes.isEmpty() || allowedPluginTypes.contains(p.getName()))
-                .filter(Predicate.not(io.kestra.core.models.Plugin::isInternal))
+                .filter(clz -> isSchemaEligiblePlugin(clz, allowedPluginTypes))
+                .filter(clz -> !isolationContext.excluded().contains(clz.getName()))
                 .flatMap(clz -> safelyResolveSubtype(declaredType, clz, typeContext).stream())
                 .toList();
         } else if (declaredType.getErasedType() == AbstractTrigger.class) {
+            if (isolationContext.probing()) {
+                return null; // probing a single type: skip subtype expansion (cheap, non-recursive)
+            }
             return getRegisteredPlugins()
                 .stream()
                 .flatMap(registeredPlugin -> registeredPlugin.getTriggers().stream())
-                .filter(p -> allowedPluginTypes.isEmpty() || allowedPluginTypes.contains(p.getName()))
-                .filter(Predicate.not(io.kestra.core.models.Plugin::isInternal))
+                .filter(clz -> isSchemaEligiblePlugin(clz, allowedPluginTypes))
+                .filter(clz -> !isolationContext.excluded().contains(clz.getName()))
                 .flatMap(clz -> safelyResolveSubtype(declaredType, clz, typeContext).stream())
                 .toList();
         } else if (declaredType.getErasedType() == TaskRunner.class) {
@@ -1007,8 +1107,11 @@ public class JsonSchemaGenerator {
                 );
                 return Optional.of(fallback);
             } catch (Exception | LinkageError fallbackException) {
+                // The type cannot be resolved at all. For task/trigger types, injectUnresolvedPluginTypes()
+                // still adds a minimal placeholder definition to the schema so the type keeps autocompleting
+                // and validating (see #12102); other categories (e.g. inputs) are excluded entirely.
                 log.warn(
-                    "Unable to resolve subtype '{}' of '{}' for schema generation, it will be excluded from autocompletion. Cause: [{}] {}",
+                    "Unable to resolve subtype '{}' of '{}' for schema generation. Cause: [{}] {}",
                     clz.getName(),
                     declaredType.getErasedType().getName(),
                     fallbackException.getClass().getSimpleName(),
@@ -1017,6 +1120,88 @@ public class JsonSchemaGenerator {
                 return Optional.empty();
             }
         }
+    }
+
+    /**
+     * Whether a registered plugin class should appear in the generated schema: not internal, and either no
+     * explicit allow-list was given or the class is on it. Shared by {@link #subtypeResolver} (which resolves
+     * eligible types) and {@link #injectUnresolvedPluginTypes} (which reconciles the ones that failed to resolve),
+     * so the two paths cannot drift.
+     */
+    private static boolean isSchemaEligiblePlugin(Class<?> pluginClass, List<String> allowedPluginTypes) {
+        return (allowedPluginTypes.isEmpty() || allowedPluginTypes.contains(pluginClass.getName()))
+            && !io.kestra.core.models.Plugin.isInternal(pluginClass);
+    }
+
+    /**
+     * Reconcile the generated schema with the plugin registry. A task/trigger type that is registered and
+     * schema-eligible but absent from {@code definitions} was dropped because its generic type hierarchy could
+     * not be resolved (e.g. a plugin jar built against an incompatible Kestra version, throwing
+     * {@link TypeNotPresentException}/{@link NoClassDefFoundError} in {@link #safelyResolveSubtype}). Instead of
+     * letting it silently disappear from autocompletion and trigger "unknown type" validation warnings (#12102),
+     * inject a minimal permissive definition and reference it from the base type's {@code anyOf}. The type then
+     * still autocompletes and validates; only its property-level detail is unavailable, since its structure could
+     * not be resolved.
+     */
+    // package-private for testing
+    void injectUnresolvedPluginTypes(ObjectNode objectNode, List<String> allowedPluginTypes) {
+        if (!(objectNode.get("definitions") instanceof ObjectNode definitions)) {
+            return;
+        }
+
+        injectUnresolvedForBase(
+            definitions,
+            Task.class.getName(),
+            getRegisteredPlugins().stream().flatMap(registeredPlugin -> registeredPlugin.getTasks().stream()),
+            allowedPluginTypes
+        );
+        injectUnresolvedForBase(
+            definitions,
+            AbstractTrigger.class.getName(),
+            getRegisteredPlugins().stream().flatMap(registeredPlugin -> registeredPlugin.getTriggers().stream()),
+            allowedPluginTypes
+        );
+    }
+
+    private void injectUnresolvedForBase(ObjectNode definitions, String baseDefinitionKey, Stream<? extends Class<?>> candidates, List<String> allowedPluginTypes) {
+        if (!(definitions.get(baseDefinitionKey) instanceof ObjectNode baseDefinition)
+            || !(baseDefinition.get("anyOf") instanceof ArrayNode anyOf)) {
+            return;
+        }
+
+        candidates
+            .filter(clz -> isSchemaEligiblePlugin(clz, allowedPluginTypes))
+            .map(Class::getName)
+            .distinct()
+            .filter(name -> !definitions.has(name))
+            .forEach(name -> {
+                populatePlaceholderDefinition(definitions.putObject(name), name);
+                anyOf.add(MAPPER.createObjectNode().put("$ref", "#/definitions/" + name));
+            });
+    }
+
+    /**
+     * Populate {@code definition} with a minimal permissive schema for a plugin type whose full schema could not be
+     * generated. It accepts any property (so valid flows are not falsely rejected) while still pinning the
+     * {@code type} discriminator, so the type keeps autocompleting and validating. Called only from
+     * {@link #injectUnresolvedPluginTypes}, which is the single backfill path for both failure modes: types dropped
+     * by {@link #safelyResolveSubtype} because their generics could not be resolved, and types excluded from the
+     * {@code anyOf} on an isolation retry (see {@link #generateRootSchemaIsolatingFailures}) because they threw
+     * during generation. See #12102.
+     */
+    private static void populatePlaceholderDefinition(ObjectNode definition, String className) {
+        definition.put("type", "object");
+        // the structure could not be resolved, so accept any property rather than falsely rejecting valid ones
+        definition.put("additionalProperties", true);
+        definition.putObject("properties").putObject("type").put("const", className);
+        definition.putArray("required").add("type");
+        definition.put("title", className.substring(className.lastIndexOf('.') + 1));
+        definition.put(
+            "markdownDescription",
+            "The full schema for this plugin could not be generated, likely because it was built against an "
+                + "incompatible Kestra version (see the server logs for the cause). The task remains usable and "
+                + "executable, but property validation and autocompletion are unavailable for it."
+        );
     }
 
     protected List<RegisteredPlugin> getRegisteredPlugins() {

--- a/core/src/test/java/io/kestra/core/docs/JsonSchemaGeneratorTest.java
+++ b/core/src/test/java/io/kestra/core/docs/JsonSchemaGeneratorTest.java
@@ -635,6 +635,18 @@ class JsonSchemaGeneratorTest {
         });
     }
 
+    @Test
+    void safelyResolveSubtypeShouldReturnEmptyInsteadOfThrowingWhenSubtypeIsUnresolvable() {
+        com.github.victools.jsonschema.generator.TypeContext typeContext = com.github.victools.jsonschema.generator.impl.TypeContextFactory.createDefaultTypeContext();
+        com.fasterxml.classmate.ResolvedType declaredType = typeContext.resolve(Task.class);
+
+        // String is unrelated to Task, so classmate throws while resolving it as a subtype;
+        // safelyResolveSubtype must swallow it (and log) rather than aborting schema generation for every other plugin.
+        Optional<com.fasterxml.classmate.ResolvedType> resolved = JsonSchemaGenerator.safelyResolveSubtype(declaredType, String.class, typeContext);
+
+        assertThat(resolved.isEmpty(), is(true));
+    }
+
     @SuperBuilder
     @ToString
     @EqualsAndHashCode

--- a/core/src/test/java/io/kestra/core/docs/JsonSchemaGeneratorTest.java
+++ b/core/src/test/java/io/kestra/core/docs/JsonSchemaGeneratorTest.java
@@ -6,6 +6,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Assertions;
@@ -660,6 +661,101 @@ class JsonSchemaGeneratorTest {
         Optional<com.fasterxml.classmate.ResolvedType> resolved = JsonSchemaGenerator.safelyResolveSubtype(declaredType, String.class, typeContext);
 
         assertThat(resolved.isEmpty(), is(true));
+    }
+
+    @Test
+    void shouldInjectPlaceholderSchemaForUnresolvedTaskType() {
+        // Given: a task type that is registered and schema-eligible, but absent from the generated schema's
+        // Task.anyOf — i.e. it was dropped by safelyResolveSubtype because its generics could not be resolved
+        // (a plugin built against an incompatible Kestra version). See #12102.
+        RegisteredPlugin plugin = RegisteredPlugin.builder()
+            .tasks(List.of(Log.class))
+            .triggers(List.of())
+            .build();
+        JsonSchemaGenerator generator = new JsonSchemaGenerator(pluginRegistry) {
+            @Override
+            protected List<RegisteredPlugin> getRegisteredPlugins() {
+                return List.of(plugin);
+            }
+        };
+        com.fasterxml.jackson.databind.ObjectMapper mapper = new com.fasterxml.jackson.databind.ObjectMapper();
+        com.fasterxml.jackson.databind.node.ObjectNode schema = mapper.createObjectNode();
+        com.fasterxml.jackson.databind.node.ObjectNode definitions = schema.putObject("definitions");
+        definitions.putObject(Task.class.getName()).putArray("anyOf");
+
+        // When
+        generator.injectUnresolvedPluginTypes(schema, List.of());
+
+        // Then: a minimal permissive definition is injected so the type still validates and autocompletes
+        com.fasterxml.jackson.databind.JsonNode injected = definitions.get(Log.class.getName());
+        assertThat(injected, is(notNullValue()));
+        assertThat(injected.get("type").asText(), is("object"));
+        assertThat(injected.get("additionalProperties").asBoolean(), is(true));
+        assertThat(injected.get("properties").get("type").get("const").asText(), is(Log.class.getName()));
+
+        // and it is referenced from the Task base type's anyOf
+        boolean referenced = false;
+        for (com.fasterxml.jackson.databind.JsonNode ref : definitions.get(Task.class.getName()).get("anyOf")) {
+            if (("#/definitions/" + Log.class.getName()).equals(ref.path("$ref").asText())) {
+                referenced = true;
+            }
+        }
+        assertThat(referenced, is(true));
+
+        // and an already-present type is neither duplicated nor overwritten
+        int anyOfSizeAfterFirst = definitions.get(Task.class.getName()).get("anyOf").size();
+        generator.injectUnresolvedPluginTypes(schema, List.of());
+        assertThat(definitions.get(Task.class.getName()).get("anyOf").size(), is(anyOfSizeAfterFirst));
+    }
+
+    @Test
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    void shouldIsolateASinglePluginThatCannotBeSchemaGenerated() {
+        // Given: two registered tasks; a first full generation that fails (as victools does atomically when one
+        // plugin built against an incompatible Kestra version throws mid-generation), and a probe that pinpoints
+        // Return as the offender. See #12102 — one broken plugin must not take the whole flow schema down.
+        List emptyLists = List.of();
+        RegisteredPlugin plugin = RegisteredPlugin.builder()
+            .tasks(List.of(Log.class, Return.class, Dag.class)).triggers(emptyLists)
+            .taskRunners(emptyLists).assets(emptyLists).assetExporters(emptyLists).charts(emptyLists)
+            .dataFilters(emptyLists).dataFiltersKPI(emptyLists).logExporters(emptyLists)
+            .additionalPlugins(emptyLists).fileRenderers(emptyLists).storages(emptyLists).secrets(emptyLists)
+            .logDataStores(emptyLists).apps(emptyLists).appBlocks(emptyLists).rules(emptyLists)
+            .build();
+        java.util.concurrent.atomic.AtomicInteger fullGenerationAttempts = new java.util.concurrent.atomic.AtomicInteger();
+        JsonSchemaGenerator generator = new JsonSchemaGenerator(pluginRegistry) {
+            @Override
+            protected List<RegisteredPlugin> getRegisteredPlugins() {
+                return List.of(plugin);
+            }
+
+            @Override
+            com.fasterxml.jackson.databind.node.ObjectNode generateRootSchema(Class<?> cls, List<String> allowedPluginTypes, boolean withOutputs) {
+                if (fullGenerationAttempts.getAndIncrement() == 0) {
+                    throw new IllegalArgumentException("simulated whole-schema generation failure");
+                }
+                return super.generateRootSchema(cls, allowedPluginTypes, withOutputs);
+            }
+
+            @Override
+            Set<String> probeUnresolvablePluginTypes(List<String> allowedPluginTypes) {
+                return Set.of(Return.class.getName());
+            }
+        };
+
+        // When
+        Map<String, Object> schema = generator.schemas(Task.class, false, List.of());
+
+        // Then: generation recovered (a retry happened), the good task is fully generated, and the offending one is
+        // present as a permissive placeholder rather than crashing the whole schema.
+        assertThat(fullGenerationAttempts.get(), is(2));
+        Map<String, Object> definitions = (Map<String, Object>) schema.get("definitions");
+        assertThat(definitions.containsKey(Log.class.getName()), is(true));
+
+        Map<String, Object> returnDefinition = (Map<String, Object>) definitions.get(Return.class.getName());
+        assertThat(returnDefinition, is(notNullValue()));
+        assertThat(returnDefinition.get("additionalProperties"), is(true));
+        assertThat(((Map<String, Object>) ((Map<String, Object>) returnDefinition.get("properties")).get("type")).get("const"), is(Return.class.getName()));
     }
 
     @SuperBuilder

--- a/core/src/test/java/io/kestra/core/docs/JsonSchemaGeneratorTest.java
+++ b/core/src/test/java/io/kestra/core/docs/JsonSchemaGeneratorTest.java
@@ -636,12 +636,27 @@ class JsonSchemaGeneratorTest {
     }
 
     @Test
-    void safelyResolveSubtypeShouldReturnEmptyInsteadOfThrowingWhenSubtypeIsUnresolvable() {
+    void safelyResolveSubtypeShouldFallBackToPlainResolveWhenSubtypeResolutionFails() {
         com.github.victools.jsonschema.generator.TypeContext typeContext = com.github.victools.jsonschema.generator.impl.TypeContextFactory.createDefaultTypeContext();
         com.fasterxml.classmate.ResolvedType declaredType = typeContext.resolve(Task.class);
 
         // String is unrelated to Task, so classmate throws while resolving it as a subtype;
-        // safelyResolveSubtype must swallow it (and log) rather than aborting schema generation for every other plugin.
+        // safelyResolveSubtype must fall back to a plain resolve() so the type still appears in the schema
+        // instead of being silently excluded from autocompletion.
+        Optional<com.fasterxml.classmate.ResolvedType> resolved = JsonSchemaGenerator.safelyResolveSubtype(declaredType, String.class, typeContext);
+
+        assertThat(resolved.isPresent(), is(true));
+        assertThat(resolved.get().getErasedType(), is(String.class));
+    }
+
+    @Test
+    void safelyResolveSubtypeShouldReturnEmptyWhenBothSubtypeAndPlainResolveFail() {
+        com.github.victools.jsonschema.generator.TypeContext typeContext = org.mockito.Mockito.mock(com.github.victools.jsonschema.generator.TypeContext.class);
+        com.fasterxml.classmate.ResolvedType declaredType = org.mockito.Mockito.mock(com.fasterxml.classmate.ResolvedType.class);
+        org.mockito.Mockito.doReturn(Task.class).when(declaredType).getErasedType();
+        org.mockito.Mockito.when(typeContext.resolveSubtype(declaredType, String.class)).thenThrow(new IllegalArgumentException("subtype resolution failed"));
+        org.mockito.Mockito.when(typeContext.resolve(String.class)).thenThrow(new NoClassDefFoundError("plain resolve also failed"));
+
         Optional<com.fasterxml.classmate.ResolvedType> resolved = JsonSchemaGenerator.safelyResolveSubtype(declaredType, String.class, typeContext);
 
         assertThat(resolved.isEmpty(), is(true));


### PR DESCRIPTION
## Summary
- `JsonSchemaGenerator.safelyResolveSubtype()` caught plugin-type resolution failures and silently dropped the type, no logging. A plugin task that fails generic-type resolution (e.g. a manually built jar hitting a classloading conflict) disappears from the JSON schema used for editor autocompletion, while still showing up on the `/plugins` page and running fine (Jackson deserialization doesn't go through this path). Matches #12102: newly installed plugins are listed and executable, but don't autocomplete and show schema-validation warnings, with no error anywhere to diagnose why.
- Broadened the `catch` from `Exception` to `Throwable` — classloader conflicts (`NoClassDefFoundError`/`LinkageError`), plausible when independently built plugin jars with cross-dependencies (e.g. `plugin-script` + `plugin-script-shell`) load in separate isolated classloaders, weren't even caught before.
- **Fallback instead of exclusion**: when `resolveSubtype(declaredType, clz)` throws, fall back to a plain `typeContext.resolve(clz)` — the same call every other plugin category (`TaskRunner`, `Chart`, `Asset`, `LogExporter`, ...) already uses with no subtype-binding walk, so it isn't exposed to this failure mode. The type now still appears in the schema/autocompletion (possibly missing some generic-derived detail) instead of vanishing entirely. Only if the fallback also fails is the type excluded, and now with a `log.warn` naming the class and cause so it's diagnosable.

Fixes #12102

## Test plan
- [x] `./gradlew :core:compileJava`
- [x] `./gradlew :core:test --tests "io.kestra.core.docs.JsonSchemaGeneratorTest"` — 22/22 pass, including:
  - `safelyResolveSubtypeShouldFallBackToPlainResolveWhenSubtypeResolutionFails` — subtype resolution fails, asserts the fallback plain resolve is used and the type is still returned.
  - `safelyResolveSubtypeShouldReturnEmptyWhenBothSubtypeAndPlainResolveFail` — both resolutions fail (mocked), asserts graceful empty result with no exception propagating.