### PR TITLE
fix(dashboards): treat null filters as empty on chart-data endpoint

### DIFF
--- a/webserver/src/main/java/io/kestra/webserver/controllers/api/DashboardController.java
+++ b/webserver/src/main/java/io/kestra/webserver/controllers/api/DashboardController.java
@@ -337,7 +337,7 @@ public class DashboardController {
             return null;
         }
 
-        TimeLineSearch timeLineSearch = TimeLineSearch.extractFrom(filters);
+        TimeLineSearch timeLineSearch = TimeLineSearch.extractFrom(filters != null ? filters : List.of());
         validateTimeline(timeLineSearch.getStartDate(), timeLineSearch.getEndDate());
 
         ZonedDateTime endDate = timeLineSearch.getEndDate();

--- a/webserver/src/test/java/io/kestra/webserver/controllers/api/DashboardControllerTest.java
+++ b/webserver/src/test/java/io/kestra/webserver/controllers/api/DashboardControllerTest.java
@@ -877,6 +877,18 @@ class DashboardControllerTest {
     }
 
     @Test
+    void shouldTreatNullFiltersAsNoFiltersOnChartData() {
+        // Raw JSON body with an explicit "filters":null, matching the reported repro exactly -
+        // going through ChartFiltersOverrides' builder would drop the null key (NON_NULL inclusion)
+        // and never exercise the bug.
+        List<Map> chartData = client.toBlocking().retrieve(
+            POST(DASHBOARD_PATH + "/_default/charts/total_executions_timeseries", "{\"filters\":null}").contentType(MediaType.APPLICATION_JSON),
+            Argument.listOf(Map.class)
+        );
+        assertThat(chartData).isNotNull();
+    }
+
+    @Test
     void shouldReturnBuiltinDefaultDashboardDefinitions() {
         Map definitions = client.toBlocking().retrieve(
             GET(DASHBOARD_PATH + "/defaults/definitions"),


### PR DESCRIPTION
## Summary
- `POST /dashboards/{id}/charts/{chartId}` called `TimeLineSearch.extractFrom(filters)` unconditionally in `buildDashboardChardDataQuery`, which does `filters.stream()` and NPEs (500) when the request body has `"filters": null`. The sibling `charts/preview` path (`buildChartPreviewDataQuery`) already guards `filters != null` before calling `extractFrom`.
- Fixed by passing `filters != null ? filters : List.of()` — `TimeLineSearch.extractFrom` already treats "no date filters present" as a first-class case (it defaults `startDate` to 8 days ago when nothing sets it), so this lets that existing default-timeline logic apply naturally instead of duplicating a second hardcoded default.

Closes #18366

## QA
Full writeup, including a test-construction gotcha caught and corrected mid-QA: https://claude.ai/code/artifact/14b54014-c2c8-4658-9464-c13c89e7ce8b

## Test plan
- [x] New `DashboardControllerTest.shouldTreatNullFiltersAsNoFiltersOnChartData` — sends a raw `{"filters":null}` JSON body (matching the issue's curl repro exactly; a builder-constructed request would drop the null key under Jackson's `NON_NULL` inclusion and never exercise the bug)
- [x] `./gradlew :webserver:test --tests io.kestra.webserver.controllers.api.DashboardControllerTest` — 20/20 pass with the fix, exact reported NPE reproduced without it (revert-and-rerun verified)