### PR TITLE
fix: show property description instead of only title in compact plugin docs

### DIFF
--- a/ui/src/components/plugins/schema/SchemaPropertiesSection.vue
+++ b/ui/src/components/plugins/schema/SchemaPropertiesSection.vue
@@ -86,7 +86,7 @@
                             >
                                 <slot
                                     name="markdown"
-                                    :content="property.title || property.description || ''"
+                                    :content="property.description || property.title || ''"
                                 />
                             </div>
                         </div>


### PR DESCRIPTION
## Summary
Fixes #17948

In the compact properties view (`SchemaPropertiesSection.vue`), the template used `property.title || property.description` to render property documentation. This meant the `description` was never displayed when a `title` was also present, causing plugins to only show the title text instead of the more detailed description.

**Before:** `property.title || property.description` (title takes priority, description never shown)  
**After:** `property.description || property.title` (description takes priority, falls back to title)

## Changes
- `ui/src/components/plugins/schema/SchemaPropertiesSection.vue`: Swapped the priority in the compact property description slot content from `property.title || property.description` to `property.description || property.title`

## Test plan
- [x] Verified the fix in compact mode property rendering
- [x] Non-compact mode uses `PropertyDetail` component and is unaffected
- [x] Falls back to `title` when no `description` is available