### PR TITLE
ci: build once per PR, skip E2E/Docker-image jobs when unneeded

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -155,23 +155,45 @@ jobs:
     with:
       java-version: 25
 
-  e2e-tests:
-    name: E2E - Tests
-    uses: kestra-io/actions/.github/workflows/kestra-oss-e2e-tests.yml@main
+  # Built once here, consumed by both the E2E tests and the PR docker image
+  # publish (previously each of them rebuilt the whole product themselves).
+  build-artifacts:
+    name: Build Artifacts
+    needs: [file-changes]
+    # Docs-only PRs (e.g. .github or markdown changes) don't need a product
+    # build; drafts are filtered by file-changes' own if. Fork PRs can't
+    # share artifacts (their runs hold no repo write token), so they keep
+    # the E2E build-from-source fallback below.
+    if: "(needs.file-changes.outputs.ui == 'true' || needs.file-changes.outputs.backend == 'true') && github.event.pull_request.head.repo.fork == false"
+    uses: kestra-io/actions/.github/workflows/kestra-oss-build-artifacts.yml@main
     with:
       java-version: 25
 
+  e2e-tests:
+    name: E2E - Tests
+    needs: [file-changes, build-artifacts]
+    # Runs when build-artifacts succeeded (prebuilt exe) or was skipped for a
+    # fork (falls back to building from source); not when the build failed.
+    if: "!cancelled() && needs.build-artifacts.result != 'failure' && (needs.file-changes.outputs.ui == 'true' || needs.file-changes.outputs.backend == 'true')"
+    uses: kestra-io/actions/.github/workflows/kestra-oss-e2e-tests.yml@main
+    with:
+      java-version: 25
+      exe-artifact: ${{ needs.build-artifacts.result == 'success' && 'exe' || '' }}
+
   generate-pull-request-docker-image:
     name: Generate PR docker image
+    needs: [build-artifacts]
+    if: "!cancelled() && needs.build-artifacts.result == 'success'"
     uses: kestra-io/actions/.github/workflows/kestra-oss-pullrequest-publish-docker.yml@main
     with:
       java-version: 25
+      skip-build: true
 
   otel-export-trace:
     name: OpenTelemetry - Export Trace
     runs-on: ubuntu-latest
     if: always()
-    needs: [ trigger-ee, file-changes, frontend, design-system-frontend, backend, e2e-tests, generate-pull-request-docker-image ]
+    needs: [ trigger-ee, file-changes, frontend, design-system-frontend, backend, build-artifacts, e2e-tests, generate-pull-request-docker-image ]
     env:
       OTLP_ENDPOINT: ${{ secrets.OTLP_ENDPOINT }}
     steps:

--- a/Makefile
+++ b/Makefile
@@ -93,6 +93,11 @@ install-plugins:
 
 # Build docker image from Kestra source.
 build-docker: build-exec
+	$(MAKE) build-docker-from-exec
+
+# Build docker image from an existing build/executable (e.g. a CI artifact),
+# skipping the frontend/Gradle build entirely.
+build-docker-from-exec:
 	cp build/executable/* docker/app/kestra && chmod +x docker/app/kestra
 	echo "${DOCKER_IMAGE}:${VERSION}"
 	docker build \

--- a/build-and-start-e2e-tests.sh
+++ b/build-and-start-e2e-tests.sh
@@ -23,7 +23,11 @@ BASE_IMAGE="$(sed -n 's/^ARG BASE_IMAGE="\(.*\)"/\1/p' Dockerfile)"
 docker pull -q "${BASE_IMAGE:-ghcr.io/kestra-io/kestra-base:latest-no-plugins}" > /dev/null 2>&1 &
 docker pull -q postgres > /dev/null 2>&1 &
 
-if [ -n "$CI" ]; then
+if [ "${E2E_USE_PREBUILT_EXE:-false}" = "true" ]; then
+  # CI already downloaded a prebuilt executable into build/executable
+  # (the Build Artifacts job's artifact), so only the image remains to build.
+  make build-docker-from-exec VERSION=$LOCAL_IMAGE_VERSION
+elif [ -n "$CI" ]; then
   # CI runners start from a fresh checkout (nothing to clean) and the workflow
   # has already run `npm ci`, so skip both.
   make build-docker VERSION=$LOCAL_IMAGE_VERSION SKIP_NPM_CI=true


### PR DESCRIPTION
## What

Extracted from the "Build once per PR, skip what's unneeded" section of #17737, on its own so it can land independently of that PR's storybook/vitest performance work.

`e2e-tests` and `generate-pull-request-docker-image` each rebuilt the entire product (npm build + Gradle `executableJar`) from source, in parallel, on every PR — including docs-only and draft PRs that don't touch `ui/` or backend code at all.

- [`pull-request.yml`](../blob/claude/frontend-ci-artifact-caching-2hfyul/.github/workflows/pull-request.yml): `e2e-tests` and `generate-pull-request-docker-image` are now gated on `ui`/`backend` file changes, and a hoisted `build-artifacts` job feeds both via the new `exe-artifact`/`skip-build` inputs — the E2E job no longer rebuilds the whole product in parallel with the identical build in the docker-image job. Fork PRs (no shared artifacts across jobs) keep the E2E build-from-source fallback.
- [`Makefile`](../blob/claude/frontend-ci-artifact-caching-2hfyul/Makefile): new `build-docker-from-exec` target — builds the Docker image from an existing `build/executable` without touching the frontend/Gradle build.
- [`build-and-start-e2e-tests.sh`](../blob/claude/frontend-ci-artifact-caching-2hfyul/build-and-start-e2e-tests.sh): new `E2E_USE_PREBUILT_EXE` env branch that calls the target above when CI already downloaded a prebuilt executable.

## Merge order

⚠️ **Merge kestra-io/actions#173 first.** It adds the `exe-artifact` and `skip-build` inputs this PR passes; until it merges, CI here fails with "invalid input" errors, then a re-run validates the whole setup live.

## Testing done

- All YAML parse-validated (`python3 -c "import yaml; yaml.safe_load(...)"`).
- `build-and-start-e2e-tests.sh` is `bash -n` clean.
- `make -n build-docker-from-exec` dry-run verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01D7Fz91uURsTHPCiTeXc2Rz)_