### PR TITLE
fix(executions): read the execution without ACL after an async operation

### DIFF
--- a/webserver/src/main/java/io/kestra/webserver/controllers/api/ExecutionController.java
+++ b/webserver/src/main/java/io/kestra/webserver/controllers/api/ExecutionController.java
@@ -2830,7 +2830,11 @@ public class ExecutionController {
                         "Failed to execute action '%s' on execution %s (operation_id=%s). Cause: %s".formatted(actionName, executionId, processed.operationId(), processed.error())
                     );
                 }
-                return executionRepository.findById(tenantId, executionId)
+                // This runs on the thread that completes the async-operation sink, which is the event-queue polling
+                // thread and carries no authenticated principal. The ACL-enforcing findById fails closed there, so it
+                // reports the execution as missing even though the command succeeded. Authorization already happened
+                // on the request thread, in the endpoint that submitted this operation.
+                return executionRepository.findByIdWithoutAcl(tenantId, executionId)
                     .orElseThrow(
                         () -> new NoSuchElementException(
                             "Execution disappeared after " + actionName.toLowerCase() + ": " + executionId


### PR DESCRIPTION
Fixes #17863
Fixes https://github.com/kestra-io/kestra-ee/issues/9777

Triggering an execution in a distributed deployment returns `404 Execution disappeared after create: <id>`, while the execution itself runs to completion on the backend. The same affects every endpoint that waits on an async operation — restart, resume, pause, kill, force-run, label and status changes — twelve in total, all routed through `awaitBlockingAction`.

## Cause

`awaitBlockingAction` waits for the `AsyncOperationProcessedEvent`, then reads the execution back so it can return it:

```java
return executionRepository.findById(tenantId, executionId)
    .orElseThrow(() -> new NoSuchElementException("Execution disappeared after " + actionName.toLowerCase() + ": " + executionId));
```

`AsyncOperationWaiter.submit` builds a `Flux.create(...)` whose sink is completed by `AsyncEventStreamingService` — from its **queue-polling thread**. So this `.map(...)` does not run on the request thread and carries **no authenticated principal**. The ACL-enforcing `findById` fails closed when the caller has no allowed namespaces, returns empty, and the endpoint reports the execution as missing.

## Fix

Use `findByIdWithoutAcl`, exactly as `ExecutionStreamingService` already does for its own queue-polling reads, and for the same documented reason (see the `#8824` regression tests, which pin that contract by mocking `findById` to deny).
