### PR TITLE
fix(core): parse a flow whose namespace is digits only

### DIFF
--- a/core/src/main/java/io/kestra/core/services/FlowParsingService.java
+++ b/core/src/main/java/io/kestra/core/services/FlowParsingService.java
@@ -1,6 +1,7 @@
 package io.kestra.core.services;
 
 import java.util.Map;
+import java.util.Objects;
 
 import org.slf4j.event.Level;
 
@@ -219,7 +220,9 @@ public class FlowParsingService {
         @Nullable final String namespace,
         final String source) throws JsonProcessingException, FlowProcessingException {
         Map<String, Object> mapFlow = YAML_MAPPER.readValue(source, JacksonMapper.MAP_TYPE_REFERENCE);
-        return injectPluginVersions(tenantId, namespace == null ? (String) mapFlow.get("namespace") : namespace, mapFlow);
+        // the namespace is read back from the parsed YAML, where a digits-only value such as
+        // `namespace: 132312312` arrives as an Integer even though it matches the namespace pattern
+        return injectPluginVersions(tenantId, namespace == null ? Objects.toString(mapFlow.get("namespace"), null) : namespace, mapFlow);
     }
 
     /**

--- a/core/src/test/java/io/kestra/core/services/FlowParsingServiceTest.java
+++ b/core/src/test/java/io/kestra/core/services/FlowParsingServiceTest.java
@@ -24,6 +24,25 @@ class FlowParsingServiceTest {
     private FlowParsingService flowParsingService;
 
     @Test
+    void shouldParseAFlowWhoseNamespaceIsDigitsOnly() throws FlowProcessingException {
+        // Given - YAML parses an unquoted digits-only namespace as an Integer
+        String source = """
+            id: digits
+            namespace: 132312312
+            tasks:
+              - id: log
+                type: io.kestra.plugin.core.log.Log
+                message: hello
+            """;
+
+        // When
+        FlowWithSource parsed = flowParsingService.parse(null, source, false);
+
+        // Then - a digits-only namespace matches the namespace pattern, so it must survive parsing
+        assertThat(parsed.getNamespace()).isEqualTo("132312312");
+    }
+
+    @Test
     void shouldNotInjectAnythingGivenFlowMap() throws FlowProcessingException {
         // Given
         Map<String, Object> task = new HashMap<>();

--- a/core/src/test/java/io/kestra/core/services/FlowParsingServiceTest.java
+++ b/core/src/test/java/io/kestra/core/services/FlowParsingServiceTest.java
@@ -43,6 +43,39 @@ class FlowParsingServiceTest {
     }
 
     @Test
+    void shouldPassANullNamespaceOnWhenTheSourceDeclaresNone() throws FlowProcessingException {
+        // Given - an in-progress source with no namespace, as POST /flows/graph accepts from the editor.
+        // injectPluginVersions is a no-op in OSS but editions override it (EE resolves governance
+        // policies from this namespace), so what gets handed over has to stay null rather than "null".
+        String source = """
+            id: nons
+            tasks:
+              - id: log
+                type: io.kestra.plugin.core.log.Log
+                message: hello
+            """;
+
+        var capturing = new CapturingFlowParsingService();
+
+        // When
+        capturing.parse(null, source, false);
+
+        // Then
+        assertThat(capturing.captured).isNull();
+    }
+
+    /** Records the namespace {@link FlowParsingService#readFlowAsMap} resolves out of the source. */
+    private static class CapturingFlowParsingService extends FlowParsingService {
+        private String captured;
+
+        @Override
+        public Map<String, Object> injectPluginVersions(String tenantId, String namespace, Map<String, Object> mapFlow) {
+            this.captured = namespace;
+            return mapFlow;
+        }
+    }
+
+    @Test
     void shouldNotInjectAnythingGivenFlowMap() throws FlowProcessingException {
         // Given
         Map<String, Object> task = new HashMap<>();


### PR DESCRIPTION
> ⚠️ **This PR was fully generated by Claude** (Claude Code), including the reproducer test and the fix. Please review accordingly.

Closes https://github.com/kestra-io/kestra/issues/18472

## What was wrong

`FlowParsingService.readFlowAsMap` read the namespace back out of the parsed YAML map with a direct cast:

```java
return injectPluginVersions(tenantId, namespace == null ? (String) mapFlow.get("namespace") : namespace, mapFlow);
```

YAML types an unquoted digits-only scalar as an `Integer`, so `namespace: 132312312` blew up with

```
class java.lang.Integer cannot be cast to class java.lang.String
```

which reached the user as a 500 toast when opening the flow editor.

## Why the value is legitimate

`AbstractFlow.namespace` is constrained by `^[a-z0-9][a-z0-9._-]*` — digits-only matches. The issue also notes a digits-only namespace saves fine from the Namespaces page. So this is purely a parsing defect, not a namespace that should have been rejected; fixing the cast lets the value reach normal validation instead of dying before it.

## The fix

`Objects.toString(mapFlow.get("namespace"), null)` — the same pattern `FlowController` already uses when pulling the namespace out of a raw map:

https://github.com/kestra-io/kestra/blob/develop/webserver/src/main/java/io/kestra/webserver/controllers/api/FlowController.java#L384

Null-safety is preserved: `Objects.toString(null, null)` returns `null`, matching what the cast produced for an absent namespace.

## Tests

`shouldParseAFlowWhoseNamespaceIsDigitsOnly` added to `FlowParsingServiceTest`, parsing a real YAML source through the public `parse(tenantId, source, strictParsing)` entry point. **Verified failing before the fix** with exactly the reported exception:

```
java.lang.ClassCastException: class java.lang.Integer cannot be cast to class java.lang.String
	at io.kestra.core.services.FlowParsingService.readFlowAsMap(FlowParsingService.java:222)
```

- `io.kestra.core.services.*` → 145 tests, 0 failures
- `*FlowController*` (webserver) → 75 tests, 0 failures