### PR TITLE
fix(build): drop invalid working-directory on the app-token action step

### DIFF
--- a/.github/workflows/publish-hey-api-plugin.yml
+++ b/.github/workflows/publish-hey-api-plugin.yml
@@ -64,7 +64,6 @@ jobs:
 
       - name: Generate GitHub App token for hey-api-plugin release
         id: hey-api-plugin-token
-        working-directory: .
         uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ secrets.GH_BOT_APP_ID }}


### PR DESCRIPTION
### ✨ Description

Follow-up to #17590, which merged with a workflow schema bug I introduced: the new "Generate GitHub App token" step had both `working-directory: .` and `uses:`/`with:`. `working-directory` is only valid on `run:` steps; combined with an action-call step it fails GitHub's workflow schema validation and blocks *any* dispatch of the workflow:

```
422 Invalid Argument - failed to parse workflow:
(Line: 68, Col: 9): Unexpected value 'uses'
(Line: 69, Col: 9): Unexpected value 'with'
(Line: 65, Col: 9): Required property is missing: run
```

Caught this immediately on re-dispatch after #17590 merged. Fix: drop the stray `working-directory: .` line — it wasn't doing anything useful there anyway (the step doesn't touch the filesystem, it just calls the GitHub API).

### 🔗 Related Issue

Follow-up to #17590. Unblocks kestra-io/client-sdk#359.

### 🛠️ Backend Checklist

- [x] Code compiles successfully and passes all checks (workflow YAML change only; validated with `python3 -c "import yaml; yaml.safe_load(...)"` and re-read against GitHub's step schema rules)
- [ ] N/A — no application code touched, CI-only fix

### 🤖 AI Authors

The GH_BOT token step wanted a passport AND a hotel room reservation at the same time — GitHub's schema said pick one, so it's keeping the passport. 🐱


---
_Generated by [Claude Code](https://claude.ai/code/session_01TP4Ak86CNvR1k3PuyZoUPT)_