### PR TITLE
fix(ci): don't run EE/Docker-publish steps that fail on Dependabot PRs

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -14,12 +14,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout  # required so the local composite action below can resolve
-      if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false }}
+      if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false && github.actor != 'dependabot[bot]' }}
       uses: actions/checkout@v7
 
+      # Dependabot PRs are not forks, but GitHub still withholds repo secrets from
+      # workflow runs it triggers, so create-github-app-token would fail with an
+      # empty app-id. Skip this and the dependent steps below for Dependabot.
     - name: Generate GitHub App token for kestra-ee dispatch
       id: ee-token
-      if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false }}
+      if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false && github.actor != 'dependabot[bot]' }}
       uses: actions/create-github-app-token@v3
       with:
         app-id: ${{ secrets.GH_BOT_APP_ID }}
@@ -33,7 +36,8 @@ jobs:
     - name: EE compile check (via Kestra webhook)
       if: ${{ github.event_name == 'pull_request'
         && github.event.pull_request.number != ''
-        && github.event.pull_request.head.repo.fork == false }}
+        && github.event.pull_request.head.repo.fork == false
+        && github.actor != 'dependabot[bot]' }}
       uses: ./.github/actions/ee-compile-check
       with:
         webhook-url: ${{ secrets.KESTRA_CI_EEBUILD_WEBHOOK_URL }}
@@ -42,12 +46,13 @@ jobs:
         pr-number: ${{ github.event.pull_request.number }}
         pr-repo: ${{ github.repository }}
 
-      # Always trigger EE OpenAPI check on non-fork PRs
+      # Always trigger EE OpenAPI check on non-fork, non-Dependabot PRs
     - name: Trigger EE OpenAPI spec check
       uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697
       if: ${{ github.event_name == 'pull_request'
         && github.event.pull_request.number != ''
-        && github.event.pull_request.head.repo.fork == false }}
+        && github.event.pull_request.head.repo.fork == false
+        && github.actor != 'dependabot[bot]' }}
       with:
         token: ${{ steps.ee-token.outputs.token }}
         repository: kestra-io/kestra-ee

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -14,15 +14,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout  # required so the local composite action below can resolve
-      if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false && github.actor != 'dependabot[bot]' }}
+      if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false && secrets.GH_BOT_APP_ID != '' }}
       uses: actions/checkout@v7
 
       # Dependabot PRs are not forks, but GitHub still withholds repo secrets from
       # workflow runs it triggers, so create-github-app-token would fail with an
-      # empty app-id. Skip this and the dependent steps below for Dependabot.
+      # empty app-id. Guard on the secret itself rather than the triggering actor,
+      # since that's the actual precondition and it covers any other case where
+      # these secrets aren't available to the run.
     - name: Generate GitHub App token for kestra-ee dispatch
       id: ee-token
-      if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false && github.actor != 'dependabot[bot]' }}
+      if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false && secrets.GH_BOT_APP_ID != '' }}
       uses: actions/create-github-app-token@v3
       with:
         app-id: ${{ secrets.GH_BOT_APP_ID }}
@@ -37,7 +39,7 @@ jobs:
       if: ${{ github.event_name == 'pull_request'
         && github.event.pull_request.number != ''
         && github.event.pull_request.head.repo.fork == false
-        && github.actor != 'dependabot[bot]' }}
+        && secrets.GH_BOT_APP_ID != '' }}
       uses: ./.github/actions/ee-compile-check
       with:
         webhook-url: ${{ secrets.KESTRA_CI_EEBUILD_WEBHOOK_URL }}
@@ -46,13 +48,13 @@ jobs:
         pr-number: ${{ github.event.pull_request.number }}
         pr-repo: ${{ github.repository }}
 
-      # Always trigger EE OpenAPI check on non-fork, non-Dependabot PRs
+      # Always trigger EE OpenAPI check on non-fork PRs where secrets are available
     - name: Trigger EE OpenAPI spec check
       uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697
       if: ${{ github.event_name == 'pull_request'
         && github.event.pull_request.number != ''
         && github.event.pull_request.head.repo.fork == false
-        && github.actor != 'dependabot[bot]' }}
+        && secrets.GH_BOT_APP_ID != '' }}
       with:
         token: ${{ steps.ee-token.outputs.token }}
         repository: kestra-io/kestra-ee


### PR DESCRIPTION
### ✨ Description

Dependabot PRs aren't forks, so `trigger-ee`'s steps ran anyway — but GitHub withholds repo secrets from workflow runs it triggers, so `create-github-app-token` failed with an empty `app-id`. Guards these steps on `secrets.GH_BOT_APP_ID != ''` instead of the fork check alone.

Companion fix in `kestra-io/actions` (same branch name) skips the PR Docker build/publish job for Dependabot too, since its `GITHUB_TOKEN` is read-only in that context and the `ghcr.io` push always failed.

### 🔗 Related Issue

Fixes the recurring CI failure seen on Dependabot PRs, e.g. https://github.com/kestra-io/kestra/actions/runs/30426932220/job/90495314436

### 📝 Additional Notes

No frontend or backend code changed — CI workflow only.

### 🤖 AI Authors

Why did the CI pipeline refuse to trust Dependabot's secrets? It had seen one too many "trust me, I'm just updating a version" commits. 🐱

---
_Generated by [Claude Code](https://claude.ai/code/session_01GAuvvjYvzZen9LgnLoNY42)_