### PR TITLE
fix(executions): wrap expression variables with render() in variable …

### DIFF
--- a/ui/src/components/executions/outputs/ExecutionVariableExplorer.vue
+++ b/ui/src/components/executions/outputs/ExecutionVariableExplorer.vue
@@ -136,9 +136,14 @@
         return isValidVariable(key) ? `.${key}` : `["${key}"]`
     }
 
+    function isExpression(value: unknown): boolean {
+        return typeof value === "string" && (value.includes("{{") || value.includes("{%"))
+    }
+
     function valueType(value: unknown): string {
         if (value === null) return "null"
         if (Array.isArray(value)) return "array"
+        if (isExpression(value)) return "expression"
         return typeof value
     }
 
@@ -422,17 +427,23 @@
             const onlyKey = Object.keys(selectedValue.value)[0]
             const treePath = `${item.expression}${formatStep(onlyKey)}`
             const debugPath = `${baseExpressionPath}${formatStep(onlyKey)}`
+            const val = (selectedValue.value as Record<string, unknown>)[onlyKey]
             expressionPath.value = treePath
-            previewedValue.value = (selectedValue.value as Record<string, unknown>)[onlyKey]
-            expression.value = `{{ ${debugPath} }}`
+            previewedValue.value = val
+            expression.value = isExpression(val) ? `{{ render(${debugPath}) }}` : `{{ ${debugPath} }}`
         }else {
-            expression.value = `{{ ${baseExpressionPath} }}`
+            expression.value = isExpression(selectedValue.value)
+                ? `{{ render(${baseExpressionPath}) }}`
+                : `{{ ${baseExpressionPath} }}`
         }
     }
 
     function onSelectPath(path: string, value: unknown) {
         expressionPath.value = path
-        expression.value = `{{ ${path} }}`
+        const isFlowOutput = sections.value.find((section) =>
+            section.items.some(i => i.expression === selectedBase.value))?.key === "flowOutputs"
+        const debugPath = isFlowOutput && !path.startsWith("execution.") ? `execution.${path}` : path
+        expression.value = isExpression(value) ? `{{ render(${debugPath}) }}` : `{{ ${debugPath} }}`
         previewedValue.value = value
     }
 

--- a/ui/tests/unit/components/executions/ExecutionVariableExplorer.spec.ts
+++ b/ui/tests/unit/components/executions/ExecutionVariableExplorer.spec.ts
@@ -184,4 +184,27 @@ describe("ExecutionVariableExplorer", () => {
         expect(wrapper.findComponent({name: "ExpressionDebugger"}).props("expression"))
             .toBe("{{ vars.bundle.values.a.b }}")
     })
+
+    test("distinguishes expression variables and offers render() expression for debugging", async () => {
+        const wrapper = mountExplorer({
+            literalVar: "Hello world",
+            exprVar: "Hello {{ inputs.name }}",
+        })
+        await flushPromises()
+
+        const sidebar = wrapper.findComponent({name: "SidebarList"})
+        const variablesSection = (sidebar.props("sections") as any[])
+            .find((section) => section.key === "variables")
+
+        const literalItem = variablesSection.items.find((item: {label: string}) => item.label === "literalVar")
+        const exprItem = variablesSection.items.find((item: {label: string}) => item.label === "exprVar")
+
+        expect(literalItem.type).toBe("string")
+        expect(exprItem.type).toBe("expression")
+
+        await selectVariable(wrapper, "exprVar")
+
+        expect(wrapper.findComponent({name: "ExpressionDebugger"}).props("expression"))
+            .toBe("{{ render(vars.exprVar) }}")
+    })
 })


### PR DESCRIPTION
Closes https://github.com/kestra-io/kestra/issues/18485

### 🔗 Related Issue

Closes https://github.com/kestra-io/kestra/issues/18485

### ✨ Description

This PR fixes how variables whose values contain Pebble expressions are handled in the Executions **Inputs/Outputs** Variable Explorer:

- **Expression Detection & Type Tagging**: Added `isExpression()` helper to identify string values containing Pebble delimiters (`{{` or `{%`) and assign them the `"expression"` type badge in the sidebar.
- **Automatic `render()` Suggested Expression**: When selecting an expression variable, trigger property, or JSON tree node, the suggested debug expression is automatically formatted as `{{ render(<path>) }}` (e.g. `{{ render(vars.greeting) }}`). This ensures the Pebble expression evaluates and resolves correctly against the execution context when evaluated in the Expression Debugger.

### 🎨 Frontend Checklist

- [x] Type checking passes (`npm run check:types`)
- [x] Code builds without errors (`npm run build`)
- [x] Unit tests pass (`npm run test:unit`)
- [x] Translations are complete if `en.json` changed (`npm run translations:check` reports no missing, extra, or stale keys)
- [x] Screenshots or video recordings attached showing the `UI` changes

### 📝 Additional Notes

- Added unit test in `ExecutionVariableExplorer.spec.ts` to verify expression tagging and `render()` expression suggestion.

### 🤖 AI Authors

Why are cats such terrible programmers?  
Because they get distracted by the mouse! 🐱

