### PR TITLE
Replace execSync with execFileSync for git command

### DIFF
--- a/ui/plugins/commit.ts
+++ b/ui/plugins/commit.ts
@@ -1,7 +1,7 @@
 import type {Plugin} from "vite"
-import {execSync} from "child_process"
+import {execFileSync} from "child_process"
 
-const getInfo = (formats: string[]): string[] => formats.map(format => execSync(`git log -1 --format=${format}`).toString().trim())
+const getInfo = (formats: string[]): string[] => formats.map(format => execFileSync("git", ["log", "-1", `--format=${format}`]).toString().trim())
 
 const comment = (message: string, author: string, date: string): string => `
 <!--


### PR DESCRIPTION
### ✨ Description

Replaces `execSync` with `execFileSync` in the commit plugin to improve security and robustness when executing the `git log` command. This change separates the command from its arguments, preventing potential shell injection vulnerabilities and making the code more maintainable.

### 🔗 Related Issue

No related issue.

### 📝 Additional Notes

- Changed from `execSync(`git log -1 --format=${format}`)` to `execFileSync("git", ["log", "-1", `--format=${format}`])`
- `execFileSync` is safer as it doesn't spawn a shell and treats arguments as separate parameters
- No functional changes to the output or behavior of the plugin

### 🤖 AI Authors

Why did the cat sit on the computer? Because it wanted to keep an eye on the mouse! 🐱

https://claude.ai/code/session_01GCfPpK1pSZmM8iftM7UzaA