### PR TITLE
fix(logs): register LEVEL IN/NOT_IN predicates in SearchableFactory

### DIFF
--- a/webserver/src/main/java/io/kestra/webserver/services/SearchableFactory.java
+++ b/webserver/src/main/java/io/kestra/webserver/services/SearchableFactory.java
@@ -190,6 +190,16 @@ public class SearchableFactory {
                 QueryFilter.Field.LEVEL, QueryFilter.Op.LESS_THAN_OR_EQUAL_TO,
                 (event, v) -> event.level() != null && event.level().toInt() <= toLevel(v).toInt()
             )
+            .searchableQueryFilterExtractor(
+                QueryFilter.Field.LEVEL, QueryFilter.Op.IN,
+                (event, v) -> v instanceof List<?> list
+                    && list.stream().anyMatch(item -> levelMatches(event, item))
+            )
+            .searchableQueryFilterExtractor(
+                QueryFilter.Field.LEVEL, QueryFilter.Op.NOT_IN,
+                (event, v) -> !(v instanceof List<?> list)
+                    || list.stream().noneMatch(item -> levelMatches(event, item))
+            )
 
             .searchableQueryFilterExtractor(
                 QueryFilter.Field.EXECUTION_ID, FollowLogEvent::executionId,
@@ -271,5 +281,9 @@ public class SearchableFactory {
 
     private static Level toLevel(Object value) {
         return value instanceof Level lvl ? lvl : Level.valueOf(value.toString());
+    }
+
+    private static boolean levelMatches(FollowLogEvent event, Object value) {
+        return event.level() != null && event.level().toInt() == toLevel(value).toInt();
     }
 }

--- a/webserver/src/test/java/io/kestra/webserver/services/FollowLogEventSearchableTest.java
+++ b/webserver/src/test/java/io/kestra/webserver/services/FollowLogEventSearchableTest.java
@@ -178,6 +178,10 @@ class FollowLogEventSearchableTest {
         new PredicateCase(baseEvent, filter(Field.LEVEL, Op.GREATER_THAN_OR_EQUAL_TO, Level.ERROR), false),
         new PredicateCase(baseEvent, filter(Field.LEVEL, Op.LESS_THAN_OR_EQUAL_TO, Level.INFO), true),
         new PredicateCase(baseEvent, filter(Field.LEVEL, Op.LESS_THAN_OR_EQUAL_TO, Level.TRACE), false),
+        new PredicateCase(baseEvent, filter(Field.LEVEL, Op.IN, List.of(Level.INFO, Level.ERROR)), true),
+        new PredicateCase(baseEvent, filter(Field.LEVEL, Op.IN, List.of(Level.WARN, Level.ERROR)), false),
+        new PredicateCase(baseEvent, filter(Field.LEVEL, Op.NOT_IN, List.of(Level.WARN, Level.ERROR)), true),
+        new PredicateCase(baseEvent, filter(Field.LEVEL, Op.NOT_IN, List.of(Level.INFO, Level.ERROR)), false),
 
         new PredicateCase(baseEvent, filter(Field.EXECUTION_ID, Op.EQUALS, "exec-123"), true),
         new PredicateCase(baseEvent, filter(Field.EXECUTION_ID, Op.EQUALS, "other"), false),


### PR DESCRIPTION
## What

The `LEVEL` query-filter field advertises `IN`/`NOT_IN` as supported operators, but the LOG `Searchable` (`SearchableFactory`) only registered `GREATER_THAN_OR_EQUAL_TO` / `LESS_THAN_OR_EQUAL_TO` extractors for it. Any `IN`/`NOT_IN` filter on log level therefore had **no registered predicate**.

This broke the EE `SearchableFactoryTest` (`LOG/LEVEL/IN`, `LOG/LEVEL/NOT_IN`: *"missing predicate for LEVEL:IN/NOT_IN"*) and the log-level filter feature's multi-value path.

## How

Register `IN`/`NOT_IN` extractors for `LEVEL`, mirroring the existing `SCOPE` list-matching idiom (`v instanceof List<?> list && list.stream().anyMatch(...)`), with a small `levelMatches` helper reusing `toLevel`. Added `LEVEL` IN/NOT_IN behavior cases to `FollowLogEventSearchableTest`.

## Verification
- `FollowLogEventSearchableTest` (OSS) green.
- EE `SearchableFactoryTest` (`webserver-ee`) now green against this branch.

## Notes
Surfaced while triaging red kestra-ee `develop`; companion PR kestra-io/actions#161 addresses the other (unrelated) cause.