### PR TITLE
refactor(iam): rename the SUPER_ADMIN query filter to INSTANCE_OWNER

### DIFF
--- a/core/src/main/java/io/kestra/core/models/QueryFilter.java
+++ b/core/src/main/java/io/kestra/core/models/QueryFilter.java
@@ -496,8 +496,8 @@ public record QueryFilter(
                 return List.of();
             }
         },
-        @JsonProperty("super_admin")
-        SUPER_ADMIN("super_admin") {
+        @JsonProperty("instance_owner")
+        INSTANCE_OWNER("instance_owner") {
             @Override
             public List<Op> supportedOp() {
                 return List.of(Op.EQUALS);
@@ -622,7 +622,7 @@ public record QueryFilter(
         USER {
             @Override
             public List<Field> supportedField() {
-                return List.of(Field.QUERY, Field.USERNAME, Field.GROUP, Field.NAME, Field.TYPE, Field.SUPER_ADMIN);
+                return List.of(Field.QUERY, Field.USERNAME, Field.GROUP, Field.NAME, Field.TYPE, Field.INSTANCE_OWNER);
             }
         },
         ROLE {
@@ -634,7 +634,7 @@ public record QueryFilter(
         INVITATION {
             @Override
             public List<Field> supportedField() {
-                return List.of(Field.QUERY, Field.EMAIL, Field.STATUS, Field.EXPIRED_AT, Field.SUPER_ADMIN);
+                return List.of(Field.QUERY, Field.EMAIL, Field.STATUS, Field.EXPIRED_AT, Field.INSTANCE_OWNER);
             }
 
             @Override

--- a/core/src/test/java/io/kestra/core/models/QueryFilterTest.java
+++ b/core/src/test/java/io/kestra/core/models/QueryFilterTest.java
@@ -457,7 +457,7 @@ public class QueryFilterTest {
             ),
 
             buildQueryFiltersForOperations(
-                Field.SUPER_ADMIN, Resource.USER,
+                Field.INSTANCE_OWNER, Resource.USER,
                 Set.of(
                     Op.EQUALS
                 )
@@ -555,7 +555,7 @@ public class QueryFilterTest {
             ),
 
             buildQueryFiltersForOperations(
-                Field.SUPER_ADMIN, Resource.INVITATION,
+                Field.INSTANCE_OWNER, Resource.INVITATION,
                 Set.of(
                     Op.EQUALS
                 )
@@ -1482,7 +1482,7 @@ public class QueryFilterTest {
             ),
 
             buildQueryFiltersForOperations(
-                Field.SUPER_ADMIN, Resource.INVITATION,
+                Field.INSTANCE_OWNER, Resource.INVITATION,
                 Set.of(
                     Op.NOT_EQUALS,
                     Op.GREATER_THAN,

--- a/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcRepository.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcRepository.java
@@ -351,8 +351,8 @@ public abstract class AbstractJdbcRepository {
             return getEnabledCondition(value, operation);
         }
 
-        if (field == QueryFilter.Field.SUPER_ADMIN) {
-            return getSuperAdminCondition(value, operation);
+        if (field == QueryFilter.Field.INSTANCE_OWNER) {
+            return getInstanceOwnerCondition(value, operation);
         }
 
         if (field == QueryFilter.Field.STATUS) {
@@ -556,8 +556,8 @@ public abstract class AbstractJdbcRepository {
         return defaultHandlers(QueryFilter.Field.ENABLED, value, operation);
     }
 
-    protected Condition getSuperAdminCondition(Object value, Op operation) {
-        throw new InvalidQueryFiltersException("getSuperAdminCondition must be overridden for JSONB-backed superAdmin field");
+    protected Condition getInstanceOwnerCondition(Object value, Op operation) {
+        throw new InvalidQueryFiltersException("getInstanceOwnerCondition must be overridden for JSONB-backed instanceOwner field");
     }
 
     protected Condition tagsCondition(Object value, QueryFilter.Op operation) {

--- a/jdbc/src/test/java/io/kestra/jdbc/repository/AbstractJdbcRepositoryTest.java
+++ b/jdbc/src/test/java/io/kestra/jdbc/repository/AbstractJdbcRepositoryTest.java
@@ -33,7 +33,7 @@ class AbstractJdbcRepositoryTest extends AbstractJdbcRepository {
         QueryFilter.Field.NAME,
         QueryFilter.Field.TAGS,
         QueryFilter.Field.ATTEMPT_NUMBER,
-        QueryFilter.Field.SUPER_ADMIN,
+        QueryFilter.Field.INSTANCE_OWNER,
         QueryFilter.Field.LOCKED,
         QueryFilter.Field.LAST_TRIGGERED_DATE,
         QueryFilter.Field.NEXT_EXECUTION_DATE,


### PR DESCRIPTION
Renames the `SUPER_ADMIN` query filter field (wire value `super_admin`) to `INSTANCE_OWNER` (`instance_owner`) and the `AbstractJdbcRepository.getSuperAdminCondition` hook to `getInstanceOwnerCondition`, aligning the generic filter framework with the Enterprise `superAdmin` → `instanceOwner` rename.

The filter field is only used by the EE user / service-account / invitation listings; the UI (which ships in lockstep) is the only caller of the wire value.

## Companion
Companion to the Enterprise PR kestra-io/kestra-ee#10109, which renames the instance-ownership flag `superAdmin` → `instanceOwner` (issue kestra-io/kestra-ee#10069). This OSS change must merge together with it.
