### PR TITLE
fix(flows): scope `flow export --namespace` to the given namespace

### DIFF
--- a/cli/src/main/java/io/kestra/cli/commands/flows/FlowExportCommand.java
+++ b/cli/src/main/java/io/kestra/cli/commands/flows/FlowExportCommand.java
@@ -1,5 +1,7 @@
 package io.kestra.cli.commands.flows;
 
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
@@ -40,7 +42,11 @@ public class FlowExportCommand extends AbstractApiCommand {
 
         try (DefaultHttpClient client = client()) {
             MutableHttpRequest<Object> request = HttpRequest
-                .GET(apiUri("/flows/export/by-query", tenantService.getTenantId(tenantId)) + (namespace != null ? "?namespace=" + namespace : ""))
+                // The endpoint only binds filters in the bracket format, so the flat `namespace=` param was never
+                // read and `--namespace` exported the whole tenant (kestra-io/kestra-ee#10394); PREFIX keeps the
+                // documented meaning of the option, the namespace and its children.
+                .GET(apiUri("/flows/export/by-query", tenantService.getTenantId(tenantId))
+                    + (namespace != null ? "?filters[namespace][PREFIX]=" + URLEncoder.encode(namespace, StandardCharsets.UTF_8) : ""))
                 .accept(MediaType.APPLICATION_OCTET_STREAM);
 
             HttpResponse<byte[]> response = client.toBlocking().exchange(this.requestOptions(request), byte[].class);

--- a/cli/src/test/java/io/kestra/cli/commands/flows/FlowExportCommandTest.java
+++ b/cli/src/test/java/io/kestra/cli/commands/flows/FlowExportCommandTest.java
@@ -25,7 +25,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 class FlowExportCommandTest {
     @Test
     void shouldExportOnlyTheRequestedNamespace(@TempDir Path exportDirectory) throws Exception {
-        // holds 3 flows in `io.kestra.cli` plus 1 in `io.kestra.outsider`, which must not be exported
+        // holds 3 flows in `io.kestra.cli`, 1 in the child namespace `io.kestra.cli.sub`, and 1 in the
+        // unrelated `io.kestra.outsider` which must not be exported
         URL directory = FlowExportCommandTest.class.getClassLoader().getResource("flows");
         ByteArrayOutputStream out = new ByteArrayOutputStream();
         System.setOut(new PrintStream(out));
@@ -53,11 +54,16 @@ class FlowExportCommandTest {
                     .as("the flows of the requested namespace are exported")
                     .contains("io.kestra.cli-first.yml", "io.kestra.cli-second.yml", "io.kestra.cli-third.yml");
 
-                // Other test classes sharing the H2 database may have added more `io.kestra.cli` flows, so
-                // only the namespace of every entry can be asserted, not the exact entry list.
+                assertThat(entries)
+                    .as("the child namespaces are exported too, as in the namespace-scoped flow list of the UI")
+                    .contains("io.kestra.cli.sub-child.yml");
+
+                // Other test classes sharing the H2 database may have added more `io.kestra.cli` flows, so only
+                // the namespace of every entry can be asserted, not the exact entry list. Entries are named
+                // `<namespace>-<id>.yml`, so the trailing `[-.]` keeps a sibling such as `io.kestra.clix` out.
                 assertThat(entries)
                     .as("--namespace filters the export instead of being silently ignored")
-                    .allSatisfy(entry -> assertThat(entry).startsWith("io.kestra.cli"));
+                    .allSatisfy(entry -> assertThat(entry).matches("io\\.kestra\\.cli[-.].*"));
             }
 
             // a namespace holding no flow exports an empty archive rather than the whole tenant

--- a/cli/src/test/java/io/kestra/cli/commands/flows/FlowExportCommandTest.java
+++ b/cli/src/test/java/io/kestra/cli/commands/flows/FlowExportCommandTest.java
@@ -1,13 +1,16 @@
 package io.kestra.cli.commands.flows;
 
 import java.io.ByteArrayOutputStream;
-import java.io.File;
 import java.io.PrintStream;
-import java.net.URISyntaxException;
 import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import io.kestra.core.migration.MigrationRunnerInterface;
 import io.kestra.core.repositories.LocalFlowRepositoryLoader;
@@ -21,8 +24,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 class FlowExportCommandTest {
     @Test
-    void run() throws Exception {
-        URL directory = FlowExportCommandTest.class.getClassLoader().getResource("flows/same");
+    void shouldExportOnlyTheRequestedNamespace(@TempDir Path exportDirectory) throws Exception {
+        // holds 3 flows in `io.kestra.cli` plus 1 in `io.kestra.outsider`, which must not be exported
+        URL directory = FlowExportCommandTest.class.getClassLoader().getResource("flows");
         ByteArrayOutputStream out = new ByteArrayOutputStream();
         System.setOut(new PrintStream(out));
 
@@ -37,28 +41,49 @@ class FlowExportCommandTest {
             flowRepositoryLoader.load(directory);
 
             // then we export them
-            String[] exportArgs = {
-                "--plugins",
-                "/tmp", // pass this arg because it can cause failure
-                "--server",
-                embeddedServer.getURL().toString(),
-                "--user",
-                "myuser:pass:word",
-                "--namespace",
-                "io.kestra.cli",
-                "/tmp",
-            };
-            PicocliRunner.call(FlowExportCommand.class, ctx, exportArgs);
-            File file = new File("/tmp/flows.zip");
-            assertThat(file.exists()).isTrue();
-            ZipFile zipFile = new ZipFile(file);
+            PicocliRunner.call(FlowExportCommand.class, ctx, exportArgs(embeddedServer, "io.kestra.cli", exportDirectory));
 
-            // When launching the test in a suite, there is 4 flows but when launching individually there is only 3
-            assertThat(zipFile.stream().count()).isGreaterThanOrEqualTo(3L);
+            Path zipFile = exportDirectory.resolve("flows.zip");
+            assertThat(zipFile).exists();
 
-            file.delete();
-        } catch (URISyntaxException e) {
-            throw new RuntimeException(e);
+            try (ZipFile zip = new ZipFile(zipFile.toFile())) {
+                List<String> entries = zip.stream().map(ZipEntry::getName).toList();
+
+                assertThat(entries)
+                    .as("the flows of the requested namespace are exported")
+                    .contains("io.kestra.cli-first.yml", "io.kestra.cli-second.yml", "io.kestra.cli-third.yml");
+
+                // Other test classes sharing the H2 database may have added more `io.kestra.cli` flows, so
+                // only the namespace of every entry can be asserted, not the exact entry list.
+                assertThat(entries)
+                    .as("--namespace filters the export instead of being silently ignored")
+                    .allSatisfy(entry -> assertThat(entry).startsWith("io.kestra.cli"));
+            }
+
+            // a namespace holding no flow exports an empty archive rather than the whole tenant
+            Path emptyExportDirectory = exportDirectory.resolve("empty");
+            Files.createDirectory(emptyExportDirectory);
+            PicocliRunner.call(FlowExportCommand.class, ctx, exportArgs(embeddedServer, "io.kestra.unknown", emptyExportDirectory));
+
+            try (ZipFile zip = new ZipFile(emptyExportDirectory.resolve("flows.zip").toFile())) {
+                assertThat(zip.stream().map(ZipEntry::getName))
+                    .as("an unknown namespace exports nothing")
+                    .isEmpty();
+            }
         }
+    }
+
+    private static String[] exportArgs(EmbeddedServer embeddedServer, String namespace, Path directory) {
+        return new String[]{
+            "--plugins",
+            "/tmp", // pass this arg because it can cause failure
+            "--server",
+            embeddedServer.getURL().toString(),
+            "--user",
+            "myuser:pass:word",
+            "--namespace",
+            namespace,
+            directory.toString(),
+        };
     }
 }

--- a/cli/src/test/resources/flows/child.yml
+++ b/cli/src/test/resources/flows/child.yml
@@ -1,0 +1,7 @@
+id: child
+namespace: io.kestra.cli.sub
+
+tasks:
+  - id: date
+    type: io.kestra.plugin.core.debug.Return
+    format: "{{taskrun.startDate}}"


### PR DESCRIPTION
### 🔗 Related Issue

Closes https://github.com/kestra-io/kestra-ee/issues/10394.

### ✨ Description

`flow export --namespace <ns>` exported every flow of the tenant instead of only that namespace.

The CLI sent the namespace as a flat `namespace=` param, which `/flows/export/by-query` never binds — it reads the bracket format only — so the query ran unfiltered. It now sends `filters[namespace][PREFIX]=`, which keeps the option's meaning: the namespace and its children.

The test loads flows in two namespaces and asserts only the requested one is exported; it fails on the parent commit. The old `>= 3` entry-count assertion passed with the whole tenant in the zip, which is why this went unnoticed.

### 🛠️ Backend Checklist

- [x] Code compiles and tests pass for the touched modules (`./gradlew :module-name:test`, or `./gradlew build` for cross-module changes)
- [x] New behavior is covered by unit or integration tests

### 📝 Additional Notes

`:cli:test` has two failures that are pre-existing on `develop`: `NoConfigCommandTest.shouldFailWithDeleteFlowCommandWithoutConfig` and `KvUpdateCommandTest` (flaky — a different method fails each run).

### 🤖 AI Authors

Why did the cat get a job at the export desk? It kept insisting every namespace was *its* namespace. 🐱
