### PR TITLE
fix(scheduler): anchor schedule next date on now when the trigger definition changes

### DIFF
--- a/core/src/main/java/io/kestra/core/models/triggers/Trigger.java
+++ b/core/src/main/java/io/kestra/core/models/triggers/Trigger.java
@@ -172,7 +172,12 @@ public class Trigger extends TriggerContext implements HasUID {
 
         if (abstractTrigger instanceof PollingTriggerInterface pollingTriggerInterface) {
             try {
-                nextDate = pollingTriggerInterface.nextEvaluationDate(conditionContext, lastTrigger);
+                // A Schedulable whose definition just changed has no history under that new definition, so we anchor
+                // the next date on now instead of on the last evaluation date. Anchoring on the last evaluation date
+                // projects the new schedule from a stale point and can yield a date in the past, which the scheduler
+                // then fires straight away as a missed schedule.
+                Optional<Trigger> anchor = abstractTrigger instanceof Schedulable ? Optional.empty() : lastTrigger;
+                nextDate = pollingTriggerInterface.nextEvaluationDate(conditionContext, anchor);
             } catch (InvalidTriggerConfigurationException e) {
                 disabled = true;
             }

--- a/scheduler/src/test/java/io/kestra/scheduler/SchedulerTriggerDefinitionChangeTest.java
+++ b/scheduler/src/test/java/io/kestra/scheduler/SchedulerTriggerDefinitionChangeTest.java
@@ -1,0 +1,100 @@
+package io.kestra.scheduler;
+
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+import io.kestra.core.models.flows.Flow;
+import io.kestra.core.models.triggers.RecoverMissedSchedules;
+import io.kestra.core.models.triggers.Trigger;
+import io.kestra.plugin.core.trigger.Schedule;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit tests for the next execution date computed when a Schedule definition changes.
+ *
+ * <p>Editing a cron makes {@code FlowListeners} run two steps back to back: the per-flow listener
+ * writes a new trigger state through {@link Trigger#of(io.kestra.core.models.flows.FlowInterface,
+ * io.kestra.core.models.triggers.AbstractTrigger, io.kestra.core.models.conditions.ConditionContext,
+ * Optional)}, then {@code AbstractScheduler.initializedTriggers} may correct it through
+ * {@link AbstractScheduler#computeScheduleInitialization}. Neither step may leave a next execution
+ * date in the past, otherwise the scheduler loop fires the freshly edited schedule immediately as a
+ * missed one.
+ */
+class SchedulerTriggerDefinitionChangeTest {
+
+    private static final DateTimeFormatter CRON_MINUTE_HOUR = DateTimeFormatter.ofPattern("m H");
+
+    private static Flow flow(Schedule schedule) {
+        return Flow.builder()
+            .id("flow")
+            .namespace("io.kestra.unittest")
+            .revision(1)
+            .triggers(List.of(schedule))
+            .build();
+    }
+
+    private static Schedule schedule(ZonedDateTime dailyAt, RecoverMissedSchedules recoverMissedSchedules) {
+        return Schedule.builder()
+            .id("schedule")
+            .type(Schedule.class.getName())
+            .cron(CRON_MINUTE_HOUR.format(dailyAt) + " * * *")
+            .recoverMissedSchedules(recoverMissedSchedules)
+            .build();
+    }
+
+    @ParameterizedTest
+    @EnumSource(RecoverMissedSchedules.class)
+    void shouldNotScheduleInThePastWhenCronIsChangedToAnAlreadyPassedTime(RecoverMissedSchedules recoverMissedSchedules) throws Exception {
+        // Given
+        ZonedDateTime now = ZonedDateTime.now();
+        // the stored trigger was last evaluated under the previous cron, ten minutes ago
+        Trigger stored = Trigger.builder()
+            .namespace("io.kestra.unittest")
+            .flowId("flow")
+            .triggerId("schedule")
+            .date(now.minusMinutes(10).truncatedTo(ChronoUnit.SECONDS))
+            .nextExecutionDate(now.plusDays(1))
+            .build();
+        // the new cron points at a time that already passed today, but after the stored evaluation date
+        Schedule updated = schedule(now.minusMinutes(5), recoverMissedSchedules);
+
+        // When
+        Trigger afterFlowListener = Trigger.of(flow(updated), updated, null, Optional.of(stored));
+        Trigger afterInitialization = AbstractScheduler
+            .computeScheduleInitialization(updated, afterFlowListener, recoverMissedSchedules, null)
+            .orElse(afterFlowListener);
+
+        // Then
+        assertThat(afterFlowListener.getNextExecutionDate()).isAfter(now);
+        assertThat(afterInitialization.getNextExecutionDate()).isAfter(now);
+    }
+
+    @Test
+    void shouldKeepTheNextOccurrenceWhenCronIsChangedToAnUpcomingTime() throws Exception {
+        // Given
+        ZonedDateTime now = ZonedDateTime.now();
+        Trigger stored = Trigger.builder()
+            .namespace("io.kestra.unittest")
+            .flowId("flow")
+            .triggerId("schedule")
+            .date(now.minusMinutes(10).truncatedTo(ChronoUnit.SECONDS))
+            .nextExecutionDate(now.plusDays(1))
+            .build();
+        ZonedDateTime upcoming = now.plusMinutes(5).truncatedTo(ChronoUnit.MINUTES);
+        Schedule updated = schedule(upcoming, RecoverMissedSchedules.ALL);
+
+        // When
+        Trigger afterFlowListener = Trigger.of(flow(updated), updated, null, Optional.of(stored));
+
+        // Then
+        assertThat(afterFlowListener.getNextExecutionDate()).isEqualTo(upcoming.truncatedTo(ChronoUnit.SECONDS));
+    }
+}


### PR DESCRIPTION
### ✨ Description

Editing a cron on a flow could make the schedule fire immediately, once, right after saving.

When a trigger definition changes, the flow-change listener recomputes the next execution date through `Trigger.of(flow, abstractTrigger, conditionContext, lastTrigger)`, which anchors the computation on the **stored trigger's last evaluation date**. That date belongs to the *previous* definition. Projecting the new cron forward from that stale anchor can produce a date in the past, and the one-second scheduler loop then picks it up and fires the freshly edited schedule as a "missed" one.

A `Schedulable` whose definition just changed has no history under that new definition, so this anchors on `now` instead — the same computation `AbstractScheduler.initializedTriggers` already performs for a brand new schedulable. An edited cron and a new cron now behave identically.

This also removes a race. `FlowListeners` runs two steps back to back on a flow change:

1. `notifyConsumersEach` → the listener above → writes the bad date;
2. `notifyConsumers` → `initializedTriggers` → `computeScheduleInitialization`, which overwrites it — but **only** for `recoverMissedSchedules` `NONE` and `LAST`.

So `ALL` (the default) failed every time, while `NONE`/`LAST` were merely papered over afterwards and could still lose the race to the scheduler loop. Fixing step 1 means step 2 has nothing left to repair: `NONE` recomputes the same value (no write) and `LAST`'s `previousDate.isAfter(current.getDate())` is now false.

The change is in `core`, so it covers both runners — `AbstractJdbcTriggerRepository#update` and, in EE, `KafkaSchedulerTriggerState#update` both reach the same factory. That 4-arg `Trigger.of` has exactly one caller chain, reached only from `FlowService.findUpdatedTrigger`, so the "no history under the new definition" assumption always holds and no legitimate `recoverMissedSchedules` catch-up is discarded.

### 🔗 Related Issue

No public GitHub issue — reported through support as Pylon ticket #2150 ("Triggers executing when saving flow"), against 1.3.30.

### 🛠️ Backend Checklist

- [x] Code compiles successfully and passes all checks
- [x] All unit and integration tests pass — see the exact scope run locally under Additional Notes

### 📝 Additional Notes

**New test** — `SchedulerTriggerDefinitionChangeTest`, a plain unit test in the style of the neighbouring `SchedulerInitializeTriggersTest`. It models the two-step `FlowListeners` sequence and asserts neither step leaves a next execution date in the past, parameterized over all three `RecoverMissedSchedules` values, plus a case pinning that a cron moved to an *upcoming* time still lands on that occurrence.

With the fix reverted, 3 of its 4 cases fail — all three on the *first* assertion, confirming the bad write happens regardless of mode:

```
FAIL [1] recoverMissedSchedules=LAST   expected 2026-08-07T14:29 to be strictly after 14:34:44
FAIL [2] recoverMissedSchedules=NONE   (same)
FAIL [3] recoverMissedSchedules=ALL    (same)
```

**Test suites run locally** (not the full build):

| suite | result |
|---|---|
| `:scheduler:test` (full module) | 29 tests, all pass |
| `:core:test --tests "io.kestra.plugin.core.trigger.*" --tests "io.kestra.core.models.triggers.*"` | 35 tests, all pass |
| `:jdbc-h2:test --tests "*Trigger*"` | 29 tests, all pass |

**Verified end to end** against a local OSS standalone instance on this branch. Repro: save a flow with `cron: "0 7 * * *"`, wait ~3 min, then change the cron to a time 2 min in the past and save.

- Before: `ALL` and the default fired immediately every time; `NONE` fired on 1 of 6 attempts (the race).
- After: 6 rounds × 3 modes = 18 cron edits to an already-passed time, **0 executions**; every trigger correctly advanced to the next day's occurrence.

**Not a recent regression** — `git diff v1.3.26..v1.3.31` over `scheduler/`, the trigger models, `Schedule` and the JDBC trigger repository touches only worker-dispatch locking. The reporter's "prod 1.3.26 is fine, dev 1.3.30 is broken" is explained by how often crons get edited in each environment, not by a code change.
