### PR TITLE
fix(executions): metrics duration formatting, concurrency panel padding

### DIFF
--- a/ui/src/components/executions/MetricsTable.vue
+++ b/ui/src/components/executions/MetricsTable.vue
@@ -40,7 +40,7 @@
             <KsTableColumn v-else-if="col === 'value'" prop="value" sortable :label="$t('value')">
                 <template #default="scope">
                     <span v-if="scope.row.type === 'timer'">
-                        {{ humanizeDuration((scope.row.value / 1000).toString()) }}
+                        {{ humanizeDuration(scope.row.value / 1000) }}
                     </span>
                     <span v-else>
                         {{ humanizeNumber(scope.row.value) }}

--- a/ui/src/components/flows/FlowConcurrency.vue
+++ b/ui/src/components/flows/FlowConcurrency.vue
@@ -11,7 +11,7 @@
         {{ $t('flowConcurrency.loadError') }}
     </KsAlert>
     <div v-else-if="concurrencyLimit && flowStore.flow?.concurrency" data-test="concurrency-limit">
-        <KsCard class="mb-3">
+        <KsCard class="concurrency-summary mb-3">
             <div class="row mb-3">
                 <span class="col d-flex align-items-center">
                     <h5 class="m-3">RUNNING</h5> {{ concurrencyLimit.running }}/{{ flowStore.flow?.concurrency?.limit }} {{ $t('active-slots') }}
@@ -24,15 +24,13 @@
                 <KsProgress :stroke-width="16" color="#5BB8FF" :percentage="progress" :showText="false" />
             </div>
         </KsCard>
-        <KsCard>
-            <Executions
-                :restoreUrl="false"
-                :topbar="false"
-                :namespace="flowStore.flow?.namespace"
-                :flowId="flowStore.flow?.id"
-                filter
-            />
-        </KsCard>
+        <Executions
+            :restoreUrl="false"
+            :topbar="false"
+            :namespace="flowStore.flow?.namespace"
+            :flowId="flowStore.flow?.id"
+            filter
+        />
     </div>
     <!-- A limit record still counting slots for a flow that no longer declares a concurrency
          block: it cannot be rendered as a ratio, but we should display it anyway. -->
@@ -135,6 +133,10 @@
 
     :deep(.kel-card) {
         background-color: var(--ks-bg-surface);
+    }
+
+    .concurrency-summary {
+        margin-inline: var(--ks-spacing-6);
     }
 
     .text-center {

--- a/ui/src/utils/filters.ts
+++ b/ui/src/utils/filters.ts
@@ -3,7 +3,7 @@ import {storageKeys} from "../utils/constants"
 import moment from "moment-timezone"
 import {durationUtils} from "@kestra-io/design-system"
 
-export function humanizeDuration (value:string, options?:any) {
+export function humanizeDuration (value:number | string, options?:any) {
     return durationUtils.humanDuration(value, options)
 }
 export function humanizeNumber (value:string) {


### PR DESCRIPTION
closes https://github.com/kestra-io/kestra-ee/issues/10300
closes https://github.com/kestra-io/kestra-ee/issues/10302

This pull request contains UI improvements and a small bug fix related to type handling in the metrics and flow concurrency components. The most important changes are summarized below:

**Bug Fixes and Type Handling:**

* Updated the `humanizeDuration` function in `filters.ts` to accept both `number` and `string` types, and updated its usage in `MetricsTable.vue` to pass a number instead of converting to a string. This ensures correct duration formatting and prevents potential type errors. [[1]](diffhunk://#diff-f5530fbac4b87c4489a6e5e299580080adc763c8b71466729e188e874ec3f222L6-R6) [[2]](diffhunk://#diff-cfc1f95a5799ad03f225ffe60223d813f491ad5b7f528cf056ea8a34ed0a7c8aL43-R43)

**UI and Layout Improvements:**

* Added a `.concurrency-summary` class to the main concurrency card in `FlowConcurrency.vue` for improved spacing and consistent layout, and applied a margin using CSS. [[1]](diffhunk://#diff-2ce9b161d476b84295e17a3bfbf2392c7bdeb2d22fe5282dbcae988d4987ce61L14-R14) [[2]](diffhunk://#diff-2ce9b161d476b84295e17a3bfbf2392c7bdeb2d22fe5282dbcae988d4987ce61R138-R141)
* Removed an unnecessary `KsCard` wrapper around the `Executions` component in `FlowConcurrency.vue` to simplify the layout.