### PR TITLE
perf(tests): unblock and speed up the OSS e2e suite

### DIFF
--- a/ui/.gitignore
+++ b/ui/.gitignore
@@ -10,3 +10,4 @@ packages/*/package-lock.json
 
 # module federation build files
 .__mf__temp
+tests/e2e/.auth/

--- a/ui/src/components/flows/Flows.vue
+++ b/ui/src/components/flows/Flows.vue
@@ -14,6 +14,7 @@
                         :icon="Plus"
                         :to="{name: 'flows/create', query: {namespace: $route.query.namespace}}"
                         :label="$t('create')"
+                        data-test="flows-create"
                     />
                 </template>
             </NavBarActions>

--- a/ui/tests/e2e/ai-copilot-tools.spec.ts
+++ b/ui/tests/e2e/ai-copilot-tools.spec.ts
@@ -1,5 +1,5 @@
-import {expect, test} from "@playwright/test"
-import {shared} from "./fixtures/shared"
+import {expect, test} from "./fixtures/auth"
+import {CHAT, openCopilotDock, sse, stubThreadCreation} from "./fixtures/copilot"
 
 /**
  * Per-tool end-to-end coverage for the AI Copilot v2 tool catalog.
@@ -13,13 +13,10 @@ import {shared} from "./fixtures/shared"
  * When the backend adds a tool, add it to PLATFORM_TOOLS / AUTHORING_TOOLS below.
  */
 
-const sse = (events: [string, unknown][]) =>
-    events.map(([event, data]) => `event: ${event}\ndata: ${JSON.stringify(data)}\n\n`).join("")
-
 const THREAD = {uid: "e2e-thread", mode: "EDIT", status: "IDLE", createdAt: "", updatedAt: ""}
 
 const D = {
-    chat: "[data-test=\"copilot-chat\"]",
+    chat: CHAT,
     input: "[data-test=\"copilot-composer-input\"]",
     send: "[data-test=\"copilot-send\"]",
     toolCall: "[data-test=\"copilot-tool-call\"]",
@@ -47,35 +44,10 @@ const AUTHORING_TOOLS = [
 
 test.describe("AI Copilot v2 — tool catalog", () => {
     test.beforeEach(async ({page}) => {
-        await page.route("**/api/v1/*/ai/threads", async (route) => {
-            if (route.request().method() === "POST") {
-                await route.fulfill({status: 200, contentType: "application/json", body: JSON.stringify(THREAD)})
-            } else {
-                await route.continue()
-            }
-        })
+        await stubThreadCreation(page, THREAD)
 
-        await test.step("login", async () => {
-            await page.goto("/ui")
-            await page.getByRole("textbox", {name: "Email"}).fill(shared.username)
-            await page.getByRole("textbox", {name: "Password"}).fill(shared.password)
-            await page.getByRole("button", {name: "Login"}).click()
-            await page.waitForTimeout(2000)
-            for (let i = 0; i < 3; i++) {
-                try { await page.goto("/ui", {waitUntil: "domcontentloaded"}); break } catch { await page.waitForTimeout(1000) }
-            }
-            await expect(page.getByRole("heading", {name: "Default Dashboard"})).toBeVisible({timeout: 25000})
-        })
-
-        await test.step("open the AI copilot dock tab", async () => {
-            const chat = page.locator(D.chat)
-            if (!(await chat.isVisible().catch(() => false))) {
-                await page.getByRole("button", {name: "Toggle panel"}).click().catch(() => {})
-                await page.waitForTimeout(500)
-            }
-            await page.getByRole("tab", {name: "AI"}).click().catch(() => {})
-            await expect(chat).toBeVisible({timeout: 15000})
-        })
+        await page.goto("/ui")
+        await openCopilotDock(page)
     })
 
     // Stub the next chat turn's SSE stream, then send a prompt.

--- a/ui/tests/e2e/ai-copilot.spec.ts
+++ b/ui/tests/e2e/ai-copilot.spec.ts
@@ -1,5 +1,5 @@
-import {expect, test} from "@playwright/test"
-import {shared} from "./fixtures/shared"
+import {expect, test} from "./fixtures/auth"
+import {CHAT, openCopilotDock, sse, stubThreadCreation} from "./fixtures/copilot"
 
 /**
  * End-to-end coverage for the AI Copilot chat drawer.
@@ -12,13 +12,10 @@ import {shared} from "./fixtures/shared"
  * Uses explicit `[data-test=…]` locators (the repo doesn't set testIdAttribute).
  */
 
-const sse = (events: [string, unknown][]) =>
-    events.map(([event, data]) => `event: ${event}\ndata: ${JSON.stringify(data)}\n\n`).join("")
-
 const THREAD = {uid: "e2e-thread", mode: "ASK", status: "IDLE", createdAt: "", updatedAt: ""}
 
 const D = {
-    chat: "[data-test=\"copilot-chat\"]",
+    chat: CHAT,
     input: "[data-test=\"copilot-composer-input\"]",
     send: "[data-test=\"copilot-send\"]",
     card: "[data-test=\"copilot-proposed-action\"]",
@@ -35,38 +32,10 @@ const FLOW_YAML = "id: applied\nnamespace: company.team\ntasks:\n  - id: log\n  
 test.describe("AI Copilot", () => {
     test.beforeEach(async ({page}) => {
         // Thread creation is always the same stubbed thread.
-        await page.route("**/api/v1/*/ai/threads", async (route) => {
-            if (route.request().method() === "POST") {
-                await route.fulfill({status: 200, contentType: "application/json", body: JSON.stringify(THREAD)})
-            } else {
-                await route.continue()
-            }
-        })
+        await stubThreadCreation(page, THREAD)
 
-        await test.step("login", async () => {
-            await page.goto("/ui")
-            await page.getByRole("textbox", {name: "Email"}).fill(shared.username)
-            await page.getByRole("textbox", {name: "Password"}).fill(shared.password)
-            await page.getByRole("button", {name: "Login"}).click()
-            // Reload so the auth cookie applies on a clean load. Let the post-login redirect
-            // settle first, and retry (the redirect can interrupt an eager goto).
-            await page.waitForURL(url => !url.pathname.includes("/login"))
-            for (let i = 0; i < 3; i++) {
-                try { await page.goto("/ui", {waitUntil: "domcontentloaded"}); break } catch { await page.waitForTimeout(1000) }
-            }
-            await expect(page.getByRole("heading", {name: "Default Dashboard"})).toBeVisible({timeout: 25000})
-        })
-
-        await test.step("open the AI copilot dock tab", async () => {
-            // The right panel is closed after login — toggle it open first, then select AI.
-            const chat = page.locator(D.chat)
-            if (!(await chat.isVisible().catch(() => false))) {
-                await page.getByRole("button", {name: "Toggle panel"}).click().catch(() => {})
-                await page.waitForTimeout(500)
-            }
-            await page.getByRole("tab", {name: "AI"}).click().catch(() => {})
-            await expect(chat).toBeVisible({timeout: 15000})
-        })
+        await page.goto("/ui")
+        await openCopilotDock(page)
     })
 
     test("streams an assistant answer", async ({page}) => {
@@ -338,13 +307,7 @@ test.describe("AI Copilot", () => {
         const tenant = new URL(page.url()).pathname.split("/")[2] || "main"
         await page.goto(`/ui/${tenant}/flows/edit/company.team/e2e-context-flow`, {waitUntil: "domcontentloaded"})
 
-        const chat = page.locator(D.chat)
-        if (!(await chat.isVisible().catch(() => false))) {
-            await page.getByRole("button", {name: "Toggle panel"}).click().catch(() => {})
-            await page.waitForTimeout(500)
-            await page.getByRole("tab", {name: "AI"}).click().catch(() => {})
-        }
-        await expect(chat).toBeVisible({timeout: 15000})
+        await openCopilotDock(page)
 
         const chip = page.locator("[data-test=\"copilot-context-chip\"]")
         await expect(chip).toBeVisible()
@@ -420,21 +383,8 @@ test.describe("AI Copilot", () => {
  * in the "page" layout. No dock here; we navigate straight to the route.
  */
 test.describe("AI Copilot — full-page /ai surface", () => {
-    test.beforeEach(async ({page}) => {
-        await test.step("login", async () => {
-            await page.goto("/ui")
-            await page.getByRole("textbox", {name: "Email"}).fill(shared.username)
-            await page.getByRole("textbox", {name: "Password"}).fill(shared.password)
-            await page.getByRole("button", {name: "Login"}).click()
-            await page.waitForTimeout(2000)
-            for (let i = 0; i < 3; i++) {
-                try { await page.goto("/ui", {waitUntil: "domcontentloaded"}); break } catch { await page.waitForTimeout(1000) }
-            }
-            await expect(page.getByRole("heading", {name: "Default Dashboard"})).toBeVisible({timeout: 25000})
-        })
-    })
-
     test("hosts the copilot full-page at /ai with the page-only Need Help section", async ({page}) => {
+        await page.goto("/ui")
         const tenant = new URL(page.url()).pathname.split("/")[2] || "main"
         await page.goto(`/ui/${tenant}/ai`, {waitUntil: "domcontentloaded"})
 

--- a/ui/tests/e2e/auth.setup.ts
+++ b/ui/tests/e2e/auth.setup.ts
@@ -1,0 +1,21 @@
+import {expect, test as setup} from "@playwright/test"
+import {shared} from "./fixtures/shared"
+import {STORAGE_STATE} from "./fixtures/auth"
+
+/**
+ * Signs in once per run and parks the resulting cookie jar for every other project
+ * to reuse, so no spec pays for the login form.
+ */
+setup("authenticate", async ({page, context}) => {
+    await page.goto("/ui")
+
+    await page.getByRole("textbox", {name: "Email"}).fill(shared.username)
+    await page.getByRole("textbox", {name: "Password"}).fill(shared.password)
+    await page.getByRole("button", {name: "Login"}).click()
+
+    // Anchor on the app shell, not the dashboard: on an instance with no flows yet the
+    // post-login redirect lands on the AI Copilot welcome page instead of the dashboard.
+    await expect(page.getByRole("button", {name: "Toggle panel"})).toBeVisible({timeout: 30000})
+
+    await context.storageState({path: STORAGE_STATE})
+})

--- a/ui/tests/e2e/executions/execution-bulk-actions.spec.ts
+++ b/ui/tests/e2e/executions/execution-bulk-actions.spec.ts
@@ -3,6 +3,11 @@ import {ExecutionState, Pagination} from "../pages/base.page"
 
 test.describe("Executions' view Bulk Actions", () => {
 
+    // Each test drives 27 real flow executions against the single shared Kestra instance,
+    // so keep them in one worker. `default` rather than `serial`: `serial` would skip the
+    // remaining tests after a failure and hide a second regression.
+    test.describe.configure({mode: "default"})
+
     test.describe("Set labels", () => {
         test.use({flow: {fileName: "hello.yaml", flowId: "my-hello-flow-1"}})
 
@@ -28,7 +33,6 @@ test.describe("Executions' view Bulk Actions", () => {
             })
 
             await test.step("Set label to 'foo:baz' using Select All on filtered 'foo:bar' executions", async () => {
-                await page.waitForTimeout(1500) // somehow the execution selection de-selects itself due a data load
                 await executionsPage.selectExecutionRowByNumber()
                 await executionsPage.clickOnSelectAll()
                 await executionsPage.clickOnSetLabels()
@@ -72,18 +76,17 @@ test.describe("Executions' view Bulk Actions", () => {
             })
 
             await test.step("Call Restart using Select All on filtered 'FAILED' & 'foo:bar' executions", async () => {
-                await page.waitForTimeout(1500) // somehow the execution selection de-selects itself due a data load
                 await executionsPage.selectExecutionRowByNumber()
                 await executionsPage.clickOnSelectAll()
                 await executionsPage.clickOnRestart()
             })
 
             await test.step("Show all 26 now successfully finished 'foo:bar' executions on a single page", async () => {
-                await page.waitForTimeout(2000) // ensure restarted executions finished
                 await executionsPage.setFilterByState(ExecutionState.SUCCESS)
                 await executionsPage.setPaginationTo(Pagination.ITEMS_50)
 
-                await executionsPage.expectCountOfExecutionsToBe(26)
+                // Restart is asynchronous — reload until the server has finished all 26.
+                await executionsPage.expectCountOfExecutionsToBeAfterRefresh(26)
             })
 
             await test.step("Switch filter to label 'a:b' which should not be affected by the Restart action", async () => {
@@ -122,17 +125,16 @@ test.describe("Executions' view Bulk Actions", () => {
             })
 
             await test.step("Call Replay using Select All on filtered 'FAILED' & 'foo:bar' executions", async () => {
-                await page.waitForTimeout(1500) // somehow the execution selection de-selects itself due a data load
                 await executionsPage.selectExecutionRowByNumber()
                 await executionsPage.clickOnSelectAll()
                 await executionsPage.clickOnReplay()
             })
 
             await test.step("Show 26 original and 26 replayed 'foo:bar' executions on a single page", async () => {
-                await page.waitForTimeout(2000) // ensure replayed executions finished
                 await executionsPage.setPaginationTo(Pagination.ITEMS_100)
 
-                expect(await executionsPage.getCountOfDisplayedExecutions()).toEqual(26 * 2)
+                // Replay is asynchronous — reload until the 26 replays have joined the originals.
+                await executionsPage.expectCountOfExecutionsToBeAfterRefresh(26 * 2)
             })
 
             await test.step("Switch filter to label 'a:b' which should not be affected by the Restart action", async () => {

--- a/ui/tests/e2e/fixtures/auth.ts
+++ b/ui/tests/e2e/fixtures/auth.ts
@@ -1,0 +1,40 @@
+import {test as base} from "@playwright/test"
+import path from "path"
+import {fileURLToPath} from "url"
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+
+/**
+ * Where the `setup` project parks the authenticated browser state.
+ *
+ * Absolute so it resolves the same whether Playwright is invoked from `ui/` or
+ * from the repository root.
+ */
+export const STORAGE_STATE = path.resolve(__dirname, "../.auth/user.json")
+
+/**
+ * Mirrors `AUTH_FLAG_KEY` in `ui/src/utils/basicAuth.ts`.
+ */
+const AUTH_FLAG_KEY = "kestraBasicAuthenticated"
+
+/**
+ * The `test` every spec should import.
+ *
+ * Signing in leaves two traces: the HttpOnly `BASIC_AUTH` cookie issued by the
+ * server, and a `sessionStorage` flag the router guard reads to decide whether a
+ * login round-trip ever happened. Playwright's `storageState` persists cookies and
+ * localStorage but *not* sessionStorage, so restoring it alone would hand the
+ * browser a valid session that the SPA still bounces to `/ui/login`. Re-seed the
+ * flag on every document instead.
+ */
+export const test = base.extend({
+    context: async ({context}, use) => {
+        await context.addInitScript(([key]) => {
+            sessionStorage.setItem(key, "true")
+        }, [AUTH_FLAG_KEY])
+
+        await use(context)
+    },
+})
+
+export {expect} from "@playwright/test"

--- a/ui/tests/e2e/fixtures/copilot.ts
+++ b/ui/tests/e2e/fixtures/copilot.ts
@@ -1,0 +1,41 @@
+import type {Page} from "@playwright/test"
+import {expect} from "@playwright/test"
+
+/**
+ * Shared plumbing for the AI Copilot specs.
+ *
+ * The AI endpoints are stubbed with `page.route` so the specs exercise the frontend
+ * turn machinery without a configured LLM provider.
+ */
+
+export const CHAT = "[data-test=\"copilot-chat\"]"
+
+/** Serialises events into the SSE wire format the copilot stream reader expects. */
+export const sse = (events: [string, unknown][]) =>
+    events.map(([event, data]) => `event: ${event}\ndata: ${JSON.stringify(data)}\n\n`).join("")
+
+/** Answers thread creation with a fixed thread, leaving every other verb alone. */
+export async function stubThreadCreation(page: Page, thread: Record<string, unknown>) {
+    await page.route("**/api/v1/*/ai/threads", async (route) => {
+        if (route.request().method() === "POST") {
+            await route.fulfill({status: 200, contentType: "application/json", body: JSON.stringify(thread)})
+        } else {
+            await route.continue()
+        }
+    })
+}
+
+/**
+ * Brings the copilot dock into view: the right panel starts collapsed, so it has to
+ * be toggled open before the AI tab can be selected.
+ */
+export async function openCopilotDock(page: Page) {
+    const chat = page.locator(CHAT)
+
+    if (!(await chat.isVisible())) {
+        await page.getByRole("button", {name: "Toggle panel"}).click()
+    }
+    await page.getByRole("tab", {name: "AI"}).click()
+
+    await expect(chat).toBeVisible()
+}

--- a/ui/tests/e2e/fixtures/executions.fixture.ts
+++ b/ui/tests/e2e/fixtures/executions.fixture.ts
@@ -1,4 +1,4 @@
-import {test as base} from "@playwright/test"
+import {test as base} from "./auth"
 import {ExecutionsPage} from "../pages/executions.page"
 import {ExecutionsApi} from "../api/executions.api"
 import {FlowsApi} from "../api/flows.api"
@@ -12,6 +12,24 @@ type ExecutionsFixtures = {
 export const test = base.extend<ExecutionsFixtures>({
     // define the default `flow` option
     flow: [{fileName: "hello.yaml", flowId: "my-hello-flow-1"}, {option: true}],
+    /*
+     * A deliberately cookie-free API context.
+     *
+     * The built-in `request` fixture inherits `use.storageState`, which now carries the
+     * BASIC_AUTH cookie. CsrfTokenFilter#hasCookieAuth then treats every POST/DELETE as
+     * cookie-authenticated and rejects it with a 403 unless it also carries an
+     * X-CSRF-TOKEN — but these helpers authenticate with the CSRF-exempt
+     * `Authorization: Basic` header instead. A fresh context keeps that path open.
+     */
+    request: async ({playwright, baseURL}, use) => {
+        const context = await playwright.request.newContext({
+            baseURL,
+            // Explicitly empty: `newContext` otherwise picks up the config's `use.storageState`.
+            storageState: {cookies: [], origins: []},
+        })
+        await use(context)
+        await context.dispose()
+    },
     executionsApi: async ({page, request,  baseURL, flow}, use) => {
         // Prepare data
         const flowsApi = new FlowsApi(request, baseURL)

--- a/ui/tests/e2e/flow.spec.ts
+++ b/ui/tests/e2e/flow.spec.ts
@@ -1,9 +1,11 @@
-import {expect, test} from "@playwright/test"
+import {expect, test} from "./fixtures/auth"
 import {v4 as uuidv4} from "uuid"
 import fs from "fs"
 import {fileURLToPath} from "url"
 import path from "path"
-import {shared} from "./fixtures/shared"
+
+// The repo doesn't set `testIdAttribute`, so `data-test` is matched by hand.
+const CREATE = "[data-test=\"flows-create\"]"
 
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = path.dirname(__filename)
@@ -18,17 +20,13 @@ test.describe("Flow Page", () => {
 
     let testUUID = ""
 
-    test.beforeEach(async ({page}) => {
+    // Both tests create and run real flows against the single shared Kestra instance, so
+    // keep them in one worker. `default` rather than `serial`: `serial` would skip the
+    // remaining tests after a failure and hide a second regression.
+    test.describe.configure({mode: "default"})
+
+    test.beforeEach(() => {
         testUUID = uuidv4().replace(/-/g, "_")
-
-        await page.goto("/ui")
-
-        await test.step("login", async () => {
-            await page.getByRole("textbox", {name: "Email"}).fill(shared.username)
-            await page.getByRole("textbox", {name: "Password"}).fill(shared.password)
-            await page.getByRole("button", {name: "Login"}).click()
-            await page.waitForURL(url => !url.pathname.includes("/login"))
-        })
     })
 
     test("should create and execute the example Flow", async ({page}) => {
@@ -37,7 +35,7 @@ test.describe("Flow Page", () => {
         await test.step("create the example Flow", async () => {
             await page.waitForURL("**/flows")
 
-            await page.getByRole("button", {name: "Create", exact: true}).click()
+            await page.locator(CREATE).click()
 
             await page.waitForURL("**/flows/new")
 
@@ -67,10 +65,12 @@ test.describe("Flow Page", () => {
         await page.goto("/ui/flows")
 
         await test.step("create a the flow by pasting the YAML", async () => {
-            await expect(page.getByRole("button", {name: "Create", exact: true})).toBeVisible()
-            await page.getByRole("button", {name: "Create", exact: true}).click()
+            await expect(page.locator(CREATE)).toBeVisible()
+            await page.locator(CREATE).click()
             await page.waitForURL("**/flows/new")
-            await page.getByTestId("monaco-editor").getByText("Hello World").isVisible()
+            // Must be awaited as an assertion: the `clear({force: true})` below skips
+            // actionability checks, so it would happily fire into an unmounted editor.
+            await expect(page.getByTestId("monaco-editor").getByText("Hello World")).toBeVisible()
 
             const monacoEditor = page.getByTestId("monaco-editor-hidden-synced-textarea")
             await monacoEditor.clear({force: true})

--- a/ui/tests/e2e/pages/base.page.ts
+++ b/ui/tests/e2e/pages/base.page.ts
@@ -1,23 +1,11 @@
 import type {Page} from "@playwright/test"
-import {expect} from "@playwright/test"
-import {shared} from "../fixtures/shared"
 
+/**
+ * There is no `login()` here: the session comes from the `setup` project's
+ * `storageState` (see `tests/e2e/auth.setup.ts`).
+ */
 export class BasePage {
     constructor(public readonly page: Page) { }
-
-    async login() {
-        await this.page.goto("/")
-        await this.page.getByRole("textbox", {name: "Email"}).fill(shared.username)
-        await this.page.getByRole("textbox", {name: "Password"}).fill(shared.password)
-        await this.page.getByRole("button", {name: "Login"}).click()
-
-        // wait for the url to not to contain login anymore, which means the login was successful
-        await this.page.waitForURL((url) => !url.toString().includes("login"), {timeout: 10000})
-
-        await this.page.goto("/")
-
-        await expect(this.page.getByRole("heading", {name: "Default Dashboard"})).toBeVisible()
-    }
 
     async addQueryParam(page: Page, key: string, value: string) {
         // Get the current URL

--- a/ui/tests/e2e/pages/executions.page.ts
+++ b/ui/tests/e2e/pages/executions.page.ts
@@ -4,7 +4,6 @@ import {BasePage, ExecutionState, Pagination} from "./base.page"
 
 export class ExecutionsPage extends BasePage {
     async goto() {
-        await this.login()
         await this.page.goto("/ui/executions")
 
         await expect(this.page.getByRole("heading", {name: "Executions"})).toBeVisible()
@@ -33,15 +32,20 @@ export class ExecutionsPage extends BasePage {
         return expect(this.page.getByRole("row")).toHaveCount(expectedCount + 1)
     }
 
-    async expectTotalExecutionsCountToBe(expectedCount: number) {
-        return expect(this.page.locator(".kel-pagination__total").first()).toHaveText(`Total ${expectedCount}`)
+    /**
+     * Same assertion, but for counts that only settle once the server finishes applying an
+     * asynchronous bulk action. The list is fetched on navigation and never polls, so the
+     * page has to be reloaded until the backend catches up.
+     */
+    async expectCountOfExecutionsToBeAfterRefresh(expectedCount: number) {
+        await expect(async () => {
+            await this.page.reload()
+            await expect(this.page.getByRole("row")).toHaveCount(expectedCount + 1, {timeout: 2000})
+        }).toPass({timeout: 60000})
     }
 
-    async getCountOfDisplayedExecutions() {
-        await this.page.waitForTimeout(20) // wait for data load to start
-        await this.page.waitForLoadState("networkidle") // wait for data load to finish
-        const rows = this.page.getByRole("row")
-        return await rows.count() - 1
+    async expectTotalExecutionsCountToBe(expectedCount: number) {
+        return expect(this.page.locator(".kel-pagination__total").first()).toHaveText(`Total ${expectedCount}`)
     }
 
     async getTotalExecutionsCount() {
@@ -63,9 +67,13 @@ export class ExecutionsPage extends BasePage {
         const checkbox = this.page.getByRole("row").nth(rowNumber).locator("label.kel-checkbox")
 
         await checkbox.waitFor({state: "visible"})
-        await checkbox.click()
 
-        await expect(checkbox).toContainClass("is-checked")
+        // A background data load can re-render the table and drop the selection, so retry
+        // until it sticks rather than sleeping first and hoping the reload already happened.
+        await expect(async () => {
+            await checkbox.click()
+            await expect(checkbox).toContainClass("is-checked", {timeout: 1000})
+        }).toPass({timeout: 15000})
     }
 
     async clickOnSelectAll() {
@@ -123,11 +131,11 @@ export class ExecutionsPage extends BasePage {
         const visibleDropdown = dropdowns.filter({has: this.page.locator(":visible")}).last()
 
         // Wait for the visible dropdown to actually appear
-        await visibleDropdown.waitFor({state: "visible", timeout: 500})
+        await visibleDropdown.waitFor({state: "visible"})
 
         // Find and click the matching option
         const option = visibleDropdown.locator(".kel-select-dropdown__item", {hasText: `${size} per page`})
-        await option.waitFor({state: "visible", timeout: 500})
+        await option.waitFor({state: "visible"})
         await option.click()
     }
 }

--- a/ui/tests/e2e/pages/flows.page.ts
+++ b/ui/tests/e2e/pages/flows.page.ts
@@ -4,7 +4,6 @@ import {BasePage} from "./base.page"
 
 export class FlowsPage extends BasePage {
     async goto() {
-        await this.login()
         await this.page.goto("/ui/main/flows")
 
         await expect(this.page.getByRole("heading", {name: "Flows"})).toBeVisible()

--- a/ui/tests/e2e/pages/mcp.page.ts
+++ b/ui/tests/e2e/pages/mcp.page.ts
@@ -1,7 +1,6 @@
 import type {Locator} from "@playwright/test"
 import {expect} from "@playwright/test"
 import {BasePage} from "./base.page"
-import {shared} from "../fixtures/shared"
 
 interface McpServerFormData {
     id?: string;
@@ -14,16 +13,6 @@ interface McpServerFormData {
 export class McpPage extends BasePage {
     async goto(): Promise<void> {
         await this.page.goto("/ui/main/admin/mcp-servers")
-
-        // If redirected to the login page, authenticate then navigate back
-        const emailInput = this.page.getByRole("textbox", {name: "Email"})
-        if (await emailInput.isVisible({timeout: 3000}).catch(() => false)) {
-            await emailInput.fill(shared.username)
-            await this.page.getByRole("textbox", {name: "Password"}).fill(shared.password)
-            await this.page.getByRole("button", {name: "Login"}).click()
-            await expect(this.page.getByRole("link", {name: "Flows"})).toBeVisible()
-            await this.page.goto("/ui/main/admin/mcp-servers")
-        }
 
         await expect(this.page.getByRole("heading", {name: "MCP Servers"})).toBeVisible()
     }

--- a/ui/tests/e2e/playwright.config.ts
+++ b/ui/tests/e2e/playwright.config.ts
@@ -4,6 +4,7 @@ dotenv.config({path: __dirname + "/.env"})
 
 import type {PlaywrightTestConfig} from "@playwright/test"
 import {devices} from "@playwright/test"
+import {STORAGE_STATE} from "./fixtures/auth"
 
 
 /**
@@ -33,10 +34,19 @@ const config: PlaywrightTestConfig = {
     fullyParallel: true,
     /* Fail the build on CI if you accidentally left test.only in the source code. */
     forbidOnly: !!process.env.CI,
-    /* Retry on CI only */
-    retries: process.env.CI ? 5 : 0,
-    /* Opt out of parallel tests on CI. */
-    workers: process.env.CI ? 1 : "50%",
+    /* Retry on CI only. Kept low: a genuinely broken test costs a full run per retry. */
+    retries: process.env.CI ? 2 : 0,
+    /*
+     * The CI runner has 4 vCPUs and also hosts the Kestra JVM, Postgres and dind, so the
+     * browsers compete with the backend under test. Two is the sweet spot; more makes the
+     * execution-heavy specs slower and flakier rather than faster.
+     */
+    workers: process.env.CI ? 2 : "50%",
+    /*
+     * Fail with an HTML report rather than being killed by the job's own 30-minute ceiling
+     * (set in kestra-io/actions), which leaves no artefacts at all.
+     */
+    globalTimeout: process.env.CI ? 20 * 60 * 1000 : undefined,
     /* Reporter to use. See https://playwright.dev/docs/test-reporters */
     reporter: [
         ["html", {open: "never"}],
@@ -48,22 +58,28 @@ const config: PlaywrightTestConfig = {
         /* Base URL to use in actions like `await page.goto("/")`. */
         baseURL: process.env.E2E_BASE_URL ?? "http://localhost:9011",
 
-        /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
-        trace: "retain-on-failure",
+        /*
+         * `on-first-retry` rather than `retain-on-failure`: the latter records a
+         * screencast and trace snapshots for *every* test and throws them away on
+         * pass, which every green test pays for.
+         */
+        trace: "on-first-retry",
         /* Capture screenshot after each test failure */
         screenshot: "only-on-failure",
-        /* Collect video when retrying the failed test */
-        video: "retain-on-failure",
-        launchOptions: {
-            slowMo: 100,
-        },
+        video: "on-first-retry",
     },
 
     /* Configure projects for major browsers */
     projects: [
+        /* Signs in once and parks the cookie jar the other projects reuse. */
+        {
+            name: "setup",
+            testMatch: /auth\.setup\.ts/,
+        },
         {
             name: "chromium",
-            use: {...devices["Desktop Chrome"]},
+            use: {...devices["Desktop Chrome"], storageState: STORAGE_STATE},
+            dependencies: ["setup"],
         },
     ],
 

--- a/ui/tests/unit/components/layout/NavBarAction.spec.ts
+++ b/ui/tests/unit/components/layout/NavBarAction.spec.ts
@@ -1,0 +1,62 @@
+import {describe, expect, test} from "vitest"
+import {mount} from "@vue/test-utils"
+import {createRouter, createWebHistory} from "vue-router"
+import NavBarAction from "../../../../src/components/layout/NavBarAction.vue"
+// The app registers the design system globally at bootstrap; unit mounts have to do it
+// themselves, and this spec is specifically about what KsButton puts in the DOM.
+import KsButton from "../../../../packages/design-system/src/components/Basic/KsButton/KsButton.vue"
+
+const router = createRouter({
+    history: createWebHistory(),
+    routes: [
+        {path: "/", name: "home", component: {template: "<div />"}},
+        {path: "/flows/new", name: "flows/create", component: {template: "<div />"}},
+    ],
+})
+
+const mountAction = (props: Record<string, unknown>, attrs: Record<string, unknown> = {}) =>
+    mount(NavBarAction, {
+        props,
+        attrs,
+        global: {
+            plugins: [router],
+            components: {KsButton},
+            // tests/unit/setup.ts stubs RouterLink with a bare `<a><slot /></a>` for the many
+            // specs that mount without a router. This one installs a real router and is about
+            // what actually reaches the DOM, so it needs the real component.
+            stubs: {RouterLink: false},
+        },
+    })
+
+describe("NavBarAction", () => {
+    test("renders an anchor, not a button, when given a `to` target", async () => {
+        await router.push("/")
+        await router.isReady()
+
+        const wrapper = mountAction({label: "Create", to: {name: "flows/create"}})
+
+        // This is why an e2e locator asking for role `button` can never match it.
+        expect(wrapper.get("a").attributes("href")).toBe("/flows/new")
+        expect(wrapper.find("button").exists()).toBe(false)
+    })
+
+    test("renders a button when there is no `to` target", () => {
+        const wrapper = mountAction({label: "Import"})
+
+        expect(wrapper.find("button").exists()).toBe(true)
+        expect(wrapper.find("a").exists()).toBe(false)
+    })
+
+    test("forwards data-test onto the rendered element so e2e can select it", async () => {
+        await router.push("/")
+        await router.isReady()
+
+        // NavBarAction and KsButton both set inheritAttrs: false and re-bind $attrs, so the
+        // attribute has to survive two hops before it reaches the DOM.
+        const asLink = mountAction({label: "Create", to: {name: "flows/create"}}, {"data-test": "flows-create"})
+        expect(asLink.get("[data-test=\"flows-create\"]").element.tagName).toBe("A")
+
+        const asButton = mountAction({label: "Import"}, {"data-test": "flows-import"})
+        expect(asButton.get("[data-test=\"flows-import\"]").element.tagName).toBe("BUTTON")
+    })
+})


### PR DESCRIPTION
## Why

The `E2E - Tests / check` job has a 30-minute ceiling and was sitting at or over it on every run. Across ~35 consecutive runs one afternoon, **not one went green** — they either failed fast or ran 1700–1817s and were killed.

Two independent problems, and only one of them was about speed.

### 1. `flow.spec.ts` could never pass

It looked up the flows-list Create action with `getByRole("button", …)`. That action carries a `to` prop, so `NavBarAction` renders it through `KsButton` with `:tag="RouterLink"` — an `<a href>`. The locator can never match, so both Flow Page tests burned all six attempts: **~8.5 min per run**, and the reason the job kept hitting its ceiling.

### 2. ~15s of every 17s test was harness overhead

The copilot specs' bodies are stubbed SSE strings that do almost no work. The `beforeEach` was doing a full form login, **two** `/ui` SPA cold boots (fresh context per test ⇒ no HTTP cache), a `waitForTimeout(2000)`, a `waitForTimeout(500)`, and `slowMo: 100` on every action.

## What changed

- **Create action gets a `data-test` hook** and the spec selects on it, per [ui/AGENTS.md](../blob/develop/ui/AGENTS.md). Not a role swap: `role="button"` on a real navigation would be an accessibility regression, and a hard-coded role is exactly what drifted here.
- **Log in once, not 31 times** — a `setup` project parks the cookie jar for the run.
- **Sleeps replaced by web-first assertions**, and the three copy-pasted copilot `beforeEach` blocks collapse into one shared helper.
- **CI config**: 2 workers instead of 1 (`fullyParallel` was already on), `slowMo` gone, `trace`/`video` on-first-retry instead of recording for every green test, retries 5 → 2, and a `globalTimeout` below the job's ceiling so an overrun produces a report instead of being killed with no artefacts.

### Two traps worth knowing about

**`storageState` does not persist sessionStorage.** `basicAuth.ts` keeps its "am I logged in?" flag there, and `main.ts`'s router guard reads it. Restoring cookies alone hands the browser a valid session that the SPA still bounces to `/ui/login` — the shared fixture re-seeds the flag with `addInitScript`.

**The `request` fixture inherits `use.storageState`.** Once the `BASIC_AUTH` cookie is on it, `CsrfTokenFilter#hasCookieAuth` starts demanding an `X-CSRF-TOKEN` on every POST/DELETE and 403s the flow/execution helpers, which authenticate with the CSRF-exempt `Authorization: Basic` header. The executions fixture builds its API context with an explicitly empty storage state. (Caught this the hard way — it 403s every bulk-action test otherwise.)

## Results

Measured locally against the e2e backend:

| | before | after |
|---|---|---|
| per copilot test | 17–22s | **5–7s** |
| `ai-copilot-tools.spec.ts` (13 tests) | ~4 min | **24.7s** |
| full suite, 2 workers | 30-min timeout | **5.8 min** |

All 26 copilot tests pass.

## Verification notes

- The 2 `flow.spec.ts` failures in my local runs are **expected**: the local harness runs the *published* `develop-no-plugins` image, which does not contain the `Flows.vue` change. CI builds the image from source (`build-and-start-e2e-tests.sh`), so it will have it. The `data-test` forwarding is covered by a unit test instead — it has to survive two `inheritAttrs: false` hops.
- The 2 `execution-bulk-actions` failures are **pre-existing locally**. I confirmed by stashing this branch and running the original code: it also fails 2 of 3 (a different 2). That spec is flaky against the published image before and after this change; CI is the real signal.

## Follow-up left out of scope

`execution-bulk-actions.spec.ts` calls `test.use({flow: …})` three times in one describe scope. Playwright merges those last-write-wins, so **all three tests currently run against `failure-then-success.yaml`** — the first test never exercises `hello.yaml` as intended. Fixing it changes what that test covers, which does not belong in a perf PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)