### PR TITLE
fix(core): bound the indent/nindent filters' amount to prevent heap exhaustion

### DIFF
--- a/core/src/main/java/io/kestra/core/runners/pebble/AbstractIndent.java
+++ b/core/src/main/java/io/kestra/core/runners/pebble/AbstractIndent.java
@@ -8,6 +8,8 @@ import io.pebbletemplates.pebble.template.EvaluationContext;
 import io.pebbletemplates.pebble.template.PebbleTemplate;
 
 public abstract class AbstractIndent {
+    private static final int MAX_AMOUNT = 10_000;
+
     public List<String> getArgumentNames() {
         return List.of("amount", "prefix");
     }
@@ -54,6 +56,11 @@ public abstract class AbstractIndent {
         int amount = ((Long) args.get("amount")).intValue();
         if (!(amount >= 0)) {
             throw new PebbleException(null, String.format("The '%s' filter expects a positive integer >=0 as argument 'amount'.", indentType), lineNumber, self.getName());
+        }
+        if (amount > MAX_AMOUNT) {
+            throw new PebbleException(
+                null, String.format("The '%s' filter's 'amount' argument cannot exceed %d, but %d was given.", indentType, MAX_AMOUNT, amount), lineNumber, self.getName()
+            );
         }
 
         String prefix = prefix(args);

--- a/core/src/test/java/io/kestra/core/runners/pebble/filters/IndentFilterTest.java
+++ b/core/src/test/java/io/kestra/core/runners/pebble/filters/IndentFilterTest.java
@@ -11,6 +11,7 @@ import io.kestra.core.runners.VariableRenderer;
 import jakarta.inject.Inject;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @KestraTest
 class IndentFilterTest {
@@ -75,6 +76,13 @@ class IndentFilterTest {
     void indentWithTab() throws IllegalVariableEvaluationException {
         String render = variableRenderer.render("{{ \"first line\nsecond line\" | indent(2, \"\t\") }}", Map.of());
         assertThat(render).isEqualTo("first line\n\t\tsecond line");
+    }
+
+    @Test
+    void indentRejectsExcessiveAmount() {
+        assertThatThrownBy(() -> variableRenderer.render("{{ 'x' | indent(2000000000) }}", Map.of()))
+            .isInstanceOf(IllegalVariableEvaluationException.class)
+            .hasMessageContaining("cannot exceed");
     }
 
 }

--- a/core/src/test/java/io/kestra/core/runners/pebble/filters/NindentFilterTest.java
+++ b/core/src/test/java/io/kestra/core/runners/pebble/filters/NindentFilterTest.java
@@ -11,6 +11,7 @@ import io.kestra.core.runners.VariableRenderer;
 import jakarta.inject.Inject;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @KestraTest
 class NindentFilterTest {
@@ -75,6 +76,13 @@ class NindentFilterTest {
     void nindentWithTab() throws IllegalVariableEvaluationException {
         String render = variableRenderer.render("{{ \"first line\nsecond line\" | nindent(2, \"\t\") }}", Map.of());
         assertThat(render).isEqualTo("\n\t\tfirst line\n\t\tsecond line");
+    }
+
+    @Test
+    void nindentRejectsExcessiveAmount() {
+        assertThatThrownBy(() -> variableRenderer.render("{{ 'x' | nindent(2000000000) }}", Map.of()))
+            .isInstanceOf(IllegalVariableEvaluationException.class)
+            .hasMessageContaining("cannot exceed");
     }
 
 }


### PR DESCRIPTION
## Summary
- `AbstractIndent.abstractApply` only lower-bounded `amount` (`>= 0`) before calling `prefix.repeat(amount)` unconditionally, so `{{ 'x' | nindent(2000000000) }}` allocates a multi-GB string from a single ordinary task expression. `VariableRenderer.renderOnce` only catches `IOException | RuntimeException`, so the resulting `OutOfMemoryError` escapes rendering entirely and OOM-kills the worker.
- Caps `amount` at 10,000 (checked *before* `repeat()` is ever called) with a bounded `PebbleException`, consistent with how `range()` was already bounded in #18418 rather than adding a differently-shaped defense.

Closes #18365

## QA
Full writeup with before/after test logs (the "before" run measurably took 3x longer allocating the ~2GB string): https://claude.ai/code/artifact/e9df6fc6-4b43-41d9-8b32-0d145739ddac

## Test plan
- [x] New tests in `IndentFilterTest`/`NindentFilterTest`: the exact `{{ 'x' | indent(2000000000) }}` / `nindent(...)` repro from the issue now throws a bounded error
- [x] `./gradlew :core:test --tests io.kestra.core.runners.pebble.filters.IndentFilterTest --tests io.kestra.core.runners.pebble.filters.NindentFilterTest` — 22/22 pass with the fix, 2/22 fail without it (revert-and-rerun verified, and the failing run visibly took 3x longer performing the unbounded allocation)
- [x] Checked all existing `indent`/`nindent` call sites in tests for `amount` values above 10,000 — none found