### PR TITLE
fix(secrets): stop sending decrypted secrets to the worker

### DIFF
--- a/core/src/main/java/io/kestra/core/runners/DefaultRunContext.java
+++ b/core/src/main/java/io/kestra/core/runners/DefaultRunContext.java
@@ -77,7 +77,6 @@ public class DefaultRunContext extends RunContext {
     private String triggerExecutionId;
     private Storage storage;
     private Map<String, Object> pluginConfiguration;
-    private List<String> secretInputs;
     private List<String> secretOutputs;
     private String traceParent;
 
@@ -162,15 +161,6 @@ public class DefaultRunContext extends RunContext {
      */
     @Override
     @JsonInclude
-    public List<String> getSecretInputs() {
-        return secretInputs;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    @JsonInclude
     public String getTraceParent() {
         return traceParent;
     }
@@ -232,18 +222,6 @@ public class DefaultRunContext extends RunContext {
     void setLogger(final RunContextLogger logger) {
         this.logger = logger;
 
-        // this is used when a run context is re-hydrated so we need to add again the secrets from the inputs
-        if (!ListUtils.isEmpty(secretInputs) && getVariables().containsKey("inputs")) {
-            @SuppressWarnings("unchecked")
-            Map<String, Object> inputs = (Map<String, Object>) getVariables().get("inputs");
-            for (String secretInput : secretInputs) {
-                String secret = findSecret(secretInput, inputs);
-                if (secret != null) {
-                    logger.usedSecret(secret);
-                }
-            }
-        }
-
         // this is used when a run context is re-hydrated so we need to add again the decrypted SECRET flow outputs
         if (!ListUtils.isEmpty(secretOutputs)) {
             secretOutputs.forEach(logger::usedSecret);
@@ -259,18 +237,6 @@ public class DefaultRunContext extends RunContext {
         List<String> updated = new ArrayList<>(ListUtils.emptyOnNull(secretOutputs));
         updated.add(secret);
         secretOutputs = updated;
-    }
-
-    @SuppressWarnings("unchecked")
-    private String findSecret(String secretInput, Map<String, Object> inputs) {
-        if (secretInput.indexOf('.') > 0) {
-            String prefix = secretInput.substring(0, secretInput.indexOf('.'));
-            String suffix = secretInput.substring(secretInput.indexOf('.') + 1);
-            Map<String, Object> subInputs = (Map<String, Object>) inputs.get(prefix);
-            return findSecret(suffix, subInputs);
-        }
-
-        return (String) inputs.get(secretInput);
     }
 
     void setPluginConfiguration(final Map<String, Object> pluginConfiguration) {
@@ -301,7 +267,6 @@ public class DefaultRunContext extends RunContext {
         runContext.logger = this.logger;
         runContext.storage = this.storage;
         runContext.pluginConfiguration = this.pluginConfiguration;
-        runContext.secretInputs = this.secretInputs;
         runContext.secretOutputs = this.secretOutputs;
         runContext.decryptVariables = this.decryptVariables;
         if (isInitialized.get()) {
@@ -788,7 +753,6 @@ public class DefaultRunContext extends RunContext {
         private RunContextLogger logger;
         private KVStoreService kvStoreService;
         private AssetManagerFactory assetManagerFactory;
-        private List<String> secretInputs;
         private Task task;
         private AbstractTrigger trigger;
 
@@ -812,7 +776,6 @@ public class DefaultRunContext extends RunContext {
             context.triggerExecutionId = triggerExecutionId;
             context.kvStoreService = kvStoreService;
             context.assetManagerFactory = assetManagerFactory;
-            context.secretInputs = secretInputs;
             context.task = task;
             context.trigger = trigger;
             return context;

--- a/core/src/main/java/io/kestra/core/runners/DefaultRunContext.java
+++ b/core/src/main/java/io/kestra/core/runners/DefaultRunContext.java
@@ -26,6 +26,7 @@ import io.kestra.core.models.Plugin;
 import io.kestra.core.models.executions.AbstractMetricEntry;
 import io.kestra.core.models.property.Property;
 import io.kestra.core.models.tasks.Task;
+import io.kestra.core.models.tasks.common.EncryptedString;
 import io.kestra.core.models.triggers.AbstractTrigger;
 import io.kestra.core.plugins.PluginConfigurations;
 import io.kestra.core.services.KVStoreService;
@@ -51,6 +52,9 @@ import static io.kestra.core.utils.Rethrow.throwFunction;
  * Default and mutable implementation of {@link RunContext}.
  */
 public class DefaultRunContext extends RunContext {
+    /** The only variables that can hold an {@link EncryptedString}, so the only ones worth walking on read. */
+    private static final Set<String> SECRET_BEARING_VARIABLES = Set.of("inputs", "outputs", "trigger");
+
     // Injected manually inside init(ApplicationContext)
     private ApplicationContext applicationContext;
     private VariableRenderer variableRenderer;
@@ -65,6 +69,8 @@ public class DefaultRunContext extends RunContext {
     private SDK sdk;
 
     private Map<String, Object> variables;
+    private boolean decryptVariables = true;
+    private Map<String, Object> decryptedVariables;
     private List<AbstractMetricEntry<?>> metrics = new ArrayList<>(4); // init to 4 to save memory as tasks usually produce few metrics if any
     private RunContextLogger logger;
     private final List<WorkerTaskResult> dynamicWorkerTaskResult = new ArrayList<>(0); // init to 0 to save memory: this is used by only one task
@@ -107,7 +113,48 @@ public class DefaultRunContext extends RunContext {
     @Override
     @JsonInclude
     public Map<String, Object> getVariables() {
+        if (!decryptVariables) {
+            return variables;
+        }
+        if (decryptedVariables == null) {
+            decryptedVariables = decryptSecretSubtrees(variables);
+        }
+        return decryptedVariables;
+    }
+
+    /**
+     * Returns the variables exactly as they were built, with secret values still encrypted. Callers serializing this
+     * run context across a process boundary must use this instead of {@link #getVariables()} so that no plaintext
+     * secret is ever written to a queue.
+     */
+    @JsonIgnore
+    Map<String, Object> rawVariables() {
         return variables;
+    }
+
+    /**
+     * Decrypts the three subtrees that can hold an {@link EncryptedString}, registering every value it decrypts with
+     * the logger so the secret is masked in this run context's logs from the moment it is first read.
+     */
+    @SuppressWarnings("unchecked")
+    private Map<String, Object> decryptSecretSubtrees(Map<String, Object> variables) {
+        // an absent key is not a reason to skip: Secret unwraps the value and warns, which is how a run context
+        // with no encryption configured has always exposed an EncryptedString
+        if (variables == null || secretKey == null) {
+            return variables;
+        }
+
+        Map<String, Object> decrypted = null;
+        final Secret secret = new Secret(secretKey, this::logger, this::usedSecretOutput);
+        for (String key : SECRET_BEARING_VARIABLES) {
+            if (variables.get(key) instanceof Map<?, ?> subtree) {
+                if (decrypted == null) {
+                    decrypted = new HashMap<>(variables);
+                }
+                decrypted.put(key, secret.decrypt((Map<String, Object>) subtree));
+            }
+        }
+        return decrypted == null ? variables : decrypted;
     }
 
     /**
@@ -117,15 +164,6 @@ public class DefaultRunContext extends RunContext {
     @JsonInclude
     public List<String> getSecretInputs() {
         return secretInputs;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    @JsonInclude
-    public List<String> getSecretOutputs() {
-        return secretOutputs;
     }
 
     /**
@@ -147,6 +185,7 @@ public class DefaultRunContext extends RunContext {
                 .putAll(this.variables)
                 .put("trace", Map.of("parent", traceParent))
                 .build();
+            this.decryptedVariables = null;
         }
     }
 
@@ -183,6 +222,7 @@ public class DefaultRunContext extends RunContext {
 
     void setVariables(final Map<String, Object> variables) {
         this.variables = Collections.unmodifiableMap(variables);
+        this.decryptedVariables = null;
     }
 
     void setStorage(final Storage storage) {
@@ -263,6 +303,7 @@ public class DefaultRunContext extends RunContext {
         runContext.pluginConfiguration = this.pluginConfiguration;
         runContext.secretInputs = this.secretInputs;
         runContext.secretOutputs = this.secretOutputs;
+        runContext.decryptVariables = this.decryptVariables;
         if (isInitialized.get()) {
             //Inject all services
             runContext.init(applicationContext);
@@ -283,7 +324,7 @@ public class DefaultRunContext extends RunContext {
      */
     @Override
     public String render(String inline) throws IllegalVariableEvaluationException {
-        return variableRenderer.render(inline, this.variables);
+        return variableRenderer.render(inline, getVariables());
     }
 
     /**
@@ -291,7 +332,7 @@ public class DefaultRunContext extends RunContext {
      */
     @Override
     public Object renderTyped(String inline) throws IllegalVariableEvaluationException {
-        return variableRenderer.renderTyped(inline, this.variables);
+        return variableRenderer.renderTyped(inline, getVariables());
     }
 
     @Override
@@ -305,7 +346,7 @@ public class DefaultRunContext extends RunContext {
     @Override
     @SuppressWarnings("unchecked")
     public String render(String inline, Map<String, Object> variables) throws IllegalVariableEvaluationException {
-        return variableRenderer.render(inline, mergeWithNullableValues(this.variables, decryptVariables(variables)));
+        return variableRenderer.render(inline, mergeWithNullableValues(getVariables(), decryptVariables(variables)));
     }
 
     /**
@@ -313,7 +354,7 @@ public class DefaultRunContext extends RunContext {
      */
     @Override
     public List<String> render(List<String> inline) throws IllegalVariableEvaluationException {
-        return variableRenderer.render(inline, this.variables);
+        return variableRenderer.render(inline, getVariables());
     }
 
     /**
@@ -322,7 +363,7 @@ public class DefaultRunContext extends RunContext {
     @Override
     @SuppressWarnings("unchecked")
     public List<String> render(List<String> inline, Map<String, Object> variables) throws IllegalVariableEvaluationException {
-        return variableRenderer.render(inline, mergeWithNullableValues(this.variables, decryptVariables(variables)));
+        return variableRenderer.render(inline, mergeWithNullableValues(getVariables(), decryptVariables(variables)));
     }
 
     /**
@@ -330,7 +371,7 @@ public class DefaultRunContext extends RunContext {
      */
     @Override
     public Set<String> render(Set<String> inline) throws IllegalVariableEvaluationException {
-        return variableRenderer.render(inline, this.variables);
+        return variableRenderer.render(inline, getVariables());
     }
 
     /**
@@ -339,18 +380,18 @@ public class DefaultRunContext extends RunContext {
     @Override
     @SuppressWarnings("unchecked")
     public Set<String> render(Set<String> inline, Map<String, Object> variables) throws IllegalVariableEvaluationException {
-        return variableRenderer.render(inline, mergeWithNullableValues(this.variables, decryptVariables(variables)));
+        return variableRenderer.render(inline, mergeWithNullableValues(getVariables(), decryptVariables(variables)));
     }
 
     @Override
     public Map<String, Object> render(Map<String, Object> inline) throws IllegalVariableEvaluationException {
-        return variableRenderer.render(inline, this.variables);
+        return variableRenderer.render(inline, getVariables());
     }
 
     @Override
     @SuppressWarnings("unchecked")
     public Map<String, Object> render(Map<String, Object> inline, Map<String, Object> variables) throws IllegalVariableEvaluationException {
-        return variableRenderer.render(inline, mergeWithNullableValues(this.variables, decryptVariables(variables)));
+        return variableRenderer.render(inline, mergeWithNullableValues(getVariables(), decryptVariables(variables)));
     }
 
     @Override
@@ -365,7 +406,7 @@ public class DefaultRunContext extends RunContext {
             return null;
         }
 
-        Map<String, Object> allVariables = mergeWithNullableValues(this.variables, decryptVariables(variables));
+        Map<String, Object> allVariables = mergeWithNullableValues(getVariables(), decryptVariables(variables));
         Map<String, String> rendered = new LinkedHashMap<>();
         for (Map.Entry<String, String> entry : inline.entrySet()) {
             String renderedKey = this.render(entry.getKey(), allVariables);
@@ -737,6 +778,7 @@ public class DefaultRunContext extends RunContext {
         private StorageInterface storageInterface;
         private MetricRegistry meterRegistry;
         private Map<String, Object> variables;
+        private boolean decryptVariables = true;
         private List<WorkerTaskResult> dynamicWorkerResults;
         private Map<String, Object> pluginConfiguration;
         private Optional<String> secretKey = Optional.empty();
@@ -747,7 +789,6 @@ public class DefaultRunContext extends RunContext {
         private KVStoreService kvStoreService;
         private AssetManagerFactory assetManagerFactory;
         private List<String> secretInputs;
-        private List<String> secretOutputs;
         private Task task;
         private AbstractTrigger trigger;
 
@@ -762,6 +803,7 @@ public class DefaultRunContext extends RunContext {
             context.variableRenderer = variableRenderer;
             context.meterRegistry = meterRegistry;
             context.variables = variables;
+            context.decryptVariables = decryptVariables;
             context.pluginConfiguration = Optional.ofNullable(pluginConfiguration).map(ImmutableMap::copyOf).orElse(ImmutableMap.of());
             context.logger = logger;
             context.secretKey = secretKey;
@@ -771,7 +813,6 @@ public class DefaultRunContext extends RunContext {
             context.kvStoreService = kvStoreService;
             context.assetManagerFactory = assetManagerFactory;
             context.secretInputs = secretInputs;
-            context.secretOutputs = secretOutputs;
             context.task = task;
             context.trigger = trigger;
             return context;

--- a/core/src/main/java/io/kestra/core/runners/RunContext.java
+++ b/core/src/main/java/io/kestra/core/runners/RunContext.java
@@ -42,12 +42,6 @@ public abstract class RunContext implements PropertyContext {
     public abstract Map<String, Object> getVariables();
 
     /**
-     * Returns the list of inputs of type SECRET.
-     */
-    @JsonInclude
-    public abstract List<String> getSecretInputs();
-
-    /**
      * OpenTelemetry trace parent
      */
     @JsonInclude

--- a/core/src/main/java/io/kestra/core/runners/RunContext.java
+++ b/core/src/main/java/io/kestra/core/runners/RunContext.java
@@ -48,14 +48,6 @@ public abstract class RunContext implements PropertyContext {
     public abstract List<String> getSecretInputs();
 
     /**
-     * Returns the plaintext values of SECRET-typed flow outputs decrypted while building this context's
-     * variables (e.g. a subflow's SECRET output consumed by this task), so they can be re-registered for
-     * log masking once this context is re-hydrated (e.g. on the worker).
-     */
-    @JsonInclude
-    public abstract List<String> getSecretOutputs();
-
-    /**
      * OpenTelemetry trace parent
      */
     @JsonInclude

--- a/core/src/main/java/io/kestra/core/runners/RunContextFactory.java
+++ b/core/src/main/java/io/kestra/core/runners/RunContextFactory.java
@@ -306,7 +306,7 @@ public class RunContextFactory {
     }
 
     protected RunVariables.Builder newRunVariablesBuilder() {
-        return new RunVariables.DefaultBuilder()
+        return new RunVariables.DefaultBuilder(encryptionConfig.asOptional())
             .withEnvs(runContextCache.getEnvVars())
             .withGlobals(runContextCache.getGlobalVars())
             .withKestraConfiguration(

--- a/core/src/main/java/io/kestra/core/runners/RunContextFactory.java
+++ b/core/src/main/java/io/kestra/core/runners/RunContextFactory.java
@@ -128,8 +128,6 @@ public class RunContextFactory {
                 .withExecution(execution)
                 .withOutputs(taskOutputService.computeOutputs(execution))
                 .withExecutionOutputs(executionOutputs(flow, execution))
-                .withDecryptVariables(decryptVariables)
-                .withSecretInputs(secretInputsFromFlow(flow))
         );
         Map<String, Object> variables = runVariablesBuilder.build(runContextLogger, PropertyContext.create(variableRenderer));
 
@@ -141,8 +139,8 @@ public class RunContextFactory {
             .withStorage(new InternalStorage(runContextLogger.logger(), StorageContext.forExecution(execution), storageInterface, namespaceService, namespaceFactory))
             .withVariableRenderer(variableRenderer)
             .withVariables(variables)
+            .withDecryptVariables(decryptVariables)
             .withSecretInputs(secretInputsFromFlow(flow))
-            .withSecretOutputs(runVariablesBuilder.secretOutputs())
             .build();
     }
 
@@ -163,9 +161,7 @@ public class RunContextFactory {
             .withExecution(execution)
             .withOutputs(taskOutputService.computeOutputs(execution))
             .withExecutionOutputs(executionOutputs(flow, execution))
-            .withTaskRun(taskRun)
-            .withDecryptVariables(decryptVariables)
-            .withSecretInputs(secretInputsFromFlow(flow));
+            .withTaskRun(taskRun);
         Map<String, Object> variables = runVariablesBuilder.build(runContextLogger, PropertyContext.create(variableRenderer));
 
         return newBuilder()
@@ -175,8 +171,8 @@ public class RunContextFactory {
             .withPluginConfiguration(pluginConfigurations.getConfigurationByPluginTypeOrAliases(task.getType(), task.getClass()))
             .withStorage(new InternalStorage(runContextLogger.logger(), StorageContext.forTask(taskRun), storageInterface, namespaceService, namespaceFactory))
             .withVariables(variables)
+            .withDecryptVariables(decryptVariables)
             .withSecretInputs(secretInputsFromFlow(flow))
-            .withSecretOutputs(runVariablesBuilder.secretOutputs())
             .withTask(task)
             .withVariableRenderer(variableRenderer)
             .build();
@@ -193,7 +189,6 @@ public class RunContextFactory {
                 newRunVariablesBuilder()
                     .withFlow(flow)
                     .withTrigger(trigger)
-                    .withSecretInputs(secretInputsFromFlow(flow))
                     .build(runContextLogger, PropertyContext.create(this.variableRenderer))
             )
             .withSecretInputs(secretInputsFromFlow(flow))
@@ -311,7 +306,7 @@ public class RunContextFactory {
     }
 
     protected RunVariables.Builder newRunVariablesBuilder() {
-        return new RunVariables.DefaultBuilder(encryptionConfig.asOptional())
+        return new RunVariables.DefaultBuilder()
             .withEnvs(runContextCache.getEnvVars())
             .withGlobals(runContextCache.getGlobalVars())
             .withKestraConfiguration(

--- a/core/src/main/java/io/kestra/core/runners/RunContextFactory.java
+++ b/core/src/main/java/io/kestra/core/runners/RunContextFactory.java
@@ -97,9 +97,6 @@ public class RunContextFactory {
     @Inject
     private Provider<RunContextInitializer> runContextInitializerProvider;
 
-    @Inject
-    private Provider<ReusableInputsExpander> reusableInputsExpanderProvider;
-
     // hacky
     public RunContextInitializer initializer() {
         return runContextInitializerProvider.get();
@@ -140,7 +137,6 @@ public class RunContextFactory {
             .withVariableRenderer(variableRenderer)
             .withVariables(variables)
             .withDecryptVariables(decryptVariables)
-            .withSecretInputs(secretInputsFromFlow(flow))
             .build();
     }
 
@@ -172,7 +168,6 @@ public class RunContextFactory {
             .withStorage(new InternalStorage(runContextLogger.logger(), StorageContext.forTask(taskRun), storageInterface, namespaceService, namespaceFactory))
             .withVariables(variables)
             .withDecryptVariables(decryptVariables)
-            .withSecretInputs(secretInputsFromFlow(flow))
             .withTask(task)
             .withVariableRenderer(variableRenderer)
             .build();
@@ -191,7 +186,6 @@ public class RunContextFactory {
                     .withTrigger(trigger)
                     .build(runContextLogger, PropertyContext.create(this.variableRenderer))
             )
-            .withSecretInputs(secretInputsFromFlow(flow))
             .withTrigger(trigger)
             .build();
     }
@@ -207,7 +201,6 @@ public class RunContextFactory {
                     .withVariables(variables)
                     .build(runContextLogger, PropertyContext.create(this.variableRenderer))
             )
-            .withSecretInputs(secretInputsFromFlow(flow))
             .build();
     }
 
@@ -280,17 +273,6 @@ public class RunContextFactory {
         }
     }
 
-    private List<String> secretInputsFromFlow(FlowInterface flow) {
-        if (flow == null || flow.getInputs() == null) {
-            return Collections.emptyList();
-        }
-
-        // Use the expander so that REUSABLE_INPUTS-referenced SECRETs are inlined alongside FORM-nested ones.
-        // On OSS the expander is a no-op when no REUSABLE_INPUTS are present, so FORM-nested SECRETs still work.
-        return flow.resolvableInputs(reusableInputsExpanderProvider.get()).stream()
-            .filter(input -> input.getType() == Type.SECRET)
-            .map(Input::getId).toList();
-    }
 
     private DefaultRunContext.Builder newBuilder() {
         return new DefaultRunContext.Builder()

--- a/core/src/main/java/io/kestra/core/runners/RunContextInitializer.java
+++ b/core/src/main/java/io/kestra/core/runners/RunContextInitializer.java
@@ -141,7 +141,7 @@ public class RunContextInitializer {
 
         variables = variablesModifier.apply(variables);
 
-        DefaultRunContext runContext = buildAndInitRunContext(variables, data.secretInputs(), data.traceParent(), workingDir);
+        DefaultRunContext runContext = buildAndInitRunContext(variables, data.traceParent(), workingDir);
         runContext.setPluginConfiguration(pluginConfigurations.getConfigurationByPluginTypeOrAliases(task.getType(), task.getClass()));
         runContext.setStorage(new InternalStorage(runContextLogger.logger(), StorageContext.forTask(taskRun), storageInterface, namespaceService, namespaceFactory));
         runContext.setLogger(runContextLogger);
@@ -261,7 +261,7 @@ public class RunContextInitializer {
         final RunContextLogger runContextLogger = contextLoggerFactory.create(workerTrigger.triggerId(), trigger);
         addSecretConsumer(variables, runContextLogger);
 
-        DefaultRunContext runContext = buildAndInitRunContext(variables, data.secretInputs(), data.traceParent(), null);
+        DefaultRunContext runContext = buildAndInitRunContext(variables, data.traceParent(), null);
         configureTrigger(runContext, runContextLogger, workerTrigger.triggerId(), trigger);
 
         return ConditionContext.builder()
@@ -296,12 +296,10 @@ public class RunContextInitializer {
      *        when non-null, {@code init()} will keep it instead of creating a new one.
      */
     private DefaultRunContext buildAndInitRunContext(Map<String, Object> variables,
-        List<String> secretInputs,
         String traceParent,
         WorkingDir workingDir) {
         var builder = new DefaultRunContext.Builder()
-            .withVariables(variables)
-            .withSecretInputs(secretInputs);
+            .withVariables(variables);
         if (workingDir != null) {
             builder = builder.withWorkingDir(workingDir);
         }

--- a/core/src/main/java/io/kestra/core/runners/RunContextInitializer.java
+++ b/core/src/main/java/io/kestra/core/runners/RunContextInitializer.java
@@ -9,7 +9,6 @@ import java.util.function.Function;
 import com.google.common.collect.Lists;
 
 import io.kestra.core.contexts.configuration.KestraConfiguration;
-import io.kestra.core.encryption.EncryptionConfig;
 import io.kestra.core.models.conditions.ConditionContext;
 import io.kestra.core.models.executions.TaskRun;
 import io.kestra.core.models.tasks.Task;
@@ -51,9 +50,6 @@ public class RunContextInitializer {
 
     @Inject
     protected NamespaceService namespaceService;
-
-    @Inject
-    protected EncryptionConfig encryptionConfig;
 
     @Inject
     protected RunContextCache runContextCache;
@@ -145,7 +141,7 @@ public class RunContextInitializer {
 
         variables = variablesModifier.apply(variables);
 
-        DefaultRunContext runContext = buildAndInitRunContext(variables, data.secretInputs(), data.secretOutputs(), data.traceParent(), workingDir);
+        DefaultRunContext runContext = buildAndInitRunContext(variables, data.secretInputs(), data.traceParent(), workingDir);
         runContext.setPluginConfiguration(pluginConfigurations.getConfigurationByPluginTypeOrAliases(task.getType(), task.getClass()));
         runContext.setStorage(new InternalStorage(runContextLogger.logger(), StorageContext.forTask(taskRun), storageInterface, namespaceService, namespaceFactory));
         runContext.setLogger(runContextLogger);
@@ -211,8 +207,9 @@ public class RunContextInitializer {
         }
 
         outputs.put(workerTaskResult.getTaskRun().getTaskId(), result);
-        variables.put("outputs", new Secret(encryptionConfig.asOptional(), runContext::logger, runContext::usedSecretOutput).decrypt(outputs));
-        variables.put("trigger", new Secret(encryptionConfig.asOptional(), runContext::logger, runContext::usedSecretOutput).decrypt(triggerOutputs));
+        // a subtask can return an encrypted output, which the run context decrypts when these variables are read
+        variables.put("outputs", outputs);
+        variables.put("trigger", triggerOutputs);
 
         runContext.setVariables(variables);
         return runContext;
@@ -264,7 +261,7 @@ public class RunContextInitializer {
         final RunContextLogger runContextLogger = contextLoggerFactory.create(workerTrigger.triggerId(), trigger);
         addSecretConsumer(variables, runContextLogger);
 
-        DefaultRunContext runContext = buildAndInitRunContext(variables, data.secretInputs(), List.of(), data.traceParent(), null);
+        DefaultRunContext runContext = buildAndInitRunContext(variables, data.secretInputs(), data.traceParent(), null);
         configureTrigger(runContext, runContextLogger, workerTrigger.triggerId(), trigger);
 
         return ConditionContext.builder()
@@ -300,13 +297,11 @@ public class RunContextInitializer {
      */
     private DefaultRunContext buildAndInitRunContext(Map<String, Object> variables,
         List<String> secretInputs,
-        List<String> secretOutputs,
         String traceParent,
         WorkingDir workingDir) {
         var builder = new DefaultRunContext.Builder()
             .withVariables(variables)
-            .withSecretInputs(secretInputs)
-            .withSecretOutputs(secretOutputs);
+            .withSecretInputs(secretInputs);
         if (workingDir != null) {
             builder = builder.withWorkingDir(workingDir);
         }

--- a/core/src/main/java/io/kestra/core/runners/RunContextLogger.java
+++ b/core/src/main/java/io/kestra/core/runners/RunContextLogger.java
@@ -186,9 +186,25 @@ public class RunContextLogger implements Supplier<org.slf4j.Logger> {
 
     public void usedSecret(String secret) {
         if (secret != null && !secret.isEmpty()) {
-            this.useSecrets.add(secret);
-            this.useSecrets.add(Base64.getEncoder().encodeToString(secret.getBytes(StandardCharsets.UTF_8)));
+            this.addSecretToMask(secret);
+            this.addSecretToMask(Base64.getEncoder().encodeToString(secret.getBytes(StandardCharsets.UTF_8)));
         }
+    }
+
+    /**
+     * Inserts a secret keeping the list ordered by descending length, because masking is a plain sequence of
+     * replacements: were a secret masked before a longer one containing it, the remainder of the longer secret
+     * would survive in the log line (masking 'pass' before 'password' leaves '******word').
+     */
+    private void addSecretToMask(final String secret) {
+        if (this.useSecrets.contains(secret)) {
+            return;
+        }
+        int index = 0;
+        while (index < this.useSecrets.size() && this.useSecrets.get(index).length() >= secret.length()) {
+            index++;
+        }
+        this.useSecrets.add(index, secret);
     }
 
     public org.slf4j.Logger logger() {

--- a/core/src/main/java/io/kestra/core/runners/RunVariables.java
+++ b/core/src/main/java/io/kestra/core/runners/RunVariables.java
@@ -1,5 +1,6 @@
 package io.kestra.core.runners;
 
+import java.security.GeneralSecurityException;
 import java.util.*;
 import java.util.function.Consumer;
 
@@ -13,8 +14,10 @@ import io.kestra.core.models.executions.TaskRun;
 import io.kestra.core.models.flows.FlowInterface;
 import io.kestra.core.models.flows.GenericFlow;
 import io.kestra.core.models.flows.State;
+import io.kestra.core.models.flows.Type;
 import io.kestra.core.models.property.PropertyContext;
 import io.kestra.core.models.tasks.Task;
+import io.kestra.core.models.tasks.common.EncryptedString;
 import io.kestra.core.models.triggers.AbstractTrigger;
 import io.kestra.core.utils.ListUtils;
 import io.kestra.core.utils.MapUtils;
@@ -337,8 +340,14 @@ public final class RunVariables {
         protected Map<String, ?> envs;
         protected Map<?, ?> globals;
         private KestraConfiguration kestraConfiguration;
+        private final Optional<String> secretKey;
 
         public DefaultBuilder() {
+            this(Optional.empty());
+        }
+
+        public DefaultBuilder(final Optional<String> secretKey) {
+            this.secretKey = secretKey;
         }
 
         // Note: for performance reason, cloning maps should be avoided as much as possible.
@@ -411,9 +420,18 @@ public final class RunVariables {
                         .forEach(input ->
                         {
                             try {
-                                putNested(inputs, input.getId(), FlowInputOutput.resolveDefaultValue(input, context));
+                                Object value = FlowInputOutput.resolveDefaultValue(input, context);
+                                // resolveDefaultValue renders a SECRET default as plaintext, so it is encrypted here:
+                                // every secret in the variables map must be encrypted until it is read, otherwise it
+                                // would be serialized in cleartext onto the worker job queue
+                                if (Type.SECRET == input.getType() && value != null) {
+                                    value = EncryptedString.from(new Secret(secretKey, logger::logger).encrypt(value.toString()));
+                                }
+                                putNested(inputs, input.getId(), value);
                             } catch (IllegalVariableEvaluationException e) {
                                 // Silent catch, if an input depends on another input, or a variable that is populated at runtime / input filling time, we can't resolve it here.
+                            } catch (GeneralSecurityException e) {
+                                throw new RuntimeException(e);
                             }
                         });
                 }

--- a/core/src/main/java/io/kestra/core/runners/RunVariables.java
+++ b/core/src/main/java/io/kestra/core/runners/RunVariables.java
@@ -1,6 +1,5 @@
 package io.kestra.core.runners;
 
-import java.security.GeneralSecurityException;
 import java.util.*;
 import java.util.function.Consumer;
 
@@ -297,8 +296,6 @@ public final class RunVariables {
 
         Builder withTaskRun(TaskRun taskRun);
 
-        Builder withDecryptVariables(boolean decryptVariables);
-
         Builder withVariables(Map<String, Object> variables);
 
         Builder withTrigger(AbstractTrigger trigger);
@@ -306,8 +303,6 @@ public final class RunVariables {
         Builder withEnvs(Map<String, ?> envs);
 
         Builder withGlobals(Map<?, ?> globals);
-
-        Builder withSecretInputs(List<String> secretInputs);
 
         Builder withKestraConfiguration(KestraConfiguration kestraConfiguration);
 
@@ -318,14 +313,6 @@ public final class RunVariables {
          * @return The immutable map of variables.
          */
         Map<String, Object> build(RunContextLogger logger, PropertyContext propertyContext);
-
-        /**
-         * Returns the plaintext values of any SECRET-typed flow output decrypted while building the
-         * variables map, so callers can carry them across the executor/worker boundary for log masking.
-         */
-        default List<String> secretOutputs() {
-            return List.of();
-        }
     }
 
     public record KestraConfiguration(String environment, String url) {
@@ -343,33 +330,15 @@ public final class RunVariables {
         protected Execution execution;
         protected TaskRun taskRun;
         protected AbstractTrigger trigger;
-        protected boolean decryptVariables = true;
         protected Map<String, Object> variables;
         protected Map<String, Object> inputs;
         protected Map<String, Object> outputs;
         protected Map<String, Object> executionOutputs;
         protected Map<String, ?> envs;
         protected Map<?, ?> globals;
-        private final Optional<String> secretKey;
-        private List<String> secretInputs;
         private KestraConfiguration kestraConfiguration;
-        private final List<String> secretOutputs;
 
         public DefaultBuilder() {
-            this(Optional.empty());
-        }
-
-        public DefaultBuilder(final Optional<String> secretKey) {
-            this.secretKey = secretKey;
-            this.secretOutputs = new ArrayList<>();
-        }
-
-        /**
-         * {@inheritDoc}
-         */
-        @Override
-        public List<String> secretOutputs() {
-            return secretOutputs;
         }
 
         // Note: for performance reason, cloning maps should be avoided as much as possible.
@@ -417,21 +386,7 @@ public final class RunVariables {
 
                 builder.put("execution", RunVariables.of(realExecution, executionOutputs));
 
-                if (!MapUtils.isEmpty(outputs)) {
-                    if (decryptVariables) {
-                        // mask SECRET-typed flow output and trigger output
-                        final Secret secret = new Secret(secretKey, logger, decrypted ->
-                        {
-                            secretOutputs.add(decrypted);
-                            logger.usedSecret(decrypted);
-                        });
-                        builder.put("outputs", secret.decrypt(outputs));
-                    } else {
-                        builder.put("outputs", outputs);
-                    }
-                } else {
-                    builder.put("outputs", Collections.emptyMap());
-                }
+                builder.put("outputs", MapUtils.isEmpty(outputs) ? Collections.emptyMap() : outputs);
 
                 if (execution.getTaskRunList() != null || realExecution.getTaskRunList() != null) {
                     var taskRunList = ListUtils.concat(execution.getTaskRunList(), realExecution.getTaskRunList());
@@ -443,12 +398,6 @@ public final class RunVariables {
                 Map<String, Object> inputs = this.inputs == null ? new HashMap<>() : new HashMap<>(this.inputs);
                 if (realExecution.getInputs() != null) {
                     inputs.putAll(realExecution.getInputs());
-                    if (decryptVariables && !ListUtils.isEmpty(secretInputs)) {
-                        final Secret secret = new Secret(secretKey, logger);
-                        for (String secretId : secretInputs) {
-                            decodeInput(secret, secretId, inputs);
-                        }
-                    }
                 }
 
                 if (flow != null && flow.getInputs() != null) {
@@ -470,26 +419,9 @@ public final class RunVariables {
                 }
 
                 if (!inputs.isEmpty()) {
+                    // secrets are left encrypted in every subtree: DefaultRunContext decrypts them when they are
+                    // read and registers each one for masking then, so a serialized context holds no plaintext
                     builder.put("inputs", inputs);
-
-                    // if a secret input is used, add it to the list of secrets to mask on the logger
-                    if (logger != null && !ListUtils.isEmpty(secretInputs)) {
-                        for (String secretInput : secretInputs) {
-                            Object secretValue = getNested(inputs, secretInput);
-                            if (secretValue != null) {
-                                String secret;
-                                // if decryption is disabled, secret input would be still a map of type and encrypted value
-                                if (!decryptVariables) {
-                                    secret = ((Map<String, String>) secretValue).get("value");
-                                } else {
-                                    secret = (String) secretValue;
-                                }
-                                if (secret != null) {
-                                    logger.usedSecret(secret);
-                                }
-                            }
-                        }
-                    }
                 }
 
                 if (realExecution.getTrigger() != null) {
@@ -500,11 +432,8 @@ public final class RunVariables {
                     );
 
                     if (executionTrigger.getVariables() != null) {
-                        Map<String, Object> triggerVariables = executionTrigger.getVariables();
-                        if (decryptVariables) {
-                            final Secret secret = new Secret(secretKey, logger);
-                            triggerVariables = secret.decrypt(triggerVariables);
-                        }
+                        // copied so that adding '_context' never mutates the Execution's own trigger variables
+                        Map<String, Object> triggerVariables = new HashMap<>(executionTrigger.getVariables());
                         triggerVariables.put("_context", triggerContext);
                         builder.put("trigger", triggerVariables);
                     } else {
@@ -574,26 +503,6 @@ public final class RunVariables {
             return builder.build();
         }
 
-        @SuppressWarnings("unchecked")
-        private void decodeInput(Secret secret, String id, Map<String, Object> inputs) {
-            // find the input value that can be nested in case the input has a '.' in it.
-            if (id.indexOf('.') > -1) {
-                String nestedId = id.substring(0, id.indexOf('.'));
-                String restOfId = id.substring(id.indexOf('.') + 1);
-                decodeInput(secret, restOfId, (Map<String, Object>) inputs.get(nestedId));
-            } else if (inputs.containsKey(id)) {
-                try {
-                    Map<String, String> encryptedString = (Map<String, String>) inputs.get(id);
-                    if (encryptedString != null) {
-                        String decoded = secret.decrypt(encryptedString.get("value"));
-                        inputs.put(id, decoded);
-                    }
-                } catch (GeneralSecurityException e) {
-                    throw new RuntimeException(e);
-                }
-            }
-        }
-
         /**
          * Nested-aware containsKey for a dotted id (e.g. {@code environment.region}): walks the nested input map and
          * returns true only when every segment resolves down to the leaf key.
@@ -606,20 +515,6 @@ public final class RunVariables {
             }
             Object child = inputs.get(id.substring(0, dot));
             return child instanceof Map<?, ?> map && containsNested((Map<String, Object>) map, id.substring(dot + 1));
-        }
-
-        /**
-         * Nested-aware get for a dotted id (e.g. {@code credentials.api_key}): walks the nested input map and returns
-         * the leaf value, or {@code null} if any segment is missing or not a map.
-         */
-        @SuppressWarnings("unchecked")
-        private Object getNested(Map<String, Object> inputs, String id) {
-            int dot = id.indexOf('.');
-            if (dot < 0) {
-                return inputs.get(id);
-            }
-            Object child = inputs.get(id.substring(0, dot));
-            return child instanceof Map<?, ?> map ? getNested((Map<String, Object>) map, id.substring(dot + 1)) : null;
         }
 
         /**

--- a/core/src/main/java/io/kestra/core/runners/Secret.java
+++ b/core/src/main/java/io/kestra/core/runners/Secret.java
@@ -53,24 +53,31 @@ final class Secret {
     Map<String, Object> decrypt(final Map<String, Object> data) {
         Map<String, Object> decryptedMap = new LinkedHashMap<>(data);
         for (var entry : data.entrySet()) {
-            if (entry.getValue() instanceof Map map) {
-                // if some value are of type EncryptedString we decode them and replace the object
+            // an encrypted value is an EncryptedString instance when it never left the JVM, and a Map{type, value}
+            // once it has been through serialization, so both shapes must be handled
+            if (entry.getValue() instanceof EncryptedString encryptedString) {
+                decryptInto(decryptedMap, entry.getKey(), encryptedString.getValue());
+            } else if (entry.getValue() instanceof Map map) {
                 if (map.get("type") instanceof String typeStr && EncryptedString.TYPE.equalsIgnoreCase(typeStr)) {
-                    try {
-                        String decoded = decrypt((String) map.get("value"));
-                        onSecretDecrypted.accept(decoded);
-                        decryptedMap.put(entry.getKey(), decoded);
-                    } catch (GeneralSecurityException | IllegalArgumentException e) {
-                        // NOTE: in rare cases, if for ex a Worker didn't have the encryption but an Executor has it,
-                        // we can have a non-encrypted output that we try to decrypt, this will lead to an IllegalArgumentException.
-                        // As it could break the executor, the best is to do nothing in this case and only log an error.
-                        logger.get().warn("Unable to decrypt the output", e);
-                    }
+                    decryptInto(decryptedMap, entry.getKey(), (String) map.get("value"));
                 } else {
                     decryptedMap.put(entry.getKey(), decrypt((Map<String, Object>) map));
                 }
             }
         }
         return decryptedMap;
+    }
+
+    private void decryptInto(final Map<String, Object> target, final String key, final String encrypted) {
+        try {
+            String decoded = decrypt(encrypted);
+            onSecretDecrypted.accept(decoded);
+            target.put(key, decoded);
+        } catch (GeneralSecurityException | IllegalArgumentException e) {
+            // NOTE: in rare cases, if for ex a Worker didn't have the encryption but an Executor has it,
+            // we can have a non-encrypted output that we try to decrypt, this will lead to an IllegalArgumentException.
+            // As it could break the executor, the best is to do nothing in this case and only log an error.
+            logger.get().warn("Unable to decrypt the output", e);
+        }
     }
 }

--- a/core/src/main/java/io/kestra/core/runners/WorkerRunContextData.java
+++ b/core/src/main/java/io/kestra/core/runners/WorkerRunContextData.java
@@ -38,13 +38,19 @@ public sealed interface WorkerRunContextData permits WorkerTaskData, WorkerTrigg
 
     /**
      * Filters a {@link RunContext}'s variables by removing the given reconstructed keys.
+     * <p>
+     * Reads the variables in their pre-decryption form, so a secret is never serialized in cleartext onto a queue;
+     * the receiving side decrypts it when it reads the variables back.
      *
      * @param runContext the RunContext whose variables to filter
      * @param keysToRemove keys to strip from the variables map
      * @return a mutable copy of the variables with the specified keys removed
      */
     static Map<String, Object> filterVariables(RunContext runContext, Set<String> keysToRemove) {
-        Map<String, Object> filtered = new HashMap<>(runContext.getVariables());
+        Map<String, Object> variables = runContext instanceof DefaultRunContext defaultRunContext
+            ? defaultRunContext.rawVariables()
+            : runContext.getVariables();
+        Map<String, Object> filtered = new HashMap<>(variables);
         filtered.keySet().removeAll(keysToRemove);
         return filtered;
     }

--- a/core/src/main/java/io/kestra/core/runners/WorkerRunContextData.java
+++ b/core/src/main/java/io/kestra/core/runners/WorkerRunContextData.java
@@ -18,9 +18,6 @@ public sealed interface WorkerRunContextData permits WorkerTaskData, WorkerTrigg
     /** The variables map, stripped of worker-reconstructed keys. */
     Map<String, Object> variables();
 
-    /** List of input keys that are secrets (for log masking). */
-    List<String> secretInputs();
-
     /** OpenTelemetry trace parent for distributed tracing. */
     @Nullable
     String traceParent();

--- a/core/src/main/java/io/kestra/core/runners/WorkerTaskData.java
+++ b/core/src/main/java/io/kestra/core/runners/WorkerTaskData.java
@@ -16,16 +16,14 @@ import io.micronaut.core.annotation.Nullable;
  * Carries the variables map (minus keys the worker reconstructs locally),
  * plus metadata needed to initialize a {@link RunContext} on the worker side.
  *
- * @param variables The variables map, stripped of worker-reconstructed keys.
+ * @param variables The variables map, stripped of worker-reconstructed keys. Secret values are still encrypted.
  * @param secretInputs List of input keys that are secrets (for log masking).
- * @param secretOutputs Plaintext values of SECRET-typed flow outputs already decrypted by the executor.
  * @param traceParent OpenTelemetry trace parent for distributed tracing.
  */
 @JsonInclude(JsonInclude.Include.ALWAYS)
 public record WorkerTaskData(
     @JsonInclude(value = JsonInclude.Include.ALWAYS, content = JsonInclude.Include.ALWAYS) Map<String, Object> variables,
     List<String> secretInputs,
-    @Nullable List<String> secretOutputs,
     @Nullable String traceParent) implements WorkerRunContextData {
 
     /**
@@ -47,7 +45,6 @@ public record WorkerTaskData(
         return new WorkerTaskData(
             WorkerRunContextData.filterVariables(runContext, WORKER_RECONSTRUCTED_KEYS),
             runContext.getSecretInputs(),
-            runContext.getSecretOutputs(),
             runContext.getTraceParent()
         );
     }

--- a/core/src/main/java/io/kestra/core/runners/WorkerTaskData.java
+++ b/core/src/main/java/io/kestra/core/runners/WorkerTaskData.java
@@ -17,13 +17,11 @@ import io.micronaut.core.annotation.Nullable;
  * plus metadata needed to initialize a {@link RunContext} on the worker side.
  *
  * @param variables The variables map, stripped of worker-reconstructed keys. Secret values are still encrypted.
- * @param secretInputs List of input keys that are secrets (for log masking).
  * @param traceParent OpenTelemetry trace parent for distributed tracing.
  */
 @JsonInclude(JsonInclude.Include.ALWAYS)
 public record WorkerTaskData(
     @JsonInclude(value = JsonInclude.Include.ALWAYS, content = JsonInclude.Include.ALWAYS) Map<String, Object> variables,
-    List<String> secretInputs,
     @Nullable String traceParent) implements WorkerRunContextData {
 
     /**
@@ -44,7 +42,6 @@ public record WorkerTaskData(
     public static WorkerTaskData from(RunContext runContext) {
         return new WorkerTaskData(
             WorkerRunContextData.filterVariables(runContext, WORKER_RECONSTRUCTED_KEYS),
-            runContext.getSecretInputs(),
             runContext.getTraceParent()
         );
     }

--- a/core/src/main/java/io/kestra/core/runners/WorkerTriggerData.java
+++ b/core/src/main/java/io/kestra/core/runners/WorkerTriggerData.java
@@ -36,7 +36,6 @@ public record WorkerTriggerData(
 
     // --- RunContext wire data ---
     @JsonInclude(value = JsonInclude.Include.ALWAYS, content = JsonInclude.Include.ALWAYS) Map<String, Object> variables,
-    List<String> secretInputs,
     @Nullable String traceParent,
 
     // --- Condition data ---
@@ -75,7 +74,6 @@ public record WorkerTriggerData(
             flow.getVariables(),
             flow.getLabels(),
             WorkerRunContextData.filterVariables(runContext, WORKER_RECONSTRUCTED_KEYS),
-            runContext.getSecretInputs(),
             runContext.getTraceParent(),
             conditionContext.getVariables()
         );

--- a/core/src/test/java/io/kestra/core/runners/RunContextLoggerLabelsTest.java
+++ b/core/src/test/java/io/kestra/core/runners/RunContextLoggerLabelsTest.java
@@ -94,7 +94,7 @@ class RunContextLoggerLabelsTest {
         Task task = mock(Task.class);
         when(task.getLogLevel()).thenReturn(Level.TRACE);
         when(task.isLogToFile()).thenReturn(false);
-        WorkerTaskData data = new WorkerTaskData(Map.of(RunVariables.LABELS, Label.toNestedMap(List.of(labels))), List.of(), List.of(), null);
+        WorkerTaskData data = new WorkerTaskData(Map.of(RunVariables.LABELS, Label.toNestedMap(List.of(labels))), List.of(), null);
         return WorkerTask.builder().taskRun(taskRun).task(task).data(data).build();
     }
 

--- a/core/src/test/java/io/kestra/core/runners/RunContextLoggerLabelsTest.java
+++ b/core/src/test/java/io/kestra/core/runners/RunContextLoggerLabelsTest.java
@@ -94,7 +94,7 @@ class RunContextLoggerLabelsTest {
         Task task = mock(Task.class);
         when(task.getLogLevel()).thenReturn(Level.TRACE);
         when(task.isLogToFile()).thenReturn(false);
-        WorkerTaskData data = new WorkerTaskData(Map.of(RunVariables.LABELS, Label.toNestedMap(List.of(labels))), List.of(), null);
+        WorkerTaskData data = new WorkerTaskData(Map.of(RunVariables.LABELS, Label.toNestedMap(List.of(labels))), null);
         return WorkerTask.builder().taskRun(taskRun).task(task).data(data).build();
     }
 

--- a/core/src/test/java/io/kestra/core/runners/RunContextLoggerTest.java
+++ b/core/src/test/java/io/kestra/core/runners/RunContextLoggerTest.java
@@ -169,12 +169,13 @@ class RunContextLoggerTest {
             false
         );
 
-        // When the outputs are decrypted while building the run variables
-        new RunVariables.DefaultBuilder(Optional.of(secretKey))
-            .withExecution(execution)
-            .withOutputs(outputs)
-            .withDecryptVariables(true)
-            .build(runContextLogger, PropertyContext.create(renderer));
+        // When the outputs are decrypted as the run context reads them
+        new DefaultRunContext.Builder()
+            .withSecretKey(Optional.of(secretKey))
+            .withLogger(runContextLogger)
+            .withVariables(Map.of("outputs", outputs))
+            .build()
+            .getVariables();
 
         // Then the decrypted plaintext is registered for log masking, exactly like a SECRET input
         runContextLogger.logger().info("the secret is {}", "my-super-secret-value");

--- a/core/src/test/java/io/kestra/core/runners/RunVariablesTest.java
+++ b/core/src/test/java/io/kestra/core/runners/RunVariablesTest.java
@@ -1,6 +1,7 @@
 package io.kestra.core.runners;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -26,6 +27,7 @@ import io.kestra.core.models.flows.input.BoolInput;
 import io.kestra.core.models.property.Property;
 import io.kestra.core.models.property.PropertyContext;
 import io.kestra.core.models.tasks.Task;
+import io.kestra.core.models.tasks.common.EncryptedString;
 import io.kestra.core.models.triggers.AbstractTrigger;
 import io.kestra.core.runners.configuration.VariableConfiguration;
 import io.kestra.core.runners.pebble.PebbleEngineFactory;
@@ -538,5 +540,53 @@ class RunVariablesTest {
             }
             // Lists (e.g. parents) — record the path but don't recurse into list elements
         }
+    }
+
+    private static Map<String, Object> encryptedString() {
+        return new HashMap<>(Map.of("type", EncryptedString.TYPE, "value", "ciphertext"));
+    }
+
+    @Test
+    void shouldNotMutateExecutionInputsWhenBuildingVariables() {
+        // Given
+        Map<String, Object> nested = new HashMap<>(Map.of("key", encryptedString()));
+        Execution execution = Execution.builder()
+            .id("exec")
+            .namespace("io.kestra.tests")
+            .flowId("flow")
+            .flowRevision(1)
+            .state(new State())
+            .inputs(new HashMap<>(Map.of("nested", nested)))
+            .build();
+
+        // When
+        new RunVariables.DefaultBuilder()
+            .withExecution(execution)
+            .build(new RunContextLogger(), PropertyContext.create(renderer));
+
+        // Then
+        assertThat(nested.get("key")).isEqualTo(encryptedString());
+    }
+
+    @Test
+    void shouldNotMutateExecutionTriggerVariablesWhenBuildingVariables() {
+        // Given
+        Map<String, Object> triggerVariables = new HashMap<>(Map.of("token", encryptedString()));
+        Execution execution = Execution.builder()
+            .id("exec")
+            .namespace("io.kestra.tests")
+            .flowId("flow")
+            .flowRevision(1)
+            .state(new State())
+            .trigger(ExecutionTrigger.builder().id("trigger").type("io.kestra.trigger").variables(triggerVariables).build())
+            .build();
+
+        // When
+        new RunVariables.DefaultBuilder()
+            .withExecution(execution)
+            .build(new RunContextLogger(), PropertyContext.create(renderer));
+
+        // Then
+        assertThat(triggerVariables).doesNotContainKey("_context");
     }
 }

--- a/core/src/test/java/io/kestra/core/runners/WorkerTaskDataTest.java
+++ b/core/src/test/java/io/kestra/core/runners/WorkerTaskDataTest.java
@@ -1,0 +1,81 @@
+package io.kestra.core.runners;
+
+import java.util.Map;
+
+import io.kestra.core.junit.annotations.KestraTest;
+import io.kestra.core.junit.annotations.LoadFlows;
+import io.kestra.core.models.executions.Execution;
+import io.kestra.core.models.executions.TaskRun;
+import io.kestra.core.models.flows.Flow;
+import io.kestra.core.models.flows.State;
+import io.kestra.core.models.tasks.ResolvedTask;
+import io.kestra.core.repositories.FlowRepositoryInterface;
+import io.kestra.core.serializers.JacksonMapper;
+
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@KestraTest
+class WorkerTaskDataTest {
+
+    @Inject
+    private RunContextFactory runContextFactory;
+
+    @Inject
+    private FlowInputOutput flowInputOutput;
+
+    @Inject
+    private FlowRepositoryInterface flowRepository;
+
+    @Test
+    @LoadFlows(value = { "flows/valids/input-log-secret.yaml" }, tenantId = "tenant6624")
+    void shouldNotSerializePlaintextSecretsWhenBuildingWireData() throws Exception {
+        // Given
+        RunContext runContext = runContextForSecretInputs("tenant6624");
+
+        // When
+        String serialized = JacksonMapper.ofJson().writeValueAsString(WorkerTaskData.from(runContext));
+
+        // Then
+        assertThat(serialized).doesNotContain("s3cr3t");
+        assertThat(serialized).doesNotContain("n3st3d");
+        assertThat(serialized).contains("io.kestra.datatype:aes_encrypted");
+    }
+
+    @Test
+    @LoadFlows(value = { "flows/valids/input-log-secret.yaml" }, tenantId = "tenant6624bis")
+    void shouldRenderSecretInputsAsPlaintextWhenReadFromTheRunContext() throws Exception {
+        // Given
+        RunContext runContext = runContextForSecretInputs("tenant6624bis");
+
+        // When
+        String rendered = runContext.render("{{ inputs.secret }}-{{ inputs.nested.key }}");
+
+        // Then
+        assertThat(rendered).isEqualTo("s3cr3t-n3st3d");
+    }
+
+    /**
+     * Builds a run context for the {@code input-log-secret} flow, which declares both a top-level and a dotted
+     * SECRET input so one payload covers both shapes.
+     */
+    private RunContext runContextForSecretInputs(String tenantId) throws Exception {
+        Flow flow = flowRepository.findById(tenantId, "io.kestra.tests", "input-log-secret").orElseThrow();
+        Execution execution = Execution.builder()
+            .id("exec6624")
+            .namespace(flow.getNamespace())
+            .tenantId(flow.getTenantId())
+            .flowId(flow.getId())
+            .flowRevision(1)
+            .state(new State())
+            .build();
+        execution = execution.withInputs(
+            flowInputOutput.readExecutionInputs(flow, execution, Map.of("secret", "s3cr3t", "nested.key", "n3st3d"))
+        );
+
+        var task = flow.getTasks().getFirst();
+        return runContextFactory.of(flow, task, execution, TaskRun.of(execution, ResolvedTask.of(task)));
+    }
+}

--- a/core/src/test/java/io/kestra/core/runners/WorkerTaskDataTest.java
+++ b/core/src/test/java/io/kestra/core/runners/WorkerTaskDataTest.java
@@ -57,6 +57,34 @@ class WorkerTaskDataTest {
         assertThat(rendered).isEqualTo("s3cr3t-n3st3d");
     }
 
+
+    @Test
+    @LoadFlows(value = { "flows/valids/input-log-secret.yaml" }, tenantId = "tenant6624ter")
+    void shouldNotSerializePlaintextSecretsWhenTheValueComesFromAnInputDefault() throws Exception {
+        // Given
+        Flow flow = flowRepository.findById("tenant6624ter", "io.kestra.tests", "input-log-secret").orElseThrow();
+        // an execution whose inputs were never resolved, so the flow defaults are filled in while building variables
+        Execution execution = Execution.builder()
+            .id("exec6624ter")
+            .namespace(flow.getNamespace())
+            .tenantId(flow.getTenantId())
+            .flowId(flow.getId())
+            .flowRevision(1)
+            .state(new State())
+            .build();
+
+        var task = flow.getTasks().getFirst();
+        var runContext = runContextFactory.of(flow, task, execution, TaskRun.of(execution, ResolvedTask.of(task)));
+
+        // When
+        String serialized = JacksonMapper.ofJson().writeValueAsString(WorkerTaskData.from(runContext));
+
+        // Then
+        assertThat(serialized).doesNotContain("password");
+        assertThat(serialized).contains("io.kestra.datatype:aes_encrypted");
+        assertThat(runContext.render("{{ inputs.secret }}")).isEqualTo("password");
+    }
+
     /**
      * Builds a run context for the {@code input-log-secret} flow, which declares both a top-level and a dotted
      * SECRET input so one payload covers both shapes.

--- a/core/src/test/java/io/kestra/core/runners/WorkerTaskRunningTest.java
+++ b/core/src/test/java/io/kestra/core/runners/WorkerTaskRunningTest.java
@@ -58,7 +58,6 @@ class WorkerTaskRunningTest {
                     "size": 1
                   }
                 },
-                "secretInputs": null,
                 "traceParent": null
               },
               "workerInstance": {

--- a/core/src/test/java/io/kestra/core/services/WorkerQueueServiceTest.java
+++ b/core/src/test/java/io/kestra/core/services/WorkerQueueServiceTest.java
@@ -77,7 +77,7 @@ class WorkerQueueServiceTest {
             .data(
                 new WorkerTriggerData(
                     "tenant", "ns", "flow", null, null, null, null,
-                    Collections.emptyMap(), null, null, Collections.emptyMap()
+                    Collections.emptyMap(), null, Collections.emptyMap()
                 )
             )
             .build();

--- a/jdbc/src/test/java/io/kestra/jdbc/runner/JdbcWorkerJobRunningStateStoreTest.java
+++ b/jdbc/src/test/java/io/kestra/jdbc/runner/JdbcWorkerJobRunningStateStoreTest.java
@@ -119,7 +119,7 @@ public abstract class JdbcWorkerJobRunningStateStoreTest {
                     .build()
             )
             .task(Log.builder().id("log").type(Log.class.getName()).message("test").build())
-            .data(new WorkerTaskData(Map.of(), List.of(), List.of(), null))
+            .data(new WorkerTaskData(Map.of(), List.of(), null))
             .build();
     }
 }

--- a/jdbc/src/test/java/io/kestra/jdbc/runner/JdbcWorkerJobRunningStateStoreTest.java
+++ b/jdbc/src/test/java/io/kestra/jdbc/runner/JdbcWorkerJobRunningStateStoreTest.java
@@ -119,7 +119,7 @@ public abstract class JdbcWorkerJobRunningStateStoreTest {
                     .build()
             )
             .task(Log.builder().id("log").type(Log.class.getName()).message("test").build())
-            .data(new WorkerTaskData(Map.of(), List.of(), null))
+            .data(new WorkerTaskData(Map.of(), null))
             .build();
     }
 }

--- a/worker-controller/src/test/java/io/kestra/controller/grpc/services/WorkerJobDispatcherTest.java
+++ b/worker-controller/src/test/java/io/kestra/controller/grpc/services/WorkerJobDispatcherTest.java
@@ -240,7 +240,7 @@ class WorkerJobDispatcherTest {
                     .build()
             )
             .task(Log.builder().id("task-1").type(Log.class.getName()).build())
-            .data(new WorkerTaskData(Map.of(), List.of(), null, null))
+            .data(new WorkerTaskData(Map.of(), List.of(), null))
             .build();
     }
 

--- a/worker-controller/src/test/java/io/kestra/controller/grpc/services/WorkerJobDispatcherTest.java
+++ b/worker-controller/src/test/java/io/kestra/controller/grpc/services/WorkerJobDispatcherTest.java
@@ -240,7 +240,7 @@ class WorkerJobDispatcherTest {
                     .build()
             )
             .task(Log.builder().id("task-1").type(Log.class.getName()).build())
-            .data(new WorkerTaskData(Map.of(), List.of(), null))
+            .data(new WorkerTaskData(Map.of(), null))
             .build();
     }
 
@@ -250,7 +250,7 @@ class WorkerJobDispatcherTest {
             .data(
                 new WorkerTriggerData(
                     "main", "io.kestra.test", "flow-1", null, 1, null, null,
-                    Map.of(), List.of(), null, Map.of()
+                    Map.of(), null, Map.of()
                 )
             )
             .build();

--- a/worker/src/test/java/io/kestra/worker/processors/internals/WorkerTriggerCallableTest.java
+++ b/worker/src/test/java/io/kestra/worker/processors/internals/WorkerTriggerCallableTest.java
@@ -74,7 +74,7 @@ class WorkerTriggerCallableTest {
             .trigger(trigger)
             .data(new WorkerTriggerData(
                 "tenant", "io.kestra.tests", "flow", ZonedDateTime.now(), null, null, null,
-                Collections.emptyMap(), Collections.emptyList(), null, Collections.emptyMap()
+                Collections.emptyMap(), null, Collections.emptyMap()
             ))
             .build();
 


### PR DESCRIPTION
### ✨ Description

Secrets were decrypted when the run context was **built**, and `WorkerTaskData.from()` then copied that variables map onto the worker job queue. `SECRET` inputs, `SECRET` flow outputs and encrypted trigger variables therefore travelled in cleartext — and for the JDBC and Kafka queue implementations they were **persisted** that way.

Decryption now happens when the variables are **read** instead of when they are built, so the encrypted form is what exists at the serialization boundary:

- `RunVariables.DefaultBuilder.build()` no longer decrypts anything.
- `DefaultRunContext` decrypts the `inputs`, `outputs` and `trigger` subtrees once, memoized, and registers each value it decrypts with the logger for masking.
- `WorkerRunContextData.filterVariables` reads the pre-decryption map, so the wire carries `EncryptedString` envelopes.
- `WorkerTaskData.secretOutputs` is removed — it carried plaintext secret values on the job envelope purely so the worker could mask them. The worker now derives them while decrypting.

This **moves** the existing single decryption pass rather than adding one, so a run context costs no more to build than before, and nothing at all when it is built and never read. Everything the eager pass needed and the lazy one does not is deleted with it: the builder's `decryptVariables` flag, secret key, `secretInputs` and `secretOutputs`, `RunContext.getSecretOutputs()`, and the `EncryptionConfig` the worker-side initializer no longer uses. Net **−100 lines** of production code.

Note that a plain "build the worker context undecrypted" fix would have been wrong: the executor renders `runIf` (`ExecutionEventMessageHandler`, `ExecutorService`) and subflow input values (`createSubflowExecutions`) against this same context, so it genuinely needs plaintext locally. Decrypt-on-read keeps those working while the serialized form stays encrypted.

**Two further bugs were found on the way, both fixed here because this change relies on them being correct:**

1. **Plaintext was being written into the live `Execution`.** `decodeInput` mutated the nested input map it was handed, and that map is shared with `Execution.getInputs()` through a shallow copy — so decoding a `FORM`-nested `SECRET` input replaced the ciphertext on the `Execution` the executor goes on to persist. Adding `_context` to the trigger variables mutated the `Execution` the same way.
2. **Log masking was order-dependent.** Secrets were replaced in registration order, so a secret that is a prefix of another left the remainder visible — `pass` registered before `password` produced `******word`. Secrets are now masked longest-first, and registering the same secret twice no longer grows the list.

`Secret.decrypt` also now handles both shapes an encrypted value can take: an `EncryptedString` instance when it never left the JVM, and a `Map{type, value}` once it has been through serialization. Only the latter was handled, so in-process paths silently skipped decryption.

### 🔗 Related Issue

Refs https://github.com/kestra-io/kestra-ee/issues/6624. Companion PR: kestra-io/kestra-ee on the same branch name (`fix/worker-job-encrypted-secrets`), which carries the EE builder cleanup and an EE-side regression test.

**Three commits, and the order is load-bearing:**

1. `fix(secrets): stop sending decrypted secrets to the worker` — the fix above.
2. `fix(secrets): encrypt a SECRET input resolved from its flow default` — closes a leak the first commit exposed. `FlowInputOutput` encrypts every `SECRET` value it reads, but the defaults fallback in `RunVariables` (*"useful for triggers"*) fills in inputs missing from the execution via `FlowInputOutput.resolveDefaultValue`, which routes `SECRET` through the same branch as `STRING` and returns **plaintext**. Since commit 1 makes the variables map the wire format, a `SECRET` resolved from its default was still serialized in cleartext: a run context for an execution with unresolved inputs produced `"inputs":{"secret":"password","nested":{"key":"password"}}`. Defaults are Pebble-rendered, so such a value can also be an expression resolving to a real secret rather than a literal. The fallback now encrypts, restoring the invariant commit 1 depends on — *every secret in the variables map is encrypted until it is read*.
3. `refactor(secrets): drop the secret-input list used for log masking` — with that invariant actually holding, the id list becomes dead. Masking was index-driven (`RunContext` carried the flow's `SECRET` input ids; `setLogger` walked the map to those positions with `findSecret`); it is now structural, since the decryptor reports each value it decrypts wherever it sits in the tree. Removes `RunContext.getSecretInputs()`, the field, builder and `clone()` plumbing, the `setLogger` block, `findSecret`, the `WorkerTaskData` / `WorkerTriggerData` wire components, `secretInputsFromFlow` with its four call sites, and the `ReusableInputsExpander` injection it needed. It also retires `findSecret`'s unguarded cast to `String`, which would have thrown `ClassCastException` on a context built with `decryptVariables=false`.

Commit 3 is only safe because of commit 2: beforehand a `SECRET` resolved from a default sat in the map as plaintext, nothing existed for the decryptor to report, and `findSecret` was the only thing masking it.

### 🛠️ Backend Checklist

- [x] Code compiles successfully and passes all checks
- [x] All unit and integration tests pass

### 📝 Additional Notes

**Regression tests.** `WorkerTaskDataTest` asserts on the *serialized* payload, which is the assertion that would have caught this originally — one case for supplied inputs, one for inputs resolved from flow defaults, plus one confirming `{{ inputs.secret }}` still renders plaintext. Both wire assertions were verified to fail when the fix is neutered. The fixture is `input-log-secret.yaml` because it declares a top-level *and* a dotted `SECRET` input, so one payload covers both code paths.

**Verification.**

| Suite | Result |
|---|---|
| `:core:test` | 3321 passing |
| `:worker:test` / `:executor:test` / `:worker-controller:test` | 113 / 159 / 81 passing |
| `:jdbc-h2:test --tests *H2RunnerTest*` | 99 passing |

3773 passing, zero failures. `InputsTest.shouldNotLogSecretInput` — which catches the prefix-masking bug fixed in commit 1 — passes with the id-driven registration removed, which is the check that mattered for commit 3. Companion EE branch: 1227 passing.

**Wire-format break.** `WorkerTaskData` loses both `secretOutputs` and `secretInputs`, and the variables encoding changes, so an old executor and a new worker are mutually incompatible mid-upgrade; a worker without `kestra.encryption.secret-key` can no longer decrypt what it receives. Accepted deliberately for 2.0. Not backported — the exposure exists back to at least 1.0, but there the whole `RunContext` is serialized into `WorkerTask` with `@JsonInclude` on `getVariables()`, so it needs a different patch.