### PR TITLE
fix(ai): keep the current flow open when applying a copilot change

### DIFF
--- a/ui/src/components/ai/copilot/CopilotContextChip.vue
+++ b/ui/src/components/ai/copilot/CopilotContextChip.vue
@@ -2,14 +2,23 @@
     <!-- Shows the page the copilot is focused on (sent as `additionalContext`). Dismissible to drop it. -->
     <div class="copilot-context" data-test="copilot-context-chip">
         <KsTag closable size="small" :icon="icon" @close="emit('clear')">
-            {{ label }}
+            <!-- Render the id/namespace/flowId via <KsId> so it stands out as a code-styled,
+                 link-coloured token — the same treatment execution/flow ids get in tables. -->
+            <i18n-t :keypath="context.keypath" scope="global" tag="span">
+                <template #[context.slot]>
+                    <!-- For a flow, show its namespace alongside the id so the full context is visible. -->
+                    <template v-if="context.namespace">
+                        <KsId :value="context.namespace" :shrink="false" /><span class="copilot-context-sep">/</span><KsId :value="context.value" :shrink="false" />
+                    </template>
+                    <KsId v-else :value="context.value" :shrink="false" />
+                </template>
+            </i18n-t>
         </KsTag>
     </div>
 </template>
 
 <script setup lang="ts">
     import {computed} from "vue"
-    import {useI18n} from "vue-i18n"
     import FileDocumentOutline from "vue-material-design-icons/FileDocumentOutline.vue"
     import PlayCircleOutline from "vue-material-design-icons/PlayCircleOutline.vue"
     import FolderOutline from "vue-material-design-icons/FolderOutline.vue"
@@ -17,8 +26,6 @@
 
     const props = defineProps<{scope: ScopeBinding}>()
     const emit = defineEmits<{clear: []}>()
-
-    const {t} = useI18n()
 
     const icon = computed(() => {
         switch (props.scope.kind) {
@@ -32,14 +39,17 @@
     })
 
     // A short, human label for the focused resource. Falls back gracefully if a field is missing.
-    const label = computed(() => {
+    // Each context i18n string ("Execution {id}" / "Namespace {namespace}" / "Flow {flow}") has one
+    // interpolation slot; the slot name differs per kind, so drive the <i18n-t> slot dynamically.
+    const context = computed(() => {
         switch (props.scope.kind) {
         case "EXECUTION":
-            return t("ai.copilot.context.execution", {id: props.scope.executionId ?? ""})
+            return {keypath: "ai.copilot.context.execution", slot: "id", value: props.scope.executionId ?? "", namespace: undefined as string | undefined}
         case "NAMESPACE":
-            return t("ai.copilot.context.namespace", {namespace: props.scope.namespace ?? ""})
+            return {keypath: "ai.copilot.context.namespace", slot: "namespace", value: props.scope.namespace ?? "", namespace: undefined as string | undefined}
         default:
-            return t("ai.copilot.context.flow", {flow: props.scope.flowId ?? ""})
+            // FLOW — show the namespace next to the id (a flow is only unique within its namespace).
+            return {keypath: "ai.copilot.context.flow", slot: "flow", value: props.scope.flowId ?? "", namespace: props.scope.namespace}
         }
     })
 </script>
@@ -48,5 +58,10 @@
     .copilot-context {
         display: flex;
         margin-bottom: var(--ks-spacing-2);
+    }
+
+    /* Separator between the namespace and flow id tokens. */
+    .copilot-context-sep {
+        color: var(--ks-text-secondary);
     }
 </style>

--- a/ui/src/components/ai/copilot/useApplyDraft.ts
+++ b/ui/src/components/ai/copilot/useApplyDraft.ts
@@ -6,6 +6,7 @@ import {flowYamlUtils as YAML_UTILS} from "@kestra-io/topology"
 import * as FlowsAPI from "@kestra-io/kestra-sdk/flows"
 import * as DashboardsAPI from "@kestra-io/kestra-sdk/dashboards"
 import {useAppDraftActions} from "override/components/ai/copilot/appDraftActions"
+import {useFlowStore} from "../../../stores/flow"
 import type {ArtefactDraftEvent} from "./types"
 
 /**
@@ -29,6 +30,12 @@ export function useApplyDraft() {
     const appSupported = appActions.supported
 
     const tenantParam = (): Record<string, string | string[]> => (route.params.tenant ? {tenant: route.params.tenant} : {})
+
+    // Per-request client option (the SDK endpoints' SECOND arg, spread into the request options and
+    // read by the global error interceptor). `showMessageOnError: false` opts this call out of the
+    // global error toast — we handle failures locally: a create that hits "already exists" is an
+    // expected step of the create→update fallback, and any real failure gets our own alert.
+    const silent = {showMessageOnError: false} as Parameters<typeof FlowsAPI.createFlow>[1]
 
     /** (A) Open the drafted YAML in the matching creation editor to review + save there. */
     function openInEditor(draft: ArtefactDraftEvent): void {
@@ -74,16 +81,32 @@ export function useApplyDraft() {
             // probe with a GET first — a 404 on a not-yet-existing flow trips the global error page.
             try {
                 await FlowsAPI.createFlow(
-                    {body: draft.yaml, draft: false, showMessageOnError: false} as Parameters<typeof FlowsAPI.createFlow>[0],
+                    {body: draft.yaml, draft: false} as Parameters<typeof FlowsAPI.createFlow>[0],
+                    silent,
                 )
             } catch (e) {
                 if (!isAlreadyExists(e)) throw e
                 await FlowsAPI.updateFlow(
-                    {namespace, id, body: draft.yaml, showMessageOnError: false} as Parameters<typeof FlowsAPI.updateFlow>[0],
+                    {namespace, id, body: draft.yaml} as Parameters<typeof FlowsAPI.updateFlow>[0],
+                    silent,
                 )
             }
-            // Land on the applied flow so the result is visible.
-            router.push({name: "flows/update", params: {namespace, id, ...tenantParam()}})
+            // When the user is already viewing this flow, apply transparently — like a save: refresh
+            // the store (source buffer + graph) in place and stay on the current tab, instead of
+            // bouncing to the flow overview and forcing a hard refresh to see the change. Otherwise
+            // open the flow so the result is visible.
+            const onThisFlow = route.name === "flows/update"
+                && String(route.params.namespace) === namespace
+                && String(route.params.id) === id
+            if (onThisFlow) {
+                // Resolve the store lazily (only when we actually refresh an open flow) so merely
+                // rendering a draft card doesn't require Pinia to be set up.
+                const flowStore = useFlowStore()
+                const data = await flowStore.loadFlow({namespace, id})
+                if (data?.source) await flowStore.loadGraph({flow: data})
+            } else {
+                router.push({name: "flows/update", params: {namespace, id, ...tenantParam()}})
+            }
         } catch (e) {
             await alertError(e, t("ai.copilot.draft.applyError"), t("ai.copilot.draft.applyTitle"))
         } finally {
@@ -107,12 +130,14 @@ export function useApplyDraft() {
             // Create, falling back to update if the id already exists — same no-probe rationale as flows.
             try {
                 await DashboardsAPI.createDashboard(
-                    {body: draft.yaml, showMessageOnError: false} as Parameters<typeof DashboardsAPI.createDashboard>[0],
+                    {body: draft.yaml} as Parameters<typeof DashboardsAPI.createDashboard>[0],
+                    silent,
                 )
             } catch (e) {
                 if (!isAlreadyExists(e)) throw e
                 await DashboardsAPI.updateDashboard(
-                    {id, body: draft.yaml, showMessageOnError: false} as Parameters<typeof DashboardsAPI.updateDashboard>[0],
+                    {id, body: draft.yaml} as Parameters<typeof DashboardsAPI.updateDashboard>[0],
+                    silent,
                 )
             }
             router.push({name: "dashboards/update", params: {dashboard: id, ...tenantParam()}})
@@ -146,10 +171,18 @@ export function useApplyDraft() {
         }
     }
 
-    /** A create failed because the artefact already exists (→ update instead). */
+    /**
+     * A create failed because the artefact already exists (→ update instead). The SDK throws the
+     * parsed error body with a `.response = {status, data}` attached; the "already exists" text can
+     * sit at `data.message` or nested in the validation errors (`_embedded.errors[].message`), so
+     * match against the whole serialized body rather than a single field.
+     */
     function isAlreadyExists(e: unknown): boolean {
-        const err = e as {response?: {status?: number; data?: {message?: string}}}
-        return err?.response?.status === 422 && /already exists/i.test(err?.response?.data?.message ?? "")
+        const err = e as {status?: number; response?: {status?: number; data?: unknown}}
+        const status = err?.response?.status ?? err?.status
+        if (status !== 422) return false
+        const body = err?.response?.data ?? err
+        return /already exists/i.test(typeof body === "string" ? body : JSON.stringify(body ?? ""))
     }
 
     return {applying, appSupported, openInEditor, apply}

--- a/ui/tests/unit/components/ai/copilot/CopilotContextChip.spec.ts
+++ b/ui/tests/unit/components/ai/copilot/CopilotContextChip.spec.ts
@@ -13,13 +13,18 @@ const KsTag = {
     template: "<span class=\"ks-tag\"><slot /><button v-if=\"closable\" class=\"close\" @click=\"$emit('close')\">x</button></span>",
 }
 const KsIcon = {name: "KsIcon", template: "<i><slot /></i>"}
+// KsId renders the id as a code-styled token; stub it to expose the value + the <code> wrapper.
+const KsId = {name: "KsId", props: {value: {type: String, default: ""}, shrink: {type: Boolean, default: true}}, template: "<code class=\"ks-id\">{{ value }}</code>"}
 
 const mountChip = (scope: any) =>
-    mount(CopilotContextChip, {props: {scope}, global: {plugins: [i18n], stubs: {KsTag, KsIcon}}})
+    mount(CopilotContextChip, {props: {scope}, global: {plugins: [i18n], stubs: {KsTag, KsIcon, KsId}}})
 
 describe("CopilotContextChip", () => {
-    it("labels a flow scope", () => {
-        expect(mountChip({kind: "FLOW", namespace: "company.team", flowId: "my-flow"}).text()).toContain("Flow: my-flow")
+    it("labels a flow scope with its namespace and id (both as code tokens)", () => {
+        const w = mountChip({kind: "FLOW", namespace: "company.team", flowId: "my-flow"})
+        expect(w.text()).toContain("Flow:")
+        // A flow is only unique within its namespace, so both are shown, namespace first.
+        expect(w.findAll("code.ks-id").map(c => c.text())).toEqual(["company.team", "my-flow"])
     })
 
     it("labels an execution scope", () => {
@@ -29,6 +34,11 @@ describe("CopilotContextChip", () => {
 
     it("labels a namespace scope", () => {
         expect(mountChip({kind: "NAMESPACE", namespace: "company.team"}).text()).toContain("Namespace: company.team")
+    })
+
+    it("renders the id as a code-styled token (KsId), like execution ids in tables", () => {
+        const w = mountChip({kind: "EXECUTION", namespace: "company.team", flowId: "my-flow", executionId: "exec-1"})
+        expect(w.find("code.ks-id").text()).toBe("exec-1")
     })
 
     it("emits clear when the chip is dismissed", async () => {

--- a/ui/tests/unit/components/ai/copilot/useApplyDraft.spec.ts
+++ b/ui/tests/unit/components/ai/copilot/useApplyDraft.spec.ts
@@ -2,12 +2,18 @@ import {describe, it, expect, vi, beforeEach} from "vitest"
 
 // --- mocks (hoisted) ---
 const push = vi.fn()
+let routeName: string | undefined = undefined
 let routeParams: Record<string, any> = {}
 vi.mock("vue-router", () => ({
     useRouter: () => ({push}),
-    useRoute: () => ({params: routeParams}),
+    useRoute: () => ({name: routeName, params: routeParams}),
 }))
 vi.mock("vue-i18n", () => ({useI18n: () => ({t: (k: string) => k})}))
+
+// Flow store — assert the in-place refresh (loadFlow/loadGraph) when applying to an open flow.
+const loadFlow = vi.fn()
+const loadGraph = vi.fn().mockResolvedValue(undefined)
+vi.mock("../../../../../src/stores/flow", () => ({useFlowStore: () => ({loadFlow, loadGraph})}))
 
 const confirm = vi.fn()
 const alert = vi.fn().mockResolvedValue(undefined)
@@ -41,6 +47,7 @@ const draft = (over = {}) => ({draftId: "d1", kind: "FLOW" as const, yaml: "id: 
 describe("useApplyDraft", () => {
     beforeEach(() => {
         vi.clearAllMocks()
+        routeName = undefined
         routeParams = {tenant: "main"}
         parsed = {namespace: "company.team", id: "my-flow"}
         alert.mockResolvedValue(undefined)
@@ -48,6 +55,8 @@ describe("useApplyDraft", () => {
         updateFlow.mockResolvedValue({})
         createDashboard.mockResolvedValue({})
         updateDashboard.mockResolvedValue({})
+        loadFlow.mockResolvedValue({source: "id: my-flow\nnamespace: company.team"})
+        loadGraph.mockResolvedValue(undefined)
     })
 
     const dashboardDraft = (over = {}) => ({draftId: "d9", kind: "DASHBOARD" as const, yaml: "id: my-dash\ntitle: My dash", valid: true, constraints: null, ...over})
@@ -64,7 +73,12 @@ describe("useApplyDraft", () => {
     it("apply CREATES the flow, then navigates to it", async () => {
         confirm.mockResolvedValueOnce(undefined) // user confirms
         await useApplyDraft().apply(draft())
-        expect(createFlow).toHaveBeenCalledWith(expect.objectContaining({body: "id: my-flow\nnamespace: company.team"}))
+        // The create opts out of the global error toast (2nd arg) so the create→update fallback and
+        // our own alert stay the only user-facing failure paths.
+        expect(createFlow).toHaveBeenCalledWith(
+            expect.objectContaining({body: "id: my-flow\nnamespace: company.team"}),
+            expect.objectContaining({showMessageOnError: false}),
+        )
         expect(updateFlow).not.toHaveBeenCalled()
         // On success it navigates to the applied flow.
         expect(push).toHaveBeenCalledWith(expect.objectContaining({
@@ -73,12 +87,42 @@ describe("useApplyDraft", () => {
         }))
     })
 
+    it("apply refreshes the flow in place (no navigation) when already viewing it", async () => {
+        routeName = "flows/update"
+        routeParams = {tenant: "main", namespace: "company.team", id: "my-flow"}
+        confirm.mockResolvedValueOnce(undefined)
+        createFlow.mockRejectedValueOnce(alreadyExists) // existing flow → update in place
+        await useApplyDraft().apply(draft())
+        expect(updateFlow).toHaveBeenCalled()
+        // Stays on the current tab and refreshes the store like a save — no bounce to overview.
+        expect(loadFlow).toHaveBeenCalledWith({namespace: "company.team", id: "my-flow"})
+        expect(loadGraph).toHaveBeenCalledWith({flow: expect.objectContaining({source: expect.any(String)})})
+        expect(push).not.toHaveBeenCalled()
+    })
+
     it("apply UPDATES the flow when create reports it already exists", async () => {
         confirm.mockResolvedValueOnce(undefined)
         createFlow.mockRejectedValueOnce(alreadyExists) // create → 422 already exists → fall back to update
         await useApplyDraft().apply(draft())
-        expect(updateFlow).toHaveBeenCalledWith(expect.objectContaining({namespace: "company.team", id: "my-flow", body: "id: my-flow\nnamespace: company.team"}))
+        expect(updateFlow).toHaveBeenCalledWith(
+            expect.objectContaining({namespace: "company.team", id: "my-flow", body: "id: my-flow\nnamespace: company.team"}),
+            expect.objectContaining({showMessageOnError: false}),
+        )
         expect(push).toHaveBeenCalledWith(expect.objectContaining({name: "flows/update"}))
+    })
+
+    it("falls back to update when the 'already exists' error is nested in the validation body", async () => {
+        // The real backend 422 puts the "already exists" text in the validation errors, not data.message.
+        confirm.mockResolvedValueOnce(undefined)
+        createFlow.mockRejectedValueOnce({
+            status: 422,
+            response: {status: 422, data: {message: "Validation failed", _embedded: {errors: [{message: "flow.id: Flow id already exists: my-flow"}]}}},
+        })
+        await useApplyDraft().apply(draft())
+        expect(updateFlow).toHaveBeenCalledWith(
+            expect.objectContaining({namespace: "company.team", id: "my-flow"}),
+            expect.objectContaining({showMessageOnError: false}),
+        )
     })
 
     it("apply surfaces an error (no update) when create fails for another reason", async () => {
@@ -120,7 +164,10 @@ describe("useApplyDraft", () => {
         parsed = {id: "my-dash"}
         confirm.mockResolvedValueOnce(true)
         await useApplyDraft().apply(dashboardDraft())
-        expect(createDashboard).toHaveBeenCalledWith(expect.objectContaining({body: "id: my-dash\ntitle: My dash"}))
+        expect(createDashboard).toHaveBeenCalledWith(
+            expect.objectContaining({body: "id: my-dash\ntitle: My dash"}),
+            expect.objectContaining({showMessageOnError: false}),
+        )
         expect(updateDashboard).not.toHaveBeenCalled()
         expect(push).toHaveBeenCalledWith(expect.objectContaining({name: "dashboards/update", params: {dashboard: "my-dash", tenant: "main"}}))
     })
@@ -130,7 +177,10 @@ describe("useApplyDraft", () => {
         confirm.mockResolvedValueOnce(true)
         createDashboard.mockRejectedValueOnce(dashboardExists)
         await useApplyDraft().apply(dashboardDraft())
-        expect(updateDashboard).toHaveBeenCalledWith(expect.objectContaining({id: "my-dash", body: "id: my-dash\ntitle: My dash"}))
+        expect(updateDashboard).toHaveBeenCalledWith(
+            expect.objectContaining({id: "my-dash", body: "id: my-dash\ntitle: My dash"}),
+            expect.objectContaining({showMessageOnError: false}),
+        )
     })
 
     it("apply alerts and skips confirm when the dashboard draft has no id", async () => {


### PR DESCRIPTION
## What

Three related fixes to the AI Copilot's flow authoring / apply flow:

### 1. Apply a change in place (the reported bug)
Applying a copilot draft to the flow you're currently viewing navigated you to the flow **overview** and required a **hard refresh** to see the change. Now, when the draft targets the flow already open, apply refreshes the flow **in place** — reloading the store's source buffer + graph and staying on the current tab, exactly like a save. Applying to a *different* flow still navigates to it.

### 2. Amending an existing flow/dashboard actually updates it
Apply does create-then-fallback-to-update. Two bugs made amending an existing flow fail:
- **The 422 wasn't recognised.** The "already exists" check only looked at one field; it now matches on the response **status** (422, from either `.response.status` or `.status`) **and** the serialized body, including the backend's nested `_embedded.errors[].message` shape.
- **The error toast still fired.** `showMessageOnError: false` was being passed in the SDK endpoint's *first* argument, where `buildClientParams` drops any non-schema key. It now rides in the endpoint's *second* argument (per-request client options), which is where the global error interceptor in `kestraHttp.ts` actually reads it — so the expected "already exists" create no longer flashes a global error toast before the update fallback runs.

### 3. Context chip shows the namespace, ids as code tokens
The flow context chip now shows its **namespace** alongside the flow id (a flow is only unique within its namespace), and ids render as code-styled, link-coloured tokens (`KsId`) — the same treatment execution ids get in tables.

## Notes
- No new i18n keys — the chip reuses the existing `ai.copilot.context.*` keys, so no translation generation is needed.
- The apply-in-place path resolves the flow store lazily (only when refreshing an open flow), so merely rendering a draft card doesn't require Pinia.

## Tests
`npm run check:types` clean; full OSS unit suite green (971 passing). Updated/added unit specs for `useApplyDraft` (in-place refresh, nested-422 fallback, toast opt-out on the 2nd arg) and `CopilotContextChip` (namespace + code-token rendering).

Closes https://github.com/kestra-io/kestra-ee/issues/9535.
