### PR TITLE
fix(ui): allowlist restored input values by declared input id

### DIFF
--- a/ui/src/composables/useInputsWizard.ts
+++ b/ui/src/composables/useInputsWizard.ts
@@ -171,8 +171,13 @@ export function useInputsWizard(deps: UseInputsWizardDeps) {
         if (!isWizard.value || !formValuesStorageKey.value) return
         try {
             const stored = localStorage.getItem(formValuesStorageKey.value)
-            if (stored) {
-                Object.assign(inputsValues, JSON.parse(stored))
+            if (!stored) return
+            const parsed = JSON.parse(stored)
+            if (!parsed || typeof parsed !== "object") return
+            // Allowlist by declared input id instead of Object.assign, to block mass-assignment of arbitrary/prototype keys.
+            const knownIds = new Set(inputsMetaData.value.map(m => m.id))
+            for (const [id, value] of Object.entries(parsed)) {
+                if (knownIds.has(id)) inputsValues[id] = value
             }
         } catch { /* ignore corrupt storage */ }
     }

--- a/ui/tests/unit/composables/useInputsWizard.spec.ts
+++ b/ui/tests/unit/composables/useInputsWizard.spec.ts
@@ -113,4 +113,22 @@ describe("useInputsWizard persistValues / restorePersistedValues", () => {
         expect(inputsValues["env.region"]).toBe("us-east")
         expect(inputsValues["name"]).toBeUndefined()
     })
+
+    test("restorePersistedValues ignores keys that are not declared inputs (mass-assignment guard)", () => {
+        localStorage.setItem(storageKey, JSON.stringify({
+            "env.region": "us-east",
+            "__proto__": {polluted: "yes"},
+            "notAnInput": "should be dropped",
+        }))
+        const {api, inputsValues} = mountWizard(
+            [{id: "env.region", type: "STRING", required: true} as InputMetaData],
+            FLOW,
+        )
+
+        api.restorePersistedValues()
+
+        expect(inputsValues["env.region"]).toBe("us-east")
+        expect(inputsValues["notAnInput"]).toBeUndefined()
+        expect(({} as any).polluted).toBeUndefined()
+    })
 })


### PR DESCRIPTION
### ✨ Description

`useInputsWizard`'s `restorePersistedValues()` restored in-progress wizard form values from `localStorage` with `Object.assign(inputsValues, JSON.parse(stored))`, merging every key from the parsed blob into the shared reactive form state — including keys like `__proto__` that are not declared flow inputs. This PR replaces the blind `Object.assign` with an explicit allowlist: only keys present in `inputsMetaData` (the flow's declared inputs) are copied over, closing off the mass-assignment/prototype-pollution surface.

### 🔗 Related Issue

Addresses code scanning alert: https://github.com/kestra-io/kestra/security/code-scanning/105 (CWE-601, reported against `ui/src/composables/useInputsWizard.ts:175`).

Note: the alert's CWE-601 (open redirect) label doesn't match this code — there's no redirect involved. The real concern the scanner's `Object.assign` + `JSON.parse` pattern match is flagging is closer to CWE-915 (mass assignment). It also isn't remotely exploitable today, since downstream (`normalizeInputValues` in `ui/src/utils/submitTask.ts`) already allowlists by the flow's declared input schema before anything is submitted — but hardening the restore path directly is cheap and removes the fragility of relying on that downstream filter alone.

### 🎨 Frontend Checklist

- [x] Code builds without errors (`npm run build`)
- [ ] All existing E2E tests pass (`npm run test:e2e`) — not run; added/verified unit tests instead (`npm run test:unit -- useInputsWizard`, all 6 passing) and `npm run check:types`
- [ ] Screenshots or video recordings attached showing the `UI` changes — no visible UI change, this is an internal data-handling fix

### 📝 Additional Notes

Added a regression test (`restorePersistedValues ignores keys that are not declared inputs (mass-assignment guard)`) covering both a stray unknown key and a `__proto__` key.

### 🤖 AI Authors

Why did the cat refuse to merge the pull request? It didn't want any more *mass* purr-assignment issues.


---
_Generated by [Claude Code](https://claude.ai/code/session_01BDiGyrn9wXzY2ebUvHVMd7)_