### PR TITLE
fix(flow): potential NPE on flow validatoin

### DIFF
--- a/core/src/main/java/io/kestra/core/validations/validator/FlowValidator.java
+++ b/core/src/main/java/io/kestra/core/validations/validator/FlowValidator.java
@@ -179,7 +179,7 @@ public class FlowValidator implements ConstraintValidator<FlowValidation, Flow> 
     }
 
     protected List<String> EEViolations(Flow flow) {
-        var assetViolations = flow.allTasks().filter(task -> task.getAssets() != null)
+        var assetViolations = flow.allTasks().filter(task -> task != null && task.getAssets() != null)
             .map(taskWithAssets -> "Task '" + taskWithAssets.getId() + "' can't have any `assets` because assets are only available in Enterprise Edition.")
             .toList();
         List<String> violations = new ArrayList<>(assetViolations);


### PR DESCRIPTION
Flow validation for an incomplete flow can have a null task which would lead to NPE.

```
Caused by: java.lang.NullPointerException: Cannot invoke "io.kestra.core.models.tasks.Task.getAssets()" because "task" is null
	at io.kestra.core.validations.validator.FlowValidator.lambda$EEViolations$0(FlowValidator.java:182)
	at java.base/java.util.stream.ReferencePipeline$2$1.accept(ReferencePipeline.java:196)
	at java.base/java.util.ArrayList$ArrayListSpliterator.forEachRemaining(ArrayList.java:1716)
	at java.base/java.util.stream.ReferencePipeline$Head.forEach(ReferencePipeline.java:803)
	at java.base/java.util.stream.ReferencePipeline$7$1FlatMap.accept(ReferencePipeline.java:293)
	at java.base/java.util.Spliterators$ArraySpliterator.forEachRemaining(Spliterators.java:1024)
	at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:570)
	at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:560)
	at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:635)
```