### PR TITLE
fix(docs): remove broken demo video from the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,12 +74,6 @@ Kestra is an open-source, event-driven orchestration platform for data, AI, and 
 🧑‍💻 The YAML definition gets automatically adjusted any time you make changes to a workflow from the UI or via an API call. Therefore, the orchestration logic is **always managed declaratively in code**, even if you modify your workflows in other ways (UI, CI/CD, Terraform, API calls).
 
 
-<p align="center">
-  <video src="https://github.com/user-attachments/assets/8bb47d22-848d-4281-a0ca-9790803ce1ea" autoplay loop muted playsinline width="640">
-    Your browser does not support the video tag. <a href="https://go.kestra.io/video/product-overview">Watch the demo here</a>.
-  </video>
-</p>
-
 ---
 
 ## 🚀 Quick Start


### PR DESCRIPTION
## What

Closes #17529.

The `<video>` element right above **Quick Start** points at `https://github.com/user-attachments/assets/8bb47d22-…`, which returns **404** (verified with curl), so the README renders a broken player.

## Why remove rather than replace

The exact same product demo is already presented ~40 lines above through the working pattern this README uses — the clickable `startvideo.png` thumbnail linking to `go.kestra.io/video/product-overview` (both URLs verified 200). A second embed of the same demo adds nothing once its asset is gone, and user-attachment video assets can only be re-created by a maintainer uploading through the GitHub UI, so a like-for-like replacement isn't something an external PR can supply. If you'd rather re-embed a fresh clip (or move one into an `/assets` dir as the issue suggests), happy to rework this on top of an uploaded asset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)