### PR TITLE
feat(core): add SDK.defaultAuthenticationOrThrow() for fail-fast auth resolution

### DIFF
--- a/core/src/main/java/io/kestra/core/runners/SDK.java
+++ b/core/src/main/java/io/kestra/core/runners/SDK.java
@@ -16,6 +16,28 @@ public interface SDK {
      */
     Optional<Auth> defaultAuthentication();
 
+    /**
+     * Same as {@link #defaultAuthentication()} but fails fast with an actionable error when no usable
+     * credentials are configured (an API token, or a username and password — a URL alone is not enough).
+     * <p>
+     * SDK-based tasks should call this instead of silently building an unauthenticated client, which
+     * surfaces to users as an opaque 401 Unauthorized at API-call time.
+     *
+     * @return the default authentication, guaranteed to carry an API token or a username/password pair.
+     * @throws IllegalArgumentException when no default credentials are configured.
+     */
+    default Auth defaultAuthenticationOrThrow() {
+        return defaultAuthentication()
+            .filter(auth -> auth.apiToken().isPresent() || (auth.username().isPresent() && auth.password().isPresent()))
+            .orElseThrow(
+                () -> new IllegalArgumentException(
+                    "No authentication method provided for the Kestra API. Set the `auth` property on the task " +
+                        "(apiToken or username/password), or configure default credentials via " +
+                        "`kestra.tasks.sdk.authentication` (api-token, or username and password) in the Kestra configuration."
+                )
+            );
+    }
+
     @ConfigurationProperties("kestra.tasks.sdk.authentication")
     record Auth(
         Optional<String> url,

--- a/core/src/test/java/io/kestra/core/runners/RunContextSDKTest.java
+++ b/core/src/test/java/io/kestra/core/runners/RunContextSDKTest.java
@@ -7,6 +7,7 @@ import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
 import jakarta.inject.Inject;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @MicronautTest(rebuildContext = true)
 class RunContextSDKTest {
@@ -82,5 +83,32 @@ class RunContextSDKTest {
 
         assertThat(runContext.sdk().defaultAuthentication()).isPresent();
         assertThat(runContext.sdk().defaultAuthentication().get().url()).isEmpty();
+    }
+
+    @Test
+    void sdkAuthOrThrowShouldFailFastWhenNotSet() {
+        RunContext runContext = runContextInitializer.forExecutor((DefaultRunContext) runContextFactory.of());
+
+        assertThatThrownBy(() -> runContext.sdk().defaultAuthenticationOrThrow())
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("No authentication method provided for the Kestra API");
+    }
+
+    @Test
+    @Property(name = "kestra.tasks.sdk.authentication.url", value = "https://my-instance.io")
+    void sdkAuthOrThrowShouldFailFastWhenUrlOnly() {
+        RunContext runContext = runContextInitializer.forExecutor((DefaultRunContext) runContextFactory.of());
+
+        assertThatThrownBy(() -> runContext.sdk().defaultAuthenticationOrThrow())
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("No authentication method provided for the Kestra API");
+    }
+
+    @Test
+    @Property(name = "kestra.tasks.sdk.authentication.api-token", value = "test-key")
+    void sdkAuthOrThrowShouldReturnAuthWhenSet() {
+        RunContext runContext = runContextInitializer.forExecutor((DefaultRunContext) runContextFactory.of());
+
+        assertThat(runContext.sdk().defaultAuthenticationOrThrow().apiToken()).contains("test-key");
     }
 }


### PR DESCRIPTION
## Why

Since 2.0, tasks that reach the Kestra API through the SDK fail with an opaque `401 Unauthorized` at API-call time when no credentials are configured, because each plugin decides on its own what to do when `SDK.defaultAuthentication()` comes back empty — and some silently build an unauthenticated client. Reported for `io.kestra.plugin.git.SyncFlows` on 2.0.0-rc11: https://kestra-io.slack.com/archives/C04HTFM3VL6/p1787823820806449

kestra-io/plugin-git#325 fixes this locally in plugin-git, but every SDK-based plugin (plugin-git, plugin-kestra, plugin-ai, EE git) re-implements the same resolve-or-fail logic.

## What

Add `SDK.defaultAuthenticationOrThrow()` — a single fail-fast entry point all plugins can use:

- returns the default authentication only when it carries **usable credentials** (an API token, or a username/password pair — a URL alone is not enough);
- otherwise throws `IllegalArgumentException` with an actionable message pointing at the task-level `auth` property and the `kestra.tasks.sdk.authentication` configuration.

`defaultAuthentication()` itself is unchanged: returning empty is legitimate (e.g. `auth.auto: false`, or url-only configuration used as a URL default).

Default method on the interface, so the EE `SDK` implementation (namespace/tenant-level resolution) inherits it as-is.

## Test plan

- [x] `:core:test --tests io.kestra.core.runners.RunContextSDKTest` — 3 new cases: throws when nothing configured, throws when url-only, returns auth when api-token set

## Follow-up

- Migrate plugin-git / plugin-kestra / plugin-ai / EE git to call `defaultAuthenticationOrThrow()` once they build against a core version containing it.
