### PR TITLE
fix(core): redact encryptedOutputs markers from task runner logs

### DIFF
--- a/core/src/main/java/io/kestra/core/models/tasks/runners/TaskLogLineMatcher.java
+++ b/core/src/main/java/io/kestra/core/models/tasks/runners/TaskLogLineMatcher.java
@@ -57,6 +57,13 @@ public class TaskLogLineMatcher {
 
     protected static final ObjectMapper MAPPER = JacksonMapper.ofJson(false);
 
+    // The key is EE-only, but the marker protocol is shared, so OSS has to redact it wherever a raw command or log line is emitted.
+    private static final String ENCRYPTED_OUTPUTS_KEY = "encryptedOutputs";
+
+    private static final Pattern ENCRYPTED_LOG_DATA = Pattern.compile("::\\{.*?" + ENCRYPTED_OUTPUTS_KEY + ".*?}::");
+
+    private static final String REDACTED = "******";
+
     /**
      * Attempts to match and extract structured data from a given log line.
      * <p>
@@ -81,7 +88,21 @@ public class TaskLogLineMatcher {
         return Optional.of(handle(logger, runContext, instant, match, matches.get()));
     }
 
+    /**
+     * Replaces every {@code ::{...}::} block carrying encrypted outputs with {@code ******}, so a command or log
+     * line embedding one can be emitted without exposing the value it is meant to encrypt. Frames are matched
+     * textually and within a single line, as the payload may not be valid JSON.
+     */
+    public static String redactEncryptedOutputs(String text) {
+        if (text == null || !text.contains(ENCRYPTED_OUTPUTS_KEY)) {
+            return text;
+        }
+
+        return ENCRYPTED_LOG_DATA.matcher(text).replaceAll(REDACTED);
+    }
+
     protected TaskLogMatch handle(Logger logger, RunContext runContext, Instant instant, TaskLogMatch match, String data) {
+        String logData = redactEncryptedOutputs(data);
 
         if (match.metrics() != null) {
             match.metrics().forEach(runContext::metric);
@@ -97,7 +118,7 @@ public class TaskLogLineMatcher {
                         .addKeyValue(ORIGINAL_TIMESTAMP_KEY, instant);
                     builder.log(it.message());
                 } catch (Exception e) {
-                    logger.warn("Invalid log '{}'", data, e);
+                    logger.warn("Invalid log '{}'", logData, e);
                 }
             });
         }
@@ -107,14 +128,14 @@ public class TaskLogLineMatcher {
                 AssetEmitter assetEmitter = runContext.assets();
                 assetEmitter.emit(match.assets());
             } catch (IllegalVariableEvaluationException e) {
-                logger.warn("Unable to get asset emitter for log '{}'", data, e);
+                logger.warn("Unable to get asset emitter for log '{}'", logData, e);
             } catch (QueueException e) {
-                logger.warn("Unable to emit asset for log '{}'", data, e);
+                logger.warn("Unable to emit asset for log '{}'", logData, e);
             }
         }
 
         if (match.otlp() != null && !match.otlp().isEmpty()) {
-            handleOtlp(logger, runContext, instant, match.otlp(), data);
+            handleOtlp(logger, runContext, instant, match.otlp(), logData);
         }
 
         return match;
@@ -197,7 +218,7 @@ public class TaskLogLineMatcher {
                         .logger()
                         .atLevel(otlpSeverityToLevel(logRecord))
                         .addKeyValue(ORIGINAL_TIMESTAMP_KEY, toInstant(logRecord.timeUnixNano(), instant))
-                        .log(logRecord.body() != null ? logRecord.body().asText() : null);
+                        .log(logRecord.body() != null ? redactEncryptedOutputs(logRecord.body().asText()) : null);
                 } catch (Exception e) {
                     logger.warn("Invalid OTLP log '{}'", data, e);
                 }

--- a/core/src/main/java/io/kestra/plugin/core/runner/Process.java
+++ b/core/src/main/java/io/kestra/plugin/core/runner/Process.java
@@ -135,7 +135,9 @@ public class Process extends TaskRunner<TaskRunnerDetailResult> {
 
         java.lang.Process process = processBuilder.start();
         long pid = process.pid();
-        logger.debug("Starting command with pid {} [{}]", pid, String.join(" ", renderedCommands));
+        if (logger.isDebugEnabled()) {
+            logger.debug("Starting command with pid {} [{}]", pid, TaskLogLineMatcher.redactEncryptedOutputs(String.join(" ", renderedCommands)));
+        }
 
         LogRunnable stdOutRunnable = new LogRunnable(process.getInputStream(), defaultLogConsumer, false);
         LogRunnable stdErrRunnable = new LogRunnable(process.getErrorStream(), defaultLogConsumer, true);

--- a/core/src/test/java/io/kestra/core/models/tasks/runners/TaskLogLineMatcherTest.java
+++ b/core/src/test/java/io/kestra/core/models/tasks/runners/TaskLogLineMatcherTest.java
@@ -430,6 +430,24 @@ class TaskLogLineMatcherTest {
     }
 
     @Test
+    void shouldRedactEncryptedOutputsFrameWhenEmbeddedInACommand() {
+        String command = "set -e\necho '::{\"encryptedOutputs\":{\"encrypted\":my secret value}}::'";
+
+        String redacted = TaskLogLineMatcher.redactEncryptedOutputs(command);
+
+        assertThat(redacted).isEqualTo("set -e\necho '******'");
+    }
+
+    @Test
+    void shouldNotRedactPlainOutputsFrame() {
+        String command = "::{\"outputs\":{\"a\":\"b\"}}::";
+
+        String redacted = TaskLogLineMatcher.redactEncryptedOutputs(command);
+
+        assertThat(redacted).isEqualTo(command);
+    }
+
+    @Test
     void shouldProcessOutputsAndOtlpWhenFramedLineContainsBoth() throws IOException {
         var runContext = runContext();
         var listAppender = appender(runContext);

--- a/script/src/main/java/io/kestra/plugin/scripts/runner/docker/Docker.java
+++ b/script/src/main/java/io/kestra/plugin/scripts/runner/docker/Docker.java
@@ -513,7 +513,7 @@ public class Docker extends TaskRunner<Docker.DockerTaskRunnerDetailResult> {
                         logger.debug(
                             "Starting command with container id {} [{}]",
                             containerId,
-                            String.join(" ", renderedCommands)
+                            TaskLogLineMatcher.redactEncryptedOutputs(String.join(" ", renderedCommands))
                         );
                     }
                 } else {

--- a/tests/src/main/java/io/kestra/core/models/tasks/runners/AbstractTaskRunnerTest.java
+++ b/tests/src/main/java/io/kestra/core/models/tasks/runners/AbstractTaskRunnerTest.java
@@ -26,6 +26,9 @@ import io.kestra.core.runners.RunContextFactory;
 import io.kestra.core.storages.StorageInterface;
 import io.kestra.core.utils.IdUtils;
 
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
 import jakarta.inject.Inject;
 
 import static io.kestra.core.tenant.TenantService.MAIN_TENANT;
@@ -226,6 +229,44 @@ public abstract class AbstractTaskRunnerTest {
         result = taskRunner2.run(runContext, commands, Collections.emptyList());
         assertThat(result).isNotNull();
         assertThat(result.getExitCode()).isZero();
+    }
+
+    /**
+     * A rendered command echoing an {@code encryptedOutputs} marker must never appear in clear text in a runner's
+     * own logs (e.g. a "Starting command ..." debug line) — the whole point of the marker is that the value it
+     * carries is sensitive. Every task runner logging its rendered command, in this repo or in an external plugin
+     * repo, must call {@link TaskLogLineMatcher#redactEncryptedOutputs(String)} on it first; this test fails until
+     * it does.
+     */
+    @Test
+    protected void shouldNotLogEncryptedOutputsWhenStartingCommand() throws Exception {
+        var runContext = runContext(this.runContextFactory);
+        var commands = initScriptCommands(runContext);
+        String secret = "hunter2";
+        Mockito.when(commands.getCommands()).thenReturn(
+            Property.ofValue(
+                ScriptService.scriptCommands(
+                    List.of("/bin/sh", "-c"),
+                    Collections.emptyList(),
+                    List.of("echo '::{\"encryptedOutputs\":{\"secret\":\"" + secret + "\"}}::'")
+                )
+            )
+        );
+
+        var listAppender = new ListAppender<ILoggingEvent>();
+        listAppender.start();
+        var logger = (ch.qos.logback.classic.Logger) runContext.logger();
+        logger.setLevel(Level.TRACE);
+        logger.addAppender(listAppender);
+
+        var taskRunner = taskRunner();
+        var result = taskRunner.run(runContext, commands, Collections.emptyList());
+
+        assertThat(result).isNotNull();
+        assertThat(result.getExitCode()).isZero();
+        assertThat(listAppender.list)
+            .extracting(ILoggingEvent::getFormattedMessage)
+            .noneMatch(message -> message != null && message.contains(secret));
     }
 
     protected RunContext runContext(RunContextFactory runContextFactory) {


### PR DESCRIPTION
### 🔗 Related Issue

Closes https://github.com/kestra-io/kestra/issues/14144.

### ✨ Description

**Problem:** an inline `shell.Script` task that declares an output sensitive via the `::{"encryptedOutputs":{"key":"value"}}::` marker had that value stored encrypted in the execution outputs — but the runner logged the fully rendered command (the whole `/bin/sh -c <script>` payload) at DEBUG before executing it, leaking the secret in clear text into the execution log, persisted in the DB and shown in the UI. Existing secret masking (`RunContextLogger.usedSecret`) couldn't catch this, since the value comes from a plain task output, never registered as a secret.

**Fix:** added `TaskLogLineMatcher.redactEncryptedOutputs(String)`, a textual, single-line replacement of any `::{...encryptedOutputs...}::` frame with `******` (the payload may not be valid JSON, so this can't be a JSON-based redaction). It's called before the "Starting command" DEBUG line in both the `Docker` and `Process` task runners, and in `TaskLogLineMatcher`'s own warn/OTLP-forwarding paths, which echoed the same raw frame. Plain `outputs` frames are left untouched — they're already shown in clear text in the Outputs tab, so redacting them would only remove debugging value.