### PR TITLE
fix(system): report plugin metrics hourly instead of daily

### DIFF
--- a/core/src/main/java/io/kestra/core/reporter/reports/PluginMetricReport.java
+++ b/core/src/main/java/io/kestra/core/reporter/reports/PluginMetricReport.java
@@ -30,7 +30,7 @@ public class PluginMetricReport extends AbstractReportable<PluginMetricReport.Pl
     @Inject
     public PluginMetricReport(PluginRegistry pluginRegistry,
         MetricRegistry metricRegistry) {
-        super(Types.PLUGIN_METRICS, Schedules.daily(), false);
+        super(Types.PLUGIN_METRICS, Schedules.hourly(), false);
         this.metricRegistry = metricRegistry;
         this.pluginRegistry = pluginRegistry;
 


### PR DESCRIPTION
Closes https://github.com/kestra-io/kestra/issues/18752.

Supersedes #18755 (closed before an amended commit was force-pushed; GitHub refuses to reopen a PR after a post-close force push).

### ✨ Description

**Problem** — `PLUGIN_METRICS` is on `Schedules.daily()` since the reporting refactor (3929bf6172, shipped in every release since v1.0.0). `Schedules.every()` starts with `lastRun = Instant.EPOCH`, so the first tick always fires ~5 minutes after boot — before any task has run, while the in-memory Micrometer timers are still empty — and sends `pluginMetrics: []`. The next report only comes 24h later, and the timers do not survive a restart. Any process with an uptime under 24h that ran tasks therefore only ever ships the empty boot sample.

This mechanism is identical on 1.3 and 2.0; the 7% → 35% jump comes from uptime distribution, not from a code difference: 1.3 instances are mostly stable production deployments living past the 24h mark, while 2.0 instances are RCs restarted at every upgrade plus ephemeral autoscaled workers that rarely survive 24h.

**Fix** — report `PLUGIN_METRICS` with `Schedules.hourly()`, matching `FeatureUsageReport` and the pre-1.0 `CollectorService` cadence (`fixed-delay: 1h`). The boot-time `[]` sample is still sent, but every following hour ships the cumulative-from-boot timers, so any session with uptime over ~1h that ran tasks reports them.

**Evidence** — `./gradlew :core:test --tests PluginMetricReportTest --tests SchedulesTest` passes; full test suite was green on #18755 (8309 passed, 0 failed). On the collector side, timers are cumulative per process: keeping the latest event per `sessionUuid` (rather than summing) stays correct.

### 🛠️ Backend Checklist

- [x] Code compiles and tests pass for the touched modules (`./gradlew :core:test`)
- [x] New behavior is covered by unit or integration tests — no new test: a test asserting the constructor's schedule argument would only restate the one-line change; `SchedulesTest` already covers the hourly cadence itself.

### 📝 Additional Notes

- Deliberately **not** suppressing the empty boot report: idle instances sending `[]` is expected per the issue, and `SYSTEM_INFORMATION`/`PLUGIN_USAGE` rely on the first-tick-fires behavior of `Schedules.every()`.
- Sessions shorter than ~1h that ran tasks will still only send the empty boot sample; flushing a final report on graceful shutdown would cover those, left out of scope here.

### 🤖 AI Authors

Why did the cat's telemetry only report once a day? Because it spent the other 23 hours in a *purr-sistent* idle state. 🐱