### PR TITLE
fix(flows): reject cyclic flow dependencies and validate trigger minSatisfied

### DIFF
--- a/core/src/main/java/io/kestra/core/executor/command/Create.java
+++ b/core/src/main/java/io/kestra/core/executor/command/Create.java
@@ -38,12 +38,14 @@ public record Create(
     @With @JsonProperty @Nullable List<Breakpoint> breakpoints,
     @With @JsonProperty @Nullable String traceParent,
     @With @JsonInclude(JsonInclude.Include.NON_EMPTY) @Nullable List<TaskFixture> fixtures,
-    @With @JsonInclude(JsonInclude.Include.NON_EMPTY) @Nullable @Schema(implementation = Object.class) Map<String, Object> variables) implements ExecutionCommand {
+    @With @JsonInclude(JsonInclude.Include.NON_EMPTY) @Nullable @Schema(implementation = Object.class) Map<String, Object> variables,
+    @With @JsonProperty @Nullable Integer executionDepth) implements ExecutionCommand {
     public static Create of(FlowId flowId) {
         return new Create(
             new ExecutionId(flowId, IdUtils.create()),
             Instant.now(),
             EventId.create(),
+            null,
             null,
             null,
             null,
@@ -73,13 +75,14 @@ public record Create(
             null,
             null,
             null,
+            null,
             null
         );
     }
 
     public Create withInputsFromReader(Function<String, Map<String, Object>> inputsReader) {
         var inputs = inputsReader.apply(this.executionId());
-        return new Create(executionFullId, timestamp, eventId, operationId, stateType, kind, trigger, labels, scheduleDate, inputs, breakpoints, traceParent, fixtures, variables);
+        return new Create(executionFullId, timestamp, eventId, operationId, stateType, kind, trigger, labels, scheduleDate, inputs, breakpoints, traceParent, fixtures, variables, executionDepth);
     }
 
     @Override

--- a/core/src/main/java/io/kestra/core/models/executions/ExecutionMetadata.java
+++ b/core/src/main/java/io/kestra/core/models/executions/ExecutionMetadata.java
@@ -29,9 +29,24 @@ public class ExecutionMetadata {
     @With
     List<String> concurrencyScopes;
 
+    /**
+     * The number of Subflow/Flow-trigger hops between this execution and the root execution that
+     * started the chain, incremented by one at each hop.
+     * Null for a root execution which is treated as depth 0.
+     */
+    @With
+    Integer executionDepth;
+
     public ExecutionMetadata nextAttempt() {
         return this.toBuilder()
             .attemptNumber(this.attemptNumber + 1)
             .build();
+    }
+
+    /**
+     * Returns {@link #executionDepth}, defaulting to 0 for a root execution or one predating this field.
+     */
+    public int executionDepthOrZero() {
+        return this.executionDepth == null ? 0 : this.executionDepth;
     }
 }

--- a/core/src/main/java/io/kestra/core/runners/ExecutableUtils.java
+++ b/core/src/main/java/io/kestra/core/runners/ExecutableUtils.java
@@ -16,6 +16,7 @@ import io.kestra.core.models.property.Property;
 import io.kestra.core.models.tasks.ExecutableTask;
 import io.kestra.core.models.tasks.Task;
 import io.kestra.core.repositories.ExecutionRepositoryInterface;
+import io.kestra.core.runners.configuration.ExecutionDepthConfiguration;
 import io.kestra.core.services.ExecutionService;
 import io.kestra.core.services.TaskOutputService;
 import io.kestra.core.trace.propagation.ExecutionTextMapSetter;
@@ -203,6 +204,15 @@ public final class ExecutableUtils {
                     throw new IllegalStateException(msg);
                 }
 
+                int executionDepth = currentExecution.getMetadata().executionDepthOrZero() + 1;
+                int maxDepth = ((DefaultRunContext) runContext).services().additionalService(ExecutionDepthConfiguration.class).maxDepth();
+                if (executionDepth > maxDepth) {
+                    // Backstop against a cross-flow execution cycle that save-time validation cannot see.
+                    String msg = "Cannot execute flow '%s'.'%s': the execution chain exceeded the maximum depth of %d. You can increase this limit via the `kestra.execution.depth.max-depth` configuration property.".formatted(subflowNamespace, subflowId, maxDepth);
+                    runContext.logger().error(msg);
+                    throw new IllegalStateException(msg);
+                }
+
                 List<Label> newLabels = inheritLabels ? new ArrayList<>(filterLabels(currentExecution.getLabels(), flow)) : new ArrayList<>(systemLabels(currentExecution));
                 if (labels != null) {
                     labels.forEach(throwConsumer(label -> newLabels.add(new Label(runContext.render(label.key()), runContext.render(label.value())))));
@@ -249,6 +259,8 @@ public final class ExecutableUtils {
                             .variables(variables.build())
                             .build()
                     );
+                execution = execution.withMetadata(execution.getMetadata().withExecutionDepth(executionDepth));
+                final Execution executionWithDepth = execution;
 
                 if (execution.getInputs().size() < inputs.size()) {
                     Map<String, Object> resolvedInputs = execution.getInputs();
@@ -266,13 +278,13 @@ public final class ExecutableUtils {
                 }
 
                 // inject the traceparent into the new execution
-                propagator.ifPresent(pg -> pg.inject(Context.current(), execution, ExecutionTextMapSetter.INSTANCE));
+                propagator.ifPresent(pg -> pg.inject(Context.current(), executionWithDepth, ExecutionTextMapSetter.INSTANCE));
 
                 return Optional.of(
                     SubflowExecution.builder()
                         .parentTask(currentTask)
                         .parentTaskRun(currentTaskRun.withState(State.Type.RUNNING))
-                        .execution(execution)
+                        .execution(executionWithDepth)
                         .build()
                 );
             })

--- a/core/src/main/java/io/kestra/core/runners/configuration/ExecutionDepthConfiguration.java
+++ b/core/src/main/java/io/kestra/core/runners/configuration/ExecutionDepthConfiguration.java
@@ -1,0 +1,18 @@
+package io.kestra.core.runners.configuration;
+
+import io.micronaut.context.annotation.ConfigurationProperties;
+import io.micronaut.core.bind.annotation.Bindable;
+
+/**
+ * Configuration for the runtime cap on the Subflow/Flow-trigger execution chain depth.
+ * <p>
+ * This is a backstop against a cross-flow execution cycle that save-time validation cannot see (e.g. a
+ * conditional Flow trigger loop), not the primary defense against it.
+ *
+ * @param maxDepth maximum number of Subflow/Flow-trigger hops between a root execution and one it
+ *        (directly or indirectly) starts. Guards a cycle rather than bounding normal depth so it's generous by default.
+ */
+@ConfigurationProperties("kestra.execution.depth")
+public record ExecutionDepthConfiguration(
+    @Bindable(defaultValue = "100") int maxDepth) {
+}

--- a/core/src/main/java/io/kestra/core/runners/pebble/functions/SubflowFunction.java
+++ b/core/src/main/java/io/kestra/core/runners/pebble/functions/SubflowFunction.java
@@ -44,7 +44,10 @@ import lombok.extern.slf4j.Slf4j;
  * <p>
  * <b>Recursion.</b> A subflow whose own inputs call {@code subflow()} is bounded by a per-thread depth
  * cap. Input resolution is synchronous and runs on the same thread, so the cap catches both direct
- * self-recursion and mutual recursion across flows without a dedicated self-call check.
+ * self-recursion and mutual recursion across flows without a dedicated self-call check. This cap is
+ * independent of {@code kestra.execution.depth.max-depth} ({@link io.kestra.core.runners.configuration.ExecutionDepthConfiguration}),
+ * which bounds the Subflow task and Flow trigger chains instead — a subflow executed here does not
+ * carry or check that depth.
  * <p>
  * <b>Bean wiring.</b> The function is only registered on server types that render execute forms
  * ({@code WEBSERVER}, {@code STANDALONE}); on other server types the bean is absent and the function

--- a/core/src/main/java/io/kestra/core/services/ExecutionService.java
+++ b/core/src/main/java/io/kestra/core/services/ExecutionService.java
@@ -277,6 +277,12 @@ public class ExecutionService {
             newExecution = newExecution.toBuilder().fixtures(createCommand.fixtures()).build();
         }
 
+        // Carries the depth a Flow trigger's evaluate() computed before the dependsOn route rebuilt this
+        // execution from the Create command; Execution.newExecution() above reset it via prebuild().
+        if (createCommand.executionDepth() != null) {
+            newExecution = newExecution.withMetadata(newExecution.getMetadata().withExecutionDepth(createCommand.executionDepth()));
+        }
+
         if (createCommand.variables() != null) {
             newExecution = newExecution.withVariables(createCommand.variables());
         }

--- a/core/src/main/java/io/kestra/core/services/FlowService.java
+++ b/core/src/main/java/io/kestra/core/services/FlowService.java
@@ -28,11 +28,15 @@ import io.kestra.core.models.Plugin;
 import io.kestra.core.models.executions.Execution;
 import io.kestra.core.models.flows.*;
 import io.kestra.core.models.flows.check.Check;
+import io.kestra.core.models.property.Property;
+import io.kestra.core.models.tasks.ExecutableTask;
 import io.kestra.core.models.tasks.RunnableTask;
+import io.kestra.core.models.tasks.Task;
 import io.kestra.core.models.topologies.FlowTopology;
 import io.kestra.core.models.triggers.AbstractTrigger;
 import io.kestra.core.models.triggers.TriggerId;
 import io.kestra.core.models.triggers.WorkerTriggerInterface;
+import io.kestra.core.models.validations.ManualConstraintViolation;
 import io.kestra.core.models.validations.ModelValidator;
 import io.kestra.core.models.validations.ValidateConstraintViolation;
 import io.kestra.core.plugins.PluginRegistry;
@@ -40,6 +44,7 @@ import io.kestra.core.queues.BroadcastQueueInterface;
 import io.kestra.core.queues.QueueException;
 import io.kestra.core.repositories.FlowRepositoryInterface;
 import io.kestra.core.repositories.FlowTopologyRepositoryInterface;
+import io.kestra.core.runners.FlowMetaStoreInterface;
 import io.kestra.core.runners.RunContext;
 import io.kestra.core.runners.RunContextFactory;
 import io.kestra.core.scheduler.events.TriggerCreated;
@@ -52,6 +57,7 @@ import io.kestra.core.serializers.JacksonMapper;
 import io.kestra.core.topologies.FlowTopologyService;
 import io.kestra.core.utils.ExecutorsUtils;
 import io.kestra.core.utils.ListUtils;
+import io.kestra.core.utils.PebbleUtil;
 import io.kestra.core.utils.SecretUtils;
 import io.kestra.plugin.core.flow.Pause;
 
@@ -99,6 +105,9 @@ public class FlowService {
     @Inject
     private ConcurrencyLimitRepositoryInterface concurrencyLimitRepository;
 
+    @Inject
+    private FlowMetaStoreInterface flowMetaStore;
+
     private final ExecutorService executorService;
 
     @Inject
@@ -138,6 +147,7 @@ public class FlowService {
         if (!flow.isDraft()) {
             FlowWithSource parsed = flowParsingService.parse(flow.getTenantId(), flow.getSource(), true);
             modelValidator.validate(flowParsingService.parseForValidation(parsed));
+            throwOnCyclicDependency(parsed);
         }
 
         FlowWithSource created = flowRepository.create(flow);
@@ -172,6 +182,7 @@ public class FlowService {
         if (!flow.isDraft()) {
             FlowWithSource parsed = flowParsingService.parse(flow.getTenantId(), flow.getSource(), true);
             modelValidator.validate(flowParsingService.parseForValidation(parsed));
+            throwOnCyclicDependency(parsed);
         }
 
         FlowWithSource updated = flowRepository.update(flow, previous);
@@ -457,6 +468,7 @@ public class FlowService {
                 constraintsBuilder.namespace(flow.getNamespace());
 
                 modelValidator.validate(parsedFlow);
+                throwOnCyclicDependency(parsedFlow);
             } catch (ConstraintViolationException e) {
                 String friendlyMessage = formatValidationError(e.getMessage());
                 constraintsBuilder.constraints(friendlyMessage);
@@ -498,6 +510,7 @@ public class FlowService {
         );
 
         FlowWithSource flowToImport = flowParsingService.parse(flow, true);
+        throwOnCyclicDependency(flowToImport);
 
         if (dryRun) {
             return maybeExisting
@@ -646,6 +659,145 @@ public class FlowService {
         });
 
         return violations;
+    }
+
+    /**
+     * Returns a message describing a cross-flow execution cycle the given flow's Subflow tasks and Flow
+     * triggers would close, or {@link Optional#empty()} when saving it introduces none.
+     * <p>
+     * Only edges that fire unconditionally are counted (no {@code disabled}/{@code runIf} on a Subflow
+     * task, no {@code when}/{@code conditions} on a Flow trigger or its {@code dependsOn} entries): a
+     * cycle gated by a condition may be intentional and terminating, and this cannot decide whether the
+     * condition ever goes false. {@code kestra.execution.depth.max-depth}
+     * ({@link io.kestra.core.runners.configuration.ExecutionDepthConfiguration}) bounds that case, and
+     * any other cycle this static check cannot see, at runtime instead.
+     * <p>
+     * Templated ({@code {{ }}}) Subflow namespace/flowId, and a {@code dependsOn} entry naming neither
+     * namespace nor flowId, are skipped for the same reason.
+     */
+    private Optional<String> checkCyclicDependency(Flow flow) {
+        String root = flow.uidWithoutRevision();
+
+        Map<String, List<String>> edges = new HashMap<>();
+        Map<String, String> displayNames = new HashMap<>();
+        for (FlowWithSource candidate : flowMetaStore.allLastVersion()) {
+            // The flow being saved contributes its own edges below, from the version being saved rather
+            // than whatever stale copy the cache may still hold for it.
+            if (!Objects.equals(candidate.getTenantId(), flow.getTenantId()) || candidate.uidWithoutRevision().equals(root) || candidate.isDraft()) {
+                continue;
+            }
+            addUnconditionalEdges(candidate, edges, displayNames);
+        }
+        addUnconditionalEdges(flow, edges, displayNames);
+
+        if (ListUtils.isEmpty(edges.get(root))) {
+            return Optional.empty();
+        }
+
+        List<String> path = new ArrayList<>(List.of(root));
+        if (!findPathToRoot(root, root, edges, path, new HashSet<>(List.of(root)), new HashSet<>())) {
+            return Optional.empty();
+        }
+
+        return Optional.of(path.stream().map(uid -> displayNames.getOrDefault(uid, uid)).collect(Collectors.joining(" → ")));
+    }
+
+    /**
+     * Rejects the save with a 422 when {@link #checkCyclicDependency} finds a cross-flow execution cycle.
+     */
+    private void throwOnCyclicDependency(FlowWithSource flow) {
+        checkCyclicDependency(flow).ifPresent(cycle -> {
+            throw new ConstraintViolationException(
+                Collections.singleton(
+                    ManualConstraintViolation.of(
+                        "Cyclic flow dependency detected: %s. Saving this flow would create an execution loop.".formatted(cycle),
+                        flow,
+                        FlowWithSource.class,
+                        "flow",
+                        cycle
+                    )
+                )
+            );
+        });
+    }
+
+    /**
+     * Adds every unconditional Subflow-task and Flow-trigger {@code dependsOn} edge {@code flow}
+     * contributes to the cross-flow graph, keyed by {@link FlowInterface#uidWithoutRevision()}, and
+     * records a {@code namespace.id} display name for each node touched.
+     */
+    private static void addUnconditionalEdges(Flow flow, Map<String, List<String>> edges, Map<String, String> displayNames) {
+        String from = flow.uidWithoutRevision();
+        displayNames.put(from, flow.getNamespace() + "." + flow.getId());
+
+        flow.allTasksWithChilds().stream()
+            .filter(task -> task instanceof ExecutableTask<?>)
+            .filter(FlowService::isUnconditionalSubflowTask)
+            .map(task -> ((ExecutableTask<?>) task).subflowId())
+            .filter(subflowId -> subflowId.namespace() != null && subflowId.flowId() != null)
+            .filter(subflowId -> !PebbleUtil.containsOpeningBlockDelimiter(subflowId.namespace()) && !PebbleUtil.containsOpeningBlockDelimiter(subflowId.flowId()))
+            .forEach(subflowId -> {
+                String to = FlowId.uidWithoutRevision(flow.getTenantId(), subflowId.namespace(), subflowId.flowId());
+                edges.computeIfAbsent(from, k -> new ArrayList<>()).add(to);
+                displayNames.putIfAbsent(to, subflowId.namespace() + "." + subflowId.flowId());
+            });
+
+        ListUtils.emptyOnNull(flow.getTriggers()).stream()
+            .filter(io.kestra.plugin.core.trigger.Flow.class::isInstance)
+            .map(io.kestra.plugin.core.trigger.Flow.class::cast)
+            .filter(FlowService::isUnconditionalFlowTrigger)
+            .flatMap(trigger -> ListUtils.emptyOnNull(trigger.getDependsOn()).stream())
+            .filter(FlowService::isUnconditionalDependency)
+            .filter(dependency -> dependency.getNamespace() != null && dependency.getFlowId() != null)
+            .forEach(dependency -> {
+                String depFrom = FlowId.uidWithoutRevision(flow.getTenantId(), dependency.getNamespace(), dependency.getFlowId());
+                edges.computeIfAbsent(depFrom, k -> new ArrayList<>()).add(from);
+                displayNames.putIfAbsent(depFrom, dependency.getNamespace() + "." + dependency.getFlowId());
+            });
+    }
+
+    private static boolean isUnconditionalSubflowTask(Task task) {
+        return !Boolean.TRUE.equals(task.getDisabled()) && (task.getRunIf() == null || "true".equals(task.getRunIf()));
+    }
+
+    private static boolean isUnconditionalFlowTrigger(io.kestra.plugin.core.trigger.Flow trigger) {
+        return !trigger.isDisabled() && (trigger.getWhen() == null || "true".equals(trigger.getWhen()));
+    }
+
+    private static boolean isUnconditionalDependency(io.kestra.plugin.core.trigger.Flow.Dependency dependency) {
+        return dependency.getWhen() == null || Property.ofValue("true").equals(dependency.getWhen());
+    }
+
+    /**
+     * Depth-first search for a path from {@code current} back to {@code root} along {@code edges}, so
+     * that {@code checkCyclicDependency} rejects only a save that closes a cycle through the flow being
+     * saved — not a save that happens to reach into an unrelated cycle among other flows.
+     * <p>
+     * {@code visiting} is the current DFS path (a back-edge into it is a cycle not involving root, and
+     * must be skipped rather than re-entered, or it recurses forever); {@code deadEnds} is nodes fully
+     * explored with no path to root, which is true regardless of which path reached them, so they are
+     * never re-explored.
+     */
+    private static boolean findPathToRoot(String current, String root, Map<String, List<String>> edges, List<String> path, Set<String> visiting, Set<String> deadEnds) {
+        for (String next : ListUtils.emptyOnNull(edges.get(current))) {
+            if (next.equals(root)) {
+                path.add(next);
+                return true;
+            }
+            if (visiting.contains(next) || deadEnds.contains(next)) {
+                continue;
+            }
+            visiting.add(next);
+            path.add(next);
+            if (findPathToRoot(next, root, edges, path, visiting, deadEnds)) {
+                return true;
+            }
+            path.removeLast();
+            visiting.remove(next);
+            deadEnds.add(next);
+        }
+
+        return false;
     }
 
     public record Relocation(String from, String to) {

--- a/core/src/main/java/io/kestra/core/validations/validator/FlowTriggerValidator.java
+++ b/core/src/main/java/io/kestra/core/validations/validator/FlowTriggerValidator.java
@@ -1,6 +1,7 @@
 package io.kestra.core.validations.validator;
 
 import io.kestra.core.models.triggers.multipleflows.MultipleCondition;
+import io.kestra.core.utils.ListUtils;
 import io.kestra.core.validations.FlowTriggerValidation;
 import io.kestra.plugin.core.trigger.Flow;
 
@@ -22,6 +23,13 @@ public class FlowTriggerValidator implements ConstraintValidator<FlowTriggerVali
         if (MultipleCondition.Mode.AT_LEAST == value.getMode() && value.getMinSatisfied() == null) {
             context.disableDefaultConstraintViolation();
             context.buildConstraintViolationWithTemplate("`minSatisfied` must be set when mode is AT_LEAST")
+                .addConstraintViolation();
+            return false;
+        }
+
+        if (value.getMinSatisfied() != null && value.getMinSatisfied() > ListUtils.emptyOnNull(value.getDependsOn()).size()) {
+            context.disableDefaultConstraintViolation();
+            context.buildConstraintViolationWithTemplate("`minSatisfied` must be lower than or equal to the number of `dependsOn`")
                 .addConstraintViolation();
             return false;
         }

--- a/core/src/main/java/io/kestra/plugin/core/trigger/Flow.java
+++ b/core/src/main/java/io/kestra/plugin/core/trigger/Flow.java
@@ -342,6 +342,7 @@ public class Flow extends AbstractTrigger implements TriggerOutput<Flow.Output> 
         // the execution snapshots the flow labels and variables, so it is built through the same factory as
         // every other creation path rather than field by field, which is how flow variables went missing here
         Execution execution = Execution.newExecution(flow, labels).withTrigger(executionTrigger);
+        execution = execution.withMetadata(execution.getMetadata().withExecutionDepth(current.getMetadata().executionDepthOrZero() + 1));
 
         try {
             Map<String, Object> renderedInputs;

--- a/core/src/test/java/io/kestra/core/services/FlowServiceTest.java
+++ b/core/src/test/java/io/kestra/core/services/FlowServiceTest.java
@@ -26,6 +26,7 @@ import io.kestra.core.repositories.ConcurrencyLimitRepositoryInterface;
 import io.kestra.core.repositories.FlowRepositoryInterface;
 import io.kestra.core.repositories.FlowTopologyRepositoryInterface;
 import io.kestra.core.runners.ConcurrencyLimit;
+import io.kestra.core.runners.FlowMetaStoreInterface;
 import io.kestra.core.scheduler.events.TriggerCreated;
 import io.kestra.core.scheduler.events.TriggerEvent;
 import io.kestra.core.scheduler.events.TriggerFlowRevisionUpdated;
@@ -63,6 +64,8 @@ class FlowServiceTest {
     private TriggerEventQueue triggerEventQueue;
     @Inject
     private ConcurrencyLimitRepositoryInterface concurrencyLimitRepository;
+    @Inject
+    private FlowMetaStoreInterface flowMetaStore;
 
     private static FlowWithSource create(String flowId, String taskId, Integer revision) {
         return create(null, TEST_NAMESPACE, flowId, taskId, revision);
@@ -619,6 +622,243 @@ class FlowServiceTest {
 
         // check that the flow has been sent to the queue 2x
         assertTrue(countDownLatch.await(10, TimeUnit.SECONDS));
+    }
+
+    @Test
+    void shouldRejectSubflowCycleAcrossTwoFlows() throws FlowProcessingException, QueueException {
+        // Given flow B, which Subflow-calls a not-yet-created flow A (#18491/#18492: two flows calling
+        // each other via Subflow save fine today and recurse without bound)
+        String flowAId = IdUtils.create();
+        String flowBId = IdUtils.create();
+        Flow flowB = Flow.builder()
+            .id(flowBId)
+            .tenantId(TenantService.MAIN_TENANT)
+            .namespace(TEST_NAMESPACE)
+            .tasks(List.of(Subflow.builder().id("call").type(Subflow.class.getName()).namespace(TEST_NAMESPACE).flowId(flowAId).build()))
+            .build();
+        flowService.create(GenericFlow.of(flowB));
+        await().atMost(Duration.ofSeconds(10)).until(() -> flowMetaStore.allLastVersion().stream().anyMatch(f -> f.getId().equals(flowBId)));
+
+        Flow flowA = Flow.builder()
+            .id(flowAId)
+            .tenantId(TenantService.MAIN_TENANT)
+            .namespace(TEST_NAMESPACE)
+            .tasks(List.of(Subflow.builder().id("call").type(Subflow.class.getName()).namespace(TEST_NAMESPACE).flowId(flowBId).build()))
+            .build();
+
+        // When saving flow A closes the A -> B -> A cycle, then it must be rejected rather than silently
+        // creating an execution loop
+        assertThatThrownBy(() -> flowService.create(GenericFlow.of(flowA)))
+            .isInstanceOf(jakarta.validation.ConstraintViolationException.class)
+            .hasMessageContaining("Cyclic flow dependency detected");
+    }
+
+    @Test
+    void shouldRejectFlowTriggerCycleAcrossTwoFlows() throws FlowProcessingException, QueueException {
+        // Given flow B, whose Flow trigger unconditionally dependsOn a not-yet-created flow A (the exact
+        // shape reported in #18492)
+        String flowAId = IdUtils.create();
+        String flowBId = IdUtils.create();
+        Flow flowB = Flow.builder()
+            .id(flowBId)
+            .tenantId(TenantService.MAIN_TENANT)
+            .namespace(TEST_NAMESPACE)
+            .tasks(List.of(Return.builder().id("t").type(Return.class.getName()).format(Property.ofValue("b")).build()))
+            .triggers(List.of(
+                io.kestra.plugin.core.trigger.Flow.builder()
+                    .id("on_a")
+                    .type(io.kestra.plugin.core.trigger.Flow.class.getName())
+                    .dependsOn(List.of(io.kestra.plugin.core.trigger.Flow.Dependency.builder().namespace(TEST_NAMESPACE).flowId(flowAId).build()))
+                    .build()
+            ))
+            .build();
+        flowService.create(GenericFlow.of(flowB));
+        await().atMost(Duration.ofSeconds(10)).until(() -> flowMetaStore.allLastVersion().stream().anyMatch(f -> f.getId().equals(flowBId)));
+
+        Flow flowA = Flow.builder()
+            .id(flowAId)
+            .tenantId(TenantService.MAIN_TENANT)
+            .namespace(TEST_NAMESPACE)
+            .tasks(List.of(Return.builder().id("t").type(Return.class.getName()).format(Property.ofValue("a")).build()))
+            .triggers(List.of(
+                io.kestra.plugin.core.trigger.Flow.builder()
+                    .id("on_b")
+                    .type(io.kestra.plugin.core.trigger.Flow.class.getName())
+                    .dependsOn(List.of(io.kestra.plugin.core.trigger.Flow.Dependency.builder().namespace(TEST_NAMESPACE).flowId(flowBId).build()))
+                    .build()
+            ))
+            .build();
+
+        // When saving flow A closes the A -> B -> A cycle via Flow triggers
+        assertThatThrownBy(() -> flowService.create(GenericFlow.of(flowA)))
+            .isInstanceOf(jakarta.validation.ConstraintViolationException.class)
+            .hasMessageContaining("Cyclic flow dependency detected");
+    }
+
+    @Test
+    void shouldNotRejectTemplatedSubflowEdgeEvenWhenItWouldOtherwiseCloseACycle() throws FlowProcessingException, QueueException {
+        // Given flow B, which unconditionally Subflow-calls flow A
+        String flowAId = IdUtils.create();
+        String flowBId = IdUtils.create();
+        Flow flowB = Flow.builder()
+            .id(flowBId)
+            .tenantId(TenantService.MAIN_TENANT)
+            .namespace(TEST_NAMESPACE)
+            .tasks(List.of(Subflow.builder().id("call").type(Subflow.class.getName()).namespace(TEST_NAMESPACE).flowId(flowAId).build()))
+            .build();
+        flowService.create(GenericFlow.of(flowB));
+        await().atMost(Duration.ofSeconds(10)).until(() -> flowMetaStore.allLastVersion().stream().anyMatch(f -> f.getId().equals(flowBId)));
+
+        // When flow A's Subflow call back to B is templated — unresolvable without executing the flow —
+        Flow flowA = Flow.builder()
+            .id(flowAId)
+            .tenantId(TenantService.MAIN_TENANT)
+            .namespace(TEST_NAMESPACE)
+            .tasks(List.of(Subflow.builder().id("call").type(Subflow.class.getName()).namespace("{{ inputs.ns }}").flowId("{{ inputs.id }}").build()))
+            .build();
+
+        // Then it must not be rejected as a cycle
+        flowService.create(GenericFlow.of(flowA));
+        assertThat(flowRepository.findById(flowA.getTenantId(), flowA.getNamespace(), flowA.getId())).isPresent();
+    }
+
+    @Test
+    void shouldNotRejectConditionalFlowTriggerEdgeEvenWhenItWouldOtherwiseCloseACycle() throws FlowProcessingException, QueueException {
+        // Given flow B, whose Flow trigger unconditionally dependsOn flow A
+        String flowAId = IdUtils.create();
+        String flowBId = IdUtils.create();
+        Flow flowB = Flow.builder()
+            .id(flowBId)
+            .tenantId(TenantService.MAIN_TENANT)
+            .namespace(TEST_NAMESPACE)
+            .tasks(List.of(Return.builder().id("t").type(Return.class.getName()).format(Property.ofValue("b")).build()))
+            .triggers(List.of(
+                io.kestra.plugin.core.trigger.Flow.builder()
+                    .id("on_a")
+                    .type(io.kestra.plugin.core.trigger.Flow.class.getName())
+                    .dependsOn(List.of(io.kestra.plugin.core.trigger.Flow.Dependency.builder().namespace(TEST_NAMESPACE).flowId(flowAId).build()))
+                    .build()
+            ))
+            .build();
+        flowService.create(GenericFlow.of(flowB));
+        await().atMost(Duration.ofSeconds(10)).until(() -> flowMetaStore.allLastVersion().stream().anyMatch(f -> f.getId().equals(flowBId)));
+
+        // When flow A's Flow trigger back to B carries a 'when' — a cycle that may be intentional and
+        // terminating, which this static check cannot decide either way —
+        Flow flowA = Flow.builder()
+            .id(flowAId)
+            .tenantId(TenantService.MAIN_TENANT)
+            .namespace(TEST_NAMESPACE)
+            .tasks(List.of(Return.builder().id("t").type(Return.class.getName()).format(Property.ofValue("a")).build()))
+            .triggers(List.of(
+                io.kestra.plugin.core.trigger.Flow.builder()
+                    .id("on_b")
+                    .type(io.kestra.plugin.core.trigger.Flow.class.getName())
+                    .when("{{ trigger.outputs.state == 'SUCCESS' }}")
+                    .dependsOn(List.of(io.kestra.plugin.core.trigger.Flow.Dependency.builder().namespace(TEST_NAMESPACE).flowId(flowBId).build()))
+                    .build()
+            ))
+            .build();
+
+        // Then it must not be rejected as a cycle here — kestra.execution.depth.max-depth bounds it instead
+        flowService.create(GenericFlow.of(flowA));
+        assertThat(flowRepository.findById(flowA.getTenantId(), flowA.getNamespace(), flowA.getId())).isPresent();
+    }
+
+    @Test
+    void shouldNotRejectCycleWhenTheDependsOnEntryItselfIsConditional() throws FlowProcessingException, QueueException {
+        // Given flow B, whose Flow trigger unconditionally dependsOn flow A
+        String flowAId = IdUtils.create();
+        String flowBId = IdUtils.create();
+        Flow flowB = Flow.builder()
+            .id(flowBId)
+            .tenantId(TenantService.MAIN_TENANT)
+            .namespace(TEST_NAMESPACE)
+            .tasks(List.of(Return.builder().id("t").type(Return.class.getName()).format(Property.ofValue("b")).build()))
+            .triggers(List.of(
+                io.kestra.plugin.core.trigger.Flow.builder()
+                    .id("on_a")
+                    .type(io.kestra.plugin.core.trigger.Flow.class.getName())
+                    .dependsOn(List.of(io.kestra.plugin.core.trigger.Flow.Dependency.builder().namespace(TEST_NAMESPACE).flowId(flowAId).build()))
+                    .build()
+            ))
+            .build();
+        flowService.create(GenericFlow.of(flowB));
+        await().atMost(Duration.ofSeconds(10)).until(() -> flowMetaStore.allLastVersion().stream().anyMatch(f -> f.getId().equals(flowBId)));
+
+        // When flow A's trigger has no 'when' of its own, but the dependsOn entry naming B does —
+        // conditional at the entry level rather than the trigger level, the other place this can hide
+        Flow flowA = Flow.builder()
+            .id(flowAId)
+            .tenantId(TenantService.MAIN_TENANT)
+            .namespace(TEST_NAMESPACE)
+            .tasks(List.of(Return.builder().id("t").type(Return.class.getName()).format(Property.ofValue("a")).build()))
+            .triggers(List.of(
+                io.kestra.plugin.core.trigger.Flow.builder()
+                    .id("on_b")
+                    .type(io.kestra.plugin.core.trigger.Flow.class.getName())
+                    .dependsOn(List.of(
+                        io.kestra.plugin.core.trigger.Flow.Dependency.builder()
+                            .namespace(TEST_NAMESPACE)
+                            .flowId(flowBId)
+                            .when(Property.ofExpression("{{ trigger.outputs.state == 'SUCCESS' }}"))
+                            .build()
+                    ))
+                    .build()
+            ))
+            .build();
+
+        // Then it must not be rejected as a cycle here — kestra.execution.depth.max-depth bounds it instead
+        flowService.create(GenericFlow.of(flowA));
+        assertThat(flowRepository.findById(flowA.getTenantId(), flowA.getNamespace(), flowA.getId())).isPresent();
+    }
+
+    @Test
+    void shouldNotConsiderDraftFlowEdgesWhenCheckingForCycles() throws FlowProcessingException, QueueException {
+        // Given flow B saved as a DRAFT, whose Flow trigger unconditionally dependsOn a not-yet-created
+        // flow A. Drafts skip the cycle check on their own save (like every other validation), but their
+        // edges must also not count when a LATER, unrelated flow is checked: the metastore cache holds
+        // B's draft shape, not its actually-active one — the same distinction
+        // DefaultFlowMetaStore.findById() already draws for a cached draft head.
+        String flowAId = IdUtils.create();
+        String flowBId = IdUtils.create();
+        String draftBSource = """
+            id: %s
+            namespace: %s
+            draft: true
+            tasks:
+              - id: t
+                type: io.kestra.plugin.core.log.Log
+                message: b
+            triggers:
+              - id: on_a
+                type: io.kestra.plugin.core.trigger.Flow
+                dependsOn:
+                  - namespace: %s
+                    flowId: %s
+            """.formatted(flowBId, TEST_NAMESPACE, TEST_NAMESPACE, flowAId);
+        flowService.create(GenericFlow.fromYaml(TenantService.MAIN_TENANT, draftBSource));
+        await().atMost(Duration.ofSeconds(10)).until(() -> flowMetaStore.allLastVersion().stream().anyMatch(f -> f.getId().equals(flowBId)));
+
+        // When flow A's Flow trigger unconditionally dependsOn B — which would close a cycle if B's
+        // draft edge counted
+        Flow flowA = Flow.builder()
+            .id(flowAId)
+            .tenantId(TenantService.MAIN_TENANT)
+            .namespace(TEST_NAMESPACE)
+            .tasks(List.of(Return.builder().id("t").type(Return.class.getName()).format(Property.ofValue("a")).build()))
+            .triggers(List.of(
+                io.kestra.plugin.core.trigger.Flow.builder()
+                    .id("on_b")
+                    .type(io.kestra.plugin.core.trigger.Flow.class.getName())
+                    .dependsOn(List.of(io.kestra.plugin.core.trigger.Flow.Dependency.builder().namespace(TEST_NAMESPACE).flowId(flowBId).build()))
+                    .build()
+            ))
+            .build();
+
+        // Then it must not be rejected — B is still a draft, so its edges do not count yet
+        flowService.create(GenericFlow.of(flowA));
+        assertThat(flowRepository.findById(flowA.getTenantId(), flowA.getNamespace(), flowA.getId())).isPresent();
     }
 
     @Test

--- a/core/src/test/java/io/kestra/core/validations/FlowTriggerValidationTest.java
+++ b/core/src/test/java/io/kestra/core/validations/FlowTriggerValidationTest.java
@@ -1,5 +1,6 @@
 package io.kestra.core.validations;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.junit.jupiter.api.Test;
@@ -103,5 +104,24 @@ class FlowTriggerValidationTest {
         assertThat(valid).isPresent();
         assertThat(valid.get().getConstraintViolations()).hasSize(1);
         assertThat(valid.get().getConstraintViolations().iterator().next().getPropertyPath().toString()).isEqualTo("minSatisfied");
+    }
+
+    @Test
+    void shouldNotBeValidWhenMinSatisfiedAboveDependsOn() {
+        // Given
+        var trigger = Flow.builder()
+            .id("flow-trigger")
+            .type(Flow.class.getName())
+            .dependsOn(List.of())
+            .minSatisfied(1)
+            .build();
+
+        // When
+        Optional<ConstraintViolationException> valid = modelValidator.isValid(trigger);
+
+        // Then
+        assertThat(valid).isPresent();
+        assertThat(valid.get().getConstraintViolations()).hasSize(1);
+        assertThat(valid.get().getMessage()).contains("`minSatisfied` must be lower than or equal to the number of `dependsOn`");
     }
 }

--- a/core/src/test/java/io/kestra/core/validations/FlowTriggerValidationTest.java
+++ b/core/src/test/java/io/kestra/core/validations/FlowTriggerValidationTest.java
@@ -60,6 +60,10 @@ class FlowTriggerValidationTest {
             .type(Flow.class.getName())
             .mode(MultipleCondition.Mode.AT_LEAST)
             .minSatisfied(2)
+            .dependsOn(List.of(
+                Flow.Dependency.builder().build(),
+                Flow.Dependency.builder().build()
+            ))
             .build();
 
         // When

--- a/core/src/test/java/io/kestra/plugin/core/flow/SubflowRunnerTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/flow/SubflowRunnerTest.java
@@ -1,5 +1,6 @@
 package io.kestra.plugin.core.flow;
 
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -11,6 +12,8 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import org.junit.jupiter.api.Test;
 
+import io.micronaut.context.annotation.Property;
+
 import io.kestra.core.executor.command.Create;
 import io.kestra.core.executor.command.ExecutionCommand;
 import io.kestra.core.junit.annotations.KestraTest;
@@ -21,11 +24,14 @@ import io.kestra.core.models.executions.ExecutionId;
 import io.kestra.core.models.executions.ExecutionKind;
 import io.kestra.core.models.executions.LogEntry;
 import io.kestra.core.models.flows.Flow;
+import io.kestra.core.models.flows.FlowInterface;
+import io.kestra.core.models.flows.GenericFlow;
 import io.kestra.core.models.flows.State;
 import io.kestra.core.queues.*;
 import io.kestra.core.repositories.ExecutionRepositoryInterface;
 import io.kestra.core.repositories.FlowRepositoryInterface;
 import io.kestra.core.runners.ExecutionEventType;
+import io.kestra.core.runners.FlowMetaStoreInterface;
 import io.kestra.core.runners.FollowExecutionEvent;
 import io.kestra.core.runners.TestRunnerUtils;
 import io.kestra.core.services.TaskOutputService;
@@ -35,9 +41,11 @@ import jakarta.inject.Inject;
 
 import static io.kestra.core.tenant.TenantService.MAIN_TENANT;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @KestraTest(startRunner = true)
+@Property(name = "kestra.execution.depth.max-depth", value = "3")
 class SubflowRunnerTest {
 
     @Inject
@@ -48,6 +56,12 @@ class SubflowRunnerTest {
 
     @Inject
     private FlowRepositoryInterface flowRepository;
+
+    @Inject
+    private FlowMetaStoreInterface flowMetaStore;
+
+    @Inject
+    protected BroadcastQueueInterface<FlowInterface> flowQueue;
 
     @Inject
     protected BroadcastQueueInterface<FollowExecutionEvent> executionEventQueue;
@@ -199,6 +213,39 @@ class SubflowRunnerTest {
         assertTrue(grandChildExecution.isPresent());
         assertThat(grandChildExecution.get().getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
         assertThat(grandChildExecution.get().getTaskRunList()).hasSize(1);
+    }
+
+    @Test
+    void shouldFailRatherThanRecurseForeverWhenTwoFlowsSubflowEachOther() throws QueueException, TimeoutException {
+        // Given two flows that Subflow-call each other. FlowService.create() now rejects this shape (see FlowServiceTest),
+        // so the pair is seeded directly through the repository and flow queue, bypassing that save-time check.
+        String flowAId = IdUtils.create();
+        String flowBId = IdUtils.create();
+        Flow flowA = Flow.builder()
+            .id(flowAId)
+            .tenantId(MAIN_TENANT)
+            .namespace("io.kestra.tests")
+            .tasks(List.of(Subflow.builder().id("call").type(Subflow.class.getName()).namespace("io.kestra.tests").flowId(flowBId).build()))
+            .build();
+        Flow flowB = Flow.builder()
+            .id(flowBId)
+            .tenantId(MAIN_TENANT)
+            .namespace("io.kestra.tests")
+            .tasks(List.of(Subflow.builder().id("call").type(Subflow.class.getName()).namespace("io.kestra.tests").flowId(flowAId).build()))
+            .build();
+        flowRepository.create(GenericFlow.of(flowA));
+        flowRepository.create(GenericFlow.of(flowB));
+        flowQueue.emit(flowA);
+        flowQueue.emit(flowB);
+        await().atMost(Duration.ofSeconds(10)).until(() ->
+            flowMetaStore.allLastVersion().stream().anyMatch(f -> f.getId().equals(flowAId))
+                && flowMetaStore.allLastVersion().stream().anyMatch(f -> f.getId().equals(flowBId)));
+
+        // When
+        Execution execution = runnerUtils.runOne(flowA, null);
+
+        // Then the chain is stopped rather than left to recurse forever
+        assertThat(execution.getState().getCurrent()).isEqualTo(State.Type.FAILED);
     }
 
     @Test

--- a/executor/src/main/java/io/kestra/executor/FlowTriggerService.java
+++ b/executor/src/main/java/io/kestra/executor/FlowTriggerService.java
@@ -22,6 +22,7 @@ import io.kestra.core.runners.FlowMetaStores;
 import io.kestra.core.runners.RunContext;
 import io.kestra.core.runners.RunContextFactory;
 import io.kestra.core.runners.TransactionContext;
+import io.kestra.core.runners.configuration.ExecutionDepthConfiguration;
 import io.kestra.core.services.ConditionService;
 import io.kestra.core.services.ExecutionOutputService;
 import io.kestra.core.services.FlowService;
@@ -42,13 +43,16 @@ public class FlowTriggerService {
     private final FlowService flowService;
     private final FlowMetaStoreInterface flowMetaStore;
     private final ExecutionOutputService executionOutputService;
+    private final ExecutionDepthConfiguration executionDepthConfiguration;
 
-    public FlowTriggerService(ConditionService conditionService, RunContextFactory runContextFactory, FlowService flowService, FlowMetaStoreInterface flowMetaStore, ExecutionOutputService executionOutputService) {
+    public FlowTriggerService(ConditionService conditionService, RunContextFactory runContextFactory, FlowService flowService, FlowMetaStoreInterface flowMetaStore, ExecutionOutputService executionOutputService,
+        ExecutionDepthConfiguration executionDepthConfiguration) {
         this.conditionService = conditionService;
         this.runContextFactory = runContextFactory;
         this.flowService = flowService;
         this.flowMetaStore = flowMetaStore;
         this.executionOutputService = executionOutputService;
+        this.executionDepthConfiguration = executionDepthConfiguration;
     }
 
     public Stream<FlowWithFlowTrigger> withFlowTriggersOnly(Stream<FlowWithSource> allFlows) {
@@ -249,6 +253,21 @@ public class FlowTriggerService {
         }
 
         RunContext runContext = runContextFactory.of(null, execution);
+
+        int nextDepth = execution.getMetadata().executionDepthOrZero() + 1;
+        if (nextDepth > executionDepthConfiguration.maxDepth()) {
+            // Backstop against a cross-flow execution cycle that save-time validation cannot see (e.g. a
+            // conditional Flow trigger loop): drop the trigger instead of creating another execution,
+            // and surface it where the user is already looking rather than failing silently.
+            runContext.logger().warn(
+                "Flow trigger on '{}.{}' was not evaluated: the execution chain exceeded the maximum depth of {}. You can increase the maximum depth by setting the 'kestra.execution.depth.max-depth' property.",
+                flow.getNamespace(),
+                flow.getId(),
+                executionDepthConfiguration.maxDepth()
+            );
+            return Collections.emptyList();
+        }
+
         return flowTriggers(flow).map(trigger -> new FlowWithFlowTrigger(flow, trigger))
             // filter on the execution state the flow listen to
             .filter(flowWithFlowTrigger -> flowWithFlowTrigger.getTrigger().getStates().contains(execution.getState().getCurrent()))

--- a/executor/src/main/java/io/kestra/executor/handler/MultipleConditionEventMessageHandler.java
+++ b/executor/src/main/java/io/kestra/executor/handler/MultipleConditionEventMessageHandler.java
@@ -53,7 +53,8 @@ public class MultipleConditionEventMessageHandler implements MessageHandler<Mult
                         .withKind(exec.getKind())
                         .withTrigger(exec.getTrigger())
                         .withLabels(exec.getLabels())
-                        .withInputs(exec.getInputs());
+                        .withInputs(exec.getInputs())
+                        .withExecutionDepth(exec.getMetadata().getExecutionDepth());
                     // Preserve terminal state (e.g. FAILED when trigger input rendering fails).
                     if (exec.getState().isTerminated()) {
                         cmd = cmd.withStateType(exec.getState().getCurrent());

--- a/executor/src/test/java/io/kestra/executor/FlowTriggerServiceTest.java
+++ b/executor/src/test/java/io/kestra/executor/FlowTriggerServiceTest.java
@@ -24,6 +24,7 @@ import io.kestra.core.models.triggers.multipleflows.MultipleConditionWindow;
 import io.kestra.core.runners.FlowMetaStoreInterface;
 import io.kestra.core.runners.ProcessedFlow;
 import io.kestra.core.runners.TransactionContext;
+import io.kestra.core.runners.configuration.ExecutionDepthConfiguration;
 import io.kestra.core.services.ConditionService;
 import io.kestra.core.services.ExecutionOutputService;
 import io.kestra.core.services.FlowService;
@@ -54,13 +55,15 @@ class FlowTriggerServiceTest {
     private FlowService flowService;
     @Inject
     private ExecutionOutputService executionOutputService;
+    @Inject
+    private ExecutionDepthConfiguration executionDepthConfiguration;
     private FlowMetaStoreInterface flowMetaStore;
     private FlowTriggerService flowTriggerService;
 
     @BeforeEach
     void setUp() {
         flowMetaStore = mock(FlowMetaStoreInterface.class);
-        flowTriggerService = new FlowTriggerService(conditionService, runContextFactory, flowService, flowMetaStore, executionOutputService);
+        flowTriggerService = new FlowTriggerService(conditionService, runContextFactory, flowService, flowMetaStore, executionOutputService, executionDepthConfiguration);
     }
 
     @Test
@@ -389,6 +392,33 @@ class FlowTriggerServiceTest {
         // Then the triggered execution stays on the upstream correlation instead of starting a new one
         assertThat(resultingExecutionsToRun).hasSize(1);
         assertThat(resultingExecutionsToRun.getFirst().getLabels()).contains(new Label(Label.CORRELATION_ID, correlationId));
+    }
+
+    @Test
+    void shouldIncrementExecutionDepthOnExecutionsComputedFromFlowTriggers() {
+        // Given an upstream execution three hops into its chain
+        var upstream = Execution.newExecution(aSimpleFlow(), EMPTY_LABELS).withState(State.Type.SUCCESS);
+        upstream = upstream.withMetadata(upstream.getMetadata().withExecutionDepth(3));
+
+        // When
+        var resultingExecutionsToRun = flowTriggerService.computeExecutionsFromFlowTriggerConditions(upstream, flowWithFlowTrigger());
+
+        // Then the triggered execution is one hop further than its cause, not a fresh root
+        assertThat(resultingExecutionsToRun).hasSize(1);
+        assertThat(resultingExecutionsToRun.getFirst().getMetadata().getExecutionDepth()).isEqualTo(4);
+    }
+
+    @Test
+    void shouldDropFlowTriggerWhenExecutionChainExceedsMaxDepth() {
+        // Given an upstream execution already at the configured cap
+        var upstream = Execution.newExecution(aSimpleFlow(), EMPTY_LABELS).withState(State.Type.SUCCESS);
+        upstream = upstream.withMetadata(upstream.getMetadata().withExecutionDepth(executionDepthConfiguration.maxDepth()));
+
+        // When
+        var resultingExecutionsToRun = flowTriggerService.computeExecutionsFromFlowTriggerConditions(upstream, flowWithFlowTrigger());
+
+        // Then the trigger is dropped rather than extending an unbounded chain
+        assertThat(resultingExecutionsToRun).isEmpty();
     }
 
     private static Flow flowWithFlowTrigger() {

--- a/executor/src/test/java/io/kestra/executor/handler/MultipleConditionEventMessageHandlerTest.java
+++ b/executor/src/test/java/io/kestra/executor/handler/MultipleConditionEventMessageHandlerTest.java
@@ -1,17 +1,31 @@
 package io.kestra.executor.handler;
 
 import java.util.Collections;
+import java.util.List;
 
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 
+import io.kestra.core.executor.command.Create;
+import io.kestra.core.executor.command.ExecutionCommand;
 import io.kestra.core.junit.annotations.KestraTest;
 import io.kestra.core.models.executions.Execution;
 import io.kestra.core.models.flows.GenericFlow;
+import io.kestra.core.models.triggers.multipleflows.MultipleConditionStateStore;
+import io.kestra.core.queues.DispatchQueueInterface;
+import io.kestra.core.queues.QueueException;
 import io.kestra.core.repositories.ExecutionRepositoryInterface;
 import io.kestra.core.repositories.FlowRepositoryInterface;
 import io.kestra.core.runners.MultipleConditionEvent;
+import io.kestra.executor.FlowTriggerService;
 
 import jakarta.inject.Inject;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @KestraTest
 class MultipleConditionEventMessageHandlerTest {
@@ -33,5 +47,32 @@ class MultipleConditionEventMessageHandlerTest {
         var multipleConditionEvent = new MultipleConditionEvent(flow, execution);
 
         multipleConditionEventMessageHandler.handle(multipleConditionEvent);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    void shouldCarryExecutionDepthAcrossToTheCreateCommand() throws QueueException {
+        // Given a trigger evaluation that already carries a non-zero execution depth — this is the
+        // hop MultipleConditionEventMessageHandler must not drop when it rebuilds the Execution
+        // returned by FlowTriggerService into a Create command (see Flow.evaluate/FlowTriggerService,
+        // which is where the depth is actually computed; the mock here just stands in for that)
+        var flow = Fixtures.flow();
+        var upstream = Execution.newExecution(flow, Collections.emptyList());
+        var triggered = Execution.newExecution(flow, Collections.emptyList());
+        triggered = triggered.withMetadata(triggered.getMetadata().withExecutionDepth(4));
+
+        FlowTriggerService flowTriggerService = mock(FlowTriggerService.class);
+        when(flowTriggerService.computeExecutionsFromFlowTriggerDependsOn(any(), any(), any())).thenReturn(List.of(triggered));
+        MultipleConditionStateStore multipleConditionStateStore = mock(MultipleConditionStateStore.class);
+        DispatchQueueInterface<ExecutionCommand> executionCommandQueue = mock(DispatchQueueInterface.class);
+        var handler = new MultipleConditionEventMessageHandler(flowTriggerService, multipleConditionStateStore, executionCommandQueue);
+
+        // When
+        handler.handle(new MultipleConditionEvent(flow, upstream));
+
+        // Then the Create command carries the depth onward, rather than resetting it to a fresh root
+        ArgumentCaptor<ExecutionCommand> captor = ArgumentCaptor.forClass(ExecutionCommand.class);
+        verify(executionCommandQueue).emit(captor.capture());
+        assertThat(((Create) captor.getValue()).executionDepth()).isEqualTo(4);
     }
 }


### PR DESCRIPTION
Closes https://github.com/kestra-io/kestra/issues/18492.
Fixes kestra-io/kestra-ee#10271.
Fixes https://github.com/kestra-io/kestra-ee/issues/10117

## Problem

Three related trigger/flow-safety gaps:

1. **`minSatisfied` validation.** A Flow trigger's `dependsOn` in `AT_LEAST` mode accepted a `minSatisfied` greater than the number of `dependsOn` entries, so the condition could never be satisfied and the trigger would silently never fire.
2. **Unbounded cross-flow execution storm.** Two flows whose Flow triggers `dependsOn` each other (or whose Subflow tasks call each other) pass every existing save-time check — both only reject a flow triggering/calling *itself* directly — and then recurse without bound at runtime: every execution of one causes an execution of the other, forever, until the flows are deleted.

## Fix

1. `FlowTriggerValidator` now rejects a save where `minSatisfied` exceeds the number of `dependsOn` entries.
2. Two complementary layers for the execution storm, since a save-time check alone cannot see every cycle (e.g. one gated by a condition) or protect flows saved before it existed:
   - **Runtime backstop.** An `executionDepth` counter carried in `Execution.metadata` (deliberately not a label, so it never surfaces as a UI chip), incremented at every Subflow-task and Flow-trigger child-execution site and capped at `kestra.execution.depth.max-depth` (default 100, generous — this guards a cycle rather than bounding normal nesting).
   - **Save-time rejection (the primary fix).** `FlowService` now builds the cross-flow graph of *unconditional* Subflow-task and Flow-trigger `dependsOn` edges across the tenant and rejects a save that would close a cycle back to the flow being saved, with a 422 naming the cycle (e.g. `bug.bash.tflow_a → bug.bash.tflow_b → bug.bash.tflow_a`). Only unconditional edges count: a cycle gated by a `when`/`runIf` may be intentional and terminating, and this check cannot decide whether the condition ever goes false — the runtime cap bounds that case instead.