### PR TITLE
fix(namespaces): nested slash paths in namespace file and folder creation

### DIFF
--- a/ui/src/components/inputs/FileExplorer.vue
+++ b/ui/src/components/inputs/FileExplorer.vue
@@ -219,7 +219,7 @@
             "
             width="500"
             appendToBody
-            @keydown.enter.prevent="dialog.name ? dialogHandler() : undefined"
+            @keydown.enter.prevent="dialog.name?.trim() ? dialogHandler() : undefined"
             @opened="focusCreationInput"
         >
             <div class="pb-1">
@@ -259,7 +259,7 @@
                     </KsButton>
                     <KsButton
                         type="primary"
-                        :disabled="!dialog.name"
+                        :disabled="!dialog.name?.trim()"
                         @click="dialogHandler"
                     >
                         {{ $t("namespace files.create.label") }}
@@ -962,16 +962,18 @@
     async function addFile({file, creation, shouldReset = true}: { file?: Omit<TreeNodeFile, "id" | "type">; creation?: boolean; shouldReset?: boolean }) {
         let FILE: Omit<TreeNodeFile, "id" | "type">
         if (creation && dialog.value.name) {
-            const [fileName, extension] = getFileNameWithExtension(dialog.value.name)
+            const [fileName, extension] = getFileNameWithExtension(dialog.value.name.trim())
             FILE = {fileName, extension, content: "", leaf: true}
         } else {
             if(!file) return
             FILE = file
         }
 
-        const {path, file: createdFile} = await filesStore.addFile(FILE, dialog.value.folder, creation)
+        const parentFolder = dialog.value.folder
+        const {path, file: createdFile} = await filesStore.addFile(FILE, parentFolder, creation)
         if (creation) {
             if(path === undefined || createdFile === undefined) return
+            reloadFolder(parentFolder)
             openTab?.({
                 name: createdFile.fileName,
                 path,
@@ -1018,12 +1020,24 @@
 
     async function addFolder(folder?: {fileName: string, children?: TreeNode[]}, creation?: boolean) {
         const parentPath = dialog.value.folder || ""
-        filesStore.addFolder({
-            fileName: dialog.value.name ?? "unknown",
+        const payload = {
+            fileName: dialog.value.name?.trim() ?? "unknown",
             parentPath,
             ...folder,
-        }, creation)
+        }
         dialog.value = {...DIALOG_DEFAULTS}
+        await filesStore.addFolder(payload, creation)
+        reloadFolder(parentPath)
+    }
+
+    /** Re-fetches an already loaded folder, since the tree only diffs its own root level and would otherwise stay stale until a refresh. */
+    function reloadFolder(path?: string) {
+        const node = path ? tree.value?.getNode(filesStore.findNodeByPath(path)?.id) : undefined
+        if (!node?.loaded) {
+            return
+        }
+        node.loaded = false
+        node.expand()
     }
 
     async function showRevisionsHistory(data: TreeNode) {

--- a/ui/src/stores/fileExplorer.spec.ts
+++ b/ui/src/stores/fileExplorer.spec.ts
@@ -1,0 +1,92 @@
+import {beforeEach, describe, expect, it, vi} from "vitest"
+import {createPinia, setActivePinia} from "pinia"
+import {isDirectory, useFileExplorerStore, type TreeNodeDirectory} from "./fileExplorer"
+
+const createDirectory = vi.fn()
+const saveOrCreateFile = vi.fn()
+
+vi.mock("override/stores/namespaces", () => ({
+    useNamespacesStore: () => ({createDirectory, saveOrCreateFile}),
+}))
+vi.mock("vue-i18n", () => ({
+    useI18n: () => ({t: (key: string) => key}),
+}))
+vi.mock("../utils/toast", () => ({
+    useToast: () => ({success: vi.fn(), error: vi.fn()}),
+}))
+
+describe("fileExplorer store", () => {
+    beforeEach(() => {
+        vi.clearAllMocks()
+        setActivePinia(createPinia())
+    })
+
+    function store() {
+        const filesStore = useFileExplorerStore()
+        filesStore.namespaceId = "io.kestra.test"
+        return filesStore
+    }
+
+    it("should create the folder hierarchy when the file name is a path", async () => {
+        const filesStore = store()
+
+        const {path, file} = await filesStore.addFile({fileName: "/work/one", extension: "txt", leaf: true}, undefined, true)
+
+        expect(saveOrCreateFile).toHaveBeenCalledWith({namespace: "io.kestra.test", path: "work/one.txt", content: ""})
+        expect(path).toBe("work/one.txt")
+        expect(file?.fileName).toBe("one.txt")
+
+        const folder = filesStore.fileTree[0]
+        expect(folder.fileName).toBe("work")
+        expect(isDirectory(folder)).toBe(true)
+        expect((folder as TreeNodeDirectory).children.map(child => child.fileName)).toEqual(["one.txt"])
+    })
+
+    it("should resolve the file name path against the selected parent folder", async () => {
+        const filesStore = store()
+        await filesStore.addFolder({fileName: "work"}, true)
+
+        const {path} = await filesStore.addFile({fileName: "nested//one", extension: "txt", leaf: true}, "work", true)
+
+        expect(saveOrCreateFile).toHaveBeenCalledWith({namespace: "io.kestra.test", path: "work/nested/one.txt", content: ""})
+        expect(path).toBe("work/nested/one.txt")
+
+        const work = filesStore.fileTree[0] as TreeNodeDirectory
+        const nested = work.children[0] as TreeNodeDirectory
+        expect(nested.fileName).toBe("nested")
+        expect(nested.children.map(child => child.fileName)).toEqual(["one.txt"])
+    })
+
+    it("should create the folder hierarchy when the folder name is a path", async () => {
+        const filesStore = store()
+
+        await filesStore.addFolder({fileName: "/work/data/"}, true)
+
+        expect(createDirectory).toHaveBeenCalledWith({namespace: "io.kestra.test", path: "work/data"})
+
+        const work = filesStore.fileTree[0] as TreeNodeDirectory
+        expect(work.fileName).toBe("work")
+        expect(work.children.map(child => child.fileName)).toEqual(["data"])
+    })
+
+    it("should keep a listed file name verbatim, spaces included", async () => {
+        const filesStore = store()
+
+        const {path} = await filesStore.addFile({fileName: " spaced ", extension: "txt", leaf: true})
+
+        expect(path).toBe(" spaced .txt")
+        expect(filesStore.fileTree.map(node => node.fileName)).toEqual([" spaced .txt"])
+    })
+
+    it("should not create anything when the name only holds separators", async () => {
+        const filesStore = store()
+
+        await filesStore.addFolder({fileName: "//"}, true)
+        const {path} = await filesStore.addFile({fileName: "/", extension: "", leaf: true}, undefined, true)
+
+        expect(createDirectory).not.toHaveBeenCalled()
+        expect(saveOrCreateFile).not.toHaveBeenCalled()
+        expect(path).toBeUndefined()
+        expect(filesStore.fileTree).toEqual([])
+    })
+})

--- a/ui/src/stores/fileExplorer.ts
+++ b/ui/src/stores/fileExplorer.ts
@@ -58,6 +58,10 @@ export function getFileNameWithExtension(fileNameWithExtension: string): [string
         : [fileNameWithExtension, ""]
 }
 
+function pathSegments(path: string): string[] {
+    return path.split("/").filter(Boolean)
+}
+
 function readFile(file: File): Promise<ArrayBuffer> {
     return new Promise((resolve, reject) => {
         const reader = new FileReader()
@@ -95,23 +99,26 @@ export const useFileExplorerStore = defineStore("fileExplorer", () => {
         }
     }
 
-    function pushToParentFolder(parentPath: string, newNode: TreeNode) {
-        const traverseAndInsert = (basePath = "", array: TreeNode[]) => {
-            for (const item of array) {
-                const folderPath = `${basePath}${item.fileName}`
-                if (folderPath === parentPath && isDirectory(item) && Array.isArray(item.children)) {
-                    if (!item.children.find((child) => child.fileName === newNode.fileName)) {
-                        item.children.push(newNode)
-                        item.children = sorted(item.children)
-                    }
-                    return true
-                } else if (isDirectory(item) && Array.isArray(item.children)) {
-                    if (traverseAndInsert(`${folderPath}/`, item.children)) return true
-                }
+    /**
+     * Creates the folder nodes missing along `segments`
+     * and returns the deepest one's children, or
+     * undefined when a file already holds one of those names.
+     */
+    function ensureFolderPath(segments: string[]): TreeNode[] | undefined {
+        let children = fileTree.value
+        for (const segment of segments) {
+            const existing = children.find((item) => item.fileName === segment)
+            if (existing && !isDirectory(existing)) {
+                return undefined
             }
-            return false
+            const folder = existing ?? folderNode(segment, [])
+            if (!existing) {
+                children.push(folder)
+                sorted(children)
+            }
+            children = folder.children
         }
-        traverseAndInsert("", fileTree.value)
+        return children
     }
 
     function getSiblingsAtPath(parentPath: string): TreeNode[] {
@@ -137,11 +144,14 @@ export const useFileExplorerStore = defineStore("fileExplorer", () => {
     }, creation?: boolean) {
         if(!namespaceId.value) return
         const {fileName, parentPath = ""} = folder
-        const NEW = folderNode(fileName, folder?.children ?? [])
-        const path = parentPath ? `${parentPath}/${fileName}` : fileName
+        const segments = [...pathSegments(parentPath), ...pathSegments(fileName)]
+        const name = segments.pop()
+        if (!name) {
+            return
+        }
+        const path = [...segments, name].join("/")
         if (creation) {
-            const siblings = getSiblingsAtPath(parentPath)
-            const conflict = siblings.find(item => item.fileName === fileName)
+            const conflict = getSiblingsAtPath(segments.join("/")).find(item => item.fileName === name)
             if (conflict) {
                 if (isDirectory(conflict)) {
                     toast.error(t("namespace files.create.folder_already_exists"))
@@ -152,31 +162,19 @@ export const useFileExplorerStore = defineStore("fileExplorer", () => {
             }
             try {
                 await namespacesStore.createDirectory({namespace: namespaceId.value, path})
-                if (!parentPath) {
-                    fileTree.value.push(NEW)
-                    fileTree.value = sorted(fileTree.value)
-                } else {
-                    pushToParentFolder(parentPath, NEW)
-                }
-                toast.success(`Folder "${fileName}" created successfully.`)
+                toast.success(`Folder "${name}" created successfully.`)
             } catch (error) {
-                console.error(`Failed to create folder: ${fileName}`, error)
+                console.error(`Failed to create folder: ${name}`, error)
                 toast.error(t("namespace files.create.folder_error"))
                 return
             }
-
+        }
+        const parent = ensureFolderPath(segments)
+        if (!parent || parent.find(item => item.fileName === name)) {
             return
         }
-        if (!parentPath) {
-            const firstFolder = NEW.fileName.split("/")[0]
-            if (!fileTree.value.find(item => item.fileName === firstFolder)) {
-                NEW.fileName = firstFolder
-                fileTree.value.push(NEW)
-                fileTree.value = sorted(fileTree.value)
-            }
-        } else {
-            pushToParentFolder(parentPath, NEW)
-        }
+        parent.push(folderNode(name, folder?.children ?? []))
+        sorted(parent)
     }
 
     async function searchFilesList(value: string) {
@@ -209,19 +207,23 @@ export const useFileExplorerStore = defineStore("fileExplorer", () => {
     async function addFile(file: Omit<TreeNodeFile, "id" | "type">, parentPath?: string, creation: boolean = false): Promise<{ path?: string; file?: TreeNodeFile; }> {
         if(!namespaceId.value) return {}
         const {fileName, extension, content = "", leaf} = file
-        const NAME = `${fileName}${extension ? `.${extension}` : ""}`
+        const segments = [...pathSegments(parentPath ?? ""), ...pathSegments(`${fileName}${extension ? `.${extension}` : ""}`)]
+        const NAME = segments.pop()
+        if (!NAME) {
+            return {}
+        }
+        const path = [...segments, NAME].join("/")
 
         const NEW: TreeNodeFile = {
             id: Utils.uid(),
             fileName: NAME,
-            extension,
+            extension: getFileNameWithExtension(NAME)[1],
             content,
             type: "File",
             leaf,
         }
-        const path = `${parentPath ? `${parentPath}/` : ""}${NAME}`
         if (creation) {
-            const siblings = getSiblingsAtPath(parentPath ?? "")
+            const siblings = getSiblingsAtPath(segments.join("/"))
             const conflict = siblings.find(item => item.fileName === NAME)
             if (conflict) {
                 if (!isDirectory(conflict)) {
@@ -244,11 +246,10 @@ export const useFileExplorerStore = defineStore("fileExplorer", () => {
                 return {}
             }
         }
-        if (!parentPath) {
-            fileTree.value.push(NEW)
-            fileTree.value = sorted(fileTree.value)
-        } else {
-            pushToParentFolder(parentPath, NEW)
+        const parent = ensureFolderPath(segments)
+        if (parent && !parent.find(item => item.fileName === NAME)) {
+            parent.push(NEW)
+            sorted(parent)
         }
         return {path, file: NEW}
     }


### PR DESCRIPTION
Closes https://github.com/kestra-io/kestra/issues/18464.

**What was the issue**

Typing a path like `/work/one.txt` in the create dialog made one file whose name was the whole string. The real folder only showed up after a page refresh, and anything created inside an existing folder stayed hidden until then too.

**Fix**

The typed name is now read as a path: it is normalized, joined with the selected parent folder, and the missing folders are added to the tree. A folder that is already open is re-fetched so the new item shows up right away.

**What now**

`/work/one.txt` creates `work/one.txt`, the tree shows the folder immediately, and the tab is named `one.txt`.
