### PR TITLE
fix(worker): register every controller gRPC service when the controller is embedded

### DIFF
--- a/worker-controller/src/main/java/io/kestra/controller/DefaultController.java
+++ b/worker-controller/src/main/java/io/kestra/controller/DefaultController.java
@@ -2,6 +2,7 @@ package io.kestra.controller;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
@@ -28,6 +29,7 @@ import io.grpc.InsecureServerCredentials;
 import io.grpc.Server;
 import io.grpc.ServerBuilder;
 import io.grpc.ServerCredentials;
+import io.grpc.ServerServiceDefinition;
 import io.grpc.health.v1.HealthCheckResponse.ServingStatus;
 import io.grpc.protobuf.services.HealthStatusManager;
 import io.grpc.protobuf.services.ProtoReflectionServiceV1;
@@ -166,9 +168,15 @@ public class DefaultController extends AbstractService implements Controller {
 
         serverBuilder.maxInboundMessageSize(grpcConfiguration.maxInboundMessageSize());
 
+        List<String> serviceNames = new ArrayList<>(workerControllerServices.size());
         for (WorkerControllerService service : workerControllerServices) {
-            serverBuilder = serverBuilder.addService(service);
+            ServerServiceDefinition definition = service.bindService();
+            serviceNames.add(definition.getServiceDescriptor().getName());
+            serverBuilder = serverBuilder.addService(definition);
         }
+        // Logged because a service missing from the context is otherwise only visible to workers as an UNIMPLEMENTED error at task runtime.
+        LOG.debug("Controller registered {} gRPC services: {}", serviceNames.size(), serviceNames.stream().sorted().toList());
+
         return serverBuilder;
     }
 

--- a/worker-controller/src/main/java/io/kestra/controller/RequiresControllerServer.java
+++ b/worker-controller/src/main/java/io/kestra/controller/RequiresControllerServer.java
@@ -1,0 +1,31 @@
+package io.kestra.controller;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import io.micronaut.context.annotation.Requires;
+
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * Restricts a bean to the server types that can host a {@link io.kestra.core.worker.Controller}.
+ * Convenient annotation for
+ * {@code @Requires(property = "kestra.server-type", pattern = "(CONTROLLER|STANDALONE|WEBSERVER)")}.
+ * <p>
+ * A {@code WEBSERVER} and a {@code STANDALONE} server both start an embedded controller unless
+ * {@code --no-controller} is passed, so any bean the controller needs must also be available there.
+ * Such beans stay uninstantiated when the embedded controller is disabled because nothing requests
+ * the {@code Controller} bean in that case.
+ * <p>
+ * Every gRPC {@link io.kestra.controller.grpc.WorkerControllerService} must carry this annotation
+ * rather than a narrower requirement: a service missing from the context is silently absent from the
+ * gRPC server, and workers only discover it as an {@code UNIMPLEMENTED} error at task runtime.
+ */
+@Documented
+@Requires(property = "kestra.server-type", pattern = "(CONTROLLER|STANDALONE|WEBSERVER)")
+@Retention(RUNTIME)
+@Target({ ElementType.METHOD, ElementType.ANNOTATION_TYPE, ElementType.TYPE, ElementType.FIELD })
+public @interface RequiresControllerServer {
+}

--- a/worker-controller/src/main/java/io/kestra/controller/discovery/ControllerStorageRegistrar.java
+++ b/worker-controller/src/main/java/io/kestra/controller/discovery/ControllerStorageRegistrar.java
@@ -10,6 +10,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import io.kestra.controller.RequiresControllerServer;
 import io.kestra.controller.config.ControllerAdvertiseConfiguration;
 import io.kestra.controller.config.ControllerConfiguration;
 import io.kestra.core.serializers.JacksonMapper;
@@ -44,7 +45,7 @@ import lombok.extern.slf4j.Slf4j;
  */
 @Singleton
 @Slf4j
-@Requires(property = "kestra.server-type", pattern = "(CONTROLLER|STANDALONE)")
+@RequiresControllerServer
 @Requires(property = "kestra.controller.advertise.enabled", value = "true", defaultValue = "false")
 public class ControllerStorageRegistrar implements ServiceLivenessListener, Closeable {
 

--- a/worker-controller/src/main/java/io/kestra/controller/grpc/services/GrpcExecutionLogController.java
+++ b/worker-controller/src/main/java/io/kestra/controller/grpc/services/GrpcExecutionLogController.java
@@ -2,6 +2,7 @@ package io.kestra.controller.grpc.services;
 
 import java.util.List;
 
+import io.kestra.controller.RequiresControllerServer;
 import io.kestra.controller.grpc.*;
 import io.kestra.controller.messages.BatchMessage;
 import io.kestra.controller.messages.MessageFormats;
@@ -11,7 +12,6 @@ import io.kestra.core.runners.ExecutionLogMetaStore;
 import io.kestra.core.worker.models.WorkerInfo;
 
 import io.grpc.stub.StreamObserver;
-import io.micronaut.context.annotation.Requires;
 import jakarta.inject.Singleton;
 import lombok.extern.slf4j.Slf4j;
 
@@ -21,7 +21,7 @@ import lombok.extern.slf4j.Slf4j;
  */
 @Slf4j
 @Singleton
-@Requires(property = "kestra.server-type", pattern = "(CONTROLLER|STANDALONE)")
+@RequiresControllerServer
 public class GrpcExecutionLogController extends ExecutionLogsServiceGrpc.ExecutionLogsServiceImplBase implements WorkerControllerService {
     private final ExecutionLogMetaStore executionLogMetaStore;
     private final WorkerInfo workerInfo;

--- a/worker-controller/src/main/java/io/kestra/controller/grpc/services/GrpcFlowMetaStoreWorkerControllerService.java
+++ b/worker-controller/src/main/java/io/kestra/controller/grpc/services/GrpcFlowMetaStoreWorkerControllerService.java
@@ -3,6 +3,7 @@ package io.kestra.controller.grpc.services;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import io.kestra.controller.RequiresControllerServer;
 import io.kestra.controller.grpc.BooleanResponse;
 import io.kestra.controller.grpc.NamespaceRequest;
 import io.kestra.controller.grpc.WorkerControllerService;
@@ -10,7 +11,6 @@ import io.kestra.controller.grpc.WorkerFlowMetaStoreServiceGrpc;
 import io.kestra.core.runners.FlowMetaStoreInterface;
 
 import io.grpc.stub.StreamObserver;
-import io.micronaut.context.annotation.Requires;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 
@@ -19,7 +19,7 @@ import jakarta.inject.Singleton;
  * Provides namespace, tenant, and flow metadata to workers via gRPC.
  */
 @Singleton
-@Requires(property = "kestra.server-type", pattern = "(CONTROLLER|STANDALONE)")
+@RequiresControllerServer
 public class GrpcFlowMetaStoreWorkerControllerService extends WorkerFlowMetaStoreServiceGrpc.WorkerFlowMetaStoreServiceImplBase implements WorkerControllerService {
 
     private static final Logger LOG = LoggerFactory.getLogger(GrpcFlowMetaStoreWorkerControllerService.class);

--- a/worker-controller/src/main/java/io/kestra/controller/grpc/services/GrpcKVMetadataControllerService.java
+++ b/worker-controller/src/main/java/io/kestra/controller/grpc/services/GrpcKVMetadataControllerService.java
@@ -6,6 +6,7 @@ import java.util.Optional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import io.kestra.controller.RequiresControllerServer;
 import io.kestra.controller.grpc.BooleanResponse;
 import io.kestra.controller.grpc.KVMetadataRequest;
 import io.kestra.controller.grpc.KVMetadataServiceGrpc;
@@ -20,7 +21,6 @@ import io.kestra.core.runners.KVMetadataStateStore;
 import io.kestra.core.worker.models.WorkerInfo;
 
 import io.grpc.stub.StreamObserver;
-import io.micronaut.context.annotation.Requires;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 
@@ -29,7 +29,7 @@ import jakarta.inject.Singleton;
  * Provides worker-safe KV metadata read/write to workers via gRPC.
  */
 @Singleton
-@Requires(property = "kestra.server-type", pattern = "(CONTROLLER|STANDALONE)")
+@RequiresControllerServer
 public class GrpcKVMetadataControllerService extends KVMetadataServiceGrpc.KVMetadataServiceImplBase implements WorkerControllerService {
 
     private static final Logger log = LoggerFactory.getLogger(GrpcKVMetadataControllerService.class);

--- a/worker-controller/src/main/java/io/kestra/controller/grpc/services/GrpcNSMetadataControllerService.java
+++ b/worker-controller/src/main/java/io/kestra/controller/grpc/services/GrpcNSMetadataControllerService.java
@@ -6,6 +6,7 @@ import java.util.Optional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import io.kestra.controller.RequiresControllerServer;
 import io.kestra.controller.grpc.*;
 import io.kestra.controller.messages.MessageFormat;
 import io.kestra.controller.messages.MessageFormats;
@@ -15,7 +16,6 @@ import io.kestra.core.namespace.NamespaceFileMetadataStateStore;
 import io.kestra.core.worker.models.WorkerInfo;
 
 import io.grpc.stub.StreamObserver;
-import io.micronaut.context.annotation.Requires;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 
@@ -24,7 +24,7 @@ import jakarta.inject.Singleton;
  * Provides worker-safe namespace file metadata read/write to workers via gRPC.
  */
 @Singleton
-@Requires(property = "kestra.server-type", pattern = "(CONTROLLER|STANDALONE)")
+@RequiresControllerServer
 public class GrpcNSMetadataControllerService extends NamespaceFileMetadataServiceGrpc.NamespaceFileMetadataServiceImplBase implements WorkerControllerService {
 
     private static final Logger log = LoggerFactory.getLogger(GrpcNSMetadataControllerService.class);

--- a/worker-controller/src/main/java/io/kestra/controller/grpc/services/WorkerCapacityMetricsPublisher.java
+++ b/worker-controller/src/main/java/io/kestra/controller/grpc/services/WorkerCapacityMetricsPublisher.java
@@ -4,11 +4,11 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Supplier;
 
+import io.kestra.controller.RequiresControllerServer;
 import io.kestra.core.metrics.MetricRegistry;
 import io.kestra.core.worker.WorkerGroups;
 import io.kestra.core.worker.WorkerQueues;
 
-import io.micronaut.context.annotation.Requires;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 import lombok.extern.slf4j.Slf4j;
@@ -34,7 +34,7 @@ import lombok.extern.slf4j.Slf4j;
  */
 @Slf4j
 @Singleton
-@Requires(property = "kestra.server-type", pattern = "(CONTROLLER|STANDALONE)")
+@RequiresControllerServer
 public class WorkerCapacityMetricsPublisher implements WorkerLifecycleListener {
 
     private final MetricRegistry metricRegistry;

--- a/worker-controller/src/test/java/io/kestra/controller/RequiresControllerServerTest.java
+++ b/worker-controller/src/test/java/io/kestra/controller/RequiresControllerServerTest.java
@@ -1,0 +1,88 @@
+package io.kestra.controller;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.junit.jupiter.api.Test;
+
+import io.kestra.controller.discovery.ControllerStorageRegistrar;
+import io.kestra.controller.grpc.WorkerControllerService;
+import io.kestra.controller.grpc.services.GrpcExecutionLogController;
+import io.kestra.controller.grpc.services.GrpcFlowMetaStoreWorkerControllerService;
+import io.kestra.controller.grpc.services.GrpcKVMetadataControllerService;
+import io.kestra.controller.grpc.services.GrpcNSMetadataControllerService;
+import io.kestra.controller.grpc.services.WorkerCapacityMetricsPublisher;
+import io.kestra.core.models.ServerType;
+
+import io.micronaut.context.ApplicationContext;
+import io.micronaut.context.env.PropertySource;
+import io.micronaut.inject.BeanDefinition;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class RequiresControllerServerTest {
+
+    @Test
+    void shouldRegisterTheSameGrpcServicesOnEveryControllerHostingServerType() {
+        // Given
+        Set<Class<?>> onDedicatedController = grpcServiceTypes(ServerType.CONTROLLER);
+
+        // Then a webserver or a standalone server running an embedded controller serves the same set,
+        // otherwise workers get UNIMPLEMENTED on the missing methods.
+        assertThat(onDedicatedController).isNotEmpty();
+        assertThat(grpcServiceTypes(ServerType.WEBSERVER)).isEqualTo(onDedicatedController);
+        assertThat(grpcServiceTypes(ServerType.STANDALONE)).isEqualTo(onDedicatedController);
+    }
+
+    @Test
+    void shouldNotRegisterMetadataGrpcServicesOnServerTypesWithoutController() {
+        Class<?>[] metadataServices = {
+            GrpcKVMetadataControllerService.class,
+            GrpcNSMetadataControllerService.class,
+            GrpcFlowMetaStoreWorkerControllerService.class,
+            GrpcExecutionLogController.class
+        };
+
+        assertThat(grpcServiceTypes(ServerType.WORKER)).doesNotContain(metadataServices);
+        assertThat(grpcServiceTypes(ServerType.EXECUTOR)).doesNotContain(metadataServices);
+        assertThat(grpcServiceTypes(ServerType.SCHEDULER)).doesNotContain(metadataServices);
+    }
+
+    @Test
+    void shouldEnableControllerBeansOnWebserver() {
+        try (ApplicationContext context = run(ServerType.WEBSERVER)) {
+            assertThat(context.containsBean(WorkerCapacityMetricsPublisher.class)).isTrue();
+            assertThat(context.containsBean(ControllerStorageRegistrar.class)).isTrue();
+        }
+    }
+
+    @Test
+    void shouldNotEnableControllerBeansOnWorker() {
+        try (ApplicationContext context = run(ServerType.WORKER)) {
+            assertThat(context.containsBean(WorkerCapacityMetricsPublisher.class)).isFalse();
+            assertThat(context.containsBean(ControllerStorageRegistrar.class)).isFalse();
+        }
+    }
+
+    private static Set<Class<?>> grpcServiceTypes(ServerType serverType) {
+        try (ApplicationContext context = run(serverType)) {
+            return context.getBeanDefinitions(WorkerControllerService.class)
+                .stream()
+                .filter(definition -> definition.isEnabled(context))
+                .map(BeanDefinition::getBeanType)
+                .collect(Collectors.toSet());
+        }
+    }
+
+    private static ApplicationContext run(ServerType serverType) {
+        return ApplicationContext.run(
+            PropertySource.of(
+                "test", Map.of(
+                    "kestra.server-type", serverType.name(),
+                    "kestra.controller.advertise.enabled", "true"
+                )
+            )
+        );
+    }
+}


### PR DESCRIPTION
A webserver starts an embedded controller unless `--no-controller` is passed, but every metadata gRPC service was gated on `kestra.server-type` being CONTROLLER or STANDALONE. On a webserver those beans were absent from the context, so the embedded gRPC server silently came up without them: worker registration and job dispatch worked, while KV, namespace files, flow metastore and execution log lookups failed at task runtime with `UNIMPLEMENTED: Method not found`.

Introduce `@RequiresControllerServer`, which also matches WEBSERVER, and apply it to every controller-hosted bean. Instantiation stays lazy, so a `--no-controller` webserver still builds none of them, and `ControllerStorageRegistrar` keeps advertising nothing since no CONTROLLER service instance ever reaches RUNNING.

The controller now logs the gRPC services it registered, as a missing one is otherwise only visible to workers as an UNIMPLEMENTED error at task runtime.
