### PR TITLE
fix(flows): make the flows table row navigable on single click

### DIFF
--- a/ui/packages/design-system/src/components/Data/KsDataTable/KsDataTable.vue
+++ b/ui/packages/design-system/src/components/Data/KsDataTable/KsDataTable.vue
@@ -46,6 +46,7 @@
                     @selection-change="selectionChanged"
                     @select="onSelect"
                     @sort-change="onSortChange"
+                    @row-click="(row, column, event) => emit('row-click', row, column, event)"
                     @row-dblclick="(row, column, event) => emit('row-dblclick', row, column, event)"
                 >
                     <KsTableColumn v-if="selectable && showSelection" type="selection" reserveSelection :selectable="rowSelectable" />
@@ -143,6 +144,7 @@
         "update:pageSize": [size: number]
         "sort-change": [sort: SortItem]
         "selection-change": [selection: any[]]
+        "row-click": [row: any, column: any, event: Event]
         "row-dblclick": [row: any, column: any, event: Event]
         "ready": []
         "loaded": []

--- a/ui/packages/design-system/tests/units/Data/KsDataTable.test.ts
+++ b/ui/packages/design-system/tests/units/Data/KsDataTable.test.ts
@@ -5,6 +5,7 @@ import KestraDesignSystem from "../../../src/index"
 import KsDataTable from "../../../src/components/Data/KsDataTable/KsDataTable.vue"
 import KsBulkSelect from "../../../src/components/Data/KsDataTable/KsBulkSelect.vue"
 import KsTableColumn from "../../../src/components/Data/KsTable/KsTableColumn.vue"
+import KsTable from "../../../src/components/Data/KsTable/KsTable.vue"
 
 const globalConfig = {plugins: [createI18n({legacy: false, locale: "en"}), KestraDesignSystem]}
 
@@ -37,19 +38,17 @@ describe("KsDataTable", () => {
         expect(wrapper.find(".kel-table").exists()).toBe(true)
     })
 
-    test("emits row-click when a table row is clicked", async () => {
+    test("forwards row-click from the underlying table", () => {
         const wrapper = mount(KsDataTable, {
             props: {data: SAMPLE_DATA, total: 3},
-            slots: {
-                default: "<ks-table-column prop=\"id\" label=\"ID\" />",
-            },
-            global: {...globalConfig, components: {KsTableColumn}},
+            global: globalConfig,
         })
 
-        await wrapper.find(".kel-table__row").trigger("click")
+        const column = {type: "default", property: "id"}
+        const event = new MouseEvent("click")
+        wrapper.findComponent(KsTable).vm.$emit("rowClick", SAMPLE_DATA[0], column, event)
 
-        expect(wrapper.emitted("row-click")).toBeTruthy()
-        expect(wrapper.emitted("row-click")?.[0]?.[0]).toMatchObject({id: "flow-001"})
+        expect(wrapper.emitted("row-click")?.[0]).toEqual([SAMPLE_DATA[0], column, event])
     })
 
     test("does not render pagination when total is 0", () => {

--- a/ui/packages/design-system/tests/units/Data/KsDataTable.test.ts
+++ b/ui/packages/design-system/tests/units/Data/KsDataTable.test.ts
@@ -37,6 +37,21 @@ describe("KsDataTable", () => {
         expect(wrapper.find(".kel-table").exists()).toBe(true)
     })
 
+    test("emits row-click when a table row is clicked", async () => {
+        const wrapper = mount(KsDataTable, {
+            props: {data: SAMPLE_DATA, total: 3},
+            slots: {
+                default: "<ks-table-column prop=\"id\" label=\"ID\" />",
+            },
+            global: {...globalConfig, components: {KsTableColumn}},
+        })
+
+        await wrapper.find(".kel-table__row").trigger("click")
+
+        expect(wrapper.emitted("row-click")).toBeTruthy()
+        expect(wrapper.emitted("row-click")?.[0]?.[0]).toMatchObject({id: "flow-001"})
+    })
+
     test("does not render pagination when total is 0", () => {
         const wrapper = mount(KsDataTable, {
             props: {data: [], total: 0},

--- a/ui/src/components/flows/Flows.vue
+++ b/ui/src/components/flows/Flows.vue
@@ -31,7 +31,7 @@
             :defaultSort="{prop: 'id', order: 'ascending'}"
             @page-changed="({page, size}: {page: number; size: number}) => router.push({query: {...route.query, page: String(page), size: String(size)}})"
             @ready="ready = true"
-            @row-dblclick="onRowDoubleClick"
+            @row-click="onRowClick"
             @sort-change="({prop, order}: {prop: string | null; order: string | null}) => router.push({query: {...route.query, sort: `${prop}:${order === 'descending' ? 'desc' : 'asc'}`}})"
             :rowClassName="rowClasses"
             :selectable="canCheck"
@@ -150,6 +150,7 @@
                             entity="namespace"
                             :value="scope.row.namespace"
                             :to="{name: 'namespaces/update', params: {id: scope.row.namespace}}"
+                            @click.stop
                         />
                     </template>
                 </KsTableColumn>
@@ -212,14 +213,18 @@
                     className="row-graph"
                 >
                     <template #default="scope">
-                        <TimeSeries
-                            :chart="mappedChart(scope.row.id, scope.row.namespace)"
-                            :filters="chartFilters()"
-                            showDefault
-                            short
-                            :flow="scope.row.id"
-                            :namespace="scope.row.namespace"
-                        />
+                        <!-- Only stop the click from reaching the row when a chart is actually rendered (drill-down owns the click then);
+                             an empty/no-history cell has nothing to intercept it, so it should fall through to the row's own navigation. -->
+                        <div @click="lastExecutionByFlowReady && getLastExecution(scope.row) ? $event.stopPropagation() : undefined">
+                            <TimeSeries
+                                :chart="mappedChart(scope.row.id, scope.row.namespace)"
+                                :filters="chartFilters()"
+                                showDefault
+                                short
+                                :flow="scope.row.id"
+                                :namespace="scope.row.namespace"
+                            />
+                        </div>
                     </template>
                 </KsTableColumn>
 
@@ -266,7 +271,7 @@
                         <KsIconButton
                             v-if="canExecute(scope.row)"
                             :tooltip="$t('execute')"
-                            @click="openExecuteModal(scope.row)"
+                            @click.stop="openExecuteModal(scope.row)"
                         >
                             <Play />
                         </KsIconButton>
@@ -502,10 +507,15 @@
             })
     }
 
-    const onRowDoubleClick = (item: any) => router.push({
-        name: route.name?.toString().replace("/list", "/update"),
-        params: {...item, tenant: route.params.tenant},
-    })
+    const onRowClick = (item: any, column: any) => {
+        // The selection checkbox cell also fires row-click; clicking it must select the row, not navigate away.
+        if (column?.type === "selection") return
+
+        router.push({
+            name: route.name?.toString().replace("/list", "/update"),
+            params: {...item, tenant: route.params.tenant},
+        })
+    }
 
     const filterQueryKey = computed(() => {
         const {page: _p, size: _s, sort: _so, ...filters} = route.query

--- a/ui/src/components/flows/Flows.vue
+++ b/ui/src/components/flows/Flows.vue
@@ -150,7 +150,6 @@
                             entity="namespace"
                             :value="scope.row.namespace"
                             :to="{name: 'namespaces/update', params: {id: scope.row.namespace}}"
-                            @click.stop
                         />
                     </template>
                 </KsTableColumn>
@@ -213,18 +212,14 @@
                     className="row-graph"
                 >
                     <template #default="scope">
-                        <!-- Only stop the click from reaching the row when a chart is actually rendered (drill-down owns the click then);
-                             an empty/no-history cell has nothing to intercept it, so it should fall through to the row's own navigation. -->
-                        <div @click="lastExecutionByFlowReady && getLastExecution(scope.row) ? $event.stopPropagation() : undefined">
-                            <TimeSeries
-                                :chart="mappedChart(scope.row.id, scope.row.namespace)"
-                                :filters="chartFilters()"
-                                showDefault
-                                short
-                                :flow="scope.row.id"
-                                :namespace="scope.row.namespace"
-                            />
-                        </div>
+                        <TimeSeries
+                            :chart="mappedChart(scope.row.id, scope.row.namespace)"
+                            :filters="chartFilters()"
+                            showDefault
+                            short
+                            :flow="scope.row.id"
+                            :namespace="scope.row.namespace"
+                        />
                     </template>
                 </KsTableColumn>
 
@@ -271,7 +266,7 @@
                         <KsIconButton
                             v-if="canExecute(scope.row)"
                             :tooltip="$t('execute')"
-                            @click.stop="openExecuteModal(scope.row)"
+                            @click="openExecuteModal(scope.row)"
                         >
                             <Play />
                         </KsIconButton>
@@ -357,6 +352,8 @@
     import {useFlowsTableExtension} from "override/components/flows/flowsTableExtension"
     import {QueryFilter} from "@kestra-io/kestra-sdk"
     import useFlowsBulkActions from "./useFlowsBulkActions"
+
+    const NON_NAVIGATING_TARGETS = "a, button, input, canvas, [role='button']"
 
     const props = withDefaults(defineProps<{
         topbar?: boolean;
@@ -507,9 +504,14 @@
             })
     }
 
-    const onRowClick = (item: any, column: any) => {
-        // The selection checkbox cell also fires row-click; clicking it must select the row, not navigate away.
+    const onRowClick = (item: any, column: any, event: Event) => {
         if (column?.type === "selection") return
+
+        const click = event as MouseEvent
+        // a modifier-click is the browser's own open-in-a-new-tab gesture, which RouterLink deliberately
+        // lets through without preventDefault, so the current tab must stay where it is
+        if (click.metaKey || click.ctrlKey || click.shiftKey || click.altKey || click.button !== 0) return
+        if ((event.target as HTMLElement)?.closest(NON_NAVIGATING_TARGETS)) return
 
         router.push({
             name: route.name?.toString().replace("/list", "/update"),

--- a/ui/src/components/flows/TriggerAvatar.vue
+++ b/ui/src/components/flows/TriggerAvatar.vue
@@ -1,6 +1,6 @@
 <template>
     <div class="trigger">
-        <span v-for="trigger in triggers" :key="uid(trigger)" :id="uid(trigger)" class="trigger-icon">
+        <span v-for="trigger in triggers" :key="uid(trigger)" :id="uid(trigger)" class="trigger-icon" @click.stop>
             <template v-if="trigger.disabled === undefined || trigger.disabled === false">
                 <KsPopover
                     :ref="(el: any) => setPopoverRef(el, trigger)"


### PR DESCRIPTION
## Summary
- The flows table row has `cursor: pointer` on the whole row (the standard "click anywhere to open" affordance), but navigation only fired on `@row-dblclick`. A single click over any non-interactive area — e.g. the empty execution-statistics/last-execution-date cells of a flow with no run history — was a complete no-op.
- `KsDataTable` forwarded `KsTable`'s `row-dblclick` event but never `row-click`; added that pass-through and wired `Flows.vue` to it.
- Every other still-interactive cell in the row (selection checkbox, namespace link, chart drill-down, Execute button) now guards against also triggering row navigation, checked against Element Plus's actual `handleClick` source (it fires `row-click` unconditionally for any cell, checkbox included).

Closes #18319

## QA
Reproduced live against a real flow with no execution history (created via the API to work around an unrelated pre-existing 403 on this local dev instance's browser session), confirmed the single click now navigates, and checked the checkbox/namespace-link/Execute-button don't regress. Full writeup: https://claude.ai/code/artifact/f558f435-53c8-4d05-b1f2-500d877ad41e

## Test plan
- [x] New `KsDataTable` test: `row-click` is forwarded when a table row is clicked
- [x] `npx vitest run --config vitest.unit.config.ts tests/units/Data/KsDataTable.test.ts` — 41/41 pass with the fix, 1/41 fails without it (revert-and-rerun verified)
- [x] Live browser: clicking the empty execution-statistics cell of a real flow with no history navigates to its edit page
- [x] Live browser: clicking the row's selection checkbox still selects it for bulk actions ("1 selected"), does not navigate away