### PR TITLE
fix(design-system): make copy buttons work without a secure context and unify clipboard handling

### DIFF
--- a/ui/packages/design-system/src/components/Data/KsMarkdown/KsMarkdown.vue
+++ b/ui/packages/design-system/src/components/Data/KsMarkdown/KsMarkdown.vue
@@ -19,6 +19,7 @@
     import KsTable from "../KsTable/KsTable.vue"
     import KsTableColumn from "../KsTable/KsTableColumn.vue"
     import {getShiki, loadLanguageOnDemand} from "./shikiHighlighter"
+    import {copyToClipboard} from "../../../utils/clipboard"
 
     const props = withDefaults(
         defineProps<{
@@ -221,7 +222,7 @@
                         title: "Copy to clipboard",
                         onClick: (e: MouseEvent) => {
                             const btn = e.currentTarget as HTMLButtonElement
-                            navigator.clipboard.writeText(value).then(() => {
+                            copyToClipboard(value).then(() => {
                                 // Swap the copy glyph for the check (not overlay it) for the confirm window.
                                 btn.classList.add("is-copied")
                                 setTimeout(() => btn.classList.remove("is-copied"), 2000)

--- a/ui/packages/design-system/src/index.ts
+++ b/ui/packages/design-system/src/index.ts
@@ -146,6 +146,7 @@ export {KsMessageBox} from "./components/Feedback/KsMessageBox"
 export {KsNotification} from "./components/Feedback/KsNotification"
 
 export {cssVar} from "./utils/css"
+export {copyToClipboard} from "./utils/clipboard"
 export * as dateUtils from "./utils/date"
 export * as stringUtils from "./utils/string"
 export * as durationUtils from "./utils/duration"

--- a/ui/packages/design-system/src/utils/clipboard.ts
+++ b/ui/packages/design-system/src/utils/clipboard.ts
@@ -1,0 +1,22 @@
+/**
+ * Copies text to the clipboard.
+ *
+ * Falls back to a hidden textarea + `document.execCommand("copy")` when the Clipboard API
+ * is unavailable, since `navigator.clipboard` is undefined in non-secure contexts
+ * (plain HTTP on a non-localhost host).
+ */
+export async function copyToClipboard(text: string): Promise<void> {
+    if (navigator.clipboard) {
+        await navigator.clipboard.writeText(text)
+        return
+    }
+
+    const node = document.createElement("textarea")
+    node.style.position = "absolute"
+    node.style.left = "-9999px"
+    node.value = text
+    document.body.appendChild(node)
+    node.select()
+    document.execCommand("copy")
+    document.body.removeChild(node)
+}

--- a/ui/packages/design-system/tests/units/Data/KsMarkdown/KsMarkdown.test.ts
+++ b/ui/packages/design-system/tests/units/Data/KsMarkdown/KsMarkdown.test.ts
@@ -122,6 +122,25 @@ describe("KsMarkdown", () => {
         expect(navigator.clipboard.writeText).toHaveBeenCalledWith("const x = 42")
     })
 
+    test("copy button falls back to execCommand when the Clipboard API is unavailable", async () => {
+        // navigator.clipboard is undefined in non-secure contexts (plain HTTP)
+        Object.defineProperty(navigator, "clipboard", {
+            value: undefined,
+            configurable: true,
+        })
+        const execCommand = vi.fn().mockReturnValue(true)
+        document.execCommand = execCommand
+
+        const wrapper = mount(KsMarkdown, {
+            props: {content: "```\nconst x = 42\n```"},
+            global: globalConfig,
+            attachTo: document.body,
+        })
+        await wrapper.find(".ks-markdown__copy-btn").trigger("click")
+        expect(execCommand).toHaveBeenCalledWith("copy")
+        wrapper.unmount()
+    })
+
     test("renders mermaid code block as mermaid div", () => {
         const wrapper = mount(KsMarkdown, {
             props: {content: "```mermaid\ngraph TD\n  A --> B\n```"},

--- a/ui/packages/design-system/tests/units/utils/clipboard.test.ts
+++ b/ui/packages/design-system/tests/units/utils/clipboard.test.ts
@@ -1,0 +1,43 @@
+import {describe, test, expect, vi, beforeEach} from "vitest"
+import {copyToClipboard} from "../../../src/utils/clipboard"
+
+describe("copyToClipboard", () => {
+    beforeEach(() => {
+        document.body.innerHTML = ""
+    })
+
+    test("uses navigator.clipboard.writeText when the Clipboard API is available", async () => {
+        const writeText = vi.fn().mockResolvedValue(undefined)
+        Object.defineProperty(navigator, "clipboard", {
+            value: {writeText},
+            configurable: true,
+        })
+
+        await copyToClipboard("hello")
+
+        expect(writeText).toHaveBeenCalledWith("hello")
+    })
+
+    test("falls back to a hidden textarea and execCommand when navigator.clipboard is undefined", async () => {
+        // navigator.clipboard is undefined in non-secure contexts (plain HTTP)
+        Object.defineProperty(navigator, "clipboard", {
+            value: undefined,
+            configurable: true,
+        })
+        let selectedValue: string | undefined
+        const execCommand = vi.fn().mockImplementation((command: string) => {
+            if (command === "copy") {
+                selectedValue = document.querySelector("textarea")?.value
+            }
+            return true
+        })
+        document.execCommand = execCommand
+
+        await copyToClipboard("fallback text")
+
+        expect(execCommand).toHaveBeenCalledWith("copy")
+        expect(selectedValue).toBe("fallback text")
+        // The helper cleans up the temporary textarea
+        expect(document.querySelector("textarea")).toBeNull()
+    })
+})

--- a/ui/src/components/admin/triggers/AddTriggerModal.vue
+++ b/ui/src/components/admin/triggers/AddTriggerModal.vue
@@ -127,7 +127,7 @@
     import {computed, provide, ref, watch} from "vue"
     import {useRouter} from "vue-router"
 
-    import {KsEditor} from "@kestra-io/design-system"
+    import {KsEditor, copyToClipboard} from "@kestra-io/design-system"
     import {flowYamlUtils as YAML_UTILS} from "@kestra-io/topology"
     import CheckIcon from "vue-material-design-icons/Check.vue"
     import ContentCopy from "vue-material-design-icons/ContentCopy.vue"
@@ -266,7 +266,7 @@
     }
 
     const copySource = async () => {
-        await navigator.clipboard.writeText(`triggers:\n${sourceYaml.value}\n`)
+        await copyToClipboard(`triggers:\n${sourceYaml.value}\n`)
         copied.value = true
         setTimeout(() => copied.value = false, COPY_FEEDBACK_MS)
     }

--- a/ui/src/components/executions/outputs/ExecutionVariableExplorer.vue
+++ b/ui/src/components/executions/outputs/ExecutionVariableExplorer.vue
@@ -103,6 +103,7 @@
         KsIconButton,
         KsEditor,
         KsJsonTree,
+        copyToClipboard,
     } from "@kestra-io/design-system"
     import * as OutputsAPI from "@kestra-io/kestra-sdk/outputs"
 
@@ -440,7 +441,7 @@
     const isRawEditor = computed(() => viewMode.value === "raw" && isExpandableValue.value)
 
     function copyValue() {
-        navigator.clipboard?.writeText(rawValue.value)
+        copyToClipboard(rawValue.value)
     }
 
     /* --------------------------------- Layout -------------------------------- */

--- a/ui/src/components/flows/TaskEditData.vue
+++ b/ui/src/components/flows/TaskEditData.vue
@@ -84,6 +84,7 @@
 <script setup lang="ts">
     import {computed, ref} from "vue"
     import {useI18n} from "vue-i18n"
+    import {copyToClipboard} from "@kestra-io/design-system"
     import Magnify from "vue-material-design-icons/Magnify.vue"
     import ChevronRight from "vue-material-design-icons/ChevronRight.vue"
     import ChevronLeft from "vue-material-design-icons/ChevronLeft.vue"
@@ -151,7 +152,7 @@
 
     let copiedTimer: ReturnType<typeof setTimeout> | undefined
     function copy(expr: string) {
-        navigator.clipboard?.writeText(expr)
+        copyToClipboard(expr)
         copied.value = expr
         clearTimeout(copiedTimer)
         copiedTimer = setTimeout(() => {

--- a/ui/src/components/plugins/schema/SchemaToCode.vue
+++ b/ui/src/components/plugins/schema/SchemaToCode.vue
@@ -24,7 +24,7 @@
 <script setup lang="ts">
     import {computed, ref} from "vue"
     import type {HighlighterCore} from "shiki/core"
-    import {KsButton, KsTooltip} from "@kestra-io/design-system"
+    import {KsButton, KsTooltip, copyToClipboard as writeToClipboard} from "@kestra-io/design-system"
     import Check from "vue-material-design-icons/Check.vue"
     import ContentCopy from "vue-material-design-icons/ContentCopy.vue"
 
@@ -52,7 +52,7 @@
 
     function copyToClipboard() {
         clearTimeout(copyResetTimer.value)
-        navigator.clipboard.writeText(props.code.trimEnd())
+        writeToClipboard(props.code.trimEnd())
         copied.value = true
 
         copyResetTimer.value = setTimeout(() => {

--- a/ui/src/utils/utils.ts
+++ b/ui/src/utils/utils.ts
@@ -1,5 +1,6 @@
 import {computed} from "vue"
 import moment from "moment"
+import {copyToClipboard} from "@kestra-io/design-system"
 import {useMiscStore} from "override/stores/misc"
 
 export type Optional<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, K>>;
@@ -242,21 +243,7 @@ export function asArray(objOrArray: any | any[]) {
 }
 
 export async function copy(text: string) {
-    if (navigator.clipboard) {
-        await navigator.clipboard.writeText(text)
-        return
-    }
-
-    const node = document.createElement("textarea")
-    node.style.position = "absolute"
-    node.style.left = "-9999px"
-    node.textContent = text
-    document.body.appendChild(node).value = text
-    node.select()
-
-    document.execCommand("copy")
-
-    document.body.removeChild(node)
+    await copyToClipboard(text)
 }
 
 export function toFormData(obj: FormData | Record<string, any>) {


### PR DESCRIPTION
Closes https://github.com/kestra-io/kestra/issues/18145.

## What

Copy buttons across the UI failed on plain HTTP deployments (any non-localhost host without TLS) because `navigator.clipboard` is undefined outside a secure context: clicking the button threw `TypeError: Cannot read properties of undefined (reading 'writeText')` and nothing was copied. This is what broke copying the task example from the plugin docs panel in the issue.

## How

- Adds a `copyToClipboard` helper to the design system (`ui/packages/design-system/src/utils/clipboard.ts`, exported from the package index): uses the Clipboard API when available, otherwise falls back to a hidden textarea + `document.execCommand("copy")`.
- `KsMarkdown` code-block copy buttons (plugin docs examples) now use it, as do the previously direct `navigator.clipboard.writeText` call sites: `SchemaToCode`, `AddTriggerModal` (both threw on HTTP), `ExecutionVariableExplorer`, `TaskEditData` (both silently no-oped on HTTP).
- The duplicate `copy` util in `ui/src/utils/utils.ts` is removed and all of its ~18 callers now import the design-system helper, so the codebase has exactly one clipboard implementation with the fallback built in.

## Tests

- New unit test for the helper (Clipboard API path + fallback path incl. textarea cleanup).
- New `KsMarkdown` test: copy button falls back to `execCommand` when `navigator.clipboard` is undefined.
- `InputsFormCopyDrag` spec re-pointed at the design-system helper.
- `npm run check:types` and eslint clean in both OSS and EE.

Companion EE PR: https://github.com/kestra-io/kestra-ee/pull/9923 - must be merged after this one, since it uses the new design-system export.