### PR TITLE
fix(dashboards): default the custom range end date time to now instead of midnight (1.3 backport)

### DIFF
--- a/ui/src/components/filter/components/layout/FilterSelect.vue
+++ b/ui/src/components/filter/components/layout/FilterSelect.vue
@@ -39,6 +39,7 @@
                 <el-date-picker
                     v-model="local.endDateValue"
                     type="datetime"
+                    :defaultTime="endDateDefaultTime"
                     :placeholder="$t('filter.select_end_date')"
                 />
             </div>
@@ -88,6 +89,9 @@
     }>();
 
     const {modelValue, timeRangeMode, startDateValue, endDateValue, dateFilterMode} = toRefs(props);
+
+    // Without a default time, picking a day in the end date panel pre-fills 00:00:00, which excludes the whole selected day; default the time part to now so picking today covers up to the current time.
+    const endDateDefaultTime = new Date();
 
     const local = reactive({
         value: modelValue.value,

--- a/ui/tests/unit/filter/filterSelect.spec.ts
+++ b/ui/tests/unit/filter/filterSelect.spec.ts
@@ -1,0 +1,45 @@
+import {describe, expect, test} from "vitest"
+import {mount} from "@vue/test-utils"
+import {createI18n} from "vue-i18n"
+import ElementPlus, {ElDatePicker} from "element-plus"
+import FilterSelect from "../../../src/components/filter/components/layout/FilterSelect.vue"
+
+const globalConfig = {
+    plugins: [
+        createI18n({legacy: false, locale: "en", fallbackWarn: false, missingWarn: false, globalInjection: true}),
+        ElementPlus,
+    ],
+}
+
+const mountCustomTimeRange = () => mount(FilterSelect, {
+    props: {
+        modelValue: "",
+        options: [],
+        filterKey: {key: "timeRange"},
+        timeRangeMode: "custom",
+    },
+    global: globalConfig,
+})
+
+describe("FilterSelect custom time range", () => {
+    test("defaults the end date picker time part to now instead of midnight", () => {
+        const before = Date.now()
+        const wrapper = mountCustomTimeRange()
+        const after = Date.now()
+
+        const pickers = wrapper.findAllComponents(ElDatePicker)
+        expect(pickers).toHaveLength(2)
+
+        const endDefaultTime = pickers[1].props("defaultTime") as Date
+        expect(endDefaultTime).toBeInstanceOf(Date)
+        expect(endDefaultTime.getTime()).toBeGreaterThanOrEqual(before)
+        expect(endDefaultTime.getTime()).toBeLessThanOrEqual(after)
+    })
+
+    test("leaves the start date picker without a default time so it keeps defaulting to midnight", () => {
+        const wrapper = mountCustomTimeRange()
+
+        const pickers = wrapper.findAllComponents(ElDatePicker)
+        expect(pickers[0].props("defaultTime")).toBeUndefined()
+    })
+})


### PR DESCRIPTION
Closes https://github.com/kestra-io/kestra/issues/17325.
Related to https://github.com/kestra-io/kestra/pull/18305.

## What

1.3 backport of https://github.com/kestra-io/kestra/pull/18305 (the issue was reported on 1.3.27). Same fix, applied to the pre-design-system filter that 1.3 still uses (`ui/src/components/filter/components/layout/FilterSelect.vue`).

In the dashboard `Interval` filter's `Custom Range` mode, picking a day as the End Date pre-filled the time with `00:00:00`, so selecting the current day silently excluded all of today's data unless the user edited the time by hand. The End Date picker now passes Element Plus's native `default-time` with the moment the filter editor was opened, so picking today defaults the range end to the current time. The Start Date picker keeps defaulting to midnight, which is the correct lower bound.

## Testing

- New unit tests assert the end picker receives a fresh `default-time` and the start picker does not.
- `check:types` and `eslint` clean on the branch.
- The identical change on develop was verified live in the running app (end date panel pre-fills the current time; the applied filter's `endDate` carries the current time instead of `00:00:00`).