### PR TITLE
fix(core): point top bar actions at their target route instead of the current page

### DIFF
--- a/ui/src/components/layout/NavBarAction.vue
+++ b/ui/src/components/layout/NavBarAction.vue
@@ -10,12 +10,16 @@
         </RouterLink>
         <slot v-else>{{ label }}</slot>
     </KsDropdownItem>
+    <!-- `to` is a declared prop, so it is not part of `$attrs` and has to be forwarded
+         explicitly: without it the RouterLink tag resolves an undefined target, renders
+         `href` for the current route (plus `aria-current="page"`) and stops being a button. -->
     <KsButton
         v-else
         :type="type ?? 'default'"
         :icon="icon"
         v-bind="$attrs"
         :tag="props.to ? RouterLink : 'button'"
+        :to="props.to"
         @click="onClick"
     >
         <slot>{{ label }}</slot>
@@ -42,8 +46,15 @@
 
     const router = useRouter()
 
-    const onClick = () => {
-        if (props.to) {
+    const onClick = (event?: MouseEvent) => {
+        // A `to` action renders as a real anchor, so the link owns navigation — including
+        // modifier clicks and "open in new tab". Pushing here as well would navigate the
+        // current tab on a cmd/middle click, so only push when the click came from
+        // something that is not the link (the dropdown item's padding around it).
+        const target = event?.target
+        const fromLink = target instanceof Element && target.closest("a") !== null
+
+        if (props.to && !fromLink) {
             router.push(props.to)
         }
         emit("click")

--- a/ui/tests/e2e/flow.spec.ts
+++ b/ui/tests/e2e/flow.spec.ts
@@ -37,7 +37,7 @@ test.describe("Flow Page", () => {
         await test.step("create the example Flow", async () => {
             await page.waitForURL("**/flows")
 
-            await page.getByRole("button", {name: "Create", exact: true}).click()
+            await page.getByRole("link", {name: "Create", exact: true}).click()
 
             await page.waitForURL("**/flows/new")
 
@@ -67,8 +67,8 @@ test.describe("Flow Page", () => {
         await page.goto("/ui/flows")
 
         await test.step("create a the flow by pasting the YAML", async () => {
-            await expect(page.getByRole("button", {name: "Create", exact: true})).toBeVisible()
-            await page.getByRole("button", {name: "Create", exact: true}).click()
+            await expect(page.getByRole("link", {name: "Create", exact: true})).toBeVisible()
+            await page.getByRole("link", {name: "Create", exact: true}).click()
             await page.waitForURL("**/flows/new")
             await page.getByTestId("monaco-editor").getByText("Hello World").isVisible()
 

--- a/ui/tests/unit/components/layout/NavBarAction.spec.ts
+++ b/ui/tests/unit/components/layout/NavBarAction.spec.ts
@@ -1,0 +1,98 @@
+import {describe, expect, test, vi} from "vitest"
+import {mount} from "@vue/test-utils"
+import {createRouter, createMemoryHistory} from "vue-router"
+import NavBarAction from "../../../../src/components/layout/NavBarAction.vue"
+import {asItemKey} from "../../../../src/components/layout/navBarActionsContext"
+
+// Mirrors what KsButton/ElButton do with `tag`: render it as the root element and pass
+// everything else through, so a `to` action really goes through RouterLink here.
+const KsButton = {
+    name: "KsButton",
+    props: ["icon", "type", "tag", "to"],
+    emits: ["click"],
+    template: "<component :is=\"tag ?? 'button'\" :to=\"to\" @click=\"$emit('click', $event)\"><slot/></component>",
+}
+
+const KsDropdownItem = {
+    name: "KsDropdownItem",
+    props: ["icon"],
+    template: "<li class=\"dropdown-item\" @click=\"$emit('click', $event)\"><slot/></li>",
+}
+
+const buildRouter = () => createRouter({
+    history: createMemoryHistory(),
+    routes: [
+        {path: "/flows", name: "flows/list", component: {template: "<div/>"}},
+        {path: "/flows/new", name: "flows/create", component: {template: "<div/>"}},
+    ],
+})
+
+const mountAction = async (props = {}, {asItem = false} = {}) => {
+    const router = buildRouter()
+    router.push({name: "flows/list"})
+    await router.isReady()
+
+    const wrapper = mount(NavBarAction, {
+        props,
+        global: {
+            plugins: [router],
+            // The suite-wide RouterLink stub renders a bare <a> with no href — this
+            // component's whole contract is the href it produces, so use the real one.
+            stubs: {RouterLink: false, KsButton, KsDropdownItem},
+            provide: {[asItemKey as unknown as symbol]: asItem},
+        },
+    })
+
+    return {wrapper, router}
+}
+
+describe("NavBarAction", () => {
+    test("a `to` action renders a link pointing at that route, not at the current one", async () => {
+        const {wrapper} = await mountAction({label: "Create", type: "primary", to: {name: "flows/create"}})
+
+        const link = wrapper.get("a")
+        expect(link.attributes("href")).toBe("/flows/new")
+        expect(link.attributes("aria-current")).toBeUndefined()
+        expect(link.text()).toBe("Create")
+    })
+
+    test("an action without `to` stays a button and emits click", async () => {
+        const {wrapper} = await mountAction({label: "Import"})
+
+        expect(wrapper.find("a").exists()).toBe(false)
+        await wrapper.get("button").trigger("click")
+        expect(wrapper.emitted("click")).toHaveLength(1)
+    })
+
+    test("clicking the link navigates exactly once — the link owns navigation", async () => {
+        const {wrapper, router} = await mountAction({label: "Create", to: {name: "flows/create"}})
+        const push = vi.spyOn(router, "push")
+
+        await wrapper.get("a").trigger("click")
+
+        // The link itself pushes; the component must not push a second time.
+        expect(push).toHaveBeenCalledTimes(1)
+        expect(wrapper.emitted("click")).toHaveLength(1)
+    })
+
+    test("a modifier click on the link leaves the current route alone", async () => {
+        const {wrapper, router} = await mountAction({label: "Create", to: {name: "flows/create"}})
+        const push = vi.spyOn(router, "push")
+
+        // cmd/ctrl-click is the browser opening a new tab — navigating here as well would
+        // move the tab the user meant to keep.
+        await wrapper.get("a").trigger("click", {metaKey: true})
+
+        expect(push).not.toHaveBeenCalled()
+    })
+
+    test("inside the actions dropdown, clicking the item outside the link still navigates", async () => {
+        const {wrapper, router} = await mountAction({label: "Source search", to: {name: "flows/create"}}, {asItem: true})
+        const push = vi.spyOn(router, "push")
+
+        expect(wrapper.get("a").attributes("href")).toBe("/flows/new")
+
+        await wrapper.get("li").trigger("click")
+        expect(push).toHaveBeenCalledWith({name: "flows/create"})
+    })
+})


### PR DESCRIPTION
## What

Top bar actions built from a route render their `KsButton` with `tag="RouterLink"` (since #17679), but `to` is a declared prop of `NavBarAction`, so it is not part of `$attrs` and never reached the link.

`RouterLink` resolved an undefined target and fell back to the current route. Rendering the real `ElButton` both ways:

```
=== `to` not forwarded (develop) ===
<a aria-current="page" href="/" class="router-link-active router-link-exact-active el-button el-button--primary">Create</a>

=== `to` forwarded (this PR) ===
<a href="/flows/new" class="el-button el-button--primary">Create</a>
```

So every route-based top bar action (create flow, source search, edit flow, edit dashboard, and the EE create test suite / view flow actions):

- stopped being a button — its accessible role became `link`,
- pointed at the page the user was already on, and picked up `router-link-active` + `aria-current="page"`,
- opened *that same page* in a new tab on a cmd/middle click, which is the opposite of what #17679 set out to enable.

Navigation kept working only because the click handler pushed the route manually.

This is what broke the scheduled E2E run on `develop` — https://github.com/kestra-io/kestra/actions/runs/30448523297, `flow.spec.ts:34` and `flow.spec.ts:61` failed all 6 attempts on `getByRole('button', { name: 'Create' })`.

## How

- Forward `to` to the `KsButton` so the link gets a real target.
- Let the link own navigation: only push from the click handler when the click did not come from a link (`event.target.closest("a")`). On the anchor the link handles everything, modifier clicks included; in the actions dropdown, a click on the padding around the link still navigates.
- Update the E2E selectors to `role: "link"` — a top bar action that navigates is an anchor now.

## Tests

- New `ui/tests/unit/components/layout/NavBarAction.spec.ts`: the link points at its own route (not the current one) and carries no `aria-current`, an action without `to` stays a button, a plain click navigates exactly once, and a modifier click leaves the current route alone. 3 of the 5 fail against the unfixed component (`expected '/flows' to be '/flows/new'`).
- `npm run test:unit` → 980/980 pass. `npm run check:types` and eslint clean.

Companion EE PR for the same two E2E selectors: https://github.com/kestra-io/kestra-ee/pull/9576

