### PR TITLE
test: mock fetch layer for Storybook to intercept SDK API calls

### DIFF
--- a/ui/.storybook/apiMock.js
+++ b/ui/.storybook/apiMock.js
@@ -67,6 +67,7 @@ const HANDLERS = {
 
     // --- executions ---------------------------------------------------------------------------
     "GET /executions/search": {results: [], total: 0},
+    "GET /executions/namespaces/:namespace/flows/:flowId/average-duration": {avgDurationMs: null, count: 0},
     "GET /outputs/:executionId": [],
 
     // --- dashboards & misc --------------------------------------------------------------------

--- a/ui/.storybook/apiMock.js
+++ b/ui/.storybook/apiMock.js
@@ -1,0 +1,287 @@
+// Storybook/Vitest API double.
+//
+// WHY THIS EXISTS
+// ---------------
+// There is no backend behind Storybook, yet almost every component tree issues HTTP calls. Before
+// this module the only stub was `axios.defaults.adapter` (see preview.jsx), which covers just the 4
+// files in src/ that still import axios. Everything else is fetch-based:
+//
+//   * the generated SDK (packages/kestra-sdk/src/openapi/*) resolves
+//     `options.fetch ?? _config.fetch ?? globalThis.fetch` per request (openapi/client/client.gen.ts),
+//   * the axios-like facade (packages/kestra-sdk/src/client-facade.ts) calls bare global `fetch`.
+//
+// `setMockClient()` only swaps the FACADE's methods, so every generated-SDK call used to escape to
+// the Vitest browser dev server. That is where the storybook warnings came from: a GET came back 200
+// with a non-JSON body, hey-api's `parseAs: "auto"` handed the store the body as TEXT (hence
+// `[Vue warn] Invalid prop "plugins". Expected Array, got String`), and a POST 404'd into a thrown
+// error that surfaced as `[FederatedModule] Failed to load plugin UI manifest` plus anonymous
+// `PromiseRejectionEvent`s, often after the story had already finished ("unknown test").
+//
+// So the interception has to happen at the fetch layer, which is what this module does. It is
+// imported FIRST by both `preview.jsx` (dev Storybook + tests) and `vitest.setup.js` (tests only) and
+// deliberately imports nothing from `src/` or the SDK: pulling either in would evaluate
+// `override/utils/route.ts` and the SDK client before the patch is installed.
+//
+// Writing a story stays cheap: an API route with no handler still answers, with an empty array, so
+// nothing throws. But it is never silent — the route, the story that hit it and the URL are logged
+// once per story, so a blank-looking story is traceable to the missing mock in one line instead of
+// surfacing as an HTML-string-shaped prop three components deep.
+
+const API_MARKER = "/api/v1"
+
+/**
+ * Payloads for the API routes stories actually reach, keyed by `METHOD <path from /api/v1 onward>`.
+ *
+ * Paths are matched prefix-agnostically (see `apiPath`), so the tenant-scoped `/api/v1/main/flows`
+ * (route.ts `basePath()`) and the tenant-less `/api/v1/plugins` (`basePathWithoutTenant()`) are keyed
+ * the same way, and it makes no difference whether the caller built an absolute or a relative URL.
+ *
+ * A `:name` segment matches any single segment and a trailing `*` matches the rest of the path, so
+ * path parameters are covered. Exact keys win over patterned ones. A value may be a plain payload or
+ * a `(context) => payload` function.
+ *
+ * Empty-but-correctly-SHAPED payloads matter: an object where a store expects an array is what turns
+ * a missing mock into a `TypeError: data.map is not a function` deep inside a component. Each shape
+ * below is the endpoint's `200` type from packages/kestra-sdk/src/openapi/types.gen.ts.
+ */
+const HANDLERS = {
+    // --- plugins ------------------------------------------------------------------------------
+    "GET /plugins": {results: [], total: 0},
+    "GET /plugins/groups/subgroups": [],
+    "GET /plugins/icons": {},
+    "GET /plugins/icons/groups": {},
+    "GET /plugins/icons/:cls": {icon: null},
+    "GET /plugins/inputs": [],
+    "GET /plugins/triggers": {results: [], total: 0},
+    "GET /plugins/schemas/:type": {},
+    "POST /plugins/pluginUiManifest": {manifest: {}},
+
+    // --- flows --------------------------------------------------------------------------------
+    "GET /flows/:namespace": [],
+    "GET /flows/:namespace/:id/revisions": [],
+    "GET /flows/:namespace/:id/dependencies": {nodes: [], edges: []},
+
+    // --- namespaces ---------------------------------------------------------------------------
+    "POST /namespaces/autocomplete": [],
+    "GET /namespaces/:namespace/files/directory": [],
+
+    // --- executions ---------------------------------------------------------------------------
+    "GET /executions/search": {results: [], total: 0},
+    "GET /outputs/:executionId": [],
+
+    // --- dashboards & misc --------------------------------------------------------------------
+    "POST /dashboards/charts/preview": {results: [], total: 0},
+    "GET /concurrency-limit/search": {results: [], total: 0},
+}
+
+/**
+ * Patterned route keys (those containing a `:param` or trailing `*`), pre-split into segments.
+ * Sorted with the most segments first so the most specific pattern wins.
+ */
+const PATTERNS = Object.keys(HANDLERS)
+    .filter((key) => key.includes("/:") || key.endsWith("*"))
+    .map((key) => ({key, segments: key.split("/")}))
+    .sort((a, b) => b.segments.length - a.segments.length)
+
+function matchesPattern(segments, requestSegments) {
+    for (let i = 0; i < segments.length; i++) {
+        const segment = segments[i]
+        if (segment === "*") return true
+        if (i >= requestSegments.length) return false
+        if (segment.startsWith(":")) continue
+        if (segment !== requestSegments[i]) return false
+    }
+    return segments.length === requestSegments.length
+}
+
+/**
+ * The `/api/v1`-onward portion of a URL, or `undefined` when the URL is not an API call.
+ * Matching on `URL.pathname` (never the raw string) keeps dev-server routes — `/@vite/`, `/@fs/`,
+ * `/@id/`, `/__vitest_*`, `/monaco/*` — out of scope: none of them contain `/api/v1`.
+ */
+function apiPath(rawUrl) {
+    let pathname
+    try {
+        // blob:/data: URLs (monaco workers) throw or have no meaningful pathname — pass those through.
+        pathname = new URL(rawUrl, window.location.href).pathname
+    } catch {
+        return undefined
+    }
+
+    const index = pathname.indexOf(API_MARKER)
+    if (index === -1) return undefined
+
+    const path = pathname.slice(index + API_MARKER.length)
+    // Drop the tenant segment so `/main/flows/x` and `/flows/x` resolve to the same handler key.
+    return path.replace(/^\/main(?=\/|$)/, "")
+}
+
+const reported = new Set()
+let currentStory = ""
+
+/**
+ * Report an API route no handler covers.
+ *
+ * The request is still answered (a non-2xx would restart the `while (true)` retry loop in the SDK's
+ * server-sent-events client and re-create the very rejection cascade this module removes), so this
+ * log line is the ONLY signal that a story is rendering against empty data — a story stays cheap to
+ * write, but nobody has to guess why it renders blank. De-duplicated per route because a polling
+ * store multiplied by 55 story files would flood CI.
+ */
+function reportUnmocked(key, rawUrl) {
+    if (reported.has(key)) return
+    reported.add(key)
+    // console.warn rather than console.error: some CI gates fail a build on console.error.
+    // The key is what a handler must be registered under; the raw URL is what was actually called.
+    console.warn(
+        `[storybook] unmocked API request: ${key} — returning empty data, so this story renders without it.`
+        + ` Add a handler in .storybook/apiMock.js (or mock it in the story).`
+        + `\n  story: ${currentStory || "unknown"}\n  url:   ${rawUrl}`,
+    )
+}
+
+/**
+ * Scope the reporting to one story: names it in the warnings and clears the de-duplication record,
+ * so an unmocked route is attributed to every story it affects rather than only the first.
+ */
+export function beginStoryScope(label) {
+    currentStory = label ?? ""
+    reported.clear()
+}
+
+/**
+ * Resolve an API call to `{status, data}`. This is the single source of truth shared by the fetch
+ * wrapper below and by `mockClientFallback()`, which story-local `setMockClient()` catch-alls use.
+ */
+export function resolveApiRequest(method, rawUrl, context = {}) {
+    const path = apiPath(rawUrl) ?? rawUrl
+    const upperMethod = method.toUpperCase()
+    const key = `${upperMethod} ${path}`
+
+    if (key in HANDLERS) {
+        const handler = HANDLERS[key]
+        return {status: 200, data: typeof handler === "function" ? handler(context) : handler}
+    }
+
+    const requestSegments = key.split("/")
+    const pattern = PATTERNS.find(({segments}) => matchesPattern(segments, requestSegments))
+    if (pattern) {
+        const handler = HANDLERS[pattern.key]
+        return {status: 200, data: typeof handler === "function" ? handler(context) : handler}
+    }
+
+    reportUnmocked(key, rawUrl)
+    // An empty ARRAY, not an empty object: it has `length`, `map`, `filter` and is iterable, so a
+    // component that expected a list degrades to "no rows" instead of throwing
+    // `TypeError: data.map is not a function` somewhere far from the missing mock. Paged consumers
+    // reading `.results` get undefined, which they already guard for. Either way the warning above
+    // is the signal — this default only keeps the story renderable.
+    return {status: 200, data: []}
+}
+
+/**
+ * Axios-like adapter over {@link resolveApiRequest}, for stories that install their own
+ * `setMockClient()` and need a default for the URIs they don't handle themselves.
+ */
+export function mockClientFallback(method, uri, data) {
+    const {status, data: payload} = resolveApiRequest(method, uri, {body: data})
+    return {data: payload, status, statusText: "OK", headers: {"content-type": "application/json"}}
+}
+
+function jsonResponse({status, data}) {
+    // Always a real JSON content-type with a non-empty body: with no content-type hey-api's
+    // `getParseAs(null)` returns "stream" and hands a ReadableStream to the store, and a 204 or an
+    // empty body is special-cased by both parsers into null/{}/response.body.
+    return new Response(JSON.stringify(data ?? {}), {
+        status,
+        statusText: status < 400 ? "OK" : "Error",
+        headers: {"content-type": "application/json"},
+    })
+}
+
+/**
+ * The installed wrapper, exported so `preview.jsx` can also hand it to `configureClient({fetch})`.
+ * The generated SDK resolves `options.fetch ?? _config.fetch ?? globalThis.fetch`, so pinning it
+ * there makes the generated-SDK path explicit instead of relying on the global patch alone.
+ */
+export let apiFetch
+
+function installFetchMock() {
+    if (window.fetch.__kestraApiMock) {
+        apiFetch = window.fetch
+        return
+    }
+
+    const native = window.fetch.bind(window)
+
+    // A plain function that never touches `this`: the SDK calls its fetch reference UNBOUND
+    // (`const _fetch = opts.fetch!; await _fetch(request)`), so a method-style wrapper would break.
+    const wrapper = (input, init) => {
+        const isRequest = typeof Request !== "undefined" && input instanceof Request
+        const rawUrl = isRequest ? input.url : String(input)
+        const path = apiPath(rawUrl)
+
+        // Anything that is not an API call — Vite's module graph, monaco assets, the storybook and
+        // vitest channels — goes to the untouched native fetch.
+        if (path === undefined) return native(input, init)
+
+        const signal = init?.signal ?? (isRequest ? input.signal : undefined)
+        if (signal?.aborted) {
+            return Promise.reject(new DOMException("Aborted", "AbortError"))
+        }
+
+        const method = init?.method ?? (isRequest ? input.method : "GET")
+        // `.clone()` so the original body stays intact for anything downstream.
+        const bodyPromise = isRequest && input.body ? input.clone().text() : Promise.resolve(init?.body)
+
+        return bodyPromise
+            .catch(() => undefined)
+            .then((body) => jsonResponse(resolveApiRequest(method, rawUrl, {body})))
+    }
+
+    wrapper.__kestraApiMock = true
+    window.fetch = wrapper
+    apiFetch = wrapper
+}
+
+/**
+ * Monaco rejects the pending work of its own `Delayer`s when an editor is disposed ("Canceled:
+ * Canceled"), so tearing a story down races monaco's cleanup. It happens entirely inside
+ * monaco-editor, is not actionable, and is the only rejection class deliberately dropped here.
+ *
+ * Both spellings are needed: `/monaco/(esm|min)/vs` is the copy served from public/ at runtime, while
+ * `monaco-editor/esm/vs` is what the Vite dev server serves out of node_modules during tests. The
+ * previous filter in preview.jsx only listed the former, which is why these still reached the log.
+ */
+const MONACO_STACK = /monaco-editor[/\\]esm[/\\]vs|[/\\]monaco[/\\](esm|min)[/\\]vs/
+
+/**
+ * Print what a rejection actually was. Vitest reports an unhandled rejection by logging the event
+ * object, which for a `PromiseRejectionEvent` prints as `{isTrusted: true}` — no message, no stack,
+ * no way to tell which call failed. This adds the reason (and, for DOM-Event reasons, the element
+ * that failed to load), and deliberately does NOT call preventDefault() except for the monaco
+ * teardown race above, so vitest still reports everything that could point at a real problem.
+ */
+function installRejectionReporter() {
+    if (window.__kestraRejectionReporter) return
+    window.__kestraRejectionReporter = true
+
+    window.addEventListener("unhandledrejection", (event) => {
+        const reason = event?.reason
+        if (typeof reason?.stack === "string" && MONACO_STACK.test(reason.stack)) {
+            event.preventDefault()
+            return
+        }
+
+        if (typeof Event !== "undefined" && reason instanceof Event) {
+            const target = reason.target
+            console.error(`[storybook] unhandled rejection with a DOM ${reason.type} event`, target?.src ?? target?.currentSrc ?? target)
+            return
+        }
+
+        console.error("[storybook] unhandled rejection:", reason?.stack ?? reason?.message ?? reason)
+    })
+}
+
+installFetchMock()
+installRejectionReporter()

--- a/ui/.storybook/apiMock.js
+++ b/ui/.storybook/apiMock.js
@@ -135,7 +135,7 @@ function reportUnmocked(key, rawUrl) {
     // The key is what a handler must be registered under; the raw URL is what was actually called.
     console.warn(
         `[storybook] unmocked API request: ${key} — returning empty data, so this story renders without it.`
-        + ` Add a handler in .storybook/apiMock.js (or mock it in the story).`
+        + " Add a handler in .storybook/apiMock.js (or mock it in the story)."
         + `\n  story: ${currentStory || "unknown"}\n  url:   ${rawUrl}`,
     )
 }

--- a/ui/.storybook/preview.jsx
+++ b/ui/.storybook/preview.jsx
@@ -1,8 +1,10 @@
+// Must stay the FIRST import: it patches window.fetch before any src/ or SDK module is evaluated.
+import {apiFetch, beginStoryScope} from "./apiMock";
 import {setup} from "@storybook/vue3-vite";
 import {withThemeByClassName} from "@storybook/addon-themes";
 import initApp from "../src/utils/init";
 import {globalI18n} from "../src/translations/i18n";
-import {configureClient} from "@kestra-io/kestra-sdk";
+import {configureClient, useClient} from "@kestra-io/kestra-sdk";
 import axios from "axios";
 import {createMemoryHistory} from "vue-router";
 import {vueRouter} from "storybook-vue3-router";
@@ -17,7 +19,8 @@ window.KESTRA_UI_PATH = "./";
 // No backend is running during storybook tests, so short-circuit every axios
 // request with an empty successful response instead of letting it hit the
 // network — this prevents network errors, proxy failures, and the Vue/axios
-// error cascade that follows.
+// error cascade that follows. The fetch-based SDK — which is everything except
+// the 4 remaining axios importers in src/ — is handled by ./apiMock instead.
 // Per axios docs, a custom adapter is just a function assigned to
 // `axios.defaults.adapter`: https://axios-http.com/docs/adapters — it must NOT
 // be read back out and re-invoked (axios.defaults.adapter is normally an array
@@ -82,7 +85,13 @@ const preview = {
         },
         defaultTheme: "light",
       }),
-  ]
+  ],
+  // Name the running story in "unmocked API request" warnings, and clear their de-duplication
+  // record, so an unmocked route is reported for every story it affects and points at the story to
+  // fix rather than at nothing.
+  beforeEach({title, name}) {
+    beginStoryScope(`${title} > ${name}`);
+  },
 };
 
 setup(async (app) => {
@@ -91,19 +100,22 @@ setup(async (app) => {
   // noisy "Not found" warnings in Storybook (it already falls back to the key).
   globalI18n.value.missingWarn = false;
   globalI18n.value.fallbackWarn = false;
-  configureClient()
+  // Pin the SDK's fetch to the mock: the generated client resolves
+  // `options.fetch ?? _config.fetch ?? globalThis.fetch`, so this makes the generated-SDK path
+  // explicit rather than depending on the global patch alone.
+  configureClient({fetch: apiFetch})
+  // The real app gives stores the full client (src/main.ts), so binding only `get` here left
+  // `$http.post/put/delete` as TypeErrors. useClient() goes through the mocked fetch like
+  // everything else.
   piniaStore.use(({store}) => {
-    store.$http = {
-        get: () => Promise.resolve({data: []}),
-    }
+    store.$http = useClient();
   });
 })
 
-window.addEventListener("unhandledrejection", (evt) => {
-    if (evt?.reason?.stack?.includes?.("/monaco/esm/vs") || evt?.reason?.stack?.includes?.("/monaco/min/vs")) {
-        evt.stopImmediatePropagation()
-    }
-})
+// The unhandledrejection listener that used to live here now lives in ./apiMock, installed before
+// anything else: it drops the same monaco teardown rejections (matching the node_modules path the
+// dev server actually serves, which this one missed) and prints the reason of every other rejection,
+// which vitest otherwise reports as a bare `PromiseRejectionEvent {isTrusted: true}`.
 
 import "../src/utils/monacoEnvironment"
 

--- a/ui/.storybook/vitest.setup.js
+++ b/ui/.storybook/vitest.setup.js
@@ -1,3 +1,8 @@
+// Must stay the FIRST import: it patches window.fetch before any src/ or SDK module is evaluated.
+// preview.jsx imports it too — the install is idempotent. Importing from both files removes any
+// dependence on the relative order of this setup file and the one addon-vitest injects itself.
+import "./apiMock"
+
 // Story templates are runtime-compiled by Vue in the browser, which triggers
 // "@vue/compiler-core: decodeEntities option is passed but will be ignored in
 // non-browser builds" — a false-positive from the esm-bundler Vue build that

--- a/ui/tests/storybook/components/admin/Triggers.stories.jsx
+++ b/ui/tests/storybook/components/admin/Triggers.stories.jsx
@@ -20,6 +20,7 @@ vi.mock("@kestra-io/kestra-sdk/plugins", () => ({
 import Triggers from "../../../../src/components/admin/triggers/Triggers.vue";
 import {vueRouter} from "storybook-vue3-router";
 import {setMockClient} from "@kestra-io/kestra-sdk"
+import {mockClientFallback} from "../../../../.storybook/apiMock";
 
 const meta = {
     title: "Components/Admin/Triggers",
@@ -135,18 +136,17 @@ const Template = (args) => ({
                 }
             }
 
-            console.log("get request", uri)
-            return {data: {}}
+            // Anything this story doesn't answer itself falls back to the shared table in
+            // .storybook/apiMock.js, which reports the route if nothing there covers it either.
+            return mockClientFallback("GET", uri)
         }
 
-        store.post = async function (uri) {
-            console.log("post request", uri)
-            return {data: {}}
+        store.post = async function (uri, data) {
+            return mockClientFallback("POST", uri, data)
         }
 
-        store.put = async function (uri) {
-            console.log("put request", uri)
-            return {data: {}}
+        store.put = async function (uri, data) {
+            return mockClientFallback("PUT", uri, data)
         }
 
         setMockClient(store);

--- a/ui/tests/storybook/components/flows/MultiPanelFlowEditorView.stories.jsx
+++ b/ui/tests/storybook/components/flows/MultiPanelFlowEditorView.stories.jsx
@@ -4,6 +4,7 @@ import {flowYamlUtils as YAML_UTILS} from "@kestra-io/topology";
 import allowFailureDemo from "../../../fixtures/flowgraphs/allow-failure-demo.json";
 import flowSchema from "../../../../src/stores/flow-schema.json";
 import {setMockClient} from "@kestra-io/kestra-sdk"
+import {mockClientFallback} from "../../../../.storybook/apiMock";
 import {useFlowStore} from "../../../../src/stores/flow";
 
 
@@ -40,21 +41,18 @@ const Template = (args) => ({
             if (uri.endsWith("/distinct-namespaces")) {
                 return {data: ["sanitychecks.flows.blueprints", "tutorial"]}
             }
-            if (uri.endsWith("/subgroups")) {
-                return {data: []}
-            }
-            console.log("get request", uri)
-            return {data: {}}
+            // Anything this story doesn't answer itself falls back to the shared table in
+            // .storybook/apiMock.js, which reports the route if nothing there covers it either.
+            return mockClientFallback("GET", uri)
         }
-        axios.post = async (uri) => {
+        axios.post = async (uri, data) => {
             if (uri.endsWith("/graph")) {
                 return {data: allowFailureDemo}
             }
             if (uri.endsWith("/validate")) {
                 return {data: {}}
             }
-            console.log("post request", uri)
-            return {data: {}}
+            return mockClientFallback("POST", uri, data)
         }
         setMockClient(axios);
 

--- a/ui/tests/storybook/components/inputs/LowCodeEditor.stories.jsx
+++ b/ui/tests/storybook/components/inputs/LowCodeEditor.stories.jsx
@@ -1,17 +1,10 @@
-import {vi} from "vitest";
-
-// onMounted() calls pluginsStore.fetchIcons(), which hits PluginsAPI.pluginIcons() directly -
-// that goes through the SDK's own internal client rather than the axios instance
-// setMockClient() swaps, so it has to be intercepted at the submodule level.
-vi.mock("@kestra-io/kestra-sdk/plugins", () => ({
-    pluginIcons: async () => ({}),
-}))
-
 import {provide, ref} from "vue";
 import {TOPOLOGY_CLICK_INJECTION_KEY} from "../../../../src/components/no-code/injectionKeys";
 import {vueRouter} from "storybook-vue3-router";
 import LowCodeEditor from "../../../../src/components/inputs/LowCodeEditor.vue";
 import {setMockClient} from "@kestra-io/kestra-sdk"
+import {mockClientFallback} from "../../../../.storybook/apiMock";
+import allowFailureDemo from "../../../fixtures/flowgraphs/allow-failure-demo.json";
 
 export default {
     title: "Components/Inputs/LowCodeEditor",
@@ -29,9 +22,7 @@ const Template = (args) => ({
     setup() {
         const axios = {}
         provide(TOPOLOGY_CLICK_INJECTION_KEY, ref())
-        axios.get = () => {
-            return  Promise.resolve({data: {}})
-        }
+        axios.get = async (uri) => mockClientFallback("GET", uri)
         setMockClient(axios);
 
         return () => (<div style="width:600px; height:600px;">
@@ -42,20 +33,30 @@ const Template = (args) => ({
 
 export const Default = Template.bind({});
 Default.args = {
-    flowGraph: {
-        nodes: []
-    },
-    flowId: "flow1",
-    namespace: "namespace1",
+    flowGraph: allowFailureDemo,
+    flowId: "allow-failure-demo",
+    namespace: "sanitychecks.flows.blueprints",
     execution: {},
     isReadOnly: false,
+    // Must stay flush against column 0 and match the graph fixture above: flowHaveTasks()
+    // (packages/topology/src/utils/vueFlowUtils.ts) matches /^tasks\s*:/m, so an indented source
+    // reads as a flow with no tasks and the topology renders its empty placeholder instead.
     source: `
-    id: flow1
-    namespace: namespace1
+id: allow-failure-demo
+namespace: sanitychecks.flows.blueprints
+tasks:
+  - id: allow_failure
+    type: io.kestra.plugin.core.flow.AllowFailure
     tasks:
-      - id: task1
-        type: taskType
-    `,
+      - id: fail_silently
+        type: io.kestra.plugin.scripts.shell.Commands
+        commands:
+          - exit 1
+  - id: print_to_console
+    type: io.kestra.plugin.scripts.shell.Commands
+    commands:
+      - echo "this will run since previous failure was allowed"
+`.trim(),
     isAllowedEdit: true,
     viewType: "default",
     expandedSubflows: [],


### PR DESCRIPTION
## ✨ Description

Adds a comprehensive fetch-layer API mock for Storybook that intercepts HTTP calls from the generated SDK and axios-based code, eliminating network errors and unhandled promise rejections during story development and testing.

**Problem:** Almost every component tree issues HTTP calls, but there's no backend behind Storybook. The previous `axios.defaults.adapter` stub only covered 4 files in `src/` that import axios directly. The generated SDK (from `packages/kestra-sdk`) and the axios-like facade both use `fetch`, which was escaping to the Vite dev server, causing:
- GET requests returning 200 with non-JSON bodies, leading to `Invalid prop` warnings
- POST requests 404'ing and throwing errors surfaced as `PromiseRejectionEvent`s
- Warnings appearing after stories finished rendering ("unknown test")

**Solution:** 
- Created `ui/.storybook/apiMock.js` that patches `window.fetch` before any SDK or `src/` modules are evaluated
- Provides a `HANDLERS` registry mapping API routes to mock payloads (keyed by `METHOD <path>`)
- Supports pattern matching for parameterized routes (`:name` segments and trailing `*`)
- Returns correctly-shaped empty payloads (arrays for lists, objects for single resources) so components degrade gracefully instead of throwing
- Logs unmocked routes once per story with the story name and URL, making it easy to trace blank-looking stories to missing mocks
- Exports `resolveApiRequest()` and `mockClientFallback()` for story-local mocks to fall back to

**Changes:**
- `preview.jsx`: Imports `apiMock` first, configures SDK client with mocked fetch, uses `useClient()` for stores, moves rejection reporter to `apiMock`
- `vitest.setup.js`: Imports `apiMock` first (install is idempotent)
- Updated story files to use `mockClientFallback()` for unmocked routes instead of returning empty objects
- `LowCodeEditor.stories.jsx`: Removed SDK mock, uses real fixture data, improved source YAML formatting

## 🔗 Related Issue

N/A

## 🎨 Frontend Checklist

- [x] Code builds without errors
- [x] Existing Storybook stories render without network errors
- [x] Unhandled promise rejections are properly reported with context
- [x] Stories can be written cheaply with automatic fallback to empty data

## 📝 Additional Notes

The fetch mock is installed at the earliest possible point (before any SDK or `src/` modules load) to ensure all API calls—whether from generated SDK code, the axios facade, or direct fetch calls—are intercepted. The pattern matching system allows flexible route definitions while maintaining specificity (exact keys win over patterns, more specific patterns win over general ones).

The `beginStoryScope()` function is called by Storybook's `beforeEach` hook to scope warnings to individual stories and clear the de-duplication record, so developers see which story needs a mock added rather than only the first story that hit an unmocked route.

https://claude.ai/code/session_01QJyb6CSvtgVh413xU3Yj6Z