### PR TITLE
fix(build): correct jq filter for scoped package name in hey-api-plugin release workflow

### DIFF
--- a/.github/workflows/publish-hey-api-plugin.yml
+++ b/.github/workflows/publish-hey-api-plugin.yml
@@ -48,7 +48,7 @@ jobs:
 
       - name: Read version
         id: version
-        run: echo "value=$(npm pkg get version --workspace @kestra-io/hey-api-plugin | jq -r '.\"@kestra-io/hey-api-plugin\"')" >> "$GITHUB_OUTPUT"
+        run: echo "value=$(npm pkg get version --workspace @kestra-io/hey-api-plugin | jq -r '.["@kestra-io/hey-api-plugin"]')" >> "$GITHUB_OUTPUT"
 
       - name: Pack (prepack builds dist)
         # Deterministic tarball name (npm pack: <scope>-<name>-<version>.tgz); avoids parsing


### PR DESCRIPTION
### ✨ Description

Fixes the *Release hey-api-plugin* workflow (`.github/workflows/publish-hey-api-plugin.yml`), which [failed on develop](https://github.com/kestra-io/kestra/actions/runs/29935084683) trying to publish `@kestra-io/hey-api-plugin` v0.1.0.

The "Read version" step used an escaped-quote jq filter:
```bash
jq -r '.\"@kestra-io/hey-api-plugin\"'
```
Inside single quotes, `\"` is passed to `jq` as literal backslash + quote characters, not an escaped quote — `jq` fails with `unexpected INVALID_CHARACTER`. The step didn't fail the job (the error is inside a `$(...)` substitution), so `steps.version.outputs.value` silently ended up empty. The downstream `gh release create` step then globbed for `ui/kestra-io-hey-api-plugin-.tgz`, found nothing, and failed with exit code 1 — no release was ever created.

Fix: use jq's bracket-string syntax (`.["@kestra-io/hey-api-plugin"]`), which needs no escaping and parses correctly.

Verified locally:
```bash
$ echo '{"@kestra-io/hey-api-plugin":"0.1.0"}' | jq -r '.["@kestra-io/hey-api-plugin"]'
0.1.0
```

Once this merges, re-dispatching the workflow from `develop` will produce the `hey-api-plugin-v0.1.0` release + tarball that [client-sdk#359](https://github.com/kestra-io/client-sdk/pull/359) depends on.

### 🔗 Related Issue

Unblocks kestra-io/client-sdk#359.

### 🛠️ Backend Checklist

- [x] Code compiles successfully and passes all checks (single-line workflow YAML change, verified the `jq` filter locally)
- [ ] N/A — no application code touched, CI-only fix

### 📝 Additional Notes

No version bump needed — `ui/packages/hey-api-plugin/package.json` is already at `0.1.0`, matching the tag client-sdk expects.

### 🤖 AI Authors

Why was the jq filter so anxious? It kept second-guessing its escape characters — turns out it just needed to relax and use brackets instead. 🐱


---
_Generated by [Claude Code](https://claude.ai/code/session_01TP4Ak86CNvR1k3PuyZoUPT)_