### PR TITLE
fix(triggers): reject webhook calls on a disabled trigger

### DIFF
--- a/core/src/test/resources/flows/valids/webhook-disabled.yaml
+++ b/core/src/test/resources/flows/valids/webhook-disabled.yaml
@@ -1,0 +1,13 @@
+id: webhook-disabled
+namespace: io.kestra.tests
+
+tasks:
+  - id: out
+    type: io.kestra.plugin.core.debug.Return
+    format: "{{trigger | json }}"
+
+triggers:
+  - id: webhook
+    type: io.kestra.plugin.core.trigger.Webhook
+    key: webhook-disabled-key
+    disabled: true

--- a/webserver/src/main/java/io/kestra/webserver/controllers/api/ExecutionController.java
+++ b/webserver/src/main/java/io/kestra/webserver/controllers/api/ExecutionController.java
@@ -788,6 +788,10 @@ public class ExecutionController {
         final AbstractWebhookTrigger webhook = processedForRuntime(flow, findWebhook(flow, key));
         this.onWebhookMatched(flow, webhook);
 
+        if (webhook.isDisabled()) {
+            throw new ConflictException("Cannot execute webhook: the trigger '%s' is disabled.".formatted(webhook.getId()));
+        }
+
         // Webhook context
         var webhookContext = new WebhookContext(
             request,

--- a/webserver/src/test/java/io/kestra/webserver/controllers/api/ExecutionControllerTest.java
+++ b/webserver/src/test/java/io/kestra/webserver/controllers/api/ExecutionControllerTest.java
@@ -178,6 +178,24 @@ class ExecutionControllerTest {
     }
 
     @Test
+    @LoadFlows(value = {"flows/valids/webhook-disabled.yaml"})
+    void webhookDisabled() {
+        HttpClientResponseException exception = assertThrows(
+            HttpClientResponseException.class,
+            () -> client.toBlocking().retrieve(
+                HttpRequest
+                    .POST(
+                        "/api/v1/main/executions/webhook/" + TESTS_FLOW_NS +"/webhook-disabled/webhook-disabled-key",
+                        null
+                    ),
+                Execution.class
+            )
+        );
+        assertThat(exception.getStatus().getCode()).isEqualTo(HttpStatus.CONFLICT.getCode());
+        assertThat(exception.getMessage()).contains("the trigger 'webhook' is disabled");
+    }
+
+    @Test
     @LoadFlows(value = { "flows/valids/webhook-draft.yaml" })
     void webhookOnDraftFlowReturnsNotFound() {
         HttpClientResponseException exception = assertThrows(


### PR DESCRIPTION
### 🔗 Related Issue

Closes https://github.com/kestra-io/kestra/issues/18505.

### ✨ Description

A Webhook trigger with `disabled: true` still created an execution when its URL was called — the endpoint matched the trigger by key and evaluated it without ever checking whether it was enabled, so the call returned `200` and a run appeared in the UI.

The webhook endpoint now rejects the call with a `409 Conflict` when the matched trigger is disabled, in the same place the existing disabled-flow check lives. The check runs on the trigger processed for runtime, so a `disabled` value coming from a Pebble expression is honoured too, and an unknown key still yields a `404` rather than leaking whether a trigger exists.

### 🛠️ Backend Checklist

- [x] Code compiles and tests pass for the touched modules (`./gradlew :module-name:test`, or `./gradlew build` for cross-module changes)
- [x] New behavior is covered by unit or integration tests

### 📝 Additional Notes

`ExecutionControllerTest.webhookDisabled` fails on the parent commit (`200` + an execution) and passes with the fix. Verified with `./gradlew :webserver:test --tests "io.kestra.webserver.controllers.api.ExecutionControllerTest"` — 23 passing.

### 🤖 AI Authors

Why was the cat sitting on the keyboard? It heard the webhook was disabled and wanted to make sure *nothing* got triggered. 🐱