### PR TITLE
fix(core): run migrate CLI commands in a minimal application context

### DIFF
--- a/cli/src/main/java/io/kestra/cli/AbstractCommand.java
+++ b/cli/src/main/java/io/kestra/cli/AbstractCommand.java
@@ -15,7 +15,6 @@ import com.google.common.collect.ImmutableMap;
 
 import io.kestra.cli.commands.servers.ServerCommandInterface;
 import io.kestra.cli.services.StartupHookInterface;
-import io.kestra.core.migration.MigrationRunner;
 import io.kestra.core.plugins.PluginManager;
 import io.kestra.core.plugins.PluginRegistry;
 import io.kestra.core.services.FlowAutoLoader;
@@ -66,12 +65,6 @@ public abstract class AbstractCommand extends BaseCommand implements Callable<In
 
     @Option(names = { "-p", "--plugins" }, description = "Path to plugins directory")
     protected Path pluginsPath = Optional.ofNullable(System.getenv("KESTRA_PLUGINS_PATH")).map(Paths::get).orElse(null);
-
-    @SuppressWarnings("unused")
-    public static Map<String, Object> propertiesOverrides() {
-        MigrationRunner.setSkipAutoRun(true);
-        return Map.of();
-    }
 
     @Override
     public Integer call() throws Exception {

--- a/cli/src/main/java/io/kestra/cli/Kestra.java
+++ b/cli/src/main/java/io/kestra/cli/Kestra.java
@@ -12,6 +12,7 @@ import org.slf4j.bridge.SLF4JBridgeHandler;
 
 import io.kestra.cli.commands.configs.sys.ConfigCommand;
 import io.kestra.cli.commands.flows.FlowCommand;
+import io.kestra.cli.commands.migrations.AbstractMigrationCommand;
 import io.kestra.cli.commands.migrations.MigrationCommand;
 import io.kestra.cli.commands.namespaces.NamespaceCommand;
 import io.kestra.cli.commands.plugins.PluginCommand;
@@ -23,6 +24,11 @@ import io.kestra.cli.services.EnvironmentProvider;
 import io.micronaut.configuration.picocli.MicronautFactory;
 import io.micronaut.context.ApplicationContext;
 import io.micronaut.context.ApplicationContextBuilder;
+import io.micronaut.context.ApplicationContextConfiguration;
+import io.micronaut.context.DefaultApplicationContext;
+import io.micronaut.context.DefaultApplicationContextBuilder;
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.inject.BeanDefinitionReference;
 import picocli.CommandLine;
 import picocli.CommandLine.Command;
 
@@ -171,12 +177,16 @@ public class Kestra implements Callable<Integer> {
         CommandLine commandLine,
         String[] environments) {
 
-        ApplicationContextBuilder builder = ApplicationContext
-            .builder()
+        Class<?> cls = commandLine.getCommandSpec().userObject().getClass();
+
+        // Pure migration commands run in a minimal context that never registers the other
+        // Kestra @Context beans (repositories, server services, the migration startup trigger),
+        // so nothing touches the database before the migration is applied explicitly.
+        ApplicationContextBuilder builder = (AbstractMigrationCommand.class.isAssignableFrom(cls)
+            ? new MigrationApplicationContextBuilder()
+            : ApplicationContext.builder())
             .mainClass(mainClass)
             .environments(environments);
-
-        Class<?> cls = commandLine.getCommandSpec().userObject().getClass();
 
         if (AbstractCommand.class.isAssignableFrom(cls)) {
             Map<String, Object> properties = new HashMap<>();
@@ -234,5 +244,64 @@ public class Kestra implements Callable<Integer> {
      */
     private static boolean isPracticalCommand(CommandLine commandLine) {
         return !(commandLine.isUsageHelpRequested() || commandLine.isVersionHelpRequested());
+    }
+
+    /**
+     * Builder that produces a {@link MigrationApplicationContext} while applying all the standard
+     * properties/environments/property-sources wiring of {@link DefaultApplicationContextBuilder#build()}.
+     */
+    private static final class MigrationApplicationContextBuilder extends DefaultApplicationContextBuilder {
+        @Override
+        protected ApplicationContext newApplicationContext() {
+            return new MigrationApplicationContext(this);
+        }
+    }
+
+    /**
+     * Minimal {@link ApplicationContext} for the {@code kestra migrate} commands: it drops the
+     * eager {@code @Context} beans that only exist to serve a running server or a data/queue role
+     * (see {@link #RUNTIME_STARTUP_PROPERTIES}), including the migration startup trigger. Starting
+     * the context therefore initializes none of them, so nothing queries the database before the
+     * migration is applied. Framework and DI-infrastructure {@code @Context} beans (e.g. value
+     * extraction, expression evaluation) are kept, and the lazily-resolved migration runner, lock,
+     * history store and {@code DataSource} are pulled on demand by the command.
+     */
+    private static final class MigrationApplicationContext extends DefaultApplicationContext {
+        /**
+         * Properties whose presence activates a runtime (server/data/queue) role. An eager
+         * {@code @Context} bean gated on any of them is a startup bean we must not initialize in
+         * the migration context — otherwise it would connect to the database (or start a server
+         * facet) before the migration runs.
+         */
+        private static final Set<String> RUNTIME_STARTUP_PROPERTIES = Set.of(
+            "kestra.repository.type",
+            "kestra.queue.type",
+            "kestra.server-type"
+        );
+
+        MigrationApplicationContext(ApplicationContextConfiguration configuration) {
+            super(configuration);
+        }
+
+        @Override
+        protected List<BeanDefinitionReference> resolveBeanDefinitionReferences() {
+            return super.resolveBeanDefinitionReferences().stream()
+                .filter(reference -> !isRuntimeStartupBean(reference))
+                .toList();
+        }
+
+        private static boolean isRuntimeStartupBean(BeanDefinitionReference<?> reference) {
+            if (!reference.isContextScope()) {
+                return false;
+            }
+            return reference.getAnnotationMetadata()
+                .getAnnotationValuesByType(Requires.class)
+                .stream()
+                .anyMatch(
+                    requires -> requires.stringValue("property")
+                        .map(RUNTIME_STARTUP_PROPERTIES::contains)
+                        .orElse(false)
+                );
+        }
     }
 }

--- a/cli/src/main/java/io/kestra/cli/Kestra.java
+++ b/cli/src/main/java/io/kestra/cli/Kestra.java
@@ -258,26 +258,19 @@ public class Kestra implements Callable<Integer> {
     }
 
     /**
-     * Minimal {@link ApplicationContext} for the {@code kestra migrate} commands: it drops the
-     * eager {@code @Context} beans that only exist to serve a running server or a data/queue role
-     * (see {@link #RUNTIME_STARTUP_PROPERTIES}), including the migration startup trigger. Starting
-     * the context therefore initializes none of them, so nothing queries the database before the
-     * migration is applied. Framework and DI-infrastructure {@code @Context} beans (e.g. value
-     * extraction, expression evaluation) are kept, and the lazily-resolved migration runner, lock,
-     * history store and {@code DataSource} are pulled on demand by the command.
+     * Minimal {@link ApplicationContext} for the {@code kestra migrate} commands: it drops every
+     * <em>conditionally-registered</em> Kestra {@code @Context} bean — the migration startup
+     * trigger, the server/liveness services, any repository/queue-backed startup bean, and the EE
+     * feature validators. Starting the context therefore initializes none of them, so nothing
+     * queries the database (or starts a server/network facet) before the migration is applied.
+     *
+     * <p>
+     * Only <em>unconditional</em> {@code @Context} beans survive: those are Micronaut and Kestra
+     * DI infrastructure (value extraction, expression evaluation, temp-file config, …) that the
+     * command still needs to be instantiated. The migration runner and its lock, history store and
+     * {@code DataSource} are lazy {@code @Singleton}s, pulled on demand by the command.
      */
     private static final class MigrationApplicationContext extends DefaultApplicationContext {
-        /**
-         * Properties whose presence activates a runtime (server/data/queue) role. An eager
-         * {@code @Context} bean gated on any of them is a startup bean we must not initialize in
-         * the migration context — otherwise it would connect to the database (or start a server
-         * facet) before the migration runs.
-         */
-        private static final Set<String> RUNTIME_STARTUP_PROPERTIES = Set.of(
-            "kestra.repository.type",
-            "kestra.queue.type",
-            "kestra.server-type"
-        );
 
         MigrationApplicationContext(ApplicationContextConfiguration configuration) {
             super(configuration);
@@ -286,22 +279,25 @@ public class Kestra implements Callable<Integer> {
         @Override
         protected List<BeanDefinitionReference> resolveBeanDefinitionReferences() {
             return super.resolveBeanDefinitionReferences().stream()
-                .filter(reference -> !isRuntimeStartupBean(reference))
+                .filter(reference -> !isConditionalKestraStartupBean(reference))
                 .toList();
         }
 
-        private static boolean isRuntimeStartupBean(BeanDefinitionReference<?> reference) {
-            if (!reference.isContextScope()) {
-                return false;
-            }
-            return reference.getAnnotationMetadata()
-                .getAnnotationValuesByType(Requires.class)
-                .stream()
-                .anyMatch(
-                    requires -> requires.stringValue("property")
-                        .map(RUNTIME_STARTUP_PROPERTIES::contains)
-                        .orElse(false)
-                );
+        /**
+         * A Kestra {@code @Context} bean whose registration is conditional (carries a
+         * {@code @Requires}, directly or via a marker stereotype such as
+         * {@code @JdbcRepositoryEnabled}). Such beans exist only to serve a runtime role and must
+         * not eager-initialize in a migration context. Dropping <em>any</em> conditional Kestra
+         * {@code @Context} bean — rather than denylisting specific gating properties — keeps this
+         * robust against beans gated via {@code @Requires(beans = …)}, a different property, or a
+         * stereotype. {@code hasStereotype(Requires.class)} is the same signal Micronaut's own
+         * {@code RequiresCondition} uses, and it reads the reference metadata without loading the
+         * bean class.
+         */
+        private static boolean isConditionalKestraStartupBean(BeanDefinitionReference<?> reference) {
+            return reference.isContextScope()
+                && reference.getBeanDefinitionName().startsWith("io.kestra")
+                && reference.getAnnotationMetadata().hasStereotype(Requires.class);
         }
     }
 }

--- a/cli/src/main/java/io/kestra/cli/commands/migrations/AbstractMigrationCommand.java
+++ b/cli/src/main/java/io/kestra/cli/commands/migrations/AbstractMigrationCommand.java
@@ -1,0 +1,33 @@
+package io.kestra.cli.commands.migrations;
+
+import io.kestra.cli.AbstractCommand;
+
+/**
+ * Base class for the pure database-migration commands ({@code migrate run/plan/unlock/repair}).
+ *
+ * <p>
+ * Commands extending this class are executed against a <em>minimal</em> {@code ApplicationContext}:
+ * {@code Kestra} detects the marker and builds a context that does not register any Kestra
+ * {@code @Context} bean (repositories, server services, and the migration startup trigger). Only the
+ * lazily-resolved {@code MigrationRunner} / {@code MigrationLock} and their {@code DataSource} are
+ * started, so no other bean touches the database before the migration runs.
+ *
+ * <p>
+ * This is why these commands need no "skip auto-run" flag: the {@code @Context} startup trigger
+ * simply never exists in their context, so they resolve the runner and invoke it explicitly.
+ *
+ * <p>
+ * Migrations do not need plugins, so external plugin loading is disabled.
+ */
+public abstract class AbstractMigrationCommand extends AbstractCommand {
+
+    @Override
+    protected boolean loadExternalPlugins() {
+        return false;
+    }
+
+    @Override
+    protected boolean isPluginManagerEnabled() {
+        return false;
+    }
+}

--- a/cli/src/main/java/io/kestra/cli/commands/migrations/MigrationCommand.java
+++ b/cli/src/main/java/io/kestra/cli/commands/migrations/MigrationCommand.java
@@ -1,6 +1,5 @@
 package io.kestra.cli.commands.migrations;
 
-import io.kestra.cli.AbstractCommand;
 import io.kestra.cli.Kestra;
 
 import lombok.SneakyThrows;
@@ -19,7 +18,7 @@ import picocli.CommandLine;
     }
 )
 @Slf4j
-public class MigrationCommand extends AbstractCommand {
+public class MigrationCommand extends AbstractMigrationCommand {
     @SneakyThrows
     @Override
     public Integer call() throws Exception {

--- a/cli/src/main/java/io/kestra/cli/commands/migrations/PlanMigrationCommand.java
+++ b/cli/src/main/java/io/kestra/cli/commands/migrations/PlanMigrationCommand.java
@@ -1,9 +1,7 @@
 package io.kestra.cli.commands.migrations;
 
 import java.util.List;
-import java.util.Map;
 
-import io.kestra.cli.AbstractCommand;
 import io.kestra.core.migration.MigrationRunner;
 import io.kestra.core.migration.MigrationScript;
 import io.kestra.jdbc.migration.AbstractSQLMigrationScript;
@@ -29,21 +27,13 @@ import picocli.CommandLine;
     description = "Show the pending database migration scripts without applying them",
     mixinStandardHelpOptions = true
 )
-public class PlanMigrationCommand extends AbstractCommand {
+public class PlanMigrationCommand extends AbstractMigrationCommand {
 
     @Inject
     private MigrationRunner migrationRunner;
 
     @CommandLine.Option(names = { "-s", "--sql" }, description = "Also print the SQL of each pending migration (SQL-based migrations only).")
     private boolean sql = false;
-
-    @SuppressWarnings("unused")
-    public static Map<String, Object> propertiesOverrides() {
-        // Prevent the eager @Context MigrationRunner from applying migrations on startup,
-        // so this command can report what is pending without changing the database.
-        MigrationRunner.setSkipAutoRun(true);
-        return Map.of();
-    }
 
     @Override
     public Integer call() throws Exception {

--- a/cli/src/main/java/io/kestra/cli/commands/migrations/RepairMigrationCommand.java
+++ b/cli/src/main/java/io/kestra/cli/commands/migrations/RepairMigrationCommand.java
@@ -1,19 +1,17 @@
 package io.kestra.cli.commands.migrations;
 
-import io.kestra.cli.AbstractCommand;
 import io.kestra.core.migration.MigrationLockedException;
-import io.kestra.core.migration.MigrationRunner;
 import io.kestra.core.migration.MigrationRunnerInterface;
+
 import jakarta.inject.Inject;
 import lombok.extern.slf4j.Slf4j;
 import picocli.CommandLine;
 
-import java.util.Map;
-
 /**
  * CLI command that repairs the stored checksum for an already-applied migration script.
  *
- * <p>Usage: {@code kestra migrate repair 2.0.01-upgrade}
+ * <p>
+ * Usage: {@code kestra migrate repair 2.0.01-upgrade}
  */
 @Slf4j
 @CommandLine.Command(
@@ -21,7 +19,7 @@ import java.util.Map;
     description = "Repair the stored checksum for an already-applied migration script",
     mixinStandardHelpOptions = true
 )
-public class RepairMigrationCommand extends AbstractCommand {
+public class RepairMigrationCommand extends AbstractMigrationCommand {
 
     @CommandLine.Parameters(
         index = "0",
@@ -32,12 +30,6 @@ public class RepairMigrationCommand extends AbstractCommand {
 
     @Inject
     private MigrationRunnerInterface migrationRunner;
-
-    @SuppressWarnings("unused")
-    public static Map<String, Object> propertiesOverrides() {
-        MigrationRunner.setSkipAutoRun(true);
-        return Map.of();
-    }
 
     @Override
     public Integer call() throws Exception {

--- a/cli/src/main/java/io/kestra/cli/commands/migrations/RunMigrationCommand.java
+++ b/cli/src/main/java/io/kestra/cli/commands/migrations/RunMigrationCommand.java
@@ -1,10 +1,6 @@
 package io.kestra.cli.commands.migrations;
 
-import java.util.Map;
-
-import io.kestra.cli.AbstractCommand;
 import io.kestra.core.migration.MigrationLockedException;
-import io.kestra.core.migration.MigrationRunner;
 import io.kestra.core.migration.MigrationRunnerInterface;
 
 import jakarta.inject.Inject;
@@ -32,16 +28,10 @@ import picocli.CommandLine;
     description = "Apply all pending database migration scripts",
     mixinStandardHelpOptions = true
 )
-public class RunMigrationCommand extends AbstractCommand {
+public class RunMigrationCommand extends AbstractMigrationCommand {
 
     @Inject
     private MigrationRunnerInterface migrationRunner;
-
-    @SuppressWarnings("unused")
-    public static Map<String, Object> propertiesOverrides() {
-        MigrationRunner.setSkipAutoRun(true);
-        return Map.of();
-    }
 
     @Override
     public Integer call() throws Exception {

--- a/cli/src/main/java/io/kestra/cli/commands/migrations/UnlockMigrationCommand.java
+++ b/cli/src/main/java/io/kestra/cli/commands/migrations/UnlockMigrationCommand.java
@@ -1,10 +1,6 @@
 package io.kestra.cli.commands.migrations;
 
-import java.util.Map;
-
-import io.kestra.cli.AbstractCommand;
 import io.kestra.core.migration.MigrationLock;
-import io.kestra.core.migration.MigrationRunner;
 
 import jakarta.inject.Inject;
 import lombok.extern.slf4j.Slf4j;
@@ -27,16 +23,10 @@ import picocli.CommandLine;
     description = "Force-release the migration lock",
     mixinStandardHelpOptions = true
 )
-public class UnlockMigrationCommand extends AbstractCommand {
+public class UnlockMigrationCommand extends AbstractMigrationCommand {
 
     @Inject
     private MigrationLock migrationLock;
-
-    @SuppressWarnings("unused")
-    public static Map<String, Object> propertiesOverrides() {
-        MigrationRunner.setSkipAutoRun(true);
-        return Map.of();
-    }
 
     @Override
     public Integer call() throws Exception {

--- a/cli/src/test/java/io/kestra/cli/commands/migrations/MigrationApplicationContextTest.java
+++ b/cli/src/test/java/io/kestra/cli/commands/migrations/MigrationApplicationContextTest.java
@@ -1,0 +1,57 @@
+package io.kestra.cli.commands.migrations;
+
+import java.nio.file.Paths;
+
+import javax.sql.DataSource;
+
+import org.junit.jupiter.api.Test;
+
+import io.kestra.cli.Kestra;
+import io.kestra.core.migration.MigrationRunner;
+import io.kestra.core.migration.MigrationRunnerInterface;
+import io.kestra.core.migration.MigrationStartupRunner;
+
+import io.micronaut.context.ApplicationContext;
+import io.micronaut.context.env.Environment;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Verifies the minimal {@code ApplicationContext} that {@link Kestra} builds for migration commands:
+ * the migration runner and its {@link DataSource} must be available, but the {@code @Context}
+ * {@link MigrationStartupRunner} (and, by the same rule, every other Kestra {@code @Context} bean)
+ * must not be registered — so starting the context never auto-applies migrations or touches the DB.
+ */
+class MigrationApplicationContextTest {
+
+    private static final String[] MIGRATE_RUN = {
+        "migrate", "run",
+        "-c", Paths.get(System.getProperty("java.io.tmpdir"), "kestra-ctx-test-no-such-config.yml").toString()
+    };
+
+    @Test
+    void migrationContext_startsRunnerAndDataSource_butNotTheStartupTrigger() {
+        try (
+            ApplicationContext ctx = Kestra.applicationContext(
+                Kestra.class,
+                new String[] { Environment.CLI, Environment.TEST },
+                MIGRATE_RUN
+            )
+        ) {
+            ctx.start();
+
+            // The runner and its datasource are resolvable (lazily) in the minimal context.
+            assertThat(ctx.containsBean(MigrationRunnerInterface.class)).isTrue();
+            assertThat(ctx.containsBean(MigrationRunner.class)).isTrue();
+            assertThat(ctx.containsBean(DataSource.class)).isTrue();
+
+            // The @Context startup trigger was filtered out, so nothing auto-migrates on start.
+            assertThat(ctx.containsBean(MigrationStartupRunner.class)).isFalse();
+
+            // Migrations are therefore still pending (no auto-run happened).
+            assertThat(ctx.getBean(MigrationRunner.class).pendingScripts()).isNotEmpty();
+        } catch (Exception e) {
+            throw new AssertionError("Minimal migration context failed", e);
+        }
+    }
+}

--- a/cli/src/test/java/io/kestra/cli/commands/migrations/MigrationApplicationContextTest.java
+++ b/cli/src/test/java/io/kestra/cli/commands/migrations/MigrationApplicationContextTest.java
@@ -1,6 +1,11 @@
 package io.kestra.cli.commands.migrations;
 
 import java.nio.file.Paths;
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.List;
 
 import javax.sql.DataSource;
 
@@ -19,8 +24,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * Verifies the minimal {@code ApplicationContext} that {@link Kestra} builds for migration commands:
  * the migration runner and its {@link DataSource} must be available, but the {@code @Context}
- * {@link MigrationStartupRunner} (and, by the same rule, every other Kestra {@code @Context} bean)
- * must not be registered — so starting the context never auto-applies migrations or touches the DB.
+ * {@link MigrationStartupRunner} (and, by the same rule, every other conditionally-gated Kestra
+ * {@code @Context} bean) must not be registered — so starting the context never auto-applies
+ * migrations or touches the DB.
  */
 class MigrationApplicationContextTest {
 
@@ -29,17 +35,19 @@ class MigrationApplicationContextTest {
         "-c", Paths.get(System.getProperty("java.io.tmpdir"), "kestra-ctx-test-no-such-config.yml").toString()
     };
 
-    @Test
-    void migrationContext_startsRunnerAndDataSource_butNotTheStartupTrigger() {
-        try (
-            ApplicationContext ctx = Kestra.applicationContext(
-                Kestra.class,
-                new String[] { Environment.CLI, Environment.TEST },
-                MIGRATE_RUN
-            )
-        ) {
-            ctx.start();
+    private ApplicationContext migrationContext() {
+        ApplicationContext ctx = Kestra.applicationContext(
+            Kestra.class,
+            new String[] { Environment.CLI, Environment.TEST },
+            MIGRATE_RUN
+        );
+        ctx.start();
+        return ctx;
+    }
 
+    @Test
+    void migrationContext_startsRunnerAndDataSource_butNotTheStartupTrigger() throws Exception {
+        try (ApplicationContext ctx = migrationContext()) {
             // The runner and its datasource are resolvable (lazily) in the minimal context.
             assertThat(ctx.containsBean(MigrationRunnerInterface.class)).isTrue();
             assertThat(ctx.containsBean(MigrationRunner.class)).isTrue();
@@ -50,8 +58,63 @@ class MigrationApplicationContextTest {
 
             // Migrations are therefore still pending (no auto-run happened).
             assertThat(ctx.getBean(MigrationRunner.class).pendingScripts()).isNotEmpty();
-        } catch (Exception e) {
-            throw new AssertionError("Minimal migration context failed", e);
         }
+    }
+
+    @Test
+    void migrationContext_doesNotTouchTheDatabaseOnStartup() throws Exception {
+        try (ApplicationContext ctx = migrationContext()) {
+            DataSource dataSource = unwrappedDataSource(ctx);
+
+            // Empirical invariant: right after start(), no eager bean has hit the database, so the
+            // schema is empty. Any repository/queue/startup @Context bean that slipped through the
+            // filter would have bootstrapped tables here.
+            assertThat(publicTables(dataSource)).isEmpty();
+
+            // Applying migrations explicitly then creates the schema, including the history table.
+            ctx.getBean(MigrationRunnerInterface.class).runAlways();
+            assertThat(publicTables(dataSource))
+                .isNotEmpty()
+                .anyMatch("kestra_migration_history"::equalsIgnoreCase);
+        }
+    }
+
+    /**
+     * The injected {@link DataSource} is Micronaut Data's contextual proxy, whose connections
+     * require an active {@code @Connectable} scope. Unwrap it via {@code io.micronaut.jdbc.DataSourceResolver}
+     * — the same class {@code JdbcMigrationHistoryStore} uses — so the test can open a plain
+     * connection. Reflection is used because {@code micronaut-jdbc} is not on the cli test
+     * <em>compile</em> classpath (only at runtime).
+     */
+    private static DataSource unwrappedDataSource(ApplicationContext ctx) throws Exception {
+        DataSource dataSource = ctx.getBean(DataSource.class);
+        Class<?> resolverType = Class.forName("io.micronaut.jdbc.DataSourceResolver");
+        return ctx.findBean(resolverType)
+            .map(resolver ->
+            {
+                try {
+                    return (DataSource) resolverType.getMethod("resolve", DataSource.class)
+                        .invoke(resolver, dataSource);
+                } catch (ReflectiveOperationException e) {
+                    throw new IllegalStateException(e);
+                }
+            })
+            .orElse(dataSource);
+    }
+
+    private static List<String> publicTables(DataSource dataSource) throws Exception {
+        List<String> tables = new ArrayList<>();
+        try (
+            Connection connection = dataSource.getConnection();
+            Statement statement = connection.createStatement();
+            ResultSet resultSet = statement.executeQuery(
+                "SELECT table_name FROM information_schema.tables WHERE table_schema = 'PUBLIC'"
+            )
+        ) {
+            while (resultSet.next()) {
+                tables.add(resultSet.getString(1));
+            }
+        }
+        return tables;
     }
 }

--- a/cli/src/test/java/io/kestra/cli/commands/migrations/PlanMigrationCommandTest.java
+++ b/cli/src/test/java/io/kestra/cli/commands/migrations/PlanMigrationCommandTest.java
@@ -2,10 +2,12 @@ package io.kestra.cli.commands.migrations;
 
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
+import java.nio.file.Paths;
 
 import org.junit.jupiter.api.Test;
 
-import io.kestra.core.migration.MigrationRunner;
+import io.kestra.cli.Kestra;
+import io.kestra.core.migration.MigrationRunnerInterface;
 
 import io.micronaut.configuration.picocli.PicocliRunner;
 import io.micronaut.context.ApplicationContext;
@@ -13,7 +15,34 @@ import io.micronaut.context.env.Environment;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+/**
+ * Tests {@code migrate plan} against the real minimal migration context built by {@link Kestra}
+ * for {@link AbstractMigrationCommand}s. Because that context never registers the
+ * {@code @Context MigrationStartupRunner}, no migration is auto-applied on startup, so every script
+ * stays pending until it is applied explicitly.
+ */
 class PlanMigrationCommandTest {
+
+    // Force a non-existent --config so the command does not pick up the developer's ~/.kestra/config.yml;
+    // the h2 datasource comes from application-test.yml (TEST environment) instead.
+    private static final String[] NO_CONFIG = {
+        "-c", Paths.get(System.getProperty("java.io.tmpdir"), "kestra-plan-test-no-such-config.yml").toString()
+    };
+
+    private ApplicationContext migrationContext(String... args) {
+        String[] full = new String[2 + NO_CONFIG.length + args.length];
+        full[0] = "migrate";
+        full[1] = "plan";
+        System.arraycopy(NO_CONFIG, 0, full, 2, NO_CONFIG.length);
+        System.arraycopy(args, 0, full, 2 + NO_CONFIG.length, args.length);
+        ApplicationContext ctx = Kestra.applicationContext(
+            Kestra.class,
+            new String[] { Environment.CLI, Environment.TEST },
+            full
+        );
+        ctx.start();
+        return ctx;
+    }
 
     @Test
     void plan_listsPendingMigrations_whenNothingApplied() {
@@ -21,14 +50,10 @@ class PlanMigrationCommandTest {
         PrintStream originalOut = System.out;
         System.setOut(new PrintStream(out));
 
-        // Skip auto-run so the fresh in-memory H2 keeps every migration pending
-        // (this is what PlanMigrationCommand.propertiesOverrides() does in production).
-        MigrationRunner.setSkipAutoRun(true);
-        try (ApplicationContext ctx = ApplicationContext.run(Environment.CLI, Environment.TEST)) {
+        try (ApplicationContext ctx = migrationContext()) {
             Integer call = PicocliRunner.call(PlanMigrationCommand.class, ctx);
             assertThat(call).isZero();
         } finally {
-            MigrationRunner.setSkipAutoRun(false);
             System.setOut(originalOut);
         }
 
@@ -42,12 +67,10 @@ class PlanMigrationCommandTest {
         PrintStream originalOut = System.out;
         System.setOut(new PrintStream(out));
 
-        MigrationRunner.setSkipAutoRun(true);
-        try (ApplicationContext ctx = ApplicationContext.run(Environment.CLI, Environment.TEST)) {
+        try (ApplicationContext ctx = migrationContext()) {
             Integer call = PicocliRunner.call(PlanMigrationCommand.class, ctx, "--sql");
             assertThat(call).isZero();
         } finally {
-            MigrationRunner.setSkipAutoRun(false);
             System.setOut(originalOut);
         }
 
@@ -57,14 +80,15 @@ class PlanMigrationCommandTest {
     }
 
     @Test
-    void plan_reportsNoPending_whenDatabaseUpToDate() {
+    void plan_reportsNoPending_afterMigrationsApplied() throws Exception {
         ByteArrayOutputStream out = new ByteArrayOutputStream();
         PrintStream originalOut = System.out;
         System.setOut(new PrintStream(out));
 
-        // Default behaviour: migrations auto-run on startup, so nothing should be pending afterwards.
-        MigrationRunner.setSkipAutoRun(false);
-        try (ApplicationContext ctx = ApplicationContext.run(Environment.CLI, Environment.TEST)) {
+        try (ApplicationContext ctx = migrationContext()) {
+            // Apply every migration explicitly in this context, then plan must report none.
+            ctx.getBean(MigrationRunnerInterface.class).runAlways();
+
             Integer call = PicocliRunner.call(PlanMigrationCommand.class, ctx);
             assertThat(call).isZero();
         } finally {

--- a/core/src/main/java/io/kestra/core/migration/MigrationRunner.java
+++ b/core/src/main/java/io/kestra/core/migration/MigrationRunner.java
@@ -5,17 +5,13 @@ import java.util.Collection;
 import java.util.Comparator;
 import java.util.List;
 
-import io.micronaut.context.annotation.Context;
 import io.micronaut.context.annotation.Requires;
-import io.micronaut.core.annotation.Order;
-import io.micronaut.core.order.Ordered;
-import jakarta.annotation.PostConstruct;
 import jakarta.inject.Inject;
-import lombok.SneakyThrows;
+import jakarta.inject.Singleton;
 import lombok.extern.slf4j.Slf4j;
 
 /**
- * Orchestrates the execution of all pending {@link MigrationScript}s on startup.
+ * Orchestrates the execution of all pending {@link MigrationScript}s.
  *
  * <p>
  * This bean is backend-agnostic — it delegates all storage and locking concerns to
@@ -23,10 +19,12 @@ import lombok.extern.slf4j.Slf4j;
  * active repository backend (JDBC or Elasticsearch).
  *
  * <p>
- * This service is {@code @Context} — it is eagerly initialized during
- * {@code ApplicationContext.start()}, before any repository or service bean queries the database.
- * {@link #initOnStartup()} runs all pending migrations unconditionally in OSS; EE overrides
- * this method to add opt-in auto-run behavior and fresh-instance detection.
+ * This is an ordinary {@code @Singleton} service. Automatic migration on startup is triggered by
+ * the {@code @Context} {@link MigrationStartupRunner}, which calls {@link #autoRun()} before any
+ * repository or service bean queries the database. {@link #autoRun()} runs all pending migrations
+ * unconditionally in OSS; EE overrides it to add opt-in auto-run behavior and fresh-instance
+ * detection. The {@code kestra migrate} CLI commands resolve this bean in a minimal context (which
+ * does not register {@link MigrationStartupRunner}) and invoke the relevant method directly.
  *
  * <p>
  * Execution flow:
@@ -42,8 +40,7 @@ import lombok.extern.slf4j.Slf4j;
  * </ol>
  */
 @Slf4j
-@Context
-@Order(Ordered.HIGHEST_PRECEDENCE)
+@Singleton
 @Requires(property = "kestra.repository.type")
 public class MigrationRunner implements MigrationRunnerInterface {
 
@@ -53,17 +50,6 @@ public class MigrationRunner implements MigrationRunnerInterface {
      * (the schema already exists from Flyway migrations).
      */
     static final List<String> INIT_SCRIPT_IDS = List.of("0-init", "0-init-ee", "0-init-queue", "0-init-queue-ee");
-
-    /**
-     * Set to {@code true} by CLI commands (e.g. {@code migrate run}, {@code migrate unlock})
-     * that handle migrations explicitly. When set, {@link #initOnStartup()} skips automatic
-     * migration execution during context startup.
-     */
-    protected static volatile boolean skipAutoRun = false;
-
-    public static void setSkipAutoRun(boolean skip) {
-        skipAutoRun = skip;
-    }
 
     protected volatile boolean hasRun = false;
 
@@ -82,29 +68,14 @@ public class MigrationRunner implements MigrationRunnerInterface {
     }
 
     /**
-     * Called once at context startup (eagerly, before any repository bean is initialized).
-     * Delegates to {@link #autoRun()} so EE can override startup behavior without
-     * needing to redeclare {@code @PostConstruct} (which is not inherited by overriding methods
-     * in Micronaut's compile-time annotation processing).
-     */
-    @PostConstruct
-    @SneakyThrows
-    protected final void initOnStartup() {
-        if (skipAutoRun) {
-            log.debug("Migration auto-run skipped (skipAutoRun flag set).");
-            return;
-        }
-        autoRun();
-    }
-
-    /**
-     * Runs migrations at context startup. OSS always applies all pending scripts.
-     * EE overrides this to respect the {@code kestra.migration.auto} configuration
-     * and handle fresh-instance detection.
+     * Runs migrations at startup, invoked by {@link MigrationStartupRunner} before any repository
+     * bean is initialized. OSS always applies all pending scripts. EE overrides this to respect the
+     * {@code kestra.migration.auto} configuration and handle fresh-instance detection.
      *
      * @throws Exception if a migration fails
      */
-    protected void autoRun() throws Exception {
+    @Override
+    public void autoRun() throws Exception {
         runAlways();
     }
 

--- a/core/src/main/java/io/kestra/core/migration/MigrationRunnerInterface.java
+++ b/core/src/main/java/io/kestra/core/migration/MigrationRunnerInterface.java
@@ -4,11 +4,24 @@ package io.kestra.core.migration;
  * Common interface for migration runners, shared by the JDBC and Elasticsearch implementations.
  *
  * <p>
- * Implementations are Micronaut {@code @Context} beans that run eagerly on
- * {@code ApplicationContext.start()} via {@code @PostConstruct}, before any repository or
- * service bean is initialized.
+ * Implementations are ordinary {@code @Singleton} beans. Automatic migration on startup is
+ * triggered by the {@code @Context} {@link MigrationStartupRunner}, which calls {@link #autoRun()}
+ * before any repository or service bean is initialized. The {@code kestra migrate} CLI commands
+ * resolve the runner in a minimal context (which does not register the startup trigger) and invoke
+ * the relevant method directly.
  */
 public interface MigrationRunnerInterface {
+
+    /**
+     * Runs migrations at startup. OSS applies all pending scripts unconditionally; EE respects the
+     * {@code kestra.migration.auto} configuration and handles fresh-instance detection.
+     *
+     * <p>
+     * Invoked by {@link MigrationStartupRunner} during {@code ApplicationContext.start()}.
+     *
+     * @throws Exception if a migration fails
+     */
+    void autoRun() throws Exception;
 
     /**
      * Unconditionally runs all pending migration scripts, bypassing any auto-run configuration.

--- a/core/src/main/java/io/kestra/core/migration/MigrationScript.java
+++ b/core/src/main/java/io/kestra/core/migration/MigrationScript.java
@@ -13,9 +13,10 @@ import io.micronaut.core.annotation.Nullable;
  * Represents a single versioned migration script.
  *
  * <p>
- * Implementations are Micronaut {@code @Singleton} beans. Because {@code MigrationRunner} is a
- * {@code @Context} bean, all dependencies injected into a script are eagerly instantiated during
- * application startup. Scripts must only depend on low-level infrastructure:
+ * Implementations are Micronaut {@code @Singleton} beans. Because the {@code @Context}
+ * {@code MigrationStartupRunner} resolves the runner (and therefore every script) during
+ * application startup, all dependencies injected into a script are eagerly instantiated at that
+ * early stage. Scripts must only depend on low-level infrastructure:
  * {@code DataSource} / {@code JooqDSLContextWrapper} for JDBC, {@code OpenSearchClient} for
  * Elasticsearch, storages, and simple {@code @ConfigurationProperties} records. Never inject
  * repositories or services — their transitive dependencies will fail to initialize at this early

--- a/core/src/main/java/io/kestra/core/migration/MigrationStartupRunner.java
+++ b/core/src/main/java/io/kestra/core/migration/MigrationStartupRunner.java
@@ -1,0 +1,45 @@
+package io.kestra.core.migration;
+
+import io.micronaut.context.annotation.Context;
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.core.annotation.Order;
+import io.micronaut.core.order.Ordered;
+import jakarta.annotation.PostConstruct;
+import jakarta.inject.Inject;
+import lombok.SneakyThrows;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Triggers automatic database migration on {@code ApplicationContext.start()}.
+ *
+ * <p>
+ * This bean is {@code @Context} and ordered {@link Ordered#HIGHEST_PRECEDENCE}, so it is eagerly
+ * initialized before any repository or service bean queries the database. It delegates to
+ * {@link MigrationRunnerInterface#autoRun()} — the OSS runner applies all pending scripts, while the
+ * EE runner respects {@code kestra.migration.auto} and handles fresh-instance detection.
+ *
+ * <p>
+ * The startup trigger is intentionally kept separate from {@link MigrationRunner} so the runner
+ * itself is an ordinary {@code @Singleton}. The {@code kestra migrate} CLI commands resolve the
+ * runner in a minimal context that never registers this trigger, and invoke the runner directly —
+ * which is why no "skip auto-run" flag is needed.
+ */
+@Slf4j
+@Context
+@Order(Ordered.HIGHEST_PRECEDENCE)
+@Requires(property = "kestra.repository.type")
+public class MigrationStartupRunner {
+
+    private final MigrationRunnerInterface migrationRunner;
+
+    @Inject
+    public MigrationStartupRunner(final MigrationRunnerInterface migrationRunner) {
+        this.migrationRunner = migrationRunner;
+    }
+
+    @PostConstruct
+    @SneakyThrows
+    void onStartup() {
+        migrationRunner.autoRun();
+    }
+}

--- a/core/src/test/java/io/kestra/core/migration/MigrationRunnerTest.java
+++ b/core/src/test/java/io/kestra/core/migration/MigrationRunnerTest.java
@@ -340,25 +340,20 @@ class MigrationRunnerTest {
     }
 
     @Test
-    void initOnStartup_skipsWhenSkipAutoRunIsTrue() {
-        // Given
+    void autoRun_appliesAllPendingScripts() throws Exception {
+        // Given: OSS autoRun() applies every pending script (this is what MigrationStartupRunner
+        // triggers at context startup).
         AtomicInteger callCount = new AtomicInteger(0);
         MigrationRunner runner = new MigrationRunner(
             noOpLock, new InMemoryHistoryStore(),
             List.of(simpleScript("2.0.01-upgrade", callCount::incrementAndGet))
         );
 
-        try {
-            MigrationRunner.setSkipAutoRun(true);
+        // When
+        runner.autoRun();
 
-            // When
-            runner.initOnStartup();
-
-            // Then
-            assertThat(callCount.get()).isEqualTo(0);
-        } finally {
-            MigrationRunner.setSkipAutoRun(false);
-        }
+        // Then
+        assertThat(callCount.get()).isEqualTo(1);
     }
 
     @Test


### PR DESCRIPTION
Closes #17612

## Problem

`kestra migrate {run,plan,unlock,repair}` started a **full** `ApplicationContext` before the migration ran. `new MicronautFactory(ctx)` starts the context — eagerly initializing every `@Context` bean (which connects to the DB) — *before* picocli executes the command, so the `skipAutoRun` flag only silenced the runner, not the rest.

## Fix

- `MigrationRunner` is now a plain `@Singleton`; the startup trigger moved to a dedicated `@Context @Order(HIGHEST_PRECEDENCE)` `MigrationStartupRunner` with the **same** `@Requires(kestra.repository.type)` gating — so server startup and tests are unchanged.
- The migration commands (new shared `AbstractMigrationCommand` base) run against a minimal context whose `resolveBeanDefinitionReferences()` drops eager `@Context` beans gated on a runtime property (`repository.type` / `queue.type` / `server-type`) — the startup trigger and any data/server bean — while keeping DI infrastructure. The runner is resolved lazily and invoked directly.
- The `skipAutoRun` static is removed entirely.

## Tests

- New `MigrationApplicationContextTest` guards the minimal context (runner + `DataSource` present, startup trigger absent, migrations pending).
- `:cli:test` (63) and core/EE migration suites green.

> Companion EE PR: kestra-io/kestra-ee (references #17612).