### PR TITLE
chore(build): re-add Allure test reporting

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -479,6 +479,27 @@ tasks.named('testCodeCoverageReport') {
 }
 
 /**********************************************************************************************************************\
+ * Allure Reports
+ **********************************************************************************************************************/
+subprojects {
+    plugins.withId('java') {
+        dependencies {
+            testImplementation "io.qameta.allure:allure-junit5"
+        }
+
+        test {
+            // allure-junit5 writes results as a side effect of the test JVM, invisible to Gradle's
+            // dependency tracking. Without declaring it as a task output, a build-cache hit on :test
+            // (org.gradle.caching=true) restores build/test-results/ but skips the JVM entirely, so
+            // no allure-results are ever produced for that run.
+            def allureResultsDir = layout.buildDirectory.dir("allure-results")
+            systemProperty 'allure.results.directory', allureResultsDir.get().asFile.absolutePath
+            outputs.dir(allureResultsDir)
+        }
+    }
+}
+
+/**********************************************************************************************************************\
  * Sonar
  **********************************************************************************************************************/
 subprojects {

--- a/platform/build.gradle
+++ b/platform/build.gradle
@@ -39,6 +39,7 @@ dependencies {
     api platform('software.amazon.awssdk:bom:2.50.2')
     api platform("dev.langchain4j:langchain4j-bom:$langchain4jVersion")
     api platform("dev.langchain4j:langchain4j-community-bom:$langchain4jCommunityVersion")
+    api platform("io.qameta.allure:allure-bom:2.35.1")
 
     constraints {
         api("io.opentelemetry.proto:opentelemetry-proto:1.11.0-alpha")


### PR DESCRIPTION
## Summary

- Re-adds the `allure-junit5` test dependency and `allure-bom` platform dependency that were removed in #15363.
- Leaves out the AspectJ weaver `javaagent` and the `mockitoAgent`/`agent` configuration rework from #15363 — the JFR Event Stream thread started by the AspectJ weaver agent was the actual source of the `OutOfMemoryError` in CI, not Allure itself.
- Explicitly wires `allure.results.directory` as a declared `test` task output so a Gradle build-cache hit on `:test` still produces `allure-results`.

Related: #15363

## Test plan

- [ ] CI passes without OOM errors
- [ ] `allure-results` are produced under each module's `build/allure-results`