### PR TITLE
fix(core): explain that Loop values must be a list instead of leaking a Jackson error

### DIFF
--- a/core/src/main/java/io/kestra/core/runners/FlowableUtils.java
+++ b/core/src/main/java/io/kestra/core/runners/FlowableUtils.java
@@ -415,6 +415,20 @@ public class FlowableUtils {
      * @return a list of String with no duplicates if the values were a list, or a list of pairs of String/String if the values were a map.
      * @throws IllegalVariableEvaluationException in case of JSON error, unsupported value type or duplicate values.
      */
+    private static final int MAX_REPORTED_VALUE_LENGTH = 100;
+
+    /**
+     * Builds the user-facing message for a `values` that did not render to a list or a map. The rendered value is
+     * truncated so a large rendered payload cannot flood the execution logs.
+     */
+    private static String notAListOrMapMessage(String renderValue) {
+        String reported = renderValue == null ? "null"
+            : renderValue.length() > MAX_REPORTED_VALUE_LENGTH
+                ? renderValue.substring(0, MAX_REPORTED_VALUE_LENGTH) + "…"
+                : renderValue;
+        return "The `values` property must be a list, a map, or an expression that renders to one, but it rendered to: " + reported;
+    }
+
     public static Either<List<String>, List<Pair<String, String>>> resolveValues(RunContext runContext, Object values) throws IllegalVariableEvaluationException {
         switch (values) {
             case String stringValue -> {
@@ -447,10 +461,13 @@ public class FlowableUtils {
                         }
                         return Either.right(resolvedValues);
                     } else {
-                        throw new IllegalVariableEvaluationException("Unknown value type: " + valuesNode.getNodeType());
+                        throw new IllegalVariableEvaluationException(notAListOrMapMessage(renderValue));
                     }
                 } catch (IOException e) {
-                    throw new IllegalVariableEvaluationException(e);
+                    // the rendered value is not parseable at all (e.g. a plain string such as
+                    // `values: "hello world"`); keep the parse error as the cause so it stays in the
+                    // stack trace, but tell the user what is actually wrong
+                    throw new IllegalVariableEvaluationException(notAListOrMapMessage(renderValue), e);
                 }
             }
             case List<?> listValue -> {

--- a/core/src/test/java/io/kestra/core/runners/FlowableUtilsTest.java
+++ b/core/src/test/java/io/kestra/core/runners/FlowableUtilsTest.java
@@ -234,6 +234,21 @@ class FlowableUtilsTest {
     }
 
     @Test
+    void resolveValues_withPlainString_shouldFailWithAUserFacingMessage() {
+        // Given
+        RunContext runContext = runContextFactory.of();
+
+        // When / Then - a plain string is not a list, and the failure must say so
+        // rather than surfacing the Jackson parse error
+        assertThatThrownBy(() -> FlowableUtils.resolveValues(runContext, "hello world"))
+            .isInstanceOf(IllegalVariableEvaluationException.class)
+            .hasMessageContaining("must be a list, a map, or an expression that renders to one")
+            .hasMessageNotContaining("JsonParseException")
+            .hasMessageNotContaining("Unrecognized token")
+            .hasMessageNotContaining("StreamReadFeature");
+    }
+
+    @Test
     void resolveValues_withStringJsonArray_shouldReturnListOfStrings() throws Exception {
         // Given
         RunContext runContext = runContextFactory.of();


### PR DESCRIPTION
> ⚠️ **This PR was fully generated by Claude** (Claude Code), including the reproducer test and the fix. Please review accordingly.

Closes https://github.com/kestra-io/kestra/issues/18454

## What was wrong

A `Loop` whose `values` is a plain string failed with Jackson internals in the **user-facing** execution log:

> Failed to process flowable task 1wLSgQ3iBD48udmrQbk97W: com.fasterxml.jackson.core.JsonParseException: Unrecognized token 'hello': was expecting (JSON String, Number, Array, Object or token 'null', 'true' or 'false') at [Source: REDACTED (`StreamReadFeature.INCLUDE_SOURCE_IN_LOCATION` disabled); line: 1 …]

## Why the message looked like that

`FlowableUtils.resolveValues` wrapped the parse failure as:

```java
} catch (IOException e) {
    throw new IllegalVariableEvaluationException(e);
}
```

`Exception(Throwable)` sets the message to `cause.toString()`, and `ExecutorService` logs `e.getMessage()` — so the Jackson text *was* the message.

## The fix

Pass an explicit message and keep the parse error as the cause:

```java
throw new IllegalVariableEvaluationException(notAListOrMapMessage(renderValue), e);
```

The cause is still handed to `logger().error(..., e)`, so the Jackson detail remains in the stack trace — which is what the issue asked for.

Two smaller decisions:

- The neighbouring non-array/non-object branch threw `"Unknown value type: NUMBER"`, which is the same mistake described in internal terms. It now shares the same wording, so `values: "hello world"` and `values: "123"` explain themselves identically.
- The rendered value is included (it is the useful part when the value came from an expression) but **truncated to 100 chars**, so a `values` expression rendering to a large payload cannot flood the execution logs.

## Tests

`resolveValues_withPlainString_shouldFailWithAUserFacingMessage` added to `FlowableUtilsTest`, asserting both the new wording *and* the absence of `JsonParseException` / `Unrecognized token` / `StreamReadFeature`. **Verified failing before the fix.**

- `FlowableUtilsTest` + all `*Loop*` tests → 46 tests, 0 failures
- Full `H2RunnerTest` → 100 tests, 0 failures (run because `resolveValues` is on the live Loop/ForEach execution path, not just a parsing helper)