### PR TITLE
chore(ci): reword the contributor onboarding messages

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -29,6 +29,9 @@ Watch out for duplicates! If you are creating a new issue, please check existing
 
 ### Your First Code Contribution
 
+#### Get the issue assigned first
+Before you start writing code, comment on the issue you would like to work on and wait until it is assigned to you. This keeps two contributors from solving the same problem twice, and gives us a chance to share context or to flag that the issue still needs a product decision. Pull requests for unassigned issues are welcome, but they may take longer to review, or be closed in favor of work that is already underway.
+
 #### Requirements
 The following dependencies are required to build Kestra locally:
 - Java 25+

--- a/.github/workflows/welcome.yml
+++ b/.github/workflows/welcome.yml
@@ -25,13 +25,13 @@ jobs:
         env:
           # Kept out of the script itself: interpolated there, a backtick or ${ would break out and run as JS.
           OPENED_MESSAGE: |
-            ### Hey @{author} :wave:
+            ### Welcome to Kestra 👋
 
-            Thanks for raising your first pull request - we really appreciate it! :heart:
+            Hey @{author}, thanks for opening your first pull request in this repository - we really appreciate it! ❤️
 
-            Make sure you've checked our [contribution guide](https://kestra.io/docs/contribute-to-kestra/contributing), and don't forget to give us a star! :star:
+            Questions along the way? Ask us on [Slack](https://kestra.io/slack).
 
-            If you're looking for more issues to contribute to, we'd suggest checking our [curated list of good first issues](https://go.kestra.io/contributing) to see if there's something you find interesting and feel comfortable tackling independently. You can further filter the list by labels to narrow down the results (we recommend `area/backend`, `area/frontend`, or `area/plugin`, depending on your preferences).
+            Thanks for all the efforts so far! 🍀
         with:
           script: |
             const author = context.payload.pull_request.user.login;
@@ -70,12 +70,15 @@ jobs:
         if: github.event.action == 'closed'
         uses: actions/github-script@v9
         env:
+          # Kept out of the script itself for the same reason as above: a backtick or ${ interpolated there would break out and run as JS.
           MERGED_MESSAGE: |
-            ### 🎉 Congrats @{author}!
+            ### First PR merged 🎉
 
-            Your first pull request has been merged - thanks a lot for your contribution, we really appreciate it! :heart:
+            Great work @{author}! Your change is now part of Kestra. ❤️
 
-            If you'd like to keep contributing, feel free to check out our [good first issues](https://go.kestra.io/contributing). And don't forget to give us a star! :star:
+            Up for another? Our [curated list of good first issues](https://go.kestra.io/contributing) is the best place to look, and you can filter it by `area/backend`, `area/frontend` or `area/plugin` depending on what you enjoy. Just comment on the one you pick and wait until we assign it to you before starting.
+
+            Thanks again for making Kestra better - and don't forget to ⭐ the repo!
         with:
           script: |
             const author = context.payload.pull_request.user.login;


### PR DESCRIPTION
## What

Rewords the two comments posted by the Contributor Onboarding workflow, and writes down the issue assignment convention that maintainers have been commenting by hand.

### `.github/workflows/welcome.yml`

- The `@mention` moves out of the `###` heading into the body, so the heading is no longer a large line of text built around a username.
- Literal emoji replace the `:wave:` / `:heart:` / `:star:` shortcodes, which do not render in email notifications.
- Plain hyphens instead of em dashes, consistently across both messages.
- The opened message drops the contribution guide link. GitHub already surfaces `CONTRIBUTING.md` on the new pull request page, so by the time this comment is posted the link is redundant.
- The opened message now says "first pull request **in this repository**", which is what the workflow actually detects: both gate checks (`listCommits` and `listForRepo`) are scoped to a single repository, so a contributor with merged pull requests in another Kestra repository still receives this comment here.
- The merged message gets a shorter heading and a different opening sentence, so the two comments no longer read from the same template.
- The merged message no longer implies that commenting on an issue is enough to claim it. Contributors are asked to wait for the assignment, which matches `CONTRIBUTING.md`.

### `.github/CONTRIBUTING.md`

Adds a **Get the issue assigned first** section under *Your first code contribution*. This is the convention maintainers were writing manually on first-time pull requests (for example on https://github.com/kestra-io/kestra/pull/17986), and it was not documented anywhere.

## Notes

`kestra` and `docs` are the only two repositories in the organisation that have this workflow, and their `welcome.yml` files were byte-identical before this change and remain byte-identical after it.

## How this was verified

The workflow only runs for non-member first-time contributors, so it cannot be exercised from this pull request. Instead:

- Both `welcome.yml` files parse with `yaml.safe_load`, and both messages were rendered with the `{author}` placeholder substituted to check the final Markdown.
- The two links kept in the messages resolve: `https://go.kestra.io/contributing` and `https://kestra.io/slack` (the latter is already the link used in `ISSUE_TEMPLATE/config.yml`).
- The `area/backend`, `area/frontend` and `area/plugin` labels referenced by the merged message exist in both repositories, so the filtering hint is accurate in both.
- The backticks introduced into `MERGED_MESSAGE` are safe because the message lives in `env:` rather than being interpolated into the `script:` block; a comment above it now records that, matching the one that already existed above `OPENED_MESSAGE`.

Companion pull request: https://github.com/kestra-io/docs/pull/5311
