### PR TITLE
feat(ai): show a tool's arguments on copilot confirmation cards

### DIFF
--- a/ui/src/components/ai/copilot/ProposedActionCard.vue
+++ b/ui/src/components/ai/copilot/ProposedActionCard.vue
@@ -19,6 +19,14 @@
                 </li>
             </ol>
             <KsText v-else size="small" class="proposed-action-summary">{{ action.summary }}</KsText>
+
+            <!-- Identifying arguments (namespace/flowId, executionId, …) so the user sees the target. -->
+            <dl v-if="argEntries.length" class="proposed-action-args" data-test="copilot-proposed-args">
+                <div v-for="[key, value] in argEntries" :key="key" class="proposed-action-arg">
+                    <dt class="proposed-action-arg-key">{{ key }}</dt>
+                    <dd class="proposed-action-arg-value">{{ value }}</dd>
+                </div>
+            </dl>
         </div>
 
         <div class="proposed-action-footer">
@@ -68,6 +76,22 @@
     const title = computed(
         () => props.action.title ?? t(isPlan.value ? "ai.copilot.confirm.planTitle" : "ai.copilot.confirm.actionTitle"),
     )
+
+    /** Longest scalar arg we'll show inline — anything above is a verbose payload (e.g. a YAML body). */
+    const MAX_ARG_LENGTH = 120
+
+    /**
+     * The identifying arguments to show under the summary, so the user sees exactly what will run
+     * (e.g. namespace/flowId, executionId). Scalars only — objects/arrays and long values (YAML/source
+     * bodies) are omitted to keep the card compact. Empty for plan cards (no concrete tool call).
+     */
+    const argEntries = computed<[string, string][]>(() => {
+        if (isPlan.value || !props.action.arguments) return []
+        return Object.entries(props.action.arguments)
+            .filter(([, value]) => typeof value === "string" || typeof value === "number" || typeof value === "boolean")
+            .map(([key, value]) => [key, String(value)] as [string, string])
+            .filter(([, value]) => value.length > 0 && value.length <= MAX_ARG_LENGTH)
+    })
 </script>
 
 <style scoped>
@@ -116,6 +140,33 @@
         display: block;
         white-space: pre-line;
         --kel-text-color: var(--ks-text-secondary);
+    }
+
+    .proposed-action-args {
+        margin: var(--ks-spacing-2) 0 0;
+        display: flex;
+        flex-direction: column;
+        gap: var(--ks-spacing-1);
+    }
+
+    .proposed-action-arg {
+        display: flex;
+        gap: var(--ks-spacing-2);
+        font-size: var(--ks-font-size-xs);
+    }
+
+    .proposed-action-arg-key {
+        flex: 0 0 auto;
+        min-width: 5rem;
+        color: var(--ks-text-secondary);
+    }
+
+    .proposed-action-arg-value {
+        margin: 0;
+        min-width: 0;
+        font-family: var(--font-family-monospace, monospace);
+        color: var(--ks-text-primary);
+        word-break: break-word;
     }
 
     .proposed-action-steps {

--- a/ui/tests/unit/components/ai/copilot/ProposedActionCard.spec.ts
+++ b/ui/tests/unit/components/ai/copilot/ProposedActionCard.spec.ts
@@ -48,6 +48,29 @@ describe("ProposedActionCard", () => {
         expect(approve(w).text()).toBe("Approve")
     })
 
+    it("shows the tool's identifying arguments", () => {
+        const args = mountCard(mutateAction).find("[data-test=\"copilot-proposed-args\"]")
+        expect(args.exists()).toBe(true)
+        expect(args.text()).toContain("id")
+        expect(args.text()).toContain("exec-1")
+    })
+
+    it("omits verbose (long) and non-scalar arguments from the args list", () => {
+        const w = mountCard({
+            confirmationId: "c8", tool: "create-flow", family: "MUTATE", summary: "Create flow",
+            arguments: {namespace: "company.team", flowId: "my-flow", body: "id: my-flow\n".repeat(50), labels: ["a"]},
+        })
+        const args = w.find("[data-test=\"copilot-proposed-args\"]")
+        expect(args.text()).toContain("company.team")
+        expect(args.text()).toContain("my-flow")
+        expect(args.text()).not.toContain("labels") // array omitted
+        expect(args.text()).not.toContain("id: my-flow") // long YAML body omitted
+    })
+
+    it("shows no args block for a plan card", () => {
+        expect(mountCard(planAction).find("[data-test=\"copilot-proposed-args\"]").exists()).toBe(false)
+    })
+
     it("falls back to a generic plan title when none is provided", () => {
         const w = mountCard({confirmationId: "c3", tool: null, summary: "do things"})
         expect(w.text()).toContain("Proposed plan")


### PR DESCRIPTION
The proposed-action card showed only the backend `title` + `summary`. It now also lists the tool's **identifying scalar arguments** (namespace/flowId, executionId, …) under the summary, so the user sees exactly what a mutate/act tool (restart/start/replay-execution, create/update-flow, create/update-dashboard) will run against.

Arrays/objects and long values (YAML/source bodies) are omitted to keep the card compact; no new i18n (arg keys are technical identifiers). Plan cards are unaffected.

Targets `feat/ai-copilot-v2-agentic-loop`.