### PR TITLE
Refactor executions page pagination and bulk action tests

### DIFF
--- a/ui/tests/e2e/executions/execution-bulk-actions.spec.ts
+++ b/ui/tests/e2e/executions/execution-bulk-actions.spec.ts
@@ -81,12 +81,11 @@ test.describe("Executions' view Bulk Actions", () => {
                 await executionsPage.clickOnRestart()
             })
 
-            await test.step("Show all 26 now successfully finished 'foo:bar' executions on a single page", async () => {
+            await test.step("Count all 26 'foo:bar' executions as successfully finished", async () => {
                 await executionsPage.setFilterByState(ExecutionState.SUCCESS)
-                await executionsPage.setPaginationTo(Pagination.ITEMS_50)
 
                 // Restart is asynchronous — reload until the server has finished all 26.
-                await executionsPage.expectCountOfExecutionsToBeAfterRefresh(26)
+                await executionsPage.expectTotalExecutionsCountToBeAfterRefresh(26)
             })
 
             await test.step("Switch filter to label 'a:b' which should not be affected by the Restart action", async () => {
@@ -130,11 +129,9 @@ test.describe("Executions' view Bulk Actions", () => {
                 await executionsPage.clickOnReplay()
             })
 
-            await test.step("Show 26 original and 26 replayed 'foo:bar' executions on a single page", async () => {
-                await executionsPage.setPaginationTo(Pagination.ITEMS_100)
-
+            await test.step("Count 26 original and 26 replayed 'foo:bar' executions", async () => {
                 // Replay is asynchronous — reload until the 26 replays have joined the originals.
-                await executionsPage.expectCountOfExecutionsToBeAfterRefresh(26 * 2)
+                await executionsPage.expectTotalExecutionsCountToBeAfterRefresh(26 * 2)
             })
 
             await test.step("Switch filter to label 'a:b' which should not be affected by the Restart action", async () => {

--- a/ui/tests/e2e/pages/executions.page.ts
+++ b/ui/tests/e2e/pages/executions.page.ts
@@ -3,6 +3,11 @@ import {expect} from "@playwright/test"
 import {BasePage, ExecutionState, Pagination} from "./base.page"
 
 export class ExecutionsPage extends BasePage {
+    /** The "Total N" counter of the pagination bar, scoped to the outermost table. */
+    private get totalLocator() {
+        return this.page.locator(".kel-pagination__total").first()
+    }
+
     async goto() {
         await this.page.goto("/ui/executions")
 
@@ -36,20 +41,24 @@ export class ExecutionsPage extends BasePage {
      * Same assertion, but for counts that only settle once the server finishes applying an
      * asynchronous bulk action. The list is fetched on navigation and never polls, so the
      * page has to be reloaded until the backend catches up.
+     *
+     * Asserts the pagination total rather than the row count: what matters is that the server
+     * finished the action, and a row count would additionally depend on the selected page size.
      */
-    async expectCountOfExecutionsToBeAfterRefresh(expectedCount: number) {
+    async expectTotalExecutionsCountToBeAfterRefresh(expectedCount: number) {
         await expect(async () => {
             await this.page.reload()
-            await expect(this.page.getByRole("row")).toHaveCount(expectedCount + 1, {timeout: 2000})
+            // Short per-attempt timeout: the retry above is what waits, not this assertion.
+            await expect(this.totalLocator).toHaveText(`Total ${expectedCount}`, {timeout: 2000})
         }).toPass({timeout: 60000})
     }
 
     async expectTotalExecutionsCountToBe(expectedCount: number) {
-        return expect(this.page.locator(".kel-pagination__total").first()).toHaveText(`Total ${expectedCount}`)
+        return expect(this.totalLocator).toHaveText(`Total ${expectedCount}`)
     }
 
     async getTotalExecutionsCount() {
-        const content = await this.page.locator(".kel-pagination__total").first().textContent()
+        const content = await this.totalLocator.textContent()
         if (!content) {
             throw new Error("Totals not found")
         }
@@ -122,20 +131,21 @@ export class ExecutionsPage extends BasePage {
         await this.page.waitForLoadState("networkidle")
     }
 
+    /*
+     * Sets the page size through the query param the view derives it from, rather than through
+     * the pagination dropdown, for the same reason the filter helpers above do:
+     *
+     *  - The dropdown handler pushes `size=` onto the route without awaiting it, and that push
+     *    sits behind async router guards. A `reload()` or a `goto()` rebuilt from `page.url()`
+     *    right after the click navigates to the pre-click URL and silently drops the selection,
+     *    leaving the list on its previous size for the rest of the test.
+     *  - Element Plus swallows a click on the size already in effect (`sizes.vue` bails out when
+     *    the clicked value equals the current one), so there is not even an event to wait on in
+     *    that case — the wait would simply time out.
+     *
+     * `page.goto` is awaited end to end, so the size is guaranteed to be in effect on return.
+     */
     async setPaginationTo(size: Pagination) {
-        // The Element-Plus dropdown is not a `select` - click on text
-        await this.page.locator(".kel-pagination .kel-select").click()
-
-        // Wait for the select dropdown to show
-        const dropdowns = this.page.locator(".kel-select-dropdown")
-        const visibleDropdown = dropdowns.filter({has: this.page.locator(":visible")}).last()
-
-        // Wait for the visible dropdown to actually appear
-        await visibleDropdown.waitFor({state: "visible"})
-
-        // Find and click the matching option
-        const option = visibleDropdown.locator(".kel-select-dropdown__item", {hasText: `${size} per page`})
-        await option.waitFor({state: "visible"})
-        await option.click()
+        await this.modifyQueryParam(this.page, {size: String(size)})
     }
 }


### PR DESCRIPTION
### ✨ Description

This PR refactors the executions page test utilities and bulk action tests to improve reliability and maintainability:

**Key changes:**

1. **Extract pagination total locator**: Created a private `totalLocator` getter to centralize access to the pagination total counter, reducing duplication across multiple methods.

2. **Improve async bulk action assertions**: Renamed `expectCountOfExecutionsToBeAfterRefresh()` to `expectTotalExecutionsCountToBeAfterRefresh()` and changed it to assert the pagination total instead of row count. This is more reliable because:
   - The pagination total directly reflects server state after async operations complete
   - Row count depends on the current page size, making assertions fragile
   - Added short per-attempt timeout with longer overall retry timeout for better test stability

3. **Simplify pagination size setting**: Replaced the fragile Element Plus dropdown interaction in `setPaginationTo()` with direct query parameter modification via `modifyQueryParam()`. This avoids race conditions where async router guards could cause the selection to be silently dropped.

4. **Update bulk action tests**: Removed unnecessary pagination size changes from test steps since assertions now use the pagination total (which is page-size independent). Updated test descriptions to reflect the actual assertions being made.

5. **Improve code documentation**: Added comprehensive comments explaining why query parameters are used instead of UI interactions for pagination.

### 🔗 Related Issue

No specific issue referenced.

### 🎨 Frontend Checklist

- [x] Code builds without errors
- [x] All existing E2E tests pass (tests updated to use more reliable assertions)
- [x] Changes improve test reliability and maintainability

### 📝 Additional Notes

These changes make the E2E tests more robust by:
- Reducing coupling to UI implementation details (Element Plus dropdown)
- Using server state (pagination total) rather than rendered row count for async operation verification
- Centralizing pagination total access to prevent future inconsistencies

https://claude.ai/code/session_019LsyeuYQWqmb9NXxaKFWjA