### PR TITLE
fix(execution): mask SECRET flow outputs and trigger outputs in logs

### DIFF
--- a/core/src/main/java/io/kestra/core/runners/DefaultRunContext.java
+++ b/core/src/main/java/io/kestra/core/runners/DefaultRunContext.java
@@ -72,6 +72,7 @@ public class DefaultRunContext extends RunContext {
     private Storage storage;
     private Map<String, Object> pluginConfiguration;
     private List<String> secretInputs;
+    private List<String> secretOutputs;
     private String traceParent;
 
     // those are only used to validate dynamic properties inside the RunContextProperty
@@ -116,6 +117,15 @@ public class DefaultRunContext extends RunContext {
     @JsonInclude
     public List<String> getSecretInputs() {
         return secretInputs;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    @JsonInclude
+    public List<String> getSecretOutputs() {
+        return secretOutputs;
     }
 
     /**
@@ -193,6 +203,22 @@ public class DefaultRunContext extends RunContext {
                 }
             }
         }
+
+        // this is used when a run context is re-hydrated so we need to add again the decrypted SECRET flow outputs
+        if (!ListUtils.isEmpty(secretOutputs)) {
+            secretOutputs.forEach(logger::usedSecret);
+        }
+    }
+
+    /**
+     * Registers a value to be masked in this run context's logs, and records it in {@link #secretOutputs}.
+     * Makes a defensive copy of the list, since {@link #clone()} may share it with another run context.
+     */
+    void usedSecretOutput(final String secret) {
+        logger.usedSecret(secret);
+        List<String> updated = new ArrayList<>(ListUtils.emptyOnNull(secretOutputs));
+        updated.add(secret);
+        secretOutputs = updated;
     }
 
     @SuppressWarnings("unchecked")
@@ -236,6 +262,7 @@ public class DefaultRunContext extends RunContext {
         runContext.storage = this.storage;
         runContext.pluginConfiguration = this.pluginConfiguration;
         runContext.secretInputs = this.secretInputs;
+        runContext.secretOutputs = this.secretOutputs;
         if (isInitialized.get()) {
             //Inject all services
             runContext.init(applicationContext);
@@ -701,6 +728,7 @@ public class DefaultRunContext extends RunContext {
         private KVStoreService kvStoreService;
         private AssetManagerFactory assetManagerFactory;
         private List<String> secretInputs;
+        private List<String> secretOutputs;
         private Task task;
         private AbstractTrigger trigger;
 
@@ -724,6 +752,7 @@ public class DefaultRunContext extends RunContext {
             context.kvStoreService = kvStoreService;
             context.assetManagerFactory = assetManagerFactory;
             context.secretInputs = secretInputs;
+            context.secretOutputs = secretOutputs;
             context.task = task;
             context.trigger = trigger;
             return context;

--- a/core/src/main/java/io/kestra/core/runners/RunContext.java
+++ b/core/src/main/java/io/kestra/core/runners/RunContext.java
@@ -48,6 +48,14 @@ public abstract class RunContext implements PropertyContext {
     public abstract List<String> getSecretInputs();
 
     /**
+     * Returns the plaintext values of SECRET-typed flow outputs decrypted while building this context's
+     * variables (e.g. a subflow's SECRET output consumed by this task), so they can be re-registered for
+     * log masking once this context is re-hydrated (e.g. on the worker).
+     */
+    @JsonInclude
+    public abstract List<String> getSecretOutputs();
+
+    /**
      * OpenTelemetry trace parent
      */
     @JsonInclude

--- a/core/src/main/java/io/kestra/core/runners/RunContextFactory.java
+++ b/core/src/main/java/io/kestra/core/runners/RunContextFactory.java
@@ -115,6 +115,16 @@ public class RunContextFactory {
 
         VariableRenderer variableRenderer = decryptVariables ? this.variableRenderer : secureVariableRendererFactory.createOrGet();
 
+        RunVariables.Builder runVariablesBuilder = runVariableModifier.apply(
+            newRunVariablesBuilder()
+                .withFlow(flow)
+                .withExecution(execution)
+                .withOutputs(taskOutputService.computeOutputs(execution))
+                .withDecryptVariables(decryptVariables)
+                .withSecretInputs(secretInputsFromFlow(flow))
+        );
+        Map<String, Object> variables = runVariablesBuilder.build(runContextLogger, PropertyContext.create(variableRenderer));
+
         return newBuilder()
             // Logger
             .withLogger(runContextLogger)
@@ -122,18 +132,9 @@ public class RunContextFactory {
             .withPluginConfiguration(Map.of())
             .withStorage(new InternalStorage(runContextLogger.logger(), StorageContext.forExecution(execution), storageInterface, namespaceService, namespaceFactory))
             .withVariableRenderer(variableRenderer)
-            .withVariables(
-                runVariableModifier.apply(
-                    newRunVariablesBuilder()
-                        .withFlow(flow)
-                        .withExecution(execution)
-                        .withOutputs(taskOutputService.computeOutputs(execution))
-                        .withDecryptVariables(decryptVariables)
-                        .withSecretInputs(secretInputsFromFlow(flow))
-                )
-                    .build(runContextLogger, PropertyContext.create(variableRenderer))
-            )
+            .withVariables(variables)
             .withSecretInputs(secretInputsFromFlow(flow))
+            .withSecretOutputs(runVariablesBuilder.secretOutputs())
             .build();
     }
 
@@ -148,24 +149,25 @@ public class RunContextFactory {
     public RunContext of(FlowInterface flow, Task task, Execution execution, TaskRun taskRun, boolean decryptVariables, VariableRenderer variableRenderer) {
         RunContextLogger runContextLogger = runContextLoggerFactory.create(taskRun, task, execution.getKind());
 
+        RunVariables.Builder runVariablesBuilder = newRunVariablesBuilder()
+            .withFlow(flow)
+            .withTask(task)
+            .withExecution(execution)
+            .withOutputs(taskOutputService.computeOutputs(execution))
+            .withTaskRun(taskRun)
+            .withDecryptVariables(decryptVariables)
+            .withSecretInputs(secretInputsFromFlow(flow));
+        Map<String, Object> variables = runVariablesBuilder.build(runContextLogger, PropertyContext.create(variableRenderer));
+
         return newBuilder()
             // Logger
             .withLogger(runContextLogger)
             // Task
             .withPluginConfiguration(pluginConfigurations.getConfigurationByPluginTypeOrAliases(task.getType(), task.getClass()))
             .withStorage(new InternalStorage(runContextLogger.logger(), StorageContext.forTask(taskRun), storageInterface, namespaceService, namespaceFactory))
-            .withVariables(
-                newRunVariablesBuilder()
-                    .withFlow(flow)
-                    .withTask(task)
-                    .withExecution(execution)
-                    .withOutputs(taskOutputService.computeOutputs(execution))
-                    .withTaskRun(taskRun)
-                    .withDecryptVariables(decryptVariables)
-                    .withSecretInputs(secretInputsFromFlow(flow))
-                    .build(runContextLogger, PropertyContext.create(variableRenderer))
-            )
+            .withVariables(variables)
             .withSecretInputs(secretInputsFromFlow(flow))
+            .withSecretOutputs(runVariablesBuilder.secretOutputs())
             .withTask(task)
             .withVariableRenderer(variableRenderer)
             .build();

--- a/core/src/main/java/io/kestra/core/runners/RunContextInitializer.java
+++ b/core/src/main/java/io/kestra/core/runners/RunContextInitializer.java
@@ -151,7 +151,7 @@ public class RunContextInitializer {
 
         variables = variablesModifier.apply(variables);
 
-        DefaultRunContext runContext = buildAndInitRunContext(variables, data.secretInputs(), data.traceParent(), workingDir);
+        DefaultRunContext runContext = buildAndInitRunContext(variables, data.secretInputs(), data.secretOutputs(), data.traceParent(), workingDir);
         runContext.setPluginConfiguration(pluginConfigurations.getConfigurationByPluginTypeOrAliases(task.getType(), task.getClass()));
         runContext.setStorage(new InternalStorage(runContextLogger.logger(), StorageContext.forTask(taskRun), storageInterface, namespaceService, namespaceFactory));
         runContext.setLogger(runContextLogger);
@@ -225,8 +225,8 @@ public class RunContextInitializer {
         }
 
         outputs.put(workerTaskResult.getTaskRun().getTaskId(), result);
-        variables.put("outputs", new Secret(encryptionConfig.asOptional(), runContext::logger).decrypt(outputs));
-        variables.put("trigger", new Secret(encryptionConfig.asOptional(), runContext::logger).decrypt(triggerOutputs));
+        variables.put("outputs", new Secret(encryptionConfig.asOptional(), runContext::logger, runContext::usedSecretOutput).decrypt(outputs));
+        variables.put("trigger", new Secret(encryptionConfig.asOptional(), runContext::logger, runContext::usedSecretOutput).decrypt(triggerOutputs));
 
         runContext.setVariables(variables);
         return runContext;
@@ -278,7 +278,7 @@ public class RunContextInitializer {
         final RunContextLogger runContextLogger = contextLoggerFactory.create(workerTrigger.triggerId(), trigger);
         addSecretConsumer(variables, runContextLogger);
 
-        DefaultRunContext runContext = buildAndInitRunContext(variables, data.secretInputs(), data.traceParent(), null);
+        DefaultRunContext runContext = buildAndInitRunContext(variables, data.secretInputs(), List.of(), data.traceParent(), null);
         configureTrigger(runContext, runContextLogger, workerTrigger.triggerId(), trigger);
 
         return ConditionContext.builder()
@@ -314,11 +314,13 @@ public class RunContextInitializer {
      */
     private DefaultRunContext buildAndInitRunContext(Map<String, Object> variables,
         List<String> secretInputs,
+        List<String> secretOutputs,
         String traceParent,
         WorkingDir workingDir) {
         var builder = new DefaultRunContext.Builder()
             .withVariables(variables)
-            .withSecretInputs(secretInputs);
+            .withSecretInputs(secretInputs)
+            .withSecretOutputs(secretOutputs);
         if (workingDir != null) {
             builder = builder.withWorkingDir(workingDir);
         }

--- a/core/src/main/java/io/kestra/core/runners/RunVariables.java
+++ b/core/src/main/java/io/kestra/core/runners/RunVariables.java
@@ -316,6 +316,14 @@ public final class RunVariables {
          * @return The immutable map of variables.
          */
         Map<String, Object> build(RunContextLogger logger, PropertyContext propertyContext);
+
+        /**
+         * Returns the plaintext values of any SECRET-typed flow output decrypted while building the
+         * variables map, so callers can carry them across the executor/worker boundary for log masking.
+         */
+        default List<String> secretOutputs() {
+            return List.of();
+        }
     }
 
     public record KestraConfiguration(String environment, String url) {
@@ -342,6 +350,7 @@ public final class RunVariables {
         private final Optional<String> secretKey;
         private List<String> secretInputs;
         private KestraConfiguration kestraConfiguration;
+        private final List<String> secretOutputs;
 
         public DefaultBuilder() {
             this(Optional.empty());
@@ -349,6 +358,15 @@ public final class RunVariables {
 
         public DefaultBuilder(final Optional<String> secretKey) {
             this.secretKey = secretKey;
+            this.secretOutputs = new ArrayList<>();
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public List<String> secretOutputs() {
+            return secretOutputs;
         }
 
         // Note: for performance reason, cloning maps should be avoided as much as possible.
@@ -398,7 +416,12 @@ public final class RunVariables {
 
                 if (!MapUtils.isEmpty(outputs)) {
                     if (decryptVariables) {
-                        final Secret secret = new Secret(secretKey, logger);
+                        // mask SECRET-typed flow output and trigger output
+                        final Secret secret = new Secret(secretKey, logger, decrypted ->
+                        {
+                            secretOutputs.add(decrypted);
+                            logger.usedSecret(decrypted);
+                        });
                         builder.put("outputs", secret.decrypt(outputs));
                     } else {
                         builder.put("outputs", outputs);

--- a/core/src/main/java/io/kestra/core/runners/Secret.java
+++ b/core/src/main/java/io/kestra/core/runners/Secret.java
@@ -2,6 +2,7 @@ package io.kestra.core.runners;
 
 import java.security.GeneralSecurityException;
 import java.util.*;
+import java.util.function.Consumer;
 import java.util.function.Supplier;
 
 import org.slf4j.Logger;
@@ -13,10 +14,21 @@ final class Secret {
 
     private final Optional<String> secretKey;
     private final Supplier<Logger> logger;
+    private final Consumer<String> onSecretDecrypted;
 
     Secret(final Optional<String> secretKey, final Supplier<Logger> logger) {
+        this(secretKey, logger, value -> {});
+    }
+
+    /**
+     * Creates a new {@link Secret} that also notifies {@code onSecretDecrypted} with each value
+     * successfully decrypted out of a {@code Map} (see {@link #decrypt(Map)}) — used to re-register
+     * a SECRET flow output's plaintext for log masking once it has been decrypted.
+     */
+    Secret(final Optional<String> secretKey, final Supplier<Logger> logger, final Consumer<String> onSecretDecrypted) {
         this.secretKey = Objects.requireNonNull(secretKey, "secretKey cannot be null");
         this.logger = Objects.requireNonNull(logger, "logger cannot be null");
+        this.onSecretDecrypted = Objects.requireNonNull(onSecretDecrypted, "onSecretDecrypted cannot be null");
     }
 
     String decrypt(final String encrypted) throws GeneralSecurityException {
@@ -46,6 +58,7 @@ final class Secret {
                 if (map.get("type") instanceof String typeStr && EncryptedString.TYPE.equalsIgnoreCase(typeStr)) {
                     try {
                         String decoded = decrypt((String) map.get("value"));
+                        onSecretDecrypted.accept(decoded);
                         decryptedMap.put(entry.getKey(), decoded);
                     } catch (GeneralSecurityException | IllegalArgumentException e) {
                         // NOTE: in rare cases, if for ex a Worker didn't have the encryption but an Executor has it,

--- a/core/src/main/java/io/kestra/core/runners/WorkerTaskData.java
+++ b/core/src/main/java/io/kestra/core/runners/WorkerTaskData.java
@@ -18,12 +18,14 @@ import io.micronaut.core.annotation.Nullable;
  *
  * @param variables The variables map, stripped of worker-reconstructed keys.
  * @param secretInputs List of input keys that are secrets (for log masking).
+ * @param secretOutputs Plaintext values of SECRET-typed flow outputs already decrypted by the executor.
  * @param traceParent OpenTelemetry trace parent for distributed tracing.
  */
 @JsonInclude(JsonInclude.Include.ALWAYS)
 public record WorkerTaskData(
     @JsonInclude(value = JsonInclude.Include.ALWAYS, content = JsonInclude.Include.ALWAYS) Map<String, Object> variables,
     List<String> secretInputs,
+    @Nullable List<String> secretOutputs,
     @Nullable String traceParent) implements WorkerRunContextData {
 
     /**
@@ -45,6 +47,7 @@ public record WorkerTaskData(
         return new WorkerTaskData(
             WorkerRunContextData.filterVariables(runContext, WORKER_RECONSTRUCTED_KEYS),
             runContext.getSecretInputs(),
+            runContext.getSecretOutputs(),
             runContext.getTraceParent()
         );
     }

--- a/core/src/test/java/io/kestra/core/runners/RunContextLoggerLabelsTest.java
+++ b/core/src/test/java/io/kestra/core/runners/RunContextLoggerLabelsTest.java
@@ -94,7 +94,7 @@ class RunContextLoggerLabelsTest {
         Task task = mock(Task.class);
         when(task.getLogLevel()).thenReturn(Level.TRACE);
         when(task.isLogToFile()).thenReturn(false);
-        WorkerTaskData data = new WorkerTaskData(Map.of(RunVariables.LABELS, Label.toNestedMap(List.of(labels))), List.of(), null);
+        WorkerTaskData data = new WorkerTaskData(Map.of(RunVariables.LABELS, Label.toNestedMap(List.of(labels))), List.of(), List.of(), null);
         return WorkerTask.builder().taskRun(taskRun).task(task).data(data).build();
     }
 

--- a/core/src/test/java/io/kestra/core/runners/RunContextLoggerTest.java
+++ b/core/src/test/java/io/kestra/core/runners/RunContextLoggerTest.java
@@ -2,11 +2,13 @@ package io.kestra.core.runners;
 
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
+import java.security.GeneralSecurityException;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Base64;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.CopyOnWriteArrayList;
 
 import org.junit.jupiter.api.Test;
@@ -15,17 +17,21 @@ import org.slf4j.Logger;
 import org.slf4j.event.KeyValuePair;
 import org.slf4j.event.Level;
 
+import io.kestra.core.encryption.EncryptionService;
 import io.kestra.core.models.executions.Execution;
 import io.kestra.core.models.executions.LogEntry;
 import io.kestra.core.models.executions.TaskRun;
 import io.kestra.core.models.executions.TaskRunAttempt;
 import io.kestra.core.models.flows.Flow;
+import io.kestra.core.models.property.PropertyContext;
+import io.kestra.core.models.tasks.common.EncryptedString;
 import io.kestra.core.queues.BroadcastQueueInterface;
 import io.kestra.core.queues.DispatchQueueInterface;
 import io.kestra.core.utils.TestsUtils;
 
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.classic.spi.LoggingEvent;
+import io.micronaut.context.annotation.Value;
 import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
 import jakarta.inject.Inject;
 
@@ -43,6 +49,12 @@ class RunContextLoggerTest {
 
     @Inject
     private LogEntryEmitter logEntryEmitter;
+
+    @Inject
+    private VariableRenderer renderer;
+
+    @Value("${kestra.encryption.secret-key}")
+    private String secretKey;
 
     @Test
     void logs() {
@@ -132,6 +144,43 @@ class RunContextLoggerTest {
         assertThat(matchingLog.stream().filter(logEntry -> logEntry.getLevel().equals(Level.INFO)).findFirst().orElseThrow().getMessage())
             .isEqualTo("test ****** ************ ****** ************");
         assertThat(matchingLog.stream().filter(logEntry -> logEntry.getLevel().equals(Level.WARN)).findFirst().orElseThrow().getMessage()).isEqualTo("test ******");
+    }
+
+    @Test
+    void shouldMaskSecretFlowOutputWhenDecrypted() throws GeneralSecurityException {
+        // Given a SECRET-typed flow output already encrypted, as it would be after being produced by a subflow.
+        // Persisted/wire-format shape is a plain Map{type, value} (as produced by JacksonMapper.toMap), not an
+        // EncryptedString instance.
+        String encrypted = EncryptionService.encrypt(secretKey, "my-super-secret-value");
+        Map<String, Object> outputs = Map.of(
+            "subflow", Map.of("outputs", Map.of("secret", Map.of("type", EncryptedString.TYPE, "value", encrypted)))
+        );
+
+        List<LogEntry> logs = new CopyOnWriteArrayList<>();
+        logQueue.addListener(log -> logs.add(log));
+
+        Flow flow = TestsUtils.mockFlow();
+        Execution execution = TestsUtils.mockExecution(flow, Map.of());
+
+        RunContextLogger runContextLogger = new RunContextLogger(
+            logEntryEmitter,
+            LogEntry.of(execution),
+            Level.TRACE,
+            false
+        );
+
+        // When the outputs are decrypted while building the run variables
+        new RunVariables.DefaultBuilder(Optional.of(secretKey))
+            .withExecution(execution)
+            .withOutputs(outputs)
+            .withDecryptVariables(true)
+            .build(runContextLogger, PropertyContext.create(renderer));
+
+        // Then the decrypted plaintext is registered for log masking, exactly like a SECRET input
+        runContextLogger.logger().info("the secret is {}", "my-super-secret-value");
+
+        List<LogEntry> matchingLog = TestsUtils.awaitLogs(logs, 1);
+        assertThat(matchingLog.getFirst().getMessage()).isEqualTo("the secret is ******");
     }
 
     @Test

--- a/core/src/test/java/io/kestra/plugin/core/flow/SubflowRunnerTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/flow/SubflowRunnerTest.java
@@ -19,6 +19,7 @@ import io.kestra.core.models.Label;
 import io.kestra.core.models.executions.Execution;
 import io.kestra.core.models.executions.ExecutionId;
 import io.kestra.core.models.executions.ExecutionKind;
+import io.kestra.core.models.executions.LogEntry;
 import io.kestra.core.models.flows.Flow;
 import io.kestra.core.models.flows.State;
 import io.kestra.core.queues.*;
@@ -56,6 +57,9 @@ class SubflowRunnerTest {
 
     @Inject
     private TaskOutputService taskOutputService;
+
+    @Inject
+    private DispatchQueueInterface<LogEntry> logQueue;
 
     @Test
     @LoadFlows({ "flows/valids/subflow-inherited-labels-child.yaml", "flows/valids/subflow-inherited-labels-parent.yaml" })
@@ -195,5 +199,29 @@ class SubflowRunnerTest {
         assertTrue(grandChildExecution.isPresent());
         assertThat(grandChildExecution.get().getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
         assertThat(grandChildExecution.get().getTaskRunList()).hasSize(1);
+    }
+
+    @Test
+    @LoadFlows({ "flows/valids/subflow-secret-output-parent.yaml", "flows/valids/subflow-secret-output-child.yaml" })
+    void shouldMaskSecretWhenParentLogsSubflowSecretOutput() throws QueueException, TimeoutException, InterruptedException, io.kestra.core.exceptions.InternalException {
+        // Given — a listener on the log queue for the parent's `log` task
+        AtomicReference<LogEntry> logEntry = new AtomicReference<>();
+        CountDownLatch countDownLatch = new CountDownLatch(1);
+        logQueue.addListener(left ->
+        {
+            if (left.getFlowId().equals("subflow-secret-output-parent") && left.getTaskId().equals("log")) {
+                logEntry.set(left);
+                countDownLatch.countDown();
+            }
+        });
+
+        // When — the parent flow logs a SECRET-typed output produced by its subflow
+        Execution execution = runnerUtils.runOne(MAIN_TENANT, "io.kestra.tests", "subflow-secret-output-parent");
+
+        // Then — the parent's log task masks the decrypted secret instead of printing it in plaintext
+        assertThat(execution.getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
+        assertTrue(countDownLatch.await(10, TimeUnit.SECONDS));
+        assertThat(logEntry.get()).isNotNull();
+        assertThat(logEntry.get().getMessage()).isEqualTo("secret is ******");
     }
 }

--- a/core/src/test/java/io/kestra/plugin/core/flow/WorkingDirectoryTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/flow/WorkingDirectoryTest.java
@@ -10,7 +10,10 @@ import java.time.Duration;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicReference;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.ExecutionMode;
@@ -24,6 +27,7 @@ import io.kestra.core.junit.annotations.LoadFlows;
 import io.kestra.core.models.annotations.Plugin;
 import io.kestra.core.models.annotations.PluginProperty;
 import io.kestra.core.models.executions.Execution;
+import io.kestra.core.models.executions.LogEntry;
 import io.kestra.core.models.executions.TaskRun;
 import io.kestra.core.models.flows.Flow;
 import io.kestra.core.models.flows.State;
@@ -32,6 +36,7 @@ import io.kestra.core.models.tasks.Output;
 import io.kestra.core.models.tasks.RunnableTask;
 import io.kestra.core.models.tasks.Task;
 import io.kestra.core.models.tasks.common.EncryptedString;
+import io.kestra.core.queues.DispatchQueueInterface;
 import io.kestra.core.queues.QueueException;
 import io.kestra.core.repositories.ExecutionRepositoryInterface;
 import io.kestra.core.runners.FilesService;
@@ -141,6 +146,12 @@ public class WorkingDirectoryTest {
         suite.invalidRunIf(runnerUtils);
     }
 
+    @Test
+    @LoadFlows({ "flows/valids/working-directory-secret-output.yml" })
+    void secretOutputMasking() throws Exception {
+        suite.secretOutputMasking(runnerUtils);
+    }
+
     @Singleton
     public static class Suite {
         @Inject
@@ -151,6 +162,8 @@ public class WorkingDirectoryTest {
         TaskOutputService taskOutputService;
         @Inject
         ExecutionRepositoryInterface executionRepository;
+        @Inject
+        DispatchQueueInterface<LogEntry> logQueue;
 
         public void success(TestRunnerUtils runnerUtils) throws TimeoutException, QueueException, io.kestra.core.exceptions.InternalException {
             Execution execution = runnerUtils.runOne(
@@ -376,6 +389,29 @@ public class WorkingDirectoryTest {
             assertThat(encryptedValue).isNotEqualTo("Hello World");
             assertThat(runContextFactory.of().decrypt(encryptedValue)).isEqualTo("Hello World");
             assertThat(taskOutputService.getOutputs(execution.findTaskRunsByTaskId("decrypted").getFirst()).get("value")).isEqualTo("Hello World");
+        }
+
+        public void secretOutputMasking(TestRunnerUtils runnerUtils) throws TimeoutException, QueueException, InterruptedException, io.kestra.core.exceptions.InternalException {
+            // Given — a listener on the log queue for the WorkingDirectory's `log` subtask
+            AtomicReference<LogEntry> logEntry = new AtomicReference<>();
+            CountDownLatch countDownLatch = new CountDownLatch(1);
+            logQueue.addListener(left ->
+            {
+                if (left.getFlowId().equals("working-directory-secret-output") && left.getTaskId().equals("log")) {
+                    logEntry.set(left);
+                    countDownLatch.countDown();
+                }
+            });
+
+            // When — a WorkingDirectory subtask (`encrypted`) produces a SECRET-typed output and the
+            // next subtask (`log`) logs it, reproducing the original repro across the subtask boundary
+            Execution execution = runnerUtils.runOne(MAIN_TENANT, "io.kestra.tests", "working-directory-secret-output");
+
+            // Then — the `log` subtask masks the decrypted secret instead of printing it in plaintext
+            assertThat(execution.getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
+            assertTrue(countDownLatch.await(10, TimeUnit.SECONDS));
+            assertThat(logEntry.get()).isNotNull();
+            assertThat(logEntry.get().getMessage()).isEqualTo("secret is ******");
         }
 
         public void invalidRunIf(TestRunnerUtils runnerUtils) throws TimeoutException, QueueException {

--- a/core/src/test/resources/flows/valids/subflow-secret-output-child.yaml
+++ b/core/src/test/resources/flows/valids/subflow-secret-output-child.yaml
@@ -1,0 +1,12 @@
+id: subflow-secret-output-child
+namespace: io.kestra.tests
+
+tasks:
+  - id: hello
+    type: io.kestra.plugin.core.log.Log
+    message: child
+
+outputs:
+  - id: secret
+    type: SECRET
+    value: "my-super-secret-value"

--- a/core/src/test/resources/flows/valids/subflow-secret-output-parent.yaml
+++ b/core/src/test/resources/flows/valids/subflow-secret-output-parent.yaml
@@ -1,0 +1,13 @@
+id: subflow-secret-output-parent
+namespace: io.kestra.tests
+
+tasks:
+  - id: subflow
+    type: io.kestra.plugin.core.flow.Subflow
+    flowId: subflow-secret-output-child
+    namespace: io.kestra.tests
+    wait: true
+
+  - id: log
+    type: io.kestra.plugin.core.log.Log
+    message: "secret is {{ outputs.subflow.outputs.secret }}"

--- a/core/src/test/resources/flows/valids/working-directory-secret-output.yml
+++ b/core/src/test/resources/flows/valids/working-directory-secret-output.yml
@@ -1,0 +1,13 @@
+id: working-directory-secret-output
+namespace: io.kestra.tests
+
+tasks:
+  - id: workingDir
+    type: io.kestra.plugin.core.flow.WorkingDirectory
+    tasks:
+      - id: encrypted
+        type: io.kestra.core.tasks.test.Encrypted
+        format: "my-super-secret-value"
+      - id: log
+        type: io.kestra.plugin.core.log.Log
+        message: "secret is {{ outputs.encrypted.value }}"

--- a/jdbc/src/test/java/io/kestra/jdbc/runner/JdbcWorkerJobRunningStateStoreTest.java
+++ b/jdbc/src/test/java/io/kestra/jdbc/runner/JdbcWorkerJobRunningStateStoreTest.java
@@ -119,7 +119,7 @@ public abstract class JdbcWorkerJobRunningStateStoreTest {
                     .build()
             )
             .task(Log.builder().id("log").type(Log.class.getName()).message("test").build())
-            .data(new WorkerTaskData(Map.of(), List.of(), null))
+            .data(new WorkerTaskData(Map.of(), List.of(), List.of(), null))
             .build();
     }
 }


### PR DESCRIPTION
Register flow and trigger outputs inside the logger used secrets so they are masked as flow inputs are.

Fix WorkingDirectory so secrets are correctly forwarded when cloning.

Fixes https://github.com/kestra-io/kestra-ee/issues/8730