### PR TITLE
fix(design-system): apply custom date-range filter with a single bound set

### DIFF
--- a/ui/packages/design-system/src/components/Data/KsDataTable/filter/layout/FilterEditPopper.vue
+++ b/ui/packages/design-system/src/components/Data/KsDataTable/filter/layout/FilterEditPopper.vue
@@ -294,12 +294,11 @@
             return {value: state.textValue, label: state.textValue}
         case "select":
             if (props.filterKey?.key === "timeRange" && state.timeRangeMode === "custom") {
+                const startDate = state.startDateValue ?? new Date()
+                const endDate = state.endDateValue ?? new Date()
                 return {
-                    value: {
-                        startDate: state.startDateValue!,
-                        endDate: state.endDateValue!,
-                    },
-                    label: `${state.startDateValue!.toLocaleDateString()} - ${state.endDateValue!.toLocaleDateString()}`,
+                    value: {startDate, endDate},
+                    label: `${startDate.toLocaleDateString()} - ${endDate.toLocaleDateString()}`,
                     meta: state.dateFilterMode ? {dateFilter: state.dateFilterMode} : undefined,
                 }
             }
@@ -314,12 +313,11 @@
             }
         case "time-range":
             if (state.timeRangeMode === "custom") {
+                const startDate = state.startDateValue ?? new Date()
+                const endDate = state.endDateValue ?? new Date()
                 return {
-                    value: {
-                        startDate: state.startDateValue!,
-                        endDate: state.endDateValue!,
-                    },
-                    label: `${state.startDateValue!.toLocaleDateString()} - ${state.endDateValue!.toLocaleDateString()}`,
+                    value: {startDate, endDate},
+                    label: `${startDate.toLocaleDateString()} - ${endDate.toLocaleDateString()}`,
                 }
             }
             return {
@@ -361,8 +359,10 @@
     const applyLive = () => {
         if (!ready.value || !state.selectedComparator) return
 
+        // A custom range needs at least one bound to be worth applying; the other bound
+        // defaults to now (getFilterValue) so typing just a Start or End date applies immediately.
         if (isTimeRange.value && state.timeRangeMode === "custom"
-            && (!state.startDateValue || !state.endDateValue)) {
+            && !state.startDateValue && !state.endDateValue) {
             return
         }
 

--- a/ui/packages/design-system/tests/units/Data/KsFilter/FilterEditPopper.test.ts
+++ b/ui/packages/design-system/tests/units/Data/KsFilter/FilterEditPopper.test.ts
@@ -100,6 +100,66 @@ describe("FilterEditPopper range comparators on a multi-select field", () => {
     })
 })
 
+describe("FilterEditPopper time range custom mode", () => {
+    const timeRangeKey: FilterKeyConfig = {
+        key: "timeRange",
+        label: "Time range",
+        valueType: "select",
+        comparators: [Comparators.EQUALS],
+        valueProvider: async () => [{label: "Last 24 hours", value: "PT24H"}],
+    }
+
+    const mountTimeRangePopper = async () => {
+        const wrapper = mount(FilterEditPopper, {
+            props: {
+                filter: {
+                    id: "f1",
+                    key: "timeRange",
+                    keyLabel: "Time range",
+                    comparator: Comparators.EQUALS,
+                    comparatorLabel: "Equals",
+                    value: "PT24H",
+                    valueLabel: "Last 24 hours",
+                },
+                filterKey: timeRangeKey,
+            },
+            global: globalConfig,
+        })
+        await flushPromises()
+        return wrapper
+    }
+
+    test("applies a custom range as soon as only the Start Date is set, defaulting End Date to now", async () => {
+        const wrapper = await mountTimeRangePopper()
+
+        wrapper.findComponent(FilterSelect).vm.$emit("update:timeRangeMode", "custom")
+        await flushPromises()
+
+        const startDate = new Date("2026-06-01T00:00:00")
+        const before = Date.now()
+        wrapper.findComponent(FilterSelect).vm.$emit("update:startDateValue", startDate)
+        await flushPromises()
+        const after = Date.now()
+
+        const updates = wrapper.emitted("update") as Array<[AppliedFilter]> | undefined
+        expect(updates).toBeTruthy()
+        const lastValue = updates!.at(-1)![0].value as {startDate: Date; endDate: Date}
+        expect(lastValue.startDate).toEqual(startDate)
+        expect(lastValue.endDate.getTime()).toBeGreaterThanOrEqual(before)
+        expect(lastValue.endDate.getTime()).toBeLessThanOrEqual(after)
+    })
+
+    test("does not apply (and does not overwrite the previous filter) when switching to custom mode with neither bound set", async () => {
+        const wrapper = await mountTimeRangePopper()
+
+        wrapper.findComponent(FilterSelect).vm.$emit("update:timeRangeMode", "custom")
+        await flushPromises()
+
+        const updates = wrapper.emitted("update") as Array<[AppliedFilter]> | undefined
+        expect(updates).toBeFalsy()
+    })
+})
+
 describe("FilterEditPopper date field", () => {
     const expirationKey: FilterKeyConfig = {
         key: "expirationDate",


### PR DESCRIPTION
## Summary
- `FilterEditPopper.vue`'s live-apply logic for `time-range`/`timeRange` filters required **both** Start and End dates to be set before emitting an update in Custom Range mode. Setting only a Start Date and clicking OK was a silent no-op — the popover reinitializes its local state from the (unchanged) applied filter next time it opens, so the typed value doesn't even survive as a draft.
- The missing bound now defaults to `new Date()` (now) instead of blocking the apply, matching the "apply that typed date" behavior described in the issue. Switching to Custom Range with *neither* bound touched still applies nothing.
- This is shared by every Custom Range time filter in the design system (Executions, Logs, Flows dashboards, metrics), not just the Executions list from the repro.

Closes #18320

## QA
Reproduced live in a browser against a local Kestra OSS instance (fresh H2 admin, Playwright-driven Chromium) before writing any fix, then proved the fix with a failing→passing Vitest run on the exact same assertion. Full writeup with before/after screenshots and logs: https://claude.ai/code/artifact/07d2df48-a925-4f0e-8f5b-af1503a884c0

## Test plan
- [x] New Vitest tests in `FilterEditPopper.test.ts`: applying with only Start Date set (End defaults to now), and switching to Custom Range with neither bound set still applies nothing
- [x] `npx vitest run --config vitest.unit.config.ts tests/units/Data/KsFilter/FilterEditPopper.test.ts` — 6/6 pass with the fix, 1/6 fails without it (revert-and-rerun verified)
- [x] Live browser reproduction before and after the fix (Playwright against local dev server)