### PR TITLE
fix(ai): hide the horizontal scrollbar safari draws on the copilot composer textarea

### DIFF
--- a/ui/src/components/ai/copilot/CopilotComposer.vue
+++ b/ui/src/components/ai/copilot/CopilotComposer.vue
@@ -379,6 +379,8 @@
         border: none;
         outline: none;
         resize: none;
+        /* Safari renders a horizontal scrollbar track on auto-overflow textareas even though wrapped text never overflows (kestra#18429). */
+        overflow-x: hidden;
         padding: 0;
         background: transparent;
         color: var(--ks-text-primary);

--- a/ui/src/components/ai/copilot/CopilotComposer.vue
+++ b/ui/src/components/ai/copilot/CopilotComposer.vue
@@ -379,7 +379,7 @@
         border: none;
         outline: none;
         resize: none;
-        /* Safari renders a horizontal scrollbar track on auto-overflow textareas even though wrapped text never overflows (kestra#18429). */
+        /* Safari renders a horizontal scrollbar track on auto-overflow textareas even though wrapped text never overflows. */
         overflow-x: hidden;
         padding: 0;
         background: transparent;


### PR DESCRIPTION
Closes https://github.com/kestra-io/kestra/issues/18429.

### ✨ Description

On `Safari` with classic scrollbars (macOS "Show scroll bars: Always", or a mouse plugged in), the `AI Copilot` composer shows a permanent horizontal scrollbar track inside the chatbox - on the full copilot page, in the sidebar chat, and on the dashboard empty state. `Safari` renders the track on any `textarea` whose `overflow-x` computes to `auto`, even though wrapped text can never overflow horizontally.

The fix sets `overflow-x: hidden` on the composer `textarea`, which removes the track by definition. Vertical behavior is untouched: the textarea still autosizes with its content and falls back to vertical scrolling once it reaches its `max-height`. Verified with `Playwright` `WebKit` 26.5 (the same engine version as the reporter's `Safari` 26.5.2) that the rule changes no layout metrics (`clientWidth`/`scrollWidth`/heights identical before and after).

**Before** (from the issue, `Safari` 26.5.2):

<img width="1018" alt="horizontal scrollbar on the copilot composer" src="https://github.com/user-attachments/assets/2c30a904-b548-44fe-a811-ae507060dd72" />

An after screenshot cannot be captured here: the scrollbar track only renders on macOS `Safari` with classic scrollbars, which is not available in this Linux environment - the after state is simply the same composer without the grey track.

### 🎨 Frontend Checklist

- [x] Type checking passes (`npm run check:types`)
- [x] Lint passes on the changed file (`npx eslint`)