### PR TITLE
fix(core): center the icon in circle and square buttons

### DIFF
--- a/ui/packages/design-system/src/components/Basic/KsButton/KsButton.vue
+++ b/ui/packages/design-system/src/components/Basic/KsButton/KsButton.vue
@@ -136,6 +136,16 @@
             padding-right: 0;
         }
 
+        /* Icon-only buttons centre the glyph. vue-material-design-icons nudges its SVG down by
+           0.125em (baseline alignment meant for inline-with-text use), which reads as off-centre
+           in a round/square button — neutralise it so the icon sits dead centre. */
+        &.is-circle,
+        &.is-square {
+            .material-design-icon > .material-design-icon__svg {
+                bottom: 0;
+            }
+        }
+
         &.is-plain:not(.is-text) {
             --kel-button-border-color: var(--ks-btn-secondary-border-default);
             --kel-button-bg-color: var(--ks-btn-secondary-bg-default);


### PR DESCRIPTION

<img width="466" height="238" alt="image" src="https://github.com/user-attachments/assets/2f9168ae-3973-4b19-b50e-982772fc3c71" />

The arrow in the AI Copilot round **send button** sits slightly below center (kestra-io/kestra-ee#9538).

## Cause
`vue-material-design-icons` renders every icon SVG with `position: absolute; bottom: -0.125em` — a baseline nudge for aligning icons inline with text, imported globally via the design system's `styles.css`. In an **icon-only** round/square button the glyph should be centered, not baseline-aligned, so that nudge pushes it down.

## Fix
Neutralize the nudge for icon-only shapes in `KsButton`:

```scss
&.is-circle, &.is-square {
    .material-design-icon > .material-design-icon__svg { bottom: 0; }
}
```

- Fixed **in the design system** (not patched at the call site) → centers the icon in the Copilot send button and every other circle/square icon-only button.
- **Icon + text** buttons are untouched — they keep the baseline alignment (scoped to `.is-circle` / `.is-square` only).
- **OSS-only**: the design system lives in OSS and EE consumes it, so no companion EE PR.

## Verification
Before/after (with center crosshairs): the arrow moves from low → dead-center. `npm run check:types` clean.

Closes https://github.com/kestra-io/kestra-ee/issues/9538.