### PR TITLE
fix(iam): stop routing EE users into the OSS basic-auth setup wizard

### DIFF
--- a/ui/src/main.ts
+++ b/ui/src/main.ts
@@ -33,10 +33,7 @@ const app = createApp(App)
 // the design system depending on the app's plugin-icon API
 app.provide(TASK_ICON_INJECTION_KEY, TaskIcon)
 
-// Fail closed: an unexpected error while probing the pre-auth endpoints tells us nothing about
-// whether this instance needs the first-run wizard, so send the user to the login page. Setup is
-// only reachable from the positive isBasicAuthInitialized === false signal in beforeResolve —
-// treating an error as "not initialized" parked EE users on the OSS wizard, which then 403s.
+// Fail closed: an error probing the pre-auth endpoints is no evidence that setup is needed.
 const handleAuthError = (to: {fullPath: string}) => {
     BasicAuth.logout()
     const fromPath = to.fullPath !== "/ui/login" ? to.fullPath : undefined

--- a/ui/src/main.ts
+++ b/ui/src/main.ts
@@ -33,13 +33,14 @@ const app = createApp(App)
 // the design system depending on the app's plugin-icon API
 app.provide(TASK_ICON_INJECTION_KEY, TaskIcon)
 
-const handleAuthError = (error: Error, to: {fullPath: string}) => {
-    if (error.message?.includes("401")) {
-        BasicAuth.logout()
-        const fromPath = to.fullPath !== "/ui/login" ? to.fullPath : undefined
-        return {name: "login", query: fromPath ? {from: fromPath} : {}}
-    }
-    return {name: "setup"}
+// Fail closed: an unexpected error while probing the pre-auth endpoints tells us nothing about
+// whether this instance needs the first-run wizard, so send the user to the login page. Setup is
+// only reachable from the positive isBasicAuthInitialized === false signal in beforeResolve —
+// treating an error as "not initialized" parked EE users on the OSS wizard, which then 403s.
+const handleAuthError = (to: {fullPath: string}) => {
+    BasicAuth.logout()
+    const fromPath = to.fullPath !== "/ui/login" ? to.fullPath : undefined
+    return {name: "login", query: fromPath ? {from: fromPath} : {}}
 }
 
 let httpClient: ReturnType<typeof setupKestraHttp> | undefined
@@ -137,7 +138,7 @@ async function beforeResolve(router: Router, to: any, from: any): Promise<unknow
         await miscStore.loadConfigs()
     } catch (error) {
         console.error("Error during authentication check:", error)
-        return handleAuthError(error as Error, to)
+        return handleAuthError(to)
     }
 }
 

--- a/ui/src/routes/routes.ts
+++ b/ui/src/routes/routes.ts
@@ -13,7 +13,16 @@ import DemoAssets from "../components/demo/Assets.vue"
 import DemoQuotas from "../components/demo/Quotas.vue"
 import DemoPolicies from "../components/demo/Policies.vue"
 
-const routes: RouteRecordRaw[] = [
+/**
+ * A route record, plus the `ossOnly` marker.
+ *
+ * Editions that build their route table on top of this one (EE) drop every record flagged
+ * `ossOnly`. Flag a route when the page it renders drives OSS-only backend endpoints, so it
+ * cannot work — and must not be reachable — outside the open-source edition.
+ */
+export type KestraRouteRecord = RouteRecordRaw & {ossOnly?: boolean}
+
+const routes: KestraRouteRecord[] = [
     //Initial
     {name: "root", path: "/", redirect: {name: "home"}, meta: {layout: {template: "<div />"}, anonymous: true}},
 
@@ -89,7 +98,9 @@ const routes: RouteRecordRaw[] = [
     {name: "admin/mcp-servers/create", path: "/:tenant?/admin/mcp-servers/new/:tab?",                 component: () => import("../components/admin/McpServer.vue")},
 
     //Setup
-    {name: "setup", path: "/:tenant?/setup", component: () => import("../components/basicauth/BasicAuthSetup.vue"), meta: {layout: FullScreenLayout, anonymous: true}},
+    // ossOnly: the wizard posts to /api/v1/{tenant}/basicAuth, an OSS-only endpoint backed by a
+    // bean that does not exist when micronaut.security is enabled. EE has its own first-run flow.
+    {name: "setup", path: "/:tenant?/setup", component: () => import("../components/basicauth/BasicAuthSetup.vue"), meta: {layout: FullScreenLayout, anonymous: true}, ossOnly: true},
     //Login
     {name: "login", path: "/:tenant?/login", component: () => import("../components/basicauth/BasicAuthLogin.vue"), meta: {layout: FullScreenLayout, anonymous: true}},
 

--- a/ui/src/routes/routes.ts
+++ b/ui/src/routes/routes.ts
@@ -13,13 +13,7 @@ import DemoAssets from "../components/demo/Assets.vue"
 import DemoQuotas from "../components/demo/Quotas.vue"
 import DemoPolicies from "../components/demo/Policies.vue"
 
-/**
- * A route record, plus the `ossOnly` marker.
- *
- * Editions that build their route table on top of this one (EE) drop every record flagged
- * `ossOnly`. Flag a route when the page it renders drives OSS-only backend endpoints, so it
- * cannot work — and must not be reachable — outside the open-source edition.
- */
+/** A route record, plus `ossOnly`: editions layering on this table (EE) drop the flagged records. */
 export type KestraRouteRecord = RouteRecordRaw & {ossOnly?: boolean}
 
 const routes: KestraRouteRecord[] = [
@@ -98,8 +92,7 @@ const routes: KestraRouteRecord[] = [
     {name: "admin/mcp-servers/create", path: "/:tenant?/admin/mcp-servers/new/:tab?",                 component: () => import("../components/admin/McpServer.vue")},
 
     //Setup
-    // ossOnly: the wizard posts to /api/v1/{tenant}/basicAuth, an OSS-only endpoint backed by a
-    // bean that does not exist when micronaut.security is enabled. EE has its own first-run flow.
+    // ossOnly: posts to /api/v1/{tenant}/basicAuth, which EE does not implement.
     {name: "setup", path: "/:tenant?/setup", component: () => import("../components/basicauth/BasicAuthSetup.vue"), meta: {layout: FullScreenLayout, anonymous: true}, ossOnly: true},
     //Login
     {name: "login", path: "/:tenant?/login", component: () => import("../components/basicauth/BasicAuthLogin.vue"), meta: {layout: FullScreenLayout, anonymous: true}},

--- a/ui/tests/unit/routesOssOnly.spec.ts
+++ b/ui/tests/unit/routesOssOnly.spec.ts
@@ -8,8 +8,7 @@ describe("routes ossOnly marker", () => {
         const setup = routes.find(route => route.name === "setup")
 
         // Then
-        // EE filters its route table on this flag. The wizard posts to /api/v1/{tenant}/basicAuth,
-        // an OSS-only endpoint, so shipping it to EE strands users on a page that can only fail.
+        // EE filters on this flag; without it the wizard ships to an edition that cannot serve it.
         expect(setup).toBeDefined()
         expect(setup?.ossOnly).toBe(true)
     })
@@ -19,8 +18,7 @@ describe("routes ossOnly marker", () => {
         const ossOnlyNames = routes.filter(route => route.ossOnly).map(route => route.name)
 
         // Then
-        // Guards against the flag spreading by copy-paste: adding one is a deliberate act that
-        // removes the page from EE, so it should show up in a diff of this list.
+        // Flagging a route removes it from EE, so any addition should surface in this diff.
         expect(ossOnlyNames).toEqual(["setup"])
     })
 })

--- a/ui/tests/unit/routesOssOnly.spec.ts
+++ b/ui/tests/unit/routesOssOnly.spec.ts
@@ -1,0 +1,26 @@
+import {describe, it, expect} from "vitest"
+
+import routes from "../../src/routes/routes"
+
+describe("routes ossOnly marker", () => {
+    it("flags the basic-auth setup wizard as ossOnly", () => {
+        // Given
+        const setup = routes.find(route => route.name === "setup")
+
+        // Then
+        // EE filters its route table on this flag. The wizard posts to /api/v1/{tenant}/basicAuth,
+        // an OSS-only endpoint, so shipping it to EE strands users on a page that can only fail.
+        expect(setup).toBeDefined()
+        expect(setup?.ossOnly).toBe(true)
+    })
+
+    it("keeps every other route registrable by downstream editions", () => {
+        // Given
+        const ossOnlyNames = routes.filter(route => route.ossOnly).map(route => route.name)
+
+        // Then
+        // Guards against the flag spreading by copy-paste: adding one is a deliberate act that
+        // removes the page from EE, so it should show up in a diff of this list.
+        expect(ossOnlyNames).toEqual(["setup"])
+    })
+})


### PR DESCRIPTION
The OSS first-run wizard is reachable in EE at `/ui/setup` and 403s on submit — it posts to `POST /api/v1/{tenant}/basicAuth`, which EE does not implement. Flags the route `ossOnly` (the filter existed, no route ever set it) and makes the pre-auth guard fail closed to login instead of to the wizard.

Pre-auth payload untouched — `/configs/login` still exposes only `isBasicAuthInitialized`, `/configs` still requires auth.

Companion EE PR: kestra-io/kestra-ee#9518
Behaviour introduced by #17539 + kestra-io/kestra-ee#9405