### PR TITLE
feat(ai): apply dashboard drafts and open app drafts from the copilot

### DIFF
--- a/ui/src/components/ai/copilot/CopilotArtefactDraft.vue
+++ b/ui/src/components/ai/copilot/CopilotArtefactDraft.vue
@@ -26,12 +26,15 @@
              KsMarkdown provides its own copy-to-clipboard control, so no separate copy button. -->
         <KsMarkdown class="copilot-draft-yaml" data-test="copilot-draft-yaml" :content="yamlBlock" />
 
-        <!-- Apply actions (flow drafts only): review in the editor, or save it directly. -->
-        <div v-if="draft.kind === 'FLOW'" class="copilot-draft-footer">
+        <!-- Apply actions. Flows + dashboards can be opened in the editor or applied directly. Apps
+             are EE-only: they can only be opened in the app editor (no direct apply), and only when
+             the EE app path is present — in OSS an app draft never occurs, so no actions show. -->
+        <div v-if="showActions" class="copilot-draft-footer">
             <KsButton size="small" data-test="copilot-draft-open" @click="openInEditor(draft)">
                 {{ t("ai.copilot.draft.openInEditor") }}
             </KsButton>
             <KsButton
+                v-if="draft.kind !== 'APP'"
                 size="small"
                 type="primary"
                 :disabled="!draft.valid || applying"
@@ -54,7 +57,12 @@
     const props = defineProps<{draft: ArtefactDraftEvent}>()
 
     const {t} = useI18n()
-    const {applying, openInEditor, apply} = useApplyDraft()
+    const {applying, appSupported, openInEditor, apply} = useApplyDraft()
+
+    // Flow + dashboard drafts always have actions; app drafts only when the EE app path is present.
+    const showActions = computed(
+        () => props.draft.kind === "FLOW" || props.draft.kind === "DASHBOARD" || (props.draft.kind === "APP" && appSupported),
+    )
 
     // Render the YAML as a fenced code block so KsMarkdown syntax-highlights it (matching the
     // assistant transcript), rather than showing it as flat monospace text.

--- a/ui/src/components/ai/copilot/useApplyDraft.ts
+++ b/ui/src/components/ai/copilot/useApplyDraft.ts
@@ -4,14 +4,17 @@ import {useI18n} from "vue-i18n"
 import {KsMessageBox} from "@kestra-io/design-system"
 import {flowYamlUtils as YAML_UTILS} from "@kestra-io/topology"
 import * as FlowsAPI from "@kestra-io/kestra-sdk/flows"
+import * as DashboardsAPI from "@kestra-io/kestra-sdk/dashboards"
+import {useAppDraftActions} from "override/components/ai/copilot/appDraftActions"
 import type {ArtefactDraftEvent} from "./types"
 
 /**
  * Actions for an AI-drafted artefact:
- *   - `openInEditor` — hand the drafted YAML to the flow-creation editor to review + save there.
- *   - `apply` — create (or update) the flow directly, behind a confirm.
+ *   - `openInEditor` — hand the drafted YAML to the matching creation editor to review + save there.
+ *   - `apply` — create (or update) the artefact directly, behind a confirm.
  *
- * Flow-only for now: apps have no OSS editor and dashboards use a separate store (future work).
+ * Handles flow and dashboard drafts (both OSS features today). Apps are EE-only — they have no OSS
+ * editor/API, and app drafts only ever occur in EE, so that path is added in `ui-ee`.
  */
 export function useApplyDraft() {
     const route = useRoute()
@@ -21,31 +24,48 @@ export function useApplyDraft() {
     /** True while a direct apply is in flight (disables the button). */
     const applying = ref(false)
 
-    /**
-     * (A) Open the drafted YAML in the flow-creation editor. Reuses the same `blueprintSourceYaml`
-     * handoff the "Use blueprint" / MCP-tool flows use — FlowCreate.vue seeds the editor from it.
-     */
+    // App drafts are EE-only; OSS reports them unsupported (no-op). EE shadows this via `override/`.
+    const appActions = useAppDraftActions()
+    const appSupported = appActions.supported
+
+    const tenantParam = (): Record<string, string | string[]> => (route.params.tenant ? {tenant: route.params.tenant} : {})
+
+    /** (A) Open the drafted YAML in the matching creation editor to review + save there. */
     function openInEditor(draft: ArtefactDraftEvent): void {
+        if (draft.kind === "APP") {
+            appActions.openInEditor(draft)
+            return
+        }
+        if (draft.kind === "DASHBOARD") {
+            // The dashboard create editor seeds its source from a `sourceYaml` query (see Create.vue).
+            router.push({name: "dashboards/create", query: {sourceYaml: draft.yaml}, params: {...tenantParam()}})
+            return
+        }
+        // FLOW: reuse the `blueprintSourceYaml` handoff FlowCreate.vue already understands.
         router.push({
             name: "flows/create",
             query: {blueprintId: "copilot-draft", blueprintSourceYaml: draft.yaml},
-            ...(route.params.tenant ? {params: {tenant: route.params.tenant}} : {}),
+            params: {...tenantParam()},
         })
     }
 
-    /** (B) Create or update the flow directly. Confirms first; wording depends on whether it exists. */
+    /** (B) Create (or update) the artefact directly. Confirms first; dispatches on the draft kind. */
     async function apply(draft: ArtefactDraftEvent): Promise<void> {
-        const {namespace, id} = parseFlowId(draft.yaml)
+        if (draft.kind === "DASHBOARD") {
+            await applyDashboard(draft)
+            return
+        }
+        await applyFlow(draft)
+    }
+
+    async function applyFlow(draft: ArtefactDraftEvent): Promise<void> {
+        const {namespace, id} = parseYaml(draft.yaml)
         if (!namespace || !id) {
             await KsMessageBox.alert(t("ai.copilot.draft.applyNoTarget"), t("ai.copilot.draft.applyTitle"), {type: "error"})
             return
         }
 
-        const confirmed = await KsMessageBox.confirm(
-            t("ai.copilot.draft.applyConfirm", {namespace, id}),
-            t("ai.copilot.draft.applyTitle"),
-            {type: "warning", confirmButtonText: t("ai.copilot.draft.apply"), cancelButtonText: t("cancel")},
-        ).then(() => true).catch(() => false)
+        const confirmed = await confirmApply(t("ai.copilot.draft.applyConfirm", {namespace, id}), t("ai.copilot.draft.applyTitle"))
         if (!confirmed) return
 
         applying.value = true
@@ -63,24 +83,61 @@ export function useApplyDraft() {
                 )
             }
             // Land on the applied flow so the result is visible.
-            router.push({
-                name: "flows/update",
-                params: {namespace, id, ...(route.params.tenant ? {tenant: route.params.tenant} : {})},
-            })
+            router.push({name: "flows/update", params: {namespace, id, ...tenantParam()}})
         } catch (e) {
-            const err = e as {response?: {data?: {message?: string}}; message?: string}
-            await KsMessageBox.alert(
-                err?.response?.data?.message ?? err?.message ?? t("ai.copilot.draft.applyError"),
-                t("ai.copilot.draft.applyTitle"),
-                {type: "error"},
-            )
+            await alertError(e, t("ai.copilot.draft.applyError"), t("ai.copilot.draft.applyTitle"))
         } finally {
             applying.value = false
         }
     }
 
-    /** Parse the flow's namespace + id out of its YAML; empty strings when it can't be read. */
-    function parseFlowId(yaml: string): {namespace: string; id: string} {
+    async function applyDashboard(draft: ArtefactDraftEvent): Promise<void> {
+        // Dashboards are tenant-scoped and identified by `id` alone (no namespace).
+        const {id} = parseYaml(draft.yaml)
+        if (!id) {
+            await KsMessageBox.alert(t("ai.copilot.draft.applyNoTarget"), t("ai.copilot.draft.applyTitleDashboard"), {type: "error"})
+            return
+        }
+
+        const confirmed = await confirmApply(t("ai.copilot.draft.applyConfirmDashboard", {id}), t("ai.copilot.draft.applyTitleDashboard"))
+        if (!confirmed) return
+
+        applying.value = true
+        try {
+            // Create, falling back to update if the id already exists — same no-probe rationale as flows.
+            try {
+                await DashboardsAPI.createDashboard(
+                    {body: draft.yaml, showMessageOnError: false} as Parameters<typeof DashboardsAPI.createDashboard>[0],
+                )
+            } catch (e) {
+                if (!isAlreadyExists(e)) throw e
+                await DashboardsAPI.updateDashboard(
+                    {id, body: draft.yaml, showMessageOnError: false} as Parameters<typeof DashboardsAPI.updateDashboard>[0],
+                )
+            }
+            router.push({name: "dashboards/update", params: {dashboard: id, ...tenantParam()}})
+        } catch (e) {
+            await alertError(e, t("ai.copilot.draft.applyErrorDashboard"), t("ai.copilot.draft.applyTitleDashboard"))
+        } finally {
+            applying.value = false
+        }
+    }
+
+    function confirmApply(message: string, title: string): Promise<boolean> {
+        return KsMessageBox.confirm(message, title, {
+            type: "warning",
+            confirmButtonText: t("ai.copilot.draft.apply"),
+            cancelButtonText: t("cancel"),
+        }).then(() => true).catch(() => false)
+    }
+
+    async function alertError(e: unknown, fallback: string, title: string): Promise<void> {
+        const err = e as {response?: {data?: {message?: string}}; message?: string}
+        await KsMessageBox.alert(err?.response?.data?.message ?? err?.message ?? fallback, title, {type: "error"})
+    }
+
+    /** Parse an artefact's namespace + id out of its YAML; empty strings when they can't be read. */
+    function parseYaml(yaml: string): {namespace: string; id: string} {
         try {
             const parsed = YAML_UTILS.parse(yaml)
             return {namespace: parsed?.namespace ?? "", id: parsed?.id ?? ""}
@@ -89,11 +146,11 @@ export function useApplyDraft() {
         }
     }
 
-    /** A create failed because the flow already exists (→ update instead), mirroring the flow store. */
+    /** A create failed because the artefact already exists (→ update instead). */
     function isAlreadyExists(e: unknown): boolean {
         const err = e as {response?: {status?: number; data?: {message?: string}}}
-        return err?.response?.status === 422 && !!err?.response?.data?.message?.includes("Flow id already exists")
+        return err?.response?.status === 422 && /already exists/i.test(err?.response?.data?.message ?? "")
     }
 
-    return {applying, openInEditor, apply}
+    return {applying, appSupported, openInEditor, apply}
 }

--- a/ui/src/components/dashboard/components/Create.vue
+++ b/ui/src/components/dashboard/components/Create.vue
@@ -61,9 +61,12 @@
     onMounted(async () => {
         dashboardStore.isCreating = true
 
-        const {blueprintId, name, params} = route.query
+        const {blueprintId, name, params, sourceYaml} = route.query
 
-        if (blueprintId) {
+        if (sourceYaml) {
+            // Seed directly from a handed-off source (e.g. an AI Copilot dashboard draft).
+            dashboardStore.sourceCode = sourceYaml as string
+        } else if (blueprintId) {
             dashboardStore.sourceCode = await blueprintsStore.getBlueprintSource({type: "community", kind: "dashboard", id: blueprintId as string})
             if (!/^id:.*$/m.test(dashboardStore.sourceCode ?? "")) {
                 dashboardStore.sourceCode = "id: " + blueprintId + "\n" + dashboardStore.sourceCode

--- a/ui/src/override/components/ai/copilot/appDraftActions.ts
+++ b/ui/src/override/components/ai/copilot/appDraftActions.ts
@@ -1,0 +1,17 @@
+import type {ArtefactDraftEvent} from "../../../../components/ai/copilot/types"
+
+/**
+ * Actions for an AI-drafted **app** artefact. Apps are an EE-only feature — they have no OSS editor
+ * or API, and `author-app` (and therefore APP drafts) only exist in EE. So the OSS implementation is
+ * a no-op that reports apps unsupported; EE shadows this file via the `override/` alias.
+ */
+export interface AppDraftActions {
+    /** Whether app drafts can be acted on (true only in EE). */
+    readonly supported: boolean
+    /** Open the drafted app YAML in the app editor to review + save (no direct write). */
+    openInEditor(draft: ArtefactDraftEvent): void
+}
+
+export function useAppDraftActions(): AppDraftActions {
+    return {supported: false, openInEditor: () => {}}
+}

--- a/ui/src/translations/de.json
+++ b/ui/src/translations/de.json
@@ -2086,6 +2086,9 @@
           "applyConfirm": "Den flow {namespace}.{id} anwenden? Er wird erstellt oder überschrieben, falls er bereits existiert.",
           "applyError": "Der flow konnte nicht angewendet werden. Bitte versuchen Sie es erneut.",
           "applyNoTarget": "Dieser Entwurf hat keinen namespace oder keine id zum Anwenden.",
+          "applyConfirmDashboard": "Apply the dashboard {id}? It will be created, or overwritten if it already exists.",
+          "applyErrorDashboard": "Couldn't apply the dashboard. Please try again.",
+          "applyTitleDashboard": "Apply dashboard",
           "title": {
             "flow": "Proposed flow",
             "dashboard": "Proposed dashboard",

--- a/ui/src/translations/en.json
+++ b/ui/src/translations/en.json
@@ -2084,8 +2084,11 @@
           "apply": "Apply",
           "applyTitle": "Apply flow",
           "applyConfirm": "Apply the flow {namespace}.{id}? It will be created, or overwritten if it already exists.",
+          "applyConfirmDashboard": "Apply the dashboard {id}? It will be created, or overwritten if it already exists.",
           "applyError": "Couldn't apply the flow. Please try again.",
+          "applyErrorDashboard": "Couldn't apply the dashboard. Please try again.",
           "applyNoTarget": "This draft has no namespace or id to apply.",
+          "applyTitleDashboard": "Apply dashboard",
           "title": {
             "flow": "Proposed flow",
             "dashboard": "Proposed dashboard",

--- a/ui/src/translations/es.json
+++ b/ui/src/translations/es.json
@@ -2086,6 +2086,9 @@
           "applyConfirm": "¿Aplicar el flow {namespace}.{id}? Se creará, o se sobrescribirá si ya existe.",
           "applyError": "No se pudo aplicar el flow. Inténtalo de nuevo.",
           "applyNoTarget": "Este borrador no tiene namespace ni id para aplicar.",
+          "applyConfirmDashboard": "Apply the dashboard {id}? It will be created, or overwritten if it already exists.",
+          "applyErrorDashboard": "Couldn't apply the dashboard. Please try again.",
+          "applyTitleDashboard": "Apply dashboard",
           "title": {
             "flow": "Proposed flow",
             "dashboard": "Proposed dashboard",

--- a/ui/src/translations/fr.json
+++ b/ui/src/translations/fr.json
@@ -2086,6 +2086,9 @@
           "applyConfirm": "Appliquer le flow {namespace}.{id} ? Il sera créé, ou écrasé s'il existe déjà.",
           "applyError": "Impossible d'appliquer le flow. Veuillez réessayer.",
           "applyNoTarget": "Ce brouillon n'a pas de namespace ni d'id à appliquer.",
+          "applyConfirmDashboard": "Apply the dashboard {id}? It will be created, or overwritten if it already exists.",
+          "applyErrorDashboard": "Couldn't apply the dashboard. Please try again.",
+          "applyTitleDashboard": "Apply dashboard",
           "title": {
             "flow": "Proposed flow",
             "dashboard": "Proposed dashboard",

--- a/ui/src/translations/hi.json
+++ b/ui/src/translations/hi.json
@@ -2086,6 +2086,9 @@
           "applyConfirm": "flow {namespace}.{id} लागू करें? यह बनाया जाएगा, या यदि यह पहले से मौजूद है तो अधिलेखित किया जाएगा।",
           "applyError": "flow लागू नहीं किया जा सका। कृपया पुनः प्रयास करें।",
           "applyNoTarget": "इस ड्राफ्ट में लागू करने के लिए कोई namespace या id नहीं है।",
+          "applyConfirmDashboard": "Apply the dashboard {id}? It will be created, or overwritten if it already exists.",
+          "applyErrorDashboard": "Couldn't apply the dashboard. Please try again.",
+          "applyTitleDashboard": "Apply dashboard",
           "title": {
             "flow": "Proposed flow",
             "dashboard": "Proposed dashboard",

--- a/ui/src/translations/it.json
+++ b/ui/src/translations/it.json
@@ -2086,6 +2086,9 @@
           "applyConfirm": "Applicare il flow {namespace}.{id}? Verrà creato oppure sovrascritto se esiste già.",
           "applyError": "Impossibile applicare il flow. Riprova.",
           "applyNoTarget": "Questa bozza non ha namespace o id da applicare.",
+          "applyConfirmDashboard": "Apply the dashboard {id}? It will be created, or overwritten if it already exists.",
+          "applyErrorDashboard": "Couldn't apply the dashboard. Please try again.",
+          "applyTitleDashboard": "Apply dashboard",
           "title": {
             "flow": "Proposed flow",
             "dashboard": "Proposed dashboard",

--- a/ui/src/translations/ja.json
+++ b/ui/src/translations/ja.json
@@ -2086,6 +2086,9 @@
           "applyConfirm": "flow {namespace}.{id} を適用しますか？作成されます。既に存在する場合は上書きされます。",
           "applyError": "flow を適用できませんでした。もう一度お試しください。",
           "applyNoTarget": "この下書きには適用する namespace または id がありません。",
+          "applyConfirmDashboard": "Apply the dashboard {id}? It will be created, or overwritten if it already exists.",
+          "applyErrorDashboard": "Couldn't apply the dashboard. Please try again.",
+          "applyTitleDashboard": "Apply dashboard",
           "title": {
             "flow": "Proposed flow",
             "dashboard": "Proposed dashboard",

--- a/ui/src/translations/ko.json
+++ b/ui/src/translations/ko.json
@@ -2086,6 +2086,9 @@
           "applyConfirm": "{namespace}.{id} flow를 적용하시겠습니까? 생성되며, 이미 존재하는 경우 덮어씁니다.",
           "applyError": "flow를 적용할 수 없습니다. 다시 시도해 주세요.",
           "applyNoTarget": "이 초안에는 적용할 namespace 또는 id가 없습니다.",
+          "applyConfirmDashboard": "Apply the dashboard {id}? It will be created, or overwritten if it already exists.",
+          "applyErrorDashboard": "Couldn't apply the dashboard. Please try again.",
+          "applyTitleDashboard": "Apply dashboard",
           "title": {
             "flow": "Proposed flow",
             "dashboard": "Proposed dashboard",

--- a/ui/src/translations/pl.json
+++ b/ui/src/translations/pl.json
@@ -2086,6 +2086,9 @@
           "applyConfirm": "Zastosować flow {namespace}.{id}? Zostanie utworzony lub nadpisany, jeśli już istnieje.",
           "applyError": "Nie udało się zastosować flow. Spróbuj ponownie.",
           "applyNoTarget": "Ten szkic nie ma namespace ani id do zastosowania.",
+          "applyConfirmDashboard": "Apply the dashboard {id}? It will be created, or overwritten if it already exists.",
+          "applyErrorDashboard": "Couldn't apply the dashboard. Please try again.",
+          "applyTitleDashboard": "Apply dashboard",
           "title": {
             "flow": "Proposed flow",
             "dashboard": "Proposed dashboard",

--- a/ui/src/translations/pt.json
+++ b/ui/src/translations/pt.json
@@ -2086,6 +2086,9 @@
           "applyConfirm": "Aplicar o flow {namespace}.{id}? Ele será criado ou substituído se já existir.",
           "applyError": "Não foi possível aplicar o flow. Tente novamente.",
           "applyNoTarget": "Este rascunho não tem namespace nem id para aplicar.",
+          "applyConfirmDashboard": "Apply the dashboard {id}? It will be created, or overwritten if it already exists.",
+          "applyErrorDashboard": "Couldn't apply the dashboard. Please try again.",
+          "applyTitleDashboard": "Apply dashboard",
           "title": {
             "flow": "Proposed flow",
             "dashboard": "Proposed dashboard",

--- a/ui/src/translations/pt_BR.json
+++ b/ui/src/translations/pt_BR.json
@@ -2086,6 +2086,9 @@
           "applyConfirm": "Aplicar o flow {namespace}.{id}? Ele será criado ou substituído se já existir.",
           "applyError": "Não foi possível aplicar o flow. Tente novamente.",
           "applyNoTarget": "Este rascunho não tem namespace nem id para aplicar.",
+          "applyConfirmDashboard": "Apply the dashboard {id}? It will be created, or overwritten if it already exists.",
+          "applyErrorDashboard": "Couldn't apply the dashboard. Please try again.",
+          "applyTitleDashboard": "Apply dashboard",
           "title": {
             "flow": "Proposed flow",
             "dashboard": "Proposed dashboard",

--- a/ui/src/translations/ru.json
+++ b/ui/src/translations/ru.json
@@ -2086,6 +2086,9 @@
           "applyConfirm": "Применить flow {namespace}.{id}? Он будет создан или перезаписан, если уже существует.",
           "applyError": "Не удалось применить flow. Пожалуйста, попробуйте снова.",
           "applyNoTarget": "В этом черновике нет namespace или id для применения.",
+          "applyConfirmDashboard": "Apply the dashboard {id}? It will be created, or overwritten if it already exists.",
+          "applyErrorDashboard": "Couldn't apply the dashboard. Please try again.",
+          "applyTitleDashboard": "Apply dashboard",
           "title": {
             "flow": "Proposed flow",
             "dashboard": "Proposed dashboard",

--- a/ui/src/translations/zh_CN.json
+++ b/ui/src/translations/zh_CN.json
@@ -2086,6 +2086,9 @@
           "applyConfirm": "应用 flow {namespace}.{id} 吗？将创建它；如果已存在则覆盖。",
           "applyError": "无法应用 flow。请重试。",
           "applyNoTarget": "此草稿没有可应用的 namespace 或 id。",
+          "applyConfirmDashboard": "Apply the dashboard {id}? It will be created, or overwritten if it already exists.",
+          "applyErrorDashboard": "Couldn't apply the dashboard. Please try again.",
+          "applyTitleDashboard": "Apply dashboard",
           "title": {
             "flow": "Proposed flow",
             "dashboard": "Proposed dashboard",

--- a/ui/tests/unit/components/ai/copilot/CopilotArtefactDraft.spec.ts
+++ b/ui/tests/unit/components/ai/copilot/CopilotArtefactDraft.spec.ts
@@ -5,8 +5,10 @@ import {ref} from "vue"
 // Stub the apply composable (it pulls in the router + flows SDK); assert wiring only.
 const openInEditor = vi.fn()
 const apply = vi.fn()
+// Mutable so a test can simulate the EE app path being present (apps are unsupported in OSS).
+const appSupported = {value: false}
 vi.mock("../../../../../src/components/ai/copilot/useApplyDraft", () => ({
-    useApplyDraft: () => ({applying: ref(false), openInEditor, apply}),
+    useApplyDraft: () => ({applying: ref(false), appSupported: appSupported.value, openInEditor, apply}),
 }))
 
 import CopilotArtefactDraft from "../../../../../src/components/ai/copilot/CopilotArtefactDraft.vue"
@@ -59,9 +61,28 @@ describe("CopilotArtefactDraft", () => {
         expect(w.find("[data-test=\"copilot-draft-open\"]").exists()).toBe(true)
     })
 
-    it("shows no apply actions for non-flow drafts (dashboard/app)", () => {
-        const w = mountDraft({draftId: "d6", kind: "DASHBOARD", yaml: "x: 1", valid: true, constraints: null})
+    it("offers Open-in-editor + Apply for a valid dashboard draft and wires them", async () => {
+        const w = mountDraft({draftId: "d6", kind: "DASHBOARD", yaml: "id: d", valid: true, constraints: null})
+        await w.find("[data-test=\"copilot-draft-open\"]").trigger("click")
+        expect(openInEditor).toHaveBeenCalled()
+        await w.find("[data-test=\"copilot-draft-apply\"]").trigger("click")
+        expect(apply).toHaveBeenCalled()
+    })
+
+    it("shows no apply actions for an app draft when apps are unsupported (OSS)", () => {
+        appSupported.value = false
+        const w = mountDraft({draftId: "d7", kind: "APP", yaml: "id: my-app", valid: true, constraints: null})
         expect(w.find("[data-test=\"copilot-draft-open\"]").exists()).toBe(false)
         expect(w.find("[data-test=\"copilot-draft-apply\"]").exists()).toBe(false)
+    })
+
+    it("offers Open-in-editor (only) for an app draft when the app path is present (EE)", async () => {
+        appSupported.value = true
+        const w = mountDraft({draftId: "d8", kind: "APP", yaml: "id: my-app", valid: true, constraints: null})
+        await w.find("[data-test=\"copilot-draft-open\"]").trigger("click")
+        expect(openInEditor).toHaveBeenCalled()
+        // Apps have no direct-apply — only open-in-editor.
+        expect(w.find("[data-test=\"copilot-draft-apply\"]").exists()).toBe(false)
+        appSupported.value = false
     })
 })

--- a/ui/tests/unit/components/ai/copilot/useApplyDraft.spec.ts
+++ b/ui/tests/unit/components/ai/copilot/useApplyDraft.spec.ts
@@ -23,8 +23,16 @@ vi.mock("@kestra-io/kestra-sdk/flows", () => ({
     updateFlow: (...a: unknown[]) => updateFlow(...a),
 }))
 
+const createDashboard = vi.fn().mockResolvedValue({})
+const updateDashboard = vi.fn().mockResolvedValue({})
+vi.mock("@kestra-io/kestra-sdk/dashboards", () => ({
+    createDashboard: (...a: unknown[]) => createDashboard(...a),
+    updateDashboard: (...a: unknown[]) => updateDashboard(...a),
+}))
+
 // A create rejection shaped like the backend's "already exists" 422.
 const alreadyExists = {response: {status: 422, data: {message: "Flow id already exists: my-flow"}}}
+const dashboardExists = {response: {status: 422, data: {message: "Dashboard id already exists: my-dash"}}}
 
 import {useApplyDraft} from "../../../../../src/components/ai/copilot/useApplyDraft"
 
@@ -38,7 +46,11 @@ describe("useApplyDraft", () => {
         alert.mockResolvedValue(undefined)
         createFlow.mockResolvedValue({})
         updateFlow.mockResolvedValue({})
+        createDashboard.mockResolvedValue({})
+        updateDashboard.mockResolvedValue({})
     })
+
+    const dashboardDraft = (over = {}) => ({draftId: "d9", kind: "DASHBOARD" as const, yaml: "id: my-dash\ntitle: My dash", valid: true, constraints: null, ...over})
 
     it("openInEditor pushes flows/create with the drafted YAML as blueprintSourceYaml", () => {
         useApplyDraft().openInEditor(draft())
@@ -91,5 +103,50 @@ describe("useApplyDraft", () => {
         expect(alert).toHaveBeenCalled()
         expect(confirm).not.toHaveBeenCalled()
         expect(createFlow).not.toHaveBeenCalled()
+    })
+
+    // --- dashboards ---
+
+    it("openInEditor pushes dashboards/create seeded with the drafted YAML", () => {
+        useApplyDraft().openInEditor(dashboardDraft())
+        expect(push).toHaveBeenCalledWith(expect.objectContaining({
+            name: "dashboards/create",
+            query: {sourceYaml: "id: my-dash\ntitle: My dash"},
+            params: {tenant: "main"},
+        }))
+    })
+
+    it("apply CREATES the dashboard, then navigates to it (id only, no namespace)", async () => {
+        parsed = {id: "my-dash"}
+        confirm.mockResolvedValueOnce(true)
+        await useApplyDraft().apply(dashboardDraft())
+        expect(createDashboard).toHaveBeenCalledWith(expect.objectContaining({body: "id: my-dash\ntitle: My dash"}))
+        expect(updateDashboard).not.toHaveBeenCalled()
+        expect(push).toHaveBeenCalledWith(expect.objectContaining({name: "dashboards/update", params: {dashboard: "my-dash", tenant: "main"}}))
+    })
+
+    it("apply UPDATES the dashboard when create reports it already exists", async () => {
+        parsed = {id: "my-dash"}
+        confirm.mockResolvedValueOnce(true)
+        createDashboard.mockRejectedValueOnce(dashboardExists)
+        await useApplyDraft().apply(dashboardDraft())
+        expect(updateDashboard).toHaveBeenCalledWith(expect.objectContaining({id: "my-dash", body: "id: my-dash\ntitle: My dash"}))
+    })
+
+    it("apply alerts and skips confirm when the dashboard draft has no id", async () => {
+        parsed = {} // no id parsed
+        await useApplyDraft().apply(dashboardDraft({yaml: "title: nope"}))
+        expect(alert).toHaveBeenCalled()
+        expect(confirm).not.toHaveBeenCalled()
+        expect(createDashboard).not.toHaveBeenCalled()
+    })
+
+    // --- apps (EE-only) ---
+
+    it("reports apps unsupported in OSS and no-ops openInEditor for an app draft", () => {
+        const {appSupported, openInEditor} = useApplyDraft()
+        expect(appSupported).toBe(false) // EE shadows override/…/appDraftActions to enable this
+        openInEditor({draftId: "da", kind: "APP", yaml: "id: my-app", valid: true, constraints: null})
+        expect(push).not.toHaveBeenCalled()
     })
 })


### PR DESCRIPTION
Extends artefact-draft actions beyond flows.

## Dashboards (OSS)
- **Open in editor** — hands the drafted YAML to the dashboard create editor (new `sourceYaml` query on `Create.vue`).
- **Apply** — creates the dashboard directly (falling back to update if the id already exists), then navigates to it.

## Apps (EE, via the override layer)
- **Open in editor** only — opens the drafted YAML in the EE app editor (`apps/create`). Apps are EE-only (no OSS editor/API), so `useApplyDraft` delegates the APP kind to `override/components/ai/copilot/appDraftActions` — a no-op in OSS (this PR), implemented in the EE companion PR. No direct-apply for apps: they're keyed by a server `uid`, so a card apply could only ever create duplicates.

## i18n
3 new keys (`applyConfirmDashboard`/`applyErrorDashboard`/`applyTitleDashboard`). ⚠️ The 12 non-en locales carry **English placeholders** (no `GEMINI_API_KEY` available to run `translations:generate`) — check stays green; the generator should translate them before this merges.

Companion: the EE PR wiring the app editor path. Targets `feat/ai-copilot-v2-agentic-loop`.