### PR TITLE
fix(kv): preserve plain text values with spaces

### DIFF
--- a/webserver/src/main/java/io/kestra/webserver/controllers/api/KVController.java
+++ b/webserver/src/main/java/io/kestra/webserver/controllers/api/KVController.java
@@ -4,6 +4,8 @@ import java.io.IOException;
 import java.time.Instant;
 import java.util.*;
 
+import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 
@@ -80,7 +82,7 @@ public class KVController {
     );
 
     private String sortMapper(String key) {
-        return key == null ? null : SORT_FIELDS.get(key);
+	return key == null ? null :SORT_FIELDS.get(key);
     }
 
     @ExecuteOn(TaskExecutors.IO)
@@ -145,7 +147,6 @@ public class KVController {
             value = new String(bytesValue);
         }
 
-        // Should never throw as the above verifies the KV entry existence
         KVEntry kvEntry = nsKvStore.get(key).orElseThrow();
 
         return new KvDetail(KVType.from(value), value, kvEntry.revision(), kvEntry.updateDate());
@@ -163,9 +164,13 @@ public class KVController {
         String ttl = httpHeaders.get("ttl");
         KVMetadata metadata = new KVMetadata(description, TypeConverter.toDuration(ttl));
         try {
-            // use ION mapper to properly handle timestamp
-            JsonNode jsonNode = JacksonMapper.ofIon().readTree(value);
-            kvStore(namespace).put(key, new KVValueAndMetadata(metadata, jsonNode));
+            try (JsonParser parser = JacksonMapper.ofIon().createParser(value)) {
+                JsonNode jsonNode = JacksonMapper.ofIon().readTree(parser);
+                if (parser.nextToken() != null) {
+                    throw new JsonParseException(parser, "Trailing content after the first Ion value");
+                }
+                kvStore(namespace).put(key, new KVValueAndMetadata(metadata, jsonNode));
+            }
         } catch (JsonProcessingException e) {
             kvStore(namespace).put(key, new KVValueAndMetadata(metadata, value));
         }

--- a/webserver/src/test/java/io/kestra/webserver/controllers/api/KVControllerTest.java
+++ b/webserver/src/test/java/io/kestra/webserver/controllers/api/KVControllerTest.java
@@ -378,6 +378,15 @@ class KVControllerTest {
         assertThat(kvEntry.description()).isEqualTo(myDescription);
     }
 
+    @ParameterizedTest
+    @ValueSource(strings = {"hello world", "hello-world-123", "John Doe Smith", "a description with several words"})
+    void setKeyValueShouldPreserveUnquotedPlainTextValue(String value) throws IOException, ResourceExpiredException {
+        client.toBlocking()
+            .exchange(HttpRequest.PUT("/api/v1/main/namespaces/" + NAMESPACE + "/kv/my-key", value).contentType(MediaType.TEXT_PLAIN));
+
+        assertThat(kvStore().getValue("my-key").get().value()).isEqualTo(value);
+    }
+
     private InternalKVStore kvStore() {
         return this.kvStore(NAMESPACE);
     }


### PR DESCRIPTION
All PRs submitted by external contributors must follow this template (proper description, related issue, and checklist sections). If you plan to work on a specific issue, comment on the issue first and wait to be assigned before starting any actual work - this avoids duplicated work and ensures a smooth contribution process. PRs that skip either rule **may be automatically closed**.

<!-- PR title must follow Conventional Commits with a single scope, lowercase description: `fix(core): handle empty trigger list`. See AGENTS.md for the allowed types and scopes. -->

---
### 🔗 Related Issue

Closes #18335

### ✨ Description

Fix KV values with spaces being truncated when saved through the API.

The parser could read the first part of the value as an Ion value and ignore the rest. This change checks for trailing content and falls back to storing the value as plain text.

Added tests for values containing spaces.

### 🛠️ Backend Checklist

- [x] Code compiles and tests pass for the touched modules
- [x] New behavior is covered by unit or integration tests

### 📝 Additional Notes

None.