### PR TITLE
fix(design-system): editor autocomplete plugin icons, state icons

### DIFF
--- a/ui/packages/design-system/src/components/Form/KsEditor.vue
+++ b/ui/packages/design-system/src/components/Form/KsEditor.vue
@@ -377,7 +377,7 @@
                 }
             }
 
-            .monaco-list-row[aria-label="_DATE_PICKER_"] {
+            .monaco-list-row[aria-label^="_DATE_PICKER_"] {
                 display: none;
             }
         }

--- a/ui/packages/design-system/src/composables/useSuggestWidgetIcons.ts
+++ b/ui/packages/design-system/src/composables/useSuggestWidgetIcons.ts
@@ -8,6 +8,13 @@ import type {TaskIconProps} from "./taskIcon"
 
 const KESTRA_ICON_WRAPPER_CLASS = "kestra-icon-wrapper"
 const SASH_DRAG_DISTANCE = 80
+const PLUGIN_FQCN = /^[a-z][\w$]*(?:\.[\w$]+)+$/
+
+// Monaco suffixes the row aria-label with ", <kind>" (and ", docs: …" once resolved), so read the rendered label.
+function suggestionLabel(row: HTMLElement): string | undefined {
+    const rendered = row.querySelector(".monaco-icon-name-container")?.textContent?.trim()
+    return rendered || row.getAttribute("aria-label")?.split(",")[0].trim()
+}
 
 type CodeEditor = monaco.editor.ICodeEditor
 
@@ -37,13 +44,13 @@ export function useSuggestWidgetIcons(ctx: SuggestWidgetIconsContext) {
 
     function replaceRowsIcons(nodes: HTMLElement[]) {
         for (const node of uniqBy(nodes, n => n.id)) {
-            const completionValue = node?.getAttribute("aria-label")
+            const completionValue = suggestionLabel(node)
             if (!completionValue || node.getAttribute("data-index") === null) continue
 
             const vsCodeIcon = node.querySelector(".suggest-icon") as HTMLElement
             node.querySelector(`.${KESTRA_ICON_WRAPPER_CLASS}`)?.remove()
 
-            if (completionValue.includes(".") && !completionValue.includes("{") && ctx.loadTaskIcon.value) {
+            if (PLUGIN_FQCN.test(completionValue) && ctx.loadTaskIcon.value) {
                 replaceRowIcon(vsCodeIcon, h(ctx.taskIcon, {
                     cls: completionValue,
                     onlyIcon: true,
@@ -89,10 +96,10 @@ export function useSuggestWidgetIcons(ctx: SuggestWidgetIconsContext) {
             })
 
             const addedRows = addedSuggestRows(mutations)
-            replaceRowsIcons(addedRows.filter(row => row.ariaLabel !== DATE_PICKER_SUGGESTION_LABEL))
+            replaceRowsIcons(addedRows.filter(row => suggestionLabel(row) !== DATE_PICKER_SUGGESTION_LABEL))
 
             addedRows.forEach(async row => {
-                if (!editor || row.ariaLabel !== DATE_PICKER_SUGGESTION_LABEL) return
+                if (!editor || suggestionLabel(row) !== DATE_PICKER_SUGGESTION_LABEL) return
                 ;(editor.getContribution("editor.contrib.suggestController") as unknown as {
                     cancelSuggestWidget: () => void
                 }).cancelSuggestWidget()


### PR DESCRIPTION
closes https://github.com/kestra-io/kestra/issues/18451

This pull request refines how suggestion icons are handled and filtered in the code editor's autocomplete widget, improving accuracy and maintainability. The main changes focus on better detection of plugin suggestions, more robust label extraction, and improved handling of date picker suggestions.

**Autocomplete Suggestion Handling Improvements:**

* Added the `suggestionLabel` function to reliably extract the rendered label from suggestion rows, handling Monaco's suffixes and ensuring accurate label matching.
* Updated all usages to use `suggestionLabel` instead of directly accessing `aria-label`, making label handling more robust in `replaceRowsIcons` and related filtering logic. [[1]](diffhunk://#diff-72bd19fb9fa81e535851e59fbac288f27b48fad67e56965f6a83171442ded890L40-R53) [[2]](diffhunk://#diff-72bd19fb9fa81e535851e59fbac288f27b48fad67e56965f6a83171442ded890L92-R102)

**Plugin Suggestion Detection:**

* Replaced the previous string-based check for plugin suggestions with a stricter regular expression (`PLUGIN_FQCN`) to accurately match fully qualified class names, reducing false positives. [[1]](diffhunk://#diff-72bd19fb9fa81e535851e59fbac288f27b48fad67e56965f6a83171442ded890R11-R17) [[2]](diffhunk://#diff-72bd19fb9fa81e535851e59fbac288f27b48fad67e56965f6a83171442ded890L40-R53)

**Date Picker Suggestion Handling:**

* Changed the CSS selector to hide all autocomplete rows whose `aria-label` starts with `_DATE_PICKER_`, supporting Monaco's label suffixes and ensuring the date picker suggestion is consistently hidden.
* Updated logic to filter out date picker suggestions using the new `suggestionLabel` function, ensuring consistent behavior even when Monaco modifies the label.