### PR TITLE
build(ui): unify the dev-server proxy target under VITE_PROXY_URL

### DIFF
--- a/ui/README.md
+++ b/ui/README.md
@@ -9,7 +9,7 @@ Kestra UI is running using [Vite](https://vite.dev/).
 ### Development:
 - (Optional) By default, your dev server will target `localhost:8080`. If your backend is running elsewhere, you can create `.env.development.local` under `ui` folder with this content:
 ```
-VITE_APP_API_URL={myApiUrl}
+VITE_PROXY_URL={myApiUrl}
 ```
 
 - Navigate into the `ui` folder and run `npm install` to install the dependencies for the frontend project.

--- a/ui/vite.config.js
+++ b/ui/vite.config.js
@@ -66,7 +66,7 @@ export default defineConfig(({mode}) => {
             },
             proxy: {
                 "^/api": {
-                    target: process.env.VITE_APP_LOGIN_URL || "http://localhost:8080",
+                    target: process.env.VITE_PROXY_URL || "http://localhost:8080",
                     ws: true,
                     changeOrigin: true,
                 },
@@ -74,7 +74,7 @@ export default defineConfig(({mode}) => {
                 // OpenAPI spec (${context-path}/swagger/kestra.yml) to compare its hash. Dev-only;
                 // the check itself is tree-shaken from production builds.
                 "^/swagger": {
-                    target: process.env.VITE_APP_LOGIN_URL || "http://localhost:8080",
+                    target: process.env.VITE_PROXY_URL || "http://localhost:8080",
                     changeOrigin: true,
                 },
             },


### PR DESCRIPTION
### 🔗 Related Issue

None — spotted while setting up a dev environment against a remote backend.

### ✨ Description

`ui/README.md` told contributors to create `.env.development.local` with `VITE_APP_API_URL={myApiUrl}` to point the dev server at a backend other than `localhost:8080`. The Vite dev-server proxy actually read `VITE_APP_LOGIN_URL`, so following the README had no effect: `/api` and `/swagger` kept being proxied to `localhost:8080`.

Both the proxy targets and the README now use a single, purpose-named variable, `VITE_PROXY_URL`. `VITE_APP_API_URL` is left untouched where it is genuinely used (`ui/src/override/utils/route.ts`, the app's runtime API base path) — it was only the README that conflated it with the dev proxy.

Evidence: with `VITE_PROXY_URL` set in `.env.development.local`, `npm run dev` proxies `/api` and `/swagger` to that host; before the change the same file was ignored.

### 🎨 Frontend Checklist

- [x] Code builds without errors (`npm run build`)
- [x] Unit tests pass (`npm run test:unit`)

No `en.json` change, and no user-visible UI change to screenshot — this is dev-server configuration only.

### 📝 Additional Notes

Anyone who already has a working `.env.development.local` with `VITE_APP_LOGIN_URL` will need to rename the key to `VITE_PROXY_URL`. That file is gitignored and local to each contributor.

### 🤖 AI Authors

Why did the cat sit on the keyboard? It heard the dev server had a `proxy` and wanted to be the one deciding where the requests go. 🐱