### PR TITLE
fix(core): keep per-emit asset lineage bundles instead of flattening

### DIFF
--- a/core/src/main/java/io/kestra/core/models/executions/TaskRun.java
+++ b/core/src/main/java/io/kestra/core/models/executions/TaskRun.java
@@ -298,7 +298,7 @@ public class TaskRun implements TenantInterface {
             ", value=" + this.getValue() +
             ", parentTaskRunId=" + this.getParentTaskRunId() +
             ", state=" + this.getState().getCurrent().toString() +
-            ", assets=" + this.getAssets() +
+            ", assetEmits=" + this.getAssetEmits() +
             ", attempts=" + this.getAttempts() +
             ")";
     }

--- a/core/src/main/java/io/kestra/core/models/executions/TaskRun.java
+++ b/core/src/main/java/io/kestra/core/models/executions/TaskRun.java
@@ -5,7 +5,9 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonSetter;
 
 import io.kestra.core.models.TenantInterface;
 import io.kestra.core.models.assets.AssetsInOut;
@@ -55,9 +57,13 @@ public class TaskRun implements TenantInterface {
     @With
     List<TaskRunAttempt> attempts;
 
+    // Lineage bundles, one AssetsInOut per (inputs -> outputs) pair, kept unmerged so each becomes its own
+    // lineage event downstream. This is the single source of truth for a taskRun's assets. The pre-existing
+    // single `assets` object is folded in here via the deprecated setAssets bridge below.
     @With
     @Nullable
-    AssetsInOut assets;
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    List<AssetsInOut> assetEmits;
 
     @NotNull
     State state;
@@ -91,6 +97,36 @@ public class TaskRun implements TenantInterface {
         return this;
     }
 
+    /**
+     * Backward-compatibility bridge for the pre-existing single `assets` bundle. Executions serialized
+     * before `assetEmits` existed carry a single `assets` object; this folds it into `assetEmits` on
+     * deserialization so old executions still load. New code should use {@link #getAssetEmits()}.
+     *
+     * @deprecated use {@code assetEmits}. Kept only so historical executions deserialize.
+     */
+    @Deprecated(forRemoval = true, since = "2.0.0")
+    @JsonSetter("assets")
+    public void setAssets(@Nullable AssetsInOut assets) {
+        if (assets == null) {
+            return;
+        }
+        if (!(this.assetEmits instanceof ArrayList)) {
+            this.assetEmits = this.assetEmits == null ? new ArrayList<>() : new ArrayList<>(this.assetEmits);
+        }
+        this.assetEmits.add(assets);
+    }
+
+    /**
+     * @deprecated use {@link #getAssetEmits()}. Returns the first bundle so callers still expecting a
+     *             single `assets` (e.g. the API layer) keep working. Not serialized.
+     */
+    @Deprecated(forRemoval = true, since = "2.0.0")
+    @JsonIgnore
+    @Nullable
+    public AssetsInOut getAssets() {
+        return this.assetEmits == null || this.assetEmits.isEmpty() ? null : this.assetEmits.getFirst();
+    }
+
     public TaskRun withState(State.Type state) {
         return new TaskRun(
             this.tenantId,
@@ -102,7 +138,7 @@ public class TaskRun implements TenantInterface {
             this.parentTaskRunId,
             this.value,
             this.attempts,
-            this.assets,
+            this.assetEmits,
             this.state.withState(state),
             this.iteration,
             this.dynamic,
@@ -131,7 +167,7 @@ public class TaskRun implements TenantInterface {
             this.parentTaskRunId,
             this.value,
             newAttempts,
-            this.assets,
+            this.assetEmits,
             this.state.withState(state),
             this.iteration,
             this.dynamic,
@@ -157,7 +193,7 @@ public class TaskRun implements TenantInterface {
             this.parentTaskRunId,
             this.value,
             newAttempts,
-            this.assets,
+            this.assetEmits,
             this.state.withState(State.Type.FAILED),
             this.iteration,
             this.dynamic,
@@ -180,7 +216,7 @@ public class TaskRun implements TenantInterface {
             .parentTaskRunId(this.getParentTaskRunId() != null ? remapTaskRunId.getOrDefault(this.getParentTaskRunId(), this.getParentTaskRunId()) : null)
             .value(this.getValue())
             .attempts(this.getAttempts())
-            .assets(this.getAssets())
+            .assetEmits(this.assetEmits)
             .state(state == null ? this.getState() : state)
             .iteration(this.getIteration())
             .build();

--- a/core/src/main/java/io/kestra/core/models/executions/TaskRun.java
+++ b/core/src/main/java/io/kestra/core/models/executions/TaskRun.java
@@ -5,7 +5,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonSetter;
 
@@ -57,8 +56,7 @@ public class TaskRun implements TenantInterface {
     @With
     List<TaskRunAttempt> attempts;
 
-    // Lineage bundles, one AssetsInOut per (inputs -> outputs) pair, kept unmerged so each becomes its own
-    // lineage event. Canonical store for a taskRun's assets (the legacy single `assets` folds in via setAssets).
+    // Lineage bundles, one AssetsInOut per (inputs -> outputs) pair, kept unmerged so each becomes its own lineage event.
     @With
     @Nullable
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
@@ -112,17 +110,6 @@ public class TaskRun implements TenantInterface {
             this.assetEmits = this.assetEmits == null ? new ArrayList<>() : new ArrayList<>(this.assetEmits);
         }
         this.assetEmits.add(assets);
-    }
-
-    /**
-     * @deprecated use {@link #getAssetEmits()}. Returns the first bundle so callers still expecting a
-     *             single `assets` (e.g. the API layer) keep working. Not serialized.
-     */
-    @Deprecated(forRemoval = true, since = "2.0.0")
-    @JsonIgnore
-    @Nullable
-    public AssetsInOut getAssets() {
-        return this.assetEmits == null || this.assetEmits.isEmpty() ? null : this.assetEmits.getFirst();
     }
 
     public TaskRun withState(State.Type state) {

--- a/core/src/main/java/io/kestra/core/models/executions/TaskRun.java
+++ b/core/src/main/java/io/kestra/core/models/executions/TaskRun.java
@@ -58,8 +58,7 @@ public class TaskRun implements TenantInterface {
     List<TaskRunAttempt> attempts;
 
     // Lineage bundles, one AssetsInOut per (inputs -> outputs) pair, kept unmerged so each becomes its own
-    // lineage event downstream. This is the single source of truth for a taskRun's assets. The pre-existing
-    // single `assets` object is folded in here via the deprecated setAssets bridge below.
+    // lineage event. Canonical store for a taskRun's assets (the legacy single `assets` folds in via setAssets).
     @With
     @Nullable
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
@@ -98,11 +97,10 @@ public class TaskRun implements TenantInterface {
     }
 
     /**
-     * Backward-compatibility bridge for the pre-existing single `assets` bundle. Executions serialized
-     * before `assetEmits` existed carry a single `assets` object; this folds it into `assetEmits` on
-     * deserialization so old executions still load. New code should use {@link #getAssetEmits()}.
+     * Folds the pre-existing single `assets` object into {@code assetEmits} when deserializing executions
+     * saved before `assetEmits` existed, so old executions still load. New code uses {@link #getAssetEmits()}.
      *
-     * @deprecated use {@code assetEmits}. Kept only so historical executions deserialize.
+     * @deprecated use {@code assetEmits}.
      */
     @Deprecated(forRemoval = true, since = "2.0.0")
     @JsonSetter("assets")

--- a/core/src/test/java/io/kestra/core/models/executions/TaskRunTest.java
+++ b/core/src/test/java/io/kestra/core/models/executions/TaskRunTest.java
@@ -1,14 +1,82 @@
 package io.kestra.core.models.executions;
 
 import java.util.Collections;
+import java.util.List;
 
 import org.junit.jupiter.api.Test;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import io.kestra.core.models.assets.AssetIdentifier;
+import io.kestra.core.models.assets.AssetsInOut;
+import io.kestra.core.models.assets.Custom;
 import io.kestra.core.models.flows.State;
+import io.kestra.core.serializers.JacksonMapper;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 class TaskRunTest {
+    private static final ObjectMapper MAPPER = JacksonMapper.ofJson();
+
+    // Backward compatibility: executions serialized before `assetEmits` existed carry a single `assets`
+    // object. It must fold into `assetEmits` so historical executions still deserialize.
+    @Test
+    void shouldFoldLegacySingleAssetsIntoAssetEmitsOnDeserialize() throws Exception {
+        TaskRun base = TaskRun.builder()
+            .tenantId("main").id("tr1").executionId("ex1").namespace("ns").flowId("f").taskId("t")
+            .state(new State())
+            .build();
+
+        // craft a pre-change payload: a single `assets` object (not the new `assetEmits` array)
+        ObjectNode node = (ObjectNode) MAPPER.valueToTree(base);
+        ObjectNode legacyAssets = MAPPER.createObjectNode();
+        legacyAssets.set(
+            "inputs", MAPPER.createArrayNode()
+                .add(MAPPER.valueToTree(new AssetIdentifier("main", "ns", "asset_a", "io.kestra.plugin.ee.assets.Table")))
+        );
+        // real old executions also carry polymorphic Asset outputs (e.g. Custom/Table), exercise that too
+        legacyAssets.set("outputs", MAPPER.createArrayNode()
+            .add(MAPPER.valueToTree(Custom.builder()
+                .tenantId("main").namespace("ns").id("asset_b").type("io.kestra.plugin.ee.assets.Table").build())));
+        node.set("assets", legacyAssets);
+
+        TaskRun restored = MAPPER.treeToValue(node, TaskRun.class);
+
+        assertThat(restored.getAssetEmits()).hasSize(1);
+        assertThat(restored.getAssetEmits().getFirst().getInputs()).hasSize(1);
+        assertThat(restored.getAssetEmits().getFirst().getInputs().getFirst().id()).isEqualTo("asset_a");
+        assertThat(restored.getAssetEmits().getFirst().getOutputs()).hasSize(1);
+        assertThat(restored.getAssetEmits().getFirst().getOutputs().getFirst().getId()).isEqualTo("asset_b");
+        // deprecated bridge still returns a single bundle for callers like ApiTaskRun
+        assertThat(restored.getAssets()).isNotNull();
+    }
+
+    // Modern payloads serialize as `assetEmits` and never write the legacy `assets` key.
+    @Test
+    void shouldSerializeAsAssetEmitsAndNotLegacyAssets() throws Exception {
+        TaskRun modern = TaskRun.builder()
+            .tenantId("main").id("tr1").executionId("ex1").namespace("ns").flowId("f").taskId("t")
+            .state(new State())
+            .assetEmits(
+                List.of(
+                    new AssetsInOut(
+                        List.of(new AssetIdentifier("main", "ns", "asset_a", "io.kestra.plugin.ee.assets.Table")),
+                        List.of()
+                    )
+                )
+            )
+            .build();
+
+        String json = MAPPER.writeValueAsString(modern);
+        assertThat(json).contains("assetEmits");
+        assertThat(json).doesNotContain("\"assets\"");
+
+        TaskRun roundTrip = MAPPER.readValue(json, TaskRun.class);
+        assertThat(roundTrip.getAssetEmits()).hasSize(1);
+        assertThat(roundTrip.getAssetEmits().getFirst().getInputs().getFirst().id()).isEqualTo("asset_a");
+    }
+
     @Test
     void onRunningResendNoAttempts() {
         TaskRun taskRun = TaskRun.builder()

--- a/core/src/test/java/io/kestra/core/models/executions/TaskRunTest.java
+++ b/core/src/test/java/io/kestra/core/models/executions/TaskRunTest.java
@@ -48,8 +48,6 @@ class TaskRunTest {
         assertThat(restored.getAssetEmits().getFirst().getInputs().getFirst().id()).isEqualTo("asset_a");
         assertThat(restored.getAssetEmits().getFirst().getOutputs()).hasSize(1);
         assertThat(restored.getAssetEmits().getFirst().getOutputs().getFirst().getId()).isEqualTo("asset_b");
-        // deprecated bridge still returns a single bundle for callers like ApiTaskRun
-        assertThat(restored.getAssets()).isNotNull();
     }
 
     // Modern payloads serialize as `assetEmits` and never write the legacy `assets` key.

--- a/executor/src/main/java/io/kestra/executor/ExecutorService.java
+++ b/executor/src/main/java/io/kestra/executor/ExecutorService.java
@@ -1180,18 +1180,20 @@ public class ExecutorService {
                         .taskRun(
                             fixtureAndTaskRun.taskRun()
                                 .withState(Optional.ofNullable(fixtureAndTaskRun.fixture().getState()).orElse(State.Type.SUCCESS))
-                                .withAssets(
-                                    new AssetsInOut(
-                                        Optional.ofNullable(assetsDeclaration).map(AssetsDeclaration::getInputs)
-                                            .map(throwFunction(assetInputs -> runContext.render(assetInputs).asList(AssetIdentifier.class)))
-                                            .stream()
-                                            .flatMap(Collection::stream)
-                                            .map(throwFunction(assetIdentifier -> assetIdentifier.withTenantId(executor.getFlow().getTenantId())))
-                                            .toList(),
-                                        fixtureAndTaskRun.fixture().getAssets() == null ? null
-                                            : fixtureAndTaskRun.fixture().getAssets().stream()
-                                                .map(asset -> asset.withTenantId(executor.getFlow().getTenantId()))
-                                                .toList()
+                                .withAssetEmits(
+                                    List.of(
+                                        new AssetsInOut(
+                                            Optional.ofNullable(assetsDeclaration).map(AssetsDeclaration::getInputs)
+                                                .map(throwFunction(assetInputs -> runContext.render(assetInputs).asList(AssetIdentifier.class)))
+                                                .stream()
+                                                .flatMap(Collection::stream)
+                                                .map(throwFunction(assetIdentifier -> assetIdentifier.withTenantId(executor.getFlow().getTenantId())))
+                                                .toList(),
+                                            fixtureAndTaskRun.fixture().getAssets() == null ? null
+                                                : fixtureAndTaskRun.fixture().getAssets().stream()
+                                                    .map(asset -> asset.withTenantId(executor.getFlow().getTenantId()))
+                                                    .toList()
+                                        )
                                     )
                                 )
                         )
@@ -1469,9 +1471,10 @@ public class ExecutorService {
                 taskOutputService.saveOutputs(taskRun, workerTaskResult.getOutputs());
 
                 ExecutionKind executionKind = Optional.ofNullable(executor.getExecution().getKind()).orElse(ExecutionKind.NORMAL);
+                boolean hasAssets = taskRun.getAssetEmits() != null && taskRun.getAssetEmits().stream()
+                    .anyMatch(bundle -> !bundle.getInputs().isEmpty() || !bundle.getOutputs().isEmpty());
                 if (
-                    taskRun.getAssets() != null &&
-                        (!taskRun.getAssets().getInputs().isEmpty() || !taskRun.getAssets().getOutputs().isEmpty())
+                    hasAssets
                         && executionKind != ExecutionKind.TEST
                 ) {
                     AssetUser assetUser = new AssetUser(

--- a/executor/src/test/java/io/kestra/executor/ExecutorServiceProcessTaskRunAssetsTest.java
+++ b/executor/src/test/java/io/kestra/executor/ExecutorServiceProcessTaskRunAssetsTest.java
@@ -169,7 +169,7 @@ class ExecutorServiceProcessTaskRunAssetsTest {
 
         var terminalTaskRun = placeholder
             .withState(terminalState)
-            .withAssets(assets);
+            .withAssetEmits(assets == null ? null : List.of(assets));
 
         var executor = new ExecutorContext(execution, FlowWithSource.of(flow, "flow-source"));
         var workerTaskResult = new WorkerTaskResult(terminalTaskRun);

--- a/webserver/src/main/java/io/kestra/webserver/models/api/ApiTaskRun.java
+++ b/webserver/src/main/java/io/kestra/webserver/models/api/ApiTaskRun.java
@@ -14,14 +14,14 @@ public record ApiTaskRun(@NotNull String id,
     String parentTaskRunId,
     String value,
     List<TaskRunAttempt> attempts,
-    AssetsInOut assets,
+    List<AssetsInOut> assetEmits,
     @NotNull State state,
     Integer iteration,
     Boolean dynamic,
     Boolean forceExecution) {
     public static ApiTaskRun of(TaskRun taskRun) {
         return new ApiTaskRun(
-            taskRun.getId(), taskRun.getTaskId(), taskRun.getParentTaskRunId(), taskRun.getValue(), taskRun.getAttempts(), taskRun.getAssets(), taskRun.getState(), taskRun.getIteration(),
+            taskRun.getId(), taskRun.getTaskId(), taskRun.getParentTaskRunId(), taskRun.getValue(), taskRun.getAttempts(), taskRun.getAssetEmits(), taskRun.getState(), taskRun.getIteration(),
             taskRun.getDynamic(), taskRun.getForceExecution()
         );
     }

--- a/worker/src/main/java/io/kestra/worker/processors/WorkerTaskProcessor.java
+++ b/worker/src/main/java/io/kestra/worker/processors/WorkerTaskProcessor.java
@@ -13,7 +13,6 @@ import java.time.Instant;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.stream.Stream;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 import java.util.zip.ZipOutputStream;
@@ -458,21 +457,22 @@ public class WorkerTaskProcessor extends AbstractWorkerJobProcessor<WorkerTask> 
                 // We need to have the task outputs injected before rendering the assets
                 Map<String, Object> formattedOutputsMap = RunVariables.executionFormattedOutputMap(taskRun, outputs);
 
-                List<AssetEmit> assetEmits = runContext.assets().emitted();
                 AssetsDeclaration assetsDeclaration = workerTask.getTask().getAssets();
 
-                taskRun = taskRun.withAssets(
-                    new AssetsInOut(
-                        Stream.concat(
-                            runContext.render(assetsDeclaration.getInputs()).asList(AssetIdentifier.class, formattedOutputsMap).stream(),
-                            assetEmits.stream().map(AssetEmit::inputs).flatMap(Collection::stream)
-                        ).toList(),
-                        Stream.concat(
-                            runContext.render(assetsDeclaration.getOutputs()).asList(Asset.class, formattedOutputsMap).stream(),
-                            assetEmits.stream().map(AssetEmit::outputs).flatMap(Collection::stream)
-                        ).toList()
-                    )
-                );
+                // Collect every lineage bundle into one list: the manual `assets:` declaration (one bundle) plus
+                // each auto-emitted (inputs -> outputs) pair, kept unmerged so persistence writes one lineage
+                // event per pair instead of a cartesian all-inputs x all-outputs.
+                List<AssetsInOut> bundles = new ArrayList<>();
+                List<AssetIdentifier> declaredInputs = runContext.render(assetsDeclaration.getInputs()).asList(AssetIdentifier.class, formattedOutputsMap);
+                List<Asset> declaredOutputs = runContext.render(assetsDeclaration.getOutputs()).asList(Asset.class, formattedOutputsMap);
+                if (!declaredInputs.isEmpty() || !declaredOutputs.isEmpty()) {
+                    bundles.add(new AssetsInOut(declaredInputs, declaredOutputs));
+                }
+                runContext.assets().emitted().forEach(emit -> bundles.add(new AssetsInOut(emit.inputs(), emit.outputs())));
+
+                if (!bundles.isEmpty()) {
+                    taskRun = taskRun.withAssetEmits(bundles);
+                }
             }
         } catch (Exception e) {
             logger.warn("Unable to render asset declaration for taskRun '{}'", taskRun, e);

--- a/worker/src/main/java/io/kestra/worker/processors/WorkerTaskProcessor.java
+++ b/worker/src/main/java/io/kestra/worker/processors/WorkerTaskProcessor.java
@@ -459,9 +459,8 @@ public class WorkerTaskProcessor extends AbstractWorkerJobProcessor<WorkerTask> 
 
                 AssetsDeclaration assetsDeclaration = workerTask.getTask().getAssets();
 
-                // Collect every lineage bundle into one list: the manual `assets:` declaration (one bundle) plus
-                // each auto-emitted (inputs -> outputs) pair, kept unmerged so persistence writes one lineage
-                // event per pair instead of a cartesian all-inputs x all-outputs.
+                // One bundle per lineage pair (the manual `assets:` declaration plus each auto-emitted pair),
+                // kept unmerged so persistence writes one event per pair instead of a cartesian graph.
                 List<AssetsInOut> bundles = new ArrayList<>();
                 List<AssetIdentifier> declaredInputs = runContext.render(assetsDeclaration.getInputs()).asList(AssetIdentifier.class, formattedOutputsMap);
                 List<Asset> declaredOutputs = runContext.render(assetsDeclaration.getOutputs()).asList(Asset.class, formattedOutputsMap);


### PR DESCRIPTION
Fixes a near-cartesian dbt asset lineage graph: the worker flat-mapped every emitted lineage bundle into one `AssetsInOut`, pairing all inputs with all outputs.

- `TaskRun` now carries `List<AssetsInOut> assetEmits` as the single source of truth for a taskRun's lineage bundles (one per emitted pair, plus the manual `assets:` declaration).
- The old single `assets` object is kept as a deprecated backward-compat bridge: `@JsonSetter("assets")` folds pre-existing executions into `assetEmits` on deserialization, and a deprecated `getAssets()` keeps `ApiTaskRun` working. Historical executions still load, no migration, no API break.
- `WorkerTaskProcessor` stops flat-mapping and collects the declaration plus each emit as separate bundles.
- `ExecutorService` triggers asset processing when any bundle has content.

Verified: legacy `{"assets":{...}}` executions fold into `assetEmits` (TaskRunTest), plus WorkerTaskProcessorTest, ExecutorServiceProcessTaskRunAssetsTest, H2RunnerTest.

- part-of: kestra-io/plugin-dbt#306
- companion PR: kestra-io/kestra-ee#9792
- companion PR: kestra-io/plugin-dbt#311
