### PR TITLE
fix(executions): forward the type prop through Resume, Pause and ResumeFromBreakpoint

### DIFF
--- a/ui/src/components/executions/overview/components/actions/Pause.vue
+++ b/ui/src/components/executions/overview/components/actions/Pause.vue
@@ -1,5 +1,6 @@
 <template>
     <NavBarAction
+        v-bind="$attrs"
         :disabled="!enabled"
         :icon="Pause"
         @click="click"
@@ -31,6 +32,8 @@
     import {computed, ref} from "vue"
     import {useI18n} from "vue-i18n"
     import {useToast} from "../../../../../utils/toast"
+
+    defineOptions({inheritAttrs: false})
 
     const props = defineProps({
         execution: {

--- a/ui/src/components/executions/overview/components/actions/Resume.vue
+++ b/ui/src/components/executions/overview/components/actions/Resume.vue
@@ -1,6 +1,7 @@
 <template>
     <NavBarAction
         v-if="enabled"
+        v-bind="$attrs"
         :icon="Play"
         @click="click"
     >
@@ -39,6 +40,8 @@
     import {useExecutionsStore} from "../../../../../stores/executions"
     import {useAuthStore} from "override/stores/auth"
     import {useToast} from "../../../../../utils/toast"
+
+    defineOptions({inheritAttrs: false})
 
     const props = defineProps<{
         // FIXME: any - execution is an untyped domain object

--- a/ui/src/components/executions/overview/components/actions/ResumeFromBreakpoint.vue
+++ b/ui/src/components/executions/overview/components/actions/ResumeFromBreakpoint.vue
@@ -1,6 +1,7 @@
 <template>
     <KsButton
         v-if="enabled"
+        v-bind="$attrs"
         :icon="Play"
         @click="click"
     >
@@ -48,6 +49,8 @@
     import {getAllTaskIds} from "../../../../../utils/flowUtils"
     import {useI18n} from "vue-i18n"
     import {useToast} from "../../../../../utils/toast"
+
+    defineOptions({inheritAttrs: false})
 
     const props = defineProps({
         execution: {

--- a/ui/tests/storybook/components/executions/overview/components/actions/Pause.stories.ts
+++ b/ui/tests/storybook/components/executions/overview/components/actions/Pause.stories.ts
@@ -1,0 +1,68 @@
+import type {Meta, StoryObj} from "@storybook/vue3-vite"
+import {expect} from "storybook/test"
+import {createI18n} from "vue-i18n"
+import {createPinia} from "pinia"
+import KestraDesignSystem from "@kestra-io/design-system"
+import Pause from "../../../../../../../src/components/executions/overview/components/actions/Pause.vue"
+import en from "../../../../../../../src/translations/en.json"
+
+const i18n = createI18n({legacy: false, locale: "en", fallbackWarn: false, missingWarn: false, messages: {en}})
+const pinia = createPinia()
+
+const execution = {
+    id: "exec-id",
+    flowId: "flow-id",
+    namespace: "io.kestra.tests",
+    state: {current: "RUNNING"},
+}
+
+const meta: Meta<typeof Pause> = {
+    title: "executions/actions/Pause",
+    component: Pause,
+    decorators: [
+        (story) => ({
+            components: {story},
+            plugins: [i18n, KestraDesignSystem, pinia],
+            template: "<div style=\"padding:24px\"><story /></div>",
+        }),
+    ],
+    parameters: {
+        docs: {
+            description: {
+                component:
+                    "Pause.vue has multiple root nodes (the button + a KsDialog), so Vue does not auto-forward attributes like `type` to the button - it re-binds `$attrs` onto the rendered button itself. These stories guard that wiring.",
+            },
+        },
+    },
+}
+export default meta
+type Story = StoryObj<typeof Pause>
+
+/** ExecutionRootTopBar passes type="primary" when Pause is the execution's sole primary action. */
+export const PrimaryAction: Story = {
+    render: () => ({
+        components: {Pause},
+        setup() {
+            return {execution}
+        },
+        template: "<Pause :execution=\"execution\" type=\"primary\" />",
+    }),
+    async play({canvasElement}) {
+        await expect(canvasElement.querySelector("button.kel-button--primary")).toBeTruthy()
+    },
+}
+
+/** Inside the "Actions" dropdown, no type is passed - the button keeps the default style. */
+export const DropdownItem: Story = {
+    render: () => ({
+        components: {Pause},
+        setup() {
+            return {execution}
+        },
+        template: "<Pause :execution=\"execution\" />",
+    }),
+    async play({canvasElement}) {
+        await expect(canvasElement.querySelector("button.kel-button")).toBeTruthy()
+        await expect(canvasElement.querySelector("button.kel-button--primary")).toBeFalsy()
+    },
+}

--- a/ui/tests/storybook/components/executions/overview/components/actions/Resume.stories.ts
+++ b/ui/tests/storybook/components/executions/overview/components/actions/Resume.stories.ts
@@ -1,0 +1,74 @@
+import type {Meta, StoryObj} from "@storybook/vue3-vite"
+import {expect} from "storybook/test"
+import {createI18n} from "vue-i18n"
+import {createPinia} from "pinia"
+import KestraDesignSystem from "@kestra-io/design-system"
+import Resume from "../../../../../../../src/components/executions/overview/components/actions/Resume.vue"
+import {useExecutionsStore} from "../../../../../../../src/stores/executions"
+import en from "../../../../../../../src/translations/en.json"
+
+const i18n = createI18n({legacy: false, locale: "en", fallbackWarn: false, missingWarn: false, messages: {en}})
+const pinia = createPinia()
+
+const execution = {
+    id: "exec-id",
+    flowId: "flow-id",
+    namespace: "io.kestra.tests",
+    state: {current: "PAUSED"},
+}
+
+const meta: Meta<typeof Resume> = {
+    title: "executions/actions/Resume",
+    component: Resume,
+    decorators: [
+        (story) => ({
+            setup() {
+                const executionsStore = useExecutionsStore()
+                ;(executionsStore as any).loadFlowForExecution = () => Promise.resolve(undefined)
+                ;(executionsStore as any).resume = () => Promise.resolve({})
+            },
+            components: {story},
+            plugins: [i18n, KestraDesignSystem, pinia],
+            template: "<div style=\"padding:24px\"><story /></div>",
+        }),
+    ],
+    parameters: {
+        docs: {
+            description: {
+                component:
+                    "Resume.vue has multiple root nodes (the button + a KsDialog), so Vue does not auto-forward attributes like `type` to the button - it re-binds `$attrs` onto the rendered button itself. These stories guard that wiring.",
+            },
+        },
+    },
+}
+export default meta
+type Story = StoryObj<typeof Resume>
+
+/** ExecutionRootTopBar passes type="primary" when Resume is the execution's sole primary action. */
+export const PrimaryAction: Story = {
+    render: () => ({
+        components: {Resume},
+        setup() {
+            return {execution}
+        },
+        template: "<Resume :execution=\"execution\" type=\"primary\" />",
+    }),
+    async play({canvasElement}) {
+        await expect(canvasElement.querySelector("button.kel-button--primary")).toBeTruthy()
+    },
+}
+
+/** Inside the "Actions" dropdown, no type is passed - the button keeps the default style. */
+export const DropdownItem: Story = {
+    render: () => ({
+        components: {Resume},
+        setup() {
+            return {execution}
+        },
+        template: "<Resume :execution=\"execution\" />",
+    }),
+    async play({canvasElement}) {
+        await expect(canvasElement.querySelector("button.kel-button")).toBeTruthy()
+        await expect(canvasElement.querySelector("button.kel-button--primary")).toBeFalsy()
+    },
+}

--- a/ui/tests/storybook/components/executions/overview/components/actions/ResumeFromBreakpoint.stories.ts
+++ b/ui/tests/storybook/components/executions/overview/components/actions/ResumeFromBreakpoint.stories.ts
@@ -1,0 +1,74 @@
+import type {Meta, StoryObj} from "@storybook/vue3-vite"
+import {expect} from "storybook/test"
+import {createI18n} from "vue-i18n"
+import {createPinia} from "pinia"
+import KestraDesignSystem from "@kestra-io/design-system"
+import ResumeFromBreakpoint from "../../../../../../../src/components/executions/overview/components/actions/ResumeFromBreakpoint.vue"
+import {useExecutionsStore} from "../../../../../../../src/stores/executions"
+import en from "../../../../../../../src/translations/en.json"
+
+const i18n = createI18n({legacy: false, locale: "en", fallbackWarn: false, missingWarn: false, messages: {en}})
+const pinia = createPinia()
+
+const execution = {
+    id: "exec-id",
+    flowId: "flow-id",
+    namespace: "io.kestra.tests",
+    state: {current: "BREAKPOINT"},
+}
+
+const meta: Meta<typeof ResumeFromBreakpoint> = {
+    title: "executions/actions/ResumeFromBreakpoint",
+    component: ResumeFromBreakpoint,
+    decorators: [
+        (story) => ({
+            setup() {
+                const executionsStore = useExecutionsStore()
+                ;(executionsStore as any).loadFlowForExecution = () => Promise.resolve(undefined)
+                ;(executionsStore as any).resumeFromBreakpoint = () => Promise.resolve({})
+            },
+            components: {story},
+            plugins: [i18n, KestraDesignSystem, pinia],
+            template: "<div style=\"padding:24px\"><story /></div>",
+        }),
+    ],
+    parameters: {
+        docs: {
+            description: {
+                component:
+                    "ResumeFromBreakpoint.vue has multiple root nodes (the button + a KsDialog), so Vue does not auto-forward attributes like `type` to the button - it re-binds `$attrs` onto the rendered button itself. These stories guard that wiring.",
+            },
+        },
+    },
+}
+export default meta
+type Story = StoryObj<typeof ResumeFromBreakpoint>
+
+/** ExecutionRootTopBar passes type="primary" when ResumeFromBreakpoint is the execution's sole primary action. */
+export const PrimaryAction: Story = {
+    render: () => ({
+        components: {ResumeFromBreakpoint},
+        setup() {
+            return {execution}
+        },
+        template: "<ResumeFromBreakpoint :execution=\"execution\" type=\"primary\" />",
+    }),
+    async play({canvasElement}) {
+        await expect(canvasElement.querySelector("button.kel-button--primary")).toBeTruthy()
+    },
+}
+
+/** Inside the "Actions" dropdown, no type is passed - the button keeps the default style. */
+export const DropdownItem: Story = {
+    render: () => ({
+        components: {ResumeFromBreakpoint},
+        setup() {
+            return {execution}
+        },
+        template: "<ResumeFromBreakpoint :execution=\"execution\" />",
+    }),
+    async play({canvasElement}) {
+        await expect(canvasElement.querySelector("button.kel-button")).toBeTruthy()
+        await expect(canvasElement.querySelector("button.kel-button--primary")).toBeFalsy()
+    },
+}


### PR DESCRIPTION
Fixes #17756

Resume, Pause and ResumeFromBreakpoint each render a button plus a KsDialog, giving them multiple root nodes. Vue only auto-forwards attributes when a component has a single root, so the `type="primary"` passed by `ExecutionRootTopBar` for the primary-action slot was silently dropped and the button always fell back to the default style. `type` is now declared as an explicit prop on all three and wired through to the rendered button.