### PR TITLE
fix(core): keep the array branch of AbstractFlow.labels in the OpenAPI spec

### DIFF
--- a/core/src/main/java/io/kestra/core/models/flows/AbstractFlow.java
+++ b/core/src/main/java/io/kestra/core/models/flows/AbstractFlow.java
@@ -81,7 +81,7 @@ public abstract class AbstractFlow implements FlowInterface {
         description = "Labels as a list of Label (key/value pairs) or as a map of string to string.",
         implementation = Object.class,
         oneOf = {
-            Label[].class,
+            List.class,
             Map.class
         }
     )


### PR DESCRIPTION
## What

`AbstractFlow.labels` declares both branches:

```java
@Schema(implementation = Object.class, oneOf = { Label[].class, Map.class })
List<Label> labels;
```

but the generated spec only ever contained one:

```yaml
labels:
  oneOf:
  - $ref: "#/components/schemas/Map_Object.Object_"
```

The array branch is dropped outright. This switches `Label[].class` → `List.class`, which restores it.

## Why it disappears

The generator can't express a typed array inside a `oneOf`. Across all 19 `oneOf` blocks in the generated spec, **not one array branch carries an `items` schema**. An array *class* (`Label[]`) doesn't degrade to an untyped array — it vanishes entirely. `SLA.labels` and `AbstractTrigger.labels` declare the same intent as `List.class` and do survive, as `{ type: array }`.

## Why it matters

`labels` is **array-only on the wire**. `ListOrMapOfLabelDeserializer` accepts a map or an array and normalises both to `List<Label>`; the field is `List<Label>`, so `ListOrMapOfLabelSerializer` always writes an array. The map form is a legacy *input* convenience, never a response shape.

So a client generated faithfully from this spec binds `labels` as a map and then fails on every labelled flow. That is exactly what happened to the Go SDK in `kestra-io/client-sdk` (it needed a tolerant `UnmarshalJSON` to work around it), and the JavaScript SDK — which generates from this spec — currently mistypes it the same way. The Java SDK escaped only because it is hand-written and ignored the spec.

## Verification

Generated `openapi.yml` before and after on this branch. The diff is exactly four added lines, in the four schemas that inherit these labels — no other schema changed:

```diff
           description: Labels as a list of Label (key/value pairs) or as a map of
             string to string.
           oneOf:
+          - type: array
           - $ref: "#/components/schemas/Map_Object.Object_"
```

`:core:test --tests JsonSchemaGeneratorTest` and the `LabelTest` / `Rfc1123LabelTest` suites pass. The change is annotation metadata only — Jackson ser/deser is untouched.

## Follow-up, not in this PR

Element typing is still lost (`{ type: array }` with no `items: $ref: Label`). Making the generator emit typed arrays inside `oneOf` would fix that for all 19 sites at once, and is worth doing separately.
