### PR TITLE
fix(core): reject restart of a PAUSED execution

### DIFF
--- a/core/src/main/java/io/kestra/core/models/flows/State.java
+++ b/core/src/main/java/io/kestra/core/models/flows/State.java
@@ -161,9 +161,13 @@ public class State {
         return this.current.isTerminated();
     }
 
+    /**
+     * A PAUSED execution cannot be restarted: it must be resumed or killed instead.
+     * Restarting it would resume the Pause task without any resume information, leading to a failed execution.
+     */
     @JsonIgnore
     public boolean canBeRestarted() {
-        return (this.current.isTerminated() || this.current.isPaused()) && !this.current.isKilled();
+        return this.current.isTerminated() && !this.current.isKilled();
     }
 
     @JsonIgnore

--- a/core/src/main/java/io/kestra/core/services/ExecutionService.java
+++ b/core/src/main/java/io/kestra/core/services/ExecutionService.java
@@ -227,8 +227,9 @@ public class ExecutionService {
     public Execution restart(final Execution execution, @Nullable Integer revision) throws Exception {
         if (!execution.getState().canBeRestarted()) {
             throw new IllegalStateException(
-                "Execution must be terminated or paused and not killed to be restarted, " +
-                    "current state is '" + execution.getState().getCurrent() + "' !"
+                "Execution must be terminated and not killed to be restarted, " +
+                    "current state is '" + execution.getState().getCurrent() + "' ! " +
+                    "A paused execution can only be resumed or killed."
             );
         }
 

--- a/core/src/test/java/io/kestra/core/runners/ExecutionServiceTest.java
+++ b/core/src/test/java/io/kestra/core/runners/ExecutionServiceTest.java
@@ -502,6 +502,22 @@ class ExecutionServiceTest {
     }
 
     @Test
+    @LoadFlows({ "flows/valids/pause-test.yaml" })
+    void shouldNotRestartPausedExecution() throws Exception {
+        Execution execution = runnerUtils.runOneUntilPaused(MAIN_TENANT, "io.kestra.tests", "pause-test");
+
+        assertThat(execution.getState().getCurrent()).isEqualTo(State.Type.PAUSED);
+
+        // a PAUSED execution must be resumed or killed, restarting it would lose the pause information
+        IllegalStateException exception = assertThrows(
+            IllegalStateException.class,
+            () -> executionService.restart(execution, null)
+        );
+
+        assertThat(exception.getMessage()).contains("current state is 'PAUSED'");
+    }
+
+    @Test
     @ExecuteFlow("flows/valids/failed-first.yaml")
     void shouldRestartAfterChangeTaskState(Execution execution) throws Exception {
         assertThat(execution.getState().getCurrent()).isEqualTo(State.Type.FAILED);

--- a/webserver/src/main/java/io/kestra/webserver/controllers/api/ExecutionController.java
+++ b/webserver/src/main/java/io/kestra/webserver/controllers/api/ExecutionController.java
@@ -1077,7 +1077,7 @@ public class ExecutionController {
             if (execution.isPresent() && !execution.get().getState().canBeRestarted()) {
                 invalids.add(
                     ManualConstraintViolation.of(
-                        "execution not in state PAUSED or terminated, or is KILLED",
+                        "execution not terminated or is KILLED, a paused execution can only be resumed or killed",
                         executionId,
                         String.class,
                         "execution",

--- a/webserver/src/test/java/io/kestra/webserver/controllers/api/ExecutionControllerRunnerTest.java
+++ b/webserver/src/test/java/io/kestra/webserver/controllers/api/ExecutionControllerRunnerTest.java
@@ -2627,6 +2627,40 @@ class ExecutionControllerRunnerTest {
 
     @Test
     @LoadFlowsWithTenant({ "flows/valids/pause-test.yaml" })
+    void restartExecutionShouldFailForPaused(String tenantId) throws QueueException {
+        when(tenantService.resolveTenant()).thenReturn(tenantId);
+        Execution pausedExecution = runnerUtils.runOneUntilPaused(tenantId, TESTS_FLOW_NS, "pause-test");
+        assertThat(pausedExecution.getState().isPaused()).isTrue();
+
+        // a paused execution can only be resumed or killed
+        HttpClientResponseException e = assertThrows(
+            HttpClientResponseException.class,
+            () -> client.toBlocking().retrieve(
+                POST(
+                    "/api/v1/%s/executions/restart/by-ids".formatted(tenantId),
+                    List.of(pausedExecution.getId())
+                ),
+                MutableHttpResponse.class
+            )
+        );
+
+        assertThat(e.getStatus().getCode()).isEqualTo(HttpStatus.BAD_REQUEST.getCode());
+        Optional<String> bulkErrorResponse = e.getResponse().getBody(String.class);
+        assertThat(bulkErrorResponse).isPresent();
+        assertThat(bulkErrorResponse.get()).contains("execution not terminated or is KILLED, a paused execution can only be resumed or killed");
+
+        // the execution is left untouched, so it can still be resumed
+        HttpResponse<?> resumeResponse = client.toBlocking().exchange(
+            POST("/api/v1/%s/executions/%s/resume".formatted(tenantId, pausedExecution.getId()), null)
+        );
+        assertThat(resumeResponse.getStatus().getCode()).isEqualTo(HttpStatus.NO_CONTENT.getCode());
+
+        Execution resumed = awaitExecution(pausedExecution.getId(), exec -> exec.getState().getCurrent() == State.Type.SUCCESS);
+        assertThat(resumed.getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
+    }
+
+    @Test
+    @LoadFlowsWithTenant({ "flows/valids/pause-test.yaml" })
     void restartExecutionShouldFailForKilled(String tenantId) throws QueueException {
         when(tenantService.resolveTenant()).thenReturn(tenantId);
         Execution pausedExecution = runnerUtils.runOneUntilPaused(tenantId, TESTS_FLOW_NS, "pause-test");
@@ -2650,7 +2684,7 @@ class ExecutionControllerRunnerTest {
         );
 
         assertThat(e.getStatus().getCode()).isEqualTo(HttpStatus.CONFLICT.getCode());
-        assertThat(e.getMessage()).contains("Illegal state: Execution must be terminated or paused and not killed to be restarted, current state is 'KILLED' !");
+        assertThat(e.getMessage()).contains("Illegal state: Execution must be terminated and not killed to be restarted, current state is 'KILLED' !");
 
         e = assertThrows(
             HttpClientResponseException.class,
@@ -2666,7 +2700,7 @@ class ExecutionControllerRunnerTest {
         assertThat(e.getStatus().getCode()).isEqualTo(HttpStatus.BAD_REQUEST.getCode());
         Optional<String> bulkErrorResponse = e.getResponse().getBody(String.class);
         assertThat(bulkErrorResponse).isPresent();
-        assertThat(bulkErrorResponse.get()).contains("execution not in state PAUSED or terminated, or is KILLED");
+        assertThat(bulkErrorResponse.get()).contains("execution not terminated or is KILLED, a paused execution can only be resumed or killed");
 
         e = assertThrows(
             HttpClientResponseException.class,
@@ -2682,7 +2716,7 @@ class ExecutionControllerRunnerTest {
         assertThat(e.getStatus().getCode()).isEqualTo(HttpStatus.BAD_REQUEST.getCode());
         bulkErrorResponse = e.getResponse().getBody(String.class);
         assertThat(bulkErrorResponse).isPresent();
-        assertThat(bulkErrorResponse.get()).contains("execution not in state PAUSED or terminated, or is KILLED");
+        assertThat(bulkErrorResponse.get()).contains("execution not terminated or is KILLED, a paused execution can only be resumed or killed");
     }
 
     @Test


### PR DESCRIPTION
### ✨ Description

It was possible to Restart a PAUSED execution via bulk actions. Such execution would attempt to resume but end up failing instead with:

```text
19:16:01.964 INFO  jdbc-execution-executor_6 e.main.company.team.manatee_770745 [tenant: main] [namespace: company.team] [flow: manatee_770745] [execution: 6TXTiyCrvsmAoak0KeQ1aM] Flow restarted
19:16:01.837 WARN  jdbc-execution-executor_6 io.kestra.executor.ExecutorService Unable to resolve the next tasks to run
java.lang.NullPointerException: Cannot invoke "java.util.Map.isEmpty()" because "resumed" is null
        at io.kestra.plugin.core.flow.Pause.findTerminalState(Pause.java:287)
        at io.kestra.plugin.core.flow.Pause.resolveNexts(Pause.java:273)
        at io.kestra.executor.ExecutorService.childNextsTaskRun(ExecutorService.java:368)
        at io.kestra.executor.ExecutorService.handleChildNext(ExecutorService.java:513)
        at io.kestra.executor.ExecutorService.process(ExecutorService.java:190)
        at io.kestra.jdbc.runner.JdbcExecutor.lambda$executionQueue$1(JdbcExecutor.java:689)
        at io.kestra.core.trace.NoopTracer.inCurrentContext(NoopTracer.java:21)
        at io.kestra.jdbc.runner.JdbcExecutor.lambda$executionQueue$0(JdbcExecutor.java:610)
        at io.kestra.jdbc.repository.AbstractJdbcExecutionRepository.lambda$lock$0(AbstractJdbcExecutionRepository.java:930)
        at org.jooq.impl.DefaultDSLContext.lambda$transactionResult0$3(DefaultDSLContext.java:533)
        at org.jooq.impl.Tools$3$1.block(Tools.java:6402)
        at java.base/java.util.concurrent.ForkJoinPool.unmanagedBlock(ForkJoinPool.java:4364)
        at java.base/java.util.concurrent.ForkJoinPool.managedBlock(ForkJoinPool.java:4310)
        at org.jooq.impl.Tools$3.get(Tools.java:6399)
        at org.jooq.impl.DefaultDSLContext.transactionResult0(DefaultDSLContext.java:581)
        at org.jooq.impl.DefaultDSLContext.transactionResult(DefaultDSLContext.java:504)
        at io.kestra.jdbc.JooqDSLContextWrapper.lambda$transactionResult$0(JooqDSLContextWrapper.java:76)
        at dev.failsafe.Functions.lambda$toCtxSupplier$11(Functions.java:243)
        at dev.failsafe.Functions.lambda$get$0(Functions.java:46)
        at dev.failsafe.internal.RetryPolicyExecutor.lambda$apply$0(RetryPolicyExecutor.java:74)
        at dev.failsafe.internal.FallbackExecutor.lambda$apply$0(FallbackExecutor.java:51)
        at dev.failsafe.SyncExecutionImpl.executeSync(SyncExecutionImpl.java:187)
        at dev.failsafe.FailsafeExecutor.call(FailsafeExecutor.java:376)
        at dev.failsafe.FailsafeExecutor.get(FailsafeExecutor.java:112)
        at io.kestra.core.utils.RetryUtils$Instance.wrap(RetryUtils.java:147)
        at io.kestra.core.utils.RetryUtils$Instance.runRetryIf(RetryUtils.java:106)
        at io.kestra.jdbc.JooqDSLContextWrapper.transactionResult(JooqDSLContextWrapper.java:74)
        at io.kestra.jdbc.repository.AbstractJdbcExecutionRepository.lock(AbstractJdbcExecutionRepository.java:911)
        at io.kestra.jdbc.runner.JdbcExecutor.executionQueue(JdbcExecutor.java:605)
        at java.base/java.util.ArrayList.forEach(ArrayList.java:1604)
        at io.kestra.jdbc.runner.JdbcExecutor.lambda$run$5(JdbcExecutor.java:318)
        at java.base/java.util.concurrent.CompletableFuture$AsyncRun.run(CompletableFuture.java:1825)
        at io.micrometer.core.instrument.internal.TimedRunnable.run(TimedRunnable.java:49)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1090)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:614)
        at java.base/java.lang.Thread.run(Thread.java:1474)
```

The [Execution States](https://kestra.io/docs/workflow-components/states#execution-states) docs mention only Resume for PAUSED executions.

---

Restarting a PAUSED execution remapped the Pause taskrun to RUNNING while keeping its PAUSED history, so `Pause.findTerminalState()` read a `null` 'resumed' output and the executor panicked the execution to FAILED. A PAUSED execution can only be resumed or killed, so both the single and the bulk restart endpoints now reject it.

### 🛠️ Backend Checklist

<!-- If this PR does not include any backend changes, delete this entire section. -->

- [x] Code compiles and tests pass for the touched modules (`./gradlew :module-name:test`, or `./gradlew build` for cross-module changes)
- [x] New behavior is covered by unit or integration tests

### 📝 Additional Notes

Regular UI actions already did not allow for restarting a PAUSED execution.
