### PR TITLE
fix(ci): skip contributor onboarding for authors who already have write access

### DIFF
--- a/.github/workflows/welcome.yml
+++ b/.github/workflows/welcome.yml
@@ -11,7 +11,7 @@ permissions: {}
 
 jobs:
   welcome:
-    # author_association misses organization members with private membership, so the membership lookup below is the authoritative check.
+    # author_association misses organization members with private membership, so the permission lookup below is the authoritative check.
     if: ${{ github.event.pull_request.user.type != 'Bot' && !contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.pull_request.author_association) && (github.event.action == 'opened' || github.event.pull_request.merged) }}
     runs-on: ubuntu-latest
     steps:
@@ -24,27 +24,22 @@ jobs:
           owner: kestra-io
           repositories: kestra
 
-      - name: Check organization membership
-        id: membership
+      - name: Check the author's repository permission
+        id: permission
         uses: actions/github-script@v9
         with:
           github-token: ${{ steps.bot-token.outputs.token }}
           script: |
             const username = context.payload.pull_request.user.login;
-            try {
-              await github.rest.orgs.checkMembershipForUser({org: context.repo.owner, username});
-              core.info(`@${username} is a member of the ${context.repo.owner} organization. Exiting..`);
-              core.setOutput('is-member', 'true');
-            } catch (error) {
-              // 404 means the author is not an organization member.
-              if (error.status !== 404) {
-                throw error;
-              }
-              core.setOutput('is-member', 'false');
-            }
+            // The organization membership endpoint answers 404 for this repository-scoped token, which is
+            // indistinguishable from a genuine non-member, so read the author's repository permission instead:
+            // organization members inherit write access, outside contributors only ever get 'read'.
+            const {data} = await github.rest.repos.getCollaboratorPermissionLevel({...context.repo, username});
+            core.info(`@${username} has '${data.permission}' permission on ${context.repo.repo}.`);
+            core.setOutput('has-write-access', String(data.permission === 'admin' || data.permission === 'write'));
 
       - name: Welcome a first pull request
-        if: github.event.action == 'opened' && steps.membership.outputs.is-member == 'false'
+        if: github.event.action == 'opened' && steps.permission.outputs.has-write-access == 'false'
         uses: actions/github-script@v9
         env:
           # Kept out of the script itself: interpolated there, a backtick or ${ would break out and run as JS.
@@ -92,7 +87,7 @@ jobs:
             });
 
       - name: Congratulate on a first merged pull request
-        if: github.event.action == 'closed' && steps.membership.outputs.is-member == 'false'
+        if: github.event.action == 'closed' && steps.permission.outputs.has-write-access == 'false'
         uses: actions/github-script@v9
         env:
           # Kept out of the script itself for the same reason as above: a backtick or ${ interpolated there would break out and run as JS.


### PR DESCRIPTION
Related to https://github.com/kestra-io/kestra/pull/18349.

## What

The organization membership check added in https://github.com/kestra-io/kestra/pull/18349 never worked. The bot token is scoped to a single repository, so `GET /orgs/kestra-io/members/{username}` answers `404` for every author, and the step could not tell that apart from a genuine non-member:

```
GET /orgs/kestra-io/members/soyasis - 404
```

Every author was therefore classified as an outside contributor. https://github.com/kestra-io/kestra/pull/18569 got the "First PR merged 🎉" congratulation even though its author is an organization member with private membership; the welcome-on-open comment was skipped there only by luck, because the author had opened a `PR` before and the `pr_count` guard caught it.

This reads the author's repository permission instead of their organization membership:

- `GET /repos/{owner}/{repo}/collaborators/{username}/permission` only needs `metadata: read`, which the repository-scoped installation token already has - no new app permission to grant.
- It separates the two populations cleanly. Every `kestra-io` member resolves to `admin`, every outside contributor to `read`, verified against both current teammates and the last dozen external contributors to this repository.
- The call is no longer wrapped in a `catch`, so a token that cannot answer fails the workflow loudly instead of silently commenting on a teammate's `PR`.

The companion change for the `docs` repository is https://github.com/kestra-io/docs/pull/5414.

## Note on release branches

`pull_request_target` runs the workflow from the `PR`'s base branch, so `PR`s targeting `releases/v1.3.x` and `releases/v1.0.x` keep the broken filter until this is backported.
