### PR TITLE
fix(core): render execution-updating task properties for each execution

### DIFF
--- a/core/src/main/java/io/kestra/plugin/core/execution/Exit.java
+++ b/core/src/main/java/io/kestra/plugin/core/execution/Exit.java
@@ -114,7 +114,9 @@ public class Exit extends Task implements ExecutionUpdatableTask {
     }
 
     private State.Type executionState(RunContext runContext) throws IllegalVariableEvaluationException {
-        return switch (runContext.render(this.state).as(ExitState.class).orElseThrow()) {
+        // the executor reuses the task instance of its cached flow for every execution of the flow,
+        // so the rendering cache of the property must be skipped to render with the current execution context
+        return switch (runContext.render(this.state.skipCache()).as(ExitState.class).orElseThrow()) {
             case ExitState.SUCCESS -> State.Type.SUCCESS;
             case WARNING -> State.Type.WARNING;
             case KILLED -> State.Type.KILLED;

--- a/core/src/main/java/io/kestra/plugin/core/execution/SetVariables.java
+++ b/core/src/main/java/io/kestra/plugin/core/execution/SetVariables.java
@@ -66,8 +66,10 @@ public class SetVariables extends Task implements ExecutionUpdatableTask {
 
     @Override
     public Execution update(Execution execution, RunContext runContext) throws Exception {
-        Map<String, Object> renderedVars = runContext.render(this.variables).asMap(String.class, Object.class);
-        boolean renderedOverwrite = runContext.render(overwrite).as(Boolean.class).orElseThrow();
+        // the executor reuses the task instance of its cached flow for every execution of the flow,
+        // so the rendering cache of the properties must be skipped to render with the current execution context
+        Map<String, Object> renderedVars = runContext.render(this.variables.skipCache()).asMap(String.class, Object.class);
+        boolean renderedOverwrite = runContext.render(this.overwrite.skipCache()).as(Boolean.class).orElseThrow();
 
         Map<String, Object> currentVariables = execution.getVariables() == null ? Collections.emptyMap() : execution.getVariables();
 

--- a/core/src/main/java/io/kestra/plugin/core/execution/UnsetVariables.java
+++ b/core/src/main/java/io/kestra/plugin/core/execution/UnsetVariables.java
@@ -69,8 +69,10 @@ public class UnsetVariables extends Task implements ExecutionUpdatableTask {
 
     @Override
     public Execution update(Execution execution, RunContext runContext) throws Exception {
-        List<String> renderedVariables = runContext.render(variables).asList(String.class);
-        boolean renderedIgnoreMissing = runContext.render(ignoreMissing).as(Boolean.class).orElseThrow();
+        // the executor reuses the task instance of its cached flow for every execution of the flow,
+        // so the rendering cache of the properties must be skipped to render with the current execution context
+        List<String> renderedVariables = runContext.render(this.variables.skipCache()).asList(String.class);
+        boolean renderedIgnoreMissing = runContext.render(this.ignoreMissing.skipCache()).as(Boolean.class).orElseThrow();
         Map<String, Object> variables = execution.getVariables();
         for (String key : renderedVariables) {
             removeVar(variables, key, renderedIgnoreMissing);

--- a/core/src/test/java/io/kestra/plugin/core/execution/SetVariablesTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/execution/SetVariablesTest.java
@@ -8,7 +8,10 @@ import io.kestra.core.junit.annotations.ExecuteFlow;
 import io.kestra.core.junit.annotations.KestraTest;
 import io.kestra.core.models.executions.Execution;
 import io.kestra.core.models.flows.State;
+import io.kestra.core.runners.RunContextFactory;
+import io.kestra.core.serializers.JacksonMapper;
 import io.kestra.core.services.TaskOutputService;
+import io.kestra.core.utils.IdUtils;
 
 import jakarta.inject.Inject;
 
@@ -18,6 +21,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 class SetVariablesTest {
     @Inject
     private TaskOutputService taskOutputService;
+
+    @Inject
+    private RunContextFactory runContextFactory;
 
     @ExecuteFlow("flows/valids/set-variables.yaml")
     @Test
@@ -33,5 +39,36 @@ class SetVariablesTest {
         assertThat(execution.getState().getCurrent()).isEqualTo(State.Type.FAILED);
         assertThat(execution.getTaskRunList()).hasSize(1);
         assertThat(execution.getTaskRunList().getFirst().getState().getCurrent()).isEqualTo(State.Type.FAILED);
+    }
+
+    @Test
+    void shouldRenderVariablesForEachExecution() throws Exception {
+        // the executor calls update() on the task instance of its cached flow, so the same task
+        // instance is reused by every execution of the flow: it must not reuse the first rendering
+        SetVariables task = JacksonMapper.ofJson().readValue(
+            """
+                {
+                  "id": "set",
+                  "type": "io.kestra.plugin.core.execution.SetVariables",
+                  "variables": {"isLts": "{{ inputs.version | startsWith('1.3.') }}"}
+                }""",
+            SetVariables.class
+        );
+
+        Execution first = task.update(execution(), runContextFactory.of(Map.of("inputs", Map.of("version", "1.3.9"))));
+        assertThat(first.getVariables()).containsEntry("isLts", "true");
+
+        Execution second = task.update(execution(), runContextFactory.of(Map.of("inputs", Map.of("version", "1.0.56"))));
+        assertThat(second.getVariables()).containsEntry("isLts", "false");
+    }
+
+    private Execution execution() {
+        return Execution.builder()
+            .id(IdUtils.create())
+            .namespace("io.kestra.unittest")
+            .flowId("set-variables")
+            .flowRevision(1)
+            .state(new State().withState(State.Type.RUNNING))
+            .build();
     }
 }

--- a/core/src/test/java/io/kestra/plugin/core/execution/UnsetVariablesTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/execution/UnsetVariablesTest.java
@@ -1,5 +1,6 @@
 package io.kestra.plugin.core.execution;
 
+import java.util.HashMap;
 import java.util.Map;
 
 import org.junit.jupiter.api.Test;
@@ -8,7 +9,10 @@ import io.kestra.core.junit.annotations.ExecuteFlow;
 import io.kestra.core.junit.annotations.KestraTest;
 import io.kestra.core.models.executions.Execution;
 import io.kestra.core.models.flows.State;
+import io.kestra.core.runners.RunContextFactory;
+import io.kestra.core.serializers.JacksonMapper;
 import io.kestra.core.services.TaskOutputService;
+import io.kestra.core.utils.IdUtils;
 
 import jakarta.inject.Inject;
 
@@ -19,11 +23,50 @@ class UnsetVariablesTest {
     @Inject
     private TaskOutputService taskOutputService;
 
+    @Inject
+    private RunContextFactory runContextFactory;
+
     @ExecuteFlow("flows/valids/unset-variables.yaml")
     @Test
     void shouldUpdateExecution(Execution execution) throws io.kestra.core.exceptions.InternalException {
         assertThat(execution.getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
         assertThat(execution.getTaskRunList()).hasSize(3);
         assertThat(((Map<String, Object>) taskOutputService.getOutputs(execution.getTaskRunList().get(2)).get("values"))).containsEntry("message", "default");
+    }
+
+    @Test
+    void shouldRenderVariablesForEachExecution() throws Exception {
+        // the executor calls update() on the task instance of its cached flow, so the same task
+        // instance is reused by every execution of the flow: it must not reuse the first rendering
+        UnsetVariables task = JacksonMapper.ofJson().readValue(
+            """
+                {
+                  "id": "unset",
+                  "type": "io.kestra.plugin.core.execution.UnsetVariables",
+                  "variables": ["{{ inputs.toUnset }}"]
+                }""",
+            UnsetVariables.class
+        );
+
+        Execution first = task.update(execution(), runContextFactory.of(Map.of("inputs", Map.of("toUnset", "first"))));
+        assertThat(first.getVariables()).containsOnlyKeys("second");
+
+        Execution second = task.update(execution(), runContextFactory.of(Map.of("inputs", Map.of("toUnset", "second"))));
+        assertThat(second.getVariables()).containsOnlyKeys("first");
+    }
+
+    private Execution execution() {
+        Map<String, Object> variables = new HashMap<>();
+        variables.put("first", "1");
+        variables.put("second", "2");
+
+        return Execution.builder()
+            .id(IdUtils.create())
+            .namespace("io.kestra.unittest")
+            .flowId("unset-variables")
+            .flowRevision(1)
+            .state(new State().withState(State.Type.RUNNING))
+            .variables(variables)
+            .build();
     }
 }


### PR DESCRIPTION
Closes #18518

### What

`SetVariables`, `UnsetVariables` and `Exit` are `ExecutionUpdatableTask`s: the executor runs them itself (`ExecutorService.handleExecutionUpdatingTasks`) by calling `update()` on `workerTask.getTask()`, which is the task instance of the executor's **cached flow**. That single instance is shared by every execution of the flow revision.

`Property` memoizes its rendered value on the instance:

```java
if (property.skipCache || property.value == null) {
    String rendered = context.render(property.expression, variables);
    property.value = deserialize(rendered, clazz);
}
return property.value;
```

So the value rendered by the *first* execution was silently reused by all the following ones, whatever their inputs. Reproduced on `v2.0.0-rc8` and hit in production: a release flow computing `IS_LTS` / `IS_LATEST` from its version input kept the booleans of the first execution — deploying an execution to the wrong docker tags.

```yaml
tasks:
  - id: computeIsLts
    type: io.kestra.plugin.core.execution.SetVariables
    variables:
      IS_LTS: "{{ inputs.VERSION | startsWith('1.3.') }}"
  - id: log
    type: io.kestra.plugin.core.log.Log
    message: "{{ inputs.VERSION }} — lts: {{ vars.IS_LTS }}"
```

Run it with `1.3.9` (→ `true`), then with `1.0.56`: it still logs `true`. Deploying the same flow under another id, or bumping its revision, resets the cache — then the first run of the new revision pins it again.

### How

Render those properties with `Property#skipCache()` inside `update()`, exactly like `424a6cb43` already did for the flowable properties used to compute the next tasks. `Labels` is not affected — it renders raw `Object` values through the run context, not through `Property`.

### Tests

Written test-first, both fail on `develop` and pass with the fix:

- `SetVariablesTest#shouldRenderVariablesForEachExecution` — one deserialized task instance, `update()` called twice with different execution contexts, asserts the second render reflects the second context.
- `UnsetVariablesTest#shouldRenderVariablesForEachExecution` — same for the list property.

`io.kestra.plugin.core.execution.*` and `io.kestra.core.models.property.*` are green (35 tests).

### Backport

Worth backporting — the bug is present in every version shipping `Property`-based `SetVariables`.
