### PR TITLE
build(script): resolve kotlp as a Maven dependency instead of downloading it

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,7 +57,6 @@ docker/app/secrets/*.yml
 
 ### Build
 core/src/main/resources/gradle.properties
-script/src/main/resources/kotlp/
 .plugins.override
 
 # H2 Database

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,4 @@
 version=2.0.0-SNAPSHOT
-kotlpVersion=0.1.0
 
 org.gradle.jvmargs=-Xmx2g -XX:MaxMetaspaceSize=512m -XX:+HeapDumpOnOutOfMemoryError
 org.gradle.parallel=true

--- a/platform/build.gradle
+++ b/platform/build.gradle
@@ -119,6 +119,8 @@ dependencies {
         api 'org.postgresql:postgresql:42.7.13'
         api 'com.github.docker-java:docker-java:3.7.1'
         api 'com.github.docker-java:docker-java-transport-httpclient5:3.7.1'
+        // Carries no classes: just the kotlp APE, read off the classpath as /kotlp/kotlp.
+        api 'io.kestra:kotlp:0.1.0'
         api "org.opensearch.client:opensearch-java:$opensearchVersion"
         api "org.opensearch.client:opensearch-rest-client:$opensearchRestVersion"
         api "org.opensearch.client:opensearch-rest-high-level-client:$opensearchRestVersion" // used by the elasticsearch plugin

--- a/platform/build.gradle
+++ b/platform/build.gradle
@@ -119,8 +119,12 @@ dependencies {
         api 'org.postgresql:postgresql:42.7.13'
         api 'com.github.docker-java:docker-java:3.7.1'
         api 'com.github.docker-java:docker-java-transport-httpclient5:3.7.1'
-        // Carries no classes: just the kotlp APE, read off the classpath as /kotlp/kotlp.
-        api 'io.kestra:kotlp:0.1.0'
+        // Carries no classes: just the kotlp APE, read off the classpath as /kotlp/kotlp. Pinned
+        // strictly ('!!') so this version always wins: any transitive request is downgraded to it
+        // rather than winning by Gradle's highest-version conflict resolution. The binary's OTLP
+        // envelope key has to match what TaskLogLineMatcher parses, and a mismatch emits valid
+        // output that Kestra silently ingests none of — so the version ships only when bumped here.
+        api 'io.kestra:kotlp:0.1.2!!'
         api "org.opensearch.client:opensearch-java:$opensearchVersion"
         api "org.opensearch.client:opensearch-rest-client:$opensearchRestVersion"
         api "org.opensearch.client:opensearch-rest-high-level-client:$opensearchRestVersion" // used by the elasticsearch plugin

--- a/script/build.gradle
+++ b/script/build.gradle
@@ -1,45 +1,14 @@
-// The kotlp binary is a mandatory embedded resource: it is a single Actually Portable Executable
-// covering Linux/macOS/BSD on amd64 and arm64, pinned by the 'kotlpVersion' Gradle property.
-def kotlpBinary = file('src/main/resources/kotlp/kotlp')
-def kotlpVersionMarker = file('src/main/resources/kotlp/kotlp.version')
-
-tasks.register('downloadKotlp') {
-    group = "build"
-    description = "Downloads the kotlp release binary into src/main/resources so it is embedded in the jar."
-    def version = kotlpVersion
-    inputs.property('kotlpVersion', version)
-    outputs.files(kotlpBinary, kotlpVersionMarker)
-    onlyIf { !(kotlpBinary.exists() && kotlpVersionMarker.exists() && kotlpVersionMarker.text.trim() == version) }
-    doLast {
-        def url = "https://github.com/kestra-io/kotlp/releases/download/v${version}/kotlp"
-        kotlpBinary.parentFile.mkdirs()
-        try {
-            def connection = URI.create(url).toURL().openConnection()
-            connection.connectTimeout = 30_000
-            connection.readTimeout = 300_000
-            if (connection.responseCode != 200) {
-                throw new GradleException("Cannot download the kotlp binary from '%s': HTTP %d.".formatted(url, connection.responseCode))
-            }
-            connection.inputStream.withStream { input ->
-                kotlpBinary.withOutputStream { output -> input.transferTo(output) }
-            }
-            kotlpVersionMarker.text = version
-        } catch (IOException e) {
-            kotlpBinary.delete()
-            kotlpVersionMarker.delete()
-            throw new GradleException("Cannot download the kotlp binary from '%s': %s.".formatted(url, e.getMessage()), e)
-        }
-    }
-}
-processResources.dependsOn downloadKotlp
-tasks.matching { it.name == 'sourcesJar' }.configureEach { dependsOn 'downloadKotlp' }
-
 dependencies {
     // Kestra
     implementation project(':core')
     annotationProcessor project(':processor')
 
     implementation 'io.micronaut:micronaut-context'
+
+    // The kotlp binary ships as a resource inside this artifact — a single Actually Portable
+    // Executable covering Linux/macOS/BSD on amd64 and arm64 — and is read off the classpath by
+    // KotlpUtils. Version is pinned by the platform BOM.
+    implementation 'io.kestra:kotlp'
 
     implementation ('com.github.docker-java:docker-java') {
         exclude group: 'com.github.docker-java', module: 'docker-java-transport-netty'

--- a/script/src/main/java/io/kestra/plugin/scripts/exec/scripts/runners/KotlpUtils.java
+++ b/script/src/main/java/io/kestra/plugin/scripts/exec/scripts/runners/KotlpUtils.java
@@ -15,8 +15,8 @@ import java.util.Set;
  * Utility to inject the embedded <a href="https://github.com/kestra-io/kotlp">kotlp</a> binary into a file destination.
  * <p>
  * kotlp is a single Actually Portable Executable covering Linux, macOS and BSD on amd64 and arm64; the same
- * binary works on Windows once renamed with an {@code .exe} extension. It is embedded at build time by the
- * {@code downloadKotlp} Gradle task of the script module.
+ * binary works on Windows once renamed with an {@code .exe} extension. It comes from the
+ * {@code io.kestra:kotlp} dependency, which carries the binary as the classpath resource this class reads.
  */
 public final class KotlpUtils {
     public static final String BINARY_NAME = "kotlp";
@@ -36,7 +36,7 @@ public final class KotlpUtils {
     public static Path copyTo(Path destination) throws IOException {
         try (InputStream binary = KotlpUtils.class.getResourceAsStream(RESOURCE_PATH)) {
             if (binary == null) {
-                throw new KestraRuntimeException("Cannot inject the kotlp binary: it was not embedded in this build. Run the 'downloadKotlp' Gradle task and rebuild.");
+                throw new KestraRuntimeException("Cannot inject the kotlp binary: the 'io.kestra:kotlp' dependency is missing from the runtime classpath.");
             }
 
             Path parent = destination.getParent();


### PR DESCRIPTION
## What

Deletes the hand-rolled `downloadKotlp` task and resolves the binary as an ordinary dependency:

```groovy
// platform/build.gradle
api 'io.kestra:kotlp:0.1.2!!'

// script/build.gradle
implementation 'io.kestra:kotlp'
```

`KotlpUtils` is unchanged: the artifact carries the APE at `/kotlp/kotlp` — the exact classpath resource it already reads — plus `/kotlp/kotlp.version`, so the binary now comes from the dependency jar instead of `script/src/main/resources/`. Also gone: the `kotlpVersion` property, the version marker file and its `.gitignore` entry.

## Why

`downloadKotlp` fetched the GitHub release asset at build time, and GitHub throttles **anonymous** release-asset downloads by closing the connection with no HTTP response — 3 of 10 cold JVM attempts failed from one IP, and `HttpURLConnection` doesn't retry a fresh connection, so it became a hard build failure (`Unexpected end of file from server`). It hit kestra-ee constantly because its self-hosted runners share one egress IP.

As a dependency, Gradle handles it: caching (a warm cache means **no download at all** — the old output sat outside every cache, so every CI job re-fetched it and burned the anonymous budget), checksums, resolution retries, offline builds, and Central's CDN. #18126 added a retry loop to survive the throttle; this removes the failure mode instead and deletes that code.

It also drops the `kotlpVersion` stopgap kestra-ee had to add to its own `gradle.properties` just to configure this OSS module — the version is BOM-managed now.

## Pinning

Strict (`!!`) because the binary's OTLP envelope key must match what `TaskLogLineMatcher` parses — a mismatch emits valid telemetry that Kestra ingests none of, silently. Verified against a locally published `0.2.0`: a competing `implementation 'io.kestra:kotlp:0.2.0'` is **downgraded** to the pinned version and the build succeeds (strict wins; it does not fail on conflict).

## Testing

Verified against a locally published artifact, then end to end on running servers:

- `:script:test` + `TaskLogLineMatcher`: **63 tests, 0 failures**, including the real-process kotlp wrap test (binary present and executable in the working dir, `process.cpu.time` reaching the run context) and the disabled case leaving the command unwrapped;
- the module jar no longer embeds the binary; **both distributions still do** — `shadowJar` for OSS and kestra-ee each contain `kotlp/kotlp` (`sha256 7f3cdea4…`, byte-identical to the released asset) and `kotlp/kotlp.version`;
- a **live OSS server** resolved it on its real classpath, and a **licensed local EE server** extracted and executed the binary straight from its fat jar (`kotlp --version → kotlp 0.1.0`);
- published POM: `io.kestra:kotlp`, `scope=runtime`, versionless via the imported `io.kestra:platform` BOM — same shape as `docker-java` and every other dependency.

Known coverage gaps found while testing, both pre-existing and worth a follow-up: no test asserts the child's stdout survives the wrap, and none asserts a non-zero exit code is proxied. I verified both by hand (`exit 42` propagates; the stdout line arrives as a LogRecord with `log.iostream=stdout`).

## Status

`io.kestra:kotlp:0.1.2` is **published on Maven Central** (kestra-io/kotlp `v0.1.2`). Verified by wiping the local artifacts and resolving from Central: `io.kestra:kotlp:{strictly 0.1.2} -> 0.1.2`, with the kotlp tests green against it.

Ready to merge. #18126 (the interim retry loop) becomes moot once this lands — it deletes the code that PR touches.
