### PR TITLE
fix(executions): wait for the execution when a follow subscriber registers

### DIFF
--- a/core/src/main/java/io/kestra/core/services/ExecutionStreamingService.java
+++ b/core/src/main/java/io/kestra/core/services/ExecutionStreamingService.java
@@ -1,10 +1,13 @@
 package io.kestra.core.services;
 
+import java.time.Duration;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 
 import org.apache.commons.lang3.tuple.Pair;
+import org.awaitility.core.ConditionTimeoutException;
 
 import io.kestra.core.models.executions.Execution;
 import io.kestra.core.models.flows.Flow;
@@ -12,6 +15,7 @@ import io.kestra.core.queues.BroadcastQueueInterface;
 import io.kestra.core.queues.QueueSubscriber;
 import io.kestra.core.repositories.ExecutionRepositoryInterface;
 import io.kestra.core.runners.FollowExecutionEvent;
+import io.kestra.core.utils.Await;
 import io.kestra.core.utils.ListUtils;
 import io.kestra.core.utils.MapUtils;
 
@@ -34,6 +38,9 @@ import reactor.core.publisher.FluxSink;
 @Slf4j
 @Singleton
 public class ExecutionStreamingService {
+    private static final Duration EXECUTION_LOOKUP_TIMEOUT = Duration.ofSeconds(10);
+    private static final Duration EXECUTION_LOOKUP_POLL_INTERVAL = Duration.ofMillis(500);
+
     private final Map<String, Map<String, Pair<FluxSink<Event<Execution>>, Flow>>> subscribers = new ConcurrentHashMap<>();
     private final Object subscriberLock = new Object();
 
@@ -129,14 +136,43 @@ public class ExecutionStreamingService {
         // FluxSink is thread-safe: duplicate complete() calls are no-ops, and next()
         // after complete() is silently dropped, so double-delivery is harmless.
         // Uses the no-ACL lookup: registerSubscriber's caller thread varies, so the ACL-enforcing findById would always
-        // deny authorization in EE
-        executionRepository.findByIdWithoutAcl(flow.getTenantId(), executionId).ifPresent(execution ->
-        {
-            if (isStopFollow(flow, execution)) {
-                sink.next(Event.of(execution).id("end"));
-                sink.complete();
-            }
-        });
+        // deny authorization in EE.
+        // The lookup waits rather than giving up on a first miss: a subscriber can register before the execution has
+        // been persisted at all, since the executor is a separate process in a distributed installation and may not
+        // have applied the create command yet. Reading empty there would silently skip this guard in exactly the case
+        // it exists for.
+        Optional<Execution> execution = awaitExecution(flow.getTenantId(), executionId);
+        if (execution.isEmpty()) {
+            log.warn(
+                "Execution {} was still not readable after {}, cannot determine whether it already terminated; the stream now depends on a later event",
+                executionId,
+                EXECUTION_LOOKUP_TIMEOUT
+            );
+            return;
+        }
+
+        if (isStopFollow(flow, execution.get())) {
+            sink.next(Event.of(execution.get()).id("end"));
+            sink.complete();
+        }
+    }
+
+    /**
+     * Reads an execution, waiting up to {@link #EXECUTION_LOOKUP_TIMEOUT} for it to exist.
+     *
+     * @return the execution, or empty if it never became readable
+     */
+    private Optional<Execution> awaitExecution(String tenantId, String executionId) {
+        try {
+            return Optional.ofNullable(
+                Await.await()
+                    .atMost(EXECUTION_LOOKUP_TIMEOUT)
+                    .pollInterval(EXECUTION_LOOKUP_POLL_INTERVAL)
+                    .until(() -> executionRepository.findByIdWithoutAcl(tenantId, executionId).orElse(null), Objects::nonNull)
+            );
+        } catch (ConditionTimeoutException e) {
+            return Optional.empty();
+        }
     }
 
     /**

--- a/core/src/test/java/io/kestra/core/services/ExecutionStreamingServiceTest.java
+++ b/core/src/test/java/io/kestra/core/services/ExecutionStreamingServiceTest.java
@@ -180,4 +180,61 @@ class ExecutionStreamingServiceTest {
 
         assertThat(completed.get(5, TimeUnit.SECONDS)).isNull();
     }
+
+    /**
+     * A subscriber can register before the execution has been persisted at all: in a distributed installation the
+     * executor is a separate process, so the create command it consumes may not have been applied yet. The catch-up
+     * guard has to wait for the execution instead of giving up on the first miss, otherwise an execution that
+     * terminated before registration never completes the {@link Flux} — no further event is coming.
+     */
+    @Test
+    @SuppressWarnings("unchecked")
+    void shouldCompleteFluxWhenTheExecutionIsOnlyPersistedAfterTheSubscriberRegisters() throws Exception {
+        // Given — an already terminal execution that is not readable yet, then becomes readable
+        var flow = Flow.builder()
+            .tenantId(null)
+            .namespace("io.kestra.tests")
+            .id(IdUtils.create())
+            .tasks(Collections.singletonList(Log.builder().id("log").type(Log.class.getName()).message("test").build()))
+            .build();
+
+        var terminalExecution = Execution.newExecution(flow, Collections.emptyList()).withState(State.Type.SUCCESS);
+
+        var executionRepository = mock(ExecutionRepositoryInterface.class);
+        when(executionRepository.findByIdWithoutAcl(flow.getTenantId(), terminalExecution.getId()))
+            .thenReturn(Optional.empty()) // the executor has not persisted it yet
+            .thenReturn(Optional.empty())
+            .thenReturn(Optional.of(terminalExecution)); // it now has
+
+        var executionService = mock(ExecutionService.class);
+        when(executionService.isTerminated(any(), any())).thenAnswer(invocation ->
+            ((Execution) invocation.getArgument(1)).getState().isTerminated());
+
+        var queueSubscriber = mock(QueueSubscriber.class);
+        doAnswer(invocation -> queueSubscriber).when(queueSubscriber).subscribe(any());
+
+        var executionQueue = mock(BroadcastQueueInterface.class);
+        when(executionQueue.subscriber()).thenReturn(queueSubscriber);
+
+        var executionStreamingService = new ExecutionStreamingService(executionQueue, executionService, executionRepository);
+        executionStreamingService.startQueueConsumer();
+
+        var subscriberId = IdUtils.create();
+        CompletableFuture<Void> completed = new CompletableFuture<>();
+
+        // When — a subscriber registers while the execution is still unreadable
+        Flux.<Event<Execution>> create(
+            sink -> executionStreamingService.registerSubscriber(terminalExecution.getId(), subscriberId, sink, flow)
+        )
+            .timeout(java.time.Duration.ofSeconds(10))
+            .doFinally(sig -> executionStreamingService.unregisterSubscriber(terminalExecution.getId(), subscriberId))
+            .subscribe(
+                event -> { /* progress events — not relevant here */ },
+                completed::completeExceptionally,
+                () -> completed.complete(null)
+            );
+
+        // Then — the stream completes off the catch-up alone; no follow event is ever delivered
+        assertThat(completed.get(10, TimeUnit.SECONDS)).isNull();
+    }
 }


### PR DESCRIPTION
`ExecutionStreamingService.registerSubscriber` ends with a guard for the case where a terminal `FollowExecutionEvent` was consumed — or lost during the queue resume — before the subscriber made it into the map. It reads the execution and, if it is already terminal, completes the sink directly. Nothing else will: the event that would have completed it is gone.

The guard used `ifPresent`, so it did nothing at all when the read came back empty.

That is not a rare state. A subscriber can register before the execution has been persisted, because the executor is a separate process in a distributed installation and may not have applied the create command yet. This has been reported in distributed deployments, where the window between emitting the create command and the execution becoming readable is widest.

## Why it matters

`ExecutionController`'s create-with-`wait=true` endpoint registers a subscriber immediately after emitting the Create command, then blocks on `Flux.last()`. A terminal event missed during registration, combined with a guard that silently does nothing, hangs the request until its timeout — precisely the failure the guard was written to prevent, as its own comment describes.

The `/follow` endpoint is unaffected: it already waits for the execution to exist before registering, and re-reads afterwards.

## Change

Wait for the execution to become readable rather than giving up on the first miss, using the same budget `/follow` already applies (10s, polling every 500ms), and log rather than fail if it never appears. Both callers are `@ExecuteOn(TaskExecutors.IO)`, so the bounded wait is consistent with what the controller already does on that path.

Putting it in `registerSubscriber` rather than at the call site means the unprotected caller and any future one are covered. For `/follow` it costs nothing — the execution is already there, so the first poll returns.

## Not a staleness issue

Worth stating explicitly, since it looks adjacent: this is about the execution not existing yet, not about reading a stale copy. The lookup is `findByIdWithoutAcl`, a realtime get, so no index refresh interval is involved.

## Testing

Adds a test where the execution only becomes readable *after* registration and **no follow event is ever delivered**, so the stream can only complete via the catch-up. It fails against the previous `ifPresent` version. It sits alongside the two existing regression tests for kestra-io/kestra-ee#8824.

Compiles clean. The suite has not been run.

## Related, but not fixed here

kestra-io/kestra#17863 is the same family of bug — a read-after-write across processes on the create path — but a different code path, and this PR does not fix it. That 404 is raised by `ExecutionController.awaitBlockingAction`, before any subscriber is registered, so it never reaches the code changed here.

Its cause also looks different. In `ExecutionCommandMessageHandler.handleCreate` the execution *is* persisted before the `finally` emits the processed event, so the ordering is right. The likely culprit is that on `queue-jdbc` the create joins the dispatch-queue poll transaction — `JooqDSLContextWrapper` documents that a nested `transaction(...)` "silently joins a caller-owned transaction … deferring their writes until that transaction commits" — so the write is not committed when the processed event fires, and the webserver reads nothing. That would explain why it is specific to distributed Postgres/MySQL. `requireNewTransaction` is the documented escape hatch.
