### PR TITLE
fix(triggers): keep the pre-backfill schedule date when a backfill is paused

### DIFF
--- a/core/src/main/java/io/kestra/core/scheduler/model/TriggerState.java
+++ b/core/src/main/java/io/kestra/core/scheduler/model/TriggerState.java
@@ -232,7 +232,9 @@ public final class TriggerState implements TriggerId {
                 .toBuilder()
                 .end(backfill.getEnd() != null ? backfill.getEnd() : ZonedDateTime.now(clock))
                 .currentDate(backfill.getCurrentDate() != null ? backfill.getCurrentDate() : backfill.getStart())
-                .previousNextExecutionDate(toZonedDateTime(nextEvaluationDate))
+                // captured once, on backfill creation: pausing re-enters this method while
+                // nextEvaluationDate points inside the backfill window.
+                .previousNextExecutionDate(backfill.getPreviousNextExecutionDate() != null ? backfill.getPreviousNextExecutionDate() : toZonedDateTime(nextEvaluationDate))
                 .build();
         }
         return update(clock).backfill(backfill).build();

--- a/scheduler/src/main/java/io/kestra/scheduler/TriggerEventHandler.java
+++ b/scheduler/src/main/java/io/kestra/scheduler/TriggerEventHandler.java
@@ -195,8 +195,9 @@ public class TriggerEventHandler {
                     .lastEventId(clock, event.eventId())
                     // clear the backfill
                     .backfill(clock, null)
-                    // restore the previous next-evaluation date.
-                    .updateForNextEvaluationDate(clock, nextEvaluationDate);
+                    // restore the previous next-evaluation date, or clear it when the trigger was
+                    // backfilled before its first evaluation so the scheduler computes a new one.
+                    .updateForNextEvaluationDate(clock, nextEvaluationDate != null ? nextEvaluationDate.toInstant() : null);
                 triggerStateStore.save(state);
             }
         });

--- a/scheduler/src/test/java/io/kestra/scheduler/TriggerEventHandlerTest.java
+++ b/scheduler/src/test/java/io/kestra/scheduler/TriggerEventHandlerTest.java
@@ -1129,6 +1129,35 @@ class TriggerEventHandlerTest {
         assertThat(updated).get().extracting(TriggerState::getLastEventId).isEqualTo(event.eventId());
     }
 
+    @Test
+    void shouldRestoreLiveNextEvaluationDateWhenDeleteBackfillEventHandledAfterPause() {
+        // GIVEN
+        ZonedDateTime liveNextEvaluationDate = SchedulerClock.now().plusHours(1);
+        Backfill backfill = Backfill.builder()
+            .start(SchedulerClock.now().minusDays(7))
+            .end(SchedulerClock.now().minusDays(6))
+            .paused(false)
+            .build();
+        // the backfill has progressed, so the next evaluation date now points inside the backfill window
+        triggerStateStore.save(triggerState
+            .updateForNextEvaluationDate(CLOCK, liveNextEvaluationDate)
+            .backfill(CLOCK, backfill)
+            .updateForNextEvaluationDate(CLOCK, backfill.getStart().plusHours(8))
+        );
+        handler = newTriggerEventHandler(List.of());
+
+        // WHEN
+        handler.handle(CLOCK, TEST_VNODE, new SetPauseBackfillTrigger(triggerId, true));
+        DeleteBackfillTrigger event = new DeleteBackfillTrigger(triggerId);
+        handler.handle(CLOCK, TEST_VNODE, event);
+
+        // THEN
+        Optional<TriggerState> updated = triggerStateStore.findById(triggerId);
+        assertThat(updated).get().extracting(TriggerState::getBackfill).isNull();
+        assertThat(updated).get().extracting(TriggerState::getNextEvaluationDate).isEqualTo(liveNextEvaluationDate.toInstant());
+        assertThat(updated).get().extracting(TriggerState::getLastEventId).isEqualTo(event.eventId());
+    }
+
     // Fixed clock on Wednesday 2024-01-03 at 10:00 in the system default zone.
     // With cron "*/1 * * * *" + DayWeek=SUNDAY condition, the next matching tick is the next
     // Sunday 00:00 in the Schedule's timezone (system default). The exact instant depends on

--- a/scheduler/src/test/java/io/kestra/scheduler/TriggerEventHandlerTest.java
+++ b/scheduler/src/test/java/io/kestra/scheduler/TriggerEventHandlerTest.java
@@ -1158,6 +1158,29 @@ class TriggerEventHandlerTest {
         assertThat(updated).get().extracting(TriggerState::getLastEventId).isEqualTo(event.eventId());
     }
 
+    @Test
+    void shouldClearNextEvaluationDateWhenDeleteBackfillEventHandledGivenTriggerNeverEvaluated() {
+        // GIVEN
+        Backfill backfill = Backfill.builder()
+            .start(SchedulerClock.now().minusDays(1))
+            .end(SchedulerClock.now())
+            .paused(false)
+            .build();
+        // a trigger backfilled before its first evaluation has no next-evaluation date to restore
+        triggerStateStore.save(triggerState.backfill(CLOCK, backfill));
+        handler = newTriggerEventHandler(List.of());
+        DeleteBackfillTrigger event = new DeleteBackfillTrigger(triggerId);
+
+        // WHEN
+        handler.handle(CLOCK, TEST_VNODE, event);
+
+        // THEN
+        Optional<TriggerState> updated = triggerStateStore.findById(triggerId);
+        assertThat(updated).get().extracting(TriggerState::getBackfill).isNull();
+        assertThat(updated).get().extracting(TriggerState::getNextEvaluationDate).isNull();
+        assertThat(updated).get().extracting(TriggerState::getLastEventId).isEqualTo(event.eventId());
+    }
+
     // Fixed clock on Wednesday 2024-01-03 at 10:00 in the system default zone.
     // With cron "*/1 * * * *" + DayWeek=SUNDAY condition, the next matching tick is the next
     // Sunday 00:00 in the Schedule's timezone (system default). The exact instant depends on


### PR DESCRIPTION
### ✨ Description

Pausing a backfill and then deleting it left the trigger sitting at the backfill's position instead of the live schedule, so it replayed every cron slot from that old point up to now (~80 executions in two minutes on an every-minute schedule).

`TriggerState.backfill()` re-snapshotted `previousNextExecutionDate` from the *current* `nextEvaluationDate` on every call. That field is meant to be captured once, at backfill creation, and is read by exactly one caller — the delete handler — to put the trigger back where the live schedule would have been. Pausing re-enters that method (`onSetPauseBackfillTrigger` → `state.backfill(clock, …paused(true))`) at a moment when `nextEvaluationDate` points *inside* the backfill window, overwriting the live date with the backfill position. Delete then faithfully restored that position.

This is also why deleting a *running* backfill worked: evaluation ticks go through `getBackFillForNextEvaluationDate`, which preserves the field.

The fix makes the capture preserve-if-present, exactly as the `end` and `currentDate` lines two rows above it already do. `Backfill.currentDate` — the backfill's own progress, which resume reads — is untouched and keeps behaving as before.

A second commit fixes a latent NPE found in the same handler: a trigger backfilled *before its first evaluation* has no `previousNextExecutionDate`, and restoring it threw `NullPointerException` out of `handle()`, so the delete event was never applied and the backfill stayed stuck on the trigger. The next-evaluation date is now cleared instead, which makes the scheduler compute a fresh one from the trigger definition.

### 🔗 Related Issue

Closes kestra-io/kestra-ee#9998

> Note: the issue was filed in `kestra-io/kestra-ee` but the bug is entirely in OSS code, so this cross-repo keyword links the issue without auto-closing it — it needs to be closed manually on merge.

### 🛠️ Backend Checklist

- [x] Code compiles successfully and passes all checks
- [ ] All unit and integration tests pass — see notes below

### 📝 Additional Notes

Both fixes were written test-first; each test was watched failing for the right reason before the production change:

- `shouldRestoreLiveNextEvaluationDateWhenDeleteBackfillEventHandledAfterPause` — failed with `expected 2026-08-18T21:44Z (live schedule) but was 2026-08-12T04:44Z (backfill position)`, the exact symptom reported.
- `shouldClearNextEvaluationDateWhenDeleteBackfillEventHandledGivenTriggerNeverEvaluated` — failed with `NullPointerException: Cannot invoke "java.time.ZonedDateTime.toInstant()" because "nextEvaluationDate" is null`.

Run locally, both green: `:scheduler:test` (114 passing, includes the pre-existing delete-backfill and pause/resume tests) and `:core:test` filtered to `io.kestra.plugin.core.trigger.*`, `io.kestra.core.scheduler.*`, `io.kestra.core.models.triggers.*` (36 passing). The full unit + integration suite is left to CI, hence the unticked box.

One deliberate non-change: the null handling stays local to `onDeleteBackfillTrigger` rather than making `TriggerState.updateForNextEvaluationDate(Clock, ZonedDateTime)` null-tolerant — that would silently swallow nulls at its ~19 other call sites, where a null date is a genuine bug.
