### PR TITLE
perf(ui): resolve trigger icons from the bulk index instead of one request per card

### DIFF
--- a/ui/src/components/admin/triggers/TriggerCard.vue
+++ b/ui/src/components/admin/triggers/TriggerCard.vue
@@ -2,7 +2,7 @@
     <div class="trigger-card">
         <div class="trigger-body">
             <div class="icon">
-                <TaskIcon class="glyph" :cls="trigger.type" :loadIcon="pluginsStore.loadIcon" onlyIcon />
+                <TaskIcon class="glyph" :cls="trigger.type" :icons="pluginsStore.icons" :loadIcon="pluginsStore.loadIcon" onlyIcon />
             </div>
             <div class="content">
                 <div class="header">
@@ -84,10 +84,14 @@
 </script>
 
 <style scoped lang="scss">
+    $card-min-height: 8.75rem;
+
     .trigger-card {
         display: flex;
         flex-direction: column;
-        min-height: 8.75rem;
+        min-height: $card-min-height;
+        content-visibility: auto;
+        contain-intrinsic-height: auto $card-min-height;
         padding: var(--ks-spacing-4) var(--ks-spacing-4) var(--ks-spacing-2);
         border: var(--ks-border-block-primary);
         border-radius: var(--ks-radius-base);

--- a/ui/src/components/admin/triggers/TriggersGrid.vue
+++ b/ui/src/components/admin/triggers/TriggersGrid.vue
@@ -133,7 +133,11 @@
 
     onMounted(async () => {
         try {
-            allTriggers.value = await pluginsStore.listTriggers()
+            const [triggers] = await Promise.all([
+                pluginsStore.listTriggers(),
+                pluginsStore.fetchIcons().catch(() => undefined),
+            ])
+            allTriggers.value = triggers
         } finally {
             loading.value = false
         }

--- a/ui/src/components/plugins/TaskIcon.vue
+++ b/ui/src/components/plugins/TaskIcon.vue
@@ -4,12 +4,12 @@
         class="task-icon"
     >
         <KsTooltip v-if="!onlyIcon" :content="cls">
-            <img v-if="!isMonochrome" class="task-icon__icon" :src="iconSrc" :alt="ariaLabel">
+            <img v-if="!isMonochrome" class="task-icon__icon" :src="iconSrc" :alt="ariaLabel" loading="lazy" decoding="async">
             <div v-else class="task-icon__icon task-icon__icon--mask" role="img" :aria-label="ariaLabel" :style="maskStyle" />
         </KsTooltip>
 
         <template v-else>
-            <img v-if="!isMonochrome" class="task-icon__icon" :src="iconSrc" :alt="ariaLabel">
+            <img v-if="!isMonochrome" class="task-icon__icon" :src="iconSrc" :alt="ariaLabel" loading="lazy" decoding="async">
             <div v-else class="task-icon__icon task-icon__icon--mask" role="img" :aria-label="ariaLabel" :style="maskStyle" />
         </template>
     </div>


### PR DESCRIPTION
closes https://github.com/kestra-io/kestra-ee/issues/10264

This pull request improves the performance and maintainability of the trigger and icon components in the admin UI. The main changes focus on optimizing how plugin icons are loaded and displayed, as well as enhancing the styling and rendering of trigger cards.

**Performance and loading improvements:**

* [`TriggersGrid.vue`](diffhunk://#diff-d2612021c92f7ec76e1739367d5aa706ba8856024ac72656d808bb93fda35afcL136-R140): Icons for plugins are now fetched in parallel with the triggers list during component mounting, improving load efficiency and user experience.
* [`TaskIcon.vue`](diffhunk://#diff-745ebb1a71a5d46c84c749f15b95c24d900d2f958dd8d6e11b8f9ce27be6eb3eL7-R12): All non-monochrome icon images are now set to load lazily and decode asynchronously, which can help reduce initial page load time and improve rendering performance.

**Component and style updates:**

* [`TriggerCard.vue`](diffhunk://#diff-cfcb47ec3b1a9d4ce1bb564328dad87b050377d803bbab09d70f44b60d901df7L5-R5): The `TaskIcon` component now receives the full `icons` object instead of just a `loadIcon` function, supporting better icon management and possible future extensibility.
* [`TriggerCard.vue`](diffhunk://#diff-cfcb47ec3b1a9d4ce1bb564328dad87b050377d803bbab09d70f44b60d901df7R87-R94): Refactored SCSS to use a variable for the card's minimum height and enabled `content-visibility: auto` and `contain-intrinsic-height`, which can improve rendering performance for large lists of cards.