### PR TITLE
fix(flows): deduplicate the flow editor's Add-a-trigger panel

### DIFF
--- a/ui/src/components/flows/MultiPanelFlowEditorView.vue
+++ b/ui/src/components/flows/MultiPanelFlowEditorView.vue
@@ -109,7 +109,7 @@
                     "triggers",
                     "items",
                 ].join("/")
-                actions.openAddTaskTab({panelIndex, tabIndex: 0}, "triggers", blockSchemaPath)
+                noCodeHandlers.onCreateTask({panelIndex, tabIndex: 0}, "triggers", blockSchemaPath)
             }
         }
     })
@@ -169,7 +169,7 @@
         }))
     }
 
-    const {panels, actions} = useNoCodePanelsFull({
+    const {panels, actions, noCodeHandlers} = useNoCodePanelsFull({
         RawNoCode,
         editorView,
         editorElements: EDITOR_ELEMENTS,

--- a/ui/src/components/flows/useNoCodePanels.ts
+++ b/ui/src/components/flows/useNoCodePanels.ts
@@ -178,7 +178,10 @@ export function setupInitialNoCodeTab(Comp: any, tab: string, handlers: Handlers
 
 export function useNoCodeHandlers(openTabs: Ref<string[]>, focusTab: (tab: string) => void, actions: ReturnType<typeof useNoCodePanels>) {
     const noCodeHandlers: Handlers = {
-        onCreateTask(opener, parentPath, blockSchemaPath, refPath, position){
+        onCreateTask(opener, parentPath, blockSchemaPath, refPath, position = "after"){
+            // Must match openAddTaskTab's own "after" default (below) exactly, or a caller that
+            // omits position (like the createTrigger route-query handler) computes a dedup key
+            // that never matches the tab actually created, and duplicates it every time.
             const createTabId = getCreateTabKey({
                 parentPath,
                 refPath,
@@ -361,6 +364,7 @@ export function useNoCodePanelsFull(options: {
 
     return {
         actions,
+        noCodeHandlers,
         openTabs,
         focusTab,
         panels,

--- a/ui/tests/unit/components/flows/useNoCodePanels.spec.ts
+++ b/ui/tests/unit/components/flows/useNoCodePanels.spec.ts
@@ -1,0 +1,58 @@
+import {ref} from "vue"
+import {describe, it, expect, vi} from "vitest"
+import {useNoCodeHandlers, getCreateTabKey} from "../../../../src/components/flows/useNoCodePanels"
+
+describe("useNoCodeHandlers.onCreateTask", () => {
+    it("focuses the existing create-tab instead of opening a duplicate on repeated calls", () => {
+        const openTabs = ref<string[]>([])
+        const focusTab = vi.fn()
+        let counter = 0
+        // Mirrors openAddTaskTab's own "after" default exactly - the mock must apply it
+        // independently, not just forward whatever it was given, or a mismatch between
+        // onCreateTask's dedup key and the tab actually created (like the one that shipped
+        // in #18321: the dedup check omitted the defaulted position) would go undetected.
+        const actions = {
+            openAddTaskTab: vi.fn((_opener, parentPath, blockSchemaPath, refPath, position = "after") => {
+                openTabs.value = [...openTabs.value, getCreateTabKey({parentPath, refPath, blockSchemaPath, position} as any, counter++)]
+            }),
+            openEditTaskTab: vi.fn(),
+        } as any
+
+        const handlers = useNoCodeHandlers(openTabs, focusTab, actions)
+        const opener = {panelIndex: 0, tabIndex: 0}
+
+        handlers.onCreateTask(opener, "triggers", "schema/path")
+        expect(actions.openAddTaskTab).toHaveBeenCalledTimes(1)
+        expect(openTabs.value).toHaveLength(1)
+
+        // Repeated call with the same parentPath/blockSchemaPath, and no explicit position
+        // (matching the createTrigger route-query handler's call), must focus the already-open
+        // tab instead of opening a duplicate.
+        handlers.onCreateTask(opener, "triggers", "schema/path")
+        expect(actions.openAddTaskTab).toHaveBeenCalledTimes(1)
+        expect(openTabs.value).toHaveLength(1)
+        expect(focusTab).toHaveBeenCalledWith(openTabs.value[0])
+    })
+
+    it("opens a distinct tab for a different parentPath", () => {
+        const openTabs = ref<string[]>([])
+        const focusTab = vi.fn()
+        let counter = 0
+        const actions = {
+            openAddTaskTab: vi.fn((_opener, parentPath, blockSchemaPath, refPath, position = "after") => {
+                openTabs.value = [...openTabs.value, getCreateTabKey({parentPath, refPath, blockSchemaPath, position} as any, counter++)]
+            }),
+            openEditTaskTab: vi.fn(),
+        } as any
+
+        const handlers = useNoCodeHandlers(openTabs, focusTab, actions)
+        const opener = {panelIndex: 0, tabIndex: 0}
+
+        handlers.onCreateTask(opener, "triggers", "schema/path")
+        handlers.onCreateTask(opener, "tasks", "schema/other-path")
+
+        expect(actions.openAddTaskTab).toHaveBeenCalledTimes(2)
+        expect(openTabs.value).toHaveLength(2)
+        expect(focusTab).not.toHaveBeenCalled()
+    })
+})


### PR DESCRIPTION
## Summary
- Clicking "Add a trigger" navigates with `?createTrigger=true`, and `MultiPanelFlowEditorView.vue`'s `onMounted` handled it by calling `actions.openAddTaskTab` directly — bypassing the dedup check `useNoCodeHandlers.onCreateTask` already provides for the same tab type from the no-code editor's own UI. Every click opened a fresh tab with a new cache-busted uid, and since panel state persists across full page reloads by design, stale tabs never went away either.
- Routing the call through `onCreateTask` surfaced a **second, latent bug**: its dedup-key computation didn't default `position` the same way `openAddTaskTab` does (`"after"`), so a caller omitting `position` (like this one) computed a key that never matched the tab actually created, duplicating it every time regardless. Both defaults now agree.

Closes #18321

## Scope
This fixes the concrete "duplicate on every click" defect the issue's repro demonstrates. The softer "panel state should reasonably reset across full page navigations" expectation is not addressed — panels still persist across reloads by design; they just no longer accumulate duplicates of the same action, which is what actually degrades the editor into "unusable slivers."

## QA
Live browser reproduction against a real local dev server, exact repro steps from the issue, plus a failing→passing unit test. Full writeup: https://claude.ai/code/artifact/af577f7a-0a8a-433f-b790-f81d4c48428f

## Test plan
- [x] New unit test `useNoCodeHandlers.onCreateTask`: repeated calls with the same parentPath/blockSchemaPath (position omitted, matching the createTrigger call site) focus the existing tab instead of duplicating
- [x] `npx vitest run --project=unit tests/unit/components/flows/useNoCodePanels.spec.ts` — 2/2 pass with both fixes, 1/2 fails without them (revert-and-rerun verified)
- [x] Live browser (Playwright against a real dev server): clicked "Add a trigger", reloaded, clicked again — 2 real tab elements confirmed via bounding boxes/localStorage without the fix, 1 with it restored
- [x] Broader flows/no-code Vitest suite (259 tests, 24 files) — unaffected