### PR TITLE
test(logs): make the LogDataStore aggregation fixture backend-agnostic

### DIFF
--- a/tests/src/main/java/io/kestra/core/repositories/AbstractLogDataStoreTest.java
+++ b/tests/src/main/java/io/kestra/core/repositories/AbstractLogDataStoreTest.java
@@ -141,10 +141,15 @@ public abstract class AbstractLogDataStoreTest {
         log(Level.INFO, "exec-sink").taskId("sink").taskRunId("tr-sink").attemptNumber(2).build()
     );
 
+    // The three levels are DISTINCT on purpose: fetchData/fetchValue aggregate COUNT over the LEVEL field, and
+    // backends legitimately differ on "COUNT of a field" — JDBC counts rows, Elasticsearch counts distinct values
+    // (cardinality). Distinct levels make COUNT(level) == 3 under both semantics, keeping the aggregation assertion
+    // backend-agnostic. Do not collapse these back to a single level. (No DISTINCT filter case filters on level.)
     private static final List<LogEntry> DISTINCT_LOGS = List.of(
         log(Level.INFO, "exec-alpha").namespace("io.kestra.alpha").flowId("alpha-flow").triggerId("alpha-trigger").taskId("alpha-task").taskRunId("alpha-tr").message("alpha message").build(),
-        log(Level.INFO, "exec-beta").namespace("io.kestra.beta").flowId("beta-flow").triggerId("beta-trigger").taskId("beta-task").taskRunId("beta-tr").message("beta message").build(),
-        log(Level.INFO, "exec-gamma").namespace("com.example.gamma").flowId("gamma-flow").triggerId("gamma-trigger").taskId("gamma-task").taskRunId("gamma-tr").message("gamma message").build()
+        log(Level.WARN, "exec-beta").namespace("io.kestra.beta").flowId("beta-flow").triggerId("beta-trigger").taskId("beta-task").taskRunId("beta-tr").message("beta message").build(),
+        log(Level.ERROR, "exec-gamma").namespace("com.example.gamma").flowId("gamma-flow").triggerId("gamma-trigger").taskId("gamma-task").taskRunId("gamma-tr").message("gamma message")
+            .build()
     );
 
     // Timestamps are relative to now, never fixed historical dates: retention-limited backends (Cloud Logging drops


### PR DESCRIPTION
## What

The `AbstractLogDataStoreTest` `DISTINCT` read-fixture used three identical `INFO` levels, so the `fetchData` / `fetchValue` `COUNT`-over-`LEVEL` assertions depended on a semantic that differs by backend:

- **JDBC** counts rows → `COUNT(level)` = 3
- **Elasticsearch** counts distinct values via `cardinality` → `COUNT(level)` = 1

This makes the fixture use **three distinct levels** (`INFO`/`WARN`/`ERROR`) so `COUNT(level)` == 3 under both semantics — keeping the contract backend-agnostic. A comment documents why they must stay distinct. No `DISTINCT` filter case filters on level, so nothing else is affected.

## Why

Follow-up to #17513 (load-once LogDataStore contract). Running that contract against the Elasticsearch log data store surfaced this over-assertion. The visibility half of the ES failures is fixed in the companion EE PR (refreshes the ES index in `awaitIndexing`); this PR fixes the aggregation half in the shared contract.

## Verification

- `:jdbc-h2:test --tests "*H2LogDataStoreTest*"` → 112/112 green
- `:repository-elasticsearch-ee:test --tests "*ElasticSearchLogDataStoreTest*"` (EE, against this branch + companion) → 112/112 green

Companion EE PR: refresh ES index in `ElasticSearchLogDataStoreTest.awaitIndexing` (same branch name).