### PR TITLE
feat(cli): detect configuration properties left over from Kestra 1.x at startup

### DIFF
--- a/cli/src/main/java/io/kestra/cli/services/DefaultStartupHook.java
+++ b/cli/src/main/java/io/kestra/cli/services/DefaultStartupHook.java
@@ -38,7 +38,10 @@ public class DefaultStartupHook implements StartupHookInterface {
 
     @Override
     public void start(AbstractCommand cmd) {
-        legacyConfigurationChecker.check();
+        // only servers are checked: the maintenance commands are the ones an operator runs to fix a stale configuration
+        if (cmd instanceof ServerCommandInterface) {
+            legacyConfigurationChecker.check();
+        }
 
         if (cmd instanceof ServerCommandInterface && !(cmd instanceof WorkerCommand)) {
             saveKestraVersion();

--- a/cli/src/main/java/io/kestra/cli/services/DefaultStartupHook.java
+++ b/cli/src/main/java/io/kestra/cli/services/DefaultStartupHook.java
@@ -5,6 +5,7 @@ import java.util.Optional;
 import io.kestra.cli.AbstractCommand;
 import io.kestra.cli.commands.servers.ServerCommandInterface;
 import io.kestra.cli.commands.servers.WorkerCommand;
+import io.kestra.core.contexts.configuration.LegacyConfigurationChecker;
 import io.kestra.core.mcp.services.McpServerService;
 import io.kestra.core.repositories.SettingRepositoryInterface;
 import io.kestra.core.services.VersionService;
@@ -32,8 +33,13 @@ public class DefaultStartupHook implements StartupHookInterface {
     @Inject
     BeanProvider<TenantService> tenantService;
 
+    @Inject
+    private LegacyConfigurationChecker legacyConfigurationChecker;
+
     @Override
     public void start(AbstractCommand cmd) {
+        legacyConfigurationChecker.check();
+
         if (cmd instanceof ServerCommandInterface && !(cmd instanceof WorkerCommand)) {
             saveKestraVersion();
             createDefaultMcpServerIfNotExist();

--- a/core/src/main/java/io/kestra/core/contexts/configuration/CoreLegacyConfigurationProvider.java
+++ b/core/src/main/java/io/kestra/core/contexts/configuration/CoreLegacyConfigurationProvider.java
@@ -1,0 +1,31 @@
+package io.kestra.core.contexts.configuration;
+
+import java.util.List;
+
+import io.kestra.core.contexts.configuration.LegacyConfiguration.Severity;
+
+import jakarta.inject.Singleton;
+
+/**
+ * The Open Source Edition properties that were valid in 1.x and are ignored since 2.0.
+ */
+@Singleton
+public class CoreLegacyConfigurationProvider implements LegacyConfigurationProvider {
+
+    private static final List<LegacyConfiguration> LEGACY_CONFIGURATIONS = List.of(
+        // the JDBC cleaner has been removed together with the legacy JDBC queue it was purging
+        LegacyConfiguration.removed("kestra.jdbc.cleaner", Severity.WARN),
+        LegacyConfiguration.removed("kestra.jdbc.executor.thread-count", Severity.WARN),
+        LegacyConfiguration.removed("kestra.jdbc.executor.clean", Severity.WARN),
+        LegacyConfiguration.removed("kestra.templates.enabled", Severity.WARN),
+        LegacyConfiguration.removed("kestra.webserver.google-analytics", Severity.WARN),
+        LegacyConfiguration.removed("kestra.webserver.html-title", Severity.WARN),
+        LegacyConfiguration.removed("kestra.webserver.html-head", Severity.WARN),
+        LegacyConfiguration.removed("kestra.plugins.local-repository-path", Severity.WARN)
+    );
+
+    @Override
+    public List<LegacyConfiguration> legacyConfigurations() {
+        return LEGACY_CONFIGURATIONS;
+    }
+}

--- a/core/src/main/java/io/kestra/core/contexts/configuration/CoreLegacyConfigurationProvider.java
+++ b/core/src/main/java/io/kestra/core/contexts/configuration/CoreLegacyConfigurationProvider.java
@@ -13,15 +13,11 @@ import jakarta.inject.Singleton;
 public class CoreLegacyConfigurationProvider implements LegacyConfigurationProvider {
 
     private static final List<LegacyConfiguration> LEGACY_CONFIGURATIONS = List.of(
-        // the JDBC cleaner has been removed together with the legacy JDBC queue it was purging
-        LegacyConfiguration.removed("kestra.jdbc.cleaner", Severity.WARN),
+        // the cleaner moved along with the queue it purges, from `JdbcCleaner` to `JdbcQueueCleaner`
+        LegacyConfiguration.renamed("kestra.jdbc.cleaner", "kestra.jdbc.queue.cleaner", Severity.WARN),
         LegacyConfiguration.removed("kestra.jdbc.executor.thread-count", Severity.WARN),
         LegacyConfiguration.removed("kestra.jdbc.executor.clean", Severity.WARN),
-        LegacyConfiguration.removed("kestra.templates.enabled", Severity.WARN),
-        LegacyConfiguration.removed("kestra.webserver.google-analytics", Severity.WARN),
-        LegacyConfiguration.removed("kestra.webserver.html-title", Severity.WARN),
-        LegacyConfiguration.removed("kestra.webserver.html-head", Severity.WARN),
-        LegacyConfiguration.removed("kestra.plugins.local-repository-path", Severity.WARN)
+        LegacyConfiguration.removed("kestra.templates.enabled", Severity.WARN)
     );
 
     @Override

--- a/core/src/main/java/io/kestra/core/contexts/configuration/LegacyConfiguration.java
+++ b/core/src/main/java/io/kestra/core/contexts/configuration/LegacyConfiguration.java
@@ -1,0 +1,39 @@
+package io.kestra.core.contexts.configuration;
+
+/**
+ * A configuration property that was valid in a previous major version and is no longer honoured.
+ *
+ * @param key         the legacy property key, or the prefix of a legacy configuration block.
+ * @param replacement the key that replaces it, or {@code null} when the property was removed outright.
+ * @param severity    whether keeping the property only warrants a warning, or must fail the startup.
+ */
+public record LegacyConfiguration(String key, String replacement, Severity severity) {
+
+    public enum Severity {
+        WARN,
+        ERROR
+    }
+
+    public LegacyConfiguration {
+        if (key == null || key.isBlank()) {
+            throw new IllegalArgumentException("The legacy configuration key cannot be null or blank.");
+        }
+    }
+
+    public static LegacyConfiguration removed(final String key, final Severity severity) {
+        return new LegacyConfiguration(key, null, severity);
+    }
+
+    public static LegacyConfiguration renamed(final String key, final String replacement, final Severity severity) {
+        return new LegacyConfiguration(key, replacement, severity);
+    }
+
+    /**
+     * @return a human-readable description of the property and of what must be done with it.
+     */
+    public String describe() {
+        return replacement == null
+            ? "`%s` has been removed.".formatted(key)
+            : "`%s` has been renamed to `%s`.".formatted(key, replacement);
+    }
+}

--- a/core/src/main/java/io/kestra/core/contexts/configuration/LegacyConfiguration.java
+++ b/core/src/main/java/io/kestra/core/contexts/configuration/LegacyConfiguration.java
@@ -25,6 +25,10 @@ public record LegacyConfiguration(String key, String replacement, Severity sever
     }
 
     public static LegacyConfiguration renamed(final String key, final String replacement, final Severity severity) {
+        if (replacement == null || replacement.isBlank()) {
+            throw new IllegalArgumentException("The replacement of the legacy configuration key '%s' cannot be null or blank.".formatted(key));
+        }
+
         return new LegacyConfiguration(key, replacement, severity);
     }
 

--- a/core/src/main/java/io/kestra/core/contexts/configuration/LegacyConfigurationChecker.java
+++ b/core/src/main/java/io/kestra/core/contexts/configuration/LegacyConfigurationChecker.java
@@ -1,0 +1,94 @@
+package io.kestra.core.contexts.configuration;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import io.kestra.core.exceptions.KestraRuntimeException;
+
+import io.micronaut.context.env.Environment;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Detects, at startup, configuration properties left over from a previous major version.
+ * <p>
+ * Such properties are silently ignored by Micronaut, so an instance upgraded without migrating its configuration
+ * starts with defaults the operator never chose. Properties whose loss only changes a tunable are reported as a
+ * warning, the ones that change the behaviour of the instance fail the startup.
+ */
+@Singleton
+@Slf4j
+public class LegacyConfigurationChecker {
+
+    private static final String MIGRATION_GUIDE_URL = "https://kestra.io/docs/migration-guide/v2.0.0";
+
+    private final Environment environment;
+    private final List<LegacyConfigurationProvider> providers;
+
+    @Inject
+    public LegacyConfigurationChecker(final Environment environment, final List<LegacyConfigurationProvider> providers) {
+        this.environment = Objects.requireNonNull(environment);
+        this.providers = Objects.requireNonNull(providers);
+    }
+
+    /**
+     * Reports every legacy property still configured on this instance.
+     *
+     * @throws KestraRuntimeException if at least one of them is declared with {@link LegacyConfiguration.Severity#ERROR}.
+     */
+    public void check() {
+        List<LegacyConfiguration> configured = providers.stream()
+            .map(LegacyConfigurationProvider::legacyConfigurations)
+            .flatMap(List::stream)
+            .filter(this::isConfigured)
+            .sorted(Comparator.comparing(LegacyConfiguration::key))
+            .toList();
+
+        if (configured.isEmpty()) {
+            return;
+        }
+
+        List<LegacyConfiguration> warnings = filterBySeverity(configured, LegacyConfiguration.Severity.WARN);
+        if (!warnings.isEmpty()) {
+            log.warn(message("Your configuration contains properties that are no longer supported and are ignored:", warnings));
+        }
+
+        List<LegacyConfiguration> errors = filterBySeverity(configured, LegacyConfiguration.Severity.ERROR);
+        if (!errors.isEmpty()) {
+            throw new KestraRuntimeException(message("Your configuration contains properties that are no longer supported and that changed the behaviour of this instance:", errors));
+        }
+    }
+
+    private boolean isConfigured(final LegacyConfiguration legacy) {
+        return keyVariants(legacy.key())
+            .anyMatch(key -> environment.containsProperty(key) || environment.containsProperties(key));
+    }
+
+    /**
+     * A property set through an environment variable may reach Micronaut with its hyphens turned into dots, as
+     * {@code KESTRA_WEBSERVER_GOOGLE_ANALYTICS} carries no way to tell both separators apart, so both spellings
+     * are looked up.
+     */
+    private static Stream<String> keyVariants(final String key) {
+        String dotted = key.replace('-', '.');
+        return dotted.equals(key) ? Stream.of(key) : Stream.of(key, dotted);
+    }
+
+    private static List<LegacyConfiguration> filterBySeverity(final List<LegacyConfiguration> configured, final LegacyConfiguration.Severity severity) {
+        return configured.stream().filter(legacy -> severity == legacy.severity()).toList();
+    }
+
+    private static String message(final String header, final List<LegacyConfiguration> legacies) {
+        return legacies.stream()
+            .map(legacy -> "  - " + legacy.describe())
+            .collect(Collectors.joining(
+                "\n",
+                header + "\n",
+                "\nRead the migration guide at %s, then update your configuration.".formatted(MIGRATION_GUIDE_URL)
+            ));
+    }
+}

--- a/core/src/main/java/io/kestra/core/contexts/configuration/LegacyConfigurationProvider.java
+++ b/core/src/main/java/io/kestra/core/contexts/configuration/LegacyConfigurationProvider.java
@@ -1,0 +1,15 @@
+package io.kestra.core.contexts.configuration;
+
+import java.util.List;
+
+/**
+ * Contributes the legacy configuration properties of one edition or module.
+ * <p>
+ * Micronaut has no registry of the valid property keys — plugins contribute arbitrary ones — so unknown properties
+ * cannot be detected generically. Instead, every property that is dropped or renamed is declared here, and
+ * {@link LegacyConfigurationChecker} reports the ones still present at startup.
+ */
+public interface LegacyConfigurationProvider {
+
+    List<LegacyConfiguration> legacyConfigurations();
+}

--- a/core/src/main/java/io/kestra/core/contexts/configuration/LegacyConfigurationProvider.java
+++ b/core/src/main/java/io/kestra/core/contexts/configuration/LegacyConfigurationProvider.java
@@ -8,6 +8,12 @@ import java.util.List;
  * Micronaut has no registry of the valid property keys — plugins contribute arbitrary ones — so unknown properties
  * cannot be detected generically. Instead, every property that is dropped or renamed is declared here, and
  * {@link LegacyConfigurationChecker} reports the ones still present at startup.
+ * <p>
+ * A key declared here must first be verified as no longer bound anywhere, which no test can prove: searching for
+ * its literal spelling is not enough, as Micronaut binds {@code kestra.webserver.google-analytics} to a
+ * {@code googleAnalytics} record component that a search for the hyphenated key never matches. Warning about a
+ * property that still works is worse than not warning at all, because an operator following the advice loses a
+ * working feature.
  */
 public interface LegacyConfigurationProvider {
 

--- a/core/src/test/java/io/kestra/core/contexts/configuration/LegacyConfigurationCheckerTest.java
+++ b/core/src/test/java/io/kestra/core/contexts/configuration/LegacyConfigurationCheckerTest.java
@@ -94,6 +94,13 @@ class LegacyConfigurationCheckerTest {
     }
 
     @Test
+    void shouldRejectABlankReplacement() {
+        // When - Then
+        assertThatThrownBy(() -> LegacyConfiguration.renamed("kestra.jdbc.cleaner", " ", Severity.WARN))
+            .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
     void shouldRejectABlankKey() {
         // When - Then
         assertThatThrownBy(() -> LegacyConfiguration.removed("  ", Severity.WARN))

--- a/core/src/test/java/io/kestra/core/contexts/configuration/LegacyConfigurationCheckerTest.java
+++ b/core/src/test/java/io/kestra/core/contexts/configuration/LegacyConfigurationCheckerTest.java
@@ -1,0 +1,119 @@
+package io.kestra.core.contexts.configuration;
+
+import java.util.List;
+import java.util.Set;
+
+import io.kestra.core.contexts.configuration.LegacyConfiguration.Severity;
+import io.kestra.core.exceptions.KestraRuntimeException;
+
+import io.micronaut.context.env.Environment;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class LegacyConfigurationCheckerTest {
+
+    @Test
+    void shouldNotFailWhenNoLegacyConfigurationIsConfigured() {
+        // Given
+        LegacyConfigurationChecker checker = checker(
+            Set.of(),
+            LegacyConfiguration.removed("kestra.jdbc.cleaner", Severity.ERROR)
+        );
+
+        // When - Then
+        assertThatCode(checker::check).doesNotThrowAnyException();
+    }
+
+    @Test
+    void shouldNotFailWhenOnlyWarningLegacyConfigurationsAreConfigured() {
+        // Given
+        LegacyConfigurationChecker checker = checker(
+            Set.of("kestra.templates.enabled"),
+            LegacyConfiguration.removed("kestra.templates.enabled", Severity.WARN)
+        );
+
+        // When - Then
+        assertThatCode(checker::check).doesNotThrowAnyException();
+    }
+
+    @Test
+    void shouldFailWhenAnErrorLegacyConfigurationIsConfigured() {
+        // Given
+        LegacyConfigurationChecker checker = checker(
+            Set.of("micronaut.security.login.failed-attempts", "kestra.templates.enabled"),
+            LegacyConfiguration.renamed("micronaut.security.login.failed-attempts", "kestra.security.login.failed-attempts", Severity.ERROR),
+            LegacyConfiguration.removed("kestra.templates.enabled", Severity.WARN),
+            LegacyConfiguration.removed("kestra.jdbc.cleaner", Severity.ERROR)
+        );
+
+        // When - Then
+        assertThatThrownBy(checker::check)
+            .isInstanceOf(KestraRuntimeException.class)
+            .hasMessageContaining("`micronaut.security.login.failed-attempts` has been renamed to `kestra.security.login.failed-attempts`.")
+            .hasMessageContaining("https://kestra.io/docs/migration-guide/v2.0.0")
+            // only the configured properties of the reported severity are listed
+            .hasMessageNotContaining("kestra.jdbc.cleaner")
+            .hasMessageNotContaining("kestra.templates.enabled");
+    }
+
+    @Test
+    void shouldDetectLegacyConfigurationGivenItsEnvironmentVariableSpelling() {
+        // Given, KESTRA_WEBSERVER_GOOGLE_ANALYTICS resolves as `kestra.webserver.google.analytics`
+        LegacyConfigurationChecker checker = checker(
+            Set.of("kestra.webserver.google.analytics"),
+            LegacyConfiguration.removed("kestra.webserver.google-analytics", Severity.ERROR)
+        );
+
+        // When - Then
+        assertThatThrownBy(checker::check)
+            .isInstanceOf(KestraRuntimeException.class)
+            .hasMessageContaining("`kestra.webserver.google-analytics` has been removed.");
+    }
+
+    @Test
+    void shouldDetectLegacyConfigurationGivenOnlyItsChildrenAreConfigured() {
+        // Given
+        Environment environment = mock(Environment.class);
+        when(environment.containsProperty(anyString())).thenReturn(false);
+        when(environment.containsProperties("kestra.jdbc.cleaner")).thenReturn(true);
+        LegacyConfigurationChecker checker = new LegacyConfigurationChecker(
+            environment,
+            List.of(() -> List.of(LegacyConfiguration.removed("kestra.jdbc.cleaner", Severity.ERROR)))
+        );
+
+        // When - Then
+        assertThatThrownBy(checker::check)
+            .isInstanceOf(KestraRuntimeException.class)
+            .hasMessageContaining("`kestra.jdbc.cleaner` has been removed.");
+    }
+
+    @Test
+    void shouldRejectABlankKey() {
+        // When - Then
+        assertThatThrownBy(() -> LegacyConfiguration.removed("  ", Severity.WARN))
+            .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void shouldDescribeARemovedAndARenamedConfiguration() {
+        // When - Then
+        assertThat(LegacyConfiguration.removed("kestra.templates.enabled", Severity.WARN).describe())
+            .isEqualTo("`kestra.templates.enabled` has been removed.");
+        assertThat(LegacyConfiguration.renamed("kestra.mail-service", "kestra.ee.mail-service", Severity.WARN).describe())
+            .isEqualTo("`kestra.mail-service` has been renamed to `kestra.ee.mail-service`.");
+    }
+
+    private static LegacyConfigurationChecker checker(final Set<String> configuredKeys, final LegacyConfiguration... legacyConfigurations) {
+        Environment environment = mock(Environment.class);
+        when(environment.containsProperty(anyString())).thenAnswer(invocation -> configuredKeys.contains(invocation.getArgument(0, String.class)));
+        when(environment.containsProperties(anyString())).thenAnswer(invocation -> configuredKeys.contains(invocation.getArgument(0, String.class)));
+
+        return new LegacyConfigurationChecker(environment, List.of(() -> List.of(legacyConfigurations)));
+    }
+}


### PR DESCRIPTION
### What

Detects, at startup, configuration properties that were valid in 1.x and are no longer honoured in 2.0.

Micronaut silently ignores unknown properties, so an instance upgraded without migrating its `application.yml` starts with defaults the operator never chose — and nothing tells them. This is the OSS half of kestra-io/kestra-ee#7493 (EE companion: kestra-io/kestra-ee#10111, same branch name).

### How

- `LegacyConfiguration` — a removed or renamed key, with a `WARN`/`ERROR` severity.
- `LegacyConfigurationProvider` — each edition contributes its own list; EE adds its keys without touching this module.
- `LegacyConfigurationChecker` — called from `DefaultStartupHook` for server commands, logs the `WARN` ones and fails the startup on the `ERROR` ones, pointing at the migration guide.

Only server commands are checked, deliberately: `kestra flow validate`, `kestra plugins install` and the `kestra sys …` commands are what an operator runs *to fix* a stale configuration, so an ERROR key must not abort them.

A generic "unknown property" check isn't feasible: Micronaut has no registry of valid keys and plugins contribute arbitrary ones under `kestra.plugins.*`, so anything generic drowns in false positives. A curated list is the practical answer — the cost is that it needs an entry whenever a config key is dropped.

Properties are looked up in both their declared spelling and their dot-only spelling, because a key set through an environment variable may reach Micronaut with its hyphens turned into dots (`KESTRA_WEBSERVER_GOOGLE_ANALYTICS`).

### Keys declared here

| Key | Change | Evidence |
| --- | --- | --- |
| `kestra.jdbc.cleaner` | renamed to `kestra.jdbc.queue.cleaner` | the cleaner moved with the queue it purges, `JdbcCleaner` → `JdbcQueueCleaner` |
| `kestra.jdbc.executor.thread-count` | removed | no binding left |
| `kestra.jdbc.executor.clean` | removed | no binding left |
| `kestra.templates.enabled` | removed | `models/templates/TemplateEnabled.java` deleted |

All are `WARN` — losing them changes a tunable, not the behaviour of the instance. The `ERROR` severity is used by the EE list (execution data in internal storage, Kafka Streams settings, indexer models).

### A trap worth knowing about

The first version of this PR also declared `kestra.webserver.google-analytics`, `.html-title`, `.html-head` and `kestra.plugins.local-repository-path` as removed. They are **not**: Micronaut binds them to the `googleAnalytics` / `htmlTitle` / `htmlHead` / `localRepositoryPath` record components of `WebserverConfiguration` and `PluginsConfiguration`, which a search for the hyphenated spelling never matches. Warning about a property that still works is worse than not warning at all — an operator following the advice would delete a working setting. This is now documented on `LegacyConfigurationProvider`, and it is the main thing to check when reviewing an added key.

For the same reason, note what no test can prove here: `EELegacyConfigurationProviderTest` on the EE side only guards against a key still *set by the shipped YAML*, not against one still *bound in code*. Verifying a new entry is a manual step.

Also deliberately absent: `kestra.variables.recursiveRendering` still exists (now on `VariableConfiguration`), despite being on the 2.0 breaking-change list.

### Tests

`LegacyConfigurationCheckerTest` — 8 unit tests covering both severities, the prefix form, the environment-variable spelling, the factory validation and the message content. `./gradlew :core:test --tests "*LegacyConfigurationCheckerTest"` passes.

### Open question for review

Severity assignment is the judgement call worth a second opinion. The alternative is to warn on everything and gate the failure behind an opt-in flag, which is gentler on upgrades but mostly defers the problem the issue is trying to solve.
