### PR TITLE
type-safe DATE_TRUNC instead of TO_CHAR for date grouping

### DIFF
--- a/jdbc-h2/src/main/java/io/kestra/repository/h2/H2RepositoryUtils.java
+++ b/jdbc-h2/src/main/java/io/kestra/repository/h2/H2RepositoryUtils.java
@@ -15,7 +15,7 @@ public final class H2RepositoryUtils {
     public static Field<Date> formatDateField(String dateField, DateUtils.GroupType groupType) {
         switch (groupType) {
             case MONTH:
-                return DSL.field("FORMATDATETIME({0}, 'yyyy-MM')", Date.class, DSL.field(DSL.quotedName(dateField)));
+                return DSL.field("DATE_TRUNC('MONTH', {0})", Date.class, DSL.field(DSL.quotedName(dateField)));
             case WEEK:
                 return DSL.field("DATE_TRUNC('WEEK', {0})", Date.class, DSL.field(DSL.quotedName(dateField)));
             case DAY:

--- a/jdbc-mysql/src/main/java/io/kestra/repository/mysql/MysqlRepositoryUtils.java
+++ b/jdbc-mysql/src/main/java/io/kestra/repository/mysql/MysqlRepositoryUtils.java
@@ -15,7 +15,7 @@ public final class MysqlRepositoryUtils {
     public static Field<Date> formatDateField(String dateField, DateUtils.GroupType groupType) {
         switch (groupType) {
             case MONTH:
-                return DSL.field("DATE_FORMAT({0}, '%Y-%m')", Date.class, DSL.field(dateField));
+                return DSL.field("STR_TO_DATE(DATE_FORMAT(now(), '%Y-%m-01'), '%Y-%m-%d')", Date.class, DSL.field(dateField));
             case WEEK:
                 return DSL.field("STR_TO_DATE(CONCAT(YEARWEEK({0}, 3), ' Monday'), '%X%V %W')", Date.class, DSL.field(dateField));
             case DAY:

--- a/jdbc-postgres/src/main/java/io/kestra/repository/postgres/PostgresRepositoryUtils.java
+++ b/jdbc-postgres/src/main/java/io/kestra/repository/postgres/PostgresRepositoryUtils.java
@@ -15,7 +15,7 @@ public final class PostgresRepositoryUtils {
     public static Field<Date> formatDateField(String dateField, DateUtils.GroupType groupType) {
         switch (groupType) {
             case MONTH:
-                return DSL.field("TO_CHAR({0}, 'YYYY-MM')", Date.class, DSL.field(dateField));
+                return DSL.field("DATE_TRUNC('month', {0})", Date.class, DSL.field(dateField));
             case WEEK:
                 return DSL.field("DATE_TRUNC('week', {0})", Date.class, DSL.field(dateField));
             case DAY:

--- a/webserver/src/test/java/io/kestra/webserver/controllers/api/DashboardControllerTest.java
+++ b/webserver/src/test/java/io/kestra/webserver/controllers/api/DashboardControllerTest.java
@@ -2,6 +2,7 @@ package io.kestra.webserver.controllers.api;
 
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
+import java.time.ZonedDateTime;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -15,6 +16,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import io.kestra.core.junit.annotations.KestraTest;
 import io.kestra.core.models.Label;
 import io.kestra.core.models.QueryFilter;
+import io.kestra.core.models.QueryFilter.Op;
 import io.kestra.core.models.dashboards.Dashboard;
 import io.kestra.core.models.executions.Execution;
 import io.kestra.core.models.executions.ExecutionKind;
@@ -1035,5 +1037,69 @@ class DashboardControllerTest {
         );
         assertThat(httpClientResponseException.getStatus().getCode()).isEqualTo(422);
         assertThat(httpClientResponseException.getMessage()).contains("catastrophic backtracking");
+    }
+
+    @Test
+    void shouldProcessDashboardIntervalRangeGreaterThanYear() {
+        String namespace = TestsUtils.randomNamespace();
+        executionRepository.save(
+            Execution.builder()
+                .tenantId(MAIN_TENANT)
+                .id(IdUtils.create())
+                .namespace(namespace)
+                .flowId("flow")
+                .state(new State(State.Type.SUCCESS))
+                .build()
+        );
+
+        String chartYaml = """
+            id: total_executions_timeseries
+            type: io.kestra.plugin.core.dashboard.chart.TimeSeries
+            chartOptions:
+              description: Executions duration and count per date
+              displayName: Total Executions
+              legend:
+                enabled: true
+              column: date
+              colorByColumn: state
+              width: 8
+            data:
+              type: io.kestra.plugin.core.dashboard.data.Executions
+              columns:
+                date:
+                  field: START_DATE
+                  displayName: Date
+                state:
+                  field: STATE
+                total:
+                  displayName: Executions
+                  agg: COUNT
+                  graphStyle: BARS
+                duration:
+                  field: DURATION
+                  displayName: Duration
+                  agg: SUM
+                  graphStyle: LINES
+            """;
+
+        ZonedDateTime currentTime = ZonedDateTime.now();
+
+        List<QueryFilter> filters = List.of(
+            QueryFilter.builder().field(QueryFilter.Field.START_DATE).value(currentTime.minusDays(2)).operation(Op.GREATER_THAN_OR_EQUAL_TO).build(),
+            QueryFilter.builder().field(QueryFilter.Field.END_DATE).value(currentTime.plusYears(2)).operation(Op.LESS_THAN_OR_EQUAL_TO).build()
+        );
+
+        var globalChartOptions = ChartFiltersOverrides.builder().filters(filters).build();
+
+        var previewRequest = new DashboardController.PreviewRequest(chartYaml, globalChartOptions);
+
+        var chartData = client.toBlocking().retrieve(
+            POST(DASHBOARD_PATH + "/charts/preview", previewRequest),
+            PagedResults.class
+        );
+
+        assertThat(chartData).isNotNull();
+        assertThat(chartData.getTotal()).isGreaterThan(0L);
+        assertThat(chartData.getResults()).isNotNull().isNotEmpty();
     }
 }


### PR DESCRIPTION
### ✨ Description

closes #17324

### 🔗 Related Issue

In PostgresRepositoryUtils.java, formatDateField mapped SQL results to Date.class while using TO_CHAR() for MONTH, HOUR, and MINUTE group types:

When jOOQ attempted to deserialize this string as a Date.class / TIMESTAMP field for the dashboard chart queries, the JDBC driver threw a casting DataAccessException.

This occurred on date ranges larger than 365 days (defaulting to MONTH grouping).

TO_CHAR() returns a PostgreSQL VARCHAR string (e.g., '2026-07').

There are two exceptions that occur for the two flows.
io.kestra.plugin.core.dashboard.data.Logs
io.kestra.plugin.core.dashboard.data.Executions

both of which boils down to the same PostgresRepositoryUtils utility.

API: POST /api/v1/main/dashboards/charts/preview
{
  "chart": "id: logs_timeseries\ntype: io.kestra.plugin.core.dashboard.chart.TimeSeries\nchartOptions:\n  description: Logs count per date grouped by level\n  displayName: Logs\n  legend:\n    enabled: true\n  column: date\n  colorByColumn: level\n  width: 12\ndata:\n  type: io.kestra.plugin.core.dashboard.data.Logs\n  columns:\n    date:\n      field: DATE\n      displayName: Execution Date\n    level:\n      field: LEVEL\n    total:\n      displayName: Total Executions\n      agg: COUNT\n      graphStyle: BARS\n",
  "globalFilter": {
    "filters": [
      {
        "field": "startDate",
        "value": "2026-07-13T18:30:00.000Z",
        "operation": "GREATER_THAN_OR_EQUAL_TO"
      },
      {
        "field": "endDate",
        "value": "2031-07-07T18:30:00.000Z",
        "operation": "LESS_THAN_OR_EQUAL_TO"
      }
    ]
  }
}


Solution:
Using PostgreSQL's native DATE_TRUNC() function which preserves the underlying TIMESTAMP data type required by Date class

### 🛠️ Backend Checklist

_If this PR does not include any backend changes, delete this entire section._

- [x] Code compiles successfully and passes all checks
- [x] All unit and integration tests pass

Passing Tests
./gradlew :core:unitTest
./gradlew :jdbc-h2:test
./gradlew :jdbc-postgres:test
./gradlew :jdbc:unitTest