### PR TITLE
fix(worker): surface gRPC message size rejections in the execution logs

### DIFF
--- a/worker-controller/src/main/java/io/kestra/controller/grpc/services/WorkerJobDispatcher.java
+++ b/worker-controller/src/main/java/io/kestra/controller/grpc/services/WorkerJobDispatcher.java
@@ -1043,8 +1043,6 @@ public class WorkerJobDispatcher {
 
         // Fail the job cleanly so the execution reaches a terminal state.
         if (job instanceof WorkerTask workerTask) {
-            // The worker never receives the job so it never logs the reason: without this the user
-            // only sees a FAILED task run with no logs.
             emitJobLog(
                 runContextLoggerFactory.create(workerTask),
                 LogEntry.of(workerTask.getTaskRun(), workerTask.getExecutionKind()),

--- a/worker-controller/src/main/java/io/kestra/controller/grpc/services/WorkerJobDispatcher.java
+++ b/worker-controller/src/main/java/io/kestra/controller/grpc/services/WorkerJobDispatcher.java
@@ -2,6 +2,7 @@ package io.kestra.controller.grpc.services;
 
 import java.io.IOException;
 import java.time.Duration;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -20,6 +21,8 @@ import java.util.stream.Stream;
 
 import javax.annotation.concurrent.ThreadSafe;
 
+import org.slf4j.event.Level;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
@@ -34,6 +37,7 @@ import io.kestra.core.executor.WorkerJobRunningStateStore;
 import io.kestra.core.metrics.MetricRegistry;
 import io.kestra.core.models.executions.ExecutionKilled;
 import io.kestra.core.models.executions.ExecutionKilledExecution;
+import io.kestra.core.models.executions.LogEntry;
 import io.kestra.core.models.executions.TaskRun;
 import io.kestra.core.models.flows.State;
 import io.kestra.core.models.triggers.TriggerContext;
@@ -160,6 +164,11 @@ public class WorkerJobDispatcher {
      */
     private final List<WorkerLifecycleListener> lifecycleListeners;
 
+    /**
+     * Builds the loggers used to surface dispatch failures in the user-facing execution logs.
+     */
+    private final RunContextLoggerFactory runContextLoggerFactory;
+
     @Inject
     public WorkerJobDispatcher(
         KeyedDispatchQueueInterface<WorkerJobEvent> workerJobEventQueue,
@@ -171,7 +180,8 @@ public class WorkerJobDispatcher {
         MetricRegistry metricRegistry,
         MetadataChangeListener metadataChangeListener,
         WorkerQueueResolver workerQueueResolver,
-        List<WorkerLifecycleListener> lifecycleListeners) {
+        List<WorkerLifecycleListener> lifecycleListeners,
+        RunContextLoggerFactory runContextLoggerFactory) {
         this.workerJobEventQueue = workerJobEventQueue;
         this.workerJobRunningStateStore = workerJobRunningStateStore;
         this.workerTaskResultQueue = workerTaskResultQueue;
@@ -180,6 +190,7 @@ public class WorkerJobDispatcher {
         this.metadataChangeListener = metadataChangeListener;
         this.workerQueueResolver = workerQueueResolver;
         this.lifecycleListeners = List.copyOf(lifecycleListeners);
+        this.runContextLoggerFactory = runContextLoggerFactory;
 
         // Construct broadcast subscribers and gauges with cleanup on partial failure.
         // @PreDestroy is not invoked when bean construction fails, so any subscriber that has
@@ -1032,14 +1043,45 @@ public class WorkerJobDispatcher {
 
         // Fail the job cleanly so the execution reaches a terminal state.
         if (job instanceof WorkerTask workerTask) {
+            // The worker never receives the job so it never logs the reason: without this the user
+            // only sees a FAILED task run with no logs.
+            emitJobLog(
+                runContextLoggerFactory.create(workerTask),
+                LogEntry.of(workerTask.getTaskRun(), workerTask.getExecutionKind()),
+                oversizedPayloadMessage("task", context.getWorkerId(), payloadSize, workerLimit)
+            );
+
             try {
                 workerTaskResultQueue.emit(new WorkerTaskResult(workerTask.getTaskRun().fail()));
             } catch (QueueException e) {
                 log.error("Failed to emit FAILED result for oversized job {}: {}", job.uid(), e.getMessage(), e);
             }
         } else if (job instanceof WorkerTrigger workerTrigger) {
+            emitJobLog(
+                runContextLoggerFactory.create(workerTrigger.triggerId(), workerTrigger.getTrigger()),
+                LogEntry.of(workerTrigger.triggerId(), workerTrigger.getTrigger()),
+                oversizedPayloadMessage("trigger", context.getWorkerId(), payloadSize, workerLimit)
+            );
+
             triggerEventQueue.send(new TriggerEvaluated(workerTrigger.triggerId(), null));
         }
+    }
+
+    private static String oversizedPayloadMessage(String jobKind, String workerId, int payloadSize, int workerLimit) {
+        return ("Cannot dispatch this %s to worker '%s': its serialized payload is %d bytes and exceeds the maximum inbound gRPC message size of %d bytes configured on that worker. "
+            + "Increase 'kestra.grpc.max-inbound-message-size' on the workers and on the worker controller, or reduce the amount of data it carries such as large inputs, variables or outputs.")
+            .formatted(jobKind, workerId, payloadSize, workerLimit);
+    }
+
+    private void emitJobLog(RunContextLogger logger, LogEntry template, String message) {
+        logger.emitLogIfEnabled(
+            template.toBuilder()
+                .level(Level.ERROR)
+                .message(message)
+                .timestamp(Instant.now())
+                .thread(Thread.currentThread().getName())
+                .build()
+        );
     }
 
     /**

--- a/worker-controller/src/test/java/io/kestra/controller/grpc/services/WorkerJobDispatcherTest.java
+++ b/worker-controller/src/test/java/io/kestra/controller/grpc/services/WorkerJobDispatcherTest.java
@@ -3,6 +3,7 @@ package io.kestra.controller.grpc.services;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.CyclicBarrier;
@@ -19,6 +20,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.slf4j.event.Level;
 
 import io.kestra.controller.grpc.WorkerJobResponse;
 import io.kestra.core.contexts.KestraContext;
@@ -26,21 +29,32 @@ import io.kestra.core.exceptions.DeserializationException;
 import io.kestra.core.executor.WorkerJobRunningStateStore;
 import io.kestra.core.metrics.MetricRegistry;
 import io.kestra.core.models.executions.ExecutionKilled;
+import io.kestra.core.models.executions.LogEntry;
 import io.kestra.core.models.executions.TaskRun;
+import io.kestra.core.models.flows.State;
 import io.kestra.core.queues.BroadcastQueueInterface;
 import io.kestra.core.queues.DispatchQueueInterface;
 import io.kestra.core.queues.KeyedDispatchQueueInterface;
 import io.kestra.core.queues.QueueException;
 import io.kestra.core.queues.QueueSubscriber;
+import io.kestra.core.runners.LogEntryEmitter;
+import io.kestra.core.runners.RunContextLoggerFactory;
 import io.kestra.core.runners.WorkerJob;
 import io.kestra.core.runners.WorkerJobEvent;
 import io.kestra.core.runners.WorkerTask;
+import io.kestra.core.runners.WorkerTaskData;
 import io.kestra.core.runners.WorkerTaskResult;
+import io.kestra.core.runners.WorkerTrigger;
+import io.kestra.core.runners.WorkerTriggerData;
+import io.kestra.core.runners.configuration.LoggingConfiguration;
+import io.kestra.core.scheduler.events.TriggerEvaluated;
 import io.kestra.core.scheduler.queue.TriggerEventQueue;
 import io.kestra.core.server.ClusterEvent;
 import io.kestra.core.utils.Either;
 import io.kestra.core.worker.WorkerGroups;
 import io.kestra.core.worker.WorkerQueues;
+import io.kestra.plugin.core.log.Log;
+import io.kestra.plugin.core.trigger.Schedule;
 
 import io.grpc.stub.StreamObserver;
 import io.micrometer.core.instrument.search.Search;
@@ -71,6 +85,7 @@ class WorkerJobDispatcherTest {
     private WorkerJobDispatcher dispatcher;
     private TriggerEventQueue mockTriggerEventQueue = mock(TriggerEventQueue.class);
     private MetricRegistry mockMetricRegistry = mock(MetricRegistry.class);
+    private LogEntryEmitter mockLogEntryEmitter = mock(LogEntryEmitter.class);
 
     // Captures for verifying interactions
     private List<MockQueueSubscriber> createdSubscribers;
@@ -91,6 +106,7 @@ class WorkerJobDispatcherTest {
         mockResultQueue = mock(DispatchQueueInterface.class);
         mockTriggerEventQueue = mock(TriggerEventQueue.class);
         mockMetricRegistry = mock(MetricRegistry.class);
+        mockLogEntryEmitter = mock(LogEntryEmitter.class);
         createdSubscribers = new ArrayList<>();
 
         // Mock workerQueueTags to return well-formed tag arrays.
@@ -156,7 +172,8 @@ class WorkerJobDispatcherTest {
     private WorkerJobDispatcher buildDispatcher(List<WorkerLifecycleListener> listeners) {
         return new WorkerJobDispatcher(
             mockQueue, mockStateStore, mockKillQueue, mockClusterEventQueue, mockResultQueue, mockTriggerEventQueue, mockMetricRegistry, mock(MetadataChangeListener.class),
-            new WorkerQueueResolver.Default(), listeners
+            new WorkerQueueResolver.Default(), listeners,
+            new RunContextLoggerFactory(mockLogEntryEmitter, new LoggingConfiguration(null))
         );
     }
 
@@ -207,6 +224,36 @@ class WorkerJobDispatcherTest {
         when(mockTask.getType()).thenReturn("task");
         when(mockTask.getTaskRun()).thenReturn(taskRun);
         return new WorkerJobEvent(workerGroup, mockTask);
+    }
+
+    private WorkerTask createWorkerTask(String taskRunId) {
+        return WorkerTask.builder()
+            .taskRun(
+                TaskRun.builder()
+                    .id(taskRunId)
+                    .tenantId("main")
+                    .namespace("io.kestra.test")
+                    .flowId("flow-1")
+                    .taskId("task-1")
+                    .executionId("exec-1")
+                    .state(new State())
+                    .build()
+            )
+            .task(Log.builder().id("task-1").type(Log.class.getName()).build())
+            .data(new WorkerTaskData(Map.of(), List.of(), null, null))
+            .build();
+    }
+
+    private WorkerTrigger createWorkerTrigger(String triggerId) {
+        return WorkerTrigger.builder()
+            .trigger(Schedule.builder().id(triggerId).type(Schedule.class.getName()).build())
+            .data(
+                new WorkerTriggerData(
+                    "main", "io.kestra.test", "flow-1", null, 1, null, null,
+                    Map.of(), List.of(), null, Map.of()
+                )
+            )
+            .build();
     }
 
     private MockQueueSubscriber getSubscriberForGroup(String group) {
@@ -477,6 +524,63 @@ class WorkerJobDispatcherTest {
             verify(context.getResponseObserver()).onNext(any(WorkerJobResponse.class));
             assertThat(context.getInFlightCount()).isEqualTo(1);
             assertThat(context.getAvailablePermits()).isEqualTo(4);
+        }
+
+        @Test
+        void shouldEmitTaskLogWhenPayloadExceedsWorkerInboundLimit() throws QueueException {
+            // Given
+            WorkerStreamContext<WorkerJobResponse> context = createWorkerContext("worker-1", WORKER_GROUP_A, 10);
+            context.addPermits(5);
+            context.setMaxInboundMessageSize(64);
+            dispatcher.registerWorker(context);
+
+            MockQueueSubscriber subscriber = getSubscriberForGroup(WORKER_GROUP_A);
+            WorkerJobEvent event = new WorkerJobEvent(WORKER_GROUP_A, createWorkerTask("taskrun-1"));
+
+            // When
+            subscriber.deliverJob(event);
+
+            // Then
+            ArgumentCaptor<LogEntry> captor = ArgumentCaptor.forClass(LogEntry.class);
+            verify(mockLogEntryEmitter).emits(captor.capture());
+
+            LogEntry logEntry = captor.getValue();
+            assertThat(logEntry.getLevel()).isEqualTo(Level.ERROR);
+            assertThat(logEntry.getTaskRunId()).isEqualTo("taskrun-1");
+            assertThat(logEntry.getExecutionId()).isEqualTo("exec-1");
+            assertThat(logEntry.getAttemptNumber()).isZero();
+            assertThat(logEntry.getMessage())
+                .contains("64 bytes")
+                .contains("kestra.grpc.max-inbound-message-size");
+
+            verify(mockResultQueue).emit(any(WorkerTaskResult.class));
+            verify(context.getResponseObserver(), never()).onNext(any(WorkerJobResponse.class));
+        }
+
+        @Test
+        void shouldEmitTriggerLogWhenPayloadExceedsWorkerInboundLimit() {
+            // Given
+            WorkerStreamContext<WorkerJobResponse> context = createWorkerContext("worker-1", WORKER_GROUP_A, 10);
+            context.addPermits(5);
+            context.setMaxInboundMessageSize(64);
+            dispatcher.registerWorker(context);
+
+            MockQueueSubscriber subscriber = getSubscriberForGroup(WORKER_GROUP_A);
+            WorkerJobEvent event = new WorkerJobEvent(WORKER_GROUP_A, createWorkerTrigger("trigger-1"));
+
+            // When
+            subscriber.deliverJob(event);
+
+            // Then
+            ArgumentCaptor<LogEntry> captor = ArgumentCaptor.forClass(LogEntry.class);
+            verify(mockLogEntryEmitter).emits(captor.capture());
+
+            LogEntry logEntry = captor.getValue();
+            assertThat(logEntry.getLevel()).isEqualTo(Level.ERROR);
+            assertThat(logEntry.getTriggerId()).isEqualTo("trigger-1");
+            assertThat(logEntry.getMessage()).contains("kestra.grpc.max-inbound-message-size");
+
+            verify(mockTriggerEventQueue).send(any(TriggerEvaluated.class));
         }
 
         @Test

--- a/worker/src/main/java/io/kestra/worker/senders/GrpcWorkerIOSenderFactory.java
+++ b/worker/src/main/java/io/kestra/worker/senders/GrpcWorkerIOSenderFactory.java
@@ -8,6 +8,7 @@ import io.kestra.controller.grpc.WorkerControllerServiceGrpc.WorkerControllerSer
 import io.kestra.core.models.executions.LogEntry;
 import io.kestra.core.models.executions.MetricEntry;
 import io.kestra.core.models.executions.TaskRun;
+import io.kestra.core.models.flows.State;
 import io.kestra.core.runners.LogEntryEmitter;
 import io.kestra.core.runners.WorkerTaskResult;
 import io.kestra.core.utils.Logs;
@@ -53,7 +54,7 @@ public class GrpcWorkerIOSenderFactory {
             {
                 Logs.logTaskRun(result.getTaskRun(), Level.ERROR, RESULT_TOO_LARGE_MESSAGE);
                 logEntryEmitter.emits(taskRunLogEntry(result.getTaskRun(), RESULT_TOO_LARGE_MESSAGE));
-                return result.withTaskRun(result.getTaskRun().fail()).withOutputs(null);
+                return result.withTaskRun(result.getTaskRun().withStateAndAttempt(State.Type.FAILED)).withOutputs(null);
             },
             // Task results must survive a transient network partition: re-queue and redrive rather than
             // drop, otherwise a completed task is left stuck RUNNING because its result is lost.

--- a/worker/src/main/java/io/kestra/worker/senders/GrpcWorkerIOSenderFactory.java
+++ b/worker/src/main/java/io/kestra/worker/senders/GrpcWorkerIOSenderFactory.java
@@ -1,10 +1,14 @@
 package io.kestra.worker.senders;
 
+import java.time.Instant;
+
 import org.slf4j.event.Level;
 
 import io.kestra.controller.grpc.WorkerControllerServiceGrpc.WorkerControllerServiceStub;
 import io.kestra.core.models.executions.LogEntry;
 import io.kestra.core.models.executions.MetricEntry;
+import io.kestra.core.models.executions.TaskRun;
+import io.kestra.core.runners.LogEntryEmitter;
 import io.kestra.core.runners.WorkerTaskResult;
 import io.kestra.core.utils.Logs;
 import io.kestra.core.worker.models.WorkerTriggerResult;
@@ -24,6 +28,10 @@ import jakarta.inject.Singleton;
 @Factory
 public class GrpcWorkerIOSenderFactory {
 
+    private static final String RESULT_TOO_LARGE_MESSAGE =
+        "Failed to send the task result to the worker controller: its serialized size exceeds the maximum inbound gRPC message size configured on the controller. "
+            + "The task run is failed and its outputs are dropped. Reduce the size of the task outputs, or increase 'kestra.grpc.max-inbound-message-size' on the worker controller.";
+
     /**
      * Creates a sender for {@link WorkerTaskResult} events (sent per-item).
      * <p>
@@ -33,7 +41,8 @@ public class GrpcWorkerIOSenderFactory {
     @Singleton
     public GrpcWorkerIOSender<WorkerTaskResult> taskResultSender(
         final WorkerControllerServiceStub controllerServiceStub,
-        final WorkerQueueRegistry workerQueueRegistry) {
+        final WorkerQueueRegistry workerQueueRegistry,
+        final LogEntryEmitter logEntryEmitter) {
         return new GrpcWorkerIOSender<>(
             workerQueueRegistry,
             "TaskResultWorkerIOSender",
@@ -42,7 +51,8 @@ public class GrpcWorkerIOSenderFactory {
             controllerServiceStub::sendWorkerTaskResults,
             result ->
             {
-                Logs.logTaskRun(result.getTaskRun(), Level.ERROR, "Failed to send result. Cause: outputs exceeds maximum size.");
+                Logs.logTaskRun(result.getTaskRun(), Level.ERROR, RESULT_TOO_LARGE_MESSAGE);
+                logEntryEmitter.emits(taskRunLogEntry(result.getTaskRun(), RESULT_TOO_LARGE_MESSAGE));
                 return result.withTaskRun(result.getTaskRun().fail()).withOutputs(null);
             },
             // Task results must survive a transient network partition: re-queue and redrive rather than
@@ -106,5 +116,16 @@ public class GrpcWorkerIOSenderFactory {
             // Metrics are best-effort and high-volume: drop on failure rather than back-pressure the worker.
             false
         );
+    }
+
+    private static LogEntry taskRunLogEntry(final TaskRun taskRun, final String message) {
+        int lastAttemptIndex = Math.max(0, taskRun.attemptNumber() - 1);
+        return LogEntry.of(taskRun, null).toBuilder()
+            .level(Level.ERROR)
+            .attemptNumber(lastAttemptIndex)
+            .message(message)
+            .timestamp(Instant.now())
+            .thread(Thread.currentThread().getName())
+            .build();
     }
 }

--- a/worker/src/test/java/io/kestra/worker/senders/GrpcWorkerIOSenderTest.java
+++ b/worker/src/test/java/io/kestra/worker/senders/GrpcWorkerIOSenderTest.java
@@ -120,7 +120,8 @@ class GrpcWorkerIOSenderTest {
         char[] largePayload = new char[2 * 1024 * 1024];
         Arrays.fill(largePayload, 'a');
         TaskRun taskRun = buildTaskResult(Map.of()).getTaskRun()
-            .withAttempts(List.of(TaskRunAttempt.builder().state(new State()).build()));
+            .withAttempts(List.of(TaskRunAttempt.builder().state(new State().withState(State.Type.SUCCESS)).build()))
+            .withState(State.Type.SUCCESS);
         WorkerTaskResult large = new WorkerTaskResult(taskRun, Map.of("output", new String(largePayload)));
 
         taskResultSender.send(List.of(large));
@@ -136,6 +137,8 @@ class GrpcWorkerIOSenderTest {
         assertThat(received.getTaskRun().getId()).isEqualTo(large.getTaskRun().getId());
         assertThat(received.getTaskRun().getState().getCurrent()).isEqualTo(State.Type.FAILED);
         assertThat(received.getOutputs()).isNull();
+        assertThat(received.getTaskRun().getAttempts()).hasSize(1);
+        assertThat(received.getTaskRun().lastAttempt().getState().getCurrent()).isEqualTo(State.Type.FAILED);
 
         ArgumentCaptor<LogEntry> logCaptor = ArgumentCaptor.forClass(LogEntry.class);
         verify(logEntryEmitter).emits(logCaptor.capture());

--- a/worker/src/test/java/io/kestra/worker/senders/GrpcWorkerIOSenderTest.java
+++ b/worker/src/test/java/io/kestra/worker/senders/GrpcWorkerIOSenderTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
+import org.slf4j.event.Level;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 
@@ -18,8 +19,11 @@ import io.kestra.controller.grpc.services.GrpcWorkerControllerService;
 import io.kestra.controller.messages.BatchMessage;
 import io.kestra.controller.messages.MessageFormats;
 import io.kestra.core.junit.annotations.KestraTest;
+import io.kestra.core.models.executions.LogEntry;
 import io.kestra.core.models.executions.TaskRun;
+import io.kestra.core.models.executions.TaskRunAttempt;
 import io.kestra.core.models.flows.State;
+import io.kestra.core.runners.LogEntryEmitter;
 import io.kestra.core.runners.WorkerTaskResult;
 import io.kestra.core.utils.IdUtils;
 import io.kestra.core.worker.Controller;
@@ -54,6 +58,9 @@ class GrpcWorkerIOSenderTest {
     @Inject
     GrpcWorkerControllerService grpcWorkerControllerService;
 
+    @Inject
+    LogEntryEmitter logEntryEmitter;
+
     private Controller controller;
 
     @MockBean(GrpcWorkerControllerService.class)
@@ -62,6 +69,11 @@ class GrpcWorkerIOSenderTest {
         // bindService() must work so the gRPC server can route incoming calls to mock methods
         when(mock.bindService()).thenCallRealMethod();
         return mock;
+    }
+
+    @MockBean(LogEntryEmitter.class)
+    LogEntryEmitter logEntryEmitter() {
+        return mock(LogEntryEmitter.class);
     }
 
     @BeforeEach
@@ -107,7 +119,9 @@ class GrpcWorkerIOSenderTest {
         // 2 MB payload — exceeds the 1 MB server-side limit set via @Property
         char[] largePayload = new char[2 * 1024 * 1024];
         Arrays.fill(largePayload, 'a');
-        WorkerTaskResult large = buildTaskResult(Map.of("output", new String(largePayload)));
+        TaskRun taskRun = buildTaskResult(Map.of()).getTaskRun()
+            .withAttempts(List.of(TaskRunAttempt.builder().state(new State()).build()));
+        WorkerTaskResult large = new WorkerTaskResult(taskRun, Map.of("output", new String(largePayload)));
 
         taskResultSender.send(List.of(large));
 
@@ -122,6 +136,15 @@ class GrpcWorkerIOSenderTest {
         assertThat(received.getTaskRun().getId()).isEqualTo(large.getTaskRun().getId());
         assertThat(received.getTaskRun().getState().getCurrent()).isEqualTo(State.Type.FAILED);
         assertThat(received.getOutputs()).isNull();
+
+        ArgumentCaptor<LogEntry> logCaptor = ArgumentCaptor.forClass(LogEntry.class);
+        verify(logEntryEmitter).emits(logCaptor.capture());
+
+        LogEntry logEntry = logCaptor.getValue();
+        assertThat(logEntry.getLevel()).isEqualTo(Level.ERROR);
+        assertThat(logEntry.getTaskRunId()).isEqualTo(taskRun.getId());
+        assertThat(logEntry.getAttemptNumber()).isZero();
+        assertThat(logEntry.getMessage()).contains("kestra.grpc.max-inbound-message-size");
     }
 
     @Test


### PR DESCRIPTION
### ✨ Description

When a worker job or a task result is rejected because it exceeds a gRPC inbound message size limit, the failure was only ever logged server-side. The user got a `FAILED` task run with **no log line at all**, so nothing explained why the execution failed or how to fix it.

Both directions of the worker/controller exchange are fixed, and each now emits an actionable ERROR log attached to the task run (or the trigger):

1. **Controller → worker** (`WorkerJobDispatcher.rejectOversizedJob`): the job payload exceeds the worker's advertised inbound limit, so the job is failed before dispatch. The reason went to the controller's own logger only, and the class had no access to the log queue at all. It now emits a `LogEntry` through `RunContextLoggerFactory` for both task and trigger jobs.

2. **Worker → controller** (`GrpcWorkerIOSenderFactory.taskResultSender`): the serialized task result exceeds the controller's inbound limit, so the fallback resends a failed result without outputs. The reason went through `Logs.logTaskRun`, which — despite the task-run MDC it prints — is a *server* logging utility that never puts a `LogEntry` on the worker log queue. It now also emits through `LogEntryEmitter`.

3. While verifying (2) in the UI, the failed task run showed a phantom **"Attempt 1/2 Success"** with the error log on the successful attempt. Cause: `TaskRun.fail()` *appends* an attempt, and the worker's result already carries its own. The fallback now uses `withStateAndAttempt(FAILED)`, which fails the attempt that actually ran. As a side effect the attempt count stays accurate, so a task with a `retry` policy no longer burns an extra attempt on this path.

The message the user now sees:

> Failed to send the task result to the worker controller: its serialized size exceeds the maximum inbound gRPC message size configured on the controller. The task run is failed and its outputs are dropped. Reduce the size of the task outputs, or increase `kestra.grpc.max-inbound-message-size` on the worker controller.

### 🔗 Related Issue

No linked issue — found while investigating a misconfigured `kestra.grpc.max-inbound-message-size` (the default is 10 MB).

### 🛠️ Backend Checklist

- [x] Code compiles successfully and passes all checks
- [x] All unit and integration tests pass

### 📝 Additional Notes

- Log entries are anchored to the zero-based index of the attempt they belong to (`attempts.size() - 1`), which is how the UI groups them (`TaskRunDetails.vue` uses `taskRun.attempts.length - 1`). Using the raw attempt count would have attributed the line to a non-existent attempt and it would have stayed invisible — the tests pin this.
- Verified: `WorkerJobDispatcherTest` (62 tests, 2 new), `GrpcWorkerIOSenderTest` (5 tests, extended), `H2RunnerTest` (99 tests) green.
- The oversized-result assertions were folded into the existing `shouldSendFailedResultWithoutOutputsWhenTaskResultIsTooLarge` rather than added as a second test: two 2 MB sends in one class break each other, since the server-side deframer failure tears down the shared channel for whichever runs second.
- Still not covered: the `LogEntry` batch sender has no fallback, so a log batch that exceeds the controller limit is dropped silently. There is no non-recursive way to report that through the log path, so it is left as a separate problem.

### 🤖 AI Authors

Why did the cat get thrown off the gRPC stream? It exceeded the maximum inbound *meow*-sage size. 🐱
