### PR TITLE
fix: prevent NPE when Switch task has only defaults and no cases

### DIFF
--- a/core/src/main/java/io/kestra/plugin/core/flow/Switch.java
+++ b/core/src/main/java/io/kestra/plugin/core/flow/Switch.java
@@ -164,7 +164,7 @@ public class Switch extends Task implements FlowableTask<Switch.Output> {
     @Override
     public List<ResolvedTask> childTasks(RunContext runContext, TaskRun parentTaskRun) throws IllegalVariableEvaluationException {
         final String value = rendererValue(runContext);
-        return cases.entrySet()
+        return (this.cases == null ? Map.<String, List<Task>>of() : this.cases).entrySet()
             .stream()
             .filter(throwPredicate(entry -> entry.getKey().equals(value)))
             .map(Map.Entry::getValue)
@@ -203,7 +203,7 @@ public class Switch extends Task implements FlowableTask<Switch.Output> {
         return Output.builder()
             .value(rendererValue(runContext))
             .defaults(
-                cases
+                this.cases == null || this.cases
                     .entrySet()
                     .stream()
                     .noneMatch(throwPredicate(entry -> entry.getKey().equals(rendererValue(runContext))))

--- a/core/src/main/java/io/kestra/plugin/core/flow/Switch.java
+++ b/core/src/main/java/io/kestra/plugin/core/flow/Switch.java
@@ -201,14 +201,10 @@ public class Switch extends Task implements FlowableTask<Switch.Output> {
 
     @Override
     public Switch.Output outputs(RunContext runContext) throws IllegalVariableEvaluationException {
+        final String value = rendererValue(runContext);
         return Output.builder()
-            .value(rendererValue(runContext))
-            .defaults(
-                MapUtils.isEmpty(this.cases) || this.cases
-                    .entrySet()
-                    .stream()
-                    .noneMatch(throwPredicate(entry -> entry.getKey().equals(rendererValue(runContext))))
-            )
+            .value(value)
+            .defaults(MapUtils.emptyOnNull(this.cases).keySet().stream().noneMatch(value::equals))
             .build();
     }
 

--- a/core/src/main/java/io/kestra/plugin/core/flow/Switch.java
+++ b/core/src/main/java/io/kestra/plugin/core/flow/Switch.java
@@ -27,6 +27,7 @@ import io.kestra.core.models.tasks.Task;
 import io.kestra.core.runners.FlowableUtils;
 import io.kestra.core.runners.RunContext;
 import io.kestra.core.utils.GraphUtils;
+import io.kestra.core.utils.MapUtils;
 import io.kestra.core.validations.SwitchTaskValidation;
 
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -164,7 +165,7 @@ public class Switch extends Task implements FlowableTask<Switch.Output> {
     @Override
     public List<ResolvedTask> childTasks(RunContext runContext, TaskRun parentTaskRun) throws IllegalVariableEvaluationException {
         final String value = rendererValue(runContext);
-        return (this.cases == null ? Map.<String, List<Task>>of() : this.cases).entrySet()
+        return MapUtils.emptyOnNull(this.cases).entrySet()
             .stream()
             .filter(throwPredicate(entry -> entry.getKey().equals(value)))
             .map(Map.Entry::getValue)
@@ -203,7 +204,7 @@ public class Switch extends Task implements FlowableTask<Switch.Output> {
         return Output.builder()
             .value(rendererValue(runContext))
             .defaults(
-                this.cases == null || this.cases
+                MapUtils.isEmpty(this.cases) || this.cases
                     .entrySet()
                     .stream()
                     .noneMatch(throwPredicate(entry -> entry.getKey().equals(rendererValue(runContext))))

--- a/core/src/test/java/io/kestra/plugin/core/flow/SwitchTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/flow/SwitchTest.java
@@ -100,6 +100,22 @@ class SwitchTest {
     }
 
     @Test
+    @LoadFlows(value = { "flows/valids/switch-defaults-only.yaml" }, tenantId = "switchdefaultsonly")
+    void switchDefaultsOnly() throws TimeoutException, QueueException, io.kestra.core.exceptions.InternalException {
+        Execution execution = runnerUtils.runOne(
+            "switchdefaultsonly",
+            "io.kestra.tests",
+            "switch-defaults-only",
+            null,
+            (f, e) -> ImmutableMap.of("string", "ANYTHING")
+        );
+
+        assertThat(execution.getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
+        assertThat(execution.getTaskRunList().get(1).getTaskId()).isEqualTo("default");
+        assertThat((Boolean) taskOutputService.getOutputs(execution.findTaskRunsByTaskId("parent-seq").getFirst()).get("defaults")).isTrue();
+    }
+
+    @Test
     @LoadFlows(value = { "flows/valids/switch-impossible.yaml" }, tenantId = "switchimpossible")
     void switchImpossible() throws TimeoutException, QueueException {
         Execution execution = runnerUtils.runOne(

--- a/core/src/test/resources/flows/valids/switch-defaults-only.yaml
+++ b/core/src/test/resources/flows/valids/switch-defaults-only.yaml
@@ -1,0 +1,15 @@
+id: switch-defaults-only
+namespace: io.kestra.tests
+
+inputs:
+  - id: string
+    type: STRING
+
+tasks:
+  - id: parent-seq
+    type: io.kestra.plugin.core.flow.Switch
+    value: "{{inputs.string}}"
+    defaults:
+      - id: default
+        type: io.kestra.plugin.core.debug.Return
+        format: "{{task.id}} > {{taskrun.startDate}}"


### PR DESCRIPTION
### 🔗 Related Issue

Closes https://github.com/kestra-io/kestra/issues/18357

### ✨ Description

A `Switch` task with only `defaults` (no `cases`) passes validation — the validator only rejects a Switch when both `cases` and `defaults` are missing — but crashes at runtime with `NullPointerException: Cannot invoke "java.util.Map.entrySet()" because "this.cases" is null`, because `childTasks()` and `outputs()` dereferenced `cases` without a null check.

`childTasks()` now treats a null `cases` as an empty map, so a defaults-only Switch falls through to the default branch instead of NPE'ing. `outputs()` short-circuits `defaults` to `true` when `cases` is null, matching the semantic meaning (the default branch was taken).

### 🛠️ Backend Checklist

- [x] Code compiles and tests pass for the touched modules (`./gradlew :core:test`)
- [x] New behavior is covered by unit or integration tests

### 📝 Additional Notes

Added `switch-defaults-only.yaml` and a `switchDefaultsOnly()` test in `SwitchTest.java` verifying a defaults-only Switch executes successfully and reports `defaults: true`. This reproduces the exact bug scenario: the flow passes validation (only rejected when *both* `cases` and `defaults` are empty) but previously NPE'd at runtime.

I commented on the issue asking to be assigned but haven't heard back yet — opening this PR in the meantime since the fix is small and ready. Happy to hold off or adjust if a maintainer prefers otherwise.

### 🤖 AI Authors

Why did the null `cases` map break up with the Switch task? It said there was no *entry* point to the relationship. 🐱