### PR TITLE
fix(executor): do not resume a Pause twice when its pauseDuration expires after a manual resume

### DIFF
--- a/core/src/test/java/io/kestra/core/runners/AbstractRunnerTest.java
+++ b/core/src/test/java/io/kestra/core/runners/AbstractRunnerTest.java
@@ -416,6 +416,12 @@ public abstract class AbstractRunnerTest {
     }
 
     @Test
+    @LoadFlows(value = { "flows/valids/pause-duration-manual-resume.yaml" }, tenantId = "pause-manual-resume")
+    public void pauseRunDurationManuallyResumed() throws Exception {
+        pauseTest.runDurationManuallyResumed("pause-manual-resume", runnerUtils);
+    }
+
+    @Test
     @LoadFlows({ "flows/valids/pause-timeout.yaml" })
     public void pauseRunTimeout() throws Exception {
         pauseTest.runTimeout(runnerUtils);

--- a/core/src/test/java/io/kestra/plugin/core/flow/PauseTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/flow/PauseTest.java
@@ -17,6 +17,7 @@ import io.kestra.core.junit.annotations.ExecuteFlow;
 import io.kestra.core.junit.annotations.KestraTest;
 import io.kestra.core.junit.annotations.LoadFlows;
 import io.kestra.core.models.executions.Execution;
+import io.kestra.core.models.executions.TaskRun;
 import io.kestra.core.models.flows.Flow;
 import io.kestra.core.models.flows.State;
 import io.kestra.core.queues.QueueException;
@@ -217,6 +218,42 @@ public class PauseTest {
             assertThat(execution.getTaskRunList().getFirst().getState().getHistories().stream().filter(history -> history.getState() == State.Type.PAUSED).count()).isEqualTo(1L);
             assertThat(execution.getTaskRunList().getFirst().getState().getHistories().stream().filter(history -> history.getState() == State.Type.RUNNING).count()).isEqualTo(1L);
             assertThat(execution.getTaskRunList()).hasSize(2);
+        }
+
+        /**
+         * A Pause with a pauseDuration that is resumed manually must not be resumed a second time when
+         * its pauseDuration elapses while the execution is still running: the second resume carries no
+         * onResume inputs and would wipe those of the manual resume.
+         */
+        @SuppressWarnings("unchecked")
+        public void runDurationManuallyResumed(String tenantId, TestRunnerUtils runnerUtils) throws Exception {
+            Execution execution = runnerUtils.runOneUntilPaused(tenantId, "io.kestra.tests", "pause-duration-manual-resume", null, null, Duration.ofSeconds(30));
+            String executionId = execution.getId();
+            Flow flow = flowRepository.findByExecution(execution);
+
+            assertThat(execution.getState().getCurrent()).isEqualTo(State.Type.PAUSED);
+            assertThat(execution.getTaskRunList()).hasSize(1);
+
+            Execution resumed = executionService.resume(execution, flow, State.Type.RUNNING, Map.of("reason", "approved"), Pause.Resumed.now());
+
+            // the 'sleep' task outlives the PT1S pauseDuration, so the leftover delay expires while running
+            execution = runnerUtils.emitAndAwaitExecution(
+                e -> e.getId().equals(executionId) && e.getState().getCurrent() == State.Type.SUCCESS,
+                resumed,
+                Duration.ofSeconds(60)
+            );
+
+            assertThat(execution.getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
+            assertThat(execution.getTaskRunList()).hasSize(3);
+
+            // the Pause must have been resumed exactly once
+            TaskRun pause = execution.findTaskRunsByTaskId("pause").getFirst();
+            assertThat(pause.getState().getHistories().stream().filter(history -> history.getState() == State.Type.PAUSED).count()).isEqualTo(1L);
+            assertThat(pause.getState().getHistories().stream().filter(history -> history.getState() == State.Type.RUNNING).count()).isEqualTo(1L);
+
+            // and the onResume inputs of the manual resume must survive it
+            Map<String, Object> outputs = (Map<String, Object>) taskOutputService.getOutputs(execution.findTaskRunsByTaskId("last").getFirst()).get("values");
+            assertThat(outputs.get("reason")).isEqualTo("approved");
         }
 
         public void runParallelDelay(TestRunnerUtils runnerUtils) throws TimeoutException, QueueException {

--- a/core/src/test/resources/flows/valids/pause-duration-manual-resume.yaml
+++ b/core/src/test/resources/flows/valids/pause-duration-manual-resume.yaml
@@ -4,13 +4,13 @@ namespace: io.kestra.tests
 tasks:
   - id: pause
     type: io.kestra.plugin.core.flow.Pause
-    pauseDuration: PT1S
+    pauseDuration: PT5S
     onResume:
       - id: reason
         type: STRING
   - id: sleep
     type: io.kestra.plugin.core.flow.Sleep
-    duration: PT5S
+    duration: PT10S
   - id: last
     type: io.kestra.plugin.core.output.OutputValues
     values:

--- a/core/src/test/resources/flows/valids/pause-duration-manual-resume.yaml
+++ b/core/src/test/resources/flows/valids/pause-duration-manual-resume.yaml
@@ -1,0 +1,17 @@
+id: pause-duration-manual-resume
+namespace: io.kestra.tests
+
+tasks:
+  - id: pause
+    type: io.kestra.plugin.core.flow.Pause
+    pauseDuration: PT1S
+    onResume:
+      - id: reason
+        type: STRING
+  - id: sleep
+    type: io.kestra.plugin.core.flow.Sleep
+    duration: PT5S
+  - id: last
+    type: io.kestra.plugin.core.output.OutputValues
+    values:
+      reason: "{{ outputs.pause.onResume.reason }}"

--- a/executor/src/main/java/io/kestra/executor/DefaultExecutor.java
+++ b/executor/src/main/java/io/kestra/executor/DefaultExecutor.java
@@ -549,6 +549,20 @@ public class DefaultExecutor extends AbstractService implements Executor {
                                 executor = executor.withExecution(markAsExecution, "pausedRestart");
                             } else {
                                 // if there is a taskRun it means we restart a paused task
+                                // The delay is only removed when it expires, so a Pause that was already resumed
+                                // (manually via the API, or by a kill) still has a pending delay. Resuming it a
+                                // second time would re-generate the Pause outputs without the onResume inputs and
+                                // wipe them, so we skip the delay unless the task run is still paused.
+                                Optional<TaskRun> pausedTaskRun = execution.findTaskRunByTaskRunIdIfPresent(executionDelay.getTaskRunId());
+                                if (pausedTaskRun.isEmpty() || pausedTaskRun.get().getState().getCurrent() != State.Type.PAUSED) {
+                                    log.debug(
+                                        "Skipping the expired pause delay of the task run '{}' of the execution '{}': it is no longer paused.",
+                                        executionDelay.getTaskRunId(),
+                                        execution.getId()
+                                    );
+                                    return null;
+                                }
+
                                 FlowInterface flow = flowMetaStore.findByExecution(execution).orElseThrow();
                                 Execution markAsExecution = executionService.markAs(
                                     execution,

--- a/executor/src/main/java/io/kestra/executor/DefaultExecutor.java
+++ b/executor/src/main/java/io/kestra/executor/DefaultExecutor.java
@@ -43,6 +43,7 @@ import io.kestra.core.server.Metric;
 import io.kestra.core.server.ServiceStateChangeEvent;
 import io.kestra.core.server.ServiceType;
 import io.kestra.core.services.ExecutionService;
+import io.kestra.core.services.ExecutionService.ExecutionWithTaskRun;
 import io.kestra.core.services.MaintenanceService;
 import io.kestra.core.utils.*;
 import io.kestra.executor.configuration.ExecutorConfiguration;
@@ -553,7 +554,10 @@ public class DefaultExecutor extends AbstractService implements Executor {
                                 // (manually via the API, or by a kill) still has a pending delay. Resuming it a
                                 // second time would re-generate the Pause outputs without the onResume inputs and
                                 // wipe them, so we skip the delay unless the task run is still paused.
-                                Optional<TaskRun> pausedTaskRun = execution.findTaskRunByTaskRunIdIfPresent(executionDelay.getTaskRunId());
+                                // The task run is resolved the same way markAs() does below — it may live in a loop
+                                // sub-execution — so the guard cannot drop a delay and leave its task run paused forever.
+                                Optional<TaskRun> pausedTaskRun = executionService.findExecutionWithTaskRun(execution, executionDelay.getTaskRunId())
+                                    .map(ExecutionWithTaskRun::taskRun);
                                 if (pausedTaskRun.isEmpty() || pausedTaskRun.get().getState().getCurrent() != State.Type.PAUSED) {
                                     log.debug(
                                         "Skipping the expired pause delay of the task run '{}' of the execution '{}': it is no longer paused.",


### PR DESCRIPTION
Closes #18507

### What

The pause `ExecutionDelay` row is only removed when it expires — nothing deletes it when the Pause is resumed manually. When the execution outlives `pauseDuration`, `DefaultExecutor.executionDelayLoop()` resumed the Pause a **second** time: it only checked that the execution was not terminated/KILLING, never that the task run was still `PAUSED`. `executionService.markAs(..., RUNNING)` then re-generated the Pause outputs via `generateOutputs(onResumeInputs = null, ...)`, wiping the `onResume` inputs from the manual resume and failing every task referencing them.

This also affected `behavior: FAIL/WARN/CANCEL`, where a manually-resumed Pause would later be failed/cancelled by its own leftover timer.

### Fix

Skip an expired `RESUME_FLOW` delay whose task run is no longer `PAUSED`, returning `null` from the lock callback so nothing is persisted or emitted.

Chosen over deleting the delay on resume: `ExecutionDelayStateStore` has no delete API, and a delete-on-resume would still race the delay loop. This guard is idempotent regardless of ordering.

### Repro (before the fix, real instance)

```
--- t=5s  (after manual resume with reason=approved)
exec: RUNNING
   wait_for_approval SUCCESS outputs= {"onResume":{"reason":"approved"},"resumed":{"on":"...33:20","to":"SUCCESS"}}
--- t=15s (past the PT10S pauseDuration, the next task is still sleeping)
exec: RUNNING
   wait_for_approval SUCCESS outputs= {"resumed":{"on":"...33:27","to":"SUCCESS"}}   <- onResume gone
--- t=40s
exec: FAILED  (show: Unable to find `onResume`)
```

The `resumed.on` timestamp moving from the manual resume to the `pauseDuration` expiry confirms the double resume.

### Tests

Added `pauseRunDurationManuallyResumed` to `AbstractRunnerTest`/`PauseTest.Suite` with `flows/valids/pause-duration-manual-resume.yaml` (`Pause` PT1S with an `onResume` input → `Sleep` PT5S → a task reading `outputs.pause.onResume.reason`), so it runs on H2, Postgres and MySQL. It asserts the Pause has exactly one `PAUSED`/`RUNNING` history entry and that the `onResume` value survives.

- Without the fix it fails with the reported ``Unable to find `onResume` used in the expression `{{ outputs.pause.onResume.reason }}` ``.
- With the fix it passes, and the full `H2RunnerTest` (101 tests) plus `core PauseTest` stay green.

Also verified on a rebuilt local instance: the issue's flow now ends `SUCCESS` with `reason` preserved.

### EE

No EE-side change is needed: `kestra-ee` includes this `:executor` module and has no executor of its own, so the guard covers every backend. `ElasticSearchExecutionDelayStateStore` has the same delete-on-expiry-only semantics but feeds this same consumer.
