### PR TITLE
feat(core): add stable machine-readable error codes to API error responses

### DIFF
--- a/core/src/main/java/io/kestra/core/exceptions/ErrorCode.java
+++ b/core/src/main/java/io/kestra/core/exceptions/ErrorCode.java
@@ -1,0 +1,45 @@
+package io.kestra.core.exceptions;
+
+/**
+ * Stable machine-readable codes exposed in API error responses so that clients can branch on the
+ * error type instead of parsing free-text messages.
+ *
+ * <p>Codes are part of the public API contract: renaming or removing a value is a breaking change,
+ * adding a new value is not — clients must treat unrecognized codes as their closest
+ * status-level equivalent.
+ */
+public enum ErrorCode {
+    INTERNAL_ERROR,
+    INVALID_REQUEST,
+    INVALID_ENTITY,
+    INVALID_QUERY_FILTERS,
+    UNAUTHORIZED,
+    FORBIDDEN,
+    NOT_FOUND,
+    FLOW_NOT_FOUND,
+    TENANT_NOT_FOUND,
+    CONFLICT,
+    LOCKED,
+    RESOURCE_EXPIRED;
+
+    /**
+     * Resolves the default {@link ErrorCode} for an HTTP status code, used when the thrown
+     * exception does not carry a more specific code.
+     *
+     * @param statusCode the HTTP status code.
+     * @return the default {@link ErrorCode} for the given status.
+     */
+    public static ErrorCode fromHttpStatusCode(final int statusCode) {
+        return switch (statusCode) {
+            case 400 -> INVALID_REQUEST;
+            case 401 -> UNAUTHORIZED;
+            case 403 -> FORBIDDEN;
+            case 404 -> NOT_FOUND;
+            case 409 -> CONFLICT;
+            case 410 -> RESOURCE_EXPIRED;
+            case 422 -> INVALID_ENTITY;
+            case 423 -> LOCKED;
+            default -> statusCode >= 400 && statusCode < 500 ? INVALID_REQUEST : INTERNAL_ERROR;
+        };
+    }
+}

--- a/core/src/main/java/io/kestra/core/exceptions/FlowNotFoundException.java
+++ b/core/src/main/java/io/kestra/core/exceptions/FlowNotFoundException.java
@@ -37,4 +37,12 @@ public class FlowNotFoundException extends NotFoundException {
     public FlowNotFoundException(final ExecutionId executionId, Integer flowRevision) {
         super(FLOW_NOT_FOUND_MESSAGE.formatted(executionId.tenantId(), executionId.namespace(), executionId.flowId(), flowRevision, executionId.executionId()));
     }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public ErrorCode getErrorCode() {
+        return ErrorCode.FLOW_NOT_FOUND;
+    }
 }

--- a/core/src/main/java/io/kestra/core/exceptions/ForbiddenException.java
+++ b/core/src/main/java/io/kestra/core/exceptions/ForbiddenException.java
@@ -1,0 +1,35 @@
+package io.kestra.core.exceptions;
+
+import java.io.Serial;
+
+/**
+ * General exception that can be thrown when access to a Kestra resource or operation is denied.
+ */
+public class ForbiddenException extends KestraRuntimeException implements HasErrorCode {
+    @Serial
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * Creates a new {@link ForbiddenException} instance.
+     */
+    public ForbiddenException() {
+        super();
+    }
+
+    /**
+     * Creates a new {@link ForbiddenException} instance.
+     *
+     * @param message the error message.
+     */
+    public ForbiddenException(final String message) {
+        super(message);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public ErrorCode getErrorCode() {
+        return ErrorCode.FORBIDDEN;
+    }
+}

--- a/core/src/main/java/io/kestra/core/exceptions/HasErrorCode.java
+++ b/core/src/main/java/io/kestra/core/exceptions/HasErrorCode.java
@@ -1,0 +1,13 @@
+package io.kestra.core.exceptions;
+
+/**
+ * Contract for exceptions that carry a stable machine-readable {@link ErrorCode} to be exposed in
+ * API error responses.
+ */
+public interface HasErrorCode {
+
+    /**
+     * @return the stable machine-readable code identifying this error.
+     */
+    ErrorCode getErrorCode();
+}

--- a/core/src/main/java/io/kestra/core/exceptions/InvalidQueryFiltersException.java
+++ b/core/src/main/java/io/kestra/core/exceptions/InvalidQueryFiltersException.java
@@ -6,7 +6,7 @@ import java.util.List;
 /**
  * General exception that can be throws when a Kestra entity field is query, but is not valid or existing.
  */
-public class InvalidQueryFiltersException extends KestraRuntimeException {
+public class InvalidQueryFiltersException extends KestraRuntimeException implements HasErrorCode {
     @Serial
     private static final long serialVersionUID = 1L;
     private static final String INVALID_QUERY_FILTER_MESSAGE = "Provided query filters are invalid: %s";
@@ -27,5 +27,13 @@ public class InvalidQueryFiltersException extends KestraRuntimeException {
      */
     public InvalidQueryFiltersException(final String invalid) {
         super(INVALID_QUERY_FILTER_MESSAGE.formatted(invalid));
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public ErrorCode getErrorCode() {
+        return ErrorCode.INVALID_QUERY_FILTERS;
     }
 }

--- a/core/src/main/java/io/kestra/core/exceptions/NotFoundException.java
+++ b/core/src/main/java/io/kestra/core/exceptions/NotFoundException.java
@@ -3,7 +3,7 @@ package io.kestra.core.exceptions;
 /**
  * General exception that can be throws when a Kestra resource or entity is not found.
  */
-public class NotFoundException extends KestraRuntimeException {
+public class NotFoundException extends KestraRuntimeException implements HasErrorCode {
     private static final long serialVersionUID = 1L;
 
     /**
@@ -20,5 +20,13 @@ public class NotFoundException extends KestraRuntimeException {
      */
     public NotFoundException(final String message) {
         super(message);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public ErrorCode getErrorCode() {
+        return ErrorCode.NOT_FOUND;
     }
 }

--- a/core/src/main/java/io/kestra/core/exceptions/ResourceAccessDeniedException.java
+++ b/core/src/main/java/io/kestra/core/exceptions/ResourceAccessDeniedException.java
@@ -2,7 +2,7 @@ package io.kestra.core.exceptions;
 
 import java.io.Serial;
 
-public class ResourceAccessDeniedException extends KestraRuntimeException {
+public class ResourceAccessDeniedException extends ForbiddenException {
     @Serial
     private static final long serialVersionUID = 1L;
 

--- a/webserver/src/main/java/io/kestra/webserver/controllers/ErrorController.java
+++ b/webserver/src/main/java/io/kestra/webserver/controllers/ErrorController.java
@@ -16,6 +16,7 @@ import com.fasterxml.jackson.databind.exc.InvalidTypeIdException;
 
 import io.kestra.core.exceptions.*;
 import io.kestra.libs.copilot.exceptions.AiException;
+import io.kestra.webserver.responses.ApiError;
 
 import io.micronaut.core.convert.exceptions.ConversionErrorException;
 import io.micronaut.http.HttpRequest;
@@ -55,7 +56,7 @@ public class ErrorController {
                 typeField.setAccessible(true);
                 Object typeClass = typeField.get(invalidTypeIdException);
 
-                JsonError error = new JsonError("Invalid type: " + typeClass)
+                JsonError error = new ApiError(ErrorCode.INVALID_ENTITY, "Invalid type: " + typeClass)
                     .link(Link.SELF, Link.of(request.getUri()))
                     .embedded(
                         "errors",
@@ -74,7 +75,7 @@ public class ErrorController {
             try {
                 String path = path(jsonMappingException);
 
-                JsonError error = new JsonError("Invalid json mapping")
+                JsonError error = new ApiError(ErrorCode.INVALID_ENTITY, "Invalid json mapping")
                     .link(Link.SELF, Link.of(request.getUri()))
                     .embedded(
                         "errors",
@@ -106,7 +107,7 @@ public class ErrorController {
 
     @Error(global = true)
     public HttpResponse<JsonError> error(HttpRequest<?> request, ConstraintViolationException e) {
-        JsonError error = new JsonError("Invalid entity: " + e.getMessage())
+        JsonError error = new ApiError(ErrorCode.INVALID_ENTITY, "Invalid entity: " + e.getMessage())
             .link(Link.SELF, Link.of(request.getUri()))
             .embedded(
                 "errors",
@@ -161,6 +162,11 @@ public class ErrorController {
     @Error(global = true)
     public HttpResponse<JsonError> error(HttpRequest<?> request, ConflictException e) {
         return jsonError(request, e, HttpStatus.CONFLICT, HttpStatus.CONFLICT.getReason());
+    }
+
+    @Error(global = true)
+    public HttpResponse<JsonError> error(HttpRequest<?> request, ForbiddenException e) {
+        return jsonError(request, e, HttpStatus.FORBIDDEN, HttpStatus.FORBIDDEN.getReason());
     }
 
     @Error(global = true)
@@ -225,20 +231,31 @@ public class ErrorController {
     }
 
     public static HttpResponse<JsonError> jsonError(HttpRequest<?> request, HttpStatus status, String reason) {
-        JsonError error = new JsonError(reason)
+        return jsonError(request, status, ErrorCode.fromHttpStatusCode(status.getCode()), reason);
+    }
+
+    public static HttpResponse<JsonError> jsonError(HttpRequest<?> request, HttpStatus status, ErrorCode code, String reason) {
+        JsonError error = new ApiError(code, reason)
             .link(Link.SELF, Link.of(request.getUri()));
 
         return jsonError(error, status, reason);
     }
 
     public static HttpResponse<JsonError> jsonError(HttpRequest<?> request, Throwable e, HttpStatus status, String reason) {
+        return jsonError(request, e, status, ErrorCode.fromHttpStatusCode(status.getCode()), reason);
+    }
+
+    public static HttpResponse<JsonError> jsonError(HttpRequest<?> request, Throwable e, HttpStatus status, ErrorCode code, String reason) {
         if (status == HttpStatus.INTERNAL_SERVER_ERROR) {
             log.error("Server error: {}", e.getMessage() != null ? e.getMessage() : "", e);
         } else {
             log.trace("Client error: {}", e.getMessage() != null ? e.getMessage() : "", e);
         }
 
-        JsonError error = new JsonError(reason + (e.getMessage() != null ? ": " + e.getMessage() : ""))
+        // An exception-provided code is more specific than the status-level default.
+        ErrorCode effectiveCode = e instanceof HasErrorCode hasErrorCode ? hasErrorCode.getErrorCode() : code;
+
+        JsonError error = new ApiError(effectiveCode, reason + (e.getMessage() != null ? ": " + e.getMessage() : ""))
             .link(Link.SELF, Link.of(request.getUri()));
 
         return jsonError(error, status, reason);

--- a/webserver/src/main/java/io/kestra/webserver/exceptions/KestraHttpStatusException.java
+++ b/webserver/src/main/java/io/kestra/webserver/exceptions/KestraHttpStatusException.java
@@ -1,0 +1,39 @@
+package io.kestra.webserver.exceptions;
+
+import java.util.Objects;
+
+import io.kestra.core.exceptions.ErrorCode;
+import io.kestra.core.exceptions.HasErrorCode;
+
+import io.micronaut.http.HttpStatus;
+import io.micronaut.http.exceptions.HttpStatusException;
+
+/**
+ * An {@link HttpStatusException} carrying a stable machine-readable {@link ErrorCode}, for code
+ * paths (e.g. server filters) that respond with an HTTP status directly instead of throwing a
+ * domain exception.
+ */
+public class KestraHttpStatusException extends HttpStatusException implements HasErrorCode {
+
+    private final ErrorCode errorCode;
+
+    /**
+     * Creates a new {@link KestraHttpStatusException} instance.
+     *
+     * @param status the HTTP status of the response.
+     * @param message the human-readable error message.
+     * @param errorCode the stable machine-readable error code.
+     */
+    public KestraHttpStatusException(final HttpStatus status, final String message, final ErrorCode errorCode) {
+        super(status, message);
+        this.errorCode = Objects.requireNonNull(errorCode, "errorCode must not be null");
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public ErrorCode getErrorCode() {
+        return errorCode;
+    }
+}

--- a/webserver/src/main/java/io/kestra/webserver/responses/ApiError.java
+++ b/webserver/src/main/java/io/kestra/webserver/responses/ApiError.java
@@ -1,0 +1,38 @@
+package io.kestra.webserver.responses;
+
+import java.util.Objects;
+
+import io.kestra.core.exceptions.ErrorCode;
+
+import io.micronaut.http.hateoas.JsonError;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+/**
+ * A {@link JsonError} carrying a stable machine-readable {@link ErrorCode} in addition to the
+ * human-readable message, so that API clients can branch on the error type without parsing
+ * message text.
+ */
+@Schema(description = "An API error response carrying a stable machine-readable code in addition to the human-readable message.")
+public class ApiError extends JsonError {
+
+    private final ErrorCode code;
+
+    /**
+     * Creates a new {@link ApiError} instance.
+     *
+     * @param code the stable machine-readable error code.
+     * @param message the human-readable error message.
+     */
+    public ApiError(final ErrorCode code, final String message) {
+        super(message);
+        this.code = Objects.requireNonNull(code, "code must not be null");
+    }
+
+    /**
+     * @return the stable machine-readable code identifying the error.
+     */
+    @Schema(description = "The stable machine-readable code identifying the error.")
+    public ErrorCode getCode() {
+        return code;
+    }
+}

--- a/webserver/src/main/java/io/kestra/webserver/tenants/TenantValidationFilter.java
+++ b/webserver/src/main/java/io/kestra/webserver/tenants/TenantValidationFilter.java
@@ -1,12 +1,14 @@
 package io.kestra.webserver.tenants;
 
+import io.kestra.core.exceptions.ErrorCode;
+import io.kestra.webserver.exceptions.KestraHttpStatusException;
+
 import io.micronaut.core.order.Ordered;
 import io.micronaut.http.BasicHttpAttributes;
 import io.micronaut.http.HttpRequest;
 import io.micronaut.http.HttpStatus;
 import io.micronaut.http.annotation.RequestFilter;
 import io.micronaut.http.annotation.ServerFilter;
-import io.micronaut.http.exceptions.HttpStatusException;
 import io.micronaut.http.uri.UriMatchInfo;
 
 import static io.kestra.core.tenant.TenantService.MAIN_TENANT;
@@ -21,7 +23,7 @@ public class TenantValidationFilter implements Ordered {
         if (routeMatch != null && routeMatch.getVariableValues().containsKey(TENANT_PATH_ATTRIBUTES)) {
             String tenant = (String) routeMatch.getVariableValues().get(TENANT_PATH_ATTRIBUTES);
             if (tenant != null && !MAIN_TENANT.equals(tenant)) {
-                throw new HttpStatusException(HttpStatus.BAD_REQUEST, "Tenant must be 'main' for OSS version");
+                throw new KestraHttpStatusException(HttpStatus.BAD_REQUEST, "Tenant must be 'main' for OSS version", ErrorCode.TENANT_NOT_FOUND);
             }
         }
     }

--- a/webserver/src/test/java/io/kestra/webserver/controllers/api/ErrorControllerTest.java
+++ b/webserver/src/test/java/io/kestra/webserver/controllers/api/ErrorControllerTest.java
@@ -14,10 +14,14 @@ import org.slf4j.LoggerFactory;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.google.common.collect.ImmutableMap;
 
+import io.kestra.core.exceptions.ErrorCode;
+import io.kestra.core.exceptions.InvalidQueryFiltersException;
 import io.kestra.core.models.flows.Flow;
 import io.kestra.core.serializers.JacksonMapper;
 import io.kestra.core.utils.IdUtils;
 import io.kestra.plugin.core.log.Log;
+import io.kestra.webserver.controllers.ErrorController;
+import io.kestra.webserver.responses.ApiError;
 
 import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.Logger;
@@ -25,6 +29,7 @@ import ch.qos.logback.classic.LoggerContext;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.AppenderBase;
 import io.micronaut.core.type.Argument;
+import io.micronaut.http.HttpResponse;
 import io.micronaut.http.HttpStatus;
 import io.micronaut.http.MediaType;
 import io.micronaut.http.client.annotation.Client;
@@ -119,6 +124,71 @@ class ErrorControllerTest {
         String response = exception.getResponse().getBody(String.class).get();
         assertThat(response).contains("Invalid entity: Unrecognized field \\\"unknown\\\" (class io.kestra.core.models.flows.FlowWithSource), not marked as ignorable");
         assertThat(response).contains("\"path\":\"io.kestra.core.models.flows.FlowWithSource[\\\"unknown\\\"]\"");
+    }
+
+    @Test
+    void shouldReturnInvalidEntityCodeWhenEntityIsInvalid() throws JsonProcessingException {
+        Map<String, Object> flow = ImmutableMap.of(
+            "id", IdUtils.create(),
+            "namespace", "io.kestra.test",
+            "tasks", Collections.singletonList(
+                ImmutableMap.of(
+                    "id", IdUtils.create(),
+                    "type", "io.kestra.invalid"
+                )
+            )
+        );
+        String yaml = JacksonMapper.ofYaml().writeValueAsString(flow);
+
+        HttpClientResponseException exception = assertThrows(
+            HttpClientResponseException.class,
+            () -> client.toBlocking().retrieve(POST("/api/v1/main/flows", yaml).contentType(MediaType.APPLICATION_YAML_TYPE), Argument.of(Flow.class), Argument.of(Object.class))
+        );
+
+        assertThat(exception.getStatus().getCode()).isEqualTo(UNPROCESSABLE_ENTITY.getCode());
+        assertThat(exception.getResponse().getBody(String.class).get()).contains("\"code\":\"INVALID_ENTITY\"");
+    }
+
+    @Test
+    void shouldReturnNotFoundCodeWhenFlowDoesNotExist() {
+        HttpClientResponseException exception = assertThrows(
+            HttpClientResponseException.class,
+            () -> client.toBlocking().retrieve(GET("/api/v1/main/flows/io.kestra.missing/missing-flow"))
+        );
+
+        assertThat(exception.getStatus().getCode()).isEqualTo(NOT_FOUND.getCode());
+        assertThat(exception.getResponse().getBody(String.class).get()).contains("\"code\":\"NOT_FOUND\"");
+    }
+
+    @Test
+    void shouldReturnForbiddenCodeWhenAccessIsDenied() {
+        HttpClientResponseException exception = assertThrows(
+            HttpClientResponseException.class,
+            () -> client.toBlocking().retrieve(GET("/test-utils/failing-with-forbidden"))
+        );
+
+        assertThat(exception.getStatus().getCode()).isEqualTo(FORBIDDEN.getCode());
+        assertThat(exception.getResponse().getBody(String.class).get()).contains("\"code\":\"FORBIDDEN\"");
+    }
+
+    @Test
+    void shouldReturnInvalidQueryFiltersCodeWhenFiltersAreInvalid() {
+        HttpResponse<JsonError> response = new ErrorController()
+            .error(GET("/api/v1/main/flows/search"), new InvalidQueryFiltersException("foo"));
+
+        assertThat(response.status().getCode()).isEqualTo(BAD_REQUEST.getCode());
+        assertThat(((ApiError) response.body()).getCode()).isEqualTo(ErrorCode.INVALID_QUERY_FILTERS);
+    }
+
+    @Test
+    void shouldReturnTenantNotFoundCodeWhenTenantIsNotMain() {
+        HttpClientResponseException exception = assertThrows(
+            HttpClientResponseException.class,
+            () -> client.toBlocking().retrieve(GET("/api/v1/unknown-tenant/flows/io.kestra.missing/missing-flow"))
+        );
+
+        assertThat(exception.getStatus().getCode()).isEqualTo(BAD_REQUEST.getCode());
+        assertThat(exception.getResponse().getBody(String.class).get()).contains("\"code\":\"TENANT_NOT_FOUND\"");
     }
 
     @Test

--- a/webserver/src/test/java/io/kestra/webserver/controllers/api/TestUtilsController.java
+++ b/webserver/src/test/java/io/kestra/webserver/controllers/api/TestUtilsController.java
@@ -1,5 +1,7 @@
 package io.kestra.webserver.controllers.api;
 
+import io.kestra.core.exceptions.ResourceAccessDeniedException;
+
 import io.micronaut.http.HttpStatus;
 import io.micronaut.http.annotation.*;
 import io.micronaut.http.exceptions.HttpStatusException;
@@ -14,27 +16,24 @@ public class TestUtilsController {
     @ExecuteOn(TaskExecutors.IO)
     @Get(uri = "/failing-with-400-client-error", produces = "application/json")
     public String failingWith400ClientError() {
-        if (true) {
-            throw new HttpStatusException(HttpStatus.BAD_REQUEST, "a client error message");
-        }
-        return "";
+        throw new HttpStatusException(HttpStatus.BAD_REQUEST, "a client error message");
+    }
+
+    @ExecuteOn(TaskExecutors.IO)
+    @Get(uri = "/failing-with-forbidden", produces = "application/json")
+    public String failingWithForbidden() {
+        throw new ResourceAccessDeniedException("Namespace io.kestra.denied is not allowed.");
     }
 
     @ExecuteOn(TaskExecutors.IO)
     @Get(uri = "/failing-with-500-server-error", produces = "application/json")
     public String failingWith500ServerError() {
-        if (true) {
-            throw new RuntimeException("an unhandled server error message");
-        }
-        return "";
+        throw new RuntimeException("an unhandled server error message");
     }
 
     @ExecuteOn(TaskExecutors.IO)
     @Get(uri = "/failing-with-server-error-with-no-error-message", produces = "application/json")
     public String failingWithServerErrorWithNoErrorMessage() {
-        if (true) {
-            throw new NullPointerException();
-        }
-        return "";
+        throw new NullPointerException();
     }
 }


### PR DESCRIPTION
Error bodies built by ErrorController now carry a stable `code` field (ErrorCode enum) alongside the human-readable message, so API clients can branch on the error type instead of parsing free-text messages.

- ErrorCode enum + HasErrorCode contract in core exceptions; NotFoundException carries NOT_FOUND, FlowNotFoundException carries FLOW_NOT_FOUND
- ApiError extends Micronaut's JsonError with the additive code property
- KestraHttpStatusException: an HttpStatusException carrying an ErrorCode, for filters that respond with a status directly
- code resolution: exception-provided code > handler-specific code >
  HTTP-status default; existing jsonError(...) signatures are unchanged
- TenantValidationFilter now emits TENANT_NOT_FOUND


See: https://github.com/kestra-io/kestra-ee/pull/9436