### PR TITLE
fix(flows): show invalid flow save errors

### DIFF
--- a/ui/src/stores/flow.ts
+++ b/ui/src/stores/flow.ts
@@ -134,10 +134,6 @@ export const useFlowStore = defineStore("flow", () => {
             return "no_op"
         }
 
-        if (flowErrors.value?.length && !isDraft) {
-            return "blocked"
-        }
-
         if (!flow.value) return "blocked"
         const source = flowYaml.value
         const validation = await onEdit({source})
@@ -177,10 +173,6 @@ export const useFlowStore = defineStore("flow", () => {
     }
 
     async function save(draft: boolean = false): Promise<FlowSaveOutcome> {
-        if (flowErrors.value?.length && !draft) {
-            return "blocked"
-        }
-
         const source = flowYaml.value
 
         if (source) {

--- a/ui/tests/unit/stores/flowDraftSave.spec.ts
+++ b/ui/tests/unit/stores/flowDraftSave.spec.ts
@@ -6,6 +6,7 @@ import {createPinia, setActivePinia} from "pinia"
 // `vi.fn(() => …)` infers zero-length call tuples and trips TS2493 under vue-tsc.
 const updateFlow = vi.fn((..._args: any[]) => Promise.resolve({id: "f", namespace: "ns", draft: false, source: ""}))
 const createFlow = vi.fn((..._args: any[]) => Promise.resolve({id: "f", namespace: "ns", draft: false, source: ""}))
+const validateFlows = vi.fn(() => Promise.resolve([{}]))
 // GET /flows/{namespace}/{id} - used by loadFlow() to fetch a flow's source
 const getFlow = vi.fn((..._args: any[]) => Promise.resolve({id: "f", namespace: "ns", draft: true, revision: 1, source: ""}))
 
@@ -16,7 +17,7 @@ vi.mock("@kestra-io/kestra-sdk", () => ({
 // saveFlow()/createFlow() and validateFlow() go through the SDK's flows submodule, not
 // useClient()'s axios instance
 vi.mock("@kestra-io/kestra-sdk/flows", () => ({
-    validateFlows: vi.fn(() => Promise.resolve([{}])),
+    validateFlows,
     updateFlow,
     createFlow,
     flow: getFlow,
@@ -70,6 +71,8 @@ describe("flow draft save — draft resolution per entry point", () => {
         updateFlow.mockClear()
         createFlow.mockClear()
         getFlow.mockClear()
+        validateFlows.mockReset()
+        validateFlows.mockResolvedValue([{}])
         setActivePinia(createPinia())
     })
 
@@ -109,6 +112,26 @@ describe("flow draft save — draft resolution per entry point", () => {
         await store.saveAll()
         expect(lastDraftParam())
             .toBe(false)
+    })
+
+    it("saveAll() sends an invalid published flow to the backend", async () => {
+        const store = await freshStore()
+        validateFlows.mockResolvedValue([{constraints: "Invalid task configuration"}])
+
+        await store.saveAll()
+
+        expect(updateFlow)
+            .toHaveBeenCalledTimes(1)
+    })
+
+    it("save() sends an invalid published flow to the backend", async () => {
+        const store = await freshStore()
+        validateFlows.mockResolvedValue([{constraints: "Invalid task configuration"}])
+
+        await store.save()
+
+        expect(updateFlow)
+            .toHaveBeenCalledTimes(1)
     })
 
     // FlowRun's executionsStore.flow (the run-panel's flow) has no `source` field: publishDraft(target)


### PR DESCRIPTION
## Summary

- submit invalid published flows to the backend on save
- restore the detailed backend validation error toast
- add regression coverage for both save paths

## Root cause

Client-side validation returned early before the save request was sent, so the backend error handler never displayed the full validation message.

Closes #17944

## Validation

- `npx oxlint src/stores/flow.ts tests/unit/stores/flowDraftSave.spec.ts`
- `npx vue-tsc --project tsconfig.test.json --noEmit`
- `npm run test:unit -- tests/unit/stores/flowDraftSave.spec.ts` *(blocked before test execution by this environment's Node 25/jsdom `localStorage.clear()` shim)*