### PR TITLE
fix(design-system): align alert icon with the first line of wrapped messages

### DIFF
--- a/ui/packages/design-system/src/components/Feedback/KsAlert.vue
+++ b/ui/packages/design-system/src/components/Feedback/KsAlert.vue
@@ -57,8 +57,27 @@
         --kel-alert-description-font-size: var(--ks-font-size-xs);
         --kel-alert-title-with-description-font-size: var(--ks-font-size-sm);
 
+        /* Element Plus centres the row, which parks the icon in the middle of a wrapped message
+           instead of beside the first line - 7px low at two lines, 14px at three. Anchor the row to
+           the top so the icon stays on line one however far the text wraps. */
+        align-items: flex-start;
+
+        /* Font size of whichever element renders line one, used below to centre the icon against it.
+           Three cases, since Element Plus shrinks the title once a description joins it. */
+        --ks-alert-first-line-font-size: var(--kel-alert-title-font-size);
+
+        &:has(.kel-alert__title.with-description) {
+            --ks-alert-first-line-font-size: var(--kel-alert-title-with-description-font-size);
+        }
+
+        &:not(:has(.kel-alert__title)) {
+            --ks-alert-first-line-font-size: var(--kel-alert-description-font-size);
+        }
+
          .kel-alert__title {
-            line-height: 1;
+            /* Matches the description so line one has the same box in both, and gives wrapped lines
+               the leading that `line-height: 1` denied them. */
+            line-height: var(--ks-line-height-base);
         }
 
         .kel-alert__description {
@@ -66,10 +85,21 @@
         }
 
         .kel-alert__icon {
+            /* Keeps the icon's own box at its natural size so a single-line alert is exactly as tall
+               as before; `align-items` above is what puts it on the first line. */
+            height: var(--kel-alert-icon-size);
+            align-self: flex-start;
+
             .material-design-icon,
             .material-design-icon > .material-design-icon__svg {
                 height: var(--kel-alert-icon-size);
                 width: var(--kel-alert-icon-size);
+            }
+
+            .material-design-icon > .material-design-icon__svg {
+                /* The icon box is taller than one line of text, so raise the glyph by half the
+                   difference to land it on the centre of line one rather than of its own box. */
+                bottom: calc((var(--kel-alert-icon-size) - var(--ks-line-height-base) * var(--ks-alert-first-line-font-size)) / 2);
             }
         }
 

--- a/ui/packages/design-system/src/components/Feedback/KsAlert.vue
+++ b/ui/packages/design-system/src/components/Feedback/KsAlert.vue
@@ -57,13 +57,10 @@
         --kel-alert-description-font-size: var(--ks-font-size-xs);
         --kel-alert-title-with-description-font-size: var(--ks-font-size-sm);
 
-        /* Element Plus centres the row, which parks the icon in the middle of a wrapped message
-           instead of beside the first line - 7px low at two lines, 14px at three. Anchor the row to
-           the top so the icon stays on line one however far the text wraps. */
+        /* Element Plus centres the row, which leaves the icon mid-block once the message wraps. */
         align-items: flex-start;
 
-        /* Font size of whichever element renders line one, used below to centre the icon against it.
-           Three cases, since Element Plus shrinks the title once a description joins it. */
+        /* Font size of whichever element renders line one; the title shrinks when a description is present. */
         --ks-alert-first-line-font-size: var(--kel-alert-title-font-size);
 
         &:has(.kel-alert__title.with-description) {
@@ -75,8 +72,6 @@
         }
 
          .kel-alert__title {
-            /* Matches the description so line one has the same box in both, and gives wrapped lines
-               the leading that `line-height: 1` denied them. */
             line-height: var(--ks-line-height-base);
         }
 
@@ -85,8 +80,6 @@
         }
 
         .kel-alert__icon {
-            /* Keeps the icon's own box at its natural size so a single-line alert is exactly as tall
-               as before; `align-items` above is what puts it on the first line. */
             height: var(--kel-alert-icon-size);
             align-self: flex-start;
 
@@ -97,8 +90,7 @@
             }
 
             .material-design-icon > .material-design-icon__svg {
-                /* The icon box is taller than one line of text, so raise the glyph by half the
-                   difference to land it on the centre of line one rather than of its own box. */
+                /* Raise the glyph by half its overhang so it centres on line one, not on its own taller box. */
                 bottom: calc((var(--kel-alert-icon-size) - var(--ks-line-height-base) * var(--ks-alert-first-line-font-size)) / 2);
             }
         }


### PR DESCRIPTION
Closes https://github.com/kestra-io/kestra/issues/18548.

> **Merge sequence - this `PR` is 1 of 2.** Merge this one first, then https://github.com/kestra-io/kestra-ee/pull/10379.
> The `EE` `PR` removes a local workaround that only becomes redundant once this lands, so merging it first would leave that component misaligned.

## What

`KsAlert` centred its icon against the whole message block instead of the line it belongs to, so any alert whose text wrapped left the icon sitting low - measured **7px at two lines, 14px at three, 21px at four**. The reported case was the dev-only SDK/OpenAPI drift banner, whose 185-character message wraps at any viewport of 1280px or less, but the same applied to every wrapping `KsAlert`.

Two causes, both in `KsAlert`:

- `Element Plus` lays `.el-alert` out with `align-items: center`, and `KsAlert` never overrode it.
- `KsAlert` set `.kel-alert__title { line-height: 1 }`, so wrapped lines had no leading at all.

## How

- Anchor the row with `align-items: flex-start` so the icon stays on line one however far the text wraps.
- Restore the title's leading to `--ks-line-height-base`, matching the description.
- Raise the glyph by half the difference between the icon box and one line of text, so it centres on line one rather than on its own taller box. The offset is derived from whichever element renders the first line, since `Element Plus` shrinks the title once a description joins it - hence the three `--ks-alert-first-line-font-size` cases.

The icon's own box keeps its natural height, so a single-line alert with an icon is **exactly as tall as before**.

## Verified

Measured in the design-system `Storybook` (`KsAlert` stories), comparing the pre-fix `CSS` against the fix in the same page:

| Case | Icon offset before | after | Alert height |
|---|---|---|---|
| Title only, 1 line, with icon | 0px | 0px | 42px, unchanged |
| Title only, 2 lines | 7px low | **0px** | 46px to 60px |
| Title only, 3 lines | 14px low | **0px** | 60px to 81px |
| Title only, 4 lines | 21px low | **0px** | 74px to 102px |
| Title + description | 10.25px low | **0px** | 50.5px to 56.5px |
| Description only, 1 and 2 lines | 0px / low | **0px** | unchanged |

Checks: design-system unit tests 4/4, `Storybook` tests 6/6, `vue-tsc` clean in `design-system`, `kestra/ui` and `kestra-ee/ui-ee`, `oxlint` + `eslint` clean.

## Notes

- Alerts **with a title** are 6-7px taller now that wrapped lines have leading. Single-line alerts with an icon are unaffected. This is the intended consequence of dropping `line-height: 1`.
- `SdkDriftBanner`'s `max-height: 4.375rem` cap now fits 2 wrapped lines instead of 3, so that dev-only banner clips below roughly 900px wide. Clipping is bottom-only now that the row is top-anchored, so the first line always stays readable - previously the centred row was trimmed at both ends.
- The close button still centres on the whole alert rather than the first line. Left as-is to keep this diff surgical; worth revisiting if it looks inconsistent on tall alerts.
- `:has()` is already used 27 times in this codebase and there is no `browserslist` constraint, so it is established practice here.

Related to https://github.com/kestra-io/kestra-ee/pull/10379.
