### PR TITLE
fix(ui): plugin icon theming and clipped rules indicator

### DIFF
--- a/ui/packages/design-system/src/components/Data/KsDataTable/KsDataTable.vue
+++ b/ui/packages/design-system/src/components/Data/KsDataTable/KsDataTable.vue
@@ -491,11 +491,11 @@
 
         &--fit {
             min-height: 0;
-            overflow: hidden;
 
             .ks-data-table-content {
                 flex: 1 1 0;
                 min-height: 0;
+                overflow: hidden;
 
                 &--slot {
                     overflow: auto;

--- a/ui/src/components/plugins/BlueprintIconStack.vue
+++ b/ui/src/components/plugins/BlueprintIconStack.vue
@@ -7,6 +7,7 @@
             :cls="cls"
             :icons="icons"
             :loadIcon="loadIcon"
+            variable="--ks-black"
             onlyIcon
         />
         <span v-if="overflow > 0" class="blueprint-icon-stack__more">+{{ overflow }}</span>
@@ -89,7 +90,9 @@
             width: var(--ks-spacing-5);
             height: var(--ks-spacing-5);
             padding: 2px;
-            background-color: var(--ks-bg-tag);
+            background-color: var(--ks-bg-plugin-icon);
+            border: 1px solid var(--ks-border-default);
+            color: var(--ks-black);
             border-radius: var(--ks-radius-base);
         }
 

--- a/ui/src/components/plugins/PluginCard.vue
+++ b/ui/src/components/plugins/PluginCard.vue
@@ -16,6 +16,7 @@
                         :cls="iconCls"
                         :icons="icons"
                         :loadIcon="loadIcon"
+                        variable="--ks-black"
                         onlyIcon
                     />
                 </slot>
@@ -161,7 +162,9 @@
             width: 2.625rem;
             height: 2.625rem;
             padding: var(--ks-spacing-1);
-            background-color: var(--ks-bg-tag);
+            background-color: var(--ks-bg-plugin-icon);
+            border: 1px solid var(--ks-border-default);
+            color: var(--ks-black);
             border-radius: var(--ks-radius-base);
         }
 

--- a/ui/src/components/plugins/PluginLayout.vue
+++ b/ui/src/components/plugins/PluginLayout.vue
@@ -24,6 +24,7 @@
                                 class="plugin-header__logo"
                                 :cls="headerIconCls"
                                 onlyIcon
+                                variable="--ks-black"
                                 :icons="icons"
                             />
 
@@ -302,8 +303,9 @@
             width: 3.75rem;
             height: 3.75rem;
             padding: var(--ks-spacing-2);
-            background-color: var(--ks-bg-tag);
+            background-color: var(--ks-bg-plugin-icon);
             border: 1px solid var(--ks-border-default);
+            color: var(--ks-black);
             border-radius: var(--ks-radius-base);
         }
 

--- a/ui/src/components/plugins/PluginTocItems.vue
+++ b/ui/src/components/plugins/PluginTocItems.vue
@@ -16,6 +16,7 @@
                     :onlyIcon="true"
                     :cls="el.cls"
                     :icons="icons"
+                    variable="--ks-black"
                 />
                 <span class="plugin-toc-elements__label">{{ shortName(el.cls) }}</span>
             </router-link>
@@ -101,7 +102,8 @@
         flex-shrink: 0;
         width: 1rem;
         height: 1rem;
-        background-color: var(--ks-bg-tag);
+        background-color: var(--ks-bg-plugin-icon);
+        color: var(--ks-black);
         border-radius: var(--ks-radius-xs);
     }
 


### PR DESCRIPTION
closes https://github.com/kestra-io/kestra/issues/18426
closes https://github.com/kestra-io/kestra/issues/18458

This pull request updates the visual styling and color handling for plugin-related icon components across the UI. The main focus is to standardize the background, border, and icon color for plugin icons, and to ensure a consistent variable is used for icon color throughout the components. Additionally, a minor CSS adjustment is made in the data table component.

**Plugin Icon Styling Updates:**

* Changed the background color for plugin icon containers from `--ks-bg-tag` to the new `--ks-bg-plugin-icon` variable, and added a border using `--ks-border-default` for better visual separation in `PluginCard.vue`, `PluginLayout.vue`, `PluginTocItems.vue`, and `BlueprintIconStack.vue` [[1]](diffhunk://#diff-bfd3a90d7d18341cdeacb62348e7b96102d4acf216e4365e995c8e53147b76a3L164-R167) [[2]](diffhunk://#diff-d14fee3e9b60971f84b8019b5abc0d4bab5ec060a7e7d4ec01a40e3e3ea06772L305-R308) [[3]](diffhunk://#diff-570457b7cb9d1b4e789d46493f49f2aaede23d6c97bd058c5048051a0018bacdL104-R106) [[4]](diffhunk://#diff-348ec305e09cb05e7d39aedc5efe1a1a635c6cd6286853a7edfe6796a4eb7543L92-R95).
* Set the icon color to use `--ks-black` in all plugin icon containers for consistent icon appearance [[1]](diffhunk://#diff-bfd3a90d7d18341cdeacb62348e7b96102d4acf216e4365e995c8e53147b76a3L164-R167) [[2]](diffhunk://#diff-d14fee3e9b60971f84b8019b5abc0d4bab5ec060a7e7d4ec01a40e3e3ea06772L305-R308) [[3]](diffhunk://#diff-570457b7cb9d1b4e789d46493f49f2aaede23d6c97bd058c5048051a0018bacdL104-R106) [[4]](diffhunk://#diff-348ec305e09cb05e7d39aedc5efe1a1a635c6cd6286853a7edfe6796a4eb7543L92-R95).

**Icon Component Prop Standardization:**

* Passed the `variable="--ks-black"` prop to all usages of the icon stack component within plugin-related components to standardize icon color [[1]](diffhunk://#diff-bfd3a90d7d18341cdeacb62348e7b96102d4acf216e4365e995c8e53147b76a3R19) [[2]](diffhunk://#diff-d14fee3e9b60971f84b8019b5abc0d4bab5ec060a7e7d4ec01a40e3e3ea06772R27) [[3]](diffhunk://#diff-570457b7cb9d1b4e789d46493f49f2aaede23d6c97bd058c5048051a0018bacdR19) [[4]](diffhunk://#diff-348ec305e09cb05e7d39aedc5efe1a1a635c6cd6286853a7edfe6796a4eb7543R10).

**Data Table Component Adjustment:**

* Moved the `overflow: hidden;` CSS property from the table container to the `.ks-data-table-content` element to improve scrolling behavior.