### PR TITLE
fix(worker): stop a worker from connecting to the database

### DIFF
--- a/cli/src/main/java/io/kestra/cli/Kestra.java
+++ b/cli/src/main/java/io/kestra/cli/Kestra.java
@@ -20,6 +20,7 @@ import io.kestra.cli.commands.servers.ServerCommand;
 import io.kestra.cli.commands.sys.SysCommand;
 import io.kestra.cli.schema.ConfigurationSchemaCommand;
 import io.kestra.cli.services.EnvironmentProvider;
+import io.kestra.core.models.ServerType;
 
 import io.micronaut.configuration.picocli.MicronautFactory;
 import io.micronaut.context.ApplicationContext;
@@ -179,42 +180,77 @@ public class Kestra implements Callable<Integer> {
 
         Class<?> cls = commandLine.getCommandSpec().userObject().getClass();
 
+        Map<String, Object> properties = AbstractCommand.class.isAssignableFrom(cls)
+            ? commandProperties(cls, commandLine)
+            : Map.of();
+
+        return contextBuilder(cls, properties)
+            .mainClass(mainClass)
+            .environments(environments)
+            .properties(properties)
+            .build();
+    }
+
+    /**
+     * Resolve the properties a command contributes to its {@link ApplicationContext}: the
+     * {@code --config} file, the command's forced overrides, and the {@code --port} option.
+     */
+    private static Map<String, Object> commandProperties(Class<?> cls, CommandLine commandLine) {
+        Map<String, Object> properties = new HashMap<>();
+
+        // if class have propertiesFromConfig, add configuration files
+        Map<String, Object> configProperties = getPropertiesFromMethod(cls, "propertiesFromConfig", commandLine.getCommandSpec().userObject());
+        if (configProperties != null) {
+            properties.putAll(configProperties);
+        }
+
+        // if class have propertiesOverrides, add force properties for this class
+        Map<String, Object> propertiesOverrides = getPropertiesFromMethod(cls, "propertiesOverrides", null);
+        if (propertiesOverrides != null && isPracticalCommand(commandLine)) {
+            properties.putAll(propertiesOverrides);
+        }
+
+        // custom server configuration
+        commandLine
+            .getParseResult()
+            .matchedArgs()
+            .stream()
+            .filter(argSpec -> ((Field) argSpec.userObject()).getName().equals("serverPort"))
+            .findFirst()
+            .ifPresent(argSpec -> properties.put("micronaut.server.port", argSpec.getValue()));
+
+        return properties;
+    }
+
+    /**
+     * Select the {@link ApplicationContext} flavour a command runs in.
+     */
+    private static ApplicationContextBuilder contextBuilder(Class<?> cls, Map<String, Object> properties) {
         // Pure migration commands run in a minimal context that never registers the other
         // Kestra @Context beans (repositories, server services, the migration startup trigger),
         // so nothing touches the database before the migration is applied explicitly.
-        ApplicationContextBuilder builder = (AbstractMigrationCommand.class.isAssignableFrom(cls)
-            ? new MigrationApplicationContextBuilder()
-            : ApplicationContext.builder())
-            .mainClass(mainClass)
-            .environments(environments);
-
-        if (AbstractCommand.class.isAssignableFrom(cls)) {
-            Map<String, Object> properties = new HashMap<>();
-
-            // if class have propertiesFromConfig, add configuration files
-            Map<String, Object> configProperties = getPropertiesFromMethod(cls, "propertiesFromConfig", commandLine.getCommandSpec().userObject());
-            if (configProperties != null) {
-                properties.putAll(configProperties);
-            }
-
-            // if class have propertiesOverrides, add force properties for this class
-            Map<String, Object> propertiesOverrides = getPropertiesFromMethod(cls, "propertiesOverrides", null);
-            if (propertiesOverrides != null && isPracticalCommand(commandLine)) {
-                properties.putAll(propertiesOverrides);
-            }
-
-            // custom server configuration
-            commandLine
-                .getParseResult()
-                .matchedArgs()
-                .stream()
-                .filter(argSpec -> ((Field) argSpec.userObject()).getName().equals("serverPort"))
-                .findFirst()
-                .ifPresent(argSpec -> properties.put("micronaut.server.port", argSpec.getValue()));
-
-            builder.properties(properties);
+        if (AbstractMigrationCommand.class.isAssignableFrom(cls)) {
+            return new MigrationApplicationContextBuilder();
         }
-        return builder.build();
+
+        // A worker runs in a context without any datasource at all.
+        if (isWorkerServerType(properties)) {
+            return new WorkerApplicationContextBuilder();
+        }
+
+        return ApplicationContext.builder();
+    }
+
+    /**
+     * The server type is read from the resolved command properties rather than from the command
+     * class, so any command forcing {@code kestra.server-type} to {@code WORKER} — including the EE
+     * ones — gets the worker context.
+     */
+    private static boolean isWorkerServerType(Map<String, Object> properties) {
+        return Optional.ofNullable(properties.get("kestra.server-type"))
+            .map(String::valueOf)
+            .filter(ServerType.WORKER.name()::equalsIgnoreCase)
+            .isPresent();
     }
 
     private static void continueOnParsingErrors(CommandLine cmd) {
@@ -254,6 +290,54 @@ public class Kestra implements Callable<Integer> {
         @Override
         protected ApplicationContext newApplicationContext() {
             return new MigrationApplicationContext(this);
+        }
+    }
+
+    /**
+     * Builder that produces a {@link WorkerApplicationContext}, see
+     * {@link MigrationApplicationContextBuilder} for the wiring it inherits.
+     */
+    private static final class WorkerApplicationContextBuilder extends DefaultApplicationContextBuilder {
+        @Override
+        protected ApplicationContext newApplicationContext() {
+            return new WorkerApplicationContext(this);
+        }
+    }
+
+    /**
+     * {@link ApplicationContext} for {@code server worker}: it drops Micronaut's JDBC datasource
+     * beans so a worker never opens a database connection.
+     *
+     * <p>
+     * A worker owns no repository and reaches the rest of the cluster over gRPC, but Micronaut turns
+     * every {@code datasources.<name>} entry into an eagerly-initialized, fail-fast Hikari pool
+     * regardless of {@code kestra.server-type}. Deployments commonly share one configuration across
+     * all server types, so a worker with no route to the database — the normal case for a remote
+     * worker — died at startup on a datasource it never uses.
+     *
+     * <p>
+     * Dropping the bean definitions is the only lever that works for every configuration source:
+     * the datasource names are user-chosen ({@code @EachProperty}), so the per-datasource
+     * {@code datasources.<name>.enabled=false} switch cannot be forced by the command, whose
+     * property overrides are resolved before any configuration is read.
+     */
+    private static final class WorkerApplicationContext extends DefaultApplicationContext {
+
+        /**
+         * Package holding {@code DatasourceConfiguration} and the {@code @Context} factory that
+         * turns it into a pool. Matching on the definition name keeps this free of class loading.
+         */
+        private static final String MICRONAUT_JDBC_PACKAGE = "io.micronaut.configuration.jdbc.";
+
+        WorkerApplicationContext(ApplicationContextConfiguration configuration) {
+            super(configuration);
+        }
+
+        @Override
+        protected List<BeanDefinitionReference> resolveBeanDefinitionReferences() {
+            return super.resolveBeanDefinitionReferences().stream()
+                .filter(reference -> !reference.getBeanDefinitionName().startsWith(MICRONAUT_JDBC_PACKAGE))
+                .toList();
         }
     }
 

--- a/cli/src/test/java/io/kestra/cli/commands/servers/WorkerServerContextTest.java
+++ b/cli/src/test/java/io/kestra/cli/commands/servers/WorkerServerContextTest.java
@@ -1,0 +1,42 @@
+package io.kestra.cli.commands.servers;
+
+import org.junit.jupiter.api.Test;
+
+import io.kestra.cli.Kestra;
+import io.kestra.core.migration.MigrationStartupRunner;
+
+import io.micronaut.context.ApplicationContext;
+import io.micronaut.context.env.Environment;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Verifies what {@code server worker} must <em>not</em> pull in, given that deployments commonly
+ * share one configuration across every server type: a worker owns no repository and talks to the
+ * rest of the cluster over gRPC, so a {@code datasources} or {@code kestra.repository.type} block
+ * inherited from that shared configuration must not make it touch the database.
+ *
+ * <p>
+ * Only the negative side is asserted here — the positive side (non-worker servers do migrate and do
+ * get a datasource) is covered by every test that boots a JDBC-backed server, all of which would
+ * fail on an empty schema.
+ */
+class WorkerServerContextTest {
+
+    private static ApplicationContext workerContext() {
+        ApplicationContext ctx = Kestra.applicationContext(
+            Kestra.class,
+            new String[] { Environment.CLI, Environment.TEST },
+            "server", "worker"
+        );
+        ctx.start();
+        return ctx;
+    }
+
+    @Test
+    void shouldNotRegisterTheMigrationStartupTriggerOnWorker() {
+        try (ApplicationContext ctx = workerContext()) {
+            assertThat(ctx.containsBean(MigrationStartupRunner.class)).isFalse();
+        }
+    }
+}

--- a/cli/src/test/java/io/kestra/cli/commands/servers/WorkerServerContextTest.java
+++ b/cli/src/test/java/io/kestra/cli/commands/servers/WorkerServerContextTest.java
@@ -1,6 +1,12 @@
 package io.kestra.cli.commands.servers;
 
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import javax.sql.DataSource;
+
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import io.kestra.cli.Kestra;
 import io.kestra.core.migration.MigrationStartupRunner;
@@ -9,6 +15,7 @@ import io.micronaut.context.ApplicationContext;
 import io.micronaut.context.env.Environment;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 
 /**
  * Verifies what {@code server worker} must <em>not</em> pull in, given that deployments commonly
@@ -23,11 +30,11 @@ import static org.assertj.core.api.Assertions.assertThat;
  */
 class WorkerServerContextTest {
 
-    private static ApplicationContext workerContext() {
+    private static ApplicationContext workerContext(String... args) {
         ApplicationContext ctx = Kestra.applicationContext(
             Kestra.class,
             new String[] { Environment.CLI, Environment.TEST },
-            "server", "worker"
+            args
         );
         ctx.start();
         return ctx;
@@ -35,8 +42,40 @@ class WorkerServerContextTest {
 
     @Test
     void shouldNotRegisterTheMigrationStartupTriggerOnWorker() {
-        try (ApplicationContext ctx = workerContext()) {
+        try (ApplicationContext ctx = workerContext("server", "worker")) {
             assertThat(ctx.containsBean(MigrationStartupRunner.class)).isFalse();
         }
+    }
+
+    @Test
+    void shouldNotRegisterADatasourceOnWorker() {
+        // Given the test configuration declares a `datasources.h2` block, as a shared configuration would.
+        try (ApplicationContext ctx = workerContext("server", "worker")) {
+            assertThat(ctx.getEnvironment().containsProperty("datasources.h2.url")).isTrue();
+
+            // Then no pool was built from it.
+            assertThat(ctx.containsBean(DataSource.class)).isFalse();
+        }
+    }
+
+    @Test
+    void shouldStartWorkerWhenTheConfiguredDatabaseIsUnreachable(@TempDir Path tempDir) throws Exception {
+        // Given a shared configuration pointing at a database the worker has no route to.
+        Path config = Files.writeString(tempDir.resolve("kestra.yml"), """
+            datasources:
+              postgres:
+                url: jdbc:postgresql://unreachable.invalid:5432/kestra
+                driverClassName: org.postgresql.Driver
+                username: kestra
+                password: k3str4
+            """);
+
+        // When/Then the worker starts instead of dying on `Failed to initialize pool`.
+        assertThatCode(() ->
+        {
+            try (ApplicationContext ctx = workerContext("server", "worker", "-c", config.toString())) {
+                assertThat(ctx.isRunning()).isTrue();
+            }
+        }).doesNotThrowAnyException();
     }
 }

--- a/core/src/main/java/io/kestra/core/migration/MigrationStartupRunner.java
+++ b/core/src/main/java/io/kestra/core/migration/MigrationStartupRunner.java
@@ -23,11 +23,17 @@ import lombok.extern.slf4j.Slf4j;
  * itself is an ordinary {@code @Singleton}. The {@code kestra migrate} CLI commands resolve the
  * runner in a minimal context that never registers this trigger, and invoke the runner directly —
  * which is why no "skip auto-run" flag is needed.
+ *
+ * <p>
+ * Workers are excluded: they own no repository (see {@code RepositoryBean}) and reach the rest of
+ * the cluster over gRPC, so they must never migrate the schema. Deployments commonly share a single
+ * configuration across every server type, which would otherwise make every worker a migrator.
  */
 @Slf4j
 @Context
 @Order(Ordered.HIGHEST_PRECEDENCE)
 @Requires(property = "kestra.repository.type")
+@Requires(property = "kestra.server-type", notEquals = "WORKER")
 public class MigrationStartupRunner {
 
     private final MigrationRunnerInterface migrationRunner;

--- a/core/src/main/java/io/kestra/core/validations/ServerCommandValidator.java
+++ b/core/src/main/java/io/kestra/core/validations/ServerCommandValidator.java
@@ -28,6 +28,15 @@ public class ServerCommandValidator {
         "kestra.storage.type", "https://kestra.io/docs/configuration-guide/setup#internal-storage-configuration"
     );
 
+    /**
+     * Database properties a worker inherits from a shared configuration but never uses: it owns no
+     * repository and reaches the rest of the cluster over gRPC.
+     */
+    private static final List<String> WORKER_IGNORED_PROPERTIES = List.of(
+        "datasources",
+        "kestra.repository.type"
+    );
+
     private final Environment environment;
 
     private final ServerType serverType;
@@ -49,6 +58,38 @@ public class ServerCommandValidator {
         if (results.stream().anyMatch(result -> !result.valid())) {
             throw new ServerCommandException("Incomplete server configuration - missing required properties");
         }
+
+        warnAboutIgnoredWorkerProperties();
+    }
+
+    private void warnAboutIgnoredWorkerProperties() {
+        final List<String> ignored = ignoredWorkerProperties(environment, serverType);
+
+        if (!ignored.isEmpty()) {
+            log.warn(
+                "A worker does not use any database, so the following configuration is ignored: {}. It can safely be removed from the worker configuration.",
+                String.join(", ", ignored)
+            );
+        }
+    }
+
+    /**
+     * Lists the database properties the given server type inherits but never uses. A worker ignores
+     * them entirely — it opens no database connection — so reporting them beats letting an operator
+     * believe their worker reads from a database it never contacts.
+     *
+     * @param environment the configuration environment to inspect
+     * @param serverType the server type the configuration is applied to
+     * @return the ignored property paths, empty for every server type but {@code WORKER}
+     */
+    static List<String> ignoredWorkerProperties(final Environment environment, final ServerType serverType) {
+        if (!ServerType.WORKER.equals(serverType)) {
+            return List.of();
+        }
+
+        return WORKER_IGNORED_PROPERTIES.stream()
+            .filter(environment::containsProperties)
+            .toList();
     }
 
     /**

--- a/core/src/test/java/io/kestra/core/validations/ServerCommandValidatorTest.java
+++ b/core/src/test/java/io/kestra/core/validations/ServerCommandValidatorTest.java
@@ -109,6 +109,37 @@ class ServerCommandValidatorTest {
     }
 
     @Test
+    void shouldReportDatabasePropertiesAsIgnoredForWorker() {
+        // Given a shared configuration carrying the database settings of the other server types.
+        try (
+            ApplicationContext context = ApplicationContext.builder()
+                .deduceEnvironment(false)
+                .properties(
+                    Map.of(
+                        "kestra.server-type", "worker",
+                        "kestra.storage.type", "local",
+                        "kestra.repository.type", "h2",
+                        "datasources.h2.url", "jdbc:h2:mem:test-worker-ignored;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE",
+                        "datasources.h2.username", "sa",
+                        "datasources.h2.password", "",
+                        "datasources.h2.driverClassName", "org.h2.Driver"
+                    )
+                )
+                .start()
+        ) {
+            Environment environment = context.getEnvironment();
+
+            assertThat(ServerCommandValidator.ignoredWorkerProperties(environment, ServerType.WORKER))
+                .as("A worker uses no database, so both the datasources block and the repository type are ignored")
+                .containsExactly("datasources", "kestra.repository.type");
+
+            assertThat(ServerCommandValidator.ignoredWorkerProperties(environment, ServerType.WEBSERVER))
+                .as("Every other server type does use them")
+                .isEmpty();
+        }
+    }
+
+    @Test
     void shouldOnlyRequireStorageForWorker() {
         Environment environment = mock(Environment.class);
         when(environment.containsProperty("kestra.storage.type")).thenReturn(true);


### PR DESCRIPTION
### ✨ Description

A v2 worker no longer touches the database, even when it inherits a `datasources` / `kestra.repository.type` block from a configuration shared across every server type.

Three fixes, one commit each:

**1. Never open a database connection from a worker** — the reported crash. Micronaut's `DatasourceFactory.dataSource` is `@Context` and `@EachBean(DatasourceConfiguration.class)`, so the mere presence of a `datasources:` block builds an eagerly-initialized, fail-fast Hikari pool regardless of `kestra.server-type`. A remote worker with no route to the database died at startup on `Failed to initialize pool` for a datasource it never uses.

`server worker` now runs in an `ApplicationContext` that drops the `io.micronaut.configuration.jdbc.*` bean definitions — the same mechanism already used for `kestra migrate` commands. The per-datasource `datasources.<name>.enabled=false` switch could not be used instead: names are user-chosen via `@EachProperty`, and a command resolves its property overrides before any configuration is read. The decision is keyed on the resolved `kestra.server-type` rather than on the command class, so any command forcing `WORKER` — including EE's — gets the worker context.

**2. Never run database migrations from a worker** — a second, silent bug of the same family found while investigating. `MigrationStartupRunner` is `@Context` at `HIGHEST_PRECEDENCE` and was gated on `kestra.repository.type` alone, so a worker that *could* reach the database acquired the migration lock and applied the schema at startup. Now excluded for `WORKER`.

This fix comes first in the branch on purpose: it is the bean that would otherwise fail with `NoSuchBeanException` once the datasource disappears.

**3. Warn about the database configuration a worker ignores** — since sharing one configuration across server types is the norm, the worker now says on startup that the inherited `datasources` and `kestra.repository.type` settings are ignored, instead of silently dropping them:

```
WARN i.k.c.v.ServerCommandValidator A worker does not use any database, so the following
configuration is ignored: datasources, kestra.repository.type. It can safely be removed
from the worker configuration.
```

This matches what the codebase already declared: `ServerCommandValidator` requires only `kestra.storage.type` for a `WORKER`, and repositories are excluded from workers by `RepositoryBean`. The datasource was simply the one thing outside that gate.

### 🔗 Related Issue

Closes https://github.com/kestra-io/kestra/issues/18001.

### 🛠️ Backend Checklist

- [x] Code compiles successfully and passes all checks
- [x] All unit and integration tests pass

### 📝 Additional Notes

**Reproducer is in the tests.** `WorkerServerContextTest` starts a worker against `jdbc:postgresql://unreachable.invalid:5432/kestra` and asserts it comes up, which is exactly the failure from the issue. Both fixes were sanity-checked by neutering them and confirming the new tests fail, then reverting.

**Verified locally:** `:cli:test` (67 tests) and `:core:test` (137 tests) green, including the existing migration-context tests. Full suite left to CI.

**Micronaut `notEquals` semantics.** `@Requires(property = "kestra.server-type", notEquals = "WORKER")` still registers the bean when the property is *absent*, so non-server CLI commands and any context without a server type keep auto-migrating. Confirmed empirically rather than assumed.

**EE needs no companion PR.** `io.kestra.ee.cli.Kestra` extends the OSS one, so `server worker` goes through the same code path; `EeMigrationRunner` is triggered by the OSS `MigrationStartupRunner` and is therefore covered too; and EE contributes no datasource beans of its own.

**`kestra.queue.type` deliberately left out of the warning in (3).** Workers demonstrably use no repository and no datasource, but `WorkerJobFetcher` does take a `@Nullable @Named(WORKER_LOCAL_CLUSTER_EVENTS) BroadcastQueueInterface`, so I did not want to claim queue configuration is ignored in every mode without establishing it. Easy follow-up if that turns out to hold.
