### PR TITLE
fix(core): bucket metric aggregation in UTC

### DIFF
--- a/jdbc-postgres/src/main/java/io/kestra/repository/postgres/PostgresMetricRepository.java
+++ b/jdbc-postgres/src/main/java/io/kestra/repository/postgres/PostgresMetricRepository.java
@@ -1,5 +1,6 @@
 package io.kestra.repository.postgres;
 
+import java.sql.Timestamp;
 import java.util.Date;
 
 import org.jooq.Field;
@@ -20,6 +21,11 @@ public class PostgresMetricRepository extends AbstractJdbcMetricRepository {
     public PostgresMetricRepository(@Named("metrics") PostgresRepository<MetricEntry> repository,
         JdbcFilterService filterService) {
         super(repository, filterService);
+    }
+
+    @Override
+    protected Field<Timestamp> groupByTimestampField(String dateField) {
+        return PostgresRepositoryUtils.utcTimestampField(dateField);
     }
 
     @Override

--- a/jdbc-postgres/src/main/java/io/kestra/repository/postgres/PostgresRepositoryUtils.java
+++ b/jdbc-postgres/src/main/java/io/kestra/repository/postgres/PostgresRepositoryUtils.java
@@ -1,5 +1,6 @@
 package io.kestra.repository.postgres;
 
+import java.sql.Timestamp;
 import java.util.Date;
 
 import org.jooq.Field;
@@ -10,6 +11,18 @@ import io.kestra.core.utils.DateUtils;
 public final class PostgresRepositoryUtils {
     private PostgresRepositoryUtils() {
         // utility class pattern
+    }
+
+    /**
+     * Renders {@code dateField} as a UTC wall-clock timestamp, for SQL-side date-part extraction.
+     * <p>
+     * Postgres date columns are {@code TIMESTAMPTZ}, which stores an absolute instant. Casting one to
+     * {@code timestamp} resolves it in the session timezone, and pgjdbc sets the session timezone
+     * from the JVM default — so a plain cast yields local, not UTC, date parts. {@code AT TIME ZONE
+     * 'UTC'} pins the conversion instead of inheriting it from the connection.
+     */
+    public static Field<Timestamp> utcTimestampField(String dateField) {
+        return DSL.field("({0} AT TIME ZONE 'UTC')", Timestamp.class, DSL.field(DSL.quotedName(dateField)));
     }
 
     public static Field<Date> formatDateField(String dateField, DateUtils.GroupType groupType) {

--- a/jdbc-postgres/src/test/java/io/kestra/repository/postgres/PostgresUtcTimestampFieldTest.java
+++ b/jdbc-postgres/src/test/java/io/kestra/repository/postgres/PostgresUtcTimestampFieldTest.java
@@ -1,0 +1,86 @@
+package io.kestra.repository.postgres;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.time.Instant;
+import java.util.List;
+import java.util.TimeZone;
+
+import org.jooq.DSLContext;
+import org.jooq.Field;
+import org.jooq.Record2;
+import org.jooq.SQLDialect;
+import org.jooq.impl.DSL;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Pins the UTC semantics of {@link PostgresRepositoryUtils#utcTimestampField(String)}.
+ * <p>
+ * Postgres date columns are {@code TIMESTAMPTZ}. A plain {@code cast(... as timestamp)} resolves in
+ * the session timezone, which pgjdbc sets from the JVM default — so date parts extracted that way
+ * follow the host's zone. Since {@code AbstractJdbcRepository#getDate} reassembles those parts in
+ * UTC, they have to be extracted in UTC too, whatever the connection's session timezone is.
+ * <p>
+ * Uses a raw connection rather than the injected datasource because the JVM default zone has to be
+ * set before the connection is opened for pgjdbc to pick it up.
+ */
+class PostgresUtcTimestampFieldTest {
+    private static final String URL = "jdbc:postgresql://localhost:5432/kestra_unit";
+    private static final String USER = "kestra";
+    private static final String PASSWORD = "k3str4";
+
+    /** Zones whose offset from UTC is non-zero, in both directions, one of them non-integral. */
+    private static final List<String> NON_UTC_ZONES = List.of("Asia/Kolkata", "Europe/Berlin", "America/Los_Angeles");
+
+    private static final Instant INSTANT = Instant.parse("2026-07-29T14:30:00Z");
+
+    @Test
+    void shouldExtractUtcDatePartsRegardlessOfSessionTimeZone() throws Exception {
+        TimeZone original = TimeZone.getDefault();
+
+        try {
+            for (String zone : NON_UTC_ZONES) {
+                // Given a JVM default zone that pgjdbc will propagate to the session timezone
+                TimeZone.setDefault(TimeZone.getTimeZone(zone));
+
+                try (Connection connection = DriverManager.getConnection(URL, USER, PASSWORD)) {
+                    DSLContext context = DSL.using(connection, SQLDialect.POSTGRES);
+
+                    // ... and a TIMESTAMPTZ column holding a known absolute instant
+                    context.execute("DROP TABLE IF EXISTS utc_timestamp_field_test");
+                    context.execute("CREATE TABLE utc_timestamp_field_test (\"timestamp\" TIMESTAMPTZ NOT NULL)");
+                    context.execute("INSERT INTO utc_timestamp_field_test VALUES ({0}::timestamptz)", DSL.val(INSTANT.toString()));
+
+                    // When extracting date parts the way groupByFields does
+                    Field<java.sql.Timestamp> timestamp = PostgresRepositoryUtils.utcTimestampField("timestamp");
+                    Record2<Integer, Integer> parts = context
+                        .select(DSL.day(timestamp), DSL.hour(timestamp))
+                        .from(DSL.table(DSL.name("utc_timestamp_field_test")))
+                        .fetchSingle();
+
+                    // Then they are the UTC wall-clock parts, not the session-zone ones
+                    assertThat(parts.value1()).as("day, JVM zone %s", zone).isEqualTo(29);
+                    assertThat(parts.value2()).as("hour, JVM zone %s", zone).isEqualTo(14);
+
+                    context.execute("DROP TABLE utc_timestamp_field_test");
+                }
+            }
+        } finally {
+            TimeZone.setDefault(original);
+        }
+    }
+
+    @Test
+    void shouldRenderAtTimeZoneUtcRatherThanAPlainCast() {
+        // Given the grouping timestamp expression for Postgres
+        Field<java.sql.Timestamp> timestamp = PostgresRepositoryUtils.utcTimestampField("timestamp");
+
+        // When rendering it
+        String sql = DSL.using(SQLDialect.POSTGRES).render(DSL.hour(timestamp));
+
+        // Then the conversion is pinned to UTC instead of inheriting the session timezone
+        assertThat(sql).contains("AT TIME ZONE 'UTC'");
+    }
+}

--- a/jdbc/src/main/java/io/kestra/jdbc/AbstractJdbcRepository.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/AbstractJdbcRepository.java
@@ -5,6 +5,7 @@ import java.sql.Timestamp;
 import java.time.DayOfWeek;
 import java.time.Instant;
 import java.time.LocalDate;
+import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.time.temporal.TemporalAdjusters;
 import java.util.*;
@@ -293,6 +294,15 @@ public abstract class AbstractJdbcRepository<T> {
 
     }
 
+    /**
+     * Reassembles an {@link Instant} from the SQL-extracted date parts (year/month/day/hour/minute)
+     * produced by {@code AbstractJdbcRepository#groupByFields}.
+     * <p>
+     * Those parts are UTC wall-clock values — the date columns hold UTC (H2 and MySQL store UTC
+     * wall-clock directly; Postgres is normalised via {@code groupByTimestampField}) — so they must
+     * be reassembled in UTC. Using the JVM default zone here would shift every bucket by the local
+     * UTC offset on a non-UTC host.
+     */
     public <R extends Record> Instant getDate(R record, String groupByType) {
         List<String> fields = Arrays.stream(record.fields()).map(Field::getName).toList();
         Integer minute = fields.contains("minute") ? record.get("minute", Integer.class) : 0;
@@ -304,13 +314,13 @@ public abstract class AbstractJdbcRepository<T> {
 
         switch (groupByType) {
             case "minute" -> {
-                return ZonedDateTime.of(year, month, day, hour, minute, 0, 0, TimeZone.getDefault().toZoneId()).toInstant();
+                return ZonedDateTime.of(year, month, day, hour, minute, 0, 0, ZoneOffset.UTC).toInstant();
             }
             case "hour" -> {
-                return ZonedDateTime.of(year, month, day, hour, 0, 0, 0, TimeZone.getDefault().toZoneId()).toInstant();
+                return ZonedDateTime.of(year, month, day, hour, 0, 0, 0, ZoneOffset.UTC).toInstant();
             }
             case "day" -> {
-                return ZonedDateTime.of(year, month, day, 0, 0, 0, 0, TimeZone.getDefault().toZoneId()).toInstant();
+                return ZonedDateTime.of(year, month, day, 0, 0, 0, 0, ZoneOffset.UTC).toInstant();
             }
             case "week" -> {
                 // week * 7 can fall outside the 1..365/366 day-of-year range (e.g. week 53 -> 371, or
@@ -318,10 +328,10 @@ public abstract class AbstractJdbcRepository<T> {
                 int maxDayOfYear = LocalDate.of(year, 12, 31).getDayOfYear();
                 int dayOfYear = Math.min(Math.max(week * 7, 1), maxDayOfYear);
                 LocalDate weekDate = LocalDate.ofYearDay(year, dayOfYear).with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY));
-                return weekDate.atStartOfDay(TimeZone.getDefault().toZoneId()).toInstant();
+                return weekDate.atStartOfDay(ZoneOffset.UTC).toInstant();
             }
             case "month" -> {
-                return ZonedDateTime.of(year, month, 1, 0, 0, 0, 0, TimeZone.getDefault().toZoneId()).toInstant();
+                return ZonedDateTime.of(year, month, 1, 0, 0, 0, 0, ZoneOffset.UTC).toInstant();
             }
             default -> throw new IllegalArgumentException("Invalid groupByType: " + groupByType);
         }

--- a/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcMetricRepository.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcMetricRepository.java
@@ -1,7 +1,7 @@
 package io.kestra.jdbc.repository;
 
 import java.time.Duration;
-import java.time.ZoneId;
+import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoUnit;
@@ -290,7 +290,10 @@ public abstract class AbstractJdbcMetricRepository extends AbstractJdbcCrudRepos
         String format) {
         List<MetricAggregation> filledResult = new ArrayList<>();
         ZonedDateTime currentDate = startDate;
-        DateTimeFormatter formatter = DateTimeFormatter.ofPattern(format).withZone(ZoneId.systemDefault());
+        // UTC, to match the bucket keys returned by AbstractJdbcRepository#getDate. Anchoring this to
+        // the JVM default zone instead would make real data points miss the slot they belong to on a
+        // non-UTC host, leaving a zero-filled bucket next to a duplicated real one.
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern(format).withZone(ZoneOffset.UTC);
         while (currentDate.isBefore(endDate)) {
             String finalCurrentDate = currentDate.format(formatter);
             MetricAggregation metricStat = result.stream()

--- a/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcRepository.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcRepository.java
@@ -116,18 +116,32 @@ public abstract class AbstractJdbcRepository {
         return DSL.week(timestampField);
     }
 
+    /**
+     * The timestamp expression that {@link #groupByFields} extracts date parts from.
+     * <p>
+     * It must yield <em>UTC</em> wall-clock parts, because
+     * {@link io.kestra.jdbc.AbstractJdbcRepository#getDate} reassembles them in UTC. The default is
+     * correct for H2 and MySQL, whose date columns already hold UTC wall-clock values. Postgres
+     * stores {@code TIMESTAMPTZ}, for which a plain cast to {@code timestamp} resolves in the
+     * session timezone, so it overrides this.
+     */
+    protected Field<Timestamp> groupByTimestampField(String dateField) {
+        return DSL.timestamp(field(dateField, Date.class));
+    }
+
     protected List<Field<?>> groupByFields(Duration duration, @Nullable String dateField, @Nullable DateUtils.GroupType groupBy) {
         return groupByFields(duration, dateField, groupBy, true);
     }
 
     protected List<Field<?>> groupByFields(Duration duration, @Nullable String dateField, @Nullable DateUtils.GroupType groupBy, boolean withAs) {
         String field = dateField != null ? dateField : "timestamp";
-        Field<Integer> month = withAs ? DSL.month(DSL.timestamp(field(field, Date.class))).as("month") : DSL.month(DSL.timestamp(field(field, Date.class)));
-        Field<Integer> year = withAs ? DSL.year(DSL.timestamp(field(field, Date.class))).as("year") : DSL.year(DSL.timestamp(field(field, Date.class)));
-        Field<Integer> day = withAs ? DSL.day(DSL.timestamp(field(field, Date.class))).as("day") : DSL.day(DSL.timestamp(field(field, Date.class)));
-        Field<Integer> week = withAs ? weekFromTimestamp(DSL.timestamp(field(field, Date.class))).as("week") : weekFromTimestamp(DSL.timestamp(field(field, Date.class)));
-        Field<Integer> hour = withAs ? DSL.hour(DSL.timestamp(field(field, Date.class))).as("hour") : DSL.hour(DSL.timestamp(field(field, Date.class)));
-        Field<Integer> minute = withAs ? DSL.minute(DSL.timestamp(field(field, Date.class))).as("minute") : DSL.minute(DSL.timestamp(field(field, Date.class)));
+        Field<Timestamp> timestamp = groupByTimestampField(field);
+        Field<Integer> month = withAs ? DSL.month(timestamp).as("month") : DSL.month(timestamp);
+        Field<Integer> year = withAs ? DSL.year(timestamp).as("year") : DSL.year(timestamp);
+        Field<Integer> day = withAs ? DSL.day(timestamp).as("day") : DSL.day(timestamp);
+        Field<Integer> week = withAs ? weekFromTimestamp(timestamp).as("week") : weekFromTimestamp(timestamp);
+        Field<Integer> hour = withAs ? DSL.hour(timestamp).as("hour") : DSL.hour(timestamp);
+        Field<Integer> minute = withAs ? DSL.minute(timestamp).as("minute") : DSL.minute(timestamp);
 
         if (groupBy == DateUtils.GroupType.MONTH || duration.toDays() > DateUtils.GroupValue.MONTH.getValue()) {
             return List.of(year, month);

--- a/jdbc/src/test/java/io/kestra/jdbc/AbstractJdbcRepositoryTest.java
+++ b/jdbc/src/test/java/io/kestra/jdbc/AbstractJdbcRepositoryTest.java
@@ -3,7 +3,7 @@ package io.kestra.jdbc;
 import java.time.DayOfWeek;
 import java.time.Instant;
 import java.time.LocalDate;
-import java.time.ZoneId;
+import java.time.ZoneOffset;
 import java.time.temporal.TemporalAdjusters;
 import java.util.List;
 import java.util.TimeZone;
@@ -25,6 +25,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 
 class AbstractJdbcRepositoryTest {
+    /** Zones with a non-zero, and deliberately non-integral, offset from UTC. */
+    private static final List<String> NON_UTC_ZONES = List.of("Asia/Kolkata", "Europe/Berlin", "America/Los_Angeles");
+
     private final TestJdbcRepository repository = new TestJdbcRepository();
 
     private static Record weekRecord(int year, int week) {
@@ -34,6 +37,38 @@ class AbstractJdbcRepositoryTest {
         record.set(yearField, year);
         record.set(weekField, week);
         return record;
+    }
+
+    private static Record partsRecord(int year, int month, int day, int hour, int minute) {
+        Field<Integer> yearField = DSL.field(DSL.name("year"), Integer.class);
+        Field<Integer> monthField = DSL.field(DSL.name("month"), Integer.class);
+        Field<Integer> dayField = DSL.field(DSL.name("day"), Integer.class);
+        Field<Integer> hourField = DSL.field(DSL.name("hour"), Integer.class);
+        Field<Integer> minuteField = DSL.field(DSL.name("minute"), Integer.class);
+        Record record = DSL.using(SQLDialect.H2).newRecord(yearField, monthField, dayField, hourField, minuteField);
+        record.set(yearField, year);
+        record.set(monthField, month);
+        record.set(dayField, day);
+        record.set(hourField, hour);
+        record.set(minuteField, minute);
+        return record;
+    }
+
+    /**
+     * Runs {@code assertions} once per non-UTC JVM default zone, restoring the original zone
+     * afterwards. The date parts handed to {@code getDate} are UTC wall-clock values, so the
+     * reassembled instant must not depend on where the host happens to be.
+     */
+    private static void underEachNonUtcDefaultZone(Runnable assertions) {
+        TimeZone original = TimeZone.getDefault();
+        try {
+            for (String zone : NON_UTC_ZONES) {
+                TimeZone.setDefault(TimeZone.getTimeZone(zone));
+                assertions.run();
+            }
+        } finally {
+            TimeZone.setDefault(original);
+        }
     }
 
     @Test
@@ -57,19 +92,43 @@ class AbstractJdbcRepositoryTest {
     }
 
     @Test
-    void shouldReturnMondayStartOfDayInDefaultZoneWhenWeekGrouping() {
+    void shouldReturnMondayStartOfDayInUtcWhenWeekGrouping() {
         // Given a regular week grouping record
         Record record = weekRecord(2021, 24);
 
         // When resolving the week bucket
         Instant date = repository.getDate(record, "week");
 
-        // Then it is the Monday at start of day, using that date's own zone offset (not the current offset)
-        ZoneId zone = TimeZone.getDefault().toZoneId();
+        // Then it is the Monday at UTC start of day
         LocalDate expectedMonday = LocalDate.ofYearDay(2021, 24 * 7)
             .with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY));
-        assertThat(date).isEqualTo(expectedMonday.atStartOfDay(zone).toInstant());
-        assertThat(date.atZone(zone).getDayOfWeek()).isEqualTo(DayOfWeek.MONDAY);
+        assertThat(date).isEqualTo(expectedMonday.atStartOfDay(ZoneOffset.UTC).toInstant());
+        assertThat(date.atZone(ZoneOffset.UTC).getDayOfWeek()).isEqualTo(DayOfWeek.MONDAY);
+    }
+
+    @Test
+    void shouldReassembleBucketsInUtcRegardlessOfDefaultZone() {
+        // Given date parts extracted as UTC wall-clock values: 2026-07-29 14:30 UTC
+        Record record = partsRecord(2026, 7, 29, 14, 30);
+
+        // When / Then each bucket is anchored in UTC, whatever the host's zone is
+        underEachNonUtcDefaultZone(() -> {
+            assertThat(repository.getDate(record, "minute")).isEqualTo(Instant.parse("2026-07-29T14:30:00Z"));
+            assertThat(repository.getDate(record, "hour")).isEqualTo(Instant.parse("2026-07-29T14:00:00Z"));
+            assertThat(repository.getDate(record, "day")).isEqualTo(Instant.parse("2026-07-29T00:00:00Z"));
+            assertThat(repository.getDate(record, "month")).isEqualTo(Instant.parse("2026-07-01T00:00:00Z"));
+        });
+    }
+
+    @Test
+    void shouldReassembleWeekBucketInUtcRegardlessOfDefaultZone() {
+        // Given a week grouping record
+        Record record = weekRecord(2021, 24);
+
+        // When / Then the Monday start-of-day is in UTC, whatever the host's zone is
+        underEachNonUtcDefaultZone(() ->
+            assertThat(repository.getDate(record, "week")).isEqualTo(Instant.parse("2021-06-14T00:00:00Z"))
+        );
     }
 
     private static final class TestJdbcRepository extends AbstractJdbcRepository<Object> {


### PR DESCRIPTION
closes #17674 

---

### ✨ Description

What does this PR change?  

 - `getDate()` reassembles in `ZoneOffset.UTC` (5 sites).
  - New `groupByTimestampField` hook on `AbstractJdbcRepository`, overridden by
    `PostgresMetricRepository` to extract through `AT TIME ZONE 'UTC'` — so all three dialects now
    feed UTC digits in. H2/MySQL keep the existing cast.
  - Metric gap-filler moves to UTC alongside, or real data points stop matching their filled slots.

 Unit tests assert exact bucket instants under `Asia/Kolkata`, `Europe/Berlin` and                                                                                  
  `America/Los_Angeles`. `PostgresUtcTimestampFieldTest` runs the real expression against real
  Postgres under each zone — reverting the fix makes it fail with `expected: 14, but was: 20`.

  Full suites green: `jdbc` (59), `jdbc-h2` (969), `jdbc-mysql` (850), `jdbc-postgres` metric tests.

### 🤖 AI Authors

I've used claude to generate tests and java docs.

## Proof

  ### 1. The tests fail without the fix (negative control)

  Reverting both halves of the fix on this branch — `getDate()` back to `TimeZone.getDefault()`,
  and the Postgres expression back to a plain cast — while keeping the new tests:


  AbstractJdbcRepositoryTest > shouldReassembleBucketsInUtcRegardlessOfDefaultZone  ✘
      expected: 2026-07-29T14:30:00Z
       but was: 2026-07-29T09:00:00Z          ← -5:30, reassembled as Asia/Kolkata

  AbstractJdbcRepositoryTest > shouldReassembleWeekBucketInUtcRegardlessOfDefaultZone  ✘
      expected: 2021-06-14T00:00:00Z
       but was: 2021-06-13T18:30:00Z          ← bucket lands on the previous day

  PostgresUtcTimestampFieldTest > shouldExtractUtcDatePartsRegardlessOfSessionTimeZone  ✘
      [hour, JVM zone Asia/Kolkata]
      expected: 14
       but was: 20                            ← real Postgres, extraction in session tz

  The Postgres failure is the one worth noting: it's against a live `postgres:14.13`, and it's the
  error the plain one-line fix would have shipped.

  ### 2. They pass with it

  AbstractJdbcRepositoryTest          5 passing
  PostgresUtcTimestampFieldTest       2 passing
  
  ### 3. Backend behaviour, measured

  Same source instant `2026-07-29T14:00:00Z`, each dialect's real column definition from the
  migrations, three JVM default zones (UTC / Asia/Kolkata / Europe/Berlin) — extracted `day, hour`:

  | Backend | Column | Extracted | Digits are |
  |---|---|---|---|
  | H2 | `TIMESTAMP` ← `PARSEDATETIME(… \|\| '+00:00')` | `29,14` / `29,14` / `29,14` | UTC, always |
  | MySQL | `DATETIME(6)` ← `STR_TO_DATE(…'%fZ')` | `29,14` / `29,14` / `29,14` | UTC, always |
  | Postgres | `TIMESTAMPTZ` | `29,14` / `29,19` / `29,16` | JVM-local |

  `SHOW TIME ZONE` on those three connections returned `UTC`, `Asia/Kolkata`, `Europe/Berlin` —
  pgjdbc propagates the JVM default into the session.