### PR TITLE
refactor(executions): skip redundant flowable resolution when children cannot progress

### DIFF
--- a/core/src/test/java/io/kestra/plugin/core/flow/IfTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/flow/IfTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.Test;
 import io.kestra.core.junit.annotations.ExecuteFlow;
 import io.kestra.core.junit.annotations.KestraTest;
 import io.kestra.core.junit.annotations.LoadFlows;
+import io.kestra.core.metrics.MetricRegistry;
 import io.kestra.core.models.executions.Execution;
 import io.kestra.core.models.executions.TaskRunAttempt;
 import io.kestra.core.models.flows.State;
@@ -29,6 +30,9 @@ class IfTest {
 
     @Inject
     private ExecutionRepositoryInterface executionRepository;
+
+    @Inject
+    private MetricRegistry metricRegistry;
 
     @Test
     @LoadFlows(value = { "flows/valids/if-condition.yaml" }, tenantId = "iftruthy")
@@ -169,5 +173,33 @@ class IfTest {
         assertThat(execution.getState().getCurrent()).isEqualTo(State.Type.FAILED);
         assertThat(execution.getTaskRunList().getFirst().getState().getCurrent()).isEqualTo(State.Type.FAILED);
         assertThat(execution.getTaskRunList().getFirst().getAttempts().getFirst().getState().getCurrent()).isEqualTo(State.Type.FAILED);
+    }
+
+    // https://github.com/kestra-io/kestra/issues/9008: the Executor used to call resolveNexts() on a
+    // running If for every executor cycle, most of them resolving to nothing. Pin the number of
+    // resolutions so a regression shows up here rather than only in a profiler.
+    @Test
+    @LoadFlows(value = { "flows/valids/if-condition.yaml" }, tenantId = "ifflowablecount")
+    void shouldResolveFlowableOnlyWhenItCanProgress() throws TimeoutException, QueueException {
+        // Given
+        double before = flowableExecutionCount();
+
+        // When
+        Execution execution = runnerUtils.runOne(
+            "ifflowablecount", "io.kestra.tests", "if-condition", null,
+            (f, e) -> Map.of("param", true), Duration.ofSeconds(120)
+        );
+
+        // Then
+        assertThat(execution.getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
+        assertThat(flowableExecutionCount() - before).isEqualTo(2d);
+    }
+
+    private double flowableExecutionCount() {
+        return metricRegistry.counter(
+            MetricRegistry.METRIC_EXECUTOR_FLOWABLE_EXECUTION_COUNT,
+            MetricRegistry.METRIC_EXECUTOR_FLOWABLE_EXECUTION_COUNT_DESCRIPTION,
+            MetricRegistry.TAG_TASK_TYPE, If.class.getName()
+        ).count();
     }
 }

--- a/executor/src/main/java/io/kestra/executor/ExecutorService.java
+++ b/executor/src/main/java/io/kestra/executor/ExecutorService.java
@@ -357,6 +357,32 @@ public class ExecutorService {
             .map(throwFunction(type -> new WorkerTaskResult(taskRun.withState(type))));
     }
 
+    /**
+     * A flowable can only create a new child task run, via {@code resolveNexts}, or terminate, via
+     * {@code resolveState}, when it has no child task run yet or when at least one of its child
+     * task runs has terminated — every {@code FlowableUtils.resolveSequentialNexts}/{@code resolveParallelNexts}/
+     * {@code resolveWaitForNext}/{@code resolveState} implementation already returns empty/absent
+     * otherwise. Checking this upfront avoids building a {@link RunContext} (and its output query)
+     * on cycles that can only resolve to nothing.
+     */
+    private boolean canChildrenProgress(Execution execution, TaskRun parentTaskRun) {
+        if (execution.getTaskRunList() == null) {
+            return true;
+        }
+
+        boolean hasChild = false;
+        for (TaskRun taskRun : execution.getTaskRunList()) {
+            if (parentTaskRun.getId().equals(taskRun.getParentTaskRunId())) {
+                hasChild = true;
+                if (taskRun.getState().isTerminated()) {
+                    return true;
+                }
+            }
+        }
+
+        return !hasChild;
+    }
+
     private List<TaskRun> childNextsTaskRun(ExecutorContext executor, TaskRun parentTaskRun, RunContext runContext) throws InternalException {
         Task parent = executor.getFlow().findTaskByTaskId(parentTaskRun.getTaskId());
         if (parent instanceof FlowableTask<?> flowableParent) {
@@ -536,8 +562,9 @@ public class ExecutorService {
         for (TaskRun taskRun : executor.getExecution().getTaskRunList()) {
             Task task = executor.getFlow().findTaskByTaskIdOrNull(taskRun.getTaskId());
 
-            // For running flowable tasks: compute both next task runs and the worker task result in a single pass
-            if (taskRun.getState().isRunning() && task instanceof FlowableTask<?>) {
+            // For running flowable tasks: compute both next task runs and the worker task result in a single pass,
+            // but only when a child can actually progress — avoids rebuilding a RunContext (and its output query) on cycles that can only resolve empty.
+            if (taskRun.getState().isRunning() && task instanceof FlowableTask<?> && this.canChildrenProgress(executor.getExecution(), taskRun)) {
                 RunContext runContext = runContextFactory.of(executor.getFlow(), task, executor.getExecution(), taskRun);
                 nextTaskRuns.addAll(this.childNextsTaskRun(executor, taskRun, runContext));
                 this.childWorkerTaskResult(executor.getFlow(), executor.getExecution(), taskRun, runContext).ifPresent(list::add);


### PR DESCRIPTION
## Summary

Fixes the redundant executor work reported in #9008: a running flowable's `resolveNexts()`/`resolveState()` were being re-evaluated on every executor cycle, even on cycles where the resolver could only return empty (e.g. an `If` task's `resolveNexts()` was called 4 times per execution, 2 of them wasted). Each call also rebuilds a `RunContext`, which runs an `outputRepository.findByExecution()` query — so every wasted call is a wasted DB query too.

- Adds `ExecutorService.canChildrenProgress(execution, parentTaskRun)`: a flowable can only produce a new child, or terminate, when it has no child task run yet or at least one child has terminated — every `FlowableUtils.resolve*Nexts`/`resolveState` implementation already returns empty/absent otherwise, so this guard never hides real work.
- Skips the whole RUNNING-flowable block in `handleFlowableTasks` (RunContext included) when the guard says no child can progress.

**Known limitation:** once any child has terminated the guard stops helping, so a `Sequential` of 5 tasks still re-resolves on every cycle from task 2 onward. This removes the redundancy at the head of each flowable, not all of it.

Verified with `LOGGER_LEVELS_IO_KESTRA_EXECUTOR=DEBUG` tracing on `IfTest.ifTruthy`: 4 `resolveNexts` calls → 2, executor cycle count unchanged (9).

Companion PR with a larger, riskier change (also collapsing executor cycles, not just resolveNexts calls) for comparison: see the linked PR for `perf/flowable-collapse-executor-cycle`.

## Test plan

- [x] New regression test `IfTest.shouldResolveFlowableOnlyWhenItCanProgress` pins the flowable-resolution count via `METRIC_EXECUTOR_FLOWABLE_EXECUTION_COUNT` (asserts a delta of exactly 2 around one execution)
- [x] `io.kestra.plugin.core.flow.IfTest` — 8/8 passing
- [x] Full `io.kestra.plugin.core.flow.*` suite (Sequential, Parallel, Dag, Switch, Pause, Loop, WorkingDirectory, AllowFailure, Finally, ...) — 123/123 passing
- [x] `H2RunnerTest` (includes `multipleIf`, 3 `If`s inside a concurrent `Parallel`) — 99/99 passing
- [x] `H2RunnerRetryTest` (verifies the retry/errors-branch race fixed in #17538 is unaffected) — 21/21 passing

Refs #9008