### PR TITLE
fix(ai): hide the New chat button on the copilot landing page instead of showing it disabled

### DIFF
--- a/ui/src/components/ai/copilot/CopilotChat.vue
+++ b/ui/src/components/ai/copilot/CopilotChat.vue
@@ -3,7 +3,7 @@
         <!-- Thread controls: start a new chat; the Recents list (switch / rename / delete) is EE-only,
              rendered by the CopilotThreadControls override (a no-op in OSS). -->
         <div class="copilot-topbar">
-            <KsButton size="small" class="copilot-topbar-pill" data-test="copilot-new-chat" :disabled="isFreshChat" @click="reset">
+            <KsButton v-if="!isFreshChat" size="small" class="copilot-topbar-pill" data-test="copilot-new-chat" @click="reset">
                 {{ $t("ai.copilot.newChat") }}
                 <Plus :size="16" />
             </KsButton>
@@ -253,8 +253,8 @@
         () => messages.value.length === 0 && !pendingConfirmation.value && !error.value && !notice.value,
     )
 
-    // "New chat" resets the conversation — so it's a no-op (and disabled) when we're already on a
-    // fresh, empty chat with no thread to clear.
+    // "New chat" resets the conversation - so it's hidden when we're already on a fresh, empty
+    // chat with no thread to clear.
     const isFreshChat = computed(() => isEmpty.value && !thread.value)
 
     // The pending proposal is always the last PROPOSED_ACTION message; the interactive card below the
@@ -390,20 +390,12 @@
         transition: background 0.15s ease, box-shadow 0.15s ease;
     }
 
-    /* Hover feedback so the pills read as interactive (the disabled New-chat pill excepted). The
-       bg interaction tokens are all near-identical dark greys, so a fill change alone is barely
-       visible — pair it with a lighter inset ring (border-strong) so the hover clearly reads. */
-    .copilot-topbar-pill:not(.is-disabled):hover {
+    /* Hover feedback so the pills read as interactive. The bg interaction tokens are all
+       near-identical dark greys, so a fill change alone is barely visible - pair it with a
+       lighter inset ring (border-strong) so the hover clearly reads. */
+    .copilot-topbar-pill:hover {
         background: var(--ks-bg-hover-elevated);
         box-shadow: inset 0 0 0 1px var(--ks-border-strong);
-    }
-
-    /* Disabled New-chat — already on a fresh, empty chat with nothing to reset. Dim the whole
-       pill (opacity) so it clearly reads as non-interactive, not just muted text. */
-    .copilot-topbar-pill.is-disabled {
-        color: var(--ks-text-inactive);
-        cursor: not-allowed;
-        opacity: 0.5;
     }
 
     .copilot-empty {

--- a/ui/tests/unit/components/ai/copilot/CopilotChat.spec.ts
+++ b/ui/tests/unit/components/ai/copilot/CopilotChat.spec.ts
@@ -219,18 +219,18 @@ describe("CopilotChat", () => {
     })
 
     it("starts a new chat via the top bar", async () => {
-        state.messages.value = [{id: "1", role: "USER", type: "TEXT", content: "hi"}] // something to reset → enabled
+        state.messages.value = [{id: "1", role: "USER", type: "TEXT", content: "hi"}] // something to reset → shown
         const w = mountChat()
         await w.find("[data-test=\"copilot-new-chat\"]").trigger("click")
         expect(state.reset).toHaveBeenCalled()
     })
 
-    it("disables New chat on a fresh, empty chat and enables it once there is something to reset", () => {
+    it("hides New chat on a fresh, empty chat and shows it once there is something to reset", () => {
         // beforeEach leaves the chat fresh (no messages, no thread) → nothing to reset.
-        expect(mountChat().find("[data-test=\"copilot-new-chat\"]").attributes("disabled")).toBeDefined()
+        expect(mountChat().find("[data-test=\"copilot-new-chat\"]").exists()).toBe(false)
 
         state.messages.value = [{id: "1", role: "USER", type: "TEXT", content: "hi"}]
-        expect(mountChat().find("[data-test=\"copilot-new-chat\"]").attributes("disabled")).toBeUndefined()
+        expect(mountChat().find("[data-test=\"copilot-new-chat\"]").exists()).toBe(true)
     })
 
     it("mounts the thread controls (EE-only Recents; a no-op in OSS)", () => {


### PR DESCRIPTION
Closes https://github.com/kestra-io/kestra/issues/18146.

## What

The New chat pill in the AI Copilot top bar was always rendered and merely disabled on a fresh, empty chat, so the /ai landing page showed a permanently greyed-out button that reads as broken. It is now hidden while there is nothing to reset (no messages, no thread) and appears as soon as a conversation starts.

- OSS landing page: the top bar shows nothing (the Recents control is an EE-only override that renders nothing in OSS).
- EE landing page: only the Recents pill shows, so past threads stay reachable.
- Both editions: New chat appears the moment there is a conversation to reset, including after the turn-cap error that tells the user to start a new chat.

Also drops the now-dead disabled-pill CSS and updates the CopilotChat unit spec to assert hidden/shown instead of disabled/enabled.