### PR TITLE
docs: add RepoCloud as a deployment option

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,8 @@ Deploy Kestra on Google Cloud Infrastructure Manager using [our Terraform module
 
 ### Deploy on RepoCloud
 
+Deploy Kestra on RepoCloud with one click:
+
 [![Deploy on RepoCloud](https://d16t0pc4846x52.cloudfront.net/deploylobe.svg)](https://repocloud.io/details/Kestra/)
 
 ### Get Started Locally in 5 Minutes

--- a/README.md
+++ b/README.md
@@ -87,6 +87,10 @@ Deploy Kestra on AWS using our CloudFormation template:
 
 Deploy Kestra on Google Cloud Infrastructure Manager using [our Terraform module](https://github.com/kestra-io/deployment-templates/tree/main/gcp/terraform/infrastructure-manager/vm-sql-gcs).
 
+### Deploy on RepoCloud
+
+[![Deploy on RepoCloud](https://d16t0pc4846x52.cloudfront.net/deploylobe.svg)](https://repocloud.io/details/Kestra/)
+
 ### Get Started Locally in 5 Minutes
 
 #### Launch Kestra in Docker


### PR DESCRIPTION
Adds [RepoCloud](https://repocloud.io) as a one-click deployment option in the Quick Start section,
alongside the existing AWS CloudFormation and Google Cloud Terraform options.

RepoCloud provides managed cloud hosting for open-source applications with one-click deployment.

- Adds new "Deploy on RepoCloud" subsection to Quick Start in `README.md`
- Uses the same markdown image button format (no explicit height) as the existing AWS Launch Stack button
- Links to: https://repocloud.io/details/Kestra/