### PR TITLE
fix(chart): set --group=1000 on dind insecure mode default args

### DIFF
--- a/charts/kestra/README.md
+++ b/charts/kestra/README.md
@@ -392,7 +392,7 @@ JDBC queue tables — this is irreversible. Back up your database before upgradi
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| dind.base.insecure | object | `{"args":["--log-level=fatal"],"image":{"pullPolicy":"IfNotPresent","repository":"docker","tag":"dind-rootless"},"securityContext":{"allowPrivilegeEscalation":true,"capabilities":{"add":["SYS_ADMIN","NET_ADMIN","DAC_OVERRIDE","SETUID","SETGID"]},"privileged":true,"runAsGroup":0,"runAsUser":0}}` | Insecure dind configuration (privileged). |
+| dind.base.insecure | object | `{"args":["--log-level=fatal","--group=1000"],"image":{"pullPolicy":"IfNotPresent","repository":"docker","tag":"dind-rootless"},"securityContext":{"allowPrivilegeEscalation":true,"capabilities":{"add":["SYS_ADMIN","NET_ADMIN","DAC_OVERRIDE","SETUID","SETGID"]},"privileged":true,"runAsGroup":0,"runAsUser":0}}` | Insecure dind configuration (privileged). |
 
 ### kestra dind rootless
 

--- a/charts/kestra/values.yaml
+++ b/charts/kestra/values.yaml
@@ -363,6 +363,7 @@ dind:
             - SETGID
       args:
         - '--log-level=fatal'
+        - '--group=1000'
   # -- Path where dind socket is mounted.
   # @section -- kestra dind
   socketPath: /dind/


### PR DESCRIPTION
Insecure dind mode runs the docker daemon as root without a matching `--group` flag, so the docker socket ends up root-owned and the non-root worker container fails to connect with a permission denied error. Rootless mode already sets `--group=1000`; this aligns insecure mode with the same default.

Closes #17803