### PR TITLE
fix(executions): make outputs explorer viewer background cover scroll…

### DIFF
--- a/ui/src/components/executions/outputs/ExecutionVariableExplorer.vue
+++ b/ui/src/components/executions/outputs/ExecutionVariableExplorer.vue
@@ -15,7 +15,7 @@
 
                     <!-- Center: tree / raw JSON of the selected value -->
                     <KsSplitterPanel class="variable-explorer__panel variable-explorer__panel--viewer">
-                        <div class="viewer">
+                        <div class="viewer" :class="{'viewer--fill': isRawEditor}">
                             <div class="viewer__header">
                                 <KsSegmented
                                     v-if="isExpandableValue && !fileSelectedOutput"
@@ -38,12 +38,11 @@
                             </template>
 
                             <KsEditor
-                                v-else-if="viewMode === 'raw' && isExpandableValue"
+                                v-else-if="isRawEditor"
                                 v-bind="editorBindings"
                                 :readOnly="true"
                                 :inline="true"
                                 :navbar="false"
-                                :options="{fullHeight: true}"
                                 :modelValue="rawValue"
                                 lang="json"
                             />
@@ -314,6 +313,8 @@
         {label: t("variable_explorer.raw_json"), value: "raw"},
     ])
 
+    const isRawEditor = computed(() => viewMode.value === "raw" && isExpandableValue.value)
+
     function copyValue() {
         navigator.clipboard?.writeText(rawValue.value)
     }
@@ -368,8 +369,7 @@
     display: flex;
     flex-direction: column;
     width: 100%;
-    height: 100%;
-    min-height: 0;
+    min-height: 100%;
     background-color: var(--ks-bg-surface);
 
     &__header {
@@ -379,12 +379,6 @@
         gap: var(--ks-spacing-2);
         padding: var(--ks-spacing-3) var(--ks-spacing-4);
         border-bottom: 1px solid var(--ks-border-default);
-    }
-
-    &__body {
-        flex: 1 1 0;
-        min-height: 0;
-        padding: var(--ks-spacing-2) var(--ks-spacing-3);
     }
 
     &__scalar {
@@ -397,6 +391,11 @@
     .file-preview {
         padding: var(--ks-spacing-4);
     }
+}
+
+.viewer--fill {
+    height: 100%;
+    min-height: 0;
 }
 
 .debug {


### PR DESCRIPTION
closes https://github.com/kestra-io/kestra-ee/issues/8968

This pull request refactors the layout and logic for displaying the raw JSON editor in the `ExecutionVariableExplorer.vue` component. The changes improve the way the raw JSON view is rendered and styled, ensuring better sizing and conditional display logic.

**Improvements to conditional rendering and logic:**

* Introduced a new computed property `isRawEditor` to centralize the logic for when the raw JSON editor should be shown, simplifying template conditions. [[1]](diffhunk://#diff-d36e60346c3ae5929c9e65d89932b311a7b2ce220b2645c97b4fb933088b276dR316-R317) [[2]](diffhunk://#diff-d36e60346c3ae5929c9e65d89932b311a7b2ce220b2645c97b4fb933088b276dL41-L46)

**Styling and layout adjustments:**

* Added a `viewer--fill` CSS class to ensure the viewer fills available space when displaying the raw editor, and applied this class conditionally. [[1]](diffhunk://#diff-d36e60346c3ae5929c9e65d89932b311a7b2ce220b2645c97b4fb933088b276dL18-R18) [[2]](diffhunk://#diff-d36e60346c3ae5929c9e65d89932b311a7b2ce220b2645c97b4fb933088b276dR396-R400)
* Modified the `.viewer` class to use `min-height: 100%` instead of `height: 100%` and removed the `.viewer__body` class to streamline and fix layout issues. [[1]](diffhunk://#diff-d36e60346c3ae5929c9e65d89932b311a7b2ce220b2645c97b4fb933088b276dL371-R372) [[2]](diffhunk://#diff-d36e60346c3ae5929c9e65d89932b311a7b2ce220b2645c97b4fb933088b276dL384-L389)