### PR TITLE
fix(logs): stop a stale search from replacing the logs list

### DIFF
--- a/ui/AGENTS.md
+++ b/ui/AGENTS.md
@@ -148,6 +148,10 @@ const pageSize = ref(25)
 
 **Never** maintain a separate `internalPage` / `pageNumber` ref *and* bind the prop to a different value — that re-introduces the drift bug (URL says page 2, UI shows page 1) that this contract exists to prevent.
 
+**Defaults that land in the URL after mount** — a page whose filter defaults are written by a `router.replace` (e.g. the Logs page's default level, via `useRouteFilterPolicy`) must gate its first `loadData` on `isRouteSettled`. `KsDataTable` loads on mount, so without the gate the page fires a request for the bare query, throws that result away when the defaults arrive, and leaves the two responses racing each other.
+
+**Stores that back a filterable list** must ignore superseded responses: keep a sequence number per search and drop a response whose sequence is no longer the newest (see `stores/logs.ts`). Otherwise the response that happens to land last wins and the list can show results for filters the user already left — or nothing at all, when the stale search matched nothing.
+
 ### The deep-watch / computed-spread trap
 
 A `computed` that returns a fresh object (via spread or `{...}`) returns a new reference on every evaluation. Watching it with `{deep: true}` does **not** add structural equality — `deep: true` enables deep dependency tracking; the equality check at the top is still `Object.is`. The callback therefore fires on every dependency change, even when the content is unchanged.

--- a/ui/AGENTS.md
+++ b/ui/AGENTS.md
@@ -148,7 +148,7 @@ const pageSize = ref(25)
 
 **Never** maintain a separate `internalPage` / `pageNumber` ref *and* bind the prop to a different value — that re-introduces the drift bug (URL says page 2, UI shows page 1) that this contract exists to prevent.
 
-**Defaults that land in the URL after mount** — a page whose filter defaults are written by a `router.replace` (e.g. the Logs page's default level, via `useRouteFilterPolicy`) must gate its first `loadData` on `isRouteSettled`. `KsDataTable` loads on mount, so without the gate the page fires a request for the bare query, throws that result away when the defaults arrive, and leaves the two responses racing each other.
+**Defaults that land in the URL after mount** — a page whose filter defaults are written by a `router.replace` (e.g. the Logs page's default level, via `useRouteFilterPolicy`) must gate its first `loadData` on `isRouteSettled`. `KsDataTable` loads on mount, so without the gate the page fires a request for the bare query, throws that result away when the defaults arrive, and leaves the two responses racing each other. Gating means the query change is what triggers the first load, so also handle the navigation never landing: `isRouteSettled` gives up after a timeout, and the page must reload when it does — otherwise the list stays empty for good, with no request in flight and nothing to retry it.
 
 **Stores that back a filterable list** must ignore superseded responses: keep a sequence number per search and drop a response whose sequence is no longer the newest (see `stores/logs.ts`). Otherwise the response that happens to land last wins and the list can show results for filters the user already left — or nothing at all, when the stale search matched nothing.
 

--- a/ui/packages/design-system/src/components/Data/KsDataTable/filter/composables/useRouteFilterPolicy.ts
+++ b/ui/packages/design-system/src/components/Data/KsDataTable/filter/composables/useRouteFilterPolicy.ts
@@ -37,6 +37,7 @@ export function useRouteFilterPolicy<T>(options: UseRouteFilterPolicyOptions<T>)
     const route = useRoute()
     const router = useRouter()
     const normalizedOnce = ref(false)
+    const normalizationPending = ref(false)
 
     const isEnabled = () => options.enabled?.() ?? true
     const shouldApplyDefaultIfMissing = () => options.applyDefaultIfMissing?.() ?? false
@@ -85,6 +86,7 @@ export function useRouteFilterPolicy<T>(options: UseRouteFilterPolicyOptions<T>)
                 return
             }
 
+            normalizationPending.value = true
             router.replace({
                 query: options.writeToRoute(route.query as Record<string, any>, nextValue),
             })
@@ -121,9 +123,18 @@ export function useRouteFilterPolicy<T>(options: UseRouteFilterPolicyOptions<T>)
         setRouteValue(options.readFromAppliedFilters(filters))
     }
 
+    watch(routeValue, (value) => {
+        if (value !== undefined) {
+            normalizationPending.value = false
+        }
+    }, {flush: "sync"})
+
+    const isRouteSettled = computed(() => !normalizationPending.value)
+
     return {
         routeValue,
         effectiveValue,
+        isRouteSettled,
         hasUnsupportedRouteValue,
         syncFromAppliedFilters,
         setRouteValue,

--- a/ui/packages/design-system/src/components/Data/KsDataTable/filter/composables/useRouteFilterPolicy.ts
+++ b/ui/packages/design-system/src/components/Data/KsDataTable/filter/composables/useRouteFilterPolicy.ts
@@ -1,4 +1,4 @@
-import {computed, ref, watch} from "vue"
+import {computed, onScopeDispose, ref, watch} from "vue"
 import {
     type LocationQuery,
     type LocationQueryRaw,
@@ -68,6 +68,30 @@ export function useRouteFilterPolicy<T>(options: UseRouteFilterPolicyOptions<T>)
         return options.fallbackValue?.()
     })
 
+    /**
+     * `isRouteSettled` stays false until the normalized query lands, so a consumer can hold its
+     * first load back instead of running it against the URL the defaults are about to replace.
+     * The navigation can also never land — a route guard aborts it, or one that supersedes it
+     * drops the value again — and a consumer waiting on it would then show nothing at all, with
+     * no request in flight and nothing to retry it. Give up after a grace period: by then the
+     * single load the gate buys is lost anyway, and loading the URL's own filters beats that.
+     */
+    const SETTLE_TIMEOUT_MS = 2000
+    let settleTimer: ReturnType<typeof setTimeout> | undefined
+
+    const settleNow = () => {
+        clearTimeout(settleTimer)
+        settleTimer = undefined
+        normalizationPending.value = false
+    }
+
+    const startSettleTimeout = () => {
+        clearTimeout(settleTimer)
+        settleTimer = setTimeout(settleNow, SETTLE_TIMEOUT_MS)
+    }
+
+    onScopeDispose(() => clearTimeout(settleTimer))
+
     watch(
         [routeValue, explicitValue, hasUnsupportedRouteValue],
         ([routeValueNow, explicitValueNow, hasUnsupportedNow]) => {
@@ -87,6 +111,7 @@ export function useRouteFilterPolicy<T>(options: UseRouteFilterPolicyOptions<T>)
             }
 
             normalizationPending.value = true
+            startSettleTimeout()
             router.replace({
                 query: options.writeToRoute(route.query as Record<string, any>, nextValue),
             })
@@ -125,7 +150,7 @@ export function useRouteFilterPolicy<T>(options: UseRouteFilterPolicyOptions<T>)
 
     watch(routeValue, (value) => {
         if (value !== undefined) {
-            normalizationPending.value = false
+            settleNow()
         }
     }, {flush: "sync"})
 

--- a/ui/src/components/logs/LogsWrapper.vue
+++ b/ui/src/components/logs/LogsWrapper.vue
@@ -98,7 +98,7 @@
 </template>
 
 <script setup lang="ts">
-    import {ref, computed, watch, useTemplateRef} from "vue"
+    import {ref, computed, nextTick, watch, useTemplateRef} from "vue"
     import {useRoute, useRouter} from "vue-router"
     import {routeFamily} from "../../utils/routeFamily"
     import {useI18n} from "vue-i18n"
@@ -273,8 +273,10 @@
         return _merge(base, queryFilter)
     }
 
+    let hasLoadedOnce = false
     const loadData = async ({page, size}: {page: number; size: number; sort?: string}) => {
         if (!loadInit.value || !isLevelRouteSettled.value) return
+        hasLoadedOnce = true
         isLoading.value = true
 
         await logsStore.findLogs(loadQuery({
@@ -413,6 +415,17 @@
     })
     watch(filterQueryKey, () => {
         dataTable.value?.resetAndReload()
+    })
+
+    // The first load is gated on the level default having landed in the URL, and the query change
+    // that lands it is what reloads the table. When the gate opens without one — `isRouteSettled`
+    // giving up on a navigation that never lands — nothing else would trigger that first load.
+    watch(isLevelRouteSettled, (settled) => {
+        if (!settled) return
+        nextTick(() => {
+            if (hasLoadedOnce || isLoading.value) return
+            dataTable.value?.reload()
+        })
     })
 
     const showStatChart = () => props.withCharts && showChart.value

--- a/ui/src/components/logs/LogsWrapper.vue
+++ b/ui/src/components/logs/LogsWrapper.vue
@@ -202,6 +202,7 @@
     )
     const {
         effectiveValue: effectiveLogLevel,
+        isRouteSettled: isLevelRouteSettled,
         syncFromAppliedFilters: syncLevelFromAppliedFilters,
     } = useRouteFilterPolicy<LevelFilterValue>({
         enabled: () => !props.filters && hasLevelFilterUI.value,
@@ -273,7 +274,7 @@
     }
 
     const loadData = async ({page, size}: {page: number; size: number; sort?: string}) => {
-        if (!loadInit.value) return
+        if (!loadInit.value || !isLevelRouteSettled.value) return
         isLoading.value = true
 
         await logsStore.findLogs(loadQuery({
@@ -344,7 +345,7 @@
 
     let lastCountedKey = ""
     const refreshLevelCounts = () => {
-        if (!loadInit.value || lastCountedKey === filterQueryKey.value) return
+        if (!loadInit.value || !isLevelRouteSettled.value || lastCountedKey === filterQueryKey.value) return
         const key = filterQueryKey.value
         lastCountedKey = key
         logsStore.levelCounts(loadQuery({})).then((counts) => {

--- a/ui/src/stores/logs.ts
+++ b/ui/src/stores/logs.ts
@@ -39,8 +39,14 @@ export const useLogsStore = defineStore("logs", () => {
     const logs = ref<Log[]>()
     const total = ref(0)
 
+    let latestSearchId = 0
+
     function findLogs(options: Record<string, any>) {
+        const searchId = ++latestSearchId
         return LogsAPI.searchLogs(toSearchParams(options)).then(response => {
+            const isSuperseded = searchId !== latestSearchId
+            if (isSuperseded) return
+
             logs.value = response.results as unknown as Log[]
             total.value = response.total ?? 0
         })

--- a/ui/tests/unit/components/logs/logsWrapperInitialLoad.spec.ts
+++ b/ui/tests/unit/components/logs/logsWrapperInitialLoad.spec.ts
@@ -1,0 +1,102 @@
+import {afterEach, beforeEach, describe, expect, it, vi} from "vitest"
+import {flushPromises, mount} from "@vue/test-utils"
+import {createI18n} from "vue-i18n"
+import {createPinia} from "pinia"
+import {createMemoryHistory, createRouter, type Router} from "vue-router"
+import KestraDesignSystem from "@kestra-io/design-system"
+
+const searchLogs = vi.fn()
+
+vi.mock("@kestra-io/kestra-sdk/logs", () => ({
+    searchLogs: (...args: any[]) => searchLogs(...args),
+    deleteLogsFromFlow: vi.fn(),
+}))
+
+import LogsWrapper from "../../../../src/components/logs/LogsWrapper.vue"
+
+const LOG = {
+    level: "INFO",
+    namespace: "ns",
+    flowId: "flow",
+    executionId: "execution",
+    thread: "thread",
+    index: 0,
+    attemptNumber: 0,
+    executionKind: "flow",
+    timestamp: "2026-06-02T08:00:00Z",
+    message: "a log line",
+}
+
+const listSearches = () => searchLogs.mock.calls
+    .map(([params]) => params)
+    .filter((params) => params.size !== 1)
+
+const levelOf = (params: any) => params.filters
+    ?.find((filter: any) => filter.field === "level")?.value
+
+function mountLogsWrapper(router: Router) {
+    return mount(LogsWrapper, {
+        global: {
+            plugins: [
+                createI18n({legacy: false, locale: "en", messages: {en: {}}}),
+                createPinia(),
+                router,
+                KestraDesignSystem,
+            ],
+            stubs: {Sections: true, TopNavBar: true},
+        },
+    })
+}
+
+const settle = async () => {
+    await flushPromises()
+    await new Promise((resolve) => setTimeout(resolve, 200))
+    await flushPromises()
+}
+
+describe("LogsWrapper initial load", () => {
+    beforeEach(() => {
+        window.sessionStorage.clear()
+        window.localStorage.clear()
+        searchLogs.mockReset()
+        searchLogs.mockResolvedValue({results: [LOG], total: 1})
+    })
+
+    afterEach(() => {
+        window.sessionStorage.clear()
+        window.localStorage.clear()
+        document.title = ""
+    })
+
+    it("searches once, with the default level, instead of first querying without it", async () => {
+        const router = createRouter({
+            history: createMemoryHistory(),
+            routes: [{name: "logs/list", path: "/:tenant?/logs", component: {template: "<div/>"}}],
+        })
+        await router.push({name: "logs/list", params: {tenant: "main"}})
+        await router.isReady()
+
+        const wrapper = mountLogsWrapper(router)
+        await settle()
+
+        expect(listSearches().map(levelOf)).toEqual(["INFO"])
+        expect(wrapper.text()).toContain("a log line")
+    })
+
+    it("still reloads when the level filter changes afterwards", async () => {
+        const router = createRouter({
+            history: createMemoryHistory(),
+            routes: [{name: "logs/list", path: "/:tenant?/logs", component: {template: "<div/>"}}],
+        })
+        await router.push({name: "logs/list", params: {tenant: "main"}})
+        await router.isReady()
+
+        const wrapper = mountLogsWrapper(router)
+        await settle()
+
+        await (wrapper.vm as any).selectLevel("WARN")
+        await settle()
+
+        expect(listSearches().map(levelOf)).toEqual(["INFO", "WARN"])
+    })
+})

--- a/ui/tests/unit/components/logs/logsWrapperInitialLoad.spec.ts
+++ b/ui/tests/unit/components/logs/logsWrapperInitialLoad.spec.ts
@@ -99,4 +99,27 @@ describe("LogsWrapper initial load", () => {
 
         expect(listSearches().map(levelOf)).toEqual(["INFO", "WARN"])
     })
+
+    it("searches anyway when the navigation writing the default never lands", async () => {
+        const router = createRouter({
+            history: createMemoryHistory(),
+            routes: [{name: "logs/list", path: "/:tenant?/logs", component: {template: "<div/>"}}],
+        })
+        await router.push({name: "logs/list", params: {tenant: "main"}})
+        await router.isReady()
+        // Stands in for anything that keeps the default out of the URL for good — a route guard
+        // rejecting the navigation, or one that supersedes it and drops the level again.
+        router.beforeEach((to, _from, next) => {
+            next(!to.query["filters[level][GREATER_THAN_OR_EQUAL_TO]"])
+        })
+
+        const wrapper = mountLogsWrapper(router)
+        await settle()
+        // The gate gives up 2s after mount rather than leaving the page blank.
+        await new Promise((resolve) => setTimeout(resolve, 2200))
+        await flushPromises()
+
+        expect(listSearches()).toHaveLength(1)
+        expect(wrapper.text()).toContain("a log line")
+    })
 })

--- a/ui/tests/unit/stores/logsSearchRace.spec.ts
+++ b/ui/tests/unit/stores/logsSearchRace.spec.ts
@@ -1,0 +1,58 @@
+import {beforeEach, describe, expect, it, vi} from "vitest"
+import {setActivePinia, createPinia} from "pinia"
+
+const searchLogs = vi.fn()
+
+vi.mock("@kestra-io/kestra-sdk/logs", () => ({
+    searchLogs: (...args: any[]) => searchLogs(...args),
+    deleteLogsFromFlow: vi.fn(),
+}))
+
+import {useLogsStore} from "../../../src/stores/logs"
+
+const log = (level: string) => ({level, message: `a ${level} line`})
+
+const levelFilterOf = (params: any) => params.filters
+    ?.find((filter: any) => filter.field === "level")?.value
+
+describe("logs store search ordering", () => {
+    beforeEach(() => {
+        setActivePinia(createPinia())
+        searchLogs.mockReset()
+    })
+
+    it("ignores a superseded search that answers after the newest one", async () => {
+        const store = useLogsStore()
+
+        let resolveStale: (value: unknown) => void = () => {}
+        searchLogs.mockImplementation((params: any) => levelFilterOf(params) === "DEBUG"
+            ? new Promise((resolve) => {
+                resolveStale = resolve
+            })
+            : Promise.resolve({results: [log("WARN")], total: 1}))
+
+        const stale = store.findLogs({page: 1, size: 25, "filters[level][GREATER_THAN_OR_EQUAL_TO]": "DEBUG"})
+        const newest = store.findLogs({page: 1, size: 25, "filters[level][GREATER_THAN_OR_EQUAL_TO]": "WARN"})
+
+        resolveStale({results: [log("DEBUG"), log("INFO"), log("WARN")], total: 3})
+        await Promise.all([stale, newest])
+
+        expect(store.logs).toEqual([log("WARN")])
+        expect(store.total).toBe(1)
+    })
+
+    it("publishes the newest search even when it answers last", async () => {
+        const store = useLogsStore()
+
+        searchLogs.mockImplementation((params: any) => Promise.resolve(
+            params.page === 1
+                ? {results: [log("DEBUG")], total: 1}
+                : {results: [log("ERROR")], total: 1},
+        ))
+
+        await store.findLogs({page: 1, size: 25})
+        await store.findLogs({page: 2, size: 25})
+
+        expect(store.logs).toEqual([log("ERROR")])
+    })
+})


### PR DESCRIPTION
Related to kestra-io/kestra-ee#8205.

Entering `/logs` fired **three** page-sized searches: `KsDataTable` loads on mount, so the first ran against the bare query (no level, no time window — a scan of the whole log table), then the default time range landed, then the default level. Each round also fired 5 level-count probes.

`findLogs` published whatever came back, without checking the response still belonged to the newest search — so the last one to land won. When the broad search is the slow one, its late answer overwrites the correct result: the list shows rows the filters exclude, or nothing when the stale search matched nothing, while every request looks fine in the network tab.

Fix:
- `useRouteFilterPolicy` exposes `isRouteSettled`; `LogsWrapper` gates its first load on it → one search per page entry instead of three.
- The logs store drops superseded responses → covers the races the gate doesn't (filter changes, pagination, refresh).

Two unit specs, both failing on `develop` and passing here. Reproduced in a browser by delaying only the discarded searches: URL says *at or above INFO* (6 lines), list rendered all 9 including DEBUG; now stays at 6.