### PR TITLE
feat(queue): add Postgres LISTEN/NOTIFY realtime wake-up for the JDBC queue

### DIFF
--- a/jdbc-postgres/build.gradle
+++ b/jdbc-postgres/build.gradle
@@ -12,7 +12,12 @@ dependencies {
     implementation project(":queue-jdbc")
 
     implementation("io.micronaut.sql:micronaut-jooq")
-    runtimeOnly("org.postgresql:postgresql")
+    // PgQueueListener needs Micronaut's DatasourceConfiguration (Hikari) to read the JDBC
+    // URL/credentials for its own dedicated (non-pooled) LISTEN connection.
+    implementation("io.micronaut.sql:micronaut-jdbc-hikari")
+    // implementation (not runtimeOnly): PgQueueListener needs org.postgresql.PGConnection/PGNotification
+    // at compile time to LISTEN/NOTIFY for the realtime queue wake-up.
+    implementation("org.postgresql:postgresql")
 
     testAnnotationProcessor project(":processor")
     testImplementation project(path: ':core', configuration: 'testArtifacts')

--- a/jdbc-postgres/src/main/java/io/kestra/repository/postgres/PgQueueChannels.java
+++ b/jdbc-postgres/src/main/java/io/kestra/repository/postgres/PgQueueChannels.java
@@ -1,0 +1,18 @@
+package io.kestra.repository.postgres;
+
+/**
+ * Shared Postgres {@code NOTIFY} channel naming for the JDBC queue's realtime wake-up mechanism.
+ * One channel per queue (not a single shared channel): Kestra's server roles subscribe to
+ * disjoint queue sets, so a dedicated channel per queue lets Postgres filter {@code LISTEN}
+ * delivery server-side — a process only receives notifications for queues it actually consumes.
+ */
+final class PgQueueChannels {
+    private static final String PREFIX = "kestra_queue_";
+
+    private PgQueueChannels() {
+    }
+
+    static String channelFor(String queueName) {
+        return PREFIX + queueName;
+    }
+}

--- a/jdbc-postgres/src/main/java/io/kestra/repository/postgres/PgQueueListener.java
+++ b/jdbc-postgres/src/main/java/io/kestra/repository/postgres/PgQueueListener.java
@@ -1,0 +1,170 @@
+package io.kestra.repository.postgres;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.time.Duration;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.ExecutorService;
+
+import org.postgresql.PGConnection;
+import org.postgresql.PGNotification;
+
+import io.kestra.core.utils.ExecutorsUtils;
+
+import io.micronaut.configuration.jdbc.hikari.DatasourceConfiguration;
+import io.micronaut.context.annotation.Context;
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Maintains a single dedicated Postgres connection — outside the Hikari pool, since it must hold
+ * a {@code LISTEN} registration for the process lifetime — that {@code LISTEN}s on the channels
+ * {@link PgQueueSignalRegistry} has active waiters for, and forwards every {@code NOTIFY} to the
+ * registry so the matching subscriber's poll loop wakes early.
+ * <p>
+ * This is a pure latency optimization layered on top of the existing poll + transactional ack
+ * path: if this connection is down, reconnecting, or has not yet caught up on a newly-registered
+ * channel, subscribers simply fall back to their regular poll backoff — no message is ever lost
+ * because of it. On every (re)connect, every waiter is force-woken via {@link PgQueueSignalRegistry#signalAll()}
+ * so a notification missed while disconnected still results in an immediate catch-up poll instead
+ * of waiting out the full backoff.
+ */
+@Slf4j
+@Singleton
+@Context
+@PostgresQueueEnabled
+public class PgQueueListener implements AutoCloseable {
+    // Also the upper bound on how long a newly-registered channel (a subscriber that just
+    // started) waits before the listener's next LISTEN sync notices it — kept short since
+    // it's a cheap local socket check, not a DB round-trip.
+    private static final int NOTIFICATION_POLL_TIMEOUT_MS = 200;
+    private static final long INITIAL_RECONNECT_BACKOFF_MS = 1000;
+    private static final long MAX_RECONNECT_BACKOFF_MS = 30_000;
+
+    private final DatasourceConfiguration datasourceConfiguration;
+    private final PgQueueSignalRegistry registry;
+    private final ExecutorService executorService;
+
+    private volatile boolean running = true;
+    private volatile Connection connection;
+
+    @Inject
+    public PgQueueListener(DatasourceConfiguration datasourceConfiguration, PgQueueSignalRegistry registry, ExecutorsUtils executorsUtils) {
+        this.datasourceConfiguration = datasourceConfiguration;
+        this.registry = registry;
+        this.executorService = executorsUtils.singleThreadExecutor("pg-queue-listen");
+    }
+
+    @PostConstruct
+    void start() {
+        executorService.execute(this::run);
+    }
+
+    private void run() {
+        long backoff = INITIAL_RECONNECT_BACKOFF_MS;
+
+        while (running) {
+            try {
+                connect();
+                // close() may have run concurrently while connect() was in flight (running flips to
+                // false, but there was nothing open yet for closeConnectionQuietly() to close): bail
+                // out and close the connection we just opened instead of leaking it for the rest of
+                // the JVM's life.
+                if (!running) {
+                    closeConnectionQuietly();
+                    break;
+                }
+                // A fresh connection has no prior LISTEN state and may have missed notifications
+                // while we were disconnected: force every subscriber to catch up via a regular poll.
+                registry.signalAll();
+                backoff = INITIAL_RECONNECT_BACKOFF_MS;
+
+                listenLoop();
+            } catch (Exception e) {
+                if (!running) {
+                    break;
+                }
+                log.warn("Postgres queue LISTEN connection lost, reconnecting in {}ms", backoff, e);
+                closeConnectionQuietly();
+                sleepQuietly(backoff);
+                backoff = Math.min(backoff * 2, MAX_RECONNECT_BACKOFF_MS);
+            }
+        }
+    }
+
+    private void listenLoop() throws SQLException {
+        Set<String> listenedChannels = new HashSet<>();
+        PGConnection pgConnection = (PGConnection) connection;
+
+        while (running) {
+            syncListenedChannels(listenedChannels);
+
+            PGNotification[] notifications = pgConnection.getNotifications(NOTIFICATION_POLL_TIMEOUT_MS);
+            if (notifications != null) {
+                for (PGNotification notification : notifications) {
+                    registry.signal(notification.getName(), notification.getParameter());
+                }
+            }
+        }
+    }
+
+    private void connect() throws SQLException {
+        connection = DriverManager.getConnection(
+            datasourceConfiguration.getJdbcUrl(),
+            datasourceConfiguration.getUsername(),
+            datasourceConfiguration.getPassword()
+        );
+    }
+
+    /**
+     * Issues {@code LISTEN} for any channel the registry has gained since the last check. Channels
+     * are only ever added (queue subscriptions live for the process lifetime), and {@code LISTEN}
+     * is otherwise idempotent, so tracking what we already listen to just avoids redundant
+     * round-trips rather than being required for correctness.
+     */
+    private void syncListenedChannels(Set<String> listenedChannels) throws SQLException {
+        for (String channel : registry.channels()) {
+            if (listenedChannels.add(channel)) {
+                try (Statement statement = connection.createStatement()) {
+                    // Channel names are always internally generated ("kestra_queue_" + queueName,
+                    // where queueName comes from our own fixed set of message class names), never
+                    // from user input; double-quoted here purely for identifier safety.
+                    statement.execute("LISTEN \"" + channel + "\"");
+                }
+            }
+        }
+    }
+
+    @PreDestroy
+    @Override
+    public void close() {
+        running = false;
+        closeConnectionQuietly();
+        ExecutorsUtils.closeExecutorService("pg-queue-listen", executorService, Duration.ofSeconds(5));
+    }
+
+    private void closeConnectionQuietly() {
+        Connection c = connection;
+        if (c != null) {
+            try {
+                c.close();
+            } catch (SQLException e) {
+                log.debug("Failed to close Postgres queue LISTEN connection", e);
+            }
+        }
+    }
+
+    private static void sleepQuietly(long millis) {
+        try {
+            Thread.sleep(millis);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+    }
+}

--- a/jdbc-postgres/src/main/java/io/kestra/repository/postgres/PgQueueListener.java
+++ b/jdbc-postgres/src/main/java/io/kestra/repository/postgres/PgQueueListener.java
@@ -108,7 +108,7 @@ public class PgQueueListener implements AutoCloseable {
             PGNotification[] notifications = pgConnection.getNotifications(NOTIFICATION_POLL_TIMEOUT_MS);
             if (notifications != null) {
                 for (PGNotification notification : notifications) {
-                    registry.signal(notification.getName(), notification.getParameter());
+                    registry.signal(notification.getName());
                 }
             }
         }

--- a/jdbc-postgres/src/main/java/io/kestra/repository/postgres/PgQueueSignalRegistry.java
+++ b/jdbc-postgres/src/main/java/io/kestra/repository/postgres/PgQueueSignalRegistry.java
@@ -1,6 +1,5 @@
 package io.kestra.repository.postgres;
 
-import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
@@ -13,18 +12,18 @@ import io.kestra.queue.poller.QueueWaker;
 import jakarta.inject.Singleton;
 
 /**
- * Registers a {@link QueueWaker} per Postgres subscriber and wakes the matching ones when
- * {@link PgQueueListener} receives a {@code NOTIFY}.
+ * Registers a {@link QueueWaker} per Postgres subscriber and wakes every waiter registered on a
+ * channel when {@link PgQueueListener} receives a {@code NOTIFY} for it.
  * <p>
  * For the common case (one subscriber per queue type, living for the process lifetime), the
  * registry's size is bounded by the number of active subscriptions, not by traffic — waiters are
  * never removed. VNode dispatch subscribers that get re-created on a vnode rebalance are the one
  * exception: their old waiter is abandoned rather than removed. This is a bounded, low-severity
- * limitation (a tiny Semaphore + Set per rebalance) that does not affect correctness — see below.
+ * limitation (a tiny Semaphore per rebalance) that does not affect correctness — see below.
  * <p>
  * Waking is a pure latency optimization: correctness never depends on it. A subscriber whose
- * notification was missed (channel not yet listened to, listener reconnecting, routing-key filter
- * momentarily stale after a VNode rebalance) still gets its message from the regular poll backoff.
+ * notification was missed (channel not yet listened to, listener reconnecting) still gets its
+ * message from the regular poll backoff.
  */
 @Singleton
 @PostgresQueueEnabled
@@ -32,9 +31,9 @@ public class PgQueueSignalRegistry implements QueueWakeRegistry {
     private final ConcurrentHashMap<String, CopyOnWriteArrayList<Waiter>> waitersByChannel = new ConcurrentHashMap<>();
 
     @Override
-    public QueueWaker waker(String queueName, List<String> routingKeys) {
+    public QueueWaker waker(String queueName) {
         String channel = PgQueueChannels.channelFor(queueName);
-        Waiter waiter = new Waiter(Set.copyOf(routingKeys));
+        Waiter waiter = new Waiter();
 
         waitersByChannel.computeIfAbsent(channel, ignored -> new CopyOnWriteArrayList<>()).add(waiter);
 
@@ -46,28 +45,24 @@ public class PgQueueSignalRegistry implements QueueWakeRegistry {
     }
 
     /**
-     * Wakes every waiter registered on {@code channel} whose owned routing keys match
-     * {@code routingKey} (or every waiter, if {@code routingKey} is empty — plain dispatch and
-     * broadcast publishes carry no routing key).
+     * Wakes every waiter registered on {@code channel}. Notifications no longer carry a
+     * routing-key filter (see {@link PostgresQueueChangeNotifier}): every subscriber on the queue
+     * still filters its own poll query for the rows it owns, so waking them all is correct — just
+     * potentially one extra no-op poll for a subscriber whose partition wasn't the one that changed.
      */
-    void signal(String channel, String routingKey) {
+    void signal(String channel) {
         CopyOnWriteArrayList<Waiter> waiters = waitersByChannel.get(channel);
         if (waiters == null) {
             return;
         }
 
-        boolean wakeAll = routingKey == null || routingKey.isEmpty();
-        for (Waiter waiter : waiters) {
-            if (wakeAll || waiter.routingKeys.isEmpty() || waiter.routingKeys.contains(routingKey)) {
-                waiter.release();
-            }
-        }
+        waiters.forEach(Waiter::release);
     }
 
     /**
-     * Force-wakes every waiter across every channel, bypassing the routing-key filter. Called on
-     * every (re)connect of {@link PgQueueListener} so no message published while disconnected is
-     * left waiting out its full poll backoff.
+     * Force-wakes every waiter across every channel. Called on every (re)connect of
+     * {@link PgQueueListener} so no message published while disconnected is left waiting out its
+     * full poll backoff.
      */
     void signalAll() {
         waitersByChannel.values().forEach(waiters -> waiters.forEach(Waiter::release));
@@ -82,12 +77,7 @@ public class PgQueueSignalRegistry implements QueueWakeRegistry {
     }
 
     private static final class Waiter {
-        private final Set<String> routingKeys;
         private final Semaphore semaphore = new Semaphore(0);
-
-        private Waiter(Set<String> routingKeys) {
-            this.routingKeys = routingKeys;
-        }
 
         private void release() {
             // Coalescing: don't stack permits beyond 1, a subscriber only needs "something changed".

--- a/jdbc-postgres/src/main/java/io/kestra/repository/postgres/PgQueueSignalRegistry.java
+++ b/jdbc-postgres/src/main/java/io/kestra/repository/postgres/PgQueueSignalRegistry.java
@@ -1,0 +1,99 @@
+package io.kestra.repository.postgres;
+
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.TimeUnit;
+
+import io.kestra.queue.jdbc.client.QueueWakeRegistry;
+import io.kestra.queue.poller.QueueWaker;
+
+import jakarta.inject.Singleton;
+
+/**
+ * Registers a {@link QueueWaker} per Postgres subscriber and wakes the matching ones when
+ * {@link PgQueueListener} receives a {@code NOTIFY}.
+ * <p>
+ * For the common case (one subscriber per queue type, living for the process lifetime), the
+ * registry's size is bounded by the number of active subscriptions, not by traffic — waiters are
+ * never removed. VNode dispatch subscribers that get re-created on a vnode rebalance are the one
+ * exception: their old waiter is abandoned rather than removed. This is a bounded, low-severity
+ * limitation (a tiny Semaphore + Set per rebalance) that does not affect correctness — see below.
+ * <p>
+ * Waking is a pure latency optimization: correctness never depends on it. A subscriber whose
+ * notification was missed (channel not yet listened to, listener reconnecting, routing-key filter
+ * momentarily stale after a VNode rebalance) still gets its message from the regular poll backoff.
+ */
+@Singleton
+@PostgresQueueEnabled
+public class PgQueueSignalRegistry implements QueueWakeRegistry {
+    private final ConcurrentHashMap<String, CopyOnWriteArrayList<Waiter>> waitersByChannel = new ConcurrentHashMap<>();
+
+    @Override
+    public QueueWaker waker(String queueName, List<String> routingKeys) {
+        String channel = PgQueueChannels.channelFor(queueName);
+        Waiter waiter = new Waiter(Set.copyOf(routingKeys));
+
+        waitersByChannel.computeIfAbsent(channel, ignored -> new CopyOnWriteArrayList<>()).add(waiter);
+
+        return max ->
+        {
+            // Best-effort wait: a timeout here just means "nothing woke us, fall back to the poll".
+            waiter.semaphore.tryAcquire(max.toMillis(), TimeUnit.MILLISECONDS);
+        };
+    }
+
+    /**
+     * Wakes every waiter registered on {@code channel} whose owned routing keys match
+     * {@code routingKey} (or every waiter, if {@code routingKey} is empty — plain dispatch and
+     * broadcast publishes carry no routing key).
+     */
+    void signal(String channel, String routingKey) {
+        CopyOnWriteArrayList<Waiter> waiters = waitersByChannel.get(channel);
+        if (waiters == null) {
+            return;
+        }
+
+        boolean wakeAll = routingKey == null || routingKey.isEmpty();
+        for (Waiter waiter : waiters) {
+            if (wakeAll || waiter.routingKeys.isEmpty() || waiter.routingKeys.contains(routingKey)) {
+                waiter.release();
+            }
+        }
+    }
+
+    /**
+     * Force-wakes every waiter across every channel, bypassing the routing-key filter. Called on
+     * every (re)connect of {@link PgQueueListener} so no message published while disconnected is
+     * left waiting out its full poll backoff.
+     */
+    void signalAll() {
+        waitersByChannel.values().forEach(waiters -> waiters.forEach(Waiter::release));
+    }
+
+    /**
+     * Snapshot of the channels with at least one registered waiter — the set {@link PgQueueListener}
+     * must be {@code LISTEN}ing on.
+     */
+    Set<String> channels() {
+        return Set.copyOf(waitersByChannel.keySet());
+    }
+
+    private static final class Waiter {
+        private final Set<String> routingKeys;
+        private final Semaphore semaphore = new Semaphore(0);
+
+        private Waiter(Set<String> routingKeys) {
+            this.routingKeys = routingKeys;
+        }
+
+        private void release() {
+            // Coalescing: don't stack permits beyond 1, a subscriber only needs "something changed".
+            if (semaphore.availablePermits() == 0) {
+                semaphore.release();
+            }
+        }
+    }
+}

--- a/jdbc-postgres/src/main/java/io/kestra/repository/postgres/PostgresQueueChangeNotifier.java
+++ b/jdbc-postgres/src/main/java/io/kestra/repository/postgres/PostgresQueueChangeNotifier.java
@@ -1,36 +1,183 @@
 package io.kestra.repository.postgres;
 
 import java.sql.Connection;
+import java.sql.DriverManager;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
+import java.time.Duration;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
 
-import org.jooq.Configuration;
-import org.jooq.exception.DataAccessException;
-
+import io.kestra.core.utils.ExecutorsUtils;
+import io.kestra.core.utils.ThreadMainFactoryBuilder;
 import io.kestra.queue.jdbc.client.QueueChangeNotifier;
 
-import jakarta.annotation.Nullable;
+import io.micronaut.configuration.jdbc.hikari.DatasourceConfiguration;
+import io.micronaut.context.annotation.Context;
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
+import lombok.extern.slf4j.Slf4j;
 
 /**
- * Emits a Postgres {@code NOTIFY} on the channel for the published queue, using the same
- * connection/transaction as the INSERT (see {@link QueueChangeNotifier}), so Postgres only
- * delivers it to listeners once the message is durably committed.
+ * Emits a Postgres {@code NOTIFY} on the channel for a published queue, after the publish
+ * transaction has committed, using a single dedicated connection outside the Hikari pool (mirroring
+ * {@link PgQueueListener}) — never the transaction's own connection. Emitting on the commit path
+ * would serialize every publish through Postgres's global NOTIFY-delivery lock, which is the
+ * mechanism that collapsed throughput under load in earlier benchmarking; keeping NOTIFY off that
+ * path removes the bottleneck entirely.
+ * <p>
+ * Emission is also coalesced per channel: a burst of publishes to the same queue collapses into at
+ * most one {@code NOTIFY} per {@link PostgresQueueNotifyConfiguration#coalesceInterval()} (leading
+ * edge immediate, then rate-limited), so a busy queue can't wake its subscriber on every single
+ * message — the fix for the second half of the same regression, where the wake-up storm amplified
+ * poll-query traffic against the {@code queues} table. This is still a pure latency optimization:
+ * a coalesced-away or otherwise lost signal never loses a message, since durable delivery is
+ * guaranteed by the poll + transactional ack path regardless.
  */
+@Slf4j
 @Singleton
+@Context
 @PostgresQueueEnabled
-public class PostgresQueueChangeNotifier implements QueueChangeNotifier {
+public class PostgresQueueChangeNotifier implements QueueChangeNotifier, AutoCloseable {
+    private static final long INITIAL_RECONNECT_BACKOFF_MS = 1000;
+    private static final long MAX_RECONNECT_BACKOFF_MS = 30_000;
+
+    private final DatasourceConfiguration datasourceConfiguration;
+    private final PostgresQueueNotifyConfiguration configuration;
+    private final ScheduledExecutorService executorService;
+
+    /**
+     * Channels with an emit already scheduled (immediate or delayed) but not yet sent: guards
+     * against scheduling more than one pending emit per channel within a coalescing window.
+     */
+    private final Set<String> pendingChannels = ConcurrentHashMap.newKeySet();
+
+    /**
+     * Last time (in {@link System#nanoTime()} units) a NOTIFY was actually sent for a channel, used
+     * to compute how long the next emit for that channel must still wait to respect
+     * {@link PostgresQueueNotifyConfiguration#coalesceInterval()}.
+     */
+    private final ConcurrentHashMap<String, Long> lastEmitNanos = new ConcurrentHashMap<>();
+
+    private volatile boolean running = true;
+    private volatile Connection connection;
+    private volatile long reconnectBackoffMs = INITIAL_RECONNECT_BACKOFF_MS;
+
+    @Inject
+    public PostgresQueueChangeNotifier(DatasourceConfiguration datasourceConfiguration, PostgresQueueNotifyConfiguration configuration) {
+        this.datasourceConfiguration = datasourceConfiguration;
+        this.configuration = configuration;
+        // Single thread: every NOTIFY (immediate or coalesced) and every (re)connect attempt runs
+        // here, so the dedicated connection is never touched from more than one thread at a time.
+        this.executorService = Executors.newSingleThreadScheduledExecutor(ThreadMainFactoryBuilder.build("pg-queue-notify_%d"));
+    }
+
+    @PostConstruct
+    void start() {
+        if (configuration.enabled()) {
+            executorService.execute(this::connect);
+        }
+    }
+
     @Override
-    public void notifyChange(Configuration configuration, String queueName, @Nullable String routingKey) {
-        Connection connection = configuration.connectionProvider().acquire();
-        try (PreparedStatement statement = connection.prepareStatement("SELECT pg_notify(?, ?)")) {
-            statement.setString(1, PgQueueChannels.channelFor(queueName));
-            statement.setString(2, routingKey == null ? "" : routingKey);
+    public void notifyChange(String queueName) {
+        if (!configuration.enabled()) {
+            return;
+        }
+
+        String channel = PgQueueChannels.channelFor(queueName);
+        if (!pendingChannels.add(channel)) {
+            // An emit for this channel is already scheduled within the current coalescing window.
+            return;
+        }
+
+        Long lastEmit = lastEmitNanos.get(channel);
+        long sinceLastEmitMs = lastEmit == null ? Long.MAX_VALUE : Duration.ofNanos(System.nanoTime() - lastEmit).toMillis();
+        long delayMs = Math.max(0, configuration.coalesceInterval().toMillis() - sinceLastEmitMs);
+
+        try {
+            executorService.schedule(() -> emit(channel), delayMs, TimeUnit.MILLISECONDS);
+        } catch (RuntimeException e) {
+            // The executor may already be shutting down (app stop racing a publish). This is a pure
+            // latency optimization: never let a scheduling failure surface as a publish failure to
+            // the caller, and don't leave the channel stuck "pending" since emit() will never run to
+            // clear it.
+            pendingChannels.remove(channel);
+            log.debug("Unable to schedule a Postgres NOTIFY for [{}], subscribers fall back to the poll", channel, e);
+        }
+    }
+
+    private void emit(String channel) {
+        pendingChannels.remove(channel);
+        lastEmitNanos.put(channel, System.nanoTime());
+
+        Connection c = connection;
+        if (c == null) {
+            log.debug("Skipping Postgres NOTIFY on [{}]: no active LISTEN/NOTIFY connection, subscribers fall back to the poll", channel);
+            return;
+        }
+
+        try (PreparedStatement statement = c.prepareStatement("SELECT pg_notify(?, '')")) {
+            statement.setString(1, channel);
             statement.execute();
         } catch (SQLException e) {
-            throw new DataAccessException("Unable to notify the Postgres queue channel for [" + queueName + "]", e);
-        } finally {
-            configuration.connectionProvider().release(connection);
+            log.warn("Failed to emit Postgres NOTIFY on [{}], reconnecting", channel, e);
+            closeConnectionQuietly();
+            connection = null;
+            executorService.execute(this::connect);
+        }
+    }
+
+    private void connect() {
+        if (!running) {
+            return;
+        }
+
+        try {
+            connection = DriverManager.getConnection(
+                datasourceConfiguration.getJdbcUrl(),
+                datasourceConfiguration.getUsername(),
+                datasourceConfiguration.getPassword()
+            );
+
+            if (!running) {
+                // close() ran concurrently while this connection was being established: don't leak it.
+                closeConnectionQuietly();
+                connection = null;
+                return;
+            }
+
+            reconnectBackoffMs = INITIAL_RECONNECT_BACKOFF_MS;
+        } catch (SQLException e) {
+            log.warn("Postgres queue NOTIFY connection failed, retrying in {}ms", reconnectBackoffMs, e);
+            if (running) {
+                executorService.schedule(this::connect, reconnectBackoffMs, TimeUnit.MILLISECONDS);
+                reconnectBackoffMs = Math.min(reconnectBackoffMs * 2, MAX_RECONNECT_BACKOFF_MS);
+            }
+        }
+    }
+
+    @PreDestroy
+    @Override
+    public void close() {
+        running = false;
+        closeConnectionQuietly();
+        ExecutorsUtils.closeExecutorService("pg-queue-notify", executorService, Duration.ofSeconds(5));
+    }
+
+    private void closeConnectionQuietly() {
+        Connection c = connection;
+        if (c != null) {
+            try {
+                c.close();
+            } catch (SQLException e) {
+                log.debug("Failed to close Postgres queue NOTIFY connection", e);
+            }
         }
     }
 }

--- a/jdbc-postgres/src/main/java/io/kestra/repository/postgres/PostgresQueueChangeNotifier.java
+++ b/jdbc-postgres/src/main/java/io/kestra/repository/postgres/PostgresQueueChangeNotifier.java
@@ -1,0 +1,36 @@
+package io.kestra.repository.postgres;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+
+import org.jooq.Configuration;
+import org.jooq.exception.DataAccessException;
+
+import io.kestra.queue.jdbc.client.QueueChangeNotifier;
+
+import jakarta.annotation.Nullable;
+import jakarta.inject.Singleton;
+
+/**
+ * Emits a Postgres {@code NOTIFY} on the channel for the published queue, using the same
+ * connection/transaction as the INSERT (see {@link QueueChangeNotifier}), so Postgres only
+ * delivers it to listeners once the message is durably committed.
+ */
+@Singleton
+@PostgresQueueEnabled
+public class PostgresQueueChangeNotifier implements QueueChangeNotifier {
+    @Override
+    public void notifyChange(Configuration configuration, String queueName, @Nullable String routingKey) {
+        Connection connection = configuration.connectionProvider().acquire();
+        try (PreparedStatement statement = connection.prepareStatement("SELECT pg_notify(?, ?)")) {
+            statement.setString(1, PgQueueChannels.channelFor(queueName));
+            statement.setString(2, routingKey == null ? "" : routingKey);
+            statement.execute();
+        } catch (SQLException e) {
+            throw new DataAccessException("Unable to notify the Postgres queue channel for [" + queueName + "]", e);
+        } finally {
+            configuration.connectionProvider().release(connection);
+        }
+    }
+}

--- a/jdbc-postgres/src/main/java/io/kestra/repository/postgres/PostgresQueueChangeNotifier.java
+++ b/jdbc-postgres/src/main/java/io/kestra/repository/postgres/PostgresQueueChangeNotifier.java
@@ -13,6 +13,7 @@ import java.util.concurrent.TimeUnit;
 
 import io.kestra.core.utils.ExecutorsUtils;
 import io.kestra.core.utils.ThreadMainFactoryBuilder;
+import io.kestra.jdbc.runner.JdbcQueueConfiguration;
 import io.kestra.queue.jdbc.client.QueueChangeNotifier;
 
 import io.micronaut.configuration.jdbc.hikari.DatasourceConfiguration;
@@ -35,9 +36,19 @@ import lombok.extern.slf4j.Slf4j;
  * most one {@code NOTIFY} per {@link PostgresQueueNotifyConfiguration#coalesceInterval()} (leading
  * edge immediate, then rate-limited), so a busy queue can't wake its subscriber on every single
  * message — the fix for the second half of the same regression, where the wake-up storm amplified
- * poll-query traffic against the {@code queues} table. This is still a pure latency optimization:
- * a coalesced-away or otherwise lost signal never loses a message, since durable delivery is
- * guaranteed by the poll + transactional ack path regardless.
+ * poll-query traffic against the {@code queues} table.
+ * <p>
+ * The effective coalescing interval is additionally floored at the subscriber's own
+ * {@link JdbcQueueConfiguration#minPollInterval()}: a subscriber's poll loop already re-polls at
+ * that cadence on its own once it has just been active (see {@code QueuePoller}'s empty-poll
+ * backoff), so a NOTIFY tighter than that floor cannot buy any extra latency in the "briefly idle
+ * under sustained load" case — it can only push a hot subscriber to poll (and pay a full
+ * transaction) more often than plain polling ever would. The floor never affects the "genuinely
+ * idle, then a message arrives" case, where the leading-edge immediate emit still fires at once,
+ * cutting the escalated backoff (up to {@code maxPollInterval}) down to the floor.
+ * <p>
+ * This is still a pure latency optimization: a coalesced-away or otherwise lost signal never loses
+ * a message, since durable delivery is guaranteed by the poll + transactional ack path regardless.
  */
 @Slf4j
 @Singleton
@@ -50,6 +61,12 @@ public class PostgresQueueChangeNotifier implements QueueChangeNotifier, AutoClo
     private final DatasourceConfiguration datasourceConfiguration;
     private final PostgresQueueNotifyConfiguration configuration;
     private final ScheduledExecutorService executorService;
+
+    /**
+     * {@code max(coalesceInterval, minPollInterval)}, computed once since both inputs are static
+     * configuration — see the class javadoc for why NOTIFY must never undercut the poll floor.
+     */
+    private final long minEmitIntervalMs;
 
     /**
      * Channels with an emit already scheduled (immediate or delayed) but not yet sent: guards
@@ -69,9 +86,10 @@ public class PostgresQueueChangeNotifier implements QueueChangeNotifier, AutoClo
     private volatile long reconnectBackoffMs = INITIAL_RECONNECT_BACKOFF_MS;
 
     @Inject
-    public PostgresQueueChangeNotifier(DatasourceConfiguration datasourceConfiguration, PostgresQueueNotifyConfiguration configuration) {
+    public PostgresQueueChangeNotifier(DatasourceConfiguration datasourceConfiguration, PostgresQueueNotifyConfiguration configuration, JdbcQueueConfiguration jdbcQueueConfiguration) {
         this.datasourceConfiguration = datasourceConfiguration;
         this.configuration = configuration;
+        this.minEmitIntervalMs = Math.max(configuration.coalesceInterval().toMillis(), jdbcQueueConfiguration.minPollInterval().toMillis());
         // Single thread: every NOTIFY (immediate or coalesced) and every (re)connect attempt runs
         // here, so the dedicated connection is never touched from more than one thread at a time.
         this.executorService = Executors.newSingleThreadScheduledExecutor(ThreadMainFactoryBuilder.build("pg-queue-notify_%d"));
@@ -98,7 +116,7 @@ public class PostgresQueueChangeNotifier implements QueueChangeNotifier, AutoClo
 
         Long lastEmit = lastEmitNanos.get(channel);
         long sinceLastEmitMs = lastEmit == null ? Long.MAX_VALUE : Duration.ofNanos(System.nanoTime() - lastEmit).toMillis();
-        long delayMs = Math.max(0, configuration.coalesceInterval().toMillis() - sinceLastEmitMs);
+        long delayMs = Math.max(0, minEmitIntervalMs - sinceLastEmitMs);
 
         try {
             executorService.schedule(() -> emit(channel), delayMs, TimeUnit.MILLISECONDS);

--- a/jdbc-postgres/src/main/java/io/kestra/repository/postgres/PostgresQueueNotifyConfiguration.java
+++ b/jdbc-postgres/src/main/java/io/kestra/repository/postgres/PostgresQueueNotifyConfiguration.java
@@ -13,5 +13,8 @@ import io.micronaut.core.bind.annotation.Bindable;
 @ConfigurationProperties("kestra.queue.postgres.notify")
 public record PostgresQueueNotifyConfiguration(
     @Bindable(defaultValue = "true") Boolean enabled,
-    @Bindable(defaultValue = "PT0.01S") Duration coalesceInterval) {
+    // Matches kestra.jdbc.queues.min-poll-interval's own default: PostgresQueueChangeNotifier
+    // floors the effective coalescing interval at that value regardless of what's configured
+    // here, so this default just documents the resulting floor rather than being load-bearing.
+    @Bindable(defaultValue = "PT0.025S") Duration coalesceInterval) {
 }

--- a/jdbc-postgres/src/main/java/io/kestra/repository/postgres/PostgresQueueNotifyConfiguration.java
+++ b/jdbc-postgres/src/main/java/io/kestra/repository/postgres/PostgresQueueNotifyConfiguration.java
@@ -1,0 +1,17 @@
+package io.kestra.repository.postgres;
+
+import java.time.Duration;
+
+import io.micronaut.context.annotation.ConfigurationProperties;
+import io.micronaut.core.bind.annotation.Bindable;
+
+/**
+ * Configuration for the Postgres {@code LISTEN}/{@code NOTIFY} realtime wake-up mechanism (see
+ * {@link PostgresQueueChangeNotifier}). Purely a latency optimization: the durable poll + ack
+ * path delivering messages is unchanged and unaffected by these settings.
+ */
+@ConfigurationProperties("kestra.queue.postgres.notify")
+public record PostgresQueueNotifyConfiguration(
+    @Bindable(defaultValue = "true") Boolean enabled,
+    @Bindable(defaultValue = "PT0.01S") Duration coalesceInterval) {
+}

--- a/jdbc-postgres/src/test/java/io/kestra/queue/postgres/PostgresQueueNotifyFallbackTest.java
+++ b/jdbc-postgres/src/test/java/io/kestra/queue/postgres/PostgresQueueNotifyFallbackTest.java
@@ -1,0 +1,72 @@
+package io.kestra.queue.postgres;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+
+import io.kestra.core.junit.annotations.KestraTest;
+import io.kestra.core.queues.DispatchQueueInterface;
+import io.kestra.core.queues.QueueSubscriber;
+import io.kestra.core.utils.IdUtils;
+import io.kestra.jdbc.JdbcTestUtils;
+import io.kestra.queue.AbstractDispatchQueueTest;
+import io.kestra.repository.postgres.PgQueueListener;
+
+import io.micronaut.context.annotation.Property;
+import jakarta.inject.Inject;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Proves the realtime wake-up is a pure latency optimization, never the delivery mechanism: with
+ * {@link PgQueueListener} stopped (simulating "no active LISTEN connection" — a missed notify, or
+ * the listener reconnecting), a published message is still delivered via the regular poll.
+ * <p>
+ * Uses its own {@code rebuildContext = true} instance (and its own test class, rather than a
+ * second method sharing a class with other tests) so permanently stopping the singleton
+ * {@link PgQueueListener} here cannot affect any other test.
+ */
+@KestraTest(environments = { "test", "queue" }, rebuildContext = true)
+@Property(name = "kestra.queue.type", value = "postgres") // the "queue" env sets this to "h2" (still matches @JdbcQueueEnabled generically), which would disable the @PostgresQueueEnabled beans under test
+@Execution(ExecutionMode.SAME_THREAD)
+class PostgresQueueNotifyFallbackTest {
+    @Inject
+    private DispatchQueueInterface<AbstractDispatchQueueTest.TestDispatch> dispatchQueue;
+
+    @Inject
+    private JdbcTestUtils jdbcTestUtils;
+
+    @Inject
+    private PgQueueListener pgQueueListener;
+
+    @BeforeEach
+    void init() {
+        jdbcTestUtils.drop();
+        jdbcTestUtils.migrate();
+    }
+
+    @Test
+    void shouldStillDeliverWhenTheListenerIsDown() throws Exception {
+        // Simulate the LISTEN connection being unavailable: no NOTIFY will ever reach a subscriber.
+        pgQueueListener.close();
+
+        CountDownLatch received = new CountDownLatch(1);
+        QueueSubscriber<AbstractDispatchQueueTest.TestDispatch> subscriber = dispatchQueue
+            .subscriber()
+            .subscribe(either -> received.countDown());
+
+        try {
+            dispatchQueue.emit(new AbstractDispatchQueueTest.TestDispatch(IdUtils.create(), 1));
+
+            // application-test.yml keeps the default poll interval fast (10ms/100ms), so the
+            // regular poll alone should deliver comfortably within a few seconds.
+            assertThat(received.await(5, TimeUnit.SECONDS)).as("message should still be delivered by the fallback poll").isTrue();
+        } finally {
+            subscriber.close();
+        }
+    }
+}

--- a/jdbc-postgres/src/test/java/io/kestra/queue/postgres/PostgresQueueNotifyLatencyTest.java
+++ b/jdbc-postgres/src/test/java/io/kestra/queue/postgres/PostgresQueueNotifyLatencyTest.java
@@ -1,0 +1,79 @@
+package io.kestra.queue.postgres;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+
+import io.kestra.core.junit.annotations.KestraTest;
+import io.kestra.core.queues.DispatchQueueInterface;
+import io.kestra.core.queues.QueueSubscriber;
+import io.kestra.core.utils.IdUtils;
+import io.kestra.jdbc.JdbcTestUtils;
+import io.kestra.queue.AbstractDispatchQueueTest;
+
+import io.micronaut.context.annotation.Property;
+import jakarta.inject.Inject;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Proves the Postgres LISTEN/NOTIFY wake-up actually cuts delivery latency, end to end
+ * (publish -&gt; pg_notify -&gt; {@link PgQueueListener} -&gt; {@link PgQueueSignalRegistry} -&gt;
+ * subscriber poll loop woken early), rather than exercising only the in-JVM registry logic.
+ * <p>
+ * The poll backoff is deliberately set far above what a test should ever wait on a plain poll
+ * (min 2s / max 5s): the test publishes only after sleeping past the point where the subscriber
+ * would have already gone to sleep for its first backoff, then asserts delivery well under that
+ * backoff. If the message could only be delivered here, it proves the NOTIFY path woke the
+ * subscriber early rather than the fallback poll happening to catch it.
+ */
+@KestraTest(environments = { "test", "queue" }, rebuildContext = true)
+@Property(name = "kestra.queue.type", value = "postgres") // the "queue" env sets this to "h2" (still matches @JdbcQueueEnabled generically), which would disable the @PostgresQueueEnabled beans under test
+@Property(name = "kestra.jdbc.queues.min-poll-interval", value = "2s")
+@Property(name = "kestra.jdbc.queues.max-poll-interval", value = "5s")
+@Execution(ExecutionMode.SAME_THREAD)
+class PostgresQueueNotifyLatencyTest {
+    @Inject
+    private DispatchQueueInterface<AbstractDispatchQueueTest.TestDispatch> dispatchQueue;
+
+    @Inject
+    private JdbcTestUtils jdbcTestUtils;
+
+    @BeforeEach
+    void init() {
+        jdbcTestUtils.drop();
+        jdbcTestUtils.migrate();
+    }
+
+    @Test
+    void shouldDeliverWellUnderThePollBackoffOnceTheSubscriberIsAsleep() throws Exception {
+        CountDownLatch received = new CountDownLatch(1);
+
+        QueueSubscriber<AbstractDispatchQueueTest.TestDispatch> subscriber = dispatchQueue
+            .subscriber()
+            .subscribe(either -> received.countDown());
+
+        try {
+            // Let the subscriber's first (empty) poll happen and go to sleep for its 2s backoff, and
+            // give PgQueueListener time to notice the newly-registered channel and LISTEN to it (it
+            // re-syncs every ~200ms), so the message below can only be delivered via a realtime
+            // wake-up, not the initial poll.
+            Thread.sleep(1000);
+
+            long start = System.nanoTime();
+            dispatchQueue.emit(new AbstractDispatchQueueTest.TestDispatch(IdUtils.create(), 1));
+
+            boolean awaited = received.await(1500, TimeUnit.MILLISECONDS);
+            long elapsedMs = (System.nanoTime() - start) / 1_000_000;
+
+            assertThat(awaited).as("message should have been delivered").isTrue();
+            assertThat(elapsedMs).as("delivery latency should be far below the 2s poll backoff").isLessThan(1500);
+        } finally {
+            subscriber.close();
+        }
+    }
+}

--- a/jdbc-postgres/src/test/java/io/kestra/repository/postgres/PgQueueSignalRegistryTest.java
+++ b/jdbc-postgres/src/test/java/io/kestra/repository/postgres/PgQueueSignalRegistryTest.java
@@ -1,0 +1,147 @@
+package io.kestra.repository.postgres;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import io.kestra.queue.poller.QueueWaker;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit tests for the routing-key targeting and coalescing logic that decides which subscriber
+ * waker(s) a Postgres NOTIFY wakes. No database involved: {@link PgQueueListener} is what talks
+ * to Postgres, this only tests the in-JVM dispatch of an already-received notification.
+ */
+class PgQueueSignalRegistryTest {
+    private final ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor();
+
+    @AfterEach
+    void tearDown() {
+        scheduler.shutdownNow();
+    }
+
+    @Test
+    void shouldWakeWaiterOnMatchingRoutingKey() throws Exception {
+        PgQueueSignalRegistry registry = new PgQueueSignalRegistry();
+        String channel = PgQueueChannels.channelFor("worker_job_event");
+        QueueWaker waker = registry.waker("worker_job_event", List.of("rk-a"));
+
+        scheduler.schedule(() -> registry.signal(channel, "rk-a"), 50, TimeUnit.MILLISECONDS);
+
+        long elapsedMs = timeAwait(waker, Duration.ofSeconds(2));
+
+        assertThat(elapsedMs).isLessThan(1500);
+    }
+
+    @Test
+    void shouldNotWakeWaiterOnNonMatchingRoutingKey() throws Exception {
+        PgQueueSignalRegistry registry = new PgQueueSignalRegistry();
+        String channel = PgQueueChannels.channelFor("worker_job_event");
+        QueueWaker waker = registry.waker("worker_job_event", List.of("rk-a"));
+
+        scheduler.schedule(() -> registry.signal(channel, "rk-b"), 20, TimeUnit.MILLISECONDS);
+
+        // The waiter only owns "rk-a": a signal for "rk-b" must not wake it, so await() should run
+        // out its full timeout instead of returning early.
+        long elapsedMs = timeAwait(waker, Duration.ofMillis(300));
+
+        assertThat(elapsedMs).isGreaterThanOrEqualTo(250);
+    }
+
+    @Test
+    void shouldWakeWildcardWaiterOnAnyRoutingKey() throws Exception {
+        // Plain dispatch/broadcast subscribers register with no owned routing keys: they must wake
+        // on a signal for ANY routing key, since they consume every message on the queue.
+        PgQueueSignalRegistry registry = new PgQueueSignalRegistry();
+        String channel = PgQueueChannels.channelFor("execution");
+        QueueWaker waker = registry.waker("execution", List.of());
+
+        scheduler.schedule(() -> registry.signal(channel, "some-vnode-key"), 50, TimeUnit.MILLISECONDS);
+
+        long elapsedMs = timeAwait(waker, Duration.ofSeconds(2));
+
+        assertThat(elapsedMs).isLessThan(1500);
+    }
+
+    @Test
+    void shouldWakeEveryWaiterOnChannelWhenRoutingKeyIsEmpty() throws Exception {
+        // Plain dispatch/broadcast publishes carry no routing key: the signal must wake every
+        // waiter on the channel regardless of what routing keys they individually own.
+        PgQueueSignalRegistry registry = new PgQueueSignalRegistry();
+        String channel = PgQueueChannels.channelFor("execution");
+        QueueWaker wakerA = registry.waker("execution", List.of("rk-a"));
+        QueueWaker wakerB = registry.waker("execution", List.of("rk-b"));
+
+        scheduler.schedule(() -> registry.signal(channel, ""), 50, TimeUnit.MILLISECONDS);
+
+        long elapsedA = timeAwait(wakerA, Duration.ofSeconds(2));
+        long elapsedB = timeAwait(wakerB, Duration.ofSeconds(2));
+
+        assertThat(elapsedA).isLessThan(1500);
+        assertThat(elapsedB).isLessThan(1500);
+    }
+
+    @Test
+    void shouldCoalesceMultipleSignalsIntoASinglePermit() {
+        PgQueueSignalRegistry registry = new PgQueueSignalRegistry();
+        String channel = PgQueueChannels.channelFor("execution");
+        QueueWaker waker = registry.waker("execution", List.of());
+
+        // Two signals fire before anyone waits: the waiter should only ever need to catch up once.
+        registry.signal(channel, "");
+        registry.signal(channel, "");
+
+        long firstAwaitMs = timeAwaitUnchecked(waker, Duration.ofMillis(300));
+        long secondAwaitMs = timeAwaitUnchecked(waker, Duration.ofMillis(300));
+
+        // First await consumes the single coalesced permit and returns immediately.
+        assertThat(firstAwaitMs).isLessThan(150);
+        // No permit left over from the second signal: the second await runs out its full timeout.
+        assertThat(secondAwaitMs).isGreaterThanOrEqualTo(250);
+    }
+
+    @Test
+    void signalAllShouldWakeEveryWaiterAcrossEveryChannelBypassingRoutingKeyFilter() throws Exception {
+        PgQueueSignalRegistry registry = new PgQueueSignalRegistry();
+        QueueWaker wakerExecution = registry.waker("execution", List.of("rk-a"));
+        QueueWaker wakerWorkerJob = registry.waker("worker_job_event", List.of("rk-b"));
+
+        scheduler.schedule(registry::signalAll, 50, TimeUnit.MILLISECONDS);
+
+        long elapsed1 = timeAwait(wakerExecution, Duration.ofSeconds(2));
+        long elapsed2 = timeAwait(wakerWorkerJob, Duration.ofSeconds(2));
+
+        assertThat(elapsed1).isLessThan(1500);
+        assertThat(elapsed2).isLessThan(1500);
+    }
+
+    @Test
+    void channelsShouldReflectEveryChannelWithAtLeastOneWaiter() {
+        PgQueueSignalRegistry registry = new PgQueueSignalRegistry();
+
+        registry.waker("execution", List.of());
+        registry.waker("worker_job_event", List.of("rk-a"));
+
+        assertThat(registry.channels()).containsExactlyInAnyOrder("kestra_queue_execution", "kestra_queue_worker_job_event");
+    }
+
+    private static long timeAwait(QueueWaker waker, Duration max) throws InterruptedException {
+        long start = System.nanoTime();
+        waker.await(max);
+        return Duration.ofNanos(System.nanoTime() - start).toMillis();
+    }
+
+    private static long timeAwaitUnchecked(QueueWaker waker, Duration max) {
+        try {
+            return timeAwait(waker, max);
+        } catch (InterruptedException e) {
+            throw new AssertionError(e);
+        }
+    }
+}

--- a/jdbc-postgres/src/test/java/io/kestra/repository/postgres/PgQueueSignalRegistryTest.java
+++ b/jdbc-postgres/src/test/java/io/kestra/repository/postgres/PgQueueSignalRegistryTest.java
@@ -1,7 +1,6 @@
 package io.kestra.repository.postgres;
 
 import java.time.Duration;
-import java.util.List;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -14,9 +13,9 @@ import io.kestra.queue.poller.QueueWaker;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
- * Unit tests for the routing-key targeting and coalescing logic that decides which subscriber
- * waker(s) a Postgres NOTIFY wakes. No database involved: {@link PgQueueListener} is what talks
- * to Postgres, this only tests the in-JVM dispatch of an already-received notification.
+ * Unit tests for the coalescing wake-up dispatch logic that decides which subscriber waker(s) a
+ * Postgres NOTIFY wakes. No database involved: {@link PgQueueListener} is what talks to Postgres,
+ * this only tests the in-JVM dispatch of an already-received notification.
  */
 class PgQueueSignalRegistryTest {
     private final ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor();
@@ -27,12 +26,12 @@ class PgQueueSignalRegistryTest {
     }
 
     @Test
-    void shouldWakeWaiterOnMatchingRoutingKey() throws Exception {
+    void shouldWakeWaiterOnSignal() throws Exception {
         PgQueueSignalRegistry registry = new PgQueueSignalRegistry();
         String channel = PgQueueChannels.channelFor("worker_job_event");
-        QueueWaker waker = registry.waker("worker_job_event", List.of("rk-a"));
+        QueueWaker waker = registry.waker("worker_job_event");
 
-        scheduler.schedule(() -> registry.signal(channel, "rk-a"), 50, TimeUnit.MILLISECONDS);
+        scheduler.schedule(() -> registry.signal(channel), 50, TimeUnit.MILLISECONDS);
 
         long elapsedMs = timeAwait(waker, Duration.ofSeconds(2));
 
@@ -40,45 +39,13 @@ class PgQueueSignalRegistryTest {
     }
 
     @Test
-    void shouldNotWakeWaiterOnNonMatchingRoutingKey() throws Exception {
-        PgQueueSignalRegistry registry = new PgQueueSignalRegistry();
-        String channel = PgQueueChannels.channelFor("worker_job_event");
-        QueueWaker waker = registry.waker("worker_job_event", List.of("rk-a"));
-
-        scheduler.schedule(() -> registry.signal(channel, "rk-b"), 20, TimeUnit.MILLISECONDS);
-
-        // The waiter only owns "rk-a": a signal for "rk-b" must not wake it, so await() should run
-        // out its full timeout instead of returning early.
-        long elapsedMs = timeAwait(waker, Duration.ofMillis(300));
-
-        assertThat(elapsedMs).isGreaterThanOrEqualTo(250);
-    }
-
-    @Test
-    void shouldWakeWildcardWaiterOnAnyRoutingKey() throws Exception {
-        // Plain dispatch/broadcast subscribers register with no owned routing keys: they must wake
-        // on a signal for ANY routing key, since they consume every message on the queue.
+    void shouldWakeEveryWaiterOnChannel() throws Exception {
         PgQueueSignalRegistry registry = new PgQueueSignalRegistry();
         String channel = PgQueueChannels.channelFor("execution");
-        QueueWaker waker = registry.waker("execution", List.of());
+        QueueWaker wakerA = registry.waker("execution");
+        QueueWaker wakerB = registry.waker("execution");
 
-        scheduler.schedule(() -> registry.signal(channel, "some-vnode-key"), 50, TimeUnit.MILLISECONDS);
-
-        long elapsedMs = timeAwait(waker, Duration.ofSeconds(2));
-
-        assertThat(elapsedMs).isLessThan(1500);
-    }
-
-    @Test
-    void shouldWakeEveryWaiterOnChannelWhenRoutingKeyIsEmpty() throws Exception {
-        // Plain dispatch/broadcast publishes carry no routing key: the signal must wake every
-        // waiter on the channel regardless of what routing keys they individually own.
-        PgQueueSignalRegistry registry = new PgQueueSignalRegistry();
-        String channel = PgQueueChannels.channelFor("execution");
-        QueueWaker wakerA = registry.waker("execution", List.of("rk-a"));
-        QueueWaker wakerB = registry.waker("execution", List.of("rk-b"));
-
-        scheduler.schedule(() -> registry.signal(channel, ""), 50, TimeUnit.MILLISECONDS);
+        scheduler.schedule(() -> registry.signal(channel), 50, TimeUnit.MILLISECONDS);
 
         long elapsedA = timeAwait(wakerA, Duration.ofSeconds(2));
         long elapsedB = timeAwait(wakerB, Duration.ofSeconds(2));
@@ -88,14 +55,28 @@ class PgQueueSignalRegistryTest {
     }
 
     @Test
+    void shouldNotWakeWaiterOnADifferentChannel() throws Exception {
+        PgQueueSignalRegistry registry = new PgQueueSignalRegistry();
+        QueueWaker waker = registry.waker("execution");
+
+        scheduler.schedule(() -> registry.signal(PgQueueChannels.channelFor("worker_job_event")), 20, TimeUnit.MILLISECONDS);
+
+        // The waiter is only registered on the "execution" channel: a signal for a different
+        // channel must not wake it, so await() should run out its full timeout instead of returning early.
+        long elapsedMs = timeAwait(waker, Duration.ofMillis(300));
+
+        assertThat(elapsedMs).isGreaterThanOrEqualTo(250);
+    }
+
+    @Test
     void shouldCoalesceMultipleSignalsIntoASinglePermit() {
         PgQueueSignalRegistry registry = new PgQueueSignalRegistry();
         String channel = PgQueueChannels.channelFor("execution");
-        QueueWaker waker = registry.waker("execution", List.of());
+        QueueWaker waker = registry.waker("execution");
 
         // Two signals fire before anyone waits: the waiter should only ever need to catch up once.
-        registry.signal(channel, "");
-        registry.signal(channel, "");
+        registry.signal(channel);
+        registry.signal(channel);
 
         long firstAwaitMs = timeAwaitUnchecked(waker, Duration.ofMillis(300));
         long secondAwaitMs = timeAwaitUnchecked(waker, Duration.ofMillis(300));
@@ -107,10 +88,10 @@ class PgQueueSignalRegistryTest {
     }
 
     @Test
-    void signalAllShouldWakeEveryWaiterAcrossEveryChannelBypassingRoutingKeyFilter() throws Exception {
+    void signalAllShouldWakeEveryWaiterAcrossEveryChannel() throws Exception {
         PgQueueSignalRegistry registry = new PgQueueSignalRegistry();
-        QueueWaker wakerExecution = registry.waker("execution", List.of("rk-a"));
-        QueueWaker wakerWorkerJob = registry.waker("worker_job_event", List.of("rk-b"));
+        QueueWaker wakerExecution = registry.waker("execution");
+        QueueWaker wakerWorkerJob = registry.waker("worker_job_event");
 
         scheduler.schedule(registry::signalAll, 50, TimeUnit.MILLISECONDS);
 
@@ -125,8 +106,8 @@ class PgQueueSignalRegistryTest {
     void channelsShouldReflectEveryChannelWithAtLeastOneWaiter() {
         PgQueueSignalRegistry registry = new PgQueueSignalRegistry();
 
-        registry.waker("execution", List.of());
-        registry.waker("worker_job_event", List.of("rk-a"));
+        registry.waker("execution");
+        registry.waker("worker_job_event");
 
         assertThat(registry.channels()).containsExactlyInAnyOrder("kestra_queue_execution", "kestra_queue_worker_job_event");
     }

--- a/jdbc-postgres/src/test/java/io/kestra/repository/postgres/PostgresQueueChangeNotifierCoalescingTest.java
+++ b/jdbc-postgres/src/test/java/io/kestra/repository/postgres/PostgresQueueChangeNotifierCoalescingTest.java
@@ -1,0 +1,97 @@
+package io.kestra.repository.postgres;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.postgresql.PGConnection;
+import org.postgresql.PGNotification;
+
+import io.kestra.core.junit.annotations.KestraTest;
+import io.kestra.core.queues.DispatchQueueInterface;
+import io.kestra.core.queues.GenericQueueInterface;
+import io.kestra.core.utils.IdUtils;
+import io.kestra.jdbc.JdbcTestUtils;
+import io.kestra.queue.AbstractDispatchQueueTest;
+
+import io.micronaut.configuration.jdbc.hikari.DatasourceConfiguration;
+import io.micronaut.context.annotation.Property;
+import jakarta.inject.Inject;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Proves {@link PostgresQueueChangeNotifier} actually coalesces: a burst of publishes to the same
+ * queue, all within one {@code coalesceInterval}, must not produce one {@code NOTIFY} per publish
+ * — the fix for the wake-up-storm half of the throughput regression this mechanism introduced
+ * (see PR #17525 benchmark analysis). Uses its own raw {@code LISTEN} connection, independent of
+ * {@link PgQueueListener}, so it counts exactly what Postgres delivered rather than what the
+ * production wake-up path happened to consume.
+ */
+@KestraTest(environments = { "test", "queue" }, rebuildContext = true)
+@Property(name = "kestra.queue.type", value = "postgres") // the "queue" env sets this to "h2" (still matches @JdbcQueueEnabled generically), which would disable the @PostgresQueueEnabled beans under test
+@Property(name = "kestra.queue.postgres.notify.coalesce-interval", value = "0.2s")
+@Execution(ExecutionMode.SAME_THREAD)
+class PostgresQueueChangeNotifierCoalescingTest {
+    @Inject
+    private DispatchQueueInterface<AbstractDispatchQueueTest.TestDispatch> dispatchQueue;
+
+    @Inject
+    private JdbcTestUtils jdbcTestUtils;
+
+    @Inject
+    private DatasourceConfiguration datasourceConfiguration;
+
+    private Connection listenConnection;
+
+    @BeforeEach
+    void init() throws SQLException {
+        jdbcTestUtils.drop();
+        jdbcTestUtils.migrate();
+
+        listenConnection = DriverManager.getConnection(
+            datasourceConfiguration.getJdbcUrl(), datasourceConfiguration.getUsername(), datasourceConfiguration.getPassword()
+        );
+        String channel = PgQueueChannels.channelFor(((GenericQueueInterface<?>) dispatchQueue).queueName());
+        try (Statement statement = listenConnection.createStatement()) {
+            statement.execute("LISTEN \"" + channel + "\"");
+        }
+    }
+
+    @AfterEach
+    void cleanup() throws SQLException {
+        listenConnection.close();
+    }
+
+    @Test
+    void shouldCoalesceABurstOfPublishesIntoFewNotifications() throws Exception {
+        int publishCount = 30;
+        for (int i = 0; i < publishCount; i++) {
+            dispatchQueue.emit(new AbstractDispatchQueueTest.TestDispatch(IdUtils.create(), i));
+        }
+
+        // Drain notifications over a window comfortably longer than the 0.2s coalesceInterval, so
+        // both the immediate leading-edge NOTIFY and any trailing coalesced one have time to arrive.
+        int received = 0;
+        long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(2);
+        PGConnection pgConnection = (PGConnection) listenConnection;
+        while (System.nanoTime() < deadline) {
+            PGNotification[] notifications = pgConnection.getNotifications(200);
+            if (notifications != null) {
+                received += notifications.length;
+            }
+        }
+
+        assertThat(received)
+            .as("a %d-message burst within one coalescing window should not produce one NOTIFY per message", publishCount)
+            .isPositive()
+            .isLessThan(publishCount);
+    }
+}

--- a/jdbc-postgres/src/test/java/io/kestra/repository/postgres/PostgresQueueChangeNotifierFloorTest.java
+++ b/jdbc-postgres/src/test/java/io/kestra/repository/postgres/PostgresQueueChangeNotifierFloorTest.java
@@ -1,0 +1,122 @@
+package io.kestra.repository.postgres;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.postgresql.PGConnection;
+import org.postgresql.PGNotification;
+
+import io.kestra.core.junit.annotations.KestraTest;
+import io.kestra.core.queues.DispatchQueueInterface;
+import io.kestra.core.queues.GenericQueueInterface;
+import io.kestra.core.utils.IdUtils;
+import io.kestra.jdbc.JdbcTestUtils;
+import io.kestra.queue.AbstractDispatchQueueTest;
+
+import io.micronaut.configuration.jdbc.hikari.DatasourceConfiguration;
+import io.micronaut.context.annotation.Property;
+import jakarta.inject.Inject;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Proves {@link PostgresQueueChangeNotifier} floors its effective coalescing interval at the
+ * subscriber's own {@code min-poll-interval}, even when {@code coalesce-interval} is configured
+ * tighter. Without this floor, a NOTIFY-driven wake-up on a briefly-idle, high-throughput queue
+ * can re-poll (and pay a full transaction) more often than plain polling ever would — the residual
+ * high-throughput regression this floor fixes.
+ * <p>
+ * Configures {@code coalesce-interval} (10ms) well below {@code min-poll-interval} (300ms) and
+ * publishes continuously, then asserts the total NOTIFY count over the observation window is
+ * bounded near what the 300ms floor would produce (a handful), not the ~100+ that the tighter
+ * configured 10ms value would produce if it weren't floored. Bounding on total count rather than
+ * per-notification arrival gaps (like the sibling {@link PostgresQueueChangeNotifierCoalescingTest})
+ * avoids a timing trap: a stalled poll loop (GC pause, CI contention) can return several
+ * already-buffered NOTIFYs in one {@code getNotifications} call, making two genuinely
+ * floor-spaced signals look like a zero-gap batch — a false failure unrelated to the mechanism
+ * under test.
+ */
+@KestraTest(environments = { "test", "queue" }, rebuildContext = true)
+@Property(name = "kestra.queue.type", value = "postgres") // the "queue" env sets this to "h2" (still matches @JdbcQueueEnabled generically), which would disable the @PostgresQueueEnabled beans under test
+@Property(name = "kestra.queue.postgres.notify.coalesce-interval", value = "0.01s")
+@Property(name = "kestra.jdbc.queues.min-poll-interval", value = "0.3s")
+@Execution(ExecutionMode.SAME_THREAD)
+class PostgresQueueChangeNotifierFloorTest {
+    @Inject
+    private DispatchQueueInterface<AbstractDispatchQueueTest.TestDispatch> dispatchQueue;
+
+    @Inject
+    private JdbcTestUtils jdbcTestUtils;
+
+    @Inject
+    private DatasourceConfiguration datasourceConfiguration;
+
+    private Connection listenConnection;
+
+    @BeforeEach
+    void init() throws SQLException {
+        jdbcTestUtils.drop();
+        jdbcTestUtils.migrate();
+
+        listenConnection = DriverManager.getConnection(
+            datasourceConfiguration.getJdbcUrl(), datasourceConfiguration.getUsername(), datasourceConfiguration.getPassword()
+        );
+        String channel = PgQueueChannels.channelFor(((GenericQueueInterface<?>) dispatchQueue).queueName());
+        try (Statement statement = listenConnection.createStatement()) {
+            statement.execute("LISTEN \"" + channel + "\"");
+        }
+    }
+
+    @AfterEach
+    void cleanup() throws SQLException {
+        listenConnection.close();
+    }
+
+    @Test
+    void shouldNotUndercutTheSubscribersPollFloorWhenCoalesceIntervalIsTighter() throws Exception {
+        long publishDurationNanos = TimeUnit.MILLISECONDS.toNanos(900);
+        long publishDeadline = System.nanoTime() + publishDurationNanos;
+
+        AtomicInteger id = new AtomicInteger();
+        Thread publisher = new Thread(() ->
+        {
+            while (System.nanoTime() < publishDeadline) {
+                try {
+                    dispatchQueue.emit(new AbstractDispatchQueueTest.TestDispatch(IdUtils.create(), id.incrementAndGet()));
+                } catch (Exception e) {
+                    throw new RuntimeException(e);
+                }
+            }
+        });
+        publisher.start();
+
+        int received = 0;
+        long collectDeadline = publishDeadline + TimeUnit.MILLISECONDS.toNanos(500);
+        PGConnection pgConnection = (PGConnection) listenConnection;
+        while (System.nanoTime() < collectDeadline) {
+            PGNotification[] notifications = pgConnection.getNotifications(200);
+            if (notifications != null) {
+                received += notifications.length;
+            }
+        }
+        publisher.join();
+
+        // Observation window is ~1.4s (900ms publishing + 500ms drain). At the 300ms floor that's
+        // at most ~5-6 NOTIFYs; at the tighter configured 10ms coalesce-interval it would be 100+.
+        // A generous upper bound well below the unfloor value proves the floor is what's actually
+        // governing emission cadence, without depending on precise per-notification timing.
+        assertThat(received)
+            .as("NOTIFY count must reflect the min-poll-interval floor (300ms), not the tighter configured coalesce-interval (10ms)")
+            .isPositive()
+            .isLessThan(20);
+    }
+}

--- a/jdbc/src/test/java/io/kestra/jdbc/queue/JdbcTestQueueFactory.java
+++ b/jdbc/src/test/java/io/kestra/jdbc/queue/JdbcTestQueueFactory.java
@@ -18,7 +18,7 @@ public class JdbcTestQueueFactory {
     public BroadcastQueueInterface<AbstractBroadcastQueueTest.TestBroadcast> broadCastQueue(JdbcDependencies dependencies) {
         return new JdbcBroadcastQueue<>(
             AbstractBroadcastQueueTest.TestBroadcast.class, dependencies.queueService(), dependencies.jdbcQueueClient(), dependencies.executorsUtils(), dependencies.metricRegistry(),
-            dependencies.ignoreExecutionService()
+            dependencies.ignoreExecutionService(), dependencies.queueWakeRegistry()
         );
     }
 
@@ -26,7 +26,7 @@ public class JdbcTestQueueFactory {
     public DispatchQueueInterface<AbstractDispatchQueueTest.TestDispatch> dispatchQueue(JdbcDependencies dependencies) {
         return new JdbcDispatchQueue<>(
             AbstractDispatchQueueTest.TestDispatch.class, dependencies.queueService(), dependencies.jdbcQueueClient(), dependencies.executorsUtils(), dependencies.metricRegistry(),
-            dependencies.ignoreExecutionService()
+            dependencies.ignoreExecutionService(), dependencies.queueWakeRegistry()
         );
     }
 
@@ -34,7 +34,7 @@ public class JdbcTestQueueFactory {
     public KeyedDispatchQueueInterface<AbstractKeyedDispatchQueueTest.TestKeyedDispatch> keyDispatchQueue(JdbcDependencies dependencies) {
         return new JdbcKeyedDispatchQueue<>(
             AbstractKeyedDispatchQueueTest.TestKeyedDispatch.class, dependencies.queueService(), dependencies.jdbcQueueClient(), dependencies.executorsUtils(), dependencies.metricRegistry(),
-            dependencies.ignoreExecutionService()
+            dependencies.ignoreExecutionService(), dependencies.queueWakeRegistry()
         );
     }
 
@@ -42,7 +42,7 @@ public class JdbcTestQueueFactory {
     public VNodeDispatchQueueInterface<AbstractVNodeDispatchQueueTest.TestVNodeDispatchDispatch> vNodeDispatchQueue(JdbcDependencies dependencies) {
         return new JdbcVNodeDispatchQueue<>(
             AbstractVNodeDispatchQueueTest.TestVNodeDispatchDispatch.class, dependencies.queueService(), dependencies.jdbcQueueClient(), dependencies.executorsUtils(),
-            dependencies.metricRegistry(), dependencies.ignoreExecutionService()
+            dependencies.metricRegistry(), dependencies.ignoreExecutionService(), dependencies.queueWakeRegistry()
         );
     }
 
@@ -50,7 +50,7 @@ public class JdbcTestQueueFactory {
     public BroadcastQueueInterface<AbstractQueueCacheTest.DeletableBroadcastTestEvent> deletableBroadcastTestEventDispatchQueue(JdbcDependencies dependencies) {
         return new JdbcBroadcastQueue<>(
             AbstractQueueCacheTest.DeletableBroadcastTestEvent.class, dependencies.queueService(), dependencies.jdbcQueueClient(), dependencies.executorsUtils(), dependencies.metricRegistry(),
-            dependencies.ignoreExecutionService()
+            dependencies.ignoreExecutionService(), dependencies.queueWakeRegistry()
         );
     }
 }

--- a/queue-jdbc/src/main/java/io/kestra/queue/jdbc/JdbcBroadcastQueue.java
+++ b/queue-jdbc/src/main/java/io/kestra/queue/jdbc/JdbcBroadcastQueue.java
@@ -14,7 +14,9 @@ import io.kestra.queue.QueueRecord;
 import io.kestra.queue.QueueService;
 import io.kestra.queue.jdbc.client.JdbcBroadcastSubscriber;
 import io.kestra.queue.jdbc.client.JdbcQueueClient;
+import io.kestra.queue.jdbc.client.QueueWakeRegistry;
 
+import jakarta.annotation.Nullable;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
@@ -23,13 +25,28 @@ public class JdbcBroadcastQueue<T extends BroadcastEvent> extends AbstractBroadc
     private final MetricRegistry metricRegistry;
     private final IgnoreExecutionService ignoreExecutionService;
 
+    @Nullable
+    private final QueueWakeRegistry queueWakeRegistry;
+
+    /**
+     * @deprecated use the overload taking a {@link QueueWakeRegistry} — kept so existing callers
+     *             built against the pre-{@link QueueWakeRegistry} signature keep compiling; they
+     *             simply get no realtime wake-up.
+     */
+    @Deprecated
     public JdbcBroadcastQueue(Class<T> cls, QueueService queueService, JdbcQueueClient jdbcQueueClient, ExecutorsUtils executorsUtils, MetricRegistry metricRegistry,
         IgnoreExecutionService ignoreExecutionService) {
+        this(cls, queueService, jdbcQueueClient, executorsUtils, metricRegistry, ignoreExecutionService, null);
+    }
+
+    public JdbcBroadcastQueue(Class<T> cls, QueueService queueService, JdbcQueueClient jdbcQueueClient, ExecutorsUtils executorsUtils, MetricRegistry metricRegistry,
+        IgnoreExecutionService ignoreExecutionService, @Nullable QueueWakeRegistry queueWakeRegistry) {
         super(cls, queueService, executorsUtils, metricRegistry);
 
         this.jdbcQueueClient = jdbcQueueClient;
         this.metricRegistry = metricRegistry;
         this.ignoreExecutionService = ignoreExecutionService;
+        this.queueWakeRegistry = queueWakeRegistry;
     }
 
     @Override
@@ -40,7 +57,8 @@ public class JdbcBroadcastQueue<T extends BroadcastEvent> extends AbstractBroadc
             jdbcQueueClient,
             queueName(),
             metricRegistry,
-            ignoreExecutionService
+            ignoreExecutionService,
+            queueWakeRegistry
         );
     }
 

--- a/queue-jdbc/src/main/java/io/kestra/queue/jdbc/JdbcDependencies.java
+++ b/queue-jdbc/src/main/java/io/kestra/queue/jdbc/JdbcDependencies.java
@@ -5,7 +5,9 @@ import io.kestra.core.services.IgnoreExecutionService;
 import io.kestra.core.utils.ExecutorsUtils;
 import io.kestra.queue.QueueService;
 import io.kestra.queue.jdbc.client.JdbcQueueClient;
+import io.kestra.queue.jdbc.client.QueueWakeRegistry;
 
+import jakarta.annotation.Nullable;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 
@@ -15,5 +17,6 @@ public record JdbcDependencies(@Inject QueueService queueService,
     @Inject JdbcQueueClient jdbcQueueClient,
     @Inject ExecutorsUtils executorsUtils,
     @Inject MetricRegistry metricRegistry,
-    @Inject IgnoreExecutionService ignoreExecutionService) {
+    @Inject IgnoreExecutionService ignoreExecutionService,
+    @Inject @Nullable QueueWakeRegistry queueWakeRegistry) {
 }

--- a/queue-jdbc/src/main/java/io/kestra/queue/jdbc/JdbcDispatchQueue.java
+++ b/queue-jdbc/src/main/java/io/kestra/queue/jdbc/JdbcDispatchQueue.java
@@ -14,7 +14,9 @@ import io.kestra.queue.QueueRecord;
 import io.kestra.queue.QueueService;
 import io.kestra.queue.jdbc.client.JdbcDispatchSubscriber;
 import io.kestra.queue.jdbc.client.JdbcQueueClient;
+import io.kestra.queue.jdbc.client.QueueWakeRegistry;
 
+import jakarta.annotation.Nullable;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
@@ -23,13 +25,28 @@ public class JdbcDispatchQueue<T extends DispatchEvent> extends AbstractDispatch
     private final MetricRegistry metricRegistry;
     private final IgnoreExecutionService ignoreExecutionService;
 
+    @Nullable
+    private final QueueWakeRegistry queueWakeRegistry;
+
+    /**
+     * @deprecated use the overload taking a {@link QueueWakeRegistry} — kept so existing callers
+     *             built against the pre-{@link QueueWakeRegistry} signature keep compiling; they
+     *             simply get no realtime wake-up.
+     */
+    @Deprecated
     public JdbcDispatchQueue(Class<T> cls, QueueService queueService, JdbcQueueClient jdbcQueueClient, ExecutorsUtils executorsUtils, MetricRegistry metricRegistry,
         IgnoreExecutionService ignoreExecutionService) {
+        this(cls, queueService, jdbcQueueClient, executorsUtils, metricRegistry, ignoreExecutionService, null);
+    }
+
+    public JdbcDispatchQueue(Class<T> cls, QueueService queueService, JdbcQueueClient jdbcQueueClient, ExecutorsUtils executorsUtils, MetricRegistry metricRegistry,
+        IgnoreExecutionService ignoreExecutionService, @Nullable QueueWakeRegistry queueWakeRegistry) {
         super(cls, queueService, executorsUtils, metricRegistry);
 
         this.jdbcQueueClient = jdbcQueueClient;
         this.metricRegistry = metricRegistry;
         this.ignoreExecutionService = ignoreExecutionService;
+        this.queueWakeRegistry = queueWakeRegistry;
     }
 
     @Override
@@ -41,7 +58,8 @@ public class JdbcDispatchQueue<T extends DispatchEvent> extends AbstractDispatch
             queueName(),
             null,
             metricRegistry,
-            ignoreExecutionService
+            ignoreExecutionService,
+            queueWakeRegistry
         );
     }
 

--- a/queue-jdbc/src/main/java/io/kestra/queue/jdbc/JdbcKeyedDispatchQueue.java
+++ b/queue-jdbc/src/main/java/io/kestra/queue/jdbc/JdbcKeyedDispatchQueue.java
@@ -14,7 +14,9 @@ import io.kestra.queue.QueueRecord;
 import io.kestra.queue.QueueService;
 import io.kestra.queue.jdbc.client.JdbcDispatchSubscriber;
 import io.kestra.queue.jdbc.client.JdbcQueueClient;
+import io.kestra.queue.jdbc.client.QueueWakeRegistry;
 
+import jakarta.annotation.Nullable;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
@@ -23,13 +25,28 @@ public class JdbcKeyedDispatchQueue<T extends KeyedDispatchEvent> extends Abstra
     private final MetricRegistry metricRegistry;
     private final IgnoreExecutionService ignoreExecutionService;
 
+    @Nullable
+    private final QueueWakeRegistry queueWakeRegistry;
+
+    /**
+     * @deprecated use the overload taking a {@link QueueWakeRegistry} — kept so existing callers
+     *             built against the pre-{@link QueueWakeRegistry} signature keep compiling; they
+     *             simply get no realtime wake-up.
+     */
+    @Deprecated
     public JdbcKeyedDispatchQueue(Class<T> cls, QueueService queueService, JdbcQueueClient JdbcQueueClient, ExecutorsUtils executorsUtils, MetricRegistry metricRegistry,
         IgnoreExecutionService ignoreExecutionService) {
+        this(cls, queueService, JdbcQueueClient, executorsUtils, metricRegistry, ignoreExecutionService, null);
+    }
+
+    public JdbcKeyedDispatchQueue(Class<T> cls, QueueService queueService, JdbcQueueClient JdbcQueueClient, ExecutorsUtils executorsUtils, MetricRegistry metricRegistry,
+        IgnoreExecutionService ignoreExecutionService, @Nullable QueueWakeRegistry queueWakeRegistry) {
         super(cls, queueService, executorsUtils, metricRegistry);
 
         this.jdbcQueueClient = JdbcQueueClient;
         this.metricRegistry = metricRegistry;
         this.ignoreExecutionService = ignoreExecutionService;
+        this.queueWakeRegistry = queueWakeRegistry;
     }
 
     @Override
@@ -41,7 +58,8 @@ public class JdbcKeyedDispatchQueue<T extends KeyedDispatchEvent> extends Abstra
             queueName(),
             routingKey == null ? List.of() : List.of(routingKey),
             metricRegistry,
-            ignoreExecutionService
+            ignoreExecutionService,
+            queueWakeRegistry
         );
     }
 

--- a/queue-jdbc/src/main/java/io/kestra/queue/jdbc/JdbcQueueFactory.java
+++ b/queue-jdbc/src/main/java/io/kestra/queue/jdbc/JdbcQueueFactory.java
@@ -35,7 +35,8 @@ public class JdbcQueueFactory implements QueueFactoryInterface<JdbcDependencies>
     @Override
     public DispatchQueueInterface<Execution> executionQueue(JdbcDependencies dependencies) {
         return new JdbcDispatchQueue<>(
-            Execution.class, dependencies.queueService(), dependencies.jdbcQueueClient(), dependencies.executorsUtils(), dependencies.metricRegistry(), dependencies.ignoreExecutionService()
+            Execution.class, dependencies.queueService(), dependencies.jdbcQueueClient(), dependencies.executorsUtils(), dependencies.metricRegistry(), dependencies.ignoreExecutionService(),
+            dependencies.queueWakeRegistry()
         );
     }
 
@@ -44,7 +45,7 @@ public class JdbcQueueFactory implements QueueFactoryInterface<JdbcDependencies>
     public DispatchQueueInterface<ExecutionCommand> executionCommandQueue(JdbcDependencies dependencies) {
         return new JdbcDispatchQueue<>(
             ExecutionCommand.class, dependencies.queueService(), dependencies.jdbcQueueClient(), dependencies.executorsUtils(), dependencies.metricRegistry(),
-            dependencies.ignoreExecutionService()
+            dependencies.ignoreExecutionService(), dependencies.queueWakeRegistry()
         );
     }
 
@@ -53,7 +54,7 @@ public class JdbcQueueFactory implements QueueFactoryInterface<JdbcDependencies>
     public DispatchQueueInterface<ExecutionEvent> executionEventQueue(JdbcDependencies dependencies) {
         return new JdbcDispatchQueue<>(
             ExecutionEvent.class, dependencies.queueService(), dependencies.jdbcQueueClient(), dependencies.executorsUtils(), dependencies.metricRegistry(),
-            dependencies.ignoreExecutionService()
+            dependencies.ignoreExecutionService(), dependencies.queueWakeRegistry()
         );
     }
 
@@ -62,7 +63,7 @@ public class JdbcQueueFactory implements QueueFactoryInterface<JdbcDependencies>
     public BroadcastQueueInterface<ExecutionKilled> killQueue(JdbcDependencies dependencies) {
         return new JdbcBroadcastQueue<>(
             ExecutionKilled.class, dependencies.queueService(), dependencies.jdbcQueueClient(), dependencies.executorsUtils(), dependencies.metricRegistry(),
-            dependencies.ignoreExecutionService()
+            dependencies.ignoreExecutionService(), dependencies.queueWakeRegistry()
         );
     }
 
@@ -71,7 +72,7 @@ public class JdbcQueueFactory implements QueueFactoryInterface<JdbcDependencies>
     public DispatchQueueInterface<SubflowExecutionResult> subflowExecutionResultQueue(JdbcDependencies dependencies) {
         return new JdbcDispatchQueue<>(
             SubflowExecutionResult.class, dependencies.queueService(), dependencies.jdbcQueueClient(), dependencies.executorsUtils(), dependencies.metricRegistry(),
-            dependencies.ignoreExecutionService()
+            dependencies.ignoreExecutionService(), dependencies.queueWakeRegistry()
         );
     }
 
@@ -80,7 +81,7 @@ public class JdbcQueueFactory implements QueueFactoryInterface<JdbcDependencies>
     public DispatchQueueInterface<SubflowExecutionEnd> subflowExecutionEndQueue(JdbcDependencies dependencies) {
         return new JdbcDispatchQueue<>(
             SubflowExecutionEnd.class, dependencies.queueService(), dependencies.jdbcQueueClient(), dependencies.executorsUtils(), dependencies.metricRegistry(),
-            dependencies.ignoreExecutionService()
+            dependencies.ignoreExecutionService(), dependencies.queueWakeRegistry()
         );
     }
 
@@ -89,7 +90,7 @@ public class JdbcQueueFactory implements QueueFactoryInterface<JdbcDependencies>
     public DispatchQueueInterface<MultipleConditionEvent> multipleConditionEventQueue(JdbcDependencies dependencies) {
         return new JdbcDispatchQueue<>(
             MultipleConditionEvent.class, dependencies.queueService(), dependencies.jdbcQueueClient(), dependencies.executorsUtils(), dependencies.metricRegistry(),
-            dependencies.ignoreExecutionService()
+            dependencies.ignoreExecutionService(), dependencies.queueWakeRegistry()
         );
     }
 
@@ -98,7 +99,7 @@ public class JdbcQueueFactory implements QueueFactoryInterface<JdbcDependencies>
     public BroadcastQueueInterface<FlowInterface> flowQueue(JdbcDependencies dependencies) {
         return new JdbcBroadcastQueue<>(
             FlowInterface.class, dependencies.queueService(), dependencies.jdbcQueueClient(), dependencies.executorsUtils(), dependencies.metricRegistry(),
-            dependencies.ignoreExecutionService()
+            dependencies.ignoreExecutionService(), dependencies.queueWakeRegistry()
         );
     }
 
@@ -107,7 +108,7 @@ public class JdbcQueueFactory implements QueueFactoryInterface<JdbcDependencies>
     public BroadcastQueueInterface<SchedulerEvent> schedulerEventQueue(JdbcDependencies dependencies) {
         return new JdbcBroadcastQueue<>(
             SchedulerEvent.class, dependencies.queueService(), dependencies.jdbcQueueClient(), dependencies.executorsUtils(), dependencies.metricRegistry(),
-            dependencies.ignoreExecutionService()
+            dependencies.ignoreExecutionService(), dependencies.queueWakeRegistry()
         );
     }
 
@@ -115,7 +116,8 @@ public class JdbcQueueFactory implements QueueFactoryInterface<JdbcDependencies>
     @Override
     public VNodeDispatchQueueInterface<TriggerEvent> triggerEventQueue(JdbcDependencies dependencies) {
         return new JdbcVNodeDispatchQueue<>(
-            TriggerEvent.class, dependencies.queueService(), dependencies.jdbcQueueClient(), dependencies.executorsUtils(), dependencies.metricRegistry(), dependencies.ignoreExecutionService()
+            TriggerEvent.class, dependencies.queueService(), dependencies.jdbcQueueClient(), dependencies.executorsUtils(), dependencies.metricRegistry(),
+            dependencies.ignoreExecutionService(), dependencies.queueWakeRegistry()
         );
     }
 
@@ -123,7 +125,8 @@ public class JdbcQueueFactory implements QueueFactoryInterface<JdbcDependencies>
     @Override
     public DispatchQueueInterface<MetricEntry> metricQueue(JdbcDependencies dependencies) {
         return new JdbcDispatchQueue<>(
-            MetricEntry.class, dependencies.queueService(), dependencies.jdbcQueueClient(), dependencies.executorsUtils(), dependencies.metricRegistry(), dependencies.ignoreExecutionService()
+            MetricEntry.class, dependencies.queueService(), dependencies.jdbcQueueClient(), dependencies.executorsUtils(), dependencies.metricRegistry(), dependencies.ignoreExecutionService(),
+            dependencies.queueWakeRegistry()
         );
     }
 
@@ -132,7 +135,7 @@ public class JdbcQueueFactory implements QueueFactoryInterface<JdbcDependencies>
     public DispatchQueueInterface<ExecutionStatistic> executionStatisticQueue(JdbcDependencies dependencies) {
         return new JdbcDispatchQueue<>(
             ExecutionStatistic.class, dependencies.queueService(), dependencies.jdbcQueueClient(), dependencies.executorsUtils(), dependencies.metricRegistry(),
-            dependencies.ignoreExecutionService()
+            dependencies.ignoreExecutionService(), dependencies.queueWakeRegistry()
         );
     }
 
@@ -141,7 +144,7 @@ public class JdbcQueueFactory implements QueueFactoryInterface<JdbcDependencies>
     public BroadcastQueueInterface<FollowExecutionEvent> followExecutionQueue(JdbcDependencies dependencies) {
         return new JdbcBroadcastQueue<>(
             FollowExecutionEvent.class, dependencies.queueService(), dependencies.jdbcQueueClient(), dependencies.executorsUtils(), dependencies.metricRegistry(),
-            dependencies.ignoreExecutionService()
+            dependencies.ignoreExecutionService(), dependencies.queueWakeRegistry()
         );
     }
 
@@ -150,7 +153,7 @@ public class JdbcQueueFactory implements QueueFactoryInterface<JdbcDependencies>
     public BroadcastQueueInterface<AsyncOperationProcessedEvent> asyncOperationProcessedEventQueue(JdbcDependencies dependencies) {
         return new JdbcBroadcastQueue<>(
             AsyncOperationProcessedEvent.class, dependencies.queueService(), dependencies.jdbcQueueClient(), dependencies.executorsUtils(), dependencies.metricRegistry(),
-            dependencies.ignoreExecutionService()
+            dependencies.ignoreExecutionService(), dependencies.queueWakeRegistry()
         );
     }
 
@@ -158,7 +161,8 @@ public class JdbcQueueFactory implements QueueFactoryInterface<JdbcDependencies>
     @Override
     public DispatchQueueInterface<LogEntry> logEntryQueue(JdbcDependencies dependencies) {
         return new JdbcDispatchQueue<>(
-            LogEntry.class, dependencies.queueService(), dependencies.jdbcQueueClient(), dependencies.executorsUtils(), dependencies.metricRegistry(), dependencies.ignoreExecutionService()
+            LogEntry.class, dependencies.queueService(), dependencies.jdbcQueueClient(), dependencies.executorsUtils(), dependencies.metricRegistry(), dependencies.ignoreExecutionService(),
+            dependencies.queueWakeRegistry()
         );
     }
 
@@ -167,7 +171,7 @@ public class JdbcQueueFactory implements QueueFactoryInterface<JdbcDependencies>
     public BroadcastQueueInterface<FollowLogEvent> followLogEventQueue(JdbcDependencies dependencies) {
         return new JdbcBroadcastQueue<>(
             FollowLogEvent.class, dependencies.queueService(), dependencies.jdbcQueueClient(), dependencies.executorsUtils(), dependencies.metricRegistry(),
-            dependencies.ignoreExecutionService()
+            dependencies.ignoreExecutionService(), dependencies.queueWakeRegistry()
         );
     }
 
@@ -176,7 +180,7 @@ public class JdbcQueueFactory implements QueueFactoryInterface<JdbcDependencies>
     public KeyedDispatchQueueInterface<WorkerJobEvent> workerJobEventQueue(JdbcDependencies dependencies) {
         return new JdbcKeyedDispatchQueue<>(
             WorkerJobEvent.class, dependencies.queueService(), dependencies.jdbcQueueClient(), dependencies.executorsUtils(), dependencies.metricRegistry(),
-            dependencies.ignoreExecutionService()
+            dependencies.ignoreExecutionService(), dependencies.queueWakeRegistry()
         );
     }
 
@@ -185,7 +189,7 @@ public class JdbcQueueFactory implements QueueFactoryInterface<JdbcDependencies>
     public DispatchQueueInterface<WorkerTaskResult> workerTaskResultQueue(JdbcDependencies dependencies) {
         return new JdbcDispatchQueue<>(
             WorkerTaskResult.class, dependencies.queueService(), dependencies.jdbcQueueClient(), dependencies.executorsUtils(), dependencies.metricRegistry(),
-            dependencies.ignoreExecutionService()
+            dependencies.ignoreExecutionService(), dependencies.queueWakeRegistry()
         );
     }
 
@@ -194,7 +198,7 @@ public class JdbcQueueFactory implements QueueFactoryInterface<JdbcDependencies>
     public BroadcastQueueInterface<McpSessionEvent> mcpSessionQueue(JdbcDependencies dependencies) {
         return new JdbcBroadcastQueue<>(
             McpSessionEvent.class, dependencies.queueService(), dependencies.jdbcQueueClient(), dependencies.executorsUtils(), dependencies.metricRegistry(),
-            dependencies.ignoreExecutionService()
+            dependencies.ignoreExecutionService(), dependencies.queueWakeRegistry()
         );
     }
 
@@ -204,7 +208,7 @@ public class JdbcQueueFactory implements QueueFactoryInterface<JdbcDependencies>
     public BroadcastQueueInterface<ClusterEvent> clusterEventQueue(JdbcDependencies dependencies) {
         return new JdbcBroadcastQueue<>(
             ClusterEvent.class, dependencies.queueService(), dependencies.jdbcQueueClient(), dependencies.executorsUtils(), dependencies.metricRegistry(),
-            dependencies.ignoreExecutionService()
+            dependencies.ignoreExecutionService(), dependencies.queueWakeRegistry()
         );
     }
 
@@ -213,7 +217,7 @@ public class JdbcQueueFactory implements QueueFactoryInterface<JdbcDependencies>
     public DispatchQueueInterface<LoopExecutionEvent> loopExecutionEventQueue(JdbcDependencies dependencies) {
         return new JdbcDispatchQueue<>(
             LoopExecutionEvent.class, dependencies.queueService(), dependencies.jdbcQueueClient(), dependencies.executorsUtils(), dependencies.metricRegistry(),
-            dependencies.ignoreExecutionService()
+            dependencies.ignoreExecutionService(), dependencies.queueWakeRegistry()
         );
     }
 }

--- a/queue-jdbc/src/main/java/io/kestra/queue/jdbc/JdbcVNodeDispatchQueue.java
+++ b/queue-jdbc/src/main/java/io/kestra/queue/jdbc/JdbcVNodeDispatchQueue.java
@@ -13,7 +13,9 @@ import io.kestra.core.utils.ExecutorsUtils;
 import io.kestra.queue.*;
 import io.kestra.queue.jdbc.client.JdbcDispatchSubscriber;
 import io.kestra.queue.jdbc.client.JdbcQueueClient;
+import io.kestra.queue.jdbc.client.QueueWakeRegistry;
 
+import jakarta.annotation.Nullable;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
@@ -22,13 +24,28 @@ public class JdbcVNodeDispatchQueue<T extends VNodeDispatchEvent> extends Abstra
     private final MetricRegistry metricRegistry;
     private final IgnoreExecutionService ignoreExecutionService;
 
+    @Nullable
+    private final QueueWakeRegistry queueWakeRegistry;
+
+    /**
+     * @deprecated use the overload taking a {@link QueueWakeRegistry} — kept so existing callers
+     *             built against the pre-{@link QueueWakeRegistry} signature keep compiling; they
+     *             simply get no realtime wake-up.
+     */
+    @Deprecated
     public JdbcVNodeDispatchQueue(Class<T> cls, QueueService queueService, JdbcQueueClient jdbcQueueClient, ExecutorsUtils executorsUtils, MetricRegistry metricRegistry,
         IgnoreExecutionService ignoreExecutionService) {
+        this(cls, queueService, jdbcQueueClient, executorsUtils, metricRegistry, ignoreExecutionService, null);
+    }
+
+    public JdbcVNodeDispatchQueue(Class<T> cls, QueueService queueService, JdbcQueueClient jdbcQueueClient, ExecutorsUtils executorsUtils, MetricRegistry metricRegistry,
+        IgnoreExecutionService ignoreExecutionService, @Nullable QueueWakeRegistry queueWakeRegistry) {
         super(cls, queueService, executorsUtils, metricRegistry);
 
         this.jdbcQueueClient = jdbcQueueClient;
         this.metricRegistry = metricRegistry;
         this.ignoreExecutionService = ignoreExecutionService;
+        this.queueWakeRegistry = queueWakeRegistry;
     }
 
     @Override
@@ -71,7 +88,8 @@ public class JdbcVNodeDispatchQueue<T extends VNodeDispatchEvent> extends Abstra
                 .map(this::vNodeRoutingKey)
                 .toList(),
             metricRegistry,
-            ignoreExecutionService
+            ignoreExecutionService,
+            queueWakeRegistry
         );
     }
 }

--- a/queue-jdbc/src/main/java/io/kestra/queue/jdbc/client/JdbcBroadcastSubscriber.java
+++ b/queue-jdbc/src/main/java/io/kestra/queue/jdbc/client/JdbcBroadcastSubscriber.java
@@ -10,12 +10,19 @@ import io.kestra.core.queues.event.Event;
 import io.kestra.core.services.IgnoreExecutionService;
 import io.kestra.queue.QueueService;
 
+import jakarta.annotation.Nullable;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 public class JdbcBroadcastSubscriber<T extends Event> extends JdbcSubscriber<T> {
     private Long maxOffset = null;
 
+    /**
+     * @deprecated use the overload taking a {@link QueueWakeRegistry} — kept so existing callers
+     *             built against the pre-{@link QueueWakeRegistry} signature keep compiling; they
+     *             simply get no realtime wake-up.
+     */
+    @Deprecated
     public JdbcBroadcastSubscriber(
         Class<T> cls,
         QueueService queueService,
@@ -23,7 +30,18 @@ public class JdbcBroadcastSubscriber<T extends Event> extends JdbcSubscriber<T> 
         String queueName,
         MetricRegistry metricRegistry,
         IgnoreExecutionService ignoreExecutionService) {
-        super(cls, queueService, jdbcQueueClient, queueName, metricRegistry, ignoreExecutionService);
+        this(cls, queueService, jdbcQueueClient, queueName, metricRegistry, ignoreExecutionService, null);
+    }
+
+    public JdbcBroadcastSubscriber(
+        Class<T> cls,
+        QueueService queueService,
+        JdbcQueueClient jdbcQueueClient,
+        String queueName,
+        MetricRegistry metricRegistry,
+        IgnoreExecutionService ignoreExecutionService,
+        @Nullable QueueWakeRegistry wakeRegistry) {
+        super(cls, queueService, jdbcQueueClient, queueName, metricRegistry, ignoreExecutionService, wakeRegistry);
     }
 
     @Override

--- a/queue-jdbc/src/main/java/io/kestra/queue/jdbc/client/JdbcDispatchSubscriber.java
+++ b/queue-jdbc/src/main/java/io/kestra/queue/jdbc/client/JdbcDispatchSubscriber.java
@@ -8,12 +8,19 @@ import io.kestra.core.queues.event.Event;
 import io.kestra.core.services.IgnoreExecutionService;
 import io.kestra.queue.QueueService;
 
+import jakarta.annotation.Nullable;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 public class JdbcDispatchSubscriber<T extends Event> extends JdbcSubscriber<T> {
     private final List<String> routingKeys;
 
+    /**
+     * @deprecated use the overload taking a {@link QueueWakeRegistry} — kept so existing callers
+     *             built against the pre-{@link QueueWakeRegistry} signature keep compiling; they
+     *             simply get no realtime wake-up.
+     */
+    @Deprecated
     public JdbcDispatchSubscriber(
         Class<T> cls,
         QueueService queueService,
@@ -22,9 +29,26 @@ public class JdbcDispatchSubscriber<T extends Event> extends JdbcSubscriber<T> {
         List<String> routingKeys,
         MetricRegistry metricRegistry,
         IgnoreExecutionService ignoreExecutionService) {
-        super(cls, queueService, jdbcQueueClient, queueName, metricRegistry, ignoreExecutionService);
+        this(cls, queueService, jdbcQueueClient, queueName, routingKeys, metricRegistry, ignoreExecutionService, null);
+    }
+
+    public JdbcDispatchSubscriber(
+        Class<T> cls,
+        QueueService queueService,
+        JdbcQueueClient jdbcQueueClient,
+        String queueName,
+        List<String> routingKeys,
+        MetricRegistry metricRegistry,
+        IgnoreExecutionService ignoreExecutionService,
+        @Nullable QueueWakeRegistry wakeRegistry) {
+        super(cls, queueService, jdbcQueueClient, queueName, metricRegistry, ignoreExecutionService, wakeRegistry);
 
         this.routingKeys = routingKeys;
+    }
+
+    @Override
+    protected List<String> ownedRoutingKeys() {
+        return routingKeys == null ? List.of() : routingKeys;
     }
 
     @Override

--- a/queue-jdbc/src/main/java/io/kestra/queue/jdbc/client/JdbcDispatchSubscriber.java
+++ b/queue-jdbc/src/main/java/io/kestra/queue/jdbc/client/JdbcDispatchSubscriber.java
@@ -47,11 +47,6 @@ public class JdbcDispatchSubscriber<T extends Event> extends JdbcSubscriber<T> {
     }
 
     @Override
-    protected List<String> ownedRoutingKeys() {
-        return routingKeys == null ? List.of() : routingKeys;
-    }
-
-    @Override
     protected Integer poll(Consumer<byte[]> messageConsumer) {
         return this.jdbcQueueClient.subscribeDispatch(this.queueName, this.routingKeys, messageConsumer);
     }

--- a/queue-jdbc/src/main/java/io/kestra/queue/jdbc/client/JdbcQueueClient.java
+++ b/queue-jdbc/src/main/java/io/kestra/queue/jdbc/client/JdbcQueueClient.java
@@ -53,11 +53,21 @@ public class JdbcQueueClient {
     @Getter
     private final JdbcQueueConfiguration configuration;
 
+    /**
+     * Notifies a realtime wake-up mechanism after a publish, so a waiting subscriber's poll loop
+     * can be woken early instead of waiting out its full backoff. Only present on Postgres; on
+     * other dialects this is {@code null} and publish behaves exactly as before.
+     */
+    @Nullable
+    private final QueueChangeNotifier changeNotifier;
+
     @Inject
-    public JdbcQueueClient(@Named("queues") AbstractJdbcRepository<JdbcQueueItem> jdbcRepository, JooqDSLContextWrapper dslContextWrapper, JdbcQueueConfiguration configuration) {
+    public JdbcQueueClient(@Named("queues") AbstractJdbcRepository<JdbcQueueItem> jdbcRepository, JooqDSLContextWrapper dslContextWrapper, JdbcQueueConfiguration configuration,
+        @Nullable QueueChangeNotifier changeNotifier) {
         this.jdbcRepository = jdbcRepository;
         this.dslContextWrapper = dslContextWrapper;
         this.configuration = configuration;
+        this.changeNotifier = changeNotifier;
     }
 
     private boolean isUnsupportedUnicode(DataException e) {
@@ -82,6 +92,16 @@ public class JdbcQueueClient {
         return false;
     }
 
+    /**
+     * Normalizes a routing key the same way it is stored in the {@code routing_key} column
+     * (empty treated as absent), so the realtime wake-up signal targets the same partitioning as
+     * the data itself.
+     */
+    @Nullable
+    private static String normalizeRoutingKey(@Nullable String routingKey) {
+        return (routingKey == null || routingKey.isEmpty()) ? null : routingKey;
+    }
+
     public void publish(String queue, @Nullable String routingKey, String key, String value) throws QueueException {
         try {
             dslContextWrapper.transaction(configuration ->
@@ -90,7 +110,7 @@ public class JdbcQueueClient {
 
                 Map<Field<?>, Object> fields = HashMap.newHashMap(5);
                 fields.put(TYPE, queue);
-                fields.put(ROUTING_KEY, (routingKey == null || routingKey.isEmpty()) ? null : routingKey);
+                fields.put(ROUTING_KEY, normalizeRoutingKey(routingKey));
                 fields.put(KEY, key);
                 fields.put(VALUE, JdbcJsonbUtils.valueOf(value));
                 fields.put(CREATED, Instant.now());
@@ -100,6 +120,10 @@ public class JdbcQueueClient {
                     .set(fields);
 
                 insert.execute();
+
+                if (changeNotifier != null) {
+                    changeNotifier.notifyChange(configuration, queue, normalizeRoutingKey(routingKey));
+                }
             });
         } catch (DataException e) { // The exception is from the data itself, not the database/network/driver so instead of fail fast, we throw a recoverable QueueException
             // Postgres refuses JSONB payloads with unsupported Unicode escape sequences such as '\0000'
@@ -148,7 +172,7 @@ public class JdbcQueueClient {
                 for (PublishedMessage entry : messages) {
                     insert = insert.values(
                         entry.queue,
-                        (entry.routingKey == null || entry.routingKey.isEmpty()) ? null : entry.routingKey,
+                        normalizeRoutingKey(entry.routingKey),
                         entry.key,
                         JdbcJsonbUtils.valueOf(entry.value),
                         now
@@ -156,6 +180,16 @@ public class JdbcQueueClient {
                 }
 
                 insert.execute();
+
+                if (changeNotifier != null) {
+                    // One notification per distinct (queue, routingKey) pair in the batch: plain
+                    // dispatch/broadcast batches collapse to one per queue; VNode/keyed batches emit
+                    // one per distinct routing key actually present, so wake-ups stay targeted.
+                    messages.stream()
+                        .map(entry -> Pair.of(entry.queue, normalizeRoutingKey(entry.routingKey)))
+                        .distinct()
+                        .forEach(pair -> changeNotifier.notifyChange(configuration, pair.getLeft(), pair.getRight()));
+                }
             });
         } catch (DataException e) { // The exception is from the data itself, not the database/network/driver so instead of fail fast, we throw a recoverable QueueException
             // Postgres refuses JSONB payloads with unsupported Unicode escape sequences such as '\0000'
@@ -166,6 +200,23 @@ public class JdbcQueueClient {
             }
             throw new QueueException("Unable to emit a message to the queue", e);
         }
+    }
+
+    public @Nullable Long fetchMaxOffset(String queue) {
+        Long initialOffset = dslContextWrapper.transactionResult(conf ->
+        {
+            DSLContext context = DSL.using(conf);
+
+            // Filters identically to subscribeBroadcast/subscribeBroadcastBatch so the seeded
+            // offset and the poll queries always operate over the same row set.
+            return context.select(DSL.max(OFFSET))
+                .from(this.jdbcRepository.getTable())
+                .where(TYPE.eq(queue))
+                .and(ROUTING_KEY.isNull())
+                .fetchAny("max", Long.class);
+        });
+
+        return initialOffset != null ? initialOffset : 0L;
     }
 
     public Integer subscribeDispatch(String queue, @Nullable List<String> routingKeys, Consumer<byte[]> consumer) {
@@ -249,23 +300,6 @@ public class JdbcQueueClient {
 
             return result.size();
         });
-    }
-
-    public @Nullable Long fetchMaxOffset(String queue) {
-        Long initialOffset = dslContextWrapper.transactionResult(conf ->
-        {
-            DSLContext context = DSL.using(conf);
-
-            // Filters identically to subscribeBroadcast/subscribeBroadcastBatch so the seeded
-            // offset and the poll queries always operate over the same row set.
-            return context.select(DSL.max(OFFSET))
-                .from(this.jdbcRepository.getTable())
-                .where(TYPE.eq(queue))
-                .and(ROUTING_KEY.isNull())
-                .fetchAny("max", Long.class);
-        });
-
-        return initialOffset != null ? initialOffset : 0L;
     }
 
     protected Pair<Integer, Long> subscribeBroadcast(String queue, @Nullable Long maxOffset, Consumer<byte[]> consumer) {

--- a/queue-jdbc/src/main/java/io/kestra/queue/jdbc/client/JdbcQueueClient.java
+++ b/queue-jdbc/src/main/java/io/kestra/queue/jdbc/client/JdbcQueueClient.java
@@ -54,9 +54,10 @@ public class JdbcQueueClient {
     private final JdbcQueueConfiguration configuration;
 
     /**
-     * Notifies a realtime wake-up mechanism after a publish, so a waiting subscriber's poll loop
-     * can be woken early instead of waiting out its full backoff. Only present on Postgres; on
-     * other dialects this is {@code null} and publish behaves exactly as before.
+     * Notifies a realtime wake-up mechanism after a publish transaction commits, so a waiting
+     * subscriber's poll loop can be woken early instead of waiting out its full backoff. Only
+     * present on Postgres; on other dialects this is {@code null} and publish behaves exactly as
+     * before.
      */
     @Nullable
     private final QueueChangeNotifier changeNotifier;
@@ -120,11 +121,11 @@ public class JdbcQueueClient {
                     .set(fields);
 
                 insert.execute();
-
-                if (changeNotifier != null) {
-                    changeNotifier.notifyChange(configuration, queue, normalizeRoutingKey(routingKey));
-                }
             });
+
+            if (changeNotifier != null) {
+                changeNotifier.notifyChange(queue);
+            }
         } catch (DataException e) { // The exception is from the data itself, not the database/network/driver so instead of fail fast, we throw a recoverable QueueException
             // Postgres refuses JSONB payloads with unsupported Unicode escape sequences such as '\0000'
             // or lone UTF-16 surrogates. Convert those into a recoverable queue error.
@@ -180,17 +181,16 @@ public class JdbcQueueClient {
                 }
 
                 insert.execute();
-
-                if (changeNotifier != null) {
-                    // One notification per distinct (queue, routingKey) pair in the batch: plain
-                    // dispatch/broadcast batches collapse to one per queue; VNode/keyed batches emit
-                    // one per distinct routing key actually present, so wake-ups stay targeted.
-                    messages.stream()
-                        .map(entry -> Pair.of(entry.queue, normalizeRoutingKey(entry.routingKey)))
-                        .distinct()
-                        .forEach(pair -> changeNotifier.notifyChange(configuration, pair.getLeft(), pair.getRight()));
-                }
             });
+
+            if (changeNotifier != null) {
+                // One notification per distinct queue in the batch, regardless of routing key: the
+                // signal is a per-channel wake-up, not per-partition (see QueueChangeNotifier).
+                messages.stream()
+                    .map(PublishedMessage::queue)
+                    .distinct()
+                    .forEach(changeNotifier::notifyChange);
+            }
         } catch (DataException e) { // The exception is from the data itself, not the database/network/driver so instead of fail fast, we throw a recoverable QueueException
             // Postgres refuses JSONB payloads with unsupported Unicode escape sequences such as '\0000'
             // or lone UTF-16 surrogates. Convert those into a recoverable queue error.

--- a/queue-jdbc/src/main/java/io/kestra/queue/jdbc/client/JdbcSubscriber.java
+++ b/queue-jdbc/src/main/java/io/kestra/queue/jdbc/client/JdbcSubscriber.java
@@ -12,11 +12,22 @@ import io.kestra.core.utils.Either;
 import io.kestra.queue.AbstractPollingSubscriber;
 import io.kestra.queue.QueueService;
 import io.kestra.queue.poller.QueuePollerConfiguration;
+import io.kestra.queue.poller.QueueWaker;
+
+import jakarta.annotation.Nullable;
 
 public abstract class JdbcSubscriber<T extends Event> extends AbstractPollingSubscriber<T> {
     protected final JdbcQueueClient jdbcQueueClient;
     protected final String queueName;
 
+    @Nullable
+    private final QueueWakeRegistry wakeRegistry;
+
+    /**
+     * @deprecated use {@link #JdbcSubscriber(Class, QueueService, JdbcQueueClient, String, MetricRegistry, IgnoreExecutionService, QueueWakeRegistry)}
+     *             — kept so existing callers built against the pre-{@link QueueWakeRegistry} signature keep compiling; they simply get no realtime wake-up.
+     */
+    @Deprecated
     public JdbcSubscriber(
         Class<T> cls,
         QueueService queueService,
@@ -24,6 +35,17 @@ public abstract class JdbcSubscriber<T extends Event> extends AbstractPollingSub
         String queueName,
         MetricRegistry metricRegistry,
         IgnoreExecutionService ignoreExecutionService) {
+        this(cls, queueService, jdbcQueueClient, queueName, metricRegistry, ignoreExecutionService, null);
+    }
+
+    public JdbcSubscriber(
+        Class<T> cls,
+        QueueService queueService,
+        JdbcQueueClient jdbcQueueClient,
+        String queueName,
+        MetricRegistry metricRegistry,
+        IgnoreExecutionService ignoreExecutionService,
+        @Nullable QueueWakeRegistry wakeRegistry) {
         super(
             cls, queueName, queueService, metricRegistry, ignoreExecutionService, new QueuePollerConfiguration(
                 jdbcQueueClient.getConfiguration().minPollInterval(),
@@ -37,9 +59,24 @@ public abstract class JdbcSubscriber<T extends Event> extends AbstractPollingSub
 
         this.jdbcQueueClient = jdbcQueueClient;
         this.queueName = queueName;
+        this.wakeRegistry = wakeRegistry;
     }
 
     protected abstract void init();
+
+    /**
+     * Routing keys this subscriber owns, used to target the realtime wake-up signal (see
+     * {@link QueueWakeRegistry}). Empty means "every routing key for this queue" (plain dispatch,
+     * broadcast). Overridden by keyed/VNode dispatch subscribers, which own a partition.
+     */
+    protected List<String> ownedRoutingKeys() {
+        return List.of();
+    }
+
+    @Override
+    protected QueueWaker waker() {
+        return wakeRegistry != null ? wakeRegistry.waker(queueName, ownedRoutingKeys()) : super.waker();
+    }
 
     @Override
     public QueueSubscriber<T> subscribe(Consumer<Either<T, DeserializationException>> consumer) {

--- a/queue-jdbc/src/main/java/io/kestra/queue/jdbc/client/JdbcSubscriber.java
+++ b/queue-jdbc/src/main/java/io/kestra/queue/jdbc/client/JdbcSubscriber.java
@@ -64,18 +64,9 @@ public abstract class JdbcSubscriber<T extends Event> extends AbstractPollingSub
 
     protected abstract void init();
 
-    /**
-     * Routing keys this subscriber owns, used to target the realtime wake-up signal (see
-     * {@link QueueWakeRegistry}). Empty means "every routing key for this queue" (plain dispatch,
-     * broadcast). Overridden by keyed/VNode dispatch subscribers, which own a partition.
-     */
-    protected List<String> ownedRoutingKeys() {
-        return List.of();
-    }
-
     @Override
     protected QueueWaker waker() {
-        return wakeRegistry != null ? wakeRegistry.waker(queueName, ownedRoutingKeys()) : super.waker();
+        return wakeRegistry != null ? wakeRegistry.waker(queueName) : super.waker();
     }
 
     @Override

--- a/queue-jdbc/src/main/java/io/kestra/queue/jdbc/client/QueueChangeNotifier.java
+++ b/queue-jdbc/src/main/java/io/kestra/queue/jdbc/client/QueueChangeNotifier.java
@@ -1,0 +1,29 @@
+package io.kestra.queue.jdbc.client;
+
+import org.jooq.Configuration;
+
+import jakarta.annotation.Nullable;
+
+/**
+ * Notifies a realtime wake-up mechanism (if the underlying JDBC backend supports one) that a
+ * message was published, so subscribers waiting on a {@link io.kestra.queue.poller.QueueWaker}
+ * can be woken before their next scheduled poll. Only Postgres provides an implementation (via
+ * {@code LISTEN}/{@code NOTIFY}); the bean is absent for other dialects, in which case
+ * {@link JdbcQueueClient} skips the call entirely and subscribers fall back to plain polling.
+ * <p>
+ * This is a pure latency optimization: the caller must remain correct if the notification is
+ * silently lost (e.g. no active listener, or a listener reconnecting), since durable delivery is
+ * guaranteed by the poll + transactional ack path regardless.
+ */
+public interface QueueChangeNotifier {
+    /**
+     * Signals that a message was published to {@code queueName} (and, for keyed/VNode dispatch
+     * queues, partitioned by {@code routingKey}), using the same transaction as the INSERT so the
+     * signal is only observable once the message is durably committed.
+     *
+     * @param configuration the jOOQ transaction configuration the INSERT ran in
+     * @param queueName the published queue name
+     * @param routingKey the message's routing key, or {@code null}/empty for plain dispatch and broadcast
+     */
+    void notifyChange(Configuration configuration, String queueName, @Nullable String routingKey);
+}

--- a/queue-jdbc/src/main/java/io/kestra/queue/jdbc/client/QueueChangeNotifier.java
+++ b/queue-jdbc/src/main/java/io/kestra/queue/jdbc/client/QueueChangeNotifier.java
@@ -1,9 +1,5 @@
 package io.kestra.queue.jdbc.client;
 
-import org.jooq.Configuration;
-
-import jakarta.annotation.Nullable;
-
 /**
  * Notifies a realtime wake-up mechanism (if the underlying JDBC backend supports one) that a
  * message was published, so subscribers waiting on a {@link io.kestra.queue.poller.QueueWaker}
@@ -12,18 +8,18 @@ import jakarta.annotation.Nullable;
  * {@link JdbcQueueClient} skips the call entirely and subscribers fall back to plain polling.
  * <p>
  * This is a pure latency optimization: the caller must remain correct if the notification is
- * silently lost (e.g. no active listener, or a listener reconnecting), since durable delivery is
- * guaranteed by the poll + transactional ack path regardless.
+ * silently lost or coalesced away (e.g. no active listener, a listener reconnecting, or a
+ * rate-limiting implementation dropping a redundant signal), since durable delivery is guaranteed
+ * by the poll + transactional ack path regardless.
  */
 public interface QueueChangeNotifier {
     /**
-     * Signals that a message was published to {@code queueName} (and, for keyed/VNode dispatch
-     * queues, partitioned by {@code routingKey}), using the same transaction as the INSERT so the
-     * signal is only observable once the message is durably committed.
+     * Signals that at least one message was published to {@code queueName}. Called after the
+     * publish transaction has committed, so a woken subscriber is guaranteed to see the row (and,
+     * unlike an in-transaction signal, the notification never contends with the transaction's own
+     * commit).
      *
-     * @param configuration the jOOQ transaction configuration the INSERT ran in
      * @param queueName the published queue name
-     * @param routingKey the message's routing key, or {@code null}/empty for plain dispatch and broadcast
      */
-    void notifyChange(Configuration configuration, String queueName, @Nullable String routingKey);
+    void notifyChange(String queueName);
 }

--- a/queue-jdbc/src/main/java/io/kestra/queue/jdbc/client/QueueWakeRegistry.java
+++ b/queue-jdbc/src/main/java/io/kestra/queue/jdbc/client/QueueWakeRegistry.java
@@ -1,7 +1,5 @@
 package io.kestra.queue.jdbc.client;
 
-import java.util.List;
-
 import io.kestra.queue.poller.QueueWaker;
 
 /**
@@ -13,10 +11,8 @@ import io.kestra.queue.poller.QueueWaker;
 public interface QueueWakeRegistry {
     /**
      * @param queueName the queue this subscriber polls
-     * @param routingKeys the routing keys this subscriber owns (empty = the subscriber consumes
-     *        every routing key for this queue, e.g. plain dispatch or broadcast)
-     * @return a waker woken early when a matching message is published, still bounded by the
-     *         caller's own backoff as a fallback
+     * @return a waker woken early when a message is published to {@code queueName}, still bounded
+     *         by the caller's own backoff as a fallback
      */
-    QueueWaker waker(String queueName, List<String> routingKeys);
+    QueueWaker waker(String queueName);
 }

--- a/queue-jdbc/src/main/java/io/kestra/queue/jdbc/client/QueueWakeRegistry.java
+++ b/queue-jdbc/src/main/java/io/kestra/queue/jdbc/client/QueueWakeRegistry.java
@@ -1,0 +1,22 @@
+package io.kestra.queue.jdbc.client;
+
+import java.util.List;
+
+import io.kestra.queue.poller.QueueWaker;
+
+/**
+ * Supplies a {@link QueueWaker} that a JDBC subscriber's poll loop waits on between two polls,
+ * backed by a realtime wake-up mechanism (Postgres {@code LISTEN}/{@code NOTIFY}). Only present
+ * for dialects that support one; absent otherwise, in which case subscribers fall back to the
+ * default sleep-based {@link QueueWaker#SLEEP}.
+ */
+public interface QueueWakeRegistry {
+    /**
+     * @param queueName the queue this subscriber polls
+     * @param routingKeys the routing keys this subscriber owns (empty = the subscriber consumes
+     *        every routing key for this queue, e.g. plain dispatch or broadcast)
+     * @return a waker woken early when a matching message is published, still bounded by the
+     *         caller's own backoff as a fallback
+     */
+    QueueWaker waker(String queueName, List<String> routingKeys);
+}

--- a/queue/src/main/java/io/kestra/queue/AbstractPollingSubscriber.java
+++ b/queue/src/main/java/io/kestra/queue/AbstractPollingSubscriber.java
@@ -12,6 +12,7 @@ import io.kestra.core.services.IgnoreExecutionService;
 import io.kestra.core.utils.Either;
 import io.kestra.queue.poller.QueuePoller;
 import io.kestra.queue.poller.QueuePollerConfiguration;
+import io.kestra.queue.poller.QueueWaker;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -33,14 +34,14 @@ public abstract class AbstractPollingSubscriber<T extends Event> extends Abstrac
 
     @Override
     public QueueSubscriber<T> subscribe(Consumer<Either<T, DeserializationException>> consumer) {
-        QueuePoller queuePoller = new QueuePoller(configuration, () -> this.poll(message -> processMessage(message, consumer)));
+        QueuePoller queuePoller = new QueuePoller(configuration, () -> this.poll(message -> processMessage(message, consumer)), waker());
 
         return internalSubscribe(queuePoller);
     }
 
     @Override
     public QueueSubscriber<T> subscribeBatch(Consumer<List<Either<T, DeserializationException>>> consumer) {
-        QueuePoller queuePoller = new QueuePoller(configuration, () -> this.pollBatch(message -> processBatchMessages(message, consumer)));
+        QueuePoller queuePoller = new QueuePoller(configuration, () -> this.pollBatch(message -> processBatchMessages(message, consumer)), waker());
 
         return internalSubscribe(queuePoller);
     }
@@ -54,6 +55,16 @@ public abstract class AbstractPollingSubscriber<T extends Event> extends Abstrac
      * Poll a batch of messages from the database or the message broker and consume it.
      */
     protected abstract Integer pollBatch(Consumer<List<byte[]>> messageConsumer);
+
+    /**
+     * The strategy used to wait between two poll attempts when the previous poll returned nothing.
+     * Defaults to a plain sleep. Backends that support a realtime wake-up mechanism (e.g. Postgres
+     * {@code LISTEN}/{@code NOTIFY}) should override this to shorten the wait on a notification,
+     * without ever exceeding the configured backoff (see {@link QueueWaker}).
+     */
+    protected QueueWaker waker() {
+        return QueueWaker.SLEEP;
+    }
 
     private QueueSubscriber<T> internalSubscribe(QueuePoller queuePoller) {
         this.queueService.execute(() ->

--- a/queue/src/main/java/io/kestra/queue/poller/QueuePoller.java
+++ b/queue/src/main/java/io/kestra/queue/poller/QueuePoller.java
@@ -14,17 +14,34 @@ import java.util.concurrent.Callable;
 public class QueuePoller {
     private final QueuePollerConfiguration configuration;
     private final Callable<Integer> pollingQuery;
+    private final QueueWaker waker;
 
     /**
-     * Creates a new {@link QueuePoller} instance.
+     * Creates a new {@link QueuePoller} instance that waits between polls with a plain sleep.
      *
      * @param configuration the {@link QueuePollerConfiguration}.
      * @param pollingQuery the query to be executed.
      */
     public QueuePoller(final QueuePollerConfiguration configuration,
         final Callable<Integer> pollingQuery) {
+        this(configuration, pollingQuery, QueueWaker.SLEEP);
+    }
+
+    /**
+     * Creates a new {@link QueuePoller} instance.
+     *
+     * @param configuration the {@link QueuePollerConfiguration}.
+     * @param pollingQuery the query to be executed.
+     * @param waker the strategy used to wait between two poll attempts when nothing was polled;
+     *        pass {@link QueueWaker#SLEEP} for a plain backoff, or a notification-aware
+     *        implementation to shorten the wait on a realtime wake-up (see {@link QueueWaker}).
+     */
+    public QueuePoller(final QueuePollerConfiguration configuration,
+        final Callable<Integer> pollingQuery,
+        final QueueWaker waker) {
         this.configuration = Objects.requireNonNull(configuration);
         this.pollingQuery = Objects.requireNonNull(pollingQuery);
+        this.waker = Objects.requireNonNull(waker);
     }
 
     /**
@@ -59,7 +76,10 @@ public class QueuePoller {
             sleep = selectedSteps.isEmpty() ? configuration.minPollInterval() : selectedSteps.getLast().pollInterval();
         }
 
-        Thread.sleep(sleep);
+        // waker.await() honors `sleep` as a hard upper bound: a notification-aware waker may return
+        // earlier on a realtime wake-up, but never later, so a missed notification still results in
+        // a poll at the usual backoff cadence (see QueueWaker).
+        waker.await(sleep);
 
         return lastPoll;
     }

--- a/queue/src/main/java/io/kestra/queue/poller/QueueWaker.java
+++ b/queue/src/main/java/io/kestra/queue/poller/QueueWaker.java
@@ -1,0 +1,30 @@
+package io.kestra.queue.poller;
+
+import java.time.Duration;
+
+/**
+ * Strategy used by {@link QueuePoller} to wait between two poll attempts when the previous poll
+ * returned no message.
+ * <p>
+ * The default implementation ({@link #SLEEP}) simply sleeps for the requested duration. Backends
+ * that support a push notification mechanism (e.g. Postgres {@code LISTEN}/{@code NOTIFY}) can
+ * supply an implementation that returns early once a notification arrives, cutting the wait short
+ * for lower latency, while still honoring {@code max} as a fallback: a poller must never block
+ * longer than the configured backoff, so a missed notification still results in a poll at the
+ * usual cadence — the notification is a latency optimization only, never the delivery mechanism.
+ */
+public interface QueueWaker {
+    /**
+     * A waker that simply sleeps for the given duration. Used when no realtime wake-up mechanism
+     * is available for the underlying backend.
+     */
+    QueueWaker SLEEP = Thread::sleep;
+
+    /**
+     * Waits at most {@code max} before returning, so the caller can re-poll.
+     *
+     * @param max the maximum duration to wait
+     * @throws InterruptedException if interrupted while waiting
+     */
+    void await(Duration max) throws InterruptedException;
+}


### PR DESCRIPTION
## Summary

- Adds a Postgres-only `LISTEN`/`NOTIFY` wake-up layer on top of the JDBC queue's existing poll + transactional-ack delivery, so subscribers react to new messages with near-realtime latency instead of only checking on the poll cadence (default 25ms–500ms).
- `NOTIFY` is a pure latency optimization: the durable delivery path (SELECT ... FOR UPDATE SKIP LOCKED + DELETE for dispatch queues, offset cursor for broadcast) is completely unchanged. A missed notification (listener down, reconnecting, or a channel not yet registered) simply falls back to the regular poll — no message can be lost because of this change.
- One Postgres `NOTIFY` channel per queue name (`kestra_queue_<name>`), not a single shared channel, so a process's one dedicated `LISTEN` connection only receives notifications for queues it actually consumes (server-side filtering).
- The `NOTIFY` payload carries the message's routing key, so a VNode/keyed-dispatch subscriber that owns only a subset of routing keys can skip waking for irrelevant partitions (best-effort only, never required for correctness).
- New `QueueWaker`/`QueueChangeNotifier`/`QueueWakeRegistry` extension points live in the dialect-agnostic `queue`/`queue-jdbc` modules, always nullable and defaulting to plain `Thread.sleep` — **H2 and MySQL are behaviorally unchanged** (verified: full `jdbc-h2`/`jdbc-mysql` test suites pass with 0 failures).
- All Postgres-only beans (`PgQueueListener`, `PgQueueSignalRegistry`, `PostgresQueueChangeNotifier`) are gated by the existing `@PostgresQueueEnabled` marker (`kestra.queue.type=postgres`).
- Every affected constructor gained an additive, backward-compatible overload (old constructor `@Deprecated`, delegates with `null`), so existing EE callers (`queue-ee-jdbc`) keep compiling unchanged — EE queues simply don't get the realtime wake-up yet (follow-up work, out of scope here).

## Test plan

- [x] New unit test `PgQueueSignalRegistryTest` — routing-key targeting, wake-all semantics, coalescing, `signalAll` bypass (no DB, deterministic).
- [x] New integration test `PostgresQueueNotifyLatencyTest` — proves a message is delivered well under a deliberately slow poll backoff (2s–5s), demonstrating the NOTIFY path actually wakes the subscriber early.
- [x] New integration test `PostgresQueueNotifyFallbackTest` — stops `PgQueueListener` before publishing and confirms the message is still delivered via the regular poll (no-loss guarantee).
- [x] Existing regression suite unaffected: `PostgresDispatchQueueTest`, `PostgresBroadcastQueueTest`, `PostgresVNodeDispatchQueueTest`, `PostgresKeyedDispatchQueueTest`, `PostgresJdbcQueueCleanerTest`, `queue`'s own `QueuePollerTest`/`AbstractPollingSubscriberTest` all pass.
- [x] Full `jdbc-h2:test` (959 tests) and `jdbc-mysql:test` (831 tests) suites pass with 0 failures — confirms the shared `QueueWaker` default is inert for other dialects.
- [x] Independent code review pass; one real issue found and fixed (a narrow `connect()`/`close()` race in `PgQueueListener` that could leak a raw Postgres connection on shutdown timing) — see the fix commit history in this branch.