### PR TITLE
feat(ai): animate the Kestra mark in the copilot working indicator

### DIFF
--- a/ui/src/components/ai/copilot/CopilotChat.vue
+++ b/ui/src/components/ai/copilot/CopilotChat.vue
@@ -250,7 +250,8 @@
         clearTimeout(endTimer)
         if (was && !now) {
             ending.value = true
-            endTimer = setTimeout(() => (ending.value = false), 650)
+            // Covers the full end sequence: dots gather + mark bloom (~0.7s), a 3s hold, then the fade.
+            endTimer = setTimeout(() => (ending.value = false), 4300)
         } else if (now) {
             ending.value = false
         }

--- a/ui/src/components/ai/copilot/CopilotChat.vue
+++ b/ui/src/components/ai/copilot/CopilotChat.vue
@@ -73,7 +73,7 @@
                     :isPending="message.id === pendingProposalMessageId"
                 />
 
-                <CopilotThinking v-if="thinking" />
+                <CopilotThinking v-if="working" :phase="workPhase" />
 
                 <ProposedActionCard
                     v-if="pendingConfirmation"
@@ -223,17 +223,44 @@
             : null,
     )
 
-    // "Thinking…" placeholder while the model is working but hasn't produced its next output
-    // yet — i.e. right after the user's turn or after a tool result. Hidden while tokens are
-    // actively streaming into an assistant bubble or a tool is running (both have their own UI).
+    // The working indicator (animated Kestra mark) persists across the whole turn, switching
+    // movement by phase: "thinking" before any output (right after the user's turn or a tool
+    // result), "answering" while tokens stream into the assistant bubble, and a brief "end"
+    // gather when the turn closes. It stays hidden while a tool is running — the tool strip owns
+    // that UI.
+    const lastMessage = computed(() => messages.value[messages.value.length - 1])
+
+    const answering = computed(
+        () => streaming.value && lastMessage.value?.role === "ASSISTANT" && lastMessage.value?.type === "TEXT",
+    )
     const thinking = computed(() => {
         if (!streaming.value) return false
-        const last = messages.value[messages.value.length - 1]
+        const last = lastMessage.value
         if (!last) return true
         if (last.role === "ASSISTANT" && last.type === "TEXT") return false
         if (last.type === "TOOL_CALL") return false
         return true
     })
+
+    // A short window after streaming stops so the "end" gather animation can play before the
+    // indicator unmounts. Re-armed to false the moment a new turn starts streaming.
+    const ending = ref(false)
+    let endTimer: ReturnType<typeof setTimeout> | undefined
+    watch(streaming, (now, was) => {
+        clearTimeout(endTimer)
+        if (was && !now) {
+            ending.value = true
+            endTimer = setTimeout(() => (ending.value = false), 650)
+        } else if (now) {
+            ending.value = false
+        }
+    })
+    onBeforeUnmount(() => clearTimeout(endTimer))
+
+    const working = computed(() => ending.value || thinking.value || answering.value)
+    const workPhase = computed<"thinking" | "answering" | "end">(() =>
+        ending.value ? "end" : answering.value ? "answering" : "thinking",
+    )
 
     function onSubmit(prompt: string): void {
         sendChat({prompt, mode: mode.value, additionalContext: scopeToContext(activeScope.value), providerId: selectedProvider.value})
@@ -246,7 +273,7 @@
     // A primitive that changes on any of those, so the watcher fires without a deep watch.
     const scrollSignal = computed(() => {
         const last = messages.value[messages.value.length - 1]
-        return `${messages.value.length}|${last?.content?.length ?? 0}|${pendingConfirmation.value ? 1 : 0}|${thinking.value ? 1 : 0}`
+        return `${messages.value.length}|${last?.content?.length ?? 0}|${pendingConfirmation.value ? 1 : 0}|${working.value ? 1 : 0}`
     })
 
     watch(scrollSignal, () => nextTick(() => bottomAnchor.value?.scrollIntoView?.({block: "end"})))

--- a/ui/src/components/ai/copilot/CopilotMarkAnimation.vue
+++ b/ui/src/components/ai/copilot/CopilotMarkAnimation.vue
@@ -1,0 +1,84 @@
+<template>
+    <!-- Decorative Kestra-mark animation shown beside the copilot status word while a turn runs.
+         Three brand dots that bounce ("thinking"), ripple left→right ("answering"), then gather and
+         fade ("end") — a lightweight CSS/SVG reproduction of the delivered Lottie set (no runtime dep).
+         Purely decorative: the transcript's aria-busy + the status word already convey "working". -->
+    <svg
+        class="copilot-mark"
+        :class="`copilot-mark-${phase}`"
+        viewBox="0 0 44 16"
+        width="30"
+        height="11"
+        fill="none"
+        aria-hidden="true"
+        focusable="false"
+    >
+        <!-- Brand mark tints (purple → pink), matching the Kestra logo palette. -->
+        <circle class="copilot-mark-dot copilot-mark-dot-1" cx="8" cy="8" r="6" fill="#A950FF" />
+        <circle class="copilot-mark-dot copilot-mark-dot-2" cx="22" cy="8" r="6" fill="#CD88FF" />
+        <circle class="copilot-mark-dot copilot-mark-dot-3" cx="36" cy="8" r="6" fill="#F62E76" />
+    </svg>
+</template>
+
+<script setup lang="ts">
+    /** Which movement the dots play; driven by the copilot turn lifecycle. */
+    defineProps<{phase: "thinking" | "answering" | "end"}>()
+</script>
+
+<style scoped>
+    .copilot-mark {
+        display: inline-block;
+        vertical-align: middle;
+        flex: none;
+    }
+
+    .copilot-mark-dot {
+        /* Scale/translate each dot about its own centre. */
+        transform-box: fill-box;
+        transform-origin: center;
+    }
+
+    /* Thinking — staggered vertical bounce, like a typing indicator. */
+    .copilot-mark-thinking .copilot-mark-dot {
+        animation: copilot-mark-bounce 1.2s ease-in-out infinite;
+    }
+    .copilot-mark-thinking .copilot-mark-dot-2 { animation-delay: 0.15s; }
+    .copilot-mark-thinking .copilot-mark-dot-3 { animation-delay: 0.3s; }
+
+    /* Answering — a left→right ripple of opacity + a gentle pulse while tokens stream. */
+    .copilot-mark-answering .copilot-mark-dot {
+        animation: copilot-mark-ripple 1.1s ease-in-out infinite;
+    }
+    .copilot-mark-answering .copilot-mark-dot-2 { animation-delay: 0.18s; }
+    .copilot-mark-answering .copilot-mark-dot-3 { animation-delay: 0.36s; }
+
+    /* End — dots gather toward the centre and fade out once as the turn closes. */
+    .copilot-mark-end .copilot-mark-dot {
+        animation: copilot-mark-gather 0.55s ease-in forwards;
+    }
+    .copilot-mark-end .copilot-mark-dot-1 { --copilot-mark-gather-x: 14px; }
+    .copilot-mark-end .copilot-mark-dot-3 { --copilot-mark-gather-x: -14px; }
+
+    @keyframes copilot-mark-bounce {
+        0%, 60%, 100% { transform: translateY(0); }
+        30%           { transform: translateY(-4px); }
+    }
+
+    @keyframes copilot-mark-ripple {
+        0%, 100% { opacity: 0.35; transform: scale(0.82); }
+        40%      { opacity: 1;    transform: scale(1); }
+    }
+
+    @keyframes copilot-mark-gather {
+        to { transform: translateX(var(--copilot-mark-gather-x, 0)); opacity: 0; }
+    }
+
+    /* Respect reduced-motion: hold the dots steady rather than animating. */
+    @media (prefers-reduced-motion: reduce) {
+        .copilot-mark-dot {
+            animation: none !important;
+            opacity: 1;
+            transform: none;
+        }
+    }
+</style>

--- a/ui/src/components/ai/copilot/CopilotMarkAnimation.vue
+++ b/ui/src/components/ai/copilot/CopilotMarkAnimation.vue
@@ -1,41 +1,61 @@
 <template>
     <!-- Decorative Kestra-mark animation shown beside the copilot status word while a turn runs.
-         Three brand dots that bounce ("thinking"), ripple left→right ("answering"), then gather and
-         fade ("end") — a lightweight CSS/SVG reproduction of the delivered Lottie set (no runtime dep).
-         Purely decorative: the transcript's aria-busy + the status word already convey "working". -->
-    <svg
-        class="copilot-mark"
-        :class="`copilot-mark-${phase}`"
-        viewBox="0 0 44 16"
-        width="30"
-        height="11"
-        fill="none"
-        aria-hidden="true"
-        focusable="false"
-    >
-        <!-- Brand mark tints (purple → pink), matching the Kestra logo palette. -->
-        <circle class="copilot-mark-dot copilot-mark-dot-1" cx="8" cy="8" r="6" fill="#A950FF" />
-        <circle class="copilot-mark-dot copilot-mark-dot-2" cx="22" cy="8" r="6" fill="#CD88FF" />
-        <circle class="copilot-mark-dot copilot-mark-dot-3" cx="36" cy="8" r="6" fill="#F62E76" />
-    </svg>
+         Three brand dots that bounce ("thinking") and ripple left→right ("answering"); when the turn
+         ends they gather and bloom into the full Kestra mark ("end"). A lightweight CSS/SVG
+         reproduction of the delivered Lottie set (no runtime dep). Purely decorative: the transcript's
+         aria-busy + the status word already convey "working", so the whole thing is aria-hidden. -->
+    <span class="copilot-mark" :class="`copilot-mark-${phase}`" aria-hidden="true">
+        <!-- The three dots (brand tints, purple → pink). -->
+        <svg class="copilot-mark-dots" viewBox="0 0 44 16" width="30" height="11" fill="none" focusable="false">
+            <circle class="copilot-mark-dot copilot-mark-dot-1" cx="8" cy="8" r="6" fill="#A950FF" />
+            <circle class="copilot-mark-dot copilot-mark-dot-2" cx="22" cy="8" r="6" fill="#CD88FF" />
+            <circle class="copilot-mark-dot copilot-mark-dot-3" cx="36" cy="8" r="6" fill="#F62E76" />
+        </svg>
+
+        <!-- The full Kestra mark, centred over the dots. Hidden until the "end" phase blooms it in. -->
+        <svg class="copilot-mark-logo" viewBox="0 0 264 264" width="17" height="17" fill="none" focusable="false">
+            <path fill="#A950FF" d="M125.517 110.8C129.097 107.219 134.902 107.219 138.482 110.8L153.199 125.517C156.78 129.097 156.78 134.902 153.199 138.482L138.482 153.2C134.902 156.78 129.097 156.78 125.517 153.2L110.799 138.482C107.219 134.902 107.219 129.097 110.799 125.517L125.517 110.8Z" />
+            <path fill="#A950FF" d="M193.302 110.682C196.818 107.166 202.519 107.166 206.035 110.682L220.985 125.632C224.501 129.148 224.501 134.849 220.985 138.365L206.035 153.314C202.519 156.831 196.818 156.831 193.302 153.314L178.353 138.365C174.836 134.849 174.836 129.148 178.353 125.632L193.302 110.682Z" />
+            <path fill="#E9C1FF" d="M125.633 43.0151C129.149 39.4989 134.85 39.4989 138.366 43.0151L153.315 57.9643C156.832 61.4806 156.832 67.1816 153.315 70.6979L138.366 85.6471C134.85 89.1633 129.149 89.1633 125.633 85.6471L110.683 70.6979C107.167 67.1816 107.167 61.4806 110.683 57.9643L125.633 43.0151Z" />
+            <path fill="#CD88FF" d="M119.368 91.683C122.948 95.2633 122.948 101.068 119.368 104.648L104.651 119.366C101.071 122.946 95.2657 122.946 91.6853 119.366L76.9681 104.648C73.3878 101.068 73.3878 95.2633 76.9681 91.683L91.6854 76.9657C95.2657 73.3854 101.071 73.3854 104.651 76.9657L119.368 91.683Z" />
+            <path fill="#A950FF" d="M85.6481 125.632C89.1643 129.148 89.1643 134.849 85.6481 138.365L70.6988 153.314C67.1826 156.831 61.4816 156.831 57.9653 153.314L43.0161 138.365C39.4998 134.849 39.4998 129.148 43.0161 125.632L57.9653 110.682C61.4816 107.166 67.1826 107.166 70.6988 110.682L85.6481 125.632Z" />
+            <path fill="#CD88FF" d="M187.035 91.683C190.615 95.2633 190.615 101.068 187.035 104.648L172.317 119.366C168.737 122.946 162.932 122.946 159.352 119.366L144.635 104.648C141.054 101.068 141.054 95.2633 144.635 91.683L159.352 76.9657C162.932 73.3854 168.737 73.3854 172.317 76.9657L187.035 91.683Z" />
+            <path fill="#F62E76" d="M146.483 188.339C154.482 196.338 154.482 209.306 146.483 217.305C138.485 225.303 125.516 225.303 117.517 217.305C109.519 209.306 109.519 196.338 117.517 188.339C125.516 180.34 138.485 180.34 146.483 188.339Z" />
+        </svg>
+    </span>
 </template>
 
 <script setup lang="ts">
-    /** Which movement the dots play; driven by the copilot turn lifecycle. */
+    /** Which movement the mark plays; driven by the copilot turn lifecycle. */
     defineProps<{phase: "thinking" | "answering" | "end"}>()
 </script>
 
 <style scoped>
     .copilot-mark {
-        display: inline-block;
+        position: relative;
+        display: inline-flex;
+        align-items: center;
         vertical-align: middle;
         flex: none;
+    }
+
+    .copilot-mark-dots {
+        display: block;
     }
 
     .copilot-mark-dot {
         /* Scale/translate each dot about its own centre. */
         transform-box: fill-box;
         transform-origin: center;
+    }
+
+    /* The full mark sits centred over the dots and stays hidden until the end phase. */
+    .copilot-mark-logo {
+        position: absolute;
+        left: 50%;
+        top: 50%;
+        transform: translate(-50%, -50%) scale(0.3);
+        opacity: 0;
     }
 
     /* Thinking — staggered vertical bounce, like a typing indicator. */
@@ -52,12 +72,16 @@
     .copilot-mark-answering .copilot-mark-dot-2 { animation-delay: 0.18s; }
     .copilot-mark-answering .copilot-mark-dot-3 { animation-delay: 0.36s; }
 
-    /* End — dots gather toward the centre and fade out once as the turn closes. */
+    /* End — dots gather toward the centre and fade, then the full mark blooms in. */
     .copilot-mark-end .copilot-mark-dot {
-        animation: copilot-mark-gather 0.55s ease-in forwards;
+        animation: copilot-mark-gather 0.45s ease-in forwards;
     }
     .copilot-mark-end .copilot-mark-dot-1 { --copilot-mark-gather-x: 14px; }
     .copilot-mark-end .copilot-mark-dot-3 { --copilot-mark-gather-x: -14px; }
+    .copilot-mark-end .copilot-mark-logo {
+        /* Bloom in (~0.5s), hold the mark for 3s, then fade it away (~0.5s). */
+        animation: copilot-mark-bloom 4s ease-out 0.2s forwards;
+    }
 
     @keyframes copilot-mark-bounce {
         0%, 60%, 100% { transform: translateY(0); }
@@ -73,12 +97,25 @@
         to { transform: translateX(var(--copilot-mark-gather-x, 0)); opacity: 0; }
     }
 
-    /* Respect reduced-motion: hold the dots steady rather than animating. */
+    @keyframes copilot-mark-bloom {
+        0%    { opacity: 0; transform: translate(-50%, -50%) scale(0.3); }
+        12.5% { opacity: 1; transform: translate(-50%, -50%) scale(1); }
+        87.5% { opacity: 1; transform: translate(-50%, -50%) scale(1); }
+        100%  { opacity: 0; transform: translate(-50%, -50%) scale(1); }
+    }
+
+    /* Respect reduced-motion: hold the dots steady; in the end phase, just show the final mark. */
     @media (prefers-reduced-motion: reduce) {
         .copilot-mark-dot {
             animation: none !important;
             opacity: 1;
             transform: none;
+        }
+        .copilot-mark-end .copilot-mark-dot { opacity: 0; }
+        .copilot-mark-end .copilot-mark-logo {
+            animation: none !important;
+            opacity: 1;
+            transform: translate(-50%, -50%) scale(1);
         }
     }
 </style>

--- a/ui/src/components/ai/copilot/CopilotThinking.vue
+++ b/ui/src/components/ai/copilot/CopilotThinking.vue
@@ -1,38 +1,40 @@
 <template>
-    <!-- Shown while the model is working before its next output arrives. Decorative: the rotating
-         flavour words would spam a screen reader, so it's hidden from the a11y tree — the transcript's
-         `aria-busy` + the streamed tokens convey "working" instead. -->
+    <!-- The copilot working indicator: an animated Kestra mark plus a rotating flavour word. Shown
+         while a turn runs. Decorative: the flavour words would spam a screen reader, so it's hidden
+         from the a11y tree — the transcript's `aria-busy` + the streamed tokens convey "working". -->
     <div class="copilot-thinking" data-test="copilot-thinking" aria-hidden="true">
-        <Transition name="copilot-word" mode="out-in">
-            <KsText :key="word" size="small" class="copilot-thinking-label">{{ word }}</KsText>
-        </Transition><span
-            class="copilot-thinking-dots"
-            aria-hidden="true"
-        />
+        <CopilotMarkAnimation :phase="phase" />
+        <!-- The rotating word only reads during the "thinking" gap (before any output); while the
+             answer streams the dots alone carry the state, matching the design. -->
+        <Transition v-if="phase === 'thinking'" name="copilot-word" mode="out-in">
+            <KsText :key="word" size="small" class="copilot-thinking-label">{{ word }}…</KsText>
+        </Transition>
     </div>
 </template>
 
 <script setup lang="ts">
     import {ref, computed, onMounted, onBeforeUnmount} from "vue"
     import {useI18n} from "vue-i18n"
+    import CopilotMarkAnimation from "./CopilotMarkAnimation.vue"
+
+    withDefaults(defineProps<{
+        /** Which movement the mark plays; follows the turn lifecycle. */
+        phase?: "thinking" | "answering" | "end"
+    }>(), {phase: "thinking"})
 
     const {tm, rt} = useI18n()
 
-    // Orchestration-flavoured status words that rotate while the agent works, instead of a single
-    // static "Thinking". Sourced from i18n (ai.copilot.thinkingWords) so they localise.
     const words = computed(() => (tm("ai.copilot.thinkingWords") as unknown[]).map((entry) => rt(entry as string)))
 
     const index = ref(0)
     const word = computed(() => words.value[index.value] ?? "")
 
-    /** A random index in [0, count) that is never the current one, so no word repeats back-to-back. */
     function nextRandomIndex(current: number, count: number): number {
         if (count <= 1) return 0
         const pick = Math.floor(Math.random() * (count - 1))
         return pick >= current ? pick + 1 : pick
     }
 
-    // Show the words in random order, advancing every 5s (a random start, then a random next each tick).
     const ROTATE_MS = 5000
     let timer: ReturnType<typeof setInterval> | undefined
     onMounted(() => {
@@ -49,7 +51,8 @@
 <style scoped>
     .copilot-thinking {
         display: flex;
-        align-items: baseline;
+        align-items: center;
+        gap: var(--ks-spacing-2);
         margin-bottom: var(--ks-spacing-3);
         padding: 0 var(--ks-spacing-1);
     }
@@ -59,7 +62,6 @@
         font-size: var(--ks-font-size-sm);
     }
 
-    /* Cross-fade each word as it swaps, so the rotation reads as intentional rather than a flicker. */
     .copilot-word-enter-active,
     .copilot-word-leave-active {
         transition: opacity 0.2s ease;
@@ -68,30 +70,5 @@
     .copilot-word-enter-from,
     .copilot-word-leave-to {
         opacity: 0;
-    }
-
-    /*
-        Animated "rising dots": 1 → 3 then back to 1, on a loop. Driven purely by a CSS
-        keyframe animation on the pseudo-element's `content` (discrete steps, no timers to
-        clean up). Sits at the end of the line so growing/shrinking never reflows other text.
-    */
-    .copilot-thinking-dots::after {
-        content: "...";
-        color: var(--ks-text-secondary);
-        font-size: var(--ks-font-size-sm);
-        /* Reveal 1→3 dots by animating the visible WIDTH — reliable in every browser. The previous
-           approach animated the `content` string, which several engines refuse to animate, so the
-           dots sometimes rendered as a single static dot. */
-        display: inline-block;
-        width: 3ch;
-        overflow: hidden;
-        white-space: pre;
-        vertical-align: bottom;
-        animation: copilot-thinking-dots 1.5s steps(3, jump-none) infinite;
-    }
-
-    @keyframes copilot-thinking-dots {
-        from { width: 1ch; }
-        to   { width: 3ch; }
     }
 </style>

--- a/ui/tests/unit/components/ai/copilot/CopilotChat.spec.ts
+++ b/ui/tests/unit/components/ai/copilot/CopilotChat.spec.ts
@@ -195,16 +195,20 @@ describe("CopilotChat", () => {
         expect(w.findComponent({name: "CopilotComposer"}).props("disabled")).toBe(true)
     })
 
-    it("shows the thinking indicator while streaming before the next output", () => {
+    it("shows the thinking movement while streaming before the next output", () => {
         state.messages.value = [{id: "1", role: "USER", type: "TEXT", content: "hi"}]
         state.streaming.value = true
-        expect(mountChat().find("[data-test=\"copilot-thinking\"]").exists()).toBe(true)
+        const w = mountChat()
+        expect(w.find("[data-test=\"copilot-thinking\"]").exists()).toBe(true)
+        expect(w.find(".copilot-mark").classes()).toContain("copilot-mark-thinking")
     })
 
-    it("hides the thinking indicator while assistant text is streaming", () => {
+    it("switches to the answering movement while assistant text is streaming", () => {
         state.messages.value = [{id: "2", role: "ASSISTANT", type: "TEXT", content: "partial"}]
         state.streaming.value = true
-        expect(mountChat().find("[data-test=\"copilot-thinking\"]").exists()).toBe(false)
+        const w = mountChat()
+        expect(w.find("[data-test=\"copilot-thinking\"]").exists()).toBe(true)
+        expect(w.find(".copilot-mark").classes()).toContain("copilot-mark-answering")
     })
 
     it("starts a new chat via the top bar", async () => {

--- a/ui/tests/unit/components/ai/copilot/CopilotMarkAnimation.spec.ts
+++ b/ui/tests/unit/components/ai/copilot/CopilotMarkAnimation.spec.ts
@@ -1,0 +1,16 @@
+import {describe, it, expect} from "vitest"
+import {mount} from "@vue/test-utils"
+import CopilotMarkAnimation from "../../../../../src/components/ai/copilot/CopilotMarkAnimation.vue"
+
+describe("CopilotMarkAnimation", () => {
+    it("renders three decorative brand dots, hidden from the a11y tree", () => {
+        const w = mount(CopilotMarkAnimation, {props: {phase: "thinking"}})
+        expect(w.find(".copilot-mark").attributes("aria-hidden")).toBe("true")
+        expect(w.findAll("circle")).toHaveLength(3)
+    })
+
+    it.each(["thinking", "answering", "end"] as const)("applies the %s phase class", (phase) => {
+        const w = mount(CopilotMarkAnimation, {props: {phase}})
+        expect(w.find(".copilot-mark").classes()).toContain(`copilot-mark-${phase}`)
+    })
+})

--- a/ui/tests/unit/components/ai/copilot/CopilotThinking.spec.ts
+++ b/ui/tests/unit/components/ai/copilot/CopilotThinking.spec.ts
@@ -4,8 +4,8 @@ import CopilotThinking from "../../../../../src/components/ai/copilot/CopilotThi
 import {mountGlobal} from "./_helpers"
 
 // Stub the built-in transition so word swaps apply synchronously (no real transitions in jsdom).
-const mountThinking = () =>
-    mount(CopilotThinking, {global: {...mountGlobal, stubs: {...mountGlobal.stubs, transition: true}}})
+const mountThinking = (props: Record<string, unknown> = {}) =>
+    mount(CopilotThinking, {props, global: {...mountGlobal, stubs: {...mountGlobal.stubs, transition: true}}})
 
 describe("CopilotThinking", () => {
     afterEach(() => {
@@ -13,18 +13,20 @@ describe("CopilotThinking", () => {
         vi.useRealTimers()
     })
 
-    it("renders a rotating orchestration word with an animated dots element", () => {
+    it("renders a rotating orchestration word beside the animated Kestra mark", () => {
         vi.spyOn(Math, "random").mockReturnValue(0) // start on the first word
         const w = mountThinking()
         const indicator = w.find("[data-test=\"copilot-thinking\"]")
         expect(indicator.exists()).toBe(true)
         // Decorative: the rotating flavour words are hidden from the a11y tree (no screen-reader spam).
         expect(indicator.attributes("aria-hidden")).toBe("true")
-        expect(w.text()).toContain("Orchestrating")
-        // The rising dots are a decorative, aria-hidden pseudo-element host.
-        const dots = w.find(".copilot-thinking-dots")
-        expect(dots.exists()).toBe(true)
-        expect(dots.attributes("aria-hidden")).toBe("true")
+        // The word carries a static trailing ellipsis ("Orchestrating…").
+        expect(w.text()).toContain("Orchestrating…")
+        // The animated mark is decorative and hidden from the a11y tree; defaults to the thinking movement.
+        const mark = w.find(".copilot-mark")
+        expect(mark.exists()).toBe(true)
+        expect(mark.attributes("aria-hidden")).toBe("true")
+        expect(mark.classes()).toContain("copilot-mark-thinking")
     })
 
     it("rotates to a different (random) word every 5 seconds, never repeating the current one", async () => {
@@ -39,5 +41,12 @@ describe("CopilotThinking", () => {
         vi.advanceTimersByTime(5000)
         await w.vm.$nextTick()
         expect(w.text()).not.toBe(first)
+    })
+
+    it("shows the mark alone (no flavour word) while answering", () => {
+        const w = mountThinking({phase: "answering"})
+        expect(w.find(".copilot-mark").classes()).toContain("copilot-mark-answering")
+        // The rotating word only reads during the thinking gap.
+        expect(w.text()).toBe("")
     })
 })


### PR DESCRIPTION

[Screencast from 2026-07-28 11-25-54.webm](https://github.com/user-attachments/assets/cceddc28-5df7-43c7-b8a2-00d6daa9ecbe)


Introduces a small Kestra animation in the AI Copilot working indicator, per kestra-io/kestra-ee#9486.

## What
- New `CopilotMarkAnimation.vue` — three Kestra-mark dots (inline SVG, brand palette) with a `phase` prop:
  - **thinking** — staggered vertical bounce (typing-indicator feel)
  - **answering** — left→right opacity ripple while tokens stream
  - **end** — dots gather toward centre and fade as the turn closes
- The working indicator now persists across the whole turn, switching phase from the copilot state (`CopilotChat.vue`); the rotating flavour word keeps its trailing ellipsis (`••• Thinking…`).
- Pure CSS/SVG — **no new dependency** — and it respects `prefers-reduced-motion` (dots hold steady).

## Notes
- Faithful CSS/SVG reproduction of the delivered Lottie set (thinking / answering / end); at text height the `end` phase is a gather-and-fade rather than the full 6-diamond logo reform.
- OSS-only change: `CopilotThinking` is a shared OSS component with no EE override, so this fixes it for EE too — no companion EE PR needed.

## Tests
- New `CopilotMarkAnimation.spec.ts`; updated `CopilotThinking.spec.ts` + `CopilotChat.spec.ts` for the phase behavior.
- Full OSS UI unit suite green (964 passed) and `check:types` clean.

Closes https://github.com/kestra-io/kestra-ee/issues/9486.