### PR TITLE
fix(executions): improve bulk by-ids API errors

### DIFF
--- a/webserver/src/main/java/io/kestra/webserver/controllers/api/ExecutionController.java
+++ b/webserver/src/main/java/io/kestra/webserver/controllers/api/ExecutionController.java
@@ -493,7 +493,7 @@ public class ExecutionController {
     @ExecuteOn(TaskExecutors.IO)
     @Operation(tags = { "Executions" }, summary = "Delete a list of executions")
     @ApiResponse(responseCode = "200", description = "On success", content = { @Content(schema = @Schema(implementation = BulkResponse.class)) })
-    @ApiResponse(responseCode = "422", description = "Deleted with errors", content = { @Content(schema = @Schema(implementation = BulkErrorResponse.class)) })
+    @ApiResponse(responseCode = "400", description = "Deleted with errors", content = { @Content(schema = @Schema(implementation = BulkErrorResponse.class)) })
     public MutableHttpResponse<?> deleteExecutionsByIds(
         @RequestBody(description = "The execution id") @Body List<String> executionsId,
         @Parameter(description = "Whether to delete non-terminated executions") @Nullable @QueryValue(defaultValue = "false") Boolean includeNonTerminated,
@@ -510,7 +510,7 @@ public class ExecutionController {
             } else {
                 invalids.add(
                     ManualConstraintViolation.of(
-                        "execution not found",
+                        execution.isEmpty() ? "execution not found" : "execution not in a deletable state",
                         executionId,
                         String.class,
                         "execution",

--- a/webserver/src/main/java/io/kestra/webserver/responses/BulkErrorResponse.java
+++ b/webserver/src/main/java/io/kestra/webserver/responses/BulkErrorResponse.java
@@ -1,5 +1,7 @@
 package io.kestra.webserver.responses;
 
+import java.util.Set;
+
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -12,5 +14,5 @@ public class BulkErrorResponse {
     @Schema(description = "The error message")
     String message;
     @Schema(description = "The list of items that failed validation")
-    Object invalids;
+    Set<?> invalids;
 }

--- a/webserver/src/test/java/io/kestra/webserver/controllers/api/ExecutionControllerRunnerTest.java
+++ b/webserver/src/test/java/io/kestra/webserver/controllers/api/ExecutionControllerRunnerTest.java
@@ -2230,6 +2230,29 @@ class ExecutionControllerRunnerTest {
     }
 
     @Test
+    @LoadFlows({ "flows/valids/sleep-long.yml" })
+    void shouldReturnTheCauseForEachInvalidExecutionWhenDeletingByIds() throws QueueException, JsonProcessingException {
+        Execution runningExecution = runnerUtils.runOneUntilRunning(TENANT_ID, TESTS_FLOW_NS, "sleep-long");
+
+        HttpClientResponseException exception = assertThrows(
+            HttpClientResponseException.class,
+            () -> client.toBlocking().exchange(
+                HttpRequest.DELETE("/api/v1/main/executions/by-ids", List.of(runningExecution.getId(), "not-found"))
+            )
+        );
+
+        assertThat(exception.getStatus().getCode()).isEqualTo(HttpStatus.BAD_REQUEST.getCode());
+        BulkErrorResponse errorResponse = exception.getResponse().getBody(BulkErrorResponse.class).orElseThrow();
+        assertThat(errorResponse.getMessage()).isEqualTo("invalid bulk delete");
+        assertThat(errorResponse.getInvalids()).hasSize(2);
+
+        var responseJson = JacksonMapper.ofJson().readTree(exception.getResponse().getBody(String.class).orElseThrow());
+        assertThat(responseJson.path("invalids").isArray()).isTrue();
+        assertThat(responseJson.path("invalids").findValuesAsText("message"))
+            .contains("execution not in a deletable state", "execution not found");
+    }
+
+    @Test
     @LoadFlowsWithTenant({ "flows/valids/minimal.yaml" })
     void deleteExecutionByQuery(String tenantId) throws TimeoutException, QueueException {
         when(tenantService.resolveTenant()).thenReturn(tenantId);
@@ -2538,7 +2561,7 @@ class ExecutionControllerRunnerTest {
             long afterException = System.currentTimeMillis();
             String errorMessage = "Duration before executions -> %d <-> duration after the exception -> %d <-> Error while pausing execution, err: %s, response: %s";
             String formatedError = String.format(
-                errorMessage, afterExec - start, afterException - start, e.getMessage(), e.getResponse().getBody(BulkErrorResponse.class).map(BulkErrorResponse::getInvalids).orElse("errors")
+                errorMessage, afterExec - start, afterException - start, e.getMessage(), e.getResponse().getBody(BulkErrorResponse.class).map(BulkErrorResponse::getInvalids).orElse(Set.of())
             );
             log.error("Error while pausing execution, err: {}, response: {}", e.getMessage(), e.getResponse().getBody(BulkErrorResponse.class).map(BulkErrorResponse::getInvalids), e);
             fail(formatedError);


### PR DESCRIPTION
### 🔗 Related Issue

Closes [[#14038](https://github.com/kestra-io/kestra/issues/14038)](https://github.com/kestra-io/kestra/issues/14038)

### ✨ Description

Improve bulk `by-ids` API error handling for execution deletion by documenting the actual HTTP `400` response, returning the correct validation cause for missing and non-deletable executions, and typing `BulkErrorResponse.invalids` as a set.

### 🛠️ Backend Checklist

* [x] Code changes are limited to the backend
* [x] Added a regression test for bulk delete validation errors
* [x] `git diff --check` passes
* [ ] Relevant Gradle tests pass locally

### 📝 Additional Notes

The targeted Gradle test could not start locally because the environment has Java 21 while the current project requires Java 25.

The official OpenAPI/SDK generation was also attempted but stopped at the Gradle OpenAPI generation step for the same Java 25 requirement.

The implementation was kept limited to the `by-ids` bulk error handling required by #14038. No generated SDK, YAML, frontend, dependency, or unrelated endpoint changes are included.