### PR TITLE
feat(executions): add IN/NOT_IN operators to the log level filter

### DIFF
--- a/core/src/main/java/io/kestra/core/models/QueryFilter.java
+++ b/core/src/main/java/io/kestra/core/models/QueryFilter.java
@@ -411,7 +411,7 @@ public record QueryFilter(
         LEVEL("level") {
             @Override
             public List<Op> supportedOp() {
-                return List.of(Op.GREATER_THAN_OR_EQUAL_TO, Op.LESS_THAN_OR_EQUAL_TO);
+                return List.of(Op.GREATER_THAN_OR_EQUAL_TO, Op.LESS_THAN_OR_EQUAL_TO, Op.IN, Op.NOT_IN);
             }
         },
         @JsonProperty("path")

--- a/core/src/test/java/io/kestra/core/models/QueryFilterTest.java
+++ b/core/src/test/java/io/kestra/core/models/QueryFilterTest.java
@@ -228,7 +228,9 @@ public class QueryFilterTest {
                 Field.LEVEL, Resource.LOG,
                 Set.of(
                     Op.GREATER_THAN_OR_EQUAL_TO,
-                    Op.LESS_THAN_OR_EQUAL_TO
+                    Op.LESS_THAN_OR_EQUAL_TO,
+                    Op.IN,
+                    Op.NOT_IN
                 )
             ),
 
@@ -1078,8 +1080,6 @@ public class QueryFilterTest {
                     Op.NOT_EQUALS,
                     Op.GREATER_THAN,
                     Op.LESS_THAN,
-                    Op.IN,
-                    Op.NOT_IN,
                     Op.STARTS_WITH,
                     Op.ENDS_WITH,
                     Op.CONTAINS,

--- a/jdbc-postgres/src/main/java/io/kestra/repository/postgres/PostgresLogDataStore.java
+++ b/jdbc-postgres/src/main/java/io/kestra/repository/postgres/PostgresLogDataStore.java
@@ -52,6 +52,11 @@ public class PostgresLogDataStore extends AbstractJdbcLogDataStore implements Ap
     }
 
     @Override
+    protected Condition notLevelsCondition(List<Level> levels) {
+        return PostgresLogRepositoryService.notLevelsCondition(levels);
+    }
+
+    @Override
     protected Field<Date> formatDateField(String dateField, DateUtils.GroupType groupType) {
         return PostgresRepositoryUtils.formatDateField(dateField, groupType);
     }

--- a/jdbc-postgres/src/main/java/io/kestra/repository/postgres/PostgresLogRepositoryService.java
+++ b/jdbc-postgres/src/main/java/io/kestra/repository/postgres/PostgresLogRepositoryService.java
@@ -35,6 +35,18 @@ public final class PostgresLogRepositoryService {
         );
     }
 
+    public static Condition notLevelsCondition(List<Level> levels) {
+        return DSL.condition(
+            "level not in (" +
+                levels
+                    .stream()
+                    .map(s -> "'" + s + "'::log_level")
+                    .collect(Collectors.joining(", "))
+                +
+                ")"
+        );
+    }
+
     @SuppressWarnings("unchecked")
     public static <F extends Enum<F>> SelectConditionStep<org.jooq.Record> where(SelectConditionStep<Record> selectConditionStep, JdbcFilterService jdbcFilterService,
         List<AbstractFilter<F>> filters, Map<F, String> fieldsMapping) {

--- a/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcLogDataStore.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcLogDataStore.java
@@ -434,6 +434,10 @@ public abstract class AbstractJdbcLogDataStore extends AbstractJdbcCrudRepositor
         return field("level").in(levels.stream().map(level -> level.name()).toList());
     }
 
+    protected Condition notLevelsCondition(List<Level> levels) {
+        return field("level").notIn(levels.stream().map(level -> level.name()).toList());
+    }
+
     public Double fetchValue(String tenantId, DataFilterKPI<Logs.Fields, ? extends ColumnDescriptor<Logs.Fields>> dataFilter, ZonedDateTime startDate, ZonedDateTime endDate,
         boolean numeratorFilter) {
         // A store that can't aggregate (canAggregate() == false) yields a zero KPI instead of running a query, so

--- a/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcRepository.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcRepository.java
@@ -639,19 +639,34 @@ public abstract class AbstractJdbcRepository {
     }
 
     private Condition handleLevelField(Object value, QueryFilter.Op operation) {
-        Level level = value instanceof Level ? (Level) value : Level.valueOf((String) value);
-
         return switch (operation) {
-            case GREATER_THAN_OR_EQUAL_TO -> levelsCondition(LogEntry.findLevelsByMin(level));
-            case LESS_THAN_OR_EQUAL_TO -> levelsCondition(LogEntry.findLevelsByMax(level));
+            case GREATER_THAN_OR_EQUAL_TO -> levelsCondition(LogEntry.findLevelsByMin(toLevel(value)));
+            case LESS_THAN_OR_EQUAL_TO -> levelsCondition(LogEntry.findLevelsByMax(toLevel(value)));
+            case IN -> levelsCondition(toLevelList(value));
+            case NOT_IN -> notLevelsCondition(toLevelList(value));
             default -> throw new InvalidQueryFiltersException(
                 "Unsupported operation for LEVEL: " + operation
             );
         };
     }
 
+    private static Level toLevel(Object value) {
+        return value instanceof Level level ? level : Level.valueOf((String) value);
+    }
+
+    private static List<Level> toLevelList(Object value) {
+        if (value instanceof List<?> list) {
+            return list.stream().map(AbstractJdbcRepository::toLevel).toList();
+        }
+        return List.of(toLevel(value));
+    }
+
     protected Condition levelsCondition(List<Level> levels) {
         return field("level").in(levels.stream().map(level -> level.name()).toList());
+    }
+
+    protected Condition notLevelsCondition(List<Level> levels) {
+        return field("level").notIn(levels.stream().map(level -> level.name()).toList());
     }
 
     protected Condition handleAttemptNumberField(Object value, QueryFilter.Op operation) {

--- a/tests/src/main/java/io/kestra/core/repositories/AbstractLogDataStoreTest.java
+++ b/tests/src/main/java/io/kestra/core/repositories/AbstractLogDataStoreTest.java
@@ -329,6 +329,8 @@ public abstract class AbstractLogDataStoreTest {
         leaf(Group.LEVELS, Field.LEVEL, Op.LESS_THAN_OR_EQUAL_TO, Level.ERROR, "exec-trace", "exec-debug", "exec-info", "exec-warn", "exec-error"),
         leaf(Group.LEVELS, Field.LEVEL, Op.GREATER_THAN_OR_EQUAL_TO, Level.ERROR, "exec-error"),
         leaf(Group.LEVELS, Field.LEVEL, Op.LESS_THAN_OR_EQUAL_TO, Level.TRACE, "exec-trace"),
+        leaf(Group.LEVELS, Field.LEVEL, Op.IN, List.of(Level.WARN, Level.ERROR), "exec-warn", "exec-error"),
+        leaf(Group.LEVELS, Field.LEVEL, Op.NOT_IN, List.of(Level.WARN, Level.ERROR), "exec-trace", "exec-debug", "exec-info"),
 
         // TASK_ID / TASK_RUN_ID / ATTEMPT_NUMBER (TASKS)
         leaf(Group.TASKS, Field.TASK_ID, Op.EQUALS, "load-data", "exec-load-data"),

--- a/ui/packages/design-system/src/components/Data/KsDataTable/filter/ConditionRow.vue
+++ b/ui/packages/design-system/src/components/Data/KsDataTable/filter/ConditionRow.vue
@@ -126,6 +126,7 @@
     import {
         Comparators,
         COMPARATOR_LABELS,
+        RANGE_COMPARATORS,
         TEXT_COMPARATORS,
         type AppliedFilter,
         type FilterKeyConfig,
@@ -171,7 +172,10 @@
         return "text"
     })
 
-    const isMulti = computed(() => keyConfig.value?.valueType === "multi-select")
+    const isMulti = computed(
+        () => keyConfig.value?.valueType === "multi-select"
+            && !RANGE_COMPARATORS.includes(props.filter.comparator),
+    )
 
     const isStatusColored = computed(() => keyConfig.value?.colored === true)
 
@@ -228,12 +232,17 @@
         })
     }
 
-    const changeComparator = (op: Comparators) =>
+    const changeComparator = (op: Comparators) => {
+        const wasMulti = isMulti.value
+        const willBeMulti = keyConfig.value?.valueType === "multi-select" && !RANGE_COMPARATORS.includes(op)
+
         emit("update", {
             ...props.filter,
             comparator: op,
             comparatorLabel: labelForComparator(op),
+            ...(wasMulti !== willBeMulti ? {value: willBeMulti ? [] : "", valueLabel: ""} : {}),
         })
+    }
 
     const onText = (value: string | number | undefined) => {
         const text = value == null ? "" : String(value)

--- a/ui/packages/design-system/src/components/Data/KsDataTable/filter/layout/FilterEditPopper.vue
+++ b/ui/packages/design-system/src/components/Data/KsDataTable/filter/layout/FilterEditPopper.vue
@@ -39,6 +39,7 @@
         type FilterKeyConfig,
         type FilterValue,
         COMPARATOR_LABELS,
+        RANGE_COMPARATORS,
         TEXT_COMPARATORS,
         KV_COMPARATORS,
     } from "../utils/filterTypes"
@@ -122,6 +123,16 @@
     const supportsServerSideSearch = computed(() =>
         (props.filterKey?.valueProvider?.length ?? 0) > 0,
     )
+
+    // Range/threshold comparators (GTE/LTE/…) always target one bound value.
+    // Other comparators (IN/NOT_IN) are multi-value.
+    const effectiveValueType = computed(() => {
+        const type = props.filterKey?.valueType
+        if (type === "multi-select" && RANGE_COMPARATORS.includes(state.selectedComparator)) {
+            return "select"
+        }
+        return type
+    })
 
     const valueComponent = computed(() => {
         if (isTextOp.value) {
@@ -213,7 +224,7 @@
             },
         }
 
-        const valueType = props.filterKey.valueType === "time-range" ? "select" : props.filterKey.valueType
+        const valueType = props.filterKey.valueType === "time-range" ? "select" : effectiveValueType.value
 
         return (
             componentConfigs[valueType as keyof typeof componentConfigs] || null
@@ -227,7 +238,7 @@
             return t("filter.kv_pair_selected", {count: state.keyValuePair.length})
         }
 
-        switch (props.filterKey?.valueType) {
+        switch (effectiveValueType.value) {
         case "multi-select":
             return `${state.keyValuePair.length} ${props.filterKey?.label} selected`
         case "select":
@@ -277,7 +288,7 @@
             }
         }
 
-        switch (props.filterKey.valueType) {
+        switch (effectiveValueType.value) {
         case "text":
             return {value: state.textValue, label: state.textValue}
         case "select":
@@ -339,7 +350,7 @@
     }
 
     const emptyValueForType = (): AppliedFilter["value"] => {
-        const type = props.filterKey?.valueType
+        const type = effectiveValueType.value
         return type === "multi-select" || type === "key-value" ? [] : ""
     }
 
@@ -413,7 +424,7 @@
                     ? [filter.value]
                     : []
         } else {
-            switch (props.filterKey.valueType) {
+            switch (effectiveValueType.value) {
             case "text":
                 state.textValue = typeof filter.value === "string" ? filter.value : ""
                 break

--- a/ui/packages/design-system/src/components/Data/KsDataTable/filter/utils/filterChipFactory.ts
+++ b/ui/packages/design-system/src/components/Data/KsDataTable/filter/utils/filterChipFactory.ts
@@ -3,6 +3,7 @@ import {
     type FilterKeyConfig,
     COMPARATOR_LABELS,
     Comparators,
+    RANGE_COMPARATORS,
     TEXT_COMPARATORS,
 } from "./filterTypes"
 import {type DecodedParam, keyOfComparator} from "./helpers"
@@ -91,6 +92,9 @@ export const processFieldValue = (
     comparator: Comparators,
 ): {value: AppliedFilter["value"]; valueLabel: string} => {
     const isTextOp = TEXT_COMPARATORS.includes(comparator)
+    // Range/threshold comparators (GTE/LTE/…) always target one bound value.
+    // Other comparators (IN/NOT_IN) are multi-value.
+    const isSingleValueOp = isTextOp || RANGE_COMPARATORS.includes(comparator)
 
     if (config?.valueType === "key-value") {
         const combinedValue = params.map(p => p?.value as string)
@@ -102,7 +106,7 @@ export const processFieldValue = (
         }
     }
 
-    if (config?.valueType === "multi-select" && !isTextOp) {
+    if (config?.valueType === "multi-select" && !isSingleValueOp) {
         const combinedValue = params.flatMap(p =>
             Array.isArray(p?.value) ? p.value : (p?.value as string)?.split(",") ?? [],
         )

--- a/ui/packages/design-system/src/components/Data/KsDataTable/filter/utils/filterTypes.ts
+++ b/ui/packages/design-system/src/components/Data/KsDataTable/filter/utils/filterTypes.ts
@@ -20,6 +20,13 @@ export const TEXT_COMPARATORS = [
     Comparators.ENDS_WITH,
     Comparators.STARTS_WITH,
 ]
+// Range/threshold comparators always target a single bound value
+export const RANGE_COMPARATORS = [
+    Comparators.GREATER_THAN,
+    Comparators.LESS_THAN,
+    Comparators.GREATER_THAN_OR_EQUAL_TO,
+    Comparators.LESS_THAN_OR_EQUAL_TO,
+]
 
 export interface DateFilterOption {
     value: string;

--- a/ui/packages/design-system/src/components/Data/KsDataTable/filter/utils/logLevelQuery.ts
+++ b/ui/packages/design-system/src/components/Data/KsDataTable/filter/utils/logLevelQuery.ts
@@ -10,20 +10,31 @@ import {Comparators} from "./filterTypes"
 const LEVEL_FILTER_PREFIX = "filters[level]["
 const LEVEL_GTE_FILTER_KEY = "filters[level][GREATER_THAN_OR_EQUAL_TO]"
 const LEVEL_LTE_FILTER_KEY = "filters[level][LESS_THAN_OR_EQUAL_TO]"
+const LEVEL_IN_FILTER_KEY = "filters[level][IN]"
+const LEVEL_NOT_IN_FILTER_KEY = "filters[level][NOT_IN]"
 const LEVEL_EQUALS_FILTER_KEY = "filters[level][EQUALS]"
 const LEGACY_LEVEL_FILTER_KEY = "level"
 
 const SUPPORTED_LEVEL_FILTER_KEYS = new Set([
     LEVEL_GTE_FILTER_KEY,
     LEVEL_LTE_FILTER_KEY,
+    LEVEL_IN_FILTER_KEY,
+    LEVEL_NOT_IN_FILTER_KEY,
     LEVEL_EQUALS_FILTER_KEY,
 ])
 
-export type LevelFilterDirection = "min" | "max";
+export type LevelFilterDirection = "min" | "max" | "in" | "not_in";
 
 export interface LevelFilterValue {
     value: string;
     direction: LevelFilterDirection;
+}
+
+const LEVEL_FILTER_KEY_BY_DIRECTION: Record<LevelFilterDirection, string> = {
+    min: LEVEL_GTE_FILTER_KEY,
+    max: LEVEL_LTE_FILTER_KEY,
+    in: LEVEL_IN_FILTER_KEY,
+    not_in: LEVEL_NOT_IN_FILTER_KEY,
 }
 
 const firstStringValue = (
@@ -54,6 +65,16 @@ export const readRouteLevelFilter = (query: LocationQuery | LocationQueryRaw): L
         return {value: gte, direction: "min"}
     }
 
+    const notIn = nonEmpty(firstStringValue(query[LEVEL_NOT_IN_FILTER_KEY]))
+    if (notIn) {
+        return {value: notIn, direction: "not_in"}
+    }
+
+    const inValues = nonEmpty(firstStringValue(query[LEVEL_IN_FILTER_KEY]))
+    if (inValues) {
+        return {value: inValues, direction: "in"}
+    }
+
     // Legacy: EQUALS (pre-rename) and bare `level` query param both meant "at or above"
     const legacyEquals = nonEmpty(firstStringValue(query[LEVEL_EQUALS_FILTER_KEY]))
     if (legacyEquals) {
@@ -81,11 +102,21 @@ export const readAppliedLevelFilter = (filters: AppliedFilter[]): LevelFilterVal
         return undefined
     }
 
-    const direction: LevelFilterDirection =
-        levelFilter.comparator === Comparators.LESS_THAN_OR_EQUAL_TO ? "max" : "min"
+    const direction: LevelFilterDirection = (() => {
+        switch (levelFilter.comparator) {
+        case Comparators.LESS_THAN_OR_EQUAL_TO:
+            return "max"
+        case Comparators.IN:
+            return "in"
+        case Comparators.NOT_IN:
+            return "not_in"
+        default:
+            return "min"
+        }
+    })()
 
     const rawValue = Array.isArray(levelFilter.value)
-        ? levelFilter.value[0]
+        ? (direction === "in" || direction === "not_in" ? levelFilter.value.join(",") : levelFilter.value[0])
         : levelFilter.value
 
     if (typeof rawValue !== "string" || rawValue.length === 0) {
@@ -113,8 +144,7 @@ export const normalizeRouteLevelFilter = (
         // Backward-compat: plain string callers default to min (≥) semantic
         const resolved: LevelFilterValue =
             typeof level === "string" ? {value: level, direction: "min"} : level
-        const key = resolved.direction === "max" ? LEVEL_LTE_FILTER_KEY : LEVEL_GTE_FILTER_KEY
-        normalized[key] = resolved.value
+        normalized[LEVEL_FILTER_KEY_BY_DIRECTION[resolved.direction]] = resolved.value
     }
 
     return normalized
@@ -126,6 +156,5 @@ export const levelToRequestParams = (
     if (!level) {
         return {}
     }
-    const key = level.direction === "max" ? LEVEL_LTE_FILTER_KEY : LEVEL_GTE_FILTER_KEY
-    return {[key]: level.value}
+    return {[LEVEL_FILTER_KEY_BY_DIRECTION[level.direction]]: level.value}
 }

--- a/ui/packages/design-system/tests/units/Data/KsFilter/ConditionRow.test.ts
+++ b/ui/packages/design-system/tests/units/Data/KsFilter/ConditionRow.test.ts
@@ -35,6 +35,128 @@ const baseFilter: AppliedFilter = {
 const mountRow = (filter: AppliedFilter) =>
     mount(ConditionRow, {props: {filter, allKeys: [multiKey]}, global: globalConfig})
 
+const rangeAndSetKey: FilterKeyConfig = {
+    key: "level",
+    label: "Level",
+    valueType: "multi-select",
+    comparators: [
+        Comparators.GREATER_THAN_OR_EQUAL_TO,
+        Comparators.LESS_THAN_OR_EQUAL_TO,
+        Comparators.IN,
+        Comparators.NOT_IN,
+    ],
+    valueProvider: async () => [
+        {label: "WARN", value: "WARN"},
+        {label: "ERROR", value: "ERROR"},
+    ],
+}
+
+const mountLevelRow = (filter: AppliedFilter) =>
+    mount(ConditionRow, {props: {filter, allKeys: [rangeAndSetKey]}, global: globalConfig})
+
+describe("ConditionRow range comparators on a multi-select field", () => {
+    test("renders a plain select (not the multi-select popover) for GREATER_THAN_OR_EQUAL_TO", () => {
+        const wrapper = mountLevelRow({
+            id: "f1",
+            key: "level",
+            keyLabel: "Level",
+            comparator: Comparators.GREATER_THAN_OR_EQUAL_TO,
+            comparatorLabel: "At or Above",
+            value: "WARN",
+            valueLabel: "WARN",
+        })
+
+        expect(wrapper.findComponent(FilterMultiSelect).exists()).toBe(false)
+        expect(wrapper.find(".cond-value-select").exists()).toBe(true)
+    })
+
+    test("renders the multi-select popover for IN", () => {
+        const wrapper = mountLevelRow({
+            id: "f1",
+            key: "level",
+            keyLabel: "Level",
+            comparator: Comparators.IN,
+            comparatorLabel: "In",
+            value: ["WARN", "ERROR"],
+            valueLabel: "WARN, ERROR",
+        })
+
+        expect(wrapper.findComponent(FilterMultiSelect).exists()).toBe(true)
+        expect(wrapper.find(".cond-value-select").exists()).toBe(false)
+    })
+
+    test("resets a stale multi-value when switching from IN to GREATER_THAN_OR_EQUAL_TO", async () => {
+        const wrapper = mountLevelRow({
+            id: "f1",
+            key: "level",
+            keyLabel: "Level",
+            comparator: Comparators.IN,
+            comparatorLabel: "In",
+            value: ["WARN", "ERROR"],
+            valueLabel: "WARN, ERROR",
+        })
+
+        const opSelect = wrapper.findComponent(".cond-op")
+        opSelect.vm.$emit("update:modelValue", Comparators.GREATER_THAN_OR_EQUAL_TO)
+        await nextTick()
+
+        const updates = wrapper.emitted("update") as Array<[AppliedFilter]> | undefined
+        expect(updates).toBeTruthy()
+        expect(updates!.at(-1)![0]).toMatchObject({
+            comparator: Comparators.GREATER_THAN_OR_EQUAL_TO,
+            value: "",
+            valueLabel: "",
+        })
+    })
+
+    test("resets a stale scalar value when switching from GREATER_THAN_OR_EQUAL_TO to IN", async () => {
+        const wrapper = mountLevelRow({
+            id: "f1",
+            key: "level",
+            keyLabel: "Level",
+            comparator: Comparators.GREATER_THAN_OR_EQUAL_TO,
+            comparatorLabel: "At or Above",
+            value: "WARN",
+            valueLabel: "WARN",
+        })
+
+        const opSelect = wrapper.findComponent(".cond-op")
+        opSelect.vm.$emit("update:modelValue", Comparators.IN)
+        await nextTick()
+
+        const updates = wrapper.emitted("update") as Array<[AppliedFilter]> | undefined
+        expect(updates).toBeTruthy()
+        expect(updates!.at(-1)![0]).toMatchObject({
+            comparator: Comparators.IN,
+            value: [],
+            valueLabel: "",
+        })
+    })
+
+    test("keeps the value when switching between the two range comparators", async () => {
+        const wrapper = mountLevelRow({
+            id: "f1",
+            key: "level",
+            keyLabel: "Level",
+            comparator: Comparators.GREATER_THAN_OR_EQUAL_TO,
+            comparatorLabel: "At or Above",
+            value: "WARN",
+            valueLabel: "WARN",
+        })
+
+        const opSelect = wrapper.findComponent(".cond-op")
+        opSelect.vm.$emit("update:modelValue", Comparators.LESS_THAN_OR_EQUAL_TO)
+        await nextTick()
+
+        const updates = wrapper.emitted("update") as Array<[AppliedFilter]> | undefined
+        expect(updates).toBeTruthy()
+        expect(updates!.at(-1)![0]).toMatchObject({
+            comparator: Comparators.LESS_THAN_OR_EQUAL_TO,
+            value: "WARN",
+        })
+    })
+})
+
 describe("ConditionRow multi-select commit on close", () => {
     test("commits a staged multi-select selection when unmounted (e.g. modal dismissed by overlay click)", async () => {
         const wrapper = mountRow(baseFilter)

--- a/ui/packages/design-system/tests/units/Data/KsFilter/FilterEditPopper.test.ts
+++ b/ui/packages/design-system/tests/units/Data/KsFilter/FilterEditPopper.test.ts
@@ -1,0 +1,100 @@
+import {describe, test, expect} from "vitest"
+import {mount, flushPromises} from "@vue/test-utils"
+import {createI18n} from "vue-i18n"
+import KestraDesignSystem from "../../../../src/index"
+import FilterEditPopper from "../../../../src/components/Data/KsDataTable/filter/layout/FilterEditPopper.vue"
+import FilterSelect from "../../../../src/components/Data/KsDataTable/filter/layout/FilterSelect.vue"
+import FilterMultiSelect from "../../../../src/components/Data/KsDataTable/filter/layout/FilterMultiSelect.vue"
+import FilterComparatorSelect from "../../../../src/components/Data/KsDataTable/filter/layout/FilterComparatorSelect.vue"
+import {Comparators, type AppliedFilter, type FilterKeyConfig} from "../../../../src/components/Data/KsDataTable/filter/utils/filterTypes"
+
+const i18n = createI18n({legacy: false, locale: "en", messages: {en: {}}})
+const globalConfig = {plugins: [i18n, KestraDesignSystem]}
+
+const levelKey: FilterKeyConfig = {
+    key: "level",
+    label: "Level",
+    valueType: "multi-select",
+    comparators: [
+        Comparators.GREATER_THAN_OR_EQUAL_TO,
+        Comparators.LESS_THAN_OR_EQUAL_TO,
+        Comparators.IN,
+        Comparators.NOT_IN,
+    ],
+    comparatorLabels: {
+        [Comparators.GREATER_THAN_OR_EQUAL_TO]: "At or Above",
+        [Comparators.LESS_THAN_OR_EQUAL_TO]: "At or Below",
+    },
+    valueProvider: async () => [
+        {label: "WARN", value: "WARN"},
+        {label: "ERROR", value: "ERROR"},
+    ],
+}
+
+const mountPopper = async (filter: AppliedFilter) => {
+    const wrapper = mount(FilterEditPopper, {
+        props: {filter, filterKey: levelKey, showComparatorSelection: true},
+        global: globalConfig,
+    })
+    await flushPromises()
+    return wrapper
+}
+
+describe("FilterEditPopper range comparators on a multi-select field", () => {
+    test("renders a plain select (not the multi-select checkbox popover) for GREATER_THAN_OR_EQUAL_TO", async () => {
+        const wrapper = await mountPopper({
+            id: "f1",
+            key: "level",
+            keyLabel: "Level",
+            comparator: Comparators.GREATER_THAN_OR_EQUAL_TO,
+            comparatorLabel: "At or Above",
+            value: "WARN",
+            valueLabel: "WARN",
+        })
+
+        expect(wrapper.findComponent(FilterSelect).exists()).toBe(true)
+        expect(wrapper.findComponent(FilterMultiSelect).exists()).toBe(false)
+    })
+
+    test("renders the multi-select checkbox popover for IN", async () => {
+        const wrapper = await mountPopper({
+            id: "f1",
+            key: "level",
+            keyLabel: "Level",
+            comparator: Comparators.IN,
+            comparatorLabel: "In",
+            value: ["WARN", "ERROR"],
+            valueLabel: "WARN, ERROR",
+        })
+
+        expect(wrapper.findComponent(FilterMultiSelect).exists()).toBe(true)
+        expect(wrapper.findComponent(FilterSelect).exists()).toBe(false)
+    })
+
+    test("switches from the multi-select popover to a plain select when the comparator changes to GREATER_THAN_OR_EQUAL_TO", async () => {
+        const wrapper = await mountPopper({
+            id: "f1",
+            key: "level",
+            keyLabel: "Level",
+            comparator: Comparators.IN,
+            comparatorLabel: "In",
+            value: ["WARN", "ERROR"],
+            valueLabel: "WARN, ERROR",
+        })
+
+        expect(wrapper.findComponent(FilterMultiSelect).exists()).toBe(true)
+
+        wrapper.findComponent(FilterComparatorSelect).vm.$emit("update:selectedComparator", Comparators.GREATER_THAN_OR_EQUAL_TO)
+        await flushPromises()
+
+        expect(wrapper.findComponent(FilterMultiSelect).exists()).toBe(false)
+        expect(wrapper.findComponent(FilterSelect).exists()).toBe(true)
+
+        const updates = wrapper.emitted("update") as Array<[AppliedFilter]> | undefined
+        expect(updates).toBeTruthy()
+        expect(updates!.at(-1)![0]).toMatchObject({
+            comparator: Comparators.GREATER_THAN_OR_EQUAL_TO,
+            value: "",
+        })
+    })
+})

--- a/ui/packages/design-system/tests/units/Data/logLevelQuery.test.ts
+++ b/ui/packages/design-system/tests/units/Data/logLevelQuery.test.ts
@@ -35,6 +35,27 @@ describe("logLevelQuery", () => {
             ).toEqual({value: "INFO", direction: "max"})
         })
 
+        test("reads the NOT_IN filter as a not_in direction", () => {
+            expect(
+                readRouteLevelFilter({"filters[level][NOT_IN]": "TRACE,DEBUG"}),
+            ).toEqual({value: "TRACE,DEBUG", direction: "not_in"})
+        })
+
+        test("reads the IN filter as an in direction", () => {
+            expect(
+                readRouteLevelFilter({"filters[level][IN]": "WARN,ERROR"}),
+            ).toEqual({value: "WARN,ERROR", direction: "in"})
+        })
+
+        test("prefers GREATER_THAN_OR_EQUAL_TO/LESS_THAN_OR_EQUAL_TO over IN/NOT_IN", () => {
+            expect(
+                readRouteLevelFilter({
+                    "filters[level][GREATER_THAN_OR_EQUAL_TO]": "INFO",
+                    "filters[level][IN]": "WARN,ERROR",
+                }),
+            ).toEqual({value: "INFO", direction: "min"})
+        })
+
         test("reads the legacy EQUALS filter as a min direction", () => {
             expect(
                 readRouteLevelFilter({"filters[level][EQUALS]": "WARN"}),
@@ -57,7 +78,7 @@ describe("logLevelQuery", () => {
         })
 
         test("flags an unsupported level comparator", () => {
-            expect(hasUnsupportedRouteLevelComparator({"filters[level][IN]": "INFO"})).toBe(true)
+            expect(hasUnsupportedRouteLevelComparator({"filters[level][CONTAINS]": "INFO"})).toBe(true)
         })
 
         test("accepts the GREATER_THAN_OR_EQUAL_TO comparator", () => {
@@ -70,6 +91,14 @@ describe("logLevelQuery", () => {
             expect(
                 hasUnsupportedRouteLevelComparator({"filters[level][LESS_THAN_OR_EQUAL_TO]": "INFO"}),
             ).toBe(false)
+        })
+
+        test("accepts the IN comparator", () => {
+            expect(hasUnsupportedRouteLevelComparator({"filters[level][IN]": "WARN,ERROR"})).toBe(false)
+        })
+
+        test("accepts the NOT_IN comparator", () => {
+            expect(hasUnsupportedRouteLevelComparator({"filters[level][NOT_IN]": "WARN,ERROR"})).toBe(false)
         })
 
         test("accepts the legacy EQUALS comparator", () => {
@@ -106,6 +135,22 @@ describe("logLevelQuery", () => {
             ).toEqual({value: "ERROR", direction: "min"})
         })
 
+        test("reads an IN comparator as an in direction, joining the array", () => {
+            expect(
+                readAppliedLevelFilter(
+                    applied([{key: "level", value: ["WARN", "ERROR"], comparator: Comparators.IN}]),
+                ),
+            ).toEqual({value: "WARN,ERROR", direction: "in"})
+        })
+
+        test("reads a NOT_IN comparator as a not_in direction, joining the array", () => {
+            expect(
+                readAppliedLevelFilter(
+                    applied([{key: "level", value: ["TRACE", "DEBUG"], comparator: Comparators.NOT_IN}]),
+                ),
+            ).toEqual({value: "TRACE,DEBUG", direction: "not_in"})
+        })
+
         test("returns undefined when no level filter is present", () => {
             expect(
                 readAppliedLevelFilter(applied([{key: "namespace", value: "demo"}])),
@@ -127,6 +172,18 @@ describe("logLevelQuery", () => {
         test("sets a LESS_THAN_OR_EQUAL_TO filter for a max-direction level", () => {
             expect(normalizeRouteLevelFilter({}, {value: "INFO", direction: "max"})).toEqual({
                 "filters[level][LESS_THAN_OR_EQUAL_TO]": "INFO",
+            })
+        })
+
+        test("sets an IN filter for an in-direction level", () => {
+            expect(normalizeRouteLevelFilter({}, {value: "WARN,ERROR", direction: "in"})).toEqual({
+                "filters[level][IN]": "WARN,ERROR",
+            })
+        })
+
+        test("sets a NOT_IN filter for a not_in-direction level", () => {
+            expect(normalizeRouteLevelFilter({}, {value: "TRACE,DEBUG", direction: "not_in"})).toEqual({
+                "filters[level][NOT_IN]": "TRACE,DEBUG",
             })
         })
 
@@ -181,6 +238,18 @@ describe("logLevelQuery", () => {
         test("maps a max direction to LESS_THAN_OR_EQUAL_TO", () => {
             expect(levelToRequestParams({value: "INFO", direction: "max"})).toEqual({
                 "filters[level][LESS_THAN_OR_EQUAL_TO]": "INFO",
+            })
+        })
+
+        test("maps an in direction to IN", () => {
+            expect(levelToRequestParams({value: "WARN,ERROR", direction: "in"})).toEqual({
+                "filters[level][IN]": "WARN,ERROR",
+            })
+        })
+
+        test("maps a not_in direction to NOT_IN", () => {
+            expect(levelToRequestParams({value: "TRACE,DEBUG", direction: "not_in"})).toEqual({
+                "filters[level][NOT_IN]": "TRACE,DEBUG",
             })
         })
 

--- a/ui/src/components/filter/configurations/logExecutionsFilter.ts
+++ b/ui/src/components/filter/configurations/logExecutionsFilter.ts
@@ -24,12 +24,17 @@ export const useLogExecutionsFilter = (
                     key: "level",
                     label: t("filter.level_log_executions.label"),
                     description: t("filter.level.description"),
-                    comparators: [Comparators.GREATER_THAN_OR_EQUAL_TO, Comparators.LESS_THAN_OR_EQUAL_TO],
+                    comparators: [
+                        Comparators.GREATER_THAN_OR_EQUAL_TO,
+                        Comparators.LESS_THAN_OR_EQUAL_TO,
+                        Comparators.IN,
+                        Comparators.NOT_IN,
+                    ],
                     comparatorLabels: {
                         [Comparators.GREATER_THAN_OR_EQUAL_TO]: "At or Above",
                         [Comparators.LESS_THAN_OR_EQUAL_TO]: "At or Below",
                     },
-                    valueType: "select",
+                    valueType: "multi-select",
                     valueProvider: async () => {
                         const {VALUES} = useValues("logs")
                         return VALUES.LEVELS
@@ -40,6 +45,7 @@ export const useLogExecutionsFilter = (
                             : "INFO"
                     ),
                     visibleByDefault: true,
+                    colored: true,
                 },
                 {
                     key: "taskId",

--- a/ui/src/components/filter/configurations/logFilter.ts
+++ b/ui/src/components/filter/configurations/logFilter.ts
@@ -54,12 +54,17 @@ export const useLogFilter = (): ComputedRef<FilterConfiguration> => {
                     key: "level",
                     label: t("filter.level_log_executions.label"),
                     description: t("filter.level.description"),
-                    comparators: [Comparators.GREATER_THAN_OR_EQUAL_TO, Comparators.LESS_THAN_OR_EQUAL_TO],
+                    comparators: [
+                        Comparators.GREATER_THAN_OR_EQUAL_TO,
+                        Comparators.LESS_THAN_OR_EQUAL_TO,
+                        Comparators.IN,
+                        Comparators.NOT_IN,
+                    ],
                     comparatorLabels: {
                         [Comparators.GREATER_THAN_OR_EQUAL_TO]: "At or Above",
                         [Comparators.LESS_THAN_OR_EQUAL_TO]: "At or Below",
                     },
-                    valueType: "select",
+                    valueType: "multi-select",
                     valueProvider: async () => {
                         const {VALUES} = useValues("logs")
                         return VALUES.LEVELS
@@ -70,6 +75,7 @@ export const useLogFilter = (): ComputedRef<FilterConfiguration> => {
                             : "INFO"
                     ),
                     visibleByDefault: true,
+                    colored: true,
                 },
                 {
                     key: "timeRange",

--- a/ui/src/components/logs/LogsWrapper.vue
+++ b/ui/src/components/logs/LogsWrapper.vue
@@ -291,7 +291,10 @@
     const downloading = ref(false)
 
     const openDownload = () => {
-        downloadLevel.value = effectiveLogLevel.value?.value
+        const level = effectiveLogLevel.value
+        downloadLevel.value = level?.direction === "min" || level?.direction === "max"
+            ? level.value
+            : undefined
         downloadTimeRange.value = selectedTimeRange.value ?? undefined
         downloadOpen.value = true
     }


### PR DESCRIPTION
## Summary
The Logs page level filter only supported `GREATER_THAN_OR_EQUAL_TO`/`LESS_THAN_OR_EQUAL_TO` ("at or above"/"at or below" a severity threshold). Adds `IN`/`NOT_IN` alongside them so users can pick an explicit set of levels (e.g. `WARN` + `ERROR` only) instead of only a severity floor/ceiling.

Closes kestra-io/kestra-ee#5629.
Closes #16813.

**Previous filter**
<img width="1026" height="326" alt="image" src="https://github.com/user-attachments/assets/e540c2ac-cd8b-4959-b377-b13633de36e2" />

**New filter**
<img width="1010" height="345" alt="image" src="https://github.com/user-attachments/assets/e39f0ec7-d827-4b82-8013-f47f36a4c179" />

<img width="988" height="608" alt="image" src="https://github.com/user-attachments/assets/961ae9b5-ffa1-47b0-be60-0dcb4637e1f4" />

## Test plan

- [x] `QueryFilterTest` — `LEVEL` now accepts `IN`/`NOT_IN` in the valid-ops matrix (and the invalid-ops matrix no longer expects them to be rejected). 759 tests, 0 failures.
- [x] `AbstractLogDataStoreTest` (shared by H2/Postgres/MySQL) — new `IN`/`NOT_IN` leaf cases for `LEVEL`. `H2LogDataStoreTest`: 114 tests, 0 failures. `PostgresLogDataStoreTest`: 114 tests, 0 failures (covers the enum-cast path).
- [x] `logLevelQuery.test.ts` — new cases for reading/writing/normalizing the `in`/`not_in` route params and applied-filter shapes. 37 tests, 0 failures.
- [x] `ConditionRow.test.ts` — new cases asserting `GTE`/`LTE` render a plain select (not the multi-select popover) even on this multi-select-typed field, and that switching comparators across the range/set boundary resets stale values. 7 tests, 0 failures.
- [x] `npm run check:types` — clean.
- [x] Manual verification of the pre-existing 73 failing test suites (`document.queryCommandSupported is not a function`, from eagerly-loaded `monaco-editor` in the jsdom `unit` project) confirmed unrelated/pre-existing by diffing against the unmodified baseline — same failures, same count, before this change.