### PR TITLE
fix(core): reject negative or zero MAX_DURATION SLA durations at save time

### DIFF
--- a/core/src/main/java/io/kestra/core/models/flows/sla/types/MaxDurationSLA.java
+++ b/core/src/main/java/io/kestra/core/models/flows/sla/types/MaxDurationSLA.java
@@ -12,6 +12,7 @@ import io.kestra.core.models.flows.sla.SLA;
 import io.kestra.core.models.flows.sla.Violation;
 import io.kestra.core.runners.RunContext;
 import io.kestra.core.validations.DurationMax;
+import io.kestra.core.validations.DurationPositive;
 
 import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
@@ -24,6 +25,7 @@ import lombok.experimental.SuperBuilder;
 public class MaxDurationSLA extends SLA implements ExecutionMonitoringSLA {
     @NotNull
     @DurationMax
+    @DurationPositive
     private Duration duration;
 
     @Override

--- a/core/src/main/java/io/kestra/core/validations/DurationPositive.java
+++ b/core/src/main/java/io/kestra/core/validations/DurationPositive.java
@@ -1,0 +1,22 @@
+package io.kestra.core.validations;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+import io.kestra.core.validations.validator.DurationPositiveValidator;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+/**
+ * Rejects a {@link java.time.Duration} that is negative or zero.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = DurationPositiveValidator.class)
+public @interface DurationPositive {
+    String message() default "duration must be positive";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+}

--- a/core/src/main/java/io/kestra/core/validations/validator/DurationPositiveValidator.java
+++ b/core/src/main/java/io/kestra/core/validations/validator/DurationPositiveValidator.java
@@ -1,0 +1,34 @@
+package io.kestra.core.validations.validator;
+
+import java.time.Duration;
+
+import io.kestra.core.validations.DurationPositive;
+
+import io.micronaut.core.annotation.AnnotationValue;
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.core.annotation.Nullable;
+import io.micronaut.validation.validator.constraints.ConstraintValidator;
+import io.micronaut.validation.validator.constraints.ConstraintValidatorContext;
+import jakarta.inject.Singleton;
+
+@Singleton
+public class DurationPositiveValidator implements ConstraintValidator<DurationPositive, Duration> {
+    @Override
+    public boolean isValid(
+        @Nullable Duration value,
+        @NonNull AnnotationValue<DurationPositive> annotationMetadata,
+        @NonNull ConstraintValidatorContext context) {
+        if (value == null) {
+            return true;
+        }
+
+        if (value.isNegative() || value.isZero()) {
+            context.disableDefaultConstraintViolation();
+            context.buildConstraintViolationWithTemplate("duration '" + value + "' must be positive")
+                .addConstraintViolation();
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/core/src/test/java/io/kestra/core/validations/MaxDurationSLAValidationTest.java
+++ b/core/src/test/java/io/kestra/core/validations/MaxDurationSLAValidationTest.java
@@ -1,0 +1,92 @@
+package io.kestra.core.validations;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+
+import io.kestra.core.junit.annotations.KestraTest;
+import io.kestra.core.models.flows.FlowSource;
+import io.kestra.core.models.flows.sla.SLA;
+import io.kestra.core.models.flows.sla.types.MaxDurationSLA;
+import io.kestra.core.models.validations.ModelValidator;
+import io.kestra.core.models.validations.ValidateConstraintViolation;
+import io.kestra.core.services.FlowService;
+
+import jakarta.inject.Inject;
+import jakarta.validation.ConstraintViolationException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@KestraTest
+class MaxDurationSLAValidationTest {
+    @Inject
+    private ModelValidator modelValidator;
+
+    @Inject
+    private FlowService flowService;
+
+    @Test
+    void shouldValidatePositiveDuration() {
+        var sla = MaxDurationSLA.builder()
+            .id("dur")
+            .type(SLA.Type.MAX_DURATION)
+            .behavior(SLA.Behavior.FAIL)
+            .duration(Duration.ofHours(1))
+            .build();
+
+        Optional<ConstraintViolationException> valid = modelValidator.isValid(sla);
+        assertThat(valid.isEmpty()).isTrue();
+    }
+
+    @Test
+    void shouldNotValidateNegativeDuration() {
+        var sla = MaxDurationSLA.builder()
+            .id("dur")
+            .type(SLA.Type.MAX_DURATION)
+            .behavior(SLA.Behavior.FAIL)
+            .duration(Duration.ofHours(-1))
+            .build();
+
+        Optional<ConstraintViolationException> valid = modelValidator.isValid(sla);
+        assertThat(valid.isEmpty()).isFalse();
+        assertThat(valid.get().getMessage()).contains("must be positive");
+    }
+
+    @Test
+    void shouldNotValidateZeroDuration() {
+        var sla = MaxDurationSLA.builder()
+            .id("dur")
+            .type(SLA.Type.MAX_DURATION)
+            .behavior(SLA.Behavior.FAIL)
+            .duration(Duration.ZERO)
+            .build();
+
+        Optional<ConstraintViolationException> valid = modelValidator.isValid(sla);
+        assertThat(valid.isEmpty()).isFalse();
+        assertThat(valid.get().getMessage()).contains("must be positive");
+    }
+
+    @Test
+    void shouldNotValidateFlowWithNegativeSLADuration() {
+        String source = """
+            id: bad_sla
+            namespace: company.team
+            sla:
+              - id: dur
+                type: MAX_DURATION
+                duration: PT-1H
+                behavior: FAIL
+            tasks:
+              - id: t
+                type: io.kestra.plugin.core.log.Log
+                message: hello
+            """;
+
+        List<ValidateConstraintViolation> results = flowService.validate("my-tenant", List.of(new FlowSource(null, source)));
+
+        assertThat(results).hasSize(1);
+        assertThat(results.getFirst().getConstraints()).contains("must be positive");
+    }
+}


### PR DESCRIPTION
### 🔗 Related Issue

Closes https://github.com/kestra-io/kestra-ee/issues/10262.

### ✨ Description

A flow SLA of type `MAX_DURATION` with a negative `duration` (e.g. `PT-1H`) was accepted at save time and the flow showed as Valid. At execution the SLA was breached on the very first evaluation, so with `behavior: FAIL` every execution failed immediately. Zero (`PT0S`) had the same effect.

The `duration` field already had an upper bound (`@DurationMax`, 10 years) but no lower bound. This PR adds a `@DurationPositive` constraint — a new annotation + Micronaut validator mirroring the existing `@DurationMax` pair — and applies it to `MaxDurationSLA.duration`. Saving the repro flow from the issue now fails validation with `duration 'PT-1H' must be positive` instead of producing a flow whose every execution fails.

### 🛠️ Backend Checklist

- [x] Code compiles and tests pass for the touched modules (`./gradlew :core:test --tests "io.kestra.core.validations.*" --tests "io.kestra.core.models.flows.*"`)
- [x] New behavior is covered by unit or integration tests

### 📝 Additional Notes

Evidence: `MaxDurationSLAValidationTest` has four cases — positive duration valid, negative rejected, zero rejected, and the issue's exact flow YAML rejected through `FlowService.validate` (the save-time path). Three of the four fail on the commit before this one; all four pass with the fix.

Scope kept to the SLA field. `@DurationPositive` is reusable, but I did not retrofit it onto retry intervals or trigger windows in this PR.

🐱 Why did the cat's SLA always fail? It set `duration: PT-9L` — it wanted its nine lives *back*.