### PR TITLE
fix(triggers): validate missing backfill configuration

### DIFF
--- a/webserver/src/main/java/io/kestra/webserver/controllers/api/TriggerController.java
+++ b/webserver/src/main/java/io/kestra/webserver/controllers/api/TriggerController.java
@@ -224,7 +224,7 @@ public class TriggerController {
     @ApiResponse(responseCode = "200", description = "On success", content = { @Content(schema = @Schema(implementation = ApiTriggerState.class)) })
     @ApiResponse(responseCode = "409", description = "If the backfill cannot be created")
     public HttpResponse<ApiTriggerState> createBackfill(
-        @Parameter(description = "The trigger that need the backfill to be created") @Body ApiCreateBackfillRequest request) {
+        @Parameter(description = "The trigger that need the backfill to be created") @Body @Valid ApiCreateBackfillRequest request) {
         TriggerId triggerId = TriggerId.of(tenantService.resolveTenant(), request.namespace(), request.flowId(), request.triggerId());
         CreateBackfillTrigger.Backfill backfill = new CreateBackfillTrigger.Backfill(
             request.backfill().start(), request.backfill().end(), request.backfill().inputs(), request.backfill().labels()
@@ -481,7 +481,7 @@ public class TriggerController {
         @Parameter(description = "The namespace.") String namespace,
         @Parameter(description = "The ID of the flow.") String flowId,
         @Parameter(description = "The ID of the trigger.") String triggerId,
-        @Parameter(description = "The backfill configuration") Backfill backfill) {
+        @Parameter(description = "The backfill configuration") @NotNull Backfill backfill) {
 
         public record Backfill(
             ZonedDateTime start,

--- a/webserver/src/test/java/io/kestra/webserver/controllers/api/TriggerControllerTest.java
+++ b/webserver/src/test/java/io/kestra/webserver/controllers/api/TriggerControllerTest.java
@@ -5,6 +5,7 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.TimeoutException;
 import java.util.stream.Stream;
 
@@ -706,6 +707,28 @@ class TriggerControllerTest {
         } catch (TimeoutException e) {
             Assertions.fail("Timeout waiting for trigger to be enabled");
         }
+    }
+
+    @Test
+    void shouldReturnUnprocessableEntityWhenCreatingBackfillWithoutBackfillConfiguration() {
+        // GIVEN
+        Map<String, String> request = Map.of(
+            "namespace", "namespace",
+            "flowId", "flow",
+            "triggerId", "trigger"
+        );
+
+        // WHEN
+        HttpClientResponseException exception = assertThrows(
+            HttpClientResponseException.class,
+            () -> client.toBlocking().retrieve(
+                HttpRequest.PUT(TRIGGER_PATH + "/backfill/create", request),
+                ApiTriggerState.class
+            )
+        );
+
+        // THEN
+        assertThat(exception.getStatus().getCode()).isEqualTo(HttpStatus.UNPROCESSABLE_ENTITY.getCode());
     }
 
     @Test


### PR DESCRIPTION
### 🔗 Related Issue

Closes https://github.com/kestra-io/kestra/issues/18408.

### ✨ Description

Validates create-backfill requests before the controller reads the nested backfill configuration. Requests that omit `backfill` now return 422 Unprocessable Entity instead of triggering a NullPointerException and returning 500.

Adds an HTTP integration regression test covering the missing-field request.

### 🛠️ Backend Checklist

- [x] Code compiles and tests pass for the touched modules (`./gradlew :module-name:test`, or `./gradlew build` for cross-module changes)
- [x] New behavior is covered by unit or integration tests

### 📝 Additional Notes

Validated with Java 25 by running `TriggerControllerTest`: 28 tests passed.

### 🤖 AI Authors

Cat joke: Why did the cat avoid the null pointer? It had already spent nine lives debugging it.