### PR TITLE
fix(core): apply the Timezone setting to revisions, dashboard dates and metric labels

### DIFF
--- a/ui/src/components/dashboard/sections/table/columns/Date.spec.ts
+++ b/ui/src/components/dashboard/sections/table/columns/Date.spec.ts
@@ -1,7 +1,8 @@
-import {describe, expect, it, vi} from "vitest"
+import {describe, expect, it, vi, beforeEach, afterEach} from "vitest"
 import {mount} from "@vue/test-utils"
 import {defineComponent} from "vue"
-import moment from "moment"
+import moment from "moment-timezone"
+import {storageKeys} from "../../../../../utils/constants"
 import DateColumn from "./Date.vue"
 
 vi.mock("@kestra-io/design-system", () => ({
@@ -13,16 +14,22 @@ vi.mock("@kestra-io/design-system", () => ({
 }))
 
 const FIELD = "2026-07-24T13:16:00.000Z"
-const absolute = () => moment(FIELD).format("llll")
+const TIMEZONE = "America/Los_Angeles"
+
+const inTimezone = (format: string) => moment(FIELD).tz(TIMEZONE).format(format)
 
 describe("dashboard table Date column", () => {
+    beforeEach(() => localStorage.clear())
+    afterEach(() => localStorage.clear())
+
     it("should render the absolute date with a tooltip carrying the full value", () => {
         const wrapper = mount(DateColumn, {props: {field: FIELD}})
 
+        const expected = moment(FIELD).tz(moment.tz.guess()).format("llll")
         const tooltip = wrapper.find("[data-test=tooltip]")
         expect(tooltip.exists()).toBe(true)
-        expect(tooltip.attributes("data-content")).toBe(absolute())
-        expect(wrapper.find("span.date").text()).toBe(absolute())
+        expect(tooltip.attributes("data-content")).toBe(expected)
+        expect(wrapper.find("span.date").text()).toBe(expected)
     })
 
     it("should render the relative date with the absolute value in the tooltip", () => {
@@ -30,8 +37,9 @@ describe("dashboard table Date column", () => {
 
         const tooltip = wrapper.find("[data-test=tooltip]")
         expect(tooltip.exists()).toBe(true)
-        expect(tooltip.attributes("data-content")).toBe(absolute())
-        expect(wrapper.find("span.date").text()).toBe(moment(FIELD).calendar(null, {sameElse: "L [at] LT"}))
+        expect(tooltip.attributes("data-content")).toBe(moment(FIELD).tz(moment.tz.guess()).format("llll"))
+        expect(wrapper.find("span.date").text())
+            .toBe(moment(FIELD).tz(moment.tz.guess()).calendar(null, {sameElse: "L [at] LT"}))
     })
 
     it("should render nothing when there is no field", () => {
@@ -39,5 +47,33 @@ describe("dashboard table Date column", () => {
 
         expect(wrapper.find("[data-test=tooltip]").exists()).toBe(false)
         expect(wrapper.text()).toBe("")
+    })
+
+    it("should format the absolute date in the timezone from settings", () => {
+        localStorage.setItem(storageKeys.TIMEZONE_STORAGE_KEY, TIMEZONE)
+
+        const wrapper = mount(DateColumn, {props: {field: FIELD}})
+
+        expect(wrapper.find("span.date").text()).toBe(inTimezone("llll"))
+        expect(wrapper.find("[data-test=tooltip]").attributes("data-content")).toBe(inTimezone("llll"))
+    })
+
+    it("should format the relative date in the timezone from settings", () => {
+        localStorage.setItem(storageKeys.TIMEZONE_STORAGE_KEY, TIMEZONE)
+
+        const wrapper = mount(DateColumn, {props: {field: FIELD, relative: true}})
+
+        expect(wrapper.find("span.date").text())
+            .toBe(moment(FIELD).tz(TIMEZONE).calendar(null, {sameElse: "L [at] LT"}))
+    })
+
+    it("should honour the date format from settings alongside the timezone", () => {
+        localStorage.setItem(storageKeys.TIMEZONE_STORAGE_KEY, TIMEZONE)
+        localStorage.setItem(storageKeys.DATE_FORMAT_STORAGE_KEY, "YYYY-MM-DD HH:mm")
+
+        const wrapper = mount(DateColumn, {props: {field: FIELD}})
+
+        // 13:16 UTC is 06:16 in Los Angeles, so a wrong timezone shows a different hour.
+        expect(wrapper.find("span.date").text()).toBe("2026-07-24 06:16")
     })
 })

--- a/ui/src/components/dashboard/sections/table/columns/Date.vue
+++ b/ui/src/components/dashboard/sections/table/columns/Date.vue
@@ -6,8 +6,9 @@
 
 <script setup lang="ts">
     import {computed} from "vue"
-    import moment from "moment"
+    import moment from "moment-timezone"
     import {storageKeys} from "../../../../../utils/constants"
+    import {date as dateFilter} from "../../../../../utils/filters"
     import {KsTooltip} from "@kestra-io/design-system"
 
     const props = defineProps({
@@ -21,19 +22,21 @@
         },
     })
 
-    const momentLongDateFormat = "llll"
-    const format = localStorage.getItem(storageKeys.DATE_FORMAT_STORAGE_KEY) ?? momentLongDateFormat
+    // The relative branch needs moment's calendar(), which dateFilter cannot express, so it applies
+    // the stored timezone itself rather than falling back to the machine's.
+    const inTimezone = (value: string) =>
+        moment(value).tz(localStorage.getItem(storageKeys.TIMEZONE_STORAGE_KEY) ?? moment.tz.guess())
 
     const date = computed(() => {
         if (!props.field) return undefined
         // moment(date) always return a Moment, if the date is undefined, it will return current date, we don't want that here
         return props.relative
-            ? moment(props.field).calendar(null, {sameElse: "L [at] LT"})
-            : moment(props.field).format(format)
+            ? inTimezone(props.field).calendar(null, {sameElse: "L [at] LT"})
+            : dateFilter(props.field)
     })
 
     const absolute = computed(() =>
-        props.field ? moment(props.field).format(format) : undefined,
+        props.field ? dateFilter(props.field) : undefined,
     )
 </script>
 

--- a/ui/src/components/flows/FlowMetrics.vue
+++ b/ui/src/components/flows/FlowMetrics.vue
@@ -71,6 +71,7 @@
     import {useI18n} from "vue-i18n"
     import {useFlowStore} from "../../stores/flow"
     import {getFormat} from "../dashboard/composables/charts"
+    import {date as dateFilter} from "../../utils/filters"
     import {cssVar, KsBar, KsLine, KsSegmented} from "@kestra-io/design-system"
     import type {KsChartSeriesItem} from "@kestra-io/design-system"
     import {KsFilter as KSFilter} from "@kestra-io/design-system"
@@ -161,7 +162,7 @@
         const data = metricsData.value[metric]
         if (!data) return []
         const aggregations = (data.aggregations ?? []) as MetricAggregation[]
-        return aggregations.map((e) => moment(e.date).format(getFormat(data.groupBy)))
+        return aggregations.map((e) => dateFilter(e.date, getFormat(data.groupBy)))
     }
 
     function getSeriesData(metric: string): KsChartSeriesItem[] {

--- a/ui/src/components/layout/Revisions.vue
+++ b/ui/src/components/layout/Revisions.vue
@@ -132,7 +132,7 @@
     import CircleOpacity from "vue-material-design-icons/CircleOpacity.vue"
     import {KsEditor} from "@kestra-io/design-system"
     import {useEditorBindings} from "../../composables/useEditorBindings"
-    import moment from "moment"
+    import {date as dateFilter} from "../../utils/filters"
 
     import {useToast} from "../../utils/toast"
     import {useFlowStore} from "../../stores/flow"
@@ -263,7 +263,7 @@
     function formatTimestamp(updatedDate?: string): string {
         if (!updatedDate) return ""
 
-        return moment(updatedDate).format("YYYY-MM-DD HH:mm")
+        return dateFilter(updatedDate, "YYYY-MM-DD HH:mm")
     }
 
     function formatRevisionText(revision: number): string {


### PR DESCRIPTION
### 🔗 Related Issue

Closes https://github.com/kestra-io/kestra/issues/18541.
Closes https://github.com/kestra-io/kestra-ee/issues/10283.

### ✨ Description

Follow-up to #18453 / #18456 ([#18528](https://github.com/kestra-io/kestra/pull/18528)). In that PR's review I said I had deliberately not swept the rest of the app for other bare `moment(...).format(...)` calls, and that it deserved its own pass. This is that pass.

Three surfaces followed the browser machine's timezone instead of the one in Settings:

- **Revisions** (`Revisions.vue`) — the revision timestamp. Now goes through `utils/filters#date`. The compact `YYYY-MM-DD HH:mm` format is kept on purpose: the dropdown has no room for a `llll`-style setting, so this applies the timezone without also switching the format.
- **Dashboard table Date column** (`columns/Date.vue`) — this one already read `DATE_FORMAT_STORAGE_KEY` but not `TIMEZONE_STORAGE_KEY`, so it half-honoured Settings. That asymmetry is what made it clearly an oversight. Both now come from the shared helper, which lets the local format lookup go away entirely.
- **Flow metrics** (`FlowMetrics.vue`) — chart category labels, so a bucket is no longer labelled with the machine's day or hour near a boundary.

The `relative` branch of the Date column needs moment's `calendar()`, which `dateFilter` cannot express, so it applies the stored timezone directly instead.

**Deliberately not changed** — four call sites from the same audit that serialise a value for submission rather than displaying an instant, where applying a timezone would alter the data sent: `Curl.vue:56`/`:59`, `submitTask.ts:36`/`:38`, and the `DATE` branch of `kvValue.ts:52` (its `DATETIME` branch already applies `.tz(tz)`). Listed in the issue so the audit is not silently partial.

### 🎨 Frontend Checklist

- [x] Type checking passes (`npm run check:types`)
- [x] Code builds without errors (`npm run build`)
- [x] Unit tests pass (`npm run test:unit` — 1839 passed)
- [x] Translations are complete if `en.json` changed (no `en.json` change in this PR)
- [ ] Screenshots or video recordings attached showing the `UI` changes

/demo-video

### 📝 Additional Notes

`Date.spec.ts` asserted the old machine-timezone behaviour (`moment(FIELD).format("llll")`), so keeping it as-is would have meant a test that passes either way. It is rewritten around an explicit `America/Los_Angeles`: three of the six cases fail against the old formatting, verified by reverting the fix under `TZ=UTC`.

`moment` becomes unused in `Revisions.vue` and its import is dropped; `FlowMetrics.vue` still uses it for the ISO range so it stays.

Same known limitation as #18528: `dateFilter` reads `localStorage`, which is not reactive, so changing the Timezone while one of these views is open does not re-render it until something else invalidates the computed. Pre-existing across every `dateFilter` caller; a reactive timezone store would be the real answer and is not a bug-fix-sized change.

### 🤖 AI Authors

Asked my cat which timezone he was in. He said "the one where it's dinner time", which is roughly how these three components were picking theirs. 🐱

---
_Generated by [Claude Code](https://claude.ai/code/session_01WAUBiJTcC3ABYSnRiUiPzZ)_
