### PR TITLE
fix(flows): validate flows as they will run

### DIFF
--- a/core/src/main/java/io/kestra/core/services/FlowParsingService.java
+++ b/core/src/main/java/io/kestra/core/services/FlowParsingService.java
@@ -130,6 +130,26 @@ public class FlowParsingService {
     }
 
     /**
+     * Parses the given abstract flow for the validation paths (save, validate endpoint, pre-execution check),
+     * returning a parsed {@link FlowWithSource}. May be overridden to apply the same governance mutations the
+     * flow will run with, so constraints are checked against the effective configuration rather than the
+     * authored source; the default parses leniently without further processing.
+     *
+     * <p>
+     * Unlike {@link #parseForRuntime(FlowInterface)} this never rejects the flow: governance blocking is owned
+     * by the save and execution gates, which frame their own errors.
+     * </p>
+     *
+     * @param flow the flow to be parsed
+     * @return a parsed {@link FlowWithSource}
+     *
+     * @throws FlowProcessingException if an error occurred while processing the flow
+     */
+    public FlowWithSource parseForValidation(final FlowInterface flow) throws FlowProcessingException {
+        return parse(flow, false);
+    }
+
+    /**
      * Converts the given abstract flow into a {@link FlowWithSource} without re-parsing it. Used by runtime
      * callers to degrade to the flow as stored when {@link #parseForRuntime(FlowInterface)} fails.
      */

--- a/core/src/main/java/io/kestra/core/services/FlowService.java
+++ b/core/src/main/java/io/kestra/core/services/FlowService.java
@@ -118,7 +118,8 @@ public class FlowService {
     /**
      * Validates and creates the given flow.
      * <p>
-     * The validation of the flow is done from the source after injecting all plugin default values.
+     * The validation of the flow is done from the source, as it will run: the governance applied at runtime is
+     * applied first, so a flow whose required properties are supplied by governance stays valid.
      *
      * @param flow The flow.
      * @return The created {@link FlowWithSource}.
@@ -136,7 +137,7 @@ public class FlowService {
         // since the draft flag is not part of the YAML source.
         if (!flow.isDraft()) {
             FlowWithSource parsed = flowParsingService.parse(flow.getTenantId(), flow.getSource(), true);
-            modelValidator.validate(flowParsingService.parse(parsed, false));
+            modelValidator.validate(flowParsingService.parseForValidation(parsed));
         }
 
         FlowWithSource created = flowRepository.create(flow);
@@ -148,12 +149,13 @@ public class FlowService {
     }
 
     /**
-     * Validates and creates the given flow.
+     * Validates and updates the given flow.
      * <p>
-     * The validation of the flow is done from the source after injecting all plugin default values.
+     * The validation of the flow is done from the source, as it will run: the governance applied at runtime is
+     * applied first, so a flow whose required properties are supplied by governance stays valid.
      *
      * @param flow The flow.
-     * @return The created {@link FlowWithSource}.
+     * @return The updated {@link FlowWithSource}.
      */
     public FlowWithSource update(GenericFlow flow, FlowInterface previous) throws FlowProcessingException, QueueException {
         // FIXME validation is done both here and in the repo
@@ -169,7 +171,7 @@ public class FlowService {
         // since the draft flag is not part of the YAML source.
         if (!flow.isDraft()) {
             FlowWithSource parsed = flowParsingService.parse(flow.getTenantId(), flow.getSource(), true);
-            modelValidator.validate(flowParsingService.parse(parsed, false));
+            modelValidator.validate(flowParsingService.parseForValidation(parsed));
         }
 
         FlowWithSource updated = flowRepository.update(flow, previous);
@@ -447,7 +449,7 @@ public class FlowService {
                     constraintsBuilder.outdated(!sentRevision.equals(lastRevision + 1));
                 }
 
-                FlowWithSource parsedFlow = flowParsingService.parse(flow, false);
+                FlowWithSource parsedFlow = flowParsingService.parseForValidation(flow);
                 constraintsBuilder.deprecationPaths(deprecationPaths(parsedFlow));
                 constraintsBuilder.warnings(warnings(parsedFlow, tenantId));
                 constraintsBuilder.infos(relocations(source).stream().map(relocation -> relocation.from() + " is replaced by " + relocation.to()).toList());
@@ -888,7 +890,7 @@ public class FlowService {
      */
     public Optional<ConstraintViolationException> validateForExecution(Flow flow) {
         try {
-            return modelValidator.isValid(flowParsingService.parse(flow, false));
+            return modelValidator.isValid(flowParsingService.parseForValidation(flow));
         } catch (FlowProcessingException e) {
             // The flow could not be processed (e.g., unknown plugin). Surface this as a violation
             // so the execution fails with the same error path as other invalid flows.

--- a/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcFlowRepository.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcFlowRepository.java
@@ -944,7 +944,7 @@ public abstract class AbstractJdbcFlowRepository extends AbstractJdbcRepository 
         try {
             // For drafts the YAML may be unparsable; if parsing fails we skip all
             // validation since draft revisions are intentionally allowed to carry invalid content.
-            FlowWithSource flowWithDefault = flowParsingService.parse(flow, false);
+            FlowWithSource flowWithDefault = flowParsingService.parseForValidation(flow);
             // Drafts are allowed to be saved invalid - they will fail at execution time instead.
             // Read the draft flag from the original GenericFlow (set from the API draft flag) rather
             // than from flowWithDefault, since `parse` re-parses the YAML source which


### PR DESCRIPTION
Flow validation parses the flow **as authored**, not as it will run. Any governance an edition applies at runtime is invisible to `ModelValidator`, so a task whose required property is supplied by governance is reported invalid and cannot be saved.

This is the seam that makes the fix possible; the behaviour change lives in the companion PR kestra-io/kestra-ee#9909 (same branch name, needs to be merged together).

### Changes

- `FlowParsingService.parseForValidation(flow)` — parses the flow as it will run. Defaults to the existing lenient parse, so **OSS behaviour is unchanged**. Unlike `parseForRuntime` it never rejects the flow: blocking is owned by the save and execution gates.
- Route the validation paths through it: `FlowService.create` / `update` / `validate` / `validateForExecution`, and `AbstractJdbcFlowRepository.update` (which re-validates independently of the service — the existing `// FIXME validation is done both here and in the repo`).

The `create`/`update` double-parse was the old plugin-defaults injection point, which is why the javadoc still claimed validation happened "after injecting all plugin default values". Updated.

### Tests

`:core:test --tests "io.kestra.core.services.*"` 95 passing, `H2FlowRepositoryTest` 122 passing. No behaviour change here, so no new OSS test; the regression is covered in the EE PR.
