### PR TITLE
fix(iam): align frontend permission gates with backend enforcement

### DIFF
--- a/ui/src/components/admin/Triggers.vue
+++ b/ui/src/components/admin/Triggers.vue
@@ -206,7 +206,7 @@
                             <template #default="scope">
                                 <div class="action-container">
                                     <IconButton
-                                        v-if="scope.row.executionId || scope.row.evaluateRunningDate"
+                                        v-if="(scope.row.executionId || scope.row.evaluateRunningDate) && authStore.user?.isAllowed(permission.EXECUTION, action.UPDATE, scope.row.namespace)"
                                         :tooltip="$t(`unlock trigger.tooltip.${scope.row.executionId ? 'execution' : 'evaluation'}`)"
                                         placement="left"
                                         @click="triggerToUnlock = scope.row"
@@ -214,6 +214,7 @@
                                         <LockOff />
                                     </IconButton>
                                     <IconButton
+                                        v-if="authStore.user?.isAllowed(permission.EXECUTION, action.UPDATE, scope.row.namespace)"
                                         :tooltip="$t('delete trigger')"
                                         placement="left"
                                         @click="confirmDeleteTrigger(scope.row)"
@@ -241,7 +242,7 @@
 
                                     <el-button
                                         :icon="CalendarCollapseHorizontalOutline"
-                                        v-if="authStore.user?.hasAnyAction(permission.EXECUTION, action.UPDATE)"
+                                        v-if="authStore.user?.isAllowed(permission.EXECUTION, action.UPDATE, scope.row.namespace)"
                                         @click="setBackfillModal(scope.row, true)"
                                         size="small"
                                         type="primary"
@@ -267,7 +268,7 @@
                                         @change="setDisabled(scope.row, $event)"
                                         inlinePrompt
                                         class="switch-text"
-                                        :disabled="scope.row.codeDisabled"
+                                        :disabled="scope.row.codeDisabled || !authStore.user?.isAllowed(permission.EXECUTION, action.UPDATE, scope.row.namespace)"
                                     />
                                 </el-tooltip>
                                 <el-tooltip v-else :content="$t('flow source not found')" effect="light">

--- a/ui/src/components/dashboard/components/Header.vue
+++ b/ui/src/components/dashboard/components/Header.vue
@@ -4,10 +4,10 @@
         :breadcrumb="[{label: $t('dashboards.labels.singular'), link: undefined}]"
         :description="props.dashboard?.description"
     >
-        <template v-if="isAllowedDashboard || isAllowedFlow" #additional-right>
+        <template v-if="isAllowedDashboardRead || isAllowedDashboardUpdate || isAllowedFlow" #additional-right>
             <ul>
                 <li
-                    v-if="ALLOWED_CREATION_ROUTES.includes(String(route.name)) && isAllowedDashboard"
+                    v-if="ALLOWED_CREATION_ROUTES.includes(String(route.name)) && isAllowedDashboardRead"
                 >
                     <Dashboards
                         @dashboard="(value: any) => props.load?.(value)"
@@ -15,7 +15,7 @@
                     />
                 </li>
                 <li
-                    v-if="props.dashboard?.id && props.dashboard?.id !== 'default' && isAllowedDashboard"
+                    v-if="props.dashboard?.id && props.dashboard?.id !== 'default' && isAllowedDashboardUpdate"
                 >
                     <router-link
                         :to="{name: 'dashboards/update', params: {id: props.dashboard?.id}}"
@@ -66,7 +66,9 @@
 
     const isAllowedFlow = computed(() => authStore.user?.isAllowed(permission.FLOW, action.CREATE, "*"));
 
-    const isAllowedDashboard = computed(() => authStore.user?.isAllowed(permission.DASHBOARD, action.CREATE, "*"));
+    const isAllowedDashboardRead = computed(() => authStore.user?.isAllowed(permission.DASHBOARD, action.READ, "*"));
+
+    const isAllowedDashboardUpdate = computed(() => authStore.user?.isAllowed(permission.DASHBOARD, action.UPDATE, "*"));
 
     const routeInfo = computed(() => ({title: props.dashboard?.title ?? t("overview")}));
 

--- a/ui/src/components/dashboard/components/selector/Item.vue
+++ b/ui/src/components/dashboard/components/selector/Item.vue
@@ -5,15 +5,21 @@
         </div>
 
         <div class="col-auto">
-            <el-button v-if="props.dashboard.id !== 'default'" link :icon="Pencil" class="mx-0" @click.stop="props.edit(props.dashboard.id)" />
-            <el-button v-if="props.dashboard.id !== 'default' && props.remove" link :icon="DeleteOutline" class="mx-0" @click.stop="props.remove(props.dashboard)" />
+            <el-button v-if="props.dashboard.id !== 'default' && canEdit" link :icon="Pencil" class="mx-0" @click.stop="props.edit(props.dashboard.id)" />
+            <el-button v-if="props.dashboard.id !== 'default' && props.remove && canDelete" link :icon="DeleteOutline" class="mx-0" @click.stop="props.remove(props.dashboard)" />
         </div>
     </el-dropdown-item>
 </template>
 
 <script setup lang="ts">
+    import {computed} from "vue";
     import DeleteOutline from "vue-material-design-icons/DeleteOutline.vue";
     import Pencil from "vue-material-design-icons/Pencil.vue";
+    import {useAuthStore} from "override/stores/auth";
+    import permission from "../../../../models/permission";
+    import action from "../../../../models/action";
+
+    const authStore = useAuthStore();
 
     const props = defineProps({
         dashboard: {
@@ -23,4 +29,7 @@
         edit: {type: Function, required: true},
         remove: {type: Function, default: undefined},
     });
+
+    const canEdit = computed(() => authStore.user?.isAllowed(permission.DASHBOARD, action.UPDATE, "*"));
+    const canDelete = computed(() => authStore.user?.isAllowed(permission.DASHBOARD, action.DELETE, "*"));
 </script>

--- a/ui/src/components/dashboard/components/selector/Selector.vue
+++ b/ui/src/components/dashboard/components/selector/Selector.vue
@@ -9,6 +9,7 @@
         <template #dropdown>
             <el-dropdown-menu class="p-3 dropdown">
                 <el-button
+                    v-if="canCreate"
                     type="primary"
                     :icon="Plus"
                     tag="router-link"
@@ -74,6 +75,14 @@
     import {getDashboard} from "../../composables/useDashboards";
 
     import Item from "./Item.vue";
+
+    import {useAuthStore} from "override/stores/auth";
+    import permission from "../../../../models/permission";
+    import action from "../../../../models/action";
+    const authStore = useAuthStore();
+
+    // Creating a dashboard requires DASHBOARD CREATE (browsing the selector only requires READ).
+    const canCreate = computed(() => authStore.user?.isAllowed(permission.DASHBOARD, action.CREATE, "*"));
 
     import {useBreakpoints, breakpointsElement} from "@vueuse/core";
     const verticalLayout = useBreakpoints(breakpointsElement).smallerOrEqual("sm");

--- a/ui/src/components/executions/outputs/Wrapper.vue
+++ b/ui/src/components/executions/outputs/Wrapper.vue
@@ -67,6 +67,7 @@
                         </div>
 
                         <el-collapse
+                            v-if="isAllowedEval"
                             v-model="debugCollapse"
                             class="mb-3 debug bordered"
                         >
@@ -157,6 +158,9 @@
     import {ElTree} from "element-plus";
     import {useExecutionsStore} from "../../../stores/executions";
     import {usePluginsStore} from "../../../stores/plugins";
+    import {useAuthStore} from "override/stores/auth";
+    import permission from "../../../models/permission";
+    import action from "../../../models/action";
 
     import {useI18n} from "vue-i18n";
     import {apiUrl} from "override/utils/route";
@@ -261,6 +265,14 @@
     const executionsStore = useExecutionsStore();
 
     const execution = computed(() => executionsStore.execution);
+
+    // Expression evaluation calls the eval endpoint, which requires FLOW UPDATE on the execution's namespace.
+    const isAllowedEval = computed(() =>
+        Boolean(
+            execution.value &&
+                useAuthStore().user?.isAllowed(permission.FLOW, action.UPDATE, execution.value.namespace),
+        ),
+    );
 
     function isValidURL(url: string) {
         try {

--- a/ui/src/components/executions/overview/components/main/cascaders/DebugPanel.vue
+++ b/ui/src/components/executions/overview/components/main/cascaders/DebugPanel.vue
@@ -10,7 +10,7 @@
         />
 
         <div class="buttons">
-            <el-button type="primary" :icon="Refresh" @click="onRender">
+            <el-button type="primary" :icon="Refresh" :disabled="!isAllowedEval" @click="onRender">
                 {{ $t("eval.render") }}
             </el-button>
             <el-button
@@ -55,6 +55,9 @@
 
     import {Execution} from "../../../../../../stores/executions";
     import {useFlowStore} from "../../../../../../stores/flow";
+    import {useAuthStore} from "override/stores/auth";
+    import permission from "../../../../../../models/permission";
+    import action from "../../../../../../models/action";
 
     import Refresh from "vue-material-design-icons/Refresh.vue";
     import CloseCircleOutline from "vue-material-design-icons/CloseCircleOutline.vue";
@@ -92,6 +95,14 @@
 
     const axios = useAxios();
 
+    // Rendering an expression calls the eval endpoint, which requires FLOW UPDATE on the execution's namespace.
+    const isAllowedEval = computed(() =>
+        Boolean(
+            props.execution &&
+                useAuthStore().user?.isAllowed(permission.FLOW, action.UPDATE, props.execution.namespace),
+        ),
+    );
+
     const result = ref<{ value: string; type: string } | undefined>(undefined);
     const error = ref<string | undefined>(undefined);
     const stackTrace = ref<string | undefined>(undefined);
@@ -122,7 +133,7 @@
     );
 
     const onRender = () => {
-        if (!props.execution) return;
+        if (!props.execution || !isAllowedEval.value) return;
 
         clearAll();
 

--- a/ui/src/components/flows/FlowRevisions.vue
+++ b/ui/src/components/flows/FlowRevisions.vue
@@ -4,6 +4,8 @@
         lang="yaml"
         :revisions="flowRevisions"
         :revisionSource="loadRevisionContent"
+        :canRestore="flowStore.isAllowedEdit"
+        :canDelete="flowStore.isAllowedDelete"
         @restore="restoreRevision"
         @deleted="onRevisionDeleted"
         class="flow-revisions"

--- a/ui/src/components/flows/Flows.vue
+++ b/ui/src/components/flows/Flows.vue
@@ -8,7 +8,7 @@
                     </el-button>
                 </li>
                 <li>
-                    <el-button :icon="Upload" @click="file?.click()">
+                    <el-button v-if="canCreate" :icon="Upload" @click="file?.click()">
                         {{ $t("import") }}
                     </el-button>
                     <input ref="file" type="file" accept=".zip, .yml, .yaml" @change="importFlows()" class="d-none">

--- a/ui/src/components/inputs/EditorButtonsWrapper.vue
+++ b/ui/src/components/inputs/EditorButtonsWrapper.vue
@@ -13,7 +13,7 @@
         <EditorButtons
             :isCreating="flowStore.isCreating"
             :isReadOnly="flowStore.isReadOnly"
-            :canDelete="true"
+            :canDelete="flowStore.isAllowedDelete"
             :isAllowedEdit="flowStore.isAllowedEdit"
             :haveChange="haveChange"
             :flowHaveTasks="Boolean(flowStore.flowHaveTasks)"

--- a/ui/src/components/inputs/FileExplorer.vue
+++ b/ui/src/components/inputs/FileExplorer.vue
@@ -26,6 +26,7 @@
             </el-select>
             <el-button-group class="d-flex">
                 <el-tooltip
+                    v-if="canCreate"
                     effect="light"
                     :content="$t('namespace files.create.file')"
                     transition=""
@@ -38,6 +39,7 @@
                     </el-button>
                 </el-tooltip>
                 <el-tooltip
+                    v-if="canCreate"
                     effect="light"
                     :content="$t('namespace files.create.folder')"
                     transition=""
@@ -70,7 +72,7 @@
                     class="hidden"
                     @change="importFiles"
                 >
-                <el-dropdown>
+                <el-dropdown v-if="canCreate">
                     <el-button>
                         <PlusBox />
                     </el-button>
@@ -110,7 +112,7 @@
             :allowDrop="
                 (_: any, drop: any, dropType: string) => !drop.data?.leaf || dropType !== 'inner'
             "
-            draggable
+            :draggable="canUpdate"
             nodeKey="id"
             v-loading="filesStore.fileTree === undefined"
             :props="{class: nodeClass, isLeaf: 'leaf'}"
@@ -163,13 +165,13 @@
                     <template #dropdown>
                         <el-dropdown-menu>
                             <el-dropdown-item
-                                v-if="!data.leaf && !multiSelected"
+                                v-if="!data.leaf && !multiSelected && canCreate"
                                 @click="toggleDialog(true, 'file', node)"
                             >
                                 {{ $t("namespace files.create.file") }}
                             </el-dropdown-item>
                             <el-dropdown-item
-                                v-if="!data.leaf && !multiSelected"
+                                v-if="!data.leaf && !multiSelected && canCreate"
                                 @click="toggleDialog(true, 'folder', node)"
                             >
                                 {{ $t("namespace files.create.folder") }}
@@ -184,7 +186,7 @@
                                 {{ $t("namespace files.export_single") }}
                             </el-dropdown-item>
                             <el-dropdown-item
-                                v-if="data.leaf && !multiSelected"
+                                v-if="data.leaf && !multiSelected && canUpdate"
                                 @click="
                                     toggleRenameDialog(
                                         true,
@@ -202,7 +204,7 @@
                                     )
                                 }}
                             </el-dropdown-item>
-                            <el-dropdown-item @click="removeSelectedFiles(data, node)">
+                            <el-dropdown-item v-if="canDelete" @click="removeSelectedFiles(data, node)">
                                 {{
                                     selectedNodes.length <= 1 ? $t(
                                         `namespace files.delete.${
@@ -342,6 +344,8 @@
                 :lang="revisionsHistory.path.split('.').pop()!"
                 :revisions="revisionsHistory.revisions"
                 :revisionSource="fetchRevisionSource"
+                :canRestore="canUpdate"
+                :canDelete="canDelete"
                 @restore="restore"
                 :editRouteQuery="false"
                 class="revision-history-dialog-body"
@@ -353,7 +357,7 @@
         </el-dialog>
 
         <el-menu
-            v-if="tabContextMenu.visible"
+            v-if="tabContextMenu.visible && canCreate"
             :style="{
                 left: `${tabContextMenu.x}px`,
                 top: `${tabContextMenu.y}px`,
@@ -382,6 +386,9 @@
     import {ref, computed, nextTick, inject, watch} from "vue";
     import {useRoute} from "vue-router";
     import {useNamespacesStore} from "override/stores/namespaces";
+    import {useAuthStore} from "override/stores/auth";
+    import permission from "../../models/permission";
+    import action from "../../models/action";
     import Utils from "../../utils/utils";
     import FileExplorerEmpty from "../../assets/icons/file_explorer_empty.svg";
     import Magnify from "vue-material-design-icons/Magnify.vue";
@@ -483,6 +490,13 @@
     const toast = useToast();
 
     const namespaceId = computed<string>(() => props.currentNS ?? route.params.namespace as string);
+
+    // Namespace files are governed by the FLOW permission on the file's namespace (see NamespaceFileController):
+    // read/export need READ, create/import need CREATE, rename/move need UPDATE, delete needs DELETE.
+    const authStore = useAuthStore();
+    const canCreate = computed(() => authStore.user?.isAllowed(permission.FLOW, action.CREATE, namespaceId.value) ?? false);
+    const canUpdate = computed(() => authStore.user?.isAllowed(permission.FLOW, action.UPDATE, namespaceId.value) ?? false);
+    const canDelete = computed(() => authStore.user?.isAllowed(permission.FLOW, action.DELETE, namespaceId.value) ?? false);
 
     const multiSelected = computed(() => selectedNodes.value.length > 1);
 
@@ -663,6 +677,7 @@
     }
 
     async function restore(source: string) {
+        if (!canUpdate.value) return;
         await namespacesStore.saveOrCreateFile({
             namespace: namespaceId.value,
             path: revisionsHistory.value.path,
@@ -688,6 +703,7 @@
     }
 
     async function removeSelectedFiles(_data?: any, node?: ElTreeNode) {
+        if (!canDelete.value) return;
         if (selectedFiles.value.length <= 1 && node) {
             selectedNodes.value = [node.data.id];
         }
@@ -727,6 +743,7 @@
     }
 
     async function dialogHandler() {
+        if (!canCreate.value) return;
         if (dialog.value.type === "file") {
             await addFile({creation: true});
         } else {
@@ -773,6 +790,7 @@
     }
 
     function renameItem() {
+        if (!canUpdate.value) return;
         const path = renameDialog.value.node?.data.id ? filesStore.getPath(renameDialog.value.node.data.id) ?? "" : "";
         const start = path.substring(0, path.lastIndexOf("/") + 1);
         namespacesStore.renameFileDirectory({
@@ -813,6 +831,7 @@
     }
 
     async function importFiles(event: Event) {
+        if (!canCreate.value) return;
         const importedFiles = (event.target as HTMLInputElement).files;
         if (!importedFiles) return;
         try {

--- a/ui/src/components/kv/KVs.vue
+++ b/ui/src/components/kv/KVs.vue
@@ -2,7 +2,7 @@
     <TopNavBar :title="routeInfo.title">
         <template #additional-right>
             <ul>
-                <li>
+                <li v-if="canAddKv">
                     <el-button :icon="Plus" type="primary" @click="namespacesStore.addKvModalVisible = true">
                         {{ $t("kv.add") }}
                     </el-button>
@@ -23,8 +23,15 @@
     import Plus from "vue-material-design-icons/Plus.vue";
     import TopNavBar from "../layout/TopNavBar.vue";
     import KVTable from "./KVTable.vue";
+    import action from "../../models/action";
+    import permission from "../../models/permission";
+    import {useAuthStore} from "override/stores/auth";
 
     const namespacesStore = useNamespacesStore();
+    const authStore = useAuthStore();
+
+    // Backend setKeyValue enforces KVSTORE CREATE for a new key.
+    const canAddKv = computed(() => authStore.user?.hasAnyAction(permission.KVSTORE, action.CREATE));
 
     const {t} = useI18n({useScope: "global"});
     const routeInfo = computed(() => ({title: t("kv.name")}));

--- a/ui/src/components/layout/Revisions.vue
+++ b/ui/src/components/layout/Revisions.vue
@@ -28,13 +28,14 @@
                                     <TrashCanOutline
                                         @mousedown.stop.prevent
                                         @click.stop.prevent="onDelete(item.value)"
-                                        v-if="item.value !== undefined && currentRevision != item.value"
+                                        v-if="item.value !== undefined && currentRevision != item.value && canDelete"
                                     />
                                 </div>
                             </el-option>
                         </el-select>
                         <el-button-group>
                             <el-button
+                                v-if="canRestore"
                                 :icon="Restore"
                                 :disabled="revisionLeftText === currentRevisionWithSource.source"
                                 @click="restoreRevision(revisionLeftIndex, revisionLeftText)"
@@ -71,6 +72,7 @@
                         </el-select>
                         <el-button-group>
                             <el-button
+                                v-if="canRestore"
                                 :icon="Restore"
                                 :disabled="revisionRightText === currentRevisionWithSource.source"
                                 @click="restoreRevision(revisionRightIndex, revisionRightText)"
@@ -152,8 +154,10 @@
         lang: string,
         revisions: Revision[],
         revisionSource: (revisionNumber: number) => Promise<string | undefined>,
-        editRouteQuery?: boolean
-    }>(), {editRouteQuery: true});
+        editRouteQuery?: boolean,
+        canRestore?: boolean,
+        canDelete?: boolean
+    }>(), {editRouteQuery: true, canRestore: true, canDelete: true});
 
     const sortedRevisions = computed(() => {
         return props.revisions.toSorted((a, b) => a.revision - b.revision);

--- a/ui/src/components/secrets/Secrets.vue
+++ b/ui/src/components/secrets/Secrets.vue
@@ -2,7 +2,7 @@
     <Navbar :title="routeInfo.title">
         <template #additional-right v-if="miscStore.configs?.secretsEnabled">
             <ul>
-                <li>
+                <li v-if="canAddSecret">
                     <el-button :icon="Plus" type="primary" @click="addSecretModalVisible = true">
                         {{ $t('secret.add') }}
                     </el-button>
@@ -85,8 +85,15 @@
     import {useMiscStore} from "override/stores/misc";
     import DemoButtons from "../demo/DemoButtons.vue";
     import EnterpriseTag from "../EnterpriseTag.vue";
+    import action from "../../models/action";
+    import permission from "../../models/permission";
+    import {useAuthStore} from "override/stores/auth";
 
     const miscStore = useMiscStore();
+    const authStore = useAuthStore();
+
+    // Backend putSecrets enforces SECRET UPDATE (there is no CREATE endpoint for secrets).
+    const canAddSecret = computed(() => authStore.user?.hasAnyAction(permission.SECRET, action.UPDATE));
 
     const props = defineProps({
         namespace: {

--- a/ui/src/components/templates/Templates.vue
+++ b/ui/src/components/templates/Templates.vue
@@ -1,8 +1,8 @@
 <template>
     <TopNavBar :title="routeInfo.title">
-        <template #additional-right v-if="user && user.hasAnyAction(permission.TEMPLATE, action.CREATE)">
+        <template #additional-right v-if="canImport || canCreate">
             <ul>
-                <li>
+                <li v-if="canImport">
                     <div class="el-input el-input-file el-input--large custom-upload">
                         <div class="el-input__wrapper">
                             <label for="importTemplates">
@@ -19,7 +19,7 @@
                         </div>
                     </div>
                 </li>
-                <li>
+                <li v-if="canCreate">
                     <router-link :to="{name: 'templates/create'}">
                         <el-button :icon="Plus" type="primary" size="large">
                             {{ $t('create') }}
@@ -183,10 +183,18 @@
                 };
             },
             canRead() {
-                return this.authStore.user?.isAllowed(permission.FLOW, action.READ);
+                return this.authStore.user?.isAllowed(permission.TEMPLATE, action.READ);
             },
             canDelete() {
-                return this.authStore.user?.isAllowed(permission.FLOW, action.DELETE);
+                return this.authStore.user?.isAllowed(permission.TEMPLATE, action.DELETE);
+            },
+            canCreate() {
+                return this.authStore.user?.hasAnyAction(permission.TEMPLATE, action.CREATE);
+            },
+            // Import replays each template through the flow import path, which the backend
+            // authorizes with FLOW CREATE+UPDATE (not TEMPLATE) — gate it accordingly.
+            canImport() {
+                return this.authStore.user?.hasAnyActionOnAnyNamespace(permission.FLOW, action.CREATE);
             },
         },
         methods: {

--- a/ui/src/stores/flow.ts
+++ b/ui/src/stores/flow.ts
@@ -869,6 +869,18 @@ function deleteFlowAndDependencies() {
         );
     })
 
+    const isAllowedDelete = computed((): boolean => {
+        if (!flow.value || !authStore.user) {
+            return false;
+        }
+
+        return authStore.user.isAllowed(
+            permission.FLOW,
+            action.DELETE,
+            flow.value?.namespace,
+        );
+    })
+
     const readOnlySystemLabel = computed(() => {
         if (!flow.value || !flow.value.labels) {
             return false;
@@ -935,6 +947,7 @@ function deleteFlowAndDependencies() {
     return {
         creationId,
         isAllowedEdit,
+        isAllowedDelete,
         readOnlySystemLabel,
         isReadOnly,
         baseOutdatedTranslationKey,


### PR DESCRIPTION
## What

Frontend companion to the kestra-ee permission-gate alignment. Following the superAdmin IAM work (kestra-io/kestra-ee#9985), we did a full pass across **all** panels — not just IAM — comparing each user-facing action's frontend gate against what the backend actually enforces (`@HasAnyPermission` + the in-method `currentUserContext.*OrThrow(Permission, Action)` check), and fixed every divergence with the backend as the source of truth.

## Frontend gate fixes (this repo)

- **Flows** — real `FLOW.DELETE` gate on the editor Delete (was hardcoded), Import gated on `FLOW.CREATE`, revision Restore/Delete gated on `FLOW.UPDATE`/`FLOW.DELETE`.
- **Namespace files** — `FileExplorer` was entirely ungated; now gated on `FLOW` per namespace (create/import → CREATE, rename/move → UPDATE, delete → DELETE), buttons **and** handlers.
- **Executions** — eval box and render-expression debug panel gated on `FLOW.UPDATE`.
- **Secrets / KV** — tenant add buttons gated (`SECRET.UPDATE` / `KVSTORE.CREATE`).
- **Templates** — export/bulk-delete/import now use `TEMPLATE` (was `FLOW`).
- **Dashboards** — read-only users can now browse (selector gated on `DASHBOARD.READ`, create button on `DASHBOARD.CREATE`); edit → UPDATE, delete → DELETE.
- **Admin triggers** — unlock/delete/backfill/enable-disable gated per-namespace.

## Verification

`npm run build` ✅ · ESLint ✅

## Companion

Backend + EE frontend changes: kestra-io/kestra-ee#10052

Related to kestra-io/kestra-ee#9985
