### PR TITLE
fix(logs): always return execution logs

### DIFF
--- a/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcLogDataStore.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcLogDataStore.java
@@ -161,8 +161,9 @@ public abstract class AbstractJdbcLogDataStore extends AbstractJdbcCrudRepositor
     @Override
     public Page<LogEntry> find(Pageable pageable, @Nullable String tenantId, @Nullable List<QueryFilter> filters) {
         // Default to NORMAL kind only; an explicit KIND filter overrides that and selects the requested kind(s).
+        // The only exception is when a filter specifies an executionId; in this case we should not restrict to any kind so the logs of that execution are always returned.
         var condition = this.filter(filters, DATE_COLUMN, Resource.LOG);
-        if (!QueryFilter.hasField(filters, QueryFilter.Field.KIND)) {
+        if (!QueryFilter.hasField(filters, QueryFilter.Field.KIND) && !QueryFilter.hasField(filters, QueryFilter.Field.EXECUTION_ID)) {
             condition = NORMAL_KIND_CONDITION.and(condition);
         }
         return toOffsetPage(findPage(pageable, tenantId, condition), pageable);
@@ -200,8 +201,9 @@ public abstract class AbstractJdbcLogDataStore extends AbstractJdbcCrudRepositor
     @Override
     public Flux<LogEntry> findAsync(@Nullable String tenantId, List<QueryFilter> filters) {
         // Default to NORMAL kind only; an explicit KIND filter overrides that and selects the requested kind(s).
+        // The only exception is when a filter specifies an executionId; in this case we should not restrict to any kind so the logs of that execution are always returned.
         var condition = this.filter(filters, DATE_COLUMN, Resource.LOG);
-        if (!QueryFilter.hasField(filters, QueryFilter.Field.KIND)) {
+        if (!QueryFilter.hasField(filters, QueryFilter.Field.KIND) && !QueryFilter.hasField(filters, QueryFilter.Field.EXECUTION_ID)) {
             condition = NORMAL_KIND_CONDITION.and(condition);
         }
         return findAsync(tenantId, condition, field(DATE_COLUMN).asc());

--- a/tests/src/main/java/io/kestra/core/repositories/AbstractLogDataStoreTest.java
+++ b/tests/src/main/java/io/kestra/core/repositories/AbstractLogDataStoreTest.java
@@ -469,6 +469,15 @@ public abstract class AbstractLogDataStoreTest {
         assertThat(results).extracting(LogEntry::getExecutionId).containsExactly("exec-normal-kind");
     }
 
+    @Test
+    void find_returnsNonNormalKindWhenExecutionIdFilter() {
+        // An EXECUTION_ID filter bypasses the NORMAL-kind default, same as an explicit KIND filter, so the
+        // logs of that execution are always returned regardless of its kind.
+        List<LogEntry> results = logDataStore.find(Pageable.UNPAGED, kindTenant, List.of(cond(Field.EXECUTION_ID, Op.EQUALS, "exec-playground-kind"))).getContent();
+
+        assertThat(results).extracting(LogEntry::getExecutionId).containsExactly("exec-playground-kind");
+    }
+
     static Stream<QueryFilter> unsupportedFilters() {
         return Stream.of(
             QueryFilter.builder().field(Field.LABELS).value(Map.of("key", "value")).operation(Op.EQUALS).build(),
@@ -498,6 +507,14 @@ public abstract class AbstractLogDataStoreTest {
         ).collectList().block();
 
         assertThat(results).extracting(LogEntry::getExecutionId).containsExactlyInAnyOrder("exec-alpha", "exec-beta");
+    }
+
+    @Test
+    void findAsync_returnsNonNormalKindWhenExecutionIdFilter() {
+        // Same NORMAL-kind-default exception as find(): an EXECUTION_ID filter always returns that execution's logs.
+        List<LogEntry> results = logDataStore.findAsync(kindTenant, List.of(cond(Field.EXECUTION_ID, Op.EQUALS, "exec-loop-kind"))).collectList().block();
+
+        assertThat(results).extracting(LogEntry::getExecutionId).containsExactly("exec-loop-kind");
     }
 
     @Test

--- a/webserver/src/test/java/io/kestra/webserver/controllers/api/LogControllerTest.java
+++ b/webserver/src/test/java/io/kestra/webserver/controllers/api/LogControllerTest.java
@@ -147,15 +147,7 @@ class LogControllerTest {
             .build();
         logRepository.save(playgroundLog);
 
-        // Execution-scoped endpoint defaults to NORMAL kind only, so a playground log is hidden...
         List<LogEntry> logs = client.toBlocking().retrieve(
-            GET("/api/v1/" + tenant + "/logs/" + playgroundLog.getExecutionId()),
-            Argument.of(List.class, LogEntry.class)
-        );
-        assertThat(logs).isEmpty();
-
-        // ...unless the caller explicitly asks for that kind.
-        logs = client.toBlocking().retrieve(
             GET("/api/v1/" + tenant + "/logs/" + playgroundLog.getExecutionId() + "?filters[kind][EQUALS]=PLAYGROUND"),
             Argument.of(List.class, LogEntry.class)
         );


### PR DESCRIPTION
When an executionId filter is passed, never add the execution kind filter so the execution logs are always returned.

Fixes #18430
Fixes https://github.com/kestra-io/kestra-ee/issues/10165