### PR TITLE
feat(flows): add Select All button to MULTISELECT input dropdown

### DIFF
--- a/ui/packages/design-system/src/components/Form/KsSelect/KsSelect.vue
+++ b/ui/packages/design-system/src/components/Form/KsSelect/KsSelect.vue
@@ -6,15 +6,17 @@
         <template v-if="$slots.prefix" #prefix>
             <slot name="prefix" />
         </template>
-        <template v-if="(selectAll && multiple) || $slots.header" #header>
-            <div v-if="selectAll && multiple" class="kel-select-all-header">
-                <button type="button" class="kel-select-all-btn" @click="selectAllVisible()">
-                    {{ $t('filter.select all') }}
-                </button>
-                <button v-if="model?.length" type="button" class="kel-select-all-btn" @click="model = []">
-                    {{ $t('filter.deselect all') }}
-                </button>
-            </div>
+        <template v-if="showSelectAll || $slots.header" #header>
+            <button
+                v-if="showSelectAll"
+                type="button"
+                class="kel-select-all-btn"
+                role="checkbox"
+                :aria-checked="allVisibleSelected ? 'true' : (someVisibleSelected ? 'mixed' : 'false')"
+                @click="toggleSelectAll()"
+            >
+                {{ $t('filter.select all') }}
+            </button>
             <slot v-if="$slots.header" name="header" />
         </template>
         <template v-if="$slots.footer" #footer>
@@ -81,10 +83,32 @@
 
     const elSelectRef = ref<InstanceType<typeof ElSelect>>()
 
-    const selectAllVisible = (): void => {
-        const opts: Array<{visible: boolean; value: any}> = (elSelectRef.value as any)?.optionsArray ?? []
-        const values = opts.filter(o => o.visible).map(o => o.value)
-        model.value = [...new Set([...(model.value ?? []), ...values])]
+    // Options passing ElSelect's own filter. `optionsArray` is exposed as a ComputedRef in the
+    // Element Plus types but unwrapped on the instance proxy, hence the cast.
+    const visibleOptions = computed<Array<{visible: boolean; value: any}>>(() =>
+        ((elSelectRef.value as any)?.optionsArray ?? []).filter((o: {visible: boolean}) => o.visible),
+    )
+
+    // Selecting nothing is meaningless, so the action stays hidden until there is something to select.
+    const showSelectAll = computed(() => Boolean(props.selectAll && props.multiple && visibleOptions.value.length))
+
+    const selectedValues = computed(() => new Set(Array.isArray(model.value) ? model.value : []))
+
+    const allVisibleSelected = computed(() =>
+        visibleOptions.value.length > 0 && visibleOptions.value.every(o => selectedValues.value.has(o.value)),
+    )
+
+    const someVisibleSelected = computed(() =>
+        !allVisibleSelected.value && visibleOptions.value.some(o => selectedValues.value.has(o.value)),
+    )
+
+    const toggleSelectAll = (): void => {
+        const values = visibleOptions.value.map(o => o.value)
+        model.value = allVisibleSelected.value
+            ? [...selectedValues.value].filter(v => !values.includes(v))
+            : [...new Set([...selectedValues.value, ...values])]
+        // Closing also clears the filter query, so the next open starts from the full list.
+        elSelectRef.value?.blur()
     }
 
     defineSlots<{
@@ -230,6 +254,33 @@
             box-shadow: none;
         }
 
+        .kel-select-dropdown__header {
+            padding: var(--ks-spacing-1);
+            border-bottom: 1px solid var(--ks-border-default);
+        }
+
+        .kel-select-all-btn {
+            display: block;
+            position: relative;
+            width: 100%;
+            background: none;
+            border: none;
+            border-radius: var(--ks-radius-xs);
+            cursor: pointer;
+            text-align: left;
+            font-family: inherit;
+            font-size: var(--ks-font-size-xs);
+            color: var(--ks-text-primary);
+            /* Mirrors the Element Plus option metrics — including the gutter kept free for the
+               check icon — so the row lines up with the list below. */
+            padding: 0 2rem 0 1.25rem;
+            height: 2.125rem;
+
+            &:hover {
+                background-color: var(--ks-bg-hover-elevated);
+            }
+        }
+
         .kel-select-dropdown__list {
             padding: var(--ks-spacing-1);
 
@@ -259,7 +310,8 @@
             }
         }
 
-        .kel-select-dropdown .kel-select-dropdown__item.is-selected::after {
+        .kel-select-dropdown .kel-select-dropdown__item.is-selected::after,
+        .kel-select-dropdown .kel-select-all-btn[aria-checked="true"]::after {
             content: "";
             position: absolute;
             right: 12px;
@@ -275,28 +327,5 @@
 
     .kel-icon.kel-select__caret.kel-select__icon {
         font-size: var(--ks-font-size-md);
-    }
-
-    .kel-select-all-header {
-        display: flex;
-        align-items: center;
-        justify-content: space-between;
-        padding: var(--ks-spacing-2) var(--ks-spacing-3);
-        border-bottom: 1px solid var(--ks-border-default);
-
-        .kel-select-all-btn {
-            background: none;
-            border: none;
-            padding: 0;
-            cursor: pointer;
-            font-family: inherit;
-            font-size: var(--ks-font-size-xs);
-            font-weight: var(--ks-font-weight-semibold);
-            color: var(--ks-text-link);
-
-            &:hover {
-                text-decoration: underline;
-            }
-        }
     }
 </style>

--- a/ui/packages/design-system/src/components/Form/KsSelect/KsSelect.vue
+++ b/ui/packages/design-system/src/components/Form/KsSelect/KsSelect.vue
@@ -1,13 +1,21 @@
 <template>
-    <ElSelect v-model="model" v-bind="({...filteredProps(), ...$attrs} as any)" :suffixIcon="resolvedSuffixIcon" :class="{'kel-select--fit': fit}" @change="emit('change', $event)">
+    <ElSelect ref="elSelectRef" v-model="model" v-bind="({...filteredProps(), ...$attrs} as any)" :suffixIcon="resolvedSuffixIcon" :class="{'kel-select--fit': fit}" @change="emit('change', $event)">
         <template v-if="$slots.default" #default>
             <slot />
         </template>
         <template v-if="$slots.prefix" #prefix>
             <slot name="prefix" />
         </template>
-        <template v-if="$slots.header" #header>
-            <slot name="header" />
+        <template v-if="(selectAll && multiple) || $slots.header" #header>
+            <div v-if="selectAll && multiple" class="kel-select-all-header">
+                <button type="button" class="kel-select-all-btn" @click="selectAllVisible()">
+                    {{ $t('filter.select all') }}
+                </button>
+                <button v-if="model?.length" type="button" class="kel-select-all-btn" @click="model = []">
+                    {{ $t('filter.deselect all') }}
+                </button>
+            </div>
+            <slot v-if="$slots.header" name="header" />
         </template>
         <template v-if="$slots.footer" #footer>
             <slot name="footer" />
@@ -22,7 +30,7 @@
 </template>
 
 <script setup lang="ts">
-    import {type Component, computed, h, markRaw} from "vue"
+    import {type Component, computed, h, markRaw, ref} from "vue"
     import {ElSelect} from "element-plus"
     import Loading from "vue-material-design-icons/Loading.vue"
     import KsIcon from "../../Basic/KsIcon.vue"
@@ -53,6 +61,7 @@
         suffixIcon?: Component | string
         loading?: boolean
         fit?: boolean
+        selectAll?: boolean
     }>(), {
         placeholder: undefined,
         size: undefined,
@@ -70,6 +79,14 @@
         change: [value: any]
     }>()
 
+    const elSelectRef = ref<InstanceType<typeof ElSelect>>()
+
+    const selectAllVisible = (): void => {
+        const opts: Array<{visible: boolean; value: any}> = (elSelectRef.value as any)?.optionsArray ?? []
+        const values = opts.filter(o => o.visible).map(o => o.value)
+        model.value = [...new Set([...(model.value ?? []), ...values])]
+    }
+
     defineSlots<{
         default?(): unknown
         prefix?(): unknown
@@ -79,7 +96,7 @@
         tag?(): unknown
     }>()
 
-    const filteredProps = useFilteredProps(props, ["fit", "suffixIcon", "loading"])
+    const filteredProps = useFilteredProps(props, ["fit", "suffixIcon", "loading", "selectAll"])
 
     // `loading` is intentionally NOT forwarded to ElSelect: ElSelect v-shows its option
     // list on `!loading`, so forwarding would hide still-valid options while they
@@ -258,5 +275,28 @@
 
     .kel-icon.kel-select__caret.kel-select__icon {
         font-size: var(--ks-font-size-md);
+    }
+
+    .kel-select-all-header {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        padding: var(--ks-spacing-2) var(--ks-spacing-3);
+        border-bottom: 1px solid var(--ks-border-default);
+
+        .kel-select-all-btn {
+            background: none;
+            border: none;
+            padding: 0;
+            cursor: pointer;
+            font-family: inherit;
+            font-size: var(--ks-font-size-xs);
+            font-weight: var(--ks-font-weight-semibold);
+            color: var(--ks-text-link);
+
+            &:hover {
+                text-decoration: underline;
+            }
+        }
     }
 </style>

--- a/ui/packages/design-system/tests/storybook/Form/KsSelect.stories.ts
+++ b/ui/packages/design-system/tests/storybook/Form/KsSelect.stories.ts
@@ -428,7 +428,7 @@ export const RichOptionContent: Story = {
     args: {size: "small", placeholder: "Previous versions"},
 }
 
-/** selectAll – "Select All / Deselect All" header for MULTISELECT flow inputs */
+/** selectAll – "Select All" header row for MULTISELECT flow inputs; selects every option matching the active filter, then closes the dropdown */
 export const SelectAll: Story = {
     render: (args) => ({
         components: {KsSelect, ElOption},
@@ -455,9 +455,7 @@ export const SelectAll: Story = {
         const canvas = within(canvasElement)
         const trigger = canvas.getByRole("combobox")
         await userEvent.click(trigger)
-        const header = document.querySelector(".kel-select-all-header")
-        await expect(header).toBeTruthy()
-        const selectAllBtn = header?.querySelector("button")
+        const selectAllBtn = document.querySelector(".kel-select-all-btn")
         await expect(selectAllBtn).toBeTruthy()
     },
 }

--- a/ui/packages/design-system/tests/storybook/Form/KsSelect.stories.ts
+++ b/ui/packages/design-system/tests/storybook/Form/KsSelect.stories.ts
@@ -19,6 +19,7 @@ const meta: Meta<typeof KsSelect> = {
         disabled: {control: "boolean"},
         allowCreate: {control: "boolean"},
         loading: {control: "boolean"},
+        selectAll: {control: "boolean"},
     },
     parameters: {
         docs: {
@@ -425,6 +426,40 @@ export const RichOptionContent: Story = {
         `,
     }),
     args: {size: "small", placeholder: "Previous versions"},
+}
+
+/** selectAll – "Select All / Deselect All" header for MULTISELECT flow inputs */
+export const SelectAll: Story = {
+    render: (args) => ({
+        components: {KsSelect, ElOption},
+        setup() {
+            const value = ref<string[]>([])
+            const JOBS = [
+                "CREATED", "RUNNING", "PAUSED",
+                "SUCCESS", "WARNING", "FAILED",
+                "KILLED", "CANCELLED",
+            ]
+            return {args, value, JOBS}
+        },
+        template: `
+            <div style="padding:24px;min-height:360px;display:flex;flex-direction:column;gap:12px">
+                <ks-select v-model="value" v-bind="args" style="width:300px">
+                    <ks-option v-for="j in JOBS" :key="j" :value="j" :label="j" />
+                </ks-select>
+                <span style="font-size:13px;opacity:0.6">Selected: {{ value.join(', ') || '(none)' }}</span>
+            </div>
+        `,
+    }),
+    args: {multiple: true, filterable: true, clearable: true, selectAll: true, placeholder: "Select statuses"},
+    async play({canvasElement}) {
+        const canvas = within(canvasElement)
+        const trigger = canvas.getByRole("combobox")
+        await userEvent.click(trigger)
+        const header = document.querySelector(".kel-select-all-header")
+        await expect(header).toBeTruthy()
+        const selectAllBtn = header?.querySelector("button")
+        await expect(selectAllBtn).toBeTruthy()
+    },
 }
 
 /** Label slot – as used in Plugin.vue for version display */

--- a/ui/packages/design-system/tests/units/Form/KsSelect.test.ts
+++ b/ui/packages/design-system/tests/units/Form/KsSelect.test.ts
@@ -1,6 +1,6 @@
 import {describe, test, expect, afterEach} from "vitest"
 import {mount} from "@vue/test-utils"
-import {defineComponent, ref} from "vue"
+import {defineComponent, nextTick, ref} from "vue"
 import {createI18n} from "vue-i18n"
 import {ElSelect} from "element-plus"
 import KestraDesignSystem from "../../../src/index"
@@ -99,32 +99,82 @@ describe("KsSelect", () => {
             document.body.innerHTML = ""
         })
 
-        test("renders select-all header when selectAll and multiple are true", () => {
+        /**
+         * The button's visibility derives from ElSelect's registered options, reached through a
+         * template ref that is only populated after the first render — so it appears one tick in.
+         */
+        const mountAndSettle = async (component: Parameters<typeof mount>[0]) => {
+            const wrapper = mount(component, {global: globalConfig})
+            await nextTick()
+            return wrapper
+        }
+
+        test("renders select-all button when selectAll and multiple are true", async () => {
+            await mountAndSettle(
+                defineComponent({
+                    components: {KsSelect, KsOption},
+                    template: `<ks-select :selectAll="true" :multiple="true">
+                        <ks-option value="A" label="Alpha" />
+                    </ks-select>`,
+                }),
+            )
+            expect(document.querySelector(".kel-select-all-btn")).toBeTruthy()
+        })
+
+        test("does not render select-all button when there are no options", () => {
             mount(KsSelect, {
                 props: {selectAll: true, multiple: true},
                 global: globalConfig,
             })
-            expect(document.querySelector(".kel-select-all-header")).toBeTruthy()
+            expect(document.querySelector(".kel-select-all-btn")).toBeFalsy()
         })
 
-        test("does not render select-all header when selectAll is true but multiple is false", () => {
-            mount(KsSelect, {
-                props: {selectAll: true, multiple: false},
-                global: globalConfig,
-            })
-            expect(document.querySelector(".kel-select-all-header")).toBeFalsy()
+        test("does not render select-all button when the filter matches no option", async () => {
+            const wrapper = await mountAndSettle(
+                defineComponent({
+                    components: {KsSelect, KsOption},
+                    template: `<ks-select :selectAll="true" :multiple="true" :filterable="true">
+                        <ks-option value="A" label="Alpha" />
+                        <ks-option value="B" label="Beta" />
+                    </ks-select>`,
+                }),
+            )
+            expect(document.querySelector(".kel-select-all-btn")).toBeTruthy()
+            const elSelect = wrapper.findComponent(ElSelect).vm as unknown as {states: {inputValue: string}}
+            elSelect.states.inputValue = "zzz"
+            await nextTick()
+            await nextTick()
+            expect(document.querySelector(".kel-select-all-btn")).toBeFalsy()
         })
 
-        test("does not render select-all header when multiple is true but selectAll is false", () => {
-            mount(KsSelect, {
-                props: {multiple: true},
-                global: globalConfig,
-            })
-            expect(document.querySelector(".kel-select-all-header")).toBeFalsy()
+        test("does not render select-all button when selectAll is true but multiple is false", () => {
+            mount(
+                defineComponent({
+                    components: {KsSelect, KsOption},
+                    template: `<ks-select :selectAll="true" :multiple="false">
+                        <ks-option value="A" label="Alpha" />
+                    </ks-select>`,
+                }),
+                {global: globalConfig},
+            )
+            expect(document.querySelector(".kel-select-all-btn")).toBeFalsy()
+        })
+
+        test("does not render select-all button when multiple is true but selectAll is false", () => {
+            mount(
+                defineComponent({
+                    components: {KsSelect, KsOption},
+                    template: `<ks-select :multiple="true">
+                        <ks-option value="A" label="Alpha" />
+                    </ks-select>`,
+                }),
+                {global: globalConfig},
+            )
+            expect(document.querySelector(".kel-select-all-btn")).toBeFalsy()
         })
 
         test("clicking select-all button updates model with all visible options", async () => {
-            const wrapper = mount(
+            const wrapper = await mountAndSettle(
                 defineComponent({
                     components: {KsSelect, KsOption},
                     template: `<ks-select v-model="value" :selectAll="true" :multiple="true">
@@ -136,49 +186,155 @@ describe("KsSelect", () => {
                         return {value: ref([])}
                     },
                 }),
-                {global: globalConfig},
             )
-            const btn = document.querySelector(".kel-select-all-header button") as HTMLButtonElement
+            const btn = document.querySelector(".kel-select-all-btn") as HTMLButtonElement
             btn.click()
-            await wrapper.vm.$nextTick()
+            await nextTick()
             const emitted = wrapper.findComponent(KsSelect).emitted("update:modelValue")
             expect(emitted).toBeTruthy()
-            expect(emitted![0][0]).toEqual(expect.arrayContaining(["A", "B", "C"]))
+            expect(emitted![0][0]).toEqual(["A", "B", "C"])
         })
 
-        test("deselect-all button is not shown when model is empty", () => {
-            mount(KsSelect, {
-                props: {selectAll: true, multiple: true, modelValue: []},
-                global: globalConfig,
-            })
-            const btns = document.querySelectorAll(".kel-select-all-header button")
-            expect(btns.length).toBe(1)
-        })
-
-        test("deselect-all button shown when model has values, and clears model on click", async () => {
-            const wrapper = mount(KsSelect, {
-                props: {selectAll: true, multiple: true, modelValue: ["A", "B"]},
-                global: globalConfig,
-            })
-            const btns = document.querySelectorAll(".kel-select-all-header button")
-            expect(btns.length).toBe(2)
-            ;(btns[1] as HTMLButtonElement).click()
-            await wrapper.vm.$nextTick()
-            expect(wrapper.emitted("update:modelValue")).toBeTruthy()
-            expect(wrapper.emitted("update:modelValue")![0]).toEqual([[]])
-        })
-
-        test("custom header slot renders alongside selectAll header", () => {
-            mount(
+        test("clicking select-all button closes the dropdown", async () => {
+            const wrapper = await mountAndSettle(
                 defineComponent({
-                    components: {KsSelect},
-                    template: `<ks-select :selectAll="true" :multiple="true">
-                        <template #header><span class="custom-header">custom</span></template>
+                    components: {KsSelect, KsOption},
+                    template: `<ks-select v-model="value" :selectAll="true" :multiple="true">
+                        <ks-option value="A" label="Alpha" />
+                    </ks-select>`,
+                    setup() {
+                        return {value: ref([])}
+                    },
+                }),
+            )
+            const elSelect = wrapper.findComponent(ElSelect).vm as unknown as {expanded: boolean}
+            ;(document.querySelector(".kel-select-all-btn") as HTMLButtonElement).click()
+            await nextTick()
+            expect(elSelect.expanded).toBe(false)
+        })
+
+        test("select-all reports unchecked when nothing is selected", async () => {
+            await mountAndSettle(
+                defineComponent({
+                    components: {KsSelect, KsOption},
+                    template: `<ks-select :modelValue="[]" :selectAll="true" :multiple="true">
+                        <ks-option value="A" label="Alpha" />
+                        <ks-option value="B" label="Beta" />
                     </ks-select>`,
                 }),
-                {global: globalConfig},
             )
-            expect(document.querySelector(".kel-select-all-header")).toBeTruthy()
+            expect(document.querySelector(".kel-select-all-btn")?.getAttribute("aria-checked")).toBe("false")
+        })
+
+        test("select-all reports mixed when only some options are selected", async () => {
+            await mountAndSettle(
+                defineComponent({
+                    components: {KsSelect, KsOption},
+                    template: `<ks-select :modelValue="['A']" :selectAll="true" :multiple="true">
+                        <ks-option value="A" label="Alpha" />
+                        <ks-option value="B" label="Beta" />
+                    </ks-select>`,
+                }),
+            )
+            expect(document.querySelector(".kel-select-all-btn")?.getAttribute("aria-checked")).toBe("mixed")
+        })
+
+        test("select-all reports checked when every option is selected", async () => {
+            await mountAndSettle(
+                defineComponent({
+                    components: {KsSelect, KsOption},
+                    template: `<ks-select :modelValue="['A', 'B']" :selectAll="true" :multiple="true">
+                        <ks-option value="A" label="Alpha" />
+                        <ks-option value="B" label="Beta" />
+                    </ks-select>`,
+                }),
+            )
+            expect(document.querySelector(".kel-select-all-btn")?.getAttribute("aria-checked")).toBe("true")
+        })
+
+        test("clicking select-all while fully selected deselects every visible option", async () => {
+            const wrapper = await mountAndSettle(
+                defineComponent({
+                    components: {KsSelect, KsOption},
+                    template: `<ks-select v-model="value" :selectAll="true" :multiple="true">
+                        <ks-option value="A" label="Alpha" />
+                        <ks-option value="B" label="Beta" />
+                    </ks-select>`,
+                    setup() {
+                        return {value: ref(["A", "B"])}
+                    },
+                }),
+            )
+            ;(document.querySelector(".kel-select-all-btn") as HTMLButtonElement).click()
+            await nextTick()
+            const emitted = wrapper.findComponent(KsSelect).emitted("update:modelValue")
+            expect(emitted).toBeTruthy()
+            expect(emitted!.at(-1)![0]).toEqual([])
+        })
+
+        test("deselecting a filtered subset keeps selections outside the filter", async () => {
+            const wrapper = await mountAndSettle(
+                defineComponent({
+                    components: {KsSelect, KsOption},
+                    template: `<ks-select v-model="value" :selectAll="true" :multiple="true" :filterable="true">
+                        <ks-option value="A" label="Alpha" />
+                        <ks-option value="B" label="Alpine" />
+                        <ks-option value="C" label="Beta" />
+                    </ks-select>`,
+                    setup() {
+                        return {value: ref(["A", "B", "C"])}
+                    },
+                }),
+            )
+            const elSelect = wrapper.findComponent(ElSelect).vm as unknown as {states: {inputValue: string}}
+            elSelect.states.inputValue = "alp"
+            await nextTick()
+            await nextTick()
+            ;(document.querySelector(".kel-select-all-btn") as HTMLButtonElement).click()
+            await nextTick()
+            const emitted = wrapper.findComponent(KsSelect).emitted("update:modelValue")
+            expect(emitted!.at(-1)![0]).toEqual(["C"])
+        })
+
+        test("select-all button only selects options matching the active filter", async () => {
+            const wrapper = await mountAndSettle(
+                defineComponent({
+                    components: {KsSelect, KsOption},
+                    template: `<ks-select v-model="value" :selectAll="true" :multiple="true" :filterable="true">
+                        <ks-option value="A" label="Alpha" />
+                        <ks-option value="B" label="Alpine" />
+                        <ks-option value="C" label="Beta" />
+                    </ks-select>`,
+                    setup() {
+                        return {value: ref([])}
+                    },
+                }),
+            )
+            // Setting the query the way ElSelect's own input handler does; a watchEffect then
+            // re-runs each option's real filter predicate and updates its `visible` flag.
+            const elSelect = wrapper.findComponent(ElSelect).vm as unknown as {states: {inputValue: string}}
+            elSelect.states.inputValue = "alp"
+            await nextTick()
+            await nextTick()
+            ;(document.querySelector(".kel-select-all-btn") as HTMLButtonElement).click()
+            await nextTick()
+            const emitted = wrapper.findComponent(KsSelect).emitted("update:modelValue")
+            expect(emitted).toBeTruthy()
+            // "Alpha" and "Alpine" match "alp"; "Beta" does not.
+            expect(emitted!.at(-1)![0]).toEqual(["A", "B"])
+        })
+
+        test("custom header slot renders alongside select-all button", async () => {
+            await mountAndSettle(
+                defineComponent({
+                    components: {KsSelect, KsOption},
+                    template: `<ks-select :selectAll="true" :multiple="true">
+                        <template #header><span class="custom-header">custom</span></template>
+                        <ks-option value="A" label="Alpha" />
+                    </ks-select>`,
+                }),
+            )
+            expect(document.querySelector(".kel-select-all-btn")).toBeTruthy()
             expect(document.querySelector(".custom-header")).toBeTruthy()
         })
 
@@ -192,7 +348,7 @@ describe("KsSelect", () => {
                 }),
                 {global: globalConfig},
             )
-            expect(document.querySelector(".kel-select-all-header")).toBeFalsy()
+            expect(document.querySelector(".kel-select-all-btn")).toBeFalsy()
             expect(document.querySelector(".custom-header")).toBeTruthy()
         })
     })

--- a/ui/packages/design-system/tests/units/Form/KsSelect.test.ts
+++ b/ui/packages/design-system/tests/units/Form/KsSelect.test.ts
@@ -1,12 +1,14 @@
-import {describe, test, expect} from "vitest"
+import {describe, test, expect, afterEach} from "vitest"
 import {mount} from "@vue/test-utils"
-import {defineComponent} from "vue"
+import {defineComponent, ref} from "vue"
+import {createI18n} from "vue-i18n"
 import {ElSelect} from "element-plus"
 import KestraDesignSystem from "../../../src/index"
 import KsSelect from "../../../src/components/Form/KsSelect/KsSelect.vue"
 import KsOption from "../../../src/components/Form/KsSelect/KsOption.vue"
 
-const globalConfig = {plugins: [KestraDesignSystem]}
+const i18n = createI18n({legacy: false, locale: "en"})
+const globalConfig = {plugins: [i18n, KestraDesignSystem]}
 
 describe("KsSelect", () => {
     test("renders trigger with placeholder", () => {
@@ -88,5 +90,110 @@ describe("KsSelect", () => {
             global: globalConfig,
         })
         expect(wrapper.find(".kel-icon.is-loading").exists()).toBe(false)
+    })
+
+    describe("selectAll", () => {
+        // ElSelect teleports dropdown content to document.body — use document.querySelector
+        // for anything inside the dropdown (header, options).
+        afterEach(() => {
+            document.body.innerHTML = ""
+        })
+
+        test("renders select-all header when selectAll and multiple are true", () => {
+            mount(KsSelect, {
+                props: {selectAll: true, multiple: true},
+                global: globalConfig,
+            })
+            expect(document.querySelector(".kel-select-all-header")).toBeTruthy()
+        })
+
+        test("does not render select-all header when selectAll is true but multiple is false", () => {
+            mount(KsSelect, {
+                props: {selectAll: true, multiple: false},
+                global: globalConfig,
+            })
+            expect(document.querySelector(".kel-select-all-header")).toBeFalsy()
+        })
+
+        test("does not render select-all header when multiple is true but selectAll is false", () => {
+            mount(KsSelect, {
+                props: {multiple: true},
+                global: globalConfig,
+            })
+            expect(document.querySelector(".kel-select-all-header")).toBeFalsy()
+        })
+
+        test("clicking select-all button updates model with all visible options", async () => {
+            const wrapper = mount(
+                defineComponent({
+                    components: {KsSelect, KsOption},
+                    template: `<ks-select v-model="value" :selectAll="true" :multiple="true">
+                        <ks-option value="A" label="Alpha" />
+                        <ks-option value="B" label="Beta" />
+                        <ks-option value="C" label="Gamma" />
+                    </ks-select>`,
+                    setup() {
+                        return {value: ref([])}
+                    },
+                }),
+                {global: globalConfig},
+            )
+            const btn = document.querySelector(".kel-select-all-header button") as HTMLButtonElement
+            btn.click()
+            await wrapper.vm.$nextTick()
+            const emitted = wrapper.findComponent(KsSelect).emitted("update:modelValue")
+            expect(emitted).toBeTruthy()
+            expect(emitted![0][0]).toEqual(expect.arrayContaining(["A", "B", "C"]))
+        })
+
+        test("deselect-all button is not shown when model is empty", () => {
+            mount(KsSelect, {
+                props: {selectAll: true, multiple: true, modelValue: []},
+                global: globalConfig,
+            })
+            const btns = document.querySelectorAll(".kel-select-all-header button")
+            expect(btns.length).toBe(1)
+        })
+
+        test("deselect-all button shown when model has values, and clears model on click", async () => {
+            const wrapper = mount(KsSelect, {
+                props: {selectAll: true, multiple: true, modelValue: ["A", "B"]},
+                global: globalConfig,
+            })
+            const btns = document.querySelectorAll(".kel-select-all-header button")
+            expect(btns.length).toBe(2)
+            ;(btns[1] as HTMLButtonElement).click()
+            await wrapper.vm.$nextTick()
+            expect(wrapper.emitted("update:modelValue")).toBeTruthy()
+            expect(wrapper.emitted("update:modelValue")![0]).toEqual([[]])
+        })
+
+        test("custom header slot renders alongside selectAll header", () => {
+            mount(
+                defineComponent({
+                    components: {KsSelect},
+                    template: `<ks-select :selectAll="true" :multiple="true">
+                        <template #header><span class="custom-header">custom</span></template>
+                    </ks-select>`,
+                }),
+                {global: globalConfig},
+            )
+            expect(document.querySelector(".kel-select-all-header")).toBeTruthy()
+            expect(document.querySelector(".custom-header")).toBeTruthy()
+        })
+
+        test("custom header slot renders alone when selectAll is not set", () => {
+            mount(
+                defineComponent({
+                    components: {KsSelect},
+                    template: `<ks-select :multiple="true">
+                        <template #header><span class="custom-header">custom</span></template>
+                    </ks-select>`,
+                }),
+                {global: globalConfig},
+            )
+            expect(document.querySelector(".kel-select-all-header")).toBeFalsy()
+            expect(document.querySelector(".custom-header")).toBeTruthy()
+        })
     })
 })

--- a/ui/src/components/inputs/InputsForm.vue
+++ b/ui/src/components/inputs/InputsForm.vue
@@ -79,6 +79,7 @@
                     multiple
                     filterable
                     clearable
+                    selectAll
                     :allowCreate="input.allowCustomValue"
                     :disabled="isComputingInput(input.id)"
                     :placeholder="isComputingInput(input.id) ? t('loading') : undefined"


### PR DESCRIPTION
All PRs submitted by external contributors that do not follow this template (including proper description, related issue, and checklist sections) **may be automatically closed**.

As a general practice, if you plan to work on a specific issue, comment on the issue first and wait to be assigned before starting any actual work. This avoids duplicated work and ensures a smooth contribution process - otherwise, the PR **may be automatically closed**.

---

### ✨ Description

What does this PR change?  
Adds a selectAll prop to the KsSelect design system component. When passed, a "Select All" and "Deselect All" button appears at the top of the dropdown. The MULTISELECT input in the Execute flow dialog uses this prop to let users select or clear all options in one click.

### 🔗 Related Issue

 Closes https://github.com/kestra-io/kestra/issues/17639

### 🎨 Frontend Checklist

- [x] Code builds without errors (`npm run build`)
- [ ] All existing E2E tests pass (`npm run test:e2e`)
- [x] Screenshots or video recordings attached showing the `UI` changes
<img width="1234" height="551" alt="image" src="https://github.com/user-attachments/assets/1985ef5a-2648-45ea-8118-d0873108fdb5" />



### 📝 Additional Notes
Added "Deselect All" button alongside "Select All" as it felt like a natural companion it only appears once at least one item is selected. Let me know if you'd prefer to remove it and keep only "Select All".