### PR TITLE
fix(core): display Reverse separator default in plugin docs

### DIFF
--- a/core/src/main/java/io/kestra/plugin/core/storage/Reverse.java
+++ b/core/src/main/java/io/kestra/plugin/core/storage/Reverse.java
@@ -72,7 +72,8 @@ public class Reverse extends Task implements RunnableTask<Reverse.Output> {
     private Property<String> from;
 
     @Schema(
-        title = "The separator used to join the file into chunks. By default, it's a newline `\\n` character. If you are on Windows, you might want to use `\\r\\n` instead."
+        title = "The separator used to join the file into chunks. By default, it's a newline `\\n` character. If you are on Windows, you might want to use `\\r\\n` instead.",
+        defaultValue = "\\n"
     )
     @Builder.Default
     private Property<String> separator = Property.ofValue("\n");

--- a/core/src/test/java/io/kestra/core/docs/JsonSchemaGeneratorTest.java
+++ b/core/src/test/java/io/kestra/core/docs/JsonSchemaGeneratorTest.java
@@ -37,6 +37,7 @@ import io.kestra.plugin.core.dashboard.data.Executions;
 import io.kestra.plugin.core.debug.Return;
 import io.kestra.plugin.core.flow.Dag;
 import io.kestra.plugin.core.log.Log;
+import io.kestra.plugin.core.storage.Reverse;
 import io.kestra.plugin.core.trigger.Schedule;
 
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -351,6 +352,14 @@ class JsonSchemaGeneratorTest {
         assertThat(((Map<String, Map<String, Object>>) generate.get("properties")).get("integerPropertyWithDefault").get("description"), is("integerPropertyWithDefault description"));
         assertThat(((Map<String, Map<String, Object>>) generate.get("properties")).get("integerPropertyWithDefault").get("$deprecated"), is(true));
         assertThat(((Map<String, Map<String, Object>>) generate.get("properties")).get("integerPropertyWithDefault").get("default"), is("10000"));
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    void shouldDisplayReverseSeparatorDefaultAsEscapedNewline() {
+        Map<String, Object> generate = jsonSchemaGenerator.properties(Task.class, Reverse.class);
+
+        assertThat(properties(generate).get("separator").get("default"), is("\\n"));
     }
 
     @SuppressWarnings("unchecked")


### PR DESCRIPTION
### ✨ Description

Expose the Reverse task separator default as the escaped `\\n` value in the generated plugin schema, so it is displayed correctly in the Docs tab. The runtime value remains a real newline.

### 🔗 Related Issue

Closes https://github.com/kestra-io/kestra/issues/14220

### 🛠️ Backend Checklist

- [x] Code changes are limited to the backend
- [x] Added a regression test for the generated schema default
- [ ] Code compiles successfully and passes all checks
- [ ] All unit and integration tests pass

### 📝 Additional Notes

`git diff --check` passes. The targeted Gradle test could not start locally because the environment has Java 21 while the project requires Java 25; the failure occurs during Gradle toolchain configuration.

### 🤖 AI Authors

The cat tried to fix the newline, but it only managed to make one long line. 🐱
