### PR TITLE
feat(executor): add an execution-terminated notifier extension point

### DIFF
--- a/core/src/main/java/io/kestra/core/runners/ExecutionTerminatedNotifier.java
+++ b/core/src/main/java/io/kestra/core/runners/ExecutionTerminatedNotifier.java
@@ -1,0 +1,20 @@
+package io.kestra.core.runners;
+
+import io.kestra.core.models.executions.Execution;
+
+import io.micronaut.context.annotation.Secondary;
+import jakarta.inject.Singleton;
+
+public interface ExecutionTerminatedNotifier {
+
+    void executionTerminated(Execution execution);
+
+    @Singleton
+    @Secondary
+    class NoopExecutionTerminatedNotifier implements ExecutionTerminatedNotifier {
+        @Override
+        public void executionTerminated(Execution execution) {
+            // no-op
+        }
+    }
+}

--- a/core/src/test/java/io/kestra/core/runners/ExecutionTerminatedNotifierTest.java
+++ b/core/src/test/java/io/kestra/core/runners/ExecutionTerminatedNotifierTest.java
@@ -1,0 +1,78 @@
+package io.kestra.core.runners;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import io.kestra.core.junit.annotations.KestraTest;
+import io.kestra.core.junit.annotations.LoadFlows;
+import io.kestra.core.models.executions.Execution;
+import io.kestra.core.models.flows.State;
+
+import io.micronaut.context.annotation.Replaces;
+import io.micronaut.test.annotation.MockBean;
+import jakarta.inject.Inject;
+
+import static io.kestra.core.tenant.TenantService.MAIN_TENANT;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.timeout;
+import static org.mockito.Mockito.verify;
+
+@KestraTest(startRunner = true)
+class ExecutionTerminatedNotifierTest {
+    @Inject
+    TestRunnerUtils runnerUtils;
+
+    @Inject
+    ExecutionTerminatedNotifier executionTerminatedNotifier;
+
+    @MockBean
+    @Replaces(ExecutionTerminatedNotifier.NoopExecutionTerminatedNotifier.class)
+    ExecutionTerminatedNotifier executionTerminatedNotifier() {
+        return mock(ExecutionTerminatedNotifier.class);
+    }
+
+    @BeforeEach
+    void resetMock() {
+        // The mock is bound once at DefaultExecutor construction and shared across this class's
+        // test methods (the runner context persists between them), so invocations accumulate
+        // unless cleared here.
+        reset(executionTerminatedNotifier);
+    }
+
+    @Test
+    @LoadFlows({ "flows/valids/restart_always_failed.yaml" })
+    void notifiesOnceOnFailure() throws Exception {
+        runnerUtils.runOne(MAIN_TENANT, "io.kestra.tests", "restart_always_failed");
+
+        // The execution's terminal DB row is visible to runOne() as soon as the state transition
+        // commits, which happens before this notifier fires later in the same doRun() cycle — so
+        // the call can trail runOne()'s return by a few milliseconds; timeout() tolerates that gap
+        // instead of racing it.
+        verify(executionTerminatedNotifier, timeout(2000).times(1))
+            .executionTerminated(argThat(execution -> execution.getState().isFailed()));
+    }
+
+    @Test
+    @LoadFlows({ "flows/valids/minimal.yaml" })
+    void notifiesOnceOnSuccess() throws Exception {
+        runnerUtils.runOne(MAIN_TENANT, "io.kestra.tests", "minimal");
+
+        verify(executionTerminatedNotifier, timeout(2000).times(1))
+            .executionTerminated(argThat(execution -> execution.getState().getCurrent() == State.Type.SUCCESS));
+    }
+
+    @Test
+    @LoadFlows({ "flows/valids/restart_always_failed.yaml" })
+    void reachesFailedEvenWhenNotifierThrows() throws Exception {
+        doThrow(new RuntimeException("notifier boom")).when(executionTerminatedNotifier).executionTerminated(any());
+
+        Execution execution = runnerUtils.runOne(MAIN_TENANT, "io.kestra.tests", "restart_always_failed");
+
+        assertThat(execution.getState().getCurrent()).isEqualTo(State.Type.FAILED);
+    }
+}

--- a/executor/src/main/java/io/kestra/executor/DefaultExecutor.java
+++ b/executor/src/main/java/io/kestra/executor/DefaultExecutor.java
@@ -77,6 +77,7 @@ public class DefaultExecutor extends AbstractService implements Executor {
     private final DispatchQueueInterface<MultipleConditionEvent> multipleConditionEventQueue;
     private final DispatchQueueInterface<LoopExecutionEvent> loopExecutionEventQueue;
     private final DispatchQueueInterface<ExecutionStatistic> executionStatisticQueue;
+    private final ExecutionTerminatedNotifier executionTerminatedNotifier;
 
     private final ExecutorService executorService;
     private final ExecutionService executionService;
@@ -145,6 +146,7 @@ public class DefaultExecutor extends AbstractService implements Executor {
         DispatchQueueInterface<MultipleConditionEvent> multipleConditionEventQueue,
         DispatchQueueInterface<LoopExecutionEvent> loopExecutionEventQueue,
         DispatchQueueInterface<ExecutionStatistic> executionStatisticQueue,
+        ExecutionTerminatedNotifier executionTerminatedNotifier,
         ExecutorService executorService,
         ExecutionService executionService,
         FlowTriggerService flowTriggerService,
@@ -182,6 +184,7 @@ public class DefaultExecutor extends AbstractService implements Executor {
         this.multipleConditionEventQueue = multipleConditionEventQueue;
         this.loopExecutionEventQueue = loopExecutionEventQueue;
         this.executionStatisticQueue = executionStatisticQueue;
+        this.executionTerminatedNotifier = executionTerminatedNotifier;
         this.executorService = executorService;
         this.executionService = executionService;
         this.flowTriggerService = flowTriggerService;
@@ -691,12 +694,15 @@ public class DefaultExecutor extends AbstractService implements Executor {
                 // purge the trigger: reset scheduler trigger at end
                 // IMPORTANT: this is to cover an edge case, execution created for failed trigger didn't have any taskrun so they will arrive directly here.
                 // We need to detect that and reset them as they will never reach the reset code later on this method.
-                if (execution.getTrigger() != null &&
-                    (execution.getState().isFailed() || execution.getState().getCurrent().isKilled() || execution.getState().getCurrent().isCancelled()) &&
-                    ListUtils.isEmpty(execution.getTaskRunList())) {
+                if (
+                    execution.getTrigger() != null &&
+                        (execution.getState().isFailed() || execution.getState().getCurrent().isKilled() || execution.getState().getCurrent().isCancelled()) &&
+                        ListUtils.isEmpty(execution.getTaskRunList())
+                ) {
                     sendTriggerExecutionTerminated(execution);
                     this.followExecutionEventQueue.emit(new FollowExecutionEvent(execution, ExecutionEventType.TERMINATED));
                     emitExecutionStatistic(execution);
+                    notifyExecutionTerminated(execution);
                 }
 
                 return;
@@ -811,6 +817,7 @@ public class DefaultExecutor extends AbstractService implements Executor {
                 this.followExecutionEventQueue.emit(new FollowExecutionEvent(executor.getExecution(), ExecutionEventType.TERMINATED));
 
                 emitExecutionStatistic(execution);
+                notifyExecutionTerminated(execution);
             } else {
                 ExecutionEvent event = new ExecutionEvent(executor.getExecution(), ExecutionEventType.UPDATED);
                 this.executionEventQueue.emit(event);
@@ -840,6 +847,7 @@ public class DefaultExecutor extends AbstractService implements Executor {
                         this.followExecutionEventQueue.emit(new FollowExecutionEvent(failedExecution, ExecutionEventType.TERMINATED));
 
                         emitExecutionStatistic(failedExecution);
+                        notifyExecutionTerminated(failedExecution);
                     } catch (QueueException ex) {
                         log.error("Unable to emit the execution {}", failedExecution.getId(), ex);
                     }
@@ -859,11 +867,20 @@ public class DefaultExecutor extends AbstractService implements Executor {
         }
     }
 
+    private void notifyExecutionTerminated(Execution execution) {
+        try {
+            this.executionTerminatedNotifier.executionTerminated(execution);
+        } catch (Exception e) {
+            log.warn("Unable to notify execution terminated for execution '{}'", execution.getId(), e);
+        }
+    }
+
     private void sendTriggerExecutionTerminated(Execution execution) {
         // The scheduler didn't manage states for the WebHook and the Flow trigger
-        if (!execution.getTrigger().getType().equals(Webhook.class.getName()) &&
-            !execution.getTrigger().getType().equals(io.kestra.plugin.core.trigger.Flow.class.getName()) &&
-            !execution.getTrigger().getType().equals(io.kestra.plugin.core.flow.Subflow.class.getName())
+        if (
+            !execution.getTrigger().getType().equals(Webhook.class.getName()) &&
+                !execution.getTrigger().getType().equals(io.kestra.plugin.core.trigger.Flow.class.getName()) &&
+                !execution.getTrigger().getType().equals(io.kestra.plugin.core.flow.Subflow.class.getName())
         ) {
             TriggerId triggerId = TriggerId.of(execution.getTenantId(), execution.getNamespace(), execution.getFlowId(), execution.getTrigger().getId());
             triggerEventQueue.send(new TriggerExecutionTerminated(triggerId, execution.getId(), execution.getState().getCurrent()));


### PR DESCRIPTION
- Adds `ExecutionTerminatedNotifier`, a new extension point called once per terminated execution from `DefaultExecutor`'s three terminal-state sites
- Defaults to a no-op (mirrors `PausedTaskNotifier`); EE is the first consumer, added in the companion PR

Companion to kestra-io/kestra-ee#10427.