### PR TITLE
fix(triggers): disambiguate colliding trigger picker labels by plugin title

### DIFF
--- a/core/src/main/java/io/kestra/core/docs/Plugin.java
+++ b/core/src/main/java/io/kestra/core/docs/Plugin.java
@@ -106,6 +106,37 @@ public class Plugin {
     }
 
     /**
+     * Resolves the human-readable title for a single plugin element (a task, trigger, ... class),
+     * using the exact same source of truth as {@link #of(RegisteredPlugin, String)} builds a whole
+     * (sub)plugin page from: the element's own subgroup title, declared via
+     * {@code @PluginSubGroup(title = ...)} on its package, when it lives in a registered subgroup;
+     * the raw subgroup package segment when that subgroup declares no title; or, when the element
+     * isn't part of any subgroup, the owning plugin's own title (as authored in its
+     * {@code metadata/index.yaml}, surfaced via {@link RegisteredPlugin#title()}).
+     * <p>
+     * Unlike guessing a display name from the element's fully qualified class name (for example the
+     * last Java package segment), this is driven entirely by each plugin's own declared identity, so
+     * two unrelated plugins that happen to share a package segment (for example
+     * {@code io.kestra.plugin.mongodb} and {@code io.kestra.plugin.debezium.mongodb}) never collide
+     * on the same derived label.
+     *
+     * @param registeredPlugin the plugin the element belongs to
+     * @param cls the plugin element's class
+     * @return a non-null, correctly-cased title
+     */
+    public static String titleFor(RegisteredPlugin registeredPlugin, Class<?> cls) {
+        String packageName = cls.getPackageName();
+        boolean isSubGroup = registeredPlugin.group() != null && packageName.length() != registeredPlugin.group().length();
+        PluginSubGroup pluginSubGroup = isSubGroup ? cls.getPackage().getDeclaredAnnotation(PluginSubGroup.class) : null;
+
+        if (pluginSubGroup == null) {
+            return registeredPlugin.title();
+        }
+
+        return !pluginSubGroup.title().isEmpty() ? pluginSubGroup.title() : packageName.substring(packageName.lastIndexOf('.') + 1);
+    }
+
+    /**
      * Filters the given list of class all internal Plugin, as well as, all legacy org.kestra classes.
      * Those classes are only filtered from the documentation to ensure backward compatibility.
      *

--- a/core/src/test/java/io/kestra/core/docs/PluginTest.java
+++ b/core/src/test/java/io/kestra/core/docs/PluginTest.java
@@ -1,0 +1,65 @@
+package io.kestra.core.docs;
+
+import java.util.jar.Manifest;
+
+import org.junit.jupiter.api.Test;
+
+import io.kestra.core.models.flows.Flow;
+import io.kestra.core.plugins.RegisteredPlugin;
+import io.kestra.plugin.core.dashboard.data.Flows;
+import io.kestra.plugin.core.storage.Delete;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class PluginTest {
+
+    @Test
+    void titleForFallsBackToThePluginsOwnTitleWhenTheClassIsNotInARegisteredSubGroup() {
+        // Real-world equivalent: io.kestra.plugin.mongodb.Trigger and
+        // io.kestra.plugin.debezium.mongodb.Trigger are both conventionally named `Trigger` and both
+        // live in a package ending in "mongodb" — a package-name-derived guess would collide the two.
+        // Each plugin's own declared title (from its metadata/index.yaml, surfaced via
+        // RegisteredPlugin#title) must disambiguate them regardless of package shape.
+        RegisteredPlugin mongodb = pluginWithTitle("MongoDB");
+        RegisteredPlugin debeziumMongodb = pluginWithTitle("Debezium MongoDB");
+
+        // The concrete class only matters for its package here; it isn't a real trigger of either
+        // plugin, it just stands in for "some class that isn't part of a declared subgroup".
+        String mongodbTitle = Plugin.titleFor(mongodb, Flow.class);
+        String debeziumMongodbTitle = Plugin.titleFor(debeziumMongodb, Flow.class);
+
+        assertThat(mongodbTitle).isEqualTo("MongoDB");
+        assertThat(debeziumMongodbTitle).isEqualTo("Debezium MongoDB");
+        assertThat(mongodbTitle).isNotEqualTo(debeziumMongodbTitle);
+    }
+
+    @Test
+    void titleForUsesTheSubGroupsOwnDeclaredTitleWhenPresent() {
+        RegisteredPlugin core = pluginWithTitleAndGroup("core", "io.kestra.plugin.core");
+
+        // io.kestra.plugin.core.dashboard.data declares @PluginSubGroup(title = "Data Filter", ...)
+        assertThat(Plugin.titleFor(core, Flows.class)).isEqualTo("Data Filter");
+    }
+
+    @Test
+    void titleForFallsBackToTheRawSubGroupSegmentWhenTheSubGroupDeclaresNoTitle() {
+        RegisteredPlugin core = pluginWithTitleAndGroup("core", "io.kestra.plugin.core");
+
+        // io.kestra.plugin.core.storage declares @PluginSubGroup(categories = CORE) with no title.
+        assertThat(Plugin.titleFor(core, Delete.class)).isEqualTo("storage");
+    }
+
+    private static RegisteredPlugin pluginWithTitle(String title) {
+        return pluginWithTitleAndGroup(title, null);
+    }
+
+    private static RegisteredPlugin pluginWithTitleAndGroup(String title, String group) {
+        Manifest manifest = new Manifest();
+        manifest.getMainAttributes().putValue("X-Kestra-Title", title);
+        if (group != null) {
+            manifest.getMainAttributes().putValue("X-Kestra-Group", group);
+        }
+
+        return RegisteredPlugin.builder().manifest(manifest).build();
+    }
+}

--- a/ui/src/components/admin/triggers/AddTriggerModal.spec.ts
+++ b/ui/src/components/admin/triggers/AddTriggerModal.spec.ts
@@ -61,7 +61,7 @@ function mountModal() {
     return mount(AddTriggerModal, {
         props: {
             visible: true,
-            trigger: {type: "io.kestra.plugin.core.trigger.Schedule", name: "Schedule", description: null, group: "core", ee: false, icon: "", deprecated: null},
+            trigger: {type: "io.kestra.plugin.core.trigger.Schedule", name: "Schedule", pluginTitle: "core", description: null, group: "core", ee: false, icon: "", deprecated: null},
         },
         global: {
             plugins: [i18n],

--- a/ui/src/components/admin/triggers/triggerCatalog.ts
+++ b/ui/src/components/admin/triggers/triggerCatalog.ts
@@ -1,4 +1,4 @@
-import {formatPluginTitle, getShortName} from "../../../utils/global"
+import {getShortName} from "../../../utils/global"
 import type {TriggerPluginDto} from "../../../stores/plugins"
 
 export const MCP_TOOL_TYPE = "io.kestra.core.models.triggers.McpTool"
@@ -6,8 +6,14 @@ export const MCP_TOOL_TYPE = "io.kestra.core.models.triggers.McpTool"
 export const isMcpTrigger = (trigger: Pick<TriggerPluginDto, "type">): boolean =>
     trigger.type === MCP_TOOL_TYPE || trigger.type.endsWith(".McpTool")
 
-export const triggerDisplayName = (trigger: Pick<TriggerPluginDto, "type" | "name">): string => {
+export const triggerDisplayName = (trigger: Pick<TriggerPluginDto, "type" | "name" | "pluginTitle">): string => {
     if (trigger.name && trigger.name !== "Trigger") return trigger.name
 
-    return formatPluginTitle(trigger.type.split(".").at(-2)) ?? getShortName(trigger.type)
+    // Most plugins name their trigger class `Trigger`, so `trigger.name` above is useless for
+    // disambiguation. Fall back to the plugin's own declared, correctly-cased title (resolved
+    // server-side from its metadata) rather than guessing from the class package: two unrelated
+    // plugins can share a package segment (e.g. io.kestra.plugin.mongodb vs
+    // io.kestra.plugin.debezium.mongodb both end in "mongodb"), and a package-derived guess would
+    // collide the two under the same wrongly-cased "Mongodb" label.
+    return trigger.pluginTitle || getShortName(trigger.type)
 }

--- a/ui/src/stores/plugins.ts
+++ b/ui/src/stores/plugins.ts
@@ -26,6 +26,10 @@ export type {Plugin} from "../utils/pluginUtils"
 export interface TriggerPluginDto {
     type: string;
     name: string;
+    // The owning plugin's (or subgroup's) declared, correctly-cased title (for example "MongoDB" or
+    // "Debezium MongoDB"), resolved server-side from the plugin's own metadata rather than guessed
+    // from the class package — see PluginController.ApiTriggerPlugin#pluginTitle.
+    pluginTitle: string;
     description: string | null;
     group: "core" | "realtime" | "app";
     ee: boolean;

--- a/ui/tests/unit/components/admin/triggers/triggerCatalog.spec.ts
+++ b/ui/tests/unit/components/admin/triggers/triggerCatalog.spec.ts
@@ -1,0 +1,64 @@
+import {describe, test, expect} from "vitest"
+
+import {triggerDisplayName, isMcpTrigger, MCP_TOOL_TYPE} from "../../../../../src/components/admin/triggers/triggerCatalog"
+
+describe("triggerDisplayName", () => {
+    test("uses the trigger's own name when it isn't the generic class name", () => {
+        expect(triggerDisplayName({
+            type: "io.kestra.plugin.core.trigger.Schedule",
+            name: "Schedule",
+            pluginTitle: "core",
+        })).toBe("Schedule")
+    })
+
+    test("falls back to the plugin's own declared title when the class is named `Trigger`", () => {
+        expect(triggerDisplayName({
+            type: "io.kestra.plugin.mongodb.Trigger",
+            name: "Trigger",
+            pluginTitle: "MongoDB",
+        })).toBe("MongoDB")
+    })
+
+    test("disambiguates two unrelated plugins that share the same last package segment", () => {
+        // io.kestra.plugin.mongodb.Trigger and io.kestra.plugin.debezium.mongodb.Trigger both end
+        // in "mongodb" and both use the conventional `Trigger` class name: a package-derived guess
+        // would collide the two under the same label. Each plugin's own declared title (surfaced by
+        // the backend, not parsed from the class package) must keep them distinct and correctly cased.
+        const mongodb = triggerDisplayName({
+            type: "io.kestra.plugin.mongodb.Trigger",
+            name: "Trigger",
+            pluginTitle: "MongoDB",
+        })
+        const debeziumMongodb = triggerDisplayName({
+            type: "io.kestra.plugin.debezium.mongodb.Trigger",
+            name: "Trigger",
+            pluginTitle: "Debezium MongoDB",
+        })
+
+        expect(mongodb).toBe("MongoDB")
+        expect(debeziumMongodb).toBe("Debezium MongoDB")
+        expect(mongodb).not.toBe(debeziumMongodb)
+    })
+
+    test("falls back to the short class name when neither name nor pluginTitle is usable", () => {
+        expect(triggerDisplayName({
+            type: "io.kestra.plugin.unknown.Trigger",
+            name: "Trigger",
+            pluginTitle: "",
+        })).toBe("Trigger")
+    })
+})
+
+describe("isMcpTrigger", () => {
+    test("matches the canonical MCP tool trigger type", () => {
+        expect(isMcpTrigger({type: MCP_TOOL_TYPE})).toBe(true)
+    })
+
+    test("matches any plugin's McpTool class", () => {
+        expect(isMcpTrigger({type: "io.kestra.plugin.core.trigger.McpTool"})).toBe(true)
+    })
+
+    test("does not match unrelated triggers", () => {
+        expect(isMcpTrigger({type: "io.kestra.plugin.mongodb.Trigger"})).toBe(false)
+    })
+})

--- a/webserver/src/main/java/io/kestra/webserver/controllers/api/PluginController.java
+++ b/webserver/src/main/java/io/kestra/webserver/controllers/api/PluginController.java
@@ -235,7 +235,7 @@ public class PluginController {
         return PagedResults.of(new ArrayListTotal<>(all, all.size()));
     }
 
-    private ApiTriggerPlugin toApiTriggerPlugin(RegisteredPlugin registeredPlugin, Class<? extends AbstractTrigger> triggerClass) {
+    protected ApiTriggerPlugin toApiTriggerPlugin(RegisteredPlugin registeredPlugin, Class<? extends AbstractTrigger> triggerClass) {
         io.swagger.v3.oas.annotations.media.Schema schema = triggerClass.getAnnotation(io.swagger.v3.oas.annotations.media.Schema.class);
         String title = triggerClass.getSimpleName();
         String description = schema != null && !schema.description().isEmpty() ? schema.description() : null;
@@ -244,6 +244,7 @@ public class PluginController {
         return new ApiTriggerPlugin(
             triggerClass.getName(),
             title,
+            io.kestra.core.docs.Plugin.titleFor(registeredPlugin, triggerClass),
             description,
             TriggerPluginCategory.classify(registeredPlugin, triggerClass),
             isEnterpriseEdition(registeredPlugin, triggerClass),
@@ -678,6 +679,11 @@ public class PluginController {
      *
      * @param type fully qualified class name (for example {@code io.kestra.plugin.core.trigger.Schedule})
      * @param name human-readable name (Schema#title if set, otherwise simple class name)
+     * @param pluginTitle the owning plugin's (or subgroup's) human-readable, correctly-cased title
+     *        (for example {@code "MongoDB"} or {@code "Debezium MongoDB"}), resolved from
+     *        its own declared metadata rather than guessed from the class package — used
+     *        by the UI to disambiguate triggers from different plugins that otherwise share
+     *        the same last Java package segment (see {@link io.kestra.core.docs.Plugin#titleFor})
      * @param description one-line description from the plugin @Schema
      * @param group category bucket ({@code core}, {@code realtime}, or {@code app})
      * @param ee true when the trigger is only available in Enterprise Edition (bundled with EE core, or shipped by a plugin distributed under an Enterprise license)
@@ -687,6 +693,7 @@ public class PluginController {
     public record ApiTriggerPlugin(
         String type,
         String name,
+        String pluginTitle,
         String description,
         TriggerPluginCategory group,
         boolean ee,

--- a/webserver/src/test/java/io/kestra/webserver/controllers/api/PluginControllerTest.java
+++ b/webserver/src/test/java/io/kestra/webserver/controllers/api/PluginControllerTest.java
@@ -3,6 +3,7 @@ package io.kestra.webserver.controllers.api;
 import java.util.Base64;
 import java.util.List;
 import java.util.Map;
+import java.util.jar.Manifest;
 
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -18,8 +19,11 @@ import io.kestra.core.models.ui.PluginDistribution;
 import io.kestra.core.models.ui.PluginUiManifest;
 import io.kestra.core.models.ui.PluginUiModuleWithGroup;
 import io.kestra.core.models.ui.TaskWithVersion;
+import io.kestra.core.plugins.RegisteredPlugin;
 import io.kestra.plugin.core.debug.Return;
 import io.kestra.plugin.core.log.Log;
+import io.kestra.plugin.core.trigger.Schedule;
+import io.kestra.plugin.core.trigger.Webhook;
 import io.kestra.webserver.controllers.api.PluginController.ApiTriggerPlugin;
 import io.kestra.webserver.responses.PagedResults;
 
@@ -489,5 +493,31 @@ class PluginControllerTest {
         assertThat(result.getResults())
             .map(ApiTriggerPlugin::name)
             .contains("Webhook");
+    }
+
+    @Test
+    void triggerPluginTitleDisambiguatesPluginsThatShareAPackageSegment() {
+        // Regression test for the "Add Trigger" picker showing colliding, wrongly-cased labels for
+        // unrelated plugins whose package happens to share a segment (e.g. io.kestra.plugin.mongodb
+        // vs io.kestra.plugin.debezium.mongodb, both conventionally named `Trigger`). The picker label
+        // must come from each plugin's own declared title, not from the trigger class' package name -
+        // this only exercises the resolution, using two real trigger classes as arbitrary stand-ins.
+        PluginController controller = new PluginController();
+
+        RegisteredPlugin mongodb = pluginWithTitle("MongoDB");
+        RegisteredPlugin debeziumMongodb = pluginWithTitle("Debezium MongoDB");
+
+        ApiTriggerPlugin mongodbTrigger = controller.toApiTriggerPlugin(mongodb, Schedule.class);
+        ApiTriggerPlugin debeziumMongodbTrigger = controller.toApiTriggerPlugin(debeziumMongodb, Webhook.class);
+
+        assertThat(mongodbTrigger.pluginTitle()).isEqualTo("MongoDB");
+        assertThat(debeziumMongodbTrigger.pluginTitle()).isEqualTo("Debezium MongoDB");
+        assertThat(mongodbTrigger.pluginTitle()).isNotEqualTo(debeziumMongodbTrigger.pluginTitle());
+    }
+
+    private static RegisteredPlugin pluginWithTitle(String title) {
+        Manifest manifest = new Manifest();
+        manifest.getMainAttributes().putValue("X-Kestra-Title", title);
+        return RegisteredPlugin.builder().manifest(manifest).build();
     }
 }


### PR DESCRIPTION
## Summary

The "Add Trigger" picker showed the MongoDB trigger as **"Mongodb Trigger"** (wrong casing) and rendered it identically to Debezium's MongoDB CDC trigger — the two were indistinguishable in the picker, even though the main Plugins page correctly shows "MongoDB" and "Debezium MongoDB" as separate, correctly-cased plugin titles.

**Root cause:**
- Backend: `webserver/src/main/java/io/kestra/webserver/controllers/api/PluginController.java`, `toApiTriggerPlugin` (~L357-359 pre-fix) set the trigger's `title` to `triggerClass.getSimpleName()` — literally always `"Trigger"`, since Kestra's convention names every plugin's trigger class `Trigger` (or `RealtimeTrigger`, etc). That field is basically useless for display.
- Frontend: `ui/src/components/admin/triggers/triggerCatalog.ts` (~L12 pre-fix) fell back to `formatPluginTitle(trigger.type.split(".").at(-2)) ?? getShortName(trigger.type)` — deriving a label from the *last Java package segment* of the fully-qualified class name. For `io.kestra.plugin.mongodb.Trigger` and `io.kestra.plugin.debezium.mongodb.Trigger`, that segment is `"mongodb"` for both — the collision.
- `ui/src/utils/global.ts`'s `formatPluginTitle()` (~L17-21) only special-cases an already-fully-uppercase string; anything else is just `capitalize()`'d — turning `"mongodb"` into `"Mongodb"`.

Every plugin already declares a correct, human-authored title in its `metadata/index.yaml` (e.g. plugin-mongodb: `title: "MongoDB"`, plugin-debezium's mongodb module: `title: "Debezium MongoDB"`), surfaced via `RegisteredPlugin#title()` and already used correctly by the main Plugins page through `Plugin#of()`. This PR reuses that same source of truth instead of guessing from the class package.

## Changes

- **core**: `Plugin#titleFor(RegisteredPlugin, Class)` — resolves a plugin element's title with the same subgroup-title precedence `Plugin#of` already uses for the Plugins page (a subgroup's own `@PluginSubGroup#title` first, then the owning plugin's own declared title), so it also correctly disambiguates subgroups within the same plugin (e.g. Redis's `list`/`json`/... submodules), not just cross-plugin collisions.
- **webserver**: `PluginController#toApiTriggerPlugin` now surfaces this as a new `pluginTitle` field on `ApiTriggerPlugin`. Made the method `protected` (matching the existing `isEnterpriseEdition`) so it's directly unit-testable.
- **ui**: `triggerCatalog.ts`'s `triggerDisplayName()` falls back to the new `pluginTitle` field instead of deriving a guess from the class package; `TriggerPluginDto` gained the matching `pluginTitle` field.

This generalizes to any two plugins whose Java package happens to share a segment, not just mongodb vs debezium-mongodb — the label is now always driven by each plugin's own declared identity.

## Tests

- `core/src/test/java/io/kestra/core/docs/PluginTest.java` (new): unit tests for `Plugin#titleFor` covering the no-subgroup fallback (the mongodb/debezium-mongodb scenario), a subgroup with its own declared title, and a subgroup with no title (raw segment fallback).
- `webserver/src/test/java/io/kestra/webserver/controllers/api/PluginControllerTest.java`: new `triggerPluginTitleDisambiguatesPluginsThatShareAPackageSegment` test calling `toApiTriggerPlugin` directly with two synthetic `RegisteredPlugin`s carrying different manifest titles, asserting distinct `pluginTitle` output.
- `ui/tests/unit/components/admin/triggers/triggerCatalog.spec.ts` (new): covers `triggerDisplayName`'s fallback chain, including a case with two trigger classes from different plugins sharing the same last package segment (`io.kestra.plugin.mongodb.Trigger` vs `io.kestra.plugin.debezium.mongodb.Trigger`) asserting distinct, correctly-cased labels; also covers `isMcpTrigger`.

### Test plan

- [x] `./gradlew :core:test --tests "io.kestra.core.docs.PluginTest"` — 3/3 passing
- [x] `./gradlew :webserver:test --tests "io.kestra.webserver.controllers.api.PluginControllerTest"` — 28/28 passing (27 existing + 1 new)
- [x] `vitest run --project=unit tests/unit/components/admin/triggers/triggerCatalog.spec.ts` — 7/7 passing
- [x] `vitest run --project=unit tests/unit/components/plugins` (regression check on plugin-related specs) — all passing

## Context

Closes kestra-io/plugin-mongodb#125 (casing) and kestra-io/plugin-mongodb#124 (duplicate label / disambiguation). See also the docs-only companion PRs kestra-io/plugin-mongodb#128 and kestra-io/plugin-debezium#210, which document the distinction between this trigger and Debezium's MongoDB CDC trigger.
