### PR TITLE
fix(plugins): revalidate plugin schemas so newly added plugins autocomplete (#12102)

### DIFF
--- a/core/src/main/java/io/kestra/core/docs/JsonSchemaCache.java
+++ b/core/src/main/java/io/kestra/core/docs/JsonSchemaCache.java
@@ -6,11 +6,13 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.atomic.AtomicLong;
 
 import io.kestra.core.models.dashboards.Dashboard;
 import io.kestra.core.models.flows.Flow;
 import io.kestra.core.models.tasks.Task;
 import io.kestra.core.models.triggers.AbstractTrigger;
+import io.kestra.core.plugins.PluginRegistry;
 
 import jakarta.inject.Singleton;
 
@@ -21,19 +23,27 @@ import jakarta.inject.Singleton;
 public class JsonSchemaCache {
 
     private final JsonSchemaGenerator jsonSchemaGenerator;
+    private final PluginRegistry pluginRegistry;
 
     private final ConcurrentMap<CacheKey, Map<String, Object>> schemaCache = new ConcurrentHashMap<>();
     private final ConcurrentMap<SchemaType, Map<String, Object>> propertiesCache = new ConcurrentHashMap<>();
 
     private final Map<SchemaType, Class<?>> classesBySchemaType = new HashMap<>();
 
+    // Hash of the plugin registry the cached schemas were generated from. When the registry changes
+    // (a plugin is installed or removed at runtime) the cached schemas become stale and must be dropped,
+    // otherwise the editor keeps completing/validating against a schema missing the new plugin (#12102).
+    private final AtomicLong cachedRegistryHash = new AtomicLong(Long.MIN_VALUE);
+
     /**
      * Creates a new {@link JsonSchemaCache} instance.
      *
      * @param jsonSchemaGenerator The {@link JsonSchemaGenerator}.
+     * @param pluginRegistry      The {@link PluginRegistry} whose content the cached schemas depend on.
      */
-    public JsonSchemaCache(final JsonSchemaGenerator jsonSchemaGenerator) {
+    public JsonSchemaCache(final JsonSchemaGenerator jsonSchemaGenerator, final PluginRegistry pluginRegistry) {
         this.jsonSchemaGenerator = Objects.requireNonNull(jsonSchemaGenerator, "JsonSchemaGenerator cannot be null");
+        this.pluginRegistry = Objects.requireNonNull(pluginRegistry, "PluginRegistry cannot be null");
         registerClassForType(SchemaType.FLOW, Flow.class);
         registerClassForType(SchemaType.TASK, Task.class);
         registerClassForType(SchemaType.TRIGGER, AbstractTrigger.class);
@@ -42,6 +52,7 @@ public class JsonSchemaCache {
 
     public Map<String, Object> getSchemaForType(final SchemaType type,
         final boolean arrayOf) {
+        invalidateIfPluginRegistryChanged();
         return schemaCache.computeIfAbsent(new CacheKey(type, arrayOf), key ->
         {
 
@@ -52,6 +63,7 @@ public class JsonSchemaCache {
     }
 
     public Map<String, Object> getPropertiesForType(final SchemaType type) {
+        invalidateIfPluginRegistryChanged();
         return propertiesCache.computeIfAbsent(type, key ->
         {
 
@@ -66,8 +78,21 @@ public class JsonSchemaCache {
         classesBySchemaType.put(type, clazz);
     }
 
+    /**
+     * Drops the cached schemas if the plugin registry changed since they were generated, so that a plugin
+     * added or removed at runtime is reflected on the next request.
+     */
+    private void invalidateIfPluginRegistryChanged() {
+        final long current = pluginRegistry.hash();
+        final long previous = cachedRegistryHash.get();
+        if (previous != current && cachedRegistryHash.compareAndSet(previous, current)) {
+            clear();
+        }
+    }
+
     public void clear() {
         schemaCache.clear();
+        propertiesCache.clear();
     }
 
     private record CacheKey(SchemaType type, boolean arrayOf) {

--- a/core/src/test/java/io/kestra/core/docs/JsonSchemaCacheTest.java
+++ b/core/src/test/java/io/kestra/core/docs/JsonSchemaCacheTest.java
@@ -1,0 +1,58 @@
+package io.kestra.core.docs;
+
+import java.util.Map;
+
+import io.kestra.core.plugins.PluginRegistry;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class JsonSchemaCacheTest {
+
+    @Test
+    void shouldServeFromCacheWhenPluginRegistryUnchanged() {
+        // Given
+        JsonSchemaGenerator generator = mock(JsonSchemaGenerator.class);
+        PluginRegistry registry = mock(PluginRegistry.class);
+        when(generator.schemas(any(), anyBoolean())).thenReturn(Map.of("version", "1"));
+        when(registry.hash()).thenReturn(1L);
+        JsonSchemaCache cache = new JsonSchemaCache(generator, registry);
+
+        // When
+        cache.getSchemaForType(SchemaType.FLOW, false);
+        cache.getSchemaForType(SchemaType.FLOW, false);
+
+        // Then: the schema is generated only once while the registry hash is stable
+        verify(generator, times(1)).schemas(any(), anyBoolean());
+    }
+
+    @Test
+    void shouldRebuildSchemaWhenPluginRegistryChanges() {
+        // Given: a registry whose content (hash) changes between calls, e.g. a plugin installed at runtime
+        JsonSchemaGenerator generator = mock(JsonSchemaGenerator.class);
+        PluginRegistry registry = mock(PluginRegistry.class);
+        when(generator.schemas(any(), anyBoolean()))
+            .thenReturn(Map.of("version", "1"))
+            .thenReturn(Map.of("version", "2"));
+        when(registry.hash()).thenReturn(1L, 1L, 2L);
+        JsonSchemaCache cache = new JsonSchemaCache(generator, registry);
+
+        // When
+        Map<String, Object> first = cache.getSchemaForType(SchemaType.FLOW, false);
+        Map<String, Object> cached = cache.getSchemaForType(SchemaType.FLOW, false);
+        Map<String, Object> afterChange = cache.getSchemaForType(SchemaType.FLOW, false);
+
+        // Then: unchanged hash serves the cached schema, changed hash regenerates it
+        assertThat(first).containsEntry("version", "1");
+        assertThat(cached).containsEntry("version", "1");
+        assertThat(afterChange).containsEntry("version", "2");
+        verify(generator, times(2)).schemas(any(), anyBoolean());
+    }
+}

--- a/webserver/src/main/java/io/kestra/webserver/controllers/api/PluginController.java
+++ b/webserver/src/main/java/io/kestra/webserver/controllers/api/PluginController.java
@@ -25,6 +25,7 @@ import io.kestra.core.repositories.ArrayListTotal;
 import io.kestra.core.utils.EditionProvider;
 import io.kestra.core.utils.Hashing;
 import io.kestra.core.utils.MapUtils;
+import io.kestra.core.utils.VersionProvider;
 import io.kestra.webserver.converters.QueryFilterFormat;
 import io.kestra.webserver.responses.PagedResults;
 import io.kestra.webserver.utils.Searchable;
@@ -40,6 +41,7 @@ import io.micronaut.http.MutableHttpResponse;
 import io.micronaut.http.annotation.Body;
 import io.micronaut.http.annotation.Controller;
 import io.micronaut.http.annotation.Get;
+import io.micronaut.http.annotation.Header;
 import io.micronaut.http.annotation.PathVariable;
 import io.micronaut.http.annotation.Post;
 import io.micronaut.http.annotation.QueryValue;
@@ -60,6 +62,10 @@ import static io.kestra.core.utils.Rethrow.throwFunction;
 public class PluginController {
     private static final String CACHE_DIRECTIVE = "public, max-age=3600";
     private static final String ICON_CACHE_DIRECTIVE = "public, max-age=31536000, immutable";
+    // Plugin schemas depend on the set of installed plugins, which can change while the server runs.
+    // They must therefore be revalidated on every use (via ETag) instead of being cached blindly, otherwise
+    // the editor keeps validating/completing against a stale schema after a plugin is added or removed (#12102).
+    private static final String REVALIDATE_CACHE_DIRECTIVE = "no-cache";
 
     @Inject
     protected JsonSchemaGenerator jsonSchemaGenerator;
@@ -69,6 +75,9 @@ public class PluginController {
 
     @Inject
     protected JsonSchemaCache jsonSchemaCache;
+
+    @Inject
+    protected VersionProvider versionProvider;
 
     @Inject
     @Named("PLUGIN")
@@ -90,10 +99,15 @@ public class PluginController {
     )
     public HttpResponse<Map<String, Object>> getSchemasFromType(
         @Parameter(description = "The schema needed") @PathVariable SchemaType type,
-        @Parameter(description = "If schema should be an array of requested type") @Nullable @QueryValue(value = "arrayOf", defaultValue = "false") Boolean arrayOf) {
-        return HttpResponse.ok()
-            .body(jsonSchemaCache.getSchemaForType(type, arrayOf))
-            .header(HttpHeaders.CACHE_CONTROL, CACHE_DIRECTIVE);
+        @Parameter(description = "If schema should be an array of requested type") @Nullable @QueryValue(value = "arrayOf", defaultValue = "false") Boolean arrayOf,
+        @Parameter(hidden = true) @Nullable @Header(HttpHeaders.IF_NONE_MATCH) String ifNoneMatch) {
+        final String etag = schemaETag("schema", type, arrayOf);
+        if (etag.equals(ifNoneMatch)) {
+            return notModified(etag);
+        }
+        return HttpResponse.ok(jsonSchemaCache.getSchemaForType(type, arrayOf))
+            .header(HttpHeaders.ETAG, etag)
+            .header(HttpHeaders.CACHE_CONTROL, REVALIDATE_CACHE_DIRECTIVE);
     }
 
     @Get(uri = "properties/{type}")
@@ -104,10 +118,30 @@ public class PluginController {
         description = "The schema will be a [JSON Schema Draft 7](http://json-schema.org/draft-07/schema)"
     )
     public HttpResponse<Map<String, Object>> getPropertiesFromType(
-        @Parameter(description = "The schema needed") @PathVariable SchemaType type) {
-        return HttpResponse.ok()
-            .body(jsonSchemaCache.getPropertiesForType(type))
-            .header(HttpHeaders.CACHE_CONTROL, CACHE_DIRECTIVE);
+        @Parameter(description = "The schema needed") @PathVariable SchemaType type,
+        @Parameter(hidden = true) @Nullable @Header(HttpHeaders.IF_NONE_MATCH) String ifNoneMatch) {
+        final String etag = schemaETag("properties", type, false);
+        if (etag.equals(ifNoneMatch)) {
+            return notModified(etag);
+        }
+        return HttpResponse.ok(jsonSchemaCache.getPropertiesForType(type))
+            .header(HttpHeaders.ETAG, etag)
+            .header(HttpHeaders.CACHE_CONTROL, REVALIDATE_CACHE_DIRECTIVE);
+    }
+
+    /**
+     * Builds a strong ETag for a plugin schema response. The tag changes whenever the installed plugin
+     * set changes (via {@link PluginRegistry#hash()}) or the server version changes, so browsers holding a
+     * previously cached schema revalidate and receive the fresh one instead of a stale cached copy.
+     */
+    private String schemaETag(final String kind, final SchemaType type, final boolean arrayOf) {
+        return "\"" + kind + "-" + type + "-" + arrayOf + "-" + versionProvider.getVersion() + "-" + pluginRegistry.hash() + "\"";
+    }
+
+    private <T> HttpResponse<T> notModified(final String etag) {
+        return HttpResponse.<T>notModified()
+            .header(HttpHeaders.ETAG, etag)
+            .header(HttpHeaders.CACHE_CONTROL, REVALIDATE_CACHE_DIRECTIVE);
     }
 
     @Get(uri = "inputs")

--- a/webserver/src/test/java/io/kestra/webserver/controllers/api/PluginControllerTest.java
+++ b/webserver/src/test/java/io/kestra/webserver/controllers/api/PluginControllerTest.java
@@ -296,6 +296,33 @@ class PluginControllerTest {
     }
 
     @Test
+    void flowSchemaIsRevalidatedWithEtag() {
+        // The flow schema depends on the installed plugin set, which can change while the server runs, so it
+        // must be revalidated on every use (ETag) instead of being cached blindly for an hour — otherwise the
+        // editor keeps completing/validating against a stale schema after a plugin is added or removed (#12102).
+        HttpResponse<Map<String, Object>> response = client.toBlocking().exchange(
+            HttpRequest.GET(PATH + "/schemas/flow"),
+            Argument.mapOf(String.class, Object.class)
+        );
+
+        assertThat(response.getStatus().getCode()).isEqualTo(HttpStatus.OK.getCode());
+        assertThat(response.getHeaders().get(HttpHeaders.CACHE_CONTROL)).isEqualTo("no-cache");
+        String etag = response.getHeaders().get(HttpHeaders.ETAG);
+        assertThat(etag).isNotBlank();
+
+        // A conditional request carrying the current ETag is answered 304 Not Modified (no re-download).
+        HttpResponse<?> conditional;
+        try {
+            conditional = client.toBlocking().exchange(
+                HttpRequest.GET(PATH + "/schemas/flow").header(HttpHeaders.IF_NONE_MATCH, etag)
+            );
+        } catch (HttpClientResponseException e) {
+            conditional = e.getResponse();
+        }
+        assertThat(conditional.getStatus().getCode()).isEqualTo(HttpStatus.NOT_MODIFIED.getCode());
+    }
+
+    @Test
     void flowProperties() {
         Map<String, Object> doc = client.toBlocking().retrieve(
             HttpRequest.GET(PATH + "/properties/flow"),


### PR DESCRIPTION
## What & why

Part of #12102 — newly installed plugins on a standalone install show up on the `/plugins` catalog page and execute fine, but do **not** appear in the flow editor's `type:` autocomplete and are flagged as unknown types.

This PR addresses the **client-side / HTTP caching** facet of that issue. It is complementary to the schema-generation work in **#17508** (and **#17568**, which is stacked into #17508) — see [Related PRs](#related-prs) below. Files are disjoint, so the PRs merge independently.

### Root cause

The editor's `type:` autocomplete and type-validation are driven entirely by the aggregated schema at `GET /api/v1/plugins/schemas/{type}` (monaco-yaml fetches it directly). That endpoint was served with `Cache-Control: public, max-age=3600` and **no ETag**, while the catalog endpoints (`/plugins`, `/plugins/groups/subgroups`) send no cache header and read the live registry.

So after a plugin set change, the browser keeps serving the **stale schema for up to an hour with no way to revalidate** → the new plugin isn't offered in autocomplete and reads as an unknown type, even though `/plugins` already lists it. Reproduced live: with a plugin removed server-side, the editor still validated its type against the cached schema until the HTTP cache was bypassed (hard reload / "Disable cache").

A second, latent contributor: the server-side `JsonSchemaCache` populates via `computeIfAbsent` and its `clear()` had **zero callers**, so a runtime registry change (EE `plugins install`, future hot-reload) would never invalidate it.

### Changes

- **`PluginController`** — `schemas/{type}` and `properties/{type}` now respond with `Cache-Control: no-cache` + a strong **`ETag`** derived from the installed plugin set (`PluginRegistry#hash()`) and the server version. A matching `If-None-Match` is answered `304 Not Modified`, so repeat editor opens still skip re-downloading the ~720 KB schema — freshness without losing the caching win.
- **`JsonSchemaCache`** — injects `PluginRegistry` and drops the cached schemas when the registry hash changes (pull-based self-invalidation; the registry is a static singleton so a push-based `clear()` from it would be fragile and miss paths). `clear()` now also clears the properties cache.

### Tests

- `JsonSchemaCacheTest` (new) — serves from cache while the registry hash is stable; regenerates when it changes.
- `PluginControllerTest#flowSchemaIsRevalidatedWithEtag` (new) — asserts `no-cache` + non-blank `ETag`, and that a matching `If-None-Match` yields `304`.

All pass; `core` and `webserver` compile clean.

### Note for EE

`JsonSchemaCache`'s constructor gained a `PluginRegistry` parameter. It's DI-injected everywhere in OSS (no `new` call sites), so OSS is unaffected — but EE code that constructs or `@Replaces` it will need the matching constructor.

<a name="related-prs"></a>
## Related PRs — #12102 has more than one root cause

This issue has **two distinct failure modes**, fixed at different layers. This PR is the **cache** layer; the **schema-generation** layer is handled separately:

| PR | Layer | What it fixes |
|----|-------|---------------|
| **#17508** (open) + **#17568** (merged into #17508's branch) | Schema **generation** (`JsonSchemaGenerator`) | A plugin built against an incompatible Kestra version fails subtype resolution and **vanishes from the schema entirely** (or crashes the whole flow schema). Adds a plain-resolve fallback, a placeholder schema for unresolved types, and per-plugin generation-failure isolation. |
| **this PR (#17582)** | HTTP **cache** (`PluginController` / `JsonSchemaCache`) | The schema *does* contain the plugin, but the browser serves a **stale cached copy** after a plugin-set change. Adds `no-cache` + ETag revalidation and registry-hash cache invalidation. |

They are complementary and synergistic (both use the plugin registry as source of truth: #17568 reconciles the schema against it, this PR keys the cache on its hash). **Suggested closing PR for #12102: #17508** — hence this PR says *"Part of #12102"* rather than *"Fixes"*, to avoid double-closing the issue.

## How to reproduce (on the buggy version, before this fix)

**Prerequisites:** a Kestra **standalone** on an affected version (e.g. `1.2.x`) and any plugin JAR that is *not* bundled in that standalone — e.g. build one locally: `git clone` a plugin repo and run `./gradlew shadowJar` (the JAR lands in `build/libs/`). Kafka (`plugin-kafka`) is a good example. Run under Java 21 (1.x standalones don't support the Java 25 removed Security Manager).

1. Start the standalone with an **empty** plugins directory:
   `java -jar kestra-<version> server standalone --plugins ./plugins`
2. In the UI, open (or create) a flow in the editor and let it load. This makes monaco-yaml fetch `GET /api/v1/plugins/schemas/flow`, which the browser then caches for one hour (`Cache-Control: public, max-age=3600`, no `ETag`). Keep DevTools **"Disable cache" OFF** — the bug depends on the browser reusing this cache.
3. Stop the server, drop the plugin JAR into `./plugins`, and restart.
4. Confirm the plugin really is installed: it appears on the **Plugins** page, and a flow using one of its task types executes successfully.
5. Back in the flow editor, reload the page normally (**F5**). The new task type (e.g. `io.kestra.plugin.kafka.Produce`) is **not** offered in `type:` autocomplete and is treated as an unknown type — because the browser is still serving the schema cached in step 2, even though the server's schema now contains it. This is the reported symptom: *installed & visible in /plugins, but no editor autocomplete*.
6. Hard-reload (**Ctrl+Shift+R**) or tick DevTools **"Disable cache"**: the schema is re-fetched from the server and the type is recognized immediately — confirming the stale HTTP cache is the cause, not the registry or the schema generation.

**After this fix:** step 5 recognizes the plugin without any hard-reload, because `/plugins/schemas/*` is served with `Cache-Control: no-cache` + an `ETag` that changes whenever the installed plugin set changes. The browser revalidates on every use and gets the fresh schema (or a lightweight `304 Not Modified` when nothing changed). Verified on a standalone built from this branch: `/plugins/schemas/flow` returns `Cache-Control: no-cache` + `ETag`, and a conditional request with the matching `If-None-Match` returns `304`.

> Tip: the effect is symmetric and easy to demonstrate either direction — you can also start *with* the plugin (editor caches a schema that has it), then remove it + restart, and watch the editor keep validating the now-removed type until a hard-reload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
