### PR TITLE
ci(system): forward a PR's change-area to the EE CI so it runs only the matching checks

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -8,28 +8,39 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  # When an OSS PR opens, run the kestra-ee compile check for its ref (via a
-  # Kestra webhook) and trigger the EE OpenAPI spec check.
+  # When an OSS PR opens, run the kestra-ee checks that its change-area can
+  # actually affect — and only those. The area comes from the `file-changes` job
+  # below, so OSS and EE agree on what changed instead of EE re-deriving it:
+  #
+  #   backend -> EE compileJava check + EE OpenAPI spec check. Both are pure Java
+  #              (the spec is generated from controller annotations), so a Vue-only
+  #              change can never move either of them.
+  #   ui      -> EE frontend suite. `ui-ee` npm-workspaces `ui/packages/*` and its
+  #              `check:types` builds the OSS design-system and OSS app tsconfigs
+  #              before its own, so an OSS `ui/**` change genuinely can break it.
   trigger-ee:
+    needs: [file-changes]
+    if: "needs.file-changes.outputs.ui == 'true' || needs.file-changes.outputs.backend == 'true'"
     runs-on: ubuntu-latest
-    # The `secrets` context is not allowed in `if:` conditions, so expose the
-    # app-id as a job-level env var (the `env` context IS allowed in `if:`) and
-    # gate the steps on that instead.
     env:
-      GH_BOT_APP_ID: ${{ secrets.GH_BOT_APP_ID }}
+      # Whether this run can reach kestra-ee at all, resolved once for every step
+      # below. The `secrets` context is not allowed in `if:` conditions but the
+      # `env` context is, hence the indirection. Dependabot PRs are not forks, yet
+      # GitHub still withholds repo secrets from the runs they trigger, so
+      # create-github-app-token would fail on an empty app-id: guard on the secret
+      # itself rather than on the triggering actor, since that is the actual
+      # precondition and it covers every other case where the secrets are absent.
+      EE_DISPATCHABLE: ${{ github.event.pull_request.number != ''
+        && github.event.pull_request.head.repo.fork == false
+        && secrets.GH_BOT_APP_ID != '' }}
     steps:
     - name: Checkout  # required so the local composite action below can resolve
-      if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false && env.GH_BOT_APP_ID != '' }}
+      if: ${{ env.EE_DISPATCHABLE == 'true' }}
       uses: actions/checkout@v7
 
-      # Dependabot PRs are not forks, but GitHub still withholds repo secrets from
-      # workflow runs it triggers, so create-github-app-token would fail with an
-      # empty app-id. Guard on the secret itself rather than the triggering actor,
-      # since that's the actual precondition and it covers any other case where
-      # these secrets aren't available to the run.
     - name: Generate GitHub App token for kestra-ee dispatch
       id: ee-token
-      if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false && env.GH_BOT_APP_ID != '' }}
+      if: ${{ env.EE_DISPATCHABLE == 'true' }}
       uses: actions/create-github-app-token@v3
       with:
         app-id: ${{ secrets.GH_BOT_APP_ID }}
@@ -41,10 +52,7 @@ jobs:
       # surface the result inline. The flow resolves the matching kestra-ee ref
       # itself (same-name branch, else develop), so no branch pre-check is needed.
     - name: EE compile check (via Kestra webhook)
-      if: ${{ github.event_name == 'pull_request'
-        && github.event.pull_request.number != ''
-        && github.event.pull_request.head.repo.fork == false
-        && env.GH_BOT_APP_ID != '' }}
+      if: ${{ env.EE_DISPATCHABLE == 'true' && needs.file-changes.outputs.backend == 'true' }}
       uses: ./.github/actions/ee-compile-check
       with:
         webhook-url: ${{ secrets.KESTRA_CI_EEBUILD_WEBHOOK_URL }}
@@ -53,17 +61,26 @@ jobs:
         pr-number: ${{ github.event.pull_request.number }}
         pr-repo: ${{ github.repository }}
 
-      # Always trigger EE OpenAPI check on non-fork PRs where secrets are available
     - name: Trigger EE OpenAPI spec check
       uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697
-      if: ${{ github.event_name == 'pull_request'
-        && github.event.pull_request.number != ''
-        && github.event.pull_request.head.repo.fork == false
-        && env.GH_BOT_APP_ID != '' }}
+      if: ${{ env.EE_DISPATCHABLE == 'true' && needs.file-changes.outputs.backend == 'true' }}
       with:
         token: ${{ steps.ee-token.outputs.token }}
         repository: kestra-io/kestra-ee
         event-type: "oss-pr-openapi-check"
+        client-payload: >-
+          {"commit_sha":"${{ github.event.pull_request.head.sha }}","pr_number":"${{ github.event.pull_request.number }}","oss_branch":"${{ github.event.pull_request.head.ref }}"}
+
+      # kestra-ee resolves its own ref (branch of the same name, else develop) and
+      # reports the verdict back as a commit status on this PR's head SHA, the same
+      # way the EE compile check above does.
+    - name: Trigger EE frontend check
+      uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697
+      if: ${{ env.EE_DISPATCHABLE == 'true' && needs.file-changes.outputs.ui == 'true' }}
+      with:
+        token: ${{ steps.ee-token.outputs.token }}
+        repository: kestra-io/kestra-ee
+        event-type: "oss-pr-frontend-check"
         client-payload: >-
           {"commit_sha":"${{ github.event.pull_request.head.sha }}","pr_number":"${{ github.event.pull_request.number }}","oss_branch":"${{ github.event.pull_request.head.ref }}"}
 


### PR DESCRIPTION
Closes https://github.com/kestra-io/kestra/issues/17805.

## Problem

`trigger-ee` had no `needs:` and no path filter, so **every** non-fork pull request fired the same two `kestra-ee` checks regardless of what it changed. Both are backend-only:

- **EE compile check** — a synchronous Kestra webhook (`curl --max-time 1800`) that clones `kestra-ee` + OSS and runs `./gradlew compileJava` over the whole EE composite build, holding the runner open for the duration.
- **EE OpenAPI spec check** — dispatches to `kestra-ee`, which checks out EE + OSS, sets up Java 25, runs `./gradlew generateOpenapiSpec` **twice** (EE composite + OSS-only), then diffs against `client-sdk`.

Meanwhile `file-changes` already computes exactly what changed, and every other job here gates on it. That verdict was never passed to the EE side, which left the EE checks wrong in both directions:

- **A UI-only PR ran both EE backend checks** — two full EE Gradle builds, an EE runner and a Kestra flow execution — for a result that is green by construction: `compileJava` compiles no Vue, and the spec is generated from Java controller annotations.
- **A UI-only PR never checked the EE frontend**, which is the one thing an OSS `ui/**` change can genuinely break. `ui-ee` npm-workspaces `ui/packages/*` and its `check:types` builds the OSS design-system and OSS app tsconfigs before its own, so a changed `Ks*` prop or topology export lands green here and surfaces later on an unrelated EE PR.
- **A backend-only PR was right, but only by coincidence** — it happened to match what the two hardcoded checks cover. Nothing enforced it.

## What

`trigger-ee` now consumes `file-changes` and dispatches per area:

| Area | EE checks |
|---|---|
| `backend` | EE compile check + EE OpenAPI spec check |
| `ui` | EE frontend suite (new — `kestra-ee`'s `oss-pr-frontend-check`, reports back as an `EE frontend check` commit status) |
| neither | job skipped entirely |

The reverse direction needed nothing: EE's own `pull-request.yml` already gates `frontend` / `backend` / `build-artifacts` / `comment-openapi-spec-changes` on its own `file-changes` outputs, and recent runs confirm it (a `ui-ee`-only EE PR runs `Frontend - Tests` and skips `Backend - Tests`).

### Drive-by in the same job

The four-clause step guard was repeated on every step, and adding a third dispatch would have made it four copies. It is now resolved once into an `EE_DISPATCHABLE` job env var, so each step's `if:` states only what distinguishes it — the change-area. The precondition is unchanged (a non-fork PR whose run was given the App secrets); since this workflow only triggers on `pull_request`, the folded-in `event_name` and `pull_request.number` checks were always true.

## Review notes

- **Draft PRs.** `file-changes` carries `if: github.event.pull_request.draft == false`, so `trigger-ee` now also skips on drafts — consistent with `frontend` / `backend` / `build-artifacts` today. `on: pull_request` doesn't listen for `ready_for_review`, so undrafting won't re-trigger until the next push; same as every other job here.
- **Not a required check.** Neither the EE compile-check commit status nor the OpenAPI dispatch is in the `develop` ruleset's required checks (ruleset `4792506` has no `required_status_checks` rule), so an area-gated skip can't block a merge.
- **`otel-export-trace`** keeps `trigger-ee` in `needs` with `if: always()` — a skipped dependency is fine.
- **The `backend` filter is negative** (`!{ui,.github}/**`), so a root-level markdown-only PR still counts as `backend` and still triggers the EE backend checks. Tightening that is a separate change, since it also governs the OSS backend test job.
- **`ui-design-system`** is already its own `file-changes` output, but the EE frontend dispatch gates on the broader `ui` flag on purpose — `ui-ee` type-checks the whole OSS app, not just `ui/packages`.

## Merge order

The `ui` dispatch is inert until its two companions land, so this is safe to merge at any point — a `repository_dispatch` for an event type nothing listens to is a no-op.

1. `kestra-io/actions#177` — adds the `ee-ref` / `oss-ref` / `pr-reporting` inputs to the reusable EE frontend suite
2. `kestra-io/kestra-ee#9643` — adds the `oss-pr-frontend-check` workflow that consumes them
3. this PR
