### PR TITLE
fix(ui): name the request that 404ed on the not-found page

### DIFF
--- a/ui/src/components/basicauth/BasicAuthLogin.vue
+++ b/ui/src/components/basicauth/BasicAuthLogin.vue
@@ -148,6 +148,7 @@
     const handleSubmit = async () => {
         try {
             coreStore.error = undefined
+            coreStore.failedRequest = undefined
             if (!form.value || isLoading.value) return
             if (!(await form.value.validate().catch(() => false))) return
 

--- a/ui/src/components/errors/Errors.vue
+++ b/ui/src/components/errors/Errors.vue
@@ -8,6 +8,11 @@
             <span v-html="$t('errors.' + code + '.content')" />
         </p>
 
+        <p v-if="failedRequest" class="failed-request">
+            <code>{{ failedRequest.method }} {{ failedRequest.url }}</code>
+            <span v-if="failedRequest.message">{{ failedRequest.message }}</span>
+        </p>
+
         <KsButton v-if="!isFullScreen()" tag="router-link" :to="{name: 'home'}" type="primary" size="large">
             {{ $t("back_to_dashboard") }}
         </KsButton>
@@ -33,6 +38,8 @@
     const coreStore = useCoreStore()
     const route = useRoute()
 
+    const failedRequest = computed(() => coreStore.failedRequest)
+
     const routeInfo = computed(() => ({title: t("errors." + props.code + ".title")}))
 
     useRouteContext(routeInfo)
@@ -45,6 +52,7 @@
         () => route.fullPath,
         () => {
             coreStore.error = undefined
+            coreStore.failedRequest = undefined
         },
     )
 </script>
@@ -64,5 +72,17 @@
     p {
         line-height: 22px;
         font-size: var(--ks-font-size-sm);
+    }
+
+    .failed-request {
+        display: flex;
+        flex-direction: column;
+        gap: 0.25rem;
+        color: var(--ks-content-secondary);
+
+        code {
+            font-family: var(--bs-font-monospace);
+            word-break: break-all;
+        }
     }
 </style>

--- a/ui/src/components/flows/blueprints/BlueprintsBrowser.vue
+++ b/ui/src/components/flows/blueprints/BlueprintsBrowser.vue
@@ -306,7 +306,10 @@
             emit("loaded")
         } catch {
             if (props.embed) error.value = true
-            else coreStore.error = 404
+            else {
+                coreStore.error = 404
+                coreStore.failedRequest = undefined
+            }
         }
     }
 

--- a/ui/src/stores/core.ts
+++ b/ui/src/stores/core.ts
@@ -5,9 +5,17 @@ import {Message} from "../components/ErrorToast.vue"
 import {TUTORIAL_NAMESPACE} from "../utils/constants"
 import {Flow} from "./flow"
 
+export interface FailedRequest {
+    status: number
+    method: string
+    url: string
+    message?: string
+}
+
 export const useCoreStore = defineStore("core", () => {
     const message = ref<Message>()
     const error = ref<any>()
+    const failedRequest = ref<FailedRequest>()
 
     async function readTutorialFlows() {
         const flows = await FlowsAPI.listFlowsByNamespace({namespace: TUTORIAL_NAMESPACE}) as Flow[]
@@ -17,6 +25,7 @@ export const useCoreStore = defineStore("core", () => {
     return {
         message,
         error,
+        failedRequest,
         readTutorialFlows,
     }
 })

--- a/ui/src/utils/kestraHttp.ts
+++ b/ui/src/utils/kestraHttp.ts
@@ -50,11 +50,32 @@ export interface KestraHttpError extends Error {
 
 export interface KestraHttpOptions {
     router?: Router
-    coreStore?: {message: unknown; error: unknown}
+    coreStore?: {message: unknown; error: unknown; failedRequest?: unknown}
     beforeLogout?: () => void
     isLoggedIn?: () => boolean
     onError?: (type: "message" | "error", error: unknown) => void
     onUnauthorized?: (navigateToLogin: () => void, error: KestraHttpError) => Promise<boolean> | boolean | void
+}
+
+function sameOriginPath(url: string): string {
+    try {
+        const parsed = new URL(url, window.location.origin)
+        return parsed.origin === window.location.origin ? parsed.pathname + parsed.search : url
+    } catch {
+        return url
+    }
+}
+
+function failedRequestOf(error: KestraHttpError) {
+    const response = error.response
+    if (!response) return undefined
+    const serverMessage = (response.data as {message?: unknown} | undefined)?.message
+    return {
+        status: response.status,
+        method: (response.config.method || "GET").toUpperCase(),
+        url: sameOriginPath(response.config.url ?? ""),
+        message: typeof serverMessage === "string" ? serverMessage : undefined,
+    }
 }
 
 export function setupKestraHttp(
@@ -77,6 +98,7 @@ export function setupKestraHttp(
                 }
             } else {
                 coreStore.error = kestraError.response?.status
+                coreStore.failedRequest = failedRequestOf(kestraError)
             }
         },
         onUnauthorized = (navigate: () => void) => {

--- a/ui/tests/unit/utils/kestraHttp.spec.ts
+++ b/ui/tests/unit/utils/kestraHttp.spec.ts
@@ -65,3 +65,53 @@ describe("setupKestraHttp router NProgress hooks", () => {
         expect(nprogressDone).toHaveBeenCalledTimes(1)
     })
 })
+
+describe("setupKestraHttp 404 diagnostics", () => {
+    type ErrorInterceptor = (error: any, response: any, request: any, opts?: any) => any
+
+    const captureErrorInterceptor = (coreStore: Record<string, unknown>): ErrorInterceptor => {
+        fakeClient.interceptors.error.use.mockClear()
+        setupKestraHttp({}, {coreStore: coreStore as any})
+        return fakeClient.interceptors.error.use.mock.calls.at(-1)![0] as ErrorInterceptor
+    }
+
+    const missingFlowPath = "/api/v1/main/flows/my.namespace/missing"
+    const missingFlowUrl = window.location.origin + missingFlowPath
+
+    const notFoundResponse = {
+        status: 404,
+        statusText: "Not Found",
+        url: missingFlowUrl,
+        headers: {forEach: () => {}},
+    }
+
+    const notFoundRequest = {
+        method: "get",
+        url: missingFlowUrl,
+    }
+
+    it("records the request that 404ed so the error page can name it", () => {
+        const coreStore: Record<string, unknown> = {}
+        const onError = captureErrorInterceptor(coreStore)
+
+        onError(Object.assign(new Error("Not Found"), {status: 404}), notFoundResponse, notFoundRequest)
+
+        expect(coreStore.error).toBe(404)
+        expect(coreStore.failedRequest).toEqual({
+            status: 404,
+            method: "GET",
+            url: missingFlowPath,
+            message: "Not Found",
+        })
+    })
+
+    it("leaves the error page untouched when the caller handles the 404 itself", () => {
+        const coreStore: Record<string, unknown> = {}
+        const onError = captureErrorInterceptor(coreStore)
+
+        onError(Object.assign(new Error("Not Found"), {status: 404}), notFoundResponse, notFoundRequest, {ignoreNotFound: true})
+
+        expect(coreStore.error).toBeUndefined()
+        expect(coreStore.failedRequest).toBeUndefined()
+    })
+})


### PR DESCRIPTION
Any fetch returning 404 swaps the whole page for a generic "Page not found", hiding which call actually failed (#9755).

The failed request now travels through the core store and is rendered under the message as `GET /api/v1/main/flows/ns/missing` plus the server message — no behaviour change to *when* the page takes over, and no new translation keys.

Unit tests cover both the recorded 404 and the `ignoreNotFound` opt-out.