### PR TITLE
fix(inputs): only show validation warnings after interaction or submit

### DIFF
--- a/ui/src/components/inputs/DurationPicker.vue
+++ b/ui/src/components/inputs/DurationPicker.vue
@@ -6,6 +6,7 @@
             controlsPosition="right"
             id="years"
             v-model="years"
+            :validateEvent="validateEvent"
             :min="0"
         />
     </div>
@@ -16,6 +17,7 @@
             controlsPosition="right"
             id="months"
             v-model="months"
+            :validateEvent="validateEvent"
             :min="0"
         />
     </div>
@@ -26,6 +28,7 @@
             controlsPosition="right"
             id="weeks"
             v-model="weeks"
+            :validateEvent="validateEvent"
             :min="0"
         />
     </div>
@@ -36,6 +39,7 @@
             controlsPosition="right"
             id="days"
             v-model="days"
+            :validateEvent="validateEvent"
             :min="0"
         />
     </div>
@@ -46,6 +50,7 @@
             controlsPosition="right"
             id="hours"
             v-model="hours"
+            :validateEvent="validateEvent"
             :min="0"
         />
     </div>
@@ -56,6 +61,7 @@
             controlsPosition="right"
             id="minutes"
             v-model="minutes"
+            :validateEvent="validateEvent"
             :min="0"
         />
     </div>
@@ -66,6 +72,7 @@
             controlsPosition="right"
             id="seconds"
             v-model="seconds"
+            :validateEvent="validateEvent"
             :min="0"
         />
     </div>
@@ -73,7 +80,7 @@
         <el-text size="small" :type="durationIssue ? 'danger': ''">
             {{ durationIssue ?? $t('input_custom_duration') }}
         </el-text>
-        <el-input type="text" id="customDuration" v-model="customDuration" @input="parseDuration" :placeholder="$t('datepicker.custom duration')" />
+        <el-input type="text" id="customDuration" v-model="customDuration" :validateEvent="validateEvent" @input="parseDuration" :placeholder="$t('datepicker.custom duration')" />
     </div>
 </template>
 
@@ -81,9 +88,16 @@
     import {Duration, Period} from "@js-joda/core";
     import {ref, watch, onMounted, onUpdated} from "vue";
 
-    const props = defineProps<{
+    const props = withDefaults(defineProps<{
         modelValue?: string;
-    }>();
+        // Forwarded to every inner Element Plus control. onMounted seeds the seven number refs, whose
+        // watchers would otherwise validate the surrounding el-form-item with no user interaction — the
+        // parent gates this on its interactedInputs set. Defaults to Element Plus's own default.
+        validateEvent?: boolean;
+    }>(), {
+        modelValue: undefined,
+        validateEvent: true,
+    });
 
     const emit = defineEmits<{
         "update:model-value": [value: string | null];

--- a/ui/src/components/inputs/InputsForm.vue
+++ b/ui/src/components/inputs/InputsForm.vue
@@ -13,11 +13,13 @@
         <el-form-item
             v-for="input in visibleInputs"
             :key="input.id"
+            :ref="(el: unknown) => registerFormItem(input.id, el)"
             :required="input.required !== false"
             :rules="requiredRules(input)"
             :prop="input.id"
             :error="inputError(input.id)"
             :inlineMessage="true"
+            @focusout="onFieldBlur(input.id)"
         >
             <template #label>
                 <Markdown :source="inputLabel(input)" class="d-inline-flex md-label" />
@@ -39,6 +41,7 @@
                 v-if="(input.type === 'ENUM' || input.type === 'SELECT') && !input.isRadio"
                 :data-testid="`input-form-${input.id}`"
                 v-model="inputsValues[input.id]"
+                :validateEvent="isInteracted(input.id)"
                 @update:model-value="onChange(input)"
                 :allowCreate="input.allowCustomValue"
                 :disabled="isComputingInput(input.id)"
@@ -60,12 +63,14 @@
                 v-if="(input.type === 'ENUM' || input.type === 'SELECT') && input.isRadio"
                 :data-testid="`input-form-${input.id}`"
                 v-model="inputsValues[input.id]"
+                :validateEvent="isInteracted(input.id)"
                 @update:model-value="onChange(input)"
             >
                 <el-radio v-for="item in input.values" :key="item" :label="item" :value="item" />
                 <el-input
                     v-if="input.allowCustomValue"
                     v-model="inputsValues[input.id]"
+                    :validateEvent="isInteracted(input.id)"
                     @update:model-value="onChange(input)"
                     :placeholder="$t('custom value')"
                 />
@@ -77,6 +82,7 @@
                 v-if="input.type === 'MULTISELECT'"
                 :data-testid="`input-form-${input.id}`"
                 v-model="multiSelectInputs[input.id]"
+                :validateEvent="isInteracted(input.id)"
                 @update:model-value="onMultiSelectChange(input, $event)"
                 multiple
                 filterable
@@ -100,6 +106,7 @@
                 v-if="input.type === 'SECRET'"
                 :data-testid="`input-form-${input.id}`"
                 v-model="inputsValues[input.id]"
+                :validateEvent="isInteracted(input.id)"
                 @update:model-value="onChange(input)"
                 showPassword
             />
@@ -107,6 +114,7 @@
                 <el-input-number
                     :data-testid="`input-form-${input.id}`"
                     v-model="inputsValues[input.id]"
+                    :validateEvent="isInteracted(input.id)"
                     @update:model-value="onChange(input)"
                     :min="input.min"
                     :max="input.max && input.max >= (input.min || -Infinity) ? input.max : Infinity"
@@ -118,6 +126,7 @@
                 <el-input-number
                     :data-testid="`input-form-${input.id}`"
                     v-model="inputsValues[input.id]"
+                    :validateEvent="isInteracted(input.id)"
                     @update:model-value="onChange(input)"
                     :min="input.min"
                     :max="input.max && input.max >= (input.min || -Infinity) ? input.max : Infinity"
@@ -129,6 +138,7 @@
                 :data-testid="`input-form-${input.id}`"
                 v-if="input.type === 'BOOLEAN'"
                 v-model="inputsValues[input.id]"
+                :validateEvent="isInteracted(input.id)"
                 @update:model-value="onChange(input)"
                 class="w-100 boolean-inputs"
             >
@@ -140,6 +150,7 @@
                 :data-testid="`input-form-${input.id}`"
                 v-if="input.type === 'BOOL'"
                 v-model="inputsValues[input.id]"
+                :validateEvent="isInteracted(input.id)"
                 @update:model-value="onChange(input)"
                 class="w-100 boolean-inputs"
             />
@@ -147,6 +158,7 @@
                 :data-testid="`input-form-${input.id}`"
                 v-if="input.type === 'DATETIME'"
                 v-model="inputsValues[input.id]"
+                :validateEvent="isInteracted(input.id)"
                 @update:model-value="onChange(input)"
                 type="datetime"
             />
@@ -154,6 +166,7 @@
                 :data-testid="`input-form-${input.id}`"
                 v-if="input.type === 'DATE'"
                 v-model="inputsValues[input.id]"
+                :validateEvent="isInteracted(input.id)"
                 @update:model-value="onChange(input)"
                 type="date"
             />
@@ -161,6 +174,7 @@
                 :data-testid="`input-form-${input.id}`"
                 v-if="input.type === 'TIME'"
                 v-model="inputsValues[input.id]"
+                :validateEvent="isInteracted(input.id)"
                 @update:model-value="onChange(input)"
                 type="time"
             />
@@ -259,11 +273,6 @@
                 @update:model-value="onChange(input)"
             />
             <Markdown v-if="input.description" :data-testid="`input-form-${input.id}`" class="markdown-tooltip text-description" :source="input.description" font-size-var="font-size-xs" />
-            <template v-for="err in input.errors ?? []" :key="err.message">
-                <el-text type="warning">
-                    {{ err.message }}
-                </el-text>
-            </template>
         </el-form-item>
 
         <div v-if="isOnRecap" class="wizard-recap" data-testid="inputs-wizard-recap">
@@ -401,6 +410,8 @@
     const inputsMetaData = ref<InputMetaData[]>([]);
     const multiSelectInputs = reactive<Record<string, any>>({});
     const inputsValidated = ref<Set<string>>(new Set());
+    const interactedInputs = ref<Set<string>>(new Set());
+    const formItemRefs = new Map<string, {validate: (trigger?: string) => Promise<unknown>}>();
     const editingArrayId = ref<string | null>(null);
     const editableItems = reactive<Record<string, string[]>>({});
 
@@ -515,6 +526,25 @@
             console.error("Failed to normalize JSON:", (e as Error).message);
             return null;
         }
+    }
+
+    function isInteracted(id: string): boolean {
+        return interactedInputs.value.has(id);
+    }
+
+    function registerFormItem(id: string, el: unknown): void {
+        if (el) {
+            formItemRefs.set(id, el as {validate: (trigger?: string) => Promise<unknown>});
+        } else {
+            formItemRefs.delete(id);
+        }
+    }
+
+    function onFieldBlur(id: string): void {
+        interactedInputs.value.add(id);
+        // el-form-item.validate() rejects on failure; the rejection is the error message being
+        // displayed, which is the point, so swallow it rather than let it escape as unhandled.
+        formItemRefs.get(id)?.validate().catch(() => {});
     }
 
     function inputError(id: string): string | undefined {
@@ -953,6 +983,9 @@
         inputsValues,
         inputsMetaData,
         inputsValidated,
+        interactedInputs,
+        isInteracted,
+        onFieldBlur,
         isComputingValues,
         isComputingInput,
         isLoadingInput,

--- a/ui/src/components/inputs/InputsForm.vue
+++ b/ui/src/components/inputs/InputsForm.vue
@@ -220,6 +220,7 @@
                         <div v-for="(_item, index) in editableItems[input.id]" :key="index" class="list-row">
                             <el-input
                                 v-model="editableItems[input.id][index]"
+                                :validateEvent="isInteracted(input.id)"
                                 class="array-cell"
                             />
                             <el-button @click="removeArrayItem(input, index)" :icon="DeleteOutline" class="delete-input" />
@@ -270,6 +271,7 @@
             <DurationPicker
                 v-if="input.type === 'DURATION'"
                 v-model="inputsValues[input.id]"
+                :validateEvent="isInteracted(input.id)"
                 @update:model-value="onChange(input)"
             />
             <Markdown v-if="input.description" :data-testid="`input-form-${input.id}`" class="markdown-tooltip text-description" :source="input.description" font-size-var="font-size-xs" />
@@ -808,7 +810,15 @@
             }];
         }
 
-        return undefined;
+        // Every other required type (STRING, INT, DATE, DURATION, FILE, …). Without this, el-form-item
+        // falls back to the implicit `{required: true}` it derives from its own `required` prop, whose
+        // message comes from async-validator's hardcoded English "%s is required" using the raw input id.
+        // Returning the rule explicitly keeps the message translated and consistent with the branches
+        // above — el-form-item patches a rule that already carries `required` instead of adding its own.
+        return [{
+            required: true,
+            message: t("is required", {field: input.displayName || input.id}),
+        }];
     }
 
     function parseArrayValue(inputId: string): unknown[] {

--- a/ui/tests/unit/components/inputs/inputsFormValidationGating.spec.ts
+++ b/ui/tests/unit/components/inputs/inputsFormValidationGating.spec.ts
@@ -1,0 +1,265 @@
+import {afterEach, beforeEach, describe, expect, test, vi} from "vitest"
+import {defineComponent, h, ref} from "vue"
+import {flushPromises, mount} from "@vue/test-utils"
+import {createPinia, setActivePinia} from "pinia"
+import {createI18n} from "vue-i18n"
+import ElementPlus, {ElForm, ElFormItem, ElInput, ElInputNumber, ElSelect} from "element-plus"
+import InputsForm from "../../../../src/components/inputs/InputsForm.vue"
+import DurationPicker from "../../../../src/components/inputs/DurationPicker.vue"
+import {useExecutionsStore} from "../../../../src/stores/executions"
+import en from "../../../../src/translations/en.json"
+
+vi.mock("vue-router", async (importOriginal) => {
+    const actual = await importOriginal<typeof import("vue-router")>()
+    return {
+        ...actual,
+        useRoute: () => ({query: {}, params: {}, name: "flow"}),
+        useRouter: () => ({replace: vi.fn(), push: vi.fn()}),
+    }
+})
+
+const i18n = createI18n({
+    legacy: false,
+    locale: "en",
+    messages: en as any,
+    fallbackWarn: false,
+    missingWarn: false,
+    globalInjection: true,
+})
+
+const flow = {namespace: "io.kestra.tests", id: "my_flow"} as any
+
+// These tests assert the *gating* — which controls are allowed to self-validate, and what rule each
+// el-form-item is handed — rather than the rendered error text. Element Plus's async validation never
+// settles under jsdom (a bare el-form + el-form-item + el-select stays stuck on `is-validating`, with
+// no Kestra code involved), so asserting on `.el-form-item__error` would pass vacuously in every case.
+function mountForm(initialInputs: any[]) {
+    const Harness = defineComponent({
+        setup(_props, {expose}) {
+            const inputs = ref<Record<string, any>>({})
+            const inputsFormRef = ref<any>(null)
+            expose({inputs, inputsFormRef})
+            // InputsForm renders bare el-form-items; the surrounding el-form (and its :model) lives in
+            // the parent (FlowRun / Resume), so mount it the same way.
+            return () => h(ElForm, {model: inputs.value}, () => [
+                h(InputsForm, {
+                    ref: inputsFormRef,
+                    flow,
+                    initialInputs,
+                    modelValue: inputs.value,
+                    "onUpdate:modelValue": (value: Record<string, any>) => {inputs.value = value},
+                }),
+            ])
+        },
+    })
+
+    return mount(Harness, {
+        global: {
+            plugins: [i18n, ElementPlus],
+            stubs: {Editor: true, Markdown: true},
+        },
+        attachTo: document.body,
+    })
+}
+
+// The harness exposes the wrapped InputsForm so tests can read its defineExpose'd state.
+const vm = (wrapper: ReturnType<typeof mountForm>) =>
+    wrapper.vm as unknown as {inputs: Record<string, any>; inputsFormRef: any}
+
+// Blurring a field is what marks it interacted — the el-form-item listens for the bubbling focusout.
+const blur = async (wrapper: ReturnType<typeof mountForm>, index = 0) => {
+    await wrapper.findAll(".el-form-item")[index].trigger("focusout")
+    await flushPromises()
+}
+
+const rulesFor = (wrapper: ReturnType<typeof mountForm>, index = 0) =>
+    wrapper.findAllComponents(ElFormItem)[index].props("rules") as any
+
+describe("InputsForm gates validation until interaction", () => {
+    beforeEach(() => {
+        setActivePinia(createPinia())
+    })
+
+    afterEach(() => {
+        document.body.innerHTML = ""
+    })
+
+    // The reported regression (#17651): a per-field `input.errors` list rendered the backend's errors
+    // with no gate at all, so the form opened already red — on required AND optional fields alike.
+    // #5232 gated it, #15177 dropped the gate. The same errors already render through the gated
+    // `:error="inputError(id)"`, so the list is redundant; if it ever comes back, this fails.
+    test("renders no backend error on load, even when validate returns one for every field", async () => {
+        const store = useExecutionsStore()
+        store.validateExecution = vi.fn().mockResolvedValue({data: {checks: [], inputs: [
+            {enabled: true, isDefault: false, input: {id: "region", type: "SELECT", values: ["us", "eu"]},
+                errors: [{message: "Missing required input:region"}]},
+            {enabled: true, isDefault: false, input: {id: "comment", type: "STRING", required: false},
+                errors: [{message: "Missing required input:comment"}]},
+        ]}})
+
+        const wrapper = mountForm([
+            {id: "region", type: "SELECT", values: ["us", "eu"]},
+            {id: "comment", type: "STRING", required: false},
+        ])
+        await flushPromises()
+
+        expect(wrapper.text()).not.toContain("Missing required input")
+        // the gated channel still holds them, ready for submit / once the field is validated
+        expect(vm(wrapper).inputsFormRef.inputError("region")).toBeUndefined()
+        vm(wrapper).inputsFormRef.inputsValidated.add("region")
+        expect(vm(wrapper).inputsFormRef.inputError("region")).toContain("Missing required")
+    })
+
+    // Cause #2: el-select & friends call formItem.validate() from their own internal watchers, with no
+    // user interaction — a value arriving from the server is enough. validateEvent is the only thing
+    // that suppresses that, so it must start false and flip once the field has been visited.
+    test("starts every control with validateEvent off, and turns it on once the field is blurred", async () => {
+        const store = useExecutionsStore()
+        store.validateExecution = vi.fn().mockResolvedValue({data: {checks: [], inputs: [
+            {enabled: true, isDefault: true, value: "us", input: {id: "region", type: "SELECT", values: ["us", "eu"]}},
+        ]}})
+
+        const wrapper = mountForm([{id: "region", type: "SELECT", values: ["us", "eu"], defaults: "us"}])
+        await flushPromises()
+
+        // a default landed from the server — still not interaction
+        expect(vm(wrapper).inputsFormRef.inputsValues.region).toBe("us")
+        expect(vm(wrapper).inputsFormRef.isInteracted("region")).toBe(false)
+        expect(wrapper.findComponent(ElSelect).props("validateEvent")).toBe(false)
+
+        await blur(wrapper)
+
+        expect(vm(wrapper).inputsFormRef.isInteracted("region")).toBe(true)
+        expect(wrapper.findComponent(ElSelect).props("validateEvent")).toBe(true)
+    })
+
+    test("gates each field independently — blurring one leaves the others untouched", async () => {
+        const store = useExecutionsStore()
+        store.validateExecution = vi.fn().mockResolvedValue({data: {checks: [], inputs: [
+            {enabled: true, isDefault: false, input: {id: "region", type: "SELECT", values: ["us", "eu"]}},
+            {enabled: true, isDefault: false, input: {id: "env", type: "SELECT", values: ["dev", "prod"]}},
+        ]}})
+
+        const wrapper = mountForm([
+            {id: "region", type: "SELECT", values: ["us", "eu"]},
+            {id: "env", type: "SELECT", values: ["dev", "prod"]},
+        ])
+        await flushPromises()
+        await blur(wrapper, 0)
+
+        expect(wrapper.findAllComponents(ElSelect).map(c => c.props("validateEvent"))).toEqual([true, false])
+        expect(vm(wrapper).inputsFormRef.isInteracted("env")).toBe(false)
+    })
+
+    // DurationPicker holds seven el-input-numbers plus an el-input, all seeded by its own onMounted —
+    // ungated they validate the surrounding el-form-item before the user has arrived.
+    test("forwards the gate into DurationPicker's inner controls", async () => {
+        const store = useExecutionsStore()
+        store.validateExecution = vi.fn().mockResolvedValue({data: {checks: [], inputs: [
+            {enabled: true, isDefault: false, input: {id: "timeout", type: "DURATION"}},
+        ]}})
+
+        const wrapper = mountForm([{id: "timeout", type: "DURATION"}])
+        await flushPromises()
+
+        const picker = wrapper.findComponent(DurationPicker)
+        expect(picker.props("validateEvent")).toBe(false)
+        // every inner Element Plus control, not just the wrapper
+        expect(picker.findAllComponents(ElInputNumber)).toHaveLength(7)
+        expect(picker.findAllComponents(ElInputNumber).every(c => c.props("validateEvent") === false)).toBe(true)
+        expect(picker.findComponent(ElInput).props("validateEvent")).toBe(false)
+
+        await blur(wrapper)
+
+        expect(picker.props("validateEvent")).toBe(true)
+        expect(picker.findAllComponents(ElInputNumber).every(c => c.props("validateEvent") === true)).toBe(true)
+    })
+
+    // Types with no el-* control of their own (STRING/JSON/YAML render Editor) used to get no rule at
+    // all, leaving el-form-item to derive an implicit `{required: true}` from its own `required` prop —
+    // whose message is async-validator's hardcoded English "%s is required" built from the raw input id.
+    test("hands a translated, displayName-based required rule to types without an explicit one", async () => {
+        const store = useExecutionsStore()
+        store.validateExecution = vi.fn().mockResolvedValue({data: {checks: [], inputs: [
+            {enabled: true, isDefault: false, input: {id: "name", displayName: "Full name", type: "STRING"}},
+        ]}})
+
+        const wrapper = mountForm([{id: "name", displayName: "Full name", type: "STRING"}])
+        await flushPromises()
+
+        expect(rulesFor(wrapper)).toEqual([{required: true, message: "Full name is required"}])
+    })
+
+    test("leaves optional inputs without a required rule", async () => {
+        const store = useExecutionsStore()
+        store.validateExecution = vi.fn().mockResolvedValue({data: {checks: [], inputs: [
+            {enabled: true, isDefault: false, input: {id: "comment", type: "STRING", required: false}},
+        ]}})
+
+        const wrapper = mountForm([{id: "comment", type: "STRING", required: false}])
+        await flushPromises()
+
+        expect(rulesFor(wrapper)).toBeUndefined()
+        expect(wrapper.findAllComponents(ElFormItem)[0].props("required")).toBe(false)
+    })
+
+    // SELECT/ENUM/MULTISELECT keep their own validator (it reads the flat inputsValues map rather than
+    // the form model) — the new fallback must not have displaced it.
+    test("keeps the existing custom validator for SELECT", async () => {
+        const store = useExecutionsStore()
+        store.validateExecution = vi.fn().mockResolvedValue({data: {checks: [], inputs: [
+            {enabled: true, isDefault: false, input: {id: "region", type: "SELECT", values: ["us", "eu"]}},
+        ]}})
+
+        const wrapper = mountForm([{id: "region", type: "SELECT", values: ["us", "eu"]}])
+        await flushPromises()
+
+        const [rule] = rulesFor(wrapper)
+        expect(rule.required).toBe(true)
+        expect(typeof rule.validator).toBe("function")
+
+        // it reports the translated message while empty, and passes once filled
+        const message = await new Promise<string | undefined>(resolve =>
+            rule.validator(rule, undefined, (e?: Error) => resolve(e?.message)))
+        expect(message).toBe("region is required")
+
+        vm(wrapper).inputsFormRef.inputsValues.region = "us"
+        const afterFill = await new Promise<string | undefined>(resolve =>
+            rule.validator(rule, undefined, (e?: Error) => resolve(e?.message)))
+        expect(afterFill).toBeUndefined()
+    })
+
+    // Blurring must actually reach the el-form-item registered by the :ref callback and run its
+    // validate() — the interactedInputs flag alone would only stop suppressing, never surface anything.
+    // Entering the "validating" state is the observable proof that validate() was invoked.
+    test("reaches the registered el-form-item and validates it on blur", async () => {
+        const store = useExecutionsStore()
+        store.validateExecution = vi.fn().mockResolvedValue({data: {checks: [], inputs: [
+            {enabled: true, isDefault: false, input: {id: "region", type: "SELECT", values: ["us", "eu"]}},
+        ]}})
+
+        const wrapper = mountForm([{id: "region", type: "SELECT", values: ["us", "eu"]}])
+        await flushPromises()
+        expect(wrapper.find(".el-form-item").classes()).not.toContain("is-validating")
+
+        await blur(wrapper)
+
+        expect(vm(wrapper).inputsFormRef.isInteracted("region")).toBe(true)
+        expect(wrapper.find(".el-form-item").classes()).toContain("is-validating")
+    })
+
+    // The registry is keyed by input id and cleared when a form item unmounts (wizard step change), so
+    // onFieldBlur has to tolerate an id it no longer holds rather than throwing on the optional call.
+    test("tolerates a blur for a field whose form item is no longer registered", async () => {
+        const store = useExecutionsStore()
+        store.validateExecution = vi.fn().mockResolvedValue({data: {checks: [], inputs: [
+            {enabled: true, isDefault: false, input: {id: "region", type: "SELECT", values: ["us", "eu"]}},
+        ]}})
+
+        const wrapper = mountForm([{id: "region", type: "SELECT", values: ["us", "eu"]}])
+        await flushPromises()
+
+        expect(() => vm(wrapper).inputsFormRef.onFieldBlur("gone")).not.toThrow()
+        expect(vm(wrapper).inputsFormRef.isInteracted("gone")).toBe(true)
+    })
+})


### PR DESCRIPTION
✨ Description

Validation warnings on the App / flow execution form are shown before the user has touched anything, so the form opens looking like it is already in an error state. This restores interaction-based validation: nothing on the initial render, a field's own warning once it has been focused and left, and everything outstanding on submit.

Two independent causes, both in ui/src/components/inputs/InputsForm.vue:

1. An ungated per-field warning list. It looped input.errors for every input in visibleInputs with no gate at all, painting the backend's errors as soon as the first validate returned:

vue
<template v-for="err in input.errors ?? []" :key="err.message">
    <el-text type="warning">{{ err.message }}</el-text>
</template>

This block was deliberately wrapped in <template v-if="executeClicked"> by #5232 ("avoid showing errors until execute button is clicked"). #15177 removed that wrapper, which is the regression — v1.3.3 still has the gate, v1.3.4 onwards does not. It is also redundant: the same errors already render through :error="inputError(input.id)", which is gated. #15651 deleted it on develop; that never reached releases/v1.3.x, which is why this reproduces only on 1.3.x.

Note this list was never specific to required fields — hence the customer reporting warnings on their optional fields too.

2. Element Plus self-validating untouched fields. el-select, el-switch, el-input-number, el-date-picker and friends call formItem.validate() from their own internal watchers, no user interaction involved, which surfaces requiredRules() on a field nobody has been near. Added an interactedInputs set gating each control's validateEvent, plus @focusout on the el-form-item that mars it immediately — so focus-then-leave-empty warns even though novalue changed, which the old all-or-nothing executeClicked gate never did.

"Show everything on submit" needs no new code: form.validate() bypasses per-control validateEvent entirely.

An error flagged renderError is still surfaced immediately on any field, touched or not. That means the field itself is broken rather than merely empty — a SELECT
whose expression/subflow() cannot resolve, or a defaults expression it until the user clicks in would leave them staring at a field thatcannot work.

🔗 Related Issue

Closes https://github.com/kestra-io/kestra/issues/17651