### PR TITLE
fix(core): keep an asset's creation date across updates

### DIFF
--- a/core/src/main/java/io/kestra/core/models/assets/Asset.java
+++ b/core/src/main/java/io/kestra/core/models/assets/Asset.java
@@ -90,7 +90,7 @@ public abstract class Asset implements HasUID, SoftDeletable<Asset>, Plugin {
      * @return this asset, merged.
      */
     public <T extends Asset> T toUpdated(T previousAsset, boolean allowTypeChange) {
-        this.created = Optional.ofNullable(this.created).or(() -> Optional.ofNullable(previousAsset).map(Asset::getCreated)).orElseGet(Instant::now);
+        this.created = Optional.ofNullable(previousAsset).map(Asset::getCreated).or(() -> Optional.ofNullable(this.created)).orElseGet(Instant::now);
         this.updated = Instant.now();
 
         String previousType = Optional.ofNullable(previousAsset).map(Asset::getType).orElse(null);

--- a/core/src/test/java/io/kestra/core/models/assets/AssetTest.java
+++ b/core/src/test/java/io/kestra/core/models/assets/AssetTest.java
@@ -1,5 +1,7 @@
 package io.kestra.core.models.assets;
 
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.Map;
 
 import org.junit.jupiter.api.Test;
@@ -50,6 +52,21 @@ class AssetTest {
 
         // Then
         assertThat(updated.getType()).isEqualTo("EC2");
+    }
+
+    @Test
+    void shouldKeepCreationDateWhenUpdating() {
+        // Given
+        Instant createdAt = Instant.now().minus(3, ChronoUnit.DAYS);
+        Custom previous = Custom.builder().namespace("io.kestra").id("my-asset").type("EC2").created(createdAt).updated(createdAt).build();
+        Custom incoming = Custom.builder().namespace("io.kestra").id("my-asset").type("EC2").build();
+
+        // When
+        Custom updated = incoming.toUpdated(previous, false);
+
+        // Then
+        assertThat(updated.getCreated()).isEqualTo(createdAt);
+        assertThat(updated.getUpdated()).isAfter(createdAt);
     }
 
     @Test


### PR DESCRIPTION
### 🔗 Related Issue

Closes https://github.com/kestra-io/kestra-ee/issues/10288.

### ✨ Description

An asset's `created` timestamp was overwritten on every update, so it was always identical to `updated` and the original registration time was lost. This happened both when an asset was edited through the API or the UI and when it was re-emitted by a flow.

`created` is defaulted to now by the `Asset` constructor, and the field is not included in a flow-emitted asset or in the YAML sent to `PUT /assets/{id}` (it is `@Hidden`). So a fresh timestamp was always present on the incoming asset, and it was kept by `toUpdated` over the stored one. The stored date is now preferred, and only `updated` is moved forward.

### 🛠️ Backend Checklist

- [x] Code compiles and tests pass for the touched modules (`./gradlew :core:test --tests "io.kestra.core.models.assets.*"`)
- [x] New behavior is covered by unit or integration tests

### 📝 Additional Notes

`AssetTest.shouldKeepCreationDateWhenUpdating` is red on `develop` and green with the fix. Create and update are both routed through `Asset.toUpdated` by the JDBC and the Elasticsearch repositories, so every write path is covered.

For assets updated before this fix, the date they were last stamped with is kept, since the original was never stored anywhere else.
