### PR TITLE
fix(ci): fail the contributor onboarding workflow when the welcome action errors

### DIFF
--- a/.github/workflows/welcome.yml
+++ b/.github/workflows/welcome.yml
@@ -21,6 +21,8 @@ jobs:
           GH_PAT_READ_ORG: ${{ secrets.GH_READ_ORG_TOKEN }}
         with:
           skip-internal-contributors: true
+          # The action defaults to false, which turns a broken GH_READ_ORG_TOKEN into a green job that silently welcomes nobody.
+          fail-on-error: true
           pr-opened-msg: |
             ### Hey @{fc-author} :wave: 
 


### PR DESCRIPTION
Closes https://github.com/kestra-io/kestra/issues/17940.

The Contributor Onboarding workflow has been reporting ✅ while welcoming nobody.

## What

Set `fail-on-error: true` on the `plbstl/first-contribution` step so an error surfaces as a red check instead of a green one.

## Why

`fail-on-error` defaults to `false`. In that mode `run()` catches every error and calls `core.error()` rather than `core.setFailed()`, so the step still exits 0.

Because we pass `skip-internal-contributors: true`, the very first thing the action does is an org-membership check — and `is_internal_contributor()` only swallows a `404`; anything else is re-thrown. So an invalid `GH_READ_ORG_TOKEN` aborts the action *before* `add_reactions` and `create_comment`, and the job still goes green.

That is the current state. Every run in the retained log window fails identically:

```
Checking if @<author> is an org member of `kestra-io`.
Org membership check returned status: 401
##[error]Bad credentials - https://docs.github.com/rest
```

Oldest retained run showing this is from 2026-07-21, so first-time contributors have gone unwelcomed for at least two and a half weeks. Recent confirmation on https://github.com/kestra-io/kestra/pull/17865 — there is no bot comment on it; the contributor was welcomed by hand.

## What this does *not* fix

The credential itself. `GH_READ_ORG_TOKEN` is an org-level secret (this repo only defines `KESTRA_CI_EEBUILD_WEBHOOK_URL` and `KESTRA_WEBHOOK_KEY`), and it renders as `***` in the logs — so it is set, but the PAT behind it has expired or been revoked. **An org admin still needs to regenerate a PAT with `read:org` scope and update the secret.** This PR only ensures we find out immediately next time, rather than weeks later.

Note the fallback shape if rotating the token is not immediate: when `GH_PAT_READ_ORG` is absent entirely the action logs `GH_PAT_READ_ORG env variable is unavailable` and *continues* to welcome normally. So dropping the `env:` line is a viable stopgap — the cost is that a genuinely new employee's first PR would get the public welcome message (existing staff are still filtered out by the prior-commits check in `is_first_time_contributor`).

## Companion PR

Same one-line change in `kestra-io/docs`, which runs an identical copy of this workflow and fails the same way.
