### PR TITLE
fix(core): avoid duplicate value in INT/FLOAT parse error messages

### DIFF
--- a/core/src/main/java/io/kestra/core/runners/FlowInputOutput.java
+++ b/core/src/main/java/io/kestra/core/runners/FlowInputOutput.java
@@ -475,9 +475,27 @@ public class FlowInputOutput {
                     String encrypted = EncryptionService.encrypt(secretKey.get(), current.toString());
                     yield EncryptedString.from(encrypted);
                 }
-                case INT -> current instanceof Integer ? current : Integer.valueOf(current.toString());
+                case INT -> {
+                    if (current instanceof Integer) {
+                        yield current;
+                    }
+                    try {
+                        yield Integer.valueOf(current.toString());
+                    } catch (NumberFormatException e) {
+                        throw new IllegalArgumentException("not a valid `INT`");
+                    } 
+                }
                 // Assuming that after the render we must have a double/int, so we can safely use its toString representation
-                case FLOAT -> current instanceof Float ? current : Float.valueOf(current.toString());
+                case FLOAT -> {
+                    if (current instanceof Float) {
+                        yield current;
+                    }
+                    try {
+                        yield Float.valueOf(current.toString());
+                    } catch (NumberFormatException e) {
+                        throw new IllegalArgumentException("not a valid `FLOAT`");
+                    } 
+                }
                 case BOOLEAN -> current instanceof Boolean ? current : Boolean.valueOf(current.toString());
                 case BOOL -> current instanceof Boolean ? current : Boolean.valueOf(current.toString());
                 case DATETIME -> current instanceof Instant ? current : Instant.parse(current.toString());

--- a/core/src/test/java/io/kestra/core/runners/FlowInputOutputTest.java
+++ b/core/src/test/java/io/kestra/core/runners/FlowInputOutputTest.java
@@ -307,6 +307,29 @@ class FlowInputOutputTest {
     }
 
     @Test
+    void shouldNotDuplicateValueInIntInputErrorMessage() {
+        // Given 
+        IntInput input = IntInput.builder()
+            .id("retry_count")
+            .type(Type.INT)
+            .required(true)
+            .build();
+
+        List<Input<?>> inputs = List.of(input);
+        Map<String, Object> data = Map.of("retry_count", "3.5");
+
+        // When
+        List<InputAndValue> values = flowInputOutput.resolveInputs(inputs, null, DEFAULT_TEST_EXECUTION, data);
+
+        // Then 
+        String errorMessage = values.get(0).exception().getMessage();
+        Assertions.assertFalse(errorMessage.contains("For input string"));
+
+        int occurrences = errorMessage.split("3\\.5", -1).length - 1;
+        Assertions.assertEquals(1, occurrences, "value should appear exactly once in: " + errorMessage);
+    }
+
+    @Test
     void resolveInputsGivenDefaultExpressions() {
         // Given
         StringInput input1 = StringInput.builder()


### PR DESCRIPTION
### Related Issue

Fixes #18289

### Description

`NumberFormatException`'s own message already embeds the value being parsed (`For input string: "3.5"`), and the error-message builder appends the value again separately (`, but received '3.5'`), producing a duplicated value in the final error for INT/FLOAT inputs and outputs.

This wraps the INT and FLOAT parsing in `FlowInputOutput.parseType()` to throw a clean message instead of letting the JDK's self-describing exception text leak through.

Before:
Invalid input for `retry_count`, For input string: "3.5", but received "3.5"

After:
Invalid input for `retry_count`, not a valid `INT`, but received `3.5`

Kept the existing `Invalid X for Y, <reason>, but received <value>` template.
Verified both the input and output repro cases from the issue.

###  Backend Checklist

<!-- If this PR does not include any backend changes, delete this entire section. -->

- [x] Code compiles and tests pass for the touched modules (`./gradlew :module-name:test`, or `./gradlew build` for cross-module changes)
- [x] New behavior is covered by unit or integration tests

###  Additional Notes

A companion PR applies the same fix to releases/v1.3.x: #<https://github.com/kestra-io/kestra/pull/18380>
