### PR TITLE
fix(flows): remove the empty gap between the Context panel sections

### DIFF
--- a/ui/src/components/flows/TaskEdit.vue
+++ b/ui/src/components/flows/TaskEdit.vue
@@ -599,8 +599,6 @@
         min-width: 0;
         min-height: 0;
         height: 100%;
-        display: flex;
-        flex-direction: column;
     }
 
     .task-edit-col-inputs {

--- a/ui/src/components/flows/TaskEdit.vue
+++ b/ui/src/components/flows/TaskEdit.vue
@@ -599,6 +599,8 @@
         min-width: 0;
         min-height: 0;
         height: 100%;
+        display: flex;
+        flex-direction: column;
     }
 
     .task-edit-col-inputs {

--- a/ui/src/styles/app.scss
+++ b/ui/src/styles/app.scss
@@ -102,7 +102,9 @@ main {
             flex: 1;
             min-height: 0;
 
-            :has(.ks-data-table-wrapper) {
+            // Every ancestor of the table is matched here, so keep the stretch out of
+            // collapsible sections, which have to hug their summary when closed.
+            :has(.ks-data-table-wrapper):not(details, details *) {
                 height: 100%;
             }
         }


### PR DESCRIPTION
Closes https://github.com/kestra-io/kestra/issues/18495.

## Problem

In the flow editor `Context` panel, the `Variables`, `KV Pair` and `Secrets` sections were spread apart by a large empty gap, and the gap stayed there when the sections were collapsed.

`app.scss` stretches a listing section to full height when its data table renders an empty state, so the empty state fills the page instead of hugging the top. The inner rule was an unqualified descendant selector, `:has(.ks-data-table-wrapper) { height: 100% }`, which matches **every** ancestor of a `.ks-data-table-wrapper`. In the `Context` panel that includes the `<details>` elements of the `KV Pair` and `Secrets` collapsibles, so each one took the full height of the panel (629px in a 693px panel) even while closed. `Variables` has no data table, so it stayed at its 29px summary height, which is why only the two lower sections drifted apart.

## Fix

Keep the stretch from descending into a `<details>` subtree. A collapsible has to hug its summary when closed, so it is never a candidate for the full-height treatment.

The only two `<details>` in the codebase are the plugin-docs `SchemaSection.vue`, which contains no data table, and the `EE` `Collapsible.vue` used by the `Context` panel. Measured against the running app, the new selector drops exactly the nine elements inside those two collapsibles and leaves every other match untouched; the listing pages match the same set as before.

## Evidence

Local `EE` instance, `Context` panel with all three sections collapsed. Before, `Secrets` sits 629px below `KV Pair`; after, the three sections stack normally.

| Before | After |
|---|---|
| <img width="420" src="https://raw.githubusercontent.com/MilosPaunovic/kestra/21ad70e0ee770eab6b85f5435b360d9efc7672d2/18495/before.png" /> | <img width="420" src="https://raw.githubusercontent.com/MilosPaunovic/kestra/21ad70e0ee770eab6b85f5435b360d9efc7672d2/18495/after.png" /> |

Section heights measured in the same instance:

| | `variables` | `kv-pair` | `secrets` |
|---|---|---|---|
| before | 29px | 629px | 629px |
| after | 29px | 29px | 29px |

Expanding `KV Pair` still works and now sizes to its content (358px) instead of being forced to 629px.

## Note on the branch history

This `PR` originally changed `.task-edit-col` in `TaskEdit.vue`. The `Context` panel is not in that component's tree, and every element carrying `.task-edit-col` already resolves to `display: flex; flex-direction: column`, so that change was a no-op. It is reverted on the branch and replaced with the `app.scss` fix above, verified against a running Enterprise instance. See the discussion below.
