### PR TITLE
docs: explain develop vs releases/vX.Y.x branch strategy in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -314,6 +314,15 @@ dev-tools/setup-worktree.sh ../worktrees/foo
 ```
 This copies the gitignored `cli/src/main/resources/application-*.yml` files from the main checkout into the worktree. Without this step Kestra cannot boot in the worktree. The script is idempotent — safe to re-run.
 
+### Branches and maintained versions
+
+`develop` tracks the next major version (currently 2.0.x) and is still pre-release (RC) — it is **not** what most users run in production. Older major/minor lines are maintained in parallel on their own long-lived `releases/vX.Y.x` branches (e.g. `releases/v1.3.x`), which receive their own bugfix and patch commits independently of `develop`.
+
+**Implication for bug reports:** a reporter's "Kestra Version" (e.g. `1.3.27`) tells you which `releases/vX.Y.x` branch to reproduce and fix against — it is very often *not* `develop`. Code on `develop` can differ substantially from a release branch (components get rewritten, composables renamed or removed, whole features redesigned), so:
+- Always check out the release branch matching the reported version before attempting to reproduce (`git worktree add <path> releases/vX.Y.x`, then run the app there — it needs its own `application-override.yml` copied in and typically its own database, since schemas/migrations diverge between branches).
+- A fix (and its PR) must target the branch the bug actually lives on, not `develop`, unless the bug is confirmed to reproduce there too.
+- Don't assume a bug is fixed just because it doesn't reproduce on `develop` — that branch may have simply rewritten the affected code, independent of any deliberate fix.
+
 ### Security Considerations
 - Use tenant isolation for multi-tenant features
 - Implement proper authorization with `@HasAnyPermission`


### PR DESCRIPTION
## Summary
- `AGENTS.md` didn't explain that `develop` tracks the unreleased 2.0.x RC while older maintained lines live on their own `releases/vX.Y.x` branches, receiving independent bugfixes.
- Adds a short "Branches and maintained versions" section (right after "Worktree setup") spelling out the implication for bug reports: reproduce and fix against the release branch matching the reporter's version, not `develop`, and don't assume a bug is fixed just because it no longer reproduces on `develop`.

## Context
While investigating https://github.com/kestra-io/kestra/issues/17350 (reported on `1.3.27`), I reproduced and initially closed it after testing only against `develop` — where the affected filter component had been substantially rewritten, not necessarily fixed. This doc gap is what caused that misstep.

## Test plan
- [x] Docs-only change, no code/build impact