### PR TITLE
fix(core): remove duplicate page name in breadcrumb

### DIFF
--- a/ui/src/components/plugins/PluginGroup.vue
+++ b/ui/src/components/plugins/PluginGroup.vue
@@ -205,7 +205,7 @@
         return crumbs
     })
 
-    const title = computed(() => groupPlugin.value?.title ?? t("plugins.names"))
+    const title = computed(() => groupPlugin.value?.title ?? (route.params.name as string))
 
     const routeInfo = computed(() => ({title: title.value, breadcrumb: breadcrumb.value}))
     useRouteContext(routeInfo)


### PR DESCRIPTION
relates to https://github.com/kestra-io/kestra-ee/issues/10363