### PR TITLE
fix(jdbc): stop the parent execution when a subflow execution is killed

### DIFF
--- a/core/src/test/resources/flows/valids/subflow-kill-child-of-parent.yaml
+++ b/core/src/test/resources/flows/valids/subflow-kill-child-of-parent.yaml
@@ -1,0 +1,7 @@
+id: subflow-kill-child-of-parent
+namespace: io.kestra.tests
+
+tasks:
+  - id: sleep
+    type: io.kestra.plugin.core.flow.Sleep
+    duration: PT60S

--- a/core/src/test/resources/flows/valids/subflow-kill-child-parent.yaml
+++ b/core/src/test/resources/flows/valids/subflow-kill-child-parent.yaml
@@ -1,0 +1,13 @@
+id: subflow-kill-child-parent
+namespace: io.kestra.tests
+
+tasks:
+  - id: call_child
+    type: io.kestra.plugin.core.flow.Subflow
+    flowId: subflow-kill-child-of-parent
+    namespace: io.kestra.tests
+    wait: true
+    transmitFailed: true
+  - id: after
+    type: io.kestra.plugin.core.log.Log
+    message: Subflow was successful

--- a/jdbc/src/main/java/io/kestra/jdbc/runner/JdbcExecutor.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/runner/JdbcExecutor.java
@@ -982,6 +982,14 @@ public class JdbcExecutor implements ExecutorInterface {
                         newExecution = executionService.killParentTaskruns(taskRun, newExecution);
                     }
 
+                    // A killed subflow taskrun must also stop the parent execution, otherwise the executor
+                    // would still be RUNNING when computing next tasks and would schedule the successors.
+                    if (taskRun.getState().getCurrent() == State.Type.KILLED
+                        && newExecution.getState().getCurrent() != State.Type.KILLING
+                        && !newExecution.getState().isTerminated()) {
+                        newExecution = newExecution.withState(State.Type.KILLING);
+                    }
+
                     current = current.withExecution(newExecution, "joinSubflowExecutionResult");
 
                     // send metrics on parent taskRun terminated

--- a/jdbc/src/test/java/io/kestra/jdbc/runner/JdbcRunnerTest.java
+++ b/jdbc/src/test/java/io/kestra/jdbc/runner/JdbcRunnerTest.java
@@ -183,4 +183,30 @@ public abstract class JdbcRunnerTest extends AbstractRunnerTest {
     protected void forEachItemNoWait() throws Exception {
         forEachItemCaseTest.forEachItemNoWait("foreachitemnowait");
     }
+
+    @Test
+    @LoadFlows(
+        value = { "flows/valids/subflow-kill-child-parent.yaml",
+            "flows/valids/subflow-kill-child-of-parent.yaml" },
+        tenantId = "subflowkillchild"
+    )
+    void killSubflowExecutionStopsParent() throws Exception {
+        Execution parent = runnerUtils.runOneUntilRunning(
+            "subflowkillchild", NAMESPACE, "subflow-kill-child-parent", null, null, Duration.ofSeconds(30)
+        );
+        Execution child = runnerUtils.awaitFlowExecution(
+            e -> e.getState().isRunning(), "subflowkillchild", NAMESPACE, "subflow-kill-child-of-parent",
+            Duration.ofSeconds(30)
+        );
+
+        runnerUtils.killExecution(child);
+
+        Execution terminated = runnerUtils.awaitExecution(e -> e.getState().isTerminated(), parent);
+
+        assertThat(terminated.getState().getCurrent()).isEqualTo(State.Type.KILLED);
+        // the task following the killed subflow must never be scheduled
+        assertThat(terminated.getTaskRunList()).hasSize(1);
+        assertThat(terminated.getTaskRunList().getFirst().getTaskId()).isEqualTo("call_child");
+        assertThat(terminated.getTaskRunList().getFirst().getState().getCurrent()).isEqualTo(State.Type.KILLED);
+    }
 }


### PR DESCRIPTION
Killing a subflow's child execution left the parent `RUNNING` when the `KILLED` taskrun was joined, so `handleNext()` still scheduled the successor tasks — they ran to `SUCCESS` on an execution that then landed in `KILLED`.

The existing cascade can't catch this: it's guarded on `taskRun.getParentTaskRunId() != null`, and `killParentTaskruns` only walks up a taskrun tree, so a top-level `Subflow` task is never reached.

Fix: transition the execution to `KILLING` when a `KILLED` subflow taskrun is joined, so the existing `KILLING` guard in `ExecutorService.process()` engages before next tasks are computed. Keying on the taskrun state keeps it `transmitFailed`-aware — with `transmitFailed: false`, `guessState` returns `SUCCESS` and the branch never fires.

New test `JdbcRunnerTest.killSubflowExecutionStopsParent` fails on the unpatched branch and passes with the fix.

Paired EE PR (Kafka executor has its own copy of this join): kestra-io/kestra-ee#10416. Targets `releases/v1.3.x` only; 2.0 not addressed here.

Related: #12557
