### PR TITLE
Remove stack trace display from expression debugger

### DIFF
--- a/ui/packages/kestra-sdk/src/openapi/types.gen.ts
+++ b/ui/packages/kestra-sdk/src/openapi/types.gen.ts
@@ -654,7 +654,6 @@ export type ExecutionControllerApiValidateExecutionInputsResponseApiInputError =
 export type ExecutionControllerEvalResult = {
     result?: string;
     error?: string;
-    stackTrace?: string;
 };
 
 export type ExecutionControllerExecutionResponse = Execution & {

--- a/ui/src/components/executions/outputs/ExpressionDebugger.vue
+++ b/ui/src/components/executions/outputs/ExpressionDebugger.vue
@@ -25,14 +25,6 @@
             <p>
                 <strong>{{ error }}</strong>
             </p>
-            <div v-if="stackTrace" class="my-2">
-                <CopyToClipboard
-                    :text="`${error}\n\n${stackTrace}`"
-                    :label="$t('copy')"
-                    class="d-inline-block me-2"
-                />
-            </div>
-            <pre v-if="stackTrace" class="stack mb-0">{{ stackTrace }}</pre>
         </KsAlert>
 
         <template v-else-if="result !== undefined">
@@ -69,7 +61,6 @@
     import * as Utils from "../../../utils/utils"
     import type {Execution} from "../../../stores/executions"
 
-    import CopyToClipboard from "../../layout/CopyToClipboard.vue"
     import VarValue from "../VarValue.vue"
 
     const props = defineProps<{
@@ -95,14 +86,12 @@
     const result = ref<string | undefined>(undefined)
     const resultLang = ref<"json" | "">("")
     const error = ref<string | undefined>(undefined)
-    const stackTrace = ref<string | undefined>(undefined)
 
     const isFileResult = computed(() => result.value !== undefined && Utils.isFile(result.value))
 
     function clear() {
         result.value = undefined
         error.value = undefined
-        stackTrace.value = undefined
     }
 
     async function onDebug() {
@@ -116,7 +105,6 @@
 
             if (response.error) {
                 error.value = response.error
-                stackTrace.value = response.stackTrace
                 return
             }
 
@@ -150,14 +138,6 @@
     }
 
     .error {
-        overflow: auto;
-    }
-
-    .stack {
-        white-space: pre-wrap;
-        word-break: break-word;
-        font-size: var(--ks-font-size-xs);
-        max-height: 15rem;
         overflow: auto;
     }
 


### PR DESCRIPTION
### ✨ Description

Realigns the frontend with the backend security fix in #17600, which removed `stackTrace` from the `/eval` endpoint results (`ExecutionController.EvalResult`) so internal Java stack traces are no longer exposed via the API.

The generated SDK type and its only consumer still carried the now-nonexistent field:
- Removed `stackTrace` from the `ExecutionControllerEvalResult` SDK type.
- Removed the dead stack-trace handling in `ExpressionDebugger` (state, template blocks, unused `CopyToClipboard` import, orphaned `.stack` style). The error message is still shown.

### 🔗 Related

Follow-up to #17600 (fixes kestra-io/kestra-ee#9035).