### PR TITLE
fix: reduce task header height and align durations in execution logs

### DIFF
--- a/ui/src/components/executions/TaskRunLine.vue
+++ b/ui/src/components/executions/TaskRunLine.vue
@@ -222,15 +222,11 @@
 </script>
 
 <style scoped lang="scss">
-    .task-duration {
-        padding: .375rem 0;
-    }
-
     .taskrun-header,
     .attempt-header {
         display: flex;
         gap: .5rem;
-        padding: 0.5rem 1rem;
+        padding: 0.25rem 1rem;
         border-bottom: 1px solid var(--ks-border-default);
 
         >* {
@@ -243,9 +239,19 @@
             font-size: var(--ks-font-size-xs)
         }
 
-        .task-duration small {
-            white-space: nowrap;
-            color: var(--ks-text-secondary);
+        .task-duration {
+            flex-shrink: 0;
+            min-width: 70px;
+            justify-content: flex-end;
+
+            small {
+                white-space: nowrap;
+                color: var(--ks-text-secondary);
+            }
+        }
+
+        .task-status {
+            flex-shrink: 0;
         }
 
     }
@@ -265,7 +271,6 @@
             white-space: nowrap;
             overflow: hidden;
             text-overflow: ellipsis;
-            padding: .375rem 0;
 
             span span {
                 color: var(--ks-text-primary);


### PR DESCRIPTION
## Summary
Fixes #17945

Addressed two issues in the Execution Logs task headers:
1. **Header height too big** - Reduced vertical padding from `0.5rem` to `0.25rem` and removed extra padding from `.task-duration` and `.task-id`
2. **Durations not aligned** - Added `min-width: 70px` and `justify-content: flex-end` to `.task-duration` so duration values align consistently across multiple task rows

## Changes
- `ui/src/components/executions/TaskRunLine.vue`:
  - Reduced `.taskrun-header` / `.attempt-header` padding from `0.5rem 1rem` to `0.25rem 1rem`
  - Added `min-width: 70px`, `flex-shrink: 0`, and `justify-content: flex-end` to `.task-duration`
  - Added `flex-shrink: 0` to `.task-status`
  - Removed extra `padding: .375rem 0` from `.task-duration` and `.task-id`

## Test plan
- [x] Task headers now have a more compact height
- [x] Duration values are right-aligned and consistent across rows
- [x] State indicators and duration text are properly aligned