### PR TITLE
fix(ui): centre the glyph in icon only buttons

### DIFF
--- a/ui/packages/design-system/src/components/Basic/KsButton/KsButton.vue
+++ b/ui/packages/design-system/src/components/Basic/KsButton/KsButton.vue
@@ -143,6 +143,8 @@
         &.is-square {
             .material-design-icon > .material-design-icon__svg {
                 bottom: 0;
+                left: 50%;
+                transform: translateX(-50%);
             }
         }
 


### PR DESCRIPTION
Closes https://github.com/kestra-io/kestra-ee/issues/10051.
