### PR TITLE
refactor(logs): drop the deprecated sizeDependencies prop from DynamicScroller items

### DIFF
--- a/ui/src/components/executions/Gantt.vue
+++ b/ui/src/components/executions/Gantt.vue
@@ -84,7 +84,6 @@
                                     :item="item"
                                     :active="active"
                                     :data-index="index"
-                                    :sizeDependencies="[selectedTaskRuns]"
                                 >
                                     <div class="d-flex flex-column">
                                         <div

--- a/ui/src/components/executions/Logs.vue
+++ b/ui/src/components/executions/Logs.vue
@@ -76,7 +76,6 @@
                     <DynamicScrollerItem
                         :item="asLog(item)"
                         :active="active"
-                        :sizeDependencies="[asLog(item).message]"
                         :data-index="asLog(item).index"
                         :key="asLog(item).uid"
                     >

--- a/ui/src/components/logs/TaskRunDetails.vue
+++ b/ui/src/components/logs/TaskRunDetails.vue
@@ -77,7 +77,6 @@
                             <DynamicScrollerItem
                                 :item="item"
                                 :active="active"
-                                :sizeDependencies="[item.message, item.image, item.isGroup, item.isGroup && isGroupExpanded(currentTaskRunIndex, item)]"
                                 :data-index="item.index"
                             >
                                 <template v-if="item.isGroup">

--- a/ui/tests/storybook/components/logs/TaskRunDetails.stories.tsx
+++ b/ui/tests/storybook/components/logs/TaskRunDetails.stories.tsx
@@ -1,0 +1,138 @@
+import {vueRouter} from "storybook-vue3-router";
+import type {Meta, StoryObj} from "@storybook/vue3";
+import {expect, userEvent, waitFor} from "storybook/test";
+import {useExecutionsStore} from "../../../../src/stores/executions";
+import TaskRunDetails from "../../../../src/components/logs/TaskRunDetails.vue";
+
+const TASK_RUN_ID = "task-run-1";
+
+const BASE_LOG = {
+    namespace: "company.team",
+    flowId: "test-flow",
+    executionId: "test-exec-id",
+    thread: "main",
+    attemptNumber: 0,
+    executionKind: "flow" as const,
+    taskRunId: TASK_RUN_ID,
+    taskId: "my-task",
+    level: "INFO",
+};
+
+// The four "Processed record NNN" lines collapse into ONE group item: normalizeLogTemplate
+// (src/utils/logs.ts) masks any run of 3+ digits, so they share a template key, and 4 consecutive
+// matches is over COLLAPSE_THRESHOLD (3). The surrounding lines have distinct templates and stay
+// ungrouped, which is what makes the group's boundaries observable.
+const FAKE_LOGS = [
+    {...BASE_LOG, index: 0, timestamp: "2025-01-01T00:00:00.000Z", message: "Starting my-task"},
+    {...BASE_LOG, index: 1, timestamp: "2025-01-01T00:00:01.000Z", message: "Processed record 100"},
+    {...BASE_LOG, index: 2, timestamp: "2025-01-01T00:00:02.000Z", message: "Processed record 200"},
+    {...BASE_LOG, index: 3, timestamp: "2025-01-01T00:00:03.000Z", message: "Processed record 300"},
+    {...BASE_LOG, index: 4, timestamp: "2025-01-01T00:00:04.000Z", message: "Processed record 400"},
+    {...BASE_LOG, index: 5, timestamp: "2025-01-01T00:00:05.000Z", message: "Finished my-task"},
+];
+
+const TASK_RUN_STATE = {
+    current: "SUCCESS",
+    startDate: "2025-01-01T00:00:00Z",
+    endDate: "2025-01-01T00:00:06Z",
+    duration: "PT6S",
+    histories: [
+        {state: "CREATED", date: "2025-01-01T00:00:00Z"},
+        {state: "RUNNING", date: "2025-01-01T00:00:00Z"},
+        {state: "SUCCESS", date: "2025-01-01T00:00:06Z"},
+    ],
+};
+
+const FAKE_EXECUTION = {
+    id: "test-exec-id",
+    flowId: "test-flow",
+    namespace: "company.team",
+    state: TASK_RUN_STATE,
+    taskRunList: [{id: TASK_RUN_ID, taskId: "my-task", state: TASK_RUN_STATE, attempts: [{state: TASK_RUN_STATE}]}],
+};
+
+const ROUTER_ROUTES = [
+    {path: "/", name: "home", component: {template: "<div/>"}},
+    {path: "/executions/:namespace/:flowId/:id/:tab?", name: "executions/update", component: {template: "<div/>"}},
+    {path: "/flows/edit/:namespace/:id/:tab?", name: "flows/update", component: {template: "<div/>"}},
+];
+
+// Note: mounting this component also triggers useTaskRunOutputs -> OutputsAPI.taskOutputsInformation,
+// a generated SDK call, which reaches the dev server and logs one rejection. It deliberately is not
+// stubbed here: vi.mock() has no effect on @kestra-io/kestra-sdk/* in a story file, because the SDK
+// is a pre-bundled dependency that vitest's browser mocker cannot intercept. The fix belongs at the
+// fetch layer, where the Storybook API double (PR #17772) answers that route with an empty list.
+const decorators = [
+    () => ({
+        setup() {
+            const executionsStore = useExecutionsStore();
+            executionsStore.execution = FAKE_EXECUTION as any;
+            (executionsStore as any).loadLogs = async () => FAKE_LOGS;
+        },
+        template: "<div style='padding:1rem'><story /></div>",
+    }),
+    vueRouter(ROUTER_ROUTES, {initialRoute: "/executions/company.team/test-flow/test-exec-id"}),
+];
+
+const meta: Meta<typeof TaskRunDetails> = {
+    title: "Components/Logs/TaskRunDetails",
+    component: TaskRunDetails,
+    parameters: {layout: "fullscreen"},
+    decorators,
+    // Passing taskRunId renders this taskrun's logs directly, without first expanding an attempt.
+    args: {taskRunId: TASK_RUN_ID, showProgressBar: false},
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+/**
+ * Collapsed runs of similar log lines are the one place where an item's height changes WITHOUT its
+ * `item` prop changing: toggleGroup() mutates an external expandedGroups set, and the item then
+ * renders `members.length` lines instead of one. DynamicScroller re-measures it through its own
+ * ResizeObserver.
+ *
+ * Asserts on aria-expanded and on the member lines appearing rather than on measured heights —
+ * heights are unreliable to assert in Storybook's sandboxed iframe, since DynamicScroller only
+ * renders what is in the viewport.
+ */
+export const ExpandsCollapsedLogGroup: Story = {
+    play: async ({canvasElement}: {canvasElement: HTMLElement}) => {
+        const toggle = await waitFor(
+            () => {
+                const button = canvasElement.querySelector<HTMLButtonElement>(".log-group-more");
+                if (!button) throw new Error("collapsed log group toggle not rendered");
+                return button;
+            },
+            {timeout: 5000},
+        );
+
+        // Collapsed: the group shows its first member plus a "×4" summary button.
+        expect(toggle.getAttribute("aria-expanded")).toBe("false");
+        expect(toggle.textContent).toContain("×4");
+        expect(canvasElement.textContent).not.toContain("Processed record 400");
+
+        await userEvent.click(toggle);
+
+        // Expanded: every member is rendered and the toggle reports the new state.
+        await waitFor(
+            () => {
+                expect(toggle.getAttribute("aria-expanded")).toBe("true");
+                expect(canvasElement.textContent).toContain("Processed record 400");
+            },
+            {timeout: 3000},
+        );
+
+        // Collapsing puts it back, so the group is not a one-way door.
+        await userEvent.click(toggle);
+        await waitFor(
+            () => {
+                expect(toggle.getAttribute("aria-expanded")).toBe("false");
+                expect(canvasElement.textContent).not.toContain("Processed record 400");
+            },
+            {timeout: 3000},
+        );
+    },
+};


### PR DESCRIPTION
### ✨ Description

Removes the deprecated `sizeDependencies` prop from the three `DynamicScrollerItem` call sites — `Logs.vue`, `Gantt.vue`, `TaskRunDetails.vue`. Three deleted lines, nothing added.

Every Storybook run prints:

```
[vue-virtual-scroller] `sizeDependencies` is deprecated and will be removed in the next major
release. Dynamic item sizing uses ResizeObserver in modern browsers.
```

It cannot be silenced from our side — the library's own `import.meta.env.MODE !== 'test'` guard was resolved when the package was built, so our `MODE=test` has no effect. Not passing the prop is the only fix.

**Why this is behaviour-preserving.** In `vue-virtual-scroller@3.0.4` the prop's watcher is:

```ts
warnDeprecatedSizeDependencies(value)
if (!context.resizeObserver) {
  onDataUpdate()          // the only re-measure it ever triggers
}
```

and the observer is created with nothing but feature detection (`useDynamicScroller.js`: `typeof ResizeObserver < "u" && new ResizeObserver(...)`, one per scroller, no prop or flag), attached to the same element whose `offsetHeight` the legacy path measured. So in any browser `onDataUpdate()` is unreachable and the prop's only remaining effect was the warning. `watchData` is not a substitute — it is gated on the same `!context.resizeObserver`, and the library's own docs call it "only for legacy no-`ResizeObserver` fallbacks".

Coverage actually improves in two places: a height change now fires on the real layout change rather than on a dependency-array identity change, and an `<img>` finishing load is caught — which the prop never caught.

Two of the removed inputs were already broken:
- `item.image` (`TaskRunDetails.vue`) is dead — no `image` field exists on `Log`.
- `Gantt.vue` passed `[selectedTaskRuns]` while `onTaskSelect` mutates that array **in place**, so the shallow compare never fired for those paths.

Each removal also deletes a per-item `{deep: true}` watcher over an array rebuilt on every render.

### 🔗 Related Issue

No issue. Follow-up to #17772, which cleaned up the rest of the Storybook test warnings; this was the last Kestra-caused one left.

### 🎨 Frontend Checklist

- [x] `npm run test:storybook` — 57 files / 189 tests pass, and **zero** occurrences of the deprecation warning (was 1 per run)
- [x] `npm run test:unit` — 124 files / 1023 tests pass
- [x] `npm run check:types` and `npm run test:lint` (0 errors) pass
- [ ] `npm run build` — not run
- [ ] `npm run test:e2e` — not run
- [ ] Screenshots / recordings — **not attached**: there is no visual change to capture, and I could not drive the real app in this environment. See the review note below for what is worth eyeballing.

### 📝 Additional Notes

**Added the missing test.** The load-bearing case was `TaskRunDetails.vue`'s collapsed-log-group expand: `toggleGroup()` mutates an external `expandedGroups` set and never touches `item`, so the item's height changed with no `item`-prop change — the one situation the prop was genuinely signalling. Nothing in the repo tested it (no test or story mounted `TaskRunDetails` at all, and the one unit spec stubs `DynamicScroller` out), so this PR adds a Storybook story that expands and re-collapses a group. It asserts on `aria-expanded` and on the member lines appearing, not on measured heights — `DynamicScroller` only renders what is in the viewport, so height assertions are unreliable in the Storybook iframe.

**Worth a reviewer's eye**, since automated tests cannot measure layout: expanding a collapsed log group and a Gantt row should push the following rows down rather than overlap them. Note the existing Gantt stories cannot show this — they all pass `taskRunList: []`, so they render the empty state and never mount the scroller.

**One known rejection in the new story.** Mounting `TaskRunDetails` triggers `useTaskRunOutputs → OutputsAPI.taskOutputsInformation`, which reaches the dev server and logs `TypeError: (data ?? []).map is not a function`. It is deliberately not stubbed: `vi.mock()` has no effect on `@kestra-io/kestra-sdk/*` in a story file, because the SDK is a pre-bundled dependency that vitest's browser mocker cannot intercept. The fix belongs at the fetch layer, and #17772's API double already answers that route with an empty list — so this resolves once that merges.

That mocker limitation is worth knowing more broadly: several existing stories carry `vi.mock("@kestra-io/kestra-sdk/…")` calls that never take effect.

### 🤖 AI Authors

I did read the template. 🐱 Why did the cat get thrown out of the log viewer? It kept insisting on `position: absolute` — every time we measured a row, it had already moved somewhere warmer.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QJyb6CSvtgVh413xU3Yj6Z)_