### PR TITLE
fix(flows): stop yaml validation squiggles from reappearing in the templated blueprint editor (1.3 backport)

### DIFF
--- a/ui/src/composables/monaco/languages/yamlLanguageConfigurator.ts
+++ b/ui/src/composables/monaco/languages/yamlLanguageConfigurator.ts
@@ -109,13 +109,9 @@ export class YamlLanguageConfigurator extends AbstractLanguageConfigurator {
 
     async configureLanguage(pluginsStore: ReturnType<typeof usePluginsStore>) {
         const validateYAML = computed(() => useBlueprintsStore().validateYAML);
-        // Keep Monaco YAML validation in sync with the blueprint store setting.
-        watch(validateYAML, (shouldValidate) =>
-            configureMonacoYaml(monaco, {validate: shouldValidate}),
-        );
 
         // Base YAML language setup shared across all YAML editors.
-        configureMonacoYaml(monaco, {
+        const monacoYaml = configureMonacoYaml(monaco, {
             enableSchemaRequest: true,
             hover: localStorage.getItem("hoverTextEditor") === "true",
             completion: true,
@@ -123,6 +119,13 @@ export class YamlLanguageConfigurator extends AbstractLanguageConfigurator {
             format: true,
             schemas: yamlSchemas(),
         });
+
+        // Keep Monaco YAML validation in sync with the blueprint store setting. The single instance must be
+        // updated in place: calling configureMonacoYaml again would stack a second undisposed instance whose
+        // validate flag can never be turned off again.
+        watch(validateYAML, (shouldValidate) =>
+            monacoYaml.update({validate: shouldValidate ?? true}),
+        );
 
         const yamlCompletion = (
             StandaloneServices.get(ILanguageFeaturesService).completionProvider


### PR DESCRIPTION
Backport of https://github.com/kestra-io/kestra/pull/18196 to `releases/v1.3.x`. Relates to https://github.com/kestra-io/kestra-ee/issues/6878, which was reported against v1.3.0-rc0.

## What

After saving a templated custom blueprint (or leaving and reopening the blueprint editor), the pre-populated template showed red squiggles in the `tasks` section even though YAML validation is intentionally disabled on that page.

## Why

The blueprint edition page toggles `blueprintsStore.validateYAML` off on mount and back on when leaving. The watcher reacting to that flag called `configureMonacoYaml()` again on every toggle, but each call creates a brand new monaco-yaml instance (worker manager plus providers) that is never disposed - it does not reconfigure the previous one. The instance stacked when leaving the page kept validating, and nothing could ever turn it off again, so it kept flagging the blueprint template syntax (`<% %>` / `<< >>`) as YAML syntax errors on the next visit.

## Fix

Keep the single `MonacoYaml` instance returned by the initial configuration and call its `update({validate})` in the watcher instead. On the monaco-yaml version pinned here (5.3.1), `update` pushes the new `validate` setting to the shared worker and revalidates, which clears the stale markers; schemas stay in place for the flow editor.

Same change as develop, adapted only for this branch's semicolon style and its extra `format: true` option. Verified on develop against a running EE instance (create templated blueprint, save, back to list, reopen: no markers; flow editor diagnostics still work).