### PR TITLE
fix(core): make the input-type exclusion a per-schema seam

### DIFF
--- a/core/src/main/java/io/kestra/core/docs/JsonSchemaGenerator.java
+++ b/core/src/main/java/io/kestra/core/docs/JsonSchemaGenerator.java
@@ -146,7 +146,7 @@ public class JsonSchemaGenerator {
             // only works while that branch is still a separate array entry. Collapsing first would
             // inline it into a flat object, leaving no branch for the strip step to remove.
             Map<String, Object> schema = MAPPER.convertValue(objectNode, MAP_TYPE_REFERENCE);
-            stripEditionRestrictedInputTypes(schema);
+            stripEditionRestrictedInputTypes(schema, cls);
 
             objectNode = MAPPER.convertValue(schema, ObjectNode.class);
             collapseSingleUseDiscriminatorWrappers(objectNode);
@@ -165,15 +165,24 @@ public class JsonSchemaGenerator {
      * must be pruned. Open-source removes the {@code @EeOnly} types; the Enterprise override of
      * {@code includeInputSubtype} keeps them all, so the excluded set is empty here (no-op).
      */
-    private void stripEditionRestrictedInputTypes(Object node) {
-        Set<String> excluded = Arrays.stream(io.kestra.core.models.flows.Type.values())
-            .filter(type -> !this.includeInputSubtype(type.cls()))
-            .map(Enum::name)
-            .collect(Collectors.toSet());
+    private void stripEditionRestrictedInputTypes(Object node, Class<?> cls) {
+        Set<String> excluded = this.excludedInputTypes(cls);
 
         if (!excluded.isEmpty()) {
             stripEditionRestrictedInputTypes(node, excluded);
         }
+    }
+
+    /**
+     * The input type names to strip from the schema generated for {@code cls}, by default the ones
+     * {@link #includeInputSubtype} rejects for this edition. Override to exclude a type for one schema only; it is
+     * applied before discriminator wrappers are collapsed, which a caller stripping the returned map cannot do.
+     */
+    protected Set<String> excludedInputTypes(Class<?> cls) {
+        return Arrays.stream(io.kestra.core.models.flows.Type.values())
+            .filter(type -> !this.includeInputSubtype(type.cls()))
+            .map(Enum::name)
+            .collect(Collectors.toSet());
     }
 
     @SuppressWarnings("unchecked")

--- a/core/src/test/java/io/kestra/core/docs/JsonSchemaGeneratorTest.java
+++ b/core/src/test/java/io/kestra/core/docs/JsonSchemaGeneratorTest.java
@@ -6,6 +6,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Assertions;
@@ -162,6 +163,28 @@ class JsonSchemaGeneratorTest {
             assertThat(schema, not(containsString("REUSABLE_INPUTS")));
             // sanity: ordinary input types are still present
             assertThat(schema, containsString("EMAIL"));
+        });
+    }
+
+    @Test
+    void excludedInputTypesAreStrippedForTheTargetedSchemaOnly() throws URISyntaxException {
+        Helpers.runApplicationContext((applicationContext) ->
+        {
+            JsonSchemaGenerator standard = applicationContext.getBean(JsonSchemaGenerator.class);
+            JsonSchemaGenerator excludingEmail = new JsonSchemaGenerator(applicationContext.getBean(PluginRegistry.class)) {
+                @Override
+                protected Set<String> excludedInputTypes(Class<?> cls) {
+                    return Flow.class.equals(cls) ? Set.of("EMAIL") : super.excludedInputTypes(cls);
+                }
+            };
+
+            // the default generator offers EMAIL, so its absence below is the override's doing and not a schema change
+            assertThat(standard.schemas(Flow.class).toString(), containsString("EMAIL"));
+            // the strip has to run before discriminator wrappers collapse: afterwards the subtype is a flat definition
+            // reached by $ref, with no branch left to remove, and EMAIL would survive here
+            assertThat(excludingEmail.schemas(Flow.class).toString(), not(containsString("EMAIL")));
+            // a class the override does not target keeps the default (empty) exclusion set
+            assertThat(excludingEmail.schemas(Dashboard.class).toString(), is(standard.schemas(Dashboard.class).toString()));
         });
     }
 


### PR DESCRIPTION
## Problem

`collapseSingleUseDiscriminatorWrappers` (added in #16054) inlines a polymorphic subtype's plain `<Class>-1` definition into its `<Class>-2` wrapper and drops `-1`. An input type excluded from a schema therefore ends up as a flat definition reached by `$ref`, and a caller that prunes the returned map has no `anyOf`/`allOf` branch left to remove.

The generator already strips edition-restricted input types *before* the collapse, but the excluded set was computed only from `includeInputSubtype`, i.e. per edition — there was no way to exclude a type for a single schema.

## Fix

Expose the excluded set as `protected Set<String> excludedInputTypes(Class<?> cls)`, applied by the existing pre-collapse strip. The default is unchanged (derived from `includeInputSubtype`), so open-source behaviour is identical.

## Evidence

New test overrides the seam for one class and asserts the type disappears from that schema while an untargeted schema is byte-identical to the default generator's. Moving the strip back after the collapse makes it fail (along with the existing `pluginSchemaShouldNotResolveTaskAndTriggerSubtypes`), so it pins the ordering rather than the current output.

`./gradlew :core:test --tests "io.kestra.core.docs.JsonSchemaGeneratorTest" --tests "io.kestra.core.docs.JsonSchemaCacheTest"` — green.

Companion PR: https://github.com/kestra-io/kestra-ee/pull/10509
