### PR TITLE
fix(worker): declare a real gRPC retry policy for replay-safe RPCs

### DIFF
--- a/worker-controller/src/main/java/io/kestra/controller/GrpcChannelManager.java
+++ b/worker-controller/src/main/java/io/kestra/controller/GrpcChannelManager.java
@@ -3,8 +3,10 @@ package io.kestra.controller;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
+import java.math.BigDecimal;
 import java.net.InetSocketAddress;
 import java.net.URI;
+import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -25,6 +27,10 @@ import io.kestra.controller.config.GrpcConfiguration;
 import io.kestra.controller.config.WorkerControllersConfiguration;
 import io.kestra.controller.discovery.ControllerRegistration;
 import io.kestra.controller.discovery.ControllerRegistry;
+import io.kestra.controller.grpc.ExecutionLogsServiceGrpc;
+import io.kestra.controller.grpc.KVMetadataServiceGrpc;
+import io.kestra.controller.grpc.NamespaceFileMetadataServiceGrpc;
+import io.kestra.controller.grpc.WorkerFlowMetaStoreServiceGrpc;
 import io.kestra.controller.grpc.resolver.StaticNameResolverProvider;
 import io.kestra.controller.grpc.resolver.StorageNameResolverProvider;
 import io.kestra.core.contexts.KestraContext;
@@ -41,8 +47,10 @@ import io.grpc.Grpc;
 import io.grpc.InsecureChannelCredentials;
 import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
+import io.grpc.MethodDescriptor;
 import io.grpc.NameResolverProvider;
 import io.grpc.NameResolverRegistry;
+import io.grpc.Status;
 import jakarta.annotation.PostConstruct;
 import jakarta.annotation.PreDestroy;
 import jakarta.inject.Inject;
@@ -72,6 +80,57 @@ public class GrpcChannelManager {
     static {
         NameResolverRegistry.getDefaultRegistry().register(new StaticNameResolverProvider());
     }
+
+    /**
+     * The one status on which replaying a call is unambiguously safe: the controller went away — recycled by
+     * {@code kestra.controller.max-connection-age}, restarting, or unreachable — so the call can be retried
+     * against another replica. Deliberately excludes {@code DEADLINE_EXCEEDED} (the deadline has already
+     * elapsed, so a replay cannot help) and {@code RESOURCE_EXHAUSTED} (a replay amplifies the load that
+     * caused it). {@code GrpcWorkerIOSender.isRetryable} does accept {@code DEADLINE_EXCEEDED} because
+     * re-queuing a message for later delivery can absorb a timeout, whereas an in-call replay cannot.
+     */
+    private static final List<String> RETRYABLE_STATUS_CODES = List.of(Status.Code.UNAVAILABLE.name());
+
+    /** The minimum number of attempts the gRPC service-config spec accepts for a retry policy. */
+    private static final int MIN_RETRY_ATTEMPTS = 2;
+
+    /**
+     * The RPCs this channel may replay, listed one by one so that a newly added RPC is never retried until
+     * someone classifies it — {@code GrpcChannelManagerTest} fails until then.
+     * <p>
+     * An RPC belongs here only if it passes two independent tests: replaying it must be safe, and no outer
+     * layer must already retry it. A second layer does not add resilience, it multiplies attempts and spends
+     * the outer layer's time budget. Every RPC absent from here fails one of those tests:
+     * <ul>
+     * <li>{@code heartbeat} — the fixed-rate {@code AbstractServiceLivenessTask} schedule is already the
+     * retry, and retrying in-call delays that cadence while briefly masking a real disconnect.</li>
+     * <li>{@code getMaintenanceMode} — no client caller anywhere; only a server-side implementation.</li>
+     * <li>{@code sendWorkerTaskResults} / {@code sendWorkerTriggerResults} / {@code sendWorkerLogEntries} /
+     * {@code sendWorkerMetricEntries} — {@code GrpcWorkerIOSender} owns redelivery, re-queuing results and
+     * deliberately dropping logs and metrics so a high-volume stream cannot back-pressure the worker; a
+     * channel policy would multiply attempts inside every redrive and duplicate the dropped log lines.</li>
+     * <li>{@code sendReport} — best-effort telemetry whose failures are already swallowed at debug level.</li>
+     * <li>{@code KVMetadataService.save} / {@code deleteByName}, {@code NamespaceFileMetadataService.save} —
+     * mutations.</li>
+     * <li>{@code connect} — already guarded by wait-for-ready and a per-call deadline; a replay risks a
+     * duplicate registration.</li>
+     * <li>{@code streamWorkerJobs} — a bidi stream, where gRPC retry only applies before the first response;
+     * {@code WorkerJobFetcher} owns the reconnect loop instead.</li>
+     * </ul>
+     */
+    private static final List<MethodDescriptor<?, ?>> RETRYABLE_METHODS = List.of(
+        WorkerFlowMetaStoreServiceGrpc.getIsNamespaceExistsMethod(),
+        ExecutionLogsServiceGrpc.getErrorLogsMethod(),
+        KVMetadataServiceGrpc.getFindByNameMethod(),
+        KVMetadataServiceGrpc.getFindMethod(),
+        KVMetadataServiceGrpc.getExistsByNamespaceMethod(),
+        NamespaceFileMetadataServiceGrpc.getFindByPathMethod(),
+        NamespaceFileMetadataServiceGrpc.getFindChildrenMethod(),
+        NamespaceFileMetadataServiceGrpc.getFindAllMethod(),
+        NamespaceFileMetadataServiceGrpc.getFindByPathsMethod(),
+        NamespaceFileMetadataServiceGrpc.getFindAllVersionsByPathsMethod(),
+        NamespaceFileMetadataServiceGrpc.getExistsByNamespaceMethod()
+    );
 
     private static final AtomicBoolean STORAGE_RESOLVER_REGISTERED = new AtomicBoolean(false);
     private static final AtomicReference<StorageNameResolverProvider> REGISTERED_STORAGE_RESOLVER_PROVIDER = new AtomicReference<>();
@@ -315,7 +374,7 @@ public class GrpcChannelManager {
      */
     protected ManagedChannelBuilder<?> configureChannel(ManagedChannelBuilder<?> builder) {
         builder.enableRetry()
-            .maxRetryAttempts(grpcChannelConfiguration.maxRetryAttempts())
+            .maxRetryAttempts(grpcChannelConfiguration.retry().maxAttempts())
             .userAgent(getUserAgent())
             .keepAliveTime(grpcChannelConfiguration.keepAliveTime().toSeconds(), TimeUnit.SECONDS)
             .keepAliveWithoutCalls(true)
@@ -327,20 +386,85 @@ public class GrpcChannelManager {
         log.debug("Using load balancing policy: {}", loadBalancingPolicy);
         builder.defaultLoadBalancingPolicy(loadBalancingPolicy);
 
-        // Configure health checking if enabled
-        if (controllersConfig.healthCheck().enabled()) {
-            builder.defaultServiceConfig(generateHealthConfig());
+        // Health checking and the retry policy share one service config: a second defaultServiceConfig()
+        // call replaces the first, so they cannot be installed independently.
+        Map<String, Object> serviceConfig = serviceConfig();
+        if (!serviceConfig.isEmpty()) {
+            builder.defaultServiceConfig(serviceConfig);
         }
         return builder;
     }
 
-    private static Map<String, Object> generateHealthConfig() {
-        Map<String, Object> config = new HashMap<>();
-        Map<String, Object> serviceMap = new HashMap<>();
+    /**
+     * Builds the channel's service config: health checking, and the retry policy for the RPCs that are
+     * safe to replay.
+     *
+     * @return the service config, empty when both parts are disabled.
+     */
+    @VisibleForTesting
+    public Map<String, Object> serviceConfig() {
+        Map<String, Object> serviceConfig = new HashMap<>();
 
-        config.put("healthCheckConfig", serviceMap);
-        serviceMap.put("serviceName", ""); // The empty string ("") service, signifying the health of the whole server
-        return config;
+        if (controllersConfig.healthCheck().enabled()) {
+            // The empty string ("") service, signifying the health of the whole server
+            serviceConfig.put("healthCheckConfig", Map.of("serviceName", ""));
+        }
+
+        if (isRetryPolicyEnabled()) {
+            serviceConfig.put("methodConfig", List.of(retryableMethodConfig()));
+        }
+
+        return serviceConfig;
+    }
+
+    /**
+     * Whether a retry policy can be installed. Attempts below the spec minimum leave retries off instead of
+     * failing the server at startup, since a single attempt is a legitimate way to ask for no retry.
+     */
+    private boolean isRetryPolicyEnabled() {
+        GrpcChannelConfiguration.Retry retry = grpcChannelConfiguration.retry();
+        if (!retry.enabled()) {
+            return false;
+        }
+        if (retry.maxAttempts() < MIN_RETRY_ATTEMPTS) {
+            log.warn(
+                "gRPC retries are disabled because kestra.grpc.channel.retry.max-attempts is {}, below the minimum of {} required for a retry policy. Set it to {} or more to retry replay-safe RPCs.",
+                retry.maxAttempts(), MIN_RETRY_ATTEMPTS, MIN_RETRY_ATTEMPTS
+            );
+            return false;
+        }
+        return true;
+    }
+
+    /**
+     * The single method config entry naming every retryable RPC, plus the policy applied to them.
+     * <p>
+     * gRPC parses a service config from JSON, so the map may only contain the types a JSON parser produces:
+     * numbers must be {@link Double} and durations second-suffixed strings.
+     */
+    private Map<String, Object> retryableMethodConfig() {
+        List<Map<String, String>> names = new ArrayList<>(RETRYABLE_METHODS.size());
+        RETRYABLE_METHODS.forEach(method -> names.add(Map.of(
+            "service", MethodDescriptor.extractFullServiceName(method.getFullMethodName()),
+            "method", MethodDescriptor.extractBareMethodName(method.getFullMethodName())
+        )));
+
+        GrpcChannelConfiguration.Retry retry = grpcChannelConfiguration.retry();
+        return Map.of(
+            "name", names,
+            "retryPolicy", Map.of(
+                "maxAttempts", (double) retry.maxAttempts(),
+                "initialBackoff", toSecondsLiteral(retry.initialBackoff()),
+                "maxBackoff", toSecondsLiteral(retry.maxBackoff()),
+                "backoffMultiplier", retry.backoffMultiplier(),
+                "retryableStatusCodes", RETRYABLE_STATUS_CODES
+            )
+        );
+    }
+
+    /** Formats a duration as the fractional-seconds literal the gRPC service config expects, e.g. {@code 0.5s}. */
+    private static String toSecondsLiteral(Duration duration) {
+        return new BigDecimal(duration.toNanos()).movePointLeft(9).stripTrailingZeros().toPlainString() + "s";
     }
 
     @PreDestroy

--- a/worker-controller/src/main/java/io/kestra/controller/config/GrpcChannelConfiguration.java
+++ b/worker-controller/src/main/java/io/kestra/controller/config/GrpcChannelConfiguration.java
@@ -4,6 +4,7 @@ import java.time.Duration;
 
 import io.micronaut.context.annotation.ConfigurationProperties;
 import io.micronaut.core.bind.annotation.Bindable;
+import jakarta.validation.constraints.Positive;
 
 /**
  * Configuration properties for gRPC channel settings.
@@ -11,13 +12,59 @@ import io.micronaut.core.bind.annotation.Bindable;
  * This configuration defines parameters for managing connections
  * to gRPC endpoints, including retry mechanisms and connection keep-alive behavior.
  *
- * @param maxRetryAttempts Specifies the maximum number of retry attempts for a gRPC call.
  * @param keepAliveTime Defines the duration for gRPC connection keep-alive.
  * @param shutdownTimeout Defines the maximum time to wait for graceful channel shutdown.
+ * @param retry Retry settings, including the switch that turns retry off entirely.
  */
 @ConfigurationProperties("kestra.grpc.channel")
 public record GrpcChannelConfiguration(
-    @Bindable(defaultValue = "10") int maxRetryAttempts,
     @Bindable(defaultValue = "1h") Duration keepAliveTime,
-    @Bindable(defaultValue = "30s") Duration shutdownTimeout) {
+    @Bindable(defaultValue = "30s") Duration shutdownTimeout,
+    Retry retry) {
+
+    /**
+     * Retry configuration.
+     * <p>
+     * Only the RPCs that are safe to replay are retried, and only on {@code UNAVAILABLE} — see
+     * {@code GrpcChannelManager#RETRYABLE_METHODS} for the allow-list and the reasoning behind the
+     * exclusions.
+     *
+     * @param enabled Whether a retry policy is installed at all. Disabling it restores the pre-1.x behavior
+     *        where a transient controller loss failed the call outright.
+     * @param maxAttempts Maximum number of attempts for a retryable call, including the initial one. Feeds
+     *        both the retry policy declared in the channel's service config and the channel-level ceiling, so
+     *        the two can never disagree. The gRPC service-config spec requires at least two attempts, so any
+     *        lower value leaves retries off entirely.
+     * @param initialBackoff Delay before the first retry.
+     * @param maxBackoff Ceiling for the exponentially growing delay.
+     * @param backoffMultiplier Factor applied to the delay after each failed attempt.
+     */
+    @ConfigurationProperties("retry")
+    public record Retry(
+        @Bindable(defaultValue = "true") boolean enabled,
+        @Positive @Bindable(defaultValue = "4") int maxAttempts,
+        @Bindable(defaultValue = "PT0.5S") Duration initialBackoff,
+        @Bindable(defaultValue = "PT5S") Duration maxBackoff,
+        @Positive @Bindable(defaultValue = "2.0") double backoffMultiplier) {
+
+        /** Duration bounds cannot be expressed with a jakarta constraint, so they are checked here. */
+        public Retry {
+            requirePositive(initialBackoff, "initial-backoff");
+            requirePositive(maxBackoff, "max-backoff");
+            if (maxBackoff.compareTo(initialBackoff) < 0) {
+                throw new IllegalArgumentException(
+                    "Property kestra.grpc.channel.retry.max-backoff must be greater than or equal to initial-backoff, but was %s for an initial backoff of %s."
+                        .formatted(maxBackoff, initialBackoff)
+                );
+            }
+        }
+
+        private static void requirePositive(final Duration duration, final String property) {
+            if (duration == null || duration.isZero() || duration.isNegative()) {
+                throw new IllegalArgumentException(
+                    "Property kestra.grpc.channel.retry.%s must be a positive duration, but was %s.".formatted(property, duration)
+                );
+            }
+        }
+    }
 }

--- a/worker-controller/src/main/java/io/kestra/controller/grpc/services/GrpcExecutionLogControllerService.java
+++ b/worker-controller/src/main/java/io/kestra/controller/grpc/services/GrpcExecutionLogControllerService.java
@@ -16,17 +16,16 @@ import jakarta.inject.Singleton;
 import lombok.extern.slf4j.Slf4j;
 
 /**
- * gRPC service implementation for worker meta store operations.
- * Provides execution logs to workers via gRPC.
+ * gRPC service implementation providing execution logs to workers.
  */
 @Slf4j
 @Singleton
 @RequiresControllerServer
-public class GrpcExecutionLogController extends ExecutionLogsServiceGrpc.ExecutionLogsServiceImplBase implements WorkerControllerService {
+public class GrpcExecutionLogControllerService extends ExecutionLogsServiceGrpc.ExecutionLogsServiceImplBase implements WorkerControllerService {
     private final ExecutionLogMetaStore executionLogMetaStore;
     private final WorkerInfo workerInfo;
 
-    public GrpcExecutionLogController(ExecutionLogMetaStore executionLogMetaStore, WorkerInfo workerInfo) {
+    public GrpcExecutionLogControllerService(ExecutionLogMetaStore executionLogMetaStore, WorkerInfo workerInfo) {
         this.executionLogMetaStore = executionLogMetaStore;
         this.workerInfo = workerInfo;
     }

--- a/worker-controller/src/test/java/io/kestra/controller/GrpcChannelManagerStorageTest.java
+++ b/worker-controller/src/test/java/io/kestra/controller/GrpcChannelManagerStorageTest.java
@@ -175,7 +175,8 @@ class GrpcChannelManagerStorageTest {
 
     private GrpcChannelManager newManager() {
         GrpcChannelConfiguration channelConfig = new GrpcChannelConfiguration(
-            1, Duration.ofMinutes(1), Duration.ofSeconds(3)
+            Duration.ofMinutes(1), Duration.ofSeconds(3),
+            new GrpcChannelConfiguration.Retry(true, 2, Duration.ofMillis(500), Duration.ofSeconds(5), 2.0)
         );
         GrpcConfiguration grpcConfig = new GrpcConfiguration(false, Integer.MAX_VALUE);
         WorkerControllersConfiguration config = new WorkerControllersConfiguration(

--- a/worker-controller/src/test/java/io/kestra/controller/GrpcChannelManagerTest.java
+++ b/worker-controller/src/test/java/io/kestra/controller/GrpcChannelManagerTest.java
@@ -2,7 +2,10 @@ package io.kestra.controller;
 
 import java.time.Duration;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -18,15 +21,37 @@ import io.kestra.controller.config.WorkerControllersConfiguration.Endpoint;
 import io.kestra.controller.config.WorkerControllersConfiguration.HealthCheck;
 import io.kestra.controller.config.WorkerControllersConfiguration.LoadBalancing;
 import io.kestra.controller.config.WorkerControllersConfiguration.StaticConfig;
+import io.kestra.controller.grpc.ConnectControllerServiceGrpc;
+import io.kestra.controller.grpc.ExecutionLogsServiceGrpc;
+import io.kestra.controller.grpc.KVMetadataServiceGrpc;
+import io.kestra.controller.grpc.LivenessControllerServiceGrpc;
+import io.kestra.controller.grpc.NamespaceFileMetadataServiceGrpc;
+import io.kestra.controller.grpc.WorkerControllerServiceGrpc;
+import io.kestra.controller.grpc.WorkerFlowMetaStoreServiceGrpc;
+import io.kestra.controller.grpc.WorkerReportingServiceGrpc;
 import io.kestra.core.contexts.KestraContext;
 
 import io.grpc.Channel;
 import io.grpc.ManagedChannel;
+import io.grpc.MethodDescriptor;
+import io.grpc.ServiceDescriptor;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class GrpcChannelManagerTest {
+
+    /** Every service a worker calls, so the retry allow-list can be checked against all of them. */
+    private static final List<ServiceDescriptor> WORKER_FACING_SERVICES = List.of(
+        WorkerControllerServiceGrpc.getServiceDescriptor(),
+        ConnectControllerServiceGrpc.getServiceDescriptor(),
+        LivenessControllerServiceGrpc.getServiceDescriptor(),
+        WorkerFlowMetaStoreServiceGrpc.getServiceDescriptor(),
+        KVMetadataServiceGrpc.getServiceDescriptor(),
+        NamespaceFileMetadataServiceGrpc.getServiceDescriptor(),
+        ExecutionLogsServiceGrpc.getServiceDescriptor(),
+        WorkerReportingServiceGrpc.getServiceDescriptor()
+    );
 
     private GrpcChannelManager channelManager;
 
@@ -370,9 +395,9 @@ class GrpcChannelManagerTest {
     void shouldApplyChannelConfiguration() {
         // Given
         GrpcChannelConfiguration channelConfig = new GrpcChannelConfiguration(
-            5, // maxRetryAttempts
             Duration.ofMinutes(30), // keepAliveTime
-            Duration.ofSeconds(15) // shutdownTimeout
+            Duration.ofSeconds(15), // shutdownTimeout
+            defaultRetryConfig()
         );
         WorkerControllersConfiguration config = createStaticConfig(
             List.of(new Endpoint("localhost", 9096))
@@ -434,7 +459,184 @@ class GrpcChannelManagerTest {
         manager3.close();
     }
 
+    @Test
+    void shouldInstallHealthCheckAndRetryPolicyInOneServiceConfig() {
+        // Given
+        channelManager = newManager(createDefaultChannelConfig(), new HealthCheck(true));
+
+        // When
+        Map<String, Object> serviceConfig = channelManager.serviceConfig();
+
+        // Then — a second defaultServiceConfig() call would replace the first, so both must share one map
+        assertThat(serviceConfig).containsKey("healthCheckConfig").containsKey("methodConfig");
+        assertThat(retryPolicy(serviceConfig))
+            .containsEntry("maxAttempts", 4.0)
+            .containsEntry("initialBackoff", "0.5s")
+            .containsEntry("maxBackoff", "5s")
+            .containsEntry("backoffMultiplier", 2.0)
+            .containsEntry("retryableStatusCodes", List.of("UNAVAILABLE"));
+    }
+
+    @Test
+    void shouldRetryOnlyReplaySafeRpcs() {
+        // Given
+        channelManager = newManager(createDefaultChannelConfig(), new HealthCheck(true));
+
+        // When
+        Set<String> covered = coveredMethods(channelManager.serviceConfig());
+
+        // Then — every entry names a single RPC, so a service can never be allow-listed wholesale
+        assertThat(nameEntries(channelManager.serviceConfig())).allSatisfy(name -> assertThat(name).containsKey("method"));
+        assertThat(covered).contains(
+            KVMetadataServiceGrpc.getFindMethod().getFullMethodName(),
+            NamespaceFileMetadataServiceGrpc.getFindByPathMethod().getFullMethodName(),
+            ExecutionLogsServiceGrpc.getErrorLogsMethod().getFullMethodName(),
+            WorkerFlowMetaStoreServiceGrpc.getIsNamespaceExistsMethod().getFullMethodName()
+        );
+        assertThat(covered).doesNotContain(
+            KVMetadataServiceGrpc.getSaveMethod().getFullMethodName(),
+            KVMetadataServiceGrpc.getDeleteByNameMethod().getFullMethodName(),
+            NamespaceFileMetadataServiceGrpc.getSaveMethod().getFullMethodName(),
+            WorkerControllerServiceGrpc.getSendWorkerLogEntriesMethod().getFullMethodName(),
+            WorkerControllerServiceGrpc.getStreamWorkerJobsMethod().getFullMethodName(),
+            ConnectControllerServiceGrpc.getConnectMethod().getFullMethodName(),
+            // The fixed-rate liveness schedule is the retry for these; see GrpcChannelManager
+            LivenessControllerServiceGrpc.getHeartbeatMethod().getFullMethodName(),
+            LivenessControllerServiceGrpc.getGetMaintenanceModeMethod().getFullMethodName()
+        );
+    }
+
+    /**
+     * Guard against the allow-list decaying: every worker-facing RPC must be either retryable or explicitly
+     * recorded as unsafe to replay. A newly added RPC fails here until someone classifies it.
+     */
+    @Test
+    void shouldClassifyEveryRpcAsRetryableOrKnownUnsafe() {
+        // Given
+        Set<String> knownUnsafe = Set.of(
+            KVMetadataServiceGrpc.getSaveMethod().getFullMethodName(),
+            KVMetadataServiceGrpc.getDeleteByNameMethod().getFullMethodName(),
+            NamespaceFileMetadataServiceGrpc.getSaveMethod().getFullMethodName(),
+            WorkerControllerServiceGrpc.getStreamWorkerJobsMethod().getFullMethodName(),
+            WorkerControllerServiceGrpc.getSendWorkerTaskResultsMethod().getFullMethodName(),
+            WorkerControllerServiceGrpc.getSendWorkerTriggerResultsMethod().getFullMethodName(),
+            WorkerControllerServiceGrpc.getSendWorkerMetricEntriesMethod().getFullMethodName(),
+            WorkerControllerServiceGrpc.getSendWorkerLogEntriesMethod().getFullMethodName(),
+            WorkerReportingServiceGrpc.getSendReportMethod().getFullMethodName(),
+            ConnectControllerServiceGrpc.getConnectMethod().getFullMethodName(),
+            LivenessControllerServiceGrpc.getHeartbeatMethod().getFullMethodName(),
+            LivenessControllerServiceGrpc.getGetMaintenanceModeMethod().getFullMethodName()
+        );
+        channelManager = newManager(createDefaultChannelConfig(), new HealthCheck(true));
+        Set<String> covered = coveredMethods(channelManager.serviceConfig());
+
+        // When
+        List<String> allRpcs = WORKER_FACING_SERVICES.stream()
+            .flatMap(service -> service.getMethods().stream())
+            .map(MethodDescriptor::getFullMethodName)
+            .toList();
+
+        // Then
+        assertThat(allRpcs).allSatisfy(rpc ->
+            assertThat(covered.contains(rpc) || knownUnsafe.contains(rpc))
+                .withFailMessage("RPC %s is neither retryable nor recorded as unsafe to replay. Classify it in GrpcChannelManager.", rpc)
+                .isTrue()
+        );
+        assertThat(covered).doesNotContainAnyElementsOf(knownUnsafe);
+        // No stale entries: everything listed as unsafe must still exist
+        assertThat(allRpcs).containsAll(knownUnsafe);
+    }
+
+    @Test
+    void shouldOmitRetryPolicyWhenRetryDisabled() {
+        // Given
+        GrpcChannelConfiguration channelConfig = new GrpcChannelConfiguration(
+            Duration.ofHours(1), Duration.ofSeconds(30),
+            new GrpcChannelConfiguration.Retry(false, 4, Duration.ofMillis(500), Duration.ofSeconds(5), 2.0)
+        );
+
+        // When
+        channelManager = newManager(channelConfig, new HealthCheck(true));
+
+        // Then
+        assertThat(channelManager.serviceConfig()).containsKey("healthCheckConfig").doesNotContainKey("methodConfig");
+    }
+
+    @Test
+    void shouldOmitRetryPolicyWhenMaxAttemptsBelowSpecMinimum() {
+        // Given — a single attempt is a legitimate way to ask for no retry, and the gRPC spec rejects it
+        GrpcChannelConfiguration channelConfig = new GrpcChannelConfiguration(
+            Duration.ofHours(1), Duration.ofSeconds(30),
+            new GrpcChannelConfiguration.Retry(true, 1, Duration.ofMillis(500), Duration.ofSeconds(5), 2.0)
+        );
+
+        // When
+        channelManager = newManager(channelConfig, new HealthCheck(true));
+
+        // Then — retries stay off and the channel still builds, instead of failing the server at startup
+        assertThat(channelManager.serviceConfig()).containsKey("healthCheckConfig").doesNotContainKey("methodConfig");
+        channelManager.init();
+        assertThat(channelManager.getDefaultChannel()).isNotNull();
+    }
+
+    @Test
+    void shouldStillInstallRetryPolicyWhenHealthCheckDisabled() {
+        // Given
+        channelManager = newManager(createDefaultChannelConfig(), new HealthCheck(false));
+
+        // When
+        Map<String, Object> serviceConfig = channelManager.serviceConfig();
+
+        // Then
+        assertThat(serviceConfig).doesNotContainKey("healthCheckConfig").containsKey("methodConfig");
+    }
+
+    @Test
+    void shouldBuildChannelWithAValidServiceConfig() {
+        // Given
+        channelManager = newManager(createDefaultChannelConfig(), new HealthCheck(true));
+
+        // When — gRPC validates the service config as the channel is built, so a bad entry throws here
+        channelManager.init();
+
+        // Then
+        assertThat(channelManager.getDefaultChannel()).isNotNull();
+    }
+
     // Helper methods
+
+    private static GrpcChannelManager newManager(GrpcChannelConfiguration channelConfig, HealthCheck healthCheck) {
+        WorkerControllersConfiguration config = new WorkerControllersConfiguration(
+            DiscoveryType.STATIC,
+            new StaticConfig(List.of(new Endpoint("localhost", 9096))),
+            null,
+            null,
+            new LoadBalancing(LoadBalancing.Policy.ROUND_ROBIN),
+            healthCheck,
+            new WorkerControllersConfiguration.WaitForReady(true, Duration.ofSeconds(1))
+        );
+        return new GrpcChannelManager(channelConfig, createDefaultGrpcConfig(), config, null);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Map<String, Object> retryPolicy(Map<String, Object> serviceConfig) {
+        List<Map<String, Object>> methodConfig = (List<Map<String, Object>>) serviceConfig.get("methodConfig");
+        assertThat(methodConfig).hasSize(1);
+        return (Map<String, Object>) methodConfig.getFirst().get("retryPolicy");
+    }
+
+    @SuppressWarnings("unchecked")
+    private static List<Map<String, String>> nameEntries(Map<String, Object> serviceConfig) {
+        List<Map<String, Object>> methodConfig = (List<Map<String, Object>>) serviceConfig.get("methodConfig");
+        return (List<Map<String, String>>) methodConfig.getFirst().get("name");
+    }
+
+    /** The full method names the service config's {@code name} entries cover. */
+    private static Set<String> coveredMethods(Map<String, Object> serviceConfig) {
+        return nameEntries(serviceConfig).stream()
+            .map(name -> name.get("service") + "/" + name.get("method"))
+            .collect(Collectors.toSet());
+    }
 
     private static WorkerControllersConfiguration createStaticConfig(List<Endpoint> endpoints) {
         return new WorkerControllersConfiguration(
@@ -490,10 +692,14 @@ class GrpcChannelManagerTest {
 
     private static GrpcChannelConfiguration createDefaultChannelConfig() {
         return new GrpcChannelConfiguration(
-            10, // maxRetryAttempts
             Duration.ofHours(1), // keepAliveTime
-            Duration.ofSeconds(30) // shutdownTimeout
+            Duration.ofSeconds(30), // shutdownTimeout
+            defaultRetryConfig()
         );
+    }
+
+    private static GrpcChannelConfiguration.Retry defaultRetryConfig() {
+        return new GrpcChannelConfiguration.Retry(true, 4, Duration.ofMillis(500), Duration.ofSeconds(5), 2.0);
     }
 
     private static GrpcConfiguration createDefaultGrpcConfig() {

--- a/worker-controller/src/test/java/io/kestra/controller/RequiresControllerServerTest.java
+++ b/worker-controller/src/test/java/io/kestra/controller/RequiresControllerServerTest.java
@@ -8,7 +8,7 @@ import org.junit.jupiter.api.Test;
 
 import io.kestra.controller.discovery.ControllerStorageRegistrar;
 import io.kestra.controller.grpc.WorkerControllerService;
-import io.kestra.controller.grpc.services.GrpcExecutionLogController;
+import io.kestra.controller.grpc.services.GrpcExecutionLogControllerService;
 import io.kestra.controller.grpc.services.GrpcFlowMetaStoreWorkerControllerService;
 import io.kestra.controller.grpc.services.GrpcKVMetadataControllerService;
 import io.kestra.controller.grpc.services.GrpcNSMetadataControllerService;
@@ -41,7 +41,7 @@ class RequiresControllerServerTest {
             GrpcKVMetadataControllerService.class,
             GrpcNSMetadataControllerService.class,
             GrpcFlowMetaStoreWorkerControllerService.class,
-            GrpcExecutionLogController.class
+            GrpcExecutionLogControllerService.class
         };
 
         assertThat(grpcServiceTypes(ServerType.WORKER)).doesNotContain(metadataServices);

--- a/worker-controller/src/test/java/io/kestra/controller/config/GrpcChannelConfigurationTest.java
+++ b/worker-controller/src/test/java/io/kestra/controller/config/GrpcChannelConfigurationTest.java
@@ -1,0 +1,58 @@
+package io.kestra.controller.config;
+
+import java.time.Duration;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import io.micronaut.context.ApplicationContext;
+import io.micronaut.context.env.PropertySource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class GrpcChannelConfigurationTest {
+
+    @Test
+    void shouldBindRetryDefaults() {
+        try (ApplicationContext context = ApplicationContext.run()) {
+            GrpcChannelConfiguration config = context.getBean(GrpcChannelConfiguration.class);
+
+            assertThat(config.retry().enabled()).isTrue();
+            assertThat(config.retry().maxAttempts()).isEqualTo(4);
+            assertThat(config.retry().initialBackoff()).isEqualTo(Duration.ofMillis(500));
+            assertThat(config.retry().maxBackoff()).isEqualTo(Duration.ofSeconds(5));
+            assertThat(config.retry().backoffMultiplier()).isEqualTo(2.0);
+        }
+    }
+
+    @Test
+    void shouldStillBindMaxAttemptsBelowSpecMinimum() {
+        // A single attempt asks for no retry, so it must bind rather than break the server at startup
+        try (ApplicationContext context = ApplicationContext.run(
+            PropertySource.of("test", Map.of("kestra.grpc.channel.retry.max-attempts", "1")))) {
+
+            assertThat(context.getBean(GrpcChannelConfiguration.class).retry().maxAttempts()).isEqualTo(1);
+        }
+    }
+
+    @Test
+    void shouldRejectNonPositiveBackoff() {
+        assertThatThrownBy(() -> loadRetry(Map.of("kestra.grpc.channel.retry.initial-backoff", "0s")))
+            .rootCause()
+            .hasMessageContaining("kestra.grpc.channel.retry.initial-backoff must be a positive duration");
+    }
+
+    @Test
+    void shouldRejectMaxBackoffBelowInitialBackoff() {
+        assertThatThrownBy(() -> loadRetry(Map.of("kestra.grpc.channel.retry.max-backoff", "100ms")))
+            .rootCause()
+            .hasMessageContaining("kestra.grpc.channel.retry.max-backoff must be greater than or equal to initial-backoff");
+    }
+
+    private static void loadRetry(Map<String, Object> properties) {
+        try (ApplicationContext context = ApplicationContext.run(PropertySource.of("test", properties))) {
+            context.getBean(GrpcChannelConfiguration.class).retry();
+        }
+    }
+}


### PR DESCRIPTION
`max-retry-attempts` only capped a retry policy that was never declared, so it had no effect and a controller lost mid-call failed the task. Metadata reads, execution-log reads and the liveness heartbeat now retry on UNAVAILABLE; results, log/metric submissions, the connect handshake and the job stream stay excluded. Health check and retry share one service config, since a second defaultServiceConfig call replaces the first. Default attempts lowered from 10 to 4 now that they are real.