### PR TITLE
fix(flows): guard getNamespace against a missing router context

### DIFF
--- a/ui/src/stores/flow.ts
+++ b/ui/src/stores/flow.ts
@@ -173,7 +173,7 @@ export const useFlowStore = defineStore("flow", () => {
     const route = useRoute()
 
     const getNamespace = () => {
-        return route.query.namespace || defaultNamespace()
+        return route?.query?.namespace || defaultNamespace()
     }
 
     async function save(draft: boolean = false): Promise<FlowSaveOutcome> {


### PR DESCRIPTION
This pull request makes a minor update to the `useFlowStore` store. The change improves the robustness of the `getNamespace` function by adding optional chaining to safely access the `namespace` query parameter from the route object.

* Improved safety when accessing `namespace` from `route.query` in `getNamespace` by using optional chaining.