### PR TITLE
fix(core): reject syntactically invalid REGEX query filters

### DIFF
--- a/core/src/main/java/io/kestra/core/models/QueryFilter.java
+++ b/core/src/main/java/io/kestra/core/models/QueryFilter.java
@@ -921,14 +921,16 @@ public record QueryFilter(
                 )
             );
         }
-        if (
-            filter.operation() == Op.REGEX
-                && filter.value() instanceof String pattern
-                && !RegexUtils.isSafeUserRegex(pattern)
-        ) {
-            errors.add(
-                "REGEX pattern for field %s is too long or prone to catastrophic backtracking".formatted(filter.field().name())
-            );
+        if (filter.operation() == Op.REGEX && filter.value() instanceof String pattern) {
+            if (!RegexUtils.isSafeUserRegex(pattern)) {
+                errors.add(
+                    "REGEX pattern for field %s is too long or prone to catastrophic backtracking".formatted(filter.field().name())
+                );
+            } else {
+                RegexUtils.syntaxError(pattern).ifPresent(error -> errors.add(
+                    "REGEX pattern '%s' for field %s is not a valid regular expression: %s".formatted(pattern, filter.field().name(), error)
+                ));
+            }
         }
     }
 

--- a/core/src/main/java/io/kestra/core/utils/RegexUtils.java
+++ b/core/src/main/java/io/kestra/core/utils/RegexUtils.java
@@ -1,9 +1,11 @@
 package io.kestra.core.utils;
 
 import java.time.Duration;
+import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
 
 import com.google.common.annotations.VisibleForTesting;
 
@@ -215,6 +217,26 @@ public final class RegexUtils {
         }
         return !NESTED_QUANTIFIER.matcher(pattern).find()
             && !ALTERNATION_WITH_REPETITION.matcher(pattern).find();
+    }
+
+    /**
+     * Checks whether a user-supplied regex pattern compiles under Java's regex engine, which is the
+     * only compile-time gate available before the pattern is handed to a database engine (e.g. via
+     * Postgres {@code ~} or MySQL {@code REGEXP}). Java's dialect and a database's are close but not
+     * identical, so a pattern accepted here may still be rejected by the engine, and vice versa.
+     *
+     * @param pattern the user-supplied regex pattern; must not be {@code null}.
+     * @return empty if the pattern compiles, otherwise the syntax error description.
+     */
+    public static Optional<String> syntaxError(String pattern) {
+        try {
+            Pattern.compile(pattern);
+            return Optional.empty();
+        } catch (PatternSyntaxException e) {
+            return Optional.of(e.getIndex() >= 0
+                ? "%s near index %d".formatted(e.getDescription(), e.getIndex())
+                : e.getDescription());
+        }
     }
 
     /**

--- a/core/src/main/java/io/kestra/core/validations/validator/SafeRegexValidator.java
+++ b/core/src/main/java/io/kestra/core/validations/validator/SafeRegexValidator.java
@@ -14,6 +14,21 @@ import jakarta.inject.Singleton;
 public class SafeRegexValidator implements ConstraintValidator<SafeRegexValidation, String> {
     @Override
     public boolean isValid(@Nullable String value, @NonNull AnnotationValue<SafeRegexValidation> annotationMetadata, @NonNull ConstraintValidatorContext context) {
-        return value == null || RegexUtils.isSafeUserRegex(value);
+        if (value == null) {
+            return true;
+        }
+
+        if (!RegexUtils.isSafeUserRegex(value)) {
+            return false;
+        }
+
+        return RegexUtils.syntaxError(value)
+            .map(error -> {
+                context.disableDefaultConstraintViolation();
+                context.buildConstraintViolationWithTemplate("invalid regex pattern '" + value + "': " + error)
+                    .addConstraintViolation();
+                return false;
+            })
+            .orElse(true);
     }
 }

--- a/core/src/test/java/io/kestra/core/models/QueryFilterTest.java
+++ b/core/src/test/java/io/kestra/core/models/QueryFilterTest.java
@@ -885,6 +885,33 @@ public class QueryFilterTest {
         assertThat(e.getMessage()).contains("catastrophic backtracking");
     }
 
+    @ParameterizedTest
+    @MethodSource("invalidSyntaxRegex")
+    void shouldThrowExceptionWhenRegexSyntaxIsInvalid(String pattern) {
+        // Given a REGEX filter that is not a syntactically valid regular expression
+        QueryFilter filter = QueryFilter.builder()
+            .field(Field.NAMESPACE)
+            .operation(Op.REGEX)
+            .value(pattern)
+            .build();
+
+        // When / Then — it must be rejected before reaching any repository backend
+        InvalidQueryFiltersException e = assertThrows(
+            InvalidQueryFiltersException.class,
+            () -> QueryFilter.validateQueryFilters(List.of(filter), Resource.EXECUTION)
+        );
+        assertThat(e.getMessage()).contains("is not a valid regular expression");
+        assertThat(e.getMessage()).contains(pattern);
+        assertThat(e.getMessage()).doesNotContain("catastrophic backtracking");
+    }
+
+    static Stream<Arguments> invalidSyntaxRegex() {
+        return Stream.of(
+            Arguments.of("[a-"),
+            Arguments.of("*abc")
+        );
+    }
+
     @Test
     void shouldNotThrowExceptionWhenRegexIsSafe() {
         // Given a safe REGEX filter

--- a/core/src/test/java/io/kestra/core/validations/SafeRegexValidationTest.java
+++ b/core/src/test/java/io/kestra/core/validations/SafeRegexValidationTest.java
@@ -52,4 +52,21 @@ class SafeRegexValidationTest {
         assertThat(valid.isPresent()).isTrue();
         assertThat(valid.get().getMessage()).contains("catastrophic backtracking");
     }
+
+    @Test
+    void shouldNotValidateInvalidRegexSyntax() {
+        // Given
+        Regex<TestField> filter = Regex.<TestField> builder()
+            .field(TestField.NAMESPACE)
+            .value("[a-")
+            .build();
+
+        // When
+        Optional<ConstraintViolationException> valid = modelValidator.isValid(filter);
+
+        // Then
+        assertThat(valid.isPresent()).isTrue();
+        assertThat(valid.get().getMessage()).contains("invalid regex pattern");
+        assertThat(valid.get().getMessage()).contains("[a-");
+    }
 }

--- a/jdbc/src/test/java/io/kestra/jdbc/repository/AbstractSQLInjectionTest.java
+++ b/jdbc/src/test/java/io/kestra/jdbc/repository/AbstractSQLInjectionTest.java
@@ -224,12 +224,21 @@ public abstract class AbstractSQLInjectionTest {
     }
 
     private static final String CATASTROPHIC_REGEX_PATTERN = "(a+)+$";
+    private static final String INVALID_SYNTAX_REGEX_PATTERN = "[a-";
 
     private QueryFilter catastrophicRegexFilter() {
         return QueryFilter.builder()
             .field(QueryFilter.Field.NAMESPACE)
             .operation(QueryFilter.Op.REGEX)
             .value(CATASTROPHIC_REGEX_PATTERN)
+            .build();
+    }
+
+    private QueryFilter invalidSyntaxRegexFilter() {
+        return QueryFilter.builder()
+            .field(QueryFilter.Field.NAMESPACE)
+            .operation(QueryFilter.Op.REGEX)
+            .value(INVALID_SYNTAX_REGEX_PATTERN)
             .build();
     }
 
@@ -250,6 +259,17 @@ public abstract class AbstractSQLInjectionTest {
         // Same guard on the execution repository's QueryFilter path
         assertThatThrownBy(() -> executionRepository.find(Pageable.from(1, 10), tenant, List.of(catastrophicRegexFilter())))
             .as("REGEX with a catastrophic-backtracking pattern should be rejected")
+            .isInstanceOf(InvalidQueryFiltersException.class);
+    }
+
+    @Test
+    void executionRegexFilterShouldRejectInvalidSyntaxPattern() {
+        var tenant = TestsUtils.randomTenant(this.getClass().getSimpleName());
+
+        // A syntactically invalid REGEX pattern must be rejected before it reaches the DB engine,
+        // instead of surfacing as a 500 that leaks the rendered SQL (kestra-ee#10266)
+        assertThatThrownBy(() -> executionRepository.find(Pageable.from(1, 10), tenant, List.of(invalidSyntaxRegexFilter())))
+            .as("REGEX with an invalid syntax pattern should be rejected")
             .isInstanceOf(InvalidQueryFiltersException.class);
     }
 

--- a/webserver/src/test/java/io/kestra/webserver/controllers/api/ExecutionControllerTest.java
+++ b/webserver/src/test/java/io/kestra/webserver/controllers/api/ExecutionControllerTest.java
@@ -385,6 +385,20 @@ class ExecutionControllerTest {
         );
         assertThat(exception.getStatus().getCode()).isEqualTo(422);
         assertThat(exception.getMessage()).isEqualTo("Illegal argument: Start date must be before End Date");
+
+        // A syntactically invalid REGEX filter must be rejected with a 400 that carries no SQL detail,
+        // instead of reaching the DB engine and leaking the rendered query (kestra-ee#10266)
+        exception = assertThrows(
+            HttpClientResponseException.class, () -> client.toBlocking().retrieve(
+                GET(
+                    "/api/v1/main/executions/search?filters[namespace][REGEX]=%5Ba-"
+                ), PagedResults.class
+            )
+        );
+        assertThat(exception.getStatus().getCode()).isEqualTo(HttpStatus.BAD_REQUEST.getCode());
+        assertThat(exception.getMessage()).doesNotContainIgnoringCase("select");
+        assertThat(exception.getMessage()).doesNotContain("SQL [");
+        assertThat(exception.getMessage()).contains("[a-");
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Rejects a syntactically invalid `REGEX` query filter value (e.g. `filters[namespace][REGEX]=[a-`) with a clean `400` instead of letting it reach the database engine, which previously produced a `500` whose body leaked the fully rendered SQL query.
- The existing REGEX validation (`QueryFilter.collectValidationErrors`) only guarded against catastrophic backtracking via `RegexUtils.isSafeUserRegex`; it never checked that the pattern actually compiles. Added `RegexUtils.syntaxError(String)` (a `Pattern.compile` gate) and wired it into both places a user regex is validated before reaching `likeRegex`: the `QueryFilter` path used by all JDBC repositories, and `SafeRegexValidator`, which backs the dashboard filter model.
Fixes https://github.com/kestra-io/kestra-ee/issues/10266

Note: the underlying disclosure that *any* unmapped exception's message (including a jOOQ `DataAccessException`'s rendered SQL) is echoed into a `500` response body is a separate, broader issue already tracked in https://github.com/kestra-io/kestra-ee/issues/8997, and is intentionally out of scope here.

## Test plan
- [x] `core:test` — extended `QueryFilterTest` (parameterized on `[a-` and `*abc`) and `SafeRegexValidationTest`
- [x] `jdbc-h2:test`, `jdbc-postgres:test`, `jdbc-mysql:test` — extended `AbstractSQLInjectionTest` with an invalid-syntax REGEX case, run across all three dialects
- [x] `webserver:test` — extended `ExecutionControllerTest.badQueryFilters` with the exact reported repro, asserting `400` and no SQL text in the response body; `ErrorControllerTest` unchanged and still passing