### PR TITLE
fix(flows): collapse the flow editor header on its own width, not the viewport

### DIFF
--- a/ui/src/components/MultiPanelEditorTabs.vue
+++ b/ui/src/components/MultiPanelEditorTabs.vue
@@ -1,5 +1,5 @@
 <template>
-    <div class="tabs-wrapper">
+    <div ref="wrapper" class="tabs-wrapper">
         <div v-if="!isMobile" class="tabs">
             <KsTooltip
                 v-for="element of tabs"
@@ -49,10 +49,11 @@
 </template>
 
 <script setup lang="ts">
+    import {computed, ref} from "vue"
     import {Tab} from "../utils/multiPanelTypes"
-    import {useMediaQuery} from "@vueuse/core"
     import ChevronDown from "vue-material-design-icons/ChevronDown.vue"
     import Check from "vue-material-design-icons/Check.vue"
+    import {EDITOR_HEADER_BREAKPOINTS, provideEditorHeaderWidth} from "../composables/useEditorHeaderWidth"
 
     defineProps<{
         tabs: Tab[],
@@ -63,7 +64,9 @@
         (e: "update:tabs", tabValue: string): void;
     }>()
 
-    const isMobile = useMediaQuery("(max-width: 768px)")
+    const wrapper = ref<HTMLElement>()
+    const headerWidth = provideEditorHeaderWidth(wrapper)
+    const isMobile = computed(() => headerWidth.value <= EDITOR_HEADER_BREAKPOINTS.tabsAsDropdown)
 
     function setTabValue(tabValue: string) {
         emit("update:tabs", tabValue)
@@ -72,6 +75,7 @@
 
 <style scoped lang="scss">
     .tabs-wrapper {
+        container: editor-header / inline-size;
         display: flex;
         align-items: center;
         justify-content: space-between;
@@ -135,7 +139,7 @@
         }
     }
 
-    @media (max-width: 1200px) {
+    @container editor-header (max-width: 950px) {
         .tabs .tab-label {
             display: none;
         }

--- a/ui/src/components/flows/FlowEditorStatCounter.vue
+++ b/ui/src/components/flows/FlowEditorStatCounter.vue
@@ -75,13 +75,13 @@
         color: var(--ks-icon-muted);
     }
 
-    @media (max-width: 1600px) {
+    @container editor-header (max-width: 1300px) {
         .stat-label {
             display: none;
         }
     }
 
-    @media (max-width: 1260px) {
+    @container editor-header (max-width: 1050px) {
         .stat-count {
             display: none;
         }

--- a/ui/src/composables/useEditorHeaderWidth.ts
+++ b/ui/src/composables/useEditorHeaderWidth.ts
@@ -1,0 +1,22 @@
+import {inject, provide, readonly, ref, type InjectionKey, type Ref} from "vue"
+import {useElementSize} from "@vueuse/core"
+
+const editorHeaderWidthKey = Symbol("editorHeaderWidth") as InjectionKey<Readonly<Ref<number>>>
+
+const UNCONSTRAINED = Number.POSITIVE_INFINITY
+
+export const EDITOR_HEADER_BREAKPOINTS = {
+    iconOnlyControls: 1000,
+    tabsAsDropdown: 500,
+} as const
+
+export function provideEditorHeaderWidth(element: Ref<HTMLElement | undefined>): Readonly<Ref<number>> {
+    const {width} = useElementSize(element, {width: UNCONSTRAINED, height: 0}, {box: "border-box"})
+    const shared = readonly(width)
+    provide(editorHeaderWidthKey, shared)
+    return shared
+}
+
+export function useEditorHeaderWidth(): Readonly<Ref<number>> {
+    return inject(editorHeaderWidthKey, ref(UNCONSTRAINED))
+}

--- a/ui/src/override/components/flows/FlowEditorStats.vue
+++ b/ui/src/override/components/flows/FlowEditorStats.vue
@@ -35,7 +35,6 @@
 <script setup lang="ts">
     import {computed, onUnmounted, watch} from "vue"
     import {useI18n} from "vue-i18n"
-    import {useMediaQuery} from "@vueuse/core"
 
     import History from "vue-material-design-icons/History.vue"
     import GraphOutline from "vue-material-design-icons/GraphOutline.vue"
@@ -44,8 +43,10 @@
     import {deferToIdle} from "../../../utils/deferToIdle"
     import ValidationError from "../../../components/flows/ValidationError.vue"
     import FlowEditorStatCounter from "../../../components/flows/FlowEditorStatCounter.vue"
+    import {EDITOR_HEADER_BREAKPOINTS, useEditorHeaderWidth} from "../../../composables/useEditorHeaderWidth"
 
-    const isNarrow = useMediaQuery("(max-width: 1260px)")
+    const headerWidth = useEditorHeaderWidth()
+    const isNarrow = computed(() => headerWidth.value <= EDITOR_HEADER_BREAKPOINTS.iconOnlyControls)
 
     const {t} = useI18n({useScope: "global"})
     const flowStore = useFlowStore()


### PR DESCRIPTION
closes https://github.com/kestra-io/kestra/issues/18374

This pull request refactors how responsive layouts are handled in the editor header and related components by replacing global media queries with container queries and a shared composable for header width. This change improves maintainability and ensures that layout changes are based on the actual container size rather than the viewport, making the UI more robust and adaptable to different embedding contexts.

Responsive layout improvements:

* Added a new composable, `useEditorHeaderWidth.ts`, which provides a shared, reactive header width via context, along with breakpoint constants for layout decisions. This enables components to react to the actual container size rather than relying on global media queries.
* Updated `MultiPanelEditorTabs.vue` and `FlowEditorStats.vue` to use the new header width composable and breakpoints, replacing previous usage of `useMediaQuery`. [[1]](diffhunk://#diff-e126039fca9c536ac982022f7563f0bd133cb0f488df47a33eea733a38a1c0aeR52-R56) [[2]](diffhunk://#diff-e126039fca9c536ac982022f7563f0bd133cb0f488df47a33eea733a38a1c0aeL66-R69) [[3]](diffhunk://#diff-2a0c51e55d1f81ab44d2d40ea81c3ca9d66764e151509826a787001655df2842L38) [[4]](diffhunk://#diff-2a0c51e55d1f81ab44d2d40ea81c3ca9d66764e151509826a787001655df2842R46-R49)

Migration to container queries:

* Replaced media queries with container queries in `MultiPanelEditorTabs.vue` and `FlowEditorStatCounter.vue`, so that tab labels and stat labels/counts hide based on the editor header's container width rather than the global window size. [[1]](diffhunk://#diff-e126039fca9c536ac982022f7563f0bd133cb0f488df47a33eea733a38a1c0aeR78) [[2]](diffhunk://#diff-e126039fca9c536ac982022f7563f0bd133cb0f488df47a33eea733a38a1c0aeL138-R142) [[3]](diffhunk://#diff-ae7bde177483b17aeca2832823b108c20827cfd48f5444dd0c3489a9efc63ee6L78-R84)

These changes collectively make the editor header and its child components more modular and responsive to their actual rendered environment.