### PR TITLE
fix(executions): build every execution from the flow processed for runtime

### DIFF
--- a/core/src/main/java/io/kestra/core/metrics/MetricRegistry.java
+++ b/core/src/main/java/io/kestra/core/metrics/MetricRegistry.java
@@ -19,6 +19,7 @@ import io.kestra.core.runners.SubflowExecutionResult;
 import io.kestra.core.runners.WorkerTask;
 import io.kestra.core.runners.WorkerTaskResult;
 import io.kestra.core.runners.WorkerTrigger;
+import io.kestra.core.utils.ListUtils;
 import io.kestra.core.worker.WorkerGroups;
 import io.kestra.core.worker.WorkerQueues;
 
@@ -557,13 +558,23 @@ public class MetricRegistry {
         return ArrayUtils.addAll(ArrayUtils.addAll(baseTags, labelTags), tenantTag);
     }
 
-    public String[] tags(TriggerEvaluationResult evaluationResult, TriggerId triggerId) {
+    /**
+     * Return tags for a trigger evaluation, tagged like the execution it produces.
+     *
+     * @param evaluationResult the evaluation result, carrying the trigger's own labels
+     * @param triggerId the evaluated trigger
+     * @param flowLabels the labels of the flow owning the trigger, which the evaluation result does not carry
+     * @return tags to apply to metrics
+     */
+    public String[] tags(TriggerEvaluationResult evaluationResult, TriggerId triggerId, @Nullable List<Label> flowLabels) {
         var baseTags = new String[] {
             TAG_FLOW_ID, triggerId.getFlowId(),
             TAG_NAMESPACE_ID, triggerId.getNamespace(),
             TAG_STATE, evaluationResult.stateType().name(),
         };
-        var labelTags = getLabelTags(evaluationResult.labels() != null ? evaluationResult.labels() : List.of());
+        // trigger labels first: getLabelTags keeps the first match, which is how the trigger overrides the
+        // flow on the execution these metrics describe (there, flow labels come first and dedup keeps the last)
+        var labelTags = getLabelTags(ListUtils.emptyOnNull(ListUtils.concat(evaluationResult.labels(), flowLabels)));
         var tenantTag = getTenantTag(triggerId.getTenantId());
         return ArrayUtils.addAll(ArrayUtils.addAll(baseTags, labelTags), tenantTag);
     }

--- a/core/src/main/java/io/kestra/core/models/flows/FlowWithException.java
+++ b/core/src/main/java/io/kestra/core/models/flows/FlowWithException.java
@@ -34,6 +34,10 @@ public class FlowWithException extends FlowWithSource {
             .disabled(flow.isDisabled())
             .exception(exception.getMessage())
             .tasks(List.of())
+            // an execution is still created for a blocked flow and then failed, so it must keep carrying these:
+            // dropping them leaves label-based filtering, notifications and SLA alerting blind to the failure
+            .labels(flow.getLabels())
+            .variables(flow.getVariables())
             .source(flow.getSource())
             .build();
     }

--- a/core/src/main/java/io/kestra/core/models/triggers/TriggerEvaluationResult.java
+++ b/core/src/main/java/io/kestra/core/models/triggers/TriggerEvaluationResult.java
@@ -28,7 +28,9 @@ import jakarta.annotation.Nullable;
  * @param executionId the generated execution ID.
  * @param stateType the execution state type (CREATED or FAILED).
  * @param trigger the execution trigger metadata containing plugin output variables and log file URI.
- * @param labels the execution labels including system labels (FROM, CORRELATION_ID).
+ * @param labels the labels the trigger contributes, including system labels (FROM, CORRELATION_ID). The flow's
+ *        own labels are deliberately absent: the execution takes those from the flow processed for runtime when
+ *        it is created, so carrying the raw flow's here would let them override governance.
  * @param flowRevision the flow revision at evaluation time.
  */
 public record TriggerEvaluationResult(

--- a/core/src/main/java/io/kestra/core/models/triggers/TriggerService.java
+++ b/core/src/main/java/io/kestra/core/models/triggers/TriggerService.java
@@ -136,14 +136,17 @@ public abstract class TriggerService {
             .build();
     }
 
+    /**
+     * Builds the labels the trigger itself contributes, deliberately without the flow's own labels: the
+     * execution is created from the flow processed for runtime and picks those up there, so carrying the
+     * raw flow's here would let them win the creation-time merge and pin back a value governance overrides.
+     */
     private static List<Label> buildLabels(String id, AbstractTrigger trigger, ConditionContext conditionContext, Map<String, Object> variables) {
-        List<Label> labels = LabelService.fromTrigger(conditionContext.getRunContext(), conditionContext.getFlow(), trigger, Map.of("trigger", variables));
+        List<Label> labels = LabelService.fromTrigger(conditionContext.getRunContext(), trigger, Map.of("trigger", variables));
         labels.add(new Label(Label.FROM, Label.FromLabel.TRIGGER.value));
         if (labels.stream().noneMatch(label -> Label.CORRELATION_ID.equals(label.key()))) {
             labels.add(new Label(Label.CORRELATION_ID, id));
         }
-        // include non-system flow labels (previously added in WorkerTriggerProcessor)
-        labels.addAll(LabelService.labelsExcludingSystem(conditionContext.getFlow().getLabels()));
         return labels;
     }
 }

--- a/core/src/main/java/io/kestra/core/runners/DefaultFlowMetaStore.java
+++ b/core/src/main/java/io/kestra/core/runners/DefaultFlowMetaStore.java
@@ -18,6 +18,7 @@ import io.kestra.core.queues.QueueSubscriber;
 import io.kestra.core.repositories.FlowRepositoryInterface;
 import io.kestra.core.services.FlowParsingService;
 
+import io.micronaut.core.annotation.Nullable;
 import jakarta.annotation.PostConstruct;
 import jakarta.annotation.PreDestroy;
 import jakarta.inject.Singleton;
@@ -114,37 +115,76 @@ public class DefaultFlowMetaStore implements FlowMetaStoreInterface {
     }
 
     @Override
-    public Optional<FlowWithSource> findByExecutionThenInjectDefaults(Execution execution) {
-        var flowId = FlowId.uid(execution.getTenantId(), execution.getNamespace(), execution.getFlowId(), Optional.ofNullable(execution.getFlowRevision()));
-        var fromCache = withDefaultCache.getIfPresent(flowId);
-        if (fromCache.isPresent()) {
-            return fromCache;
+    public Optional<FlowWithSource> findByExecutionForRuntime(Execution execution) {
+        // probe the cache before resolving the flow: this runs on every executor message, and an execution
+        // pinned to a revision the meta-store no longer holds resolves through the repository. The key is the
+        // one injectDefaults would compute, as findByExecution asks for that exact revision.
+        if (execution.getFlowRevision() != null) {
+            var fromCache = withDefaultCache.getIfPresent(
+                FlowId.uid(execution.getTenantId(), execution.getNamespace(), execution.getFlowId(), Optional.of(execution.getFlowRevision()))
+            );
+            if (fromCache.isPresent()) {
+                return fromCache;
+            }
         }
 
-        var flowWithDefault = findByExecution(execution).map(it -> parseForRuntime(it, execution));
-        flowWithDefault.ifPresent(it -> withDefaultCache.put(flowId, it));
-        return flowWithDefault;
+        return findByExecution(execution).map(it -> injectDefaults(it, execution));
+    }
+
+    @Override
+    public Optional<FlowWithSource> findByIdForRuntime(String tenantId, String namespace, String id, Optional<Integer> revision) {
+        return findById(tenantId, namespace, id, revision).map(it -> injectDefaults(it, null));
+    }
+
+    @Override
+    public Optional<FlowWithSource> findByIdFromTaskForRuntime(String tenantId, String namespace, String id, Optional<Integer> revision, String fromTenant,
+        String fromNamespace, String fromId) {
+        return findByIdFromTask(tenantId, namespace, id, revision, fromTenant, fromNamespace, fromId).map(it -> injectDefaults(it, null));
     }
 
     /**
-     * Parses the flow resolved for a running execution, converting failures into outcomes the executor
-     * handles — this method must never throw, a throw here would escape the executor's queue consumer:
-     * <ul>
-     * <li>governance rejection ({@link FlowBlockedException}) is logged against the execution and surfaced as a
-     * {@link FlowWithException}, which the executor fails fast on;</li>
-     * <li>any other parse failure is logged against the execution and the flow is returned as stored, so the
-     * execution proceeds with the un-processed flow.</li>
-     * </ul>
+     * Parses a flow for runtime, memoized on the resolved flow UID. Keying on the resolved flow rather than on
+     * the requested identifier is what makes the cache safe: the UID always carries a revision, and the entry
+     * for a revision is expired whenever that flow — or a setting it resolves against — changes.
      */
-    private FlowWithSource parseForRuntime(FlowInterface flow, Execution execution) {
+    private FlowWithSource injectDefaults(FlowInterface flow, @Nullable Execution execution) {
+        var fromCache = withDefaultCache.getIfPresent(flow.uid());
+        if (fromCache.isPresent()) {
+            return fromCache.get();
+        }
+
+        ParsedFlow parsed = parseForRuntimeSafely(flow, execution);
+        if (parsed.cacheable()) {
+            withDefaultCache.put(flow.uid(), parsed.flow());
+        }
+        return parsed.flow();
+    }
+
+    /**
+     * Parses the flow resolved for an execution — running or about to be created — converting failures into
+     * outcomes the executor handles: this method must never throw, a throw here would escape the executor's
+     * queue consumer:
+     * <ul>
+     * <li>governance rejection ({@link FlowBlockedException}) is logged and surfaced as a
+     * {@link FlowWithException}, which the executor fails fast on;</li>
+     * <li>any other parse failure is logged and the flow is returned as stored, so the execution proceeds
+     * with the un-processed flow.</li>
+     * </ul>
+     * Failures are logged against the execution when there is one, which is not the case on the creation path
+     * where the execution does not exist yet.
+     */
+    private ParsedFlow parseForRuntimeSafely(FlowInterface flow, @Nullable Execution execution) {
         try {
-            return flowParsingService.parseForRuntime(flow);
+            return new ParsedFlow(flowParsingService.parseForRuntime(flow), true);
         } catch (FlowBlockedException e) {
-            logToExecution(execution, e);
-            return FlowWithException.from(flow, e);
+            logBlocked(flow, execution, e);
+            // a governance rejection is deterministic, so it is memoized like a successful parse
+            return new ParsedFlow(FlowWithException.from(flow, e), true);
         } catch (Exception e) {
-            logToExecution(execution, e);
-            return FlowParsingService.toFlowWithSource(flow);
+            logParseFailure(flow, execution, e);
+            // possibly transient, and the cache has no TTL: memoizing it would pin an un-governed flow for
+            // every later execution of this revision until the flow or a setting it resolves against changes
+            return new ParsedFlow(FlowParsingService.toFlowWithSource(flow), false);
         }
     }
 
@@ -164,9 +204,33 @@ public class DefaultFlowMetaStore implements FlowMetaStoreInterface {
         }
     }
 
+    private void logBlocked(FlowInterface flow, @Nullable Execution execution, FlowBlockedException e) {
+        if (execution == null) {
+            log.warn("Flow {} is blocked by governance: {}", flow.uid(), e.getMessage());
+            return;
+        }
+
+        logToExecution(execution, e);
+    }
+
+    private void logParseFailure(FlowInterface flow, @Nullable Execution execution, Exception e) {
+        if (execution == null) {
+            log.error("Unable to parse flow {} for runtime", flow.uid(), e);
+            return;
+        }
+
+        logToExecution(execution, e);
+    }
+
     private void logToExecution(Execution execution, Exception e) {
         var logger = runContextLoggerFactory.create(execution);
         logger.emitLogs(RunContextLogger.logEntries(Execution.loggingEventFromException(e), LogEntry.of(execution)));
+    }
+
+    /**
+     * A flow parsed for runtime, and whether the outcome is stable enough to memoize.
+     */
+    private record ParsedFlow(FlowWithSource flow, boolean cacheable) {
     }
 
 }

--- a/core/src/main/java/io/kestra/core/runners/ExecutableUtils.java
+++ b/core/src/main/java/io/kestra/core/runners/ExecutableUtils.java
@@ -132,7 +132,7 @@ public final class ExecutableUtils {
                         }
                         ExecutionService executionService = ((DefaultRunContext) runContext).services().additionalService(ExecutionService.class);
                         try {
-                            Flow flow = flowMetaStore.findByExecutionThenInjectDefaults(subflowExecution).orElseThrow(() -> new FlowNotFoundException(subflowExecution));
+                            Flow flow = flowMetaStore.findByExecutionForRuntime(subflowExecution).orElseThrow(() -> new FlowNotFoundException(subflowExecution));
                             Execution restartedChild = executionService.restart(subflowExecution, flow, null);
 
                             // In a loop context, the restarted child execution still has trigger variables
@@ -173,7 +173,7 @@ public final class ExecutableUtils {
                 String subflowId = runContext.render(currentTask.subflowId().flowId());
                 Optional<Integer> subflowRevision = currentTask.subflowId().revision();
 
-                FlowInterface flow = flowMetaStore.findByIdFromTask(
+                FlowInterface flow = flowMetaStore.findByIdFromTaskForRuntime(
                     currentExecution.getTenantId(),
                     subflowNamespace,
                     subflowId,

--- a/core/src/main/java/io/kestra/core/runners/FlowMetaStoreInterface.java
+++ b/core/src/main/java/io/kestra/core/runners/FlowMetaStoreInterface.java
@@ -57,5 +57,26 @@ public interface FlowMetaStoreInterface {
         );
     }
 
-    Optional<FlowWithSource> findByExecutionThenInjectDefaults(Execution execution);
+    Optional<FlowWithSource> findByExecutionForRuntime(Execution execution);
+
+    /**
+     * Find a flow by identifier, processed for runtime — plugin defaults injected and, on editions supporting
+     * it, governance applied. Callers creating an execution must use this rather than
+     * {@link #findById(String, String, String, Optional)}: an execution snapshots the flow labels and variables
+     * at creation time, so it must be built from the same flow the executor will run.
+     * <p>
+     * WARNING: this method will NOT check if the namespace is allowed, so it should not be used inside a task.
+     */
+    Optional<FlowWithSource> findByIdForRuntime(String tenantId, String namespace, String id, Optional<Integer> revision);
+
+    /**
+     * Same as {@link #findByIdForRuntime(String, String, String, Optional)}, checking that the namespace
+     * is allowed, so it can be used inside a task creating a child execution.
+     * <p>
+     * WARNING: like every flow lookup, this is unsupported on a dedicated worker, which resolves flow metadata
+     * over gRPC and has no parsing service — callers reachable from worker task execution must tolerate an
+     * {@link UnsupportedOperationException}.
+     */
+    Optional<FlowWithSource> findByIdFromTaskForRuntime(String tenantId, String namespace, String id, Optional<Integer> revision, String fromTenant,
+        String fromNamespace, String fromId);
 }

--- a/core/src/main/java/io/kestra/core/runners/FlowMetaStores.java
+++ b/core/src/main/java/io/kestra/core/runners/FlowMetaStores.java
@@ -1,0 +1,40 @@
+package io.kestra.core.runners;
+
+import java.util.Optional;
+
+import io.kestra.core.models.flows.Flow;
+import io.kestra.core.models.flows.FlowWithSource;
+
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Helpers over {@link FlowMetaStoreInterface} shared by the routes that create an execution.
+ */
+@Slf4j
+public final class FlowMetaStores {
+
+    private FlowMetaStores() {
+    }
+
+    /**
+     * Returns the given flow processed for runtime, degrading to the raw flow when it can no longer be
+     * resolved, which is the case when it was deleted meanwhile. Callers holding a flow and creating an
+     * execution from it use this rather than {@link FlowMetaStoreInterface#findByIdForRuntime} directly, so that
+     * a flow vanishing mid-flight behaves the same on every route instead of once per caller.
+     */
+    public static Flow findForRuntimeOrRaw(FlowMetaStoreInterface flowMetaStore, Flow flow) {
+        Optional<FlowWithSource> resolved = flowMetaStore.findByIdForRuntime(
+            flow.getTenantId(),
+            flow.getNamespace(),
+            flow.getId(),
+            Optional.ofNullable(flow.getRevision())
+        );
+
+        if (resolved.isEmpty()) {
+            log.warn("Flow {} cannot be resolved for runtime. Proceeding with the raw flow.", flow.uid());
+            return flow;
+        }
+
+        return resolved.get();
+    }
+}

--- a/core/src/main/java/io/kestra/core/runners/pebble/functions/SubflowFunction.java
+++ b/core/src/main/java/io/kestra/core/runners/pebble/functions/SubflowFunction.java
@@ -10,9 +10,8 @@ import java.util.Optional;
 
 import io.kestra.core.models.Label;
 import io.kestra.core.models.executions.Execution;
-import io.kestra.core.models.flows.Flow;
-import io.kestra.core.models.flows.FlowInterface;
 import io.kestra.core.models.flows.FlowWithException;
+import io.kestra.core.models.flows.FlowWithSource;
 import io.kestra.core.models.flows.State;
 import io.kestra.core.runners.FlowInputOutput;
 import io.kestra.core.runners.FlowMetaStoreInterface;
@@ -149,8 +148,10 @@ public class SubflowFunction implements KestraFunction {
             // ACL is scoped to the caller flow (callerNamespace/callerId), matching the Subflow task trust model:
             // if the caller flow may reference the target, so may subflow(). Note this is reachable at execute-form
             // render time, not only at execution time, so anyone able to open the form triggers this resolution.
-            FlowInterface targetFlow = flowMetaStore.get()
-                .findByIdFromTask(tenantId, namespace, id, revision, tenantId, callerNamespace, callerId)
+            // resolved for runtime so a governance rejection surfaces as a FlowWithException here, rather than
+            // becoming a created-then-failed execution
+            FlowWithSource targetFlow = flowMetaStore.get()
+                .findByIdFromTaskForRuntime(tenantId, namespace, id, revision, tenantId, callerNamespace, callerId)
                 .orElseThrow(
                     () -> new PebbleException(
                         null, "Unable to find flow '" + namespace + "'.'" + id + "'"
@@ -180,7 +181,7 @@ public class SubflowFunction implements KestraFunction {
 
             Execution terminated;
             try {
-                terminated = executionService.get().runAndWait(execution, (Flow) targetFlow, timeout);
+                terminated = executionService.get().runAndWait(execution, targetFlow, timeout);
             } catch (Exception e) {
                 throw new PebbleException(e, "Failed to run subflow '" + namespace + "'.'" + id + "': " + e.getMessage(), lineNumber, self.getName());
             }

--- a/core/src/main/java/io/kestra/core/services/FlowParsingService.java
+++ b/core/src/main/java/io/kestra/core/services/FlowParsingService.java
@@ -46,7 +46,7 @@ public class FlowParsingService {
      * Parses the given abstract flow, returning a parsed {@link FlowWithSource}.
      *
      * <p>
-     * This parses the flow as authored: plugin versions are injected (required to resolve versioned plugin
+     * This parses the raw flow: plugin versions are injected (required to resolve versioned plugin
      * classes) but no runtime governance is applied — use {@link #parseForRuntime(FlowInterface)} for the
      * executor and scheduler paths.
      * </p>

--- a/core/src/main/java/io/kestra/core/services/LabelService.java
+++ b/core/src/main/java/io/kestra/core/services/LabelService.java
@@ -4,7 +4,6 @@ import java.util.*;
 
 import io.kestra.core.exceptions.IllegalVariableEvaluationException;
 import io.kestra.core.models.Label;
-import io.kestra.core.models.flows.FlowInterface;
 import io.kestra.core.models.triggers.AbstractTrigger;
 import io.kestra.core.runners.RunContext;
 import io.kestra.core.utils.ListUtils;
@@ -28,14 +27,16 @@ public final class LabelService {
     }
 
     /**
-     * Return flow labels excluding system labels concatenated with trigger labels.
-     *
-     * Trigger labels will be rendered via the run context but not flow labels.
+     * Return the trigger's own labels, rendered via the run context, excluding system labels.
      * In case rendering is not possible, the label will be omitted.
+     * <p>
+     * Deliberately excludes the flow's labels: an execution snapshots those at creation time and must take them
+     * from the flow processed for runtime, which only {@link io.kestra.core.models.executions.Execution#newExecution}
+     * is given. Folding the raw flow's labels in here would make them win the creation-time merge — see
+     * {@link io.kestra.core.services.ExecutionService#create}, where these labels are appended last.
      */
-    public static List<Label> fromTrigger(RunContext runContext, FlowInterface flow, AbstractTrigger trigger, Map<String, Object> variables) {
-
-        final List<Label> labels = new ArrayList<>(labelsExcludingSystem(flow.getLabels())); // no need for rendering
+    public static List<Label> fromTrigger(RunContext runContext, AbstractTrigger trigger, Map<String, Object> variables) {
+        final List<Label> labels = new ArrayList<>();
 
         // It is better to remove system labels before rendering
         List<Label> triggerLabels = labelsExcludingSystem(trigger.getLabels());

--- a/core/src/main/java/io/kestra/core/services/WebhookService.java
+++ b/core/src/main/java/io/kestra/core/services/WebhookService.java
@@ -18,10 +18,13 @@ import io.kestra.core.models.executions.Execution;
 import io.kestra.core.models.executions.ExecutionId;
 import io.kestra.core.models.executions.ExecutionTrigger;
 import io.kestra.core.models.flows.Flow;
+import io.kestra.core.models.flows.FlowInterface;
 import io.kestra.core.models.flows.State;
 import io.kestra.core.models.triggers.AbstractTrigger;
 import io.kestra.core.queues.DispatchQueueInterface;
 import io.kestra.core.runners.FlowInputOutput;
+import io.kestra.core.runners.FlowMetaStoreInterface;
+import io.kestra.core.runners.FlowMetaStores;
 import io.kestra.core.runners.RunContext;
 import io.kestra.core.runners.RunContextFactory;
 import io.kestra.core.utils.IdUtils;
@@ -49,7 +52,6 @@ import static io.kestra.core.models.Label.CORRELATION_ID;
 public class WebhookService {
     public static final String TEST_EVENT_HEADER = "X-Kestra-Test-Event";
 
-    private static final String FROM_TRIGGER = "trigger";
     private static final String FROM_TEST_EVENT = "testEvent";
 
     @Inject
@@ -81,6 +83,9 @@ public class WebhookService {
 
     @Inject
     private AsyncOperationsConfiguration asyncOperationsConfiguration;
+
+    @Inject
+    private FlowMetaStoreInterface flowMetaStore;
 
     /**
      * Parse query parameters from the webhook request URI.
@@ -122,6 +127,9 @@ public class WebhookService {
      * @throws WebhookInputRenderException if the trigger inputs cannot be rendered or processed
      */
     public Optional<Execution> newExecution(WebhookContext context, Flow flow, AbstractWebhookTrigger trigger, io.kestra.core.models.tasks.Output output) {
+        // the trigger is matched on the raw flow, but the execution is built from the flow the executor will run
+        FlowInterface resolvedFlow = FlowMetaStores.findForRuntimeOrRaw(flowMetaStore, context.flow());
+
         Execution execution = Execution.builder()
             // The caller mints the id before reading the request so that files stored for the call already live
             // under this execution; it is only null for a context built without one.
@@ -131,18 +139,19 @@ public class WebhookService {
             .flowId(context.flow().getId())
             .flowRevision(context.flow().getRevision())
             .inputs(trigger.getInputs())
-            .variables(context.flow().getVariables())
+            .variables(resolvedFlow.getVariables())
             .state(new State())
             .trigger(ExecutionTrigger.of(trigger, output))
             .build();
 
         var runContext = runContext(flow, execution);
 
-        // Add labels
+        // Add labels, flow first so the trigger's own override it, as Execution#newExecution does elsewhere
         List<Label> labels = new ArrayList<>();
         labels.add(new Label(Label.FROM, isTestEvent(context) ? FROM_TEST_EVENT : Label.FromLabel.TRIGGER.value));
+        labels.addAll(LabelService.labelsExcludingSystem(resolvedFlow.getLabels()));
         // The trigger's own labels, as the other trigger types get them through TriggerService
-        labels.addAll(LabelService.fromTrigger(runContext, flow, trigger, Map.of()));
+        labels.addAll(LabelService.fromTrigger(runContext, trigger, Map.of()));
         if (labels.stream().noneMatch(label -> label.key().equals(CORRELATION_ID))) {
             labels.add(new Label(CORRELATION_ID, execution.getId()));
         }

--- a/core/src/main/java/io/kestra/plugin/core/trigger/Flow.java
+++ b/core/src/main/java/io/kestra/plugin/core/trigger/Flow.java
@@ -324,33 +324,28 @@ public class Flow extends AbstractTrigger implements TriggerOutput<Flow.Output> 
                 .build()
         );
 
-        List<Label> labels = LabelService.fromTrigger(runContext, flow, this, Map.of("trigger", executionTrigger.getVariables()));
+        List<Label> labels = LabelService.fromTrigger(runContext, this, Map.of("trigger", executionTrigger.getVariables()));
         Streams.of(current.getLabels())
             .filter(label -> label.key().equals(Label.CORRELATION_ID))
             .findFirst()
             .ifPresent(label -> labels.add(label));
 
-        Execution.ExecutionBuilder builder = Execution.builder()
-            .id(IdUtils.create())
-            .tenantId(flow.getTenantId())
-            .namespace(flow.getNamespace())
-            .flowId(flow.getId())
-            .flowRevision(flow.getRevision())
-            .labels(labels)
-            .state(new State())
-            .trigger(executionTrigger);
+        // the execution snapshots the flow labels and variables, so it is built through the same factory as
+        // every other creation path rather than field by field, which is how flow variables went missing here
+        Execution execution = Execution.newExecution(flow, labels).withTrigger(executionTrigger);
 
         try {
+            Map<String, Object> renderedInputs;
             if (this.inputs != null) {
                 if (outputs != null && !outputs.isEmpty()) {
-                    builder.inputs(runContext.render(this.inputs, Map.of(TRIGGER_VAR, Map.of(OUTPUTS_VAR, outputs))));
+                    renderedInputs = runContext.render(this.inputs, Map.of(TRIGGER_VAR, Map.of(OUTPUTS_VAR, outputs)));
                 } else {
-                    builder.inputs(runContext.render(this.inputs));
+                    renderedInputs = runContext.render(this.inputs);
                 }
             } else {
-                builder.inputs(new HashMap<>());
+                renderedInputs = new HashMap<>();
             }
-            return Optional.of(builder.build());
+            return Optional.of(execution.withInputs(renderedInputs));
         } catch (Exception e) {
             logger.warn(
                 "Failed to trigger flow {}.{} for trigger {}, invalid inputs",
@@ -359,8 +354,7 @@ public class Flow extends AbstractTrigger implements TriggerOutput<Flow.Output> 
                 this.getId(),
                 e
             );
-            var failedExecution = builder.build().withState(State.Type.FAILED);
-            return Optional.of(failedExecution);
+            return Optional.of(execution.withState(State.Type.FAILED));
         }
     }
 

--- a/core/src/main/java/io/kestra/plugin/core/trigger/SchedulableExecutionFactory.java
+++ b/core/src/main/java/io/kestra/plugin/core/trigger/SchedulableExecutionFactory.java
@@ -13,7 +13,6 @@ import io.kestra.core.models.Label;
 import io.kestra.core.models.conditions.ConditionContext;
 import io.kestra.core.models.executions.Execution;
 import io.kestra.core.models.executions.ExecutionTrigger;
-import io.kestra.core.models.flows.FlowInterface;
 import io.kestra.core.models.flows.State;
 import io.kestra.core.models.triggers.*;
 import io.kestra.core.runners.RunContext;
@@ -35,7 +34,7 @@ final class SchedulableExecutionFactory {
         RunContext runContext = conditionContext.getRunContext();
         ExecutionTrigger executionTrigger = ExecutionTrigger.of((AbstractTrigger) trigger, variables);
 
-        List<Label> labels = getLabels(trigger, runContext, triggerContext.getBackfill(), conditionContext.getFlow(), variables);
+        List<Label> labels = getLabels(trigger, runContext, triggerContext.getBackfill(), variables);
 
         List<Label> executionLabels = new ArrayList<>(ListUtils.emptyOnNull(labels));
         executionLabels.add(new Label(Label.FROM, Label.FromLabel.TRIGGER.value));
@@ -88,9 +87,13 @@ final class SchedulableExecutionFactory {
         return inputs;
     }
 
-    private static List<Label> getLabels(Schedulable trigger, RunContext runContext, Backfill backfill, FlowInterface flow, Map<String, Object> variables)
+    /**
+     * Builds the labels the trigger and its backfill contribute, without the flow's own labels: the execution
+     * takes those from the flow processed for runtime when it is created.
+     */
+    private static List<Label> getLabels(Schedulable trigger, RunContext runContext, Backfill backfill, Map<String, Object> variables)
         throws IllegalVariableEvaluationException {
-        List<Label> labels = LabelService.fromTrigger(runContext, flow, (AbstractTrigger) trigger, Map.of("trigger", variables));
+        List<Label> labels = LabelService.fromTrigger(runContext, (AbstractTrigger) trigger, Map.of("trigger", variables));
 
         if (backfill != null) {
             // It is better to remove system labels before rendering

--- a/core/src/test/java/io/kestra/core/metrics/MetricRegistryTest.java
+++ b/core/src/test/java/io/kestra/core/metrics/MetricRegistryTest.java
@@ -10,6 +10,8 @@ import io.kestra.core.models.Label;
 import io.kestra.core.models.executions.Execution;
 import io.kestra.core.models.flows.State;
 import io.kestra.core.models.triggers.AbstractTrigger;
+import io.kestra.core.models.triggers.TriggerEvaluationResult;
+import io.kestra.core.models.triggers.TriggerId;
 import io.kestra.core.utils.IdUtils;
 
 import io.micronaut.test.annotation.MockBean;
@@ -115,6 +117,60 @@ class MetricRegistryTest {
     }
 
     @Test
+    void shouldTagTriggerEvaluationWithFlowLabelWhenTheEvaluationResultDoesNotCarryIt() {
+        // Given a configured label key the flow declares and the trigger does not
+        when(mockConfig.getLabels()).thenReturn(List.of("owner_team"));
+        TriggerEvaluationResult evaluationResult = evaluationResult(List.of(new Label(Label.FROM, "trigger")));
+
+        // When
+        var tags = metricRegistry.tags(evaluationResult, triggerId(), List.of(new Label("owner_team", "platform")));
+
+        // Then the flow label is tagged, as it is on the execution the trigger creates
+        assertThat(tags).containsExactly(
+            "flow_id", "flow",
+            "namespace_id", "io.kestra.unittest",
+            "state", "CREATED",
+            "label_owner_team", "platform"
+        );
+    }
+
+    @Test
+    void shouldPreferTriggerLabelOverFlowLabelWhenTaggingATriggerEvaluation() {
+        // Given the flow and the trigger declaring the same configured label key
+        when(mockConfig.getLabels()).thenReturn(List.of("owner_team"));
+        TriggerEvaluationResult evaluationResult = evaluationResult(List.of(new Label("owner_team", "data")));
+
+        // When
+        var tags = metricRegistry.tags(evaluationResult, triggerId(), List.of(new Label("owner_team", "platform")));
+
+        // Then the trigger wins, matching the merge the created execution applies
+        assertThat(tags).containsExactly(
+            "flow_id", "flow",
+            "namespace_id", "io.kestra.unittest",
+            "state", "CREATED",
+            "label_owner_team", "data"
+        );
+    }
+
+    @Test
+    void shouldTagTriggerEvaluationWithPlaceholderWhenNeitherFlowNorTriggerCarriesTheLabel() {
+        // Given a configured label key nothing declares, and null label lists on both sides
+        when(mockConfig.getLabels()).thenReturn(List.of("owner_team"));
+        TriggerEvaluationResult evaluationResult = evaluationResult(null);
+
+        // When
+        var tags = metricRegistry.tags(evaluationResult, triggerId(), null);
+
+        // Then
+        assertThat(tags).containsExactly(
+            "flow_id", "flow",
+            "namespace_id", "io.kestra.unittest",
+            "state", "CREATED",
+            "label_owner_team", "__none__"
+        );
+    }
+
+    @Test
     void triggerTagsWithNullLabelsAndMetricsLabelsConfigured() {
         when(mockConfig.getLabels()).thenReturn(
             List.of("owner_team")
@@ -131,5 +187,13 @@ class MetricRegistryTest {
             "label_owner_team",
             "__none__"
         );
+    }
+
+    private static TriggerEvaluationResult evaluationResult(List<Label> labels) {
+        return new TriggerEvaluationResult(IdUtils.create(), State.Type.CREATED, null, labels, 1, null, null);
+    }
+
+    private static TriggerId triggerId() {
+        return TriggerId.of(null, "io.kestra.unittest", "flow", "trigger");
     }
 }

--- a/core/src/test/java/io/kestra/core/runners/DefaultFlowMetaStoreTest.java
+++ b/core/src/test/java/io/kestra/core/runners/DefaultFlowMetaStoreTest.java
@@ -10,8 +10,10 @@ import org.junit.jupiter.api.Test;
 import io.kestra.core.exceptions.FlowBlockedException;
 import io.kestra.core.exceptions.FlowProcessingException;
 import io.kestra.core.junit.annotations.KestraTest;
+import io.kestra.core.models.Label;
 import io.kestra.core.models.executions.Execution;
 import io.kestra.core.models.flows.Flow;
+import io.kestra.core.models.flows.FlowId;
 import io.kestra.core.models.flows.FlowInterface;
 import io.kestra.core.models.flows.FlowWithException;
 import io.kestra.core.models.flows.FlowWithSource;
@@ -30,7 +32,9 @@ import jakarta.inject.Inject;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -144,12 +148,12 @@ class DefaultFlowMetaStoreTest {
     }
 
     @Test
-    void findByExecutionThenInjectDefaults() throws FlowProcessingException, QueueException {
+    void findByExecutionForRuntime() throws FlowProcessingException, QueueException {
         Flow test = createFlow();
         FlowWithSource created = flowService.create(GenericFlow.of(test));
         Execution execution = Execution.newExecution(created, null, null, Optional.empty());
 
-        Optional<FlowWithSource> maybeFlow = flowMetaStore.findByExecutionThenInjectDefaults(execution);
+        Optional<FlowWithSource> maybeFlow = flowMetaStore.findByExecutionForRuntime(execution);
 
         assertThat(maybeFlow).isPresent();
         assertThat(maybeFlow.get().getId()).isEqualTo(test.getId());
@@ -158,13 +162,88 @@ class DefaultFlowMetaStoreTest {
     }
 
     @Test
-    void findByExecutionThenInjectDefaultsShouldReturnEmptyForAbsentFlow() {
+    void findByExecutionForRuntimeShouldReturnEmptyForAbsentFlow() {
         Flow test = createFlow();
         Execution execution = Execution.newExecution(test, null, null, Optional.empty());
 
-        Optional<FlowWithSource> maybeFlow = flowMetaStore.findByExecutionThenInjectDefaults(execution);
+        Optional<FlowWithSource> maybeFlow = flowMetaStore.findByExecutionForRuntime(execution);
 
         assertThat(maybeFlow).isEmpty();
+    }
+
+    @Test
+    void shouldReturnFlowProcessedForRuntimeWhenFindingById() throws FlowProcessingException {
+        // Given a stored flow and a parsing service processing it for runtime
+        FlowWithSource flow = createFlow().toBuilder().revision(1).build();
+        FlowWithSource processed = flow.toBuilder().labels(List.of(new Label("team", "platform"))).build();
+        FlowParsingService parsingService = mock(FlowParsingService.class);
+        when(parsingService.parseForRuntime(flow)).thenReturn(processed);
+        DefaultFlowMetaStore metaStore = metaStore(flow, parsingService);
+
+        // When
+        Optional<FlowWithSource> resolved = metaStore.findByIdForRuntime(flow.getTenantId(), flow.getNamespace(), flow.getId(), Optional.of(1));
+
+        // Then the flow is the one processed for runtime, not the one as stored
+        assertThat(resolved).isPresent();
+        assertThat(resolved.get().getLabels()).containsExactly(new Label("team", "platform"));
+        verify(parsingService).parseForRuntime(flow);
+    }
+
+    @Test
+    void shouldReturnFlowProcessedForRuntimeWhenFindingByIdFromTask() throws FlowProcessingException {
+        // Given a stored flow and a parsing service processing it for runtime
+        FlowWithSource flow = createFlow().toBuilder().revision(1).build();
+        FlowWithSource processed = flow.toBuilder().labels(List.of(new Label("team", "platform"))).build();
+        FlowParsingService parsingService = mock(FlowParsingService.class);
+        when(parsingService.parseForRuntime(flow)).thenReturn(processed);
+        DefaultFlowMetaStore metaStore = metaStore(flow, parsingService);
+
+        // When a subflow task resolves it
+        Optional<FlowWithSource> resolved = metaStore.findByIdFromTaskForRuntime(
+            flow.getTenantId(), flow.getNamespace(), flow.getId(), Optional.of(1),
+            flow.getTenantId(), flow.getNamespace(), "parent"
+        );
+
+        // Then the child execution is built from the flow processed for runtime
+        assertThat(resolved).isPresent();
+        assertThat(resolved.get().getLabels()).containsExactly(new Label("team", "platform"));
+        verify(parsingService).parseForRuntime(flow);
+    }
+
+    @Test
+    void shouldSurfaceBlockedFlowAsFlowWithExceptionOnCreationPath() throws FlowProcessingException {
+        // Given a parsing service rejecting the flow at runtime
+        FlowWithSource flow = createFlow().toBuilder().revision(1).build();
+        FlowParsingService parsingService = mock(FlowParsingService.class);
+        when(parsingService.parseForRuntime(flow)).thenThrow(new FlowBlockedException("Blocked by governance policy"));
+        DefaultFlowMetaStore metaStore = metaStore(flow, parsingService);
+
+        // When
+        Optional<FlowWithSource> resolved = metaStore.findByIdForRuntime(flow.getTenantId(), flow.getNamespace(), flow.getId(), Optional.of(1));
+
+        // Then the rejection is surfaced as a FlowWithException the executor fails fast on — never a throw
+        assertThat(resolved).isPresent();
+        assertThat(resolved.get()).isInstanceOf(FlowWithException.class);
+        assertThat(((FlowWithException) resolved.get()).getException()).contains("Blocked by governance policy");
+    }
+
+    @Test
+    void shouldDegradeToStoredFlowWhenRuntimeParsingFailsOnCreationPath() throws FlowProcessingException {
+        // Given a parsing service failing on a non-governance error
+        FlowWithSource flow = createFlow().toBuilder().revision(1).build();
+        FlowParsingService parsingService = mock(FlowParsingService.class);
+        when(parsingService.parseForRuntime(flow)).thenThrow(new FlowProcessingException("invalid"));
+        DefaultFlowMetaStore metaStore = metaStore(flow, parsingService);
+
+        // When
+        Optional<FlowWithSource> resolved = metaStore.findByIdForRuntime(flow.getTenantId(), flow.getNamespace(), flow.getId(), Optional.of(1));
+
+        // Then the execution proceeds with the flow as stored — never a throw
+        assertThat(resolved).isPresent();
+        assertThat(resolved.get()).isNotInstanceOf(FlowWithException.class);
+        assertThat(resolved.get().getId()).isEqualTo(flow.getId());
+        assertThat(resolved.get().getRevision()).isEqualTo(flow.getRevision());
+        assertThat(resolved.get().getLabels()).isNullOrEmpty();
     }
 
     @Test
@@ -261,7 +340,7 @@ class DefaultFlowMetaStoreTest {
         DefaultFlowMetaStore metaStore = metaStore(flow, parsingService);
 
         // When
-        Optional<FlowWithSource> resolved = metaStore.findByExecutionThenInjectDefaults(executionOf(flow));
+        Optional<FlowWithSource> resolved = metaStore.findByExecutionForRuntime(executionOf(flow));
 
         // Then the rejection is surfaced as a FlowWithException the executor fails fast on — never a throw
         assertThat(resolved).isPresent();
@@ -278,12 +357,47 @@ class DefaultFlowMetaStoreTest {
         DefaultFlowMetaStore metaStore = metaStore(flow, parsingService);
 
         // When
-        Optional<FlowWithSource> resolved = metaStore.findByExecutionThenInjectDefaults(executionOf(flow));
+        Optional<FlowWithSource> resolved = metaStore.findByExecutionForRuntime(executionOf(flow));
 
         // Then the execution proceeds with the flow as stored — never a throw
         assertThat(resolved).isPresent();
         assertThat(resolved.get()).isNotInstanceOf(FlowWithException.class);
         assertThat(resolved.get().getId()).isEqualTo(flow.getId());
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void shouldServeCachedFlowWithoutResolvingItWhenFindingByExecution() throws FlowProcessingException {
+        // Given an execution pinned to a revision the meta-store no longer holds, already memoized for runtime
+        FlowWithSource head = createFlow().toBuilder().revision(2).build();
+        FlowWithSource processed = head.toBuilder().revision(1).labels(List.of(new Label("team", "platform"))).build();
+        Execution execution = Execution.builder()
+            .id(IdUtils.create())
+            .tenantId(head.getTenantId())
+            .namespace(head.getNamespace())
+            .flowId(head.getId())
+            .flowRevision(1)
+            .build();
+
+        FlowRepositoryInterface repository = mock(FlowRepositoryInterface.class);
+        when(repository.findAllWithSourceForAllTenants()).thenReturn(List.of(head));
+        FlowParsingService parsingService = mock(FlowParsingService.class);
+        FlowWithDefaultCache withDefaultCache = mock(FlowWithDefaultCache.class);
+        when(withDefaultCache.getIfPresent(FlowId.uid(head.getTenantId(), head.getNamespace(), head.getId(), Optional.of(1))))
+            .thenReturn(Optional.of(processed));
+
+        DefaultFlowMetaStore metaStore = new DefaultFlowMetaStore(
+            repository, parsingService, mock(RunContextLoggerFactory.class), mock(BroadcastQueueInterface.class), withDefaultCache
+        );
+
+        // When
+        Optional<FlowWithSource> resolved = metaStore.findByExecutionForRuntime(execution);
+
+        // Then the memoized flow is served without a repository lookup — this runs on every executor message
+        assertThat(resolved).isPresent();
+        assertThat(resolved.get().getLabels()).containsExactly(new Label("team", "platform"));
+        verify(repository, never()).findByIdWithSource(any(), any(), any(), any());
+        verify(parsingService, never()).parseForRuntime(any());
     }
 
     @SuppressWarnings("unchecked")

--- a/core/src/test/java/io/kestra/core/services/LabelServiceTest.java
+++ b/core/src/test/java/io/kestra/core/services/LabelServiceTest.java
@@ -42,51 +42,42 @@ class LabelServiceTest {
     }
 
     @Test
-    void shouldReturnLabelsFromFlowAndTrigger() {
+    void shouldReturnLabelsFromTrigger() {
+        // Given
         RunContext runContext = runContextFactory.of(Map.of("variable", "variableValue"));
-        Flow flow = Flow.builder()
-            .labels(List.of(new Label("key", "value"), new Label(Label.SYSTEM_PREFIX + "label", "systemValue")))
-            .build();
         AbstractTrigger trigger = Schedule.builder()
             .labels(List.of(new Label("scheduleLabel", "scheduleValue"), new Label("variable", "{{variable}}")))
             .build();
 
-        List<Label> labels = LabelService.fromTrigger(runContext, flow, trigger, Collections.emptyMap());
+        // When
+        List<Label> labels = LabelService.fromTrigger(runContext, trigger, Collections.emptyMap());
 
-        assertThat(labels).hasSize(3);
-        assertThat(labels).contains(new Label("key", "value"), new Label("scheduleLabel", "scheduleValue"), new Label("variable", "variableValue"));
+        // Then only the trigger's labels are returned, so the flow's cannot override the resolved ones
+        assertThat(labels).containsExactly(new Label("scheduleLabel", "scheduleValue"), new Label("variable", "variableValue"));
     }
 
     @Test
     void shouldFilterNonRenderableLabels() {
         RunContext runContext = runContextFactory.of();
-        Flow flow = Flow.builder()
-            .labels(List.of(new Label("key", "value"), new Label(Label.SYSTEM_PREFIX + "label", "systemValue")))
-            .build();
         AbstractTrigger trigger = Schedule.builder()
             .labels(List.of(new Label("scheduleLabel", "scheduleValue"), new Label("variable", "{{variable}}")))
             .build();
 
-        List<Label> labels = LabelService.fromTrigger(runContext, flow, trigger, Collections.emptyMap());
+        List<Label> labels = LabelService.fromTrigger(runContext, trigger, Collections.emptyMap());
 
-        assertThat(labels).hasSize(2);
-        assertThat(labels).contains(new Label("key", "value"), new Label("scheduleLabel", "scheduleValue"));
+        assertThat(labels).containsExactly(new Label("scheduleLabel", "scheduleValue"));
     }
 
     @Test
     void shouldRenderLabelValueUsingProvidedVariables() {
         RunContext runContext = runContextFactory.of();
-        Flow flow = Flow.builder()
-            .labels(List.of(new Label("key", "value")))
-            .build();
         AbstractTrigger trigger = Schedule.builder()
             .labels(List.of(new Label("dynamicLabel", "{{ trigger.executionId }}")))
             .build();
 
-        List<Label> labels = LabelService.fromTrigger(runContext, flow, trigger, Map.of("trigger", Map.of("executionId", "exec-123")));
+        List<Label> labels = LabelService.fromTrigger(runContext, trigger, Map.of("trigger", Map.of("executionId", "exec-123")));
 
-        assertThat(labels).hasSize(2);
-        assertThat(labels).contains(new Label("key", "value"), new Label("dynamicLabel", "exec-123"));
+        assertThat(labels).containsExactly(new Label("dynamicLabel", "exec-123"));
     }
 
     @Test

--- a/core/src/test/java/io/kestra/plugin/core/trigger/FlowTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/trigger/FlowTest.java
@@ -14,6 +14,7 @@ import io.kestra.core.models.executions.ExecutionTrigger;
 import io.kestra.core.models.flows.State;
 import io.kestra.core.models.property.Property;
 import io.kestra.core.runners.RunContextFactory;
+import io.kestra.core.services.LabelService;
 import io.kestra.core.utils.IdUtils;
 import io.kestra.plugin.core.debug.Return;
 
@@ -244,10 +245,12 @@ class FlowTest {
         );
 
         assertThat(evaluate.isPresent()).isTrue();
-        assertThat(evaluate.get().getLabels()).hasSize(3);
-        assertThat(evaluate.get().getLabels()).contains(new Label("triggering-execution-id", triggeringExecution.getId()));
-        assertThat(evaluate.get().getLabels()).contains(new Label("triggering-namespace", "io.kestra.unittest.upstream"));
-        assertThat(evaluate.get().getLabels()).contains(new Label("triggering-flow-id", "upstream-flow"));
+        assertThat(LabelService.labelsExcludingSystem(evaluate.get().getLabels()))
+            .containsExactlyInAnyOrder(
+                new Label("triggering-execution-id", triggeringExecution.getId()),
+                new Label("triggering-namespace", "io.kestra.unittest.upstream"),
+                new Label("triggering-flow-id", "upstream-flow")
+            );
     }
 
     @Test
@@ -292,8 +295,8 @@ class FlowTest {
         );
 
         assertThat(evaluate.isPresent()).isTrue();
-        assertThat(evaluate.get().getLabels()).hasSize(1);
-        assertThat(evaluate.get().getLabels()).contains(new Label("triggering-execution-id", triggeringExecution.getId()));
+        assertThat(LabelService.labelsExcludingSystem(evaluate.get().getLabels()))
+            .containsExactly(new Label("triggering-execution-id", triggeringExecution.getId()));
         assertThat(evaluate.get().getLabels()).noneMatch(label -> label.key().equals("unknown-trigger-field"));
     }
 }

--- a/core/src/test/java/io/kestra/plugin/core/trigger/ScheduleTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/trigger/ScheduleTest.java
@@ -104,7 +104,7 @@ class ScheduleTest {
         );
 
         assertThat(evaluate.isPresent()).isTrue();
-        assertThat(evaluate.get().labels()).hasSize(4);
+        assertThat(evaluate.get().labels()).hasSize(2);
         assertTrue(evaluate.get().labels().stream().anyMatch(label -> label.key().equals(Label.CORRELATION_ID)));
         assertTrue(evaluate.get().labels().stream().anyMatch(label -> label.equals(new Label(Label.FROM, "trigger"))));
         var vars = evaluate.get().trigger().getVariables();
@@ -113,8 +113,12 @@ class ScheduleTest {
         assertThat(dateFromVars((String) vars.get("date"), date)).isEqualTo(date);
         assertThat(dateFromVars((String) vars.get("next"), date)).isEqualTo(date.plusMonths(1));
         assertThat(dateFromVars((String) vars.get("previous"), date)).isEqualTo(date.minusMonths(1));
-        assertThat(evaluate.get().labels()).contains(new Label("flow-label-1", "flow-label-1"));
-        assertThat(evaluate.get().labels()).contains(new Label("flow-label-2", "flow-label-2"));
+        // the flow's labels are deliberately absent: the execution takes them from the flow processed for
+        // runtime when it is created, so carrying the raw flow's here would let them override governance
+        assertThat(evaluate.get().labels()).doesNotContain(
+            new Label("flow-label-1", "flow-label-1"),
+            new Label("flow-label-2", "flow-label-2")
+        );
         assertThat(inputs.size()).isEqualTo(2);
         assertThat(inputs.get("input1")).isNull();
         assertThat(inputs.get("input2")).isEqualTo("default");
@@ -138,7 +142,7 @@ class ScheduleTest {
         );
 
         assertThat(evaluate.isPresent()).isTrue();
-        assertThat(evaluate.get().labels()).hasSize(4);
+        assertThat(evaluate.get().labels()).hasSize(2);
         assertTrue(evaluate.get().labels().stream().anyMatch(label -> label.key().equals(Label.CORRELATION_ID)));
         assertTrue(evaluate.get().labels().stream().anyMatch(label -> label.equals(new Label(Label.FROM, "trigger"))));
         var inputs = evaluate.get().inputs();

--- a/core/src/test/resources/flows/valids/webhook-plugin-labels.yaml
+++ b/core/src/test/resources/flows/valids/webhook-plugin-labels.yaml
@@ -1,0 +1,21 @@
+id: webhook-plugin-labels
+namespace: io.kestra.tests
+
+labels:
+  team: platform
+  env: dev
+
+variables:
+  region: eu-west-1
+
+tasks:
+  - id: log
+    type: io.kestra.plugin.core.log.Log
+    message: hello
+
+triggers:
+  - id: webhook1
+    type: io.kestra.plugin.core.trigger.Webhook
+    key: labels-case
+    labels:
+      env: from-trigger

--- a/executor/src/main/java/io/kestra/executor/DefaultExecutor.java
+++ b/executor/src/main/java/io/kestra/executor/DefaultExecutor.java
@@ -562,7 +562,7 @@ public class DefaultExecutor extends AbstractService implements Executor {
                             executionDelay.getDelayType().equals(ExecutionDelay.DelayType.RESTART_FAILED_TASK)
                                 && execution.getState().getCurrent() != State.Type.KILLING
                         ) {
-                            FlowWithSource flow = flowMetaStore.findByExecutionThenInjectDefaults(execution).orElseThrow(() -> new FlowNotFoundException(execution));
+                            FlowWithSource flow = flowMetaStore.findByExecutionForRuntime(execution).orElseThrow(() -> new FlowNotFoundException(execution));
                             Execution newAttempt = executionService.retryTask(
                                 execution,
                                 flow,
@@ -575,7 +575,7 @@ public class DefaultExecutor extends AbstractService implements Executor {
                             executionDelay.getDelayType().equals(ExecutionDelay.DelayType.RESTART_FAILED_FLOW)
                                 && execution.getState().getCurrent() != State.Type.KILLING
                         ) {
-                            FlowWithSource flow = flowMetaStore.findByExecutionThenInjectDefaults(execution).orElseThrow(() -> new FlowNotFoundException(execution));
+                            FlowWithSource flow = flowMetaStore.findByExecutionForRuntime(execution).orElseThrow(() -> new FlowNotFoundException(execution));
                             Execution newExecution = executionService.replay(executor.getExecution(), flow, null, null, Optional.empty());
                             executor = executor.withExecution(newExecution, "retryFailedFlow");
                         }
@@ -611,7 +611,7 @@ public class DefaultExecutor extends AbstractService implements Executor {
             {
                 Optional<ExecutorContext> maybeExecutor = executionStateStore.lock(slaMonitor.getExecutionId(), execution ->
                 {
-                    FlowWithSource flow = flowMetaStore.findByExecutionThenInjectDefaults(execution).orElseThrow(() -> new FlowNotFoundException(execution));
+                    FlowWithSource flow = flowMetaStore.findByExecutionForRuntime(execution).orElseThrow(() -> new FlowNotFoundException(execution));
                     Optional<SLA> sla = flow.getSla().stream().filter(s -> s.getId().equals(slaMonitor.getSlaId())).findFirst();
                     if (sla.isEmpty()) {
                         // this can happen in case the flow has been updated and the SLA removed
@@ -708,7 +708,7 @@ public class DefaultExecutor extends AbstractService implements Executor {
             // or from a worker task in an afterExecution block, in this case we need to load the flow
             if (executor.getFlow() == null && executor.getExecution().getState().isTerminated()) {
                 var execution = executor.getExecution();
-                FlowWithSource flow = flowMetaStore.findByExecutionThenInjectDefaults(execution).orElseThrow(() -> new FlowNotFoundException(execution));
+                FlowWithSource flow = flowMetaStore.findByExecutionForRuntime(execution).orElseThrow(() -> new FlowNotFoundException(execution));
                 executor = executor.withFlow(flow);
             }
             boolean isTerminated = executor.getFlow() != null && executionService.isTerminated(executor.getFlow(), executor.getExecution());

--- a/executor/src/main/java/io/kestra/executor/FlowTriggerService.java
+++ b/executor/src/main/java/io/kestra/executor/FlowTriggerService.java
@@ -15,6 +15,8 @@ import io.kestra.core.models.triggers.AbstractTrigger;
 import io.kestra.core.models.triggers.multipleflows.MultipleCondition;
 import io.kestra.core.models.triggers.multipleflows.MultipleConditionStateStore;
 import io.kestra.core.models.triggers.multipleflows.MultipleConditionWindow;
+import io.kestra.core.runners.FlowMetaStoreInterface;
+import io.kestra.core.runners.FlowMetaStores;
 import io.kestra.core.runners.RunContext;
 import io.kestra.core.runners.RunContextFactory;
 import io.kestra.core.runners.TransactionContext;
@@ -34,11 +36,13 @@ public class FlowTriggerService {
     private final ConditionService conditionService;
     private final RunContextFactory runContextFactory;
     private final FlowService flowService;
+    private final FlowMetaStoreInterface flowMetaStore;
 
-    public FlowTriggerService(ConditionService conditionService, RunContextFactory runContextFactory, FlowService flowService) {
+    public FlowTriggerService(ConditionService conditionService, RunContextFactory runContextFactory, FlowService flowService, FlowMetaStoreInterface flowMetaStore) {
         this.conditionService = conditionService;
         this.runContextFactory = runContextFactory;
         this.flowService = flowService;
+        this.flowMetaStore = flowMetaStore;
     }
 
     public Stream<FlowWithFlowTrigger> withFlowTriggersOnly(Stream<FlowWithSource> allFlows) {
@@ -63,6 +67,11 @@ public class FlowTriggerService {
      * This method computes executions to trigger from flow triggers from a given execution.
      * It only computes those depending on standard (non-dependsOn) conditions, so it must be used
      * in conjunction with {@link #computeExecutionsFromFlowTriggerDependsOn(Execution, Flow, MultipleConditionStateStore)}.
+     * <p>
+     * Triggers are matched on the raw flow and the execution is built from the flow resolved for runtime, so a
+     * trigger that exists only because governance adds one does not fire, while a flow governance blocks still
+     * does — its execution is created and the executor fails it fast, rather than
+     * the trigger going silent.
      */
     public List<Execution> computeExecutionsFromFlowTriggerConditions(Execution execution, Flow flow) {
         List<FlowWithFlowTrigger> flowWithFlowTriggers = computeFlowTriggers(execution, flow)
@@ -76,13 +85,15 @@ public class FlowTriggerService {
             return Collections.emptyList();
         }
 
+        Flow resolved = FlowMetaStores.findForRuntimeOrRaw(flowMetaStore, flow);
+
         // compute all executions to create from flow triggers without taken into account multiple conditions
         return flowWithFlowTriggers.stream()
             .map(
                 f -> f.getTrigger().evaluate(
                     Optional.empty(),
-                    runContextFactory.of(f.getFlow(), execution),
-                    f.getFlow(),
+                    runContextFactory.of(resolved, execution),
+                    resolved,
                     execution
                 )
             )
@@ -95,6 +106,9 @@ public class FlowTriggerService {
      * This method computes executions to trigger from flow triggers from a given execution.
      * It only computes those depending on dependsOn, so it must be used
      * in conjunction with {@link #computeExecutionsFromFlowTriggerConditions(Execution, Flow)}.
+     * <p>
+     * Triggers are matched on the raw flow and the execution is built from the flow resolved for runtime, as on
+     * the standard-conditions route.
      */
     public List<Execution> computeExecutionsFromFlowTriggerDependsOn(Execution execution, Flow flow, MultipleConditionStateStore multipleConditionStorage) {
         List<FlowWithFlowTrigger> flowWithFlowTriggers = computeFlowTriggers(execution, flow)
@@ -107,6 +121,11 @@ public class FlowTriggerService {
         if (flowWithFlowTriggers.isEmpty()) {
             return Collections.emptyList();
         }
+
+        // resolved before entering the window transaction: the store runs the consumer inside a transaction
+        // holding a pooled connection, and resolving there can need a second one — a repository read when the
+        // head revision moved, or a governance lookup on a cache miss — deadlocking the pool under load
+        Flow resolved = FlowMetaStores.findForRuntimeOrRaw(flowMetaStore, flow);
 
         List<Execution> executions = flowWithFlowTriggers.stream()
             .flatMap(
@@ -124,7 +143,8 @@ public class FlowTriggerService {
                     flowWithMultipleCondition.getFlow(),
                     flowWithMultipleCondition.getMultipleCondition(),
                     buildOutputs(execution),
-                    (txContext, multipleConditionWindow) -> processMultipleConditionWindow(txContext, flowWithMultipleCondition, multipleConditionWindow, execution, multipleConditionStorage)
+                    (txContext,
+                        multipleConditionWindow) -> processMultipleConditionWindow(txContext, flowWithMultipleCondition, multipleConditionWindow, execution, multipleConditionStorage, resolved)
                 )
             )
             .filter(Objects::nonNull)
@@ -137,7 +157,7 @@ public class FlowTriggerService {
     }
 
     private Execution processMultipleConditionWindow(TransactionContext txContext, FlowWithFlowTriggerAndMultipleCondition flowWithMultipleCondition,
-        MultipleConditionWindow multipleConditionWindow, Execution execution, MultipleConditionStateStore multipleConditionStateStore) {
+        MultipleConditionWindow multipleConditionWindow, Execution execution, MultipleConditionStateStore multipleConditionStateStore, Flow resolved) {
         if (!multipleConditionWindow.isValid(ZonedDateTime.now())) {
             return null;
         }
@@ -170,8 +190,8 @@ public class FlowTriggerService {
         ) {
             Optional<Execution> maybeExecution = flowWithMultipleCondition.getTrigger().evaluate(
                 Optional.of(updatedWindow),
-                runContext,
-                flowWithMultipleCondition.getFlow(),
+                runContextFactory.of(resolved, execution),
+                resolved,
                 execution
             );
 

--- a/executor/src/main/java/io/kestra/executor/handler/ExecutionCommandMessageHandler.java
+++ b/executor/src/main/java/io/kestra/executor/handler/ExecutionCommandMessageHandler.java
@@ -12,7 +12,7 @@ import io.kestra.core.killswitch.KillSwitchService;
 import io.kestra.core.models.Label;
 import io.kestra.core.models.executions.Execution;
 import io.kestra.core.models.executions.TaskRun;
-import io.kestra.core.models.flows.Flow;
+import io.kestra.core.models.flows.FlowWithSource;
 import io.kestra.core.models.flows.State;
 import io.kestra.core.runners.ExecutionEvent;
 import io.kestra.core.runners.ExecutionEventType;
@@ -87,7 +87,7 @@ public class ExecutionCommandMessageHandler implements ExecutorMessageHandler<Ex
             AsyncOperationProcessedEvent.Outcome outcome = AsyncOperationProcessedEvent.Outcome.SUCCEEDED;
             String error = null;
             try {
-                var flow = flowMetaStore.findByExecutionThenInjectDefaults(execution).orElseThrow(() -> new FlowNotFoundException(execution));
+                var flow = flowMetaStore.findByExecutionForRuntime(execution).orElseThrow(() -> new FlowNotFoundException(execution));
                 var executorContext = new ExecutorContext(execution, flow);
                 var newExecution = switch (message) {
                     case Restart restartCommand ->
@@ -131,7 +131,7 @@ public class ExecutionCommandMessageHandler implements ExecutorMessageHandler<Ex
         String error = null;
         try {
             var flow = flowMetaStore
-                .findById(command.tenantId(), command.namespace(), command.flowId(), Optional.ofNullable(command.flowRevision()))
+                .findByIdForRuntime(command.tenantId(), command.namespace(), command.flowId(), Optional.ofNullable(command.flowRevision()))
                 .orElseThrow(() -> new FlowNotFoundException(command.executionFullId(), command.flowRevision()));
 
             var newExecution = executionService.create(command, flow);
@@ -175,16 +175,14 @@ public class ExecutionCommandMessageHandler implements ExecutorMessageHandler<Ex
             // Apply inputs override if the controller merged new inputs before emitting the command
             final var sourceExecution = command.inputs() != null ? raw.withInputs(command.inputs()) : raw;
 
-            // findByExecutionThenInjectDefaults returns FlowWithSource (a Flow subtype);
-            // findById returns FlowInterface — cast is safe since all concrete implementations return Flow.
-            Flow flow;
+            FlowWithSource flow;
             if (command.revision() != null) {
-                flow = (Flow) flowMetaStore
-                    .findById(command.tenantId(), command.namespace(), command.flowId(), Optional.of(command.revision()))
+                flow = flowMetaStore
+                    .findByIdForRuntime(command.tenantId(), command.namespace(), command.flowId(), Optional.of(command.revision()))
                     .orElseThrow(() -> new FlowNotFoundException(sourceExecution));
             } else {
                 flow = flowMetaStore
-                    .findByExecutionThenInjectDefaults(sourceExecution)
+                    .findByExecutionForRuntime(sourceExecution)
                     .orElseThrow(() -> new FlowNotFoundException(sourceExecution));
             }
 

--- a/executor/src/main/java/io/kestra/executor/handler/ExecutionEventMessageHandler.java
+++ b/executor/src/main/java/io/kestra/executor/handler/ExecutionEventMessageHandler.java
@@ -127,7 +127,7 @@ public class ExecutionEventMessageHandler implements ExecutorMessageHandler<Exec
                 () ->
                 {
                     try {
-                        final FlowWithSource flow = flowMetaStore.findByExecutionThenInjectDefaults(execution).orElseThrow(() -> new FlowNotFoundException(execution));
+                        final FlowWithSource flow = flowMetaStore.findByExecutionForRuntime(execution).orElseThrow(() -> new FlowNotFoundException(execution));
 
                         // A flow that resolves to a FlowWithException (unparsable, or blocked at execution
                         // pre-flight) cannot be processed: fail the execution fast instead of leaving it stuck.

--- a/executor/src/main/java/io/kestra/executor/handler/LoopExecutionEventMessageHandler.java
+++ b/executor/src/main/java/io/kestra/executor/handler/LoopExecutionEventMessageHandler.java
@@ -95,7 +95,7 @@ public class LoopExecutionEventMessageHandler implements ExecutorMessageHandler<
         return executionStateStore.lock(message.loopRun().parent().getId(), execution ->
         {
             try {
-                final FlowWithSource flow = flowMetaStore.findByExecutionThenInjectDefaults(execution).orElseThrow(() -> new FlowNotFoundException(execution));
+                final FlowWithSource flow = flowMetaStore.findByExecutionForRuntime(execution).orElseThrow(() -> new FlowNotFoundException(execution));
                 ExecutorContext executor = new ExecutorContext(execution, flow);
                 TaskRun parentTaskRun = execution.findTaskRunByTaskRunId(message.loopRun().taskRunId());
                 Loop loop = (Loop) executor.getFlow().findTaskByTaskId(message.loopRun().taskId());

--- a/executor/src/main/java/io/kestra/executor/handler/SubflowExecutionEndMessageHandler.java
+++ b/executor/src/main/java/io/kestra/executor/handler/SubflowExecutionEndMessageHandler.java
@@ -63,7 +63,7 @@ public class SubflowExecutionEndMessageHandler implements MessageHandler<Subflow
         executionStateStore.lock(message.parentExecutionId(), execution ->
         {
             try {
-                FlowWithSource flow = flowMetaStore.findByExecutionThenInjectDefaults(execution).orElseThrow(() -> new FlowNotFoundException(execution));
+                FlowWithSource flow = flowMetaStore.findByExecutionForRuntime(execution).orElseThrow(() -> new FlowNotFoundException(execution));
                 ExecutableTask<?> executableTask = (ExecutableTask<?>) flow.findTaskByTaskId(message.taskId());
                 if (!executableTask.waitForExecution()) {
                     return null;

--- a/executor/src/main/java/io/kestra/executor/handler/WorkerTaskResultMessageHandler.java
+++ b/executor/src/main/java/io/kestra/executor/handler/WorkerTaskResultMessageHandler.java
@@ -74,7 +74,7 @@ public class WorkerTaskResultMessageHandler implements ExecutorMessageHandler<Wo
                     // process worker task result
                     executorService.addWorkerTaskResult(
                         current,
-                        () -> flowMetaStore.findByExecutionThenInjectDefaults(execution).orElseThrow(() -> new FlowNotFoundException(execution)),
+                        () -> flowMetaStore.findByExecutionForRuntime(execution).orElseThrow(() -> new FlowNotFoundException(execution)),
                         message
                     );
                     // join worker result

--- a/executor/src/test/java/io/kestra/executor/FlowTriggerServiceTest.java
+++ b/executor/src/test/java/io/kestra/executor/FlowTriggerServiceTest.java
@@ -1,16 +1,28 @@
 package io.kestra.executor;
 
 import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.BiFunction;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import io.kestra.core.context.TestRunContextFactory;
+import io.kestra.core.exceptions.FlowBlockedException;
 import io.kestra.core.models.Label;
 import io.kestra.core.models.executions.Execution;
 import io.kestra.core.models.executions.ExecutionKind;
 import io.kestra.core.models.flows.Flow;
+import io.kestra.core.models.flows.FlowId;
+import io.kestra.core.models.flows.FlowWithException;
+import io.kestra.core.models.flows.FlowWithSource;
 import io.kestra.core.models.flows.State;
+import io.kestra.core.models.triggers.multipleflows.MultipleCondition;
+import io.kestra.core.models.triggers.multipleflows.MultipleConditionStateStore;
+import io.kestra.core.models.triggers.multipleflows.MultipleConditionWindow;
+import io.kestra.core.runners.FlowMetaStoreInterface;
+import io.kestra.core.runners.TransactionContext;
 import io.kestra.core.services.ConditionService;
 import io.kestra.core.services.FlowService;
 import io.kestra.core.utils.IdUtils;
@@ -22,6 +34,11 @@ import jakarta.inject.Inject;
 import static io.kestra.core.repositories.AbstractFlowRepositoryTest.TEST_NAMESPACE;
 import static io.kestra.core.tenant.TenantService.MAIN_TENANT;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @MicronautTest
 class FlowTriggerServiceTest {
@@ -33,11 +50,13 @@ class FlowTriggerServiceTest {
     private ConditionService conditionService;
     @Inject
     private FlowService flowService;
+    private FlowMetaStoreInterface flowMetaStore;
     private FlowTriggerService flowTriggerService;
 
     @BeforeEach
     void setUp() {
-        flowTriggerService = new FlowTriggerService(conditionService, runContextFactory, flowService);
+        flowMetaStore = mock(FlowMetaStoreInterface.class);
+        flowTriggerService = new FlowTriggerService(conditionService, runContextFactory, flowService, flowMetaStore);
     }
 
     @Test
@@ -190,6 +209,205 @@ class FlowTriggerServiceTest {
         assertThat(resultingExecutionsToRun).isEmpty();
     }
 
+    @Test
+    void shouldBuildExecutionFromFlowResolvedForRuntimeWhenAFlowTriggerMatches() {
+        // Given a flow whose trigger matches, resolved for runtime with an extra label and variable
+        FlowWithSource raw = flowWithFlowTriggerSource();
+        FlowWithSource resolved = raw.toBuilder()
+            .labels(List.of(new Label("team", "platform")))
+            .variables(Map.of("env", "prod"))
+            .build();
+        when(flowMetaStore.findByIdForRuntime(MAIN_TENANT, TEST_NAMESPACE, raw.getId(), Optional.of(1)))
+            .thenReturn(Optional.of(resolved));
+        var simpleFlowExecution = Execution.newExecution(aSimpleFlow(), EMPTY_LABELS).withState(State.Type.SUCCESS);
+
+        // When
+        var resultingExecutionsToRun = flowTriggerService.computeExecutionsFromFlowTriggerConditions(simpleFlowExecution, raw);
+
+        // Then the execution snapshots the resolved flow, not the raw one
+        assertThat(resultingExecutionsToRun).hasSize(1);
+        assertThat(resultingExecutionsToRun.getFirst().getLabels()).contains(new Label("team", "platform"));
+        assertThat(resultingExecutionsToRun.getFirst().getVariables()).containsEntry("env", "prod");
+    }
+
+    @Test
+    void shouldNotResolveFlowForRuntimeWhenNoFlowTriggerMatches() {
+        // Given a flow whose trigger condition does not match
+        FlowWithSource neverMatching = flowWithFlowTriggerSource().toBuilder()
+            .triggers(List.of(flowTriggerWithWhen("false")))
+            .build();
+        var simpleFlowExecution = Execution.newExecution(aSimpleFlow(), EMPTY_LABELS).withState(State.Type.SUCCESS);
+
+        // When
+        var resultingExecutionsToRun = flowTriggerService.computeExecutionsFromFlowTriggerConditions(simpleFlowExecution, neverMatching);
+
+        // Then nothing is parsed for runtime: this runs on every state transition of every execution
+        assertThat(resultingExecutionsToRun).isEmpty();
+        verify(flowMetaStore, never()).findByIdForRuntime(any(), any(), any(), any());
+    }
+
+    @Test
+    void shouldStillCreateExecutionWhenResolvedFlowIsBlocked() {
+        // Given a flow whose trigger matches but which governance blocks at runtime
+        FlowWithSource raw = flowWithFlowTriggerSource();
+        when(flowMetaStore.findByIdForRuntime(MAIN_TENANT, TEST_NAMESPACE, raw.getId(), Optional.of(1)))
+            .thenReturn(Optional.of(FlowWithException.from(raw, new FlowBlockedException("Blocked by governance policy"))));
+        var simpleFlowExecution = Execution.newExecution(aSimpleFlow(), EMPTY_LABELS).withState(State.Type.SUCCESS);
+
+        // When
+        var resultingExecutionsToRun = flowTriggerService.computeExecutionsFromFlowTriggerConditions(simpleFlowExecution, raw);
+
+        // Then the trigger still fires so the executor fails the execution, rather than going silent
+        assertThat(resultingExecutionsToRun).hasSize(1);
+    }
+
+    @Test
+    void shouldSnapshotFlowVariablesOnExecutionsComputedFromFlowTriggers() {
+        // Given a triggered flow declaring variables
+        var simpleFlow = aSimpleFlow();
+        var triggeredFlow = flowWithFlowTrigger().toBuilder()
+            .variables(Map.of("env", "prod"))
+            .build();
+        var simpleFlowExecution = Execution.newExecution(simpleFlow, EMPTY_LABELS).withState(State.Type.SUCCESS);
+
+        // When
+        var resultingExecutionsToRun = flowTriggerService.computeExecutionsFromFlowTriggerConditions(
+            simpleFlowExecution,
+            triggeredFlow
+        );
+
+        // Then the created execution carries them, like every other execution created from a flow
+        assertThat(resultingExecutionsToRun).hasSize(1);
+        assertThat(resultingExecutionsToRun.getFirst().getVariables()).containsEntry("env", "prod");
+    }
+
+    @Test
+    void shouldPreferResolvedLabelOverRawOneWhenAFlowTriggerMatches() {
+        // Given a flow whose raw label governance overrides at runtime
+        FlowWithSource raw = flowWithFlowTriggerSource().toBuilder()
+            .labels(List.of(new Label("env", "dev")))
+            .build();
+        FlowWithSource resolved = raw.toBuilder()
+            .labels(List.of(new Label("env", "prod")))
+            .build();
+        when(flowMetaStore.findByIdForRuntime(MAIN_TENANT, TEST_NAMESPACE, raw.getId(), Optional.of(1)))
+            .thenReturn(Optional.of(resolved));
+        var simpleFlowExecution = Execution.newExecution(aSimpleFlow(), EMPTY_LABELS).withState(State.Type.SUCCESS);
+
+        // When
+        var resultingExecutionsToRun = flowTriggerService.computeExecutionsFromFlowTriggerConditions(simpleFlowExecution, raw);
+
+        // Then the override wins, so the raw value never pins itself back onto the execution
+        assertThat(resultingExecutionsToRun).hasSize(1);
+        assertThat(resultingExecutionsToRun.getFirst().getLabels()).contains(new Label("env", "prod"));
+        assertThat(resultingExecutionsToRun.getFirst().getLabels()).doesNotContain(new Label("env", "dev"));
+    }
+
+    @Test
+    void shouldBuildExecutionFromFlowResolvedForRuntimeWhenADependsOnFlowTriggerMatches() {
+        // Given a dependsOn trigger whose window is satisfied, on a flow governance mutates at runtime
+        FlowWithSource raw = flowWithFlowTriggerSource().toBuilder()
+            .labels(List.of(new Label("env", "dev")))
+            .triggers(List.of(flowTriggerDependingOn(aSimpleFlow())))
+            .build();
+        FlowWithSource resolved = raw.toBuilder()
+            .labels(List.of(new Label("env", "prod"), new Label("team", "platform")))
+            .variables(Map.of("env", "prod"))
+            .build();
+        when(flowMetaStore.findByIdForRuntime(MAIN_TENANT, TEST_NAMESPACE, raw.getId(), Optional.of(1)))
+            .thenReturn(Optional.of(resolved));
+        var simpleFlowExecution = Execution.newExecution(aSimpleFlow(), EMPTY_LABELS).withState(State.Type.SUCCESS);
+
+        // When
+        var resultingExecutionsToRun = flowTriggerService.computeExecutionsFromFlowTriggerDependsOn(
+            simpleFlowExecution,
+            raw,
+            new SatisfiedWindowStateStore()
+        );
+
+        // Then this route snapshots the resolved flow too, though its execution is created through a command
+        assertThat(resultingExecutionsToRun).hasSize(1);
+        assertThat(resultingExecutionsToRun.getFirst().getLabels()).contains(new Label("team", "platform"));
+        assertThat(resultingExecutionsToRun.getFirst().getLabels()).contains(new Label("env", "prod"));
+        assertThat(resultingExecutionsToRun.getFirst().getLabels()).doesNotContain(new Label("env", "dev"));
+        assertThat(resultingExecutionsToRun.getFirst().getVariables()).containsEntry("env", "prod");
+    }
+
+    @Test
+    void shouldNotResolveFlowForRuntimeWhenNoDependsOnFlowTriggerMatches() {
+        // Given a dependsOn trigger whose standard condition does not match
+        FlowWithSource neverMatching = flowWithFlowTriggerSource().toBuilder()
+            .triggers(List.of(flowTriggerDependingOn(aSimpleFlow(), "false")))
+            .build();
+        var simpleFlowExecution = Execution.newExecution(aSimpleFlow(), EMPTY_LABELS).withState(State.Type.SUCCESS);
+
+        // When
+        var resultingExecutionsToRun = flowTriggerService.computeExecutionsFromFlowTriggerDependsOn(
+            simpleFlowExecution,
+            neverMatching,
+            new SatisfiedWindowStateStore()
+        );
+
+        // Then the flow is never parsed for runtime, as a window is processed far more often than it fires
+        assertThat(resultingExecutionsToRun).isEmpty();
+        verify(flowMetaStore, never()).findByIdForRuntime(any(), any(), any(), any());
+    }
+
+    @Test
+    void shouldAssignCorrelationIdOnExecutionsComputedFromFlowTriggersWhenUpstreamCarriesNone() {
+        // Given an upstream execution stripped of its correlation id
+        var upstream = Execution.newExecution(aSimpleFlow(), EMPTY_LABELS)
+            .withState(State.Type.SUCCESS)
+            .withLabels(List.of(new Label("env", "dev")));
+
+        // When
+        var resultingExecutionsToRun = flowTriggerService.computeExecutionsFromFlowTriggerConditions(upstream, flowWithFlowTrigger());
+
+        // Then the triggered execution opens its own correlation rather than going without one
+        assertThat(resultingExecutionsToRun).hasSize(1);
+        assertThat(resultingExecutionsToRun.getFirst().getLabels())
+            .anyMatch(label -> Label.CORRELATION_ID.equals(label.key()) && label.value() != null);
+    }
+
+    @Test
+    void shouldCarryParentCorrelationIdOnExecutionsComputedFromFlowTriggers() {
+        // Given an upstream execution already carrying a correlation id
+        var upstream = Execution.newExecution(aSimpleFlow(), EMPTY_LABELS).withState(State.Type.SUCCESS);
+        String correlationId = upstream.getLabels().stream()
+            .filter(label -> Label.CORRELATION_ID.equals(label.key()))
+            .findFirst()
+            .orElseThrow()
+            .value();
+
+        // When
+        var resultingExecutionsToRun = flowTriggerService.computeExecutionsFromFlowTriggerConditions(upstream, flowWithFlowTrigger());
+
+        // Then the triggered execution stays on the upstream correlation instead of starting a new one
+        assertThat(resultingExecutionsToRun).hasSize(1);
+        assertThat(resultingExecutionsToRun.getFirst().getLabels()).contains(new Label(Label.CORRELATION_ID, correlationId));
+    }
+
+    private static Flow flowWithFlowTrigger() {
+        return Flow.builder()
+            .id("flow-with-flow-trigger")
+            .namespace(TEST_NAMESPACE)
+            .tenantId(MAIN_TENANT)
+            .tasks(List.of(simpleLogTask()))
+            .triggers(List.of(flowTriggerWithNoConditions()))
+            .build();
+    }
+
+    private static FlowWithSource flowWithFlowTriggerSource() {
+        return FlowWithSource.builder()
+            .id("flow-with-flow-trigger")
+            .namespace(TEST_NAMESPACE)
+            .tenantId(MAIN_TENANT)
+            .revision(1)
+            .tasks(List.of(simpleLogTask()))
+            .triggers(List.of(flowTriggerWithNoConditions()))
+            .build();
+    }
+
     private static Flow aSimpleFlow() {
         return Flow.builder()
             .id("simple-flow")
@@ -308,11 +526,65 @@ class FlowTriggerServiceTest {
             .build();
     }
 
+    private static io.kestra.plugin.core.trigger.Flow flowTriggerDependingOn(Flow upstream) {
+        return flowTriggerDependingOn(upstream, null);
+    }
+
+    private static io.kestra.plugin.core.trigger.Flow flowTriggerDependingOn(Flow upstream, String when) {
+        return io.kestra.plugin.core.trigger.Flow.builder()
+            .id("flowTrigger")
+            .type(io.kestra.plugin.core.trigger.Flow.class.getName())
+            .when(when)
+            .dependsOn(
+                List.of(
+                    io.kestra.plugin.core.trigger.Flow.Dependency.builder()
+                        .namespace(upstream.getNamespace())
+                        .flowId(upstream.getId())
+                        .build()
+                )
+            )
+            .build();
+    }
+
     private static Log simpleLogTask() {
         return Log.builder()
             .id(IdUtils.create())
             .type(Log.class.getName())
             .message("Hello World")
             .build();
+    }
+
+    /**
+     * Hands the trigger a fresh window and runs the consumer inline, so a single upstream execution is enough
+     * to satisfy the dependsOn and fire.
+     */
+    private static class SatisfiedWindowStateStore implements MultipleConditionStateStore {
+        @Override
+        public Optional<MultipleConditionWindow> get(FlowId flow, String conditionId) {
+            return Optional.empty();
+        }
+
+        @Override
+        public List<MultipleConditionWindow> expired(String tenantId) {
+            return List.of();
+        }
+
+        @Override
+        public Execution process(FlowId flow, MultipleCondition multipleCondition, Map<String, Object> outputs,
+            BiFunction<TransactionContext, MultipleConditionWindow, Execution> consumer) {
+            return consumer.apply(null, create(flow, multipleCondition, outputs));
+        }
+
+        @Override
+        public void save(TransactionContext txContext, MultipleConditionWindow multipleConditionWindow) {
+        }
+
+        @Override
+        public void save(MultipleConditionWindow multipleConditionWindow) {
+        }
+
+        @Override
+        public void delete(MultipleConditionWindow multipleConditionWindow) {
+        }
     }
 }

--- a/executor/src/test/java/io/kestra/executor/handler/ExecutionCommandMessageHandlerTest.java
+++ b/executor/src/test/java/io/kestra/executor/handler/ExecutionCommandMessageHandlerTest.java
@@ -19,8 +19,6 @@ import io.kestra.core.killswitch.EvaluationType;
 import io.kestra.core.killswitch.KillSwitchService;
 import io.kestra.core.models.executions.Execution;
 import io.kestra.core.models.executions.ExecutionId;
-import io.kestra.core.models.flows.Flow;
-import io.kestra.core.models.flows.FlowInterface;
 import io.kestra.core.models.flows.FlowWithSource;
 import io.kestra.core.models.flows.State;
 import io.kestra.core.runners.FlowMetaStoreInterface;
@@ -89,10 +87,10 @@ class ExecutionCommandMessageHandlerTest {
     @Test
     void shouldEmitSucceededOutcomeOnHappyPath() {
         // Given
-        var flow = mock(FlowInterface.class);
+        var flow = mock(FlowWithSource.class);
         var execution = executionWithState(State.Type.CREATED);
         var context = mock(ExecutorContext.class);
-        when(flowMetaStore.findById(any(), any(), any(), any())).thenReturn(Optional.of(flow));
+        when(flowMetaStore.findByIdForRuntime(any(), any(), any(), any())).thenReturn(Optional.of(flow));
         when(executionService.create(eq(createCommand), eq(flow))).thenReturn(execution);
         when(killSwitchService.evaluate(execution)).thenReturn(EvaluationType.PASS);
         when(executionEventMessageHandler.handle(any())).thenReturn(Optional.of(context));
@@ -103,13 +101,16 @@ class ExecutionCommandMessageHandlerTest {
         // Then
         assertThat(result).contains(context);
         verify(asyncOperationService).emitProcessedIfAsync(createCommand, "tenant", "exec-1", Outcome.SUCCEEDED, null);
+        // the new execution snapshots the flow labels and variables, so it must never be built from the
+        // raw flow — that dropped policy-injected labels on every non-triggered execution
+        verify(flowMetaStore, never()).findById(any(), any(), any(), any());
     }
 
     @Test
     void shouldEmitFailedOutcomeWhenFlowNotFound() {
         // Bug #1: FlowNotFoundException previously escaped the try/finally, so emitProcessedIfAsync
         // was never called and the controller would time out with a 504 instead of a clean error.
-        when(flowMetaStore.findById(any(), any(), any(), any())).thenReturn(Optional.empty());
+        when(flowMetaStore.findByIdForRuntime(any(), any(), any(), any())).thenReturn(Optional.empty());
 
         // When — must not throw
         assertThatCode(() -> handler.handle(createCommand)).doesNotThrowAnyException();
@@ -122,9 +123,9 @@ class ExecutionCommandMessageHandlerTest {
     void shouldEmitFailedOutcomeWhenStateStoreCreateFails() {
         // Bug #2: executionStateStore.create() failure was swallowed (only logged) and the handler
         // continued to emit SUCCEEDED — the controller returned 200 for an execution never persisted.
-        var flow = mock(FlowInterface.class);
+        var flow = mock(FlowWithSource.class);
         var execution = mock(Execution.class); // state stubs not needed — exception fires before getState()
-        when(flowMetaStore.findById(any(), any(), any(), any())).thenReturn(Optional.of(flow));
+        when(flowMetaStore.findByIdForRuntime(any(), any(), any(), any())).thenReturn(Optional.of(flow));
         when(executionService.create(eq(createCommand), eq(flow))).thenReturn(execution);
         doThrow(new RuntimeException("DB unavailable")).when(executionStateStore).create(execution);
 
@@ -137,9 +138,9 @@ class ExecutionCommandMessageHandlerTest {
 
     @Test
     void shouldEmitFailedOutcomeWhenEventHandlerFails() {
-        var flow = mock(FlowInterface.class);
+        var flow = mock(FlowWithSource.class);
         var execution = executionWithState(State.Type.CREATED);
-        when(flowMetaStore.findById(any(), any(), any(), any())).thenReturn(Optional.of(flow));
+        when(flowMetaStore.findByIdForRuntime(any(), any(), any(), any())).thenReturn(Optional.of(flow));
         when(executionService.create(eq(createCommand), eq(flow))).thenReturn(execution);
         when(killSwitchService.evaluate(execution)).thenReturn(EvaluationType.PASS);
         when(executionEventMessageHandler.handle(any())).thenThrow(new RuntimeException("handler error"));
@@ -152,9 +153,9 @@ class ExecutionCommandMessageHandlerTest {
     @Test
     void shouldPersistExecutionAndReturnEmptyWhenKillSwitchActive() {
         // Given
-        var flow = mock(FlowInterface.class);
+        var flow = mock(FlowWithSource.class);
         var execution = mock(Execution.class); // no state stubs needed — kill switch fires before getState()
-        when(flowMetaStore.findById(any(), any(), any(), any())).thenReturn(Optional.of(flow));
+        when(flowMetaStore.findByIdForRuntime(any(), any(), any(), any())).thenReturn(Optional.of(flow));
         when(executionService.create(eq(createCommand), eq(flow))).thenReturn(execution);
         when(killSwitchService.evaluate(execution)).thenReturn(EvaluationType.IGNORE);
 
@@ -232,7 +233,7 @@ class ExecutionCommandMessageHandlerTest {
         var newExecution = mockExecution("new-exec-id", "tenant", "ns", "flow-id");
         var context = mock(ExecutorContext.class);
         when(executionStateStore.findById("source-exec-id")).thenReturn(sourceExecution);
-        when(flowMetaStore.findByExecutionThenInjectDefaults(any())).thenReturn(Optional.of(flow));
+        when(flowMetaStore.findByExecutionForRuntime(any())).thenReturn(Optional.of(flow));
         when(executionService.replay(any(), eq(flow), isNull(), isNull(), any(), eq(true), eq("new-exec-id")))
             .thenReturn(newExecution);
         when(executionEventMessageHandler.handle(any())).thenReturn(Optional.of(context));
@@ -261,7 +262,7 @@ class ExecutionCommandMessageHandlerTest {
     void replayShouldEmitFailedOutcomeWhenFlowNotFound() {
         // Given
         when(executionStateStore.findById("source-exec-id")).thenReturn(sourceExecution);
-        when(flowMetaStore.findByExecutionThenInjectDefaults(any())).thenReturn(Optional.empty());
+        when(flowMetaStore.findByExecutionForRuntime(any())).thenReturn(Optional.empty());
 
         // When — must not throw
         assertThatCode(() -> handler.handle(replayCommand)).doesNotThrowAnyException();
@@ -276,7 +277,7 @@ class ExecutionCommandMessageHandlerTest {
         var flow = mock(FlowWithSource.class);
         var newExecution = mockExecution("new-exec-id", "tenant", "ns", "flow-id");
         when(executionStateStore.findById("source-exec-id")).thenReturn(sourceExecution);
-        when(flowMetaStore.findByExecutionThenInjectDefaults(any())).thenReturn(Optional.of(flow));
+        when(flowMetaStore.findByExecutionForRuntime(any())).thenReturn(Optional.of(flow));
         when(executionService.replay(any(), any(), any(), any(), any(), eq(true), eq("new-exec-id")))
             .thenReturn(newExecution);
         doThrow(new RuntimeException("DB unavailable")).when(executionStateStore).create(newExecution);
@@ -294,7 +295,7 @@ class ExecutionCommandMessageHandlerTest {
         var flow = mock(FlowWithSource.class);
         var newExecution = mockExecution("new-exec-id", "tenant", "ns", "flow-id");
         when(executionStateStore.findById("source-exec-id")).thenReturn(sourceExecution);
-        when(flowMetaStore.findByExecutionThenInjectDefaults(any())).thenReturn(Optional.of(flow));
+        when(flowMetaStore.findByExecutionForRuntime(any())).thenReturn(Optional.of(flow));
         when(executionService.replay(any(), eq(flow), isNull(), isNull(), any(), eq(true), eq("new-exec-id")))
             .thenReturn(newExecution);
         when(killSwitchService.evaluate(newExecution)).thenReturn(EvaluationType.KILL);
@@ -317,7 +318,7 @@ class ExecutionCommandMessageHandlerTest {
         var flow = mock(FlowWithSource.class);
         var newExecution = mockExecution("new-exec-id", "tenant", "ns", "flow-id");
         when(executionStateStore.findById("source-exec-id")).thenReturn(sourceExecution);
-        when(flowMetaStore.findByExecutionThenInjectDefaults(any())).thenReturn(Optional.of(flow));
+        when(flowMetaStore.findByExecutionForRuntime(any())).thenReturn(Optional.of(flow));
         when(executionService.replay(any(), eq(flow), isNull(), isNull(), any(), eq(true), eq("new-exec-id")))
             .thenReturn(newExecution);
         when(killSwitchService.evaluate(newExecution)).thenReturn(EvaluationType.IGNORE);
@@ -336,11 +337,11 @@ class ExecutionCommandMessageHandlerTest {
     void replayShouldApplyRevisionWhenSpecified() throws Exception {
         // Given
         var commandWithRevision = replayCommand.withRevision(3);
-        var flow = mock(Flow.class);
+        var flow = mock(FlowWithSource.class);
         var newExecution = mockExecution("new-exec-id", "tenant", "ns", "flow-id");
         var context = mock(ExecutorContext.class);
         when(executionStateStore.findById("source-exec-id")).thenReturn(sourceExecution);
-        when(flowMetaStore.findById("tenant", "ns", "flow-id", Optional.of(3))).thenReturn(Optional.of(flow));
+        when(flowMetaStore.findByIdForRuntime("tenant", "ns", "flow-id", Optional.of(3))).thenReturn(Optional.of(flow));
         when(executionService.replay(any(), eq(flow), isNull(), eq(3), any(), eq(true), eq("new-exec-id")))
             .thenReturn(newExecution);
         when(executionEventMessageHandler.handle(any())).thenReturn(Optional.of(context));
@@ -350,7 +351,10 @@ class ExecutionCommandMessageHandlerTest {
 
         // Then
         assertThat(result).contains(context);
-        verify(flowMetaStore).findById("tenant", "ns", "flow-id", Optional.of(3));
+        // the replayed execution snapshots the flow labels and variables, so the pinned revision must be
+        // resolved as the executor will run it
+        verify(flowMetaStore).findByIdForRuntime("tenant", "ns", "flow-id", Optional.of(3));
+        verify(flowMetaStore, never()).findById(any(), any(), any(), any());
     }
 
     // ---- helpers ----

--- a/executor/src/test/java/io/kestra/executor/handler/ExecutionEventMessageHandlerFlowWithExceptionTest.java
+++ b/executor/src/test/java/io/kestra/executor/handler/ExecutionEventMessageHandlerFlowWithExceptionTest.java
@@ -61,7 +61,7 @@ class ExecutionEventMessageHandlerFlowWithExceptionTest {
         var flow = Fixtures.flow();
         var execution = Execution.newExecution(flow, Collections.emptyList());
         executionRepository.save(execution);
-        when(flowMetaStore.findByExecutionThenInjectDefaults(any()))
+        when(flowMetaStore.findByExecutionForRuntime(any()))
             .thenReturn(Optional.of(FlowWithException.from(flow, new IllegalStateException("blocked by governance policy"))));
 
         // When
@@ -78,7 +78,7 @@ class ExecutionEventMessageHandlerFlowWithExceptionTest {
         var flow = Fixtures.flow();
         var execution = Execution.newExecution(flow, Collections.emptyList()).withState(State.Type.SUCCESS);
         executionRepository.save(execution);
-        when(flowMetaStore.findByExecutionThenInjectDefaults(any()))
+        when(flowMetaStore.findByExecutionForRuntime(any()))
             .thenReturn(Optional.of(FlowWithException.from(flow, new IllegalStateException("blocked by governance policy"))));
 
         // When

--- a/jdbc/src/test/java/io/kestra/jdbc/runner/AbstractJdbcDeserializationIssuesTest.java
+++ b/jdbc/src/test/java/io/kestra/jdbc/runner/AbstractJdbcDeserializationIssuesTest.java
@@ -107,7 +107,18 @@ public abstract class AbstractJdbcDeserializationIssuesTest {
             }
 
             @Override
-            public Optional<FlowWithSource> findByExecutionThenInjectDefaults(Execution execution) {
+            public Optional<FlowWithSource> findByExecutionForRuntime(Execution execution) {
+                return Optional.empty();
+            }
+
+            @Override
+            public Optional<FlowWithSource> findByIdForRuntime(String tenantId, String namespace, String id, Optional<Integer> revision) {
+                return Optional.empty();
+            }
+
+            @Override
+            public Optional<FlowWithSource> findByIdFromTaskForRuntime(String tenantId, String namespace, String id, Optional<Integer> revision, String fromTenant,
+                String fromNamespace, String fromId) {
                 return Optional.empty();
             }
         };

--- a/scheduler/src/main/java/io/kestra/scheduler/TriggerScheduler.java
+++ b/scheduler/src/main/java/io/kestra/scheduler/TriggerScheduler.java
@@ -22,6 +22,7 @@ import com.google.common.base.Throwables;
 
 import io.kestra.core.exceptions.InvalidTriggerConfigurationException;
 import io.kestra.core.metrics.MetricRegistry;
+import io.kestra.core.models.Label;
 import io.kestra.core.models.conditions.ConditionContext;
 import io.kestra.core.models.executions.Execution;
 import io.kestra.core.models.flows.FlowId;
@@ -340,7 +341,7 @@ public class TriggerScheduler {
         // Evaluate Schedulable
         Optional<TriggerEvaluationResult> evaluationResult = schedulableEvaluator.evaluate(trigger, triggerContext, triggerEvaluationContext.conditionContext());
         if (evaluationResult.isPresent()) {
-            log(clock, triggerContext, evaluationResult.get());
+            log(clock, triggerContext, evaluationResult.get(), triggerEvaluationContext.flow().getLabels());
             boolean allowConcurrent = ((AbstractTrigger) trigger).isAllowConcurrent();
             triggerState = triggerState
                 .updateOnExecutionCreated(clock, evaluationResult.get().stateType())
@@ -433,9 +434,11 @@ public class TriggerScheduler {
         return Optional.empty();
     }
 
-    private void log(Clock clock, TriggerContext triggerContext, TriggerEvaluationResult evaluationResult) {
+    private void log(Clock clock, TriggerContext triggerContext, TriggerEvaluationResult evaluationResult, List<Label> flowLabels) {
         metricRegistry
-            .counter(MetricRegistry.METRIC_SCHEDULER_TRIGGER_COUNT, MetricRegistry.METRIC_SCHEDULER_TRIGGER_COUNT_DESCRIPTION, metricRegistry.tags(evaluationResult, triggerContext))
+            .counter(
+                MetricRegistry.METRIC_SCHEDULER_TRIGGER_COUNT, MetricRegistry.METRIC_SCHEDULER_TRIGGER_COUNT_DESCRIPTION, metricRegistry.tags(evaluationResult, triggerContext, flowLabels)
+            )
             .increment();
 
         ZonedDateTime now = ZonedDateTime.now(clock).truncatedTo(ChronoUnit.SECONDS);
@@ -455,7 +458,7 @@ public class TriggerScheduler {
                 metricRegistry
                     .timer(
                         MetricRegistry.METRIC_SCHEDULER_TRIGGER_DELAY_DURATION, MetricRegistry.METRIC_SCHEDULER_TRIGGER_DELAY_DURATION_DESCRIPTION,
-                        metricRegistry.tags(evaluationResult, triggerContext)
+                        metricRegistry.tags(evaluationResult, triggerContext, flowLabels)
                     )
                     .record(Duration.between(triggerContext.getDate(), now));
             }

--- a/webserver/src/main/java/io/kestra/webserver/controllers/api/ExecutionController.java
+++ b/webserver/src/main/java/io/kestra/webserver/controllers/api/ExecutionController.java
@@ -92,6 +92,7 @@ import io.kestra.webserver.responses.BulkErrorResponse;
 import io.kestra.webserver.responses.BulkResponse;
 import io.kestra.webserver.responses.PagedResults;
 import io.kestra.webserver.services.ExecutionDependenciesStreamingService;
+import io.kestra.webserver.services.FlowLabelsResolver;
 import io.kestra.webserver.services.MicronautHttpService;
 import io.kestra.webserver.services.SseConnectionMetrics;
 import io.kestra.webserver.services.WebhookBodyService;
@@ -244,6 +245,12 @@ public class ExecutionController {
 
     @Inject
     private WebhookService webhookService;
+
+    @Inject
+    private FlowLabelsResolver flowLabelsResolver;
+
+    @Inject
+    private FlowMetaStoreInterface flowMetaStore;
 
     @Inject
     private WebhookBodyService webhookBodyService;
@@ -741,7 +748,8 @@ public class ExecutionController {
         String path,
         HttpRequest<?> request) throws IllegalVariableEvaluationException, IOException {
         Flow flow = executableFlow(maybeFlow);
-        AbstractWebhookTrigger webhook = findWebhook(flow, key);
+        // Processed here too: how the body is read is the trigger's fetchType, which governance can change
+        AbstractWebhookTrigger webhook = processedForRuntime(flow, findWebhook(flow, key));
 
         // Minted before the body is read, so that a stored body lives under the execution that will carry it.
         String executionId = IdUtils.create();
@@ -779,7 +787,9 @@ public class ExecutionController {
         String executionId,
         URI storedBodyUri) throws IllegalVariableEvaluationException {
         Flow flow = executableFlow(maybeFlow);
-        final AbstractWebhookTrigger webhook = findWebhook(flow, key);
+        // Matched on the raw flow so an unknown key stays a 404, then evaluated as the executor would
+        // run it: the trigger is part of the flow, so its configuration is the processed one.
+        final AbstractWebhookTrigger webhook = processedForRuntime(flow, findWebhook(flow, key));
         this.onWebhookMatched(flow, webhook);
 
         // Webhook context
@@ -799,8 +809,9 @@ public class ExecutionController {
         } catch (Exception e) {
             // The failed execution takes the identifier the call was given, so that anything already stored for it
             // is attached to it, and purged with it.
+            // No labels: the executor builds the execution from the flow processed for runtime, which
+            // contributes them itself.
             var createCommand = Create.of(new ExecutionId(flow.getTenantId(), flow.getNamespace(), flow.getId(), executionId, flow.getRevision()))
-                .withLabels(LabelService.labelsExcludingSystem(flow.getLabels()))
                 .withStateType(State.Type.FAILED)
                 .withTrigger(ExecutionTrigger.of(webhook, Map.of()));
 
@@ -847,6 +858,21 @@ public class ExecutionController {
     }
 
     /**
+     * @return the same trigger as the flow processed for runtime carries it, so that what governs the flow
+     *         governs its triggers too; the one given when the processed flow can no longer supply it, which
+     *         is the case for a flow governance blocks — rejected a step later by the edition's gate.
+     */
+    private AbstractWebhookTrigger processedForRuntime(Flow flow, AbstractWebhookTrigger webhook) {
+        return ListUtils.emptyOnNull(FlowMetaStores.findForRuntimeOrRaw(flowMetaStore, flow).getTriggers())
+            .stream()
+            .filter(processed -> webhook.getId().equals(processed.getId()))
+            .filter(AbstractWebhookTrigger.class::isInstance)
+            .map(AbstractWebhookTrigger.class::cast)
+            .findFirst()
+            .orElse(webhook);
+    }
+
+    /**
      * @return the webhook trigger of the flow the given key matches
      * @throws HttpStatusException if no webhook trigger matches the key
      */
@@ -886,7 +912,7 @@ public class ExecutionController {
         @Parameter(description = "The labels as a list of 'key:value'") @Nullable @QueryValue @Format("MULTI") List<String> labels,
         @Parameter(description = "The flow revision or latest if null") @QueryValue Optional<Integer> revision) {
         Flow flow = flowService.getFlowIfExecutableOrThrow(tenantService.resolveTenant(), namespace, id, revision);
-        List<Label> parsedLabels = parseLabels(labels);
+        List<Label> parsedLabels = parseLabels(labels, flow);
         Execution execution = Execution.newExecution(flow, parsedLabels);
         return flowInputOutput
             .validateExecutionInputs(flow.getInputs(), flow, execution, inputs)
@@ -926,7 +952,6 @@ public class ExecutionController {
         @Parameter(description = "Set a list of breakpoints at specific tasks 'id.value', separated by a coma.") @QueryValue Optional<String> breakpoints,
         @Parameter(description = "Specific execution kind") @QueryValue Optional<ExecutionKind> kind) {
         final String tenantId = tenantService.resolveTenant();
-        List<Label> parsedLabels = parseLabels(labels);
         final Flow flow;
         try {
             flow = flowService.getFlowIfExecutableOrThrow(tenantId, namespace, id, revision);
@@ -945,6 +970,9 @@ public class ExecutionController {
             }
             throw e;
         }
+
+        // parsed once the flow is known: which labels the caller may set can depend on it
+        List<Label> parsedLabels = parseLabels(labels, flow);
 
         if (flow.isDraft()) {
             controlDraftExecutableAs(flow, kind.orElse(null));
@@ -1109,7 +1137,11 @@ public class ExecutionController {
         }
     }
 
-    protected List<Label> parseLabels(List<String> labels) {
+    /**
+     * Parses the labels a caller supplied for an execution of the given flow, rejecting the ones that are not
+     * theirs to set — the system namespace here, and whatever {@link FlowLabelsResolver} restricts for this flow.
+     */
+    protected List<Label> parseLabels(List<String> labels, FlowInterface flow) {
         List<Label> parsedLabels = labels == null ? new ArrayList<>()
             : RequestUtils.toMap(labels).entrySet().stream()
                 .map(entry -> new Label(entry.getKey(), entry.getValue()))
@@ -1126,6 +1158,8 @@ public class ExecutionController {
         if (first.isPresent()) {
             throw new IllegalArgumentException("System labels can only be set by Kestra itself, offending label: " + first.get().key() + "=" + first.get().value());
         }
+
+        parsedLabels = new ArrayList<>(flowLabelsResolver.resolve(flow, parsedLabels));
 
         // default the origin to "api" when the client didn't set it (the UI sends system.from=ui)
         if (parsedLabels.stream().noneMatch(l -> l.key().equals(Label.FROM))) {

--- a/webserver/src/main/java/io/kestra/webserver/services/FlowLabelsResolver.java
+++ b/webserver/src/main/java/io/kestra/webserver/services/FlowLabelsResolver.java
@@ -1,0 +1,29 @@
+package io.kestra.webserver.services;
+
+import java.util.List;
+
+import io.kestra.core.models.Label;
+import io.kestra.core.models.flows.FlowInterface;
+
+import jakarta.inject.Singleton;
+
+/**
+ * Resolves which of the labels a caller supplied apply to an execution of a given flow.
+ *
+ * <p>
+ * A caller may override a label the flow declares, or add one of its own — that is the point of passing labels
+ * when starting an execution. This service is the single place deciding when they may not, so that every route
+ * accepting caller labels shares one rule, and the executor's creation path stays free of any such lookup.
+ */
+@Singleton
+public class FlowLabelsResolver {
+
+    /**
+     * @param flow the flow the execution will run
+     * @param labels the labels the caller supplied, already parsed
+     * @return the labels to carry onto the execution; all of them here, editions may restrict
+     */
+    public List<Label> resolve(FlowInterface flow, List<Label> labels) {
+        return labels;
+    }
+}

--- a/webserver/src/test/java/io/kestra/webserver/controllers/api/WebhookPluginTest.java
+++ b/webserver/src/test/java/io/kestra/webserver/controllers/api/WebhookPluginTest.java
@@ -9,6 +9,7 @@ import io.kestra.core.junit.annotations.LoadFlows;
 import io.kestra.core.models.Label;
 import io.kestra.core.runners.TestRunnerUtils;
 import io.kestra.core.services.WebhookService;
+import io.kestra.plugin.core.trigger.WebhookResponse;
 
 import io.micronaut.http.HttpStatus;
 import io.micronaut.http.client.annotation.Client;
@@ -132,5 +133,33 @@ public class WebhookPluginTest {
         );
 
         assertThat((Object) exception.getStatus()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+
+    @Test
+    @LoadFlows("flows/valids/webhook-plugin-labels.yaml")
+    void shouldSnapshotFlowLabelsAndVariablesOnAWebhookExecution() {
+        // Given a flow declaring labels and variables, and a trigger overriding one of the labels
+
+        // When
+        var response = client.toBlocking().exchange(
+            POST(
+                "/api/v1/%s/executions/webhook/io.kestra.tests/webhook-plugin-labels/labels-case".formatted(MAIN_TENANT),
+                "{\"test\": \"data\"}"
+            ),
+            WebhookResponse.class
+        );
+
+        // Then the response body reports the flow's labels, with the trigger's own overriding them
+        assertThat((Object) response.getStatus()).isEqualTo(HttpStatus.OK);
+        assertThat(response.body().labels()).contains(new Label("team", "platform"), new Label("env", "from-trigger"));
+        assertThat(response.body().labels()).doesNotContain(new Label("env", "dev"));
+
+        // And the created execution snapshots both, as it is built from the flow processed for runtime
+        var execution = runnerUtils.awaitFlowExecution(
+            e -> e.getTrigger() != null && e.getTrigger().getId().equals("webhook1"),
+            MAIN_TENANT, TESTS_FLOW_NS, "webhook-plugin-labels"
+        );
+        assertThat(execution.getLabels()).contains(new Label("team", "platform"), new Label("env", "from-trigger"));
+        assertThat(execution.getVariables()).containsEntry("region", "eu-west-1");
     }
 }

--- a/worker/src/main/java/io/kestra/worker/stores/GrpcWorkerFlowMetaStore.java
+++ b/worker/src/main/java/io/kestra/worker/stores/GrpcWorkerFlowMetaStore.java
@@ -125,7 +125,18 @@ public class GrpcWorkerFlowMetaStore implements FlowMetaStoreInterface, WorkerMe
     }
 
     @Override
-    public Optional<FlowWithSource> findByExecutionThenInjectDefaults(Execution execution) {
-        throw new UnsupportedOperationException("findByExecutionThenInjectDefaults is not supported on workers");
+    public Optional<FlowWithSource> findByExecutionForRuntime(Execution execution) {
+        throw new UnsupportedOperationException("findByExecutionForRuntime is not supported on workers");
+    }
+
+    @Override
+    public Optional<FlowWithSource> findByIdForRuntime(String tenantId, String namespace, String id, Optional<Integer> revision) {
+        throw new UnsupportedOperationException("findByIdForRuntime is not supported on workers");
+    }
+
+    @Override
+    public Optional<FlowWithSource> findByIdFromTaskForRuntime(String tenantId, String namespace, String id, Optional<Integer> revision, String fromTenant,
+        String fromNamespace, String fromId) {
+        throw new UnsupportedOperationException("findByIdFromTaskForRuntime is not supported on workers");
     }
 }


### PR DESCRIPTION
### ✨ Description

Every route that creates an execution now builds it from the flow **processed for runtime** — plugin defaults injected and, in the Enterprise Edition, governance policies applied — instead of the flow as authored.

An `Execution` snapshots the flow's `labels` and `variables` at creation time. Resolving the authored definition therefore dropped everything a runtime parse adds, on every route except the ones a trigger drives. And where authored labels *were* carried, they won: `ExecutionService.create` appends the trigger's labels last, `Label.deduplicate` keeps the last occurrence, and `LabelService.fromTrigger` folded the flow's authored labels into that list — so the authored value overrode the value plugin defaults or governance had resolved.

**Changes**

| Area | Change |
|---|---|
| `core` — `FlowMetaStoreInterface`, `DefaultFlowMetaStore` | Adds `findByIdThenInjectDefaults` and its `findByIdFromTask` sibling (which keeps the namespace-allowed check). The meta-store could only hand back a runtime-processed flow once an execution existed, while every path creating one needs that flow *before* it exists. Both memoize on the resolved flow UID rather than on the requested identifier, which is what makes one cache safe for every entry point. |
| `executor` — `ExecutionCommandMessageHandler` | A `Create` command resolves its flow with `findByIdThenInjectDefaults`, on the creation and the replay paths alike. |
| `core` — `ExecutableUtils`, `SubflowFunction` | A subflow task resolves its child with `findByIdFromTaskThenInjectDefaults`. The Pebble `subflow()` function goes through it too, which also surfaces a governance rejection there rather than as a created-then-failed execution. |
| `executor` — `FlowTriggerService`, `plugin.core.trigger.Flow` | Both flow-trigger routes evaluated the flow as authored. The standard-condition one sends the execution straight to the queue, so it carried neither an injected label nor a flow variable at all; the `dependsOn` one goes through a `Create` command but hand-built its labels. Both now resolve the processed flow — only once a trigger is about to fire, so matching still runs on the authored definition — and build through `Execution.newExecution` rather than setting the field. |
| `webserver` — `ExecutionController`, new `FlowLabelsResolver` | `parseLabels` takes the flow and delegates to `FlowLabelsResolver`, the single place deciding whether a label passed when starting an execution applies to the target flow. Identity in OSS — callers keep overriding flow labels and adding their own; editions replace it to restrict. The webhook route resolves the processed flow for its labels, variables and trigger evaluation (the key is still matched on the authored flow, so an unknown key stays a 404). |
| `core` — `LabelService` | Adds `fromTriggerOnly`, returning just the trigger's labels, and deprecates `fromTrigger` for removal: `Execution.newExecution` is left as the single place a flow contributes its own labels. |
| `core`/`scheduler` — `TriggerService`, `TriggerEvaluationResult`, `MetricRegistry`, `TriggerScheduler` | `TriggerService` added the flow's labels a second time on top of the trigger's, so `TriggerEvaluationResult` and every realtime trigger send carried them twice. Removing that dropped them from the `scheduler.trigger.count` and `scheduler.trigger.delay.duration` tags, so those are now passed explicitly — trigger labels first, so a trigger still wins. |
| `worker` — `GrpcWorkerFlowMetaStore` | A dedicated worker resolves flow metadata over gRPC and has no parsing service, so the new lookups throw `UnsupportedOperationException` there, as the existing runtime-processed lookup already does. |

**Tests**

- `DefaultFlowMetaStoreTest` — the new lookups return the processed flow and memoize on the resolved UID.
- `FlowTriggerServiceTest` — both flow-trigger routes carry the processed flow's labels and variables.
- `LabelServiceTest`, `MetricRegistryTest`, `FlowTest`, `ScheduleTest`, `WebhookPluginTest`, `ExecutionCommandMessageHandlerTest` — updated or extended for the above.

### 🔗 Related Issue

Refs https://github.com/kestra-io/kestra-ee/issues/9611 — this is the OSS half of the fix for the first bug reported there (label injection skipped on executions that are not trigger-driven). The `labels: {}` behaviour reported as the second bug in that issue is untouched here, so the issue stays open.

### 🛠️ Backend Checklist

- [ ] Code compiles successfully and passes all checks
- [ ] All unit and integration tests pass

### 📝 Additional Notes

- **Companion PR:** https://github.com/kestra-io/kestra-ee/pull/9873 — same branch name. The Enterprise Edition side adds the policy-aware `FlowLabelsResolver` and the end-to-end coverage of each creation route under governance. Please merge them together: without the EE PR the new `FlowLabelsResolver` seam is simply identity, and without this PR the EE tests fail.
- `LabelService.fromTrigger` is deprecated rather than removed since it is public API reachable from plugins; it now delegates to `fromTriggerOnly` and is unused in this repo.
- The webhook route deliberately keeps its response body reporting the flow's labels — that body is public-facing, whereas policy-injected labels are internal.

### ⚠️ Known gap — flow triggers evaluate the authored trigger

Every other route now evaluates the trigger as the flow processed for runtime carries it: schedule, polling and realtime take it from the parsed flow in `DefaultSchedulableTriggerFetcher`, and the webhook route re-resolves it through `ExecutionController#processedForRuntime`. `FlowTriggerService` does not — it passes the resolved flow to `evaluate`, but the trigger instance itself still comes from the authored definition, so a policy changing a flow trigger's own configuration is ignored there. Only its labels and variables are governed, which is what this PR fixes.

A blocked flow is also handled three different ways: the scheduler skips the trigger (`TriggerFlowParser#parseOrSkip` returns `null`), a flow trigger still creates the execution and lets the executor fail it, and the webhook route falls back to the authored trigger for the edition's gate to reject. Both are follow-ups, not addressed here.

