### PR TITLE
fix(flows): render a readable message for the quota duration constraint

### DIFF
--- a/core/src/main/java/io/kestra/core/models/flows/quota/Quota.java
+++ b/core/src/main/java/io/kestra/core/models/flows/quota/Quota.java
@@ -21,7 +21,7 @@ import lombok.experimental.SuperBuilder;
 @EqualsAndHashCode
 public class Quota {
     @NotNull
-    @DurationMin(minutes = 1)
+    @DurationMin(minutes = 1, message = "must be longer than or equal to 1 minute")
     private Duration duration;
 
     @NotNull


### PR DESCRIPTION
## Summary

`Quota.duration` used `@DurationMin(minutes = 1)` with no custom message, so it fell back to Hibernate Validator's default message for that constraint, which is built from EL expressions that don't get evaluated in Kestra's validator setup. This caused raw EL template text to show up instead of a readable message.

Added an explicit static `message`, referenced from the same pattern already used by `TimeWindow`'s duration constraints.

## Test plan

- [ ] Create a flow with `quotas[0].duration: PT10S` and confirm the error now reads "must be longer than or equal to 1 minute" instead of raw EL syntax.

Fixes #18480