### PR TITLE
fix(tests): disable Micronaut embedded gPRC server

### DIFF
--- a/repository-memory/src/test/resources/application-test.yml
+++ b/repository-memory/src/test/resources/application-test.yml
@@ -12,3 +12,9 @@ kestra:
     liveness:
       enabled: false
     termination-grace-period: 5s
+# Disable Micronaut embedded gRPC server and health check
+grpc:
+  server:
+    enabled: false
+    health:
+      enabled: false

--- a/runner-memory/src/test/resources/application-test.yml
+++ b/runner-memory/src/test/resources/application-test.yml
@@ -16,3 +16,9 @@ kestra:
     liveness:
       enabled: false
     termination-grace-period: 5s
+# Disable Micronaut embedded gRPC server and health check
+grpc:
+  server:
+    enabled: false
+    health:
+      enabled: false

--- a/storage-local/src/test/resources/application-test.yml
+++ b/storage-local/src/test/resources/application-test.yml
@@ -7,3 +7,9 @@ kestra:
     type: memory
   queue:
     type: memory
+# Disable Micronaut embedded gRPC server and health check
+grpc:
+  server:
+    enabled: false
+    health:
+      enabled: false


### PR DESCRIPTION
It sometimes fails to bind when test modules are run concurrently leading to test initialization failures
