### PR TITLE
perf(ui): plan the async chunk graph per page

### DIFF
--- a/ui/plugins/consolidateChunks.js
+++ b/ui/plugins/consolidateChunks.js
@@ -493,19 +493,19 @@ export function consolidateChunks({pages = {}} = {}) {
             // A cycle among the planned chunks is what mergeCycles exists to
             // prevent; one left standing throws at run time, not at build time.
             const planned = new Set(asyncChunk.values())
-            const name = (file) => bundle[file]?.name ?? ""
+            const nameOf = (file) => bundle[file]?.name ?? ""
             const deps = (file) => (bundle[file]?.type === "chunk" ? bundle[file].imports ?? [] : [])
             for (const file of Object.keys(bundle)) {
-                if (!planned.has(name(file))) continue
+                if (!planned.has(nameOf(file))) continue
                 const stack = [[file]]
                 const seen = new Set([file])
                 while (stack.length) {
                     const path = /** @type {string[]} */ (stack.pop())
                     for (const dep of deps(path[path.length - 1])) {
                         if (dep === file) {
-                            this.error(`Chunks import each other: ${[...path, dep].map(name).join(" -> ")}. Either mergeCycles missed this cycle or a group outside the plan is part of it.`)
+                            this.error(`Chunks import each other: ${[...path, dep].map(nameOf).join(" -> ")}. Either mergeCycles missed this cycle or a group outside the plan is part of it.`)
                         }
-                        if (seen.has(dep) || !planned.has(name(dep))) continue
+                        if (seen.has(dep) || !planned.has(nameOf(dep))) continue
                         seen.add(dep)
                         stack.push([...path, dep])
                     }

--- a/ui/plugins/consolidateChunks.js
+++ b/ui/plugins/consolidateChunks.js
@@ -87,11 +87,26 @@ function collectLazySubtrees(ctx) {
         // The other lazy group's declared modules are its own to place; swallowing
         // them here would make one lazy chunk statically pull in the other.
         const others = LAZY_GROUPS.filter((group) => group.name !== name)
+        const declared = new Set(ids.filter((id) => isRealModule(id) && pattern.test(id)))
         const subtree = new Set()
-        for (const id of staticClosure(ctx, ids.filter((candidate) => isRealModule(candidate) && pattern.test(candidate)))) {
-            if (eager.has(id) || !isRealModule(id)) continue
+        for (const id of staticClosure(ctx, [...declared])) {
+            if (eager.has(id) || declared.has(id) || !isRealModule(id)) continue
             if (others.some((group) => group.pattern.test(id))) continue
             subtree.add(id)
+        }
+
+        // Keep only what nothing outside the toolchain imports. A module the app
+        // also uses would drag this whole chunk into every page importing it —
+        // that is how a type-only helper like openFlow.ts once put Monaco on the
+        // flow overview.
+        for (let shrinking = true; shrinking;) {
+            shrinking = false
+            for (const id of subtree) {
+                const importers = ctx.getModuleInfo(id)?.importers ?? []
+                if (!importers.some((importer) => !declared.has(importer) && !subtree.has(importer))) continue
+                subtree.delete(id)
+                shrinking = true
+            }
         }
         lazySubtrees.set(name, subtree)
     }
@@ -161,6 +176,9 @@ let pageGroups = PAGE_GROUPS
 /** Chunk for what no hot page reaches: application plumbing and its dependencies. */
 const REST = "rest"
 
+/** Chunk for what a lazy toolchain shares with the application. */
+const TOOLCHAIN_SHARED = "toolchain-shared"
+
 /** Under this many source bytes a chunk is not worth a request of its own. */
 const MIN_CHUNK_SIZE = 320 * 1024
 
@@ -226,12 +244,20 @@ function planAsyncChunks(ctx) {
     }
 
     const reach = collectLazyReach(ctx, ids)
+    // What a toolchain imports may not sit in the catch-all: opening the editor
+    // would then fetch every unprofiled page along with Monaco.
+    const toolchain = new Set(LAZY_GROUPS.flatMap(({name, pattern}) =>
+        [...(lazySubtrees.get(name) ?? []), ...ids.filter((id) => pattern.test(id))]))
+    const usedByToolchain = new Set([...toolchain].flatMap((id) => ctx.getModuleInfo(id)?.importedIds ?? [])
+        .filter((id) => !toolchain.has(id)))
+
     /** @type {Map<string, {size: number, pages: string[], lazy: string}>} */
     const chunks = new Map()
     for (const id of ids) {
         const owners = pages.get(id)?.sort() ?? []
         const lazy = reach.get(id) ?? ""
-        const name = owners.length ? chunkName(owners, lazy) : chunkName([FEATURE.exec(id)?.[1] ?? REST], lazy)
+        const fallback = usedByToolchain.has(id) ? TOOLCHAIN_SHARED : FEATURE.exec(id)?.[1] ?? REST
+        const name = owners.length ? chunkName(owners, lazy) : chunkName([fallback], lazy)
         asyncChunk.set(id, name)
         const chunk = chunks.get(name) ?? {size: 0, pages: owners, lazy}
         chunk.size += ctx.getModuleInfo(id)?.code?.length ?? 0
@@ -246,7 +272,7 @@ function planAsyncChunks(ctx) {
         if (chunk.size >= MIN_CHUNK_SIZE) continue
         if (!chunk.pages.length) {
             const rest = chunkName([REST], chunk.lazy)
-            if (name !== rest) folded.set(name, rest)
+            if (name !== rest && !name.startsWith(TOOLCHAIN_SHARED)) folded.set(name, rest)
             continue
         }
         const superset = [...chunks]
@@ -382,14 +408,23 @@ export function consolidateChunks({pages = {}} = {}) {
             // catch-all, or an untainted chunk reaching a lazy toolchain.
             const lazyNames = LAZY_GROUPS.map((group) => group.name)
             const isRest = (name) => /^rest($|-)/.test(name)
+            // A feature chunk may reach the catch-all; a hot page's may not.
+            const isPageChunk = (name) => name.startsWith("common-") ||
+                pageGroups.some(({name: page}) => name === page || name.startsWith(`${page}-`))
             for (const chunk of Object.values(bundle)) {
                 // shiki-langs belongs to the markdown toolchain and may reach it.
-                if (chunk.type !== "chunk" || lazyNames.includes(chunk.name) || chunk.name === "shiki-langs") continue
+                if (chunk.type !== "chunk" || chunk.name === "shiki-langs") continue
                 for (const dependency of (chunk.imports ?? []).map((file) => bundle[file]?.name ?? "")) {
+                    if (lazyNames.includes(chunk.name)) {
+                        if (isRest(dependency)) {
+                            this.error(`Lazy chunk '${chunk.name}' statically imports the catch-all '${dependency}' chunk, so loading it fetches every unprofiled page. Its shared modules belong in '${TOOLCHAIN_SHARED}'.`)
+                        }
+                        continue
+                    }
                     if (lazyNames.includes(dependency) && !chunk.name.includes(dependency)) {
                         this.error(`Chunk '${chunk.name}' statically imports the lazy '${dependency}' chunk, so every page reaching '${chunk.name}' now downloads it. Its modules should be reported as reaching '${dependency}' by collectLazyReach.`)
                     }
-                    if (isRest(dependency) && !isRest(chunk.name)) {
+                    if (isRest(dependency) && isPageChunk(chunk.name)) {
                         this.error(`Chunk '${chunk.name}' statically imports the catch-all '${dependency}' chunk, which drags every unprofiled page along. A hot page's modules should all be owned by planAsyncChunks.`)
                     }
                 }

--- a/ui/plugins/consolidateChunks.js
+++ b/ui/plugins/consolidateChunks.js
@@ -294,6 +294,66 @@ function planAsyncChunks(ctx) {
         return target
     }
     for (const [id, name] of asyncChunk) asyncChunk.set(id, resolve(name))
+    mergeCycles(ctx)
+}
+
+/**
+ * Merges every group of planned chunks that import each other into one chunk.
+ * Two chunks importing each other build cleanly and then throw ("X is not a
+ * function") the first time either loads, so a cycle is never shippable.
+ * @param {import("rolldown").PluginContext} ctx
+ */
+function mergeCycles(ctx) {
+    /** @type {Map<string, Set<string>>} */
+    const edges = new Map()
+    for (const [id, name] of asyncChunk) {
+        const targets = edges.get(name) ?? new Set()
+        for (const dep of ctx.getModuleInfo(id)?.importedIds ?? []) {
+            const target = asyncChunk.get(dep)
+            if (target && target !== name) targets.add(target)
+        }
+        edges.set(name, targets)
+    }
+
+    // Tarjan: every component with more than one chunk is a cycle to collapse.
+    let index = 0
+    const order = new Map(), low = new Map(), onStack = new Set(), stack = []
+    /** @type {Map<string, string>} */
+    const merged = new Map()
+    const visit = (name) => {
+        order.set(name, index)
+        low.set(name, index)
+        index++
+        stack.push(name)
+        onStack.add(name)
+        for (const target of edges.get(name) ?? []) {
+            if (!order.has(target)) {
+                visit(target)
+                low.set(name, Math.min(low.get(name), low.get(target)))
+            } else if (onStack.has(target)) {
+                low.set(name, Math.min(low.get(name), order.get(target)))
+            }
+        }
+        if (low.get(name) !== order.get(name)) return
+        const component = []
+        let popped
+        do {
+            popped = stack.pop()
+            onStack.delete(popped)
+            component.push(popped)
+        } while (popped !== name)
+        if (component.length === 1) return
+        // The catch-all's name wins, so the merged chunk still reads as what it
+        // is — and so the guards below keep recognising it.
+        const target = component.sort().find((member) => member.startsWith(REST)) ?? component.sort()[0]
+        for (const member of component) merged.set(member, target)
+    }
+    for (const name of edges.keys()) if (!order.has(name)) visit(name)
+
+    for (const [id, name] of asyncChunk) {
+        const target = merged.get(name)
+        if (target) asyncChunk.set(id, target)
+    }
 }
 
 // Negative priorities keep module federation's own groups (priority >= 0)
@@ -426,6 +486,28 @@ export function consolidateChunks({pages = {}} = {}) {
                     }
                     if (isRest(dependency) && isPageChunk(chunk.name)) {
                         this.error(`Chunk '${chunk.name}' statically imports the catch-all '${dependency}' chunk, which drags every unprofiled page along. A hot page's modules should all be owned by planAsyncChunks.`)
+                    }
+                }
+            }
+
+            // A cycle among the planned chunks is what mergeCycles exists to
+            // prevent; one left standing throws at run time, not at build time.
+            const planned = new Set(asyncChunk.values())
+            const name = (file) => bundle[file]?.name ?? ""
+            const deps = (file) => (bundle[file]?.type === "chunk" ? bundle[file].imports ?? [] : [])
+            for (const file of Object.keys(bundle)) {
+                if (!planned.has(name(file))) continue
+                const stack = [[file]]
+                const seen = new Set([file])
+                while (stack.length) {
+                    const path = /** @type {string[]} */ (stack.pop())
+                    for (const dep of deps(path[path.length - 1])) {
+                        if (dep === file) {
+                            this.error(`Chunks import each other: ${[...path, dep].map(name).join(" -> ")}. Either mergeCycles missed this cycle or a group outside the plan is part of it.`)
+                        }
+                        if (seen.has(dep) || !planned.has(name(dep))) continue
+                        seen.add(dep)
+                        stack.push([...path, dep])
                     }
                 }
             }

--- a/ui/plugins/consolidateChunks.js
+++ b/ui/plugins/consolidateChunks.js
@@ -173,9 +173,6 @@ const PAGE_GROUPS = [
 /** {@link PAGE_GROUPS} widened with the patterns the build passed in. */
 let pageGroups = PAGE_GROUPS
 
-/** Chunk for what no hot page reaches: application plumbing and its dependencies. */
-const REST = "rest"
-
 /** Chunk for what a lazy toolchain shares with the application. */
 const TOOLCHAIN_SHARED = "toolchain-shared"
 
@@ -217,9 +214,6 @@ function collectLazyReach(ctx, ids) {
     return new Map([...reach].map(([id, names]) => [id, [...names].sort().join("-")]))
 }
 
-/** The feature directory a module lives in, chunk enough for a page nobody profiled. */
-const FEATURE = /src[\\/](?:override[\\/])?(?:components|dashboard)[\\/]([^\\/]+)[\\/]/
-
 /** `pages` is the set of hot pages reaching the module, `lazy` the toolchains it reaches. */
 const chunkName = (pages, lazy) => [pages.length > 1 ? `common-${pages.join("-")}` : pages[0], lazy].filter(Boolean).join("-")
 
@@ -244,8 +238,8 @@ function planAsyncChunks(ctx) {
     }
 
     const reach = collectLazyReach(ctx, ids)
-    // What a toolchain imports may not sit in the catch-all: opening the editor
-    // would then fetch every unprofiled page along with Monaco.
+    // A module a toolchain imports gets a chunk of its own, so the toolchain
+    // never has to reach into a chunk holding unrelated pages.
     const toolchain = new Set(LAZY_GROUPS.flatMap(({name, pattern}) =>
         [...(lazySubtrees.get(name) ?? []), ...ids.filter((id) => pattern.test(id))]))
     const usedByToolchain = new Set([...toolchain].flatMap((id) => ctx.getModuleInfo(id)?.importedIds ?? [])
@@ -256,8 +250,14 @@ function planAsyncChunks(ctx) {
     for (const id of ids) {
         const owners = pages.get(id)?.sort() ?? []
         const lazy = reach.get(id) ?? ""
-        const fallback = usedByToolchain.has(id) ? TOOLCHAIN_SHARED : FEATURE.exec(id)?.[1] ?? REST
-        const name = owners.length ? chunkName(owners, lazy) : chunkName([fallback], lazy)
+        // Only hot pages and the toolchains' shared modules are planned. Putting
+        // what is left in one catch-all chunk was tried and doubled what a cold
+        // page downloads (cases: 2.0 -> 4.7 MB gzip); automatic chunking splits
+        // it finely, and a page nobody profiled fetches around a dozen files.
+        const name = owners.length ? chunkName(owners, lazy)
+            : usedByToolchain.has(id) ? chunkName([TOOLCHAIN_SHARED], lazy)
+                : undefined
+        if (!name) continue
         asyncChunk.set(id, name)
         const chunk = chunks.get(name) ?? {size: 0, pages: owners, lazy}
         chunk.size += ctx.getModuleInfo(id)?.code?.length ?? 0
@@ -269,19 +269,12 @@ function planAsyncChunks(ctx) {
     /** @type {Map<string, string>} */
     const folded = new Map()
     for (const [name, chunk] of [...chunks].sort((a, b) => a[1].pages.length - b[1].pages.length)) {
-        if (chunk.size >= MIN_CHUNK_SIZE) continue
-        if (!chunk.pages.length) {
-            const rest = chunkName([REST], chunk.lazy)
-            if (name !== rest && !name.startsWith(TOOLCHAIN_SHARED)) folded.set(name, rest)
-            continue
-        }
+        if (chunk.size >= MIN_CHUNK_SIZE || !chunk.pages.length) continue
         const superset = [...chunks]
             .filter(([other, candidate]) => other !== name && candidate.lazy === chunk.lazy &&
                 candidate.pages.length > chunk.pages.length &&
                 chunk.pages.every((page) => candidate.pages.includes(page)))
             .sort((a, b) => a[1].pages.length - b[1].pages.length)[0]
-        // Without a superset the chunk stays: dropping page code into the
-        // catch-all would make that page pull in every other page's code.
         if (superset) folded.set(name, superset[0])
     }
     const resolve = (name) => {
@@ -343,9 +336,7 @@ function mergeCycles(ctx) {
             component.push(popped)
         } while (popped !== name)
         if (component.length === 1) return
-        // The catch-all's name wins, so the merged chunk still reads as what it
-        // is — and so the guards below keep recognising it.
-        const target = component.sort().find((member) => member.startsWith(REST)) ?? component.sort()[0]
+        const target = component.sort()[0]
         for (const member of component) merged.set(member, target)
     }
     for (const name of edges.keys()) if (!order.has(name)) visit(name)
@@ -467,25 +458,12 @@ export function consolidateChunks({pages = {}} = {}) {
             // Static edges that undo the split: a page chunk reaching the
             // catch-all, or an untainted chunk reaching a lazy toolchain.
             const lazyNames = LAZY_GROUPS.map((group) => group.name)
-            const isRest = (name) => /^rest($|-)/.test(name)
-            // A feature chunk may reach the catch-all; a hot page's may not.
-            const isPageChunk = (name) => name.startsWith("common-") ||
-                pageGroups.some(({name: page}) => name === page || name.startsWith(`${page}-`))
             for (const chunk of Object.values(bundle)) {
                 // shiki-langs belongs to the markdown toolchain and may reach it.
-                if (chunk.type !== "chunk" || chunk.name === "shiki-langs") continue
+                if (chunk.type !== "chunk" || chunk.name === "shiki-langs" || lazyNames.includes(chunk.name)) continue
                 for (const dependency of (chunk.imports ?? []).map((file) => bundle[file]?.name ?? "")) {
-                    if (lazyNames.includes(chunk.name)) {
-                        if (isRest(dependency)) {
-                            this.error(`Lazy chunk '${chunk.name}' statically imports the catch-all '${dependency}' chunk, so loading it fetches every unprofiled page. Its shared modules belong in '${TOOLCHAIN_SHARED}'.`)
-                        }
-                        continue
-                    }
                     if (lazyNames.includes(dependency) && !chunk.name.includes(dependency)) {
                         this.error(`Chunk '${chunk.name}' statically imports the lazy '${dependency}' chunk, so every page reaching '${chunk.name}' now downloads it. Its modules should be reported as reaching '${dependency}' by collectLazyReach.`)
-                    }
-                    if (isRest(dependency) && isPageChunk(chunk.name)) {
-                        this.error(`Chunk '${chunk.name}' statically imports the catch-all '${dependency}' chunk, which drags every unprofiled page along. A hot page's modules should all be owned by planAsyncChunks.`)
                     }
                 }
             }

--- a/ui/plugins/consolidateChunks.js
+++ b/ui/plugins/consolidateChunks.js
@@ -33,7 +33,7 @@ const isRealModule = (id) =>
  */
 const matches = (pattern) => (id) => isRealModule(id) && pattern.test(id)
 
-const MONACO_MODULES = /node_modules[\\/](monaco-editor|monaco-yaml|monaco-worker-manager|monaco-marker-data-provider)[\\/]|design-system[\\/]src[\\/](components[\\/]Form[\\/]KsEditor\.vue|composables[\\/](useKsEditor|useEditor|useSuggestWidgetIcons|PlaceholderContentWidget)|utils[\\/]monacoSetup)/
+const MONACO_MODULES = /node_modules[\\/](monaco-editor|monaco-yaml|monaco-worker-manager|monaco-marker-data-provider)[\\/]|design-system[\\/]src[\\/](components[\\/]Form[\\/]KsEditor\.vue|composables[\\/](useKsEditor|useEditor|useSuggestWidgetIcons|PlaceholderContentWidget)|utils[\\/]monacoSetup)|src[\\/](override[\\/])?composables[\\/]monaco[\\/]/
 // Entries that look like typos are real unified-ecosystem package names.
 const MARKDOWN_MODULES = /design-system[\\/]src[\\/]components[\\/]Data[\\/]KsMarkdown[\\/]|node_modules[\\/](shiki|@shikijs|oniguruma-to-es|regex(-recursion|-utilities)?|remark-[^\\/]+|micromark[^\\/]*|mdast[^\\/]*|unified|unist[^\\/]*|vfile[^\\/]*|hast[^\\/]*|devlop|ccount|character-[^\\/]+|decode-named-character-reference|markdown-table|longest-streak|trim-lines|zwitch|bail|trough|escape-string-regexp)[\\/]/ // codespell:ignore devlop,trough
 
@@ -144,6 +144,132 @@ function collectStaticLangs(ctx) {
     }
 }
 
+/**
+ * Pages hot enough to deserve a chunk of their own, so that opening one costs a
+ * couple of requests and moving between its tabs costs none.
+ */
+const PAGE_GROUPS = [
+    {name: "login", pattern: /src[\\/]components[\\/](login[\\/]|basicauth[\\/]BasicAuthLogin)/},
+    {name: "flow", pattern: /src[\\/](override[\\/])?components[\\/](flows|no-code|inputs)[\\/]/},
+    {name: "execution", pattern: /src[\\/](override[\\/])?components[\\/](executions|logs)[\\/]/},
+    {name: "dashboard", pattern: /src[\\/](dashboard[\\/]|(override[\\/])?components[\\/]dashboard[\\/])/},
+]
+
+/** {@link PAGE_GROUPS} widened with the patterns the build passed in. */
+let pageGroups = PAGE_GROUPS
+
+/** Chunk for what no hot page reaches: application plumbing and its dependencies. */
+const REST = "rest"
+
+/** Under this many source bytes a chunk is not worth a request of its own. */
+const MIN_CHUNK_SIZE = 320 * 1024
+
+/**
+ * Module id -> name of the chunk it belongs to, for everything the groups above
+ * leave behind. Filled during buildEnd.
+ * @type {Map<string, string>}
+ */
+const asyncChunk = new Map()
+
+/**
+ * Names the lazy toolchains a module statically reaches, so that a chunk holding
+ * it is never one an unrelated page loads: that page would download Monaco too.
+ * @param {import("rolldown").PluginContext} ctx
+ * @param {string[]} ids
+ * @returns {Map<string, string>}
+ */
+function collectLazyReach(ctx, ids) {
+    /** @type {Map<string, Set<string>>} */
+    const reach = new Map()
+    for (const {name, pattern} of LAZY_GROUPS) {
+        const queue = [...(lazySubtrees.get(name) ?? []), ...ids.filter((id) => pattern.test(id))]
+        const seen = new Set(queue)
+        while (queue.length) {
+            const id = queue.pop()
+            for (const importer of ctx.getModuleInfo(id)?.importers ?? []) {
+                if (seen.has(importer)) continue
+                seen.add(importer)
+                queue.push(importer)
+                const names = reach.get(importer)
+                if (names) names.add(name)
+                else reach.set(importer, new Set([name]))
+            }
+        }
+    }
+    return new Map([...reach].map(([id, names]) => [id, [...names].sort().join("-")]))
+}
+
+/** The feature directory a module lives in, chunk enough for a page nobody profiled. */
+const FEATURE = /src[\\/](?:override[\\/])?(?:components|dashboard)[\\/]([^\\/]+)[\\/]/
+
+/** `pages` is the set of hot pages reaching the module, `lazy` the toolchains it reaches. */
+const chunkName = (pages, lazy) => [pages.length > 1 ? `common-${pages.join("-")}` : pages[0], lazy].filter(Boolean).join("-")
+
+/**
+ * Plans a chunk for every module the groups above leave behind: one per hot page,
+ * one per set of pages sharing code, one per feature directory for the rest.
+ * @param {import("rolldown").PluginContext} ctx
+ */
+function planAsyncChunks(ctx) {
+    asyncChunk.clear()
+    const ids = [...ctx.getModuleIds()].filter(isRealModule)
+
+    /** @type {Map<string, string[]>} */
+    const pages = new Map()
+    for (const {name, pattern} of pageGroups) {
+        for (const id of staticClosure(ctx, ids.filter((candidate) => pattern.test(candidate)))) {
+            if (!isRealModule(id)) continue
+            const names = pages.get(id)
+            if (names) names.push(name)
+            else pages.set(id, [name])
+        }
+    }
+
+    const reach = collectLazyReach(ctx, ids)
+    /** @type {Map<string, {size: number, pages: string[], lazy: string}>} */
+    const chunks = new Map()
+    for (const id of ids) {
+        const owners = pages.get(id)?.sort() ?? []
+        const lazy = reach.get(id) ?? ""
+        const name = owners.length ? chunkName(owners, lazy) : chunkName([FEATURE.exec(id)?.[1] ?? REST], lazy)
+        asyncChunk.set(id, name)
+        const chunk = chunks.get(name) ?? {size: 0, pages: owners, lazy}
+        chunk.size += ctx.getModuleInfo(id)?.code?.length ?? 0
+        chunks.set(name, chunk)
+    }
+
+    // Fold the slivers into a chunk serving a superset of their pages: no page
+    // gains a request, and only pages already loading the target gain bytes.
+    /** @type {Map<string, string>} */
+    const folded = new Map()
+    for (const [name, chunk] of [...chunks].sort((a, b) => a[1].pages.length - b[1].pages.length)) {
+        if (chunk.size >= MIN_CHUNK_SIZE) continue
+        if (!chunk.pages.length) {
+            const rest = chunkName([REST], chunk.lazy)
+            if (name !== rest) folded.set(name, rest)
+            continue
+        }
+        const superset = [...chunks]
+            .filter(([other, candidate]) => other !== name && candidate.lazy === chunk.lazy &&
+                candidate.pages.length > chunk.pages.length &&
+                chunk.pages.every((page) => candidate.pages.includes(page)))
+            .sort((a, b) => a[1].pages.length - b[1].pages.length)[0]
+        // Without a superset the chunk stays: dropping page code into the
+        // catch-all would make that page pull in every other page's code.
+        if (superset) folded.set(name, superset[0])
+    }
+    const resolve = (name) => {
+        const seen = new Set()
+        let target = name
+        while (folded.has(target) && !seen.has(target)) {
+            seen.add(target)
+            target = /** @type {string} */ (folded.get(target))
+        }
+        return target
+    }
+    for (const [id, name] of asyncChunk) asyncChunk.set(id, resolve(name))
+}
+
 // Negative priorities keep module federation's own groups (priority >= 0)
 // winning every module they target; recursion off so shared deps stay put.
 const GROUPS = [
@@ -200,6 +326,21 @@ const GROUPS = [
         priority: -40,
         includeDependenciesRecursively: false,
     },
+    // One chunk for every module-federation share wrapper: alone they are
+    // forty-odd two-kilobyte requests, most of them on every page.
+    {
+        name: "mf-shared",
+        test: (id) => id.includes("__loadShare__"),
+        priority: -44,
+        includeDependenciesRecursively: false,
+    },
+    // Everything reached only through a dynamic import, planned per page by
+    // {@link planAsyncChunks} instead of left to fragment into hundreds of files.
+    {
+        name: (id) => asyncChunk.get(id) ?? null,
+        priority: -50,
+        includeDependenciesRecursively: false,
+    },
 ]
 
 /**
@@ -209,9 +350,14 @@ const GROUPS = [
  * Must be registered after the federation plugin: MF strips user-declared
  * `codeSplitting.groups` in its `config` hook (grouping its init wrappers can
  * break remote init order), so this appends to the groups MF installed there.
+ * @param {{pages?: Record<string, RegExp>}} [options] Directories to count towards
+ * a page, keyed by {@link PAGE_GROUPS} name — e.g. the tabs an edition adds to it.
  * @returns {import("vite").Plugin}
  */
-export function consolidateChunks() {
+export function consolidateChunks({pages = {}} = {}) {
+    pageGroups = PAGE_GROUPS.map((page) => pages[page.name]
+        ? {...page, pattern: new RegExp(`${page.pattern.source}|${pages[page.name].source}`)}
+        : page)
     return {
         name: "kestra:consolidate-chunks",
         apply: "build",
@@ -229,8 +375,26 @@ export function consolidateChunks() {
         buildEnd() {
             collectStaticLangs(this)
             collectLazySubtrees(this)
+            planAsyncChunks(this)
         },
         generateBundle(_options, bundle) {
+            // Static edges that undo the split: a page chunk reaching the
+            // catch-all, or an untainted chunk reaching a lazy toolchain.
+            const lazyNames = LAZY_GROUPS.map((group) => group.name)
+            const isRest = (name) => /^rest($|-)/.test(name)
+            for (const chunk of Object.values(bundle)) {
+                // shiki-langs belongs to the markdown toolchain and may reach it.
+                if (chunk.type !== "chunk" || lazyNames.includes(chunk.name) || chunk.name === "shiki-langs") continue
+                for (const dependency of (chunk.imports ?? []).map((file) => bundle[file]?.name ?? "")) {
+                    if (lazyNames.includes(dependency) && !chunk.name.includes(dependency)) {
+                        this.error(`Chunk '${chunk.name}' statically imports the lazy '${dependency}' chunk, so every page reaching '${chunk.name}' now downloads it. Its modules should be reported as reaching '${dependency}' by collectLazyReach.`)
+                    }
+                    if (isRest(dependency) && !isRest(chunk.name)) {
+                        this.error(`Chunk '${chunk.name}' statically imports the catch-all '${dependency}' chunk, which drags every unprofiled page along. A hot page's modules should all be owned by planAsyncChunks.`)
+                    }
+                }
+            }
+
             // A static edge into shiki-langs would make every markdown render
             // fetch all ~350 grammars, which is exactly what this split avoids.
             const isLangChunk = (name) => /(^|[\\/])shiki-langs-/.test(name)

--- a/ui/src/components/Tabs.vue
+++ b/ui/src/components/Tabs.vue
@@ -66,16 +66,12 @@
 </template>
 
 <script setup lang="ts">
-    import {ref, computed, useAttrs, onMounted, onBeforeUnmount, watch, nextTick, h, defineAsyncComponent, defineComponent, toHandlers, type Component} from "vue"
+    import {ref, computed, useAttrs, onMounted, onBeforeUnmount, watch, nextTick, h, defineComponent, toHandlers, type Component} from "vue"
     import {useRoute, useRouter} from "vue-router"
     import EnterpriseBadge from "./EnterpriseBadge.vue"
     import {useRouteTabsStore, type RouteTab} from "../stores/routeTabs"
     import {useActiveTab} from "../composables/useActiveTab"
     import {routeFamily} from "../utils/routeFamily"
-
-    // Async: it reaches the editor bindings, which statically put Monaco on the
-    // graph of every page that renders tabs.
-    const BlueprintDetail = defineAsyncComponent(() => import("override/components/flows/blueprints/BlueprintDetail.vue"))
 
     export interface Tab extends RouteTab {
         "v-on"?: Record<string, unknown>;
@@ -85,7 +81,6 @@
          * for tabs hosting a full-page listing (e.g. KsDataTable with fitHeight).
          */
         fullContainer?: boolean;
-        blueprintDetail?: boolean;
     }
 
     defineOptions({inheritAttrs: false})
@@ -128,8 +123,6 @@
     const activeTabName = useActiveTab()
     const tabsOwnerId = Symbol("route-tabs-owner")
 
-    const selectedBlueprintId = ref<string | undefined>(undefined)
-
     const isEmbedded = computed(() => props.embedActiveTab !== undefined)
 
     const visibleTabs = computed(() => props.tabs.filter(t => !t.hidden))
@@ -142,18 +135,15 @@
     /**
      * A page is router-driven when its active route exposes a `meta.tab`, i.e. tab
      * identity lives in a matched child route and `<router-view>` owns the content.
-     * Embedded mode, the blueprint modal, and not-yet-migrated pages keep the
-     * dynamic `<component :is>` path below.
+     * Embedded mode and not-yet-migrated pages keep the dynamic
+     * `<component :is>` path below.
      */
     const isRouterDriven = computed(() => route?.meta?.tab !== undefined)
 
-    const useRouterView = computed(() =>
-        !props.vertical && !isEmbedded.value && !selectedBlueprintId.value && isRouterDriven.value,
-    )
+    const useRouterView = computed(() => !props.vertical && !isEmbedded.value && isRouterDriven.value)
 
     /** Whether TabBody would render anything — mirrors the null cases in TabBody's render. */
     const hasTabBody = computed(() => {
-        if (selectedBlueprintId.value) return true
         const tab = activeTab.value as Tab | undefined
         return tab !== undefined && (isEditorActiveTab(tab) || Boolean(tab.component))
     })
@@ -249,10 +239,6 @@
         {deep: true},
     )
 
-    watch(activeTab, () => {
-        selectedBlueprintId.value = undefined
-    })
-
     /**
      * Each tab's route component is code-split (`() => import(...)`), and vue-router
      * doesn't commit a navigation until that chunk resolves — so the first visit to
@@ -293,24 +279,12 @@
         setup() {
             return () => {
                 const tab = activeTab.value as Tab | undefined
-                if (selectedBlueprintId.value) {
-                    return h(BlueprintDetail, {
-                        blueprintId: selectedBlueprintId.value,
-                        blueprintType: "community",
-                        onBack: () => (selectedBlueprintId.value = undefined),
-                        combinedView: true,
-                        kind: tab?.props?.blueprintKind,
-                        embed: tab?.props?.embed ?? true,
-                        system: tab?.props?.system ?? false,
-                    })
-                }
                 if (!tab || !(isEditorActiveTab(tab) || tab.component)) return null
                 return h(tab.component as Component, {
                     ...tab.props,
                     ...attrsWithoutClass.value,
                     ...toHandlers(tab["v-on"] ?? {}),
                     namespace: getNamespaceToForward(tab),
-                    ...(tab.blueprintDetail ? {onGoToDetail: (id: string) => (selectedBlueprintId.value = id)} : {}),
                 })
             }
         },

--- a/ui/src/components/Tabs.vue
+++ b/ui/src/components/Tabs.vue
@@ -66,13 +66,16 @@
 </template>
 
 <script setup lang="ts">
-    import {ref, computed, useAttrs, onMounted, onBeforeUnmount, watch, nextTick, h, defineComponent, toHandlers, type Component} from "vue"
+    import {ref, computed, useAttrs, onMounted, onBeforeUnmount, watch, nextTick, h, defineAsyncComponent, defineComponent, toHandlers, type Component} from "vue"
     import {useRoute, useRouter} from "vue-router"
     import EnterpriseBadge from "./EnterpriseBadge.vue"
-    import BlueprintDetail from "override/components/flows/blueprints/BlueprintDetail.vue"
     import {useRouteTabsStore, type RouteTab} from "../stores/routeTabs"
     import {useActiveTab} from "../composables/useActiveTab"
     import {routeFamily} from "../utils/routeFamily"
+
+    // Async: it reaches the editor bindings, which statically put Monaco on the
+    // graph of every page that renders tabs.
+    const BlueprintDetail = defineAsyncComponent(() => import("override/components/flows/blueprints/BlueprintDetail.vue"))
 
     export interface Tab extends RouteTab {
         "v-on"?: Record<string, unknown>;

--- a/ui/src/components/namespaces/utils/useHelpers.ts
+++ b/ui/src/components/namespaces/utils/useHelpers.ts
@@ -20,7 +20,6 @@ export interface Tab {
     component: Component;
     props?: Record<string, any>;
     count?: number;
-    blueprintDetail?: boolean;
     fullContainer?: boolean;
 }
 

--- a/ui/src/composables/useEditorBindings.ts
+++ b/ui/src/composables/useEditorBindings.ts
@@ -5,7 +5,6 @@ import {useMiscStore} from "override/stores/misc"
 import {getTheme} from "../utils/utils"
 import {usePluginsStore} from "../stores/plugins"
 import {useFlowStore} from "../stores/flow"
-import configureLanguageFn from "./monaco/languages/languagesConfigurator"
 import type {editor as monacoEditor} from "monaco-editor/editor/editor.api"
 
 export function useEditorBindings() {
@@ -21,7 +20,11 @@ export function useEditorBindings() {
             return getTheme()
         }),
         loadTaskIcon: pluginsStore.loadIcon,
-        configureLanguage: (editor: monacoEditor.ICodeEditor | undefined, language: string, schemaType?: string) =>
-            configureLanguageFn(flowStore, pluginsStore, t, editor, language, schemaType, router),
+        // Imported here rather than at module scope: forty-odd components use
+        // these bindings, and statically this put Monaco on all of their graphs.
+        configureLanguage: async (editor: monacoEditor.ICodeEditor | undefined, language: string, schemaType?: string) => {
+            const {default: configureLanguageFn} = await import("./monaco/languages/languagesConfigurator")
+            return configureLanguageFn(flowStore, pluginsStore, t, editor, language, schemaType, router)
+        },
     })
 }


### PR DESCRIPTION
Two things: chunk planning for the async graph (it grouped only `$initial` modules, so every route component, composable and mdi icon fell through to automatic splitting), and Monaco no longer sitting on the static graph of pages that merely bind an editor.

## Bundle

| | before | after |
|---|---:|---:|
| boot chunks | 30 | 13 |
| chunks with a static edge to Monaco | 8 | **0** |
| chunk cycles | 1 (`app ↔ index`) | 1 (`app ↔ index`) |

## JS requests per page (kestra-ee build)

| page | requests before | requests after | gzip after |
|---|---:|---:|---:|
| login *(measured in browser)* | 66 | **19** | 1258 kB |
| dashboard | 38 | **16** | 1332 kB |
| `flows/edit` incl. every tab | 104 + 1–2 per tab | **21**, 0 per tab | 2008 kB |
| execution page | 114 | **19** | 1562 kB |
| cases *(unprofiled page)* | ~100 | **25** | 2019 kB |

Only the hot pages and the modules a lazy toolchain shares with the app are planned; everything else keeps rolldown's own splitting. Planning the remainder into one catch-all chunk was tried and reverted — it cost a cold page 4.7 MB gzip instead of 2.0 MB, and it was the source of a `rest ↔ cluster` cycle that threw `St is not a function` on every page in it.

## `flows/edit` → Overview tab, beyond boot

| | chunks | raw | gzip |
|---|---:|---:|---:|
| before | 12 | 6853 kB | 1866 kB |
| after | 8 | 2582 kB | 773 kB |

Monaco (4264 kB raw / 1085 kB gzip) is now fetched only when an editor mounts. It had three separate ways onto that page:

| cause | fix |
|---|---|
| `useEditorBindings` imported the language configurator at module scope; 40 components use those bindings | dynamic `import()` inside `configureLanguage` — already async, already awaited by `useKsEditor` |
| `Tabs.vue` statically imported `BlueprintDetail` for an **unreachable** branch — gated on a `blueprintDetail` tab flag no tab sets, duplicating state `Blueprints.vue` has owned since #16457 | branch deleted (34 lines) |
| a lazy group swallowed app modules privately reachable from it — `openFlow.ts`, whose only import is a vue-router *type*, lived in the Monaco chunk | groups keep only what nothing outside the toolchain imports; what they share with the app goes to `toolchain-shared` (501 B) so a toolchain never reaches the catch-all |

## Chunk planning

- **Page groups** — static closure of each hot page's directories, computed at `buildEnd`. Reached by one page → that page's chunk; by several → `common-<pages>`. Ownership from the graph, so a page chunk's only outward edges are chunks it needs.
- **Lazy-toolchain taint** — modules statically reaching Monaco/markdown get a `…-monaco` / `…-markdown` variant, so no page inherits a toolchain through a chunk it shares.
- **Sliver folding** — a chunk under 320 kB folds into one serving a superset of its pages: no page gains a request, only pages already loading the target gain bytes.
- **`mf-shared`** — 48 federation share wrappers in one chunk instead of ~35 two-kilobyte requests on every page.
- **Cycle merge + guard** — planning collapses any cycle among its own chunks into one, and `generateBundle` walks the emitted graph and fails on any cycle involving a planned chunk. A cyclic pair builds cleanly and then throws `X is not a function` the first time either loads, so this is the difference between a build error and a dead page.
- **Toolchain guard** — fails when an untainted chunk statically imports a lazy toolchain. Not vacuous: it caught `shiki-langs → markdown` while being written.

## Verified

- `npm run check:types`: design-system, app and tests clean. `oxlint` + `eslint` clean.
- OSS build 40 chunks, EE build 38, both with the guard green.
- All 19 app chunks `import()`ed in a browser: no evaluation error (cycle/TDZ check).
- 62 federation shared modules registered in the share scope with the merged wrapper chunk.
- Login page renders and fetches no Monaco.

Not covered: authenticated pages and federated plugin UIs need a click-through. Worth knowing separately — `@vue-flow/core` (337 kB source) and dagre are in the **boot** bundle, because `stores/flow.ts` imports the `@kestra-io/topology` barrel for a YAML helper and that barrel exports `Topology.vue`. A `flowYamlUtils` subpath export would take it off the login path; it is a 68-file import rewrite, so not in here.

Companion PR: https://github.com/kestra-io/kestra-ee/pull/10425

🤖 Generated with [Claude Code](https://claude.com/claude-code)
