### PR TITLE
Fix/loop execution

### DIFF
--- a/core/src/main/java/io/kestra/core/models/executions/ExecutionKind.java
+++ b/core/src/main/java/io/kestra/core/models/executions/ExecutionKind.java
@@ -1,15 +1,24 @@
 package io.kestra.core.models.executions;
 
+import jakarta.validation.constraints.NotNull;
+
 /**
  * Describe the kind of execution:
  * - TEST: created by a test
  * - PLAYGROUND: created by a playground
  * - LOOP: a virtual loop-iteration execution
- * - NORMAL: anything else, for backward compatibility NORMAL is not persisted but null is used instead
+ * - NORMAL: anything else, for backward compatibility NORMAL is not persisted, but null is used instead
  */
 public enum ExecutionKind {
     NORMAL,
     TEST,
     PLAYGROUND,
-    LOOP
+    LOOP;
+
+    /**
+     * @return true if the execution is normal (Kind.NORMAL or null)
+     */
+    public static boolean isNormal(@NotNull Execution execution) {
+        return execution.getKind() == null || execution.getKind() == NORMAL;
+    }
 }

--- a/executor/src/main/java/io/kestra/executor/DefaultExecutor.java
+++ b/executor/src/main/java/io/kestra/executor/DefaultExecutor.java
@@ -852,7 +852,7 @@ public class DefaultExecutor extends AbstractService implements Executor {
      * Asynchronously emits a raw execution-statistic row for the indexer to persist for every terminal NORMAL-kind execution.
      */
     private void emitExecutionStatistic(Execution execution) {
-        if (execution.getKind() == null || ExecutionKind.NORMAL == execution.getKind()) {
+        if (ExecutionKind.isNormal(execution)) {
             // An end date should always be set, but use the current date as a safety belt
             Instant bucket = execution.getState().getEndDate().orElse(Instant.now()).truncatedTo(ChronoUnit.MINUTES);
             this.executionStatisticQueue.emitAsync(new ExecutionStatistic(execution, bucket));

--- a/executor/src/main/java/io/kestra/executor/ExecutorService.java
+++ b/executor/src/main/java/io/kestra/executor/ExecutorService.java
@@ -1725,13 +1725,15 @@ public class ExecutorService {
     /**
      * Handle flow ExecutionChangedSLA on an executor.
      * If there are SLA violations, it will take care of updating the execution based on the SLA behavior.
+     * NOTE: Loop executions are skipped.
      *
      * @see #processViolation(RunContext, ExecutorContext, Violation)
      *      <p>
      *      WARNING: ATM, only the first violation will update the execution.
      */
     public ExecutorContext handleExecutionChangedSLA(ExecutorContext executor) throws QueueException {
-        if (executor.getFlow() == null || ListUtils.isEmpty(executor.getFlow().getSla()) || executor.getExecution().getState().isTerminated()) {
+        if (executor.getFlow() == null || ListUtils.isEmpty(executor.getFlow().getSla()) || executor.getExecution().getState().isTerminated() ||
+            executor.getExecution().getKind() ==  ExecutionKind.LOOP) {
             return executor;
         }
 

--- a/executor/src/main/java/io/kestra/executor/ExecutorService.java
+++ b/executor/src/main/java/io/kestra/executor/ExecutorService.java
@@ -1075,7 +1075,8 @@ public class ExecutorService {
     }
 
     private ExecutorContext handleAfterExecution(ExecutorContext executor) {
-        if (!executor.getExecution().getState().isTerminated()) {
+        // LOOP sub-executions must not execute afterExecution tasks
+        if (!executor.getExecution().getState().isTerminated() || executor.getExecution().getKind() == ExecutionKind.LOOP) {
             return executor;
         }
 

--- a/executor/src/main/java/io/kestra/executor/FlowTriggerService.java
+++ b/executor/src/main/java/io/kestra/executor/FlowTriggerService.java
@@ -238,7 +238,7 @@ public class FlowTriggerService {
             // prevent recursive flow triggers
             !flowService.removeUnwanted(flow, execution) ||
             // filter out Test Executions
-                (execution.getKind() != null && execution.getKind() != ExecutionKind.NORMAL) ||
+                !ExecutionKind.isNormal(execution) ||
                 // ensure flow & triggers are enabled
                 flow.isDisabled() || flow instanceof FlowWithException ||
                 // a draft revision is never picked up implicitly (see withFlowTriggersOnly)

--- a/executor/src/main/java/io/kestra/executor/handler/ExecutionEventMessageHandler.java
+++ b/executor/src/main/java/io/kestra/executor/handler/ExecutionEventMessageHandler.java
@@ -159,8 +159,8 @@ public class ExecutionEventMessageHandler implements ExecutorMessageHandler<Exec
 
                         // process actions that must be done after the execution has been created
                         if ((execution.getState().getCurrent() == State.Type.CREATED || execution.getState().failedThenRestarted())) {
-                            // create an SLA monitor if needed
-                            if (!ListUtils.isEmpty(flow.getSla())) {
+                            // create an SLA monitor if needed, we skip LOOP executions
+                            if (!ListUtils.isEmpty(flow.getSla()) && execution.getKind() != ExecutionKind.LOOP) {
                                 try {
                                     List<SLAMonitor> monitors = new ArrayList<>();
                                     for (SLA sla : flow.getSla()) {

--- a/executor/src/test/java/io/kestra/executor/ExecutorServiceTest.java
+++ b/executor/src/test/java/io/kestra/executor/ExecutorServiceTest.java
@@ -23,6 +23,7 @@ import io.kestra.core.models.flows.sla.SLA;
 import io.kestra.core.models.flows.sla.types.ExecutionAssertionSLA;
 import io.kestra.core.runners.WorkerTaskResult;
 import io.kestra.core.utils.IdUtils;
+import io.kestra.plugin.core.flow.Loop;
 import io.kestra.plugin.core.log.Log;
 
 import io.micrometer.core.instrument.MeterRegistry;
@@ -158,6 +159,66 @@ class ExecutorServiceTest {
         ExecutorContext result = executorService.handleExecutionChangedSLA(executor);
 
         assertThat(result.getExecution().getState().getCurrent()).isEqualTo(State.Type.CREATED);
+    }
+
+    @Test
+    void shouldSkipAfterExecutionTasksWhenExecutionKindIsLoop() throws Exception {
+        var innerTask = Log.builder().id("inner").type(Log.class.getName()).message("inner").build();
+        var afterTask = Log.builder().id("after").type(Log.class.getName()).message("after").build();
+        var loopTask = Loop.builder().id("loop").type(Loop.class.getName()).values("[\"a\"]").tasks(List.of(innerTask)).build();
+
+        var flow = Flow.builder()
+            .tenantId("tenant")
+            .namespace("io.kestra.unit-test")
+            .id(IdUtils.create())
+            .tasks(List.of(loopTask))
+            .afterExecution(List.of(afterTask))
+            .build();
+
+        var loopTaskRun = TaskRun.builder()
+            .tenantId("tenant")
+            .id(IdUtils.create())
+            .executionId(IdUtils.create())
+            .namespace(flow.getNamespace())
+            .flowId(flow.getId())
+            .taskId(loopTask.getId())
+            .state(new State())
+            .build();
+
+        var parentExecution = Execution.builder()
+            .tenantId("tenant")
+            .id(loopTaskRun.getExecutionId())
+            .namespace(flow.getNamespace())
+            .flowId(flow.getId())
+            .flowRevision(1)
+            .state(new State())
+            .build();
+
+        var innerTaskRun = TaskRun.builder()
+            .tenantId("tenant")
+            .id(IdUtils.create())
+            .executionId(IdUtils.create())
+            .namespace(flow.getNamespace())
+            .flowId(flow.getId())
+            .taskId(innerTask.getId())
+            .parentTaskRunId(loopTaskRun.getId())
+            .state(new State())
+            .build()
+            .withState(State.Type.SUCCESS);
+
+        var loopExecution = parentExecution.loopExecution(loopTaskRun, 0, null, "a")
+            .toBuilder()
+            .taskRunList(List.of(innerTaskRun))
+            .build();
+
+        var executor = new ExecutorContext(loopExecution, FlowWithSource.of(flow, "flow-source"));
+
+        ExecutorContext result = executorService.process(executor);
+
+        // a Loop sub-execution reuses the parent flow, which may declare afterExecution tasks: they
+        // belong to the parent execution's own completion, not to each loop iteration's sub-execution
+        assertThat(result.getExecution().getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
+        assertThat(result.getExecution().getTaskRunList()).extracting(TaskRun::getTaskId).containsExactly("inner");
     }
 
     private Asset asset(String id) {

--- a/executor/src/test/java/io/kestra/executor/ExecutorServiceTest.java
+++ b/executor/src/test/java/io/kestra/executor/ExecutorServiceTest.java
@@ -4,11 +4,11 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import io.kestra.core.assets.AssetService;
-import io.kestra.core.junit.annotations.KestraTest;
 import io.kestra.core.metrics.MetricRegistry;
 import io.kestra.core.models.assets.Asset;
 import io.kestra.core.models.assets.AssetsInOut;
@@ -19,6 +19,8 @@ import io.kestra.core.models.executions.TaskRun;
 import io.kestra.core.models.flows.Flow;
 import io.kestra.core.models.flows.FlowWithSource;
 import io.kestra.core.models.flows.State;
+import io.kestra.core.models.flows.sla.SLA;
+import io.kestra.core.models.flows.sla.types.ExecutionAssertionSLA;
 import io.kestra.core.runners.WorkerTaskResult;
 import io.kestra.core.utils.IdUtils;
 import io.kestra.plugin.core.log.Log;
@@ -35,14 +37,8 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
-/**
- * Covers ExecutorService's own logic around processTaskRunAssets: the guard deciding whether to call
- * it, and applying the escalated TaskRun it returns. The escalation logic itself (assetFailureBehavior,
- * allowFailure/allowWarning clamps, mark-and-continue upserts) only exists in the EE AssetService
- * implementation and is covered there directly (core-ee's AssetServiceTest).
- */
-@KestraTest
-class ExecutorServiceProcessTaskRunAssetsTest {
+@MicronautTest
+class ExecutorServiceTest {
     @Inject
     private ExecutorService executorService;
 
@@ -136,6 +132,32 @@ class ExecutorServiceProcessTaskRunAssetsTest {
 
         assertThat(executor.getExecution().getTaskRunList().getFirst().getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
         verify(assetService).processTaskRunAssets(any(), any(), any(), any(), any());
+    }
+
+    @Test
+    void shouldSkipSLAEvaluationWhenExecutionKindIsLoop() throws Exception {
+        SLA sla = ExecutionAssertionSLA.builder()
+            .id("always-fails")
+            .type(SLA.Type.EXECUTION_ASSERTION)
+            .behavior(SLA.Behavior.FAIL)
+            ._assert("false")
+            .build();
+        var task = Log.builder().id("task").type(Log.class.getName()).message("hello").build();
+        var flow = Flow.builder().tenantId("tenant").namespace("io.kestra.unit-test").id(IdUtils.create()).tasks(List.of(task)).sla(List.of(sla)).build();
+        var execution = Execution.builder()
+            .tenantId("tenant")
+            .id(IdUtils.create())
+            .namespace(flow.getNamespace())
+            .flowId(flow.getId())
+            .flowRevision(1)
+            .kind(ExecutionKind.LOOP)
+            .state(new State())
+            .build();
+        var executor = new ExecutorContext(execution, FlowWithSource.of(flow, "flow-source"));
+
+        ExecutorContext result = executorService.handleExecutionChangedSLA(executor);
+
+        assertThat(result.getExecution().getState().getCurrent()).isEqualTo(State.Type.CREATED);
     }
 
     private Asset asset(String id) {

--- a/executor/src/test/java/io/kestra/executor/handler/ExecutionEventMessageHandlerTest.java
+++ b/executor/src/test/java/io/kestra/executor/handler/ExecutionEventMessageHandlerTest.java
@@ -12,10 +12,13 @@ import io.kestra.core.junit.annotations.KestraTest;
 import io.kestra.core.killswitch.EvaluationType;
 import io.kestra.core.killswitch.KillSwitchService;
 import io.kestra.core.models.executions.Execution;
+import io.kestra.core.models.executions.ExecutionKind;
 import io.kestra.core.models.flows.Concurrency;
 import io.kestra.core.models.flows.GenericFlow;
 import io.kestra.core.models.flows.State;
 import io.kestra.core.models.flows.quota.Quota;
+import io.kestra.core.models.flows.sla.SLA;
+import io.kestra.core.models.flows.sla.types.MaxDurationSLA;
 import io.kestra.core.repositories.ExecutionRepositoryInterface;
 import io.kestra.core.repositories.FlowRepositoryInterface;
 import io.kestra.core.runners.ExecutionEvent;
@@ -23,6 +26,7 @@ import io.kestra.core.runners.ExecutionEventType;
 import io.kestra.core.services.QuotaService;
 import io.kestra.executor.ExecutorContext;
 import io.kestra.executor.KillSwitchActionService;
+import io.kestra.executor.SLAMonitorStateStore;
 
 import io.micronaut.test.annotation.MockBean;
 import jakarta.inject.Inject;
@@ -31,6 +35,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -54,6 +59,9 @@ class ExecutionEventMessageHandlerTest {
     @Inject
     QuotaService quotaService;
 
+    @Inject
+    SLAMonitorStateStore slaMonitorStateStore;
+
     @MockBean(KillSwitchService.class)
     KillSwitchService killSwitchService() {
         return mock(KillSwitchService.class);
@@ -69,8 +77,14 @@ class ExecutionEventMessageHandlerTest {
         return mock(QuotaService.class);
     }
 
+    @MockBean(SLAMonitorStateStore.class)
+    SLAMonitorStateStore slaMonitorStateStore() {
+        return mock(SLAMonitorStateStore.class);
+    }
+
     @BeforeEach
     void setUp() {
+        reset(slaMonitorStateStore);
         when(killSwitchService.evaluate(any(ExecutionEvent.class))).thenReturn(EvaluationType.PASS);
     }
 
@@ -227,5 +241,38 @@ class ExecutionEventMessageHandlerTest {
         // Then
         assertThat(maybeExecutor).isPresent();
         assertThat(maybeExecutor.get().getExecution().getState().getCurrent()).isEqualTo(State.Type.CANCELLED);
+    }
+
+    @Test
+    void shouldCreateSlaMonitorForNonLoopExecution() {
+        // Given
+        SLA sla = MaxDurationSLA.builder().id("max-duration").type(SLA.Type.MAX_DURATION).behavior(SLA.Behavior.FAIL).duration(Duration.ofHours(1)).build();
+        var flow = flowRepository.create(GenericFlow.of(Fixtures.flowWithSla(sla)));
+        var execution = Execution.newExecution(flow, null, Collections.emptyList(), Optional.empty(), ExecutionKind.NORMAL);
+        executionRepository.save(execution);
+        var executionEvent = new ExecutionEvent(execution, ExecutionEventType.CREATED);
+
+        // When
+        executionEventMessageHandler.handle(executionEvent);
+
+        // Then
+        verify(slaMonitorStateStore).save(any());
+    }
+
+    @Test
+    void shouldNotCreateSlaMonitorForLoopExecution() {
+        // Given: a Loop execution, which re-triggers the parent flow's SLA on each iteration
+        // and must not accumulate a monitor per iteration
+        SLA sla = MaxDurationSLA.builder().id("max-duration").type(SLA.Type.MAX_DURATION).behavior(SLA.Behavior.FAIL).duration(Duration.ofHours(1)).build();
+        var flow = flowRepository.create(GenericFlow.of(Fixtures.flowWithSla(sla)));
+        var execution = Execution.newExecution(flow, null, Collections.emptyList(), Optional.empty(), ExecutionKind.LOOP);
+        executionRepository.save(execution);
+        var executionEvent = new ExecutionEvent(execution, ExecutionEventType.CREATED);
+
+        // When
+        executionEventMessageHandler.handle(executionEvent);
+
+        // Then
+        verify(slaMonitorStateStore, never()).save(any());
     }
 }

--- a/executor/src/test/java/io/kestra/executor/handler/Fixtures.java
+++ b/executor/src/test/java/io/kestra/executor/handler/Fixtures.java
@@ -5,6 +5,7 @@ import java.util.List;
 import io.kestra.core.models.flows.Concurrency;
 import io.kestra.core.models.flows.Flow;
 import io.kestra.core.models.flows.quota.Quota;
+import io.kestra.core.models.flows.sla.SLA;
 import io.kestra.core.utils.IdUtils;
 import io.kestra.plugin.core.log.Log;
 
@@ -39,6 +40,16 @@ final class Fixtures {
             .id(IdUtils.create())
             .tasks(List.of(Log.builder().id("log").type(Log.class.getName()).message("Hello World").build()))
             .quotas(List.of(quota))
+            .build();
+    }
+
+    static Flow flowWithSla(SLA sla) {
+        return Flow.builder()
+            .tenantId("tenant")
+            .namespace("namespace")
+            .id(IdUtils.create())
+            .tasks(List.of(Log.builder().id("log").type(Log.class.getName()).message("Hello World").build()))
+            .sla(List.of(sla))
             .build();
     }
 }


### PR DESCRIPTION
- LOOP executions should not evaluate SLAs
- Only run afterExecution tasks on non LOOP executions

Fixes #18392
Fixes #18362