### PR TITLE
Feat: Indexed Fields ( Executions searchable via task or execution outputs )

### DIFF
--- a/core/src/main/java/io/kestra/core/models/executions/ExecutionIndexedField.java
+++ b/core/src/main/java/io/kestra/core/models/executions/ExecutionIndexedField.java
@@ -1,0 +1,26 @@
+package io.kestra.core.models.executions;
+
+import io.kestra.core.models.HasUID;
+
+/**
+ * A single indexed field value for an execution.
+ * <p>
+ * Stored in a dedicated table ({@code execution_indexed_fields}) as a plain string key/value pair so executions can
+ * be searched efficiently. One row is stored per (execution, key).
+ */
+public record ExecutionIndexedField(
+    String tenantId,
+    String executionId,
+    String key,
+    String value,
+    String namespace,
+    String flowId) implements HasUID {
+    /**
+     * Synthetic stable identifier used as the table primary key. Built from the execution id and the field key so
+     * re-computing an execution's indexed fields is idempotent.
+     */
+    @Override
+    public String uid() {
+        return executionId + "-" + key;
+    }
+}

--- a/core/src/main/java/io/kestra/core/models/flows/Flow.java
+++ b/core/src/main/java/io/kestra/core/models/flows/Flow.java
@@ -108,6 +108,14 @@ public class Flow extends AbstractFlow implements HasUID {
     @Valid
     List<Output> outputs;
 
+    @Schema(
+        title = "Indexed fields available and searchable for executions of this flow.",
+        description = "Indexed fields are computed from Pebble expressions when the execution ends and stored in a dedicated, searchable key/value table so executions can be looked up without indexing the full outputs."
+    )
+    @PluginProperty(dynamic = true)
+    @Valid
+    List<IndexedField> indexedFields;
+
     // implementation = Object.class prevents the Micronaut OpenAPI annotation processor from following
     // the @JsonSubTypes on AbstractRetry, which causes a PostponeToNextRoundException at compile time
     // due to the Micronaut constraint validators on the concrete retry subtypes (Constant, Exponential, Random).

--- a/core/src/main/java/io/kestra/core/models/flows/IndexedField.java
+++ b/core/src/main/java/io/kestra/core/models/flows/IndexedField.java
@@ -1,0 +1,53 @@
+package io.kestra.core.models.flows;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+/**
+ * Definition of a flow's indexed field.
+ * <p>
+ * An indexed field is a key/value pair computed from a Pebble expression when the execution ends.
+ * The value is coerced to a plain string and stored in a dedicated, searchable table so executions can be
+ * looked up by these fields without indexing the full (and potentially large) task or flow outputs.
+ */
+@SuperBuilder
+@Getter
+@NoArgsConstructor
+public class IndexedField implements Data {
+    /**
+     * The indexed field's unique key (name).
+     */
+    @NotNull
+    @NotBlank
+    @Pattern(regexp = "^[a-zA-Z0-9][.a-zA-Z0-9_-]*")
+    String id;
+
+    /**
+     * Short description of the indexed field.
+     */
+    String description;
+
+    /**
+     * The Pebble expression used to compute the indexed field value. The result is coerced to a plain string.
+     */
+    @NotNull
+    @Schema(title = "The Pebble expression used to compute the indexed field value. The result is coerced to a plain string.")
+    String value;
+
+    String displayName;
+
+    @Override
+    public Type getType() {
+        return Type.STRING;
+    }
+
+    @Override
+    public String getDisplayName() {
+        return displayName;
+    }
+}

--- a/core/src/main/java/io/kestra/core/repositories/ExecutionRepositoryInterface.java
+++ b/core/src/main/java/io/kestra/core/repositories/ExecutionRepositoryInterface.java
@@ -38,6 +38,17 @@ public interface ExecutionRepositoryInterface extends QueryBuilderInterface<Exec
     ArrayListTotal<Execution> findByFlowId(String tenantId, String namespace, String id, Pageable pageable);
 
     /**
+     * Search executions matching an indexed field key/value pair.
+     *
+     * @param tenantId the tenant id
+     * @param key the indexed field key
+     * @param value the value to match
+     * @param exactMatch when {@code true} matches the value exactly, otherwise uses a substring (contains) match
+     * @param pageable the pagination
+     */
+    ArrayListTotal<Execution> findByIndexedField(String tenantId, String key, String value, boolean exactMatch, Pageable pageable);
+
+    /**
      * Finds all the executions that were triggered by the given execution id.
      *
      * @param tenantId the tenant id.

--- a/core/src/main/java/io/kestra/core/repositories/IndexedFieldRepositoryInterface.java
+++ b/core/src/main/java/io/kestra/core/repositories/IndexedFieldRepositoryInterface.java
@@ -1,0 +1,40 @@
+package io.kestra.core.repositories;
+
+import java.util.List;
+
+import io.kestra.core.models.executions.Execution;
+import io.kestra.core.models.executions.ExecutionIndexedField;
+
+/**
+ * Repository for execution indexed fields, used to store and retrieve the indexed fields of executions.
+ * WARNING: don't use it directly, use the {@link io.kestra.core.services.IndexedFieldService}.
+ */
+public interface IndexedFieldRepositoryInterface {
+    /**
+     * Save an indexed field.
+     */
+    ExecutionIndexedField save(ExecutionIndexedField indexedField);
+
+    /**
+     * Find all indexed fields for a given execution.
+     */
+    List<ExecutionIndexedField> findByExecution(Execution execution);
+
+    /**
+     * Find execution ids matching an indexed field key and value.
+     *
+     * @param tenantId the tenant id
+     * @param key the indexed field key
+     * @param value the value to match
+     * @param exactMatch when {@code true} matches the value exactly, otherwise uses a substring (contains) match
+     * @return the matching execution ids
+     */
+    List<String> findExecutionIds(String tenantId, String key, String value, boolean exactMatch);
+
+    /**
+     * Purge (hard delete) all indexed fields for a given list of execution ids.
+     *
+     * @return the number of deleted indexed fields
+     */
+    int purgeByExecutionIds(List<String> executionIds);
+}

--- a/core/src/main/java/io/kestra/core/services/ExecutionService.java
+++ b/core/src/main/java/io/kestra/core/services/ExecutionService.java
@@ -99,6 +99,7 @@ public class ExecutionService {
 
     @Inject
     private ExecutionOutputService executionOutputService;
+    private IndexedFieldService indexedFieldService;
 
     @Inject
     private DispatchQueueInterface<ExecutionCommand> executionCommandQueue;
@@ -722,6 +723,7 @@ public class ExecutionService {
                     builder.executionsCount(this.executionRepository.purge(executions));
                     builder.taskOutputsCount(this.taskOutputService.purge(executions));
                     builder.executionOutputsCount(this.executionOutputService.purge(executions));
+                    builder.indexedFieldsCount(this.indexedFieldService.purge(executions));
                 }
 
                 if (purgeLog) {
@@ -768,6 +770,7 @@ public class ExecutionService {
         boolean deleteMetrics,
         boolean deleteStorage) throws IOException {
         this.executionRepository.purge(execution);
+        this.indexedFieldService.purge(java.util.List.of(execution));
 
         if (deleteLogs) {
             this.logRepository.purge(execution);
@@ -1186,6 +1189,7 @@ public class ExecutionService {
 
         @Builder.Default
         private int executionOutputsCount = 0;
+        private int indexedFieldsCount = 0;
 
         @Builder.Default
         private int logsCount = 0;

--- a/core/src/main/java/io/kestra/core/services/IndexedFieldService.java
+++ b/core/src/main/java/io/kestra/core/services/IndexedFieldService.java
@@ -1,0 +1,96 @@
+package io.kestra.core.services;
+
+import java.util.List;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.kestra.core.exceptions.IllegalVariableEvaluationException;
+import io.kestra.core.models.executions.Execution;
+import io.kestra.core.models.executions.ExecutionIndexedField;
+import io.kestra.core.models.flows.Flow;
+import io.kestra.core.models.flows.IndexedField;
+import io.kestra.core.repositories.IndexedFieldRepositoryInterface;
+import io.kestra.core.runners.RunContext;
+
+import jakarta.inject.Singleton;
+
+/**
+ * Service to compute and store execution indexed fields. Indexed fields are evaluated from Pebble expressions when an
+ * execution ends and persisted in a dedicated, searchable table.
+ */
+@Singleton
+public class IndexedFieldService {
+    private static final Logger LOG = LoggerFactory.getLogger(IndexedFieldService.class);
+
+    /**
+     * Maximum length of an indexed field value. Values are stored in a {@code VARCHAR(1024)} column so the index stays
+     * portable and bounded across H2, PostgreSQL and MySQL; longer rendered values are truncated.
+     */
+    public static final int MAX_VALUE_LENGTH = 1024;
+
+    private final IndexedFieldRepositoryInterface indexedFieldRepository;
+
+    public IndexedFieldService(IndexedFieldRepositoryInterface indexedFieldRepository) {
+        this.indexedFieldRepository = indexedFieldRepository;
+    }
+
+    /**
+     * Compute and persist the indexed fields declared on a flow for a finished execution.
+     *
+     * @param runContext the run context used to render the Pebble expressions
+     * @param flow the flow declaring the indexed fields
+     * @param execution the finished execution
+     */
+    public void saveIndexedFields(RunContext runContext, Flow flow, Execution execution) {
+        if (flow.getIndexedFields() == null || flow.getIndexedFields().isEmpty()) {
+            return;
+        }
+
+        for (IndexedField indexedField : flow.getIndexedFields()) {
+            try {
+                String rendered = runContext.render(indexedField.getValue());
+                if (rendered == null || rendered.isBlank()) {
+                    continue;
+                }
+
+                if (rendered.length() > MAX_VALUE_LENGTH) {
+                    LOG.debug(
+                        "Indexed field '{}' for execution '{}' was truncated from {} to {} characters",
+                        indexedField.getId(),
+                        execution.getId(),
+                        rendered.length(),
+                        MAX_VALUE_LENGTH
+                    );
+                    rendered = rendered.substring(0, MAX_VALUE_LENGTH);
+                }
+
+                ExecutionIndexedField field = new ExecutionIndexedField(
+                    execution.getTenantId(),
+                    execution.getId(),
+                    indexedField.getId(),
+                    rendered,
+                    execution.getNamespace(),
+                    execution.getFlowId()
+                );
+                indexedFieldRepository.save(field);
+            } catch (IllegalVariableEvaluationException e) {
+                LOG.warn(
+                    "Failed to render indexed field '{}' for execution '{}': {}",
+                    indexedField.getId(),
+                    execution.getId(),
+                    e.getMessage()
+                );
+            }
+        }
+    }
+
+    /**
+     * Purge (hard delete) indexed fields for a given list of executions.
+     *
+     * @return the number of deleted indexed fields
+     */
+    public int purge(List<Execution> executions) {
+        return this.indexedFieldRepository.purgeByExecutionIds(executions.stream().map(Execution::getId).toList());
+    }
+}

--- a/core/src/test/java/io/kestra/core/repositories/AbstractIndexedFieldRepositoryTest.java
+++ b/core/src/test/java/io/kestra/core/repositories/AbstractIndexedFieldRepositoryTest.java
@@ -1,0 +1,99 @@
+package io.kestra.core.repositories;
+
+import java.util.*;
+
+import org.junit.jupiter.api.Test;
+
+import io.kestra.core.models.executions.Execution;
+import io.kestra.core.models.executions.ExecutionIndexedField;
+import io.kestra.core.models.flows.State;
+import io.kestra.core.utils.IdUtils;
+import io.kestra.core.utils.TestsUtils;
+
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import jakarta.inject.Inject;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@MicronautTest(transactional = false)
+public abstract class AbstractIndexedFieldRepositoryTest {
+    @Inject
+    protected IndexedFieldRepositoryInterface indexedFieldRepository;
+
+    private Execution createExecution(String tenant, String executionId) {
+        return Execution.builder()
+            .id(executionId)
+            .tenantId(tenant)
+            .namespace("io.kestra.unittest")
+            .flowId("test-flow")
+            .flowRevision(1)
+            .state(new State())
+            .build();
+    }
+
+    @Test
+    void should_save_and_find_by_execution() {
+        String tenant = TestsUtils.randomTenant(this.getClass().getSimpleName());
+        String executionId = IdUtils.create();
+        Execution execution = createExecution(tenant, executionId);
+
+        indexedFieldRepository.save(new ExecutionIndexedField(tenant, executionId, "customer", "acme", "io.kestra.unittest", "test-flow"));
+        indexedFieldRepository.save(new ExecutionIndexedField(tenant, executionId, "order", "12345", "io.kestra.unittest", "test-flow"));
+
+        List<ExecutionIndexedField> fields = indexedFieldRepository.findByExecution(execution);
+        assertThat(fields).hasSize(2);
+        assertThat(fields)
+            .extracting(ExecutionIndexedField::key)
+            .containsExactlyInAnyOrder("customer", "order");
+        assertThat(fields)
+            .extracting(ExecutionIndexedField::value)
+            .containsExactlyInAnyOrder("acme", "12345");
+    }
+
+    @Test
+    void should_find_execution_ids_by_exact_value() {
+        String tenant = TestsUtils.randomTenant(this.getClass().getSimpleName());
+        String executionId = IdUtils.create();
+        indexedFieldRepository.save(new ExecutionIndexedField(tenant, executionId, "customer", "acme", "io.kestra.unittest", "test-flow"));
+
+        List<String> exact = indexedFieldRepository.findExecutionIds(tenant, "customer", "acme", true);
+        assertThat(exact).containsExactly(executionId);
+
+        List<String> noMatch = indexedFieldRepository.findExecutionIds(tenant, "customer", "other", true);
+        assertThat(noMatch).isEmpty();
+    }
+
+    @Test
+    void should_find_execution_ids_by_substring_value() {
+        String tenant = TestsUtils.randomTenant(this.getClass().getSimpleName());
+        String executionId = IdUtils.create();
+        indexedFieldRepository.save(new ExecutionIndexedField(tenant, executionId, "customer", "acme-corp", "io.kestra.unittest", "test-flow"));
+
+        List<String> matches = indexedFieldRepository.findExecutionIds(tenant, "customer", "corp", false);
+        assertThat(matches).containsExactly(executionId);
+    }
+
+    @Test
+    void should_isolate_tenants() {
+        String tenant1 = TestsUtils.randomTenant(this.getClass().getSimpleName());
+        String tenant2 = TestsUtils.randomTenant(this.getClass().getSimpleName());
+        String executionId = IdUtils.create();
+        indexedFieldRepository.save(new ExecutionIndexedField(tenant1, executionId, "customer", "acme", "io.kestra.unittest", "test-flow"));
+
+        assertThat(indexedFieldRepository.findExecutionIds(tenant1, "customer", "acme", true)).containsExactly(executionId);
+        assertThat(indexedFieldRepository.findExecutionIds(tenant2, "customer", "acme", true)).isEmpty();
+    }
+
+    @Test
+    void should_purge_by_execution_ids() {
+        String tenant = TestsUtils.randomTenant(this.getClass().getSimpleName());
+        String executionId1 = IdUtils.create();
+        String executionId2 = IdUtils.create();
+        indexedFieldRepository.save(new ExecutionIndexedField(tenant, executionId1, "customer", "acme", "io.kestra.unittest", "test-flow"));
+        indexedFieldRepository.save(new ExecutionIndexedField(tenant, executionId2, "customer", "other", "io.kestra.unittest", "test-flow"));
+
+        int purged = indexedFieldRepository.purgeByExecutionIds(List.of(executionId1, executionId2));
+        assertThat(purged).isEqualTo(2);
+        assertThat(indexedFieldRepository.findByExecution(createExecution(tenant, executionId1))).isEmpty();
+    }
+}

--- a/core/src/test/java/io/kestra/plugin/core/flow/IndexedFieldsTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/flow/IndexedFieldsTest.java
@@ -1,0 +1,49 @@
+package io.kestra.plugin.core.flow;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import io.kestra.core.junit.annotations.ExecuteFlow;
+import io.kestra.core.junit.annotations.KestraTest;
+import io.kestra.core.models.executions.Execution;
+import io.kestra.core.models.executions.ExecutionIndexedField;
+import io.kestra.core.repositories.IndexedFieldRepositoryInterface;
+
+import jakarta.inject.Inject;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@KestraTest(startRunner = true)
+class IndexedFieldsTest {
+    @Inject
+    private IndexedFieldRepositoryInterface indexedFieldRepository;
+
+    @Test
+    @ExecuteFlow("flows/valids/indexed-fields.yaml")
+    void shouldStoreIndexedFieldsWhenExecutionEnds(Execution execution) {
+        List<ExecutionIndexedField> fields = indexedFieldRepository.findByExecution(execution);
+        assertThat(fields).hasSize(2);
+        assertThat(fields)
+            .extracting(ExecutionIndexedField::key)
+            .containsExactlyInAnyOrder("customerId", "region");
+        assertThat(fields)
+            .filteredOn(field -> field.key().equals("customerId"))
+            .extracting(ExecutionIndexedField::value)
+            .containsExactly("acme-corp");
+        assertThat(fields)
+            .filteredOn(field -> field.key().equals("region"))
+            .extracting(ExecutionIndexedField::value)
+            .containsExactly("europe");
+    }
+
+    @Test
+    @ExecuteFlow("flows/valids/indexed-fields.yaml")
+    void shouldBeSearchableByIndexedField(Execution execution) {
+        List<String> exact = indexedFieldRepository.findExecutionIds(execution.getTenantId(), "customerId", "acme-corp", true);
+        assertThat(exact).contains(execution.getId());
+
+        List<String> substring = indexedFieldRepository.findExecutionIds(execution.getTenantId(), "customerId", "acme", false);
+        assertThat(substring).contains(execution.getId());
+    }
+}

--- a/core/src/test/resources/flows/valids/indexed-fields.yaml
+++ b/core/src/test/resources/flows/valids/indexed-fields.yaml
@@ -1,0 +1,13 @@
+id: indexed-fields
+namespace: io.kestra.tests
+
+indexedFields:
+  - id: customerId
+    value: "acme-corp"
+  - id: region
+    value: "{{ outputs.setoutput.value }}"
+
+tasks:
+  - id: setoutput
+    type: io.kestra.plugin.core.debug.Return
+    format: "europe"

--- a/executor/src/main/java/io/kestra/executor/ExecutorService.java
+++ b/executor/src/main/java/io/kestra/executor/ExecutorService.java
@@ -70,6 +70,7 @@ public class ExecutorService {
     private final TaskOutputService taskOutputService;
     private final ExecutionOutputService executionOutputService;
     private final PausedTaskNotifier pausedTaskNotifier;
+    private final IndexedFieldService indexedFieldService;
 
     @Inject
     public ExecutorService(
@@ -88,6 +89,7 @@ public class ExecutorService {
         TaskOutputService taskOutputService,
         ExecutionOutputService executionOutputService,
         PausedTaskNotifier pausedTaskNotifier) {
+        IndexedFieldService indexedFieldService) {
         this.runContextFactory = runContextFactory;
         this.metricRegistry = metricRegistry;
         this.flowExecutorInterface = flowExecutorInterface;
@@ -103,6 +105,7 @@ public class ExecutorService {
         this.taskOutputService = taskOutputService;
         this.executionOutputService = executionOutputService;
         this.pausedTaskNotifier = pausedTaskNotifier;
+        this.indexedFieldService = indexedFieldService;
     }
 
     /**
@@ -461,8 +464,9 @@ public class ExecutorService {
         Execution newExecution = executor.getExecution()
             .withState(finalState);
 
+        RunContext runContext = runContextFactory.of(executor.getFlow(), executor.getExecution());
+
         if (flow.getOutputs() != null) {
-            RunContext runContext = runContextFactory.of(executor.getFlow(), executor.getExecution());
             var inputAndOutput = runContext.inputAndOutput();
 
             try {
@@ -478,6 +482,14 @@ public class ExecutorService {
                 );
                 runContext.logger().error("Failed to render output values: {}", e.getMessage(), e);
                 newExecution = newExecution.withState(State.Type.FAILED);
+            }
+        }
+
+        if (flow.getIndexedFields() != null) {
+            try {
+                indexedFieldService.saveIndexedFields(runContext, flow, newExecution);
+            } catch (Exception e) {
+                runContext.logger().warn("Failed to save indexed fields: {}", e.getMessage(), e);
             }
         }
 

--- a/jdbc-h2/src/main/java/io/kestra/repository/h2/H2IndexedFieldRepository.java
+++ b/jdbc-h2/src/main/java/io/kestra/repository/h2/H2IndexedFieldRepository.java
@@ -1,0 +1,15 @@
+package io.kestra.repository.h2;
+
+import io.kestra.core.models.executions.ExecutionIndexedField;
+import io.kestra.core.repositories.RepositoryBean;
+import io.kestra.jdbc.repository.AbstractJdbcIndexedFieldRepository;
+
+import jakarta.inject.Named;
+
+@RepositoryBean
+@H2RepositoryEnabled
+public class H2IndexedFieldRepository extends AbstractJdbcIndexedFieldRepository {
+    public H2IndexedFieldRepository(@Named("indexedfields") H2Repository<ExecutionIndexedField> jdbcRepository) {
+        super(jdbcRepository);
+    }
+}

--- a/jdbc-h2/src/main/java/io/kestra/repository/h2/migration/V2_0_23ExecutionIndexedFieldsMigration.java
+++ b/jdbc-h2/src/main/java/io/kestra/repository/h2/migration/V2_0_23ExecutionIndexedFieldsMigration.java
@@ -1,0 +1,36 @@
+package io.kestra.repository.h2.migration;
+
+import java.util.List;
+
+import javax.sql.DataSource;
+
+import io.kestra.jdbc.migration.AbstractV2_0_23ExecutionIndexedFieldsMigration;
+
+import io.micronaut.context.annotation.Requires;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+
+/**
+ * OSS H2 execution indexed fields migration.
+ */
+@Singleton
+@Requires(property = "kestra.repository.type", pattern = "h2|memory")
+public class V2_0_23ExecutionIndexedFieldsMigration extends AbstractV2_0_23ExecutionIndexedFieldsMigration {
+
+    private final DataSource dataSource;
+
+    @Inject
+    public V2_0_23ExecutionIndexedFieldsMigration(final DataSource dataSource) {
+        this.dataSource = dataSource;
+    }
+
+    @Override
+    protected DataSource dataSource() {
+        return dataSource;
+    }
+
+    @Override
+    public List<String> sqlResources() {
+        return List.of("/migrations/2.0.23-execution-indexed-fields-h2.sql");
+    }
+}

--- a/jdbc-h2/src/main/resources/migrations/2.0.23-execution-indexed-fields-h2.sql
+++ b/jdbc-h2/src/main/resources/migrations/2.0.23-execution-indexed-fields-h2.sql
@@ -1,0 +1,15 @@
+-- New table: execution indexed fields
+CREATE TABLE IF NOT EXISTS execution_indexed_fields (
+    "key"          VARCHAR(250) NOT NULL PRIMARY KEY,
+    "tenant_id"    VARCHAR(150),
+    "execution_id" VARCHAR(150) NOT NULL,
+    "field_key"    VARCHAR(128) NOT NULL,
+    "field_value"  TEXT,
+    "namespace"    VARCHAR(150),
+    "flow_id"      VARCHAR(150),
+    "value"        TEXT
+);
+
+CREATE INDEX IF NOT EXISTS execution_indexed_fields_execution_id ON execution_indexed_fields ("execution_id");
+CREATE INDEX IF NOT EXISTS execution_indexed_fields_tenant_key_value ON execution_indexed_fields ("tenant_id", "field_key", "field_value");
+CREATE INDEX IF NOT EXISTS execution_indexed_fields_tenant_ns_flow ON execution_indexed_fields ("tenant_id", "namespace", "flow_id");

--- a/jdbc-h2/src/test/java/io/kestra/repository/h2/H2IndexedFieldRepositoryTest.java
+++ b/jdbc-h2/src/test/java/io/kestra/repository/h2/H2IndexedFieldRepositoryTest.java
@@ -1,0 +1,6 @@
+package io.kestra.repository.h2;
+
+import io.kestra.core.repositories.AbstractIndexedFieldRepositoryTest;
+
+class H2IndexedFieldRepositoryTest extends AbstractIndexedFieldRepositoryTest {
+}

--- a/jdbc-mysql/src/main/java/io/kestra/repository/mysql/MysqlIndexedFieldRepository.java
+++ b/jdbc-mysql/src/main/java/io/kestra/repository/mysql/MysqlIndexedFieldRepository.java
@@ -1,0 +1,15 @@
+package io.kestra.repository.mysql;
+
+import io.kestra.core.models.executions.ExecutionIndexedField;
+import io.kestra.core.repositories.RepositoryBean;
+import io.kestra.jdbc.repository.AbstractJdbcIndexedFieldRepository;
+
+import jakarta.inject.Named;
+
+@RepositoryBean
+@MysqlRepositoryEnabled
+public class MysqlIndexedFieldRepository extends AbstractJdbcIndexedFieldRepository {
+    public MysqlIndexedFieldRepository(@Named("indexedfields") MysqlRepository<ExecutionIndexedField> jdbcRepository) {
+        super(jdbcRepository);
+    }
+}

--- a/jdbc-mysql/src/main/java/io/kestra/repository/mysql/migration/V2_0_23ExecutionIndexedFieldsMigration.java
+++ b/jdbc-mysql/src/main/java/io/kestra/repository/mysql/migration/V2_0_23ExecutionIndexedFieldsMigration.java
@@ -1,0 +1,36 @@
+package io.kestra.repository.mysql.migration;
+
+import java.util.List;
+
+import javax.sql.DataSource;
+
+import io.kestra.jdbc.migration.AbstractV2_0_23ExecutionIndexedFieldsMigration;
+
+import io.micronaut.context.annotation.Requires;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+
+/**
+ * OSS MySQL execution indexed fields migration.
+ */
+@Singleton
+@Requires(property = "kestra.repository.type", pattern = "mysql")
+public class V2_0_23ExecutionIndexedFieldsMigration extends AbstractV2_0_23ExecutionIndexedFieldsMigration {
+
+    private final DataSource dataSource;
+
+    @Inject
+    public V2_0_23ExecutionIndexedFieldsMigration(final DataSource dataSource) {
+        this.dataSource = dataSource;
+    }
+
+    @Override
+    protected DataSource dataSource() {
+        return dataSource;
+    }
+
+    @Override
+    public List<String> sqlResources() {
+        return List.of("/migrations/2.0.23-execution-indexed-fields-mysql.sql");
+    }
+}

--- a/jdbc-mysql/src/main/resources/migrations/2.0.23-execution-indexed-fields-mysql.sql
+++ b/jdbc-mysql/src/main/resources/migrations/2.0.23-execution-indexed-fields-mysql.sql
@@ -1,0 +1,15 @@
+-- New table: execution indexed fields
+CREATE TABLE IF NOT EXISTS execution_indexed_fields (
+    `key`          VARCHAR(250) NOT NULL PRIMARY KEY,
+    `tenant_id`    VARCHAR(150),
+    `execution_id` VARCHAR(150) NOT NULL,
+    `field_key`    VARCHAR(128) NOT NULL,
+    `field_value`  TEXT,
+    `namespace`    VARCHAR(150),
+    `flow_id`      VARCHAR(150),
+    `value`        TEXT
+) ENGINE INNODB CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+CREATE INDEX IF NOT EXISTS execution_indexed_fields_execution_id ON execution_indexed_fields (`execution_id`);
+CREATE INDEX IF NOT EXISTS execution_indexed_fields_tenant_key_value ON execution_indexed_fields (`tenant_id`, `field_key`, `field_value`);
+CREATE INDEX IF NOT EXISTS execution_indexed_fields_tenant_ns_flow ON execution_indexed_fields (`tenant_id`, `namespace`, `flow_id`);

--- a/jdbc-postgres/src/main/java/io/kestra/repository/postgres/PostgresIndexedFieldRepository.java
+++ b/jdbc-postgres/src/main/java/io/kestra/repository/postgres/PostgresIndexedFieldRepository.java
@@ -1,0 +1,15 @@
+package io.kestra.repository.postgres;
+
+import io.kestra.core.models.executions.ExecutionIndexedField;
+import io.kestra.core.repositories.RepositoryBean;
+import io.kestra.jdbc.repository.AbstractJdbcIndexedFieldRepository;
+
+import jakarta.inject.Named;
+
+@RepositoryBean
+@PostgresRepositoryEnabled
+public class PostgresIndexedFieldRepository extends AbstractJdbcIndexedFieldRepository {
+    public PostgresIndexedFieldRepository(@Named("indexedfields") PostgresRepository<ExecutionIndexedField> jdbcRepository) {
+        super(jdbcRepository);
+    }
+}

--- a/jdbc-postgres/src/main/java/io/kestra/repository/postgres/migration/V2_0_23ExecutionIndexedFieldsMigration.java
+++ b/jdbc-postgres/src/main/java/io/kestra/repository/postgres/migration/V2_0_23ExecutionIndexedFieldsMigration.java
@@ -1,0 +1,36 @@
+package io.kestra.repository.postgres.migration;
+
+import java.util.List;
+
+import javax.sql.DataSource;
+
+import io.kestra.jdbc.migration.AbstractV2_0_23ExecutionIndexedFieldsMigration;
+
+import io.micronaut.context.annotation.Requires;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+
+/**
+ * OSS Postgres execution indexed fields migration.
+ */
+@Singleton
+@Requires(property = "kestra.repository.type", pattern = "postgres")
+public class V2_0_23ExecutionIndexedFieldsMigration extends AbstractV2_0_23ExecutionIndexedFieldsMigration {
+
+    private final DataSource dataSource;
+
+    @Inject
+    public V2_0_23ExecutionIndexedFieldsMigration(final DataSource dataSource) {
+        this.dataSource = dataSource;
+    }
+
+    @Override
+    protected DataSource dataSource() {
+        return dataSource;
+    }
+
+    @Override
+    public List<String> sqlResources() {
+        return List.of("/migrations/2.0.23-execution-indexed-fields-postgres.sql");
+    }
+}

--- a/jdbc-postgres/src/main/resources/migrations/2.0.23-execution-indexed-fields-postgres.sql
+++ b/jdbc-postgres/src/main/resources/migrations/2.0.23-execution-indexed-fields-postgres.sql
@@ -1,0 +1,15 @@
+-- New table: execution indexed fields
+CREATE TABLE IF NOT EXISTS execution_indexed_fields (
+    "key"          VARCHAR(250) NOT NULL PRIMARY KEY,
+    "tenant_id"    VARCHAR(150),
+    "execution_id" VARCHAR(150) NOT NULL,
+    "field_key"    VARCHAR(128) NOT NULL,
+    "field_value"  TEXT,
+    "namespace"    VARCHAR(150),
+    "flow_id"      VARCHAR(150),
+    "value"        TEXT
+);
+
+CREATE INDEX IF NOT EXISTS execution_indexed_fields_execution_id ON execution_indexed_fields ("execution_id");
+CREATE INDEX IF NOT EXISTS execution_indexed_fields_tenant_key_value ON execution_indexed_fields ("tenant_id", "field_key", "field_value");
+CREATE INDEX IF NOT EXISTS execution_indexed_fields_tenant_ns_flow ON execution_indexed_fields ("tenant_id", "namespace", "flow_id");

--- a/jdbc/src/main/java/io/kestra/jdbc/JdbcTableConfigsFactory.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/JdbcTableConfigsFactory.java
@@ -9,6 +9,7 @@ import io.kestra.core.models.Setting;
 import io.kestra.core.models.dashboards.Dashboard;
 import io.kestra.core.models.executions.Execution;
 import io.kestra.core.models.executions.ExecutionOutput;
+import io.kestra.core.models.executions.ExecutionIndexedField;
 import io.kestra.core.models.executions.LogEntry;
 import io.kestra.core.models.executions.MetricEntry;
 import io.kestra.core.models.executions.TaskOutput;
@@ -163,6 +164,11 @@ public class JdbcTableConfigsFactory {
     @Named("executionoutputs")
     public InstantiableJdbcTableConfig executionOutputs() {
         return new InstantiableJdbcTableConfig("executionoutputs", ExecutionOutput.class, "execution_outputs");
+    }    
+        
+    @Named("indexedfields")
+    public InstantiableJdbcTableConfig indexedFields() {
+        return new InstantiableJdbcTableConfig("indexedfields", ExecutionIndexedField.class, "execution_indexed_fields");
     }
 
     @Bean

--- a/jdbc/src/main/java/io/kestra/jdbc/migration/AbstractV2_0_23ExecutionIndexedFieldsMigration.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/migration/AbstractV2_0_23ExecutionIndexedFieldsMigration.java
@@ -1,0 +1,22 @@
+package io.kestra.jdbc.migration;
+
+/**
+ * Abstract base for the 2.0.23 execution indexed fields migration.
+ *
+ * <p>
+ * Creates the {@code execution_indexed_fields} table that stores per-execution key/value pairs (plain string values)
+ * computed from flow-declared Pebble expressions at execution end, so executions can be searched efficiently without
+ * indexing the full task or flow outputs.
+ */
+public abstract class AbstractV2_0_23ExecutionIndexedFieldsMigration extends AbstractSQLMigrationScript {
+
+    @Override
+    public String scriptId() {
+        return "2.0.23-execution-indexed-fields";
+    }
+
+    @Override
+    public String description() {
+        return "Create the execution_indexed_fields table for searchable indexed fields";
+    }
+}

--- a/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcExecutionRepository.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcExecutionRepository.java
@@ -26,6 +26,8 @@ import io.kestra.core.models.flows.State;
 import io.kestra.core.models.triggers.TriggerId;
 import io.kestra.core.repositories.ArrayListTotal;
 import io.kestra.core.repositories.ExecutionRepositoryInterface;
+import io.kestra.core.repositories.ExecutionRepositoryInterface.DateFilter;
+import io.kestra.core.repositories.IndexedFieldRepositoryInterface;
 import io.kestra.core.utils.DateUtils;
 import io.kestra.core.utils.Either;
 import io.kestra.core.utils.Enums;
@@ -38,6 +40,7 @@ import io.kestra.plugin.core.dashboard.data.Executions;
 import io.micronaut.context.event.ApplicationEventPublisher;
 import io.micronaut.data.model.Pageable;
 import jakarta.annotation.Nullable;
+import jakarta.inject.Inject;
 import lombok.Getter;
 import lombok.SneakyThrows;
 import reactor.core.publisher.Flux;
@@ -54,6 +57,9 @@ public abstract class AbstractJdbcExecutionRepository extends AbstractJdbcCrudRe
     private final SystemFlowsConfiguration systemFlowsConfiguration;
 
     private final JdbcFilterService filterService;
+
+    @Inject
+    private IndexedFieldRepositoryInterface indexedFieldRepository;
 
     @Getter
     private final Map<Executions.Fields, String> fieldsMapping = Map.of(
@@ -307,6 +313,17 @@ public abstract class AbstractJdbcExecutionRepository extends AbstractJdbcCrudRe
     @Override
     public ArrayListTotal<Execution> findByFlowId(String tenantId, String namespace, String id, Pageable pageable) {
         var condition = field("namespace").eq(namespace).and(field("flow_id").eq(id));
+        return findPage(pageable, tenantId, condition);
+    }
+
+    @Override
+    public ArrayListTotal<Execution> findByIndexedField(String tenantId, String key, String value, boolean exactMatch, Pageable pageable) {
+        List<String> executionIds = indexedFieldRepository.findExecutionIds(tenantId, key, value, exactMatch);
+        if (executionIds.isEmpty()) {
+            return new ArrayListTotal<>(List.of(), 0);
+        }
+
+        var condition = KEY_FIELD.in(executionIds);
         return findPage(pageable, tenantId, condition);
     }
 

--- a/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcIndexedFieldRepository.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcIndexedFieldRepository.java
@@ -1,0 +1,103 @@
+package io.kestra.jdbc.repository;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.jooq.Field;
+import org.jooq.impl.DSL;
+
+import io.kestra.core.models.executions.Execution;
+import io.kestra.core.models.executions.ExecutionIndexedField;
+import io.kestra.core.repositories.IndexedFieldRepositoryInterface;
+import io.kestra.jdbc.AbstractJdbcRepository;
+
+public class AbstractJdbcIndexedFieldRepository extends io.kestra.jdbc.repository.AbstractJdbcRepository implements IndexedFieldRepositoryInterface {
+    public static final Field<String> EXECUTION_ID_FIELD = field("execution_id", String.class);
+    public static final Field<String> TENANT_ID_FIELD = field("tenant_id", String.class);
+    public static final Field<String> FIELD_KEY_FIELD = field("field_key", String.class);
+    public static final Field<String> FIELD_VALUE_FIELD = field("field_value", String.class);
+
+    private final AbstractJdbcRepository<ExecutionIndexedField> jdbcRepository;
+
+    public AbstractJdbcIndexedFieldRepository(AbstractJdbcRepository<ExecutionIndexedField> jdbcRepository) {
+        this.jdbcRepository = jdbcRepository;
+    }
+
+    @Override
+    public ExecutionIndexedField save(ExecutionIndexedField indexedField) {
+        Map<Field<Object>, Object> fields = HashMap.newHashMap(7);
+        fields.put(field("tenant_id"), indexedField.tenantId());
+        fields.put(field("execution_id"), indexedField.executionId());
+        fields.put(field("field_key"), indexedField.key());
+        fields.put(field("field_value"), indexedField.value());
+        fields.put(field("namespace"), indexedField.namespace());
+        fields.put(field("flow_id"), indexedField.flowId());
+        jdbcRepository.persist(indexedField, fields);
+        return indexedField;
+    }
+
+    @Override
+    public List<ExecutionIndexedField> findByExecution(Execution execution) {
+        var condition = EXECUTION_ID_FIELD.eq(execution.getId());
+        return this.jdbcRepository
+            .getDslContextWrapper()
+            .transactionResult(configuration ->
+            {
+                var select = DSL
+                    .using(configuration)
+                    .select()
+                    .from(this.jdbcRepository.getTable())
+                    .where(buildTenantCondition(execution.getTenantId()))
+                    .and(condition);
+
+                return select.fetch().map(record -> map(record));
+            });
+    }
+
+    @Override
+    public List<String> findExecutionIds(String tenantId, String key, String value, boolean exactMatch) {
+        var condition = FIELD_KEY_FIELD.eq(key)
+            .and(exactMatch ? FIELD_VALUE_FIELD.eq(value) : FIELD_VALUE_FIELD.contains(value));
+
+        return this.jdbcRepository
+            .getDslContextWrapper()
+            .transactionResult(configuration ->
+            {
+                var select = DSL
+                    .using(configuration)
+                    .selectDistinct(EXECUTION_ID_FIELD)
+                    .from(this.jdbcRepository.getTable())
+                    .where(buildTenantCondition(tenantId))
+                    .and(condition);
+
+                return select.fetch().map(record -> record.get(EXECUTION_ID_FIELD));
+            });
+    }
+
+    @Override
+    public int purgeByExecutionIds(List<String> executionIds) {
+        return this.jdbcRepository
+            .getDslContextWrapper()
+            .transactionResult(configuration ->
+            {
+                var delete = DSL
+                    .using(configuration)
+                    .delete(this.jdbcRepository.getTable())
+                    .where(EXECUTION_ID_FIELD.in(executionIds));
+
+                return delete.execute();
+            });
+    }
+
+    private static ExecutionIndexedField map(org.jooq.Record record) {
+        return new ExecutionIndexedField(
+            record.get(TENANT_ID_FIELD),
+            record.get(EXECUTION_ID_FIELD),
+            record.get(FIELD_KEY_FIELD),
+            record.get(FIELD_VALUE_FIELD),
+            record.get(field("namespace", String.class)),
+            record.get(field("flow_id", String.class))
+        );
+    }
+}

--- a/webserver/src/main/java/io/kestra/webserver/controllers/api/ExecutionController.java
+++ b/webserver/src/main/java/io/kestra/webserver/controllers/api/ExecutionController.java
@@ -636,6 +636,22 @@ public class ExecutionController {
     }
 
     @ExecuteOn(TaskExecutors.IO)
+    @Get(uri = "/indexed-fields/search")
+    @Operation(tags = { "Executions" }, summary = "Search for executions by an indexed field")
+    public PagedResults<ApiLightExecution> searchExecutionsByIndexedField(
+        @Parameter(description = "The indexed field key") @QueryValue String key,
+        @Parameter(description = "The value to match") @QueryValue String value,
+        @Parameter(description = "Whether to match the value exactly or as a substring") @QueryValue(defaultValue = "true") boolean exactMatch,
+        @Parameter(description = "The current page") @QueryValue(defaultValue = "1") @Min(1) int page,
+        @Parameter(description = "The current page size") @QueryValue(defaultValue = "10") @Min(1) int size) {
+        var executions = executionRepository.findByIndexedField(tenantService.resolveTenant(), key, value, exactMatch, PageableUtils.from(page, size));
+        var apiExecution = executions.stream()
+            .map(execution -> ApiLightExecution.of(execution))
+            .toList();
+        return PagedResults.of(new ArrayListTotal<>(apiExecution, executions.getTotal()));
+    }
+
+    @ExecuteOn(TaskExecutors.IO)
     @Get(uri = "/webhook/{namespace}/{id}/{key}{/path}", consumes = { MediaType.ALL })
     @Operation(tags = { "Executions" }, summary = "Trigger a new execution by GET webhook trigger")
     @ApiResponse(responseCode = "200", description = "On success", content = { @Content(schema = @Schema(implementation = WebhookResponse.class)) })


### PR DESCRIPTION
Fixes #18000 

## Indexed Fields

Add a new flow-level capability to derive searchable key/value pairs from Pebble
expressions at execution end, stored in a dedicated `execution_indexed_fields` table
so executions can be found without indexing full outputs.

### Feature
- Declare `indexedFields` on a flow, each a `key` plus a Pebble `value` (literal or
  expression referencing outputs, inputs, etc.).
- Fields are rendered from the final run context once, in the executor `onEnd` hook,
  alongside outputs.
- Values are capped at 1024 chars (truncated, not failing the insert) to stay portable.
- New endpoint `GET /api/v1/{tenant}/executions/indexed-fields/search` supports exact
  and substring (`LIKE`) lookups, tenant isolated, returning matching executions.
- Deleting/purging an execution also removes its indexed rows.

### Design
- One row per (execution, key): `tenant_id`, `execution_id`, `field_key`, `field_value`,
  `namespace`, `flow_id`.
- Portable btree index on `(tenant_id, field_key, field_value)` for exact match; substring
  via `LIKE` (H2) / `pg_trgm` GIN (Postgres) / ngram FULLTEXT (MySQL) as a later accelerator.
- Migrations at version `2.0.23` for H2, MySQL and Postgres.
- Indexed fields are intentionally NOT exposed in the run context during execution.

### Tested
- Unit tests for the repository (save, findByExecution, tenant isolation, purge, substring
  search) and an end-to-end test that runs a real flow and verifies fields are computed and
  searchable. Live run on a standalone server confirmed exact + substring search works.
  
  
```
I tested the Indexed Fields implementation end to end on a running standalone (runLocal) server with the following steps:

1. Created a flow with indexed fields declared at flow level, mixing a literal value and a Pebble expression resolved from a task output:
   - customerId: "acme-corp"  (literal)
   - region: "{{ outputs.setoutput.value }}"  (dynamic, resolves from a task output)

2. Triggered the execution via the API. It ran to SUCCESS (CREATED -> RUNNING -> SUCCESS).

3. Queried the new search endpoint GET /api/v1/{tenant}/executions/indexed-fields/search:
   - exact match key=customerId value=acme-corp  -> returns the execution (total:1)
   - substring match key=customerId value=acme exactMatch=false -> returns the execution (total:1)
   - exact match key=region value=europe (the Pebble expression resolved correctly) -> returns the execution (total:1)
   - substring match key=region value=uro exactMatch=false -> returns the execution (total:1)
   - non matching value -> returns total:0 (correct)

This confirms that indexed fields are computed at execution end, persisted in the new execution_indexed_fields table (migration 2.0.23 applied on startup), and searchable by exact and substring match, with tenant isolation.

4. Automated tests also pass:
   - H2IndexedFieldRepositoryTest (save/find/tenant isolation/purge/substring search)
   - IndexedFieldsTest (real flow run: indexed fields computed at execution end and searchable)

5. Production note: indexed field values are capped at 1024 characters (truncated, not failing the insert) so large rendered values stay portable and do not blow up the index. DB specific fulltext accelerators (Postgres pg_trgm GIN, MySQL ngram FULLTEXT) are left as an incremental follow up.

```