### PR TITLE
fix(core): do not remember the page number when navigating back to a list page

### DIFF
--- a/ui/src/composables/useRestoreUrl.ts
+++ b/ui/src/composables/useRestoreUrl.ts
@@ -13,6 +13,9 @@ interface UseRestoreUrlOptions {
     restoreUrl?: boolean;
 }
 
+// Pagination is navigation state, not a filter: coming back to a list page must land on the first page (https://github.com/kestra-io/kestra-ee/issues/7241).
+const NON_RESTORABLE_KEYS = ["page"]
+
 function getLocalStorageName(route: RouteLocation): string {
     const tenant = route.params.tenant
     return `${route.name?.toString().replace("/", "_")}${route.params.tab ? "_" + route.params.tab : ""}${tenant ? "_" + tenant : ""}_restore_url`
@@ -33,6 +36,8 @@ export function getRestoredQuery(route: RouteLocation) {
     let change = false
 
     for (const key in localStorageValue) {
+        // skip values persisted before this key became non-restorable
+        if (NON_RESTORABLE_KEYS.includes(key)) continue
         const value = localStorageValue[key]
         if (query[key] || !value) continue
         // empty array breaks the application
@@ -61,10 +66,14 @@ export default function useRestoreUrl(options: UseRestoreUrlOptions = {}) {
 
     const saveRestoreUrl = () => {
         if (!restoreUrl || route.query.noRestore) return
-        if (Object.keys(route.query).length === 0) {
+        const query = {...route.query}
+        for (const key of NON_RESTORABLE_KEYS) {
+            delete query[key]
+        }
+        if (Object.keys(query).length === 0) {
             window.sessionStorage.removeItem(localStorageName.value)
         } else {
-            window.sessionStorage.setItem(localStorageName.value, JSON.stringify(route.query))
+            window.sessionStorage.setItem(localStorageName.value, JSON.stringify(query))
         }
     }
 

--- a/ui/tests/unit/composables/useRestoreUrl.spec.ts
+++ b/ui/tests/unit/composables/useRestoreUrl.spec.ts
@@ -1,0 +1,70 @@
+import {afterEach, describe, expect, test, vi} from "vitest"
+import {defineComponent} from "vue"
+import {mount} from "@vue/test-utils"
+import type {RouteLocation} from "vue-router"
+import useRestoreUrl, {getRestoredQuery} from "../../../src/composables/useRestoreUrl"
+
+const mocks = vi.hoisted(() => ({
+    route: {
+        name: "executions/list",
+        params: {} as Record<string, string>,
+        query: {} as Record<string, string>,
+        fullPath: "/executions",
+    },
+    replace: vi.fn(),
+}))
+
+vi.mock("vue-router", () => ({
+    useRoute: () => mocks.route,
+    useRouter: () => ({replace: mocks.replace}),
+}))
+
+const STORAGE_KEY = "executions_list_restore_url"
+
+function mountComposable() {
+    let api!: ReturnType<typeof useRestoreUrl>
+    const Comp = defineComponent({
+        setup() {
+            api = useRestoreUrl()
+            return () => null
+        },
+    })
+    mount(Comp)
+    return api
+}
+
+describe("useRestoreUrl pagination exclusion", () => {
+    afterEach(() => {
+        window.sessionStorage.clear()
+        mocks.route.query = {}
+        mocks.replace.mockClear()
+    })
+
+    test("saveRestoreUrl does not persist the page number", () => {
+        mocks.route.query = {namespace: "company", page: "5"}
+
+        const {saveRestoreUrl} = mountComposable()
+        saveRestoreUrl()
+
+        expect(JSON.parse(window.sessionStorage.getItem(STORAGE_KEY)!)).toEqual({namespace: "company"})
+    })
+
+    test("saveRestoreUrl clears the saved state when only the page number remains", () => {
+        window.sessionStorage.setItem(STORAGE_KEY, JSON.stringify({namespace: "company"}))
+        mocks.route.query = {page: "5"}
+
+        const {saveRestoreUrl} = mountComposable()
+        saveRestoreUrl()
+
+        expect(window.sessionStorage.getItem(STORAGE_KEY)).toBeNull()
+    })
+
+    test("getRestoredQuery ignores a page number persisted before the key became non-restorable", () => {
+        window.sessionStorage.setItem(STORAGE_KEY, JSON.stringify({namespace: "company", page: "5"}))
+
+        const {query, change} = getRestoredQuery(mocks.route as unknown as RouteLocation)
+
+        expect(change).toBe(true)
+        expect(query).toEqual({namespace: "company"})
+    })
+})


### PR DESCRIPTION
Closes https://github.com/kestra-io/kestra-ee/issues/7241.

## What

Selecting a page in a paginated list (for example Executions), navigating to another part of the UI and coming back restored the previously selected page instead of starting from the first page. The page number is now excluded from the URL state persisted by useRestoreUrl, both when saving and when restoring values persisted earlier in the same session. All list pages going through useRestoreUrl (Executions, Flows, Logs, KV, Secrets, Triggers, Namespaces, Plugins, and the EE pages importing the same composable) now come back on page 1 while applied filters keep being restored.

## Why

Customer report (Pylon #1529, Aimtec): pagination is navigation state, not a filter, so it should not survive navigating away. https://github.com/kestra-io/kestra/pull/15206 only covered the ForEachItem Gantt ExecutionID filter case, the general page persistence remained.

Same fix for 1.3 (the composable implementations have diverged, so this is a re-implementation rather than a cherry-pick): https://github.com/kestra-io/kestra/pull/18128.

Covered by a new unit spec for the save and restore paths, and verified with npm run check:types.