### PR TITLE
fix(core): stop empty screens sliding in on tab switch

### DIFF
--- a/ui/src/styles/app.scss
+++ b/ui/src/styles/app.scss
@@ -71,6 +71,10 @@ main {
         transition: padding 0.3s ease;
         padding: 0 2rem;
 
+        &:has(section.empty) {
+            transition: none;
+        }
+
         &.full-height {
             flex: 1;
             display: flex;


### PR DESCRIPTION
closes https://github.com/kestra-io/kestra-ee/issues/10120