### PR TITLE
fix(design-system): low-contrast hover text in dark date picker panels

### DIFF
--- a/ui/packages/design-system/src/components/Form/KsDatePicker.vue
+++ b/ui/packages/design-system/src/components/Form/KsDatePicker.vue
@@ -62,6 +62,11 @@
         color: var(--ks-text-inactive);
     }
 
+    .kel-date-picker,
+    .kel-date-range-picker {
+        --kel-datepicker-hover-text-color: var(--ks-text-link);
+    }
+
     .kel-date-range-picker {
         --kel-datepicker-border-color: var(--ks-border-default);
         --kel-datepicker-inner-border-color: var(--ks-border-default);


### PR DESCRIPTION
Closes https://github.com/kestra-io/kestra-ee/issues/10173.

### ✨ Description

In the Backfill executions modal (and anywhere else a date picker opens), hovering a year in the year picker colored the text with the raw primary purple, which is nearly unreadable on dark backgrounds. The same variable drives the hovered month and day cells and the panel header buttons, so those were equally dim in dark themes.

The `--kel-datepicker-hover-text-color` variable now resolves to the theme-aware `--ks-text-link` token: in light mode it is the same primary purple as before (no visual change), while in both dark themes it resolves to a light, readable purple.

| Before | After |
|--------|-------|
| ![before](https://raw.githubusercontent.com/MilosPaunovic/kestra/93cdc9dd55a41c717f7be21e65c7e10a98e5298b/10173/before.png) | ![after](https://raw.githubusercontent.com/MilosPaunovic/kestra/93cdc9dd55a41c717f7be21e65c7e10a98e5298b/10173/after.png) |

### 🎨 Frontend Checklist

- [x] Type checking passes (`npm run check:types`)
- [x] Screenshots attached showing the `UI` changes

### 🤖 AI Authors

Why did the cat hover over 2022 in the year picker? It wanted to paws and reflect on nine of its lives. 🐱
