### PR TITLE
perf(tests): speed up the E2E CI job

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,8 +44,10 @@ buildSkipTests: clean
 test: clean
 	./gradlew test
 
+# Set SKIP_NPM_CI=true when dependencies are already installed (e.g. the CI
+# workflow ran `npm ci` beforehand) to avoid a redundant reinstall.
 build-frontend:
-	cd ui && npm ci && npm run build
+	cd ui && { [ "${SKIP_NPM_CI}" = "true" ] && [ -d node_modules ] || npm ci; } && npm run build
 
 build-exec: build-frontend
 	./gradlew -q executableJar --no-daemon --priority=normal

--- a/build-and-start-e2e-tests.sh
+++ b/build-and-start-e2e-tests.sh
@@ -15,8 +15,26 @@ start_time=$(date +%s)
 
 echo ""
 echo "Building the image for this current repository"
-./gradlew clean -q
-make build-docker VERSION=$LOCAL_IMAGE_VERSION
+
+# Pull the images needed later (docker build base + compose services) in the
+# background so the downloads overlap with the Gradle/npm build instead of
+# sitting on the critical path.
+BASE_IMAGE="$(sed -n 's/^ARG BASE_IMAGE="\(.*\)"/\1/p' Dockerfile)"
+docker pull -q "${BASE_IMAGE:-ghcr.io/kestra-io/kestra-base:latest-no-plugins}" > /dev/null 2>&1 &
+docker pull -q postgres > /dev/null 2>&1 &
+docker pull -q docker:dind-rootless > /dev/null 2>&1 &
+
+if [ -n "$CI" ]; then
+  # CI runners start from a fresh checkout (nothing to clean) and the workflow
+  # has already run `npm ci`, so skip both.
+  make build-docker VERSION=$LOCAL_IMAGE_VERSION SKIP_NPM_CI=true
+else
+  ./gradlew clean -q
+  make build-docker VERSION=$LOCAL_IMAGE_VERSION
+fi
+
+# Let any still-running background pull finish before compose starts.
+wait
 
 end_time=$(date +%s)
 elapsed=$(( end_time - start_time ))

--- a/build-and-start-e2e-tests.sh
+++ b/build-and-start-e2e-tests.sh
@@ -22,7 +22,6 @@ echo "Building the image for this current repository"
 BASE_IMAGE="$(sed -n 's/^ARG BASE_IMAGE="\(.*\)"/\1/p' Dockerfile)"
 docker pull -q "${BASE_IMAGE:-ghcr.io/kestra-io/kestra-base:latest-no-plugins}" > /dev/null 2>&1 &
 docker pull -q postgres > /dev/null 2>&1 &
-docker pull -q docker:dind-rootless > /dev/null 2>&1 &
 
 if [ -n "$CI" ]; then
   # CI runners start from a fresh checkout (nothing to clean) and the workflow

--- a/ui/tests/e2e/api/executions.api.ts
+++ b/ui/tests/e2e/api/executions.api.ts
@@ -38,8 +38,13 @@ export class ExecutionsApi extends BaseApi {
         this.executionIds.push(responseJson["id"])
     }
 
+    /** Concurrent bulk variant of {@link generateExecutionViaApi} — the calls are independent. */
+    async generateExecutionsViaApi(count: number, labels: [string, string][] = []) {
+        await Promise.all(Array.from({length: count}, () => this.generateExecutionViaApi(labels)))
+    }
+
     async removeExecutionsViaApi() {
-        for (const executionId of this.executionIds) {
+        await Promise.all(this.executionIds.map(async (executionId) => {
             const params = new URLSearchParams()
             params.append("deleteLogs", "true")
             params.append("deleteMetric", "true")
@@ -55,7 +60,7 @@ export class ExecutionsApi extends BaseApi {
             if (status !== 204) {
                 throw new Error(`Deletion of execution ${executionId} failed with HTTP ${status}`)
             }
-        };
+        }))
     }
 
 }

--- a/ui/tests/e2e/docker-compose-postgres.yml
+++ b/ui/tests/e2e/docker-compose-postgres.yml
@@ -1,6 +1,4 @@
 volumes:
-  dind-socket:
-    driver: local
   tmp-data:
     driver: local
 
@@ -20,26 +18,8 @@ services:
   init:
     image: busybox
     volumes:
-      - dind-socket:/dind
       - tmp-data:/tmp/kestra-wd
-    command: "chown -R 1000:1000 -R /dind /tmp/kestra-wd"
-
-  dind:
-    image: docker:dind-rootless
-    privileged: true
-    user: "1000"
-    environment:
-      DOCKER_HOST: unix://dind/docker.sock
-      TINI_SUBREAPER: 1
-    command:
-      - --log-level=fatal
-      - --group=1000
-    volumes:
-      - dind-socket:/dind
-      - tmp-data:/tmp/kestra-wd
-    depends_on:
-      init:
-        condition: service_completed_successfully
+    command: "chown -R 1000:1000 /tmp/kestra-wd"
 
   kestra:
     container_name: kestra-e2e-backend
@@ -55,7 +35,6 @@ services:
       retries: 30
       start_period: 5s
     volumes:
-      - dind-socket:/dind
       - tmp-data:/tmp/kestra-wd:rw
       - ./data/entrypoint.sh:/app/entrypoint.sh:ro
       - ./data/flows/:/app/flows/:ro
@@ -67,7 +46,7 @@ services:
     links:
       - postgres
     depends_on:
-      dind:
-        condition: service_started
+      init:
+        condition: service_completed_successfully
       postgres:
         condition: service_healthy

--- a/ui/tests/e2e/executions/execution-bulk-actions.spec.ts
+++ b/ui/tests/e2e/executions/execution-bulk-actions.spec.ts
@@ -1,9 +1,17 @@
 import {test, expect} from "../fixtures/executions.fixture"
 import {ExecutionState, Pagination} from "../pages/base.page"
 
+/*
+ * One more labeled execution than the page size, so "Select All" has to reach
+ * beyond the visible page — the exact semantics under test. Kept small: every
+ * execution is a real flow run on the shared Kestra instance.
+ */
+const PAGE_SIZE = Pagination.ITEMS_10
+const LABELED_COUNT = PAGE_SIZE + 1
+
 test.describe("Executions' view Bulk Actions", () => {
 
-    // Each test drives 27 real flow executions against the single shared Kestra instance,
+    // Each test drives real flow executions against the single shared Kestra instance,
     // so keep them in one worker. `default` rather than `serial`: `serial` would skip the
     // remaining tests after a failure and hide a second regression.
     test.describe.configure({mode: "default"})
@@ -15,21 +23,19 @@ test.describe("Executions' view Bulk Actions", () => {
             test.slow() // creating many executions
             expect(page.getByRole("heading", {name: "Executions"})).toBeVisible()
 
-            await test.step("Generate 26 executions with the 'foo:bar' label and a single 'a:b' one", async () => {
-                for (let i = 0; i < 26; i++) {
-                    await executionsApi.generateExecutionViaApi([["foo", "bar"]])
-                }
+            await test.step(`Generate ${LABELED_COUNT} executions with the 'foo:bar' label and a single 'a:b' one`, async () => {
+                await executionsApi.generateExecutionsViaApi(LABELED_COUNT, [["foo", "bar"]])
                 await executionsApi.generateExecutionViaApi([["a", "b"]])
                 await page.reload()
             })
 
             await test.step("Filter just the executions featuring the 'foo:bar' label", async () => {
-                await executionsPage.setPaginationTo(Pagination.ITEMS_25)
+                await executionsPage.setPaginationTo(PAGE_SIZE)
                 await executionsPage.setFilterByFlowId(executionsApi.flowId)
                 await executionsPage.setFilterByLabel("foo", "bar")
 
-                await executionsPage.expectCountOfExecutionsToBe(25)
-                await executionsPage.expectTotalExecutionsCountToBe(26)
+                await executionsPage.expectCountOfExecutionsToBe(PAGE_SIZE)
+                await executionsPage.expectTotalExecutionsCountToBe(LABELED_COUNT)
             })
 
             await test.step("Set label to 'foo:baz' using Select All on filtered 'foo:bar' executions", async () => {
@@ -57,22 +63,20 @@ test.describe("Executions' view Bulk Actions", () => {
             test.slow() // creating and resuming many executions
             expect(page.getByRole("heading", {name: "Executions ", exact: true})).toBeVisible()
 
-            await test.step("Generate 26 executions with the 'foo:bar' label and a single 'a:b' one", async () => {
-                for (let i = 0; i < 26; i++) {
-                    await executionsApi.generateExecutionViaApi([["foo", "bar"]])
-                }
+            await test.step(`Generate ${LABELED_COUNT} executions with the 'foo:bar' label and a single 'a:b' one`, async () => {
+                await executionsApi.generateExecutionsViaApi(LABELED_COUNT, [["foo", "bar"]])
                 await executionsApi.generateExecutionViaApi([["a", "b"]])
                 await page.reload()
             })
 
             await test.step("Filter just 'FAILED' executions featuring the 'foo:bar' label", async () => {
-                await executionsPage.setPaginationTo(Pagination.ITEMS_25)
+                await executionsPage.setPaginationTo(PAGE_SIZE)
                 await executionsPage.setFilterByFlowId(executionsApi.flowId)
                 await executionsPage.setFilterByLabel("foo", "bar")
                 await executionsPage.setFilterByState(ExecutionState.FAILED)
 
-                await executionsPage.expectCountOfExecutionsToBe(25)
-                expect(await executionsPage.getTotalExecutionsCount()).toEqual(26)
+                await executionsPage.expectCountOfExecutionsToBe(PAGE_SIZE)
+                expect(await executionsPage.getTotalExecutionsCount()).toEqual(LABELED_COUNT)
             })
 
             await test.step("Call Restart using Select All on filtered 'FAILED' & 'foo:bar' executions", async () => {
@@ -81,11 +85,11 @@ test.describe("Executions' view Bulk Actions", () => {
                 await executionsPage.clickOnRestart()
             })
 
-            await test.step("Count all 26 'foo:bar' executions as successfully finished", async () => {
+            await test.step(`Count all ${LABELED_COUNT} 'foo:bar' executions as successfully finished`, async () => {
                 await executionsPage.setFilterByState(ExecutionState.SUCCESS)
 
-                // Restart is asynchronous — reload until the server has finished all 26.
-                await executionsPage.expectTotalExecutionsCountToBeAfterRefresh(26)
+                // Restart is asynchronous — reload until the server has finished all of them.
+                await executionsPage.expectTotalExecutionsCountToBeAfterRefresh(LABELED_COUNT)
             })
 
             await test.step("Switch filter to label 'a:b' which should not be affected by the Restart action", async () => {
@@ -105,22 +109,20 @@ test.describe("Executions' view Bulk Actions", () => {
             test.slow() // creating and resuming many executions
             expect(page.getByRole("heading", {name: "Executions"})).toBeVisible()
 
-            await test.step("Generate 26 executions with the 'foo:bar' label and a single 'a:b' one", async () => {
-                for (let i = 0; i < 26; i++) {
-                    await executionsApi.generateExecutionViaApi([["foo", "bar"]])
-                }
+            await test.step(`Generate ${LABELED_COUNT} executions with the 'foo:bar' label and a single 'a:b' one`, async () => {
+                await executionsApi.generateExecutionsViaApi(LABELED_COUNT, [["foo", "bar"]])
                 await executionsApi.generateExecutionViaApi([["a", "b"]])
                 await page.reload()
             })
 
             await test.step("Filter just 'FAILED' executions featuring the 'foo:bar' label", async () => {
-                await executionsPage.setPaginationTo(Pagination.ITEMS_25)
+                await executionsPage.setPaginationTo(PAGE_SIZE)
                 await executionsPage.setFilterByFlowId(executionsApi.flowId)
                 await executionsPage.setFilterByLabel("foo", "bar")
                 await executionsPage.setFilterByState(ExecutionState.FAILED)
 
-                await executionsPage.expectCountOfExecutionsToBe(25)
-                expect(await executionsPage.getTotalExecutionsCount()).toEqual(26)
+                await executionsPage.expectCountOfExecutionsToBe(PAGE_SIZE)
+                expect(await executionsPage.getTotalExecutionsCount()).toEqual(LABELED_COUNT)
             })
 
             await test.step("Call Replay using Select All on filtered 'FAILED' & 'foo:bar' executions", async () => {
@@ -129,9 +131,9 @@ test.describe("Executions' view Bulk Actions", () => {
                 await executionsPage.clickOnReplay()
             })
 
-            await test.step("Count 26 original and 26 replayed 'foo:bar' executions", async () => {
-                // Replay is asynchronous — reload until the 26 replays have joined the originals.
-                await executionsPage.expectTotalExecutionsCountToBeAfterRefresh(26 * 2)
+            await test.step(`Count ${LABELED_COUNT} original and ${LABELED_COUNT} replayed 'foo:bar' executions`, async () => {
+                // Replay is asynchronous — reload until the replays have joined the originals.
+                await executionsPage.expectTotalExecutionsCountToBeAfterRefresh(LABELED_COUNT * 2)
             })
 
             await test.step("Switch filter to label 'a:b' which should not be affected by the Restart action", async () => {

--- a/ui/tests/e2e/pages/executions.page.ts
+++ b/ui/tests/e2e/pages/executions.page.ts
@@ -128,7 +128,6 @@ export class ExecutionsPage extends BasePage {
             await this.page.reload()
             await expect(this.page.getByRole("row")).toHaveCount(1)
         }).toPass({timeout: 30000})
-        await this.page.waitForLoadState("networkidle")
     }
 
     /*

--- a/ui/tests/e2e/playwright.config.ts
+++ b/ui/tests/e2e/playwright.config.ts
@@ -37,7 +37,7 @@ const config: PlaywrightTestConfig = {
     /* Retry on CI only. Kept low: a genuinely broken test costs a full run per retry. */
     retries: process.env.CI ? 2 : 0,
     /*
-     * The CI runner has 4 vCPUs and also hosts the Kestra JVM, Postgres and dind, so the
+     * The CI runner has 4 vCPUs and also hosts the Kestra JVM and Postgres, so the
      * browsers compete with the backend under test. Two is the sweet spot; more makes the
      * execution-heavy specs slower and flakier rather than faster.
      */


### PR DESCRIPTION
## What

Cuts the E2E CI job's wall-clock time while testing the same things. Measured on a green scheduled run ([30491690152](https://github.com/kestra-io/kestra/actions/runs/30491690152)), the ~12-minute job (16+ when flaky) splits into: build 157s, backend boot ~50s, Playwright 6.5min — of which ~3min were two chronic flaky retries in the bulk-actions specs.

### Build stage
- Skip `./gradlew clean` in CI — the checkout is fresh, so the invocation is pure overhead. Local behavior unchanged.
- Skip the duplicate `npm ci` in CI via a new `SKIP_NPM_CI` make variable — the workflow already runs `npm ci` two steps before `make build-frontend` reinstalls node_modules from scratch (~40s).
- Pre-pull the Docker images needed later (kestra-base, postgres) in the background at script start so the downloads overlap with the Gradle build instead of sitting on the critical path.

### Drop the unused dind sidecar
No E2E flow or fixture exercises a Docker-runner task, so the `docker:dind-rootless` container and its `dind-socket` volume in `docker-compose-postgres.yml` were pure overhead — an extra image to pull, an extra privileged container to boot, and CPU/memory pressure on the already-contended 4-vCPU runner for zero test coverage. Removed the service, its volume, the `init` container's now-unnecessary chown of it, and a stale comment in `playwright.config.ts` that referenced it.

### Test stage (same coverage, less load)
The three bulk-action tests each created 26+1 executions **serially** over the API, then bulk-restarted/replayed all 26 on a 4-vCPU runner that also hosts the JVM, Postgres, dind and the browsers. That contention is exactly what made stragglers miss the 60s reload-poll window and trigger retries.
- The dataset shrinks from 26 executions / 25-per-page to `PAGE_SIZE + 1` = 11 / 10-per-page. The semantics under test — *Select All reaches beyond the visible page* — are identical and now explicit in the constant.
- Executions are created and deleted concurrently.
- Dropped a `waitForLoadState("networkidle")`.

Note: [#17726](https://github.com/kestra-io/kestra/pull/17726) landed on `develop` while this branch was open and independently reworked the same pagination helpers (URL-driven `setPaginationTo`, total-counter-based after-refresh assertion). This branch is now rebased on top of it and keeps its version of those helpers — my earlier dropdown-click race fix is superseded by its simpler URL-based approach.

## Expected result

Job time should drop from ~12min to ~8–9min, and the two chronic bulk-actions flakes (each retry costs ~90s and they have failed most scheduled runs this week) should disappear since the contention that caused them is gone.

## Verified

Ran the actual CI script end to end locally (`build-and-start-e2e-tests.sh`: fresh Gradle build → local Docker image build from source → dind-free `docker compose up` → full Playwright suite): **32 passed**, 260s total (125s of that is the test run itself). `tsc --noEmit` clean on the e2e tsconfig.

🤖 Generated with [Claude Code](https://claude.com/claude-code)