### PR TITLE
feat(core): add ProtectedZipInputStream to guard against ZIP-bomb attacks

### DIFF
--- a/core/src/main/java/io/kestra/core/models/HasSource.java
+++ b/core/src/main/java/io/kestra/core/models/HasSource.java
@@ -10,6 +10,8 @@ import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 import java.util.zip.ZipOutputStream;
 
+import io.kestra.core.security.ProtectedZipInputStream;
+import io.kestra.core.security.SecurityConfiguration.ZipBombProtectionConfiguration;
 import io.micronaut.http.multipart.CompletedFileUpload;
 
 /**
@@ -56,11 +58,13 @@ public interface HasSource {
     /**
      * Static helper method for reading an uploaded source or archive file.
      *
+     * @param zipBombProtection the ZIP-bomb protection configuration applied when the upload is a
+     *        ZIP archive, may be {@code null} to disable protection.
      * @param fileUpload the upload file.
      * @param reader the source reader.
      * @throws IOException if the file cannot be read.
      */
-    static void readSourceFile(final CompletedFileUpload fileUpload, final BiConsumer<String, String> reader) throws IOException {
+    static void readSourceFile(final ZipBombProtectionConfiguration zipBombProtection, final CompletedFileUpload fileUpload, final BiConsumer<String, String> reader) throws IOException {
         String fileName = fileUpload.getFilename().toLowerCase();
         try (InputStream inputStream = fileUpload.getInputStream()) {
 
@@ -73,7 +77,7 @@ public interface HasSource {
                 }
             } else if (fileName.endsWith(".zip")) {
 
-                try (ZipInputStream archive = new ZipInputStream(inputStream)) {
+                try (ZipInputStream archive = ProtectedZipInputStream.of(inputStream, zipBombProtection)) {
                     ZipEntry entry;
                     while ((entry = archive.getNextEntry()) != null) {
                         if (entry.isDirectory() || !isYAML(entry.getName())) {

--- a/core/src/main/java/io/kestra/core/security/ProtectedZipInputStream.java
+++ b/core/src/main/java/io/kestra/core/security/ProtectedZipInputStream.java
@@ -1,0 +1,109 @@
+package io.kestra.core.security;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipInputStream;
+
+import io.kestra.core.security.SecurityConfiguration.ZipBombProtectionConfiguration;
+
+/**
+ * A {@link ZipInputStream} that guards against ZIP-bomb attacks by enforcing a maximum
+ * number of entries and a maximum uncompressed size per entry.
+ * <p>
+ * Both limits are checked <em>during</em> decompression rather than after an entry has
+ * been fully buffered into memory: the entry count is checked as soon as an entry is
+ * opened, and the per-entry size is checked on every {@code read()} call, so an oversized
+ * entry fails before it is fully read (e.g. via {@code readAllBytes()}) rather than after.
+ */
+public class ProtectedZipInputStream extends ZipInputStream {
+
+    private final int maxEntries;
+    private final long maxEntrySize;
+    private int entryCount = 0;
+    private long currentEntryBytes = 0;
+
+    /**
+     * Returns a {@link ZipInputStream} enforcing the given ZIP-bomb protection
+     * configuration, or a plain {@link ZipInputStream} when the configuration is
+     * {@code null} or disabled.
+     *
+     * @param inputStream the underlying stream to read the ZIP archive from.
+     * @param config the ZIP-bomb protection configuration, may be {@code null}.
+     * @return a protected or plain {@link ZipInputStream} depending on the configuration.
+     */
+    public static ZipInputStream of(final InputStream inputStream, final ZipBombProtectionConfiguration config) {
+        if (config == null || !Boolean.TRUE.equals(config.enabled())) {
+            return new ZipInputStream(inputStream);
+        }
+        return new ProtectedZipInputStream(inputStream, config.maxNumberOfEntries(), config.maxEntrySize());
+    }
+
+    private ProtectedZipInputStream(final InputStream inputStream, final int maxEntries, final int maxEntrySize) {
+        super(inputStream);
+        this.maxEntries = maxEntries;
+        this.maxEntrySize = maxEntrySize;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @throws ZipBombDetectedException if opening this entry would exceed the configured
+     *         maximum number of entries.
+     */
+    @Override
+    public ZipEntry getNextEntry() throws IOException {
+        ZipEntry entry = super.getNextEntry();
+        if (entry != null) {
+            entryCount++;
+            if (entryCount > maxEntries) {
+                throw ZipBombDetectedException.tooManyEntries(maxEntries);
+            }
+            currentEntryBytes = 0;
+        }
+        return entry;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @throws ZipBombDetectedException if the current entry's uncompressed size exceeds
+     *         the configured maximum entry size.
+     */
+    @Override
+    public int read(byte[] b, int off, int len) throws IOException {
+        int n = super.read(b, off, len);
+        if (n > 0) {
+            currentEntryBytes += n;
+            if (currentEntryBytes > maxEntrySize) {
+                throw ZipBombDetectedException.entryTooLarge(maxEntrySize);
+            }
+        }
+        return n;
+    }
+
+    /**
+     * Exception thrown when a ZIP archive violates the configured ZIP-bomb protection
+     * limits. Extends {@link IllegalArgumentException} so it is handled the same way as
+     * other invalid-user-input errors (e.g. mapped to an HTTP 422 response by the webserver).
+     */
+    public static final class ZipBombDetectedException extends IllegalArgumentException {
+        private ZipBombDetectedException(String message) {
+            super(message);
+        }
+
+        private static ZipBombDetectedException tooManyEntries(int maxEntries) {
+            return new ZipBombDetectedException(
+                "Cannot decompress the archive because it contains more than %d entries. This limit is enforced by ZIP-bomb protection (kestra.security.zip-bomb-protection.max-number-of-entries)."
+                    .formatted(maxEntries)
+            );
+        }
+
+        private static ZipBombDetectedException entryTooLarge(long maxEntrySize) {
+            return new ZipBombDetectedException(
+                "Cannot decompress this archive entry because its uncompressed size exceeds %d bytes. This limit is enforced by ZIP-bomb protection (kestra.security.zip-bomb-protection.max-entry-size)."
+                    .formatted(maxEntrySize)
+            );
+        }
+    }
+}

--- a/core/src/main/java/io/kestra/core/security/SecurityConfiguration.java
+++ b/core/src/main/java/io/kestra/core/security/SecurityConfiguration.java
@@ -1,0 +1,38 @@
+package io.kestra.core.security;
+
+import java.util.Objects;
+
+import io.micronaut.context.annotation.ConfigurationProperties;
+import io.micronaut.core.annotation.Nullable;
+import io.micronaut.core.bind.annotation.Bindable;
+
+/**
+ * Configuration for security-related guards applied to user-supplied input.
+ */
+@ConfigurationProperties("kestra.security")
+public record SecurityConfiguration(
+    @Nullable ZipBombProtectionConfiguration zipBombProtection
+) {
+
+    /**
+     * Configuration for the ZIP-bomb protection enforced by {@link ProtectedZipInputStream}
+     * when decompressing a user-uploaded ZIP archive.
+     *
+     * @param enabled whether the protection is active. Defaults to {@code false}.
+     * @param maxNumberOfEntries the maximum number of entries allowed in the archive.
+     * @param maxEntrySize the maximum uncompressed size, in bytes, allowed for a single entry.
+     */
+    @ConfigurationProperties("zip-bomb-protection")
+    public record ZipBombProtectionConfiguration(
+        @Bindable(defaultValue = "false") Boolean enabled,
+        @Nullable Integer maxNumberOfEntries,
+        @Nullable Integer maxEntrySize
+    ) {
+        public ZipBombProtectionConfiguration {
+            if (Boolean.TRUE.equals(enabled)) {
+                Objects.requireNonNull(maxNumberOfEntries, "maxNumberOfEntries");
+                Objects.requireNonNull(maxEntrySize, "maxEntrySize");
+            }
+        }
+    }
+}

--- a/core/src/test/java/io/kestra/core/models/HasSourceTest.java
+++ b/core/src/test/java/io/kestra/core/models/HasSourceTest.java
@@ -21,7 +21,7 @@ class HasSourceTest {
 
         // When - Then the unsupported type is reported as an IllegalArgumentException
         // instead of a StringIndexOutOfBoundsException raised by substring(-1)
-        assertThatThrownBy(() -> HasSource.readSourceFile(fileUpload, (source, name) ->
+        assertThatThrownBy(() -> HasSource.readSourceFile(null, fileUpload, (source, name) ->
         {
         }))
             .isInstanceOf(IllegalArgumentException.class)

--- a/core/src/test/java/io/kestra/core/security/ProtectedZipInputStreamTest.java
+++ b/core/src/test/java/io/kestra/core/security/ProtectedZipInputStreamTest.java
@@ -1,0 +1,147 @@
+package io.kestra.core.security;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipInputStream;
+import java.util.zip.ZipOutputStream;
+
+import org.junit.jupiter.api.Test;
+
+import io.kestra.core.security.ProtectedZipInputStream.ZipBombDetectedException;
+import io.kestra.core.security.SecurityConfiguration.ZipBombProtectionConfiguration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class ProtectedZipInputStreamTest {
+
+    private static byte[] zipOf(String... entryContents) throws IOException {
+        try (
+            ByteArrayOutputStream bos = new ByteArrayOutputStream();
+            ZipOutputStream archive = new ZipOutputStream(bos)
+        ) {
+            for (int i = 0; i < entryContents.length; i++) {
+                archive.putNextEntry(new ZipEntry("entry-" + i + ".yaml"));
+                archive.write(entryContents[i].getBytes(StandardCharsets.UTF_8));
+                archive.closeEntry();
+            }
+            archive.finish();
+            return bos.toByteArray();
+        }
+    }
+
+    @Test
+    void shouldReadAllEntriesWhenWithinLimits() throws IOException {
+        // Given a ZIP with 2 small entries and a config allowing up to 3 entries of 100 bytes
+        byte[] zip = zipOf("hello", "world");
+        ZipBombProtectionConfiguration config = new ZipBombProtectionConfiguration(true, 3, 100);
+
+        // When reading all entries through the protected stream
+        int count = 0;
+        try (ZipInputStream archive = ProtectedZipInputStream.of(new ByteArrayInputStream(zip), config)) {
+            ZipEntry entry;
+            while ((entry = archive.getNextEntry()) != null) {
+                assertThat(archive.readAllBytes()).isNotEmpty();
+                count++;
+            }
+        }
+
+        // Then every entry was read successfully
+        assertThat(count).isEqualTo(2);
+    }
+
+    @Test
+    void shouldSucceedWhenExactlyAtEntryCountAndSizeLimit() throws IOException {
+        // Given a ZIP with exactly as many entries, and exactly as large a payload, as the config allows
+        byte[] zip = zipOf("12345", "67890");
+        ZipBombProtectionConfiguration config = new ZipBombProtectionConfiguration(true, 2, 5);
+
+        // When reading every entry through the protected stream
+        int count = 0;
+        try (ZipInputStream archive = ProtectedZipInputStream.of(new ByteArrayInputStream(zip), config)) {
+            ZipEntry entry;
+            while ((entry = archive.getNextEntry()) != null) {
+                assertThat(archive.readAllBytes()).hasSize(5);
+                count++;
+            }
+        }
+
+        // Then no limit is exceeded: exactly maxEntries entries of exactly maxEntrySize bytes each succeed
+        assertThat(count).isEqualTo(2);
+    }
+
+    @Test
+    void shouldThrowZipBombDetectedExceptionWhenTooManyEntries() throws IOException {
+        // Given a ZIP with 3 entries but a config allowing only 2
+        byte[] zip = zipOf("a", "b", "c");
+        ZipBombProtectionConfiguration config = new ZipBombProtectionConfiguration(true, 2, 100);
+
+        // When reading past the allowed number of entries
+        // Then a ZipBombDetectedException is thrown, naming the violated config key
+        assertThatThrownBy(() -> {
+            try (ZipInputStream archive = ProtectedZipInputStream.of(new ByteArrayInputStream(zip), config)) {
+                while (archive.getNextEntry() != null) {
+                    archive.readAllBytes();
+                }
+            }
+        })
+            .isInstanceOf(ZipBombDetectedException.class)
+            .hasMessageContaining("more than 2 entries")
+            .hasMessageContaining("kestra.security.zip-bomb-protection.max-number-of-entries");
+    }
+
+    @Test
+    void shouldThrowZipBombDetectedExceptionWhenEntryTooLarge() throws IOException {
+        // Given a single entry larger than the configured max entry size
+        byte[] zip = zipOf("this content is way larger than the tiny configured limit");
+        ZipBombProtectionConfiguration config = new ZipBombProtectionConfiguration(true, 10, 10);
+
+        // When fully reading that entry
+        // Then a ZipBombDetectedException is thrown before the whole entry is buffered
+        assertThatThrownBy(() -> {
+            try (ZipInputStream archive = ProtectedZipInputStream.of(new ByteArrayInputStream(zip), config)) {
+                archive.getNextEntry();
+                archive.readAllBytes();
+            }
+        })
+            .isInstanceOf(ZipBombDetectedException.class)
+            .hasMessageContaining("exceeds 10 bytes")
+            .hasMessageContaining("kestra.security.zip-bomb-protection.max-entry-size");
+    }
+
+    @Test
+    void shouldReturnPlainZipInputStreamWhenConfigDisabled() throws IOException {
+        // Given a ZIP exceeding a disabled config's limits
+        byte[] zip = zipOf("a", "b", "c");
+        ZipBombProtectionConfiguration disabled = new ZipBombProtectionConfiguration(false, 1, 1);
+
+        // When reading through the returned stream
+        int count = 0;
+        try (ZipInputStream archive = ProtectedZipInputStream.of(new ByteArrayInputStream(zip), disabled)) {
+            assertThat(archive).isNotInstanceOf(ProtectedZipInputStream.class);
+            ZipEntry entry;
+            while ((entry = archive.getNextEntry()) != null) {
+                archive.readAllBytes();
+                count++;
+            }
+        }
+
+        // Then no limit is enforced
+        assertThat(count).isEqualTo(3);
+    }
+
+    @Test
+    void shouldReturnPlainZipInputStreamWhenConfigNull() throws IOException {
+        // Given a ZIP and a null config
+        byte[] zip = zipOf("a", "b", "c");
+
+        // When obtaining a stream
+        try (ZipInputStream archive = ProtectedZipInputStream.of(new ByteArrayInputStream(zip), null)) {
+            // Then a plain, unprotected ZipInputStream is returned
+            assertThat(archive).isNotInstanceOf(ProtectedZipInputStream.class);
+        }
+    }
+}

--- a/webserver/src/main/java/io/kestra/webserver/controllers/api/FlowController.java
+++ b/webserver/src/main/java/io/kestra/webserver/controllers/api/FlowController.java
@@ -28,6 +28,7 @@ import io.kestra.core.models.validations.ModelValidator;
 import io.kestra.core.models.validations.ValidateConstraintViolation;
 import io.kestra.core.queues.QueueException;
 import io.kestra.core.repositories.FlowRepositoryInterface;
+import io.kestra.core.security.SecurityConfiguration;
 import io.kestra.core.serializers.JacksonMapper;
 import io.kestra.core.serializers.YamlParser;
 import io.kestra.core.services.ExpressionCategory;
@@ -101,6 +102,9 @@ public class FlowController {
 
     @Inject
     private ExpressionContextService expressionContextService;
+
+    @Inject
+    private SecurityConfiguration securityConfiguration;
 
     @ExecuteOn(TaskExecutors.IO)
     @Get(uri = "{namespace}/{id}/graph")
@@ -856,7 +860,7 @@ public class FlowController {
         String tenantId = tenantService.resolveTenant();
         final List<String> wrongFiles = new ArrayList<>();
         try {
-            HasSource.readSourceFile(fileUpload, (source, name) ->
+            HasSource.readSourceFile(securityConfiguration.zipBombProtection(), fileUpload, (source, name) ->
             {
                 try {
                     this.importFlow(tenantId, source);

--- a/webserver/src/main/java/io/kestra/webserver/controllers/api/NamespaceFileController.java
+++ b/webserver/src/main/java/io/kestra/webserver/controllers/api/NamespaceFileController.java
@@ -21,6 +21,8 @@ import io.kestra.core.models.QueryFilter;
 import io.kestra.core.models.namespaces.files.NamespaceFileMetadata;
 import io.kestra.core.namespace.NamespaceFileService;
 import io.kestra.core.repositories.ArrayListTotal;
+import io.kestra.core.security.ProtectedZipInputStream;
+import io.kestra.core.security.SecurityConfiguration;
 import io.kestra.core.services.FlowService;
 import io.kestra.core.storages.*;
 import io.kestra.core.tenant.TenantService;
@@ -60,6 +62,8 @@ public class NamespaceFileController {
     private NamespaceFactory namespaceFactory;
     @Inject
     private NamespaceFileService namespaceFileService;
+    @Inject
+    private SecurityConfiguration securityConfiguration;
 
     private final List<Pattern> forbiddenPathPatterns = List.of(
         Pattern.compile("/" + FLOWS_FOLDER + "(/.*)?$")
@@ -202,7 +206,7 @@ public class NamespaceFileController {
         String tenantId = tenantService.resolveTenant();
         List<NamespaceFile> createdFiles = new ArrayList<>();
         if (fileContent.getFilename().toLowerCase().endsWith(".zip")) {
-            try (ZipInputStream archive = new ZipInputStream(fileContent.getInputStream())) {
+            try (ZipInputStream archive = ProtectedZipInputStream.of(fileContent.getInputStream(), securityConfiguration.zipBombProtection())) {
                 ZipEntry entry;
                 while ((entry = archive.getNextEntry()) != null) {
                     if (entry.isDirectory()) {

--- a/webserver/src/test/java/io/kestra/webserver/controllers/api/FlowControllerZipBombTest.java
+++ b/webserver/src/test/java/io/kestra/webserver/controllers/api/FlowControllerZipBombTest.java
@@ -1,0 +1,75 @@
+package io.kestra.webserver.controllers.api;
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import org.junit.jupiter.api.Test;
+
+import io.micronaut.context.annotation.Property;
+import io.micronaut.http.HttpRequest;
+import io.micronaut.http.MediaType;
+import io.micronaut.http.client.annotation.Client;
+import io.micronaut.http.client.exceptions.HttpClientResponseException;
+import io.micronaut.http.client.multipart.MultipartBody;
+import io.micronaut.reactor.http.client.ReactorHttpClient;
+import jakarta.inject.Inject;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * Verifies that {@code /flows/import} rejects a ZIP archive violating the configured
+ * ZIP-bomb protection limits with an HTTP 422, instead of decompressing it.
+ */
+@MicronautTest
+@Property(name = "kestra.security.zip-bomb-protection.enabled", value = "true")
+@Property(name = "kestra.security.zip-bomb-protection.max-number-of-entries", value = "2")
+@Property(name = "kestra.security.zip-bomb-protection.max-entry-size", value = "1000")
+class FlowControllerZipBombTest {
+
+    @Inject
+    @Client("/")
+    ReactorHttpClient client;
+
+    @Test
+    void shouldRejectZipWithTooManyEntries() throws IOException {
+        // Given a ZIP archive with more entries than the configured limit allows
+        File zip = File.createTempFile("flows-bomb", ".zip");
+        try (
+            ByteArrayOutputStream bos = new ByteArrayOutputStream();
+            ZipOutputStream archive = new ZipOutputStream(bos)
+        ) {
+            for (int i = 0; i < 3; i++) {
+                archive.putNextEntry(new ZipEntry("flow-" + i + ".yaml"));
+                archive.write(("id: flow-" + i + "\nnamespace: io.kestra.tests\ntasks:\n  - id: t\n    type: io.kestra.plugin.core.log.Log\n    message: hello").getBytes());
+                archive.closeEntry();
+            }
+            archive.finish();
+            Files.write(zip.toPath(), bos.toByteArray());
+        }
+
+        var body = MultipartBody.builder()
+            .addPart("fileUpload", "flows.zip", zip)
+            .build();
+
+        // When importing that archive
+        HttpClientResponseException exception = assertThrows(
+            HttpClientResponseException.class,
+            () -> client.toBlocking().exchange(
+                HttpRequest.POST("/api/v1/main/flows/import", body).contentType(MediaType.MULTIPART_FORM_DATA)
+            )
+        );
+
+        // Then the import is rejected with a 422, naming the violated ZIP-bomb protection limit
+        assertThat(exception.getStatus().getCode()).isEqualTo(422);
+        assertThat(exception.getResponse().getBody(String.class).orElse(""))
+            .contains("kestra.security.zip-bomb-protection.max-number-of-entries");
+
+        zip.delete();
+    }
+}

--- a/webserver/src/test/java/io/kestra/webserver/controllers/api/NamespaceFileControllerZipBombTest.java
+++ b/webserver/src/test/java/io/kestra/webserver/controllers/api/NamespaceFileControllerZipBombTest.java
@@ -1,0 +1,77 @@
+package io.kestra.webserver.controllers.api;
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import org.junit.jupiter.api.Test;
+
+import io.kestra.core.utils.TestsUtils;
+
+import io.micronaut.context.annotation.Property;
+import io.micronaut.http.HttpRequest;
+import io.micronaut.http.MediaType;
+import io.micronaut.http.client.annotation.Client;
+import io.micronaut.http.client.exceptions.HttpClientResponseException;
+import io.micronaut.http.client.multipart.MultipartBody;
+import io.micronaut.reactor.http.client.ReactorHttpClient;
+import jakarta.inject.Inject;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * Verifies that {@code /namespaces/{namespace}/files} rejects a ZIP archive violating the
+ * configured ZIP-bomb protection limits with an HTTP 422, instead of decompressing it.
+ */
+@MicronautTest
+@Property(name = "kestra.security.zip-bomb-protection.enabled", value = "true")
+@Property(name = "kestra.security.zip-bomb-protection.max-number-of-entries", value = "1000")
+@Property(name = "kestra.security.zip-bomb-protection.max-entry-size", value = "10")
+class NamespaceFileControllerZipBombTest {
+
+    @Inject
+    @Client("/")
+    ReactorHttpClient client;
+
+    @Test
+    void shouldRejectZipWithEntryLargerThanConfiguredLimit() throws IOException {
+        // Given a ZIP archive with a single entry larger than the configured max entry size
+        String namespace = TestsUtils.randomNamespace();
+        File zip = File.createTempFile("namespace-files-bomb", ".zip");
+        try (
+            ByteArrayOutputStream bos = new ByteArrayOutputStream();
+            ZipOutputStream archive = new ZipOutputStream(bos)
+        ) {
+            archive.putNextEntry(new ZipEntry("oversized.txt"));
+            archive.write("this content is way larger than the ten byte configured limit".getBytes());
+            archive.closeEntry();
+            archive.finish();
+            Files.write(zip.toPath(), bos.toByteArray());
+        }
+
+        var body = MultipartBody.builder()
+            .addPart("fileContent", "files.zip", zip)
+            .build();
+
+        // When uploading that archive
+        HttpClientResponseException exception = assertThrows(
+            HttpClientResponseException.class,
+            () -> client.toBlocking().exchange(
+                HttpRequest.POST("/api/v1/main/namespaces/" + namespace + "/files?path=/ignored.zip", body)
+                    .contentType(MediaType.MULTIPART_FORM_DATA_TYPE)
+            )
+        );
+
+        // Then the upload is rejected with a 422, naming the violated ZIP-bomb protection limit
+        assertThat(exception.getStatus().getCode()).isEqualTo(422);
+        assertThat(exception.getResponse().getBody(String.class).orElse(""))
+            .contains("kestra.security.zip-bomb-protection.max-entry-size");
+
+        zip.delete();
+    }
+}


### PR DESCRIPTION
## Summary
- Adds a reusable `ProtectedZipInputStream extends ZipInputStream` (`core/.../security/`) that enforces a max entry count and a max per-entry uncompressed size, checked *during* decompression rather than after an entry is fully buffered — replacing the duplicated, buggy inline guard that had to be copied at every ZIP-read call site.
- Wires it into the two places that decompress a **user-uploaded** ZIP archive: flow import (`HasSource.readSourceFile`) and namespace file upload (`NamespaceFileController`). Two other ZIP-read sites (`WorkingDirectory` cache, `WorkerTaskProcessor` cache) decompress Kestra's own trusted internal archives, not user input, and were left untouched by design.
- New opt-in config `kestra.security.zip-bomb-protection.{enabled,max-number-of-entries,max-entry-size}` (disabled by default). A violation throws an unchecked `ZipBombDetectedException extends IllegalArgumentException`, which rides the existing `IllegalArgumentExceptionHandler` to an HTTP 422.
- A companion EE PR (kestra-io/kestra-ee#9488) wires the same protection into `BackupService.restore` for user-restorable backups. That PR originally needed a `ProtectedZipFile` (random-access `ZipFile` sibling) since restore looked up entries by name; it was later refactored to a single forward `ZipInputStream` pass instead (backup archives always write their header entry first and resources in a fixed order), so `ProtectedZipFile` was added and then removed in this same PR — only `ProtectedZipInputStream` remains, with a single protection mechanism shared by both consumers.

## Test plan
- [x] New unit tests: `ProtectedZipInputStreamTest` (6 cases — within limits, exactly-at-boundary, too-many-entries, entry-too-large, disabled/null config passthrough)
- [x] `HasSourceTest` updated for the new signature
- [x] New end-to-end webserver tests: `FlowControllerZipBombTest`, `NamespaceFileControllerZipBombTest` (assert HTTP 422 on a bomb upload)
- [x] Existing `FlowControllerTest` (63 tests) and `NamespaceFileControllerTest` (23 tests) re-run with zero regressions
- [x] Code-reviewed (approved, no blocking findings) across two rounds