### PR TITLE
fix(jdbc): detect deadlocks nested deeper than one cause level

### DIFF
--- a/jdbc/src/main/java/io/kestra/jdbc/JooqDSLContextWrapper.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/JooqDSLContextWrapper.java
@@ -3,6 +3,9 @@ package io.kestra.jdbc;
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.time.Duration;
+import java.util.Collections;
+import java.util.IdentityHashMap;
+import java.util.Set;
 import java.util.function.Predicate;
 
 import javax.sql.DataSource;
@@ -114,23 +117,39 @@ public class JooqDSLContextWrapper {
     static final class DeadlockPredicate implements Predicate<Throwable> {
         @Override
         public boolean test(Throwable e) {
-            if (!(e.getCause() instanceof SQLException cause)) {
+            // Walk the full cause chain: once Postgres aborts a transaction after a deadlock,
+            // a later statement in the same failed attempt surfaces a secondary "current transaction is aborted" exception
+            // that wraps the original deadlock one level deeper.
+            // Track visited causes by identity to stop on a cyclic chain (e.g. a cause pointing back to an exception already seen).
+            Set<Throwable> seen = Collections.newSetFromMap(new IdentityHashMap<>());
+            Throwable cause = e.getCause();
+            while (cause != null && seen.add(cause)) {
+                if (isDeadlockOrLockTimeout(cause)) {
+                    return true;
+                }
+                cause = cause.getCause();
+            }
+            return false;
+        }
+
+        private static boolean isDeadlockOrLockTimeout(Throwable cause) {
+            if (!(cause instanceof SQLException sqlException)) {
                 return false;
             }
 
             // MySQL/MariaDB vendor codes:
             // 1213 = ER_LOCK_DEADLOCK
             // 1205 = ER_LOCK_WAIT_TIMEOUT
-            int vendorCode = cause.getErrorCode();
+            int vendorCode = sqlException.getErrorCode();
             if (vendorCode == 1213 || vendorCode == 1205) {
                 return true;
             }
 
             return
             // standard deadlock
-            "40001".equals(cause.getSQLState()) ||
+            "40001".equals(sqlException.getSQLState()) ||
             // postgres deadlock
-                "40P01".equals(cause.getSQLState());
+                "40P01".equals(sqlException.getSQLState());
         }
     }
 }

--- a/jdbc/src/test/java/io/kestra/jdbc/JooqDSLContextWrapperDeadlockPredicateTest.java
+++ b/jdbc/src/test/java/io/kestra/jdbc/JooqDSLContextWrapperDeadlockPredicateTest.java
@@ -1,0 +1,127 @@
+package io.kestra.jdbc;
+
+import java.sql.SQLException;
+
+import org.jooq.exception.DataAccessException;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class JooqDSLContextWrapperDeadlockPredicateTest {
+    private final JooqDSLContextWrapper.DeadlockPredicate predicate = new JooqDSLContextWrapper.DeadlockPredicate();
+
+    @Test
+    void shouldMatchDirectPostgresDeadlock() {
+        // Given
+        SQLException postgresDeadlock = new SQLException("ERROR: deadlock detected", "40P01");
+        DataAccessException exception = new DataAccessException("deadlock", postgresDeadlock);
+
+        // When
+        boolean result = predicate.test(exception);
+
+        // Then
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    void shouldMatchDirectMysqlDeadlock() {
+        // Given
+        // vendor code 1213 = ER_LOCK_DEADLOCK
+        SQLException mysqlDeadlock = new SQLException("Deadlock found when trying to get lock", "40001", 1213);
+        DataAccessException exception = new DataAccessException("deadlock", mysqlDeadlock);
+
+        // When
+        boolean result = predicate.test(exception);
+
+        // Then
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    void shouldMatchMysqlLockWaitTimeout() {
+        // Given
+        // vendor code 1205 = ER_LOCK_WAIT_TIMEOUT
+        SQLException lockWaitTimeout = new SQLException("Lock wait timeout exceeded", "HY000", 1205);
+        DataAccessException exception = new DataAccessException("lock wait timeout", lockWaitTimeout);
+
+        // When
+        boolean result = predicate.test(exception);
+
+        // Then
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    void shouldMatchStandardSqlStateDeadlock() {
+        // Given
+        SQLException standardDeadlock = new SQLException("deadlock detected", "40001");
+        DataAccessException exception = new DataAccessException("deadlock", standardDeadlock);
+
+        // When
+        boolean result = predicate.test(exception);
+
+        // Then
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    void shouldMatchDeadlockNestedTwoLevelsDeep() {
+        // Given
+        // Reproduces the CI failure shape: once Postgres aborts a transaction after a deadlock, a
+        // later statement in the same failed attempt surfaces a secondary "current transaction is
+        // aborted" (25P02) exception wrapping the original deadlock (40P01) one level deeper.
+        SQLException originalDeadlock = new SQLException("ERROR: deadlock detected", "40P01");
+        SQLException abortedTransaction = new SQLException("ERROR: current transaction is aborted, commands ignored until end of transaction block", "25P02", originalDeadlock);
+        DataAccessException exception = new DataAccessException("aborted", abortedTransaction);
+
+        // When
+        boolean result = predicate.test(exception);
+
+        // Then
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    void shouldNotMatchUnrelatedSqlException() {
+        // Given
+        SQLException unrelated = new SQLException("syntax error", "42601");
+        DataAccessException exception = new DataAccessException("syntax error", unrelated);
+
+        // When
+        boolean result = predicate.test(exception);
+
+        // Then
+        assertThat(result).isFalse();
+    }
+
+    @Test
+    void shouldNotMatchExceptionWithNoCause() {
+        // Given
+        DataAccessException exception = new DataAccessException("no cause here");
+
+        // When
+        boolean result = predicate.test(exception);
+
+        // Then
+        assertThat(result).isFalse();
+    }
+
+    @Test
+    void shouldTerminateOnCyclicCauseChainInsteadOfMatching() {
+        // Given
+        // Some libraries produce cause chains that cycle back to an already-seen exception. Neither
+        // exception here is a deadlock, so the predicate must terminate and return false rather than
+        // looping forever walking the cycle.
+        SQLException a = new SQLException("a");
+        SQLException b = new SQLException("b");
+        a.initCause(b);
+        b.initCause(a);
+        DataAccessException exception = new DataAccessException("cyclic", a);
+
+        // When
+        boolean result = predicate.test(exception);
+
+        // Then
+        assertThat(result).isFalse();
+    }
+}


### PR DESCRIPTION
DeadlockPredicate only inspected e.getCause(), one level deep. Under Postgres, once a statement deadlocks (SQLState 40P01) the transaction is poisoned, so a later statement in the same failed retry attempt surfaces a secondary "current transaction is aborted" exception (25P02) wrapping the original deadlock one level deeper. The single-level check missed this shape, so the retry never fired.

Walk the full cause chain instead, guarding against cyclic chains with an identity-based seen-set to avoid circular cause chain.