### PR TITLE
fix(flows): open the source search preview link at the flow's edit tab

### DIFF
--- a/ui/src/components/flows/SourceSearchPreview.vue
+++ b/ui/src/components/flows/SourceSearchPreview.vue
@@ -27,7 +27,7 @@
                         <KsButton
                             v-if="!replaceMode"
                             tag="router-link"
-                            :to="{path: `/flows/edit/${selection.namespace}/${selection.id}/source`}"
+                            :to="editorLinkTarget"
                         >
                             {{ $t('source_search.open_in_editor') }}
                         </KsButton>
@@ -144,6 +144,7 @@
 <script setup lang="ts">
     import {ref, computed, watch} from "vue"
     import {useI18n} from "vue-i18n"
+    import {useRoute} from "vue-router"
     import {KsEditor} from "@kestra-io/design-system"
     import FileTreeOutline from "vue-material-design-icons/FileTreeOutline.vue"
     import FileDocumentOutline from "vue-material-design-icons/FileDocumentOutline.vue"
@@ -179,6 +180,7 @@
     }>()
 
     const {t} = useI18n()
+    const route = useRoute()
     const flowStore = useFlowStore()
 
     const isLoading = ref(false)
@@ -189,6 +191,14 @@
     const flowSelection = computed(() => props.selection?.type === "flows" ? props.selection : null)
 
     const editorKey = computed(() => flowSelection.value ? `${flowSelection.value.namespace}/${flowSelection.value.id}` : "")
+
+    const editorLinkTarget = computed(() => {
+        if (!flowSelection.value) return {}
+        return {
+            name: "flows/update/edit",
+            params: {tenant: route.params.tenant, namespace: flowSelection.value.namespace, id: flowSelection.value.id},
+        }
+    })
 
     const excludedFromReplaceCount = computed(() => props.excludedFromReplaceCount ?? 0)
 

--- a/ui/src/components/flows/SourceSearchResults.vue
+++ b/ui/src/components/flows/SourceSearchResults.vue
@@ -79,7 +79,7 @@
                                         {{ $t('source_search.replace_all_in_flow') }}
                                     </KsButton>
                                     <router-link
-                                        :to="{path: `/flows/edit/${group.namespace}/${group.id}/source`}"
+                                        :to="editorLinkTarget(group)"
                                         class="result-group-open-link"
                                         :aria-label="$t('source_search.open_flow')"
                                         :title="$t('source_search.open_flow')"
@@ -305,6 +305,7 @@
 
 <script setup lang="ts">
     import {ref, computed, watch, nextTick, type Component} from "vue"
+    import {useRoute} from "vue-router"
     import _escape from "lodash/escape"
     import Lock from "vue-material-design-icons/Lock.vue"
     import FindReplace from "vue-material-design-icons/FindReplace.vue"
@@ -362,6 +363,7 @@
     }>()
 
     const {t} = useI18n()
+    const route = useRoute()
 
     const SECRET_PATTERN = /secret\(\s*['"]([^'"]+)['"]\s*\)/
 
@@ -480,6 +482,13 @@
 
     function groupKey(group: SourceSearchResult) {
         return `flows:${group.namespace}.${group.id}`
+    }
+
+    function editorLinkTarget(group: SourceSearchResult) {
+        return {
+            name: "flows/update/edit",
+            params: {tenant: route.params.tenant, namespace: group.namespace, id: group.id},
+        }
     }
 
     function matchKey(group: SourceSearchResult, match: SourceMatch) {

--- a/ui/tests/storybook/components/SourceSearchPreview.stories.tsx
+++ b/ui/tests/storybook/components/SourceSearchPreview.stories.tsx
@@ -7,6 +7,7 @@ import {useFlowStore} from "../../../src/stores/flow"
 // does not declare, so each story needs them registered or useLink() throws.
 const routes = [
     {path: "/", name: "home", component: {template: "<div />"}},
+    {path: "/flows/edit/:namespace/:id/edit", name: "flows/update/edit", component: {template: "<div />"}},
     {path: "/kv", name: "kv/list", component: {template: "<div />"}},
     {path: "/secrets", name: "secrets/list", component: {template: "<div />"}},
     {path: "/namespaces/edit/:id/files", name: "namespaces/update/files", component: {template: "<div />"}},

--- a/ui/tests/storybook/components/SourceSearchResults.stories.tsx
+++ b/ui/tests/storybook/components/SourceSearchResults.stories.tsx
@@ -1,6 +1,15 @@
 import SourceSearchResults from "../../../src/components/flows/SourceSearchResults.vue"
 import type {Meta, StoryObj} from "@storybook/vue3-vite"
+import {vueRouter} from "storybook-vue3-router"
 import type {SearchResourceType, SearchStatus} from "../../../src/utils/crossResourceSearch"
+
+// Each flow group's "open in editor" link resolves a named route the global preview
+// router does not declare, so it needs to be registered here or useLink() throws.
+const routes = [
+    {path: "/", name: "home", component: {template: "<div />"}},
+    {path: "/flows/edit/:namespace/:id/edit", name: "flows/update/edit", component: {template: "<div />"}},
+    {path: "/:pathMatch(.*)*", name: "catchAll", component: {template: "<div />"}},
+]
 
 const meta: Meta<typeof SourceSearchResults> = {
     title: "flows/SourceSearchResults",
@@ -10,6 +19,7 @@ const meta: Meta<typeof SourceSearchResults> = {
             components: {story: storyFn},
             template: `<div style="height: 600px; width: 480px;"><story /></div>`,
         }),
+        vueRouter(routes, {initialRoute: "/"}),
     ],
 }
 

--- a/ui/tests/unit/components/flows/SourceSearchPreview.spec.ts
+++ b/ui/tests/unit/components/flows/SourceSearchPreview.spec.ts
@@ -57,9 +57,13 @@ vi.mock("@kestra-io/design-system", async (importOriginal) => {
     }
 })
 
+const {mockRoute} = vi.hoisted(() => ({
+    mockRoute: {query: {} as Record<string, unknown>, params: {} as Record<string, unknown>},
+}))
+
 vi.mock("vue-router", () => ({
     useRouter: () => ({push: vi.fn()}),
-    useRoute: () => ({query: {}, params: {}}),
+    useRoute: () => mockRoute,
     RouterLink: {
         template: "<a><slot /></a>",
         props: ["to"],
@@ -71,10 +75,16 @@ import en from "../../../../src/translations/en.json"
 
 const i18n = createI18n({legacy: false, locale: "en", messages: en})
 
+const RouterLinkProbe = {
+    props: ["to"],
+    template: "<a data-test=\"router-link-probe\" :data-to=\"JSON.stringify(to)\"><slot /></a>",
+}
+
 function createGlobal() {
     setActivePinia(createPinia())
     return {
         plugins: [i18n, KestraDesignSystem],
+        stubs: {RouterLink: RouterLinkProbe},
     }
 }
 
@@ -99,6 +109,7 @@ describe("SourceSearchPreview", () => {
         mockRevealLineInCenter.mockReset()
         mockClearDecoration.mockReset()
         mockCreateDecorationsCollection.mockClear()
+        mockRoute.params = {}
     })
 
     test("shows empty state when nothing is selected", async () => {
@@ -278,5 +289,38 @@ describe("SourceSearchPreview", () => {
         await flushPromises()
 
         expect(wrapper.text()).toContain("Never shown or searched")
+    })
+
+    test("points the Open in editor link at the flow's edit tab route with the current tenant", async () => {
+        mockLoadFlow.mockResolvedValue({source: "id: my-flow\nnamespace: ns"})
+        mockRoute.params = {tenant: "acme"}
+
+        const wrapper = mount(SourceSearchPreview, {
+            props: baseProps({selection: {type: "flows", namespace: "ns", id: "my-flow", line: 1, column: 0}, query: ""}),
+            global: createGlobal(),
+        })
+        await flushPromises()
+
+        const link = wrapper.get("[data-test='router-link-probe']")
+        expect(JSON.parse(link.attributes("data-to")!)).toEqual({
+            name: "flows/update/edit",
+            params: {tenant: "acme", namespace: "ns", id: "my-flow"},
+        })
+    })
+
+    test("resolves the Open in editor link without a tenant in OSS single-tenant mode", async () => {
+        mockLoadFlow.mockResolvedValue({source: "id: my-flow\nnamespace: ns"})
+
+        const wrapper = mount(SourceSearchPreview, {
+            props: baseProps({selection: {type: "flows", namespace: "ns", id: "my-flow", line: 1, column: 0}, query: ""}),
+            global: createGlobal(),
+        })
+        await flushPromises()
+
+        const link = wrapper.get("[data-test='router-link-probe']")
+        expect(JSON.parse(link.attributes("data-to")!)).toEqual({
+            name: "flows/update/edit",
+            params: {tenant: undefined, namespace: "ns", id: "my-flow"},
+        })
     })
 })

--- a/ui/tests/unit/components/flows/SourceSearchResults.spec.ts
+++ b/ui/tests/unit/components/flows/SourceSearchResults.spec.ts
@@ -1,4 +1,4 @@
-import {describe, test, expect, vi} from "vitest"
+import {describe, test, expect, vi, beforeEach} from "vitest"
 import {mount, flushPromises} from "@vue/test-utils"
 import {createI18n} from "vue-i18n"
 import KestraDesignSystem from "@kestra-io/design-system"
@@ -8,9 +8,13 @@ import type {NamespaceFileState, KvMatchEntry, SecretMatchEntry, ResourceGroup} 
 import type {SourceSearchResult} from "../../../../src/utils/sourceSearchDiff"
 import en from "../../../../src/translations/en.json"
 
+const {mockRoute} = vi.hoisted(() => ({
+    mockRoute: {query: {} as Record<string, unknown>, params: {} as Record<string, unknown>},
+}))
+
 vi.mock("vue-router", () => ({
     useRouter: () => ({push: vi.fn()}),
-    useRoute: () => ({query: {}, params: {}}),
+    useRoute: () => mockRoute,
     RouterLink: {
         template: "<a><slot /></a>",
         props: ["to"],
@@ -19,8 +23,14 @@ vi.mock("vue-router", () => ({
 
 const i18n = createI18n({legacy: false, locale: "en", messages: en})
 
+const RouterLinkProbe = {
+    props: ["to"],
+    template: "<a :data-to=\"JSON.stringify(to)\"><slot /></a>",
+}
+
 const globalConfig = {
     plugins: [i18n, KestraDesignSystem],
+    stubs: {RouterLink: RouterLinkProbe},
 }
 
 const makeFlowResult = (namespace: string, id: string, snippets: string[], editable = true) => ({
@@ -58,6 +68,10 @@ function mountResults(overrides: Record<string, unknown> = {}) {
 }
 
 describe("SourceSearchResults", () => {
+    beforeEach(() => {
+        mockRoute.params = {}
+    })
+
     test("renders a flow group for each result", async () => {
         const flowsResults = [
             makeFlowResult("company.data", "flow-one", ["line [mark]match[/mark] here"]),
@@ -239,5 +253,30 @@ describe("SourceSearchResults", () => {
         const vm = wrapper.vm as unknown as {collapseAll: () => void; expandAll: () => void}
         expect(() => vm.collapseAll()).not.toThrow()
         expect(() => vm.expandAll()).not.toThrow()
+    })
+
+    test("points the group's open link at the flow's edit tab route with the current tenant", () => {
+        mockRoute.params = {tenant: "acme"}
+        const flowsResults = [makeFlowResult("ns", "flow-id", ["frag"])]
+
+        const wrapper = mountResults({flowsResults})
+
+        const link = wrapper.find("[data-test='source-search-open-link']")
+        expect(JSON.parse(link.attributes("data-to")!)).toEqual({
+            name: "flows/update/edit",
+            params: {tenant: "acme", namespace: "ns", id: "flow-id"},
+        })
+    })
+
+    test("resolves the group's open link without a tenant in OSS single-tenant mode", () => {
+        const flowsResults = [makeFlowResult("ns", "flow-id", ["frag"])]
+
+        const wrapper = mountResults({flowsResults})
+
+        const link = wrapper.find("[data-test='source-search-open-link']")
+        expect(JSON.parse(link.attributes("data-to")!)).toEqual({
+            name: "flows/update/edit",
+            params: {tenant: undefined, namespace: "ns", id: "flow-id"},
+        })
     })
 })


### PR DESCRIPTION
## Summary

- The "Open in editor" link in the Source search preview and results panel (`SourceSearchPreview.vue`, `SourceSearchResults.vue`) built a raw path string (`/flows/edit/<namespace>/<id>/source`), which is missing the `:tenant` segment and points at a `source` tab that doesn't exist, so the link always 404'd.
- Both links now build the target via the named `flows/update/edit` route with `params.tenant` pulled from `useRoute()`, matching the existing pattern in `SubFlowLink.vue`.
- Added unit tests asserting the resolved link target includes the tenant param (or omits it in single-tenant OSS mode) and points at the `edit` tab.

Closes: https://github.com/kestra-io/kestra-ee/issues/10006

## Test plan

- [x] `npm run check:types` (pre-existing unrelated failure in `useTaskRunOutputs.ts`, confirmed present without this change)
- [x] `npm run test:unit` (1830 passed)
- [x] `npm run test:lint` (0 errors)
- [x] `node ui/src/translations/check.js` / `npm run translations:check` (clean, no i18n changes)