### PR TITLE
fix(tests): support directory paths in the @LoadFlows metastore wait

### DIFF
--- a/core/src/main/java/io/kestra/core/repositories/LocalFlowRepositoryLoader.java
+++ b/core/src/main/java/io/kestra/core/repositories/LocalFlowRepositoryLoader.java
@@ -11,7 +11,9 @@ import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -22,6 +24,7 @@ import org.apache.commons.io.FileUtils;
 import io.kestra.core.exceptions.FlowProcessingException;
 import io.kestra.core.models.flows.FlowId;
 import io.kestra.core.models.flows.FlowInterface;
+import io.kestra.core.models.flows.FlowWithSource;
 import io.kestra.core.models.flows.GenericFlow;
 import io.kestra.core.queues.QueueException;
 import io.kestra.core.serializers.YamlParser;
@@ -46,11 +49,11 @@ public class LocalFlowRepositoryLoader {
     @Inject
     private FlowService flowService;
 
-    public void load(URL basePath) throws IOException, URISyntaxException {
-        load(MAIN_TENANT, basePath);
+    public List<FlowWithSource> load(URL basePath) throws IOException, URISyntaxException {
+        return load(MAIN_TENANT, basePath);
     }
 
-    public void load(String tenantId, URL basePath) throws IOException, URISyntaxException {
+    public List<FlowWithSource> load(String tenantId, URL basePath) throws IOException, URISyntaxException {
         URI uri = basePath.toURI();
 
         if (uri.getScheme().equals("jar")) {
@@ -73,23 +76,32 @@ public class LocalFlowRepositoryLoader {
                     }
                 }
 
-                this.load(tenantId, tempDirectory.toFile());
+                return this.load(tenantId, tempDirectory.toFile());
             }
         } else {
-            this.load(tenantId, Paths.get(uri).toFile());
+            return this.load(tenantId, Paths.get(uri).toFile());
         }
     }
 
-    public void load(File basePath) throws IOException {
-        load(MAIN_TENANT, basePath);
+    public List<FlowWithSource> load(File basePath) throws IOException {
+        return load(MAIN_TENANT, basePath);
     }
 
-    public void load(String tenantId, File basePath) throws IOException {
+    /**
+     * Loads every flow found under {@code basePath} (a single file or a directory walked
+     * recursively) into the repository, creating or updating each one.
+     *
+     * @return the persisted flows (with their assigned revision) that were successfully created or
+     *         updated, in encounter order. Flows that fail to load are logged and skipped, so they
+     *         are absent from the returned list.
+     */
+    public List<FlowWithSource> load(String tenantId, File basePath) throws IOException {
         Map<String, FlowInterface> flowByUidInRepository = flowRepository.findAllForAllTenants()
             .stream()
             .filter(flow -> tenantId.equals(flow.getTenantId()))
             .collect(Collectors.toMap(FlowId::uidWithoutRevision, Function.identity()));
 
+        List<FlowWithSource> loaded = new ArrayList<>();
         try (Stream<Path> pathStream = Files.walk(basePath.toPath())) {
             pathStream.filter(YamlParser::isValidExtension)
                 .forEach(Rethrow.throwConsumer(file ->
@@ -100,17 +112,22 @@ public class LocalFlowRepositoryLoader {
 
                         FlowInterface existing = flowByUidInRepository.get(parsed.uidWithoutRevision());
 
+                        FlowWithSource persisted;
                         if (existing == null) {
-                            flowService.create(parsed);
+                            persisted = flowService.create(parsed);
                             log.trace("Created flow {}.{}", parsed.getNamespace(), parsed.getId());
                         } else {
-                            flowService.update(parsed, existing);
+                            persisted = flowService.update(parsed, existing);
                             log.trace("Updated flow {}.{}", parsed.getNamespace(), parsed.getId());
                         }
+
+                        loaded.add(persisted);
                     } catch (FlowProcessingException | ConstraintViolationException | QueueException e) {
                         log.warn("Unable to create flow {}", file, e);
                     }
                 }));
         }
+
+        return loaded;
     }
 }

--- a/core/src/test/java/io/kestra/core/junit/extensions/FlowLoaderDirectoryTest.java
+++ b/core/src/test/java/io/kestra/core/junit/extensions/FlowLoaderDirectoryTest.java
@@ -1,0 +1,39 @@
+package io.kestra.core.junit.extensions;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import io.kestra.core.junit.annotations.KestraTest;
+import io.kestra.core.junit.annotations.LoadFlows;
+import io.kestra.core.models.flows.FlowInterface;
+import io.kestra.core.repositories.FlowRepositoryInterface;
+
+import jakarta.inject.Inject;
+
+import static io.kestra.core.tenant.TenantService.MAIN_TENANT;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Guards {@link AbstractLoaderExtension} against the directory regression: {@code @LoadFlows} must
+ * accept a directory path and load every flow it contains (not just single files). Without the fix,
+ * the metastore-wait loop tries to parse the directory itself as a flow and fails.
+ */
+@KestraTest
+class FlowLoaderDirectoryTest {
+
+    @Inject
+    private FlowRepositoryInterface flowRepository;
+
+    @Test
+    @LoadFlows({ "flows/loaddir" })
+    void shouldLoadEveryFlowInDirectory() {
+        List<String> ids = flowRepository.findAllForAllTenants().stream()
+            .filter(flow -> MAIN_TENANT.equals(flow.getTenantId()))
+            .filter(flow -> "io.kestra.tests.loaddir".equals(flow.getNamespace()))
+            .map(FlowInterface::getId)
+            .toList();
+
+        assertThat(ids).containsExactlyInAnyOrder("load-directory-first", "load-directory-second");
+    }
+}

--- a/core/src/test/resources/flows/loaddir/load-directory-first.yaml
+++ b/core/src/test/resources/flows/loaddir/load-directory-first.yaml
@@ -1,0 +1,7 @@
+id: load-directory-first
+namespace: io.kestra.tests.loaddir
+
+tasks:
+  - id: hello
+    type: io.kestra.plugin.core.log.Log
+    message: first

--- a/core/src/test/resources/flows/loaddir/load-directory-second.yaml
+++ b/core/src/test/resources/flows/loaddir/load-directory-second.yaml
@@ -1,0 +1,7 @@
+id: load-directory-second
+namespace: io.kestra.tests.loaddir
+
+tasks:
+  - id: hello
+    type: io.kestra.plugin.core.log.Log
+    message: second

--- a/tests/src/main/java/io/kestra/core/junit/extensions/AbstractLoaderExtension.java
+++ b/tests/src/main/java/io/kestra/core/junit/extensions/AbstractLoaderExtension.java
@@ -9,11 +9,13 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.Duration;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Stream;
 
+import org.awaitility.core.ConditionTimeoutException;
 import org.junit.jupiter.api.extension.ExtensionContext;
 
 import io.kestra.core.junit.services.TestTenantLifecycle;
@@ -30,12 +32,11 @@ import io.kestra.core.utils.TestsUtils;
 import io.micronaut.context.ApplicationContext;
 import io.micronaut.data.model.Pageable;
 import io.micronaut.test.extensions.junit5.MicronautJunit5Extension;
-import lombok.extern.slf4j.Slf4j;
 
 import static io.kestra.core.junit.extensions.ExtensionUtils.loadFile;
 import static io.kestra.core.utils.Rethrow.throwFunction;
+import static org.awaitility.Awaitility.await;
 
-@Slf4j
 public abstract class AbstractLoaderExtension {
 
     protected ApplicationContext context;
@@ -102,68 +103,24 @@ public abstract class AbstractLoaderExtension {
         }
 
         // The flow metastore's cache is updated asynchronously (via a queue subscription) after
-        // FlowService.create()/update() returns. Under concurrent test load that lag can outlast a
-        // freshly-loaded flow's very first execution transitions, so a Flow trigger on it silently
-        // misses them (no retry). Block here until every loaded flow's persisted revision is visible
-        // in the metastore cache, so tests never race their own fixtures. We match against the cache
-        // (the source of truth for flow liveness) rather than re-reading the repository, whose
-        // tenant-scoped lookups are eventually consistent on some backends.
-        //
-        // The wait settles rather than requiring completeness: a few flows never reach the cache at
-        // all — e.g. those whose queue event fails to deserialize (task aliases), which the metastore
-        // logs and drops. Those flows are still persisted and queryable; only the cache-backed
-        // trigger fast-path is unavailable for them. So we stop once the cache has stopped catching
-        // up (a quiet period with no further progress), capped by an overall budget, and warn about
-        // any stragglers instead of failing the whole fixture. Fixtures whose flows all cache — the
-        // common case, including every trigger test — settle in well under the quiet period.
+        // FlowService.create()/update() returns, so a Flow trigger on a freshly-loaded flow can
+        // miss its first executions. Await until every loaded flow is visible in the cache, so tests
+        // never race their own fixtures. Best-effort: a few valid flows never reach the cache (their
+        // queue event fails to deserialize, e.g. task aliases) — they are still persisted, so we
+        // don't fail the fixture on them.
         FlowMetaStoreInterface flowMetaStore = context.getBean(FlowMetaStoreInterface.class);
-        List<FlowWithSource> pending = new ArrayList<>(loadedFlows);
-        waitForFlowsInMetaStore(tenantId, flowMetaStore, pending);
-    }
-
-    private static final Duration METASTORE_WAIT_BUDGET = Duration.ofSeconds(30);
-    private static final Duration METASTORE_WAIT_QUIET_PERIOD = Duration.ofSeconds(3);
-    private static final Duration METASTORE_WAIT_POLL_INTERVAL = Duration.ofMillis(100);
-
-    private static void waitForFlowsInMetaStore(String tenantId, FlowMetaStoreInterface flowMetaStore, List<FlowWithSource> pending) {
-        long deadline = System.nanoTime() + METASTORE_WAIT_BUDGET.toNanos();
-        long lastProgress = System.nanoTime();
-        int lastPendingSize = pending.size();
-
-        while (!pending.isEmpty() && System.nanoTime() < deadline) {
-            pending.removeIf(flow -> flowMetaStore.allLastVersion().stream()
-                .anyMatch(
-                    cached -> tenantId.equals(cached.getTenantId())
-                        && cached.getNamespace().equals(flow.getNamespace())
-                        && cached.getId().equals(flow.getId())
-                        && cached.getRevision().equals(flow.getRevision())
-                )
-            );
-
-            if (pending.size() < lastPendingSize) {
-                lastPendingSize = pending.size();
-                lastProgress = System.nanoTime();
-            } else if (System.nanoTime() - lastProgress > METASTORE_WAIT_QUIET_PERIOD.toNanos()) {
-                // The cache stopped catching up: the remaining flows are unlikely to ever surface.
-                break;
-            }
-
-            if (!pending.isEmpty()) {
-                try {
-                    Thread.sleep(METASTORE_WAIT_POLL_INTERVAL.toMillis());
-                } catch (InterruptedException e) {
-                    Thread.currentThread().interrupt();
-                    return;
-                }
-            }
-        }
-
-        if (!pending.isEmpty()) {
-            log.warn(
-                "{} loaded flow(s) never appeared in the flow metastore cache (e.g. flows whose queue event fails to deserialize, such as task aliases); they are still persisted, proceeding: {}",
-                pending.size(),
-                pending.stream().map(flow -> flow.getNamespace() + "." + flow.getId()).toList()
-            );
+        try {
+            await().atMost(Duration.ofSeconds(10)).until(() -> {
+                Collection<FlowWithSource> cached = flowMetaStore.allLastVersion();
+                return loadedFlows.stream().allMatch(flow -> cached.stream().anyMatch(
+                    c -> tenantId.equals(c.getTenantId())
+                        && c.getNamespace().equals(flow.getNamespace())
+                        && c.getId().equals(flow.getId())
+                        && c.getRevision().equals(flow.getRevision())
+                ));
+            });
+        } catch (ConditionTimeoutException ignored) {
+            // Best-effort — some loaded flows never reach the cache (see above); they are persisted.
         }
     }
 

--- a/tests/src/main/java/io/kestra/core/junit/extensions/AbstractLoaderExtension.java
+++ b/tests/src/main/java/io/kestra/core/junit/extensions/AbstractLoaderExtension.java
@@ -3,16 +3,23 @@ package io.kestra.core.junit.extensions;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.nio.charset.Charset;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
+import java.util.stream.Stream;
 
 import org.junit.jupiter.api.extension.ExtensionContext;
 
 import io.kestra.core.junit.services.TestTenantLifecycle;
 import io.kestra.core.models.flows.Flow;
 import io.kestra.core.models.flows.FlowWithSource;
+import io.kestra.core.models.flows.GenericFlow;
 import io.kestra.core.repositories.ExecutionRepositoryInterface;
 import io.kestra.core.repositories.FlowRepositoryInterface;
 import io.kestra.core.repositories.LocalFlowRepositoryLoader;
@@ -23,10 +30,12 @@ import io.kestra.core.utils.TestsUtils;
 import io.micronaut.context.ApplicationContext;
 import io.micronaut.data.model.Pageable;
 import io.micronaut.test.extensions.junit5.MicronautJunit5Extension;
+import lombok.extern.slf4j.Slf4j;
 
 import static io.kestra.core.junit.extensions.ExtensionUtils.loadFile;
-import static org.awaitility.Awaitility.await;
+import static io.kestra.core.utils.Rethrow.throwFunction;
 
+@Slf4j
 public abstract class AbstractLoaderExtension {
 
     protected ApplicationContext context;
@@ -81,37 +90,84 @@ public abstract class AbstractLoaderExtension {
             LocalFlowRepositoryLoader.class
         );
 
+        // A path may be a single flow file or a directory: the loader walks it recursively and
+        // returns every flow it actually created/updated (with its assigned revision), so the
+        // metastore-wait below operates on real flows regardless of whether a directory
+        // (e.g. "flows/valids") was passed.
+        List<FlowWithSource> loadedFlows = new ArrayList<>();
         for (String path : paths) {
             URL resource = loadFile(path);
 
-            TestsUtils.loads(tenantId, repositoryLoader, resource);
+            loadedFlows.addAll(TestsUtils.loads(tenantId, repositoryLoader, resource));
         }
 
         // The flow metastore's cache is updated asynchronously (via a queue subscription) after
         // FlowService.create()/update() returns. Under concurrent test load that lag can outlast a
         // freshly-loaded flow's very first execution transitions, so a Flow trigger on it silently
-        // misses them (no retry). Block here until every loaded flow is actually visible in the
-        // metastore cache, so tests never race their own fixtures.
-        FlowRepositoryInterface flowRepository = context.getBean(FlowRepositoryInterface.class);
+        // misses them (no retry). Block here until every loaded flow's persisted revision is visible
+        // in the metastore cache, so tests never race their own fixtures. We match against the cache
+        // (the source of truth for flow liveness) rather than re-reading the repository, whose
+        // tenant-scoped lookups are eventually consistent on some backends.
+        //
+        // The wait settles rather than requiring completeness: a few flows never reach the cache at
+        // all — e.g. those whose queue event fails to deserialize (task aliases), which the metastore
+        // logs and drops. Those flows are still persisted and queryable; only the cache-backed
+        // trigger fast-path is unavailable for them. So we stop once the cache has stopped catching
+        // up (a quiet period with no further progress), capped by an overall budget, and warn about
+        // any stragglers instead of failing the whole fixture. Fixtures whose flows all cache — the
+        // common case, including every trigger test — settle in well under the quiet period.
         FlowMetaStoreInterface flowMetaStore = context.getBean(FlowMetaStoreInterface.class);
-        for (String path : paths) {
-            Flow flow = getFlow(path);
-            FlowWithSource persisted = flowRepository.findByIdWithSource(tenantId, flow.getNamespace(), flow.getId())
-                .orElseThrow();
+        List<FlowWithSource> pending = new ArrayList<>(loadedFlows);
+        waitForFlowsInMetaStore(tenantId, flowMetaStore, pending);
+    }
 
-            await().atMost(Duration.ofSeconds(5)).until(
-                () -> flowMetaStore.allLastVersion().stream()
-                    .anyMatch(
-                        cached -> tenantId.equals(cached.getTenantId())
-                            && cached.getNamespace().equals(flow.getNamespace())
-                            && cached.getId().equals(flow.getId())
-                            && cached.getRevision().equals(persisted.getRevision())
-                    )
+    private static final Duration METASTORE_WAIT_BUDGET = Duration.ofSeconds(30);
+    private static final Duration METASTORE_WAIT_QUIET_PERIOD = Duration.ofSeconds(3);
+    private static final Duration METASTORE_WAIT_POLL_INTERVAL = Duration.ofMillis(100);
+
+    private static void waitForFlowsInMetaStore(String tenantId, FlowMetaStoreInterface flowMetaStore, List<FlowWithSource> pending) {
+        long deadline = System.nanoTime() + METASTORE_WAIT_BUDGET.toNanos();
+        long lastProgress = System.nanoTime();
+        int lastPendingSize = pending.size();
+
+        while (!pending.isEmpty() && System.nanoTime() < deadline) {
+            pending.removeIf(flow -> flowMetaStore.allLastVersion().stream()
+                .anyMatch(
+                    cached -> tenantId.equals(cached.getTenantId())
+                        && cached.getNamespace().equals(flow.getNamespace())
+                        && cached.getId().equals(flow.getId())
+                        && cached.getRevision().equals(flow.getRevision())
+                )
+            );
+
+            if (pending.size() < lastPendingSize) {
+                lastPendingSize = pending.size();
+                lastProgress = System.nanoTime();
+            } else if (System.nanoTime() - lastProgress > METASTORE_WAIT_QUIET_PERIOD.toNanos()) {
+                // The cache stopped catching up: the remaining flows are unlikely to ever surface.
+                break;
+            }
+
+            if (!pending.isEmpty()) {
+                try {
+                    Thread.sleep(METASTORE_WAIT_POLL_INTERVAL.toMillis());
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    return;
+                }
+            }
+        }
+
+        if (!pending.isEmpty()) {
+            log.warn(
+                "{} loaded flow(s) never appeared in the flow metastore cache (e.g. flows whose queue event fails to deserialize, such as task aliases); they are still persisted, proceeding: {}",
+                pending.size(),
+                pending.stream().map(flow -> flow.getNamespace() + "." + flow.getId()).toList()
             );
         }
     }
 
-    protected void deleteFlows(String tenantId, String[] paths) throws URISyntaxException {
+    protected void deleteFlows(String tenantId, String[] paths) throws URISyntaxException, IOException {
         if (!context.isRunning()) {
             return;
         }
@@ -119,10 +175,11 @@ public abstract class AbstractLoaderExtension {
         FlowRepositoryInterface flowRepository = context.getBean(FlowRepositoryInterface.class);
         ExecutionRepositoryInterface executionRepository = context.getBean(ExecutionRepositoryInterface.class);
 
+        // A path may be a single flow file or a directory: resolve it to every flow it declares so
+        // directory fixtures (e.g. "flows/valids") are cleaned up as thoroughly as they were loaded.
         Set<String> flowIds = new HashSet<>();
         for (String path : paths) {
-            Flow flow = getFlow(path);
-            flowIds.add(flow.getId());
+            getFlows(tenantId, path).forEach(flow -> flowIds.add(flow.getId()));
         }
         flowRepository.findAllForAllTenants().stream()
             .filter(flow -> flowIds.contains(flow.getId()))
@@ -139,5 +196,20 @@ public abstract class AbstractLoaderExtension {
         URL resource = loadFile(path);
         Flow flow = YamlParser.parse(Paths.get(resource.toURI()).toFile(), Flow.class);
         return flow;
+    }
+
+    /**
+     * Resolves a resource path to the flows it declares. The path may be a single flow file or a
+     * directory, in which case it is walked recursively for {@code *.yaml}/{@code *.yml} files.
+     */
+    protected static List<GenericFlow> getFlows(String tenantId, String path) throws URISyntaxException, IOException {
+        Path resource = Paths.get(loadFile(path).toURI());
+
+        try (Stream<Path> pathStream = Files.walk(resource)) {
+            return pathStream
+                .filter(YamlParser::isValidExtension)
+                .map(throwFunction(file -> GenericFlow.fromYaml(tenantId, Files.readString(file, Charset.defaultCharset()))))
+                .toList();
+        }
     }
 }

--- a/tests/src/main/java/io/kestra/core/junit/extensions/FlowLoaderWithTenantExtension.java
+++ b/tests/src/main/java/io/kestra/core/junit/extensions/FlowLoaderWithTenantExtension.java
@@ -1,5 +1,6 @@
 package io.kestra.core.junit.extensions;
 
+import java.io.IOException;
 import java.net.URISyntaxException;
 
 import org.apache.commons.lang3.StringUtils;
@@ -41,7 +42,7 @@ public class FlowLoaderWithTenantExtension extends AbstractLoaderExtension imple
     }
 
     @Override
-    public void afterEach(ExtensionContext extensionContext) throws URISyntaxException {
+    public void afterEach(ExtensionContext extensionContext) throws URISyntaxException, IOException {
         ExtensionContext.Store store = extensionContext.getStore(NAMESPACE);
         String tenantId = store.get(KEY_TENANT_ID, String.class);
 

--- a/tests/src/main/java/io/kestra/core/junit/extensions/WithFlowExtension.java
+++ b/tests/src/main/java/io/kestra/core/junit/extensions/WithFlowExtension.java
@@ -1,5 +1,6 @@
 package io.kestra.core.junit.extensions;
 
+import java.io.IOException;
 import java.net.URISyntaxException;
 
 import org.apache.commons.lang3.StringUtils;
@@ -43,7 +44,7 @@ public class WithFlowExtension extends AbstractLoaderExtension implements
     }
 
     @Override
-    public void afterEach(ExtensionContext extensionContext) throws URISyntaxException {
+    public void afterEach(ExtensionContext extensionContext) throws URISyntaxException, IOException {
         ExtensionContext.Store store = extensionContext.getStore(NAMESPACE);
         String tenantId = store.get(KEY_TENANT_ID, String.class);
 

--- a/tests/src/main/java/io/kestra/core/utils/TestsUtils.java
+++ b/tests/src/main/java/io/kestra/core/utils/TestsUtils.java
@@ -27,6 +27,7 @@ import io.kestra.core.models.executions.LogEntry;
 import io.kestra.core.models.executions.TaskRun;
 import io.kestra.core.models.flows.Flow;
 import io.kestra.core.models.flows.FlowInterface;
+import io.kestra.core.models.flows.FlowWithSource;
 import io.kestra.core.models.flows.State;
 import io.kestra.core.models.property.Property;
 import io.kestra.core.models.tasks.Task;
@@ -115,12 +116,12 @@ abstract public class TestsUtils {
         return mapper.readValue(read, cls);
     }
 
-    public static void loads(String tenantId, LocalFlowRepositoryLoader repositoryLoader) throws IOException, URISyntaxException {
-        TestsUtils.loads(tenantId, repositoryLoader, Objects.requireNonNull(TestsUtils.class.getClassLoader().getResource("flows/valids")));
+    public static List<FlowWithSource> loads(String tenantId, LocalFlowRepositoryLoader repositoryLoader) throws IOException, URISyntaxException {
+        return TestsUtils.loads(tenantId, repositoryLoader, Objects.requireNonNull(TestsUtils.class.getClassLoader().getResource("flows/valids")));
     }
 
-    public static void loads(String tenantId, LocalFlowRepositoryLoader repositoryLoader, URL url) throws IOException, URISyntaxException {
-        repositoryLoader.load(tenantId, url);
+    public static List<FlowWithSource> loads(String tenantId, LocalFlowRepositoryLoader repositoryLoader, URL url) throws IOException, URISyntaxException {
+        return repositoryLoader.load(tenantId, url);
     }
 
     public static List<LogEntry> filterLogs(List<LogEntry> logs, TaskRun taskRun) {

--- a/tests/src/test/java/io/kestra/tests/architecture/BaseArchitectureTest.java
+++ b/tests/src/test/java/io/kestra/tests/architecture/BaseArchitectureTest.java
@@ -31,7 +31,7 @@ public class BaseArchitectureTest {
 
     @ArchTest
     public static final ArchRule no_production_use_of_awaitility = noClasses()
-        .that().doNotBelongToAnyOf(io.kestra.core.utils.Await.class)
+        .that().doNotBelongToAnyOf(io.kestra.core.utils.Await.class, io.kestra.core.junit.extensions.AbstractLoaderExtension.class)
         .should().dependOnClassesThat().resideInAPackage("org.awaitility")
         .because("you should not use it directly but use " + io.kestra.core.utils.Await.class.getName() + " wrapper instead");
 }

--- a/tests/src/test/java/io/kestra/tests/architecture/BaseArchitectureTest.java
+++ b/tests/src/test/java/io/kestra/tests/architecture/BaseArchitectureTest.java
@@ -31,7 +31,7 @@ public class BaseArchitectureTest {
 
     @ArchTest
     public static final ArchRule no_production_use_of_awaitility = noClasses()
-        .that().doNotBelongToAnyOf(io.kestra.core.utils.Await.class, io.kestra.core.junit.extensions.AbstractLoaderExtension.class)
+        .that().doNotBelongToAnyOf(io.kestra.core.utils.Await.class)
         .should().dependOnClassesThat().resideInAPackage("org.awaitility")
         .because("you should not use it directly but use " + io.kestra.core.utils.Await.class.getName() + " wrapper instead");
 }


### PR DESCRIPTION
## What
The metastore-wait added to `AbstractLoaderExtension.loadFlows` parsed each annotation path directly as a single `Flow`, which fails for **directory** fixtures (e.g. `@LoadTestResources(flows = {"flows/valids"})`): reading a directory as YAML yields its file listing, not a flow. This broke EE controller tests (`FlowControllerAllTest`, `ExecutionControllerAllTest`, `ExecutionControllerPolicyGateTest`) across all backends with `ParameterResolutionException: ... Illegal flow source`.

## How
- `LocalFlowRepositoryLoader.load(...)` now returns the persisted `List<FlowWithSource>` it created/updated (all overloads; source-compatible — no caller used the return value). `TestsUtils.loads(...)` forwards it.
- `loadFlows` drives the metastore-wait from those persisted flows, so a directory expands to the flows it actually contains — directories and single files behave identically. `deleteFlows` is likewise folder-aware.
- The wait matches the **metastore cache** (the source of truth for flow liveness) rather than re-reading the repository, whose tenant-scoped lookups are eventually consistent on Elasticsearch.
- The wait **settles** rather than requiring completeness: a few valid flows never reach the cache (their queue event fails to deserialize, e.g. task aliases like `alias-task`) yet are still persisted, so it stops once the cache stops catching up (3s quiet period, 30s cap) and warns about stragglers instead of failing the fixture. awaitility is no longer used here (removed from the ArchUnit exclusion).

## Test
- New guard test `FlowLoaderDirectoryTest` loads a directory via `@LoadFlows`.
- Verified green: OSS `FailTest`, `TriggerTest` (`@LoadFlows` + Flow trigger), ArchUnit; and downstream EE `FlowControllerAllTest`/`ExecutionControllerAllTest` (H2/Postgres/Mysql/Elastic).

Companion EE PR: kestra-io/kestra-ee (ES loop TASK_ID mapping) — linked below.