### PR TITLE
fix(core): order SubflowExecutionEnd batch locks to avoid executor deadlock

### DIFF
--- a/jdbc/src/main/java/io/kestra/jdbc/runner/JdbcExecutor.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/runner/JdbcExecutor.java
@@ -344,7 +344,7 @@ public class JdbcExecutor implements ExecutorInterface {
         this.receiveCancellations.addFirst(this.subflowExecutionResultQueue.receive(Executor.class, this::subflowExecutionResultQueue));
         this.receiveCancellations.addFirst(
             ((JdbcQueue<SubflowExecutionEnd>) this.subflowExecutionEndQueue)
-                .receiveTransaction(null, Executor.class, (dslContext, eithers) -> eithers.forEach(this::subflowExecutionEndQueue))
+                .receiveTransaction(null, Executor.class, (dslContext, eithers) -> this.subflowExecutionEndQueue(eithers))
         );
         this.receiveCancellations.addFirst(this.multipleConditionEventQueue.receive(Executor.class, this::multipleConditionEventQueue));
         this.receiveCancellations.addFirst(maintenanceService.listen(new MaintenanceService.MaintenanceListener() {
@@ -1031,64 +1031,81 @@ public class JdbcExecutor implements ExecutorInterface {
         }
     }
 
-    private void subflowExecutionEndQueue(Either<SubflowExecutionEnd, DeserializationException> either) {
-        if (either.isRight()) {
-            log.error("Unable to deserialize a subflow execution end: {}", either.getRight().getMessage());
-            return;
+    private void subflowExecutionEndQueue(List<Either<SubflowExecutionEnd, DeserializationException>> eithers) {
+        // Group the batch by parent execution id and process the parents in sorted id order.
+        // Acquiring the per-parent `executions` FOR UPDATE locks in a deterministic order across
+        // all executor instances prevents the cross-parent lock-ordering deadlock that occurs under
+        // heavy subflow fan-out (many child ends landing in the same batch on multiple executors).
+        // Grouping by parent also avoids re-locking and re-reading the same parent row once per child.
+        // A TreeMap keeps the parent ids sorted; the ArrayList values preserve child-end arrival order.
+        Map<String, List<SubflowExecutionEnd>> messagesByParent = new TreeMap<>();
+        for (Either<SubflowExecutionEnd, DeserializationException> either : eithers) {
+            if (either.isRight()) {
+                log.error("Unable to deserialize a subflow execution end: {}", either.getRight().getMessage());
+                continue;
+            }
+
+            SubflowExecutionEnd message = either.getLeft();
+
+            // we filter all messages for which there is a kill switch as the kill switch will apply to the child execution anyway
+            if (killSwitchService.evaluate(message.getChildExecution()) != EvaluationType.PASS) {
+                log.warn("Ignoring subflow execution end for child execution {} as there is a kill switch in it", message.getChildExecution().getId());
+                continue;
+            }
+            // we filter all messages for which there is a kill switch as the kill switch will apply to the parent execution anyway
+            if (killSwitchService.evaluate(message.getParentExecutionId()) != EvaluationType.PASS) {
+                log.warn("Ignoring subflow execution end for parent execution {} as there is a kill switch in it", message.getParentExecutionId());
+                continue;
+            }
+
+            if (log.isDebugEnabled()) {
+                executorService.log(log, true, message);
+            }
+
+            messagesByParent.computeIfAbsent(message.getParentExecutionId(), ignored -> new ArrayList<>()).add(message);
         }
 
-        SubflowExecutionEnd message = either.getLeft();
+        messagesByParent.forEach(this::subflowExecutionEndForParent);
+    }
 
-        // we filter all messages for which there is a kill switch as the kill switch will apply to the child execution anyway
-        if (killSwitchService.evaluate(message.getChildExecution()) != EvaluationType.PASS) {
-            log.warn("Ignoring subflow execution end for child execution {} as there is a kill switch in it", message.getChildExecution().getId());
-            return;
-        }
-        // we filter all messages for which there is a kill switch as the kill switch will apply to the parent execution anyway
-        if (killSwitchService.evaluate(message.getParentExecutionId()) != EvaluationType.PASS) {
-            log.warn("Ignoring subflow execution end for parent execution {} as there is a kill switch in it", message.getParentExecutionId());
-            return;
-        }
-
-        if (log.isDebugEnabled()) {
-            executorService.log(log, true, message);
-        }
-
-        executionRepository.lock(message.getParentExecutionId(), pair ->
+    private void subflowExecutionEndForParent(String parentExecutionId, List<SubflowExecutionEnd> messages) {
+        executionRepository.lock(parentExecutionId, pair ->
         {
             Execution execution = pair.getLeft();
 
             if (execution == null) {
-                throw new IllegalStateException("Execution state don't exist for " + message.getParentExecutionId() + ", receive " + message);
+                throw new IllegalStateException("Execution state don't exist for " + parentExecutionId + ", receive " + messages);
             }
 
-            try {
-                FlowWithSource flow = findFlowOrThrow(execution);
-                ExecutableTask<?> executableTask = (ExecutableTask<?>) flow.findTaskByTaskId(message.getTaskId());
-                if (!executableTask.waitForExecution()) {
-                    return null;
-                }
-
-                TaskRun taskRun = execution.findTaskRunByTaskRunId(message.getTaskRunId()).withState(message.getState()).withOutputs(message.getOutputs());
-                FlowInterface childFlow = flowMetaStore.findByExecution(message.getChildExecution()).orElseThrow();
-                RunContext runContext = runContextFactory.of(
-                    childFlow,
-                    (Task) executableTask,
-                    message.getChildExecution(),
-                    taskRun
-                );
-
-                SubflowExecutionResult subflowExecutionResult = ExecutableUtils
-                    .subflowExecutionResultFromChildExecution(runContext, childFlow, message.getChildExecution(), executableTask, taskRun);
-                if (subflowExecutionResult != null) {
-                    try {
-                        this.subflowExecutionResultQueue.emit(subflowExecutionResult);
-                    } catch (QueueException ex) {
-                        log.error("Unable to emit the subflow execution result", ex);
+            for (SubflowExecutionEnd message : messages) {
+                try {
+                    FlowWithSource flow = findFlowOrThrow(execution);
+                    ExecutableTask<?> executableTask = (ExecutableTask<?>) flow.findTaskByTaskId(message.getTaskId());
+                    if (!executableTask.waitForExecution()) {
+                        continue;
                     }
+
+                    TaskRun taskRun = execution.findTaskRunByTaskRunId(message.getTaskRunId()).withState(message.getState()).withOutputs(message.getOutputs());
+                    FlowInterface childFlow = flowMetaStore.findByExecution(message.getChildExecution()).orElseThrow();
+                    RunContext runContext = runContextFactory.of(
+                        childFlow,
+                        (Task) executableTask,
+                        message.getChildExecution(),
+                        taskRun
+                    );
+
+                    SubflowExecutionResult subflowExecutionResult = ExecutableUtils
+                        .subflowExecutionResultFromChildExecution(runContext, childFlow, message.getChildExecution(), executableTask, taskRun);
+                    if (subflowExecutionResult != null) {
+                        try {
+                            this.subflowExecutionResultQueue.emit(subflowExecutionResult);
+                        } catch (QueueException ex) {
+                            log.error("Unable to emit the subflow execution result", ex);
+                        }
+                    }
+                } catch (InternalException | FlowNotFoundException e) {
+                    log.error("Unable to process the subflow execution end", e);
                 }
-            } catch (InternalException | FlowNotFoundException e) {
-                log.error("Unable to process the subflow execution end", e);
             }
             return null;
         });


### PR DESCRIPTION
## What & why

Fixes #17574.

Under heavy subflow fan-out, executors on a Postgres backend crash in a
restart loop. Root cause (full analysis in #17574):

1. The `SubflowExecutionEnd` queue consumer processes a batch of up to
   `pollSize` (default 100) messages in **one transaction**, each taking a
   `SELECT … FOR UPDATE` on a parent `executions` row.
2. Two executors locking overlapping parent rows in different order deadlock
   on `executions`. The deadlock (`40P01`) aborts the shared transaction and
   subsequent statements fail with `25P02` (*current transaction is aborted*),
   which the retry predicate does not match.
3. The `25P02` reaches `JdbcQueue.poll`'s catch-all, which (since #16816 made
   poll failures fatal) calls `KestraContext.shutdown()` → executor crash.

## Changes

- **`JdbcExecutor` — group + ordered locking.** The `SubflowExecutionEnd` batch
  is grouped by parent execution id and processed once per parent in sorted,
  deterministic order. Concurrent batches on different executors now acquire
  overlapping parent locks in the same order, so a lock cycle can no longer
  form. Grouping also collapses the repeated read-lock of the same parent row
  during a fan-out. The consumer stays `receiveTransaction`, so the cross-JVM
  duplicate-prevention is unchanged, and it remains one commit per batch.
- **`JdbcQueue` — transient deadlocks are no longer fatal.** The poll-loop
  catch now inspects the whole cause chain for a transient DB error
  (deadlock `40P01`/`40001`, MySQL lock-wait `1205`) — necessary because the
  deadlock hides behind the top-level `25P02`. On a transient error it logs and
  re-polls a fresh batch instead of shutting down; genuinely unrecoverable
  errors still fail fast. This also protects against deadlocks originating from
  the periodic delay/SLA sweeps (other multi-row lockers).

## Tests

- New `JdbcQueueTransientErrorTest`: deadlock-behind-aborted-tx, direct `40P01`,
  `40001`, MySQL `1205`, non-transient → false, null → false.
- `H2QueueTest` (incl. `shouldShutdownWhenConsumerFails`) still green —
  unrecoverable errors still shut down.
- `H2RunnerTest`: 86 tests pass, including all 12 subflow / forEachItem tests
  that exercise the `SubflowExecutionEnd` path.

## Notes

- Targeted at `releases/v1.3.x`; the same fix should be forward-ported to
  `develop`.
- `isTransientDatabaseError` intentionally mirrors the SQLState set in
  `JooqDSLContextWrapper.predicate()` (comment links them); happy to
  consolidate into a shared helper if preferred.
