### PR TITLE
docs: add Zenith Hosting deploy option to Quick Start

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,12 @@ Deploy Kestra on AWS using our CloudFormation template:
 
 Deploy Kestra on Google Cloud Infrastructure Manager using [our Terraform module](https://github.com/kestra-io/deployment-templates/tree/main/gcp/terraform/infrastructure-manager/vm-sql-gcs).
 
+### Launch on Zenith (third-party managed hosting)
+
+One-click managed Kestra from a community provider, with storage, backups and a free subdomain included:
+
+[![Deploy with Zenith](https://cdn.zenith.hosting/buttons/deploy-with-zenith.svg)](https://zenith.hosting/host/kestra)
+
 ### Get Started Locally in 5 Minutes
 
 #### Launch Kestra in Docker


### PR DESCRIPTION
### ✨ Description

hey, i work on Zenith Hosting, a startup doing one-click hosting for open source apps. we added Kestra to our marketplace, so this PR adds a small "Deploy with Zenith" badge under Quick Start, next to the existing AWS and Google Cloud launch options (links to https://zenith.hosting/host/kestra).

it is labelled as third-party managed hosting so it reads as one more community option, not an official Kestra one. one file, six added lines, nothing else touched. happy to reword, move it, or drop it entirely if you would rather keep that section to first-party deployments.

we share a cut of revenue with the projects we host. happy to explain if you're curious: hello@zenith.hosting

### 🔗 Related Issue

Closes https://github.com/kestra-io/kestra/issues/17787

### 📝 Additional Notes

Docs only. No frontend or backend changes, so those checklist sections are removed per the template.

### 🤖 AI Authors

Being straight with you since the template asks: this PR was prepared with AI assistance, reviewed and owned by me.

Cat joke as requested: why did the cat sit on the orchestrator? it heard the flows had great scheduling and it wanted the best nap slot. 🐱
