### PR TITLE
fix(design-system): limit KsDurationPicker to fixed-length units

### DIFF
--- a/ui/packages/design-system/src/components/Form/KsDurationPicker.vue
+++ b/ui/packages/design-system/src/components/Form/KsDurationPicker.vue
@@ -2,39 +2,6 @@
     <div class="ks-duration-picker" v-bind="$attrs">
         <div class="ks-duration-picker__fields">
             <div class="ks-duration-picker__field">
-                <label for="ks-duration-years">{{ $t('years') }}</label>
-                <KsInputNumber
-                    size="small"
-                    controlsPosition="right"
-                    id="ks-duration-years"
-                    v-model="years"
-                    :disabled="disabled"
-                    :min="0"
-                />
-            </div>
-            <div class="ks-duration-picker__field">
-                <label for="ks-duration-months">{{ $t('months') }}</label>
-                <KsInputNumber
-                    size="small"
-                    controlsPosition="right"
-                    id="ks-duration-months"
-                    v-model="months"
-                    :disabled="disabled"
-                    :min="0"
-                />
-            </div>
-            <div class="ks-duration-picker__field">
-                <label for="ks-duration-weeks">{{ $t('weeks') }}</label>
-                <KsInputNumber
-                    size="small"
-                    controlsPosition="right"
-                    id="ks-duration-weeks"
-                    v-model="weeks"
-                    :disabled="disabled"
-                    :min="0"
-                />
-            </div>
-            <div class="ks-duration-picker__field">
                 <label for="ks-duration-days">{{ $t('days') }}</label>
                 <KsInputNumber
                     size="small"
@@ -102,9 +69,6 @@
         "update:modelValue": [value: string | null]
     }>()
 
-    const years = ref(0)
-    const months = ref(0)
-    const weeks = ref(0)
     const days = ref(0)
     const hours = ref(0)
     const minutes = ref(0)
@@ -114,9 +78,6 @@
 
     const updateDuration = () => {
         let duration = "P"
-        if (years.value > 0) duration += `${years.value}Y`
-        if (months.value > 0) duration += `${months.value}M`
-        if (weeks.value > 0) duration += `${weeks.value}W`
         if (days.value > 0) duration += `${days.value}D`
 
         if (hours.value > 0 || minutes.value > 0 || seconds.value > 0) {
@@ -136,14 +97,14 @@
         customDuration.value = durationString
 
         if (!durationString || durationString === "P") {
-            years.value = 0; months.value = 0; weeks.value = 0; days.value = 0
+            days.value = 0
             hours.value = 0; minutes.value = 0; seconds.value = 0
             durationIssue.value = null
             return
         }
 
         const match = durationString.match(
-            /^P(?:(\d+)Y)?(?:(\d+)M)?(?:(\d+)W)?(?:(\d+)D)?(?:T(?:(\d+)H)?(?:(\d+)M)?(?:(\d+)S)?)?$/,
+            /^P(?:(\d+)D)?(?:T(?:(\d+)H)?(?:(\d+)M)?(?:(\d+)S)?)?$/,
         )
 
         if (!match) {
@@ -152,19 +113,13 @@
             return
         }
 
-        years.value = parseInt(match[1] ?? "0")
-        months.value = parseInt(match[2] ?? "0")
-        weeks.value = parseInt(match[3] ?? "0")
-        days.value = parseInt(match[4] ?? "0")
-        hours.value = parseInt(match[5] ?? "0")
-        minutes.value = parseInt(match[6] ?? "0")
-        seconds.value = parseInt(match[7] ?? "0")
+        days.value = parseInt(match[1] ?? "0")
+        hours.value = parseInt(match[2] ?? "0")
+        minutes.value = parseInt(match[3] ?? "0")
+        seconds.value = parseInt(match[4] ?? "0")
         durationIssue.value = null
     }
 
-    watch(years, updateDuration)
-    watch(months, updateDuration)
-    watch(weeks, updateDuration)
     watch(days, updateDuration)
     watch(hours, updateDuration)
     watch(minutes, updateDuration)

--- a/ui/packages/design-system/tests/storybook/Form/KsDurationPicker.stories.ts
+++ b/ui/packages/design-system/tests/storybook/Form/KsDurationPicker.stories.ts
@@ -11,8 +11,10 @@ const meta: Meta<typeof KsDurationPicker> = {
         docs: {
             description: {
                 component:
-                    "KsDurationPicker allows users to input an ISO 8601 duration (e.g. `P1Y2M3DT4H5M6S`) " +
-                    "either via individual number fields for each unit, or by typing the duration string directly.",
+                    "KsDurationPicker allows users to input an ISO 8601 duration (e.g. `P3DT4H5M6S`) " +
+                    "either via individual number fields for each unit, or by typing the duration string directly. " +
+                    "It is limited to days/hours/minutes/seconds — the units `java.time.Duration` (fixed-length) " +
+                    "can represent — so years, months and weeks are not supported.",
             },
         },
     },
@@ -51,7 +53,7 @@ export const WithValue: Story = {
     render: () => ({
         components: {KsDurationPicker},
         setup() {
-            const value = ref<string | null>("P1Y2M3DT4H30M")
+            const value = ref<string | null>("P3DT4H30M")
             return {value}
         },
         template: `
@@ -98,7 +100,7 @@ export const DateOnly: Story = {
     render: () => ({
         components: {KsDurationPicker},
         setup() {
-            const value = ref<string | null>("P2Y6M15D")
+            const value = ref<string | null>("P15D")
             return {value}
         },
         template: `

--- a/ui/packages/design-system/tests/units/Form/KsDurationPicker.test.ts
+++ b/ui/packages/design-system/tests/units/Form/KsDurationPicker.test.ts
@@ -14,11 +14,11 @@ describe("KsDurationPicker", () => {
         expect(wrapper.find(".ks-duration-picker").exists()).toBe(true)
     })
 
-    test("renders all 7 number inputs", () => {
+    test("renders all 4 number inputs", () => {
         const wrapper = mount(KsDurationPicker, {
             global: globalConfig,
         })
-        expect(wrapper.findAll(".ks-duration-picker__field").length).toBe(7)
+        expect(wrapper.findAll(".ks-duration-picker__field").length).toBe(4)
     })
 
     test("renders custom duration text input", () => {
@@ -35,7 +35,7 @@ describe("KsDurationPicker", () => {
         })
 
         const unitInputs = wrapper.findAll(".ks-duration-picker__field input")
-        expect(unitInputs).toHaveLength(7)
+        expect(unitInputs).toHaveLength(4)
         unitInputs.forEach((input) => {
             expect(input.attributes("disabled")).toBeDefined()
         })
@@ -44,7 +44,7 @@ describe("KsDurationPicker", () => {
 
     test("parses modelValue on mount and populates fields", async () => {
         const wrapper = mount(KsDurationPicker, {
-            props: {modelValue: "P1Y2M3W4DT5H6M7S"},
+            props: {modelValue: "P4DT5H6M7S"},
             global: globalConfig,
         })
         await wrapper.vm.$nextTick()
@@ -69,7 +69,7 @@ describe("KsDurationPicker", () => {
 
     test("emits update:modelValue with ISO string when modelValue provided", async () => {
         const wrapper = mount(KsDurationPicker, {
-            props: {modelValue: "P1Y"},
+            props: {modelValue: "P1D"},
             global: globalConfig,
         })
         await wrapper.vm.$nextTick()
@@ -80,7 +80,7 @@ describe("KsDurationPicker", () => {
 
     test("reacts to modelValue prop change", async () => {
         const wrapper = mount(KsDurationPicker, {
-            props: {modelValue: "P1Y"},
+            props: {modelValue: "P1D"},
             global: globalConfig,
         })
         await wrapper.vm.$nextTick()
@@ -90,6 +90,22 @@ describe("KsDurationPicker", () => {
 
         const emitted = wrapper.emitted("update:modelValue")
         expect(emitted).toBeTruthy()
+    })
+
+    test("rejects calendar-based (year/month/week) durations as invalid", async () => {
+        const wrapper = mount(KsDurationPicker, {
+            global: globalConfig,
+        })
+
+        const customInputEl = wrapper.find(".ks-duration-picker__custom input")
+        await customInputEl.setValue("P1Y")
+        await customInputEl.trigger("input")
+        await wrapper.vm.$nextTick()
+
+        expect(wrapper.text()).toContain("Invalid ISO 8601 duration: P1Y")
+        const emitted = wrapper.emitted("update:modelValue")
+        const lastEmit = emitted![emitted!.length - 1]
+        expect(lastEmit[0]).toBeNull()
     })
 
     test("custom duration input shows invalid message for bad input", async () => {


### PR DESCRIPTION
## Summary
- Fixes kestra-io/kestra-ee#9369: saving a namespace/tenant Quota fails with `Text cannot be parsed to a Duration` because `KsDurationPicker` lets users compose calendar-based ISO-8601 durations (e.g. `P1Y`, `P2M`, `P3W`), which `java.time.Duration.parse()` cannot handle (`Duration` only supports the fixed-length `PnDTnHnMnS` subset).
- Removes the Years/Months/Weeks fields from `KsDurationPicker` and tightens its custom-input parser/regex to the same fixed-length subset, so the component can no longer emit a value the backend rejects. Typing `P1Y` in the custom box now shows the existing "Invalid ISO 8601 duration" message instead of silently producing an unparseable value.

<img width="846" height="387" alt="image" src="https://github.com/user-attachments/assets/708fd1d4-2fa2-4a0a-9b64-b82ba4e50fca" />

## Test plan
- [x] `npm run unit:test` in `ui/packages/design-system` — updated/added tests pass (field count 7→4, calendar-duration seeds replaced, new regression test asserting `P1Y` is rejected)
- [x] `npm run types:test` — clean
- [x] `npm run lint:test` — clean (pre-existing unrelated warnings only)
- [ ] Manual: Namespace Edit → Quotas → add a quota with days/hours → Save succeeds; Tenant Edit same