### PR TITLE
fix(flows): gate the Edit flow fallback on an existing, non-creating flow

### DIFF
--- a/ui/src/override/components/flows/Actions.vue
+++ b/ui/src/override/components/flows/Actions.vue
@@ -61,7 +61,7 @@
                 </template>
             </KsDropdown>
             <NavBarAction
-                v-else-if="canEdit && !deleted"
+                v-else-if="flow && canEdit && !deleted && !flowStore.isCreating"
                 :icon="Pencil"
                 :label="$t('edit flow')"
                 @click="editFlow"

--- a/ui/tests/unit/override/components/flows/Actions.spec.ts
+++ b/ui/tests/unit/override/components/flows/Actions.spec.ts
@@ -7,7 +7,8 @@ import KestraDesignSystem from "@kestra-io/design-system"
 const publishDraft = vi.fn().mockResolvedValue("saved")
 
 const routeState = {tab: "edit"}
-const flowState = {deleted: false}
+const flowState = {deleted: false, exists: true, isCreating: false}
+const editorState = {isAllowedEdit: true}
 
 vi.mock("vue-router", () => ({
     useRoute: () => ({params: {tab: routeState.tab}, query: {}}),
@@ -20,8 +21,10 @@ vi.mock("override/stores/auth", () => ({
 
 vi.mock("../../../../../src/stores/flow", () => ({
     useFlowStore: () => ({
-        flow: {id: "f", namespace: "ns", draft: true, deleted: flowState.deleted, source: "id: f\nnamespace: ns\n"},
-        isCreating: false,
+        flow: flowState.exists
+            ? {id: "f", namespace: "ns", draft: true, deleted: flowState.deleted, source: "id: f\nnamespace: ns\n"}
+            : undefined,
+        isCreating: flowState.isCreating,
         createFlow: vi.fn(),
     }),
 }))
@@ -51,7 +54,9 @@ vi.mock("../../../../../src/components/flows/useFlowEditorActions", () => ({
         canSave: false,
         hasErrors: false,
         isReadOnly: false,
-        isAllowedEdit: true,
+        get isAllowedEdit() {
+            return editorState.isAllowedEdit
+        },
         // The real composable returns computed refs; `isDraft` is read from script (not just
         // auto-unwrapped in a template), so the mock has to be a ref for that read to work.
         isDraft: computed(() => true),
@@ -115,6 +120,9 @@ describe("Actions.vue — publish a draft flow", () => {
         vi.clearAllMocks()
         routeState.tab = "edit"
         flowState.deleted = false
+        flowState.exists = true
+        flowState.isCreating = false
+        editorState.isAllowedEdit = true
     })
 
     it("shows an enabled Publish action for an unchanged draft flow, and clicking it publishes", async () => {
@@ -135,6 +143,9 @@ describe("Actions.vue — the quick action pair is the same shape on every tab",
         vi.clearAllMocks()
         routeState.tab = "edit"
         flowState.deleted = false
+        flowState.exists = true
+        flowState.isCreating = false
+        editorState.isAllowedEdit = true
     })
 
     it("pairs the save-family control with Execute on the editor tab", () => {
@@ -156,6 +167,20 @@ describe("Actions.vue — the quick action pair is the same shape on every tab",
             expect(findExecute(wrapper).exists()).toBe(true)
         },
     )
+
+    it("offers no Edit flow on the create page, where there is no flow to edit yet", () => {
+        // Given — the create-flow landing: creation started, but no flow exists yet
+        routeState.tab = "edit"
+        flowState.exists = false
+        flowState.isCreating = true
+        editorState.isAllowedEdit = false
+
+        // When
+        const wrapper = mountActions()
+
+        // Then — Edit flow used to render here and navigate to an undefined flow
+        expect(findButtonByText(wrapper, "Edit flow")).toBeUndefined()
+    })
 
     it("promotes Restore to the primary slot on a deleted flow, and offers no Execute", () => {
         routeState.tab = "overview"


### PR DESCRIPTION
On `/flows/new`, `flowStore.isCreating` is `true` but `flowStore.flow` is not set until the flow exists, so the save/publish control is skipped and the `v-else-if` fallback falls through to **Edit flow**. Clicking it pushes `flows/update/edit` with an undefined id and namespace, so nothing happens.

The fallback is now gated on an existing flow and on creation not being in progress, which leaves it where it belongs: the overview of an already-saved flow.

```
v-else-if="flow && canEdit && !deleted && !flowStore.isCreating"
```

Closes https://github.com/kestra-io/kestra-ee/issues/9897

## Why this PR shrank

This PR originally fixed three dead ends on the flow creation page. [#18303](https://github.com/kestra-io/kestra/pull/18303) landed on `develop` in the meantime and dropped the flow-creation funnel entirely — `NewFlowLanding.vue`, `ImportYaml.vue` and their tests are deleted; `/flows/new` now initialises the flow and mounts the editor directly, with an auto-generated id/namespace. That superseded two of the three fixes here:

- **"Open editor greyed out with no sign why" (kestra-ee#9898)** — moot, the required-field landing form it applied to no longer exists.
- **"Create a system flow lands on Overview" (kestra-ee#9907)** — already fixed independently by #18303's namespace-aware routing (its description calls out and fixes the exact same query-param-vs-child-route bug).

Only the **Edit flow** button fix (kestra-ee#9897) still applies on top of the new direct-editor flow and is kept here. kestra-ee#9898 and #9907 are left open rather than closed by this PR, since they should be verified against #18303's fix and closed there.

## Tests

`Actions.spec.ts`: no Edit flow on the create page, where there is no flow to edit yet.

## Verification

- `npm run test:unit` — 191 files / 1816 tests, all green
- `npm run test:lint` — 0 errors
- `npm run check:types` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)