### PR TITLE
fix(core): keep an all-hidden column selection across a refresh (1.3 backport)

### DIFF
--- a/ui/src/composables/useTableColumns.ts
+++ b/ui/src/composables/useTableColumns.ts
@@ -55,16 +55,18 @@ export function useTableColumns({columns, storageKey, initialVisibleColumns = []
 
     const initializeVisibleColumns = () => {
         const stored = localStorage.getItem(visibilityStorageKey);
-        if (stored) {
-            try {
-                const parsed = stored.split(",");
-                const valid = parsed.filter(p => columns.some(c => c.prop === p));
-                if (valid.length) {
-                    visibleColumns.value = valid;
-                    return;
-                }
-            } catch { // ignore
-            } 
+        if (stored !== null) {
+            // An empty entry means the user deliberately hid every column; only a missing
+            // entry (or one whose columns no longer exist) may fall back to the defaults.
+            if (stored === "") {
+                visibleColumns.value = [];
+                return;
+            }
+            const valid = stored.split(",").filter(p => columns.some(c => c.prop === p));
+            if (valid.length) {
+                visibleColumns.value = valid;
+                return;
+            }
         }
         visibleColumns.value = initialVisibleColumns.length
             ? initialVisibleColumns

--- a/ui/tests/unit/composables/useTableColumns.spec.ts
+++ b/ui/tests/unit/composables/useTableColumns.spec.ts
@@ -1,0 +1,87 @@
+import {describe, test, expect, afterEach, beforeEach} from "vitest";
+import {defineComponent} from "vue";
+import {mount} from "@vue/test-utils";
+
+import {useTableColumns, type ColumnConfig} from "../../../src/composables/useTableColumns";
+
+const COLUMNS: ColumnConfig[] = [
+    {label: "A", prop: "a", default: true},
+    {label: "B", prop: "b", default: true},
+    {label: "C", prop: "c", default: false}
+];
+
+/**
+ * The composable calls `onMounted`, so it needs a real component instance; mounting
+ * synchronously runs that hook, so `initializeVisibleColumns` has already applied by the
+ * time this returns.
+ */
+const setup = (storageKey: string, initialVisibleColumns: string[] = []) => {
+    let table!: ReturnType<typeof useTableColumns>;
+    mount(defineComponent({
+        setup() {
+            table = useTableColumns({columns: COLUMNS, storageKey, initialVisibleColumns});
+            return () => null;
+        }
+    }));
+    return table;
+};
+
+describe("useTableColumns", () => {
+    // The composable also writes a `ks-column-order-*` key, so the tree has to be cleared
+    // after the last test too or the repo's leak guard trips.
+    beforeEach(() => localStorage.clear());
+    afterEach(() => localStorage.clear());
+
+    test("should keep every column hidden when the stored selection is empty", () => {
+        localStorage.setItem("columns_all-hidden", "");
+
+        const table = setup("all-hidden");
+
+        expect(table.visibleColumns.value).toEqual([]);
+        expect(table.visibleCount.value).toBe(0);
+    });
+
+    test("should keep every column hidden after re-initializing a deselect-all", () => {
+        const table = setup("deselect-all");
+
+        // Toggle only what is on: `c` is not default-flagged, so toggling it would turn it on.
+        COLUMNS.filter(column => table.isVisible(column)).forEach(column => table.toggleColumn(column));
+        expect(localStorage.getItem("columns_deselect-all")).toBe("");
+
+        table.initializeVisibleColumns();
+
+        expect(table.visibleColumns.value).toEqual([]);
+    });
+
+    test("should keep the stored columns that still exist and drop the rest", () => {
+        localStorage.setItem("columns_partly-stale", "gone,a,c");
+
+        const table = setup("partly-stale");
+
+        expect(table.visibleColumns.value).toEqual(["a", "c"]);
+        expect(table.visibleCount.value).toBe(2);
+        expect(table.totalCount.value).toBe(COLUMNS.length);
+    });
+
+    // No initialVisibleColumns, so this exercises the `default` flag branch rather than
+    // echoing the argument back.
+    test("should fall back to the default-flagged columns when no selection was ever stored", () => {
+        const table = setup("never-stored");
+
+        expect(table.visibleColumns.value).toEqual(["a", "b"]);
+    });
+
+    test("should fall back to the default-flagged columns when the stored columns no longer exist", () => {
+        localStorage.setItem("columns_stale", "gone,removed");
+
+        const table = setup("stale");
+
+        expect(table.visibleColumns.value).toEqual(["a", "b"]);
+    });
+
+    test("should prefer explicit initialVisibleColumns over the default flags", () => {
+        const table = setup("explicit", ["c"]);
+
+        expect(table.visibleColumns.value).toEqual(["c"]);
+    });
+});


### PR DESCRIPTION
### 🔗 Related Issue

Backport of the **app-level half** of https://github.com/kestra-io/kestra/pull/18531 to `releases/v1.3.x`, as decided in https://github.com/kestra-io/kestra/pull/18531#pullrequestreview-5017069337 ("`origin/releases/v1.3.x` carries the identical `if (stored)` at `ui/src/composables/useTableColumns.ts:58`"). Original issue https://github.com/kestra-io/kestra/issues/18487 is already closed by the develop PR, so no closing keyword here.

The design-system half of that PR is **not** backported: `ui/packages/design-system` does not exist on this branch, so https://github.com/kestra-io/kestra/issues/18433 (the `KsIconButton` glyph centring) has nothing to apply to.

### ✨ Description

`useTableColumns` persists the visible columns as a comma-joined string, so hiding every column stores `""`. Re-initializing read that back with a truthiness check, treated the deliberate "hide everything" choice as a missing preference and restored the defaults — undoing the selection on the next dropdown open or page refresh, which is the "same reset can also occur after refreshing the page" case in 18487.

An empty entry is now distinguished from a missing one. A stored entry whose columns no longer exist still falls back to the defaults, so a removed column does not leave a table with nothing in it.

**Scope note that differs from develop, in this branch's favour:** develop has two copies of this composable, and the develop PR had to fix both to stop the dropdown switches disagreeing with the table. On 1.3 there is only one — `ui/src/composables/useTableColumns.ts` — and `DraggableTableColumns.vue:40` consumes it alongside every feature table (`Flows`, `Executions`, `KVTable`, `SecretsTable`, `Triggers`, `FlowTriggers`, `MetricsTable`). So this single change covers both the switches and the rendered table, and the split-brain state described in https://github.com/kestra-io/kestra/pull/18531#pullrequestreview-5015894356 cannot occur here.

### 🎨 Frontend Checklist

- [x] Type checking passes (`npm run check:types`)
- [x] Code builds without errors (`npm run build`)
- [x] Unit tests pass (`npm run test:unit` — 27 files, 187 tests)
- [x] Translations unchanged — `en.json` is not touched
- [ ] Screenshots or video recordings attached — see Additional Notes

### 📝 Additional Notes

- **The composable had no test file on this branch at all.** Six added; the two regression cases (`stored selection is empty`, `re-initializing a deselect-all`) fail against `releases/v1.3.x` and pass here. `c` is deliberately `default: false` so the fallback cases assert `["a", "b"]` rather than "every column", which is the weakness you pointed out in the design-system spec.
- **No screenshot.** No running instance available here. The repro is worth one manual pass before merge: `/ui/main/flows` → hide all columns → refresh → the picker should still read 0 of 7.
- **Not backported, deliberately:** the `SecretsTable` hand-rolled storage reader (https://github.com/kestra-io/kestra/issues/18543) and the `KsIconButton` `:size` clamp (https://github.com/kestra-io/kestra/issues/18544). Both are follow-ups on develop and neither is part of this regression.
- **Merge order.** Independent of the other two 1.3 backports — no shared file.

### 🤖 AI Authors

Template read. I told my cat to hide every column. She hid them all, then the page refreshed and they came back — she has requested this fix personally. 🐱

---
_Generated by [Claude Code](https://claude.ai/code/session_01D7z6UoPNC4QReogvgDLnxX)_