### PR TITLE
fix(core): keep the base definition key when collapsing discriminator wrappers

### DIFF
--- a/core/src/main/java/io/kestra/core/docs/JsonSchemaGenerator.java
+++ b/core/src/main/java/io/kestra/core/docs/JsonSchemaGenerator.java
@@ -212,8 +212,11 @@ public class JsonSchemaGenerator {
      * {@code <Class>} object, and a {@code <Class>-2} wrapper ({@code allOf: [{$ref: <Class>-1}, {
      * required: ["type"], ...}]}) carrying the discriminator {@code required} needed to use it as
      * an {@code anyOf} branch. When the plain definition is referenced from nowhere else, keeping
-     * it separate only adds an indirection with no reuse benefit — inline it into its wrapper and
-     * drop it, cutting the schema's definition count without changing what it validates.
+     * it separate only adds an indirection with no reuse benefit — merge the wrapper's addition
+     * into it and drop the wrapper, cutting the schema's definition count without changing what it
+     * validates. The plain definition's key is the one kept, with every reference to the wrapper
+     * rewritten to it: downstream consumers (the EE no-code editors among them) address subtype
+     * definitions by that name.
      */
     private void collapseSingleUseDiscriminatorWrappers(ObjectNode objectNode) {
         if (!(objectNode.get("definitions") instanceof ObjectNode definitions)) {
@@ -223,7 +226,8 @@ public class JsonSchemaGenerator {
         Map<String, Integer> refCounts = new HashMap<>();
         countRefs(objectNode, refCounts);
 
-        List<String> baseKeysToRemove = new ArrayList<>();
+        List<String> wrapperKeysToRemove = new ArrayList<>();
+        Map<String, String> refRewrites = new HashMap<>();
         definitions.properties().forEach(entry ->
         {
             String wrapperKey = entry.getKey();
@@ -247,11 +251,33 @@ public class JsonSchemaGenerator {
                 return;
             }
 
-            definitions.set(wrapperKey, mergeAllOfBranches(base, extra));
-            baseKeysToRemove.add(baseKey);
+            definitions.set(baseKey, mergeAllOfBranches(base, extra));
+            wrapperKeysToRemove.add(wrapperKey);
+            refRewrites.put("#/definitions/" + wrapperKey, ref);
         });
 
-        baseKeysToRemove.forEach(definitions::remove);
+        wrapperKeysToRemove.forEach(definitions::remove);
+        if (!refRewrites.isEmpty()) {
+            rewriteRefs(objectNode, refRewrites);
+        }
+    }
+
+    private static void rewriteRefs(JsonNode node, Map<String, String> rewrites) {
+        if (node instanceof ObjectNode obj) {
+            obj.properties().forEach(entry ->
+            {
+                if (entry.getKey().equals("$ref") && entry.getValue() instanceof TextNode ref) {
+                    String rewritten = rewrites.get(ref.asText());
+                    if (rewritten != null) {
+                        obj.put("$ref", rewritten);
+                    }
+                } else {
+                    rewriteRefs(entry.getValue(), rewrites);
+                }
+            });
+        } else if (node instanceof ArrayNode arr) {
+            arr.forEach(child -> rewriteRefs(child, rewrites));
+        }
     }
 
     /** Merges {@code extra} onto a copy of {@code base}, unioning {@code properties}/{@code required} instead of overwriting them. */

--- a/core/src/test/java/io/kestra/core/docs/JsonSchemaGeneratorTest.java
+++ b/core/src/test/java/io/kestra/core/docs/JsonSchemaGeneratorTest.java
@@ -192,18 +192,23 @@ class JsonSchemaGeneratorTest {
 
             String base = "io.kestra.core.http.client.configurations.BasicAuthConfiguration";
             assertThat(
-                "the plain definition, only ever used by its own wrapper, must be inlined away instead of kept as a separate entry",
-                definitions.containsKey(base + "-1"), is(false)
+                "the wrapper, whose only content is a $ref to the plain definition plus the discriminator addition, must be inlined away instead of kept as a separate entry",
+                definitions.containsKey(base + "-2"), is(false)
             );
 
-            var wrapper = definitions.get(base + "-2");
-            assertThat("the wrapper must survive, carrying its own discriminator addition", wrapper, is(notNullValue()));
-            assertThat((List<String>) wrapper.get("required"), hasItem("type"));
+            var merged = definitions.get(base + "-1");
+            assertThat("the plain definition must survive under its own key — downstream consumers address subtypes by it", merged, is(notNullValue()));
+            assertThat("the wrapper's discriminator addition must not be lost in the merge", (List<String>) merged.get("required"), hasItem("type"));
 
-            var properties = (Map<String, Object>) wrapper.get("properties");
+            var properties = (Map<String, Object>) merged.get("properties");
             assertThat(
                 "the original class's own properties must not be lost in the merge",
                 properties.keySet(), hasItems("username", "password")
+            );
+
+            assertThat(
+                "no reference to the dropped wrapper may survive anywhere in the schema",
+                generate.toString().contains(base + "-2"), is(false)
             );
         });
     }


### PR DESCRIPTION
Unblocks the EE build (failing `io.kestra.ee.docs.JsonSchemaGeneratorTest`, reported in Slack after https://github.com/kestra-io/kestra/pull/16054 merged).

### Problem

The single-use discriminator-wrapper collapse from #16054 merged the plain `<Class>-1` definition into its `<Class>-2` wrapper and kept the **wrapper's** key — renaming every collapsed subtype definition. Downstream consumers address subtype definitions by the plain key: the EE no-code editors and `io.kestra.ee.docs.JsonSchemaGeneratorTest` (apps, policies, reusable-inputs cases) broke, blocking EE merges.

### Fix

Collapse in the other direction: merge the wrapper's discriminator addition into the plain definition, keep the plain key, and rewrite every `$ref` to the dropped wrapper. Same definition count, same validation semantics, stable names.

A companion EE PR fixes the remaining reusable-inputs failure (EE's `stripReusableInputs` predates the collapse and only handled the inline-`allOf` shape) — that one is EE-side regardless of this change.

### Evidence

- `:core:test --tests JsonSchemaGeneratorTest --tests PluginSchemaBundleServiceTest` green (collapse test updated to pin base-key survival and no dangling wrapper refs).
- `:webserver:test --tests PluginControllerTest` green.
- EE `:core-ee:test --tests io.kestra.ee.docs.JsonSchemaGeneratorTest` green against this branch (with the companion EE fix).
