### PR TITLE
fix(dashboards): give namespace and flow columns more width in dashboard tables [merge 2/2]

### DIFF
--- a/ui/src/components/dashboard/sections/Table.vue
+++ b/ui/src/components/dashboard/sections/Table.vue
@@ -28,6 +28,7 @@
                         :key
                         :label="value.displayName || key"
                         :width="value.field === 'STATE' ? 140 : undefined"
+                        :minWidth="ENTITY_LINK_FIELDS.includes(value.field) ? 140 : undefined"
                     >
                         <template #default="scope">
                             <template v-if="resolvedComponent(value.field) === undefined">
@@ -82,6 +83,9 @@
     const route = useRoute()
 
     const containerID = `${props.chart.id}__${Math.random()}`
+
+    // Identifier columns get a larger share of the flexible width so namespace and flow ids stay readable; dates truncate recoverably behind their tooltip.
+    const ENTITY_LINK_FIELDS = ["NAMESPACE", "FLOW_ID"]
 
     const hasIdColumn = computed(() =>
         Object.values(props.chart.data?.columns ?? {}).some((c: any) => c?.field === "ID"),


### PR DESCRIPTION
Closes https://github.com/kestra-io/kestra-ee/issues/9846.

**Merge order: 2 of 2** - merge https://github.com/kestra-io/kestra/pull/18297 first. The two PRs are code-independent (this one only touches `Table.vue`), but shrinking the date columns is only acceptable once truncated dates are hover-recoverable, which that PR introduces.

## What

In dashboard `Table` charts every flexible column got an equal share of the panel width, so in the half-width Executions and Next Executions panels the Namespace and Flow identifiers were truncated after a few characters while short values (relative dates, 8-char execution ids) kept room they did not need.

The identifier columns (`NAMESPACE`, `FLOW_ID`) now declare `min-width: 140`, so Element Plus distributes the flexible space in their favour in every dashboard table. Date columns shrink instead, which stays recoverable because of the ellipsis + tooltip treatment from https://github.com/kestra-io/kestra/pull/18297.

Note: https://github.com/kestra-io/kestra-ee/issues/9485 (moving the per-row entity icons into the column header) is a pending design decision and stays open; this PR only rebalances the widths and does not pre-empt it.