### PR TITLE
fix(core): reject a blank key on a webhook trigger

### DIFF
--- a/core/src/main/java/io/kestra/plugin/core/trigger/AbstractWebhookTrigger.java
+++ b/core/src/main/java/io/kestra/plugin/core/trigger/AbstractWebhookTrigger.java
@@ -7,6 +7,7 @@ import io.kestra.core.models.annotations.PluginProperty;
 import io.kestra.core.models.triggers.AbstractTrigger;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import lombok.Builder;
@@ -31,6 +32,7 @@ import reactor.core.publisher.Mono;
 public abstract class AbstractWebhookTrigger extends AbstractTrigger {
     @Size(max = 256)
     @NotNull
+    @NotBlank
     @Schema(
         title = "The unique key that will be part of the URL.",
         description = "The key is used for generating the webhook URL.\n" +


### PR DESCRIPTION
> ⚠️ **This PR was fully generated by Claude** (Claude Code). Please review accordingly.

Closes https://github.com/kestra-io/kestra-ee/issues/10272

## What was wrong

`AbstractWebhookTrigger.key` carried `@NotNull` and `@Size(max = 256)`. A *missing* key was correctly rejected with 422, but `key: ""` and `key: "   "` both saved as **Valid**:

```yaml
triggers:
  - id: h
    type: io.kestra.plugin.core.trigger.Webhook
    key: ""        # saves with 200
```

The webhook then can never fire — calling it answers 403 — so the flow looks healthy and is silently untriggerable.

## The fix

Added `@NotBlank` alongside the existing `@NotNull` on `key`.

Placed on `AbstractWebhookTrigger` rather than on `Webhook`, because that is where `key` is declared and the constraint is equally true for anything else extending it. The class-level `@WebhookValidation` validator was not the right home — it is `Webhook`-specific and only concerns `responseContentType`, whereas `key` is shared.

## Tests

No new test: the behaviour is a stock `@NotBlank` constraint, so a test for it would mostly exercise bean validation rather than anything in Kestra.

The existing `WebhookTest` still passes, including `shouldFetchBodyAndStayValidWhenTriggerDeclaresNoFetchType`, which parses a real trigger with a normal key and asserts it stays valid — so ordinary webhooks are unaffected. All `*Webhook*` tests in core pass.