### PR TITLE
fix(webserver): stop leaking sensitive instance metadata via /api/v1/configs

### DIFF
--- a/ui/src/components/basicauth/BasicAuthLogin.vue
+++ b/ui/src/components/basicauth/BasicAuthLogin.vue
@@ -120,7 +120,7 @@
 
 
     const checkServerInitialization = async () => {
-        const response = await axios.get(`${apiUrlWithoutTenants()}/configs`, {timeout: 10000})
+        const response = await axios.get(`${apiUrlWithoutTenants()}/configs/login`, {timeout: 10000})
         return response.data?.isBasicAuthInitialized
     }
 

--- a/ui/src/components/basicauth/BasicAuthSetup.vue
+++ b/ui/src/components/basicauth/BasicAuthSetup.vue
@@ -160,7 +160,7 @@
     import {useMiscStore} from "override/stores/misc"
     import {useSurveySkip} from "../../composables/useSurveyData"
     import {trackSetupEvent} from "../../composables/usePosthog"
-    import {identifyPosthogUser, initPosthogIfEnabled} from "../../utils/posthog"
+    import {identifyPosthogUser} from "../../utils/posthog"
 
     import AccountOutline from "vue-material-design-icons/AccountOutline.vue"
     import LightningBolt from "vue-material-design-icons/LightningBolt.vue"
@@ -211,20 +211,19 @@
 
     const initializeSetup = async () => {
         try {
-            const config = await miscStore.loadConfigs()
+            // Public, unauthenticated endpoint: only isBasicAuthInitialized is available at this stage.
+            const loginConfig = await miscStore.loadLoginConfig()
 
-            if (config?.isBasicAuthInitialized) {
+            if (loginConfig?.isBasicAuthInitialized) {
                 localStorage.removeItem("basicAuthSetupInProgress")
                 localStorage.removeItem("setupStartTime")
                 router.push({name: "login"})
                 return
             }
 
-            await initPosthogIfEnabled(config)
-
-            trackSetupEvent("setup_flow:started", {
-                setup_step: "account_creation",
-            }, userFormData.value)
+            // The full configuration (needed for posthog init and setup-flow tracking) requires
+            // authentication and is not available until the account below has been created;
+            // trackSetupEvent/initPosthogIfEnabled no-op gracefully without it.
 
             localStorage.setItem("basicAuthSetupInProgress", "true")
             localStorage.setItem("setupStartTime", Date.now().toString())
@@ -318,9 +317,8 @@
                 password: userFormData.value.password,
             })
 
-            const configs = await miscStore.loadConfigs()
-
-            await identifyPosthogUser(configs, {email: normalizedEmail})
+            // addBasicAuth() above already loaded the full (now-authenticated) configuration.
+            await identifyPosthogUser(miscStore.configs, {email: normalizedEmail})
 
             trackSetupEvent("setup_flow:account_created", {
                 user_email: normalizedEmail,

--- a/ui/src/main.ts
+++ b/ui/src/main.ts
@@ -81,9 +81,9 @@ async function beforeResolve(router: Router, to: any, from: any): Promise<unknow
         if(!httpClient) {
             setupAxios(router)
         }
-        const configs = await miscStore.loadConfigs()
+        const loginConfig = await miscStore.loadLoginConfig()
 
-        if(!configs.isBasicAuthInitialized) {
+        if(!loginConfig.isBasicAuthInitialized) {
             // Since, Configs takes preference
             // we need to check if any regex validation error in BE.
             const validationErrors = await miscStore.loadBasicAuthValidationErrors()
@@ -125,6 +125,9 @@ async function beforeResolve(router: Router, to: any, from: any): Promise<unknow
         if (isSetupInProgress === "true") {
             return {name: "setup"}
         }
+
+        // Now that the user is authenticated, load the full instance configuration.
+        await miscStore.loadConfigs()
     } catch (error) {
         console.error("Error during authentication check:", error)
         return handleAuthError(error as Error, to)

--- a/ui/src/override/stores/misc.ts
+++ b/ui/src/override/stores/misc.ts
@@ -28,6 +28,12 @@ export const useMiscStore = defineStore("misc", () => {
         return response.data
     }
 
+    // Public, unauthenticated endpoint exposing only what the login/setup UI needs.
+    async function loadLoginConfig() {
+        const response = await axios.get(`${apiUrlWithoutTenants()}/configs/login`)
+        return response.data
+    }
+
     async function loadBasicAuthValidationErrors() {
         const response = await axios.get(`${apiUrlWithoutTenants()}/basicAuthValidationErrors`)
         return response.data
@@ -46,12 +52,7 @@ export const useMiscStore = defineStore("misc", () => {
         password: string;
     }) {
         const email = options.username
-        const analyticsEnabled = configs.value?.isUiAnonymousUsageEnabled === true
         const uid = ensureUid()
-
-        if (analyticsEnabled) {
-            void initPosthogIfEnabled(configs.value)
-        }
 
         await axios.post(`${apiUrl()}/basicAuth`, {
             uid,
@@ -59,11 +60,19 @@ export const useMiscStore = defineStore("misc", () => {
             password: options.password,
         })
 
+        // The call above logs the caller in (it sets the auth cookie on success), so the
+        // full configuration can now be loaded to drive analytics for this event.
+        const freshConfigs = await loadConfigs()
+
+        if (freshConfigs?.isUiAnonymousUsageEnabled === true) {
+            void initPosthogIfEnabled(freshConfigs)
+        }
+
         const apiStore = useApiStore()
 
         return apiStore.posthogEvents({
             type: "ossauth",
-            iid: configs.value?.uuid,
+            iid: freshConfigs?.uuid,
             uid,
             date: new Date().toISOString(),
             counter: 0,
@@ -77,6 +86,7 @@ export const useMiscStore = defineStore("misc", () => {
         lastContextTab,
         theme,
         loadConfigs,
+        loadLoginConfig,
         loadBasicAuthValidationErrors,
         loadAllUsages,
         addBasicAuth,

--- a/ui/tests/unit/stores/miscAddBasicAuth.spec.ts
+++ b/ui/tests/unit/stores/miscAddBasicAuth.spec.ts
@@ -1,0 +1,80 @@
+import {describe, it, expect, vi, beforeEach} from "vitest"
+import {setActivePinia, createPinia} from "pinia"
+
+const axiosGet = vi.fn()
+const axiosPost = vi.fn().mockResolvedValue({data: {}})
+
+vi.mock("@kestra-io/kestra-sdk", () => ({
+    useClient: () => ({
+        get: axiosGet,
+        post: axiosPost,
+    }),
+}))
+
+const initPosthogIfEnabled = vi.fn()
+const capturePosthogEvent = vi.fn()
+const disablePosthog = vi.fn()
+
+vi.mock("../../../src/utils/posthog", () => ({
+    initPosthogIfEnabled,
+    capturePosthogEvent,
+    disablePosthog,
+}))
+
+vi.mock("../../../src/utils/uid", () => ({
+    ensureUid: vi.fn(() => "uid-123"),
+    getUid: vi.fn(() => "uid-123"),
+}))
+
+describe("misc store addBasicAuth", () => {
+    beforeEach(() => {
+        vi.resetModules()
+        axiosGet.mockReset()
+        axiosPost.mockClear()
+        initPosthogIfEnabled.mockClear()
+        capturePosthogEvent.mockClear()
+        disablePosthog.mockClear()
+        setActivePinia(createPinia())
+    })
+
+    it("loads the full (now-authenticated) configs after the basicAuth POST succeeds, and uses them for analytics", async () => {
+        axiosGet.mockResolvedValue({
+            data: {isBasicAuthInitialized: true, isUiAnonymousUsageEnabled: true, uuid: "instance-uuid"},
+        })
+
+        const {useMiscStore} = await import("override/stores/misc")
+        const miscStore = useMiscStore()
+
+        await miscStore.addBasicAuth({username: "admin@kestra.io", password: "StrongPass1"})
+
+        // POST happens before any config is fetched (the endpoint is public/unauthenticated at that point).
+        expect(axiosPost).toHaveBeenCalledTimes(1)
+        expect(axiosPost.mock.calls[0][0]).toMatch(/\/basicAuth$/)
+
+        // The store now holds the freshly (authenticated) loaded configs.
+        expect(axiosGet.mock.calls[0][0]).toMatch(/\/configs$/)
+        expect(miscStore.configs).toEqual({isBasicAuthInitialized: true, isUiAnonymousUsageEnabled: true, uuid: "instance-uuid"})
+
+        // Analytics init/event use the freshly loaded configs, not a stale/undefined value.
+        expect(initPosthogIfEnabled).toHaveBeenCalledWith(miscStore.configs)
+        expect(capturePosthogEvent).toHaveBeenCalledTimes(1)
+        const [capturedConfigs, , eventPayload] = capturePosthogEvent.mock.calls[0]
+        expect(capturedConfigs).toEqual(miscStore.configs)
+        expect(eventPayload.iid).toBe("instance-uuid")
+    })
+
+    it("skips posthog init when analytics is disabled, but still fires the ossauth event", async () => {
+        axiosGet.mockResolvedValue({
+            data: {isBasicAuthInitialized: true, isUiAnonymousUsageEnabled: false, uuid: "instance-uuid-2"},
+        })
+
+        const {useMiscStore} = await import("override/stores/misc")
+        const miscStore = useMiscStore()
+
+        await miscStore.addBasicAuth({username: "admin2@kestra.io", password: "StrongPass1"})
+
+        expect(initPosthogIfEnabled).not.toHaveBeenCalled()
+        expect(disablePosthog).toHaveBeenCalledTimes(1)
+        expect(capturePosthogEvent).not.toHaveBeenCalled()
+    })
+})

--- a/ui/tests/unit/stores/miscLoginConfig.spec.ts
+++ b/ui/tests/unit/stores/miscLoginConfig.spec.ts
@@ -1,0 +1,56 @@
+import {describe, it, expect, vi, beforeEach} from "vitest"
+import {setActivePinia, createPinia} from "pinia"
+
+const axiosGet = vi.fn()
+
+vi.mock("@kestra-io/kestra-sdk", () => ({
+    useClient: () => ({
+        get: axiosGet,
+        post: vi.fn(),
+    }),
+}))
+
+vi.mock("../../../src/utils/posthog", () => ({
+    initPosthogIfEnabled: vi.fn(),
+}))
+
+vi.mock("../../../src/utils/uid", () => ({
+    ensureUid: vi.fn(() => "uid-123"),
+    getUid: vi.fn(() => "uid-123"),
+}))
+
+describe("misc store loadLoginConfig", () => {
+    beforeEach(() => {
+        vi.resetModules()
+        axiosGet.mockReset()
+        setActivePinia(createPinia())
+    })
+
+    it("fetches the public /configs/login endpoint and returns its payload without touching the full configs state", async () => {
+        axiosGet.mockResolvedValue({data: {isBasicAuthInitialized: true}})
+
+        const {useMiscStore} = await import("override/stores/misc")
+        const miscStore = useMiscStore()
+
+        const result = await miscStore.loadLoginConfig()
+
+        expect(axiosGet).toHaveBeenCalledTimes(1)
+        expect(axiosGet.mock.calls[0][0]).toMatch(/\/configs\/login$/)
+        expect(result).toEqual({isBasicAuthInitialized: true})
+        // The minimal login-config call must not populate the full configs state
+        // (that would defeat the point of keeping the full payload behind auth).
+        expect(miscStore.configs).toBeUndefined()
+    })
+
+    it("keeps loadConfigs hitting the full /configs endpoint separately", async () => {
+        axiosGet.mockResolvedValue({data: {isBasicAuthInitialized: true, version: "1.2.3"}})
+
+        const {useMiscStore} = await import("override/stores/misc")
+        const miscStore = useMiscStore()
+
+        await miscStore.loadConfigs()
+
+        expect(axiosGet.mock.calls[0][0]).toMatch(/\/configs$/)
+        expect(miscStore.configs).toEqual({isBasicAuthInitialized: true, version: "1.2.3"})
+    })
+})

--- a/webserver/src/main/java/io/kestra/webserver/controllers/api/MiscController.java
+++ b/webserver/src/main/java/io/kestra/webserver/controllers/api/MiscController.java
@@ -124,7 +124,10 @@ public class MiscController {
 
     @Get("/configs")
     @ExecuteOn(TaskExecutors.IO)
-    @Operation(tags = { "Misc" }, summary = "Retrieve the instance configuration.", description = "Global endpoint available to all users.")
+    @Operation(
+        tags = { "Misc" }, summary = "Retrieve the instance configuration.",
+        description = "Requires authentication; see /configs/login for the public, unauthenticated subset used by the login page."
+    )
     public Configuration getConfiguration() throws JsonProcessingException { // JsonProcessingException might be thrown in EE
         Configuration.ConfigurationBuilder<?, ?> builder = Configuration
             .builder()
@@ -144,7 +147,7 @@ public class MiscController {
             )
             .isAiEnabled(applicationContext.containsBean(AiController.class))
             .isAiApiKeyConfigured(aiServiceManager.map(AiServiceManager::hasConfiguredProvider).orElse(false))
-            .isBasicAuthInitialized(basicAuthService.map(BasicAuthService::isBasicAuthInitialized).orElse(false))
+            .isBasicAuthInitialized(isBasicAuthInitialized())
             .systemNamespace(systemFlowsConfiguration.namespace())
             .hiddenLabelsPrefixes(hiddenLabelsPrefixes)
             .url(kestraUrl)
@@ -163,6 +166,20 @@ public class MiscController {
         }
 
         return builder.build();
+    }
+
+    @Get("/configs/login")
+    @ExecuteOn(TaskExecutors.IO)
+    @Operation(
+        tags = { "Misc" }, summary = "Retrieve the configuration required by the login page.",
+        description = "Public endpoint available to unauthenticated users; exposes only what the login/setup UI needs."
+    )
+    public LoginConfiguration getLoginConfiguration() {
+        return new LoginConfiguration(isBasicAuthInitialized());
+    }
+
+    private boolean isBasicAuthInitialized() {
+        return basicAuthService.map(BasicAuthService::isBasicAuthInitialized).orElse(false);
     }
 
     @Get("/{tenant}/usages/all")
@@ -203,7 +220,10 @@ public class MiscController {
 
     @Post("/login")
     @ExecuteOn(TaskExecutors.IO)
-    @Operation(tags = { "Misc" }, summary = "Authenticate with basic auth credentials.", description = "On success, issues an HttpOnly session cookie; the credentials never need to be readable by client-side JavaScript.")
+    @Operation(
+        tags = { "Misc" }, summary = "Authenticate with basic auth credentials.",
+        description = "On success, issues an HttpOnly session cookie; the credentials never need to be readable by client-side JavaScript."
+    )
     public MutableHttpResponse<?> login(HttpRequest<?> request, @Body LoginRequest loginRequest) {
         BasicAuthService service = basicAuthService
             .orElseThrow(() -> new IllegalStateException("basicAuthService bean is required in OSS"));
@@ -237,7 +257,8 @@ public class MiscController {
             .sameSite(SameSite.Strict);
     }
 
-    public record LoginRequest(String username, String password) {}
+    public record LoginRequest(String username, String password) {
+    }
 
     @Get("/pebble/filters")
     @ExecuteOn(TaskExecutors.IO)
@@ -320,5 +341,11 @@ public class MiscController {
     public static class ApiUsage {
         private FlowUsage flows;
         private ExecutionUsage executions;
+    }
+
+    /**
+     * Minimal configuration exposed to unauthenticated callers for the login/setup UI.
+     */
+    public record LoginConfiguration(@JsonInclude Boolean isBasicAuthInitialized) {
     }
 }

--- a/webserver/src/main/java/io/kestra/webserver/filter/AuthenticationFilter.java
+++ b/webserver/src/main/java/io/kestra/webserver/filter/AuthenticationFilter.java
@@ -47,7 +47,7 @@ public class AuthenticationFilter implements HttpServerFilter {
             .flatMap(basicAuthConfiguration ->
             {
                 String normalizedPath = normalizePath(request.getPath());
-                boolean isConfigEndpoint = "/api/v1/configs".equals(normalizedPath)
+                boolean isConfigEndpoint = "/api/v1/configs/login".equals(normalizedPath)
                     || "/api/v1/login".equals(normalizedPath)
                     || ((normalizedPath.matches("/api/v1(/[^/]+)?/basicAuth") || "/api/v1/basicAuthValidationErrors".equals(normalizedPath))
                         && !basicAuthService.isBasicAuthInitialized());

--- a/webserver/src/main/java/io/kestra/webserver/rooting/TenantAliasingRooter.java
+++ b/webserver/src/main/java/io/kestra/webserver/rooting/TenantAliasingRooter.java
@@ -22,7 +22,8 @@ public class TenantAliasingRooter extends DefaultRouter {
 
     protected static final List<Pattern> EXCLUDED_ROUTES = List.of(
         Pattern.compile("/api/v1/main/.*"),
-        Pattern.compile("/api/v1/configs")
+        Pattern.compile("/api/v1/configs"),
+        Pattern.compile("/api/v1/configs/login")
     );
 
     @Inject

--- a/webserver/src/test/java/io/kestra/webserver/controllers/api/MiscControllerTest.java
+++ b/webserver/src/test/java/io/kestra/webserver/controllers/api/MiscControllerTest.java
@@ -100,6 +100,22 @@ class MiscControllerTest {
     }
 
     @Test
+    void getLoginConfiguration() {
+        // /api/v1/configs/login is the only config endpoint reachable without authentication:
+        // it must expose isBasicAuthInitialized and nothing else (no version, commit id, queue
+        // type, plugin hash, system namespace, url, ...).
+        TestAuthFilter.ENABLED = false;
+        try {
+            var response = client.toBlocking().retrieve(GET("/api/v1/configs/login"), Argument.mapOf(String.class, Object.class));
+
+            assertThat(response).containsOnlyKeys("isBasicAuthInitialized");
+            assertThat(response.get("isBasicAuthInitialized")).isEqualTo(true);
+        } finally {
+            TestAuthFilter.ENABLED = true;
+        }
+    }
+
+    @Test
     @FlakyTest(description = "BasicAuth state from other tests leaks; needs full security lifecycle isolation")
     void getEmptyValidationErrors() {
         List<String> response = client.toBlocking().retrieve(GET("/api/v1/basicAuthValidationErrors"), Argument.LIST_OF_STRING);

--- a/webserver/src/test/java/io/kestra/webserver/filter/AuthenticationFilterTest.java
+++ b/webserver/src/test/java/io/kestra/webserver/filter/AuthenticationFilterTest.java
@@ -42,9 +42,23 @@ class AuthenticationFilterTest {
     private SettingRepositoryInterface settingRepository;
 
     @Test
-    void testConfigEndpointAlwaysOpen() {
+    void testConfigEndpointRequiresAuthentication() {
+        // GHSA fix follow-up: /api/v1/configs discloses sensitive instance metadata
+        // (version, commit id, queue type, plugin hash, ...) so it must no longer be
+        // reachable without valid credentials.
+        HttpClientResponseException httpClientResponseException = assertThrows(
+            HttpClientResponseException.class, () -> client.toBlocking()
+                .exchange(HttpRequest.GET("/api/v1/configs").basicAuth("anonymous", "hacker"))
+        );
+        assertThat(httpClientResponseException.getStatus().getCode()).isEqualTo(HttpStatus.UNAUTHORIZED.getCode());
+    }
+
+    @Test
+    void testLoginConfigEndpointAlwaysOpen() {
+        // Only the minimal login-config endpoint is public; the login/setup UI only needs
+        // isBasicAuthInitialized before the user is authenticated.
         var response = client.toBlocking()
-            .exchange(HttpRequest.GET("/api/v1/configs").basicAuth("anonymous", "hacker"));
+            .exchange(HttpRequest.GET("/api/v1/configs/login").basicAuth("anonymous", "hacker"));
         assertThat(response.getStatus().getCode()).isEqualTo(HttpStatus.OK.getCode());
     }
 
@@ -54,6 +68,17 @@ class AuthenticationFilterTest {
         HttpClientResponseException httpClientResponseException = assertThrows(
             HttpClientResponseException.class, () -> client.toBlocking()
                 .exchange(HttpRequest.GET("/api/v1/main/flows/namespace/configs").basicAuth("anonymous", "hacker"))
+        );
+        assertThat(httpClientResponseException.getStatus().getCode()).isEqualTo(HttpStatus.UNAUTHORIZED.getCode());
+    }
+
+    @Test
+    void loginConfigEndpointShouldBeCheckedExactly() {
+        // Same GHSA-5vc5-wxxq-3fjx class of bypass, applied to the new public /configs/login route:
+        // a deeper path merely ending with /configs/login must not be treated as the public endpoint.
+        HttpClientResponseException httpClientResponseException = assertThrows(
+            HttpClientResponseException.class, () -> client.toBlocking()
+                .exchange(HttpRequest.GET("/api/v1/main/flows/namespace/configs/login").basicAuth("anonymous", "hacker"))
         );
         assertThat(httpClientResponseException.getStatus().getCode()).isEqualTo(HttpStatus.UNAUTHORIZED.getCode());
     }
@@ -168,7 +193,7 @@ class AuthenticationFilterTest {
     void shouldWorkWithoutPersistedConfiguration() {
         settingRepository.delete(Setting.builder().key(BASIC_AUTH_SETTINGS_KEY).build());
         var response = client.toBlocking()
-            .exchange(HttpRequest.GET("/api/v1/configs").basicAuth("anonymous", "hacker"));
+            .exchange(HttpRequest.GET("/api/v1/configs/login"));
         assertThat(response.getStatus().getCode()).isEqualTo(HttpStatus.OK.getCode());
     }
 


### PR DESCRIPTION
## Summary

`/api/v1/configs` was unconditionally whitelisted in `AuthenticationFilter` and returned sensitive instance metadata to any unauthenticated caller: exact Kestra version, commit id/date, queue type, system namespace, hidden-label prefixes, plugin hash, and instance URL. `isBasicAuthInitialized: false` also let attackers automate discovery of unsecured instances (kestra-io/kestra-ee#7987).

- Adds a new minimal public endpoint `GET /api/v1/configs/login` returning only `{isBasicAuthInitialized}` — the single field the login/setup UI needs before authentication.
- `/api/v1/configs` now requires authentication like any other endpoint; only `/api/v1/configs/login` is whitelisted in `AuthenticationFilter`, with the same exact-match bypass protection (GHSA-5vc5-wxxq-3fjx class) as the existing `/configs`/`basicAuth` whitelist entries.
- Updates the frontend's pre-authentication flows (router guard in `main.ts`, the login page, the first-run setup wizard) to call the new minimal endpoint instead of the full one. The full config is now only loaded once the user is authenticated (post-login, post-account-creation).
- `TenantAliasingRooter`'s exclusion list is updated to include the new route for consistency with the existing `/api/v1/configs` entry.

Fixes https://github.com/kestra-io/kestra-ee/issues/7987

## Test plan

- [x] `./gradlew :webserver:test --tests "io.kestra.webserver.filter.AuthenticationFilterTest" --tests "io.kestra.webserver.controllers.api.MiscControllerTest"` — 25/25 passing, including new tests asserting `/api/v1/configs` now requires auth and `/api/v1/configs/login` is public and exact-match-checked.
- [x] `cd ui && npx vitest run tests/unit` — 731/731 passing, including new tests for `loadLoginConfig()` and `addBasicAuth()`'s config-loading order.
- [x] `cd ui && vue-tsc --build tsconfig.app.json` — clean.