### PR TITLE
fix(dashboards): apply the state filter on the executions list when clicking dashboard chart segments

### DIFF
--- a/ui/src/components/dashboard/composables/charts.js
+++ b/ui/src/components/dashboard/composables/charts.js
@@ -2,6 +2,7 @@ import _merge from "lodash/merge";
 import Utils from "../../../utils/utils";
 import {cssVariable, State} from "@kestra-io/ui-libs";
 import {getSchemeValue} from "../../../utils/scheme";
+import {useMiscStore} from "override/stores/misc";
 
 export function tooltip(tooltipModel) {
     const titleLines = tooltipModel.title || [];
@@ -104,6 +105,140 @@ export function extractState(value) {
     }
 
     return value;
+}
+
+// Maps a dashboard `where` FilterType to the list comparator key used in the URL.
+// Types with no list equivalent (OR, REGEX, IS_NULL/IS_NOT_NULL, IS_TRUE/IS_FALSE) are omitted (skipped).
+const WHERE_TYPE_TO_COMPARATOR = {
+    EQUAL_TO: "EQUALS",
+    NOT_EQUAL_TO: "NOT_EQUALS",
+    IN: "IN",
+    NOT_IN: "NOT_IN",
+    CONTAINS: "CONTAINS",
+    STARTS_WITH: "STARTS_WITH",
+    ENDS_WITH: "ENDS_WITH",
+    PREFIX: "PREFIX",
+    GREATER_THAN: "GREATER_THAN",
+    GREATER_THAN_OR_EQUAL_TO: "GREATER_THAN_OR_EQUAL_TO",
+    LESS_THAN: "LESS_THAN",
+    LESS_THAN_OR_EQUAL_TO: "LESS_THAN_OR_EQUAL_TO",
+};
+
+// Per data-source drill-down config, keyed by the short name of `chart.data.type`
+// (io.kestra.plugin.core.dashboard.data.<Name>). Sources without a list to drill into (e.g. Metrics) are omitted,
+// so a click on such a chart simply does not navigate rather than landing on the wrong page.
+const DRILL_DOWNS = {
+    Executions: {
+        route: "executions/list",
+        fieldKey: {NAMESPACE: "namespace", FLOW_ID: "flowId", STATE: "state", LABELS: "labels", SCOPE: "scope", TRIGGER_EXECUTION_ID: "triggerExecutionId"},
+        multiSelect: ["namespace", "flowId", "state", "scope"],
+        timeFiltered: true,
+    },
+    Logs: {
+        route: "logs/list",
+        fieldKey: {NAMESPACE: "namespace", FLOW_ID: "flowId", TRIGGER_ID: "triggerId", TASK_ID: "taskId", TASK_RUN_ID: "taskRunId", ATTEMPT_NUMBER: "attemptNumber"},
+        multiSelect: ["namespace"],
+        timeFiltered: true,
+    },
+    Flows: {
+        // Flows have no time dimension - the flows list rejects a timeRange filter - so timeFiltered is false.
+        route: "flows/list",
+        fieldKey: {NAMESPACE: "namespace"},
+        multiSelect: ["namespace"],
+        timeFiltered: false,
+    },
+    Triggers: {
+        route: "admin/triggers",
+        fieldKey: {NAMESPACE: "namespace", FLOW_ID: "flowId", TRIGGER_ID: "triggerId", WORKER_ID: "workerId"},
+        multiSelect: ["namespace"],
+        timeFiltered: true,
+    },
+};
+
+function drillDownFor(dataType) {
+    const sourceName = dataType?.split(".").pop();
+    return sourceName ? DRILL_DOWNS[sourceName] : undefined;
+}
+
+// Resolves the list comparator for a (filterKey, dashboard FilterType), honoring multi-select fields
+// (equality -> IN/NOT_IN). Returns null when the operator can't be represented for that field.
+function comparatorFor(descriptor, filterKey, type) {
+    if (descriptor.multiSelect.includes(filterKey)) {
+        if (type === "EQUAL_TO" || type === "IN") return "IN";
+        if (type === "NOT_EQUAL_TO" || type === "NOT_IN") return "NOT_IN";
+    }
+    return WHERE_TYPE_TO_COMPARATOR[type ?? ""] ?? null;
+}
+
+function encodeFilter(filterKey, comparator, labelKey, value) {
+    if (filterKey === "labels") {
+        return labelKey ? {[`filters[labels][${comparator}][${labelKey}]`]: value} : {};
+    }
+    return {[`filters[${filterKey}][${comparator}]`]: value};
+}
+
+function asString(value) {
+    return Array.isArray(value) ? value.join(",") : String(value);
+}
+
+export function dimensionFilter(descriptor, column, value) {
+    const filterKey = descriptor.fieldKey[column?.field ?? ""];
+    if (!filterKey) return {};
+    const comparator = comparatorFor(descriptor, filterKey, "EQUAL_TO");
+    if (!comparator) return {};
+    const resolved = filterKey === "state" ? extractState(value) : value;
+    return encodeFilter(filterKey, comparator, column?.labelKey, resolved);
+}
+
+// Translates a chart's `where` conditions into list `filters[...]` query params
+export function whereToFilters(descriptor, where) {
+    const out = {};
+    if (!Array.isArray(where)) return out;
+
+    for (const condition of where) {
+        if (condition?.value === undefined || condition.value === null) continue;
+        const filterKey = descriptor.fieldKey[condition.field ?? ""];
+        if (!filterKey) continue;
+        const comparator = comparatorFor(descriptor, filterKey, condition.type);
+        if (!comparator) continue;
+        Object.assign(out, encodeFilter(filterKey, comparator, condition.labelKey, asString(condition.value)));
+    }
+
+    return out;
+}
+
+export function chartSegmentDrillDown(chart, column, value) {
+    const descriptor = drillDownFor(chart?.data?.type);
+    if (!descriptor) return null;
+    return {
+        name: descriptor.route,
+        timeFiltered: descriptor.timeFiltered,
+        query: {
+            ...whereToFilters(descriptor, chart?.data?.where),
+            ...dimensionFilter(descriptor, column, value),
+        },
+    };
+}
+
+/**
+ * Pushes the list route resolved by {@link chartSegmentDrillDown}, augmenting its filters with the
+ * query the list pages expect: user scope, first page, and the default time range when supported.
+ */
+export function pushChartDrillDown(router, route, drillDown, extraFilters = {}) {
+    router.push({
+        name: drillDown.name,
+        params: {tenant: route.params.tenant},
+        query: {
+            ...drillDown.query,
+            ...extraFilters,
+            scope: "USER",
+            size: 100,
+            page: 1,
+            ...(drillDown.timeFiltered
+                ? {"filters[timeRange][EQUALS]": useMiscStore()?.configs?.chartDefaultDuration ?? "PT24H"}
+                : {}),
+        },
+    });
 }
 
 export function chartClick(moment, router, route, event, parsedData, elements, type = "label") {

--- a/ui/src/components/dashboard/sections/Bar.vue
+++ b/ui/src/components/dashboard/sections/Bar.vue
@@ -12,7 +12,6 @@
 
 <script lang="ts" setup>
     import {PropType, computed, watch} from "vue";
-    import moment from "moment";
     import {Bar} from "vue-chartjs";
 
     import NoData from "../../layout/NoData.vue";
@@ -23,7 +22,7 @@
 
     import {customBarLegend} from "../composables/useLegend";
     import {useTheme} from "../../../utils/utils.js";
-    import {defaultConfig, getConsistentHEXColor, chartClick} from "../composables/charts.js";
+    import {defaultConfig, getConsistentHEXColor, chartSegmentDrillDown, pushChartDrillDown} from "../composables/charts.js";
 
 
     import {useRoute, useRouter} from "vue-router";
@@ -109,10 +108,26 @@
                 },
             },
             onClick: (e, elements) => {
-                chartClick(moment, router, route, {}, parsedData.value, elements, "label");
+                onSegmentClick(elements);
             },
         }, theme.value);
     });
+
+    // The series dimension is the first column that is neither aggregated nor the x-axis column.
+    const seriesColumn = computed(() => {
+        const entry = Object.entries(data.columns ?? {})
+            .find(([key, value]) => !(value as Record<string, any>).agg && key !== chartOptions.column);
+        return entry?.[1] as {field?: string; labelKey?: string} | undefined;
+    });
+
+    function onSegmentClick(elements: {datasetIndex: number}[]) {
+        if (!elements?.length) return;
+        const label = parsedData.value.datasets[elements[0].datasetIndex]?.label;
+        if (!label) return;
+        const drillDown = chartSegmentDrillDown(props.chart, seriesColumn.value, label);
+        if (!drillDown) return;
+        pushChartDrillDown(router, route, drillDown);
+    }
 
     function isDurationAgg() {
         return aggregator[0][1].field === "DURATION";

--- a/ui/src/components/dashboard/sections/Pie.vue
+++ b/ui/src/components/dashboard/sections/Pie.vue
@@ -33,7 +33,7 @@
 
     import {Doughnut, Pie} from "vue-chartjs";
 
-    import {defaultConfig, getConsistentHEXColor, chartClick} from "../composables/charts.js";
+    import {defaultConfig, getConsistentHEXColor, chartSegmentDrillDown, pushChartDrillDown} from "../composables/charts.js";
     import {totalsDurationLegend, totalsLegend} from "../composables/useLegend";
 
     import moment from "moment";
@@ -81,10 +81,25 @@
                 },
             },
             onClick: (e, elements) => {
-                chartClick(moment, router, route, {}, parsedData.value, elements, "dataset");
+                onSegmentClick(elements);
             },
         }, theme.value);
     });
+
+    // The pie's single dimension is the column without an aggregation.
+    const dimensionColumn = computed(() => {
+        const entry = Object.entries(props.chart.data.columns).find(([, column]) => !("agg" in (column as Record<string, any>)));
+        return entry?.[1] as {field?: string; labelKey?: string} | undefined;
+    });
+
+    function onSegmentClick(elements: {index: number}[]) {
+        if (!elements?.length) return;
+        const label = parsedData.value.labels[elements[0].index];
+        if (!label) return;
+        const drillDown = chartSegmentDrillDown(props.chart, dimensionColumn.value, label);
+        if (!drillDown) return;
+        pushChartDrillDown(router, route, drillDown);
+    }
 
     const centerPlugin = computed(() => ({
         id: "centerPlugin",

--- a/ui/src/components/dashboard/sections/TimeSeries.vue
+++ b/ui/src/components/dashboard/sections/TimeSeries.vue
@@ -31,7 +31,7 @@
     import NoData from "../../layout/NoData.vue";
     import {Chart, getDashboard, useChartGenerator} from "../composables/useDashboards";
     import {customBarLegend} from "../composables/useLegend";
-    import {defaultConfig, getConsistentHEXColor, chartClick, tooltip} from "../composables/charts.js";
+    import {defaultConfig, getConsistentHEXColor, chartSegmentDrillDown, pushChartDrillDown, tooltip} from "../composables/charts.js";
     import {cssVariable, Utils} from "@kestra-io/ui-libs";
     import KestraUtils, {useTheme} from "../../../utils/utils";
 
@@ -148,10 +148,22 @@
                 if (data.type === "io.kestra.plugin.core.dashboard.data.Logs") {
                     return;
                 }
-                chartClick(moment, router, route, {}, parsedData.value, elements, "label");
+                onSegmentClick(elements);
             },
         }, theme.value);
     });
+
+    function onSegmentClick(elements: {datasetIndex: number}[]) {
+        if (!elements?.length) return;
+        const dataset = parsedData.value.datasets[elements[0].datasetIndex] as Record<string, any> | undefined;
+        // The yB duration line has no drillable dimension; stacked bars are labelled by colorByColumn.
+        if (!dataset || dataset.type === "line" || !dataset.label) return;
+        const colorByColumn = (chartOptions as Record<string, any>)?.colorByColumn as string | undefined;
+        const column = colorByColumn ? (data.columns as Record<string, any> | undefined)?.[colorByColumn] : undefined;
+        const drillDown = chartSegmentDrillDown(props.chart, column, dataset.label);
+        if (!drillDown) return;
+        pushChartDrillDown(router, route, drillDown);
+    }
 
     function isDuration(field) {
         return field === "DURATION";

--- a/ui/tests/unit/components/dashboard/composables/charts.spec.ts
+++ b/ui/tests/unit/components/dashboard/composables/charts.spec.ts
@@ -1,0 +1,87 @@
+import {beforeEach, describe, expect, it} from "vitest";
+import {createPinia, setActivePinia} from "pinia";
+import {chartSegmentDrillDown, pushChartDrillDown} from "../../../../../src/components/dashboard/composables/charts.js";
+
+const EXECUTIONS_CHART = {
+    data: {
+        type: "io.kestra.plugin.core.dashboard.data.Executions",
+        columns: {
+            date: {field: "START_DATE", displayName: "Date"},
+            state: {field: "STATE"},
+            total: {field: "ID", agg: "COUNT"},
+        },
+    },
+};
+
+describe("chartSegmentDrillDown", () => {
+    it("should map a STATE dimension to the executions state filter", () => {
+        const result = chartSegmentDrillDown(EXECUTIONS_CHART, {field: "STATE"}, "FAILED");
+
+        expect(result).toEqual({
+            name: "executions/list",
+            timeFiltered: true,
+            query: {"filters[state][IN]": "FAILED"},
+        });
+    });
+
+    it("should extract the state from a comma-joined series label", () => {
+        const result = chartSegmentDrillDown(EXECUTIONS_CHART, {field: "STATE"}, "company.team, FAILED");
+
+        expect(result?.query).toEqual({"filters[state][IN]": "FAILED"});
+    });
+
+    it("should return null for data sources without a list to drill into", () => {
+        const chart = {data: {type: "io.kestra.plugin.core.dashboard.data.Metrics", columns: {}}};
+
+        expect(chartSegmentDrillDown(chart, {field: "STATE"}, "FAILED")).toBeNull();
+    });
+});
+
+describe("pushChartDrillDown", () => {
+    beforeEach(() => {
+        setActivePinia(createPinia());
+    });
+
+    it("should push the list route with scope, pagination and the default time range", () => {
+        const pushed: Record<string, any>[] = [];
+        const router = {push: (to: Record<string, any>) => pushed.push(to)};
+        const route = {params: {tenant: "main"}};
+
+        pushChartDrillDown(router, route, {
+            name: "executions/list",
+            timeFiltered: true,
+            query: {"filters[state][IN]": "FAILED"},
+        });
+
+        expect(pushed).toEqual([{
+            name: "executions/list",
+            params: {tenant: "main"},
+            query: {
+                "filters[state][IN]": "FAILED",
+                scope: "USER",
+                size: 100,
+                page: 1,
+                "filters[timeRange][EQUALS]": "PT24H",
+            },
+        }]);
+    });
+
+    it("should merge extra filters and omit the time range when the list does not support it", () => {
+        const pushed: Record<string, any>[] = [];
+        const router = {push: (to: Record<string, any>) => pushed.push(to)};
+        const route = {params: {tenant: "main"}};
+
+        pushChartDrillDown(router, route, {
+            name: "flows/list",
+            timeFiltered: false,
+            query: {},
+        }, {"filters[namespace][IN]": "company.team"});
+
+        expect(pushed[0].query).toEqual({
+            "filters[namespace][IN]": "company.team",
+            scope: "USER",
+            size: 100,
+            page: 1,
+        });
+    });
+});


### PR DESCRIPTION
Closes https://github.com/kestra-io/kestra/issues/16336.

## What

1.0.x port of https://github.com/kestra-io/kestra/pull/18205 (merged into `releases/v1.3.x`).

Clicking a segment of the default dashboard's **pie, bar or time series** charts navigated to the executions list with the legacy `state=<value>` query parameter, which the list's filter system ignores - the list opened unfiltered. Verified reproducible on stock `v1.0.55`: the drill-down URL showed all 5 seeded executions instead of the 3 FAILED ones.

Unlike 1.3.x (where https://github.com/kestra-io/kestra/pull/16729 had already fixed the pie), 1.0.x never received any part of the drill-down rework, so this PR brings the whole mapping over:

- `charts.js` gains the data-source-aware drill-down from PR 16729/18205 (`chartSegmentDrillDown` + descriptor map translating dashboard columns and `where` conditions into modern `filters[...]` query params) and the shared `pushChartDrillDown` route push (scope, pagination, default time range).
- `Pie.vue` maps the clicked slice through the chart's non-aggregated dimension column.
- `Bar.vue` maps the clicked dataset through the series column (first non-aggregated, non-x-axis column).
- `TimeSeries.vue` maps it through `colorByColumn`, keeps the Logs guard, and skips the duration line dataset.
- Same unit test as on 1.3.x, adapted to the `.js` module.

## Verified

Against a local `kestra/kestra:v1.0.55-no-plugins` backend with 3 FAILED + 2 SUCCESS executions:

- Time series FAILED segment → `/main/executions?...filters[state][EQUALS]=FAILED...` (the filter bar normalizes `IN` with a single value to `EQUALS`), list shows only the 3 FAILED executions.
- Per-namespace bar SUCCESS segment → only the 2 SUCCESS executions.
- Pie FAILED slice → same FAILED-filtered list.
- `eslint` on the changed files and the unit test pass. (`check:types` is a no-op on this branch by design.)