### PR TITLE
fix(core): strict boolean KV validation, If truthiness docs, and allowFailure on execution-updating tasks

### DIFF
--- a/core/src/main/java/io/kestra/plugin/core/flow/If.java
+++ b/core/src/main/java/io/kestra/plugin/core/flow/If.java
@@ -42,7 +42,7 @@ import lombok.experimental.SuperBuilder;
 @Schema(
     title = "Branch tasks based on a rendered condition.",
     description = """
-        Renders `condition` and coerces it to boolean (empty string/0/null is false, everything else true). Executes `then` when true, `else` when false, with optional `errors`/`finally` blocks.
+        Renders `condition` and coerces it to boolean (the strings `false`, `0`, `-0`, an empty string and null are false; every other value is true). Executes `then` when true, `else` when false, with optional `errors`/`finally` blocks.
 
         Frequently used after previous task results to drive control flow."""
 )
@@ -78,7 +78,7 @@ import lombok.experimental.SuperBuilder;
 public class If extends Task implements FlowableTask<If.Output> {
     @Schema(
         title = "The `If` condition which can be any expression that evaluates to a boolean value.",
-        description = "Boolean coercion allows 0, -0, null and '' to evaluate to false, all other values will evaluate to true."
+        description = "Boolean coercion evaluates the strings 'false', '0', '-0', an empty string and null to false; all other values evaluate to true."
     )
     // Note: we can't use Property<String> here because of the cache of the property evaluation which causes issue when using If in a ForEach with concurrencyLimit > 1!
     // See https://github.com/kestra-io/kestra/issues/8697

--- a/core/src/main/java/io/kestra/plugin/core/kv/Set.java
+++ b/core/src/main/java/io/kestra/plugin/core/kv/Set.java
@@ -119,7 +119,7 @@ public class Set extends Task implements RunnableTask<VoidOutput> {
             if (renderedValue instanceof String renderedValueStr) {
                 renderedValue = switch (renderedKvType) {
                     case NUMBER -> JacksonMapper.ofJson().readValue(renderedValueStr, Number.class);
-                    case BOOLEAN -> TypeConverter.toBoolean(renderedValueStr);
+                    case BOOLEAN -> parseBoolean(renderedValueStr);
                     case DATETIME -> TypeConverter.toInstant(renderedValueStr);
                     case DATE -> parseDate(renderedValueStr);
                     // We parse duration to make sure it's valid but we store it as a raw duration string
@@ -161,5 +161,20 @@ public class Set extends Task implements RunnableTask<VoidOutput> {
         } catch (DateTimeParseException e) {
             return LocalDate.ofInstant(Instant.parse(value), ZoneOffset.UTC);
         }
+    }
+
+    /**
+     * Parses a {@code BOOLEAN}-typed KV value, failing the task on anything but {@code true}/{@code false}
+     * (case-insensitive) so a typo is not silently coerced to {@code false}, matching how the other typed values reject
+     * invalid input.
+     */
+    private static Boolean parseBoolean(String value) {
+        if ("true".equalsIgnoreCase(value)) {
+            return Boolean.TRUE;
+        }
+        if ("false".equalsIgnoreCase(value)) {
+            return Boolean.FALSE;
+        }
+        throw new IllegalArgumentException("Cannot parse '%s' as a BOOLEAN value: expected 'true' or 'false'.".formatted(value));
     }
 }

--- a/core/src/test/java/io/kestra/plugin/core/execution/SetVariablesTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/execution/SetVariablesTest.java
@@ -41,6 +41,15 @@ class SetVariablesTest {
         assertThat(execution.getTaskRunList().getFirst().getState().getCurrent()).isEqualTo(State.Type.FAILED);
     }
 
+    @ExecuteFlow("flows/valids/set-variables-allow-failure.yaml")
+    @Test
+    void shouldWarnAndContinueWhenAllowFailureIsSet(Execution execution) {
+        assertThat(execution.getState().getCurrent()).isEqualTo(State.Type.WARNING);
+        assertThat(execution.getTaskRunList()).hasSize(2);
+        assertThat(execution.findTaskRunsByTaskId("set-vars").getFirst().getState().getCurrent()).isEqualTo(State.Type.WARNING);
+        assertThat(execution.findTaskRunsByTaskId("after").getFirst().getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
+    }
+
     @Test
     void shouldRenderVariablesForEachExecution() throws Exception {
         // the executor calls update() on the task instance of its cached flow, so the same task

--- a/core/src/test/java/io/kestra/plugin/core/execution/SetVariablesTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/execution/SetVariablesTest.java
@@ -50,6 +50,15 @@ class SetVariablesTest {
         assertThat(execution.findTaskRunsByTaskId("after").getFirst().getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
     }
 
+    @ExecuteFlow("flows/valids/set-variables-allow-warning.yaml")
+    @Test
+    void shouldSucceedWhenAllowFailureAndAllowWarningAreSet(Execution execution) {
+        assertThat(execution.getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
+        assertThat(execution.getTaskRunList()).hasSize(2);
+        assertThat(execution.findTaskRunsByTaskId("set-vars").getFirst().getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
+        assertThat(execution.findTaskRunsByTaskId("after").getFirst().getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
+    }
+
     @Test
     void shouldRenderVariablesForEachExecution() throws Exception {
         // the executor calls update() on the task instance of its cached flow, so the same task

--- a/core/src/test/java/io/kestra/plugin/core/kv/SetTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/kv/SetTest.java
@@ -248,6 +248,26 @@ class SetTest {
         assertThat(kv.getValue(key).orElseThrow().value()).isEqualTo("200.1");
     }
 
+    @Test
+    void booleanTypeAcceptsTrueAndFalseCaseInsensitive() throws Exception {
+        String key = "bool_key";
+
+        KVStore kv = createAndPerformSetTask(key, "FALSE", KVType.BOOLEAN);
+        assertThat((Boolean) kv.getValue(key).orElseThrow().value()).isFalse();
+
+        kv = createAndPerformSetTask(key, "True", KVType.BOOLEAN);
+        assertThat((Boolean) kv.getValue(key).orElseThrow().value()).isTrue();
+    }
+
+    @Test
+    void booleanTypeRejectsInvalidValue() {
+        IllegalArgumentException exception = Assertions.assertThrows(
+            IllegalArgumentException.class,
+            () -> createAndPerformSetTask("invalid_bool", "yes", KVType.BOOLEAN)
+        );
+        assertThat(exception.getMessage()).contains("Cannot parse 'yes' as a BOOLEAN value");
+    }
+
     private KVStore createAndPerformSetTask(String key, String value, KVType type) throws Exception {
         Set set = Set.builder()
             .id(Set.class.getSimpleName())

--- a/core/src/test/resources/flows/valids/set-variables-allow-failure.yaml
+++ b/core/src/test/resources/flows/valids/set-variables-allow-failure.yaml
@@ -1,0 +1,17 @@
+id: set-variables-allow-failure
+namespace: io.kestra.tests
+
+variables:
+  name: World
+
+tasks:
+  - id: set-vars
+    type: io.kestra.plugin.core.execution.SetVariables
+    variables:
+      message: Hello
+      name: Loïc
+    overwrite: false
+    allowFailure: true
+  - id: after
+    type: io.kestra.plugin.core.log.Log
+    message: "allowFailure honored, flow continued"

--- a/core/src/test/resources/flows/valids/set-variables-allow-warning.yaml
+++ b/core/src/test/resources/flows/valids/set-variables-allow-warning.yaml
@@ -1,0 +1,18 @@
+id: set-variables-allow-warning
+namespace: io.kestra.tests
+
+variables:
+  name: World
+
+tasks:
+  - id: set-vars
+    type: io.kestra.plugin.core.execution.SetVariables
+    variables:
+      message: Hello
+      name: Loïc
+    overwrite: false
+    allowFailure: true
+    allowWarning: true
+  - id: after
+    type: io.kestra.plugin.core.log.Log
+    message: "allowWarning honored, flow continued"

--- a/executor/src/main/java/io/kestra/executor/ExecutorService.java
+++ b/executor/src/main/java/io/kestra/executor/ExecutorService.java
@@ -1517,29 +1517,17 @@ public class ExecutorService {
 
                     // State.Type.fail resolves the failure against allowFailure/allowWarning: FAILED, WARNING or SUCCESS.
                     State.Type failState = State.Type.fail(task);
+                    // Fail the execution only when the task itself ends FAILED; WARNING/SUCCESS let it continue.
                     if (failState == State.Type.FAILED) {
-                        // No allowFailure: the task fails and the execution fails with it.
-                        workerTaskResults.add(
-                            WorkerTaskResult.builder()
-                                .taskRun(workerTask.getTaskRun().fail())
-                                .build()
-                        );
                         executor.withException(e, "handleExecutionUpdatingTasks");
-                    } else if (task.isAllowWarning()) {
-                        // allowFailure + allowWarning: promote the failed task to SUCCESS and let the execution continue.
-                        workerTaskResults.add(
-                            WorkerTaskResult.builder()
-                                .taskRun(workerTask.getTaskRun().fail().withState(State.Type.SUCCESS))
-                                .build()
-                        );
-                    } else {
-                        // allowFailure: downgrade the failed task to WARNING and let the execution continue.
-                        workerTaskResults.add(
-                            WorkerTaskResult.builder()
-                                .taskRun(workerTask.getTaskRun().fail().withState(State.Type.WARNING))
-                                .build()
-                        );
                     }
+
+                    TaskRunAttempt failedAttempt = TaskRunAttempt.builder().state(new State().withState(failState)).build();
+                    workerTaskResults.add(
+                        WorkerTaskResult.builder()
+                            .taskRun(workerTask.getTaskRun().withAttempts(List.of(failedAttempt)).withState(failState))
+                            .build()
+                    );
                 }
                 return true;
             });

--- a/executor/src/main/java/io/kestra/executor/ExecutorService.java
+++ b/executor/src/main/java/io/kestra/executor/ExecutorService.java
@@ -1511,12 +1511,25 @@ public class ExecutorService {
                             .build()
                     );
                 } catch (Exception e) {
-                    workerTaskResults.add(
-                        WorkerTaskResult.builder()
-                            .taskRun(workerTask.getTaskRun().fail())
-                            .build()
-                    );
-                    executor.withException(e, "handleExecutionUpdatingTasks");
+                    Task task = workerTask.getTask();
+                    // Log against the task run so the failure carries its taskId/taskRunId, not only the execution.
+                    executorTask.runContext().logger().error("Failed to process task: {}", e.getMessage(), e);
+
+                    if (task.isAllowFailure()) {
+                        // Honor allowFailure: end the task run WARNING (or SUCCESS with allowWarning) and let the execution continue.
+                        workerTaskResults.add(
+                            WorkerTaskResult.builder()
+                                .taskRun(workerTask.getTaskRun().fail().withState(State.Type.fail(task)))
+                                .build()
+                        );
+                    } else {
+                        workerTaskResults.add(
+                            WorkerTaskResult.builder()
+                                .taskRun(workerTask.getTaskRun().fail())
+                                .build()
+                        );
+                        executor.withException(e, "handleExecutionUpdatingTasks");
+                    }
                 }
                 return true;
             });

--- a/executor/src/main/java/io/kestra/executor/ExecutorService.java
+++ b/executor/src/main/java/io/kestra/executor/ExecutorService.java
@@ -1515,20 +1515,22 @@ public class ExecutorService {
                     // Log against the task run so the failure carries its taskId/taskRunId, not only the execution.
                     executorTask.runContext().logger().error("Failed to process task: {}", e.getMessage(), e);
 
-                    if (task.isAllowFailure()) {
-                        // Honor allowFailure: end the task run WARNING (or SUCCESS with allowWarning) and let the execution continue.
-                        workerTaskResults.add(
-                            WorkerTaskResult.builder()
-                                .taskRun(workerTask.getTaskRun().fail().withState(State.Type.fail(task)))
-                                .build()
-                        );
-                    } else {
+                    // State.Type.fail resolves the failure against allowFailure/allowWarning: FAILED, WARNING or SUCCESS.
+                    State.Type failState = State.Type.fail(task);
+                    if (failState == State.Type.FAILED) {
                         workerTaskResults.add(
                             WorkerTaskResult.builder()
                                 .taskRun(workerTask.getTaskRun().fail())
                                 .build()
                         );
                         executor.withException(e, "handleExecutionUpdatingTasks");
+                    } else {
+                        // allowFailure (WARNING) or allowFailure + allowWarning (SUCCESS): let the execution continue.
+                        workerTaskResults.add(
+                            WorkerTaskResult.builder()
+                                .taskRun(workerTask.getTaskRun().fail().withState(failState))
+                                .build()
+                        );
                     }
                 }
                 return true;

--- a/executor/src/main/java/io/kestra/executor/ExecutorService.java
+++ b/executor/src/main/java/io/kestra/executor/ExecutorService.java
@@ -1518,17 +1518,25 @@ public class ExecutorService {
                     // State.Type.fail resolves the failure against allowFailure/allowWarning: FAILED, WARNING or SUCCESS.
                     State.Type failState = State.Type.fail(task);
                     if (failState == State.Type.FAILED) {
+                        // No allowFailure: the task fails and the execution fails with it.
                         workerTaskResults.add(
                             WorkerTaskResult.builder()
                                 .taskRun(workerTask.getTaskRun().fail())
                                 .build()
                         );
                         executor.withException(e, "handleExecutionUpdatingTasks");
-                    } else {
-                        // allowFailure (WARNING) or allowFailure + allowWarning (SUCCESS): let the execution continue.
+                    } else if (task.isAllowWarning()) {
+                        // allowFailure + allowWarning: promote the failed task to SUCCESS and let the execution continue.
                         workerTaskResults.add(
                             WorkerTaskResult.builder()
-                                .taskRun(workerTask.getTaskRun().fail().withState(failState))
+                                .taskRun(workerTask.getTaskRun().fail().withState(State.Type.SUCCESS))
+                                .build()
+                        );
+                    } else {
+                        // allowFailure: downgrade the failed task to WARNING and let the execution continue.
+                        workerTaskResults.add(
+                            WorkerTaskResult.builder()
+                                .taskRun(workerTask.getTaskRun().fail().withState(State.Type.WARNING))
                                 .build()
                         );
                     }

--- a/executor/src/main/java/io/kestra/executor/ExecutorService.java
+++ b/executor/src/main/java/io/kestra/executor/ExecutorService.java
@@ -1522,7 +1522,7 @@ public class ExecutorService {
                         executor.withException(e, "handleExecutionUpdatingTasks");
                     }
 
-                    TaskRunAttempt failedAttempt = TaskRunAttempt.builder().state(new State().withState(failState)).build();
+                    TaskRunAttempt failedAttempt = TaskRunAttempt.builder().state(new State(failState)).build();
                     workerTaskResults.add(
                         WorkerTaskResult.builder()
                             .taskRun(workerTask.getTaskRun().withAttempts(List.of(failedAttempt)).withState(failState))


### PR DESCRIPTION
### What this PR does

Three core task-semantics bugs from the bug bash, each accepting or hiding something it should have surfaced:

- **kv.Set BOOLEAN accepted anything** (kestra-ee#10324) — `kvType: BOOLEAN` coerced any non-`"true"` string to `false` and still succeeded, so `"yes"`, `"1"`, `"maybe"` all silently stored `false`. Every other `kvType` (NUMBER, DATETIME, DATE, DURATION, JSON) fails the task on a bad value. BOOLEAN now accepts only `true`/`false` (case-insensitive) and fails the task on anything else, matching the others.
- **If docs contradicted behaviour** (kestra#18499) — the `If` task documented that only an empty string / `0` / `null` are false, but the code (`TruthUtils`) also treats the string `"false"` (and `"-0"`) as false. A condition rendering to `"false"` correctly runs `else`; the docs were the thing that was wrong. Behaviour is unchanged — only the two `@Schema` descriptions now state the real coercion rule.
- **allowFailure ignored by SetVariables / UnsetVariables / Labels** (kestra-ee#10360) — these three are inline *execution-updating* tasks, not worker tasks, so when they failed the executor hard-failed the whole execution and ignored `allowFailure` (unlike every runnable task). The executor now honours `allowFailure` for them — the task ends `WARNING` (or `SUCCESS` with `allowWarning`) and the flow continues — and logs the failure against the task run so it carries its `taskId`/`taskRunId` instead of only surfacing at execution level (the issue's secondary complaint).

### Evidence

- `SetTest` — `booleanTypeRejectsInvalidValue` (`"yes"` → task fails), `booleanTypeAcceptsTrueAndFalseCaseInsensitive`.
- `SetVariablesTest.shouldWarnAndContinueWhenAllowFailureIsSet` (new flow `set-variables-allow-failure.yaml`) — the failing `SetVariables` ends `WARNING`, the next task runs `SUCCESS`, execution ends `WARNING`.
- `H2RunnerTest` green (executor change).

### Note on scope

Kept as one PR since each fix is small; they share the "core task semantics" theme. #10360 touches the executor failure path — it was earmarked for 2.1, but turned out to be a contained change to a single catch block, so it's included here.

Closes https://github.com/kestra-io/kestra/issues/18499.

### EE issues (same fixes, cross-repo — close manually on merge)

GitHub only auto-closes issues in this repo:

- https://github.com/kestra-io/kestra-ee/issues/10324
- https://github.com/kestra-io/kestra-ee/issues/10360
