### PR TITLE
ci: generate PR docker image on every commit (incl. drafts)

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -195,11 +195,15 @@ jobs:
   generate-pull-request-docker-image:
     name: Generate PR docker image
     needs: [build-artifacts]
-    if: "!cancelled() && needs.build-artifacts.result == 'success'"
+    # Refresh the PR docker image on every commit, including drafts and
+    # docs-only PRs where build-artifacts is skipped (only skip on an actual
+    # build failure). Reuse the shared `exe` when build-artifacts produced it,
+    # otherwise let the reusable workflow build it from source itself.
+    if: "!cancelled() && needs.build-artifacts.result != 'failure'"
     uses: kestra-io/actions/.github/workflows/kestra-oss-pullrequest-publish-docker.yml@main
     with:
       java-version: 25
-      skip-build: true
+      skip-build: ${{ needs.build-artifacts.result == 'success' }}
 
   otel-export-trace:
     name: OpenTelemetry - Export Trace


### PR DESCRIPTION
## What
Make the `generate-pull-request-docker-image` job run on **every commit**, including **draft** and docs-only PRs.

## Why
The build-once refactor in #17750 chained the docker-image job behind `build-artifacts` → `file-changes`, and `file-changes` is gated on `if: draft == false`. Consequence: on a **draft** PR, `file-changes` is skipped → `build-artifacts` is skipped → the docker job's `if: needs.build-artifacts.result == 'success'` is false → **no docker image is published**.

This broke the long-lived QA PR (#16172), which relies on a fresh `ghcr.io/kestra-io/kestra-pr:<n>` image after each commit. Before #17750 the docker job ran independently and drafts still got an image.

## How
- `if: !cancelled() && needs.build-artifacts.result != 'failure'` — run unless the build actually failed (so it also runs when `build-artifacts` is *skipped* for drafts/docs-only PRs).
- `skip-build: ${{ needs.build-artifacts.result == 'success' }}` — reuse the shared `exe` artifact when `build-artifacts` produced it; otherwise the reusable workflow builds from source itself.

This keeps #17750's build-once optimization for normal PRs while restoring an image on every commit.

## Behavior matrix
| PR type | build-artifacts | docker | source of exe |
|---|---|---|---|
| non-draft, backend/ui change | success | runs | shared artifact (skip-build) |
| draft (e.g. QA PR) | skipped | **runs** | built in docker job |
| docs-only | skipped | runs | built in docker job |
| build failed | failure | skipped | — |
| fork | skipped | skipped (reusable fork guard) | — |