### PR TITLE
fix(script): pin the kotlp version in the script module's gradle.properties

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,4 @@
 version=2.0.0-SNAPSHOT
-kotlpVersion=0.1.0
 
 org.gradle.jvmargs=-Xmx2g -XX:MaxMetaspaceSize=512m -XX:+HeapDumpOnOutOfMemoryError
 org.gradle.parallel=true

--- a/script/build.gradle
+++ b/script/build.gradle
@@ -1,5 +1,6 @@
 // The kotlp binary is a mandatory embedded resource: it is a single Actually Portable Executable
-// covering Linux/macOS/BSD on amd64 and arm64, pinned by the 'kotlpVersion' Gradle property.
+// covering Linux/macOS/BSD on amd64 and arm64, pinned by the 'kotlpVersion' property in this module's
+// own gradle.properties (see the note there on why it does not live in the root one).
 def kotlpBinary = file('src/main/resources/kotlp/kotlp')
 def kotlpVersionMarker = file('src/main/resources/kotlp/kotlp.version')
 

--- a/script/gradle.properties
+++ b/script/gradle.properties
@@ -1,0 +1,6 @@
+# Pins the kotlp release binary that ':script:downloadKotlp' embeds into the jar (see build.gradle).
+# It is declared in this module's own gradle.properties rather than the root one: Gradle gives the
+# root project's file to every project, but only for its own build, so a root-level property is
+# invisible to builds that include ':script' from another root project (kestra-ee). A module-level
+# file is read in both cases, and takes precedence over the consuming root's. Override: -PkotlpVersion
+kotlpVersion=0.1.0


### PR DESCRIPTION
## What

Move the pinned `kotlp` version from the root `gradle.properties` into `script/gradle.properties`, the `script` module's own properties file. `build.gradle` still reads a plain `kotlpVersion` project property — no custom file parsing.

## Why

Gradle hands the **root project's** `gradle.properties` to every project, but only within its own build. So `kotlpVersion` is invisible to any build that includes `:script` from a different root project — most importantly `kestra-ee`, whose `settings.gradle` maps `:script` to `../kestra/script`. Every EE build fails at configuration time:

```
Could not get unknown property 'kotlpVersion' for task ':script:downloadKotlp' of type org.gradle.api.DefaultTask.
```

The obvious workaround — copying `kotlpVersion=0.1.0` into `kestra-ee/gradle.properties` — duplicates a pinned version across two repositories, where it silently drifts on the next bump. A module-level `gradle.properties` is read in **both** layouts, so one declaration serves every consumer, and it stays a normal Gradle property rather than a bespoke pin file.

Two properties of the resolution order make this safe, both verified below: a module's own `gradle.properties` takes precedence over the consuming root's, so a downstream repository cannot accidentally shadow the pin; and `-PkotlpVersion` still overrides everything, which is handy to try a prerelease binary.

## Testing

Verified on Gradle 9.7, deleting `script/src/main/resources/kotlp/` before each download run:

- `./gradlew :script:downloadKotlp` from the **kestra** root → downloads, marker reads `0.1.0`.
- Same from the **kestra-ee** root → downloads, marker reads `0.1.0`. Fails with the error above on `develop` today.
- `-PkotlpVersion=9.9.9` → requests `.../download/v9.9.9/kotlp`, fails with HTTP 404, so the CLI override still wins.
- With a conflicting `kotlpVersion` in the *consuming* root's `gradle.properties`, `:script:properties` still reports the value from `script/gradle.properties` — the module pin wins.

## Note for kestra-ee

kestra-ee needs no change once this merges. Stopgap PR kestra-io/kestra-ee#9869 sets the property in EE so builds work before then; it becomes redundant once this lands and can be reverted, and per the precedence check above it cannot shadow this pin in the meantime.
