### PR TITLE
fix(ci): forward OTLP secrets to backend/frontend/design-system test jobs

### DIFF
--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -63,6 +63,8 @@ jobs:
       SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
       GOOGLE_SERVICE_ACCOUNT: ${{ secrets.GOOGLE_SERVICE_ACCOUNT }}
       DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
+      OTLP_ENDPOINT: ${{ secrets.OTLP_ENDPOINT }}
+      OTLP_HEADERS: ${{ secrets.OTLP_HEADERS }}
     with:
       java-version: 25
 
@@ -73,6 +75,8 @@ jobs:
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
       GITHUB_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      OTLP_ENDPOINT: ${{ secrets.OTLP_ENDPOINT }}
+      OTLP_HEADERS: ${{ secrets.OTLP_HEADERS }}
 
   design-system-frontend-tests:
     name: Design System Frontend tests
@@ -80,6 +84,8 @@ jobs:
     uses: kestra-io/actions/.github/workflows/kestra-oss-designsystem-tests.yml@main
     secrets:
       GITHUB_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      OTLP_ENDPOINT: ${{ secrets.OTLP_ENDPOINT }}
+      OTLP_HEADERS: ${{ secrets.OTLP_HEADERS }}
 
   publish-develop-docker:
     name: Publish Docker


### PR DESCRIPTION
## Summary
- `main-build.yml` calls `backend-tests`, `frontend-tests`, and `design-system-frontend-tests` with an explicit `secrets:` map (not `secrets: inherit`), which only forwards what's listed.
- `OTLP_ENDPOINT`/`OTLP_HEADERS` were missing from those maps, so the reusable workflows' `env.OTLP_ENDPOINT` was always empty and the `Setup - OpenTelemetry` step (which starts the host-metrics collector) was skipped on every run of these three jobs — self-hosted or GitHub-hosted alike.
- Found by tracing why run [31623593288](https://github.com/kestra-io/kestra/actions/runs/31623593288) had a full trace (built post-hoc by the `otel-export-trace` job) but zero host metrics for `backend-tests`/`frontend-tests`/`design-system-frontend-tests`.
- Requires kestra-io/actions#192 (declares `OTLP_ENDPOINT`/`OTLP_HEADERS` under `on.workflow_call.secrets` on those three reusable workflows) to be merged first, otherwise GitHub Actions rejects passing an undeclared secret.

## Test plan
- [ ] Merge kestra-io/actions#192 first
- [ ] Merge this PR
- [ ] Confirm a subsequent `develop` run populates `metrics-hostmetricsreceiver.otel-github-actions` for `backend-tests`/`frontend-tests`/`design-system-frontend-tests`