### PR TITLE
fix(core): stop number formatting from crashing for the pt_BR and zh_CN languages

### DIFF
--- a/ui/src/translations/i18n.ts
+++ b/ui/src/translations/i18n.ts
@@ -29,7 +29,8 @@ export function setI18nLanguage(i18n: I18n, locale: (typeof SUPPORT_LOCALES)[num
    *
    * axios.defaults.headers.common['Accept-Language'] = locale
    */
-  document.querySelector("html")?.setAttribute("lang", locale)
+  // The html lang attribute must be a BCP 47 tag, so the underscore codes ("pt_BR") get their hyphen form.
+  document.querySelector("html")?.setAttribute("lang", locale.replace(/_/g, "-"))
 }
 
 export async function loadLocaleMessages(i18n: I18n, locale: (typeof SUPPORT_LOCALES)[number], additionalTranslationsProvider: Record<string, () => Promise<any>>) {

--- a/ui/src/utils/filters.ts
+++ b/ui/src/utils/filters.ts
@@ -10,7 +10,7 @@ export function humanizeDuration (value:string, options?:any) {
     return Utils.humanDuration(value, options);
 }
 export function humanizeNumber (value:string) {
-    return parseInt(value).toLocaleString(Utils.getLang());
+    return parseInt(value).toLocaleString(Utils.getLanguageTag());
 }
 export function cap (value:string) {
     return value ? value.toString().capitalize() : "";

--- a/ui/src/utils/utils.ts
+++ b/ui/src/utils/utils.ts
@@ -248,6 +248,14 @@ export default class Utils {
         return localStorage.getItem("lang") || "en";
     }
 
+    /**
+     * The stored language as a valid BCP 47 tag ("pt_BR" -> "pt-BR") for Intl APIs and the html lang
+     * attribute, which reject the underscore form getLang() returns.
+     */
+    static getLanguageTag() {
+        return Utils.getLang().replace(/_/g, "-");
+    }
+
     static splitFirst(str: string, separator: string) {
         return str.split(separator).slice(1).join(separator);
     }

--- a/ui/tests/unit/utils/filters.spec.ts
+++ b/ui/tests/unit/utils/filters.spec.ts
@@ -1,0 +1,26 @@
+import {afterEach, describe, expect, it} from "vitest";
+import {humanizeNumber} from "../../../src/utils/filters";
+
+describe("humanizeNumber", () => {
+    afterEach(() => {
+        localStorage.removeItem("lang");
+    });
+
+    it("formats with the default language when none is stored", () => {
+        expect(humanizeNumber("1234567")).toBe((1234567).toLocaleString("en"));
+    });
+
+    // Underscore codes are not valid BCP 47 tags: passed raw to toLocaleString they
+    // throw RangeError, which is what happened for the pt_BR and zh_CN locales.
+    it.each(["pt_BR", "zh_CN"])("formats for the underscore locale %s instead of throwing", (lang) => {
+        localStorage.setItem("lang", lang);
+
+        expect(humanizeNumber("1234567")).toBe((1234567).toLocaleString(lang.replace("_", "-")));
+    });
+
+    it("formats for a plain locale code", () => {
+        localStorage.setItem("lang", "de");
+
+        expect(humanizeNumber("1234567")).toBe((1234567).toLocaleString("de"));
+    });
+});


### PR DESCRIPTION
Related to https://github.com/kestra-io/kestra/issues/18401.

Backport of https://github.com/kestra-io/kestra/pull/18395 to `releases/v1.0.x`.

`getLang()` returns the raw stored language code, and the underscore codes `pt_BR` and `zh_CN` are not valid BCP 47 language tags - `toLocaleString("pt_BR")` throws `RangeError: Incorrect locale information provided`, so `humanizeNumber()` crashed for every user running the `UI` in Brazilian Portuguese or Simplified Chinese.

Hand-ported rather than cherry-picked: on this branch `ui/src/utils/utils.ts` is still the class-style `Utils`, so `getLanguageTag()` is added as a static method next to `getLang()`. Same three call-site changes as the develop `PR` (`humanizeNumber`, the `html` `lang` attribute) plus the same unit test, which reproduces the exact `RangeError` against the previous code. The moment and cronstrue consumers are deliberately untouched, matching the develop `PR`.

Unit test green on this branch (4/4).
