### PR TITLE
build(deps): resolve moment-timezone to its 1970-2030 data build

### DIFF
--- a/ui/vite.config.js
+++ b/ui/vite.config.js
@@ -81,9 +81,15 @@ export default defineConfig(({mode}) => {
         },
         resolve: {
             preserveSymlinks: true,
-            dedupe: ["echarts", "vue-echarts", "dayjs", "vue", "vue-router", "vue-i18n", "@vueuse/core", "pinia", "@vue-flow/core", "@vue-flow/background", "@vue-flow/controls"],
+            dedupe: ["echarts", "vue-echarts", "dayjs", "vue", "vue-router", "vue-i18n", "@vueuse/core", "pinia", "@vue-flow/core", "@vue-flow/background", "@vue-flow/controls", "moment"],
             alias: [
                 {find: "override", replacement: path.resolve(__dirname, "src/override/")},
+                // moment-timezone's default entry loads data/packed/latest.json: 718 kB of the
+                // eager vendor chunk, for zone transitions nobody displays. This build keeps every
+                // zone name (tz.names() feeds the settings picker) but only 1970-2030 transitions,
+                // so a date past 2030 formats with the last 2030 offset. Not the rolling
+                // 10-year-range build: its window moves with the package release date.
+                {find: /^moment-timezone$/, replacement: "moment-timezone/builds/moment-timezone-with-data-1970-2030"},
             ],
         },
         plugins: [

--- a/ui/vite.config.js
+++ b/ui/vite.config.js
@@ -84,11 +84,7 @@ export default defineConfig(({mode}) => {
             dedupe: ["echarts", "vue-echarts", "dayjs", "vue", "vue-router", "vue-i18n", "@vueuse/core", "pinia", "@vue-flow/core", "@vue-flow/background", "@vue-flow/controls", "moment"],
             alias: [
                 {find: "override", replacement: path.resolve(__dirname, "src/override/")},
-                // moment-timezone's default entry loads data/packed/latest.json: 718 kB of the
-                // eager vendor chunk, for zone transitions nobody displays. This build keeps every
-                // zone name (tz.names() feeds the settings picker) but only 1970-2030 transitions,
-                // so a date past 2030 formats with the last 2030 offset. Not the rolling
-                // 10-year-range build: its window moves with the package release date.
+                // moment timezones are heavy. only load what is common 
                 {find: /^moment-timezone$/, replacement: "moment-timezone/builds/moment-timezone-with-data-1970-2030"},
             ],
         },


### PR DESCRIPTION
### ✨ Description

`moment-timezone`'s default entry is two lines: require the library, then
`moment.tz.load(require('./data/packed/latest.json'))`. That JSON is 722 kB of packed
IANA transitions, and it landed in the eager `vendor` chunk — **45% of it**, measured as a
contiguous 718.5 kB region starting at `Africa/Abidjan|LMT GMT|…`.

Nothing displays that history. The whole API surface used across the app is
`.tz(zone).format(…)`, `moment.tz.guess()`, and one `moment.tz.names()` call feeding the
settings timezone picker:

- `ui/packages/design-system/src/utils/date.ts:18` (`dateFilter`)
- `ui/src/utils/filters.ts:29`, `ui/packages/topology/src/utils/utils.ts:15`
- `ui/src/components/kv/kvValue.ts:14,31`, `ui/src/components/kv/KVTable.vue:446`
- `ui/src/components/flows/FlowRun.vue:429`
- `ui/src/components/settings/BasicSettings.vue:402` (the only `tz.names()` caller)

So the bare specifier now resolves to the `1970-2030` data build that moment-timezone
already ships. `moment` joins `resolve.dedupe` so that build's `require("moment")` reuses
the shared copy rather than adding a second one.

**Result:**

| chunk | before | after |
|---|---|---|
| `vendor-*.js` | 1,604.93 kB / 315.42 kB gzip | **1,012.28 kB / 299.79 kB gzip** |
| eager payload from `index.html` | 3,854.91 kB / 877.80 kB gzip | **3,262.26 kB / 862.18 kB gzip** |

−592.65 kB raw, −15.6 kB gzip. The gzip win is small because packed tz data compresses
~20:1; the real saving is 592 kB less JS to parse on every cold load.

### 🎨 Frontend Checklist

- [x] Type checking passes (`npm run check:types`)
- [x] Code builds without errors (`npm run build`)
- [x] Unit tests pass (`npm run test:unit`) — 205 files, 1968 tests
- [x] Translations are complete if `en.json` changed — `en.json` untouched
- [x] Screenshots or video recordings attached showing the `UI` changes — **n/a, no visual change**; evidence is the build report above

### 📝 Additional Notes

**The trade-off, stated plainly.** I diffed every one of the 597 zones against the full
dataset, year by year:

- Offsets are **identical through 2030-12-31**.
- From **2031-07-01** onward, **199 of 597 zones** report standard time for summer dates —
  a silent 1-hour display error (`Africa/Cairo +03:00 → +02:00`, `America/Adak −09:00 → −10:00`).

Display only: cron and schedule computation happen backend-side against the JDK's full tz
database. `tz.names()` still returns all 597 zones, so the settings picker is unchanged, and
`dataVersion` is still `2026b`. If any surface can realistically show a post-2030 date — a
far-horizon backfill, an arbitrary KV date value — say so and I'll instead keep the full data
and switch `BasicSettings.vue` to `Intl.supportedValuesOf("timeZone")`, which needs no bundled
data at all.

**Deliberately not the `10-year-range` build.** I measured it too: 919.80 kB / 291.15 kB gzip,
a further 92.5 kB raw for 8.6 kB gzip. Its window is `release year ± 5` — **2021–2031** for
0.6.2 — so it is wrong for *past* dates as well (201 zones off in 2020), and the window shifts
on every `moment-timezone` bump. A fixed `1970-2030` label can be reasoned about from the
filename.

**Out of scope.** While measuring this I confirmed the scary `4,357.91 kB` line in the build
report is the **`monaco`** chunk, not `vendor` — 1,033 files, 9.50 MB of unminified ESM, driven
by `import "monaco-editor/features/register.all"`. It is lazy (`KsEditor` is an async component,
and `consolidateChunks.js:483` fails the build if any eager chunk imports it), and its large
contributions — diff editor, inline completions, suggest, hover, find, folding, colorPicker,
gotoSymbol, quickAccess — are all genuinely used. Trimming the remainder would shave a few
hundred kB off a chunk nothing eagerly downloads, at the cost of an editor quietly losing a
keybinding. Left alone on purpose.

### 🤖 AI Authors

Why did the cat sit on the timezone database? It heard there were 597 *zones* and wanted to
nap in every single one. Turns out it only ever needed the one it was already lying in. 🐱
