### PR TITLE
fix(worker): exclude the dialect JDBC repositories from a worker context

### DIFF
--- a/cli/src/test/java/io/kestra/cli/commands/servers/WorkerServerContextTest.java
+++ b/cli/src/test/java/io/kestra/cli/commands/servers/WorkerServerContextTest.java
@@ -10,6 +10,8 @@ import org.junit.jupiter.api.io.TempDir;
 
 import io.kestra.cli.Kestra;
 import io.kestra.core.migration.MigrationStartupRunner;
+import io.kestra.core.repositories.FlowRepositoryInterface;
+import io.kestra.repository.h2.H2Repository;
 
 import io.micronaut.context.ApplicationContext;
 import io.micronaut.context.env.Environment;
@@ -55,6 +57,18 @@ class WorkerServerContextTest {
 
             // Then no pool was built from it.
             assertThat(ctx.containsBean(DataSource.class)).isFalse();
+        }
+    }
+
+    @Test
+    void shouldNotRegisterARepositoryOnWorker() {
+        // Given the test configuration declares `kestra.repository.type: h2`, as a shared configuration would.
+        try (ApplicationContext ctx = workerContext("server", "worker")) {
+            assertThat(ctx.getEnvironment().getProperty("kestra.repository.type", String.class)).contains("h2");
+
+            // Then neither the repositories nor the dialect beans backing them were registered.
+            assertThat(ctx.containsBean(FlowRepositoryInterface.class)).isFalse();
+            assertThat(ctx.containsBean(H2Repository.class)).isFalse();
         }
     }
 

--- a/jdbc-h2/src/main/java/io/kestra/repository/h2/H2Repository.java
+++ b/jdbc-h2/src/main/java/io/kestra/repository/h2/H2Repository.java
@@ -23,6 +23,7 @@ import lombok.SneakyThrows;
 import static io.kestra.jdbc.repository.AbstractJdbcRepository.KEY_FIELD;
 
 @Requires(condition = H2Repository.H2Condition.class)
+@Requires(property = "kestra.server-type", notEquals = "WORKER")
 @EachBean(JdbcTableConfig.class)
 public class H2Repository<T> extends io.kestra.jdbc.AbstractJdbcRepository<T> {
 

--- a/jdbc-mysql/src/main/java/io/kestra/repository/mysql/MysqlRepository.java
+++ b/jdbc-mysql/src/main/java/io/kestra/repository/mysql/MysqlRepository.java
@@ -32,6 +32,7 @@ import jakarta.inject.Inject;
 
 @SuppressWarnings("this-escape")
 @Requires(condition = MysqlRepository.MysqlCondition.class)
+@Requires(property = "kestra.server-type", notEquals = "WORKER")
 @EachBean(JdbcTableConfig.class)
 public class MysqlRepository<T> extends AbstractJdbcRepository<T> {
 

--- a/jdbc-postgres/src/main/java/io/kestra/repository/postgres/PostgresRepository.java
+++ b/jdbc-postgres/src/main/java/io/kestra/repository/postgres/PostgresRepository.java
@@ -34,6 +34,7 @@ import static io.kestra.jdbc.repository.AbstractJdbcRepository.KEY_FIELD;
 import static io.kestra.jdbc.repository.AbstractJdbcRepository.VALUE_FIELD;
 
 @Requires(condition = PostgresRepository.PostgresCondition.class)
+@Requires(property = "kestra.server-type", notEquals = "WORKER")
 @EachBean(JdbcTableConfig.class)
 public class PostgresRepository<T> extends io.kestra.jdbc.AbstractJdbcRepository<T> {
 


### PR DESCRIPTION
### ✨ Description

A worker deployed as a dedicated service owns no repository, and its application context already drops every datasource. Domain repositories carry `@RepositoryBean`, which keeps them out of a worker, but the three `@EachBean(JdbcTableConfig)` dialect repositories — `PostgresRepository`, `H2Repository`, `MysqlRepository` — are gated by their own `@Requires(condition = …)` and stayed registered. Anything resolving one on a worker reached `JooqDSLContextWrapper` and died on the missing `DataSource`.

They cannot carry `@RepositoryBean` itself: it bundles `@Singleton`, which conflicts with `@EachBean`, so they get the server-type condition directly.

### 🔗 Related Issue

Related to https://github.com/kestra-io/kestra-ee/issues/10067 — closed by the companion EE PR, see the note below.

### 🛠️ Backend Checklist

- [x] Code compiles successfully and passes all checks
- [x] All unit and integration tests pass — `WorkerServerContextTest`, `ServerCommandValidatorTest`

### 📝 Additional Notes

- **Companion PR:** kestra-io/kestra-ee, branch `fix/worker-repository-beans` (same name).
- `WorkerServerContextTest.shouldNotRegisterARepositoryOnWorker` was sanity-checked by removing the condition again: it fails on the `H2Repository` assertion, so it does guard the change.
- **Scope:** on its own this is hygiene rather than the fix for the linked issue. With `kestra.secret.type=jdbc` it turns the reported `DependencyInjectionException` into a missing-bean condition; what makes that actionable, and what makes the configuration work, lives in the EE PR. Its value here is that a worker context is now free of repository beans whatever the backend, so `containsBean(...)` guards behave uniformly.
