### PR TITLE
fix(triggers): keep WorkerJobRunning entry alive for realtime per-emission results (backport)

### DIFF
--- a/jdbc/src/main/java/io/kestra/jdbc/JdbcWorkerTriggerResultQueueService.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/JdbcWorkerTriggerResultQueueService.java
@@ -10,6 +10,8 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import io.kestra.core.exceptions.DeserializationException;
+import io.kestra.core.models.flows.State;
+import io.kestra.core.models.triggers.RealtimeTriggerInterface;
 import io.kestra.core.models.triggers.TriggerContext;
 import io.kestra.core.runners.WorkerTriggerResult;
 import io.kestra.core.utils.Either;
@@ -50,13 +52,38 @@ public class JdbcWorkerTriggerResultQueueService implements Closeable {
                     }
                 } else {
                     WorkerTriggerResult workerTriggerResult = either.getLeft();
-                    workerJobRunningStateStore.deleteByKey(workerTriggerResult.getTriggerContext().uid());
+                    if (isTerminalTriggerResult(workerTriggerResult)) {
+                        workerJobRunningStateStore.deleteByKey(workerTriggerResult.getTriggerContext().uid());
+                    }
                 }
                 consumer.accept(either);
             });
         }));
 
         return disposable.get();
+    }
+
+    /**
+     * Checks whether a result means the trigger is done running on the worker, and its
+     * {@link io.kestra.core.runners.WorkerJobRunning} entry can be released.
+     *
+     * <p>
+     * A polling trigger is evaluated once, so its single result is always terminal. A realtime trigger
+     * sends one result per emitted execution while it keeps running; those must not release the entry,
+     * which the liveness coordinator relies on to resubmit the trigger when its worker dies. Only a
+     * terminal result does — a FAILED evaluation, or an error reported without an execution.
+     *
+     * @param result the {@link WorkerTriggerResult} to check.
+     * @return {@code true} if the entry can be released.
+     */
+    static boolean isTerminalTriggerResult(final WorkerTriggerResult result) {
+        if (!(result.getTrigger() instanceof RealtimeTriggerInterface)) {
+            return true;
+        }
+
+        return result.getExecution()
+            .map(execution -> State.Type.FAILED.equals(execution.getState().getCurrent()))
+            .orElse(true);
     }
 
     /**

--- a/jdbc/src/test/java/io/kestra/jdbc/JdbcWorkerTriggerResultQueueServiceTest.java
+++ b/jdbc/src/test/java/io/kestra/jdbc/JdbcWorkerTriggerResultQueueServiceTest.java
@@ -1,0 +1,135 @@
+package io.kestra.jdbc;
+
+import java.time.Duration;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.reactivestreams.Publisher;
+
+import io.kestra.core.models.annotations.Plugin;
+import io.kestra.core.models.conditions.ConditionContext;
+import io.kestra.core.models.executions.Execution;
+import io.kestra.core.models.flows.State;
+import io.kestra.core.models.triggers.AbstractTrigger;
+import io.kestra.core.models.triggers.PollingTriggerInterface;
+import io.kestra.core.models.triggers.RealtimeTriggerInterface;
+import io.kestra.core.models.triggers.TriggerContext;
+import io.kestra.core.runners.WorkerTriggerResult;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class JdbcWorkerTriggerResultQueueServiceTest {
+
+    @Test
+    void shouldReleaseRunningEntryWhenPollingTriggerEmitsAnExecution() {
+        // Given
+        WorkerTriggerResult result = resultOf(pollingTrigger(), execution(State.Type.CREATED));
+
+        // When - Then
+        assertThat(JdbcWorkerTriggerResultQueueService.isTerminalTriggerResult(result)).isTrue();
+    }
+
+    @Test
+    void shouldReleaseRunningEntryWhenPollingTriggerEmitsNoExecution() {
+        // Given
+        WorkerTriggerResult result = resultOf(pollingTrigger(), null);
+
+        // When - Then
+        assertThat(JdbcWorkerTriggerResultQueueService.isTerminalTriggerResult(result)).isTrue();
+    }
+
+    @Test
+    void shouldKeepRunningEntryWhenRealtimeTriggerEmitsAnExecution() {
+        // Given
+        // A realtime trigger sends one result per emitted execution while it keeps running,
+        // so the WorkerJobRunning entry must survive for the liveness coordinator to resubmit it.
+        WorkerTriggerResult result = resultOf(realtimeTrigger(), execution(State.Type.CREATED));
+
+        // When - Then
+        assertThat(JdbcWorkerTriggerResultQueueService.isTerminalTriggerResult(result)).isFalse();
+    }
+
+    @Test
+    void shouldReleaseRunningEntryWhenRealtimeTriggerEmitsAFailedExecution() {
+        // Given
+        WorkerTriggerResult result = resultOf(realtimeTrigger(), execution(State.Type.FAILED));
+
+        // When - Then
+        assertThat(JdbcWorkerTriggerResultQueueService.isTerminalTriggerResult(result)).isTrue();
+    }
+
+    @Test
+    void shouldReleaseRunningEntryWhenRealtimeTriggerEmitsNoExecution() {
+        // Given
+        // An error reported without an execution: the trigger is no longer running on the worker.
+        WorkerTriggerResult result = resultOf(realtimeTrigger(), null);
+
+        // When - Then
+        assertThat(JdbcWorkerTriggerResultQueueService.isTerminalTriggerResult(result)).isTrue();
+    }
+
+    private static WorkerTriggerResult resultOf(AbstractTrigger trigger, Execution execution) {
+        return WorkerTriggerResult.builder()
+            .trigger(trigger)
+            .triggerContext(
+                TriggerContext.builder()
+                    .namespace("io.kestra.tests")
+                    .flowId("flow")
+                    .triggerId(trigger.getId())
+                    .build()
+            )
+            .execution(Optional.ofNullable(execution))
+            .build();
+    }
+
+    private static Execution execution(State.Type stateType) {
+        return Execution.builder()
+            .id("execution")
+            .namespace("io.kestra.tests")
+            .flowId("flow")
+            .state(new State(stateType, new State()))
+            .build();
+    }
+
+    private static AbstractTrigger realtimeTrigger() {
+        return TestRealtimeTrigger.builder()
+            .id("realtime")
+            .type(TestRealtimeTrigger.class.getName())
+            .build();
+    }
+
+    private static AbstractTrigger pollingTrigger() {
+        return TestPollingTrigger.builder()
+            .id("polling")
+            .type(TestPollingTrigger.class.getName())
+            .interval(Duration.ofSeconds(30))
+            .build();
+    }
+
+    @Plugin(internal = true)
+    @SuperBuilder
+    @NoArgsConstructor
+    public static class TestRealtimeTrigger extends AbstractTrigger implements RealtimeTriggerInterface {
+        @Override
+        public Publisher<Execution> evaluate(ConditionContext conditionContext, TriggerContext context) {
+            throw new UnsupportedOperationException("not evaluated in this test");
+        }
+    }
+
+    @Plugin(internal = true)
+    @SuperBuilder
+    @NoArgsConstructor
+    @Getter
+    public static class TestPollingTrigger extends AbstractTrigger implements PollingTriggerInterface {
+        private Duration interval;
+
+        @Override
+        public Optional<Execution> evaluate(ConditionContext conditionContext, TriggerContext context) {
+            throw new UnsupportedOperationException("not evaluated in this test");
+        }
+    }
+}


### PR DESCRIPTION
✨ Description

A realtime trigger sends one WorkerTriggerResult per emitted execution while it keeps running on the worker. Every one of those results released the trigger's WorkerJobRunning entry — the record the liveness coordinator reads to work out what a dead worker was holding.

The practical effect: once a realtime trigger has processed a single message, it can no longer be reassigned when its worker goes away. It stays pinned to a worker that no longer exists until someone hits "Restart trigger" in the UI. This bites hardest on rolling worker deployments, where it happens on every rollout.

This PR makes the release conditional. Polling triggers are evaluated once, so their single result is still always terminal and behaviour is unchanged. Realtime triggers only release the entry on a genuinely terminal result — a FAILED execution, or an error reported without an execution.

v1.3.14 already received the other half of this fix (1557cec52f (https://github.com/kestra-io/kestra/commit/1557cec52f), which added the TERMINATED_GRACEFULLY re-emit branch to the liveness coordinator). That branch has been in place but starved of data ever since; this change is what makes it work.