### PR TITLE
fix(ci): use env not secrets in trigger-ee if: conditions (unbreaks all PR CI)

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -12,9 +12,14 @@ jobs:
   # Kestra webhook) and trigger the EE OpenAPI spec check.
   trigger-ee:
     runs-on: ubuntu-latest
+    # The `secrets` context is not allowed in `if:` conditions, so expose the
+    # app-id as a job-level env var (the `env` context IS allowed in `if:`) and
+    # gate the steps on that instead.
+    env:
+      GH_BOT_APP_ID: ${{ secrets.GH_BOT_APP_ID }}
     steps:
     - name: Checkout  # required so the local composite action below can resolve
-      if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false && secrets.GH_BOT_APP_ID != '' }}
+      if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false && env.GH_BOT_APP_ID != '' }}
       uses: actions/checkout@v7
 
       # Dependabot PRs are not forks, but GitHub still withholds repo secrets from
@@ -24,7 +29,7 @@ jobs:
       # these secrets aren't available to the run.
     - name: Generate GitHub App token for kestra-ee dispatch
       id: ee-token
-      if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false && secrets.GH_BOT_APP_ID != '' }}
+      if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false && env.GH_BOT_APP_ID != '' }}
       uses: actions/create-github-app-token@v3
       with:
         app-id: ${{ secrets.GH_BOT_APP_ID }}
@@ -39,7 +44,7 @@ jobs:
       if: ${{ github.event_name == 'pull_request'
         && github.event.pull_request.number != ''
         && github.event.pull_request.head.repo.fork == false
-        && secrets.GH_BOT_APP_ID != '' }}
+        && env.GH_BOT_APP_ID != '' }}
       uses: ./.github/actions/ee-compile-check
       with:
         webhook-url: ${{ secrets.KESTRA_CI_EEBUILD_WEBHOOK_URL }}
@@ -54,7 +59,7 @@ jobs:
       if: ${{ github.event_name == 'pull_request'
         && github.event.pull_request.number != ''
         && github.event.pull_request.head.repo.fork == false
-        && secrets.GH_BOT_APP_ID != '' }}
+        && env.GH_BOT_APP_ID != '' }}
       with:
         token: ${{ steps.ee-token.outputs.token }}
         repository: kestra-io/kestra-ee


### PR DESCRIPTION
## Problem

Every OSS PR (and `develop` itself) is currently failing the **Pull Request Workflow at startup** — the run creates **zero jobs**, so `Backend - Tests`, `Frontend - Tests`, `E2E - Tests` and `Generate PR docker image` never post checks. Only the standalone `Codespell` and `dependency-submission` workflows run, so PRs appear to have just two checks.

GitHub reports:

```
Invalid workflow file: .github/workflows/pull-request.yml
Unrecognized named-value: 'secrets'. Located at position 93 within expression:
github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false && secrets.GH_BOT_APP_ID != ''
```

## Root cause

Regression from #17748. The `trigger-ee` job guards its steps with `secrets.GH_BOT_APP_ID != ''` **inside `if:` conditions**. The `secrets` context is **not permitted in `if:`** — it invalidates the entire workflow file, which fails the run before any job is scheduled.

## Fix

Expose the app-id as a **job-level `env` var** (the `env` context *is* allowed in `if:`) and gate on `env.GH_BOT_APP_ID != ''` at all four sites. The `with:` blocks keep using `secrets.GH_BOT_APP_ID` / `secrets.GH_BOT_PRIVATE_KEY`, which is valid there.

The Dependabot-guard intent of #17748 is preserved: on Dependabot runs the secret is withheld, so `env.GH_BOT_APP_ID` is empty and the steps still skip.