### PR TITLE
fix: align state and duration items in task run header

### DIFF
--- a/ui/src/components/executions/TaskRunLine.vue
+++ b/ui/src/components/executions/TaskRunLine.vue
@@ -222,10 +222,6 @@
 </script>
 
 <style scoped lang="scss">
-    .task-duration {
-        padding: .375rem 0;
-    }
-
     .taskrun-header,
     .attempt-header {
         display: flex;
@@ -243,9 +239,18 @@
             font-size: var(--ks-font-size-xs)
         }
 
-        .task-duration small {
-            white-space: nowrap;
-            color: var(--ks-text-secondary);
+        .task-duration {
+            min-width: 70px;
+
+            small {
+                white-space: nowrap;
+                color: var(--ks-text-secondary);
+            }
+        }
+
+        .task-status,
+        .task-duration {
+            flex-shrink: 0;
         }
 
     }


### PR DESCRIPTION
## Summary
Fixes #17961

Aligned the state indicator (KsExecutionStatus) and duration text (Duration component) in task run headers so they look consistent across rows.

## Changes
- `ui/src/components/executions/TaskRunLine.vue`:
  - Added `min-width: 70px` to `.task-duration` so duration values align across multiple task rows
  - Added `flex-shrink: 0` to both `.task-status` and `.task-duration` to prevent them from being squeezed by the flex layout
  - Removed unnecessary vertical padding from `.task-duration` that caused height inconsistency with the state square
  - Moved `.task-duration small` styling inside the `.task-duration` block for cleaner scoping

## Test plan
- [x] Verified state squares and duration text are now aligned at the same height
- [x] Duration values with different lengths (e.g., "2.00s" vs "1m 30s") align consistently
- [x] Both `.taskrun-header` and `.attempt-header` share the same alignment