### PR TITLE
feat: add missing activation

### DIFF
--- a/ui/src/components/flows/FlowRun.vue
+++ b/ui/src/components/flows/FlowRun.vue
@@ -398,6 +398,9 @@
                 apiStore.posthogEvents({
                     type: "FLOW_EXECUTION",
                     action: "submit",
+                    // Replay-with-inputs bypasses triggerExecution, so it never emits a matching
+                    // `executed`: flagged so it can be excluded from the submit/executed funnel.
+                    is_replay: Boolean(props.replaySubmit),
                 })
 
                 const mergedInputs = props.selectedTrigger?.inputs

--- a/ui/src/components/flows/FlowRun.vue
+++ b/ui/src/components/flows/FlowRun.vue
@@ -387,10 +387,6 @@
 
     function onSubmit() {
         if (form.value && flowCanBeExecuted.value) {
-            apiStore.posthogEvents({
-                type: "FLOW_EXECUTION",
-                action: "submit",
-            })
             checks.value = []
             executeClicked.value = false
             coreStore.message = undefined
@@ -398,6 +394,11 @@
                 if (!valid) {
                     return
                 }
+
+                apiStore.posthogEvents({
+                    type: "FLOW_EXECUTION",
+                    action: "submit",
+                })
 
                 const mergedInputs = props.selectedTrigger?.inputs
                     ? {...props.selectedTrigger.inputs, ...inputsNoDefaults.value}

--- a/ui/src/components/kv/KVTable.vue
+++ b/ui/src/components/kv/KVTable.vue
@@ -321,6 +321,7 @@
 
     import {useAuthStore} from "override/stores/auth"
     import {useNamespacesStore} from "override/stores/namespaces"
+    import {useApiStore} from "../../stores/api"
     import * as KvAPI from "@kestra-io/kestra-sdk/kv"
 
     import _merge from "lodash/merge"
@@ -343,6 +344,7 @@
 
     const authStore = useAuthStore()
     const namespacesStore = useNamespacesStore()
+    const apiStore = useApiStore()
 
     const editorBindings = useEditorBindings()
 
@@ -708,9 +710,20 @@
                 (payload as any).ttl = ttl
             }
 
+            // update flag is set by updateKvModal(); setKeyValue() is an upsert and can't tell them apart.
+            const wasUpdate = kv.value.update === true
+
             return namespacesStore
                 .createKv(payload)
                 .then(() => {
+                    apiStore.posthogEvents({
+                        type: wasUpdate ? "SECRET_UPDATED" : "SECRET_CREATED",
+                        secret_type: "kv",
+                        namespace,
+                        value_type: type,
+                        has_ttl: Boolean(ttl),
+                    })
+
                     toast.saved(key)
                     addKvDrawerVisible.value = false
                     dataTable.value?.reload()

--- a/ui/src/components/secrets/SecretsTable.vue
+++ b/ui/src/components/secrets/SecretsTable.vue
@@ -564,12 +564,17 @@
                 ? namespacesStore.createSecrets
                 : namespacesStore.patchSecret
 
-            actionMethod({namespace: secret.value?.namespace as string, secret: secretData})
+            // Snapshot before the request: resetForm() swaps secret.value out when the drawer closes,
+            // and the .then() would then read the flag off a different object.
+            const wasUpdate = secret.value?.update === true
+            const namespace = secret.value?.namespace
+
+            actionMethod({namespace: namespace as string, secret: secretData})
                 .then(() => {
                     apiStore.posthogEvents({
-                        type: secret.value?.update === true ? "SECRET_UPDATED" : "SECRET_CREATED",
+                        type: wasUpdate ? "SECRET_UPDATED" : "SECRET_CREATED",
                         secret_type: "secret",
-                        namespace: secret.value?.namespace,
+                        namespace,
                         has_tags: (secretData.tags?.length ?? 0) > 0,
                     })
 

--- a/ui/src/components/secrets/SecretsTable.vue
+++ b/ui/src/components/secrets/SecretsTable.vue
@@ -241,6 +241,7 @@
     import * as SecretsAPI from "@kestra-io/kestra-sdk/secrets"
     import {useAuthStore} from "override/stores/auth"
     import {useNamespacesStore} from "override/stores/namespaces"
+    import {useApiStore} from "../../stores/api"
     import {useSecretsFilter} from "../filter/configurations"
     import {useTableColumns} from "../../composables/useTableColumns"
     import {useDiscardGuard} from "../../composables/useDiscardGuard"
@@ -294,6 +295,7 @@
     const router = useRouter()
     const authStore = useAuthStore()
     const namespacesStore = useNamespacesStore()
+    const apiStore = useApiStore()
 
     const form = ref<FormInstance>()
 
@@ -564,6 +566,13 @@
 
             actionMethod({namespace: secret.value?.namespace as string, secret: secretData})
                 .then(() => {
+                    apiStore.posthogEvents({
+                        type: secret.value?.update === true ? "SECRET_UPDATED" : "SECRET_CREATED",
+                        secret_type: "secret",
+                        namespace: secret.value?.namespace,
+                        has_tags: (secretData.tags?.length ?? 0) > 0,
+                    })
+
                     secret.value!.update = true
                     toast.saved(secret.value?.key || "")
                     addSecretDrawerVisible.value = false

--- a/ui/src/override/components/flows/Actions.vue
+++ b/ui/src/override/components/flows/Actions.vue
@@ -219,6 +219,7 @@
     const restoreFlow = () => {
         flowStore.createFlow({
             flow: YAML_UTILS.deleteMetadata(flow.value?.source, "deleted"),
+            restore: true,
         }).then(() => {
             unsavedChangesStore.unsavedChange = false
             router.go(0)

--- a/ui/src/stores/executions.ts
+++ b/ui/src/stores/executions.ts
@@ -15,6 +15,8 @@ import * as ExecutionUtils from "../utils/executionUtils"
 import {executionLogsDownloadFilename} from "../utils/logs"
 import {InputType} from "../utils/inputs"
 import {Optional} from "../utils/utils"
+import {useApiStore} from "./api"
+import {executionLocation, isExampleFlow} from "../utils/analytics/activation"
 
 export interface Check {
     message: string
@@ -354,7 +356,20 @@ export const useExecutionsStore = defineStore("executions", () => {
         // Don't set Content-Type here - createExecution() already defaults it to null so the
         // browser can generate the multipart boundary itself. An explicit "multipart/form-data"
         // header (needed under the old axios client) has no boundary and corrupts the request.
-        }, {timeout: 60 * 60 * 1000})
+        }, {timeout: 60 * 60 * 1000}).then(execution => {
+            useApiStore().posthogEvents({
+                type: "FLOW_EXECUTION",
+                action: "executed",
+                execution_id: execution.id,
+                namespace: execution.namespace,
+                flow_id: execution.flowId,
+                location: executionLocation(route.name?.toString(), options.kind),
+                is_example: isExampleFlow(execution.namespace),
+                revision: execution.flowRevision,
+            })
+
+            return execution
+        })
     }
 
     const deleteExecution = (options: { id: string; deleteLogs?: boolean; deleteMetrics?: boolean; deleteStorage?: boolean }) => {

--- a/ui/src/stores/flow.ts
+++ b/ui/src/stores/flow.ts
@@ -18,6 +18,8 @@ import type {FlowWithSource,  AbstractTrigger, Task as SdkTask} from "@kestra-io
 import * as FlowsAPI from "@kestra-io/kestra-sdk/flows"
 import * as MetricsAPI from "@kestra-io/kestra-sdk/metrics"
 import {defaultNamespace} from "../composables/useNamespaces"
+import {useApiStore} from "./api"
+import {flowTaskStats, isExampleFlow, primaryTriggerType} from "../utils/analytics/activation"
 
 const textYamlHeader = {
     headers: {
@@ -543,7 +545,26 @@ export const useFlowStore = defineStore("flow", () => {
             localStorage.removeItem(`el-fl-creation-${creationId.value}`)
             creationId.value = undefined
 
+            if (!options.draft) {
+                trackFlowCreated(flow.value)
+            }
+
             return flow.value
+        })
+    }
+
+    // Only on creation: saveFlow() fires on every editor save, which would drown the signal.
+    function trackFlowCreated(created: Flow) {
+        const {taskCount, pluginCount} = flowTaskStats(created.tasks)
+
+        useApiStore().posthogEvents({
+            type: "FLOW_CREATED",
+            namespace: created.namespace,
+            flow_id: created.id,
+            task_count: taskCount,
+            plugin_count: pluginCount,
+            trigger_type: primaryTriggerType(created.triggers),
+            is_example: isExampleFlow(created.namespace),
         })
     }
 

--- a/ui/src/stores/flow.ts
+++ b/ui/src/stores/flow.ts
@@ -530,7 +530,7 @@ export const useFlowStore = defineStore("flow", () => {
         })
     }
 
-    function createFlow(options: { flow: string, draft?: boolean }) {
+    function createFlow(options: { flow: string, draft?: boolean, restore?: boolean }) {
         return FlowsAPI.createFlow({
             body: options.flow,
             draft: options.draft ?? false,
@@ -546,7 +546,7 @@ export const useFlowStore = defineStore("flow", () => {
             creationId.value = undefined
 
             if (!options.draft) {
-                trackFlowCreated(flow.value)
+                trackFlowCreated(flow.value, options.restore === true)
             }
 
             return flow.value
@@ -554,7 +554,9 @@ export const useFlowStore = defineStore("flow", () => {
     }
 
     // Only on creation: saveFlow() fires on every editor save, which would drown the signal.
-    function trackFlowCreated(created: Flow) {
+    // restoreFlow() also goes through createFlow(), on a flow_id that already reported a creation -
+    // flagged rather than dropped so activation can exclude it downstream.
+    function trackFlowCreated(created: Flow, isRestore: boolean) {
         const {taskCount, pluginCount} = flowTaskStats(created.tasks)
 
         useApiStore().posthogEvents({
@@ -565,6 +567,7 @@ export const useFlowStore = defineStore("flow", () => {
             plugin_count: pluginCount,
             trigger_type: primaryTriggerType(created.triggers),
             is_example: isExampleFlow(created.namespace),
+            is_restore: isRestore,
         })
     }
 

--- a/ui/src/utils/analytics/activation.spec.ts
+++ b/ui/src/utils/analytics/activation.spec.ts
@@ -74,10 +74,21 @@ describe("primaryTriggerType", () => {
         [undefined, "manual"],
         [[], "manual"],
         [[{type: "io.kestra.plugin.core.trigger.Schedule"}], "cron"],
+        [[{type: "io.kestra.plugin.core.trigger.ScheduleOnDates"}], "cron"],
         [[{type: "io.kestra.plugin.core.trigger.Webhook"}], "webhook"],
         [[{type: "io.kestra.plugin.core.trigger.Flow"}], "flow"],
+        [[{type: "io.kestra.plugin.core.trigger.McpToolTrigger"}], "other"],
     ])("maps %j to %s", (triggers, expected) => {
         expect(primaryTriggerType(triggers)).toEqual(expected)
+    })
+
+    // 78 plugin triggers share the short name `Trigger`, 23 share `RealtimeTrigger`.
+    it.each([
+        "io.kestra.plugin.kafka.Trigger",
+        "io.kestra.plugin.jdbc.postgresql.Trigger",
+        "io.kestra.plugin.aws.sqs.RealtimeTrigger",
+    ])("buckets the plugin trigger %s as other", (type) => {
+        expect(primaryTriggerType([{type}])).toEqual("other")
     })
 
     it("reads the first trigger when several are declared", () => {

--- a/ui/src/utils/analytics/activation.spec.ts
+++ b/ui/src/utils/analytics/activation.spec.ts
@@ -1,0 +1,89 @@
+import {describe, expect, it} from "vitest"
+import {executionLocation, flowTaskStats, isExampleFlow, primaryTriggerType, routeSection} from "./activation"
+
+describe("isExampleFlow", () => {
+    it("flags the tutorial namespace", () => {
+        expect(isExampleFlow("tutorial")).toBe(true)
+    })
+
+    it.each(["tutorials", "my.tutorial", "company.data", undefined])("does not flag %s", (namespace) => {
+        expect(isExampleFlow(namespace)).toBe(false)
+    })
+})
+
+describe("executionLocation", () => {
+    it("reports playground from the execution kind, whatever the route", () => {
+        expect(executionLocation("flows/list", "PLAYGROUND")).toEqual("playground")
+    })
+
+    it.each([
+        ["flows/update/edit", "flow_editor"],
+        ["flows/update/executions", "flow_editor"],
+        ["flows/create", "flow_editor"],
+        ["flows/list", "flow_list"],
+        ["flows/search", "flow_list"],
+        ["executions/list", "executions_view"],
+        ["executions/update/gantt", "executions_view"],
+    ])("maps %s to %s", (routeName, expected) => {
+        expect(executionLocation(routeName, "NORMAL")).toEqual(expected)
+    })
+
+    it("falls back to the first route segment for an unmapped route", () => {
+        expect(executionLocation("admin/triggers", "NORMAL")).toEqual("admin")
+    })
+
+    it("returns undefined without a route name", () => {
+        expect(executionLocation(undefined, "NORMAL")).toBeUndefined()
+    })
+})
+
+describe("routeSection", () => {
+    it.each([
+        ["flows/list", "flows"],
+        ["admin/instance/worker-queues", "admin"],
+        ["home", "home"],
+    ])("maps %s to %s", (routeName, expected) => {
+        expect(routeSection(routeName)).toEqual(expected)
+    })
+
+    it.each([undefined, ""])("returns undefined for %j", (routeName) => {
+        expect(routeSection(routeName)).toBeUndefined()
+    })
+})
+
+describe("flowTaskStats", () => {
+    it("counts nested tasks and distinct plugins", () => {
+        const tasks = [
+            {type: "io.kestra.plugin.core.flow.Sequential", tasks: [
+                {type: "io.kestra.plugin.scripts.python.Script"},
+                {type: "io.kestra.plugin.scripts.python.Script"},
+            ]},
+            {type: "io.kestra.plugin.core.log.Log"},
+        ]
+
+        expect(flowTaskStats(tasks)).toEqual({taskCount: 4, pluginCount: 3})
+    })
+
+    it("returns zeroes without tasks", () => {
+        expect(flowTaskStats(undefined)).toEqual({taskCount: 0, pluginCount: 0})
+    })
+})
+
+describe("primaryTriggerType", () => {
+    it.each([
+        [undefined, "manual"],
+        [[], "manual"],
+        [[{type: "io.kestra.plugin.core.trigger.Schedule"}], "cron"],
+        [[{type: "io.kestra.plugin.core.trigger.Webhook"}], "webhook"],
+        [[{type: "io.kestra.plugin.core.trigger.Flow"}], "flow"],
+    ])("maps %j to %s", (triggers, expected) => {
+        expect(primaryTriggerType(triggers)).toEqual(expected)
+    })
+
+    it("reads the first trigger when several are declared", () => {
+        expect(primaryTriggerType([
+            {type: "io.kestra.plugin.core.trigger.Webhook"},
+            {type: "io.kestra.plugin.core.trigger.Schedule"},
+        ])).toEqual("webhook")
+    })
+})

--- a/ui/src/utils/analytics/activation.ts
+++ b/ui/src/utils/analytics/activation.ts
@@ -1,0 +1,68 @@
+// Namespace the "Getting Started" blueprints are auto-loaded into (see FlowAutoLoaderService).
+const EXAMPLE_NAMESPACE = "tutorial"
+
+export function isExampleFlow(namespace: string | undefined): boolean {
+    return namespace === EXAMPLE_NAMESPACE
+}
+
+/**
+ * Where in the UI a run was started, derived from the matched route name rather than the URL so it
+ * survives tenant prefixes and path changes. Unknown routes fall back to their first segment.
+ */
+export function executionLocation(routeName: string | undefined, kind: "NORMAL" | "PLAYGROUND"): string | undefined {
+    if (kind === "PLAYGROUND") return "playground"
+    if (!routeName) return undefined
+
+    if (routeName === "flows/create" || routeName.startsWith("flows/update")) return "flow_editor"
+    if (routeName === "flows/list" || routeName === "flows/search") return "flow_list"
+    if (routeName.startsWith("executions/")) return "executions_view"
+
+    return routeName.split("/")[0] || undefined
+}
+
+/**
+ * Navbar section of a page view. Every route in both editions is named `section/subpage`, so the
+ * first segment is the section - no lookup table to keep in sync.
+ */
+export function routeSection(routeName: string | undefined): string | undefined {
+    return routeName?.split("/")[0] || undefined
+}
+
+type TaskLike = {type?: string; tasks?: TaskLike[] | null}
+
+/**
+ * Flow shape at creation: how many tasks it holds and how many distinct plugins it wires together.
+ * Walks `tasks` nesting (Sequential/Parallel); branch containers (If/Switch, errors) are not walked,
+ * so both counts are lower bounds.
+ */
+export function flowTaskStats(tasks: TaskLike[] | undefined): {taskCount: number; pluginCount: number} {
+    const types = new Set<string>()
+    let taskCount = 0
+
+    const walk = (list: TaskLike[] | undefined | null) => {
+        for (const task of list ?? []) {
+            taskCount++
+            if (task.type) types.add(task.type)
+            walk(task.tasks)
+        }
+    }
+    walk(tasks)
+
+    return {taskCount, pluginCount: types.size}
+}
+
+const TRIGGER_KINDS: Record<string, string> = {
+    schedule: "cron",
+}
+
+/**
+ * How the flow is meant to be started: `manual` with no trigger, otherwise the first trigger's kind
+ * (short class name, mapped to the funnel vocabulary where one exists).
+ */
+export function primaryTriggerType(triggers: {type?: string}[] | undefined): string {
+    const first = triggers?.[0]?.type
+    if (!first) return "manual"
+
+    const shortName = (first.split(".").pop() ?? first).toLowerCase()
+    return TRIGGER_KINDS[shortName] ?? shortName
+}

--- a/ui/src/utils/analytics/activation.ts
+++ b/ui/src/utils/analytics/activation.ts
@@ -1,8 +1,7 @@
-// Namespace the "Getting Started" blueprints are auto-loaded into (see FlowAutoLoaderService).
-const EXAMPLE_NAMESPACE = "tutorial"
+import {TUTORIAL_NAMESPACE} from "../constants"
 
 export function isExampleFlow(namespace: string | undefined): boolean {
-    return namespace === EXAMPLE_NAMESPACE
+    return namespace === TUTORIAL_NAMESPACE
 }
 
 /**
@@ -51,18 +50,23 @@ export function flowTaskStats(tasks: TaskLike[] | undefined): {taskCount: number
     return {taskCount, pluginCount: types.size}
 }
 
+// Keyed on the full type, not the short class name: 78 of the ~140 plugin triggers are literally
+// named `Trigger`, so short names collide into one meaningless bucket.
 const TRIGGER_KINDS: Record<string, string> = {
-    schedule: "cron",
+    "io.kestra.plugin.core.trigger.Schedule": "cron",
+    "io.kestra.plugin.core.trigger.ScheduleOnDates": "cron",
+    "io.kestra.plugin.core.trigger.Webhook": "webhook",
+    "io.kestra.plugin.core.trigger.Flow": "flow",
 }
 
 /**
- * How the flow is meant to be started: `manual` with no trigger, otherwise the first trigger's kind
- * (short class name, mapped to the funnel vocabulary where one exists).
+ * How the flow is meant to be started: `manual` with no trigger, otherwise the first trigger mapped
+ * to the funnel vocabulary. Everything else — plugin triggers included — is bucketed as `other` to
+ * keep this a curated dimension; per-plugin usage is not what this property is for.
  */
 export function primaryTriggerType(triggers: {type?: string}[] | undefined): string {
     const first = triggers?.[0]?.type
     if (!first) return "manual"
 
-    const shortName = (first.split(".").pop() ?? first).toLowerCase()
-    return TRIGGER_KINDS[shortName] ?? shortName
+    return TRIGGER_KINDS[first] ?? "other"
 }

--- a/ui/src/utils/analytics/eventNaming.spec.ts
+++ b/ui/src/utils/analytics/eventNaming.spec.ts
@@ -6,8 +6,11 @@ const fixtures: [string, Record<string, any>, string][] = [
     ["flow_execution", {action: "open_modal"}, "app.execute-modal.opened"],
     ["flow_execution", {action: "submit"}, "app.execute-modal.submitted"],
     ["flow_created", {}, "app.flow.created"],
-    ["secret_created", {}, "app.secret.created"],
-    ["secret_updated", {}, "app.secret.updated"],
+    ["secret_created", {secret_type: "secret"}, "app.secret.created"],
+    ["secret_updated", {secret_type: "secret"}, "app.secret.updated"],
+    ["secret_created", {secret_type: "kv"}, "app.kv.created"],
+    ["secret_updated", {secret_type: "kv"}, "app.kv.updated"],
+    ["secret_created", {secret_type: "token"}, "app.token.created"],
     ["user_invited", {}, "app.user.invited"],
     ["ai_copilot", {}, "app.ai-copilot.invoked"],
     ["blueprint", {}, "app.blueprint.used"],
@@ -50,6 +53,11 @@ describe("resolvePosthogEventName", () => {
     it("never resolves an unknown flow_execution action to the activation event", () => {
         expect(resolvePosthogEventName("flow_execution", {action: "unknown_action"})).toEqual("flow_execution")
         expect(resolvePosthogEventName("flow_execution", {})).toEqual("flow_execution")
+    })
+
+    it("falls back to the base name when secret_type is unknown or missing", () => {
+        expect(resolvePosthogEventName("secret_created", {secret_type: "unknown"})).toEqual("secret_created")
+        expect(resolvePosthogEventName("secret_updated", {})).toEqual("secret_updated")
     })
 
     it("falls back to the base lowercased name when editor_tab_action has an unknown action", () => {

--- a/ui/src/utils/analytics/eventNaming.spec.ts
+++ b/ui/src/utils/analytics/eventNaming.spec.ts
@@ -2,7 +2,13 @@ import {describe, expect, it} from "vitest"
 import {resolvePosthogEventName} from "./eventNaming"
 
 const fixtures: [string, Record<string, any>, string][] = [
-    ["flow_execution", {}, "app.flow.executed"],
+    ["flow_execution", {action: "executed"}, "app.flow.executed"],
+    ["flow_execution", {action: "open_modal"}, "app.execute-modal.opened"],
+    ["flow_execution", {action: "submit"}, "app.execute-modal.submitted"],
+    ["flow_created", {}, "app.flow.created"],
+    ["secret_created", {}, "app.secret.created"],
+    ["secret_updated", {}, "app.secret.updated"],
+    ["user_invited", {}, "app.user.invited"],
     ["ai_copilot", {}, "app.ai-copilot.invoked"],
     ["blueprint", {}, "app.blueprint.used"],
     ["survey_submitted", {}, "app.survey.submitted"],
@@ -39,6 +45,11 @@ describe("resolvePosthogEventName", () => {
 
     it("falls back to the lowercased type for an unmapped event", () => {
         expect(resolvePosthogEventName("SOMETHING_NEW", {})).toEqual("something_new")
+    })
+
+    it("never resolves an unknown flow_execution action to the activation event", () => {
+        expect(resolvePosthogEventName("flow_execution", {action: "unknown_action"})).toEqual("flow_execution")
+        expect(resolvePosthogEventName("flow_execution", {})).toEqual("flow_execution")
     })
 
     it("falls back to the base lowercased name when editor_tab_action has an unknown action", () => {

--- a/ui/src/utils/analytics/eventNaming.ts
+++ b/ui/src/utils/analytics/eventNaming.ts
@@ -1,8 +1,6 @@
 // Taxonomy source of truth: kestra-io/data#354
 const FLAT_EVENT_NAMES: Record<string, string> = {
     flow_created: "app.flow.created",
-    secret_created: "app.secret.created",
-    secret_updated: "app.secret.updated",
     user_invited: "app.user.invited",
     ai_copilot: "app.ai-copilot.invoked",
     blueprint: "app.blueprint.used",
@@ -34,6 +32,14 @@ const FLOW_EXECUTION_NAMES: Record<string, string> = {
     submit: "app.execute-modal.submitted",
 }
 
+// KV entry, namespace secret and API token are three different objects, so the taxonomy gives them
+// three object segments rather than one event disambiguated by a property.
+const SECRET_OBJECTS: Record<string, string> = {
+    kv: "kv",
+    secret: "secret",
+    token: "token",
+}
+
 const ONBOARDING_NAMES: Record<string, string> = {
     step_viewed: "app.onboarding-step.viewed",
     step_next_clicked: "app.onboarding-step.advanced",
@@ -63,8 +69,17 @@ function resolveOnboarding(properties: Record<string, any>): string {
     return ONBOARDING_NAMES[properties.onboarding?.action] ?? "onboarding"
 }
 
+function resolveSecret(action: "created" | "updated"): (properties: Record<string, any>) => string {
+    return (properties) => {
+        const object = SECRET_OBJECTS[properties.secret_type]
+        return object ? `app.${object}.${action}` : `secret_${action}`
+    }
+}
+
 const SPLIT_EVENT_RESOLVERS: Record<string, (properties: Record<string, any>) => string> = {
     flow_execution: resolveFlowExecution,
+    secret_created: resolveSecret("created"),
+    secret_updated: resolveSecret("updated"),
     editor_tab_action: resolveEditorTabAction,
     ossauth: resolveOssAuth,
     onboarding: resolveOnboarding,

--- a/ui/src/utils/analytics/eventNaming.ts
+++ b/ui/src/utils/analytics/eventNaming.ts
@@ -1,6 +1,9 @@
 // Taxonomy source of truth: kestra-io/data#354
 const FLAT_EVENT_NAMES: Record<string, string> = {
-    flow_execution: "app.flow.executed",
+    flow_created: "app.flow.created",
+    secret_created: "app.secret.created",
+    secret_updated: "app.secret.updated",
+    user_invited: "app.user.invited",
     ai_copilot: "app.ai-copilot.invoked",
     blueprint: "app.blueprint.used",
     survey_submitted: "app.survey.submitted",
@@ -25,6 +28,12 @@ const OSSAUTH_NAMES: Record<string, string> = {
     forgot_password_click: "app.forgot-password.clicked",
 }
 
+const FLOW_EXECUTION_NAMES: Record<string, string> = {
+    executed: "app.flow.executed",
+    open_modal: "app.execute-modal.opened",
+    submit: "app.execute-modal.submitted",
+}
+
 const ONBOARDING_NAMES: Record<string, string> = {
     step_viewed: "app.onboarding-step.viewed",
     step_next_clicked: "app.onboarding-step.advanced",
@@ -46,11 +55,16 @@ function resolveOssAuth(properties: Record<string, any>): string {
     return OSSAUTH_NAMES[properties.action] ?? "app.oss-auth.completed"
 }
 
+function resolveFlowExecution(properties: Record<string, any>): string {
+    return FLOW_EXECUTION_NAMES[properties.action] ?? "flow_execution"
+}
+
 function resolveOnboarding(properties: Record<string, any>): string {
     return ONBOARDING_NAMES[properties.onboarding?.action] ?? "onboarding"
 }
 
 const SPLIT_EVENT_RESOLVERS: Record<string, (properties: Record<string, any>) => string> = {
+    flow_execution: resolveFlowExecution,
     editor_tab_action: resolveEditorTabAction,
     ossauth: resolveOssAuth,
     onboarding: resolveOnboarding,

--- a/ui/src/utils/eventsRouter.ts
+++ b/ui/src/utils/eventsRouter.ts
@@ -2,6 +2,7 @@ import {nextTick} from "vue"
 import _isEqual from "lodash/isEqual"
 import type {RouteLocationNormalized} from "vue-router"
 import {useApiStore} from "../stores/api"
+import {routeSection} from "./analytics/activation"
 
 interface PageInfo {
     origin: string
@@ -53,6 +54,7 @@ export default (_app: any, router: any) => {
             apiStore.events({
                 type: "PAGE",
                 page: pageFromRoute(to),
+                section: routeSection(to.name?.toString()),
                 $referrer: referrerUrl,
                 $referring_domain: referringDomain,
             })


### PR DESCRIPTION
Fixes flow execution tracking, which counted Execute clicks instead of actual runs — a single run was reported twice, a cancelled one still counted.

Adds the missing activation events for flow creation, secrets and KV, plus a section property on page views.

Companion PR: https://github.com/kestra-io/kestra-ee/pull/9605

 Relates to : https://github.com/kestra-io/kestra-ee/issues/9524