### PR TITLE
feat(system): allow configuring the fail-fast mechanism

### DIFF
--- a/queue/src/main/java/io/kestra/queue/AbstractSubscriber.java
+++ b/queue/src/main/java/io/kestra/queue/AbstractSubscriber.java
@@ -81,24 +81,30 @@ public abstract class AbstractSubscriber<T extends Event> implements QueueSubscr
             try {
                 consumer.accept(event);
             } catch (Exception e) {
+                String redeliver = queueService.failFast() ? "Message will be redelivered" : "Message will be lost as fail-fast is disabled (kestra.queue.fail-fast=false)!";
                 if (event.isLeft()) {
                     log.error(
-                        "{} failed to process message with key '{}'. Message will be redelivered. You can ignore this message by starting Kestra with `--ignore-queue-records {}`.",
+                        "{} failed to process message with key '{}'. {}. You can ignore this message by starting Kestra with `--ignore-queue-records {}`.",
                         logPrefix,
                         event.getLeft().key(),
+                        redeliver,
                         event.getLeft().key(),
                         e
                     );
                     log.debug(new String(message));
                 } else {
                     log.error(
-                        "{} failed to process message (deserialization error). Message will be redelivered.",
+                        "{} failed to process message (deserialization error). {}.",
                         logPrefix,
+                        redeliver,
                         e
                     );
                     log.debug(new String(message));
                 }
-                throw e;
+
+                if (queueService.failFast()) {
+                    throw e;
+                }
             }
         });
     }

--- a/queue/src/main/java/io/kestra/queue/QueueConfiguration.java
+++ b/queue/src/main/java/io/kestra/queue/QueueConfiguration.java
@@ -18,6 +18,8 @@ public class QueueConfiguration {
     @Nullable
     String prefix;
 
+    Boolean failFast = true;
+
     @Getter
     @ConfigurationProperties("message-protection")
     public static class MessageProtection {

--- a/queue/src/main/java/io/kestra/queue/QueueService.java
+++ b/queue/src/main/java/io/kestra/queue/QueueService.java
@@ -116,4 +116,11 @@ public class QueueService {
             return Either.right(new DeserializationException(e, new String(record)));
         }
     }
+
+    /**
+     * @return true if the fail-fast mode is enabled (true by default)
+     */
+    public boolean failFast() {
+        return Boolean.TRUE.equals(queueConfiguration.getFailFast());
+    }
 }

--- a/queue/src/test/java/io/kestra/queue/AbstractSubscriberTest.java
+++ b/queue/src/test/java/io/kestra/queue/AbstractSubscriberTest.java
@@ -10,15 +10,18 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import io.kestra.core.exceptions.DeserializationException;
+import io.kestra.core.metrics.MetricConfig;
 import io.kestra.core.metrics.MetricRegistry;
 import io.kestra.core.queues.QueueSubscriber;
 import io.kestra.core.queues.event.Event;
 import io.kestra.core.services.IgnoreExecutionService;
 import io.kestra.core.utils.Either;
 
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNoException;
-import static org.mockito.ArgumentMatchers.anyString;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -31,14 +34,19 @@ class AbstractSubscriberTest {
     @BeforeEach
     void setUp() {
         queueService = mock(QueueService.class);
-        metricRegistry = mock(MetricRegistry.class);
+        metricRegistry = new MetricRegistry(new SimpleMeterRegistry(), new MetricConfig());
         ignoreExecutionService = mock(IgnoreExecutionService.class);
-        when(metricRegistry.timer(anyString(), anyString(), anyString(), anyString()))
-            .thenReturn(mock(io.micrometer.core.instrument.Timer.class));
     }
 
     private TestSubscriber createSubscriber() {
         return new TestSubscriber(queueService, metricRegistry, ignoreExecutionService);
+    }
+
+    private Consumer<Either<TestEvent, DeserializationException>> failingConsumer() {
+        return ignored ->
+        {
+            throw new RuntimeException("Boom");
+        };
     }
 
     @Test
@@ -497,6 +505,32 @@ class AbstractSubscriberTest {
         // shutdown() is called twice because markEnd(Throwable) always calls it,
         // but KestraContext.Initializer.shutdown() itself is idempotent via AtomicBoolean
         assertThat(noOpContext.isShutdownCalled()).isTrue();
+    }
+
+    @Test
+    void shouldRethrowWhenConsumerFailsAndFailFastEnabled() {
+        // Given
+        var subscriber = createSubscriber();
+        byte[] message = "irrelevant".getBytes();
+        when(queueService.deserialize(TestEvent.class, message)).thenReturn(Either.left(new TestEvent("key1")));
+        when(queueService.failFast()).thenReturn(true);
+
+        // When/Then
+        assertThatThrownBy(() -> subscriber.processMessage(message, failingConsumer()))
+            .isInstanceOf(RuntimeException.class)
+            .hasMessage("Boom");
+    }
+
+    @Test
+    void shouldSwallowExceptionWhenConsumerFailsAndFailFastDisabled() {
+        // Given
+        var subscriber = createSubscriber();
+        byte[] message = "irrelevant".getBytes();
+        when(queueService.deserialize(TestEvent.class, message)).thenReturn(Either.left(new TestEvent("key1")));
+        when(queueService.failFast()).thenReturn(false);
+
+        // When/Then
+        assertThatNoException().isThrownBy(() -> subscriber.processMessage(message, failingConsumer()));
     }
 
     /**


### PR DESCRIPTION
By default queues are fail-fast: if a subscriber fail to process the message, it is not acknowledge and the suscriber throws, usually closing Kestra.

With this change, this is now configurable and the user may choose to opt-out and ignore the message instead (which is usually not a good idea).

Closes https://github.com/kestra-io/kestra-ee/issues/9498

@aj-emerich it migt be documented in the queue configuration section in 2.0 but as it's highly dangerous I'm not sure it's a good idea. We might revisit this later.