### PR TITLE
fix(executions): pdfjs-dist eagerly bundled into the shared executions/flows chunk

### DIFF
--- a/ui/src/components/executions/RawPreview.vue
+++ b/ui/src/components/executions/RawPreview.vue
@@ -39,13 +39,15 @@
 </template>
 
 <script setup lang="ts">
-    import {ref, computed} from "vue"
+    import {ref, computed, defineAsyncComponent} from "vue"
     import Wrap from "vue-material-design-icons/Wrap.vue"
     import CopyToClipboard from "../layout/CopyToClipboard.vue"
     import {KsMarkdown, KsEditor} from "@kestra-io/design-system"
     import {useEditorBindings} from "../../composables/useEditorBindings"
     import ListPreview from "../ListPreview.vue"
-    import PdfPreview from "../PdfPreview.vue"
+
+    // Async so pdfjs-dist (~417 kB) is fetched only when an output actually is a PDF.
+    const PdfPreview = defineAsyncComponent(() => import("../PdfPreview.vue"))
 
     export interface Preview {
         truncated?: boolean;


### PR DESCRIPTION
### ✨ Description

`RawPreview.vue` statically imported `PdfPreview.vue`, which pulls in `pdfjs-dist`. That put **417 kB raw / 123 kB gzip of PDF rendering code into `common-execution-flow`** — the chunk shared by every executions page and every flows page — despite the preview already being behind `v-else-if="type === 'PDF'"`.

Loading it through `defineAsyncComponent` moves `pdfjs-dist` into a chunk of its own, fetched only when an output actually is a PDF.

Measured by building `develop` and this branch back to back (`vite build`):

| chunk | before | after | delta |
|---|---|---|---|
| `common-execution-flow` | 671.3 kB (199.1 kB gzip) | 252.9 kB (75.7 kB gzip) | **−418.4 kB / −123.4 kB gzip** |
| `PdfPreview` (new, lazy) | — | 418.2 kB (123.4 kB gzip) | fetched on demand |

Exactly one new chunk; no other chunk in the build changed size. `pdf.worker.min.mjs` was already a separate lazy asset and is untouched.

### 🎨 Frontend Checklist

- [x] Type checking passes (`npm run check:types`)
- [x] Code builds without errors (`npm run build`)
- [x] Unit tests pass (`npm run test:unit`) — 205 files, 1968 tests
- [x] Translations are complete if `en.json` changed — no translation change
- [ ] Screenshots or video recordings attached showing the `UI` changes — **nothing to show: the rendered output is byte-for-byte identical, only when the code is fetched changes.** I did not run the app; the evidence is the build diff above.

### 📝 Additional Notes

- **No test added on purpose.** A test asserting "`PdfPreview` is registered asynchronously" would pin the implementation rather than any behavior a reviewer cares about, which `AGENTS.md` explicitly rules out. The build-output diff is the verification.
- The `DOMMatrix` polyfill in `tests/unit/setup.ts` is left in place — it is still needed by any test that renders the PDF branch, and removing it is out of scope here.
- This came out of a bundle audit; the same audit found larger offenders that are **not** in this PR, each worth its own: `mailchecker` is 840 kB (98.9%) of the `BasicAuthSetup` chunk, 39 statically pre-registered Shiki grammars are 2.18 MB of the `markdown` chunk (C++ alone is 611 kB), and `material-file-icons` is 474 kB (70%) of the `flow` chunk.

### 🤖 AI Authors

Why did the cat sit on the PDF preview? It heard there was a *byte* to catch — but it left when it found out the whole thing was lazy-loaded and it'd have to wait. 🐱