### PR TITLE
fix(ui): keep disabled dropdown items readable in dark mode

### DIFF
--- a/ui/src/styles/layout/element-plus-overload.scss
+++ b/ui/src/styles/layout/element-plus-overload.scss
@@ -843,6 +843,14 @@ form.ks-horizontal {
             }
         }
 
+        &.is-disabled {
+            color: var(--ks-content-inactive);
+
+            i {
+                color: inherit;
+            }
+        }
+
         &:not(.is-disabled):hover {
             background-color: var(--ks-dropdown-background-hover);
         }

--- a/ui/tests/storybook/components/executions/Outputs.stories.jsx
+++ b/ui/tests/storybook/components/executions/Outputs.stories.jsx
@@ -1,0 +1,77 @@
+import {
+    ElButton,
+    ElDropdown,
+    ElDropdownItem,
+    ElDropdownMenu,
+} from "element-plus";
+import {expect, userEvent, waitFor, within} from "storybook/test";
+
+import Outputs from "../../../../src/components/executions/Outputs.vue";
+
+export default {
+    title: "Components/Executions/Outputs",
+    component: Outputs,
+};
+
+const Disabled = {
+    render: () => ({
+        components: {
+            ElButton,
+            ElDropdown,
+            ElDropdownItem,
+            ElDropdownMenu,
+            Outputs,
+        },
+        template: `
+            <div style="min-height: 320px; padding: 48px; background: var(--ks-background-body)">
+                <el-dropdown trigger="click">
+                    <el-button>Options</el-button>
+                    <template #dropdown>
+                        <el-dropdown-menu>
+                            <el-dropdown-item>Metrics</el-dropdown-item>
+                            <Outputs :outputs="{}" :execution="{}" />
+                            <el-dropdown-item>Replay</el-dropdown-item>
+                        </el-dropdown-menu>
+                    </template>
+                </el-dropdown>
+            </div>
+        `,
+    }),
+    async play({canvasElement}) {
+        const canvas = within(canvasElement);
+        await userEvent.click(canvas.getByRole("button", {name: "Options"}));
+
+        const page = within(canvasElement.ownerDocument.body);
+        const disabledItem = await page.findByRole("menuitem", {name: "Outputs"});
+        const expectedColor = getComputedStyle(canvasElement.ownerDocument.documentElement)
+            .getPropertyValue("--ks-content-inactive")
+            .trim();
+
+        const probe = canvasElement.ownerDocument.createElement("span");
+        probe.style.color = expectedColor;
+        canvasElement.ownerDocument.body.appendChild(probe);
+        const resolvedExpectedColor = getComputedStyle(probe).color;
+        probe.remove();
+
+        await expect(disabledItem).toHaveAttribute("aria-disabled", "true");
+        await waitFor(() => expect(getComputedStyle(disabledItem).color).toBe(resolvedExpectedColor));
+
+        const icon = disabledItem.querySelector("i");
+        await expect(icon).toBeTruthy();
+        await expect(getComputedStyle(icon).color).toBe(resolvedExpectedColor);
+    },
+};
+
+export const DisabledDarkMode = {
+    ...Disabled,
+    globals: {
+        theme: "dark",
+    },
+};
+
+export const DisabledLightMode = {
+    ...Disabled,
+    globals: {
+        theme: "light",
+    },
+};


### PR DESCRIPTION
## ✨ Description

Keeps disabled dropdown items readable in dark mode on the maintained `releases/v1.3.x` UI.

The affected `v1.3.27` execution menu still uses Element Plus `el-dropdown-item`. In the dark theme, `--el-text-color-disabled` resolves to `#2C303F`, almost the same as the dropdown background `#262A35`. This PR:

- gives disabled dropdown labels the existing semantic `--ks-content-inactive` color
- makes the dropdown icon inherit that same color
- adds dark- and light-theme Storybook regression coverage around the actual `Outputs.vue` component

This is intentionally scoped to old Element Plus dropdown items. The current `develop` branch has already migrated this path to the namespaced design-system dropdown, where the inactive token is already applied.

## 🔗 Related Issue

Closes https://github.com/kestra-io/kestra/issues/17392

## 🎨 Frontend Checklist

- [x] Code builds without errors (`npm run build`)
- [ ] All existing E2E tests pass (`npm run test:e2e`) — not run; this visual state is covered by the focused Storybook test
- [x] Screenshots attached below showing the UI change

## Validation

- `npm run build` — passed
- `npm run test:storybook -- tests/storybook/components/executions/Outputs.stories.jsx` — 2 tests passed in Chromium
- `npx eslint tests/storybook/components/executions/Outputs.stories.jsx` — passed
- Manual `v1.3.27` browser reproduction:
  - before: `#2C303F` on `#262A35`, contrast `1.09:1`
  - after: `#9797A6` on `#262A35`, contrast `4.98:1`
  - the item remains disabled (`aria-disabled="true"`) and visually distinct from enabled white items

## Screenshots

| Before — disabled Outputs is nearly invisible | After — readable but still visibly disabled |
| --- | --- |
| ![Before fix](https://raw.githubusercontent.com/byp411426/kestra/pr-assets-17392/.github/pr-assets/17392/before.jpg) | ![After fix](https://raw.githubusercontent.com/byp411426/kestra/pr-assets-17392/.github/pr-assets/17392/after.jpg) |

## 📝 Additional Notes

The reproduction, build, and tests were run locally without Docker.

## 🤖 AI Authors

Cat joke: the dropdown asked the cat for better contrast, so it turned up the purr-ightness. 🐱