### PR TITLE
refactor(core): use global $t instead of locally imported t in vue templates

### DIFF
--- a/ui/packages/design-system/src/components/Data/KsDataTable/filter/layout/FilterChip.vue
+++ b/ui/packages/design-system/src/components/Data/KsDataTable/filter/layout/FilterChip.vue
@@ -8,7 +8,7 @@
     >
         <span class="content">
             <span class="key">{{ filter.keyLabel }}</span>
-            <span v-if="!hasValue(filter.value)" class="in">{{ t("filter.in any") }}</span>
+            <span v-if="!hasValue(filter.value)" class="in">{{ $t("filter.in any") }}</span>
             <span v-else-if="shouldShowComparatorLabel" class="comparator" :class="{negative: isNegative}">{{ getComparatorLabel() }}</span>
             <KsTooltip
                 v-if="hasValue(filter.value)"

--- a/ui/packages/design-system/src/components/Form/KsEditor.vue
+++ b/ui/packages/design-system/src/components/Form/KsEditor.vue
@@ -4,14 +4,14 @@
             <slot name="nav">
                 <div class="text-nowrap">
                     <KsButtonGroup>
-                        <KsTooltip :content="t('Fold content lines')">
+                        <KsTooltip :content="$t('Fold content lines')">
                             <KsButton
                                 :icon="icon.UnfoldLessHorizontal"
                                 @click="autoFold(true)"
                                 size="small"
                             />
                         </KsTooltip>
-                        <KsTooltip :content="t('Unfold content lines')">
+                        <KsTooltip :content="$t('Unfold content lines')">
                             <KsButton
                                 :icon="icon.UnfoldMoreHorizontal"
                                 @click="unfoldAll"
@@ -127,7 +127,6 @@
     const datePicker = ref()
 
     const {
-        t,
         icon,
         containerClass,
         showPlaceholder,

--- a/ui/src/components/MultiPanelGenericEditorView.vue
+++ b/ui/src/components/MultiPanelGenericEditorView.vue
@@ -4,7 +4,7 @@
             <div class="tabs-actions">
                 <KsButton
                     :icon="splitOrientation === 'vertical' ? ViewSplitVertical : ViewSplitHorizontal"
-                    :tooltip="splitOrientation === 'vertical' ? t('split_horizontal') : t('split_vertical')"
+                    :tooltip="splitOrientation === 'vertical' ? $t('split_horizontal') : $t('split_vertical')"
                     class="orientation-toggle"
                     @click="toggleOrientation"
                 />
@@ -28,15 +28,12 @@
 <script lang="ts" setup>
     import {computed, useSlots} from "vue"
     import {useStorage} from "@vueuse/core"
-    import {useI18n} from "vue-i18n"
     import ViewSplitVertical from "vue-material-design-icons/ViewSplitVertical.vue"
     import ViewSplitHorizontal from "vue-material-design-icons/ViewSplitHorizontal.vue"
     import MultiPanelEditorTabs from "./MultiPanelEditorTabs.vue"
     import MultiPanelTabs from "./MultiPanelTabs.vue"
     import {EditorElement, Panel} from "../utils/multiPanelTypes"
     import {useStoredPanels} from "../composables/useStoredPanels"
-
-    const {t} = useI18n()
 
     const splitOrientation = useStorage<"vertical" | "horizontal">("editor-split-orientation", "vertical")
 

--- a/ui/src/components/admin/AdminItem.vue
+++ b/ui/src/components/admin/AdminItem.vue
@@ -1,6 +1,6 @@
 <template>
     <KsSideBarItem
-        :title="title ?? t('admin')"
+        :title="title ?? $t('admin')"
         :icon="CogOutline"
         :active="active"
         class="admin-item"
@@ -10,13 +10,13 @@
             <KsTooltip placement="top" effect="light">
                 <template #content>
                     <div class="admin-item__tooltip">
-                        <div>{{ t("version") }}: {{ configs.version }}</div>
+                        <div>{{ $t("version") }}: {{ configs.version }}</div>
                         <div v-if="configs.commitId">
-                            {{ t("commit_id") }}:
+                            {{ $t("commit_id") }}:
                             <span class="admin-item__commit">{{ configs.commitId }}</span>
                         </div>
                         <div v-if="configs.commitDate">
-                            {{ t("date") }}: {{ dateUtils.dateFilter(configs.commitDate) }}
+                            {{ $t("date") }}: {{ dateUtils.dateFilter(configs.commitDate) }}
                         </div>
                     </div>
                 </template>
@@ -30,7 +30,6 @@
 
 <script setup lang="ts">
     import {computed, onUnmounted, watch} from "vue"
-    import {useI18n} from "vue-i18n"
     import {useRoute, useRouter, type RouteLocationRaw} from "vue-router"
     import CogOutline from "vue-material-design-icons/CogOutline.vue"
     import {KsSideBarItem, KsTooltip, dateUtils} from "@kestra-io/design-system"
@@ -46,7 +45,6 @@
 
     const OWNER = Symbol("admin-tabs")
 
-    const {t} = useI18n({useScope: "global"})
     const route = useRoute()
     const router = useRouter()
     const store = useRouteTabsStore()

--- a/ui/src/components/admin/McpServerCard.vue
+++ b/ui/src/components/admin/McpServerCard.vue
@@ -14,21 +14,21 @@
 
             <div class="meta-row">
                 <span class="meta">
-                    <span class="label">{{ t("type") }}:</span>
+                    <span class="label">{{ $t("type") }}:</span>
                     <span>{{ typeLabel }}</span>
                 </span>
                 <span
                     v-if="tenant"
                     class="meta"
                 >
-                    <span class="label">{{ t("tenant.name") }}:</span>
+                    <span class="label">{{ $t("tenant.name") }}:</span>
                     <span>{{ tenant }}</span>
                 </span>
             </div>
 
             <div class="meta-row">
                 <span class="meta">
-                    <span class="label">{{ t("mcp.auth_type") }}:</span>
+                    <span class="label">{{ $t("mcp.auth_type") }}:</span>
                     <span>{{ authLabel }}</span>
                 </span>
             </div>
@@ -40,7 +40,7 @@
                 size="small"
                 class="status-tag managed"
             >
-                {{ t("mcp.managed_by_kestra") }}
+                {{ $t("mcp.managed_by_kestra") }}
                 <KsIcon>
                     <Lock />
                 </KsIcon>
@@ -56,7 +56,7 @@
 
             <KsIconButton
                 v-if="canDelete && !isDefault"
-                :tooltip="t('delete')"
+                :tooltip="$t('delete')"
                 placement="left"
                 @click.stop.prevent="emit('delete')"
             >

--- a/ui/src/components/admin/McpServerList.vue
+++ b/ui/src/components/admin/McpServerList.vue
@@ -1,14 +1,14 @@
 <template>
     <TopNavBar
-        :title="t('mcp.servers')"
-        :longDescription="t('mcp.page_description')"
+        :title="$t('mcp.servers')"
+        :longDescription="$t('mcp.page_description')"
     >
         <template
             v-if="showCreate"
             #actions
         >
             <Action
-                :label="t('mcp.create')"
+                :label="$t('mcp.create')"
                 :to="{name: 'admin/mcp-servers/create', params: {tab: 'edit', tenant: route.params.tenant}}"
             />
         </template>
@@ -30,18 +30,18 @@
         <KsNoData
             v-else-if="displayServers.length === 0"
             class="empty"
-            :description="t('mcp.no_servers')"
+            :description="$t('mcp.no_servers')"
         />
 
         <div
             v-else
             class="server-list"
         >
-            <h2 class="list-title">{{ t("mcp.your_servers") }}</h2>
+            <h2 class="list-title">{{ $t("mcp.your_servers") }}</h2>
 
             <section class="list-card">
                 <header class="list-header">
-                    {{ t("mcp.servers_count", {count: displayServers.length}) }}
+                    {{ $t("mcp.servers_count", {count: displayServers.length}) }}
                 </header>
 
                 <McpServerCard

--- a/ui/src/components/admin/mcp/tabs/McpConnect.vue
+++ b/ui/src/components/admin/mcp/tabs/McpConnect.vue
@@ -3,7 +3,7 @@
         <section class="section">
             <h3 class="heading">
                 <LinkVariant class="heading-icon" />
-                {{ t("mcp.connect_tab.server_url") }}
+                {{ $t("mcp.connect_tab.server_url") }}
             </h3>
             <KsInput
                 :modelValue="serverUrl"
@@ -13,13 +13,13 @@
                 <template #suffix>
                     <KsTooltip
                         trigger="click"
-                        :content="t('copied')"
+                        :content="$t('copied')"
                         :autoClose="2000"
                         placement="top"
                     >
                         <ContentCopy
                             class="copy"
-                            :aria-label="t('copy_to_clipboard')"
+                            :aria-label="$t('copy_to_clipboard')"
                             @click="copyUrl"
                         />
                     </KsTooltip>
@@ -31,7 +31,7 @@
     <div class="mcp-connect">
         <h3 class="heading">
             <Connection class="heading-icon" />
-            {{ t("mcp.client_setup") }}
+            {{ $t("mcp.client_setup") }}
         </h3>
 
         <KsTabs
@@ -51,7 +51,7 @@
                 <p
                     v-if="authHintKey"
                     class="hint"
-                    v-html="t(authHintKey)"
+                    v-html="$t(authHintKey)"
                 />
                 <p class="hint">
                     {{ clientHint }}
@@ -93,10 +93,10 @@
                 class="paths"
             >
                 <p class="path-hint">
-                    {{ t("mcp.connect_tab.claude_desktop_mac") }}
+                    {{ $t("mcp.connect_tab.claude_desktop_mac") }}
                 </p>
                 <p class="path-hint">
-                    {{ t("mcp.connect_tab.claude_desktop_win") }}
+                    {{ $t("mcp.connect_tab.claude_desktop_win") }}
                 </p>
             </div>
         </section>

--- a/ui/src/components/admin/mcp/tabs/McpEdit.vue
+++ b/ui/src/components/admin/mcp/tabs/McpEdit.vue
@@ -7,7 +7,7 @@
             @submit.prevent="onSubmit"
         >
             <KsFormItem
-                :label="t('mcp.server_id')"
+                :label="$t('mcp.server_id')"
                 prop="id"
                 required
                 labelPosition="left"
@@ -16,7 +16,7 @@
             >
                 <KsInput
                     v-model="form.id"
-                    :placeholder="t('mcp.id_placeholder')"
+                    :placeholder="$t('mcp.id_placeholder')"
                     :disabled="idDisabled"
                     class="mono id-input"
                     @change="autoSubmit"
@@ -30,23 +30,23 @@
                 </KsInput>
             </KsFormItem>
 
-            <KsFormItem :label="t('description')">
+            <KsFormItem :label="$t('description')">
                 <KsInput
                     v-model="form.description"
                     type="textarea"
                     :rows="2"
-                    :placeholder="t('description')"
+                    :placeholder="$t('description')"
                     :disabled="readOnly"
                     @change="autoSubmit"
                 />
             </KsFormItem>
 
-            <KsFormItem :label="t('mcp.instructions')">
+            <KsFormItem :label="$t('mcp.instructions')">
                 <KsInput
                     v-model="form.instructions"
                     type="textarea"
                     :rows="3"
-                    :placeholder="t('mcp.instructions')"
+                    :placeholder="$t('mcp.instructions')"
                     class="mono"
                     :disabled="readOnly"
                     @change="autoSubmit"
@@ -54,7 +54,7 @@
             </KsFormItem>
 
             <KsFormItem
-                :label="t('mcp.private_server')"
+                :label="$t('mcp.private_server')"
                 labelPosition="left"
                 class="spread-row"
             >
@@ -71,27 +71,27 @@
                 :closable="false"
                 class="type-hint"
             >
-                {{ t("mcp.public_hint") }}
+                {{ $t("mcp.public_hint") }}
             </KsAlert>
 
             <KsFormItem v-if="isPrivate">
                 <KsRadioCardGroup
                     v-model="form.authType"
                     :options="authOptions"
-                    :ariaLabel="t('mcp.auth_type')"
+                    :ariaLabel="$t('mcp.auth_type')"
                     @change="autoSubmit"
                 />
             </KsFormItem>
 
             <KsFormItem
                 v-if="isOAuth"
-                :label="t('mcp.oauth_provider')"
+                :label="$t('mcp.oauth_provider')"
                 prop="oauthProvider"
                 :rules="oauthProviderRules"
             >
                 <KsSelect
                     v-model="form.oauthProvider"
-                    :placeholder="t('mcp.oauth_provider_placeholder')"
+                    :placeholder="$t('mcp.oauth_provider_placeholder')"
                     :disabled="readOnly"
                     class="full-width"
                     @change="autoSubmit"
@@ -107,7 +107,7 @@
 
             <KsFormItem
                 v-if="isOAuth"
-                :label="t('mcp.scopes_supported')"
+                :label="$t('mcp.scopes_supported')"
             >
                 <KsSelect
                     v-model="form.oauthScopesSupported"
@@ -115,18 +115,18 @@
                     filterable
                     allowCreate
                     defaultFirstOption
-                    :placeholder="t('mcp.scopes_supported_placeholder')"
+                    :placeholder="$t('mcp.scopes_supported_placeholder')"
                     :disabled="readOnly"
                     class="full-width"
                     @change="autoSubmit"
                 />
                 <div class="field-hint">
-                    {{ t("mcp.scopes_supported_hint") }}
+                    {{ $t("mcp.scopes_supported_hint") }}
                 </div>
             </KsFormItem>
 
             <KsFormItem
-                :label="t('enabled')"
+                :label="$t('enabled')"
                 labelPosition="left"
                 class="spread-row"
             >

--- a/ui/src/components/admin/mcp/tabs/McpToolFlows.vue
+++ b/ui/src/components/admin/mcp/tabs/McpToolFlows.vue
@@ -13,7 +13,7 @@
                     :icon="Plus"
                     @click="createToolFlow"
                 >
-                    {{ t("mcp.tools.create_tool_flow") }}
+                    {{ $t("mcp.tools.create_tool_flow") }}
                 </KsButton>
             </template>
         </Empty>
@@ -25,7 +25,7 @@
             :total="filteredTools.length"
             :loading="loading"
             :rowKey="rowKey"
-            :noDataText="t('mcp.tools.no_tools')"
+            :noDataText="$t('mcp.tools.no_tools')"
         >
             <template #navbar>
                 <KSFilter
@@ -50,7 +50,7 @@
 
             <KsTableColumn
                 prop="toolName"
-                :label="t('mcp.tools.tool_name')"
+                :label="$t('mcp.tools.tool_name')"
             >
                 <template #default="scope">
                     <KsId :value="(scope.row as McpTool).toolName" :shrink="false" />
@@ -85,7 +85,7 @@
                                 :key="ann"
                                 class="annotation"
                             >
-                                {{ t(`mcp.tools.${ann}`) }}
+                                {{ $t(`mcp.tools.${ann}`) }}
                             </KsTag>
                         </div>
                     </template>
@@ -110,7 +110,7 @@
 
             <KsTableColumn
                 prop="state"
-                :label="t('mcp.tools.state')"
+                :label="$t('mcp.tools.state')"
                 width="120"
             >
                 <template #default="scope">

--- a/ui/src/components/dashboard/sections/Bar.vue
+++ b/ui/src/components/dashboard/sections/Bar.vue
@@ -33,7 +33,7 @@
         <div v-if="!props.short && canExpand" class="chart-footer">
             <KsButton text size="small" :aria-expanded="expanded" @click="expanded = !expanded">
                 <span class="expand-toggle">
-                    {{ expanded ? t("showLess") : `${t("dashboards.viewAll")} (${totalNamespaces})` }}
+                    {{ expanded ? $t("showLess") : `${$t("dashboards.viewAll")} (${totalNamespaces})` }}
                     <component :is="expanded ? ChevronUp : ChevronDown" :size="14" />
                 </span>
             </KsButton>

--- a/ui/src/components/demo/Apps.vue
+++ b/ui/src/components/demo/Apps.vue
@@ -3,7 +3,7 @@
     <Empty
         type="apps"
         demoCta
-        :title="t(`${keyPrefix}.title`)"
+        :title="$t(`${keyPrefix}.title`)"
     >
         <template #description>
             {{ $t(`${keyPrefix}.message`) }}

--- a/ui/src/components/demo/Assets.vue
+++ b/ui/src/components/demo/Assets.vue
@@ -3,7 +3,7 @@
     <Empty
         type="assets"
         demoCta
-        :title="t(`demos.assets.title`)"
+        :title="$t(`demos.assets.title`)"
     >
         <template #description>
             {{ $t(`demos.assets.message`) }}

--- a/ui/src/components/demo/Blueprints.vue
+++ b/ui/src/components/demo/Blueprints.vue
@@ -3,7 +3,7 @@
     <Empty
         type="blueprints"
         demoCta
-        :title="t(`demos.blueprints.title`)"
+        :title="$t(`demos.blueprints.title`)"
     >
         <template #description>
             {{ $t(`demos.blueprints.message`) }}

--- a/ui/src/components/demo/Cases.vue
+++ b/ui/src/components/demo/Cases.vue
@@ -3,10 +3,10 @@
     <Empty
         type="cases"
         demoCta
-        :title="t(`demos.cases.title`)"
+        :title="$t(`demos.cases.title`)"
     >
         <template #description>
-            {{ t(`demos.cases.message`) }}
+            {{ $t(`demos.cases.message`) }}
         </template>
     </Empty>
 </template>

--- a/ui/src/components/demo/Dashboards.vue
+++ b/ui/src/components/demo/Dashboards.vue
@@ -3,10 +3,10 @@
     <Empty
         type="dashboards"
         demoCta
-        :title="t(`${keyPrefix}.title`)"
+        :title="$t(`${keyPrefix}.title`)"
     >
         <template #description>
-            {{ t(`${keyPrefix}.message`) }}
+            {{ $t(`${keyPrefix}.message`) }}
         </template>
     </Empty>
 </template>

--- a/ui/src/components/demo/Policies.vue
+++ b/ui/src/components/demo/Policies.vue
@@ -3,7 +3,7 @@
     <Empty
         type="policies"
         demoCta
-        :title="t(`demos.policies.title`)"
+        :title="$t(`demos.policies.title`)"
     >
         <template #description>
             {{ $t(`demos.policies.message`) }}

--- a/ui/src/components/demo/Tests.vue
+++ b/ui/src/components/demo/Tests.vue
@@ -3,7 +3,7 @@
     <Empty
         type="tests"
         demoCta
-        :title="t(`demos.tests.title`)"
+        :title="$t(`demos.tests.title`)"
     >
         <template #description>
             {{ $t(`demos.tests.message`) }}

--- a/ui/src/components/executions/Executions.vue
+++ b/ui/src/components/executions/Executions.vue
@@ -224,7 +224,7 @@
                             :status="scope.row?.state?.current"
                             size="small"
                             clickable
-                            :aria-label="t('filter by status', {status: scope.row?.state?.current})"
+                            :aria-label="$t('filter by status', {status: scope.row?.state?.current})"
                             @click.stop="onStateClick(scope.row?.state?.current)"
                         />
                     </template>

--- a/ui/src/components/executions/Gantt.vue
+++ b/ui/src/components/executions/Gantt.vue
@@ -14,7 +14,7 @@
         <KsEmptyState v-if="series.length === 0" :image="emptyIllustration">
             <template #description>
                 <span class="gantt-empty-status">
-                    {{ t("execution_status") }}
+                    {{ $t("execution_status") }}
                     <KsExecutionStatus :status="execution.state.current" />
                 </span>
                 <span v-if="emptyStateHint" class="gantt-empty-hint">{{ emptyStateHint }}</span>
@@ -43,18 +43,18 @@
                             <div class="top">
                                 <div class="summary">
                                     <span class="item">
-                                        <span class="label">{{ t("total_duration") }}</span>
+                                        <span class="label">{{ $t("total_duration") }}</span>
                                         <Duration class="value" :histories="execution.state.histories" />
                                     </span>
                                     <span class="separator">/</span>
                                     <span class="item">
-                                        <span class="label">{{ t("tasks") }}</span>
+                                        <span class="label">{{ $t("tasks") }}</span>
                                         <span class="value">{{ tasksSummary }}</span>
                                     </span>
                                 </div>
                                 <div class="actions">
                                     <KsButton class="copy-logs" :icon="ContentCopy" link @click="copyAllLogs">
-                                        {{ t("copy all logs") }}
+                                        {{ $t("copy all logs") }}
                                     </KsButton>
                                     <KsExecutionStatus :status="execution.state.current" />
                                 </div>
@@ -116,7 +116,7 @@
                                             <div>
                                                 <KsTooltip v-if="item.attempts > 1" placement="right">
                                                     <template #content>
-                                                        <span>{{ t("this_task_has") }} {{ item.attempts }} {{ t("attempts").toLowerCase() }}.</span>
+                                                        <span>{{ $t("this_task_has") }} {{ item.attempts }} {{ $t("attempts").toLowerCase() }}.</span>
                                                     </template>
                                                     <Warning class="attempt_warn me-3" />
                                                 </KsTooltip>
@@ -176,8 +176,8 @@
                         <!-- Task runs exist but the active filters/search hid them all. -->
                         <KsNoData
                             v-else
-                            :title="t('gantt_no_tasks_match_filters_title')"
-                            :description="t('gantt_no_tasks_match_filters')"
+                            :title="$t('gantt_no_tasks_match_filters_title')"
+                            :description="$t('gantt_no_tasks_match_filters')"
                         />
                     </template>
                 </KsCard>

--- a/ui/src/components/executions/Logs.vue
+++ b/ui/src/components/executions/Logs.vue
@@ -26,17 +26,17 @@
                 <KsButton class="logs-toolbar__text-btn" @click="expandCollapseAll()" :disabled="raw_view" :icon="logDisplayButtonIcon">
                     {{ logDisplayButtonText }}
                 </KsButton>
-                <KsTooltip :content="!raw_view ? t('logs_view.raw_details') : t('logs_view.compact_details')">
+                <KsTooltip :content="!raw_view ? $t('logs_view.raw_details') : $t('logs_view.compact_details')">
                     <KsButton class="logs-toolbar__text-btn" @click="toggleViewType" :icon="logViewTypeButtonIcon">
-                        {{ !raw_view ? t('logs_view.raw') : t('logs_view.compact') }}
+                        {{ !raw_view ? $t('logs_view.raw') : $t('logs_view.compact') }}
                     </KsButton>
                 </KsTooltip>
             </div>
             <div class="logs-toolbar__actions">
                 <Restart v-if="executionsStore.execution" :execution="executionsStore.execution" />
                 <LogDisplaySettings />
-                <KsButton square type="default" size="default" :icon="Download" :aria-label="t('download logs')" :tooltip="t('download logs')" @click="downloadContent()" />
-                <KsButton square type="default" size="default" :icon="ContentCopy" :aria-label="t('copy logs')" :tooltip="t('copy logs')" @click="copyAllLogs()" />
+                <KsButton square type="default" size="default" :icon="Download" :aria-label="$t('download logs')" :tooltip="$t('download logs')" @click="downloadContent()" />
+                <KsButton square type="default" size="default" :icon="ContentCopy" :aria-label="$t('copy logs')" :tooltip="$t('copy logs')" @click="copyAllLogs()" />
             </div>
         </div>
 
@@ -58,8 +58,8 @@
         <KsCard v-else class="attempt-wrapper" style="--kel-card-padding: 0">
             <KsNoData
                 v-if="Array.isArray((executionsStore.logs as any)) && temporalLogs.length === 0"
-                :title="t('no_logs_data_title')"
-                :description="t('no_logs_data_description')"
+                :title="$t('no_logs_data_title')"
+                :description="$t('no_logs_data_description')"
             />
             <DynamicScroller
                 v-if="temporalLogs.length > 0"

--- a/ui/src/components/executions/TaskRunActions.vue
+++ b/ui/src/components/executions/TaskRunActions.vue
@@ -11,7 +11,7 @@
                 >
                     <span class="d-inline-flex align-items-center">
                         <AiIcon class="me-1" />
-                        <span>{{ t('fix_with_ai') }}</span>
+                        <span>{{ $t('fix_with_ai') }}</span>
                     </span>
                 </KsDropdownItem>
                 <SubFlowLink
@@ -63,19 +63,19 @@
                     :icon="Download"
                     @click="downloadContent(taskRun.id)"
                 >
-                    {{ t("download logs") }}
+                    {{ $t("download logs") }}
                 </KsDropdownItem>
                 <KsDropdownItem
                     :icon="Copy"
                     @click="copyContent(taskRun.id)"
                 >
-                    {{ t("copy logs") }}
+                    {{ $t("copy logs") }}
                 </KsDropdownItem>
                 <KsDropdownItem
                     :icon="Delete"
                     @click="deleteLogs(taskRun.id)"
                 >
-                    {{ t("delete logs") }}
+                    {{ $t("delete logs") }}
                 </KsDropdownItem>
                 <WorkerInfo
                     component="KsDropdownItem"

--- a/ui/src/components/executions/overview/components/Banner.vue
+++ b/ui/src/components/executions/overview/components/Banner.vue
@@ -30,19 +30,19 @@
 
                 <span class="execution-banner__id">
                     <code>{{ execution.id }}</code>
-                    <KsIconButton :tooltip="t('copy')" placement="top" @click="copyId">
+                    <KsIconButton :tooltip="$t('copy')" placement="top" @click="copyId">
                         <ContentCopy />
                     </KsIconButton>
                 </span>
 
                 <span v-if="replayed" class="execution-banner__replay">
                     <Replay />
-                    {{ t("replayed") }}
+                    {{ $t("replayed") }}
                 </span>
 
                 <span v-if="restarted" class="execution-banner__restart">
                     <Restart />
-                    {{ t("restarted") }}
+                    {{ $t("restarted") }}
                 </span>
             </div>
 
@@ -65,15 +65,15 @@
                     <template #content>
                         <div class="date-tooltip">
                             <div class="date-tooltip__row">
-                                <span class="date-tooltip__label">{{ t("created date") }}:</span>
+                                <span class="date-tooltip__label">{{ $t("created date") }}:</span>
                                 <KsDateAgo :date="createdDate" :inverted="true" :showTooltip="false" format="L LTS" />
                             </div>
                             <div v-if="scheduleDate" class="date-tooltip__row">
-                                <span class="date-tooltip__label">{{ t("scheduleDate") }}:</span>
+                                <span class="date-tooltip__label">{{ $t("scheduleDate") }}:</span>
                                 <KsDateAgo :date="scheduleDate" :inverted="true" :showTooltip="false" format="L LTS" />
                             </div>
                             <div class="date-tooltip__row">
-                                <span class="date-tooltip__label">{{ t("latest_update") }}:</span>
+                                <span class="date-tooltip__label">{{ $t("latest_update") }}:</span>
                                 <KsDateAgo :date="latestUpdate" :inverted="true" :showTooltip="false" format="L LTS" />
                             </div>
                         </div>
@@ -88,7 +88,7 @@
                 <router-link v-if="originalLink" class="meta-item" :to="originalLink">
                     <History />
                     <span>
-                        {{ t("original execution") }}:
+                        {{ $t("original execution") }}:
                         <span class="meta-item__link">{{ execution.originalId }}</span>
                     </span>
                 </router-link>
@@ -98,11 +98,11 @@
                 <RunTimeline :histories="execution.state.histories ?? []" />
 
                 <KsButton :icon="ContentCopy" @click="copyLogs" link>
-                    {{ t("copy logs") }}
+                    {{ $t("copy logs") }}
                 </KsButton>
 
                 <KsButton v-if="isFailed" class="fix-with-ai" :icon="Creation" @click="fixErrorWithAi">
-                    {{ t("fix_with_ai") }}
+                    {{ $t("fix_with_ai") }}
                 </KsButton>
             </div>
         </div>
@@ -123,7 +123,7 @@
             <div class="execution-banner__stats">
                 <span v-if="execution.flowRevision !== undefined" class="footer-stat">
                     <History />
-                    {{ execution.flowRevision }} {{ t("revision") }}(s)
+                    {{ execution.flowRevision }} {{ $t("revision") }}(s)
                 </span>
                 <span class="footer-stat">
                     <ClockTimeFourOutline />
@@ -131,11 +131,11 @@
                 </span>
                 <span v-if="(execution.metadata?.attemptNumber ?? 0) > 0" class="footer-stat">
                     <GraphOutline />
-                    {{ execution.metadata.attemptNumber }} {{ t("attempt") }}(s)
+                    {{ execution.metadata.attemptNumber }} {{ $t("attempt") }}(s)
                 </span>
                 <span v-if="taskCount > 0" class="footer-stat">
                     <LayersTripleOutline />
-                    {{ completedTaskCount }}/{{ taskCount }} {{ t("task") }}(s)
+                    {{ completedTaskCount }}/{{ taskCount }} {{ $t("task") }}(s)
                 </span>
             </div>
         </div>

--- a/ui/src/components/executions/overview/components/actions/Restart.vue
+++ b/ui/src/components/executions/overview/components/actions/Restart.vue
@@ -49,22 +49,22 @@
         <template #header>
             <div class="modal-header m-0">
                 <h3 class="modal-title">
-                    {{ t("restart execution title") }}
+                    {{ $t("restart execution title") }}
                 </h3>
                 <KsDivider />
             </div>
         </template>
 
         <div class="p-3 pt-0">
-            <p class="mb-0" v-html="t('restart confirm', {id: escape(execution.id)})" />
+            <p class="mb-0" v-html="$t('restart confirm', {id: escape(execution.id)})" />
         </div>
 
         <template #footer>
             <KsButton @click="isOpen = false">
-                {{ t("cancel") }}
+                {{ $t("cancel") }}
             </KsButton>
             <KsButton type="primary" @click="handleRestartExecute">
-                {{ t("restart") }}
+                {{ $t("restart") }}
             </KsButton>
         </template>
     </KsDialog>
@@ -79,7 +79,7 @@
         <template #header>
             <div class="modal-header m-0">
                 <h3 class="modal-title">
-                    {{ t("replay execution title") }}
+                    {{ $t("replay execution title") }}
                 </h3>
                 <KsDivider />
             </div>
@@ -87,23 +87,23 @@
 
         <div class="p-3 pt-0">
             <p class="mb-0">
-                {{ t("replay execution description") }}
+                {{ $t("replay execution description") }}
             </p>
             <KsId :value="execution.id" :shrink="false" />
 
             <h4 class="section-title">
-                {{ t("replay using") }}:
+                {{ $t("replay using") }}:
             </h4>
 
             <KsRadioGroup v-model="replayRevisionMode" class="radio-vertical">
                 <KsRadio value="original" class="radio-item">
-                    {{ t("flow revision original") }}
+                    {{ $t("flow revision original") }}
                 </KsRadio>
                 <KsRadio value="latest" class="radio-item">
-                    {{ t("flow revision latest") }}
+                    {{ $t("flow revision latest") }}
                 </KsRadio>
                 <KsRadio value="specific" class="radio-item">
-                    {{ t("flow revision specific") }}
+                    {{ $t("flow revision specific") }}
                 </KsRadio>
             </KsRadioGroup>
 
@@ -126,30 +126,30 @@
             <template v-if="hasInputs">
                 <template v-if="!taskRun">
                     <h4 class="section-title">
-                        {{ t("replay inputs") }}:
+                        {{ $t("replay inputs") }}:
                     </h4>
 
                     <KsRadioGroup v-if="canReuseInputs" v-model="inputMode" class="radio-vertical">
                         <KsRadio value="reuse" class="radio-item">
-                            {{ t("reuse original inputs") }}
+                            {{ $t("reuse original inputs") }}
                         </KsRadio>
                         <KsRadio value="modify" class="radio-item">
-                            {{ t("modify inputs") }}
+                            {{ $t("modify inputs") }}
                         </KsRadio>
                     </KsRadioGroup>
                 </template>
                 <p v-if="!canReuseInputs" class="execution-description mt-2 mb-0">
-                    {{ t("replay inputs new required") }}
+                    {{ $t("replay inputs new required") }}
                 </p>
             </template>
         </div>
 
         <template #footer>
             <KsButton @click="isOpen = false">
-                {{ t("cancel") }}
+                {{ $t("cancel") }}
             </KsButton>
             <KsButton type="primary" @click="handleReplayExecute">
-                {{ t("execute") }}
+                {{ $t("execute") }}
             </KsButton>
         </template>
     </KsDialog>
@@ -163,7 +163,7 @@
     >
         <template #header>
             <span
-                v-html="t('replay the execution', {
+                v-html="$t('replay the execution', {
                     executionId: escape(execution.id),
                     flowId: escape(execution.flowId)
                 })"

--- a/ui/src/components/flows/Flows.vue
+++ b/ui/src/components/flows/Flows.vue
@@ -265,7 +265,7 @@
                     <div class="flow-actions-cell">
                         <KsIconButton
                             v-if="canExecute(scope.row)"
-                            :tooltip="t('execute')"
+                            :tooltip="$t('execute')"
                             @click="openExecuteModal(scope.row)"
                         >
                             <Play />

--- a/ui/src/components/flows/FlowsSearch.vue
+++ b/ui/src/components/flows/FlowsSearch.vue
@@ -6,8 +6,8 @@
                 <KsIconButton
                     :aria-expanded="replaceOpen"
                     :aria-pressed="replaceOpen"
-                    :aria-label="replaceOpen ? t('source_search.hide_replace') : t('source_search.show_replace')"
-                    :tooltip="replaceOpen ? t('source_search.hide_replace') : t('source_search.show_replace')"
+                    :aria-label="replaceOpen ? $t('source_search.hide_replace') : $t('source_search.show_replace')"
+                    :tooltip="replaceOpen ? $t('source_search.hide_replace') : $t('source_search.show_replace')"
                     class="source-search__replace-toggle"
                     :class="{'source-search__replace-toggle--active': replaceOpen}"
                     @click="replaceOpen = !replaceOpen"
@@ -20,36 +20,36 @@
                         <KsSearch
                             v-model="query"
                             clearable
-                            :placeholder="t('source_search.search_placeholder')"
-                            :aria-label="t('source_search.search_aria')"
+                            :placeholder="$t('source_search.search_placeholder')"
+                            :aria-label="$t('source_search.search_aria')"
                             :aria-invalid="failedSelectedTypes.includes('flows')"
                             @keydown.down.prevent="goToMatch(1)"
                             @keydown.up.prevent="goToMatch(-1)"
                             @keydown.enter.exact.prevent="goToMatch(1)"
                             @keydown.enter.shift.prevent="goToMatch(-1)"
                         />
-                        <div class="source-search__toggles" role="group" :aria-label="t('source_search.options_aria')">
+                        <div class="source-search__toggles" role="group" :aria-label="$t('source_search.options_aria')">
                             <KsCheckboxButton
                                 v-model="caseSensitive"
                                 size="small"
-                                :title="t('source_search.match_case')"
-                                :aria-label="t('source_search.match_case')"
+                                :title="$t('source_search.match_case')"
+                                :aria-label="$t('source_search.match_case')"
                             >
                                 <span class="source-search__toggle-label">Aa</span>
                             </KsCheckboxButton>
                             <KsCheckboxButton
                                 v-model="wholeWord"
                                 size="small"
-                                :title="t('source_search.match_whole_word')"
-                                :aria-label="t('source_search.match_whole_word')"
+                                :title="$t('source_search.match_whole_word')"
+                                :aria-label="$t('source_search.match_whole_word')"
                             >
                                 <span class="source-search__toggle-label"><u>ab</u></span>
                             </KsCheckboxButton>
                             <KsCheckboxButton
                                 v-model="regexEnabled"
                                 size="small"
-                                :title="t('source_search.use_regex')"
-                                :aria-label="t('source_search.use_regex')"
+                                :title="$t('source_search.use_regex')"
+                                :aria-label="$t('source_search.use_regex')"
                             >
                                 <span class="source-search__toggle-label">.*</span>
                             </KsCheckboxButton>
@@ -58,14 +58,14 @@
 
                     <p v-if="showFlowOnlyToggleHint" class="source-search__toggle-hint">
                         <InformationOutline />
-                        {{ t('source_search.flow_only_toggle_hint') }}
+                        {{ $t('source_search.flow_only_toggle_hint') }}
                     </p>
 
                     <div v-if="replaceOpen" class="source-search__replace-row">
                         <KsSearch
                             v-model="replacement"
-                            :placeholder="t('source_search.replace_placeholder')"
-                            :aria-label="t('source_search.replace_aria')"
+                            :placeholder="$t('source_search.replace_placeholder')"
+                            :aria-label="$t('source_search.replace_aria')"
                         >
                             <template #prefix>
                                 <FindReplace />
@@ -75,29 +75,29 @@
                             :type="showDiffPreview ? 'primary' : 'default'"
                             :disabled="!query"
                             :loading="previewLoading"
-                            :tooltip="t('source_search.replace_all_tooltip')"
+                            :tooltip="$t('source_search.replace_all_tooltip')"
                             @click="triggerReplacePreview"
                         >
-                            {{ t('source_search.replace_all') }}
+                            {{ $t('source_search.replace_all') }}
                         </KsButton>
                     </div>
 
                     <p v-if="replaceOpen" class="source-search__toggle-hint">
                         <InformationOutline />
-                        {{ t('source_search.replace_scope_hint') }}
+                        {{ $t('source_search.replace_scope_hint') }}
                     </p>
 
                     <KsAlert
                         v-if="crossResourceSearchStore.truncatedFor('flows')"
                         type="warning"
                         class="source-search__truncation-alert"
-                        :description="t('source_search.truncated_flows', {shown: crossResourceSearchStore.countFor('flows'), total: crossResourceSearchStore.totalFor('flows')})"
+                        :description="$t('source_search.truncated_flows', {shown: crossResourceSearchStore.countFor('flows'), total: crossResourceSearchStore.totalFor('flows')})"
                     />
                 </div>
             </div>
 
             <div class="source-search__scope-row" data-test="source-search-type-pills">
-                <span id="source-search-in-label" class="source-search__scope-label">{{ t('source_search.search_in') }}</span>
+                <span id="source-search-in-label" class="source-search__scope-label">{{ $t('source_search.search_in') }}</span>
                 <div class="source-search__pills" role="group" aria-labelledby="source-search-in-label">
                     <KsCheckTag
                         v-for="type in SEARCH_RESOURCE_TYPES"
@@ -105,7 +105,7 @@
                         pill
                         :checked="selectedTypes.includes(type)"
                         :class="{'source-search__pill--failed': query && crossResourceSearchStore.statusFor(type) === 'failed'}"
-                        :title="type !== 'flows' ? t(type === 'files' ? 'source_search.path_only_hint' : 'source_search.key_only_hint') : undefined"
+                        :title="type !== 'flows' ? $t(type === 'files' ? 'source_search.path_only_hint' : 'source_search.key_only_hint') : undefined"
                         @change="(checked) => setTypeSelected(type, checked)"
                     >
                         <template #icon>
@@ -118,14 +118,14 @@
                         <PencilOff v-else-if="type !== 'flows'" />
                     </KsCheckTag>
                     <KsButton class="source-search__pill-outline" size="small" @click="selectAllTypes">
-                        {{ t('source_search.select_all_types') }}
+                        {{ $t('source_search.select_all_types') }}
                     </KsButton>
                 </div>
             </div>
 
             <div v-if="query" class="source-search__filter-row">
                 <div class="source-search__field">
-                    <label>{{ t('namespace') }}</label>
+                    <label>{{ $t('namespace') }}</label>
                     <NamespaceSelect
                         v-model="namespace"
                         data-type="flow"
@@ -133,7 +133,7 @@
                     />
                 </div>
                 <div v-if="selectedTypes.includes('flows')" class="source-search__field">
-                    <label>{{ t('source_search.flow_section') }}</label>
+                    <label>{{ $t('source_search.flow_section') }}</label>
                     <KsSegmented v-model="scope" size="small" :options="scopeOptions" />
                 </div>
 
@@ -146,20 +146,20 @@
                     class="source-search__summary"
                 >
                     <template #matches>
-                        <strong>{{ t('source_search.match_count', summaryMatchCount) }}</strong>
+                        <strong>{{ $t('source_search.match_count', summaryMatchCount) }}</strong>
                     </template>
                     <template #resources>
-                        <strong>{{ t('source_search.count_resources', summaryResourceCount) }}</strong>
+                        <strong>{{ $t('source_search.count_resources', summaryResourceCount) }}</strong>
                     </template>
                     <template #types>
-                        <strong>{{ t('source_search.count_types', summaryActiveTypeCount) }}</strong>
+                        <strong>{{ $t('source_search.count_types', summaryActiveTypeCount) }}</strong>
                     </template>
                 </i18n-t>
 
                 <div v-if="!showLoadingState" class="source-search__match-nav">
                     <KsIconButton
                         :disabled="visibleFlatSelections.length === 0"
-                        :tooltip="t('source_search.previous_match')"
+                        :tooltip="$t('source_search.previous_match')"
                         @click="goToMatch(-1)"
                     >
                         <ChevronUp />
@@ -167,13 +167,13 @@
                     <span class="source-search__match-count">{{ matchNavLabel }}</span>
                     <KsIconButton
                         :disabled="visibleFlatSelections.length === 0"
-                        :tooltip="t('source_search.next_match')"
+                        :tooltip="$t('source_search.next_match')"
                         @click="goToMatch(1)"
                     >
                         <ChevronDown />
                     </KsIconButton>
                     <KsIconButton
-                        :tooltip="allCollapsed ? t('source_search.expand_all') : t('source_search.collapse_all')"
+                        :tooltip="allCollapsed ? $t('source_search.expand_all') : $t('source_search.collapse_all')"
                         @click="toggleCollapseAll"
                     >
                         <ArrowExpandVertical v-if="allCollapsed" />
@@ -189,7 +189,7 @@
             type="error"
             class="source-search__type-failed-banner"
         >
-            <div class="source-search__alert-title">{{ t('source_search.type_search_failed', {type: typeLabel(type)}) }}</div>
+            <div class="source-search__alert-title">{{ $t('source_search.type_search_failed', {type: typeLabel(type)}) }}</div>
             <div>{{ crossResourceSearchStore.errorMessageFor(type) }}</div>
         </KsAlert>
 
@@ -199,14 +199,14 @@
             class="source-search__rbac-banner"
         >
             <div class="source-search__alert-title">
-                {{ t('source_search.exclusion_title', {count: totalExcludedFromReplaceCount}) }}
+                {{ $t('source_search.exclusion_title', {count: totalExcludedFromReplaceCount}) }}
             </div>
             <ul class="source-search__exclusion-list">
                 <li v-if="flowsReadOnlyMatchCount > 0">
-                    {{ t('source_search.exclusion_flows_readonly', {count: flowsReadOnlyMatchCount}) }}
+                    {{ $t('source_search.exclusion_flows_readonly', {count: flowsReadOnlyMatchCount}) }}
                 </li>
                 <li v-for="item in nonFlowSearchOnlyExclusions" :key="item.type">
-                    {{ t('source_search.exclusion_search_only', {type: typeLabel(item.type), count: item.count}) }}
+                    {{ $t('source_search.exclusion_search_only', {type: typeLabel(item.type), count: item.count}) }}
                 </li>
             </ul>
         </KsAlert>
@@ -216,7 +216,7 @@
             type="info"
             class="source-search__progress-banner"
         >
-            {{ t(filesProgressInfo.failed > 0 ? 'source_search.files_progress_banner_failed' : 'source_search.files_progress_banner_ok', filesProgressInfo) }}
+            {{ $t(filesProgressInfo.failed > 0 ? 'source_search.files_progress_banner_failed' : 'source_search.files_progress_banner_ok', filesProgressInfo) }}
         </KsAlert>
 
         <div v-if="!query" class="source-search__states">
@@ -227,10 +227,10 @@
                     </span>
                 </template>
                 <template #description>
-                    <h3>{{ t('source_search.empty_title') }}</h3>
-                    <p>{{ t('source_search.empty_description') }}</p>
+                    <h3>{{ $t('source_search.empty_title') }}</h3>
+                    <p>{{ $t('source_search.empty_description') }}</p>
                 </template>
-                <div class="source-search__examples" role="list" :aria-label="t('source_search.examples_aria')">
+                <div class="source-search__examples" role="list" :aria-label="$t('source_search.examples_aria')">
                     <button
                         v-for="example in exampleQueries"
                         :key="example"
@@ -254,21 +254,21 @@
         <div v-else-if="showEmptyResultsState" class="source-search__states">
             <KsEmpty :background="false">
                 <template #description>
-                    <h3>{{ t('source_search.no_results_in_types', {query, types: selectedTypesLabel}) }}</h3>
+                    <h3>{{ $t('source_search.no_results_in_types', {query, types: selectedTypesLabel}) }}</h3>
                     <p v-if="hiddenTypeHint">{{ hiddenTypeHint }}</p>
                 </template>
                 <div class="source-search__examples">
                     <KsButton v-if="hiddenTypeCounts.length > 0" type="primary" @click="selectAllTypes">
-                        {{ t('source_search.select_all_types') }}
+                        {{ $t('source_search.select_all_types') }}
                     </KsButton>
                     <KsButton v-if="caseSensitive" @click="caseSensitive = false">
-                        {{ t('source_search.turn_off', {option: t('source_search.match_case')}) }}
+                        {{ $t('source_search.turn_off', {option: $t('source_search.match_case')}) }}
                     </KsButton>
                     <KsButton v-if="wholeWord" @click="wholeWord = false">
-                        {{ t('source_search.turn_off', {option: t('source_search.match_whole_word')}) }}
+                        {{ $t('source_search.turn_off', {option: $t('source_search.match_whole_word')}) }}
                     </KsButton>
                     <KsButton v-if="regexEnabled" @click="regexEnabled = false">
-                        {{ t('source_search.turn_off', {option: t('source_search.use_regex')}) }}
+                        {{ $t('source_search.turn_off', {option: $t('source_search.use_regex')}) }}
                     </KsButton>
                 </div>
             </KsEmpty>

--- a/ui/src/components/flows/TaskEditData.vue
+++ b/ui/src/components/flows/TaskEditData.vue
@@ -3,7 +3,7 @@
         v-if="isCollapsed"
         class="task-edit-data-rail"
         type="button"
-        :aria-label="`${t('expand')} — ${title}`"
+        :aria-label="`${$t('expand')} — ${title}`"
         :title="title"
         :data-test="`task-edit-data-${kind}`"
         @click="emit('toggle')"
@@ -20,7 +20,7 @@
             <KsIconButton
                 v-if="collapsible"
                 class="task-edit-data-collapse"
-                :tooltip="t('collapse')"
+                :tooltip="$t('collapse')"
                 @click="emit('toggle')"
             >
                 <component :is="stacked ? ChevronDown : (side === 'right' ? ChevronRight : ChevronLeft)" />
@@ -32,8 +32,8 @@
             <input
                 v-model="filter"
                 class="task-edit-data-filter-input"
-                :placeholder="t('block_editor.filter_data')"
-                :aria-label="t('block_editor.filter_data')"
+                :placeholder="$t('block_editor.filter_data')"
+                :aria-label="$t('block_editor.filter_data')"
                 autocomplete="off"
                 spellcheck="false"
             >
@@ -64,7 +64,7 @@
                             @dragstart="chip.expr && onDragStart($event, chip.expr)"
                         >
                             <span class="task-edit-data-chip-label">{{ chip.label }}</span>
-                            <span v-if="copied === chip.expr" class="task-edit-data-chip-action">{{ t("copied") }}</span>
+                            <span v-if="copied === chip.expr" class="task-edit-data-chip-action">{{ $t("copied") }}</span>
                         </button>
                         <div v-else class="task-edit-data-chip task-edit-data-chip--static">
                             <span class="task-edit-data-chip-label">{{ chip.label }}</span>
@@ -75,7 +75,7 @@
             </div>
 
             <p v-if="visibleSections.length === 0" class="task-edit-data-empty">
-                {{ t("block_editor.no_data_matches") }}
+                {{ $t("block_editor.no_data_matches") }}
             </p>
         </div>
     </div>
@@ -83,7 +83,6 @@
 
 <script setup lang="ts">
     import {computed, ref} from "vue"
-    import {useI18n} from "vue-i18n"
     import {copyToClipboard} from "@kestra-io/design-system"
     import Magnify from "vue-material-design-icons/Magnify.vue"
     import ChevronRight from "vue-material-design-icons/ChevronRight.vue"
@@ -124,7 +123,6 @@
 
     const emit = defineEmits<{(e: "toggle"): void}>()
 
-    const {t} = useI18n()
 
     const filter = ref("")
     const collapsed = ref(new Set<string>())

--- a/ui/src/components/flows/TestEventDialog.vue
+++ b/ui/src/components/flows/TestEventDialog.vue
@@ -1,11 +1,11 @@
 <template>
     <KsDialog v-model="open" destroyOnClose :appendToBody="true" width="560px" scrollable>
         <template #header>
-            <span>{{ t("test_event.title") }}</span>
+            <span>{{ $t("test_event.title") }}</span>
         </template>
 
         <p class="test-event-description">
-            {{ t("test_event.description", {trigger: target?.triggerId}) }}
+            {{ $t("test_event.description", {trigger: target?.triggerId}) }}
         </p>
 
         <p class="test-event-url">
@@ -13,7 +13,7 @@
         </p>
 
         <KsForm labelPosition="top">
-            <KsFormItem :label="t('test_event.payload')">
+            <KsFormItem :label="$t('test_event.payload')">
                 <KsEditor
                     v-bind="editorBindings"
                     v-model="payload"
@@ -24,7 +24,7 @@
                 />
             </KsFormItem>
 
-            <KsFormItem :label="t('test_event.headers')">
+            <KsFormItem :label="$t('test_event.headers')">
                 <KsInput
                     v-model="headers"
                     type="textarea"
@@ -36,25 +36,25 @@
 
         <KsAlert v-if="result && result.ok" type="success" :closable="false">
             <template #title>
-                <span>{{ t("test_event.response", {status: result.status}) }}</span>
+                <span>{{ $t("test_event.response", {status: result.status}) }}</span>
                 <RouterLink v-if="result.executionId" :to="executionRoute(result.executionId)" class="test-event-link">
-                    {{ t("test_event.execution_created") }}
+                    {{ $t("test_event.execution_created") }}
                 </RouterLink>
             </template>
         </KsAlert>
 
         <KsAlert v-else-if="result" type="error" :closable="false">
             <template #title>
-                <span>{{ t("test_event.failed", {status: result.status}) }}</span>
+                <span>{{ $t("test_event.failed", {status: result.status}) }}</span>
             </template>
         </KsAlert>
 
         <template #footer>
             <KsButton @click="open = false">
-                {{ t("close") }}
+                {{ $t("close") }}
             </KsButton>
             <KsButton type="primary" :disabled="sending" @click="send">
-                {{ sending ? t("test_event.sending") : t("test_event.send") }}
+                {{ sending ? $t("test_event.sending") : $t("test_event.send") }}
             </KsButton>
         </template>
     </KsDialog>
@@ -62,7 +62,6 @@
 
 <script setup lang="ts">
     import {computed, ref, watch} from "vue"
-    import {useI18n} from "vue-i18n"
     import {useRoute} from "vue-router"
 
     import {EXECUTION_PARENT_ROUTE} from "../executions/executionTabs"
@@ -89,7 +88,6 @@
         sent: [result: TestEventResult];
     }>()
 
-    const {t} = useI18n()
     const route = useRoute()
     const editorBindings = useEditorBindings()
 

--- a/ui/src/components/flows/TriggerFlow.vue
+++ b/ui/src/components/flows/TriggerFlow.vue
@@ -22,7 +22,7 @@
             large
         >
             <template #header>
-                <span v-html="t('execute the flow', {id: flowId})" />
+                <span v-html="$t('execute the flow', {id: flowId})" />
             </template>
             <FlowRun ref="flowRunRef" :embed="true" @execution-trigger="handleExecutionStart" :redirect="!playgroundStore.enabled" />
             <template #footer>
@@ -41,7 +41,7 @@
             <KsForm
                 labelPosition="top"
             >
-                <KsFormItem :label="t('namespace')">
+                <KsFormItem :label="$t('namespace')">
                     <KsSelect
                         v-model="localNamespace"
                     >
@@ -55,7 +55,7 @@
                 </KsFormItem>
                 <KsFormItem
                     v-if="localNamespace && executionsStore.flowsExecutable.length > 0"
-                    :label="t('flow')"
+                    :label="$t('flow')"
                 >
                     <KsSelect
                         v-model="localFlow"
@@ -69,7 +69,7 @@
                         />
                     </KsSelect>
                 </KsFormItem>
-                <KsFormItem v-if="localFlow" :label="t('inputs')">
+                <KsFormItem v-if="localFlow" :label="$t('inputs')">
                     <div class="w-100">
                         <FlowRun ref="selectFlowRunRef" :embed="true" @execution-trigger="handleExecutionStart" :redirect="!playgroundStore.enabled" />
                     </div>

--- a/ui/src/components/inputs/InputsForm.vue
+++ b/ui/src/components/inputs/InputsForm.vue
@@ -23,7 +23,7 @@
                         <KsButton
                             type="text"
                             :icon="ContentCopyIcon"
-                            :tooltip="t('copy_to_clipboard')"
+                            :tooltip="$t('copy_to_clipboard')"
                             class="input-copy-btn"
                             @click.prevent="copyInputRef(input.id)"
                         />
@@ -50,7 +50,7 @@
                     @update:model-value="onChange(input)"
                     :allowCreate="input.allowCustomValue"
                     :disabled="isComputingInput(input.id)"
-                    :placeholder="isComputingInput(input.id) ? t('loading') : undefined"
+                    :placeholder="isComputingInput(input.id) ? $t('loading') : undefined"
                     :loading="isLoadingInput(input.id)"
                     filterable
                     clearable
@@ -92,7 +92,7 @@
                     selectAll
                     :allowCreate="input.allowCustomValue"
                     :disabled="isComputingInput(input.id)"
-                    :placeholder="isComputingInput(input.id) ? t('loading') : undefined"
+                    :placeholder="isComputingInput(input.id) ? $t('loading') : undefined"
                     :loading="isLoadingInput(input.id)"
                 >
                     <KsOption

--- a/ui/src/components/layout/SideBar.vue
+++ b/ui/src/components/layout/SideBar.vue
@@ -30,7 +30,7 @@
                 @update:collapsed="(value: boolean) => onSectionCollapseChange(section, value)"
             >
                 <template v-if="getSectionCollapsed(section) && sectionHasNewChild(section)" #suffix>
-                    <KsNewBadge>{{ t("new") }}</KsNewBadge>
+                    <KsNewBadge>{{ $t("new") }}</KsNewBadge>
                 </template>
                 <MenuLink
                     v-for="item in getDisplayedItems(section)"

--- a/ui/src/components/logs/LogDisplaySettings.vue
+++ b/ui/src/components/logs/LogDisplaySettings.vue
@@ -1,28 +1,28 @@
 <template>
-    <KsPopover placement="bottom-end" trigger="click" :title="t('display_settings')" width="300">
+    <KsPopover placement="bottom-end" trigger="click" :title="$t('display_settings')" width="300">
         <template #reference>
-            <KsButton square type="default" size="default" :icon="Cog" :aria-label="t('display_settings')" />
+            <KsButton square type="default" size="default" :icon="Cog" :aria-label="$t('display_settings')" />
         </template>
         <template #default>
             <div class="log-display-settings">
                 <div class="row row--stack">
-                    <span class="row-label">{{ t('density') }}</span>
+                    <span class="row-label">{{ $t('density') }}</span>
                     <KsSegmented v-model="logsDensity" :options="densityOptions" block class="density-segmented" />
                 </div>
                 <div class="row">
-                    <span class="row-label">{{ t('font size') }}</span>
+                    <span class="row-label">{{ $t('font size') }}</span>
                     <KsInputNumber v-model="logsFontSize" :min="10" :max="24" :step="1" controlsPosition="right" class="row-number" />
                 </div>
                 <div class="row">
-                    <span class="row-label">{{ t('pretty_json') }}</span>
+                    <span class="row-label">{{ $t('pretty_json') }}</span>
                     <KsSwitch v-model="logsPrettyJson" />
                 </div>
                 <div class="row">
-                    <span class="row-label">{{ t('expand_by_default') }}</span>
+                    <span class="row-label">{{ $t('expand_by_default') }}</span>
                     <KsSwitch v-model="logsExpandByDefault" :disabled="!logsPrettyJson" />
                 </div>
                 <div class="row">
-                    <span class="row-label">{{ t('body_line_clamp') }}</span>
+                    <span class="row-label">{{ $t('body_line_clamp') }}</span>
                     <div class="clamp-control">
                         <KsInputNumber
                             v-if="clampEnabled"

--- a/ui/src/components/logs/LogsWrapper.vue
+++ b/ui/src/components/logs/LogsWrapper.vue
@@ -44,8 +44,8 @@
                             </div>
                             <div class="logs-toolbar__actions">
                                 <LogDisplaySettings />
-                                <KsButton square type="default" size="default" :icon="Download" :aria-label="t('download logs')" :tooltip="t('download logs')" @click="openDownload" />
-                                <KsButton square type="default" size="default" :icon="ContentCopy" :aria-label="t('copy logs')" :tooltip="t('copy logs')" @click="copyAllLogs" />
+                                <KsButton square type="default" size="default" :icon="Download" :aria-label="$t('download logs')" :tooltip="$t('download logs')" @click="openDownload" />
+                                <KsButton square type="default" size="default" :icon="ContentCopy" :aria-label="$t('copy logs')" :tooltip="$t('copy logs')" @click="copyAllLogs" />
                             </div>
                         </div>
                         <div v-if="logsStore.logs !== undefined && logsStore.logs?.length > 0" class="logs-wrapper">
@@ -75,22 +75,22 @@
             </KsDataTable>
         </div>
 
-        <KsDialog v-model="downloadOpen" :title="t('download logs')" destroyOnClose>
-            <p class="download-hint">{{ t('download_logs_description') }}</p>
+        <KsDialog v-model="downloadOpen" :title="$t('download logs')" destroyOnClose>
+            <p class="download-hint">{{ $t('download_logs_description') }}</p>
             <QuickFilters
                 :levels="VALUES.LEVELS"
                 :intervals="quickIntervals"
                 :level="downloadLevel"
                 :timeRange="downloadTimeRange"
-                :levelLabel="t('filter.level_log_executions.label')"
-                :intervalLabel="t('filter.timeRange_log.label')"
+                :levelLabel="$t('filter.level_log_executions.label')"
+                :intervalLabel="$t('filter.timeRange_log.label')"
                 @update:level="(value: string) => (downloadLevel = value)"
                 @update:time-range="(value: string) => (downloadTimeRange = value)"
             />
             <template #footer>
-                <KsButton @click="downloadOpen = false">{{ t('cancel') }}</KsButton>
+                <KsButton @click="downloadOpen = false">{{ $t('cancel') }}</KsButton>
                 <KsButton type="primary" :loading="downloading" @click="downloadLogs">
-                    {{ t('download') }}
+                    {{ $t('download') }}
                 </KsButton>
             </template>
         </KsDialog>

--- a/ui/src/components/logs/TaskRunDetails.vue
+++ b/ui/src/components/logs/TaskRunDetails.vue
@@ -104,7 +104,7 @@
                                             <ChevronDown />
                                         </KsIcon>
                                         <span class="log-group-count">×{{ item.members.length }}</span>
-                                        <span class="log-group-label">{{ isGroupExpanded(currentTaskRunIndex, item) ? t("collapse") : t("similar lines") }}</span>
+                                        <span class="log-group-label">{{ isGroupExpanded(currentTaskRunIndex, item) ? $t("collapse") : $t("similar lines") }}</span>
                                     </button>
                                 </template>
                                 <template v-else>
@@ -119,7 +119,7 @@
                                                 :icon="Download"
                                                 rel="noopener noreferrer"
                                             >
-                                                {{ t("download") }}
+                                                {{ $t("download") }}
                                             </KsButton>
                                             <FilePreview
                                                 :value="item.logFile"
@@ -247,7 +247,7 @@
                         }"
                         size="small"
                     >
-                        {{ t("iterations") }}
+                        {{ $t("iterations") }}
                     </KsButton>
                     <TaskRunLoopProgress
                         :currentTaskRunId="asTaskRun(currentTaskRun).id"

--- a/ui/src/components/no-code/blocks/BlockCard.vue
+++ b/ui/src/components/no-code/blocks/BlockCard.vue
@@ -18,7 +18,7 @@
         <DragVertical
             v-if="draggable"
             class="block-card-grip"
-            :aria-label="t('block_editor.drag_reorder')"
+            :aria-label="$t('block_editor.drag_reorder')"
             @mousedown.stop
         />
 
@@ -42,8 +42,8 @@
             <KsIconButton
                 v-if="runnable"
                 class="block-card-action block-card-action--run"
-                :aria-label="t('playground.run_task')"
-                :tooltip="t('playground.run_task')"
+                :aria-label="$t('playground.run_task')"
+                :tooltip="$t('playground.run_task')"
                 data-test="block-card-run"
                 tabindex="-1"
                 @click.stop="emit('run')"
@@ -54,8 +54,8 @@
             <KsIconButton
                 v-if="!panelMaximized"
                 class="block-card-action"
-                :aria-label="t('block_editor.open_in_split')"
-                :tooltip="t('block_editor.open_in_split')"
+                :aria-label="$t('block_editor.open_in_split')"
+                :tooltip="$t('block_editor.open_in_split')"
                 data-test="block-card-open-split"
                 tabindex="-1"
                 @click.stop="emit('open-split')"
@@ -65,8 +65,8 @@
 
             <KsIconButton
                 class="block-card-action"
-                :aria-label="t('block_editor.duplicate')"
-                :tooltip="`${t('block_editor.duplicate')} (d)`"
+                :aria-label="$t('block_editor.duplicate')"
+                :tooltip="`${$t('block_editor.duplicate')} (d)`"
                 data-test="block-card-duplicate"
                 tabindex="-1"
                 @click.stop="emit('duplicate')"
@@ -76,8 +76,8 @@
 
             <KsIconButton
                 class="block-card-action block-card-action--danger"
-                :aria-label="t('block_editor.delete')"
-                :tooltip="`${t('block_editor.delete')} (⌫)`"
+                :aria-label="$t('block_editor.delete')"
+                :tooltip="`${$t('block_editor.delete')} (⌫)`"
                 data-test="block-card-delete"
                 tabindex="-1"
                 @click.stop="emit('delete')"

--- a/ui/src/components/no-code/blocks/BlockCommandMenu.vue
+++ b/ui/src/components/no-code/blocks/BlockCommandMenu.vue
@@ -8,7 +8,7 @@
             <div
                 class="block-command-menu"
                 role="dialog"
-                :aria-label="t('block_editor.command_menu.title')"
+                :aria-label="$t('block_editor.command_menu.title')"
                 @click.stop
                 @keydown="onKeydown"
             >
@@ -17,8 +17,8 @@
                         ref="searchInput"
                         v-model="query"
                         class="block-command-menu-input"
-                        :placeholder="t('block_editor.command_menu.search_placeholder')"
-                        :aria-label="t('block_editor.command_menu.search_placeholder')"
+                        :placeholder="$t('block_editor.command_menu.search_placeholder')"
+                        :aria-label="$t('block_editor.command_menu.search_placeholder')"
                         aria-controls="block-command-menu-listbox"
                         :aria-activedescendant="activeIndex >= 0 ? `block-command-menu-option-${activeIndex}` : undefined"
                         clearable
@@ -31,7 +31,7 @@
                     id="block-command-menu-listbox"
                     class="block-command-menu-list"
                     role="listbox"
-                    :aria-label="t('block_editor.command_menu.title')"
+                    :aria-label="$t('block_editor.command_menu.title')"
                     data-test="block-command-menu-list"
                 >
                     <template v-if="filteredItems.length">
@@ -62,7 +62,7 @@
                             </button>
                         </template>
                     </template>
-                    <p v-else class="block-command-menu-empty">{{ t('block_editor.command_menu.no_match') }}</p>
+                    <p v-else class="block-command-menu-empty">{{ $t('block_editor.command_menu.no_match') }}</p>
                 </div>
             </div>
         </div>
@@ -71,7 +71,6 @@
 
 <script setup lang="ts">
     import {computed, nextTick, onMounted, ref, watch, type Component} from "vue"
-    import {useI18n} from "vue-i18n"
 
     import {KsInput} from "@kestra-io/design-system"
 
@@ -100,7 +99,6 @@
         (e: "close"): void
     }>()
 
-    const {t} = useI18n()
 
     const query = ref("")
     const activeIndex = ref(0)

--- a/ui/src/components/no-code/blocks/BlockEditor.vue
+++ b/ui/src/components/no-code/blocks/BlockEditor.vue
@@ -46,17 +46,17 @@
                         data-test="block-editor-canvas"
                         :tabindex="focusedId ? -1 : 0"
                         role="group"
-                        :aria-label="t('block_editor.canvas_aria')"
+                        :aria-label="$t('block_editor.canvas_aria')"
                         @focus="onCanvasEntryFocus"
                     >
                         <BlockSectionCard
                             name="flow"
-                            :title="t('no_code.sections.flow')"
+                            :title="$t('no_code.sections.flow')"
                             :icon="FlowIcon"
                             :actionIcon="Cog"
                             hideCount
                             :count="0"
-                            :addLabel="t('block_editor.configure')"
+                            :addLabel="$t('block_editor.configure')"
                             addTest="block-editor-configure-flow"
                             @add="openFlowProperties"
                         >

--- a/ui/src/components/no-code/blocks/BlockEditorStatusBar.vue
+++ b/ui/src/components/no-code/blocks/BlockEditorStatusBar.vue
@@ -1,22 +1,22 @@
 <template>
     <KsDialog
         :modelValue="shortcutsOpen"
-        :title="t('block_editor.shortcuts.title')"
+        :title="$t('block_editor.shortcuts.title')"
         data-test="block-editor-shortcuts"
         @update:modelValue="(open?: boolean) => emit('update:shortcutsOpen', open ?? false)"
     >
         <div class="block-editor-shortcuts">
             <div v-for="group in shortcutGroups" :key="group.group" class="block-editor-shortcuts-col">
-                <span class="block-editor-shortcuts-heading">{{ t(`block_editor.shortcuts.group_${group.group}`) }}</span>
+                <span class="block-editor-shortcuts-heading">{{ $t(`block_editor.shortcuts.group_${group.group}`) }}</span>
                 <div v-for="binding in group.bindings" :key="binding.id" class="block-editor-shortcut">
                     <span class="block-editor-shortcut-keys">
                         <kbd v-for="key in displayKeys(binding.keys)" :key="key">{{ key }}</kbd>
                         <template v-if="binding.alt?.length">
-                            <span class="block-editor-shortcut-or">{{ t('block_editor.shortcuts.or') }}</span>
+                            <span class="block-editor-shortcut-or">{{ $t('block_editor.shortcuts.or') }}</span>
                             <kbd v-for="key in displayKeys(binding.alt)" :key="key">{{ key }}</kbd>
                         </template>
                     </span>
-                    <span>{{ t(binding.i18nKey) }}</span>
+                    <span>{{ $t(binding.i18nKey) }}</span>
                 </div>
             </div>
         </div>
@@ -25,8 +25,8 @@
     <button
         type="button"
         class="block-editor-help"
-        :aria-label="t('block_editor.shortcuts.title')"
-        :title="t('block_editor.shortcuts.title')"
+        :aria-label="$t('block_editor.shortcuts.title')"
+        :title="$t('block_editor.shortcuts.title')"
         data-test="block-editor-help"
         @click="emit('update:shortcutsOpen', true)"
     >
@@ -38,7 +38,7 @@
         <span class="block-editor-footer-context">{{ footerContext }}</span>
         <span v-for="hint in footerHints" :key="hint.id" class="block-editor-footer-hint">
             <kbd v-for="key in displayKeys(hint.keys)" :key="key">{{ key }}</kbd>
-            {{ t(hint.i18nKey) }}
+            {{ $t(hint.i18nKey) }}
         </span>
     </div>
 
@@ -51,7 +51,7 @@
                 data-test="block-editor-undo"
                 @click="emit('undo')"
             >
-                {{ t("block_editor.undo") }}
+                {{ $t("block_editor.undo") }}
             </button>
         </div>
     </Transition>
@@ -59,7 +59,6 @@
 
 <script setup lang="ts">
     import Keyboard from "vue-material-design-icons/Keyboard.vue"
-    import {useI18n} from "vue-i18n"
     import {displayKeys, type FooterHint} from "./shortcutHints"
     import type {BlockEditorKeyBinding, BlockEditorKeymapGroup} from "./keymap"
 
@@ -76,7 +75,6 @@
         undo: []
     }>()
 
-    const {t} = useI18n()
 </script>
 
 <style scoped lang="scss">

--- a/ui/src/components/no-code/blocks/BlockEmptyDrop.vue
+++ b/ui/src/components/no-code/blocks/BlockEmptyDrop.vue
@@ -8,7 +8,7 @@
     >
         <span class="block-empty-drop-lead">
             <PlusCircleOutline class="block-empty-drop-ico" />
-            {{ variant === "empty" ? t("block_editor.empty_add_lead", {label}) : t("block_editor.inline_add", {label}) }}
+            {{ variant === "empty" ? $t("block_editor.empty_add_lead", {label}) : $t("block_editor.inline_add", {label}) }}
         </span>
 
         <span v-if="hint" class="block-empty-drop-hint">{{ hint }}</span>
@@ -16,10 +16,8 @@
 </template>
 
 <script setup lang="ts">
-    import {useI18n} from "vue-i18n"
     import PlusCircleOutline from "vue-material-design-icons/PlusCircleOutline.vue"
 
-    const {t} = useI18n()
 
     withDefaults(defineProps<{
         label: string

--- a/ui/src/components/no-code/blocks/BlockErrorBadge.vue
+++ b/ui/src/components/no-code/blocks/BlockErrorBadge.vue
@@ -4,7 +4,7 @@
             <div class="block-error-tooltip">
                 <div class="block-error-tooltip-head">
                     <AlertCircle :size="14" />
-                    <span>{{ t("error detected") }}</span>
+                    <span>{{ $t("error detected") }}</span>
                 </div>
                 <ul class="block-error-tooltip-list">
                     <li v-for="issue in issues" :key="issue">{{ issue }}</li>
@@ -14,7 +14,7 @@
         <span
             class="block-error-badge"
             data-test="block-card-warning"
-            :aria-label="t('flow_editor_stats.errors.label', {count: issues.length})"
+            :aria-label="$t('flow_editor_stats.errors.label', {count: issues.length})"
         >
             <AlertCircle :size="14" />
             <span v-if="issues.length > 1" class="block-error-badge-count">{{ issues.length }}</span>
@@ -23,12 +23,10 @@
 </template>
 
 <script setup lang="ts">
-    import {useI18n} from "vue-i18n"
     import AlertCircle from "vue-material-design-icons/AlertCircle.vue"
 
     defineProps<{issues: string[]}>()
 
-    const {t} = useI18n()
 </script>
 
 <style scoped lang="scss">

--- a/ui/src/components/no-code/blocks/BlockTaskPicker.vue
+++ b/ui/src/components/no-code/blocks/BlockTaskPicker.vue
@@ -12,13 +12,13 @@
                 @click.stop
                 @keydown="onPickerKeydown"
             >
-                <p class="block-editor-picker-context">{{ t('block_editor.inserting_into', {section: sectionLabel}) }}</p>
+                <p class="block-editor-picker-context">{{ $t('block_editor.inserting_into', {section: sectionLabel}) }}</p>
 
                 <KsInput
                     :ref="(el) => (picker.pickerSearchInput.value = el)"
                     v-model="taskPickerSearch"
-                    :placeholder="t('block_editor.search_task_placeholder')"
-                    :aria-label="t('block_editor.search_task_placeholder')"
+                    :placeholder="$t('block_editor.search_task_placeholder')"
+                    :aria-label="$t('block_editor.search_task_placeholder')"
                     aria-controls="block-editor-picker-listbox"
                     :aria-activedescendant="pickerFocusedIndex >= 0 ? `block-editor-picker-option-${pickerFocusedIndex}` : undefined"
                     clearable
@@ -38,7 +38,7 @@
                         @click="setPickerTab(tab.id)"
                     >
                         <component :is="tab.icon" class="block-editor-picker-tab-ico" />
-                        {{ t(tab.labelKey) }}
+                        {{ $t(tab.labelKey) }}
                         <span v-if="tab.id === 'apps'" class="block-editor-picker-tab-count">{{ appGroups.length }}</span>
                     </button>
                 </div>
@@ -48,7 +48,7 @@
                     v-ks-loading="pluginsLoading"
                     class="block-editor-picker-list"
                     :class="{'block-editor-picker-list--loading': pluginsLoading}"
-                    :aria-label="t('block_editor.pick_task_type')"
+                    :aria-label="$t('block_editor.pick_task_type')"
                     data-test="block-editor-picker-list"
                     role="listbox"
                 >
@@ -62,7 +62,7 @@
                         >
                             <TaskIcon class="block-editor-picker-icon" :cls="grp.sampleFqcn" :icons="pluginsStore.icons" :loadIcon="pluginsStore.loadIcon" :onlyIcon="true" />
                             <span class="block-editor-picker-app-name">{{ grp.group }}</span>
-                            <span class="block-editor-picker-app-count">{{ t('block_editor.app_actions', {count: grp.count}) }}</span>
+                            <span class="block-editor-picker-app-count">{{ $t('block_editor.app_actions', {count: grp.count}) }}</span>
                         </button>
                     </template>
 
@@ -76,7 +76,7 @@
                             @keydown.enter="appFilter = undefined"
                         >
                             <ChevronLeft class="block-editor-picker-back-ico" />
-                            {{ t('block_editor.all_apps') }}
+                            {{ $t('block_editor.all_apps') }}
                         </div>
 
                         <button
@@ -100,19 +100,19 @@
                         </button>
 
                         <p v-if="!pluginsLoading && displayedEntries.length === 0" class="block-editor-picker-empty">
-                            {{ (!hasSearch && pickerTab === "recent") ? t("block_editor.no_recent") : t("block_editor.no_task_results") }}
+                            {{ (!hasSearch && pickerTab === "recent") ? $t("block_editor.no_recent") : $t("block_editor.no_task_results") }}
                         </p>
 
                         <p v-else-if="hasSearch && pickerHiddenCount > 0" class="block-editor-picker-more">
-                            {{ t("block_editor.picker_more_results", {count: pickerHiddenCount}) }}
+                            {{ $t("block_editor.picker_more_results", {count: pickerHiddenCount}) }}
                         </p>
                     </template>
                 </div>
 
                 <div class="block-editor-picker-footer" aria-hidden="true">
-                    <span><kbd>↑</kbd><kbd>↓</kbd> {{ t('block_editor.kbd_navigate') }}</span>
-                    <span><kbd>↵</kbd> {{ t('block_editor.kbd_add') }}</span>
-                    <span><kbd>esc</kbd> {{ t('block_editor.kbd_close') }}</span>
+                    <span><kbd>↑</kbd><kbd>↓</kbd> {{ $t('block_editor.kbd_navigate') }}</span>
+                    <span><kbd>↵</kbd> {{ $t('block_editor.kbd_add') }}</span>
+                    <span><kbd>esc</kbd> {{ $t('block_editor.kbd_close') }}</span>
                 </div>
             </div>
         </div>
@@ -122,14 +122,12 @@
 <script setup lang="ts">
     import ChevronLeft from "vue-material-design-icons/ChevronLeft.vue"
     import {KsInput, vKsLoading} from "@kestra-io/design-system"
-    import {useI18n} from "vue-i18n"
     import TaskIcon from "../../plugins/TaskIcon.vue"
     import {usePluginsStore} from "../../../stores/plugins"
     import type {TaskPickerApi} from "./useTaskPicker"
 
     const props = defineProps<{picker: TaskPickerApi}>()
 
-    const {t} = useI18n()
     const pluginsStore = usePluginsStore()
 
     const {

--- a/ui/src/components/no-code/blocks/BranchLane.vue
+++ b/ui/src/components/no-code/blocks/BranchLane.vue
@@ -14,7 +14,7 @@
                 size="small"
                 class="branch-lane-depth-pill"
             >
-                {{ t("block_editor.depth_pill", {depth}) }}
+                {{ $t("block_editor.depth_pill", {depth}) }}
             </KsTag>
         </div>
 
@@ -77,7 +77,7 @@
             <KsAlert
                 v-else-if="laneName === 'then'"
                 type="warning"
-                :title="t('block_editor.then_required_warning')"
+                :title="$t('block_editor.then_required_warning')"
                 class="branch-lane-warning"
             />
 
@@ -88,11 +88,11 @@
                 :data-block-id="tasks.length === 0 ? `__lane:${parentPath}` : undefined"
                 :class="{'block-kbd-focused': tasks.length === 0 && focusedId === `__lane:${parentPath}`}"
                 :tabindex="tasks.length === 0 && focusedId === `__lane:${parentPath}` ? 0 : -1"
-                :aria-label="t('block_editor.add_to_lane', {lane: laneLabel})"
+                :aria-label="$t('block_editor.add_to_lane', {lane: laneLabel})"
                 @click="emit('add-at-path', parentPath, tasks.length - 1, $event)"
             >
                 <PlusCircleOutline class="branch-lane-add-icon" />
-                {{ t("block_editor.add_to_lane", {lane: laneLabel}) }}
+                {{ $t("block_editor.add_to_lane", {lane: laneLabel}) }}
             </button>
         </div>
     </div>

--- a/ui/src/components/no-code/blocks/DagDependsOnEditor.vue
+++ b/ui/src/components/no-code/blocks/DagDependsOnEditor.vue
@@ -1,15 +1,15 @@
 <template>
     <div class="dag-depends-on" data-test="dag-depends-on">
         <SourceBranch class="dag-depends-on-icon" aria-hidden="true" />
-        <span class="dag-depends-on-label">{{ t("block_editor.depends_on_label") }}</span>
+        <span class="dag-depends-on-label">{{ $t("block_editor.depends_on_label") }}</span>
         <KsSelect
             :modelValue="dependsOn ?? []"
             multiple
             filterable
             size="small"
             class="dag-depends-on-select"
-            :placeholder="t('block_editor.depends_on_placeholder')"
-            :aria-label="t('block_editor.depends_on_label')"
+            :placeholder="$t('block_editor.depends_on_placeholder')"
+            :aria-label="$t('block_editor.depends_on_label')"
             data-test="dag-depends-on-select"
             @click.stop
             @update:modelValue="onUpdate"
@@ -25,11 +25,9 @@
 </template>
 
 <script setup lang="ts">
-    import {useI18n} from "vue-i18n"
     import SourceBranch from "vue-material-design-icons/SourceBranch.vue"
     import {KsSelect, KsOption} from "@kestra-io/design-system"
 
-    const {t} = useI18n()
 
     defineProps<{
         dependsOn?: string[]

--- a/ui/src/components/no-code/blocks/FlowPropertiesEdit.vue
+++ b/ui/src/components/no-code/blocks/FlowPropertiesEdit.vue
@@ -1,17 +1,17 @@
 <template>
     <div class="flow-properties-edit" data-test="flow-properties-edit">
         <header v-if="!hideHeader" class="flow-properties-head">
-            <KsIconButton :tooltip="t('back')" data-test="flow-properties-back" @click="emit('close')">
+            <KsIconButton :tooltip="$t('back')" data-test="flow-properties-back" @click="emit('close')">
                 <ChevronLeft />
             </KsIconButton>
-            <span class="flow-properties-title">{{ t("no_code.sections.flow") }}</span>
+            <span class="flow-properties-title">{{ $t("no_code.sections.flow") }}</span>
         </header>
 
         <div v-if="createTarget" class="flow-properties-body" data-test="flow-properties-create">
             <FieldNavBreadcrumb
                 class="flow-properties-crumb"
                 :frames="[{path: createTarget.parentPath, label: createTarget.label}]"
-                :rootLabel="t('no_code.sections.flow')"
+                :rootLabel="$t('no_code.sections.flow')"
                 @navigate="closeCreate"
                 @back="closeCreate"
             />
@@ -61,7 +61,6 @@
 
 <script setup lang="ts">
     import {computed, inject, provide, ref} from "vue"
-    import {useI18n} from "vue-i18n"
     import {flowYamlUtils as YAML_UTILS} from "@kestra-io/topology"
     import {KsForm, KsIconButton} from "@kestra-io/design-system"
     import ChevronLeft from "vue-material-design-icons/ChevronLeft.vue"
@@ -80,7 +79,6 @@
         UPDATE_YAML_FUNCTION_INJECTION_KEY,
     } from "../injectionKeys"
 
-    const {t} = useI18n()
     const flowStore = useFlowStore()
 
     const props = defineProps<{hideHeader?: boolean; hostedInModal?: boolean}>()

--- a/ui/src/components/no-code/blocks/FlowPropertiesModal.vue
+++ b/ui/src/components/no-code/blocks/FlowPropertiesModal.vue
@@ -10,11 +10,11 @@
     >
         <template #header>
             <div class="flow-properties-modal-header">
-                <span class="flow-properties-modal-title">{{ t("no_code.sections.flow") }}</span>
+                <span class="flow-properties-modal-title">{{ $t("no_code.sections.flow") }}</span>
                 <KsIconButton
                     class="flow-properties-modal-header-action"
-                    :aria-label="t('close')"
-                    :tooltip="t('close')"
+                    :aria-label="$t('close')"
+                    :tooltip="$t('close')"
                     data-test="flow-properties-modal-close"
                     @click="emit('close')"
                 >
@@ -30,14 +30,12 @@
 </template>
 
 <script setup lang="ts">
-    import {useI18n} from "vue-i18n"
     import {KsDialog, KsIconButton} from "@kestra-io/design-system"
     import Close from "vue-material-design-icons/Close.vue"
     import FlowPropertiesEdit from "./FlowPropertiesEdit.vue"
 
     const emit = defineEmits<{(e: "close"): void}>()
 
-    const {t} = useI18n()
 </script>
 
 <style lang="scss" scoped>

--- a/ui/src/components/no-code/blocks/FlowableClusterCard.vue
+++ b/ui/src/components/no-code/blocks/FlowableClusterCard.vue
@@ -38,13 +38,13 @@
             </KsTag>
 
             <span v-if="!expanded" class="flowable-cluster-summary" aria-hidden="true">
-                {{ t("block_editor.collapsed_summary", {count: totalNestedCount}) }}
+                {{ $t("block_editor.collapsed_summary", {count: totalNestedCount}) }}
             </span>
 
             <div class="flowable-cluster-actions">
                 <KsIconButton
-                    :aria-label="t('block_editor.configure')"
-                    :tooltip="t('block_editor.configure')"
+                    :aria-label="$t('block_editor.configure')"
+                    :tooltip="$t('block_editor.configure')"
                     data-test="flowable-cluster-configure"
                     tabindex="-1"
                     @click.stop="emit('select', path)"
@@ -53,8 +53,8 @@
                 </KsIconButton>
 
                 <KsIconButton
-                    :aria-label="t('block_editor.duplicate')"
-                    :tooltip="`${t('block_editor.duplicate')} (d)`"
+                    :aria-label="$t('block_editor.duplicate')"
+                    :tooltip="`${$t('block_editor.duplicate')} (d)`"
                     data-test="block-card-duplicate"
                     tabindex="-1"
                     @click.stop="emit('duplicate', path)"
@@ -64,8 +64,8 @@
 
                 <KsIconButton
                     class="flowable-cluster-action--danger"
-                    :aria-label="t('block_editor.delete')"
-                    :tooltip="`${t('block_editor.delete')} (⌫)`"
+                    :aria-label="$t('block_editor.delete')"
+                    :tooltip="`${$t('block_editor.delete')} (⌫)`"
                     data-test="block-card-delete"
                     tabindex="-1"
                     @click.stop="emit('delete', path)"
@@ -100,8 +100,8 @@
             <div v-if="isSwitchTask" class="flowable-cluster-add-case">
                 <KsInput
                     v-model="newCaseKey"
-                    :placeholder="t('block_editor.switch_case_key_placeholder')"
-                    :aria-label="t('block_editor.switch_case_key_placeholder')"
+                    :placeholder="$t('block_editor.switch_case_key_placeholder')"
+                    :aria-label="$t('block_editor.switch_case_key_placeholder')"
                     size="small"
                     class="flowable-cluster-case-input"
                     data-test="flowable-add-case-input"
@@ -111,15 +111,15 @@
                     class="flowable-cluster-add-case-btn"
                     type="button"
                     :disabled="!newCaseKey.trim() || isCaseKeyTaken"
-                    :title="isCaseKeyTaken ? t('block_editor.switch_case_key_taken', {key: newCaseKey.trim()}) : undefined"
+                    :title="isCaseKeyTaken ? $t('block_editor.switch_case_key_taken', {key: newCaseKey.trim()}) : undefined"
                     data-test="flowable-add-case-btn"
                     @click="addCase"
                 >
                     <PlusCircleOutline class="flowable-cluster-add-icon" />
-                    {{ t("block_editor.add_switch_case") }}
+                    {{ $t("block_editor.add_switch_case") }}
                 </button>
                 <span v-if="isCaseKeyTaken" class="flowable-cluster-case-taken" data-test="flowable-add-case-taken">
-                    {{ t("block_editor.switch_case_key_taken", {key: newCaseKey.trim()}) }}
+                    {{ $t("block_editor.switch_case_key_taken", {key: newCaseKey.trim()}) }}
                 </span>
             </div>
         </div>

--- a/ui/src/components/no-code/blocks/LeafBlockCard.vue
+++ b/ui/src/components/no-code/blocks/LeafBlockCard.vue
@@ -18,7 +18,7 @@
         <DragVertical
             v-if="draggable"
             class="leaf-block-card-grip"
-            :aria-label="t('block_editor.drag_reorder')"
+            :aria-label="$t('block_editor.drag_reorder')"
             @mousedown.stop
         />
 
@@ -42,8 +42,8 @@
             <KsIconButton
                 v-if="runnable"
                 class="leaf-block-card-action leaf-block-card-action--run"
-                :aria-label="t('playground.run_task')"
-                :tooltip="t('playground.run_task')"
+                :aria-label="$t('playground.run_task')"
+                :tooltip="$t('playground.run_task')"
                 data-test="block-card-run"
                 tabindex="-1"
                 @click.stop="emit('run')"
@@ -54,8 +54,8 @@
             <KsIconButton
                 v-if="showOpenSplit && !panelMaximized"
                 class="leaf-block-card-action"
-                :aria-label="t('block_editor.open_in_split')"
-                :tooltip="t('block_editor.open_in_split')"
+                :aria-label="$t('block_editor.open_in_split')"
+                :tooltip="$t('block_editor.open_in_split')"
                 data-test="block-card-open-split"
                 tabindex="-1"
                 @click.stop="emit('open-split')"
@@ -66,8 +66,8 @@
             <KsIconButton
                 v-if="showDuplicate"
                 class="leaf-block-card-action"
-                :aria-label="t('block_editor.duplicate')"
-                :tooltip="`${t('block_editor.duplicate')} (d)`"
+                :aria-label="$t('block_editor.duplicate')"
+                :tooltip="`${$t('block_editor.duplicate')} (d)`"
                 data-test="block-card-duplicate"
                 tabindex="-1"
                 @click.stop="emit('duplicate')"
@@ -77,8 +77,8 @@
 
             <KsIconButton
                 class="leaf-block-card-action leaf-block-card-action--danger"
-                :aria-label="t('block_editor.delete')"
-                :tooltip="`${t('block_editor.delete')} (⌫)`"
+                :aria-label="$t('block_editor.delete')"
+                :tooltip="`${$t('block_editor.delete')} (⌫)`"
                 data-test="block-card-delete"
                 tabindex="-1"
                 @click.stop="emit('delete')"

--- a/ui/src/components/no-code/blocks/TaskEditModal.vue
+++ b/ui/src/components/no-code/blocks/TaskEditModal.vue
@@ -15,8 +15,8 @@
                 <KsIconButton
                     class="task-edit-modal-header-action"
                     :type="docsOpen ? 'primary' : 'default'"
-                    :aria-label="t('documentation.documentation')"
-                    :tooltip="t('documentation.documentation')"
+                    :aria-label="$t('documentation.documentation')"
+                    :tooltip="$t('documentation.documentation')"
                     data-test="task-edit-modal-docs-toggle"
                     @click="toggleDocs"
                 >
@@ -24,8 +24,8 @@
                 </KsIconButton>
                 <KsIconButton
                     class="task-edit-modal-header-action"
-                    :aria-label="t('block_editor.open_in_tabs')"
-                    :tooltip="t('block_editor.open_in_tabs')"
+                    :aria-label="$t('block_editor.open_in_tabs')"
+                    :tooltip="$t('block_editor.open_in_tabs')"
                     data-test="task-edit-modal-open-in-tabs"
                     @click="emit('open-in-tabs')"
                 >
@@ -33,8 +33,8 @@
                 </KsIconButton>
                 <KsIconButton
                     class="task-edit-modal-header-action"
-                    :aria-label="t('close')"
-                    :tooltip="t('close')"
+                    :aria-label="$t('close')"
+                    :tooltip="$t('close')"
                     data-test="task-edit-modal-close"
                     @click="emit('close')"
                 >
@@ -96,14 +96,14 @@
                 <KsText size="small">
                     <i18n-t keypath="block_editor.open_mode_hint" scope="global">
                         <template #settings>
-                            <router-link :to="{name: 'preferences'}">{{ t("settings.label") }}</router-link>
+                            <router-link :to="{name: 'preferences'}">{{ $t("settings.label") }}</router-link>
                         </template>
                     </i18n-t>
                 </KsText>
                 <KsIconButton
                     class="task-edit-modal-hint-dismiss"
-                    :aria-label="t('close')"
-                    :tooltip="t('close')"
+                    :aria-label="$t('close')"
+                    :tooltip="$t('close')"
                     data-test="task-edit-modal-open-mode-hint-dismiss"
                     @click="dismissHint"
                 >

--- a/ui/src/components/no-code/components/FieldNavBreadcrumb.vue
+++ b/ui/src/components/no-code/components/FieldNavBreadcrumb.vue
@@ -1,13 +1,13 @@
 <template>
-    <nav class="field-nav-breadcrumb" :aria-label="t('no_code.nav.breadcrumb_aria')">
+    <nav class="field-nav-breadcrumb" :aria-label="$t('no_code.nav.breadcrumb_aria')">
         <button
             type="button"
             class="field-nav-back"
-            :aria-label="t('no_code.nav.back')"
+            :aria-label="$t('no_code.nav.back')"
             @click="emit('back')"
         >
             <ChevronLeft :size="16" />
-            <span>{{ t("no_code.nav.back") }}</span>
+            <span>{{ $t("no_code.nav.back") }}</span>
         </button>
 
         <span class="field-nav-sep">/</span>
@@ -32,13 +32,11 @@
 </template>
 
 <script setup lang="ts">
-    import {useI18n} from "vue-i18n"
     import ChevronLeft from "vue-material-design-icons/ChevronLeft.vue"
     import ChevronRight from "vue-material-design-icons/ChevronRight.vue"
 
     import type {Crumb} from "../utils/useFieldNavigation"
 
-    const {t} = useI18n()
 
     defineProps<{
         frames: Crumb[];

--- a/ui/src/components/no-code/components/tasks/TaskDict.vue
+++ b/ui/src/components/no-code/components/tasks/TaskDict.vue
@@ -1,7 +1,7 @@
 <template>
     <KsAlert
         v-if="duplicatedKeys?.length"
-        :title="t('duplicate-pair', {label: t('key'), key: duplicatedKeys[0]})"
+        :title="$t('duplicate-pair', {label: $t('key'), key: duplicatedKeys[0]})"
         type="error"
         :closable="false"
         class="mb-2"
@@ -32,7 +32,7 @@
                     />
                     <div class="delete-container">
                         <button @click="removeItem(index)" class="remove-entry">
-                            {{ te(`no_code.remove.${root}`) ? t(`no_code.remove.${root}`) : t('no_code.remove.default') }} <DeleteOutline />
+                            {{ te(`no_code.remove.${root}`) ? $t(`no_code.remove.${root}`) : $t('no_code.remove.default') }} <DeleteOutline />
                         </button>
                     </div>
                 </template>
@@ -82,7 +82,7 @@
     import Wrapper from "./Wrapper.vue"
     import {useBlockComponent} from "./useBlockComponent"
 
-    const {t, te} = useI18n()
+    const {te} = useI18n()
 
     defineOptions({
         inheritAttrs: false,

--- a/ui/src/components/no-code/components/tasks/TaskObjectField.vue
+++ b/ui/src/components/no-code/components/tasks/TaskObjectField.vue
@@ -62,9 +62,9 @@
                     <span
                         v-if="pluginDefault !== undefined"
                         class="plugin-default-hint"
-                        :title="t('block_editor.plugin_default_tooltip')"
+                        :title="$t('block_editor.plugin_default_tooltip')"
                     >
-                        {{ t("block_editor.plugin_default", {value: pluginDefault}) }}
+                        {{ $t("block_editor.plugin_default", {value: pluginDefault}) }}
                     </span>
 
                     <ClearButton
@@ -106,8 +106,8 @@
                     filled
                     class="inline-code-toggle"
                     :type="pebbleState ? 'primary' : 'default'"
-                    :tooltip="t('no_code.toggle_pebble')"
-                    :aria-label="t('no_code.toggle_pebble')"
+                    :tooltip="$t('no_code.toggle_pebble')"
+                    :aria-label="$t('no_code.toggle_pebble')"
                     @click="pebbleState = !pebbleState"
                 >
                     <IconCodeTags />
@@ -133,14 +133,13 @@
             data-test="field-required-missing"
         >
             <AlertCircleOutline class="required-missing-icon" />
-            {{ t("block_editor.required_missing") }}
+            {{ $t("block_editor.required_missing") }}
         </span>
     </KsFormItem>
 </template>
 
 <script setup lang="ts">
     import {computed, inject, ref, useTemplateRef} from "vue"
-    import {useI18n} from "vue-i18n"
     import {useBlockComponent} from "./useBlockComponent"
     import {FIELD_NAV_INJECTION_KEY, PLUGIN_DEFAULTS_INJECTION_KEY} from "../../injectionKeys"
 
@@ -244,7 +243,6 @@
         return getBlockComponent.value(props.schema ?? {}, props.fieldKey, props.siblingKeys)
     })
 
-    const {t} = useI18n()
 
     const pluginDefaults = inject(PLUGIN_DEFAULTS_INJECTION_KEY, undefined)
     const pluginDefault = computed(() => {

--- a/ui/src/components/onboarding/tour/ProductTourItem.vue
+++ b/ui/src/components/onboarding/tour/ProductTourItem.vue
@@ -5,11 +5,11 @@
                 <Play :size="18" />
             </span>
             <span class="product-tour-label">
-                {{ t("onboarding.tour.menu") }}
+                {{ $t("onboarding.tour.menu") }}
             </span>
         </RouterLink>
         <span class="product-tour-dismiss">
-            <KsIconButton :tooltip="t('onboarding.tour.actions.dismiss')" placement="top" @click="dismiss">
+            <KsIconButton :tooltip="$t('onboarding.tour.actions.dismiss')" placement="top" @click="dismiss">
                 <Close />
             </KsIconButton>
         </span>
@@ -17,13 +17,11 @@
 </template>
 
 <script setup lang="ts">
-    import {useI18n} from "vue-i18n"
     import Play from "vue-material-design-icons/Play.vue"
     import Close from "vue-material-design-icons/Close.vue"
 
     import {useProductTourMenuEntry} from "./useProductTourEntry"
 
-    const {t} = useI18n()
     const {visible, tourRoute, dismiss} = useProductTourMenuEntry()
 </script>
 

--- a/ui/src/components/onboarding/tour/ProductTourNudge.vue
+++ b/ui/src/components/onboarding/tour/ProductTourNudge.vue
@@ -1,32 +1,30 @@
 <template>
     <div v-if="visible && isBlueprints" class="product-tour-nudge">
         <span class="product-tour-nudge__dismiss">
-            <KsIconButton :tooltip="t('onboarding.tour.actions.dismiss')" placement="top" @click="dismiss">
+            <KsIconButton :tooltip="$t('onboarding.tour.actions.dismiss')" placement="top" @click="dismiss">
                 <Close />
             </KsIconButton>
         </span>
         <p class="product-tour-nudge__title">
-            {{ t("onboarding.tour.nudge.title") }}
+            {{ $t("onboarding.tour.nudge.title") }}
         </p>
         <RouterLink :to="tourRoute" class="product-tour-nudge__link">
             <span class="product-tour-nudge__play">
                 <Play :size="14" />
             </span>
-            <span>{{ t("onboarding.tour.nudge.action") }}</span>
+            <span>{{ $t("onboarding.tour.nudge.action") }}</span>
         </RouterLink>
     </div>
 </template>
 
 <script setup lang="ts">
     import {computed} from "vue"
-    import {useI18n} from "vue-i18n"
     import {useRoute} from "vue-router"
     import Play from "vue-material-design-icons/Play.vue"
     import Close from "vue-material-design-icons/Close.vue"
 
     import {useProductTourNudge} from "./useProductTourEntry"
 
-    const {t} = useI18n()
     const route = useRoute()
     const {visible, tourRoute, dismiss} = useProductTourNudge()
 

--- a/ui/src/components/plugins/PluginDocumentation.vue
+++ b/ui/src/components/plugins/PluginDocumentation.vue
@@ -94,18 +94,18 @@
                 <div class="dp-intro-icon">
                     <BookOpenVariant :size="22" />
                 </div>
-                <h2 class="dp-intro-title">{{ t("plugins.intro_title") }}</h2>
-                <p class="dp-intro-sub">{{ t("plugins.intro_sub") }}</p>
+                <h2 class="dp-intro-title">{{ $t("plugins.intro_title") }}</h2>
+                <p class="dp-intro-sub">{{ $t("plugins.intro_sub") }}</p>
                 <div class="dp-intro-callout">
                     <CursorPointer :size="17" class="dp-intro-callout-icon" />
-                    <p>{{ t("plugins.intro_callout_prefix") }}<code>type</code>{{ t("plugins.intro_callout_suffix") }}</p>
+                    <p>{{ $t("plugins.intro_callout_prefix") }}<code>type</code>{{ $t("plugins.intro_callout_suffix") }}</p>
                 </div>
             </div>
 
             <div class="dp-intro-search-wrap">
                 <KsInput
                     v-model="introSearch"
-                    :placeholder="t('plugins.intro_search_placeholder')"
+                    :placeholder="$t('plugins.intro_search_placeholder')"
                     clearable
                     size="small"
                     class="dp-intro-search"
@@ -131,38 +131,38 @@
 
             <div class="dp-intro-body">
                 <template v-if="introSection === 'overview'">
-                    <div class="dp-intro-sec-label">{{ t("plugins.intro_start_here") }}</div>
+                    <div class="dp-intro-sec-label">{{ $t("plugins.intro_start_here") }}</div>
                     <div class="dp-intro-qstart">
                         <button type="button" class="dp-intro-qrow" @click="introSection = 'flow'">
                             <span class="dp-intro-qnum">1</span>
                             <span class="dp-intro-qtext">
-                                <span class="dp-intro-qt">{{ t("plugins.intro_step1_title") }}</span>
-                                <span class="dp-intro-qd">{{ t("plugins.intro_step1_desc_prefix") }}<code>id</code>{{ t("plugins.intro_step1_desc_mid") }}<code>namespace</code>{{ t("plugins.intro_step1_desc_suffix") }}</span>
-                                <span class="dp-intro-qcta">{{ t("plugins.intro_step1_cta") }}</span>
+                                <span class="dp-intro-qt">{{ $t("plugins.intro_step1_title") }}</span>
+                                <span class="dp-intro-qd">{{ $t("plugins.intro_step1_desc_prefix") }}<code>id</code>{{ $t("plugins.intro_step1_desc_mid") }}<code>namespace</code>{{ $t("plugins.intro_step1_desc_suffix") }}</span>
+                                <span class="dp-intro-qcta">{{ $t("plugins.intro_step1_cta") }}</span>
                             </span>
                             <ChevronRight :size="18" class="dp-intro-qchevron" />
                         </button>
                         <button type="button" class="dp-intro-qrow" @click="introSection = 'tasks'">
                             <span class="dp-intro-qnum">2</span>
                             <span class="dp-intro-qtext">
-                                <span class="dp-intro-qt">{{ t("plugins.intro_step2_title") }}</span>
-                                <span class="dp-intro-qd">{{ t("plugins.intro_step2_desc") }}</span>
-                                <span class="dp-intro-qcta">{{ t("plugins.intro_step2_cta") }}</span>
+                                <span class="dp-intro-qt">{{ $t("plugins.intro_step2_title") }}</span>
+                                <span class="dp-intro-qd">{{ $t("plugins.intro_step2_desc") }}</span>
+                                <span class="dp-intro-qcta">{{ $t("plugins.intro_step2_cta") }}</span>
                             </span>
                             <ChevronRight :size="18" class="dp-intro-qchevron" />
                         </button>
                         <button type="button" class="dp-intro-qrow" @click="introSection = 'inputs'">
                             <span class="dp-intro-qnum">3</span>
                             <span class="dp-intro-qtext">
-                                <span class="dp-intro-qt">{{ t("plugins.intro_step3_title") }}</span>
-                                <span class="dp-intro-qd">{{ t("plugins.intro_step3_desc_prefix") }}<code>inputs</code>{{ t("plugins.intro_step3_desc_mid") }}<code>variables</code>{{ t("plugins.intro_step3_desc_suffix") }}</span>
-                                <span class="dp-intro-qcta">{{ t("plugins.intro_step3_cta") }}</span>
+                                <span class="dp-intro-qt">{{ $t("plugins.intro_step3_title") }}</span>
+                                <span class="dp-intro-qd">{{ $t("plugins.intro_step3_desc_prefix") }}<code>inputs</code>{{ $t("plugins.intro_step3_desc_mid") }}<code>variables</code>{{ $t("plugins.intro_step3_desc_suffix") }}</span>
+                                <span class="dp-intro-qcta">{{ $t("plugins.intro_step3_cta") }}</span>
                             </span>
                             <ChevronRight :size="18" class="dp-intro-qchevron" />
                         </button>
                     </div>
 
-                    <div class="dp-intro-sec-label">{{ t("plugins.intro_learn_more") }}</div>
+                    <div class="dp-intro-sec-label">{{ $t("plugins.intro_learn_more") }}</div>
                     <div class="dp-intro-linkgrid">
                         <a
                             v-for="link in learnMoreLinks"
@@ -183,9 +183,9 @@
                     <template v-if="introSearch && filteredFlowRows.length === 0">
                         <div class="dp-intro-empty">
                             <div class="dp-intro-empty-icon"><Magnify :size="22" /></div>
-                            <h4>{{ t("plugins.intro_no_matches_title", {q: introSearch}) }}</h4>
-                            <p>{{ t("plugins.intro_no_matches_sub") }}</p>
-                            <KsButton class="dp-intro-clear-btn" size="small" @click="introSearch = ''">{{ t("plugins.intro_clear_search") }}</KsButton>
+                            <h4>{{ $t("plugins.intro_no_matches_title", {q: introSearch}) }}</h4>
+                            <p>{{ $t("plugins.intro_no_matches_sub") }}</p>
+                            <KsButton class="dp-intro-clear-btn" size="small" @click="introSearch = ''">{{ $t("plugins.intro_clear_search") }}</KsButton>
                         </div>
                     </template>
                     <KsMarkdown
@@ -199,9 +199,9 @@
                     <template v-if="introSearch && filteredTaskRows.length === 0">
                         <div class="dp-intro-empty">
                             <div class="dp-intro-empty-icon"><Magnify :size="22" /></div>
-                            <h4>{{ t("plugins.intro_no_matches_title", {q: introSearch}) }}</h4>
-                            <p>{{ t("plugins.intro_no_matches_sub") }}</p>
-                            <KsButton class="dp-intro-clear-btn" size="small" @click="introSearch = ''">{{ t("plugins.intro_clear_search") }}</KsButton>
+                            <h4>{{ $t("plugins.intro_no_matches_title", {q: introSearch}) }}</h4>
+                            <p>{{ $t("plugins.intro_no_matches_sub") }}</p>
+                            <KsButton class="dp-intro-clear-btn" size="small" @click="introSearch = ''">{{ $t("plugins.intro_clear_search") }}</KsButton>
                         </div>
                     </template>
                     <KsMarkdown
@@ -215,9 +215,9 @@
                     <template v-if="introSearch && filteredInputRows.length === 0">
                         <div class="dp-intro-empty">
                             <div class="dp-intro-empty-icon"><Magnify :size="22" /></div>
-                            <h4>{{ t("plugins.intro_no_matches_title", {q: introSearch}) }}</h4>
-                            <p>{{ t("plugins.intro_no_matches_sub") }}</p>
-                            <KsButton class="dp-intro-clear-btn" size="small" @click="introSearch = ''">{{ t("plugins.intro_clear_search") }}</KsButton>
+                            <h4>{{ $t("plugins.intro_no_matches_title", {q: introSearch}) }}</h4>
+                            <p>{{ $t("plugins.intro_no_matches_sub") }}</p>
+                            <KsButton class="dp-intro-clear-btn" size="small" @click="introSearch = ''">{{ $t("plugins.intro_clear_search") }}</KsButton>
                         </div>
                     </template>
                     <KsMarkdown
@@ -231,12 +231,12 @@
                     <template v-if="introSearch">
                         <div v-if="filteredPebbleRows.length === 0" class="dp-intro-empty">
                             <div class="dp-intro-empty-icon"><Magnify :size="22" /></div>
-                            <h4>{{ t("plugins.intro_no_matches_title", {q: introSearch}) }}</h4>
-                            <p>{{ t("plugins.intro_no_matches_sub") }}</p>
-                            <KsButton class="dp-intro-clear-btn" size="small" @click="introSearch = ''">{{ t("plugins.intro_clear_search") }}</KsButton>
+                            <h4>{{ $t("plugins.intro_no_matches_title", {q: introSearch}) }}</h4>
+                            <p>{{ $t("plugins.intro_no_matches_sub") }}</p>
+                            <KsButton class="dp-intro-clear-btn" size="small" @click="introSearch = ''">{{ $t("plugins.intro_clear_search") }}</KsButton>
                         </div>
                         <template v-else>
-                            <p class="dp-intro-result-count">{{ t("plugins.intro_result_count", {count: filteredPebbleRows.length}) }}</p>
+                            <p class="dp-intro-result-count">{{ $t("plugins.intro_result_count", {count: filteredPebbleRows.length}) }}</p>
                             <div class="dp-intro-fn-list">
                                 <div
                                     v-for="row in filteredPebbleRows"

--- a/ui/src/components/plugins/PluginListWrapper.vue
+++ b/ui/src/components/plugins/PluginListWrapper.vue
@@ -6,10 +6,10 @@
         <template v-else>
             <div v-if="!pluginsStore.editorPlugin && showFlowDoc" class="flow-doc">
                 <div class="flow-doc-header">
-                    <span class="flow-doc-title">{{ t("flow_description") }}</span>
+                    <span class="flow-doc-title">{{ $t("flow_description") }}</span>
                 </div>
                 <KsMarkdown v-if="flowDescription" :content="flowDescription" class="flow-doc-content" />
-                <p v-else class="flow-doc-empty">{{ t("flow_no_description") }}</p>
+                <p v-else class="flow-doc-empty">{{ $t("flow_no_description") }}</p>
             </div>
             <PluginList
                 :plugins="pluginsData ?? []"
@@ -21,14 +21,12 @@
 
 <script setup lang="ts">
     import {onMounted, ref, computed} from "vue"
-    import {useI18n} from "vue-i18n"
     import {useMiscStore} from "override/stores/misc"
     import {usePluginsStore} from "../../stores/plugins"
     import {useFlowStore} from "../../stores/flow"
     import {KsMarkdown} from "@kestra-io/design-system"
     import PluginList from "./PluginList.vue"
 
-    const {t} = useI18n()
     const isLoading = ref(false)
     const pluginsStore = usePluginsStore()
     const flowStore = useFlowStore()

--- a/ui/src/components/plugins/schema/SchemaPropertiesSection.vue
+++ b/ui/src/components/plugins/schema/SchemaPropertiesSection.vue
@@ -27,7 +27,7 @@
             <div v-if="showFilter" class="prop-filter-bar">
                 <KsInput
                     v-model="filterText"
-                    :placeholder="t('plugins.filter_properties')"
+                    :placeholder="$t('plugins.filter_properties')"
                     clearable
                     size="small"
                 >
@@ -50,7 +50,7 @@
                             class="compact-prop"
                         >
                             <div class="compact-prop-top">
-                                <span v-if="property['$required']" class="compact-req-dot" :title="t('plugins.required')" />
+                                <span v-if="property['$required']" class="compact-req-dot" :title="$t('plugins.required')" />
                                 <span class="compact-prop-name">{{ String(propertyKey) }}</span>
                                 <template v-for="type in nonDeprecatedTypes(extractTypeInfo(property).types)" :key="type">
                                     <a v-if="type.startsWith('#')" :href="type" class="compact-type-tag compact-type-tag-link" @click.stop>
@@ -60,21 +60,21 @@
                                 </template>
                                 <span v-if="property.default !== undefined" class="compact-meta-tag">{{ property.default }}</span>
                                 <span v-if="showDynamic && !isDynamic(property)" class="compact-meta-tag compact-meta-tag-static">
-                                    {{ t('plugins.non_dynamic') }}
+                                    {{ $t('plugins.non_dynamic') }}
                                 </span>
                                 <span v-if="showDynamic && isDynamic(property)" class="compact-meta-tag compact-meta-tag-dynamic">
-                                    {{ t('plugins.dynamic') }}
+                                    {{ $t('plugins.dynamic') }}
                                 </span>
                                 <KsIcon
                                     v-if="property['$beta']"
-                                    :tooltip="t('plugins.beta')"
+                                    :tooltip="$t('plugins.beta')"
                                     class="property-flag property-flag--warning"
                                 >
                                     <AlphaBBox />
                                 </KsIcon>
                                 <KsIcon
                                     v-if="property['$deprecated']"
-                                    :tooltip="t('plugins.deprecated')"
+                                    :tooltip="$t('plugins.deprecated')"
                                     class="property-flag property-flag--warning"
                                 >
                                     <Alert />

--- a/ui/src/components/triggers/TriggerEnableDialog.vue
+++ b/ui/src/components/triggers/TriggerEnableDialog.vue
@@ -6,22 +6,22 @@
         @update:modelValue="emit('update:modelValue', !!$event)"
     >
         <template #header>
-            <span>{{ count && count > 1 ? t("trigger enable dialog.bulk title", {count}) : t("trigger enable dialog.title") }}</span>
+            <span>{{ count && count > 1 ? $t("trigger enable dialog.bulk title", {count}) : $t("trigger enable dialog.title") }}</span>
         </template>
 
         <KsAlert type="info" :closable="false" class="description">
-            {{ count && count > 1 ? t("trigger enable dialog.bulk description") : t("trigger enable dialog.description") }}
+            {{ count && count > 1 ? $t("trigger enable dialog.bulk description") : $t("trigger enable dialog.description") }}
         </KsAlert>
 
         <slot />
 
         <p id="trigger-enable-strategy-label" class="strategy-label">
-            {{ t("trigger enable dialog.strategy") }}
+            {{ $t("trigger enable dialog.strategy") }}
         </p>
 
         <KsRadioGroup v-model="choice" class="radio-vertical" aria-labelledby="trigger-enable-strategy-label">
             <KsRadio value="SKIP" class="radio-item">
-                {{ t("trigger enable dialog.options.skip") }}
+                {{ $t("trigger enable dialog.options.skip") }}
             </KsRadio>
             <KsRadio value="FOLLOW_CONFIGURATION" class="radio-item">
                 <i18n-t keypath="trigger enable dialog.options.follow" scope="global">
@@ -34,10 +34,10 @@
 
         <template #footer>
             <KsButton @click="emit('update:modelValue', false)">
-                {{ t("cancel") }}
+                {{ $t("cancel") }}
             </KsButton>
             <KsButton type="primary" @click="confirm">
-                {{ t("enable") }}
+                {{ $t("enable") }}
             </KsButton>
         </template>
     </KsDialog>
@@ -45,9 +45,7 @@
 
 <script setup lang="ts">
     import {ref, watch} from "vue"
-    import {useI18n} from "vue-i18n"
 
-    const {t} = useI18n()
 
     const props = defineProps<{
         modelValue: boolean;

--- a/ui/src/override/components/flows/Actions.vue
+++ b/ui/src/override/components/flows/Actions.vue
@@ -10,25 +10,25 @@
         <NavBarAction
             v-if="isEditTab && canEdit && !deleted && !flowStore.isCreating"
             :icon="ContentCopy"
-            :label="t('copy')"
+            :label="$t('copy')"
             @click="editorCopyFlow"
         />
         <NavBarAction
             v-if="isEditTab && editorIsAllowedEdit && !deleted"
             :icon="Download"
-            :label="t('flow_export')"
+            :label="$t('flow_export')"
             @click="editorExportYaml"
         />
         <NavBarAction
             v-if="isEditTab && canDelete && !deleted && !flowStore.isCreating"
             :icon="Delete"
-            :label="t('delete')"
+            :label="$t('delete')"
             @click="editorDeleteFlow"
         />
         <NavBarAction
             v-if="tab === 'logs' && hasLogs"
             :icon="TrashCan"
-            :label="t('delete logs')"
+            :label="$t('delete logs')"
             @click="deleteLogs"
         />
 
@@ -40,14 +40,14 @@
                 :buttonProps="{disabled: editorHasErrors}"
                 @click="editorSaveOrPublish"
             >
-                {{ isPublishAction ? t('publish') : t('save') }}
+                {{ isPublishAction ? $t('publish') : $t('save') }}
                 <template #dropdown>
                     <KsDropdownMenu>
                         <KsDropdownItem v-if="isPublishAction" :icon="ContentSave" @click="editorSave">
-                            {{ t('save') }}
+                            {{ $t('save') }}
                         </KsDropdownItem>
                         <KsDropdownItem :icon="FileDocumentEditOutline" @click="editorSaveAsDraft">
-                            {{ t('save_as_draft') }}
+                            {{ $t('save_as_draft') }}
                         </KsDropdownItem>
                         <KsDropdownItem
                             v-if="editorHaveChange && !flowStore.isCreating"
@@ -55,7 +55,7 @@
                             :disabled="editorHasErrors || editorIsReadOnly"
                             @click="editorSaveAndExecute"
                         >
-                            {{ t('save_and_execute') }}
+                            {{ $t('save_and_execute') }}
                         </KsDropdownItem>
                     </KsDropdownMenu>
                 </template>
@@ -63,7 +63,7 @@
             <NavBarAction
                 v-else-if="canEdit && !deleted"
                 :icon="Pencil"
-                :label="t('edit flow')"
+                :label="$t('edit flow')"
                 @click="editFlow"
             />
         </template>
@@ -73,7 +73,7 @@
                 v-if="deleted"
                 type="primary"
                 :icon="BackupRestore"
-                :label="t('restore')"
+                :label="$t('restore')"
                 @click="restoreFlow"
             />
             <TriggerFlow

--- a/ui/src/override/components/flows/FlowEditorStats.vue
+++ b/ui/src/override/components/flows/FlowEditorStats.vue
@@ -4,8 +4,8 @@
             v-if="hasFlow"
             :icon="History"
             :count="revisionsCount"
-            :suffix="t('flow_editor_stats.revisions.suffix')"
-            :tooltip="t('flow_editor_stats.revisions.tooltip')"
+            :suffix="$t('flow_editor_stats.revisions.suffix')"
+            :tooltip="$t('flow_editor_stats.revisions.tooltip')"
             tab="revisions"
         />
 
@@ -13,8 +13,8 @@
             v-if="hasFlow"
             :icon="GraphOutline"
             :count="dependenciesCount"
-            :suffix="t('flow_editor_stats.dependencies.suffix')"
-            :tooltip="t('flow_editor_stats.dependencies.tooltip')"
+            :suffix="$t('flow_editor_stats.dependencies.suffix')"
+            :tooltip="$t('flow_editor_stats.dependencies.tooltip')"
             tab="dependencies"
         />
 


### PR DESCRIPTION
Closes https://github.com/kestra-io/kestra/issues/18239.

> ⚠️ **Merge order: merge this PR first, then the EE companion https://github.com/kestra-io/kestra-ee/pull/9997.**
>
> Both branches are named `refactor/template-global-t`, so the EE checks currently build against the OSS branch. If there is a gap after the OSS merge deletes that branch, re-trigger the EE checks so they run against develop.

## What

Sweeps every .vue file in the ui workspace and replaces bare `t(` calls in top-level `<template>` sections with the globally injected `$t(`, per the frontend convention in ui/AGENTS.md (templates always use `$t`; `useI18n()` is only for script-side usage).

- Where `t` was destructured from `useI18n()` solely for the template, the destructure and the `vue-i18n` import are removed.
- Where `t` is still used in the script section, it is kept and only the template call sites change.
- KsEditor.vue's template referenced a `t` coming from the `useKsEditor` composable (plain global-scope `useI18n()`), so `$t` is equivalent there; the now-unused destructured `t` is dropped.
- KsBulkSelect.vue and PluginCard.vue are deliberately untouched: they use local-scope i18n with component-local message files, so their `t` is not equivalent to the global `$t`.

No behavior change: all remaining converted call sites resolved through the global i18n scope already.

Verified with `npm run check:types` (design-system + app + test) and eslint on all changed files.

EE companion: https://github.com/kestra-io/kestra-ee/pull/9997



