### PR TITLE
fix(core): keep per-emit asset lineage bundles instead of flattening (1.3 backport)

### DIFF
--- a/core/src/main/java/io/kestra/core/assets/AssetService.java
+++ b/core/src/main/java/io/kestra/core/assets/AssetService.java
@@ -5,6 +5,7 @@ import java.util.List;
 import io.kestra.core.models.assets.Asset;
 import io.kestra.core.models.assets.AssetIdentifier;
 import io.kestra.core.models.assets.AssetUser;
+import io.kestra.core.models.assets.AssetsInOut;
 import io.kestra.core.queues.QueueException;
 
 import io.micronaut.context.annotation.Secondary;
@@ -17,7 +18,7 @@ public interface AssetService {
 
     Asset syncUpsert(@Nullable Asset inRepository, AssetUser assetUser, Asset assetToUpsert) throws QueueException;
 
-    void assetLineage(AssetUser assetUser, List<AssetIdentifier> inputs, List<AssetIdentifier> outputs) throws QueueException;
+    void assetLineage(AssetUser assetUser, List<AssetIdentifier> inputs, List<AssetIdentifier> outputs, List<AssetsInOut> bundles) throws QueueException;
 
     void deleteAsset(Asset toDelete, AssetUser assetUser) throws QueueException;
 
@@ -36,7 +37,7 @@ public interface AssetService {
         }
 
         @Override
-        public void assetLineage(AssetUser assetUser, List<AssetIdentifier> inputs, List<AssetIdentifier> outputs) {
+        public void assetLineage(AssetUser assetUser, List<AssetIdentifier> inputs, List<AssetIdentifier> outputs, List<AssetsInOut> bundles) {
             // no-op
         }
 

--- a/core/src/main/java/io/kestra/core/models/executions/TaskRun.java
+++ b/core/src/main/java/io/kestra/core/models/executions/TaskRun.java
@@ -64,6 +64,12 @@ public class TaskRun implements TenantInterface {
     @Nullable
     AssetsInOut assets;
 
+    // Lineage bundles, one AssetsInOut per (inputs -> outputs) pair, kept unmerged so each becomes its own lineage event.
+    @With
+    @Nullable
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    List<AssetsInOut> assetEmits;
+
     @NotNull
     State state;
 
@@ -95,6 +101,7 @@ public class TaskRun implements TenantInterface {
             this.attempts,
             this.outputs,
             this.assets,
+            this.assetEmits,
             this.state.withState(state),
             this.iteration,
             this.dynamic,
@@ -124,6 +131,7 @@ public class TaskRun implements TenantInterface {
             newAttempts,
             this.outputs,
             this.assets,
+            this.assetEmits,
             this.state.withState(state),
             this.iteration,
             this.dynamic,
@@ -148,6 +156,7 @@ public class TaskRun implements TenantInterface {
             newAttempts,
             this.outputs,
             this.assets,
+            this.assetEmits,
             this.state.withState(State.Type.FAILED),
             this.iteration,
             this.dynamic,
@@ -168,6 +177,7 @@ public class TaskRun implements TenantInterface {
             .attempts(this.getAttempts())
             .outputs(this.getOutputs())
             .assets(this.getAssets())
+            .assetEmits(this.getAssetEmits())
             .state(state == null ? this.getState() : state)
             .iteration(this.getIteration())
             .build();
@@ -253,6 +263,7 @@ public class TaskRun implements TenantInterface {
             ", state=" + this.getState().getCurrent().toString() +
             ", outputs=" + this.getOutputs() +
             ", assets=" + this.getAssets() +
+            ", assetEmits=" + this.getAssetEmits() +
             ", attempts=" + this.getAttempts() +
             ")";
     }

--- a/core/src/main/java/io/kestra/core/models/executions/TaskRun.java
+++ b/core/src/main/java/io/kestra/core/models/executions/TaskRun.java
@@ -5,7 +5,9 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonSetter;
 
 import io.kestra.core.models.TenantInterface;
 import io.kestra.core.models.assets.AssetsInOut;
@@ -60,10 +62,6 @@ public class TaskRun implements TenantInterface {
     @Schema(implementation = Object.class)
     Variables outputs;
 
-    @With
-    @Nullable
-    AssetsInOut assets;
-
     // Lineage bundles, one AssetsInOut per (inputs -> outputs) pair, kept unmerged so each becomes its own lineage event.
     @With
     @Nullable
@@ -88,6 +86,35 @@ public class TaskRun implements TenantInterface {
         // no-op for backward compatibility
     }
 
+    /**
+     * Folds the pre-existing single `assets` object into {@code assetEmits} when deserializing executions
+     * saved before `assetEmits` existed, so old executions still load. New code uses {@link #getAssetEmits()}.
+     *
+     * @deprecated use {@code assetEmits}.
+     */
+    @Deprecated(forRemoval = true, since = "1.3.33")
+    @JsonSetter("assets")
+    public void setAssets(@Nullable AssetsInOut assets) {
+        if (assets == null) {
+            return;
+        }
+        if (!(this.assetEmits instanceof ArrayList)) {
+            this.assetEmits = this.assetEmits == null ? new ArrayList<>() : new ArrayList<>(this.assetEmits);
+        }
+        this.assetEmits.add(assets);
+    }
+
+    /**
+     * @deprecated use {@link #getAssetEmits()}. Returns the first bundle so callers still expecting a
+     *             single `assets` (e.g. the API layer) keep working. Not serialized.
+     */
+    @Deprecated(forRemoval = true, since = "1.3.33")
+    @JsonIgnore
+    @Nullable
+    public AssetsInOut getAssets() {
+        return this.assetEmits == null || this.assetEmits.isEmpty() ? null : this.assetEmits.getFirst();
+    }
+
     public TaskRun withState(State.Type state) {
         return new TaskRun(
             this.tenantId,
@@ -100,7 +127,6 @@ public class TaskRun implements TenantInterface {
             this.value,
             this.attempts,
             this.outputs,
-            this.assets,
             this.assetEmits,
             this.state.withState(state),
             this.iteration,
@@ -130,7 +156,6 @@ public class TaskRun implements TenantInterface {
             this.value,
             newAttempts,
             this.outputs,
-            this.assets,
             this.assetEmits,
             this.state.withState(state),
             this.iteration,
@@ -155,7 +180,6 @@ public class TaskRun implements TenantInterface {
             this.value,
             newAttempts,
             this.outputs,
-            this.assets,
             this.assetEmits,
             this.state.withState(State.Type.FAILED),
             this.iteration,
@@ -176,7 +200,6 @@ public class TaskRun implements TenantInterface {
             .value(this.getValue())
             .attempts(this.getAttempts())
             .outputs(this.getOutputs())
-            .assets(this.getAssets())
             .assetEmits(this.getAssetEmits())
             .state(state == null ? this.getState() : state)
             .iteration(this.getIteration())
@@ -262,7 +285,6 @@ public class TaskRun implements TenantInterface {
             ", parentTaskRunId=" + this.getParentTaskRunId() +
             ", state=" + this.getState().getCurrent().toString() +
             ", outputs=" + this.getOutputs() +
-            ", assets=" + this.getAssets() +
             ", assetEmits=" + this.getAssetEmits() +
             ", attempts=" + this.getAttempts() +
             ")";

--- a/core/src/main/java/io/kestra/core/models/executions/TaskRun.java
+++ b/core/src/main/java/io/kestra/core/models/executions/TaskRun.java
@@ -5,9 +5,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonSetter;
 
 import io.kestra.core.models.TenantInterface;
 import io.kestra.core.models.assets.AssetsInOut;
@@ -62,6 +60,10 @@ public class TaskRun implements TenantInterface {
     @Schema(implementation = Object.class)
     Variables outputs;
 
+    @With
+    @Nullable
+    AssetsInOut assets;
+
     // Lineage bundles, one AssetsInOut per (inputs -> outputs) pair, kept unmerged so each becomes its own lineage event.
     @With
     @Nullable
@@ -86,35 +88,6 @@ public class TaskRun implements TenantInterface {
         // no-op for backward compatibility
     }
 
-    /**
-     * Folds the pre-existing single `assets` object into {@code assetEmits} when deserializing executions
-     * saved before `assetEmits` existed, so old executions still load. New code uses {@link #getAssetEmits()}.
-     *
-     * @deprecated use {@code assetEmits}.
-     */
-    @Deprecated(forRemoval = true, since = "1.3.33")
-    @JsonSetter("assets")
-    public void setAssets(@Nullable AssetsInOut assets) {
-        if (assets == null) {
-            return;
-        }
-        if (!(this.assetEmits instanceof ArrayList)) {
-            this.assetEmits = this.assetEmits == null ? new ArrayList<>() : new ArrayList<>(this.assetEmits);
-        }
-        this.assetEmits.add(assets);
-    }
-
-    /**
-     * @deprecated use {@link #getAssetEmits()}. Returns the first bundle so callers still expecting a
-     *             single `assets` (e.g. the API layer) keep working. Not serialized.
-     */
-    @Deprecated(forRemoval = true, since = "1.3.33")
-    @JsonIgnore
-    @Nullable
-    public AssetsInOut getAssets() {
-        return this.assetEmits == null || this.assetEmits.isEmpty() ? null : this.assetEmits.getFirst();
-    }
-
     public TaskRun withState(State.Type state) {
         return new TaskRun(
             this.tenantId,
@@ -127,6 +100,7 @@ public class TaskRun implements TenantInterface {
             this.value,
             this.attempts,
             this.outputs,
+            this.assets,
             this.assetEmits,
             this.state.withState(state),
             this.iteration,
@@ -156,6 +130,7 @@ public class TaskRun implements TenantInterface {
             this.value,
             newAttempts,
             this.outputs,
+            this.assets,
             this.assetEmits,
             this.state.withState(state),
             this.iteration,
@@ -180,6 +155,7 @@ public class TaskRun implements TenantInterface {
             this.value,
             newAttempts,
             this.outputs,
+            this.assets,
             this.assetEmits,
             this.state.withState(State.Type.FAILED),
             this.iteration,
@@ -200,6 +176,7 @@ public class TaskRun implements TenantInterface {
             .value(this.getValue())
             .attempts(this.getAttempts())
             .outputs(this.getOutputs())
+            .assets(this.getAssets())
             .assetEmits(this.getAssetEmits())
             .state(state == null ? this.getState() : state)
             .iteration(this.getIteration())
@@ -285,6 +262,7 @@ public class TaskRun implements TenantInterface {
             ", parentTaskRunId=" + this.getParentTaskRunId() +
             ", state=" + this.getState().getCurrent().toString() +
             ", outputs=" + this.getOutputs() +
+            ", assets=" + this.getAssets() +
             ", assetEmits=" + this.getAssetEmits() +
             ", attempts=" + this.getAttempts() +
             ")";

--- a/executor/src/main/java/io/kestra/executor/ExecutorService.java
+++ b/executor/src/main/java/io/kestra/executor/ExecutorService.java
@@ -972,8 +972,8 @@ public class ExecutorService {
                                         fixtureAndTaskRun.fixture().getOutputs() == null ? null : runContext.render(fixtureAndTaskRun.fixture().getOutputs())
                                     )
                                 )
-                                .withAssetEmits(
-                                    List.of(new AssetsInOut(
+                                .withAssets(
+                                    new AssetsInOut(
                                         Optional.ofNullable(assetsDeclaration).map(AssetsDeclaration::getInputs)
                                             .map(throwFunction(assetInputs -> runContext.render(assetInputs).asList(AssetIdentifier.class)))
                                             .stream()
@@ -984,7 +984,7 @@ public class ExecutorService {
                                             : fixtureAndTaskRun.fixture().getAssets().stream()
                                                 .map(asset -> asset.withTenantId(executor.getFlow().getTenantId()))
                                                 .toList()
-                                    ))
+                                    )
                                 )
                         )
                         .build();
@@ -1264,9 +1264,10 @@ public class ExecutorService {
                 .record(taskRun.getState().getDurationOrComputeIt());
 
             ExecutionKind executionKind = Optional.ofNullable(executor.getExecution().getKind()).orElse(ExecutionKind.NORMAL);
-            // Per-emit lineage bundles. Executions saved before assetEmits existed are folded into it on
-            // deserialization by TaskRun.setAssets, so reading assetEmits also covers the legacy single `assets`.
-            List<AssetsInOut> assetBundles = taskRun.getAssetEmits() == null ? List.of() : taskRun.getAssetEmits();
+            // Per-emit lineage bundles, falling back to the legacy single `assets` for task runs produced before assetEmits existed.
+            List<AssetsInOut> assetBundles = taskRun.getAssetEmits() != null && !taskRun.getAssetEmits().isEmpty()
+                ? taskRun.getAssetEmits()
+                : (taskRun.getAssets() != null ? List.of(taskRun.getAssets()) : List.of());
             if (
                 assetBundles.stream().anyMatch(bundle -> !bundle.getInputs().isEmpty() || !bundle.getOutputs().isEmpty())
                     && executionKind != ExecutionKind.TEST

--- a/executor/src/main/java/io/kestra/executor/ExecutorService.java
+++ b/executor/src/main/java/io/kestra/executor/ExecutorService.java
@@ -1264,9 +1264,12 @@ public class ExecutorService {
                 .record(taskRun.getState().getDurationOrComputeIt());
 
             ExecutionKind executionKind = Optional.ofNullable(executor.getExecution().getKind()).orElse(ExecutionKind.NORMAL);
+            // Per-emit lineage bundles, falling back to the legacy single `assets` for task runs produced before assetEmits existed.
+            List<AssetsInOut> assetBundles = taskRun.getAssetEmits() != null && !taskRun.getAssetEmits().isEmpty()
+                ? taskRun.getAssetEmits()
+                : (taskRun.getAssets() != null ? List.of(taskRun.getAssets()) : List.of());
             if (
-                taskRun.getAssets() != null &&
-                    (!taskRun.getAssets().getInputs().isEmpty() || !taskRun.getAssets().getOutputs().isEmpty())
+                assetBundles.stream().anyMatch(bundle -> !bundle.getInputs().isEmpty() || !bundle.getOutputs().isEmpty())
                     && executionKind != ExecutionKind.TEST
             ) {
                 AssetUser assetUser = new AssetUser(
@@ -1282,18 +1285,25 @@ public class ExecutorService {
                     taskRun.getState().getEndDate().orElse(null)
                 );
 
-                List<AssetIdentifier> outputIdentifiers = taskRun.getAssets().getOutputs().stream()
+                // Union across bundles for usage, external-asset creation and triggers (once per asset), while the
+                // bundles themselves are passed through so USED_BY edges stay per-pair instead of a cartesian join.
+                List<AssetIdentifier> outputIdentifiers = assetBundles.stream()
+                    .flatMap(bundle -> bundle.getOutputs().stream())
                     .map(asset -> asset.withTenantId(taskRun.getTenantId()))
                     .map(AssetIdentifier::of)
+                    .distinct()
                     .toList();
-                List<AssetIdentifier> inputAssets = taskRun.getAssets().getInputs().stream()
+                List<AssetIdentifier> inputAssets = assetBundles.stream()
+                    .flatMap(bundle -> bundle.getInputs().stream())
                     .map(assetIdentifier -> assetIdentifier.withTenantId(taskRun.getTenantId()))
+                    .distinct()
                     .toList();
                 try {
                     assetService.assetLineage(
                         assetUser,
                         inputAssets,
-                        outputIdentifiers
+                        outputIdentifiers,
+                        assetBundles
                     );
                 } catch (QueueException e) {
                     log.warn("Unable to submit asset lineage event for {} -> {}", inputAssets, outputIdentifiers, e);
@@ -1301,14 +1311,16 @@ public class ExecutorService {
 
                 // don't update output asserts if task fail
                 if (!taskRun.getState().isFailed()) {
-                    taskRun.getAssets().getOutputs().forEach(asset ->
-                    {
-                        try {
-                            assetService.asyncUpsert(assetUser, asset);
-                        } catch (QueueException e) {
-                            log.warn("Unable to submit asset upsert event for asset {}", asset.getId(), e);
-                        }
-                    });
+                    assetBundles.stream()
+                        .flatMap(bundle -> bundle.getOutputs().stream())
+                        .forEach(asset ->
+                        {
+                            try {
+                                assetService.asyncUpsert(assetUser, asset);
+                            } catch (QueueException e) {
+                                log.warn("Unable to submit asset upsert event for asset {}", asset.getId(), e);
+                            }
+                        });
                 }
             }
         }

--- a/executor/src/main/java/io/kestra/executor/ExecutorService.java
+++ b/executor/src/main/java/io/kestra/executor/ExecutorService.java
@@ -972,8 +972,8 @@ public class ExecutorService {
                                         fixtureAndTaskRun.fixture().getOutputs() == null ? null : runContext.render(fixtureAndTaskRun.fixture().getOutputs())
                                     )
                                 )
-                                .withAssets(
-                                    new AssetsInOut(
+                                .withAssetEmits(
+                                    List.of(new AssetsInOut(
                                         Optional.ofNullable(assetsDeclaration).map(AssetsDeclaration::getInputs)
                                             .map(throwFunction(assetInputs -> runContext.render(assetInputs).asList(AssetIdentifier.class)))
                                             .stream()
@@ -984,7 +984,7 @@ public class ExecutorService {
                                             : fixtureAndTaskRun.fixture().getAssets().stream()
                                                 .map(asset -> asset.withTenantId(executor.getFlow().getTenantId()))
                                                 .toList()
-                                    )
+                                    ))
                                 )
                         )
                         .build();
@@ -1264,10 +1264,9 @@ public class ExecutorService {
                 .record(taskRun.getState().getDurationOrComputeIt());
 
             ExecutionKind executionKind = Optional.ofNullable(executor.getExecution().getKind()).orElse(ExecutionKind.NORMAL);
-            // Per-emit lineage bundles, falling back to the legacy single `assets` for task runs produced before assetEmits existed.
-            List<AssetsInOut> assetBundles = taskRun.getAssetEmits() != null && !taskRun.getAssetEmits().isEmpty()
-                ? taskRun.getAssetEmits()
-                : (taskRun.getAssets() != null ? List.of(taskRun.getAssets()) : List.of());
+            // Per-emit lineage bundles. Executions saved before assetEmits existed are folded into it on
+            // deserialization by TaskRun.setAssets, so reading assetEmits also covers the legacy single `assets`.
+            List<AssetsInOut> assetBundles = taskRun.getAssetEmits() == null ? List.of() : taskRun.getAssetEmits();
             if (
                 assetBundles.stream().anyMatch(bundle -> !bundle.getInputs().isEmpty() || !bundle.getOutputs().isEmpty())
                     && executionKind != ExecutionKind.TEST

--- a/openapi.yml
+++ b/openapi.yml
@@ -8148,6 +8148,9 @@ components:
               - A MAJOR.MINOR version (e.g., `1.1`).
               - A MAJOR.MINOR.PATCH version, optionally with any qualifier
                 (e.g., `1.1.2`, `1.1.0-SNAPSHOT`).
+        pluginDefaultsRef:
+          title: Reference (`ref`) of the `pluginDefaults` to apply to this trigger.
+          type: string
         description:
           type: string
         conditions:
@@ -8284,7 +8287,7 @@ components:
         id:
           maxLength: 150
           minLength: 1
-          pattern: "^[a-zA-Z0-9][a-zA-Z0-9._-]*"
+          pattern: "^[a-zA-Z0-9][a-zA-Z0-9._:-]*"
           type: string
         type:
           minLength: 1
@@ -9693,6 +9696,9 @@ components:
           nullable: true
           allOf:
           - $ref: "#/components/schemas/ExecutionKind"
+        progress:
+          type: string
+          nullable: true
     Map_Object.Object_:
       type: object
       properties:
@@ -10188,6 +10194,10 @@ components:
           type: string
         forced:
           type: boolean
+        ref:
+          title: Optional reference id used to apply this default only to plugins
+            that opt in via `pluginDefaultsRef`.
+          type: string
         values:
           type: object
           additionalProperties: false
@@ -10665,6 +10675,9 @@ components:
               - A MAJOR.MINOR version (e.g., `1.1`).
               - A MAJOR.MINOR.PATCH version, optionally with any qualifier
                 (e.g., `1.1.2`, `1.1.0-SNAPSHOT`).
+        pluginDefaultsRef:
+          title: Reference (`ref`) of the `pluginDefaults` to apply to this task.
+          type: string
         description:
           type: string
         retry:
@@ -10788,6 +10801,11 @@ components:
           nullable: true
           allOf:
           - $ref: "#/components/schemas/AssetsInOut"
+        assetEmits:
+          type: array
+          nullable: true
+          items:
+            $ref: "#/components/schemas/AssetsInOut"
         state:
           $ref: "#/components/schemas/State"
         iteration:

--- a/worker/src/main/java/io/kestra/worker/DefaultWorker.java
+++ b/worker/src/main/java/io/kestra/worker/DefaultWorker.java
@@ -1002,20 +1002,21 @@ public class DefaultWorker implements Worker {
                 // We need to have the task outputs injected before rendering the assets
                 Map<String, Object> formattedOutputsMap = RunVariables.executionFormattedOutputMap(taskRun);
 
-                List<AssetEmit> assetEmits = runContext.assets().emitted();
                 AssetsDeclaration assetsDeclaration = workerTask.getTask().getAssets();
-                taskRun = taskRun.withAssets(
-                    new AssetsInOut(
-                        Stream.concat(
-                            runContext.render(assetsDeclaration.getInputs()).asList(AssetIdentifier.class, formattedOutputsMap).stream(),
-                            assetEmits.stream().map(AssetEmit::inputs).flatMap(Collection::stream)
-                        ).toList(),
-                        Stream.concat(
-                            runContext.render(assetsDeclaration.getOutputs()).asList(Asset.class, formattedOutputsMap).stream(),
-                            assetEmits.stream().map(AssetEmit::outputs).flatMap(Collection::stream)
-                        ).toList()
-                    )
-                );
+
+                // One bundle per lineage pair (the manual `assets:` declaration plus each auto-emitted pair),
+                // kept unmerged so persistence writes one event per pair instead of a cartesian graph.
+                List<AssetsInOut> bundles = new ArrayList<>();
+                List<AssetIdentifier> declaredInputs = runContext.render(assetsDeclaration.getInputs()).asList(AssetIdentifier.class, formattedOutputsMap);
+                List<Asset> declaredOutputs = runContext.render(assetsDeclaration.getOutputs()).asList(Asset.class, formattedOutputsMap);
+                if (!declaredInputs.isEmpty() || !declaredOutputs.isEmpty()) {
+                    bundles.add(new AssetsInOut(declaredInputs, declaredOutputs));
+                }
+                runContext.assets().emitted().forEach(emit -> bundles.add(new AssetsInOut(emit.inputs(), emit.outputs())));
+
+                if (!bundles.isEmpty()) {
+                    taskRun = taskRun.withAssetEmits(bundles);
+                }
             }
         } catch (Exception e) {
             logger.warn("Unable to save output on taskRun '{}'", taskRun, e);


### PR DESCRIPTION
Backport of #18009 to `releases/v1.3.x`.

With `assets.enableAuto: true` on a task that emits many models (for example dbt), the asset lineage graph collapsed into a near-cartesian product: every emit was merged into one `assets` bundle, so USED_BY was drawn from every input to every output.

This keeps each emit as its own bundle:
- `TaskRun`: the single `assets` field is replaced by a per-emit `assetEmits` list, mirroring #18009.
- `DefaultWorker` builds one bundle per emit (plus the manual `assets:` declaration as its own bundle) instead of flattening.
- `ExecutorService` reads `assetEmits` and passes the bundles to `assetLineage`, so USED_BY edges are written per pair.

Backward compatibility (1.3 is a minor). Following Loic's review guidance for the backport:
- A deprecated `@JsonSetter("assets") setAssets(...)` folds the old single `assets` object into `assetEmits` on deserialization, so old executions in the DB still load. This is the same deserialize bridge kept on 2.0.
- The deprecated `getAssets()` getter is kept (2.0 drops it). Loic asked to keep it here so callers expecting a single `assets` keep working.
- `assetEmits` is `@JsonInclude(NON_EMPTY)`.

- part-of: kestra-io/plugin-dbt#306
- companion PR: kestra-io/kestra-ee#9853
