### PR TITLE
feat(design-system): consistent clickable namespace and flow references across tables

### DIFF
--- a/ui/AGENTS.md
+++ b/ui/AGENTS.md
@@ -322,7 +322,7 @@ If your `<style>` block needs to exist:
 | `KsCard` | Card container |
 | `KsTable` / `KsTableColumn` | Basic table |
 | `KsDataTable` / `KsFilter` / `KsBulkSelect` | Advanced data table with filtering, sorting, pagination, bulk actions. **Pagination is fully controlled** — bind `:currentPage` / `:pageSize` (or `v-model:`). See "Data tables & pagination state". |
-| `KsEntityLink` | Clickable cross-entity reference (namespace / flow) for table cells — leading icon + violet link |
+| `KsEntityLink` | Clickable cross-entity reference (namespace / flow) for table cells — neutral tag with leading icon, violet on hover |
 | `KsBadge` | Small indicator badge |
 | `KsNewBadge` | Compact uppercase "NEW" pill flagging a newly shipped feature — caller supplies the label via the default slot |
 | `KsTag` / `KsCheckTag` | Tag / label; clickable checkbox-style tag |

--- a/ui/AGENTS.md
+++ b/ui/AGENTS.md
@@ -322,6 +322,7 @@ If your `<style>` block needs to exist:
 | `KsCard` | Card container |
 | `KsTable` / `KsTableColumn` | Basic table |
 | `KsDataTable` / `KsFilter` / `KsBulkSelect` | Advanced data table with filtering, sorting, pagination, bulk actions. **Pagination is fully controlled** — bind `:currentPage` / `:pageSize` (or `v-model:`). See "Data tables & pagination state". |
+| `KsEntityLink` | Clickable cross-entity reference (namespace / flow) for table cells — leading icon + violet link |
 | `KsBadge` | Small indicator badge |
 | `KsNewBadge` | Compact uppercase "NEW" pill flagging a newly shipped feature — caller supplies the label via the default slot |
 | `KsTag` / `KsCheckTag` | Tag / label; clickable checkbox-style tag |

--- a/ui/packages/design-system/src/components/Data/KsEntityLink/KsEntityLink.vue
+++ b/ui/packages/design-system/src/components/Data/KsEntityLink/KsEntityLink.vue
@@ -35,16 +35,17 @@
     align-items: center;
     gap: var(--ks-spacing-1);
     max-width: 100%;
-    color: var(--ks-text-link);
+    color: var(--ks-text-primary);
+    background: var(--ks-bg-tag);
     text-decoration: none;
-    border-radius: var(--ks-radius-xs);
-    padding: 0.125rem var(--ks-spacing-1);
-    margin: -0.125rem calc(-1 * var(--ks-spacing-1));
-    transition: background-color var(--ks-duration-fast) var(--ks-ease-standard);
+    border-radius: var(--ks-radius-base);
+    padding: 0.125rem var(--ks-spacing-2);
+    transition: background-color var(--ks-duration-fast) var(--ks-ease-standard), color var(--ks-duration-fast) var(--ks-ease-standard);
 }
 
 .ks-entity-link:hover {
     background: var(--ks-bg-tag-hover);
+    color: var(--ks-text-link);
     text-decoration: underline;
 }
 
@@ -55,7 +56,6 @@
 .ks-entity-link:focus-visible {
     outline: var(--ks-border-width-base) solid var(--ks-border-focus);
     outline-offset: var(--ks-spacing-px);
-    border-radius: var(--ks-radius-xs);
 }
 
 .ks-entity-link__icon {

--- a/ui/packages/design-system/src/components/Data/KsEntityLink/KsEntityLink.vue
+++ b/ui/packages/design-system/src/components/Data/KsEntityLink/KsEntityLink.vue
@@ -1,0 +1,72 @@
+<template>
+    <RouterLink :to="to" :title="value" class="ks-entity-link" @click.stop>
+        <component :is="icon" aria-hidden="true" class="ks-entity-link__icon" />
+        <span class="ks-entity-link__value">{{ value }}</span>
+    </RouterLink>
+</template>
+
+<script lang="ts">
+    export type KsEntityLinkEntity = "namespace" | "flow"
+</script>
+
+<script setup lang="ts">
+    import {computed, type Component} from "vue"
+    import {RouterLink, type RouteLocationRaw} from "vue-router"
+    import FolderOpenOutline from "vue-material-design-icons/FolderOpenOutline.vue"
+    import FileTreeOutline from "vue-material-design-icons/FileTreeOutline.vue"
+
+    const ENTITY_ICONS: Record<KsEntityLinkEntity, Component> = {
+        namespace: FolderOpenOutline,
+        flow: FileTreeOutline,
+    }
+
+    const props = defineProps<{
+        entity: KsEntityLinkEntity
+        value: string
+        to: RouteLocationRaw
+    }>()
+
+    const icon = computed(() => ENTITY_ICONS[props.entity])
+</script>
+
+<style scoped lang="scss">
+.ks-entity-link {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--ks-spacing-1);
+    max-width: 100%;
+    color: var(--ks-text-link);
+    text-decoration: none;
+    border-radius: var(--ks-radius-xs);
+    padding: 0.125rem var(--ks-spacing-1);
+    margin: -0.125rem calc(-1 * var(--ks-spacing-1));
+    transition: background-color var(--ks-duration-fast) var(--ks-ease-standard);
+}
+
+.ks-entity-link:hover {
+    background: var(--ks-bg-tag-hover);
+    text-decoration: underline;
+}
+
+.ks-entity-link:active {
+    background: var(--ks-bg-tag-active);
+}
+
+.ks-entity-link:focus-visible {
+    outline: var(--ks-border-width-base) solid var(--ks-border-focus);
+    outline-offset: var(--ks-spacing-px);
+    border-radius: var(--ks-radius-xs);
+}
+
+.ks-entity-link__icon {
+    flex-shrink: 0;
+    width: var(--ks-icon-size-sm);
+    height: var(--ks-icon-size-sm);
+}
+
+.ks-entity-link__value {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+</style>

--- a/ui/packages/design-system/src/index.ts
+++ b/ui/packages/design-system/src/index.ts
@@ -493,6 +493,7 @@ declare module "vue" {
         KsDropdownMenu: typeof KsDropdownMenu
         KsEmpty: typeof KsEmpty
         KsEmptyState: typeof KsEmptyState
+        KsEntityLink: typeof KsEntityLink
         KsExecutionStatus: typeof KsExecutionStatus
         KsFilter: typeof KsFilter
         KsForm: typeof KsForm

--- a/ui/packages/design-system/src/index.ts
+++ b/ui/packages/design-system/src/index.ts
@@ -53,6 +53,8 @@ import KsDropdownItem from "./components/Navigation/KsDropdown/KsDropdownItem.vu
 import KsDropdownMenu from "./components/Navigation/KsDropdown/KsDropdownMenu.vue"
 import KsEmpty from "./components/Data/KsEmpty.vue"
 import KsEmptyState from "./components/Data/KsEmptyState.vue"
+import KsEntityLink from "./components/Data/KsEntityLink/KsEntityLink.vue"
+export type {KsEntityLinkEntity} from "./components/Data/KsEntityLink/KsEntityLink.vue"
 import KsExecutionStatus from "./components/Data/KsExecutionStatus/KsExecutionStatus.vue"
 import KsFilter from "./components/Data/KsDataTable/KsFilter.vue"
 import KsForm from "./components/Form/KsForm/KsForm.vue"
@@ -253,6 +255,7 @@ const components: Record<string, Component> = {
     KsEditor,
     KsEmpty,
     KsEmptyState,
+    KsEntityLink,
     KsExecutionStatus,
     KsFilter,
     KsForm,
@@ -361,6 +364,7 @@ export {
     KsEditor,
     KsEmpty,
     KsEmptyState,
+    KsEntityLink,
     KsExecutionStatus,
     KsFilter,
     KsForm,

--- a/ui/packages/design-system/tests/storybook/Data/KsEntityLink.stories.ts
+++ b/ui/packages/design-system/tests/storybook/Data/KsEntityLink.stories.ts
@@ -1,0 +1,98 @@
+import type {Meta, StoryObj} from "@storybook/vue3-vite"
+import KsEntityLink from "../../../src/components/Data/KsEntityLink/KsEntityLink.vue"
+
+const meta: Meta<typeof KsEntityLink> = {
+    title: "Components/Data/KsEntityLink",
+    component: KsEntityLink,
+    tags: ["autodocs"],
+    argTypes: {
+        entity: {control: "select", options: ["namespace", "flow"]},
+    },
+    parameters: {
+        docs: {description: {component: "Clickable cross-entity reference (namespace or flow) used in table cells: leading entity icon and violet link text, following the shared quiet entity-link pattern (kestra-ee#9432)."}},
+    },
+}
+export default meta
+type Story = StoryObj<typeof KsEntityLink>
+
+export const Namespace: Story = {
+    render: (args) => ({
+        components: {KsEntityLink},
+        setup() { return {args} },
+        template: "<div style=\"padding:24px\"><ks-entity-link v-bind=\"args\" /></div>",
+    }),
+    args: {
+        entity: "namespace",
+        value: "company.team",
+        to: "/namespaces/edit/company.team",
+    },
+}
+
+export const Flow: Story = {
+    render: (args) => ({
+        components: {KsEntityLink},
+        setup() { return {args} },
+        template: "<div style=\"padding:24px\"><ks-entity-link v-bind=\"args\" /></div>",
+    }),
+    args: {
+        entity: "flow",
+        value: "order_pipeline",
+        to: "/flows/edit/company.team/order_pipeline",
+    },
+}
+
+export const Truncated: Story = {
+    render: () => ({
+        components: {KsEntityLink},
+        template: `
+            <div style="padding:24px;width:8.5rem;border:1px dashed var(--ks-border-default)">
+                <ks-entity-link
+                    entity="namespace"
+                    value="sanitychecks.plugins.plugin-ansible"
+                    to="/namespaces/edit/sanitychecks.plugins.plugin-ansible"
+                />
+            </div>
+        `,
+    }),
+}
+
+export const States: Story = {
+    render: () => ({
+        components: {KsEntityLink},
+        template: `
+            <div style="padding:24px;display:flex;gap:32px;align-items:end">
+                <div style="display:grid;gap:8px;justify-items:start">
+                    <span style="font-size:11px;text-transform:uppercase;color:var(--ks-text-dim)">Rest</span>
+                    <ks-entity-link entity="namespace" value="company.team" to="/namespaces/edit/company.team" />
+                </div>
+                <div style="display:grid;gap:8px;justify-items:start">
+                    <span style="font-size:11px;text-transform:uppercase;color:var(--ks-text-dim)">Hover</span>
+                    <ks-entity-link
+                        entity="namespace"
+                        value="company.team"
+                        to="/namespaces/edit/company.team"
+                        style="background: var(--ks-bg-tag-hover); text-decoration: underline;"
+                    />
+                </div>
+                <div style="display:grid;gap:8px;justify-items:start">
+                    <span style="font-size:11px;text-transform:uppercase;color:var(--ks-text-dim)">Focus</span>
+                    <ks-entity-link
+                        entity="namespace"
+                        value="company.team"
+                        to="/namespaces/edit/company.team"
+                        style="outline: 2px solid var(--ks-border-focus); outline-offset: 1px;"
+                    />
+                </div>
+                <div style="display:grid;gap:8px;justify-items:start">
+                    <span style="font-size:11px;text-transform:uppercase;color:var(--ks-text-dim)">Active</span>
+                    <ks-entity-link
+                        entity="namespace"
+                        value="company.team"
+                        to="/namespaces/edit/company.team"
+                        style="background: var(--ks-bg-tag-active);"
+                    />
+                </div>
+            </div>
+        `,
+    }),
+}

--- a/ui/packages/design-system/tests/storybook/Data/KsEntityLink.stories.ts
+++ b/ui/packages/design-system/tests/storybook/Data/KsEntityLink.stories.ts
@@ -9,7 +9,7 @@ const meta: Meta<typeof KsEntityLink> = {
         entity: {control: "select", options: ["namespace", "flow"]},
     },
     parameters: {
-        docs: {description: {component: "Clickable cross-entity reference (namespace or flow) used in table cells: leading entity icon and violet link text, following the shared quiet entity-link pattern (kestra-ee#9432)."}},
+        docs: {description: {component: "Clickable cross-entity reference (namespace or flow) used in table cells: a neutral tag with a leading entity icon, turning violet on hover so rest-state rows keep their visual hierarchy (kestra-ee#9432)."}},
     },
 }
 export default meta

--- a/ui/packages/design-system/tests/units/Data/KsEntityLink/KsEntityLink.test.ts
+++ b/ui/packages/design-system/tests/units/Data/KsEntityLink/KsEntityLink.test.ts
@@ -1,0 +1,91 @@
+import {describe, test, expect, vi} from "vitest"
+import {mount} from "@vue/test-utils"
+import {createRouter, createMemoryHistory} from "vue-router"
+import KestraDesignSystem from "../../../../src/index"
+import KsEntityLink from "../../../../src/components/Data/KsEntityLink/KsEntityLink.vue"
+
+const router = createRouter({
+    history: createMemoryHistory(),
+    routes: [
+        {path: "/", component: {template: "<div/>"}},
+        {name: "namespaces/update", path: "/namespaces/edit/:id", component: {template: "<div/>"}},
+        {name: "flows/update", path: "/flows/edit/:namespace/:id", component: {template: "<div/>"}},
+    ],
+})
+
+// The DS test setup globally stubs RouterLink with a plain <a><slot/></a> (no
+// href/navigation) so unrelated tests don't need a router. Opt out here since
+// this component's contract (navigation, stopPropagation) depends on the real one.
+const globalConfig = {plugins: [router, KestraDesignSystem], stubs: {RouterLink: false}}
+
+describe("KsEntityLink", () => {
+    test("renders an anchor whose accessible name is the value", () => {
+        const wrapper = mount(KsEntityLink, {
+            props: {
+                entity: "namespace",
+                value: "company.team",
+                to: {name: "namespaces/update", params: {id: "company.team"}},
+            },
+            global: globalConfig,
+        })
+        const link = wrapper.find("a")
+        expect(link.exists()).toBe(true)
+        expect(link.text()).toBe("company.team")
+    })
+
+    test("sets the title attribute to the value", () => {
+        const wrapper = mount(KsEntityLink, {
+            props: {
+                entity: "flow",
+                value: "order_pipeline",
+                to: {name: "flows/update", params: {namespace: "company.team", id: "order_pipeline"}},
+            },
+            global: globalConfig,
+        })
+        expect(wrapper.find("a").attributes("title")).toBe("order_pipeline")
+    })
+
+    test("renders the namespace icon for the namespace entity", () => {
+        const wrapper = mount(KsEntityLink, {
+            props: {entity: "namespace", value: "company.team", to: "/namespaces/edit/company.team"},
+            global: globalConfig,
+        })
+        expect(wrapper.find(".folder-open-outline-icon").exists()).toBe(true)
+        expect(wrapper.find(".file-tree-outline-icon").exists()).toBe(false)
+    })
+
+    test("renders the flow icon for the flow entity", () => {
+        const wrapper = mount(KsEntityLink, {
+            props: {entity: "flow", value: "order_pipeline", to: "/flows/edit/company.team/order_pipeline"},
+            global: globalConfig,
+        })
+        expect(wrapper.find(".file-tree-outline-icon").exists()).toBe(true)
+        expect(wrapper.find(".folder-open-outline-icon").exists()).toBe(false)
+    })
+
+    test("the icon is decorative", () => {
+        const wrapper = mount(KsEntityLink, {
+            props: {entity: "namespace", value: "company.team", to: "/namespaces/edit/company.team"},
+            global: globalConfig,
+        })
+        expect(wrapper.find(".material-design-icon").attributes("aria-hidden")).toBe("true")
+    })
+
+    test("stops click propagation while still triggering navigation", async () => {
+        const pushSpy = vi.spyOn(router, "push")
+        let rowClicked = false
+
+        const wrapper = mount({
+            components: {KsEntityLink},
+            setup() {
+                return {onRowClick: () => { rowClicked = true }}
+            },
+            template: "<div @click=\"onRowClick\"><ks-entity-link entity=\"namespace\" value=\"company.team\" :to=\"{name: 'namespaces/update', params: {id: 'company.team'}}\" /></div>",
+        }, {global: globalConfig})
+
+        await wrapper.find("a").trigger("click")
+
+        expect(rowClicked).toBe(false)
+        expect(pushSpy).toHaveBeenCalledWith({name: "namespaces/update", params: {id: "company.team"}})
+    })
+})

--- a/ui/src/components/admin/mcp/tabs/McpToolFlows.vue
+++ b/ui/src/components/admin/mcp/tabs/McpToolFlows.vue
@@ -90,19 +90,20 @@
                         </div>
                     </template>
                     <template v-else-if="col.prop === 'flow'">
-                        <router-link
+                        <KsEntityLink
+                            v-if="(scope.row as McpTool).flowId"
+                            entity="flow"
+                            :value="(scope.row as McpTool).flowId"
                             :to="flowRouteFor(scope.row as McpTool)"
-                            class="flow-link"
-                            :title="t('mcp.tools.view_flow')"
-                        >
-                            <span class="flow-id">{{ (scope.row as McpTool).flowId }}</span>
-                        </router-link>
+                        />
                     </template>
                     <template v-else-if="col.prop === 'namespace'">
-                        <span class="namespace">
-                            <FolderOpenOutline />
-                            {{ (scope.row as McpTool).namespace }}
-                        </span>
+                        <KsEntityLink
+                            v-if="(scope.row as McpTool).namespace"
+                            entity="namespace"
+                            :value="(scope.row as McpTool).namespace"
+                            :to="namespaceRouteFor(scope.row as McpTool)"
+                        />
                     </template>
                 </template>
             </KsTableColumn>
@@ -134,7 +135,6 @@
     import {useToolFlowCreation} from "../useToolFlowCreation"
 
     import {KsButton, KsDataTable, KsFilter as KSFilter, KsId, KsTableColumn, KsTag, decodeSearchParams} from "@kestra-io/design-system"
-    import FolderOpenOutline from "vue-material-design-icons/FolderOpenOutline.vue"
     import Plus from "vue-material-design-icons/Plus.vue"
     import Empty from "../../../layout/empty/Empty.vue"
 
@@ -267,6 +267,16 @@
         }
     }
 
+    function namespaceRouteFor(tool: McpTool): RouteLocationRaw {
+        return {
+            name: "namespaces/update",
+            params: {
+                id: tool.namespace,
+                ...(route.params.tenant ? {tenant: route.params.tenant} : {}),
+            },
+        }
+    }
+
     async function load() {
         const id = serverId.value
         if (!id) {
@@ -319,29 +329,5 @@
     .annotation {
         border: none;
         background: var(--ks-bg-tag);
-    }
-
-    .flow-link {
-        display: inline-flex;
-        align-items: center;
-        gap: var(--ks-spacing-2);
-        color: var(--ks-text-primary);
-        text-decoration: none;
-
-        &:hover {
-            color: var(--ks-text-link);
-        }
-    }
-
-    .flow-id {
-        font-family: var(--ks-font-family-mono);
-        font-size: var(--ks-font-size-sm);
-    }
-
-    .namespace {
-        display: inline-flex;
-        align-items: center;
-        gap: var(--ks-spacing-2);
-        color: var(--ks-text-primary);
     }
 </style>

--- a/ui/src/components/admin/triggers/TriggersManage.vue
+++ b/ui/src/components/admin/triggers/TriggersManage.vue
@@ -117,12 +117,12 @@
                 </template>
                 <template #default="scope">
                     <template v-if="col.prop === 'flowId'">
-                        <router-link
+                        <KsEntityLink
                             v-if="scope.row.namespace && scope.row.flowId"
+                            entity="flow"
+                            :value="scope.row.flowId"
                             :to="{name: 'flows/update', params: {tenant: route.params?.tenant, namespace: scope.row.namespace, id: scope.row.flowId}}"
-                        >
-                            <BreakableText :value="scope.row.flowId" />
-                        </router-link>
+                        />
                         <span v-else><BreakableText :value="scope.row.flowId" /></span>
                         <MarkdownTooltip
                             v-if="scope.row.namespace && scope.row.flowId"
@@ -132,7 +132,12 @@
                         />
                     </template>
                     <template v-else-if="col.prop === 'namespace'">
-                        <BreakableText :value="scope.row.namespace" />
+                        <KsEntityLink
+                            v-if="scope.row.namespace"
+                            entity="namespace"
+                            :value="scope.row.namespace"
+                            :to="{name: 'namespaces/update', params: {tenant: route.params?.tenant, id: scope.row.namespace}}"
+                        />
                     </template>
                     <template v-else-if="col.prop === 'workerId'">
                         <KsId :value="scope.row.workerId" :shrink="true" />

--- a/ui/src/components/dashboard/sections/table/columns/Link.vue
+++ b/ui/src/components/dashboard/sections/table/columns/Link.vue
@@ -1,17 +1,24 @@
 <template>
+    <KsEntityLink
+        v-if="linkData && props.flow"
+        entity="flow"
+        :value="label"
+        :to="{name: 'flows/update', params: {namespace: linkData.NAMESPACE, id: linkData.FLOW_ID}}"
+    />
+
     <RouterLink
-        v-if="linkData"
+        v-else-if="linkData && props.execution"
         :to="{
-            name: props.execution ? 'executions/update' : props.flow ? 'flows/update' : undefined,
+            name: 'executions/update',
             params: {
                 namespace: linkData.NAMESPACE,
-                ...(props.execution && {flowId: linkData.FLOW_ID, id: label,}),
-                ...(props.flow && {id: linkData.FLOW_ID,}),
+                flowId: linkData.FLOW_ID,
+                id: label,
             },
         }"
     >
         <code class="link" :class="{colored: props.colored}">
-            {{ props.execution ? label.slice(0, 8) : label }}
+            {{ label.slice(0, 8) }}
         </code>
     </RouterLink>
 

--- a/ui/src/components/dashboard/sections/table/columns/Namespace.vue
+++ b/ui/src/components/dashboard/sections/table/columns/Namespace.vue
@@ -1,7 +1,10 @@
 <template>
-    <RouterLink :to="{name: 'namespaces/update', params: {id: props.field}}">
-        <code class="link">{{ props.field }}</code>
-    </RouterLink>
+    <KsEntityLink
+        v-if="props.field"
+        entity="namespace"
+        :value="props.field"
+        :to="{name: 'namespaces/update', params: {id: props.field}}"
+    />
 </template>
 
 <script setup lang="ts">
@@ -12,10 +15,3 @@
         },
     })
 </script>
-
-<style scoped>
-.link {
-    color: var(--ks-text-primary);
-    font-size: var(--ks-font-size-sm);
-}
-</style>

--- a/ui/src/components/executions/Executions.vue
+++ b/ui/src/components/executions/Executions.vue
@@ -175,7 +175,6 @@
                 :label="col.label"
                 :class="col.prop === 'flowRevision' ? 'shrink' : ''"
                 :align="col.prop === 'inputs' ? 'center' : undefined"
-                :formatter="col.prop === 'namespace' ? ((_ : any, __: any, cellValue: string) => h(BreakableText, {value: cellValue})) : undefined"
                 :sortable="isColumnSortable(col.prop) ? 'custom' : false"
                 :sortOrders="isColumnSortable(col.prop) ? ['ascending', 'descending'] : []"
             >
@@ -190,15 +189,20 @@
                         <Duration :field="scope.row?.state?.duration" :startDate="scope.row?.state?.startDate" />
                     </template>
                     <template v-else-if="col.prop === 'namespace' && $route.name !== 'flows/update'">
-                        <span :title="scope.row?.namespace"><BreakableText :value="scope.row?.namespace" /></span>
+                        <KsEntityLink
+                            v-if="scope.row?.namespace"
+                            entity="namespace"
+                            :value="scope.row.namespace"
+                            :to="{name: 'namespaces/update', params: {id: scope.row.namespace}}"
+                        />
                     </template>
                     <template v-else-if="col.prop === 'flowId' && $route.name !== 'flows/update'">
-                        <router-link
-                            :to="{name: 'flows/update', params: {namespace: scope.row?.namespace, id: scope.row?.flowId}
-                            }"
-                        >
-                            <BreakableText :value="scope.row?.flowId" />
-                        </router-link>
+                        <KsEntityLink
+                            v-if="scope.row?.flowId"
+                            entity="flow"
+                            :value="scope.row.flowId"
+                            :to="{name: 'flows/update', params: {namespace: scope.row?.namespace, id: scope.row?.flowId}}"
+                        />
                     </template>
                     <template v-else-if="col.prop === 'labels'">
                         <Labels :labels="filteredLabels(scope.row?.labels)" @click.prevent.stop />
@@ -408,7 +412,6 @@
     import {filterValidLabels, keepSupportedFilters} from "./utils"
     import {useToast} from "../../utils/toast"
     import {storageKeys} from "../../utils/constants"
-    import BreakableText from "../BreakableText"
     import * as Utils from "../../utils/utils"
     import Duration from "../../components/dashboard/sections/table/columns/Duration.vue"
 

--- a/ui/src/components/executions/overview/components/Banner.vue
+++ b/ui/src/components/executions/overview/components/Banner.vue
@@ -24,7 +24,9 @@
             </div>
 
             <div class="execution-banner__top">
-                <span class="execution-banner__flow">{{ execution.flowId }}</span>
+                <router-link class="execution-banner__flow" :to="createLink('flows', execution)">
+                    {{ execution.flowId }}
+                </router-link>
 
                 <span class="execution-banner__id">
                     <code>{{ execution.id }}</code>
@@ -375,6 +377,12 @@
             font-weight: 700;
             font-size: var(--ks-font-size-xl);
             color: var(--ks-text-primary);
+            text-decoration: none;
+
+            &:hover {
+                color: var(--ks-text-link);
+                text-decoration: underline;
+            }
         }
 
         &__id {

--- a/ui/src/components/flows/Flows.vue
+++ b/ui/src/components/flows/Flows.vue
@@ -137,10 +137,16 @@
                     sortable="custom"
                     :sortOrders="['ascending', 'descending']"
                     :label="$t('namespace')"
-                    :formatter="(_: any, __: any, cellValue: string) =>
-                        h(BreakableText, {value: cellValue})
-                    "
-                />
+                >
+                    <template #default="scope">
+                        <KsEntityLink
+                            v-if="scope.row?.namespace"
+                            entity="namespace"
+                            :value="scope.row.namespace"
+                            :to="{name: 'namespaces/update', params: {id: scope.row.namespace}}"
+                        />
+                    </template>
+                </KsTableColumn>
 
                 <KsTableColumn
                     v-else-if="colProp === 'state.startDate' && user?.hasAny(resource.EXECUTION)"
@@ -260,7 +266,7 @@
 </template>
 
 <script setup lang="ts">
-    import {ref, computed, useTemplateRef, watch, h} from "vue"
+    import {ref, computed, useTemplateRef, watch} from "vue"
     import {useRoute, useRouter} from "vue-router"
     import {useI18n} from "vue-i18n"
     import _merge from "lodash/merge"

--- a/ui/src/components/flows/Flows.vue
+++ b/ui/src/components/flows/Flows.vue
@@ -299,6 +299,7 @@
     import {KsFilter as KSFilter} from "@kestra-io/design-system"
     import MarkdownTooltip from "../layout/MarkdownTooltip.vue"
     import TimeSeries from "../dashboard/sections/TimeSeries.vue"
+    import type {Chart} from "../dashboard/types"
     import TopNavBar from "../../components/layout/TopNavBar.vue"
 
     import action from "../../models/action"
@@ -470,46 +471,8 @@
 
     const selectionIds = computed(() => selection.value.map((flow: any) => ({id: flow.id, namespace: flow.namespace})))
 
-    interface ChartDefinition {
-        id: string;
-        type: string;
-        chartOptions: {
-            displayName: string;
-            description: string;
-            legend: {enabled: boolean};
-            column: string;
-            colorByColumn: string;
-            width: number;
-        };
-        data: {
-            type: string;
-            columns: {
-                date: {
-                    field: string;
-                    displayName: string;
-                };
-                state: {
-                    field: string;
-                };
-                total: {
-                    displayName: string;
-                    agg: string;
-                    graphStyle: string;
-                };
-                duration: {
-                    field: string;
-                    displayName: string;
-                    agg: string;
-                    graphStyle: string;
-                };
-            };
-            where: {field: string; type: string; value: string}[];
-        };
-        content?: string;
-    }
-
     // Chart definition for mappedChart
-    const CHART_DEFINITION: ChartDefinition = {
+    const CHART_DEFINITION: Chart = {
         id: "total_executions_timeseries",
         type: "io.kestra.plugin.core.dashboard.chart.TimeSeries",
         chartOptions: {
@@ -731,13 +694,13 @@
         return MAPPED_CHARTS
     }
 
-    function chartFilters() {
+    function chartFilters(): QueryFilter[] {
         const DEFAULT_DURATION = miscStore.configs?.chartDefaultDuration ?? "PT24H"
         return [{
             field: "timeRange",
             value: DEFAULT_DURATION,
             operation: "EQUALS",
-        } satisfies QueryFilter]
+        }]
     }
 
     async function exportFlowsAsStream() {

--- a/ui/src/components/kv/InheritedKVs.vue
+++ b/ui/src/components/kv/InheritedKVs.vue
@@ -2,7 +2,12 @@
     <KsTable :data="store.inheritedKVs" tableLayout="auto">
         <KsTableColumn prop="namespace" :label="$t('namespace')">
             <template #default="scope">
-                <code>{{ scope.row.namespace }}</code>
+                <KsEntityLink
+                    v-if="scope.row.namespace"
+                    entity="namespace"
+                    :value="scope.row.namespace"
+                    :to="{name: 'namespaces/update', params: {id: scope.row.namespace}}"
+                />
             </template>
         </KsTableColumn>
 

--- a/ui/src/components/kv/KVTable.vue
+++ b/ui/src/components/kv/KVTable.vue
@@ -47,7 +47,16 @@
                 sortable="custom"
                 :sortOrders="['ascending', 'descending']"
                 :label="$t('namespace')"
-            />
+            >
+                <template #default="scope">
+                    <KsEntityLink
+                        v-if="scope.row.namespace"
+                        entity="namespace"
+                        :value="scope.row.namespace"
+                        :to="{name: 'namespaces/update', params: {id: scope.row.namespace}}"
+                    />
+                </template>
+            </KsTableColumn>
             <KsTableColumn
                 v-else-if="colProp === 'key'"
                 prop="key"

--- a/ui/src/components/secrets/SecretsTable.vue
+++ b/ui/src/components/secrets/SecretsTable.vue
@@ -55,12 +55,12 @@
             >
                 <template #default="scope">
                     <template v-if="col.prop === 'namespace'">
-                        <KsTag
-                            class="namespace-tag"
-                        >
-                            <FolderOpenOutline />
-                            {{ scope.row?.namespace }}
-                        </KsTag>
+                        <KsEntityLink
+                            v-if="scope.row?.namespace"
+                            entity="namespace"
+                            :value="scope.row.namespace"
+                            :to="{name: 'namespaces/update', params: {id: scope.row.namespace}}"
+                        />
                     </template>
                     <template v-else-if="col.prop === 'description'">
                         {{ scope.row?.description }}
@@ -223,7 +223,6 @@
     import Lock from "vue-material-design-icons/Lock.vue"
     import Plus from "vue-material-design-icons/Plus.vue"
     import Delete from "vue-material-design-icons/Delete.vue"
-    import FolderOpenOutline from "vue-material-design-icons/FolderOpenOutline.vue"
     import ContentCopy from "vue-material-design-icons/ContentCopy.vue"
     import ContentSave from "vue-material-design-icons/ContentSave.vue"
     import FileDocumentEdit from "vue-material-design-icons/FileDocumentEdit.vue"
@@ -614,16 +613,6 @@
         display: flex;
         flex-direction: column;
         min-height: 0;
-    }
-
-    .namespace-tag {
-        padding: 0 6px;
-
-        :deep(.kel-tag__content) {
-            display: flex;
-            align-items: center;
-            gap: 4px;
-        }
     }
 
     .secret-tag-row {

--- a/ui/src/translations/de.json
+++ b/ui/src/translations/de.json
@@ -2286,8 +2286,7 @@
         "open_world": "Open world",
         "destructive": "Destruktiv",
         "idempotent": "Idempotent",
-        "return_direct": "Direktrückgabe",
-        "view_flow": "flow öffnen"
+        "return_direct": "Direktrückgabe"
       },
       "connect_tab": {
         "server_url": "Server-URL",

--- a/ui/src/translations/en.json
+++ b/ui/src/translations/en.json
@@ -2286,8 +2286,7 @@
         "open_world": "Open world",
         "destructive": "Destructive",
         "idempotent": "Idempotent",
-        "return_direct": "Return direct",
-        "view_flow": "Open flow"
+        "return_direct": "Return direct"
       },
       "connect_tab": {
         "server_url": "Server URL",

--- a/ui/src/translations/es.json
+++ b/ui/src/translations/es.json
@@ -2286,8 +2286,7 @@
         "open_world": "Open world",
         "destructive": "Destructivo",
         "idempotent": "Idempotente",
-        "return_direct": "Retorno directo",
-        "view_flow": "Abrir flow"
+        "return_direct": "Retorno directo"
       },
       "connect_tab": {
         "server_url": "URL del servidor",

--- a/ui/src/translations/fr.json
+++ b/ui/src/translations/fr.json
@@ -2286,8 +2286,7 @@
         "open_world": "Open world",
         "destructive": "Destructif",
         "idempotent": "Idempotent",
-        "return_direct": "Retour direct",
-        "view_flow": "Ouvrir le flow"
+        "return_direct": "Retour direct"
       },
       "connect_tab": {
         "server_url": "URL du serveur",

--- a/ui/src/translations/hi.json
+++ b/ui/src/translations/hi.json
@@ -2286,8 +2286,7 @@
         "open_world": "Open world",
         "destructive": "विनाशकारी",
         "idempotent": "Idempotent",
-        "return_direct": "सीधा वापसी",
-        "view_flow": "flow खोलें"
+        "return_direct": "सीधा वापसी"
       },
       "connect_tab": {
         "server_url": "सर्वर URL",

--- a/ui/src/translations/it.json
+++ b/ui/src/translations/it.json
@@ -2286,8 +2286,7 @@
         "open_world": "Open world",
         "destructive": "Distruttivo",
         "idempotent": "Idempotente",
-        "return_direct": "Ritorno diretto",
-        "view_flow": "Apri flow"
+        "return_direct": "Ritorno diretto"
       },
       "connect_tab": {
         "server_url": "URL del server",

--- a/ui/src/translations/ja.json
+++ b/ui/src/translations/ja.json
@@ -2286,8 +2286,7 @@
         "open_world": "Open world",
         "destructive": "破壊的",
         "idempotent": "冪等",
-        "return_direct": "直接返却",
-        "view_flow": "flowを開く"
+        "return_direct": "直接返却"
       },
       "connect_tab": {
         "server_url": "サーバーURL",

--- a/ui/src/translations/ko.json
+++ b/ui/src/translations/ko.json
@@ -2286,8 +2286,7 @@
         "open_world": "Open world",
         "destructive": "파괴적",
         "idempotent": "멱등",
-        "return_direct": "직접 반환",
-        "view_flow": "flow 열기"
+        "return_direct": "직접 반환"
       },
       "connect_tab": {
         "server_url": "서버 URL",

--- a/ui/src/translations/pl.json
+++ b/ui/src/translations/pl.json
@@ -2286,8 +2286,7 @@
         "open_world": "Open world",
         "destructive": "Destrukcyjny",
         "idempotent": "Idempotentny",
-        "return_direct": "Zwrot bezpośredni",
-        "view_flow": "Otwórz flow"
+        "return_direct": "Zwrot bezpośredni"
       },
       "connect_tab": {
         "server_url": "URL serwera",

--- a/ui/src/translations/pt.json
+++ b/ui/src/translations/pt.json
@@ -2286,8 +2286,7 @@
         "open_world": "Open world",
         "destructive": "Destrutivo",
         "idempotent": "Idempotente",
-        "return_direct": "Retorno direto",
-        "view_flow": "Abrir flow"
+        "return_direct": "Retorno direto"
       },
       "connect_tab": {
         "server_url": "URL do Servidor",

--- a/ui/src/translations/pt_BR.json
+++ b/ui/src/translations/pt_BR.json
@@ -2286,8 +2286,7 @@
         "open_world": "Open world",
         "destructive": "Destrutivo",
         "idempotent": "Idempotente",
-        "return_direct": "Retorno direto",
-        "view_flow": "Abrir flow"
+        "return_direct": "Retorno direto"
       },
       "connect_tab": {
         "server_url": "URL do Servidor",

--- a/ui/src/translations/ru.json
+++ b/ui/src/translations/ru.json
@@ -2286,8 +2286,7 @@
         "open_world": "Open world",
         "destructive": "Деструктивный",
         "idempotent": "Идемпотентный",
-        "return_direct": "Прямой возврат",
-        "view_flow": "Открыть flow"
+        "return_direct": "Прямой возврат"
       },
       "connect_tab": {
         "server_url": "URL сервера",

--- a/ui/src/translations/zh_CN.json
+++ b/ui/src/translations/zh_CN.json
@@ -2286,8 +2286,7 @@
         "open_world": "Open world",
         "destructive": "破坏性",
         "idempotent": "幂等",
-        "return_direct": "直接返回",
-        "view_flow": "打开 flow"
+        "return_direct": "直接返回"
       },
       "connect_tab": {
         "server_url": "服务器 URL",


### PR DESCRIPTION
## Summary

Namespace and flow references are rendered inconsistently across Kestra tables: dead (non-clickable) text on Executions/Flows/Triggers, a `KsTag` + `FolderOpenOutline` chip on Secrets, and plain spans elsewhere. A validated UX design, adjusted per design review ("entity link": a neutral tag with a leading entity icon that turns violet on hover, real anchor — keeping violet reserved for each row's primary element), settles on a single pattern for every cross-entity namespace/flow cell, matching the icon vocabulary already used in the left nav.

This PR adds a new design-system component, `KsEntityLink`, and applies it to every OSS table that references a namespace or a flow from another entity's row.

- **New component**: `KsEntityLink` (`entity: "namespace" | "flow"`, `value`, `to`) — a real `RouterLink` with a leading `FolderOpenOutline`/`FileTreeOutline` icon (left-nav parity), violet link text, hover/active/focus states from `--ks-*` tokens only, and a built-in `@click.stop` (propagation only, never `preventDefault`) so row-click navigation and middle/cmd-click both keep working. Storybook story + unit tests included.
- **Executions**: namespace cell (dead text) and flow cell (bare link) both become `KsEntityLink`.
- **Flows**: namespace column (plain formatter) becomes `KsEntityLink`. The flow `id` column is left as a plain link — it's the row's own entity, not a cross-entity reference.
- **Triggers (admin)**: namespace cell (dead text) and flow cell (bare link) both become `KsEntityLink`.
- **MCP tool flows (admin)**: flow cell (bare link) and namespace cell (icon + text span) both become `KsEntityLink`.
- **Secrets**: namespace `KsTag` chip becomes `KsEntityLink`; removes the component's only `:deep()` block (`.namespace-tag`).
- **KV / Inherited KV**: namespace cell (plain text / `<code>`) becomes `KsEntityLink`.
- **Dashboard table charts**: the `NAMESPACE` and `FLOW_ID` column renderers (used by the default Overview dashboard, among others) become `KsEntityLink`; execution-id links keep their existing rendering (row's own entity).
- **Execution page banner**: the flow title (dead text) becomes a link to the flow, keeping its title typography.

No new i18n keys — the accessible name is the value itself (`title`/content), matching the approved design.

## Demo

https://github.com/user-attachments/assets/9a73d194-d63e-4af4-9fbb-fbd0cc26b7d0

part-of: https://github.com/kestra-io/kestra-ee/issues/9432

## Test plan

- [x] `npx vitest run --config vitest.unit.config.ts` (design-system, 706 tests) passes, including new `KsEntityLink` unit tests (accessible name, icon per entity, `title`, click stops propagation while navigation still fires)
- [x] `vue-tsc --noEmit` (design-system, covers `src` + Storybook) passes
- [x] `npm run check:types` — no new errors (pre-existing, unrelated failures on `develop` confirmed identical before/after this change via `git stash`)
- [x] `npm run test:lint` — 0 errors
- [x] `npm run test:unit` (755 tests) passes
- [x] `npm run translations:check` — no missing/extra keys across all 12 locales
