### PR TITLE
fix(core): use a mutable map in RunVariables.computeTasksMap

### DIFF
--- a/core/src/main/java/io/kestra/core/runners/RunVariables.java
+++ b/core/src/main/java/io/kestra/core/runners/RunVariables.java
@@ -642,7 +642,9 @@ public final class RunVariables {
             {
                 if (taskRun.getState() != null) {
                     if (taskRun.getValue() == null) {
-                        tasksMap.put(taskRun.getTaskId(), Map.of("state", taskRun.getState().getCurrent()));
+                        Map<String, Object> stateMap = new HashMap<>();
+                        stateMap.put("state", taskRun.getState().getCurrent());
+                        tasksMap.put(taskRun.getTaskId(), stateMap);
                     } else {
                         if (tasksMap.containsKey(taskRun.getTaskId())) {
                             @SuppressWarnings("unchecked")

--- a/core/src/main/java/io/kestra/core/runners/RunVariables.java
+++ b/core/src/main/java/io/kestra/core/runners/RunVariables.java
@@ -642,7 +642,7 @@ public final class RunVariables {
             {
                 if (taskRun.getState() != null) {
                     if (taskRun.getValue() == null) {
-                        Map<String, Object> stateMap = new HashMap<>();
+                        Map<String, Object> stateMap = HashMap.newHashMap(2);
                         stateMap.put("state", taskRun.getState().getCurrent());
                         tasksMap.put(taskRun.getTaskId(), stateMap);
                     } else {

--- a/core/src/test/java/io/kestra/core/runners/RunVariablesTest.java
+++ b/core/src/test/java/io/kestra/core/runners/RunVariablesTest.java
@@ -336,6 +336,39 @@ class RunVariablesTest {
     }
 
     @Test
+    @SuppressWarnings("unchecked")
+    void shouldBuildTasksMapWhenSameTaskIdHasValuelessAndValuedTaskRuns() {
+        // Given — the crash order: a valueless taskRun for "hello" recorded first (stored as an
+        // immutable Map.of in computeTasksMap), then another taskRun for the SAME id carrying a
+        // value (as produced by a Loop/iteration whose parent context is concatenated in). This is
+        // the SubflowExecutionEnd queue crash: computeTasksMap must not put() into an immutable map.
+        TaskRun valueless = TaskRun.builder()
+            .id(IdUtils.create()).taskId("hello").executionId("exec-id")
+            .namespace("ns").flowId("flow").state(new State())
+            .build();
+        TaskRun valued = TaskRun.builder()
+            .id(IdUtils.create()).taskId("hello").executionId("exec-id")
+            .namespace("ns").flowId("flow").value("item-1").state(new State())
+            .build();
+
+        Execution execution = Execution.builder()
+            .id("exec-id").namespace("ns").flowId("flow").state(new State())
+            .taskRunList(List.of(valueless, valued))
+            .build();
+
+        // When
+        Map<String, Object> variables = new RunVariables.DefaultBuilder()
+            .withExecution(execution)
+            .build(new RunContextLogger(), PropertyContext.create(renderer));
+
+        // Then — the valueless state and the per-value state coexist under the same task id
+        Map<String, Object> tasks = (Map<String, Object>) variables.get("tasks");
+        Map<String, Object> hello = (Map<String, Object>) tasks.get("hello");
+        assertThat(hello).containsKey("state");
+        assertThat(hello).containsKey("item-1");
+    }
+
+    @Test
     void shouldExposeFlowVarsWhenNoExecution() {
         Flow flow = Flow.builder()
             .id("id-value")


### PR DESCRIPTION
## What

`RunVariables.computeTasksMap()` stored an **immutable** `Map.of("state", …)` for a valueless task run, then `put()` into that same map when a *valued* task run for the **same task id** followed — throwing `UnsupportedOperationException`. On the `SubflowExecutionEnd` path this is treated as fatal and **crash-loops the executor** (the poisoned queue message is redelivered on every restart).

This PR stores a mutable map in the valueless branch so the per-value merge succeeds regardless of task-run ordering.

## Root cause / why it surfaces now

- Latent since **#5386** (v0.20.0): the immutable-map pattern was harmless because the value-first ordering allocates a `HashMap`.
- Made reachable by *"Loop should use the execution context of its parent"* — `build()` now `concat`s the parent's valueless loop-task run with the child's valued iteration runs (same id), producing the valueless-then-valued ordering that detonates the immutable map.

## Test

Added `RunVariablesTest.shouldBuildTasksMapWhenSameTaskIdHasValuelessAndValuedTaskRuns` — fails on `UnsupportedOperationException` before the fix, green after.

Fixes #17629
