### PR TITLE
fix(core): stop the translation workflow opening PRs with no translation in them

### DIFF
--- a/.github/workflows/auto-translate-ui-keys.yml
+++ b/.github/workflows/auto-translate-ui-keys.yml
@@ -14,6 +14,13 @@ on:
         default: "false"
         required: false
 
+# Scheduled runs fire every three hours and each one opens its own timestamped branch. Without a
+# concurrency group two overlapping runs generate the same change and open two PRs for it, leaving
+# the loser with an empty diff once the winner merges — see kestra-io/kestra#17822.
+concurrency:
+  group: auto-translate-ui-keys-${{ github.ref_name }}
+  cancel-in-progress: false
+
 jobs:
   translations:
     name: Translations

--- a/ui/scripts/generate_translations.ts
+++ b/ui/scripts/generate_translations.ts
@@ -15,7 +15,7 @@
  * Requires the `@google/genai` package and Node 22+ (for native TypeScript type stripping and fs.globSync).
  */
 import {execFileSync} from "node:child_process"
-import {globSync, readFileSync, writeFileSync} from "node:fs"
+import {existsSync, globSync, readFileSync, writeFileSync} from "node:fs"
 import {dirname, resolve} from "node:path"
 import {fileURLToPath} from "node:url"
 import {GoogleGenAI} from "@google/genai"
@@ -27,6 +27,33 @@ process.chdir(resolve(dirname(fileURLToPath(import.meta.url)), "../.."))
 
 const MODEL = "gemini-2.5-flash"
 const client = new GoogleGenAI({apiKey: process.env.GEMINI_API_KEY})
+
+/**
+ * Writes `nextContent` only if it differs from what is on disk by more than trailing whitespace,
+ * and matches the file's existing final-newline style when it does.
+ *
+ * Without this the generator is not formatting-neutral: it serialises with `JSON.stringify`, which
+ * emits no final newline, while most editors add one when a developer touches a language file by
+ * hand. Every scheduled run then stripped those twelve newlines back off and opened a PR whose
+ * entire diff was `\ No newline at end of file` — see #17823.
+ *
+ * @returns whether the file was written
+ */
+function writeIfChanged(filePath: string, nextContent: string): boolean {
+    if (!existsSync(filePath)) {
+        writeFileSync(filePath, nextContent)
+        return true
+    }
+
+    const currentContent = readFileSync(filePath, "utf-8")
+    if (currentContent.trimEnd() === nextContent.trimEnd()) return false
+
+    // Preserve whatever final-newline convention the file already uses, so a real content change
+    // doesn't smuggle in an unrelated whitespace flip alongside it.
+    const endsWithNewline = currentContent.endsWith("\n")
+    writeFileSync(filePath, endsWithNewline ? `${nextContent.trimEnd()}\n` : nextContent.trimEnd())
+    return true
+}
 
 type NestedValue = string | NestedValue[] | NestedDict;
 type NestedDict = {[key: string]: NestedValue};
@@ -251,7 +278,7 @@ async function main(
     const updatedTargetDict = unflattenDict(orderedTargetFlat)
 
     const output = {[languageCode]: updatedTargetDict}
-    writeFileSync(`ui/src/translations/${languageCode}.json`, JSON.stringify(output, null, 2))
+    writeIfChanged(`ui/src/translations/${languageCode}.json`, JSON.stringify(output, null, 2))
 }
 
 // ---------------------------------------------------------------------------
@@ -405,7 +432,7 @@ async function translateLocaleFile(filePath: string, retranslateModifiedKeys: bo
         result[code] = unflattenDict(prunedTargetFlat)
     }
 
-    writeFileSync(filePath, serializeLocaleModule(result))
+    writeIfChanged(filePath, serializeLocaleModule(result))
 }
 
 const LANGUAGES: ReadonlyArray<readonly [string, string]> = [


### PR DESCRIPTION
## What

Two recent scheduled runs produced PRs that contained no translation work at all:

- **#17823** — merged. Its entire diff, across all twelve language files, was `\ No newline at end of file`.
- **#17822** — closed. Zero files changed.

Two different faults, one per symptom.

## The whitespace PRs were a loop the generator was driving

`generate_translations.ts` serialises with `JSON.stringify(output, null, 2)`, which emits **no** final newline. An editor saving a language file by hand generally adds one. `.editorconfig` does set `insert_final_newline=false`, but that only binds editors that read it, so in practice both states occur.

So a feature PR would land a language file with a trailing newline, the next scheduled run would strip it back off, and that one byte was enough to get past the workflow's `git diff --cached --quiet` guard and open a PR. Tracing `de.json` through its last eighteen commits shows it flipping the whole way — feature PRs adding the newline, `chore(core): localize to languages other than english` runs removing it:

```
11032bffd7  no newline    chore(core): localize to languages other than english (#17823)
e57143d41a  HAS newline   feat(executions): render HTML file outputs in a sandboxed …
2d9456b5a3  no newline    feat(onboarding): spotlight the part of the page each tour …
…
f9a61f36d5  HAS newline   fix(flows): surface flow editor setup failures instead of …
870a5a51ee  HAS newline   feat(execution): update execution progress component and …
0b58b196e0  no newline    feat: AI Copilot v2 agentic loop (#17388)
```

That is also why so many of these PRs carry a suspiciously round `-12`: `+216/-12`, `+96/-12`, `+2208/-60`. Twelve files, one stripped newline each, riding along with the real work.

Writes now go through `writeIfChanged`, which skips the write entirely when the new content differs from what is on disk only in trailing whitespace, and otherwise preserves whatever final-newline style the file already had. The generator stops arbitrating a convention it was never the right place to enforce, and a run with nothing to translate leaves the working tree untouched.

## The empty PR was a race

The schedule fires every three hours, each run cuts a branch off `date +%s`, and nothing prevented two runs overlapping. Both generate the same change and both open a PR for it; whichever loses is left with an empty diff once the winner merges. The workflow now takes a concurrency group, with `cancel-in-progress: false` so a queued run waits rather than being killed midway through a push.

## Verification

Both paths were exercised against the real generator rather than a mock.

**No content change, formatting drift present** — a final newline was appended to `de/es/fr.json` to imitate an editor save, then the generator was run:

```
before:  de.json endsWithNL=no   (and es, fr)
after:   de.json endsWithNL=yes  (and es, fr)  ← drift preserved, not reverted
git status -- ui/packages/  ← clean, no incidental *.locale.ts churn either
```

Previously this run would have stripped all three newlines back off, which is precisely the #17823 diff.

**Real content change** — `pluginPage.search` was blanked in `de.json` on a file carrying a trailing newline:

```
Translating pluginPage|search: … -> 'Suchen in über 1400 Plugins'
value      = "Suchen in über 1400 Plugins"   ← translated
endsWithNL = yes                             ← style preserved, no whitespace flip smuggled in
```

The EE side was verified the same way, drifting in the opposite direction (newline removed), and likewise left it alone.

There is no existing test convention for `ui/scripts/`, and the generator imports `@google/genai` at module load, so adding one would mean standing up mocking infrastructure for a build script. The end-to-end runs above seemed the better evidence; happy to add a harness if reviewers would rather have one.

## Side effect worth knowing

`writeIfChanged` covers both write paths, including the design-system `*.locale.ts` files. Those were being reserialised on every run and, because the workflow only stages `ui/src/translations/*.json`, silently discarded. That churn stops too — which also removes the "revert any incidental `*.locale.ts` changes afterward" step that local runs currently need.

Separately, and **not** changed here: the workflow still stages only `ui/src/translations/*.json`, so `*.locale.ts` translations generated by the nightly are never committed. That looks like a real gap, but committing them is a behaviour change I did not want to slip into a fix PR. Happy to open a follow-up.

## Companion PR

kestra-io/kestra-ee#9659 applies the same two fixes to EE's own copy of the generator and workflow. They are independent and can merge in either order.


Closes https://github.com/kestra-io/kestra/issues/17835.
