### PR TITLE
fix(tests): remove external network dependency from core sanity checks

### DIFF
--- a/core/src/test/resources/sanity-checks/namespace_files.yaml
+++ b/core/src/test/resources/sanity-checks/namespace_files.yaml
@@ -2,14 +2,18 @@ id: namespace_files
 namespace: sanitychecks.core
 
 tasks:
-  - id: download
-    type: io.kestra.plugin.core.http.Download
-    uri: https://raw.githubusercontent.com/kestra-io/scripts/refs/heads/main/automation/list_kestra_repos.py
+  # Kept local on purpose: the check only needs some file to round-trip through namespace files,
+  # and the external URI used before made CI fail whenever the host rate-limited the runner.
+  - id: write_file
+    type: io.kestra.plugin.core.storage.Write
+    content: |
+      print("sanity-check")
+    extension: .py
 
   - id: upload_files
     type: io.kestra.plugin.core.namespace.UploadFiles
-    filesMap: 
-      main.py: "{{ outputs.download.uri }}"
+    filesMap:
+      main.py: "{{ outputs.write_file.uri }}"
     namespace: "{{ flow.namespace }}"
 
   - id: download_files
@@ -21,7 +25,7 @@ tasks:
   - id: assert_upload_download
     type: io.kestra.plugin.core.execution.Assert
     conditions:
-      - "{{ read(outputs.download.uri) == read(outputs.download_files.files['/main.py']) }}"
+      - "{{ read(outputs.write_file.uri) == read(outputs.download_files.files['/main.py']) }}"
 
   - id: delete_files
     type: io.kestra.plugin.core.namespace.DeleteFiles

--- a/core/src/test/resources/sanity-checks/purge_current_execution_files.yaml
+++ b/core/src/test/resources/sanity-checks/purge_current_execution_files.yaml
@@ -2,9 +2,14 @@ id: purge_current_execution_files
 namespace: sanitychecks.core
 
 tasks:
-  - id: download
-    type: io.kestra.plugin.core.http.Download
-    uri: https://huggingface.co/datasets/kestra/datasets/raw/main/csv/orders.csv
+  # Kept local on purpose: the purge only needs some file in the execution's internal storage,
+  # and the external URI used before made CI fail whenever the host rate-limited the runner.
+  - id: write_file
+    type: io.kestra.plugin.core.storage.Write
+    content: |
+      id,name
+      1,sanity-check
+    extension: .csv
 
   - id: purge
     type: io.kestra.plugin.core.storage.PurgeCurrentExecutionFiles


### PR DESCRIPTION
## Summary

`SanityCheckTest.qaPurgeExecutionFiles` failed in CI on [#17842](https://github.com/kestra-io/kestra/pull/17842) as:

```
java.lang.AssertionError: Expected size: 2 but was: 1
  taskId=download  state=FAILED
```

**That PR was not at fault** — it touches only JUnit fixture plumbing. The assertion failure was downstream noise: the flow's first task died on a third-party rate limit, so only 1 of the 2 task runs ever existed.

```
io.kestra.core.http.client.HttpClientResponseException:
  Failed http request with response code '429' and body:
  <h1>429</h1>
  <p>We had to rate limit you. Upgrade to a paid plan (https://hf.co/pricing) ...</p>
    at io.kestra.plugin.core.http.Download.run(Download.java:90)
```

`sanity-checks/purge_current_execution_files.yaml` pulled `orders.csv` from `huggingface.co`, and Hugging Face throttled the shared GitHub Actions egress IP. Nothing in Kestra misbehaved — the HTTP client, executor and purge task all did the right thing with a real 429. The check is simply not deterministic, and it fails for reasons that have nothing to do with the PR under test.

## Changes

The download here is **incidental**: the check exists to validate `PurgeCurrentExecutionFiles`, and only needs *some* file in the execution's internal storage to purge. Reaching over the public internet to obtain one is a pure flake source.

- **`purge_current_execution_files.yaml`** — `io.kestra.plugin.core.http.Download` → `io.kestra.plugin.core.storage.Write`.
- **`namespace_files.yaml`** — same accidental dependency (on `raw.githubusercontent.com`, to obtain a file to round-trip through namespace files), same treatment. Task renamed `download` → `write_file` with its two output references updated.

`storage.Write` is the **network-free pattern already established in this very directory** — `sanity-checks/write.yaml` and `sanity-checks/purge_storage.yaml` both use it.

## Test plan

- [x] `./gradlew :core:test --tests "io.kestra.core.tasks.test.SanityCheckTest"` → **16/16 passing**
- [x] `qaPurgeExecutionFiles` drops from 1.5s to 0.088s — the network round-trip disappearing
- [x] No `io.kestra.plugin.core.http` task and no `http(s)://` URL remains in either flow, so no outbound call is structurally possible — stronger than an egress-blocked run
- [x] No stale `outputs.download` references repo-wide; `all_core.yaml` and `SanityCheckTest` reference only flow ids, not task ids