### PR TITLE
refactor(executions): dispatch a newly-created root task run in the same executor cycle

### DIFF
--- a/core/src/test/java/io/kestra/plugin/core/flow/IfTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/flow/IfTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.Test;
 import io.kestra.core.junit.annotations.ExecuteFlow;
 import io.kestra.core.junit.annotations.KestraTest;
 import io.kestra.core.junit.annotations.LoadFlows;
+import io.kestra.core.metrics.MetricRegistry;
 import io.kestra.core.models.executions.Execution;
 import io.kestra.core.models.executions.TaskRunAttempt;
 import io.kestra.core.models.flows.State;
@@ -29,6 +30,9 @@ class IfTest {
 
     @Inject
     private ExecutionRepositoryInterface executionRepository;
+
+    @Inject
+    private MetricRegistry metricRegistry;
 
     @Test
     @LoadFlows(value = { "flows/valids/if-condition.yaml" }, tenantId = "iftruthy")
@@ -169,5 +173,33 @@ class IfTest {
         assertThat(execution.getState().getCurrent()).isEqualTo(State.Type.FAILED);
         assertThat(execution.getTaskRunList().getFirst().getState().getCurrent()).isEqualTo(State.Type.FAILED);
         assertThat(execution.getTaskRunList().getFirst().getAttempts().getFirst().getState().getCurrent()).isEqualTo(State.Type.FAILED);
+    }
+
+    // https://github.com/kestra-io/kestra/issues/9008: the Executor used to call resolveNexts() on a
+    // running If for every executor cycle, most of them resolving to nothing. Pin the number of
+    // resolutions so a regression shows up here rather than only in a profiler.
+    @Test
+    @LoadFlows(value = { "flows/valids/if-condition.yaml" }, tenantId = "ifflowablecount")
+    void shouldResolveFlowableOnlyWhenItCanProgress() throws TimeoutException, QueueException {
+        // Given
+        double before = flowableExecutionCount();
+
+        // When
+        Execution execution = runnerUtils.runOne(
+            "ifflowablecount", "io.kestra.tests", "if-condition", null,
+            (f, e) -> Map.of("param", true), Duration.ofSeconds(120)
+        );
+
+        // Then
+        assertThat(execution.getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
+        assertThat(flowableExecutionCount() - before).isEqualTo(2d);
+    }
+
+    private double flowableExecutionCount() {
+        return metricRegistry.counter(
+            MetricRegistry.METRIC_EXECUTOR_FLOWABLE_EXECUTION_COUNT,
+            MetricRegistry.METRIC_EXECUTOR_FLOWABLE_EXECUTION_COUNT_DESCRIPTION,
+            MetricRegistry.TAG_TASK_TYPE, If.class.getName()
+        ).count();
     }
 }

--- a/executor/src/main/java/io/kestra/executor/ExecutorContext.java
+++ b/executor/src/main/java/io/kestra/executor/ExecutorContext.java
@@ -28,13 +28,15 @@ public class ExecutorContext {
 
     private Execution execution;
     private Exception exception;
-    private final List<String> from = new ArrayList<>();
-    private boolean executionUpdated = false;
     private FlowWithSource flow;
+
+    private final List<String> from = new ArrayList<>(8);
+    private boolean executionUpdated = false;
+    private int nextCount = 0;
+
     // We usually only use one of the lists above, not many in each processing loop.
     // And as we always use addAll the capacity of the list will grow to what's needed when used,
     // so we initialize them with 0 to save memory.
-    private final List<TaskRun> nexts = new ArrayList<>(0);
     private final List<ExecutorWorkerTask> workerTasks = new ArrayList<>(0);
     private final List<ExecutionDelay> executionDelays = new ArrayList<>(0);
     private final List<SubflowExecution<?>> subflowExecutions = new ArrayList<>(0);
@@ -92,9 +94,21 @@ public class ExecutorContext {
         return this;
     }
 
+    /**
+     * Callers must only pass task runs not already present in the execution.
+     */
     public ExecutorContext withTaskRun(List<TaskRun> taskRuns, String from) {
-        this.nexts.addAll(taskRuns);
         this.from.add(from);
+
+        // Merge into the execution immediately, so a task run created earlier in this same process() pass is visible to later steps of the same pass
+        // (e.g. handleWorkerTasks dispatching a child created by handleFlowableTasks in the same cycle).
+        if (!taskRuns.isEmpty()) {
+            List<TaskRun> merged = this.execution.getTaskRunList() == null ? new ArrayList<>() : new ArrayList<>(this.execution.getTaskRunList());
+            merged.addAll(taskRuns);
+            this.execution = this.execution.withTaskRunList(merged);
+            this.executionUpdated = true;
+            this.nextCount = nextCount + taskRuns.size();
+        }
 
         return this;
     }

--- a/executor/src/main/java/io/kestra/executor/ExecutorService.java
+++ b/executor/src/main/java/io/kestra/executor/ExecutorService.java
@@ -357,6 +357,32 @@ public class ExecutorService {
             .map(throwFunction(type -> new WorkerTaskResult(taskRun.withState(type))));
     }
 
+    /**
+     * A flowable can only create a new child task run, via {@code resolveNexts}, or terminate, via
+     * {@code resolveState}, when it has no child task run yet or when at least one of its child
+     * task runs has terminated — every {@code FlowableUtils.resolveSequentialNexts}/{@code resolveParallelNexts}/
+     * {@code resolveWaitForNext}/{@code resolveState} implementation already returns empty/absent
+     * otherwise. Checking this upfront avoids building a {@link RunContext} (and its output query)
+     * on cycles that can only resolve to nothing.
+     */
+    private boolean canChildrenProgress(Execution execution, TaskRun parentTaskRun) {
+        if (execution.getTaskRunList() == null) {
+            return true;
+        }
+
+        boolean hasChild = false;
+        for (TaskRun taskRun : execution.getTaskRunList()) {
+            if (parentTaskRun.getId().equals(taskRun.getParentTaskRunId())) {
+                hasChild = true;
+                if (taskRun.getState().isTerminated()) {
+                    return true;
+                }
+            }
+        }
+
+        return !hasChild;
+    }
+
     private List<TaskRun> childNextsTaskRun(ExecutorContext executor, TaskRun parentTaskRun, RunContext runContext) throws InternalException {
         Task parent = executor.getFlow().findTaskByTaskId(parentTaskRun.getTaskId());
         if (parent instanceof FlowableTask<?> flowableParent) {
@@ -536,8 +562,9 @@ public class ExecutorService {
         for (TaskRun taskRun : executor.getExecution().getTaskRunList()) {
             Task task = executor.getFlow().findTaskByTaskIdOrNull(taskRun.getTaskId());
 
-            // For running flowable tasks: compute both next task runs and the worker task result in a single pass
-            if (taskRun.getState().isRunning() && task instanceof FlowableTask<?>) {
+            // For running flowable tasks: compute both next task runs and the worker task result in a single pass,
+            // but only when a child can actually progress — avoids rebuilding a RunContext (and its output query) on cycles that can only resolve empty.
+            if (taskRun.getState().isRunning() && task instanceof FlowableTask<?> && this.canChildrenProgress(executor.getExecution(), taskRun)) {
                 RunContext runContext = runContextFactory.of(executor.getFlow(), task, executor.getExecution(), taskRun);
                 nextTaskRuns.addAll(this.childNextsTaskRun(executor, taskRun, runContext));
                 this.childWorkerTaskResult(executor.getFlow(), executor.getExecution(), taskRun, runContext).ifPresent(list::add);

--- a/executor/src/main/java/io/kestra/executor/ExecutorService.java
+++ b/executor/src/main/java/io/kestra/executor/ExecutorService.java
@@ -213,45 +213,31 @@ public class ExecutorService {
         return executor;
     }
 
-    public Execution onNexts(Execution execution, List<TaskRun> nexts) {
+    public Execution onNext(Execution execution, int nextCount) {
         if (log.isTraceEnabled()) {
             Logs.logExecution(
                 execution,
                 Level.TRACE,
-                "Found {} next(s) {}",
-                nexts.size(),
-                nexts
+                "Found {} next(s) tasks to process",
+                nextCount
             );
         }
 
-        List<TaskRun> executionTasksRun;
-        Execution newExecution;
-
-        if (execution.getTaskRunList() == null) {
-            executionTasksRun = nexts;
-        } else {
-            executionTasksRun = new ArrayList<>(execution.getTaskRunList());
-            executionTasksRun.addAll(nexts);
+        if (execution.getState().getCurrent() != State.Type.CREATED) {
+            return execution;
         }
 
-        // update Execution
-        newExecution = execution.withTaskRunList(executionTasksRun);
+        metricRegistry
+            .counter(MetricRegistry.METRIC_EXECUTOR_EXECUTION_STARTED_COUNT, MetricRegistry.METRIC_EXECUTOR_EXECUTION_STARTED_COUNT_DESCRIPTION, metricRegistry.tags(execution))
+            .increment();
 
-        if (execution.getState().getCurrent() == State.Type.CREATED) {
-            metricRegistry
-                .counter(MetricRegistry.METRIC_EXECUTOR_EXECUTION_STARTED_COUNT, MetricRegistry.METRIC_EXECUTOR_EXECUTION_STARTED_COUNT_DESCRIPTION, metricRegistry.tags(execution))
-                .increment();
+        Logs.logExecution(
+            execution,
+            Level.INFO,
+            "Flow started"
+        );
 
-            Logs.logExecution(
-                execution,
-                Level.INFO,
-                "Flow started"
-            );
-
-            newExecution = newExecution.withState(State.Type.RUNNING);
-        }
-
-        return newExecution;
+        return execution.withState(State.Type.RUNNING);
     }
 
     public ExecutorContext handleFailedExecutionFromExecutor(ExecutorContext executor, Exception e) {
@@ -562,8 +548,7 @@ public class ExecutorService {
         for (TaskRun taskRun : executor.getExecution().getTaskRunList()) {
             Task task = executor.getFlow().findTaskByTaskIdOrNull(taskRun.getTaskId());
 
-            // For running flowable tasks: compute both next task runs and the worker task result in a single pass,
-            // but only when a child can actually progress — avoids rebuilding a RunContext (and its output query) on cycles that can only resolve empty.
+            // For running flowable tasks: compute both next task runs and the worker task result in a single pass.
             if (taskRun.getState().isRunning() && task instanceof FlowableTask<?> && this.canChildrenProgress(executor.getExecution(), taskRun)) {
                 RunContext runContext = runContextFactory.of(executor.getFlow(), task, executor.getExecution(), taskRun);
                 nextTaskRuns.addAll(this.childNextsTaskRun(executor, taskRun, runContext));

--- a/executor/src/main/java/io/kestra/executor/handler/ExecutionEventMessageHandler.java
+++ b/executor/src/main/java/io/kestra/executor/handler/ExecutionEventMessageHandler.java
@@ -249,10 +249,10 @@ public class ExecutionEventMessageHandler implements ExecutorMessageHandler<Exec
                         }
                         executor = executorService.process(executor);
 
-                        if (!executor.getNexts().isEmpty()) {
+                        if (executor.getNextCount() > 0) {
                             executor.withExecution(
-                                executorService.onNexts(executor.getExecution(), executor.getNexts()),
-                                "onNexts"
+                                executorService.onNext(executor.getExecution(), executor.getNextCount()),
+                                "onNext"
                             );
                         }
 


### PR DESCRIPTION
## Summary

### 1. Skip redundant flowable resolution

Fixes the redundant executor work reported in #9008: a running flowable's resolveNexts()/resolveState() was being re-evaluated on every executor cycle, even on cycles where the resolver could only return empty (e.g. an If task's resolveNexts() was called 4 times per execution, 2 of them wasted). Each call also rebuilds a `RunContext`, which runs an outputRepository.findByExecution() query — so every wasted call is a wasted DB query too.

Adds `ExecutorService.canChildrenProgress(execution, parentTaskRun)`: a flowable can only produce a new child, or terminate, when it has no child task run yet or at least one child has terminated — every FlowableUtils.resolve*Nexts/resolveState implementation already returns empty/absent otherwise, so this guard never hides real work.
Skips the whole RUNNING-flowable block in handleFlowableTasks (RunContext included) when the guard says no child can progress.
Known limitation: once any child has terminated the guard stops helping, so a Sequential of 5 tasks still re-resolves on every cycle from task 2 onward. This removes the redundancy at the head of each flowable, not all of it.

Verified with LOGGER_LEVELS_IO_KESTRA_EXECUTOR=DEBUG tracing on IfTest.ifTruthy: 4 resolveNexts calls → 2,

### 2. Dispatch a newly-created root task run in the same executor cycle

`ExecutorContext.withTaskRun` used to only append new task runs to a separate `nexts` list, merged into the execution by `onNexts()` only after `process()` returned. That meant `handleWorkerTasks` could never see a task run created earlier in the same pass, costing a full executor cycle (execution-store lock + queue round-trip) between e.g. `handleNext` creating the flow's first task and `handleWorkerTasks` dispatching it to RUNNING.

- `withTaskRun` now merges new task runs into the execution as soon as they're produced, and sets `executionUpdated` directly on that merge.
- `onNexts()`'s own merge logic is now dead code (its one caller always passes an execution already merged into) and has been stripped back down to its one remaining job: the CREATED → RUNNING transition.

**Why this PR doesn't also reorder `handleFlowableTasks` before `handleWorkerTasks`** (which would collapse the *second* redundant cycle too, per #9008): It breaks every `Loop`-based test. The `Loop` case inside `handleFlowableTasks` transitions its own CREATED task run straight to RUNNING as it spawns sub-executions. Running `handleWorkerTasks` after that would leave the Loop task run RUNNING with no attempts (`handleWorkerTasks` only attaches the first RUNNING attempt to task runs it finds still CREATED), which crashes `LoopExecutionEventMessageHandler.terminateLoop()` (`attempts.getLast()` on an empty list) the moment the first sub-execution finishes. It would need either splitting `handleFlowableTasks` into a reorderable "compute nexts" half and a position-sensitive "custom executor logic" half, or making `Loop`'s spawn logic not bypass `handleWorkerTasks`'s attempt-injection.

Verified with `LOGGER_LEVELS_IO_KESTRA_EXECUTOR=DEBUG` tracing on `IfTest.ifTruthy`: 9 executor cycles → 8 (the `handleNext`-creates / `handleWorkerTasks`-dispatches pair now collapses into one; the `handleFlowableTasks`-creates / `handleWorkerTasks`-dispatches pair does not, for the reason above).

## Test plan

- [x] Same regression test as #17832 (`IfTest.shouldResolveFlowableOnlyWhenItCanProgress`) — flowable-resolution count unchanged at 2
- [x] `io.kestra.plugin.core.flow.IfTest` — 8/8 passing
- [x] Full `io.kestra.plugin.core.flow.*` suite — 123/123 passing (including the 5 Loop-based classes that failed with the full reorder before it was reverted)
- [x] `H2RunnerTest` — 99/99 passing
- [x] `H2RunnerRetryTest` — 21/21 passing

Closes #9008