### PR TITLE
fix(build): publish hey-api-plugin releases to kestra-io/hey-api-plugin

### DIFF
--- a/.github/workflows/publish-hey-api-plugin.yml
+++ b/.github/workflows/publish-hey-api-plugin.yml
@@ -5,6 +5,13 @@ name: Release hey-api-plugin
 # external client-sdk repo consumes it, and it does so via the release .tgz URL (see client-sdk's
 # package.json). Keeping it off npm avoids a public package while still sharing one source of truth.
 #
+# The release itself is published to kestra-io/hey-api-plugin, NOT this repo: kestra-io/kestra's tag
+# ruleset only allows vX.Y.Z release tags for actual product releases, and this repo's Releases page
+# is watched by clients and the website for "latest release per branch" — a hey-api-plugin-vX.Y.Z tag
+# here would either violate that ruleset or pollute that page. kestra-io/hey-api-plugin has no source
+# of its own; it exists solely to host these tarballs. Publishing there needs a token with
+# contents:write on that repo specifically — see the HEY_API_PLUGIN_RELEASE_TOKEN secret below.
+#
 # The released version is whatever is in ui/packages/hey-api-plugin/package.json — bump that in a
 # normal commit first, then dispatch this workflow. It fails if the tag already exists (bump first).
 on:
@@ -20,7 +27,7 @@ on:
         default: "false"
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   release:
@@ -58,10 +65,11 @@ jobs:
       - name: Create GitHub Release with the tarball
         working-directory: .
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.HEY_API_PLUGIN_RELEASE_TOKEN }}
         run: |
           version="${{ steps.version.outputs.value }}"
           tarball="ui/kestra-io-hey-api-plugin-${version}.tgz"
-          gh release create "hey-api-plugin-v${version}" "$tarball" \
+          gh release create "v${version}" "$tarball" \
+            --repo kestra-io/hey-api-plugin \
             --title "@kestra-io/hey-api-plugin v${version}" \
-            --notes "Shared Kestra SDK generator plugin + fetch runtime. Consumed by client-sdk via this release tarball; the OSS and EE UIs consume it as an npm workspace. Not published to npm."
+            --notes "Shared Kestra SDK generator plugin + fetch runtime, built from kestra-io/kestra's ui/packages/hey-api-plugin. Consumed by client-sdk via this release tarball; the OSS and EE UIs consume the same source directly as an npm workspace. Not published to npm."

--- a/.github/workflows/publish-hey-api-plugin.yml
+++ b/.github/workflows/publish-hey-api-plugin.yml
@@ -9,8 +9,8 @@ name: Release hey-api-plugin
 # ruleset only allows vX.Y.Z release tags for actual product releases, and this repo's Releases page
 # is watched by clients and the website for "latest release per branch" — a hey-api-plugin-vX.Y.Z tag
 # here would either violate that ruleset or pollute that page. kestra-io/hey-api-plugin has no source
-# of its own; it exists solely to host these tarballs. Publishing there needs a token with
-# contents:write on that repo specifically — see the HEY_API_PLUGIN_RELEASE_TOKEN secret below.
+# of its own; it exists solely to host these tarballs. Publishing there uses the same GH_BOT app
+# token pattern as the kestra-ee dispatch in pull-request.yml, scoped to just that one repo.
 #
 # The released version is whatever is in ui/packages/hey-api-plugin/package.json — bump that in a
 # normal commit first, then dispatch this workflow. It fails if the tag already exists (bump first).
@@ -62,10 +62,20 @@ jobs:
         # `npm pack --json`, whose stdout is polluted by the prepack build logs.
         run: npm pack --workspace @kestra-io/hey-api-plugin --pack-destination .
 
+      - name: Generate GitHub App token for hey-api-plugin release
+        id: hey-api-plugin-token
+        working-directory: .
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ secrets.GH_BOT_APP_ID }}
+          private-key: ${{ secrets.GH_BOT_PRIVATE_KEY }}
+          owner: kestra-io
+          repositories: hey-api-plugin
+
       - name: Create GitHub Release with the tarball
         working-directory: .
         env:
-          GH_TOKEN: ${{ secrets.HEY_API_PLUGIN_RELEASE_TOKEN }}
+          GH_TOKEN: ${{ steps.hey-api-plugin-token.outputs.token }}
         run: |
           version="${{ steps.version.outputs.value }}"
           tarball="ui/kestra-io-hey-api-plugin-${version}.tgz"


### PR DESCRIPTION
### ✨ Description

Follow-up to #17588. That PR fixed a `jq` parsing bug in the *Release hey-api-plugin* workflow, but re-dispatching it from `develop` surfaced a second, separate failure:

```
HTTP 422: Validation Failed
pre_receive Repository rule violations found
Cannot create ref due to creations being restricted.
Published releases must have a valid tag
```

`kestra-io/kestra` has a tag-creation ruleset that only allows `vX.Y.Z`-style semver tags (matching the existing product releases: `v1.0.52`, `v1.3.29`, `v0.22.46`, ...). The workflow's `hey-api-plugin-v0.1.0` tag doesn't match that pattern, so ref creation is rejected. Getting a ruleset exception for this pattern isn't the right fix either: this repo's Releases page is watched by clients and the website to determine the "latest release per branch" — even a rule-compliant hey-api-plugin tag would pollute that page.

Fix: publish the release to a new, dedicated repo — [kestra-io/hey-api-plugin](https://github.com/kestra-io/hey-api-plugin) — that exists solely to host these tarballs and has no such ruleset. The plugin source and build stay in this repo (`ui/packages/hey-api-plugin`) as the single source of truth; only the publish *destination* changes. Since the tag no longer needs to avoid colliding with this repo's product-release tags, it's back to a plain `v${version}`.

To authenticate the cross-repo release creation, this reuses the same pattern `pull-request.yml` already uses to dispatch to `kestra-ee`: `actions/create-github-app-token` mints a short-lived installation token from the org's existing `GH_BOT` app (`GH_BOT_APP_ID`/`GH_BOT_PRIVATE_KEY`), scoped via `repositories: hey-api-plugin` to just that one repo. No new secret needed.

### 🔗 Related Issue

Unblocks kestra-io/client-sdk#359 (via kestra-io/client-sdk#362). Follow-up to #17588.

### 🛠️ Backend Checklist

- [x] Code compiles successfully and passes all checks (workflow YAML change only)
- [ ] N/A — no application code touched, CI-only fix

### 📝 Additional Notes

**One prerequisite before this can run successfully**: the `GH_BOT` GitHub App needs repository access to `kestra-io/hey-api-plugin` (org Settings → GitHub Apps → GH_BOT → Repository access → add `hey-api-plugin`). If the app is already set to "All repositories" for the org, this is a no-op. I don't have permission to check or change GitHub App installation settings myself, so this needs a human with org admin access to confirm/add.

Also note: `permissions.contents` dropped from `write` to `read` at the workflow level, since this workflow no longer creates a ref/release on this repo — only on the (separately authenticated) target repo.

### 🤖 AI Authors

Why did the release tag go to therapy? It had a serious case of ref-erential restriction anxiety about which repo it belonged in — turns out it just needed the right passport (a scoped GH_BOT token), not a whole new visa (a new secret). 🐱
