### PR TITLE
build(deps): stop npm rewriting package-lock.json with spurious peer flags

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -405,6 +405,7 @@ This copies the gitignored `cli/src/main/resources/application-*.yml` files from
 - **A Gradle build fails with no visible cause:** run `./gradlew clean` and retry once. When it repeats, read the actual error instead of retrying again.
 - **Tests fail on connection errors:** the databases are not running. `docker compose -f docker-compose-ci.yml up -d`.
 - **The frontend build fails on dependency resolution:** check the Node and npm versions against `package.json` engines before touching anything else.
+- **`npm install` fails with `EBADENGINE`:** the UI workspaces require npm >= 11.7 and set `engine-strict=true`. Older npm mislabels the `sass`/`sass-embedded` platform binaries as peer dependencies and rewrites `package-lock.json` on every install. Install the pinned npm (`npm i -g npm@11.16.0`) or use the Node release named in `ui/.nvmrc`.
 - **The UI builds but the app never mounts:** module federation, so the cause is usually workspace resolution rather than the change itself. Verify against a running instance rather than against the dev server.
 - **Debug logging:** `--logging.level.io.kestra=DEBUG`.
 

--- a/ui/.npmrc
+++ b/ui/.npmrc
@@ -1,0 +1,3 @@
+# npm < 11.7 mislabels the platform binaries of sass/sass-embedded as peer deps and
+# rewrites package-lock.json on every install; engine-strict turns that into a clear error.
+engine-strict=true

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -106,6 +106,9 @@
                 "xss": "^1.0.15",
                 "yaml": "^2.9.0"
             },
+            "engines": {
+                "npm": ">=11.7.0"
+            },
             "optionalDependencies": {
                 "@esbuild/darwin-arm64": "^0.28.1",
                 "@esbuild/darwin-x64": "^0.28.1",

--- a/ui/package.json
+++ b/ui/package.json
@@ -4,6 +4,9 @@
     "private": true,
     "type": "module",
     "packageManager": "npm@11.16.0",
+    "engines": {
+        "npm": ">=11.7.0"
+    },
     "workspaces": [
         "packages/*"
     ],


### PR DESCRIPTION
### 🔗 Related Issue

None — reported directly, no issue filed.

### ✨ Description

`npm install` was rewriting `ui/package-lock.json` on every run, adding a batch of `"peer": true` entries that the next contributor silently reverted.

Vite 8 declares `sass` and `sass-embedded` as **optional peer dependencies**. npm below 11.7 propagates the peer flag from those nodes down onto their platform-specific binaries — all 13 `@parcel/watcher-*` and 20 `sass-embedded-*` packages — so the lockfile flip-flops depending on who installed last.

Measured against the current lockfile:

| npm | `ui/package-lock.json` |
|---|---|
| 10.9.7 | +33 lines, `"peer": true` 22 → 55 |
| 11.6.2 | +71 / −66, 22 → 60 |
| 11.7.0 and up (through 12.0.2) | clean |

Two things kept it alive:

- `packageManager: "npm@11.16.0"` is declared but npm does not self-enforce it — that field only takes effect under Corepack.
- `.nvmrc` says `24`, and Node 24 bundled npm **11.6.2** for much of its life. Following the repo's own instructions was enough to reproduce it.

CI never caught it, because `npm ci` does not write the lockfile.

**Fix:** declare the npm floor in `engines` and set `engine-strict=true` in a new `ui/.npmrc`, so an unsupported npm fails fast:

```
npm error code EBADENGINE
npm error notsup Required: {"npm":">=11.7.0"}
npm error notsup Actual:   {"npm":"11.6.2","node":"v22.22.2"}
```

A `preinstall` guard does **not** work here — npm builds and saves the ideal tree *before* running `preinstall`, so the lockfile is already dirty by the time the guard fires (verified). `engine-strict` aborts during resolution and leaves the lockfile untouched.

The floor is `>=11.7.0` rather than the pinned `11.16.0` so Node 25 users (npm 11.12.1) are not forced to upgrade npm by hand.

### 🎨 Frontend Checklist

No source files change — this PR is npm configuration plus the resulting `engines` entry in the lockfile — so the type/build/test items below are not meaningful here and were not run:

- [ ] Type checking passes (`npm run check:types`) — n/a, no source changes
- [ ] Code builds without errors (`npm run build`) — n/a, no source changes
- [ ] Unit tests pass (`npm run test:unit`) — n/a, no source changes
- [x] Translations are complete — `npm run translations:check` reports no missing, extra, uncompilable, mismatched or untranslated keys (also confirms `npx`-based scripts still work under `engine-strict`)
- [ ] Screenshots — n/a, no UI changes

What was verified instead, being what this change could actually break:

- [x] `npm ci` succeeds under `engine-strict` — the CI path — 1452 packages, `patch-package` applies all 3 patches
- [x] `npm install` succeeds end-to-end and leaves `package-lock.json` clean
- [x] An unsupported npm now aborts with `EBADENGINE` **before** touching the lockfile
- [x] Lockfile resolution matrix re-run against npm 10.9.7, 11.6.2, 11.7.0, 11.9.0, 11.11.0, 11.12.1, 11.16.0, 11.17.0, 11.19.0 and 12.0.2 to locate the 11.7.0 boundary

### 📝 Additional Notes

Anyone currently on npm 10 or 11.6 will now get a hard `EBADENGINE` failure instead of silent lockfile churn. That is the intent, but it is a visible change for the team — worth a heads-up in the frontend channel when this merges. The remedy is in the error message itself and in the new `AGENTS.md` troubleshooting entry: `npm i -g npm@11.16.0`, or use the Node release named in `ui/.nvmrc`.

`packageManager` is left at `npm@11.16.0` — it still documents the intended version and works for anyone running Corepack.

### 🤖 AI Authors

Why did the cat refuse to leave the `package-lock.json`? She heard 33 `peer: true` entries had escaped and she was not about to let another one past her. 🐱

## Related PRs

- [kestra-io/kestra-ee#10402](https://github.com/kestra-io/kestra-ee/pull/10402) — companion PR applying the same change to `ui-ee/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SpELGqpHsm7AttLzFpdbMB