### PR TITLE
fix(core): validate and fail-execution on out-of-range user durations

### DIFF
--- a/core/src/main/java/io/kestra/core/models/flows/sla/types/MaxDurationSLA.java
+++ b/core/src/main/java/io/kestra/core/models/flows/sla/types/MaxDurationSLA.java
@@ -11,6 +11,7 @@ import io.kestra.core.models.flows.sla.ExecutionMonitoringSLA;
 import io.kestra.core.models.flows.sla.SLA;
 import io.kestra.core.models.flows.sla.Violation;
 import io.kestra.core.runners.RunContext;
+import io.kestra.core.validations.DurationMax;
 
 import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
@@ -22,6 +23,7 @@ import lombok.experimental.SuperBuilder;
 @NoArgsConstructor
 public class MaxDurationSLA extends SLA implements ExecutionMonitoringSLA {
     @NotNull
+    @DurationMax
     private Duration duration;
 
     @Override

--- a/core/src/main/java/io/kestra/core/models/tasks/retrys/AbstractRetry.java
+++ b/core/src/main/java/io/kestra/core/models/tasks/retrys/AbstractRetry.java
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 
 import dev.failsafe.RetryPolicy;
 import dev.failsafe.RetryPolicyBuilder;
+import io.kestra.core.validations.DurationMax;
 import jakarta.validation.constraints.Min;
 import lombok.Builder;
 import lombok.Getter;
@@ -28,6 +29,7 @@ import lombok.experimental.SuperBuilder;
 public abstract class AbstractRetry {
     abstract public String getType();
 
+    @DurationMax
     private Duration maxDuration;
 
     @Min(1)

--- a/core/src/main/java/io/kestra/core/models/tasks/retrys/Constant.java
+++ b/core/src/main/java/io/kestra/core/models/tasks/retrys/Constant.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 
 import dev.failsafe.RetryPolicyBuilder;
+import io.kestra.core.validations.DurationMax;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.AssertTrue;
 import jakarta.validation.constraints.NotNull;
@@ -26,6 +27,7 @@ public class Constant extends AbstractRetry {
     protected String type = "constant";
 
     @NotNull
+    @DurationMax
     private Duration interval;
 
     @Override

--- a/core/src/main/java/io/kestra/core/models/tasks/retrys/Exponential.java
+++ b/core/src/main/java/io/kestra/core/models/tasks/retrys/Exponential.java
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 
 import dev.failsafe.RetryPolicyBuilder;
+import io.kestra.core.validations.DurationMax;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.AssertTrue;
 import jakarta.validation.constraints.NotNull;
@@ -27,9 +28,11 @@ public class Exponential extends AbstractRetry {
     protected String type = "exponential";
 
     @NotNull
+    @DurationMax
     private Duration interval;
 
     @NotNull
+    @DurationMax
     private Duration maxInterval;
 
     private Double delayFactor;

--- a/core/src/main/java/io/kestra/core/models/tasks/retrys/Random.java
+++ b/core/src/main/java/io/kestra/core/models/tasks/retrys/Random.java
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 
 import dev.failsafe.RetryPolicyBuilder;
+import io.kestra.core.validations.DurationMax;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.AssertTrue;
 import jakarta.validation.constraints.NotNull;
@@ -27,9 +28,11 @@ public class Random extends AbstractRetry {
     protected String type = "random";
 
     @NotNull
+    @DurationMax
     private Duration minInterval;
 
     @NotNull
+    @DurationMax
     private Duration maxInterval;
 
     @Override

--- a/core/src/main/java/io/kestra/core/models/triggers/TimeWindow.java
+++ b/core/src/main/java/io/kestra/core/models/triggers/TimeWindow.java
@@ -9,6 +9,7 @@ import java.time.temporal.ChronoUnit;
 import org.apache.commons.lang3.tuple.Pair;
 
 import io.kestra.core.models.annotations.PluginProperty;
+import io.kestra.core.validations.DurationMax;
 import io.kestra.core.validations.TimeWindowValidation;
 import io.kestra.core.validations.TimezoneId;
 
@@ -48,6 +49,7 @@ public class TimeWindow {
     )
     @PluginProperty
     @With
+    @DurationMax
     private Duration window;
 
     @Schema(
@@ -60,6 +62,7 @@ public class TimeWindow {
     )
     @PluginProperty
     @With
+    @DurationMax
     private Duration windowAdvance;
 
     @Schema(

--- a/core/src/main/java/io/kestra/core/utils/DateUtils.java
+++ b/core/src/main/java/io/kestra/core/utils/DateUtils.java
@@ -39,6 +39,18 @@ public class DateUtils {
         }
     }
 
+    /**
+     * Adds {@code duration} to {@code instant}, throwing a checked {@link InternalException} when the
+     * result is out of range instead of the unchecked exception raised by {@link Instant#plus}.
+     */
+    public static Instant plusOrThrow(Instant instant, Duration duration) throws InternalException {
+        try {
+            return instant.plus(duration);
+        } catch (ArithmeticException | DateTimeException e) {
+            throw new InternalException("The duration '%s' is out of the supported range when added to '%s'.".formatted(duration, instant), e);
+        }
+    }
+
     public static GroupType groupByType(Duration duration) {
         if (duration.toDays() > GroupValue.MONTH.getValue()) {
             return GroupType.MONTH;

--- a/core/src/main/java/io/kestra/core/validations/DurationMax.java
+++ b/core/src/main/java/io/kestra/core/validations/DurationMax.java
@@ -1,0 +1,25 @@
+package io.kestra.core.validations;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+import io.kestra.core.validations.validator.DurationMaxValidator;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+/**
+ * Rejects a {@link java.time.Duration} larger than {@link #max()} (default 10 years).
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = DurationMaxValidator.class)
+public @interface DurationMax {
+    /** Maximum allowed duration, as an ISO-8601 string. Defaults to 10 years. */
+    String max() default "P3650D";
+
+    String message() default "duration must not exceed {max}";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+}

--- a/core/src/main/java/io/kestra/core/validations/validator/DurationMaxValidator.java
+++ b/core/src/main/java/io/kestra/core/validations/validator/DurationMaxValidator.java
@@ -1,0 +1,37 @@
+package io.kestra.core.validations.validator;
+
+import java.time.Duration;
+
+import io.kestra.core.validations.DurationMax;
+
+import io.micronaut.core.annotation.AnnotationValue;
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.core.annotation.Nullable;
+import io.micronaut.validation.validator.constraints.ConstraintValidator;
+import io.micronaut.validation.validator.constraints.ConstraintValidatorContext;
+import jakarta.inject.Singleton;
+
+@Singleton
+public class DurationMaxValidator implements ConstraintValidator<DurationMax, Duration> {
+    @Override
+    public boolean isValid(
+        @Nullable Duration value,
+        @NonNull AnnotationValue<DurationMax> annotationMetadata,
+        @NonNull ConstraintValidatorContext context) {
+        if (value == null) {
+            return true;
+        }
+
+        String maxValue = annotationMetadata.stringValue("max").orElse("P3650D");
+        Duration max = Duration.parse(maxValue);
+
+        if (value.compareTo(max) > 0) {
+            context.disableDefaultConstraintViolation();
+            context.buildConstraintViolationWithTemplate("duration '" + value + "' must not exceed " + maxValue)
+                .addConstraintViolation();
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/core/src/test/java/io/kestra/core/utils/DateUtilsTest.java
+++ b/core/src/test/java/io/kestra/core/utils/DateUtilsTest.java
@@ -1,0 +1,32 @@
+package io.kestra.core.utils;
+
+import java.time.Duration;
+import java.time.Instant;
+
+import org.junit.jupiter.api.Test;
+
+import io.kestra.core.exceptions.InternalException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class DateUtilsTest {
+
+    @Test
+    void shouldAddDurationToInstantNormally() throws Exception {
+        Instant now = Instant.parse("2025-01-01T00:00:00Z");
+
+        assertThat(DateUtils.plusOrThrow(now, Duration.ofHours(2)))
+            .isEqualTo(Instant.parse("2025-01-01T02:00:00Z"));
+    }
+
+    @Test
+    void shouldThrowInternalExceptionWhenInstantOverflows() {
+        Instant now = Instant.parse("2025-01-01T00:00:00Z");
+
+        // a duration large enough to overflow Instant.plus
+        assertThatThrownBy(() -> DateUtils.plusOrThrow(now, Duration.ofHours(9_000_000_000_000L)))
+            .isInstanceOf(InternalException.class)
+            .hasMessageContaining("out of the supported range");
+    }
+}

--- a/core/src/test/java/io/kestra/core/validations/ConstantRetryValidationTest.java
+++ b/core/src/test/java/io/kestra/core/validations/ConstantRetryValidationTest.java
@@ -44,4 +44,25 @@ public class ConstantRetryValidationTest {
         assertThat(valid.get().getConstraintViolations()).hasSize(1);
         assertThat(valid.get().getMessage()).contains("'interval' must be less than 'maxDuration'");
     }
+
+    @Test
+    void shouldRejectIntervalAboveTenYears() {
+        // an interval beyond the 10-year @DurationMax cap
+        var retry = Constant.builder()
+            .interval(Duration.ofDays(3651))
+            .build();
+
+        Optional<ConstraintViolationException> valid = modelValidator.isValid(retry);
+        assertThat(valid.isEmpty()).isFalse();
+        assertThat(valid.get().getMessage()).contains("must not exceed P3650D");
+    }
+
+    @Test
+    void shouldAcceptIntervalAtTenYears() {
+        var retry = Constant.builder()
+            .interval(Duration.ofDays(3650))
+            .build();
+
+        assertThat(modelValidator.isValid(retry).isEmpty()).isTrue();
+    }
 }

--- a/core/src/test/java/io/kestra/core/validations/DurationMaxValidationTest.java
+++ b/core/src/test/java/io/kestra/core/validations/DurationMaxValidationTest.java
@@ -1,0 +1,53 @@
+package io.kestra.core.validations;
+
+import java.time.Duration;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+
+import io.kestra.core.junit.annotations.KestraTest;
+import io.kestra.core.models.triggers.TimeWindow;
+import io.kestra.core.models.validations.ModelValidator;
+
+import jakarta.inject.Inject;
+import jakarta.validation.ConstraintViolationException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@KestraTest
+class DurationMaxValidationTest {
+    @Inject
+    private ModelValidator modelValidator;
+
+    @Test
+    void shouldAcceptWindowWithinTenYears() {
+        TimeWindow window = TimeWindow.builder()
+            .window(Duration.ofDays(30))
+            .build();
+
+        assertThat(modelValidator.isValid(window).isEmpty()).isTrue();
+    }
+
+    @Test
+    void shouldRejectWindowAboveTenYears() {
+        TimeWindow window = TimeWindow.builder()
+            .window(Duration.ofDays(3651))
+            .build();
+
+        Optional<ConstraintViolationException> valid = modelValidator.isValid(window);
+        assertThat(valid.isEmpty()).isFalse();
+        assertThat(valid.get().getMessage()).contains("must not exceed P3650D");
+    }
+
+    @Test
+    void shouldRejectWindowAdvanceAboveTenYears() {
+        TimeWindow window = TimeWindow.builder()
+            .window(Duration.ofDays(1))
+            .windowAdvance(Duration.ofDays(3651))
+            .build();
+
+        Optional<ConstraintViolationException> valid = modelValidator.isValid(window);
+        assertThat(valid.isEmpty()).isFalse();
+        assertThat(valid.get().getMessage()).contains("must not exceed P3650D");
+    }
+}

--- a/executor/src/main/java/io/kestra/executor/ExecutorService.java
+++ b/executor/src/main/java/io/kestra/executor/ExecutorService.java
@@ -1,5 +1,6 @@
 package io.kestra.executor;
 
+import java.time.DateTimeException;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.*;
@@ -584,29 +585,33 @@ public class ExecutorService {
                 Instant nextRetryDate = null;
                 AbstractRetry.Behavior behavior = null;
 
-                // Case task has a retry
-                if (task.getRetry() != null) {
-                    AbstractRetry retry = task.getRetry();
-                    behavior = retry.getBehavior();
-                    nextRetryDate = behavior.equals(AbstractRetry.Behavior.CREATE_NEW_EXECUTION) ? taskRun.nextRetryDate(retry, executor.getExecution()) : taskRun.nextRetryDate(retry);
-                } else {
-                    // Case parent task has a retry
-                    Task parentTaskWithRetry = searchForParentTaskWithRetry(taskRun, executor);
-                    AbstractRetry retry = parentTaskWithRetry != null ? parentTaskWithRetry.getRetry() : null;
-                    if (retry != null) {
-                        // The parent's errors/finally tasks (e.g. AllowFailure.errors) must complete before the retry timer is allowed to fire.
-                        if (!isErrorOrFinallyHandlingPending(taskRun, parentTaskWithRetry, executor, nextTaskRuns)) {
+                try {
+                    // Case task has a retry
+                    if (task.getRetry() != null) {
+                        AbstractRetry retry = task.getRetry();
+                        behavior = retry.getBehavior();
+                        nextRetryDate = behavior.equals(AbstractRetry.Behavior.CREATE_NEW_EXECUTION) ? taskRun.nextRetryDate(retry, executor.getExecution()) : taskRun.nextRetryDate(retry);
+                    } else {
+                        // Case parent task has a retry
+                        Task parentTaskWithRetry = searchForParentTaskWithRetry(taskRun, executor);
+                        AbstractRetry retry = parentTaskWithRetry != null ? parentTaskWithRetry.getRetry() : null;
+                        if (retry != null) {
+                            // The parent's errors/finally tasks (e.g. AllowFailure.errors) must complete before the retry timer is allowed to fire.
+                            if (!isErrorOrFinallyHandlingPending(taskRun, parentTaskWithRetry, executor, nextTaskRuns)) {
+                                behavior = retry.getBehavior();
+                                nextRetryDate = behavior.equals(AbstractRetry.Behavior.CREATE_NEW_EXECUTION) ? taskRun.nextRetryDate(retry, executor.getExecution()) : taskRun.nextRetryDate(retry);
+                            }
+                        }
+                        // Case flow has a retry
+                        else if (executor.getFlow().getRetry() != null) {
+                            retry = executor.getFlow().getRetry();
                             behavior = retry.getBehavior();
-                            nextRetryDate = behavior.equals(AbstractRetry.Behavior.CREATE_NEW_EXECUTION) ? taskRun.nextRetryDate(retry, executor.getExecution()) : taskRun.nextRetryDate(retry);
+                            nextRetryDate = behavior.equals(AbstractRetry.Behavior.CREATE_NEW_EXECUTION) ? executionService.nextRetryDate(retry, executor.getExecution())
+                                : taskRun.nextRetryDate(retry);
                         }
                     }
-                    // Case flow has a retry
-                    else if (executor.getFlow().getRetry() != null) {
-                        retry = executor.getFlow().getRetry();
-                        behavior = retry.getBehavior();
-                        nextRetryDate = behavior.equals(AbstractRetry.Behavior.CREATE_NEW_EXECUTION) ? executionService.nextRetryDate(retry, executor.getExecution())
-                            : taskRun.nextRetryDate(retry);
-                    }
+                } catch (DateTimeException | ArithmeticException e) {
+                    throw new InternalException("The retry interval or maxDuration is out of the supported range.", e);
                 }
 
                 if (nextRetryDate != null) {
@@ -1000,7 +1005,7 @@ public class ExecutorService {
                             return ExecutionDelay.builder()
                                 .taskRunId(workerTaskResult.getTaskRun().getId())
                                 .executionId(executor.getExecution().getId())
-                                .date(workerTaskResult.getTaskRun().getState().maxDate().plus(duration != null ? duration : timeout))
+                                .date(DateUtils.plusOrThrow(workerTaskResult.getTaskRun().getState().maxDate(), duration != null ? duration : timeout))
                                 .state(duration != null ? behavior.mapToState() : State.Type.fail(pauseTask))
                                 .delayType(ExecutionDelay.DelayType.RESUME_FLOW)
                                 .build();

--- a/executor/src/main/java/io/kestra/executor/handler/ExecutionEventMessageHandler.java
+++ b/executor/src/main/java/io/kestra/executor/handler/ExecutionEventMessageHandler.java
@@ -32,6 +32,7 @@ import io.kestra.core.services.QuotaService;
 import io.kestra.core.services.WorkerQueueService;
 import io.kestra.core.trace.Tracer;
 import io.kestra.core.trace.TracerFactory;
+import io.kestra.core.utils.DateUtils;
 import io.kestra.core.utils.ListUtils;
 import io.kestra.core.utils.TruthUtils;
 import io.kestra.core.worker.WorkerQueues;
@@ -160,18 +161,22 @@ public class ExecutionEventMessageHandler implements ExecutorMessageHandler<Exec
                         if ((execution.getState().getCurrent() == State.Type.CREATED || execution.getState().failedThenRestarted())) {
                             // create an SLA monitor if needed
                             if (!ListUtils.isEmpty(flow.getSla())) {
-                                List<SLAMonitor> monitors = flow.getSla().stream()
-                                    .filter(ExecutionMonitoringSLA.class::isInstance)
-                                    .map(ExecutionMonitoringSLA.class::cast)
-                                    .map(
-                                        sla -> SLAMonitor.builder()
-                                            .executionId(execution.getId())
-                                            .slaId(((SLA) sla).getId())
-                                            .deadline(execution.getState().getStartDate().plus(sla.getDuration()))
-                                            .build()
-                                    )
-                                    .toList();
-                                monitors.forEach(monitor -> slaMonitorStateStore.save(monitor));
+                                try {
+                                    List<SLAMonitor> monitors = new ArrayList<>();
+                                    for (SLA sla : flow.getSla()) {
+                                        if (sla instanceof ExecutionMonitoringSLA monitoringSla) {
+                                            monitors.add(SLAMonitor.builder()
+                                                .executionId(execution.getId())
+                                                .slaId(sla.getId())
+                                                .deadline(DateUtils.plusOrThrow(execution.getState().getStartDate(), monitoringSla.getDuration()))
+                                                .build());
+                                        }
+                                    }
+                                    monitors.forEach(slaMonitorStateStore::save);
+                                } catch (InternalException e) {
+                                    Execution failedExecution = fail(execution, e);
+                                    return new ExecutorContext(execution).withExecution(failedExecution, "slaMonitorInvalidDuration");
+                                }
                             }
 
                             // handle quotas

--- a/executor/src/main/java/io/kestra/executor/handler/MultipleConditionEventMessageHandler.java
+++ b/executor/src/main/java/io/kestra/executor/handler/MultipleConditionEventMessageHandler.java
@@ -1,7 +1,11 @@
 package io.kestra.executor.handler;
 
+import java.time.DateTimeException;
+import java.util.List;
+
 import io.kestra.core.executor.command.Create;
 import io.kestra.core.executor.command.ExecutionCommand;
+import io.kestra.core.models.executions.Execution;
 import io.kestra.core.models.executions.ExecutionId;
 import io.kestra.core.models.triggers.multipleflows.MultipleConditionStateStore;
 import io.kestra.core.queues.DispatchQueueInterface;
@@ -33,7 +37,15 @@ public class MultipleConditionEventMessageHandler implements MessageHandler<Mult
 
     @Override
     public void handle(MultipleConditionEvent message) {
-        flowTriggerService.computeExecutionsFromFlowTriggerDependsOn(message.execution(), message.flow(), multipleConditionStateStore)
+        final List<Execution> executions;
+        try {
+            executions = flowTriggerService.computeExecutionsFromFlowTriggerDependsOn(message.execution(), message.flow(), multipleConditionStateStore);
+        } catch (DateTimeException | ArithmeticException e) {
+            log.error("Skipping flow-trigger evaluation for flow '{}': the trigger window is out of the supported range.", message.flow().getId(), e);
+            return;
+        }
+
+        executions
             .forEach(exec ->
             {
                 try {


### PR DESCRIPTION
## What & why

An unbounded user `Duration` fed into `Instant`/`ZonedDateTime.plus()` overflowed with an unchecked `DateTimeException` that escaped the queue consumer. Under `kestra.queue.fail-fast=true` that shut the whole instance down and left a poison-pill message that crash-looped on restart.

This **replaces the earlier saturation approach**. Saturation silently reinterpreted an out-of-range duration as "effectively forever" (an SLA that never fires, a Pause that waits ~forever), hiding the user's mistake. The new behaviour: **reject bad config where we can (validation), and where we can't, fail the individual execution with a clear error — never crash or stall the executor.**

## How

Two layers, both required:

**Layer A — save-time validation.** A new `@DurationMax` constraint (single global sanity cap, default 10 years / `P3650D`) on the plain-`Duration` fields, rejecting absurd literals with a `422`:
- `MaxDurationSLA.duration`
- retry `Constant.interval`, `Exponential.interval`/`maxInterval`, `Random.minInterval`/`maxInterval`, `AbstractRetry.maxDuration`
- `TimeWindow.window`/`windowAdvance`

**Layer B — runtime guard.** `DateUtils.plusOrThrow(Instant, Duration)` throws a handler-caught `InternalException` on overflow so the single execution fails cleanly (via the existing `handleFailedExecutionFromExecutor` path) and the poison-pill message drains, instead of crashing the executor:
- SLA — `ExecutionEventMessageHandler`
- Pause — `ExecutorService` (`RESUME_FLOW` delay)
- retry arithmetic — `ExecutorService.handleFlowableTasks`
- flow-trigger window — `MultipleConditionEventMessageHandler` wraps the window computation to **log and skip** (no execution to fail)

Layer B is the only fix that covers `Property<Duration>` fields (`Pause`, `LoopUntil`) whose values only exist at runtime, and existing bad flows already sitting on the queue. `fail-fast` stays `true` — this is all handler-level, no queue-layer change.

## Tests
- `DateUtilsTest` — `plusOrThrow` overflow behaviour
- `DurationMaxValidationTest` — `TimeWindow` window/windowAdvance cap + boundary
- `ConstantRetryValidationTest` — retry interval cap boundary
- Executor module compiles; `H2RunnerTest` executor gate green

Closes #18369
Closes #18421
Closes #18423
