### PR TITLE
refactor(core): use global $t in templates instead of composition t

### DIFF
--- a/ui/packages/design-system/src/components/Data/KsEmpty.vue
+++ b/ui/packages/design-system/src/components/Data/KsEmpty.vue
@@ -6,7 +6,7 @@
         <template #description>
             <slot name="description">
                 <!-- eslint-disable-next-line vue/no-v-html -->
-                <span v-html="description ?? t('no_data').replaceAll('\n', '<br >')" />
+                <span v-html="description ?? $t('no_data').replaceAll('\n', '<br >')" />
             </slot>
         </template>
         <template v-if="$slots.image" #image>
@@ -17,7 +17,6 @@
 
 <script setup lang="ts">
     import {ElEmpty} from "element-plus"
-    import {useI18n} from "vue-i18n"
     import {useFilteredProps} from "../../utils/filteredProps"
     import noDataImage from "../../assets/images/no-data.png"
 
@@ -43,7 +42,6 @@
 
     const filteredProps = useFilteredProps(props, slots.image ? ["image", "description", "background"] : ["description", "background"])
 
-    const {t} = useI18n({useScope: "global"})
 </script>
 
 <style lang="scss">

--- a/ui/packages/design-system/src/components/Data/KsEmptyState.vue
+++ b/ui/packages/design-system/src/components/Data/KsEmptyState.vue
@@ -23,7 +23,7 @@
                     target="_blank"
                     :href="video"
                 >
-                    {{ t("ks_empty_state.watch_the_video") }}
+                    {{ $t("ks_empty_state.watch_the_video") }}
                 </KsButton>
             </div>
 
@@ -34,7 +34,7 @@
                 target="_blank"
                 rel="noopener"
             >
-                {{ t("ks_empty_state.learn_more") }}
+                {{ $t("ks_empty_state.learn_more") }}
                 <ArrowTopRight :size="14" />
             </a>
         </div>
@@ -43,7 +43,6 @@
 
 <script setup lang="ts">
     import {useNetwork} from "@vueuse/core"
-    import {useI18n} from "vue-i18n"
     import ArrowTopRight from "vue-material-design-icons/ArrowTopRight.vue"
     import KsButton from "../Basic/KsButton/KsButton.vue"
 
@@ -62,7 +61,6 @@
     }>()
 
     const {isOnline} = useNetwork()
-    const {t} = useI18n({useScope: "global"})
 </script>
 
 <style lang="scss" scoped>

--- a/ui/packages/design-system/src/components/Data/KsJsonTree.vue
+++ b/ui/packages/design-system/src/components/Data/KsJsonTree.vue
@@ -6,7 +6,7 @@
                 type="button"
                 class="toggle"
                 :aria-expanded="expanded"
-                :aria-label="expanded ? t('collapse') : t('expand')"
+                :aria-label="expanded ? $t('collapse') : $t('expand')"
                 @click="expanded = !expanded"
             >
                 <KsIcon size="s" class="chevron" :class="{collapsed: !expanded}"><ChevronDown /></KsIcon>
@@ -42,7 +42,6 @@
 
 <script setup lang="ts">
     import {computed, ref, watch, onMounted, onBeforeUnmount} from "vue"
-    import {useI18n} from "vue-i18n"
     import ChevronDown from "vue-material-design-icons/ChevronDown.vue"
 
     const props = withDefaults(defineProps<{
@@ -52,7 +51,6 @@
         defaultExpanded?: boolean,
     }>(), {depth: 0})
 
-    const {t} = useI18n()
 
     const expanded = ref(props.defaultExpanded ?? props.depth < 1)
 

--- a/ui/packages/design-system/src/components/Data/KsNoData.vue
+++ b/ui/packages/design-system/src/components/Data/KsNoData.vue
@@ -1,20 +1,19 @@
 <template>
     <div class="empty-state">
         <component :is="icon ?? FilterRemoveOutlineIcon" class="empty-icon" />
-        <strong>{{ title ?? t("ks_no_data.no_results") }}</strong>
+        <strong>{{ title ?? $t("ks_no_data.no_results") }}</strong>
         <p v-if="$slots.default"><slot /></p>
         <!-- eslint-disable-next-line vue/no-v-html -->
         <p v-else-if="description" v-html="description" />
         <template v-else>
-            <p>{{ t("ks_no_data.nothing_here") }}</p>
-            <p>{{ t("ks_no_data.will_appear") }}</p>
+            <p>{{ $t("ks_no_data.nothing_here") }}</p>
+            <p>{{ $t("ks_no_data.will_appear") }}</p>
         </template>
     </div>
 </template>
 
 <script setup lang="ts">
     import type {Component} from "vue"
-    import {useI18n} from "vue-i18n"
     import FilterRemoveOutlineIcon from "vue-material-design-icons/FilterRemoveOutline.vue"
 
     defineProps<{
@@ -23,7 +22,6 @@
         icon?: Component
     }>()
 
-    const {t} = useI18n({useScope: "global"})
 </script>
 
 <style scoped lang="scss">

--- a/ui/packages/design-system/src/components/Form/KsPasswordRequirements.vue
+++ b/ui/packages/design-system/src/components/Form/KsPasswordRequirements.vue
@@ -5,14 +5,13 @@
             :key="rule.key"
             class="ks-password-requirements__item"
         >
-            <KsCheckItem :met="rule.met">{{ rule.label ?? t(`password_requirements.${rule.key}`) }}</KsCheckItem>
+            <KsCheckItem :met="rule.met">{{ rule.label ?? $t(`password_requirements.${rule.key}`) }}</KsCheckItem>
         </li>
     </ul>
 </template>
 
 <script setup lang="ts">
     import {computed, watch} from "vue"
-    import {useI18n} from "vue-i18n"
     import KsCheckItem from "../Data/KsCheckItem.vue"
 
     export type PasswordRule = {
@@ -39,7 +38,6 @@
         (e: "update:valid", valid: boolean): void
     }>()
 
-    const {t} = useI18n({useScope: "global"})
 
     const computedRules = computed(() =>
         (props.rules ?? DEFAULT_RULES).map((rule) => ({...rule, met: rule.test(props.password)})),

--- a/ui/packages/design-system/src/components/Navigation/KsTopNavBar/KsTopNavBar.vue
+++ b/ui/packages/design-system/src/components/Navigation/KsTopNavBar/KsTopNavBar.vue
@@ -4,7 +4,7 @@
             v-if="sidebarCollapsed"
             class="icon-btn"
             data-testid="topnav-sidebar-toggle"
-            :ariaLabel="t('topnav_sidebar_toggle')"
+            :ariaLabel="$t('topnav_sidebar_toggle')"
             @click="$emit('sidebar-toggle')"
         >
             <Menu />
@@ -29,7 +29,7 @@
                     v-if="!hideBookmark"
                     class="icon-btn star"
                     :class="{active: isBookmarked}"
-                    :ariaLabel="t('topnav_bookmark')"
+                    :ariaLabel="$t('topnav_bookmark')"
                     @click="$emit('star-click')"
                 >
                     <component :is="isBookmarked ? StarIcon : StarOutlineIcon" />
@@ -62,7 +62,7 @@
                 v-if="showDockToggle"
                 class="icon-btn dock-toggle"
                 :class="{'is-open': isDockOpen}"
-                :ariaLabel="t('topnav_dock_toggle')"
+                :ariaLabel="$t('topnav_dock_toggle')"
                 @click="$emit('dock-toggle')"
             >
                 <DockRight />
@@ -73,7 +73,6 @@
 
 <script setup lang="ts">
     import {type Component} from "vue"
-    import {useI18n} from "vue-i18n"
     import Menu from "vue-material-design-icons/Menu.vue"
     import StarOutlineIcon from "vue-material-design-icons/StarOutline.vue"
     import StarIcon from "vue-material-design-icons/Star.vue"
@@ -124,7 +123,6 @@
         "panel-toggle"?(): unknown
     }>()
 
-    const {t} = useI18n({useScope: "global"})
 </script>
 
 <style scoped lang="scss">

--- a/ui/packages/topology/src/nodes/NodeMenu.vue
+++ b/ui/packages/topology/src/nodes/NodeMenu.vue
@@ -15,8 +15,8 @@
     </KsIconButton>
 
     <KsDropdown v-else-if="actions.length > 1" trigger="click" placement="right-start" @click.stop>
-        <KsIconButton :aria-label="t('more actions')" class="node-action-button">
-            <DotsVertical :alt="t('more actions')" />
+        <KsIconButton :aria-label="$t('more actions')" class="node-action-button">
+            <DotsVertical :alt="$t('more actions')" />
         </KsIconButton>
         <template #dropdown>
             <KsDropdownMenu>
@@ -36,7 +36,6 @@
 </template>
 
 <script setup lang="ts">
-    import {useI18n} from "vue-i18n"
     import {KsIconButton, KsDropdown, KsDropdownMenu, KsDropdownItem} from "@kestra-io/design-system"
     import DotsVertical from "vue-material-design-icons/DotsVertical.vue"
 
@@ -54,7 +53,6 @@
 
     defineProps<{actions: NodeAction[]}>()
 
-    const {t} = useI18n()
 </script>
 
 <style scoped lang="scss">

--- a/ui/src/components/PwaInstallPrompt.vue
+++ b/ui/src/components/PwaInstallPrompt.vue
@@ -2,20 +2,20 @@
     <KsAlert
         v-if="visible"
         type="info"
-        :title="t('pwa.install_title')"
+        :title="$t('pwa.install_title')"
         closable
         class="pwa-install-prompt"
         @close="dismiss"
     >
         <p class="pwa-install-description">
-            {{ t("pwa.install_description") }}
+            {{ $t("pwa.install_description") }}
         </p>
         <div class="pwa-install-actions">
             <KsButton type="primary" size="small" @click="install">
-                {{ t("pwa.install") }}
+                {{ $t("pwa.install") }}
             </KsButton>
             <KsButton text size="small" @click="dismiss">
-                {{ t("pwa.dismiss") }}
+                {{ $t("pwa.dismiss") }}
             </KsButton>
         </div>
     </KsAlert>
@@ -23,10 +23,8 @@
 
 <script setup lang="ts">
     import {computed} from "vue"
-    import {useI18n} from "vue-i18n"
     import {usePwaInstall} from "../composables/usePwaInstall"
 
-    const {t} = useI18n({useScope: "global"})
     const {canInstall, promptInstall, dismiss, dismissed} = usePwaInstall()
 
     const visible = computed(() => canInstall.value && !dismissed.value)

--- a/ui/src/components/admin/McpServer.vue
+++ b/ui/src/components/admin/McpServer.vue
@@ -2,7 +2,7 @@
     <TopNavBar :title="details.title" :breadcrumb="details.breadcrumb">
         <template v-if="showCreateToolFlow" #actions>
             <KsButton type="primary" :icon="Plus" @click="createToolFlow">
-                {{ t("mcp.tools.create_tool_flow") }}
+                {{ $t("mcp.tools.create_tool_flow") }}
             </KsButton>
         </template>
     </TopNavBar>
@@ -12,7 +12,6 @@
 <script lang="ts" setup>
     import {computed, watch, onMounted} from "vue"
     import {useRoute, useRouter} from "vue-router"
-    import {useI18n} from "vue-i18n"
     import Plus from "vue-material-design-icons/Plus.vue"
     import TopNavBar from "../layout/TopNavBar.vue"
     import Tabs from "../Tabs.vue"
@@ -22,7 +21,6 @@
     import {useToolFlowCreation} from "./mcp/useToolFlowCreation"
     import useRouteContext from "../../composables/useRouteContext"
 
-    const {t} = useI18n({useScope: "global"})
     const route = useRoute()
     const router = useRouter()
     const mcpStore = useMcpStore()

--- a/ui/src/components/dashboard/sections/Pie.vue
+++ b/ui/src/components/dashboard/sections/Pie.vue
@@ -14,7 +14,7 @@
             />
             <div class="pie-center-label">
                 <div class="pie-center-label__total">{{ totalValue }}</div>
-                <div v-if="showSuccessRatio" class="pie-center-label__success">{{ successRatio }}% {{ t("success") }}</div>
+                <div v-if="showSuccessRatio" class="pie-center-label__success">{{ successRatio }}% {{ $t("success") }}</div>
             </div>
         </div>
         <KsNoData v-else class="empty" />
@@ -32,7 +32,6 @@
 <script setup lang="ts">
     import {computed, ref, watch} from "vue"
     import {useRoute} from "vue-router"
-    import {useI18n} from "vue-i18n"
 
     import moment from "moment"
     import {KsPie, ChartFeature, TooltipType, durationUtils, type KsChartSeriesItem} from "@kestra-io/design-system"
@@ -57,7 +56,6 @@
     })
 
     const route = useRoute()
-    const {t} = useI18n()
 
     const {drillDown} = useChartDrillDown(props.chart)
 

--- a/ui/src/components/dashboard/sections/TableQuickFilter.vue
+++ b/ui/src/components/dashboard/sections/TableQuickFilter.vue
@@ -9,7 +9,7 @@
                 :style="{'--tab-color': `var(${tab.token})`}"
                 @click="selectTab(tab.key)"
             >
-                {{ t(`dashboards.quick_filters.${tab.key}`) }}
+                {{ $t(`dashboards.quick_filters.${tab.key}`) }}
                 <Motion
                     v-if="activeTab === tab.key"
                     as="span"
@@ -24,7 +24,6 @@
 
 <script setup lang="ts">
     import {computed, ref} from "vue"
-    import {useI18n} from "vue-i18n"
 
     import {Motion} from "motion-v"
     import {QueryFilter} from "@kestra-io/kestra-sdk"
@@ -41,7 +40,6 @@
 
     const emit = defineEmits<{change: [filter: QueryFilter | null, tab: QuickFilterTabKey]}>()
 
-    const {t} = useI18n({useScope: "global"})
 
     const hasQuickFilters = computed(() => chartHasQuickFilters(props.chart))
 

--- a/ui/src/components/executions/ExecutionActions.vue
+++ b/ui/src/components/executions/ExecutionActions.vue
@@ -2,7 +2,7 @@
     <KsDropdown trigger="click" placement="bottom-end" :persistent="true">
         <KsButton link data-onboarding-target="execution-actions-menu">
             <KsIcon><DotsVertical /></KsIcon>
-            <span class="d-none d-lg-inline-block">{{ t("actions") }}</span>
+            <span class="d-none d-lg-inline-block">{{ $t("actions") }}</span>
         </KsButton>
         <template #dropdown>
             <KsDropdownMenu>
@@ -21,7 +21,6 @@
 
 <script setup lang="ts">
     import {provide, type Component} from "vue"
-    import {useI18n} from "vue-i18n"
     import DotsVertical from "vue-material-design-icons/DotsVertical.vue"
     import {asItemKey} from "../layout/navBarActionsContext"
     import type {Execution} from "../../stores/executions"
@@ -37,7 +36,6 @@
         execution: Execution;
     }>()
 
-    const {t} = useI18n({useScope: "global"})
 
     provide(asItemKey, true)
 </script>

--- a/ui/src/components/executions/TaskRunLine.vue
+++ b/ui/src/components/executions/TaskRunLine.vue
@@ -31,14 +31,14 @@
         >
             <KsTooltip>
                 <template #content>
-                    {{ t("from") }} :
+                    {{ $t("from") }} :
                     {{ dateFilter(selectedAttempt(currentTaskRun).state.startDate) }}
                     <br>
-                    {{ t("to") }} :
+                    {{ $t("to") }} :
                     {{ dateFilter(selectedAttempt(currentTaskRun).state.endDate) }}
                     <br>
                     <Clock />
-                    <strong>{{ t("duration") }}:</strong>
+                    <strong>{{ $t("duration") }}:</strong>
                     {{ humanizeDuration(selectedAttempt(currentTaskRun).state.duration) }}
                 </template>
                 <span>
@@ -61,7 +61,7 @@
                 size="small"
                 :status="currentTaskRun.state.current"
                 clickable
-                :aria-label="t('filter by status', {status: currentTaskRun.state.current})"
+                :aria-label="$t('filter by status', {status: currentTaskRun.state.current})"
                 @click.stop="navigateToStateFilter(currentTaskRun.state.current)"
             />
         </div>
@@ -87,13 +87,13 @@
             :disabled="!currentTaskRun.attempts || currentTaskRun.attempts?.length <= 1"
         >
             <template #label="{value}">
-                {{ `${t('attempt')} ${(value ?? 0) + 1}/${attempts(currentTaskRun).length}` }}
+                {{ `${$t('attempt')} ${(value ?? 0) + 1}/${attempts(currentTaskRun).length}` }}
             </template>
             <KsOption
                 v-for="(_, index) in attempts(currentTaskRun)"
                 :key="`attempt-${index}-${currentTaskRun.id}`"
                 :value="index"
-                :label="`${t('attempt')} ${index + 1}`"
+                :label="`${$t('attempt')} ${index + 1}`"
             />
         </KsSelect>
 
@@ -111,7 +111,6 @@
 
 <script setup lang="ts">
     import {computed} from "vue"
-    import {useI18n} from "vue-i18n"
     import {State, KsExecutionStatus} from "@kestra-io/design-system"
     import TaskIcon from "../plugins/TaskIcon.vue"
     import TaskRunActions from "./TaskRunActions.vue"
@@ -125,7 +124,6 @@
     import {usePluginsStore} from "../../stores/plugins"
     import {date as dateFilter, humanizeDuration} from "../../utils/filters"
 
-    const {t} = useI18n()
     const pluginsStore = usePluginsStore()
     const {navigateToStateFilter} = useStateFilter()
 

--- a/ui/src/components/executions/overview/components/RunTimeline.vue
+++ b/ui/src/components/executions/overview/components/RunTimeline.vue
@@ -14,14 +14,14 @@
                 :icon="ArrowExpand"
                 link
             >
-                {{ t("see timeline") }}
+                {{ $t("see timeline") }}
             </KsButton>
         </template>
 
         <div class="run-timeline">
             <div class="run-timeline__header">
-                <span class="run-timeline__title">{{ t("run timeline") }}</span>
-                <KsIconButton :tooltip="t('close')" placement="top" @click="visible = false">
+                <span class="run-timeline__title">{{ $t("run timeline") }}</span>
+                <KsIconButton :tooltip="$t('close')" placement="top" @click="visible = false">
                     <Close />
                 </KsIconButton>
             </div>
@@ -43,7 +43,6 @@
 
 <script setup lang="ts">
     import {ref} from "vue"
-    import {useI18n} from "vue-i18n"
 
     import moment from "moment"
     import {KsExecutionStatus} from "@kestra-io/design-system"
@@ -55,7 +54,6 @@
 
     defineProps<{histories: Histories[]}>()
 
-    const {t} = useI18n({useScope: "global"})
 
     const POPPER_STYLE = {
         padding: "0",

--- a/ui/src/components/flows/BackfillBanner.vue
+++ b/ui/src/components/flows/BackfillBanner.vue
@@ -17,7 +17,7 @@
                 v-if="!row.backfill.paused"
                 data-test="backfill-pause"
                 size="small"
-                :tooltip="t('pause backfill')"
+                :tooltip="$t('pause backfill')"
                 @click="emit('pause')"
             >
                 <Pause />
@@ -26,7 +26,7 @@
                 v-else
                 data-test="backfill-resume"
                 size="small"
-                :tooltip="t('continue backfill')"
+                :tooltip="$t('continue backfill')"
                 @click="emit('resume')"
             >
                 <Play />
@@ -34,7 +34,7 @@
             <KsIconButton
                 data-test="backfill-stop"
                 size="small"
-                :tooltip="t('delete backfill')"
+                :tooltip="$t('delete backfill')"
                 class="bf-stop"
                 @click="emit('stop')"
             >
@@ -47,7 +47,6 @@
 <script setup lang="ts">
     import moment from "moment"
     import {computed} from "vue"
-    import {useI18n} from "vue-i18n"
 
     import Play from "vue-material-design-icons/Play.vue"
     import Pause from "vue-material-design-icons/Pause.vue"
@@ -55,7 +54,6 @@
 
     import {dateUtils, KsIconButton, KsProgress} from "@kestra-io/design-system"
 
-    const {t} = useI18n()
 
     const props = defineProps<{
         row: {

--- a/ui/src/components/flows/SourceSearchPreview.vue
+++ b/ui/src/components/flows/SourceSearchPreview.vue
@@ -1,7 +1,7 @@
 <template>
     <div class="source-search-preview" data-test="source-search-preview">
         <div v-if="!props.selected" class="source-search-preview__empty">
-            <KsNoData :title="t('source_search.preview_empty')" />
+            <KsNoData :title="$t('source_search.preview_empty')" />
         </div>
 
         <div v-else-if="isLoading" class="source-search-preview__loading" v-ks-loading="true" />
@@ -9,7 +9,7 @@
         <KsAlert
             v-else-if="error"
             type="error"
-            :title="t('source_search.preview_error')"
+            :title="$t('source_search.preview_error')"
             class="source-search-preview__error"
         />
 
@@ -29,7 +29,6 @@
 
 <script setup lang="ts">
     import {ref, computed, watch} from "vue"
-    import {useI18n} from "vue-i18n"
     import {KsEditor} from "@kestra-io/design-system"
     import {useFlowStore} from "../../stores/flow"
     import type {KsEditorExposes} from "@kestra-io/design-system"
@@ -39,7 +38,6 @@
         query: string
     }>()
 
-    const {t} = useI18n()
     const flowStore = useFlowStore()
 
     const isLoading = ref(false)

--- a/ui/src/components/flows/SourceSearchResults.vue
+++ b/ui/src/components/flows/SourceSearchResults.vue
@@ -21,7 +21,7 @@
                     >
                         <span class="result-group-namespace">{{ item.model.namespace }}.</span>
                         <span class="result-group-id">{{ item.model.id }}</span>
-                        <span class="result-group-count">{{ t("source_search.match_count", {count: item.fragments.length}) }}</span>
+                        <span class="result-group-count">{{ $t("source_search.match_count", {count: item.fragments.length}) }}</span>
                     </span>
                 </template>
 
@@ -47,7 +47,7 @@
                             class="open-flow-link"
                             data-test="source-search-open-link"
                         >
-                            {{ t("source_search.open_flow") }}
+                            {{ $t("source_search.open_flow") }}
                             <KsIcon size="xs"><ArrowRight /></KsIcon>
                         </router-link>
                     </div>
@@ -59,7 +59,6 @@
 
 <script setup lang="ts">
     import {ref, watch} from "vue"
-    import {useI18n} from "vue-i18n"
     import _escape from "lodash/escape"
     import ArrowRight from "vue-material-design-icons/ArrowRight.vue"
 
@@ -72,7 +71,6 @@
         (e: "select", value: {namespace: string; id: string; matchIndex: number}): void
     }>()
 
-    const {t} = useI18n()
 
     const expanded = ref<string[]>([])
 

--- a/ui/src/components/layout/Environment.vue
+++ b/ui/src/components/layout/Environment.vue
@@ -2,7 +2,7 @@
     <div v-if="name" id="environment">
         <span class="dot" />
         <span class="name" :title="name">{{ name }}</span>
-        <span class="label">{{ t("environment") }}</span>
+        <span class="label">{{ $t("environment") }}</span>
     </div>
 </template>
 
@@ -11,9 +11,7 @@
     import {useLayoutStore} from "../../stores/layout"
     import {useMiscStore} from "override/stores/misc"
     import {computed} from "vue"
-    import {useI18n} from "vue-i18n"
 
-    const {t} = useI18n()
     const layoutStore = useLayoutStore()
     const miscStore = useMiscStore()
 

--- a/ui/src/components/logs/LogLine.vue
+++ b/ui/src/components/logs/LogLine.vue
@@ -14,7 +14,7 @@
             :style="{color: `var(--ks-log-${levelLower})`}"
             :role="clickableLevel ? 'button' : undefined"
             :tabindex="clickableLevel ? 0 : undefined"
-            :title="clickableLevel ? t('filter_for') : undefined"
+            :title="clickableLevel ? $t('filter_for') : undefined"
             @click="clickableLevel && props.log.level && emit('filter-level', props.log.level)"
             @keydown.enter="clickableLevel && props.log.level && emit('filter-level', props.log.level)"
             @keydown.space.prevent="clickableLevel && props.log.level && emit('filter-level', props.log.level)"
@@ -58,10 +58,8 @@
     import {logsFontSize, logsDensity, logsBodyClamp, logsPrettyJson, logsExpandByDefault, DENSITY_PADDING} from "../../composables/useLogDisplay"
     import {Log} from "../../stores/logs"
     import {useRouter} from "vue-router"
-    import {useI18n} from "vue-i18n"
     import * as Filters from "../../utils/filters"
 
-    const {t} = useI18n()
 
     // Props
     const props = defineProps<{

--- a/ui/src/components/logs/LogValueActions.vue
+++ b/ui/src/components/logs/LogValueActions.vue
@@ -16,19 +16,19 @@
             <div class="log-value-menu">
                 <button v-if="filterable" type="button" class="log-value-action" @click="apply(false)">
                     <MagnifyPlusOutline :size="16" />
-                    <span>{{ t("filter_for") }}</span>
+                    <span>{{ $t("filter_for") }}</span>
                 </button>
                 <button v-if="filterable" type="button" class="log-value-action" @click="apply(true)">
                     <MagnifyMinusOutline :size="16" />
-                    <span>{{ t("filter_out") }}</span>
+                    <span>{{ $t("filter_out") }}</span>
                 </button>
                 <button type="button" class="log-value-action" @click="copyValue">
                     <ContentCopy :size="16" />
-                    <span>{{ t("copy_value") }}</span>
+                    <span>{{ $t("copy_value") }}</span>
                 </button>
                 <router-link v-if="to" :to="to" class="log-value-action" @click="open = false">
                     <OpenInNew :size="16" />
-                    <span>{{ t("open_page") }}</span>
+                    <span>{{ $t("open_page") }}</span>
                 </router-link>
             </div>
         </template>
@@ -37,7 +37,6 @@
 
 <script setup lang="ts">
     import {ref} from "vue"
-    import {useI18n} from "vue-i18n"
     import MagnifyPlusOutline from "vue-material-design-icons/MagnifyPlusOutline.vue"
     import MagnifyMinusOutline from "vue-material-design-icons/MagnifyMinusOutline.vue"
     import ContentCopy from "vue-material-design-icons/ContentCopy.vue"
@@ -55,7 +54,6 @@
         filter: [{field: string, value: string, negate: boolean}]
     }>()
 
-    const {t} = useI18n()
     const open = ref(false)
 
     const apply = (negate: boolean) => {

--- a/ui/src/components/namespaces/components/NamespaceFilesEmpty.vue
+++ b/ui/src/components/namespaces/components/NamespaceFilesEmpty.vue
@@ -1,18 +1,18 @@
 <template>
     <div class="namespace-files-empty">
         <KsEmptyState
-            :title="t('empty.namespaceFiles.title')"
+            :title="$t('empty.namespaceFiles.title')"
             :image="artwork"
             :video="namespaceFilesLinks?.video"
             :learnMore="namespaceFilesLinks?.learnMore"
         >
             <template #description>
-                {{ t("empty.namespaceFiles.content") }}
+                {{ $t("empty.namespaceFiles.content") }}
                 <code class="namespace-files-empty-snippet">read('path/to/file')</code>
             </template>
             <template #action>
                 <KsButton type="primary" :icon="FilePlus" @click="emit('newFile')">
-                    {{ t("namespace files.new_file") }}
+                    {{ $t("namespace files.new_file") }}
                 </KsButton>
             </template>
         </KsEmptyState>
@@ -20,14 +20,12 @@
 </template>
 
 <script setup lang="ts">
-    import {useI18n} from "vue-i18n"
     import {KsButton, KsEmptyState} from "@kestra-io/design-system"
     import FilePlus from "vue-material-design-icons/FilePlus.vue"
 
     import artwork from "../../../assets/empty_visuals/generic.svg"
     import {links} from "../../layout/empty/links"
 
-    const {t} = useI18n()
 
     const namespaceFilesLinks = links.namespaceFiles
 


### PR DESCRIPTION
## What

Replace the vue-i18n composition `t()` with the globally-injected `$t()` in `<template>` sections, for components where `t` was used **only** in the template. The now-unused `const { t } = useI18n()` binding and its `import { useI18n } from "vue-i18n"` are removed.

## Why

`$t` is globally injected (`legacy: false`), so it's already available in every template and refers to the global scope. A `useI18n()` call + `t` binding that exists *only* to feed the template is pure boilerplate.

## Safety / scope of the change

The conversion is only applied when it is provably behavior-preserving:

- `t` comes from a **global-scope** `useI18n({ useScope: "global" })`, or a bare `useI18n()` in a file with **no local `<i18n>` messages** (every lookup falls through to the global scope — functionally identical to `$t`).
- `t` is **not** referenced anywhere in `<script>`.

Explicitly **excluded**:

- `useScope: "local"` components (`PluginCard.vue`, `KsBulkSelect.vue`) — there `t` ≠ `$t`.
- Any file that uses `t` in `<script>` — the `useI18n` import is kept unchanged.
- Templates where `t` appears as a non-call value (e.g. arrow-fn params like `.filter(t => …)`).

## Files

21 components (`ui/src` + `ui/packages/design-system` + `ui/packages/topology`).

## Verification

- `npm run check:types` — clean (no new errors; only pre-existing `TS2883` node_modules-portability noise remains).
- `eslint` on all changed files — clean.
- Independent bidirectional check: every changed file has no `t` in `<script>`, no bare `t(` left in `<template>`, no orphaned `useI18n` import; every retained `t` binding is genuinely used in `<script>`.
