### PR TITLE
fix(flows): live validation for custom blueprint editor (1.3 backport)

### DIFF
--- a/ui/src/stores/blueprints.ts
+++ b/ui/src/stores/blueprints.ts
@@ -1,4 +1,4 @@
-import {ref} from "vue";
+import {computed, ref} from "vue";
 import {defineStore} from "pinia";
 
 import {useAxios} from "../utils/axios";
@@ -58,6 +58,12 @@ export const useBlueprintsStore = defineStore("blueprints", () => {
     const graph = ref<any | undefined>(undefined);
 
     const validateYAML = ref<boolean>(true); // Used to enable/disable YAML validation in Monaco editor, for the purpose of Templated Blueprints
+
+    const validation = ref<{constraints?: string} | undefined>(undefined);
+
+    const validationErrors = computed<string[] | undefined>(
+        () => validation.value?.constraints ? [validation.value.constraints] : undefined,
+    );
 
     const getBlueprints = async (options: Options) => {
         const PARAMS = {params: options.params, ...VALIDATE};
@@ -149,6 +155,16 @@ export const useBlueprintsStore = defineStore("blueprints", () => {
         return response.data;
     };
 
+    const validateFlowBlueprint = async (source: string): Promise<void> => {
+        const url = `${apiUrl()}/blueprints/flows/validate`;
+        const response = await axios.post(url, source, {
+            headers: {"Content-Type": "application/x-yaml"},
+            showMessageOnError: false
+        });
+
+        validation.value = response.data;
+    };
+
     const deleteFlowBlueprint = async (idToDelete: string) => {
         const url = `${apiUrl()}/blueprints/flows/${idToDelete}`;
         await axios.delete(url);
@@ -181,6 +197,9 @@ export const useBlueprintsStore = defineStore("blueprints", () => {
         getFlowBlueprint,
         createFlowBlueprint,
         updateFlowBlueprint,
+        validation,
+        validationErrors,
+        validateFlowBlueprint,
         deleteFlowBlueprint,
     };
 });


### PR DESCRIPTION
Backport of #18163 to `releases/v1.3.x`.

Adds the store plumbing for live validation of custom flow blueprints: a `validation` ref, a `validationErrors` computed, and `validateFlowBlueprint(source)` which posts the YAML source to the new EE endpoint `POST /blueprints/flows/validate` with `showMessageOnError: false` so the editor shows the error inline instead of a toast.

Adapted to 1.3: the store uses `useAxios()` rather than the SDK client, since `ui/packages/kestra-sdk` does not exist on this branch.

Paired with kestra-ee backport of kestra-io/kestra-ee#9937, which adds the endpoint and wires the indicator into the blueprint editor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)