### PR TITLE
feat(ai): send the current page to the copilot as additionalContext

### DIFF
--- a/ui/src/components/ai/copilot/CopilotChat.vue
+++ b/ui/src/components/ai/copilot/CopilotChat.vue
@@ -123,14 +123,14 @@
     import CopilotContextChip from "./CopilotContextChip.vue"
     import CopilotThreadControls from "override/components/ai/copilot/CopilotThreadControls.vue"
     import {useAiChat} from "./useAiChat"
-    import {scopeFromRoute} from "./routeScope"
+    import {scopeFromRoute, scopeToContext} from "./routeScope"
     import type {Mode, ScopeBinding} from "./types"
     import {useMiscStore} from "override/stores/misc"
 
     const props = defineProps<{
         /** Initial mode; defaults to EDIT. */
         initialMode?: Mode
-        /** Artefact in focus, passed as `inFocus` on each turn. */
+        /** Scope the user is focused on; sent as `additionalContext` on each turn. */
         inFocus?: ScopeBinding | null
     }>()
 
@@ -213,7 +213,7 @@
     })
 
     function onSubmit(prompt: string): void {
-        sendChat({prompt, mode: mode.value, inFocus: activeScope.value, providerId: selectedProvider.value})
+        sendChat({prompt, mode: mode.value, additionalContext: scopeToContext(activeScope.value), providerId: selectedProvider.value})
     }
 
     // Keep the transcript pinned to the bottom as content arrives: new messages, streamed

--- a/ui/src/components/ai/copilot/CopilotContextChip.vue
+++ b/ui/src/components/ai/copilot/CopilotContextChip.vue
@@ -1,5 +1,5 @@
 <template>
-    <!-- Shows the page the copilot is focused on (sent as `inFocus`). Dismissible to drop the scope. -->
+    <!-- Shows the page the copilot is focused on (sent as `additionalContext`). Dismissible to drop it. -->
     <div class="copilot-context" data-test="copilot-context-chip">
         <KsTag closable size="small" :icon="icon" @close="emit('clear')">
             {{ label }}

--- a/ui/src/components/ai/copilot/routeScope.ts
+++ b/ui/src/components/ai/copilot/routeScope.ts
@@ -43,3 +43,16 @@ export function scopeFromRoute(route: RouteLike | undefined | null): ScopeBindin
             return null
     }
 }
+
+/**
+ * Converts a scope into the free-form `additionalContext` map sent on a chat turn (what the user is
+ * currently viewing). Returns undefined when there's no scope, and omits absent fields.
+ */
+export function scopeToContext(scope: ScopeBinding | null | undefined): Record<string, unknown> | undefined {
+    if (!scope) return undefined
+    const currentView: Record<string, unknown> = {kind: scope.kind}
+    if (scope.namespace) currentView.namespace = scope.namespace
+    if (scope.flowId) currentView.flowId = scope.flowId
+    if (scope.executionId) currentView.executionId = scope.executionId
+    return {currentView}
+}

--- a/ui/src/components/ai/copilot/types.ts
+++ b/ui/src/components/ai/copilot/types.ts
@@ -55,7 +55,11 @@ export interface CreateThreadRequest {
 export interface ChatTurnRequest {
     prompt: string
     mode?: Mode | null
-    inFocus?: ScopeBinding | null
+    /**
+     * Free-form, per-turn context (e.g. what the user is currently viewing). The backend renders it
+     * into the model input for this turn only — it is not persisted. Replaces the old `inFocus`.
+     */
+    additionalContext?: Record<string, unknown> | null
     providerId?: string | null
 }
 

--- a/ui/tests/unit/components/ai/copilot/CopilotChat.spec.ts
+++ b/ui/tests/unit/components/ai/copilot/CopilotChat.spec.ts
@@ -25,7 +25,7 @@ const state = {
     restoreThread: vi.fn(),
 }
 vi.mock("../../../../../src/components/ai/copilot/useAiChat", () => ({useAiChat: () => state}))
-// CopilotChat derives `inFocus` from the current route — mock a mutable route so tests control it.
+// CopilotChat derives the page scope from the current route — mock a mutable route so tests control it.
 let routeStub: {name?: string; params: Record<string, any>} = {name: undefined, params: {}}
 vi.mock("vue-router", () => ({useRoute: () => routeStub}))
 // The provider list is fetched on mount — stub the SDK so no real request fires.
@@ -98,17 +98,17 @@ describe("CopilotChat", () => {
         const w = mountChat({initialMode: "PLAN"})
         w.findComponent({name: "CopilotComposer"}).vm.$emit("submit", "do it")
         await flushPromises()
-        expect(state.sendChat).toHaveBeenCalledWith({prompt: "do it", mode: "PLAN", inFocus: null, providerId: undefined})
+        expect(state.sendChat).toHaveBeenCalledWith({prompt: "do it", mode: "PLAN", additionalContext: undefined, providerId: undefined})
     })
 
-    it("sends the current page as inFocus when on a detail route (context-awareness)", async () => {
+    it("sends the current page as additionalContext on a detail route (context-awareness)", async () => {
         routeStub = {name: "executions/update", params: {namespace: "company.team", flowId: "my-flow", id: "exec-1"}}
         const w = mountChat()
         w.findComponent({name: "CopilotComposer"}).vm.$emit("submit", "why did this fail?")
         await flushPromises()
         expect(state.sendChat).toHaveBeenCalledWith(expect.objectContaining({
             prompt: "why did this fail?",
-            inFocus: {kind: "EXECUTION", namespace: "company.team", flowId: "my-flow", executionId: "exec-1"},
+            additionalContext: {currentView: {kind: "EXECUTION", namespace: "company.team", flowId: "my-flow", executionId: "exec-1"}},
         }))
     })
 
@@ -132,7 +132,7 @@ describe("CopilotChat", () => {
 
         w.findComponent({name: "CopilotComposer"}).vm.$emit("submit", "no scope please")
         await flushPromises()
-        expect(state.sendChat).toHaveBeenCalledWith(expect.objectContaining({prompt: "no scope please", inFocus: null}))
+        expect(state.sendChat).toHaveBeenCalledWith(expect.objectContaining({prompt: "no scope please", additionalContext: undefined}))
     })
 
     it("surfaces a warning notice when a turn yields no output", () => {

--- a/ui/tests/unit/components/ai/copilot/routeScope.spec.ts
+++ b/ui/tests/unit/components/ai/copilot/routeScope.spec.ts
@@ -1,5 +1,5 @@
 import {describe, it, expect} from "vitest"
-import {scopeFromRoute} from "../../../../../src/components/ai/copilot/routeScope"
+import {scopeFromRoute, scopeToContext} from "../../../../../src/components/ai/copilot/routeScope"
 
 describe("scopeFromRoute", () => {
     it("maps an execution detail route to an EXECUTION scope", () => {
@@ -35,5 +35,19 @@ describe("scopeFromRoute", () => {
             .toEqual({kind: "FLOW", namespace: "a", flowId: "f"})
         expect(scopeFromRoute({name: "namespaces/update", params: {id: ""}}))
             .toEqual({kind: "NAMESPACE", namespace: undefined})
+    })
+})
+
+describe("scopeToContext", () => {
+    it("wraps a scope as a currentView additionalContext map, omitting absent fields", () => {
+        expect(scopeToContext({kind: "EXECUTION", namespace: "company.team", flowId: "my-flow", executionId: "exec-1"}))
+            .toEqual({currentView: {kind: "EXECUTION", namespace: "company.team", flowId: "my-flow", executionId: "exec-1"}})
+        expect(scopeToContext({kind: "NAMESPACE", namespace: "company.team"}))
+            .toEqual({currentView: {kind: "NAMESPACE", namespace: "company.team"}})
+    })
+
+    it("returns undefined when there is no scope", () => {
+        expect(scopeToContext(null)).toBeUndefined()
+        expect(scopeToContext(undefined)).toBeUndefined()
     })
 })


### PR DESCRIPTION
## What

Restores copilot page-context awareness after the backend contract changed.

The tool-invocation-context refactor (#17442) replaced the structured **`inFocus`** (`ScopeBinding`) on the chat turn with a free-form **`additionalContext: Map`** that the backend renders into the model input. The FE was still sending `inFocus`, which the backend now **ignores** — so **the copilot was getting no page context at all**.

Now, when the copilot opens on a flow / execution / namespace page, the turn sends:
```json
"additionalContext": { "currentView": { "kind": "EXECUTION", "namespace": "…", "flowId": "…", "executionId": "…" } }
```
(absent fields omitted; `undefined` when there's no scope).

## How
- `ChatTurnRequest.inFocus` → `additionalContext?: Record<string, unknown>`.
- New `scopeToContext(scope)` in `routeScope.ts` builds the map from the existing `scopeFromRoute()` output.
- `CopilotChat.onSubmit` sends `additionalContext: scopeToContext(activeScope)`.
- The **context chip UI is unchanged** — it still shows/clears what's in scope; only the wire field changed.

## Tests
- `routeScope.spec` — `scopeToContext` mapping (+ undefined when no scope).
- `CopilotChat.spec` — a detail route sends the `currentView` context; a plain route / dismissed chip sends `undefined`.
- 117/117 copilot unit tests pass; lint + test-step type-check clean. No new i18n keys.

## Scope
Frontend-only; shared with EE via the `kestra` alias.