### PR TITLE
fix(assets): isolate a failed asset write from the caller's transaction

### DIFF
--- a/jdbc-h2/src/test/java/io/kestra/jdbc/h2/H2JooqDSLContextWrapperNestedTransactionTest.java
+++ b/jdbc-h2/src/test/java/io/kestra/jdbc/h2/H2JooqDSLContextWrapperNestedTransactionTest.java
@@ -1,0 +1,7 @@
+package io.kestra.jdbc.h2;
+
+import io.kestra.jdbc.JooqDSLContextWrapperNestedTransactionTest;
+
+class H2JooqDSLContextWrapperNestedTransactionTest extends JooqDSLContextWrapperNestedTransactionTest {
+
+}

--- a/jdbc-mysql/src/test/java/io/kestra/jdbc/mysql/MysqlJooqDSLContextWrapperNestedTransactionTest.java
+++ b/jdbc-mysql/src/test/java/io/kestra/jdbc/mysql/MysqlJooqDSLContextWrapperNestedTransactionTest.java
@@ -1,0 +1,7 @@
+package io.kestra.jdbc.mysql;
+
+import io.kestra.jdbc.JooqDSLContextWrapperNestedTransactionTest;
+
+class MysqlJooqDSLContextWrapperNestedTransactionTest extends JooqDSLContextWrapperNestedTransactionTest {
+
+}

--- a/jdbc-postgres/src/test/java/io/kestra/jdbc/postgres/PostgresJooqDSLContextWrapperNestedTransactionTest.java
+++ b/jdbc-postgres/src/test/java/io/kestra/jdbc/postgres/PostgresJooqDSLContextWrapperNestedTransactionTest.java
@@ -1,0 +1,7 @@
+package io.kestra.jdbc.postgres;
+
+import io.kestra.jdbc.JooqDSLContextWrapperNestedTransactionTest;
+
+class PostgresJooqDSLContextWrapperNestedTransactionTest extends JooqDSLContextWrapperNestedTransactionTest {
+
+}

--- a/jdbc/src/main/java/io/kestra/jdbc/JooqDSLContextWrapper.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/JooqDSLContextWrapper.java
@@ -25,6 +25,8 @@ import io.kestra.core.models.tasks.retrys.Random;
 import io.kestra.core.utils.RetryUtils;
 
 import io.micronaut.data.connection.jdbc.advice.DelegatingDataSource;
+import io.micronaut.transaction.SynchronousTransactionManager;
+import io.micronaut.transaction.TransactionDefinition;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 
@@ -41,19 +43,34 @@ public class JooqDSLContextWrapper {
 
     private final DSLContext dslContext;
     private final DataSource rawDataSource;
+    private final SynchronousTransactionManager<Connection> transactionManager;
 
     /**
      * @param dataSource used by {@link #requireNewTransaction(TransactionalRunnable)}, and an
      *        explicit dependency to ensure Micronaut destroys this bean before the DataSource.
      *        Without it, the @EachBean-derived DSLContext/Configuration may be destroyed
      *        together with the DataSource, leaving this wrapper with a stale DSLContext.
+     * @param transactionManager used by {@link #nestedTransactionResult(TransactionalCallable)}
+     *        to open a {@code Propagation.NESTED} transaction directly — jOOQ's own
+     *        {@code TransactionProvider} always requests {@code TransactionDefinition.DEFAULT}
+     *        (REQUIRED), so nested/savepoint semantics can only be reached through this manager.
      */
     @Inject
-    public JooqDSLContextWrapper(DSLContext dslContext, DataSource dataSource) {
+    public JooqDSLContextWrapper(DSLContext dslContext, DataSource dataSource, SynchronousTransactionManager<Connection> transactionManager) {
         this.dslContext = dslContext;
         // Unwrap any Micronaut Data AOP proxy: the wrapped DataSource hands back the current
         // thread's transaction-bound connection instead of a new one.
         this.rawDataSource = DelegatingDataSource.unwrapDataSource(dataSource);
+        this.transactionManager = transactionManager;
+    }
+
+    /**
+     * For a wrapper built manually around an ad-hoc datasource (e.g. a dedicated log database)
+     * that has no Micronaut-managed transaction manager of its own; {@link #nestedTransactionResult}
+     * is unavailable on an instance built this way.
+     */
+    public JooqDSLContextWrapper(DSLContext dslContext, DataSource dataSource) {
+        this(dslContext, dataSource, null);
     }
 
     /**
@@ -112,6 +129,35 @@ public class JooqDSLContextWrapper {
                     throw new DataAccessException("Unable to run a transaction on a new connection", e);
                 }
                 return null;
+            }
+        );
+    }
+
+    /**
+     * Runs {@code transactional} inside a {@code Propagation.NESTED} transaction: if a
+     * transaction is already open on the current thread (e.g. the dispatch-queue poll
+     * transaction), this opens a SAVEPOINT and, on failure, rolls back to it instead of
+     * dooming the caller's transaction — the only way to clear Postgres's
+     * aborted-transaction state without aborting the outer transaction too (see
+     * {@link #transaction(TransactionalRunnable)}). With no open transaction, this behaves
+     * like a plain new one. Not retried on deadlock: a deadlock inside a savepoint can't be
+     * retried in isolation once the parent transaction is already dead.
+     */
+    public <T> T nestedTransactionResult(TransactionalCallable<T> transactional) {
+        if (transactionManager == null) {
+            throw new UnsupportedOperationException("This JooqDSLContextWrapper has no transaction manager (built for an ad-hoc datasource); nestedTransactionResult is unavailable.");
+        }
+        return transactionManager.execute(
+            TransactionDefinition.of(TransactionDefinition.Propagation.NESTED),
+            status ->
+            {
+                try {
+                    return transactional.run(dslContext.configuration());
+                } catch (Exception e) {
+                    throw e;
+                } catch (Throwable t) {
+                    throw new DataAccessException("Unable to run a nested transaction", t);
+                }
             }
         );
     }

--- a/jdbc/src/test/java/io/kestra/jdbc/JooqDSLContextWrapperNestedTransactionTest.java
+++ b/jdbc/src/test/java/io/kestra/jdbc/JooqDSLContextWrapperNestedTransactionTest.java
@@ -1,0 +1,101 @@
+package io.kestra.jdbc;
+
+import org.jooq.exception.DataAccessException;
+import org.jooq.impl.DSL;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import io.kestra.core.junit.annotations.KestraTest;
+import io.kestra.core.utils.IdUtils;
+
+import jakarta.inject.Inject;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * kestra-ee#10347: a write that violates a NOT NULL constraint on a caller-owned (e.g.
+ * dispatch-queue poll) transaction must not abort that transaction. On Postgres, a plain
+ * {@link JooqDSLContextWrapper#transaction} joins the caller's transaction, so catching the
+ * exception in Java can't undo the DB-level abort — the next statement on that same
+ * transaction fails too. {@link JooqDSLContextWrapper#nestedTransactionResult} exists to isolate
+ * exactly this: a SAVEPOINT-scoped nested transaction that rolls back to the savepoint on
+ * failure, leaving the caller's transaction untouched.
+ */
+@KestraTest
+public abstract class JooqDSLContextWrapperNestedTransactionTest {
+
+    @Inject
+    private JooqDSLContextWrapper dslContextWrapper;
+
+    @BeforeEach
+    void setUp() {
+        dslContextWrapper.transaction(
+            configuration -> DSL.using(configuration).execute("CREATE TABLE IF NOT EXISTS nested_tx_test (id VARCHAR(50) NOT NULL PRIMARY KEY)")
+        );
+    }
+
+    @AfterEach
+    void tearDown() {
+        dslContextWrapper.transaction(
+            configuration -> DSL.using(configuration).execute("DELETE FROM nested_tx_test")
+        );
+    }
+
+    @Test
+    void nestedTransactionRollsBackWithoutAbortingCallerTransaction() {
+        String survivorId = IdUtils.create();
+
+        dslContextWrapper.transaction(configuration ->
+        {
+            assertThatThrownBy(
+                () -> dslContextWrapper.nestedTransactionResult(
+                    nestedConfiguration -> DSL.using(nestedConfiguration)
+                        .insertInto(DSL.table("nested_tx_test"), DSL.field("id"))
+                        .values((Object) null)
+                        .execute()
+                )
+            ).isInstanceOf(DataAccessException.class);
+
+            // still inside the SAME caller transaction: this write must succeed, proving the
+            // constraint violation above did not abort it (on Postgres, a doomed transaction
+            // rejects every further statement with "current transaction is aborted")
+            DSL.using(configuration)
+                .insertInto(DSL.table("nested_tx_test"), DSL.field("id"))
+                .values(survivorId)
+                .execute();
+        });
+
+        Integer count = dslContextWrapper.transactionResult(
+            configuration -> DSL.using(configuration)
+                .selectCount()
+                .from(DSL.table("nested_tx_test"))
+                .where(DSL.field("id").eq(survivorId))
+                .fetchOne(0, Integer.class)
+        );
+        assertThat(count).isEqualTo(1);
+    }
+
+    @Test
+    void nestedTransactionWithNoAmbientTransactionBehavesLikeANewOne() {
+        String id = IdUtils.create();
+
+        Integer inserted = dslContextWrapper.nestedTransactionResult(
+            configuration -> DSL.using(configuration)
+                .insertInto(DSL.table("nested_tx_test"), DSL.field("id"))
+                .values(id)
+                .execute()
+        );
+        assertThat(inserted).isEqualTo(1);
+
+        Integer count = dslContextWrapper.transactionResult(
+            configuration -> DSL.using(configuration)
+                .selectCount()
+                .from(DSL.table("nested_tx_test"))
+                .where(DSL.field("id").eq(id))
+                .fetchOne(0, Integer.class)
+        );
+        assertThat(count).isEqualTo(1);
+    }
+}


### PR DESCRIPTION
- Asset writes join whatever transaction the caller already has open — for `processTaskRunAssets` that is the executor's execution-lock transaction (`AbstractJdbcExecutionRepository.lock`). On Postgres an uncaught constraint violation aborts that transaction at the database level, so the `catch` around the call cannot undo it and the execution-state persist that follows fails too, outside the catch. With fail-fast queues and no DLQ the unacked message then takes the instance down again on every restart
- Adds `JooqDSLContextWrapper.nestedTransactionResult`, a `Propagation.NESTED` (SAVEPOINT) transaction: `ROLLBACK TO SAVEPOINT` is the only thing that clears Postgres's aborted-transaction state without dooming the outer transaction
- Not wrapped in the deadlock retryer — a deadlock inside a savepoint cannot be retried once the parent transaction is already dead
- Sanity-checked by reverting to the plain joined call: H2 never aborts, Postgres fails with `current transaction is aborted` on the second statement in the same transaction

The validation half is split out into https://github.com/kestra-io/kestra/pull/18835, which is independent of this one.

Related to https://github.com/kestra-io/kestra-ee/issues/10347.

Companion PR: kestra-io/kestra-ee#10468
