### PR TITLE
fix(core): run queue and KV purges on the executor only

### DIFF
--- a/core/src/main/java/io/kestra/core/annotations/RequiresExecutor.java
+++ b/core/src/main/java/io/kestra/core/annotations/RequiresExecutor.java
@@ -1,0 +1,30 @@
+package io.kestra.core.annotations;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import io.micronaut.context.annotation.Requires;
+
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * Restricts a bean to the Executor, or to a standalone server.
+ *
+ * <p>Use it on cluster-global scheduled jobs, such as purges, so that a single component does the
+ * work instead of every component operating on the same rows. Jobs acting on component-local state
+ * are the exception: metrics must run wherever they are scraped, and Scheduler- or Worker-specific
+ * housekeeping belongs to those components.
+ *
+ * <p>The default value keeps such jobs enabled when {@code kestra.server-type} is not set, as in
+ * tests and {@code runLocal}.
+ *
+ * @see io.kestra.core.models.ServerType
+ */
+@Documented
+@Requires(property = "kestra.server-type", pattern = "(EXECUTOR|STANDALONE)", defaultValue = "STANDALONE")
+@Retention(RUNTIME)
+@Target({ElementType.PACKAGE, ElementType.ANNOTATION_TYPE, ElementType.TYPE})
+public @interface RequiresExecutor {
+}

--- a/core/src/main/java/io/kestra/core/storages/kv/KVPurgeCleaner.java
+++ b/core/src/main/java/io/kestra/core/storages/kv/KVPurgeCleaner.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.time.Instant;
 import java.util.List;
 
+import io.kestra.core.annotations.RequiresExecutor;
 import io.kestra.core.models.FetchVersion;
 import io.kestra.core.models.QueryFilter;
 import io.kestra.core.models.QueryFilter.Field;
@@ -25,7 +26,7 @@ import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @Requires(property = "kestra.kv.purge-expired.enabled", value = "true", defaultValue = "true")
-@Requires(property = "kestra.server-type", notEquals = "WORKER")
+@RequiresExecutor
 @Singleton
 public class KVPurgeCleaner {
 

--- a/queue-jdbc/src/main/java/io/kestra/queue/jdbc/client/JdbcQueueCleaner.java
+++ b/queue-jdbc/src/main/java/io/kestra/queue/jdbc/client/JdbcQueueCleaner.java
@@ -10,6 +10,7 @@ import org.jooq.*;
 import org.jooq.Record;
 import org.jooq.impl.DSL;
 
+import io.kestra.core.annotations.RequiresExecutor;
 import io.kestra.core.queues.BroadcastQueueInterface;
 import io.kestra.jdbc.JdbcTableConfig;
 import io.kestra.jdbc.JooqDSLContextWrapper;
@@ -25,6 +26,7 @@ import lombok.extern.slf4j.Slf4j;
 
 @Singleton
 @JdbcQueueEnabled
+@RequiresExecutor
 @Slf4j
 public class JdbcQueueCleaner {
     private static final Field<Object> CREATED_FIELD = AbstractJdbcRepository.field("created");


### PR DESCRIPTION
## What

Introduces `@RequiresExecutor` and applies it to the two OSS `@Scheduled` jobs that were running on more than one component.

| Job | Before | Components it ran on | After |
|---|---|---|---|
| `JdbcQueueCleaner.deleteQueue` | `@JdbcQueueEnabled` only — **no server-type guard** | all 7 | `EXECUTOR`, `STANDALONE` |
| `KVPurgeCleaner.purgeExpired` | `notEquals = "WORKER"` | 6 | `EXECUTOR`, `STANDALONE` |

## Why

`JdbcQueueCleaner` is the more serious of the two: with no guard at all, every component in a cluster armed its own hourly timer and ran `DELETE FROM queues` against the same shared table at the same time — including the MySQL batch-delete loop, which several pods would then interleave. `KVPurgeCleaner`'s `notEquals = "WORKER"` still leaves the executor, webserver, scheduler, indexer and controller purging the same KV entries.

Neither job holds component-local state, so exactly one component is enough. This follows up on the discussion about keeping scheduled background work on the executor unless the job is genuinely specific to another component — we've had support tickets traced back to several components running the same purge.

## The annotation

`@RequiresExecutor` is the executor-side sibling of the existing `@WebServerEnabled` and `@RequiresControllerServer`, so this stays a one-line, greppable convention rather than a copy-pasted `@Requires` per class:

```java
@Requires(property = "kestra.server-type", pattern = "(EXECUTOR|STANDALONE)", defaultValue = "STANDALONE")
```

The `defaultValue` matters — it keeps these jobs enabled where `kestra.server-type` isn't set, i.e. tests and `runLocal`, matching what `@WebServerEnabled` already does.

Its javadoc spells out the exception Loïc raised: jobs acting on component-local state must **not** use it. Metrics registered in a node's own `MeterRegistry` (`QueueLagPoller`, `SharedServiceInstanceMetricService`) have to run wherever they're scraped, and Scheduler/Worker housekeeping (`TriggerSchedulerMonitor`) belongs to those components.

## Behaviour change worth a look

These purges now stop entirely in a deployment with no executor and no standalone server. That isn't a supported Kestra topology, but if anyone runs a webserver-only install, KV TTLs and queue retention would silently stop being enforced there.

## Not in this PR

- `ExecutionStatisticsCompactor` — currently `(STANDALONE|WEBSERVER|INDEXER)`, so webserver and indexer compact the same buckets concurrently. Needs a call on executor-only vs indexer-only, so I left it out.
- The cluster-wide reportables (`FeatureUsageReport`, `ServiceUsageReport`) are `STANDALONE|EXECUTOR|WEBSERVER`, so executor and webserver both send them and duplicate usage telemetry. Separate concern from `ReportableScheduler` itself, which is per-node by design.
- EE has the same pattern in `NotificationPurgeCleaner` and its `KVPurgeCleaner` subclass — follow-up PR, depends on this one for the annotation.

## Tests

`:jdbc-h2:test --tests H2JdbcQueueCleanerTest` and `:core:test --tests KVPurgeCleanerTest` both pass. Both run under `server-type: STANDALONE`, so the beans still resolve. Checked the `application-queue.yml` test environment that pins `server-type: WEBSERVER` — none of the tests using it inject either cleaner.
