### PR TITLE
feat(execution): allow flowable parallel tasks to fail-fast they chil…

### DIFF
--- a/core/src/main/java/io/kestra/core/models/executions/Execution.java
+++ b/core/src/main/java/io/kestra/core/models/executions/Execution.java
@@ -1038,6 +1038,31 @@ public class Execution implements SoftDeletable<Execution>, TenantInterface, Has
             .toList();
     }
 
+    /**
+     * Find every descendant of this {@link TaskRun}, at any depth, in breadth-first order.
+     * Unlike {@link #findChildren(TaskRun)}, which returns only direct children, this walks the
+     * {@code parentTaskRunId} chain recursively.
+     */
+    public List<TaskRun> findAllChildren(TaskRun parentTaskRun) {
+        if (this.taskRunList == null) {
+            return Collections.emptyList();
+        }
+
+        Map<String, List<TaskRun>> childrenByParentId = this.taskRunList.stream()
+            .filter(taskRun -> taskRun.getParentTaskRunId() != null)
+            .collect(Collectors.groupingBy(TaskRun::getParentTaskRunId));
+
+        List<TaskRun> result = new ArrayList<>();
+        Deque<TaskRun> toVisit = new ArrayDeque<>(childrenByParentId.getOrDefault(parentTaskRun.getId(), Collections.emptyList()));
+        while (!toVisit.isEmpty()) {
+            TaskRun current = toVisit.poll();
+            result.add(current);
+            toVisit.addAll(childrenByParentId.getOrDefault(current.getId(), Collections.emptyList()));
+        }
+
+        return result;
+    }
+
     public List<String> findParentsValues(TaskRun taskRun, boolean withCurrent) {
         return (withCurrent ? Stream.concat(findParents(taskRun).stream(), Stream.of(taskRun)) : findParents(taskRun).stream())
             .filter(t -> t.getValue() != null)

--- a/core/src/main/java/io/kestra/core/models/executions/ExecutionKilled.java
+++ b/core/src/main/java/io/kestra/core/models/executions/ExecutionKilled.java
@@ -40,6 +40,7 @@ import lombok.experimental.SuperBuilder;
     {
         @JsonSubTypes.Type(value = ExecutionKilledExecution.class, name = "execution"),
         @JsonSubTypes.Type(value = ExecutionKilledTrigger.class, name = "trigger"),
+        @JsonSubTypes.Type(value = ExecutionKilledTaskRuns.class, name = "taskruns"),
     }
 )
 abstract public class ExecutionKilled implements TenantInterface, HasUID, BroadcastEvent {

--- a/core/src/main/java/io/kestra/core/models/executions/ExecutionKilledTaskRuns.java
+++ b/core/src/main/java/io/kestra/core/models/executions/ExecutionKilledTaskRuns.java
@@ -1,0 +1,59 @@
+package io.kestra.core.models.executions;
+
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import io.kestra.core.models.TenantInterface;
+import io.kestra.core.runners.WorkerTask;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.*;
+import lombok.experimental.SuperBuilder;
+
+/**
+ * A targeted {@link ExecutionKilled} event that interrupts a subset of an execution's task runs
+ * without killing the whole execution — unlike {@link ExecutionKilledExecution}.
+ */
+@Getter
+@SuperBuilder
+@EqualsAndHashCode
+@ToString
+@NoArgsConstructor
+public class ExecutionKilledTaskRuns extends ExecutionKilled implements TenantInterface {
+    @NotNull
+    @JsonInclude
+    @Builder.Default
+    protected String type = "taskruns";
+
+    /**
+     * The execution owning the targeted task runs.
+     */
+    @NotNull
+    String executionId;
+
+    /**
+     * The task runs to interrupt.
+     */
+    @NotNull
+    List<String> taskRunIds;
+
+    /**
+     * The state to move the targeted task runs to once interrupted.
+     */
+    @NotNull
+    io.kestra.core.models.flows.State.Type taskRunState;
+
+    public boolean isFor(WorkerTask workerTask) {
+        String taskTenantId = workerTask.getTaskRun().getTenantId();
+        String taskExecutionId = workerTask.getTaskRun().getExecutionId();
+        return (taskTenantId == null || taskTenantId.equals(this.tenantId))
+            && taskExecutionId.equals(this.executionId)
+            && this.taskRunIds.contains(workerTask.getTaskRun().getId());
+    }
+
+    @Override
+    public String uid() {
+        return this.executionId;
+    }
+}

--- a/core/src/main/java/io/kestra/plugin/core/flow/Dag.java
+++ b/core/src/main/java/io/kestra/plugin/core/flow/Dag.java
@@ -88,7 +88,7 @@ import lombok.experimental.SuperBuilder;
         )
     }
 )
-public class Dag extends Task implements FlowableTask<VoidOutput> {
+public class Dag extends Task implements FlowableTask<VoidOutput>, OnChildFailureInterface {
     @NotNull
     @Builder.Default
     @Schema(
@@ -96,6 +96,17 @@ public class Dag extends Task implements FlowableTask<VoidOutput> {
         description = "If the value is `0`, no concurrency limit exists for the tasks in a DAG and all tasks that can run in parallel will start at the same time."
     )
     private final Property<Integer> concurrent = Property.ofValue(0);
+
+    @NotNull
+    @Builder.Default
+    @Schema(
+        title = "What to do with the other still-running tasks when one task fails.",
+        description = """
+            `CONTINUE` (default): other tasks keep running to completion, as today.
+
+            `CANCELLED` / `FAILED`: as soon as a task fails with no retry left, every other still-running task in this DAG is interrupted and lands in the given state. The DAG itself still resolves to `FAILED` and its `errors`/`finally` tasks still run normally."""
+    )
+    private final Property<OnChildFailure> onChildFailure = Property.ofValue(OnChildFailure.CONTINUE);
 
     @Valid
     @NotEmpty

--- a/core/src/main/java/io/kestra/plugin/core/flow/OnChildFailureInterface.java
+++ b/core/src/main/java/io/kestra/plugin/core/flow/OnChildFailureInterface.java
@@ -1,0 +1,53 @@
+package io.kestra.plugin.core.flow;
+
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+
+import io.kestra.core.models.executions.Execution;
+import io.kestra.core.models.executions.TaskRun;
+import io.kestra.core.models.flows.State;
+import io.kestra.core.models.property.Property;
+import io.kestra.core.utils.Enums;
+
+/**
+ * Marks a flowable task that can interrupt its still-running children as soon as one of them fails,
+ * instead of letting them run to completion while the flowable itself is already terminal.
+ */
+public interface OnChildFailureInterface {
+    Property<OnChildFailure> getOnChildFailure();
+
+    /**
+     * Every task run under {@code parentTaskRun}, at any depth, that has not yet terminated.
+     */
+    default List<TaskRun> nonTerminatedChildrenTaskRuns(Execution execution, TaskRun parentTaskRun) {
+        return execution.findAllChildren(parentTaskRun).stream()
+            .filter(taskRun -> !taskRun.getState().isTerminated())
+            .toList();
+    }
+
+    enum OnChildFailure {
+        CONTINUE,
+        CANCELLED,
+        FAILED,
+        UNKNOWN;
+
+        @JsonCreator
+        public static OnChildFailure fromString(final String value) {
+            return Enums.getForNameIgnoreCase(value, OnChildFailure.class, UNKNOWN);
+        }
+
+        /**
+         * The task-run state to apply to interrupted children.
+         *
+         * @throws IllegalStateException if called on {@link #CONTINUE} or {@link #UNKNOWN}, which never trigger an interrupt.
+         */
+        public State.Type toTaskRunState() {
+            return switch (this) {
+                case CANCELLED -> State.Type.CANCELLED;
+                case FAILED -> State.Type.FAILED;
+                case CONTINUE, UNKNOWN -> throw new IllegalStateException("No task run state is defined for onChildFailure value '%s'.".formatted(this));
+            };
+        }
+    }
+}

--- a/core/src/main/java/io/kestra/plugin/core/flow/Parallel.java
+++ b/core/src/main/java/io/kestra/plugin/core/flow/Parallel.java
@@ -99,10 +99,32 @@ import lombok.experimental.SuperBuilder;
                             type: io.kestra.plugin.core.debug.Return
                             format: "{{ task.id }}"
                 """
+        ),
+        @Example(
+            full = true,
+            title = """
+                Stop the other branches as soon as one task fails
+                """,
+            code = """
+                id: parallel_fail_fast
+                namespace: company.team
+
+                tasks:
+                  - id: parallel
+                    type: io.kestra.plugin.core.flow.Parallel
+                    onChildFailure: CANCELLED
+                    tasks:
+                      - id: fails_fast
+                        type: io.kestra.plugin.core.execution.Fail
+
+                      - id: long_running
+                        type: io.kestra.plugin.core.flow.Sleep
+                        duration: PT1M
+                """
         )
     }
 )
-public class Parallel extends AbstractBranch<VoidOutput> {
+public class Parallel extends AbstractBranch<VoidOutput> implements OnChildFailureInterface {
     @NotNull
     @Builder.Default
     @Schema(
@@ -110,6 +132,17 @@ public class Parallel extends AbstractBranch<VoidOutput> {
         description = "If the value is `0`, no limit exist and all tasks will start at the same time."
     )
     private final Property<Integer> concurrent = Property.ofValue(0);
+
+    @NotNull
+    @Builder.Default
+    @Schema(
+        title = "What to do with the other still-running tasks when one task fails.",
+        description = """
+            `CONTINUE` (default): other tasks keep running to completion, as today.
+
+            `CANCELLED` / `FAILED`: as soon as a task fails with no retry left, every other still-running task in this Parallel is interrupted and lands in the given state. The Parallel itself still resolves to `FAILED` and its `errors`/`finally` tasks still run normally."""
+    )
+    private final Property<OnChildFailure> onChildFailure = Property.ofValue(OnChildFailure.FAILED);
 
     @Override
     public GraphCluster tasksTree(Execution execution, TaskRun taskRun, List<String> parentValues) throws IllegalVariableEvaluationException {

--- a/core/src/test/java/io/kestra/core/runners/AbstractRunnerTest.java
+++ b/core/src/test/java/io/kestra/core/runners/AbstractRunnerTest.java
@@ -131,6 +131,22 @@ public abstract class AbstractRunnerTest {
     }
 
     @Test
+    @LoadFlows({ "flows/valids/parallel-fail-fast-cancelled.yaml" })
+    void parallelFailFastCancelled() throws QueueException, TimeoutException {
+        Execution execution = runnerUtils.runOneUntil(
+            MAIN_TENANT,
+            NAMESPACE, "parallel-fail-fast-cancelled", null, null, Duration.ofSeconds(20),
+            execution1 -> execution1.getState().isTerminated()
+                && execution1.getTaskRunList() != null
+                && execution1.getTaskRunList().stream().allMatch(taskRun -> taskRun.getState().isTerminated())
+        );
+
+        assertThat(execution.getState().getCurrent()).isEqualTo(State.Type.FAILED);
+        // the sibling must be cancelled quickly instead of running its full PT10S duration
+        assertThat(execution.findTaskRunsByTaskId("sleep").getFirst().getState().getCurrent()).isEqualTo(State.Type.CANCELLED);
+    }
+
+    @Test
     @LoadFlows({ "flows/valids/restart_last_failed.yaml" })
     void restartFailed() throws Exception {
         restartCaseTest.restartFailedThenSuccess();

--- a/core/src/test/java/io/kestra/plugin/core/flow/DagTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/flow/DagTest.java
@@ -25,6 +25,7 @@ import io.kestra.core.utils.TestsUtils;
 import jakarta.inject.Inject;
 import jakarta.validation.ConstraintViolationException;
 
+import static io.kestra.core.tenant.TenantService.MAIN_TENANT;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @KestraTest(startRunner = true)
@@ -99,6 +100,23 @@ public class DagTest {
             .isTrue();
         assertThat(execution.findTaskRunsByTaskId("e2").getFirst().getState().getStartDate().isAfter(execution.findTaskRunsByTaskId("e1").getFirst().getState().getEndDate().orElseThrow()))
             .isTrue();
+    }
+
+    @Test
+    @LoadFlows({ "flows/valids/dag-fail-fast-cancelled.yaml" })
+    void dagFailFastCancelled() throws QueueException, TimeoutException {
+        Execution execution = runnerUtils.runOneUntil(
+            MAIN_TENANT,
+            "io.kestra.tests", "dag-fail-fast-cancelled", null, null, Duration.ofSeconds(20),
+            execution1 -> execution1.getState().isTerminated()
+                && execution1.getTaskRunList() != null
+                && execution1.getTaskRunList().stream().allMatch(taskRun -> taskRun.getState().isTerminated())
+        );
+
+        assertThat(execution.getState().getCurrent()).isEqualTo(State.Type.FAILED);
+        assertThat(execution.findTaskRunsByTaskId("fails_fast").getFirst().getState().getCurrent()).isEqualTo(State.Type.FAILED);
+        // the sibling must be cancelled quickly instead of running its full PT10S duration
+        assertThat(execution.findTaskRunsByTaskId("sleep").getFirst().getState().getCurrent()).isEqualTo(State.Type.CANCELLED);
     }
 
     private Flow parse(String path) {

--- a/core/src/test/java/io/kestra/plugin/core/flow/ParallelTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/flow/ParallelTest.java
@@ -80,4 +80,73 @@ class ParallelTest {
         assertThat(execution.getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
         assertThat(execution.getTaskRunList()).hasSize(7);
     }
+
+    @Test
+    @LoadFlows({ "flows/valids/parallel-fail-fast-cancelled.yaml" })
+    void parallelFailFastCancelled() throws QueueException, TimeoutException {
+        Execution execution = runnerUtils.runOneUntil(
+            MAIN_TENANT,
+            "io.kestra.tests", "parallel-fail-fast-cancelled", null, null, Duration.ofSeconds(20),
+            this::allTaskRunsTerminated
+        );
+
+        assertThat(execution.getState().getCurrent()).isEqualTo(State.Type.FAILED);
+        assertThat(execution.findTaskRunsByTaskId("parallel").getFirst().getState().getCurrent()).isEqualTo(State.Type.FAILED);
+        assertThat(execution.findTaskRunsByTaskId("fails_fast").getFirst().getState().getCurrent()).isEqualTo(State.Type.FAILED);
+        // the sibling must be cancelled quickly instead of running its full PT10S duration
+        assertThat(execution.findTaskRunsByTaskId("sleep").getFirst().getState().getCurrent()).isEqualTo(State.Type.CANCELLED);
+    }
+
+    @Test
+    @LoadFlows({ "flows/valids/parallel-fail-fast-failed.yaml" })
+    void parallelFailFastFailed() throws QueueException, TimeoutException {
+        Execution execution = runnerUtils.runOneUntil(
+            MAIN_TENANT,
+            "io.kestra.tests", "parallel-fail-fast-failed", null, null, Duration.ofSeconds(20),
+            this::allTaskRunsTerminated
+        );
+
+        assertThat(execution.getState().getCurrent()).isEqualTo(State.Type.FAILED);
+        assertThat(execution.findTaskRunsByTaskId("parallel").getFirst().getState().getCurrent()).isEqualTo(State.Type.FAILED);
+        assertThat(execution.findTaskRunsByTaskId("sleep").getFirst().getState().getCurrent()).isEqualTo(State.Type.FAILED);
+    }
+
+    @Test
+    @LoadFlows({ "flows/valids/parallel-fail-fast-errors.yaml" })
+    void parallelFailFastErrors() throws QueueException, TimeoutException {
+        Execution execution = runnerUtils.runOneUntil(
+            MAIN_TENANT,
+            "io.kestra.tests", "parallel-fail-fast-errors", null, null, Duration.ofSeconds(20),
+            this::allTaskRunsTerminated
+        );
+
+        // fail-fast cancellation must not turn into an execution-level KILL: errors/finally still run
+        assertThat(execution.getState().getCurrent()).isEqualTo(State.Type.FAILED);
+        assertThat(execution.findTaskRunsByTaskId("sleep").getFirst().getState().getCurrent()).isEqualTo(State.Type.CANCELLED);
+        assertThat(execution.findTaskRunsByTaskId("e1").getFirst().getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
+        assertThat(execution.findTaskRunsByTaskId("f1").getFirst().getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
+    }
+
+    @Test
+    @LoadFlows({ "flows/valids/parallel-fail-fast-nested.yaml" })
+    void parallelFailFastNested() throws QueueException, TimeoutException {
+        Execution execution = runnerUtils.runOneUntil(
+            MAIN_TENANT,
+            "io.kestra.tests", "parallel-fail-fast-nested", null, null, Duration.ofSeconds(20),
+            this::allTaskRunsTerminated
+        );
+
+        assertThat(execution.getState().getCurrent()).isEqualTo(State.Type.FAILED);
+        assertThat(execution.findTaskRunsByTaskId("sequence").getFirst().getState().getCurrent()).isEqualTo(State.Type.CANCELLED);
+        // sleep2 must never start: the nested Sequential must not proceed to its next task once
+        // its own task run is KILLING, even though sleep1 (if it started at all) ends CANCELLED,
+        // not FAILED
+        assertThat(execution.findTaskRunsByTaskId("sleep2")).isEmpty();
+    }
+
+    private boolean allTaskRunsTerminated(Execution execution) {
+        return execution.getState().isTerminated()
+            && execution.getTaskRunList() != null
+            && execution.getTaskRunList().stream().allMatch(taskRun -> taskRun.getState().isTerminated());
+    }
 }

--- a/core/src/test/resources/flows/valids/dag-fail-fast-cancelled.yaml
+++ b/core/src/test/resources/flows/valids/dag-fail-fast-cancelled.yaml
@@ -1,0 +1,15 @@
+id: dag-fail-fast-cancelled
+namespace: io.kestra.tests
+
+tasks:
+  - id: dag
+    type: io.kestra.plugin.core.flow.Dag
+    onChildFailure: CANCELLED
+    tasks:
+      - task:
+          id: fails_fast
+          type: io.kestra.plugin.core.execution.Fail
+      - task:
+          id: sleep
+          type: io.kestra.plugin.core.flow.Sleep
+          duration: PT10S

--- a/core/src/test/resources/flows/valids/parallel-fail-fast-cancelled.yaml
+++ b/core/src/test/resources/flows/valids/parallel-fail-fast-cancelled.yaml
@@ -1,0 +1,14 @@
+id: parallel-fail-fast-cancelled
+namespace: io.kestra.tests
+
+tasks:
+  - id: parallel
+    type: io.kestra.plugin.core.flow.Parallel
+    onChildFailure: CANCELLED
+    tasks:
+      - id: fails_fast
+        type: io.kestra.plugin.core.execution.Fail
+
+      - id: sleep
+        type: io.kestra.plugin.core.flow.Sleep
+        duration: PT10S

--- a/core/src/test/resources/flows/valids/parallel-fail-fast-errors.yaml
+++ b/core/src/test/resources/flows/valids/parallel-fail-fast-errors.yaml
@@ -1,0 +1,22 @@
+id: parallel-fail-fast-errors
+namespace: io.kestra.tests
+
+tasks:
+  - id: parallel
+    type: io.kestra.plugin.core.flow.Parallel
+    onChildFailure: CANCELLED
+    errors:
+      - id: e1
+        type: io.kestra.plugin.core.log.Log
+        message: "handled"
+    finally:
+      - id: f1
+        type: io.kestra.plugin.core.log.Log
+        message: "cleaned up"
+    tasks:
+      - id: fails_fast
+        type: io.kestra.plugin.core.execution.Fail
+
+      - id: sleep
+        type: io.kestra.plugin.core.flow.Sleep
+        duration: PT10S

--- a/core/src/test/resources/flows/valids/parallel-fail-fast-failed.yaml
+++ b/core/src/test/resources/flows/valids/parallel-fail-fast-failed.yaml
@@ -1,0 +1,14 @@
+id: parallel-fail-fast-failed
+namespace: io.kestra.tests
+
+tasks:
+  - id: parallel
+    type: io.kestra.plugin.core.flow.Parallel
+    onChildFailure: FAILED
+    tasks:
+      - id: fails_fast
+        type: io.kestra.plugin.core.execution.Fail
+
+      - id: sleep
+        type: io.kestra.plugin.core.flow.Sleep
+        duration: PT10S

--- a/core/src/test/resources/flows/valids/parallel-fail-fast-nested.yaml
+++ b/core/src/test/resources/flows/valids/parallel-fail-fast-nested.yaml
@@ -1,0 +1,20 @@
+id: parallel-fail-fast-nested
+namespace: io.kestra.tests
+
+tasks:
+  - id: parallel
+    type: io.kestra.plugin.core.flow.Parallel
+    onChildFailure: CANCELLED
+    tasks:
+      - id: fails_fast
+        type: io.kestra.plugin.core.execution.Fail
+
+      - id: sequence
+        type: io.kestra.plugin.core.flow.Sequential
+        tasks:
+          - id: sleep1
+            type: io.kestra.plugin.core.flow.Sleep
+            duration: PT10S
+          - id: sleep2
+            type: io.kestra.plugin.core.flow.Sleep
+            duration: PT10S

--- a/executor/src/main/java/io/kestra/executor/ExecutorService.java
+++ b/executor/src/main/java/io/kestra/executor/ExecutorService.java
@@ -559,7 +559,14 @@ public class ExecutorService {
             if (taskRun.getState().isRunning() && task instanceof FlowableTask<?> && this.canChildrenProgress(executor.getExecution(), taskRun)) {
                 RunContext runContext = runContextFactory.of(executor.getFlow(), task, executor.getExecution(), taskRun);
                 nextTaskRuns.addAll(this.childNextsTaskRun(executor, taskRun, runContext));
-                this.childWorkerTaskResult(executor.getFlow(), executor.getExecution(), taskRun, runContext).ifPresent(list::add);
+                Optional<WorkerTaskResult> flowableResult = this.childWorkerTaskResult(executor.getFlow(), executor.getExecution(), taskRun, runContext);
+                if (flowableResult.isPresent()) {
+                    list.add(flowableResult.get());
+                    // fail-fast: a flowable that just resolved to FAILED asks to interrupt its still-running children
+                    if (flowableResult.get().getTaskRun().getState().isFailed() && task instanceof OnChildFailureInterface onChildFailure) {
+                        this.interruptOnChildFailure(executor, onChildFailure, taskRun, runContext);
+                    }
+                }
             }
 
             // For KILLING flowable tasks: only compute worker task result (kill-path) — no new child tasks
@@ -793,12 +800,16 @@ public class ExecutorService {
                     .collect(Collectors.toCollection(ArrayList::new));
             }
 
-            // If the task is a flowable and is terminated, check that all children are terminated.
-            // This may not be the case for parallel flowable tasks like Parallel, Dag, ForEach...
+            // If the task is a flowable and is terminated, check that all children flowable tasks are terminated.
+            // This may not be the case for parallel flowable tasks like Parallel, Dag, ...
             // After a failed task, some child flowable may not be correctly terminated.
+            // Restricted to flowable children on purpose (fixes #6780's original intent): a leaf task
+            // run that is still running is genuinely in progress on a worker and will report its own terminal state.
             if (task instanceof FlowableTask<?> && taskRun.getState().isTerminated()) {
+                FlowWithSource flow = executor.getFlow();
                 List<TaskRun> updated = executor.getExecution().findChildren(taskRun).stream()
                     .filter(child -> !child.getState().isTerminated())
+                    .filter(child -> flow.findTaskByTaskIdOrNull(child.getTaskId()) instanceof FlowableTask<?>)
                     .map(throwFunction(child -> child.withState(taskRun.getState().getCurrent())))
                     .toList();
                 if (!updated.isEmpty()) {
@@ -839,6 +850,59 @@ public class ExecutorService {
         this.addWorkerTaskResults(executor, list);
 
         return executor;
+    }
+
+    /**
+     * Interrupts every still-running task run in the task subtree so they don't keep executing on an already-failed branch.
+     * Send an {@link ExecutionKilledTaskRuns} event to the Worker to interrupt the non-terminated task runs.
+     */
+    private void interruptOnChildFailure(ExecutorContext executor, OnChildFailureInterface onChildFailure, TaskRun parentTaskRun, RunContext runContext) throws InternalException {
+        OnChildFailureInterface.OnChildFailure config = runContext.render(onChildFailure.getOnChildFailure())
+            .as(OnChildFailureInterface.OnChildFailure.class)
+            .orElse(OnChildFailureInterface.OnChildFailure.CONTINUE);
+        if (config == OnChildFailureInterface.OnChildFailure.CONTINUE || config == OnChildFailureInterface.OnChildFailure.UNKNOWN) {
+            return;
+        }
+
+        List<TaskRun> nonTerminated = onChildFailure.nonTerminatedChildrenTaskRuns(executor.getExecution(), parentTaskRun);
+        if (nonTerminated.isEmpty()) {
+            return;
+        }
+
+        State.Type targetState = config.toTaskRunState();
+        List<String> leafTaskRunIds = new ArrayList<>();
+        List<WorkerTaskResult> resolvedFlowables = new ArrayList<>();
+
+        for (TaskRun descendant : nonTerminated) {
+            Task descendantTask = executor.getFlow().findTaskByTaskIdOrNull(descendant.getTaskId());
+            if (descendantTask instanceof FlowableTask<?>) {
+                // A flowable task has no worker job of its own to interrupt: resolve it directly to the configured state.
+                // Its own descendants are covered independently in this same loop, since nonTerminatedChildrenTaskRuns() is already fully recursive.
+                resolvedFlowables.add(new WorkerTaskResult(descendant.withStateAndAttempt(targetState)));
+            } else {
+                leafTaskRunIds.add(descendant.getId());
+            }
+        }
+
+        if (!resolvedFlowables.isEmpty()) {
+            this.addWorkerTaskResults(executor, resolvedFlowables);
+        }
+
+        if (!leafTaskRunIds.isEmpty()) {
+            try {
+                killQueue.emit(
+                    ExecutionKilledTaskRuns.builder()
+                        .tenantId(parentTaskRun.getTenantId())
+                        .executionId(parentTaskRun.getExecutionId())
+                        .taskRunIds(leafTaskRunIds)
+                        .taskRunState(targetState)
+                        .state(ExecutionKilled.State.EXECUTED)
+                        .build()
+                );
+            } catch (QueueException e) {
+                log.error("Unable to interrupt task runs {} after child failure", leafTaskRunIds, e);
+            }
+        }
     }
 
     private Task searchForParentTaskWithRetry(TaskRun taskRun, ExecutorContext executor) {

--- a/worker/src/main/java/io/kestra/worker/processors/AbstractWorkerJobProcessor.java
+++ b/worker/src/main/java/io/kestra/worker/processors/AbstractWorkerJobProcessor.java
@@ -4,6 +4,7 @@ import java.util.ConcurrentModificationException;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
 
 import io.kestra.core.metrics.MetricRegistry;
 import io.kestra.core.models.flows.State;
@@ -30,13 +31,13 @@ public abstract class AbstractWorkerJobProcessor<T extends WorkerJob> implements
     private final AtomicReference<WorkerJob> currentWorkerJob = new AtomicReference<>();
     private final AtomicReference<AbstractWorkerCallable> currentWorkerCallable = new AtomicReference<>();
 
-    // Bound once instead of passed as `this::kill` on every process() call: `this` never changes
-    // across the many jobs a single processor instance handles, so re-capturing it as a fresh
-    // lambda per call was pure allocation churn.
-    private final Runnable killAction = this::kill;
+    // Bound once instead of passed as `this::interrupt` on every process() call: `this` never
+    // changes across the many jobs a single processor instance handles, so re-capturing it as a
+    // fresh lambda per call was pure allocation churn.
+    private final Consumer<State.Type> interruptAction = this::interrupt;
 
     private final AtomicBoolean stopped = new AtomicBoolean(false);
-    private final AtomicBoolean killRequested = new AtomicBoolean(false);
+    private final AtomicReference<State.Type> pendingInterruptState = new AtomicReference<>();
     private final AtomicBoolean shutdownInterrupted = new AtomicBoolean(false);
 
     public AbstractWorkerJobProcessor(String workerGroup,
@@ -57,7 +58,7 @@ public abstract class AbstractWorkerJobProcessor<T extends WorkerJob> implements
     @Override
     public void process(final T job) {
         if (currentWorkerJob.compareAndSet(null, job)) {
-            executionKilledManager.register(job.uid(), job, killAction);
+            executionKilledManager.register(job.uid(), job, interruptAction);
             try {
                 doProcess(job);
             } finally {
@@ -74,10 +75,11 @@ public abstract class AbstractWorkerJobProcessor<T extends WorkerJob> implements
 
     protected io.kestra.core.models.flows.State.Type callJob(AbstractWorkerCallable workerJobCallable) {
         this.currentWorkerCallable.set(workerJobCallable);
-        // Propagate a kill that arrived before currentWorkerCallable was set
-        // (between register() and here, kill() was a no-op).
-        if (killRequested.get()) {
-            workerJobCallable.kill();
+        // Propagate an interrupt that arrived before currentWorkerCallable was set
+        // (between register() and here, interrupt() was a no-op).
+        State.Type pendingState = pendingInterruptState.get();
+        if (pendingState != null) {
+            workerJobCallable.kill(pendingState);
         }
         try {
             return tracer.inCurrentContext(
@@ -112,8 +114,17 @@ public abstract class AbstractWorkerJobProcessor<T extends WorkerJob> implements
 
     @Override
     public void kill() {
-        killRequested.set(true);
-        Optional.ofNullable(currentWorkerCallable.get()).ifPresent(AbstractWorkerCallable::kill);
+        interrupt(State.Type.KILLED);
+    }
+
+    /**
+     * Interrupts the currently running job, marking it to report {@code state} as its outcome.
+     * Used both for a real kill ({@code KILLED}) and for a fail-fast interrupt targeting a
+     * caller-chosen state (e.g. {@code CANCELLED}).
+     */
+    protected void interrupt(State.Type state) {
+        pendingInterruptState.set(state);
+        Optional.ofNullable(currentWorkerCallable.get()).ifPresent(callable -> callable.kill(state));
     }
 
     @Override

--- a/worker/src/main/java/io/kestra/worker/processors/internals/AbstractWorkerCallable.java
+++ b/worker/src/main/java/io/kestra/worker/processors/internals/AbstractWorkerCallable.java
@@ -25,7 +25,8 @@ import static io.kestra.core.models.flows.State.Type.*;
 
 @SuppressWarnings("this-escape")
 public abstract class AbstractWorkerCallable implements Callable<State.Type> {
-    volatile boolean killed = false;
+    /** The state to report once interrupted, or {@code null} if not interrupted (or interrupted without marking, e.g. on timeout). */
+    volatile State.Type killedState = null;
 
     Logger logger;
 
@@ -58,7 +59,7 @@ public abstract class AbstractWorkerCallable implements Callable<State.Type> {
 
     @Synchronized
     public void kill() {
-        this.kill(true);
+        this.kill(KILLED);
     }
 
     /** {@inheritDoc} **/
@@ -69,9 +70,9 @@ public abstract class AbstractWorkerCallable implements Callable<State.Type> {
 
         try {
             // Guard against a kill received before currentThread was recorded:
-            // interrupt() was a no-op, so honor the killed flag here.
-            if (this.killed) {
-                return KILLED;
+            // interrupt() was a no-op, so honor the killedState flag here.
+            if (this.killedState != null) {
+                return this.killedState;
             }
             return doCall();
         } catch (Throwable e) {
@@ -109,8 +110,13 @@ public abstract class AbstractWorkerCallable implements Callable<State.Type> {
         }
     }
 
-    protected void kill(boolean markAsKilled) {
-        this.killed = markAsKilled;
+    /**
+     * Interrupts the running job.
+     * If {@code state} is non-null, the job is marked to eventually report that state as its outcome
+     * instead of the one {@link #doCall()} would otherwise produce.
+     */
+    public void kill(State.Type state) {
+        this.killedState = state;
 
         // When we arrive here, the thread run() method may be ended but the thread "in the stopping process".
         // So we don't interrupt if the shutdownLatch is 0 as this means the run() method is done or if the thread is no more alive.
@@ -123,8 +129,8 @@ public abstract class AbstractWorkerCallable implements Callable<State.Type> {
         this.exception = e;
         Span.current().recordException(e).setStatus(StatusCode.ERROR);
 
-        if (this.killed) {
-            return KILLED;
+        if (this.killedState != null) {
+            return this.killedState;
         } else {
             logger.error(e.getMessage(), e);
             return FAILED;
@@ -167,7 +173,7 @@ public abstract class AbstractWorkerCallable implements Callable<State.Type> {
             if (onTimeout != null) {
                 onTimeout.run();
             }
-            kill(false);
+            kill(null);
             // Clear the interrupt flag set by Failsafe's withInterrupt() so it doesn't leak to the caller.
             Thread.interrupted();
             return this.exceptionHandler(new TimeoutExceededException(timeout));

--- a/worker/src/main/java/io/kestra/worker/processors/internals/AbstractWorkerTriggerCallable.java
+++ b/worker/src/main/java/io/kestra/worker/processors/internals/AbstractWorkerTriggerCallable.java
@@ -2,6 +2,7 @@ package io.kestra.worker.processors.internals;
 
 import java.time.Duration;
 
+import io.kestra.core.models.flows.State;
 import io.kestra.core.models.triggers.WorkerTriggerInterface;
 import io.kestra.core.runners.RunContext;
 import io.kestra.core.runners.WorkerTrigger;
@@ -30,10 +31,10 @@ abstract class AbstractWorkerTriggerCallable extends AbstractWorkerCallable {
     }
 
     @Override
-    protected void kill(final boolean markAsKilled) {
+    public void kill(final State.Type state) {
         try {
             ((WorkerTriggerInterface) workerTrigger.getTrigger()).kill();
-            if (markAsKilled) {
+            if (state != null) {
                 // Let some time for the target thread to end, so we have a chance to not have to interrupt it.
                 // Killing a trigger is part of normal operations (updating a flow, disabling it, restarting Kestra),
                 // so we want to have a chance to end them properly and release their resources (transactions for ex).
@@ -42,7 +43,7 @@ abstract class AbstractWorkerTriggerCallable extends AbstractWorkerCallable {
         } catch (Exception e) {
             logger.warn("Error while killing trigger: '{}'", getType(), e);
         } finally {
-            super.kill(markAsKilled); //interrupt
+            super.kill(state); //interrupt
         }
     }
 }

--- a/worker/src/main/java/io/kestra/worker/processors/internals/WorkerTaskCallable.java
+++ b/worker/src/main/java/io/kestra/worker/processors/internals/WorkerTaskCallable.java
@@ -43,13 +43,13 @@ public class WorkerTaskCallable extends AbstractWorkerCallable {
     }
 
     @Override
-    protected void kill(final boolean markAsKilled) {
+    public void kill(final State.Type state) {
         try {
             task.kill();
         } catch (Exception e) {
             logger.warn("Error while killing task: '{}'", getType(), e);
         } finally {
-            super.kill(markAsKilled); //interrupt
+            super.kill(state); //interrupt
         }
     }
 

--- a/worker/src/main/java/io/kestra/worker/services/ExecutionKilledManager.java
+++ b/worker/src/main/java/io/kestra/worker/services/ExecutionKilledManager.java
@@ -2,6 +2,7 @@ package io.kestra.worker.services;
 
 import java.time.Duration;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Consumer;
 
 import org.slf4j.event.Level;
 
@@ -11,7 +12,9 @@ import com.github.benmanes.caffeine.cache.Caffeine;
 import io.kestra.core.metrics.MetricRegistry;
 import io.kestra.core.models.executions.ExecutionKilled;
 import io.kestra.core.models.executions.ExecutionKilledExecution;
+import io.kestra.core.models.executions.ExecutionKilledTaskRuns;
 import io.kestra.core.models.executions.ExecutionKilledTrigger;
+import io.kestra.core.models.flows.State;
 import io.kestra.core.runners.WorkerJob;
 import io.kestra.core.runners.WorkerTask;
 import io.kestra.core.runners.WorkerTrigger;
@@ -28,8 +31,9 @@ import lombok.extern.slf4j.Slf4j;
  * This class:
  * <ul>
  * <li>Maintains a cache of killed execution IDs for pre-processing checks</li>
- * <li>Tracks running jobs with their kill callbacks</li>
- * <li>Matches incoming kill events against running jobs and invokes callbacks</li>
+ * <li>Tracks running jobs with their interrupt callbacks</li>
+ * <li>Matches incoming kill/cancel events against running jobs and invokes callbacks, remembering
+ * task-run-scoped cancellations that arrive before the matching job is registered</li>
  * </ul>
  */
 @Singleton
@@ -44,7 +48,13 @@ public class ExecutionKilledManager {
     private final Cache<String, ExecutionKilledExecution> killedExecutions;
 
     /**
-     * Registry of running jobs with their kill callbacks.
+     * Task-run-scoped interrupts received before the matching job was registered on this worker,
+     * applied as soon as {@link #register} sees a matching job.
+     */
+    private final Cache<String, State.Type> pendingTaskRunInterrupts;
+
+    /**
+     * Registry of running jobs with their interrupt callbacks.
      */
     private final ConcurrentHashMap<String, KillableJob> runningJobs = new ConcurrentHashMap<>();
 
@@ -53,6 +63,9 @@ public class ExecutionKilledManager {
     @Inject
     public ExecutionKilledManager(MetricRegistry metricRegistry) {
         this.killedExecutions = Caffeine.newBuilder()
+            .expireAfterWrite(KILLED_CACHE_TTL)
+            .build();
+        this.pendingTaskRunInterrupts = Caffeine.newBuilder()
             .expireAfterWrite(KILLED_CACHE_TTL)
             .build();
         this.workerKilledCounter = metricRegistry.counter(
@@ -78,7 +91,7 @@ public class ExecutionKilledManager {
             {
                 if (killableJob.job() instanceof WorkerTask workerTask && killedExecution.isEqual(workerTask)) {
                     Logs.logTaskRun(workerTask.getTaskRun(), Level.INFO, "Killing running task");
-                    killableJob.killAction().run();
+                    killableJob.interruptAction().accept(State.Type.KILLED);
                 }
             });
         } else if (killed instanceof ExecutionKilledTrigger killedTrigger) {
@@ -92,21 +105,46 @@ public class ExecutionKilledManager {
             {
                 if (killableJob.job() instanceof WorkerTrigger workerTrigger && killedTrigger.isEqual(workerTrigger.triggerId())) {
                     Logs.logTrigger(workerTrigger.triggerId(), Level.INFO, "Killing running trigger");
-                    killableJob.killAction().run();
+                    killableJob.interruptAction().accept(State.Type.KILLED);
+                }
+            });
+        } else if (killed instanceof ExecutionKilledTaskRuns killedTaskRuns) {
+            log.info("[tenant: {}] [execution: {}] Received task run interrupt command for {}", killedTaskRuns.getTenantId(), killedTaskRuns.getExecutionId(), killedTaskRuns.getTaskRunIds());
+
+            // Store all pending task run interrupts in the cache so, if they arrive later, they will still be interrupted.
+            killedTaskRuns.getTaskRunIds().forEach(taskRunId -> pendingTaskRunInterrupts.put(taskRunId, killedTaskRuns.getTaskRunState()));
+
+            runningJobs.forEach((_, killableJob) ->
+            {
+                if (killableJob.job() instanceof WorkerTask workerTask && killedTaskRuns.isFor(workerTask)) {
+                    State.Type pendingState = pendingTaskRunInterrupts.asMap().remove(workerTask.getTaskRun().getId());
+                    if (pendingState != null) {
+                        Logs.logTaskRun(workerTask.getTaskRun(), Level.INFO, "Cancelling running task");
+                        killableJob.interruptAction().accept(pendingState);
+                    }
                 }
             });
         }
     }
 
     /**
-     * Registers a running job with its kill callback.
+     * Registers a running job with its interrupt callback. If a task-run-scoped interrupt for this
+     * job was received before it got here, it is applied immediately and the pending entry removed.
      *
      * @param jobUid the unique identifier of the job
      * @param job the worker job
-     * @param killAction the action to invoke to kill the job
+     * @param interruptAction the action to invoke to interrupt the job, given the state to report
      */
-    public void register(String jobUid, WorkerJob job, Runnable killAction) {
-        runningJobs.put(jobUid, new KillableJob(job, killAction));
+    public void register(String jobUid, WorkerJob job, Consumer<State.Type> interruptAction) {
+        runningJobs.put(jobUid, new KillableJob(job, interruptAction));
+
+        if (job instanceof WorkerTask workerTask && workerTask.getTaskRun().getId() != null) {
+            State.Type pendingState = pendingTaskRunInterrupts.asMap().remove(workerTask.getTaskRun().getId());
+            if (pendingState != null) {
+                Logs.logTaskRun(workerTask.getTaskRun(), Level.INFO, "Cancelling running task");
+                interruptAction.accept(pendingState);
+            }
+        }
     }
 
     /**
@@ -128,6 +166,6 @@ public class ExecutionKilledManager {
         return killedExecutions.getIfPresent(executionId) != null;
     }
 
-    record KillableJob(WorkerJob job, Runnable killAction) {
+    record KillableJob(WorkerJob job, Consumer<State.Type> interruptAction) {
     }
 }

--- a/worker/src/test/java/io/kestra/worker/services/ExecutionKilledManagerTest.java
+++ b/worker/src/test/java/io/kestra/worker/services/ExecutionKilledManagerTest.java
@@ -1,14 +1,19 @@
 package io.kestra.worker.services;
 
+import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import io.kestra.core.metrics.MetricRegistry;
 import io.kestra.core.models.executions.ExecutionKilledExecution;
+import io.kestra.core.models.executions.ExecutionKilledTaskRuns;
 import io.kestra.core.models.executions.ExecutionKilledTrigger;
 import io.kestra.core.models.executions.TaskRun;
+import io.kestra.core.models.flows.State;
 import io.kestra.core.models.triggers.AbstractTrigger;
 import io.kestra.core.models.triggers.TriggerId;
 import io.kestra.core.runners.WorkerTask;
@@ -96,7 +101,7 @@ class ExecutionKilledManagerTest {
         WorkerTask mockTask = createMockWorkerTask("exec-1", "tenant-1");
 
         // When
-        manager.register("job-1", mockTask, () ->
+        manager.register("job-1", mockTask, state ->
         {
         });
 
@@ -116,7 +121,7 @@ class ExecutionKilledManagerTest {
         // Given
         AtomicBoolean killed = new AtomicBoolean(false);
         WorkerTask mockTask = createMockWorkerTask("exec-1", null);
-        manager.register("job-1", mockTask, () -> killed.set(true));
+        manager.register("job-1", mockTask, state -> killed.set(true));
 
         ExecutionKilledExecution killEvent = ExecutionKilledExecution.builder()
             .executionId("exec-1")
@@ -134,7 +139,7 @@ class ExecutionKilledManagerTest {
         // Given
         AtomicBoolean killed = new AtomicBoolean(false);
         WorkerTask mockTask = createMockWorkerTask("exec-2", null);
-        manager.register("job-1", mockTask, () -> killed.set(true));
+        manager.register("job-1", mockTask, state -> killed.set(true));
 
         ExecutionKilledExecution killEvent = ExecutionKilledExecution.builder()
             .executionId("exec-1")
@@ -158,9 +163,9 @@ class ExecutionKilledManagerTest {
         WorkerTask task2 = createMockWorkerTask("exec-1", null);
         WorkerTask task3 = createMockWorkerTask("exec-other", null);
 
-        manager.register("job-1", task1, () -> killed1.set(true));
-        manager.register("job-2", task2, () -> killed2.set(true));
-        manager.register("job-3", task3, () -> killed3.set(true));
+        manager.register("job-1", task1, state -> killed1.set(true));
+        manager.register("job-2", task2, state -> killed2.set(true));
+        manager.register("job-3", task3, state -> killed3.set(true));
 
         ExecutionKilledExecution killEvent = ExecutionKilledExecution.builder()
             .executionId("exec-1")
@@ -180,7 +185,7 @@ class ExecutionKilledManagerTest {
         // Given
         AtomicBoolean killed = new AtomicBoolean(false);
         WorkerTask mockTask = createMockWorkerTask("exec-1", null);
-        manager.register("job-1", mockTask, () -> killed.set(true));
+        manager.register("job-1", mockTask, state -> killed.set(true));
         manager.unregister("job-1");
 
         ExecutionKilledExecution killEvent = ExecutionKilledExecution.builder()
@@ -199,7 +204,7 @@ class ExecutionKilledManagerTest {
         // Given
         AtomicBoolean killed = new AtomicBoolean(false);
         WorkerTask mockTask = createMockWorkerTask("exec-1", "tenant-A");
-        manager.register("job-1", mockTask, () -> killed.set(true));
+        manager.register("job-1", mockTask, state -> killed.set(true));
 
         ExecutionKilledExecution killEvent = ExecutionKilledExecution.builder()
             .executionId("exec-1")
@@ -218,7 +223,7 @@ class ExecutionKilledManagerTest {
         // Given
         AtomicBoolean killed = new AtomicBoolean(false);
         WorkerTask mockTask = createMockWorkerTask("exec-1", "tenant-A");
-        manager.register("job-1", mockTask, () -> killed.set(true));
+        manager.register("job-1", mockTask, state -> killed.set(true));
 
         ExecutionKilledExecution killEvent = ExecutionKilledExecution.builder()
             .executionId("exec-1")
@@ -260,7 +265,7 @@ class ExecutionKilledManagerTest {
         // Given
         AtomicBoolean killed = new AtomicBoolean(false);
         WorkerTrigger mockTrigger = createMockWorkerTrigger("ns", "flow-1", "trigger-1", null);
-        manager.register("job-1", mockTrigger, () -> killed.set(true));
+        manager.register("job-1", mockTrigger, state -> killed.set(true));
 
         ExecutionKilledTrigger killEvent = ExecutionKilledTrigger.builder()
             .namespace("ns")
@@ -280,7 +285,7 @@ class ExecutionKilledManagerTest {
         // Given
         AtomicBoolean killed = new AtomicBoolean(false);
         WorkerTrigger mockTrigger = createMockWorkerTrigger("ns", "flow-1", "trigger-1", null);
-        manager.register("job-1", mockTrigger, () -> killed.set(true));
+        manager.register("job-1", mockTrigger, state -> killed.set(true));
 
         ExecutionKilledTrigger killEvent = ExecutionKilledTrigger.builder()
             .namespace("ns")
@@ -300,7 +305,7 @@ class ExecutionKilledManagerTest {
         // Given
         AtomicBoolean killed = new AtomicBoolean(false);
         WorkerTask mockTask = createMockWorkerTask("exec-1", null);
-        manager.register("job-1", mockTask, () -> killed.set(true));
+        manager.register("job-1", mockTask, state -> killed.set(true));
 
         ExecutionKilledTrigger killEvent = ExecutionKilledTrigger.builder()
             .namespace("ns")
@@ -320,7 +325,7 @@ class ExecutionKilledManagerTest {
         // Given
         AtomicBoolean killed = new AtomicBoolean(false);
         WorkerTrigger mockTrigger = createMockWorkerTrigger("ns", "flow-1", "trigger-1", null);
-        manager.register("job-1", mockTrigger, () -> killed.set(true));
+        manager.register("job-1", mockTrigger, state -> killed.set(true));
 
         ExecutionKilledExecution killEvent = ExecutionKilledExecution.builder()
             .executionId("exec-1")
@@ -354,7 +359,7 @@ class ExecutionKilledManagerTest {
         // Given
         AtomicBoolean killed = new AtomicBoolean(false);
         WorkerTask mockTask = createMockWorkerTask("exec-1", null);
-        manager.register("job-1", mockTask, () -> killed.set(true));
+        manager.register("job-1", mockTask, state -> killed.set(true));
 
         ExecutionKilledExecution killEvent = ExecutionKilledExecution.builder()
             .executionId("exec-1")
@@ -376,7 +381,7 @@ class ExecutionKilledManagerTest {
     void shouldPreserveKilledStateAfterJobUnregisters() {
         // Given
         WorkerTask mockTask = createMockWorkerTask("exec-1", null);
-        manager.register("job-1", mockTask, () ->
+        manager.register("job-1", mockTask, state ->
         {
         });
 
@@ -392,10 +397,121 @@ class ExecutionKilledManagerTest {
         assertThat(manager.isExecutionKilled("exec-1")).isTrue();
     }
 
+    // --- onKillReceived - ExecutionKilledTaskRuns ---
+
+    @Test
+    void shouldInterruptOnlyMatchingTaskRunsOnExecutionKilledTaskRuns() {
+        // Given
+        AtomicBoolean interrupted1 = new AtomicBoolean(false);
+        AtomicBoolean interrupted2 = new AtomicBoolean(false);
+        WorkerTask task1 = createMockWorkerTask("exec-1", null, "taskrun-1");
+        WorkerTask task2 = createMockWorkerTask("exec-1", null, "taskrun-2");
+        manager.register("job-1", task1, state -> interrupted1.set(true));
+        manager.register("job-2", task2, state -> interrupted2.set(true));
+
+        ExecutionKilledTaskRuns event = ExecutionKilledTaskRuns.builder()
+            .executionId("exec-1")
+            .taskRunIds(List.of("taskrun-1"))
+            .taskRunState(State.Type.CANCELLED)
+            .build();
+
+        // When
+        manager.onKillReceived(event);
+
+        // Then
+        assertThat(interrupted1.get()).isTrue();
+        assertThat(interrupted2.get()).isFalse();
+    }
+
+    @Test
+    void shouldPassTheConfiguredStateToTheInterruptAction() {
+        // Given
+        AtomicReference<State.Type> reportedState = new AtomicReference<>();
+        WorkerTask task = createMockWorkerTask("exec-1", null, "taskrun-1");
+        manager.register("job-1", task, reportedState::set);
+
+        ExecutionKilledTaskRuns event = ExecutionKilledTaskRuns.builder()
+            .executionId("exec-1")
+            .taskRunIds(List.of("taskrun-1"))
+            .taskRunState(State.Type.FAILED)
+            .build();
+
+        // When
+        manager.onKillReceived(event);
+
+        // Then
+        assertThat(reportedState.get()).isEqualTo(State.Type.FAILED);
+    }
+
+    @Test
+    void shouldNotAffectKilledExecutionsCacheOnTaskRunsEvent() {
+        // Given
+        ExecutionKilledTaskRuns event = ExecutionKilledTaskRuns.builder()
+            .executionId("exec-1")
+            .taskRunIds(List.of("taskrun-1"))
+            .taskRunState(State.Type.CANCELLED)
+            .build();
+
+        // When
+        manager.onKillReceived(event);
+
+        // Then: an ExecutionKilledTaskRuns must never poison the whole-execution kill cache,
+        // otherwise every other task of the same execution would be treated as killed too
+        assertThat(manager.isExecutionKilled("exec-1")).isFalse();
+    }
+
+    @Test
+    void shouldRememberPendingInterruptAndApplyOnLateRegister() {
+        // Given: the interrupt arrives before the matching job is registered on this worker
+        ExecutionKilledTaskRuns event = ExecutionKilledTaskRuns.builder()
+            .executionId("exec-1")
+            .taskRunIds(List.of("taskrun-1"))
+            .taskRunState(State.Type.CANCELLED)
+            .build();
+        manager.onKillReceived(event);
+
+        // When
+        AtomicReference<State.Type> reportedState = new AtomicReference<>();
+        WorkerTask task = createMockWorkerTask("exec-1", null, "taskrun-1");
+        manager.register("job-1", task, reportedState::set);
+
+        // Then
+        assertThat(reportedState.get()).isEqualTo(State.Type.CANCELLED);
+    }
+
+    @Test
+    void shouldNotReapplyPendingInterruptOnASecondRegister() {
+        // Given
+        ExecutionKilledTaskRuns event = ExecutionKilledTaskRuns.builder()
+            .executionId("exec-1")
+            .taskRunIds(List.of("taskrun-1"))
+            .taskRunState(State.Type.CANCELLED)
+            .build();
+        manager.onKillReceived(event);
+
+        AtomicInteger callCount = new AtomicInteger(0);
+        WorkerTask task = createMockWorkerTask("exec-1", null, "taskrun-1");
+        manager.register("job-1", task, state -> callCount.incrementAndGet());
+        assertThat(callCount.get()).isEqualTo(1);
+
+        // When: the same task run registers again (e.g. re-dispatched)
+        manager.register("job-1", task, state -> callCount.incrementAndGet());
+
+        // Then: the pending entry was already consumed, so this is a no-op
+        assertThat(callCount.get()).isEqualTo(1);
+    }
+
     // --- Helper methods ---
 
+    private static final AtomicInteger TASK_RUN_ID_SEQUENCE = new AtomicInteger();
+
     private static WorkerTask createMockWorkerTask(String executionId, String tenantId) {
+        return createMockWorkerTask(executionId, tenantId, "taskrun-" + TASK_RUN_ID_SEQUENCE.incrementAndGet());
+    }
+
+    private static WorkerTask createMockWorkerTask(String executionId, String tenantId, String taskRunId) {
         TaskRun taskRun = mock(TaskRun.class);
+        when(taskRun.getId()).thenReturn(taskRunId);
         when(taskRun.getExecutionId()).thenReturn(executionId);
         when(taskRun.getTenantId()).thenReturn(tenantId);
 


### PR DESCRIPTION
…d tasks

Parallel and Dag can have one failing tasks and other still processing concurrenctly which would lead to those tasks being run un-necessary.

You can now configure `onChildFailure`  on both so when one child task fail, the worker can be asked to interrupt any still running child tasks in FAILED or CANCELLED.

https://github.com/kestra-io/kestra/issues/15365

## Breaking change

The default is `FAILED` so now Dag and Parallel will fail concurrently running tasks when one task fail.
Use `CONTINUE` to keep the previous behavior.
