### PR TITLE
fix(executions): array input item rows in the execute flow modal

### DIFF
--- a/ui/src/components/inputs/InputsForm.vue
+++ b/ui/src/components/inputs/InputsForm.vue
@@ -201,16 +201,32 @@
 
                     <div v-else class="edit_input">
                         <div>
-                            <div v-for="(_item, index) in editableItems[input.id]" :key="index" class="list-row">
-                                <KsInput
-                                    v-model="editableItems[input.id][index]"
-                                    class="array-cell"
-                                />
-                                <KsButton @click="removeArrayItem(input, index)" :icon="DeleteOutline" class="delete-input" :tooltip="$t('remove this item')" />
-                                <div class="d-flex flex-column controls-input">
-                                    <ChevronUp @click="moveArrayItem(input, 'up', index)" />
-                                    <ChevronDown @click="moveArrayItem(input, 'down', index)" />
+                            <div
+                                v-for="(_item, index) in editableItems[input.id]"
+                                :key="index"
+                                :data-testid="`array-item-${input.id}-${index}`"
+                                class="list-row"
+                            >
+                                <div
+                                    :data-testid="`array-item-field-${input.id}-${index}`"
+                                    class="array-cell-wrapper"
+                                >
+                                    <KsInput
+                                        v-model="editableItems[input.id][index]"
+                                        class="array-cell"
+                                    />
+                                    <div class="controls-input">
+                                        <ChevronUp @click="moveArrayItem(input, 'up', index)" />
+                                        <ChevronDown @click="moveArrayItem(input, 'down', index)" />
+                                    </div>
                                 </div>
+                                <KsIconButton
+                                    :tooltip="$t('remove this item')"
+                                    :data-testid="`array-item-remove-${input.id}-${index}`"
+                                    @click="removeArrayItem(input, index)"
+                                >
+                                    <DeleteOutline />
+                                </KsIconButton>
                             </div>
                         </div>
                         <KsButton
@@ -1165,14 +1181,23 @@
 
 .edit_input {
     .list-row {
-        position: relative;
-        margin-bottom: 8px;
+        display: flex;
+        align-items: center;
+        gap: var(--ks-spacing-2);
+        margin-bottom: var(--ks-spacing-2);
+
+        .array-cell-wrapper {
+            position: relative;
+            flex: 1;
+            min-width: 0;
+        }
 
         .array-cell {
             :deep(.kel-input__wrapper) {
                 box-shadow: none;
                 border: 1px solid var(--ks-border-default);
                 border-radius: 5px;
+                padding-right: var(--ks-spacing-5);
             }
 
             :deep(.kel-input__inner) {
@@ -1185,30 +1210,17 @@
             }
         }
 
-        .delete-input {
-            position: absolute;
-            right: 28px;
-            top: 50%;
-            transform: translateY(-50%);
-            padding: 4px;
-            border: none;
-            color: var(--ks-text-secondary);
-            background: transparent;
-
-            &:hover {
-                color: var(--ks-status-error);
-            }
-        }
-
         .controls-input {
             position: absolute;
+            display: flex;
+            flex-direction: column;
             right: 2px;
             top: 50%;
             transform: translateY(-50%);
-            padding: 3px;
+            padding: 0 var(--ks-spacing-1);
             border-left: 1px solid var(--ks-border-default);
             color: var(--ks-text-secondary);
-            background: transparent;
+            cursor: pointer;
         }
     }
 


### PR DESCRIPTION
closes https://github.com/kestra-io/kestra-ee/issues/10142

<img width="1002" height="840" alt="Capture d’écran 2026-08-28 à 10 12 17" src="https://github.com/user-attachments/assets/bfc2f883-174d-4a5a-a902-0640abe5df4f" />

This pull request refactors the UI for editing array-type inputs in the `InputsForm.vue` component. The main focus is on improving accessibility, testability, and visual consistency by restructuring the markup and updating the styling for array item controls.

**Component markup improvements:**

* Refactored the array item markup in `InputsForm.vue` to wrap each input and its controls in a dedicated `.array-cell-wrapper`, added `data-testid` attributes for better testability, and replaced the old delete button with a `KsIconButton` for consistency and accessibility.

**Styling and layout enhancements:**

* Updated the `.list-row` and related classes in the `<style>` section to use Flexbox for better alignment, spacing, and responsive layout of array items and controls.
* Removed obsolete `.delete-input` styles and improved `.controls-input` to use Flexbox, update padding, and ensure proper alignment and usability of the up/down controls.