### PR TITLE
docs: comment, test and design-system rules in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,10 +12,36 @@ This document provides essential information for AI coding agents working on the
 - **Simplicity first (KISS)**: overengineering and "gas factories" are strictly forbidden.
 - **Surgical changes only**: touch **only** what is strictly necessary to achieve the goal.
 - **Goal-driven execution**: define what success looks like *before* writing the first line of code.
-- **Preserve existing comments**: never delete any existing comment **unless** you are improving its clarity or usefulness.
-- **Keep comments short and only where they earn their place**: a comment you write should be **one sentence**, or two at most when the *why* genuinely needs it (a non-obvious constraint, a workaround, a subtle ordering or concurrency requirement). Do **not** comment obvious code — no restating what the next line plainly says (`// increment the counter`), no narrating a self-explanatory getter, loop, or well-named call. If the code is readable, the comment is noise; if it isn't, prefer making the code clearer over explaining it.
-- **Write clear, maintainable, and well-documented code**
-- **Build & test are mandatory**
+- **Reuse before writing**: the pattern you need almost always exists already. Find the closest equivalent in the codebase and follow it instead of inventing a second way to do the same thing.
+- **No comments by default**: see [Comments](#comments). Over-commenting is one of the most common reasons a PR written by an agent has to be revised.
+- **How Kestra looks is decided by the design system**: see [UI Design System](#ui-design-system). No color, spacing, radius or component pattern may be invented in feature code.
+- **A test has to be able to fail for a reason a reviewer would care about**: see [When a test earns its place](#when-a-test-earns-its-place). More tests do not make a change safer.
+- **Build and test only what you touched** rather than the whole repo: see [What to run after a change](#what-to-run-after-a-change).
+
+## Comments
+
+**The default is no comment.** Small methods with accurate names need no explanation, and every comment is a second thing that has to be kept in sync with the code. Over-commenting is easy to slip into: the next line gets narrated, the method name gets restated above the method, and `// Step 1` / `// Step 2` scaffolding is left behind. None of that will be accepted in review.
+
+The reader to write for is the developer opening the file in a month. They do not have time to read a paragraph, and most of what a paragraph would tell them is already in the code.
+
+Write a comment only when a reviewer would otherwise have to ask **why** the code exists:
+
+- a non-obvious constraint, or an upstream bug being worked around (link the issue)
+- an ordering, locking or concurrency requirement that the code itself cannot express
+- a deliberate omission, so that the next person does not "fix" it back
+
+Keep it to **one sentence**. When a paragraph seems necessary, make the code clearer instead.
+
+Never write:
+
+- a restatement of the line below it (`// increment the counter`, `// return the result`)
+- a narration of a self-explanatory getter, loop, or well-named call
+- section banners (`// ---- helpers ----`), changelog notes, or a `// TODO` with no issue link
+- a comment on every entry of a list when the rule is already stated once above the list
+
+**Existing comments** should be left alone unless the code they describe changed. When that code is deleted, delete the comment with it rather than rewording it around the gap. When the code changed, either correct the comment or remove it.
+
+**Javadoc** describes the contract rather than the body. Add it on public API called from other modules or from plugins, and on anything whose behavior cannot be seen from the signature (nullability, thread-safety, side effects, units, ownership of a returned collection). Skip it on getters, setters, builders, an override that adds nothing (a bare `{@inheritDoc}` is noise), and any method whose name already says everything.
 
 ## Project
 
@@ -24,7 +50,7 @@ Monorepo built with Java (backend) and Vue (frontend), using Gradle as the build
 ## Tech Stack
 - **Backend:** Java 25, Micronaut Framework, Lombok
 - **Frontend:** Vue 3, TypeScript, Vite, Element Plus, Pinia
-- **Build:** Gradle 8.x with multi-project structure (77 submodules)
+- **Build:** Gradle, multi-project. The version is pinned in `gradle/wrapper/gradle-wrapper.properties`, and `settings.gradle` is the list of modules
 - **Testing:** JUnit 5, Mockito, AssertJ, Vitest, Playwright
 
 ## Critical Code Patterns
@@ -121,16 +147,22 @@ public enum MyEnum {
 ```
 
 ### Documentation
-- Javadoc for all public classes and methods - be concise
-- Use `@param`, `@return`, `@throws` appropriately
-- Use `{@inheritDoc}` for inherited methods
-- Include usage examples for complex methods
+
+See [Comments](#comments) for when a Javadoc block is worth writing at all. Once you have decided that it is:
+
+- Keep it to the contract: what the caller has to know that the signature does not already say
+- Use `@param`, `@return` and `@throws` only where each adds something. `@param name the name` is noise
+- Skip a bare `{@inheritDoc}` on an override that changes nothing
+- Add a usage example only when the call site would otherwise be guessed wrong
 
 ## Webserver Constraints
 - Put classes used by only controllers in the webserver module (not core)
 - No business code/rule inside controllers - instead use a Service class
 - All APIs must return a valid JSON object
 - APIs should not return a response being a JSON array which cannot be evolved in a backwards-compatible way
+- Any endpoint returning a collection should be paged through `PagedResults` with `page` and `size` parameters, like the rest of the API
+- A DTO used by a single controller belongs as an inner record of that controller. Promote it to `io.kestra.webserver.models.api` only once a second caller exists, and name it with the `Api` prefix there (`ApiExecution`, `ApiTriggerState`, `ApiPluginArtifact`)
+- Import a class rather than writing its fully-qualified name, as soon as it is used more than once in the same file
 - Unit tests must assert that a user can only access a given API if authorized to do so, and that access is denied otherwise
 - APIs must be documented with OpenAPI annotations
 - Use DTOs for requests/responses
@@ -146,12 +178,32 @@ public enum MyEnum {
 
 ## Testing Guidelines
 
+### When a test earns its place
+
+More tests do not make a change safer. Every test is code that has to be read, kept passing, and understood by whoever changes that behavior next, so a test is only worth its cost when it can fail for a reason a reviewer would care about.
+
+**Add a test when:**
+
+- new behavior is introduced, or a bug is fixed. The test should fail on the commit before yours; if it passes there, it is testing something else
+- an edge case would be easy to get wrong later: an empty collection, a null, a boundary, a race, a permission check
+- the change is in the executor, the scheduler, the queue, or an ACL path, where a regression is expensive and hard to notice
+
+**Don't add a test when:**
+
+- it only exercises getters, setters, builders, or a Lombok-generated method
+- it asserts behavior that the framework already documents (Jackson serializing a field, Micronaut injecting a bean)
+- it repeats an existing test with one property changed. One test per behavior, rather than one per property, since otherwise there would be hundreds of them
+- the mocks would have to restate the implementation for the assertions to pass. Such a test is pinned to the current code rather than to the behavior, so it is broken by every legitimate refactor
+- it exists only to move a coverage number
+
+**Delete tests too.** Removing a feature should reduce the test count rather than raise it. When a test no longer describes behavior anyone relies on, or when it duplicates another one, delete it in the same PR and say so in the description. A redundant test that is always green is still maintenance cost.
+
 ### Java Tests
 
 **DO**:
 - Place tests in same package structure as source code
 - Simple unit test with mocks over complex integration tests when possible
-- Add // Given-When-Then comments for clarity
+- Structure the body as given / when / then. The three marker comments are optional and should be dropped when the test is only a few obvious lines
 - Test method naming: `should<ExpectedBehavior>When<ConditionOrAction>` (also `...Given<Input>`, `...For<Condition>`, `...If<Condition>`), e.g. `shouldThrowExceptionWhenDividingByZero()`
 - Use `@MicronautTest` for tests that require Micronaut beans
 - Use `@KestraTest` for tests that require running Kestra services (e.g., Executor, Scheduler)
@@ -192,10 +244,16 @@ class ServiceTest {
 - Storybook component tests
 - Use JSdom environment for DOM testing
 - **Prefer Storybook component tests over Vitest unit tests whenever possible** — components render through their real story setup (props, slots, design-system deps) instead of being stubbed out, catching regressions unit mocks miss. Fall back to a Vitest unit test only when the logic under test isn't component-rendering behavior (e.g. a pure helper/composable) or no story exists and adding one isn't practical.
+- Don't keep a Vitest test that only re-asserts what a story already covers. Delete it when you add the story.
+- Assert on `data-test` attributes and rendered text. A test written against `.el-*` or `.ks-*` class names is broken by the next Element Plus or design-system upgrade, without any behavior having changed.
 
 ## UI Design System
 
-The full UI design-system rules, component catalogue, token reference, and frontend best practices live in [ui/AGENTS.md](ui/AGENTS.md). That file is auto-loaded by AI coding agents whenever work happens under `ui/` in OSS or `ui-ee/` in Enterprise edition, and should be consulted (and kept up to date) for any frontend change.
+The design system at [ui/packages/design-system/](ui/packages/design-system/) is the **single source of truth for every design decision** in Kestra: colors, typography, spacing, radii, shadows, and the component vocabulary. Nothing rendered to a user may be styled outside it.
+
+In practice that means no hex codes, no `rgb()`, no `--el-*` or `--bs-*` variables, no hardcoded pixel spacing, no `:deep()` into another component, and no locally built equivalent of a component that already exists. When the design you need cannot be expressed with the existing `Ks*` components and `--ks-*` tokens, that is a gap in the design system: raise it with design and add the token, the prop or the component upstream. Approximating it with custom CSS in a feature component is not an option, since the result will only be right in the one theme you checked it in.
+
+The full rules, the component catalogue, the token reference and the frontend best practices live in [ui/AGENTS.md](ui/AGENTS.md), which is auto-loaded for work under `ui/` in OSS and `ui-ee/` in Enterprise Edition. Read it before any frontend change, and update it in the same PR whenever a component, a prop or a token is added.
 
 @ui/AGENTS.md
 
@@ -220,6 +278,20 @@ The full UI design-system rules, component catalogue, token reference, and front
 - Use enums for fixed sets of values
 
 ## Build Commands
+
+### What to run after a change
+
+A whole-repo `./gradlew build` can take tens of minutes, and almost nothing about a three-line change can be learned from it. Start with the narrowest command that covers what you touched, and widen it only once that one passes.
+
+| What changed | Run |
+|---|---|
+| One backend module | `./gradlew :<module>:test --tests "TheClassName"`, then `./gradlew :<module>:test` |
+| Anything in the executor | `./gradlew :jdbc-h2:test --tests "H2RunnerTest"` (mandatory) |
+| Something crossing module boundaries | `./gradlew build -x integrationTest` |
+| A Vue component or composable | `cd ui && npm run check:types && npm run test:unit && npm run lint` |
+| A design-system component | the above, plus `npm run test:storybook` |
+| `en.json`, whether a key was added or a value edited | `cd ui && npm run translations:generate && npm run translations:check` |
+| A controller or its DTOs | that module's tests, including the authorization tests for the route |
 
 ### Java Backend
 
@@ -311,7 +383,7 @@ docker compose -f docker-compose-ci.yml down
 
 ### Worktree setup
 
-When working in an EE worktree (detected by: the working directory is under a `worktrees/` directory):
+When working in an OSS worktree (the working directory is under a `worktrees/` directory):
 ```bash
 dev-tools/setup-worktree.sh ../worktrees/foo
 ```
@@ -330,16 +402,11 @@ This copies the gitignored `cli/src/main/resources/application-*.yml` files from
 
 ## Troubleshooting
 
-**Common Issues:**
-- **Build failures:** Run `./gradlew clean` and retry
-- **Test failures:** Check for service dependencies (Docker containers)
-- **Frontend issues:** Ensure Node.js version matches package.json requirements
-
-**Debugging:**
-- Use IDE debugging with remote JVM debugging
-- Use Micronaut's built-in health endpoints
-- Enable debug logging: `--logging.level.io.kestra=DEBUG`
-- Use JUnit and Vitest reports for test failures
+- **A Gradle build fails with no visible cause:** run `./gradlew clean` and retry once. When it repeats, read the actual error instead of retrying again.
+- **Tests fail on connection errors:** the databases are not running. `docker compose -f docker-compose-ci.yml up -d`.
+- **The frontend build fails on dependency resolution:** check the Node and npm versions against `package.json` engines before touching anything else.
+- **The UI builds but the app never mounts:** module federation, so the cause is usually workspace resolution rather than the change itself. Verify against a running instance rather than against the dev server.
+- **Debug logging:** `--logging.level.io.kestra=DEBUG`.
 
 ## Module Structure
 
@@ -353,7 +420,7 @@ This copies the gitignored `cli/src/main/resources/application-*.yml` files from
 - `worker` - The component that executes tasks and manages worker instances
 - `worker-controller` - The component that manages worker instances and job distribution
 - `indexer` - The component responsible for indexing executions
-- `plateform` - provides the Platform Bill of Materials (BOM) for dependency management
+- `platform` - provides the Platform Bill of Materials (BOM) for dependency management
 
 **Queuing Layer:**
 - `queue` - Core API for queue implementations
@@ -373,16 +440,24 @@ This copies the gitignored `cli/src/main/resources/application-*.yml` files from
 - Builder pattern for object construction (often with Lombok `@Builder`)
 
 ## Pull request guidelines
-- Always add tests, keep your branch rebased instead of merged, and adhere to the commit message recommendations from https://www.conventionalcommits.org/en/v1.0.0.
+
+- **One PR, one scope.** When you cannot pick a single conventional-commit scope for the title, the PR is doing too much and should be split.
+- Title format `type(scope): lowercase description`, following https://www.conventionalcommits.org/en/v1.0.0. Name the changed things rather than the actions taken on them: `fix(cases): assignees header, missing Acknowledged status, auto-link toggle`.
 - Use types: chore, feat, fix, refactor, test, docs, build
 - Use scopes: apps, assets, core, dashboards, deps, design-system, executions, flows, iam, namespaces, plugins, secrets, storage, scheduler, system, tasks, tenants, tests, topology, triggers, variables, version, worker
+- Put the closing keyword on the first line of the description, as a full URL so that the link is not lost in a squash merge: `Closes https://github.com/kestra-io/kestra/issues/<id>.`
+- Cover new behavior with tests that could fail, following [When a test earns its place](#when-a-test-earns-its-place). "Add tests" never means one test per changed line.
+- Run `npm run lint` in `ui/` before pushing any frontend change. Otherwise one comment per violation is posted by reviewdog, and the human review is buried under trailing-comma suggestions.
+- Attach a screenshot or a short recording for every user-visible change, taken against a running instance.
+- Keep the branch rebased on `develop` rather than merged.
+- Fill in `.github/pull_request_template.md`, and delete the checklist section that does not apply instead of leaving it unticked.
+- Write the description as problem, fix and evidence, once each. No table restating the diff, and no checklist of tests that all passed.
+- Never commit generated output by hand: the twelve non-English translation files, `fingerprints.json`, and the generated SDK are produced by their scripts or by CI.
 
 ## Issue guidelines
 - **Classify an issue with its GitHub issue type, not a `kind/*` label.** The `kind/bug` label is retired — do not add it. Set the type instead: `gh issue create --title … ` followed by `gh issue edit <number> --type Bug`, or `gh issue edit <number> --type Task|Feature|Epic`. Available types are `Task`, `Bug`, `Feature` and `Epic` (list them with `gh api /orgs/kestra-io/issue-types`).
 - **Do add the `area/*` labels** — `area/frontend`, `area/backend`, `area/devops`, `area/docs`, `area/plugin`, `area/qa`, `area/analytics` — since those drive routing and are still in use.
 - Leave triage labels such as `kind/cooldown` to `kestrabot`; it applies them automatically on new issues.
-
-This document should be updated as the codebase evolves. When in doubt, follow existing patterns in the codebase and maintain consistency with established conventions.
 
 ## UI Translations
 
@@ -438,3 +513,9 @@ npm run translations:check               # must report no missing / extra / stal
 ```
 
 `en.json` itself normally merges cleanly, since branches usually add different keys; it is the generated files that collide.
+
+## Keeping this file up to date
+
+When a review comment corrects something that is not written here, and the correction is a rule rather than a one-off, add it in the same PR: one or two lines, with the example next to the rule. Delete a rule once it no longer matches the codebase. A guideline that no longer matches the code is worse than no guideline, since it will be followed confidently.
+
+When in doubt, follow the existing patterns in the codebase and stay consistent with them.

--- a/ui/AGENTS.md
+++ b/ui/AGENTS.md
@@ -22,6 +22,8 @@ Under the hood, the design system wraps Element Plus under the `kel` namespace a
 
 These rules are what keep the UI maintainable as it grows. Treat any deviation as a bug.
 
+**How Kestra looks is decided by the design system; what it does is decided by feature code.** A new visual pattern (a new card treatment, a different spacing rhythm, another status color, a bespoke empty state, a one-off modal layout) counts as a design-system change and belongs in `ui/packages/design-system/`, after a conversation with design. Approximating one inside a feature component is the fastest route to a screen that is fine in the one theme you checked it in and wrong everywhere else. When nothing in the catalogue below covers what you need, raise it as a gap in the design system instead of improvising around it.
+
 1. **Use a `Ks*` component if one exists.** Check the tables below before writing anything custom or importing from `element-plus`. New screens that mix `<el-button>` and `<KsButton>` are a regression.
 2. **Colors come from `--ks-*` tokens. Always.** No hex codes, no `rgb(...)`, no Element Plus tokens (`--el-*`), no Bootstrap variables, no SCSS color variables in component code. If the token you need does not exist, talk to design and add it to `ks-theme-light.scss` / `ks-theme-dark.scss` / `ks-theme-dark-2.scss` — do not pick a one-off color.
 3. **Typography comes from `KsText` or typography tokens.** Use `<KsText>` (with `size`, `type`, `tag`, `truncated`, `lineClamp`) for body copy. For headings or one-off needs, use the `$font-family-*` and `$font-size-*` SCSS variables only inside the design-system package — feature code should not redefine them.
@@ -32,6 +34,12 @@ These rules are what keep the UI maintainable as it grows. Treat any deviation a
 8. **Don't fork — extend.** If a `Ks*` component is *almost* what you need, add a prop or a slot to the component in `ui/packages/design-system/`. Copy-pasting the component into your feature folder is forbidden.
 9. **Every new `Ks*` component needs a Storybook story and a unit test.** Stories double as living documentation for design and product reviewers.
 10. **i18n keys live with the design system component**, not inside feature code, when they belong to the component (e.g. `KsEmpty`, `KsDurationPicker`). Register them via `registerDesignSystemI18n`.
+11. **Check that a token exists before using it.** With an invalid `var(--ks-…)` and no fallback, the property is silently inherited instead, so the mistake remains invisible until the computed style is measured. The cases feature was released using `--ks-font-size-medium`, `--ks-font-size-small`, `--ks-radius-2` and `--ks-border-active`, none of which are declared anywhere. One grep is enough:
+
+    ```bash
+    grep -rn -- "--ks-your-token" packages/design-system/src/assets/styles/
+    ```
+12. **Copying an existing rule is not proof that it is correct.** Several hundred `:deep()` selectors, some hex codes and some raw pixel values are older than these rules and are being removed over time. Treat them as debt rather than as precedent: don't add more, and clean up the ones in the component you are already editing.
 
 ## Best practices for keeping the design system healthy
 
@@ -227,6 +235,24 @@ Rules:
 - Use `data-test="..."` selectors for E2E tests with **Playwright**. Never select on `.el-*` or `.ks-*` class names — those are not stable contracts and will break on Element Plus / DS upgrades.
 - Storybook stories cover: each variant prop, dark mode, edge cases (empty content, very long text, error state). A `*.stories.ts` file with one default story is not enough.
 - Visual regressions caught in Storybook are cheaper to fix than caught in production.
+- A test only earns its place when it can fail for a reason a reviewer would care about. Don't test that a prop is passed through, that a computed returns its own input, or that a `Ks*` component renders: the template is only restated by those assertions, and they are broken by every refactor. Delete a Vitest test once a story covers the same behavior, and say so in the PR description.
+
+### Checking a frontend change before pushing
+
+```bash
+npm run check:types && npm run test:unit && npm run lint
+```
+
+`npm run lint` is not optional. Without it, one PR comment per eslint violation is posted by reviewdog (missing trailing commas, mostly) and the human review is buried underneath them.
+
+Then read your own diff for the design-system violations that no linter catches:
+
+```bash
+git diff -U0 develop... -- '*.vue' '*.scss' \
+  | grep -nE '^\+.*(#[0-9a-fA-F]{3,8}\b|rgba?\(|--el-|--bs-|:deep\(|(padding|margin|gap|border-radius|font-size)[[:space:]]*:[[:space:]]*[0-9]+px)'
+```
+
+Every match has to be replaced with a `--ks-*` token, a `Ks*` prop, or a change in the design system. For a user-visible change, also check it in light **and** dark mode, and attach a screenshot to the PR.
 
 ### Deprecation contract
 
@@ -330,7 +356,7 @@ If your `<style>` block needs to exist:
 | `KsTable` / `KsTableColumn` | Basic table |
 | `KsDataTable` / `KsFilter` / `KsBulkSelect` | Advanced data table with filtering, sorting, pagination, bulk actions. **Pagination is fully controlled** — bind `:currentPage` / `:pageSize` (or `v-model:`). See "Data tables & pagination state". |
 | `KsEntityLink` | Clickable cross-entity reference (namespace / flow) for table cells — neutral tag with leading icon, violet on hover |
-| `KsBadge` | Small indicator badge. Overlays a wrapped child by default; pass `inline` for a standalone counter in the normal flow, next to a tab or menu label |
+| `KsBadge` | Small indicator badge |
 | `KsNewBadge` | Compact uppercase "NEW" pill flagging a newly shipped feature — caller supplies the label via the default slot |
 | `KsTag` / `KsCheckTag` | Tag / label; clickable checkbox-style tag |
 | `KsAvatar` | Avatar with fallback |


### PR DESCRIPTION
Coding agents over-comment, style outside the design system, and add a test per changed line. AGENTS.md was not explicit enough about any of the three, so the same review comments keep repeating.

- New `Comments` section: no comment by default, one sentence when a reviewer would otherwise have to ask why
- New `When a test earns its place`: when to add a test, when not to, and when to delete one
- `UI Design System` now states the rule itself before pointing at `ui/AGENTS.md`
- New `What to run after a change` table, so a three-line change no longer gets a whole-repo build
- `ui/AGENTS.md`: no new visual patterns, check a token exists before using it, and a pre-push check
- Fixes: hardcoded Gradle version, the `plateform` typo, and the OSS worktree section that said "EE worktree"

Docs only, no code changes.