### PR TITLE
feat(ai): support custom HTTP headers on every copilot model provider

### DIFF
--- a/webserver/src/main/java/io/kestra/webserver/services/ai/AiConfiguration.java
+++ b/webserver/src/main/java/io/kestra/webserver/services/ai/AiConfiguration.java
@@ -1,5 +1,9 @@
 package io.kestra.webserver.services.ai;
 
+import java.util.Map;
+
+import io.micronaut.core.annotation.Nullable;
+
 public interface AiConfiguration {
     String type();
 
@@ -11,5 +15,16 @@ public interface AiConfiguration {
 
     default Double topP() {
         return null;
+    }
+
+    /**
+     * Custom HTTP headers to send with every request to the model API, {@code null} or empty when none are
+     * configured. Lets a deployment authenticate against, or route through, an internal AI gateway.
+     *
+     * @return the headers to add to each request, keyed by header name.
+     */
+    @Nullable
+    default Map<String, String> customHeaders() {
+        return Map.of();
     }
 }

--- a/webserver/src/main/java/io/kestra/webserver/services/ai/AiServiceManager.java
+++ b/webserver/src/main/java/io/kestra/webserver/services/ai/AiServiceManager.java
@@ -20,6 +20,8 @@ import io.micronaut.context.annotation.Requires;
 import io.micronaut.context.env.Environment;
 import io.micronaut.context.env.PropertyPlaceholderResolver;
 import io.micronaut.core.annotation.Nullable;
+import io.micronaut.core.naming.NameUtils;
+import io.micronaut.core.naming.conventions.StringConvention;
 import jakarta.inject.Singleton;
 import lombok.extern.slf4j.Slf4j;
 
@@ -59,13 +61,13 @@ public class AiServiceManager {
         List<AiProviderConfiguration> configs = new java.util.ArrayList<>(
             providersConfiguration.providers() != null ? providersConfiguration.providers() : List.of()
         );
+        int declaredProviderCount = configs.size();
 
         String legacyType = environment.get("kestra.ai.type", String.class).orElse(null);
         if (legacyType != null) {
             Map<String, Object> rawConfig = environment.get("kestra.ai." + legacyType, Map.class).orElse(null);
 
-            Map<String, Object> legacyConfig = rawConfig.entrySet().stream()
-                .collect(java.util.stream.Collectors.toMap(e -> io.micronaut.core.naming.NameUtils.camelCase(e.getKey()), Map.Entry::getValue));
+            Map<String, Object> legacyConfig = normalizeConfigurationKeys(rawConfig);
 
             configs.add(
                 new AiProviderConfiguration(
@@ -81,8 +83,10 @@ public class AiServiceManager {
         // AI Copilot requires an explicitly configured provider. When none is configured no service is
         // registered, and the Copilot surfaces as unavailable until the user adds a provider.
         PropertyPlaceholderResolver placeholderResolver = environment.getPlaceholderResolver();
-        for (AiProviderConfiguration rawProvider : configs) {
-            AiProviderConfiguration provider = resolveConfigurationPlaceholders(rawProvider, placeholderResolver);
+        for (int i = 0; i < configs.size(); i++) {
+            // The legacy single-provider configuration, when set, is the entry appended past the declared ones.
+            String configurationPath = i < declaredProviderCount ? "kestra.ai.providers[" + i + "].configuration" : "kestra.ai." + legacyType;
+            AiProviderConfiguration provider = resolveConfiguration(configs.get(i), configurationPath, placeholderResolver, environment);
             AiServiceInterface aiService = createAiService(
                 provider,
                 pluginRegistry,
@@ -180,25 +184,60 @@ public class AiServiceManager {
     }
 
     /**
-     * Returns a copy of the given provider whose configuration values have had their {@code ${...}} placeholders
-     * resolved. Needed because Micronaut does not resolve placeholders for values nested inside an untyped
-     * {@code Map<String, Object>} within a {@code List} element when bound from a YAML property source.
+     * Returns a copy of the given provider ready for Jackson: its custom HTTP headers re-read from the property
+     * source, and its {@code ${...}} placeholders resolved. Both are needed because Micronaut applies its
+     * camel-case key convention at every nesting level of the untyped configuration map — which would turn the
+     * header name {@code X-Api-Key} into {@code xApiKey} — and resolves no placeholder nested inside it.
      */
-    private static AiProviderConfiguration resolveConfigurationPlaceholders(AiProviderConfiguration provider, PropertyPlaceholderResolver resolver) {
+    private static AiProviderConfiguration resolveConfiguration(
+        AiProviderConfiguration provider,
+        String configurationPath,
+        PropertyPlaceholderResolver resolver,
+        Environment environment) {
         if (provider.configuration() == null) {
             return provider;
         }
 
-        Map<String, Object> resolved = new HashMap<>(provider.configuration().size());
-        provider.configuration().forEach((key, value) -> resolved.put(key, resolvePlaceholders(value, resolver)));
+        Map<String, Object> configuration = new HashMap<>(provider.configuration());
+        Map<String, Object> customHeaders = rawCustomHeaders(configurationPath, environment);
+        if (!customHeaders.isEmpty()) {
+            configuration.put("customHeaders", customHeaders);
+        }
+        configuration.replaceAll((key, value) -> resolvePlaceholders(value, resolver));
 
         return new AiProviderConfiguration(
             provider.id(),
             provider.displayName(),
             provider.type(),
             provider.isDefault(),
-            resolved
+            configuration,
+            provider.systemPrompt()
         );
+    }
+
+    /** Returns the provider's custom headers with the names exactly as written, empty when it declares none. */
+    private static Map<String, Object> rawCustomHeaders(String configurationPath, Environment environment) {
+        try {
+            Map<String, Object> headers = environment.getProperties(configurationPath + ".custom-headers", StringConvention.RAW);
+            // The property may also be written in camel case, which lands under a different raw key.
+            return headers.isEmpty() ? environment.getProperties(configurationPath + ".customHeaders", StringConvention.RAW) : headers;
+        } catch (Exception e) {
+            // Reading raw properties resolves placeholders, which throws when one cannot be resolved: keep the
+            // bound headers rather than aborting the startup over a single misconfigured value.
+            log.warn("Could not read the custom headers of the AI provider at '{}': {}", configurationPath, e.getMessage());
+            return Map.of();
+        }
+    }
+
+    /**
+     * Camel-cases the provider properties so Jackson binds them to the typed configuration. Only the legacy
+     * single-provider configuration needs it, being read as a raw map: Micronaut already camel-cases the keys of a
+     * {@code providers} entry. Nested maps are left alone — {@code customHeaders} is keyed by HTTP header names.
+     */
+    static Map<String, Object> normalizeConfigurationKeys(Map<String, Object> configuration) {
+        Map<String, Object> normalized = new HashMap<>(configuration.size());
+        configuration.forEach((key, value) -> normalized.put(NameUtils.camelCase(key), value));
+        return normalized;
     }
 
     /**

--- a/webserver/src/main/java/io/kestra/webserver/services/ai/gemini/GeminiAiService.java
+++ b/webserver/src/main/java/io/kestra/webserver/services/ai/gemini/GeminiAiService.java
@@ -82,6 +82,7 @@ public class GeminiAiService extends AiService<GeminiConfiguration> {
             .thinkingConfig(thinkingConfig())
             .returnThinking(true)
             .sendThinking(true)
+            .customHeaders(getAiConfiguration().customHeaders())
             .timeout(getAiConfiguration().timeout());
 
         if (getAiConfiguration().clientPem() != null) {
@@ -118,6 +119,7 @@ public class GeminiAiService extends AiService<GeminiConfiguration> {
             .thinkingConfig(thinkingConfig())
             .returnThinking(true)
             .sendThinking(true)
+            .customHeaders(getAiConfiguration().customHeaders())
             .timeout(getAiConfiguration().timeout())
             .build();
     }

--- a/webserver/src/main/java/io/kestra/webserver/services/ai/gemini/GeminiConfiguration.java
+++ b/webserver/src/main/java/io/kestra/webserver/services/ai/gemini/GeminiConfiguration.java
@@ -1,12 +1,15 @@
 package io.kestra.webserver.services.ai.gemini;
 
 import java.time.Duration;
+import java.util.Map;
 
 import io.kestra.webserver.services.ai.AiConfiguration;
 import io.kestra.webserver.services.ai.ThinkingEffort;
 
 import io.micronaut.core.annotation.Nullable;
 import io.micronaut.core.bind.annotation.Bindable;
+import io.micronaut.core.convert.format.MapFormat;
+import io.micronaut.core.naming.conventions.StringConvention;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 public record GeminiConfiguration(
@@ -25,6 +28,8 @@ public record GeminiConfiguration(
     @Bindable(defaultValue = "false") boolean thinkingEnabled,
     @Nullable Integer thinkingBudgetTokens,
     @Nullable ThinkingEffort thinkingEffort,
+    @Nullable
+    @MapFormat(transformation = MapFormat.MapTransformation.FLAT, keyFormat = StringConvention.RAW) Map<String, String> customHeaders,
     Duration timeout) implements AiConfiguration {
     public GeminiConfiguration {
         if (modelName == null)

--- a/webserver/src/test/java/io/kestra/webserver/services/ai/AiProviderConfigurationBindingTest.java
+++ b/webserver/src/test/java/io/kestra/webserver/services/ai/AiProviderConfigurationBindingTest.java
@@ -1,0 +1,74 @@
+package io.kestra.webserver.services.ai;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import io.kestra.core.junit.annotations.KestraTest;
+
+import io.micronaut.context.annotation.Property;
+import jakarta.inject.Inject;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Covers how {@code kestra.ai} reaches the typed provider configuration. Micronaut applies its camel-case key
+ * convention at every nesting level of the untyped configuration map, so custom HTTP header names have to be
+ * recovered from the raw property source: bound naively, {@code X-Api-Key} arrives as {@code xApiKey}.
+ * <p>
+ * The {@code providers} configuration is covered end to end, up to the outgoing request, by
+ * {@link io.kestra.webserver.services.ai.gemini.GeminiAiServiceTest}.
+ */
+@KestraTest
+// The test environment already declares the legacy single-provider configuration, which only lacks custom headers.
+@Property(name = "kestra.ai.gemini.custom-headers.X-Api-Key", value = "secret")
+@Property(name = "kestra.ai.gemini.custom-headers.Authorization", value = "Bearer token")
+@Property(name = "kestra.ai.providers[0].id", value = AiProviderConfigurationBindingTest.HEADERLESS_PROVIDER_ID)
+@Property(name = "kestra.ai.providers[0].type", value = "gemini")
+@Property(name = "kestra.ai.providers[0].configuration.model-name", value = "gemini-2.5-flash")
+@Property(name = "kestra.ai.providers[0].configuration.api-key", value = "fake-key")
+class AiProviderConfigurationBindingTest {
+    static final String HEADERLESS_PROVIDER_ID = "gemini-without-headers";
+
+    @Inject
+    private AiServiceManager aiServiceManager;
+
+    private AiConfiguration configurationOf(String providerId) {
+        return ((AiService<?>) aiServiceManager.getAiService(providerId)).getAiConfiguration();
+    }
+
+    @Test
+    void shouldKeepCustomHeaderNamesVerbatimForLegacySingleProvider() {
+        assertThat(configurationOf("gemini-legacy").customHeaders())
+            .isEqualTo(Map.of("X-Api-Key", "secret", "Authorization", "Bearer token"));
+    }
+
+    @Test
+    void shouldLeaveCustomHeadersUnsetWhenNoneConfigured() {
+        assertThat(configurationOf(HEADERLESS_PROVIDER_ID).customHeaders()).isNullOrEmpty();
+    }
+
+    @Test
+    void shouldCamelCaseProviderPropertiesWrittenInKebabCase() {
+        Map<String, Object> normalized = AiServiceManager.normalizeConfigurationKeys(Map.of(
+            "model-name", "gemini-2.5-flash",
+            "api-key", "fake-key",
+            "custom-headers", Map.of("X-Api-Key", "secret")
+        ));
+
+        // Only the provider properties are normalized: the nested header names are left alone
+        assertThat(normalized).containsEntry("modelName", "gemini-2.5-flash");
+        assertThat(normalized).containsEntry("apiKey", "fake-key");
+        assertThat(normalized).containsEntry("customHeaders", Map.of("X-Api-Key", "secret"));
+    }
+
+    @Test
+    void shouldLeaveProviderPropertiesAlreadyInCamelCaseUnchanged() {
+        Map<String, Object> normalized = AiServiceManager.normalizeConfigurationKeys(
+            Map.of("modelName", "gemini-2.5-flash", "apiKey", "fake-key")
+        );
+
+        assertThat(normalized).containsEntry("modelName", "gemini-2.5-flash");
+        assertThat(normalized).containsEntry("apiKey", "fake-key");
+    }
+}

--- a/webserver/src/test/java/io/kestra/webserver/services/ai/gemini/GeminiAiServiceTest.java
+++ b/webserver/src/test/java/io/kestra/webserver/services/ai/gemini/GeminiAiServiceTest.java
@@ -1,0 +1,107 @@
+package io.kestra.webserver.services.ai.gemini;
+
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.Test;
+
+import io.kestra.core.junit.annotations.KestraTest;
+import io.kestra.webserver.services.ai.AiService;
+import io.kestra.webserver.services.ai.AiServiceManager;
+
+import com.github.tomakehurst.wiremock.junit5.WireMockTest;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import dev.langchain4j.model.chat.response.StreamingChatResponseHandler;
+import io.micronaut.context.annotation.Property;
+import jakarta.inject.Inject;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.okJson;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathMatching;
+import static com.github.tomakehurst.wiremock.client.WireMock.verify;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Checks that the custom headers configured on a provider are sent to the model API, on both the chat and the
+ * streaming path. The provider is built by {@link AiServiceManager} from the properties below, so this also covers
+ * the header names surviving the configuration binding — Micronaut's camel-case convention would otherwise turn
+ * {@code X-Api-Key} into {@code xApiKey}.
+ */
+@KestraTest
+@WireMockTest(httpPort = GeminiAiServiceTest.MODEL_API_PORT)
+@Property(name = "kestra.ai.providers[0].id", value = GeminiAiServiceTest.PROVIDER_ID)
+@Property(name = "kestra.ai.providers[0].type", value = "gemini")
+@Property(name = "kestra.ai.providers[0].configuration.base-url", value = "http://localhost:" + GeminiAiServiceTest.MODEL_API_PORT)
+@Property(name = "kestra.ai.providers[0].configuration.model-name", value = "gemini-2.5-flash")
+@Property(name = "kestra.ai.providers[0].configuration.api-key", value = "fake-key")
+@Property(name = "kestra.ai.providers[0].configuration.custom-headers.X-Api-Key", value = "secret")
+@Property(name = "kestra.ai.providers[0].configuration.custom-headers.X-Gateway-Route", value = "internal")
+class GeminiAiServiceTest {
+    static final int MODEL_API_PORT = 28184;
+    static final String PROVIDER_ID = "gemini-custom-headers";
+
+    // Paths are relative to the configured base URL, which is why they carry no API version prefix.
+    private static final String GENERATE_CONTENT_PATH = "/models/.*:generateContent";
+    private static final String STREAM_GENERATE_CONTENT_PATH = "/models/.*:streamGenerateContent";
+
+    private static final String RESPONSE = """
+        {"candidates":[{"content":{"parts":[{"text":"ok"}],"role":"model"},"finishReason":"STOP"}],\
+        "usageMetadata":{"promptTokenCount":1,"candidatesTokenCount":1,"totalTokenCount":2}}""";
+
+    @Inject
+    private AiServiceManager aiServiceManager;
+
+    private AiService<?> configuredProvider() {
+        return (AiService<?>) aiServiceManager.getAiService(PROVIDER_ID);
+    }
+
+    /** Asserts the model API was called with every configured header. */
+    private static void verifyCustomHeadersSentTo(String path) {
+        verify(
+            postRequestedFor(urlPathMatching(path))
+                .withHeader("X-Api-Key", equalTo("secret"))
+                .withHeader("X-Gateway-Route", equalTo("internal"))
+        );
+    }
+
+    @Test
+    void shouldSendCustomHeadersOnChatRequests() {
+        // Given a model API that answers a chat request
+        stubFor(post(urlPathMatching(GENERATE_CONTENT_PATH)).willReturn(okJson(RESPONSE)));
+
+        // When the configured provider is asked to answer a prompt
+        configuredProvider().chatModel(List.of()).chat("hi");
+
+        // Then the request carried the configured headers
+        verifyCustomHeadersSentTo(GENERATE_CONTENT_PATH);
+    }
+
+    @Test
+    void shouldSendCustomHeadersOnStreamingChatRequests() throws InterruptedException {
+        stubFor(post(urlPathMatching(STREAM_GENERATE_CONTENT_PATH)).willReturn(okJson(RESPONSE)));
+
+        CountDownLatch answered = new CountDownLatch(1);
+        configuredProvider().streamingChatModel(List.of()).chat("hi", new StreamingChatResponseHandler() {
+            @Override
+            public void onPartialResponse(String partialResponse) {
+            }
+
+            @Override
+            public void onCompleteResponse(ChatResponse completeResponse) {
+                answered.countDown();
+            }
+
+            @Override
+            public void onError(Throwable error) {
+                answered.countDown();
+            }
+        });
+
+        assertThat(answered.await(10, TimeUnit.SECONDS)).isTrue();
+        verifyCustomHeadersSentTo(STREAM_GENERATE_CONTENT_PATH);
+    }
+}


### PR DESCRIPTION
### ✨ Description

Custom HTTP headers now work on **every** AI Copilot provider. Five already supported them (OpenAI, Azure OpenAI, DeepSeek, Ollama, OpenRouter); the blocker for the rest was langchain4j, which has exposed `customHeaders` on all the remaining chat model builders since 1.15.0. We are on 1.18.1, so this unblocks Gemini here, and Anthropic, Mistral, Bedrock and Vertex AI in the companion EE PR. `customHeaders()` moves onto the `AiConfiguration` interface so every provider shares one contract instead of a per-provider convention.

```yaml
kestra:
  ai:
    providers:
      - id: gemini
        type: gemini
        configuration:
          model-name: gemini-2.5-flash
          api-key: "{{ secret('GEMINI_API_KEY') }}"
          custom-headers:
            X-Api-Key: secret
            X-Gateway-Route: internal
```

**This also fixes a bug that made the existing support unusable.** Header names configured under a `providers` entry never reached the model API intact: Micronaut applies its camel-case key convention at *every* nesting level of the untyped `configuration` map, so `X-Api-Key` was sent as `xApiKey` — the hyphens were eaten. Every hyphenated header name was affected, which is most real ones (`Authorization` survived only by having no hyphen; header names are case-insensitive per RFC 7230). Headers are now re-read from the raw property source with `StringConvention.RAW`, which returns them exactly as written.