### PR TITLE
test(tests): stabilize retrySubflow/head404 and disable broken ForEachItem on release CI

### DIFF
--- a/core/src/test/java/io/kestra/core/runners/TaskWithAllowWarningTest.java
+++ b/core/src/test/java/io/kestra/core/runners/TaskWithAllowWarningTest.java
@@ -12,6 +12,7 @@ import java.util.concurrent.TimeoutException;
 import java.util.stream.IntStream;
 
 import org.apache.commons.lang3.StringUtils;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import io.kestra.core.junit.annotations.ExecuteFlow;
@@ -58,6 +59,7 @@ public class TaskWithAllowWarningTest {
     }
 
     @Test
+    @Disabled("This test does not test failing in subflow foreach as the subflow is not called, needs to be rework before reactivation")
     @LoadFlows({ "flows/valids/task-allow-warning-executable-foreachitem.yml" })
     void executableTask_ForEachItem() throws TimeoutException, QueueException, URISyntaxException, IOException {
         URI file = storageUpload();

--- a/core/src/test/java/io/kestra/plugin/core/flow/RetryCaseTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/flow/RetryCaseTest.java
@@ -211,7 +211,8 @@ public class RetryCaseTest {
         assertThat(execution.getTaskRunList().get(1).attemptNumber()).isEqualTo(3);
     }
 
-    public void retrySubflow(Execution execution) {
+    public void retrySubflow(String tenant) throws TimeoutException, QueueException {
+        Execution execution = runnerUtils.runOne(tenant, "io.kestra.tests", "retry-subflow");
         assertThat(execution.getState().getCurrent()).isEqualTo(State.Type.FAILED);
         assertThat(execution.getTaskRunList().get(0).getAttempts().size()).isEqualTo(3);
     }

--- a/core/src/test/java/io/kestra/plugin/core/http/RequestTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/http/RequestTest.java
@@ -108,23 +108,28 @@ class RequestTest {
 
     @Test
     void head404() throws Exception {
-        final String url = "https://bdnb-data.s3.fr-par.scw.cloud/bnb_export_metropole_sql_dump.tar.gz";
+        try (
+            ApplicationContext applicationContext = ApplicationContext.run();
+            EmbeddedServer server = applicationContext.getBean(EmbeddedServer.class).start();
+        ) {
+            String url = server.getURL().toString() + "/not-found";
 
-        Request task = Request.builder()
-            .id(RequestTest.class.getSimpleName())
-            .type(RequestTest.class.getName())
-            .uri(Property.ofValue(url))
-            .method(Property.ofValue("HEAD"))
-            .build();
+            Request task = Request.builder()
+                .id(RequestTest.class.getSimpleName())
+                .type(RequestTest.class.getName())
+                .uri(Property.ofValue(url))
+                .method(Property.ofValue("HEAD"))
+                .build();
 
-        RunContext runContext = TestsUtils.mockRunContext(this.runContextFactory, task, ImmutableMap.of());
+            RunContext runContext = TestsUtils.mockRunContext(this.runContextFactory, task, ImmutableMap.of());
 
-        HttpClientResponseException exception = assertThrows(
-            HttpClientResponseException.class,
-            () -> task.run(runContext)
-        );
+            HttpClientResponseException exception = assertThrows(
+                HttpClientResponseException.class,
+                () -> task.run(runContext)
+            );
 
-        assertThat(exception.getResponse().getStatus().getCode()).isEqualTo(404);
+            assertThat(exception.getResponse().getStatus().getCode()).isEqualTo(404);
+        }
     }
 
     @Test

--- a/jdbc/src/test/java/io/kestra/jdbc/runner/JdbcRunnerRetryTest.java
+++ b/jdbc/src/test/java/io/kestra/jdbc/runner/JdbcRunnerRetryTest.java
@@ -113,9 +113,9 @@ public abstract class JdbcRunnerRetryTest {
     }
 
     @Test
-    @ExecuteFlow("flows/valids/retry-subflow.yaml")
-    void retrySubflow(Execution execution) {
-        retryCaseTest.retrySubflow(execution);
+    @LoadFlows(value = { "flows/valids/retry-subflow.yaml", "flows/valids/failed-first.yaml" }, tenantId = "retrysubflowtenant")
+    void retrySubflow() throws TimeoutException, QueueException {
+        retryCaseTest.retrySubflow("retrysubflowtenant");
     }
 
     @Test


### PR DESCRIPTION
## What

Fixes the failing Backend tests on `releases/v1.0.x` (surfaced during the v1.0.52 pre-release). Companion to #17675 (same two fixes on `releases/v1.3.x`).

### `*RunnerRetryTest.retrySubflow` (H2/Mysql/Postgres)
`retry-subflow.yaml` launches subflow `failed-first`, but the test only loaded `retry-subflow.yaml` via `@ExecuteFlow`. The subflow was never in the repository, so the executor failed with `Unable to find flow 'failed-first'` and the execution ended after **1 attempt** instead of retrying to **3** (`expected: 3 but was: 1`).

Fix: also `@LoadFlows({ "flows/valids/failed-first.yaml" })`. Change is in the shared `JdbcRunnerRetryTest`, so it covers all three DB variants.

### `RequestTest.head404`
The test hit a **real external URL** (`bdnb-data.s3.fr-par.scw.cloud`) expecting 404. Scaleway's S3 now returns **403** for that object (`expected: 404 but was: 403`).

Fix: use the local embedded server and request an undefined route (`/not-found` → 404), mirroring the other Request tests and the develop fix (#15646).

### `TaskWithAllowWarningTest.executableTask_ForEachItem` (the reported flaky)
The `ForEachItem` spawns subflow `for-each-item-subflow-failed`, but the test only loads its own flow — so it fails, or flakes when a sibling test happens to leave that subflow loaded (test ordering). `releases/v1.3.x` and `develop` already `@Disabled` this test with *"needs to be rework before reactivation"*; this backports that decision.

## Verification
Reproduced the failures locally, then confirmed green on this branch:
- `:jdbc-h2:test --tests "...H2RunnerRetryTest.retrySubflow"` → 1 passed
- `:core:test --tests "...RequestTest.head404"` → 1 passed