### PR TITLE
fix(executions): wait for all WorkingDirectory subtasks before terminating the flowable

### DIFF
--- a/core/src/main/java/io/kestra/plugin/core/flow/WorkingDirectory.java
+++ b/core/src/main/java/io/kestra/plugin/core/flow/WorkingDirectory.java
@@ -8,6 +8,7 @@ import java.time.Duration;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 import java.util.zip.ZipOutputStream;
@@ -33,6 +34,7 @@ import io.kestra.core.models.tasks.VoidOutput;
 import io.kestra.core.runners.*;
 import io.kestra.core.serializers.FileSerde;
 import io.kestra.core.utils.IdUtils;
+import io.kestra.core.utils.ListUtils;
 import io.kestra.core.utils.NamespaceFilesUtils;
 import io.kestra.core.validations.WorkingDirectoryTaskValidation;
 
@@ -240,6 +242,16 @@ public class WorkingDirectory extends Sequential implements NamespaceFilesInterf
 
         // resolve to no next tasks as the worker will execute all tasks
         return Collections.emptyList();
+    }
+
+    @Override
+    public Optional<State.Type> resolveState(RunContext runContext, Execution execution, TaskRun parentTaskRun) throws IllegalVariableEvaluationException {
+        // subtasks run inside the Worker and each reports through its own queue message, so a failed
+        // subtask must not terminate the WorkingDirectory while a sibling's terminal result is still in flight
+        boolean hasInFlightSubtask = ListUtils.emptyOnNull(execution.getTaskRunList()).stream()
+            .anyMatch(taskRun -> parentTaskRun.getId().equals(taskRun.getParentTaskRunId()) && !taskRun.getState().isTerminated());
+
+        return hasInFlightSubtask ? Optional.empty() : super.resolveState(runContext, execution, parentTaskRun);
     }
 
     public WorkerTask workerTask(TaskRun parent, Task task, RunContext runContext) {

--- a/core/src/test/java/io/kestra/plugin/core/flow/WorkingDirectoryTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/flow/WorkingDirectoryTest.java
@@ -10,6 +10,7 @@ import java.time.Duration;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -48,6 +49,7 @@ import io.kestra.core.storages.InternalStorage;
 import io.kestra.core.storages.NamespaceFactory;
 import io.kestra.core.storages.StorageContext;
 import io.kestra.core.storages.StorageInterface;
+import io.kestra.plugin.core.debug.Return;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.inject.Inject;
@@ -119,6 +121,77 @@ public class WorkingDirectoryTest {
     @LoadFlows({ "flows/valids/working-directory-namespace-files-with-namespaces.yaml" })
     void namespaceFilesWithNamespace() throws TimeoutException, IOException, QueueException, URISyntaxException, InternalException {
         suite.namespaceFilesWithNamespaces(runnerUtils);
+    }
+
+    @Test
+    void shouldNotResolveTerminalStateWhenASubtaskIsStillRunning() throws Exception {
+        // Given a WorkingDirectory whose subtasks run inside the Worker and report through independent
+        // queue messages: t4 has already failed but t3's terminal (SUCCESS) result hasn't been joined yet
+        WorkingDirectory workingDirectory = fourSubtasksWorkingDirectory();
+        TaskRun parentTaskRun = TaskRun.builder().id("worker-run").taskId("worker").state(new State()).build();
+        RunContext runContext = runContextFactory.of(workingDirectory, Map.of());
+
+        Execution execution = Execution.builder()
+            .taskRunList(List.of(
+                parentTaskRun,
+                childTaskRun(parentTaskRun, "t1", State.Type.SUCCESS),
+                childTaskRun(parentTaskRun, "t2", State.Type.SUCCESS),
+                childTaskRun(parentTaskRun, "t3", State.Type.RUNNING),
+                childTaskRun(parentTaskRun, "t4", State.Type.FAILED)
+            ))
+            .build();
+
+        // When resolving the state while t3 is still RUNNING
+        Optional<State.Type> resolvedState = workingDirectory.resolveState(runContext, execution, parentTaskRun);
+
+        // Then it must not terminate yet
+        assertThat(resolvedState).isEmpty();
+    }
+
+    @Test
+    void shouldResolveFailedWhenAllSubtasksHaveTerminatedAndOneFailed() throws Exception {
+        // Given a WorkingDirectory whose subtasks have all reported their terminal result, t4 among them FAILED
+        WorkingDirectory workingDirectory = fourSubtasksWorkingDirectory();
+        TaskRun parentTaskRun = TaskRun.builder().id("worker-run").taskId("worker").state(new State()).build();
+        RunContext runContext = runContextFactory.of(workingDirectory, Map.of());
+
+        Execution execution = Execution.builder()
+            .taskRunList(List.of(
+                parentTaskRun,
+                childTaskRun(parentTaskRun, "t1", State.Type.SUCCESS),
+                childTaskRun(parentTaskRun, "t2", State.Type.SUCCESS),
+                childTaskRun(parentTaskRun, "t3", State.Type.SUCCESS),
+                childTaskRun(parentTaskRun, "t4", State.Type.FAILED)
+            ))
+            .build();
+
+        // When resolving the state now that every subtask has terminated
+        Optional<State.Type> resolvedState = workingDirectory.resolveState(runContext, execution, parentTaskRun);
+
+        // Then the WorkingDirectory resolves to FAILED as t4 failed
+        assertThat(resolvedState).contains(State.Type.FAILED);
+    }
+
+    private static WorkingDirectory fourSubtasksWorkingDirectory() {
+        return WorkingDirectory.builder()
+            .id("worker")
+            .type(WorkingDirectory.class.getName())
+            .tasks(List.of(
+                Return.builder().id("t1").type(Return.class.getName()).format(Property.ofValue("first")).build(),
+                Return.builder().id("t2").type(Return.class.getName()).format(Property.ofValue("second")).build(),
+                Return.builder().id("t3").type(Return.class.getName()).format(Property.ofValue("third")).build(),
+                Return.builder().id("t4").type(Return.class.getName()).format(Property.ofValue("fourth")).build()
+            ))
+            .build();
+    }
+
+    private static TaskRun childTaskRun(TaskRun parentTaskRun, String taskId, State.Type state) {
+        return TaskRun.builder()
+            .id(taskId + "-run")
+            .taskId(taskId)
+            .parentTaskRunId(parentTaskRun.getId())
+            .state(new State().withState(state))
+            .build();
     }
 
     @Test


### PR DESCRIPTION
## Summary
- A `WorkingDirectory` runs all its subtasks inside the Worker; each subtask reports its terminal result through an independent queue message. When one subtask failed, `WorkingDirectory` (inherited from `Sequential`/`FlowableUtils.resolveState`) could resolve to a terminal state as soon as it saw that failure, without checking whether a sibling's terminal message had already been joined. The executor then force-marked that still-non-terminal sibling to the parent's terminal state, discarding its real outcome and outputs.
- This surfaced as a rare flake in `WorkingDirectoryTest` (`namespaceFiles`/`namespaceFilesWithNamespace`, missing output for a task that actually succeeded), reproduced on CI independently of and prior to PR #18237 (e.g. run 32038144489 on `refactor/compact-2.0-migrations`, a day before that PR's branch existed) — so it's an unrelated pre-existing bug, not something introduced by #18237.
- Adds a `resolveState` override on `WorkingDirectory` that defers to `Optional.empty()` while any child taskrun is still non-terminal, so the flowable only resolves once every reported subtask has actually finished.

## Test plan
- [x] `./gradlew :core:test --tests "io.kestra.plugin.core.flow.WorkingDirectoryTest"` — 14/14 passing, including two new unit tests (`shouldNotResolveTerminalStateWhenASubtaskIsStillRunning`, `shouldResolveFailedWhenAllSubtasksHaveTerminatedAndOneFailed`) exercising the new guard directly
- [x] `./gradlew :core:test --tests "io.kestra.plugin.core.flow.SequentialTest" --tests "io.kestra.plugin.core.flow.AllowFailureTest" --tests "io.kestra.plugin.core.flow.ParallelTest" --tests "io.kestra.plugin.core.flow.DagTest" --tests "io.kestra.core.runners.FlowableUtilsTest"` — all passing, no regression on sibling flowables
- [x] `./gradlew :jdbc-h2:test --tests "io.kestra.runner.h2.H2RunnerTest"` — 99/99 passing (executor contract, per repo guidelines for executor-behavior changes)