### PR TITLE
feat(flows): let callers override TriggerFlow's execute submission

### DIFF
--- a/ui/src/components/flows/FlowRun.vue
+++ b/ui/src/components/flows/FlowRun.vue
@@ -150,7 +150,7 @@
         return style.toLowerCase() as AlertType
     }
 
-    interface ReplaySubmitOptions {
+    export interface ReplaySubmitOptions {
         formRef: FormInstance
         id: string
         namespace: string

--- a/ui/src/components/flows/TriggerFlow.vue
+++ b/ui/src/components/flows/TriggerFlow.vue
@@ -1,15 +1,17 @@
 <template>
     <div class="trigger-flow-wrapper">
         <span data-onboarding-target="flow-execute-button">
-            <KsButton
-                :id="actionId"
-                :icon="PlayOutlineIcon"
-                :type="type"
-                :disabled="actionDisabled"
-                @click="runAction()"
-            >
-                {{ actionLabel }}
-            </KsButton>
+            <slot name="button" :execute="runAction" :disabled="actionDisabled">
+                <KsButton
+                    :id="actionId"
+                    :icon="PlayOutlineIcon"
+                    :type="type"
+                    :disabled="actionDisabled"
+                    @click="runAction()"
+                >
+                    {{ actionLabel }}
+                </KsButton>
+            </slot>
         </span>
         <KsDialog
             id="execute-flow-dialog"
@@ -24,7 +26,7 @@
             <template #header>
                 <span v-html="$t('execute the flow', {id: flowId})" />
             </template>
-            <FlowRun ref="flowRunRef" :embed="true" @execution-trigger="handleExecutionStart" :redirect="!playgroundStore.enabled" />
+            <FlowRun ref="flowRunRef" :embed="true" :replaySubmit="submit" @execution-trigger="handleExecutionStart" :redirect="!playgroundStore.enabled" />
             <template #footer>
                 <FlowRunActions :flowRun="flowRunRef" />
             </template>
@@ -92,7 +94,7 @@
     import {useExecutionsStore} from "../../stores/executions"
     import {usePlaygroundStore} from "../../stores/playground"
     import {useFlowStore} from "../../stores/flow"
-    import FlowRun from "./FlowRun.vue"
+    import FlowRun, {type ReplaySubmitOptions} from "./FlowRun.vue"
     import FlowRunActions from "./FlowRunActions.vue"
     import FlowWarningDialog from "./FlowWarningDialog.vue"
     import PlayOutlineIcon from "vue-material-design-icons/PlayOutline.vue"
@@ -109,10 +111,14 @@
         disabled?: boolean
         type?: "default" | "primary" | "success" | "warning" | "info" | "danger" | "text" | ""
         flowSource?: string | null
+        submit?: ((options: ReplaySubmitOptions) => void | Promise<void>) | null
+        lazy?: boolean
     }>(), {
         disabled: false,
         type: "primary",
         flowSource: null,
+        submit: null,
+        lazy: false,
     })
 
     const {t} = useI18n({useScope: "global"})
@@ -138,7 +144,10 @@
 
     async function handleExecutionStart() {
         closeModal()
-        toast.success(t("execution_started"))
+        // a caller that overrides the submission owns the user feedback too, otherwise it toasts twice
+        if (!props.submit) {
+            toast.success(t("execution_started"))
+        }
     }
 
     function isDisabled() {
@@ -270,7 +279,7 @@
             
             loadDefinition()
         },
-        {immediate: true},
+        {immediate: !props.lazy},
     )
 
     watch(

--- a/ui/tests/unit/components/flows/TriggerFlow.spec.ts
+++ b/ui/tests/unit/components/flows/TriggerFlow.spec.ts
@@ -1,0 +1,118 @@
+import {describe, it, expect, vi} from "vitest"
+import {shallowMount} from "@vue/test-utils"
+import {createI18n} from "vue-i18n"
+
+const loadFlowForExecution = vi.fn().mockResolvedValue(undefined)
+
+vi.mock("../../../../src/stores/api", () => ({
+    useApiStore: () => ({posthogEvents: vi.fn()}),
+}))
+
+vi.mock("../../../../src/stores/executions", () => ({
+    useExecutionsStore: () => ({flow: undefined, loadFlowForExecution, loadNamespaces: vi.fn(), flowsExecutable: [], namespaces: []}),
+}))
+
+vi.mock("../../../../src/stores/playground", () => ({
+    usePlaygroundStore: () => ({enabled: false}),
+}))
+
+vi.mock("../../../../src/stores/flow", () => ({
+    useFlowStore: () => ({executeFlow: false}),
+}))
+
+const toastSuccess = vi.fn()
+vi.mock("../../../../src/utils/toast", () => ({
+    useToast: () => ({success: toastSuccess, error: vi.fn(), confirm: vi.fn()}),
+}))
+
+import TriggerFlow from "../../../../src/components/flows/TriggerFlow.vue"
+import FlowRun from "../../../../src/components/flows/FlowRun.vue"
+
+const i18n = createI18n({legacy: false, locale: "en", missingWarn: false, fallbackWarn: false, messages: {en: {}}})
+
+function mountTriggerFlow(props: Record<string, unknown> = {}, slots: Record<string, string> = {}) {
+    return shallowMount(TriggerFlow, {
+        props: {flowId: "my_flow", namespace: "company.team", ...props},
+        slots,
+        global: {plugins: [i18n]},
+    })
+}
+
+describe("TriggerFlow — submit override", () => {
+    it("forwards the submit prop to FlowRun as replaySubmit", () => {
+        const submit = vi.fn()
+        const wrapper = mountTriggerFlow({submit})
+
+        expect(wrapper.findComponent(FlowRun).props("replaySubmit")).toBe(submit)
+    })
+
+    it("defaults to the normal execute path (replaySubmit unset) when no submit override is given", () => {
+        const wrapper = mountTriggerFlow()
+
+        expect(wrapper.findComponent(FlowRun).props("replaySubmit")).toBeFalsy()
+    })
+})
+
+describe("TriggerFlow — lazy loading", () => {
+    it("does not load the flow on mount when lazy", () => {
+        loadFlowForExecution.mockClear()
+        mountTriggerFlow({lazy: true})
+
+        expect(loadFlowForExecution).not.toHaveBeenCalled()
+    })
+
+    it("loads the flow on click when lazy", async () => {
+        loadFlowForExecution.mockClear()
+        const wrapper = mountTriggerFlow({lazy: true})
+
+        await wrapper.find("#execute-button").trigger("click")
+
+        expect(loadFlowForExecution).toHaveBeenCalledWith({flowId: "my_flow", namespace: "company.team", store: true})
+    })
+
+    it("loads the flow on mount when not lazy (default, unchanged behavior)", () => {
+        loadFlowForExecution.mockClear()
+        mountTriggerFlow()
+
+        expect(loadFlowForExecution).toHaveBeenCalledWith({flowId: "my_flow", namespace: "company.team", store: true})
+    })
+})
+
+describe("TriggerFlow — #button slot", () => {
+    it("renders the slot content instead of the default button, and its execute opens the dialog", async () => {
+        loadFlowForExecution.mockClear()
+        const wrapper = mountTriggerFlow({lazy: true}, {
+            button: "<template #button=\"{execute}\"><button class=\"custom-trigger\" @click=\"execute()\">Run it</button></template>",
+        })
+
+        expect(wrapper.find("#execute-button").exists()).toBe(false)
+        const custom = wrapper.find(".custom-trigger")
+        expect(custom.exists()).toBe(true)
+
+        await custom.trigger("click")
+
+        expect(loadFlowForExecution).toHaveBeenCalledWith({flowId: "my_flow", namespace: "company.team", store: true})
+    })
+})
+
+describe("TriggerFlow — execution-started feedback", () => {
+    it("toasts on its own when it owns the submission", async () => {
+        toastSuccess.mockClear()
+        const wrapper = mountTriggerFlow()
+
+        wrapper.findComponent(FlowRun).vm.$emit("executionTrigger")
+        await wrapper.vm.$nextTick()
+
+        expect(toastSuccess).toHaveBeenCalledTimes(1)
+    })
+
+    it("stays silent when a submit override owns the feedback, so the caller's toast is not duplicated", async () => {
+        toastSuccess.mockClear()
+        const wrapper = mountTriggerFlow({submit: vi.fn()})
+
+        wrapper.findComponent(FlowRun).vm.$emit("executionTrigger")
+        await wrapper.vm.$nextTick()
+
+        expect(toastSuccess).not.toHaveBeenCalled()
+    })
+})


### PR DESCRIPTION
### 🔗 Related Issue

None — companion change enabling kestra-io/kestra-ee#10474 (case actions execute modal); full change is kestra-io/kestra-ee#10475.

### ✨ Description

`TriggerFlow` (the "Execute flow" button + modal used across the app) always submitted through the normal execution-trigger endpoint and always preloaded the flow on mount. Neither works for a caller that needs to submit somewhere else, or that renders several `TriggerFlow`s at once.

- `submit`: optional override forwarded to the inner `FlowRun`'s existing `replaySubmit` prop. Unset, behavior is unchanged.
- `lazy`: skips preloading the flow on mount; the flow still loads before the modal opens. Needed when several `TriggerFlow`s share the page — without it they raced to write the same shared `flow` store slot.
- `#button` slot: lets a caller supply its own trigger element instead of the default button, with `{execute, disabled}` as slot props.

All three are additive and default to today's behavior; the four existing call sites are untouched.