### PR TITLE
chore(core): rework the pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,37 +1,38 @@
-All PRs submitted by external contributors that do not follow this template (including proper description, related issue, and checklist sections) **may be automatically closed**.
+All PRs submitted by external contributors must follow this template (proper description, related issue, and checklist sections). If you plan to work on a specific issue, comment on the issue first and wait to be assigned before starting any actual work - this avoids duplicated work and ensures a smooth contribution process. PRs that skip either rule **may be automatically closed**.
 
-As a general practice, if you plan to work on a specific issue, comment on the issue first and wait to be assigned before starting any actual work. This avoids duplicated work and ensures a smooth contribution process - otherwise, the PR **may be automatically closed**.
+<!-- PR title must follow Conventional Commits with a single scope, lowercase description: `fix(core): handle empty trigger list`. See AGENTS.md for the allowed types and scopes. -->
 
 ---
 
-### ✨ Description
-
-What does this PR change?  
-_Example: Replaces legacy scroll directive with the new API._
-
 ### 🔗 Related Issue
 
-Which issue does this PR resolve? Use [GitHub Keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue) to automatically link the pull request to the issue.  
-_Example: Closes https://github.com/kestra-io/kestra/issues/ISSUE_NUMBER._
+<!-- Put the closing keyword on the first line so the link is visible without scrolling and survives squash merges: -->
+<!-- Closes https://github.com/kestra-io/kestra/issues/ISSUE_NUMBER. -->
+
+### ✨ Description
+
+<!-- What does this PR change, from the user's point of view? Example: Replaces legacy scroll directive with the new API. -->
 
 ### 🎨 Frontend Checklist
 
-_If this PR does not include any frontend changes, delete this entire section._
+<!-- If this PR does not include any frontend changes, delete this entire section. All commands run from the `ui/` directory. -->
 
+- [ ] Type checking passes (`npm run check:types`)
 - [ ] Code builds without errors (`npm run build`)
-- [ ] All existing E2E tests pass (`npm run test:e2e`)
+- [ ] Unit tests pass (`npm run test:unit`)
+- [ ] Translations are complete if `en.json` changed (`npm run translations:check` reports no missing, extra, or stale keys)
 - [ ] Screenshots or video recordings attached showing the `UI` changes
 
 ### 🛠️ Backend Checklist
 
-_If this PR does not include any backend changes, delete this entire section._
+<!-- If this PR does not include any backend changes, delete this entire section. -->
 
-- [ ] Code compiles successfully and passes all checks
-- [ ] All unit and integration tests pass
+- [ ] Code compiles and tests pass for the touched modules (`./gradlew :module-name:test`, or `./gradlew build` for cross-module changes)
+- [ ] New behavior is covered by unit or integration tests
 
 ### 📝 Additional Notes
 
-Add any extra context or details reviewers should be aware of.
+<!-- Any extra context reviewers should be aware of: trade-offs, follow-ups, things you deliberately did not do. -->
 
 ### 🤖 AI Authors
 


### PR DESCRIPTION
### ✨ Description

This `PR` only touches `.github/pull_request_template.md` - the text every contributor sees pre-filled when opening a `PR` against this repo. No code changes.

**Why:** external contributors regularly leave the template's instruction text ("What does this PR change? Example: ...") in their final description, the checklist commands are incomplete or lack the working directory, and the issue link is buried below the description. The template also repeated the "may be automatically closed" warning twice.

**What changed:**

- All instruction text is now inside HTML comments (`<!-- -->`), which GitHub hides when the description renders. A contributor who submits without editing now produces a clean skeleton of headings and checkboxes instead of leftover template prose.
- The two intro warning paragraphs are merged into one, so the auto-close warning appears once.
- The "Related Issue" section moved above "Description", with a commented example of the closing keyword line (`Closes https://github.com/kestra-io/kestra/issues/NUMBER.`), so the issue link ends up at the top of the body where it is visible without scrolling.
- New commented reminder that the `PR` title must follow Conventional Commits: one scope, lowercase description.
- Frontend checklist: now says commands run from `ui/`, adds `npm run check:types` and `npm run translations:check` (both are `CI` gates today but were missing), and replaces the full local e2e run with `npm run test:unit` - `CI` owns e2e.
- Backend checklist: replaces the vague "passes all checks" with the concrete Gradle commands (`./gradlew :module-name:test`, `./gradlew build`) and adds a checkbox asking that new behavior is covered by tests.

**Kept as is:** the two contribution policy rules (follow the template, comment on the issue and wait for assignment before working) and the `AI` authors cat-joke section.

**How to review:** the raw diff is small, but the easiest check is to open the file on this branch and imagine it as a freshly opened `PR` form - everything in `<!-- -->` vanishes, everything else is what the contributor and reviewer will actually see.