### PR TITLE
fix(triggers): correct timezone handling in generated date columns

### DIFF
--- a/jdbc-h2/src/main/java/io/kestra/repository/h2/migration/V2_0_23FixTriggerDateColumnsMigration.java
+++ b/jdbc-h2/src/main/java/io/kestra/repository/h2/migration/V2_0_23FixTriggerDateColumnsMigration.java
@@ -1,0 +1,54 @@
+package io.kestra.repository.h2.migration;
+
+import java.util.List;
+
+import javax.sql.DataSource;
+
+import io.kestra.jdbc.migration.AbstractSQLMigrationScript;
+
+import io.micronaut.context.annotation.Requires;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+
+/**
+ * H2 migration: stop the {@code triggers} date columns from depending on the stored
+ * {@code Instant} being exactly 27 characters wide.
+ *
+ * <p>
+ * {@code LEFT(value, 26)} drops the trailing {@code Z} only when the fraction is exactly six
+ * digits. At any other width the {@code Z} survives, H2 reads the value as a zoned timestamp and
+ * shifts it into the session timezone — silently wrong on any server not running in UTC. No
+ * current writer produces another width, so this is hardening rather than a live bug; removing the
+ * {@code Z} explicitly is correct for every fraction width.
+ */
+@Singleton
+@Requires(property = "kestra.repository.type", pattern = "h2|memory")
+public class V2_0_23FixTriggerDateColumnsMigration extends AbstractSQLMigrationScript {
+
+    private final DataSource dataSource;
+
+    @Inject
+    public V2_0_23FixTriggerDateColumnsMigration(final DataSource dataSource) {
+        this.dataSource = dataSource;
+    }
+
+    @Override
+    public String scriptId() {
+        return "2.0.23-fix-trigger-date-columns";
+    }
+
+    @Override
+    public String description() {
+        return "H2: fix timezone shift in triggers next_evaluation_date and last_triggered_date";
+    }
+
+    @Override
+    protected DataSource dataSource() {
+        return dataSource;
+    }
+
+    @Override
+    public List<String> sqlResources() {
+        return List.of("/migrations/2.0.23-fix-trigger-date-columns-h2.sql");
+    }
+}

--- a/jdbc-h2/src/main/resources/migrations/2.0.23-fix-trigger-date-columns-h2.sql
+++ b/jdbc-h2/src/main/resources/migrations/2.0.23-fix-trigger-date-columns-h2.sql
@@ -1,0 +1,10 @@
+-- Hardening: removes the width dependency in the two trigger date columns.
+--
+-- JdbcMapper writes an Instant as `uuuu-MM-dd'T'HH:mm:ss.SSSSSS'Z'` (27 chars), and LEFT(v, 26)
+-- drops the trailing 'Z' only at exactly that width. Any other width leaves the 'Z' in place, H2
+-- then reads the value as TIMESTAMP WITH TIME ZONE and converts it into the session timezone on
+-- the way into the zoneless column -- so the stored value is shifted by the server's UTC offset,
+-- and is correct only on a server running in UTC.
+ALTER TABLE triggers ALTER COLUMN "next_evaluation_date" TIMESTAMP GENERATED ALWAYS AS (CAST(REPLACE(LEFT(JQ_STRING("value", '.nextEvaluationDate'), 26), 'Z', '') AS TIMESTAMP));
+
+ALTER TABLE triggers ALTER COLUMN "last_triggered_date" TIMESTAMP GENERATED ALWAYS AS (CAST(REPLACE(LEFT(JQ_STRING("value", '.lastTriggeredDate'), 26), 'Z', '') AS TIMESTAMP));

--- a/jdbc-h2/src/test/java/io/kestra/repository/h2/migration/H2V2_0_23FixTriggerDateColumnsMigrationTest.java
+++ b/jdbc-h2/src/test/java/io/kestra/repository/h2/migration/H2V2_0_23FixTriggerDateColumnsMigrationTest.java
@@ -1,0 +1,156 @@
+package io.kestra.repository.h2.migration;
+
+import org.jooq.Field;
+import org.jooq.impl.DSL;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+
+import io.kestra.jdbc.JooqDSLContextWrapper;
+
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import jakarta.inject.Inject;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * H2-specific integration test for {@link V2_0_23FixTriggerDateColumnsMigration}.
+ *
+ * <p>
+ * The width dependency only shows on a server whose timezone is not UTC, so the session timezone
+ * is forced — otherwise these would pass unchanged on a UTC CI machine even with the fix reverted.
+ */
+@MicronautTest(transactional = false)
+@Execution(ExecutionMode.SAME_THREAD)
+class H2V2_0_23FixTriggerDateColumnsMigrationTest {
+
+    private static final Field<Object> KEY = DSL.field(DSL.quotedName("key"));
+    private static final Field<Object> VALUE = DSL.field(DSL.quotedName("value"));
+
+    /** Read as text so the assertions cannot be perturbed by a client-side timezone conversion. */
+    private static final Field<String> NEXT_EVALUATION_DATE =
+        DSL.field("CAST(\"next_evaluation_date\" AS VARCHAR)", String.class);
+    private static final Field<String> LAST_TRIGGERED_DATE =
+        DSL.field("CAST(\"last_triggered_date\" AS VARCHAR)", String.class);
+
+    private static final String LEGACY_KEY = "fix-trigger-date-columns-legacy";
+    private static final String CURRENT_KEY = "fix-trigger-date-columns-current";
+
+    /** 3 fractional digits, so LEFT(value, 26) leaves the 'Z' in place. */
+    private static final String LEGACY_VALUE = """
+        {"namespace":"io.kestra.tests","flowId":"migration","triggerId":"legacy","disabled":false,\
+        "nextEvaluationDate":"2024-06-01T10:00:00.000Z","lastTriggeredDate":"2024-06-01T10:00:00.000Z"}""";
+
+    /** Current JdbcMapper format: 6 fractional digits. */
+    private static final String CURRENT_VALUE = """
+        {"namespace":"io.kestra.tests","flowId":"migration","triggerId":"current","disabled":false,\
+        "nextEvaluationDate":"2024-06-01T10:00:00.123456Z","lastTriggeredDate":"2024-06-01T10:00:00.123456Z"}""";
+
+    /** The pre-fix expression, restored so the migration has something wrong to recompute. */
+    private static final String PRE_FIX_NEXT_EVALUATION_DATE = """
+        ALTER TABLE triggers ALTER COLUMN "next_evaluation_date" TIMESTAMP \
+        GENERATED ALWAYS AS (CAST(LEFT(JQ_STRING("value", '.nextEvaluationDate'), 26) AS TIMESTAMP))""";
+
+    @Inject
+    JooqDSLContextWrapper dslContextWrapper;
+
+    @Inject
+    V2_0_23FixTriggerDateColumnsMigration migration;
+
+    @BeforeEach
+    @AfterEach
+    void cleanup() {
+        dslContextWrapper.transaction(
+            configuration -> DSL.using(configuration)
+                .deleteFrom(DSL.table("triggers"))
+                .where(KEY.in(LEGACY_KEY, CURRENT_KEY))
+                .execute()
+        );
+    }
+
+    /** Guarantees the fixed definition is in place even if a test fails after reverting it. */
+    @AfterEach
+    void restoreFixedColumnDefinition() throws Exception {
+        migration.migrate();
+    }
+
+    @Test
+    void shouldResolveThreeDigitTimestampToUtcWhenServerIsNotUtc() throws Exception {
+        // Given
+        migration.migrate();
+
+        // When
+        insertWithSessionTimeZone(LEGACY_KEY, LEGACY_VALUE);
+
+        // Then — 2024-06-01T10:00:00Z, not shifted by the +05:30 session offset
+        assertThat(read(NEXT_EVALUATION_DATE, LEGACY_KEY)).isEqualTo("2024-06-01 10:00:00");
+        assertThat(read(LAST_TRIGGERED_DATE, LEGACY_KEY)).isEqualTo("2024-06-01 10:00:00");
+    }
+
+    @Test
+    void shouldKeepMicrosecondPrecisionForCurrentFormat() throws Exception {
+        // Given
+        migration.migrate();
+
+        // When
+        insertWithSessionTimeZone(CURRENT_KEY, CURRENT_VALUE);
+
+        // Then
+        assertThat(read(NEXT_EVALUATION_DATE, CURRENT_KEY)).isEqualTo("2024-06-01 10:00:00.123456");
+        assertThat(read(LAST_TRIGGERED_DATE, CURRENT_KEY)).isEqualTo("2024-06-01 10:00:00.123456");
+    }
+
+    @Test
+    void shouldRecomputeRowsStoredUnderThePreFixExpression() throws Exception {
+        // Given a row written while next_evaluation_date still depended on the 27-character width
+        execute(PRE_FIX_NEXT_EVALUATION_DATE);
+        insertWithSessionTimeZone(LEGACY_KEY, LEGACY_VALUE);
+        assertThat(read(NEXT_EVALUATION_DATE, LEGACY_KEY))
+            .as("the pre-fix expression must shift the value by the +05:30 session offset")
+            .isEqualTo("2024-06-01 15:30:00");
+
+        // When
+        migration.migrate();
+
+        // Then the already-stored row has been recomputed, not just newly inserted ones
+        assertThat(read(NEXT_EVALUATION_DATE, LEGACY_KEY)).isEqualTo("2024-06-01 10:00:00");
+    }
+
+    private void execute(String sql) {
+        dslContextWrapper.transaction(configuration -> DSL.using(configuration).execute(sql));
+    }
+
+    /**
+     * Inserts under a non-UTC session timezone, which is what makes the width dependency
+     * observable. The generated columns are computed and stored at insert time, so the timezone is
+     * restored before reading. jOOQ binds one connection for the lambda and cannot hand it to
+     * another thread while it is checked out, so the {@code finally} keeps the setting from leaking
+     * back into the pool even if the insert throws.
+     */
+    private void insertWithSessionTimeZone(String key, String valueJson) {
+        dslContextWrapper.transaction(configuration -> {
+            var context = DSL.using(configuration);
+            context.execute("SET TIME ZONE '+05:30'");
+            try {
+                context.insertInto(DSL.table("triggers"))
+                    .set(KEY, (Object) key)
+                    .set(VALUE, (Object) valueJson)
+                    .execute();
+            } finally {
+                context.execute("SET TIME ZONE LOCAL");
+            }
+        });
+    }
+
+    private String read(Field<String> field, String key) {
+        return dslContextWrapper.transactionResult(
+            configuration -> DSL.using(configuration)
+                .select(field)
+                .from(DSL.table("triggers"))
+                .where(KEY.eq(key))
+                .fetchOne(field)
+        );
+    }
+}

--- a/jdbc-mysql/src/main/java/io/kestra/repository/mysql/migration/V2_0_23FixDatetimeOffsetMigration.java
+++ b/jdbc-mysql/src/main/java/io/kestra/repository/mysql/migration/V2_0_23FixDatetimeOffsetMigration.java
@@ -1,0 +1,53 @@
+package io.kestra.repository.mysql.migration;
+
+import java.util.List;
+
+import javax.sql.DataSource;
+
+import io.kestra.jdbc.migration.AbstractSQLMigrationScript;
+import io.kestra.repository.mysql.MysqlRepositoryEnabled;
+
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+
+/**
+ * MySQL migration: fix the UTC-offset extraction in the {@code multipleconditions} date columns.
+ *
+ * <p>
+ * The offset written by the {@code .SSSXXX} serializer is six characters, but the extraction read
+ * five of them, so {@code +05:30} was interpreted as {@code +05:03}. Only timezones with a non-zero
+ * minutes part were affected; the rest survived because the dropped character was a {@code 0}.
+ * {@code MultipleConditionWindow.start} / {@code end} are {@link java.time.ZonedDateTime}, so the
+ * window lookup could match a window up to 41 minutes away from the intended one.
+ */
+@Singleton
+@MysqlRepositoryEnabled
+public class V2_0_23FixDatetimeOffsetMigration extends AbstractSQLMigrationScript {
+
+    private final DataSource dataSource;
+
+    @Inject
+    public V2_0_23FixDatetimeOffsetMigration(final DataSource dataSource) {
+        this.dataSource = dataSource;
+    }
+
+    @Override
+    public String scriptId() {
+        return "2.0.23-fix-datetime-offset";
+    }
+
+    @Override
+    public String description() {
+        return "MySQL: fix UTC offset extraction in multipleconditions date columns";
+    }
+
+    @Override
+    protected DataSource dataSource() {
+        return dataSource;
+    }
+
+    @Override
+    public List<String> sqlResources() {
+        return List.of("/migrations/2.0.23-fix-datetime-offset-mysql.sql");
+    }
+}

--- a/jdbc-mysql/src/main/resources/migrations/2.0.23-fix-datetime-offset-mysql.sql
+++ b/jdbc-mysql/src/main/resources/migrations/2.0.23-fix-datetime-offset-mysql.sql
@@ -1,0 +1,33 @@
+-- Fixes the UTC-offset extraction in the multipleconditions date columns.
+--
+-- The offset written by the `.SSSXXX` serializer is always 6 characters (`+02:00`, `-03:30`), but
+-- the extraction read only 5 of them: SUBSTRING(v, LENGTH(v) - 5, 5) yields `-03:3` for `-03:30`,
+-- which CONVERT_TZ then reads as `-03:03`. Offsets whose minutes part is `00` survived by accident
+-- because the dropped character was a `0`, so only timezones with a non-zero minutes part were
+-- affected -- Newfoundland (-03:30), Marquesas (-09:30), India (+05:30), Nepal (+05:45),
+-- Adelaide (+09:30), Iran, Myanmar, Chatham. The sibling SUBSTRING(v, 1, LENGTH(v) - 6) that
+-- strips the offset off the datetime part already used 6, which is the disagreement that gave the
+-- bug away. RIGHT(v, 6) takes the whole offset.
+ALTER TABLE multipleconditions MODIFY COLUMN `start_date` DATETIME(6) GENERATED ALWAYS AS (
+    IF(
+        SUBSTRING(value ->> '$.start', LENGTH(value ->> '$.start'), LENGTH(value ->> '$.start')) = 'Z',
+        STR_TO_DATE(value ->> '$.start', '%Y-%m-%dT%H:%i:%s.%fZ'),
+        CONVERT_TZ(
+            STR_TO_DATE(SUBSTRING(value ->> '$.start', 1, LENGTH(value ->> '$.start') - 6), '%Y-%m-%dT%H:%i:%s.%f'),
+            RIGHT(value ->> '$.start', 6),
+            'UTC'
+        )
+    )
+) STORED NOT NULL;
+
+ALTER TABLE multipleconditions MODIFY COLUMN `end_date` DATETIME(6) GENERATED ALWAYS AS (
+    IF(
+        SUBSTRING(value ->> '$.end', LENGTH(value ->> '$.end'), LENGTH(value ->> '$.end')) = 'Z',
+        STR_TO_DATE(value ->> '$.end', '%Y-%m-%dT%H:%i:%s.%fZ'),
+        CONVERT_TZ(
+            STR_TO_DATE(SUBSTRING(value ->> '$.end', 1, LENGTH(value ->> '$.end') - 6), '%Y-%m-%dT%H:%i:%s.%f'),
+            RIGHT(value ->> '$.end', 6),
+            'UTC'
+        )
+    )
+) STORED NOT NULL;

--- a/jdbc-mysql/src/test/java/io/kestra/repository/mysql/migration/MysqlV2_0_23FixDatetimeOffsetMigrationTest.java
+++ b/jdbc-mysql/src/test/java/io/kestra/repository/mysql/migration/MysqlV2_0_23FixDatetimeOffsetMigrationTest.java
@@ -1,0 +1,144 @@
+package io.kestra.repository.mysql.migration;
+
+import org.jooq.Field;
+import org.jooq.impl.DSL;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+
+import io.kestra.jdbc.JooqDSLContextWrapper;
+
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import jakarta.inject.Inject;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * MySQL-specific integration test for {@link V2_0_23FixDatetimeOffsetMigration}.
+ *
+ * <p>
+ * Only offsets with a non-zero minutes part were corrupted; a whole-hour offset passes either way
+ * because the character the extraction dropped is a {@code 0}. A negative offset is the damaging
+ * case — it moves {@code end_date} backwards, expiring a live window early.
+ */
+@MicronautTest(transactional = false)
+@Execution(ExecutionMode.SAME_THREAD)
+class MysqlV2_0_23FixDatetimeOffsetMigrationTest {
+
+    private static final Field<Object> KEY = DSL.field(DSL.quotedName("key"));
+    private static final Field<Object> VALUE = DSL.field(DSL.quotedName("value"));
+
+    /** Read as text so the assertions cannot be perturbed by a client-side timezone conversion. */
+    private static final Field<String> START_DATE = DSL.field("CAST(`start_date` AS CHAR)", String.class);
+    private static final Field<String> END_DATE = DSL.field("CAST(`end_date` AS CHAR)", String.class);
+
+    private static final String UTC_KEY = "fix-datetime-offset-utc";
+    private static final String PARIS_KEY = "fix-datetime-offset-paris";
+    private static final String KOLKATA_KEY = "fix-datetime-offset-kolkata";
+    private static final String NEWFOUNDLAND_KEY = "fix-datetime-offset-newfoundland";
+
+    /** Every window below spans the same instants: 10:00:00Z to 11:00:00Z on 2024-06-01. */
+    private static final String EXPECTED_START = "2024-06-01 10:00:00.000000";
+    private static final String EXPECTED_END = "2024-06-01 11:00:00.000000";
+
+    /** The pre-fix expression, restored so the migration has something wrong to recompute. */
+    private static final String PRE_FIX_END_DATE = """
+        ALTER TABLE multipleconditions MODIFY COLUMN `end_date` DATETIME(6) GENERATED ALWAYS AS (
+            IF(
+                SUBSTRING(value ->> '$.end', LENGTH(value ->> '$.end'), LENGTH(value ->> '$.end')) = 'Z',
+                STR_TO_DATE(value ->> '$.end', '%Y-%m-%dT%H:%i:%s.%fZ'),
+                CONVERT_TZ(
+                    STR_TO_DATE(SUBSTRING(value ->> '$.end', 1, LENGTH(value ->> '$.end') - 6), '%Y-%m-%dT%H:%i:%s.%f'),
+                    SUBSTRING(value ->> '$.end', LENGTH(value ->> '$.end') - 5, 5),
+                    'UTC'
+                )
+            )
+        ) STORED NOT NULL""";
+
+    @Inject
+    JooqDSLContextWrapper dslContextWrapper;
+
+    @Inject
+    V2_0_23FixDatetimeOffsetMigration migration;
+
+    @BeforeEach
+    @AfterEach
+    void cleanup() {
+        dslContextWrapper.transaction(
+            configuration -> DSL.using(configuration)
+                .deleteFrom(DSL.table("multipleconditions"))
+                .where(KEY.in(UTC_KEY, PARIS_KEY, KOLKATA_KEY, NEWFOUNDLAND_KEY))
+                .execute()
+        );
+    }
+
+    /** Guarantees the fixed definition is in place even if a test fails after reverting it. */
+    @AfterEach
+    void restoreFixedColumnDefinition() throws Exception {
+        migration.migrate();
+    }
+
+    @Test
+    void shouldResolveOffsetsWithNonZeroMinutesToUtc() throws Exception {
+        // Given
+        migration.migrate();
+
+        // When
+        insert(UTC_KEY, "2024-06-01T10:00:00.000Z", "2024-06-01T11:00:00.000Z");
+        insert(PARIS_KEY, "2024-06-01T12:00:00.000+02:00", "2024-06-01T13:00:00.000+02:00");
+        insert(KOLKATA_KEY, "2024-06-01T15:30:00.000+05:30", "2024-06-01T16:30:00.000+05:30");
+        insert(NEWFOUNDLAND_KEY, "2024-06-01T06:30:00.000-03:30", "2024-06-01T07:30:00.000-03:30");
+
+        // Then
+        for (String key : new String[]{UTC_KEY, PARIS_KEY, KOLKATA_KEY, NEWFOUNDLAND_KEY}) {
+            assertThat(read(START_DATE, key)).as("start_date of %s", key).isEqualTo(EXPECTED_START);
+            assertThat(read(END_DATE, key)).as("end_date of %s", key).isEqualTo(EXPECTED_END);
+        }
+    }
+
+    @Test
+    void shouldRecomputeRowsStoredUnderThePreFixExpression() throws Exception {
+        // Given a row written while end_date still used the truncated offset
+        execute(PRE_FIX_END_DATE);
+        insert(NEWFOUNDLAND_KEY, "2024-06-01T06:30:00.000-03:30", "2024-06-01T07:30:00.000-03:30");
+        assertThat(read(END_DATE, NEWFOUNDLAND_KEY))
+            .as("the pre-fix expression reads -03:30 as -03:03, expiring this window 27 minutes early")
+            .isEqualTo("2024-06-01 10:33:00.000000");
+
+        // When
+        migration.migrate();
+
+        // Then the already-stored row has been recomputed, not just newly inserted ones
+        assertThat(read(END_DATE, NEWFOUNDLAND_KEY)).isEqualTo(EXPECTED_END);
+    }
+
+    private void execute(String sql) {
+        dslContextWrapper.transaction(configuration -> DSL.using(configuration).execute(sql));
+    }
+
+    private void insert(String key, String start, String end) {
+        String valueJson = """
+            {"namespace":"io.kestra.tests","flowId":"migration","conditionId":"%s",\
+            "start":"%s","end":"%s"}""".formatted(key, start, end);
+
+        dslContextWrapper.transaction(
+            configuration -> DSL.using(configuration)
+                .insertInto(DSL.table("multipleconditions"))
+                .set(KEY, (Object) key)
+                .set(VALUE, (Object) valueJson)
+                .execute()
+        );
+    }
+
+    private String read(Field<String> field, String key) {
+        return dslContextWrapper.transactionResult(
+            configuration -> DSL.using(configuration)
+                .select(field)
+                .from(DSL.table("multipleconditions"))
+                .where(KEY.eq(key))
+                .fetchOne(field)
+        );
+    }
+}


### PR DESCRIPTION
Two independent bugs in generated date columns,?

## 1. MySQL: truncated UTC offset (`multipleconditions`)

The offset-bearing branch of the generated columns extracted the offset with `SUBSTRING(v, LENGTH(v) - 5, 5)` — 5 characters, where the offset written by `.SSSXXX` is always 6. `-03:30` becomes `-03:3`, which `CONVERT_TZ` then reads as `-03:03`. The sibling `SUBSTRING(v, 1, LENGTH(v) - 6)` that strips the offset off the datetime part already used 6, which is the disagreement that gave it away.

Offsets whose minutes part is `00` survived by accident, because the dropped character was a `0`. So only timezones with a non-zero minutes part are affected: Newfoundland (`-03:30`), Marquesas (`-09:30`), India (`+05:30`), Nepal (`+05:45`), Adelaide (`+09:30`), Iran, Myanmar, Chatham.

Verified against a real MySQL:

| stored value | extracted | `end_date` | correct |
|---|---|---|---|
| `2024-06-01T07:30:00.000-03:30` | `-03:3` | **10:33:00** | 11:00:00 |
| `2024-06-01T16:30:00.000+05:30` | `+05:3` | **11:27:00** | 11:00:00 |
| `2024-06-01T13:00:00.000+02:00` | `+02:0` | 11:00:00 | 11:00:00 ✅ |

**Impact.** `end_date` is read by `AbstractJdbcMultipleConditionStateStore.expired()` (`end_date < now`), which feeds `FlowTriggerService` and deletes the window. A **negative** half-hour offset moves the stored UTC value *backwards*, so a still-active window is deleted ~27 minutes early and the flow-trigger results accumulated in it are silently discarded. A positive offset moves it the other way and merely leaves a dead window around longer. `start_date` is not read by any query; it is realigned because both columns derive from the same window and must not disagree.

## 2. H2: width dependency in the trigger date columns

`CAST(LEFT(value, 26) AS TIMESTAMP)` on `triggers.next_evaluation_date` / `last_triggered_date` drops the trailing `Z` only when the stored `Instant` carries exactly 6 fractional digits. At any other width the `Z` survives, H2 reads the value as `TIMESTAMP WITH TIME ZONE` and converts it into the session timezone on the way into the zoneless column — so the value is shifted by the server's UTC offset, and correct only on a server running in UTC.

```
server timezone = Europe/Paris          (both values denote 2024-06-01T10:00:00Z)
  2024-06-01T10:00:00.000Z      ->  2024-06-01 12:00:00      <-- shifted
  2024-06-01T10:00:00.123456Z   ->  2024-06-01 10:00:00.123456
```

**This is hardening, not a live bug.** No current writer produces another width.

## Tests

Each suite restores the pre-fix expression, seeds a row through it, asserts the *wrong* value, then migrates and asserts the corrected one — so the negative control is permanent rather than a one-off manual check, and recomputation of already-stored rows is actually proven. The H2 test forces `SET TIME ZONE '+05:30'` for the insert, because otherwise it would pass on a UTC CI machine even with the fix reverted.

- `:jdbc-h2:test` — 3 passing
- `:jdbc-mysql:test` — 2 passing, against a freshly created schema

Both were also confirmed to fail with the fix reverted, with exactly the wrong values shown above.
