### PR TITLE
fix(core): consistent padding for the editor documentation panel across the app

### DIFF
--- a/ui/src/components/plugins/PluginDocumentation.vue
+++ b/ui/src/components/plugins/PluginDocumentation.vue
@@ -87,6 +87,7 @@
         <KsMarkdown
             v-else-if="overrideIntro"
             :content="overrideIntro"
+            class="dp-override-intro"
             :class="{'position-absolute': absolute}"
         />
 
@@ -571,6 +572,11 @@
 
   .plugin-schema {
     display: block;
+    padding: var(--ks-spacing-5) var(--ks-spacing-4) var(--ks-spacing-6);
+  }
+
+  .dp-override-intro {
+    width: 100%;
     padding: var(--ks-spacing-5) var(--ks-spacing-4) var(--ks-spacing-6);
   }
 

--- a/ui/src/components/plugins/PluginDocumentationWrapper.vue
+++ b/ui/src/components/plugins/PluginDocumentationWrapper.vue
@@ -14,7 +14,6 @@
 
 <style scoped lang="scss">
 .plugin-doc-wrapper {
-    padding: var(--ks-spacing-4);
     background-color: var(--ks-bg-surface);
 }
 
@@ -23,7 +22,6 @@
 }
 
 .editorPlugin{
-    padding: 1rem ;
     min-height: 100%;
 }
 </style>


### PR DESCRIPTION
Relates to https://github.com/kestra-io/kestra-ee/issues/10191