### PR TITLE
fix(plugins): resolve auto-install artifacts from real class packages, not the manifest group

### DIFF
--- a/cli/src/main/java/io/kestra/cli/schema/PluginsSchemaCommand.java
+++ b/cli/src/main/java/io/kestra/cli/schema/PluginsSchemaCommand.java
@@ -2,6 +2,7 @@ package io.kestra.cli.schema;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
@@ -185,11 +186,42 @@ public class PluginsSchemaCommand extends AbstractCommand {
                 entry.put("title", plugin.title());
                 entry.put("groupId", artifact.groupId());
                 entry.put("artifactId", artifact.artifactId());
-                entry.put("group", plugin.group());
+                entry.put("group", packageGroupOf(plugin));
                 return entry;
             }))
             .flatMap(Optional::stream)
             .toList();
+    }
+
+    /**
+     * The package group backing type-to-artifact matching: the longest common package prefix of the
+     * plugin's registered classes, since those packages are what flow {@code type} values are matched
+     * against. The manifest's {@code X-Kestra-Group} is only a fallback — some plugins declare one
+     * that differs from their real packages (e.g. plugin-transform-json declares
+     * {@code io.kestra.plugin.json} while its types live under {@code io.kestra.plugin.transform.jsonata}).
+     */
+    static String packageGroupOf(final RegisteredPlugin plugin) {
+        List<String> packages = plugin.allClass().stream()
+            .map(Class::getPackageName)
+            .distinct()
+            .toList();
+        return commonPackagePrefix(packages).orElse(plugin.group());
+    }
+
+    static Optional<String> commonPackagePrefix(final List<String> packages) {
+        if (packages.isEmpty()) {
+            return Optional.empty();
+        }
+        List<String> prefix = new ArrayList<>(List.of(packages.getFirst().split("\\.")));
+        for (String pkg : packages) {
+            List<String> segments = List.of(pkg.split("\\."));
+            int common = 0;
+            while (common < Math.min(prefix.size(), segments.size()) && prefix.get(common).equals(segments.get(common))) {
+                common++;
+            }
+            prefix = prefix.subList(0, common);
+        }
+        return prefix.isEmpty() ? Optional.empty() : Optional.of(String.join(".", prefix));
     }
 
     /**

--- a/cli/src/test/java/io/kestra/cli/schema/PluginsSchemaCommandTest.java
+++ b/cli/src/test/java/io/kestra/cli/schema/PluginsSchemaCommandTest.java
@@ -1,0 +1,40 @@
+package io.kestra.cli.schema;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class PluginsSchemaCommandTest {
+
+    @Test
+    void shouldReturnThePackageItselfForASinglePackage() {
+        assertThat(PluginsSchemaCommand.commonPackagePrefix(List.of("io.kestra.plugin.transform.jsonata")))
+            .contains("io.kestra.plugin.transform.jsonata");
+    }
+
+    @Test
+    void shouldReturnTheCommonPrefixAcrossPackages() {
+        assertThat(
+            PluginsSchemaCommand.commonPackagePrefix(
+                List.of(
+                    "io.kestra.plugin.aws.s3",
+                    "io.kestra.plugin.aws.sqs",
+                    "io.kestra.plugin.aws"
+                )
+            )
+        ).contains("io.kestra.plugin.aws");
+    }
+
+    @Test
+    void shouldReturnEmptyWhenPackagesShareNoPrefix() {
+        assertThat(PluginsSchemaCommand.commonPackagePrefix(List.of("io.kestra.plugin.aws", "com.acme.plugin")))
+            .isEmpty();
+    }
+
+    @Test
+    void shouldReturnEmptyForNoPackages() {
+        assertThat(PluginsSchemaCommand.commonPackagePrefix(List.of())).isEmpty();
+    }
+}

--- a/core/src/main/java/io/kestra/core/plugins/PluginCatalogService.java
+++ b/core/src/main/java/io/kestra/core/plugins/PluginCatalogService.java
@@ -171,8 +171,12 @@ public class PluginCatalogService {
     /**
      * Extends the hosted catalog with the entries carried by the plugin schema bundle, so a plugin
      * the hosted catalog does not list — a private or in-house one, built into the bundle from a
-     * local plugin folder — resolves and installs like any other. Hosted entries win on conflict:
-     * they carry the license and version metadata the API is authoritative for.
+     * local plugin folder — resolves and installs like any other. On conflict the hosted entry wins,
+     * except its package {@code group}: the bundle derives it from the plugin's scanned classes, the
+     * ground truth for type-to-artifact matching, while the hosted value mirrors the manifest's
+     * {@code X-Kestra-Group}, which some plugins declare wrong (e.g. plugin-transform-json declares
+     * {@code io.kestra.plugin.json} while its types live under {@code io.kestra.plugin.transform.jsonata},
+     * mapping every transform type to plugin-transform-records).
      *
      * @param hosted the manifests retrieved from the Kestra API.
      * @return the merged manifests.
@@ -182,18 +186,37 @@ public class PluginCatalogService {
             return hosted;
         }
 
-        List<PluginManifest> fromBundle = schemaBundleService.catalogEntries();
+        List<PluginManifest> fromBundle = schemaBundleService.catalogEntries().stream()
+            .filter(manifest -> manifest.groupId() != null && manifest.artifactId() != null && manifest.group() != null)
+            .toList();
         if (fromBundle.isEmpty()) {
             return hosted;
         }
+
+        Map<String, String> bundleGroups = fromBundle.stream()
+            .collect(
+                Collectors.toMap(
+                    manifest -> manifest.groupId() + ":" + manifest.artifactId(),
+                    PluginManifest::group,
+                    (first, second) -> first
+                )
+            );
 
         Set<String> known = hosted.stream()
             .map(manifest -> manifest.groupId() + ":" + manifest.artifactId())
             .collect(Collectors.toSet());
 
-        List<PluginManifest> merged = new ArrayList<>(hosted);
+        List<PluginManifest> merged = new ArrayList<>(hosted.size() + fromBundle.size());
+        hosted.stream()
+            .map(manifest ->
+            {
+                String bundleGroup = bundleGroups.get(manifest.groupId() + ":" + manifest.artifactId());
+                return bundleGroup == null || bundleGroup.equals(manifest.group())
+                    ? manifest
+                    : new PluginManifest(manifest.title(), manifest.groupId(), manifest.artifactId(), bundleGroup);
+            })
+            .forEach(merged::add);
         fromBundle.stream()
-            .filter(manifest -> manifest.groupId() != null && manifest.artifactId() != null && manifest.group() != null)
             .filter(manifest -> !known.contains(manifest.groupId() + ":" + manifest.artifactId()))
             .forEach(merged::add);
 

--- a/core/src/test/java/io/kestra/core/plugins/PluginCatalogServiceTest.java
+++ b/core/src/test/java/io/kestra/core/plugins/PluginCatalogServiceTest.java
@@ -343,19 +343,21 @@ class PluginCatalogServiceTest {
     }
 
     @Test
-    void shouldPreferHostedEntryOverBundleEntryForSameArtifact() {
-        // Given — the same artifact on both sides: the hosted one carries the authoritative metadata
+    void shouldPreferBundleGroupOverHostedGroupForSameArtifact() {
+        // Given — the same artifact on both sides: the hosted group mirrors a wrong manifest
+        // X-Kestra-Group (the plugin-transform-json case), the bundle group is derived from the
+        // plugin's real class packages
         when(blockingClient.exchange(any(), any(Argument.class)))
             .thenReturn(
                 HttpResponse.ok(
                     List.of(
-                        Map.of("name", "plugin-serdes", "title", "Serdes", "group", "io.kestra.plugin.serdes", "license", "OPENSOURCE")
+                        Map.of("name", "plugin-transform-json", "title", "JSONata", "group", "io.kestra.plugin.json", "license", "OPENSOURCE")
                     )
                 )
             );
         PluginSchemaBundleService schemaBundleService = mock(PluginSchemaBundleService.class);
         when(schemaBundleService.catalogEntries()).thenReturn(
-            List.of(new PluginCatalogService.PluginManifest("Stale", "io.kestra.plugin", "plugin-serdes", "io.kestra.plugin.stale"))
+            List.of(new PluginCatalogService.PluginManifest("JSONata", "io.kestra.plugin", "plugin-transform-json", "io.kestra.plugin.transform.jsonata"))
         );
 
         PluginCatalogService service = new PluginCatalogService(httpClient, false, true, executorsUtils, schemaBundleService);
@@ -363,11 +365,12 @@ class PluginCatalogServiceTest {
         // When
         List<PluginCatalogService.PluginManifest> result = service.get();
 
-        // Then
+        // Then — one entry, hosted title kept, bundle group kept
         assertThat(result).singleElement().satisfies(manifest ->
         {
-            assertThat(manifest.artifactId()).isEqualTo("plugin-serdes");
-            assertThat(manifest.group()).isEqualTo("io.kestra.plugin.serdes");
+            assertThat(manifest.title()).isEqualTo("JSONata");
+            assertThat(manifest.artifactId()).isEqualTo("plugin-transform-json");
+            assertThat(manifest.group()).isEqualTo("io.kestra.plugin.transform.jsonata");
         });
     }
 


### PR DESCRIPTION
Part of https://github.com/kestra-io/kestra-ee/issues/6145 (KIP-45 QA follow-up; reported in Slack during develop-slim QA, no standalone issue).

### Problem

Reported during develop-slim QA (see [QA report](https://github.com/kestra-io/kestra-ee/issues/6145#issuecomment-5439129183)): saving a flow with `io.kestra.plugin.transform.jsonata.TransformValue` (or any `io.kestra.plugin.transform.*` type) auto-installs **plugin-transform-records** instead of the right artifact, and the save keeps failing with 422 on the still-missing type after the wrong jar is installed.

Root cause: some plugins declare an `X-Kestra-Group` manifest value that does not match their class packages — `plugin-transform-json` declares `io.kestra.plugin.json` while its types live under `io.kestra.plugin.transform.jsonata`, `plugin-transform-grok` declares `io.kestra.plugin.grok`. Both the hosted catalog and the schema bundle mirror that manifest value, so the longest-prefix type→artifact match only ever finds `io.kestra.plugin.transform` (plugin-transform-records) for those types.

### Fix

- `PluginsSchemaCommand` now derives each bundle entry's package group from the longest common package prefix of the plugin's scanned classes — the packages flow `type` values are actually matched against — falling back to the manifest group when a plugin registers no classes.
- `PluginCatalogService.withBundleEntries` keeps the hosted entry on a `groupId:artifactId` conflict but takes the bundle's group, since the hosted value mirrors the same wrong manifest while staying authoritative for license/version metadata.

The manifest values themselves should still be corrected in `kestra-io/plugin-transform` (and the hosted catalog data refreshed) — this change makes the resolution robust against that class of bad metadata either way. Note the fix takes effect on slim images once a new bundle is baked by release CI; the currently published bundles carry the manifest-derived groups.

### Evidence

Reproduced on `kestra/kestra:develop-slim`:

```
$ curl -X POST .../api/v1/plugins/auto-install/detect -d 'type: io.kestra.plugin.transform.jsonata.TransformValue ...'
{"artifacts":[{"groupId":"io.kestra.plugin","artifactId":"plugin-transform-records", ...}]}   # wrong
```

The jar's own content vs its manifest:

```
X-Kestra-Group: io.kestra.plugin.json
classes: io/kestra/plugin/transform/jsonata/**
```

Covered by `PluginsSchemaCommandTest` (common-prefix derivation) and `PluginCatalogServiceTest#shouldPreferBundleGroupOverHostedGroupForSameArtifact` (replacing the test that pinned the old hosted-group-wins behavior, which this bug proved wrong).
