### PR TITLE
fix(execution): error logs didn't surface in loop executions

### DIFF
--- a/ui/src/components/executions/overview/components/main/ErrorAlert.vue
+++ b/ui/src/components/executions/overview/components/main/ErrorAlert.vue
@@ -63,7 +63,10 @@
             namespace: props.execution.namespace,
             flowId: props.execution.flowId,
         },
-        query: {"filters[level][EQUALS]": "ERROR"},
+        query: {
+            "filters[level][GREATER_THAN_OR_EQUAL_TO]": "ERROR",
+            "filters[kind][IN]": props.execution.kind,
+        },
     }
 
     function stripBackticks(message: string): string {
@@ -75,7 +78,10 @@
             const response = await store.loadLogs({
                 store: false,
                 executionId: props.execution.id,
-                params: {minLevel: "ERROR"},
+                params: {
+                    "filters[level][GREATER_THAN_OR_EQUAL_TO]": "ERROR",
+                    "filters[kind][IN]": props.execution.kind,
+                },
                 showMessageOnError: false,
             })
 


### PR DESCRIPTION
Fixes #17486


<img width="2491" height="1355" alt="Capture d’écran du 2026-08-06 10-02-48" src="https://github.com/user-attachments/assets/d8bac79f-698e-42cc-b31d-fce692578a70" />
