### PR TITLE
fix(core): reject a Flow trigger whose minSatisfied exceeds its dependsOn count

### DIFF
--- a/core/src/main/java/io/kestra/core/validations/validator/FlowTriggerValidator.java
+++ b/core/src/main/java/io/kestra/core/validations/validator/FlowTriggerValidator.java
@@ -19,9 +19,22 @@ public class FlowTriggerValidator implements ConstraintValidator<FlowTriggerVali
             return true; // nulls are allowed according to spec
         }
 
-        if (MultipleCondition.Mode.AT_LEAST == value.getMode() && value.getMinSatisfied() == null) {
+        if (MultipleCondition.Mode.AT_LEAST != value.getMode()) {
+            return true;
+        }
+
+        if (value.getMinSatisfied() == null) {
             context.disableDefaultConstraintViolation();
             context.buildConstraintViolationWithTemplate("`minSatisfied` must be set when mode is AT_LEAST")
+                .addConstraintViolation();
+            return false;
+        }
+
+        if (value.getDependsOn() != null && value.getMinSatisfied() > value.getDependsOn().size()) {
+            context.disableDefaultConstraintViolation();
+            context.buildConstraintViolationWithTemplate(
+                    "`minSatisfied` cannot be greater than the number of `dependsOn` conditions (" + value.getDependsOn().size() + ")"
+                )
                 .addConstraintViolation();
             return false;
         }

--- a/core/src/test/java/io/kestra/core/validations/FlowTriggerValidationTest.java
+++ b/core/src/test/java/io/kestra/core/validations/FlowTriggerValidationTest.java
@@ -1,11 +1,13 @@
 package io.kestra.core.validations;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.junit.jupiter.api.Test;
 
 import io.kestra.core.junit.annotations.KestraTest;
 import io.kestra.core.models.triggers.multipleflows.MultipleCondition;
+import io.kestra.core.models.flows.State;
 import io.kestra.core.models.validations.ModelValidator;
 import io.kestra.plugin.core.trigger.Flow;
 
@@ -103,5 +105,51 @@ class FlowTriggerValidationTest {
         assertThat(valid).isPresent();
         assertThat(valid.get().getConstraintViolations()).hasSize(1);
         assertThat(valid.get().getConstraintViolations().iterator().next().getPropertyPath().toString()).isEqualTo("minSatisfied");
+    }
+
+    @Test
+    void shouldNotBeValidWhenMinSatisfiedExceedsTheNumberOfDependencies() {
+        // Given
+        var trigger = Flow.builder()
+            .id("flow-trigger")
+            .type(Flow.class.getName())
+            .mode(MultipleCondition.Mode.AT_LEAST)
+            .minSatisfied(99)
+            .dependsOn(List.of(
+                Flow.Dependency.builder()
+                    .namespace("company.team")
+                    .flowId("upstream_flow")
+                    .states(List.of(State.Type.SUCCESS))
+                    .build()
+            ))
+            .build();
+
+        // When
+        Optional<ConstraintViolationException> valid = modelValidator.isValid(trigger);
+
+        // Then
+        assertThat(valid).isPresent();
+        assertThat(valid.get().getMessage()).contains("`minSatisfied` cannot be greater than the number of `dependsOn` conditions");
+    }
+
+    @Test
+    void shouldBeValidWhenMinSatisfiedEqualsTheNumberOfDependencies() {
+        // Given
+        var trigger = Flow.builder()
+            .id("flow-trigger")
+            .type(Flow.class.getName())
+            .mode(MultipleCondition.Mode.AT_LEAST)
+            .minSatisfied(2)
+            .dependsOn(List.of(
+                Flow.Dependency.builder().namespace("company.team").flowId("a").states(List.of(State.Type.SUCCESS)).build(),
+                Flow.Dependency.builder().namespace("company.team").flowId("b").states(List.of(State.Type.SUCCESS)).build()
+            ))
+            .build();
+
+        // When
+        Optional<ConstraintViolationException> valid = modelValidator.isValid(trigger);
+
+        // Then
+        assertThat(valid).isEmpty();
     }
 }


### PR DESCRIPTION
> ⚠️ **This PR was fully generated by Claude** (Claude Code), including the reproducer tests and the fix. Please review accordingly.

Closes https://github.com/kestra-io/kestra-ee/issues/10271

## What was wrong

A `Flow` trigger in `AT_LEAST` mode accepted a `minSatisfied` larger than the number of `dependsOn` conditions. The flow saved as **Valid** (HTTP 200), but the threshold could never be reached, so the trigger silently never fired.

```yaml
triggers:
  - id: f
    type: io.kestra.plugin.core.trigger.Flow
    mode: AT_LEAST
    minSatisfied: 99      # only one dependency below
    dependsOn:
      - namespace: company.team
        flowId: upstream_flow
        states: [SUCCESS]
```

The lower bound was already guarded — `@Positive` on the field, and `FlowTriggerValidator` requires `minSatisfied` whenever the mode is `AT_LEAST`. Only the upper bound was missing.

## The fix

`FlowTriggerValidator` now also rejects `minSatisfied > dependsOn.size()`. The early return for non-`AT_LEAST` modes keeps the two `AT_LEAST` checks from nesting.

The new check is deliberately scoped to `dependsOn != null`: the field has no `@NotNull`, and whether an `AT_LEAST` trigger should be allowed to omit `dependsOn` entirely is a separate question I did not want to change here — `shouldBeValidWhenModeIsAtLeastWithMinSatisfied` covers exactly that shape and still passes untouched.

## Tests

Two tests added to `FlowTriggerValidationTest`:

- `shouldNotBeValidWhenMinSatisfiedExceedsTheNumberOfDependencies` — the issue's repro (`minSatisfied: 99`, one dependency). **Verified failing before the fix**, passing after.
- `shouldBeValidWhenMinSatisfiedEqualsTheNumberOfDependencies` — pins the `==` boundary as valid (it passed before the fix too, so the new check is not off-by-one).

All of `io.kestra.core.validations.*` plus `MultipleConditionTriggerCaseTest` pass: 125 tests, 0 failures.