### PR TITLE
fix(core): return 400 for a malformed query filter

### DIFF
--- a/core/src/main/java/io/kestra/core/exceptions/InvalidQueryFiltersException.java
+++ b/core/src/main/java/io/kestra/core/exceptions/InvalidQueryFiltersException.java
@@ -28,4 +28,14 @@ public class InvalidQueryFiltersException extends KestraRuntimeException {
     public InvalidQueryFiltersException(final String invalid) {
         super(INVALID_QUERY_FILTER_MESSAGE.formatted(invalid));
     }
+
+    /**
+     * Creates a new {@link InvalidQueryFiltersException} instance.
+     *
+     * @param invalid the invalid filter.
+     * @param cause the underlying cause.
+     */
+    public InvalidQueryFiltersException(final String invalid, final Throwable cause) {
+        super(INVALID_QUERY_FILTER_MESSAGE.formatted(invalid), cause);
+    }
 }

--- a/core/src/main/java/io/kestra/core/models/QueryFilter.java
+++ b/core/src/main/java/io/kestra/core/models/QueryFilter.java
@@ -110,7 +110,12 @@ public record QueryFilter(
         IS_NULL,
         IS_NOT_NULL,
         REGEX,
-        PREFIX
+        PREFIX;
+
+        @JsonCreator
+        public static Op fromString(String value) {
+            return Enums.getForNameIgnoreCase(value, Op.class);
+        }
     }
 
     @SuppressWarnings("unchecked")

--- a/webserver/src/main/java/io/kestra/webserver/converters/QueryFilterFormatBinder.java
+++ b/webserver/src/main/java/io/kestra/webserver/converters/QueryFilterFormatBinder.java
@@ -8,6 +8,7 @@ import java.util.regex.Pattern;
 
 import com.google.common.annotations.VisibleForTesting;
 
+import io.kestra.core.exceptions.InvalidQueryFiltersException;
 import io.kestra.core.models.QueryFilter;
 import io.kestra.core.models.QueryFilter.Logical;
 import io.kestra.webserver.configuration.QueryFilterConfiguration;
@@ -54,7 +55,9 @@ public class QueryFilterFormatBinder implements AnnotatedRequestArgumentBinder<Q
 
             Matcher m = FILTER_PATTERN.matcher(key);
             if (!m.matches()) {
-                continue;
+                throw new InvalidQueryFiltersException(
+                    "Query filter '%s' is malformed. Expected filters[<field>][<operation>] or filters[<field>][<operation>][<key>].".formatted(key)
+                );
             }
 
             String prefixChain = m.group(1);
@@ -67,7 +70,7 @@ public class QueryFilterFormatBinder implements AnnotatedRequestArgumentBinder<Q
         }
         List<QueryFilter> filters = root.build(maxWidth);
         if (filters.size() > maxWidth) {
-            throw new IllegalArgumentException(
+            throw new InvalidQueryFiltersException(
                 "QueryFilter root width (" + filters.size() + ") exceeds maximum of " + maxWidth
             );
         }
@@ -83,7 +86,7 @@ public class QueryFilterFormatBinder implements AnnotatedRequestArgumentBinder<Q
         int depth = 0;
         while (pm.find()) {
             if (++depth > maxDepth) {
-                throw new IllegalArgumentException(
+                throw new InvalidQueryFiltersException(
                     "QueryFilter nesting depth exceeds maximum of " + maxDepth
                 );
             }
@@ -129,7 +132,7 @@ public class QueryFilterFormatBinder implements AnnotatedRequestArgumentBinder<Q
 
     private static void checkWidth(int count, int maxWidth) {
         if (count > maxWidth) {
-            throw new IllegalArgumentException(
+            throw new InvalidQueryFiltersException(
                 "QueryFilter node width (" + count + ") exceeds maximum of " + maxWidth
             );
         }
@@ -153,8 +156,14 @@ public class QueryFilterFormatBinder implements AnnotatedRequestArgumentBinder<Q
         }
 
         void addLeaf(String fieldStr, String operationStr, String nestedKey, List<String> values) {
-            QueryFilter.Field field = QueryFilter.Field.fromString(fieldStr);
-            QueryFilter.Op op = QueryFilter.Op.valueOf(operationStr);
+            QueryFilter.Field field;
+            QueryFilter.Op op;
+            try {
+                field = QueryFilter.Field.fromString(fieldStr);
+                op = QueryFilter.Op.fromString(operationStr);
+            } catch (IllegalArgumentException e) {
+                throw new InvalidQueryFiltersException(e.getMessage(), e);
+            }
 
             if (field == QueryFilter.Field.LABELS && nestedKey != null) {
                 labelsByOp.computeIfAbsent(op, k -> new HashMap<>()).put(nestedKey, values.getFirst());

--- a/webserver/src/main/java/io/kestra/webserver/services/ai/agent/tool/QueryFilterToolExecutor.java
+++ b/webserver/src/main/java/io/kestra/webserver/services/ai/agent/tool/QueryFilterToolExecutor.java
@@ -102,7 +102,7 @@ public final class QueryFilterToolExecutor implements ToolExecutor {
             String operatorName = String.valueOf(entry.get("operator"));
             QueryFilter.Op op;
             try {
-                op = QueryFilter.Op.valueOf(operatorName);
+                op = QueryFilter.Op.fromString(operatorName);
             } catch (IllegalArgumentException e) {
                 throw new IllegalArgumentException("Unknown operator '%s' for field '%s'".formatted(operatorName, field.name()));
             }

--- a/webserver/src/test/java/io/kestra/webserver/controllers/api/ExecutionControllerTest.java
+++ b/webserver/src/test/java/io/kestra/webserver/controllers/api/ExecutionControllerTest.java
@@ -417,6 +417,15 @@ class ExecutionControllerTest {
         assertThat(exception.getMessage()).doesNotContainIgnoringCase("select");
         assertThat(exception.getMessage()).doesNotContain("SQL [");
         assertThat(exception.getMessage()).contains("[a-");
+
+        exception = assertThrows(
+            HttpClientResponseException.class, () -> client.toBlocking().retrieve(
+                GET(
+                    "/api/v1/main/executions/search?filters[namespace][BOGUS_OP]=test"
+                ), PagedResults.class
+            )
+        );
+        assertThat(exception.getStatus().getCode()).isEqualTo(HttpStatus.BAD_REQUEST.getCode());
     }
 
     @Test

--- a/webserver/src/test/java/io/kestra/webserver/converters/QueryFilterFormatBinderTest.java
+++ b/webserver/src/test/java/io/kestra/webserver/converters/QueryFilterFormatBinderTest.java
@@ -8,6 +8,7 @@ import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.Test;
 
+import io.kestra.core.exceptions.InvalidQueryFiltersException;
 import io.kestra.core.models.QueryFilter;
 import io.kestra.webserver.utils.RequestUtils;
 
@@ -115,15 +116,30 @@ class QueryFilterFormatBinderTest {
     }
 
     @Test
-    void testGetQueryFiltersWithInvalidFilterPattern() {
+    void shouldRejectMalformedFilterKey() {
         // GIVEN
         Map<String, List<String>> queryParams = Map.of(
             "filters[invalid]", List.of("test-value")
         );
+        // WHEN / THEN
+        assertThrows(
+            InvalidQueryFiltersException.class, () -> QueryFilterFormatBinder.getQueryFilters(queryParams)
+        );
+    }
+
+    @Test
+    void shouldRejectUnknownOperator() {
+        // GIVEN
+        Map<String, List<String>> queryParams = Map.of(
+            "filters[namespace][BOGUS_OP]", List.of("test-namespace")
+        );
         // WHEN
-        List<QueryFilter> filters = QueryFilterFormatBinder.getQueryFilters(queryParams);
-        // THEN
-        assertEquals(0, filters.size(), "Invalid filters should be ignored");
+        InvalidQueryFiltersException ex = assertThrows(
+            InvalidQueryFiltersException.class, () -> QueryFilterFormatBinder.getQueryFilters(queryParams)
+        );
+        // THEN — the offending token is named, and the internal enum class name is not leaked
+        assertTrue(ex.getMessage().contains("BOGUS_OP"), "Expected the offending token, got: " + ex.getMessage());
+        assertFalse(ex.getMessage().contains("io.kestra"), "Internal class name leaked: " + ex.getMessage());
     }
 
     @Test
@@ -233,8 +249,8 @@ class QueryFilterFormatBinderTest {
 
         // WHEN / THEN — parser throws on the 4th descent; no SQL is generated
         // Equivalent SQL: <none — request is rejected at the binder>
-        IllegalArgumentException ex = assertThrows(
-            IllegalArgumentException.class, () -> QueryFilterFormatBinder.getQueryFilters(queryParams, 3, Integer.MAX_VALUE)
+        InvalidQueryFiltersException ex = assertThrows(
+            InvalidQueryFiltersException.class, () -> QueryFilterFormatBinder.getQueryFilters(queryParams, 3, Integer.MAX_VALUE)
         );
         assertTrue(
             ex.getMessage().contains("depth"),
@@ -252,8 +268,8 @@ class QueryFilterFormatBinderTest {
 
         // WHEN / THEN — width check throws; the OR node would have 21 children
         // Equivalent SQL: <none — request is rejected at the binder>
-        IllegalArgumentException ex = assertThrows(
-            IllegalArgumentException.class, () -> QueryFilterFormatBinder.getQueryFilters(queryParams, Integer.MAX_VALUE, 20)
+        InvalidQueryFiltersException ex = assertThrows(
+            InvalidQueryFiltersException.class, () -> QueryFilterFormatBinder.getQueryFilters(queryParams, Integer.MAX_VALUE, 20)
         );
         assertTrue(
             ex.getMessage().contains("width"),
@@ -274,8 +290,8 @@ class QueryFilterFormatBinderTest {
 
         // WHEN / THEN — root produces 21 sibling leaves, exceeding the width cap
         // Equivalent SQL: <none — request is rejected at the binder>
-        IllegalArgumentException ex = assertThrows(
-            IllegalArgumentException.class, () -> QueryFilterFormatBinder.getQueryFilters(queryParams, Integer.MAX_VALUE, 20)
+        InvalidQueryFiltersException ex = assertThrows(
+            InvalidQueryFiltersException.class, () -> QueryFilterFormatBinder.getQueryFilters(queryParams, Integer.MAX_VALUE, 20)
         );
         assertTrue(
             ex.getMessage().contains("width"),


### PR DESCRIPTION
Closes https://github.com/kestra-io/kestra/issues/18646.

filters[...] query params on search endpoints returned 422 when the filter expression itself was unparseable (unknown field or operator name, malformed bracket shape, nesting/width past the configured cap) while every other filter validation already used 400 via InvalidQueryFiltersException. Clients couldn't reliably branch on status to detect "the filter I sent is invalid".

QueryFilterFormatBinder now raises InvalidQueryFiltersException for these structural errors instead of letting a raw IllegalArgumentException escape to ErrorController's 422 handler. A malformed filters[...] key is now rejected instead of silently dropped, which previously returned unfiltered results. QueryFilter.Op gained a fromString factory (matching Field and Logical) so the binder no longer leaks the internal enum class name in error messages.

Filter *value* errors (bad scope value, unparseable timeRange, inverted dates, an out-of-range group index) are unchanged and still return 422 - the request was understood, just not processable.
