### PR TITLE
test(tests): unflake MysqlJdbcQueueCleanerTest

### DIFF
--- a/jdbc-mysql/src/test/java/io/kestra/queue/mysql/MysqlJdbcQueueCleanerTest.java
+++ b/jdbc-mysql/src/test/java/io/kestra/queue/mysql/MysqlJdbcQueueCleanerTest.java
@@ -1,9 +1,5 @@
 package io.kestra.queue.mysql;
 
-import org.junit.jupiter.api.Test;
-
-import io.kestra.core.junit.annotations.FlakyTest;
-import io.kestra.core.queues.QueueException;
 import io.kestra.jdbc.queue.AbstractJdbcQueueCleanerTest;
 
 import io.micronaut.context.annotation.Property;
@@ -12,10 +8,4 @@ import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
 @MicronautTest(rebuildContext = true)
 @Property(name = "kestra.jdbc.queue.cleaner.retention", value = "PT0S")
 public class MysqlJdbcQueueCleanerTest extends AbstractJdbcQueueCleanerTest {
-    @Test
-    @Override
-    @FlakyTest(description = "Zero-retention queue cleanup races with DB transaction commit timing")
-    protected void shouldClean() throws QueueException, InterruptedException {
-        super.shouldClean();
-    }
 }

--- a/jdbc/src/test/java/io/kestra/jdbc/queue/AbstractJdbcQueueCleanerTest.java
+++ b/jdbc/src/test/java/io/kestra/jdbc/queue/AbstractJdbcQueueCleanerTest.java
@@ -1,5 +1,7 @@
 package io.kestra.jdbc.queue;
 
+import java.time.Duration;
+
 import org.junit.jupiter.api.Test;
 
 import io.kestra.core.queues.BroadcastQueueInterface;
@@ -10,6 +12,7 @@ import io.kestra.queue.jdbc.client.JdbcQueueCleaner;
 import jakarta.inject.Inject;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
 
 public abstract class AbstractJdbcQueueCleanerTest {
     @Inject
@@ -19,13 +22,18 @@ public abstract class AbstractJdbcQueueCleanerTest {
     private BroadcastQueueInterface<AbstractBroadcastQueueTest.TestBroadcast> testQueue;
 
     @Test
-    protected void shouldClean() throws QueueException, InterruptedException {
+    protected void shouldClean() throws QueueException {
         var message = new AbstractBroadcastQueueTest.TestBroadcast("key", 1);
         testQueue.emit(message);
 
-        Thread.sleep(100); // wait a little as queue cleaner is datetime based
+        // Poll as some databases (e.g. MySQL) round the 'created' datetime to the next whole second,
+        // which can push it briefly into the future relative to the cleaner's now()-based cutoff.
+        // pollInSameThread() is required because of Micronaut's test-transaction support.
+        long cleaned = await()
+            .pollInSameThread()
+            .atMost(Duration.ofSeconds(5))
+            .until(jdbcQueueCleaner::deleteQueue, count -> count >= 1);
 
-        long cleaned = jdbcQueueCleaner.deleteQueue();
         assertThat(cleaned).isGreaterThanOrEqualTo(1);
     }
 }


### PR DESCRIPTION
MySQL's DATETIME column has no fractional-second precision, so the inserted 'created' timestamp can round up to the next whole second, occasionally landing after the cleaner's now()-based delete cutoff computed ~100ms later. Replace the fixed sleep + single assertion with an Awaitility poll.