### PR TITLE
fix(system): let button icons inherit their button's text colour on the license bar

### DIFF
--- a/ui/src/components/admin/stats/Pricing.vue
+++ b/ui/src/components/admin/stats/Pricing.vue
@@ -55,10 +55,6 @@
             border-radius: 8px;
             background: var(--ks-bg-surface);
             box-shadow: 0px 1px 4px 0px var(--ks-shadow-element);
-
-            :deep(svg) {
-                color: var(--ks-icon-muted);
-            }
         }
 
         .edition {


### PR DESCRIPTION
### ✨ Description

The `.bar :deep(svg)` rule painted every icon in the license bar with `--ks-icon-muted`, including the one on the primary "Get a Demo" button, where it should match the white label.

Removing the rule lets each icon inherit its own button's text colour — muted on the secondary button, white on the primary. It also drops a `:deep()` selector, which `ui/AGENTS.md` disallows.

### 🔗 Related Issue

Closes https://github.com/kestra-io/kestra/issues/18449

### 🎨 Frontend Checklist

- [x] Code builds without errors (`npm run build`)
- [ ] All existing E2E tests pass (`npm run test:e2e`)