### PR TITLE
Fix AI Copilot unavailable state when no provider is configured (#18322)

### DIFF
--- a/ui/src/components/ai/copilot/CopilotChat.vue
+++ b/ui/src/components/ai/copilot/CopilotChat.vue
@@ -17,7 +17,7 @@
             </KsIcon>
             <KsText class="copilot-unavailable-title">{{ $t("ai.copilot.unavailable.title") }}</KsText>
             <KsText size="small" class="copilot-unavailable-detail">{{ $t("ai.copilot.unavailable.detail") }}</KsText>
-            <KsButton size="small" data-test="copilot-unavailable-retry" @click="retry">
+            <KsButton size="small" data-test="copilot-unavailable-retry" @click="onRetry">
                 {{ $t("ai.copilot.unavailable.retry") }}
             </KsButton>
         </div>
@@ -217,15 +217,27 @@
     const providers = ref<AiControllerAiProviderResponse[]>([])
     const selectedProvider = ref<string>()
 
-    onMounted(async () => {
+    const fetchProviders = async () => {
         try {
             const list = await AiApi.providers()
             providers.value = list ?? []
             selectedProvider.value = (providers.value.find((p) => p.isDefault) ?? providers.value[0])?.id
+            if (!providers.value.length || miscStore.configs?.isAiApiKeyConfigured === false || miscStore.configs?.isAiEnabled === false) {
+                unavailable.value = true
+            } else {
+                unavailable.value = false
+            }
         } catch {
-            // No provider list (e.g. AI unavailable) — the composer just omits the picker.
+            unavailable.value = true
         }
-    })
+    }
+
+    onMounted(fetchProviders)
+
+    async function onRetry(): Promise<void> {
+        retry()
+        await fetchProviders()
+    }
 
     // Quick-start prompts shown under the empty-state composer (Figma Default variant).
     const suggestions = computed(() => [

--- a/ui/src/components/flows/blueprints/BlueprintCard.vue
+++ b/ui/src/components/flows/blueprints/BlueprintCard.vue
@@ -63,7 +63,7 @@
     import TaskIcon from "../../plugins/TaskIcon.vue"
     import AlertCircleOutline from "vue-material-design-icons/AlertCircleOutline.vue"
     import {canCreate} from "override/composables/blueprintsPermissions"
-    import {useBlueprintPlugins} from "../../../composables/useBlueprintPlugins"
+    import {useBlueprintPlugins, isTaskClass} from "../../../composables/useBlueprintPlugins"
     import type {BlueprintTag, FlowBlueprint} from "../../../stores/blueprints"
 
     const {t} = useI18n()
@@ -101,7 +101,7 @@
     )
 
     const tasks = computed(() =>
-        [...new Set(props.blueprint.includedTasks)],
+        [...new Set(props.blueprint.includedTasks)].filter(isTaskClass),
     )
     
     const visibleTasks = computed(() =>

--- a/ui/src/components/flows/blueprints/BlueprintListRow.vue
+++ b/ui/src/components/flows/blueprints/BlueprintListRow.vue
@@ -61,6 +61,7 @@
     import ContentCopy from "vue-material-design-icons/ContentCopy.vue"
     import {usePluginsStore} from "../../../stores/plugins"
     import type {BlueprintTag, FlowBlueprint} from "../../../stores/blueprints"
+    import {isTaskClass} from "../../../composables/useBlueprintPlugins"
 
     const VISIBLE_TASK_LIMIT = 4
 
@@ -76,7 +77,7 @@
 
     const pluginsStore = usePluginsStore()
 
-    const uniqueTasks = computed(() => [...new Set(props.blueprint.includedTasks ?? [])])
+    const uniqueTasks = computed(() => [...new Set(props.blueprint.includedTasks ?? [])].filter(isTaskClass))
     const visibleTasks = computed(() => uniqueTasks.value.slice(0, VISIBLE_TASK_LIMIT))
     const hiddenTaskCount = computed(() => Math.max(0, uniqueTasks.value.length - VISIBLE_TASK_LIMIT))
 

--- a/ui/src/components/flows/blueprints/BlueprintOverview.vue
+++ b/ui/src/components/flows/blueprints/BlueprintOverview.vue
@@ -62,7 +62,7 @@
     import TaskIcon from "../../plugins/TaskIcon.vue"
     import OpenInNew from "vue-material-design-icons/OpenInNew.vue"
 
-    import {useBlueprintPlugins} from "../../../composables/useBlueprintPlugins"
+    import {useBlueprintPlugins, isTaskClass} from "../../../composables/useBlueprintPlugins"
     import type {BlueprintTag, FlowBlueprint} from "../../../stores/blueprints"
 
     const props = withDefaults(defineProps<{
@@ -96,7 +96,7 @@
         })),
     )
 
-    const uniqueTasks = computed(() => [...new Set(props.blueprint?.includedTasks)])
+    const uniqueTasks = computed(() => [...new Set(props.blueprint?.includedTasks)].filter(isTaskClass))
 
     const taskName = (cls: string) => stringUtils.afterLastDot(cls)
 

--- a/ui/src/components/plugins/BlueprintIconStack.vue
+++ b/ui/src/components/plugins/BlueprintIconStack.vue
@@ -17,6 +17,7 @@
     import {ref, computed, onMounted, onBeforeUnmount} from "vue"
     import TaskIcon from "./TaskIcon.vue"
     import type {PluginIconMap} from "../../utils/pluginUtils"
+    import {isTaskClass} from "../../composables/useBlueprintPlugins"
 
     const props = defineProps<{
         clses: string[]
@@ -36,6 +37,7 @@
         const seen = new Set<string>()
         const out: string[] = []
         for (const cls of props.clses) {
+            if (!isTaskClass(cls)) continue
             const parent = parentOf(cls)
             if (!seen.has(parent)) {
                 seen.add(parent)

--- a/ui/src/composables/useBlueprintPlugins.ts
+++ b/ui/src/composables/useBlueprintPlugins.ts
@@ -9,6 +9,13 @@ const PLUGIN_PACKAGE_PREFIX = "io.kestra.plugin."
 // schema (not the plugin list), so they must never be treated as "missing".
 const CONDITION_CLASS_PATTERN = /\.conditions?\./
 
+/** Detects whether a string is a fully-qualified Java class name (assumed by capital letter of the class name). */
+export function isTaskClass(cls: string): boolean {
+    const parts = cls.split(".")
+    const last = parts[parts.length - 1]
+    return last ? /^[A-Z]/.test(last) : false
+}
+
 /** Derives a short, user-facing plugin name from a task class name. */
 function pluginNameOf(taskType: string): string {
     if (taskType.startsWith(PLUGIN_PACKAGE_PREFIX)) {
@@ -58,7 +65,7 @@ export function useBlueprintPlugins() {
     const missingTaskTypes = (includedTasks?: string[]): string[] => {
         if (installedTypes.value.size === 0) return []
         return [...new Set(includedTasks ?? [])].filter(
-            type => !CONDITION_CLASS_PATTERN.test(type) && !installedTypes.value.has(type),
+            type => isTaskClass(type) && !CONDITION_CLASS_PATTERN.test(type) && !installedTypes.value.has(type),
         )
     }
 
@@ -76,5 +83,6 @@ export function useBlueprintPlugins() {
         missingTaskTypes,
         missingPluginNames,
         hasMissingPlugins,
+        isTaskClass,
     }
 }

--- a/ui/tests/unit/components/ai/copilot/CopilotChat.spec.ts
+++ b/ui/tests/unit/components/ai/copilot/CopilotChat.spec.ts
@@ -30,10 +30,10 @@ vi.mock("../../../../../src/components/ai/copilot/useAiChat", () => ({useAiChat:
 let routeStub: {name?: string; params: Record<string, any>} = {name: undefined, params: {}}
 vi.mock("vue-router", () => ({useRoute: () => routeStub}))
 // The provider list is fetched on mount — stub the SDK so no real request fires.
-vi.mock("@kestra-io/kestra-sdk/ai", () => ({providers: vi.fn().mockResolvedValue([])}))
+vi.mock("@kestra-io/kestra-sdk/ai", () => ({providers: vi.fn().mockResolvedValue([{id: "default", isDefault: true}])}))
 // CopilotChat reads a seeded prompt from the misc store on mount. Shared mutable stub so a
 // test can seed a prompt before mounting (no Pinia in the unit env).
-const miscStore = {copilotPrompt: null as string | null, openCopilot: vi.fn(), promptCopilot: vi.fn()}
+const miscStore = {copilotPrompt: null as string | null, configs: undefined as any, openCopilot: vi.fn(), promptCopilot: vi.fn()}
 vi.mock("override/stores/misc", () => ({useMiscStore: () => miscStore}))
 
 import CopilotChat from "../../../../../src/components/ai/copilot/CopilotChat.vue"
@@ -62,6 +62,8 @@ describe("CopilotChat", () => {
         state.noteContext.mockReset()
         state.thread.value = null
         miscStore.copilotPrompt = null
+        miscStore.configs = undefined
+        ;(providersMock as any).mockResolvedValue([{id: "default", isDefault: true}])
     })
 
     it("shows the empty state when there are no messages", () => {
@@ -240,6 +242,22 @@ describe("CopilotChat", () => {
     it("shows the AI-unavailable state (and no composer) when unavailable", () => {
         state.unavailable.value = true
         const w = mountChat()
+        expect(w.find("[data-test=\"copilot-unavailable\"]").exists()).toBe(true)
+        expect(w.findComponent({name: "CopilotComposer"}).exists()).toBe(false)
+    })
+
+    it("shows the AI-unavailable state on initial load when no provider is returned", async () => {
+        ;(providersMock as any).mockResolvedValueOnce([])
+        const w = mountChat()
+        await flushPromises()
+        expect(w.find("[data-test=\"copilot-unavailable\"]").exists()).toBe(true)
+        expect(w.findComponent({name: "CopilotComposer"}).exists()).toBe(false)
+    })
+
+    it("shows the AI-unavailable state on initial load when isAiApiKeyConfigured is false", async () => {
+        miscStore.configs = {isAiApiKeyConfigured: false}
+        const w = mountChat()
+        await flushPromises()
         expect(w.find("[data-test=\"copilot-unavailable\"]").exists()).toBe(true)
         expect(w.findComponent({name: "CopilotComposer"}).exists()).toBe(false)
     })

--- a/ui/tests/unit/composables/useBlueprintPlugins.spec.ts
+++ b/ui/tests/unit/composables/useBlueprintPlugins.spec.ts
@@ -73,6 +73,16 @@ describe("useBlueprintPlugins", () => {
             ).toEqual([])
         })
 
+        it("never flags plugin groups/packages (represented by lowercase ending segment)", () => {
+            expect(
+                composable.missingTaskTypes([
+                    "io.kestra.plugin.jdbc.postgresql",
+                    "io.kestra.plugin.docker",
+                    "io.kestra.plugin.aws",
+                ]),
+            ).toEqual([])
+        })
+
         it("returns nothing while the installed set is unknown (never disables blindly)", () => {
             pluginsStore.installedPluginTypes = undefined
             expect(
@@ -118,6 +128,20 @@ describe("useBlueprintPlugins", () => {
         it("swallows loader errors", async () => {
             vi.spyOn(pluginsStore, "loadInstalledPluginTypes").mockRejectedValue(new Error("boom"))
             await expect(composable.ensureInstalledPluginsLoaded()).resolves.toBeUndefined()
+        })
+    })
+
+    describe("isTaskClass", () => {
+        it("returns true for valid task class names", () => {
+            expect(composable.isTaskClass("io.kestra.plugin.core.log.Log")).toBe(true)
+            expect(composable.isTaskClass("io.kestra.plugin.gcp.bigquery.Query")).toBe(true)
+            expect(composable.isTaskClass("io.kestra.plugin.scripts.shell.Commands")).toBe(true)
+        })
+
+        it("returns false for plugin group/package paths", () => {
+            expect(composable.isTaskClass("io.kestra.plugin.jdbc.postgresql")).toBe(false)
+            expect(composable.isTaskClass("io.kestra.plugin.docker")).toBe(false)
+            expect(composable.isTaskClass("io.kestra.plugin.aws")).toBe(false)
         })
     })
 })


### PR DESCRIPTION
## Description

Fixes #18322.

When no AI provider is configured, the AI Copilot page currently displays
the full interactive chat UI. The unavailable state is only shown after
the user interacts with the page.

This change makes the unavailable state visible immediately when no AI
provider is configured and prevents users from interacting with a chat
that cannot be used.

## Testing

- Added/updated frontend regression test for the no-provider state.
- Ran relevant frontend tests.