### PR TITLE
fix(dashboards): keep table dates on one line and show the full value on hover [merge 1/2]

### DIFF
--- a/ui/src/components/dashboard/sections/table/columns/Date.spec.ts
+++ b/ui/src/components/dashboard/sections/table/columns/Date.spec.ts
@@ -1,0 +1,43 @@
+import {describe, expect, it, vi} from "vitest"
+import {mount} from "@vue/test-utils"
+import {defineComponent} from "vue"
+import moment from "moment"
+import DateColumn from "./Date.vue"
+
+vi.mock("@kestra-io/design-system", () => ({
+    KsTooltip: defineComponent({
+        name: "KsTooltip",
+        props: {content: {type: String, default: undefined}},
+        template: "<span data-test=\"tooltip\" :data-content=\"content\"><slot /></span>",
+    }),
+}))
+
+const FIELD = "2026-07-24T13:16:00.000Z"
+const absolute = () => moment(FIELD).format("llll")
+
+describe("dashboard table Date column", () => {
+    it("should render the absolute date with a tooltip carrying the full value", () => {
+        const wrapper = mount(DateColumn, {props: {field: FIELD}})
+
+        const tooltip = wrapper.find("[data-test=tooltip]")
+        expect(tooltip.exists()).toBe(true)
+        expect(tooltip.attributes("data-content")).toBe(absolute())
+        expect(wrapper.find("span.date").text()).toBe(absolute())
+    })
+
+    it("should render the relative date with the absolute value in the tooltip", () => {
+        const wrapper = mount(DateColumn, {props: {field: FIELD, relative: true}})
+
+        const tooltip = wrapper.find("[data-test=tooltip]")
+        expect(tooltip.exists()).toBe(true)
+        expect(tooltip.attributes("data-content")).toBe(absolute())
+        expect(wrapper.find("span.date").text()).toBe(moment(FIELD).calendar(null, {sameElse: "L [at] LT"}))
+    })
+
+    it("should render nothing when there is no field", () => {
+        const wrapper = mount(DateColumn, {props: {}})
+
+        expect(wrapper.find("[data-test=tooltip]").exists()).toBe(false)
+        expect(wrapper.text()).toBe("")
+    })
+})

--- a/ui/src/components/dashboard/sections/table/columns/Date.vue
+++ b/ui/src/components/dashboard/sections/table/columns/Date.vue
@@ -1,8 +1,7 @@
 <template>
-    <KsTooltip v-if="props.relative && date" :content="absolute">
-        <span>{{ date }}</span>
+    <KsTooltip v-if="date" :content="absolute">
+        <span class="date">{{ date }}</span>
     </KsTooltip>
-    <span v-else>{{ date }}</span>
 </template>
 
 <script setup lang="ts">
@@ -37,3 +36,14 @@
         props.field ? moment(props.field).format(format) : undefined,
     )
 </script>
+
+<style scoped lang="scss">
+    .date {
+        display: inline-block;
+        max-width: 100%;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+        vertical-align: bottom;
+    }
+</style>


### PR DESCRIPTION
Closes https://github.com/kestra-io/kestra-ee/issues/9845.

**Merge order: 1 of 2** - merge this PR before its sibling https://github.com/kestra-io/kestra/pull/18299, which relies on the tooltip recovery introduced here.

## What

In dashboard `Table` charts, absolute dates (e.g. the Start Date column of the default dashboard's Executions panel) rendered as a bare `span`: in narrow columns the value wrapped onto two lines, doubling the row height so fewer rows fit the fixed 240px viewport, and the full value could not be recovered on hover.

`Date.vue` now wraps every date in the same `KsTooltip` that relative dates (`NEXT_EXECUTION_DATE`) already had, with the tooltip carrying the full formatted value, and renders the cell value `nowrap` with ellipsis truncation. Rows keep a single-line height and a truncated date is always recoverable on hover.

Covered by a new unit test asserting the tooltip content for both the absolute and the relative branch, plus the empty-field case.