### PR TITLE
fix(onboarding): keep the product tour on step 1 until a flow editor opens

### DIFF
--- a/ui/src/components/onboarding/tour/tourScenes.ts
+++ b/ui/src/components/onboarding/tour/tourScenes.ts
@@ -63,7 +63,11 @@ const isTourExecution = (route: TourRoute) =>
     && route.params.namespace === TOUR_NAMESPACE
     && route.params.flowId === TOUR_FLOW_ID
 
-const isFlowEditor = (route: TourRoute) => String(route.name ?? "").startsWith(FLOW_PARENT_ROUTE)
+const isTourFlow = (route: TourRoute) =>
+    route.params.namespace === TOUR_NAMESPACE && route.params.id === TOUR_FLOW_ID
+
+const isFlowEditor = (route: TourRoute) =>
+    String(route.name ?? "").startsWith(FLOW_PARENT_ROUTE) && isTourFlow(route)
 
 const adoptExecution = (
     {store, route}: TourSceneContext & {route: TourRoute},
@@ -96,7 +100,7 @@ export const TOUR_SCENES: TourScene[] = [
             await actions.openCopilot()
         },
         action: ({actions}) => actions.generateFlow(),
-        completedByUser: ({route}) => route.name !== "ai",
+        completedByUser: ({route}) => route.name === "flows/create" || isFlowEditor(route),
     },
     {
         id: "flow_generated",
@@ -215,7 +219,8 @@ export const TOUR_SCENES: TourScene[] = [
             await actions.showTaskDocs(TOUR_WEBHOOK_TRIGGER_TYPE)
         },
         action: ({actions}) => actions.openTriggersTab(),
-        completedByUser: ({route}) => route.name === `${FLOW_PARENT_ROUTE}/triggers`,
+        completedByUser: ({route}) =>
+            route.name === `${FLOW_PARENT_ROUTE}/triggers` && isTourFlow(route),
     },
     {
         id: "test_event",

--- a/ui/tests/unit/onboarding/tourScenes.spec.ts
+++ b/ui/tests/unit/onboarding/tourScenes.spec.ts
@@ -9,6 +9,8 @@ import {
     tourSceneIndex,
 } from "../../../src/components/onboarding/tour/tourScenes"
 import {
+    TOUR_FLOW_ID,
+    TOUR_NAMESPACE,
     TOUR_FLOW_BASE,
     TOUR_NOTIFY_TASK_BROKEN,
     TOUR_NOTIFY_TASK_FIXED,
@@ -21,6 +23,16 @@ import {
 import en from "../../../src/translations/en.json"
 
 const translations = (en as any).en.onboarding.tour
+
+const TOUR_FLOW_PARAMS = {namespace: TOUR_NAMESPACE, id: TOUR_FLOW_ID}
+
+const completedOn = (
+    id: string,
+    route: {name: string; params?: Record<string, unknown>},
+) => {
+    const scene = TOUR_SCENES.find((candidate) => candidate.id === id)
+    return Boolean(scene?.completedByUser?.({route: {params: {}, ...route}} as any))
+}
 
 describe("product tour scenes", () => {
     it("has unique scene ids", () => {
@@ -141,6 +153,25 @@ describe("product tour scenes", () => {
             "webhook_trigger",
             "test_event",
         ])
+    })
+
+    it("leaves the copilot step until the flow lands in an editor", () => {
+        expect(completedOn("copilot", {name: "ai"})).toBe(false)
+        expect(completedOn("copilot", {name: "flows/list"})).toBe(false)
+        expect(completedOn("copilot", {name: "executions/list"})).toBe(false)
+
+        expect(completedOn("copilot", {name: "flows/create"})).toBe(true)
+        expect(completedOn("copilot", {name: "flows/update", params: TOUR_FLOW_PARAMS})).toBe(true)
+    })
+
+    it("follows the user into the tour flow only, not any flow", () => {
+        const otherFlow = {namespace: "other", id: "other"}
+
+        expect(completedOn("first_execution", {name: "flows/update", params: TOUR_FLOW_PARAMS})).toBe(true)
+        expect(completedOn("first_execution", {name: "flows/update", params: otherFlow})).toBe(false)
+
+        expect(completedOn("webhook_trigger", {name: "flows/update/triggers", params: TOUR_FLOW_PARAMS})).toBe(true)
+        expect(completedOn("webhook_trigger", {name: "flows/update/triggers", params: otherFlow})).toBe(false)
     })
 
     it("names every step, for the plan listed on the intro card", () => {


### PR DESCRIPTION
closes https://github.com/kestra-io/kestra-ee/issues/9672

This pull request improves the logic for determining when specific onboarding tour steps are considered complete, ensuring that tour progression only advances when the user is interacting with the designated "tour flow" rather than any flow. It also adds comprehensive tests to verify the updated behavior.

**Tour logic improvements:**

* Refined the `isFlowEditor` function to check that the user is editing the specific "tour flow" by introducing and using a new `isTourFlow` helper. This ensures tour steps only complete when the user is on the correct flow (`tourScenes.ts`).
* Updated the `completedByUser` conditions for the "copilot" and "webhook_trigger" tour scenes to use the new logic, so these steps only complete when the user navigates to the correct tour flow routes (`tourScenes.ts`). [[1]](diffhunk://#diff-56c4ac07f23322731f51d73864aaa1dc642cddcb4d080c6351187e615de88f8fL99-R103) [[2]](diffhunk://#diff-56c4ac07f23322731f51d73864aaa1dc642cddcb4d080c6351187e615de88f8fL218-R223)

**Testing improvements:**

* Added new test helpers and test cases to confirm that tour steps only complete when the user is interacting with the correct flow and not with any other flow, covering the new logic in detail (`tourScenes.spec.ts`). [[1]](diffhunk://#diff-ca595258a4ef909de4ac43ca6ec418895ae6f5504de0cb2109d3f19701670182R27-R36) [[2]](diffhunk://#diff-ca595258a4ef909de4ac43ca6ec418895ae6f5504de0cb2109d3f19701670182R158-R176)
* Added missing imports for `TOUR_FLOW_ID` and `TOUR_NAMESPACE` to support the new tests (`tourScenes.spec.ts`).