### PR TITLE
fix(flows): validate input defaults, trigger inputs, webhook key and namespace at save

### DIFF
--- a/core/src/main/java/io/kestra/core/models/flows/input/SelectInput.java
+++ b/core/src/main/java/io/kestra/core/models/flows/input/SelectInput.java
@@ -69,7 +69,8 @@ public class SelectInput extends Input<String> implements RenderableInput {
 
     @Override
     public void validate(String input) throws ConstraintViolationException {
-        if (this.getAllowCustomValue()) {
+        // values is null when the options come from an expression that has not been rendered yet.
+        if (this.getAllowCustomValue() || values == null) {
             return;
         }
 

--- a/core/src/main/java/io/kestra/core/models/flows/input/SelectInput.java
+++ b/core/src/main/java/io/kestra/core/models/flows/input/SelectInput.java
@@ -69,10 +69,11 @@ public class SelectInput extends Input<String> implements RenderableInput {
 
     @Override
     public void validate(String input) throws ConstraintViolationException {
-        if (this.getRequired() && values.stream().noneMatch(v -> Objects.equals(v.value(), input))) {
-            if (this.getAllowCustomValue()) {
-                return;
-            }
+        if (this.getAllowCustomValue()) {
+            return;
+        }
+
+        if (values.stream().noneMatch(v -> Objects.equals(v.value(), input))) {
             throw ManualConstraintViolation.toConstraintViolationException(
                 "it must match the values `" + values.stream().map(ValueOption::value).toList() + "`",
                 this,

--- a/core/src/main/java/io/kestra/core/runners/FlowInputOutput.java
+++ b/core/src/main/java/io/kestra/core/runners/FlowInputOutput.java
@@ -582,10 +582,31 @@ public class FlowInputOutput {
         );
     }
 
+    /**
+     * Coerces a scalar input value to its typed form for {@code type}, returning empty for types whose parsing needs
+     * execution-time infrastructure (FILE, SECRET) or structural/document handling (URI, ARRAY, MULTISELECT, JSON,
+     * ION, YAML, FORM, REUSABLE_INPUTS). Shared by input resolution ({@link #parseType}) and save-time flow validation
+     * so both coerce a literal identically.
+     */
+    public static Optional<Object> parseScalarInputValue(Type type, Object current) {
+        return Optional.ofNullable(switch (type) {
+            case STRING, EMAIL, SELECT -> current.toString();
+            case INT -> TypeConverter.toInteger(current);
+            case FLOAT -> TypeConverter.toFloat(current);
+            case BOOL -> TypeConverter.toBoolean(current);
+            case DATETIME -> TypeConverter.toInstant(current);
+            case DATE -> TypeConverter.toLocalDate(current);
+            case TIME -> TypeConverter.toLocalTime(current);
+            case DURATION -> TypeConverter.toDuration(current);
+            case FILE, URI, SECRET, JSON, ION, YAML, ARRAY, MULTISELECT, FORM, REUSABLE_INPUTS -> null;
+        });
+    }
+
     private Object parseType(Execution execution, Type type, String id, Type elementType, Object current, Data data) throws Exception {
         try {
             return switch (type) {
-                case SELECT, STRING, EMAIL -> current.toString();
+                case STRING, EMAIL, SELECT, INT, FLOAT, BOOL, DATETIME, DATE, TIME, DURATION ->
+                    parseScalarInputValue(type, current).orElseThrow();
                 case SECRET -> {
                     if (secretKey.isEmpty()) {
                         throw new Exception("Unable to use a `SECRET` input/output as encryption is not configured");
@@ -596,14 +617,6 @@ public class FlowInputOutput {
                     String encrypted = EncryptionService.encrypt(secretKey.get(), current.toString());
                     yield EncryptedString.from(encrypted);
                 }
-                case INT -> TypeConverter.toInteger(current);
-                // Assuming that after the render we must have a double/int, so we can safely use its toString representation
-                case FLOAT -> TypeConverter.toFloat(current);
-                case BOOL -> TypeConverter.toBoolean(current);
-                case DATETIME -> TypeConverter.toInstant(current);
-                case DATE -> TypeConverter.toLocalDate(current);
-                case TIME -> TypeConverter.toLocalTime(current);
-                case DURATION -> TypeConverter.toDuration(current);
                 case FILE -> {
                     URI uri = URI.create(current.toString().replace(File.separator, "/"));
 

--- a/core/src/main/java/io/kestra/core/services/FlowParsingService.java
+++ b/core/src/main/java/io/kestra/core/services/FlowParsingService.java
@@ -1,6 +1,7 @@
 package io.kestra.core.services;
 
 import java.util.Map;
+import java.util.Objects;
 
 import org.slf4j.event.Level;
 
@@ -219,7 +220,7 @@ public class FlowParsingService {
         @Nullable final String namespace,
         final String source) throws JsonProcessingException, FlowProcessingException {
         Map<String, Object> mapFlow = YAML_MAPPER.readValue(source, JacksonMapper.MAP_TYPE_REFERENCE);
-        return injectPluginVersions(tenantId, namespace == null ? (String) mapFlow.get("namespace") : namespace, mapFlow);
+        return injectPluginVersions(tenantId, namespace == null ? Objects.toString(mapFlow.get("namespace"), null) : namespace, mapFlow);
     }
 
     /**

--- a/core/src/main/java/io/kestra/core/validations/validator/FlowValidator.java
+++ b/core/src/main/java/io/kestra/core/validations/validator/FlowValidator.java
@@ -9,6 +9,7 @@ import java.util.stream.Stream;
 import io.kestra.core.models.flows.Data;
 import io.kestra.core.models.flows.Flow;
 import io.kestra.core.models.flows.Input;
+import io.kestra.core.models.flows.Type;
 import io.kestra.core.models.flows.input.EeOnly;
 import io.kestra.core.models.flows.input.FormInput;
 import io.kestra.core.models.tasks.ExecutableTask;
@@ -16,6 +17,8 @@ import io.kestra.core.models.tasks.Task;
 import io.kestra.core.models.triggers.AbstractTrigger;
 import io.kestra.core.services.NamespaceService;
 import io.kestra.core.utils.ListUtils;
+import io.kestra.core.utils.PebbleUtil;
+import io.kestra.core.utils.TypeConverter;
 import io.kestra.core.validations.FlowValidation;
 import io.kestra.plugin.core.trigger.AbstractWebhookTrigger;
 import io.kestra.plugin.core.trigger.Schedule;
@@ -27,6 +30,8 @@ import io.micronaut.validation.validator.constraints.ConstraintValidator;
 import io.micronaut.validation.validator.constraints.ConstraintValidatorContext;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.ConstraintViolationException;
 
 import static io.kestra.core.models.Label.READ_ONLY;
 import static io.kestra.core.models.Label.SYSTEM_PREFIX;
@@ -113,6 +118,8 @@ public class FlowValidator implements ConstraintValidator<FlowValidation, Flow> 
         }
 
         findMissingInputsForTriggers(value).forEach(violations::add);
+
+        validateDeclaredInputValues(value, violations);
 
         // system labels
         ListUtils.emptyOnNull(value.getLabels()).stream()
@@ -312,6 +319,103 @@ public class FlowValidator implements ConstraintValidator<FlowValidation, Flow> 
                             : Stream.of("Missing inputs for %s Trigger '%s', missing inputs: '%s'".formatted(triggerInputs.kind(), trigger.getId(), missingInputs));
                     })
             );
+    }
+
+    /**
+     * Validates the literal values a flow declares for its own inputs — input {@code defaults} and the values a
+     * trigger supplies to inputs — against each input's declared type and constraints, so a type mismatch (an
+     * {@code INT} default of {@code "abc"}) or an out-of-list {@code SELECT} value is rejected at save time instead
+     * of only failing when the flow runs. Pebble expressions are left untouched: they can only be resolved at runtime.
+     */
+    private void validateDeclaredInputValues(Flow value, List<String> violations) {
+        List<Input<?>> inputs = value.resolvableInputs();
+        if (inputs.isEmpty()) {
+            return;
+        }
+
+        for (Input<?> input : inputs) {
+            if (input.getDefaults() != null) {
+                literalValueViolation(input, input.getDefaults().toString())
+                    .ifPresent(message -> violations.add("Invalid default for input '%s': %s".formatted(input.getId(), message)));
+            }
+        }
+
+        if (ListUtils.emptyOnNull(value.getTriggers()).isEmpty()) {
+            return;
+        }
+
+        Map<String, Input<?>> inputsById = inputs.stream()
+            .collect(Collectors.toMap(Data::getId, input -> input, (first, second) -> first));
+
+        for (AbstractTrigger trigger : value.getTriggers()) {
+            inputsSuppliedBy(trigger).ifPresent(triggerInputs ->
+                triggerInputs.supplied().forEach((inputId, suppliedValue) -> {
+                    Input<?> input = inputsById.get(inputId);
+                    if (input != null) {
+                        literalValueViolation(input, suppliedValue)
+                            .ifPresent(message -> violations.add(
+                                "Invalid value for input '%s' supplied by %s Trigger '%s': %s".formatted(inputId, triggerInputs.kind(), trigger.getId(), message)));
+                    }
+                }));
+        }
+    }
+
+    /**
+     * @return the constraint message when {@code rawValue} — a literal default or a value a trigger supplies — cannot
+     * satisfy the input's type or its own constraints, or empty when it is valid, is a Pebble expression, or is of a
+     * type that can only be resolved at execution time (e.g. {@code FILE}, {@code SECRET} or structured types).
+     */
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    private static Optional<String> literalValueViolation(Input<?> input, Object rawValue) {
+        if (rawValue == null) {
+            return Optional.empty();
+        }
+
+        String asString = rawValue.toString();
+        if (PebbleUtil.containsOpeningBlockDelimiter(asString)) {
+            return Optional.empty();
+        }
+
+        Object typed;
+        try {
+            typed = coerceToInputType(input.getType(), rawValue, asString);
+        } catch (Exception e) {
+            return Optional.of("`%s` is not a valid %s value".formatted(asString, input.getType()));
+        }
+
+        if (typed == null) {
+            return Optional.empty();
+        }
+
+        try {
+            ((Input) input).validate(typed);
+        } catch (ConstraintViolationException e) {
+            String message = e.getConstraintViolations().stream()
+                .map(ConstraintViolation::getMessage)
+                .collect(Collectors.joining(", "));
+            return Optional.of(message.isEmpty() ? "invalid value" : message);
+        }
+
+        return Optional.empty();
+    }
+
+    /**
+     * Coerces a literal value to its input type for save-time validation, returning {@code null} for types whose
+     * literal cannot be resolved without execution-time infrastructure (storage, encryption) or whose structure is
+     * out of scope for this check.
+     */
+    private static Object coerceToInputType(Type type, Object rawValue, String asString) {
+        return switch (type) {
+            case STRING, EMAIL, SELECT -> asString;
+            case INT -> TypeConverter.toInteger(rawValue);
+            case FLOAT -> TypeConverter.toFloat(rawValue);
+            case BOOL -> TypeConverter.toBoolean(rawValue);
+            case DATETIME -> TypeConverter.toInstant(rawValue);
+            case DATE -> TypeConverter.toLocalDate(rawValue);
+            case TIME -> TypeConverter.toLocalTime(rawValue);
+            case DURATION -> TypeConverter.toDuration(rawValue);
+            case FILE, URI, SECRET, JSON, ION, YAML, ARRAY, MULTISELECT, FORM, REUSABLE_INPUTS -> null;
+        };
     }
 
     private static Optional<TriggerInputs> inputsSuppliedBy(AbstractTrigger trigger) {

--- a/core/src/main/java/io/kestra/core/validations/validator/FlowValidator.java
+++ b/core/src/main/java/io/kestra/core/validations/validator/FlowValidator.java
@@ -9,16 +9,15 @@ import java.util.stream.Stream;
 import io.kestra.core.models.flows.Data;
 import io.kestra.core.models.flows.Flow;
 import io.kestra.core.models.flows.Input;
-import io.kestra.core.models.flows.Type;
 import io.kestra.core.models.flows.input.EeOnly;
 import io.kestra.core.models.flows.input.FormInput;
 import io.kestra.core.models.tasks.ExecutableTask;
 import io.kestra.core.models.tasks.Task;
 import io.kestra.core.models.triggers.AbstractTrigger;
+import io.kestra.core.runners.FlowInputOutput;
 import io.kestra.core.services.NamespaceService;
 import io.kestra.core.utils.ListUtils;
 import io.kestra.core.utils.PebbleUtil;
-import io.kestra.core.utils.TypeConverter;
 import io.kestra.core.validations.FlowValidation;
 import io.kestra.plugin.core.trigger.AbstractWebhookTrigger;
 import io.kestra.plugin.core.trigger.Schedule;
@@ -378,7 +377,7 @@ public class FlowValidator implements ConstraintValidator<FlowValidation, Flow> 
 
         Object typed;
         try {
-            typed = coerceToInputType(input.getType(), rawValue, asString);
+            typed = FlowInputOutput.parseScalarInputValue(input.getType(), rawValue).orElse(null);
         } catch (Exception e) {
             return Optional.of("`%s` is not a valid %s value".formatted(asString, input.getType()));
         }
@@ -397,25 +396,6 @@ public class FlowValidator implements ConstraintValidator<FlowValidation, Flow> 
         }
 
         return Optional.empty();
-    }
-
-    /**
-     * Coerces a literal value to its input type for save-time validation, returning {@code null} for types whose
-     * literal cannot be resolved without execution-time infrastructure (storage, encryption) or whose structure is
-     * out of scope for this check.
-     */
-    private static Object coerceToInputType(Type type, Object rawValue, String asString) {
-        return switch (type) {
-            case STRING, EMAIL, SELECT -> asString;
-            case INT -> TypeConverter.toInteger(rawValue);
-            case FLOAT -> TypeConverter.toFloat(rawValue);
-            case BOOL -> TypeConverter.toBoolean(rawValue);
-            case DATETIME -> TypeConverter.toInstant(rawValue);
-            case DATE -> TypeConverter.toLocalDate(rawValue);
-            case TIME -> TypeConverter.toLocalTime(rawValue);
-            case DURATION -> TypeConverter.toDuration(rawValue);
-            case FILE, URI, SECRET, JSON, ION, YAML, ARRAY, MULTISELECT, FORM, REUSABLE_INPUTS -> null;
-        };
     }
 
     private static Optional<TriggerInputs> inputsSuppliedBy(AbstractTrigger trigger) {

--- a/core/src/main/java/io/kestra/plugin/core/trigger/AbstractWebhookTrigger.java
+++ b/core/src/main/java/io/kestra/plugin/core/trigger/AbstractWebhookTrigger.java
@@ -31,7 +31,6 @@ import reactor.core.publisher.Mono;
 @NoArgsConstructor
 public abstract class AbstractWebhookTrigger extends AbstractTrigger {
     @Size(max = 256)
-    @NotNull
     @NotBlank
     @Schema(
         title = "The unique key that will be part of the URL.",

--- a/core/src/test/java/io/kestra/core/models/flows/input/SelectInputTest.java
+++ b/core/src/test/java/io/kestra/core/models/flows/input/SelectInputTest.java
@@ -172,6 +172,19 @@ class SelectInputTest {
     }
 
     @Test
+    void validateRejectsOutOfListValueForOptionalInput() {
+        SelectInput input = SelectInput
+            .builder()
+            .id("id")
+            .values(List.of(new ValueOption("a", "a"), new ValueOption("b", "b"), new ValueOption("c", "c")))
+            .required(false)
+            .build();
+
+        assertThatThrownBy(() -> input.validate("zzz"))
+            .hasMessageContaining("[a, b, c]");
+    }
+
+    @Test
     void valueOptionDeserializesFromStringOrObject() {
         ValueOption fromString = ValueOption.from("V1");
         assertThat(fromString.label()).isEqualTo("V1");

--- a/core/src/test/java/io/kestra/core/models/flows/input/SelectInputTest.java
+++ b/core/src/test/java/io/kestra/core/models/flows/input/SelectInputTest.java
@@ -185,6 +185,18 @@ class SelectInputTest {
     }
 
     @Test
+    void validateAcceptsAnyValueWhenValuesComeFromAnUnrenderedExpression() {
+        SelectInput input = SelectInput
+            .builder()
+            .id("id")
+            .expression("{{ values }}")
+            .required(false)
+            .build();
+
+        input.validate("789");
+    }
+
+    @Test
     void valueOptionDeserializesFromStringOrObject() {
         ValueOption fromString = ValueOption.from("V1");
         assertThat(fromString.label()).isEqualTo("V1");

--- a/core/src/test/java/io/kestra/core/services/FlowParsingServiceTest.java
+++ b/core/src/test/java/io/kestra/core/services/FlowParsingServiceTest.java
@@ -68,4 +68,21 @@ class FlowParsingServiceTest {
         assertThat(task.getLevel()).isEqualTo(Property.ofValue(Level.INFO));
         assertThat(parsed.getSource()).isEqualTo(source);
     }
+
+    @Test
+    void shouldParseFlowWithDigitsOnlyNamespace() throws FlowProcessingException {
+        // A digits-only namespace is read from the YAML as an Integer; it must not break parsing with a raw cast.
+        String source = """
+            id: test
+            namespace: 132312312
+            tasks:
+              - id: log
+                type: io.kestra.plugin.core.log.Log
+                message: hi
+            """;
+
+        FlowWithSource parsed = flowParsingService.parse(null, source, false);
+
+        assertThat(parsed.getNamespace()).isEqualTo("132312312");
+    }
 }

--- a/core/src/test/java/io/kestra/core/validations/FlowValidationTest.java
+++ b/core/src/test/java/io/kestra/core/validations/FlowValidationTest.java
@@ -357,6 +357,118 @@ class FlowValidationTest {
     }
 
     @Test
+    void inputDefaultOutsideSelectValues_failValidation() {
+        Flow flow = YamlParser.parse("""
+            id: test
+            namespace: unittest
+            inputs:
+              - id: color
+                type: SELECT
+                values: [red, green, blue]
+                defaults: purple
+            tasks:
+              - id: hello
+                type: io.kestra.plugin.core.log.Log
+                message: hi
+            """, Flow.class);
+
+        Optional<ConstraintViolationException> validate = modelValidator.isValid(flow);
+
+        assertThat(validate).isPresent();
+        assertThat(validate.get().getMessage()).contains("Invalid default for input 'color'");
+        assertThat(validate.get().getMessage()).contains("it must match the values");
+    }
+
+    @Test
+    void inputDefaultNotMatchingType_failValidation() {
+        Flow flow = YamlParser.parse("""
+            id: test
+            namespace: unittest
+            inputs:
+              - id: count
+                type: INT
+                defaults: notanumber
+            tasks:
+              - id: hello
+                type: io.kestra.plugin.core.log.Log
+                message: hi
+            """, Flow.class);
+
+        Optional<ConstraintViolationException> validate = modelValidator.isValid(flow);
+
+        assertThat(validate).isPresent();
+        assertThat(validate.get().getMessage()).contains("Invalid default for input 'count'");
+        assertThat(validate.get().getMessage()).contains("is not a valid INT value");
+    }
+
+    @Test
+    void inputDefaultAsExpression_valid() {
+        Flow flow = YamlParser.parse("""
+            id: test
+            namespace: unittest
+            inputs:
+              - id: count
+                type: INT
+                defaults: "{{ 1 + 1 }}"
+            tasks:
+              - id: hello
+                type: io.kestra.plugin.core.log.Log
+                message: hi
+            """, Flow.class);
+
+        assertThat(modelValidator.isValid(flow)).isEmpty();
+    }
+
+    @Test
+    void triggerInputNotMatchingType_failValidation() {
+        Flow flow = YamlParser.parse("""
+            id: test
+            namespace: unittest
+            inputs:
+              - id: num
+                type: INT
+                required: true
+            triggers:
+              - id: every_minute
+                type: io.kestra.plugin.core.trigger.Schedule
+                cron: "* * * * *"
+                inputs:
+                  num: abc
+            tasks:
+              - id: hello
+                type: io.kestra.plugin.core.log.Log
+                message: "n={{ inputs.num }}"
+            """, Flow.class);
+
+        Optional<ConstraintViolationException> validate = modelValidator.isValid(flow);
+
+        assertThat(validate).isPresent();
+        assertThat(validate.get().getMessage()).contains("Invalid value for input 'num' supplied by Schedule Trigger 'every_minute'");
+        assertThat(validate.get().getMessage()).contains("is not a valid INT value");
+    }
+
+    @Test
+    void webhookBlankKey_failValidation() {
+        Flow flow = YamlParser.parse("""
+            id: test
+            namespace: unittest
+            tasks:
+              - id: hello
+                type: io.kestra.plugin.core.log.Log
+                message: hi
+            triggers:
+              - id: hook
+                type: io.kestra.plugin.core.trigger.Webhook
+                key: "   "
+            """, Flow.class);
+
+        Optional<ConstraintViolationException> validate = modelValidator.isValid(flow);
+
+        assertThat(validate).isPresent();
+        assertThat(validate.get().getMessage()).contains("must not be blank");
+    }
+
+    @Test
     void eeAllowsDefiningAssets() {
         Flow flow = Flow.builder()
             .id(TestsUtils.randomString())

--- a/webserver/src/main/java/io/kestra/webserver/controllers/ErrorController.java
+++ b/webserver/src/main/java/io/kestra/webserver/controllers/ErrorController.java
@@ -92,7 +92,6 @@ public class ErrorController {
 
         // A conversion error is always caused by bad client input, so it surfaces as a clean client error and the
         // raw exception message is not sent back to the caller: it carries the target DTO's internal class name.
-        log.debug("Unable to convert request input", e);
         return jsonError(request, HttpStatus.UNPROCESSABLE_ENTITY, "Invalid request body");
     }
 

--- a/webserver/src/main/java/io/kestra/webserver/controllers/ErrorController.java
+++ b/webserver/src/main/java/io/kestra/webserver/controllers/ErrorController.java
@@ -90,7 +90,10 @@ public class ErrorController {
             }
         }
 
-        return jsonError(request, e, HttpStatus.UNPROCESSABLE_ENTITY, "Internal server error");
+        // A conversion error is always caused by bad client input, so it surfaces as a clean client error and the
+        // raw exception message is not sent back to the caller: it carries the target DTO's internal class name.
+        log.debug("Unable to convert request input", e);
+        return jsonError(request, HttpStatus.UNPROCESSABLE_ENTITY, "Invalid request body");
     }
 
     @SuppressWarnings("unchecked")

--- a/webserver/src/test/java/io/kestra/webserver/controllers/api/ErrorControllerTest.java
+++ b/webserver/src/test/java/io/kestra/webserver/controllers/api/ErrorControllerTest.java
@@ -122,6 +122,24 @@ class ErrorControllerTest {
     }
 
     @Test
+    void malformedBodyDoesNotLeakInternalClassNames() {
+        HttpClientResponseException exception = assertThrows(
+            HttpClientResponseException.class, () -> client.toBlocking().retrieve(
+                POST("/api/v1/main/triggers/backfill/delete", "\"hello\"").contentType(MediaType.APPLICATION_JSON),
+                Argument.of(String.class),
+                Argument.of(JsonError.class)
+            )
+        );
+
+        assertThat(exception.getStatus().getCode()).isEqualTo(UNPROCESSABLE_ENTITY.getCode());
+
+        String response = exception.getResponse().getBody(String.class).get();
+        assertThat(response).contains("Invalid request body");
+        assertThat(response).doesNotContain("Internal server error");
+        assertThat(response).doesNotContain("ApiTriggerId");
+    }
+
+    @Test
     void clientError400() {
         HttpClientResponseException exception = assertThrows(
             HttpClientResponseException.class, () -> client.toBlocking().retrieve(


### PR DESCRIPTION
### What this PR does

Bug-bash batch: bad flow / input / trigger configuration was accepted at save time (or at request time) and only surfaced later at runtime, or as a raw `500`. This tightens validation at the point of entry so the failure is caught where it is authored.

Six fixes, one theme (reject bad input up front):

- **Input defaults not validated** (kestra#18333 / kestra-ee#10259) — a literal `defaults` is now checked against the input's own type and allowed values at save. A `SELECT` default outside `values`, or an `INT` default of `notanumber`, is rejected instead of validating green and failing on first run.
- **Trigger inputs not type-checked** (kestra-ee#10298) — the values a Schedule/Webhook trigger supplies to an input are validated against the target input's type at save (e.g. `"abc"` for an `INT`), so a typo no longer silently stops a schedule.
- **Optional SELECT accepted out-of-list value** (kestra-ee#10258) — the values check was gated on `required: true`; an optional `SELECT` now rejects a value outside its list too (`allowCustomValue` still bypasses it).
- **Webhook blank key** (kestra-ee#10272) — `key` is now `@NotBlank`; a blank/whitespace key (which produced an un-triggerable `403` webhook) is rejected at save.
- **Digits-only namespace → 500** (kestra#18472) — a numeric namespace read from YAML no longer throws a raw `Integer cannot be cast to String`; it is coerced to its string form.
- **Malformed request body leaked internals** (kestra-ee#10273) — a scalar body sent to an endpoint expecting an object returned `422` labelled `Internal server error` and leaked the DTO class name. It now returns a clean `422 Invalid request body`; the raw cause is kept in the server debug log only.

The save-time literal check covers scalar and `SELECT` inputs; infrastructure-backed and structured types (`FILE`, `SECRET`, `JSON`/`ION`/`YAML`, `URI`, `ARRAY`, `MULTISELECT`) are skipped because their literal cannot be resolved without execution-time machinery, and Pebble expressions are left for runtime.

All fixes are in OSS core/webserver; EE inherits them (its `FlowValidator` only overrides the EE-specific hooks).

### Evidence

- `FlowValidationTest` — SELECT default out-of-list, INT default `notanumber`, expression default (skipped), trigger INT input `abc`, webhook blank key.
- `SelectInputTest` — optional SELECT rejects out-of-list.
- `FlowParsingServiceTest` — digits-only namespace parses to `"132312312"`.
- `ErrorControllerTest` — scalar body → clean `422`, no `ApiTriggerId` / `Internal server error` in the response.

Closes https://github.com/kestra-io/kestra/issues/18333.
Closes https://github.com/kestra-io/kestra/issues/18472.

### EE issues (same fixes, cross-repo — close manually on merge)

GitHub only auto-closes issues in this repo, so these are linked for reference and must be closed by hand once this merges:

- https://github.com/kestra-io/kestra-ee/issues/10259 (dup of #18333)
- https://github.com/kestra-io/kestra-ee/issues/10258
- https://github.com/kestra-io/kestra-ee/issues/10298
- https://github.com/kestra-io/kestra-ee/issues/10272
- https://github.com/kestra-io/kestra-ee/issues/10273