### PR TITLE
ci: add required-checks gate job for branch protection

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -299,6 +299,30 @@ jobs:
       java-version: 25
       skip-build: ${{ needs.build-artifacts.result == 'success' }}
 
+  # Single gate for "require status checks to pass". The test jobs above are
+  # path-gated with `if:`, and several are reusable workflows (`uses:`) whose
+  # nested checks are never reported when the caller job is skipped — so a
+  # branch-protection rule on them individually would wait forever for a status
+  # that never arrives. This job always runs, and fails only when a required job
+  # actually failed or was cancelled; skipped and successful jobs both pass.
+  # Require only this check in branch protection instead of the individual jobs.
+  required-checks:
+    name: Required checks
+    if: always()
+    needs: [file-changes, frontend, design-system-frontend, backend, build-artifacts, e2e-tests]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fail if any required job failed or was cancelled
+        if: >-
+          contains(needs.*.result, 'failure') ||
+          contains(needs.*.result, 'cancelled')
+        run: |
+          echo "A required job failed or was cancelled:"
+          echo '${{ toJSON(needs) }}'
+          exit 1
+      - name: Success
+        run: echo "All required jobs passed or were legitimately skipped."
+
   otel-export-trace:
     name: OpenTelemetry - Export Trace
     runs-on: ubuntu-latest


### PR DESCRIPTION
## What

Adds a single `required-checks` gate job to the OSS PR workflow so that "Require status checks to pass" can finally be enabled without deadlocking.

## Why

The test jobs (`backend`, `frontend`, `design-system-frontend`, `e2e-tests`) are path-gated with `if:`, and several are reusable workflows (`uses:`) whose *nested* checks are never reported when the caller job is skipped. A branch-protection rule on those checks individually therefore waits forever for a status that never arrives — the exact failure described in kestra-io/kestra-ee#9851.

## How

The new job is `if: always()`, so it always runs and always reports. It fails only when a required job genuinely `failure`d or was `cancelled`; `skipped` and `success` both pass.

```yaml
needs: [file-changes, frontend, design-system-frontend, backend, build-artifacts, e2e-tests]
```

- The four checks currently required in branch protection: `backend`, `frontend`, `design-system-frontend`, `e2e-tests`.
- `file-changes` drives the `if:` skips — if it fails, everything wrongly skips, so it must block.
- `build-artifacts` feeds e2e; a build failure skips e2e (which would otherwise pass silently), so it's caught directly here.

`translations` is intentionally left out for now — we'll add it when doing the EE side.

## Rollout

This job is purely additive and **not** wired into branch protection by this PR — at worst it's a non-blocking check. Once it's observed behaving correctly on real PRs, branch protection can be switched to require **only** `Required checks` and drop the four granular entries.

Refs kestra-io/kestra-ee#9851