### PR TITLE
fix(core): reject invalid BOOL input values

### DIFF
--- a/core/src/main/java/io/kestra/core/runners/FlowInputOutput.java
+++ b/core/src/main/java/io/kestra/core/runners/FlowInputOutput.java
@@ -593,7 +593,18 @@ public class FlowInputOutput {
             case STRING, EMAIL, SELECT -> current.toString();
             case INT -> TypeConverter.toInteger(current);
             case FLOAT -> TypeConverter.toFloat(current);
-            case BOOL -> TypeConverter.toBoolean(current);
+            case BOOL -> {
+                if (current instanceof Boolean b) {
+                    yield b;
+                }
+
+                if (!(current instanceof String s &&
+                    (s.equalsIgnoreCase("true") || s.equalsIgnoreCase("false")))) {
+                    throw new IllegalArgumentException("Unable to parse `" + current + "` as a boolean");
+                }
+
+                yield TypeConverter.toBoolean(current);
+            }
             case DATETIME -> TypeConverter.toInstant(current);
             case DATE -> TypeConverter.toLocalDate(current);
             case TIME -> TypeConverter.toLocalTime(current);

--- a/core/src/test/java/io/kestra/core/runners/FlowInputOutputTest.java
+++ b/core/src/test/java/io/kestra/core/runners/FlowInputOutputTest.java
@@ -24,6 +24,7 @@ import io.kestra.core.encryption.EncryptionService;
 import io.kestra.core.exceptions.InputOutputValidationException;
 import io.kestra.core.models.executions.Execution;
 import io.kestra.core.models.flows.*;
+import io.kestra.core.models.flows.input.BoolInput;
 import io.kestra.core.models.flows.input.EmailInput;
 import io.kestra.core.models.flows.input.FileInput;
 import io.kestra.core.models.flows.input.FloatInput;
@@ -61,7 +62,6 @@ import reactor.core.publisher.Mono;
 
 import static io.kestra.core.tenant.TenantService.MAIN_TENANT;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @MicronautTest
 class FlowInputOutputTest {
@@ -1236,6 +1236,78 @@ class FlowInputOutputTest {
         // Then — "" is preserved for EMAIL inputs
         assertThat(values).hasSize(1);
         assertThat(values.getFirst().value()).isEqualTo("");
+        assertThat(values.getFirst().exceptions()).isNull();
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"yes", "1", "maybe", "xyz"})
+    void shouldRejectInvalidBooleanInput(String value) {
+        // Given
+        BoolInput input = BoolInput.builder()
+            .id("active")
+            .type(Type.BOOL)
+            .required(true)
+            .build();
+
+        // When
+        List<InputAndValue> values = flowInputOutput.resolveInputs(
+            List.of(input),
+            null,
+            DEFAULT_TEST_EXECUTION,
+            Map.of("active", value)
+        );
+
+        // Then
+        assertThat(values).hasSize(1);
+        assertThat(values.getFirst().exceptions())
+            .as("an invalid BOOL value must produce a validation error")
+            .isNotNull()
+            .isNotEmpty();
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"true", "false", "TRUE", "False"})
+    void shouldAcceptValidBooleanStringInput(String value) {
+        // Given
+        BoolInput input = BoolInput.builder()
+            .id("active")
+            .type(Type.BOOL)
+            .required(true)
+            .build();
+
+        // When
+        List<InputAndValue> values = flowInputOutput.resolveInputs(
+            List.of(input),
+            null,
+            DEFAULT_TEST_EXECUTION,
+            Map.of("active", value)
+        );
+
+        // Then
+        assertThat(values).hasSize(1);
+        assertThat(values.getFirst().exceptions()).isNull();
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void shouldAcceptBooleanInput(boolean value) {
+        // Given
+        BoolInput input = BoolInput.builder()
+            .id("active")
+            .type(Type.BOOL)
+            .required(true)
+            .build();
+
+        // When
+        List<InputAndValue> values = flowInputOutput.resolveInputs(
+            List.of(input),
+            null,
+            DEFAULT_TEST_EXECUTION,
+            Map.of("active", value)
+        );
+
+        // Then
+        assertThat(values).hasSize(1);
         assertThat(values.getFirst().exceptions()).isNull();
     }
 


### PR DESCRIPTION
### Related Issue

Closes https://github.com/kestra-io/kestra/issues/18342

### Description

Fixes BOOL input validation so that invalid string values are rejected instead of being silently coerced to `false`.

Previously, values such as `maybe`, `yes`, or `1` were accepted and resolved to `false`.

After this change:
- `true` → accepted
- `false` → accepted
- `maybe` → rejected with `422`
- `yes` → rejected with `422`
- `1` → rejected with `422`

This makes BOOL input validation consistent with the other typed input types.

### Additional Notes

The behavior was verified locally with valid and invalid BOOL input values.