### PR TITLE
fix(core): shut down mcp keep-alive schedulers on context close

### DIFF
--- a/webserver/src/main/java/io/kestra/mcp/KestraFluxStreamableServerTransportProvider.java
+++ b/webserver/src/main/java/io/kestra/mcp/KestraFluxStreamableServerTransportProvider.java
@@ -83,7 +83,7 @@ public class KestraFluxStreamableServerTransportProvider implements McpStreamabl
                 .doFirst(() -> logger.debug("Initiating graceful shutdown with {} active sessions", mcpSessionService.listMcpStreamableServerSession().size()))
                 .flatMap(McpStreamableServerSession::closeGracefully)
                 .then();
-        }).then().doOnSuccess(v ->
+        }).then().doFinally(_ ->
         {
             mcpSessionService.clear();
             this.keepAliveScheduler.shutdown();

--- a/webserver/src/main/java/io/kestra/mcp/McpServerHandlerTransport.java
+++ b/webserver/src/main/java/io/kestra/mcp/McpServerHandlerTransport.java
@@ -1,5 +1,6 @@
 package io.kestra.mcp;
 
+import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -16,6 +17,7 @@ import io.micronaut.context.annotation.Requires;
 import io.modelcontextprotocol.server.McpAsyncServer;
 import io.modelcontextprotocol.server.McpServerFeatures;
 import io.modelcontextprotocol.spec.McpSchema;
+import jakarta.annotation.PreDestroy;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 import lombok.extern.slf4j.Slf4j;
@@ -26,6 +28,8 @@ import reactor.core.publisher.Mono;
 @Requires(beans = DispatchQueueInterface.class)
 @Slf4j
 public class McpServerHandlerTransport {
+    private static final Duration SHUTDOWN_TIMEOUT = Duration.ofSeconds(10);
+
     private final Map<HandlerKey, KestraFluxStreamableServerTransportProvider> handlers = new ConcurrentHashMap<>();
     private final Map<HandlerKey, McpAsyncServer> servers = new ConcurrentHashMap<>();
     private final McpErrorResponseMapper mcpErrorResponseMapper;
@@ -57,6 +61,22 @@ public class McpServerHandlerTransport {
             servers.put(handlerKey, buildServer(handlerKey, transportProvider));
             return transportProvider;
         });
+    }
+
+    /**
+     * Shuts down every server built by this registry when the application context closes.
+     * <p>
+     * Each {@link KestraFluxStreamableServerTransportProvider} starts a keep-alive scheduler in its
+     * constructor; without this hook those schedulers outlive the context and keep pinging dead
+     * sessions for the lifetime of the JVM, which is particularly visible in tests where many
+     * contexts are created in a single JVM.
+     */
+    @PreDestroy
+    public void close() {
+        Flux.fromIterable(Set.copyOf(handlers.keySet()))
+            .concatMap(key -> evictAndNotify(key.tenantId(), key.serverId()).onErrorComplete())
+            .then()
+            .block(SHUTDOWN_TIMEOUT);
     }
 
     public Mono<Void> refreshTools(String tenantId, String serverId) {

--- a/webserver/src/test/java/io/kestra/mcp/McpServerHandlerTransportTest.java
+++ b/webserver/src/test/java/io/kestra/mcp/McpServerHandlerTransportTest.java
@@ -1,0 +1,92 @@
+package io.kestra.mcp;
+
+import java.util.List;
+import java.util.UUID;
+
+import org.junit.jupiter.api.Test;
+
+import io.kestra.core.junit.annotations.KestraTest;
+import io.kestra.core.models.flows.Flow;
+import io.kestra.core.models.flows.GenericFlow;
+import io.kestra.core.models.property.Property;
+import io.kestra.core.repositories.FlowRepositoryInterface;
+import io.kestra.core.utils.IdUtils;
+import io.kestra.plugin.core.debug.Return;
+import io.kestra.plugin.core.trigger.McpToolTrigger;
+
+import jakarta.inject.Inject;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@KestraTest(environments = "h2")
+@io.micronaut.context.annotation.Property(name = "kestra.server-type", value = "WEBSERVER")
+class McpServerHandlerTransportTest {
+
+    @Inject
+    McpServerHandlerTransport mcpServerHandlerTransport;
+
+    @Inject
+    FlowRepositoryInterface flowRepository;
+
+    @Test
+    void shouldShutDownEveryBuiltServerWhenContextIsDestroyed() {
+        // Given — two servers built by the registry, each holding a keep-alive scheduler
+        String serverA = UUID.randomUUID().toString();
+        String serverB = UUID.randomUUID().toString();
+        flowRepository.create(GenericFlow.of(buildFlowWithMcpTrigger(serverA)));
+        flowRepository.create(GenericFlow.of(buildFlowWithMcpTrigger(serverB)));
+
+        mcpServerHandlerTransport.getServerHandler(contextFor(serverA));
+        mcpServerHandlerTransport.getServerHandler(contextFor(serverB));
+        assertThat(mcpServerHandlerTransport.listToolsForServer(null, serverA).collectList().block()).hasSize(1);
+        assertThat(mcpServerHandlerTransport.listToolsForServer(null, serverB).collectList().block()).hasSize(1);
+
+        // When — the context closes
+        mcpServerHandlerTransport.close();
+
+        // Then — no server is left behind, so no keep-alive scheduler outlives the context
+        assertThat(mcpServerHandlerTransport.listToolsForServer(null, serverA).collectList().block()).isEmpty();
+        assertThat(mcpServerHandlerTransport.listToolsForServer(null, serverB).collectList().block()).isEmpty();
+    }
+
+    @Test
+    void shouldCompleteWhenClosingWithoutAnyBuiltServer() {
+        // Given / When / Then — closing an untouched registry must not block or throw
+        mcpServerHandlerTransport.close();
+    }
+
+    private KestraMcpTransportContext contextFor(String serverId) {
+        return KestraMcpTransportContext.builder()
+            .tenantId(null)
+            .serverId(serverId)
+            .build();
+    }
+
+    private Flow buildFlowWithMcpTrigger(String serverId) {
+        return Flow.builder()
+            .id(IdUtils.create())
+            .namespace("io.kestra.mcp.shutdown")
+            .tasks(
+                List.of(
+                    Return.builder()
+                        .id("task")
+                        .type(Return.class.getName())
+                        .format(Property.ofValue("done"))
+                        .build()
+                )
+            )
+            .triggers(
+                List.of(
+                    McpToolTrigger.builder()
+                        .id("mcp-trigger")
+                        .type(McpToolTrigger.class.getName())
+                        .toolName("tool-" + IdUtils.create().toLowerCase())
+                        .title("Test Tool")
+                        .toolDescription("A test MCP tool")
+                        .mcpServer(serverId)
+                        .build()
+                )
+            )
+            .build();
+    }
+}


### PR DESCRIPTION
MCP servers were never shut down when the application context closed.

McpServerHandlerTransport lazily builds one KestraFluxStreamableServerTransportProvider per (tenantId, serverId), and each one starts a KeepAliveScheduler in its constructor. Only evictAndNotify — called when a server is deleted or disabled — ever stopped one. On a normal context shutdown the schedulers were left running.

Each leaked scheduler holds a Flux.interval on the shared boundedElastic pool and pings every session it can see every 30 seconds. Sessions that were initialised over POST but never opened an SSE stream reject the ping immediately, producing a steady stream of:

WARN boundedElastic-4 i.m.util.KeepAliveScheduler Failed to send keep-alive ping to
session McpStreamableServerSession@...: Stream unavailable for session <uuid>

In production this leaks a scheduler and the objects it retains per webserver restart within a JVM. It is most visible in tests, where many contexts are created in one JVM and the warnings continue for the rest of the run.

Two changes:

- McpServerHandlerTransport gets a @PreDestroy that evicts every built handler and server, bounded by a 10s block.
- KestraFluxStreamableServerTransportProvider.closeGracefully() releases the scheduler in doFinally instead of doOnSuccess, so an error while closing sessions cannot leave the interval running.