### PR TITLE
fix(flows): use pencil-lock icon for search-only source search markers

### DIFF
--- a/ui/src/components/flows/FlowsSearch.vue
+++ b/ui/src/components/flows/FlowsSearch.vue
@@ -115,7 +115,7 @@
                         <span v-if="query && crossResourceSearchStore.statusFor(type) !== 'idle'" class="source-search__pill-count">{{ crossResourceSearchStore.countFor(type) }}</span>
                         <Loading v-if="crossResourceSearchStore.statusFor(type) === 'counting'" class="source-search__pill-spin" />
                         <AlertCircleOutline v-else-if="query && crossResourceSearchStore.statusFor(type) === 'failed'" :title="crossResourceSearchStore.errorMessageFor(type)" />
-                        <Lock v-else-if="type !== 'flows'" />
+                        <PencilLockOutline v-else-if="type !== 'flows'" />
                     </KsCheckTag>
                     <KsButton class="source-search__pill-outline" size="small" @click="selectAllTypes">
                         {{ $t('source_search.select_all_types') }}
@@ -340,7 +340,7 @@
     import Magnify from "vue-material-design-icons/Magnify.vue"
     import InformationOutline from "vue-material-design-icons/InformationOutline.vue"
     import AlertCircleOutline from "vue-material-design-icons/AlertCircleOutline.vue"
-    import Lock from "vue-material-design-icons/Lock.vue"
+    import PencilLockOutline from "vue-material-design-icons/PencilLockOutline.vue"
     import Loading from "vue-material-design-icons/Loading.vue"
     import FileTreeOutline from "vue-material-design-icons/FileTreeOutline.vue"
     import FolderOpenOutline from "vue-material-design-icons/FolderOpenOutline.vue"

--- a/ui/src/components/flows/FlowsSearch.vue
+++ b/ui/src/components/flows/FlowsSearch.vue
@@ -115,7 +115,7 @@
                         <span v-if="query && crossResourceSearchStore.statusFor(type) !== 'idle'" class="source-search__pill-count">{{ crossResourceSearchStore.countFor(type) }}</span>
                         <Loading v-if="crossResourceSearchStore.statusFor(type) === 'counting'" class="source-search__pill-spin" />
                         <AlertCircleOutline v-else-if="query && crossResourceSearchStore.statusFor(type) === 'failed'" :title="crossResourceSearchStore.errorMessageFor(type)" />
-                        <PencilOff v-else-if="type !== 'flows'" />
+                        <Lock v-else-if="type !== 'flows'" />
                     </KsCheckTag>
                     <KsButton class="source-search__pill-outline" size="small" @click="selectAllTypes">
                         {{ $t('source_search.select_all_types') }}
@@ -340,7 +340,7 @@
     import Magnify from "vue-material-design-icons/Magnify.vue"
     import InformationOutline from "vue-material-design-icons/InformationOutline.vue"
     import AlertCircleOutline from "vue-material-design-icons/AlertCircleOutline.vue"
-    import PencilOff from "vue-material-design-icons/PencilOff.vue"
+    import Lock from "vue-material-design-icons/Lock.vue"
     import Loading from "vue-material-design-icons/Loading.vue"
     import FileTreeOutline from "vue-material-design-icons/FileTreeOutline.vue"
     import FolderOpenOutline from "vue-material-design-icons/FolderOpenOutline.vue"

--- a/ui/src/components/flows/SourceSearchResults.vue
+++ b/ui/src/components/flows/SourceSearchResults.vue
@@ -22,7 +22,7 @@
                 </KsTag>
                 <KsTag v-else-if="type !== 'flows'" size="small" round>
                     <template #icon>
-                        <PencilOff />
+                        <PencilLockOutline />
                     </template>
                     {{ $t('source_search.tag_search_only') }}
                 </KsTag>
@@ -316,7 +316,7 @@
     import LockOutline from "vue-material-design-icons/LockOutline.vue"
     import FileDocumentOutline from "vue-material-design-icons/FileDocumentOutline.vue"
     import InformationOutline from "vue-material-design-icons/InformationOutline.vue"
-    import PencilOff from "vue-material-design-icons/PencilOff.vue"
+    import PencilLockOutline from "vue-material-design-icons/PencilLockOutline.vue"
     import AlertCircleOutline from "vue-material-design-icons/AlertCircleOutline.vue"
     import Refresh from "vue-material-design-icons/Refresh.vue"
     import Loading from "vue-material-design-icons/Loading.vue"


### PR DESCRIPTION
## Summary

- The "Search in" type pills (Namespace files, KV keys, Secret keys) and the results-list "Search only" tag both used `PencilOff` to mean "this type is search-only, can't be replaced" - at pill size (14px icon / 12px label) its diagonal slash reads as an "x" remove control, and since the one type that actually is removable from replace scope ("Flows") has no icon at all, the signal looked inverted.
- Replaced `PencilOff` with `PencilLockOutline` in both places (`FlowsSearch.vue` pills and `SourceSearchResults.vue`'s results tag), so the same "can't be replaced" concept uses one glyph everywhere it appears, including when both markers are visible together in replace mode.
- `Lock` was tried first, matching the per-flow-group read-only tag, but it collides with the Secrets pill's own `LockOutline` type-icon (double padlock) and with `Lock`'s separate, already-established meaning in `SourceSearchResults.vue`: an RBAC read-only marker for individual non-editable flows (`group.editable === false`) and secret-value chips. `PencilLockOutline` avoids both collisions while staying legible at pill size.
- No copy change: existing tooltips/labels are untouched.

Closes: https://github.com/kestra-io/kestra-ee/issues/10004

## Test plan

- [x] `cd ui && rtk npm run check:types` - clean
- [x] `npm run test:unit` - 1848/1848 tests passed (one unrelated `KsMarkdown`/shiki teardown-timing error, pre-existing, unaffected by this change)
- [x] `npm run test:lint` - 0 errors, only pre-existing warnings unrelated to the touched files
- [x] `npm run translations:check` - clean, no i18n changes needed