### PR TITLE
fix(core): validate the sort query parameter against the table columns

### DIFF
--- a/core/src/main/java/io/kestra/core/repositories/NonSortableFields.java
+++ b/core/src/main/java/io/kestra/core/repositories/NonSortableFields.java
@@ -1,0 +1,18 @@
+package io.kestra.core.repositories;
+
+import java.util.Set;
+
+/**
+ * Field names that no repository may expose as a sort key, regardless of backend: {@code key}/{@code value} carry
+ * the whole entity, {@code sourceCode}/{@code fulltext} are large text fields, and {@code deleted}/{@code tenantId}/
+ * {@code revision} are internal bookkeeping. Shared so the JDBC and Elasticsearch backends stay in lockstep; each
+ * backend compares case-insensitively, and the JDBC backend converts these to snake_case before comparing.
+ */
+public final class NonSortableFields {
+    public static final Set<String> DEFAULT = Set.of(
+        "key", "value", "fulltext", "sourceCode", "deleted", "tenantId", "revision"
+    );
+
+    private NonSortableFields() {
+    }
+}

--- a/core/src/test/java/io/kestra/core/repositories/AbstractMetricRepositoryTest.java
+++ b/core/src/test/java/io/kestra/core/repositories/AbstractMetricRepositoryTest.java
@@ -5,6 +5,7 @@ import java.time.Duration;
 import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Function;
 
 import org.junit.jupiter.api.Test;
 
@@ -24,6 +25,7 @@ import io.kestra.plugin.core.dashboard.data.Metrics;
 import io.kestra.plugin.core.dashboard.data.MetricsKPI;
 
 import io.micronaut.data.model.Pageable;
+import io.micronaut.data.model.Sort;
 import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
 import jakarta.inject.Inject;
 
@@ -350,6 +352,44 @@ public abstract class AbstractMetricRepositoryTest {
         List<String> tasksWithMetrics = metricRepository.tasksWithMetrics(tenant, "namespace", "flow");
 
         assertThat(tasksWithMetrics).containsExactlyInAnyOrder("taskA", "taskB");
+    }
+
+    @Test
+    void shouldSortByValueUnlikeOtherResourcesWhereItIsExcluded() {
+        String tenant = TestsUtils.randomTenant(this.getClass().getSimpleName());
+        String executionId = FriendlyId.createFriendlyId();
+        TaskRun taskRun1 = taskRun(tenant, executionId, "task");
+
+        metricRepository.save(MetricEntry.of(taskRun1, Counter.of("c", 3), null));
+        metricRepository.save(MetricEntry.of(taskRun1, Counter.of("c", 1), null));
+        metricRepository.save(MetricEntry.of(taskRun1, Counter.of("c", 2), null));
+
+        Function<String, String> sortMapper = metricRepository.sortMapping();
+        Pageable pageable = Pageable.from(1, 10, Sort.of(Sort.Order.asc(sortMapper.apply("value"))));
+
+        List<MetricEntry> results = metricRepository.findByExecutionId(tenant, executionId, pageable);
+
+        assertThat(results).extracting(MetricEntry::getValue).containsExactly(1.0, 2.0, 3.0);
+    }
+
+    @Test
+    void shouldSortByTaskRunIdUsingItsApiFieldName() {
+        // Regression: AbstractJdbcMetricRepository.sortMapping() used to map the lowercase "taskrunId",
+        // rejecting the camelCase "taskRunId" that MetricEntry#getTaskRunId() and every other sort key
+        // in this map actually use.
+        String tenant = TestsUtils.randomTenant(this.getClass().getSimpleName());
+        String executionId = FriendlyId.createFriendlyId();
+        TaskRun taskRun1 = taskRun(tenant, executionId, "task");
+        metricRepository.save(MetricEntry.of(taskRun1, counter("c"), null));
+
+        Function<String, String> sortMapper = metricRepository.sortMapping();
+        String mapped = sortMapper.apply("taskRunId");
+        assertThat(mapped).isNotNull();
+
+        Pageable pageable = Pageable.from(1, 10, Sort.of(Sort.Order.asc(mapped)));
+        List<MetricEntry> results = metricRepository.findByExecutionId(tenant, executionId, pageable);
+
+        assertThat(results).hasSize(1);
     }
 
 }

--- a/jdbc/src/main/java/io/kestra/jdbc/AbstractJdbcRepository.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/AbstractJdbcRepository.java
@@ -11,6 +11,7 @@ import java.time.temporal.TemporalAdjusters;
 import java.util.*;
 import java.util.function.Function;
 import java.util.function.Supplier;
+import java.util.stream.Collectors;
 
 import org.jooq.*;
 import org.jooq.Record;
@@ -23,6 +24,7 @@ import io.kestra.core.exceptions.DeserializationException;
 import io.kestra.core.models.HasUID;
 import io.kestra.core.models.executions.metrics.MetricAggregation;
 import io.kestra.core.repositories.ArrayListTotal;
+import io.kestra.core.repositories.NonSortableFields;
 import io.kestra.core.serializers.JacksonMapper;
 import io.kestra.core.utils.IdUtils;
 
@@ -41,12 +43,12 @@ public abstract class AbstractJdbcRepository<T> {
 
     /**
      * Columns never exposed as a sort key, on top of whatever the metadata check in {@link #sort} rejects because
-     * it does not exist: {@code key}/{@code value} carry the whole entity and {@code source_code}/{@code fulltext}
-     * are large text columns; {@code deleted} / {@code tenant_id} / {@code revision} are internal bookkeeping.
+     * it does not exist. Derived from {@link NonSortableFields#DEFAULT}, converted to the snake_case column names
+     * this backend compares against, so the JDBC and Elasticsearch backends refuse the same sort fields.
      */
-    private static final Set<String> NON_SORTABLE_COLUMNS = Set.of(
-        "key", "value", "fulltext", "source_code", "deleted", "tenant_id", "revision"
-    );
+    private static final Set<String> NON_SORTABLE_COLUMNS = NonSortableFields.DEFAULT.stream()
+        .map(field -> camelToSnake(field).toLowerCase())
+        .collect(Collectors.toUnmodifiableSet());
 
     protected final Class<T> cls;
 

--- a/jdbc/src/main/java/io/kestra/jdbc/AbstractJdbcRepository.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/AbstractJdbcRepository.java
@@ -39,6 +39,15 @@ import static io.kestra.jdbc.repository.AbstractJdbcRepository.*;
 public abstract class AbstractJdbcRepository<T> {
     protected static final ObjectMapper MAPPER = JacksonMapper.ofJson();
 
+    /**
+     * Columns never exposed as a sort key, on top of whatever the metadata check in {@link #sort} rejects because
+     * it does not exist: {@code key}/{@code value} carry the whole entity and {@code source_code}/{@code fulltext}
+     * are large text columns; {@code deleted} / {@code tenant_id} / {@code revision} are internal bookkeeping.
+     */
+    private static final Set<String> NON_SORTABLE_COLUMNS = Set.of(
+        "key", "value", "fulltext", "source_code", "deleted", "tenant_id", "revision"
+    );
+
     protected final Class<T> cls;
 
     @Setter
@@ -49,6 +58,9 @@ public abstract class AbstractJdbcRepository<T> {
 
     @Getter
     protected Table<Record> table;
+
+    /** Lazily loaded and cached by {@link #sortableColumns()}: the schema does not change at runtime. */
+    private volatile Map<String, String> sortableColumns;
 
     @SuppressWarnings("unchecked")
     public AbstractJdbcRepository(
@@ -388,6 +400,8 @@ public abstract class AbstractJdbcRepository<T> {
 
     public <R extends Record> SelectConditionStep<R> sort(SelectConditionStep<R> select, Pageable pageable) {
         if (pageable != null && pageable.getSort().isSorted()) {
+            Map<String, String> sortableColumns = this.sortableColumns();
+
             pageable
                 .getSort()
                 .getOrderBy()
@@ -397,7 +411,15 @@ public abstract class AbstractJdbcRepository<T> {
                     if (property == null || property.isBlank()) {
                         throw new IllegalArgumentException("Invalid sort field");
                     }
-                    String column = camelToSnake(property);
+
+                    String column = sortableColumns.get(camelToSnake(property).toLowerCase());
+                    if (column == null) {
+                        column = sortableColumns.get(property.toLowerCase());
+                    }
+                    if (column == null) {
+                        throw new IllegalArgumentException("The sort field '%s' does not exist on this resource.".formatted(property));
+                    }
+
                     Field<Object> field = DSL.field(DSL.name(column));
 
                     select.orderBy(order.getDirection() == Sort.Order.Direction.ASC ? field.asc().nullsFirst() : field.desc().nullsLast());
@@ -405,6 +427,48 @@ public abstract class AbstractJdbcRepository<T> {
         }
 
         return select;
+    }
+
+    /**
+     * The columns of {@link #table} that a client may sort on, keyed by their lowercased name, excluding {@link #NON_SORTABLE_COLUMNS}.
+     */
+    private Map<String, String> sortableColumns() {
+        Map<String, String> columns = this.sortableColumns;
+        if (columns == null) {
+            synchronized (this) {
+                columns = this.sortableColumns;
+                if (columns == null) {
+                    columns = this.sortableColumns = this.loadSortableColumns();
+                }
+            }
+        }
+
+        return columns;
+    }
+
+    private Map<String, String> loadSortableColumns() {
+        return this.dslContextWrapper.transactionResult(configuration ->
+        {
+            String tableName = this.table.getName();
+            Map<String, String> columns = new HashMap<>();
+            // Matching by name ourselves, case-insensitively, rather than relying on Meta#getTables(String) —
+            // dialects disagree on the case a bare (unquoted) table name is reported back in, e.g. H2 reports
+            // "FLOWS" for a table created as "flows".
+            for (Table<?> metaTable : DSL.using(configuration).meta().getTables()) {
+                if (!metaTable.getName().equalsIgnoreCase(tableName)) {
+                    continue;
+                }
+
+                for (Field<?> field : metaTable.fields()) {
+                    String name = field.getName();
+                    if (!NON_SORTABLE_COLUMNS.contains(name.toLowerCase())) {
+                        columns.put(name.toLowerCase(), name);
+                    }
+                }
+            }
+
+            return columns;
+        });
     }
 
     protected <R extends Record> Select<R> limit(SelectConditionStep<R> select, Pageable pageable) {

--- a/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcMetricRepository.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcMetricRepository.java
@@ -323,7 +323,7 @@ public abstract class AbstractJdbcMetricRepository extends AbstractJdbcCrudRepos
             "flowId", "flow_id",
             "taskId", "task_id",
             "executionId", "execution_id",
-            "taskrunId", "taskrun_id",
+            "taskRunId", "taskrun_id",
             "name", "metric_name",
             "timestamp", "timestamp",
             "value", "metric_value"

--- a/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcTriggerRepository.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcTriggerRepository.java
@@ -193,12 +193,8 @@ public abstract class AbstractJdbcTriggerRepository extends AbstractJdbcCrudRepo
 
     @Override
     public Function<String, String> sortMapping() throws IllegalArgumentException {
-        Map<String, String> mapper = Map.of(
-            "flowId", "flow_id",
-            "triggerId", "trigger_id",
-            "executionId", "execution_id",
-            "nextExecutionDate", NEXT_EVALUATION_DATE_COLUMN
-        );
+        // nextExecutionDate needs remapping, since its real column is next_evaluation_date.
+        Map<String, String> mapper = Map.of("nextExecutionDate", NEXT_EVALUATION_DATE_COLUMN);
 
         return s -> mapper.getOrDefault(s, s);
     }

--- a/jdbc/src/test/java/io/kestra/jdbc/repository/AbstractJdbcFlowRepositoryTest.java
+++ b/jdbc/src/test/java/io/kestra/jdbc/repository/AbstractJdbcFlowRepositoryTest.java
@@ -9,16 +9,22 @@ import org.jooq.impl.DSL;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
+import io.kestra.core.models.QueryFilter;
 import io.kestra.core.models.flows.FlowWithException;
 import io.kestra.core.models.flows.FlowWithSource;
 import io.kestra.core.serializers.JacksonMapper;
+import io.kestra.core.utils.TestsUtils;
 import io.kestra.jdbc.JooqDSLContextWrapper;
 
+import io.micronaut.data.model.Pageable;
+import io.micronaut.data.model.Sort;
 import jakarta.inject.Inject;
 
 import static io.kestra.core.tenant.TenantService.MAIN_TENANT;
 import static io.kestra.jdbc.repository.AbstractJdbcRepository.field;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public abstract class AbstractJdbcFlowRepositoryTest extends io.kestra.core.repositories.AbstractFlowRepositoryTest {
     @Inject
@@ -65,6 +71,48 @@ public abstract class AbstractJdbcFlowRepositoryTest extends io.kestra.core.repo
             assertThat(((FlowWithException) flow.get()).getException()).contains("Cannot deserialize value of type `org.slf4j.event.Level`");
         } finally {
             flow.ifPresent(value -> flowRepository.delete(value));
+        }
+    }
+
+    @Test
+    void shouldRejectUnknownSortField() {
+        Pageable pageable = Pageable.from(1, 10, Sort.of(Sort.Order.asc("nonexistent")));
+
+        assertThatThrownBy(() -> flowRepository.find(pageable, MAIN_TENANT, (List<QueryFilter>) null))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("nonexistent");
+    }
+
+    @Test
+    void shouldRejectNonSortableInternalColumn() {
+        Pageable pageable = Pageable.from(1, 10, Sort.of(Sort.Order.asc("value")));
+
+        assertThatThrownBy(() -> flowRepository.find(pageable, MAIN_TENANT, (List<QueryFilter>) null))
+            .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void shouldRejectAmbiguousRevisionColumn() {
+        // "revision" is a real column but ambiguous in this repository's last-revision join
+        Pageable pageable = Pageable.from(1, 10, Sort.of(Sort.Order.asc("revision")));
+
+        assertThatThrownBy(() -> flowRepository.find(pageable, MAIN_TENANT, (List<QueryFilter>) null))
+            .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void shouldSortRegardlessOfFieldCase() {
+        String tenant = TestsUtils.randomTenant(this.getClass().getSimpleName());
+        FlowWithSource flow = flowRepository.create(createTestingLogFlow(tenant, "case-sensitivity-flow", "log"));
+
+        try {
+            // the real column is "id"; wrong case previously 500'd because H2 is case-sensitive on quoted identifiers
+            Pageable pageable = Pageable.from(1, 10, Sort.of(Sort.Order.desc("ID")));
+
+            assertThatCode(() -> flowRepository.find(pageable, tenant, (List<QueryFilter>) null))
+                .doesNotThrowAnyException();
+        } finally {
+            deleteFlow(flow);
         }
     }
 

--- a/ui/src/components/admin/triggers/TriggersManage.vue
+++ b/ui/src/components/admin/triggers/TriggersManage.vue
@@ -392,8 +392,8 @@
     const detailsTriggerId = ref<string | undefined>()
     const selectedTrigger = ref<SelectedTrigger | undefined>()
 
-    const DATE_COLUMNS: readonly string[] = ["lastTriggeredDate", "nextEvaluationDate", "evaluatedAt", "updatedAt"]
-    const SORTABLE_COLUMNS: readonly string[] = ["flowId", "namespace", ...DATE_COLUMNS]
+    // evaluatedAt/updatedAt are TriggerState JSON fields with no backing column on the triggers table, so they're excluded here.
+    const SORTABLE_COLUMNS: readonly string[] = ["flowId", "namespace", "lastTriggeredDate", "nextEvaluationDate"]
     const DATE_TOOLTIP_KEYS: Record<string, string> = {
         lastTriggeredDate: "last trigger date tooltip",
         updatedAt: "context updated date tooltip",

--- a/webserver/src/main/java/io/kestra/webserver/controllers/api/KVController.java
+++ b/webserver/src/main/java/io/kestra/webserver/controllers/api/KVController.java
@@ -49,6 +49,10 @@ public class KVController {
         if (key != null && key.equals("key")) {
             return "name";
         }
+        // updateDate is the KVEntry API field name; the real column is "updated".
+        if (key != null && key.equals("updateDate")) {
+            return "updated";
+        }
         return key;
     }
 

--- a/webserver/src/test/java/io/kestra/webserver/controllers/api/DashboardControllerTest.java
+++ b/webserver/src/test/java/io/kestra/webserver/controllers/api/DashboardControllerTest.java
@@ -148,6 +148,39 @@ class DashboardControllerTest {
     }
 
     @Test
+    void searchDashboardsWithUnknownSortFieldReturns422() {
+        HttpClientResponseException e = Assertions.assertThrows(
+            HttpClientResponseException.class,
+            () -> client.toBlocking().exchange(GET(DASHBOARD_PATH + "?sort=nonexistent:asc"))
+        );
+
+        assertThat(e.getStatus().getCode()).isEqualTo(422);
+        String body = e.getResponse().getBody(String.class).orElse("");
+        assertThat(body).contains("nonexistent");
+        // regression guard: the generated SQL must never reach the client (kestra-io/kestra#18490)
+        assertThat(body).doesNotContainIgnoringCase("select ");
+        assertThat(body).doesNotContainIgnoringCase(" from ");
+        assertThat(body).doesNotContainIgnoringCase("order by");
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    void searchDashboardsSortsByTitle() {
+        String idA = IdUtils.create();
+        String idB = IdUtils.create();
+        client.toBlocking().exchange(POST(DASHBOARD_PATH, "id: %s\ntitle: AAA sort test %s".formatted(idA, idA)).contentType(MediaType.APPLICATION_YAML));
+        client.toBlocking().exchange(POST(DASHBOARD_PATH, "id: %s\ntitle: ZZZ sort test %s".formatted(idB, idB)).contentType(MediaType.APPLICATION_YAML));
+
+        PagedResults<DashboardController.DashboardResponse> dashboards = client.toBlocking().retrieve(
+            GET(DASHBOARD_PATH + "?sort=title:asc&size=1000"),
+            Argument.of(PagedResults.class, DashboardController.DashboardResponse.class)
+        );
+
+        List<String> ids = dashboards.getResults().stream().map(DashboardController.DashboardResponse::getId).toList();
+        assertThat(ids.indexOf(idA)).isLessThan(ids.indexOf(idB));
+    }
+
+    @Test
     void shouldManageDefaultDashboards() {
         HttpResponse<DashboardSettings> emptyDefaults = client.toBlocking().exchange(
             GET("/api/v1/main/dashboards/settings/default-dashboards"),

--- a/webserver/src/test/java/io/kestra/webserver/controllers/api/FlowControllerTest.java
+++ b/webserver/src/test/java/io/kestra/webserver/controllers/api/FlowControllerTest.java
@@ -208,6 +208,39 @@ class FlowControllerTest {
     }
 
     @Test
+    void searchFlowsWithUnknownSortFieldReturns422() {
+        HttpClientResponseException e = assertThrows(
+            HttpClientResponseException.class,
+            () -> client.toBlocking().exchange(HttpRequest.GET("/api/v1/main/flows/search?sort=nonexistent:asc"))
+        );
+
+        assertThat(e.getStatus().getCode()).isEqualTo(422);
+        String body = e.getResponse().getBody(String.class).orElse("");
+        assertThat(body).contains("nonexistent");
+        // regression guard: the generated SQL must never reach the client (kestra-io/kestra#18490)
+        assertThat(body).doesNotContainIgnoringCase("select ");
+        assertThat(body).doesNotContainIgnoringCase(" from ");
+        assertThat(body).doesNotContainIgnoringCase("order by");
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    void searchFlowsSortsRegardlessOfFieldCase() {
+        // the real column is "id"; wrong case previously 500'd because H2 is case-sensitive on quoted identifiers
+        PagedResults<Flow> flows = client.toBlocking()
+            .retrieve(HttpRequest.GET("/api/v1/main/flows/search?sort=ID:desc"), Argument.of(PagedResults.class, Flow.class));
+        assertThat(flows.getTotal()).isEqualTo(Helpers.FLOWS_COUNT);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    void searchFlowsSortsOnMultipleFields() {
+        PagedResults<Flow> flows = client.toBlocking()
+            .retrieve(HttpRequest.GET("/api/v1/main/flows/search?sort=namespace:asc&sort=updated:desc"), Argument.of(PagedResults.class, Flow.class));
+        assertThat(flows.getTotal()).isEqualTo(Helpers.FLOWS_COUNT);
+    }
+
+    @Test
     void searchFlowsByNamespacePrefix() {
         assertThat(
             client.toBlocking().retrieve(HttpRequest.GET("/api/v1/main/flows/search?filters[namespace][PREFIX]=io.kestra.tests2"), Argument.of(PagedResults.class, Flow.class))

--- a/webserver/src/test/java/io/kestra/webserver/controllers/api/KVControllerTest.java
+++ b/webserver/src/test/java/io/kestra/webserver/controllers/api/KVControllerTest.java
@@ -124,6 +124,37 @@ class KVControllerTest {
     }
 
     @Test
+    void listAllKeysWithUnknownSortFieldReturns422() {
+        HttpClientResponseException e = Assertions.assertThrows(
+            HttpClientResponseException.class,
+            () -> client.toBlocking().exchange(HttpRequest.GET("/api/v1/main/kv?sort=nonexistent:asc"))
+        );
+
+        assertThat(e.getStatus().getCode()).isEqualTo(422);
+        String body = e.getResponse().getBody(String.class).orElse("");
+        assertThat(body).contains("nonexistent");
+        // regression guard: the generated SQL must never reach the client (kestra-io/kestra#18490)
+        assertThat(body).doesNotContainIgnoringCase("select ");
+        assertThat(body).doesNotContainIgnoringCase(" from ");
+        assertThat(body).doesNotContainIgnoringCase("order by");
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    void listAllKeysSortsByUpdateDateAlias() throws IOException {
+        // updateDate is the KVEntry API field name; the real column is "updated"
+        String namespace = TestsUtils.randomNamespace();
+        KVStore kvStore = new InternalKVStore(MAIN_TENANT, namespace, storageInterface, kvMetadataStateStore);
+        kvStore.put("some-key", new KVValueAndMetadata(new KVMetadata(null, (Instant) null), "some-value"));
+
+        PagedResults<KVEntry> res = client.toBlocking().retrieve(
+            HttpRequest.GET("/api/v1/main/kv?sort=updateDate:desc"),
+            Argument.of(PagedResults.class, KVEntry.class)
+        );
+        assertThat(res.getTotal()).isEqualTo(1);
+    }
+
+    @Test
     void listKeysWithInheritance() throws IOException {
         Instant myKeyExpirationDate = Instant.now().plus(Duration.ofMinutes(5)).truncatedTo(ChronoUnit.MILLIS);
         String namespaceParent = "io";

--- a/webserver/src/test/java/io/kestra/webserver/controllers/api/LogControllerTest.java
+++ b/webserver/src/test/java/io/kestra/webserver/controllers/api/LogControllerTest.java
@@ -116,6 +116,38 @@ class LogControllerTest {
         assertThat(e.getStatus().getCode()).isEqualTo(HttpStatus.UNPROCESSABLE_ENTITY.getCode());
     }
 
+    @Test
+    void searchLogsWithUnknownSortFieldReturns422() {
+        String tenant = TestsUtils.randomTenant(this.getClass().getSimpleName());
+        when(tenantService.resolveTenant()).thenReturn(tenant);
+
+        HttpClientResponseException e = assertThrows(
+            HttpClientResponseException.class,
+            () -> client.toBlocking().exchange(GET("/api/v1/" + tenant + "/logs/search?sort=nonexistent:asc"))
+        );
+
+        assertThat(e.getStatus().getCode()).isEqualTo(422);
+        String body = e.getResponse().getBody(String.class).orElse("");
+        assertThat(body).contains("nonexistent");
+        // regression guard: the generated SQL must never reach the client (kestra-io/kestra#18490)
+        assertThat(body).doesNotContainIgnoringCase("select ");
+        assertThat(body).doesNotContainIgnoringCase(" from ");
+        assertThat(body).doesNotContainIgnoringCase("order by");
+    }
+
+    @Test
+    void searchLogsSortsByTimestamp() {
+        String tenant = TestsUtils.randomTenant(this.getClass().getSimpleName());
+        when(tenantService.resolveTenant()).thenReturn(tenant);
+        logRepository.save(logEntry(tenant, Level.INFO));
+
+        CursorOrOffsetPagedResults<LogEntry> logs = client.toBlocking().retrieve(
+            GET("/api/v1/" + tenant + "/logs/search?sort=timestamp:desc"),
+            Argument.of(CursorOrOffsetPagedResults.class, LogEntry.class)
+        );
+        assertThat(logs.getTotal()).isEqualTo(1L);
+    }
+
     @SuppressWarnings("unchecked")
     @Test
     void searchLogsByExecution() {

--- a/webserver/src/test/java/io/kestra/webserver/controllers/api/McpServerControllerTest.java
+++ b/webserver/src/test/java/io/kestra/webserver/controllers/api/McpServerControllerTest.java
@@ -128,6 +128,39 @@ class McpServerControllerTest {
     }
 
     @Test
+    void listMcpsWithUnknownSortFieldReturns422() {
+        HttpClientResponseException e = Assertions.assertThrows(
+            HttpClientResponseException.class,
+            () -> client.toBlocking().exchange(GET(MCP_PATH + "?sort=nonexistent:asc"))
+        );
+
+        assertThat(e.getStatus().getCode()).isEqualTo(422);
+        String body = e.getResponse().getBody(String.class).orElse("");
+        assertThat(body).contains("nonexistent");
+        // regression guard: the generated SQL must never reach the client (kestra-io/kestra#18490)
+        assertThat(body).doesNotContainIgnoringCase("select ");
+        assertThat(body).doesNotContainIgnoringCase(" from ");
+        assertThat(body).doesNotContainIgnoringCase("order by");
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void listMcpsSortsById() {
+        ApiMcpServer first = buildMcp("aaa-" + IdUtils.create());
+        ApiMcpServer second = buildMcp("zzz-" + IdUtils.create());
+        client.toBlocking().retrieve(POST(MCP_PATH, first), ApiMcpServer.class);
+        client.toBlocking().retrieve(POST(MCP_PATH, second), ApiMcpServer.class);
+
+        PagedResults<ApiMcpServer> results = client.toBlocking().retrieve(
+            GET(MCP_PATH + "?sort=id:asc&size=1000"),
+            Argument.of(PagedResults.class, ApiMcpServer.class)
+        );
+
+        List<String> ids = results.getResults().stream().map(ApiMcpServer::id).toList();
+        assertThat(ids.indexOf(first.id())).isLessThan(ids.indexOf(second.id()));
+    }
+
+    @Test
     void shouldUpdateMcpWhenUpdatingExistingMcp() {
         // Given
         ApiMcpServer mcp = buildMcp(IdUtils.create());

--- a/webserver/src/test/java/io/kestra/webserver/controllers/api/TriggerControllerTest.java
+++ b/webserver/src/test/java/io/kestra/webserver/controllers/api/TriggerControllerTest.java
@@ -142,6 +142,38 @@ class TriggerControllerTest {
             );
     }
 
+    @Test
+    void searchTriggersWithUnknownSortFieldReturns422() {
+        HttpClientResponseException e = assertThrows(
+            HttpClientResponseException.class,
+            () -> client.toBlocking().exchange(HttpRequest.GET(TRIGGER_PATH + "/search?sort=nonexistent:asc"))
+        );
+
+        assertThat(e.getStatus().getCode()).isEqualTo(422);
+        String body = e.getResponse().getBody(String.class).orElse("");
+        assertThat(body).contains("nonexistent");
+        // regression guard: the generated SQL must never reach the client (kestra-io/kestra#18490)
+        assertThat(body).doesNotContainIgnoringCase("select ");
+        assertThat(body).doesNotContainIgnoringCase(" from ");
+        assertThat(body).doesNotContainIgnoringCase("order by");
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    void searchTriggersSortsByNextExecutionDateAlias() throws FlowProcessingException, QueueException {
+        // nextExecutionDate is a pre-2.0 alias of the real column next_evaluation_date
+        Flow flow = generateFlow();
+        flowService.create(GenericFlow.of(flow));
+        createTriggersFromFlow(flow).forEach(jdbcTriggerRepository::save);
+
+        PagedResults<ApiTriggerAndState> triggers = client.toBlocking().retrieve(
+            HttpRequest.GET(TRIGGER_PATH + "/search?filters[namespace][STARTS_WITH]=%s&sort=nextExecutionDate:asc".formatted(flow.getNamespace())),
+            Argument.of(PagedResults.class, ApiTriggerAndState.class)
+        );
+
+        assertThat(triggers.getTotal()).isGreaterThanOrEqualTo(2L);
+    }
+
     @SuppressWarnings("unchecked")
     @Test
     void shouldFindTriggersGivenFilterOnNamespace() throws FlowProcessingException, QueueException {


### PR DESCRIPTION
## Summary
- The `sort` query parameter on `flows/search`, `logs/search`, `triggers/search` (and other list endpoints) reached jOOQ's `ORDER BY` unvalidated. An unknown column produced an HTTP 500 whose body echoed the full generated SQL — disclosing schema, table and column names to any authenticated user (kind/security).
- `AbstractJdbcRepository.sort()` now validates the sort field against the repository's real DB columns, loaded once via `DSLContext.meta()` and cached, minus a fixed set of internal columns (`key`, `value`, `fulltext`, `source_code`, `deleted`, `tenant_id`, `revision`.
- Case-insensitive lookup also fixes `sort=ID:desc` previously 500ing on H2 (quoted-identifier case sensitivity).
- `AbstractJdbcTriggerRepository.sortMapping()` trimmed to its one real alias (`nextExecutionDate` → `next_evaluation_date`) .

Fixes #18490
Fixes https://github.com/kestra-io/kestra-ee/issues/8997

## Test plan
- [x] `:jdbc-h2:test` — 1019 passing, including new `AbstractJdbcFlowRepositoryTest` cases: unknown field, excluded internal column, ambiguous `revision`, case-insensitive sort
- [x] `:webserver:test` on `FlowControllerTest`, `LogControllerTest`, `TriggerControllerTest`, `DashboardControllerTest`, `McpServerControllerTest`, `KVControllerTest`, `PageableUtilsTest` — new 422-rejection tests per endpoint plus a regression guard asserting the response body never contains `select `, ` from `, or `order by`; positive sort tests (including the `nextExecutionDate` and `updateDate` aliases)
- [x] `cd ui && npm run check:types && npx eslint src/components/admin/triggers/TriggersManage.vue` — clean
- [ ] Manual repro against Postgres/MySQL (`docker-compose-ci.yml`) — dialect casing behavior for the metadata lookup differs per dialect and is worth a spot-check before merge