### PR TITLE
fix(ui): let the Concurrency Limits page target the administered tenant

### DIFF
--- a/ui/src/components/admin/ConcurrencyLimits.vue
+++ b/ui/src/components/admin/ConcurrencyLimits.vue
@@ -47,17 +47,21 @@
 </template>
 
 <script lang="ts" setup>
-    import {computed, onMounted, ref} from "vue"
+    import {computed, ref, watch} from "vue"
+    import {useRoute} from "vue-router"
     import {useI18n} from "vue-i18n"
     import TopNavBar from "../layout/TopNavBar.vue"
     import Empty from "../layout/empty/Empty.vue"
     import useRouteContext from "../../composables/useRouteContext"
     import {useClient} from "@kestra-io/kestra-sdk"
     import IconEdit from "vue-material-design-icons/Pencil.vue"
-    import {apiUrl, apiUrlWithoutTenants} from "override/utils/route"
+    import {apiUrlWithTenant, apiUrlWithoutTenants} from "override/utils/route"
     import {useDiscardGuard} from "../../composables/useDiscardGuard"
 
     const {t} = useI18n()
+    const route = useRoute()
+
+    const baseUrl = computed(() => apiUrlWithTenant(route))
 
     const routeInfo = computed(() => {
         return {
@@ -81,7 +85,7 @@
     }>()
 
     async function loadData(){
-        const response = await axios.get(`${apiUrl()}/concurrency-limit/search`)
+        const response = await axios.get(`${baseUrl.value}/concurrency-limit/search`)
         if(response?.status !== 200){
             throw new Error(`Failed to load concurrency limits: status ${response?.status}`)
         }
@@ -111,9 +115,7 @@
         editRunning.value = false
     }
 
-    onMounted(() => {
-        loadData()
-    })
+    watch(baseUrl, () => loadData(), {immediate: true})
 
     useRouteContext(routeInfo)
 </script>


### PR DESCRIPTION
Part of https://github.com/kestra-io/kestra-ee/issues/9682

This pull request updates the `ConcurrencyLimits.vue` component to improve how it handles API URLs and data loading, making it more responsive to route changes and tenant context. The main improvements are in how the base API URL is constructed and when data is loaded.

**API URL handling and data loading improvements:**

* Replaced the old `apiUrl` function with `apiUrlWithTenant`, ensuring that API requests are properly scoped to the current tenant context. The base URL is now a computed property that reacts to route changes.
* Updated the data loading logic to use the new `baseUrl` computed property, so API calls are made to the correct tenant-specific endpoint.
* Replaced the `onMounted` hook with a `watch` on `baseUrl`, triggering data reloads whenever the route (and thus the tenant context) changes. This ensures the component always displays up-to-date data for the current tenant.