### PR TITLE
[backport releases/v1.3.x] fix(plugins): revalidate plugin schemas so newly added plugins autocomplete (#12102)

### DIFF
--- a/core/src/main/java/io/kestra/core/docs/JsonSchemaCache.java
+++ b/core/src/main/java/io/kestra/core/docs/JsonSchemaCache.java
@@ -6,6 +6,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.atomic.AtomicLong;
 
 import io.kestra.core.models.dashboards.Dashboard;
 import io.kestra.core.models.flows.Flow;
@@ -13,6 +14,7 @@ import io.kestra.core.models.flows.PluginDefault;
 import io.kestra.core.models.tasks.Task;
 import io.kestra.core.models.templates.Template;
 import io.kestra.core.models.triggers.AbstractTrigger;
+import io.kestra.core.plugins.PluginRegistry;
 
 import jakarta.inject.Singleton;
 
@@ -23,19 +25,27 @@ import jakarta.inject.Singleton;
 public class JsonSchemaCache {
 
     private final JsonSchemaGenerator jsonSchemaGenerator;
+    private final PluginRegistry pluginRegistry;
 
     private final ConcurrentMap<CacheKey, Map<String, Object>> schemaCache = new ConcurrentHashMap<>();
     private final ConcurrentMap<SchemaType, Map<String, Object>> propertiesCache = new ConcurrentHashMap<>();
 
     private final Map<SchemaType, Class<?>> classesBySchemaType = new HashMap<>();
 
+    // Hash of the plugin registry the cached schemas were generated from. When the registry changes
+    // (a plugin is installed or removed at runtime) the cached schemas become stale and must be dropped,
+    // otherwise the editor keeps completing/validating against a schema missing the new plugin (#12102).
+    private final AtomicLong cachedRegistryHash = new AtomicLong(Long.MIN_VALUE);
+
     /**
      * Creates a new {@link JsonSchemaCache} instance.
      *
      * @param jsonSchemaGenerator The {@link JsonSchemaGenerator}.
+     * @param pluginRegistry      The {@link PluginRegistry} whose content the cached schemas depend on.
      */
-    public JsonSchemaCache(final JsonSchemaGenerator jsonSchemaGenerator) {
+    public JsonSchemaCache(final JsonSchemaGenerator jsonSchemaGenerator, final PluginRegistry pluginRegistry) {
         this.jsonSchemaGenerator = Objects.requireNonNull(jsonSchemaGenerator, "JsonSchemaGenerator cannot be null");
+        this.pluginRegistry = Objects.requireNonNull(pluginRegistry, "PluginRegistry cannot be null");
         registerClassForType(SchemaType.FLOW, Flow.class);
         registerClassForType(SchemaType.TEMPLATE, Template.class);
         registerClassForType(SchemaType.TASK, Task.class);
@@ -46,6 +56,7 @@ public class JsonSchemaCache {
 
     public Map<String, Object> getSchemaForType(final SchemaType type,
         final boolean arrayOf) {
+        invalidateIfPluginRegistryChanged();
         return schemaCache.computeIfAbsent(new CacheKey(type, arrayOf), key ->
         {
 
@@ -56,6 +67,7 @@ public class JsonSchemaCache {
     }
 
     public Map<String, Object> getPropertiesForType(final SchemaType type) {
+        invalidateIfPluginRegistryChanged();
         return propertiesCache.computeIfAbsent(type, key ->
         {
 
@@ -70,8 +82,21 @@ public class JsonSchemaCache {
         classesBySchemaType.put(type, clazz);
     }
 
+    /**
+     * Drops the cached schemas if the plugin registry changed since they were generated, so that a plugin
+     * added or removed at runtime is reflected on the next request.
+     */
+    private void invalidateIfPluginRegistryChanged() {
+        final long current = pluginRegistry.hash();
+        final long previous = cachedRegistryHash.get();
+        if (previous != current && cachedRegistryHash.compareAndSet(previous, current)) {
+            clear();
+        }
+    }
+
     public void clear() {
         schemaCache.clear();
+        propertiesCache.clear();
     }
 
     private record CacheKey(SchemaType type, boolean arrayOf) {

--- a/core/src/test/java/io/kestra/core/docs/JsonSchemaCacheTest.java
+++ b/core/src/test/java/io/kestra/core/docs/JsonSchemaCacheTest.java
@@ -1,0 +1,58 @@
+package io.kestra.core.docs;
+
+import java.util.Map;
+
+import io.kestra.core.plugins.PluginRegistry;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class JsonSchemaCacheTest {
+
+    @Test
+    void shouldServeFromCacheWhenPluginRegistryUnchanged() {
+        // Given
+        JsonSchemaGenerator generator = mock(JsonSchemaGenerator.class);
+        PluginRegistry registry = mock(PluginRegistry.class);
+        when(generator.schemas(any(), anyBoolean())).thenReturn(Map.of("version", "1"));
+        when(registry.hash()).thenReturn(1L);
+        JsonSchemaCache cache = new JsonSchemaCache(generator, registry);
+
+        // When
+        cache.getSchemaForType(SchemaType.FLOW, false);
+        cache.getSchemaForType(SchemaType.FLOW, false);
+
+        // Then: the schema is generated only once while the registry hash is stable
+        verify(generator, times(1)).schemas(any(), anyBoolean());
+    }
+
+    @Test
+    void shouldRebuildSchemaWhenPluginRegistryChanges() {
+        // Given: a registry whose content (hash) changes between calls, e.g. a plugin installed at runtime
+        JsonSchemaGenerator generator = mock(JsonSchemaGenerator.class);
+        PluginRegistry registry = mock(PluginRegistry.class);
+        when(generator.schemas(any(), anyBoolean()))
+            .thenReturn(Map.of("version", "1"))
+            .thenReturn(Map.of("version", "2"));
+        when(registry.hash()).thenReturn(1L, 1L, 2L);
+        JsonSchemaCache cache = new JsonSchemaCache(generator, registry);
+
+        // When
+        Map<String, Object> first = cache.getSchemaForType(SchemaType.FLOW, false);
+        Map<String, Object> cached = cache.getSchemaForType(SchemaType.FLOW, false);
+        Map<String, Object> afterChange = cache.getSchemaForType(SchemaType.FLOW, false);
+
+        // Then: unchanged hash serves the cached schema, changed hash regenerates it
+        assertThat(first).containsEntry("version", "1");
+        assertThat(cached).containsEntry("version", "1");
+        assertThat(afterChange).containsEntry("version", "2");
+        verify(generator, times(2)).schemas(any(), anyBoolean());
+    }
+}

--- a/webserver/src/main/java/io/kestra/webserver/controllers/api/PluginController.java
+++ b/webserver/src/main/java/io/kestra/webserver/controllers/api/PluginController.java
@@ -10,6 +10,7 @@ import io.kestra.core.models.flows.Input;
 import io.kestra.core.models.flows.Type;
 import io.kestra.core.models.tasks.FlowableTask;
 import io.kestra.core.plugins.PluginRegistry;
+import io.kestra.core.utils.VersionProvider;
 
 import io.micronaut.cache.annotation.Cacheable;
 import io.micronaut.core.annotation.NonNull;
@@ -19,6 +20,7 @@ import io.micronaut.http.HttpResponse;
 import io.micronaut.http.MutableHttpResponse;
 import io.micronaut.http.annotation.Controller;
 import io.micronaut.http.annotation.Get;
+import io.micronaut.http.annotation.Header;
 import io.micronaut.http.annotation.PathVariable;
 import io.micronaut.http.annotation.QueryValue;
 import io.micronaut.scheduling.TaskExecutors;
@@ -34,6 +36,10 @@ import static io.kestra.core.utils.Rethrow.throwFunction;
 @Controller("/api/v1/plugins/")
 public class PluginController {
     private static final String CACHE_DIRECTIVE = "public, max-age=3600";
+    // Plugin schemas depend on the set of installed plugins, which can change while the server runs.
+    // They must therefore be revalidated on every use (via ETag) instead of being cached blindly, otherwise
+    // the editor keeps validating/completing against a stale schema after a plugin is added or removed (#12102).
+    private static final String REVALIDATE_CACHE_DIRECTIVE = "no-cache";
 
     @Inject
     protected JsonSchemaGenerator jsonSchemaGenerator;
@@ -44,6 +50,9 @@ public class PluginController {
     @Inject
     protected JsonSchemaCache jsonSchemaCache;
 
+    @Inject
+    protected VersionProvider versionProvider;
+
     @Get(uri = "schemas/{type}")
     @ExecuteOn(TaskExecutors.IO)
     @Operation(
@@ -53,10 +62,15 @@ public class PluginController {
     )
     public HttpResponse<Map<String, Object>> getSchemasFromType(
         @Parameter(description = "The schema needed") @PathVariable SchemaType type,
-        @Parameter(description = "If schema should be an array of requested type") @Nullable @QueryValue(value = "arrayOf", defaultValue = "false") Boolean arrayOf) {
-        return HttpResponse.ok()
-            .body(jsonSchemaCache.getSchemaForType(type, arrayOf))
-            .header(HttpHeaders.CACHE_CONTROL, CACHE_DIRECTIVE);
+        @Parameter(description = "If schema should be an array of requested type") @Nullable @QueryValue(value = "arrayOf", defaultValue = "false") Boolean arrayOf,
+        @Parameter(hidden = true) @Nullable @Header(HttpHeaders.IF_NONE_MATCH) String ifNoneMatch) {
+        final String etag = schemaETag("schema", type, arrayOf);
+        if (etag.equals(ifNoneMatch)) {
+            return notModified(etag);
+        }
+        return HttpResponse.ok(jsonSchemaCache.getSchemaForType(type, arrayOf))
+            .header(HttpHeaders.ETAG, etag)
+            .header(HttpHeaders.CACHE_CONTROL, REVALIDATE_CACHE_DIRECTIVE);
     }
 
     @Get(uri = "properties/{type}")
@@ -67,10 +81,30 @@ public class PluginController {
         description = "The schema will be a [JSON Schema Draft 7](http://json-schema.org/draft-07/schema)"
     )
     public HttpResponse<Map<String, Object>> getPropertiesFromType(
-        @Parameter(description = "The schema needed") @PathVariable SchemaType type) {
-        return HttpResponse.ok()
-            .body(jsonSchemaCache.getPropertiesForType(type))
-            .header(HttpHeaders.CACHE_CONTROL, CACHE_DIRECTIVE);
+        @Parameter(description = "The schema needed") @PathVariable SchemaType type,
+        @Parameter(hidden = true) @Nullable @Header(HttpHeaders.IF_NONE_MATCH) String ifNoneMatch) {
+        final String etag = schemaETag("properties", type, false);
+        if (etag.equals(ifNoneMatch)) {
+            return notModified(etag);
+        }
+        return HttpResponse.ok(jsonSchemaCache.getPropertiesForType(type))
+            .header(HttpHeaders.ETAG, etag)
+            .header(HttpHeaders.CACHE_CONTROL, REVALIDATE_CACHE_DIRECTIVE);
+    }
+
+    /**
+     * Builds a strong ETag for a plugin schema response. The tag changes whenever the installed plugin
+     * set changes (via {@link PluginRegistry#hash()}) or the server version changes, so browsers holding a
+     * previously cached schema revalidate and receive the fresh one instead of a stale cached copy.
+     */
+    private String schemaETag(final String kind, final SchemaType type, final boolean arrayOf) {
+        return "\"" + kind + "-" + type + "-" + arrayOf + "-" + versionProvider.getVersion() + "-" + pluginRegistry.hash() + "\"";
+    }
+
+    private <T> HttpResponse<T> notModified(final String etag) {
+        return HttpResponse.<T>notModified()
+            .header(HttpHeaders.ETAG, etag)
+            .header(HttpHeaders.CACHE_CONTROL, REVALIDATE_CACHE_DIRECTIVE);
     }
 
     @Get(uri = "inputs")

--- a/webserver/src/test/java/io/kestra/webserver/controllers/api/PluginControllerTest.java
+++ b/webserver/src/test/java/io/kestra/webserver/controllers/api/PluginControllerTest.java
@@ -17,8 +17,12 @@ import io.kestra.plugin.core.debug.Return;
 import io.kestra.plugin.core.log.Log;
 
 import io.micronaut.core.type.Argument;
+import io.micronaut.http.HttpHeaders;
 import io.micronaut.http.HttpRequest;
+import io.micronaut.http.HttpResponse;
+import io.micronaut.http.HttpStatus;
 import io.micronaut.http.client.annotation.Client;
+import io.micronaut.http.client.exceptions.HttpClientResponseException;
 import io.micronaut.reactor.http.client.ReactorHttpClient;
 import jakarta.inject.Inject;
 
@@ -162,6 +166,33 @@ class PluginControllerTest {
         );
 
         assertThat(doc.get("$ref")).isEqualTo("#/definitions/io.kestra.core.models.flows.Flow");
+    }
+
+    @Test
+    void flowSchemaIsRevalidatedWithEtag() {
+        // The flow schema depends on the installed plugin set, which can change while the server runs, so it
+        // must be revalidated on every use (ETag) instead of being cached blindly for an hour — otherwise the
+        // editor keeps completing/validating against a stale schema after a plugin is added or removed (#12102).
+        HttpResponse<Map<String, Object>> response = client.toBlocking().exchange(
+            HttpRequest.GET(PATH + "/schemas/flow"),
+            Argument.mapOf(String.class, Object.class)
+        );
+
+        assertThat(response.getStatus().getCode()).isEqualTo(HttpStatus.OK.getCode());
+        assertThat(response.getHeaders().get(HttpHeaders.CACHE_CONTROL)).isEqualTo("no-cache");
+        String etag = response.getHeaders().get(HttpHeaders.ETAG);
+        assertThat(etag).isNotBlank();
+
+        // A conditional request carrying the current ETag is answered 304 Not Modified (no re-download).
+        HttpResponse<?> conditional;
+        try {
+            conditional = client.toBlocking().exchange(
+                HttpRequest.GET(PATH + "/schemas/flow").header(HttpHeaders.IF_NONE_MATCH, etag)
+            );
+        } catch (HttpClientResponseException e) {
+            conditional = e.getResponse();
+        }
+        assertThat(conditional.getStatus().getCode()).isEqualTo(HttpStatus.NOT_MODIFIED.getCode());
     }
 
     @Test


### PR DESCRIPTION
Backport of:
- kestra-io/kestra#17582 — fix(plugins): revalidate plugin schemas so newly added plugins autocomplete (#12102) (cherry-picked from `518b6926`)

Cherry-picked with `-x`. The release-branch `PluginController` lacks the develop-only plugin-search feature, so the controller change was applied manually to the slimmer release version (ETag/no-cache revalidation only); test imports (`HttpStatus`, `HttpResponse`, `HttpHeaders`, `HttpClientResponseException`) were added for the release-branch test file. OSS + EE `releases/v1.3.x` compile locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)