### PR TITLE
fix: cleaner should not be running on worker

### DIFF
--- a/core/src/main/java/io/kestra/core/storages/kv/KVPurgeCleaner.java
+++ b/core/src/main/java/io/kestra/core/storages/kv/KVPurgeCleaner.java
@@ -25,6 +25,7 @@ import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @Requires(property = "kestra.kv.purge-expired.enabled", value = "true", defaultValue = "true")
+@Requires(property = "kestra.server-type", notEquals = "WORKER")
 @Singleton
 public class KVPurgeCleaner {
 


### PR DESCRIPTION
 Stops the expired KV entries purge from being scheduled on a worker. It needs database access, which a worker doesn't have: every hourly tick failed and logged an error with a stack trace, for work that was never the worker's to do.
 
 companion PR : https://github.com/kestra-io/kestra-ee/pull/9650