### PR TITLE
Fix/merge exec indices

### DIFF
--- a/jdbc-h2/src/main/java/io/kestra/repository/h2/migration/V2_0_22ExecutionsNamespaceFlowIdMigration.java
+++ b/jdbc-h2/src/main/java/io/kestra/repository/h2/migration/V2_0_22ExecutionsNamespaceFlowIdMigration.java
@@ -1,0 +1,36 @@
+package io.kestra.repository.h2.migration;
+
+import java.util.List;
+
+import javax.sql.DataSource;
+
+import io.kestra.jdbc.migration.AbstractV2_0_22ExecutionsNamespaceFlowIdMigration;
+
+import io.micronaut.context.annotation.Requires;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+
+/**
+ * OSS H2 executions namespace/flow_id index merge migration.
+ */
+@Singleton
+@Requires(property = "kestra.repository.type", pattern = "h2|memory")
+public class V2_0_22ExecutionsNamespaceFlowIdMigration extends AbstractV2_0_22ExecutionsNamespaceFlowIdMigration {
+
+    private final DataSource dataSource;
+
+    @Inject
+    public V2_0_22ExecutionsNamespaceFlowIdMigration(final DataSource dataSource) {
+        this.dataSource = dataSource;
+    }
+
+    @Override
+    protected DataSource dataSource() {
+        return dataSource;
+    }
+
+    @Override
+    public List<String> sqlResources() {
+        return List.of("/migrations/2.0.22-executions-namespace-flow-id-h2.sql");
+    }
+}

--- a/jdbc-h2/src/main/resources/migrations/2.0.22-executions-namespace-flow-id-h2.sql
+++ b/jdbc-h2/src/main/resources/migrations/2.0.22-executions-namespace-flow-id-h2.sql
@@ -1,0 +1,9 @@
+-- 2.0.21: merge executions_namespace (deleted, tenant_id, namespace) and executions_flow_id
+-- (deleted, tenant_id, flow_id) into a single composite index. A flow always belongs to a
+-- namespace, so (deleted, tenant_id, namespace, flow_id) still serves namespace-only queries
+-- through its leftmost prefix while giving namespace + flow_id queries a full four-column seek,
+-- and it removes one index from the hottest write table.
+CREATE INDEX IF NOT EXISTS executions_namespace__flow_id ON executions ("deleted", "tenant_id", "namespace", "flow_id");
+
+DROP INDEX IF EXISTS executions_namespace;
+DROP INDEX IF EXISTS executions_flow_id;

--- a/jdbc-mysql/src/main/java/io/kestra/repository/mysql/migration/V2_0_22ExecutionsNamespaceFlowIdMigration.java
+++ b/jdbc-mysql/src/main/java/io/kestra/repository/mysql/migration/V2_0_22ExecutionsNamespaceFlowIdMigration.java
@@ -1,0 +1,36 @@
+package io.kestra.repository.mysql.migration;
+
+import java.util.List;
+
+import javax.sql.DataSource;
+
+import io.kestra.jdbc.migration.AbstractV2_0_22ExecutionsNamespaceFlowIdMigration;
+import io.kestra.repository.mysql.MysqlRepositoryEnabled;
+
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+
+/**
+ * OSS MySQL executions namespace/flow_id index merge migration.
+ */
+@Singleton
+@MysqlRepositoryEnabled
+public class V2_0_22ExecutionsNamespaceFlowIdMigration extends AbstractV2_0_22ExecutionsNamespaceFlowIdMigration {
+
+    private final DataSource dataSource;
+
+    @Inject
+    public V2_0_22ExecutionsNamespaceFlowIdMigration(final DataSource dataSource) {
+        this.dataSource = dataSource;
+    }
+
+    @Override
+    protected DataSource dataSource() {
+        return dataSource;
+    }
+
+    @Override
+    public List<String> sqlResources() {
+        return List.of("/migrations/2.0.22-executions-namespace-flow-id-mysql.sql");
+    }
+}

--- a/jdbc-mysql/src/main/resources/migrations/2.0.22-executions-namespace-flow-id-mysql.sql
+++ b/jdbc-mysql/src/main/resources/migrations/2.0.22-executions-namespace-flow-id-mysql.sql
@@ -1,0 +1,23 @@
+-- 2.0.21: merge ix_namespace (deleted, tenant_id, namespace) and ix_flowId (deleted, tenant_id,
+-- flow_id) into a single composite index. A flow always belongs to a namespace, so
+-- (deleted, tenant_id, namespace, flow_id) still serves namespace-only queries through its
+-- leftmost prefix while giving namespace + flow_id queries a full four-column seek, and it removes
+-- one index from the hottest write table.
+
+SET @idx_exists = (SELECT COUNT(*) FROM information_schema.statistics WHERE table_schema = DATABASE() AND table_name = 'executions' AND index_name = 'ix_namespace__flow_id');
+SET @sql = IF(@idx_exists = 0, 'ALTER TABLE executions ADD INDEX ix_namespace__flow_id (deleted, tenant_id, namespace, flow_id), ALGORITHM=INPLACE, LOCK=NONE', 'SELECT 1');
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+SET @idx_exists = (SELECT COUNT(*) FROM information_schema.statistics WHERE table_schema = DATABASE() AND table_name = 'executions' AND index_name = 'ix_namespace');
+SET @sql = IF(@idx_exists > 0, 'ALTER TABLE executions DROP INDEX ix_namespace', 'SELECT 1');
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+SET @idx_exists = (SELECT COUNT(*) FROM information_schema.statistics WHERE table_schema = DATABASE() AND table_name = 'executions' AND index_name = 'ix_flowId');
+SET @sql = IF(@idx_exists > 0, 'ALTER TABLE executions DROP INDEX ix_flowId', 'SELECT 1');
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;

--- a/jdbc-postgres/src/main/java/io/kestra/repository/postgres/migration/V2_0_22ExecutionsNamespaceFlowIdMigration.java
+++ b/jdbc-postgres/src/main/java/io/kestra/repository/postgres/migration/V2_0_22ExecutionsNamespaceFlowIdMigration.java
@@ -1,0 +1,36 @@
+package io.kestra.repository.postgres.migration;
+
+import java.util.List;
+
+import javax.sql.DataSource;
+
+import io.kestra.jdbc.migration.AbstractV2_0_22ExecutionsNamespaceFlowIdMigration;
+import io.kestra.repository.postgres.PostgresRepositoryEnabled;
+
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+
+/**
+ * OSS PostgreSQL executions namespace/flow_id index merge migration.
+ */
+@Singleton
+@PostgresRepositoryEnabled
+public class V2_0_22ExecutionsNamespaceFlowIdMigration extends AbstractV2_0_22ExecutionsNamespaceFlowIdMigration {
+
+    private final DataSource dataSource;
+
+    @Inject
+    public V2_0_22ExecutionsNamespaceFlowIdMigration(final DataSource dataSource) {
+        this.dataSource = dataSource;
+    }
+
+    @Override
+    protected DataSource dataSource() {
+        return dataSource;
+    }
+
+    @Override
+    public List<String> sqlResources() {
+        return List.of("/migrations/2.0.22-executions-namespace-flow-id-postgres.sql");
+    }
+}

--- a/jdbc-postgres/src/main/resources/migrations/2.0.22-executions-namespace-flow-id-postgres.sql
+++ b/jdbc-postgres/src/main/resources/migrations/2.0.22-executions-namespace-flow-id-postgres.sql
@@ -1,0 +1,21 @@
+-- 2.0.21: merge executions_namespace (deleted, tenant_id, namespace) and executions_flow_id
+-- (deleted, tenant_id, flow_id) into a single composite index. A flow always belongs to a
+-- namespace, so (deleted, tenant_id, namespace, flow_id) still serves namespace-only queries
+-- through its leftmost prefix while giving namespace + flow_id queries a full four-column seek,
+-- and it removes one index from the hottest write table.
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1
+        FROM pg_index i
+        JOIN pg_class c ON c.oid = i.indexrelid
+        WHERE c.relname = 'executions_namespace__flow_id' AND NOT i.indisvalid
+    ) THEN
+        EXECUTE 'DROP INDEX executions_namespace__flow_id';
+    END IF;
+END $$;
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS executions_namespace__flow_id ON executions ("deleted", "tenant_id", "namespace", "flow_id");
+
+DROP INDEX CONCURRENTLY IF EXISTS executions_namespace;
+DROP INDEX CONCURRENTLY IF EXISTS executions_flow_id;

--- a/jdbc/src/main/java/io/kestra/jdbc/migration/AbstractV2_0_22ExecutionsNamespaceFlowIdMigration.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/migration/AbstractV2_0_22ExecutionsNamespaceFlowIdMigration.java
@@ -1,0 +1,25 @@
+package io.kestra.jdbc.migration;
+
+/**
+ * Abstract base for the 2.0.22 executions namespace/flow_id index merge migration.
+ *
+ * <p>
+ * Replaces the two overlapping indexes {@code (deleted, tenant_id, namespace)} and
+ * {@code (deleted, tenant_id, flow_id)} on the {@code executions} table with a single composite
+ * {@code (deleted, tenant_id, namespace, flow_id)} index. Since a flow always belongs to a
+ * namespace, the merged index still serves namespace-only queries through its leftmost prefix,
+ * serves namespace + flow_id queries with a full four-column seek, and removes one index from the
+ * hottest write table.
+ */
+public abstract class AbstractV2_0_22ExecutionsNamespaceFlowIdMigration extends AbstractSQLMigrationScript {
+
+    @Override
+    public String scriptId() {
+        return "2.0.22-executions-namespace-flow-id";
+    }
+
+    @Override
+    public String description() {
+        return "Executions: merge namespace and flow_id indexes";
+    }
+}

--- a/ui/src/components/filter/configurations/executionFilter.ts
+++ b/ui/src/components/filter/configurations/executionFilter.ts
@@ -10,6 +10,15 @@ import {useI18n} from "vue-i18n"
 import {useRoute} from "vue-router"
 import {labelComparatorLabels} from "./labelComparatorLabels"
 import {routeFamily} from "../../../utils/routeFamily"
+import {keepTopLevelFilters} from "../../../utils/queryFilters"
+
+/**
+ * Applied filters forwarded to the flowId option lookup to narrow it by what the list already shows.
+ *
+ * Only the namespace-bearing filters are forwarded so existing indices should be used.
+ * Everything else is deliberately left out.
+ */
+const FLOW_ID_NARROWING_FIELDS = ["namespace", "scope"]
 
 export const useExecutionFilter = (): ComputedRef<FilterConfiguration> => {
     const {t} = useI18n()
@@ -70,7 +79,10 @@ export const useExecutionFilter = (): ComputedRef<FilterConfiguration> => {
                         const search = options?.search?.trim()
                         const ids = await useExecutionsStore().findDistinctFieldValues({
                             field: "flowId",
-                            filters: search ? {"filters[flowId][CONTAINS]": search} : undefined,
+                            filters: {
+                                ...keepTopLevelFilters(route.query, FLOW_ID_NARROWING_FIELDS),
+                                ...(search ? {"filters[flowId][CONTAINS]": search} : {}),
+                            },
                             size: 100,
                         })
                         return ids.map(id => ({label: id, value: id}))

--- a/ui/src/stores/executions.ts
+++ b/ui/src/stores/executions.ts
@@ -4,7 +4,7 @@ import {apiUrl} from "override/utils/route"
 import * as Utils from "../utils/utils"
 import {useCoreStore} from "./core"
 import throttle from "lodash/throttle"
-import {useRoute} from "vue-router"
+import {useRoute, type LocationQuery} from "vue-router"
 import {CLUSTER_PREFIX} from "@kestra-io/design-system"
 import {routeQueryToQueryFilters} from "../utils/queryFilters"
 import {TaskRun, useClient, type Execution as SDKExecution, type StateType} from "@kestra-io/kestra-sdk"
@@ -306,7 +306,7 @@ export const useExecutionsStore = defineStore("executions", () => {
 
     const findDistinctFieldValues = async (options: {
         field: string;
-        filters?: Record<string, string>;
+        filters?: LocationQuery;
         size?: number;
     }): Promise<string[]> => {
         return ExecutionsAPI.findDistinctFieldValues({

--- a/ui/src/utils/queryFilters.spec.ts
+++ b/ui/src/utils/queryFilters.spec.ts
@@ -1,0 +1,101 @@
+import {describe, expect, it} from "vitest"
+import {keepTopLevelFilters} from "./queryFilters"
+
+describe("keepTopLevelFilters", () => {
+    it("should keep the allowlisted filters", () => {
+        const query = {
+            "filters[namespace][PREFIX]": "company.team",
+            "filters[scope][IN]": "USER",
+        }
+
+        expect(keepTopLevelFilters(query, ["namespace", "scope"])).toEqual(query)
+    })
+
+    it("should drop the filters that are not allowlisted", () => {
+        const query = {
+            "filters[namespace][PREFIX]": "company.team",
+            "filters[state][IN]": ["RUNNING", "FAILED"],
+            "filters[kind][EQUALS]": "NORMAL",
+            "filters[flowId][EQUALS]": "my-flow",
+        }
+
+        expect(keepTopLevelFilters(query, ["namespace"])).toEqual({
+            "filters[namespace][PREFIX]": "company.team",
+        })
+    })
+
+    it("should drop pagination, sort and other bare params", () => {
+        const query = {
+            "filters[namespace][PREFIX]": "company.team",
+            page: "2",
+            size: "50",
+            sort: "state.startDate:desc",
+            dateFilter: "START_DATE",
+            q: "some text",
+        }
+
+        expect(keepTopLevelFilters(query, ["namespace"])).toEqual({
+            "filters[namespace][PREFIX]": "company.team",
+        })
+    })
+
+    it("should drop the date filters a custom time range encodes to", () => {
+        const query = {
+            "filters[namespace][PREFIX]": "company.team",
+            "filters[startDate][GREATER_THAN_OR_EQUAL_TO]": "2026-07-01T00:00:00Z",
+            "filters[endDate][LESS_THAN_OR_EQUAL_TO]": "2026-07-30T00:00:00Z",
+            "filters[timeRange][EQUALS]": "PT12H",
+        }
+
+        expect(keepTopLevelFilters(query, ["namespace"])).toEqual({
+            "filters[namespace][PREFIX]": "company.team",
+        })
+    })
+
+    it("should drop a labels filter including its sub-key", () => {
+        const query = {
+            "filters[namespace][PREFIX]": "company.team",
+            "filters[labels][EQUALS][mykey]": "myvalue",
+        }
+
+        expect(keepTopLevelFilters(query, ["namespace"])).toEqual({
+            "filters[namespace][PREFIX]": "company.team",
+        })
+    })
+
+    it("should keep a labels filter with its sub-key when allowlisted", () => {
+        const query = {"filters[labels][EQUALS][mykey]": "myvalue"}
+
+        expect(keepTopLevelFilters(query, ["labels"])).toEqual(query)
+    })
+
+    it("should never forward a filter nested in a logical group, even when allowlisted", () => {
+        // Dropping one disjunct of an OR would tighten the lookup and could hide values the list
+        // shows, so grouped filters are skipped entirely.
+        const query = {
+            "filters[or][0][namespace][EQUALS]": "company.team",
+            "filters[or][1][namespace][EQUALS]": "company.other",
+        }
+
+        expect(keepTopLevelFilters(query, ["namespace"])).toEqual({})
+    })
+
+    it("should keep multi-value filters as arrays", () => {
+        const query = {"filters[namespace][IN]": ["company.team", "company.other"]}
+
+        expect(keepTopLevelFilters(query, ["namespace"])).toEqual(query)
+    })
+
+    it("should drop empty, null and unparsable filter params", () => {
+        const query = {
+            "filters[namespace][PREFIX]": "",
+            "filters[namespace][IN]": null,
+            "filters[namespace][PREFIX2": "broken",
+            "filters[scope][IN]": "USER",
+        }
+
+        expect(keepTopLevelFilters(query, ["namespace", "scope"])).toEqual({
+            "filters[scope][IN]": "USER",
+        })
+    })
+})

--- a/ui/src/utils/queryFilters.ts
+++ b/ui/src/utils/queryFilters.ts
@@ -6,7 +6,7 @@ import type {QueryFilter, QueryFilterField, QueryFilterLogical, QueryFilterOp} f
 const QUERY_FILTER_LOGICAL: Record<LogicalOperator, QueryFilterLogical> = {AND: "and", OR: "or"}
 
 /**
- * Builds a `QueryFilter` group node. The backend rejects a node that also carries a
+ * Builds a `QueryFilter` group node. TExecutions.tshe backend rejects a node that also carries a
  * `field`/`operation`/`value` (see `QueryFilter`'s canonical constructor), so a group is only ever
  * `logical` + `children`, with `logical` in the lowercase form its enum accepts.
  */
@@ -107,3 +107,24 @@ export const routeQueryToQueryFilters = (query: LocationQuery): QueryFilter[] =>
 
     return root.build()
 }
+
+/**
+ * Keeps only the top-level `filters[...]` params of a route query that sit on one of `fields`.
+ *
+ * Use it to narrow a filter dropdown's own value lookup by the filters already applied to the list.
+ * Because top-level filter params are ANDed together, forwarding a subset of them can only loosen
+ * the lookup - so it never hides a value the list itself would show. That is also why members of a
+ * nested AND/OR group are never forwarded: dropping one disjunct of an OR would tighten the lookup
+ * instead, and could hide values the list shows.
+ *
+ * Pagination and sort params are dropped for free: they are not `filters[...]` keys.
+ */
+export const keepTopLevelFilters = (query: LocationQuery, fields: string[]): LocationQuery =>
+    Object.fromEntries(
+        Object.entries(query).filter(([key, value]) => {
+            if (!key.startsWith("filters[") || !value) return false
+
+            const parsed = parseFilterKey(key)
+            return parsed !== null && parsed.chain.length === 0 && fields.includes(parsed.field)
+        }),
+    )


### PR DESCRIPTION
### Merge namespace and flow_id indexes on the executions table

The executions table carried two overlapping b-tree indexes, (deleted,
tenant_id, namespace) and (deleted, tenant_id, flow_id). Since a flow always
belongs to a namespace, a single composite (deleted, tenant_id, namespace,
flow_id) still serves namespace-only queries through its leftmost prefix, gives
namespace + flow_id queries a full four-column seek, and removes one index from
the hottest write table.

### Narrow the flowId filter options by the applied namespace (UI)

Merging the namespace and flow_id indexes made flow_id the fourth column of
(deleted, tenant_id, namespace, flow_id), so the flowId filter autocomplete  lost the pre-sorted index-only scan its dedicated index used to give it and now
scans every execution row of the tenant.

The autocomplete was already sending a filter, but only the typed substring: the
namespace and other filters applied to the list were never forwarded. Forward the
applied ones instead, which both narrows the dropdown to values that can actually
match and carries the namespace predicate that lets the lookup use the merged
index as a bounded range scan.

Closes #17074

