### PR TITLE
fix(dashboards): restore the missing no-code chart fields

### DIFF
--- a/ui/src/components/no-code/components/TaskEditor.vue
+++ b/ui/src/components/no-code/components/TaskEditor.vue
@@ -288,11 +288,29 @@
         return typeMap.value[selectedTaskType.value ?? ""] || []
     })
 
+    const resolvedSchemas = computed(() => {
+        return resolvedTypes.value.map((type) => definitions.value?.[type])
+    })
+
+    const dataTypes = computed(() => {
+        const types = new Set<string>()
+        for(const s of resolvedSchemas.value){
+            const dataResolved = s?.properties?.data?.$ref
+                ? getValueAtJsonPath(fullSchema.value, s.properties.data.$ref)
+                : s?.properties?.data
+            const typeConst = dataResolved?.properties?.type?.const
+            if(typeConst){
+                types.add(typeConst)
+            }
+        }
+        return Array.from(types)
+    })
+
     const versionedSchema = ref<Schemas|undefined>()
     const isPluginSchemaLoading = ref(false)
 
     watch([selectedTaskType, resolvedTypes], async ([val, types]) => {
-        if(types.length > 1 && val){
+        if(types.length > 1 && val && dataTypes.value.length <= 1){
             isPluginSchemaLoading.value = true
             try{
                 const {schema} = await pluginsStore.load({
@@ -305,6 +323,8 @@
             } finally {
                 isPluginSchemaLoading.value = false
             }
+        } else {
+            versionedSchema.value = undefined
         }
     }, {immediate: true})
 
@@ -330,10 +350,6 @@
                 ? resolvedTypes.value[0]
                 : selectedTaskType.value ?? "")
             : ""
-    })
-
-    const resolvedSchemas = computed(() => {
-        return resolvedTypes.value.map((type) => definitions.value?.[type])
     })
 
     const REQUIRED_FIELDS = ["id", "data"]
@@ -387,20 +403,6 @@
         }
 
         return undefined
-    })
-
-    const dataTypes = computed(() => {
-        const types = new Set<string>()
-        for(const s of resolvedSchemas.value){
-            const dataResolved = s.properties?.data?.$ref
-                ? getValueAtJsonPath(fullSchema.value, s.properties?.data?.$ref)
-                : s.properties?.data
-            const typeConst = dataResolved?.properties?.type?.const
-            if(typeConst){
-                types.add(typeConst)
-            }
-        }
-        return Array.from(types)
     })
 
     const dataTypesMap = computed(() => dataTypes.value.length > 1 ? {


### PR DESCRIPTION
closes https://github.com/kestra-io/kestra-ee/issues/9360

### Reproducer

1. Dashboards → Create dashboard, switch to the **No Code** panel.
2. Add a chart and pick `io.kestra.plugin.core.dashboard.chart.KPI`.
3. Set `data.type` to `io.kestra.plugin.core.dashboard.data.ExecutionsKPI`.

Equivalent starting YAML (the KPI chart's own `@Example`, minus everything the form should let you fill in):

```yaml
id: kpi_repro
title: KPI repro
charts:
  - id: kpi_success_ratio
    type: io.kestra.plugin.core.dashboard.chart.KPI
    data:
      type: io.kestra.plugin.core.dashboard.data.ExecutionsKPI
```

**Actual:** `chartOptions` and `data` render as empty Complex groups. No `displayName` / `numberType` / `width`, and nothing under `data` beyond the `type` dropdown, so `columns`, `numerator` and `where` are unreachable from the form.

**Expected** (as in in [the docs example](https://kestra.io/docs/ui/dashboard#example-build-a-kpi-success-ratio-chart)): `chartOptions` → `description`, `displayName`, `numberType`, `width`; `data` → `columns`, `numerator`, `where`.

Affects every data chart, since each has one definition per data source and all are discriminated the same way.


FROM

<img width="1740" height="1996" alt="image" src="https://github.com/user-attachments/assets/a2a9e59b-e790-4d29-8053-6c740646c5cd" />

TO

<img width="1740" height="1996" alt="image" src="https://github.com/user-attachments/assets/555496cf-50db-4772-a30f-1cff23ed6e49" />

