### PR TITLE
fix(execution): make State.getStartDate tolerant to no history

### DIFF
--- a/core/src/main/java/io/kestra/core/models/flows/State.java
+++ b/core/src/main/java/io/kestra/core/models/flows/State.java
@@ -129,6 +129,11 @@ public class State {
 
     @JsonProperty(access = JsonProperty.Access.READ_ONLY)
     public Instant getStartDate() {
+        // this specifically might happen for dynamic task runs
+        if (this.histories.isEmpty()) {
+            return null;
+        }
+
         return this.histories.getFirst().getDate();
     }
 


### PR DESCRIPTION
This might happen for dynamic taskruns.

Fixes #17055
