### PR TITLE
fix(dashboards): apply the state filter on the executions list when clicking dashboard bar and time series chart segments

### DIFF
--- a/ui/src/components/dashboard/composables/charts.ts
+++ b/ui/src/components/dashboard/composables/charts.ts
@@ -261,6 +261,32 @@ export function chartSegmentDrillDown(
     };
 }
 
+/**
+ * Pushes the list route resolved by {@link chartSegmentDrillDown}, augmenting its filters with the
+ * query the list pages expect: user scope, first page, and the default time range when supported.
+ */
+export function pushChartDrillDown(
+    router: any,
+    route: any,
+    drillDown: {name: string; query: Record<string, string>; timeFiltered: boolean},
+    extraFilters: Record<string, string> = {},
+) {
+    router.push({
+        name: drillDown.name,
+        params: {tenant: route.params.tenant},
+        query: {
+            ...drillDown.query,
+            ...extraFilters,
+            scope: "USER",
+            size: 100,
+            page: 1,
+            ...(drillDown.timeFiltered
+                ? {"filters[timeRange][EQUALS]": useMiscStore()?.configs?.chartDefaultDuration ?? "PT24H"}
+                : {}),
+        },
+    });
+}
+
 export function chartClick(moment: any, router: any, route: any, event: any, parsedData: any, elements: any, type = "label", filters: Record<string, any> = {}) {
     const query: Record<string, any> = {};
 

--- a/ui/src/components/dashboard/sections/Bar.vue
+++ b/ui/src/components/dashboard/sections/Bar.vue
@@ -12,7 +12,6 @@
 
 <script setup lang="ts">
     import {PropType, computed, watch} from "vue";
-    import moment from "moment";
     import {Bar} from "vue-chartjs";
     import type {TooltipItem, ChartEvent, ActiveElement, ChartData} from "chart.js";
 
@@ -25,7 +24,7 @@
 
     import {customBarLegend} from "../composables/useLegend";
     import {useTheme} from "../../../utils/utils";
-    import {defaultConfig, getConsistentHEXColor, chartClick} from "../composables/charts";
+    import {defaultConfig, getConsistentHEXColor, chartSegmentDrillDown, pushChartDrillDown} from "../composables/charts";
 
 
     import {useRoute, useRouter} from "vue-router";
@@ -112,10 +111,26 @@
                 },
             },
             onClick: (_e: ChartEvent, elements: ActiveElement[]) => {
-                chartClick(moment, router, route, {}, parsedData.value, elements, "label");
+                onSegmentClick(elements);
             },
         }, theme.value);
     });
+
+    // The series dimension is the first column that is neither aggregated nor the x-axis column.
+    const seriesColumn = computed(() => {
+        const entry = Object.entries(data?.columns ?? {})
+            .find(([key, value]) => !(value as Record<string, any>).agg && key !== (chartOptions?.column ?? ""));
+        return entry?.[1] as {field?: string; labelKey?: string} | undefined;
+    });
+
+    function onSegmentClick(elements: ActiveElement[]) {
+        if (!elements?.length) return;
+        const label = parsedData.value.datasets[elements[0].datasetIndex]?.label;
+        if (!label) return;
+        const drillDown = chartSegmentDrillDown(props.chart, seriesColumn.value, label);
+        if (!drillDown) return;
+        pushChartDrillDown(router, route, drillDown);
+    }
 
     function isDurationAgg() {
         return aggregator[0][1].field === "DURATION";

--- a/ui/src/components/dashboard/sections/Pie.vue
+++ b/ui/src/components/dashboard/sections/Pie.vue
@@ -34,13 +34,12 @@
 
     import {Doughnut, Pie} from "vue-chartjs";
 
-    import {defaultConfig, getConsistentHEXColor, chartSegmentDrillDown} from "../composables/charts";
+    import {defaultConfig, getConsistentHEXColor, chartSegmentDrillDown, pushChartDrillDown} from "../composables/charts";
     import {totalsDurationLegend, totalsLegend} from "../composables/useLegend";
 
     import moment from "moment";
 
     import {useRoute, useRouter} from "vue-router";
-    import {useMiscStore} from "override/stores/misc";
     import {FilterObject} from "../../../utils/filters";
 
     const route = useRoute();
@@ -117,19 +116,7 @@
         if (!label) return;
         const drillDown = chartSegmentDrillDown(props.chart, dimensionColumn.value, label);
         if (!drillDown) return;
-        router.push({
-            name: drillDown.name,
-            params: {tenant: route.params.tenant},
-            query: {
-                ...drillDown.query,
-                scope: "USER",
-                size: 100,
-                page: 1,
-                ...(drillDown.timeFiltered
-                    ? {"filters[timeRange][EQUALS]": useMiscStore()?.configs?.chartDefaultDuration ?? "PT24H"}
-                    : {}),
-            },
-        });
+        pushChartDrillDown(router, route, drillDown);
     }
 
     const centerPlugin = computed(() => ({

--- a/ui/src/components/dashboard/sections/TimeSeries.vue
+++ b/ui/src/components/dashboard/sections/TimeSeries.vue
@@ -32,7 +32,7 @@
     import NoData from "../../layout/NoData.vue";
     import {Chart, getDashboard, useChartGenerator} from "../composables/useDashboards";
     import {customBarLegend} from "../composables/useLegend";
-    import {defaultConfig, getConsistentHEXColor, chartClick, tooltip} from "../composables/charts";
+    import {defaultConfig, getConsistentHEXColor, chartSegmentDrillDown, pushChartDrillDown, tooltip} from "../composables/charts";
     import {cssVariable} from "@kestra-io/ui-libs";
     import KestraUtils, {useTheme} from "../../../utils/utils";
     import {FilterObject} from "../../../utils/filters";
@@ -159,13 +159,25 @@
                 if (data?.type === "io.kestra.plugin.core.dashboard.data.Logs" || props.execution) {
                     return;
                 }
-                chartClick(moment, router, route, {}, parsedData.value, elements, "label", {
-                    ...(props.namespace ? {"filters[namespace][IN]": props.namespace} : {}),
-                    ...(props.flow ? {"filters[flowId][EQUALS]": props.flow} : {})              
-                });
+                onSegmentClick(elements);
             },
         }, theme.value);
     });
+
+    function onSegmentClick(elements: ActiveElement[]) {
+        if (!elements?.length) return;
+        const dataset = parsedData.value.datasets[elements[0].datasetIndex] as Record<string, any> | undefined;
+        // The yB duration line has no drillable dimension; stacked bars are labelled by colorByColumn.
+        if (!dataset || dataset.type === "line" || !dataset.label) return;
+        const colorByColumn = (chartOptions as Record<string, any>)?.colorByColumn as string | undefined;
+        const column = colorByColumn ? (data?.columns as Record<string, any> | undefined)?.[colorByColumn] : undefined;
+        const drillDown = chartSegmentDrillDown(props.chart, column, dataset.label);
+        if (!drillDown) return;
+        pushChartDrillDown(router, route, drillDown, {
+            ...(props.namespace ? {"filters[namespace][IN]": props.namespace} : {}),
+            ...(props.flow ? {"filters[flowId][EQUALS]": props.flow} : {}),
+        });
+    }
 
     function isDuration(field: string | undefined): boolean {
         return field === "DURATION";

--- a/ui/tests/unit/components/dashboard/composables/charts.spec.ts
+++ b/ui/tests/unit/components/dashboard/composables/charts.spec.ts
@@ -1,0 +1,87 @@
+import {beforeEach, describe, expect, it} from "vitest";
+import {createPinia, setActivePinia} from "pinia";
+import {chartSegmentDrillDown, pushChartDrillDown} from "../../../../../src/components/dashboard/composables/charts";
+
+const EXECUTIONS_CHART = {
+    data: {
+        type: "io.kestra.plugin.core.dashboard.data.Executions",
+        columns: {
+            date: {field: "START_DATE", displayType: "DATE"},
+            state: {field: "STATE"},
+            total: {field: "ID", agg: "COUNT"},
+        },
+    },
+};
+
+describe("chartSegmentDrillDown", () => {
+    it("should map a STATE dimension to the executions state filter", () => {
+        const result = chartSegmentDrillDown(EXECUTIONS_CHART, {field: "STATE"}, "FAILED");
+
+        expect(result).toEqual({
+            name: "executions/list",
+            timeFiltered: true,
+            query: {"filters[state][IN]": "FAILED"},
+        });
+    });
+
+    it("should extract the state from a comma-joined series label", () => {
+        const result = chartSegmentDrillDown(EXECUTIONS_CHART, {field: "STATE"}, "company.team, FAILED");
+
+        expect(result?.query).toEqual({"filters[state][IN]": "FAILED"});
+    });
+
+    it("should return null for data sources without a list to drill into", () => {
+        const chart = {data: {type: "io.kestra.plugin.core.dashboard.data.Metrics", columns: {}}};
+
+        expect(chartSegmentDrillDown(chart, {field: "STATE"}, "FAILED")).toBeNull();
+    });
+});
+
+describe("pushChartDrillDown", () => {
+    beforeEach(() => {
+        setActivePinia(createPinia());
+    });
+
+    it("should push the list route with scope, pagination and the default time range", () => {
+        const pushed: Record<string, any>[] = [];
+        const router = {push: (to: Record<string, any>) => pushed.push(to)};
+        const route = {params: {tenant: "main"}};
+
+        pushChartDrillDown(router, route, {
+            name: "executions/list",
+            timeFiltered: true,
+            query: {"filters[state][IN]": "FAILED"},
+        });
+
+        expect(pushed).toEqual([{
+            name: "executions/list",
+            params: {tenant: "main"},
+            query: {
+                "filters[state][IN]": "FAILED",
+                scope: "USER",
+                size: 100,
+                page: 1,
+                "filters[timeRange][EQUALS]": "PT24H",
+            },
+        }]);
+    });
+
+    it("should merge extra filters and omit the time range when the list does not support it", () => {
+        const pushed: Record<string, any>[] = [];
+        const router = {push: (to: Record<string, any>) => pushed.push(to)};
+        const route = {params: {tenant: "main"}};
+
+        pushChartDrillDown(router, route, {
+            name: "flows/list",
+            timeFiltered: false,
+            query: {},
+        }, {"filters[namespace][IN]": "company.team"});
+
+        expect(pushed[0].query).toEqual({
+            "filters[namespace][IN]": "company.team",
+            scope: "USER",
+            size: 100,
+            page: 1,
+        });
+    });
+});


### PR DESCRIPTION
Closes https://github.com/kestra-io/kestra/issues/16336.

## What

Clicking a segment of the default dashboard's bar or time series charts navigated to the executions list with the legacy `state=<value>` query parameter, which the list's filter system ignores - the list opened unfiltered (the exact URL reported in the issue: `/ui/main/executions?state=FAILED&scope=USER&size=100&page=1&filters[timeRange][EQUALS]=PT24H`).

The pie chart was already fixed on this branch by https://github.com/kestra-io/kestra/pull/16729 (shipped in v1.3.23), but the `Bar` and `TimeSeries` dashboard sections still went through the legacy `chartClick` helper. This PR ports the same data-source-aware drill-down to them:

- `Bar.vue` resolves the clicked series column (first non-aggregated, non-x-axis column) and maps it through `chartSegmentDrillDown`, producing `filters[state][IN]=FAILED` and friends.
- `TimeSeries.vue` does the same via its `colorByColumn`, keeps the existing Logs/execution guards, skips the duration line dataset, and still merges the namespace/flow filters it received as props.
- The route push (scope, pagination, default time range) is extracted into a shared `pushChartDrillDown` used by all three charts, so `Pie.vue` now goes through the same code path instead of its own inline copy.
- Added a unit test covering the dimension mapping and the pushed query.

Not needed on `develop` / `releases/v2.0.x` - those already use the `useChartDrillDown` composable with the modern filter syntax everywhere.

## Verified

Against a local `kestra/kestra:v1.3.33-no-plugins` backend with 3 FAILED + 2 SUCCESS executions:

- Time series FAILED segment → `/ui/main/executions?filters[state][IN]=FAILED&scope=USER&size=100&page=1&filters[timeRange][EQUALS]=PT24H`, list shows only the 3 FAILED executions with a `State in FAILED` chip.
- Per-namespace bar SUCCESS segment → `filters[state][IN]=SUCCESS`, list shows only the 2 SUCCESS executions.
- Pie FAILED slice (refactor regression check) → same FAILED URL as before the refactor.
- `npm run check:types`, `eslint` on the changed files, and the new unit test all pass.