### PR TITLE
test(executions): drop the useless escape in the FilePreview spec that breaks the oxlint check

### DIFF
--- a/ui/tests/unit/components/executions/FilePreview.spec.ts
+++ b/ui/tests/unit/components/executions/FilePreview.spec.ts
@@ -24,7 +24,7 @@ vi.mock("override/utils/route", () => ({
 
 import FilePreview from "../../../../src/components/executions/FilePreview.vue"
 
-const FULL_HTML = "<html><body><h1>Hi</h1><script>document.title='ok'<\/script></body></html>"
+const FULL_HTML = "<html><body><h1>Hi</h1><script>document.title='ok'</script></body></html>"
 const BIG_SIZE = 11 * 1024 * 1024  // 11 MB — over the 10 MB threshold
 const SMALL_SIZE = 1024             // 1 KB — under threshold
 


### PR DESCRIPTION
The `Frontend - Tests` job has been red on `develop` since #17585 was merged. It is not a test failure — the job dies at the **oxlint** step, before Vitest and Storybook ever run:

```
##[error]Unnecessary escape character '/'
Found 41 warnings and 1 error.
##[error]Process completed with exit code 1.
```

The `FULL_HTML` fixture in `ui/tests/unit/components/executions/FilePreview.spec.ts` used the `<\/script>` HTML-inlining idiom, but this is a TypeScript module that is never inlined into a script tag, so the backslash is a useless escape. `no-useless-escape` sits in oxlint's `correctness` category, which `ui/.oxlintrc.json` sets to `error`.

The string value is unchanged — `"\/"` and `"/"` are the same character in JavaScript — so the test behaviour is identical.

Verified locally with oxlint 1.77.0 against `ui/`: **exit 0, 0 errors** (the 41 remaining warnings are pre-existing and non-blocking). This is not an oxlint version regression — 1.76.0 flags it too; PR #17585's last CI run was 2026-07-28 and it was merged on 2026-08-03 without a re-run.