### PR TITLE
fix(ci): forward OTLP secrets to build-artifacts/e2e-tests/publish-maven

### DIFF
--- a/.github/workflows/e2e-scheduling.yml
+++ b/.github/workflows/e2e-scheduling.yml
@@ -21,6 +21,9 @@ concurrency:
 jobs:
   e2e:
     uses: kestra-io/actions/.github/workflows/kestra-oss-e2e-tests.yml@main
+    secrets:
+      OTLP_ENDPOINT: ${{ secrets.OTLP_ENDPOINT }}
+      OTLP_HEADERS: ${{ secrets.OTLP_HEADERS }}
     with:
       java-version: 25
 

--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -110,6 +110,8 @@ jobs:
       SONATYPE_GPG_KEYID: ${{ secrets.SONATYPE_GPG_KEYID }}
       SONATYPE_GPG_PASSWORD: ${{ secrets.SONATYPE_GPG_PASSWORD }}
       SONATYPE_GPG_FILE: ${{ secrets.SONATYPE_GPG_FILE }}
+      OTLP_ENDPOINT: ${{ secrets.OTLP_ENDPOINT }}
+      OTLP_HEADERS: ${{ secrets.OTLP_HEADERS }}
     with:
       java-version: 25
 

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -19,6 +19,9 @@ jobs:
   build-artifacts:
     name: Build Artifacts
     uses: kestra-io/actions/.github/workflows/kestra-oss-build-artifacts.yml@main
+    secrets:
+      OTLP_ENDPOINT: ${{ secrets.OTLP_ENDPOINT }}
+      OTLP_HEADERS: ${{ secrets.OTLP_HEADERS }}
     with:
       java-version: 25
 
@@ -60,6 +63,8 @@ jobs:
       SONATYPE_GPG_KEYID: ${{ secrets.SONATYPE_GPG_KEYID }}
       SONATYPE_GPG_PASSWORD: ${{ secrets.SONATYPE_GPG_PASSWORD }}
       SONATYPE_GPG_FILE: ${{ secrets.SONATYPE_GPG_FILE }}
+      OTLP_ENDPOINT: ${{ secrets.OTLP_ENDPOINT }}
+      OTLP_HEADERS: ${{ secrets.OTLP_HEADERS }}
     with:
       java-version: 25
 

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -265,6 +265,9 @@ jobs:
     # the E2E build-from-source fallback below.
     if: "(needs.file-changes.outputs.ui == 'true' || needs.file-changes.outputs.backend == 'true') && github.event.pull_request.head.repo.fork == false"
     uses: kestra-io/actions/.github/workflows/kestra-oss-build-artifacts.yml@main
+    secrets:
+      OTLP_ENDPOINT: ${{ secrets.OTLP_ENDPOINT }}
+      OTLP_HEADERS: ${{ secrets.OTLP_HEADERS }}
     with:
       java-version: 25
 
@@ -275,6 +278,9 @@ jobs:
     # fork (falls back to building from source); not when the build failed.
     if: "!cancelled() && needs.build-artifacts.result != 'failure' && (needs.file-changes.outputs.ui == 'true' || needs.file-changes.outputs.backend == 'true')"
     uses: kestra-io/actions/.github/workflows/kestra-oss-e2e-tests.yml@main
+    secrets:
+      OTLP_ENDPOINT: ${{ secrets.OTLP_ENDPOINT }}
+      OTLP_HEADERS: ${{ secrets.OTLP_HEADERS }}
     with:
       java-version: 25
       exe-artifact: ${{ needs.build-artifacts.result == 'success' && 'exe' || '' }}


### PR DESCRIPTION
## Summary
Follow-up to #18115, which fixed backend-tests/frontend-tests/design-system-frontend-tests. This covers the remaining jobs going through reusable workflows that were missing OTLP secrets:

- `pull-request.yml`: `build-artifacts`, `e2e-tests` — previously passed **no** `secrets:` block at all to `kestra-oss-build-artifacts.yml`/`kestra-oss-e2e-tests.yml`.
- `pre-release.yml`: `build-artifacts` (same as above), `publish-maven` — explicit Sonatype-only secrets map.
- `e2e-scheduling.yml`: `e2e` — same as build-artifacts/e2e-tests above.
- `main-build.yml`: `publish-develop-maven` — explicit Sonatype-only secrets map.

Net effect before this fix: the `Setup - OpenTelemetry` step (host-metrics collector) never ran on any Build Artifacts / E2E / Publish Maven job, on any trigger (PR, pre-release, scheduled e2e, develop push).

**Requires kestra-io/actions#193 merged first** — it declares `OTLP_ENDPOINT`/`OTLP_HEADERS` under `workflow_call.secrets` on these reusable workflows; without it, GitHub Actions rejects passing an undeclared secret.

## Test plan
- [ ] Merge kestra-io/actions#193 first
- [ ] Merge this PR
- [ ] Confirm a subsequent PR/pre-release/scheduled-e2e run populates host metrics for build-artifacts/e2e-tests/publish-maven jobs