### PR TITLE
fix(design-system): restore TypeScript ambient types in Monaco editor

### DIFF
--- a/ui/packages/design-system/src/components/Form/KsEditor.vue
+++ b/ui/packages/design-system/src/components/Form/KsEditor.vue
@@ -201,6 +201,7 @@
     import "monaco-editor/esm/vs/editor/standalone/browser/iPadShowKeyboard/iPadShowKeyboard"
     import "monaco-editor/esm/vs/editor/standalone/browser/quickAccess/standaloneCommandsQuickAccess"
     import "monaco-editor/esm/vs/language/json/monaco.contribution"
+    import "monaco-editor/esm/vs/language/typescript/monaco.contribution"
     import "monaco-editor/esm/vs/basic-languages/monaco.contribution"
 
     import type {VNode} from "vue"

--- a/ui/src/main.ts
+++ b/ui/src/main.ts
@@ -4,18 +4,14 @@ import type {Router} from "vue-router"
 import "./utils/monacoEnvironment"
 
 const NodeTypesRaw = import.meta.glob("/node_modules/@types/node/**/*.d.ts", {eager: true, query: "?raw", import: "default"}) as Record<string, string>
-function loadNodeTypes(tries = 0) {
-    import("monaco-editor/esm/vs/editor/editor.api").then(({languages}) => {
-        if (languages.typescript) {
-            for (const path in NodeTypesRaw) {
-                languages.typescript.typescriptDefaults.addExtraLib(NodeTypesRaw[path], `file://${path}`)
-            }
-        } else if (tries <= 15) {
-            setTimeout(() => loadNodeTypes(tries + 1), (tries + 1) * 100)
-        }
-    })
-}
-loadNodeTypes()
+Promise.all([
+    import("monaco-editor/esm/vs/language/typescript/monaco.contribution"),
+    import("monaco-editor/esm/vs/editor/editor.api"),
+]).then(([, {languages}]) => {
+    for (const path in NodeTypesRaw) {
+        languages.typescript.typescriptDefaults.addExtraLib(NodeTypesRaw[path], `file://${path}`)
+    }
+})
 
 import App from "./App.vue"
 import initApp from "./utils/init"


### PR DESCRIPTION
## What & why

**Regression** introduced by the Monaco editor update to `0.52.x`.

Monaco's ESM build leaves `languages.typescript` **undefined** until the TypeScript *contribution* module is explicitly imported. Nothing in the app imported it, so:

- The ambient `@types/node` injection in `main.ts` polled `languages.typescript` (up to 15 retries) against a namespace that would never appear, then silently gave up — no Node globals (`process`, `Buffer`, …) in JS/TS editor autocomplete.
- The `setCompilerOptions` guard in `KsEditor.vue` (`if (monaco.languages.typescript)`) was skipped for the same reason.

## Changes

- Import `monaco-editor/esm/vs/language/typescript/monaco.contribution` in `KsEditor.vue` (alongside the existing `json` / `basic-languages` contributions) — this also re-enables the neighbouring `setCompilerOptions` block.
- Import the same contribution in `main.ts` and drop the `setTimeout` retry hack; the ambient types are now added deterministically via `Promise.all([contribution, editor.api])`.

Both imports resolve to the same Monaco singleton, so importing in both entry points costs nothing at runtime — it just makes each self-sufficient regardless of load order.

## Testing

- `npm run check:types` passes (design-system, app, tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)