### PR TITLE
fix(design-system): stop text buttons shifting layout on hover

### DIFF
--- a/ui/packages/design-system/src/components/Basic/KsButton/KsButton.vue
+++ b/ui/packages/design-system/src/components/Basic/KsButton/KsButton.vue
@@ -182,12 +182,14 @@
         &.is-text {
             &:hover {
                 background-color: var(--ks-bg-hover);
-                border: 1px solid var(--ks-btn-secondary-border-hover);
+                /* Draw the hover ring with an inset shadow rather than a border: a border adds
+                   1px on each side and shifts surrounding layout, a shadow doesn't affect the box. */
+                box-shadow: inset 0 0 0 1px var(--ks-btn-secondary-border-hover);
             }
 
             &:active {
                 background-color: var(--ks-btn-secondary-bg-active);
-                border: 0;
+                box-shadow: none;
             }
         }
 


### PR DESCRIPTION
## What
Text buttons (`KsButton … text`) had **no border at rest** but gained `border: 1px solid` on `:hover`. That extra 1px per side grows the button's box by 2px and shifts surrounding layout on hover.

## Fix
Paint the hover ring with an **inset box-shadow** (`box-shadow: inset 0 0 0 1px …`) instead of a border. A shadow is painted, not laid out, so:
- Hover no longer changes the button's box → **no layout shift**.
- Rest-state size/appearance is unchanged → no regression elsewhere.
- Visually the 1px inset ring reads the same as the old border.

Surfaced by the AI Copilot v2 Recents dropdown (Rename/Delete buttons nudging the row on hover), but the fix is design-system-wide.

## Scope
Design-system only; no behavior change other than removing the shift. Targets the `feat/ai-copilot-v2-agentic-loop` branch.