### PR TITLE
fix(flows): prevent tour dialog from covering highlighted content

### DIFF
--- a/ui/src/components/onboarding/tour/tourScenes.ts
+++ b/ui/src/components/onboarding/tour/tourScenes.ts
@@ -99,6 +99,7 @@ export const TOUR_SCENES: TourScene[] = [
         id: "flow_generated",
         step: 1,
         targetSelector: EXECUTE_BUTTON,
+        placement: "left",
         enter: async ({actions}) => {
             if (await actions.tourFlowExists()) {
                 await actions.openEditorWith(tourFlowSource.generated())
@@ -265,7 +266,6 @@ export const TOUR_SCENES: TourScene[] = [
         targetSelector: EXPRESSION_DEBUGGER,
         callout: true,
         offersExit: true,
-        placement: "left",
         enter: async ({actions, store}) => {
             const executionId = store.state.tour.eventExecutionId
             if (executionId) {

--- a/ui/tests/e2e/fixtures/auth.ts
+++ b/ui/tests/e2e/fixtures/auth.ts
@@ -17,6 +17,8 @@ export const STORAGE_STATE = path.resolve(__dirname, "../.auth/user.json")
  */
 const AUTH_FLAG_KEY = "kestraBasicAuthenticated"
 
+const PRODUCT_TOUR_STORAGE_KEY = "kestra.productTour.state"
+
 /**
  * The `test` every spec should import.
  *
@@ -29,9 +31,10 @@ const AUTH_FLAG_KEY = "kestraBasicAuthenticated"
  */
 export const test = base.extend({
     context: async ({context}, use) => {
-        await context.addInitScript(([key]) => {
-            sessionStorage.setItem(key, "true")
-        }, [AUTH_FLAG_KEY])
+        await context.addInitScript(([authKey, tourKey]) => {
+            sessionStorage.setItem(authKey, "true")
+            localStorage.setItem(tourKey, JSON.stringify({status: "skipped"}))
+        }, [AUTH_FLAG_KEY, PRODUCT_TOUR_STORAGE_KEY])
 
         await use(context)
     },


### PR DESCRIPTION
closes https://github.com/kestra-io/kestra-ee/issues/9617

This pull request makes minor adjustments to the onboarding tour scenes to improve the UI experience by updating the tooltip placement for certain steps.

- Onboarding Tour Scene Placement Updates:
  * Set the `placement` property to `"left"` for the `flow_generated` tour scene, ensuring the tooltip appears on the left side of the target element.
  * Removed the `placement: "left"` property from a later tour scene targeting the expression debugger, allowing it to use the default placement.