### PR TITLE
fix(assets): mark External as internal so it cannot be user-declared

### DIFF
--- a/ui/src/components/flows/FlowRun.vue
+++ b/ui/src/components/flows/FlowRun.vue
@@ -150,7 +150,7 @@
         return style.toLowerCase() as AlertType
     }
 
-    interface ReplaySubmitOptions {
+    export interface ReplaySubmitOptions {
         formRef: FormInstance
         id: string
         namespace: string

--- a/ui/src/components/flows/TriggerFlow.vue
+++ b/ui/src/components/flows/TriggerFlow.vue
@@ -1,15 +1,17 @@
 <template>
     <div class="trigger-flow-wrapper">
         <span data-onboarding-target="flow-execute-button">
-            <KsButton
-                :id="actionId"
-                :icon="PlayOutlineIcon"
-                :type="type"
-                :disabled="actionDisabled"
-                @click="runAction()"
-            >
-                {{ actionLabel }}
-            </KsButton>
+            <slot name="button" :execute="runAction" :disabled="actionDisabled">
+                <KsButton
+                    :id="actionId"
+                    :icon="PlayOutlineIcon"
+                    :type="type"
+                    :disabled="actionDisabled"
+                    @click="runAction()"
+                >
+                    {{ actionLabel }}
+                </KsButton>
+            </slot>
         </span>
         <KsDialog
             id="execute-flow-dialog"
@@ -24,7 +26,7 @@
             <template #header>
                 <span v-html="$t('execute the flow', {id: flowId})" />
             </template>
-            <FlowRun ref="flowRunRef" :embed="true" @execution-trigger="handleExecutionStart" :redirect="!playgroundStore.enabled" />
+            <FlowRun ref="flowRunRef" :embed="true" :replaySubmit="submit" @execution-trigger="handleExecutionStart" :redirect="!playgroundStore.enabled" />
             <template #footer>
                 <FlowRunActions :flowRun="flowRunRef" />
             </template>
@@ -92,7 +94,7 @@
     import {useExecutionsStore} from "../../stores/executions"
     import {usePlaygroundStore} from "../../stores/playground"
     import {useFlowStore} from "../../stores/flow"
-    import FlowRun from "./FlowRun.vue"
+    import FlowRun, {type ReplaySubmitOptions} from "./FlowRun.vue"
     import FlowRunActions from "./FlowRunActions.vue"
     import FlowWarningDialog from "./FlowWarningDialog.vue"
     import PlayOutlineIcon from "vue-material-design-icons/PlayOutline.vue"
@@ -109,10 +111,14 @@
         disabled?: boolean
         type?: "default" | "primary" | "success" | "warning" | "info" | "danger" | "text" | ""
         flowSource?: string | null
+        submit?: ((options: ReplaySubmitOptions) => void | Promise<void>) | null
+        lazy?: boolean
     }>(), {
         disabled: false,
         type: "primary",
         flowSource: null,
+        submit: null,
+        lazy: false,
     })
 
     const {t} = useI18n({useScope: "global"})
@@ -270,7 +276,7 @@
             
             loadDefinition()
         },
-        {immediate: true},
+        {immediate: !props.lazy},
     )
 
     watch(

--- a/ui/tests/unit/components/flows/TriggerFlow.spec.ts
+++ b/ui/tests/unit/components/flows/TriggerFlow.spec.ts
@@ -1,0 +1,91 @@
+import {describe, it, expect, vi} from "vitest"
+import {shallowMount} from "@vue/test-utils"
+import {createI18n} from "vue-i18n"
+
+const loadFlowForExecution = vi.fn().mockResolvedValue(undefined)
+
+vi.mock("../../../../src/stores/api", () => ({
+    useApiStore: () => ({posthogEvents: vi.fn()}),
+}))
+
+vi.mock("../../../../src/stores/executions", () => ({
+    useExecutionsStore: () => ({flow: undefined, loadFlowForExecution, loadNamespaces: vi.fn(), flowsExecutable: [], namespaces: []}),
+}))
+
+vi.mock("../../../../src/stores/playground", () => ({
+    usePlaygroundStore: () => ({enabled: false}),
+}))
+
+vi.mock("../../../../src/stores/flow", () => ({
+    useFlowStore: () => ({executeFlow: false}),
+}))
+
+import TriggerFlow from "../../../../src/components/flows/TriggerFlow.vue"
+import FlowRun from "../../../../src/components/flows/FlowRun.vue"
+
+const i18n = createI18n({legacy: false, locale: "en", missingWarn: false, fallbackWarn: false, messages: {en: {}}})
+
+function mountTriggerFlow(props: Record<string, unknown> = {}, slots: Record<string, unknown> = {}) {
+    return shallowMount(TriggerFlow, {
+        props: {flowId: "my_flow", namespace: "company.team", ...props},
+        slots,
+        global: {plugins: [i18n]},
+    })
+}
+
+describe("TriggerFlow — submit override", () => {
+    it("forwards the submit prop to FlowRun as replaySubmit", () => {
+        const submit = vi.fn()
+        const wrapper = mountTriggerFlow({submit})
+
+        expect(wrapper.findComponent(FlowRun).props("replaySubmit")).toBe(submit)
+    })
+
+    it("defaults to the normal execute path (replaySubmit unset) when no submit override is given", () => {
+        const wrapper = mountTriggerFlow()
+
+        expect(wrapper.findComponent(FlowRun).props("replaySubmit")).toBeFalsy()
+    })
+})
+
+describe("TriggerFlow — lazy loading", () => {
+    it("does not load the flow on mount when lazy", () => {
+        loadFlowForExecution.mockClear()
+        mountTriggerFlow({lazy: true})
+
+        expect(loadFlowForExecution).not.toHaveBeenCalled()
+    })
+
+    it("loads the flow on click when lazy", async () => {
+        loadFlowForExecution.mockClear()
+        const wrapper = mountTriggerFlow({lazy: true})
+
+        await wrapper.find("#execute-button").trigger("click")
+
+        expect(loadFlowForExecution).toHaveBeenCalledWith({flowId: "my_flow", namespace: "company.team", store: true})
+    })
+
+    it("loads the flow on mount when not lazy (default, unchanged behavior)", () => {
+        loadFlowForExecution.mockClear()
+        mountTriggerFlow()
+
+        expect(loadFlowForExecution).toHaveBeenCalledWith({flowId: "my_flow", namespace: "company.team", store: true})
+    })
+})
+
+describe("TriggerFlow — #button slot", () => {
+    it("renders the slot content instead of the default button, and its execute opens the dialog", async () => {
+        loadFlowForExecution.mockClear()
+        const wrapper = mountTriggerFlow({lazy: true}, {
+            button: "<template #button=\"{execute}\"><button class=\"custom-trigger\" @click=\"execute()\">Run it</button></template>",
+        })
+
+        expect(wrapper.find("#execute-button").exists()).toBe(false)
+        const custom = wrapper.find(".custom-trigger")
+        expect(custom.exists()).toBe(true)
+
+        await custom.trigger("click")
+
+        expect(loadFlowForExecution).toHaveBeenCalledWith({flowId: "my_flow", namespace: "company.team", store: true})
+    })
+})


### PR DESCRIPTION
- The companion EE fix (kestra-ee #10469) treats a stored External asset as a placeholder that a declared type always wins over.
- That premise silently breaks if a user ever deliberately sets an asset's type to External, since External is otherwise an ordinary plugin-declarable type.
- Marking it internal keeps it out of the plugin-listing endpoint and the flow-YAML schema, so it stays inference-only.
- Caveat: this does not block deserialization/parsing of an External asset from YAML/API — internal is only consulted by PluginController and JsonSchemaGenerator, never by PluginDeserializer/DefaultPluginRegistry. Accepted tradeoff, not a gap in this PR.
- Companion to kestra-ee PR #10469.