### PR TITLE
fix(core): stale log level counters when the log search matches nothing

### DIFF
--- a/ui/src/components/executions/Logs.vue
+++ b/ui/src/components/executions/Logs.vue
@@ -51,7 +51,7 @@
             :logCursor="logCursor"
            
             @opened-taskruns-count="openedTaskrunsCount = $event"
-            @log-indices-by-level="Object.entries($event).forEach(([levelName, indices]) => logIndicesByLevel[levelName] = indices)"
+            @log-indices-by-level="setLogIndicesByLevel"
             :targetFlow="executionsStore.flow"
             :showProgressBar="false"
         />
@@ -207,9 +207,12 @@
     const filter = ref<string | undefined>(undefined)
     const openedTaskrunsCount = ref(0)
     const raw_view = ref((localStorage.getItem(storageKeys.LOGS_VIEW_TYPE) ?? "false").toLowerCase() === "true")
-    const logIndicesByLevel = ref<Record<string, string[]>>(
-        Object.fromEntries(LogUtils.levelOrLower(undefined as any).map((level: string) => [level, []])),
-    )
+    const emptyLogIndicesByLevel = () =>
+        Object.fromEntries(LogUtils.levelOrLower(undefined as any).map((level: string) => [level, [] as string[]]))
+    const logIndicesByLevel = ref<Record<string, string[]>>(emptyLogIndicesByLevel())
+    const setLogIndicesByLevel = (indices: Record<string, string[]>) => {
+        logIndicesByLevel.value = {...emptyLogIndicesByLevel(), ...indices}
+    }
     const logCursor = ref<string | undefined>(undefined)
     const logsLoading = ref(false)
 


### PR DESCRIPTION

Closes https://github.com/kestra-io/kestra-ee/issues/10456.


Searching the **Logs** tab of an execution for a string that matches no log line left the per-level counter chips showing their previous values instead of dropping to zero. With the search box cleared just before, those values are the whole-execution totals, so a zero-result search looked identical to no search at all.

The chips are built from a level-to-matching-indices map emitted by the taskrun log view, which only carries levels that still have a match. The parent merged that map into its state instead of replacing it, so a level dropping to zero was never reported and its chip kept whatever it last showed. The same thing kept `(3) TRACE` and `(6) DEBUG` chips visible after the level filter settled on `INFO`.

The emitted map is now assigned over an all-levels-zeroed base, so a level absent from it goes back to zero and its chip disappears. That matches the standalone Logs page, which already renders only levels with a non-zero count.