### PR TITLE
fix(system): register the system worker under its own service type

### DIFF
--- a/core/src/main/java/io/kestra/core/server/ServiceType.java
+++ b/core/src/main/java/io/kestra/core/server/ServiceType.java
@@ -13,8 +13,21 @@ public enum ServiceType {
     SCHEDULER,
     WEBSERVER,
     WORKER,
+    SYSTEM_WORKER,
     CONTROLLER,
     INVALID;
+
+    /**
+     * Checks whether this type denotes a service executing worker jobs, whatever the worker flavour.
+     * <p>
+     * Liveness handling must use this rather than comparing to {@link #WORKER}, otherwise the jobs
+     * of a crashed {@link #SYSTEM_WORKER} would never be re-emitted.
+     *
+     * @return {@code true} if this type is a worker.
+     */
+    public boolean isWorker() {
+        return this == WORKER || this == SYSTEM_WORKER;
+    }
 
     @JsonCreator
     public static ServiceType fromString(final String value) {

--- a/core/src/test/java/io/kestra/core/server/ServiceTypeTest.java
+++ b/core/src/test/java/io/kestra/core/server/ServiceTypeTest.java
@@ -1,0 +1,36 @@
+package io.kestra.core.server;
+
+import java.util.EnumSet;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ServiceTypeTest {
+
+    private static final Set<ServiceType> WORKER_TYPES = EnumSet.of(ServiceType.WORKER, ServiceType.SYSTEM_WORKER);
+
+    @ParameterizedTest
+    @EnumSource(ServiceType.class)
+    void shouldBeWorkerOnlyForWorkerTypes(final ServiceType type) {
+        // Given / When / Then
+        // Liveness handling relies on this to re-emit the jobs of any crashed worker flavour,
+        // so a newly added worker type must be declared in WORKER_TYPES too.
+        assertThat(type.isWorker()).isEqualTo(WORKER_TYPES.contains(type));
+    }
+
+    @Test
+    void shouldParseSystemWorkerIgnoringCase() {
+        // Given / When / Then
+        assertThat(ServiceType.fromString("system_worker")).isEqualTo(ServiceType.SYSTEM_WORKER);
+    }
+
+    @Test
+    void shouldReturnInvalidWhenParsingUnknownType() {
+        // Given / When / Then
+        assertThat(ServiceType.fromString("NOT_A_SERVICE")).isEqualTo(ServiceType.INVALID);
+    }
+}

--- a/executor/src/main/java/io/kestra/executor/DefaultServiceLivenessCoordinator.java
+++ b/executor/src/main/java/io/kestra/executor/DefaultServiceLivenessCoordinator.java
@@ -167,7 +167,7 @@ public class DefaultServiceLivenessCoordinator extends AbstractServiceLivenessTa
     protected void handleAllWorkersForUncleanShutdown(Instant now) {
         serviceInstanceRepository.processAllNonRunningInstances((txContext, serviceInstance) ->
         {
-            if (!serviceInstance.is(ServiceType.WORKER)) {
+            if (!serviceInstance.type().isWorker()) {
                 return;
             }
 
@@ -229,7 +229,7 @@ public class DefaultServiceLivenessCoordinator extends AbstractServiceLivenessTa
 
                 // Eventually restart worker tasks
                 if (
-                    serviceInstance.is(ServiceType.WORKER) &&
+                    serviceInstance.type().isWorker() &&
                         serviceInstance.config().workerTaskRestartStrategy().equals(WorkerTaskRestartStrategy.IMMEDIATELY)
                 ) {
                     log.info("Trigger task restart for non-responding worker after timeout: {}.", serviceInstance.uid());
@@ -332,7 +332,7 @@ public class DefaultServiceLivenessCoordinator extends AbstractServiceLivenessTa
         store
             .findAllInstancesInStates(Set.of(DISCONNECTED, TERMINATING, TERMINATED_GRACEFULLY, TERMINATED_FORCED))
             .stream()
-            .filter(instance -> !instance.is(ServiceType.WORKER)) // WORKERS are handle above.
+            .filter(instance -> !instance.type().isWorker()) // WORKERS are handle above.
             .filter(instance -> instance.isTerminationGracePeriodElapsed(now) || instance.state().equals(TERMINATED_GRACEFULLY))
             .peek(instance -> maybeLogNonRespondingAfterTerminationGracePeriod(instance, now))
             .forEach(instance -> safelyUpdate(instance, NOT_RUNNING, DEFAULT_REASON_FOR_NOT_RUNNING));

--- a/worker/src/main/java/io/kestra/worker/systemworker/SystemWorker.java
+++ b/worker/src/main/java/io/kestra/worker/systemworker/SystemWorker.java
@@ -28,6 +28,10 @@ import lombok.extern.slf4j.Slf4j;
  * Does not implement {@link io.kestra.core.runners.Worker} on purpose so it
  * does not collide with the regular {@link io.kestra.worker.WorkerAgent}
  * singleton in STANDALONE mode where both run in the same JVM.
+ * <p>
+ * Registers as {@link ServiceType#SYSTEM_WORKER} rather than {@link ServiceType#WORKER}: the
+ * {@link io.kestra.core.server.ServiceRegistry} is keyed by service type, so sharing the type with
+ * the {@link io.kestra.worker.WorkerAgent} would make one evict the other in STANDALONE mode.
  */
 @Singleton
 @Requires(property = "kestra.server-type", pattern = "(EXECUTOR|STANDALONE)")
@@ -44,7 +48,7 @@ public class SystemWorker extends AbstractWorker {
         MetricRegistry metricRegistry,
         ServerConfig serverConfig) {
         super(
-            ServiceType.WORKER,
+            ServiceType.SYSTEM_WORKER,
             eventPublisher,
             workerJobExecutor,
             directQueueJobFetcher,


### PR DESCRIPTION
The embedded system worker registered as a regular WORKER, so the services view listed it as a second worker. It now registers as SYSTEM_WORKER and liveness handling uses ServiceType#isWorker(), so its jobs are still re-emitted on crash.

Closes https://github.com/kestra-io/kestra-ee/issues/7918. Closes https://github.com/kestra-io/kestra-ee/issues/9718.

