### PR TITLE
fix(ai): stop the copilot working-indicator dots from clipping at the top

### DIFF
--- a/ui/src/components/ai/copilot/CopilotMarkAnimation.vue
+++ b/ui/src/components/ai/copilot/CopilotMarkAnimation.vue
@@ -41,6 +41,9 @@
 
     .copilot-mark-dots {
         display: block;
+        /* The dots sit near the top of the viewBox and the "thinking" bounce lifts them past it;
+           an SVG's viewport clips by default, so let them overflow to show the full bounce. */
+        overflow: visible;
     }
 
     .copilot-mark-dot {


### PR DESCRIPTION
<img width="1435" height="959" alt="image" src="https://github.com/user-attachments/assets/c7608565-2ec3-423d-bb89-bc353bf0e958" />

## What

While a turn runs in the AI Copilot, the animated Kestra dots next to the status word (Triggering…, Branching…, …) were **cut off at the top** — the top of the bounce clipped against the container instead of showing the full arc.

## Why

The dots live in an `<svg class="copilot-mark-dots" viewBox="0 0 44 16">`; the circles sit at `cy=8, r=6` (only ~2 units of headroom above them), and the "thinking" bounce lifts them by 4px. An `<svg>` clips its content to its viewport by default (UA `overflow: hidden`), so the peak of the bounce was clipped by the SVG's own box.

## Fix

Give `.copilot-mark-dots` `overflow: visible` so the dots can bounce past their SVG box. One-line, scoped CSS change in `CopilotMarkAnimation.vue`; no markup/script change, and it also gives the "answering" ripple (a slight scale-up) room. Reduced-motion behaviour is unchanged.

## Verification

Froze the bounce at its peak and compared the SVG viewport (dashed box):

- **Before** (`overflow: hidden`): the leading dot is sliced flat across the top.
- **After** (`overflow: visible`): the dot's full rounded top rises above the box — complete bounce, no clip.

_(before/after screenshot attached below)_

`npm run check:types` clean; `CopilotMarkAnimation` + `CopilotThinking` unit specs pass (7/7).

Closes https://github.com/kestra-io/kestra-ee/issues/9569.
