### PR TITLE
fix(core): prevent NPE in MetricRegistry when trigger has null labels

### DIFF
--- a/core/src/main/java/io/kestra/core/metrics/MetricRegistry.java
+++ b/core/src/main/java/io/kestra/core/metrics/MetricRegistry.java
@@ -536,7 +536,7 @@ public class MetricRegistry {
         var baseTags = new String[] {
             TAG_TRIGGER_TYPE, trigger.getType(),
         };
-        var labelTags = getLabelTags(trigger.getLabels());
+        var labelTags = getLabelTags(trigger.getLabels() != null ? trigger.getLabels() : List.of());
         return ArrayUtils.addAll(baseTags, labelTags);
     }
 

--- a/core/src/test/java/io/kestra/core/metrics/MetricRegistryTest.java
+++ b/core/src/test/java/io/kestra/core/metrics/MetricRegistryTest.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.parallel.ExecutionMode;
 import io.kestra.core.models.Label;
 import io.kestra.core.models.executions.Execution;
 import io.kestra.core.models.flows.State;
+import io.kestra.core.models.triggers.AbstractTrigger;
 import io.kestra.core.utils.IdUtils;
 
 import io.micronaut.test.annotation.MockBean;
@@ -109,6 +110,25 @@ class MetricRegistryTest {
             "namespace_id", "io.kestra.unittest",
             "state", "SUCCESS",
             "label_execution-label-foo",
+            "__none__"
+        );
+    }
+
+    @Test
+    void triggerTagsWithNullLabelsAndMetricsLabelsConfigured() {
+        when(mockConfig.getLabels()).thenReturn(
+            List.of("owner_team")
+        );
+
+        AbstractTrigger trigger = mock(AbstractTrigger.class);
+        when(trigger.getType()).thenReturn("io.kestra.plugin.core.trigger.Schedule");
+        when(trigger.getLabels()).thenReturn(null);
+
+        var tags = metricRegistry.tags(trigger);
+
+        assertThat(tags).containsExactly(
+            "trigger_type", "io.kestra.plugin.core.trigger.Schedule",
+            "label_owner_team",
             "__none__"
         );
     }


### PR DESCRIPTION
### ✨ Description

When `kestra.metrics.labels` is configured, `MetricRegistry.tags(AbstractTrigger)` passed `trigger.getLabels()` into `getLabelTags()` without a null check. Triggers with no labels return `null` from `getLabels()`, so `getLabelTags` NPEs on `for (Label label : labels)` and the worker crash-loops (see stack in #16728).

This aligns the `AbstractTrigger` path with the already-safe `tags(TriggerEvaluationResult)` overload:

```java
getLabelTags(trigger.getLabels() != null ? trigger.getLabels() : List.of())
```

Missing configured label keys still emit the `__none__` placeholder, consistent with execution tag behavior.

### 🔗 Related Issue

Fixes https://github.com/kestra-io/kestra/issues/16728

### 🛠️ Backend Checklist

- [x] Code compiles successfully and passes all checks
- [x] All unit and integration tests pass

### 📝 Additional Notes

- Prior attempt https://github.com/kestra-io/kestra/pull/16844 was closed without merge after review/test fixups stalled; rebased approach onto current `develop` with a lean unit test.
- Test: `./gradlew :core:test --tests io.kestra.core.metrics.MetricRegistryTest` — 3/3 PASSED (including new `triggerTagsWithNullLabelsAndMetricsLabelsConfigured`).

### 🤖 AI Authors

Why did the cat sit on the computer? It wanted to keep an eye on the mouse.