### PR TITLE
ci: run backend and e2e tests on an 8-core runner

### DIFF
--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -65,6 +65,7 @@ jobs:
       DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
     with:
       java-version: 25
+      runner: ubuntu-latest-8-core
 
   frontend-tests:
     name: Frontend tests

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -166,6 +166,7 @@ jobs:
       DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
     with:
       java-version: 25
+      runner: ubuntu-latest-8-core
 
   # Built once here, consumed by both the E2E tests and the PR docker image
   # publish (previously each of them rebuilt the whole product themselves).
@@ -191,6 +192,7 @@ jobs:
     with:
       java-version: 25
       exe-artifact: ${{ needs.build-artifacts.result == 'success' && 'exe' || '' }}
+      runner: ubuntu-latest-8-core
 
   generate-pull-request-docker-image:
     name: Generate PR docker image


### PR DESCRIPTION
## Summary
- Adds `runner: ubuntu-latest-8-core` to the `backend` job in `pull-request.yml`, the `e2e-tests` job in `pull-request.yml`, and the `backend-tests` job in `main-build.yml` — the two CPU-bound jobs on the critical path (Gradle `check javadoc` at 9-25min, Playwright E2E at 15-17min on the default 4 vCPU runner).
- Everything else (frontend tests, design-system tests, publish jobs, CodeQL, dependency checks, etc.) stays on the free default `ubuntu-latest`.

## Dependency
This depends on [kestra-io/actions#190](https://github.com/kestra-io/actions/pull/190), which adds the opt-in `runner` input those reusable workflows read (default `ubuntu-latest`, so no other consumer is affected). **This PR's CI will fail until that one merges** — the `runner` input doesn't exist on `kestra-io/actions@main` yet.

## Test plan
- [ ] kestra-io/actions#190 merged first
- [ ] `Backend - Tests` job in this PR's own CI run picks up the 8-core runner (check `runner_name`/labels via `gh api .../jobs`)
- [ ] Compare `Gradle - check and javadoc` step duration against recent `develop` runs (baseline ~9-25min) — expect a drop toward ~14min
- [ ] Confirm no OOM / heap dump (`-XX:+HeapDumpOnOutOfMemoryError`) on the new runner