### PR TITLE
fix: move task runner badge to title row in topology nodes

### DIFF
--- a/ui/packages/topology/src/nodes/BasicNode.vue
+++ b/ui/packages/topology/src/nodes/BasicNode.vue
@@ -11,13 +11,13 @@
                 <component :is="taskIconComponent" :cls="cls" :class="taskIconBg" variable="--ks-topology-icon-color" :icons="icons" />
             </div>
             <div class="node-content">
-                <slot name="badge" />
                 <div class="node-title">
                     <div class="task-title" :title="hoverTooltip">
                         <KsTooltip :content="hoverTooltip">
                             {{ displayTitle }}
                         </KsTooltip>
                     </div>
+                    <slot name="badge" />
                     <slot name="title-status" />
                     <slot name="title-actions" />
                 </div>

--- a/ui/packages/topology/src/nodes/TaskNode.vue
+++ b/ui/packages/topology/src/nodes/TaskNode.vue
@@ -480,7 +480,7 @@ button.playground-button {
 }
 
 .runner-badge {
-    align-self: flex-start;
+    flex-shrink: 0;
     padding: 0 var(--ks-spacing-2);
     border-radius: var(--ks-radius-base);
     background-color: var(--ks-bg-tag);
@@ -490,6 +490,7 @@ button.playground-button {
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
+    max-width: 80px;
 }
 
 .details-slide-enter-active,


### PR DESCRIPTION
## Summary
Fixes #17955

The task runner badge was rendered above the title text in topology nodes because the `#badge` slot was placed before the `.node-title` div inside a column-flex container. This caused the runner label to stack vertically above the task title, pushing content down and misaligning the node layout.

## Changes
- `ui/packages/topology/src/nodes/BasicNode.vue`: Moved `<slot name="badge" />` from before `.node-title` to inside it, so the badge renders inline with the title text
- `ui/packages/topology/src/nodes/TaskNode.vue`: Updated `.runner-badge` CSS — replaced `align-self: flex-start` with `flex-shrink: 0` and added `max-width: 80px` for proper inline layout with text truncation

## Before/After
**Before:** Runner badge stacks above the title, pushing content down  
**After:** Runner badge renders inline in the title area alongside the task name

## Test plan
- [x] Runner badge now appears on the same row as the task title
- [x] Badge text truncates with ellipsis when exceeding max-width
- [x] Nodes without a task runner are unaffected (badge slot is empty)
- [x] Status tag and title actions remain properly positioned