### PR TITLE
fix(scheduler): stop a scheduled fire from retrying DefaultScheduler's whole bean graph

### DIFF
--- a/scheduler/src/main/java/io/kestra/scheduler/TriggerSchedulerMonitor.java
+++ b/scheduler/src/main/java/io/kestra/scheduler/TriggerSchedulerMonitor.java
@@ -19,6 +19,7 @@ import io.kestra.core.scheduler.model.TriggerType;
 import io.kestra.core.scheduler.store.TriggerStateStore;
 import io.kestra.core.utils.Logs;
 
+import io.micronaut.context.BeanProvider;
 import io.micronaut.context.annotation.Requires;
 import io.micronaut.core.util.CollectionUtils;
 import io.micronaut.scheduling.annotation.Scheduled;
@@ -35,28 +36,39 @@ public class TriggerSchedulerMonitor implements Runnable {
     private final MetricRegistry metricRegistry;
     private final ExecutionRepositoryInterface executionRepository;
     private final TriggerStateStore triggerStateStore;
-    private final DefaultScheduler defaultScheduler;
+    private final BeanProvider<DefaultScheduler> defaultSchedulerProvider;
 
     @Inject
     public TriggerSchedulerMonitor(MetricRegistry metricRegistry,
         ExecutionRepositoryInterface executionRepository,
         @Named("cached") TriggerStateStore triggerStateStore,
-        DefaultScheduler defaultScheduler) {
+        BeanProvider<DefaultScheduler> defaultSchedulerProvider) {
         this.metricRegistry = metricRegistry;
         this.executionRepository = executionRepository;
         this.triggerStateStore = triggerStateStore;
-        this.defaultScheduler = defaultScheduler;
+        this.defaultSchedulerProvider = defaultSchedulerProvider;
     }
 
     @Scheduled(fixedDelay = "PT10S", initialDelay = "PT30S")
     @Override
     public void run() {
         try {
+            // Resolved lazily so that a DefaultScheduler construction failure (its VNodesAssigner
+            // subscribes to the event queue from @PostConstruct, which can fail before a JDBC
+            // connection is available) is caught below instead of escalating to Micronaut's
+            // scheduled-task executor, which would otherwise retry constructing this bean's entire
+            // dependency graph on every tick.
+            DefaultScheduler scheduler = defaultSchedulerProvider.get();
+            if (!scheduler.getState().isRunning()) {
+                LOG.debug("Scheduler is not running (state={}). Skip trigger monitoring.", scheduler.getState());
+                return;
+            }
+
             // Retrieve all locked triggers from all corresponding virtual nodes.
             // Realtime triggers stay locked for their entire processing lifetime and are not bound to a
             // single execution lifecycle, so they would otherwise be reported as blocked indefinitely.
             ZonedDateTime now = SchedulerClock.now();
-            List<TriggerState> triggers = this.triggerStateStore.findTriggersEligibleForScheduling(now, defaultScheduler.currentVNodesAssignment(), true)
+            List<TriggerState> triggers = this.triggerStateStore.findTriggersEligibleForScheduling(now, scheduler.currentVNodesAssignment(), true)
                 .stream()
                 .filter(state -> !TriggerType.REALTIME.equals(state.getType()))
                 .toList();

--- a/scheduler/src/test/java/io/kestra/scheduler/TriggerSchedulerMonitorTest.java
+++ b/scheduler/src/test/java/io/kestra/scheduler/TriggerSchedulerMonitorTest.java
@@ -12,10 +12,12 @@ import io.kestra.core.models.triggers.TriggerId;
 import io.kestra.core.repositories.ExecutionRepositoryInterface;
 import io.kestra.core.scheduler.model.TriggerState;
 import io.kestra.core.scheduler.model.TriggerType;
+import io.kestra.core.server.Service.ServiceState;
 import io.kestra.scheduler.utils.InMemoryTriggerStateStore;
 
 import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.noop.NoopTimer;
+import io.micronaut.context.BeanProvider;
 import reactor.core.publisher.Flux;
 
 import static org.mockito.ArgumentMatchers.any;
@@ -34,8 +36,10 @@ class TriggerSchedulerMonitorTest {
     private ExecutionRepositoryInterface executionRepository;
     private InMemoryTriggerStateStore triggerStateStore;
     private DefaultScheduler defaultScheduler;
+    private BeanProvider<DefaultScheduler> schedulerProvider;
     private TriggerSchedulerMonitor monitor;
 
+    @SuppressWarnings("unchecked")
     @BeforeEach
     void setUp() {
         metricRegistry = mock(MetricRegistry.class);
@@ -49,8 +53,12 @@ class TriggerSchedulerMonitorTest {
 
         defaultScheduler = mock(DefaultScheduler.class);
         when(defaultScheduler.currentVNodesAssignment()).thenReturn(Set.of(TEST_VNODE));
+        when(defaultScheduler.getState()).thenReturn(ServiceState.RUNNING);
 
-        monitor = new TriggerSchedulerMonitor(metricRegistry, executionRepository, triggerStateStore, defaultScheduler);
+        schedulerProvider = mock(BeanProvider.class);
+        when(schedulerProvider.get()).thenReturn(defaultScheduler);
+
+        monitor = new TriggerSchedulerMonitor(metricRegistry, executionRepository, triggerStateStore, schedulerProvider);
     }
 
     @Test
@@ -78,6 +86,32 @@ class TriggerSchedulerMonitorTest {
 
         // Then findAllByTrigger is invoked once per non-realtime trigger.
         verify(executionRepository, times(2)).findAllByTrigger(any());
+    }
+
+    @Test
+    void shouldNotPropagateWhenSchedulerFailsToConstruct() {
+        // Given a scheduler that fails to construct (e.g. a dependency's @PostConstruct throwing).
+        when(schedulerProvider.get()).thenThrow(new RuntimeException("boom"));
+        triggerStateStore.save(lockedTriggerOf("schedule-trigger", TriggerType.SCHEDULE));
+
+        // When the monitor runs, the failure is caught locally instead of propagating to the caller.
+        monitor.run();
+
+        // Then no trigger is inspected.
+        verify(executionRepository, never()).findAllByTrigger(any());
+    }
+
+    @Test
+    void shouldSkipMonitoringWhenSchedulerIsNotRunning() {
+        // Given a constructed scheduler that is not currently running.
+        when(defaultScheduler.getState()).thenReturn(ServiceState.TERMINATING);
+        triggerStateStore.save(lockedTriggerOf("schedule-trigger", TriggerType.SCHEDULE));
+
+        // When the monitor runs
+        monitor.run();
+
+        // Then no trigger is inspected.
+        verify(executionRepository, never()).findAllByTrigger(any());
     }
 
     private static TriggerState lockedTriggerOf(String triggerId, TriggerType type) {


### PR DESCRIPTION
## Summary
- In the same CI incident as #18781, a torn-down test context kept firing `TriggerSchedulerMonitor` every 10 seconds for 19 minutes because `DefaultScheduler` failed to construct (`NoConnectionException` from `DefaultVNodesAssigner`'s `@PostConstruct` queue subscription, itself triggered by an earlier gRPC port-bind failure in the same test). See job https://github.com/kestra-io/kestra/actions/runs/33152593355/job/98793121966.
- Because `DefaultScheduler` was a constructor-injected dependency, that construction failure escalated to Micronaut's scheduled-task executor (`DefaultTaskExceptionHandler`), which retried constructing `TriggerSchedulerMonitor`'s entire dependency graph on every tick, producing a full stack trace every 10 seconds for 19 minutes.
- `TriggerSchedulerMonitor` now resolves `DefaultScheduler` lazily via `BeanProvider<DefaultScheduler>`, so `TriggerSchedulerMonitor` itself always constructs successfully. Resolution moved inside `run()`'s existing try/catch, so a `DefaultScheduler` construction failure is now caught and logged locally instead of escalating to the framework's scheduled-task retry machinery. Also skips monitoring when the scheduler isn't running (`getState().isRunning()`), matching the guard `DefaultScheduler` already uses internally.
- Out of scope, filed separately for follow-up: the underlying gRPC random-port bind flake, and the fact that the test's uncaught-exception handler silently tears down the context without failing the waiting JUnit thread (that's what let the hang run the full 30 minutes rather than failing fast).

## Test plan
- [x] Added `shouldNotPropagateWhenSchedulerFailsToConstruct` and `shouldSkipMonitoringWhenSchedulerIsNotRunning` to `TriggerSchedulerMonitorTest`, covering the new guard behavior — each fails if its corresponding branch is removed.
- [x] `./gradlew :scheduler:test` — 118 tests pass.
- [x] `./gradlew :jdbc-h2:test --tests H2RunnerTest` — 100 tests pass (mandatory for scheduler/executor changes per AGENTS.md).