### PR TITLE
fix(core): correct preselect spelling flagged by codespell

### DIFF
--- a/ui/src/components/dependencies/composables/useDependencies.ts
+++ b/ui/src/components/dependencies/composables/useDependencies.ts
@@ -138,7 +138,7 @@ export function transformResponse(
  *
  * @param graphRef    - Template ref pointing to the KsGraph component instance.
  * @param subtype     - Dependency subtype: FLOW, EXECUTION, NAMESPACE, or ASSET.
- * @param initialNodeID - ID of the node to pre-select after the first render.
+ * @param initialNodeID - ID of the node to preselect after the first render.
  * @param params      - Vue Router params (id, namespace, flowId).
  * @param isTesting   - When true, uses generated fixture data instead of the API.
  * @param fetchAssetDependencies - Custom async fetcher for ASSET subtypes.
@@ -453,7 +453,7 @@ export function useDependencies(
     /**
      * Polls until ECharts has completed the initial force layout and node positions
      * are available, then centres the view on the selected node (or fits all nodes
-     * for NAMESPACE graphs where no node is pre-selected).
+     * for NAMESPACE graphs where no node is preselected).
      *
      * Why polling instead of listening for the `finished` event:
      * `chartNodes` is set synchronously, which schedules a Vue microtask flush.

--- a/ui/tests/unit/dependencies/composables/useDependencies.spec.ts
+++ b/ui/tests/unit/dependencies/composables/useDependencies.spec.ts
@@ -38,7 +38,7 @@ function setCSSVars() {
 
 // ─── Controlled graph fixture ─────────────────────────────────────────────────
 // A --e1--> B --e2--> C    D (isolated, no edges)
-// A is the pre-selected initial node.
+// A is the preselected initial node.
 function makeControlledElements() {
     return [
         {data: {id: "A", type: "NODE", flow: "flow-a", namespace: "ns", metadata: {subtype: "FLOW"}}},
@@ -337,7 +337,7 @@ describe("useDependencies composable", () => {
         const wrapper = mount({
             template: "<div></div>",
             setup() {
-                // Use initialNodeID="X" (nonexistent) so no node is pre-selected,
+                // Use initialNodeID="X" (nonexistent) so no node is preselected,
                 // leaving selectedNodeID undefined and letting tests control selection.
                 const composable = useDependencies(graphRef as any, FLOW, "X", {}, fetchAssetDependencies)
                 return {composable}


### PR DESCRIPTION
Codespell fails on `pre-select` / `pre-selected` in the dependencies composable and its test. All four occurrences are in comments/Javadoc, so this is a comment-only change with no behavior impact.

- `ui/src/components/dependencies/composables/useDependencies.ts` lines 141, 456
- `ui/tests/unit/dependencies/composables/useDependencies.spec.ts` lines 41, 340