### PR TITLE
feat(core): add locked query filter and assetFailureBehavior task property

### DIFF
--- a/core/src/main/java/io/kestra/core/assets/AssetService.java
+++ b/core/src/main/java/io/kestra/core/assets/AssetService.java
@@ -1,11 +1,17 @@
 package io.kestra.core.assets;
 
 import java.util.List;
+import java.util.Optional;
+import java.util.function.Supplier;
 
 import io.kestra.core.exceptions.InternalException;
 import io.kestra.core.models.assets.Asset;
 import io.kestra.core.models.assets.AssetIdentifier;
 import io.kestra.core.models.assets.AssetUser;
+import io.kestra.core.models.executions.Execution;
+import io.kestra.core.models.executions.ExecutionKind;
+import io.kestra.core.models.executions.TaskRun;
+import io.kestra.core.models.flows.FlowWithSource;
 import io.kestra.core.queues.QueueException;
 
 import io.micronaut.context.annotation.Secondary;
@@ -21,6 +27,16 @@ public interface AssetService {
     void assetLineage(AssetUser assetUser, List<AssetIdentifier> inputs, List<AssetIdentifier> outputs) throws QueueException;
 
     void deleteAsset(Asset toDelete, AssetUser assetUser) throws QueueException;
+
+    /**
+     * Emits lineage for, then upserts (mark-and-continue: one asset's conflict must not stop the rest),
+     * a just-terminated taskRun's declared assets. If any upsert fails, escalates the taskRun's state
+     * per the owning task's {@code assetFailureBehavior}, clamped by {@code allowFailure}/{@code allowWarning}.
+     * The owning task is only resolved from {@code flow} once an upsert has actually failed.
+     *
+     * @return the escalated taskRun, or empty if its state is unchanged
+     */
+    Optional<TaskRun> processTaskRunAssets(AssetUser assetUser, TaskRun taskRun, Execution execution, Supplier<FlowWithSource> flow, ExecutionKind executionKind);
 
     @Singleton
     @Secondary
@@ -44,6 +60,12 @@ public interface AssetService {
         @Override
         public void deleteAsset(Asset toDelete, AssetUser assetUser) throws QueueException {
             // no-op
+        }
+
+        @Override
+        public Optional<TaskRun> processTaskRunAssets(AssetUser assetUser, TaskRun taskRun, Execution execution, Supplier<FlowWithSource> flow, ExecutionKind executionKind) {
+            // no-op
+            return Optional.empty();
         }
     }
 }

--- a/core/src/main/java/io/kestra/core/models/QueryFilter.java
+++ b/core/src/main/java/io/kestra/core/models/QueryFilter.java
@@ -700,7 +700,8 @@ public record QueryFilter(
                     Field.TYPE,
                     Field.NAMESPACE,
                     Field.METADATA,
-                    Field.UPDATED
+                    Field.UPDATED,
+                    Field.LOCKED
                 );
             }
         },

--- a/core/src/main/java/io/kestra/core/models/assets/AssetsDeclaration.java
+++ b/core/src/main/java/io/kestra/core/models/assets/AssetsDeclaration.java
@@ -6,7 +6,9 @@ import java.util.Optional;
 import com.fasterxml.jackson.annotation.JsonCreator;
 
 import io.kestra.core.models.property.Property;
+import io.kestra.core.models.tasks.AssetFailureBehavior;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 
 @Getter
@@ -15,18 +17,26 @@ public class AssetsDeclaration {
     private Property<List<AssetIdentifier>> inputs;
     private Property<List<Asset>> outputs;
 
+    @Schema(
+        title = "Asset failure behavior",
+        description = "Behavior applied to the task state when a declared asset fails to render, emit, or be persisted (e.g. a lock conflict): FAIL escalates it to FAILED, WARN (default) warns it if it would otherwise succeed, IGNORE leaves the state untouched."
+    )
+    private Property<AssetFailureBehavior> assetFailureBehavior;
+
     @JsonCreator
-    public AssetsDeclaration(Property<Boolean> enableAuto, Property<List<AssetIdentifier>> inputs, Property<List<Asset>> outputs) {
+    public AssetsDeclaration(Property<Boolean> enableAuto, Property<List<AssetIdentifier>> inputs, Property<List<Asset>> outputs, Property<AssetFailureBehavior> assetFailureBehavior) {
         this.enableAuto = Optional.ofNullable(enableAuto).orElse(Property.ofValue(false));
         this.inputs = inputs;
         this.outputs = outputs;
+        this.assetFailureBehavior = Optional.ofNullable(assetFailureBehavior).orElse(Property.ofValue(AssetFailureBehavior.WARN));
     }
 
     public AssetsDeclaration(boolean enableAuto, List<AssetIdentifier> inputs, List<Asset> outputs) {
         this(
             Property.ofValue(enableAuto),
             Property.ofValue(inputs),
-            Property.ofValue(outputs)
+            Property.ofValue(outputs),
+            null
         );
     }
 }

--- a/core/src/main/java/io/kestra/core/models/executions/TaskRunWithOutput.java
+++ b/core/src/main/java/io/kestra/core/models/executions/TaskRunWithOutput.java
@@ -6,5 +6,8 @@ import java.util.Map;
  * Utility class to hold a {@link TaskRun} and its outputs.
  * Must only be used as a temporary carrier for methods that must return both.
  */
-public record TaskRunWithOutput(TaskRun taskRun, Map<String, Object> outputs) {
+public record TaskRunWithOutput(TaskRun taskRun, Map<String, Object> outputs, boolean assetEmissionFailed) {
+    public TaskRunWithOutput(TaskRun taskRun, Map<String, Object> outputs) {
+        this(taskRun, outputs, false);
+    }
 }

--- a/core/src/main/java/io/kestra/core/models/tasks/AssetFailureBehavior.java
+++ b/core/src/main/java/io/kestra/core/models/tasks/AssetFailureBehavior.java
@@ -1,0 +1,29 @@
+package io.kestra.core.models.tasks;
+
+import io.kestra.core.models.flows.State;
+
+public enum AssetFailureBehavior {
+    IGNORE,
+    FAIL,
+    WARN;
+
+    /**
+     * Apply this behavior to <code>current</code>:
+     * - never escalates a state that already terminated in error (FAILED/KILLED/CANCELLED)
+     * - FAIL -> always FAILED
+     * - WARN -> WARNING, only if <code>current</code> is SUCCESS
+     * - IGNORE -> unchanged
+     */
+    public State.Type apply(State.Type current) {
+        if (current.isTerminatedInError()) {
+            return current;
+        }
+        if (this == FAIL) {
+            return State.Type.FAILED;
+        }
+        if (this == WARN && current == State.Type.SUCCESS) {
+            return State.Type.WARNING;
+        }
+        return current;
+    }
+}

--- a/core/src/test/java/io/kestra/core/models/QueryFilterTest.java
+++ b/core/src/test/java/io/kestra/core/models/QueryFilterTest.java
@@ -44,6 +44,16 @@ public class QueryFilterTest {
         assertThat(e.getMessage()).contains("Operation");
     }
 
+    @Test
+    void shouldThrowExceptionWhenFieldIsNotSupportedForResource() {
+        QueryFilter filter = QueryFilter.builder().field(Field.LOCKED).operation(Op.EQUALS).value(true).build();
+        InvalidQueryFiltersException e = assertThrows(
+            InvalidQueryFiltersException.class,
+            () -> QueryFilter.validateQueryFilters(List.of(filter), Resource.FLOW)
+        );
+        assertThat(e.getMessage()).contains("LOCKED", "FLOW");
+    }
+
     static Stream<Arguments> validOperationFilters() {
         return Stream.of(
             buildQueryFiltersForOperations(
@@ -326,6 +336,13 @@ public class QueryFilterTest {
                     Op.REGEX,
                     Op.IN,
                     Op.NOT_IN
+                )
+            ),
+
+            buildQueryFiltersForOperations(
+                Field.LOCKED, Resource.ASSET,
+                Set.of(
+                    Op.EQUALS
                 )
             ),
 
@@ -1171,6 +1188,24 @@ public class QueryFilterTest {
                     Op.LESS_THAN_OR_EQUAL_TO,
                     Op.GREATER_THAN,
                     Op.GREATER_THAN_OR_EQUAL_TO
+                )
+            ),
+
+            buildQueryFiltersForOperations(
+                Field.LOCKED, Resource.ASSET,
+                Set.of(
+                    Op.NOT_EQUALS,
+                    Op.GREATER_THAN,
+                    Op.LESS_THAN,
+                    Op.GREATER_THAN_OR_EQUAL_TO,
+                    Op.LESS_THAN_OR_EQUAL_TO,
+                    Op.IN,
+                    Op.NOT_IN,
+                    Op.STARTS_WITH,
+                    Op.ENDS_WITH,
+                    Op.CONTAINS,
+                    Op.REGEX,
+                    Op.PREFIX
                 )
             ),
 

--- a/core/src/test/java/io/kestra/core/models/tasks/AssetFailureBehaviorTest.java
+++ b/core/src/test/java/io/kestra/core/models/tasks/AssetFailureBehaviorTest.java
@@ -1,0 +1,45 @@
+package io.kestra.core.models.tasks;
+
+import java.util.stream.Stream;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import io.kestra.core.models.flows.State;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class AssetFailureBehaviorTest {
+
+    @ParameterizedTest
+    @MethodSource("cases")
+    void apply(AssetFailureBehavior behavior, State.Type current, State.Type expected) {
+        assertThat(behavior.apply(current)).isEqualTo(expected);
+    }
+
+    private static Stream<Arguments> cases() {
+        return Stream.of(
+            // IGNORE never changes anything
+            Arguments.of(AssetFailureBehavior.IGNORE, State.Type.SUCCESS, State.Type.SUCCESS),
+            Arguments.of(AssetFailureBehavior.IGNORE, State.Type.WARNING, State.Type.WARNING),
+            Arguments.of(AssetFailureBehavior.IGNORE, State.Type.FAILED, State.Type.FAILED),
+            Arguments.of(AssetFailureBehavior.IGNORE, State.Type.KILLED, State.Type.KILLED),
+            Arguments.of(AssetFailureBehavior.IGNORE, State.Type.CANCELLED, State.Type.CANCELLED),
+
+            // WARN escalates SUCCESS only; a terminated-in-error state is never touched
+            Arguments.of(AssetFailureBehavior.WARN, State.Type.SUCCESS, State.Type.WARNING),
+            Arguments.of(AssetFailureBehavior.WARN, State.Type.WARNING, State.Type.WARNING),
+            Arguments.of(AssetFailureBehavior.WARN, State.Type.FAILED, State.Type.FAILED),
+            Arguments.of(AssetFailureBehavior.WARN, State.Type.KILLED, State.Type.KILLED),
+            Arguments.of(AssetFailureBehavior.WARN, State.Type.CANCELLED, State.Type.CANCELLED),
+
+            // FAIL always fails, except a state that already terminated in error
+            Arguments.of(AssetFailureBehavior.FAIL, State.Type.SUCCESS, State.Type.FAILED),
+            Arguments.of(AssetFailureBehavior.FAIL, State.Type.WARNING, State.Type.FAILED),
+            Arguments.of(AssetFailureBehavior.FAIL, State.Type.FAILED, State.Type.FAILED),
+            Arguments.of(AssetFailureBehavior.FAIL, State.Type.KILLED, State.Type.KILLED),
+            Arguments.of(AssetFailureBehavior.FAIL, State.Type.CANCELLED, State.Type.CANCELLED)
+        );
+    }
+}

--- a/core/src/test/java/io/kestra/core/reporter/reports/AbstractFeatureUsageReportTest.java
+++ b/core/src/test/java/io/kestra/core/reporter/reports/AbstractFeatureUsageReportTest.java
@@ -130,7 +130,7 @@ public abstract class AbstractFeatureUsageReportTest {
                         .runIf("{{ 1 == 1 }}")
                         .allowWarning(true)
                         .taskCache(new Cache(true, Duration.ofMinutes(1)))
-                        .assets(new AssetsDeclaration(null, null, null))
+                        .assets(new AssetsDeclaration(null, null, null, null))
                         .build(),
                     Sequential.builder()
                         .id("seq")
@@ -156,7 +156,7 @@ public abstract class AbstractFeatureUsageReportTest {
                         .logToFile(true)
                         .failOnTriggerError(true)
                         .allowConcurrent(true)
-                        .assets(new AssetsDeclaration(null, null, null))
+                        .assets(new AssetsDeclaration(null, null, null, null))
                         .build()
                 )
             )

--- a/executor/src/main/java/io/kestra/executor/ExecutorService.java
+++ b/executor/src/main/java/io/kestra/executor/ExecutorService.java
@@ -1432,72 +1432,63 @@ public class ExecutorService {
 
         if (taskRun.getState().isTerminated()) {
             log.trace("TaskRun terminated: {}", taskRun);
-            metricRegistry
-                .counter(
-                    MetricRegistry.METRIC_EXECUTOR_TASKRUN_ENDED_COUNT,
-                    MetricRegistry.METRIC_EXECUTOR_TASKRUN_ENDED_COUNT_DESCRIPTION,
-                    metricRegistry.tags(workerTaskResult)
-                )
-                .increment();
 
-            metricRegistry
-                .timer(
-                    MetricRegistry.METRIC_EXECUTOR_TASKRUN_ENDED_DURATION,
-                    MetricRegistry.METRIC_EXECUTOR_TASKRUN_ENDED_DURATION_DESCRIPTION,
-                    metricRegistry.tags(workerTaskResult)
-                )
-                .record(taskRun.getState().getDurationOrComputeIt());
+            // may be escalated below by assetFailureBehavior; kept separate from `taskRun` for the metrics in the finally block
+            TaskRun finalTaskRun = taskRun;
+            try {
+                // outputs
+                taskOutputService.saveOutputs(taskRun, workerTaskResult.getOutputs());
 
-            // outputs
-            taskOutputService.saveOutputs(taskRun, workerTaskResult.getOutputs());
-
-            ExecutionKind executionKind = Optional.ofNullable(executor.getExecution().getKind()).orElse(ExecutionKind.NORMAL);
-            if (
-                taskRun.getAssets() != null &&
-                    (!taskRun.getAssets().getInputs().isEmpty() || !taskRun.getAssets().getOutputs().isEmpty())
-                    && executionKind != ExecutionKind.TEST
-            ) {
-                AssetUser assetUser = new AssetUser(
-                    taskRun.getTenantId(),
-                    taskRun.getNamespace(),
-                    taskRun.getFlowId(),
-                    newExecution.getFlowRevision(),
-                    taskRun.getExecutionId(),
-                    taskRun.getTaskId(),
-                    taskRun.getId(),
-                    taskRun.getState().getCurrent(),
-                    taskRun.getState().getStartDate(),
-                    taskRun.getState().getEndDate().orElse(null)
-                );
-
-                List<AssetIdentifier> outputIdentifiers = taskRun.getAssets().getOutputs().stream()
-                    .map(asset -> asset.withTenantId(taskRun.getTenantId()))
-                    .map(AssetIdentifier::of)
-                    .toList();
-                List<AssetIdentifier> inputAssets = taskRun.getAssets().getInputs().stream()
-                    .map(assetIdentifier -> assetIdentifier.withTenantId(taskRun.getTenantId()))
-                    .toList();
-                try {
-                    assetService.assetLineage(
-                        assetUser,
-                        inputAssets,
-                        outputIdentifiers
+                ExecutionKind executionKind = Optional.ofNullable(executor.getExecution().getKind()).orElse(ExecutionKind.NORMAL);
+                if (
+                    taskRun.getAssets() != null &&
+                        (!taskRun.getAssets().getInputs().isEmpty() || !taskRun.getAssets().getOutputs().isEmpty())
+                        && executionKind != ExecutionKind.TEST
+                ) {
+                    AssetUser assetUser = new AssetUser(
+                        taskRun.getTenantId(),
+                        taskRun.getNamespace(),
+                        taskRun.getFlowId(),
+                        newExecution.getFlowRevision(),
+                        taskRun.getExecutionId(),
+                        taskRun.getTaskId(),
+                        taskRun.getId(),
+                        taskRun.getState().getCurrent(),
+                        taskRun.getState().getStartDate(),
+                        taskRun.getState().getEndDate().orElse(null)
                     );
-                } catch (QueueException e) {
-                    log.warn("Unable to submit asset lineage event for {} -> {}", inputAssets, outputIdentifiers, e);
-                }
 
-                // don't update output assets if task fail
-                if (!taskRun.getState().isFailed()) {
-                    // Plain for-loop so a locked-asset InternalException from asyncUpsert propagates and fails the execution (fail-fast, ordering-dependent).
-                    for (var asset : taskRun.getAssets().getOutputs()) {
-                        try {
-                            assetService.asyncUpsert(assetUser, asset);
-                        } catch (QueueException e) {
-                            log.warn("Unable to submit asset upsert event for asset {}", asset.getId(), e);
+                    try {
+                        Optional<TaskRun> escalated = assetService.processTaskRunAssets(assetUser, taskRun, newExecution, flow, executionKind);
+                        if (escalated.isPresent()) {
+                            finalTaskRun = escalated.get();
+                            executor.withExecution(executor.getExecution().withTaskRun(finalTaskRun), "addWorkerTaskResult");
                         }
+                    } catch (Exception e) {
+                        // a bug in asset-lineage/escalation processing must not prevent the taskRun's own
+                        // (already-terminated) result from being recorded; metrics below still tag from taskRun
+                        log.error("Unable to process assets for taskRun {}", taskRun.getId(), e);
                     }
                 }
+            } finally {
+                // tagged from finalTaskRun so a state escalated above by assetFailureBehavior is reflected in the metrics too
+                WorkerTaskResult finalWorkerTaskResult = workerTaskResult.withTaskRun(finalTaskRun);
+                metricRegistry
+                    .counter(
+                        MetricRegistry.METRIC_EXECUTOR_TASKRUN_ENDED_COUNT,
+                        MetricRegistry.METRIC_EXECUTOR_TASKRUN_ENDED_COUNT_DESCRIPTION,
+                        metricRegistry.tags(finalWorkerTaskResult)
+                    )
+                    .increment();
+
+                // duration from the original taskRun: withState() above would otherwise inflate it by the escalation delay
+                metricRegistry
+                    .timer(
+                        MetricRegistry.METRIC_EXECUTOR_TASKRUN_ENDED_DURATION,
+                        MetricRegistry.METRIC_EXECUTOR_TASKRUN_ENDED_DURATION_DESCRIPTION,
+                        metricRegistry.tags(finalWorkerTaskResult)
+                    )
+                    .record(taskRun.getState().getDurationOrComputeIt());
             }
         }
     }

--- a/executor/src/test/java/io/kestra/executor/ExecutorServiceProcessTaskRunAssetsTest.java
+++ b/executor/src/test/java/io/kestra/executor/ExecutorServiceProcessTaskRunAssetsTest.java
@@ -1,0 +1,181 @@
+package io.kestra.executor;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import io.kestra.core.assets.AssetService;
+import io.kestra.core.junit.annotations.KestraTest;
+import io.kestra.core.metrics.MetricRegistry;
+import io.kestra.core.models.assets.Asset;
+import io.kestra.core.models.assets.AssetsInOut;
+import io.kestra.core.models.assets.Custom;
+import io.kestra.core.models.executions.Execution;
+import io.kestra.core.models.executions.ExecutionKind;
+import io.kestra.core.models.executions.TaskRun;
+import io.kestra.core.models.flows.Flow;
+import io.kestra.core.models.flows.FlowWithSource;
+import io.kestra.core.models.flows.State;
+import io.kestra.core.runners.WorkerTaskResult;
+import io.kestra.core.utils.IdUtils;
+import io.kestra.plugin.core.log.Log;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micronaut.test.annotation.MockBean;
+import jakarta.inject.Inject;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+/**
+ * Covers ExecutorService's own logic around processTaskRunAssets: the guard deciding whether to call
+ * it, and applying the escalated TaskRun it returns. The escalation logic itself (assetFailureBehavior,
+ * allowFailure/allowWarning clamps, mark-and-continue upserts) only exists in the EE AssetService
+ * implementation and is covered there directly (core-ee's AssetServiceTest).
+ */
+@KestraTest
+class ExecutorServiceProcessTaskRunAssetsTest {
+    @Inject
+    private ExecutorService executorService;
+
+    @Inject
+    private AssetService assetService;
+
+    @Inject
+    private MeterRegistry meterRegistry;
+
+    @MockBean(AssetService.class)
+    AssetService assetService() {
+        return mock(AssetService.class);
+    }
+
+    @BeforeEach
+    void setUp() {
+        reset(assetService);
+    }
+
+    @Test
+    void shouldNotCallAssetServiceWhenTaskRunHasNoAssets() throws Exception {
+        runExecutor(null, ExecutionKind.NORMAL, State.Type.SUCCESS);
+
+        verifyNoInteractions(assetService);
+    }
+
+    @Test
+    void shouldNotCallAssetServiceWhenAssetsAreEmpty() throws Exception {
+        runExecutor(new AssetsInOut(Collections.emptyList(), Collections.emptyList()), ExecutionKind.NORMAL, State.Type.SUCCESS);
+
+        verifyNoInteractions(assetService);
+    }
+
+    @Test
+    void shouldNotCallAssetServiceForTestExecutions() throws Exception {
+        runExecutor(new AssetsInOut(Collections.emptyList(), List.of(asset("a"))), ExecutionKind.TEST, State.Type.SUCCESS);
+
+        verifyNoInteractions(assetService);
+    }
+
+    @Test
+    void shouldNotCallAssetServiceWhenTaskRunNotTerminated() throws Exception {
+        runExecutor(new AssetsInOut(Collections.emptyList(), List.of(asset("a"))), ExecutionKind.NORMAL, State.Type.RUNNING);
+
+        verifyNoInteractions(assetService);
+    }
+
+    @Test
+    void shouldApplyEscalatedTaskRunWhenAssetServiceReturnsOne() throws Exception {
+        when(assetService.processTaskRunAssets(any(), any(), any(), any(), any()))
+            .thenAnswer(invocation -> Optional.of(((TaskRun) invocation.getArgument(1)).withState(State.Type.WARNING)));
+
+        ExecutorContext executor = runExecutor(new AssetsInOut(Collections.emptyList(), List.of(asset("a"))), ExecutionKind.NORMAL, State.Type.SUCCESS);
+
+        assertThat(executor.getExecution().getTaskRunList().getFirst().getState().getCurrent()).isEqualTo(State.Type.WARNING);
+        // the ended-count metric must be tagged from the escalated state, not the original SUCCESS the
+        // taskRun actually finished with
+        String flowId = executor.getFlow().getId();
+        assertThat(
+            meterRegistry.get(MetricRegistry.METRIC_EXECUTOR_TASKRUN_ENDED_COUNT)
+                .tag(MetricRegistry.TAG_FLOW_ID, flowId)
+                .tag(MetricRegistry.TAG_STATE, State.Type.WARNING.name())
+                .counter().count()
+        ).isEqualTo(1.0);
+    }
+
+    @Test
+    void shouldKeepTaskRunResultWhenAssetServiceThrows() throws Exception {
+        when(assetService.processTaskRunAssets(any(), any(), any(), any(), any()))
+            .thenThrow(new RuntimeException("boom"));
+
+        ExecutorContext executor = runExecutor(new AssetsInOut(Collections.emptyList(), List.of(asset("a"))), ExecutionKind.NORMAL, State.Type.SUCCESS);
+
+        // a bug in asset-lineage/escalation processing must not prevent the taskRun's own
+        // already-terminated result from being recorded
+        assertThat(executor.getExecution().getTaskRunList().getFirst().getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
+        String flowId = executor.getFlow().getId();
+        assertThat(
+            meterRegistry.get(MetricRegistry.METRIC_EXECUTOR_TASKRUN_ENDED_COUNT)
+                .tag(MetricRegistry.TAG_FLOW_ID, flowId)
+                .tag(MetricRegistry.TAG_STATE, State.Type.SUCCESS.name())
+                .counter().count()
+        ).isEqualTo(1.0);
+    }
+
+    @Test
+    void shouldKeepOriginalTaskRunWhenAssetServiceReturnsEmpty() throws Exception {
+        when(assetService.processTaskRunAssets(any(), any(), any(), any(), any())).thenReturn(Optional.empty());
+
+        ExecutorContext executor = runExecutor(new AssetsInOut(Collections.emptyList(), List.of(asset("a"))), ExecutionKind.NORMAL, State.Type.SUCCESS);
+
+        assertThat(executor.getExecution().getTaskRunList().getFirst().getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
+        verify(assetService).processTaskRunAssets(any(), any(), any(), any(), any());
+    }
+
+    private Asset asset(String id) {
+        return Custom.builder().tenantId("tenant").namespace("io.kestra.unit-test").id(id).type("io.kestra.Custom").build();
+    }
+
+    private ExecutorContext runExecutor(AssetsInOut assets, ExecutionKind kind, State.Type terminalState) throws Exception {
+        var task = Log.builder().id("task").type(Log.class.getName()).message("hello").build();
+        var flow = Flow.builder().tenantId("tenant").namespace("io.kestra.unit-test").id(IdUtils.create()).tasks(List.of(task)).build();
+
+        var placeholder = TaskRun.builder()
+            .tenantId("tenant")
+            .id(IdUtils.create())
+            .executionId(IdUtils.create())
+            .namespace(flow.getNamespace())
+            .flowId(flow.getId())
+            .taskId(task.getId())
+            .state(new State())
+            .build();
+
+        var execution = Execution.builder()
+            .tenantId("tenant")
+            .id(placeholder.getExecutionId())
+            .namespace(flow.getNamespace())
+            .flowId(flow.getId())
+            .flowRevision(1)
+            .kind(kind)
+            .state(new State())
+            .taskRunList(List.of(placeholder))
+            .build();
+
+        var terminalTaskRun = placeholder
+            .withState(terminalState)
+            .withAssets(assets);
+
+        var executor = new ExecutorContext(execution, FlowWithSource.of(flow, "flow-source"));
+        var workerTaskResult = new WorkerTaskResult(terminalTaskRun);
+
+        executorService.addWorkerTaskResult(executor, executor::getFlow, workerTaskResult);
+
+        return executor;
+    }
+}

--- a/jdbc-h2/src/main/java/io/kestra/repository/h2/migration/V2_0_21LocksLockedUntilMigration.java
+++ b/jdbc-h2/src/main/java/io/kestra/repository/h2/migration/V2_0_21LocksLockedUntilMigration.java
@@ -1,0 +1,48 @@
+package io.kestra.repository.h2.migration;
+
+import javax.sql.DataSource;
+
+import io.kestra.core.migration.MigrationScript;
+import io.kestra.jdbc.migration.AbstractSQLMigrationScript;
+
+import io.micronaut.context.annotation.Requires;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+
+/**
+ * H2 migration: add a {@code locks.locked_until} generated column so {@code AbstractJdbcLeaseStore} can
+ * push the active-lease expiry filter into SQL instead of fetching every row for the category/tenant.
+ */
+@Singleton
+@Requires(property = "kestra.repository.type", pattern = "h2|memory")
+public class V2_0_21LocksLockedUntilMigration extends AbstractSQLMigrationScript {
+
+    private static final String SCRIPT_ID = "2.0.21-locks-locked-until";
+
+    private final DataSource dataSource;
+
+    @Inject
+    public V2_0_21LocksLockedUntilMigration(final DataSource dataSource) {
+        this.dataSource = dataSource;
+    }
+
+    @Override
+    public String scriptId() {
+        return SCRIPT_ID;
+    }
+
+    @Override
+    public String description() {
+        return "H2: add locks.locked_until generated column for active-lease expiry pushdown";
+    }
+
+    @Override
+    public String checksum() {
+        return MigrationScript.checksumOfResources("/migrations/2.0.21-locks-locked-until-h2.sql");
+    }
+
+    @Override
+    public void migrate() throws Exception {
+        executeSqlResource(dataSource, "/migrations/2.0.21-locks-locked-until-h2.sql");
+    }
+}

--- a/jdbc-h2/src/main/resources/migrations/2.0.21-locks-locked-until-h2.sql
+++ b/jdbc-h2/src/main/resources/migrations/2.0.21-locks-locked-until-h2.sql
@@ -1,0 +1,5 @@
+-- AbstractJdbcLeaseStore filters active leases by lockedUntil; pushing that expiry check into the
+-- SQL WHERE clause via this generated column avoids fetching every row for the category/tenant first.
+-- JdbcMapper always serializes Instant with a fixed 6-digit fraction (zero-padded, never omitted, see
+-- JdbcMapper.INSTANT_FORMATTER), so LEFT(...,23) reliably captures a millisecond-precision prefix.
+ALTER TABLE locks ADD COLUMN IF NOT EXISTS "locked_until" TIMESTAMP GENERATED ALWAYS AS (PARSEDATETIME(LEFT(JQ_STRING("value", '.lockedUntil'), 23) || '+00:00', 'yyyy-MM-dd''T''HH:mm:ss.SSSXXX'));

--- a/jdbc-h2/src/test/java/io/kestra/repository/h2/migration/H2V2_0_21LocksLockedUntilMigrationTest.java
+++ b/jdbc-h2/src/test/java/io/kestra/repository/h2/migration/H2V2_0_21LocksLockedUntilMigrationTest.java
@@ -1,0 +1,107 @@
+package io.kestra.repository.h2.migration;
+
+import java.time.Instant;
+
+import org.jooq.Field;
+import org.jooq.impl.DSL;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+
+import io.kestra.jdbc.JooqDSLContextWrapper;
+
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import jakarta.inject.Inject;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+/**
+ * H2-specific integration test for {@link V2_0_21LocksLockedUntilMigration}: the generated
+ * {@code locked_until} column must reflect the JSON value's {@code lockedUntil} for lease rows, stay
+ * NULL for rows without one, and the migration must be re-runnable.
+ */
+@MicronautTest(transactional = false)
+@Execution(ExecutionMode.SAME_THREAD)
+class H2V2_0_21LocksLockedUntilMigrationTest {
+
+    private static final Field<Object> KEY = DSL.field(DSL.quotedName("key"));
+    private static final Field<Object> VALUE = DSL.field(DSL.quotedName("value"));
+    private static final Field<Instant> LOCKED_UNTIL = DSL.field(DSL.quotedName("locked_until"), Instant.class);
+
+    private static final String LEASE_KEY = "lease_locked-until-seed-1";
+    private static final String MUTEX_KEY = "mutex_locked-until-seed-1";
+
+    @Inject
+    JooqDSLContextWrapper dslContextWrapper;
+
+    @Inject
+    V2_0_21LocksLockedUntilMigration migration;
+
+    @BeforeEach
+    @AfterEach
+    void cleanup() {
+        dslContextWrapper.transaction(
+            configuration -> DSL.using(configuration)
+                .deleteFrom(DSL.table("locks"))
+                .where(KEY.in(LEASE_KEY, MUTEX_KEY))
+                .execute()
+        );
+    }
+
+    @Test
+    void generatedColumnReflectsLockedUntilFromValue() throws Exception {
+        migration.migrate();
+
+        // JdbcMapper always serializes a 6-digit fraction (production-shaped); the generated column
+        // truncates to millisecond precision (LEFT(...,23)), so the round trip must drop the last 3 digits
+        Instant lockedUntil = Instant.parse("2026-01-01T00:00:00.123Z");
+        insertLock(LEASE_KEY, "{\"category\":\"lease\",\"id\":\"locked-until-seed-1\",\"tenantId\":\"tenant-a\",\"owner\":\"o\",\"lockedUntil\":\"2026-01-01T00:00:00.123456Z\"}");
+
+        assertThat(readLockedUntil(LEASE_KEY)).isEqualTo(lockedUntil);
+    }
+
+    @Test
+    void generatedColumnIsNullWhenValueHasNoLockedUntil() throws Exception {
+        migration.migrate();
+
+        insertLock(MUTEX_KEY, "{\"category\":\"mutex\",\"id\":\"locked-until-seed-1\",\"owner\":\"o\"}");
+
+        assertThat(readLockedUntil(MUTEX_KEY)).isNull();
+    }
+
+    @Test
+    void reRunningTheMigrationIsIdempotent() throws Exception {
+        assertThatCode(() ->
+        {
+            migration.migrate();
+            migration.migrate();
+        }).doesNotThrowAnyException();
+
+        Instant lockedUntil = Instant.parse("2026-01-01T00:00:00.123Z");
+        insertLock(LEASE_KEY, "{\"category\":\"lease\",\"id\":\"locked-until-seed-1\",\"tenantId\":\"tenant-a\",\"owner\":\"o\",\"lockedUntil\":\"2026-01-01T00:00:00.123456Z\"}");
+        assertThat(readLockedUntil(LEASE_KEY)).isEqualTo(lockedUntil);
+    }
+
+    private void insertLock(String key, String valueJson) {
+        dslContextWrapper.transaction(
+            configuration -> DSL.using(configuration)
+                .insertInto(DSL.table("locks"))
+                .set(KEY, (Object) key)
+                .set(VALUE, (Object) valueJson)
+                .execute()
+        );
+    }
+
+    private Instant readLockedUntil(String key) {
+        return dslContextWrapper.transactionResult(
+            configuration -> DSL.using(configuration)
+                .select(LOCKED_UNTIL)
+                .from(DSL.table("locks"))
+                .where(KEY.eq(key))
+                .fetchOne(LOCKED_UNTIL)
+        );
+    }
+}

--- a/jdbc-mysql/src/main/java/io/kestra/repository/mysql/migration/V2_0_21LocksLockedUntilMigration.java
+++ b/jdbc-mysql/src/main/java/io/kestra/repository/mysql/migration/V2_0_21LocksLockedUntilMigration.java
@@ -1,0 +1,48 @@
+package io.kestra.repository.mysql.migration;
+
+import javax.sql.DataSource;
+
+import io.kestra.core.migration.MigrationScript;
+import io.kestra.jdbc.migration.AbstractSQLMigrationScript;
+import io.kestra.repository.mysql.MysqlRepositoryEnabled;
+
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+
+/**
+ * MySQL migration: add a {@code locks.locked_until} generated column so {@code AbstractJdbcLeaseStore}
+ * can push the active-lease expiry filter into SQL instead of fetching every row for the category/tenant.
+ */
+@Singleton
+@MysqlRepositoryEnabled
+public class V2_0_21LocksLockedUntilMigration extends AbstractSQLMigrationScript {
+
+    private static final String SCRIPT_ID = "2.0.21-locks-locked-until";
+
+    private final DataSource dataSource;
+
+    @Inject
+    public V2_0_21LocksLockedUntilMigration(final DataSource dataSource) {
+        this.dataSource = dataSource;
+    }
+
+    @Override
+    public String scriptId() {
+        return SCRIPT_ID;
+    }
+
+    @Override
+    public String description() {
+        return "MySQL: add locks.locked_until generated column for active-lease expiry pushdown";
+    }
+
+    @Override
+    public String checksum() {
+        return MigrationScript.checksumOfResources("/migrations/2.0.21-locks-locked-until-mysql.sql");
+    }
+
+    @Override
+    public void migrate() throws Exception {
+        executeSqlResource(dataSource, "/migrations/2.0.21-locks-locked-until-mysql.sql");
+    }
+}

--- a/jdbc-mysql/src/main/resources/migrations/2.0.21-locks-locked-until-mysql.sql
+++ b/jdbc-mysql/src/main/resources/migrations/2.0.21-locks-locked-until-mysql.sql
@@ -1,0 +1,8 @@
+-- generated column lets AbstractJdbcLeaseStore push the lockedUntil expiry check into SQL instead of fetching every row
+-- MySQL lacks IF NOT EXISTS on ALTER TABLE ADD COLUMN, so guard via information_schema for idempotency
+-- generated columns disallow stored functions (ER_GENERATED_COLUMN_FUNCTION_IS_NOT_ALLOWED), so inline STR_TO_DATE like executions.start_date/end_date; JdbcMapper always emits a trailing 'Z', so no CONVERT_TZ needed
+SET @col_exists = (SELECT COUNT(*) FROM information_schema.columns WHERE table_schema = DATABASE() AND table_name = 'locks' AND column_name = 'locked_until');
+SET @sql = IF(@col_exists = 0, 'ALTER TABLE `locks` ADD COLUMN `locked_until` DATETIME(6) GENERATED ALWAYS AS (STR_TO_DATE(value ->> ''$.lockedUntil'', ''%Y-%m-%dT%H:%i:%s.%fZ'')) STORED', 'SELECT 1');
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;

--- a/jdbc-mysql/src/test/java/io/kestra/repository/mysql/migration/MysqlV2_0_21LocksLockedUntilMigrationTest.java
+++ b/jdbc-mysql/src/test/java/io/kestra/repository/mysql/migration/MysqlV2_0_21LocksLockedUntilMigrationTest.java
@@ -1,0 +1,107 @@
+package io.kestra.repository.mysql.migration;
+
+import java.time.Instant;
+
+import org.jooq.Field;
+import org.jooq.impl.DSL;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+
+import io.kestra.jdbc.JdbcJsonbUtils;
+import io.kestra.jdbc.JooqDSLContextWrapper;
+
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import jakarta.inject.Inject;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+/**
+ * MySQL-specific integration test for {@link V2_0_21LocksLockedUntilMigration}: the generated
+ * {@code locked_until} column must reflect the JSON value's {@code lockedUntil} for lease rows, stay
+ * NULL for rows without one, and the migration must be re-runnable.
+ */
+@MicronautTest(transactional = false)
+@Execution(ExecutionMode.SAME_THREAD)
+class MysqlV2_0_21LocksLockedUntilMigrationTest {
+
+    private static final Field<Object> KEY = DSL.field(DSL.quotedName("key"));
+    private static final Field<Object> VALUE = DSL.field(DSL.quotedName("value"));
+    private static final Field<Instant> LOCKED_UNTIL = DSL.field(DSL.quotedName("locked_until"), Instant.class);
+
+    private static final String LEASE_KEY = "lease_locked-until-seed-1";
+    private static final String MUTEX_KEY = "mutex_locked-until-seed-1";
+
+    @Inject
+    JooqDSLContextWrapper dslContextWrapper;
+
+    @Inject
+    V2_0_21LocksLockedUntilMigration migration;
+
+    @BeforeEach
+    @AfterEach
+    void cleanup() {
+        dslContextWrapper.transaction(
+            configuration -> DSL.using(configuration)
+                .deleteFrom(DSL.table("locks"))
+                .where(KEY.in(LEASE_KEY, MUTEX_KEY))
+                .execute()
+        );
+    }
+
+    @Test
+    void generatedColumnReflectsLockedUntilFromValue() throws Exception {
+        migration.migrate();
+
+        // DATETIME(6) + STR_TO_DATE's %f keep the full 6-digit fraction, unlike H2's LEFT(...,23) millisecond truncation
+        Instant lockedUntil = Instant.parse("2026-01-01T00:00:00.123456Z");
+        insertLock(LEASE_KEY, "{\"category\":\"lease\",\"id\":\"locked-until-seed-1\",\"tenantId\":\"tenant-a\",\"owner\":\"o\",\"lockedUntil\":\"2026-01-01T00:00:00.123456Z\"}");
+
+        assertThat(readLockedUntil(LEASE_KEY)).isEqualTo(lockedUntil);
+    }
+
+    @Test
+    void generatedColumnIsNullWhenValueHasNoLockedUntil() throws Exception {
+        migration.migrate();
+
+        insertLock(MUTEX_KEY, "{\"category\":\"mutex\",\"id\":\"locked-until-seed-1\",\"owner\":\"o\"}");
+
+        assertThat(readLockedUntil(MUTEX_KEY)).isNull();
+    }
+
+    @Test
+    void reRunningTheMigrationIsIdempotent() throws Exception {
+        assertThatCode(() ->
+        {
+            migration.migrate();
+            migration.migrate();
+        }).doesNotThrowAnyException();
+
+        Instant lockedUntil = Instant.parse("2026-01-01T00:00:00.123456Z");
+        insertLock(LEASE_KEY, "{\"category\":\"lease\",\"id\":\"locked-until-seed-1\",\"tenantId\":\"tenant-a\",\"owner\":\"o\",\"lockedUntil\":\"2026-01-01T00:00:00.123456Z\"}");
+        assertThat(readLockedUntil(LEASE_KEY)).isEqualTo(lockedUntil);
+    }
+
+    private void insertLock(String key, String valueJson) {
+        dslContextWrapper.transaction(
+            configuration -> DSL.using(configuration)
+                .insertInto(DSL.table("locks"))
+                .set(KEY, (Object) key)
+                .set(VALUE, (Object) JdbcJsonbUtils.valueOf(valueJson))
+                .execute()
+        );
+    }
+
+    private Instant readLockedUntil(String key) {
+        return dslContextWrapper.transactionResult(
+            configuration -> DSL.using(configuration)
+                .select(LOCKED_UNTIL)
+                .from(DSL.table("locks"))
+                .where(KEY.eq(key))
+                .fetchOne(LOCKED_UNTIL)
+        );
+    }
+}

--- a/jdbc-postgres/src/main/java/io/kestra/repository/postgres/migration/V2_0_21LocksLockedUntilMigration.java
+++ b/jdbc-postgres/src/main/java/io/kestra/repository/postgres/migration/V2_0_21LocksLockedUntilMigration.java
@@ -1,0 +1,49 @@
+package io.kestra.repository.postgres.migration;
+
+import javax.sql.DataSource;
+
+import io.kestra.core.migration.MigrationScript;
+import io.kestra.jdbc.migration.AbstractSQLMigrationScript;
+import io.kestra.repository.postgres.PostgresRepositoryEnabled;
+
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+
+/**
+ * PostgreSQL migration: add a {@code locks.locked_until} generated column so
+ * {@code AbstractJdbcLeaseStore} can push the active-lease expiry filter into SQL instead of fetching
+ * every row for the category/tenant.
+ */
+@Singleton
+@PostgresRepositoryEnabled
+public class V2_0_21LocksLockedUntilMigration extends AbstractSQLMigrationScript {
+
+    private static final String SCRIPT_ID = "2.0.21-locks-locked-until";
+
+    private final DataSource dataSource;
+
+    @Inject
+    public V2_0_21LocksLockedUntilMigration(final DataSource dataSource) {
+        this.dataSource = dataSource;
+    }
+
+    @Override
+    public String scriptId() {
+        return SCRIPT_ID;
+    }
+
+    @Override
+    public String description() {
+        return "PostgreSQL: add locks.locked_until generated column for active-lease expiry pushdown";
+    }
+
+    @Override
+    public String checksum() {
+        return MigrationScript.checksumOfResources("/migrations/2.0.21-locks-locked-until-postgres.sql");
+    }
+
+    @Override
+    public void migrate() throws Exception {
+        executeSqlResource(dataSource, "/migrations/2.0.21-locks-locked-until-postgres.sql");
+    }
+}

--- a/jdbc-postgres/src/main/resources/migrations/2.0.21-locks-locked-until-postgres.sql
+++ b/jdbc-postgres/src/main/resources/migrations/2.0.21-locks-locked-until-postgres.sql
@@ -1,0 +1,3 @@
+-- AbstractJdbcLeaseStore filters active leases by lockedUntil; pushing that expiry check into the
+-- SQL WHERE clause via this generated column avoids fetching every row for the category/tenant first.
+ALTER TABLE locks ADD COLUMN IF NOT EXISTS locked_until TIMESTAMPTZ GENERATED ALWAYS AS (PARSE_ISO8601_DATETIME(value ->> 'lockedUntil')) STORED;

--- a/jdbc-postgres/src/test/java/io/kestra/repository/postgres/migration/PostgresV2_0_21LocksLockedUntilMigrationTest.java
+++ b/jdbc-postgres/src/test/java/io/kestra/repository/postgres/migration/PostgresV2_0_21LocksLockedUntilMigrationTest.java
@@ -1,0 +1,96 @@
+package io.kestra.repository.postgres.migration;
+
+import java.time.Instant;
+
+import org.jooq.Field;
+import org.jooq.impl.DSL;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+
+import io.kestra.jdbc.JdbcJsonbUtils;
+import io.kestra.jdbc.JooqDSLContextWrapper;
+
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import jakarta.inject.Inject;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+@MicronautTest(transactional = false)
+@Execution(ExecutionMode.SAME_THREAD)
+class PostgresV2_0_21LocksLockedUntilMigrationTest {
+
+    private static final Field<Object> KEY = DSL.field(DSL.quotedName("key"));
+    private static final Field<Object> VALUE = DSL.field(DSL.quotedName("value"));
+    private static final Field<Instant> LOCKED_UNTIL = DSL.field(DSL.quotedName("locked_until"), Instant.class);
+
+    private static final String LEASE_KEY = "lease_locked-until-seed-1";
+    private static final String MUTEX_KEY = "mutex_locked-until-seed-1";
+
+    @Inject
+    JooqDSLContextWrapper dslContextWrapper;
+
+    @Inject
+    V2_0_21LocksLockedUntilMigration migration;
+
+    @BeforeEach
+    @AfterEach
+    void cleanup() {
+        dslContextWrapper.transaction(
+            configuration -> DSL.using(configuration)
+                .deleteFrom(DSL.table("locks"))
+                .where(KEY.in(LEASE_KEY, MUTEX_KEY))
+                .execute()
+        );
+    }
+
+    @Test
+    void generatedColumnReflectsLockedUntilFromValue() throws Exception {
+        migration.migrate();
+        Instant lockedUntil = Instant.parse("2026-01-01T00:00:00.123456Z");
+        insertLock(LEASE_KEY, "{\"category\":\"lease\",\"id\":\"locked-until-seed-1\",\"tenantId\":\"tenant-a\",\"owner\":\"o\",\"lockedUntil\":\"2026-01-01T00:00:00.123456Z\"}");
+        assertThat(readLockedUntil(LEASE_KEY)).isEqualTo(lockedUntil);
+    }
+
+    @Test
+    void generatedColumnIsNullWhenValueHasNoLockedUntil() throws Exception {
+        migration.migrate();
+        insertLock(MUTEX_KEY, "{\"category\":\"mutex\",\"id\":\"locked-until-seed-1\",\"owner\":\"o\"}");
+        assertThat(readLockedUntil(MUTEX_KEY)).isNull();
+    }
+
+    @Test
+    void reRunningTheMigrationIsIdempotent() throws Exception {
+        assertThatCode(() ->
+        {
+            migration.migrate();
+            migration.migrate();
+        }).doesNotThrowAnyException();
+        Instant lockedUntil = Instant.parse("2026-01-01T00:00:00.123456Z");
+        insertLock(LEASE_KEY, "{\"category\":\"lease\",\"id\":\"locked-until-seed-1\",\"tenantId\":\"tenant-a\",\"owner\":\"o\",\"lockedUntil\":\"2026-01-01T00:00:00.123456Z\"}");
+        assertThat(readLockedUntil(LEASE_KEY)).isEqualTo(lockedUntil);
+    }
+
+    private void insertLock(String key, String valueJson) {
+        dslContextWrapper.transaction(
+            configuration -> DSL.using(configuration)
+                .insertInto(DSL.table("locks"))
+                .set(KEY, (Object) key)
+                .set(VALUE, (Object) JdbcJsonbUtils.valueOf(valueJson))
+                .execute()
+        );
+    }
+
+    private Instant readLockedUntil(String key) {
+        return dslContextWrapper.transactionResult(
+            configuration -> DSL.using(configuration)
+                .select(LOCKED_UNTIL)
+                .from(DSL.table("locks"))
+                .where(KEY.eq(key))
+                .fetchOne(LOCKED_UNTIL)
+        );
+    }
+}

--- a/worker/src/main/java/io/kestra/worker/processors/WorkerTaskProcessor.java
+++ b/worker/src/main/java/io/kestra/worker/processors/WorkerTaskProcessor.java
@@ -32,6 +32,7 @@ import io.kestra.core.models.assets.AssetsDeclaration;
 import io.kestra.core.models.assets.AssetsInOut;
 import io.kestra.core.models.executions.*;
 import io.kestra.core.models.flows.State;
+import io.kestra.core.models.tasks.AssetFailureBehavior;
 import io.kestra.core.models.tasks.RunnableTask;
 import io.kestra.core.models.tasks.Task;
 import io.kestra.core.runners.*;
@@ -289,6 +290,34 @@ public class WorkerTaskProcessor extends AbstractWorkerJobProcessor<WorkerTask> 
                 state = WARNING;
             }
 
+            if (taskRunWithOutput.assetEmissionFailed()) {
+                AssetsDeclaration assetsDeclaration = workerTask.getTask().getAssets();
+                AssetFailureBehavior assetFailureBehavior = AssetFailureBehavior.WARN;
+                if (assetsDeclaration != null) {
+                    try {
+                        assetFailureBehavior = runContext.render(assetsDeclaration.getAssetFailureBehavior()).as(AssetFailureBehavior.class).orElse(AssetFailureBehavior.WARN);
+                    } catch (IllegalVariableEvaluationException e) {
+                        runContext.logger().warn("Unable to render assetFailureBehavior, defaulting to WARN", e);
+                    }
+                }
+                State.Type newState = assetFailureBehavior.apply(state);
+                if (newState != state) {
+                    runContext.logger().warn(
+                        "Task state changed from {} to {} because an asset failed to be emitted (assetFailureBehavior: {})",
+                        state, newState, assetFailureBehavior
+                    );
+                } else {
+                    runContext.logger().warn(
+                        "An asset failed to be emitted but the task state was not changed (assetFailureBehavior: {})",
+                        assetFailureBehavior
+                    );
+                }
+                state = newState;
+            }
+
+            // allowFailure has final say over any FAILED state reaching this point, whether the task's own
+            // genuine failure or one escalated by assetFailureBehavior; gated on shouldBeRetried so a pending retry
+            // is not prematurely softened
             if (workerTask.getTask().isAllowFailure() && !taskRunWithOutput.taskRun().shouldBeRetried(workerTask.getTask().getRetry()) && state.isFailed()) {
                 state = WARNING;
             }
@@ -423,6 +452,7 @@ public class WorkerTaskProcessor extends AbstractWorkerJobProcessor<WorkerTask> 
 
         Map<String, Object> outputs = Optional.ofNullable(workerTaskCallable.getTaskOutput()).map(it -> it.toMap()).orElse(null);
 
+        boolean assetEmissionFailed = false;
         try {
             if (workerTask.getTask().getAssets() != null) {
                 // We need to have the task outputs injected before rendering the assets
@@ -445,10 +475,11 @@ public class WorkerTaskProcessor extends AbstractWorkerJobProcessor<WorkerTask> 
                 );
             }
         } catch (Exception e) {
-            logger.warn("Unable to save output on taskRun '{}'", taskRun, e);
+            logger.warn("Unable to render asset declaration for taskRun '{}'", taskRun, e);
+            assetEmissionFailed = true;
         }
 
-        return new TaskRunWithOutput(taskRun, outputs);
+        return new TaskRunWithOutput(taskRun, outputs, assetEmissionFailed);
     }
 
     private List<TaskRunAttempt> addAttempt(WorkerTask workerTask, TaskRunAttempt taskRunAttempt) {

--- a/worker/src/test/java/io/kestra/worker/processors/WorkerTaskProcessorTest.java
+++ b/worker/src/test/java/io/kestra/worker/processors/WorkerTaskProcessorTest.java
@@ -4,18 +4,25 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 import org.junit.jupiter.api.Test;
 
 import io.kestra.core.junit.annotations.KestraTest;
 import io.kestra.core.metrics.MetricRegistry;
+import io.kestra.core.models.assets.AssetsDeclaration;
 import io.kestra.core.models.executions.Execution;
+import io.kestra.core.models.executions.LogEntry;
 import io.kestra.core.models.executions.TaskRun;
 import io.kestra.core.models.flows.Flow;
+import io.kestra.core.models.flows.State;
+import io.kestra.core.models.property.Property;
+import io.kestra.core.models.tasks.AssetFailureBehavior;
 import io.kestra.core.models.tasks.ResolvedTask;
 import io.kestra.core.models.tasks.RunnableTask;
 import io.kestra.core.models.tasks.Task;
 import io.kestra.core.models.tasks.VoidOutput;
+import io.kestra.core.queues.DispatchQueueInterface;
 import io.kestra.core.runners.RunContext;
 import io.kestra.core.runners.RunContextFactory;
 import io.kestra.core.runners.RunContextInitializer;
@@ -74,6 +81,9 @@ class WorkerTaskProcessorTest {
     @Inject
     private RunContextFactory runContextFactory;
 
+    @Inject
+    private DispatchQueueInterface<LogEntry> logQueue;
+
     @Test
     void shouldEmitFailedResultWhenTaskFailsOnItsOwnDuringShutdownDrain() throws Exception {
         // Given a processor in the graceful drain window (stopped) that did NOT interrupt the task
@@ -107,6 +117,122 @@ class WorkerTaskProcessorTest {
         assertThat(results)
             .as("an interrupted task's failure must be deferred for resubmission, not reported")
             .noneMatch(result -> result.getTaskRun().getState().isFailed());
+    }
+
+    @Test
+    void shouldKeepSuccessWhenAssetEmissionFailsAndBehaviorIsIgnore() throws Exception {
+        InMemoryWorkerQueue<WorkerTaskResult> resultQueue = new InMemoryWorkerQueue<>(100);
+        WorkerTaskProcessor processor = newProcessor(resultQueue);
+        List<LogEntry> logs = new CopyOnWriteArrayList<>();
+        logQueue.addListener(logs::add);
+
+        processor.process(assetEmissionFailureWorkerTask(AssetFailureBehavior.IGNORE));
+
+        List<WorkerTaskResult> results = drain(resultQueue);
+        String taskRunId = results.getLast().getTaskRun().getId();
+        assertThat(results.getLast().getTaskRun().getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
+        // state is unchanged, but the failed asset emission is still surfaced to the user
+        LogEntry escalationLog = TestsUtils.awaitLog(logs, log -> taskRunId.equals(log.getTaskRunId()) && log.getMessage().contains("assetFailureBehavior"));
+        assertThat(escalationLog).isNotNull();
+        assertThat(escalationLog.getMessage()).contains("not changed").contains("IGNORE");
+    }
+
+    @Test
+    void shouldClampToWarningWhenAssetFailureBehaviorIsFailAndAllowFailureIsSet() throws Exception {
+        InMemoryWorkerQueue<WorkerTaskResult> resultQueue = new InMemoryWorkerQueue<>(100);
+        WorkerTaskProcessor processor = newProcessor(resultQueue);
+
+        processor.process(assetEmissionFailureWorkerTask(AssetFailureBehavior.FAIL, true, false));
+
+        List<WorkerTaskResult> results = drain(resultQueue);
+        // allowFailure applies uniformly to a FAILED state, whether genuine or escalated by assetFailureBehavior
+        assertThat(results.getLast().getTaskRun().getState().getCurrent()).isEqualTo(State.Type.WARNING);
+    }
+
+    @Test
+    void shouldClampToSuccessWhenAssetFailureBehaviorIsWarnAndAllowWarningIsSet() throws Exception {
+        InMemoryWorkerQueue<WorkerTaskResult> resultQueue = new InMemoryWorkerQueue<>(100);
+        WorkerTaskProcessor processor = newProcessor(resultQueue);
+        List<LogEntry> logs = new CopyOnWriteArrayList<>();
+        logQueue.addListener(logs::add);
+
+        processor.process(assetEmissionFailureWorkerTask(AssetFailureBehavior.WARN, false, true));
+
+        List<WorkerTaskResult> results = drain(resultQueue);
+        String taskRunId = results.getLast().getTaskRun().getId();
+        // allowWarning has final say: a WARNING escalated purely from assetFailureBehavior is clamped down
+        assertThat(results.getLast().getTaskRun().getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
+        // the final state (SUCCESS) alone can't tell escalation-then-clamp apart from no escalation at
+        // all — the log line is what actually proves assetFailureBehavior ran
+        LogEntry escalationLog = TestsUtils.awaitLog(logs, log -> taskRunId.equals(log.getTaskRunId()) && log.getMessage().contains("assetFailureBehavior"));
+        assertThat(escalationLog).isNotNull();
+        assertThat(escalationLog.getMessage()).contains("SUCCESS").contains("WARNING").contains("WARN");
+    }
+
+    @Test
+    void shouldNotEscalateWhenTaskAlreadyFailedOnItsOwn() throws Exception {
+        InMemoryWorkerQueue<WorkerTaskResult> resultQueue = new InMemoryWorkerQueue<>(100);
+        WorkerTaskProcessor processor = newProcessor(resultQueue);
+        List<LogEntry> logs = new CopyOnWriteArrayList<>();
+        logQueue.addListener(logs::add);
+
+        processor.process(taskFailsAndAssetEmissionFailsWorkerTask(AssetFailureBehavior.WARN));
+
+        List<WorkerTaskResult> results = drain(resultQueue);
+        String taskRunId = results.getLast().getTaskRun().getId();
+        // a task that already terminated in error on its own is not touched by assetFailureBehavior
+        assertThat(results.getLast().getTaskRun().getState().getCurrent()).isEqualTo(State.Type.FAILED);
+        LogEntry escalationLog = TestsUtils.awaitLog(logs, log -> taskRunId.equals(log.getTaskRunId()) && log.getMessage().contains("assetFailureBehavior"));
+        assertThat(escalationLog).isNotNull();
+        assertThat(escalationLog.getMessage()).contains("not changed");
+    }
+
+    @Test
+    void shouldClampToWarningWhenTaskAlreadyFailedOnItsOwnAndAllowFailureIsSet() throws Exception {
+        InMemoryWorkerQueue<WorkerTaskResult> resultQueue = new InMemoryWorkerQueue<>(100);
+        WorkerTaskProcessor processor = newProcessor(resultQueue);
+
+        processor.process(taskFailsAndAssetEmissionFailsWorkerTask(AssetFailureBehavior.FAIL, true));
+
+        List<WorkerTaskResult> results = drain(resultQueue);
+        // a genuine pre-existing failure is untouched by assetFailureBehavior (apply() no-ops on an already
+        // terminated-in-error state), so allowFailure still applies its ordinary softening here
+        assertThat(results.getLast().getTaskRun().getState().getCurrent()).isEqualTo(State.Type.WARNING);
+    }
+
+    @Test
+    void shouldFailTaskWhenAssetEmissionFailsAndBehaviorIsFail() throws Exception {
+        InMemoryWorkerQueue<WorkerTaskResult> resultQueue = new InMemoryWorkerQueue<>(100);
+        WorkerTaskProcessor processor = newProcessor(resultQueue);
+        List<LogEntry> logs = new CopyOnWriteArrayList<>();
+        logQueue.addListener(logs::add);
+
+        processor.process(assetEmissionFailureWorkerTask(AssetFailureBehavior.FAIL));
+
+        List<WorkerTaskResult> results = drain(resultQueue);
+        String taskRunId = results.getLast().getTaskRun().getId();
+        assertThat(results.getLast().getTaskRun().getState().getCurrent()).isEqualTo(State.Type.FAILED);
+        // the user must be able to tell FAILED came from the asset emission, not the task's own logic
+        LogEntry escalationLog = TestsUtils.awaitLog(logs, log -> taskRunId.equals(log.getTaskRunId()) && log.getMessage().contains("assetFailureBehavior"));
+        assertThat(escalationLog).isNotNull();
+        assertThat(escalationLog.getMessage()).contains("SUCCESS").contains("FAILED").contains("FAIL");
+    }
+
+    @Test
+    void shouldWarnTaskWhenAssetEmissionFailsAndBehaviorIsWarn() throws Exception {
+        InMemoryWorkerQueue<WorkerTaskResult> resultQueue = new InMemoryWorkerQueue<>(100);
+        WorkerTaskProcessor processor = newProcessor(resultQueue);
+        List<LogEntry> logs = new CopyOnWriteArrayList<>();
+        logQueue.addListener(logs::add);
+
+        processor.process(assetEmissionFailureWorkerTask(AssetFailureBehavior.WARN));
+
+        List<WorkerTaskResult> results = drain(resultQueue);
+        String taskRunId = results.getLast().getTaskRun().getId();
+        assertThat(results.getLast().getTaskRun().getState().getCurrent()).isEqualTo(State.Type.WARNING);
+        LogEntry escalationLog = TestsUtils.awaitLog(logs, log -> taskRunId.equals(log.getTaskRunId()) && log.getMessage().contains("assetFailureBehavior"));
+        assertThat(escalationLog).isNotNull();
+        assertThat(escalationLog.getMessage()).contains("SUCCESS").contains("WARNING").contains("WARN");
     }
 
     private WorkerTaskProcessor newProcessor(WorkerQueue<WorkerTaskResult> resultQueue) {
@@ -147,6 +273,56 @@ class WorkerTaskProcessorTest {
             .build();
     }
 
+    private WorkerTask assetEmissionFailureWorkerTask(AssetFailureBehavior assetFailureBehavior) {
+        return assetEmissionFailureWorkerTask(assetFailureBehavior, false, false);
+    }
+
+    private WorkerTask assetEmissionFailureWorkerTask(AssetFailureBehavior assetFailureBehavior, boolean allowFailure, boolean allowWarning) {
+        AssetEmissionFailure task = AssetEmissionFailure.builder()
+            .type(AssetEmissionFailure.class.getName())
+            .id("asset-task")
+            .allowFailure(allowFailure)
+            .allowWarning(allowWarning)
+            // rendered value is a plain string, not JSON, so binding it as List<AssetIdentifier> fails
+            .assets(new AssetsDeclaration(Property.ofValue(false), Property.ofExpression("{{ 'not-json' }}"), Property.ofValue(List.of()), Property.ofValue(assetFailureBehavior)))
+            .build();
+
+        return workerTaskFor(task);
+    }
+
+    private WorkerTask taskFailsAndAssetEmissionFailsWorkerTask(AssetFailureBehavior assetFailureBehavior) {
+        return taskFailsAndAssetEmissionFailsWorkerTask(assetFailureBehavior, false);
+    }
+
+    private WorkerTask taskFailsAndAssetEmissionFailsWorkerTask(AssetFailureBehavior assetFailureBehavior, boolean allowFailure) {
+        AlwaysFail task = AlwaysFail.builder()
+            .type(AlwaysFail.class.getName())
+            .id("failing-asset-task")
+            .allowFailure(allowFailure)
+            // rendered value is a plain string, not JSON, so binding it as List<AssetIdentifier> fails
+            .assets(new AssetsDeclaration(Property.ofValue(false), Property.ofExpression("{{ 'not-json' }}"), Property.ofValue(List.of()), Property.ofValue(assetFailureBehavior)))
+            .build();
+
+        return workerTaskFor(task);
+    }
+
+    private WorkerTask workerTaskFor(Task task) {
+        Flow flow = Flow.builder()
+            .id(IdUtils.create())
+            .namespace("io.kestra.unit-test")
+            .tasks(List.of(task))
+            .build();
+
+        Execution execution = TestsUtils.mockExecution(flow, Map.of());
+        ResolvedTask resolvedTask = ResolvedTask.of(task);
+
+        return WorkerTask.builder()
+            .data(WorkerTaskData.from(runContextFactory.of(Map.of("key", "value"))))
+            .task(task)
+            .taskRun(TaskRun.of(execution, resolvedTask))
+            .build();
+    }
+
     private static List<WorkerTaskResult> drain(WorkerQueue<WorkerTaskResult> queue) throws InterruptedException {
         List<WorkerTaskResult> results = new ArrayList<>();
         WorkerTaskResult result;
@@ -167,6 +343,23 @@ class WorkerTaskProcessorTest {
         @Override
         public VoidOutput run(RunContext runContext) {
             throw new RuntimeException("simulated task failure during shutdown drain");
+        }
+    }
+
+    /**
+     * A task that succeeds on its own but whose asset declaration fails to render, modeling a task
+     * emitting a malformed asset. Constructed and executed directly by the processor, so no plugin
+     * registration is needed.
+     */
+    @SuperBuilder
+    @Getter
+    @NoArgsConstructor
+    public static class AssetEmissionFailure extends Task implements RunnableTask<VoidOutput> {
+        @Override
+        public VoidOutput run(RunContext runContext) {
+            // null, not new VoidOutput(): the empty bean has no properties and Jackson's
+            // FAIL_ON_EMPTY_BEANS would blow up when the processor serializes the output to a map
+            return null;
         }
     }
 }


### PR DESCRIPTION
- Add `QueryFilter.Field.LOCKED` (EQUALS only), exposed exclusively on `Resource.ASSET`'s supported fields, backing the Assets page's locked/unlocked filter (see companion kestra-io/kestra-ee PR)
- Add a task-level `assetFailureBehavior` property (`IGNORE` default / `FAIL` / `WARN`) so a task can escalate when rendering or emitting its asset declaration fails, instead of the failure being silently logged

Refs kestra-io/kestra-ee#9466, kestra-io/kestra-ee#9467