### PR TITLE
fix(flows): return 422 instead of 500 when a bulk-import flow omits namespace

### DIFF
--- a/webserver/src/main/java/io/kestra/webserver/controllers/api/FlowController.java
+++ b/webserver/src/main/java/io/kestra/webserver/controllers/api/FlowController.java
@@ -280,22 +280,28 @@ public class FlowController {
         @Parameter(description = "Whether the query must match on word boundaries only") @QueryValue(defaultValue = "false") boolean wholeWord,
         @Parameter(description = "Whether the query is a regular expression rather than a literal string") @QueryValue(defaultValue = "false") boolean regex,
         @Parameter(description = "Restricts matches to a top-level section of the flow YAML") @QueryValue(defaultValue = "all") SourceSearchScope scope) throws HttpStatusException {
-        return PagedResults.of(sourceSearchService.search(
-            PageableUtils.from(page, size, sort),
-            tenantService.resolveTenant(),
-            namespace,
-            query,
-            caseSensitive,
-            wholeWord,
-            regex,
-            scope
-        ));
+        return PagedResults.of(
+            sourceSearchService.search(
+                PageableUtils.from(page, size, sort),
+                tenantService.resolveTenant(),
+                namespace,
+                query,
+                caseSensitive,
+                wholeWord,
+                regex,
+                scope
+            )
+        );
     }
 
     @ExecuteOn(TaskExecutors.IO)
     @Post(uri = "/source/replace/preview")
-    @Operation(tags = { "Flows" }, summary = "Preview a Source Search replace-all operation", description = "Computes the matched lines and their proposed replacement for every matching flow, without persisting anything.")
-    public SourceSearchReplacePreviewResponse previewReplaceBySourceCode(@RequestBody(description = "The search query and replacement") @Body @Valid SourceSearchReplacePreviewRequest request) {
+    @Operation(
+        tags = { "Flows" }, summary = "Preview a Source Search replace-all operation",
+        description = "Computes the matched lines and their proposed replacement for every matching flow, without persisting anything."
+    )
+    public SourceSearchReplacePreviewResponse previewReplaceBySourceCode(
+        @RequestBody(description = "The search query and replacement") @Body @Valid SourceSearchReplacePreviewRequest request) {
         return sourceSearchService.preview(
             tenantService.resolveTenant(),
             request.namespace(),
@@ -310,8 +316,12 @@ public class FlowController {
 
     @ExecuteOn(TaskExecutors.IO)
     @Post(uri = "/source/replace/apply")
-    @Operation(tags = { "Flows" }, summary = "Apply a Source Search replace-all operation", description = "Replaces every match in the given flows and persists the new revisions. Flows the caller is not allowed to edit are skipped.")
-    public SourceSearchReplaceApplyResponse applyReplaceBySourceCode(@RequestBody(description = "The search query, replacement and target flows") @Body @Valid SourceSearchReplaceApplyRequest request) throws QueueException {
+    @Operation(
+        tags = { "Flows" }, summary = "Apply a Source Search replace-all operation",
+        description = "Replaces every match in the given flows and persists the new revisions. Flows the caller is not allowed to edit are skipped."
+    )
+    public SourceSearchReplaceApplyResponse applyReplaceBySourceCode(
+        @RequestBody(description = "The search query, replacement and target flows") @Body @Valid SourceSearchReplaceApplyRequest request) throws QueueException {
         return sourceSearchService.apply(
             tenantService.resolveTenant(),
             request.query(),
@@ -326,8 +336,12 @@ public class FlowController {
 
     @ExecuteOn(TaskExecutors.IO)
     @Post(uri = "/source/replace/line")
-    @Operation(tags = { "Flows" }, summary = "Apply a Source Search replace on a single match line", description = "Replaces the matches on one line of one flow and persists the new revision. Returns the flow as skipped if it is not editable or fails validation.")
-    public SourceSearchReplaceApplyResponse replaceLineBySourceCode(@RequestBody(description = "The search query, replacement and target match line") @Body @Valid SourceSearchReplaceLineRequest request) throws QueueException {
+    @Operation(
+        tags = { "Flows" }, summary = "Apply a Source Search replace on a single match line",
+        description = "Replaces the matches on one line of one flow and persists the new revision. Returns the flow as skipped if it is not editable or fails validation."
+    )
+    public SourceSearchReplaceApplyResponse replaceLineBySourceCode(
+        @RequestBody(description = "The search query, replacement and target match line") @Body @Valid SourceSearchReplaceLineRequest request) throws QueueException {
         return sourceSearchService.applyLine(
             tenantService.resolveTenant(),
             request.query(),
@@ -462,10 +476,15 @@ public class FlowController {
             // control namespace to update
             Set<ManualConstraintViolation<GenericFlow>> invalids = flows
                 .stream()
-                .filter(flow -> !flow.getNamespace().equals(namespace) && (!flow.getNamespace().startsWith(namespace) || !allowNamespaceChild))
+                .filter(
+                    flow -> flow.getNamespace() == null
+                        || (!flow.getNamespace().equals(namespace) && (!flow.getNamespace().startsWith(namespace) || !allowNamespaceChild))
+                )
                 .map(
                     flow -> ManualConstraintViolation.of(
-                        String.format("%s - flow namespace is invalid", flow.uid()),
+                        flow.getNamespace() == null
+                            ? String.format("%s - flow namespace is required", flow.getId())
+                            : String.format("%s - flow namespace is invalid", flow.uid()),
                         flow,
                         GenericFlow.class,
                         "flow.namespace",
@@ -793,7 +812,6 @@ public class FlowController {
         }
         return validateConstraintViolationBuilder.build();
     }
-
 
     @ExecuteOn(TaskExecutors.IO)
     @Get(uri = "/export/by-query", produces = MediaType.APPLICATION_OCTET_STREAM)

--- a/webserver/src/test/java/io/kestra/webserver/controllers/api/FlowControllerTest.java
+++ b/webserver/src/test/java/io/kestra/webserver/controllers/api/FlowControllerTest.java
@@ -9,8 +9,6 @@ import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.time.Duration;
-import java.time.ZonedDateTime;
 import java.util.*;
 import java.util.zip.ZipFile;
 
@@ -18,12 +16,10 @@ import org.hamcrest.Matchers;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.slf4j.event.Level;
 
 import com.google.common.collect.ImmutableList;
 
 import io.kestra.core.Helpers;
-import io.kestra.core.junit.annotations.FlakyTest;
 import io.kestra.core.junit.annotations.KestraTest;
 import io.kestra.core.models.Label;
 import io.kestra.core.models.flows.*;
@@ -54,7 +50,6 @@ import io.kestra.webserver.models.flows.SourceSearchReplacePreviewResponse;
 import io.kestra.webserver.models.flows.SourceSearchResult;
 import io.kestra.webserver.responses.BulkResponse;
 import io.kestra.webserver.responses.PagedResults;
-import io.kestra.webserver.utils.RequestUtils;
 
 import io.micronaut.core.type.Argument;
 import io.micronaut.http.*;
@@ -263,9 +258,11 @@ class FlowControllerTest {
 
     @Test
     void shouldReturnBadRequestForInvalidRegexQuery() {
-        assertThatThrownBy(() -> client.toBlocking().retrieve(
-            HttpRequest.GET(FLOW_PATH + "/source?q=" + URLEncoder.encode("concurrency:(\\s*limit:", StandardCharsets.UTF_8) + "&regex=true")
-        ))
+        assertThatThrownBy(
+            () -> client.toBlocking().retrieve(
+                HttpRequest.GET(FLOW_PATH + "/source?q=" + URLEncoder.encode("concurrency:(\\s*limit:", StandardCharsets.UTF_8) + "&regex=true")
+            )
+        )
             .isInstanceOf(HttpClientResponseException.class)
             .satisfies(e -> assertThat(((HttpClientResponseException) e).getStatus().getCode()).isEqualTo(HttpStatus.BAD_REQUEST.getCode()));
     }
@@ -312,9 +309,11 @@ class FlowControllerTest {
         String namespace = "io.kestra.sourcesearch.badbackref.preview";
         createSourceSearchFlow(namespace, "badbackref-flow", "aaa");
 
-        assertThatThrownBy(() -> client.toBlocking().retrieve(
-            HttpRequest.POST(FLOW_PATH + "/source/replace/preview", new SourceSearchReplacePreviewRequest("(a)", false, false, true, namespace, null, "$9"))
-        ))
+        assertThatThrownBy(
+            () -> client.toBlocking().retrieve(
+                HttpRequest.POST(FLOW_PATH + "/source/replace/preview", new SourceSearchReplacePreviewRequest("(a)", false, false, true, namespace, null, "$9"))
+            )
+        )
             .isInstanceOf(HttpClientResponseException.class)
             .satisfies(e -> assertThat(((HttpClientResponseException) e).getStatus().getCode()).isEqualTo(HttpStatus.BAD_REQUEST.getCode()));
     }
@@ -325,12 +324,14 @@ class FlowControllerTest {
         String id = "badbackref-flow";
         createSourceSearchFlow(namespace, id, "aaa");
 
-        assertThatThrownBy(() -> client.toBlocking().retrieve(
-            HttpRequest.POST(
-                FLOW_PATH + "/source/replace/apply",
-                new SourceSearchReplaceApplyRequest("(a)", false, false, true, null, "$9", List.of(new IdWithNamespace(namespace, id)))
+        assertThatThrownBy(
+            () -> client.toBlocking().retrieve(
+                HttpRequest.POST(
+                    FLOW_PATH + "/source/replace/apply",
+                    new SourceSearchReplaceApplyRequest("(a)", false, false, true, null, "$9", List.of(new IdWithNamespace(namespace, id)))
+                )
             )
-        ))
+        )
             .isInstanceOf(HttpClientResponseException.class)
             .satisfies(e -> assertThat(((HttpClientResponseException) e).getStatus().getCode()).isEqualTo(HttpStatus.BAD_REQUEST.getCode()));
     }
@@ -341,12 +342,14 @@ class FlowControllerTest {
         String id = "badbackref-flow";
         createSourceSearchFlow(namespace, id, "aaa");
 
-        assertThatThrownBy(() -> client.toBlocking().retrieve(
-            HttpRequest.POST(
-                FLOW_PATH + "/source/replace/line",
-                new SourceSearchReplaceLineRequest("(a)", false, false, true, "$9", namespace, id, 3, 13)
+        assertThatThrownBy(
+            () -> client.toBlocking().retrieve(
+                HttpRequest.POST(
+                    FLOW_PATH + "/source/replace/line",
+                    new SourceSearchReplaceLineRequest("(a)", false, false, true, "$9", namespace, id, 3, 13)
+                )
             )
-        ))
+        )
             .isInstanceOf(HttpClientResponseException.class)
             .satisfies(e -> assertThat(((HttpClientResponseException) e).getStatus().getCode()).isEqualTo(HttpStatus.BAD_REQUEST.getCode()));
     }
@@ -572,6 +575,29 @@ class FlowControllerTest {
         );
 
         assertTrue(exception.getMessage().contains("flow namespace is invalid"));
+    }
+
+    @Test
+    void updateFlowsInNamespaceWithMissingNamespaceReturns422() {
+        String flowWithoutNamespace = """
+            id: crashflow
+            tasks:
+              - id: t
+                type: io.kestra.plugin.core.log.Log
+                message: hi
+            """;
+
+        HttpClientResponseException exception = assertThrows(
+            HttpClientResponseException.class, () -> client.toBlocking().exchange(
+                HttpRequest.POST("/api/v1/main/flows/io.kestra.updatenamespace", flowWithoutNamespace)
+                    .contentType(MediaType.APPLICATION_YAML_TYPE)
+            )
+        );
+
+        assertThat(exception.getStatus().getCode())
+            .as("a missing namespace is a validation error, not an unhandled 500")
+            .isEqualTo(HttpStatus.UNPROCESSABLE_ENTITY.getCode());
+        assertTrue(exception.getMessage().contains("flow namespace is required"));
     }
 
     @Test


### PR DESCRIPTION
## Summary
- `bulkUpdateOrCreate`'s namespace-mismatch check called `flow.getNamespace().equals(namespace)` unconditionally. A flow source with no `namespace:` field returns `getNamespace() == null`, so the `.equals()` call NPEs and falls through to the generic `Throwable` handler as a 500.
- Treats a null namespace as invalid up front, alongside the existing mismatched-namespace check, so it surfaces as the same 422 `ConstraintViolationException` instead.

Closes #18359

## Scope
The issue also flags the same endpoint's default behavior of deleting flows missing from the payload as a footgun. Left unchanged: it's already an explicit, opt-out `delete` query param (documented in both bulk-import endpoints' `@Operation` description), not an undocumented default — changing that default is a separate product decision, out of scope for this crash fix.

## QA
Full writeup with before/after test logs: https://claude.ai/code/artifact/caa78e7e-4303-4b9d-9187-939ac3502542

## Test plan
- [x] New test `updateFlowsInNamespaceWithMissingNamespaceReturns422`: the exact repro from the issue (source with no `namespace:` line) now returns 422
- [x] `./gradlew :webserver:test --tests io.kestra.webserver.controllers.api.FlowControllerTest` (targeted namespace-import tests) pass with the fix, exact reported NPE reproduced without it (revert-and-rerun verified)