### PR TITLE
perf(ui): bundle only 1970-2030 of the moment-timezone database

### DIFF
--- a/ui/tests/unit/utils/momentTimezoneData.spec.ts
+++ b/ui/tests/unit/utils/momentTimezoneData.spec.ts
@@ -1,0 +1,47 @@
+import {describe, it, expect} from "vitest"
+import moment from "moment-timezone"
+
+// vite.config.js aliases moment-timezone to the 1970-2030 build to keep the full IANA
+// database out of the boot chunk. These guard the two things that trade-off can break:
+// the zone list the timezone picker renders, and offset accuracy inside the window.
+describe("moment-timezone bundled data", () => {
+    const DATA_RANGE_END = 2030
+
+    it("should expose the full zone list for the timezone picker", () => {
+        const names = moment.tz.names()
+
+        expect(names.length).toBeGreaterThan(500)
+        expect(names).toContain("Europe/Paris")
+        expect(names).toContain("America/New_York")
+        expect(names).toContain("Asia/Tokyo")
+        expect(names).toContain("Australia/Sydney")
+    })
+
+    it.each([
+        // Historical dates matter: executions and backfills are displayed in the user's timezone.
+        ["2015-07-01", "Europe/Paris", "+02:00"],
+        ["2015-01-01", "Europe/Paris", "+01:00"],
+        ["2015-07-01", "America/New_York", "-04:00"],
+        ["2015-01-01", "America/New_York", "-05:00"],
+        ["2015-07-01", "Australia/Sydney", "+10:00"],
+        // France had no summer time between 1946 and 1976, so this only passes with real
+        // historical rules rather than today's rule projected backwards.
+        ["1975-07-01", "Europe/Paris", "+01:00"],
+        ["1980-07-01", "Europe/Paris", "+02:00"],
+        ["2024-07-01", "Europe/Paris", "+02:00"],
+        ["2029-07-01", "Europe/Paris", "+02:00"],
+    ])("should resolve the DST offset for %s in %s", (date, zone, expected) => {
+        expect(moment.tz(date, zone).format("Z")).toBe(expected)
+    })
+
+    // The bundled data stops at 2030. Fail while there is still room to react, rather than
+    // silently rendering standard time for in-range dates once the window is passed.
+    it("should still cover dates two years out", () => {
+        const twoYearsOut = moment().add(2, "years")
+
+        expect(
+            twoYearsOut.year(),
+            `moment-timezone data stops at ${DATA_RANGE_END}; switch the vite.config.js alias to a wider build`,
+        ).toBeLessThanOrEqual(DATA_RANGE_END)
+    })
+})

--- a/ui/vite.config.js
+++ b/ui/vite.config.js
@@ -84,6 +84,15 @@ export default defineConfig(({mode}) => {
             dedupe: ["echarts", "vue-echarts", "dayjs", "vue", "vue-router", "vue-i18n", "@vueuse/core", "pinia", "@vue-flow/core", "@vue-flow/background", "@vue-flow/controls"],
             alias: [
                 {find: "override", replacement: path.resolve(__dirname, "src/override/")},
+                // moment-timezone's default entry bundles the whole IANA database (705 kB of
+                // JSON, 1900-2100) into the eager boot chunk. The 1970-2030 build carries the
+                // same 597 zone names and identical offsets across that window; see
+                // tests/unit/utils/momentTimezoneData.spec.ts, which fails once "now" gets
+                // close enough to 2030 that the range must be widened.
+                {
+                    find: /^moment-timezone$/,
+                    replacement: path.resolve(__dirname, "node_modules/moment-timezone/builds/moment-timezone-with-data-1970-2030.js"),
+                },
             ],
         },
         plugins: [


### PR DESCRIPTION
### ✨ Description

`moment-timezone`'s default entry pulls `data/packed/latest.json` — **705 kB of IANA data covering 1900–2100** — into the eager boot chunk, via `src/utils/init.ts`. The `1970-2030` prebuilt carries the **same 597 zone names** and **identical offsets** across that window.

Aliased in `vite.config.js` rather than edited at the nine import sites. The alias also covers the design-system and topology packages and anything added later, so a new `import "moment-timezone"` cannot quietly restore the full database — which is the failure mode nine scattered edits would have.

### ⚠️ Read this before approving: the win is parse time, not transfer

Packed timezone data compresses about **17:1**, so most of the headline number never crossed the wire:

| | raw | gzip | brotli |
|---|---|---|---|
| full (current) | 723 kB | 41 kB | 27 kB |
| 1970-2030 | 144 kB | 22 kB | 18 kB |
| **saving** | **579 kB** | **19 kB** | **9 kB** |

So this removes **579 kB of JavaScript the browser must parse, compile and hold in memory at boot**, for roughly **19 kB** of download. That is still worth having — parse cost is real on low-end devices — but it is not a 700 kB transfer win, and if the trade isn't worth the 2030 ceiling to you, this is a reasonable PR to close.

Login route, cold boot in Chromium (uncompressed, static server):

| | requests | raw bytes |
|---|---|---|
| before | 43 | 5,399,544 |
| after | 43 | **4,806,894** |

`vendor` chunk: 2,557 kB → 1,978 kB.

### 🕒 Why 1970-2030 and not the 54 kB build

`moment-timezone` also ships a `10-year-range` build at 54 kB. It is **wrong for past dates**, which matters here because executions and backfills are rendered in the user's timezone. Verified against the full dataset:

| date / zone | full | 1970-2030 | 10-year |
|---|---|---|---|
| 2005-07-01 Europe/Paris | +02:00 | +02:00 | ❌ +01:00 |
| 2015-07-01 Europe/Paris | +02:00 | +02:00 | ❌ +01:00 |
| 2015-07-01 America/New_York | −04:00 | −04:00 | ❌ −05:00 |
| 2015-07-01 Australia/Sydney | +10:00 | +10:00 | ❌ +11:00 |
| 2035-07-01 Europe/Paris | +02:00 | ❌ +01:00 | ❌ +01:00 |

All three builds expose all 597 zone names, so the timezone picker in `BasicSettings.vue` is unaffected either way.

**The known limit:** dates after 2030 resolve to standard time instead of DST — a one-hour display error. `tests/unit/utils/momentTimezoneData.spec.ts` fails once "now" comes within two years of 2030, so the range gets widened while there is still room to react rather than silently degrading.

### 🎨 Frontend Checklist

- [x] Code builds without errors (`npm run build`)
- [x] `npm run check:types` — design-system compiled, app checked, test checked
- [x] `npm run test:unit` — 187 files / 1775 tests
- [ ] Screenshots — no visual change

### 📝 Additional Notes

The new test asserts real historical rules, not today's rule projected backwards: France had no summer time between 1946 and 1976, so `1975-07-01 Europe/Paris` is `+01:00`. I had that expectation wrong at first and the bundled data corrected me — worth keeping as a regression anchor.

**EE is not covered.** `ui-ee/vite.config.js` has its own `resolve` block and would need the same alias to benefit; happy to raise the companion if this direction is accepted.

Found while attributing the login route's boot bytes after kestra-io/kestra-ee#9952. The larger item in that profile is `element-plus` at ~19% of boot JS, which is a separate PR.

### 🤖 AI Authors

The cat has reviewed the timezone data and reports she observes exactly two: dinner time, and not-dinner time. Neither requires 705 kB. 🐱

---
_Generated by [Claude Code](https://claude.ai/code/session_01AkcKnwmzDM7tBgT3XC9xwZ)_