### PR TITLE
feat(core): normalize PostHog event names to surface.object.action

### DIFF
--- a/ui/src/stores/api.ts
+++ b/ui/src/stores/api.ts
@@ -6,6 +6,7 @@ import {useMiscStore} from "override/stores/misc"
 import {capturePosthogEvent, disablePosthog} from "../utils/posthog"
 import {ensureUid} from "../utils/uid"
 import {PendingEventsBuffer} from "../utils/analytics/pendingEvents"
+import {resolvePosthogEventName} from "../utils/analytics/eventNaming"
 
 export const API_URL = "https://api.kestra.io"
 
@@ -186,7 +187,7 @@ export const useApiStore = defineStore("api", () => {
         delete finalData.date
         delete finalData.counter
 
-        const eventName = type === "PAGE" ? "$pageview" : data.type.toLowerCase()
+        const eventName = type === "PAGE" ? "$pageview" : resolvePosthogEventName(data.type, finalData as Record<string, any>)
 
         if (type === "PAGE") {
             const origin = data.page?.origin ?? window.location.origin

--- a/ui/src/utils/analytics/eventNaming.spec.ts
+++ b/ui/src/utils/analytics/eventNaming.spec.ts
@@ -1,37 +1,39 @@
 import {describe, expect, it} from "vitest"
 import {resolvePosthogEventName} from "./eventNaming"
 
+const fixtures: [string, Record<string, any>, string][] = [
+    ["flow_execution", {}, "app.flow.executed"],
+    ["ai_copilot", {}, "app.ai-copilot.invoked"],
+    ["blueprint", {}, "app.blueprint.used"],
+    ["survey_submitted", {}, "app.survey.submitted"],
+    ["survey_skipped", {}, "app.survey.skipped"],
+    ["setup_flow:account_created", {}, "app.account.created"],
+    ["setup_flow:account_creation_failed", {}, "app.account.creation-failed"],
+    ["setup_flow:marketing_survey_submitted", {}, "app.marketing-survey.submitted"],
+    ["setup_flow:marketing_survey_skipped", {}, "app.marketing-survey.skipped"],
+    ["setup_flow:completed", {}, "app.setup-flow.completed"],
+    ["error", {}, "app.error.occurred"],
+    ["editor_tab_action", {action: "open"}, "app.editor-tab.opened"],
+    ["editor_tab_action", {action: "close"}, "app.editor-tab.closed"],
+    ["editor_tab_action", {action: "plugin_doc"}, "app.plugin-doc.viewed"],
+    ["editor_tab_action", {action: "files_open"}, "app.editor-files.opened"],
+    ["editor_tab_action", {action: "blueprint_selection"}, "app.editor-blueprint.selected"],
+    ["ossauth", {action: "forgot_password_click"}, "app.forgot-password.clicked"],
+    ["ossauth", {}, "app.oss-auth.completed"],
+    ["onboarding", {onboarding: {action: "step_viewed"}}, "app.onboarding-step.viewed"],
+    ["onboarding", {onboarding: {action: "step_next_clicked"}}, "app.onboarding-step.advanced"],
+    ["onboarding", {onboarding: {action: "step_auto_advanced"}}, "app.onboarding-step.auto-advanced"],
+    ["onboarding", {onboarding: {action: "step_validation_failed"}}, "app.onboarding-step.validation-failed"],
+    ["onboarding", {onboarding: {action: "tutorial_completed"}}, "app.onboarding.completed"],
+    ["onboarding", {onboarding: {action: "finish_explore_blueprints_clicked"}}, "app.onboarding.completed"],
+    ["onboarding", {onboarding: {action: "finish_create_flow_clicked"}}, "app.onboarding.completed"],
+    ["onboarding", {onboarding: {action: "tutorial_canceled"}}, "app.onboarding.cancelled"],
+    ["onboarding", {onboarding: {action: "flow_saved_during_tutorial"}}, "app.onboarding-step.viewed"],
+    ["onboarding", {onboarding: {action: "flow_executed_during_tutorial"}}, "app.onboarding-step.viewed"],
+]
+
 describe("resolvePosthogEventName", () => {
-    it.each([
-        ["flow_execution", {}, "app.flow.executed"],
-        ["ai_copilot", {}, "app.ai-copilot.invoked"],
-        ["blueprint", {}, "app.blueprint.used"],
-        ["survey_submitted", {}, "app.survey.submitted"],
-        ["survey_skipped", {}, "app.survey.skipped"],
-        ["setup_flow:account_created", {}, "app.account.created"],
-        ["setup_flow:account_creation_failed", {}, "app.account.creation-failed"],
-        ["setup_flow:marketing_survey_submitted", {}, "app.marketing-survey.submitted"],
-        ["setup_flow:marketing_survey_skipped", {}, "app.marketing-survey.skipped"],
-        ["setup_flow:completed", {}, "app.setup-flow.completed"],
-        ["error", {}, "app.error.occurred"],
-        ["editor_tab_action", {action: "open"}, "app.editor-tab.opened"],
-        ["editor_tab_action", {action: "close"}, "app.editor-tab.closed"],
-        ["editor_tab_action", {action: "plugin_doc"}, "app.plugin-doc.viewed"],
-        ["editor_tab_action", {action: "files_open"}, "app.editor-files.opened"],
-        ["editor_tab_action", {action: "blueprint_selection"}, "app.editor-blueprint.selected"],
-        ["ossauth", {action: "forgot_password_click"}, "app.forgot-password.clicked"],
-        ["ossauth", {}, "app.oss-auth.completed"],
-        ["onboarding", {onboarding: {action: "step_viewed"}}, "app.onboarding-step.viewed"],
-        ["onboarding", {onboarding: {action: "step_next_clicked"}}, "app.onboarding-step.advanced"],
-        ["onboarding", {onboarding: {action: "step_auto_advanced"}}, "app.onboarding-step.auto-advanced"],
-        ["onboarding", {onboarding: {action: "step_validation_failed"}}, "app.onboarding-step.validation-failed"],
-        ["onboarding", {onboarding: {action: "tutorial_completed"}}, "app.onboarding.completed"],
-        ["onboarding", {onboarding: {action: "finish_explore_blueprints_clicked"}}, "app.onboarding.completed"],
-        ["onboarding", {onboarding: {action: "finish_create_flow_clicked"}}, "app.onboarding.completed"],
-        ["onboarding", {onboarding: {action: "tutorial_canceled"}}, "app.onboarding.cancelled"],
-        ["onboarding", {onboarding: {action: "flow_saved_during_tutorial"}}, "app.onboarding-step.viewed"],
-        ["onboarding", {onboarding: {action: "flow_executed_during_tutorial"}}, "app.onboarding-step.viewed"],
-    ])("resolves %s with %j to %s", (type, properties, expected) => {
+    it.each(fixtures)("resolves %s with %j to %s", (type, properties, expected) => {
         expect(resolvePosthogEventName(type, properties)).toEqual(expected)
     })
 
@@ -55,36 +57,9 @@ describe("resolvePosthogEventName", () => {
         expect(resolvePosthogEventName("onboarding", {action: "step_viewed"})).toEqual("onboarding")
     })
 
-    it("matches the surface.object.action shape for every mapped output", () => {
-        const mappedNames = [
-            "app.flow.executed",
-            "app.ai-copilot.invoked",
-            "app.blueprint.used",
-            "app.survey.submitted",
-            "app.survey.skipped",
-            "app.account.created",
-            "app.account.creation-failed",
-            "app.marketing-survey.submitted",
-            "app.marketing-survey.skipped",
-            "app.setup-flow.completed",
-            "app.error.occurred",
-            "app.editor-tab.opened",
-            "app.editor-tab.closed",
-            "app.plugin-doc.viewed",
-            "app.editor-files.opened",
-            "app.editor-blueprint.selected",
-            "app.forgot-password.clicked",
-            "app.oss-auth.completed",
-            "app.onboarding-step.viewed",
-            "app.onboarding-step.advanced",
-            "app.onboarding-step.auto-advanced",
-            "app.onboarding-step.validation-failed",
-            "app.onboarding.completed",
-            "app.onboarding.cancelled",
-        ]
-
-        mappedNames.forEach((name) => {
-            expect(name).toMatch(/^app\.[a-z0-9-]+\.[a-z0-9-]+$/)
+    it("resolves every mapped fixture to a surface.object.action shaped name", () => {
+        fixtures.forEach(([type, properties]) => {
+            expect(resolvePosthogEventName(type, properties)).toMatch(/^app\.[a-z0-9-]+\.[a-z0-9-]+$/)
         })
     })
 })

--- a/ui/src/utils/analytics/eventNaming.spec.ts
+++ b/ui/src/utils/analytics/eventNaming.spec.ts
@@ -1,0 +1,90 @@
+import {describe, expect, it} from "vitest"
+import {resolvePosthogEventName} from "./eventNaming"
+
+describe("resolvePosthogEventName", () => {
+    it.each([
+        ["flow_execution", {}, "app.flow.executed"],
+        ["ai_copilot", {}, "app.ai-copilot.invoked"],
+        ["blueprint", {}, "app.blueprint.used"],
+        ["survey_submitted", {}, "app.survey.submitted"],
+        ["survey_skipped", {}, "app.survey.skipped"],
+        ["setup_flow:account_created", {}, "app.account.created"],
+        ["setup_flow:account_creation_failed", {}, "app.account.creation-failed"],
+        ["setup_flow:marketing_survey_submitted", {}, "app.marketing-survey.submitted"],
+        ["setup_flow:marketing_survey_skipped", {}, "app.marketing-survey.skipped"],
+        ["setup_flow:completed", {}, "app.setup-flow.completed"],
+        ["error", {}, "app.error.occurred"],
+        ["editor_tab_action", {action: "open"}, "app.editor-tab.opened"],
+        ["editor_tab_action", {action: "close"}, "app.editor-tab.closed"],
+        ["editor_tab_action", {action: "plugin_doc"}, "app.plugin-doc.viewed"],
+        ["editor_tab_action", {action: "files_open"}, "app.editor-files.opened"],
+        ["editor_tab_action", {action: "blueprint_selection"}, "app.editor-blueprint.selected"],
+        ["ossauth", {action: "forgot_password_click"}, "app.forgot-password.clicked"],
+        ["ossauth", {}, "app.oss-auth.completed"],
+        ["onboarding", {onboarding: {action: "step_viewed"}}, "app.onboarding-step.viewed"],
+        ["onboarding", {onboarding: {action: "step_next_clicked"}}, "app.onboarding-step.advanced"],
+        ["onboarding", {onboarding: {action: "step_auto_advanced"}}, "app.onboarding-step.auto-advanced"],
+        ["onboarding", {onboarding: {action: "step_validation_failed"}}, "app.onboarding-step.validation-failed"],
+        ["onboarding", {onboarding: {action: "tutorial_completed"}}, "app.onboarding.completed"],
+        ["onboarding", {onboarding: {action: "finish_explore_blueprints_clicked"}}, "app.onboarding.completed"],
+        ["onboarding", {onboarding: {action: "finish_create_flow_clicked"}}, "app.onboarding.completed"],
+        ["onboarding", {onboarding: {action: "tutorial_canceled"}}, "app.onboarding.cancelled"],
+        ["onboarding", {onboarding: {action: "flow_saved_during_tutorial"}}, "app.onboarding-step.viewed"],
+        ["onboarding", {onboarding: {action: "flow_executed_during_tutorial"}}, "app.onboarding-step.viewed"],
+    ])("resolves %s with %j to %s", (type, properties, expected) => {
+        expect(resolvePosthogEventName(type, properties)).toEqual(expected)
+    })
+
+    it("falls back to the lowercased type for an unmapped event", () => {
+        expect(resolvePosthogEventName("SOMETHING_NEW", {})).toEqual("something_new")
+    })
+
+    it("falls back to the base lowercased name when editor_tab_action has an unknown action", () => {
+        expect(resolvePosthogEventName("editor_tab_action", {action: "unknown_action"})).toEqual("editor_tab_action")
+    })
+
+    it("falls back to app.oss-auth.completed when ossauth has an unknown action", () => {
+        expect(resolvePosthogEventName("ossauth", {action: "unknown_action"})).toEqual("app.oss-auth.completed")
+    })
+
+    it("falls back to onboarding when the nested onboarding.action is unknown", () => {
+        expect(resolvePosthogEventName("onboarding", {onboarding: {action: "unknown_action"}})).toEqual("onboarding")
+    })
+
+    it("reads the discriminator from the nested onboarding.action, not a top-level action", () => {
+        expect(resolvePosthogEventName("onboarding", {action: "step_viewed"})).toEqual("onboarding")
+    })
+
+    it("matches the surface.object.action shape for every mapped output", () => {
+        const mappedNames = [
+            "app.flow.executed",
+            "app.ai-copilot.invoked",
+            "app.blueprint.used",
+            "app.survey.submitted",
+            "app.survey.skipped",
+            "app.account.created",
+            "app.account.creation-failed",
+            "app.marketing-survey.submitted",
+            "app.marketing-survey.skipped",
+            "app.setup-flow.completed",
+            "app.error.occurred",
+            "app.editor-tab.opened",
+            "app.editor-tab.closed",
+            "app.plugin-doc.viewed",
+            "app.editor-files.opened",
+            "app.editor-blueprint.selected",
+            "app.forgot-password.clicked",
+            "app.oss-auth.completed",
+            "app.onboarding-step.viewed",
+            "app.onboarding-step.advanced",
+            "app.onboarding-step.auto-advanced",
+            "app.onboarding-step.validation-failed",
+            "app.onboarding.completed",
+            "app.onboarding.cancelled",
+        ]
+
+        mappedNames.forEach((name) => {
+            expect(name).toMatch(/^app\.[a-z0-9-]+\.[a-z0-9-]+$/)
+        })
+    })
+})

--- a/ui/src/utils/analytics/eventNaming.ts
+++ b/ui/src/utils/analytics/eventNaming.ts
@@ -1,0 +1,68 @@
+// Taxonomy source of truth: kestra-io/data#354
+const FLAT_EVENT_NAMES: Record<string, string> = {
+    flow_execution: "app.flow.executed",
+    ai_copilot: "app.ai-copilot.invoked",
+    blueprint: "app.blueprint.used",
+    survey_submitted: "app.survey.submitted",
+    survey_skipped: "app.survey.skipped",
+    "setup_flow:account_created": "app.account.created",
+    "setup_flow:account_creation_failed": "app.account.creation-failed",
+    "setup_flow:marketing_survey_submitted": "app.marketing-survey.submitted",
+    "setup_flow:marketing_survey_skipped": "app.marketing-survey.skipped",
+    "setup_flow:completed": "app.setup-flow.completed",
+    error: "app.error.occurred",
+}
+
+const EDITOR_TAB_ACTION_NAMES: Record<string, string> = {
+    open: "app.editor-tab.opened",
+    close: "app.editor-tab.closed",
+    plugin_doc: "app.plugin-doc.viewed",
+    files_open: "app.editor-files.opened",
+    blueprint_selection: "app.editor-blueprint.selected",
+}
+
+const OSSAUTH_NAMES: Record<string, string> = {
+    forgot_password_click: "app.forgot-password.clicked",
+}
+
+const ONBOARDING_NAMES: Record<string, string> = {
+    step_viewed: "app.onboarding-step.viewed",
+    step_next_clicked: "app.onboarding-step.advanced",
+    step_auto_advanced: "app.onboarding-step.auto-advanced",
+    step_validation_failed: "app.onboarding-step.validation-failed",
+    tutorial_completed: "app.onboarding.completed",
+    finish_explore_blueprints_clicked: "app.onboarding.completed",
+    finish_create_flow_clicked: "app.onboarding.completed",
+    tutorial_canceled: "app.onboarding.cancelled",
+    flow_saved_during_tutorial: "app.onboarding-step.viewed",
+    flow_executed_during_tutorial: "app.onboarding-step.viewed",
+}
+
+function resolveEditorTabAction(properties: Record<string, any>): string {
+    return EDITOR_TAB_ACTION_NAMES[properties.action] ?? "editor_tab_action"
+}
+
+function resolveOssAuth(properties: Record<string, any>): string {
+    return OSSAUTH_NAMES[properties.action] ?? "app.oss-auth.completed"
+}
+
+function resolveOnboarding(properties: Record<string, any>): string {
+    return ONBOARDING_NAMES[properties.onboarding?.action] ?? "onboarding"
+}
+
+const SPLIT_EVENT_RESOLVERS: Record<string, (properties: Record<string, any>) => string> = {
+    editor_tab_action: resolveEditorTabAction,
+    ossauth: resolveOssAuth,
+    onboarding: resolveOnboarding,
+}
+
+export function resolvePosthogEventName(type: string, properties: Record<string, any>): string {
+    const lowerType = type.toLowerCase()
+
+    const splitResolver = SPLIT_EVENT_RESOLVERS[lowerType]
+    if (splitResolver) {
+        return splitResolver(properties)
+    }
+
+    return FLAT_EVENT_NAMES[lowerType] ?? lowerType
+}


### PR DESCRIPTION
## Summary

- Frontend PostHog events funnel through a single choke point (`posthogEvents()` in `ui/src/stores/api.ts`), so the entire `app.*` rename is implemented with one pure resolver (`ui/src/utils/analytics/eventNaming.ts`) called there, instead of touching every call site.
- Adds `resolvePosthogEventName(type, properties)` implementing the `app.<object>.<action>` mapping agreed in the tracking issue below (flat 1:1 renames, plus `editor_tab_action` / `ossauth` / `onboarding` split by their discriminating property, with `onboarding`'s discriminator read from the nested `onboarding.action`). Unmapped events fall back to the lowercased `type` so the dbt drift monitor (kestra-io/data#428) still catches anything unmapped.
- The backend `/v1/reports/events` payload (`type`) is deliberately left untouched — backend event naming is explicitly out of scope per data#354 Q7. Resolving the PostHog name only inside `posthogEvents()` keeps the two paths decoupled with no call-site changes.
- Two in-tutorial onboarding actions (`flow_saved_during_tutorial`, `flow_executed_during_tutorial`) are folded into `app.onboarding-step.viewed` per product decision, with the original action retained as a property.

part-of: https://github.com/kestra-io/data/issues/354

## Test plan

- [x] `npm run check:types` passes
- [x] `npm run test:unit` — 789/789 tests pass, including new `eventNaming.spec.ts` covering every flat/split mapping, the nested `onboarding.action` discriminator, unmapped-type fallback, and a drift guard asserting the `app.<object>.<action>` shape
- [x] `npm run test:lint` — 0 errors
- [x] `node src/translations/check.js` (now `check.ts`) — no missing/extra keys in any locale (this change adds no i18n keys)