### PR TITLE
Feat/concurrency limit flow sync

### DIFF
--- a/core/src/main/java/io/kestra/core/models/flows/quota/Quota.java
+++ b/core/src/main/java/io/kestra/core/models/flows/quota/Quota.java
@@ -2,6 +2,7 @@ package io.kestra.core.models.flows.quota;
 
 import java.time.Duration;
 
+import lombok.EqualsAndHashCode;
 import org.hibernate.validator.constraints.time.DurationMin;
 
 import jakarta.validation.constraints.NotNull;
@@ -17,6 +18,7 @@ import lombok.experimental.SuperBuilder;
 @SuperBuilder
 @Getter
 @NoArgsConstructor
+@EqualsAndHashCode
 public class Quota {
     @NotNull
     @DurationMin(minutes = 1)

--- a/core/src/main/java/io/kestra/core/repositories/ConcurrencyLimitRepositoryInterface.java
+++ b/core/src/main/java/io/kestra/core/repositories/ConcurrencyLimitRepositoryInterface.java
@@ -15,6 +15,12 @@ public interface ConcurrencyLimitRepositoryInterface {
     ConcurrencyLimit update(ConcurrencyLimit concurrencyLimit);
 
     /**
+     * Delete a concurrency limit.
+     * WARNING: this is inherently unsafe and must only be used for administration
+     */
+    ConcurrencyLimit delete(ConcurrencyLimit concurrencyLimit);
+
+    /**
      * Returns all concurrency limits from the database for a given tenant
      */
     List<ConcurrencyLimit> find(String tenantId);

--- a/core/src/main/java/io/kestra/core/services/FlowService.java
+++ b/core/src/main/java/io/kestra/core/services/FlowService.java
@@ -13,6 +13,9 @@ import java.util.stream.IntStream;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
+import com.google.common.annotations.VisibleForTesting;
+import io.kestra.core.repositories.ConcurrencyLimitRepositoryInterface;
+import io.kestra.core.runners.ConcurrencyLimit;
 import org.apache.commons.lang3.ClassUtils;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 
@@ -67,7 +70,7 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class FlowService {
     @Inject
-    private FlowRepositoryInterface flowRepository;
+    protected FlowRepositoryInterface flowRepository; // Used in EE
 
     @Inject
     private FlowParsingService flowParsingService;
@@ -92,6 +95,9 @@ public class FlowService {
 
     @Inject
     private PluginRegistry pluginRegistry;
+
+    @Inject
+    private ConcurrencyLimitRepositoryInterface concurrencyLimitRepository;
 
     private final ExecutorService executorService;
 
@@ -135,7 +141,7 @@ public class FlowService {
 
         FlowWithSource created = flowRepository.create(flow);
 
-        // impact downstream consumers: topology, scheduler and flow metastore
+        // impact downstream consumers: topology, scheduler, flow metastore, concurrency limit
         impactDownstreamConsumers(created);
 
         return created;
@@ -191,7 +197,8 @@ public class FlowService {
         return deleted;
     }
 
-    private void impactDownstreamConsumers(FlowWithSource flow) throws QueueException {
+    // overridden in EE
+    protected void impactDownstreamConsumers(FlowWithSource flow) throws QueueException {
         // update the topology asynchronously
         executorService.submit(() -> updateTopology(flow));
 
@@ -200,6 +207,9 @@ public class FlowService {
 
         // send it to the flow queue for the flow metastore
         flowQueue.emit(flow);
+
+        // update concurrency limit if any
+        updateConcurrencyLimit(flow);
     }
 
     private void updateTopology(FlowWithSource flow) {
@@ -291,6 +301,48 @@ public class FlowService {
                     trigger -> sendTriggerEvent(new TriggerCreated(TriggerId.of(flow, trigger), flow.getRevision()))
                 );
         }
+    }
+
+    private void updateConcurrencyLimit(FlowWithSource flow) {
+        var previous = flow.getRevision() <= 1 ? null : flowRepository.findById(flow.getTenantId(), flow.getNamespace(), flow.getId(), Optional.of(flow.getRevision() - 1)).orElse(null);
+
+        // If the previous revision was soft-deleted, its concurrency limit was already removed:
+        // treat this as if there was no previous so a new concurrency limit is re-initialized.
+        if (previous != null && previous.isDeleted()) {
+            previous = null;
+        }
+
+        if (flow.isDeleted()) {
+            removeConcurrencyLimit(flow);
+            return;
+        }
+
+        // A draft revision is never picked up by the executor, so it must not get a live concurrency limit.
+        if (flow.isDraft()) {
+            return;
+        }
+
+        if (previous != null) {
+            if (previous.getConcurrency() == null && flow.getConcurrency() != null) {
+                initConcurrencyLimit(flow);
+            }
+
+            if (previous.getConcurrency() != null && flow.getConcurrency() == null) {
+                removeConcurrencyLimit(flow);
+            }
+        } else if (flow.getConcurrency() != null) {
+            initConcurrencyLimit(flow);
+        }
+    }
+
+    private void removeConcurrencyLimit(FlowWithSource flow) {
+        var concurrencyLimit = new ConcurrencyLimit(flow.getTenantId(), flow.getNamespace(), flow.getId(), 0);
+        concurrencyLimitRepository.delete(concurrencyLimit);
+    }
+
+    private void initConcurrencyLimit(FlowWithSource flow) {
+        var concurrencyLimit = new ConcurrencyLimit(flow.getTenantId(), flow.getNamespace(), flow.getId(), 0);
+        concurrencyLimitRepository.update(concurrencyLimit);
     }
 
     private void sendTriggerEvent(TriggerEvent event) {
@@ -712,7 +764,7 @@ public class FlowService {
         return !f.uidWithoutRevision().equals(FlowId.uidWithoutRevision(execution));
     }
 
-    public static List<AbstractTrigger> findRemovedTrigger(Flow flow, Flow previous) {
+    private static List<AbstractTrigger> findRemovedTrigger(Flow flow, Flow previous) {
         return ListUtils.emptyOnNull(previous.getTriggers())
             .stream()
             .filter(
@@ -723,7 +775,7 @@ public class FlowService {
             .toList();
     }
 
-    public static List<AbstractTrigger> findUpdatedTrigger(Flow flow, Flow previous) {
+    private static List<AbstractTrigger> findUpdatedTrigger(Flow flow, Flow previous) {
         return ListUtils.emptyOnNull(flow.getTriggers())
             .stream()
             .filter(
@@ -734,7 +786,7 @@ public class FlowService {
             .toList();
     }
 
-    public static List<AbstractTrigger> findNewTrigger(Flow flow, Flow previous) {
+    private static List<AbstractTrigger> findNewTrigger(Flow flow, Flow previous) {
         return ListUtils.emptyOnNull(flow.getTriggers())
             .stream()
             .filter(
@@ -745,7 +797,8 @@ public class FlowService {
             .toList();
     }
 
-    public static List<AbstractTrigger> findUnchangedTrigger(Flow flow, Flow previous) {
+    @VisibleForTesting
+    static List<AbstractTrigger> findUnchangedTrigger(Flow flow, Flow previous) {
         return ListUtils.emptyOnNull(flow.getTriggers())
             .stream()
             .filter(

--- a/core/src/test/java/io/kestra/core/repositories/AbstractConcurrencyLimitRepositoryTest.java
+++ b/core/src/test/java/io/kestra/core/repositories/AbstractConcurrencyLimitRepositoryTest.java
@@ -39,6 +39,16 @@ public abstract class AbstractConcurrencyLimitRepositoryTest {
     }
 
     @Test
+    void delete() {
+        ConcurrencyLimit concurrencyLimit = concurrencyLimitRepository.update(create("delete"));
+
+        concurrencyLimitRepository.delete(concurrencyLimit);
+
+        var limit = concurrencyLimitRepository.findById("tenant", "namespace", "delete");
+        assertThat(limit).isEmpty();
+    }
+
+    @Test
     void list() {
         concurrencyLimitRepository.update(create("list1"));
         concurrencyLimitRepository.update(create("list2"));

--- a/core/src/test/java/io/kestra/core/services/FlowServiceTest.java
+++ b/core/src/test/java/io/kestra/core/services/FlowServiceTest.java
@@ -22,8 +22,10 @@ import io.kestra.core.models.triggers.AbstractTrigger;
 import io.kestra.core.models.validations.ValidateConstraintViolation;
 import io.kestra.core.queues.BroadcastQueueInterface;
 import io.kestra.core.queues.QueueException;
+import io.kestra.core.repositories.ConcurrencyLimitRepositoryInterface;
 import io.kestra.core.repositories.FlowRepositoryInterface;
 import io.kestra.core.repositories.FlowTopologyRepositoryInterface;
+import io.kestra.core.runners.ConcurrencyLimit;
 import io.kestra.core.scheduler.events.TriggerCreated;
 import io.kestra.core.scheduler.events.TriggerEvent;
 import io.kestra.core.scheduler.events.TriggerFlowRevisionUpdated;
@@ -59,6 +61,8 @@ class FlowServiceTest {
     private BroadcastQueueInterface<FlowInterface> flowQueue;
     @Inject
     private TriggerEventQueue triggerEventQueue;
+    @Inject
+    private ConcurrencyLimitRepositoryInterface concurrencyLimitRepository;
 
     private static FlowWithSource create(String flowId, String taskId, Integer revision) {
         return create(null, TEST_NAMESPACE, flowId, taskId, revision);
@@ -608,6 +612,195 @@ class FlowServiceTest {
 
         // check that the flow has been sent to the queue 2x
         assertTrue(countDownLatch.await(10, TimeUnit.SECONDS));
+    }
+
+    @Test
+    void shouldInitConcurrencyLimitWhenCreatingFlowWithConcurrency() throws FlowProcessingException, QueueException {
+        // Given a flow created with a concurrency limit
+        Flow flow = Flow.builder()
+            .id(IdUtils.create())
+            .tenantId(TenantService.MAIN_TENANT)
+            .namespace(TEST_NAMESPACE)
+            .tasks(List.of(Return.builder().id("task").type(Return.class.getName()).format(Property.ofValue("test")).build()))
+            .concurrency(Concurrency.builder().limit(1).build())
+            .build();
+
+        // When
+        flowService.create(GenericFlow.of(flow));
+
+        // Then a concurrency limit is initialized at 0
+        Optional<ConcurrencyLimit> limit = concurrencyLimitRepository.findById(flow.getTenantId(), flow.getNamespace(), flow.getId());
+        assertThat(limit).isPresent();
+        assertThat(limit.get().getRunning()).isEqualTo(0);
+    }
+
+    @Test
+    void shouldNotInitConcurrencyLimitWhenCreatingFlowWithoutConcurrency() throws FlowProcessingException, QueueException {
+        // Given a flow created without a concurrency limit
+        Flow flow = Flow.builder()
+            .id(IdUtils.create())
+            .tenantId(TenantService.MAIN_TENANT)
+            .namespace(TEST_NAMESPACE)
+            .tasks(List.of(Return.builder().id("task").type(Return.class.getName()).format(Property.ofValue("test")).build()))
+            .build();
+
+        // When
+        flowService.create(GenericFlow.of(flow));
+
+        // Then no concurrency limit is created
+        Optional<ConcurrencyLimit> limit = concurrencyLimitRepository.findById(flow.getTenantId(), flow.getNamespace(), flow.getId());
+        assertThat(limit).isEmpty();
+    }
+
+    @Test
+    void shouldInitConcurrencyLimitWhenAddingConcurrencyOnUpdate() throws FlowProcessingException, QueueException {
+        // Given a flow created without a concurrency limit
+        Flow flow = Flow.builder()
+            .id(IdUtils.create())
+            .tenantId(TenantService.MAIN_TENANT)
+            .namespace(TEST_NAMESPACE)
+            .tasks(List.of(Return.builder().id("task").type(Return.class.getName()).format(Property.ofValue("test")).build()))
+            .build();
+        FlowWithSource created = flowService.create(GenericFlow.of(flow));
+
+        // When the flow is updated to add a concurrency limit
+        Flow updated = flow.toBuilder()
+            .concurrency(Concurrency.builder().limit(1).build())
+            .build();
+        flowService.update(GenericFlow.of(updated), created);
+
+        // Then a concurrency limit is initialized at 0
+        Optional<ConcurrencyLimit> limit = concurrencyLimitRepository.findById(flow.getTenantId(), flow.getNamespace(), flow.getId());
+        assertThat(limit).isPresent();
+        assertThat(limit.get().getRunning()).isEqualTo(0);
+    }
+
+    @Test
+    void shouldRemoveConcurrencyLimitWhenRemovingConcurrencyOnUpdate() throws FlowProcessingException, QueueException {
+        // Given a flow created with a concurrency limit
+        Flow flow = Flow.builder()
+            .id(IdUtils.create())
+            .tenantId(TenantService.MAIN_TENANT)
+            .namespace(TEST_NAMESPACE)
+            .tasks(List.of(Return.builder().id("task").type(Return.class.getName()).format(Property.ofValue("test")).build()))
+            .concurrency(Concurrency.builder().limit(1).build())
+            .build();
+        FlowWithSource created = flowService.create(GenericFlow.of(flow));
+        assertThat(concurrencyLimitRepository.findById(flow.getTenantId(), flow.getNamespace(), flow.getId())).isPresent();
+
+        // When the flow is updated to remove the concurrency limit
+        Flow updated = flow.toBuilder().concurrency(null).build();
+        flowService.update(GenericFlow.of(updated), created);
+
+        // Then the concurrency limit is removed
+        Optional<ConcurrencyLimit> limit = concurrencyLimitRepository.findById(flow.getTenantId(), flow.getNamespace(), flow.getId());
+        assertThat(limit).isEmpty();
+    }
+
+    @Test
+    void shouldNotResetConcurrencyLimitWhenUpdatingFlowWithConcurrencyUnchanged() throws FlowProcessingException, QueueException {
+        // Given a flow created with a concurrency limit and some running executions tracked
+        Flow flow = Flow.builder()
+            .id(IdUtils.create())
+            .tenantId(TenantService.MAIN_TENANT)
+            .namespace(TEST_NAMESPACE)
+            .tasks(List.of(Return.builder().id("task").type(Return.class.getName()).format(Property.ofValue("original")).build()))
+            .concurrency(Concurrency.builder().limit(5).build())
+            .build();
+        FlowWithSource created = flowService.create(GenericFlow.of(flow));
+        ConcurrencyLimit running = concurrencyLimitRepository.findById(flow.getTenantId(), flow.getNamespace(), flow.getId())
+            .orElseThrow()
+            .withRunning(3);
+        concurrencyLimitRepository.update(running);
+
+        // When the flow is updated but keeps a (non-null) concurrency limit
+        Flow updated = flow.toBuilder()
+            .tasks(List.of(Return.builder().id("task").type(Return.class.getName()).format(Property.ofValue("updated")).build()))
+            .concurrency(Concurrency.builder().limit(10).build())
+            .build();
+        flowService.update(GenericFlow.of(updated), created);
+
+        // Then the running counter is untouched (not reset to 0)
+        Optional<ConcurrencyLimit> limit = concurrencyLimitRepository.findById(flow.getTenantId(), flow.getNamespace(), flow.getId());
+        assertThat(limit).isPresent();
+        assertThat(limit.get().getRunning()).isEqualTo(3);
+    }
+
+    @Test
+    void shouldRemoveConcurrencyLimitWhenDeletingFlow() throws FlowProcessingException, QueueException {
+        // Given a flow created with a concurrency limit
+        Flow flow = Flow.builder()
+            .id(IdUtils.create())
+            .tenantId(TenantService.MAIN_TENANT)
+            .namespace(TEST_NAMESPACE)
+            .tasks(List.of(Return.builder().id("task").type(Return.class.getName()).format(Property.ofValue("test")).build()))
+            .concurrency(Concurrency.builder().limit(1).build())
+            .build();
+        FlowWithSource created = flowService.create(GenericFlow.of(flow));
+        assertThat(concurrencyLimitRepository.findById(flow.getTenantId(), flow.getNamespace(), flow.getId())).isPresent();
+
+        // When the flow is deleted
+        flowService.delete(created);
+
+        // Then the concurrency limit is removed
+        Optional<ConcurrencyLimit> limit = concurrencyLimitRepository.findById(flow.getTenantId(), flow.getNamespace(), flow.getId());
+        assertThat(limit).isEmpty();
+    }
+
+    @Test
+    void shouldInitConcurrencyLimitWhenRecreatingPreviouslyDeletedFlowWithConcurrency() throws FlowProcessingException, QueueException {
+        // Given a flow created with a concurrency limit, then deleted (which removes the limit)
+        String flowId = IdUtils.create();
+        Flow flow = Flow.builder()
+            .id(flowId)
+            .tenantId(TenantService.MAIN_TENANT)
+            .namespace(TEST_NAMESPACE)
+            .tasks(List.of(Return.builder().id("task").type(Return.class.getName()).format(Property.ofValue("test")).build()))
+            .concurrency(Concurrency.builder().limit(1).build())
+            .build();
+        FlowWithSource created = flowService.create(GenericFlow.of(flow));
+        flowService.delete(created);
+        assertThat(concurrencyLimitRepository.findById(flow.getTenantId(), flow.getNamespace(), flowId)).isEmpty();
+
+        // When the flow is recreated with the same id and a concurrency limit
+        Flow recreated = flow.toBuilder()
+            .tasks(List.of(Return.builder().id("task").type(Return.class.getName()).format(Property.ofValue("revived")).build()))
+            .build();
+        flowService.create(GenericFlow.of(recreated));
+
+        // Then the concurrency limit is re-initialized, since the previous (soft-deleted) revision
+        // must not be treated as a live "previous" for the concurrency-limit sync.
+        Optional<ConcurrencyLimit> limit = concurrencyLimitRepository.findById(flow.getTenantId(), flow.getNamespace(), flowId);
+        assertThat(limit).isPresent();
+        assertThat(limit.get().getRunning()).isEqualTo(0);
+    }
+
+    @Test
+    void shouldNotInitConcurrencyLimitWhenCreatingDraftFlowWithConcurrency() throws FlowProcessingException, QueueException {
+        // A draft flow is never picked up by the executor, so it must not get a live concurrency limit.
+        String flowId = IdUtils.create();
+        String source = """
+            id: %s
+            namespace: %s
+            draft: true
+            concurrency:
+              limit: 1
+            tasks:
+              - id: log
+                type: io.kestra.plugin.core.log.Log
+                message: hello
+            """.formatted(flowId, TEST_NAMESPACE);
+
+        FlowWithSource saved = flowService.create(GenericFlow.fromYaml(TenantService.MAIN_TENANT, source));
+
+        try {
+            assertThat(saved.isDraft()).isTrue();
+            Optional<ConcurrencyLimit> limit = concurrencyLimitRepository.findById(saved.getTenantId(), saved.getNamespace(), flowId);
+            assertThat(limit).isEmpty();
+        } finally {
+            flowRepository.findByIdWithSource(saved.getTenantId(), saved.getNamespace(), saved.getId())
+                .ifPresent(f -> flowRepository.delete(f));
+        }
     }
 
     @Test

--- a/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcConcurrencyLimitRepository.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcConcurrencyLimitRepository.java
@@ -42,6 +42,12 @@ public class AbstractJdbcConcurrencyLimitRepository extends AbstractJdbcReposito
     }
 
     @Override
+    public ConcurrencyLimit delete(ConcurrencyLimit concurrencyLimit) {
+        this.jdbcRepository.delete(concurrencyLimit);
+        return concurrencyLimit;
+    }
+
+    @Override
     public Optional<ConcurrencyLimit> findById(String tenantId, String namespace, String flowId) {
         return jdbcRepository
             .getDslContextWrapper()

--- a/ui/src/components/layout/empty/links.ts
+++ b/ui/src/components/layout/empty/links.ts
@@ -100,7 +100,7 @@ export const links: Record<string, EmptyLinks> = {
         learnMore: "https://kestra.io/docs/enterprise/governance/audit-logs",
     },
     quotas: {
-        learnMore: "https://kestra.io/docs/enterprise/governance/quotas",
+        learnMore: "https://kestra.io/docs/workflow-components/quotas",
     },
     instance: {
         video: "https://www.youtube.com/watch?v=pcC3OAJPQao",


### PR DESCRIPTION
Synchronize concurrency limit on flow update.

Fixes https://github.com/kestra-io/kestra-ee/issues/8106

Part-of: https://github.com/kestra-io/kestra-ee/issues/8930