### PR TITLE
fix(executions): fail fast on follow-dependencies for an unknown execution

### DIFF
--- a/webserver/src/main/java/io/kestra/webserver/controllers/api/ExecutionController.java
+++ b/webserver/src/main/java/io/kestra/webserver/controllers/api/ExecutionController.java
@@ -2801,14 +2801,10 @@ public class ExecutionController {
         //  But as we need the correlationId to unsubscribe, we have no choice but to do it eagerly.
         //  This should not be an issue as long as it executes on an IO thread.
 
-        // Check if execution exists
-        Execution current = Await.await()
-            .atMost(Duration.ofSeconds(10))
-            .pollInterval(Duration.ofMillis(500))
-            .until(
-                () -> executionRepository.findById(tenantService.resolveTenant(), executionId).orElse(null),
-                Objects::nonNull
-            );
+        // Check if execution exists; a missing id must fail fast instead of pinning this IO thread
+        Execution current = executionRepository
+            .findById(tenantService.resolveTenant(), executionId)
+            .orElseThrow(() -> new NoSuchElementException("Unable to find execution '" + executionId + "'"));
 
         String correlationId = current.getLabels().stream().filter(label -> label.key().equals(CORRELATION_ID)).findAny().map(label -> label.value()).orElseThrow();
 

--- a/webserver/src/test/java/io/kestra/webserver/controllers/api/ExecutionControllerRunnerTest.java
+++ b/webserver/src/test/java/io/kestra/webserver/controllers/api/ExecutionControllerRunnerTest.java
@@ -3127,6 +3127,25 @@ class ExecutionControllerRunnerTest {
     }
 
     @Test
+    void followDependenciesOnUnknownExecutionReturnsNotFoundImmediately() {
+        long start = System.nanoTime();
+
+        HttpClientResponseException e = assertThrows(
+            HttpClientResponseException.class, () -> client.toBlocking().retrieve(
+                HttpRequest.GET("/api/v1/main/executions/does-not-exist/follow-dependencies")
+            )
+        );
+
+        long elapsedMs = (System.nanoTime() - start) / 1_000_000;
+        assertThat(e.getStatus().getCode())
+            .as("an unknown execution id is a 404, not an unhandled 500")
+            .isEqualTo(HttpStatus.NOT_FOUND.getCode());
+        assertThat(elapsedMs)
+            .as("must fail fast instead of pinning the IO thread on a 10s busy-wait")
+            .isLessThan(5000);
+    }
+
+    @Test
     @LoadFlows(
         value = { "flows/valids/follow-dependencies-partial-parent.yaml",
             "flows/valids/follow-dependencies-partial-child.yaml" },


### PR DESCRIPTION
## Summary
- `followDependenciesExecutions` busy-waited up to 10s on an IO thread via `Await.await().atMost(10s).pollInterval(500ms).until(...)` to look up the execution, then let the resulting `org.awaitility.core.ConditionTimeoutException` escape as an unmapped 500 for a missing id. A handful of concurrent bogus-id requests cheaply exhausts the IO thread pool.
- Replaced the polling lookup with a single `findById`, throwing `NoSuchElementException` (already mapped to 404 in `ErrorController`) immediately when the execution doesn't exist — matching the issue's own suggested fix.

Closes #18358

## QA
Full writeup with before/after test logs (timing-based proof — the "before" run measurably took 10s longer): https://claude.ai/code/artifact/c1816641-b715-4dd0-b3ce-c3c9e414a7e5

## Test plan
- [x] New test `followDependenciesOnUnknownExecutionReturnsNotFoundImmediately`: asserts 404 (not 500) and elapsed time under 5s for the exact repro from the issue
- [x] `./gradlew :webserver:test --tests io.kestra.webserver.controllers.api.ExecutionControllerRunnerTest.followDependenciesOnUnknownExecutionReturnsNotFoundImmediately` — passes in ~1s with the fix, fails (500, ~10s wait) without it (revert-and-rerun verified)
- [x] Existing follow-dependencies tests against real executions (`triggerExecutionAndFollowDependencies`, `shouldEndOnlyTerminatedDependenciesWhenFollowedExecutionIsStillRunning`) still pass unchanged