### PR TITLE
fix(core): apply the Timezone setting to revisions, dashboard dates and metric labels (1.3 backport)

### DIFF
--- a/ui/src/components/dashboard/sections/table/columns/Date.spec.ts
+++ b/ui/src/components/dashboard/sections/table/columns/Date.spec.ts
@@ -1,0 +1,38 @@
+import {describe, expect, it, beforeEach, afterEach} from "vitest";
+import {mount} from "@vue/test-utils";
+import moment from "moment-timezone";
+
+import {storageKeys} from "../../../../../utils/constants";
+import DateColumn from "./Date.vue";
+
+const FIELD = "2026-07-24T13:16:00.000Z";
+const TIMEZONE = "America/Los_Angeles";
+
+describe("dashboard table Date column", () => {
+    beforeEach(() => localStorage.clear());
+    afterEach(() => localStorage.clear());
+
+    it("should format in the timezone from settings rather than the machine one", () => {
+        localStorage.setItem(storageKeys.TIMEZONE_STORAGE_KEY, TIMEZONE);
+
+        const wrapper = mount(DateColumn, {props: {field: FIELD}});
+
+        expect(wrapper.text()).toBe(moment(FIELD).tz(TIMEZONE).format("llll"));
+    });
+
+    // The format used to be read once at module scope, so a change in Settings only took
+    // effect after a full reload.
+    it("should honour the date format from settings alongside the timezone", () => {
+        localStorage.setItem(storageKeys.TIMEZONE_STORAGE_KEY, TIMEZONE);
+        localStorage.setItem(storageKeys.DATE_FORMAT_STORAGE_KEY, "YYYY-MM-DD HH:mm");
+
+        const wrapper = mount(DateColumn, {props: {field: FIELD}});
+
+        // 13:16 UTC is 06:16 in Los Angeles, so a wrong timezone shows a different hour.
+        expect(wrapper.text()).toBe("2026-07-24 06:16");
+    });
+
+    it("should render nothing when there is no field", () => {
+        expect(mount(DateColumn, {props: {}}).text()).toBe("");
+    });
+});

--- a/ui/src/components/dashboard/sections/table/columns/Date.vue
+++ b/ui/src/components/dashboard/sections/table/columns/Date.vue
@@ -4,8 +4,7 @@
 
 <script setup lang="ts">
     import {computed} from "vue";
-    import moment from "moment";
-    import {storageKeys} from "../../../../../utils/constants"
+    import {date as dateFilter} from "../../../../../utils/filters";
 
     const props = defineProps({
         field: {
@@ -14,12 +13,10 @@
         },
     });
 
-    const momentLongDateFormat = "llll";
-    const format = localStorage.getItem(storageKeys.DATE_FORMAT_STORAGE_KEY) ?? momentLongDateFormat;
     const formatDateIfPresent = (rawDate: string|undefined) => {
         if(rawDate){
             // moment(date) always return a Moment, if the date is undefined, it will return current date, we don't want that here
-            return moment(rawDate).format(format) ?? props.field;
+            return dateFilter(rawDate);
         } else {
             return undefined;
         }

--- a/ui/src/components/flows/FlowMetrics.vue
+++ b/ui/src/components/flows/FlowMetrics.vue
@@ -48,7 +48,7 @@
     import {ref, computed, watch} from "vue";
     import {useRoute, useRouter} from "vue-router";
     import {Bar} from "vue-chartjs";
-    import moment from "moment";
+    import {date as dateFilter} from "../../utils/filters";
     import {useI18n} from "vue-i18n";
     import {useMiscStore} from "override/stores/misc";
     import {useFlowStore} from "../../stores/flow";
@@ -94,7 +94,7 @@
         
         return {
             labels: aggregations.map((e: MetricAggregation) =>
-                moment(e.date).format(getFormat(groupBy)),
+                dateFilter(e.date, getFormat(groupBy)),
             ),
             datasets: [
                 !display.value

--- a/ui/src/components/layout/Revisions.vue
+++ b/ui/src/components/layout/Revisions.vue
@@ -116,7 +116,7 @@
     import Restore from "vue-material-design-icons/Restore.vue";
     import TrashCanOutline from "vue-material-design-icons/TrashCanOutline.vue";
     import Editor from "../../components/inputs/Editor.vue";
-    import moment from "moment";
+    import {date as dateFilter} from "../../utils/filters";
 
     import {useToast} from "../../utils/toast";
     import {useFlowStore} from "../../stores/flow";
@@ -230,7 +230,9 @@
     function formatTimestamp(updatedDate?: string): string {
         if (!updatedDate) return "";
 
-        return moment(updatedDate).format("YYYY-MM-DD HH:mm");
+        // Pinned format: the revision list has a fixed-width column, so it does not follow
+        // the date format from Settings — only the timezone.
+        return dateFilter(updatedDate, "YYYY-MM-DD HH:mm");
     }
 
     function formatRevisionText(revision: number): string {


### PR DESCRIPTION
### 🔗 Related Issue

Backport of https://github.com/kestra-io/kestra/pull/18546 to `releases/v1.3.x`, as decided in https://github.com/kestra-io/kestra/pull/18546#pullrequestreview-5015861735 ("both changed files carry the same bug on `origin/releases/v1.3.x` — all three surfaces"). Original issue https://github.com/kestra-io/kestra/issues/18541 is already closed by the develop PR, so no closing keyword here.

### ✨ Description

Three display surfaces formatted an instant with a bare `moment(...)`, so they followed the browser machine's timezone while the rest of the app uses the Timezone from Settings: the dashboard table Date column, the flow metrics chart labels, and the revision list timestamps. All three now go through `utils/filters#date`.

For the dashboard column that also fixes a second defect on this branch: the date format was read into a module-level `const`, so changing it in Settings only took effect after a full page reload. `filters#date` reads it per call.

The revision list keeps its pinned `YYYY-MM-DD HH:mm` format on purpose — the column is fixed-width — so only its timezone changes.

**What is adapted, and why the cherry-pick does not apply:** 1.3's `columns/Date.vue` has no `relative` variant and no tooltip, so the `inTimezone`/`calendar()` half of the develop change has nothing to apply to and the whole column collapses to one `dateFilter(rawDate)` call. `develop`'s `Date.spec.ts` is written against the tooltip markup, so the spec here is a 1.3-shaped rewrite rather than a copy.

### 🎨 Frontend Checklist

- [x] Type checking passes (`npm run check:types`)
- [x] Code builds without errors (`npm run build`)
- [x] Unit tests pass (`npm run test:unit` — 27 files, 184 tests)
- [x] Translations unchanged — `en.json` is not touched
- [ ] Screenshots or video recordings attached — see Additional Notes

### 📝 Additional Notes

- **The new spec fails on this branch's parent.** Reverting `Date.vue` and running under `TZ=UTC` fails 2 of the 3 cases (`should format in the timezone from settings`, `should honour the date format from settings`), so it catches both defects rather than just describing them.
- **`FlowMetrics` and `Revisions` have no test.** Both are one-line pass-throughs, same as on develop. The visible effect for `FlowMetrics` is chart axis labels, which is the one thing worth eyeballing.
- **No screenshot.** No running instance available here, and the sandbox proxy blocks GitHub `user-attachments`.
- **Merge order.** Independent of the other two 1.3 backports — no shared file.

### 🤖 AI Authors

Template read. My cat has been sitting in a different timezone from the clock all along — turns out she was reading `moment()` instead of the Settings. 🐱

---
_Generated by [Claude Code](https://claude.ai/code/session_01D7z6UoPNC4QReogvgDLnxX)_