### PR TITLE
fix(core): inspect getDeadline() in DAILY_TIME_WINDOW branch of TimeWindowValidator

### DIFF
--- a/core/src/main/java/io/kestra/core/validations/validator/TimeWindowValidator.java
+++ b/core/src/main/java/io/kestra/core/validations/validator/TimeWindowValidator.java
@@ -59,7 +59,7 @@ public class TimeWindowValidator implements ConstraintValidator<TimeWindowValida
                     if (value.getWindowAdvance() != null) {
                         context.buildConstraintViolationWithTemplate("Time window of type `DAILY_TIME_WINDOW` cannot have a window advance.").addConstraintViolation();
                     }
-                    if (value.getStartTime() != null) {
+                    if (value.getDeadline() != null) {
                         context.buildConstraintViolationWithTemplate("Time window of type `DAILY_TIME_WINDOW` cannot have a deadline.").addConstraintViolation();
                     }
                     yield false;

--- a/core/src/test/java/io/kestra/core/validations/TimeWindowValidationTest.java
+++ b/core/src/test/java/io/kestra/core/validations/TimeWindowValidationTest.java
@@ -77,13 +77,40 @@ class TimeWindowValidationTest {
 
     @Test
     void shouldNotValidateDailyTimeWindowWhenInvalidParam() {
-        var sla = TimeWindow.builder().type(TimeWindow.Type.DAILY_TIME_WINDOW).startTime(LocalTime.now()).endTime(LocalTime.now()).window(Duration.ofHours(1)).build();
+        var sla = TimeWindow.builder()
+            .type(TimeWindow.Type.DAILY_TIME_WINDOW)
+            .startTime(LocalTime.now())
+            .endTime(LocalTime.now())
+            .window(Duration.ofHours(1))
+            .deadline(LocalTime.now())
+            .build();
 
         Optional<ConstraintViolationException> valid = modelValidator.isValid(sla);
         assertThat(valid.isEmpty()).isFalse();
         assertThat(valid.get().getConstraintViolations()).hasSize(2);
         assertThat(valid.get().getMessage()).contains(": Time window of type `DAILY_TIME_WINDOW` cannot have a window.\n");
         assertThat(valid.get().getMessage()).contains(": Time window of type `DAILY_TIME_WINDOW` cannot have a deadline.\n");
+    }
+
+    @Test
+    void shouldNotValidateDailyTimeWindowWhenStartTimeLooksLikeADeadline() {
+        // Regression guard for kestra-io/kestra#18763: the DAILY_TIME_WINDOW branch used
+        // to inspect getStartTime() while reporting "cannot have a deadline", so a valid
+        // startTime+endTime+window combination (the startTime is required for this type!)
+        // produced a spurious "cannot have a deadline" violation alongside the real
+        // "cannot have a window" one.
+        var sla = TimeWindow.builder()
+            .type(TimeWindow.Type.DAILY_TIME_WINDOW)
+            .startTime(LocalTime.now())
+            .endTime(LocalTime.now())
+            .window(Duration.ofHours(1))
+            .build();
+
+        Optional<ConstraintViolationException> valid = modelValidator.isValid(sla);
+        assertThat(valid.isEmpty()).isFalse();
+        assertThat(valid.get().getConstraintViolations()).hasSize(1);
+        assertThat(valid.get().getMessage()).contains(": Time window of type `DAILY_TIME_WINDOW` cannot have a window.\n");
+        assertThat(valid.get().getMessage()).doesNotContain("cannot have a deadline");
     }
 
     @Test


### PR DESCRIPTION
Closes https://github.com/kestra-io/kestra/issues/18763

### What changed

The `DAILY_TIME_WINDOW` case in `TimeWindowValidator` was inspecting the wrong field. The check meant to flag an invalid `deadline` was looking at `startTime`, which is itself required for this type. Two failure modes flowed from that:

- When a user set a `deadline` with no `startTime`, the validator would call `disableDefaultConstraintViolation()` and then never add a replacement message, producing an `HV000033` 500 in the UI/API.
- When a user set a legitimate `startTime` + `endTime` + an unrelated invalid field like `window`, the same wrong getter fired and the user got a false "cannot have a deadline" message alongside the real one.

This swaps the check to `getDeadline()` and updates the existing test that was passing only because of the bug. A new regression-guard test covers the exact scenario the reporter hit (valid `startTime` + `endTime` + invalid `window`, expecting exactly one violation, not two).

### Why now

Both repro scenarios are reachable through the regular flow authoring path, so any user editing a trigger that uses `DAILY_TIME_WINDOW` either gets a server error or a confusing false-positive. The fix is one line; the test coverage is what makes the change safe to merge.

### Notes

- I did not add an explicit test for scenario 1 ("deadline alone, no startTime"). That path was already covered indirectly by the existing `shouldNotValidateDailyTimeWindowWhenInvalidParam` once I added a `deadline` to its inputs — the message it asserts ("cannot have a deadline") can only be produced by the `getDeadline() != null` branch after the fix.
- No changes outside the validator and its test. Spotless left those files alone.

### Backend checklist

- [x] `./gradlew :core:test --tests io.kestra.core.validations.TimeWindowValidationTest` passes (14/14)
- [x] `./gradlew :core:spotlessApply` ran; only the two files in this PR were reformatted, the rest were reverted

🐱 Why did the cat sit on the keyboard? Because it wanted to check the getter.