### PR TITLE
fix(executions): skip orphaned task outputs when listing an execution's task outputs

### DIFF
--- a/core/src/main/java/io/kestra/core/models/executions/Execution.java
+++ b/core/src/main/java/io/kestra/core/models/executions/Execution.java
@@ -488,21 +488,30 @@ public class Execution implements SoftDeletable<Execution>, TenantInterface, Has
             .toList();
     }
 
+    /**
+     * Find a task run by its task run id.
+     *
+     * @see #findTaskRunByTaskRunIdIfPresent(String) for a safe alternative
+     * @throws InternalException if the task run doesn't exist
+     */
     public TaskRun findTaskRunByTaskRunId(String id) throws InternalException {
-        Optional<TaskRun> find = (this.taskRunList == null ? Collections.<TaskRun> emptyList()
-            : this.taskRunList)
+        return findTaskRunByTaskRunIdIfPresent(id)
+            .orElseThrow(() -> new InternalException(
+                "Can't find taskrun with taskrunId '" + id + "' on execution '" + this.id + "' "
+                    + this.toStringState()
+            ));
+    }
+
+    /**
+     * Find a task run by its task run id if present, else return an empty optional.
+     *
+     * @see #findTaskRunByTaskRunId(String) for a fail-fast alternative
+     */
+    public Optional<TaskRun> findTaskRunByTaskRunIdIfPresent(String id) {
+        return ListUtils.emptyOnNull(this.taskRunList)
             .stream()
             .filter(taskRun -> taskRun.getId().equals(id))
             .findFirst();
-
-        if (find.isEmpty()) {
-            throw new InternalException(
-                "Can't find taskrun with taskrunId '" + id + "' on execution '" + this.id + "' "
-                    + this.toStringState()
-            );
-        }
-
-        return find.get();
     }
 
     public TaskRun findTaskRunByTaskIdAndValue(String id, List<String> values)

--- a/core/src/test/java/io/kestra/core/models/executions/ExecutionTest.java
+++ b/core/src/test/java/io/kestra/core/models/executions/ExecutionTest.java
@@ -3,10 +3,12 @@ package io.kestra.core.models.executions;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
+import io.kestra.core.exceptions.InternalException;
 import io.kestra.core.models.Label;
 import io.kestra.core.models.flows.Flow;
 import io.kestra.core.models.flows.State;
@@ -14,8 +16,40 @@ import io.kestra.core.utils.IdUtils;
 import io.kestra.plugin.core.debug.Return;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class ExecutionTest {
+
+    @Test
+    void findTaskRunByTaskRunIdIfPresentShouldReturnEmptyWhenTaskRunNotFound() {
+        // Given
+        Execution execution = Execution.builder()
+            .id("executionId")
+            .taskRunList(List.of(TaskRun.builder().id("existing").state(new State()).build()))
+            .state(new State())
+            .build();
+
+        // When
+        Optional<TaskRun> result = execution.findTaskRunByTaskRunIdIfPresent("missing");
+
+        // Then
+        assertThat(result).isEqualTo(Optional.empty());
+    }
+
+    @Test
+    void findTaskRunByTaskRunIdShouldThrowWhenTaskRunNotFound() {
+        // Given
+        Execution execution = Execution.builder()
+            .id("executionId")
+            .taskRunList(List.of(TaskRun.builder().id("existing").state(new State()).build()))
+            .state(new State())
+            .build();
+
+        // When / Then
+        assertThatThrownBy(() -> execution.findTaskRunByTaskRunId("missing"))
+            .isInstanceOf(InternalException.class)
+            .hasMessageContaining("Can't find taskrun with taskrunId 'missing'");
+    }
 
     @Test
     void hasTaskRunJoinableTrue() {

--- a/webserver/src/main/java/io/kestra/webserver/controllers/api/OutputController.java
+++ b/webserver/src/main/java/io/kestra/webserver/controllers/api/OutputController.java
@@ -5,6 +5,7 @@ import java.util.Map;
 
 import io.kestra.core.exceptions.InternalException;
 import io.kestra.core.exceptions.NotFoundException;
+import io.kestra.core.models.executions.TaskRun;
 import io.kestra.core.repositories.ExecutionRepositoryInterface;
 import io.kestra.core.repositories.TaskOutputRepositoryInterface;
 import io.kestra.core.services.ExecutionOutputService;
@@ -22,8 +23,6 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import jakarta.inject.Inject;
-
-import static io.kestra.core.utils.Rethrow.throwFunction;
 
 @Controller("/api/v1/{tenant}/outputs")
 public class OutputController {
@@ -65,28 +64,26 @@ public class OutputController {
         @Parameter(description = "The execution id") @PathVariable String executionId,
         @Parameter(description = "The task run id") @PathVariable String taskRunId) throws InternalException {
         var execution = executionRepository.findById(tenantService.resolveTenant(), executionId).orElseThrow(NotFoundException::new);
-        var taskRun = execution.findTaskRunByTaskRunId(taskRunId);
+        var taskRun = execution.findTaskRunByTaskRunIdIfPresent(taskRunId).orElseThrow(NotFoundException::new);
         return taskOutputService.getOutputs(taskRun);
     }
 
     @ExecuteOn(TaskExecutors.IO)
     @Get(uri = "tasks/{executionId}")
     @Operation(tags = { "Outputs" }, summary = "List the task runs of an execution having outputs")
-    public List<TaskOutputInformation> getTaskOutputsInformation(@Parameter(description = "The execution id") @PathVariable String executionId) throws InternalException {
+    public List<TaskOutputInformation> getTaskOutputsInformation(@Parameter(description = "The execution id") @PathVariable String executionId) {
         var execution = executionRepository.findById(tenantService.resolveTenant(), executionId).orElseThrow(NotFoundException::new);
         return taskOutputRepository.findByExecution(execution).stream()
-            .map(throwFunction(taskOutput ->
-            {
-                var taskRun = execution.findTaskRunByTaskRunId(taskOutput.taskRunId());
-                return new TaskOutputInformation(
+            // A LoopUntil iteration prunes its previous iteration's task runs but not their stored outputs,
+            // so an output row can outlive the task run it belongs to: skip it rather than fail the whole list.
+            .flatMap(taskOutput -> execution.findTaskRunByTaskRunIdIfPresent(taskOutput.taskRunId()).stream()
+                .map((TaskRun taskRun) -> new TaskOutputInformation(
                     taskRun.getTaskId(),
                     taskRun.getId(),
                     taskRun.getValue(),
                     taskRun.getIteration(),
                     taskOutput.value() != null
-                );
-            }
-            ))
+                )))
             .toList();
     }
 

--- a/webserver/src/test/java/io/kestra/webserver/controllers/api/OutputControllerTest.java
+++ b/webserver/src/test/java/io/kestra/webserver/controllers/api/OutputControllerTest.java
@@ -20,12 +20,14 @@ import io.kestra.core.utils.IdUtils;
 
 import io.micronaut.core.type.Argument;
 import io.micronaut.http.HttpRequest;
+import io.micronaut.http.HttpStatus;
 import io.micronaut.http.client.annotation.Client;
 import io.micronaut.http.client.exceptions.HttpClientResponseException;
 import io.micronaut.reactor.http.client.ReactorHttpClient;
 import jakarta.inject.Inject;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @KestraTest
@@ -75,12 +77,45 @@ class OutputControllerTest {
         String taskRunId = "notFound";
         String tenantId = TenantService.MAIN_TENANT;
 
-        assertThrows(
-            HttpClientResponseException.class, () -> client.toBlocking().retrieve(
-                HttpRequest.GET("/api/v1/" + tenantId + "/outputs/tasks/executionId/" + taskRunId),
-                TaskOutput.class
-            )
+        assertThatThrownBy(() -> client.toBlocking().retrieve(
+            HttpRequest.GET("/api/v1/" + tenantId + "/outputs/tasks/executionId/" + taskRunId),
+            TaskOutput.class
+        ))
+            .isInstanceOf(HttpClientResponseException.class)
+            .extracting(e -> ((HttpClientResponseException) e).getStatus())
+            .isEqualTo(HttpStatus.NOT_FOUND);
+    }
+
+    @Test
+    void getTaskOutputInformationShouldSkipOrphanedTaskOutput() {
+        String tenantId = TenantService.MAIN_TENANT;
+        String executionId = IdUtils.create();
+        String taskRunId = "taskRunId";
+        String orphanTaskRunId = "orphanTaskRunId";
+        // A LoopUntil iteration prunes the previous iteration's task run but not its stored output,
+        // so the execution can carry an output row whose task run id no longer exists (#18231).
+        var execution = Execution.builder()
+            .tenantId(tenantId)
+            .id(executionId)
+            .namespace("namespace")
+            .flowId("flowId")
+            .taskRunList(List.of(TaskRun.builder().tenantId(tenantId).id(taskRunId).build()))
+            .state(new State())
+            .build();
+        String value = """
+            {"some":"output"}""";
+        executionRepository.save(execution);
+
+        taskOutputRepository.save(new TaskOutput(taskRunId, tenantId, executionId, value.getBytes(StandardCharsets.UTF_8), null));
+        taskOutputRepository.save(new TaskOutput(orphanTaskRunId, tenantId, executionId, value.getBytes(StandardCharsets.UTF_8), null));
+
+        List<OutputController.TaskOutputInformation> response = client.toBlocking().retrieve(
+            HttpRequest.GET("/api/v1/" + tenantId + "/outputs/tasks/" + executionId),
+            Argument.listOf(OutputController.TaskOutputInformation.class)
         );
+
+        assertThat(response).hasSize(1);
+        assertThat(response.getFirst().taskRunId()).isEqualTo(taskRunId);
     }
 
     @Test
@@ -116,12 +151,13 @@ class OutputControllerTest {
     void getTaskOutputInformationShouldThrowNotFoundWhenTaskRunNotFound() {
         String tenantId = TenantService.MAIN_TENANT;
 
-        assertThrows(
-            HttpClientResponseException.class, () -> client.toBlocking().retrieve(
-                HttpRequest.GET("/api/v1/" + tenantId + "/outputs/tasks/not-found"),
-                Argument.listOf(OutputController.TaskOutputInformation.class)
-            )
-        );
+        assertThatThrownBy(() -> client.toBlocking().retrieve(
+            HttpRequest.GET("/api/v1/" + tenantId + "/outputs/tasks/not-found"),
+            Argument.listOf(OutputController.TaskOutputInformation.class)
+        ))
+            .isInstanceOf(HttpClientResponseException.class)
+            .extracting(e -> ((HttpClientResponseException) e).getStatus())
+            .isEqualTo(HttpStatus.NOT_FOUND);
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Fixes #18231: `GET /api/v1/{tenant}/outputs/tasks/{executionId}` returned an unhandled `InternalException` (HTTP 500) when the execution contained a `TaskOutput` row whose task run no longer exists — this happens because `ExecutionService.retryWaitFor()` prunes a `LoopUntil` iteration's task runs between iterations without deleting their stored outputs, so the output row outlives the task run.
- Added `Execution.findTaskRunByTaskRunIdIfPresent(String)` (returns `Optional<TaskRun>`); the existing throwing `findTaskRunByTaskRunId` now delegates to it, so behavior for all other callers is unchanged.
- `OutputController#getTaskOutputsInformation` now skips orphaned output rows instead of failing the whole list; `OutputController#getTaskRunOutputs` now returns a proper `404 Not Found` instead of letting the exception escape as a 500.

## Test plan
- [x] `./gradlew :webserver:test --tests "io.kestra.webserver.controllers.api.OutputControllerTest"` — new regression test reproduces the orphaned-output scenario end-to-end via the real HTTP layer; two existing "not found" tests tightened to assert the status is specifically 404 (a 500 also satisfied the old assertion, which is why this slipped through)
- [x] `./gradlew :core:test --tests "io.kestra.core.models.executions.ExecutionTest"` — unit coverage for both the new `Optional`-returning lookup and the throwing variant's message/type