### PR TITLE
fix(ai): open flow blueprints from the copilot "need help" card

### DIFF
--- a/ui/src/components/ai/copilot/CopilotHelp.vue
+++ b/ui/src/components/ai/copilot/CopilotHelp.vue
@@ -4,7 +4,7 @@
     <div class="copilot-help" data-test="copilot-help">
         <KsText size="small" class="copilot-help-title">{{ $t("welcome_copilot.need_help") }}</KsText>
 
-        <RouterLink class="copilot-help-card" :to="{name: 'blueprints', params: {kind: 'community', tab: 'flow'}}">
+        <RouterLink class="copilot-help-card" :to="{name: 'blueprints', params: {kind: 'flow', tab: 'community'}}">
             <KsIcon class="copilot-help-icon"><FileTreeOutline /></KsIcon>
             <span class="copilot-help-text">
                 <KsText class="copilot-help-card-title">{{ $t("welcome_copilot.success_page.items.blueprints.title") }}</KsText>

--- a/ui/tests/unit/components/ai/copilot/CopilotHelp.spec.ts
+++ b/ui/tests/unit/components/ai/copilot/CopilotHelp.spec.ts
@@ -34,7 +34,7 @@ describe("CopilotHelp", () => {
         const link = w.find(".router-link-stub")
         expect(link.exists()).toBe(true)
         const to = JSON.parse(link.attributes("data-to") ?? "{}")
-        expect(to).toEqual({name: "blueprints", params: {kind: "community", tab: "flow"}})
+        expect(to).toEqual({name: "blueprints", params: {kind: "flow", tab: "community"}})
     })
 
     it("links the Slack card to the external community URL, opened safely in a new tab", () => {


### PR DESCRIPTION
The **Blueprints** card in the AI Copilot "Need Help?" section 404'd: its route params were swapped (`kind: community, tab: flow`), producing `/blueprints/community/flow`.

Point it at the flow blueprints route — `{kind: "flow", tab: "community"}` → `/blueprints/flow/community` — matching the sidebar "Blueprints" link and the onboarding resources. Updated the unit test, which had pinned the same swapped params.

No EE change needed: `CopilotHelp.vue` is an OSS component with no EE override, and the `blueprints` route is identical in both editions, so this fixes the card in EE too.

Closes https://github.com/kestra-io/kestra/issues/17662.