### PR TITLE
fix(tasks): coerce non-string Log message list elements instead of crashing

### DIFF
--- a/core/src/main/java/io/kestra/plugin/core/log/Log.java
+++ b/core/src/main/java/io/kestra/plugin/core/log/Log.java
@@ -84,7 +84,6 @@ public class Log extends Task implements RunnableTask<VoidOutput> {
     @Builder.Default
     private Property<Level> level = Property.ofValue(Level.INFO);
 
-    @SuppressWarnings("unchecked")
     @Override
     public VoidOutput run(RunContext runContext) throws Exception {
         Logger logger = runContext.logger();
@@ -95,11 +94,9 @@ public class Log extends Task implements RunnableTask<VoidOutput> {
             String render = runContext.render(stringValue);
             this.log(logger, renderedLevel, render);
         } else if (this.message instanceof Collection<?> collectionValue) {
-            Collection<String> messages = (Collection<String>) collectionValue;
-            messages.forEach(throwConsumer(message ->
+            collectionValue.forEach(throwConsumer(message ->
             {
-                String render;
-                render = runContext.render(message);
+                String render = runContext.render(String.valueOf(message));
                 this.log(logger, renderedLevel, render);
             }));
         } else {

--- a/core/src/test/java/io/kestra/plugin/core/log/LogTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/log/LogTest.java
@@ -1,0 +1,49 @@
+package io.kestra.plugin.core.log;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import io.kestra.core.junit.annotations.KestraTest;
+import io.kestra.core.models.executions.LogEntry;
+import io.kestra.core.queues.DispatchQueueInterface;
+import io.kestra.core.runners.RunContext;
+import io.kestra.core.runners.RunContextFactory;
+import io.kestra.core.utils.IdUtils;
+import io.kestra.core.utils.TestsUtils;
+
+import jakarta.inject.Inject;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@KestraTest
+class LogTest {
+    @Inject
+    RunContextFactory runContextFactory;
+
+    @Inject
+    private DispatchQueueInterface<LogEntry> logQueue;
+
+    @Test
+    void shouldLogNonStringMessageListElementsInsteadOfCrashing() throws Exception {
+        List<LogEntry> logs = new ArrayList<>();
+        logQueue.addListener(logs::add);
+
+        Log task = Log.builder()
+            .id(IdUtils.create())
+            .type(Log.class.getName())
+            .message(List.of("hello", 42, true))
+            .build();
+
+        RunContext runContext = TestsUtils.mockRunContext(runContextFactory, task, Map.of());
+        task.run(runContext);
+
+        List<LogEntry> matchingLogs = TestsUtils.awaitLogs(logs, 3);
+
+        assertThat(matchingLogs.stream().filter(logEntry -> logEntry.getMessage().equals("hello")).count()).isEqualTo(1L);
+        assertThat(matchingLogs.stream().filter(logEntry -> logEntry.getMessage().equals("42")).count()).isEqualTo(1L);
+        assertThat(matchingLogs.stream().filter(logEntry -> logEntry.getMessage().equals("true")).count()).isEqualTo(1L);
+    }
+}


### PR DESCRIPTION
## Summary
- `Log.run()` cast each collection element to `String` before rendering it (`Collection<String> messages = (Collection<String>) collectionValue;` then `runContext.render(message)` binding to the `String` overload), so a natural, valid-looking flow like `message: ["hello", 42]` validates and saves cleanly but throws a `ClassCastException` at execution time.
- Elements are now stringified with `String.valueOf(...)` before rendering — a no-op for elements that were already strings (preserving Pebble-templating for those), and a safe conversion for numbers/booleans/maps instead of a hard cast. Removed the now-unused `@SuppressWarnings("unchecked")` on `run()` along with the unchecked cast it existed for.

Closes #18356

## QA
Full writeup with before/after test logs: https://claude.ai/code/artifact/55f767b7-bb92-4101-ae01-5e8de2cc627f

## Test plan
- [x] New `LogTest.shouldLogNonStringMessageListElementsInsteadOfCrashing`: the exact repro from the issue (`["hello", 42, true]`) now logs all three elements instead of crashing after the first
- [x] `./gradlew :core:test --tests io.kestra.plugin.core.log.LogTest` — passes with the fix, fails with the exact reported `ClassCastException` without it (revert-and-rerun verified)
- [x] Checked other test usages of the `Log` task — all incidental (filler task in unrelated tests), no conflicts with the message-handling change