### PR TITLE
feat(promote): add PROMOTION_TARGETS QueryFilter resource

### DIFF
--- a/core/src/main/java/io/kestra/core/models/QueryFilter.java
+++ b/core/src/main/java/io/kestra/core/models/QueryFilter.java
@@ -766,6 +766,15 @@ public record QueryFilter(
                 );
             }
         },
+        PROMOTION_TARGETS {
+            @Override
+            public List<Field> supportedField() {
+                return List.of(
+                    Field.QUERY,
+                    Field.ID
+                );
+            }
+        },
         AUDIT_LOG {
             @Override
             public List<Field> supportedField() {

--- a/core/src/test/java/io/kestra/core/models/QueryFilterTest.java
+++ b/core/src/test/java/io/kestra/core/models/QueryFilterTest.java
@@ -54,6 +54,16 @@ public class QueryFilterTest {
         assertThat(e.getMessage()).contains("LOCKED", "FLOW");
     }
 
+    @Test
+    void shouldThrowExceptionWhenFieldIsNotSupportedForPromotionTargets() {
+        QueryFilter filter = QueryFilter.builder().field(Field.NAMESPACE).operation(Op.EQUALS).value("io.kestra").build();
+        InvalidQueryFiltersException e = assertThrows(
+            InvalidQueryFiltersException.class,
+            () -> QueryFilter.validateQueryFilters(List.of(filter), Resource.PROMOTION_TARGETS)
+        );
+        assertThat(e.getMessage()).contains("NAMESPACE", "PROMOTION_TARGETS");
+    }
+
     static Stream<Arguments> validOperationFilters() {
         return Stream.of(
             buildQueryFiltersForOperations(
@@ -348,6 +358,28 @@ public class QueryFilterTest {
 
             buildQueryFiltersForOperations(
                 Field.TYPE, Resource.CREDENTIALS,
+                Set.of(
+                    Op.EQUALS,
+                    Op.NOT_EQUALS,
+                    Op.CONTAINS,
+                    Op.STARTS_WITH,
+                    Op.ENDS_WITH,
+                    Op.REGEX,
+                    Op.IN,
+                    Op.NOT_IN
+                )
+            ),
+
+            buildQueryFiltersForOperations(
+                Field.QUERY, Resource.PROMOTION_TARGETS,
+                Set.of(
+                    Op.EQUALS,
+                    Op.NOT_EQUALS
+                )
+            ),
+
+            buildQueryFiltersForOperations(
+                Field.ID, Resource.PROMOTION_TARGETS,
                 Set.of(
                     Op.EQUALS,
                     Op.NOT_EQUALS,
@@ -1234,6 +1266,34 @@ public class QueryFilterTest {
 
             buildQueryFiltersForOperations(
                 Field.TYPE, Resource.CREDENTIALS,
+                Set.of(
+                    Op.PREFIX,
+                    Op.LESS_THAN,
+                    Op.LESS_THAN_OR_EQUAL_TO,
+                    Op.GREATER_THAN,
+                    Op.GREATER_THAN_OR_EQUAL_TO
+                )
+            ),
+
+            buildQueryFiltersForOperations(
+                Field.QUERY, Resource.PROMOTION_TARGETS,
+                Set.of(
+                    Op.GREATER_THAN,
+                    Op.LESS_THAN,
+                    Op.GREATER_THAN_OR_EQUAL_TO,
+                    Op.LESS_THAN_OR_EQUAL_TO,
+                    Op.IN,
+                    Op.NOT_IN,
+                    Op.STARTS_WITH,
+                    Op.ENDS_WITH,
+                    Op.CONTAINS,
+                    Op.REGEX,
+                    Op.PREFIX
+                )
+            ),
+
+            buildQueryFiltersForOperations(
+                Field.ID, Resource.PROMOTION_TARGETS,
                 Set.of(
                     Op.PREFIX,
                     Op.LESS_THAN,

--- a/ui/AGENTS.md
+++ b/ui/AGENTS.md
@@ -308,6 +308,7 @@ If your `<style>` block needs to exist:
 | `KsAutocomplete` | Autocomplete input with suggestions |
 | `KsCheckbox` / `KsCheckboxGroup` / `KsCheckboxButton` | Checkbox variants |
 | `KsRadio` / `KsRadioGroup` / `KsRadioButton` | Radio button variants |
+| `KsRadioCardGroup` | Single-select radio group rendered as option cards (title + optional hint/icon/disabled); options-driven via `:options` + `v-model` |
 | `KsSwitch` | Toggle switch |
 | `KsDatePicker` / `KsTimePicker` | Date and time pickers |
 | `KsColorPicker` | Color picker |

--- a/ui/packages/design-system/src/components/Form/KsCheckbox/KsCheckbox.vue
+++ b/ui/packages/design-system/src/components/Form/KsCheckbox/KsCheckbox.vue
@@ -47,11 +47,11 @@
         --kel-checkbox-text-color: var(--ks-text-primary);
         --kel-checkbox-checked-text-color: var(--ks-text-primary);
         --kel-checkbox-font-size: var(--ks-font-size-base);
-        --kel-checkbox-border-radius: var(--ks-radius-xs);
         --kel-checkbox-font-weight: var(--kbs-body-font-weight);
-
-        html.dark & {
-            --kel-checkbox-bg-color: var(--ks-bg-input);
-        }
+        --kel-checkbox-input-width: 1rem;
+        --kel-checkbox-input-height: 1rem;
+        --kel-checkbox-border-radius: 0.3rem;
+        --kel-checkbox-input-border: 1px solid var(--ks-border-strong);
+        --kel-checkbox-bg-color: transparent;
     }
 </style>

--- a/ui/packages/design-system/src/components/Form/KsCheckbox/KsCheckbox.vue
+++ b/ui/packages/design-system/src/components/Form/KsCheckbox/KsCheckbox.vue
@@ -50,7 +50,7 @@
         --kel-checkbox-font-weight: var(--kbs-body-font-weight);
         --kel-checkbox-input-width: 1rem;
         --kel-checkbox-input-height: 1rem;
-        --kel-checkbox-border-radius: 0.3rem;
+        --kel-checkbox-border-radius: var(--ks-radius-xs);
         --kel-checkbox-input-border: 1px solid var(--ks-border-strong);
         --kel-checkbox-bg-color: transparent;
     }

--- a/ui/packages/design-system/src/components/Form/KsRadio/KsRadioCardGroup.vue
+++ b/ui/packages/design-system/src/components/Form/KsRadio/KsRadioCardGroup.vue
@@ -1,8 +1,8 @@
 <template>
-    <div class="ks-radio-card-group" role="radiogroup">
+    <div class="ks-radio-card-group" role="radiogroup" :aria-label="ariaLabel">
         <label
             v-for="option in options"
-            :key="String(option.value)"
+            :key="`${typeof option.value}:${option.value}`"
             class="card"
             :class="{selected: model === option.value, disabled: option.disabled}"
         >
@@ -39,6 +39,7 @@
             disabled?: boolean
             icon?: Component
         }[]
+        ariaLabel?: string
     }>()
 
     const emit = defineEmits<{
@@ -98,6 +99,11 @@
                     &::after {
                         transform: scale(1);
                     }
+                }
+
+                &:focus-visible {
+                    outline: 2px solid var(--ks-border-focus);
+                    outline-offset: 2px;
                 }
             }
 

--- a/ui/packages/design-system/src/components/Form/KsRadio/KsRadioCardGroup.vue
+++ b/ui/packages/design-system/src/components/Form/KsRadio/KsRadioCardGroup.vue
@@ -1,0 +1,142 @@
+<template>
+    <div class="ks-radio-card-group" role="radiogroup">
+        <label
+            v-for="option in options"
+            :key="String(option.value)"
+            class="card"
+            :class="{selected: model === option.value, disabled: option.disabled}"
+        >
+            <input
+                v-model="model"
+                type="radio"
+                :name="name"
+                :value="option.value"
+                :disabled="option.disabled"
+                @change="emit('change', option.value)"
+            >
+            <span class="title">{{ option.label }}</span>
+            <component
+                :is="option.icon"
+                v-if="option.icon"
+                :size="16"
+                class="icon"
+            />
+            <span v-if="option.hint" class="hint">{{ option.hint }}</span>
+        </label>
+    </div>
+</template>
+
+<script setup lang="ts">
+    import {useId, type Component} from "vue"
+
+    const model = defineModel<string | number | boolean>()
+
+    defineProps<{
+        options: {
+            value: string | number | boolean
+            label: string
+            hint?: string
+            disabled?: boolean
+            icon?: Component
+        }[]
+    }>()
+
+    const emit = defineEmits<{
+        change: [value: string | number | boolean]
+    }>()
+
+    const name = useId()
+</script>
+
+<style scoped lang="scss">
+    .ks-radio-card-group {
+        display: flex;
+        flex-direction: column;
+        gap: var(--ks-spacing-2);
+        width: 100%;
+
+        .card {
+            display: flex;
+            align-items: center;
+            gap: var(--ks-spacing-4);
+            padding: var(--ks-spacing-2) var(--ks-spacing-4);
+            border: 1px solid var(--ks-border-default);
+            border-radius: var(--ks-radius-lg);
+            background: var(--ks-bg-inactive);
+            color: var(--ks-text-primary);
+            cursor: pointer;
+            transition: all 0.15s;
+
+            input[type="radio"] {
+                appearance: none;
+                -webkit-appearance: none;
+                flex-shrink: 0;
+                display: grid;
+                place-content: center;
+                width: 1.25rem;
+                height: 1.25rem;
+                margin: 0;
+                border: 2px solid var(--ks-border-strong);
+                border-radius: 50%;
+                background: transparent;
+                cursor: pointer;
+                transition: border-color 0.15s ease;
+
+                &::after {
+                    content: "";
+                    width: 0.625rem;
+                    height: 0.625rem;
+                    border-radius: 50%;
+                    background: var(--ks-toggle-active);
+                    transform: scale(0);
+                    transition: transform 0.15s ease;
+                }
+
+                &:checked {
+                    border-color: var(--ks-toggle-active);
+
+                    &::after {
+                        transform: scale(1);
+                    }
+                }
+            }
+
+            .title {
+                display: inline-flex;
+                align-items: center;
+                gap: var(--ks-spacing-2);
+                font-size: var(--ks-font-size-sm);
+                color: var(--ks-text-primary);
+            }
+
+            .icon {
+                flex-shrink: 0;
+            }
+
+            .hint {
+                margin-left: auto;
+                font-size: var(--ks-font-size-sm);
+                color: var(--ks-text-secondary);
+                text-align: right;
+            }
+
+            &.selected {
+                border-color: var(--ks-border-strong);
+                background: var(--ks-bg-active);
+            }
+
+            &.disabled {
+                opacity: 0.4;
+                cursor: not-allowed;
+
+                input[type="radio"] {
+                    cursor: not-allowed;
+                }
+            }
+
+            &:hover:not(.selected):not(.disabled) {
+                border-color: var(--ks-border-strong);
+            }
+        }
+    }
+</style>

--- a/ui/packages/design-system/src/index.ts
+++ b/ui/packages/design-system/src/index.ts
@@ -78,6 +78,7 @@ import KsPopover from "./components/Feedback/KsPopover.vue"
 import KsProgress from "./components/Data/KsProgress.vue"
 import KsRadio from "./components/Form/KsRadio/KsRadio.vue"
 import KsRadioButton from "./components/Form/KsRadio/KsRadioButton.vue"
+import KsRadioCardGroup from "./components/Form/KsRadio/KsRadioCardGroup.vue"
 import KsRadioGroup from "./components/Form/KsRadio/KsRadioGroup.vue"
 import KsRow from "./components/Basic/KsRow/KsRow.vue"
 import KsScrollbar from "./components/Basic/KsScrollbar.vue"
@@ -278,6 +279,7 @@ const components: Record<string, Component> = {
     KsProgress,
     KsRadio,
     KsRadioButton,
+    KsRadioCardGroup,
     KsRadioGroup,
     KsRow,
     KsScrollbar,
@@ -386,6 +388,7 @@ export {
     KsProgress,
     KsRadio,
     KsRadioButton,
+    KsRadioCardGroup,
     KsRadioGroup,
     KsRow,
     KsScrollbar,
@@ -514,6 +517,7 @@ declare module "vue" {
         KsProgress: typeof KsProgress
         KsRadio: typeof KsRadio
         KsRadioButton: typeof KsRadioButton
+        KsRadioCardGroup: typeof KsRadioCardGroup
         KsRadioGroup: typeof KsRadioGroup
         KsRow: typeof KsRow
         KsScrollbar: typeof KsScrollbar

--- a/ui/packages/design-system/tests/storybook/Form/KsRadioCardGroup.stories.ts
+++ b/ui/packages/design-system/tests/storybook/Form/KsRadioCardGroup.stories.ts
@@ -1,0 +1,93 @@
+import type {Meta, StoryObj} from "@storybook/vue3-vite"
+import {ref} from "vue"
+import LockOutline from "vue-material-design-icons/LockOutline.vue"
+import KsRadioCardGroup from "../../../src/components/Form/KsRadio/KsRadioCardGroup.vue"
+
+const meta: Meta<typeof KsRadioCardGroup> = {
+    title: "Components/Form/KsRadioCardGroup",
+    component: KsRadioCardGroup,
+    tags: ["autodocs"],
+    parameters: {
+        docs: {description: {component: "KsRadioCardGroup renders a single-select radio group as bordered option cards, each with a title and an optional hint, icon, and disabled state."}},
+    },
+}
+export default meta
+type Story = StoryObj<typeof KsRadioCardGroup>
+
+export const Default: Story = {
+    render: () => ({
+        components: {KsRadioCardGroup},
+        setup() {
+            const value = ref("SERVER")
+            const options = [
+                {value: "SERVER", label: "Server", hint: "This instance deploys with a shared token"},
+                {value: "CLIENT", label: "Client", hint: "Your browser deploys with your own token"},
+            ]
+            return {value, options}
+        },
+        template: `
+            <div style="padding:24px;max-width:520px">
+                <ks-radio-card-group v-model="value" :options="options" />
+                <span style="display:block;margin-top:8px;font-size:13px;opacity:0.6">Selected: {{ value }}</span>
+            </div>
+        `,
+    }),
+}
+
+export const WithIcon: Story = {
+    render: () => ({
+        components: {KsRadioCardGroup},
+        setup() {
+            const value = ref("BASIC")
+            const options = [
+                {value: "BASIC", label: "Basic auth", hint: "Username & password"},
+                {value: "API_TOKEN", label: "API token", hint: "Bearer token", icon: LockOutline},
+                {value: "OAUTH", label: "OAuth", hint: "Sign in with a provider", icon: LockOutline},
+            ]
+            return {value, options}
+        },
+        template: `
+            <div style="padding:24px;max-width:520px">
+                <ks-radio-card-group v-model="value" :options="options" />
+            </div>
+        `,
+    }),
+}
+
+export const Disabled: Story = {
+    render: () => ({
+        components: {KsRadioCardGroup},
+        setup() {
+            const value = ref("BASIC")
+            const options = [
+                {value: "BASIC", label: "Basic auth", hint: "Username & password"},
+                {value: "API_TOKEN", label: "API token", hint: "Enterprise only", disabled: true, icon: LockOutline},
+            ]
+            return {value, options}
+        },
+        template: `
+            <div style="padding:24px;max-width:520px">
+                <ks-radio-card-group v-model="value" :options="options" />
+            </div>
+        `,
+    }),
+}
+
+export const LongText: Story = {
+    render: () => ({
+        components: {KsRadioCardGroup},
+        setup() {
+            const value = ref("a")
+            const options = [
+                {value: "a", label: "A concise option", hint: "A much longer hint that explains the trade-offs of this option in more detail than usually fits on a single line"},
+                {value: "b", label: "Another option"},
+            ]
+            return {value, options}
+        },
+        template: `
+            <div style="padding:24px;max-width:520px">
+                <ks-radio-card-group v-model="value" :options="options" />
+            </div>
+        `,
+    }),
+}

--- a/ui/packages/design-system/tests/storybook/Form/KsRadioCardGroup.stories.ts
+++ b/ui/packages/design-system/tests/storybook/Form/KsRadioCardGroup.stories.ts
@@ -27,7 +27,7 @@ export const Default: Story = {
         },
         template: `
             <div style="padding:24px;max-width:520px">
-                <ks-radio-card-group v-model="value" :options="options" />
+                <ks-radio-card-group v-model="value" :options="options" ariaLabel="Connection mode" />
                 <span style="display:block;margin-top:8px;font-size:13px;opacity:0.6">Selected: {{ value }}</span>
             </div>
         `,

--- a/ui/packages/design-system/tests/units/Form/KsRadioCardGroup.test.ts
+++ b/ui/packages/design-system/tests/units/Form/KsRadioCardGroup.test.ts
@@ -1,0 +1,63 @@
+import {describe, test, expect} from "vitest"
+import {mount} from "@vue/test-utils"
+import KestraDesignSystem from "../../../src/index"
+import KsRadioCardGroup from "../../../src/components/Form/KsRadio/KsRadioCardGroup.vue"
+
+const globalConfig = {plugins: [KestraDesignSystem]}
+
+const OPTIONS = [
+    {value: "SERVER", label: "Server", hint: "shared token"},
+    {value: "CLIENT", label: "Client"},
+]
+
+describe("KsRadioCardGroup", () => {
+    test("renders a card per option inside a radiogroup", () => {
+        const wrapper = mount(KsRadioCardGroup, {
+            props: {modelValue: "SERVER", options: OPTIONS},
+            global: globalConfig,
+        })
+        expect(wrapper.find("[role='radiogroup']").exists()).toBe(true)
+        expect(wrapper.findAll(".card")).toHaveLength(2)
+    })
+
+    test("marks the selected option", () => {
+        const wrapper = mount(KsRadioCardGroup, {
+            props: {modelValue: "SERVER", options: OPTIONS},
+            global: globalConfig,
+        })
+        const cards = wrapper.findAll(".card")
+        expect(cards[0].classes()).toContain("selected")
+        expect(cards[1].classes()).not.toContain("selected")
+    })
+
+    test("renders the hint when present", () => {
+        const wrapper = mount(KsRadioCardGroup, {
+            props: {modelValue: "SERVER", options: OPTIONS},
+            global: globalConfig,
+        })
+        expect(wrapper.find(".hint").text()).toBe("shared token")
+    })
+
+    test("emits update:modelValue and change on selection", async () => {
+        const wrapper = mount(KsRadioCardGroup, {
+            props: {modelValue: "SERVER", options: OPTIONS},
+            global: globalConfig,
+        })
+        await wrapper.findAll("input[type='radio']")[1].setValue()
+        expect(wrapper.emitted("update:modelValue")?.at(-1)).toEqual(["CLIENT"])
+        expect(wrapper.emitted("change")?.at(-1)).toEqual(["CLIENT"])
+    })
+
+    test("disables an option and its input", () => {
+        const wrapper = mount(KsRadioCardGroup, {
+            props: {
+                modelValue: "a",
+                options: [{value: "a", label: "A"}, {value: "b", label: "B", disabled: true}],
+            },
+            global: globalConfig,
+        })
+        const disabledCard = wrapper.findAll(".card")[1]
+        expect(disabledCard.classes()).toContain("disabled")
+        expect(disabledCard.find("input").attributes("disabled")).toBeDefined()
+    })
+})

--- a/ui/packages/design-system/tests/units/Form/KsRadioCardGroup.test.ts
+++ b/ui/packages/design-system/tests/units/Form/KsRadioCardGroup.test.ts
@@ -48,6 +48,14 @@ describe("KsRadioCardGroup", () => {
         expect(wrapper.emitted("change")?.at(-1)).toEqual(["CLIENT"])
     })
 
+    test("names the radiogroup with ariaLabel", () => {
+        const wrapper = mount(KsRadioCardGroup, {
+            props: {modelValue: "SERVER", options: OPTIONS, ariaLabel: "Connection mode"},
+            global: globalConfig,
+        })
+        expect(wrapper.find("[role='radiogroup']").attributes("aria-label")).toBe("Connection mode")
+    })
+
     test("disables an option and its input", () => {
         const wrapper = mount(KsRadioCardGroup, {
             props: {

--- a/ui/src/components/admin/mcp/tabs/McpEdit.vue
+++ b/ui/src/components/admin/mcp/tabs/McpEdit.vue
@@ -75,31 +75,11 @@
             </KsAlert>
 
             <KsFormItem v-if="isPrivate">
-                <div class="auth-list">
-                    <label
-                        v-for="opt in AUTH_OPTIONS"
-                        :key="opt.value"
-                        class="auth-option"
-                        :class="{
-                            'is-selected': form.authType === opt.value,
-                            'is-disabled': isOptionDisabled(opt),
-                        }"
-                    >
-                        <input
-                            v-model="form.authType"
-                            type="radio"
-                            :value="opt.value"
-                            :disabled="isOptionDisabled(opt)"
-                            @change="autoSubmit"
-                        >
-                        <span class="auth-name">{{ t(opt.labelKey) }}</span>
-                        <LockOutline
-                            v-if="opt.ee && isOss"
-                            :size="14"
-                        />
-                        <span class="auth-hint">{{ authHint(opt) }}</span>
-                    </label>
-                </div>
+                <KsRadioCardGroup
+                    v-model="form.authType"
+                    :options="authOptions"
+                    @change="autoSubmit"
+                />
             </KsFormItem>
 
             <KsFormItem
@@ -271,6 +251,16 @@
         }
         return t(opt.hintKey)
     }
+
+    const authOptions = computed(() =>
+        AUTH_OPTIONS.map((opt) => ({
+            value: opt.value,
+            label: t(opt.labelKey),
+            hint: authHint(opt),
+            disabled: isOptionDisabled(opt),
+            icon: opt.ee && isOss.value ? LockOutline : undefined,
+        })),
+    )
 
     const buildPayload = (): McpServerPayload => {
         const isOauth = form.value.authType === "OAUTH"
@@ -457,90 +447,6 @@
     .id-input {
         width: 170px;
         min-height: 30px;
-    }
-
-    .auth-list {
-        display: flex;
-        flex-direction: column;
-        gap: var(--ks-spacing-2);
-        width: 100%;
-    }
-
-    .auth-option {
-        display: flex;
-        align-items: center;
-        gap: var(--ks-spacing-4);
-        padding: var(--ks-spacing-2) var(--ks-spacing-4);
-        border: 1px solid var(--ks-border-default);
-        border-radius: var(--ks-radius-lg);
-        background: var(--ks-bg-inactive);
-        color: var(--ks-text-primary);
-        cursor: pointer;
-        transition: all 0.15s;
-    }
-
-    .auth-option input[type="radio"] {
-        appearance: none;
-        -webkit-appearance: none;
-        flex-shrink: 0;
-        display: grid;
-        place-content: center;
-        width: 1.25rem;
-        height: 1.25rem;
-        margin: 0;
-        border: 2px solid var(--ks-border-strong);
-        border-radius: 50%;
-        background: transparent;
-        cursor: pointer;
-        transition: border-color 0.15s ease;
-    }
-
-    .auth-option input[type="radio"]::after {
-        content: "";
-        width: 0.625rem;
-        height: 0.625rem;
-        border-radius: 50%;
-        background: var(--ks-toggle-active);
-        transform: scale(0);
-        transition: transform 0.15s ease;
-    }
-
-    .auth-option input[type="radio"]:checked {
-        border-color: var(--ks-toggle-active);
-    }
-
-    .auth-option input[type="radio"]:checked::after {
-        transform: scale(1);
-    }
-
-    .auth-option input[type="radio"]:disabled {
-        cursor: not-allowed;
-    }
-
-    .auth-option.is-selected {
-        border-color: var(--ks-border-strong);
-        background: var(--ks-bg-active);
-    }
-
-    .auth-option.is-disabled {
-        opacity: 0.4;
-        cursor: not-allowed;
-    }
-
-    .auth-option:hover:not(.is-selected):not(.is-disabled) {
-        border-color: var(--ks-border-strong);
-    }
-
-    .auth-name {
-        font-size: var(--ks-font-size-sm);
-        font-weight: var(--ks-font-weight-regular);
-        color: var(--ks-text-primary);
-    }
-
-    .auth-hint {
-        margin-left: auto;
-        font-size: var(--ks-font-size-sm);
-        color: var(--ks-text-secondary);
     }
 
     .field-hint {

--- a/ui/src/components/admin/mcp/tabs/McpEdit.vue
+++ b/ui/src/components/admin/mcp/tabs/McpEdit.vue
@@ -78,6 +78,7 @@
                 <KsRadioCardGroup
                     v-model="form.authType"
                     :options="authOptions"
+                    :ariaLabel="t('mcp.auth_type')"
                     @change="autoSubmit"
                 />
             </KsFormItem>

--- a/ui/src/components/demo/Promote.vue
+++ b/ui/src/components/demo/Promote.vue
@@ -4,7 +4,6 @@
         type="promote"
         demoCta
         :title="$t('demos.promote.title')"
-        learnMore="https://kestra.io/docs/enterprise"
     >
         <template #description>
             {{ $t('demos.promote.message') }}

--- a/ui/src/components/demo/Promote.vue
+++ b/ui/src/components/demo/Promote.vue
@@ -1,0 +1,43 @@
+<template>
+    <TopNavBar :title="routeInfo.title" v-if="!isFullScreen() && !embed" />
+    <Empty
+        type="promote"
+        demoCta
+        :title="$t('demos.promote.title')"
+        learnMore="https://kestra.io/docs/enterprise"
+    >
+        <template #description>
+            {{ $t('demos.promote.message') }}
+        </template>
+    </Empty>
+</template>
+
+<script setup lang="ts">
+    import {computed} from "vue"
+    import {useI18n} from "vue-i18n"
+    import Empty from "../layout/empty/Empty.vue"
+    import TopNavBar from "../../components/layout/TopNavBar.vue"
+    import useRouteContext from "../../composables/useRouteContext"
+
+    const {t} = useI18n()
+
+    defineProps({
+        embed: {
+            type: Boolean,
+            default: false,
+        },
+    })
+
+    defineOptions({
+        name: "PromoteDemo",
+        inheritAttrs: false,
+    })
+
+    const routeInfo = computed(() => ({title: t("demos.promote.title")}))
+
+    useRouteContext(routeInfo)
+
+    function isFullScreen() {
+        return document.getElementsByTagName("html")[0].classList.contains("full-screen")
+    }
+</script>

--- a/ui/src/components/flows/Flows.vue
+++ b/ui/src/components/flows/Flows.vue
@@ -81,6 +81,11 @@
                 >
                     {{ $t("disable") }}
                 </KsButton>
+                <component
+                    :is="flowsExtension.bulkAction"
+                    v-if="flowsExtension.bulkAction && !dataTable?.queryBulkAction"
+                    :flows="dataTable?.selection ?? []"
+                />
             </template>
 
             <KsTableColumn

--- a/ui/src/components/flows/Flows.vue
+++ b/ui/src/components/flows/Flows.vue
@@ -239,6 +239,7 @@
                         <KsDateAgo v-if="scope.row.updated" :date="scope.row.updated" inverted />
                     </template>
                 </KsTableColumn>
+
             </template>
 
             <KsTableColumn columnKey="action" className="row-action" :label="$t('actions')">

--- a/ui/src/components/flows/Flows.vue
+++ b/ui/src/components/flows/Flows.vue
@@ -240,6 +240,19 @@
                     </template>
                 </KsTableColumn>
 
+                <KsTableColumn
+                    v-else-if="extensionColumn(colProp)"
+                    :label="extensionColumn(colProp)!.label"
+                >
+                    <template #header>
+                        <component :is="extensionColumn(colProp)!.header" v-if="extensionColumn(colProp)!.header" />
+                        <template v-else>{{ extensionColumn(colProp)!.label }}</template>
+                    </template>
+                    <template #default="scope">
+                        <component :is="extensionColumn(colProp)!.cell" :row="scope.row" />
+                    </template>
+                </KsTableColumn>
+
             </template>
 
             <KsTableColumn columnKey="action" className="row-action" :label="$t('actions')">
@@ -329,8 +342,9 @@
     import {useMiscStore} from "override/stores/misc"
     import {useExecutionsStore} from "../../stores/executions"
 
-    import {useTableColumns} from "../../composables/useTableColumns"
+    import {useTableColumns, type ColumnConfig} from "../../composables/useTableColumns"
     import useRouteContext from "../../composables/useRouteContext"
+    import {useFlowsTableExtension} from "override/components/flows/flowsTableExtension"
     import {QueryFilter} from "@kestra-io/kestra-sdk"
     import useFlowsBulkActions from "./useFlowsBulkActions"
 
@@ -370,7 +384,7 @@
     const latestExecutions = ref<any[]>([])
     const file = ref<HTMLInputElement | null>(null)
 
-    const optionalColumns = ref([
+    const optionalColumns = ref<ColumnConfig[]>([
         {
             label: t("labels"),
             prop: "labels",
@@ -415,6 +429,19 @@
         },
     ])
 
+    const flowsExtension = useFlowsTableExtension()
+    optionalColumns.value.push(...flowsExtension.columns)
+
+    const extensionColumn = (prop: string) => flowsExtension.columns.find(column => column.prop === prop)
+    const extensionColumnsVisible = computed(() =>
+        flowsExtension.columns.some(column => displayColumns.value.includes(column.prop)),
+    )
+    const loadExtensionData = (rows: {id: string; namespace: string}[]) => {
+        if (extensionColumnsVisible.value) {
+            flowsExtension.load?.(rows.map(row => ({id: row.id, namespace: row.namespace})))
+        }
+    }
+
     const {
         visibleColumns: displayColumns,
         updateVisibleColumns,
@@ -422,6 +449,12 @@
         columns: optionalColumns.value,
         storageKey: "flows",
         initialVisibleColumns: [],
+    })
+
+    watch(extensionColumnsVisible, visible => {
+        if (visible && flowStore.flows?.length) {
+            loadExtensionData(flowStore.flows)
+        }
     })
 
     const user = computed(() => authStore.user)
@@ -460,6 +493,7 @@
                         lastExecutionByFlowReady.value = true
                     })
                 }
+                loadExtensionData(data.results)
             })
     }
 

--- a/ui/src/components/flows/flowTabs.ts
+++ b/ui/src/components/flows/flowTabs.ts
@@ -68,6 +68,13 @@ export const FLOW_TAB_ROUTES: RouteRecordRaw[] = [
         meta: {tab: "edit", title: "edit", maximized: true},
     },
     {
+        name: `${FLOW_PARENT_ROUTE}/promote`,
+        path: "promote",
+        component: () => import("../demo/Promote.vue"),
+        props: {embed: true},
+        meta: {tab: "promote", title: "promote.label", locked: true},
+    },
+    {
         name: `${FLOW_PARENT_ROUTE}/revisions`,
         path: "revisions",
         component: () => import("./FlowRevisions.vue"),

--- a/ui/src/components/layout/empty/links.ts
+++ b/ui/src/components/layout/empty/links.ts
@@ -120,4 +120,9 @@ export const links: Record<string, EmptyLinks> = {
         video: "https://www.youtube.com/watch?v=fs86GLg-OGM",
         learnMore: "https://kestra.io/docs/how-to-guides/namespace-variables-vs-kvstore",
     },
+    /** @todo Replace the placeholder video and learnMore links with the real promotion docs/video once published. */
+    promotionTargets: {
+        video: "https://www.youtube.com/watch?v=XhICXP_GXic",
+        learnMore: "https://kestra.io/docs/enterprise",
+    },
 }

--- a/ui/src/components/layout/empty/links.ts
+++ b/ui/src/components/layout/empty/links.ts
@@ -121,7 +121,7 @@ export const links: Record<string, EmptyLinks> = {
         learnMore: "https://kestra.io/docs/how-to-guides/namespace-variables-vs-kvstore",
     },
     /** @todo Replace the placeholder video and learnMore links with the real promotion docs/video once published. */
-    promotionTargets: {
+    promote: {
         video: "https://www.youtube.com/watch?v=XhICXP_GXic",
         learnMore: "https://kestra.io/docs/enterprise",
     },

--- a/ui/src/override/components/flows/flowsTableExtension.ts
+++ b/ui/src/override/components/flows/flowsTableExtension.ts
@@ -1,0 +1,21 @@
+import type {Component} from "vue"
+import type {ColumnConfig} from "../../../composables/useTableColumns"
+
+export interface FlowsTableFlowRef {
+    id: string;
+    namespace: string;
+}
+
+export interface FlowsTableExtensionColumn extends ColumnConfig {
+    cell: Component;
+    header?: Component;
+}
+
+export interface FlowsTableExtension {
+    columns: FlowsTableExtensionColumn[];
+    load?: (flows: FlowsTableFlowRef[]) => void;
+}
+
+export function useFlowsTableExtension(): FlowsTableExtension {
+    return {columns: []}
+}

--- a/ui/src/override/components/flows/flowsTableExtension.ts
+++ b/ui/src/override/components/flows/flowsTableExtension.ts
@@ -13,6 +13,7 @@ export interface FlowsTableExtensionColumn extends ColumnConfig {
 
 export interface FlowsTableExtension {
     columns: FlowsTableExtensionColumn[];
+    bulkAction?: Component;
     load?: (flows: FlowsTableFlowRef[]) => void;
 }
 

--- a/ui/src/override/components/useLeftMenu.ts
+++ b/ui/src/override/components/useLeftMenu.ts
@@ -32,6 +32,7 @@ import Battery40 from "vue-material-design-icons/Battery40.vue"
 import Gauge from "vue-material-design-icons/Gauge.vue"
 import ShieldAccount from "vue-material-design-icons/ShieldAccount.vue"
 import ShieldCheckOutline from "vue-material-design-icons/ShieldCheckOutline.vue"
+import RocketLaunchOutline from "vue-material-design-icons/RocketLaunchOutline.vue"
 import McpIcon from "../../components/McpIcon.vue"
 
 export type MenuItem = {
@@ -336,6 +337,20 @@ export function useLeftMenu() {
                         },
                         icon: {
                             element: FileDocumentOutline,
+                        },
+                        attributes: {
+                            locked: true,
+                        },
+                    },
+                    {
+                        id: "promote",
+                        title: t("promote.label"),
+                        routes: routeStartWith("promote"),
+                        href: {
+                            name: "promote/targets",
+                        },
+                        icon: {
+                            element: RocketLaunchOutline,
                         },
                         attributes: {
                             locked: true,

--- a/ui/src/routes/routes.ts
+++ b/ui/src/routes/routes.ts
@@ -13,6 +13,7 @@ import DemoAssets from "../components/demo/Assets.vue"
 import DemoCases from "../components/demo/Cases.vue"
 import DemoQuotas from "../components/demo/Quotas.vue"
 import DemoPolicies from "../components/demo/Policies.vue"
+import DemoPromote from "../components/demo/Promote.vue"
 import {EXECUTION_ROUTE} from "../components/executions/executionTabs"
 import {FLOW_ROUTE} from "../components/flows/flowTabs"
 import {NAMESPACE_PARENT_ROUTE, createNamespaceTabRoutes} from "../utils/namespaceTabRoutes"
@@ -124,6 +125,7 @@ const routes: KestraRouteRecord[] = [
     {name: "admin/quotas/list", path: "/:tenant?/admin/quotas", component: DemoQuotas},
     {name: "admin/policies", path: "/:tenant?/admin/policies", component: DemoPolicies},
     {name: "admin/instance", path: "/:tenant?/admin/instance", component: DemoInstance},
+    {name: "promote/targets", path: "/:tenant?/promote/targets", component: DemoPromote},
 ]
 
 export default routes

--- a/ui/src/translations/de.json
+++ b/ui/src/translations/de.json
@@ -941,6 +941,9 @@
       }
     },
     "apps": "Apps",
+    "promote": {
+      "label": "Bereitstellen"
+    },
     "demos": {
       "enterprise_edition": "Enterprise Edition",
       "get_a_demo_button": "Demo anfordern",
@@ -976,6 +979,10 @@
         "header": "Incident Management",
         "title": "Triage and resolve incidents without leaving Kestra.",
         "message": "Cases in Kestra Enterprise Edition let you open, assign, and track incidents directly from failed executions, with SLA tracking, activity timelines, and linked executions and assets to speed up root-cause analysis."
+      },
+      "promote": {
+        "title": "Flows über Umgebungen hinweg promoten",
+        "message": "Kestra Enterprise Edition ermöglicht es Ihnen, flows direkt über die UI von einer Umgebung in eine andere zu promoten – wie z.B. von Dev über Staging zu Production – ohne Git- oder CI/CD-Pipelines zu benötigen. Überprüfen Sie einen Diff dessen, was sich genau ändern wird, bevor Sie promoten, schützen Sie sensible Ziele mit einem Bestätigungsgate, erkennen Sie Abweichungen auf einen Blick und führen Sie eine vollständige Historie darüber, wer was, wo und wann promotet hat."
       },
       "IAM": {
         "title": "Benutzer über IAM mit SSO, SCIM und RBAC verwalten",

--- a/ui/src/translations/de.json
+++ b/ui/src/translations/de.json
@@ -942,7 +942,7 @@
     },
     "apps": "Apps",
     "promote": {
-      "label": "Bereitstellen"
+      "label": "Hochstufen"
     },
     "demos": {
       "enterprise_edition": "Enterprise Edition",

--- a/ui/src/translations/en.json
+++ b/ui/src/translations/en.json
@@ -941,6 +941,9 @@
       }
     },
     "apps": "Apps",
+    "promote": {
+      "label": "Promote"
+    },
     "demos": {
       "enterprise_edition": "Enterprise Edition",
       "get_a_demo_button": "Get a Demo",
@@ -976,6 +979,10 @@
         "header": "Incident Management",
         "title": "Triage and resolve incidents without leaving Kestra.",
         "message": "Cases in Kestra Enterprise Edition let you open, assign, and track incidents directly from failed executions, with SLA tracking, activity timelines, and linked executions and assets to speed up root-cause analysis."
+      },
+      "promote": {
+        "title": "Promote Flows Across Environments",
+        "message": "Kestra Enterprise Edition lets you promote flows from one environment to another — such as dev to staging to production — directly from the UI, no Git or CI/CD pipelines required. Review a diff of exactly what will change before promoting, protect sensitive targets with a confirmation gate, spot drift at a glance, and keep a full history of who promoted what, where, and when."
       },
       "IAM": {
         "title": "Manage Users through IAM with SSO, SCIM and RBAC",

--- a/ui/src/translations/es.json
+++ b/ui/src/translations/es.json
@@ -942,7 +942,7 @@
     },
     "apps": "Aplicaciones",
     "promote": {
-      "label": "Desplegar"
+      "label": "Promocionar"
     },
     "demos": {
       "enterprise_edition": "Edición Enterprise",

--- a/ui/src/translations/es.json
+++ b/ui/src/translations/es.json
@@ -941,6 +941,9 @@
       }
     },
     "apps": "Aplicaciones",
+    "promote": {
+      "label": "Desplegar"
+    },
     "demos": {
       "enterprise_edition": "Edición Enterprise",
       "get_a_demo_button": "Obtener una Demo",
@@ -976,6 +979,10 @@
         "header": "Incident Management",
         "title": "Triage and resolve incidents without leaving Kestra.",
         "message": "Cases in Kestra Enterprise Edition let you open, assign, and track incidents directly from failed executions, with SLA tracking, activity timelines, and linked executions and assets to speed up root-cause analysis."
+      },
+      "promote": {
+        "title": "Promover Flows a través de entornos",
+        "message": "Kestra Enterprise Edition le permite promocionar flows de un entorno a otro — como de desarrollo a staging a producción — directamente desde la UI, sin necesidad de Git o pipelines de CI/CD. Revise un diff de exactamente lo que cambiará antes de promocionar, proteja objetivos sensibles con una puerta de confirmación, detecte desviaciones de un vistazo y mantenga un historial completo de quién promocionó qué, dónde y cuándo."
       },
       "IAM": {
         "title": "Gestionar usuarios a través de IAM con SSO, SCIM y RBAC",

--- a/ui/src/translations/fr.json
+++ b/ui/src/translations/fr.json
@@ -941,6 +941,9 @@
       }
     },
     "apps": "Applications",
+    "promote": {
+      "label": "Déployer"
+    },
     "demos": {
       "enterprise_edition": "Édition Enterprise",
       "get_a_demo_button": "Obtenir une démo",
@@ -976,6 +979,10 @@
         "header": "Incident Management",
         "title": "Triage and resolve incidents without leaving Kestra.",
         "message": "Cases in Kestra Enterprise Edition let you open, assign, and track incidents directly from failed executions, with SLA tracking, activity timelines, and linked executions and assets to speed up root-cause analysis."
+      },
+      "promote": {
+        "title": "Promouvoir les Flows entre les environnements",
+        "message": "Kestra Enterprise Edition vous permet de promouvoir des flows d'un environnement à un autre — par exemple, de dev à staging à production — directement depuis l'interface utilisateur, sans nécessiter de pipelines Git ou CI/CD. Examinez un diff de ce qui va changer exactement avant de promouvoir, protégez les cibles sensibles avec un mécanisme de confirmation, repérez les dérives en un coup d'œil, et conservez un historique complet de qui a promu quoi, où et quand."
       },
       "IAM": {
         "title": "Gérer les utilisateurs via IAM avec SSO, SCIM et RBAC",

--- a/ui/src/translations/fr.json
+++ b/ui/src/translations/fr.json
@@ -942,7 +942,7 @@
     },
     "apps": "Applications",
     "promote": {
-      "label": "Déployer"
+      "label": "Promouvoir"
     },
     "demos": {
       "enterprise_edition": "Édition Enterprise",

--- a/ui/src/translations/hi.json
+++ b/ui/src/translations/hi.json
@@ -942,7 +942,7 @@
     },
     "apps": "ऐप्स",
     "promote": {
-      "label": "तैनात करें"
+      "label": "पदोन्नत करें"
     },
     "demos": {
       "enterprise_edition": "एंटरप्राइज एडिशन",

--- a/ui/src/translations/hi.json
+++ b/ui/src/translations/hi.json
@@ -941,6 +941,9 @@
       }
     },
     "apps": "ऐप्स",
+    "promote": {
+      "label": "तैनात करें"
+    },
     "demos": {
       "enterprise_edition": "एंटरप्राइज एडिशन",
       "get_a_demo_button": "डेमो प्राप्त करें",
@@ -976,6 +979,10 @@
         "header": "Incident Management",
         "title": "Triage and resolve incidents without leaving Kestra.",
         "message": "Cases in Kestra Enterprise Edition let you open, assign, and track incidents directly from failed executions, with SLA tracking, activity timelines, and linked executions and assets to speed up root-cause analysis."
+      },
+      "promote": {
+        "title": "Flows को Environments में आगे बढ़ाएँ",
+        "message": "Kestra Enterprise Edition आपको एक environment से दूसरे में flows को प्रमोट करने की अनुमति देता है — जैसे dev से staging से production तक — सीधे UI से, किसी Git या CI/CD pipelines की आवश्यकता नहीं है। प्रमोट करने से पहले ठीक क्या बदलेगा, इसका diff देखें, संवेदनशील targets को एक confirmation gate से सुरक्षित रखें, एक नज़र में drift का पता लगाएं, और किसने क्या, कहाँ और कब प्रमोट किया, इसका पूरा history रखें।"
       },
       "IAM": {
         "title": "IAM के माध्यम से SSO, SCIM और RBAC के साथ उपयोगकर्ताओं का प्रबंधन करें।",

--- a/ui/src/translations/it.json
+++ b/ui/src/translations/it.json
@@ -941,6 +941,9 @@
       }
     },
     "apps": "Applicazioni",
+    "promote": {
+      "label": "Distribuisci"
+    },
     "demos": {
       "enterprise_edition": "Edizione Enterprise",
       "get_a_demo_button": "Ottieni una Demo",
@@ -976,6 +979,10 @@
         "header": "Incident Management",
         "title": "Triage and resolve incidents without leaving Kestra.",
         "message": "Cases in Kestra Enterprise Edition let you open, assign, and track incidents directly from failed executions, with SLA tracking, activity timelines, and linked executions and assets to speed up root-cause analysis."
+      },
+      "promote": {
+        "title": "Promuovere flow Tra Ambienti",
+        "message": "Kestra Enterprise Edition ti permette di promuovere i flow da un ambiente all'altro — come ad esempio da dev a staging a production — direttamente dalla UI, senza la necessità di Git o pipeline CI/CD. Rivedi un diff di esattamente cosa cambierà prima di promuovere, proteggi i target sensibili con un gate di conferma, individua il drift a colpo d'occhio, e mantieni una cronologia completa di chi ha promosso cosa, dove e quando."
       },
       "IAM": {
         "title": "Gestisci gli utenti tramite IAM con SSO, SCIM e RBAC",

--- a/ui/src/translations/it.json
+++ b/ui/src/translations/it.json
@@ -942,7 +942,7 @@
     },
     "apps": "Applicazioni",
     "promote": {
-      "label": "Distribuisci"
+      "label": "Promuovi"
     },
     "demos": {
       "enterprise_edition": "Edizione Enterprise",

--- a/ui/src/translations/ja.json
+++ b/ui/src/translations/ja.json
@@ -942,7 +942,7 @@
     },
     "apps": "アプリケーション",
     "promote": {
-      "label": "デプロイ"
+      "label": "プロモート"
     },
     "demos": {
       "enterprise_edition": "エンタープライズエディション",

--- a/ui/src/translations/ja.json
+++ b/ui/src/translations/ja.json
@@ -941,6 +941,9 @@
       }
     },
     "apps": "アプリケーション",
+    "promote": {
+      "label": "デプロイ"
+    },
     "demos": {
       "enterprise_edition": "エンタープライズエディション",
       "get_a_demo_button": "デモを取得",
@@ -976,6 +979,10 @@
         "header": "Incident Management",
         "title": "Triage and resolve incidents without leaving Kestra.",
         "message": "Cases in Kestra Enterprise Edition let you open, assign, and track incidents directly from failed executions, with SLA tracking, activity timelines, and linked executions and assets to speed up root-cause analysis."
+      },
+      "promote": {
+        "title": "環境間でFlowsをプロモート",
+        "message": "Kestra Enterprise Editionでは、GitやCI/CDパイプラインを必要とせず、UIから直接、flowをある環境から別の環境へ（開発環境からステージング、本番環境など）プロモートできます。プロモートする前に、何が変更されるかを正確にdiffで確認し、機密性の高いターゲットを承認ゲートで保護し、変更のずれ（ドリフト）を一目で特定し、誰が、何を、どこで、いつプロモートしたかの完全な履歴を保持できます。"
       },
       "IAM": {
         "title": "IAMを通じてユーザーを管理（SSO、SCIM、RBACを使用）",

--- a/ui/src/translations/ko.json
+++ b/ui/src/translations/ko.json
@@ -942,7 +942,7 @@
     },
     "apps": "앱",
     "promote": {
-      "label": "배포"
+      "label": "승격"
     },
     "demos": {
       "enterprise_edition": "엔터프라이즈 에디션",

--- a/ui/src/translations/ko.json
+++ b/ui/src/translations/ko.json
@@ -941,6 +941,9 @@
       }
     },
     "apps": "앱",
+    "promote": {
+      "label": "배포"
+    },
     "demos": {
       "enterprise_edition": "엔터프라이즈 에디션",
       "get_a_demo_button": "데모 받기",
@@ -976,6 +979,10 @@
         "header": "Incident Management",
         "title": "Triage and resolve incidents without leaving Kestra.",
         "message": "Cases in Kestra Enterprise Edition let you open, assign, and track incidents directly from failed executions, with SLA tracking, activity timelines, and linked executions and assets to speed up root-cause analysis."
+      },
+      "promote": {
+        "title": "환경 간 Flows 승격",
+        "message": "Kestra Enterprise Edition을 사용하면 Git 또는 CI/CD 파이프라인 없이 UI에서 직접 `flow`를 한 환경에서 다른 환경으로(예: 개발 환경에서 스테이징, 프로덕션 환경으로) 승격할 수 있습니다. 승격하기 전에 정확히 무엇이 변경될지 차이점(diff)을 검토하고, 확인 게이트를 통해 민감한 대상을 보호하며, 드리프트(drift)를 한눈에 파악하고, 누가, 무엇을, 어디서, 언제 승격했는지에 대한 전체 기록을 유지합니다."
       },
       "IAM": {
         "title": "IAM을 통해 SSO, SCIM 및 RBAC로 사용자 관리",

--- a/ui/src/translations/pl.json
+++ b/ui/src/translations/pl.json
@@ -942,7 +942,7 @@
     },
     "apps": "Aplikacje",
     "promote": {
-      "label": "Wdróż"
+      "label": "Promuj"
     },
     "demos": {
       "enterprise_edition": "Enterprise Edition",

--- a/ui/src/translations/pl.json
+++ b/ui/src/translations/pl.json
@@ -941,6 +941,9 @@
       }
     },
     "apps": "Aplikacje",
+    "promote": {
+      "label": "Wdróż"
+    },
     "demos": {
       "enterprise_edition": "Enterprise Edition",
       "get_a_demo_button": "Uzyskaj Demo",
@@ -976,6 +979,10 @@
         "header": "Incident Management",
         "title": "Triage and resolve incidents without leaving Kestra.",
         "message": "Cases in Kestra Enterprise Edition let you open, assign, and track incidents directly from failed executions, with SLA tracking, activity timelines, and linked executions and assets to speed up root-cause analysis."
+      },
+      "promote": {
+        "title": "Promowanie Flows Pomiędzy Środowiskami",
+        "message": "Kestra Enterprise Edition pozwala promować flow z jednego środowiska do drugiego — na przykład z deweloperskiego do stagingu, a następnie do produkcji — bezpośrednio z UI, bez potrzeby użycia Git lub potoków CI/CD. Przejrzyj różnice (diff) dokładnie tego, co ulegnie zmianie przed promocją, chroń wrażliwe cele bramką potwierdzenia, szybko wykrywaj dryf i zachowaj pełną historię tego, kto, co, gdzie i kiedy promował."
       },
       "IAM": {
         "title": "Zarządzaj użytkownikami przez IAM z SSO, SCIM i RBAC",

--- a/ui/src/translations/pt.json
+++ b/ui/src/translations/pt.json
@@ -942,7 +942,7 @@
     },
     "apps": "Aplicativos",
     "promote": {
-      "label": "Implantar"
+      "label": "Promover"
     },
     "demos": {
       "enterprise_edition": "Edição Enterprise",

--- a/ui/src/translations/pt.json
+++ b/ui/src/translations/pt.json
@@ -941,6 +941,9 @@
       }
     },
     "apps": "Aplicativos",
+    "promote": {
+      "label": "Implantar"
+    },
     "demos": {
       "enterprise_edition": "Edição Enterprise",
       "get_a_demo_button": "Obter uma Demonstração",
@@ -976,6 +979,10 @@
         "header": "Incident Management",
         "title": "Triage and resolve incidents without leaving Kestra.",
         "message": "Cases in Kestra Enterprise Edition let you open, assign, and track incidents directly from failed executions, with SLA tracking, activity timelines, and linked executions and assets to speed up root-cause analysis."
+      },
+      "promote": {
+        "title": "Promover Flows Entre Ambientes",
+        "message": "Kestra Enterprise Edition permite promover flows de um ambiente para outro — como de desenvolvimento para staging para produção — diretamente da UI, sem a necessidade de Git ou pipelines de CI/CD. Revise um diff do que exatamente será alterado antes de promover, proteja alvos sensíveis com uma etapa de confirmação, identifique desvios rapidamente e mantenha um histórico completo de quem promoveu o quê, onde e quando."
       },
       "IAM": {
         "title": "Gerencie Usuários através do IAM com SSO, SCIM e RBAC",

--- a/ui/src/translations/pt_BR.json
+++ b/ui/src/translations/pt_BR.json
@@ -941,6 +941,9 @@
       }
     },
     "apps": "Aplicativos",
+    "promote": {
+      "label": "Implantar"
+    },
     "demos": {
       "enterprise_edition": "Edição Enterprise",
       "get_a_demo_button": "Obter uma Demonstração",
@@ -976,6 +979,10 @@
         "header": "Incident Management",
         "title": "Triage and resolve incidents without leaving Kestra.",
         "message": "Cases in Kestra Enterprise Edition let you open, assign, and track incidents directly from failed executions, with SLA tracking, activity timelines, and linked executions and assets to speed up root-cause analysis."
+      },
+      "promote": {
+        "title": "Promover Flows Entre Ambientes",
+        "message": "Kestra Enterprise Edition permite que você promova flows de um ambiente para outro — como de desenvolvimento para homologação para produção — diretamente da UI, sem a necessidade de Git ou pipelines de CI/CD. Revise um diff do que exatamente será alterado antes de promover, proteja alvos sensíveis com um gate de confirmação, identifique desvios rapidamente e mantenha um histórico completo de quem promoveu o quê, onde e quando."
       },
       "IAM": {
         "title": "Gerencie Usuários através do IAM com SSO, SCIM e RBAC",

--- a/ui/src/translations/pt_BR.json
+++ b/ui/src/translations/pt_BR.json
@@ -942,7 +942,7 @@
     },
     "apps": "Aplicativos",
     "promote": {
-      "label": "Implantar"
+      "label": "Promover"
     },
     "demos": {
       "enterprise_edition": "Edição Enterprise",

--- a/ui/src/translations/ru.json
+++ b/ui/src/translations/ru.json
@@ -941,6 +941,9 @@
       }
     },
     "apps": "Приложения",
+    "promote": {
+      "label": "Развернуть"
+    },
     "demos": {
       "enterprise_edition": "Enterprise Edition (Корпоративная версия)",
       "get_a_demo_button": "Получить демо-версию",
@@ -976,6 +979,10 @@
         "header": "Incident Management",
         "title": "Triage and resolve incidents without leaving Kestra.",
         "message": "Cases in Kestra Enterprise Edition let you open, assign, and track incidents directly from failed executions, with SLA tracking, activity timelines, and linked executions and assets to speed up root-cause analysis."
+      },
+      "promote": {
+        "title": "Продвигать Flows между средами",
+        "message": "Kestra Enterprise Edition позволяет продвигать flows из одной среды в другую — например, из dev в staging и затем в production — непосредственно из UI, без необходимости использования Git или CI/CD пайплайнов. Просматривайте diff того, что именно изменится перед продвижением, защищайте конфиденциальные цели с помощью подтверждающего шлюза, мгновенно выявляйте расхождения и ведите полную историю того, кто, что, куда и когда продвинул."
       },
       "IAM": {
         "title": "Управление пользователями через IAM с SSO, SCIM и RBAC",

--- a/ui/src/translations/ru.json
+++ b/ui/src/translations/ru.json
@@ -942,7 +942,7 @@
     },
     "apps": "Приложения",
     "promote": {
-      "label": "Развернуть"
+      "label": "Продвинуть"
     },
     "demos": {
       "enterprise_edition": "Enterprise Edition (Корпоративная версия)",

--- a/ui/src/translations/zh_CN.json
+++ b/ui/src/translations/zh_CN.json
@@ -942,7 +942,7 @@
     },
     "apps": "应用程序",
     "promote": {
-      "label": "部署"
+      "label": "提升"
     },
     "demos": {
       "enterprise_edition": "企业版",

--- a/ui/src/translations/zh_CN.json
+++ b/ui/src/translations/zh_CN.json
@@ -941,6 +941,9 @@
       }
     },
     "apps": "应用程序",
+    "promote": {
+      "label": "部署"
+    },
     "demos": {
       "enterprise_edition": "企业版",
       "get_a_demo_button": "获取演示",
@@ -976,6 +979,10 @@
         "header": "Incident Management",
         "title": "Triage and resolve incidents without leaving Kestra.",
         "message": "Cases in Kestra Enterprise Edition let you open, assign, and track incidents directly from failed executions, with SLA tracking, activity timelines, and linked executions and assets to speed up root-cause analysis."
+      },
+      "promote": {
+        "title": "跨环境提升 Flow",
+        "message": "Kestra 企业版允许您直接从 UI 将 flow 从一个环境提升到另一个环境 — 例如从开发环境到预发布环境再到生产环境 — 无需 Git 或 CI/CD 流水线。在提升前查看确切的变更 diff，通过确认门保护敏感目标，一目了然地发现偏差，并保留谁在何时何地提升了什么的完整历史记录。"
       },
       "IAM": {
         "title": "通过IAM使用SSO、SCIM和RBAC管理用户",

--- a/ui/src/utils/kestraHttp.ts
+++ b/ui/src/utils/kestraHttp.ts
@@ -120,6 +120,9 @@ export function setupKestraHttp(
     function handleErrorCentrally(error: KestraHttpError): KestraHttpError {
         const status = error.status
         if (status === 404) {
+            /** Callers expecting a 404 can pass `showMessageOnError: false`
+             * to handle it locally instead of the global not-found page.
+            */
             if (error.config?.showMessageOnError !== false) {
                 onError("error", error)
             }

--- a/ui/src/utils/kestraHttp.ts
+++ b/ui/src/utils/kestraHttp.ts
@@ -120,8 +120,6 @@ export function setupKestraHttp(
     function handleErrorCentrally(error: KestraHttpError): KestraHttpError {
         const status = error.status
         if (status === 404) {
-            // Let callers handle an expected 404 locally (e.g. rehydrating a Copilot thread that no
-            // longer exists) by passing `showMessageOnError: false`, instead of the global not-found page.
             if (error.config?.showMessageOnError !== false) {
                 onError("error", error)
             }


### PR DESCRIPTION
Adds a PROMOTION_TARGETS resource to QueryFilter (supports query + id) so the EE promotion-target list endpoint (/api/v1/{tenant}/promotion-targets) can use the standard QueryFilterFormat filtering, consistent with the other list endpoints.