### PR TITLE
fix(docs): load searched document in panel instead of opening new tab

### DIFF
--- a/ui/src/components/docs/ContextChildCard.vue
+++ b/ui/src/components/docs/ContextChildCard.vue
@@ -9,7 +9,7 @@
         >
             <div class="card h-100">
                 <div class="card-body d-flex align-items-center">
-                    <span class="card-icon">
+                    <span v-if="item.icon" class="card-icon">
                         <img
                             :src="docStore.resourceUrl(item.icon.replace(/^\/src\/contents\//, ''))"
                             :alt="item.title"
@@ -32,7 +32,7 @@
 </template>
 
 <script setup lang="ts">
-    import {computed, ref, onMounted} from "vue";
+    import {computed, ref, watchEffect} from "vue";
     import {useDocStore} from "../../stores/doc";
 
     import ContextDocsLink from "./ContextDocsLink.vue";
@@ -57,9 +57,9 @@
 
 
     const resourcesWithMetadata = ref<Record<string, any>>({});
-    onMounted(async () => {
+    watchEffect(async () => {
         resourcesWithMetadata.value = await docStore.children(currentPage.value);
-    })
+    });
 
     const navigation = computed(() => {
         let parentMetadata: Record<string, any> = {};

--- a/ui/src/components/docs/ContextDocs.vue
+++ b/ui/src/components/docs/ContextDocs.vue
@@ -32,7 +32,7 @@
                 <DocsMenu />
                 <DocsLayout>
                     <template #content>
-                        <MDCRenderer v-if="ast?.body" :body="ast.body" :data="ast.data" :key="ast" :components="proseComponents" />
+                        <MDCRenderer v-if="ast?.body" :body="ast.body" :data="ast.data" :components="proseComponents" />
                     </template>
                 </DocsLayout>
             </template>

--- a/ui/src/components/docs/ContextDocsSearch.vue
+++ b/ui/src/components/docs/ContextDocsSearch.vue
@@ -25,7 +25,7 @@
                     :key="result.url"
                     class="search-result"
                     :class="{'selected': index === selectedIndex}"
-                    :href="result.parsedUrl.replace(/^docs\//, '')"
+                    :href="result.parsedUrl.replace(/^https?:\/\/[^/]+/, '').replace(/^\//, '')"
                     useRaw
                     :data-index="index"
                     @click="resetSearch"


### PR DESCRIPTION
All PRs submitted by external contributors that do not follow this template (including proper description, related issue, and checklist sections) **may be automatically closed**.

As a general practice, if you plan to work on a specific issue, comment on the issue first and wait to be assigned before starting any actual work. This avoids duplicated work and ensures a smooth contribution process - otherwise, the PR **may be automatically closed**.

---

### ✨ Description

When you searched for something in the docs panel and clicked a result, the content below never changed — it just stayed on whatever page was already loaded. Turns out the search results were using ContextDocsLink with the full https://kestra.io/docs/... URL, which the component treated as an external link and opened in a new tab. So the panel never actually knew you clicked anything.

Fixed by normalizing the URL to a relative path before handing it to ContextDocsLink, so it navigates inside the panel like it should.

Also fixed a crash where item.icon could be undefined on some docs cards, and swapped out the manual onMounted + watch pattern in ContextChildCard with watchEffect so it re-fetches automatically when the page changes. Removed :key="ast" from MDCRenderer as well — it was causing the whole doc tree to remount twice on every navigation due to the two-stage render.

### 🔗 Related Issue

 Closes https://github.com/kestra-io/kestra/issues/17355

### 🎨 Frontend Checklist

- [x] Code builds without errors (`npm run build`)
- [ ] All existing E2E tests pass (`npm run test:e2e`)
- [x] Screenshots or video recordings attached showing the `UI` changes

[Screencast from 2026-07-26 15-18-52.webm](https://github.com/user-attachments/assets/b822b8ff-dc54-47f3-9b0d-bba85adbc747)

### 📝 Additional Notes

Only frontend changes. The ContextDocs.vue tweak is a nice-to-have rather than a hard requirement — the real fix is the URL normalization in ContextDocsSearch.vue.

