### PR TITLE
fix(chart): backport --group=1000 dind insecure mode fix

### DIFF
--- a/charts/kestra/README.md
+++ b/charts/kestra/README.md
@@ -282,7 +282,7 @@ The **workerGroups** follow exactly the same pattern you see in deployments key 
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| dind.base.insecure | object | `{"args":["--log-level=fatal"],"image":{"pullPolicy":"IfNotPresent","repository":"docker","tag":"dind-rootless"},"securityContext":{"allowPrivilegeEscalation":true,"capabilities":{"add":["SYS_ADMIN","NET_ADMIN","DAC_OVERRIDE","SETUID","SETGID"]},"privileged":true,"runAsGroup":0,"runAsUser":0}}` | Insecure dind configuration (privileged). |
+| dind.base.insecure | object | `{"args":["--log-level=fatal","--group=1000"],"image":{"pullPolicy":"IfNotPresent","repository":"docker","tag":"dind-rootless"},"securityContext":{"allowPrivilegeEscalation":true,"capabilities":{"add":["SYS_ADMIN","NET_ADMIN","DAC_OVERRIDE","SETUID","SETGID"]},"privileged":true,"runAsGroup":0,"runAsUser":0}}` | Insecure dind configuration (privileged). |
 
 ### kestra dind rootless
 

--- a/charts/kestra/values.yaml
+++ b/charts/kestra/values.yaml
@@ -347,6 +347,7 @@ dind:
             - SETGID
       args:
         - '--log-level=fatal'
+        - '--group=1000'
   # -- Path where dind socket is mounted.
   # @section -- kestra dind
   socketPath: /dind/


### PR DESCRIPTION
Backports PR #17813 (\`fix(chart): set --group=1000 on dind insecure mode default args\`) to this release line — it was never backported since merging, so this branch's chart was missing it.