### PR TITLE
build(script): retry the kotlp download and authenticate when possible

### DIFF
--- a/script/build.gradle
+++ b/script/build.gradle
@@ -12,23 +12,42 @@ tasks.register('downloadKotlp') {
     onlyIf { !(kotlpBinary.exists() && kotlpVersionMarker.exists() && kotlpVersionMarker.text.trim() == version) }
     doLast {
         def url = "https://github.com/kestra-io/kotlp/releases/download/v${version}/kotlp"
+        // GitHub throttles anonymous release-asset downloads by closing the connection without a
+        // response ("Unexpected end of file from server"). CI runners behind a shared egress IP hit
+        // it regularly, so authenticate when a token is available and always retry a few times.
+        def token = System.getenv("GITHUB_TOKEN") ?: System.getenv("GH_TOKEN")
+        def attempts = 5
         kotlpBinary.parentFile.mkdirs()
-        try {
-            def connection = URI.create(url).toURL().openConnection()
-            connection.connectTimeout = 30_000
-            connection.readTimeout = 300_000
-            if (connection.responseCode != 200) {
-                throw new GradleException("Cannot download the kotlp binary from '%s': HTTP %d.".formatted(url, connection.responseCode))
+        IOException lastFailure = null
+        for (int attempt = 1; attempt <= attempts; attempt++) {
+            try {
+                def connection = URI.create(url).toURL().openConnection()
+                connection.connectTimeout = 30_000
+                connection.readTimeout = 300_000
+                if (token) {
+                    connection.setRequestProperty("Authorization", "Bearer %s".formatted(token))
+                }
+                if (connection.responseCode != 200) {
+                    throw new GradleException("Cannot download the kotlp binary from '%s': HTTP %d.".formatted(url, connection.responseCode))
+                }
+                def expectedLength = connection.contentLengthLong
+                def downloaded = connection.inputStream.withStream { input ->
+                    kotlpBinary.withOutputStream { output -> input.transferTo(output) }
+                }
+                if (0 < expectedLength && downloaded != expectedLength) {
+                    throw new IOException("truncated download, got %d of %d bytes".formatted(downloaded, expectedLength))
+                }
+                kotlpVersionMarker.text = version
+                return
+            } catch (IOException e) {
+                lastFailure = e
+                kotlpBinary.delete()
+                kotlpVersionMarker.delete()
+                logger.warn("Cannot download the kotlp binary from '{}' (attempt {}/{}): {}. Retrying.", url, attempt, attempts, e.getMessage())
+                sleep(2_000L * attempt)
             }
-            connection.inputStream.withStream { input ->
-                kotlpBinary.withOutputStream { output -> input.transferTo(output) }
-            }
-            kotlpVersionMarker.text = version
-        } catch (IOException e) {
-            kotlpBinary.delete()
-            kotlpVersionMarker.delete()
-            throw new GradleException("Cannot download the kotlp binary from '%s': %s.".formatted(url, e.getMessage()), e)
         }
+        throw new GradleException("Cannot download the kotlp binary from '%s' after %d attempts: %s.".formatted(url, attempts, lastFailure.getMessage()), lastFailure)
     }
 }
 processResources.dependsOn downloadKotlp


### PR DESCRIPTION
## What

`:script:downloadKotlp` now retries 5× with a linear backoff, sends `Authorization: Bearer $GITHUB_TOKEN` / `$GH_TOKEN` when one is set, and verifies the downloaded size against `Content-Length`.

## Why

`kestra-ee` CI has been failing on:

```
Execution failed for task ':script:downloadKotlp' (registered in build file '../kestra/script/build.gradle').
> Cannot download the kotlp binary from 'https://github.com/kestra-io/kotlp/releases/download/v0.1.0/kotlp': Unexpected end of file from server.
```

GitHub throttles **anonymous** release-asset downloads (the redirect target `release-assets.githubusercontent.com`) by closing the TCP connection without sending any HTTP response.

Measured from a laptop:

| Client | Result |
|---|---|
| `curl -L`, anonymous | ~1 in 6 dies (`curl: (56) Connection died, tried 5 times before giving up`) |
| Java `HttpURLConnection`, 10 cold JVMs | **3 failed** with `SocketException: Unexpected end of file from server` |
| same, after ~40 requests from one IP | failure rate above 40% |
| authenticated (`Authorization: Bearer`) ×6 | 6/6 OK |

`curl` hides the problem — it silently retries a connection that dies before any data arrives. Java's `HttpURLConnection` does not retry a fresh connection, so the EOF propagated straight out of the task and a single blip failed the whole build.

The throttle is per egress IP, which explains why this looked EE-only: EE's self-hosted runner pool NATs out through one shared IP and every job re-downloads the asset, whereas OSS runs on GitHub-hosted runners with a fresh IP per job. It is not deterministic per environment — in kestra-ee run [31617939821](https://github.com/kestra-io/kestra-ee/actions/runs/31617939821), `Backend - Tests / Check` downloaded the binary successfully at 16:35:08 while `Build Artifacts / Build Jar` failed on the same URL 52s later, on the same commit and the same runner pool.

## Testing

- `./gradlew :script:downloadKotlp` with a token present: green.
- Same without a token: hit the throttle live and logged `Cannot download the kotlp binary ... (attempt 1/5): Unexpected end of file from server. Retrying.`, then succeeded on attempt 2 — the retry demonstrably rides through the real failure.

## Scope

This is the **immediate unblock** for the currently-broken builds. The structural fix is kestra-io/kotlp#4, which publishes the binary to Maven Central as `io.kestra:kotlp` so the build resolves it as an ordinary dependency (cached, checksummed, no anonymous HTTP download at all). Once that ships and the follow-up PR swaps `:script` over, `downloadKotlp` — and this retry loop with it — is deleted.