### PR TITLE
fix(design-system): remove the manual resize handle from the KsPassword textarea

### DIFF
--- a/ui/packages/design-system/src/components/Form/KsPassword.vue
+++ b/ui/packages/design-system/src/components/Form/KsPassword.vue
@@ -6,6 +6,7 @@
             v-bind="({...filteredProps(), ...$attrs} as any)"
             @change="emit('change', $event)"
             autosize
+            resize="none"
             type="textarea"
         >
             <template v-if="$slots.prepend" #prepend>


### PR DESCRIPTION
Closes https://github.com/kestra-io/kestra-ee/issues/10282.

## What

In the `Add promotion target` dialog (Promote), the `API token` field could be dragged taller through the browser's native textarea resize handle. Growing it past the viewport makes the dialog overlay scrollable, and the scrollbar that appears re-centers the dialog, shifting the whole layout slightly to the left.

`KsPassword` renders its masked value in an `autosize` textarea, so the field already grows with its content; the manual resize handle adds nothing for a secret field. This forces `resize: none` on the `KsPassword` textarea, which removes the handle for every consumer (`API token`, secrets, password forms).

## Evidence

Before (the token field dragged taller, dialog outgrowing the viewport):

![before](https://raw.githubusercontent.com/MilosPaunovic/kestra/ed474bd87c4fb422b8d0c2a03c4f67bc00cad75a/10282/before.png)

After (the same drag leaves the field untouched, no handle):

![after](https://raw.githubusercontent.com/MilosPaunovic/kestra/ed474bd87c4fb422b8d0c2a03c4f67bc00cad75a/10282/after.png)
