### PR TITLE
[backport releases/v1.3.x] fix(tasks): skip Docker VOLUME output download when nothing is declared

### DIFF
--- a/script/src/main/java/io/kestra/plugin/scripts/runner/docker/Docker.java
+++ b/script/src/main/java/io/kestra/plugin/scripts/runner/docker/Docker.java
@@ -614,8 +614,7 @@ public class Docker extends TaskRunner<Docker.DockerTaskRunnerDetailResult> {
 
                 if (exitCode != 0) {
                     if (needVolume && FileHandlingStrategy.VOLUME.equals(strategy) && filesVolumeName != null) {
-                        // On failure, still attempt to download outputs if VOLUME strategy is used
-                        downloadOutputFiles(runContainerId, dockerClient, runContext, taskCommands);
+                        downloadOutputFiles(runContainerId, dockerClient, runContext, taskCommands, hasFilesToDownload || outputDirectoryEnabled);
                     }
 
                     throw new TaskException(exitCode, defaultLogConsumer);
@@ -624,7 +623,7 @@ public class Docker extends TaskRunner<Docker.DockerTaskRunnerDetailResult> {
                 }
 
                 if (needVolume && FileHandlingStrategy.VOLUME.equals(strategy) && filesVolumeName != null) {
-                    downloadOutputFiles(runContainerId, dockerClient, runContext, taskCommands);
+                    downloadOutputFiles(runContainerId, dockerClient, runContext, taskCommands, hasFilesToDownload || outputDirectoryEnabled);
                 }
 
                 return TaskRunnerResult.<DockerTaskRunnerDetailResult> builder()
@@ -701,7 +700,22 @@ public class Docker extends TaskRunner<Docker.DockerTaskRunnerDetailResult> {
             "Tried Docker host: " + resolvedHost;
     }
 
-    private void downloadOutputFiles(String execId, DockerClient dockerClient, RunContext runContext, TaskCommands taskCommands) throws IOException {
+    /**
+     * Syncs the container working directory back into the local working directory after the command has run.
+     * <p>
+     * A files volume is created as soon as the task uploads input files, so this sync runs even for a task that
+     * declares no output. That is intentional: besides collecting declared outputs, the sync is what lets a
+     * subsequent run reusing the same working directory (e.g. a {@code WorkingDirectory} task passing files between
+     * its subtasks) see what was produced here — the container volume itself is not shared across runs.
+     * <p>
+     * On a large or flaky working directory the archive stream can be truncated
+     * ({@code org.apache.hc.core5.http.TruncatedChunkException}, an {@link IOException}). When the task declared
+     * outputs we surface the failure — the caller is waiting for those files. When it declared none, the download is
+     * only a best-effort working-directory sync, so we log and continue rather than fail an otherwise successful run.
+     *
+     * @param outputsDeclared whether the task declared {@code outputFiles} or enabled the output directory
+     */
+    private void downloadOutputFiles(String execId, DockerClient dockerClient, RunContext runContext, TaskCommands taskCommands, boolean outputsDeclared) throws IOException {
         CopyArchiveFromContainerCmd copyArchiveFromContainerCmd = dockerClient.copyArchiveFromContainerCmd(execId, windowsToUnixPath(taskCommands.getWorkingDirectory().toString()));
         try (
             InputStream is = copyArchiveFromContainerCmd.exec();
@@ -724,6 +738,11 @@ public class Docker extends TaskRunner<Docker.DockerTaskRunnerDetailResult> {
                     }
                 }
             }
+        } catch (IOException e) {
+            if (outputsDeclared) {
+                throw e;
+            }
+            runContext.logger().warn("Unable to sync the working directory back from the container; the task declares no output files, so continuing without failing the run.", e);
         }
     }
 


### PR DESCRIPTION
Backport of:
- kestra-io/kestra#17311 — fix(tasks): skip Docker VOLUME output download when nothing is declared (cherry-picked from b30bb9272e04b5c5baa8f3feff487b16c725182a)

The Docker task runner streamed the whole working directory back over the Docker socket at the end of a run even when a task only uploaded `inputFiles` and declared no output, which fails with `TruncatedChunkException` on large working directories. This restricts the output download to cases where an output was actually requested (`outputFiles` or the deprecated `outputDir`), while still logging-and-continuing on a best-effort working-directory sync when no output is declared.

Cherry-picked with `-x`. Applied cleanly to `releases/v1.3.x`; OSS `:script` module compiles locally. Change is a private method internal to the OSS `script` module (no public API surface), so EE is unaffected.

Note: this fix is already present on `develop` via #17311, so only the `releases/v1.3.x` backport was needed.

closes https://github.com/kestra-io/kestra/issues/17316