### PR TITLE
perf(ui): keep the logs surface and the demo pages off the eager path

### DIFF
--- a/ui/src/components/dashboard/DrillDownDrawer.vue
+++ b/ui/src/components/dashboard/DrillDownDrawer.vue
@@ -45,15 +45,18 @@
 </template>
 
 <script lang="ts" setup>
-    import {computed, ref} from "vue"
+    import {computed, defineAsyncComponent, ref} from "vue"
     import {useRoute, useRouter} from "vue-router"
     import get from "lodash/get"
     import {KsExecutionStatus} from "@kestra-io/design-system"
     import Labels from "../layout/Labels.vue"
-    import LogsWrapper from "../logs/LogsWrapper.vue"
     import {useDrillDownStore} from "../../stores/drillDown"
     import {getDrillDownPreview} from "./composables/drillDownPreview"
     import {buildFullQuery} from "./composables/chartDrillDown"
+
+    // Only rendered for the logs preview mode, and it reaches the dashboard chart
+    // stack: a static import would put it in the chunk App.vue loads on every page.
+    const LogsWrapper = defineAsyncComponent(() => import("../logs/LogsWrapper.vue"))
 
     const route = useRoute()
     const router = useRouter()

--- a/ui/src/routes/routes.ts
+++ b/ui/src/routes/routes.ts
@@ -3,18 +3,6 @@ import type {RouteRecordRaw} from "vue-router"
 import OnlyLeftMenuLayout from "../components/layout/OnlyLeftMenuLayout.vue"
 import FullScreenLayout from "../components/layout/FullScreenLayout.vue"
 import Errors from "../components/errors/Errors.vue"
-import DemoIAM from "../components/demo/IAM.vue"
-import DemoTenants from "../components/demo/Tenants.vue"
-import DemoAuditLogs from "../components/demo/AuditLogs.vue"
-import DemoInstance from "../components/demo/Instance.vue"
-import DemoApps from "../components/demo/Apps.vue"
-import DemoTests from "../components/demo/Tests.vue"
-import DemoAssets from "../components/demo/Assets.vue"
-import DemoCases from "../components/demo/Cases.vue"
-import DemoQuotas from "../components/demo/Quotas.vue"
-import DemoPolicies from "../components/demo/Policies.vue"
-import DemoPromote from "../components/demo/Promote.vue"
-import DemoDashboards from "../components/demo/Dashboards.vue"
 import {EXECUTION_ROUTE} from "../components/executions/executionTabs"
 import {FLOW_ROUTE} from "../components/flows/flowTabs"
 import {NAMESPACE_PARENT_ROUTE, createNamespaceTabRoutes} from "../utils/namespaceTabRoutes"
@@ -114,19 +102,19 @@ const routes: KestraRouteRecord[] = [
     {name: "errors/404-wildcard", path: "/:tenant?/:pathMatch(.*)", component: Errors, props: {code: 404}},
 
     //Demo Pages
-    {name: "dashboards/create", path: "/:tenant?/dashboards/new", component: DemoDashboards},
-    {name: "dashboards/update", path: "/:tenant?/dashboards/:dashboard/edit", component: DemoDashboards},
-    {name: "apps/list", path: "/:tenant?/apps", component: DemoApps},
-    {name: "tests/list", path: "/:tenant?/tests", component: DemoTests},
-    {name: "assets/list", path: "/:tenant?/assets", component: DemoAssets},
-    {name: "cases/list", path: "/:tenant?/cases", component: DemoCases},
-    {name: "admin/iam", path: "/:tenant?/admin/iam", component: DemoIAM},
-    {name: "admin/tenants/list", path: "/:tenant?/admin/tenants/list", component: DemoTenants},
-    {name: "admin/auditlogs/list", path: "/:tenant?/admin/auditlogs", component: DemoAuditLogs},
-    {name: "admin/quotas/list", path: "/:tenant?/admin/quotas", component: DemoQuotas},
-    {name: "admin/policies", path: "/:tenant?/admin/policies", component: DemoPolicies},
-    {name: "admin/instance", path: "/:tenant?/admin/instance", component: DemoInstance},
-    {name: "promote/targets", path: "/:tenant?/promote/targets", component: DemoPromote},
+    {name: "dashboards/create", path: "/:tenant?/dashboards/new", component: () => import("../components/demo/Dashboards.vue")},
+    {name: "dashboards/update", path: "/:tenant?/dashboards/:dashboard/edit", component: () => import("../components/demo/Dashboards.vue")},
+    {name: "apps/list", path: "/:tenant?/apps", component: () => import("../components/demo/Apps.vue")},
+    {name: "tests/list", path: "/:tenant?/tests", component: () => import("../components/demo/Tests.vue")},
+    {name: "assets/list", path: "/:tenant?/assets", component: () => import("../components/demo/Assets.vue")},
+    {name: "cases/list", path: "/:tenant?/cases", component: () => import("../components/demo/Cases.vue")},
+    {name: "admin/iam", path: "/:tenant?/admin/iam", component: () => import("../components/demo/IAM.vue")},
+    {name: "admin/tenants/list", path: "/:tenant?/admin/tenants/list", component: () => import("../components/demo/Tenants.vue")},
+    {name: "admin/auditlogs/list", path: "/:tenant?/admin/auditlogs", component: () => import("../components/demo/AuditLogs.vue")},
+    {name: "admin/quotas/list", path: "/:tenant?/admin/quotas", component: () => import("../components/demo/Quotas.vue")},
+    {name: "admin/policies", path: "/:tenant?/admin/policies", component: () => import("../components/demo/Policies.vue")},
+    {name: "admin/instance", path: "/:tenant?/admin/instance", component: () => import("../components/demo/Instance.vue")},
+    {name: "promote/targets", path: "/:tenant?/promote/targets", component: () => import("../components/demo/Promote.vue")},
 ]
 
 export default routes


### PR DESCRIPTION
### 🔗 Related Issue

None — this started from `INEFFECTIVE_DYNAMIC_IMPORT` warnings in the EE `npm run build` output.

> **Follow-up stacked on this one:** https://github.com/kestra-io/kestra/pull/18640 takes ECharts off the eager path too. It is based on this branch and only pays off on top of it, so merge this one first.

### ✨ Description

`App.vue` statically imports `DrillDownDrawer`, which statically imported `LogsWrapper`. Since `App.vue` is the root component, that single edge pulled the whole logs surface — and everything it reaches, including `Sections.vue` → `dashboard-types.ts` → the Bar/KPI/Markdown/Pie/Table/TimeSeries chart map — into `app-*.js`, the chunk `index.html` preloads on **every page**. The `() => import(...)` in `routes.ts` and `flowTabs.ts` was doing nothing.

`DrillDownDrawer` only renders `LogsWrapper` behind `v-if="preview?.mode === 'logs'"`, so this was eagerly shipping something most sessions never render.

`routes.ts` had the same problem with the demo pages: it statically imported all 12 `Demo*.vue` components while `executionTabs.ts`/`flowTabs.ts` imported three of them lazily. The byte cost is small (each is a ~30-line `Empty` placeholder), but they were inconsistent with every other route in that file, and EE filters all of them out at runtime while still shipping them.

Both are now lazy. Measured on the eager (preloaded) chunk closure of the OSS build:

| | chunks | raw | gzip |
|---|---|---|---|
| before | 18 | 4120 KB | 1088 KB |
| after | 16 | 3875 KB | 1013 KB |
| **saved** | **2** | **245 KB** | **75 KB** |

Verified the dashboard chart type map and the logs timeseries chart definition are gone from `app-*.js`.

`INEFFECTIVE_DYNAMIC_IMPORT` warnings drop from 6 to 2. The two that remain are `BranchLane` ⇄ `FlowableClusterCard`, where `defineAsyncComponent` breaks a genuine recursive-component cycle rather than code-splitting — those are intentional and should stay.

### 🎨 Frontend Checklist

- [x] Type checking passes (`npm run check:types`)
- [x] Code builds without errors (`npm run build`)
- [x] Unit tests pass (`npm run test:unit`) — 197 files, 1851 tests
- [x] Translations are complete if `en.json` changed (`npm run translations:check` reports no missing, extra, or stale keys) — no translation changes
- [ ] Screenshots or video recordings attached showing the `UI` changes — no visual change; this is chunk-graph only

### 📝 Additional Notes

No behavior change is intended: `LogsWrapper` was already rendered behind a `v-if`, and the demo routes resolve the same components, just lazily.

One follow-up deliberately left out of both this PR and #18640: `consolidateChunks.js` already reasons about the eager closure, so an assertion that `LogsWrapper`/Monaco/markdown never enter it would catch the next `App.vue`-reachable static import at build time, instead of in a warning nobody reads. It already has a guard of exactly this shape for lazy-chunk cycles, which is what caught the tricky case in #18640.