### PR TITLE
chore(system): lower default max DB pool size to 20

### DIFF
--- a/jdbc/src/main/java/io/kestra/jdbc/DatasourcePoolSizeDefaulter.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/DatasourcePoolSizeDefaulter.java
@@ -15,10 +15,14 @@ import jakarta.inject.Singleton;
  * the duration of message processing. Only applies when the user has not explicitly configured
  * {@code datasources.<name>.maximum-pool-size} themselves, and only for whichever datasource is
  * actually declared (it never creates a datasource for a dialect that isn't configured).
+ * <p>
+ * Also, default the idle size to half that value as otherwise HikariCP will use the maximum-pool-size.
+ * <p>
+ * To balance performance with resource usage, we raise the default to {@link #DEFAULT_MAXIMUM_POOL_SIZE}.
  */
 @Singleton
 public class DatasourcePoolSizeDefaulter implements BeanCreatedEventListener<DatasourceConfiguration> {
-    private static final int DEFAULT_MAXIMUM_POOL_SIZE = 25;
+    private static final int DEFAULT_MAXIMUM_POOL_SIZE = 20;
 
     private final Environment environment;
 
@@ -33,6 +37,10 @@ public class DatasourcePoolSizeDefaulter implements BeanCreatedEventListener<Dat
 
         if (!environment.containsProperty("datasources." + configuration.getName() + ".maximum-pool-size")) {
             configuration.setMaximumPoolSize(DEFAULT_MAXIMUM_POOL_SIZE);
+
+            if (!environment.containsProperty("datasources." + configuration.getName() + ".minimum-idle")) {
+                configuration.setMinimumIdle(DEFAULT_MAXIMUM_POOL_SIZE / 2);
+            }
         }
 
         return configuration;

--- a/jdbc/src/test/java/io/kestra/jdbc/DatasourcePoolSizeDefaulterTest.java
+++ b/jdbc/src/test/java/io/kestra/jdbc/DatasourcePoolSizeDefaulterTest.java
@@ -33,7 +33,7 @@ class DatasourcePoolSizeDefaulterTest {
         DatasourceConfiguration result = new DatasourcePoolSizeDefaulter(environment).onCreated(event);
 
         // Then
-        assertThat(result.getMaximumPoolSize()).isEqualTo(25);
+        assertThat(result.getMaximumPoolSize()).isEqualTo(20);
     }
 
     @Test


### PR DESCRIPTION
So when we run with distributed components in a stock database we only take 80 connections not the whole 100.

Also configure idle size to half the default pool size.
