### PR TITLE
fix(executions): 403 toast and force-run gating on queued executions

### DIFF
--- a/ui/src/components/executions/Executions.vue
+++ b/ui/src/components/executions/Executions.vue
@@ -119,10 +119,10 @@
                             <KsDropdownItem v-if="canUpdate" :icon="PauseBox" @click="pauseExecutions()">
                                 {{ $t("pause") }}
                             </KsDropdownItem>
-                            <KsDropdownItem v-if="canUpdate" :icon="QueueFirstInLastOut" @click="unqueueDialogVisible = true">
+                            <KsDropdownItem v-if="canUnqueue" :icon="QueueFirstInLastOut" @click="unqueueDialogVisible = true">
                                 {{ $t("unqueue") }}
                             </KsDropdownItem>
-                            <KsDropdownItem v-if="canUpdate" :icon="RunFast" @click="forceRunExecutions()">
+                            <KsDropdownItem v-if="canForceRun" :icon="RunFast" @click="forceRunExecutions()">
                                 {{ $t("force run") }}
                             </KsDropdownItem>
                         </KsDropdownMenu>
@@ -719,7 +719,7 @@
     })
 
     const canCheck = computed(() => {
-        return canDelete.value || canUpdate.value || canKill.value
+        return canDelete.value || canUpdate.value || canKill.value || canForceRun.value || canUnqueue.value
     })
 
     const canReplay = computed(() => {
@@ -736,6 +736,14 @@
 
     const canKill = computed(() => {
         return authStore.user?.isAllowed(resource.EXECUTION, action.KILL, props.namespace)
+    })
+
+    const canForceRun = computed(() => {
+        return authStore.user?.isAllowed(resource.EXECUTION, action.FORCE_RUN, props.namespace)
+    })
+
+    const canUnqueue = computed(() => {
+        return authStore.user?.isAllowed(resource.EXECUTION, action.UNQUEUE, props.namespace)
     })
 
     const isAllowedEdit = computed(() => {

--- a/ui/src/components/executions/overview/components/actions/ForceRun.vue
+++ b/ui/src/components/executions/overview/components/actions/ForceRun.vue
@@ -80,7 +80,7 @@
         if (
             !user?.isAllowed(
                 resource.EXECUTION,
-                action.UPDATE,
+                action.FORCE_RUN,
                 props.execution.namespace,
             )
         ) {

--- a/ui/src/components/executions/overview/components/actions/Unqueue.vue
+++ b/ui/src/components/executions/overview/components/actions/Unqueue.vue
@@ -74,7 +74,7 @@
     })
 
     const enabled = computed(() => {
-        if (!(authStore.user?.isAllowed(resource.EXECUTION, action.UPDATE, props.execution.namespace))) {
+        if (!(authStore.user?.isAllowed(resource.EXECUTION, action.UNQUEUE, props.execution.namespace))) {
             return false
         }
 

--- a/ui/src/components/flows/FlowConcurrency.vue
+++ b/ui/src/components/flows/FlowConcurrency.vue
@@ -90,18 +90,18 @@
         error.value = false
 
         try {
-            const response = await axios.get(`${apiUrl()}/concurrency-limit/search`)
-            const limits = response.data?.results || []
-
-            const currentFlowLimit = limits.find(
-                (limit: any) =>
-                    limit.namespace === flowStore.flow?.namespace &&
-                    limit.flowId === flowStore.flow?.id,
+            const response = await axios.get(
+                `${apiUrl()}/concurrency-limit/${flowStore.flow.namespace}/${flowStore.flow.id}`,
+                {ignoreNotFound: true, showMessageOnError: false},
             )
 
-            concurrencyLimit.value = currentFlowLimit
-        } catch {
-            error.value = true
+            concurrencyLimit.value = response.data
+        } catch (err: any) {
+            if (err?.status === 404 || err?.response?.status === 404) {
+                concurrencyLimit.value = undefined
+            } else {
+                error.value = true
+            }
         } finally {
             loading.value = false
         }

--- a/ui/tests/unit/components/FlowConcurrency.spec.ts
+++ b/ui/tests/unit/components/FlowConcurrency.spec.ts
@@ -10,10 +10,10 @@ vi.mock("../../../src/stores/flow", () => ({
     }),
 }))
 
-let mockLimits: Record<string, any>[] = []
+const getMock = vi.fn()
 vi.mock("@kestra-io/kestra-sdk", () => ({
     useClient: () => ({
-        get: vi.fn(async () => ({data: {results: mockLimits}})),
+        get: getMock,
     }),
 }))
 
@@ -51,25 +51,31 @@ async function mountComponent() {
 describe("FlowConcurrency", () => {
     beforeEach(() => {
         mockFlow = undefined
-        mockLimits = []
+        getMock.mockReset()
     })
 
     it("shows the running ratio when the flow declares a concurrency block", async () => {
         mockFlow = {namespace: "io.kestra.tests", id: "flow", concurrency: {limit: 2, behavior: "QUEUE"}}
-        mockLimits = [{tenantId: "main", namespace: "io.kestra.tests", flowId: "flow", running: 1}]
+        getMock.mockResolvedValue({data: {tenantId: "main", namespace: "io.kestra.tests", flowId: "flow", running: 1}})
 
         const wrapper = await mountComponent()
 
         expect(wrapper.find("[data-test=\"concurrency-limit\"]").exists()).toBe(true)
         expect(wrapper.text()).toContain("1/2")
         expect(wrapper.find("[data-test=\"concurrency-stale-limit\"]").exists()).toBe(false)
+        // The regression this endpoint fixes: reading a flow-scoped record instead of the
+        // instance-owner-only /search, which 403s for any other user on a QUEUED execution.
+        expect(getMock).toHaveBeenCalledWith(
+            "/api/v1/main/concurrency-limit/io.kestra.tests/flow",
+            {ignoreNotFound: true, showMessageOnError: false},
+        )
     })
 
     it("surfaces a leftover limit still holding slots for a flow without a concurrency block", async () => {
         // The reported symptom of kestra-ee#9200: the stuck counter was only visible to a
         // superadmin because this tab used to render nothing without a concurrency block.
         mockFlow = {namespace: "io.kestra.tests", id: "flow"}
-        mockLimits = [{tenantId: "main", namespace: "io.kestra.tests", flowId: "flow", running: 1}]
+        getMock.mockResolvedValue({data: {tenantId: "main", namespace: "io.kestra.tests", flowId: "flow", running: 1}})
 
         const wrapper = await mountComponent()
 
@@ -79,7 +85,7 @@ describe("FlowConcurrency", () => {
 
     it("stays quiet when a leftover limit holds no slot", async () => {
         mockFlow = {namespace: "io.kestra.tests", id: "flow"}
-        mockLimits = [{tenantId: "main", namespace: "io.kestra.tests", flowId: "flow", running: 0}]
+        getMock.mockResolvedValue({data: {tenantId: "main", namespace: "io.kestra.tests", flowId: "flow", running: 0}})
 
         const wrapper = await mountComponent()
 
@@ -89,10 +95,19 @@ describe("FlowConcurrency", () => {
 
     it("keeps the empty state when the flow has a limit but no record yet", async () => {
         mockFlow = {namespace: "io.kestra.tests", id: "flow", concurrency: {limit: 1, behavior: "CANCEL"}}
-        mockLimits = []
+        getMock.mockRejectedValue({status: 404, response: {status: 404}})
 
         const wrapper = await mountComponent()
 
         expect(wrapper.find(".empty").attributes("data-type")).toBe("concurrency_executions")
+    })
+
+    it("shows an error when the request fails for a reason other than a missing record", async () => {
+        mockFlow = {namespace: "io.kestra.tests", id: "flow", concurrency: {limit: 1, behavior: "CANCEL"}}
+        getMock.mockRejectedValue({status: 500, response: {status: 500}})
+
+        const wrapper = await mountComponent()
+
+        expect(wrapper.find(".alert").attributes("data-type")).toBe("error")
     })
 })

--- a/webserver/src/main/java/io/kestra/webserver/controllers/api/ConcurrencyLimitController.java
+++ b/webserver/src/main/java/io/kestra/webserver/controllers/api/ConcurrencyLimitController.java
@@ -34,6 +34,15 @@ public class ConcurrencyLimitController {
     }
 
     @ExecuteOn(TaskExecutors.IO)
+    @Get(uri = "/{namespace}/{flowId}")
+    @Operation(tags = { "Flows" }, summary = "Get the concurrency limit of a flow")
+    public HttpResponse<ConcurrencyLimit> getConcurrencyLimit(String namespace, String flowId) {
+        return concurrencyLimitRepository.findById(tenantService.resolveTenant(), namespace, flowId)
+            .map(HttpResponse::ok)
+            .orElseGet(HttpResponse::notFound);
+    }
+
+    @ExecuteOn(TaskExecutors.IO)
     @Put("/{namespace}/{flowId}")
     @Operation(tags = { "Flows" }, summary = "Update a flow concurrency limit")
     public HttpResponse<ConcurrencyLimit> updateConcurrencyLimit(@Body @Valid ConcurrencyLimit concurrencyLimit) {

--- a/webserver/src/test/java/io/kestra/webserver/controllers/api/ConcurrencyLimitControllerTest.java
+++ b/webserver/src/test/java/io/kestra/webserver/controllers/api/ConcurrencyLimitControllerTest.java
@@ -66,5 +66,25 @@ class ConcurrencyLimitControllerTest {
         );
         assertThat(updated).isNotNull();
         assertThat(updated.getRunning()).isEqualTo(99);
+
+        // the flow-scoped GET returns the same record
+        ConcurrencyLimit scoped = client.toBlocking().retrieve(
+            GET("/api/v1/main/concurrency-limit/" + concurrencyLimit.getNamespace() + "/" + concurrencyLimit.getFlowId()),
+            ConcurrencyLimit.class
+        );
+        assertThat(scoped.getNamespace()).isEqualTo(concurrencyLimit.getNamespace());
+        assertThat(scoped.getFlowId()).isEqualTo(concurrencyLimit.getFlowId());
+    }
+
+    @Test
+    void shouldReturnNotFoundWhenGettingConcurrencyLimitForUnknownFlow() {
+        HttpClientResponseException e = assertThrows(
+            HttpClientResponseException.class,
+            () -> client.toBlocking().exchange(
+                GET("/api/v1/main/concurrency-limit/unknown.namespace/unknown-flow")
+            )
+        );
+
+        assertThat(e.getStatus().getCode()).isEqualTo(HttpStatus.NOT_FOUND.getCode());
     }
 }


### PR DESCRIPTION
Opening a QUEUED execution always calls the concurrency-limit search endpoint to display the running/limit ratio; EE restricts that search to instance owners, so any other user got a global 403 toast. Add a flow-scoped GET so the pending panel can read its own flow's limit under a normal FLOW.VIEW check instead.

Also gate the Force Run / Unqueue controls on their own FORCE_RUN / UNQUEUE actions instead of EXECUTION.UPDATE, so a user without them never sees an enabled button that 403s on click.

Closes https://github.com/kestra-io/kestra-ee/issues/10182.