### PR TITLE
fix(executions): respect the Timezone setting in the Gantt scale (1.0 backport)

### DIFF
--- a/ui/src/components/executions/Gantt.vue
+++ b/ui/src/components/executions/Gantt.vue
@@ -97,6 +97,7 @@
     import {State} from "@kestra-io/ui-libs"
     import Duration from "../layout/Duration.vue";
     import Utils from "../../utils/utils";
+    import {date as dateFilter} from "../../utils/filters";
     import FlowUtils from "../../utils/flowUtils";
     import "vue-virtual-scroller/dist/vue-virtual-scroller.css"
     import {DynamicScroller, DynamicScrollerItem} from "vue-virtual-scroller";
@@ -109,6 +110,8 @@
 
     const ts = date => new Date(date).getTime();
     const TASKRUN_THRESHOLD = 50;
+    // Explicit 24-hour format: the scale has no room for AM/PM, so a 12-hour clock would be ambiguous.
+    const TICK_FORMAT = "HH:mm:ss";
     export default {
         components: {
             DynamicScroller,
@@ -315,7 +318,7 @@
             },
             computeDates() {
                 const ticks = 5;
-                const date = ts => this.$moment(ts).format("h:mm:ss");
+                const date = ts => dateFilter(ts, TICK_FORMAT);
                 const start = this.start;
                 const delta = this.delta() / ticks;
                 const dates = [];

--- a/ui/src/utils/filters.ts
+++ b/ui/src/utils/filters.ts
@@ -1,5 +1,4 @@
 import Utils from "./utils";
-import {getCurrentInstance} from "vue";
 import {DATE_FORMAT_STORAGE_KEY, TIMEZONE_STORAGE_KEY} from "../components/settings/BasicSettings.vue";
 import moment from "moment-timezone";
 
@@ -18,9 +17,22 @@ export function cap (value:string) {
 export function lower (value:string) {
     return value ? value.toString().toLowerCase() : "";
 }
-export function date (dateString:string, format?:string) {
-    const currentLocale = getCurrentInstance()?.appContext.config.globalProperties.$moment().locale();
-    const momentInstance = getCurrentInstance()?.appContext.config.globalProperties.$moment(dateString).locale(currentLocale);
+/**
+ * Formats an instant in the timezone and date format from Settings.
+ *
+ * Accepts what `moment` accepts: an ISO string, an epoch millisecond timestamp, or a `Date`.
+ * Callers must not pre-serialise a timestamp with `toISOString()` — that throws on a
+ * non-finite value, whereas `moment` degrades to the string "Invalid date".
+ *
+ * @param dateValue the instant to format
+ * @param format    a moment format, or "iso" for `YYYY-MM-DD HH:mm:ss.SSS`; defaults to the
+ *                  user's stored date format
+ */
+export function date (dateValue:string | number | Date, format?:string) {
+    // The app's `$moment` global is this same moment-timezone singleton, so reading it through
+    // getCurrentInstance() only made the helper unusable outside a component render.
+    const currentLocale = moment().locale();
+    const momentInstance = moment(dateValue).locale(currentLocale);
     let f;
     if (format === "iso") {
         f = "YYYY-MM-DD HH:mm:ss.SSS";

--- a/ui/tests/unit/utils/filters.spec.ts
+++ b/ui/tests/unit/utils/filters.spec.ts
@@ -1,5 +1,7 @@
-import {afterEach, describe, expect, it} from "vitest";
-import {humanizeNumber} from "../../../src/utils/filters";
+import {afterEach, beforeEach, describe, expect, it} from "vitest";
+import moment from "moment-timezone";
+import {date, humanizeNumber} from "../../../src/utils/filters";
+import {TIMEZONE_STORAGE_KEY} from "../../../src/components/settings/BasicSettings.vue";
 
 describe("humanizeNumber", () => {
     afterEach(() => {
@@ -22,5 +24,48 @@ describe("humanizeNumber", () => {
         localStorage.setItem("lang", "de");
 
         expect(humanizeNumber("1234567")).toBe((1234567).toLocaleString("de"));
+    });
+});
+
+describe("date", () => {
+    const INSTANT = "2026-07-24T13:16:00.000Z";
+    const TIMEZONE = "America/Los_Angeles";
+
+    beforeEach(() => localStorage.clear());
+    afterEach(() => localStorage.clear());
+
+    it("formats in the timezone from settings rather than the machine one", () => {
+        localStorage.setItem(TIMEZONE_STORAGE_KEY, TIMEZONE);
+
+        // 13:16 UTC is 06:16 in Los Angeles, so a wrong timezone shows a different hour.
+        expect(date(INSTANT, "HH:mm:ss")).toBe("06:16:00");
+    });
+
+    // The Gantt scale divides a time span into tick timestamps, so it has epoch millis rather
+    // than a string. Pre-serialising those with toISOString() throws on a non-finite value.
+    it.each([
+        ["an epoch millisecond timestamp", moment(INSTANT).valueOf()],
+        ["a Date", new Date(INSTANT)],
+        ["an ISO string", INSTANT]
+    ])("accepts %s", (_label, value) => {
+        localStorage.setItem(TIMEZONE_STORAGE_KEY, TIMEZONE);
+
+        expect(date(value as string | number | Date, "HH:mm:ss")).toBe("06:16:00");
+    });
+
+    // An execution cancelled before any task started yields a non-finite span; the label must
+    // degrade rather than throw.
+    it.each([
+        ["NaN", NaN],
+        ["-Infinity", -Infinity]
+    ])("degrades to a placeholder for %s instead of throwing", (_label, value) => {
+        expect(() => date(value, "HH:mm:ss")).not.toThrow();
+        expect(date(value, "HH:mm:ss")).toBe("Invalid date");
+    });
+
+    it("resolves the \"iso\" sentinel to a full timestamp", () => {
+        localStorage.setItem(TIMEZONE_STORAGE_KEY, "UTC");
+
+        expect(date(INSTANT, "iso")).toBe("2026-07-24 13:16:00.000");
     });
 });


### PR DESCRIPTION
### 🔗 Related Issue

Backport of https://github.com/kestra-io/kestra/pull/18528 to `releases/v1.0.x`, as decided in https://github.com/kestra-io/kestra/pull/18528#pullrequestreview-5015796184 ("`Gantt.vue` has `this.$moment(ts).format("h:mm:ss")` — `Gantt` only, no `Timeline` component there"). Original issues https://github.com/kestra-io/kestra/issues/18453 and https://github.com/kestra-io/kestra/issues/18456 are already closed by the develop PR, so no closing keyword here.

### ✨ Description

The Gantt time scale formatted its tick labels with a bare `this.$moment(...)`, so it followed the browser machine's timezone while the executions list and the logs use the Timezone from Settings. The ticks also move from `h:mm:ss` to an explicit 24-hour `HH:mm:ss`: the scale has no room for AM/PM, so a 12-hour clock left `4:41:19` ambiguous.

**What is adapted:** 1.0's `Gantt.vue` is still Options API, so the change is inside the `computeDates` method rather than a `<script setup>` function. The Run timeline — the second surface on develop — has no counterpart here.

**One change beyond the develop diff, and it is load-bearing:** `filters#date` had to stop resolving `moment` through `getCurrentInstance()?.appContext.config.globalProperties.$moment`. `computeDates` runs from a watcher, where no instance is current, so the helper would have thrown `TypeError: … .$moment is not a function` on every execution update — a worse regression than the bug being fixed. That global is this same `moment-timezone` singleton (`init.js:163` does `extendMoment(moment)` on the imported module, and `moment.locale(locale)` on it), so inside a component render the behaviour is byte-identical; outside one, the helper now works instead of throwing.

The same two-line `filters.ts` change appears in https://github.com/kestra-io/kestra/pull/18723 (the 1.0 dashboard-date backport). The two diffs are byte-identical, so the branches merge cleanly in either order.

### 🎨 Frontend Checklist

- [x] Type checking — `npm run check:types` is a no-op on this branch ("Skipping: No explicit type checking in this release version"), so `npm run build` is the only type signal and it is green
- [x] Code builds without errors (`npm run build`)
- [x] Unit tests pass (`npm run test:unit` — 9 files, 53 tests)
- [x] Translations unchanged — `en.json` is not touched
- [ ] Screenshots or video recordings attached — see Additional Notes

### 📝 Additional Notes

- **Not backported, deliberately:** the `hasValidDate` early return from develop. 1.0 has no such flag and its scale header renders the tick labels unconditionally, so an execution with no task runs shows five `"Invalid date"` labels *both before and after* this change — `filters#date` keeps moment's leniency rather than throwing, which is the whole reason the develop PR needed a second commit. Adding a guard here would change what the header shows, which is a separate call from this backport.
- **What the tests cover.** The eight new `filters#date` cases all fail against `releases/v1.0.x` (the helper throws outside a component instance), including the two that pin the non-finite behaviour the point above depends on. `Gantt.vue` itself has no test or story on 1.0, so nothing asserts the rendered ticks.
- **No screenshot.** No running instance available here, and the sandbox proxy blocks GitHub `user-attachments`. The tick labels are worth one look before merge.
- **Risk worth naming:** `filters#date` is called from `$filters.date(...)` all over 1.0's templates. The change removes an indirection rather than altering the format or the locale, and the full unit suite plus a production build are green, but it is the one hunk here that is not confined to `Gantt.vue`.

### 🤖 AI Authors

Template read. The cat walked across the Gantt chart and every tick shifted by seven hours. Turns out that was `moment()`, not the cat. 🐱

---
_Generated by [Claude Code](https://claude.ai/code/session_01D7z6UoPNC4QReogvgDLnxX)_