### PR TITLE
fix(design-system): bundle component locales instead of chunking them

### DIFF
--- a/ui/packages/design-system/src/i18n/index.ts
+++ b/ui/packages/design-system/src/i18n/index.ts
@@ -8,13 +8,17 @@ export function setDesignSystemLocale(locale: string) {
     designSystemLocale.value = locale
 }
 
+// Eager: a lazy glob makes every locale file its own dynamic-import boundary, so the bundler
+// emits one chunk per file and the app fetches them serially before it can render anything.
 const localeModules = import.meta.glob<{default: Record<string, object>}>(
     "../components/**/*.locale.ts",
+    {eager: true},
 )
 
-export async function registerDesignSystemI18n(i18n: I18n) {
-    for (const loadMod of Object.values(localeModules)) {
-        const mod = await loadMod()
+/** Merges the component locale files into the app messages. Synchronous, so callers cannot
+ * render before the design-system keys exist. */
+export function registerDesignSystemI18n(i18n: I18n) {
+    for (const mod of Object.values(localeModules)) {
         for (const [lang, messages] of Object.entries(mod.default)) {
             i18n.global.mergeLocaleMessage(lang, messages)
         }

--- a/ui/packages/design-system/src/index.ts
+++ b/ui/packages/design-system/src/index.ts
@@ -464,7 +464,7 @@ const KestraDesignSystem = {
 
         const symbol = (app as unknown as {__VUE_I18N_SYMBOL__?: symbol}).__VUE_I18N_SYMBOL__
         const i18n = symbol ? (app._context.provides[symbol] as I18n | undefined) : undefined
-        if (i18n) void registerDesignSystemI18n(i18n)
+        if (i18n) registerDesignSystemI18n(i18n)
     },
 }
 

--- a/ui/src/utils/init.ts
+++ b/ui/src/utils/init.ts
@@ -123,7 +123,7 @@ export default async (
 
     // Merge design-system locales before first render, so parent computeds
     // that call t() on design-system keys don't cache the raw key.
-    await registerDesignSystemI18n(i18n)
+    registerDesignSystemI18n(i18n)
 
     if(locale !== "en"){
         // FIXME: any - loadLocaleMessages/setI18nLanguage expect literal locale types

--- a/ui/tests/unit/designSystem/i18n.spec.ts
+++ b/ui/tests/unit/designSystem/i18n.spec.ts
@@ -1,0 +1,25 @@
+import {describe, expect, it} from "vitest"
+import {mount} from "@vue/test-utils"
+import {createI18n} from "vue-i18n"
+import KestraDesignSystem, {registerDesignSystemI18n} from "@kestra-io/design-system"
+import KsEmpty from "@kestra-io/design-system/components/Data/KsEmpty.vue"
+
+const mountKsEmpty = (locale: string) => {
+    const i18n = createI18n({legacy: false, locale, messages: {}})
+
+    // No await: the merge has to be done by the time the first render reads t(),
+    // or parent computeds cache the raw key.
+    registerDesignSystemI18n(i18n)
+
+    return mount(KsEmpty, {global: {plugins: [i18n, KestraDesignSystem]}})
+}
+
+describe("registerDesignSystemI18n", () => {
+    it("renders a design-system string on first render", () => {
+        expect(mountKsEmpty("en").text()).toContain("Looks like there's nothing here")
+    })
+
+    it("renders a design-system string translated for a non-English locale", () => {
+        expect(mountKsEmpty("fr").text()).toContain("On dirait qu'il n'y a rien ici")
+    })
+})


### PR DESCRIPTION
### ✨ Description

Eager-globs the design-system `*.locale.ts` files so they compile into the design-system chunk, and makes `registerDesignSystemI18n` synchronous.

The lazy glob made every locale file a dynamic-import boundary: one chunk per file, fetched serially before `app.mount()`. Today only the `consolidateChunks` design-system group keeps them out of the shipped build — remove that group and all 8 requests come back. Eager makes it structural, and the synchronous merge also fixes the fire-and-forget `void registerDesignSystemI18n(i18n)` on the plugin install path.

Per-language splitting was measured and rejected: all 13 languages are 46 KB gzipped total, and the authoring format (one file, all languages) is what the translation generator/checker and `fingerprints-design-system.json` consume.

Production build, cold boot in Chromium up to mount (uncompressed, static server):

| | chunks | modulepreload | first-paint requests | first-paint bytes |
|---|---|---|---|---|
| before | 296 | 8 | 55 | 5,399,966 |
| after | 296 | 8 | 55 | 5,399,432 |

Unchanged, as expected — the group already merged them. Mechanism check with `consolidateChunks()` disabled: lazy emits `KsEmpty.locale-*.js`, `KsFilter.locale-*.js`, … (8 chunks, 185 first-paint requests, 6 locale fetches before mount); eager emits none.

### 🔗 Related Issue

Closes https://github.com/kestra-io/kestra-ee/issues/9948.

### 🎨 Frontend Checklist

- [x] Code builds without errors (`npm run build`)
- [x] `npm run check:types`, `npm run test:unit` (187 files / 1766 tests), design-system `unit:test` (96 files / 778 tests) pass
- [ ] Screenshots — no visual change

### 📝 Additional Notes

New test `ui/tests/unit/designSystem/i18n.spec.ts` mounts `KsEmpty` right after `registerDesignSystemI18n` with no await and asserts the label is translated in `en` and `fr`; it fails against the old lazy implementation. Verified in the built app too: `$t("no_data")` at mount resolves to the French and Japanese strings.

### 🤖 AI Authors

Why did the cat sit on the bundler? It heard there were too many chunks and only one of them was tuna. 🐱

---
_Generated by [Claude Code](https://claude.ai/code/session_01DkqRmhps1ycqPuFUvg7m79)_