### PR TITLE
fix(core): avoid duplicate value in INT/FLOAT parse error messages

### DIFF
--- a/core/src/main/java/io/kestra/core/runners/FlowInputOutput.java
+++ b/core/src/main/java/io/kestra/core/runners/FlowInputOutput.java
@@ -515,9 +515,27 @@ public class FlowInputOutput {
                     String encrypted = EncryptionService.encrypt(secretKey.get(), current.toString());
                     yield EncryptedString.from(encrypted);
                 }
-                case INT -> current instanceof Integer ? current : Integer.valueOf(current.toString());
+                case INT -> {
+                    if (current instanceof Integer) {
+                        yield current;
+                    } 
+                    try {
+                        yield Integer.valueOf(current.toString());
+                    } catch (NumberFormatException e) {
+                        throw new IllegalArgumentException("not a valid `INT`");
+                    }
+                }
                 // Assuming that after the render we must have a double/int, so we can safely use its toString representation
-                case FLOAT -> current instanceof Float ? current : Float.valueOf(current.toString());
+                case FLOAT -> {
+                    if (current instanceof Float) {
+                        yield current;
+                    }
+                    try {
+                        yield Float.valueOf(current.toString());
+                    } catch (NumberFormatException e) {
+                        throw new IllegalArgumentException("not a valid `FLOAT`");
+                    }
+                }
                 case BOOLEAN -> current instanceof Boolean ? current : Boolean.valueOf(current.toString());
                 case BOOL -> current instanceof Boolean ? current : Boolean.valueOf(current.toString());
                 case DATETIME -> current instanceof Instant ? current : Instant.parse(current.toString());

--- a/core/src/test/java/io/kestra/core/runners/FlowInputOutputTest.java
+++ b/core/src/test/java/io/kestra/core/runners/FlowInputOutputTest.java
@@ -323,6 +323,29 @@ class FlowInputOutputTest {
     }
 
     @Test
+    void shouldNotDuplicateValueInIntInputErrorMessage() {
+        // Given 
+        IntInput input = IntInput.builder()
+            .id("retry_count")
+            .type(Type.INT)
+            .required(true)
+            .build();
+
+        List<Input<?>> inputs = List.of(input);
+        Map<String, Object> data = Map.of("retry_count", "3.5");
+
+        // When
+        List<InputAndValue> values = flowInputOutput.resolveInputs(inputs, null, DEFAULT_TEST_EXECUTION, data);
+
+        // Then 
+        String errorMessage = values.get(0).exceptions().iterator().next().getMessage();
+        Assertions.assertFalse(errorMessage.contains("For input string"));
+
+        int occurrences = errorMessage.split("3\\.5", -1).length - 1;
+        Assertions.assertTrue(occurrences <= 1, "value should not be duplicated in: " + errorMessage);
+    }
+
+    @Test
     void resolveInputsGivenDefaultExpressions() {
         // Given
         StringInput input1 = StringInput.builder()


### PR DESCRIPTION
### Related Issue

Fixes #18289

### Description
Same root cause and fix as #<https://github.com/kestra-io/kestra/pull/18378> (releases/v1.0.x), applied here to releases/v1.3.x the unguarded Integer.valueOf()/Float.valueOf() calls in FlowInputOutput.parseType() let NumberFormatException's self-describing message duplicate the value already present in the outer error wrapper.

Before:
Invalid value for input `retry_count`. Cause: For input string: "3.5"

After:
Invalid value for input `retry_count`. Cause: not a valid `INT`

Verified both input and output repro cases and added a regression test covering the message.

### Backend Checklist

<!-- If this PR does not include any backend changes, delete this entire section. -->

- [x] Code compiles and tests pass for the touched modules (`./gradlew :module-name:test`, or `./gradlew build` for cross-module changes)
- [x] New behavior is covered by unit or integration tests
