### PR TITLE
Fix git config in SDK update workflow

### DIFF
--- a/.github/workflows/update-generated-sdk.yml
+++ b/.github/workflows/update-generated-sdk.yml
@@ -62,6 +62,9 @@ jobs:
       - name: Checkout the chore/update-kestra-sdk branch
         shell: bash
         run: |
+          # the merge below creates a merge commit, which requires a committer identity
+          git config user.name "kestra-io"
+          git config user.email "hello@kestra.io"
           # the checkout above is a single-branch clone of develop, so the remote chore
           # branch is not present locally. Fetch it, with its history, explicitly first.
           git fetch origin chore/update-kestra-sdk || true


### PR DESCRIPTION
### ✨ Description

Adds git user configuration to the SDK update workflow before performing a merge operation. The merge commit creation requires a committer identity to be set, which was previously missing and could cause the workflow to fail.

### 🔗 Related Issue

N/A

### 🛠️ Backend Checklist

- [x] Code compiles successfully and passes all checks
- [x] Workflow configuration is valid

### 📝 Additional Notes

This is a minimal fix to the GitHub Actions workflow that configures git user identity (`user.name` and `user.email`) before executing a merge operation. This ensures the automated SDK update workflow can successfully create merge commits without authentication errors.

The change is placed immediately before the git fetch operation with an explanatory comment indicating why the configuration is necessary.

https://claude.ai/code/session_01CiHfGuZxVycHwMdHZHEhmu