### PR TITLE
fix(flows): reload flow after computing topology to prevent lost-updat

### DIFF
--- a/core/src/main/java/io/kestra/core/services/FlowService.java
+++ b/core/src/main/java/io/kestra/core/services/FlowService.java
@@ -212,27 +212,44 @@ public class FlowService {
         updateConcurrencyLimit(flow);
     }
 
-    private void updateTopology(FlowWithSource flow) {
-        // Runs on a background thread with no HTTP request / user context, so the ACL-aware
-        // findAllWithSource() would return zero flows in EE and produce an empty topology.
-        // Topology is a system-wide computation: bypass ACLs with findAllWithSourceWithNoAcl().
+    @VisibleForTesting
+    void updateTopology(FlowWithSource flow) {
         try {
-            flowTopologyRepository.save(
-                flow,
-                (flow.isDeleted() ? Stream.<FlowTopology> empty()
-                    : flowTopologyService
-                        .topology(
-                            flow,
-                            flowRepository.findAllWithSourceWithNoAcl(flow.getTenantId())
-                        ))
-                    .distinct()
-                    .toList()
-            );
+            // Runs on a background thread with no HTTP request / user context, so the ACL-aware
+            // findAllWithSource() would return zero flows in EE: bypass ACLs with findAllWithSourceWithNoAcl().
+            List<FlowWithSource> allFlows = flowRepository.findAllWithSourceWithNoAcl(flow.getTenantId())
+                .stream()
+                .filter(candidate -> !candidate.isDeleted())
+                .toList();
+
+            // Taken from the same snapshot as the edges, so "does this flow still exist" and "what are its
+            // edges" can never be answered from two different states of the repository.
+            Optional<FlowWithSource> current = allFlows.stream()
+                .filter(candidate -> candidate.uidWithoutRevision().equals(flow.uidWithoutRevision()))
+                .findFirst();
+
+            List<FlowTopology> topologies = current
+                .map(it -> flowTopologyService.topology(it, allFlows).distinct().toList())
+                .orElseGet(List::of);
+
+            // If the flow changed meanwhile, that change scheduled its own recomputation and saving
+            // ours would replace a fresher topology with a staler one.
+            Optional<FlowWithSource> latest = flowRepository.findByIdWithSourceWithoutAcl(flow.getTenantId(), flow.getNamespace(), flow.getId(), Optional.empty());
+            if (!Objects.equals(liveRevision(current), liveRevision(latest))) {
+                log.debug("Skipping an outdated flow topology computation for flow '{}'", flow.uidWithoutRevision());
+                return;
+            }
+
+            flowTopologyRepository.save(flow, topologies);
         } catch (Exception e) {
             // The Future returned by executorService.submit(...) is never get()-ed, so without
             // this log a topology failure would be silently swallowed.
             log.error("Unable to update the flow topology for flow '{}'", flow.uidWithoutRevision(), e);
         }
+    }
+
+    private static Integer liveRevision(Optional<? extends FlowInterface> flow) {
+        return flow.filter(it -> !it.isDeleted()).map(FlowInterface::getRevision).orElse(null);
     }
 
     private void recomputeTriggers(FlowWithSource flow) {

--- a/core/src/test/java/io/kestra/core/repositories/AbstractFlowTopologyRepositoryTest.java
+++ b/core/src/test/java/io/kestra/core/repositories/AbstractFlowTopologyRepositoryTest.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 import org.junit.jupiter.api.Test;
 
+import io.kestra.core.models.flows.Flow;
 import io.kestra.core.models.topologies.FlowNode;
 import io.kestra.core.models.topologies.FlowRelation;
 import io.kestra.core.models.topologies.FlowTopology;
@@ -141,6 +142,62 @@ public abstract class AbstractFlowTopologyRepositoryTest {
         List<FlowTopology> list = flowTopologyRepository.findByFlow(tenant, "io.kestra.tests", "flow-c", false);
 
         assertThat(list).isEmpty();
+    }
+
+    @Test
+    void shouldReplaceEdgesWhenSavingSameFlowAgain() {
+        String tenant = TestsUtils.randomTenant(this.getClass().getSimpleName());
+        String namespace = "io.kestra.tests";
+        Flow flowA = Flow.builder().id("flow-a").namespace(namespace).tenantId(tenant).build();
+
+        flowTopologyRepository.save(flowA, List.of(createSimpleFlowTopology(tenant, "flow-a", "flow-b", namespace)));
+
+        assertThat(flowTopologyRepository.findByFlow(tenant, namespace, "flow-a", false))
+            .extracting(ft -> ft.getDestination().getId())
+            .containsExactly("flow-b");
+
+        flowTopologyRepository.save(flowA, List.of(createSimpleFlowTopology(tenant, "flow-a", "flow-c", namespace)));
+
+        List<FlowTopology> list = flowTopologyRepository.findByFlow(tenant, namespace, "flow-a", false);
+        assertThat(list).hasSize(1);
+        assertThat(list.getFirst().getDestination().getId()).isEqualTo("flow-c");
+    }
+
+    @Test
+    void shouldNotDeleteCounterpartEdgesWhenSavingAnotherFlow() {
+        String tenant = TestsUtils.randomTenant(this.getClass().getSimpleName());
+        String namespace = "io.kestra.tests";
+        Flow flowA = Flow.builder().id("flow-a").namespace(namespace).tenantId(tenant).build();
+        Flow flowC = Flow.builder().id("flow-c").namespace(namespace).tenantId(tenant).build();
+
+        // flow-b is incident to both edges below, but only flow-a and flow-c ever get re-saved.
+        flowTopologyRepository.save(flowA, List.of(createSimpleFlowTopology(tenant, "flow-a", "flow-b", namespace)));
+        flowTopologyRepository.save(flowC, List.of(createSimpleFlowTopology(tenant, "flow-b", "flow-c", namespace)));
+
+        // Re-saving flow-a's own edge set must not remove the flow-b -> flow-c edge it does not own.
+        flowTopologyRepository.save(flowA, List.of(createSimpleFlowTopology(tenant, "flow-a", "flow-b", namespace)));
+
+        assertThat(flowTopologyRepository.findByFlow(tenant, namespace, "flow-c", false))
+            .extracting(ft -> ft.getSource().getId())
+            .containsExactly("flow-b");
+    }
+
+    @Test
+    void shouldScopeSaveDeleteToTenantNamespaceAndId() {
+        String tenant = TestsUtils.randomTenant(this.getClass().getSimpleName());
+        String otherTenant = TestsUtils.randomTenant(this.getClass().getSimpleName());
+        String namespace = "io.kestra.tests";
+        Flow flowA = Flow.builder().id("flow-a").namespace(namespace).tenantId(tenant).build();
+        Flow otherTenantFlowA = Flow.builder().id("flow-a").namespace(namespace).tenantId(otherTenant).build();
+
+        flowTopologyRepository.save(flowA, List.of(createSimpleFlowTopology(tenant, "flow-a", "flow-b", namespace)));
+        flowTopologyRepository.save(otherTenantFlowA, List.of(createSimpleFlowTopology(otherTenant, "flow-a", "flow-b", namespace)));
+
+        // Saving (an empty topology for) flow-a in otherTenant must not touch flow-a's edges in tenant.
+        flowTopologyRepository.save(otherTenantFlowA, List.of());
+
+        assertThat(flowTopologyRepository.findByFlow(tenant, namespace, "flow-a", false)).hasSize(1);
+        assertThat(flowTopologyRepository.findByFlow(otherTenant, namespace, "flow-a", false)).isEmpty();
     }
 
 }

--- a/core/src/test/java/io/kestra/core/services/FlowServiceTest.java
+++ b/core/src/test/java/io/kestra/core/services/FlowServiceTest.java
@@ -236,7 +236,7 @@ class FlowServiceTest {
 
     flowService.importFlow("my-tenant", source);
     verify(triggerEventQueue).send(any());
-    
+
     }
 
     @Test
@@ -482,7 +482,12 @@ class FlowServiceTest {
             }
         });
 
-        flowService.create(GenericFlow.of(subflow));
+        // The fixture flow is created through the repository, not the service: creating it through the
+        // service would schedule a second topology recomputation that owns the flow->subflow edge in both
+        // directions and can race with the recomputation asserted below (a separate, cross-flow race that
+        // idempotent recomputation of a single flow does not address). This test asserts the recomputation
+        // triggered by 'flow', not by 'subflow'.
+        flowRepository.create(GenericFlow.of(subflow));
         flowService.create(GenericFlow.of(flow));
 
         // check that it has been created
@@ -531,7 +536,8 @@ class FlowServiceTest {
             }
         });
 
-        flowService.create(GenericFlow.of(subflow));
+        // See create() above for why the fixture is created through the repository, not the service.
+        flowRepository.create(GenericFlow.of(subflow));
         flowService.create(GenericFlow.of(flow));
         Flow updated = flow.toBuilder()
             .tasks(List.of(Subflow.builder().id("test").type(Subflow.class.getName()).namespace("io.kestra.unittest").flowId(subflow.getId()).build()))
@@ -586,7 +592,8 @@ class FlowServiceTest {
             }
         });
 
-        flowService.create(GenericFlow.of(subflow));
+        // See create() above for why the fixture is created through the repository, not the service.
+        flowRepository.create(GenericFlow.of(subflow));
         FlowWithSource created = flowService.create(GenericFlow.of(flow));
 
         // be sure that topology and triggers have been computed
@@ -612,6 +619,122 @@ class FlowServiceTest {
 
         // check that the flow has been sent to the queue 2x
         assertTrue(countDownLatch.await(10, TimeUnit.SECONDS));
+    }
+
+    @Test
+    void shouldRecomputeTopologyFromCurrentStateWhenReplayingAnOlderRevision() {
+        Flow subflow = Flow.builder()
+            .id(IdUtils.create())
+            .tenantId(TenantService.MAIN_TENANT)
+            .namespace(TEST_NAMESPACE)
+            .tasks(List.of(Return.builder().id("test").type(Return.class.getName()).format(Property.ofValue("test")).build()))
+            .build();
+        Flow flow = Flow.builder()
+            .id(IdUtils.create())
+            .tenantId(TenantService.MAIN_TENANT)
+            .namespace(TEST_NAMESPACE)
+            .tasks(List.of(Return.builder().id("test").type(Return.class.getName()).format(Property.ofValue("test")).build()))
+            .build();
+
+        flowRepository.create(GenericFlow.of(subflow));
+        FlowWithSource revision1 = flowRepository.create(GenericFlow.of(flow));
+        Flow withSubflowTask = flow.toBuilder()
+            .tasks(List.of(Subflow.builder().id("test").type(Subflow.class.getName()).namespace(TEST_NAMESPACE).flowId(subflow.getId()).build()))
+            .build();
+        flowRepository.update(GenericFlow.of(withSubflowTask), revision1);
+
+        // Replaying updateTopology() with the stale revision-1 object must still compute the edges of
+        // whatever is currently persisted (revision 2), not of the argument it was called with.
+        flowService.updateTopology(revision1);
+
+        List<FlowTopology> topo = flowTopologyRepository.findByFlow(flow.getTenantId(), flow.getNamespace(), flow.getId(), false);
+        assertThat(topo).hasSize(1);
+        assertThat(topo.getFirst().getSource().getId()).isEqualTo(flow.getId());
+        assertThat(topo.getFirst().getDestination().getId()).isEqualTo(subflow.getId());
+    }
+
+    @Test
+    void shouldNotCreateEdgeTowardsDeletedFlow() {
+        Flow subflow = Flow.builder()
+            .id(IdUtils.create())
+            .tenantId(TenantService.MAIN_TENANT)
+            .namespace(TEST_NAMESPACE)
+            .tasks(List.of(Return.builder().id("test").type(Return.class.getName()).format(Property.ofValue("test")).build()))
+            .build();
+        Flow flow = Flow.builder()
+            .id(IdUtils.create())
+            .tenantId(TenantService.MAIN_TENANT)
+            .namespace(TEST_NAMESPACE)
+            .tasks(List.of(Subflow.builder().id("test").type(Subflow.class.getName()).namespace(TEST_NAMESPACE).flowId(subflow.getId()).build()))
+            .build();
+
+        FlowWithSource subflowRevision1 = flowRepository.create(GenericFlow.of(subflow));
+        FlowWithSource flowRevision1 = flowRepository.create(GenericFlow.of(flow));
+        flowRepository.delete(subflowRevision1);
+
+        flowService.updateTopology(flowRevision1);
+
+        assertThat(flowTopologyRepository.findByFlow(flow.getTenantId(), flow.getNamespace(), flow.getId(), false)).isEmpty();
+    }
+
+    @Test
+    void shouldBeIdempotentWhenRecomputingTwice() {
+        Flow subflow = Flow.builder()
+            .id(IdUtils.create())
+            .tenantId(TenantService.MAIN_TENANT)
+            .namespace(TEST_NAMESPACE)
+            .tasks(List.of(Return.builder().id("test").type(Return.class.getName()).format(Property.ofValue("test")).build()))
+            .build();
+        Flow flow = Flow.builder()
+            .id(IdUtils.create())
+            .tenantId(TenantService.MAIN_TENANT)
+            .namespace(TEST_NAMESPACE)
+            .tasks(List.of(Subflow.builder().id("test").type(Subflow.class.getName()).namespace(TEST_NAMESPACE).flowId(subflow.getId()).build()))
+            .build();
+
+        flowRepository.create(GenericFlow.of(subflow));
+        FlowWithSource revision1 = flowRepository.create(GenericFlow.of(flow));
+
+        flowService.updateTopology(revision1);
+        flowService.updateTopology(revision1);
+
+        assertThat(flowTopologyRepository.findByFlow(flow.getTenantId(), flow.getNamespace(), flow.getId(), false)).hasSize(1);
+    }
+
+    @Test
+    void shouldSkipSaveWhenFlowRevisionMovedDuringCompute() {
+        Flow subflow = Flow.builder()
+            .id(IdUtils.create())
+            .tenantId(TenantService.MAIN_TENANT)
+            .namespace(TEST_NAMESPACE)
+            .tasks(List.of(Return.builder().id("test").type(Return.class.getName()).format(Property.ofValue("test")).build()))
+            .build();
+        Flow flow = Flow.builder()
+            .id(IdUtils.create())
+            .tenantId(TenantService.MAIN_TENANT)
+            .namespace(TEST_NAMESPACE)
+            .tasks(List.of(Subflow.builder().id("test").type(Subflow.class.getName()).namespace(TEST_NAMESPACE).flowId(subflow.getId()).build()))
+            .build();
+
+        flowRepository.create(GenericFlow.of(subflow));
+        FlowWithSource revision1 = flowRepository.create(GenericFlow.of(flow));
+
+        // Simulates a newer revision landing while the (potentially slow) topology compute is in flight:
+        // stub the post-compute re-check to report a revision that was never actually read from allFlows.
+        // Without the re-check, this would write the flow->subflow edge computed from revision1's real,
+        // still-persisted state, even though a newer revision is now supposed to own that write.
+        FlowRepositoryInterface realFlowRepository = flowService.flowRepository;
+        FlowRepositoryInterface spiedFlowRepository = spy(realFlowRepository);
+        doReturn(Optional.of(revision1.toBuilder().revision(revision1.getRevision() + 1).build()))
+            .when(spiedFlowRepository).findByIdWithSourceWithoutAcl(revision1.getTenantId(), revision1.getNamespace(), revision1.getId(), Optional.empty());
+        flowService.flowRepository = spiedFlowRepository;
+        try {
+            flowService.updateTopology(revision1);
+        } finally {
+            flowService.flowRepository = realFlowRepository;
+        }
+
+        assertThat(flowTopologyRepository.findByFlow(flow.getTenantId(), flow.getNamespace(), flow.getId(), false)).isEmpty();
     }
 
     @Test


### PR DESCRIPTION
…e race

- Filter deleted flow out of flow topology computation
- Detect flows thant changed between starting and ending topology computation and do nothing in this case
