### PR TITLE
fix(assets): mark External as internal so it cannot be user-declared

### DIFF
--- a/core/src/main/java/io/kestra/core/models/assets/External.java
+++ b/core/src/main/java/io/kestra/core/models/assets/External.java
@@ -11,7 +11,7 @@ import lombok.Builder;
 import lombok.NoArgsConstructor;
 
 @NoArgsConstructor
-@Plugin
+@Plugin(internal = true)
 public class External extends Asset {
     public static final String ASSET_TYPE = External.class.getName();
 


### PR DESCRIPTION
- The companion EE fix (kestra-ee #10469) treats a stored External asset as a placeholder that a declared type always wins over.
- That premise silently breaks if a user ever deliberately sets an asset's type to External, since External is otherwise an ordinary plugin-declarable type.
- Marking it internal keeps it out of the plugin-listing endpoint and the flow-YAML schema, so it stays inference-only.
- Caveat: this does not block deserialization/parsing of an External asset from YAML/API — internal is only consulted by PluginController and JsonSchemaGenerator, never by PluginDeserializer/DefaultPluginRegistry. Accepted tradeoff, not a gap in this PR.
- Companion to kestra-ee PR #10469.