### PR TITLE
test(tests): bound a single test method so a hung test fails by itself

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -239,6 +239,10 @@ subprojects {subProj ->
             t.timeout = java.time.Duration.ofMinutes(
                 (System.getenv('GRADLE_TEST_TIMEOUT_MIN') ?: '30').toInteger()
             )
+            // Bounds a single test method so it fails by itself, rather than a hung test consuming
+            // the module's whole Gradle-level timeout above and discarding every test's JUnit XML.
+            t.systemProperty 'junit.jupiter.execution.timeout.default',
+                System.getenv('JUNIT_TEST_TIMEOUT_MIN') ? "${System.getenv('JUNIT_TEST_TIMEOUT_MIN')} m" : '5 m'
             t.finalizedBy jacocoTestReport
             t.doFirst {
                 logger.lifecycle("[TASK START] ${t.path}")


### PR DESCRIPTION
## Summary
- A `:core:test` run hung for 19 minutes and was killed by Gradle's 30-minute task timeout, which discards the whole module's JUnit XML report along with it. See job https://github.com/kestra-io/kestra/actions/runs/33152593355/job/98793121966 (Pre Release, v2.0.0-rc12, attempt 2).
- Adds a JUnit Platform default per-test timeout (`junit.jupiter.execution.timeout.default`, 5 minutes, overridable via `JUNIT_TEST_TIMEOUT_MIN`) to `commonTestConfig` in `build.gradle`, so the next hung test fails as a named JUnit `TimeoutException` instead of silently consuming the whole module's build-level timeout. 5 minutes was picked with ~10x headroom over the slowest observed test in that run (`BaseArchitectureTest.no_java_util_logging`, 32s).

## Test plan
- [x] Manually verified the mechanism: temporarily set the default to `2 s`, added a scratch test with `Thread.sleep(60_000)`, ran `./gradlew :core:test --tests` — the scratch test failed in ~2s with `TimeoutException: hangs() timed out after 2 seconds` and the module still produced a normal report. Scratch test was then removed and the value restored to 5m.
- [x] `./gradlew :scheduler:test` (118 tests) and `./gradlew :jdbc-h2:test --tests H2RunnerTest` (100 tests) still pass — this change is applied via the shared `commonTestConfig`, used by every subproject's `test`/`unitTest`/`integrationTest`/`flakyTest` tasks.