### PR TITLE
fix(triggers): bound the Schedule when-condition tick walk to prevent a scheduler CPU pin

### DIFF
--- a/core/src/main/java/io/kestra/plugin/core/trigger/Schedule.java
+++ b/core/src/main/java/io/kestra/plugin/core/trigger/Schedule.java
@@ -183,6 +183,11 @@ public class Schedule extends AbstractTrigger implements Schedulable, TriggerOut
     private static final CronParser CRON_PARSER = new CronParser(CRON_DEFINITION_BUILDER.instance());
     private static final CronParser CRON_PARSER_WITH_SECONDS = new CronParser(CRON_DEFINITION_BUILDER.withSeconds().withValidRange(0, 59).withStrictRange().and().instance());
 
+    // Caps the when-condition tick walk below so a frequent cron (e.g. per-second) paired with a
+    // rarely-matching `when` can't pin the scheduling-loop thread rendering millions of ticks
+    // synchronously. 10 years of even a daily cron (~3650 ticks) stays well under this.
+    private static final int MAX_WHEN_CONDITION_ITERATIONS = 10_000;
+
     @NotNull
     @Schema(
         title = "The cron expression.",
@@ -486,13 +491,14 @@ public class Schedule extends AbstractTrigger implements Schedulable, TriggerOut
 
     /**
      * Walks forward from {@code fromDate} through successive cron executions and returns the
-     * first one where all schedule conditions match. Gives up after 10 years of lookahead.
+     * first one where all schedule conditions match. Gives up after 10 years of lookahead, or
+     * {@value #MAX_WHEN_CONDITION_ITERATIONS} ticks, whichever comes first.
      */
     @VisibleForTesting
     Optional<ZonedDateTime> findNextDateMatchingConditions(ExecutionTime executionTime, ConditionContext conditionContext, ZonedDateTime fromDate) throws InternalException {
         int upperYearBound = SchedulerClock.now().getYear() + 10;
 
-        while (fromDate.getYear() < upperYearBound) {
+        for (int iteration = 0; fromDate.getYear() < upperYearBound && iteration < MAX_WHEN_CONDITION_ITERATIONS; iteration++) {
             Optional<ZonedDateTime> candidate = executionTime.nextExecution(fromDate);
             if (candidate.isEmpty()) {
                 return candidate;
@@ -515,13 +521,14 @@ public class Schedule extends AbstractTrigger implements Schedulable, TriggerOut
 
     /**
      * Walks backward from {@code fromDate} through preceding cron executions and returns the
-     * first one where all schedule conditions match. Gives up after 10 years of lookback.
+     * first one where all schedule conditions match. Gives up after 10 years of lookback, or
+     * {@value #MAX_WHEN_CONDITION_ITERATIONS} ticks, whichever comes first.
      */
     @VisibleForTesting
     Optional<ZonedDateTime> findPreviousDateMatchingConditions(ExecutionTime executionTime, ConditionContext conditionContext, ZonedDateTime fromDate) throws InternalException {
         int lowerYearBound = SchedulerClock.now().getYear() - 10;
 
-        while (fromDate.getYear() > lowerYearBound) {
+        for (int iteration = 0; fromDate.getYear() > lowerYearBound && iteration < MAX_WHEN_CONDITION_ITERATIONS; iteration++) {
             Optional<ZonedDateTime> candidate = executionTime.lastExecution(fromDate);
             if (candidate.isEmpty()) {
                 return candidate;

--- a/core/src/test/java/io/kestra/plugin/core/trigger/ScheduleTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/trigger/ScheduleTest.java
@@ -373,6 +373,30 @@ class ScheduleTest {
     }
 
     @Test
+    void neverMatchingWhenOnFrequentCronDoesNotHangTheEvaluation() throws Exception {
+        Schedule trigger = Schedule.builder()
+            .id("schedule")
+            .type(Schedule.class.getName())
+            .cron("* * * * * *")
+            .withSeconds(true)
+            .when("{{ false }}")
+            .build();
+
+        long start = System.nanoTime();
+        Optional<ZonedDateTime> next = trigger.findNextDateMatchingConditions(
+            trigger.executionTime(),
+            conditionContext(trigger),
+            ZonedDateTime.now()
+        );
+        long elapsed = Duration.ofNanos(System.nanoTime() - start).toSeconds();
+
+        assertThat(next).isEmpty();
+        assertThat(elapsed)
+            .as("the tick walk must be bounded by an iteration cap, not just a 10-year lookahead")
+            .isLessThan(10);
+    }
+
+    @Test
     void lateMaximumDelay() {
         Schedule trigger = Schedule.builder()
             .id("schedule").type(Schedule.class.getName())


### PR DESCRIPTION
## Summary
- `findNextDateMatchingConditions`/`findPreviousDateMatchingConditions` walked forward/backward one cron tick at a time, rendering the `when` condition at each step, bounded only by a 10-year lookahead. A frequent cron (e.g. `withSeconds: true` with `"* * * * * *"`) paired with a rarely-matching `when` could run up to ~315 million iterations synchronously on the scheduling-loop thread, pinning it and stalling every other schedule trigger sharing that loop.
- Adds a `MAX_WHEN_CONDITION_ITERATIONS` cap (10,000) alongside the existing year bound, applied to both the forward and backward walk.

Closes #18413

## Scope
10,000 iterations comfortably covers every legitimate case (e.g. "first Monday of the month" needs at most a handful of weekly ticks, even over the full 10-year lookahead) while capping the pathological sub-minute-cron case. Evaluating `when` at fire time instead of by walking every tick, as the issue also suggests, would be a larger behavioral change to how `next`/`previous` outputs are computed — left out of this fix to keep it surgical.

## QA
Full writeup with before/after test logs: https://claude.ai/code/artifact/584904f3-c41e-466d-8a04-ed04063161f7

## Test plan
- [x] New test `neverMatchingWhenOnFrequentCronDoesNotHangTheEvaluation`: the exact repro from the issue (per-second cron, always-false `when`) now returns in well under a second
- [x] `./gradlew :core:test --tests io.kestra.plugin.core.trigger.ScheduleTest` — 23/23 pass with the fix
- [x] Confirmed via revert-and-rerun that the new test catches the vulnerability: with the iteration cap removed, the same test doesn't complete within 45 seconds (killed via `timeout`)