### PR TITLE
tests(flake): flaky trace tests with async span export

### DIFF
--- a/webserver/src/test/java/io/kestra/webserver/otel/TracesTest.java
+++ b/webserver/src/test/java/io/kestra/webserver/otel/TracesTest.java
@@ -1,5 +1,6 @@
 package io.kestra.webserver.otel;
 
+import java.time.Duration;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
@@ -27,6 +28,7 @@ import io.opentelemetry.sdk.trace.data.SpanData;
 import jakarta.inject.Inject;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -66,9 +68,14 @@ public class TracesTest {
         );
         assertThat(result.getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
 
-        List<SpanData> spans = otelTesting.getSpans().stream().filter(span -> tenantId.equals(span.getAttributes().get(TraceUtils.ATTR_TENANT_ID))).toList();
-        assertThat(spans).hasSizeGreaterThanOrEqualTo(6); // rarely, CI shows 6 traces and not 7 and even sometimes 14, probably due to asynchronicity
-        assertThat(spans).extracting(SpanData::getName).contains("EXECUTOR - %s_io.kestra.tests_trace-parent".formatted(tenantId), "WORKER - io.kestra.plugin.core.output.OutputValues");
+        // spans are ended and exported asynchronously to the execution completion, so wait until the expected ones are visible
+        await().atMost(Duration.ofSeconds(10)).untilAsserted(() ->
+            assertThat(spansForTenant(tenantId))
+                .extracting(SpanData::getName)
+                .contains("EXECUTOR - %s_io.kestra.tests_trace-parent".formatted(tenantId), "WORKER - io.kestra.plugin.core.output.OutputValues")
+        );
+
+        List<SpanData> spans = spansForTenant(tenantId);
         Attributes attributes = spans.getFirst().getAttributes();
         assertThat(attributes.size()).isEqualTo(5);
         assertThat(attributes.get(TraceUtils.ATTR_TENANT_ID)).isEqualTo(tenantId);
@@ -92,18 +99,26 @@ public class TracesTest {
         );
         assertThat(result.getState().getCurrent()).isEqualTo(State.Type.FAILED);
 
-        List<SpanData> spans = otelTesting.getSpans().stream()
+        // spans are ended and exported asynchronously to the execution completion, so wait until the expected ones are visible
+        // Both the WORKER task span and the EXECUTOR span must have Status=Error
+        await().atMost(Duration.ofSeconds(10)).untilAsserted(() ->
+        {
+            List<SpanData> spans = spansForTenant(tenantId);
+
+            List<SpanData> workerSpans = spans.stream().filter(s -> s.getName().startsWith("WORKER - ")).toList();
+            assertThat(workerSpans).isNotEmpty();
+            assertThat(workerSpans).allMatch(s -> s.getStatus().getStatusCode() == StatusCode.ERROR);
+
+            List<SpanData> executorSpans = spans.stream().filter(s -> s.getName().startsWith("EXECUTOR - ")).toList();
+            assertThat(executorSpans).isNotEmpty();
+            assertThat(executorSpans).anyMatch(s -> s.getStatus().getStatusCode() == StatusCode.ERROR);
+        });
+    }
+
+    private List<SpanData> spansForTenant(String tenantId) {
+        return otelTesting.getSpans().stream()
             .filter(span -> tenantId.equals(span.getAttributes().get(TraceUtils.ATTR_TENANT_ID)))
             .toList();
-
-        // Both the WORKER task span and the EXECUTOR span must have Status=Error
-        List<SpanData> workerSpans = spans.stream().filter(s -> s.getName().startsWith("WORKER - ")).toList();
-        assertThat(workerSpans).isNotEmpty();
-        assertThat(workerSpans).allMatch(s -> s.getStatus().getStatusCode() == StatusCode.ERROR);
-
-        List<SpanData> executorSpans = spans.stream().filter(s -> s.getName().startsWith("EXECUTOR - ")).toList();
-        assertThat(executorSpans).isNotEmpty();
-        assertThat(executorSpans).anyMatch(s -> s.getStatus().getStatusCode() == StatusCode.ERROR);
     }
 
     @MockBean


### PR DESCRIPTION
### ✨ Description

Fixes flaky OpenTelemetry trace tests by adding proper synchronization for asynchronous span export. The tests were failing intermittently because spans are ended and exported asynchronously after execution completion, but the assertions were checking for spans immediately.

Example of a failing run: https://github.com/kestra-io/kestra/actions/runs/31389426325/job/93457519980 — `runningAFlowShouldGenerateTraces` failed with `Expecting size of: [...] to be greater than or equal to 6 but was 5` on an unrelated PR (#18024).

**Changes:**
- Added `await().atMost(Duration.ofSeconds(10))` to both trace test methods to wait for spans to be exported before assertions
- Removed the `hasSizeGreaterThanOrEqualTo(6)` assertion: the span count equals the number of executor cycles plus one and is not deterministic — cycles coalesce depending on event interleaving, and since the executor dispatches the root task run in its creation cycle the minimum dropped to 5, under the threshold
- Extracted common span filtering logic into a new `spansForTenant()` helper method to reduce duplication
- Updated assertions to run within the await block, ensuring they check for spans only after they've been exported

### 🔗 Related Issue

Resolves flaky test failures in `TracesTest` due to race conditions with async span export, as seen in [this CI run](https://github.com/kestra-io/kestra/actions/runs/31389426325/job/93457519980).

### 🛠️ Backend Checklist

- [x] Code compiles successfully and passes all checks
- [x] All unit and integration tests pass (flaky tests now stabilized)

### 📝 Additional Notes

The root cause was that OpenTelemetry spans are exported asynchronously, but the test assertions were running synchronously immediately after execution completion. By using Awaitility to poll for the expected spans with a reasonable timeout, the tests now reliably wait for the spans to be available before asserting on them.

The 10-second timeout is conservative and should accommodate even slow CI environments while still failing quickly if spans are genuinely missing.

https://claude.ai/code/session_017CQuvfAKNaEioMxvmmWpEL