### PR TITLE
fix: bug-bash quick wins — page=0 SQL leak + Get Started onboarding link

### DIFF
--- a/ui/src/components/onboarding/execution/OverviewBottom.vue
+++ b/ui/src/components/onboarding/execution/OverviewBottom.vue
@@ -34,7 +34,7 @@
             : {
                 title: t("execution_guide.get_started.title"),
                 description: t("execution_guide.get_started.text"),
-                link: "",
+                link: "https://kestra.io/docs/quickstart?utm_source=app&utm_medium=referral&utm_campaign=onboarding-welcome",
                 icon: RocketLaunchOutline,
             },
         {

--- a/webserver/src/main/java/io/kestra/webserver/utils/PageableUtils.java
+++ b/webserver/src/main/java/io/kestra/webserver/utils/PageableUtils.java
@@ -19,6 +19,13 @@ public class PageableUtils {
     }
 
     public static Pageable from(int page, int size, List<String> sort, Function<String, String> sortMapper) throws HttpStatusException {
+        if (page < 1) {
+            throw new HttpStatusException(
+                HttpStatus.UNPROCESSABLE_ENTITY,
+                "The page number must be greater than or equal to 1."
+            );
+        }
+
         if (size > MAX_PAGE_SIZE) {
             throw new HttpStatusException(
                 HttpStatus.UNPROCESSABLE_ENTITY,

--- a/webserver/src/test/java/io/kestra/webserver/utils/PageableUtilsTest.java
+++ b/webserver/src/test/java/io/kestra/webserver/utils/PageableUtilsTest.java
@@ -42,6 +42,20 @@ class PageableUtilsTest {
     }
 
     @Test
+    void shouldThrowWhenPageIsBelowOne() {
+        // page=0 previously reached the repository and produced a 500 leaking the SQL query
+        // (kestra-io/kestra-ee#10223) — it must now be rejected with a clean 422
+        for (int page : new int[]{0, -1}) {
+            HttpStatusException e = assertThrows(
+                HttpStatusException.class,
+                () -> PageableUtils.from(page, 10)
+            );
+            assertEquals(HttpStatus.UNPROCESSABLE_ENTITY, e.getStatus());
+            assertThat(e.getMessage()).contains("greater than or equal to 1");
+        }
+    }
+
+    @Test
     void shouldThrowWhenSizeExceedsMaxPageSize() {
         // When a size above the cap is requested
         HttpStatusException e = assertThrows(


### PR DESCRIPTION
Two unrelated Kestra 2.0 bug-bash fixes, grouped as quick wins.

Closes https://github.com/kestra-io/kestra-ee/issues/10223.
Closes #18442.

## 1. `page=0` returns 500 and leaks the SQL query (#10223)

Pages are 1-based. `AbstractJdbcRepository` turns a page into a SQL offset with `pageable.getOffset() - pageable.getSize()`, which assumes `page >= 1`:

- `page=1` → `1*size - size` = `0` ✅
- `page=0` → `0*size - size` = `-size` ❌ → negative `OFFSET` → the DB throws and the raw SQL (table/column names) is serialized into the 500 body

`size` was already capped in `PageableUtils.from`; `page` had no lower bound. Added a `page < 1` guard there, so the request is rejected with a clean **422** before any query is built — fixing `/users`, `/credentials` and every other list endpoint at once, and removing the SQL leak for this trigger.

**Test:** `PageableUtilsTest.shouldThrowWhenPageIsBelowOne` (page 0 and -1 → 422).

## 2. "Get Started" onboarding card does nothing (#18442)

On the flow Overview empty state ("Need Help?"), the **Get Started** card had `link: ""`, so `OverviewCard` rendered a non-clickable `<div>` with no icon — unlike its two sibling cards. Set it to the quickstart guide URL (same `utm` pattern as the siblings) so it opens like the others.

## Notes

- #10223 is filed in `kestra-ee` but the fix is in OSS (`PageableUtils` is shared).
- The SQL string reaching the response on an unexpected 500 is a broader hardening concern; this PR fixes the `page=0` trigger, not a global exception-message scrubber.