### PR TITLE
fix(core): stop building topology nodes that share a uid

### DIFF
--- a/core/src/main/java/io/kestra/core/models/hierarchies/AbstractGraph.java
+++ b/core/src/main/java/io/kestra/core/models/hierarchies/AbstractGraph.java
@@ -45,13 +45,22 @@ public abstract class AbstractGraph {
         return this;
     }
 
+    protected AbstractGraph nodeIdentity() {
+        return this;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o)
             return true;
-        if (!(o instanceof AbstractGraph))
+        if (!(o instanceof AbstractGraph other))
             return false;
-        return o.hashCode() == this.hashCode();
+        return this.nodeIdentity() == other.nodeIdentity();
+    }
+
+    @Override
+    public int hashCode() {
+        return System.identityHashCode(this.nodeIdentity());
     }
 
     public enum BranchType {

--- a/core/src/main/java/io/kestra/core/models/hierarchies/SubflowGraphTask.java
+++ b/core/src/main/java/io/kestra/core/models/hierarchies/SubflowGraphTask.java
@@ -40,9 +40,8 @@ public class SubflowGraphTask extends AbstractGraphTask {
         SubflowGraphTask previous = this;
         return new SubflowGraphTask(this.getUid(), new SubflowTaskWrapper<>(runContext, this.executableTask()), this.getTaskRun(), this.getValues(), this.getRelationType()) {
             @Override
-            public int hashCode() {
-                // Since edges are handled by a hashmap, we need to keep the same hash and uid is not a good candidate as it changes whenever a node is moved to a cluster
-                return previous.hashCode();
+            protected AbstractGraph nodeIdentity() {
+                return previous;
             }
         };
     }

--- a/core/src/main/java/io/kestra/core/utils/GraphUtils.java
+++ b/core/src/main/java/io/kestra/core/utils/GraphUtils.java
@@ -21,6 +21,9 @@ import io.kestra.core.models.triggers.AbstractTrigger;
 import io.kestra.core.scheduler.model.TriggerState;
 import io.kestra.plugin.core.flow.Dag;
 
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
 public class GraphUtils {
     public static FlowGraph flowGraph(Flow flow, Execution execution) throws IllegalVariableEvaluationException {
         return GraphUtils.flowGraph(flow, execution, null);
@@ -643,9 +646,29 @@ public class GraphUtils {
             return Collections.singletonList(null);
         }
 
-        return taskRuns
+        List<TaskRun> ofParent = taskRuns
             .stream()
             .filter(taskRun -> parent == null || (taskRun.getParentTaskRunId().equals(parent.getId())))
             .toList();
+
+        Map<List<String>, TaskRun> byValues = new LinkedHashMap<>();
+        List<TaskRun> duplicates = new ArrayList<>();
+        for (TaskRun taskRun : ofParent) {
+            if (byValues.putIfAbsent(execution.findParentsValues(taskRun, true), taskRun) != null) {
+                duplicates.add(taskRun);
+            }
+        }
+
+        if (!duplicates.isEmpty()) {
+            log.warn(
+                "Execution '{}' has {} duplicated task run(s) for task '{}': {}. Only the first one of each value is kept in the topology.",
+                execution.getId(),
+                duplicates.size(),
+                task.getId(),
+                duplicates.stream().map(TaskRun::getId).toList()
+            );
+        }
+
+        return List.copyOf(byValues.values());
     }
 }

--- a/core/src/test/java/io/kestra/core/models/hierarchies/AbstractGraphTest.java
+++ b/core/src/test/java/io/kestra/core/models/hierarchies/AbstractGraphTest.java
@@ -1,0 +1,146 @@
+package io.kestra.core.models.hierarchies;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import io.kestra.core.models.executions.Execution;
+import io.kestra.core.models.executions.TaskRun;
+import io.kestra.core.models.flows.Flow;
+import io.kestra.core.models.flows.State;
+import io.kestra.core.models.tasks.Task;
+import io.kestra.core.serializers.YamlParser;
+import io.kestra.core.utils.GraphUtils;
+import io.kestra.core.utils.IdUtils;
+import io.kestra.plugin.core.log.Log;
+
+import static io.kestra.core.tenant.TenantService.MAIN_TENANT;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class AbstractGraphTest {
+    @Test
+    void shouldNotBeEqualWhenHashCodesCollide() {
+        AbstractGraph first = new CollidingHashCodeGraph("first");
+        AbstractGraph second = new CollidingHashCodeGraph("second");
+
+        assertThat(first).as("equality must not be delegated to the hash code").isNotEqualTo(second);
+        assertThat(second).as("equality must not be delegated to the hash code").isNotEqualTo(first);
+    }
+
+    @Test
+    void shouldBeEqualToTheNodeItStandsInFor() {
+        GraphTask original = graphTask("original");
+        AbstractGraph standIn = new StandInGraph("rendered", original);
+
+        assertThat(standIn).isEqualTo(original);
+        assertThat(original).isEqualTo(standIn);
+        assertThat(standIn).hasSameHashCodeAs(original);
+    }
+
+    @Test
+    void shouldNotBeEqualWhenUidIsEqualButNodesDiffer() {
+        GraphTask first = graphTask("same");
+        GraphTask second = graphTask("same");
+
+        assertThat(first).as("a node is identified by nodeIdentity(), not by its mutable uid").isNotEqualTo(second);
+        assertThat(first).isEqualTo(first);
+    }
+
+    @Test
+    void shouldNotContainDuplicateUidsWhenATaskHasDuplicatedTaskRuns() throws Exception {
+        List<AbstractGraph> nodes = GraphUtils.nodes(GraphUtils.of(chainFlow(), executionWithDuplicatedTaskRun()));
+
+        assertThat(nodes).extracting(AbstractGraph::getUid).doesNotHaveDuplicates();
+    }
+
+    @Test
+    void shouldNotContainSelfLoopWhenATaskHasDuplicatedTaskRuns() throws Exception {
+        List<FlowGraph.Edge> edges = GraphUtils.edges(GraphUtils.of(chainFlow(), executionWithDuplicatedTaskRun()));
+
+        assertThat(edges)
+            .as("two nodes sharing a uid would make the chain edge between them a self-loop")
+            .noneSatisfy(edge -> assertThat(edge.getSource()).isEqualTo(edge.getTarget()));
+    }
+
+    private GraphTask graphTask(String uid) {
+        Task task = Log.builder()
+            .id(uid)
+            .type(Log.class.getName())
+            .message("hello")
+            .build();
+
+        return new GraphTask(task, null, List.of(), null);
+    }
+
+    private Flow chainFlow() {
+        return YamlParser.parse("""
+            id: chain
+            namespace: io.kestra.tests
+            tasks:
+              - id: task_0
+                type: io.kestra.plugin.core.log.Log
+                message: hello
+              - id: task_1
+                type: io.kestra.plugin.core.log.Log
+                message: hello
+              - id: task_2
+                type: io.kestra.plugin.core.log.Log
+                message: hello
+            """, Flow.class);
+    }
+
+    private Execution executionWithDuplicatedTaskRun() {
+        Flow flow = chainFlow();
+        String executionId = IdUtils.create();
+
+        List<TaskRun> taskRuns = new ArrayList<>();
+        taskRuns.add(taskRun(executionId, flow, "task_0"));
+        taskRuns.add(taskRun(executionId, flow, "task_1"));
+        taskRuns.add(taskRun(executionId, flow, "task_1"));
+        taskRuns.add(taskRun(executionId, flow, "task_2"));
+
+        return Execution.newExecution(flow, List.of())
+            .toBuilder()
+            .id(executionId)
+            .taskRunList(taskRuns)
+            .build();
+    }
+
+    private TaskRun taskRun(String executionId, Flow flow, String taskId) {
+        return TaskRun.builder()
+            .id(IdUtils.create())
+            .executionId(executionId)
+            .tenantId(MAIN_TENANT)
+            .namespace(flow.getNamespace())
+            .flowId(flow.getId())
+            .taskId(taskId)
+            .state(new State())
+            .build();
+    }
+
+    private static final class CollidingHashCodeGraph extends AbstractGraph {
+        private CollidingHashCodeGraph(String uid) {
+            super(uid);
+        }
+
+        @Override
+        public int hashCode() {
+            return 42;
+        }
+    }
+
+    private static final class StandInGraph extends AbstractGraph {
+        private final AbstractGraph standsInFor;
+
+        private StandInGraph(String uid, AbstractGraph standsInFor) {
+            super(uid);
+            this.standsInFor = standsInFor;
+        }
+
+        @Override
+        protected AbstractGraph nodeIdentity() {
+            return standsInFor;
+        }
+    }
+}

--- a/core/src/test/java/io/kestra/core/utils/GraphUtilsTest.java
+++ b/core/src/test/java/io/kestra/core/utils/GraphUtilsTest.java
@@ -67,7 +67,7 @@ class GraphUtilsTest {
     }
 
     @Test
-    void shouldThrowWhenATaskHasDuplicatedTaskRuns() throws Exception {
+    void shouldWalkSuccessorsWhenATaskHasDuplicatedTaskRuns() throws Exception {
         Flow flow = chainFlow(3);
         String executionId = IdUtils.create();
 
@@ -86,13 +86,9 @@ class GraphUtilsTest {
 
         GraphCluster graph = GraphUtils.of(flow, execution);
 
-        assertThat(GraphUtils.edges(graph))
-            .as("two task runs sharing a uid turn the chain edge between them into a self-loop")
-            .anySatisfy(edge -> assertThat(edge.getSource()).isEqualTo(edge.getTarget()));
-
-        assertThatThrownBy(() -> GraphUtils.successors(graph, Set.of(duplicated.getId())))
-            .isInstanceOf(CyclicGraphException.class)
-            .hasMessageContaining("root.task_1 -> root.task_1");
+        assertThat(GraphUtils.successors(graph, Set.of(duplicated.getId())))
+            .extracting(AbstractGraph::getUid)
+            .contains("root.task_1", "root.task_2");
     }
 
     @Test


### PR DESCRIPTION
> **Stacked on #18109** — base is `fix/core-graphutils-cycle-safe-traversal`, not `develop`. Merge #18109 first; GitHub will retarget this to `develop` automatically. It also updates one test from #18109, which is why it is stacked rather than parallel.

Follow-up to #18109, which stopped a `StackOverflowError` from killing an instance when a replay walked a self-loop. This PR removes the self-loop at its source.

## Problem 1: duplicated task runs build duplicated nodes

`GraphUtils.fillGraph()` builds **one node per task run**, and `AbstractGraphTask.getUid()` is the task id plus its values. So a task carrying two task runs with the same values produces two distinct nodes sharing a uid, and the sequential chain edge between them becomes a self-loop once `GraphUtils.edges()` maps nodes to uids:

```
edge root.first  -> root.second
edge root.second -> root.second   <== SELF LOOP
edge root.second -> root.third
```

`(taskId, values)` identifies at most one task run — `Execution.findTaskRunByTaskIdAndValue()` already relies on it, using `findFirst()`. Duplicates are therefore corrupt state. `findTaskRuns()` now keeps the first task run per value and logs the duplicates it drops, naming the execution, the task and the dropped task run ids, so the underlying producer stays diagnosable.

## Problem 2: equality decided by hash code

`AbstractGraph.equals()` returned `o.hashCode() == this.hashCode()` while the class defined **no `hashCode()`**. It therefore compared identity hashes, and any colliding pair of unrelated nodes compared equal.

**This turned out to be load-bearing, not merely broken.** `SubflowGraphTask.withRenderedSubflowId()` deliberately overrides `hashCode()` to return `previous.hashCode()`, with the comment *"Since edges are handled by a hashmap, we need to keep the same hash"* — it relies on the delegation so the graph treats the rendered node and the node it replaced as **one node** and keeps its edges.

So node substitution is now expressed directly, through a `nodeIdentity()` hook that defaults to `this`, with `equals()`/`hashCode()` derived from it. The substitution mechanism survives and is now self-documenting; colliding hashes no longer alias unrelated nodes.

Identity, rather than uid, remains the basis for equality on purpose: uid is mutable — `GraphCluster.updateUidWithChildren()` rewrites the uid of nodes that are already inside a `Graph` — and nodes are keys of the Guava `ValueGraph` backing `Graph`, so hashing on uid mutates a live key and loses the node.

### Both alternatives were measured, not assumed

I implemented each and ran the suite before settling on the hook:

| Approach | Result |
|---|---|
| uid-based `equals`/`hashCode` (the intuitive fix) | **18 `FlowGraphTest` failures**, and it did not even fix the duplicate-uid symptom |
| drop the `equals` override entirely (identity) | **2 failures** — `subflow()` and `dynamicIdSubflow()`, i.e. exactly the substitution mechanism |
| `nodeIdentity()` hook | all green |

A regression guard test now documents why uid equality must not be reintroduced.

## Tests

`AbstractGraphTest` (new, plain unit test):

| Test | Before | After |
|---|---|---|
| `shouldNotBeEqualWhenHashCodesCollide` | fails — colliding nodes compare equal | passes |
| `shouldBeEqualToTheNodeItStandsInFor` | n/a (needs the new hook) | passes — substitution preserved, symmetric, same hash |
| `shouldNotContainDuplicateUidsWhenATaskHasDuplicatedTaskRuns` | fails | passes |
| `shouldNotContainSelfLoopWhenATaskHasDuplicatedTaskRuns` | fails | passes |
| `shouldNotBeEqualWhenUidIsEqualButNodesDiffer` | passes | passes — guards against reintroducing uid equality |

The collision test's red baseline was verified against the unmodified code in isolation (the other tests reference the new hook and cannot compile against it).

`GraphUtilsTest.shouldThrowWhenATaskHasDuplicatedTaskRuns` from #18109 is replaced by `shouldWalkSuccessorsWhenATaskHasDuplicatedTaskRuns`: with the self-loop prevented at its source, that input no longer raises `CyclicGraphException`, it walks correctly. Cycle detection stays covered by `shouldThrowWhenGraphContainsCycle`, and remains the backstop for any other back-edge.

Regression sweep, all green: `io.kestra.core.models.hierarchies.*` (incl. all 19 `FlowGraphTest`), `GraphUtilsTest`, `ExecutionServiceTest`, `*GraphService*`, `*DagTest*` — 68 passing in `:core`; `*GraphController*`, `*ExecutionController*` — 128 passing in `:webserver`.

## Still open

**How the duplicate task run was produced in the first place.** This PR makes the graph layer robust and logs the duplicate; it does not stop whatever created it. A redelivered queue message remains the prime suspect, since the thread that crashed in production logged `Can't change state, already RUNNING` from `State.withState()` milliseconds earlier — the signature of a duplicated state transition. The new warning gives the execution id, task id and task run ids needed to chase it.

**An `Error` in a queue handler still exits the JVM** (`AbstractPollingSubscriber.internalSubscribe()` and `ExecutionCommandMessageHandler` both catch `Exception`).
