### PR TITLE
build: budget gradle workers/forks for the 8-core CI runner

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -253,6 +253,10 @@ subprojects {subProj ->
             // set Xmx for test workers
             t.maxHeapSize = '4g'
 
+            // Parallelize across forks on CI, where org.gradle.workers.max budgets for
+            // it; stay single-forked locally so a laptop isn't oversubscribed.
+            t.maxParallelForks = (System.getenv('CI') ? 2 : 1)
+
             // configure en_US default locale for tests
             t.systemProperty 'user.language', 'en'
             t.systemProperty 'user.country', 'US'
@@ -285,9 +289,10 @@ subprojects {subProj ->
                 junitXml.outputLocation = layout.buildDirectory.dir("test-results/test")
             }
 
-            // Integration tests typically not parallel (but you can enable)
-            maxParallelForks = 1
             commonTestConfig(t)
+            // Integration tests share DB state, so keep this one single-forked
+            // regardless of commonTestConfig's CI default.
+            maxParallelForks = 1
         }
 
         tasks.register('unitTest', Test) { Test t ->

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,3 +5,7 @@ org.gradle.parallel=true
 org.gradle.caching=true
 org.gradle.priority=low
 org.gradle.continue=true
+# Deliberate, rather than defaulting to the CPU count: on the CI runner, 6
+# concurrent 4g test forks (build.gradle maxHeapSize) plus the 2g daemon and
+# the MySQL/Postgres containers from docker-compose-ci.yml fit its 32g RAM.
+org.gradle.workers.max=6


### PR DESCRIPTION
## Summary
- Sets `org.gradle.workers.max=6` explicitly (was unset, defaulting to CPU count) so moving to `ubuntu-latest-8-core` (8 vCPU / 32 GB) doesn't oversubscribe RAM: 6 concurrent test forks at 4-5g `maxHeapSize` + the 2g daemon + the MySQL/Postgres containers from `docker-compose-ci.yml` fit comfortably in 32g.
- Gives the non-integration test tasks (`test`, `unitTest`, `flakyTest`, via `commonTestConfig`) `maxParallelForks = 2` on CI (`CI` env var), stays at `1` locally so a laptop isn't oversubscribed.
- `integrationTest` stays at `maxParallelForks = 1` everywhere — those tests share DB state, so parallelizing them is a separate, riskier change.

## Why draft
Depends on #18073 (the `ubuntu-latest-8-core` runner switch) landing and being verified first — this PR is the highest-leverage change but also the one most likely to surface latent test-isolation bugs (shared DB schema, fixed ports, static state) once forks run concurrently. Land it as its own PR, after the runner switch is green, so a regression is attributable to one change at a time.

## Test plan
- [ ] #18073 merged and its `Backend - Tests` duration confirmed improved
- [ ] `CI=true ./gradlew :queue:unitTest` and `./gradlew :webserver:test --dry-run` verified locally (config evaluates cleanly under both the CI and local fork-count branches)
- [ ] Full `./gradlew check` on the 8-core runner: watch for new flaky-test-report entries and confirm no OOM / heap dump (`-XX:+HeapDumpOnOutOfMemoryError`)
- [ ] Compare `Gradle - check and javadoc` duration against #18073's baseline