### PR TITLE
fix(execution): loop sub-executions should not compute flow outputs

### DIFF
--- a/core/src/test/java/io/kestra/plugin/core/flow/FlowOutputTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/flow/FlowOutputTest.java
@@ -2,6 +2,7 @@ package io.kestra.plugin.core.flow;
 
 import java.util.List;
 
+import io.kestra.core.repositories.ExecutionRepositoryInterface;
 import org.junit.jupiter.api.Test;
 
 import io.kestra.core.exceptions.InternalException;
@@ -13,12 +14,16 @@ import io.kestra.core.services.ExecutionOutputService;
 
 import jakarta.inject.Inject;
 
+import static io.kestra.core.utils.Rethrow.throwPredicate;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @KestraTest(startRunner = true)
 class FlowOutputTest {
     @Inject
     private ExecutionOutputService executionOutputService;
+
+    @Inject
+    private ExecutionRepositoryInterface executionRepository;
 
     @Test
     @ExecuteFlow(value = "flows/valids/flow-with-outputs.yml", tenantId = "shouldgetsuccessexecutionforflowwithoutputs")
@@ -56,5 +61,18 @@ class FlowOutputTest {
     @ExecuteFlow(value = "flows/valids/flow-with-outputs.yml", tenantId = "shouldnotstoreoutputsinsidetheexecution")
     void shouldNotStoreOutputsInsideTheExecution(Execution execution) {
         assertThat(execution.getOutputs()).isNull();
+    }
+
+    @Test
+    @ExecuteFlow(value = "flows/valids/flow-with-outputs-with-loop.yml", tenantId = "loopexecutionsshouldnotcomputeoutputs")
+    void loopExecutionsShouldNotComputeOutputs(Execution execution) throws InternalException {
+        assertThat(executionOutputService.getOutputs(execution)).hasSize(1);
+
+        // 2 loop sub-executions, one per iteration, all in SUCCESS without outputs
+        List<Execution> subExecutions = executionRepository.findLoopSubExecutions(execution.getTenantId(), execution.getId(), null);
+        assertThat(subExecutions).hasSize(2);
+        assertThat(subExecutions).allMatch(e -> e.getState().getCurrent() == State.Type.SUCCESS);
+        assertThat(subExecutions).allMatch(throwPredicate(e -> executionOutputService.getOutputs(e) == null));
+
     }
 }

--- a/core/src/test/resources/flows/valids/flow-with-outputs-with-loop.yml
+++ b/core/src/test/resources/flows/valids/flow-with-outputs-with-loop.yml
@@ -1,0 +1,22 @@
+id: flow-with-outputs-with-loop
+namespace: io.kestra.tests
+
+tasks:
+  - id: loop
+    type: io.kestra.plugin.core.flow.Loop
+    values:
+      - a
+      - b
+    tasks:
+      - id: inner
+        type: io.kestra.plugin.core.log.Log
+        message: "iteration {{ item.value }}"
+
+  - id: after_loop
+    type: io.kestra.plugin.core.debug.Return
+    format: done
+
+outputs:
+  - id: out
+    type: STRING
+    value: "{{ outputs.after_loop.value }}"

--- a/executor/src/main/java/io/kestra/executor/ExecutorService.java
+++ b/executor/src/main/java/io/kestra/executor/ExecutorService.java
@@ -461,7 +461,7 @@ public class ExecutorService {
         Execution newExecution = executor.getExecution()
             .withState(finalState);
 
-        if (flow.getOutputs() != null) {
+        if (flow.getOutputs() != null && executor.getExecution().getKind() != ExecutionKind.LOOP) {
             RunContext runContext = runContextFactory.of(executor.getFlow(), executor.getExecution());
             var inputAndOutput = runContext.inputAndOutput();
 


### PR DESCRIPTION
As they are only the loop sub-tasks execution.

Fixes https://github.com/kestra-io/kestra-ee/issues/10038
