### PR TITLE
fix(executions): expose saved-filter injection key via tracking util

### DIFF
--- a/ui/src/App.vue
+++ b/ui/src/App.vue
@@ -21,7 +21,6 @@
 
     import {ref, computed, watch, onMounted, provide} from "vue"
     import {useRoute} from "vue-router"
-    import {SAVED_FILTER_ANALYTICS_INJECTION_KEY} from "@kestra-io/design-system"
     import {useApiStore} from "./stores/api"
     import {useLayoutStore} from "./stores/layout"
     import {useCoreStore} from "./stores/core"
@@ -31,7 +30,7 @@
     import * as BasicAuth from "./utils/basicAuth"
     import {applyFontScale, getAppFontSizeMode} from "./utils/appFontSize"
     import {initPosthogIfEnabled} from "./utils/posthog"
-    import {trackSavedFilter} from "./utils/savedFilterTracking"
+    import {SAVED_FILTER_ANALYTICS_INJECTION_KEY, trackSavedFilter} from "./utils/savedFilterTracking"
     import ErrorToast from "./components/ErrorToast.vue"
     import OnboardingOverlay from "./components/onboarding/OnboardingOverlay.vue"
     import DefaultLayout from "override/components/layout/DefaultLayout.vue"

--- a/ui/src/utils/savedFilterTracking.ts
+++ b/ui/src/utils/savedFilterTracking.ts
@@ -2,6 +2,8 @@ import type {SavedFilterAnalyticsEvent} from "@kestra-io/design-system"
 import {useApiStore} from "../stores/api"
 import {useMiscStore} from "override/stores/misc"
 
+export {SAVED_FILTER_ANALYTICS_INJECTION_KEY} from "@kestra-io/design-system"
+
 export function trackSavedFilter({action, page, filtersCount}: SavedFilterAnalyticsEvent) {
     try {
         if (useMiscStore().configs?.isUiAnonymousUsageEnabled === false) return


### PR DESCRIPTION
## What

Re-export `SAVED_FILTER_ANALYTICS_INJECTION_KEY` from `ui/src/utils/savedFilterTracking.ts`, and import it (together with `trackSavedFilter`) from that util in `App.vue` instead of directly from the `@kestra-io/design-system` barrel.

## Why

kestra-ee `develop` CI has been red since kestra-ee#9089 merged. That PR added a direct barrel import to the EE app shell:

```ts
// ui-ee/src/App.vue
import {SAVED_FILTER_ANALYTICS_INJECTION_KEY} from "@kestra-io/design-system"
```

EE's `ui-ee` type-check runs `vue-tsc --build tsconfig.app.json` with `preserveSymlinks: true` and no project-reference redirect for the design-system. A direct **value** import from the design-system barrel in `App.vue` pulls the entire design-system *source* into the ui-ee program, which TS then type-checks under ui-ee's config and fails to resolve the design-system's own transitive dependencies:

```
Cannot find module 'motion-v' | 'mermaid' | 'monaco-editor/...' | 'moment-timezone' | 'remark-*'
```

Importing the injection key through this OSS util — a referenced project consumed via emitted declarations — avoids dragging the design-system source into the EE check. Verified locally: the design-system source errors disappear and the key resolves.

`#17130` (which introduced `SAVED_FILTER_ANALYTICS_INJECTION_KEY`) is already merged; this is the follow-up that lets the EE app shell consume the key safely.

## Companion PR

Must merge **before** the EE side: kestra-ee `App.vue` will import both symbols from `kestra/src/utils/savedFilterTracking`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)