### PR TITLE
fix(secrets): give the secret value field a real placeholder instead of the dialog title

### DIFF
--- a/ui/scripts/translations/fingerprints.json
+++ b/ui/scripts/translations/fingerprints.json
@@ -1497,6 +1497,7 @@
   "secret|names": "d8707d411d99",
   "secret|tags": "1331275bc537",
   "secret|update": "1f9665371ec3",
+  "secret|valuePlaceholder": "48af1d986544",
   "see timeline": "83dcfd4908fa",
   "seeing old revision": "086575f0ce3d",
   "select a state": "b058fc7c5e0b",

--- a/ui/src/components/secrets/SecretsTable.vue
+++ b/ui/src/components/secrets/SecretsTable.vue
@@ -165,13 +165,13 @@
                     <KsInput v-model="secret.key" :disabled="secret.update" :placeholder="$t('secret.keyPlaceholder')" required />
                 </KsFormItem>
                 <KsFormItem v-if="!secret.update" :label="$t('secret.name')" prop="value" required inline class="field-item">
-                    <KsPassword v-model="secret.value" :placeholder="secretModalTitle" />
+                    <KsPassword v-model="secret.value" :placeholder="$t('secret.valuePlaceholder')" />
                 </KsFormItem>
                 <KsFormItem v-if="secret.update" :label="$t('secret.name')" prop="value" inline class="field-item">
                     <div class="secret-value-control">
                         <KsPassword
                             v-model="secret.value"
-                            :placeholder="secretModalTitle"
+                            :placeholder="$t('secret.valuePlaceholder')"
                             :disabled="!secret.updateValue"
                         />
                         <KsSwitch

--- a/ui/src/translations/de.json
+++ b/ui/src/translations/de.json
@@ -1391,6 +1391,7 @@
       "key": "Name",
       "keyPlaceholder": "Name, über den dieses Secret referenziert wird, z. B. MY_API_TOKEN",
       "name": "Secret-Wert",
+      "valuePlaceholder": "Secret-Wert eingeben",
       "description": "Beschreibung",
       "descriptionPlaceholder": "Beschreibe dieses Secret",
       "tags": "Tags",

--- a/ui/src/translations/en.json
+++ b/ui/src/translations/en.json
@@ -1391,6 +1391,7 @@
       "key": "Name",
       "keyPlaceholder": "Name used to reference this secret, e.g. MY_API_TOKEN",
       "name": "Secret value",
+      "valuePlaceholder": "Enter the secret value",
       "description": "Description",
       "descriptionPlaceholder": "Describe this secret",
       "tags": "Tags",

--- a/ui/src/translations/es.json
+++ b/ui/src/translations/es.json
@@ -1391,6 +1391,7 @@
       "key": "Nombre",
       "keyPlaceholder": "Nombre para referenciar este secreto, ej. MY_API_TOKEN",
       "name": "Valor secreto",
+      "valuePlaceholder": "Introduce el valor secreto",
       "description": "Descripción",
       "descriptionPlaceholder": "Describe este secreto",
       "tags": "Etiquetas",

--- a/ui/src/translations/fr.json
+++ b/ui/src/translations/fr.json
@@ -1391,6 +1391,7 @@
       "key": "Nom",
       "keyPlaceholder": "Nom utilisé pour référencer ce secret, par exemple MY_API_TOKEN",
       "name": "Valeur secrète",
+      "valuePlaceholder": "Saisir la valeur secrète",
       "description": "Description",
       "descriptionPlaceholder": "Décrire ce secret",
       "tags": "Tags",

--- a/ui/src/translations/hi.json
+++ b/ui/src/translations/hi.json
@@ -1391,6 +1391,7 @@
       "key": "नाम",
       "keyPlaceholder": "इस गुप्त को संदर्भित करने के लिए उपयोग किया जाने वाला नाम, उदाहरण के लिए MY_API_TOKEN",
       "name": "गुप्त मान",
+      "valuePlaceholder": "गुप्त मान दर्ज करें",
       "description": "विवरण",
       "descriptionPlaceholder": "इस secret का वर्णन करें",
       "tags": "टैग",

--- a/ui/src/translations/it.json
+++ b/ui/src/translations/it.json
@@ -1391,6 +1391,7 @@
       "key": "Nome",
       "keyPlaceholder": "Nome usato per fare riferimento a questo segreto, ad es. MY_API_TOKEN",
       "name": "Valore segreto",
+      "valuePlaceholder": "Inserisci il valore segreto",
       "description": "Descrizione",
       "descriptionPlaceholder": "Descrivi questo segreto",
       "tags": "Etichette",

--- a/ui/src/translations/ja.json
+++ b/ui/src/translations/ja.json
@@ -1391,6 +1391,7 @@
       "key": "名前",
       "keyPlaceholder": "このシークレットを参照するために使用される名前。例: MY_API_TOKEN",
       "name": "秘密の値",
+      "valuePlaceholder": "秘密の値を入力",
       "description": "説明",
       "descriptionPlaceholder": "このシークレットの説明",
       "tags": "タグ",

--- a/ui/src/translations/ko.json
+++ b/ui/src/translations/ko.json
@@ -1391,6 +1391,7 @@
       "key": "이름",
       "keyPlaceholder": "이 시크릿을 참조하는 데 사용되는 이름, 예: MY_API_TOKEN",
       "name": "비밀 value",
+      "valuePlaceholder": "비밀 value 입력",
       "description": "설명",
       "descriptionPlaceholder": "이 비밀을 설명하세요",
       "tags": "태그",

--- a/ui/src/translations/pl.json
+++ b/ui/src/translations/pl.json
@@ -1391,6 +1391,7 @@
       "key": "Nazwa",
       "keyPlaceholder": "Nazwa używana do odwoływania się do tego sekretu, np. MY_API_TOKEN",
       "name": "Wartość sekretu",
+      "valuePlaceholder": "Wprowadź wartość sekretu",
       "description": "Opis",
       "descriptionPlaceholder": "Opisz ten sekret",
       "tags": "Tagi",

--- a/ui/src/translations/pt.json
+++ b/ui/src/translations/pt.json
@@ -1391,6 +1391,7 @@
       "key": "Nome",
       "keyPlaceholder": "Nome usado para referenciar este segredo, por exemplo, MY_API_TOKEN",
       "name": "Valor secreto",
+      "valuePlaceholder": "Insira o valor secreto",
       "description": "Descrição",
       "descriptionPlaceholder": "Descreva este segredo",
       "tags": "Tags",

--- a/ui/src/translations/pt_BR.json
+++ b/ui/src/translations/pt_BR.json
@@ -1391,6 +1391,7 @@
       "key": "Nome",
       "keyPlaceholder": "Nome usado para referenciar este segredo, ex: MY_API_TOKEN",
       "name": "Valor do segredo",
+      "valuePlaceholder": "Insira o valor do segredo",
       "description": "Descrição",
       "descriptionPlaceholder": "Descreva este segredo",
       "tags": "Etiquetas",

--- a/ui/src/translations/ru.json
+++ b/ui/src/translations/ru.json
@@ -1391,6 +1391,7 @@
       "key": "Имя",
       "keyPlaceholder": "Имя, используемое для ссылки на этот секрет, например, MY_API_TOKEN",
       "name": "Секретное значение",
+      "valuePlaceholder": "Введите секретное значение",
       "description": "Описание",
       "descriptionPlaceholder": "Опишите этот секрет",
       "tags": "Теги",

--- a/ui/src/translations/zh_CN.json
+++ b/ui/src/translations/zh_CN.json
@@ -1391,6 +1391,7 @@
       "key": "名称",
       "keyPlaceholder": "用于引用此密钥的名称，例如 MY_API_TOKEN",
       "name": "秘密值",
+      "valuePlaceholder": "输入秘密值",
       "description": "描述",
       "descriptionPlaceholder": "描述此 secret",
       "tags": "标签",


### PR DESCRIPTION
Closes https://github.com/kestra-io/kestra-ee/issues/10334

### What

The **Secret value** field in the create/edit secret dialog bound its placeholder to `secretModalTitle`, the computed that renders the dialog's own title. So the field showed `Create` when creating a secret and `Update secret 'MY_KEY'` when editing one, instead of a hint describing what to type. Its neighbours (`secret.keyPlaceholder`, `secret.descriptionPlaceholder`) already had proper hints; the value field was the only one without.

### How

- Added `secret.valuePlaceholder` ("Enter the secret value") and used it on both the create and the edit input, so the two paths stay consistent. `secretModalTitle` keeps its real job, the dialog title.
- Translated the new key into the 12 locales, each mirroring that locale's existing wording for `secret.name` ("Secret value"), and added its fingerprint. `npm run translations:check` is clean.

### Before / after

| | Create | Edit |
|---|---|---|
| Before | `Create` | `Update secret 'MY_KEY'` |
| After | `Enter the secret value` | `Enter the secret value` |

Reported against 2.0.0-rc10 EE; the component is shared OSS code (`ui/src/components/secrets/SecretsTable.vue`) with no EE override, so the fix covers both editions.
