### PR TITLE
feat(execution): add support for allowed and denied list for HTTP tasks

### DIFF
--- a/core/src/main/java/io/kestra/core/http/client/HttpClient.java
+++ b/core/src/main/java/io/kestra/core/http/client/HttpClient.java
@@ -11,6 +11,7 @@ import java.security.KeyManagementException;
 import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
 import java.time.Duration;
+import java.util.Collections;
 import java.util.List;
 import java.util.function.Consumer;
 
@@ -526,6 +527,8 @@ public class HttpClient implements Closeable {
         HttpRequest request,
         HttpClientContext httpClientContext,
         HttpClientResponseHandler<HttpResponse<T>> responseHandler) throws HttpClientException {
+        validateUri(request.getUri());
+
         try {
             return this.client.execute(request.to(runContext), httpClientContext, responseHandler);
         } catch (SocketException e) {
@@ -540,6 +543,25 @@ public class HttpClient implements Closeable {
             }
 
             throw new RuntimeException(e);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private void validateUri(URI uri) {
+        String requestUri = uri.toString();
+        List<String> allowedList = (List<String>) ((DefaultRunContext) runContext).getTaskProperty("kestra.tasks.http.allowed-list", List.class).orElse(Collections.emptyList());
+        List<String> deniedList = (List<String>) ((DefaultRunContext) runContext).getTaskProperty("kestra.tasks.http.denied-list", List.class).orElse(Collections.emptyList());
+
+        // first check that if there is an allow list, it matches one
+        if (!allowedList.isEmpty()) {
+            if (allowedList.stream().noneMatch(requestUri::startsWith)) {
+                throw new IllegalArgumentException("The URI " +  requestUri + " is not in the configured allowed list (kestra.tasks.http.allowed-list).");
+            }
+        }
+
+        // then check that there are no exclusion for it
+        if (deniedList.stream().anyMatch(requestUri::startsWith)) {
+            throw new IllegalArgumentException("The URI " +  requestUri + " is in the configured denied list (kestra.tasks.http.denied-list).");
         }
     }
 

--- a/core/src/main/java/io/kestra/core/runners/DefaultRunContext.java
+++ b/core/src/main/java/io/kestra/core/runners/DefaultRunContext.java
@@ -65,9 +65,9 @@ public class DefaultRunContext extends RunContext {
     private SDK sdk;
 
     private Map<String, Object> variables;
-    private List<AbstractMetricEntry<?>> metrics = new ArrayList<>();
+    private List<AbstractMetricEntry<?>> metrics = new ArrayList<>(4); // init to 4 to save memory as tasks usually produce few metrics if any
     private RunContextLogger logger;
-    private final List<WorkerTaskResult> dynamicWorkerTaskResult = new ArrayList<>();
+    private final List<WorkerTaskResult> dynamicWorkerTaskResult = new ArrayList<>(0); // init to 0 to save memory: this is used by only one task
     private String triggerExecutionId;
     private Storage storage;
     private Map<String, Object> pluginConfiguration;
@@ -233,7 +233,6 @@ public class DefaultRunContext extends RunContext {
         runContext.variables = new HashMap<>(this.variables);
         runContext.workingDir = this.workingDir;
         runContext.logger = this.logger;
-        runContext.metrics = new ArrayList<>();
         runContext.storage = this.storage;
         runContext.pluginConfiguration = this.pluginConfiguration;
         runContext.secretInputs = this.secretInputs;
@@ -665,6 +664,19 @@ public class DefaultRunContext extends RunContext {
      */
     public Services services() {
         return new Services(this.applicationContext);
+    }
+
+    /**
+     * Get a task configuration property from the underlying application context.
+     * A task property is a property under the 'kestra.tasks' configuration root.
+     *
+     * @throws IllegalArgumentException if a property is not inside the 'kestra.tasks' configuration root.
+     */
+    public <T> Optional<T> getTaskProperty(String name, Class<T> clazz) {
+        if (!name.startsWith("kestra.tasks.")) {
+            throw new IllegalArgumentException("A plugin can only access configuration properties from the 'kestra.tasks' root property");
+        }
+        return this.applicationContext.getProperty(name, clazz);
     }
 
     /**

--- a/core/src/test/java/io/kestra/core/http/client/HttpClientTest.java
+++ b/core/src/test/java/io/kestra/core/http/client/HttpClientTest.java
@@ -229,6 +229,23 @@ class HttpClientTest {
         }
     }
 
+    @Test
+    void shouldDenyUrlFromConfig() throws IllegalVariableEvaluationException, IOException {
+        try (HttpClient client = client()) {
+            var exception = assertThrows(IllegalArgumentException.class, () -> client.request(
+                HttpRequest.of(URI.create("http://dangerous-url.com")),
+                String.class
+            ));
+            assertThat(exception.getMessage()).isEqualTo("The URI http://dangerous-url.com is in the configured denied list (kestra.tasks.http.denied-list).");
+
+            exception = assertThrows(IllegalArgumentException.class, () -> client.request(
+                HttpRequest.of(URI.create("http://dangerous-url.com/path")),
+                String.class
+            ));
+            assertThat(exception.getMessage()).isEqualTo("The URI http://dangerous-url.com/path is in the configured denied list (kestra.tasks.http.denied-list).");
+        }
+    }
+
     private static final String UUID = IdUtils.create();
 
     static Stream<Arguments> postJsonSource() throws JsonProcessingException {

--- a/core/src/test/java/io/kestra/plugin/core/http/RequestTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/http/RequestTest.java
@@ -115,12 +115,10 @@ class RequestTest {
 
     @Test
     void head404() throws Exception {
-        final String url = "https://bdnb-data.s3.fr-par.scw.cloud/bnb_export_metropole_sql_dump.tar.gz";
-
         Request task = Request.builder()
             .id(RequestTest.class.getSimpleName())
             .type(RequestTest.class.getName())
-            .uri(Property.ofValue(url))
+            .uri(Property.ofValue(serverUrl() + "/not-found"))
             .method(Property.ofValue("HEAD"))
             .build();
 

--- a/core/src/test/resources/application-test.yml
+++ b/core/src/test/resources/application-test.yml
@@ -76,6 +76,12 @@ kestra:
       - type: io.kestra.core.runners.test.task.Alias
         values:
           prop0: value0
+
+  tasks:
+    http:
+      denied-list:
+        - http://dangerous-url.com
+
   grpc:
     maxRetryAttempts: 1
     shutdownTimeout: 3s


### PR DESCRIPTION
HTTP tasks and functions can be exposed to SSRF as they can access any URLs from the server which include internal URLs.

Add support for configuring globally allowed and denied list of accessible URLs to protect against SSRF.

Fixes https://github.com/kestra-io/kestra-ee/issues/9037
