### PR TITLE
fix(ai): order the copilot mode selector by capability

### DIFF
--- a/ui/src/components/ai/copilot/CopilotComposer.vue
+++ b/ui/src/components/ai/copilot/CopilotComposer.vue
@@ -155,11 +155,12 @@
     const draft = defineModel<string>({default: ""})
     const textareaEl = ref<HTMLTextAreaElement>()
 
-    // Values are the backend Mode enum; icons match the Figma mode pills.
+    // Values are the backend Mode enum; icons match the Figma mode pills. Ordered by increasing
+    // capability, matching the backend's cumulative tool families (Ask ⊂ Plan ⊂ Edit).
     const modeOptions = computed<{label: string; value: Mode; icon: Component}[]>(() => [
         {label: t("ai.copilot.mode.ask"), value: "ASK", icon: ChatQuestionOutline},
-        {label: t("ai.copilot.mode.edit"), value: "EDIT", icon: Wrench},
         {label: t("ai.copilot.mode.plan"), value: "PLAN", icon: MapOutline},
+        {label: t("ai.copilot.mode.edit"), value: "EDIT", icon: Wrench},
     ])
 
     const currentMode = computed(() => modeOptions.value.find((o) => o.value === props.mode))

--- a/ui/src/components/ai/copilot/types.ts
+++ b/ui/src/components/ai/copilot/types.ts
@@ -1,10 +1,12 @@
 /**
  * Wire types for the AI Copilot v2 agentic loop.
  *
- * These mirror the backend DTOs on branch `feat/ai-copilot-v2-agentic-loop`:
- *   - io.kestra.webserver.services.ai.agent.dto.AgentDtos
- *   - io.kestra.webserver.services.ai.agent.dto.AgentEvents
- *   - io.kestra.webserver.services.ai.agent.domain.{Mode,ThreadStatus,ScopeBinding,ToolCall,...}
+ * These mirror the backend types on branch `feat/ai-copilot-v2-agentic-loop`:
+ *   - io.kestra.webserver.services.ai.agent.data.{ApiChatTurnRequest, ApiThreadDetail, ApiThreadSummary, AgentEvents}
+ *   - io.kestra.core.ai.agent.models.{AgentMode, AgentThreadStatus, AgentToolCall, …}
+ *
+ * (ScopeBinding is now frontend-local — used by routeScope.ts to build the free-form
+ * `additionalContext`; the backend no longer has a structured in-focus type.)
  *
  * Keep this file in sync with those records — it is the single source of truth
  * for the shapes the frontend exchanges with `…/ai/threads`.

--- a/ui/tests/unit/components/ai/copilot/CopilotComposer.spec.ts
+++ b/ui/tests/unit/components/ai/copilot/CopilotComposer.spec.ts
@@ -10,9 +10,9 @@ const input = (w: ReturnType<typeof mountComposer>) => w.find("[data-test=\"copi
 const sendBtn = (w: ReturnType<typeof mountComposer>) => w.find("[data-test=\"copilot-send\"]")
 
 describe("CopilotComposer", () => {
-    it("offers the three modes (Ask / Edit / Plan)", () => {
+    it("offers the three modes ordered by capability (Ask / Plan / Edit)", () => {
         const labels = mountComposer().findAll(".ks-dropdown-item").map((b) => b.text())
-        expect(labels).toEqual(["Ask", "Edit", "Plan"])
+        expect(labels).toEqual(["Ask", "Plan", "Edit"])
     })
 
     it("disables send until there is non-whitespace input", async () => {
@@ -48,8 +48,8 @@ describe("CopilotComposer", () => {
 
     it("relays mode changes from the dropdown via update:mode", async () => {
         const w = mountComposer()
-        // The dropdown items are Ask / Edit / Plan; clicking "Plan" emits PLAN.
-        await w.findAll(".ks-dropdown-item")[2].trigger("click")
+        // The dropdown items are Ask / Plan / Edit; clicking "Plan" (index 1) emits PLAN.
+        await w.findAll(".ks-dropdown-item")[1].trigger("click")
         expect(w.emitted("update:mode")?.[0]).toEqual(["PLAN"])
     })
 


### PR DESCRIPTION
Lists the copilot modes as **Ask · Plan · Edit** (increasing capability) instead of Ask · Edit · Plan, matching the backend's now-cumulative tool families (`ASK` ⊂ `PLAN` ⊂ `EDIT`, per `4206c03e` moving ACT tools PLAN→EDIT).

Also refreshes the `types.ts` header comment to the current backend package paths (`…agent.data.*` / `io.kestra.core.ai.agent.models.*`) and notes `ScopeBinding` is now FE-local.

Targets `feat/ai-copilot-v2-agentic-loop`.