### PR TITLE
fix(core): surface meaningful 503 errors when AI Copilot provider fails

### DIFF
--- a/webserver/src/main/java/io/kestra/webserver/controllers/api/AiController.java
+++ b/webserver/src/main/java/io/kestra/webserver/controllers/api/AiController.java
@@ -7,6 +7,7 @@ import java.util.Map;
 import com.fasterxml.jackson.annotation.JsonCreator;
 
 import io.kestra.core.tenant.TenantService;
+import io.kestra.libs.copilot.exceptions.AiException;
 import io.kestra.webserver.services.ai.AiServiceInterface;
 import io.kestra.webserver.services.ai.AiServiceManager;
 import io.kestra.webserver.services.ai.GenerationResult;
@@ -54,9 +55,16 @@ public class AiController {
             return HttpResponse.<String> status(HttpStatus.SERVICE_UNAVAILABLE).body("AI Copilot is not available: no AI provider is configured or reachable.");
         }
 
-        GenerationResult result = service
-            .generateFlow(new UserInfo(httpClientAddressResolver.resolve(httpRequest), httpRequest.getHeaders().get("X-Kestra-User-Id")), flowGenerationPrompt, tenantService.resolveTenant());
-        return toHttpResponse(result);
+        try {
+            GenerationResult result = service
+                .generateFlow(new UserInfo(httpClientAddressResolver.resolve(httpRequest), httpRequest.getHeaders().get("X-Kestra-User-Id")), flowGenerationPrompt, tenantService.resolveTenant());
+            return toHttpResponse(result);
+        } catch (AiException e) {
+            throw e;
+        } catch (Exception e) {
+            log.error("AI flow generation failed.", e);
+            return HttpResponse.<String> status(HttpStatus.SERVICE_UNAVAILABLE).body(providerErrorMessage(e));
+        }
     }
 
     @ExecuteOn(TaskExecutors.IO)
@@ -70,9 +78,33 @@ public class AiController {
             return HttpResponse.<String> status(HttpStatus.SERVICE_UNAVAILABLE).body("AI Copilot is not available: no AI provider is configured or reachable.");
         }
 
-        GenerationResult result = service
-            .generateDashboard(new UserInfo(httpClientAddressResolver.resolve(httpRequest), httpRequest.getHeaders().get("X-Kestra-User-Id")), dashboardGenerationPrompt);
-        return toHttpResponse(result);
+        try {
+            GenerationResult result = service
+                .generateDashboard(new UserInfo(httpClientAddressResolver.resolve(httpRequest), httpRequest.getHeaders().get("X-Kestra-User-Id")), dashboardGenerationPrompt);
+            return toHttpResponse(result);
+        } catch (AiException e) {
+            throw e;
+        } catch (Exception e) {
+            log.error("AI dashboard generation failed.", e);
+            return HttpResponse.<String> status(HttpStatus.SERVICE_UNAVAILABLE).body(providerErrorMessage(e));
+        }
+    }
+
+    static String providerErrorMessage(Exception e) {
+        String message = e.getMessage();
+        if (message != null) {
+            String lower = message.toLowerCase();
+            if (lower.contains("401") || lower.contains("unauthorized") || lower.contains("authentication") || lower.contains("api key") || lower.contains("apikey")) {
+                return "AI provider authentication failed. Please verify that the configured API key is valid and has not expired.";
+            }
+            if (lower.contains("429") || lower.contains("too many requests") || lower.contains("rate limit") || lower.contains("ratelimit")) {
+                return "AI provider rate limit exceeded. Please wait a moment before trying again.";
+            }
+            if (lower.contains("quota") || lower.contains("insufficient_quota") || lower.contains("billing")) {
+                return "AI provider quota exceeded or a billing issue was detected. Please check your provider account.";
+            }
+        }
+        return "AI Copilot failed to generate a response. This may be due to a temporary issue with the AI provider. Please try again.";
     }
 
     protected HttpResponse<String> toHttpResponse(GenerationResult result) {

--- a/webserver/src/test/java/io/kestra/webserver/controllers/api/AiControllerTest.java
+++ b/webserver/src/test/java/io/kestra/webserver/controllers/api/AiControllerTest.java
@@ -317,4 +317,45 @@ class AiControllerTest {
         assertThat(exception).isNotNull();
         assertThat(exception.getStatus().getCode()).isEqualTo(503);
     }
+
+    @Test
+    void shouldReturn503WhenProviderReturnsUnauthorized() {
+        // Given: AI provider returns 401
+        extension.stubFor(post(anyUrl()).willReturn(aResponse().withStatus(401).withBody("Unauthorized: Invalid API key")));
+
+        // When
+        HttpClientResponseException exception = catchThrowableOfType(
+            HttpClientResponseException.class,
+            () -> client.toBlocking().exchange(
+                HttpRequest.POST(
+                    "/api/v1/main/ai/generate/flow",
+                    new AiController.FlowGenerationPrompt(IdUtils.create(), "Generate a flow", "yaml", "io.kestra.tests", null)
+                ),
+                String.class
+            )
+        );
+
+        // Then
+        assertThat(exception).isNotNull();
+        assertThat(exception.getStatus().getCode()).isEqualTo(503);
+    }
+
+    @Test
+    void shouldClassifyProviderErrorByKeyword() {
+        // Given / When / Then
+        assertThat(AiController.providerErrorMessage(new RuntimeException("HTTP 401: Unauthorized")))
+            .contains("authentication");
+
+        assertThat(AiController.providerErrorMessage(new RuntimeException("Rate limit exceeded (429)")))
+            .contains("rate limit");
+
+        assertThat(AiController.providerErrorMessage(new RuntimeException("Insufficient quota for this billing period")))
+            .contains("quota");
+
+        assertThat(AiController.providerErrorMessage(new RuntimeException("Connection reset by peer")))
+            .contains("temporary issue");
+
+        assertThat(AiController.providerErrorMessage(new RuntimeException((String) null)))
+            .contains("temporary issue");
+    }
 }


### PR DESCRIPTION
## Summary

Closes #17041.

Before this fix, any exception thrown by LangChain4j that was **not** an `AiException` (e.g. an HTTP 401 from the upstream AI provider for an invalid API key, a 429 rate-limit response, a quota exhaustion error, or a transient network failure) would propagate through to Micronaut's generic `Throwable` handler and produce a cryptic `500 Internal Server Error` with no actionable information for the user.

Changes:
- Added try-catch to `generateFlow` and `generateDashboard` in `AiController`:
  - `AiException` is re-thrown so the existing global error handler (which maps it to 422) continues to work
  - All other exceptions are caught, logged, and mapped to **503 Service Unavailable** with a human-readable body
- Added `providerErrorMessage(Exception)` static helper that classifies the exception message by keyword:
  - 401 / unauthorized / api key → authentication failure message
  - 429 / rate limit → rate-limit message
  - quota / billing → quota/billing message
  - anything else → generic "temporary issue" message
- Added two new unit tests in `AiControllerTest`:
  - `shouldReturn503WhenProviderReturnsUnauthorized` — WireMock stubs a 401 from the provider; asserts the client sees 503
  - `shouldClassifyProviderErrorByKeyword` — unit-tests the classification logic directly for auth, rate-limit, quota, and unknown cases

## Test plan

- [ ] Configure an AI provider with an intentionally invalid API key; trigger flow generation — should now see a 503 with an auth-failure message instead of a generic 500
- [ ] Run `./gradlew :webserver:test --tests "io.kestra.webserver.controllers.api.AiControllerTest"` — both new tests should pass
- [ ] Run existing `mTLS` and null-yaml regression tests — should be unaffected