### PR TITLE
fix(core): keep the context drawer panel in sync on window resize

### DIFF
--- a/ui/src/components/ContextDrawer.vue
+++ b/ui/src/components/ContextDrawer.vue
@@ -4,9 +4,9 @@
             class="drawerSplitter"
             :style="{width: `${maxDrawerWidth}px`}"
         >
-            <KsSplitterPanel class="drawerSpacerPanel" :min="0" />
+            <KsSplitterPanel class="drawerSpacerPanel" :min="0" :size="spacerWidth" />
 
-            <KsSplitterPanel v-model:size="drawerWidth" :min="MIN_DRAWER_WIDTH" :max="maxDrawerWidth">
+            <KsSplitterPanel v-model:size="drawerWidth" :min="MIN_DRAWER_WIDTH">
                 <div class="drawerContent">
                     <div v-if="showTabBar" class="tabBar">
                         <KsTabs
@@ -98,9 +98,11 @@
     const {width: windowWidth} = useWindowSize()
     const maxDrawerWidth = computed(() => windowWidth.value * 0.5)
 
+    const spacerWidth = computed(() => Math.max(maxDrawerWidth.value - drawerWidth.value, 0))
+
     watch(maxDrawerWidth, (value) => {
         drawerWidth.value = Math.min(Math.max(drawerWidth.value, MIN_DRAWER_WIDTH), value)
-    })
+    }, {immediate: true})
 
     function setActiveTab(tab: string) {
         if (tab) miscStore.lastContextTab = tab


### PR DESCRIPTION
closes https://github.com/kestra-io/kestra/issues/18462

This pull request makes improvements to the `ContextDrawer.vue` component to better handle the sizing and layout of the drawer panels, ensuring more consistent and responsive behavior.

**Drawer layout and sizing improvements:**

* The `spacerWidth` is now dynamically computed to ensure the spacer panel always fills the remaining space, improving drawer layout responsiveness. (`ui/src/components/ContextDrawer.vue`)
* The `drawerWidth` is now clamped to valid values immediately when `maxDrawerWidth` changes, preventing layout glitches. (`ui/src/components/ContextDrawer.vue`)
* The `KsSplitterPanel` for the drawer spacer now receives a dynamic `:size` prop, and the main drawer panel no longer has an explicit `:max` prop, relying instead on the computed logic. (`ui/src/components/ContextDrawer.vue`)