### PR TITLE
fix(pwa): enhance background styling for PWA install prompt

### DIFF
--- a/ui/src/components/PwaInstallPrompt.vue
+++ b/ui/src/components/PwaInstallPrompt.vue
@@ -43,6 +43,18 @@
         max-width: calc(100vw - var(--ks-spacing-6));
         z-index: 1000;
         box-shadow: var(--ks-shadow-lg);
+        &:before {
+            content: "";
+            z-index: -1;
+            position: absolute;
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 100%;
+            background-color: var(--ks-bg-base);
+            border-radius: var(--ks-radius-lg);
+            opacity: 1;
+        }
     }
 
     .pwa-install-description {


### PR DESCRIPTION
## Before 
<img width="677" height="427" alt="Screenshot 2026-08-14 at 15 58 03" src="https://github.com/user-attachments/assets/287a81f8-fb4c-4ffc-9dd7-e88df09b5cec" />

## After
<img width="708" height="430" alt="Screenshot 2026-08-14 at 15 58 30" src="https://github.com/user-attachments/assets/a79ddcca-c558-4be6-802d-9db78fce80cc" />

