### PR TITLE
fix(system): bound webserver direct memory and plugin-derived caches

### DIFF
--- a/charts/kestra/README.md
+++ b/charts/kestra/README.md
@@ -338,6 +338,7 @@ JDBC queue tables — this is irreversible. Back up your database before upgradi
 | common.extraVolumeMounts | list | `[]` | Extra volume mounts to add to containers. |
 | common.extraVolumes | list | `[]` | Extra volumes to add to pods. |
 | common.initContainers | list | `[]` | Additional init containers to run before main container. |
+| common.jvm.extraOpts | string | `""` | Extra JVM options, injected through `_JAVA_OPTIONS` so they override the image defaults (`-XX:MaxRAMPercentage=50.0` and `-XX:MaxDirectMemorySize=256M`). Raise `-XX:MaxDirectMemorySize` here if a component needs more direct memory than the 256M default. |
 | common.jvm.forceActiveProcessors | object | `{"count":"auto","enabled":false,"value":2}` | Sometimes you can have problems with cgroup and cpu limits, then you can force the JVM to use a specific number of processors. |
 | common.kind | string | `"Deployment"` | Kind of deployment (Deployment or StatefulSet). |
 | common.labels | object | `{}` | Labels applied to all resources. |
@@ -461,7 +462,6 @@ JDBC queue tables — this is irreversible. Back up your database before upgradi
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| common.jvm.extraOpts | string | `""` |  |
 | common.updateStrategy | object | `{}` | StatefulSet update strategy. |
 | extraManifests | list | `[]` | Extra Kubernetes manifests to deploy with the chart. |
 | fullnameOverride | string | `""` |  |

--- a/charts/kestra/values.yaml
+++ b/charts/kestra/values.yaml
@@ -166,6 +166,8 @@ common:
       enabled: false
       count: 'auto' # 'auto' or 'value'
       value: 2 # used if count is 'value'
+    # -- Extra JVM options, injected through `_JAVA_OPTIONS` so they override the image defaults (`-XX:MaxRAMPercentage=50.0` and `-XX:MaxDirectMemorySize=256M`). Raise `-XX:MaxDirectMemorySize` here if a component needs more direct memory than the 256M default.
+    # @section -- common settings
     # extraOpts is empty to keep the value deterministic
     extraOpts: ""
 ### -------------------------------

--- a/cli/src/main/resources/application.yml
+++ b/cli/src/main/resources/application.yml
@@ -64,8 +64,10 @@ micronaut:
       filter:
         enabled: false
   caches:
+    # Entries are weighed by their serialized JSON size (io.kestra.webserver.cache.JsonBytesCacheWeigher),
+    # so maximum-weight is a byte bound rather than an entry count.
     default:
-      maximum-weight: 10485760
+      maximum-weight: 67108864
     # One cache per icon index: the methods behind them take no argument, so they all resolve to the same cache
     # key and sharing a cache would make them serve each other's entries. Each therefore holds a single entry.
     plugin-icons:

--- a/core/src/main/java/io/kestra/core/docs/JsonSchemaCache.java
+++ b/core/src/main/java/io/kestra/core/docs/JsonSchemaCache.java
@@ -1,12 +1,15 @@
 package io.kestra.core.docs;
 
+import java.time.Duration;
 import java.util.EnumMap;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicLong;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.Ticker;
 
 import io.kestra.core.models.dashboards.Dashboard;
 import io.kestra.core.models.flows.Flow;
@@ -14,19 +17,29 @@ import io.kestra.core.models.tasks.Task;
 import io.kestra.core.models.triggers.AbstractTrigger;
 import io.kestra.core.plugins.PluginRegistry;
 
+import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 
 /**
  * Service for getting schemas.
+ * <p>
+ * Cached schemas are bounded: a single entry (e.g. the Flow schema over a full plugin set) can weigh tens of
+ * megabytes, so entries idle for {@link #IDLE_EXPIRY} are released instead of being held for the JVM lifetime.
  */
 @Singleton
 public class JsonSchemaCache {
 
+    // A schema left unread for this long is regenerated on the next request rather than kept on heap forever.
+    private static final Duration IDLE_EXPIRY = Duration.ofHours(1);
+
+    // The key domains (SchemaType x arrayOf) are small; this is a backstop should they ever grow.
+    private static final long MAXIMUM_ENTRIES = 32;
+
     private final JsonSchemaGenerator jsonSchemaGenerator;
     private final PluginRegistry pluginRegistry;
 
-    private final ConcurrentMap<CacheKey, Map<String, Object>> schemaCache = new ConcurrentHashMap<>();
-    private final ConcurrentMap<SchemaType, Map<String, Object>> propertiesCache = new ConcurrentHashMap<>();
+    private final Cache<CacheKey, Map<String, Object>> schemaCache;
+    private final Cache<SchemaType, Map<String, Object>> propertiesCache;
 
     private final Map<SchemaType, Class<?>> classesBySchemaType = new EnumMap<>(SchemaType.class);
 
@@ -41,9 +54,25 @@ public class JsonSchemaCache {
      * @param jsonSchemaGenerator The {@link JsonSchemaGenerator}.
      * @param pluginRegistry      The {@link PluginRegistry} whose content the cached schemas depend on.
      */
+    @Inject
     public JsonSchemaCache(final JsonSchemaGenerator jsonSchemaGenerator, final PluginRegistry pluginRegistry) {
+        this(jsonSchemaGenerator, pluginRegistry, Ticker.systemTicker());
+    }
+
+    // Visible for tests, so idle expiry can be exercised with a controlled ticker.
+    JsonSchemaCache(final JsonSchemaGenerator jsonSchemaGenerator, final PluginRegistry pluginRegistry, final Ticker ticker) {
         this.jsonSchemaGenerator = Objects.requireNonNull(jsonSchemaGenerator, "JsonSchemaGenerator cannot be null");
         this.pluginRegistry = Objects.requireNonNull(pluginRegistry, "PluginRegistry cannot be null");
+        this.schemaCache = Caffeine.newBuilder()
+            .expireAfterAccess(IDLE_EXPIRY)
+            .maximumSize(MAXIMUM_ENTRIES)
+            .ticker(ticker)
+            .build();
+        this.propertiesCache = Caffeine.newBuilder()
+            .expireAfterAccess(IDLE_EXPIRY)
+            .maximumSize(MAXIMUM_ENTRIES)
+            .ticker(ticker)
+            .build();
         registerClassForType(SchemaType.FLOW, Flow.class);
         registerClassForType(SchemaType.TASK, Task.class);
         registerClassForType(SchemaType.TRIGGER, AbstractTrigger.class);
@@ -53,7 +82,7 @@ public class JsonSchemaCache {
     public Map<String, Object> getSchemaForType(final SchemaType type,
         final boolean arrayOf) {
         invalidateIfPluginRegistryChanged();
-        return schemaCache.computeIfAbsent(new CacheKey(type, arrayOf), key ->
+        return schemaCache.get(new CacheKey(type, arrayOf), key ->
         {
 
             Class<?> cls = Optional.ofNullable(classesBySchemaType.get(type))
@@ -64,7 +93,7 @@ public class JsonSchemaCache {
 
     public Map<String, Object> getPropertiesForType(final SchemaType type) {
         invalidateIfPluginRegistryChanged();
-        return propertiesCache.computeIfAbsent(type, key ->
+        return propertiesCache.get(type, key ->
         {
 
             Class<?> cls = Optional.ofNullable(classesBySchemaType.get(type))
@@ -91,8 +120,8 @@ public class JsonSchemaCache {
     }
 
     public void clear() {
-        schemaCache.clear();
-        propertiesCache.clear();
+        schemaCache.invalidateAll();
+        propertiesCache.invalidateAll();
     }
 
     private record CacheKey(SchemaType type, boolean arrayOf) {

--- a/core/src/test/java/io/kestra/core/docs/JsonSchemaCacheTest.java
+++ b/core/src/test/java/io/kestra/core/docs/JsonSchemaCacheTest.java
@@ -1,6 +1,10 @@
 package io.kestra.core.docs;
 
+import java.time.Duration;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicLong;
+
+import com.github.benmanes.caffeine.cache.Ticker;
 
 import io.kestra.core.plugins.PluginRegistry;
 
@@ -53,6 +57,28 @@ class JsonSchemaCacheTest {
         assertThat(first).containsEntry("version", "1");
         assertThat(cached).containsEntry("version", "1");
         assertThat(afterChange).containsEntry("version", "2");
+        verify(generator, times(2)).schemas(any(), anyBoolean());
+    }
+
+    @Test
+    void shouldRegenerateSchemaWhenEntryWasIdleLongerThanExpiry() {
+        // Given: a controlled clock so idle expiry can be simulated
+        JsonSchemaGenerator generator = mock(JsonSchemaGenerator.class);
+        PluginRegistry registry = mock(PluginRegistry.class);
+        when(generator.schemas(any(), anyBoolean())).thenReturn(Map.of("version", "1"));
+        when(registry.hash()).thenReturn(1L);
+        AtomicLong nanos = new AtomicLong();
+        Ticker ticker = nanos::get;
+        JsonSchemaCache cache = new JsonSchemaCache(generator, registry, ticker);
+
+        // When: a second read within the idle window, then a third one after two hours of idleness
+        cache.getSchemaForType(SchemaType.FLOW, false);
+        nanos.addAndGet(Duration.ofMinutes(30).toNanos());
+        cache.getSchemaForType(SchemaType.FLOW, false);
+        nanos.addAndGet(Duration.ofHours(2).toNanos());
+        cache.getSchemaForType(SchemaType.FLOW, false);
+
+        // Then: the idle entry is released and regenerated on the next request
         verify(generator, times(2)).schemas(any(), anyBoolean());
     }
 }

--- a/gradle/jar/selfrun.bat
+++ b/gradle/jar/selfrun.bat
@@ -90,7 +90,9 @@ SET "JAVA_ADD_OPENS=--add-opens java.base/java.nio=ALL-UNNAMED --add-opens java.
 
 REM Java options that Kestra engineers think are best for Kestra, they should be added before JAVA_OPTS so they are overridable:
 REM -XX:MaxRAMPercentage=50.0: configure max heap to 50% of available RAM (default 25%)
-SET "KESTRA_JAVA_OPTS=-XX:MaxRAMPercentage=50.0"
+REM -XX:MaxDirectMemorySize=256M: cap direct (off-heap) memory; when unset the JVM defaults it to the max heap size,
+REM letting Netty's pooled direct arenas silently double the process footprint under load
+SET "KESTRA_JAVA_OPTS=-XX:MaxRAMPercentage=50.0 -XX:MaxDirectMemorySize=256M"
 
 java %KESTRA_JAVA_OPTS% %JAVA_OPTS% %JAVA_ADD_OPENS% --enable-native-access=ALL-UNNAMED -jar "%this%" %*
 

--- a/gradle/jar/selfrun.sh
+++ b/gradle/jar/selfrun.sh
@@ -36,7 +36,9 @@ fi
 
 # Java options that Kestra engineers think are best for Kestra, they should be added before JAVA_OPTS so they are overridable:
 # -XX:MaxRAMPercentage=50.0: configure max heap to 50% of available RAM (default 25%)
-KESTRA_JAVA_OPTS="-XX:MaxRAMPercentage=50.0"
+# -XX:MaxDirectMemorySize=256M: cap direct (off-heap) memory; when unset the JVM defaults it to the max heap size,
+# letting Netty's pooled direct arenas silently double the process footprint under load
+KESTRA_JAVA_OPTS="-XX:MaxRAMPercentage=50.0 -XX:MaxDirectMemorySize=256M"
 
 # Exec
 exec java ${KESTRA_JAVA_OPTS} ${JAVA_OPTS} ${JAVA_ADD_OPENS} ${JAVA_UNSAFE_MEMORY_ACCESS} --enable-native-access=ALL-UNNAMED -jar "$0" "$@"

--- a/webserver/src/main/java/io/kestra/webserver/cache/JsonBytesCacheWeigher.java
+++ b/webserver/src/main/java/io/kestra/webserver/cache/JsonBytesCacheWeigher.java
@@ -1,0 +1,62 @@
+package io.kestra.webserver.cache;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.benmanes.caffeine.cache.Weigher;
+import io.kestra.core.serializers.JacksonMapper;
+import jakarta.inject.Named;
+import jakarta.inject.Singleton;
+import lombok.extern.slf4j.Slf4j;
+
+import java.io.IOException;
+import java.io.OutputStream;
+
+/**
+ * Weighs entries of the {@code default} Micronaut cache by their serialized JSON size in bytes, so that
+ * {@code micronaut.caches.default.maximum-weight} is an actual byte bound.
+ * <p>
+ * Without a {@link Weigher} bean named after the cache, Caffeine falls back to
+ * {@link Weigher#singletonWeigher()} which counts every entry as 1, turning the configured
+ * maximum weight into an entry count instead of a byte budget.
+ */
+@Slf4j
+@Singleton
+@Named(JsonBytesCacheWeigher.CACHE_NAME)
+public class JsonBytesCacheWeigher implements Weigher<Object, Object> {
+
+    public static final String CACHE_NAME = "default";
+
+    // Entries that cannot be serialized fall back to a fixed weight instead of failing the cache write.
+    static final int FALLBACK_WEIGHT = 1024;
+
+    private static final ObjectMapper MAPPER = JacksonMapper.ofJson();
+
+    @Override
+    public int weigh(final Object key, final Object value) {
+        try {
+            CountingOutputStream out = new CountingOutputStream();
+            MAPPER.writeValue(out, value);
+            return (int) Math.min(out.count, Integer.MAX_VALUE);
+        } catch (IOException e) {
+            log.warn("Cannot weigh cache entry of type '{}': falling back to a weight of {} bytes.",
+                value == null ? "null" : value.getClass().getName(), FALLBACK_WEIGHT, e);
+            return FALLBACK_WEIGHT;
+        }
+    }
+
+    /**
+     * Counts written bytes without buffering them, so weighing a multi-megabyte entry allocates nothing.
+     */
+    private static final class CountingOutputStream extends OutputStream {
+        private long count;
+
+        @Override
+        public void write(final int b) {
+            count++;
+        }
+
+        @Override
+        public void write(final byte[] b, final int off, final int len) {
+            count += len;
+        }
+    }
+}

--- a/webserver/src/test/java/io/kestra/webserver/cache/JsonBytesCacheWeigherTest.java
+++ b/webserver/src/test/java/io/kestra/webserver/cache/JsonBytesCacheWeigherTest.java
@@ -1,0 +1,44 @@
+package io.kestra.webserver.cache;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class JsonBytesCacheWeigherTest {
+
+    private final JsonBytesCacheWeigher weigher = new JsonBytesCacheWeigher();
+
+    @Test
+    void shouldWeighEntriesByTheirSerializedJsonSizeWhenValueIsSerializable() {
+        // Given
+        Map<String, String> small = Map.of("icon", "a".repeat(100));
+        Map<String, String> large = Map.of("icon", "a".repeat(100_000));
+
+        // When
+        int smallWeight = weigher.weigh("key", small);
+        int largeWeight = weigher.weigh("key", large);
+
+        // Then: weights track the serialized byte size, not a per-entry constant
+        assertThat(smallWeight).isGreaterThan(100).isLessThan(1_000);
+        assertThat(largeWeight).isGreaterThan(100_000);
+    }
+
+    @Test
+    void shouldFallBackToFixedWeightWhenValueCannotBeSerialized() {
+        // Given: a value whose serialization fails
+        Object unserializable = new Object() {
+            @SuppressWarnings("unused")
+            public String getBroken() {
+                throw new IllegalStateException("boom");
+            }
+        };
+
+        // When
+        int weight = weigher.weigh("key", unserializable);
+
+        // Then
+        assertThat(weight).isEqualTo(JsonBytesCacheWeigher.FALLBACK_WEIGHT);
+    }
+}

--- a/webserver/src/test/java/io/kestra/webserver/cache/JsonBytesCacheWeigherWiringTest.java
+++ b/webserver/src/test/java/io/kestra/webserver/cache/JsonBytesCacheWeigherWiringTest.java
@@ -1,0 +1,40 @@
+package io.kestra.webserver.cache;
+
+import java.util.Map;
+
+import com.github.benmanes.caffeine.cache.Cache;
+
+import io.kestra.core.junit.annotations.KestraTest;
+import io.micronaut.cache.CacheManager;
+import io.micronaut.cache.SyncCache;
+import io.micronaut.context.annotation.Property;
+
+import org.junit.jupiter.api.Test;
+
+import jakarta.inject.Inject;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@KestraTest
+@Property(name = "micronaut.caches.default.maximum-weight", value = "67108864")
+class JsonBytesCacheWeigherWiringTest {
+
+    @Inject
+    private CacheManager<Object> cacheManager;
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void shouldUseJsonBytesWeigherForDefaultCacheWhenMaximumWeightIsConfigured() {
+        // Given
+        SyncCache<Object> cache = cacheManager.getCache(JsonBytesCacheWeigher.CACHE_NAME);
+        Cache<Object, Object> nativeCache = (Cache<Object, Object>) cache.getNativeCache();
+
+        // When
+        nativeCache.put("key", Map.of("payload", "x".repeat(50_000)));
+        nativeCache.cleanUp();
+
+        // Then: with the singleton weigher the weighted size would be 1, with the byte weigher it tracks bytes
+        long weightedSize = nativeCache.policy().eviction().orElseThrow().weightedSize().getAsLong();
+        assertThat(weightedSize).isGreaterThan(50_000L);
+    }
+}


### PR DESCRIPTION
### ✨ Description

Two independent memory ceilings:

- **Direct memory**: `selfrun.sh`/`.bat` set `-XX:MaxRAMPercentage=50.0` with no `-XX:MaxDirectMemorySize`, so the JVM caps direct memory at the max heap size and Netty's pooled arenas can silently double the pod footprint. Now defaults to `256M`, overridable via `JAVA_OPTS` / `_JAVA_OPTIONS`; documented in the Helm chart (`common.jvm.extraOpts`).
- **Caches**: `micronaut.caches.default.maximum-weight: 10485760` had no weigher, so Caffeine weighed every entry as 1 — the declared bound acted as a ~10M-*entry* cache while the bytes stayed unbounded. Added a `@Named("default")` `Weigher` that weighs entries by serialized JSON size, so the bound means what it says (raised to 64MiB). `JsonSchemaCache` (multi-MB schemas held for the JVM lifetime) is now a bounded Caffeine cache with 1h idle expiry.

⚠️ **Sequencing**: capping direct memory converts silent bloat into explicit OOMs under the same first-load burst — this must land **together with or after** kestra-io/kestra-ee#9949, never before it.

Before/after RSS/heap/NMT numbers on a full 213-plugin set: [measurement comment on the issue](https://github.com/kestra-io/kestra-ee/issues/9950#issuecomment-5296317390). Headline: plugin *instances* account for &lt;1MiB of the ~1GiB baseline (894 instances), so the lazy-registration idea in the issue is deliberately **not** attempted here — the cost is classloading + jar ZIP directories, not instantiation.

### 🔗 Related Issue

Part of https://github.com/kestra-io/kestra-ee/issues/9950.

### 🛠️ Backend Checklist

- [x] Code compiles successfully and passes all checks
- [x] All unit and integration tests pass — CI on the current head `49e6514`: **8130 tests, 0 failed** (core 3354, webserver 1184), flaky suite 10/10, and `kestra-ee/backend-tests` green. Covers the new `JsonSchemaCacheTest` idle-expiry case, `JsonBytesCacheWeigherTest`, `JsonBytesCacheWeigherWiringTest`, and `PluginControllerTest` unchanged.

### 📝 Additional Notes

**Interaction with #18586** (*"stop inlining icon bytes in the bulk plugin icon indexes"*, merged while this was open): that change moved the icon indexes out of `default` into four dedicated `maximum-size: 1` caches and made them metadata-only. Two consequences, both handled in the rebase:

- The two changes compose without interference — Micronaut only attaches a `Weigher` when `maximum-weight` is set (`DefaultSyncCache#buildCache`), and the four new caches are bounded by `maximum-size`, so the `default`-named weigher here can never bind to them. `PluginControllerTest` passes unchanged.
- The 22.9MB icons index in my measurement comment is now **historical**: post-#18586 those routes return metadata only. It is no longer what `default` is sized for, so the config comment no longer claims it. The weigher is still needed — `default` still holds the per-input-type documentation entries and still had no weigher. Correction posted on the issue [here](https://github.com/kestra-io/kestra-ee/issues/9950#issuecomment-5412121595).

Rebased twice onto a moving `develop` (`933b197` → `40e88b1` → `aeb668b`). Conflicts were `JsonSchemaCache.java` against c7e4859 (*use EnumMap instead of HashMap*), resolved by keeping upstream's `EnumMap` alongside this branch's `Duration`/Caffeine changes, and `application.yml` against #18586, resolved by keeping upstream's four icon caches alongside the byte bound here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mj48nFoMFCvbynnRcWcjrY