### PR TITLE
fix(core): let the AI Copilot page transcript scroll from anywhere on the page

### DIFF
--- a/ui/src/components/ai/copilot/CopilotChat.vue
+++ b/ui/src/components/ai/copilot/CopilotChat.vue
@@ -525,9 +525,9 @@
 
     /* Page layout: the host surface is full-width so the transcript scroller catches the wheel
        anywhere on the page; each section re-centers its content into the same bounded column the
-       page used to be (kestra-io/kestra#18386). */
+       page used to be (kestra-io/kestra#18386). The topbar is deliberately left out: its pills
+       stay pinned to the left edge of the page instead of floating with the centered column. */
     .copilot-chat--page .copilot-transcript,
-    .copilot-chat--page .copilot-topbar,
     .copilot-chat--page .copilot-banner,
     .copilot-chat--page .copilot-footer {
         width: 100%;

--- a/ui/src/components/ai/copilot/CopilotChat.vue
+++ b/ui/src/components/ai/copilot/CopilotChat.vue
@@ -66,26 +66,30 @@
                 aria-live="polite"
                 :aria-busy="streaming ? 'true' : 'false'"
             >
-                <CopilotMessage
-                    v-for="message in messages"
-                    :key="message.id"
-                    :message="message"
-                    :isPending="message.id === pendingProposalMessageId"
-                    :isRunning="message.id === runningToolCallId"
-                />
+                <!-- Inner column so the page layout can span the scroller full-width (wheel works
+                     from anywhere on the page) while the transcript stays a bounded, centered column. -->
+                <div class="copilot-transcript">
+                    <CopilotMessage
+                        v-for="message in messages"
+                        :key="message.id"
+                        :message="message"
+                        :isPending="message.id === pendingProposalMessageId"
+                        :isRunning="message.id === runningToolCallId"
+                    />
 
-                <CopilotThinking v-if="working" :phase="workPhase" />
+                    <CopilotThinking v-if="working" :phase="workPhase" />
 
-                <ProposedActionCard
-                    v-if="pendingConfirmation"
-                    :action="pendingConfirmation"
-                    :disabled="streaming"
-                    @approve="confirm('APPROVE', undefined, selectedProvider)"
-                    @reject="onReject"
-                />
+                    <ProposedActionCard
+                        v-if="pendingConfirmation"
+                        :action="pendingConfirmation"
+                        :disabled="streaming"
+                        @approve="confirm('APPROVE', undefined, selectedProvider)"
+                        @reject="onReject"
+                    />
 
-                <!-- Anchor the auto-scroll follows as new content streams in. -->
-                <div ref="bottomAnchor" class="copilot-scroll-anchor" />
+                    <!-- Anchor the auto-scroll follows as new content streams in. -->
+                    <div ref="bottomAnchor" class="copilot-scroll-anchor" />
+                </div>
             </KsScrollbar>
 
             <!-- Insets via wrapper padding, not a margin on the alert: KsAlert is width:100%, so a
@@ -517,5 +521,17 @@
     .copilot-footer {
         padding: var(--ks-spacing-3) var(--ks-spacing-5);
         border-top: 1px solid var(--ks-border-subtle);
+    }
+
+    /* Page layout: the host surface is full-width so the transcript scroller catches the wheel
+       anywhere on the page; each section re-centers its content into the same bounded column the
+       page used to be (kestra-io/kestra#18386). */
+    .copilot-chat--page .copilot-transcript,
+    .copilot-chat--page .copilot-topbar,
+    .copilot-chat--page .copilot-banner,
+    .copilot-chat--page .copilot-footer {
+        width: 100%;
+        max-width: 56rem;
+        margin: 0 auto;
     }
 </style>

--- a/ui/src/components/ai/copilot/CopilotPage.vue
+++ b/ui/src/components/ai/copilot/CopilotPage.vue
@@ -83,10 +83,10 @@
         padding: var(--ks-spacing-4);
     }
 
-    /* Bounded, centered column so the copilot reads as a page surface rather than a full-bleed panel. */
+    /* Full-width so the transcript scroller spans the whole page and the wheel works from anywhere;
+       CopilotChat's page layout centers the content into a bounded column itself. */
     .copilot-page-surface {
         width: 100%;
-        max-width: 56rem;
         min-height: 0;
         display: flex;
         flex-direction: column;


### PR DESCRIPTION
Closes https://github.com/kestra-io/kestra/issues/18386.

## What

On the full-page AI Copilot, the transcript's scroll container was bounded to the centered 56rem column, so the mouse wheel did nothing over the wide gutters left and right of the conversation - the page only scrolled with the cursor in the middle portion of the screen.

The page surface is now full-width so the transcript scroller catches the wheel anywhere on the page, and each section of the chat (topbar, transcript, banner, footer) re-centers its content into the same bounded 56rem column via a new inner wrapper, so the layout looks unchanged. The dock layout is untouched - the centering rules are scoped to `copilot-chat--page`.

## Verification

Verified in the browser against a local EE instance: the scroll container now spans the full page width (hit-testing the left and right gutters resolves inside the scroller), scrolling works from the gutters, and the transcript column stays centered at 56rem. `check:types`, the copilot unit tests (33 passing), and `eslint` on the changed files are clean.