### PR TITLE
fix(design-system): reject unsafe URL schemes in KsMarkdown links and images

### DIFF
--- a/ui/packages/design-system/src/components/Data/KsMarkdown/KsMarkdown.vue
+++ b/ui/packages/design-system/src/components/Data/KsMarkdown/KsMarkdown.vue
@@ -93,6 +93,26 @@
         }
     }
 
+    // Markdown-native links and images never go through the raw-HTML `xss` whitelist below,
+    // so their URL needs its own scheme allowlist — otherwise `[x](javascript:…)` renders as a
+    // live anchor and executes in the viewer's session (stored XSS).
+    const ALLOWED_URL_SCHEMES = ["http:", "https:", "mailto:", "tel:", "ftp:"]
+
+    function sanitizeUrl(url: unknown): string | undefined {
+        if (typeof url !== "string") return undefined
+
+        const value = url.trim()
+        if (!value) return undefined
+
+        // Whitespace and control characters are dropped before the scheme is matched, so that
+        // neither "java\tscript:" nor a newline-split scheme can smuggle a rejected scheme through.
+        const compacted = Array.from(value).filter((char) => char.charCodeAt(0) > 0x20).join("")
+        const scheme = compacted.match(/^([a-z][a-z0-9+.-]*):/i)
+        if (!scheme) return value // relative URL, fragment or query-only link
+
+        return ALLOWED_URL_SCHEMES.includes(scheme[1].toLowerCase() + ":") ? value : undefined
+    }
+
     function htmlEscape(content: string): string {
         return xss(content, {
             whiteList: {
@@ -287,7 +307,7 @@
         }
 
         case "link": {
-            const url = node.url as string
+            const url = sanitizeUrl(node.url)
             if (props.components?.a) {
                 return h(props.components.a as any, {
                     href: url,
@@ -296,7 +316,7 @@
                 }, {default: () => renderNodes(node.children)})
             }
 
-            const isExternal = url.startsWith("http://") || url.startsWith("https://")
+            const isExternal = url !== undefined && (url.startsWith("http://") || url.startsWith("https://"))
             return h("a", {
                 href: url,
                 title: node.title ?? undefined,
@@ -306,20 +326,22 @@
             }, renderNodes(node.children))
         }
 
-        case "image":
+        case "image": {
+            const src = sanitizeUrl(node.url)
             if (props.components?.img) {
                 return h(props.components.img as any, {
-                    src: node.url as string,
+                    src,
                     alt: (node.alt ?? "") as string,
                 })
             }
 
             return h("img", {
-                src: node.url as string,
+                src,
                 alt: (node.alt ?? "") as string,
                 title: node.title ?? undefined,
                 class: "ks-markdown__image",
             })
+        }
 
         case "strong":
             return h("strong", renderNodes(node.children))

--- a/ui/packages/design-system/tests/units/Data/KsMarkdown/KsMarkdown.test.ts
+++ b/ui/packages/design-system/tests/units/Data/KsMarkdown/KsMarkdown.test.ts
@@ -220,6 +220,62 @@ describe("KsMarkdown", () => {
         expect(link.attributes("target")).toBeUndefined()
     })
 
+    test("drops the href of a javascript: markdown link", () => {
+        const wrapper = mount(KsMarkdown, {
+            props: {content: "[Click here](javascript:alert(document.domain))"},
+            global: globalConfig,
+        })
+        const link = wrapper.find("a.ks-markdown__link")
+        expect(link.exists()).toBe(true)
+        expect(link.text()).toBe("Click here")
+        expect(link.attributes("href")).toBeUndefined()
+    })
+
+    test("drops the href of an obfuscated javascript: markdown link", () => {
+        const wrapper = mount(KsMarkdown, {
+            props: {content: "[Click here](<JaVa\tScRiPt:alert(1)>)"},
+            global: globalConfig,
+        })
+        const link = wrapper.find("a.ks-markdown__link")
+        expect(link.exists()).toBe(true)
+        expect(link.attributes("href")).toBeUndefined()
+    })
+
+    test("drops the href of a data: markdown link", () => {
+        const wrapper = mount(KsMarkdown, {
+            props: {content: "[Click here](data:text/html;base64,PHNjcmlwdD5hbGVydCgxKTwvc2NyaXB0Pg==)"},
+            global: globalConfig,
+        })
+        expect(wrapper.find("a.ks-markdown__link").attributes("href")).toBeUndefined()
+    })
+
+    test("keeps a mailto: link", () => {
+        const wrapper = mount(KsMarkdown, {
+            props: {content: "[Mail us](mailto:hello@kestra.io)"},
+            global: globalConfig,
+        })
+        expect(wrapper.find("a.ks-markdown__link").attributes("href")).toBe("mailto:hello@kestra.io")
+    })
+
+    test("keeps an anchor-only link", () => {
+        const wrapper = mount(KsMarkdown, {
+            props: {content: "[Section](#my-title)"},
+            global: globalConfig,
+        })
+        expect(wrapper.find("a.ks-markdown__link").attributes("href")).toBe("#my-title")
+    })
+
+    test("drops the src of a javascript: markdown image", () => {
+        const wrapper = mount(KsMarkdown, {
+            props: {content: "![oops](javascript:alert(document.domain))"},
+            global: globalConfig,
+        })
+        const img = wrapper.find("img.ks-markdown__image")
+        expect(img.exists()).toBe(true)
+        expect(img.attributes("src")).toBeUndefined()
+        expect(img.attributes("alt")).toBe("oops")
+    })
+
     test("renders thematic break", () => {
         const wrapper = mount(KsMarkdown, {
             props: {content: "---"},


### PR DESCRIPTION
### 🔗 Related Issue

Closes https://github.com/kestra-io/kestra-ee/issues/10245.

### ✨ Description

`KsMarkdown` rendered Markdown-native links and images straight from the AST, so only raw-HTML nodes went through the `xss` whitelist — `[x](javascript:…)` became a live anchor and executed in the viewer's session (stored XSS in EE case descriptions and comments). Link `href` and image `src` now pass a scheme allowlist (http, https, mailto, tel, ftp); relative URLs and fragments are kept, everything else is dropped so the anchor renders inert.

### 🎨 Frontend Checklist

- [x] Type checking passes (`vue-tsc --noEmit`, design-system)
- [x] Unit tests pass (6 new `KsMarkdown` cases; verified they fail without the fix)
- [x] Lint passes (`oxlint && eslint`)

Why don't cats play poker in the jungle? Too many cheetahs. 🐱


---
_Generated by [Claude Code](https://claude.ai/code/session_01UXaJwVEBi1MdcQLeiBWcva)_