### PR TITLE
feat(flows): add sortable "Last Modified" column to the flows list

### DIFF
--- a/core/src/main/java/io/kestra/core/models/flows/FlowWithSource.java
+++ b/core/src/main/java/io/kestra/core/models/flows/FlowWithSource.java
@@ -39,6 +39,7 @@ public class FlowWithSource extends Flow {
             .retry(this.retry)
             .sla(this.sla)
             .checks(this.checks)
+            .updated(this.updated)
             .build();
     }
 

--- a/core/src/test/java/io/kestra/core/models/flows/FlowWithSourceTest.java
+++ b/core/src/test/java/io/kestra/core/models/flows/FlowWithSourceTest.java
@@ -1,5 +1,6 @@
 package io.kestra.core.models.flows;
 
+import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 
@@ -144,5 +145,31 @@ class FlowWithSourceTest {
 
         assertThat(of.equalsWithoutRevision(flow)).isTrue();
         assertThat(of.getSource()).isEqualTo(expectedSource);
+    }
+
+    @Test
+    void toFlowShouldPreserveRevisionAndUpdated() {
+        Instant updated = Instant.parse("2026-08-06T08:55:00.788514407Z");
+        FlowWithSource flowWithSource = FlowWithSource.builder()
+            .id(IdUtils.create())
+            .namespace("io.kestra.unittest")
+            .revision(2)
+            .updated(updated)
+            .tasks(
+                List.of(
+                    Log.builder()
+                        .id(IdUtils.create())
+                        .type(Log.class.getName())
+                        .message("Hello World")
+                        .build()
+                )
+            )
+            .source("source")
+            .build();
+
+        Flow flow = flowWithSource.toFlow();
+
+        assertThat(flow.getRevision()).isEqualTo(2);
+        assertThat(flow.getUpdated()).isEqualTo(updated);
     }
 }

--- a/core/src/test/java/io/kestra/core/repositories/AbstractFlowRepositoryTest.java
+++ b/core/src/test/java/io/kestra/core/repositories/AbstractFlowRepositoryTest.java
@@ -164,6 +164,43 @@ public abstract class AbstractFlowRepositoryTest {
         }
     }
 
+    @Test
+    void shouldSortByUpdatedWhenSortRequested() {
+        // Given: flows created in an order that differs from their id order, so a working
+        // sort on `updated` must reorder them rather than return the default (id) order.
+        String tenant = TestsUtils.randomTenant(this.getClass().getSimpleName());
+
+        FlowWithSource first = flowRepository.create(GenericFlow.of(builder(tenant, "sort-flow-c", TEST_FLOW_ID).build()));
+        FlowWithSource second = flowRepository.create(GenericFlow.of(builder(tenant, "sort-flow-a", TEST_FLOW_ID).build()));
+        FlowWithSource third = flowRepository.create(GenericFlow.of(builder(tenant, "sort-flow-b", TEST_FLOW_ID).build()));
+
+        try {
+            // When
+            ArrayListTotal<Flow> ascending = flowRepository.find(
+                Pageable.from(1, 10, Sort.of(Sort.Order.asc("updated"))),
+                tenant,
+                List.of()
+            );
+            ArrayListTotal<Flow> descending = flowRepository.find(
+                Pageable.from(1, 10, Sort.of(Sort.Order.desc("updated"))),
+                tenant,
+                List.of()
+            );
+
+            // Then: both directions return every flow ordered by `updated`. An ignored sort would
+            // yield a single fixed order that cannot be both ascending and descending.
+            assertThat(ascending).hasSize(3);
+            assertThat(descending).hasSize(3);
+            assertThat(ascending).allSatisfy(flow -> assertThat(flow.getUpdated()).isNotNull());
+            assertThat(ascending).isSortedAccordingTo(Comparator.comparing(Flow::getUpdated));
+            assertThat(descending).isSortedAccordingTo(Comparator.comparing(Flow::getUpdated).reversed());
+        } finally {
+            deleteFlow(first);
+            deleteFlow(second);
+            deleteFlow(third);
+        }
+    }
+
     @ParameterizedTest
     @MethodSource("filterCombinations")
     void should_find_all(QueryFilter filter) {

--- a/ui/src/components/flows/Flows.vue
+++ b/ui/src/components/flows/Flows.vue
@@ -227,6 +227,18 @@
                         <TriggerAvatar :flow="scope.row" />
                     </template>
                 </KsTableColumn>
+
+                <KsTableColumn
+                    v-else-if="colProp === 'updated'"
+                    prop="updated"
+                    sortable="custom"
+                    :sortOrders="['ascending', 'descending']"
+                    :label="$t('last modified')"
+                >
+                    <template #default="scope">
+                        <KsDateAgo v-if="scope.row.updated" :date="scope.row.updated" inverted />
+                    </template>
+                </KsTableColumn>
             </template>
 
             <KsTableColumn columnKey="action" className="row-action" :label="$t('actions')">
@@ -391,6 +403,12 @@
             prop: "triggers",
             default: true,
             description: t("filter.table_column.flows.triggers"),
+        },
+        {
+            label: t("last modified"),
+            prop: "updated",
+            default: false,
+            description: t("filter.table_column.flows.last modified"),
         },
     ])
 


### PR DESCRIPTION
### What this does

Adds a **"Last Modified"** column to the flows list page, sourced from the flow's `updated` timestamp (the timestamp of the latest revision). The column is:

- **opt-in** — off by default, enabled from the table column picker (persisted per user), like the other optional flows columns;
- **server-sortable** — clicking the header issues `?sort=updated:asc|desc`, handled by the existing sort plumbing.

Closes https://github.com/kestra-io/kestra/issues/17872

### The `toFlow()` fix

While wiring this up, the Elasticsearch backend returned flow rows **without** `updated` even though the value was stored. Root cause: `FlowWithSource.toFlow()` copied `revision` but never `updated` (its sibling factory `of()` does copy it). With `serialization-inclusion: non_null`, the null field was omitted entirely. The JDBC backends were unaffected because they deserialize the stored `value` JSON directly rather than going through `toFlow()`.

Fix: `toFlow()` now copies `updated`, mirroring `of()`.

**Equality safety:** `updated` is not part of `Flow.equals()`/`hashCode()` — `Flow` uses `@EqualsAndHashCode(callSuper=false)` and `updated` is an inherited `AbstractFlow` field — and `equalsWithoutRevision` (the source-change dedup) already excludes `updated`. So this change cannot affect equality/dedup.

### Tests

- `FlowWithSourceTest#toFlowShouldPreserveRevisionAndUpdated` — unit guard on the fix.
- `AbstractFlowRepositoryTest#shouldSortByUpdatedWhenSortRequested` — shared repository test asserting `sort=updated` orders rows in both directions; runs across H2/MySQL/Postgres **and** the Elasticsearch backend (EE inherits this abstract test).

### Enterprise companion

The Elasticsearch index needs the `updated` field mapped + a reindex of existing docs for sorting to work there — handled in the companion EE PR.
