### PR TITLE
fix(core): stop rendering an empty content section under a decorative tab bar

### DIFF
--- a/ui/src/components/Tabs.vue
+++ b/ui/src/components/Tabs.vue
@@ -52,9 +52,11 @@
         </router-view>
 
         <!-- Embedded mode, blueprint modal, and pages not yet migrated to child routes:
-             keep the dynamic component path (no URL segment to drive a router-view). -->
+             keep the dynamic component path (no URL segment to drive a router-view).
+             Skipped entirely when the tab has no body: a decorative tab bar (e.g. detail
+             pages passing embedActiveTab) must not emit an empty flex-growing section. -->
         <section
-            v-else-if="activeTab"
+            v-else-if="activeTab && hasTabBody"
             v-bind="attrsWithoutClass"
             :class="[containerClass, {maximized: (activeTab as Tab).maximized, 'no-overflow': (activeTab as Tab).noOverflow}]"
         >
@@ -145,6 +147,13 @@
     const useRouterView = computed(() =>
         !props.vertical && !isEmbedded.value && !selectedBlueprintId.value && isRouterDriven.value,
     )
+
+    /** Whether TabBody would render anything — mirrors the null cases in TabBody's render. */
+    const hasTabBody = computed(() => {
+        if (selectedBlueprintId.value) return true
+        const tab = activeTab.value as Tab | undefined
+        return tab !== undefined && (isEditorActiveTab(tab) || Boolean(tab.component))
+    })
 
     const isEditorActiveTab = (tab: Tab): boolean => {
         const TAB = tab.name

--- a/ui/tests/unit/components/Tabs.spec.ts
+++ b/ui/tests/unit/components/Tabs.spec.ts
@@ -15,7 +15,7 @@ const router = createRouter({
     routes: [{path: "/", name: "home", component: {template: "<div />"}}],
 })
 
-const mountTabs = (props: Record<string, unknown>) =>
+const mountTabs = (props: InstanceType<typeof Tabs>["$props"]) =>
     mount(Tabs, {
         props,
         global: {

--- a/ui/tests/unit/components/Tabs.spec.ts
+++ b/ui/tests/unit/components/Tabs.spec.ts
@@ -1,0 +1,60 @@
+import {describe, expect, test, vi} from "vitest"
+import {mount} from "@vue/test-utils"
+import {createPinia} from "pinia"
+import {createRouter, createWebHistory} from "vue-router"
+import Tabs from "../../../src/components/Tabs.vue"
+
+// Statically imported by Tabs.vue but only rendered for the blueprint modal; stub it
+// out so the spec doesn't pull the whole blueprints dependency graph.
+vi.mock("override/components/flows/blueprints/BlueprintDetail.vue", () => ({
+    default: {name: "BlueprintDetail", template: "<div />"},
+}))
+
+const router = createRouter({
+    history: createWebHistory(),
+    routes: [{path: "/", name: "home", component: {template: "<div />"}}],
+})
+
+const mountTabs = (props: Record<string, unknown>) =>
+    mount(Tabs, {
+        props,
+        global: {
+            plugins: [router, createPinia()],
+            // The app registers the design system globally at bootstrap; this spec is
+            // about whether the content <section> renders, so the bar can be stubbed.
+            stubs: {
+                KsTabs: {template: "<div class=\"ks-tabs-bar\"><slot /></div>"},
+                KsTabPane: true,
+                EnterpriseBadge: true,
+            },
+        },
+    })
+
+describe("Tabs", () => {
+    test("renders no content section when the embedded active tab has no component — regression for kestra-ee#9695", async () => {
+        await router.push("/")
+        await router.isReady()
+
+        // Decorative tab bar, as used by EE detail pages (Group.vue / Role.vue via
+        // IAMTabs): tabs mirror routed pages, so they carry no `component`. An empty
+        // full-container section would flex-grow and push the page content down.
+        const wrapper = mountTabs({
+            tabs: [{name: "groups", title: "Groups", fullContainer: true}],
+            embedActiveTab: "groups",
+        })
+
+        expect(wrapper.find("section").exists()).toBe(false)
+    })
+
+    test("renders the content section when the embedded active tab has a component", async () => {
+        await router.push("/")
+        await router.isReady()
+
+        const wrapper = mountTabs({
+            tabs: [{name: "details", title: "Details", component: {template: "<p data-test=\"tab-body\">body</p>"}}],
+            embedActiveTab: "details",
+        })
+
+        expect(wrapper.get("section [data-test=\"tab-body\"]").text()).toBe("body")
+    })
+})


### PR DESCRIPTION
## What

When `Tabs` is used purely as a decorative tab bar (`embedActiveTab` set with tabs that carry no `component` — e.g. the EE IAM detail pages `Group.vue` / `Role.vue` via `IAMTabs`), the embedded/legacy branch still rendered its content `<section>` even though `TabBody` resolves to `null`. Since the IAM tabs are marked `fullContainer`, that empty section gets `flex: 1` from `main > section.full-container` and swallows the entire viewport, pushing the real page content to the bottom of the screen.

This PR skips rendering the section entirely when the active tab has no body to render (no component, not the editor tab, no blueprint detail), and adds a unit regression test that fails without the fix.

## Why

Fixes the EE issue where the IAM group detail page (and role detail page) opened looking blank, with the Details/Roles/Members panels pushed to the bottom of the window: https://github.com/kestra-io/kestra-ee/issues/9695

Companion EE PR: https://github.com/kestra-io/kestra-ee/pull/9702 (merge this OSS PR first).