### PR TITLE
fix(dashboards): default the custom range end date time to now instead of midnight

### DIFF
--- a/ui/packages/design-system/src/components/Data/KsDataTable/filter/layout/FilterSelect.vue
+++ b/ui/packages/design-system/src/components/Data/KsDataTable/filter/layout/FilterSelect.vue
@@ -45,6 +45,7 @@
                 <KsDatePicker
                     v-model="local.endDateValue"
                     type="datetime"
+                    :defaultTime="endDateDefaultTime"
                     :placeholder="$t('filter.select_end_date')"
                 />
             </div>
@@ -94,6 +95,9 @@
     }>()
 
     const {modelValue, timeRangeMode, startDateValue, endDateValue, dateFilterMode} = toRefs(props)
+
+    // Without a default time, picking a day in the end date panel pre-fills 00:00:00, which excludes the whole selected day; default the time part to now so picking today covers up to the current time.
+    const endDateDefaultTime = new Date()
 
     const local = reactive({
         value: modelValue.value,

--- a/ui/packages/design-system/tests/units/Data/KsFilter/FilterSelect.test.ts
+++ b/ui/packages/design-system/tests/units/Data/KsFilter/FilterSelect.test.ts
@@ -1,0 +1,42 @@
+import {describe, test, expect} from "vitest"
+import {mount} from "@vue/test-utils"
+import {createI18n} from "vue-i18n"
+import KestraDesignSystem from "../../../../src/index"
+import FilterSelect from "../../../../src/components/Data/KsDataTable/filter/layout/FilterSelect.vue"
+import KsDatePicker from "../../../../src/components/Form/KsDatePicker.vue"
+
+const i18n = createI18n({legacy: false, locale: "en", messages: {en: {}}})
+const globalConfig = {plugins: [i18n, KestraDesignSystem]}
+
+const mountCustomTimeRange = () => mount(FilterSelect, {
+    props: {
+        modelValue: "",
+        options: [],
+        filterKey: {key: "timeRange"},
+        timeRangeMode: "custom",
+    },
+    global: globalConfig,
+})
+
+describe("FilterSelect custom time range", () => {
+    test("defaults the end date picker time part to now instead of midnight", () => {
+        const before = Date.now()
+        const wrapper = mountCustomTimeRange()
+        const after = Date.now()
+
+        const pickers = wrapper.findAllComponents(KsDatePicker)
+        expect(pickers).toHaveLength(2)
+
+        const endDefaultTime = pickers[1].vm.$attrs.defaultTime as Date
+        expect(endDefaultTime).toBeInstanceOf(Date)
+        expect(endDefaultTime.getTime()).toBeGreaterThanOrEqual(before)
+        expect(endDefaultTime.getTime()).toBeLessThanOrEqual(after)
+    })
+
+    test("leaves the start date picker without a default time so it keeps defaulting to midnight", () => {
+        const wrapper = mountCustomTimeRange()
+
+        const pickers = wrapper.findAllComponents(KsDatePicker)
+        expect(pickers[0].vm.$attrs.defaultTime).toBeUndefined()
+    })
+})


### PR DESCRIPTION
Closes https://github.com/kestra-io/kestra/issues/17325.

## What

In the dashboard `Interval` filter's `Custom Range` mode, picking a day as the End Date pre-filled the time with `00:00:00`, so selecting the current day silently excluded all of today's data unless the user edited the time by hand.

The End Date picker now passes Element Plus's native `default-time` with the moment the filter editor was opened, so picking today defaults the range end to the current time, as suggested in the issue and confirmed by Ben. The Start Date picker keeps defaulting to midnight, which is the correct lower bound.

## Why the end picker only

For a range start, midnight is the desired default (covers the day from its beginning). For a range end, midnight excludes the entire selected day - today most visibly, since the rest of the day is where the recent data lives.

## Testing

- New unit tests for `FilterSelect` assert the end picker receives a fresh `default-time` and the start picker does not.
- Verified in the running app: `Interval` -> `Custom Range` -> clicking today as End Date pre-fills the current time in the panel, and the applied filter's `endDate` carries the current time instead of `00:00:00`.