### PR TITLE
fix(system): let the browser handle right-click on sidebar links

### DIFF
--- a/ui/src/components/layout/SideBar.vue
+++ b/ui/src/components/layout/SideBar.vue
@@ -1,5 +1,5 @@
 <template>
-    <KsSideBar id="side-menu" v-bind="$attrs" :class="{'is-collapsed': collapsed}" @contextmenu.prevent="onContextMenu">
+    <KsSideBar id="side-menu" v-bind="$attrs" :class="{'is-collapsed': collapsed}" @contextmenu="onContextMenu">
         <template #header>
             <KsIconButton
                 class="header-toggle"
@@ -127,6 +127,12 @@
     const CONTEXT_MENU_HEIGHT = 60
 
     function onContextMenu(event: MouseEvent) {
+        if ((event.target as HTMLElement).closest("a[href]")) {
+            // contextmenu doesn't trigger the click listener that closes our menu, so close it explicitly here.
+            hideContextMenu()
+            return
+        }
+        event.preventDefault()
         const x = Math.max(0, Math.min(event.clientX, window.innerWidth - CONTEXT_MENU_WIDTH))
         const y = Math.max(0, Math.min(event.clientY, window.innerHeight - CONTEXT_MENU_HEIGHT))
         contextMenu.value = {visible: true, x, y}

--- a/ui/tests/storybook/layout/SideBar.stories.jsx
+++ b/ui/tests/storybook/layout/SideBar.stories.jsx
@@ -1,4 +1,5 @@
 import {shallowRef} from "vue";
+import {expect, waitFor, within} from "storybook/test";
 import {vueRouter} from "storybook-vue3-router";
 import HomeIcon from "vue-material-design-icons/Home.vue";
 import ContentCopy from "vue-material-design-icons/ContentCopy.vue";
@@ -88,6 +89,7 @@ Default.args = {
       },
       child: [
         {
+          id: "dashboard-submenu1",
           title: "Submenu 1",
           href: "/dashboard/submenu1",
           icon: {
@@ -96,6 +98,7 @@ Default.args = {
           },
         },
         {
+          id: "dashboard-submenu2",
           title: "Submenu 2",
           href: "/dashboard/submenu2",
           icon: {
@@ -114,6 +117,7 @@ Default.args = {
       },
       child: [
         {
+          id: "settings-submenu1",
           title: "Submenu 1",
           href: "/settings/submenu1",
           icon: {
@@ -122,6 +126,7 @@ Default.args = {
           },
         },
         {
+          id: "settings-submenu2",
           title: "Submenu 2",
           href: "/settings/submenu2",
           icon: {
@@ -132,4 +137,29 @@ Default.args = {
       ]
     },
   ]
+};
+
+export const ContextMenuOnLink = Template.bind({});
+ContextMenuOnLink.args = Default.args;
+ContextMenuOnLink.play = async ({canvasElement}) => {
+  const link = within(canvasElement).getByRole("link", {name: /Flows/});
+
+  const event = new MouseEvent("contextmenu", {bubbles: true, cancelable: true});
+  link.dispatchEvent(event);
+
+  await expect(event.defaultPrevented).toBe(false);
+  await expect(within(document.body).queryByRole("menu")).toBeNull();
+};
+
+export const ContextMenuOnSectionTitle = Template.bind({});
+ContextMenuOnSectionTitle.args = Default.args;
+ContextMenuOnSectionTitle.play = async ({canvasElement}) => {
+  const sectionTitle = within(canvasElement).getByRole("button", {name: /Dashboard/});
+
+  const event = new MouseEvent("contextmenu", {bubbles: true, cancelable: true});
+  sectionTitle.dispatchEvent(event);
+
+  await waitFor(() => {
+    within(document.body).getByRole("menuitem", {name: /Customize sidebar/});
+  });
 };


### PR DESCRIPTION
## Summary

Right-clicking anywhere in the left sidebar suppressed the browser's native context menu for the whole surface, replacing it with the app's own "Customize sidebar" entry. Power users lost native actions like "Open link in new tab" when right-clicking a nav item. The `contextmenu` handler now checks what is under the pointer and only takes over when the pointer is not on a navigable link.

## Before / After

- **Right-click on a link (e.g. Flows, Executions, a favourite):**
  - Before: browser context menu was suppressed; only the custom "Customize sidebar" menu appeared.
  - After: the browser's native context menu opens (Open link in new tab, Copy link address, etc.); the custom menu does not appear.
- **Right-click on the background (header strip, section title row, empty area below the last section):**
  - Before and after: unchanged, the custom "Customize sidebar" menu opens.

`Cmd/Ctrl+click`, `Shift+click` and middle-click on sidebar links already worked correctly before this change and are unaffected: vue-router's `guardEvent` returns before `preventDefault()` for modifier and non-primary-button clicks.

Two implementation notes:
- The guard uses `closest("a[href]")` rather than `closest("a")`, so it covers Favourites (`BookmarkLink` renders a `router-link`) while still routing genuinely disabled items, which render as `<span>` with no `href`, to the custom menu.
- The early return calls `hideContextMenu()` because `contextmenu` does not fire the `click` listener that closes the custom menu; without it, the custom menu would stay open behind the browser's.

## Demo

https://github.com/user-attachments/assets/09bf9e5f-2b66-44e6-bbd7-710e0516eb79



closes: https://github.com/kestra-io/kestra/issues/18032

## Test plan

- [x] `ui/tests/storybook/layout/SideBar.stories.jsx`: added `ContextMenuOnLink` (contextmenu on a nav anchor is not default-prevented and no menu is exposed) and `ContextMenuOnSectionTitle` (contextmenu on a section title row opens the custom "Customize sidebar" menu) play-function stories, queried by ARIA role rather than design-system class names. `npm run test:storybook` passes.
- [x] `ContextMenuOnLink` was confirmed to fail when the fix is reverted (`defaultPrevented` becomes `true`), so it guards the actual regression.
- [x] The story fixture's `Dashboard` and `Settings` sub-items were missing `id`, which `resolveSectionItemIds` filters on, so both sections previously rendered empty. Adding the ids makes those sections render, which is what lets the section-title case be exercised.
- [x] `npm run test:lint` passes: 0 errors, and the 4 remaining warnings are pre-existing in files this PR does not touch.
- [x] `npm run check:types` passes for the design-system, app and test projects.
- [x] `npm run translations:check` is clean; no new i18n keys, `customize sidebar` already exists in every locale.
- [x] Live browser QA against a local Kestra instance with the real menu data: nav link and Favourites bookmark both leave the event un-prevented with no custom menu; header strip, section titles and the empty tail all open "Customize sidebar"; and with the custom menu already open, right-clicking a link defers to the browser and closes the custom menu.

> Note: the native menu itself is browser chrome, so it cannot be asserted from page JS. What the tests assert is the mechanism, that the page no longer calls `preventDefault()` on the event.


