### PR TITLE
feat(core): add url to the default SDK authentication

### DIFF
--- a/core/src/main/java/io/kestra/core/runners/RunContextSDKFactory.java
+++ b/core/src/main/java/io/kestra/core/runners/RunContextSDKFactory.java
@@ -13,6 +13,7 @@ public class RunContextSDKFactory {
 
     static class SDKImpl implements SDK {
         private static final String AUTH_PROP = "kestra.tasks.sdk.authentication";
+        private static final String URL_PROP = AUTH_PROP + ".url";
         private static final String API_TOKEN_PROP = AUTH_PROP + ".api-token";
         private static final String USERNAME_PROP = AUTH_PROP + ".username";
         private static final String PASSWORD_PROP = AUTH_PROP + ".password";
@@ -20,8 +21,12 @@ public class RunContextSDKFactory {
         private final Auth sdkAuthentication;
 
         SDKImpl(ApplicationContext applicationContext) {
+            Optional<String> maybeUrl = applicationContext
+                .getProperty(URL_PROP, String.class)
+                .filter(url -> !url.isBlank()); // to avoid Optional.of("")
+
             this.sdkAuthentication = applicationContext.getProperty(API_TOKEN_PROP, String.class)
-                .map(it -> new SDK.Auth(Optional.of(it), Optional.empty(), Optional.empty()))
+                .map(it -> new SDK.Auth(maybeUrl, Optional.of(it), Optional.empty(), Optional.empty()))
                 .orElseGet(() ->
                 {
                     Optional<String> maybeUserName = applicationContext
@@ -33,12 +38,15 @@ public class RunContextSDKFactory {
                         .filter(password -> !password.isBlank()); // to avoid Optional.of("")
 
                     if (maybePassword.isPresent() && maybeUserName.isPresent()) {
-                        return new SDK.Auth(Optional.empty(), maybeUserName, maybePassword);
+                        return new SDK.Auth(maybeUrl, Optional.empty(), maybeUserName, maybePassword);
                     }
                     if (maybeUserName.isPresent() || maybePassword.isPresent()) {
                         throw new IllegalArgumentException(
                             "Both username and password must be provided if either is present: please configure both '" + USERNAME_PROP + "' and '" + PASSWORD_PROP + "' properties"
                         );
+                    }
+                    if (maybeUrl.isPresent()) {
+                        return new SDK.Auth(maybeUrl, Optional.empty(), Optional.empty(), Optional.empty());
                     }
                     return null;
                 });

--- a/core/src/main/java/io/kestra/core/runners/SDK.java
+++ b/core/src/main/java/io/kestra/core/runners/SDK.java
@@ -9,7 +9,7 @@ import io.micronaut.context.annotation.ConfigurationProperties;
  */
 public interface SDK {
     /**
-     * @return the default authentication to the API for SDK interactions.
+     * @return the default authentication to the API for SDK interactions, including the API URL to use if configured.
      *         On OSS: it returns an authentication configured inside the application configuration une the 'kestra.tasks.sdk.authentication' config properties.
      *         On EE: it tries first to locate a default authentication configured at the namespace level, then at the tenant level, then defaults to the application configuration provided one
      *         if any.
@@ -18,6 +18,7 @@ public interface SDK {
 
     @ConfigurationProperties("kestra.tasks.sdk.authentication")
     record Auth(
+        Optional<String> url,
         Optional<String> apiToken,
         Optional<String> username,
         Optional<String> password) {

--- a/core/src/test/java/io/kestra/core/runners/RunContextSDKTest.java
+++ b/core/src/test/java/io/kestra/core/runners/RunContextSDKTest.java
@@ -29,6 +29,7 @@ class RunContextSDKTest {
         RunContext runContext = runContextInitializer.forExecutor((DefaultRunContext) runContextFactory.of());
 
         assertThat(runContext.sdk().defaultAuthentication()).isPresent();
+        assertThat(runContext.sdk().defaultAuthentication().get().url()).isEmpty();
         assertThat(runContext.sdk().defaultAuthentication().get().username()).isEmpty();
         assertThat(runContext.sdk().defaultAuthentication().get().password()).isEmpty();
         assertThat(runContext.sdk().defaultAuthentication().get().apiToken()).isPresent();
@@ -42,10 +43,44 @@ class RunContextSDKTest {
         RunContext runContext = runContextInitializer.forExecutor((DefaultRunContext) runContextFactory.of());
 
         assertThat(runContext.sdk().defaultAuthentication()).isPresent();
+        assertThat(runContext.sdk().defaultAuthentication().get().url()).isEmpty();
         assertThat(runContext.sdk().defaultAuthentication().get().apiToken()).isEmpty();
         assertThat(runContext.sdk().defaultAuthentication().get().username()).isPresent();
         assertThat(runContext.sdk().defaultAuthentication().get().password()).isPresent();
         assertThat(runContext.sdk().defaultAuthentication().get().username().get()).isEqualTo("username");
         assertThat(runContext.sdk().defaultAuthentication().get().password().get()).isEqualTo("password");
+    }
+
+    @Test
+    @Property(name = "kestra.tasks.sdk.authentication.url", value = "https://my-instance.io")
+    @Property(name = "kestra.tasks.sdk.authentication.api-token", value = "test-key")
+    void sdkAuthShouldReturnUrlAlongsideApiKeyWhenSet() {
+        RunContext runContext = runContextInitializer.forExecutor((DefaultRunContext) runContextFactory.of());
+
+        assertThat(runContext.sdk().defaultAuthentication()).isPresent();
+        assertThat(runContext.sdk().defaultAuthentication().get().url()).contains("https://my-instance.io");
+        assertThat(runContext.sdk().defaultAuthentication().get().apiToken()).contains("test-key");
+    }
+
+    @Test
+    @Property(name = "kestra.tasks.sdk.authentication.url", value = "https://my-instance.io")
+    void sdkAuthShouldReturnUrlOnlyWhenSet() {
+        RunContext runContext = runContextInitializer.forExecutor((DefaultRunContext) runContextFactory.of());
+
+        assertThat(runContext.sdk().defaultAuthentication()).isPresent();
+        assertThat(runContext.sdk().defaultAuthentication().get().url()).contains("https://my-instance.io");
+        assertThat(runContext.sdk().defaultAuthentication().get().apiToken()).isEmpty();
+        assertThat(runContext.sdk().defaultAuthentication().get().username()).isEmpty();
+        assertThat(runContext.sdk().defaultAuthentication().get().password()).isEmpty();
+    }
+
+    @Test
+    @Property(name = "kestra.tasks.sdk.authentication.url", value = "   ")
+    @Property(name = "kestra.tasks.sdk.authentication.api-token", value = "test-key")
+    void sdkAuthShouldFilterOutBlankUrl() {
+        RunContext runContext = runContextInitializer.forExecutor((DefaultRunContext) runContextFactory.of());
+
+        assertThat(runContext.sdk().defaultAuthentication()).isPresent();
+        assertThat(runContext.sdk().defaultAuthentication().get().url()).isEmpty();
     }
 }


### PR DESCRIPTION
- Adds `url` as a new field on `SDK.Auth`, alongside `apiToken`/`username`/`password`
- `RunContextSDKFactory` threads `kestra.tasks.sdk.authentication.url` through with the same blank-filtering as the existing properties
- A config-only `url` (no token, no username/password) now yields a present `Auth` instead of `null`, so a URL-only default can still be consumed
- Companion PR: kestra-io/kestra-ee#9609 (adds the same field to the namespace/tenant "default authentication" UI)