### PR TITLE
fix(core): read negative epoch timestamps with the same unit as positive ones

### DIFF
--- a/core/src/main/java/io/kestra/core/runners/pebble/AbstractDate.java
+++ b/core/src/main/java/io/kestra/core/runners/pebble/AbstractDate.java
@@ -104,9 +104,9 @@ public abstract class AbstractDate {
         }
 
         if (value instanceof Long longValue) {
-            if (value.toString().length() == 13) {
+            if (digitCount(longValue) == 13) {
                 return Instant.ofEpochMilli(longValue).atZone(zoneId);
-            } else if (value.toString().length() == 19) {
+            } else if (digitCount(longValue) == 19) {
                 if (value.toString().endsWith("000")) {
                     long seconds = longValue / 1_000_000_000;
                     int nanos = (int) (longValue % 1_000_000_000);
@@ -141,5 +141,10 @@ public abstract class AbstractDate {
                 }
             }
         }
+    }
+
+    private static int digitCount(long value) {
+        int length = Long.toString(value).length();
+        return value < 0 ? length - 1 : length;
     }
 }

--- a/core/src/test/java/io/kestra/core/runners/pebble/filters/DateFilterTest.java
+++ b/core/src/test/java/io/kestra/core/runners/pebble/filters/DateFilterTest.java
@@ -233,4 +233,20 @@ class DateFilterTest {
             """);
     }
 
+    @Test
+    void shouldRenderNegativeMillisTimestamp() throws IllegalVariableEvaluationException {
+        String render = variableRenderer.render(
+            """
+                {{ -1234567890123 | date(format="iso_milli", timeZone="UTC") }}
+                {{ 1234567890123 | date(format="iso_milli", timeZone="UTC") }}
+                """,
+            Map.of()
+        );
+
+        assertThat(render).isEqualTo("""
+            1930-11-18T00:28:29.877Z
+            2009-02-13T23:31:30.123Z
+            """);
+    }
+
 }


### PR DESCRIPTION
- closes #18508