### PR TITLE
perf(design-system): install only Element Plus's global config, not its components

### DIFF
--- a/ui/.storybook/preview.jsx
+++ b/ui/.storybook/preview.jsx
@@ -8,6 +8,7 @@ import {configureClient, useClient} from "@kestra-io/kestra-sdk";
 import axios from "axios";
 import {createMemoryHistory} from "vue-router";
 import {vueRouter} from "storybook-vue3-router";
+import ElementPlus from "element-plus";
 
 import "../src/styles/vendor.scss";
 import "../src/styles/app.scss";
@@ -95,6 +96,15 @@ const preview = {
 };
 
 setup(async (app) => {
+  // Storybook only: several fixtures (theme/ShowCase.vue above all) render raw `<el-*>` tags
+  // on purpose, to exercise Element Plus theming. The app itself never does, so the design
+  // system installs only Element Plus's global config and lets the unused components
+  // tree-shake. Registering them here keeps those fixtures rendering.
+  // Must precede initApp: Element Plus's installer no-ops once INSTALLED_KEY is set, and the
+  // design system sets it. Installing first also means the design system skips its own
+  // provideGlobalConfig, since this call already supplies the same namespace.
+  app.use(ElementPlus, {namespace: "kel"});
+
   const {piniaStore} = await initApp(app, [], {}, en);
   // Isolated stories lack many namespaced i18n keys, so silence vue-i18n's
   // noisy "Not found" warnings in Storybook (it already falls back to the key).

--- a/ui/packages/design-system/src/index.ts
+++ b/ui/packages/design-system/src/index.ts
@@ -1,6 +1,6 @@
 import {defineAsyncComponent} from "vue"
 import type {App, AsyncComponentLoader, Component} from "vue"
-import ElementPlus, {INSTALLED_KEY} from "element-plus"
+import {provideGlobalConfig, INSTALLED_KEY} from "element-plus"
 import type {I18n} from "vue-i18n"
 import {registerDesignSystemI18n} from "./i18n"
 
@@ -454,8 +454,14 @@ export {
 
 const KestraDesignSystem = {
     install(app: App) {
+        // Element Plus's installer registers all ~124 of its components globally, which
+        // pins the whole library into the eager bundle. Nothing renders `<el-*>` tags —
+        // every Ks* wrapper imports the El* component it needs — so the only part of the
+        // installer we need is the global config, which is what carries the `kel` prefix
+        // (including to ElMessage and friends, via its `global` flag).
         if (!(app as any)[INSTALLED_KEY]) {
-            app.use(ElementPlus, {namespace: "kel"})
+            (app as any)[INSTALLED_KEY] = true
+            provideGlobalConfig({namespace: "kel"}, app, true)
         }
         for (const [name, component] of Object.entries(components)) {
             app.component(name, component)

--- a/ui/tests/unit/designSystem/noGlobalElementPlusTags.spec.ts
+++ b/ui/tests/unit/designSystem/noGlobalElementPlusTags.spec.ts
@@ -1,0 +1,43 @@
+import {describe, it, expect} from "vitest"
+import {readdirSync, readFileSync} from "node:fs"
+import {join, relative} from "node:path"
+
+// The design system installs only Element Plus's global config, not its ~124 components, so
+// nothing is globally registered under `el-*`. That is safe exactly as long as shipped code
+// keeps addressing Element Plus through the Ks* wrappers, which import each El* component by
+// name. A raw `<el-select>` in src/ would render as an unresolved element instead — silently,
+// since Vue only warns. Storybook fixtures are exempt: some render raw tags to exercise
+// theming, and .storybook/preview.jsx registers the full library for them.
+describe("Element Plus global registration", () => {
+    const root = join(__dirname, "../../..")
+
+    const vueFilesIn = (dir: string) => {
+        let entries
+        try {
+            entries = readdirSync(join(root, dir), {recursive: true, encoding: "utf8"})
+        } catch {
+            return []
+        }
+        return entries
+            .filter((entry) => entry.endsWith(".vue") && !entry.includes("node_modules"))
+            .map((entry) => join(root, dir, entry))
+    }
+
+    it("should not use <el-*> tags in shipped code", () => {
+        const files = [
+            ...vueFilesIn("src"),
+            ...vueFilesIn("packages/design-system/src"),
+            ...vueFilesIn("packages/topology/src"),
+        ]
+        expect(files.length).toBeGreaterThan(100)
+
+        const offenders = files
+            .filter((file) => /<el-[a-z-]+/.test(readFileSync(file, "utf8")))
+            .map((file) => relative(root, file))
+
+        expect(
+            offenders,
+            "Use the Ks* wrapper, or import the El* component by name; <el-*> relies on a global registration the design system no longer performs.",
+        ).toEqual([])
+    })
+})


### PR DESCRIPTION
### ✨ Description

`packages/design-system/src/index.ts` called `app.use(ElementPlus, {namespace: "kel"})`, which registers **all ~124 Element Plus components globally** and so pins the whole library into the eager bundle. No shipped code relies on that registration.

```diff
-app.use(ElementPlus, {namespace: "kel"})
+provideGlobalConfig({namespace: "kel"}, app, true)
```

Element Plus's `makeInstaller` is exactly three steps — guard, register every component, `provideGlobalConfig`. Only the last one matters here: it carries the `kel` namespace, and its `global` flag also routes that config to the imperative services (`ElMessage`, `ElMessageBox`, `ElNotification`) which render outside the app tree.

The `Ks*` wrappers keep importing the `El*` components they need by name, so those tree-shake exactly as before. What leaves the bundle is the ~46 components nothing wraps, plus the registration overhead for all 124.

### 🔍 What relies on global registration

Checked across **both** `ui/` and `ui-ee/`, since the design system is shared:

| check | `src/` + `packages/*/src/` | `ui-ee/src/` | `ui/tests/` |
|---|---|---|---|
| `<el-*>` tags in templates | 0 | 0 | **42** |
| `$message` / `$notify` / `$confirm` / `$alert` / `$prompt` / `$loading` | 0 | 0 | 0 |
| Element Plus directives (`v-loading`, …) | 0 | 0 | 0 |
| direct `element-plus` imports | design system only | 0 | — |

`vKsLoading` is `vLoading` imported directly from `element-plus`, so the loading directive never depended on the installer either.

**The `tests/` column is the interesting one, and I got it wrong first time round.** Storybook fixtures — `theme/ShowCase.vue` above all — render raw `<el-*>` tags *on purpose*, to exercise Element Plus theming. CI caught it: `ShowCase.stories.jsx > Element Plus Playground` failed with `[ElOption] usage: <el-select><el-option /></el-select>`, because `KsOption` → `ElOption` throws when its `<el-select>` parent no longer resolves.

Worth noting how that surfaced: only **1 of 244** stories failed, but the others were not really fine — Vue merely *warns* on an unresolved element, so `<el-button>` and friends had silently become inert custom elements. `ElOption` threw only because it explicitly requires the select injection.

So `.storybook/preview.jsx` now installs the full library for stories. Rewriting `ShowCase.vue` to `Ks*` would defeat its purpose. Ordering is load-bearing and commented: the install must precede `initApp`, because Element Plus's installer no-ops once `INSTALLED_KEY` is set and the design system sets it.

### 🧷 The invariant, now enforced

This change is safe exactly as long as shipped code keeps addressing Element Plus through the `Ks*` wrappers. `tests/unit/designSystem/noGlobalElementPlusTags.spec.ts` asserts no `<el-*>` in `src/` or `packages/*/src/`, so that stops being something a reviewer has to re-check by hand.

It also closes a fidelity gap this PR opens: Storybook now runs *with* global registration while production runs without, so Storybook alone can no longer catch a product component that depends on it. The test covers that instead.

### 📊 Measurements

Production build, cold boot in Chromium on `/login`, uncompressed:

| | requests | raw | gzip |
|---|---|---|---|
| before | 43 | 5,399,544 | 1,257,893 |
| after | 43 | **5,169,728** | **1,185,425** |

**−230 kB raw / −72 kB gzip (−5.8%)** at an unchanged request count. `design-system` chunk: **1,114 kB → 908 kB**.

Element Plus was ~19% of boot JS in the profile, so this recovers less than that headline suggests — **78 of its 124 components are genuinely wrapped by `Ks*`** and were already retained by name. The unused remainder is what this frees.

### 🧪 Namespace parity

Dropping the installer makes `provideGlobalConfig` solely responsible for the `kel` prefix. If it were wrong, every Element Plus component would render `el-*` classes and lose its styling. Asserted in a real browser on the login form:

| | `kel-*` classes | `el-*` classes |
|---|---|---|
| before | 45 | 0 |
| after | **45** | **0** |

Rendered classes include `kel-form`, `kel-form-item`, `kel-form-item__content`; `#app` innerHTML length is unchanged (6447 → 6448).

### 🎨 Frontend Checklist

- [x] Code builds without errors (`npm run build`)
- [x] `npm run check:types` — design-system compiled, app checked, test checked
- [x] `npm run test:storybook` — 68 files / 244 tests
- [x] Design-system `storybook:test` — 80 files / 479 tests, every component rendered in a real browser
- [x] `npm run test:unit` — 186 files / 1764 tests, plus the new invariant test
- [ ] Screenshots — no visual change (see the namespace table above)

### 📝 Additional Notes

`trigger-ee` passes on this branch, which builds `ui-ee` against it — that is the real evidence for the EE column above, since my own EE check was only static.

Independent of #18187 (moment-timezone data), which touches `vite.config.js` only — the two can land in either order.

Not attempted: Element Plus ships per-component style imports, so there may be more to recover on the CSS side (`design-system-*.css` is 324 kB gzip across the boot path). Larger change, wants its own measurement.

### 🤖 AI Authors

The cat evaluated 124 components, found 78 acceptable for sitting on, and asked why we were carrying the other 46 up the stairs. 🐱