### PR TITLE
docs: add Azure Terraform quick start

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,10 @@ Deploy Kestra on AWS using our CloudFormation template:
 
 [![Launch Stack](https://cdn.jsdelivr.net/gh/buildkite/cloudformation-launch-stack-button-svg@master/launch-stack.svg)](https://console.aws.amazon.com/cloudformation/home#/stacks/create/review?templateURL=https://kestra-deployment-templates.s3.eu-west-3.amazonaws.com/aws/cloudformation/ec2-rds-s3/kestra-oss.yaml&stackName=kestra-oss)
 
+### Launch on Azure (Terraform deployment)
+
+Deploy Kestra on an Azure Virtual Machine with Azure Database for PostgreSQL and Azure Blob Storage using [our Terraform module](https://github.com/kestra-io/deployment-templates/tree/main/azure/terraform/kestra-oss). See the [Azure VM installation guide](https://kestra.io/docs/installation/azure-vm) for architecture and configuration details.
+
 ### Launch on Google Cloud (Terraform deployment)
 
 Deploy Kestra on Google Cloud Infrastructure Manager using [our Terraform module](https://github.com/kestra-io/deployment-templates/tree/main/gcp/terraform/infrastructure-manager/vm-sql-gcs).


### PR DESCRIPTION
## Summary

- add an Azure Terraform deployment option alongside the existing AWS and Google Cloud quick starts
- link the official Kestra Azure Terraform module and Azure VM installation guide
- point users to a deployment path with private PostgreSQL networking, Azure Blob Storage, managed HTTPS ingress, reproducible Kestra configuration, and an optional governed APIM/Azure OpenAI model gateway

The corresponding implementation is proposed in [kestra-io/deployment-templates#29](https://github.com/kestra-io/deployment-templates/pull/29).

## Validation

- rebased this documentation change onto the current `origin/develop` tip
- ran `terraform fmt -check -recursive`, `terraform validate`, and `git diff --check` on the linked module
- applied the complete Terraform configuration in Azure resource group `kestra-terraform-pr-20260817`
- verified the final live `terraform plan` reports no changes
- verified Front Door HTTPS `/ping` and `/ui/` return HTTP 200; protected APIs return 401 anonymously and 200 with authentication
- executed persisted Blob/PostgreSQL flow `validation.azure/terraform_smoke`; execution `4aMh7Zznz5j7ae0WOnjjnk` finished `SUCCESS` and remained available after a stateless VM replacement
- verified Kestra v1.3.33 uses a Terraform-generated encryption key and that a `SECRET` APIM key remains encrypted and absent from execution JSON and logs
- called APIM with a deliberately invalid caller `api-key`; APIM removed it, authenticated to Azure OpenAI through managed identity, and returned HTTP 200
- executed Kestra flow `validation.azure/apim_model_gateway_smoke`; execution `3pvm8HQxZthdIsgeEKvmJY` finished `SUCCESS`
- verified dimensional Application Insights metrics for the canary: Prompt Tokens 15, Completion Tokens 6, and Total Tokens 21

The live validation used `Standard_B2als_v2` because `Standard_B2s` capacity was unavailable in West Europe at deployment time.