### PR TITLE
fix(plugins): show feature-specific docs in the editor documentation panel

### DIFF
--- a/ui/src/components/no-code/components/TaskEditor.vue
+++ b/ui/src/components/no-code/components/TaskEditor.vue
@@ -341,10 +341,13 @@
 
     provide(DATA_TYPES_MAP_INJECTION_KEY, dataTypesMap)
 
+    const miscStore = useMiscStore()
+    const hash = computed(() => miscStore.configs?.pluginsHash ?? 0)
+
     watch([selectedTaskType, fullSchema], ([task]) => {
         if (task) {
             if(isPlugin.value){
-                pluginsStore.updateDocumentation(taskModel.value as Parameters<typeof pluginsStore.updateDocumentation>[0])
+                pluginsStore.updateDocumentation({cls: task, version: taskModel.value?.version, hash: hash.value})
             }
         }
     }, {immediate: true})
@@ -367,9 +370,6 @@
 
         onTaskInput(value)
     }
-
-    const miscStore = useMiscStore()
-    const hash = computed(() => miscStore.configs?.pluginsHash ?? 0)
 
     const onTaskEditorClick = inject(ON_TASK_EDITOR_CLICK_INJECTION_KEY, (elt?: PartialNoCodeElement) => {
         if(isPlugin.value && elt?.type){

--- a/ui/src/components/plugins/PluginDocumentation.vue
+++ b/ui/src/components/plugins/PluginDocumentation.vue
@@ -81,6 +81,12 @@
             </Suspense>
         </template>
 
+        <KsMarkdown
+            v-else-if="overrideIntro"
+            :content="overrideIntro"
+            :class="{'position-absolute': absolute}"
+        />
+
         <div v-else-if="introContent" class="dp-intro" :class="{'position-absolute': absolute}">
             <div class="dp-intro-hero">
                 <div class="dp-intro-icon">

--- a/ui/tests/storybook/components/plugins/PluginDocumentation.stories.jsx
+++ b/ui/tests/storybook/components/plugins/PluginDocumentation.stories.jsx
@@ -1,4 +1,5 @@
 import PluginDocumentation from "../../../../src/components/plugins/PluginDocumentation.vue";
+import dashboardIntro from "../../../../src/assets/docs/dashboard_home.md?raw"
 import {setMockClient} from "@kestra-io/kestra-sdk"
 
 export default {
@@ -22,6 +23,9 @@ const Template = (args) => ({
 });
 
 export const Default = Template.bind({});
-Default.args = {
-    overrideIntro: "This is an overridden intro content.",
+Default.args = {};
+
+export const WithOverrideIntro = Template.bind({});
+WithOverrideIntro.args = {
+    overrideIntro: dashboardIntro,
 };


### PR DESCRIPTION
## Problem

The editor **Documentation** panel showed the generic **Flow** documentation instead of the feature-specific docs, across every non-flow editor. Two distinct root causes hide behind the same symptom:

### 1. The intro ignored `overrideIntro`
The doc-panel redesign (#17048) replaced the intro's plain-markdown render with a hardcoded, flow-centric tabbed layout (Overview / Flow / Tasks / Inputs / Pebble / Examples, parsed from `basic.md`). It silently stopped honoring the `overrideIntro` prop, so any editor supplying a feature-specific intro fell back to the flow docs.

| Editor | Intended intro | Was showing |
|---|---|---|
| Dashboards (OSS) | `dashboard_home.md` | ❌ flow docs |
| Apps (EE) | `apps_home.md` | ❌ flow docs |
| Test Suites (EE) | `tests_home.md` | ❌ flow docs |

Apps & Test Suites `import` this exact OSS component, so they are fixed by the same one-line change.

### 2. No-Code block selection didn't load chart docs (#17579)
In the dashboard **No-Code** tab, the reactive watch passed the raw block model (which carries `type`, not `cls`) to `updateDocumentation()`, so `cls` was always `undefined`, the guard reset `editorPlugin`, and the panel stayed on the intro no matter which chart block was selected. This part incorporates the fix from #17640 — thanks @Lalithkishore1224.

## Fix
- **`PluginDocumentation.vue`** — render `overrideIntro` verbatim when provided; keep the rich flow intro for the default (flow-editor) case.
- **`TaskEditor.vue`** (No-Code) — pass the selected type as `cls` (with `version` + `hash`) so selecting a block loads that chart's documentation.
- Storybook story covers both intro branches.

## Verification
- `npm run check:types` — green across all three tsconfigs (design-system, app, test).
- Verified live in the real multi-panel editor (see Demo): flow editor shows the flow intro and a task's plugin doc on click; dashboard editor shows the dashboard docs.

Fixes #17579. Supersedes #17640 (its change is included here with credit).

## Demo

Real multi-panel editor (local instance). The Docs panel is docked on the right in every editor:

1. **Flow editor** — shows the flow documentation, and clicking a task's `type` switches it to that task's own plugin doc (`Log`).
2. **Dashboard editor** — now shows the dashboard's own documentation instead of the generic Flow intro. Apps and Test Suites editors in EE reuse this component and are fixed the same way.

https://github.com/user-attachments/assets/455ff0e0-3f2a-4d22-a5f8-5fa286ff83c3
