### PR TITLE
fix(dashboards): fall back to the bundled dashboard when a reference is dangling

### DIFF
--- a/ui/src/components/dashboard/Dashboard.vue
+++ b/ui/src/components/dashboard/Dashboard.vue
@@ -171,6 +171,7 @@
                     title: err,
                     message: err,
                 }
+                await useDefaultDashboardBundledInUI()
             }
         }
 

--- a/ui/src/stores/dashboard.ts
+++ b/ui/src/stores/dashboard.ts
@@ -205,10 +205,12 @@ export const useDashboardStore = defineStore("dashboard", () => {
         return false
     }
 
+    const silent = {showMessageOnError: false} as Parameters<typeof DashboardsAPI.dashboard>[1]
+
     async function load(id: Dashboard["id"]) : Promise<Dashboard | undefined> {
         let data
         try{
-            data = await DashboardsAPI.dashboard({id}) as Dashboard
+            data = await DashboardsAPI.dashboard({id}, silent) as Dashboard
         } catch {
             return undefined
         }
@@ -242,7 +244,10 @@ export const useDashboardStore = defineStore("dashboard", () => {
 
     async function generate(id: Dashboard["id"], chartId: Chart["id"], parameters: ChartFiltersOverrides) {
         try {
-            return await DashboardsAPI.dashboardChartData({id, chartId, ...parameters} as globalThis.Parameters<typeof DashboardsAPI.dashboardChartData>[0])
+            return await DashboardsAPI.dashboardChartData(
+                {id, chartId, ...parameters} as globalThis.Parameters<typeof DashboardsAPI.dashboardChartData>[0],
+                silent as globalThis.Parameters<typeof DashboardsAPI.dashboardChartData>[1],
+            )
         } catch (e: any) {
             if (e.status === 404) return undefined
             throw e

--- a/ui/tests/unit/stores/dashboardDanglingId.spec.ts
+++ b/ui/tests/unit/stores/dashboardDanglingId.spec.ts
@@ -1,0 +1,85 @@
+import {describe, it, expect, vi, beforeEach} from "vitest"
+import {setActivePinia, createPinia} from "pinia"
+
+vi.mock("@kestra-io/design-system", () => ({
+    stringUtils: {afterLastDot: (s: string) => s?.split(".").pop() ?? s},
+    durationUtils: {humanDuration: () => "", duration: () => 0},
+    State: {},
+}))
+
+vi.mock("nprogress", () => ({
+    start: vi.fn(),
+    done: vi.fn(),
+    set: vi.fn(),
+    inc: vi.fn(),
+}))
+
+vi.mock("vue-router", () => ({
+    useRouter: () => ({
+        beforeEach: vi.fn(),
+        afterEach: vi.fn(),
+        replace: vi.fn(),
+        push: vi.fn(),
+    }),
+}))
+
+vi.mock("vue-i18n", () => ({
+    useI18n: () => ({t: (key: string) => key}),
+}))
+
+const dashboardFn = vi.fn()
+const dashboardChartDataFn = vi.fn()
+
+vi.mock("@kestra-io/kestra-sdk/dashboards", () => ({
+    dashboard: (...args: any[]) => dashboardFn(...args),
+    dashboardChartData: (...args: any[]) => dashboardChartDataFn(...args),
+}))
+
+const TEST_TIMEOUT_MS = 20_000
+
+const notFound = () => Object.assign(new Error("Not Found"), {status: 404})
+
+describe("dashboard store dangling id handling", () => {
+    beforeEach(() => {
+        vi.resetModules()
+        dashboardFn.mockReset()
+        dashboardChartDataFn.mockReset()
+        setActivePinia(createPinia())
+    })
+
+    it("opts the dashboard lookup out of global error handling", {timeout: TEST_TIMEOUT_MS}, async () => {
+        dashboardFn.mockRejectedValueOnce(notFound())
+
+        const {useDashboardStore} = await import("../../../src/stores/dashboard")
+        const dashboardStore = useDashboardStore()
+
+        await expect(dashboardStore.load("deleted-dashboard-id")).resolves.toBeUndefined()
+        expect(dashboardFn).toHaveBeenCalledWith(
+            {id: "deleted-dashboard-id"},
+            expect.objectContaining({showMessageOnError: false}),
+        )
+    })
+
+    it("opts the chart data request out of global error handling", {timeout: TEST_TIMEOUT_MS}, async () => {
+        dashboardChartDataFn.mockRejectedValueOnce(notFound())
+
+        const {useDashboardStore} = await import("../../../src/stores/dashboard")
+        const dashboardStore = useDashboardStore()
+
+        await expect(dashboardStore.generate("deleted-dashboard-id", "chart", {})).resolves.toBeUndefined()
+        expect(dashboardChartDataFn).toHaveBeenCalledWith(
+            expect.objectContaining({id: "deleted-dashboard-id", chartId: "chart"}),
+            expect.objectContaining({showMessageOnError: false}),
+        )
+    })
+
+    it("still propagates unexpected chart data failures", {timeout: TEST_TIMEOUT_MS}, async () => {
+        const error = Object.assign(new Error("Server Error"), {status: 500})
+        dashboardChartDataFn.mockRejectedValueOnce(error)
+
+        const {useDashboardStore} = await import("../../../src/stores/dashboard")
+        const dashboardStore = useDashboardStore()
+
+        await expect(dashboardStore.generate("d1", "chart", {})).rejects.toBe(error)
+    })
+})


### PR DESCRIPTION
### ✨ Description

A dashboard id can outlive the dashboard it points to, either from a stale `localStorage` entry (`userDashboard/<tenant>/<routeFamily>`, written when the user picks a dashboard) or from a tenant default whose dashboard was deleted afterwards. In that case the Flow Overview rendered the global **"Page not found"** screen instead of falling back to the dashboard bundled in the UI, and reloading did not help because the dangling id is read again on every visit.

Two things were needed:

- **`ui/src/stores/dashboard.ts`** — `load()` and `generate()` already caught the 404 locally, but that catch never mattered: the global error interceptor in `ui/src/utils/kestraHttp.ts` runs first and sets `coreStore.error = 404`, and `DefaultLayout.vue` then swaps the whole page. Both requests now pass `showMessageOnError: false`, which is the existing mechanism for an expected, locally handled 404 (same pattern as `useApplyDraft.ts`).
- **`ui/src/components/dashboard/Dashboard.vue`** — with the interceptor silenced, the missing-dashboard branch only warned and showed a toast, leaving an empty dashboard. It now falls back to the bundled definition, keeping the toast so the user still learns the configured dashboard is gone.

### 🔗 Related Issue

Fixes https://github.com/kestra-io/kestra/issues/17752

### 🧪 How it was verified

Against the `kestra/kestra:develop` image built 2026-07-31, with a dangling id planted in `localStorage` and the same `GET /dashboards/deleted-dashboard-id → 404` occurring in both runs:

| | Page body |
|---|---|
| before | `/ Page not found Workspace Dashboards …` |
| after | `/ Flows / tutorial / hello-world Overview Execute …` |

Unit tests cover both the opt-out being passed and non-404 errors still propagating.

### 🎨 Frontend Checklist

- [x] Code builds without errors (`npm run check:types`, `eslint` clean on touched files)
- [x] Targeted unit tests pass (`dashboardDanglingId.spec.ts`, plus the existing dashboard specs, 36 passing)
- [ ] All existing E2E tests pass (`npm run test:e2e`) — not run locally
- [x] Behaviour verified in a browser against a real backend

### 📝 Additional Notes

Found while re-reviewing #17522, which targeted a different endpoint (`/dashboards/settings/default-dashboards`) that always returns 200 in OSS and therefore could not produce this symptom.
