### PR TITLE
fix(core): reject legacy flat filter parameters instead of ignoring them

### DIFF
--- a/cli/src/main/java/io/kestra/cli/commands/flows/FlowExportCommand.java
+++ b/cli/src/main/java/io/kestra/cli/commands/flows/FlowExportCommand.java
@@ -1,5 +1,7 @@
 package io.kestra.cli.commands.flows;
 
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
@@ -40,7 +42,11 @@ public class FlowExportCommand extends AbstractApiCommand {
 
         try (DefaultHttpClient client = client()) {
             MutableHttpRequest<Object> request = HttpRequest
-                .GET(apiUri("/flows/export/by-query", tenantService.getTenantId(tenantId)) + (namespace != null ? "?namespace=" + namespace : ""))
+                // Bracket format: the flat `namespace=` param was never read by the endpoint, so `--namespace` silently
+                // exported every namespace in the tenant, and is now rejected outright (kestra-io/kestra-ee#10326).
+                // PREFIX keeps the documented meaning of the option - the namespace and its children.
+                .GET(apiUri("/flows/export/by-query", tenantService.getTenantId(tenantId))
+                    + (namespace != null ? "?filters[namespace][PREFIX]=" + URLEncoder.encode(namespace, StandardCharsets.UTF_8) : ""))
                 .accept(MediaType.APPLICATION_OCTET_STREAM);
 
             HttpResponse<byte[]> response = client.toBlocking().exchange(this.requestOptions(request), byte[].class);

--- a/ui/src/components/executions/Executions.vue
+++ b/ui/src/components/executions/Executions.vue
@@ -450,7 +450,7 @@
     import TriggerFlow from "../../components/flows/TriggerFlow.vue"
     import TriggerAvatar from "../../components/flows/TriggerAvatar.vue"
 
-    import {filterValidLabels, keepSupportedFilters, FILTER_FIELD_PATTERN} from "./utils"
+    import {filterValidLabels, keepSupportedFilters, onlyBracketFilters, FILTER_FIELD_PATTERN} from "./utils"
     import {useToast} from "../../utils/toast"
     import {storageKeys} from "../../utils/constants"
     import * as Utils from "../../utils/utils"
@@ -1130,8 +1130,10 @@
     })
 
     async function exportExecutionsAsStream() {
+        // The export endpoint takes filters and nothing else, and now 422s on flat legacy params, so send only the
+        // bracket-format keys rather than the raw route query.
         await executionsStore.exportExecutionsAsCSV(
-            dropUnsupportedFilters(route.query),
+            onlyBracketFilters(dropUnsupportedFilters(route.query)),
         )
     }
 </script>

--- a/ui/src/components/executions/utils.spec.ts
+++ b/ui/src/components/executions/utils.spec.ts
@@ -1,0 +1,35 @@
+import {describe, expect, it} from "vitest"
+
+import {onlyBracketFilters} from "./utils"
+
+describe("onlyBracketFilters", () => {
+    it("keeps bracket-format filters, including nested groups", () => {
+        expect(
+            onlyBracketFilters({
+                "filters[state][EQUALS]": "RUNNING",
+                "filters[or][0][namespace][EQUALS]": "a",
+                "filters[labels][EQUALS][foo]": "bar",
+            }),
+        ).toEqual({
+            "filters[state][EQUALS]": "RUNNING",
+            "filters[or][0][namespace][EQUALS]": "a",
+            "filters[labels][EQUALS][foo]": "bar",
+        })
+    })
+
+    it("drops flat legacy params the API now rejects", () => {
+        // A bookmarked pre-2.0 URL, or a flat programmatic navigation, must not reach an endpoint that takes
+        // nothing but filters - it answers 422 (kestra-io/kestra-ee#10326).
+        expect(
+            onlyBracketFilters({
+                state: "RUNNING",
+                namespace: "io.kestra.tests",
+                "filters[state][EQUALS]": "RUNNING",
+            }),
+        ).toEqual({"filters[state][EQUALS]": "RUNNING"})
+    })
+
+    it("drops pagination keys, which the export endpoint does not take", () => {
+        expect(onlyBracketFilters({page: 1, size: 25, sort: "state.startDate:desc"})).toEqual({})
+    })
+})

--- a/ui/src/components/executions/utils.ts
+++ b/ui/src/components/executions/utils.ts
@@ -26,3 +26,16 @@ export const keepSupportedFilters = (
         }),
     )
 }
+
+/**
+ * Keeps only bracket-format filter params. The API rejects pre-2.0 flat params such as `state=RUNNING` outright
+ * (kestra-io/kestra-ee#10326), so a route query carrying one - a bookmarked pre-2.0 URL, a flat programmatic
+ * navigation - must not be forwarded verbatim to an endpoint that takes nothing but filters.
+ */
+export const onlyBracketFilters = (
+    query: Record<string, unknown>,
+): Record<string, unknown> => {
+    return Object.fromEntries(
+        Object.entries(query).filter(([key]) => FILTER_FIELD_PATTERN.test(key)),
+    )
+}

--- a/ui/src/components/onboarding/tour/useTourActions.ts
+++ b/ui/src/components/onboarding/tour/useTourActions.ts
@@ -193,8 +193,8 @@ export function useTourActions() {
         await router.push({
             name: "executions/list",
             params: {tenant: tenant()},
-            // Bracket format: the flat `namespace=`/`scope=` params are not read by the API and are now rejected
-            // outright (kestra-io/kestra-ee#10326), so the tour never actually scoped this list.
+            // Bracket format: flat filter params are dropped on their way to the API (and rejected by it now -
+            // kestra-io/kestra-ee#10326), so the tour never actually scoped this list to its own namespace.
             query: {
                 "filters[namespace][EQUALS]": TOUR_NAMESPACE,
                 "filters[scope][EQUALS]": "USER",

--- a/ui/src/components/onboarding/tour/useTourActions.ts
+++ b/ui/src/components/onboarding/tour/useTourActions.ts
@@ -193,7 +193,12 @@ export function useTourActions() {
         await router.push({
             name: "executions/list",
             params: {tenant: tenant()},
-            query: {namespace: TOUR_NAMESPACE, scope: "USER"},
+            // Bracket format: the flat `namespace=`/`scope=` params are not read by the API and are now rejected
+            // outright (kestra-io/kestra-ee#10326), so the tour never actually scoped this list.
+            query: {
+                "filters[namespace][EQUALS]": TOUR_NAMESPACE,
+                "filters[scope][EQUALS]": "USER",
+            },
         })
     }
 

--- a/webserver/src/main/java/io/kestra/webserver/configuration/QueryFilterConfiguration.java
+++ b/webserver/src/main/java/io/kestra/webserver/configuration/QueryFilterConfiguration.java
@@ -27,11 +27,17 @@ import io.micronaut.core.bind.annotation.Bindable;
  * <p>
  * Per-Resource overrides are independent of the global value — they may be tighter or looser than the global cap,
  * but still subject to the same floor.
+ * <p>
+ * A third, unrelated safeguard is exposed here: {@code reject-legacy-params}. When enabled (the default), the binder
+ * rejects pre-2.0 flat filter parameters ({@code state=RUNNING}) instead of silently ignoring them. It exists as a
+ * configuration switch only so that an operator with a stuck integration can buy time on upgrade; it is expected to
+ * stay enabled.
  */
 @ConfigurationProperties("kestra.webserver.query-filter")
 public record QueryFilterConfiguration(
     @Bindable(defaultValue = "3") int maxDepth,
     @Bindable(defaultValue = "20") int maxWidth,
+    @Bindable(defaultValue = "true") boolean rejectLegacyParams,
     @Nullable Map<String, ResourceLimits> resources) {
 
     public static final int FLOOR_DEPTH = 3;

--- a/webserver/src/main/java/io/kestra/webserver/converters/QueryFilterFormatBinder.java
+++ b/webserver/src/main/java/io/kestra/webserver/converters/QueryFilterFormatBinder.java
@@ -16,6 +16,7 @@ import io.kestra.webserver.configuration.QueryFilterConfiguration;
 import io.kestra.webserver.utils.RequestUtils;
 
 import io.micronaut.core.convert.ArgumentConversionContext;
+import io.micronaut.core.type.Argument;
 import io.micronaut.http.HttpRequest;
 import io.micronaut.http.annotation.QueryValue;
 import io.micronaut.http.bind.binders.AnnotatedRequestArgumentBinder;
@@ -153,9 +154,11 @@ public class QueryFilterFormatBinder implements AnnotatedRequestArgumentBinder<Q
 
         List<String> legacy = legacyParams(source.getParameters().asMap().keySet(), declared.get());
         if (!legacy.isEmpty()) {
+            String example = legacy.getFirst();
             throw new IllegalArgumentException(
                 "Legacy filter parameter(s) " + legacy + " are no longer supported and would have been silently "
-                    + "ignored. Use the bracket format instead, e.g. filters[" + legacy.getFirst() + "][EQUALS]=value."
+                    + "ignored. Use the bracket format instead, e.g. filters[" + example + "]["
+                    + QueryFilter.Field.fromString(example).supportedOp().getFirst() + "]=value."
             );
         }
     }
@@ -171,7 +174,9 @@ public class QueryFilterFormatBinder implements AnnotatedRequestArgumentBinder<Q
     }
 
     /**
-     * The query parameter names the matched route actually binds - argument names plus any {@code @QueryValue} alias.
+     * The query parameter names the matched route can actually bind. Arguments already satisfied by a URI variable are
+     * excluded by Micronaut, which only makes the check stricter: those names arrive in the path, not the query string.
+     * <p>
      * Empty when the route arguments cannot be read, in which case the legacy check is skipped entirely: an unknown
      * route surface must not turn into a wave of false rejections.
      */
@@ -179,11 +184,21 @@ public class QueryFilterFormatBinder implements AnnotatedRequestArgumentBinder<Q
         return RouteAttributes.getRouteMatch(source)
             .filter(MethodBasedRouteMatch.class::isInstance)
             .map(routeMatch -> ((MethodBasedRouteMatch<?, ?>) routeMatch).getRequiredArguments().stream()
-                .flatMap(argument -> Stream.concat(
-                    Stream.of(argument.getName()),
-                    argument.getAnnotationMetadata().stringValue(QueryValue.class).stream()
-                ))
+                .flatMap(QueryFilterFormatBinder::boundNames)
                 .collect(Collectors.toSet()));
+    }
+
+    /**
+     * The name(s) an argument can be bound from. An explicit {@code @QueryValue("alias")} <em>replaces</em> the
+     * argument name rather than adding to it: {@code @QueryValue(value = "existing") Boolean existingOnly} is only
+     * ever read from {@code existing}, so sparing {@code existingOnly} would spare a parameter that is silently
+     * ignored - and {@code existingOnly} happens to be a filter field name too.
+     */
+    private static Stream<String> boundNames(Argument<?> argument) {
+        return argument.getAnnotationMetadata().stringValue(QueryValue.class)
+            .filter(alias -> !alias.isBlank())
+            .map(Stream::of)
+            .orElseGet(() -> Stream.of(argument.getName()));
     }
 
     private static List<Object> parseValues(List<String> values, QueryFilter.Field field, QueryFilter.Op operation) {

--- a/webserver/src/main/java/io/kestra/webserver/converters/QueryFilterFormatBinder.java
+++ b/webserver/src/main/java/io/kestra/webserver/converters/QueryFilterFormatBinder.java
@@ -5,6 +5,8 @@ import java.nio.charset.StandardCharsets;
 import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import com.google.common.annotations.VisibleForTesting;
 
@@ -15,7 +17,10 @@ import io.kestra.webserver.utils.RequestUtils;
 
 import io.micronaut.core.convert.ArgumentConversionContext;
 import io.micronaut.http.HttpRequest;
+import io.micronaut.http.annotation.QueryValue;
 import io.micronaut.http.bind.binders.AnnotatedRequestArgumentBinder;
+import io.micronaut.web.router.MethodBasedRouteMatch;
+import io.micronaut.web.router.RouteAttributes;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 
@@ -29,6 +34,15 @@ public class QueryFilterFormatBinder implements AnnotatedRequestArgumentBinder<Q
     private static final Pattern PREFIX_SEG = Pattern.compile(
         "\\[(?i:(and|or))]\\[(\\d+)]"
     );
+
+    /**
+     * The pre-2.0 flat filter parameter names ({@code state}, {@code namespace}, {@code q}, ...), derived from the
+     * filter fields themselves so the set cannot drift as fields are added or removed. A request carrying one of
+     * these is rejected rather than silently widened - see {@link #rejectLegacyParams(HttpRequest)}.
+     */
+    private static final Set<String> LEGACY_FILTER_PARAMS = Arrays.stream(QueryFilter.Field.values())
+        .map(QueryFilter.Field::value)
+        .collect(Collectors.toUnmodifiableSet());
 
     private final QueryFilterConfiguration configuration;
 
@@ -109,6 +123,10 @@ public class QueryFilterFormatBinder implements AnnotatedRequestArgumentBinder<Q
                 )
             );
 
+        if (configuration.rejectLegacyParams()) {
+            rejectLegacyParams(source);
+        }
+
         int maxDepth = configuration.maxDepthFor(resource);
         int maxWidth = configuration.maxWidthFor(resource);
 
@@ -116,6 +134,56 @@ public class QueryFilterFormatBinder implements AnnotatedRequestArgumentBinder<Q
         List<QueryFilter> filters = getQueryFilters(queryParams, maxDepth, maxWidth);
 
         return () -> Optional.of(filters);
+    }
+
+    /**
+     * Rejects pre-2.0 flat filter parameters, which this binder does not read: only {@code filters[field][OP]=value}
+     * is honoured, so a request scoped with {@code state=RUNNING} used to degrade to "match everything" - dangerous
+     * on the by-query bulk endpoints, where it widens a delete or a kill to the whole tenant.
+     * <p>
+     * A parameter is only legacy when the matched route does not declare it as a real argument: names such as
+     * {@code namespace} or {@code flowId} are legitimate query values on several endpoints, and those must keep
+     * working.
+     */
+    private static void rejectLegacyParams(HttpRequest<?> source) {
+        Optional<Set<String>> declared = declaredParamNames(source);
+        if (declared.isEmpty()) {
+            return;
+        }
+
+        List<String> legacy = legacyParams(source.getParameters().asMap().keySet(), declared.get());
+        if (!legacy.isEmpty()) {
+            throw new IllegalArgumentException(
+                "Legacy filter parameter(s) " + legacy + " are no longer supported and would have been silently "
+                    + "ignored. Use the bracket format instead, e.g. filters[" + legacy.getFirst() + "][EQUALS]=value."
+            );
+        }
+    }
+
+    @VisibleForTesting
+    static List<String> legacyParams(Collection<String> paramNames, Set<String> declaredNames) {
+        return paramNames.stream()
+            .filter(name -> !name.startsWith("filters["))
+            .filter(LEGACY_FILTER_PARAMS::contains)
+            .filter(name -> !declaredNames.contains(name))
+            .sorted()
+            .toList();
+    }
+
+    /**
+     * The query parameter names the matched route actually binds - argument names plus any {@code @QueryValue} alias.
+     * Empty when the route arguments cannot be read, in which case the legacy check is skipped entirely: an unknown
+     * route surface must not turn into a wave of false rejections.
+     */
+    private static Optional<Set<String>> declaredParamNames(HttpRequest<?> source) {
+        return RouteAttributes.getRouteMatch(source)
+            .filter(MethodBasedRouteMatch.class::isInstance)
+            .map(routeMatch -> ((MethodBasedRouteMatch<?, ?>) routeMatch).getRequiredArguments().stream()
+                .flatMap(argument -> Stream.concat(
+                    Stream.of(argument.getName()),
+                    argument.getAnnotationMetadata().stringValue(QueryValue.class).stream()
+                ))
+                .collect(Collectors.toSet()));
     }
 
     private static List<Object> parseValues(List<String> values, QueryFilter.Field field, QueryFilter.Op operation) {

--- a/webserver/src/test/java/io/kestra/webserver/configuration/QueryFilterConfigurationTest.java
+++ b/webserver/src/test/java/io/kestra/webserver/configuration/QueryFilterConfigurationTest.java
@@ -13,7 +13,7 @@ class QueryFilterConfigurationTest {
     @Test
     void shouldClampGlobalsBelowFloor() {
         // GIVEN / WHEN — clamping happens in the canonical constructor
-        QueryFilterConfiguration config = new QueryFilterConfiguration(1, 5, null);
+        QueryFilterConfiguration config = new QueryFilterConfiguration(1, 5, true, null);
 
         // THEN — clamped up to the floor
         assertEquals(QueryFilterConfiguration.FLOOR_DEPTH, config.maxDepth());
@@ -23,7 +23,7 @@ class QueryFilterConfigurationTest {
     @Test
     void shouldNotClampGlobalsAtOrAboveFloor() {
         // GIVEN / WHEN
-        QueryFilterConfiguration config = new QueryFilterConfiguration(10, 100, null);
+        QueryFilterConfiguration config = new QueryFilterConfiguration(10, 100, true, null);
 
         // THEN — unchanged
         assertEquals(10, config.maxDepth());
@@ -39,6 +39,7 @@ class QueryFilterConfigurationTest {
         QueryFilterConfiguration config = new QueryFilterConfiguration(
             QueryFilterConfiguration.FLOOR_DEPTH,
             QueryFilterConfiguration.FLOOR_WIDTH,
+            true,
             Map.of("EXECUTION", limits)
         );
 
@@ -53,7 +54,7 @@ class QueryFilterConfigurationTest {
         // GIVEN — EXECUTION overrides depth only; width unset
         QueryFilterConfiguration.ResourceLimits limits = new QueryFilterConfiguration.ResourceLimits(8, null);
 
-        QueryFilterConfiguration config = new QueryFilterConfiguration(3, 20, Map.of("EXECUTION", limits));
+        QueryFilterConfiguration config = new QueryFilterConfiguration(3, 20, true, Map.of("EXECUTION", limits));
 
         // WHEN / THEN
         assertEquals(8, config.maxDepthFor(QueryFilter.Resource.EXECUTION));
@@ -70,7 +71,7 @@ class QueryFilterConfigurationTest {
 
     @Test
     void shouldFallBackToGlobalWhenResourceIsNull() {
-        QueryFilterConfiguration config = new QueryFilterConfiguration(5, 50, null);
+        QueryFilterConfiguration config = new QueryFilterConfiguration(5, 50, true, null);
 
         assertEquals(5, config.maxDepthFor(null));
         assertEquals(50, config.maxWidthFor(null));

--- a/webserver/src/test/java/io/kestra/webserver/controllers/api/ExecutionControllerTest.java
+++ b/webserver/src/test/java/io/kestra/webserver/controllers/api/ExecutionControllerTest.java
@@ -388,6 +388,28 @@ class ExecutionControllerTest {
     }
 
     @Test
+    void shouldRejectLegacyFlatFilterParams() {
+        // GIVEN — a pre-2.0 client scoping the search the flat way. Only filters[field][OP]=value is read, so this
+        // used to degrade to "match everything" (kestra-io/kestra-ee#10326): on the by-query bulk endpoints that
+        // turned a scoped delete or kill into a tenant-wide one.
+        HttpClientResponseException exception = assertThrows(
+            HttpClientResponseException.class, () -> client.toBlocking().retrieve(
+                GET("/api/v1/main/executions/search?state=RUNNING&namespace=" + TESTS_FLOW_NS), PagedResults.class
+            )
+        );
+
+        // THEN — rejected, naming both offending params
+        assertThat(exception.getStatus().getCode()).isEqualTo(422);
+        assertThat(exception.getMessage()).contains("[namespace, state]");
+
+        // AND — the supported bracket format is untouched
+        PagedResults<?> results = client.toBlocking().retrieve(
+            GET("/api/v1/main/executions/search?filters[state][EQUALS]=RUNNING"), PagedResults.class
+        );
+        assertThat(results.getTotal()).isNotNull();
+    }
+
+    @Test
     @LoadFlows(value = { "flows/valids/inputs.yaml" })
     void shouldValidateInputsForCreateExecutionGivenSimpleInputs() {
         // given

--- a/webserver/src/test/java/io/kestra/webserver/controllers/api/FlowControllerTest.java
+++ b/webserver/src/test/java/io/kestra/webserver/controllers/api/FlowControllerTest.java
@@ -185,8 +185,15 @@ class FlowControllerTest {
         PagedResults<Flow> flows = client.toBlocking().retrieve(HttpRequest.GET("/api/v1/main/flows/search?filters[q][EQUALS]=*"), Argument.of(PagedResults.class, Flow.class));
         assertThat(flows.getTotal()).isEqualTo(Helpers.FLOWS_COUNT);
 
-        PagedResults<Flow> flows_oldParameters = client.toBlocking().retrieve(HttpRequest.GET("/api/v1/main/flows/search?q=*"), Argument.of(PagedResults.class, Flow.class));
-        assertThat(flows_oldParameters.getTotal()).isEqualTo(Helpers.FLOWS_COUNT);
+        // The pre-2.0 flat `q` parameter is not read by the filter binder. It used to be dropped silently, which made
+        // the search match everything - this assertion previously passed for that reason, not because `q` was honoured.
+        // It is now rejected instead (kestra-io/kestra-ee#10326).
+        HttpClientResponseException e = assertThrows(
+            HttpClientResponseException.class,
+            () -> client.toBlocking().retrieve(HttpRequest.GET("/api/v1/main/flows/search?q=*"), Argument.of(PagedResults.class, Flow.class))
+        );
+        assertThat(e.getStatus().getCode()).isEqualTo(HttpStatus.UNPROCESSABLE_ENTITY.getCode());
+        assertThat(e.getMessage()).contains("[q]");
     }
 
     @SuppressWarnings("unchecked")

--- a/webserver/src/test/java/io/kestra/webserver/controllers/api/NamespaceControllerTest.java
+++ b/webserver/src/test/java/io/kestra/webserver/controllers/api/NamespaceControllerTest.java
@@ -62,6 +62,23 @@ public class NamespaceControllerTest {
 
     @SuppressWarnings("unchecked")
     @Test
+    void shouldKeepRouteDeclaredParamsWorkingAlongsideFilters() {
+        // GIVEN — `existingOnly` is both a filter field name and a real argument of this route (bound as `existing`),
+        // so the legacy-flat-param safeguard must not reject it. See kestra-io/kestra-ee#10326.
+        flow("my.ns");
+
+        // WHEN
+        PagedResults<Namespace> list = client.toBlocking().retrieve(
+            HttpRequest.GET("/api/v1/main/namespaces/search?existing=true"),
+            Argument.of(PagedResults.class, Namespace.class)
+        );
+
+        // THEN
+        assertThat(list.getTotal()).isNotNull();
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
     void list() {
         flow("my.ns");
         flow("my.ns.flow");

--- a/webserver/src/test/java/io/kestra/webserver/controllers/api/NamespaceControllerTest.java
+++ b/webserver/src/test/java/io/kestra/webserver/controllers/api/NamespaceControllerTest.java
@@ -24,11 +24,14 @@ import io.kestra.webserver.responses.PagedResults;
 
 import io.micronaut.core.type.Argument;
 import io.micronaut.http.HttpRequest;
+import io.micronaut.http.HttpStatus;
 import io.micronaut.http.client.annotation.Client;
+import io.micronaut.http.client.exceptions.HttpClientResponseException;
 import io.micronaut.reactor.http.client.ReactorHttpClient;
 import jakarta.inject.Inject;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 
@@ -75,6 +78,18 @@ public class NamespaceControllerTest {
 
         // THEN
         assertThat(list.getTotal()).isNotNull();
+
+        // AND — the argument name is NOT a second way in: `existingOnly` is never read by Micronaut, so it must be
+        // rejected like any other silently-ignored flat param rather than spared as "route-declared"
+        HttpClientResponseException e = assertThrows(
+            HttpClientResponseException.class,
+            () -> client.toBlocking().retrieve(
+                HttpRequest.GET("/api/v1/main/namespaces/search?existingOnly=true"),
+                Argument.of(PagedResults.class, Namespace.class)
+            )
+        );
+        assertThat(e.getStatus().getCode()).isEqualTo(HttpStatus.UNPROCESSABLE_ENTITY.getCode());
+        assertThat(e.getMessage()).contains("[existingOnly]");
     }
 
     @SuppressWarnings("unchecked")

--- a/webserver/src/test/java/io/kestra/webserver/converters/QueryFilterFormatBinderTest.java
+++ b/webserver/src/test/java/io/kestra/webserver/converters/QueryFilterFormatBinderTest.java
@@ -1,5 +1,6 @@
 package io.kestra.webserver.converters;
 
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -338,6 +339,54 @@ class QueryFilterFormatBinderTest {
             List.of("after-execution-error", "after-execution-finally", "avoidinfiniteexecutionloop"),
             flowId.value()
         );
+    }
+
+    @Test
+    void shouldFlagLegacyFlatFilterParams() {
+        // GIVEN — a pre-2.0 URL that scopes a bulk action the flat way
+        List<String> legacy = QueryFilterFormatBinder.legacyParams(
+            Set.of("state", "namespace", "size"),
+            Set.of("size")
+        );
+
+        // THEN — both filter-shaped params are reported, the route's own `size` is not
+        assertEquals(List.of("namespace", "state"), legacy);
+    }
+
+    @Test
+    void shouldNotFlagParamsTheRouteActuallyDeclares() {
+        // GIVEN — `namespace` is a real query value on several endpoints (e.g. IAM binding search)
+        List<String> legacy = QueryFilterFormatBinder.legacyParams(
+            Set.of("namespace", "type", "id"),
+            Set.of("namespace", "type", "id")
+        );
+
+        // THEN — declared params must keep working
+        assertTrue(legacy.isEmpty(), "Route-declared params must not be treated as legacy");
+    }
+
+    @Test
+    void shouldNotFlagBracketFormatOrUnknownParams() {
+        // GIVEN — the supported format, plus a param that is not a filter field at all
+        List<String> legacy = QueryFilterFormatBinder.legacyParams(
+            Set.of("filters[state][EQUALS]", "filters[namespace][EQUALS]", "utm_source"),
+            Set.of()
+        );
+
+        // THEN — nothing rejected: only known flat filter names are
+        assertTrue(legacy.isEmpty());
+    }
+
+    @Test
+    void shouldDeriveLegacyParamNamesFromFilterFields() {
+        // GIVEN/WHEN — a field added to QueryFilter.Field is covered without touching this binder
+        List<String> legacy = QueryFilterFormatBinder.legacyParams(
+            Arrays.stream(QueryFilter.Field.values()).map(QueryFilter.Field::value).toList(),
+            Set.of()
+        );
+
+        // THEN — every field value is a rejectable flat param
+        assertEquals(QueryFilter.Field.values().length, legacy.size());
     }
 
     @Test


### PR DESCRIPTION
Closes kestra-io/kestra-ee#10326

### What

Only `filters[field][OP]=value` is read by the query-filter binder. The pre-2.0 flat parameters (`state=RUNNING`, `namespace=x`, `q=*`) were dropped silently, so the query degraded to *match everything*. On the by-query bulk endpoints — kill, delete, restart, change-status, set-labels — a request the caller believed was scoped to one namespace or one state ran against **every execution in the tenant**.

They are now rejected with `422` instead:

```
GET /api/v1/main/executions/search?state=RUNNING
→ 422 Illegal argument: Legacy filter parameter(s) [state] are no longer supported and would
  have been silently ignored. Use the bracket format instead, e.g. filters[state][EQUALS]=value.
```

### How

`QueryFilterFormatBinder` is the single choke point for every filter-accepting endpoint in OSS *and* EE (EE declares no binder of its own), so the check lives there and no controller is touched. A query parameter is rejected when all three hold:

1. it is not in `filters[...]` form;
2. its name is a `QueryFilter.Field` value;
3. the matched route does not declare it as a real argument (`MethodBasedRouteMatch#getRequiredArguments`, plus any `@QueryValue("alias")`).

Condition 3 is what keeps this safe. Several routes legitimately declare parameters that collide with filter-field names — `IAMBindingController.searchBindings` takes `type`, `id` and `namespace`; `NamespaceController.searchNamespaces` takes `existingOnly` (bound as `existing`) — and they keep working. A hand-written denylist would have broken all of them.

The rejected set is derived from `QueryFilter.Field` rather than hand-listed, so it cannot drift as fields are added or removed. When the route arguments cannot be read at all, the check is skipped rather than guessing.

### Escape hatch

```yaml
kestra:
  webserver:
    query-filter:
      reject-legacy-params: false   # default: true
```

For an operator with a stuck integration to buy time on upgrade. Expected to stay enabled.

### Behaviour change

`FlowControllerTest.searchFlowsAll` asserted that `?q=*` still returned every flow "with the old parameters". It passed because the parameter was ignored and the search matched everything — not because `q` was honoured. It now asserts the rejection.

### ⚠️ Companion EE change required

The same pattern is encoded in EE tests, which will fail until they are updated (each of these currently passes only *because* the parameter is ignored):

- `webserver-ee/.../FlowControllerTest.java` — `flows/search?q=*`, and `flows/{enable,disable}/by-query?namespace=…`, which today enables/disables **every flow in the tenant**
- `webserver-ee/.../IAMBindingControllerTest.java` — `bindings/search?q=*`
- `webserver-ee/.../IAMGroupControllerTest.java` — `groups/{id}/members?q=*`
- `webserver-ee/.../ImpersonateTest.java` — `flows/search?q=*`

Verified unaffected: namespace-file search, flow source search, apps preview, promotion flow-source, testsuite search, policy detail — those routes either declare the parameter or take no filters at all.

### Tests

- `QueryFilterFormatBinderTest` — 4 unit tests over the rejection rule (flags legacy, spares route-declared, spares bracket/unknown params, set derived from `Field`)
- `ExecutionControllerTest.shouldRejectLegacyFlatFilterParams` — end-to-end 422 on `?state=RUNNING&namespace=…`, bracket format still 200
- `NamespaceControllerTest.shouldKeepRouteDeclaredParamsWorkingAlongsideFilters` — a route-declared param on a filters endpoint still works
- Full `:webserver:test` green (1183 passing)