### PR TITLE
feat(core): ResumableTaskInterface for reattach after worker restart

### DIFF
--- a/core/src/main/java/io/kestra/core/models/tasks/ResumableTaskInterface.java
+++ b/core/src/main/java/io/kestra/core/models/tasks/ResumableTaskInterface.java
@@ -1,0 +1,29 @@
+package io.kestra.core.models.tasks;
+
+import java.time.Duration;
+
+import io.kestra.core.models.property.Property;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+/**
+ * Marker interface for tasks that trigger a long-running external job and then poll it, so they can
+ * reattach to the in-flight job after a worker restart instead of triggering a duplicate. The
+ * reattach logic stays in the task's {@code run()}. This interface shares the opt-in toggle and the
+ * persist/recall/forget plumbing of {@link ResumableTaskService}, keyed by the taskrun id.
+ */
+public interface ResumableTaskInterface {
+    @Schema(
+        title = "Reattach to a running job after a worker restart",
+        description = "If true, the external job identifier is remembered after triggering so that, on a worker " +
+            "restart, the task reattaches to the in-flight job instead of triggering a duplicate."
+    )
+    Property<Boolean> getResumeOnRestart();
+
+    @Schema(
+        title = "Resume handle time-to-live",
+        description = "Optional expiry for the remembered job identifier. Defaults to no expiry. Set at least the " +
+            "maximum expected run duration when used."
+    )
+    Property<Duration> getResumeTtl();
+}

--- a/core/src/main/java/io/kestra/core/models/tasks/ResumableTaskService.java
+++ b/core/src/main/java/io/kestra/core/models/tasks/ResumableTaskService.java
@@ -1,0 +1,61 @@
+package io.kestra.core.models.tasks;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.util.Optional;
+
+import io.kestra.core.exceptions.ResourceExpiredException;
+import io.kestra.core.runners.RunContext;
+import io.kestra.core.storages.kv.KVMetadata;
+import io.kestra.core.storages.kv.KVValueAndMetadata;
+
+/**
+ * Remembers, recalls and forgets a single opaque resume handle (for example a remote run id) for the
+ * current taskrun, in the flow namespace KV store keyed by the taskrun id. The key is stable across a
+ * worker restart and unique per execution, so a resubmitted attempt finds the same handle and handles
+ * from different executions never collide.
+ */
+public final class ResumableTaskService {
+    private static final String KEY_PREFIX = "resume_";
+
+    private ResumableTaskService() {
+    }
+
+    /** The KV key holding the current taskrun's resume handle. */
+    public static String key(RunContext runContext) {
+        return KEY_PREFIX + runContext.taskRunInfo().taskRunId();
+    }
+
+    /**
+     * The remembered resume handle, empty when nothing is stored or the entry has expired. A read
+     * failure propagates so the caller can fail rather than silently re-trigger.
+     */
+    public static Optional<String> recall(RunContext runContext) throws IOException {
+        try {
+            return runContext.namespaceKv(runContext.flowInfo().namespace())
+                .getValue(key(runContext))
+                .map(value -> String.valueOf(value.value()));
+        } catch (ResourceExpiredException e) {
+            return Optional.empty();
+        }
+    }
+
+    /** Remembers the resume handle so a later attempt can reattach. Best-effort. */
+    public static void remember(RunContext runContext, String handle, Duration ttl) {
+        try {
+            runContext.namespaceKv(runContext.flowInfo().namespace())
+                .put(key(runContext), new KVValueAndMetadata(new KVMetadata("task resume handle", ttl), handle));
+        } catch (IOException e) {
+            runContext.logger().warn("Could not persist resume handle, a worker restart may re-trigger the job", e);
+        }
+    }
+
+    /** Forgets the resume handle once the job has reached a terminal state. Best-effort. */
+    public static void forget(RunContext runContext) {
+        try {
+            runContext.namespaceKv(runContext.flowInfo().namespace()).delete(key(runContext));
+        } catch (IOException e) {
+            runContext.logger().debug("Could not delete resume handle", e);
+        }
+    }
+}

--- a/core/src/test/java/io/kestra/core/models/tasks/ResumableTaskServiceTest.java
+++ b/core/src/test/java/io/kestra/core/models/tasks/ResumableTaskServiceTest.java
@@ -1,0 +1,72 @@
+package io.kestra.core.models.tasks;
+
+import java.time.Duration;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import io.kestra.core.junit.annotations.KestraTest;
+import io.kestra.core.runners.RunContext;
+import io.kestra.core.runners.RunContextFactory;
+import io.kestra.core.utils.IdUtils;
+import io.kestra.core.utils.TestsUtils;
+import io.kestra.plugin.core.log.Log;
+
+import jakarta.inject.Inject;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@KestraTest
+class ResumableTaskServiceTest {
+    @Inject
+    RunContextFactory runContextFactory;
+
+    @Test
+    void shouldReturnEmptyWhenNothingRemembered() throws Exception {
+        // Given
+        RunContext runContext = runContext();
+
+        // When / Then
+        assertThat(ResumableTaskService.recall(runContext)).isEmpty();
+    }
+
+    @Test
+    void shouldRecallHandleWhenRemembered() throws Exception {
+        // Given
+        RunContext runContext = runContext();
+
+        // When
+        ResumableTaskService.remember(runContext, "789", Duration.ofMinutes(60));
+
+        // Then
+        assertThat(ResumableTaskService.recall(runContext)).contains("789");
+    }
+
+    @Test
+    void shouldReturnEmptyWhenForgotten() throws Exception {
+        // Given
+        RunContext runContext = runContext();
+        ResumableTaskService.remember(runContext, "789", Duration.ofMinutes(60));
+
+        // When
+        ResumableTaskService.forget(runContext);
+
+        // Then
+        assertThat(ResumableTaskService.recall(runContext)).isEmpty();
+    }
+
+    @Test
+    void shouldKeyByTaskRunId() {
+        // Given
+        RunContext runContext = runContext();
+
+        // Then
+        assertThat(ResumableTaskService.key(runContext))
+            .isEqualTo("resume_" + runContext.taskRunInfo().taskRunId());
+    }
+
+    private RunContext runContext() {
+        Log task = Log.builder().id(IdUtils.create()).type(Log.class.getName()).message("noop").build();
+        return TestsUtils.mockRunContext(runContextFactory, task, Map.of());
+    }
+}


### PR DESCRIPTION
Adds an opt-in `ResumableTaskInterface` and a `ResumableTaskService` helper so a task that triggers a long-running external job can reattach to it after a worker restart instead of triggering a duplicate, with the reattach decision left in each task's `run()`. Shared plumbing only: remember/recall/forget an opaque handle in the flow namespace KV store, keyed by the taskrun id (stable across a restart, unique per execution).
 
- issue kestra-io/plugin-dbt#307) for reuse across plugins.
