### PR TITLE
fix(ai): show the link cursor on the copilot Product tour and Blueprints help cards

### DIFF
--- a/ui/src/components/onboarding/execution/OverviewCard.vue
+++ b/ui/src/components/onboarding/execution/OverviewCard.vue
@@ -1,10 +1,11 @@
 <template>
+    <!-- Anchor attributes are only bound for the external-link variant: passing them as
+         `undefined` would fall through onto RouterLink's anchor and wipe the href it renders,
+         losing the native link cursor (https://github.com/kestra-io/kestra/issues/18148). -->
     <component
         :is="to ? RouterLink : link ? 'a' : 'div'"
         :to="to"
-        :href="link || undefined"
-        :target="link ? '_blank' : undefined"
-        :rel="link ? 'noopener noreferrer' : undefined"
+        v-bind="link ? {href: link, target: '_blank', rel: 'noopener noreferrer'} : {}"
         class="card"
     >
         <KsIcon class="icon">

--- a/ui/tests/unit/components/onboarding/execution/OverviewCard.spec.ts
+++ b/ui/tests/unit/components/onboarding/execution/OverviewCard.spec.ts
@@ -1,0 +1,59 @@
+import {describe, expect, test} from "vitest"
+import {mount} from "@vue/test-utils"
+import {createRouter, createWebHistory} from "vue-router"
+import OverviewCard from "../../../../../src/components/onboarding/execution/OverviewCard.vue"
+
+const router = createRouter({
+    history: createWebHistory(),
+    routes: [
+        {path: "/", name: "home", component: {template: "<div />"}},
+        {path: "/blueprints", name: "blueprints", component: {template: "<div />"}},
+    ],
+})
+
+const mountCard = (props: Record<string, unknown> = {}) =>
+    mount(OverviewCard, {
+        props: {title: "Card title", description: "Card description", ...props},
+        global: {
+            plugins: [router],
+            stubs: {
+                KsIcon: true,
+                // tests/unit/setup.ts stubs RouterLink globally for router-less mounts; this spec
+                // is about the href the real RouterLink puts in the DOM, so it needs the real one.
+                RouterLink: false,
+            },
+        },
+    })
+
+describe("OverviewCard", () => {
+    test("keeps the router-resolved href on an internal `to` card", async () => {
+        await router.push("/")
+        await router.isReady()
+
+        const wrapper = mountCard({to: {name: "blueprints"}})
+
+        // Regression for https://github.com/kestra-io/kestra/issues/18148: passing the unset
+        // `link` props as `href/target/rel: undefined` fell through onto RouterLink's anchor and
+        // wiped its href, so the card lost the native link cursor while staying clickable.
+        const anchor = wrapper.get("a")
+        expect(anchor.attributes("href")).toBe("/blueprints")
+        expect(anchor.attributes("target")).toBeUndefined()
+        expect(anchor.attributes("rel")).toBeUndefined()
+    })
+
+    test("renders an external `link` card as an anchor opening safely in a new tab", () => {
+        const wrapper = mountCard({link: "https://kestra.io/slack"})
+
+        const anchor = wrapper.get("a")
+        expect(anchor.attributes("href")).toBe("https://kestra.io/slack")
+        expect(anchor.attributes("target")).toBe("_blank")
+        expect(anchor.attributes("rel")).toContain("noopener")
+    })
+
+    test("renders a plain non-interactive div when given neither `to` nor `link`", () => {
+        const wrapper = mountCard()
+
+        expect(wrapper.find("a").exists()).toBe(false)
+        expect(wrapper.get("div.card").attributes("href")).toBeUndefined()
+    })
+})


### PR DESCRIPTION
Closes https://github.com/kestra-io/kestra/issues/18148.

## What

On the AI Copilot page, the Product tour and Blueprints help cards showed the default arrow cursor while being clickable; only the external Slack Community card showed the pointer cursor.

## Why

`OverviewCard` renders internal cards through `RouterLink`, but it always bound the external-link attributes, so a card with a `to` target still received `href/target/rel: undefined`. Vue's fallthrough attribute merging lets those parent-provided attrs override the ones the child renders, so the `undefined` href wiped the href `RouterLink` puts on its anchor. An anchor without href is not a link for the browser (no native pointer cursor, no middle-click or copy-link), yet the card stayed clickable through RouterLink's click handler - exactly the symptom in the issue.

## Fix

Bind the anchor attributes only for the external-link variant, so RouterLink keeps its resolved href. Added a unit test mounting the card with a real router that locks the href in place, plus coverage for the external-link and plain variants.