### PR TITLE
fix(executions): reload task logs when the followed execution changes

### DIFF
--- a/ui/src/components/logs/TaskRunDetails.spec.ts
+++ b/ui/src/components/logs/TaskRunDetails.spec.ts
@@ -1,0 +1,136 @@
+import {afterAll, afterEach, beforeEach, describe, expect, it, vi} from "vitest"
+import {flushPromises, mount} from "@vue/test-utils"
+import {createI18n} from "vue-i18n"
+import {nextTick, reactive} from "vue"
+
+const store = vi.hoisted(() => ({
+    executions: {} as Record<string, any>,
+}))
+
+vi.mock("../../stores/executions", () => ({
+    useExecutionsStore: () => store.executions,
+}))
+vi.mock("../../stores/core", () => ({
+    useCoreStore: () => ({message: undefined}),
+}))
+vi.mock("@kestra-io/kestra-sdk", () => ({
+    useClient: () => ({}),
+}))
+vi.mock("@kestra-io/kestra-sdk/outputs", () => ({
+    taskRunOutputs: vi.fn().mockResolvedValue({}),
+}))
+
+import TaskRunDetails from "./TaskRunDetails.vue"
+
+const i18n = createI18n({legacy: false, globalInjection: true, locale: "en", messages: {en: {}}})
+
+const execution = (id: string, state: string) => ({
+    id,
+    namespace: "company.team",
+    flowId: "simple-dag",
+    flowRevision: 1,
+    kind: "PLAYGROUND",
+    state: {current: state},
+    // Kept empty so the component's root `v-if` renders nothing: this spec drives the
+    // log-loading watcher, not the taskrun list.
+    taskRunList: [],
+})
+
+const logsFor = (id: string) => ({results: [{level: "INFO", message: `log of ${id}`}], total: 1})
+
+function mountDetails() {
+    return mount(TaskRunDetails, {
+        props: {targetFlow: {id: "simple-dag", namespace: "company.team"}},
+        global: {plugins: [i18n]},
+    })
+}
+
+describe("TaskRunDetails log loading across executions", () => {
+    let openedStreams: string[]
+
+    afterEach(() => {
+        vi.useRealTimers()
+    })
+
+    // `useLogDisplay` seeds its display settings into localStorage when the component is imported.
+    afterAll(() => {
+        localStorage.clear()
+    })
+
+    beforeEach(() => {
+        vi.useFakeTimers()
+        openedStreams = []
+        store.executions = reactive({
+            execution: undefined as any,
+            logs: undefined,
+            loadLogs: vi.fn(({executionId}: {executionId: string}) => Promise.resolve(logsFor(executionId))),
+            followLogs: vi.fn(({id}: {id: string}) => {
+                openedStreams.push(id)
+                return Promise.resolve({close: vi.fn(), onmessage: null, onerror: null})
+            }),
+            loadFlowForExecution: vi.fn().mockResolvedValue({id: "simple-dag"}),
+            subscribeToExecution: vi.fn(() => ({close: vi.fn()})),
+        })
+    })
+
+    /**
+     * Regression test for kestra-io/kestra#14018: a playground re-run lands while the previous
+     * execution's log stream is still inside its two-second grace period. The `!logsSSE` guards
+     * used to read that stream as "these logs are already covered", so the new execution's logs
+     * were never fetched and its taskruns rendered with empty consoles.
+     */
+    it("should load the new execution logs when re-run before the previous stream is closed", async () => {
+        store.executions.execution = execution("exec-1", "RUNNING")
+        mountDetails()
+        await flushPromises()
+        expect(openedStreams).toEqual(["exec-1"])
+
+        store.executions.execution = {...execution("exec-1", "SUCCESS")}
+        await nextTick()
+        await flushPromises()
+
+        // Re-run inside the grace period, so exec-1's stream is still open.
+        vi.advanceTimersByTime(500)
+        store.executions.execution = execution("exec-2", "RESTARTED")
+        await nextTick()
+        await flushPromises()
+
+        expect(store.executions.loadLogs).toHaveBeenCalledWith(
+            expect.objectContaining({executionId: "exec-2"}),
+        )
+    })
+
+    it("should drop the previous execution logs when the followed execution changes", async () => {
+        store.executions.execution = execution("exec-1", "SUCCESS")
+        const wrapper = mountDetails()
+        await flushPromises()
+        expect((wrapper.vm as any).filteredLogs).toEqual([{level: "INFO", message: "log of exec-1"}])
+
+        store.executions.loadLogs.mockReturnValue(new Promise(() => {}))
+        store.executions.execution = execution("exec-2", "RESTARTED")
+        await nextTick()
+        await flushPromises()
+
+        expect((wrapper.vm as any).filteredLogs).toEqual([])
+    })
+
+    /**
+     * A replay starts in RESTARTED, which is not a running state, so the grace-period close is
+     * armed before the execution reaches RUNNING. Left pending it closed the stream that had
+     * just been opened for that same execution, two seconds into the run.
+     */
+    it("should keep the stream open when the execution reaches running after a restarted state", async () => {
+        store.executions.execution = execution("exec-1", "RESTARTED")
+        mountDetails()
+        await flushPromises()
+
+        store.executions.execution = execution("exec-1", "RUNNING")
+        await nextTick()
+        await flushPromises()
+        expect(openedStreams).toEqual(["exec-1"])
+
+        const stream = await store.executions.followLogs.mock.results[0].value
+        vi.advanceTimersByTime(5000)
+        expect(stream.close).not.toHaveBeenCalled()
+    })
+})

--- a/ui/src/components/logs/TaskRunDetails.vue
+++ b/ui/src/components/logs/TaskRunDetails.vue
@@ -360,6 +360,10 @@
     const selectedAttemptNumberByTaskRunId = ref<Record<string, number>>({})
     const executionSSE = ref<any>(undefined) // FIXME: any
     const logsSSE = ref<any>(undefined) // FIXME: any
+    // Execution that `rawLogs` and any open logs SSE belong to, so both can be dropped
+    // when the view moves to another execution.
+    const logsExecutionId = ref<string | undefined>(undefined)
+    const logsCloseTimeout = ref<ReturnType<typeof setTimeout> | undefined>(undefined)
     const flow = ref<any>(undefined) // FIXME: any
     const logsBuffer = ref<any[]>([]) // FIXME: any
     const shownSubflowsIds = ref<{subflowExecutionId: string; taskRunIndex: number}[]>([])
@@ -633,6 +637,16 @@
                 return
             }
 
+            // A replay or a new playground run is a new execution with new taskrun ids, so logs
+            // held for the previous one are unusable. Dropping the stream here also stops the
+            // `!logsSSE.value` guards below from reading a stream that still follows the previous
+            // execution as "these logs are already covered" (kestra-io/kestra#14018).
+            if (logsExecutionId.value !== undefined && logsExecutionId.value !== newExecution.id) {
+                closeLogsSSE()
+                rawLogs.value = []
+                logsBuffer.value = []
+            }
+
             if (!oldExecution) {
                 nextTick(() => {
                     const parentScroller =
@@ -666,7 +680,8 @@
 
             if (!State.isRunning(followedExecution.value.state.current)) {
                 // wait a bit to make sure we don't miss logs as log indexer is asynchronous
-                setTimeout(() => {
+                cancelLogsSSEClose()
+                logsCloseTimeout.value = setTimeout(() => {
                     closeLogsSSE()
                 }, 2000)
 
@@ -759,7 +774,15 @@
         )
     }
 
+    function cancelLogsSSEClose() {
+        if (logsCloseTimeout.value) {
+            clearTimeout(logsCloseTimeout.value)
+            logsCloseTimeout.value = undefined
+        }
+    }
+
     function closeLogsSSE() {
+        cancelLogsSSEClose()
         if (logsSSE.value) {
             logsSSE.value.close()
             logsSSE.value = undefined
@@ -839,6 +862,11 @@
     }
 
     function followLogs(executionId: string) {
+        // A replay starts in RESTARTED, which is not a running state, so the grace-period close
+        // is armed before the execution reaches RUNNING; leaving it pending would close this
+        // stream two seconds in, mid-execution.
+        cancelLogsSSEClose()
+        logsExecutionId.value = executionId
         executionsStore.followLogs({id: executionId, params: buildLogParams()}).then((sse: any) => { // FIXME: any
             logsSSE.value = sse
 
@@ -988,13 +1016,23 @@
     }
 
     function loadLogs(executionId?: string) {
+        const id = executionId ?? followedExecution.value?.id
+        if (!id) {
+            return
+        }
+        logsExecutionId.value = id
         const p = buildLogParams()
         executionsStore
             .loadLogs({
-                executionId: executionId!,
+                executionId: id,
                 params: p,
             })
             .then((logs: any) => { // FIXME: any
+                // A response for an execution the view has since left would otherwise overwrite
+                // the current one's logs when it lands.
+                if (logsExecutionId.value !== id) {
+                    return
+                }
                 // `loadLogs` returns a paginated response `{ results, total }`, and `rawLogs` must be an array of log lines.
                 rawLogs.value = logs?.results ?? logs ?? []
                 // Discard any buffered SSE logs to prevent duplicates after the full REST fetch replaces `rawLogs`.

--- a/ui/src/components/logs/TaskRunDetails.vue
+++ b/ui/src/components/logs/TaskRunDetails.vue
@@ -360,8 +360,7 @@
     const selectedAttemptNumberByTaskRunId = ref<Record<string, number>>({})
     const executionSSE = ref<any>(undefined) // FIXME: any
     const logsSSE = ref<any>(undefined) // FIXME: any
-    // Execution that `rawLogs` and any open logs SSE belong to, so both can be dropped
-    // when the view moves to another execution.
+    // Execution `rawLogs` and any open logs SSE belong to, so both can be dropped on a change.
     const logsExecutionId = ref<string | undefined>(undefined)
     const logsCloseTimeout = ref<ReturnType<typeof setTimeout> | undefined>(undefined)
     const flow = ref<any>(undefined) // FIXME: any
@@ -637,10 +636,7 @@
                 return
             }
 
-            // A replay or a new playground run is a new execution with new taskrun ids, so logs
-            // held for the previous one are unusable. Dropping the stream here also stops the
-            // `!logsSSE.value` guards below from reading a stream that still follows the previous
-            // execution as "these logs are already covered" (kestra-io/kestra#14018).
+            // Closed here so the `!logsSSE.value` guards below cannot read a stream still following the previous execution as "already covered" (kestra-io/kestra#14018).
             if (logsExecutionId.value !== undefined && logsExecutionId.value !== newExecution.id) {
                 closeLogsSSE()
                 rawLogs.value = []
@@ -862,9 +858,7 @@
     }
 
     function followLogs(executionId: string) {
-        // A replay starts in RESTARTED, which is not a running state, so the grace-period close
-        // is armed before the execution reaches RUNNING; leaving it pending would close this
-        // stream two seconds in, mid-execution.
+        // A replay is RESTARTED, not a running state, so the grace-period close is armed before RUNNING and would otherwise close this stream mid-execution.
         cancelLogsSSEClose()
         logsExecutionId.value = executionId
         executionsStore.followLogs({id: executionId, params: buildLogParams()}).then((sse: any) => { // FIXME: any
@@ -1028,8 +1022,7 @@
                 params: p,
             })
             .then((logs: any) => { // FIXME: any
-                // A response for an execution the view has since left would otherwise overwrite
-                // the current one's logs when it lands.
+                // A response for an execution the view has since left would overwrite the current one's logs.
                 if (logsExecutionId.value !== id) {
                     return
                 }


### PR DESCRIPTION
### 🔗 Related Issue

Closes https://github.com/kestra-io/kestra/issues/14018.

### ✨ Description

Re-running a task in the Playground left the task consoles empty.

`TaskRunDetails` guarded its log loading on `if (!logsSSE.value)` without checking *which* execution that stream followed. A terminated execution keeps its stream open for a two-second grace period, so a re-run inside that window neither streamed nor fetched the new execution's logs — and since its taskruns have new ids, the lines left in `rawLogs` matched nothing and rendered empty.

The execution the logs belong to is now tracked: on a change the stream is closed, the kept lines dropped, and the load decision re-run. Two related fixes in the same diff — the grace-period timer is held in a ref and cancelled when a stream opens (a replay starts in `RESTARTED`, not a running state, so it was armed before `RUNNING` and closed the stream mid-run), and a late `loadLogs` response for an abandoned execution is discarded.

Deliberately untouched: carried-over tasks showing no logs is by design, since `ExecutionService.replay` copies outputs, never logs.

### 🎨 Frontend Checklist

- [x] `npm run check:types`
- [x] `npm run build`
- [x] `npm run test:unit` — 205 files / 1964 tests
- [x] Translations — no translation files touched
- [ ] Screenshots — no visual change to capture; covered by `TaskRunDetails.spec.ts` instead (3 cases, all failing on `develop`)

### 🤖 AI Authors

🐱 A cat hears "tail", chases it, and loses the log — which is precisely the bug.