### PR TITLE
build(version): publish RC tags to Maven Central

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -67,6 +67,8 @@ jobs:
       OTLP_HEADERS: ${{ secrets.OTLP_HEADERS }}
     with:
       java-version: 25
+      # RC tags are published to Maven Central like regular releases
+      publish-rc: true
 
   generate-configuration-schema:
     name: Generate Configuration Schema


### PR DESCRIPTION
## What

Opts in to the new `publish-rc` input of the reusable `kestra-oss-publish-maven.yml` workflow, so `vX.Y.Z-rcN` tags are published to Maven Central exactly like regular releases (same test gating in `pre-release.yml`, same signing/staging via the vanniktech plugin — an `-rcN` version is a valid non-SNAPSHOT release version).

## What stays skipped for RCs (unchanged)

- GitHub release + release-note merge (`kestra-oss-publish-github.yml` skips `-rc` refs)
- Configuration schema publish (`pre-release.yml` guard)
- Helm release (`release-docker.yml` guard)
- Docker `vX.Y` minor retag / `latest`/`lts` retags

## Dependencies

⚠️ **Merge kestra-io/actions#201 first** — passing an input the referenced workflow doesn't define fails the run at trigger time. Companion EE PR: kestra-io/kestra-ee (same branch name).

## Note

Maven Central is immutable: once an RC is published it stays forever and appears in `maven-metadata.xml` (dynamic-version consumers may resolve it). This is the intended trade-off.