### PR TITLE
fix(core): 500 on labels search filters that need a label key

### DIFF
--- a/core/src/test/java/io/kestra/core/repositories/AbstractFlowRepositoryTest.java
+++ b/core/src/test/java/io/kestra/core/repositories/AbstractFlowRepositoryTest.java
@@ -57,6 +57,7 @@ import lombok.experimental.SuperBuilder;
 
 import static io.kestra.core.models.flows.FlowScope.SYSTEM;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.*;
 
 @MicronautTest(transactional = false)
@@ -404,11 +405,45 @@ public abstract class AbstractFlowRepositoryTest {
                 .extracting(Flow::getId)
                 .containsExactlyInAnyOrder("flow-without-label", "flow-with-different-label");
 
+            QueryFilter containsKeyValueFilter = QueryFilter.builder()
+                .field(QueryFilter.Field.LABELS)
+                .operation(QueryFilter.Op.CONTAINS)
+                .value(Map.of("foo", "ar"))
+                .build();
+
+            assertThat(flowRepository.find(Pageable.UNPAGED, tenant, List.of(containsKeyValueFilter)))
+                .extracting(Flow::getId)
+                .containsExactlyInAnyOrder("flow-with-label");
+
+            QueryFilter notContainsKeyValueFilter = QueryFilter.builder()
+                .field(QueryFilter.Field.LABELS)
+                .operation(QueryFilter.Op.NOT_CONTAINS)
+                .value(Map.of("foo", "ar"))
+                .build();
+
+            assertThat(flowRepository.find(Pageable.UNPAGED, tenant, List.of(notContainsKeyValueFilter)))
+                .extracting(Flow::getId)
+                .containsExactlyInAnyOrder("flow-without-label", "flow-with-different-label");
+
         } finally {
             deleteFlow(flowWithLabel);
             deleteFlow(flowWithoutLabel);
             deleteFlow(flowWithDifferentLabel);
         }
+    }
+
+    @Test
+    void shouldThrowExceptionWhenLabelsOperationRequiresKeyButValueIsScalar() {
+        String tenant = TestsUtils.randomTenant(this.getClass().getSimpleName());
+
+        QueryFilter filter = QueryFilter.builder()
+            .field(QueryFilter.Field.LABELS)
+            .operation(QueryFilter.Op.EQUALS)
+            .value("x")
+            .build();
+
+        assertThatThrownBy(() -> flowRepository.find(Pageable.UNPAGED, tenant, List.of(filter)))
+            .isInstanceOf(InvalidQueryFiltersException.class);
     }
 
     @Test

--- a/jdbc-h2/src/main/java/io/kestra/repository/h2/H2ExecutionRepositoryService.java
+++ b/jdbc-h2/src/main/java/io/kestra/repository/h2/H2ExecutionRepositoryService.java
@@ -9,6 +9,7 @@ import org.jooq.Condition;
 import org.jooq.Field;
 import org.jooq.impl.DSL;
 
+import io.kestra.core.exceptions.InvalidQueryFiltersException;
 import io.kestra.core.models.QueryFilter;
 import io.kestra.core.models.executions.Execution;
 import io.kestra.core.utils.Either;
@@ -52,7 +53,7 @@ public abstract class H2ExecutionRepositoryService {
                 case NOT_CONTAINS -> conditions.add(containsCondition.not());
                 case IS_NULL -> conditions.add(labelKeyCondition(query).not());
                 case IS_NOT_NULL -> conditions.add(labelKeyCondition(query));
-                default -> throw new UnsupportedOperationException("Unsupported operation for query: " + operation);
+                default -> throw new InvalidQueryFiltersException("Unsupported operation for query: " + operation);
             }
         } else {
             var labels = input.left().get();
@@ -70,7 +71,7 @@ public abstract class H2ExecutionRepositoryService {
                     case IN -> inConditions.add(value == null ? valueField.isNull() : valueField.eq((String) value));
                     case IS_NULL -> conditions.add(labelKeyCondition((String) key).not());
                     case IS_NOT_NULL -> conditions.add(labelKeyCondition((String) key));
-                    default -> throw new UnsupportedOperationException("Unsupported operation: " + operation);
+                    default -> throw new InvalidQueryFiltersException("Unsupported operation: " + operation);
                 }
             });
         }

--- a/jdbc-h2/src/main/java/io/kestra/repository/h2/H2FlowRepositoryService.java
+++ b/jdbc-h2/src/main/java/io/kestra/repository/h2/H2FlowRepositoryService.java
@@ -8,6 +8,7 @@ import org.jooq.Condition;
 import org.jooq.Field;
 import org.jooq.impl.DSL;
 
+import io.kestra.core.exceptions.InvalidQueryFiltersException;
 import io.kestra.core.models.QueryFilter;
 import io.kestra.core.models.flows.FlowInterface;
 import io.kestra.jdbc.AbstractJdbcRepository;
@@ -73,7 +74,7 @@ public abstract class H2FlowRepositoryService {
                 case NOT_CONTAINS -> conditions.add(containsCondition.not());
                 case IS_NULL -> conditions.add(labelKeyCondition(label).not());
                 case IS_NOT_NULL -> conditions.add(labelKeyCondition(label));
-                default -> throw new UnsupportedOperationException("Unsupported operation: " + operation);
+                default -> throw new InvalidQueryFiltersException("Unsupported operation: " + operation);
             }
         } else if (labels instanceof Map<?, ?> labelValues) {
             labelValues.forEach((key, value) ->
@@ -85,9 +86,11 @@ public abstract class H2FlowRepositoryService {
                     case EQUALS -> value == null ? valueField.isNull() : valueField.eq((String) value);
                     case NOT_EQUALS, NOT_IN -> value == null ? valueField.isNotNull() : valueField.isNull().or(valueField.ne((String) value));
                     case IN -> value == null ? valueField.isNull() : valueField.eq((String) value);
+                    case CONTAINS -> DSL.coalesce(valueField, "").contains((String) value);
+                    case NOT_CONTAINS -> DSL.coalesce(valueField, "").contains((String) value).not();
                     case IS_NULL -> labelKeyCondition((String) key).not();
                     case IS_NOT_NULL -> labelKeyCondition((String) key);
-                    default -> throw new UnsupportedOperationException("Unsupported operation: " + operation);
+                    default -> throw new InvalidQueryFiltersException("Unsupported operation: " + operation);
                 };
 
                 if (operation == QueryFilter.Op.IN) {

--- a/jdbc-mysql/src/main/java/io/kestra/repository/mysql/MysqlExecutionRepositoryService.java
+++ b/jdbc-mysql/src/main/java/io/kestra/repository/mysql/MysqlExecutionRepositoryService.java
@@ -6,6 +6,7 @@ import org.jooq.Condition;
 import org.jooq.Field;
 import org.jooq.impl.DSL;
 
+import io.kestra.core.exceptions.InvalidQueryFiltersException;
 import io.kestra.core.models.QueryFilter;
 import io.kestra.core.models.executions.Execution;
 import io.kestra.core.utils.Either;
@@ -43,7 +44,7 @@ public abstract class MysqlExecutionRepositoryService {
                 case NOT_CONTAINS -> conditions.add(labelContainsCondition(query).not());
                 case IS_NULL -> conditions.add(labelKeyCondition(query).not());
                 case IS_NOT_NULL -> conditions.add(labelKeyCondition(query));
-                default -> throw new UnsupportedOperationException("Unsupported operation for query: " + operation);
+                default -> throw new InvalidQueryFiltersException("Unsupported operation for query: " + operation);
             }
         } else {
             var labels = input.getLeft();
@@ -72,7 +73,7 @@ public abstract class MysqlExecutionRepositoryService {
                         conditions.add(labelKeyCondition((String) key).not());
                     case IS_NOT_NULL ->
                         conditions.add(labelKeyCondition((String) key));
-                    default -> throw new UnsupportedOperationException("Unsupported operation: " + operation);
+                    default -> throw new InvalidQueryFiltersException("Unsupported operation: " + operation);
                 }
             });
         }

--- a/jdbc-mysql/src/main/java/io/kestra/repository/mysql/MysqlFlowRepositoryService.java
+++ b/jdbc-mysql/src/main/java/io/kestra/repository/mysql/MysqlFlowRepositoryService.java
@@ -6,6 +6,7 @@ import org.jooq.Condition;
 import org.jooq.Field;
 import org.jooq.impl.DSL;
 
+import io.kestra.core.exceptions.InvalidQueryFiltersException;
 import io.kestra.core.models.QueryFilter;
 import io.kestra.core.models.flows.FlowInterface;
 import io.kestra.jdbc.AbstractJdbcRepository;
@@ -64,7 +65,7 @@ public abstract class MysqlFlowRepositoryService {
                 case NOT_CONTAINS -> conditions.add(labelContainsCondition(label).not());
                 case IS_NULL -> conditions.add(labelKeyCondition(label).not());
                 case IS_NOT_NULL -> conditions.add(labelKeyCondition(label));
-                default -> throw new UnsupportedOperationException("Unsupported operation: " + operation);
+                default -> throw new InvalidQueryFiltersException("Unsupported operation: " + operation);
             }
         } else if (labels instanceof Map<?, ?> labelValues) {
             labelValues.forEach((key, value) ->
@@ -81,12 +82,16 @@ public abstract class MysqlFlowRepositoryService {
                     conditions.add(labelMatches.ne(value != null));
                 else if (operation.equals(NOT_EQUALS)) {
                     conditions.add(labelMatches.ne(value != null));
+                } else if (operation.equals(QueryFilter.Op.CONTAINS)) {
+                    conditions.add(labelValueContainsCondition((String) key, (String) value));
+                } else if (operation.equals(QueryFilter.Op.NOT_CONTAINS)) {
+                    conditions.add(labelValueContainsCondition((String) key, (String) value).not());
                 } else if (operation.equals(QueryFilter.Op.IS_NULL)) {
                     conditions.add(labelKeyCondition((String) key).not());
                 } else if (operation.equals(QueryFilter.Op.IS_NOT_NULL)) {
                     conditions.add(labelKeyCondition((String) key));
                 } else {
-                    throw new UnsupportedOperationException("Unsupported operation: " + operation);
+                    throw new InvalidQueryFiltersException("Unsupported operation: " + operation);
                 }
             });
         }
@@ -105,6 +110,24 @@ public abstract class MysqlFlowRepositoryService {
                     "JSON_SEARCH(value, 'one', CONCAT('%', ?, '%'), NULL, '$.labels[*].value') IS NOT NULL", query
                 )
             );
+    }
+
+    private static Condition labelValueContainsCondition(String key, String value) {
+        return DSL.condition(
+            """
+            EXISTS (
+                SELECT 1
+                FROM JSON_TABLE(value, '$.labels[*]' COLUMNS (
+                    label_key VARCHAR(255) PATH '$.key',
+                    label_value VARCHAR(255) PATH '$.value'
+                )) AS labels
+                WHERE labels.label_key = ?
+                  AND LOWER(labels.label_value) LIKE LOWER(CONCAT('%', ?, '%'))
+            )
+            """,
+            key,
+            value
+        );
     }
 
     private static Condition labelKeyCondition(String key) {

--- a/jdbc-postgres/src/main/java/io/kestra/repository/postgres/PostgresExecutionRepositoryService.java
+++ b/jdbc-postgres/src/main/java/io/kestra/repository/postgres/PostgresExecutionRepositoryService.java
@@ -7,6 +7,7 @@ import org.jooq.Field;
 import org.jooq.impl.DSL;
 import org.jooq.impl.SQLDataType;
 
+import io.kestra.core.exceptions.InvalidQueryFiltersException;
 import io.kestra.core.models.QueryFilter;
 import io.kestra.core.models.executions.Execution;
 import io.kestra.core.models.flows.State;
@@ -43,7 +44,7 @@ public abstract class PostgresExecutionRepositoryService {
                 case NOT_CONTAINS -> conditions.add(labelContainsCondition(query).not());
                 case IS_NULL -> conditions.add(labelKeyCondition(query).not());
                 case IS_NOT_NULL -> conditions.add(labelKeyCondition(query));
-                default -> throw new UnsupportedOperationException("Unsupported operation for query: " + operation);
+                default -> throw new InvalidQueryFiltersException("Unsupported operation for query: " + operation);
             }
         } else {
             var labels = input.getLeft();
@@ -63,7 +64,7 @@ public abstract class PostgresExecutionRepositoryService {
                     case IN -> inConditions.add(labelMatches.isTrue());
                     case IS_NULL -> conditions.add(labelKeyCondition((String) key).not());
                     case IS_NOT_NULL -> conditions.add(labelKeyCondition((String) key));
-                    default -> throw new UnsupportedOperationException("Unsupported operation: " + operation);
+                    default -> throw new InvalidQueryFiltersException("Unsupported operation: " + operation);
                 }
             });
         }

--- a/jdbc-postgres/src/main/java/io/kestra/repository/postgres/PostgresFlowRepositoryService.java
+++ b/jdbc-postgres/src/main/java/io/kestra/repository/postgres/PostgresFlowRepositoryService.java
@@ -9,6 +9,7 @@ import org.jooq.Condition;
 import org.jooq.Field;
 import org.jooq.impl.DSL;
 
+import io.kestra.core.exceptions.InvalidQueryFiltersException;
 import io.kestra.core.models.QueryFilter;
 import io.kestra.core.models.flows.FlowInterface;
 import io.kestra.jdbc.AbstractJdbcRepository;
@@ -66,7 +67,7 @@ public abstract class PostgresFlowRepositoryService {
                 case NOT_CONTAINS -> conditions.add(labelContainsCondition(label).not());
                 case IS_NULL -> conditions.add(labelKeyCondition(label).not());
                 case IS_NOT_NULL -> conditions.add(labelKeyCondition(label));
-                default -> throw new UnsupportedOperationException("Unsupported operation: " + operation);
+                default -> throw new InvalidQueryFiltersException("Unsupported operation: " + operation);
             }
         } else if (labels instanceof Map<?, ?> labelValues) {
             labelValues.forEach((key, value) ->
@@ -85,12 +86,16 @@ public abstract class PostgresFlowRepositoryService {
                     conditions.add(labelMatches.isFalse());
                 } else if (operation.equals(QueryFilter.Op.NOT_EQUALS)) {
                     conditions.add(labelMatches.isFalse());
+                } else if (operation.equals(QueryFilter.Op.CONTAINS)) {
+                    conditions.add(labelValueContainsCondition((String) key, (String) value));
+                } else if (operation.equals(QueryFilter.Op.NOT_CONTAINS)) {
+                    conditions.add(labelValueContainsCondition((String) key, (String) value).not());
                 } else if (operation.equals(QueryFilter.Op.IS_NULL)) {
                     conditions.add(labelKeyCondition((String) key).not());
                 } else if (operation.equals(QueryFilter.Op.IS_NOT_NULL)) {
                     conditions.add(labelKeyCondition((String) key));
                 } else {
-                    throw new UnsupportedOperationException("Unsupported operation: " + operation);
+                    throw new InvalidQueryFiltersException("Unsupported operation: " + operation);
                 }
             });
         }
@@ -107,6 +112,15 @@ public abstract class PostgresFlowRepositoryService {
             "    OR lower(lbl ->> 'key') LIKE lower('%' || ? || '%')" +
             ")";
         return DSL.condition(sql, query, query);
+    }
+
+    private static Condition labelValueContainsCondition(String key, String value) {
+        String sql = "EXISTS (" +
+            " SELECT 1 FROM jsonb_array_elements(COALESCE(value -> 'labels', '[]'::jsonb)) AS lbl" +
+            " WHERE lbl ->> 'key' = ?" +
+            "   AND lower(lbl ->> 'value') LIKE lower('%' || ? || '%')" +
+            ")";
+        return DSL.condition(sql, key, value);
     }
 
     private static Condition labelKeyCondition(String key) {

--- a/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcRepository.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcRepository.java
@@ -46,6 +46,13 @@ public abstract class AbstractJdbcRepository {
 
     protected static final int FETCH_SIZE = 100;
 
+    /**
+     * Operations valid on the {@link QueryFilter.Field#LABELS} field when its value is a plain
+     * string, i.e. {@code filters[labels][OP]=value} with no label key. Every other operation
+     * requires a keyed map value ({@code filters[labels][OP][key]=value}).
+     */
+    private static final Set<Op> SCALAR_LABEL_OPS = EnumSet.of(Op.CONTAINS, Op.NOT_CONTAINS, Op.IS_NULL, Op.IS_NOT_NULL);
+
     @Getter
     @Inject
     // Micronaut field-injects this for bean-managed repositories; log-store plugins (deserialized,
@@ -386,6 +393,13 @@ public abstract class AbstractJdbcRepository {
             if (value instanceof Map<?, ?> map) {
                 return findLabelCondition(Either.left(map), operation);
             } else if (value instanceof String string) {
+                if (!SCALAR_LABEL_OPS.contains(operation)) {
+                    throw new InvalidQueryFiltersException(
+                        "Operation %s on the labels field requires a label key, as in filters[labels][%s][<key>]=<value>. Operations supported without a key are %s.".formatted(
+                            operation, operation, SCALAR_LABEL_OPS
+                        )
+                    );
+                }
                 return findLabelCondition(Either.right(string), operation);
             } else {
                 throw new InvalidQueryFiltersException("Label field value must be instance of Map or String");

--- a/webserver/src/test/java/io/kestra/webserver/controllers/api/FlowControllerTest.java
+++ b/webserver/src/test/java/io/kestra/webserver/controllers/api/FlowControllerTest.java
@@ -1592,6 +1592,16 @@ class FlowControllerTest {
     }
 
     @Test
+    void labelsEqualsWithoutKeyReturnsBadRequestNotServerError() {
+        HttpClientResponseException e = assertThrows(
+            HttpClientResponseException.class,
+            () -> client.toBlocking().retrieve(GET("/api/v1/main/flows/search?filters[labels][EQUALS]=x"), Argument.of(PagedResults.class, Flow.class))
+        );
+
+        assertThat(e.getStatus().getCode()).isEqualTo(HttpStatus.BAD_REQUEST.getCode());
+    }
+
+    @Test
     void validateTask() throws IOException {
         URL resource = TestsUtils.class.getClassLoader().getResource("tasks/validTask.json");
 


### PR DESCRIPTION
Fixes https://github.com/kestra-io/kestra-ee/issues/10150

## Problem

`GET /api/v1/{tenant}/flows/search?filters[labels][EQUALS]=x` and the same on `executions/search` returned HTTP 500 "Unsupported operation: EQUALS" instead of a client error, both on OSS and EE.

The labels filter accepts two value shapes over the wire: a keyed `Map<String,String>` when a label key is given (`filters[labels][EQUALS][env]=prod`, the only form any first-party client sends), and a plain `String` when it isn't (`filters[labels][EQUALS]=x`). `QueryFilter.Field.LABELS.supportedOp()` advertises 8 operations regardless of shape, but each JDBC dialect's condition builder only implements a subset per shape, and threw `UnsupportedOperationException` for the rest — which has no webserver error handler, so `Throwable → 500`.

While tracing which operations each dialect actually implements, a second instance of the same bug turned up: flows' map-value `CONTAINS`/`NOT_CONTAINS` (`filters[labels][CONTAINS][key]=value`) 500'd on all three dialects even though executions already supported the identical combination.

## Fix

- `AbstractJdbcRepository.getConditionOnField` now rejects a scalar-value labels operation that requires a key (e.g. `EQUALS` with no key) with `InvalidQueryFiltersException`, which the webserver already maps to 400, naming the `filters[labels][OP][key]=value` form the caller needs.
- The remaining `UnsupportedOperationException` throws in the six H2/Postgres/MySQL flow/execution label condition builders are swapped to `InvalidQueryFiltersException` too, as defense in depth for direct repository callers.
- Implemented map-value `CONTAINS`/`NOT_CONTAINS` for flows on all three dialects, mirroring the equivalent execution-side condition that already existed.

## Test plan

- [x] `./gradlew :jdbc-h2:test --tests "*FlowRepositoryTest" --tests "*ExecutionRepositoryTest"`
- [x] `./gradlew :jdbc-postgres:test --tests "*FlowRepositoryTest" --tests "*ExecutionRepositoryTest"`
- [x] `./gradlew :jdbc-mysql:test --tests "*FlowRepositoryTest" --tests "*ExecutionRepositoryTest"`
- [x] `./gradlew :webserver:test --tests "io.kestra.webserver.controllers.api.FlowControllerTest"`