### PR TITLE
fix(executions): surface loop iteration failures in the parent execution's error log

### DIFF
--- a/executor/src/main/java/io/kestra/executor/handler/LoopExecutionEventMessageHandler.java
+++ b/executor/src/main/java/io/kestra/executor/handler/LoopExecutionEventMessageHandler.java
@@ -44,6 +44,7 @@ public class LoopExecutionEventMessageHandler implements ExecutorMessageHandler<
     private final DispatchQueueInterface<Execution> executionQueue;
     private final BroadcastQueueInterface<FollowExecutionEvent> followExecutionEventQueue;
     private final KillSwitchService killSwitchService;
+    private final RunContextLoggerFactory runContextLoggerFactory;
 
     @Inject
     public LoopExecutionEventMessageHandler(
@@ -55,7 +56,8 @@ public class LoopExecutionEventMessageHandler implements ExecutorMessageHandler<
         FlowMetaStoreInterface flowMetaStore,
         DispatchQueueInterface<Execution> executionQueue,
         BroadcastQueueInterface<FollowExecutionEvent> followExecutionEventQueue,
-        KillSwitchService killSwitchService) {
+        KillSwitchService killSwitchService,
+        RunContextLoggerFactory runContextLoggerFactory) {
         this.executorService = executorService;
         this.executionService = executionService;
         this.taskOutputService = taskOutputService;
@@ -65,6 +67,7 @@ public class LoopExecutionEventMessageHandler implements ExecutorMessageHandler<
         this.executionQueue = executionQueue;
         this.followExecutionEventQueue = followExecutionEventQueue;
         this.killSwitchService = killSwitchService;
+        this.runContextLoggerFactory = runContextLoggerFactory;
     }
 
     @Override
@@ -98,6 +101,8 @@ public class LoopExecutionEventMessageHandler implements ExecutorMessageHandler<
                 Loop loop = (Loop) executor.getFlow().findTaskByTaskId(message.loopRun().taskId());
 
                 if (loop.getTransmitFailed() && message.state().isTerminatedInError()) {
+                    // the failure happened inside an isolated loop sub-execution: log inside the parent exec
+                    logLoopIterationFailure(parentTaskRun, loop, executor, message);
                     // immediately terminate the loop
                     return terminateLoop(parentTaskRun, loop, executor, message.state());
                 } else {
@@ -192,6 +197,18 @@ public class LoopExecutionEventMessageHandler implements ExecutorMessageHandler<
                 return executorService.handleFailedExecutionFromExecutor(new ExecutorContext(execution), e);
             }
         });
+    }
+
+    private void logLoopIterationFailure(TaskRun parentTaskRun, Loop loop, ExecutorContext executor, LoopExecutionEvent message) {
+        RunContextLogger runContextLogger = runContextLoggerFactory.create(parentTaskRun, loop, executor.getExecution().getKind());
+        runContextLogger.logger().error(
+            "Loop iteration {} ended in {} in sub-execution [[link execution=\"{}\" flowId=\"{}\" namespace=\"{}\"]], check that execution's logs for details",
+            message.loopRun().index(),
+            message.state(),
+            message.executionId(),
+            executor.getExecution().getFlowId(),
+            executor.getExecution().getNamespace()
+        );
     }
 
     private Map<String, Object> buildIterationOutput(LoopExecutionEvent message) {

--- a/executor/src/test/java/io/kestra/executor/handler/LoopExecutionEventMessageHandlerTest.java
+++ b/executor/src/test/java/io/kestra/executor/handler/LoopExecutionEventMessageHandlerTest.java
@@ -4,14 +4,17 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.slf4j.event.Level;
 
 import io.kestra.core.exceptions.InternalException;
 import io.kestra.core.killswitch.EvaluationType;
 import io.kestra.core.killswitch.KillSwitchService;
 import io.kestra.core.models.executions.Execution;
+import io.kestra.core.models.executions.LogEntry;
 import io.kestra.core.models.executions.LoopExecutionEvent;
 import io.kestra.core.models.executions.LoopRun;
 import io.kestra.core.models.executions.TaskRun;
@@ -19,6 +22,7 @@ import io.kestra.core.models.executions.TaskRunAttempt;
 import io.kestra.core.models.flows.Flow;
 import io.kestra.core.models.flows.GenericFlow;
 import io.kestra.core.models.flows.State;
+import io.kestra.core.queues.DispatchQueueInterface;
 import io.kestra.core.repositories.ExecutionRepositoryInterface;
 import io.kestra.core.repositories.FlowRepositoryInterface;
 import io.kestra.core.services.TaskOutputService;
@@ -53,6 +57,9 @@ class LoopExecutionEventMessageHandlerTest {
 
     @Inject
     KillSwitchService killSwitchService;
+
+    @Inject
+    private DispatchQueueInterface<LogEntry> logQueue;
 
     @MockBean(KillSwitchService.class)
     KillSwitchService killSwitchService() {
@@ -116,16 +123,26 @@ class LoopExecutionEventMessageHandlerTest {
         String loopTaskRunId = IdUtils.create();
         var loopTaskRun = loopTaskRun(loopTaskRunId, execution);
         executionRepository.save(execution.withTaskRunList(List.of(loopTaskRun)));
+        List<LogEntry> logs = new CopyOnWriteArrayList<>();
+        logQueue.addListener(logs::add);
 
         // When — one iteration fails, loop should terminate immediately
         var loopRun = new LoopRun(execution, "loop", loopTaskRunId, 0, null, "a", null);
-        var message = new LoopExecutionEvent(loopRun, execution.getId(), State.Type.FAILED, null);
+        var message = new LoopExecutionEvent(loopRun, "sub-execution-id", State.Type.FAILED, null);
         var maybeExecutor = handler.handle(message);
 
         // Then
         assertThat(maybeExecutor).isPresent();
         var taskRun = maybeExecutor.get().getExecution().findTaskRunByTaskRunId(loopTaskRunId);
         assertThat(taskRun.getState().getCurrent()).isEqualTo(State.Type.FAILED);
+
+        // check that a log was created for the parent execution
+        List<LogEntry> matchingLog = TestsUtils.awaitLogs(logs, 1);
+        LogEntry errorLog = matchingLog.getFirst();
+        assertThat(errorLog.getLevel()).isEqualTo(Level.ERROR);
+        assertThat(errorLog.getExecutionId()).isEqualTo(execution.getId());
+        assertThat(errorLog.getTaskRunId()).isEqualTo(loopTaskRunId);
+        assertThat(errorLog.getMessage()).contains("sub-execution-id").contains("FAILED");
     }
 
     @Test


### PR DESCRIPTION
## Summary

When a `Loop` task's sub-execution (one iteration) fails at the executor level — e.g. an `IllegalVariableEvaluationException` while rendering a `Subflow` task's `inputs` — the exception is only logged inside the isolated loop sub-execution. The parent execution never gets an ERROR-level `LogEntry`, so the UI's execution error banner (`ErrorAlert.vue`), which fetches ERROR logs scoped only to the parent execution id, renders empty.

Emit a log on the parent when a loop iteration fails, pointing at the failed sub-execution.

## Screenshot of the new error message

<img width="2300" height="181" alt="image" src="https://github.com/user-attachments/assets/c56ad653-16bc-4803-86f4-be86c4f94ee1" />


## Changes

- `LoopExecutionEventMessageHandler`: inject `RunContextLoggerFactory` and, in the branch where a loop iteration terminates the parent loop task in error (`transmitFailed=true` + `isTerminatedInError()`), emit a persisted ERROR log on the parent taskrun referencing the failed sub-execution id and iteration index.
- Extended the existing `shouldTerminateLoopImmediatelyWhenTransmitFailedIsEnabled` test to assert the ERROR log is emitted and correctly scoped to the parent execution/taskrun.

Closes kestra-io/kestra-ee#8699

## Test plan

- [x] `./gradlew :executor:test --tests "io.kestra.executor.handler.LoopExecutionEventMessageHandlerTest"` — 7/7 passing
- [x] `./gradlew :core:test --tests "*Loop*"` — 32/32 passing
- [x] Code review pass (approved, minor nit about state-aware wording applied)