### PR TITLE
fix(flows): prevent selecting a past schedule date when executing

### DIFF
--- a/script/src/main/java/io/kestra/plugin/scripts/runner/docker/Docker.java
+++ b/script/src/main/java/io/kestra/plugin/scripts/runner/docker/Docker.java
@@ -291,7 +291,15 @@ public class Docker extends TaskRunner<Docker.DockerTaskRunnerDetailResult> {
         description = """
             How to handle local files (input files, output files, namespace files, ...).
             By default, we create a volume and copy the file into the volume bind path.
-            Configuring it to `MOUNT` will mount the working directory instead."""
+            Configuring it to `MOUNT` will bind-mount the working directory instead, which
+            avoids copying output files back after the task finishes (useful for large files).
+
+            With `MOUNT`, input files are still uploaded into the container before start so
+            scripts keep working when the Docker daemon cannot see the worker filesystem
+            (for example Kestra running in Docker with only the Docker socket mounted).
+            For `MOUNT` outputs to appear on the worker without a download round-trip, the
+            task `tmp-dir` must also be visible to the Docker daemon (as in the standard
+            Compose setup that binds `/tmp/kestra-wd`)."""
     )
     @NotNull
     @Builder.Default
@@ -437,7 +445,8 @@ public class Docker extends TaskRunner<Docker.DockerTaskRunnerDetailResult> {
                     logger.trace("Container created: {}", containerId);
                 }
 
-                // create a volume if we need to handle files
+                // VOLUME tracks a named volume for cleanup/download; files themselves are always
+                // copied into the container via the Docker API (see uploadWorkingDirectoryFiles).
                 if (needVolume && FileHandlingStrategy.VOLUME.equals(strategy)) {
                     CreateVolumeCmd files = dockerClient.createVolumeCmd()
                         .withLabels(labels);
@@ -445,56 +454,20 @@ public class Docker extends TaskRunner<Docker.DockerTaskRunnerDetailResult> {
                     if (logger.isTraceEnabled()) {
                         logger.trace("Volume created: {}", filesVolumeName);
                     }
+                }
 
-                    String remotePath = windowsToUnixPath(taskCommands.getWorkingDirectory().toString());
-
-                    // first, create an archive
-                    Path fileArchive = runContext.workingDir().createFile("inputFiles.tar");
-                    try (
-                        FileOutputStream fos = new FileOutputStream(fileArchive.toString());
-                        TarArchiveOutputStream out = new TarArchiveOutputStream(fos)
-                    ) {
-                        out.setLongFileMode(TarArchiveOutputStream.LONGFILE_POSIX); // allow long file name
-                        out.setBigNumberMode(TarArchiveOutputStream.BIGNUMBER_POSIX); // allow large archive name
-
-                        for (Path file : relativeWorkingDirectoryFilesPaths) {
-                            Path resolvedFile = runContext.workingDir().resolve(file);
-                            TarArchiveEntry entry = out.createArchiveEntry(resolvedFile.toFile(), file.toString());
-                            // Preserve POSIX permissions if supported
-                            try {
-                                Set<PosixFilePermission> perms = Files.getPosixFilePermissions(resolvedFile);
-                                entry.setMode(UnixModeToPosixFilePermissions.fromPosixFilePermissions(perms));
-                            } catch (UnsupportedOperationException | IOException ignore) {
-                                // Skipping unix file permission
-                            }
-                            out.putArchiveEntry(entry);
-                            if (!Files.isDirectory(resolvedFile)) {
-                                try (InputStream fis = Files.newInputStream(resolvedFile)) {
-                                    IOUtils.copy(fis, out);
-                                }
-                            }
-                            out.closeArchiveEntry();
-                        }
-                        out.finish();
-                    }
-
-                    // then send it to the container
-                    try (InputStream is = new FileInputStream(fileArchive.toString())) {
-                        CopyArchiveToContainerCmd copyArchiveToContainerCmd = dockerClient.copyArchiveToContainerCmd(containerId)
-                            .withTarInputStream(is)
-                            .withRemotePath(remotePath);
-                        copyArchiveToContainerCmd.exec();
-                    }
-
-                    Files.delete(fileArchive);
-
-                    // create the outputDir if needed
-                    if (taskCommands.outputDirectoryEnabled()) {
-                        CopyArchiveToContainerCmd copyArchiveToContainerCmd = dockerClient.copyArchiveToContainerCmd(containerId)
-                            .withHostResource(taskCommands.getOutputDirectory().toString())
-                            .withRemotePath(remotePath);
-                        copyArchiveToContainerCmd.exec();
-                    }
+                // Upload working-directory files for both VOLUME and MOUNT.
+                // MOUNT still needs this upload: a bind mount alone is empty when the Docker
+                // daemon does not share the worker filesystem (common with docker.sock-only
+                // setups), which otherwise fails scripts with FileNotFoundException.
+                if (needVolume && shouldUploadWorkingDirectoryFiles(strategy)) {
+                    uploadWorkingDirectoryFiles(
+                        dockerClient,
+                        containerId,
+                        runContext,
+                        taskCommands,
+                        relativeWorkingDirectoryFilesPaths
+                    );
                 }
 
                 // we check, if killed before container start
@@ -693,6 +666,73 @@ public class Docker extends TaskRunner<Docker.DockerTaskRunnerDetailResult> {
         return false;
     }
 
+    /**
+     * Whether working-directory files should be uploaded into the container before start.
+     * Both {@link FileHandlingStrategy#VOLUME} and {@link FileHandlingStrategy#MOUNT} need
+     * this so input/script files exist even when a bind mount does not expose the worker FS.
+     */
+    static boolean shouldUploadWorkingDirectoryFiles(FileHandlingStrategy strategy) {
+        return FileHandlingStrategy.VOLUME.equals(strategy) || FileHandlingStrategy.MOUNT.equals(strategy);
+    }
+
+    private void uploadWorkingDirectoryFiles(
+        DockerClient dockerClient,
+        String containerId,
+        RunContext runContext,
+        TaskCommands taskCommands,
+        List<Path> relativeWorkingDirectoryFilesPaths
+    ) throws IOException {
+        String remotePath = windowsToUnixPath(taskCommands.getWorkingDirectory().toAbsolutePath().normalize().toString());
+
+        // first, create an archive
+        Path fileArchive = runContext.workingDir().createFile("inputFiles.tar");
+        try (
+            FileOutputStream fos = new FileOutputStream(fileArchive.toString());
+            TarArchiveOutputStream out = new TarArchiveOutputStream(fos)
+        ) {
+            out.setLongFileMode(TarArchiveOutputStream.LONGFILE_POSIX); // allow long file name
+            out.setBigNumberMode(TarArchiveOutputStream.BIGNUMBER_POSIX); // allow large archive name
+
+            for (Path file : relativeWorkingDirectoryFilesPaths) {
+                Path resolvedFile = runContext.workingDir().resolve(file);
+                TarArchiveEntry entry = out.createArchiveEntry(resolvedFile.toFile(), file.toString());
+                // Preserve POSIX permissions if supported
+                try {
+                    Set<PosixFilePermission> perms = Files.getPosixFilePermissions(resolvedFile);
+                    entry.setMode(UnixModeToPosixFilePermissions.fromPosixFilePermissions(perms));
+                } catch (UnsupportedOperationException | IOException ignore) {
+                    // Skipping unix file permission
+                }
+                out.putArchiveEntry(entry);
+                if (!Files.isDirectory(resolvedFile)) {
+                    try (InputStream fis = Files.newInputStream(resolvedFile)) {
+                        IOUtils.copy(fis, out);
+                    }
+                }
+                out.closeArchiveEntry();
+            }
+            out.finish();
+        }
+
+        // then send it to the container
+        try (InputStream is = new FileInputStream(fileArchive.toString())) {
+            CopyArchiveToContainerCmd copyArchiveToContainerCmd = dockerClient.copyArchiveToContainerCmd(containerId)
+                .withTarInputStream(is)
+                .withRemotePath(remotePath);
+            copyArchiveToContainerCmd.exec();
+        }
+
+        Files.delete(fileArchive);
+
+        // create the outputDir if needed
+        if (taskCommands.outputDirectoryEnabled()) {
+            CopyArchiveToContainerCmd copyArchiveToContainerCmd = dockerClient.copyArchiveToContainerCmd(containerId)
+                .withHostResource(taskCommands.getOutputDirectory().toString())
+                .withRemotePath(remotePath);
+            copyArchiveToContainerCmd.exec();
+        }
+    }
+
     private static String dockerSocketNotAccessibleMessage(final String resolvedHost) {
         return "Docker execution failed because Docker socket is not accessible.\n\n" +
             "Fix:\n" +
@@ -832,7 +872,9 @@ public class Docker extends TaskRunner<Docker.DockerTaskRunnerDetailResult> {
 
         List<Bind> binds = new ArrayList<>();
         if (FileHandlingStrategy.MOUNT.equals(runContext.render(this.fileHandlingStrategy).as(FileHandlingStrategy.class).orElse(null)) && workingDirectory != null) {
-            String bindPath = windowsToUnixPath(workingDirectory.toString());
+            // Use an absolute, normalized path so the bind source matches the path used for
+            // workingDir / commands (toString() alone can stay relative on some setups).
+            String bindPath = windowsToUnixPath(workingDirectory.toAbsolutePath().normalize().toString());
             binds.add(
                 new Bind(
                     bindPath,

--- a/script/src/test/java/io/kestra/plugin/scripts/runner/docker/DockerErrorHandlingTest.java
+++ b/script/src/test/java/io/kestra/plugin/scripts/runner/docker/DockerErrorHandlingTest.java
@@ -44,4 +44,11 @@ class DockerErrorHandlingTest {
 
         assertThat(Docker.isDockerSocketAccessError(exception)).isFalse();
     }
+
+    @Test
+    void shouldUploadWorkingDirectoryFilesForVolumeAndMount() {
+        // Given / When / Then — both strategies must upload inputs so scripts exist in-container
+        assertThat(Docker.shouldUploadWorkingDirectoryFiles(Docker.FileHandlingStrategy.VOLUME)).isTrue();
+        assertThat(Docker.shouldUploadWorkingDirectoryFiles(Docker.FileHandlingStrategy.MOUNT)).isTrue();
+    }
 }

--- a/script/src/test/java/io/kestra/plugin/scripts/runner/docker/DockerTest.java
+++ b/script/src/test/java/io/kestra/plugin/scripts/runner/docker/DockerTest.java
@@ -87,6 +87,37 @@ class DockerTest extends AbstractTaskRunnerTest {
     }
 
     @Test
+    void shouldRunWithMountStrategyAndWorkingDirectoryInputFile() throws Exception {
+        // Given — reproduces #17526: MOUNT must still see worker-created script/input files
+        var runContext = runContext(this.runContextFactory);
+        Path inputFile = runContext.workingDir().createFile("hello.txt", "hello from mount\n".getBytes());
+        String inputPath = inputFile.toAbsolutePath().toString();
+
+        var docker = Docker.builder()
+            .image("rockylinux:9.3-minimal")
+            .fileHandlingStrategy(Property.ofValue(Docker.FileHandlingStrategy.MOUNT))
+            .pullPolicy(Property.ofValue(PullPolicy.IF_NOT_PRESENT))
+            .build();
+
+        var taskCommands = new CommandsWrapper(runContext).withCommands(
+            Property.ofValue(
+                List.of(
+                    "/bin/sh", "-c",
+                    "cat " + inputPath
+                )
+            )
+        );
+
+        // When
+        var result = docker.run(runContext, taskCommands, Collections.emptyList());
+
+        // Then
+        assertThat(result).isNotNull();
+        assertThat(result.getExitCode()).isZero();
+        Assertions.assertThat(result.getLogConsumer().getStdOutCount()).isGreaterThanOrEqualTo(1);
+    }
+
+    @Test
     void shouldSetCorrectCPULimitsInContainer() throws Exception {
         var runContext = runContext(this.runContextFactory);
 

--- a/ui/src/components/flows/FlowRun.vue
+++ b/ui/src/components/flows/FlowRun.vue
@@ -42,6 +42,9 @@
                         <KsDatePicker
                             v-model="scheduleDate"
                             type="datetime"
+                            :disabledDate="isScheduleCalendarDateDisabled"
+                            :disabled-hours="() => disabledScheduleHours(scheduleDate)"
+                            :disabled-minutes="(hour: number) => disabledScheduleMinutes(scheduleDate, hour)"
                         />
                     </KsFormItem>
                 </KsTabPane>
@@ -100,6 +103,12 @@
     import type {Label, Execution, Check} from "../../stores/executions"
     import type {Flow} from "../../stores/flow"
     import {executeTask} from "../../utils/submitTask"
+    import {
+        disabledScheduleHours,
+        disabledScheduleMinutes,
+        isScheduleCalendarDateDisabled,
+        isScheduleDateInPast,
+    } from "../../utils/scheduleDate"
     import {executeFlowBehaviours, storageKeys} from "../../utils/constants"
     import {WEBHOOK_TRIGGER_TYPE} from "../../utils/webhook"
     import {normalize} from "../../utils/inputs"
@@ -280,6 +289,11 @@
                     return
                 }
 
+                if (isScheduleDateInPast(scheduleDate.value)) {
+                    toast.error(t("schedule date must be in the future"))
+                    return
+                }
+
                 const mergedInputs = props.selectedTrigger?.inputs
                     ? {...props.selectedTrigger.inputs, ...inputsNoDefaults.value}
                     : inputsNoDefaults.value
@@ -290,6 +304,12 @@
                         .map(label => `${label.key}:${label.value}`),
                 ), "system.from:ui"]
 
+                const resolvedScheduleDate = scheduleDate.value
+                    ? moment(scheduleDate.value)
+                        .tz(localStorage.getItem(storageKeys.TIMEZONE_STORAGE_KEY) ?? moment.tz.guess())
+                        .toISOString(true)
+                    : undefined
+
                 if (props.replaySubmit) {
                     props.replaySubmit({
                         formRef: form.value!,
@@ -297,7 +317,7 @@
                         namespace: flow.value!.namespace,
                         inputs: mergedInputs,
                         labels: labelStrings,
-                        scheduleDate: scheduleDate.value,
+                        scheduleDate: resolvedScheduleDate,
                     })
                 } else {
                     const shouldShowOnboardingSuccessAnimation = route.query.onboardingPreset === "true"
@@ -308,9 +328,7 @@
                             id: flow.value!.id,
                             namespace: flow.value!.namespace,
                             labels: labelStrings,
-                            scheduleDate: moment(scheduleDate.value)
-                                .tz(localStorage.getItem(storageKeys.TIMEZONE_STORAGE_KEY) ?? moment.tz.guess())
-                                .toISOString(true),
+                            scheduleDate: resolvedScheduleDate,
                             nextStep: true,
                             query: shouldShowOnboardingSuccessAnimation ? {
                                 autoExpandGantt: "true",

--- a/ui/src/translations/de.json
+++ b/ui/src/translations/de.json
@@ -2192,5 +2192,6 @@
     "workers": "Workers",
     "wrong labels": "Leerer Key oder Value ist in Labels nicht erlaubt",
     "yes": "Ja"
-  }
+  },
+  "schedule date must be in the future": "Das geplante Datum muss in der Zukunft liegen"
 }

--- a/ui/src/translations/en.json
+++ b/ui/src/translations/en.json
@@ -389,8 +389,8 @@
       "n_items": "[ {count} items ]"
     },
     "file_preview": {
-        "big_file_warning": "This file is {size}. It may take a while to load blocking your browser. Do you want to load it anyway?",
-        "load_anyway": "Load anyway"
+      "big_file_warning": "This file is {size}. It may take a while to load blocking your browser. Do you want to load it anyway?",
+      "load_anyway": "Load anyway"
     },
     "no_variables": "No variables available.",
     "download": "Download",
@@ -513,7 +513,7 @@
     "Editor fontsize": "Editor font size",
     "Editor fontfamily": "Editor font family",
     "errors": {
-       "404": {
+      "404": {
         "title": "Page not found",
         "content": "The requested URL was not found on this server.<br />That’s all we know.",
         "flow or execution": "The flow or execution you are looking for does not exist."
@@ -2192,5 +2192,6 @@
         "label": "{count} Error(s)"
       }
     }
-  }
+  },
+  "schedule date must be in the future": "Schedule date must be in the future"
 }

--- a/ui/src/translations/es.json
+++ b/ui/src/translations/es.json
@@ -2192,5 +2192,6 @@
     "workers": "Workers",
     "wrong labels": "No se permite una key o value vacía en las etiquetas",
     "yes": "Sí"
-  }
+  },
+  "schedule date must be in the future": "La fecha programada debe ser en el futuro"
 }

--- a/ui/src/translations/fr.json
+++ b/ui/src/translations/fr.json
@@ -2192,5 +2192,6 @@
     "workers": "Workers",
     "wrong labels": "Clé ou valeur vide détecté dans les labels",
     "yes": "Oui"
-  }
+  },
+  "schedule date must be in the future": "La date planifiée doit être dans le futur"
 }

--- a/ui/src/translations/hi.json
+++ b/ui/src/translations/hi.json
@@ -2192,5 +2192,6 @@
     "workers": "Workers",
     "wrong labels": "labels में खाली key या value की अनुमति नहीं है",
     "yes": "हाँ"
-  }
+  },
+  "schedule date must be in the future": "शेड्यूल तिथि भविष्य में होनी चाहिए"
 }

--- a/ui/src/translations/it.json
+++ b/ui/src/translations/it.json
@@ -2192,5 +2192,6 @@
     "workers": "Workers",
     "wrong labels": "Chiave o valore vuoto non sono ammessi nelle etichette",
     "yes": "Sì"
-  }
+  },
+  "schedule date must be in the future": "La data di pianificazione deve essere nel futuro"
 }

--- a/ui/src/translations/ja.json
+++ b/ui/src/translations/ja.json
@@ -2192,5 +2192,6 @@
     "workers": "Workers",
     "wrong labels": "ラベルには空のkeyまたはvalueを設定できません",
     "yes": "はい"
-  }
+  },
+  "schedule date must be in the future": "スケジュール日時は未来である必要があります"
 }

--- a/ui/src/translations/ko.json
+++ b/ui/src/translations/ko.json
@@ -2192,5 +2192,6 @@
     "workers": "Workers",
     "wrong labels": "라벨에 빈 key 또는 value는 허용되지 않습니다",
     "yes": "네"
-  }
+  },
+  "schedule date must be in the future": "예약 날짜는 미래여야 합니다"
 }

--- a/ui/src/translations/pl.json
+++ b/ui/src/translations/pl.json
@@ -2192,5 +2192,6 @@
     "workers": "Workers",
     "wrong labels": "Pusta wartość lub key nie jest dozwolona w etykietach",
     "yes": "Tak"
-  }
+  },
+  "schedule date must be in the future": "Data zaplanowania musi być w przyszłości"
 }

--- a/ui/src/translations/pt.json
+++ b/ui/src/translations/pt.json
@@ -2192,5 +2192,6 @@
     "workers": "Workers",
     "wrong labels": "Chave ou valor vazio não é permitido em labels",
     "yes": "Sim"
-  }
+  },
+  "schedule date must be in the future": "A data agendada deve ser no futuro"
 }

--- a/ui/src/translations/pt_BR.json
+++ b/ui/src/translations/pt_BR.json
@@ -2192,5 +2192,6 @@
     "workers": "Workers",
     "wrong labels": "Chave ou valor vazio não é permitido em labels",
     "yes": "Sim"
-  }
+  },
+  "schedule date must be in the future": "A data agendada deve ser no futuro"
 }

--- a/ui/src/translations/ru.json
+++ b/ui/src/translations/ru.json
@@ -2192,5 +2192,6 @@
     "workers": "Workers",
     "wrong labels": "Пустой key или value не допускается в метках",
     "yes": "Да"
-  }
+  },
+  "schedule date must be in the future": "Дата планирования должна быть в будущем"
 }

--- a/ui/src/translations/zh_CN.json
+++ b/ui/src/translations/zh_CN.json
@@ -1,4 +1,5 @@
 {
+  "schedule date must be in the future": "计划日期必须是未来时间",
   "zh_CN": {
     "Add flow": "添加流程",
     "Default log level": "默认日志级别",

--- a/ui/src/utils/scheduleDate.ts
+++ b/ui/src/utils/scheduleDate.ts
@@ -1,0 +1,68 @@
+/**
+ * Helpers for the Execute dialog "Schedule date" picker.
+ * Past dates/times must be blocked — the executor ignores past scheduleDate
+ * and starts immediately, which makes a past selection misleading.
+ */
+
+const MS_PER_DAY = 8.64e7
+
+/** Calendar days strictly before today (local) are disabled. */
+export function isScheduleCalendarDateDisabled(date: Date, now: Date = new Date()): boolean {
+    return date.getTime() < now.getTime() - MS_PER_DAY
+}
+
+function isSameLocalDay(a: Date, b: Date): boolean {
+    return (
+        a.getFullYear() === b.getFullYear() &&
+        a.getMonth() === b.getMonth() &&
+        a.getDate() === b.getDate()
+    )
+}
+
+/** Hours already past on the selected day (local). Empty when the day is in the future. */
+export function disabledScheduleHours(selected: Date | string | undefined | null, now: Date = new Date()): number[] {
+    if (selected == null || selected === "") {
+        return []
+    }
+    const selectedDate = selected instanceof Date ? selected : new Date(selected)
+    if (Number.isNaN(selectedDate.getTime()) || !isSameLocalDay(selectedDate, now)) {
+        return []
+    }
+    const currentHour = now.getHours()
+    return Array.from({length: currentHour}, (_, hour) => hour)
+}
+
+/** Minutes already past for the selected hour on today (local). */
+export function disabledScheduleMinutes(
+    selected: Date | string | undefined | null,
+    hour: number,
+    now: Date = new Date(),
+): number[] {
+    if (selected == null || selected === "") {
+        return []
+    }
+    const selectedDate = selected instanceof Date ? selected : new Date(selected)
+    if (Number.isNaN(selectedDate.getTime()) || !isSameLocalDay(selectedDate, now)) {
+        return []
+    }
+    if (hour !== now.getHours()) {
+        return []
+    }
+    const currentMinute = now.getMinutes()
+    return Array.from({length: currentMinute}, (_, minute) => minute)
+}
+
+/** True when the schedule instant is strictly before now. */
+export function isScheduleDateInPast(
+    scheduleDate: Date | string | undefined | null,
+    now: Date = new Date(),
+): boolean {
+    if (scheduleDate == null || scheduleDate === "") {
+        return false
+    }
+    const date = scheduleDate instanceof Date ? scheduleDate : new Date(scheduleDate)
+    if (Number.isNaN(date.getTime())) {
+        return false
+    }
+    return date.getTime() < now.getTime()
+}

--- a/ui/tests/unit/utils/scheduleDate.spec.ts
+++ b/ui/tests/unit/utils/scheduleDate.spec.ts
@@ -1,0 +1,41 @@
+import {describe, expect, test} from "vitest"
+import {
+    disabledScheduleHours,
+    disabledScheduleMinutes,
+    isScheduleCalendarDateDisabled,
+    isScheduleDateInPast,
+} from "../../../src/utils/scheduleDate"
+
+describe("scheduleDate helpers", () => {
+    const now = new Date("2026-07-29T14:30:00")
+
+    test("disables calendar days before today", () => {
+        expect(isScheduleCalendarDateDisabled(new Date("2026-07-28T12:00:00"), now)).toBe(true)
+        expect(isScheduleCalendarDateDisabled(new Date("2026-07-29T00:00:00"), now)).toBe(false)
+        expect(isScheduleCalendarDateDisabled(new Date("2026-07-30T12:00:00"), now)).toBe(false)
+    })
+
+    test("disables hours already past when the selected day is today", () => {
+        expect(disabledScheduleHours(new Date("2026-07-29T16:00:00"), now)).toEqual(
+            Array.from({length: 14}, (_, hour) => hour),
+        )
+        expect(disabledScheduleHours(new Date("2026-07-30T10:00:00"), now)).toEqual([])
+        expect(disabledScheduleHours(undefined, now)).toEqual([])
+    })
+
+    test("disables minutes already past for the current hour on today", () => {
+        expect(disabledScheduleMinutes(new Date("2026-07-29T14:45:00"), 14, now)).toEqual(
+            Array.from({length: 30}, (_, minute) => minute),
+        )
+        expect(disabledScheduleMinutes(new Date("2026-07-29T15:00:00"), 15, now)).toEqual([])
+        expect(disabledScheduleMinutes(new Date("2026-07-30T14:00:00"), 14, now)).toEqual([])
+    })
+
+    test("detects schedule dates strictly in the past", () => {
+        expect(isScheduleDateInPast(new Date("2026-07-29T14:29:59"), now)).toBe(true)
+        expect(isScheduleDateInPast(new Date("2026-07-29T14:30:00"), now)).toBe(false)
+        expect(isScheduleDateInPast(new Date("2026-07-29T15:00:00"), now)).toBe(false)
+        expect(isScheduleDateInPast(undefined, now)).toBe(false)
+        expect(isScheduleDateInPast("", now)).toBe(false)
+    })
+})


### PR DESCRIPTION
### ✨ Description

When scheduling an execution from the Execute dialog, the UI allowed selecting a date and time in the past. The executor ignores past `scheduleDate` values and starts immediately, so the control was misleading.

This change:
- disables past calendar days in the schedule date picker
- disables hours/minutes already elapsed when the selected day is today
- blocks submit with a clear error if a past value is still present
- only sends `scheduleDate` when one is set (instead of always sending "now")

### 🔗 Related Issue

Closes https://github.com/kestra-io/kestra/issues/17348

### 🎨 Frontend Checklist

- [x] Unit tests added for schedule-date helpers
- [x] Translations added for the validation message

### 📝 Additional Notes

- Helpers live in `ui/src/utils/scheduleDate.ts` so the picker rules are unit-tested without mounting the dialog.
