### PR TITLE
ci(tests): upload frontend test coverage to Codecov

### DIFF
--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -80,6 +80,7 @@ jobs:
     uses: kestra-io/actions/.github/workflows/kestra-oss-designsystem-tests.yml@main
     secrets:
       GITHUB_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   publish-develop-docker:
     name: Publish Docker

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -140,6 +140,7 @@ jobs:
     uses: kestra-io/actions/.github/workflows/kestra-oss-designsystem-tests.yml@main
     secrets:
       GITHUB_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   backend:
     name: Backend - Tests

--- a/codecov.yml
+++ b/codecov.yml
@@ -58,9 +58,14 @@ component_management:
       paths:
         - webserver/**
 
-ignore:
-  - ui/**
-# we are not mature yet to have a ui code coverage
+    - component_id: ui
+      name: Ui
+      paths:
+        - ui/**
+    - component_id: design-system
+      name: Design System
+      paths:
+        - ui/packages/design-system/**
 
 flag_management:
   default_rules:
@@ -72,3 +77,32 @@ flag_management:
       - type: patch
         target: 75%
         threshold: 10%
+  individual_flags:
+    - name: ui-unit
+      carryforward: true
+      statuses:
+        - type: project
+          informational: true
+        - type: patch
+          informational: true
+    - name: ui-storybook
+      carryforward: true
+      statuses:
+        - type: project
+          informational: true
+        - type: patch
+          informational: true
+    - name: design-system-unit
+      carryforward: true
+      statuses:
+        - type: project
+          informational: true
+        - type: patch
+          informational: true
+    - name: design-system-storybook
+      carryforward: true
+      statuses:
+        - type: project
+          informational: true
+        - type: patch
+          informational: true

--- a/ui/packages/design-system/vitest.unit.config.ts
+++ b/ui/packages/design-system/vitest.unit.config.ts
@@ -8,5 +8,8 @@ export default defineConfig({
         globals: true,
         include: ["tests/**/*.test.ts"],
         setupFiles: ["./tests/units/setup.ts"],
+        coverage: {
+            include: ["src/**/*.{ts,vue}"],
+        },
     },
 })

--- a/ui/vitest.config.js
+++ b/ui/vitest.config.js
@@ -114,7 +114,7 @@ export default defineConfig({
             }),
         ],
         coverage: {
-            reporter: ["text", "html"],
+            reporter: ["text", "html", "lcov"],
             include: [
                 "src/**/*.{ts,vue}",
             ],


### PR DESCRIPTION
### ✨ Description

Track `ui` and `design-system` Vitest coverage in Codecov as **informational** (non-blocking) flags instead of ignoring `ui/**` entirely.

- Adds `lcov` to `ui`'s coverage reporters (its explicit override otherwise produces no Codecov-ingestible format).
- Adds an explicit `src`-scoped `coverage.include` to `design-system`'s unit config (had none, so `--coverage` would instrument the whole package).
- Wires `CODECOV_TOKEN` through to the `design-system-frontend` job, which didn't previously receive it.
- New `ui-unit`/`ui-storybook`/`design-system-unit`/`design-system-storybook` flags are `informational: true` — they report but never block a PR, unlike the backend's existing blocking thresholds.

Companion PRs: kestra-io/actions#170 (the actual CI steps) and kestra-io/kestra-ee (ui-ee equivalent).

### 🎨 Frontend Checklist

- [x] Code builds without errors (`npm run build`)
- [x] Verified a clean, isolated `vitest run --coverage` produces a valid `lcov.info` with real `src/` paths

### 📝 Additional Notes

Frontend coverage was deliberately removed from Codecov in July (#10038) — the rationale then was that line coverage is the wrong metric for frontend and the config wasn't right. This PR keeps that spirit by making the new flags informational-only rather than a blocking gate, while still giving visibility into trend over time.

### 🤖 AI Authors

Why did the coverage report refuse to merge? It had too many unresolved branches. 🐱


---
_Generated by [Claude Code](https://claude.ai/code/session_01TcuEvhvESAPs8pd3YWHwS6)_