### PR TITLE
fix(namespaces): return 422 instead of 500 on a non-hierarchical path

### DIFF
--- a/webserver/src/main/java/io/kestra/webserver/controllers/api/NamespaceFileController.java
+++ b/webserver/src/main/java/io/kestra/webserver/controllers/api/NamespaceFileController.java
@@ -31,8 +31,10 @@ import io.micronaut.core.annotation.Nullable;
 import io.micronaut.data.model.Pageable;
 import io.micronaut.http.HttpHeaders;
 import io.micronaut.http.HttpResponse;
+import io.micronaut.http.HttpStatus;
 import io.micronaut.http.MediaType;
 import io.micronaut.http.annotation.*;
+import io.micronaut.http.exceptions.HttpStatusException;
 import io.micronaut.http.multipart.CompletedFileUpload;
 import io.micronaut.http.server.types.files.StreamedFile;
 import io.micronaut.scheduling.TaskExecutors;
@@ -379,6 +381,10 @@ public class NamespaceFileController {
     private void forbiddenPathsGuard(URI path) {
         if (path == null) {
             return;
+        }
+
+        if (path.getPath() == null) {
+            throw new HttpStatusException(HttpStatus.UNPROCESSABLE_ENTITY, "The path '%s' is not a valid hierarchical path.".formatted(path));
         }
 
         if (forbiddenPathPatterns.stream().anyMatch(pattern -> pattern.matcher(path.getPath()).matches())) {

--- a/webserver/src/test/java/io/kestra/webserver/controllers/api/NamespaceFileControllerTest.java
+++ b/webserver/src/test/java/io/kestra/webserver/controllers/api/NamespaceFileControllerTest.java
@@ -249,6 +249,26 @@ class NamespaceFileControllerTest {
     }
 
     @Test
+    void moveFileDirectoryWithOpaqueUriFromReturns422() {
+        String namespace = TestsUtils.randomNamespace();
+        HttpClientResponseException e = assertThrows(
+            HttpClientResponseException.class,
+            () -> client
+                .toBlocking()
+                .exchange(
+                    HttpRequest.PUT(
+                        "/api/v1/main/namespaces/" + namespace + "/files?from=a:b&to=/x.txt",
+                        null
+                    )
+                )
+        );
+
+        assertThat(e.getStatus().getCode())
+            .as("a non-hierarchical 'from' is a validation error, not an unhandled 500")
+            .isEqualTo(HttpStatus.UNPROCESSABLE_ENTITY.getCode());
+    }
+
+    @Test
     void createGetFileContent() throws IOException {
         String namespace = TestsUtils.randomNamespace();
         MultipartBody body = MultipartBody.builder()

--- a/webserver/src/test/java/io/kestra/webserver/controllers/api/NamespaceFileControllerTest.java
+++ b/webserver/src/test/java/io/kestra/webserver/controllers/api/NamespaceFileControllerTest.java
@@ -28,6 +28,7 @@ import io.kestra.plugin.core.flow.Subflow;
 import io.micronaut.core.annotation.Nullable;
 import io.micronaut.core.type.Argument;
 import io.micronaut.http.HttpRequest;
+import io.micronaut.http.HttpStatus;
 import io.micronaut.http.MediaType;
 import io.micronaut.http.client.annotation.Client;
 import io.micronaut.http.client.exceptions.HttpClientResponseException;
@@ -225,6 +226,26 @@ class NamespaceFileControllerTest {
                     )
                 )
         );
+    }
+
+    @Test
+    void createNamespaceDirectoryWithOpaqueUriPathReturns422() {
+        String namespace = TestsUtils.randomNamespace();
+        HttpClientResponseException e = assertThrows(
+            HttpClientResponseException.class,
+            () -> client
+                .toBlocking()
+                .exchange(
+                    HttpRequest.POST(
+                        "/api/v1/main/namespaces/" + namespace + "/files/directory?path=a:b",
+                        null
+                    )
+                )
+        );
+
+        assertThat(e.getStatus().getCode())
+            .as("a non-hierarchical path is a validation error, not an unhandled 500")
+            .isEqualTo(HttpStatus.UNPROCESSABLE_ENTITY.getCode());
     }
 
     @Test


### PR DESCRIPTION
## Summary
- `forbiddenPathsGuard` (shared by every namespace-file endpoint: create, list, move, directory) called `path.getPath()` unconditionally and fed it into `Pattern.matcher(...)`. For an opaque-shaped input like `a:b`, the resulting URI's path is null, and `Matcher.matches()` NPEs trying to read its length — caught only by the generic `Throwable` handler → 500.
- Added a null-path check that throws a proper 422 before the guard ever reaches the regex match.

Closes #18417
Closes #18407

## Scope
Fixing the shared guard covers create, list, move, and directory uniformly, matching the issue's own suggested fix — and directly benefits the sibling file-move issue (#18407), which hits the exact same guard via a different query param (`from=`). Added its own regression test to confirm.

## QA
Full writeup with before/after test logs: https://claude.ai/code/artifact/abf180bd-c7d0-4d5b-80d3-f2603c547a61

## Test plan
- [x] New test `createNamespaceDirectoryWithOpaqueUriPathReturns422`: the exact repro from #18417 (`path=a:b`) now returns 422
- [x] New test `moveFileDirectoryWithOpaqueUriFromReturns422`: the exact repro from #18407 (`from=a:b`) now returns 422
- [x] `./gradlew :webserver:test --tests io.kestra.webserver.controllers.api.NamespaceFileControllerTest` — 25/25 pass with the fix, exact reported NPE reproduced without it (revert-and-rerun verified)
