### PR TITLE
fix(execution): flow outputs 404

### DIFF
--- a/webserver/src/main/java/io/kestra/webserver/controllers/api/OutputController.java
+++ b/webserver/src/main/java/io/kestra/webserver/controllers/api/OutputController.java
@@ -1,7 +1,6 @@
 package io.kestra.webserver.controllers.api;
 
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 import io.kestra.core.exceptions.InternalException;
 import io.kestra.core.exceptions.NotFoundException;
@@ -51,7 +50,7 @@ public class OutputController {
     )
     public Map<String, Object> getExecutionOutputs(@Parameter(description = "The execution id") @PathVariable String executionId) throws InternalException {
         var execution = executionRepository.findById(tenantService.resolveTenant(), executionId).orElseThrow(NotFoundException::new);
-        return executionOutputService.getOutputs(execution);
+        return Optional.ofNullable(executionOutputService.getOutputs(execution)).orElse(Collections.emptyMap());
     }
 
     @ExecuteOn(TaskExecutors.IO)


### PR DESCRIPTION
Flow outputs 404 on the UI as the service returns null which the endpoint then translate to a 404.

Return an empty map instead.