### PR TITLE
build(plugins): rename the no-plugins image to slim everywhere

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE="ghcr.io/kestra-io/kestra-base:latest-no-plugins"
+ARG BASE_IMAGE="ghcr.io/kestra-io/kestra-base:latest-slim"
 FROM ${BASE_IMAGE}
 
 ENV PATH="/app/.venv/bin:$PATH"

--- a/build-and-start-e2e-tests.sh
+++ b/build-and-start-e2e-tests.sh
@@ -20,7 +20,7 @@ echo "Building the image for this current repository"
 # background so the downloads overlap with the Gradle/npm build instead of
 # sitting on the critical path.
 BASE_IMAGE="$(sed -n 's/^ARG BASE_IMAGE="\(.*\)"/\1/p' Dockerfile)"
-docker pull -q "${BASE_IMAGE:-ghcr.io/kestra-io/kestra-base:latest-no-plugins}" > /dev/null 2>&1 &
+docker pull -q "${BASE_IMAGE:-ghcr.io/kestra-io/kestra-base:latest-slim}" > /dev/null 2>&1 &
 docker pull -q postgres > /dev/null 2>&1 &
 
 if [ "${E2E_USE_PREBUILT_EXE:-false}" = "true" ]; then

--- a/ui/run-e2e-tests.sh
+++ b/ui/run-e2e-tests.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 set -e
-KESTRA_DOCKER_IMAGE_TO_TEST="kestra/kestra:develop-no-plugins"
+KESTRA_DOCKER_IMAGE_TO_TEST="kestra/kestra:develop-slim"
 
 # Parse arguments
 while [[ $# -gt 0 ]]; do

--- a/ui/tests/e2e/start-e2e-tests-backend.sh
+++ b/ui/tests/e2e/start-e2e-tests-backend.sh
@@ -2,7 +2,7 @@
 set -e
 
 # Default values
-KESTRA_DOCKER_IMAGE_TO_TEST="kestra/kestra:develop-no-plugins"
+KESTRA_DOCKER_IMAGE_TO_TEST="kestra/kestra:develop-slim"
 E2E_TEST_CONFIG_DIR="$(dirname "${BASH_SOURCE[0]}")"
 KESTRA_BASE_URL="http://127.0.0.1:9011/ui/"
 


### PR DESCRIPTION
## Summary
- Consumer-side half of the no-plugins -> slim rename, split from #16054 to fix a chicken-and-egg CI problem: #16054 now carries the base-image publisher change (publishes `-slim` alongside `-no-plugins`), and this PR switches the consumers (this repo's `Dockerfile` default, `build-and-start-e2e-tests.sh`, `ui/run-e2e-tests.sh`, `ui/tests/e2e/start-e2e-tests-backend.sh`) over to `-slim`.
- One lean image instead of two near-identical variants: `-slim` replaces `-no-plugins`. `-no-plugins` stays published as a deprecated alias for one release so other repos can migrate on their own schedule.

## Merge order
1. `kestra-io/kestra#16054` — plugin auto-install feature + publishes the `-slim` base-image tags
2. **This PR** — merge right after #16054 lands on develop, once `global-push-base-image.yml` has actually run (manually trigger `workflow_dispatch` on it from develop — it's schedule/dispatch-only, does not fire on push) and published the `-slim` tags
3. `kestra-io/actions#204` — needs both 1 (the `-PpluginsSchemaBundle` Gradle property) and 2/the published tag
4. `kestra-io/kestra-ee#10242`, `kestra-io/kestractl#99`, `kestra-io/client-sdk#388`, `kestra-io/plugin-git#323`, `kestra-io/plugin-kestra#175` — image-tag rename in other repos, any order, after step 2
5. `kestra-io/docs#5155` and the rest — cosmetic, no dependency

Related: kestra-io/kestra-ee#6145

## Test plan
- [ ] Merge only after #16054 is on develop and `global-push-base-image.yml` has been manually dispatched to publish the `-slim` tags
- [ ] E2E / docker-build checks green once the tag exists