### PR TITLE
fix(core): show copy confirmation on copy

### DIFF
--- a/ui/src/components/kv/KVTable.vue
+++ b/ui/src/components/kv/KVTable.vue
@@ -96,7 +96,7 @@
                     v-if="scope.row.key !== undefined"
                     :tooltip="$t('copy_to_clipboard')"
                     placement="left"
-                    @click="Utils.copy(`\{\{ kv('${scope.row.key}') \}\}`)"
+                    @click="copyKey(scope.row.key)"
                 >
                     <ContentCopy />
                 </KsIconButton>
@@ -620,6 +620,11 @@
             description: entry.description,
         }
         viewKvDrawerVisible.value = true
+    }
+
+    async function copyKey(key: string) {
+        await Utils.copy(`{{ kv('${key}') }}`)
+        toast.success(t("copied"))
     }
 
     function removeKv(namespace: string, key: string) {


### PR DESCRIPTION
## What

The KV Store "Copy to Clipboard" row action gave no visible confirmation after copying (#17352). This routes the button through a small `copyKey` handler that fires the app's standard "Copied" success toast after the clipboard write, so a successful copy is confirmed the same way it is elsewhere in the UI.

## Details

- `ui/src/components/kv/KVTable.vue`: the copy `KsIconButton` called `Utils.copy(...)` directly. `Utils.copy` only writes to the clipboard and returns no feedback, so this button had none.
- New handler:
  ```ts
  async function copyKey(key: string) {
      await Utils.copy(`{{ kv('${key}') }}`)
      toast.success(t("copied"))
  }
  ```
  The copied value is unchanged (the previous `\{`/`\}` were no-op escapes inside the template literal). `toast` (`useToast`) and `t` were already wired into this component, and the `copied` translation key already exists.
- Mirrors the existing copy-confirmation pattern used in `ui/src/components/executions/Gantt.vue` and `.../overview/components/Banner.vue` rather than introducing a new toast style. I deliberately did not reuse `CopyToClipboard.vue`'s click tooltip here, because the button already renders a hover tooltip at the same placement (they would collide) and that component is absolutely-positioned for code overlays, not table cells.

## Verification

`npm run check:types` (vue-tsc build of design-system + app + test), `oxlint`, and `eslint` on the changed file all pass. I couldn't click the button in a browser in this environment, so the toast wasn't visually observed — it's verified by types/lint and by mirroring an existing working pattern.

Closes #17352.

---

*AI disclosure: this PR was drafted with Claude Code (AI-assisted). The change mirrors an existing app pattern; I verified it with the project's type-check and lint (both pass).*
