### PR TITLE
fix(ui): show both title and description in compact docs panel (#18501)

### DIFF
--- a/ui/src/components/plugins/schema/SchemaPropertiesSection.vue
+++ b/ui/src/components/plugins/schema/SchemaPropertiesSection.vue
@@ -527,6 +527,10 @@
             margin-top: var(--ks-spacing-2);
         }
 
+        :deep(.ks-markdown + .ks-markdown) {
+            margin-top: var(--ks-spacing-2);
+        }
+
         :deep(code) {
             font-family: var(--ks-font-family-mono);
             font-size: 0.92em;

--- a/ui/src/components/plugins/schema/SchemaPropertiesSection.vue
+++ b/ui/src/components/plugins/schema/SchemaPropertiesSection.vue
@@ -85,8 +85,14 @@
                                 class="compact-prop-desc"
                             >
                                 <slot
+                                    v-if="property.title"
                                     name="markdown"
-                                    :content="property.title || property.description || ''"
+                                    :content="sanitizeForMarkdown(property.title)"
+                                />
+                                <slot
+                                    v-if="property.description"
+                                    name="markdown"
+                                    :content="sanitizeForMarkdown(property.description)"
                                 />
                             </div>
                         </div>
@@ -184,6 +190,7 @@
         extractTypeInfo,
         isDeprecated,
         isDynamic,
+        sanitizeForMarkdown,
         type JSONProperty,
         type JSONSchema,
         type SchemaExample,

--- a/ui/src/components/plugins/schema/SchemaPropertiesSection.vue
+++ b/ui/src/components/plugins/schema/SchemaPropertiesSection.vue
@@ -512,14 +512,14 @@
 
     .compact-prop-desc {
         margin-top: var(--ks-spacing-2);
-        font-size: var(--ks-font-size-base);
-        line-height: 1.65;
+        font-size: var(--ks-font-size-sm);
+        line-height: 1.5;
         color: var(--ks-text-secondary);
 
         :deep(p) {
             margin: 0;
-            font-size: var(--ks-font-size-base);
-            line-height: 1.65;
+            font-size: var(--ks-font-size-sm);
+            line-height: 1.5;
             color: var(--ks-text-secondary);
         }
 


### PR DESCRIPTION
Closes https://github.com/kestra-io/kestra/issues/18501

### ✨ Description

In the flow editor's Docs panel (compact mode), property descriptions were not rendered when a property title was present. The template short-circuited on `property.title`, causing the longer `property.description` text to be ignored.

This PR splits the title and description rendering into two separate conditional slots (`v-if="property.title"` and `v-if="property.description"`), matching the pattern used in `PropertyDetail.vue`. It also applies `sanitizeForMarkdown` to both fields for consistency.

### 🎨 Frontend Checklist

- [x] Type checking passes (`npm run check:types`)
- [x] Code builds without errors (`npm run build`)
- [x] Unit tests pass (`npm run test:unit`)
- [x] Screenshots or video recordings attached showing the `UI` changes

### 📷 Screenshots

| After (Fixed) |
|---|
| Both title and description are rendered correctly |

<img width="838" height="588" alt="image" src="https://github.com/user-attachments/assets/f441e68d-1edc-4107-9275-df56afb0e572" />