### PR TITLE
fix(core): prevent a single icon fetch failure from emptying the plugin catalog

### DIFF
--- a/core/src/main/java/io/kestra/core/plugins/PluginCatalogService.java
+++ b/core/src/main/java/io/kestra/core/plugins/PluginCatalogService.java
@@ -161,16 +161,22 @@ public class PluginCatalogService {
 
                     String icon = null;
                     if (icons) {
-                        // Get icon
-                        HttpResponse<String> response = httpClient
-                            .toBlocking()
-                            .exchange(
-                                HttpRequest.create(HttpMethod.GET, "/v1/plugins/icons/" + plugin.get("group")),
-                                String.class
-                            );
-                        icon = response.getBody()
-                            .map(svg -> Base64.getEncoder().encodeToString(svg.getBytes(StandardCharsets.UTF_8)))
-                            .orElse(null);
+                        // A failure while fetching a single icon must never empty the whole catalog:
+                        // the icon fetch runs inside this stream, so an uncaught exception would abort
+                        // load() entirely and get() would return an empty (and cached) plugin list.
+                        try {
+                            HttpResponse<String> response = httpClient
+                                .toBlocking()
+                                .exchange(
+                                    HttpRequest.create(HttpMethod.GET, "/v1/plugins/icons/" + plugin.get("group")),
+                                    String.class
+                                );
+                            icon = response.getBody()
+                                .map(svg -> Base64.getEncoder().encodeToString(svg.getBytes(StandardCharsets.UTF_8)))
+                                .orElse(null);
+                        } catch (Exception e) {
+                            log.warn("Failed to load icon for plugin group '{}': {}", plugin.get("group"), e.getMessage());
+                        }
                     }
 
                     return new PluginManifest(

--- a/core/src/test/java/io/kestra/core/plugins/PluginCatalogServiceTest.java
+++ b/core/src/test/java/io/kestra/core/plugins/PluginCatalogServiceTest.java
@@ -1,0 +1,108 @@
+package io.kestra.core.plugins;
+
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import io.kestra.core.contexts.KestraContext;
+
+import io.micronaut.core.type.Argument;
+import io.micronaut.http.HttpRequest;
+import io.micronaut.http.HttpResponse;
+import io.micronaut.http.client.BlockingHttpClient;
+import io.micronaut.http.client.HttpClient;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class PluginCatalogServiceTest {
+
+    private HttpClient httpClient;
+    private BlockingHttpClient blockingClient;
+
+    @BeforeEach
+    void setUp() {
+        KestraContext kestraContext = mock(KestraContext.class);
+        when(kestraContext.getVersion()).thenReturn("1.3.0");
+        KestraContext.setContext(kestraContext);
+
+        httpClient = mock(HttpClient.class);
+        blockingClient = mock(BlockingHttpClient.class);
+        when(httpClient.toBlocking()).thenReturn(blockingClient);
+    }
+
+    @AfterEach
+    void tearDown() {
+        KestraContext.setContext(null);
+    }
+
+    @Test
+    void shouldReturnPluginManifests() {
+        // Given
+        stubPluginList(
+            Map.of("name", "plugin-serdes", "title", "Serdes", "group", "io.kestra.plugin", "license", "OPENSOURCE")
+        );
+
+        PluginCatalogService service = new PluginCatalogService(httpClient, false, true);
+
+        // When
+        List<PluginCatalogService.PluginManifest> result = service.get();
+
+        // Then
+        assertThat(result).hasSize(1);
+        assertThat(result.getFirst().title()).isEqualTo("Serdes");
+        assertThat(result.getFirst().groupId()).isEqualTo("io.kestra.plugin");
+        assertThat(result.getFirst().artifactId()).isEqualTo("plugin-serdes");
+    }
+
+    /**
+     * Regression test: the icon for each plugin is fetched from inside the stream that builds the
+     * catalog. If a single icon request fails at transport level (timeout, connection reset, TLS
+     * error, or a gateway that path-filters /icons/*), it must not discard the whole catalog.
+     * Before the fix, the uncaught exception aborted load() and get() returned an empty list.
+     */
+    @Test
+    void shouldKeepCatalogWhenSingleIconFetchFails() {
+        // Given: two plugins, and the icon request fails at transport level for one of them.
+        stubPluginList(
+            Map.of("name", "plugin-good", "title", "Good", "group", "io.kestra.plugin.good", "license", "OPENSOURCE"),
+            Map.of("name", "plugin-bad", "title", "Bad", "group", "io.kestra.plugin.bad", "license", "OPENSOURCE")
+        );
+        when(blockingClient.exchange(any(HttpRequest.class), eq(String.class)))
+            .thenAnswer(invocation -> {
+                HttpRequest<?> request = invocation.getArgument(0);
+                if (request.getPath().contains("io.kestra.plugin.bad")) {
+                    throw new RuntimeException("icon request failed (simulated read timeout)");
+                }
+                return HttpResponse.ok("<svg>icon</svg>");
+            });
+
+        PluginCatalogService service = new PluginCatalogService(httpClient, true, false);
+
+        // When
+        List<PluginCatalogService.PluginManifest> result = service.get();
+
+        // Then: both plugins are still present; the failing icon simply degrades to null.
+        assertThat(result).hasSize(2);
+        assertThat(result)
+            .filteredOn(m -> m.artifactId().equals("plugin-good"))
+            .singleElement()
+            .satisfies(m -> assertThat(m.icon()).isNotNull());
+        assertThat(result)
+            .filteredOn(m -> m.artifactId().equals("plugin-bad"))
+            .singleElement()
+            .satisfies(m -> assertThat(m.icon()).isNull());
+    }
+
+    @SafeVarargs
+    private void stubPluginList(Map<String, Object>... plugins) {
+        when(blockingClient.exchange(any(), any(Argument.class)))
+            .thenReturn(HttpResponse.ok(List.of(plugins)));
+    }
+}


### PR DESCRIPTION
## What

`PluginCatalogService.load()` builds the "Versioned Plugins" install catalog from `GET /v1/plugins`, and for **each** plugin also fetches its icon via `GET /v1/plugins/icons/{group}` — from **inside** the `parallelStream().map(...)` that builds the list, with **no error handling**.

Because that per-icon call is unguarded, a failure on **any single** icon request throws out of the whole stream → `load()` aborts → the `CompletableFuture` completes exceptionally → `get()` catches it and returns the **empty** plugin list. That empty result is then cached for up to 1h with no retry. The UI shows an **empty install catalog** even when `/v1/plugins` itself returned every plugin correctly.

The failure is also near-silent (the outer catch logs only `WARN` with a message, no stack, no failing URL).

### What actually triggers the throw

I validated against the live API: `GET /v1/plugins/icons/{group}` returns **HTTP 200 with a fallback SVG for every group name**, real or unknown (checked all 227 real groups → 0 non-200). So the trigger is **not** an HTTP error status — it is a **transport-level failure on the individual icon request**: a read timeout, connection reset, TLS handshake failure, or a gateway/WAF that path-filters `/icons/*`. When `/v1/plugins` succeeds but one icon request fails that way, the pre-fix code discards the entire catalog.

## Fix

Wrap the per-icon fetch in a `try/catch` so a failing icon request degrades to a `null` icon **for that one plugin** instead of discarding the entire catalog, and log the offending group at `WARN`.

This mirrors the 2.0 (`develop`) redesign, which decoupled icons from the catalog list entirely (icons served lazily via their own endpoint with their own error handling). That refactor is a contract change (icon endpoint + `PluginManifest` shape + frontend), so it was not backportable; this is the minimal, behavior-preserving hardening for the 1.x line — icons still inline as base64, no API/frontend contract change.

## Scope / caveat

This hardens the **per-icon** path only. If `/v1/plugins` itself is unreachable (total egress loss to `api.kestra.io`), the catalog is still legitimately empty — that is a connectivity problem, not something this change should mask.

## Impact

- Present in every released version through v1.3.x (the unguarded path is identical from v1.0.51 → current 1.3.x; already fixed on `develop`/2.0).
- Surfaced by a self-managed EE customer on core 1.0.51 whose UI showed an empty catalog.

## Testing

Adds `PluginCatalogServiceTest` (new — this class had no test):

- `shouldReturnPluginManifests` — basic `get()` contract.
- `shouldKeepCatalogWhenSingleIconFetchFails` — **regression test**: stubs the icon request to fail at transport level for one of two plugins and asserts the catalog still returns **both** (the failing icon degrades to `null`).

Verified the regression test **fails against the pre-fix code** (catalog returns empty, with the silent `WARN "Failed to retrieve available plugins…"`) and **passes with the guard**. Also boot-tested: `server local` starts on 1.3.29 with the change, `/health` UP, `/api/v1/plugins` returns 401 (not 500). `./gradlew :core:test --tests "io.kestra.core.plugins.PluginCatalogServiceTest"` → 2 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)