### PR TITLE
fix(dashboards): correct execution chart durations (1.3 backport)

### DIFF
--- a/core/src/test/java/io/kestra/core/repositories/AbstractExecutionRepositoryTest.java
+++ b/core/src/test/java/io/kestra/core/repositories/AbstractExecutionRepositoryTest.java
@@ -59,6 +59,7 @@ import static io.kestra.core.models.flows.FlowScope.SYSTEM;
 import static io.kestra.core.models.flows.FlowScope.USER;
 import static java.time.temporal.ChronoUnit.SECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.within;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.doReturn;
@@ -767,6 +768,54 @@ public abstract class AbstractExecutionRepositoryTest {
         assertThat(data).first().hasFieldOrProperty("count");
         assertThat(data).first().extracting("count").hasToString("1");
         assertThat(data).first().hasFieldOrPropertyWithValue("id", execution.getId());
+    }
+
+    @Test
+    protected void dashboard_fetchData_durationAggregationInSeconds() throws IOException {
+        var tenantId = TestsUtils.randomTenant(this.getClass().getSimpleName());
+        var executionCreateDate = Instant.now().minus(Duration.ofMinutes(5));
+
+        // sub-minute durations only: the Postgres state_duration column loses the minutes part of longer durations
+        executionRepository.save(executionWithDuration(tenantId, executionCreateDate, Duration.ofMillis(500)));
+        executionRepository.save(executionWithDuration(tenantId, executionCreateDate, Duration.ofMillis(1500)));
+
+        var now = ZonedDateTime.now();
+        ArrayListTotal<Map<String, Object>> data = executionRepository.fetchData(
+            tenantId, Executions.builder()
+                .type(Executions.class.getName())
+                .columns(
+                    Map.of(
+                        "state", ColumnDescriptor.<Executions.Fields> builder().field(Executions.Fields.STATE).build(),
+                        "total", ColumnDescriptor.<Executions.Fields> builder().field(Executions.Fields.ID).agg(AggregationType.COUNT).build(),
+                        "duration", ColumnDescriptor.<Executions.Fields> builder().field(Executions.Fields.DURATION).agg(AggregationType.SUM).build()
+                    )
+                ).build(),
+            now.minusHours(1),
+            now,
+            null
+        );
+
+        assertThat(data.getTotal()).isEqualTo(1L);
+        assertThat(data).first().extracting("total").hasToString("2");
+        // the DURATION column is exposed in seconds, keeping the sub-second part: 0.5s + 1.5s
+        assertThat(((Number) data.getFirst().get("duration")).doubleValue()).isCloseTo(2.0d, within(0.001d));
+    }
+
+    private Execution executionWithDuration(String tenantId, Instant createDate, Duration duration) {
+        return Execution.builder()
+            .tenantId(tenantId)
+            .id(IdUtils.create())
+            .namespace("io.kestra.unittest")
+            .flowId("some-execution")
+            .flowRevision(1)
+            .state(
+                new State(
+                    Type.SUCCESS,
+                    List.of(new State.History(State.Type.CREATED, createDate), new State.History(Type.SUCCESS, createDate.plus(duration)))
+                )
+            )
+            .taskRunList(List.of())
+            .build();
     }
 
     @Test

--- a/jdbc-h2/src/main/resources/migrations/h2/V1_57__executions_state_duration_millis.sql
+++ b/jdbc-h2/src/main/resources/migrations/h2/V1_57__executions_state_duration_millis.sql
@@ -1,0 +1,7 @@
+-- executions.state_duration was generated in seconds (the raw .state.duration JSON value), while every consumer
+-- (dashboard charts divide by 1000 to render seconds) and the Postgres and MySQL columns use milliseconds.
+-- Regenerate the column in milliseconds.
+DROP INDEX IF EXISTS executions_state_duration;
+ALTER TABLE executions DROP COLUMN IF EXISTS "state_duration";
+ALTER TABLE executions ADD COLUMN IF NOT EXISTS "state_duration" FLOAT GENERATED ALWAYS AS (JQ_DOUBLE("value", '.state.duration') * 1000);
+CREATE INDEX IF NOT EXISTS executions_state_duration ON executions ("deleted", "tenant_id", "state_duration");

--- a/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcExecutionRepository.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcExecutionRepository.java
@@ -1063,7 +1063,8 @@ public abstract class AbstractJdbcExecutionRepository extends AbstractJdbcCrudRe
         } else if (field.getName().equals(START_DATE_FIELD.getName())) {
             return START_DATE_FIELD;
         } else if (field.getName().equals(fieldsMapping.get(Executions.Fields.DURATION))) {
-            return DSL.field("{0} / 1000", Long.class, field);
+            // divide by a decimal so Postgres does not integer-divide, which truncated sub-second durations to 0
+            return DSL.field("{0} / 1000.0", Double.class, field);
         }
         return field;
     }

--- a/jdbc/src/main/java/io/kestra/jdbc/services/JdbcFilterService.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/services/JdbcFilterService.java
@@ -30,11 +30,12 @@ public class JdbcFilterService extends AbstractFilterService<SelectConditionStep
 
     public AggregateFunction<?> buildAggregation(Field<?> field, AggregationType agg) {
 
+        // coerce instead of cast: a SQL cast renders as CAST(... AS DECIMAL) on MySQL, which has scale 0 and rounds every value to an integer
         return switch (agg) {
-            case AVG -> avg(field.cast(Double.class));
-            case MAX -> max(field.cast(Double.class));
-            case MIN -> min(field.cast(Double.class));
-            case SUM -> sum(field.cast(Double.class));
+            case AVG -> avg(field.coerce(Double.class));
+            case MAX -> max(field.coerce(Double.class));
+            case MIN -> min(field.coerce(Double.class));
+            case SUM -> sum(field.coerce(Double.class));
             case COUNT -> field != null ? count(field) : count();
         };
     }


### PR DESCRIPTION
Related to https://github.com/kestra-io/kestra/issues/18290.

Backport of the backend part of https://github.com/kestra-io/kestra/pull/18344 to `releases/v1.3.x`.

## What

The duration values behind dashboard execution charts were wrong on all three JDBC databases:

- **H2**: the `state_duration` generated column stored **seconds** (the raw `.state.duration` JSON value) while Postgres and MySQL store milliseconds, so every dashboard duration on H2 was 1000x too small (the `duration = 0s` reported in the issue). A new Flyway migration (`V1_57`) regenerates the column in milliseconds, keeping the nullability introduced by `V1_48`.
- **Postgres**: `state_duration / 1000` is BIGINT **integer division**, truncating every sub-second execution to 0. Now `/ 1000.0`.
- **MySQL**: the aggregation layer's jOOQ `cast(Double.class)` renders as `CAST(... AS DECIMAL)` - scale 0, rounding every value to a whole number. Now `coerce`, which keeps the Java-side type without emitting any SQL cast.

The frontend changes of the original PR are not needed on this branch: its chart already formats durations as seconds through its own tooltip and axis callbacks, so the display becomes correct with the backend fixes alone.

The new shared repository test `dashboard_fetchData_durationAggregationInSeconds` guards all three defects; verified green locally on H2 (full `H2ExecutionRepositoryTest` class), Postgres and MySQL on this branch.