### PR TITLE
fix: recompute trigger scheduling on importFlow (fixes #17479)

### DIFF
--- a/core/src/main/java/io/kestra/core/services/FlowService.java
+++ b/core/src/main/java/io/kestra/core/services/FlowService.java
@@ -444,9 +444,15 @@ public class FlowService {
                 )
                 .orElseGet(() -> FlowWithSource.of(flowToImport, source).toBuilder().tenantId(tenantId).revision(1).build());
         } else {
-            return maybeExisting
+            FlowWithSource saved = maybeExisting
                 .map(previous -> flowRepository.update(flow, previous))
                 .orElseGet(() -> flowRepository.create(flow));
+            try {
+                impactDownstreamConsumers(saved);
+            } catch (QueueException e) {
+                throw new FlowProcessingException(e.getMessage(), e);
+            }
+            return saved;
         }
     }
 

--- a/core/src/test/java/io/kestra/core/services/FlowServiceTest.java
+++ b/core/src/test/java/io/kestra/core/services/FlowServiceTest.java
@@ -229,6 +229,27 @@ class FlowServiceTest {
     }
 
     @Test
+    void importFlow_ShouldEmitTriggerCreatedEventForNewTriggerInSyncedFlow() throws FlowProcessingException, QueueException {
+        reset(triggerEventQueue);
+
+    String source = """
+        id: import_with_trigger
+        namespace: some.namespace
+        triggers:
+          - id: daily
+            type: io.kestra.plugin.core.trigger.Schedule
+            cron: "0 6 * * *"
+        tasks:
+          - id: task
+            type: io.kestra.plugin.core.log.Log
+            message: Hello""";
+
+    flowService.importFlow("my-tenant", source);
+    verify(triggerEventQueue).send(any());
+    
+    }
+
+    @Test
     void findByNamespacePrefix() {
         FlowWithSource exactMatch = create(null, "prefix.namespace", "prefixExact", "test", 1);
         flowRepository.create(GenericFlow.of(exactMatch));


### PR DESCRIPTION
 Fixes https://github.com/kestra-io/kestra/issues/17479

### Description

Flows created via `FlowService.importFlow()`, used both by the `SyncFlows` plugin task and the webserver's `/import` (bulk import) endpoint, never had their triggers registered with the scheduler correctly.

Root cause: `importFlow()`'s non-dry-run branch called `flowRepository.update()`/`flowRepository.create()` directly, bypassing `impactDownstreamConsumers()`, the method that fires the `TriggerCreated`/`TriggerUpdated` events consumed by `TriggerEventHandler` to compute each trigger's `next_evaluation_epoch`.

As a result, a trigger on a flow imported this way would appear in the Triggers UI, but with no `Next evaluation date`, and would never actually fire until the flow was manually edited and re-saved through the normal UI update path (which does call `impactDownstreamConsumers()`).

This fix calls `impactDownstreamConsumers()` after `importFlow()` creates/updates the flow, matching the existing behavior in `create()`/`update()`.

Trigger imported, schedule computed immediately:

<img width="1568" height="402" alt="after" src="https://github.com/user-attachments/assets/145d49c4-b59b-4ad5-9e43-5368abe187b2" />

###  Related Issue

 Closes https://github.com/kestra-io/kestra/issues/17479

###  Additional Notes
- Added a regression test (`importFlow_ShouldEmitTriggerCreatedEventForNewTriggerInSyncedFlow`) verifying `importFlow()` now fires the same trigger event `create()`/`update()` do.
- Verified manually via the UI's Import feature (both a hand-written flow and the exact flow file used to reproduce the original issue) trigger scheduling now populates immediately on import, no manual re-save needed.
- I wasn't able to test the literal `SyncFlows` git-sync path locally due to a plugin/core version mismatch when adding `plugin-git` to my local dev build, but `SyncFlows` calls the exact same `FlowService.importFlow()` method (confirmed by reading the plugin-git source at the version bundled with the reported `kestra:v2.0.0-rc5` image), so the fix applies identically to that path.