### PR TITLE
fix(dashboards): separate date and time with a space in time series chart labels

### DIFF
--- a/ui/src/components/dashboard/sections/TimeSeries.vue
+++ b/ui/src/components/dashboard/sections/TimeSeries.vue
@@ -115,8 +115,8 @@
 
     const shortAxisLabel = (value: string): string => {
         if (typeof value !== "string") return value
-        const [datePart, ...timeParts] = value.split(":")
-        if (timeParts.length) return timeParts.join(":")
+        const [datePart, timePart] = value.split(" ")
+        if (timePart) return timePart
         const segments = datePart.split("-")
         return segments.length === 3 ? segments.slice(1).join("-") : datePart
     }

--- a/ui/src/utils/utils.ts
+++ b/ui/src/utils/utils.ts
@@ -273,9 +273,9 @@ export function getDateFormat(startDate: moment.MomentInput, endDate: moment.Mom
     } else if (duration.asDays() > 1) {
         return "yyyy-MM-DD"
     } else if (duration.asHours() > 1) {
-        return "yyyy-MM-DD:HH:00"
+        return "yyyy-MM-DD HH:00"
     } else {
-        return "yyyy-MM-DD:HH:mm"
+        return "yyyy-MM-DD HH:mm"
     }
 }
 

--- a/ui/tests/unit/utils/utils.spec.ts
+++ b/ui/tests/unit/utils/utils.spec.ts
@@ -1,5 +1,5 @@
 import {afterAll, beforeEach, describe, expect, it, vi} from "vitest"
-import {getTheme, getSelectedTheme, switchTheme, type SelectedTheme, flatten, executionVars} from "../../../src/utils/utils"
+import {getTheme, getSelectedTheme, switchTheme, type SelectedTheme, flatten, executionVars, getDateFormat} from "../../../src/utils/utils"
 
 function mockSystemPrefersDark(prefersDark: boolean) {
     vi.stubGlobal("matchMedia", vi.fn().mockImplementation((query: string) => ({
@@ -100,6 +100,36 @@ describe("flatten()", () => {
     it("flattens arrays with index keys and keeps nulls", () => {
         expect(flatten({list: ["a", "b"], empty: null}))
             .toEqual({"list.0": "a", "list.1": "b", empty: null})
+    })
+})
+
+describe("getDateFormat()", () => {
+    it("returns a date-only format when no dates and no time range are provided", () => {
+        expect(getDateFormat(undefined, undefined, undefined)).toBe("yyyy-MM-DD")
+    })
+
+    it("returns a month format for ranges over a year", () => {
+        expect(getDateFormat(undefined, undefined, "P400D")).toBe("yyyy-MM")
+    })
+
+    it("returns a week format for ranges over 180 days", () => {
+        expect(getDateFormat(undefined, undefined, "P200D")).toBe("yyyy-'W'ww")
+    })
+
+    it("returns a date-only format for ranges over a day", () => {
+        expect(getDateFormat(undefined, undefined, "P7D")).toBe("yyyy-MM-DD")
+    })
+
+    it("separates date and hour with a space for ranges over an hour", () => {
+        expect(getDateFormat(undefined, undefined, "PT24H")).toBe("yyyy-MM-DD HH:00")
+    })
+
+    it("separates date and time with a space for ranges up to an hour", () => {
+        expect(getDateFormat(undefined, undefined, "PT30M")).toBe("yyyy-MM-DD HH:mm")
+    })
+
+    it("derives the duration from start and end dates when no time range is provided", () => {
+        expect(getDateFormat("2026-08-17T00:00:00Z", "2026-08-17T12:00:00Z", undefined)).toBe("yyyy-MM-DD HH:00")
     })
 })
 


### PR DESCRIPTION
Closes https://github.com/kestra-io/kestra/issues/18244.

## What

On the dashboard time series chart, hourly and minute-level timestamps in the tooltip and axis were formatted with a colon between the date and the time (`2026-08-17:19:00`), which reads like a timestamp with seconds (17:19:00).

- `getDateFormat` now separates the date and the time with a space: `2026-08-17 19:00`.
- The X axis short-label helper in `TimeSeries.vue` (which strips the date part so the axis shows only the time) now splits on the space instead of the colon.
- Added unit tests for `getDateFormat` covering every duration bucket, asserting the space separator for the hourly and minute formats.

Other consumers of the formatted value (grouping keys, lexical sort of the X axis) are unaffected since the format stays fixed-width.

## Example

| Range selected | Tooltip before | Tooltip after | X axis (unchanged) |
|---|---|---|---|
| Up to 1 hour | `2026-08-17:19:30` | `2026-08-17 19:30` | `19:30` |
| 1 hour to 1 day (e.g. last 24 hours) | `2026-08-17:19:00` | `2026-08-17 19:00` | `19:00` |
| 1 to 180 days | `2026-08-17` | `2026-08-17` | `08-17` |
| 180 to 365 days | `2026-W33` | `2026-W33` | `2026-W33` |
| Over a year | `2026-08` | `2026-08` | `2026-08` |
