### PR TITLE
Allow overriding the runStandalone plugin directory

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -654,7 +654,7 @@ tasks.register('runLocal') {
 
 tasks.register('runStandalone') {
     group = "application"
-    description = "Run Kestra as server standalone"
+    description = "Run Kestra as server standalone (plugin directory: -PstandalonePlugins=<dir>, default '../local/plugins')"
     dependsOn ':cli:runStandalone'
 }
 

--- a/cli/build.gradle
+++ b/cli/build.gradle
@@ -11,13 +11,19 @@ tasks.register('runLocal', JavaExec) {
     args 'server', 'local', '--plugins', '../local/plugins'
 }
 
+// Plugin directory used by `runStandalone`, resolved from the `cli` project directory when relative.
+// Override with `-PstandalonePlugins=/path/to/plugins` or the `KESTRA_PLUGINS_PATH` environment variable.
+def standalonePlugins = providers.gradleProperty('standalonePlugins')
+    .orElse(providers.environmentVariable('KESTRA_PLUGINS_PATH'))
+    .getOrElse('../local/plugins')
+
 tasks.register('runStandalone', JavaExec) {
     group = "application"
-    description = "Run Kestra as server standalone"
+    description = "Run Kestra as server standalone (plugin directory: -PstandalonePlugins=<dir>, default '../local/plugins')"
     classpath = sourceSets.main.runtimeClasspath
     mainClass = "io.kestra.cli.Kestra"
     environment 'MICRONAUT_ENVIRONMENTS', 'override'
-    args 'server', 'standalone', '--plugins', '../local/plugins'
+    args 'server', 'standalone', '--plugins', standalonePlugins
 }
 
 dependencies {


### PR DESCRIPTION
### ✨ Description

`runStandalone` hardcoded its plugin directory to `../local/plugins`, so running the standalone server against a different set of plugins meant editing `cli/build.gradle`. The directory is now resolved from, in order of precedence:

1. the `standalonePlugins` Gradle property — `./gradlew runStandalone -PstandalonePlugins=/path/to/plugins`
2. the `KESTRA_PLUGINS_PATH` environment variable
3. `../local/plugins`, the existing default

```bash
./gradlew runStandalone                                    # ../local/plugins, unchanged
./gradlew runStandalone -PstandalonePlugins=/opt/plugins
KESTRA_PLUGINS_PATH=/opt/plugins ./gradlew runStandalone
```

`runLocal` is deliberately untouched — it keeps its hardcoded path.

A relative value is resolved from the `cli` project directory, same as the existing `../local/plugins` default; absolute paths avoid the ambiguity. `KESTRA_PLUGINS_PATH` is also the Micronaut environment form of Kestra's own `kestra.plugins.path`, so the forked server reads the same directory either way.

### 🔗 Related Issue

No linked issue. Companion PR in `kestra-ee`: https://github.com/kestra-io/kestra-ee/pull/9932 (same branch name, same change applied to the EE `runStandalone` task).

### 🛠️ Backend Checklist

- [ ] Code compiles successfully and passes all checks
- [ ] All unit and integration tests pass

Left unchecked deliberately: a full local build needs a Java 25 toolchain that isn't available in the environment I ran in, so I'm relying on CI rather than claiming a green build I didn't see. See the notes below for what I did verify.

### 📝 Additional Notes

Build-script only — no production code, no test changes. What I verified: the same provider chain in an isolated Gradle project, asserting the arguments actually handed to the forked JVM:

| invocation | resulting `--plugins` |
| --- | --- |
| `runStandalone` | `../local/plugins` |
| `runStandalone -PstandalonePlugins=/opt/my-plugins` | `/opt/my-plugins` |
| `KESTRA_PLUGINS_PATH=/env/plugins runStandalone` | `/env/plugins` |

The property is named `standalonePlugins` rather than `plugins` on purpose — `-Pplugins=…` would shadow `project.plugins` in the build script.

### 🤖 AI Authors

Why did the cat sit on the build script? It heard there was a `catch` block, and it wanted to be caught. 🐱

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CA4ebitsfhhqVtmCyMfa92

---
_Generated by [Claude Code](https://claude.ai/code/session_01CA4ebitsfhhqVtmCyMfa92)_