### PR TITLE
feat(charts): expose disabling the webserver's embedded controller as a values option

### DIFF
--- a/charts/kestra/README.md
+++ b/charts/kestra/README.md
@@ -308,13 +308,12 @@ configurations:
 > **Note:** The webserver pod also starts an embedded controller by default. In distributed mode
 > workers only connect to `<release-name>-controller`, so this embedded controller is unused.
 > This is harmless — Kestra supports multiple controllers for load balancing — but wastes resources.
-> To disable it, add `--no-controller` to the webserver's `extraArgs`:
+> Disable it with:
 >
 > ```yaml
 > deployments:
 >   webserver:
->     extraArgs:
->       - --no-controller
+>     controller: false
 > ```
 
 ### Upgrade prerequisite
@@ -383,6 +382,7 @@ JDBC queue tables — this is irreversible. Back up your database before upgradi
 | deployments.standalone.enabled | bool | `true` | Enable standalone Kestra deployment. |
 | deployments.standalone.extraArgs | list | `[]` | Extra arguments to pass to the container. |
 | deployments.standalone.workerThreads | int | `0` | Number of worker threads for standalone deployment ; "0" to auto-configure based on CPU. |
+| deployments.webserver.controller | bool | `true` | Enable the webserver's embedded gRPC worker controller. Set to `false` (adds `--no-controller`) when also running a dedicated `deployments.controller` Deployment, to avoid running two controllers for the same release. |
 | deployments.webserver.enabled | bool | `false` | Enable webserver in distributed mode. |
 | deployments.webserver.extraArgs | list | `[]` | Extra arguments to pass to the container. |
 | deployments.worker.enabled | bool | `false` | Enable worker in distributed mode. |

--- a/charts/kestra/README.md.gotmpl
+++ b/charts/kestra/README.md.gotmpl
@@ -322,13 +322,12 @@ configurations:
 > **Note:** The webserver pod also starts an embedded controller by default. In distributed mode
 > workers only connect to `<release-name>-controller`, so this embedded controller is unused.
 > This is harmless — Kestra supports multiple controllers for load balancing — but wastes resources.
-> To disable it, add `--no-controller` to the webserver's `extraArgs`:
+> Disable it with:
 >
 > ```yaml
 > deployments:
 >   webserver:
->     extraArgs:
->       - --no-controller
+>     controller: false
 > ```
 
 ### Upgrade prerequisite

--- a/charts/kestra/templates/deployment.yaml
+++ b/charts/kestra/templates/deployment.yaml
@@ -182,6 +182,9 @@ spec:
                 --thread={{ $content.workerThreads }} \
                 {{- end }}
                 {{- end }}
+                {{- if and (eq $type "webserver") (not $content.controller) }}
+                --no-controller \
+                {{- end }}
                 {{- with $content.extraArgs }}
                 {{- range $key, $value := $content.extraArgs }}
                 {{- $value }} \

--- a/charts/kestra/tests/deployment_webserver_controller_test.yaml
+++ b/charts/kestra/tests/deployment_webserver_controller_test.yaml
@@ -1,0 +1,44 @@
+suite: Deployment webserver controller
+
+templates:
+  - templates/deployment.yaml
+
+tests:
+  - it: does not append --no-controller when controller is left at its default
+    set:
+      deployments:
+        standalone:
+          enabled: false
+        webserver:
+          enabled: true
+    asserts:
+      - isKind:
+          of: Deployment
+      - notMatchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: "--no-controller"
+
+  - it: appends --no-controller when controller is explicitly disabled
+    set:
+      deployments:
+        standalone:
+          enabled: false
+        webserver:
+          enabled: true
+          controller: false
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: "--no-controller"
+
+  - it: does not affect other deployment types (e.g. standalone)
+    set:
+      deployments:
+        standalone:
+          enabled: true
+        webserver:
+          controller: false
+    asserts:
+      - notMatchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: "--no-controller"

--- a/charts/kestra/values.yaml
+++ b/charts/kestra/values.yaml
@@ -230,6 +230,11 @@ deployments:
     # -- Enable webserver in distributed mode.
     # @section -- kestra deployments
     enabled: false
+    # -- Enable the webserver's embedded gRPC worker controller. Set to `false` (adds
+    # `--no-controller`) when also running a dedicated `deployments.controller` Deployment, to
+    # avoid running two controllers for the same release.
+    # @section -- kestra deployments
+    controller: true
     # -- Extra arguments to pass to the container.
     # @section -- kestra deployments
     extraArgs: []


### PR DESCRIPTION
## Summary
- Adds `deployments.webserver.controller` (boolean, default `true`) to the Helm chart, mapping `false` to `--no-controller` on the webserver's CLI invocation.
- In distributed mode, the webserver starts an embedded gRPC worker controller by default. When also running a dedicated `deployments.controller` Deployment (the topology this chart's README recommends), that leaves two controllers running for one release. Today the only way to disable the embedded one is passing `--no-controller` through the generic `deployments.webserver.extraArgs`, which isn't surfaced anywhere in `values.yaml`.
- Purely additive and backward-compatible: default (`true`) preserves today's behavior exactly.

Closes #18149

## Changes
- `charts/kestra/values.yaml`: new `deployments.webserver.controller` value.
- `charts/kestra/templates/deployment.yaml`: conditionally appends `--no-controller` to the webserver's command when `controller` is `false`, scoped only to the webserver Deployment.
- `charts/kestra/README.md.gotmpl` / `README.md`: updated the existing distributed-mode note to document the new option (regenerated via `helm-docs`).
- `charts/kestra/tests/deployment_webserver_controller_test.yaml`: new helm-unittest suite covering the default (no-op), disabled (`--no-controller` appended), and isolation from other deployment types (e.g. `standalone`).

## Test plan
- [x] `helm lint charts/kestra`
- [x] `helm template` with `deployments.webserver.controller` unset/`true`/`false` — confirmed rendered command matches expectations in each case
- [x] `helm template` with `deployments.standalone.enabled=true` and `deployments.webserver.controller=false` — confirmed the flag does not leak into the standalone Deployment
- [x] `helm unittest charts/kestra -f tests/deployment_webserver_controller_test.yaml` — 3/3 passing
- [x] Confirmed the pre-existing failures in `tests/jvm_active_processor_test.yaml` are unrelated (present identically on `develop` before this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)