### PR TITLE
fix: return 422 when trigger backfill/create omits backfill

### DIFF
--- a/webserver/src/main/java/io/kestra/webserver/controllers/api/TriggerController.java
+++ b/webserver/src/main/java/io/kestra/webserver/controllers/api/TriggerController.java
@@ -223,8 +223,15 @@ public class TriggerController {
     @Operation(tags = { "Triggers" }, summary = "Create a backfill")
     @ApiResponse(responseCode = "200", description = "On success", content = { @Content(schema = @Schema(implementation = ApiTriggerState.class)) })
     @ApiResponse(responseCode = "409", description = "If the backfill cannot be created")
+    @ApiResponse(responseCode = "422", description = "If the backfill field is missing or invalid")
     public HttpResponse<ApiTriggerState> createBackfill(
         @Parameter(description = "The trigger that need the backfill to be created") @Body ApiCreateBackfillRequest request) {
+        if (request == null || request.backfill() == null) {
+            throw new IllegalArgumentException("The 'backfill' field is required");
+        }
+        if (request.backfill().start() == null) {
+            throw new IllegalArgumentException("The 'backfill.start' field is required");
+        }
         TriggerId triggerId = TriggerId.of(tenantService.resolveTenant(), request.namespace(), request.flowId(), request.triggerId());
         CreateBackfillTrigger.Backfill backfill = new CreateBackfillTrigger.Backfill(
             request.backfill().start(), request.backfill().end(), request.backfill().inputs(), request.backfill().labels()

--- a/webserver/src/test/java/io/kestra/webserver/controllers/api/TriggerControllerTest.java
+++ b/webserver/src/test/java/io/kestra/webserver/controllers/api/TriggerControllerTest.java
@@ -5,6 +5,7 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.TimeoutException;
 import java.util.stream.Stream;
 
@@ -706,6 +707,25 @@ class TriggerControllerTest {
         } catch (TimeoutException e) {
             Assertions.fail("Timeout waiting for trigger to be enabled");
         }
+    }
+
+    @Test
+    void shouldReturnUnprocessableWhenBackfillCreateOmitsBackfill() {
+        HttpClientResponseException e = assertThrows(
+            HttpClientResponseException.class, () -> client.toBlocking().retrieve(
+                HttpRequest.PUT(
+                    TRIGGER_PATH + "/backfill/create",
+                    Map.of(
+                        "namespace", "ns",
+                        "flowId", "flow",
+                        "triggerId", "trig"
+                    )
+                ),
+                ApiTriggerState.class
+            )
+        );
+
+        assertThat(e.getStatus().getCode()).isEqualTo(HttpStatus.UNPROCESSABLE_ENTITY.getCode());
     }
 
     @Test


### PR DESCRIPTION
## Summary

fix: return 422 when trigger backfill/create omits backfill

## Changes

- Guard createBackfill against a null request.backfill() (was NPE -> 500).
- Also require backfill.start before building CreateBackfillTrigger.Backfill.
- Document 422 on the OpenAPI annotation and add a controller test.

Fixes #18408
