### PR TITLE
fix(ui): point welcome page blueprints links at the community tab

### DIFF
--- a/ui/src/components/onboarding/OnboardingOverlay.vue
+++ b/ui/src/components/onboarding/OnboardingOverlay.vue
@@ -539,7 +539,7 @@
     const goToBlueprints = () => {
         trackCurrentStepAction("finish_explore_blueprints_clicked");
         completeGuide();
-        void router.push({name: "blueprints", params: {kind: "flow", tab: "all"}});
+        void router.push({name: "blueprints", params: {kind: "flow", tab: "community"}});
     };
 
     const goToCreateFlow = () => {

--- a/ui/src/components/onboarding/useOnboardingResources.ts
+++ b/ui/src/components/onboarding/useOnboardingResources.ts
@@ -28,7 +28,7 @@ export function useOnboardingResources() {
             descriptionKey: "welcome_copilot.success_page.items.blueprints.description",
             icon: ShapePlusOutline,
             iconClass: "is-blueprints",
-            to: {name: "blueprints", params: {kind: "flow", tab: "all"}},
+            to: {name: "blueprints", params: {kind: "flow", tab: "community"}},
         },
         {
             titleKey: "welcome_copilot.success_page.items.slack.title",


### PR DESCRIPTION
Closes https://github.com/kestra-io/kestra-ee/issues/8668.

## What

The **Blueprints** card on the AI Copilot welcome page (`/ui/main/welcome`, under "Need Help?") navigated to `/blueprints/flow/all`, which is not a valid blueprints tab (valid tabs are `community` and `custom`) and shows a "not found" page. The product tour's finish-step "Explore blueprints" action had the same wrong target.

Both links now point at `/blueprints/flow/community`, matching the sidebar link.

## Why targeting releases/v1.3.x

The bug only exists on 1.3: on `develop` this onboarding code was replaced by the product tour and the copilot help card already links to the community tab.