### PR TITLE
docs(core): document the GitHub issue-type convention for coding agents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -375,6 +375,11 @@ This copies the gitignored `cli/src/main/resources/application-*.yml` files from
 - Use types: chore, feat, fix, refactor, test, docs, build
 - Use scopes: apps, assets, core, dashboards, deps, design-system, executions, flows, iam, namespaces, plugins, secrets, storage, scheduler, system, tasks, tenants, tests, topology, triggers, variables, version, worker
 
+## Issue guidelines
+- **Classify an issue with its GitHub issue type, not a `kind/*` label.** The `kind/bug` label is retired — do not add it. Set the type instead: `gh issue create --title … ` followed by `gh issue edit <number> --type Bug`, or `gh issue edit <number> --type Task|Feature|Epic`. Available types are `Task`, `Bug`, `Feature` and `Epic` (list them with `gh api /orgs/kestra-io/issue-types`).
+- **Do add the `area/*` labels** — `area/frontend`, `area/backend`, `area/devops`, `area/docs`, `area/plugin`, `area/qa`, `area/analytics` — since those drive routing and are still in use.
+- Leave triage labels such as `kind/cooldown` to `kestrabot`; it applies them automatically on new issues.
+
 This document should be updated as the codebase evolves. When in doubt, follow existing patterns in the codebase and maintain consistency with established conventions.
 
 ## UI Translations

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -4914,6 +4914,7 @@
             "os": [
                 "android"
             ],
+            "peer": true,
             "engines": {
                 "node": ">= 10.0.0"
             },
@@ -4934,6 +4935,7 @@
             "os": [
                 "darwin"
             ],
+            "peer": true,
             "engines": {
                 "node": ">= 10.0.0"
             },
@@ -4954,6 +4956,7 @@
             "os": [
                 "darwin"
             ],
+            "peer": true,
             "engines": {
                 "node": ">= 10.0.0"
             },
@@ -4974,6 +4977,7 @@
             "os": [
                 "freebsd"
             ],
+            "peer": true,
             "engines": {
                 "node": ">= 10.0.0"
             },
@@ -4994,6 +4998,7 @@
             "os": [
                 "linux"
             ],
+            "peer": true,
             "engines": {
                 "node": ">= 10.0.0"
             },
@@ -5014,6 +5019,7 @@
             "os": [
                 "linux"
             ],
+            "peer": true,
             "engines": {
                 "node": ">= 10.0.0"
             },
@@ -5034,6 +5040,7 @@
             "os": [
                 "linux"
             ],
+            "peer": true,
             "engines": {
                 "node": ">= 10.0.0"
             },
@@ -5054,6 +5061,7 @@
             "os": [
                 "linux"
             ],
+            "peer": true,
             "engines": {
                 "node": ">= 10.0.0"
             },
@@ -5074,6 +5082,7 @@
             "os": [
                 "linux"
             ],
+            "peer": true,
             "engines": {
                 "node": ">= 10.0.0"
             },
@@ -5094,6 +5103,7 @@
             "os": [
                 "linux"
             ],
+            "peer": true,
             "engines": {
                 "node": ">= 10.0.0"
             },
@@ -5114,6 +5124,7 @@
             "os": [
                 "win32"
             ],
+            "peer": true,
             "engines": {
                 "node": ">= 10.0.0"
             },
@@ -5134,6 +5145,7 @@
             "os": [
                 "win32"
             ],
+            "peer": true,
             "engines": {
                 "node": ">= 10.0.0"
             },
@@ -5154,6 +5166,7 @@
             "os": [
                 "win32"
             ],
+            "peer": true,
             "engines": {
                 "node": ">= 10.0.0"
             },
@@ -17873,6 +17886,7 @@
             ],
             "license": "MIT",
             "optional": true,
+            "peer": true,
             "dependencies": {
                 "sass": "1.100.0"
             }
@@ -17883,6 +17897,7 @@
             "integrity": "sha512-B5j0rYMlinhhOo9tjQebMVVn0TfyXAF+wB3b2ggZUuJ/is/Y+7+JGjirAMxHZ9Z3hIP98NPfamlAkBHa1lAaXQ==",
             "license": "MIT",
             "optional": true,
+            "peer": true,
             "dependencies": {
                 "chokidar": "^5.0.0",
                 "immutable": "^5.1.5",
@@ -17910,6 +17925,7 @@
             "os": [
                 "android"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=14.0.0"
             }
@@ -17926,6 +17942,7 @@
             "os": [
                 "android"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=14.0.0"
             }
@@ -17942,6 +17959,7 @@
             "os": [
                 "android"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=14.0.0"
             }
@@ -17958,6 +17976,7 @@
             "os": [
                 "android"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=14.0.0"
             }
@@ -17974,6 +17993,7 @@
             "os": [
                 "darwin"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=14.0.0"
             }
@@ -17990,6 +18010,7 @@
             "os": [
                 "darwin"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=14.0.0"
             }
@@ -18006,6 +18027,7 @@
             "os": [
                 "linux"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=14.0.0"
             }
@@ -18022,6 +18044,7 @@
             "os": [
                 "linux"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=14.0.0"
             }
@@ -18038,6 +18061,7 @@
             "os": [
                 "linux"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=14.0.0"
             }
@@ -18054,6 +18078,7 @@
             "os": [
                 "linux"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=14.0.0"
             }
@@ -18070,6 +18095,7 @@
             "os": [
                 "linux"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=14.0.0"
             }
@@ -18086,6 +18112,7 @@
             "os": [
                 "linux"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=14.0.0"
             }
@@ -18102,6 +18129,7 @@
             "os": [
                 "linux"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=14.0.0"
             }
@@ -18118,6 +18146,7 @@
             "os": [
                 "linux"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=14.0.0"
             }
@@ -18134,6 +18163,7 @@
                 "!linux",
                 "!win32"
             ],
+            "peer": true,
             "dependencies": {
                 "sass": "1.100.0"
             }
@@ -18144,6 +18174,7 @@
             "integrity": "sha512-B5j0rYMlinhhOo9tjQebMVVn0TfyXAF+wB3b2ggZUuJ/is/Y+7+JGjirAMxHZ9Z3hIP98NPfamlAkBHa1lAaXQ==",
             "license": "MIT",
             "optional": true,
+            "peer": true,
             "dependencies": {
                 "chokidar": "^5.0.0",
                 "immutable": "^5.1.5",
@@ -18171,6 +18202,7 @@
             "os": [
                 "win32"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=14.0.0"
             }
@@ -18187,6 +18219,7 @@
             "os": [
                 "win32"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=14.0.0"
             }


### PR DESCRIPTION
Records how coding agents should classify issues, plus the lockfile normalisation npm keeps re-adding.

## `docs(core)` — issue-type convention

The `kind/bug` label is retired, so an agent that reaches for it leaves the issue unclassified.

- **Classification goes through the GitHub issue type**, not a `kind/*` label: `gh issue edit <number> --type Bug` (also `Task`, `Feature`, `Epic`; list them with `gh api /orgs/kestra-io/issue-types`).
- **The `area/*` labels are still applied** — `area/frontend`, `area/backend`, `area/devops`, `area/docs`, `area/plugin`, `area/qa`, `area/analytics` — since they drive routing.
- **Triage labels such as `kind/cooldown` are left to `kestrabot`**, which applies them automatically on new issues.

The EE counterpart is kestra-io/kestra-ee#9638. EE inherits this file via `@../kestra/AGENTS.md`, so that PR only records the EE-specific differences.

## `build(deps)` — lockfile peer markers

Running npm in `ui/` reconciles peer-dependency metadata for the platform-specific optional binaries of `@parcel/watcher` and `sass-embedded`, adding `"peer": true` to 33 entries. No package versions, resolved URLs or integrity hashes change — verified by diffing for `version`/`resolved`/`integrity`/`dev`/`optional` lines, of which there are none. Committing the normalisation stops the same diff reappearing on every unrelated branch that happens to run npm.

## Scope change

This PR originally also carried the placeholder-integrity work for #17790 — a corrected generator prompt, a placeholder-parity retry, a parity check in the shared translation checker, and 86 repaired translation values. That has been dropped here and is parked on the `wip/translation-placeholder-parity` branch (commit `bce5bbbad6`) pending a decision on the EE side, where `instance setup.create user.password.confirm error.1` intentionally keeps a `{regex}` placeholder that the English source does not yet use. Enforcing parity would fail EE CI on that key, since EE imports the shared checker from this repository.

#17790 therefore stays open.