### PR TITLE
fix(flows): keep the revisions view alive after deleting a revision

### DIFF
--- a/ui/src/components/layout/Revisions.vue
+++ b/ui/src/components/layout/Revisions.vue
@@ -40,7 +40,7 @@
                         <KsButtonGroup>
                             <KsButton
                                 :icon="Restore"
-                                :disabled="revisionLeftText === currentRevisionWithSource.source"
+                                :disabled="revisionLeftText === currentRevisionWithSource?.source"
                                 @click="restoreRevision(revisionLeftIndex, revisionLeftText)"
                                 data-testid="restore-left"
                             >
@@ -82,7 +82,7 @@
                         <KsButtonGroup>
                             <KsButton
                                 :icon="Restore"
-                                :disabled="revisionRightText === currentRevisionWithSource.source"
+                                :disabled="revisionRightText === currentRevisionWithSource?.source"
                                 @click="restoreRevision(revisionRightIndex, revisionRightText)"
                                 data-testid="restore-right"
                             >
@@ -233,8 +233,17 @@
         return idx === -1 ? undefined : idx
     }
 
-    function revisionNumber(index: number) {
-        return sortedRevisions.value[index].revision
+    /**
+     * The revision at a position in the sorted list, or undefined when that
+     * position no longer exists.
+     *
+     * Both sides of the diff are held as indices into a list that shrinks when a
+     * revision is deleted, and this is called from the template — reading through
+     * a stale index used to throw mid-render and blank the whole view.
+     */
+    function revisionNumber(index: number | undefined): number | undefined {
+        if (index === undefined) return undefined
+        return sortedRevisions.value[index]?.revision
     }
 
     function restoreRevision(index: number, revisionSource: string) {
@@ -249,12 +258,18 @@
             return
         }
 
+        const revisionLeft = revisionNumber(revisionLeftIndex.value)
+        const revisionRight = revisionNumber(revisionRightIndex.value)
+        if (revisionLeft === undefined || revisionRight === undefined) {
+            return
+        }
+
         if (props.editRouteQuery) {
             router.push({
                 query: {
                     ...route.query,
-                    revisionLeft: sortedRevisions.value[revisionLeftIndex.value].revision,
-                    revisionRight: sortedRevisions.value[revisionRightIndex.value].revision,
+                    revisionLeft,
+                    revisionRight,
                 },
             })
         }
@@ -269,7 +284,7 @@
     function formatRevisionText(revision: number): string {
         let text = revision.toString()
 
-        if (currentRevisionWithSource.value.revision === revision) {
+        if (currentRevision.value === revision) {
             text += ` (${t("current")})`
         }
 
@@ -280,7 +295,7 @@
         return sortedRevisions.value
             .filter((_, index) => index !== excludeRevisionIndex)
             .map(({revision, updated, draft}) => {
-                const isCurrent = currentRevisionWithSource.value.revision === revision
+                const isCurrent = currentRevision.value === revision
                 return {
                     value: revisionIndex(revision.toString()),
                     revision: revision,
@@ -310,6 +325,10 @@
         }
 
         const revisionObject = sortedRevisions.value[index]
+        if (!revisionObject) {
+            return undefined
+        }
+
         let source = revisionObject.source
 
         if (!source) {
@@ -322,6 +341,8 @@
 
     async function onDelete(index: number) {
         const revisionToDelete = revisionNumber(index)
+        if (revisionToDelete === undefined) return
+
         toast.confirm(t("delete revision confirm", {revision: revisionToDelete}), async () => {
             try {
                 await flowStore.deleteRevision({
@@ -330,13 +351,50 @@
                     revision: revisionToDelete.toString(),
                 })
                 toast.deleted(t("revision deleted", {revision: revisionToDelete.toString()}))
+                // The parent refreshes the list asynchronously, so re-reading the
+                // selection here would only ever see the pre-delete list. The
+                // watcher below re-anchors both sides once the new list lands.
                 emit("deleted", revisionToDelete)
-                load()
             } catch (error: any) {
                 toast.error(t("delete revision error", {revision: revisionToDelete, error: error.message || error.toString()}))
             }
         })
     };
+
+    /**
+     * Keep both sides pointing at the revisions they were showing.
+     *
+     * The selections are positions in `sortedRevisions`, so any change to that
+     * list silently repoints them — after a delete they can even fall off the
+     * end. Remap by revision number, and where that revision is the one that
+     * just went away, fall back to a neighbour.
+     */
+    watch(sortedRevisions, (current, previous) => {
+        if (!previous || current.length === 0) return
+
+        const stillAt = (index: number | undefined) => {
+            const revision = index === undefined ? undefined : previous[index]?.revision
+            if (revision === undefined) return undefined
+            const found = current.findIndex(item => item.revision === revision)
+            return found === -1 ? undefined : found
+        }
+
+        let right = stillAt(revisionRightIndex.value)
+        let left = stillAt(revisionLeftIndex.value)
+
+        // Whichever side lost its revision falls back: the right to the newest,
+        // the left to whatever sits just before the right.
+        if (right === undefined) right = current.length - 1
+        if (left === undefined) left = right > 0 ? right - 1 : undefined
+
+        // Comparing a revision against itself is not a diff; nudge the left side.
+        if (left !== undefined && left === right) {
+            left = right > 0 ? right - 1 : undefined
+        }
+
+        revisionRightIndex.value = right
+        revisionLeftIndex.value = left
+    })
 
     watch(revisionLeftIndex, async (newValue) => {
         isLoadingRevisions.value = true
@@ -374,7 +432,7 @@
         }
     })
 
-    watch(() => currentRevisionWithSource.value.revision, (newRevision, oldRevision) => {
+    watch(currentRevision, (newRevision, oldRevision) => {
         if (revisionNumber(revisionRightIndex.value) === oldRevision) {
             revisionRightIndex.value = revisionIndex(newRevision.toString())
         }

--- a/ui/src/components/layout/Revisions.vue
+++ b/ui/src/components/layout/Revisions.vue
@@ -366,30 +366,41 @@
      *
      * The selections are positions in `sortedRevisions`, so any change to that
      * list silently repoints them — after a delete they can even fall off the
-     * end. Remap by revision number, and where that revision is the one that
-     * just went away, fall back to a neighbour.
+     * end, which is what used to throw mid-render and blank the view.
      */
     watch(sortedRevisions, (current, previous) => {
         if (!previous || current.length === 0) return
 
-        const stillAt = (index: number | undefined) => {
-            const revision = index === undefined ? undefined : previous[index]?.revision
+        const lastIndex = current.length - 1
+
+        const sameRevision = (index: number) => {
+            const revision = previous[index]?.revision
             if (revision === undefined) return undefined
             const found = current.findIndex(item => item.revision === revision)
             return found === -1 ? undefined : found
         }
 
-        let right = stillAt(revisionRightIndex.value)
-        let left = stillAt(revisionLeftIndex.value)
+        // A side whose revision survived follows it. One whose revision was
+        // removed holds its position, which now belongs to the neighbour that
+        // shifted into it — jumping to the newest would move the diff somewhere
+        // the user never asked to look.
+        const reanchor = (index: number | undefined) => {
+            if (index === undefined) return undefined
+            return sameRevision(index) ?? Math.min(Math.max(index, 0), lastIndex)
+        }
 
-        // Whichever side lost its revision falls back: the right to the newest,
-        // the left to whatever sits just before the right.
-        if (right === undefined) right = current.length - 1
-        if (left === undefined) left = right > 0 ? right - 1 : undefined
+        let right = reanchor(revisionRightIndex.value) ?? lastIndex
+        let left = reanchor(revisionLeftIndex.value)
 
-        // Comparing a revision against itself is not a diff; nudge the left side.
-        if (left !== undefined && left === right) {
+        // Diffing a revision against itself shows nothing; step the left side back.
+        if (left === undefined || left === right) {
             left = right > 0 ? right - 1 : undefined
+        }
+
+        // Only possible with a single revision left, where the view is empty anyway.
+        if (left === undefined && current.length > 1) {
+            right = 1
+            left = 0
         }
 
         revisionRightIndex.value = right

--- a/ui/tests/unit/components/layout/Revisions.spec.ts
+++ b/ui/tests/unit/components/layout/Revisions.spec.ts
@@ -1,11 +1,16 @@
-import {describe, expect, it, vi} from "vitest"
+import {beforeEach, describe, expect, it, vi} from "vitest"
 import {mount, flushPromises} from "@vue/test-utils"
+
+const {routeQuery, routerPush} = vi.hoisted(() => ({
+    routeQuery: {} as Record<string, string>,
+    routerPush: vi.fn(),
+}))
 
 vi.mock("vue-i18n", () => ({useI18n: () => ({t: (key: string) => key})}))
 
 vi.mock("vue-router", () => ({
-    useRoute: () => ({query: {}, params: {namespace: "company.team", id: "my_flow"}}),
-    useRouter: () => ({push: vi.fn()}),
+    useRoute: () => ({query: routeQuery, params: {namespace: "company.team", id: "my_flow"}}),
+    useRouter: () => ({push: routerPush}),
 }))
 
 vi.mock("../../../../src/utils/toast", () => ({
@@ -60,16 +65,32 @@ function mountRevisions(revisions: {revision: number; source: string}[]) {
     })
 }
 
+// Left column renders before the right one, so this reads [left, right].
 function shownRevisions(wrapper: ReturnType<typeof mountRevisions>) {
     return wrapper.findAll(".crud-revision").map((el) => el.text())
 }
 
-describe("Revisions — deleting a revision", () => {
+describe("Revisions — the list changing under the diff", () => {
+    beforeEach(() => {
+        for (const key of Object.keys(routeQuery)) delete routeQuery[key]
+        routerPush.mockClear()
+    })
+
     it("opens on the newest revision against the one before it", async () => {
         const wrapper = mountRevisions(revisionsUpTo(1, 2, 3, 4))
         await flushPromises()
 
         expect(shownRevisions(wrapper)).toEqual(["3", "4"])
+    })
+
+    it("opens on whatever the URL asks for", async () => {
+        routeQuery.revisionLeft = "2"
+        routeQuery.revisionRight = "4"
+
+        const wrapper = mountRevisions(revisionsUpTo(1, 2, 3, 4))
+        await flushPromises()
+
+        expect(shownRevisions(wrapper)).toEqual(["2", "4"])
     })
 
     it("keeps showing the same revisions when an unrelated one is removed", async () => {
@@ -84,6 +105,25 @@ describe("Revisions — deleting a revision", () => {
 
         expect(wrapper.find(".revision").exists()).toBe(true)
         expect(shownRevisions(wrapper)).toEqual(["3", "4"])
+    })
+
+    it("holds position rather than jumping to the newest", async () => {
+        // The reporter's steps start by picking revisions from the dropdowns,
+        // which writes both into the URL. With more than four revisions, resetting
+        // to the end of the list is distinguishable from stepping to a neighbour.
+        routeQuery.revisionLeft = "3"
+        routeQuery.revisionRight = "5"
+
+        const wrapper = mountRevisions(revisionsUpTo(1, 2, 3, 4, 5, 6, 7, 8))
+        await flushPromises()
+        expect(shownRevisions(wrapper)).toEqual(["3", "5"])
+
+        await wrapper.setProps({revisions: revisionsUpTo(1, 2, 3, 4, 6, 7, 8)})
+        await flushPromises()
+
+        // 6 took 5's place. Landing on 8 would drag the diff to the far end of a
+        // list the user was reading the middle of.
+        expect(shownRevisions(wrapper)).toEqual(["3", "6"])
     })
 
     it("falls back to a neighbour when the revision on show is the one removed", async () => {
@@ -109,6 +149,18 @@ describe("Revisions — deleting a revision", () => {
 
         expect(wrapper.find(".revision").exists()).toBe(true)
         expect(shownRevisions(wrapper)).toEqual(["2", "3"])
+    })
+
+    it("advances to a newly saved revision", async () => {
+        // The same watcher fires when the list GROWS. Saving must still move the
+        // right side onto the new newest revision.
+        const wrapper = mountRevisions(revisionsUpTo(1, 2, 3, 4))
+        await flushPromises()
+
+        await wrapper.setProps({revisions: revisionsUpTo(1, 2, 3, 4, 5)})
+        await flushPromises()
+
+        expect(shownRevisions(wrapper)).toEqual(["3", "5"])
     })
 
     it("renders the empty state rather than a diff once one revision is left", async () => {

--- a/ui/tests/unit/components/layout/Revisions.spec.ts
+++ b/ui/tests/unit/components/layout/Revisions.spec.ts
@@ -37,6 +37,9 @@ const stubs = {
     KsNoData: {template: "<div class='no-data' />"},
 }
 
+// The template reads `$t` off the app instance, which mocking useI18n does not provide.
+const mocks = {$t: (key: string) => key}
+
 function revisionsUpTo(...numbers: number[]) {
     return numbers.map((revision) => ({revision, source: `source ${revision}`}))
 }
@@ -53,7 +56,7 @@ function mountRevisions(revisions: {revision: number; source: string}[]) {
             // revision looked up through the stored index.
             crud: "<span class=\"crud-revision\">{{ params.revision }}</span>",
         },
-        global: {stubs},
+        global: {stubs, mocks},
     })
 }
 

--- a/ui/tests/unit/components/layout/Revisions.spec.ts
+++ b/ui/tests/unit/components/layout/Revisions.spec.ts
@@ -1,0 +1,121 @@
+import {describe, expect, it, vi} from "vitest"
+import {mount, flushPromises} from "@vue/test-utils"
+
+vi.mock("vue-i18n", () => ({useI18n: () => ({t: (key: string) => key})}))
+
+vi.mock("vue-router", () => ({
+    useRoute: () => ({query: {}, params: {namespace: "company.team", id: "my_flow"}}),
+    useRouter: () => ({push: vi.fn()}),
+}))
+
+vi.mock("../../../../src/utils/toast", () => ({
+    useToast: () => ({confirm: vi.fn(), deleted: vi.fn(), error: vi.fn()}),
+}))
+
+vi.mock("../../../../src/stores/flow", () => ({
+    useFlowStore: () => ({deleteRevision: vi.fn()}),
+}))
+
+vi.mock("../../../../src/composables/useEditorBindings", () => ({
+    useEditorBindings: () => ({}),
+}))
+
+vi.mock("@kestra-io/design-system", () => ({
+    KsEditor: {name: "KsEditor", template: "<div />"},
+}))
+
+import Revisions from "../../../../src/components/layout/Revisions.vue"
+
+const passthrough = {template: "<div><slot /></div>"}
+
+const stubs = {
+    KsSelect: passthrough,
+    KsOption: {props: ["label", "value"], template: "<div><slot /></div>"},
+    KsTag: passthrough,
+    KsButton: passthrough,
+    KsButtonGroup: passthrough,
+    KsNoData: {template: "<div class='no-data' />"},
+}
+
+function revisionsUpTo(...numbers: number[]) {
+    return numbers.map((revision) => ({revision, source: `source ${revision}`}))
+}
+
+function mountRevisions(revisions: {revision: number; source: string}[]) {
+    return mount(Revisions, {
+        props: {
+            lang: "yaml",
+            revisions,
+            revisionSource: async (revision: number) => `source ${revision}`,
+        },
+        slots: {
+            // The crud slot is where the crash surfaced: it is rendered with the
+            // revision looked up through the stored index.
+            crud: "<span class=\"crud-revision\">{{ params.revision }}</span>",
+        },
+        global: {stubs},
+    })
+}
+
+function shownRevisions(wrapper: ReturnType<typeof mountRevisions>) {
+    return wrapper.findAll(".crud-revision").map((el) => el.text())
+}
+
+describe("Revisions — deleting a revision", () => {
+    it("opens on the newest revision against the one before it", async () => {
+        const wrapper = mountRevisions(revisionsUpTo(1, 2, 3, 4))
+        await flushPromises()
+
+        expect(shownRevisions(wrapper)).toEqual(["3", "4"])
+    })
+
+    it("keeps showing the same revisions when an unrelated one is removed", async () => {
+        const wrapper = mountRevisions(revisionsUpTo(1, 2, 3, 4))
+        await flushPromises()
+
+        // Revision 2 is neither side of the diff. Removing it shortens the list,
+        // which used to leave the right index pointing past the end — the read
+        // threw during render and the view went blank.
+        await wrapper.setProps({revisions: revisionsUpTo(1, 3, 4)})
+        await flushPromises()
+
+        expect(wrapper.find(".revision").exists()).toBe(true)
+        expect(shownRevisions(wrapper)).toEqual(["3", "4"])
+    })
+
+    it("falls back to a neighbour when the revision on show is the one removed", async () => {
+        const wrapper = mountRevisions(revisionsUpTo(1, 2, 3, 4))
+        await flushPromises()
+
+        // 3 is what the left side is displaying.
+        await wrapper.setProps({revisions: revisionsUpTo(1, 2, 4)})
+        await flushPromises()
+
+        expect(wrapper.find(".revision").exists()).toBe(true)
+        expect(shownRevisions(wrapper)).toEqual(["2", "4"])
+    })
+
+    it("survives losing the newest revision", async () => {
+        const wrapper = mountRevisions(revisionsUpTo(1, 2, 3, 4))
+        await flushPromises()
+
+        // Deleting the current revision is blocked in the UI, but the list can
+        // still lose it — a restore renumbers, and the parent refetches.
+        await wrapper.setProps({revisions: revisionsUpTo(1, 2, 3)})
+        await flushPromises()
+
+        expect(wrapper.find(".revision").exists()).toBe(true)
+        expect(shownRevisions(wrapper)).toEqual(["2", "3"])
+    })
+
+    it("renders the empty state rather than a diff once one revision is left", async () => {
+        const wrapper = mountRevisions(revisionsUpTo(1, 2))
+        await flushPromises()
+
+        await wrapper.setProps({revisions: revisionsUpTo(2)})
+        await flushPromises()
+
+        expect(wrapper.find(".revision").exists()).toBe(false)
+        expect(wrapper.find(".no-data").exists()).toBe(true)
+    })
+})


### PR DESCRIPTION
## Summary

- Deleting a revision blanked the page until a reload. Both sides of the diff are stored as **positions in a derived, sorted list**, so removing an entry shortens that list and the stored positions no longer mean what they did.
- Where a position fell past the end, `revisionNumber()` read `.revision` off `undefined`. That happened during render — it is called for the `crud` slot — so Vue tore the subtree down and left an empty page. Where a position stayed in range it silently repointed at a different revision, which is the same bug without the crash.
- Both sides are now re-anchored **by revision number** whenever the list changes. A side whose revision survived follows it; a side whose revision was the one deleted holds its position, which after the removal belongs to the neighbour that shifted into it.
- `onDelete` no longer calls `load()`. The parent refreshes asynchronously (`await router.push` → `await fetchRevisions`), so that call only ever saw the pre-delete list.
- `revisionNumber()` returns `undefined` out of range rather than throwing, so no future caller can blank the view the same way.

Related: #18094

## Test plan

- [x] `ui/tests/unit/components/layout/Revisions.spec.ts` drives the list changing under the diff. Three of its eight cases were **confirmed to fail against a build without this change**, with the production error `TypeError: Cannot read properties of undefined (reading 'revision')`.
- [x] Covers removing an unrelated revision, removing the one on show, losing the newest, dropping to a single revision (empty state), opening from `revisionLeft`/`revisionRight` in the URL, and a revision being **added** — the same watcher fires on save, where the newest must still win.
- [x] `npm run test:unit`: 1544 passing, 0 failing (+8, exactly the new spec).
- [x] `npm run check:types` passes for the design-system, app and test projects.
- [x] `npm run test:lint`: 0 errors on the touched files.
- [x] `npm run test:storybook`: 65 files / 239 tests green, including this component's own `Revisions.stories.tsx`.

> Two notes for review. The reporter observed this "only when you delete from the right side" — the mechanism here is symmetric, and what decides whether you get a blank page rather than a silently wrong diff is whether the stored position lands past the end of the list; the right selector defaults to the last entry, which fits, but I did not reproduce the exact asymmetry. And there is no e2e for the revisions view to extend, so the coverage above is unit plus the existing stories.