### PR TITLE
docs(ai): tighten comments in the copilot UI components

### DIFF
--- a/ui/src/components/ai/copilot/CopilotArtefactDraft.vue
+++ b/ui/src/components/ai/copilot/CopilotArtefactDraft.vue
@@ -24,9 +24,9 @@
              KsMarkdown provides its own copy-to-clipboard control, so no separate copy button. -->
         <KsMarkdown class="copilot-draft-yaml" data-test="copilot-draft-yaml" :content="yamlBlock" />
 
-        <!-- Apply actions. Flows + dashboards can be opened in the editor or applied directly. Apps
-             are EE-only: they can only be opened in the app editor (no direct apply), and only when
-             the EE app path is present — in OSS an app draft never occurs, so no actions show. -->
+        <!-- Apply actions: flows + dashboards open in the editor or apply directly. Apps are EE-only —
+             open in the app editor only (no direct apply), and only when the EE app path is present, so
+             OSS shows no actions. -->
         <div v-if="showActions" class="copilot-draft-footer">
             <KsButton size="small" data-test="copilot-draft-open" @click="openInEditor(draft)">
                 {{ $t("ai.copilot.draft.openInEditor") }}

--- a/ui/src/components/ai/copilot/CopilotChat.vue
+++ b/ui/src/components/ai/copilot/CopilotChat.vue
@@ -155,9 +155,9 @@
 
     const mode = ref<AgentMode>(props.initialMode ?? "EDIT")
 
-    // Context-awareness: when the copilot opens on a flow / execution / namespace page, send that
-    // page as `inFocus` so the agent knows what the user is looking at. An explicit `inFocus` prop
-    // (if a parent ever passes one) still wins. Recomputed as the route changes while the drawer is open.
+    // When the copilot opens on a flow / execution / namespace page, send that page as `inFocus` so
+    // the agent knows what the user is looking at; recomputed as the route changes. An explicit
+    // `inFocus` prop still wins.
     const routeInFocus = computed<ScopeBinding | null>(() => props.inFocus ?? scopeFromRoute(route))
 
     // The user can dismiss individual context pills to run a turn without that resource. Dismissals
@@ -181,9 +181,9 @@
         // Once every focused resource is dismissed there's nothing left to show or send.
         return Object.entries(effective).some(([field, value]) => field !== "kind" && value) ? effective : null
     })
-    // Announce focus changes in the transcript (display-only). Navigating to a new resource adds its
-    // primary pill; dismissing a pill removes it. Also re-arms dismissals for the newly-focused
-    // resource. `noteContext` no-ops until a conversation has started, so the empty state stays clean.
+    // Announce focus changes in the transcript (display-only) and re-arm dismissals for the
+    // newly-focused resource. `noteContext` no-ops until a conversation has started, so the empty
+    // state stays clean.
     let previousFocus: ScopeBinding | null = routeInFocus.value
     watch(
         () => JSON.stringify(routeInFocus.value),
@@ -264,11 +264,9 @@
             : null,
     )
 
-    // The working indicator (animated Kestra mark) persists across the whole turn, switching
-    // movement by phase: "thinking" before any output (right after the user's turn or a tool
-    // result), "answering" while tokens stream into the assistant bubble, and a brief "end"
-    // gather when the turn closes. It stays hidden while a tool is running — the tool strip owns
-    // that UI.
+    // The working indicator (animated Kestra mark) persists across the whole turn, switching movement
+    // by phase — "thinking" before any output, "answering" while tokens stream, an "end" gather when
+    // the turn closes. It stays hidden while a tool runs — the tool strip owns that UI.
     const lastMessage = computed(() => messages.value[messages.value.length - 1])
 
     const answering = computed(
@@ -331,10 +329,9 @@
         footerComposer.value?.focus()
     }
 
-    // Seeded prompts: an entry point (e.g. "Fix with AI") calls miscStore.promptCopilot(text),
-    // which opens this tab and stashes the text. Prefill the composer with it and focus, then
-    // clear the store so it doesn't re-seed on the next open. Runs on mount (drawer just opened)
-    // and via a watcher (drawer already open / kept alive).
+    // Seeded prompts: an entry point (e.g. "Fix with AI") stashes text via miscStore, which opens
+    // this tab. Prefill the composer with it and focus, then clear the store so it doesn't re-seed —
+    // run on mount (drawer just opened) and via a watcher (already open / kept alive).
     async function consumeSeededPrompt(): Promise<void> {
         const seeded = miscStore.copilotPrompt
         if (!seeded) return

--- a/ui/src/components/ai/copilot/CopilotMarkAnimation.vue
+++ b/ui/src/components/ai/copilot/CopilotMarkAnimation.vue
@@ -1,9 +1,9 @@
 <template>
-    <!-- Decorative Kestra-mark animation shown beside the copilot status word while a turn runs.
-         Three brand dots that bounce ("thinking") and ripple left→right ("answering"); when the turn
-         ends they gather and bloom into the full Kestra mark ("end"). A lightweight CSS/SVG
-         reproduction of the delivered Lottie set (no runtime dep). Purely decorative: the transcript's
-         aria-busy + the status word already convey "working", so the whole thing is aria-hidden. -->
+    <!-- Decorative Kestra-mark animation shown beside the copilot status word while a turn runs: three
+         brand dots that bounce ("thinking"), ripple ("answering"), then gather and bloom into the full
+         mark ("end") — a lightweight CSS/SVG reproduction of the delivered Lottie set (no runtime dep).
+         Purely decorative and aria-hidden: the transcript's aria-busy + the status word already convey
+         "working". -->
     <span class="copilot-mark" :class="`copilot-mark-${phase}`" aria-hidden="true">
         <!-- The three dots (brand tints, purple → pink). -->
         <svg class="copilot-mark-dots" viewBox="0 0 44 16" width="30" height="11" fill="none" focusable="false">

--- a/ui/src/components/ai/copilot/CopilotPage.vue
+++ b/ui/src/components/ai/copilot/CopilotPage.vue
@@ -1,9 +1,9 @@
 <template>
     <!--
-        Full-page host for the v2 AI Copilot. Reuses the very same CopilotChat as the right-side
-        dock (same agent, composer, transcript, thread controls) in the "page" layout — this is the
-        #7909 onboarding cutover, making the copilot a discoverable full-width home. The legacy
-        one-shot generator (`../AiCopilot.vue` + onboarding WelcomeCopilot) is retired by this change.
+        Full-page host for the v2 AI Copilot — reuses the same CopilotChat as the right-side dock in the
+        "page" layout (the #7909 onboarding cutover, making the copilot a discoverable full-width home).
+        The legacy one-shot generator (`../AiCopilot.vue` + onboarding WelcomeCopilot) is retired by this
+        change.
     -->
     <!-- Hidden for a user without the COPILOT permission; the watcher redirects them to dashboards. -->
     <div v-if="!denied" class="copilot-page-root">
@@ -52,11 +52,11 @@
     const authStore = useAuthStore()
     const canCreateFlow = computed(() => authStore.user?.hasAnyActionOnAnyNamespace(resource.FLOW, action.CREATE))
 
-    // The copilot is gated by the backend's `@HasAnyResource(COPILOT)`, and `/ai` is also the
-    // post-login landing — so a user without that permission can arrive here directly (redirect,
-    // typed URL, refresh). Send them to their dashboards rather than strand them on a surface they
-    // can't use. Reactive (not a router guard) so it fires once the user/permissions finish loading,
-    // and never misfires while they're still loading. A no-op in OSS, where auth is permissive.
+    // The copilot is gated by the backend's `@HasAnyResource(COPILOT)` and `/ai` is the post-login
+    // landing, so a permission-less user can arrive here directly (redirect, typed URL, refresh) —
+    // send them to their dashboards rather than strand them. Reactive (not a router guard) so it fires
+    // once permissions finish loading and never misfires while loading; a no-op in OSS, where auth is
+    // permissive.
     const denied = computed(() => !!authStore.user && !authStore.user.hasAny(resource.COPILOT))
     watch(
         denied,

--- a/ui/src/components/ai/copilot/CopilotThinking.vue
+++ b/ui/src/components/ai/copilot/CopilotThinking.vue
@@ -1,7 +1,7 @@
 <template>
-    <!-- The copilot working indicator: an animated Kestra mark plus a rotating flavour word. Shown
-         while a turn runs. Decorative: the flavour words would spam a screen reader, so it's hidden
-         from the a11y tree — the transcript's `aria-busy` + the streamed tokens convey "working". -->
+    <!-- The copilot working indicator: an animated Kestra mark plus a rotating flavour word, shown
+         while a turn runs. Decorative and hidden from the a11y tree (the flavour words would spam a
+         screen reader) — the transcript's `aria-busy` + streamed tokens convey "working". -->
     <div class="copilot-thinking" data-test="copilot-thinking" aria-hidden="true">
         <CopilotMarkAnimation :phase="phase" />
         <!-- The rotating word only reads during the "thinking" gap (before any output); while the

--- a/ui/src/components/ai/copilot/ProposedActionCard.vue
+++ b/ui/src/components/ai/copilot/ProposedActionCard.vue
@@ -83,9 +83,9 @@
     const MAX_ARG_LENGTH = 120
 
     /**
-     * The identifying arguments to show under the summary, so the user sees exactly what will run
-     * (e.g. namespace/flowId, executionId). Scalars only — objects/arrays and long values (YAML/source
-     * bodies) are omitted to keep the card compact. Empty for plan cards (no concrete tool call).
+     * The identifying arguments shown under the summary so the user sees exactly what will run (e.g.
+     * namespace/flowId, executionId). Scalars only — objects/arrays and long values (YAML/source bodies)
+     * are omitted to keep the card compact; empty for plan cards (no concrete tool call).
      */
     const argEntries = computed<[string, string][]>(() => {
         if (isPlan.value || !props.action.arguments) return []

--- a/ui/src/components/ai/copilot/useAiChat.ts
+++ b/ui/src/components/ai/copilot/useAiChat.ts
@@ -301,9 +301,9 @@ export function useAiChat() {
         try {
             await streamSse({url, body, signal: abort.signal, onFrame: reduce})
             // The stream closed cleanly but added nothing to the transcript and left no proposal —
-            // e.g. a transient provider hiccup returned only `done`. Surface a notice rather than
-            // leaving the panel silent, so the user knows to retry. A streamed error event already
-            // surfaces its own reason, so don't stack the empty-turn notice on top of it.
+            // e.g. a transient provider hiccup returned only `done`; surface a notice rather than
+            // leaving the panel silent. A streamed error event already surfaces its own reason, so
+            // don't stack the empty-turn notice on top of it.
             if (messages.value.length === countBefore && !pendingConfirmation.value && !errorDetail.value && !error.value) {
                 notice.value = "emptyTurn"
             }
@@ -381,8 +381,8 @@ export function useAiChat() {
     }
 
     /**
-     * Appends a display-only system line noting a context (focus) change. Not a turn — never sent to
-     * the backend or persisted. Suppressed until a conversation has started: before that the context
+     * Appends a display-only system line noting a context (focus) change — never a turn, so never sent
+     * to the backend or persisted. Suppressed until a conversation has started: before that the context
      * pills already convey the focus, so the empty state stays clean.
      */
     function noteContext(notice: ContextNotice): void {


### PR DESCRIPTION
## What

Applies the `AGENTS.md` comment guideline — *keep comments short and only where they earn their place (one sentence, or two for genuine "why"); don't narrate obvious code* — to the AI Copilot UI components.

- **7 files tightened, comment-only**: the few 3–5 sentence comments become 1–2 crisp sentences, preserving the load-bearing reasoning (OSS/EE differences, `@HasAnyResource(COPILOT)` gating, `aria-hidden` rationale, empty-turn vs. streamed-error handling, seeded-prompt handoff).
- **8 other copilot files left untouched** — their comments were already 1–2 sentences of genuine reasoning, not obvious-code narration, so nothing was removed.

No behaviour change: every non-comment line is byte-identical.

## Test

- Diff is 100% comment text (no code / template / CSS moved).
- `npm run check:types` clean; copilot unit specs green (161).

Closes https://github.com/kestra-io/kestra-ee/issues/9660.