### PR TITLE
fix(executions): respect the Timezone setting in the Gantt scale and state-history timeline (1.3 backport)

### DIFF
--- a/ui/src/components/executions/Gantt.vue
+++ b/ui/src/components/executions/Gantt.vue
@@ -135,7 +135,7 @@
 
 <script setup lang="ts">
     import {ref, computed, watch, onUnmounted} from "vue";
-    import moment from "moment";
+    import {date as dateFilter} from "../../utils/filters";
     import {useI18n} from "vue-i18n";
     import {useRoute} from "vue-router";
     // @ts-expect-error no types yet
@@ -165,6 +165,9 @@
     } from "../filter/utils/logLevelQuery";
     import {useRouteFilterPolicy} from "../filter/composables/useRouteFilterPolicy";
     import {useExecutionsStore, type Execution} from "../../stores/executions";
+
+    // Explicit 24-hour format: the scale has no room for AM/PM, so a 12-hour clock would be ambiguous.
+    const TICK_FORMAT = "HH:mm:ss";
 
     interface TaskRun {
         id: string;
@@ -397,15 +400,13 @@
 
     const startTime = computed<string>(() => {
         if (!execution.value) return "";
-        return moment(execution.value.state.histories![0].date).format("HH:mm:ss");
+        return dateFilter(execution.value.state.histories![0].date, TICK_FORMAT);
     });
 
     const endTime = computed<string>(() => {
-        if (!execution.value) return "";
-        const endDate = State.isRunning(execution.value.state.current)
-            ? new Date()
-            : new Date(stop());
-        return moment(endDate).format("HH:mm:ss");
+        if (!execution.value || !hasValidDate.value) return "";
+        const endDate = State.isRunning(execution.value.state.current) ? Date.now() : stop();
+        return dateFilter(endDate, TICK_FORMAT);
     });
 
     // Methods
@@ -507,8 +508,15 @@
     }
 
     function computeDates(): void {
+        // An execution cancelled or failed before any task started has no span to divide, so
+        // `delta()` is non-finite and every tick would be an unusable placeholder.
+        if (!hasValidDate.value) {
+            dates.value = [];
+            return;
+        }
+
         const ticks = 5;
-        const formatDate = (timestamp: number): string => moment(timestamp).format("h:mm:ss");
+        const formatDate = (timestamp: number): string => dateFilter(timestamp, TICK_FORMAT);
         const startVal = start.value;
         const deltaVal = delta() / ticks;
         const newDates: string[] = [];

--- a/ui/src/components/executions/overview/components/sidebar/Timeline.vue
+++ b/ui/src/components/executions/overview/components/sidebar/Timeline.vue
@@ -23,15 +23,15 @@
     import type {Histories} from "../../../../../stores/executions";
 
     import {getSchemeValue} from "../../../../../utils/scheme";
-
-    import moment from "moment";
+    import {date as dateFilter} from "../../../../../utils/filters";
 
     import ChevronDown from "vue-material-design-icons/ChevronDown.vue";
 
     const props = defineProps<{ histories: Histories[] }>();
 
     const formatDate = (date: string) => {
-        return moment(date)?.format("YYYY-MM-DD HH:mm:ss.SSS") ?? date;
+        // "iso" is the filter's sentinel for YYYY-MM-DD HH:mm:ss.SSS.
+        return dateFilter(date, "iso");
     };
 </script>
 

--- a/ui/src/utils/filters.ts
+++ b/ui/src/utils/filters.ts
@@ -17,9 +17,20 @@ export function cap (value:string) {
 export function lower (value:string) {
     return value ? value.toString().toLowerCase() : "";
 }
-export function date (dateString:string, format?:string) {
+/**
+ * Formats an instant in the timezone and date format from Settings.
+ *
+ * Accepts what `moment` accepts: an ISO string, an epoch millisecond timestamp, or a `Date`.
+ * Callers must not pre-serialise a timestamp with `toISOString()` — that throws on a
+ * non-finite value, whereas `moment` degrades to the string "Invalid date".
+ *
+ * @param dateValue the instant to format
+ * @param format    a moment format, or "iso" for `YYYY-MM-DD HH:mm:ss.SSS`; defaults to the
+ *                  user's stored date format
+ */
+export function date (dateValue:string | number | Date, format?:string) {
     const currentLocale = moment().locale();
-    const momentInstance = moment(dateString).locale(currentLocale);
+    const momentInstance = moment(dateValue).locale(currentLocale);
     let f;
     if (format === "iso") {
         f = "YYYY-MM-DD HH:mm:ss.SSS";

--- a/ui/tests/unit/utils/filters.spec.ts
+++ b/ui/tests/unit/utils/filters.spec.ts
@@ -1,5 +1,7 @@
-import {afterEach, describe, expect, it} from "vitest";
-import {humanizeNumber} from "../../../src/utils/filters";
+import {afterEach, beforeEach, describe, expect, it} from "vitest";
+import moment from "moment-timezone";
+import {date, humanizeNumber} from "../../../src/utils/filters";
+import {storageKeys} from "../../../src/utils/constants";
 
 describe("humanizeNumber", () => {
     afterEach(() => {
@@ -22,5 +24,48 @@ describe("humanizeNumber", () => {
         localStorage.setItem("lang", "de");
 
         expect(humanizeNumber("1234567")).toBe((1234567).toLocaleString("de"));
+    });
+});
+
+describe("date", () => {
+    const INSTANT = "2026-07-24T13:16:00.000Z";
+    const TIMEZONE = "America/Los_Angeles";
+
+    beforeEach(() => localStorage.clear());
+    afterEach(() => localStorage.clear());
+
+    it("formats in the timezone from settings rather than the machine one", () => {
+        localStorage.setItem(storageKeys.TIMEZONE_STORAGE_KEY, TIMEZONE);
+
+        // 13:16 UTC is 06:16 in Los Angeles, so a wrong timezone shows a different hour.
+        expect(date(INSTANT, "HH:mm:ss")).toBe("06:16:00");
+    });
+
+    // The Gantt scale divides a time span into tick timestamps, so it has epoch millis rather
+    // than a string. Pre-serialising those with toISOString() threw on a non-finite value.
+    it.each([
+        ["an epoch millisecond timestamp", moment(INSTANT).valueOf()],
+        ["a Date", new Date(INSTANT)],
+        ["an ISO string", INSTANT]
+    ])("accepts %s", (_label, value) => {
+        localStorage.setItem(storageKeys.TIMEZONE_STORAGE_KEY, TIMEZONE);
+
+        expect(date(value as string | number | Date, "HH:mm:ss")).toBe("06:16:00");
+    });
+
+    // An execution cancelled before any task started yields a non-finite span; the label must
+    // degrade rather than throw, which is what `new Date(NaN).toISOString()` did.
+    it.each([
+        ["NaN", NaN],
+        ["-Infinity", -Infinity]
+    ])("degrades to a placeholder for %s instead of throwing", (_label, value) => {
+        expect(() => date(value, "HH:mm:ss")).not.toThrow();
+        expect(date(value, "HH:mm:ss")).toBe("Invalid date");
+    });
+
+    it("resolves the \"iso\" sentinel to a full timestamp", () => {
+        localStorage.setItem(storageKeys.TIMEZONE_STORAGE_KEY, "UTC");
+
+        expect(date(INSTANT, "iso")).toBe("2026-07-24 13:16:00.000");
     });
 });


### PR DESCRIPTION
### 🔗 Related Issue

Backport of https://github.com/kestra-io/kestra/pull/18528 to `releases/v1.3.x`, as decided in https://github.com/kestra-io/kestra/pull/18528#pullrequestreview-5015796184 ("the bug reproduces on both older lines"). Original issues https://github.com/kestra-io/kestra/issues/18453 and https://github.com/kestra-io/kestra/issues/18456 are already closed by the develop PR, so no closing keyword here.

### ✨ Description

The Gantt time scale and the execution Overview state-history timeline formatted their timestamps with a bare `moment(...)`, so both followed the browser machine's timezone while the executions list and the logs use the Timezone from Settings. The same execution showed a different clock time depending on which surface you looked at.

Both now format through `utils/filters#date`, which applies the stored timezone and date format the way the rest of the app does. The Gantt ticks also move from `h:mm:ss` to an explicit 24-hour `HH:mm:ss`: the scale has no room for AM/PM, so a 12-hour clock left `4:41:19` ambiguous.

`filters#date` takes `string | number | Date` rather than only a string, so the scale passes the epoch millis it already holds instead of serialising them with `toISOString()` — which throws on the non-finite span of an execution with no task runs, where `moment` degrades to `"Invalid date"`. `computeDates` and `endTime` additionally return early on `hasValidDate`, the flag the component already computes for that state and the scale header is already gated on.

**What is adapted, and why the cherry-pick does not apply:** 1.3 predates the Run timeline rewrite, so the second call site is `overview/components/sidebar/Timeline.vue` rather than `RunTimeline.vue`, and the file uses semicolons. Everything else matches the develop change line for line.

### 🎨 Frontend Checklist

- [x] Type checking passes (`npm run check:types`)
- [x] Code builds without errors (`npm run build`)
- [x] Unit tests pass (`npm run test:unit` — 27 files, 188 tests)
- [x] Translations unchanged — `en.json` is not touched
- [ ] Screenshots or video recordings attached — see Additional Notes

### 📝 Additional Notes

- **No screenshot.** I have no running instance in this environment, and the sandbox proxy blocks GitHub `user-attachments`, so the visible result is unverified. The change is a substitution at three call sites, so the risk is in whether `filters#date` is the right helper rather than in layout — but a look at the Gantt header before merge would be worth it.
- **What the tests cover.** The seven new `filters#date` cases assert the helper contract the three call sites now depend on: the timezone from Settings, the three accepted input shapes, and non-finite input degrading instead of throwing. They pass against `releases/v1.3.x` too — 1.3's `filters#date` already applied the timezone, so what the backport changes is *who calls it*. Neither `Gantt.vue` nor `Timeline.vue` has a test or a story on 1.3 (`find src -name "*.stories.*"` returns nothing there), so nothing asserts their rendered output. Say the word if you want a mounted `Timeline.vue` spec instead; it needs an Element Plus stub harness that does not exist on this branch yet.
- **Merge order.** Independent of the other two 1.3 backports — no shared file with https://github.com/kestra-io/kestra/pull/18546 or the column-picker one.

### 🤖 AI Authors

Yes, I read the template. Why did the cat sit on the Gantt chart? It heard there were five ticks and wanted every one of them. 🐱

---
_Generated by [Claude Code](https://claude.ai/code/session_01D7z6UoPNC4QReogvgDLnxX)_