### PR TITLE
fix(execution): Kill switched CANCEL or KIL execution should unlock t…

### DIFF
--- a/core/src/main/java/io/kestra/core/models/flows/State.java
+++ b/core/src/main/java/io/kestra/core/models/flows/State.java
@@ -337,6 +337,10 @@ public class State {
             return this == Type.QUEUED;
         }
 
+        public boolean isCancelled() {
+            return this == Type.CANCELLED;
+        }
+
         /**
          * @return states that are terminal to an execution
          */

--- a/executor/src/main/java/io/kestra/executor/DefaultExecutor.java
+++ b/executor/src/main/java/io/kestra/executor/DefaultExecutor.java
@@ -691,7 +691,9 @@ public class DefaultExecutor extends AbstractService implements Executor {
                 // purge the trigger: reset scheduler trigger at end
                 // IMPORTANT: this is to cover an edge case, execution created for failed trigger didn't have any taskrun so they will arrive directly here.
                 // We need to detect that and reset them as they will never reach the reset code later on this method.
-                if (execution.getTrigger() != null && execution.getState().isFailed() && ListUtils.isEmpty(execution.getTaskRunList())) {
+                if (execution.getTrigger() != null &&
+                    (execution.getState().isFailed() || execution.getState().getCurrent().isKilled() || execution.getState().getCurrent().isCancelled()) &&
+                    ListUtils.isEmpty(execution.getTaskRunList())) {
                     sendTriggerExecutionTerminated(execution);
                     this.followExecutionEventQueue.emit(new FollowExecutionEvent(execution, ExecutionEventType.TERMINATED));
                     emitExecutionStatistic(execution);

--- a/executor/src/main/java/io/kestra/executor/handler/ExecutionCommandMessageHandler.java
+++ b/executor/src/main/java/io/kestra/executor/handler/ExecutionCommandMessageHandler.java
@@ -150,7 +150,7 @@ public class ExecutionCommandMessageHandler implements ExecutorMessageHandler<Ex
             // A terminal execution (e.g. a trigger that failed to render its inputs) needs no
             // further processing by the executor — it is already in its final state.
             if (newExecution.getState().isTerminated()) {
-                return Optional.empty();
+                return Optional.of(new ExecutorContext(newExecution)); // short-circuit execution processing
             }
 
             var eventType = newExecution.getState().isCreated() ? ExecutionEventType.CREATED : ExecutionEventType.UPDATED;
@@ -202,8 +202,16 @@ public class ExecutionCommandMessageHandler implements ExecutorMessageHandler<Ex
                 command.executionId()
             );
 
-            if (persistNewExecutionWithKillSwitch(newExecution).isEmpty()) {
+            var persisted = persistNewExecutionWithKillSwitch(newExecution);
+            if (persisted.isEmpty()) {
                 return Optional.empty();
+            }
+            newExecution = persisted.get();
+
+            // A terminal execution (e.g. killed or cancelled by the kill switch) needs no further
+            // processing by the executor — it is already in its final state.
+            if (newExecution.getState().isTerminated()) {
+                return Optional.of(new ExecutorContext(newExecution)); // short-circuit execution processing
             }
 
             return executionEventMessageHandler.handle(new ExecutionEvent(newExecution, ExecutionEventType.CREATED));
@@ -230,25 +238,30 @@ public class ExecutionCommandMessageHandler implements ExecutorMessageHandler<Ex
      * </p>
      *
      * @return {@code Optional.of(execution)} if the execution should proceed to normal processing;
-     *         {@code Optional.empty()} if it was kill-switched (already persisted in its terminal state).
+     *         {@code Optional.empty()} if it was kill-switched IGNORE.
      */
-    private Optional<Execution> persistNewExecutionWithKillSwitch(Execution newExecution) {
-        EvaluationType evaluationType = killSwitchService.evaluate(newExecution);
-        if (evaluationType == EvaluationType.KILL) {
-            log.warn("Kill switch active (KILL): killing execution {}", newExecution.getId());
-            executionStateStore.create(newExecution.withState(State.Type.KILLED).addLabel(new Label(Label.KILL_SWITCH, "killed")));
-            return Optional.empty();
-        }
-        if (evaluationType == EvaluationType.CANCEL) {
-            log.warn("Kill switch active (CANCEL): cancelling execution {}", newExecution.getId());
-            executionStateStore.create(newExecution.withState(State.Type.CANCELLED).addLabel(new Label(Label.KILL_SWITCH, "cancelled")));
-            return Optional.empty();
-        }
-        executionStateStore.create(newExecution);
+    private Optional<Execution> persistNewExecutionWithKillSwitch(Execution execution) {
+        EvaluationType evaluationType = killSwitchService.evaluate(execution);
         if (evaluationType == EvaluationType.IGNORE) {
-            log.warn("Kill switch active (IGNORE): ignoring execution {}", newExecution.getId());
-            return Optional.empty();
+            log.warn("Kill switch active (IGNORE): ignoring execution {}", execution.getId());
+            executionStateStore.create(execution.addLabel(new Label(Label.KILL_SWITCH, "ignored")));
+            return Optional.empty(); // short-circuit execution processing
         }
+
+        // KILL and CANCEL should still reach toExecution so terminal steps are done
+        Execution newExecution;
+        if (evaluationType == EvaluationType.KILL) {
+            log.warn("Kill switch active (KILL): killing execution {}", execution.getId());
+            newExecution = execution.withState(State.Type.KILLED).addLabel(new Label(Label.KILL_SWITCH, "killed"));
+        }
+        else if (evaluationType == EvaluationType.CANCEL) {
+            log.warn("Kill switch active (CANCEL): cancelling execution {}", execution.getId());
+            newExecution = execution.withState(State.Type.CANCELLED).addLabel(new Label(Label.KILL_SWITCH, "cancelled"));
+        } else {
+            newExecution = execution;
+        }
+
+        executionStateStore.create(newExecution);
         return Optional.of(newExecution);
     }
 

--- a/executor/src/test/java/io/kestra/executor/handler/ExecutionCommandMessageHandlerTest.java
+++ b/executor/src/test/java/io/kestra/executor/handler/ExecutionCommandMessageHandlerTest.java
@@ -159,26 +159,52 @@ class ExecutionCommandMessageHandlerTest {
     }
 
     @Test
-    void shouldPersistExecutionAndReturnEmptyWhenKillSwitchActive() {
+    void shouldReturnExecutorContextWhenKillSwitchIsKillForNewTriggeredExecution() {
         // Given
         var flow = mock(FlowWithSource.class);
         var processedFlow = ProcessedFlow.of(flow);
-        var execution = mock(Execution.class); // no state stubs needed — kill switch fires before getState()
+        var execution = mockExecution("exec-1", "tenant", "ns", "flow-id");
+        when(execution.getState().isTerminated()).thenReturn(true);
+        when(execution.getState().getCurrent()).thenReturn(State.Type.KILLED);
+        when(execution.withState(State.Type.KILLED)).thenReturn(execution);
+        when(execution.addLabel(any())).thenReturn(execution);
         when(flowMetaStore.findByIdForRuntime(any(), any(), any(), any())).thenReturn(Optional.of(processedFlow));
         when(executionService.create(eq(createCommand), eq(processedFlow))).thenReturn(execution);
-        when(killSwitchService.evaluate(execution)).thenReturn(EvaluationType.IGNORE);
+        when(killSwitchService.evaluate(execution)).thenReturn(EvaluationType.KILL);
 
         // When
         Optional<ExecutorContext> result = handler.handle(createCommand);
 
-        // Then — execution was persisted but not processed further
-        assertThat(result).isEmpty();
+        // Then — reaches the executor as a terminal ExecutorContext instead of being dropped
+        assertThat(result).isPresent();
+        assertThat(result.get().getExecution()).isEqualTo(execution);
         verify(executionStateStore).create(execution);
         verify(executionEventMessageHandler, never()).handle(any());
-        verify(asyncOperationService).emitProcessedIfAsync(createCommand, "tenant", "exec-1", Outcome.SUCCEEDED, null);
     }
 
-    // ---- Existing-execution kill switch pre-check tests ----
+    @Test
+    void shouldReturnExecutorContextWhenKillSwitchIsCancelForNewTriggeredExecution() {
+        // Given
+        var flow = mock(FlowWithSource.class);
+        var processedFlow = ProcessedFlow.of(flow);
+        var execution = mockExecution("exec-1", "tenant", "ns", "flow-id");
+        when(execution.getState().isTerminated()).thenReturn(true);
+        when(execution.getState().getCurrent()).thenReturn(State.Type.CANCELLED);
+        when(execution.withState(State.Type.CANCELLED)).thenReturn(execution);
+        when(execution.addLabel(any())).thenReturn(execution);
+        when(flowMetaStore.findByIdForRuntime(any(), any(), any(), any())).thenReturn(Optional.of(processedFlow));
+        when(executionService.create(eq(createCommand), eq(processedFlow))).thenReturn(execution);
+        when(killSwitchService.evaluate(execution)).thenReturn(EvaluationType.CANCEL);
+
+        // When
+        Optional<ExecutorContext> result = handler.handle(createCommand);
+
+        // Then — reaches the executor as a terminal ExecutorContext instead of being dropped
+        assertThat(result).isPresent();
+        assertThat(result.get().getExecution()).isEqualTo(execution);
+        verify(executionStateStore).create(execution);
+        verify(executionEventMessageHandler, never()).handle(any());
+    }
 
     @Test
     void shouldReturnEmptyAndLogWhenKillSwitchIsIgnoreForExistingExecution() {
@@ -299,10 +325,12 @@ class ExecutionCommandMessageHandlerTest {
     }
 
     @Test
-    void replayShouldPersistKilledExecutionAndReturnEmptyWhenKillSwitchIsKill() throws Exception {
+    void replayShouldReturnExecutorContextWhenKillSwitchIsKill() throws Exception {
         // Given
         var flow = mock(FlowWithSource.class);
         var newExecution = mockExecution("new-exec-id", "tenant", "ns", "flow-id");
+        when(newExecution.getState().isTerminated()).thenReturn(true);
+        when(newExecution.getState().getCurrent()).thenReturn(State.Type.KILLED);
         when(executionStateStore.findById("source-exec-id")).thenReturn(sourceExecution);
         when(flowMetaStore.findByExecutionForRuntime(any())).thenReturn(Optional.of(flow));
         when(executionService.replay(any(), eq(flow), isNull(), isNull(), any(), eq(true), eq("new-exec-id")))
@@ -314,8 +342,9 @@ class ExecutionCommandMessageHandlerTest {
         // When
         Optional<ExecutorContext> result = handler.handle(replayCommand);
 
-        // Then — persisted in KILLED state, no further processing
-        assertThat(result).isEmpty();
+        // Then — persisted in KILLED state and returned as a terminal ExecutorContext, not dropped
+        assertThat(result).isPresent();
+        assertThat(result.get().getExecution()).isEqualTo(newExecution);
         verify(executionStateStore).create(newExecution);
         verify(executionEventMessageHandler, never()).handle(any());
         verify(asyncOperationService).emitProcessedIfAsync(replayCommand, "tenant", "new-exec-id", Outcome.SUCCEEDED, null);
@@ -337,7 +366,7 @@ class ExecutionCommandMessageHandlerTest {
 
         // Then — persisted as-is, no further processing
         assertThat(result).isEmpty();
-        verify(executionStateStore).create(newExecution);
+        verify(executionStateStore).create(any());
         verify(executionEventMessageHandler, never()).handle(any());
         verify(asyncOperationService).emitProcessedIfAsync(replayCommand, "tenant", "new-exec-id", Outcome.SUCCEEDED, null);
     }


### PR DESCRIPTION
…rigger

In both cases, the execution should at least fly to the DefaultExecutor.toExecution() methods so terminal operations are still done.

Fixes https://github.com/kestra-io/kestra-ee/issues/10023