### PR TITLE
fix(ai): keep line breaks and render fenced code blocks in copilot user messages

### DIFF
--- a/ui/src/components/ai/copilot/CopilotMessage.vue
+++ b/ui/src/components/ai/copilot/CopilotMessage.vue
@@ -1,7 +1,10 @@
 <template>
     <div v-if="message.role === 'USER'" class="copilot-msg copilot-msg-user">
         <div class="copilot-bubble copilot-bubble-user">
-            <KsText size="small" class="copilot-bubble-text">{{ message.content }}</KsText>
+            <template v-for="(segment, index) in userSegments" :key="index">
+                <pre v-if="segment.code" class="copilot-user-code" data-test="copilot-user-code">{{ segment.content }}</pre>
+                <KsText v-else size="small" class="copilot-bubble-text">{{ segment.content }}</KsText>
+            </template>
         </div>
     </div>
 
@@ -116,6 +119,26 @@
         isRunning?: boolean
     }>()
 
+    // The user prompt rendered literally, split on ``` fences only — full markdown would mangle
+    // pasted code (a YAML `# comment` must not become a heading) (kestra-io/kestra-ee#10420).
+    const userSegments = computed<{code: boolean; content: string}[]>(() => {
+        const content = props.message.content ?? ""
+        const segments: {code: boolean; content: string}[] = []
+        const push = (code: boolean, text: string) => {
+            const value = code ? text : text.trim()
+            if (value.trim()) segments.push({code, content: value})
+        }
+        const fence = /```[^\n]*\n([\s\S]*?)(?:\n?```|$)/g
+        let cursor = 0
+        for (const match of content.matchAll(fence)) {
+            push(false, content.slice(cursor, match.index))
+            push(true, match[1])
+            cursor = (match.index ?? 0) + match[0].length
+        }
+        push(false, content.slice(cursor))
+        return segments
+    })
+
     // Display-only proposal for a historical PROPOSED_ACTION message: the live event carries the full
     // proposal; a reloaded one carries the summary as `content` and the held tool as `toolCall`.
     const historicalProposal = computed<ProposedActionEvent>(() =>
@@ -215,6 +238,28 @@
         padding: var(--ks-spacing-2) var(--ks-spacing-3);
         border-radius: var(--ks-radius-lg);
         background: var(--ks-bg-elevated);
+    }
+
+    /* Pasted multi-line text keeps its line breaks and indentation instead of collapsing into
+       one long line (kestra-io/kestra-ee#10420). */
+    .copilot-bubble-text {
+        white-space: pre-wrap;
+        word-break: break-word;
+    }
+
+    /* A ``` fenced segment of the user prompt, shown as a literal code block. Wraps instead of
+       scrolling so the whole snippet stays readable inside the narrow bubble. */
+    .copilot-user-code {
+        margin: var(--ks-spacing-1) 0;
+        padding: var(--ks-spacing-2);
+        border: 1px solid var(--ks-border-subtle);
+        border-radius: var(--ks-radius-sm);
+        background: var(--ks-bg-base);
+        font-family: var(--ks-font-family-mono);
+        font-size: var(--ks-font-size-sm);
+        line-height: 1.5;
+        white-space: pre-wrap;
+        word-break: break-word;
     }
 
     /* Assistant replies get their own left-aligned bubble (surface fill) so they read as

--- a/ui/tests/storybook/components/ai/copilot/CopilotMessage.stories.ts
+++ b/ui/tests/storybook/components/ai/copilot/CopilotMessage.stories.ts
@@ -24,6 +24,17 @@ export const UserPrompt: Story = {
     args: {message: {id: "1", role: "USER", type: "TEXT", content: "Add error handling to my dbt flow."}},
 }
 
+export const UserPromptWithCode: Story = {
+    args: {
+        message: {
+            id: "1c",
+            role: "USER",
+            type: "TEXT",
+            content: "This flow fails on start:\n```yaml\nid: hello\nnamespace: company.team\ntasks:\n  - id: log\n    type: io.kestra.plugin.core.log.Log\n    message: Hello\n```\nAny idea why?",
+        },
+    },
+}
+
 export const AssistantMarkdown: Story = {
     args: {message: {id: "2", role: "ASSISTANT", type: "TEXT", content: "Sure — I'll add a `errors:` block with a **Slack** alert."}},
 }

--- a/ui/tests/unit/components/ai/copilot/CopilotMessage.spec.ts
+++ b/ui/tests/unit/components/ai/copilot/CopilotMessage.spec.ts
@@ -14,6 +14,34 @@ describe("CopilotMessage", () => {
         expect(w.text()).toContain("hello there")
     })
 
+    it("renders a ``` fenced segment of the user prompt as a literal code block", () => {
+        const w = mountMessage({
+            id: "1a", role: "USER", type: "TEXT",
+            content: "Fix this flow:\n```yaml\nid: demo\nnamespace: company.team\n```\nIt fails on start.",
+        })
+        const code = w.find("[data-test=\"copilot-user-code\"]")
+        expect(code.exists()).toBe(true)
+        expect(code.element.textContent).toBe("id: demo\nnamespace: company.team")
+        const texts = w.findAll(".copilot-bubble-text")
+        expect(texts[0].text()).toBe("Fix this flow:")
+        expect(texts[1].text()).toBe("It fails on start.")
+    })
+
+    it("treats an unclosed ``` fence as a code block running to the end of the prompt", () => {
+        const w = mountMessage({
+            id: "1b", role: "USER", type: "TEXT",
+            content: "Why is this wrong?\n```yaml\nid: demo\ntasks: []",
+        })
+        expect(w.find("[data-test=\"copilot-user-code\"]").element.textContent).toBe("id: demo\ntasks: []")
+    })
+
+    it("renders a plain user prompt without any code block", () => {
+        const w = mountMessage({id: "1c", role: "USER", type: "TEXT", content: "id: demo\nnamespace: company.team"})
+        expect(w.find("[data-test=\"copilot-user-code\"]").exists()).toBe(false)
+        // Line breaks survive into the DOM; `white-space: pre-wrap` renders them.
+        expect(w.find(".copilot-bubble-text").element.textContent).toBe("id: demo\nnamespace: company.team")
+    })
+
     it("renders assistant text as a styled bubble through the markdown renderer", () => {
         const w = mountMessage({id: "2", role: "ASSISTANT", type: "TEXT", content: "**bold** answer"})
         expect(w.find(".copilot-bubble-assistant").exists()).toBe(true)


### PR DESCRIPTION
Closes https://github.com/kestra-io/kestra-ee/issues/10420.

### ✨ Description

When a `YAML` `flow` or any multi-line code snippet is pasted into the `AI Copilot` composer, the sent message showed up in the chat as one long flattened string, because the user bubble rendered the prompt through default HTML whitespace collapsing. Assistant replies already render code blocks through `KsMarkdown`; only the user side was affected.

Two changes in `CopilotMessage.vue`:

- The user bubble now preserves line breaks and indentation (`white-space: pre-wrap`), so pasted code stays readable even without fences.
- Any ``` fenced segment of the prompt is rendered as a literal monospace code block, styled with design-system tokens. An unclosed fence runs to the end of the prompt, matching how markdown renderers treat it.

Full markdown rendering of user text was deliberately avoided: the prompt must stay literal, otherwise a pasted `YAML` comment like `# retries` would be reinterpreted as a heading and lists or emphasis would mangle the pasted content.

Covered by three new unit tests (fenced segment, unclosed fence, plain multi-line prompt) and a new `UserPromptWithCode` Storybook story for visual review in both themes.

### 🎨 Frontend Checklist

- [x] Type checking passes (`npm run check:types`)
- [x] Code builds without errors (`npm run build`)
- [x] Unit tests pass (`npm run test:unit`)
- [x] Translations are complete if `en.json` changed (`npm run translations:check` reports no missing, extra, or stale keys)
- [x] Screenshots or video recordings attached showing the `UI` changes

### Before

<img width="770" height="767" alt="image" src="https://github.com/user-attachments/assets/bc5b56a9-1a72-41fd-905a-9ac02f361079" />

### After

<img width="770" height="767" alt="image" src="https://github.com/user-attachments/assets/c947ce8c-4bda-4652-b5a9-12d02baaba59" />
<img width="770" height="767" alt="image" src="https://github.com/user-attachments/assets/4dea1f09-d3ea-4182-a570-577745865486" />
