### PR TITLE
feat(triggers): add timezone support to flow trigger daily windows

### DIFF
--- a/core/src/main/java/io/kestra/core/models/triggers/TimeWindow.java
+++ b/core/src/main/java/io/kestra/core/models/triggers/TimeWindow.java
@@ -2,14 +2,22 @@ package io.kestra.core.models.triggers;
 
 import java.time.Duration;
 import java.time.LocalTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.temporal.ChronoUnit;
+
+import org.apache.commons.lang3.tuple.Pair;
 
 import io.kestra.core.models.annotations.PluginProperty;
 import io.kestra.core.validations.TimeWindowValidation;
+import io.kestra.core.validations.TimezoneId;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.With;
+
+import static io.kestra.core.models.triggers.TimeWindow.Type.DURATION_WINDOW;
 
 @Getter
 @Builder
@@ -67,6 +75,72 @@ public class TimeWindow {
     )
     @PluginProperty
     private LocalTime endTime;
+
+    @Schema(
+        title = "The timezone used to resolve the daily deadline, start and end times",
+        description = "Defaults to the server timezone. Set a time-zone ID such as `Europe/Paris` so that daily windows follow the intended zone, including daylight-saving transitions."
+    )
+    @PluginProperty
+    @TimezoneId
+    private String timezone;
+
+    /** The zone in which the daily deadline, start and end times are resolved; the server default when unset. */
+    public ZoneId zoneId() {
+        return timezone != null ? ZoneId.of(timezone) : ZoneId.systemDefault();
+    }
+
+    /**
+     * Computes the concrete start/end instants of this window relative to {@code now}.
+     * <p>
+     * Always resolves in {@link #zoneId()} regardless of {@code now}'s own zone -- {@code now} is
+     * re-expressed in that zone first. The two {@code DAILY_*} types then resolve
+     * {@code deadline}/{@code startTime}/{@code endTime} with a null preferred offset (via
+     * {@link ZonedDateTime#of} and {@link java.time.LocalDate#atStartOfDay(ZoneId)}), so the
+     * result depends only on the date, the configured time and the zone -- never on what offset
+     * {@code now} itself happens to carry across a daylight-saving transition.
+     */
+    public Pair<ZonedDateTime, ZonedDateTime> boundaries(ZonedDateTime now) {
+        ZoneId zone = zoneId();
+        now = now.withZoneSameInstant(zone);
+        Type resolvedType = type != null ? type : DURATION_WINDOW;
+
+        return switch (resolvedType) {
+            case DURATION_WINDOW -> {
+                Duration windowDuration = window == null ? Duration.ofDays(1) : window;
+                if (windowDuration.toDays() > 0) {
+                    now = now.withHour(0);
+                }
+
+                if (windowDuration.toHours() > 0) {
+                    now = now.withMinute(0);
+                }
+
+                if (windowDuration.toMinutes() > 0) {
+                    now = now.withSecond(0)
+                        .withMinute(0)
+                        .plusMinutes(windowDuration.toMinutes() * (now.getMinute() / windowDuration.toMinutes()));
+                }
+
+                ZonedDateTime startWindow = windowAdvance == null ? now : now.plus(windowAdvance).truncatedTo(ChronoUnit.MILLIS);
+                yield Pair.of(
+                    startWindow,
+                    startWindow.plus(windowDuration).minus(Duration.ofMillis(1)).truncatedTo(ChronoUnit.MILLIS)
+                );
+            }
+            case SLIDING_WINDOW -> Pair.of(
+                now.truncatedTo(ChronoUnit.MILLIS),
+                now.truncatedTo(ChronoUnit.MILLIS).plus(window == null ? Duration.ofDays(1) : window)
+            );
+            case DAILY_TIME_WINDOW -> Pair.of(
+                ZonedDateTime.of(now.toLocalDate(), startTime, zone).truncatedTo(ChronoUnit.MILLIS),
+                ZonedDateTime.of(now.toLocalDate(), endTime, zone).truncatedTo(ChronoUnit.MILLIS)
+            );
+            case DAILY_TIME_DEADLINE -> Pair.of(
+                now.toLocalDate().atStartOfDay(zone),
+                ZonedDateTime.of(now.toLocalDate(), deadline, zone).truncatedTo(ChronoUnit.MILLIS)
+            );
+        };
+    }
 
     public enum Type {
         DAILY_TIME_DEADLINE,

--- a/core/src/main/java/io/kestra/core/models/triggers/Window.java
+++ b/core/src/main/java/io/kestra/core/models/triggers/Window.java
@@ -4,6 +4,7 @@ import java.time.Duration;
 import java.time.LocalTime;
 
 import io.kestra.core.models.annotations.PluginProperty;
+import io.kestra.core.validations.TimezoneId;
 import io.kestra.core.validations.WindowValidation;
 
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -22,7 +23,8 @@ import lombok.Getter;
         - `deadline` set: daily time deadline window (conditions must be met before the given time each day).
         - `from` and `to` both set: daily time window (conditions must be met within the given time range each day).
         - `lookback` set: sliding window (conditions must be met within the past duration).
-        - otherwise: duration window (default, conditions must be met within a fixed duration, configurable via `every` and `offset`)."""
+        - otherwise: duration window (default, conditions must be met within a fixed duration, configurable via `every` and `offset`).
+        `deadline`, `from`, `to`, `every` and `offset` are resolved daily/midnight boundaries anchored on `timezone` (defaults to the server timezone); `lookback` is unaffected by `timezone`."""
 )
 public class Window {
     @Schema(
@@ -68,6 +70,14 @@ public class Window {
     private Duration lookback;
 
     @Schema(
+        title = "The timezone used to resolve the daily deadline, start and end times",
+        description = "Defaults to the server timezone. Set a time-zone ID such as `Europe/Paris` so that daily windows follow the intended zone, including daylight-saving transitions. Has no effect on `lookback`."
+    )
+    @PluginProperty
+    @TimezoneId
+    private String timezone;
+
+    @Schema(
         title = "Whether the trigger can fire only once per window",
         description = """
             When `false` (the default), the window state is NOT reset after a successful evaluation, meaning the trigger can fire again within the same window each time conditions are satisfied.
@@ -96,6 +106,7 @@ public class Window {
             return TimeWindow.builder()
                 .type(TimeWindow.Type.DAILY_TIME_DEADLINE)
                 .deadline(deadline)
+                .timezone(timezone)
                 .build();
         }
         if (from != null && to != null) {
@@ -103,18 +114,21 @@ public class Window {
                 .type(TimeWindow.Type.DAILY_TIME_WINDOW)
                 .startTime(from)
                 .endTime(to)
+                .timezone(timezone)
                 .build();
         }
         if (lookback != null) {
             return TimeWindow.builder()
                 .type(TimeWindow.Type.SLIDING_WINDOW)
                 .window(lookback)
+                .timezone(timezone)
                 .build();
         }
         return TimeWindow.builder()
             .type(TimeWindow.Type.DURATION_WINDOW)
             .window(every)
             .windowAdvance(offset)
+            .timezone(timezone)
             .build();
     }
 }

--- a/core/src/main/java/io/kestra/core/models/triggers/multipleflows/MultipleConditionStateStore.java
+++ b/core/src/main/java/io/kestra/core/models/triggers/multipleflows/MultipleConditionStateStore.java
@@ -1,15 +1,11 @@
 package io.kestra.core.models.triggers.multipleflows;
 
-import java.time.Duration;
 import java.time.ZonedDateTime;
-import java.time.temporal.ChronoUnit;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.BiFunction;
-
-import org.apache.commons.lang3.tuple.Pair;
 
 import com.google.common.annotations.VisibleForTesting;
 
@@ -17,8 +13,6 @@ import io.kestra.core.models.executions.Execution;
 import io.kestra.core.models.flows.FlowId;
 import io.kestra.core.models.triggers.TimeWindow;
 import io.kestra.core.runners.TransactionContext;
-
-import static io.kestra.core.models.triggers.TimeWindow.Type.DURATION_WINDOW;
 
 public interface MultipleConditionStateStore {
     Optional<MultipleConditionWindow> get(FlowId flow, String conditionId);
@@ -28,46 +22,10 @@ public interface MultipleConditionStateStore {
     Execution process(FlowId flow, MultipleCondition multipleCondition, Map<String, Object> outputs, BiFunction<TransactionContext, MultipleConditionWindow, Execution> consumer);
 
     default MultipleConditionWindow create(FlowId flow, MultipleCondition multipleCondition, Map<String, Object> outputs) {
-        ZonedDateTime now = ZonedDateTime.now().withNano(0);
         TimeWindow timeWindow = multipleCondition.getTimeWindow() != null ? multipleCondition.getTimeWindow() : TimeWindow.builder().build();
 
-        TimeWindow.Type type = timeWindow.getType() != null ? timeWindow.getType() : DURATION_WINDOW;
-        var startAndEnd = switch (type) {
-            case DURATION_WINDOW -> {
-                Duration window = timeWindow.getWindow() == null ? Duration.ofDays(1) : timeWindow.getWindow();
-                if (window.toDays() > 0) {
-                    now = now.withHour(0);
-                }
-
-                if (window.toHours() > 0) {
-                    now = now.withMinute(0);
-                }
-
-                if (window.toMinutes() > 0) {
-                    now = now.withSecond(0)
-                        .withMinute(0)
-                        .plusMinutes(window.toMinutes() * (now.getMinute() / window.toMinutes()));
-                }
-
-                ZonedDateTime startWindow = timeWindow.getWindowAdvance() == null ? now : now.plus(timeWindow.getWindowAdvance()).truncatedTo(ChronoUnit.MILLIS);
-                yield Pair.of(
-                    startWindow,
-                    startWindow.plus(window).minus(Duration.ofMillis(1)).truncatedTo(ChronoUnit.MILLIS)
-                );
-            }
-            case SLIDING_WINDOW -> Pair.of(
-                now.truncatedTo(ChronoUnit.MILLIS),
-                now.truncatedTo(ChronoUnit.MILLIS).plus(timeWindow.getWindow() == null ? Duration.ofDays(1) : timeWindow.getWindow())
-            );
-            case DAILY_TIME_WINDOW -> Pair.of(
-                now.truncatedTo(ChronoUnit.DAYS).plusSeconds(timeWindow.getStartTime().toSecondOfDay()),
-                now.truncatedTo(ChronoUnit.DAYS).plusSeconds(timeWindow.getEndTime().toSecondOfDay())
-            );
-            case DAILY_TIME_DEADLINE -> Pair.of(
-                now.truncatedTo(ChronoUnit.DAYS),
-                now.truncatedTo(ChronoUnit.DAYS).plusSeconds(timeWindow.getDeadline().toSecondOfDay())
-            );
-        };
+        // boundaries() re-expresses `now` in timeWindow.zoneId() regardless of the zone passed in here
+        var startAndEnd = timeWindow.boundaries(ZonedDateTime.now().withNano(0));
 
         return MultipleConditionWindow.builder()
             .namespace(flow.getNamespace())

--- a/core/src/main/java/io/kestra/plugin/core/trigger/Flow.java
+++ b/core/src/main/java/io/kestra/plugin/core/trigger/Flow.java
@@ -116,7 +116,7 @@ import static io.kestra.core.topologies.FlowTopologyService.SIMULATED_EXECUTION;
         @Example(
             full = true,
             title = """
-                2) Trigger the `silver_layer` flow once the `bronze_layer` flow finishes successfully by 9 AM.
+                2) Trigger the `silver_layer` flow once the `bronze_layer` flow finishes successfully by 9 AM Paris time.
 
                 ```yaml
                 id: bronze_layer
@@ -141,6 +141,7 @@ import static io.kestra.core.topologies.FlowTopologyService.SIMULATED_EXECUTION;
                     type: io.kestra.plugin.core.trigger.Flow
                     window:
                       deadline: "09:00:00"
+                      timezone: Europe/Paris
                     dependsOn:
                       - namespace: company.team
                         flowId: bronze_layer

--- a/core/src/test/java/io/kestra/core/models/triggers/TimeWindowTest.java
+++ b/core/src/test/java/io/kestra/core/models/triggers/TimeWindowTest.java
@@ -1,0 +1,147 @@
+package io.kestra.core.models.triggers;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+
+import org.apache.commons.lang3.tuple.Pair;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class TimeWindowTest {
+    private static final ZoneId PARIS = ZoneId.of("Europe/Paris");
+
+    @Test
+    void shouldFallBackToSystemZoneWhenTimezoneIsNull() {
+        // Given
+        TimeWindow timeWindow = TimeWindow.builder().build();
+
+        // When-Then
+        assertThat(timeWindow.zoneId()).isEqualTo(ZoneId.systemDefault());
+    }
+
+    @Test
+    void shouldResolveConfiguredZone() {
+        // Given
+        TimeWindow timeWindow = TimeWindow.builder().timezone("Asia/Tokyo").build();
+
+        // When-Then
+        assertThat(timeWindow.zoneId()).isEqualTo(ZoneId.of("Asia/Tokyo"));
+    }
+
+    @Test
+    void shouldUseWallClockDeadlineWhenSpringForwardGivenEuropeParis() {
+        // Given: 2025-03-30 is the Paris spring-forward day (23h calendar day)
+        TimeWindow timeWindow = TimeWindow.builder()
+            .type(TimeWindow.Type.DAILY_TIME_DEADLINE)
+            .deadline(LocalTime.of(9, 0))
+            .timezone(PARIS.getId())
+            .build();
+        ZonedDateTime now = ZonedDateTime.of(LocalDate.of(2025, 3, 30), LocalTime.of(0, 30), PARIS);
+
+        // When
+        Pair<ZonedDateTime, ZonedDateTime> boundaries = timeWindow.boundaries(now);
+
+        // Then
+        assertThat(boundaries.getRight().toInstant()).isEqualTo(Instant.parse("2025-03-30T07:00:00Z"));
+        assertThat(boundaries.getRight().toLocalTime()).isEqualTo(LocalTime.of(9, 0));
+        assertThat(Duration.between(boundaries.getLeft(), boundaries.getRight())).isEqualTo(Duration.ofHours(8));
+    }
+
+    @Test
+    void shouldUseWallClockDeadlineWhenFallBackGivenEuropeParis() {
+        // Given: 2025-10-26 is the Paris fall-back day (25h calendar day)
+        TimeWindow timeWindow = TimeWindow.builder()
+            .type(TimeWindow.Type.DAILY_TIME_DEADLINE)
+            .deadline(LocalTime.of(9, 0))
+            .timezone(PARIS.getId())
+            .build();
+        ZonedDateTime now = ZonedDateTime.of(LocalDate.of(2025, 10, 26), LocalTime.of(0, 30), PARIS);
+
+        // When
+        Pair<ZonedDateTime, ZonedDateTime> boundaries = timeWindow.boundaries(now);
+
+        // Then
+        assertThat(boundaries.getRight().toInstant()).isEqualTo(Instant.parse("2025-10-26T08:00:00Z"));
+        assertThat(boundaries.getRight().toLocalTime()).isEqualTo(LocalTime.of(9, 0));
+        assertThat(Duration.between(boundaries.getLeft(), boundaries.getRight())).isEqualTo(Duration.ofHours(10));
+    }
+
+    @Test
+    void shouldShiftForwardWhenDailyTimeFallsInDstGap() {
+        // Given: 02:30 does not exist on the Paris spring-forward day
+        TimeWindow timeWindow = TimeWindow.builder()
+            .type(TimeWindow.Type.DAILY_TIME_DEADLINE)
+            .deadline(LocalTime.of(2, 30))
+            .timezone(PARIS.getId())
+            .build();
+        ZonedDateTime now = ZonedDateTime.of(LocalDate.of(2025, 3, 30), LocalTime.of(0, 0), PARIS);
+
+        // When
+        Pair<ZonedDateTime, ZonedDateTime> boundaries = timeWindow.boundaries(now);
+
+        // Then
+        assertThat(boundaries.getRight()).isEqualTo(ZonedDateTime.of(2025, 3, 30, 3, 30, 0, 0, PARIS));
+    }
+
+    @Test
+    void shouldPickEarlierOffsetWhenDailyTimeIsAmbiguousRegardlessOfWhenCreateRuns() {
+        // Given: 02:30 occurs twice on the Paris fall-back day
+        TimeWindow timeWindow = TimeWindow.builder()
+            .type(TimeWindow.Type.DAILY_TIME_DEADLINE)
+            .deadline(LocalTime.of(2, 30))
+            .timezone(PARIS.getId())
+            .build();
+        ZonedDateTime beforeTransition = ZonedDateTime.of(LocalDate.of(2025, 10, 26), LocalTime.of(0, 10), PARIS);
+        ZonedDateTime afterTransition = ZonedDateTime.of(LocalDate.of(2025, 10, 26), LocalTime.of(10, 0), PARIS);
+
+        // When
+        ZonedDateTime resolvedBefore = timeWindow.boundaries(beforeTransition).getRight();
+        ZonedDateTime resolvedAfter = timeWindow.boundaries(afterTransition).getRight();
+
+        // Then: same instant regardless of the offset `now` happened to carry
+        assertThat(resolvedBefore.toInstant()).isEqualTo(Instant.parse("2025-10-26T00:30:00Z"));
+        assertThat(resolvedAfter.toInstant()).isEqualTo(resolvedBefore.toInstant());
+    }
+
+    @Test
+    void shouldSpanTwentyFiveHoursWhenDailyWindowCoversFallBack() {
+        // Given
+        TimeWindow timeWindow = TimeWindow.builder()
+            .type(TimeWindow.Type.DAILY_TIME_WINDOW)
+            .startTime(LocalTime.MIDNIGHT)
+            .endTime(LocalTime.of(23, 59, 59))
+            .timezone(PARIS.getId())
+            .build();
+        ZonedDateTime now = ZonedDateTime.of(LocalDate.of(2025, 10, 26), LocalTime.of(12, 0), PARIS);
+
+        // When
+        Pair<ZonedDateTime, ZonedDateTime> boundaries = timeWindow.boundaries(now);
+
+        // Then
+        assertThat(Duration.between(boundaries.getLeft(), boundaries.getRight())).isEqualTo(Duration.ofHours(24).plusMinutes(59).plusSeconds(59));
+    }
+
+    @Test
+    void shouldAnchorDurationWindowToMidnightInConfiguredZone() {
+        // Given: `now` is expressed in UTC, but the configured timezone is America/New_York
+        ZoneId newYork = ZoneId.of("America/New_York");
+        TimeWindow timeWindow = TimeWindow.builder()
+            .type(TimeWindow.Type.DURATION_WINDOW)
+            .window(Duration.ofDays(1))
+            .timezone(newYork.getId())
+            .build();
+        ZonedDateTime now = ZonedDateTime.of(LocalDate.of(2025, 6, 15), LocalTime.of(14, 30), ZoneId.of("UTC"));
+
+        // When
+        Pair<ZonedDateTime, ZonedDateTime> boundaries = timeWindow.boundaries(now);
+
+        // Then: the window is anchored to midnight in the configured zone, not in `now`'s own zone
+        assertThat(boundaries.getLeft().toLocalTime()).isEqualTo(LocalTime.MIDNIGHT);
+        assertThat(boundaries.getLeft().getZone()).isEqualTo(newYork);
+    }
+}

--- a/core/src/test/java/io/kestra/core/models/triggers/WindowTest.java
+++ b/core/src/test/java/io/kestra/core/models/triggers/WindowTest.java
@@ -1,0 +1,76 @@
+package io.kestra.core.models.triggers;
+
+import java.time.Duration;
+import java.time.LocalTime;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class WindowTest {
+    private static final String TIMEZONE = "Asia/Tokyo";
+
+    @Test
+    void shouldPropagateTimezoneForDailyTimeDeadline() {
+        // Given
+        Window window = Window.builder().deadline(LocalTime.of(9, 0)).timezone(TIMEZONE).build();
+
+        // When
+        TimeWindow timeWindow = window.toTimeWindow();
+
+        // Then
+        assertThat(timeWindow.getType()).isEqualTo(TimeWindow.Type.DAILY_TIME_DEADLINE);
+        assertThat(timeWindow.getTimezone()).isEqualTo(TIMEZONE);
+    }
+
+    @Test
+    void shouldPropagateTimezoneForDailyTimeWindow() {
+        // Given
+        Window window = Window.builder().from(LocalTime.of(6, 0)).to(LocalTime.of(9, 0)).timezone(TIMEZONE).build();
+
+        // When
+        TimeWindow timeWindow = window.toTimeWindow();
+
+        // Then
+        assertThat(timeWindow.getType()).isEqualTo(TimeWindow.Type.DAILY_TIME_WINDOW);
+        assertThat(timeWindow.getTimezone()).isEqualTo(TIMEZONE);
+    }
+
+    @Test
+    void shouldPropagateTimezoneForSlidingWindow() {
+        // Given
+        Window window = Window.builder().lookback(Duration.ofHours(1)).timezone(TIMEZONE).build();
+
+        // When
+        TimeWindow timeWindow = window.toTimeWindow();
+
+        // Then
+        assertThat(timeWindow.getType()).isEqualTo(TimeWindow.Type.SLIDING_WINDOW);
+        assertThat(timeWindow.getTimezone()).isEqualTo(TIMEZONE);
+    }
+
+    @Test
+    void shouldPropagateTimezoneForDurationWindow() {
+        // Given
+        Window window = Window.builder().every(Duration.ofDays(1)).offset(Duration.ofHours(6)).timezone(TIMEZONE).build();
+
+        // When
+        TimeWindow timeWindow = window.toTimeWindow();
+
+        // Then
+        assertThat(timeWindow.getType()).isEqualTo(TimeWindow.Type.DURATION_WINDOW);
+        assertThat(timeWindow.getTimezone()).isEqualTo(TIMEZONE);
+    }
+
+    @Test
+    void shouldPropagateNullTimezoneWhenNotSet() {
+        // Given
+        Window window = Window.builder().build();
+
+        // When
+        TimeWindow timeWindow = window.toTimeWindow();
+
+        // Then
+        assertThat(timeWindow.getTimezone()).isNull();
+    }
+}

--- a/core/src/test/java/io/kestra/core/models/triggers/multipleflows/AbstractMultipleConditionStateStoreTest.java
+++ b/core/src/test/java/io/kestra/core/models/triggers/multipleflows/AbstractMultipleConditionStateStoreTest.java
@@ -1,7 +1,9 @@
 package io.kestra.core.models.triggers.multipleflows;
 
 import java.time.Duration;
+import java.time.Instant;
 import java.time.LocalTime;
+import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoUnit;
@@ -182,6 +184,52 @@ public abstract class AbstractMultipleConditionStateStoreTest {
         String tenant = TestsUtils.randomTenant(this.getClass().getSimpleName());
 
         Pair<Flow, MultipleCondition> pair = mockFlow(tenant, Window.builder().deadline(LocalTime.now().minusSeconds(1)).build());
+
+        MultipleConditionWindow window = multipleConditionStateStore.create(pair.getKey(), pair.getRight(), Collections.emptyMap());
+        multipleConditionStateStore.save(window.with(ImmutableMap.of("a", true)));
+        assertThat(window.getFlowId()).isEqualTo(pair.getLeft().getId());
+        window = multipleConditionStateStore.create(pair.getKey(), pair.getRight(), Collections.emptyMap());
+
+        assertThat(window.getResults()).isEmpty();
+
+        List<MultipleConditionWindow> expired = multipleConditionStateStore.expired(tenant);
+        assertThat(expired.size()).isEqualTo(1);
+    }
+
+    @Test
+    void dailyTimeDeadline_NonServerTimezone() throws Exception {
+        String tenant = TestsUtils.randomTenant(this.getClass().getSimpleName());
+        ZoneId kolkata = ZoneId.of("Asia/Kolkata");
+
+        Pair<Flow, MultipleCondition> pair = mockFlow(tenant, Window.builder().deadline(LocalTime.now(kolkata).plusSeconds(2)).timezone(kolkata.getId()).build());
+
+        MultipleConditionWindow window = multipleConditionStateStore.create(pair.getKey(), pair.getRight(), Collections.emptyMap());
+        // resolved in the configured zone, before the JDBC round-trip re-expresses it in the JVM's own zone
+        assertThat(window.getEnd().getZone()).isEqualTo(kolkata);
+        Instant expectedEnd = window.getEnd().toInstant();
+
+        multipleConditionStateStore.save(window.with(ImmutableMap.of("a", true)));
+        assertThat(window.getFlowId()).isEqualTo(pair.getLeft().getId());
+        window = multipleConditionStateStore.get(pair.getKey(), pair.getRight().getId()).orElseThrow();
+
+        assertThat(window.getResults().get("a")).isTrue();
+        assertThat(window.getEnd().toInstant()).isEqualTo(expectedEnd);
+
+        List<MultipleConditionWindow> expired = multipleConditionStateStore.expired(tenant);
+        assertThat(expired.size()).isZero();
+
+        Thread.sleep(2005);
+
+        expired = multipleConditionStateStore.expired(tenant);
+        assertThat(expired.size()).isEqualTo(1);
+    }
+
+    @Test
+    void dailyTimeDeadline_NonServerTimezone_Expired() throws Exception {
+        String tenant = TestsUtils.randomTenant(this.getClass().getSimpleName());
+        ZoneId kolkata = ZoneId.of("Asia/Kolkata");
+
+        Pair<Flow, MultipleCondition> pair = mockFlow(tenant, Window.builder().deadline(LocalTime.now(kolkata).minusSeconds(1)).timezone(kolkata.getId()).build());
 
         MultipleConditionWindow window = multipleConditionStateStore.create(pair.getKey(), pair.getRight(), Collections.emptyMap());
         multipleConditionStateStore.save(window.with(ImmutableMap.of("a", true)));

--- a/core/src/test/java/io/kestra/core/validations/TimeWindowValidationTest.java
+++ b/core/src/test/java/io/kestra/core/validations/TimeWindowValidationTest.java
@@ -121,4 +121,21 @@ class TimeWindowValidationTest {
         assertThat(valid.get().getConstraintViolations()).hasSize(1);
         assertThat(valid.get().getMessage()).isEqualTo(": Time window of type `SLIDING_WINDOW` cannot have a deadline.\n");
     }
+
+    @Test
+    void shouldValidateWhenTimezoneIsValid() {
+        var sla = TimeWindow.builder().type(TimeWindow.Type.DAILY_TIME_DEADLINE).deadline(LocalTime.now()).timezone("Europe/Paris").build();
+
+        Optional<ConstraintViolationException> valid = modelValidator.isValid(sla);
+        assertThat(valid.isEmpty()).isTrue();
+    }
+
+    @Test
+    void shouldNotValidateWhenTimezoneIsInvalid() {
+        var sla = TimeWindow.builder().type(TimeWindow.Type.DAILY_TIME_DEADLINE).deadline(LocalTime.now()).timezone("Not/AZone").build();
+
+        Optional<ConstraintViolationException> valid = modelValidator.isValid(sla);
+        assertThat(valid.isEmpty()).isFalse();
+        assertThat(valid.get().getMessage()).contains("is not a valid time-zone ID");
+    }
 }

--- a/core/src/test/java/io/kestra/core/validations/WindowValidationTest.java
+++ b/core/src/test/java/io/kestra/core/validations/WindowValidationTest.java
@@ -149,4 +149,41 @@ class WindowValidationTest {
         // Then
         assertThat(valid.isEmpty()).isTrue();
     }
+
+    @Test
+    void shouldValidateWhenTimezoneIsValid() {
+        // Given
+        var window = Window.builder().deadline(LocalTime.now()).timezone("Europe/Paris").build();
+
+        // When
+        Optional<ConstraintViolationException> valid = modelValidator.isValid(window);
+
+        // Then
+        assertThat(valid.isEmpty()).isTrue();
+    }
+
+    @Test
+    void shouldValidateWhenTimezoneIsAnOffset() {
+        // Given
+        var window = Window.builder().deadline(LocalTime.now()).timezone("+02:00").build();
+
+        // When
+        Optional<ConstraintViolationException> valid = modelValidator.isValid(window);
+
+        // Then
+        assertThat(valid.isEmpty()).isTrue();
+    }
+
+    @Test
+    void shouldNotValidateWhenTimezoneIsInvalid() {
+        // Given
+        var window = Window.builder().deadline(LocalTime.now()).timezone("Not/AZone").build();
+
+        // When
+        Optional<ConstraintViolationException> valid = modelValidator.isValid(window);
+
+        // Then
+        assertThat(valid.isEmpty()).isFalse();
+        assertThat(valid.get().getMessage()).contains("is not a valid time-zone ID");
+    }
 }


### PR DESCRIPTION
## Summary
- Adds a `timezone` property to `Window`/`TimeWindow` so `DAILY_TIME_DEADLINE` and `DAILY_TIME_WINDOW` flow-trigger windows resolve in a configured zone instead of always the server's default zone, mirroring the existing `Schedule.timezone` property.
- Fixes a pre-existing DST bug found while implementing this: the old `truncatedTo(DAYS).plusSeconds(secondOfDay)` computation used instant-based arithmetic across a local-date boundary, so a configured deadline of `09:00` resolved to `10:00` or `08:00` on DST transition days. Daily boundaries now resolve via `ZonedDateTime.of(LocalDate, LocalTime, ZoneId)`, which follows the JDK's documented gap/overlap semantics.
- Extracted the window-boundary computation out of `MultipleConditionStateStore.create()` into a testable `TimeWindow.boundaries(ZonedDateTime now)` method.

Closes #18248

## Test plan
- [x] New `TimeWindowTest` covering zone resolution and DST gap/overlap/span cases (spring-forward, fall-back, ambiguous/non-existent local times)
- [x] New `WindowTest` covering `timezone` propagation through all four `toTimeWindow()` branches
- [x] `WindowValidationTest`/`TimeWindowValidationTest` extended with valid/invalid timezone cases
- [x] `AbstractMultipleConditionStateStoreTest` extended with an `Asia/Kolkata` (half-hour offset) case, run and passing against H2, Postgres, and MySQL — exercising the JDBC generated-column offset parsing that previously had a bug on MySQL
- [x] `H2RunnerTest` run clean (existing regression-guard tests unmodified and passing)
- [x] Code-reviewed; one real issue found and fixed (zone resolution derived from the wrong source), one false-positive nit disproved by compiling without it