### PR TITLE
fix(variables): item.* loop variables missing from editor autocompletion

### DIFF
--- a/core/src/main/java/io/kestra/core/runners/RunVariables.java
+++ b/core/src/main/java/io/kestra/core/runners/RunVariables.java
@@ -69,7 +69,7 @@ public final class RunVariables {
         "flow.namespace",
         "flow.revision",
         "flow.tenantId",
-        // ForEach/EachParallel/EachSequential iteration context (item.*)
+        // Loop iteration context (item.*)
         "item",
         "item.index",
         "item.key",

--- a/core/src/main/java/io/kestra/core/services/ExpressionContextService.java
+++ b/core/src/main/java/io/kestra/core/services/ExpressionContextService.java
@@ -54,7 +54,7 @@ public class ExpressionContextService {
         "taskrun.parentId", "taskrun.startDate", "taskrun.value",
         "parent", "parent.task", "parent.task.id", "parent.taskrun", "parent.taskrun.value",
         "parents",
-        "item.index", "item.key", "item.parent", "item.parent.index", "item.parent.key",
+        "item", "item.index", "item.key", "item.parent", "item.parent.index", "item.parent.key",
         "item.parent.value", "item.parents", "item.value"
     );
 

--- a/ui/src/components/flows/TaskEdit.vue
+++ b/ui/src/components/flows/TaskEdit.vue
@@ -341,6 +341,8 @@
             taskrun: ["id", "startDate", "attemptsCount", "parentId", "value", "iteration"],
             task: ["id", "type"],
             trigger: ["id", "date", "type"],
+            item: ["value", "key", "index"],
+            "item.parent": ["value", "key", "index"],
             error: ["taskId", "message", "stackTrace"],
             kestra: ["environment", "url"],
         }
@@ -348,7 +350,7 @@
         for (const [root, fields] of Object.entries(CONTEXT_FIELDS)) {
             for (const field of fields) ctx.push({label: `${root}.${field}`, expr: `{{ ${root}.${field} }}`})
         }
-        for (const root of ["labels", "envs", "globals", "parent", "parents"]) {
+        for (const root of ["labels", "envs", "globals", "parent", "parents", "item.parents"]) {
             ctx.push({label: root, expr: `{{ ${root} }}`})
         }
         ctx.push({label: "now()", expr: "{{ now() }}"})

--- a/ui/src/override/services/flowAutoCompletionProvider.ts
+++ b/ui/src/override/services/flowAutoCompletionProvider.ts
@@ -62,6 +62,7 @@ export class FlowAutoCompletion extends YamlAutoCompletion {
             "globals",
             "parent",
             "parents",
+            "item",
             "error",
             "kestra",
         ]
@@ -228,6 +229,16 @@ export class FlowAutoCompletion extends YamlAutoCompletion {
                 return Promise.resolve(["id", "type"])
             case "taskrun":
                 return Promise.resolve(["id", "startDate", "attemptsCount", "parentId", "value", "iteration"])
+            case "parent":
+                return Promise.resolve(["task", "taskrun"])
+            case "parent.task":
+                return Promise.resolve(["id"])
+            case "parent.taskrun":
+                return Promise.resolve(["value"])
+            case "item":
+                return Promise.resolve(["value", "key", "index", "parent", "parents"])
+            case "item.parent":
+                return Promise.resolve(["value", "key", "index"])
             case "error":
                 return Promise.resolve(["taskId", "message", "stackTrace"])
             case "kestra":

--- a/ui/tests/unit/override/flowAutoCompletionProvider.spec.ts
+++ b/ui/tests/unit/override/flowAutoCompletionProvider.spec.ts
@@ -45,3 +45,25 @@ describe("FlowAutoCompletion inputs autocomplete with FORM groups", () => {
         expect(result).toEqual([])
     })
 })
+
+describe("FlowAutoCompletion loop item.* and parent.* nested fields", () => {
+    it("`item.` lists the loop iteration fields", async () => {
+        const result = await provider().nestedFieldAutoCompletion("", parsed, "item")
+        expect(result).toEqual(["value", "key", "index", "parent", "parents"])
+    })
+
+    it("`item.parent.` lists the enclosing loop's fields", async () => {
+        const result = await provider().nestedFieldAutoCompletion("", parsed, "item.parent")
+        expect(result).toEqual(["value", "key", "index"])
+    })
+
+    it("`parent.` lists the flowable ancestor's fields", async () => {
+        const result = await provider().nestedFieldAutoCompletion("", parsed, "parent")
+        expect(result).toEqual(["task", "taskrun"])
+    })
+
+    it("`parent.task.` and `parent.taskrun.` resolve to their leaf fields", async () => {
+        expect(await provider().nestedFieldAutoCompletion("", parsed, "parent.task")).toEqual(["id"])
+        expect(await provider().nestedFieldAutoCompletion("", parsed, "parent.taskrun")).toEqual(["value"])
+    })
+})

--- a/ui/tests/unit/services/flowAutoCompletionProvider.spec.ts
+++ b/ui/tests/unit/services/flowAutoCompletionProvider.spec.ts
@@ -204,6 +204,7 @@ describe("FlowAutoCompletionProvider", () => {
         expect(result).toContain("outputs")
         expect(result).toContain("inputs")
         expect(result).toContain("kestra")
+        expect(result).toContain("item")
 
         // Function snippets are generated from functionsWithDefaults
         for (const fn of mockFunctions.filter(fn => fn.name !== "subflow")) {


### PR DESCRIPTION
Closes https://github.com/kestra-io/kestra/issues/18389.

RunVariables.EXECUTION_CONTEXT_PATHS already listed item.* for Loop iterations, but the Monaco editor's `{{ }}` autocompletion and the no-code block editor's variable chips read from separate hardcoded lists that were never updated to include it.

Also wires up the
adjacent parent/parent.task/parent.taskrun nested completions, which were offered at root but silently returned nothing when drilled into.

Also fixes ExpressionContextService.TASK_LEVEL_PATHS, which listed every item.* child but not the bare "item" entry, leaking it into TestSuite-scoped expression context where no loop is in scope.

All PRs submitted by external contributors must follow this template (proper description, related issue, and checklist sections). If you plan to work on a specific issue, comment on the issue first and wait to be assigned before starting any actual work - this avoids duplicated work and ensures a smooth contribution process. PRs that skip either rule **may be automatically closed**.

<img width="1185" height="468" alt="image" src="https://github.com/user-attachments/assets/f3efe3e7-9d7a-4ed9-b3e3-24f35097dfcb" />
