### PR TITLE
fix(executions): validate label keys on every execution label API

### DIFF
--- a/webserver/src/main/java/io/kestra/webserver/controllers/api/ExecutionController.java
+++ b/webserver/src/main/java/io/kestra/webserver/controllers/api/ExecutionController.java
@@ -54,6 +54,7 @@ import io.kestra.core.models.topologies.FlowTopology;
 import io.kestra.core.models.topologies.FlowTopologyGraph;
 import io.kestra.core.models.triggers.AbstractTrigger;
 import io.kestra.core.models.validations.ManualConstraintViolation;
+import io.kestra.core.models.validations.ModelValidator;
 import io.kestra.core.preview.FilePreview;
 import io.kestra.core.preview.FileRenderer;
 import io.kestra.core.queues.BroadcastQueueInterface;
@@ -254,6 +255,9 @@ public class ExecutionController {
 
     @Inject
     private AsyncOperationsConfiguration asyncOperationsConfiguration;
+
+    @Inject
+    private ModelValidator modelValidator;
 
     @Inject
     private FileRendererService fileRendererService;
@@ -1152,6 +1156,8 @@ public class ExecutionController {
             : RequestUtils.toMap(labels).entrySet().stream()
                 .map(entry -> new Label(entry.getKey(), entry.getValue()))
                 .collect(Collectors.toList());
+
+        parsedLabels.forEach(modelValidator::validate);
 
         // system labels can only be set by Kestra itself; the only exceptions accepted from a
         // client are system.correlationId and system.from=ui (sent by the UI). Any other
@@ -2402,7 +2408,7 @@ public class ExecutionController {
     @ApiResponse(responseCode = "202", description = "Accepted", content = { @Content(schema = @Schema(implementation = ApiAsyncOperationResponse.class)) })
     @ApiResponse(responseCode = "400", description = "Validation errors", content = { @Content(schema = @Schema(implementation = BulkErrorResponse.class)) })
     public MutableHttpResponse<ApiAsyncOperationResponse> setLabelsOnTerminatedExecutionsByIds(
-        @RequestBody(description = "The request containing a list of labels and a list of executions") @Body SetLabelsByIdsRequest setLabelsByIds) throws QueueException {
+        @RequestBody(description = "The request containing a list of labels and a list of executions") @Body @Valid SetLabelsByIdsRequest setLabelsByIds) throws QueueException {
         List<Execution> executions = new ArrayList<>();
         Set<ManualConstraintViolation<String>> invalids = new HashSet<>();
 
@@ -2443,17 +2449,22 @@ public class ExecutionController {
             );
         }
 
+        // merge and validate every execution's labels before emitting anything, so a rejected
+        // batch (e.g. a system label in the payload) never applies to some executions but not others
+        Map<String, List<Label>> mergedLabelsByExecutionId = new HashMap<>(executions.size());
+        for (Execution execution : executions) {
+            List<Label> deduplicated = Label.deduplicate(ListUtils.concat(execution.getLabels(), setLabelsByIds.executionLabels()));
+            mergedLabelsByExecutionId.put(execution.getId(), mergeSystemLabels(execution, deduplicated));
+        }
+
         this.updateLabelsCounter.increment(executions.size());
 
         return submitBatchAction(executions, (execution, opId) ->
-        {
-            List<Label> deduplicated = Label.deduplicate(ListUtils.concat(execution.getLabels(), setLabelsByIds.executionLabels()));
-            List<Label> merged = mergeSystemLabels(execution, deduplicated);
-            executionCommandQueue.emit(UpdateLabels.from(execution, merged).withOperationId(opId));
-        });
+            executionCommandQueue.emit(UpdateLabels.from(execution, mergedLabelsByExecutionId.get(execution.getId())).withOperationId(opId))
+        );
     }
 
-    public record SetLabelsByIdsRequest(@NotNull List<String> executionsId, @NotNull List<Label> executionLabels) {
+    public record SetLabelsByIdsRequest(@NotNull List<String> executionsId, @NotNull @Valid List<Label> executionLabels) {
     }
 
     @ExecuteOn(TaskExecutors.IO)

--- a/webserver/src/test/java/io/kestra/webserver/controllers/api/ExecutionControllerTest.java
+++ b/webserver/src/test/java/io/kestra/webserver/controllers/api/ExecutionControllerTest.java
@@ -20,6 +20,7 @@ import com.google.common.collect.ImmutableMap;
 
 import io.kestra.core.junit.annotations.KestraTest;
 import io.kestra.core.junit.annotations.LoadFlows;
+import io.kestra.core.models.Label;
 import io.kestra.core.models.executions.Execution;
 import io.kestra.core.models.executions.statistics.ExecutionStatistic;
 import io.kestra.core.models.flows.Flow;
@@ -467,6 +468,110 @@ class ExecutionControllerTest {
         );
 
         assertThat(error.getStatus().getCode()).isEqualTo(HttpStatus.UNPROCESSABLE_ENTITY.getCode());
+    }
+
+    @Test
+    @LoadFlows(value = { "flows/valids/minimal.yaml" })
+    void shouldRejectInvalidLabelKeyWhenCreatingAnExecution() {
+        var error = assertThrows(
+            HttpClientResponseException.class, () -> client.toBlocking().retrieve(
+                HttpRequest
+                    .POST("/api/v1/main/executions/io.kestra.tests/minimal?labels=Team:x", null)
+                    .contentType(MediaType.MULTIPART_FORM_DATA_TYPE),
+                Execution.class
+            )
+        );
+
+        assertThat(error.getStatus().getCode()).isEqualTo(HttpStatus.UNPROCESSABLE_ENTITY.getCode());
+    }
+
+    @Test
+    void shouldRejectMissingExecutionsIdWhenSetLabelsOnTerminatedByIdsCalled() {
+        var exception = assertThrows(
+            HttpClientResponseException.class,
+            () -> client.toBlocking().exchange(
+                HttpRequest.POST(
+                    "/api/v1/main/executions/labels/by-ids",
+                    Map.of("executionLabels", List.of(new Label("team", "data")))
+                )
+            )
+        );
+        assertThat(exception.getStatus().getCode()).isEqualTo(HttpStatus.UNPROCESSABLE_ENTITY.getCode());
+    }
+
+    @Test
+    void shouldRejectMissingExecutionLabelsWhenSetLabelsOnTerminatedByIdsCalled() {
+        Execution execution = terminatedExecution();
+
+        var exception = assertThrows(
+            HttpClientResponseException.class,
+            () -> client.toBlocking().exchange(
+                HttpRequest.POST(
+                    "/api/v1/main/executions/labels/by-ids",
+                    Map.of("executionsId", List.of(execution.getId()))
+                )
+            )
+        );
+        assertThat(exception.getStatus().getCode()).isEqualTo(HttpStatus.UNPROCESSABLE_ENTITY.getCode());
+
+        // the label must not have been silently dropped: the execution keeps its labels unchanged
+        Execution reloaded = client.toBlocking().retrieve(GET("/api/v1/main/executions/" + execution.getId()), Execution.class);
+        assertThat(reloaded.getLabels()).isEqualTo(execution.getLabels());
+    }
+
+    @Test
+    void shouldRejectInvalidLabelKeyWhenSetLabelsOnTerminatedByIdsCalled() {
+        Execution execution = terminatedExecution();
+
+        var exception = assertThrows(
+            HttpClientResponseException.class,
+            () -> client.toBlocking().exchange(
+                HttpRequest.POST(
+                    "/api/v1/main/executions/labels/by-ids",
+                    new ExecutionController.SetLabelsByIdsRequest(List.of(execution.getId()), List.of(new Label("Team", "x")))
+                )
+            )
+        );
+        assertThat(exception.getStatus().getCode()).isEqualTo(HttpStatus.UNPROCESSABLE_ENTITY.getCode());
+    }
+
+    @Test
+    void shouldNotPartiallyApplyLabelsWhenSetLabelsOnTerminatedByIdsRejectsASystemLabel() {
+        Execution execution1 = terminatedExecution();
+        Execution execution2 = terminatedExecution();
+
+        var exception = assertThrows(
+            HttpClientResponseException.class,
+            () -> client.toBlocking().exchange(
+                HttpRequest.POST(
+                    "/api/v1/main/executions/labels/by-ids",
+                    new ExecutionController.SetLabelsByIdsRequest(
+                        List.of(execution1.getId(), execution2.getId()),
+                        List.of(new Label(Label.CORRELATION_ID, "spoofed"))
+                    )
+                )
+            )
+        );
+        assertThat(exception.getStatus().getCode()).isEqualTo(HttpStatus.UNPROCESSABLE_ENTITY.getCode());
+
+        // the batch is all-or-nothing: neither execution gained the spoofed label
+        for (Execution execution : List.of(execution1, execution2)) {
+            Execution reloaded = client.toBlocking().retrieve(GET("/api/v1/main/executions/" + execution.getId()), Execution.class);
+            assertThat(reloaded.getLabels()).doesNotContain(new Label(Label.CORRELATION_ID, "spoofed"));
+        }
+    }
+
+    private Execution terminatedExecution() {
+        Execution execution = Execution.builder()
+            .id(IdUtils.create())
+            .tenantId(MAIN_TENANT)
+            .namespace(TESTS_FLOW_NS)
+            .flowId("minimal")
+            .flowRevision(1)
+            .state(new State().withState(State.Type.SUCCESS))
+            .build();
+        executionRepository.save(execution);
+        return execution;
     }
 
     @Test


### PR DESCRIPTION
## Problem

Invalid label keys (e.g. `Team`, which must start with a lowercase letter) were accepted when triggering an execution and when bulk-setting labels by ids, but rejected by the single-execution set-labels endpoint and by flow definitions so a malformed label could be stored and then never edited from the execution's own label editor.

The by-ids endpoint (`POST /executions/labels/by-ids`) also carried no bean validation at all on its request body:
- a missing `executionsId` reached the id loop directly and threw a raw NPE, surfacing as a `500`
- labels sent under the wrong JSON field name resolved to `null`, silently produced a no-op write, and the caller still got a `202`

Closes https://github.com/kestra-io/kestra/issues/18332.
Closes https://github.com/kestra-io/kestra-ee/issues/10310.
Closes https://github.com/kestra-io/kestra-ee/issues/10328.

## Fix

- Added `@Valid` to the `@Body SetLabelsByIdsRequest` parameter and to its `executionLabels` list, so `Label`'s existing key-pattern constraint cascades — matching the two sibling label endpoints, which already do this.
- Injected `ModelValidator` and validate each parsed label inside `parseLabels()`, so the execution-trigger `?labels=key:value` query param is checked the same way flow definitions already are.
- Made the by-ids batch write atomic: every execution's merged labels are now computed and validated in one pass *before* any `UpdateLabels` command is emitted, so a batch that gets rejected (e.g. a spoofed `system.*` label) can no longer apply to some executions before failing on a later one.