### PR TITLE
fix(flows): add top padding to the Source search YAML preview editor

### DIFF
--- a/ui/src/components/flows/SourceSearchPreview.vue
+++ b/ui/src/components/flows/SourceSearchPreview.vue
@@ -88,7 +88,7 @@
                     lang="yaml"
                     :readOnly="true"
                     :navbar="false"
-                    :options="{editor: {padding: {top: 8}}}"
+                    :options="{editor: {padding: {top: 16, bottom: 16}}}"
                     @editorMounted="applyHighlight"
                 />
             </template>

--- a/ui/src/components/flows/SourceSearchPreview.vue
+++ b/ui/src/components/flows/SourceSearchPreview.vue
@@ -88,6 +88,7 @@
                     lang="yaml"
                     :readOnly="true"
                     :navbar="false"
+                    :options="{editor: {padding: {top: 8}}}"
                     @editorMounted="applyHighlight"
                 />
             </template>

--- a/ui/tests/unit/components/flows/SourceSearchPreview.spec.ts
+++ b/ui/tests/unit/components/flows/SourceSearchPreview.spec.ts
@@ -137,6 +137,7 @@ describe("SourceSearchPreview", () => {
 
         expect(wrapper.find("[data-test='ks-editor']").exists()).toBe(true)
         expect(mockRevealLineInCenter).toHaveBeenCalledWith(2)
+        expect(wrapper.findComponent({name: "KsEditor"}).props("options")).toEqual({editor: {padding: {top: 16, bottom: 16}}})
     })
 
     test("shows error state when loadFlow rejects", async () => {

--- a/ui/tests/unit/components/flows/SourceSearchPreview.spec.ts
+++ b/ui/tests/unit/components/flows/SourceSearchPreview.spec.ts
@@ -42,7 +42,7 @@ vi.mock("@kestra-io/design-system", async (importOriginal) => {
         KsEditor: {
             name: "KsEditor",
             template: "<div class=\"ks-editor-mock\" data-test=\"ks-editor\"></div>",
-            props: ["modelValue", "lang", "readOnly", "navbar"],
+            props: ["modelValue", "lang", "readOnly", "navbar", "options"],
             emits: ["editorMounted"],
             setup(_props: unknown, {emit, expose}: {emit: (e: string, ...args: unknown[]) => void; expose: (api: Record<string, unknown>) => void}) {
                 expose({


### PR DESCRIPTION
## Summary

- The Source search preview pane renders the flow YAML in a read-only `KsEditor` with `navbar` disabled, so line 1 sat flush against the file-name header bar above it with no breathing room.
- Added `:options="{editor: {padding: {top: 8}}}"` to that single `KsEditor` usage. Monaco supports this construction option natively via `KsEditor`'s existing `options.editor` passthrough, so no design-system change was needed.
- Scoped to this one read-only preview only; no other `KsEditor` call site (flow editor, revisions diff, etc.) was touched.

Closes: https://github.com/kestra-io/kestra-ee/issues/10005

## Test plan

- [x] `npm run check:types` — clean except the pre-existing, unrelated `useTaskRunOutputs.ts` failure present on `develop`
- [x] `npm run test:unit` — 1831 tests passed, including updated `SourceSearchPreview.spec.ts`
- [x] `npm run test:lint` — 0 errors (pre-existing warnings only, none in touched files)
- [x] `node ui/src/translations/check.js` — no missing/extra/stale keys (no i18n change needed)
- [x] Verified visually in Storybook (`flows/SourceSearchPreview`, `FlowWithSource` story) comparing 0px vs 8px top padding