### PR TITLE
feat(triggers): allow recovering missed schedules when re-enabling a trigger

### DIFF
--- a/core/src/main/java/io/kestra/core/scheduler/events/SetDisableTrigger.java
+++ b/core/src/main/java/io/kestra/core/scheduler/events/SetDisableTrigger.java
@@ -10,19 +10,28 @@ import jakarta.annotation.Nullable;
 
 /**
  * A command to disable/enable a trigger.
+ *
+ * @param recoverMissedSchedules when {@code true}, missed schedules are recovered on re-enable according to the
+ *                               trigger's own {@code recoverMissedSchedules} configuration;
+ *                               {@code null} or {@code false} means missed schedules are skipped.
  */
 public record SetDisableTrigger(
     TriggerId id,
     boolean disabled,
+    @Nullable Boolean recoverMissedSchedules,
     Instant timestamp,
     EventId eventId,
     @Nullable String operationId) implements TriggerEvent, AsyncOperation {
 
     public SetDisableTrigger(TriggerId id, Boolean disabled) {
-        this(id, disabled, Instant.now(), EventId.create(), null);
+        this(id, disabled, null);
+    }
+
+    public SetDisableTrigger(TriggerId id, Boolean disabled, @Nullable Boolean recoverMissedSchedules) {
+        this(id, disabled, recoverMissedSchedules, Instant.now(), EventId.create(), null);
     }
 
     public SetDisableTrigger withOperationId(String operationId) {
-        return new SetDisableTrigger(id, disabled, timestamp, eventId, operationId);
+        return new SetDisableTrigger(id, disabled, recoverMissedSchedules, timestamp, eventId, operationId);
     }
 }

--- a/core/src/test/java/io/kestra/scheduler/events/TriggerEventTest.java
+++ b/core/src/test/java/io/kestra/scheduler/events/TriggerEventTest.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 
 import io.kestra.core.models.triggers.TriggerId;
 import io.kestra.core.scheduler.events.ResetTrigger;
+import io.kestra.core.scheduler.events.SetDisableTrigger;
 import io.kestra.core.scheduler.events.TriggerCreated;
 import io.kestra.core.scheduler.events.TriggerEvent;
 import io.kestra.core.scheduler.events.TriggerEventType;
@@ -25,6 +26,27 @@ class TriggerEventTest {
         // When - then
         String serialized = JacksonMapper.ofJson().writeValueAsString(event);
         assertThat(JacksonMapper.ofJson().readValue(serialized, TriggerEvent.class)).isEqualTo(event);
+    }
+
+    @Test
+    void shouldDeserializeSetDisableTriggerWithoutRecoverMissedSchedulesWhenPayloadIsFromOlderVersion() throws JsonProcessingException {
+        // Given - a payload serialized by a version predating the recoverMissedSchedules field
+        String serialized = """
+            {
+              "type": "SET_DISABLE_TRIGGER",
+              "id": {"tenantId": "tenant", "namespace": "namespace", "flowId": "flow", "triggerId": "trigger"},
+              "disabled": false,
+              "timestamp": "2026-01-01T00:00:00Z",
+              "eventId": "01942e9a-7b3c-7000-8000-000000000000"
+            }
+            """;
+
+        // When
+        TriggerEvent event = JacksonMapper.ofJson().readValue(serialized, TriggerEvent.class);
+
+        // Then
+        assertThat(event).isInstanceOf(SetDisableTrigger.class);
+        assertThat(((SetDisableTrigger) event).recoverMissedSchedules()).isNull();
     }
 
     @Test

--- a/scheduler/src/main/java/io/kestra/scheduler/TriggerEventHandler.java
+++ b/scheduler/src/main/java/io/kestra/scheduler/TriggerEventHandler.java
@@ -13,6 +13,7 @@ import io.kestra.core.async.AsyncOperation;
 import io.kestra.core.async.AsyncOperationProcessedEvent;
 import io.kestra.core.async.AsyncOperationService;
 import io.kestra.core.events.EventId;
+import io.kestra.core.exceptions.IllegalVariableEvaluationException;
 import io.kestra.core.models.conditions.ConditionContext;
 import io.kestra.core.models.executions.Execution;
 import io.kestra.core.models.executions.ExecutionKilled;
@@ -24,6 +25,8 @@ import io.kestra.core.models.flows.State;
 import io.kestra.core.models.triggers.AbstractTrigger;
 import io.kestra.core.models.triggers.Backfill;
 import io.kestra.core.models.triggers.PollingTriggerInterface;
+import io.kestra.core.models.triggers.RecoverMissedSchedules;
+import io.kestra.core.models.triggers.Schedulable;
 import io.kestra.core.models.triggers.TriggerContext;
 import io.kestra.core.models.triggers.TriggerId;
 import io.kestra.core.queues.BroadcastQueueInterface;
@@ -53,6 +56,7 @@ import io.kestra.core.utils.Logs;
 import io.kestra.scheduler.internals.NextEvaluationDate;
 import io.kestra.scheduler.stores.FlowMetaStore;
 
+import jakarta.annotation.Nullable;
 import jakarta.inject.Inject;
 import jakarta.inject.Named;
 import jakarta.inject.Singleton;
@@ -233,16 +237,83 @@ public class TriggerEventHandler {
             state = state
                 .lastEventId(clock, event.eventId())
                 .disabled(clock, event.disabled());
-            // if the trigger is re-enabled, re-compute the next evaluation date
-            // this is required to not backfill all missed scheduling after re-enabling trigger.
+            // if the trigger is re-enabled, re-compute the next evaluation date so missed schedules
+            // are not backfilled, unless the event requests a specific recovery behavior.
             if (wasDisabled && !event.disabled()) {
                 Pair<Flow, AbstractTrigger> data = findTrigger(event, null);
                 if (data.getRight() != null) {
-                    state = state.updateForNextEvaluationDate(clock, nextEvaluationDate(clock, data.getLeft(), data.getRight(), state.context()));
+                    state = updateForReEnabledTrigger(clock, state, data.getLeft(), data.getRight(), event.recoverMissedSchedules());
                 }
             }
             triggerStateStore.save(state);
         });
+    }
+
+    /**
+     * Updates the state of a re-enabled trigger. When recovery is requested, missed schedules are recovered
+     * according to the trigger's own {@code recoverMissedSchedules} configuration; the configuration is always
+     * re-resolved (never overridden per action) so that this decision and the scheduler startup recovery
+     * ({@code TriggerScheduler#onStart}) stay consistent across restarts and vNode re-assignments.
+     * By default (no recovery requested), missed schedules are skipped by re-computing the next evaluation date.
+     */
+    private TriggerState updateForReEnabledTrigger(Clock clock, TriggerState state, Flow flow,
+            AbstractTrigger trigger, @Nullable Boolean recoverMissedSchedules) {
+        return switch (resolveRecoverMissedSchedules(flow, trigger, recoverMissedSchedules)) {
+            // Keep the frozen past nextEvaluationDate so the scheduling loop replays each missed tick.
+            case ALL -> state.getNextEvaluationDate() != null
+                ? state
+                : state.updateForNextEvaluationDate(clock, nextEvaluationDate(clock, flow, trigger, state.context()));
+            case LAST -> updateForLastMissedSchedule(clock, state, flow, trigger);
+            // Also advance evaluatedAt so the startup recovery cannot resurrect the skipped schedules.
+            case NONE -> state
+                .evaluatedAt(clock, ZonedDateTime.now(clock))
+                .updateForNextEvaluationDate(clock, nextEvaluationDateSkippingMissed(clock, state, flow, trigger));
+        };
+    }
+
+    private RecoverMissedSchedules resolveRecoverMissedSchedules(Flow flow, AbstractTrigger trigger,
+            @Nullable Boolean recoverMissedSchedules) {
+        if (!Boolean.TRUE.equals(recoverMissedSchedules) || !(trigger instanceof Schedulable schedulable)) {
+            return RecoverMissedSchedules.NONE;
+        }
+        return Optional.ofNullable(schedulable.getRecoverMissedSchedules())
+            .orElseGet(() -> schedulable.defaultRecoverMissedSchedules(runContextFactory.of(flow, trigger)));
+    }
+
+    private TriggerState updateForLastMissedSchedule(Clock clock, TriggerState state, Flow flow, AbstractTrigger trigger) {
+        // A running backfill must resume untouched: recomputing the next evaluation date would re-derive
+        // the backfill from the new date and silently drop or corrupt its remaining range.
+        if (state.getBackfill() != null) {
+            return state;
+        }
+        // Never evaluated (e.g. created disabled): there is no missed schedule to recover, and the last
+        // cron tick before now could even predate the trigger's creation.
+        if (state.getEvaluatedAt() == null) {
+            return state.updateForNextEvaluationDate(clock, nextEvaluationDateSkippingMissed(clock, state, flow, trigger));
+        }
+        RunContext runContext = runContextFactory.of(flow, trigger);
+        ConditionContext conditionContext = conditionService.conditionContext(runContext, flow, null);
+        try {
+            ZonedDateTime previousDate = ((Schedulable) trigger).previousEvaluationDate(conditionContext);
+            if (previousDate.toInstant().isAfter(state.getEvaluatedAt())) {
+                return state.updateForNextEvaluationDate(clock, previousDate);
+            }
+            // Nothing was missed: keep the stored next evaluation date.
+            return state;
+        } catch (IllegalVariableEvaluationException e) {
+            Logs.logTrigger(state, Level.WARN, "Cannot compute the previous evaluation date, missed schedules will be skipped. Cause: {}", e.getMessage());
+            return state.updateForNextEvaluationDate(clock, nextEvaluationDateSkippingMissed(clock, state, flow, trigger));
+        }
+    }
+
+    /**
+     * Computes the next evaluation date of a re-enabled trigger so that missed schedules are skipped: the stale
+     * pre-disable evaluation date is dropped from the trigger context so the computation seeds from now, while a
+     * running backfill is preserved so it resumes from its current date.
+     */
+    private ZonedDateTime nextEvaluationDateSkippingMissed(Clock clock, TriggerState state, Flow flow, AbstractTrigger trigger) {
+        TriggerContext context = state.context().toBuilder().date(null).build();
+        return nextEvaluationDate(clock, flow, trigger, context);
     }
 
     /**

--- a/scheduler/src/test/java/io/kestra/scheduler/TriggerEventHandlerTest.java
+++ b/scheduler/src/test/java/io/kestra/scheduler/TriggerEventHandlerTest.java
@@ -22,6 +22,7 @@ import io.kestra.core.models.executions.ExecutionKilledTrigger;
 import io.kestra.core.models.flows.FlowWithSource;
 import io.kestra.core.models.flows.State;
 import io.kestra.core.models.triggers.Backfill;
+import io.kestra.core.models.triggers.RecoverMissedSchedules;
 import io.kestra.core.models.triggers.TriggerEvaluationResult;
 import io.kestra.core.models.triggers.TriggerId;
 import io.kestra.core.queues.BroadcastQueueInterface;
@@ -307,6 +308,191 @@ class TriggerEventHandlerTest {
         assertThat(updated.get().getUpdatedAt()).isAfter(triggerState.getUpdatedAt());
         assertThat(updated.get().getNextEvaluationDate()).isAfter(initialNextEvaluationDate.toInstant());
         assertThat(updated.get().getLastEventId()).isEqualTo(event.eventId());
+    }
+
+    @Test
+    void shouldSkipMissedSchedulesWhenReEnablingTriggerPreviouslyEvaluated() {
+        // GIVEN: a trigger evaluated 45 minutes before being disabled, re-enabled without any recovery behavior
+        ZonedDateTime evaluatedAt = SchedulerClock.now().minusMinutes(45);
+        triggerStateStore.save(
+            triggerState
+                .evaluatedAt(CLOCK, evaluatedAt)
+                .updateForNextEvaluationDate(CLOCK, evaluatedAt.plusMinutes(15))
+                .disabled(CLOCK, true)
+        );
+        handler = newTriggerEventHandler(List.of(Fixtures.defaultFlow()));
+        SetDisableTrigger event = new SetDisableTrigger(triggerId, false);
+
+        // WHEN
+        Instant beforeHandler = Instant.now();
+        handler.handle(CLOCK, TEST_VNODE, event);
+
+        // THEN: the next evaluation date is in the future, no missed schedule is replayed
+        Optional<TriggerState> updated = triggerStateStore.findById(triggerId);
+        assertThat(updated).isPresent();
+        assertThat(updated.get().isDisabled()).isFalse();
+        assertThat(updated.get().getNextEvaluationDate()).isAfter(beforeHandler);
+    }
+
+    @Test
+    void shouldAdvanceEvaluatedAtWhenReEnablingTriggerWithoutRecovery() {
+        // GIVEN: a trigger evaluated 45 minutes before being disabled
+        ZonedDateTime evaluatedAt = SchedulerClock.now().minusMinutes(45);
+        triggerStateStore.save(
+            triggerState
+                .evaluatedAt(CLOCK, evaluatedAt)
+                .updateForNextEvaluationDate(CLOCK, evaluatedAt.plusMinutes(15))
+                .disabled(CLOCK, true)
+        );
+        handler = newTriggerEventHandler(List.of(Fixtures.defaultFlow()));
+        SetDisableTrigger event = new SetDisableTrigger(triggerId, false);
+
+        // WHEN
+        handler.handle(CLOCK, TEST_VNODE, event);
+
+        // THEN: evaluatedAt is advanced so the startup recovery cannot resurrect the skipped schedules
+        Optional<TriggerState> updated = triggerStateStore.findById(triggerId);
+        assertThat(updated).isPresent();
+        assertThat(updated.get().getEvaluatedAt()).isAfter(evaluatedAt.toInstant());
+        assertThat(updated.get().getEvaluatedAt()).isBeforeOrEqualTo(Instant.now());
+    }
+
+    @Test
+    void shouldKeepPastNextEvaluationDateWhenReEnablingTriggerWithRecoverTrueAndNoConfiguration() {
+        // GIVEN: a trigger without any recoverMissedSchedules configuration (plugin default is ALL)
+        ZonedDateTime initialNextEvaluationDate = SchedulerClock.now().minusMinutes(30);
+        triggerStateStore.save(triggerState.updateForNextEvaluationDate(CLOCK, initialNextEvaluationDate).disabled(CLOCK, true));
+        handler = newTriggerEventHandler(List.of(Fixtures.defaultFlow()));
+        SetDisableTrigger event = new SetDisableTrigger(triggerId, false, true);
+
+        // WHEN
+        handler.handle(CLOCK, TEST_VNODE, event);
+
+        // THEN: the frozen past next evaluation date is kept so every missed schedule replays
+        Optional<TriggerState> updated = triggerStateStore.findById(triggerId);
+        assertThat(updated).isPresent();
+        assertThat(updated.get().isDisabled()).isFalse();
+        assertThat(updated.get().getNextEvaluationDate()).isEqualTo(initialNextEvaluationDate.toInstant());
+    }
+
+    @Test
+    void shouldSetNextEvaluationDateToLastMissedScheduleWhenReEnablingTriggerWithRecoverTrueAndConfiguredLast() {
+        // GIVEN: a trigger configured with recoverMissedSchedules: LAST, evaluated 45 minutes before being disabled
+        ZonedDateTime evaluatedAt = SchedulerClock.now().minusMinutes(45);
+        triggerStateStore.save(
+            triggerState
+                .evaluatedAt(CLOCK, evaluatedAt)
+                .updateForNextEvaluationDate(CLOCK, evaluatedAt.plusMinutes(15))
+                .disabled(CLOCK, true)
+        );
+        handler = newTriggerEventHandler(List.of(Fixtures.defaultFlow(builder -> builder.recoverMissedSchedules(RecoverMissedSchedules.LAST).build())));
+        SetDisableTrigger event = new SetDisableTrigger(triggerId, false, true);
+
+        // WHEN
+        Instant beforeHandler = Instant.now();
+        handler.handle(CLOCK, TEST_VNODE, event);
+
+        // THEN: the next evaluation date is the last missed cron tick, in the past but within the last period
+        Optional<TriggerState> updated = triggerStateStore.findById(triggerId);
+        assertThat(updated).isPresent();
+        assertThat(updated.get().isDisabled()).isFalse();
+        assertThat(updated.get().getNextEvaluationDate()).isBefore(Instant.now());
+        assertThat(updated.get().getNextEvaluationDate()).isAfter(beforeHandler.minusSeconds(15 * 60 + 1));
+    }
+
+    @Test
+    void shouldSkipMissedSchedulesWhenReEnablingTriggerWithRecoverTrueAndConfiguredNone() {
+        // GIVEN: a trigger configured with recoverMissedSchedules: NONE, evaluated 45 minutes before being disabled
+        ZonedDateTime evaluatedAt = SchedulerClock.now().minusMinutes(45);
+        triggerStateStore.save(
+            triggerState
+                .evaluatedAt(CLOCK, evaluatedAt)
+                .updateForNextEvaluationDate(CLOCK, evaluatedAt.plusMinutes(15))
+                .disabled(CLOCK, true)
+        );
+        handler = newTriggerEventHandler(List.of(Fixtures.defaultFlow(builder -> builder.recoverMissedSchedules(RecoverMissedSchedules.NONE).build())));
+        SetDisableTrigger event = new SetDisableTrigger(triggerId, false, true);
+
+        // WHEN
+        Instant beforeHandler = Instant.now();
+        handler.handle(CLOCK, TEST_VNODE, event);
+
+        // THEN: the configured NONE applies, missed schedules are skipped
+        Optional<TriggerState> updated = triggerStateStore.findById(triggerId);
+        assertThat(updated).isPresent();
+        assertThat(updated.get().isDisabled()).isFalse();
+        assertThat(updated.get().getNextEvaluationDate()).isAfter(beforeHandler);
+    }
+
+    @Test
+    void shouldKeepBackfillWhenReEnablingTriggerWithRecoverTrueAndConfiguredLast() {
+        // GIVEN: a trigger disabled in the middle of a backfill, configured with recoverMissedSchedules: LAST
+        ZonedDateTime evaluatedAt = SchedulerClock.now().minusDays(2);
+        Backfill backfill = Backfill.builder()
+            .start(SchedulerClock.now().minusDays(3))
+            .end(SchedulerClock.now().minusDays(1))
+            .currentDate(evaluatedAt)
+            .paused(false)
+            .build();
+        triggerStateStore.save(
+            triggerState
+                .evaluatedAt(CLOCK, evaluatedAt)
+                .backfill(CLOCK, backfill)
+                .updateForNextEvaluationDate(CLOCK, evaluatedAt.plusMinutes(15))
+                .disabled(CLOCK, true)
+        );
+        handler = newTriggerEventHandler(List.of(Fixtures.defaultFlow(builder -> builder.recoverMissedSchedules(RecoverMissedSchedules.LAST).build())));
+        SetDisableTrigger event = new SetDisableTrigger(triggerId, false, true);
+
+        // WHEN
+        handler.handle(CLOCK, TEST_VNODE, event);
+
+        // THEN: the backfill resumes untouched
+        Optional<TriggerState> updated = triggerStateStore.findById(triggerId);
+        assertThat(updated).isPresent();
+        assertThat(updated.get().isDisabled()).isFalse();
+        assertThat(updated.get().getBackfill()).isNotNull();
+        assertThat(updated.get().getNextEvaluationDate()).isEqualTo(evaluatedAt.plusMinutes(15).toInstant());
+    }
+
+    @Test
+    void shouldSkipMissedSchedulesWhenReEnablingNeverEvaluatedTriggerWithRecoverTrueAndConfiguredLast() {
+        // GIVEN: a trigger never evaluated (e.g. created disabled), configured with recoverMissedSchedules: LAST
+        triggerStateStore.save(
+            triggerState
+                .updateForNextEvaluationDate(CLOCK, SchedulerClock.now().minusMinutes(30))
+                .disabled(CLOCK, true)
+        );
+        handler = newTriggerEventHandler(List.of(Fixtures.defaultFlow(builder -> builder.recoverMissedSchedules(RecoverMissedSchedules.LAST).build())));
+        SetDisableTrigger event = new SetDisableTrigger(triggerId, false, true);
+
+        // WHEN
+        Instant beforeHandler = Instant.now();
+        handler.handle(CLOCK, TEST_VNODE, event);
+
+        // THEN: there is no missed schedule to recover, the next evaluation date is in the future
+        Optional<TriggerState> updated = triggerStateStore.findById(triggerId);
+        assertThat(updated).isPresent();
+        assertThat(updated.get().isDisabled()).isFalse();
+        assertThat(updated.get().getNextEvaluationDate()).isAfter(beforeHandler);
+    }
+
+    @Test
+    void shouldIgnoreRecoverMissedSchedulesWhenDisablingTrigger() {
+        // GIVEN
+        ZonedDateTime initialNextEvaluationDate = SchedulerClock.now().plusMinutes(5);
+        triggerStateStore.save(triggerState.updateForNextEvaluationDate(CLOCK, initialNextEvaluationDate));
+        handler = newTriggerEventHandler(List.of(Fixtures.defaultFlow()));
+        SetDisableTrigger event = new SetDisableTrigger(triggerId, true, true);
+
+        // WHEN
+        handler.handle(CLOCK, TEST_VNODE, event);
+
+        // THEN
+        Optional<TriggerState> updated = triggerStateStore.findById(triggerId);
+        assertThat(updated).isPresent();
+        assertThat(updated.get().isDisabled()).isTrue();
+        assertThat(updated.get().getNextEvaluationDate()).isEqualTo(initialNextEvaluationDate.toInstant());
     }
 
     @Test

--- a/ui/src/components/admin/triggers/TriggersManage.vue
+++ b/ui/src/components/admin/triggers/TriggersManage.vue
@@ -200,9 +200,11 @@
                         :disabled="!scope.row.codeDisabled"
                         effect="light"
                     >
+                        <!-- update:modelValue (not change) keeps the switch prop-controlled: the knob only
+                             moves when the row data changes, so cancelling the enable dialog leaves it intact. -->
                         <KsSwitch
                             :modelValue="!(scope.row.disabled || scope.row.codeDisabled)"
-                            @change="(value: string | number | boolean) => setDisabled(scope.row, Boolean(value))"
+                            @update:modelValue="(value: string | number | boolean | undefined) => setDisabled(scope.row, Boolean(value))"
                             :disabled="scope.row.codeDisabled"
                         />
                     </KsTooltip>
@@ -317,6 +319,16 @@
                 </KsButton>
             </template>
         </KsDialog>
+
+        <TriggerEnableDialog
+            v-model="isEnableDialogOpen"
+            :count="enableDialogTrigger ? undefined : (queryBulkAction ? total : selection?.length)"
+            @confirm="onEnableDialogConfirm"
+        >
+            <p v-if="!enableDialogTrigger">
+                {{ $t("bulk action async warning") }}
+            </p>
+        </TriggerEnableDialog>
     </div>
 </template>
 
@@ -354,6 +366,7 @@
     import BackfillBanner from "../../flows/BackfillBanner.vue"
     import Vars from "../../executions/Vars.vue"
     import MarkdownTooltip from "../../layout/MarkdownTooltip.vue"
+    import TriggerEnableDialog from "../../triggers/TriggerEnableDialog.vue"
 
     const triggerFilter = useTriggerFilter()
 
@@ -696,6 +709,12 @@
         })
     }
 
+    const isEnableDialogOpen = ref(false)
+    // The schedule trigger being enabled; null when enabling in bulk.
+    const enableDialogTrigger = ref<any>(null)
+
+    const isScheduleTrigger = (row: any) => row?.kind === "SCHEDULE" || row?.type === "io.kestra.plugin.core.trigger.Schedule"
+
     const setDisabled = (trigger: any, value: boolean) => {
         if (trigger.codeDisabled) {
             KsMessage({
@@ -706,7 +725,16 @@
             })
             return
         }
-        triggerStore.setDisabled({...trigger, disabled: !value})
+        if (value && isScheduleTrigger(trigger)) {
+            enableDialogTrigger.value = trigger
+            isEnableDialogOpen.value = true
+            return
+        }
+        doSetDisabled(trigger, !value)
+    }
+
+    const doSetDisabled = (trigger: any, disabled: boolean, recoverMissedSchedules?: boolean) => {
+        triggerStore.setDisabled({...trigger, disabled, recoverMissedSchedules})
             .then((updatedTrigger: any) => {
                 toast.saved(updatedTrigger.triggerId)
                 triggers.value = triggers.value?.map((tr: any) => {
@@ -718,6 +746,19 @@
                         : tr
                 })
             })
+    }
+
+    const onEnableDialogConfirm = (recoverMissedSchedules?: boolean) => {
+        if (enableDialogTrigger.value) {
+            doSetDisabled(enableDialogTrigger.value, false, recoverMissedSchedules)
+        } else {
+            genericConfirmCallback(
+                "setDisabledByQuery",
+                "setDisabledByTriggers",
+                "bulk success disabled status.false",
+                {disabled: false, recoverMissedSchedules},
+            )
+        }
     }
 
     const confirmDeleteTrigger = (trigger: TriggerDeleteOptions) => {
@@ -822,6 +863,14 @@
     }
 
     const setDisabledTriggers = (bool: boolean) => {
+        // Enabling may recover missed schedules: the dialog carries both the confirmation and the
+        // recovery choice. In query mode trigger types are unknowable so it is always shown; in
+        // selection mode only when the selection contains a schedule trigger.
+        if (!bool && (queryBulkAction.value || selection.value?.some((sel: any) => isScheduleTrigger(findRowBySelection(sel))))) {
+            enableDialogTrigger.value = null
+            isEnableDialogOpen.value = true
+            return
+        }
         genericConfirmAction(
             `bulk disabled status.${bool}`,
             "setDisabledByQuery",
@@ -830,6 +879,9 @@
             {disabled: bool},
         )
     }
+
+    const findRowBySelection = (sel: any) => triggersMerged.value.find((row: any) =>
+        (row.triggerId ?? row.id) === sel.triggerId && row.flowId === sel.flowId && row.namespace === sel.namespace)
 
     const checkBackfill = computed(() => {
         if (!backfill.value?.start) {

--- a/ui/src/components/flows/FlowTriggers.vue
+++ b/ui/src/components/flows/FlowTriggers.vue
@@ -148,9 +148,11 @@
                         :content="$t('trigger disabled')"
                         :disabled="!scope.row.sourceDisabled"
                     >
+                        <!-- update:modelValue (not change) keeps the switch prop-controlled: the knob only
+                             moves when the row data changes, so cancelling the enable dialog leaves it intact. -->
                         <KsSwitch
                             :modelValue="!(scope.row.disabled || scope.row.sourceDisabled)"
-                            @change="setDisabled(scope.row, $event as boolean)"
+                            @update:modelValue="(value: string | number | boolean | undefined) => setDisabled(scope.row, Boolean(value))"
                             inlinePrompt
                             class="switch-text"
                             :disabled="scope.row.sourceDisabled"
@@ -279,6 +281,12 @@
         </template>
     </KsDialog>
 
+    <TriggerEnableDialog
+        v-model="isEnableDialogOpen"
+        :count="enableDialogTrigger ? undefined : selection.length"
+        @confirm="onEnableDialogConfirm"
+    />
+
     <KsDrawer
         v-if="isOpen"
         v-model="isOpen"
@@ -312,6 +320,7 @@
     import BackfillBanner from "./BackfillBanner.vue"
     import Empty from "../layout/empty/Empty.vue"
     import LogsWrapper from "../logs/LogsWrapper.vue"
+    import TriggerEnableDialog from "../triggers/TriggerEnableDialog.vue"
 
     import action from "../../models/action"
     import resource from "../../models/resource"
@@ -571,12 +580,39 @@
             })
     }
 
+    const isEnableDialogOpen = ref(false)
+    // The schedule trigger being enabled; null when enabling the bulk selection.
+    const enableDialogTrigger = ref<any>(null)
+
+    const isScheduleTrigger = (row: any) => row?.kind === "SCHEDULE" || isSchedule(row?.type)
+
     const setDisabled = (trigger: any, value: boolean) => {
-        triggerStore.setDisabled({...trigger, disabled: !value})
+        if (value && isScheduleTrigger(trigger)) {
+            enableDialogTrigger.value = trigger
+            isEnableDialogOpen.value = true
+            return
+        }
+        doSetDisabled(trigger, !value)
+    }
+
+    const doSetDisabled = (trigger: any, disabled: boolean, recoverMissedSchedules?: boolean) => {
+        triggerStore.setDisabled({...trigger, disabled, recoverMissedSchedules})
             .then(() => {
                 toast.saved(trigger.triggerId)
                 loadDataAfterAction()
             })
+    }
+
+    const onEnableDialogConfirm = (recoverMissedSchedules?: boolean) => {
+        if (enableDialogTrigger.value) {
+            doSetDisabled(enableDialogTrigger.value, false, recoverMissedSchedules)
+        } else {
+            runBulk(
+                () => triggerStore.setDisabledByTriggers({triggers: selection.value, disabled: false, recoverMissedSchedules}),
+                "bulk success disabled status.false",
+                t("enable"),
+            )
+        }
     }
 
     const unlock = (trigger: any) => {
@@ -629,6 +665,11 @@
     }
 
     const bulkSetDisabled = (disabled: boolean) => {
+        if (!disabled && selection.value.some((sel: any) => isScheduleTrigger(findRowBySelection(sel)))) {
+            enableDialogTrigger.value = null
+            isEnableDialogOpen.value = true
+            return
+        }
         const confirmKey = disabled ? "bulk disabled status.true" : "bulk disabled status.false"
         const successKey = disabled ? "bulk success disabled status.true" : "bulk success disabled status.false"
         const actionLabel = disabled ? t("disable") : t("enable")
@@ -641,6 +682,9 @@
             ),
         )
     }
+
+    const findRowBySelection = (sel: any) =>
+        triggersWithType.value.find((row: any) => (row.triggerId ?? row.id) === sel.triggerId)
 
     const bulkUnlock = () => {
         toast.confirm(

--- a/ui/src/components/triggers/TriggerEnableDialog.vue
+++ b/ui/src/components/triggers/TriggerEnableDialog.vue
@@ -1,0 +1,92 @@
+<template>
+    <KsDialog
+        :modelValue="modelValue"
+        destroyOnClose
+        :appendToBody="true"
+        @update:modelValue="emit('update:modelValue', !!$event)"
+    >
+        <template #header>
+            <span>{{ count && count > 1 ? t("trigger enable dialog.bulk title", {count}) : t("trigger enable dialog.title") }}</span>
+        </template>
+
+        <KsAlert type="info" :closable="false" class="description">
+            {{ count && count > 1 ? t("trigger enable dialog.bulk description") : t("trigger enable dialog.description") }}
+        </KsAlert>
+
+        <slot />
+
+        <p id="trigger-enable-strategy-label" class="strategy-label">
+            {{ t("trigger enable dialog.strategy") }}
+        </p>
+
+        <KsRadioGroup v-model="choice" class="radio-vertical" aria-labelledby="trigger-enable-strategy-label">
+            <KsRadio value="SKIP" class="radio-item">
+                {{ t("trigger enable dialog.options.skip") }}
+            </KsRadio>
+            <KsRadio value="FOLLOW_CONFIGURATION" class="radio-item">
+                <i18n-t keypath="trigger enable dialog.options.follow" scope="global">
+                    <template #property>
+                        <code>recoverMissedSchedules</code>
+                    </template>
+                </i18n-t>
+            </KsRadio>
+        </KsRadioGroup>
+
+        <template #footer>
+            <KsButton @click="emit('update:modelValue', false)">
+                {{ t("cancel") }}
+            </KsButton>
+            <KsButton type="primary" @click="confirm">
+                {{ t("enable") }}
+            </KsButton>
+        </template>
+    </KsDialog>
+</template>
+
+<script setup lang="ts">
+    import {ref, watch} from "vue"
+    import {useI18n} from "vue-i18n"
+
+    const {t} = useI18n()
+
+    const props = defineProps<{
+        modelValue: boolean;
+        count?: number;
+    }>()
+
+    const emit = defineEmits<{
+        (e: "update:modelValue", value: boolean): void;
+        (e: "confirm", recoverMissedSchedules: boolean | undefined): void;
+    }>()
+
+    const choice = ref<"SKIP" | "FOLLOW_CONFIGURATION">("SKIP")
+
+    watch(() => props.modelValue, (open) => {
+        if (open) choice.value = "SKIP"
+    })
+
+    const confirm = () => {
+        emit("confirm", choice.value === "FOLLOW_CONFIGURATION" ? true : undefined)
+        emit("update:modelValue", false)
+    }
+</script>
+
+<style lang="scss" scoped>
+.description {
+    margin-bottom: var(--ks-spacing-3);
+}
+
+.strategy-label {
+    margin-bottom: var(--ks-spacing-2);
+}
+
+.radio-vertical {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+}
+
+.radio-item {
+    margin-bottom: var(--ks-spacing-1);
+}
+</style>

--- a/ui/src/stores/trigger.ts
+++ b/ui/src/stores/trigger.ts
@@ -41,6 +41,8 @@ interface TriggerDisabledOptions {
     flowId: string;
     triggerId: string;
     disabled: boolean;
+    /** When true, missed schedules are recovered on enable according to the trigger's own configuration. */
+    recoverMissedSchedules?: boolean;
 }
 
 /** Bulk trigger id list, as forwarded raw by callers (e.g. a data table's row selection). */
@@ -121,7 +123,7 @@ export const useTriggerStore = defineStore("trigger", () => {
         return TriggersAPI.disabledTriggersByQuery(options)
     }
 
-    async function setDisabledByTriggers(options: {triggers: TriggerIdList, disabled: boolean}) {
+    async function setDisabledByTriggers(options: {triggers: TriggerIdList, disabled: boolean, recoverMissedSchedules?: boolean}) {
         return TriggersAPI.disabledTriggersByIds(options)
     }
 

--- a/ui/src/translations/en.json
+++ b/ui/src/translations/en.json
@@ -836,6 +836,17 @@
       "tooltip": "Restart the trigger"
     },
     "trigger disabled": "Trigger is disabled within Flow source",
+    "trigger enable dialog": {
+      "title": "Enable trigger",
+      "bulk title": "Enable {count} triggers",
+      "description": "This trigger may have missed schedules while it was disabled.",
+      "bulk description": "The selected triggers may have missed schedules while they were disabled.",
+      "strategy": "Select the strategy to use:",
+      "options": {
+        "skip": "Do not recover missed schedules",
+        "follow": "Follow the trigger's {property} configuration"
+      }
+    },
     "flow source not found": "Flow source not found",
     "date format": "Date format",
     "timezone": "Timezone",

--- a/webserver/src/main/java/io/kestra/webserver/controllers/api/TriggerController.java
+++ b/webserver/src/main/java/io/kestra/webserver/controllers/api/TriggerController.java
@@ -381,7 +381,7 @@ public class TriggerController {
     public HttpResponse<ApiTriggerState> disableTriggerById(
         @Parameter(description = "The trigger") @Body final ApiDisableTriggerRequest request) throws HttpStatusException {
         TriggerId triggerId = TriggerId.of(tenantService.resolveTenant(), request.namespace(), request.flowId(), request.triggerId());
-        TriggerState state = triggerStateService.toggleTriggerById(triggerId, request.disabled());
+        TriggerState state = triggerStateService.toggleTriggerById(triggerId, request.disabled(), request.recoverMissedSchedules());
         return HttpResponse.ok(ApiTriggerState.from(state));
     }
 
@@ -392,7 +392,7 @@ public class TriggerController {
     public MutableHttpResponse<ApiAsyncOperationResponse> disabledTriggersByIds(
         @Parameter(description = "The triggers you want to set the disabled state") @Body @Valid SetDisabledRequest request) {
         return HttpResponse.accepted().body(
-            triggerStateService.toggleAllByIds(toTriggerIds(request.triggers(), tenantService.resolveTenant()), request.disabled())
+            triggerStateService.toggleAllByIds(toTriggerIds(request.triggers(), tenantService.resolveTenant()), request.disabled(), request.recoverMissedSchedules())
         );
     }
 
@@ -403,9 +403,10 @@ public class TriggerController {
     public MutableHttpResponse<ApiAsyncOperationResponse> disabledTriggersByQuery(
         @Parameter(description = "Filters. PHP-style nested query is used - examples: `filters[flowId][EQUALS]=hello-world`, `filters[namespace][CONTAINS]=test`", in = ParameterIn.QUERY)
         @QueryFilterFormat(Resource.TRIGGER) List<QueryFilter> filters,
-        @Parameter(description = "The disabled state") @QueryValue(defaultValue = "true") Boolean disabled) {
+        @Parameter(description = "The disabled state") @QueryValue(defaultValue = "true") Boolean disabled,
+        @Parameter(description = "When true, missed schedules are recovered on enable according to the trigger's recoverMissedSchedules configuration; omitted or false, missed schedules are skipped") @QueryValue @Nullable Boolean recoverMissedSchedules) {
         return HttpResponse.accepted().body(
-            triggerStateService.toggleAllMatching(tenantService.resolveTenant(), QueryFilterUtils.rewriteTriggerDateFilters(filters, null), disabled)
+            triggerStateService.toggleAllMatching(tenantService.resolveTenant(), QueryFilterUtils.rewriteTriggerDateFilters(filters, null), disabled, recoverMissedSchedules)
         );
     }
     // endregion
@@ -460,7 +461,13 @@ public class TriggerController {
 
     public record SetDisabledRequest(
         @NotNull @NotEmpty List<ApiTriggerId> triggers,
-        @NotNull Boolean disabled) {
+        @NotNull Boolean disabled,
+        @Parameter(description = "When true, missed schedules are recovered on enable according to the trigger's recoverMissedSchedules configuration; omitted or false, missed schedules are skipped")
+        @Nullable Boolean recoverMissedSchedules) {
+
+        public SetDisabledRequest(List<ApiTriggerId> triggers, Boolean disabled) {
+            this(triggers, disabled, null);
+        }
     }
 
     public record ApiCreateBackfillRequest(
@@ -482,7 +489,13 @@ public class TriggerController {
         @Parameter(description = "The namespace.") String namespace,
         @Parameter(description = "The ID of the flow.") String flowId,
         @Parameter(description = "The ID of the trigger.") String triggerId,
-        @Parameter(description = "Specifies whether trigger should be disabled") boolean disabled) {
+        @Parameter(description = "Specifies whether trigger should be disabled") boolean disabled,
+        @Parameter(description = "When true, missed schedules are recovered on enable according to the trigger's recoverMissedSchedules configuration; omitted or false, missed schedules are skipped")
+        @Nullable Boolean recoverMissedSchedules) {
+
+        public ApiDisableTriggerRequest(String namespace, String flowId, String triggerId, boolean disabled) {
+            this(namespace, flowId, triggerId, disabled, null);
+        }
     }
 
     public record ApiTriggerId(

--- a/webserver/src/main/java/io/kestra/webserver/services/TriggerStateService.java
+++ b/webserver/src/main/java/io/kestra/webserver/services/TriggerStateService.java
@@ -34,6 +34,7 @@ import io.kestra.webserver.models.api.ApiAsyncOperationResponse;
 
 import io.micronaut.http.HttpStatus;
 import io.micronaut.http.exceptions.HttpStatusException;
+import jakarta.annotation.Nullable;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 
@@ -309,14 +310,16 @@ public class TriggerStateService {
     /**
      * Enables or disables a trigger and waits for the scheduler to acknowledge.
      *
+     * @param recoverMissedSchedules when {@code true}, missed schedules are recovered on enable according to the
+     *                               trigger's own configuration; {@code null} or {@code false} means they are skipped.
      * @throws NotFoundException if the flow or trigger does not exist.
      * @throws ConflictException if the change failed.
      */
-    public TriggerState toggleTriggerById(TriggerId trigger, boolean disabled) throws NotFoundException, ConflictException {
+    public TriggerState toggleTriggerById(TriggerId trigger, boolean disabled, @Nullable Boolean recoverMissedSchedules) throws NotFoundException, ConflictException {
         validateToggleable(trigger);
         awaitBlockingAction(
             trigger.uid(),
-            operationId -> triggerEventQueue.send(new SetDisableTrigger(trigger, disabled).withOperationId(operationId)),
+            operationId -> triggerEventQueue.send(new SetDisableTrigger(trigger, disabled, recoverMissedSchedules).withOperationId(operationId)),
             "Set disabled"
         );
         return refresh(trigger, "set-disabled");
@@ -325,7 +328,7 @@ public class TriggerStateService {
     /**
      * Enables or disables the given triggers. Missing triggers are silently skipped.
      */
-    public ApiAsyncOperationResponse toggleAllByIds(List<TriggerId> triggers, boolean disabled) {
+    public ApiAsyncOperationResponse toggleAllByIds(List<TriggerId> triggers, boolean disabled, @Nullable Boolean recoverMissedSchedules) {
         List<TriggerId> toggleable = triggers.stream()
             .filter(id ->
             {
@@ -338,14 +341,14 @@ public class TriggerStateService {
             })
             .toList();
         return submitBatch(
-            toggleable, (id, operationId) -> triggerEventQueue.send(new SetDisableTrigger(id, disabled).withOperationId(operationId))
+            toggleable, (id, operationId) -> triggerEventQueue.send(new SetDisableTrigger(id, disabled, recoverMissedSchedules).withOperationId(operationId))
         );
     }
 
     /**
      * Enables or disables triggers matching the given filters.
      */
-    public ApiAsyncOperationResponse toggleAllMatching(String tenant, List<QueryFilter> filters, boolean disabled) {
+    public ApiAsyncOperationResponse toggleAllMatching(String tenant, List<QueryFilter> filters, boolean disabled, @Nullable Boolean recoverMissedSchedules) {
         String operationId = IdUtils.create();
         int count = triggerRepository.find(tenant, filters)
             .map(trigger ->
@@ -353,7 +356,7 @@ public class TriggerStateService {
                 TriggerId id = TriggerId.of(trigger);
                 try {
                     validateToggleable(id);
-                    triggerEventQueue.send(new SetDisableTrigger(id, disabled).withOperationId(operationId));
+                    triggerEventQueue.send(new SetDisableTrigger(id, disabled, recoverMissedSchedules).withOperationId(operationId));
                     return 1;
                 } catch (NotFoundException ignored) {
                     return 0;

--- a/webserver/src/test/java/io/kestra/webserver/controllers/api/TriggerControllerTest.java
+++ b/webserver/src/test/java/io/kestra/webserver/controllers/api/TriggerControllerTest.java
@@ -620,6 +620,95 @@ class TriggerControllerTest {
     }
 
     @Test
+    void shouldAcceptSetDisabledWhenRecoverMissedSchedulesProvided() throws FlowProcessingException, QueueException {
+        // GIVEN
+        String namespace = "ns-" + IdUtils.create().toLowerCase();
+        Flow flow = generateFlowWithTrigger(namespace);
+        flowService.create(GenericFlow.of(flow));
+
+        final TriggerState trigger = createTriggerFromFlow(flow, true);
+        // Wait for the scheduler to initialize trigger states before updating them
+        Awaitility.await().atMost(Duration.ofSeconds(30)).pollInterval(Duration.ofMillis(100))
+            .until(() -> jdbcTriggerRepository.findById(trigger).isPresent());
+        jdbcTriggerRepository.save(trigger);
+
+        // WHEN
+        HttpResponse<ApiTriggerState> response = client.toBlocking().exchange(
+            HttpRequest.PUT(
+                TRIGGER_PATH + "/set-disabled",
+                new TriggerController.ApiDisableTriggerRequest(trigger.getNamespace(), trigger.getFlowId(), trigger.getTriggerId(), false, true)
+            ),
+            ApiTriggerState.class
+        );
+
+        // THEN
+        assertThat(response.getStatus().getCode()).isEqualTo(HttpStatus.OK.getCode());
+        assertThat(response.body().disabled()).isFalse();
+    }
+
+    @Test
+    void shouldAcceptSetDisabledByIdsWhenRecoverMissedSchedulesProvided() throws FlowProcessingException, QueueException {
+        // GIVEN
+        String namespace = "ns-" + IdUtils.create().toLowerCase();
+        Flow flow = generateFlowWithTrigger(namespace);
+        flowService.create(GenericFlow.of(flow));
+
+        final TriggerState trigger = createTriggerFromFlow(flow, true);
+        // Wait for the scheduler to initialize trigger states before updating them
+        Awaitility.await().atMost(Duration.ofSeconds(30)).pollInterval(Duration.ofMillis(100))
+            .until(() -> jdbcTriggerRepository.findById(trigger).isPresent());
+        jdbcTriggerRepository.save(trigger);
+
+        List<TriggerController.ApiTriggerId> triggers = List.of(
+            new TriggerController.ApiTriggerId(trigger.getNamespace(), trigger.getFlowId(), trigger.getTriggerId())
+        );
+
+        // WHEN
+        HttpResponse<ApiAsyncOperationResponse> response = client.toBlocking().exchange(
+            HttpRequest.POST(TRIGGER_PATH + "/set-disabled/by-triggers", new TriggerController.SetDisabledRequest(triggers, false, true)),
+            ApiAsyncOperationResponse.class
+        );
+
+        // THEN
+        assertThat(response.getStatus().getCode()).isEqualTo(HttpStatus.ACCEPTED.getCode());
+        assertThat(response.body().totalItems()).isEqualTo(1);
+        try {
+            Await.until(() -> !jdbcTriggerRepository.findById(trigger).get().isDisabled(), Duration.ofSeconds(1), Duration.ofSeconds(30));
+        } catch (TimeoutException e) {
+            Assertions.fail("Timeout waiting for trigger to be enabled");
+        }
+    }
+
+    @Test
+    void shouldAcceptSetDisabledByQueryWhenRecoverMissedSchedulesProvided() throws FlowProcessingException, QueueException {
+        // GIVEN
+        String namespace = "ns-" + IdUtils.create().toLowerCase();
+        Flow flow = generateFlowWithTrigger(namespace);
+        flowService.create(GenericFlow.of(flow));
+
+        final TriggerState trigger = createTriggerFromFlow(flow, true);
+        // Wait for the scheduler to initialize trigger states before updating them
+        Awaitility.await().atMost(Duration.ofSeconds(30)).pollInterval(Duration.ofMillis(100))
+            .until(() -> jdbcTriggerRepository.findById(trigger).isPresent());
+        jdbcTriggerRepository.save(trigger);
+
+        // WHEN
+        HttpResponse<ApiAsyncOperationResponse> response = client.toBlocking().exchange(
+            HttpRequest.POST(TRIGGER_PATH + "/set-disabled/by-query?filters[namespace][EQUALS]=%s&disabled=false&recoverMissedSchedules=true".formatted(namespace), null),
+            ApiAsyncOperationResponse.class
+        );
+
+        // THEN
+        assertThat(response.getStatus().getCode()).isEqualTo(HttpStatus.ACCEPTED.getCode());
+        assertThat(response.body().totalItems()).isEqualTo(1);
+        try {
+            Await.until(() -> !jdbcTriggerRepository.findById(trigger).get().isDisabled(), Duration.ofSeconds(1), Duration.ofSeconds(30));
+        } catch (TimeoutException e) {
+            Assertions.fail("Timeout waiting for trigger to be enabled");
+        }
+    }
+
+    @Test
     void shouldReturnBadRequestWhenDisableByTriggersMissingBody() {
         HttpClientResponseException e = assertThrows(
             HttpClientResponseException.class, () -> client.toBlocking().retrieve(


### PR DESCRIPTION
Re-enabling a trigger always skipped missed schedules. The set-disabled APIs (single, by-triggers, by-query) now accept an optional boolean recoverMissedSchedules: when true, missed schedules are recovered according to the trigger's own recoverMissedSchedules configuration (ALL/LAST/NONE, plugin default ALL). Omitting the field keeps the current skip behavior.

The recovery choice deliberately cannot override the configured value: the scheduler re-applies the configured recovery on every startup and vNode re-assignment, so a per-action override would be silently cancelled (or resurrected) by any restart or rebalance mid-recovery. Re-deriving from the configuration keeps both decisions consistent; a one-time forced recovery remains available via backfill.

LAST recovery leaves an in-progress backfill untouched (recomputing the next evaluation date would drop or corrupt its remaining range) and is not applied to a never-evaluated trigger (the last cron tick before now could predate the trigger's creation).

The UI shows a recovery-choice dialog when enabling a Schedule trigger, both per row and in bulk, on the flow Triggers tab and the administration Triggers page. The enable switches are now prop-driven (update:modelValue instead of change) so cancelling the dialog leaves the switch state intact.

Also fixes two re-enable consistency bugs: the recompute used the stale pre-disable evaluation date, silently replaying every missed schedule despite the intent to skip them; and evaluatedAt is now advanced on skip so the startup recovery of a LAST/ALL-configured trigger cannot resurrect schedules the user chose to skip.