### PR TITLE
fix(triggers): enforce required-input check on Webhook triggers too

### DIFF
--- a/core/src/main/java/io/kestra/core/validations/validator/FlowValidator.java
+++ b/core/src/main/java/io/kestra/core/validations/validator/FlowValidator.java
@@ -13,9 +13,11 @@ import io.kestra.core.models.flows.input.EeOnly;
 import io.kestra.core.models.flows.input.FormInput;
 import io.kestra.core.models.tasks.ExecutableTask;
 import io.kestra.core.models.tasks.Task;
+import io.kestra.core.models.triggers.AbstractTrigger;
 import io.kestra.core.services.NamespaceService;
 import io.kestra.core.utils.ListUtils;
 import io.kestra.core.validations.FlowValidation;
+import io.kestra.plugin.core.trigger.AbstractWebhookTrigger;
 import io.kestra.plugin.core.trigger.Schedule;
 
 import io.micronaut.core.annotation.AnnotationValue;
@@ -110,8 +112,7 @@ public class FlowValidator implements ConstraintValidator<FlowValidation, Flow> 
             violations.add("Duplicate output with name [" + String.join(", ", duplicateIds) + "]");
         }
 
-        // No missing defaults for schedule triggers
-        findMissingInputsForScheduleTriggers(value).forEach(violations::add);
+        findMissingInputsForTriggers(value).forEach(violations::add);
 
         // system labels
         ListUtils.emptyOnNull(value.getLabels()).stream()
@@ -279,38 +280,49 @@ public class FlowValidator implements ConstraintValidator<FlowValidation, Flow> 
     }
 
     /**
-     * @return the violation formatted message of missing inputs for each schedule trigger
+     * @return the violation formatted message of missing inputs for each trigger able to supply them
      */
-    private Stream<String> findMissingInputsForScheduleTriggers(Flow value) {
-        if (
-            !ListUtils.emptyOnNull(value.getTriggers()).isEmpty()
-                && !ListUtils.emptyOnNull(value.getInputs()).isEmpty()
-        ) {
-            // Find inputs without defaults (expanded to dotted leaf paths; schedules provide values keyed by
-            // the same dotted path, matching how FlowInputOutput resolves them).
-            Set<String> inputsWithoutDefaults = value.resolvableInputs().stream()
-                .filter(input -> input.getDefaults() == null)
-                .map(Data::getId)
-                .collect(Collectors.toSet());
-            // Find schedules with missing inputs or null inputs
-            return value.getTriggers().stream()
-                .filter(Schedule.class::isInstance)
-                .map(Schedule.class::cast)
-                .flatMap(schedule ->
-                {
-                    Set<String> violations = new HashSet<>();
-                    Map<String, Object> scheduleInputs = schedule.getInputs() != null ? schedule.getInputs() : new HashMap<>();
-                    var missingInputs = inputsWithoutDefaults.stream()
-                        .filter(inputId -> !scheduleInputs.containsKey(inputId))
-                        .collect(Collectors.joining(" | "));
-                    if (!missingInputs.isEmpty()) {
-                        violations.add("Missing inputs for Schedule Trigger '%s', missing inputs: '%s'".formatted(schedule.getId(), missingInputs));
-                    }
-                    return violations.stream();
-                });
-        } else {
+    private Stream<String> findMissingInputsForTriggers(Flow value) {
+        if (ListUtils.emptyOnNull(value.getTriggers()).isEmpty() || ListUtils.emptyOnNull(value.getInputs()).isEmpty()) {
             return Stream.empty();
         }
+
+        // Inputs no execution can fill on its own, expanded to dotted leaf paths: triggers supply values keyed by
+        // the same dotted path, matching how FlowInputOutput resolves them.
+        Set<String> inputsNeedingATriggerValue = value.resolvableInputs().stream()
+            .filter(input -> input.getDefaults() == null && !Boolean.FALSE.equals(input.getRequired()))
+            .map(Data::getId)
+            .collect(Collectors.toCollection(LinkedHashSet::new));
+
+        if (inputsNeedingATriggerValue.isEmpty()) {
+            return Stream.empty();
+        }
+
+        return value.getTriggers().stream()
+            .flatMap(
+                trigger -> inputsSuppliedBy(trigger).stream()
+                    .flatMap(triggerInputs ->
+                    {
+                        String missingInputs = inputsNeedingATriggerValue.stream()
+                            .filter(inputId -> !triggerInputs.supplied().containsKey(inputId))
+                            .collect(Collectors.joining(" | "));
+
+                        return missingInputs.isEmpty()
+                            ? Stream.<String> empty()
+                            : Stream.of("Missing inputs for %s Trigger '%s', missing inputs: '%s'".formatted(triggerInputs.kind(), trigger.getId(), missingInputs));
+                    })
+            );
+    }
+
+    private static Optional<TriggerInputs> inputsSuppliedBy(AbstractTrigger trigger) {
+        return switch (trigger) {
+            case Schedule schedule -> Optional.of(new TriggerInputs("Schedule", schedule.getInputs() == null ? Map.of() : schedule.getInputs()));
+            case AbstractWebhookTrigger webhook -> Optional.of(new TriggerInputs("Webhook", webhook.getInputs() == null ? Map.of() : webhook.getInputs()));
+            default -> Optional.empty();
+        };
+    }
+
+    private record TriggerInputs(String kind, Map<String, Object> supplied) {
     }
 
     /**

--- a/core/src/test/java/io/kestra/core/validations/FlowValidationTest.java
+++ b/core/src/test/java/io/kestra/core/validations/FlowValidationTest.java
@@ -264,6 +264,77 @@ class FlowValidationTest {
     }
 
     @Test
+    void webhookFlowMissingRequiredInput_failValidation() {
+        Flow flow = YamlParser.parse("""
+            id: test
+            namespace: unittest
+            inputs:
+              - id: name
+                type: STRING
+                required: true
+            tasks:
+              - id: hello
+                type: io.kestra.plugin.core.log.Log
+                message: hi
+            triggers:
+              - id: hook
+                type: io.kestra.plugin.core.trigger.Webhook
+                key: mykey
+            """, Flow.class);
+
+        Optional<ConstraintViolationException> validate = modelValidator.isValid(flow);
+
+        assertThat(validate).isPresent();
+        assertThat(validate.get().getMessage()).contains("Missing inputs for Webhook Trigger 'hook', missing inputs: 'name'");
+    }
+
+    @Test
+    void webhookFlowSuppliesRequiredInput_valid() {
+        Flow flow = YamlParser.parse("""
+            id: test
+            namespace: unittest
+            inputs:
+              - id: name
+                type: STRING
+                required: true
+            tasks:
+              - id: hello
+                type: io.kestra.plugin.core.log.Log
+                message: hi
+            triggers:
+              - id: hook
+                type: io.kestra.plugin.core.trigger.Webhook
+                key: mykey
+                inputs:
+                  name: "{{ trigger.body.name }}"
+            """, Flow.class);
+
+        assertThat(modelValidator.isValid(flow)).isEmpty();
+    }
+
+    @Test
+    void webhookFlowMissingOptionalInput_valid() {
+        Flow flow = YamlParser.parse("""
+            id: test
+            namespace: unittest
+            inputs:
+              - id: name
+                type: STRING
+                required: false
+            tasks:
+              - id: hello
+                type: io.kestra.plugin.core.log.Log
+                message: hi
+            triggers:
+              - id: hook
+                type: io.kestra.plugin.core.trigger.Webhook
+                key: mykey
+            """, Flow.class);
+
+        assertThat(modelValidator.isValid(flow)).isEmpty();
+    }
+
+    @Test
     void shouldGetConstraintErrorGivenOptionalInputWithDefault() {
         // Given
         GenericFlow flow = GenericFlow.fromYaml(TenantService.MAIN_TENANT, """


### PR DESCRIPTION
### 🔗 Related Issue

Closes https://github.com/kestra-io/kestra-ee/issues/10355.

### ✨ Description

A flow whose required input has no default is refused at save time when a `Schedule` trigger cannot supply it, but the same flow saves without complaint with a `Webhook` trigger. Every webhook call then answers `200` with an execution id while the execution fails immediately on `Missing required input`, so the caller believes it worked.

`FlowValidator` only looked at `Schedule` triggers. The check now covers any trigger that carries an `inputs` map — `Schedule` and `Webhook` (via `AbstractWebhookTrigger`, so future webhook subclasses are included) — and reports the offending trigger by kind: `Missing inputs for Webhook Trigger 'hook', missing inputs: 'name'`.

### 🛠️ Backend Checklist

- [x] Code compiles and tests pass for the touched modules (`./gradlew :module-name:test`, or `./gradlew build` for cross-module changes)
- [x] New behavior is covered by unit or integration tests

`:core:test --tests "io.kestra.core.validations.*"` → 126 passing. Also ran `io.kestra.core.models.flows.*` and `io.kestra.plugin.core.trigger.*` (252 passing), and `:webserver:test` `WebhookPluginTest` + `FlowControllerTest` (79 passing).

The three new tests in `FlowValidationTest` all fail on `develop` / pass here for the first one, and guard the two ways the check must not fire (trigger supplies the input; the input is optional).

### 📝 Additional Notes

**One behaviour change beyond the issue.** The existing check flagged *any* input without a default, ignoring `required`. Extending that as-is to webhooks would have broken working flows: an optional input with no default resolves to `null` at runtime and needs nothing from the trigger. The filter is now `required && defaults == null` for both trigger kinds, which also removes the pre-existing false positive on `Schedule`. No existing test or fixture relied on it.

Missing input ids are now collected in declaration order (`LinkedHashSet`) rather than `HashSet` order, so the message is stable across runs.

### 🤖 AI Authors

Why did the cat refuse to configure the webhook trigger? It only responds to `curl` up requests. 🐱
