### PR TITLE
fix(webserver): validate label keys on the execution-trigger and bulk set-labels paths

### DIFF
--- a/webserver/src/main/java/io/kestra/webserver/controllers/api/ExecutionController.java
+++ b/webserver/src/main/java/io/kestra/webserver/controllers/api/ExecutionController.java
@@ -55,6 +55,7 @@ import io.kestra.core.models.topologies.FlowTopology;
 import io.kestra.core.models.topologies.FlowTopologyGraph;
 import io.kestra.core.models.triggers.AbstractTrigger;
 import io.kestra.core.models.validations.ManualConstraintViolation;
+import io.kestra.core.models.validations.ModelValidator;
 import io.kestra.core.plugins.PluginRegistry;
 import io.kestra.core.preview.FilePreview;
 import io.kestra.core.preview.FileRenderer;
@@ -250,6 +251,9 @@ public class ExecutionController {
 
     @Inject
     private WebhookBodyService webhookBodyService;
+
+    @Inject
+    private ModelValidator modelValidator;
 
     @Inject
     private AsyncOperationWaiter asyncOperationWaiter;
@@ -1154,6 +1158,10 @@ public class ExecutionController {
             : RequestUtils.toMap(labels).entrySet().stream()
                 .map(entry -> new Label(entry.getKey(), entry.getValue()))
                 .collect(Collectors.toList());
+
+        // the label key format is enforced on the flow definition and on the single set-labels
+        // endpoint, so enforce it here too rather than letting a malformed key in through this door
+        parsedLabels.forEach(modelValidator::validate);
 
         // system labels can only be set by Kestra itself; the only exceptions accepted from a
         // client are system.correlationId and system.from=ui (sent by the UI). Any other
@@ -2417,7 +2425,7 @@ public class ExecutionController {
     @ApiResponse(responseCode = "202", description = "Accepted", content = { @Content(schema = @Schema(implementation = ApiAsyncOperationResponse.class)) })
     @ApiResponse(responseCode = "400", description = "Validation errors", content = { @Content(schema = @Schema(implementation = BulkErrorResponse.class)) })
     public MutableHttpResponse<ApiAsyncOperationResponse> setLabelsOnTerminatedExecutionsByIds(
-        @RequestBody(description = "The request containing a list of labels and a list of executions") @Body SetLabelsByIdsRequest setLabelsByIds) throws QueueException {
+        @RequestBody(description = "The request containing a list of labels and a list of executions") @Body @Valid SetLabelsByIdsRequest setLabelsByIds) throws QueueException {
         List<Execution> executions = new ArrayList<>();
         Set<ManualConstraintViolation<String>> invalids = new HashSet<>();
 
@@ -2468,7 +2476,7 @@ public class ExecutionController {
         });
     }
 
-    public record SetLabelsByIdsRequest(@NotNull List<String> executionsId, @NotNull List<Label> executionLabels) {
+    public record SetLabelsByIdsRequest(@NotNull List<String> executionsId, @NotNull List<@Valid Label> executionLabels) {
     }
 
     @ExecuteOn(TaskExecutors.IO)

--- a/webserver/src/test/java/io/kestra/webserver/controllers/api/ExecutionControllerRunnerTest.java
+++ b/webserver/src/test/java/io/kestra/webserver/controllers/api/ExecutionControllerRunnerTest.java
@@ -3035,6 +3035,43 @@ class ExecutionControllerRunnerTest {
     }
 
     @Test
+    @LoadFlows(value = { "flows/valids/minimal.yaml" }, tenantId = "shouldrejectinvalidlabelkeyontrigger")
+    void shouldRejectAnInvalidLabelKeyWhenTriggeringAnExecution() {
+        String tenantId = "shouldrejectinvalidlabelkeyontrigger";
+        when(tenantService.resolveTenant()).thenReturn(tenantId);
+
+        HttpClientResponseException e = assertThrows(
+            HttpClientResponseException.class, () -> client.toBlocking().retrieve(
+                HttpRequest
+                    .POST("/api/v1/%s/executions/io.kestra.tests/minimal?labels=Team:x&wait=true".formatted(tenantId), null)
+                    .contentType(MediaType.MULTIPART_FORM_DATA_TYPE),
+                Execution.class
+            )
+        );
+        assertThat(e.getStatus().getCode()).isEqualTo(HttpStatus.UNPROCESSABLE_ENTITY.getCode());
+        assertThat(e.getMessage()).contains("Invalid label key");
+    }
+
+    @Test
+    @LoadFlowsWithTenant({ "flows/valids/minimal.yaml" })
+    void shouldRejectAnInvalidLabelKeyWhenSettingLabelsByIds(String tenantId) throws TimeoutException, QueueException {
+        when(tenantService.resolveTenant()).thenReturn(tenantId);
+        Execution result = runnerUtils.runOne(tenantId, TESTS_FLOW_NS, "minimal");
+
+        HttpClientResponseException e = assertThrows(
+            HttpClientResponseException.class, () -> client.toBlocking().exchange(
+                HttpRequest.POST(
+                    "/api/v1/%s/executions/labels/by-ids".formatted(tenantId),
+                    new ExecutionController.SetLabelsByIdsRequest(List.of(result.getId()), List.of(new Label("Team", "x")))
+                ),
+                ApiAsyncOperationResponse.class
+            )
+        );
+        assertThat(e.getStatus().getCode()).isEqualTo(HttpStatus.UNPROCESSABLE_ENTITY.getCode());
+        assertThat(e.getMessage()).contains("Invalid label key");
+    }
+
+    @Test
     @LoadFlows(value = { "flows/valids/minimal.yaml" }, tenantId = "shouldsuspendatbreakpointthenresume")
     void shouldSuspendAtBreakpointThenResume() {
         String tenantId = "shouldsuspendatbreakpointthenresume";

--- a/webserver/src/test/java/io/kestra/webserver/controllers/api/ExecutionControllerRunnerTest.java
+++ b/webserver/src/test/java/io/kestra/webserver/controllers/api/ExecutionControllerRunnerTest.java
@@ -3054,6 +3054,24 @@ class ExecutionControllerRunnerTest {
 
     @Test
     @LoadFlowsWithTenant({ "flows/valids/minimal.yaml" })
+    void shouldRejectAMissingExecutionsIdWhenSettingLabelsByIds(String tenantId) {
+        when(tenantService.resolveTenant()).thenReturn(tenantId);
+
+        HttpClientResponseException e = assertThrows(
+            HttpClientResponseException.class, () -> client.toBlocking().exchange(
+                HttpRequest.POST(
+                    "/api/v1/%s/executions/labels/by-ids".formatted(tenantId),
+                    new ExecutionController.SetLabelsByIdsRequest(null, List.of(new Label("team", "data")))
+                ),
+                ApiAsyncOperationResponse.class
+            )
+        );
+        assertThat(e.getStatus().getCode()).isEqualTo(HttpStatus.UNPROCESSABLE_ENTITY.getCode());
+        assertThat(e.getMessage()).contains("executionsId");
+    }
+
+    @Test
+    @LoadFlowsWithTenant({ "flows/valids/minimal.yaml" })
     void shouldRejectAnInvalidLabelKeyWhenSettingLabelsByIds(String tenantId) throws TimeoutException, QueueException {
         when(tenantService.resolveTenant()).thenReturn(tenantId);
         Execution result = runnerUtils.runOne(tenantId, TESTS_FLOW_NS, "minimal");


### PR DESCRIPTION
> ⚠️ **This PR was fully generated by Claude** (Claude Code), including the reproducer tests and the fix. Please review accordingly.

Closes https://github.com/kestra-io/kestra/issues/18332
Closes https://github.com/kestra-io/kestra-ee/issues/10310

## What was wrong

The label-key format (`^[\p{Ll}][\p{L}0-9._-]*$`, declared on `Label`) was enforced on flow definitions and on `POST /executions/{id}/actions/labels`, but **not** on two other write paths:

| Path | Before |
|---|---|
| `POST /executions/{ns}/{flow}?labels=Team:x` | 200, stored |
| `POST /executions/labels/by-ids` with key `Team` | 202, stored |
| `POST /executions/{id}/actions/labels` with key `Team` | 422 ✅ |

So a label could be created but not subsequently edited from the execution's own editor, and malformed keys leaked into storage.

## The fix

**1. `parseLabels`** (the `?labels=` query path) built `Label` records by hand and never validated them. It now runs each caller-supplied label through the injected `ModelValidator`, which throws the same `ConstraintViolationException` that the single set-labels endpoint already maps to 422.

Validation happens on the caller-supplied labels only — before the method appends `system.from`, and before the EE subclass appends `system.username` — so neither internal label is subject to it (both are well-formed regardless).

**2. `setLabelsOnTerminatedExecutionsByIds`** took a plain `@Body SetLabelsByIdsRequest`. The body is now `@Valid` and the record declares `List<@Valid Label> executionLabels`, so element-level constraints actually run.

## Also fixes kestra-ee#10310

Making the body `@Valid` makes the record's existing `@NotNull executionsId` actually fire. Omitting `executionsId` previously produced:

```
500 Internal server error: Cannot invoke "java.util.List.iterator()" because the return value of
"...SetLabelsByIdsRequest.executionsId()" is null
```

and now answers **422 naming the field**. That issue asked for a 400, but 422-naming-the-field is what the sibling `labels/by-query` endpoint already returns for the same mistake (the issue notes this itself), so I matched the sibling rather than introducing a third shape.

## EE impact

`parseLabels` is `protected` and EE's `ExecutionController` overrides it. The override calls `super.parseLabels(...)` and then appends `system.username`, which happens after validation and is a valid key — so EE behaviour is unchanged apart from the intended rejection.

## Tests

Three tests added to `ExecutionControllerRunnerTest`, each **verified failing before the fix**:

- `shouldRejectAnInvalidLabelKeyWhenTriggeringAnExecution` — `?labels=Team:x` → 422 (`nothing was thrown` before).
- `shouldRejectAnInvalidLabelKeyWhenSettingLabelsByIds` — by-ids with key `Team` → 422 (`nothing was thrown` before).
- `shouldRejectAMissingExecutionsIdWhenSettingLabelsByIds` — by-ids with no ids → 422 (`expected: 422 but was: 500` before).

Full `ExecutionControllerRunnerTest` passes: **113 tests, 0 failures**. That class already covers the accepted-label paths (`system.from:ui`, `system.correlationId`, multi-label triggers, by-query set-labels), which is what makes the regression risk here measurable rather than assumed.