### PR TITLE
refactor(core): use EnumMap instead of HashMap for enum-keyed maps

### DIFF
--- a/core/src/main/java/io/kestra/core/docs/JsonSchemaCache.java
+++ b/core/src/main/java/io/kestra/core/docs/JsonSchemaCache.java
@@ -1,6 +1,6 @@
 package io.kestra.core.docs;
 
-import java.util.HashMap;
+import java.util.EnumMap;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -28,7 +28,7 @@ public class JsonSchemaCache {
     private final ConcurrentMap<CacheKey, Map<String, Object>> schemaCache = new ConcurrentHashMap<>();
     private final ConcurrentMap<SchemaType, Map<String, Object>> propertiesCache = new ConcurrentHashMap<>();
 
-    private final Map<SchemaType, Class<?>> classesBySchemaType = new HashMap<>();
+    private final Map<SchemaType, Class<?>> classesBySchemaType = new EnumMap<>(SchemaType.class);
 
     // Hash of the plugin registry the cached schemas were generated from. When the registry changes
     // (a plugin is installed or removed at runtime) the cached schemas become stale and must be dropped,

--- a/core/src/main/java/io/kestra/core/models/executions/statistics/DailyExecutionStatistics.java
+++ b/core/src/main/java/io/kestra/core/models/executions/statistics/DailyExecutionStatistics.java
@@ -1,7 +1,7 @@
 package io.kestra.core.models.executions.statistics;
 
 import java.time.Instant;
-import java.util.HashMap;
+import java.util.EnumMap;
 import java.util.Map;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
@@ -27,7 +27,7 @@ public class DailyExecutionStatistics {
 
     @Builder.Default
     @JsonInclude
-    private Map<State.Type, Long> executionCounts = new HashMap<>(
+    private Map<State.Type, Long> executionCounts = new EnumMap<>(
         ImmutableMap.<State.Type, Long> builder()
             .put(State.Type.CREATED, 0L)
             .put(State.Type.RUNNING, 0L)

--- a/core/src/main/java/io/kestra/core/models/executions/statistics/ExecutionCountStatistics.java
+++ b/core/src/main/java/io/kestra/core/models/executions/statistics/ExecutionCountStatistics.java
@@ -1,6 +1,6 @@
 package io.kestra.core.models.executions.statistics;
 
-import java.util.HashMap;
+import java.util.EnumMap;
 import java.util.Map;
 
 import io.kestra.core.models.flows.State;
@@ -42,7 +42,7 @@ public record ExecutionCountStatistics(
     }
 
     private static Map<State.Type, Long> withAllStatesZero(final Map<State.Type, Long> counts) {
-        Map<State.Type, Long> map = new HashMap<>(DEFAULT_COUNTS);
+        Map<State.Type, Long> map = new EnumMap<>(DEFAULT_COUNTS);
         map.putAll(counts);
         return map;
     }


### PR DESCRIPTION
## Summary
- `EnumMap` is array-backed and faster than `HashMap` for enum keys.
- Converts `ExecutionCountStatistics` and `DailyExecutionStatistics`'s `State.Type`-keyed count maps from `HashMap` to `EnumMap`, bringing them in line with the `EnumMap` already used for the same key type in `AbstractJdbcExecutionStatisticsRepository`.
- Converts `JsonSchemaCache`'s `classesBySchemaType` registry (keyed by `SchemaType`) from `HashMap` to `EnumMap`.