### PR TITLE
fix: keep execute button visible in execution modal with many inputs

### DIFF
--- a/ui/src/components/flows/TriggerFlow.vue
+++ b/ui/src/components/flows/TriggerFlow.vue
@@ -318,3 +318,24 @@
         padding-right: 0;
     }
 </style>
+
+<style lang="scss">
+    /* Constrain the execution dialog height so the footer (Execute button)
+       stays visible without scrolling the entire modal. Only the dialog body
+       scrolls; the header and footer remain fixed.  */
+    #execute-flow-dialog {
+        display: flex;
+        flex-direction: column;
+        max-height: 80vh;
+
+        .kel-dialog__body {
+            overflow-y: auto;
+            flex: 1;
+            min-height: 0;
+        }
+
+        .kel-dialog__footer {
+            flex-shrink: 0;
+        }
+    }
+</style>


### PR DESCRIPTION
## Summary
- Fixed the execution modal so the Execute button is always visible at the bottom
- Added scrollable area for inputs section while keeping the footer fixed
- Users no longer need to scroll past all inputs to find the Execute button

Closes #17943

## Test Plan
- Open the execution modal for a flow with many inputs
- Verify the Execute button is visible without scrolling
- Verify inputs are scrollable within their section
- Verify normal flows with few inputs still work correctly