### PR TITLE
fix(scheduler): restore vNode assignments on scheduling-loops when exiting maintenance mode

### DIFF
--- a/scheduler/src/main/java/io/kestra/scheduler/DefaultScheduler.java
+++ b/scheduler/src/main/java/io/kestra/scheduler/DefaultScheduler.java
@@ -49,6 +49,7 @@ public class DefaultScheduler extends AbstractService implements Scheduler {
     private final TriggerSchedulingLoopFactory schedulerEventLoopFactory;
 
     private ExecutorService executorService;
+    private int maxThreads;
     // Thread-safe: mutated by the vNodes rebalance listener thread and iterated from doStop().
     private final List<TriggerSchedulingLoop> schedulingLoops = new CopyOnWriteArrayList<>();
     private final VNodesAssigner vNodesAssigner;
@@ -140,6 +141,7 @@ public class DefaultScheduler extends AbstractService implements Scheduler {
     }
 
     private void doStart(int maxThreads) {
+        this.maxThreads = maxThreads;
         this.metricRegistry.gauge(MetricRegistry.METRIC_SCHEDULER_EVENTLOOP_THREAD_MAX, MetricRegistry.METRIC_SCHEDULER_EVENTLOOP_THREAD_MAX_DESCRIPTION, maxThreads);
 
         // Create the scheduling loops
@@ -175,32 +177,18 @@ public class DefaultScheduler extends AbstractService implements Scheduler {
 
                 metricAssignedVNodesCount.set(vNodes.size());
 
-                final int numSchedulingLoop = Math.min(maxThreads, vNodes.size());
-
                 // (Re)initialize trigger state store for assigned VNodes
                 triggerStateStore.init(vNodes);
 
-                // (Re)create TriggerSchedulingLoop
-                for (int i = 0; i < numSchedulingLoop; i++) {
-                    TriggerSchedulingLoop schedulingLoop = schedulerEventLoopFactory.create(i, clock);
-                    schedulingLoops.add(schedulingLoop);
-                }
-
-                // Assign scheduling-loops to VNodes
-                schedulingLoops.forEach(schedulingLoop ->
-                {
-                    // Compute vNodes assignments for the current event-loop
-                    Set<Integer> assignments = vNodes.stream()
-                        .filter(vNodeId -> vNodeId % maxThreads == schedulingLoop.id())
-                        .collect(Collectors.toSet());
-                    schedulingLoop.setAssignments(assignments);
-                });
-
                 currentVNodesAssignment.addAll(vNodes);
+
+                // Create and assign the scheduling-loops even in maintenance mode, so that exiting
+                // maintenance only has to resubmit them.
+                assignVNodesToSchedulingLoops();
 
                 // Restart scheduling only if not in maintenance mode
                 if (!maintenanceService.isInMaintenanceMode()) {
-                    startScheduling();
+                    startScheduling(false);
                 }
             }
         });
@@ -225,15 +213,47 @@ public class DefaultScheduler extends AbstractService implements Scheduler {
                     return; // scheduler is either terminating or already terminated.
                 }
 
-                // restart scheduling
-                startScheduling();
+                // restart scheduling, restoring the vNode assignments revoked when entering maintenance
+                startScheduling(true);
                 setState(ServiceState.RUNNING);
             }
         });
 
     }
 
-    private void startScheduling() {
+    /**
+     * (Re)creates the {@link TriggerSchedulingLoop} for the currently assigned vNodes and distributes
+     * those vNodes across them.
+     */
+    private void assignVNodesToSchedulingLoops() {
+        if (currentVNodesAssignment.isEmpty()) {
+            return; // nothing to assign
+        }
+
+        final int numSchedulingLoop = Math.min(maxThreads, currentVNodesAssignment.size());
+        for (int i = schedulingLoops.size(); i < numSchedulingLoop; i++) {
+            schedulingLoops.add(schedulerEventLoopFactory.create(i, clock));
+        }
+
+        schedulingLoops.forEach(schedulingLoop ->
+        {
+            Set<Integer> assignments = currentVNodesAssignment.stream()
+                .filter(vNodeId -> vNodeId % schedulingLoops.size() == schedulingLoop.id())
+                .collect(Collectors.toSet());
+            schedulingLoop.setAssignments(assignments);
+        });
+    }
+
+    /**
+     * Starts, or restarts, the scheduling.
+     *
+     * @param reassignVNodes whether the vNodes must be redistributed across the scheduling-loops first.
+     */
+    private void startScheduling(boolean reassignVNodes) {
+        if (reassignVNodes) {
+            assignVNodesToSchedulingLoops();
+        }
+
         if (schedulingLoops.isEmpty()) {
             return; // nothing to start
         }

--- a/scheduler/src/test/java/io/kestra/scheduler/DefaultSchedulerTest.java
+++ b/scheduler/src/test/java/io/kestra/scheduler/DefaultSchedulerTest.java
@@ -247,6 +247,61 @@ class DefaultSchedulerTest {
         }
     }
 
+    @Test
+    void shouldRestoreVNodesAssignmentsOnSchedulingLoopsWhenExitingMaintenanceMode() {
+        // GIVEN
+        try (DefaultScheduler scheduler = createDefaultScheduler();) {
+            scheduler.start(2);
+            serviceLivenessStore.put(scheduler);
+            vNodeController.checkServicesAndRebalanceVNodes();
+
+            // WHEN
+            maintenanceService.setMaintenanceMode(true);
+            org.awaitility.Awaitility.await().atMost(Duration.ofSeconds(5)).untilAsserted(() ->
+                assertThat(scheduler.schedulingLoops()).allMatch(Predicate.not(TriggerSchedulingLoop::isRunning))
+            );
+            maintenanceService.setMaintenanceMode(false);
+            org.awaitility.Awaitility.await().atMost(Duration.ofSeconds(5)).untilAsserted(() ->
+                assertThat(scheduler.schedulingLoops()).allMatch(TriggerSchedulingLoop::isRunning)
+            );
+
+            // THEN
+            Set<Integer> loopAssignments = scheduler.schedulingLoops()
+                .stream()
+                .flatMap(loop -> loop.assignments().stream())
+                .collect(Collectors.toSet());
+            assertThat(loopAssignments).isEqualTo(scheduler.currentVNodesAssignment());
+        }
+    }
+
+    @Test
+    void shouldAssignAllVNodesToSchedulingLoopsWhenMaxThreadsIsGreaterThanAssignedVNodes() {
+        // GIVEN
+        try (DefaultScheduler scheduler1 = createDefaultScheduler();
+            DefaultScheduler scheduler2 = createDefaultScheduler();
+            DefaultScheduler scheduler3 = createDefaultScheduler();) {
+            scheduler1.start(8);
+            scheduler2.start(8);
+            scheduler3.start(8);
+            serviceLivenessStore.put(scheduler1);
+            serviceLivenessStore.put(scheduler2);
+            serviceLivenessStore.put(scheduler3);
+
+            // WHEN
+            vNodeController.checkServicesAndRebalanceVNodes();
+
+            // THEN
+            List.of(scheduler1, scheduler2, scheduler3).forEach(scheduler ->
+            {
+                Set<Integer> loopAssignments = scheduler.schedulingLoops()
+                    .stream()
+                    .flatMap(loop -> loop.assignments().stream())
+                    .collect(Collectors.toSet());
+                assertThat(loopAssignments).isEqualTo(scheduler.currentVNodesAssignment());
+            });
+        }
+    }
+
     private TriggerScheduler newTriggerScheduler() {
         return new TriggerScheduler(
             triggerStateStore,


### PR DESCRIPTION
### ✨ Description

Fixes the scheduler going silent after a maintenance-mode cycle.

Entering maintenance mode revokes the per-loop vNode assignments (`stopAllSchedulingLoop` calls `setAssignments(Set.of())` on every loop), but exiting it only resubmitted the loops. Since a maintenance toggle triggers no vNodes rebalance — `VNodeController` deliberately keeps `MAINTENANCE` schedulers in the active set — `onVNodesAssigned` never fires again and the assignments are never recomputed. The result:

- every scheduling-loop restarts with an empty assignment set, so `TriggerScheduler.onSchedule` is never called and already-registered triggers stop firing;
- `startTriggerEventConsumers` builds its vNode→loop map from those empty assignments while still subscribing with the full `currentVNodesAssignment`, so every trigger event is dropped with `Received trigger events for a non assigned vNode [N]. Event skipped.` — which is why newly saved flows never register;
- the service still reports `RUNNING`, so nothing looks wrong until the server is restarted (a restart changes cluster membership → rebalance → assignments restored).

This PR extracts the distribution into `assignVNodesToSchedulingLoops()` and restores it before restarting the scheduling on maintenance exit.

It also fixes a second orphaning bug in the same code: assignments were distributed with `vNodeId % maxThreads` while only `min(maxThreads, vNodes.size())` loops exist, so any vNode whose modulo exceeded the loop count got no loop at all — silently unscheduled, same `non assigned vNode` error. This hits HA clusters where a scheduler is assigned fewer vNodes than it has threads, with no maintenance mode involved. The distribution now uses the number of loops that effectively exist.

### 🔗 Related Issue

Closes https://github.com/kestra-io/kestra-ee/issues/10013

### 🛠️ Backend Checklist

- [x] Code compiles successfully and passes all checks
- [x] All unit and integration tests pass

### 📝 Additional Notes

Two regression tests added to `DefaultSchedulerTest`, both failing before the change:

- `shouldRestoreVNodesAssignmentsOnSchedulingLoopsWhenExitingMaintenanceMode` — was `expected: [0..15] but was: []`
- `shouldAssignAllVNodesToSchedulingLoopsWhenMaxThreadsIsGreaterThanAssignedVNodes` — was `expected: [13, 15] but was: []`

The existing `shouldStopAndRestartSchedulingLoopWhenEnteringAndExitingMaintenanceMode` passed throughout because it only asserted the loops were *running*, never that they were *assigned*.

`./gradlew :scheduler:test` → 114 passing.

Out of scope, noticed while investigating:

- `shouldStopAndRestartSchedulingLoopWhenEnteringAndExitingMaintenanceMode` takes ~30s, pre-existing (measured at 31.6s on `develop` with this fix stashed). It sits in `doStop()`'s `executorService.awaitTermination(30, SECONDS)` and terminates gracefully afterwards, so something in the pool only finishes at the timeout boundary. Worth its own look.
- `stopAllConsumers()` disposes the consumer disposables but never clears the list, so it gains one already-disposed entry per maintenance cycle. Harmless (`Disposable` is idempotent), left alone to keep this diff surgical.

### 🤖 AI Authors

Why did the scheduler cat stop chasing triggers after its nap? It woke up with zero vNodes assigned — no mice in its territory, so it just sat there purring `RUNNING` at 50ms intervals. 🐱
