### PR TITLE
fix(executions): bypass ACL for internal execution-streaming lookups

### DIFF
--- a/core/src/main/java/io/kestra/core/services/ExecutionStreamingService.java
+++ b/core/src/main/java/io/kestra/core/services/ExecutionStreamingService.java
@@ -75,7 +75,9 @@ public class ExecutionStreamingService {
             Map<String, Pair<FluxSink<Event<Execution>>, Flow>> executionSubscribers = subscribers.get(event.executionId());
 
             if (!MapUtils.isEmpty(executionSubscribers)) {
-                Optional<Execution> execution = executionRepository.findById(event.tenantId(), event.executionId());
+                // This fan-out runs on the queue-polling thread, which has no authenticated principal,
+                // so the ACL-enforcing findById would always deny authorization on EE.
+                Optional<Execution> execution = executionRepository.findByIdWithoutAcl(event.tenantId(), event.executionId());
                 if (execution.isEmpty()) {
                     log.error("Unable to find the execution id {}", event.executionId());
                     return;
@@ -126,7 +128,9 @@ public class ExecutionStreamingService {
         // already in a terminal state, deliver the "end" event directly.
         // FluxSink is thread-safe: duplicate complete() calls are no-ops, and next()
         // after complete() is silently dropped, so double-delivery is harmless.
-        executionRepository.findById(flow.getTenantId(), executionId).ifPresent(execution ->
+        // Uses the no-ACL lookup: registerSubscriber's caller thread varies, so the ACL-enforcing findById would always
+        // deny authorization in EE
+        executionRepository.findByIdWithoutAcl(flow.getTenantId(), executionId).ifPresent(execution ->
         {
             if (isStopFollow(flow, execution)) {
                 sink.next(Event.of(execution).id("end"));

--- a/core/src/test/java/io/kestra/core/services/ExecutionStreamingServiceTest.java
+++ b/core/src/test/java/io/kestra/core/services/ExecutionStreamingServiceTest.java
@@ -1,21 +1,27 @@
 package io.kestra.core.services;
 
 import java.util.Collections;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
 
 import org.junit.jupiter.api.Test;
 
+import io.kestra.core.exceptions.DeserializationException;
 import io.kestra.core.junit.annotations.KestraTest;
 import io.kestra.core.models.executions.Execution;
 import io.kestra.core.models.flows.Flow;
 import io.kestra.core.models.flows.GenericFlow;
 import io.kestra.core.models.flows.State;
 import io.kestra.core.queues.BroadcastQueueInterface;
+import io.kestra.core.queues.QueueSubscriber;
 import io.kestra.core.repositories.ExecutionRepositoryInterface;
 import io.kestra.core.repositories.FlowRepositoryInterface;
 import io.kestra.core.runners.ExecutionEventType;
 import io.kestra.core.runners.FollowExecutionEvent;
+import io.kestra.core.utils.Either;
 import io.kestra.core.utils.IdUtils;
 import io.kestra.plugin.core.log.Log;
 
@@ -24,6 +30,10 @@ import jakarta.inject.Inject;
 import reactor.core.publisher.Flux;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 /**
  * Tests for {@link ExecutionStreamingService}.
@@ -101,6 +111,73 @@ class ExecutionStreamingServiceTest {
         // called sink.complete() after finding the terminal execution in the repository.
         // A timeout here means the event was dropped (e.g. findById returned empty) or the
         // event type was not TERMINATED, reproducing the webhook wait:true hang.
+        assertThat(completed.get(5, TimeUnit.SECONDS)).isNull();
+    }
+
+    /**
+     * Guards against kestra-io/kestra-ee#8824 reappearing: the internal fan-out lookup runs on a
+     * queue-polling thread with no authenticated principal, so EE's ACL-enforcing {@code findById}
+     * always denies there. This pins that the streaming service reads via {@code findByIdWithoutAcl}
+     * instead — mocking {@code findById} to always deny reproduces the EE hang if the service
+     * regresses to using it.
+     */
+    @Test
+    @SuppressWarnings("unchecked")
+    void shouldCompleteFluxWhenTheAclFilteredLookupWouldDenyTheExecution() throws Exception {
+        // Given — a flow and an execution, exposed only through findByIdWithoutAcl (findById always
+        // denies, simulating EE's ACL falseCondition() fallback on a non-request thread)
+        var flow = Flow.builder()
+            .tenantId(null)
+            .namespace("io.kestra.tests")
+            .id(IdUtils.create())
+            .tasks(Collections.singletonList(Log.builder().id("log").type(Log.class.getName()).message("test").build()))
+            .build();
+
+        var runningExecution = Execution.newExecution(flow, Collections.emptyList()).withState(State.Type.RUNNING);
+        var terminalExecution = runningExecution.withState(State.Type.SUCCESS);
+
+        var executionRepository = mock(ExecutionRepositoryInterface.class);
+        when(executionRepository.findById(any(), any())).thenReturn(Optional.empty());
+        when(executionRepository.findByIdWithoutAcl(flow.getTenantId(), runningExecution.getId()))
+            .thenReturn(Optional.of(runningExecution)) // registerSubscriber's catch-up guard: not yet terminal
+            .thenReturn(Optional.of(terminalExecution)); // queue-consumer fan-out: now terminal
+
+        var executionService = mock(ExecutionService.class);
+        when(executionService.isTerminated(any(), any())).thenAnswer(invocation ->
+            ((Execution) invocation.getArgument(1)).getState().isTerminated());
+
+        AtomicReference<Consumer<Either<FollowExecutionEvent, DeserializationException>>> queueConsumer = new AtomicReference<>();
+        var queueSubscriber = mock(QueueSubscriber.class);
+        doAnswer(invocation ->
+        {
+            queueConsumer.set(invocation.getArgument(0));
+            return queueSubscriber;
+        }).when(queueSubscriber).subscribe(any());
+
+        var executionQueue = mock(BroadcastQueueInterface.class);
+        when(executionQueue.subscriber()).thenReturn(queueSubscriber);
+
+        var executionStreamingService = new ExecutionStreamingService(executionQueue, executionService, executionRepository);
+        executionStreamingService.startQueueConsumer();
+
+        var subscriberId = IdUtils.create();
+        CompletableFuture<Void> completed = new CompletableFuture<>();
+
+        Flux.<Event<Execution>> create(
+            sink -> executionStreamingService.registerSubscriber(runningExecution.getId(), subscriberId, sink, flow)
+        )
+            .timeout(java.time.Duration.ofSeconds(5))
+            .doFinally(sig -> executionStreamingService.unregisterSubscriber(runningExecution.getId(), subscriberId))
+            .subscribe(
+                event -> { /* progress events — not relevant here */ },
+                completed::completeExceptionally,
+                () -> completed.complete(null)
+            );
+
+        // Deliver the TERMINATED FollowExecutionEvent through the captured queue consumer, exactly
+        // as the real queue-polling thread would — with no request context in scope.
+        queueConsumer.get().accept(Either.left(new FollowExecutionEvent(terminalExecution, ExecutionEventType.TERMINATED)));
+
         assertThat(completed.get(5, TimeUnit.SECONDS)).isNull();
     }
 }

--- a/webserver/src/main/java/io/kestra/webserver/services/ExecutionDependenciesStreamingService.java
+++ b/webserver/src/main/java/io/kestra/webserver/services/ExecutionDependenciesStreamingService.java
@@ -77,7 +77,14 @@ public class ExecutionDependenciesStreamingService {
             }
 
             String executionId = either.getLeft().executionId();
-            Execution execution = executionRepositoryInterface.findById(either.getLeft().tenantId(), executionId).orElseThrow();
+            // This fan-out runs on the queue-polling thread, which has no authenticated principal,
+            // so the ACL-enforcing findById would always deny authorization on EE.
+            Optional<Execution> maybeExecution = executionRepositoryInterface.findByIdWithoutAcl(either.getLeft().tenantId(), executionId);
+            if (maybeExecution.isEmpty()) {
+                log.error("Unable to find the execution id {}", executionId);
+                return;
+            }
+            Execution execution = maybeExecution.get();
             Optional<String> correlationId = execution.getLabels().stream().filter(label -> label.key().equals(CORRELATION_ID)).findAny().map(label -> label.value());
 
             // Get all subscribers for this correlationId


### PR DESCRIPTION
## Summary

Fixes kestra-io/kestra-ee#8824 — a `Webhook` trigger with `wait: true` hangs indefinitely in EE's distributed deployment, even though the execution completes successfully.

**Root cause:** `ExecutionStreamingService`'s queue-consumer fan-out and its post-registration catch-up guard both re-read the execution via the ACL-enforcing `executionRepository.findById(tenantId, id)`. That call runs on a queue-polling thread with no authenticated principal. In EE, the ACL override degrades to `DSL.falseCondition()` when there is no allowed namespace for the (absent) user — so the lookup always returns empty on a background thread, the terminal SSE event is silently dropped. This explains every symptom in the issue: standalone works (ACL bypassed off-request-thread there), distributed fails, the errors keep appearing after the execution is terminal and persisted, and `/executions/search` still finds it (that runs inside the authenticated request).

`ExecutionDependenciesStreamingService` (the execution-dependencies SSE panel) has the exact same shape of bug.

## Changes

- `core/.../services/ExecutionStreamingService.java` — switch both internal lookups (queue-consumer fan-out, post-registration catch-up guard) to `findByIdWithoutAcl`. Authorization for who may follow an execution is already enforced where subscribers register (`/follow`'s `isExecutionAllowedOrThrow` in EE, or the webhook's secret key for the deliberately anonymous `wait: true` path), so bypassing ACL on these internal reads is safe.
- `webserver/.../services/ExecutionDependenciesStreamingService.java` — same fix, plus replaces a bare `.orElseThrow()` with a logged early-return (throwing out of a queue-subscriber callback was a separate hazard: it could crash/redelivery-loop the shared queue consumer under `fail-fast=true`).
- `core/.../services/ExecutionStreamingServiceTest.java` — new regression test that mocks `findById` to always deny (simulating the EE ACL fallback) while `findByIdWithoutAcl` returns the real execution. Verified this test fails against the pre-fix code and passes with the fix.

## Test plan

- [x] `./gradlew :core:test --tests "ExecutionStreamingServiceTest"` — both tests pass
- [x] New test verified to fail against the pre-fix code (reproduces `Unable to find the execution id ... for event type TERMINATED`) and pass with the fix
- [x] `:core:compileTestJava` / `:webserver:compileJava` — clean, no new warnings
- [x] Code review via the `code-review` agent — approved, no blocking issues
- [ ] Manual end-to-end verification on a distributed EE stack (postgres + separate webserver/executor, `kestra.server-type: WEBSERVER`) with the flow from the issue — OSS cannot reproduce EE's ACL divergence, so this is the only check that fully closes the loop