### PR TITLE
fix(core): validate a SELECT input value even when the input is optional

### DIFF
--- a/core/src/main/java/io/kestra/core/models/flows/input/SelectInput.java
+++ b/core/src/main/java/io/kestra/core/models/flows/input/SelectInput.java
@@ -69,10 +69,11 @@ public class SelectInput extends Input<String> implements RenderableInput {
 
     @Override
     public void validate(String input) throws ConstraintViolationException {
-        if (this.getRequired() && values.stream().noneMatch(v -> Objects.equals(v.value(), input))) {
-            if (this.getAllowCustomValue()) {
-                return;
-            }
+        if (this.getAllowCustomValue() || values == null) {
+            return;
+        }
+
+        if (values.stream().noneMatch(v -> Objects.equals(v.value(), input))) {
             throw ManualConstraintViolation.toConstraintViolationException(
                 "it must match the values `" + values.stream().map(ValueOption::value).toList() + "`",
                 this,

--- a/core/src/test/java/io/kestra/core/models/flows/input/SelectInputTest.java
+++ b/core/src/test/java/io/kestra/core/models/flows/input/SelectInputTest.java
@@ -172,6 +172,46 @@ class SelectInputTest {
     }
 
     @Test
+    void validateRejectsValueOutsideValuesWhenInputIsOptional() {
+        SelectInput input = SelectInput
+            .builder()
+            .id("id")
+            .values(List.of(new ValueOption("Prod", "123"), new ValueOption("Staging", "456")))
+            .required(false)
+            .build();
+
+        input.validate("123");
+
+        assertThatThrownBy(() -> input.validate("789"))
+            .hasMessageContaining("[123, 456]");
+    }
+
+    @Test
+    void validateAcceptsAnyValueWhenCustomValuesAreAllowed() {
+        SelectInput input = SelectInput
+            .builder()
+            .id("id")
+            .values(List.of(new ValueOption("Prod", "123")))
+            .required(false)
+            .allowCustomValue(true)
+            .build();
+
+        input.validate("789");
+    }
+
+    @Test
+    void validateAcceptsAnyValueWhenValuesComeFromAnUnrenderedExpression() {
+        SelectInput input = SelectInput
+            .builder()
+            .id("id")
+            .expression("{{ values }}")
+            .required(false)
+            .build();
+
+        input.validate("789");
+    }
+
+    @Test
     void valueOptionDeserializesFromStringOrObject() {
         ValueOption fromString = ValueOption.from("V1");
         assertThat(fromString.label()).isEqualTo("V1");


### PR DESCRIPTION
> ⚠️ **This PR was fully generated by Claude** (Claude Code), including the reproducer test and the fix. Please review accordingly.

Closes https://github.com/kestra-io/kestra-ee/issues/10258

## What was wrong

`SelectInput.validate` was gated on `getRequired()`:

```java
if (this.getRequired() && values.stream().noneMatch(v -> Objects.equals(v.value(), input))) {
```

So a SELECT input with `required: false` accepted **any** value, including one not in its `values` list. The identical value on a `required: true` SELECT is correctly rejected.

## Why the gate was safe to drop

`FlowInputOutput` only calls `validate` once the value has resolved to something non-null:

https://github.com/kestra-io/kestra/blob/develop/core/src/main/java/io/kestra/core/runners/FlowInputOutput.java#L431-L441

```java
if (value == null) {
    if (input.getRequired()) { ...error... } else { resolvable.resolveWithValue(null); }
} else {
    parsedInput.ifPresent(parsed -> ((Input) resolvable.get().input()).validate(parsed.getValue()));
}
```

An absent optional input therefore never reaches `validate`, so the `required` check was never doing the job it looked like it was doing.

`MultiselectInput.validate` already validates regardless of `required`, gated only on `allowCustomValue` — this brings SELECT in line with it.

## The `values == null` guard

`values` is null on a SELECT that sources its options from `expression` and has not been rendered yet. The old `required` gate incidentally shielded that path from an NPE for optional inputs; removing the gate would have exposed it, so the guard is part of the fix rather than an extra.

## Tests

Three tests added to `SelectInputTest`:

- `validateRejectsValueOutsideValuesWhenInputIsOptional` — the reproducer. **Verified failing before the fix** (`Expecting code to raise a throwable`) and passing after.
- `validateAcceptsAnyValueWhenCustomValuesAreAllowed` — `allowCustomValue` still bypasses validation.
- `validateAcceptsAnyValueWhenValuesComeFromAnUnrenderedExpression` — covers the null-values guard.

`SelectInputTest`, `MultiselectInputTest`, `InputsTest` and `FlowInputOutputTest` all pass (99 tests, 0 failures).