### PR TITLE
fix(flows): reject a file upload for an input that isn't of type FILE

### DIFF
--- a/core/src/main/java/io/kestra/core/runners/FlowInputOutput.java
+++ b/core/src/main/java/io/kestra/core/runners/FlowInputOutput.java
@@ -168,7 +168,7 @@ public class FlowInputOutput {
         // Inline reusable-inputs references, then flatten FORMs so FILE part matching works against dotted leaf ids.
         final List<Input<?>> inputs = Input.expandToLeaves(reusableInputsExpander.expand(execution.getTenantId(), execution.getNamespace(), rawInputs));
         return Flux.from(data)
-            .publishOn(Schedulers.boundedElastic()).<Map.Entry<String, String>> handle((input, sink) ->
+            .publishOn(Schedulers.boundedElastic()).<Map.Entry<String, Object>> handle((input, sink) ->
             {
                 if (input instanceof CompletedFileUpload fileUpload) {
                     boolean oldStyleInput = false;
@@ -184,15 +184,21 @@ public class FlowInputOutput {
                     }
                     String inputId = oldStyleInput ? fileUpload.getFilename() : fileUpload.getName();
                     String fileName = oldStyleInput ? FileInput.DEFAULT_EXTENSION : fileUpload.getFilename();
+                    // An input not declared at all is left to the "undeclared input" warning below rather than rejected here.
+                    boolean acceptsFile = ListUtils.emptyOnNull(inputs).stream()
+                        .filter(i -> i.getId().equals(inputId))
+                        .findFirst()
+                        .map(i -> acceptsFileUpload(i.getType()))
+                        .orElse(true);
 
-                    if (!uploadFiles) {
+                    if (!uploadFiles || !acceptsFile) {
                         URI from = URI.create(
                             "kestra://" + StorageContext
                                 .forInput(execution, inputId, fileName)
                                 .getContextStorageURI()
                         );
                         fileUpload.discard();
-                        sink.next(Map.entry(inputId, from.toString()));
+                        sink.next(Map.entry(inputId, new UploadedFile(from.toString())));
                     } else {
                         try {
                             final String fileExtension = FileInput.DEFAULT_EXTENSION;
@@ -205,7 +211,7 @@ public class FlowInputOutput {
                             ) {
                                 inputStream.transferTo(outputStream);
                                 URI from = storageInterface.from(execution, inputId, fileName, tempFile);
-                                sink.next(Map.entry(inputId, from.toString()));
+                                sink.next(Map.entry(inputId, new UploadedFile(from.toString())));
                             } finally {
                                 if (!tempFile.delete()) {
                                     tempFile.deleteOnExit();
@@ -225,6 +231,18 @@ public class FlowInputOutput {
                 }
             })
             .collectMap(Map.Entry::getKey, Map.Entry::getValue);
+    }
+
+    private static boolean acceptsFileUpload(Type type) {
+        return type == Type.FILE;
+    }
+
+    /**
+     * Marks a value read from a multipart file part, so {@link #resolveInputs} can tell it apart
+     * from user-typed text before it reaches {@link #parseType}, without ever leaking the wrapper
+     * into a resolved input's value.
+     */
+    private record UploadedFile(String uri) {
     }
 
     public Map<String, Object> readExecutionInputs(
@@ -380,6 +398,15 @@ public class FlowInputOutput {
                 return resolvable.get();
             }
             resolvable.setInput(input);
+
+            // Reject a file upload bound to an input that doesn't accept one.
+            if (resolvable.isFromFileUpload() && !acceptsFileUpload(input.getType())) {
+                resolvable.resolveWithError(InputOutputValidationException.of(
+                    "A file upload is only accepted by an input of type FILE, but this input is of type %s.".formatted(input.getType()),
+                    input
+                ));
+                return resolvable.get();
+            }
 
             Object value = resolvable.get().value();
 
@@ -654,14 +681,22 @@ public class FlowInputOutput {
          * Specify whether the input's value is resoled.
          */
         private boolean isResolved;
+        /**
+         * Whether the raw value came from a multipart file part, as opposed to user-typed text.
+         */
+        private final boolean fromFileUpload;
 
         public static ResolvableInput of(@NotNull final Input<?> input, @Nullable final Object value) {
-            return new ResolvableInput(new InputAndValue(input, value), false);
+            if (value instanceof UploadedFile(String uri)) {
+                return new ResolvableInput(new InputAndValue(input, uri), false, true);
+            }
+            return new ResolvableInput(new InputAndValue(input, value), false, false);
         }
 
-        private ResolvableInput(InputAndValue input, boolean isResolved) {
+        private ResolvableInput(InputAndValue input, boolean isResolved, boolean fromFileUpload) {
             this.input = input;
             this.isResolved = isResolved;
+            this.fromFileUpload = fromFileUpload;
         }
 
         @Override
@@ -702,6 +737,10 @@ public class FlowInputOutput {
 
         public boolean isResolved() {
             return isResolved;
+        }
+
+        public boolean isFromFileUpload() {
+            return fromFileUpload;
         }
     }
 }

--- a/core/src/test/java/io/kestra/core/runners/FlowInputOutputTest.java
+++ b/core/src/test/java/io/kestra/core/runners/FlowInputOutputTest.java
@@ -10,11 +10,13 @@ import java.security.GeneralSecurityException;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Stream;
 
 import org.jetbrains.annotations.Nullable;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.reactivestreams.Publisher;
 
@@ -32,8 +34,10 @@ import io.kestra.core.models.flows.input.IonInput;
 import io.kestra.core.models.flows.input.MultiselectInput;
 import io.kestra.core.models.flows.input.ReusableInputsInput;
 import io.kestra.core.models.flows.input.SecretInput;
+import io.kestra.core.models.flows.input.SelectInput;
 import io.kestra.core.models.flows.input.StringInput;
 import io.kestra.core.models.flows.input.URIInput;
+import io.kestra.core.models.flows.input.YamlInput;
 import io.kestra.core.models.property.Property;
 import io.kestra.core.models.tasks.common.EncryptedString;
 import io.kestra.core.secret.SecretNotFoundException;
@@ -57,6 +61,7 @@ import reactor.core.publisher.Mono;
 
 import static io.kestra.core.tenant.TenantService.MAIN_TENANT;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @MicronautTest
 class FlowInputOutputTest {
@@ -768,6 +773,111 @@ class FlowInputOutputTest {
         // Then
         assertThat(result.get("upload")).isInstanceOf(URI.class);
         assertThat(result.get("upload").toString()).contains(executionId);
+    }
+
+    private static Stream<Input<?>> inputsThatDoNotAcceptFileUploads() {
+        return Stream.of(
+            IonInput.builder().id("upload").type(Type.ION).build(),
+            YamlInput.builder().id("upload").type(Type.YAML).build(),
+            StringInput.builder().id("upload").type(Type.STRING).build(),
+            SelectInput.builder().id("upload").type(Type.SELECT).build(),
+            EmailInput.builder().id("upload").type(Type.EMAIL).build(),
+            SecretInput.builder().id("upload").type(Type.SECRET).build(),
+            URIInput.builder().id("upload").type(Type.URI).build()
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("inputsThatDoNotAcceptFileUploads")
+    void shouldRejectFileUploadForEveryInputTypeOtherThanFile(Input<?> input) {
+        // Given
+        Publisher<CompletedPart> data = Mono.just(new MemoryCompletedFileUpload("upload", "data.txt", "content".getBytes(StandardCharsets.UTF_8)));
+
+        // When
+        List<InputAndValue> values = flowInputOutput.validateExecutionInputs(List.of(input), null, DEFAULT_TEST_EXECUTION, data).block();
+
+        // Then
+        assertThat(values).hasSize(1);
+        assertThat(values.getFirst().exceptions())
+            .as("a file upload for a %s input must be rejected", input.getType())
+            .isNotEmpty();
+        // the raw value must stay a plain String (the storage URI), never leak the internal upload marker
+        assertThat(values.getFirst().value()).isInstanceOf(String.class);
+    }
+
+    @Test
+    void shouldIgnoreFileUploadOnDisabledInputInsteadOfRejectingIt() {
+        // Given
+        StringInput trigger = StringInput.builder().id("trigger").build();
+        // disabled: dependsOn condition never matches
+        IonInput disabledPayload = IonInput.builder()
+            .id("payload")
+            .type(Type.ION)
+            .dependsOn(new DependsOn(List.of("trigger"), "{{ inputs.trigger equals 'enable-payload' }}"))
+            .build();
+        Publisher<CompletedPart> data = Flux.concat(
+            Mono.just(new MemoryCompletedPart("trigger", "something-else".getBytes(StandardCharsets.UTF_8))),
+            Mono.just(new MemoryCompletedFileUpload("payload", "data.ion", "{a:1}".getBytes(StandardCharsets.UTF_8)))
+        );
+
+        // When
+        List<InputAndValue> values = flowInputOutput.validateExecutionInputs(List.of(trigger, disabledPayload), null, DEFAULT_TEST_EXECUTION, data).block();
+
+        // Then: a disabled input is dropped like any other disabled input, not rejected for its stray file upload
+        InputAndValue payloadResult = values.stream().filter(it -> it.input().getId().equals("payload")).findFirst().orElseThrow();
+        assertThat(payloadResult.enabled()).isFalse();
+        assertThat(payloadResult.exceptions()).isNull();
+    }
+
+    @Test
+    void shouldStillAcceptFileUploadOnFileInputAlongsideOtherInputs() {
+        // Given
+        Flow flow = Flow.builder()
+            .id("test-flow")
+            .tenantId(MAIN_TENANT)
+            .namespace("io.kestra.test")
+            .inputs(
+                List.of(
+                    FileInput.builder().id("upload").type(Type.FILE).build(),
+                    StringInput.builder().id("comment").type(Type.STRING).build()
+                )
+            )
+            .build();
+
+        // When
+        Map<String, Object> result = flowInputOutput.readExecutionInputs(
+            flow,
+            IdUtils.create(),
+            Flux.concat(
+                Mono.just(new MemoryCompletedFileUpload("upload", "data.csv", "col1,col2".getBytes(StandardCharsets.UTF_8))),
+                Mono.just(new MemoryCompletedPart("comment", "hello".getBytes(StandardCharsets.UTF_8)))
+            )
+        ).block();
+
+        // Then
+        assertThat(result.get("upload")).isInstanceOf(URI.class);
+        assertThat(result.get("comment")).isEqualTo("hello");
+    }
+
+    @Test
+    void shouldNotFailWhenFlowHasNoDeclaredInputsAndAFileIsUploaded() {
+        // Given
+        Flow flow = Flow.builder()
+            .id("test-flow")
+            .tenantId(MAIN_TENANT)
+            .namespace("io.kestra.test")
+            .inputs(null)
+            .build();
+
+        // When: an undeclared-inputs flow must not NPE while looking up the (null) declared input list
+        Map<String, Object> outputs = flowInputOutput.readExecutionInputs(
+            flow,
+            IdUtils.create(),
+            Flux.just(new MemoryCompletedFileUpload("upload", "data.txt", "content".getBytes(StandardCharsets.UTF_8)))
+        ).block();
+
+        // Then: the upload is stored under an undeclared input id, which is a separate (pre-existing) warning path
+        assertThat(outputs).isEmpty();
     }
 
     @Test

--- a/core/src/test/resources/flows/valids/inputs-ion-file.yaml
+++ b/core/src/test/resources/flows/valids/inputs-ion-file.yaml
@@ -1,0 +1,11 @@
+id: inputs-ion-file
+namespace: io.kestra.tests
+
+inputs:
+  - id: payload
+    type: ION
+
+tasks:
+  - id: task
+    type: io.kestra.plugin.core.debug.Return
+    format: "{{ inputs.payload }}"

--- a/webserver/src/test/java/io/kestra/webserver/controllers/api/ExecutionControllerRunnerTest.java
+++ b/webserver/src/test/java/io/kestra/webserver/controllers/api/ExecutionControllerRunnerTest.java
@@ -449,6 +449,26 @@ class ExecutionControllerRunnerTest {
     }
 
     @Test
+    @LoadFlows(value = { "flows/valids/inputs-ion-file.yaml" }, tenantId = "ioninputfile")
+    void shouldRejectFileUploadOnIonInput() {
+        String tenantId = "ioninputfile";
+        when(tenantService.resolveTenant()).thenReturn(tenantId);
+        MultipartBody requestBody = MultipartBody.builder()
+            .addPart("payload", "data.ion", MediaType.TEXT_PLAIN_TYPE, "{name:\"Ada\"}".getBytes(StandardCharsets.UTF_8))
+            .build();
+
+        HttpClientResponseException e = assertThrows(
+            HttpClientResponseException.class,
+            () -> triggerExecutionExecution(tenantId, TESTS_FLOW_NS, "inputs-ion-file", requestBody, false)
+        );
+
+        String response = e.getResponse().getBody(String.class).orElseThrow();
+
+        assertThat(response).contains("Invalid entity");
+        assertThat(response).contains("Invalid value for input `payload`");
+    }
+
+    @Test
     @LoadFlows(value = { "flows/valids/inputs.yaml" }, tenantId = "triggerexecutionandwait")
     void triggerExecutionAndWait() {
         String tenantId = "triggerexecutionandwait";


### PR DESCRIPTION
## Summary

- Fixes kestra-io/kestra-ee#9896: starting an execution through the API (which the generated SDK also uses) with a file uploaded for a flow input declared `type: ION` silently ran with the value `"kestra"` instead of the file's contents. Nothing warned the user.
- Root cause: `FlowInputOutput.readData()` bound any multipart file part to any input regardless of its declared type — it just wrote the bytes to storage and handed the resulting `kestra://...` URI string to whatever parser the declared type selects. For `JSON` that string fails to parse and the execution is correctly refused; for `ION` the lenient Ion parser reads only the first token — `kestra` is a valid Ion symbol — and silently returns `"kestra"`, discarding the rest.
- Fix: a file upload is now only accepted for inputs declared `type: FILE`. Every other type is rejected with a clear per-input validation error (422)

## Test plan

- [x] `core/src/test/java/io/kestra/core/runners/FlowInputOutputTest.java` — new tests: exact bug regression (ION input + uploaded file → rejected, not `"kestra"`), a parameterized rejection matrix across `ION`/`YAML`/`STRING`/`SELECT`/`EMAIL`/`SECRET`/`URI` asserting the value stays a plain `String` (no internal-marker leak), a `FILE` input still accepting an upload alongside another input, an undeclared-inputs flow not NPEing, and a `dependsOn`-disabled input with a stray file part being ignored rather than rejected.
- [x] `webserver/src/test/java/io/kestra/webserver/controllers/api/ExecutionControllerRunnerTest.java` — new end-to-end test posting a real multipart file to an `ION` input and asserting a 422 response, using new fixture `core/src/test/resources/flows/valids/inputs-ion-file.yaml`.