### PR TITLE
fix(core): align metric aggregation buckets to calendar boundaries

### DIFF
--- a/core/src/test/java/io/kestra/core/repositories/AbstractMetricRepositoryTest.java
+++ b/core/src/test/java/io/kestra/core/repositories/AbstractMetricRepositoryTest.java
@@ -94,6 +94,29 @@ public abstract class AbstractMetricRepositoryTest {
         assertThat(aggregationResults.getAggregations().size()).isBetween(26, 27);
         assertThat(aggregationResults.getGroupBy()).isEqualTo("week");
 
+        // A window over 365 days groups by month; the bucket containing endDate must still be
+        // emitted, otherwise the most recent data point is silently zero-filled away (regression
+        // for JDBC backends walking un-floored buckets from startDate). endDate is captured fresh
+        // here (not the `now` above, which predates the save) so it is guaranteed to be at or
+        // after the counter's own timestamp.
+        ZonedDateTime monthlyEnd = ZonedDateTime.now();
+        aggregationResults = metricRepository.aggregateByFlowId(
+            tenant,
+            "namespace",
+            "flow",
+            null,
+            counter.getName(),
+            monthlyEnd.minusDays(400),
+            monthlyEnd,
+            "sum"
+        );
+
+        // The `timer` entry above reuses the metric name "counter" too, reporting its duration in
+        // milliseconds, so the expected sum is the counter's value plus the timer's millisecond value.
+        double expectedMonthlySum = 1.0 + timer.getValue();
+        assertThat(aggregationResults.getGroupBy()).isEqualTo("month");
+        assertThat(aggregationResults.getAggregations().stream().mapToDouble(bucket -> bucket.value).sum()).isEqualTo(expectedMonthlySum);
+
         // avg/min/max must aggregate over a window with mostly empty buckets without failing
         // (regression for the Elasticsearch backend returning a null value for empty buckets).
         for (String aggregation : List.of("avg", "min", "max")) {

--- a/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcMetricRepository.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcMetricRepository.java
@@ -1,10 +1,12 @@
 package io.kestra.jdbc.repository;
 
+import java.time.DayOfWeek;
 import java.time.Duration;
+import java.time.Instant;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
-import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoUnit;
+import java.time.temporal.TemporalAdjusters;
 import java.util.*;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -269,43 +271,49 @@ public abstract class AbstractJdbcMetricRepository extends AbstractJdbcCrudRepos
     private List<MetricAggregation> fillDate(List<MetricAggregation> result, ZonedDateTime startDate, ZonedDateTime endDate) {
         DateUtils.GroupType groupByType = DateUtils.groupByType(Duration.between(startDate, endDate));
 
-        if (groupByType.equals(DateUtils.GroupType.MONTH)) {
-            return fillDate(result, startDate, endDate, ChronoUnit.MONTHS, "YYYY-MM");
-        } else if (groupByType.equals(DateUtils.GroupType.WEEK)) {
-            return fillDate(result, startDate, endDate, ChronoUnit.WEEKS, "YYYY-ww");
-        } else if (groupByType.equals(DateUtils.GroupType.DAY)) {
-            return fillDate(result, startDate, endDate, ChronoUnit.DAYS, "YYYY-MM-DD");
-        } else if (groupByType.equals(DateUtils.GroupType.HOUR)) {
-            return fillDate(result, startDate, endDate, ChronoUnit.HOURS, "YYYY-MM-DD HH");
-        } else {
-            return fillDate(result, startDate, endDate, ChronoUnit.MINUTES, "YYYY-MM-DD HH:mm");
-        }
+        return switch (groupByType) {
+            case MONTH -> fillDate(result, startDate, endDate, ChronoUnit.MONTHS);
+            case WEEK -> fillDate(result, startDate, endDate, ChronoUnit.WEEKS);
+            case DAY -> fillDate(result, startDate, endDate, ChronoUnit.DAYS);
+            case HOUR -> fillDate(result, startDate, endDate, ChronoUnit.HOURS);
+            case MINUTE -> fillDate(result, startDate, endDate, ChronoUnit.MINUTES);
+        };
     }
 
     private List<MetricAggregation> fillDate(
         List<MetricAggregation> result,
         ZonedDateTime startDate,
         ZonedDateTime endDate,
-        ChronoUnit unit,
-        String format) {
+        ChronoUnit unit) {
         List<MetricAggregation> filledResult = new ArrayList<>();
-        ZonedDateTime currentDate = startDate;
-        // UTC, to match the bucket keys returned by AbstractJdbcRepository#getDate. Anchoring this to
-        // the JVM default zone instead would make real data points miss the slot they belong to on a
-        // non-UTC host, leaving a zero-filled bucket next to a duplicated real one.
-        DateTimeFormatter formatter = DateTimeFormatter.ofPattern(format).withZone(ZoneOffset.UTC);
+        // Floored to the bucket boundary so the generated buckets line up with the calendar-floored
+        // instants AbstractJdbcRepository#getDate reassembles from the SQL year/month/week/day parts;
+        // otherwise the last bucket walked from an unfloored startDate can fall short of endDate and
+        // silently drop the most recent data point.
+        ZonedDateTime currentDate = truncateToBucket(startDate, unit);
         while (currentDate.isBefore(endDate)) {
-            String finalCurrentDate = currentDate.format(formatter);
+            Instant bucketInstant = currentDate.toInstant();
             MetricAggregation metricStat = result.stream()
-                .filter(metric -> formatter.format(metric.date).equals(finalCurrentDate))
+                .filter(metric -> metric.date.equals(bucketInstant))
                 .findFirst()
-                .orElse(MetricAggregation.builder().date(currentDate.toInstant()).value(0.0).build());
+                .orElse(MetricAggregation.builder().date(bucketInstant).value(0.0).build());
 
             filledResult.add(metricStat);
             currentDate = currentDate.plus(1, unit);
         }
 
         return filledResult;
+    }
+
+    private static ZonedDateTime truncateToBucket(ZonedDateTime date, ChronoUnit unit) {
+        ZonedDateTime utc = date.withZoneSameInstant(ZoneOffset.UTC);
+        // MONTHS/WEEKS aren't supported by truncatedTo, and must match AbstractJdbcRepository#getDate's
+        // calendar-floored buckets (first-of-month, Monday-of-week).
+        return switch (unit) {
+            case MONTHS -> utc.withDayOfMonth(1).truncatedTo(ChronoUnit.DAYS);
+            case WEEKS -> utc.with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY)).truncatedTo(ChronoUnit.DAYS);
+            default -> utc.truncatedTo(unit);
+        };
     }
 
     @Override


### PR DESCRIPTION
## Summary

- `aggregateByFlowId`'s `fillDate` walked bucket boundaries forward from the raw `startDate` instead of flooring to the calendar boundary first. For month-grouped windows (>365 days) this made the last emitted bucket fall short of `endDate` on most days of the month, silently zero-filling away the most recent data point.
- This was surfaced by 3 failing tests on kestra-ee PR [#9658](https://github.com/kestra-io/kestra-ee/pull/9658) (`H2/Mysql/PostgresMetricRepositoryAclTest#shouldScopeAggregateByFlowIdToAllowedNamespace`) — the failures are date-dependent and are also present on kestra-ee's `develop`, unrelated to that PR's actual change.
- Fix: floor the bucket iteration to the same calendar boundary `AbstractJdbcRepository#getDate` reconstructs on the DB side (first-of-month, Monday-of-week, truncated day/hour/minute), and compare buckets by `Instant` instead of a `DateTimeFormatter`-based string key (which also misused `YYYY`/`DD` and was locale-dependent).
- Added a regression test in `AbstractMetricRepositoryTest` for a >365-day window asserting the summed aggregation value, not just bucket count.

## Test plan

- [x] `./gradlew :jdbc-h2:test :jdbc-postgres:test :jdbc-mysql:test --tests "*MetricRepositoryTest"` — all pass
- [x] kestra-ee `H2MetricRepositoryAclTest` (composite-built against this branch) — 6/6 pass, including the previously-failing `shouldScopeAggregateByFlowIdToAllowedNamespace`