### PR TITLE
test(tests): stabilize retrySubflow and head404 on release CI

### DIFF
--- a/core/src/test/java/io/kestra/plugin/core/flow/RetryCaseTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/flow/RetryCaseTest.java
@@ -138,7 +138,8 @@ public class RetryCaseTest {
         assertThat(execution.getTaskRunList().get(1).attemptNumber()).isEqualTo(3);
     }
 
-    public void retrySubflow(Execution execution) {
+    public void retrySubflow(String tenant) throws TimeoutException, QueueException {
+        Execution execution = runnerUtils.runOne(tenant, "io.kestra.tests", "retry-subflow");
         assertThat(execution.getState().getCurrent()).isEqualTo(State.Type.FAILED);
         assertThat(execution.getTaskRunList().get(0).getAttempts().size()).isEqualTo(3);
     }

--- a/core/src/test/java/io/kestra/plugin/core/http/RequestTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/http/RequestTest.java
@@ -119,23 +119,28 @@ class RequestTest {
 
     @Test
     void head404() throws Exception {
-        final String url = "https://bdnb-data.s3.fr-par.scw.cloud/bnb_export_metropole_sql_dump.tar.gz";
+        try (
+            ApplicationContext applicationContext = ApplicationContext.run();
+            EmbeddedServer server = applicationContext.getBean(EmbeddedServer.class).start();
+        ) {
+            String url = server.getURL().toString() + "/not-found";
 
-        Request task = Request.builder()
-            .id(RequestTest.class.getSimpleName())
-            .type(RequestTest.class.getName())
-            .uri(Property.ofValue(url))
-            .method(Property.ofValue("HEAD"))
-            .build();
+            Request task = Request.builder()
+                .id(RequestTest.class.getSimpleName())
+                .type(RequestTest.class.getName())
+                .uri(Property.ofValue(url))
+                .method(Property.ofValue("HEAD"))
+                .build();
 
-        RunContext runContext = TestsUtils.mockRunContext(this.runContextFactory, task, ImmutableMap.of());
+            RunContext runContext = TestsUtils.mockRunContext(this.runContextFactory, task, ImmutableMap.of());
 
-        HttpClientResponseException exception = assertThrows(
-            HttpClientResponseException.class,
-            () -> task.run(runContext)
-        );
+            HttpClientResponseException exception = assertThrows(
+                HttpClientResponseException.class,
+                () -> task.run(runContext)
+            );
 
-        assertThat(exception.getResponse().getStatus().getCode()).isEqualTo(404);
+            assertThat(exception.getResponse().getStatus().getCode()).isEqualTo(404);
+        }
     }
 
     @Test

--- a/jdbc/src/test/java/io/kestra/jdbc/runner/JdbcRunnerRetryTest.java
+++ b/jdbc/src/test/java/io/kestra/jdbc/runner/JdbcRunnerRetryTest.java
@@ -112,9 +112,9 @@ public abstract class JdbcRunnerRetryTest {
     }
 
     @Test
-    @ExecuteFlow("flows/valids/retry-subflow.yaml")
-    void retrySubflow(Execution execution) {
-        retryCaseTest.retrySubflow(execution);
+    @LoadFlows(value = { "flows/valids/retry-subflow.yaml", "flows/valids/failed-first.yaml" }, tenantId = "retrysubflowtenant")
+    void retrySubflow() throws TimeoutException, QueueException {
+        retryCaseTest.retrySubflow("retrysubflowtenant");
     }
 
     @Test


### PR DESCRIPTION
## What

Fixes two consistently-failing Backend tests on `releases/v1.3.x` (surfaced during the v1.3.30 pre-release).

### `*RunnerRetryTest.retrySubflow` (H2/Mysql/Postgres)
`retry-subflow.yaml` launches subflow `failed-first`, but the test only loaded `retry-subflow.yaml` via `@ExecuteFlow`. The subflow was never in the repository, so the executor failed with `Unable to find flow 'failed-first'` and the execution ended after **1 attempt** instead of retrying to **3** (`expected: 3 but was: 1`).

Fix: also `@LoadFlows({ "flows/valids/failed-first.yaml" })` so the subflow runs and the flow-level retry accumulates 3 attempts. Change is in the shared `JdbcRunnerRetryTest`, so it covers all three DB variants.

### `RequestTest.head404`
The test hit a **real external URL** (`bdnb-data.s3.fr-par.scw.cloud`) expecting 404. Scaleway's S3 now returns **403** for that object (`expected: 404 but was: 403`) — behaviour we don't control.

Fix: use the local embedded server and request an undefined route (`/not-found` → 404), mirroring `head()` and the develop fix (#15646). No more external dependency.

## Verification
Reproduced both failures locally, then confirmed green:
- `:jdbc-h2:test --tests "...H2RunnerRetryTest.retrySubflow"`
- `:core:test --tests "...RequestTest.head404"`

## Note
`develop`'s `retrySubflow` uses the same single-`@ExecuteFlow` annotation with no `failed-first` load, so it may carry the same latent bug — worth a separate check.