### PR TITLE
fix(core): reject a negative duration on a MAX_DURATION SLA

### DIFF
--- a/core/src/main/java/io/kestra/core/models/flows/sla/types/MaxDurationSLA.java
+++ b/core/src/main/java/io/kestra/core/models/flows/sla/types/MaxDurationSLA.java
@@ -12,6 +12,7 @@ import io.kestra.core.models.flows.sla.SLA;
 import io.kestra.core.models.flows.sla.Violation;
 import io.kestra.core.runners.RunContext;
 import io.kestra.core.validations.DurationMax;
+import io.kestra.core.validations.DurationMin;
 
 import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
@@ -23,6 +24,7 @@ import lombok.experimental.SuperBuilder;
 @NoArgsConstructor
 public class MaxDurationSLA extends SLA implements ExecutionMonitoringSLA {
     @NotNull
+    @DurationMin
     @DurationMax
     private Duration duration;
 

--- a/core/src/main/java/io/kestra/core/validations/DurationMin.java
+++ b/core/src/main/java/io/kestra/core/validations/DurationMin.java
@@ -1,0 +1,25 @@
+package io.kestra.core.validations;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+import io.kestra.core.validations.validator.DurationMinValidator;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+/**
+ * Rejects a {@link java.time.Duration} smaller than {@link #min()} (default zero, so negative durations).
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = DurationMinValidator.class)
+public @interface DurationMin {
+    /** Minimum allowed duration, as an ISO-8601 string. Defaults to zero. */
+    String min() default "PT0S";
+
+    String message() default "duration must be at least {min}";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+}

--- a/core/src/main/java/io/kestra/core/validations/validator/DurationMinValidator.java
+++ b/core/src/main/java/io/kestra/core/validations/validator/DurationMinValidator.java
@@ -1,0 +1,37 @@
+package io.kestra.core.validations.validator;
+
+import java.time.Duration;
+
+import io.kestra.core.validations.DurationMin;
+
+import io.micronaut.core.annotation.AnnotationValue;
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.core.annotation.Nullable;
+import io.micronaut.validation.validator.constraints.ConstraintValidator;
+import io.micronaut.validation.validator.constraints.ConstraintValidatorContext;
+import jakarta.inject.Singleton;
+
+@Singleton
+public class DurationMinValidator implements ConstraintValidator<DurationMin, Duration> {
+    @Override
+    public boolean isValid(
+        @Nullable Duration value,
+        @NonNull AnnotationValue<DurationMin> annotationMetadata,
+        @NonNull ConstraintValidatorContext context) {
+        if (value == null) {
+            return true;
+        }
+
+        String minValue = annotationMetadata.stringValue("min").orElse("PT0S");
+        Duration min = Duration.parse(minValue);
+
+        if (value.compareTo(min) < 0) {
+            context.disableDefaultConstraintViolation();
+            context.buildConstraintViolationWithTemplate("duration '" + value + "' must be at least " + minValue)
+                .addConstraintViolation();
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/core/src/test/java/io/kestra/core/validations/MaxDurationSLAValidationTest.java
+++ b/core/src/test/java/io/kestra/core/validations/MaxDurationSLAValidationTest.java
@@ -1,0 +1,68 @@
+package io.kestra.core.validations;
+
+import java.time.Duration;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+
+import io.kestra.core.junit.annotations.KestraTest;
+import io.kestra.core.models.flows.sla.SLA;
+import io.kestra.core.models.flows.sla.types.MaxDurationSLA;
+import io.kestra.core.models.validations.ModelValidator;
+
+import jakarta.inject.Inject;
+import jakarta.validation.ConstraintViolationException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@KestraTest
+class MaxDurationSLAValidationTest {
+    @Inject
+    private ModelValidator modelValidator;
+
+    private static MaxDurationSLA.MaxDurationSLABuilder<?, ?> sla(Duration duration) {
+        return MaxDurationSLA.builder()
+            .id("dur")
+            .type(SLA.Type.MAX_DURATION)
+            .behavior(SLA.Behavior.FAIL)
+            .duration(duration);
+    }
+
+    @Test
+    void shouldBeValidWithAPositiveDuration() {
+        Optional<ConstraintViolationException> valid = modelValidator.isValid(sla(Duration.ofHours(1)).build());
+
+        assertThat(valid).isEmpty();
+    }
+
+    @Test
+    void shouldNotBeValidWhenDurationIsNegative() {
+        Optional<ConstraintViolationException> valid = modelValidator.isValid(sla(Duration.ofHours(-1)).build());
+
+        assertThat(valid).isPresent();
+        assertThat(valid.get().getConstraintViolations())
+            .anySatisfy(violation -> {
+                assertThat(violation.getPropertyPath().toString()).isEqualTo("duration");
+                assertThat(violation.getMessage()).contains("must be at least PT0S");
+            });
+    }
+
+    @Test
+    void shouldBeValidWithAZeroDuration() {
+        Optional<ConstraintViolationException> valid = modelValidator.isValid(sla(Duration.ZERO).build());
+
+        assertThat(valid).isEmpty();
+    }
+
+    @Test
+    void shouldStillRejectADurationAboveTheMaximum() {
+        Optional<ConstraintViolationException> valid = modelValidator.isValid(sla(Duration.ofDays(4000)).build());
+
+        assertThat(valid).isPresent();
+        assertThat(valid.get().getConstraintViolations())
+            .anySatisfy(violation -> {
+                assertThat(violation.getPropertyPath().toString()).isEqualTo("duration");
+                assertThat(violation.getMessage()).contains("must not exceed");
+            });
+    }
+}


### PR DESCRIPTION
> ⚠️ **This PR was fully generated by Claude** (Claude Code), including the reproducer tests and the fix. Please review accordingly.

Closes https://github.com/kestra-io/kestra-ee/issues/10262

## What was wrong

A flow SLA with a negative `duration` saved as **Valid**, then breached on the first evaluation of every execution — with `behavior: FAIL`, every run of the flow failed immediately.

```yaml
sla:
  - id: dur
    type: MAX_DURATION
    duration: PT-1H     # accepted at save
    behavior: FAIL
```

`MaxDurationSLA.duration` already carried `@DurationMax`; there was simply no lower bound.

## The fix

Added `@DurationMin` — a direct mirror of the existing `io.kestra.core.validations.DurationMax` (same annotation shape, same validator shape, same message style), defaulting to `PT0S` — and applied it to `MaxDurationSLA.duration` next to `@DurationMax`.

I used Kestra's own annotation rather than Hibernate's `org.hibernate.validator.constraints.time.DurationMin`. Hibernate's `DurationMax` does appear once in the codebase (`core/models/dashboards/TimeWindow`), but I verified by probe that Kestra's `@DurationMax` is definitely enforced by `ModelValidator`, and I did not want to depend on the Hibernate one being wired.

**One reviewable judgement call:** zero is treated as *valid* (inclusive boundary). A `PT0S` SLA is arguably just as degenerate as a negative one, but that is not what the issue reports, so I left it alone and pinned it with a test. Happy to flip it if you'd rather `PT0S` were rejected too.

## Tests

New `MaxDurationSLAValidationTest`:

- `shouldNotBeValidWhenDurationIsNegative` — the reproducer. **Verified failing before the fix** (`Expecting Optional to contain a value but it was empty`), passing after, and it asserts on the `duration` property path specifically.
- `shouldBeValidWithAPositiveDuration` / `shouldBeValidWithAZeroDuration` — pin both boundaries.
- `shouldStillRejectADurationAboveTheMaximum` — proves the pre-existing `@DurationMax` still fires.

> Note on method: my first version of the negative test asserted only `assertThat(valid).isPresent()` and **passed before the fix** — the SLA under test had null `type`/`behavior`, so unrelated violations made it green. The committed tests build a fully valid SLA and assert on the `duration` violation specifically.

`io.kestra.core.validations.*` and `io.kestra.core.models.flows.sla.*` pass: 135 tests, 0 failures.