### PR TITLE
fix(test): disable the Micronaut embedded gPRC server

### DIFF
--- a/executor/src/test/resources/application-test.yml
+++ b/executor/src/test/resources/application-test.yml
@@ -83,3 +83,10 @@ datasources:
     username: sa
     password: ""
     driverClassName: org.h2.Driver
+
+# Disable Micronaut embedded gRPC server
+grpc:
+  server:
+    enabled: false
+    health:
+      enabled: false

--- a/scheduler/src/test/resources/application-test.yml
+++ b/scheduler/src/test/resources/application-test.yml
@@ -71,3 +71,10 @@ datasources:
     username: sa
     password: ""
     driverClassName: org.h2.Driver
+
+# Disable Micronaut embedded gRPC server
+grpc:
+  server:
+    enabled: false
+    health:
+      enabled: false


### PR DESCRIPTION
We didn't use it.
And it sometimes cause test flakyness when it fails to bind to a port due to test parallelism when another test from another module resolves to the same random port.

See for ex this CI run: https://github.com/kestra-io/kestra/pull/18137