### PR TITLE
fix(core): hide split toggle when no bottom panel exists

### DIFF
--- a/ui/src/components/MultiPanelGenericEditorView.vue
+++ b/ui/src/components/MultiPanelGenericEditorView.vue
@@ -3,6 +3,7 @@
         <MultiPanelEditorTabs :tabs="editorElements" @update:tabs="setTabValue" :openTabs="openTabs">
             <div class="tabs-actions">
                 <KsButton
+                    v-if="bottomVisible && slots['bottom-panel']"
                     :icon="splitOrientation === 'vertical' ? ViewSplitVertical : ViewSplitHorizontal"
                     :tooltip="splitOrientation === 'vertical' ? $t('split_horizontal') : $t('split_vertical')"
                     class="orientation-toggle"

--- a/ui/tests/unit/components/MultiPanelGenericEditorView.spec.ts
+++ b/ui/tests/unit/components/MultiPanelGenericEditorView.spec.ts
@@ -38,13 +38,15 @@ const editorElements = [
     },
 ]
 
-function mountEditor() {
+function mountEditor({withBottomPanel = true} = {}) {
     return mount(MultiPanelGenericEditorView, {
         global: globalConfig,
         props: {
             editorElements,
             defaultActiveTabs: ["code"],
+            bottomVisible: withBottomPanel,
         },
+        slots: withBottomPanel ? {"bottom-panel": "<div />"} : {},
     })
 }
 
@@ -65,6 +67,14 @@ describe("MultiPanelGenericEditorView split orientation", () => {
 
         // Then: splitOrientation is "vertical"
         expect((wrapper.vm as any).splitOrientation).toBe("vertical")
+    })
+
+    test("hides the toggle button when there is no bottom panel", () => {
+        // Given: the component is mounted without a bottom panel
+        const wrapper = mountEditor({withBottomPanel: false})
+
+        // Then: the orientation toggle is not rendered
+        expect(wrapper.find(".orientation-toggle").exists()).toBe(false)
     })
 
     test("toggle button exists with accessible aria-label", () => {


### PR DESCRIPTION
The split-orientation toggle showed up in every multi-panel editor (Policies, Dashboards, Apps, Test Suites), but it only does something in the flow editor when Playground mode is on, since that's the only place a bottom panel exists. Everywhere else clicking it did nothing.

Now the button only renders when a bottom panel is actually there.

closes https://github.com/kestra-io/kestra-ee/issues/10228
closes [kestra-io/kestra-ee/issues/10195](https://github.com/kestra-io/kestra-ee/issues/10195)
closes [kestra-io/kestra#18328](https://github.com/kestra-io/kestra/issues/18328)