### PR TITLE
fix(flows): stop yaml validation squiggles from reappearing in the templated blueprint editor

### DIFF
--- a/ui/src/composables/monaco/languages/yamlLanguageConfigurator.ts
+++ b/ui/src/composables/monaco/languages/yamlLanguageConfigurator.ts
@@ -126,19 +126,22 @@ export class YamlLanguageConfigurator extends AbstractLanguageConfigurator {
 
     async configureLanguage(pluginsStore: ReturnType<typeof usePluginsStore>) {
         const validateYAML = computed(() => useBlueprintsStore().validateYAML)
-        // Keep Monaco YAML validation in sync with the blueprint store setting.
-        watch(validateYAML, (shouldValidate) =>
-            configureMonacoYaml(monaco, {validate: shouldValidate}),
-        )
 
         // Base YAML language setup shared across all YAML editors.
-        configureMonacoYaml(monaco, {
+        const monacoYaml = configureMonacoYaml(monaco, {
             enableSchemaRequest: true,
             hover: localStorage.getItem("hoverTextEditor") === "true",
             completion: true,
             validate: validateYAML.value ?? true,
             schemas: yamlSchemas(),
         })
+
+        // Keep Monaco YAML validation in sync with the blueprint store setting. The single instance must be
+        // updated in place: calling configureMonacoYaml again would stack a second undisposed instance whose
+        // validate flag can never be turned off again.
+        watch(validateYAML, (shouldValidate) =>
+            monacoYaml.update({validate: shouldValidate ?? true}),
+        )
 
         const yamlCompletion = (
             StandaloneServices.get(ILanguageFeaturesService).completionProvider


### PR DESCRIPTION
Closes https://github.com/kestra-io/kestra-ee/issues/6878.

## What

After saving a templated custom blueprint (or more generally after leaving and reopening the blueprint editor), the pre-populated template showed red squiggles in the `tasks` section even though YAML validation is intentionally disabled on that page.

## Why

The blueprint edition page toggles `blueprintsStore.validateYAML` off on mount and back on when leaving. The watcher reacting to that flag called `configureMonacoYaml()` again on every toggle, but each call creates a brand new monaco-yaml instance (worker manager plus providers) that is never disposed - it does not reconfigure the previous one. The instance stacked when leaving the page had `validate: true` and no schemas, and since nothing could ever turn it off again, it kept flagging the blueprint template syntax (`<% %>` / `<< >>`) as YAML syntax errors on the next visit while the store flag said validation was off.

## Fix

Keep the single `MonacoYaml` instance returned by the initial configuration and call its `update({validate})` in the watcher instead. Disabling validation now disposes the instance's validation provider, which also clears the existing yaml markers, and re-enabling revalidates with the schemas still in place.

Verified locally against a running EE instance: creating a templated blueprint, saving, navigating back to the list and reopening it no longer produces markers, and the flow editor still gets yaml diagnostics afterwards (same single instance, schemas kept).