### PR TITLE
fix(namespaces): reject a file and a directory sharing the same path

### DIFF
--- a/core/src/main/java/io/kestra/core/storages/InternalNamespace.java
+++ b/core/src/main/java/io/kestra/core/storages/InternalNamespace.java
@@ -13,6 +13,7 @@ import java.util.stream.Stream;
 import org.apache.commons.lang3.tuple.Pair;
 import org.slf4j.Logger;
 
+import io.kestra.core.exceptions.ConflictException;
 import io.kestra.core.models.FetchVersion;
 import io.kestra.core.models.QueryFilter;
 import io.kestra.core.models.namespaces.files.NamespaceFileMetadata;
@@ -368,7 +369,7 @@ public class InternalNamespace implements Namespace {
     public List<NamespaceFile> putFile(final Path path, final InputStream content, final Conflicts onAlreadyExist) throws IOException, URISyntaxException {
         final Path normalizedPath = NamespaceFile.normalize(path);
 
-        Optional<NamespaceFileMetadata> inRepository = findByPath(normalizedPath, true);
+        Optional<NamespaceFileMetadata> inRepository = discardConflictingEntry(findByPath(normalizedPath, true), false, normalizedPath);
         int currentVersion = inRepository.map(NamespaceFileMetadata::getVersion).orElse(0);
         NamespaceFile namespaceFile = NamespaceFile.of(namespace, normalizedPath, currentVersion + 1);
         Path storagePath = namespaceFile.storagePath();
@@ -453,6 +454,52 @@ public class InternalNamespace implements Namespace {
     }
 
     /**
+     * Discards an entry returned by a path lookup when it is not of the expected kind.
+     * <p>
+     * A path is either a file or a directory, never both, but path lookups match {@code <path>} and
+     * {@code <path>/} alike, so a directory entry can be returned while writing a file and the other
+     * way around. Taking it at face value corrupts the path: writing a file over a directory entry
+     * derives the new revision from that entry and then stores it as a directory pinned to revision 1,
+     * so the content lands one revision ahead of the indexed one and can never be read back.
+     * <p>
+     * A live entry of the other kind is a genuine conflict and is rejected. A deleted one no longer
+     * owns the path, so it is purged and the write starts from a clean slate.
+     *
+     * @return the entry when it is of the expected kind, otherwise {@link Optional#empty()}.
+     * @throws ConflictException if a live entry of the other kind holds the path.
+     */
+    private Optional<NamespaceFileMetadata> discardConflictingEntry(Optional<NamespaceFileMetadata> found, boolean expectDirectory, Path path) throws IOException {
+        Optional<NamespaceFileMetadata> conflicting = found.filter(metadata -> metadata.isDirectory() != expectDirectory);
+        if (conflicting.isEmpty()) {
+            return found;
+        }
+
+        NamespaceFileMetadata metadata = conflicting.get();
+        if (!metadata.isDeleted()) {
+            throw new ConflictException(
+                String.format(
+                    "Cannot create %s '%s' in namespace '%s': a %s already exists at this path.",
+                    expectDirectory ? "directory" : "file",
+                    path,
+                    namespace,
+                    metadata.isDirectory() ? "directory" : "file"
+                )
+            );
+        }
+
+        logger.debug(
+            "Purging deleted {} '{}' of namespace '{}', its path is being reused by a {}.",
+            metadata.isDirectory() ? "directory" : "file",
+            metadata.getPath(),
+            namespace,
+            expectDirectory ? "directory" : "file"
+        );
+        this.purge(NamespaceFile.fromMetadata(metadata));
+
+        return Optional.empty();
+    }
+
+    /**
      * Make all parent directories for a given path.
      */
     private List<NamespaceFile> mkDirs(String path) throws IOException {
@@ -475,6 +522,8 @@ public class InternalNamespace implements Namespace {
     @Override
     public NamespaceFile createDirectory(Path path) throws IOException {
         final Path normalizedPath = NamespaceFile.normalize(path);
+
+        discardConflictingEntry(findByPath(normalizedPath, true), true, normalizedPath);
 
         NamespaceFileMetadata nsFileMetadata = namespaceFileMetadataRepository.save(
             NamespaceFileMetadata.builder()

--- a/core/src/test/java/io/kestra/core/storages/InternalNamespaceTest.java
+++ b/core/src/test/java/io/kestra/core/storages/InternalNamespaceTest.java
@@ -13,6 +13,8 @@ import org.apache.commons.lang3.tuple.Pair;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import io.kestra.core.exceptions.ConflictException;
+import io.kestra.core.models.namespaces.files.NamespaceFileMetadata;
 import io.kestra.core.repositories.NamespaceFileMetadataRepositoryInterface;
 import io.kestra.core.utils.PathMatcherPredicate;
 import io.kestra.core.utils.TestsUtils;
@@ -23,10 +25,14 @@ import lombok.extern.slf4j.Slf4j;
 
 import static io.kestra.core.tenant.TenantService.MAIN_TENANT;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @MicronautTest
 @Slf4j
 class InternalNamespaceTest {
+
+    private static final Path COLLIDING_FILE = Path.of("/queries/report.sql");
+    private static final String COLLIDING_FILE_CONTENT = "SELECT 1";
 
     @Inject
     private StorageInterface storageInterface;
@@ -325,5 +331,163 @@ class InternalNamespaceTest {
 
         // When / Then
         Assertions.assertThrows(FileNotFoundException.class, () -> namespace.getFileContent(Path.of("/a.txt"), null));
+    }
+
+    @Test
+    void shouldCreateReadableFirstRevisionWhenNothingCollides() throws IOException, URISyntaxException {
+        // Given
+        final String namespaceId = TestsUtils.randomNamespace();
+        final InternalNamespace namespace = new InternalNamespace(log, MAIN_TENANT, namespaceId, storageInterface, namespaceFileMetadataRepository);
+        namespace.createDirectory(Path.of("/queries"));
+
+        // When
+        namespace.putFile(COLLIDING_FILE, new ByteArrayInputStream(COLLIDING_FILE_CONTENT.getBytes()));
+
+        // Then
+        assertCollidingFileIsUsable(namespace, namespaceId);
+    }
+
+    @Test
+    void shouldRejectPutFileWhenADirectoryHoldsThePath() throws IOException {
+        // Given a directory occupying the path of the file about to be written. Path lookups match
+        // '<path>' and '<path>/' alike, so without the kind check the directory entry is taken as the
+        // file's previous revision: the content lands one revision ahead of the indexed one and the
+        // file can never be read back.
+        final String namespaceId = TestsUtils.randomNamespace();
+        final InternalNamespace namespace = new InternalNamespace(log, MAIN_TENANT, namespaceId, storageInterface, namespaceFileMetadataRepository);
+        namespace.createDirectory(COLLIDING_FILE);
+
+        // When / Then
+        assertThatThrownBy(() -> namespace.putFile(COLLIDING_FILE, new ByteArrayInputStream(COLLIDING_FILE_CONTENT.getBytes())))
+            .isInstanceOf(ConflictException.class)
+            .hasMessageContaining("a directory already exists at this path");
+
+        assertThat(collidingFileObjectExists(namespaceId, 2)).as("no revision 2 object written").isFalse();
+        assertThat(storageInterface.getAttributes(MAIN_TENANT, namespaceId, collidingFileUri(namespaceId, 1)).getType())
+            .as("nothing was written over the directory in storage")
+            .isEqualTo(FileAttributes.FileType.Directory);
+        assertThat(namespace.getFileMetadata(COLLIDING_FILE).getType())
+            .as("the directory entry is left untouched in the index")
+            .isEqualTo(FileAttributes.FileType.Directory);
+    }
+
+    @Test
+    void shouldRejectCreateDirectoryWhenAFileHoldsThePath() throws IOException, URISyntaxException {
+        // Given
+        final String namespaceId = TestsUtils.randomNamespace();
+        final InternalNamespace namespace = new InternalNamespace(log, MAIN_TENANT, namespaceId, storageInterface, namespaceFileMetadataRepository);
+        namespace.putFile(COLLIDING_FILE, new ByteArrayInputStream(COLLIDING_FILE_CONTENT.getBytes()));
+
+        // When / Then
+        assertThatThrownBy(() -> namespace.createDirectory(COLLIDING_FILE))
+            .isInstanceOf(ConflictException.class)
+            .hasMessageContaining("a file already exists at this path");
+
+        assertCollidingFileIsUsable(namespace, namespaceId);
+    }
+
+    @Test
+    void shouldCreateTheFileWhenOnlyADeletedDirectoryHoldsThePath() throws IOException, URISyntaxException {
+        // Given a soft-deleted directory entry left behind at the file's path, as an instance is left
+        // after deleting such an entry through the API: deletion only marks it deleted, so it used to
+        // keep the path hostage and break every subsequent creation of that file.
+        final String namespaceId = TestsUtils.randomNamespace();
+        final InternalNamespace namespace = new InternalNamespace(log, MAIN_TENANT, namespaceId, storageInterface, namespaceFileMetadataRepository);
+        seedDeletedDirectoryAtCollidingPath(namespaceId);
+
+        // When
+        namespace.putFile(COLLIDING_FILE, new ByteArrayInputStream(COLLIDING_FILE_CONTENT.getBytes()));
+
+        // Then
+        assertCollidingFileIsUsable(namespace, namespaceId);
+    }
+
+    @Test
+    void shouldCreateTheDirectoryWhenOnlyADeletedFileHoldsThePath() throws IOException, URISyntaxException {
+        // Given
+        final String namespaceId = TestsUtils.randomNamespace();
+        final InternalNamespace namespace = new InternalNamespace(log, MAIN_TENANT, namespaceId, storageInterface, namespaceFileMetadataRepository);
+        namespace.putFile(COLLIDING_FILE, new ByteArrayInputStream(COLLIDING_FILE_CONTENT.getBytes()));
+        namespace.delete(COLLIDING_FILE);
+
+        // When
+        namespace.createDirectory(COLLIDING_FILE);
+
+        // Then
+        assertThat(namespace.getFileMetadata(COLLIDING_FILE).getType()).isEqualTo(FileAttributes.FileType.Directory);
+    }
+
+    @Test
+    void shouldCreateTheFileOnceTheCollidingDirectoryHasBeenDeleted() throws IOException, URISyntaxException {
+        // Given a live directory at the file's path, then deleted. The write below can only succeed if
+        // the stale directory was removed from storage as well as from the index.
+        final String namespaceId = TestsUtils.randomNamespace();
+        final InternalNamespace namespace = new InternalNamespace(log, MAIN_TENANT, namespaceId, storageInterface, namespaceFileMetadataRepository);
+        namespace.createDirectory(COLLIDING_FILE);
+
+        // When
+        namespace.delete(COLLIDING_FILE);
+        namespace.putFile(COLLIDING_FILE, new ByteArrayInputStream(COLLIDING_FILE_CONTENT.getBytes()));
+
+        // Then
+        assertCollidingFileIsUsable(namespace, namespaceId);
+    }
+
+    @Test
+    void shouldRecreateTheFileAfterItHasBeenDeleted() throws IOException, URISyntaxException {
+        // Given
+        final String namespaceId = TestsUtils.randomNamespace();
+        final InternalNamespace namespace = new InternalNamespace(log, MAIN_TENANT, namespaceId, storageInterface, namespaceFileMetadataRepository);
+        seedDeletedDirectoryAtCollidingPath(namespaceId);
+        namespace.putFile(COLLIDING_FILE, new ByteArrayInputStream(COLLIDING_FILE_CONTENT.getBytes()));
+
+        // When
+        namespace.delete(COLLIDING_FILE);
+        namespace.putFile(COLLIDING_FILE, new ByteArrayInputStream(COLLIDING_FILE_CONTENT.getBytes()));
+
+        // Then
+        try (InputStream is = namespace.getFileContent(COLLIDING_FILE, null)) {
+            assertThat(new String(is.readAllBytes())).isEqualTo(COLLIDING_FILE_CONTENT);
+        }
+        assertThat(namespace.getFileMetadata(COLLIDING_FILE).getType()).isEqualTo(FileAttributes.FileType.File);
+    }
+
+    /**
+     * Writes a directory entry straight to the index, as an object-storage folder marker picked up by a
+     * metadata back-fill would, then soft-deletes it as a deletion through the API does.
+     */
+    private void seedDeletedDirectoryAtCollidingPath(String namespaceId) {
+        NamespaceFileMetadata directory = namespaceFileMetadataRepository.save(
+            NamespaceFileMetadata.builder()
+                .tenantId(MAIN_TENANT)
+                .namespace(namespaceId)
+                .path(COLLIDING_FILE + "/")
+                .size(0L)
+                .build()
+        );
+        namespaceFileMetadataRepository.save(directory.toDeleted());
+    }
+
+    /** Asserts the invariants a usable namespace file holds: one revision, backed by storage, readable, typed as a file. */
+    private void assertCollidingFileIsUsable(InternalNamespace namespace, String namespaceId) throws IOException {
+        int indexedRevision = namespace.get(COLLIDING_FILE).version();
+
+        assertThat(indexedRevision).as("a brand-new file is revision 1").isEqualTo(1);
+        assertThat(collidingFileObjectExists(namespaceId, indexedRevision))
+            .as("the revision recorded in the index (%s) exists in storage", indexedRevision)
+            .isTrue();
+        assertThat(collidingFileObjectExists(namespaceId, 2)).as("no revision 2 object for a brand-new file").isFalse();
+        try (InputStream is = namespace.getFileContent(COLLIDING_FILE, null)) {
+            assertThat(new String(is.readAllBytes())).isEqualTo(COLLIDING_FILE_CONTENT);
+        }
+        assertThat(namespace.getFileMetadata(COLLIDING_FILE).getType()).isEqualTo(FileAttributes.FileType.File);
+    }
+
+    private boolean collidingFileObjectExists(String namespaceId, int revision) throws IOException {
+        return storageInterface.exists(MAIN_TENANT, namespaceId, collidingFileUri(namespaceId, revision));
+    }
+
+    private URI collidingFileUri(String namespaceId, int revision) {
+        return NamespaceFile.of(namespaceId, COLLIDING_FILE, revision).storagePath().toUri();
     }
 }


### PR DESCRIPTION
Backport of #17659 to `releases/v1.3.x` — cherry-pick of 5b7f7b3be544d513bf90ecda3c45824432ad5da8.