### PR TITLE
fix(executions): show the BOOL input toggle as on when its default is true, and delete the unused normalize twin that let it regress

### DIFF
--- a/ui/src/utils/inputs.ts
+++ b/ui/src/utils/inputs.ts
@@ -165,8 +165,13 @@ export function normalize(type: InputType | undefined, value: any) {
 
     if (type === "BOOLEAN" && value === undefined) {
         res = "undefined"
-    } else if (type === "BOOL" && value === undefined) {
-        res = false
+    } else if (type === "BOOL") {
+        // `defaults` is a Property, which serialises as its expression string, so `defaults: true`
+        // reaches the form as the string "true". KsSwitch (el-switch) only accepts a real boolean:
+        // given anything else it emits `update:modelValue` = false during setup, which both turns the
+        // toggle off and marks the input as user-edited — so the validate response can no longer
+        // restore the default. Coerce here.
+        res = value === true || value === "true"
     } else if (value === null || value === undefined) {
         res = undefined
     } else if (type === "DATE" || type === "DATETIME") {
@@ -200,8 +205,10 @@ export function normalizeForComponents(type: InputType | undefined, value: any) 
         res = JSON.stringify(res).toString()
     } else if (type === "BOOLEAN" && value === undefined) {
         res = "undefined"
-    } else if (type === "BOOL" && value === undefined) {
-        res = false
+    } else if (type === "BOOL") {
+        // See normalize(): a BOOL default arrives as the string "true"/"false" and el-switch resets
+        // anything that isn't a real boolean.
+        res = value === true || value === "true"
     } else if (type === "STRING" && Array.isArray(res)) {
         res = res.toString()
     }

--- a/ui/src/utils/inputs.ts
+++ b/ui/src/utils/inputs.ts
@@ -191,26 +191,3 @@ export function normalize(type: InputType | undefined, value: any) {
     }
     return res
 }
-
-export function normalizeForComponents(type: InputType | undefined, value: any) {
-    let res = value
-
-    if (value === null) {
-        res = undefined
-    } else if (type === "DATE" || type === "DATETIME") {
-        res = moment(res).toISOString()
-    } else if (type === "TIME") {
-        res = moment().startOf("day").add(res, "seconds").toString()
-    } else if (type === "ARRAY") {
-        res = JSON.stringify(res).toString()
-    } else if (type === "BOOLEAN" && value === undefined) {
-        res = "undefined"
-    } else if (type === "BOOL") {
-        // See normalize(): a BOOL default arrives as the string "true"/"false" and el-switch resets
-        // anything that isn't a real boolean.
-        res = value === true || value === "true"
-    } else if (type === "STRING" && Array.isArray(res)) {
-        res = res.toString()
-    }
-    return res
-}

--- a/ui/tests/unit/components/inputs/inputsFormBoolDefault.spec.ts
+++ b/ui/tests/unit/components/inputs/inputsFormBoolDefault.spec.ts
@@ -1,0 +1,157 @@
+import {afterEach, beforeEach, describe, expect, test, vi} from "vitest"
+import {flushPromises, mount} from "@vue/test-utils"
+import {createPinia, setActivePinia} from "pinia"
+import {createI18n} from "vue-i18n"
+import KestraDesignSystem from "@kestra-io/design-system"
+import InputsForm from "../../../../src/components/inputs/InputsForm.vue"
+import {useExecutionsStore} from "../../../../src/stores/executions"
+
+vi.mock("vue-router", () => ({
+    useRoute: () => ({query: {}, params: {}, name: "flow"}),
+    useRouter: () => ({replace: vi.fn(), push: vi.fn()}),
+}))
+
+const globalConfig = {
+    plugins: [
+        createI18n({legacy: false, locale: "en", fallbackWarn: false, missingWarn: false}),
+        KestraDesignSystem,
+    ],
+}
+
+const flow = {namespace: "company.team", id: "get_data"} as any
+
+/**
+ * Stubs the validate round-trip the way `FlowInputOutput` actually behaves: `defaults` is resolved
+ * server-side ONLY when the form submits no value for the input; a submitted value is echoed back
+ * with `isDefault: false`. A mock that unconditionally answers "the default is true" would paper
+ * over this bug, because the toggle's spurious reset writes `false` into the form and the very next
+ * round-trip is what cements it as the user's own choice.
+ * `defaults` itself is stringified: Input.defaults is a Property, which serialises as its expression.
+ */
+function stubValidate(id: string, defaults: boolean | undefined) {
+    return vi.fn(({formData}: {formData?: FormData}) => {
+        const submitted = formData?.get(id) ?? null
+        const value = submitted !== null ? submitted === "true" : defaults
+        return Promise.resolve({
+            status: 200,
+            headers: {},
+            data: {
+                checks: [],
+                inputs: [{
+                    enabled: true,
+                    isDefault: submitted === null && defaults !== undefined,
+                    value,
+                    input: {id, type: "BOOL", required: false, defaults: defaults === undefined ? undefined : String(defaults)},
+                }],
+            },
+        })
+    })
+}
+
+// Mounted for real (no `shallow`): the bug lives in el-switch's own setup, which resets a
+// non-boolean modelValue to false — a stubbed switch would happily accept the string "true"
+// and the regression would sail straight through.
+function mountForm(inputs: any[]) {
+    return mount(InputsForm, {
+        global: globalConfig,
+        props: {flow, initialInputs: inputs as any},
+    })
+}
+
+function isToggleOn(wrapper: ReturnType<typeof mountForm>, id = "mybool") {
+    const input = wrapper.find(`[data-testid="input-form-${id}"] input`)
+    return (input.element as HTMLInputElement).checked
+}
+
+// A BOOL `defaults` reaches the form as the STRING "true", because Input.defaults is a Property and
+// Property serialises as its expression. el-switch compares modelValue against activeValue by
+// identity, so "true" !== true: it emits `update:modelValue` = false during setup, which turns the
+// toggle off AND runs the form's change handler. That change bumps the validate generation, so the
+// in-flight response carrying the real default is dropped as stale and the follow-up round-trip
+// submits `false` — the toggle is then off for good and the execution runs with the wrong value.
+// Regression, fixed more than once: https://github.com/kestra-io/kestra-ee/issues/9772 (and /8978).
+describe("InputsForm BOOL default", () => {
+    beforeEach(() => {
+        setActivePinia(createPinia())
+    })
+
+    afterEach(() => {
+        document.body.innerHTML = ""
+    })
+
+    test("renders the toggle ON for a `defaults: true` that arrives as the string \"true\"", async () => {
+        const store = useExecutionsStore()
+        store.validateExecution = stubValidate("mybool", true)
+
+        const wrapper = mountForm([{id: "mybool", type: "BOOL", defaults: "true"}])
+        await flushPromises()
+
+        expect(wrapper.vm.inputsValues.mybool).toBe(true)
+        expect(isToggleOn(wrapper)).toBe(true)
+    })
+
+    test("does not let the toggle mark itself user-edited, so the default survives validation", async () => {
+        const store = useExecutionsStore()
+        store.validateExecution = stubValidate("mybool", true)
+
+        const wrapper = mountForm([{id: "mybool", type: "BOOL", defaults: "true"}])
+        await flushPromises()
+
+        // The el-switch reset that caused the bug also fired @update:model-value, which clears
+        // isDefault and makes the next validate submit `false` as if the user had picked it.
+        expect(wrapper.vm.inputsMetaData[0].isDefault).toBe(true)
+        expect(store.validateExecution).toHaveBeenCalledTimes(1)
+        expect(wrapper.emitted("update:modelValue")?.at(-1)?.[0]).toEqual({mybool: true})
+    })
+
+    test("renders the toggle OFF for `defaults: false`", async () => {
+        const store = useExecutionsStore()
+        store.validateExecution = stubValidate("mybool", false)
+
+        const wrapper = mountForm([{id: "mybool", type: "BOOL", defaults: "false"}])
+        await flushPromises()
+
+        expect(wrapper.vm.inputsValues.mybool).toBe(false)
+        expect(isToggleOn(wrapper)).toBe(false)
+    })
+
+    test("renders the toggle OFF when there is no default", async () => {
+        const store = useExecutionsStore()
+        store.validateExecution = stubValidate("mybool", undefined)
+
+        const wrapper = mountForm([{id: "mybool", type: "BOOL", required: false}])
+        await flushPromises()
+
+        expect(wrapper.vm.inputsValues.mybool).toBe(false)
+        expect(isToggleOn(wrapper)).toBe(false)
+    })
+
+    test("still lets the user turn a defaulted-on toggle off", async () => {
+        const store = useExecutionsStore()
+        store.validateExecution = stubValidate("mybool", true)
+
+        const wrapper = mountForm([{id: "mybool", type: "BOOL", defaults: "true"}])
+        await flushPromises()
+
+        await wrapper.find("[data-testid=\"input-form-mybool\"] input").setValue(false)
+        await flushPromises()
+
+        expect(wrapper.vm.inputsValues.mybool).toBe(false)
+        expect(isToggleOn(wrapper)).toBe(false)
+        expect(wrapper.vm.inputsMetaData[0].isDefault).toBe(false)
+    })
+
+    // A BOOL nested in a FORM goes through the wizard's dotted-leaf path; same coercion must apply.
+    test("applies the coercion to a BOOL nested in a FORM (dotted leaf id)", async () => {
+        const store = useExecutionsStore()
+        store.validateExecution = stubValidate("setup.mybool", true)
+
+        const wrapper = mountForm([
+            {id: "setup", type: "FORM", inputs: [{id: "mybool", type: "BOOL", defaults: "true"}]},
+        ])
+        await flushPromises()
+
+        expect(wrapper.vm.inputsValues["setup.mybool"]).toBe(true)
+        expect(isToggleOn(wrapper, "setup.mybool")).toBe(true)
+    })
+})

--- a/ui/tests/unit/utils/inputs.spec.ts
+++ b/ui/tests/unit/utils/inputs.spec.ts
@@ -1,5 +1,5 @@
 import {describe, expect, it} from "vitest"
-import {flattenInputs, unflattenToForms, formChildName, buildWizardSteps, normalize, normalizeForComponents} from "../../../src/utils/inputs"
+import {flattenInputs, unflattenToForms, formChildName, buildWizardSteps, normalize} from "../../../src/utils/inputs"
 import {inputsToFormData} from "../../../src/utils/submitTask"
 
 const momentStub = {
@@ -31,15 +31,6 @@ describe("normalize for BOOL always yields a real boolean", () => {
         for (const value of ["true", "false", true, false, undefined, null, "", "TRUE", 1, 0, {}]) {
             expect(typeof normalize("BOOL", value)).toBe("boolean")
         }
-    })
-
-    // Same rule, second copy of the helper — kept in lockstep so fixing one and not the other
-    // can't reintroduce the bug.
-    it("applies the same coercion in normalizeForComponents", () => {
-        expect(normalizeForComponents("BOOL", "true")).toBe(true)
-        expect(normalizeForComponents("BOOL", "false")).toBe(false)
-        expect(normalizeForComponents("BOOL", true)).toBe(true)
-        expect(normalizeForComponents("BOOL", undefined)).toBe(false)
     })
 
     // BOOLEAN is the retired input type; it uses a radio group with an "undefined" third state,

--- a/ui/tests/unit/utils/inputs.spec.ts
+++ b/ui/tests/unit/utils/inputs.spec.ts
@@ -1,10 +1,54 @@
 import {describe, expect, it} from "vitest"
-import {flattenInputs, unflattenToForms, formChildName, buildWizardSteps} from "../../../src/utils/inputs"
+import {flattenInputs, unflattenToForms, formChildName, buildWizardSteps, normalize, normalizeForComponents} from "../../../src/utils/inputs"
 import {inputsToFormData} from "../../../src/utils/submitTask"
 
 const momentStub = {
     $moment: (_d: any) => ({toISOString: () => "iso", format: (_f: string) => "fmt"}),
 }
+
+// Regression guard, fixed more than once: `defaults` is a Property, so it crosses the wire as its
+// expression STRING — a `defaults: true` BOOL arrives as "true". el-switch only accepts a real
+// boolean; anything else makes it emit `update:modelValue` = false during setup, which turns the
+// toggle off AND marks the input as user-edited so the default can never come back.
+// See https://github.com/kestra-io/kestra-ee/issues/9772 (and /8978 before it).
+describe("normalize for BOOL always yields a real boolean", () => {
+    it("coerces the string form of a default", () => {
+        expect(normalize("BOOL", "true")).toBe(true)
+        expect(normalize("BOOL", "false")).toBe(false)
+    })
+
+    it("passes real booleans through", () => {
+        expect(normalize("BOOL", true)).toBe(true)
+        expect(normalize("BOOL", false)).toBe(false)
+    })
+
+    it("falls back to false when there is no value at all", () => {
+        expect(normalize("BOOL", undefined)).toBe(false)
+        expect(normalize("BOOL", null)).toBe(false)
+    })
+
+    it("never yields a non-boolean, whatever the input", () => {
+        for (const value of ["true", "false", true, false, undefined, null, "", "TRUE", 1, 0, {}]) {
+            expect(typeof normalize("BOOL", value)).toBe("boolean")
+        }
+    })
+
+    // Same rule, second copy of the helper — kept in lockstep so fixing one and not the other
+    // can't reintroduce the bug.
+    it("applies the same coercion in normalizeForComponents", () => {
+        expect(normalizeForComponents("BOOL", "true")).toBe(true)
+        expect(normalizeForComponents("BOOL", "false")).toBe(false)
+        expect(normalizeForComponents("BOOL", true)).toBe(true)
+        expect(normalizeForComponents("BOOL", undefined)).toBe(false)
+    })
+
+    // BOOLEAN is the retired input type; it uses a radio group with an "undefined" third state,
+    // so it must NOT be swept into the boolean coercion.
+    it("leaves the retired BOOLEAN type's tri-state alone", () => {
+        expect(normalize("BOOLEAN", undefined)).toBe("undefined")
+        expect(normalize("BOOLEAN", "true")).toBe("true")
+    })
+})
 
 describe("flattenInputs", () => {
     it("returns [] for undefined", () => {


### PR DESCRIPTION
Closes https://github.com/kestra-io/kestra-ee/issues/9772.
Closes https://github.com/kestra-io/kestra/issues/13214.

## What

A BOOL input declared with `defaults: true` rendered with its toggle **off**, and the execution then ran with `false`.

`Input.defaults` is a `Property`, which serialises as its expression string — so `defaults: true` reaches the form as the **string** `"true"`. `el-switch` compares `modelValue` against `activeValue` by identity, and `"true" !== true`, so during its own setup it emits `update:modelValue` = `false`. That does two things: it turns the toggle off, and it runs the form's change handler. The change bumps `inputGeneration`, so the in-flight validate response carrying the real default is discarded as stale, and the follow-up round-trip submits `false` — the toggle is off for good.

The fix coerces a BOOL value to a real boolean in `normalize()`, so the switch accepts the default.

This affects the flow execute form and, through the same shared `InputsForm`, the EE Apps `CreateExecutionForm` block.

## Why it came back, and what stops the next one

This is a regression. The identical fix landed on `releases/v1.3.x` as 6265761bfa (for https://github.com/kestra-io/kestra-ee/issues/8978) but **never reached `develop`** — `git merge-base --is-ancestor 6265761bfa develop` is false. There were no tests on either branch, so nothing caught the drift.

There was also a second way for it to come back, which this PR removes. `normalizeForComponents` was a near-duplicate of `normalize` with **no callers anywhere** — not in `ui/src`, `ui/tests`, `ui/packages`, `kestra-ee/ui-ee` or `ui-libs`. It had already silently drifted from the function it mirrors: it checked `value === null` first (so a null BOOL yielded `undefined` rather than `false`) and never grew the `MULTISELECT`, `JSON` and `YAML` branches `normalize` gained later. Keeping it meant writing every normalization rule twice, which is exactly how a fix goes missing again — someone edits the copy they landed on and the two diverge. It is deleted in its own commit, so the fix stays reviewable on its own.

## Tests

Two layers, since the previous fixes had none:

- `tests/unit/utils/inputs.spec.ts` — `normalize` always yields a real boolean for BOOL (`"true"`, `"false"`, real booleans, `undefined`, `null`), and the retired `BOOLEAN` type's `"undefined"` tri-state is left alone.
- `tests/unit/components/inputs/inputsFormBoolDefault.spec.ts` — mounts `InputsForm` **for real** (no `shallow`), because the bug lives inside `el-switch`'s setup and a stubbed switch would happily accept the string. The validate stub mirrors `FlowInputOutput` (a default is resolved only when the form submits no value), which is what makes the stale-response round-trip reproducible. Covers: toggle on for `defaults: true`, `isDefault` not clobbered, off for `defaults: false`, off with no default, the user can still turn it off, and a BOOL nested in a `FORM` (dotted leaf id).

Verified both directions — with the fix reverted, the helper assertions and the 3 "should be on" component tests fail; with it, the full OSS unit suite is green (139 files / 1156 tests). `npm run check:types`, `oxlint` and `eslint` clean.
