### PR TITLE
fix(namespaces): unpack an imported zip in the namespace files tab

### DIFF
--- a/ui/src/components/inputs/FileExplorer.vue
+++ b/ui/src/components/inputs/FileExplorer.vue
@@ -950,6 +950,9 @@
         } finally {
             (event.target as HTMLInputElement).value = ""
             dialog.value = {...DIALOG_DEFAULTS}
+            selectedNodes.value = []
+            lastClickedIndex.value = null
+            syncTreeCurrentKey()
         }
     }
 

--- a/ui/src/composables/useBaseNamespaces.ts
+++ b/ui/src/composables/useBaseNamespaces.ts
@@ -15,7 +15,7 @@ function base(namespace: string) {
 }
 
 const slashPrefix = (path: string) => (path.startsWith("/") ? path : `/${path}`)
-const safePath = (path: string) => encodeURIComponent(path).replace(/%2C|%2F/g, "/")
+const safePath = (path: string) => encodeURIComponent(path).replace(/%2F/g, "/")
 export const VALIDATE = {validateStatus: (status: number) => status === 200 || status === 404}
 
 export const useBaseNamespacesStore = () => {
@@ -204,10 +204,10 @@ export const useBaseNamespacesStore = () => {
         return await FilesAPI.searchNamespaceFiles({namespace: payload.namespace, q: payload.query}) ?? []
     }
 
-    async function importFileDirectory(payload: {namespace: string; path: string; content: ArrayBuffer}) {
+    /** Sent as a File, not a Blob: the server unpacks only a part named `*.zip`, and a Blob arrives as `filename="blob"`. */
+    async function importFileDirectory(payload: {namespace: string; path: string; file: File}) {
         const DATA = new FormData()
-        const BLOB = new Blob([payload.content], {type: "text/plain"})
-        DATA.append("fileContent", BLOB)
+        DATA.append("fileContent", payload.file, payload.file.name)
 
         const URL = `${base(payload.namespace)}/files?path=${slashPrefix(safePath(payload.path))}`
         // Don't set Content-Type - the browser must generate the multipart boundary itself.

--- a/ui/src/stores/fileExplorer.spec.ts
+++ b/ui/src/stores/fileExplorer.spec.ts
@@ -4,9 +4,11 @@ import {isDirectory, useFileExplorerStore, type TreeNodeDirectory} from "./fileE
 
 const createDirectory = vi.fn()
 const saveOrCreateFile = vi.fn()
+const importFileDirectory = vi.fn()
+const readDirectory = vi.fn()
 
 vi.mock("override/stores/namespaces", () => ({
-    useNamespacesStore: () => ({createDirectory, saveOrCreateFile}),
+    useNamespacesStore: () => ({createDirectory, saveOrCreateFile, importFileDirectory, readDirectory}),
 }))
 vi.mock("vue-i18n", () => ({
     useI18n: () => ({t: (key: string) => key}),
@@ -76,6 +78,30 @@ describe("fileExplorer store", () => {
 
         expect(path).toBe(" spaced .txt")
         expect(filesStore.fileTree.map(node => node.fileName)).toEqual([" spaced .txt"])
+    })
+
+    it("should upload each imported file under its relative path and take the tree from the server", async () => {
+        const filesStore = store()
+        readDirectory.mockResolvedValue([{type: "File", fileName: "one.txt"}, {type: "File", fileName: "two.txt"}])
+        const zip = new File(["PK"], "io.kestra.test_files.zip", {type: "application/zip"})
+        const nested = new File(["print(1)"], "main.py")
+        Object.defineProperty(nested, "webkitRelativePath", {value: "scripts/nested/main.py"})
+
+        await filesStore.importFiles([zip, nested] as unknown as FileList)
+
+        expect(importFileDirectory).toHaveBeenNthCalledWith(1, {namespace: "io.kestra.test", path: "io.kestra.test_files.zip", file: zip})
+        expect(importFileDirectory).toHaveBeenNthCalledWith(2, {namespace: "io.kestra.test", path: "scripts/nested/main.py", file: nested})
+        expect(filesStore.fileTree.map(node => node.fileName)).toEqual(["one.txt", "two.txt"])
+    })
+
+    it("should still reload the tree when one of the uploads fails", async () => {
+        const filesStore = store()
+        readDirectory.mockResolvedValue([{type: "File", fileName: "one.txt"}])
+        importFileDirectory.mockResolvedValueOnce(undefined).mockRejectedValueOnce(new Error("403"))
+
+        await expect(filesStore.importFiles([new File([""], "one.txt"), new File([""], "two.txt")] as unknown as FileList)).rejects.toThrow("403")
+
+        expect(filesStore.fileTree.map(node => node.fileName)).toEqual(["one.txt"])
     })
 
     it("should not create anything when the name only holds separators", async () => {

--- a/ui/src/stores/fileExplorer.ts
+++ b/ui/src/stores/fileExplorer.ts
@@ -62,17 +62,6 @@ function pathSegments(path: string): string[] {
     return path.split("/").filter(Boolean)
 }
 
-function readFile(file: File): Promise<ArrayBuffer> {
-    return new Promise((resolve, reject) => {
-        const reader = new FileReader()
-        reader.onload = () => resolve(reader.result as ArrayBuffer)
-        reader.onerror = reject
-        reader.readAsArrayBuffer(file)
-    })
-}
-
-
-
 function isNotRootTreeNode(node: ElTreeNode | {level: 0}): node is ElTreeNode {
     return node.level > 0
 }
@@ -353,68 +342,19 @@ export const useFileExplorerStore = defineStore("fileExplorer", () => {
         return null
     }
 
+    /** The tree is reloaded rather than updated in place: a zip is expanded server-side. */
     async function importFiles(importedFiles: FileList) {
         if(!namespaceId.value) return
-        for (const file of Array.from(importedFiles)) {
-            if ((file as any).webkitRelativePath) {
-                const filePath: string = (file as any).webkitRelativePath
-                const pathParts = filePath.split("/")
-                let currentFolder: TreeNode[] | undefined = fileTree.value
-                const folderPath: string[] = []
-                for (let i = 0; i < pathParts.length - 1; i++) {
-                    const folderName = pathParts[i]
-                    folderPath.push(folderName)
-                    if(!currentFolder) continue
-                    const folderIndex = currentFolder.findIndex(
-                        (item: any) => typeof item === "object" && item.fileName === folderName,
-                    )
-                    if (folderIndex === -1) {
-                        const newFolder: TreeNodeDirectory = {
-                            id: Utils.uid(),
-                            fileName: folderName,
-                            children: [],
-                            type: "Directory",
-                            leaf: false,
-                        }
-                        currentFolder.push(newFolder)
-                        sorted(currentFolder)
-                        currentFolder = newFolder.children
-                    } else {
-                        currentFolder = (currentFolder[folderIndex] as TreeNodeDirectory).children
-                    }
-                }
-                const fileName = pathParts[pathParts.length - 1]
-                const [name, extension] = getFileNameWithExtension(fileName)
-                const content = await readFile(file)
+        try {
+            for (const file of Array.from(importedFiles)) {
                 await namespacesStore.importFileDirectory({
                     namespace: namespaceId.value,
-                    content,
-                    path: `${folderPath}/${fileName}`,
-                })
-                currentFolder?.push({
-                    id: Utils.uid(),
-                    fileName: `${name}${extension ? `.${extension}` : ""}`,
-                    extension,
-                    type: "File",
-                    leaf: true,
-                })
-            } else {
-                const content = await readFile(file)
-                const [name, extension] = getFileNameWithExtension(file.name)
-                await namespacesStore.importFileDirectory({
-                    namespace: namespaceId.value,
-                    content,
-                    path: file.name,
-                })
-
-                fileTree.value.push({
-                    id: Utils.uid(),
-                    fileName: `${name}${extension ? `.${extension}` : ""}`,
-                    extension,
-                    type: "File",
-                    leaf: true,
+                    path: file.webkitRelativePath || file.name,
+                    file,
                 })
             }
+        } finally {
+            await loadNodes()
         }
     }
 

--- a/ui/tests/unit/stores/namespacesFileImport.spec.ts
+++ b/ui/tests/unit/stores/namespacesFileImport.spec.ts
@@ -1,0 +1,59 @@
+import {beforeEach, describe, expect, test, vi} from "vitest"
+import {createPinia, setActivePinia} from "pinia"
+
+const postMock = vi.fn()
+
+vi.mock("@kestra-io/kestra-sdk", () => ({
+    useClient: () => ({
+        get: vi.fn(),
+        post: (...args: unknown[]) => postMock(...args),
+        put: vi.fn(),
+        patch: vi.fn(),
+        delete: vi.fn(),
+    }),
+}))
+vi.mock("@kestra-io/kestra-sdk/namespaces", () => ({}))
+vi.mock("@kestra-io/kestra-sdk/flows", () => ({}))
+vi.mock("@kestra-io/kestra-sdk/kv", () => ({}))
+vi.mock("@kestra-io/kestra-sdk/files", () => ({}))
+vi.mock("@kestra-io/kestra-sdk/secrets", () => ({}))
+vi.mock("override/utils/route", () => ({
+    apiUrl: () => "http://localhost:8080/api/v1/main",
+}))
+
+const {useBaseNamespacesStore} = await import("../../../src/composables/useBaseNamespaces")
+
+describe("namespaces store importFileDirectory", () => {
+    beforeEach(() => {
+        setActivePinia(createPinia())
+        postMock.mockReset()
+        postMock.mockResolvedValue({data: undefined})
+    })
+
+    async function upload(file: File, path = file.name) {
+        await useBaseNamespacesStore().importFileDirectory({namespace: "io.kestra.test", path, file})
+        const [url, body] = postMock.mock.calls[0] as [string, FormData]
+        return {url, part: body.get("fileContent") as File}
+    }
+
+    test("keeps the file name on the multipart part so the server can unpack a zip", async () => {
+        const {url, part} = await upload(new File(["PK"], "io.kestra.test_files.zip", {type: "application/zip"}))
+
+        expect(part.name).toBe("io.kestra.test_files.zip")
+        expect(part.type).toBe("application/zip")
+        expect(url).toBe("http://localhost:8080/api/v1/main/namespaces/io.kestra.test/files?path=/io.kestra.test_files.zip")
+    })
+
+    test("uploads a nested file to its relative path", async () => {
+        const {url, part} = await upload(new File(["print(1)"], "main.py"), "data/scripts/main.py")
+
+        expect(part.name).toBe("main.py")
+        expect(url).toBe("http://localhost:8080/api/v1/main/namespaces/io.kestra.test/files?path=/data/scripts/main.py")
+    })
+
+    test("treats a comma in the file name as part of the name, not as a path separator", async () => {
+        const {url} = await upload(new File(["a,b"], "report,v2.csv"))
+
+        expect(url).toBe("http://localhost:8080/api/v1/main/namespaces/io.kestra.test/files?path=/report%2Cv2.csv")
+    })
+})


### PR DESCRIPTION
Closes https://github.com/kestra-io/kestra-ee/issues/10319

**Why `importFiles` is shorter:** the old code guessed what the tree should look like and drew it itself. That can't work for a zip, since only the server knows what's inside. So now we ask the server for the tree, and the guessing code is dead.

**Performance:** faster per upload (no more copying the whole file into memory first). Cost added: one small "list files" request per import, regardless of how many files. Tree redraw is the same code as opening the tab.

One visible change: expanded folders collapse after an import.
