### PR TITLE
test(flows): guard the Dependencies tab against the single-dependency off-by-one

### DIFF
--- a/ui/src/components/flows/composables/useFlowRoot.ts
+++ b/ui/src/components/flows/composables/useFlowRoot.ts
@@ -8,7 +8,7 @@ import {useRouteTabsStore} from "../../../stores/routeTabs"
 import {useAuthStore} from "override/stores/auth"
 import {useMiscStore} from "override/stores/misc"
 import {useActiveTab} from "../../../composables/useActiveTab"
-import {FLOW_PARENT_ROUTE, FLOW_TAB_ROUTES, isFlowTabAllowed} from "../flowTabs"
+import {dependenciesTabMeta, FLOW_PARENT_ROUTE, FLOW_TAB_ROUTES, isFlowTabAllowed} from "../flowTabs"
 
 export function useFlowRoot() {
     const {t} = useI18n()
@@ -64,12 +64,7 @@ export function useFlowRoot() {
                     title: t(meta.title as string),
                     locked: meta.locked as boolean | undefined,
                     // Dependencies surfaces a live count and is disabled when there are none.
-                    ...(name === "dependencies"
-                        ? {
-                            count: (dependenciesCount.value ?? 0) > 0 ? dependenciesCount.value : undefined,
-                            disabled: !dependenciesCount.value,
-                        }
-                        : {}),
+                    ...(name === "dependencies" ? dependenciesTabMeta(dependenciesCount.value) : {}),
                 }
             })
     })

--- a/ui/src/components/flows/flowTabs.ts
+++ b/ui/src/components/flows/flowTabs.ts
@@ -30,6 +30,22 @@ export function isFlowTabAllowed(tabName: string, ctx: {user: any; namespace: st
     }
 }
 
+/**
+ * Badge + disabled state of the Dependencies tab, derived from the flow's dependency count.
+ *
+ * `count` is the number of *other* flows the topology links to this one, so the flow's own
+ * node is already excluded by the store (see `loadDependencies`). Subtracting it a second
+ * time here left every flow with exactly one dependency showing a count of 0, which read as
+ * "no dependencies" and greyed the tab out - see kestra-io/kestra-ee#10028. Shared with
+ * kestra-ee's `FlowRoot.vue`, which builds the same tab bar.
+ */
+export function dependenciesTabMeta(count: number | undefined): {count?: number; disabled: boolean} {
+    return {
+        count: (count ?? 0) > 0 ? count : undefined,
+        disabled: !count,
+    }
+}
+
 /** localStorage key remembering the user's preferred default tab (see BasicSettings.vue), used as the redirect fallback below. */
 const DEFAULT_TAB_STORAGE_KEY = "flowDefaultTab"
 

--- a/ui/tests/unit/components/flows/flowDependenciesTab.spec.ts
+++ b/ui/tests/unit/components/flows/flowDependenciesTab.spec.ts
@@ -1,0 +1,98 @@
+import {beforeEach, describe, expect, it, vi} from "vitest"
+import {createPinia, setActivePinia} from "pinia"
+
+import {dependenciesTabMeta} from "../../../../src/components/flows/flowTabs"
+
+const flowDependencies = vi.fn()
+
+vi.mock("nprogress", () => ({
+    start: vi.fn(),
+    done: vi.fn(),
+    set: vi.fn(),
+    inc: vi.fn(),
+}))
+
+vi.mock("vue-router", () => ({
+    useRoute: () => ({query: {}, params: {}}),
+    useRouter: () => ({
+        push: vi.fn(),
+        replace: vi.fn(),
+        beforeEach: vi.fn(),
+        afterEach: vi.fn(),
+    }),
+}))
+
+vi.mock("@kestra-io/kestra-sdk", () => ({
+    useClient: () => ({
+        get: vi.fn(),
+        post: vi.fn(),
+        put: vi.fn(),
+        patch: vi.fn(),
+        delete: vi.fn(),
+    }),
+}))
+
+vi.mock("@kestra-io/kestra-sdk/flows", () => ({
+    flowDependencies: (...args: any[]) => flowDependencies(...args),
+}))
+
+vi.mock("@kestra-io/design-system", async (importOriginal) => {
+    const actual = await importOriginal<typeof import("@kestra-io/design-system")>()
+    const KsNotification = Object.assign(vi.fn(), {closeAll: vi.fn()})
+    return {...actual, KsMessageBox: vi.fn(), KsNotification}
+})
+
+// The payload GET /flows/{namespace}/{id}/dependencies returns for the pair from
+// kestra-io/kestra-ee#10028: `submit_to_ray` has a flow trigger on `preprocess_video`.
+// It is the same graph whichever of the two flows is asked about - the topology row is
+// stored once, and the endpoint matches it as either source or destination.
+const ONE_DEPENDENCY_GRAPH = {
+    nodes: [
+        {uid: "main_solutions.ai_preprocess_video", namespace: "solutions.ai", id: "preprocess_video"},
+        {uid: "main_solutions.ai_submit_to_ray", namespace: "solutions.ai", id: "submit_to_ray"},
+    ],
+    edges: [
+        {
+            source: "main_solutions.ai_preprocess_video",
+            target: "main_solutions.ai_submit_to_ray",
+            relation: "FLOW_TRIGGER",
+        },
+    ],
+}
+
+describe("dependenciesTabMeta", () => {
+    it("keeps the tab reachable for a flow with a single dependency", () => {
+        // Regression guard for kestra-io/kestra-ee#10028: the count the store exposes already
+        // excludes the flow's own node, so 1 means "one other flow" - not "nothing to show".
+        expect(dependenciesTabMeta(1)).toEqual({count: 1, disabled: false})
+    })
+
+    it("disables the tab and hides the badge when the flow has no dependency", () => {
+        expect(dependenciesTabMeta(0)).toEqual({count: undefined, disabled: true})
+    })
+
+    it("disables the tab while the count has not been fetched yet", () => {
+        expect(dependenciesTabMeta(undefined)).toEqual({count: undefined, disabled: true})
+    })
+})
+
+describe("flow store dependency count", () => {
+    beforeEach(() => {
+        setActivePinia(createPinia())
+        flowDependencies.mockReset()
+    })
+
+    it("counts the other flows of the topology, from either end of the edge", async () => {
+        flowDependencies.mockResolvedValue(ONE_DEPENDENCY_GRAPH)
+        const {useFlowStore} = await import("../../../../src/stores/flow")
+        const store = useFlowStore()
+
+        for (const id of ["preprocess_video", "submit_to_ray"]) {
+            const {count} = await store.loadDependencies({namespace: "solutions.ai", id, subtype: "FLOW"}, true)
+
+            expect(count, `dependency count returned for ${id}`).toBe(1)
+            expect(store.dependenciesCount, `dependency count stored for ${id}`).toBe(1)
+            expect(dependenciesTabMeta(store.dependenciesCount).disabled, `Dependencies tab disabled for ${id}`).toBe(false)
+        }
+    })
+})


### PR DESCRIPTION
Closes kestra-io/kestra-ee#10028.

## What the reporter saw

On 2.0.0-rc8, `solutions.ai.submit_to_ray` has a flow trigger on `solutions.ai.preprocess_video`. The child's **Dependencies** tab works; the parent's is greyed out with a 🚫 cursor.

## What is actually going on

Not a backend issue. A topology edge is stored once and the endpoint matches it as either source or destination, so both flows get the same graph. Verified against a local server with exactly the reporter's pair:

```
GET /api/v1/main/flows/solutions.ai/preprocess_video/dependencies
GET /api/v1/main/flows/solutions.ai/submit_to_ray/dependencies
# both -> 2 nodes, 1 edge (FLOW_TRIGGER)
```

The tab was disabled by the frontend count arithmetic. The store already excludes the flow's own node (`nodes - 1` -> `1`), and the tab badge subtracted it **again**:

```ts
count: (dependenciesCount.value ?? 0) > 0 ? dependenciesCount.value - 1 : 0
```

So any flow with exactly one dependency landed on `0` -> `disabled: true`. That also explains the asymmetry in the screenshot: the child had two dependencies, so it survived the extra subtraction and showed a badge of `1` next to a `2 Dependencies` toolbar stat reading the same store value.

The extra subtraction was removed in #18162 (shipped in v2.0.0-rc9), so the reported symptom is already gone on `develop` and on `releases/v2.0.x`.

## What this PR adds

The regression guard that was missing, plus one home for the derivation:

- `dependenciesTabMeta(count)` in `flowTabs.ts`, next to `isFlowTabAllowed` — kestra-ee's `FlowRoot.vue` builds the same tab bar and carries its own copy of these two lines, which is how the two can drift apart again.
- `useFlowRoot` uses it.
- `ui/tests/unit/components/flows/flowDependenciesTab.spec.ts` — asserts a single dependency keeps the tab reachable, and that the store's count for the reporter's exact API payload is `1` from either end of the edge. Re-introducing the rc8 arithmetic fails both.

Follow-up (EE): point `ui-ee/src/components/flows/FlowRoot.vue` at the same helper so the copy disappears.

## Tests

`npm run test:unit` — 192 files, 1825 tests, green. `npm run check:types` and eslint clean.
