### PR TITLE
fix(cli): use logger instead of stdout for the startup ready message

### DIFF
--- a/cli/src/main/java/io/kestra/cli/commands/servers/StandAloneCommand.java
+++ b/cli/src/main/java/io/kestra/cli/commands/servers/StandAloneCommand.java
@@ -21,6 +21,7 @@ import io.kestra.core.utils.Await;
 import jakarta.annotation.Nullable;
 import jakarta.inject.Inject;
 import jakarta.inject.Provider;
+import lombok.extern.slf4j.Slf4j;
 import picocli.CommandLine;
 import picocli.CommandLine.Option;
 
@@ -28,6 +29,7 @@ import picocli.CommandLine.Option;
     name = "standalone",
     description = "Start the standalone all-in-one server"
 )
+@Slf4j
 public class StandAloneCommand extends AbstractServerCommand {
     @CommandLine.Spec
     CommandLine.Model.CommandSpec spec;
@@ -142,7 +144,7 @@ public class StandAloneCommand extends AbstractServerCommand {
                 fileWatcher.startListeningFromConfig();
             }
 
-            embeddedServer.ifPresent(server -> System.out.println("\n✅ Kestra is ready! Open the UI at: " + server.getURL()));
+            embeddedServer.ifPresent(server -> log.info("✅ Kestra is ready! Open the UI at: {}", server.getURL()));
 
             Await.await().forever().until(() -> !this.applicationContext.isRunning());
         }

--- a/cli/src/main/java/io/kestra/cli/commands/servers/WebServerCommand.java
+++ b/cli/src/main/java/io/kestra/cli/commands/servers/WebServerCommand.java
@@ -95,7 +95,7 @@ public class WebServerCommand extends AbstractServerCommand {
         }
 
         log.info("Webserver started");
-        embeddedServer.ifPresent(server -> System.out.println("\n✅ Kestra is ready! Open the UI at: " + server.getURL()));
+        embeddedServer.ifPresent(server -> log.info("✅ Kestra is ready! Open the UI at: {}", server.getURL()));
         Await.await().forever().until(() -> !this.applicationContext.isRunning());
         return 0;
     }


### PR DESCRIPTION
## What

The `✅ Kestra is ready!` startup banner was written straight to `System.out`, bypassing the logging framework and breaking log parsers that expect every line to come from the configured logger.

Route it through `log.info` in both server commands:

- `StandAloneCommand` - also gains `@Slf4j`, since Lombok generates `log` as `private static final`, so the one on `AbstractServerCommand` is not inherited.
- `WebServerCommand` - already had a logger; just swaps the `System.out.println` call.

The leading `\n` is dropped, as the logger owns line formatting, and the URL becomes a `{}` parameter instead of string concatenation.

## Notes

`grep -rn "Kestra is ready" --include=*.java` confirms these were the only two occurrences.

Closes #17946
