### PR TITLE
fix(core): apply plugin defaults to the task inside a TemplatedTask spec

### DIFF
--- a/core/src/main/java/io/kestra/core/services/PluginDefaultService.java
+++ b/core/src/main/java/io/kestra/core/services/PluginDefaultService.java
@@ -34,6 +34,7 @@ import io.kestra.core.models.flows.FlowInterface;
 import io.kestra.core.models.flows.FlowWithException;
 import io.kestra.core.models.flows.FlowWithSource;
 import io.kestra.core.models.flows.PluginDefault;
+import io.kestra.core.models.tasks.Task;
 import io.kestra.core.plugins.PluginRegistry;
 import io.kestra.core.queues.QueueException;
 import io.kestra.core.queues.QueueFactoryInterface;
@@ -41,9 +42,11 @@ import io.kestra.core.queues.QueueInterface;
 import io.kestra.core.runners.RunContextLogger;
 import io.kestra.core.serializers.JacksonMapper;
 import io.kestra.core.serializers.YamlParser;
+import io.kestra.core.utils.ListUtils;
 import io.kestra.core.utils.Logs;
 import io.kestra.core.utils.MapUtils;
 import io.kestra.plugin.core.flow.Template;
+import io.kestra.plugin.core.templating.TemplatedTask;
 
 import io.micronaut.context.annotation.Value;
 import io.micronaut.core.annotation.Nullable;
@@ -384,7 +387,7 @@ public class PluginDefaultService {
     public Map<String, Object> injectVersionDefaults(@Nullable final String tenantId,
         final String namespace,
         final Map<String, Object> mapFlow) throws FlowProcessingException {
-        return innerInjectDefault(tenantId, namespace, mapFlow, true);
+        return innerInjectDefault(tenantId, namespace, mapFlow, true).flow();
     }
 
     /**
@@ -448,9 +451,9 @@ public class PluginDefaultService {
         namespace = namespace == null ? (String) mapFlow.get("namespace") : namespace;
         revision = revision == null ? (Integer) mapFlow.get("revision") : revision;
 
-        mapFlow = innerInjectDefault(tenant, namespace, mapFlow, onlyVersions);
+        InjectedDefaults injected = innerInjectDefault(tenant, namespace, mapFlow, onlyVersions);
 
-        FlowWithSource withDefault = YamlParser.parse(mapFlow, FlowWithSource.class, strictParsing);
+        FlowWithSource withDefault = YamlParser.parse(injected.flow(), FlowWithSource.class, strictParsing);
 
         // revision, tenants, and deleted are not in the 'source', so we copy them manually
         FlowWithSource full = withDefault.toBuilder()
@@ -460,19 +463,31 @@ public class PluginDefaultService {
             .source(source)
             .build();
 
-        if (templatesEnabled && tenant != null) {
-            // This is a hack to set the tenant in template tasks.
-            // When using the Template task, we need the tenant to fetch the Template from the database.
-            // However, as the task is executed on the Executor we cannot retrieve it from the tenant service and have no other options.
-            // So we save it at flow creation/updating time.
-            full.allTasksWithChilds().stream().filter(task -> task instanceof Template).forEach(task -> ((Template) task).setTenantId(tenant));
+        boolean setTemplateTenant = templatesEnabled && tenant != null;
+        if (!onlyVersions || setTemplateTenant) {
+            for (Task task : full.allTasksWithChilds()) {
+                if (!onlyVersions && task instanceof TemplatedTask templatedTask) {
+                    // A TemplatedTask only knows which plugin it runs once its spec is rendered, so the map walk
+                    // above cannot inject defaults into it. Carry the resolved defaults on the task instead: the
+                    // worker running it cannot resolve them itself, as namespace-level defaults are not reachable
+                    // from a worker node. Always set, so a value written in the flow source is never honoured.
+                    templatedTask.setResolvedPluginDefaults(injected.defaults().isEmpty() ? null : injected.defaults());
+                }
+
+                if (setTemplateTenant && task instanceof Template template) {
+                    // This is a hack to set the tenant in template tasks.
+                    // When using the Template task, we need the tenant to fetch the Template from the database.
+                    // However, as the task is executed on the Executor we cannot retrieve it from the tenant service and have no other options.
+                    // So we save it at flow creation/updating time.
+                    template.setTenantId(tenant);
+                }
+            }
         }
 
         return full;
     }
 
-    @SuppressWarnings("unchecked")
-    private Map<String, Object> innerInjectDefault(final String tenantId, final String namespace, Map<String, Object> flowAsMap, final boolean onlyVersions) {
+    private InjectedDefaults innerInjectDefault(final String tenantId, final String namespace, Map<String, Object> flowAsMap, final boolean onlyVersions) {
         List<PluginDefault> allDefaults = getAllDefaults(tenantId, namespace, flowAsMap);
 
         if (onlyVersions) {
@@ -491,13 +506,29 @@ public class PluginDefaultService {
 
         if (allDefaults.isEmpty()) {
             // no defaults to inject - return immediately.
-            return flowAsMap;
+            return new InjectedDefaults(flowAsMap, List.of());
         }
 
         // alias-canonicalize all defaults (type-matched and named) so a default declared with a plugin alias
         // also matches the canonical plugin type.
         addAliases(allDefaults);
 
+        return new InjectedDefaults(applyDefaults(flowAsMap, allDefaults, onlyVersions), allDefaults);
+    }
+
+    /**
+     * Applies the given already-resolved defaults to an arbitrary plugin tree: either a whole flow, or a single
+     * plugin definition as done for {@link TemplatedTask}.
+     *
+     * <p>
+     * The defaults must already be alias-canonicalized (see {@code addAliases}); this method is otherwise pure,
+     * so it can run on a node that cannot resolve defaults itself.
+     * </p>
+     *
+     * @param allDefaults the resolved defaults, ordered most-important-first (flow, namespace, global)
+     */
+    @SuppressWarnings("unchecked")
+    private Map<String, Object> applyDefaults(Map<String, Object> pluginTree, final List<PluginDefault> allDefaults, final boolean onlyVersions) {
         // split named (ref) defaults from type-matched defaults: a 'ref' default is applied only to plugins
         // that explicitly opt in via 'pluginDefaultsRef', never by type matching.
         Map<Boolean, List<PluginDefault>> byHasRef = allDefaults
@@ -524,42 +555,71 @@ public class PluginDefaultService {
         // forced defaults stamp over the result, so the last (admin-most) entry wins — global beats namespace beats flow.
         Map<String, List<PluginDefault>> forced = pluginDefaultsToMap(allDefaultsGroup.getOrDefault(true, Collections.emptyList()));
 
-        Object pluginDefaults = flowAsMap.get(PLUGIN_DEFAULTS_FIELD);
+        Object pluginDefaults = pluginTree.get(PLUGIN_DEFAULTS_FIELD);
         if (pluginDefaults != null) {
-            flowAsMap.remove(PLUGIN_DEFAULTS_FIELD);
+            pluginTree.remove(PLUGIN_DEFAULTS_FIELD);
         }
 
         // 1. non-forced type-matched defaults — suppressed for plugins that opted into a named (ref) default
         if (!defaults.isEmpty()) {
-            flowAsMap = (Map<String, Object>) recursiveDefaults(flowAsMap, defaults, false);
+            pluginTree = (Map<String, Object>) recursiveDefaults(pluginTree, defaults, false);
         }
 
         // 2. named (ref) defaults — applied to plugins declaring a matching 'pluginDefaultsRef', UNLESS a forced
         // type-matched default also applies to that plugin: enforcement takes over entirely and the ref is ignored
         // (it must not stack on top of enforced values). Skipped when only injecting version defaults.
         if (!onlyVersions && !refMatches.isEmpty()) {
-            flowAsMap = (Map<String, Object>) recursiveRefDefaults(flowAsMap, refMatches, forced.keySet());
+            pluginTree = (Map<String, Object>) recursiveRefDefaults(pluginTree, refMatches, forced.keySet());
         }
 
         // 3. forced type-matched defaults are admin enforcement and applied LAST so they win over everything,
         // including a forced ref default — otherwise a flow could bypass enforcement via a forced ref.
         // A WARN is logged when enforced onto a plugin that declared a 'pluginDefaultsRef'.
         if (!forced.isEmpty()) {
-            flowAsMap = (Map<String, Object>) recursiveDefaults(flowAsMap, forced, true);
+            pluginTree = (Map<String, Object>) recursiveDefaults(pluginTree, forced, true);
         }
 
         // 4. consume the 'pluginDefaultsRef' marker for refs that were actually applied (resolved + type match);
         // a surviving marker therefore unambiguously means "unresolved or inapplicable" (validation error + runtime failure).
         if (!onlyVersions && !refMatches.isEmpty()) {
-            flowAsMap = (Map<String, Object>) stripAppliedRefMarkers(flowAsMap, refMatches);
+            pluginTree = (Map<String, Object>) stripAppliedRefMarkers(pluginTree, refMatches);
         }
 
         if (pluginDefaults != null) {
-            flowAsMap.put(PLUGIN_DEFAULTS_FIELD, pluginDefaults);
+            pluginTree.put(PLUGIN_DEFAULTS_FIELD, pluginDefaults);
         }
 
-        return flowAsMap;
+        return pluginTree;
+    }
 
+    /**
+     * The result of resolving and injecting defaults into a flow: the defaulted flow, and the defaults that were
+     * resolved for it. The resolved defaults are carried further for plugins that build their definition at
+     * runtime and must apply the defaults themselves — see {@link #applyResolvedDefaults(Map, List)}.
+     */
+    private record InjectedDefaults(Map<String, Object> flow, List<PluginDefault> defaults) {
+    }
+
+    /**
+     * Applies already-resolved defaults to a single plugin definition.
+     *
+     * <p>
+     * Defaults are normally injected while parsing the flow, but a {@link TemplatedTask} only knows the plugin it
+     * runs once its spec has been rendered, at which point the flow is long parsed and the defaults can no longer
+     * be resolved: namespace-level defaults are not reachable from a worker. It therefore carries the defaults
+     * resolved for its flow and applies them itself through this method.
+     * </p>
+     *
+     * @param plugin the plugin definition, as a map
+     * @param resolvedDefaults the defaults resolved for the flow the plugin belongs to
+     * @return the plugin definition with the matching defaults applied
+     */
+    public Map<String, Object> applyResolvedDefaults(final Map<String, Object> plugin, final List<PluginDefault> resolvedDefaults) {
+        if (ListUtils.isEmpty(resolvedDefaults)) {
+            return plugin;
+        }
+
+        return applyDefaults(plugin, resolvedDefaults, false);
     }
 
     /**
@@ -963,7 +1023,7 @@ public class PluginDefaultService {
         }
 
         Map<String, Object> mapFlow = NON_DEFAULT_OBJECT_MAPPER.convertValue(flow, JacksonMapper.MAP_TYPE_REFERENCE);
-        mapFlow = innerInjectDefault(flow.getTenantId(), flow.getNamespace(), mapFlow, false);
+        mapFlow = innerInjectDefault(flow.getTenantId(), flow.getNamespace(), mapFlow, false).flow();
         return YamlParser.parse(mapFlow, Flow.class, false);
     }
 }

--- a/core/src/main/java/io/kestra/plugin/core/templating/TemplatedTask.java
+++ b/core/src/main/java/io/kestra/plugin/core/templating/TemplatedTask.java
@@ -1,23 +1,32 @@
 package io.kestra.plugin.core.templating;
 
+import java.util.List;
+import java.util.Map;
+
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import io.kestra.core.exceptions.IllegalVariableEvaluationException;
 import io.kestra.core.models.annotations.Example;
 import io.kestra.core.models.annotations.Plugin;
+import io.kestra.core.models.flows.PluginDefault;
 import io.kestra.core.models.property.Property;
 import io.kestra.core.models.tasks.Output;
 import io.kestra.core.models.tasks.RunnableTask;
 import io.kestra.core.models.tasks.Task;
+import io.kestra.core.runners.DefaultRunContext;
 import io.kestra.core.runners.RunContext;
 import io.kestra.core.serializers.JacksonMapper;
+import io.kestra.core.services.PluginDefaultService;
+import io.kestra.core.utils.ListUtils;
 
+import io.swagger.v3.oas.annotations.Hidden;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 import lombok.ToString;
 import lombok.experimental.SuperBuilder;
 
@@ -30,6 +39,8 @@ import lombok.experimental.SuperBuilder;
     title = "Render and run a task from a templated spec.",
     description = """
         Renders a YAML task definition from `spec` using Pebble and executes it. The rendered task must be a RunnableTask and cannot itself be `TemplatedTask`.
+
+        The plugin defaults declared for the rendered task type are applied to it, as they are for any task declared directly in the flow.
 
         Useful for highly dynamic task definitions driven by inputs or previous outputs."""
 )
@@ -52,11 +63,27 @@ public class TemplatedTask extends Task implements RunnableTask<Output> {
     @Schema(title = "The templated task specification")
     private Property<String> spec;
 
+    /**
+     * The plugin defaults resolved for the flow this task belongs to, set while the flow is parsed.
+     *
+     * <p>
+     * The templated plugin is only known once {@code spec} has been rendered, which happens on a worker, long
+     * after the flow was parsed and where the defaults can no longer be resolved. They are therefore resolved
+     * with the rest of the flow's defaults and carried here — see
+     * {@link PluginDefaultService#applyResolvedDefaults(Map, List)}.
+     * </p>
+     */
+    @Hidden
+    @Setter // we have no other option here as we need to update the task inside the flow when parsing it
+    @EqualsAndHashCode.Exclude
+    @ToString.Exclude
+    private List<PluginDefault> resolvedPluginDefaults;
+
     @Override
     public Output run(RunContext runContext) throws Exception {
         String taskSpec = runContext.render(this.spec).as(String.class).orElseThrow();
         try {
-            Task task = OBJECT_MAPPER.readValue(taskSpec, Task.class);
+            Task task = parseTask(runContext, taskSpec);
             if (task instanceof TemplatedTask) {
                 throw new IllegalArgumentException("The templated task cannot be of type 'io.kestra.plugin.core.templating.TemplatedTask'");
             }
@@ -75,5 +102,41 @@ public class TemplatedTask extends Task implements RunnableTask<Output> {
         } catch (JsonProcessingException e) {
             throw new IllegalVariableEvaluationException(e);
         }
+    }
+
+    /**
+     * Builds the templated task from its rendered spec: plugin defaults are applied to it as they would have been
+     * to a task declared directly in the flow, then the task is validated so that a missing required property is
+     * reported as such instead of failing the plugin at runtime.
+     */
+    private Task parseTask(RunContext runContext, String taskSpec) throws JsonProcessingException {
+        Map<String, Object> spec = OBJECT_MAPPER.readValue(taskSpec, JacksonMapper.MAP_TYPE_REFERENCE);
+
+        // the task built here is a task of this flow: it inherits this task's id unless the spec sets its own,
+        // as the id is otherwise required and would fail validation.
+        if (this.id != null) {
+            spec.putIfAbsent("id", this.id);
+        }
+
+        if (!ListUtils.isEmpty(this.resolvedPluginDefaults)) {
+            spec = ((DefaultRunContext) runContext).getApplicationContext()
+                .getBean(PluginDefaultService.class)
+                .applyResolvedDefaults(spec, this.resolvedPluginDefaults);
+        }
+
+        Task task;
+        try {
+            task = OBJECT_MAPPER.convertValue(spec, Task.class);
+        } catch (IllegalArgumentException e) {
+            // convertValue wraps deserialization failures; unwrap so they are reported as spec errors
+            if (e.getCause() instanceof JsonProcessingException cause) {
+                throw cause;
+            }
+            throw e;
+        }
+
+        runContext.validate(task);
+
+        return task;
     }
 }

--- a/core/src/test/java/io/kestra/core/services/PluginDefaultServiceTest.java
+++ b/core/src/test/java/io/kestra/core/services/PluginDefaultServiceTest.java
@@ -32,7 +32,9 @@ import io.kestra.core.models.triggers.TriggerOutput;
 import io.kestra.core.runners.RunContext;
 import io.kestra.core.utils.TestsUtils;
 import io.kestra.plugin.core.condition.Expression;
+import io.kestra.plugin.core.flow.Sequential;
 import io.kestra.plugin.core.log.Log;
+import io.kestra.plugin.core.templating.TemplatedTask;
 import io.kestra.plugin.core.trigger.Schedule;
 
 import ch.qos.logback.classic.Logger;
@@ -48,6 +50,7 @@ import lombok.experimental.SuperBuilder;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.is;
 
 @KestraTest
@@ -82,6 +85,40 @@ class PluginDefaultServiceTest {
         // Then
         Log task = (Log) result.getTasks().getFirst();
         assertThat(task.getMessage(), is("This is a default message"));
+    }
+
+    @Test
+    void shouldCarryResolvedDefaultsWhenInjectingDefaultsGivenNestedTemplatedTask() throws FlowProcessingException {
+        // Given: a templated task nested in a flowable — its spec is a plain string, so the injection walk
+        // cannot reach the plugin it templates.
+        var tenant = TestsUtils.randomTenant(PluginDefaultServiceTest.class.getSimpleName());
+        FlowInterface flow = GenericFlow.fromYaml(tenant, """
+            id: test
+            namespace: io.kestra.unittest
+            pluginDefaults:
+              - type: io.kestra.plugin.core.debug.Return
+                values:
+                  format: This is a default format
+            tasks:
+              - id: parent
+                type: io.kestra.plugin.core.flow.Sequential
+                tasks:
+                  - id: templated
+                    type: io.kestra.plugin.core.templating.TemplatedTask
+                    spec: |
+                      type: io.kestra.plugin.core.debug.Return
+            """);
+
+        // When
+        FlowWithSource result = pluginDefaultService.injectAllDefaults(flow, true);
+
+        // Then: the resolved defaults are carried on the task, to be applied once its spec is rendered.
+        Sequential parent = (Sequential) result.getTasks().getFirst();
+        TemplatedTask templated = (TemplatedTask) parent.getTasks().getFirst();
+        assertThat(
+            templated.getResolvedPluginDefaults().stream().map(PluginDefault::getType).toList(),
+            hasItem("io.kestra.plugin.core.debug.Return")
+        );
     }
 
     @Test

--- a/core/src/test/java/io/kestra/plugin/core/templating/TemplatedTaskTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/templating/TemplatedTaskTest.java
@@ -1,17 +1,34 @@
 package io.kestra.plugin.core.templating;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 
 import org.junit.jupiter.api.Test;
+import org.slf4j.LoggerFactory;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 import io.kestra.core.context.TestRunContextFactory;
 import io.kestra.core.junit.annotations.KestraTest;
+import io.kestra.core.models.executions.Execution;
+import io.kestra.core.models.flows.FlowWithSource;
+import io.kestra.core.models.flows.GenericFlow;
 import io.kestra.core.models.property.Property;
 import io.kestra.core.models.tasks.Output;
+import io.kestra.core.models.tasks.Task;
 import io.kestra.core.runners.RunContext;
+import io.kestra.core.serializers.JacksonMapper;
+import io.kestra.core.services.PluginDefaultService;
+import io.kestra.core.utils.TestsUtils;
 import io.kestra.plugin.core.debug.Return;
+import io.kestra.plugin.core.log.Log;
 
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.AppenderBase;
 import jakarta.inject.Inject;
+import jakarta.validation.ConstraintViolationException;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -21,6 +38,9 @@ class TemplatedTaskTest {
 
     @Inject
     private TestRunContextFactory runContextFactory;
+
+    @Inject
+    private PluginDefaultService pluginDefaultService;
 
     @Test
     void templatedType() throws Exception {
@@ -68,6 +88,225 @@ class TemplatedTaskTest {
 
         var exception = assertThrows(IllegalArgumentException.class, () -> templatedTask.run(runContext));
         assertThat(exception.getMessage()).isEqualTo("The templated task cannot be of type 'io.kestra.plugin.core.templating.TemplatedTask'");
+    }
+
+    @Test
+    void shouldApplyDefaultWhenSpecOmitsPropertyGivenNonForcedPluginDefault() throws Exception {
+        // Given
+        TemplatedTask templatedTask = templatedTaskOf("""
+            id: templated-defaults
+            namespace: io.kestra.unittest
+            pluginDefaults:
+              - type: io.kestra.plugin.core.debug.Return
+                values:
+                  format: It's alive!
+            tasks:
+              - id: template
+                type: io.kestra.plugin.core.templating.TemplatedTask
+                spec: |
+                  type: io.kestra.plugin.core.debug.Return
+            """);
+
+        // When
+        Output output = templatedTask.run(runContextFactory.of());
+
+        // Then
+        assertThat(((Return.Output) output).getValue()).isEqualTo("It's alive!");
+    }
+
+    @Test
+    void shouldKeepSpecValueWhenSpecSetsPropertyGivenNonForcedPluginDefault() throws Exception {
+        // Given
+        TemplatedTask templatedTask = templatedTaskOf("""
+            id: templated-defaults
+            namespace: io.kestra.unittest
+            pluginDefaults:
+              - type: io.kestra.plugin.core.debug.Return
+                values:
+                  format: It's alive!
+            tasks:
+              - id: template
+                type: io.kestra.plugin.core.templating.TemplatedTask
+                spec: |
+                  type: io.kestra.plugin.core.debug.Return
+                  format: It's mine!
+            """);
+
+        // When
+        Output output = templatedTask.run(runContextFactory.of());
+
+        // Then
+        assertThat(((Return.Output) output).getValue()).isEqualTo("It's mine!");
+    }
+
+    @Test
+    void shouldOverrideSpecValueWhenSpecSetsPropertyGivenForcedPluginDefault() throws Exception {
+        // Given
+        TemplatedTask templatedTask = templatedTaskOf("""
+            id: templated-defaults
+            namespace: io.kestra.unittest
+            pluginDefaults:
+              - type: io.kestra.plugin.core.debug.Return
+                forced: true
+                values:
+                  format: It's alive!
+            tasks:
+              - id: template
+                type: io.kestra.plugin.core.templating.TemplatedTask
+                spec: |
+                  type: io.kestra.plugin.core.debug.Return
+                  format: It's mine!
+            """);
+
+        // When
+        Output output = templatedTask.run(runContextFactory.of());
+
+        // Then
+        assertThat(((Return.Output) output).getValue()).isEqualTo("It's alive!");
+    }
+
+    /**
+     * The flow reported in ticket #2253: a plain task and a templated task of the same type must both pick up the
+     * default. The report used a namespace-level default, declared on the flow here — both are resolved into the
+     * same list, so the templated task sees them identically.
+     */
+    @Test
+    void shouldLogSameMessageWhenPlainAndTemplatedTaskRunGivenPluginDefaultForTaskType() throws Exception {
+        // Given
+        FlowWithSource flow = flowOf("""
+            id: test_defaults
+            namespace: company.team
+
+            pluginDefaults:
+              - type: io.kestra.plugin.core.log.Log
+                values:
+                  message: "{{ vars.message }} xyz"
+
+            variables:
+              message: abc
+
+            tasks:
+              - id: test1
+                type: io.kestra.plugin.core.log.Log
+              - id: test2
+                type: io.kestra.plugin.core.templating.TemplatedTask
+                spec: |
+                  type: io.kestra.plugin.core.log.Log
+            """);
+
+        Log plain = (Log) flow.getTasks().getFirst();
+        TemplatedTask templated = (TemplatedTask) flow.getTasks().get(1);
+
+        // the expectation is the plain task's own defaulted message rather than a literal, so the test does not also
+        // pin down which default level wins: the core test configuration declares a global default for this type.
+        String expected = runContextOf(flow, plain).render((String) plain.getMessage());
+        assertThat(expected).isNotBlank();
+
+        // When
+        List<String> logged = capturingFlowLogs(() ->
+        {
+            plain.run(runContextOf(flow, plain));
+            templated.run(runContextOf(flow, templated));
+        });
+
+        // Then - the invariant the report asks for: the templated task logs exactly what the plain task logs
+        assertThat(logged.stream().filter(expected::equals).count()).isEqualTo(2);
+    }
+
+    @Test
+    void shouldApplyDefaultWhenSpecDeclaresPluginDefaultsRefGivenNamedPluginDefault() throws Exception {
+        // Given
+        TemplatedTask templatedTask = templatedTaskOf("""
+            id: templated-defaults
+            namespace: io.kestra.unittest
+            pluginDefaults:
+              - type: io.kestra.plugin.core.debug.Return
+                ref: alive
+                values:
+                  format: It's alive!
+            tasks:
+              - id: template
+                type: io.kestra.plugin.core.templating.TemplatedTask
+                spec: |
+                  type: io.kestra.plugin.core.debug.Return
+                  pluginDefaultsRef: alive
+            """);
+
+        // When
+        Output output = templatedTask.run(runContextFactory.of());
+
+        // Then
+        assertThat(((Return.Output) output).getValue()).isEqualTo("It's alive!");
+    }
+
+    @Test
+    void shouldFailValidationWhenSpecOmitsRequiredPropertyGivenNoPluginDefault() {
+        // Given
+        RunContext runContext = runContextFactory.of();
+        TemplatedTask templatedTask = TemplatedTask.builder()
+            .id("template")
+            .type(TemplatedTask.class.getName())
+            .spec(Property.ofValue("type: io.kestra.plugin.core.http.Download"))
+            .build();
+
+        // When
+        var exception = assertThrows(ConstraintViolationException.class, () -> templatedTask.run(runContext));
+
+        // Then
+        assertThat(exception.getMessage()).contains("uri");
+    }
+
+    /**
+     * The single templated task of the given flow, parsed the way the runtime does: plugin defaults are resolved
+     * while the flow is parsed, so the whole path must be exercised for them to reach the task. The task is
+     * serialized and read back, as it is when the executor hands it to a worker.
+     */
+    private TemplatedTask templatedTaskOf(String source) throws Exception {
+        FlowWithSource flow = flowOf(source);
+
+        ObjectMapper mapper = JacksonMapper.ofJson();
+        return (TemplatedTask) mapper.readValue(mapper.writeValueAsString(flow.getTasks().getFirst()), Task.class);
+    }
+
+    private FlowWithSource flowOf(String source) throws Exception {
+        String tenant = TestsUtils.randomTenant(TemplatedTaskTest.class.getSimpleName());
+        return pluginDefaultService.injectAllDefaults(GenericFlow.fromYaml(tenant, source), true);
+    }
+
+    /**
+     * A run context as the executor builds it, so that the flow's own variables resolve and the task logs under the
+     * 'flow' logger {@link #capturingFlowLogs(ThrowingRunnable)} listens on.
+     */
+    private RunContext runContextOf(FlowWithSource flow, Task task) {
+        Execution execution = TestsUtils.mockExecution(flow, Map.of(), null);
+        return runContextFactory.of(flow, task, execution, TestsUtils.mockTaskRun(execution, task));
+    }
+
+    /** Runs the given tasks and returns what they logged. */
+    private static List<String> capturingFlowLogs(ThrowingRunnable runnable) throws Exception {
+        Logger flowLogger = (Logger) LoggerFactory.getLogger("flow");
+        List<String> messages = new ArrayList<>();
+        AppenderBase<ILoggingEvent> appender = new AppenderBase<>() {
+            @Override
+            protected void append(ILoggingEvent event) {
+                messages.add(event.getFormattedMessage());
+            }
+        };
+        appender.setContext(flowLogger.getLoggerContext());
+        appender.start();
+        flowLogger.addAppender(appender);
+
+        try {
+            runnable.run();
+        } finally {
+            flowLogger.detachAppender(appender);
+        }
+
+        return messages;
+    }
+
+    private interface ThrowingRunnable {
+        void run() throws Exception;
     }
 
 }


### PR DESCRIPTION
Closes #8807.

## Problem

With a namespace default of `message: "{{ vars.message }} xyz"` on `io.kestra.plugin.core.log.Log`:

```yaml
tasks:
  - id: test1
    type: io.kestra.plugin.core.log.Log          # logs "abc xyz"
  - id: test2
    type: io.kestra.plugin.core.templating.TemplatedTask
    spec: |
      type: io.kestra.plugin.core.log.Log        # NPEs
```
PluginDefaultService.innerInjectDefault walks the flow as a Map and applies defaults to
nodes carrying a type key. TemplatedTask.spec is a string, so the walk stops there, and
TemplatedTask.run then deserializes its task with no defaults layer. Global, namespace and
flow defaults all feed that one walk, which is why all three fail identically. forced: true
defaults are skipped too, so a templated task escapes enforcement.

Changes
- PluginDefaultService: innerInjectDefault returns the defaulted flow and the defaults it
  resolved; the pure map transform is split out as applyDefaults and exposed as
  applyResolvedDefaults(Map, List<PluginDefault>) for a single plugin definition.
- parseFlowWithAllDefaults stamps the resolved defaults onto every TemplatedTask, reusing
  the task-tree walk the Template tenant injection already does. Skipped on the
  version-defaults-only path so nothing enters persisted flow source, and always overwritten so
  a value written in a flow is never honoured.
- TemplatedTask.run parses the rendered spec to a map, applies the defaults, then builds and
  validates the task via runContext.validate.