### PR TITLE
refactor(executions): use partial indexes for nullable trigger_id and parent_id columns

### DIFF
--- a/jdbc-postgres/src/main/resources/migrations/2.0.01-upgrade-postgres.sql
+++ b/jdbc-postgres/src/main/resources/migrations/2.0.01-upgrade-postgres.sql
@@ -41,7 +41,7 @@ CREATE INDEX IF NOT EXISTS idx_trigger_next_evaluation_date ON triggers (next_ev
 
 -- Executions: trigger reference
 ALTER TABLE executions ADD COLUMN IF NOT EXISTS "trigger_id" VARCHAR(150) GENERATED ALWAYS AS (value -> 'trigger' ->> 'id') STORED;
-CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_executions_trigger_id ON executions ("trigger_id");
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_executions_trigger_id ON executions ("trigger_id") WHERE "trigger_id" IS NOT NULL;
 
 -- Worker 2.0: replace worker_uuid with worker_uid
 DROP INDEX IF EXISTS worker_job_running_worker_uuid;
@@ -52,4 +52,4 @@ CREATE INDEX IF NOT EXISTS worker_job_running_worker_uid ON worker_job_running (
 -- Executions: parent execution ID and loop run index
 ALTER TABLE executions ADD COLUMN IF NOT EXISTS "parent_id" VARCHAR(100) GENERATED ALWAYS AS (value #>> '{parentId}') STORED;
 ALTER TABLE executions ADD COLUMN IF NOT EXISTS "loop_run_index" INT GENERATED ALWAYS AS ((value #>> '{loopRun,index}')::INT) STORED;
-CREATE INDEX CONCURRENTLY IF NOT EXISTS executions_parent_id ON executions ("deleted", "tenant_id", "parent_id");
+CREATE INDEX CONCURRENTLY IF NOT EXISTS executions_parent_id ON executions ("deleted", "tenant_id", "parent_id") WHERE "parent_id" IS NOT NULL;


### PR DESCRIPTION
## Summary
- `executions.trigger_id` and `executions.parent_id` are null for the majority of rows (only sub-flow/triggered executions populate them), and no query path filters on `IS NULL`/`IS NOT NULL` for these two columns.
- Adding `WHERE ... IS NOT NULL` to `idx_executions_trigger_id` and `executions_parent_id` in `2.0.01-upgrade-postgres.sql` keeps these indexes smaller and lowers insertion cost, with no impact on existing lookups.

## Test plan
- [ ] Run Postgres-backed JDBC tests to confirm the migration applies cleanly