### PR TITLE
fix(dashboards): separate date and time with a space in time series chart labels (1.3 backport)

### DIFF
--- a/ui/src/utils/utils.ts
+++ b/ui/src/utils/utils.ts
@@ -305,9 +305,9 @@ export default class Utils {
         } else if (duration.asDays() > 1) {
             return "yyyy-MM-DD";
         } else if (duration.asHours() > 1) {
-            return "yyyy-MM-DD:HH:00";
+            return "yyyy-MM-DD HH:00";
         } else {
-            return "yyyy-MM-DD:HH:mm";
+            return "yyyy-MM-DD HH:mm";
         }
     }
 


### PR DESCRIPTION
Related to https://github.com/kestra-io/kestra/issues/18244.
Backport of https://github.com/kestra-io/kestra/pull/18269 to `releases/v1.3.x`.

## What

On the dashboard time series chart, hourly and minute-level timestamps in the tooltip and axis were formatted with a colon between the date and the time (`2026-08-17:19:00`), which reads like a timestamp with seconds. `getDateFormat` now separates them with a space: `2026-08-17 19:00`.

Unlike develop, this branch has no X axis short-label helper parsing the format, so only the two format strings change. Nothing else consumes the formatted value structurally.