### PR TITLE
fix(ui): add bottom margin to new flow landing page (#18285)

### DIFF
--- a/ui/src/components/flows/create/ImportYaml.vue
+++ b/ui/src/components/flows/create/ImportYaml.vue
@@ -134,7 +134,7 @@
         display: flex;
         flex-direction: column;
         gap: var(--ks-spacing-4);
-        padding: var(--ks-spacing-6) var(--ks-spacing-4);
+        padding: var(--ks-spacing-6) var(--ks-spacing-4) 0;
         width: 100%;
         max-width: 48rem;
         margin: 0 auto;
@@ -210,5 +210,6 @@
     .import-actions {
         display: flex;
         justify-content: flex-end;
+        margin-bottom: var(--ks-spacing-6);
     }
 </style>

--- a/ui/src/components/flows/create/NewFlowLanding.vue
+++ b/ui/src/components/flows/create/NewFlowLanding.vue
@@ -197,7 +197,7 @@
         display: flex;
         flex-direction: column;
         align-items: center;
-        padding: var(--ks-spacing-8) var(--ks-spacing-4);
+        padding: var(--ks-spacing-8) var(--ks-spacing-4) 0;
         min-height: 100%;
     }
 
@@ -223,6 +223,7 @@
         gap: var(--ks-spacing-4);
         width: 100%;
         max-width: 36rem;
+        margin-bottom: var(--ks-spacing-8);
     }
 
     .primary-card-body {


### PR DESCRIPTION
✨ Description
Fixed an issue on the new flow landing page (NewFlowLanding.vue) and YAML import page (ImportYaml.vue) where the bottom card action touched the bottom edge of the screen without bottom margin/padding when scrolling on smaller screens (e.g. 15.6" laptop screens at 100% zoom).

Added margin-bottom: var(--ks-spacing-8) to .landing-body and adjusted .new-flow-landing container padding in NewFlowLanding.vue.
Added margin-bottom: var(--ks-spacing-6) to .import-actions and adjusted .import-yaml container padding in ImportYaml.vue.
This ensures that block-level margin is preserved during flexbox overflow scroll in WebKit/Blink browsers, guaranteeing proper bottom spacing below the last card element.
🔗 Related Issue
Closes https://github.com/kestra-io/kestra/issues/18285

🎨 Frontend Checklist
 Code builds without errors (npm run build)
 All existing E2E tests pass (npm run test:e2e)
 Screenshots or video recordings attached showing the UI changes
📝 Additional Notes

- **Technical Context**: Modern WebKit/Blink browsers collapse flex container `padding-bottom` when the parent container (`main`) scrolls overflow content. Shifting the bottom spacing to a `margin-bottom` on the child block elements (`.landing-body` and `.import-actions`) ensures the bottom spacing is explicitly included in the scrollHeight calculation across all browsers.
- **Layout Compatibility**: On larger viewports where content fits without scrolling, `min-height: 100%` on `.new-flow-landing` continues to stretch smoothly without double padding.



🤖 AI Authors
Why was the cat sitting on the computer keyboard?
Because it wanted to keep an eye on the mouse! 🐱


