### PR TITLE
fix(core): governance policy and scheduled-run behaviour

### DIFF
--- a/core/src/main/java/io/kestra/core/exceptions/ForbiddenException.java
+++ b/core/src/main/java/io/kestra/core/exceptions/ForbiddenException.java
@@ -1,0 +1,21 @@
+package io.kestra.core.exceptions;
+
+/**
+ * General exception that can be thrown when a Kestra resource or entity exists but the caller is not allowed to
+ * perform the requested operation on it.
+ * <p>
+ * When propagated in the context of a REST API call, this exception should result in an HTTP 403 Forbidden
+ * response.
+ */
+public class ForbiddenException extends KestraRuntimeException {
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * Creates a new {@link ForbiddenException} instance.
+     *
+     * @param message the error message.
+     */
+    public ForbiddenException(final String message) {
+        super(message);
+    }
+}

--- a/core/src/main/java/io/kestra/core/runners/ExecutableUtils.java
+++ b/core/src/main/java/io/kestra/core/runners/ExecutableUtils.java
@@ -190,13 +190,15 @@ public final class ExecutableUtils {
                     });
 
                 if (flow.isDisabled()) {
-                    String msg = "Cannot execute a flow which is disabled";
+                    String msg = "Cannot execute flow '%s'.'%s': it is disabled.".formatted(subflowNamespace, subflowId);
                     runContext.logger().error(msg);
                     throw new IllegalStateException(msg);
                 }
 
                 if (flow instanceof FlowWithException fwe) {
-                    String msg = "Cannot execute an invalid flow: " + fwe.getException();
+                    // The flow could not be resolved for runtime, either because it is invalid or because
+                    // governance blocks it. Which one it was is in the carried message, so state neither here.
+                    String msg = "Cannot execute flow '%s'.'%s': %s".formatted(subflowNamespace, subflowId, fwe.getException());
                     runContext.logger().error(msg);
                     throw new IllegalStateException(msg);
                 }

--- a/core/src/main/java/io/kestra/core/runners/pebble/functions/SubflowFunction.java
+++ b/core/src/main/java/io/kestra/core/runners/pebble/functions/SubflowFunction.java
@@ -166,10 +166,18 @@ public class SubflowFunction implements KestraFunction {
                 );
 
             if (targetFlow instanceof FlowWithException fwe) {
-                throw new PebbleException(null, "Cannot run the invalid flow '" + namespace + "'.'" + id + "': " + fwe.getException(), lineNumber, self.getName());
+                // The flow could not be resolved for runtime, either because it is invalid or because governance
+                // blocks it. Which one it was is in the carried message, so state neither here.
+                throw new PebbleException(
+                    null, "Cannot execute flow '%s'.'%s': %s".formatted(namespace, id, fwe.getException()),
+                    lineNumber, self.getName()
+                );
             }
             if (targetFlow.isDisabled()) {
-                throw new PebbleException(null, "Cannot run the disabled flow '" + namespace + "'.'" + id + "'.", lineNumber, self.getName());
+                throw new PebbleException(
+                    null, "Cannot execute flow '%s'.'%s': it is disabled.".formatted(namespace, id),
+                    lineNumber, self.getName()
+                );
             }
 
             Execution execution;

--- a/core/src/main/java/io/kestra/plugin/core/trigger/SchedulableExecutionFactory.java
+++ b/core/src/main/java/io/kestra/plugin/core/trigger/SchedulableExecutionFactory.java
@@ -56,8 +56,12 @@ final class SchedulableExecutionFactory {
 
         Map<String, Object> allInputs = getInputs(trigger, runContext, triggerContext.getBackfill());
 
+        Execution executionForRendering = execution.withLabels(
+            LabelService.forExecution(conditionContext.getFlow(), executionLabels, execution.getId())
+        );
+
         // add inputs and inject defaults (FlowInputOutput handles defaults internally)
-        execution = execution.withInputs(runContext.inputAndOutput().readInputs(conditionContext.getFlow(), execution, allInputs));
+        Map<String, Object> inputs = runContext.inputAndOutput().readInputs(conditionContext.getFlow(), executionForRendering, allInputs);
 
         return new TriggerEvaluationResult(
             runContext.getTriggerExecutionId(),
@@ -66,7 +70,7 @@ final class SchedulableExecutionFactory {
             executionLabels,
             conditionContext.getFlow().getRevision(),
             Optional.ofNullable(scheduleDate).map(ChronoZonedDateTime::toInstant).orElse(null),
-            runContext.inputAndOutput().readInputs(conditionContext.getFlow(), execution, allInputs)
+            inputs
         );
     }
 

--- a/core/src/test/java/io/kestra/plugin/core/trigger/ScheduleTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/trigger/ScheduleTest.java
@@ -553,6 +553,32 @@ class ScheduleTest {
         assertThat(inputs.get("multiselectInput")).isEqualTo(List.of("option3"));
     }
 
+    @Test
+    void shouldRenderInputDefaultsReferencingFlowLabels() throws Exception {
+        // Given
+        Schedule trigger = Schedule.builder().id("schedule").type(Schedule.class.getName()).cron("0 0 1 * *").build();
+
+        ZonedDateTime date = ZonedDateTime.now()
+            .withDayOfMonth(1)
+            .withHour(0)
+            .withMinute(0)
+            .withSecond(0)
+            .truncatedTo(ChronoUnit.SECONDS)
+            .minusMonths(1);
+
+        // When
+        Optional<TriggerEvaluationResult> evaluate = trigger.eval(
+            conditionContextWithLabelInput(trigger),
+            triggerContext(date, trigger)
+        );
+
+        // Then
+        assertThat(evaluate).isPresent();
+        assertThat(evaluate.get().inputs()).containsEntry("labelEcho", "platform/critical");
+        // the flow's labels are exposed for rendering only, never carried by the execution the executor creates
+        assertThat(evaluate.get().labels()).doesNotContain(new Label("team", "platform"), new Label("app.tier", "critical"));
+    }
+
     private ConditionContext conditionContext(AbstractTrigger trigger) {
         Flow flow = Flow.builder()
             .id(IdUtils.create())
@@ -654,6 +680,46 @@ class ScheduleTest {
                             )
                         )
                         .autoSelectFirst(true)
+                        .build()
+                )
+            )
+            .build();
+
+        TriggerContext triggerContext = TriggerContext.builder()
+            .namespace(flow.getNamespace())
+            .flowId(flow.getId())
+            .triggerId(trigger.getId())
+            .build();
+
+        return ConditionContext.builder()
+            .runContext(
+                runContextInitializer.forScheduler(
+                    (DefaultRunContext) runContextFactory.of(),
+                    triggerContext, trigger
+                )
+            )
+            .flow(flow)
+            .build();
+    }
+
+    private ConditionContext conditionContextWithLabelInput(AbstractTrigger trigger) {
+        Flow flow = Flow.builder()
+            .id(IdUtils.create())
+            .namespace("io.kestra.tests")
+            .labels(
+                List.of(
+                    new Label("team", "platform"),
+                    new Label("app.tier", "critical")
+                )
+            )
+            .inputs(
+                List.of(
+                    StringInput.builder()
+                        .id("labelEcho")
+                        .type(Type.STRING)
+                        .required(false)
+                        // dotted keys are nested by Label.toNestedMap, so dot notation is the only working form
+                        .defaults(Property.ofExpression("{{ labels.team }}/{{ labels.app.tier }}"))
                         .build()
                 )
             )

--- a/scheduler/src/main/java/io/kestra/scheduler/TriggerScheduler.java
+++ b/scheduler/src/main/java/io/kestra/scheduler/TriggerScheduler.java
@@ -11,6 +11,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.tuple.Pair;
@@ -20,6 +21,7 @@ import org.slf4j.event.Level;
 
 import com.google.common.base.Throwables;
 
+import io.kestra.core.exceptions.FlowBlockedException;
 import io.kestra.core.exceptions.InvalidTriggerConfigurationException;
 import io.kestra.core.metrics.MetricRegistry;
 import io.kestra.core.models.Label;
@@ -46,6 +48,7 @@ import io.kestra.core.scheduler.vnodes.VNodes;
 import io.kestra.core.services.ConditionService;
 import io.kestra.core.services.FlowParsingService;
 import io.kestra.core.utils.IdUtils;
+import io.kestra.core.utils.ListUtils;
 import io.kestra.core.utils.Logs;
 import io.kestra.core.utils.TruthUtils;
 import io.kestra.core.utils.TypeConverter;
@@ -152,7 +155,7 @@ public class TriggerScheduler {
 
         flowMetaStore.findAllForVNodes(vNodesAssignments)
             .stream()
-            .map(flow -> TriggerFlowParser.parseOrSkip(flowParsingService, flow, log))
+            .map(this::parseForTriggerOrSkip)
             .filter(Objects::nonNull)
             .filter(flow -> flow.getTriggers() != null && !flow.getTriggers().isEmpty())
             .flatMap(
@@ -265,6 +268,44 @@ public class TriggerScheduler {
 
         // Record metrics
         metricEvaluationLoopDuration.record(Duration.between(scheduledTime, clock.instant()));
+    }
+
+    /**
+     * Parses a flow for trigger initialization, skipping ({@code null}) one governance blocks.
+     */
+    private FlowWithSource parseForTriggerOrSkip(final FlowWithSource flow) {
+        try {
+            return TriggerFlowParser.parseForTrigger(flowParsingService, flow, log);
+        } catch (FlowBlockedException e) {
+            log.warn(
+                "Flow on tenant {}, namespace '{}', flow '{}' is blocked by governance, skipping its triggers: {}",
+                flow.getTenantId(),
+                flow.getNamespace(),
+                flow.getId(),
+                e.getMessage()
+            );
+            logBlockedByGovernance(flow, e);
+            return null;
+        }
+    }
+
+    /**
+     * Reports a governance block in the logs of every trigger the blocked flow declares. No trigger state is
+     * initialized for such a flow, so this is the only report those triggers ever get.
+     */
+    private void logBlockedByGovernance(final FlowWithSource flow, final FlowBlockedException e) {
+        ListUtils.emptyOnNull(flow.getTriggers()).stream()
+            .filter(Predicate.not(AbstractTrigger::isDisabled))
+            .forEach(trigger ->
+                Logs.logExecution(
+                    flow,
+                    runContextFactory.of(flow, trigger).logger(),
+                    Level.WARN,
+                    "[trigger: {}] Skipped: {}",
+                    trigger.getId(),
+                    e.getMessage()
+                )
+            );
     }
 
     /**

--- a/scheduler/src/main/java/io/kestra/scheduler/internals/DefaultSchedulableTriggerFetcher.java
+++ b/scheduler/src/main/java/io/kestra/scheduler/internals/DefaultSchedulableTriggerFetcher.java
@@ -15,6 +15,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.event.Level;
 
+import io.kestra.core.exceptions.FlowBlockedException;
 import io.kestra.core.exceptions.InvalidTriggerConfigurationException;
 import io.kestra.core.models.conditions.ConditionContext;
 import io.kestra.core.models.flows.FlowId;
@@ -27,6 +28,7 @@ import io.kestra.core.runners.RunContextFactory;
 import io.kestra.core.scheduler.model.TriggerState;
 import io.kestra.core.scheduler.store.TriggerStateStore;
 import io.kestra.core.services.FlowParsingService;
+import io.kestra.core.utils.ListUtils;
 import io.kestra.core.utils.Logs;
 import io.kestra.scheduler.SchedulableTriggerFetcher;
 import io.kestra.scheduler.models.TriggerEvaluationContext;
@@ -84,9 +86,13 @@ public class DefaultSchedulableTriggerFetcher implements SchedulableTriggerFetch
                     return null;
                 }
 
-                final FlowWithSource flow = TriggerFlowParser.parseOrSkip(flowParsingService, maybeFlowTrigger.get(), LOG);
-                if (flow == null) {
+                final FlowWithSource rawFlow = maybeFlowTrigger.get();
+                final FlowWithSource flow;
+                try {
+                    flow = TriggerFlowParser.parseForTrigger(flowParsingService, rawFlow, LOG);
+                } catch (FlowBlockedException e) {
                     // Skip the flow: it is blocked by governance and must not run.
+                    logBlockedByGovernance(rawFlow, triggerState, e);
                     return null;
                 }
 
@@ -147,6 +153,26 @@ public class DefaultSchedulableTriggerFetcher implements SchedulableTriggerFetch
         } catch (DateTimeException e) {
             throw new InvalidTriggerConfigurationException();
         }
+    }
+
+    /**
+     * Reports a governance block in the trigger's own logs. Skipping is otherwise invisible to the user: the
+     * trigger simply stops firing, and the only trace is a server-side log they cannot reach.
+     */
+    private void logBlockedByGovernance(final FlowWithSource flow, final TriggerState triggerState, final FlowBlockedException e) {
+        ListUtils.emptyOnNull(flow.getTriggers()).stream()
+            .filter(it -> it.getId().equals(triggerState.getTriggerId()))
+            .findFirst()
+            .ifPresent(trigger ->
+                Logs.logExecution(
+                    flow,
+                    runContextFactory.of(flow, trigger).logger(),
+                    Level.WARN,
+                    "[trigger: {}] Skipped: {}",
+                    trigger.getId(),
+                    e.getMessage()
+                )
+            );
     }
 
     private void logError(final ZonedDateTime now, ConditionContext conditionContext, FlowInterface flow, AbstractTrigger trigger, Throwable e) {

--- a/scheduler/src/main/java/io/kestra/scheduler/internals/TriggerFlowParser.java
+++ b/scheduler/src/main/java/io/kestra/scheduler/internals/TriggerFlowParser.java
@@ -15,21 +15,19 @@ public final class TriggerFlowParser {
     }
 
     /**
-     * Parses the given flow for trigger evaluation. A flow rejected by governance is skipped ({@code null});
-     * any other parse failure degrades to the flow as stored so existing triggers keep evaluating.
+     * Parses the given flow for trigger evaluation, degrading to the flow as stored when parsing fails so
+     * existing triggers keep evaluating.
+     *
+     * @throws FlowBlockedException when governance rejects the flow, whose triggers must then not run. Checked
+     *         deliberately: a caller has to decide what to report, and a block reported as an ordinary parse
+     *         failure is the confusion this guards against.
      */
-    public static FlowWithSource parseOrSkip(final FlowParsingService flowParsingService, final FlowWithSource flow, final Logger logger) {
+    public static FlowWithSource parseForTrigger(final FlowParsingService flowParsingService, final FlowWithSource flow, final Logger logger)
+        throws FlowBlockedException {
         try {
             return flowParsingService.parseForRuntime(flow).flow();
         } catch (FlowBlockedException e) {
-            logger.warn(
-                "Flow on tenant {}, namespace '{}', flow '{}' is blocked by governance, skipping its triggers: {}",
-                flow.getTenantId(),
-                flow.getNamespace(),
-                flow.getId(),
-                e.getMessage()
-            );
-            return null;
+            throw e;
         } catch (Exception e) {
             logger.warn(
                 "Can't parse flow on tenant {}, namespace '{}', flow '{}' with errors '{}'",

--- a/scheduler/src/test/java/io/kestra/scheduler/internals/TriggerFlowParserTest.java
+++ b/scheduler/src/test/java/io/kestra/scheduler/internals/TriggerFlowParserTest.java
@@ -11,6 +11,7 @@ import io.kestra.core.runners.ProcessedFlow;
 import io.kestra.core.services.FlowParsingService;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -24,33 +25,35 @@ class TriggerFlowParserTest {
         .build();
 
     @Test
-    void shouldSkipFlowWhenBlockedByGovernance() throws FlowProcessingException {
+    void shouldThrowWithTheReasonWhenBlockedByGovernance() throws FlowProcessingException {
         // Given
         FlowParsingService flowParsingService = mock(FlowParsingService.class);
-        when(flowParsingService.parseForRuntime(flow)).thenThrow(new FlowBlockedException("Blocked by governance policy"));
+        when(flowParsingService.parseForRuntime(flow)).thenThrow(new FlowBlockedException("Blocked by governance policy: policy=deny-log"));
 
-        // When / Then a blocked flow is skipped: its triggers must not run
-        assertThat(TriggerFlowParser.parseOrSkip(flowParsingService, flow, LOGGER)).isNull();
+        // When / Then the block reaches the caller with its reason, so it can report it against the trigger
+        assertThatThrownBy(() -> TriggerFlowParser.parseForTrigger(flowParsingService, flow, LOGGER))
+            .isInstanceOf(FlowBlockedException.class)
+            .hasMessage("Blocked by governance policy: policy=deny-log");
     }
 
     @Test
-    void shouldDegradeToStoredFlowWhenParsingFails() throws FlowProcessingException {
+    void shouldDegradeToStoredFlowWhenParsingFails() throws Exception {
         // Given
         FlowParsingService flowParsingService = mock(FlowParsingService.class);
         when(flowParsingService.parseForRuntime(flow)).thenThrow(new FlowProcessingException("invalid"));
 
         // When / Then a non-governance failure keeps the flow as stored so existing triggers keep evaluating
-        assertThat(TriggerFlowParser.parseOrSkip(flowParsingService, flow, LOGGER)).isSameAs(flow);
+        assertThat(TriggerFlowParser.parseForTrigger(flowParsingService, flow, LOGGER)).isSameAs(flow);
     }
 
     @Test
-    void shouldReturnParsedFlowWhenParsingSucceeds() throws FlowProcessingException {
+    void shouldReturnParsedFlowWhenParsingSucceeds() throws Exception {
         // Given
         FlowParsingService flowParsingService = mock(FlowParsingService.class);
         FlowWithSource parsed = flow.toBuilder().revision(2).build();
         when(flowParsingService.parseForRuntime(flow)).thenReturn(ProcessedFlow.of(parsed));
 
         // When / Then
-        assertThat(TriggerFlowParser.parseOrSkip(flowParsingService, flow, LOGGER)).isSameAs(parsed);
+        assertThat(TriggerFlowParser.parseForTrigger(flowParsingService, flow, LOGGER)).isSameAs(parsed);
     }
 }

--- a/webserver/src/main/java/io/kestra/webserver/controllers/ErrorController.java
+++ b/webserver/src/main/java/io/kestra/webserver/controllers/ErrorController.java
@@ -165,6 +165,11 @@ public class ErrorController {
     }
 
     @Error(global = true)
+    public HttpResponse<JsonError> error(HttpRequest<?> request, ForbiddenException e) {
+        return jsonError(request, e, HttpStatus.FORBIDDEN, HttpStatus.FORBIDDEN.getReason());
+    }
+
+    @Error(global = true)
     public HttpResponse<JsonError> error(HttpRequest<?> request, InvalidQueryFiltersException e) {
         return jsonError(request, e, HttpStatus.BAD_REQUEST, "Invalid query filters");
     }


### PR DESCRIPTION
### ✨ Description

Four changes to how governance policies and scheduled runs behave.

**1. Scheduled runs can read the flow's own labels** (`fix(triggers)`)

Input rendering happens *before* the executor merges the flow's labels onto the execution, and `SchedulableExecutionFactory` is the one creation path that hand-rolls `Execution.builder()` instead of `Execution.newExecution(...)`. So an execution created by `Schedule` or `ScheduleOnDates` carried only trigger-contributed labels (`system.from`, `system.correlationId`) at render time, and an input `defaults` referencing a flow label failed with ``Unable to find `...` ``. No execution was created — the evaluation failure is swallowed to a warning — while the same flow started manually rendered fine.

Rendering now happens against a throwaway copy carrying the merged set. `Execution.withLabels` returns a new instance, so the execution handed to the executor is untouched and label ownership stays with the executor.

This also folds the two identical `readInputs` calls into one. That is required, not opportunistic: the second call fed the `TriggerEvaluationResult` and would otherwise still have rendered against the un-merged execution.

**2. `ForbiddenException` mapped to HTTP 403** (`feat(core)`)

There was no typed exception for "the entity exists, but this operation is not allowed on it", so callers wanting a 403 either reached for Micronaut's `HttpStatusException` from inside a service or settled for a 409. Mirrors `ConflictException` — a plain core exception plus a global handler in `ErrorController`. Consumed by the companion EE PR.

**3. A governance block is reported in the trigger's own logs** (`fix(scheduler)`)

A trigger whose flow a policy blocks simply stopped firing. The only trace was a server-side warning users cannot reach, so the trigger looked broken with no explanation. It is now reported through the trigger's run context — `RunContextLogger` is the only path that reaches the UI; a `trigger.*`-named slf4j logger does not — on every skipped evaluation, and once per declared trigger at scheduler start, where a blocked flow never gets a trigger state and would otherwise get no report at all.

`TriggerFlowParser.parseOrSkip` becomes `parseForTrigger` and throws `FlowBlockedException` rather than returning `null`. Its old contract encoded three outcomes in one nullable return: the parsed flow, `null` for a governance block, and *the same instance back* for a degraded parse. A caller could not tell a block from a parse failure and had no reason to report either. The checked exception hands over the reason and makes each caller decide.

**4. Normalized the errors refusing to execute a subflow** (`fix(flows)`)

A flow that cannot be resolved for runtime is carried as a `FlowWithException` for two unrelated reasons — it is structurally invalid, or governance blocks it — and `FlowWithException` keeps only the message, discarding the cause. Both subflow paths reported "invalid flow", which is wrong and confusing for the second.

Both now state neither cause, since the carried message already says which it was, and emit one identical message that names the flow:

- `Cannot execute flow 'ns'.'id': <reason>`
- `Cannot execute flow 'ns'.'id': it is disabled.`

### 🔗 Related Issue

Related to https://github.com/kestra-io/kestra-ee/issues/9877 (part 1 wording, and the Schedule row of its route table).

This does **not** close that issue: the explicit parse-outcome refactor, the audit-log record of a blocked attempt, and the check-ordering divergence between `ExecutableUtils` and `SubflowFunction` are all still open.

### 🛠️ Backend Checklist

- [x] Code compiles successfully and passes all checks
- [ ] All unit and integration tests pass

### 📝 Additional Notes

**Deliberately not changed.** Flow triggers still create an execution for a policy-blocked flow, which the executor then fails. That is currently the only route where a governance block reaches notifications and SLA alerting, so making it silent would need the audit-log record first. The issue's target for that row should be revisited rather than implemented.

**What ran locally** (the tests box is unticked because I did not run the full suite, not because something failed):

- `:scheduler:test` — 112 passing
- `:core:test --tests ScheduleTest, ScheduleOnDatesTest, FlowInputOutputTest, LabelServiceTest, ExecutionTest` — 119 passing
- `:core:compileJava`

**Test coverage of the changes.** The scheduled-labels fix has an end-to-end regression test in `ScheduleTest` (watched fail on the reported symptom first) and the `TriggerFlowParser` contract change is unit-tested. The four subflow messages and the trigger-visible governance log are **not** covered — no test asserted those messages before either, and there is no cheap unit seam for them.

**Companion PR:** https://github.com/kestra-io/kestra-ee/pull/10034 flips the policy-block status code onto the `ForbiddenException` added here. Both branches share the name `fix/policy-behavior`, and this PR must merge first.

### 🤖 AI Authors

Why did the cat sit on the keyboard during the review? It heard the branch had too many *paws*-itory conflicts. 🐱
