### PR TITLE
fix(core): surface swallowed evaluation errors instead of hiding them

### DIFF
--- a/core/src/main/java/io/kestra/core/runners/FlowableUtils.java
+++ b/core/src/main/java/io/kestra/core/runners/FlowableUtils.java
@@ -447,8 +447,15 @@ public class FlowableUtils {
                         }
                         return Either.right(resolvedValues);
                     } else {
-                        throw new IllegalVariableEvaluationException("Unknown value type: " + valuesNode.getNodeType());
+                        throw new IllegalVariableEvaluationException(
+                            "The `values` must be a list, a map, or an expression that renders to one, but got: '" + renderValue + "'."
+                        );
                     }
+                } catch (JsonProcessingException e) {
+                    throw new IllegalVariableEvaluationException(
+                        "The `values` must be a list, a map, or an expression that renders to one, but got: '" + renderValue + "'.",
+                        e
+                    );
                 } catch (IOException e) {
                     throw new IllegalVariableEvaluationException(e);
                 }

--- a/core/src/test/java/io/kestra/core/runners/FlowableUtilsTest.java
+++ b/core/src/test/java/io/kestra/core/runners/FlowableUtilsTest.java
@@ -316,6 +316,30 @@ class FlowableUtilsTest {
     }
 
     @Test
+    void resolveValues_withPlainString_shouldThrowClearMessageNotJacksonError() {
+        // Given
+        RunContext runContext = runContextFactory.of();
+
+        // When/Then
+        assertThatThrownBy(() -> FlowableUtils.resolveValues(runContext, "hello world"))
+            .isInstanceOf(IllegalVariableEvaluationException.class)
+            .hasMessageContaining("must be a list, a map, or an expression")
+            .hasMessageNotContaining("Unrecognized token")
+            .hasMessageNotContaining("StreamReadFeature");
+    }
+
+    @Test
+    void resolveValues_withNonContainerJson_shouldThrowClearMessage() {
+        // Given
+        RunContext runContext = runContextFactory.of();
+
+        // When/Then a valid JSON scalar (a number) is still not a list or a map
+        assertThatThrownBy(() -> FlowableUtils.resolveValues(runContext, "5"))
+            .isInstanceOf(IllegalVariableEvaluationException.class)
+            .hasMessageContaining("must be a list, a map, or an expression");
+    }
+
+    @Test
     void resolveValues_withMap_shouldReturnListOfPairs() throws Exception {
         // Given
         RunContext runContext = runContextFactory.of();

--- a/executor/src/main/java/io/kestra/executor/SLAService.java
+++ b/executor/src/main/java/io/kestra/executor/SLAService.java
@@ -29,8 +29,8 @@ public class SLAService {
                     try {
                         return sla.evaluate(runContext, execution);
                     } catch (Exception e) {
-                        runContext.logger().error("Ignoring SLA '{}' because of the error: {}", sla.getId(), e.getMessage(), e);
-                        return Optional.<Violation> empty();
+                        runContext.logger().error("SLA '{}' could not be evaluated and is treated as violated: {}", sla.getId(), e.getMessage(), e);
+                        return Optional.of(new Violation(sla.getId(), sla.getBehavior(), sla.getLabels(), "SLA could not be evaluated: " + e.getMessage()));
                     }
                 }
             )
@@ -49,8 +49,8 @@ public class SLAService {
             maybeViolation.ifPresent(violation -> runContext.logger().warn("SLA '{}' violated: {}", violation.slaId(), violation.reason()));
             return maybeViolation;
         } catch (Exception e) {
-            runContext.logger().error("Ignoring SLA '{}' because of the error: {}", sla.getId(), e.getMessage(), e);
-            return Optional.empty();
+            runContext.logger().error("SLA '{}' could not be evaluated and is treated as violated: {}", sla.getId(), e.getMessage(), e);
+            return Optional.of(new Violation(sla.getId(), sla.getBehavior(), sla.getLabels(), "SLA could not be evaluated: " + e.getMessage()));
         }
     }
 }

--- a/executor/src/test/java/io/kestra/executor/SLAServiceTest.java
+++ b/executor/src/test/java/io/kestra/executor/SLAServiceTest.java
@@ -1,0 +1,62 @@
+package io.kestra.executor;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import io.kestra.core.models.executions.Execution;
+import io.kestra.core.models.flows.Flow;
+import io.kestra.core.models.flows.State;
+import io.kestra.core.models.flows.sla.SLA;
+import io.kestra.core.models.flows.sla.Violation;
+import io.kestra.core.models.flows.sla.types.ExecutionAssertionSLA;
+import io.kestra.core.runners.RunContext;
+import io.kestra.core.runners.RunContextFactory;
+import io.kestra.core.utils.IdUtils;
+import io.kestra.plugin.core.log.Log;
+
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import jakarta.inject.Inject;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@MicronautTest
+class SLAServiceTest {
+    @Inject
+    private SLAService slaService;
+
+    @Inject
+    private RunContextFactory runContextFactory;
+
+    @Test
+    void shouldReturnViolationWithDeclaredBehaviorWhenAssertionCannotBeEvaluated() {
+        SLA sla = ExecutionAssertionSLA.builder()
+            .id("broken")
+            .type(SLA.Type.EXECUTION_ASSERTION)
+            .behavior(SLA.Behavior.FAIL)
+            ._assert("{{ nope.missing.thing }}")
+            .build();
+        Flow flow = Flow.builder()
+            .tenantId("tenant")
+            .namespace("io.kestra.unit-test")
+            .id(IdUtils.create())
+            .tasks(List.of(Log.builder().id("t").type(Log.class.getName()).message("hi").build()))
+            .sla(List.of(sla))
+            .build();
+        Execution execution = Execution.builder()
+            .tenantId("tenant")
+            .id(IdUtils.create())
+            .namespace(flow.getNamespace())
+            .flowId(flow.getId())
+            .flowRevision(1)
+            .state(new State())
+            .build();
+        RunContext runContext = runContextFactory.of(flow, execution);
+
+        List<Violation> violations = slaService.evaluateExecutionChangedSLA(runContext, flow, execution);
+
+        assertThat(violations).hasSize(1);
+        assertThat(violations.getFirst().behavior()).isEqualTo(SLA.Behavior.FAIL);
+        assertThat(violations.getFirst().reason()).contains("could not be evaluated");
+    }
+}

--- a/scheduler/src/main/java/io/kestra/scheduler/internals/SchedulableEvaluator.java
+++ b/scheduler/src/main/java/io/kestra/scheduler/internals/SchedulableEvaluator.java
@@ -6,8 +6,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.event.Level;
 
-import com.google.common.base.Throwables;
-
 import io.kestra.core.metrics.MetricRegistry;
 import io.kestra.core.models.conditions.ConditionContext;
 import io.kestra.core.models.triggers.AbstractTrigger;
@@ -67,19 +65,23 @@ public class SchedulableEvaluator {
                     return evaluationResult;
                 } catch (Exception e) {
                     Logger logger = runContext.logger();
+                    log.error(
+                        "Failed to evaluate trigger '{}' on flow '{}.{}': {}",
+                        context.getTriggerId(),
+                        context.getNamespace(),
+                        context.getFlowId(),
+                        e.getMessage(),
+                        e
+                    );
                     Logs.logTrigger(
                         context,
                         logger,
-                        Level.WARN,
-                        "[date: {}] Evaluate Failed with error '{}'",
+                        Level.ERROR,
+                        "[date: {}] Evaluation failed: {}",
                         context.getDate(),
                         e.getMessage(),
                         e
                     );
-
-                    if (logger.isTraceEnabled()) {
-                        logger.trace(Throwables.getStackTraceAsString(e));
-                    }
                     return Optional.empty();
                 }
             });


### PR DESCRIPTION
Closes https://github.com/kestra-io/kestra/issues/18454.
Closes https://github.com/kestra-io/kestra-ee/issues/10309.
Closes https://github.com/kestra-io/kestra-ee/issues/10297.

## Problem

Three places caught an evaluation error and silently discarded it, so a broken flow looked healthy while doing the wrong thing.

## Fix

- **Loop `values` (#18454)** — a plain string (or an expression rendering to a scalar) made `FlowableUtils.resolveValues` leak a raw Jackson `JsonParseException` into the user log. It now throws a clear `IllegalVariableEvaluationException` — *"The `values` must be a list, a map, or an expression that renders to one, but got: '…'"* — keeping the Jackson detail as the cause for debug logs.
- **SLA assertion (#10309)** — a broken `EXECUTION_ASSERTION` expression was caught and the SLA skipped, letting the run pass as if it had no SLA. `SLAService` now treats an unevaluable SLA as violated with the **SLA's own declared behavior** (fail-closed), consistent with how flow `checks` already stop on a broken gate.
- **Schedule trigger input (#10297)** — a broken input expression made the trigger silently produce no execution, with nothing on the server log. `SchedulableEvaluator` now logs the failure at **ERROR on the server log** so operators can see why the trigger isn't running.

## Evidence

`FlowableUtilsTest` (+2: plain string asserts no Jackson leak; non-container JSON), new `SLAServiceTest` (broken assertion → violation with declared behavior), and the `H2RunnerTest` gate all pass.

## Scope note

`#10297` is fixed as server-log visibility only — surfacing the error on the Triggers page would need a new trigger-state error field, and creating a synthetic failed execution was deliberately excluded, both out of scope for this bugfix.
