### PR TITLE
fix(core): constant-time basic-auth credential verification

### DIFF
--- a/core/src/main/java/io/kestra/core/endpoints/BasicAuthEndpointsFilter.java
+++ b/core/src/main/java/io/kestra/core/endpoints/BasicAuthEndpointsFilter.java
@@ -6,6 +6,7 @@ import java.util.Optional;
 
 import org.reactivestreams.Publisher;
 
+import io.kestra.core.utils.AuthUtils;
 import io.micronaut.context.annotation.Requires;
 import io.micronaut.core.async.publisher.Publishers;
 import io.micronaut.http.*;
@@ -53,8 +54,11 @@ public class BasicAuthEndpointsFilter implements HttpServerFilter {
 
             final String[] values = credentials.split(":", 2);
             if (values.length == 2) {
-                return this.endpointBasicAuthConfiguration.getUsername().equals(values[0]) &&
-                    this.endpointBasicAuthConfiguration.getPassword().equals(values[1]);
+                // Compare both operands without short-circuiting so a wrong username cannot be
+                // distinguished from a wrong password by response time (GHSA-38rc-2jxj-2h75).
+                boolean usernameMatches = AuthUtils.constantTimeEquals(this.endpointBasicAuthConfiguration.getUsername(), values[0]);
+                boolean passwordMatches = AuthUtils.constantTimeEquals(this.endpointBasicAuthConfiguration.getPassword(), values[1]);
+                return usernameMatches & passwordMatches;
             }
         }
 

--- a/core/src/main/java/io/kestra/core/utils/AuthUtils.java
+++ b/core/src/main/java/io/kestra/core/utils/AuthUtils.java
@@ -10,7 +10,7 @@ import org.apache.commons.lang3.RandomStringUtils;
 import org.bouncycastle.crypto.generators.OpenBSDBCrypt;
 
 /**
- * Utility class for BasicAuth password hashing.
+ * Utility class for BasicAuth password hashing and constant-time credential comparison.
  *
  * <p>
  * Passwords at rest are stored as {@code bcrypt(sha512(salt|password))}.
@@ -97,6 +97,31 @@ public final class AuthUtils {
         } catch (Exception e) {
             // storedHash is malformed (e.g. a legacy SHA-512 hex string) – fail closed
             return false;
+        }
+    }
+
+    /**
+     * Compares two strings in constant time, regardless of where they first differ or of a length mismatch.
+     *
+     * <p>
+     * Comparing SHA-256 digests instead of the raw bytes avoids {@link MessageDigest#isEqual} short-circuiting
+     * on differing lengths, which would otherwise leak the length of the expected value.
+     *
+     * @return {@code true} if both strings are non-null and equal, {@code false} otherwise
+     */
+    public static boolean constantTimeEquals(String left, String right) {
+        if (left == null || right == null) {
+            return false;
+        }
+        return MessageDigest.isEqual(sha256(left), sha256(right));
+    }
+
+    private static byte[] sha256(String input) {
+        try {
+            return MessageDigest.getInstance("SHA-256").digest(input.getBytes(StandardCharsets.UTF_8));
+        } catch (NoSuchAlgorithmException e) {
+            // SHA-256 is required by the JVM spec — this cannot happen.
+            throw new IllegalStateException("SHA-256 not available", e);
         }
     }
 }

--- a/core/src/test/java/io/kestra/core/endpoints/BasicAuthEndpointsFilterTest.java
+++ b/core/src/test/java/io/kestra/core/endpoints/BasicAuthEndpointsFilterTest.java
@@ -75,6 +75,16 @@ class BasicAuthEndpointsFilterTest {
 
             assertThat(e.getStatus().getCode()).isEqualTo(HttpStatus.UNAUTHORIZED.getCode());
         });
+
+        test(true, (client, httpRequest) ->
+        {
+            HttpClientResponseException e = assertThrows(HttpClientResponseException.class, () ->
+            {
+                client.toBlocking().exchange(httpRequest.basicAuth("wrongUser", "bar"));
+            });
+
+            assertThat(e.getStatus().getCode()).isEqualTo(HttpStatus.UNAUTHORIZED.getCode());
+        });
     }
 
     @Test

--- a/core/src/test/java/io/kestra/core/utils/AuthUtilsTest.java
+++ b/core/src/test/java/io/kestra/core/utils/AuthUtilsTest.java
@@ -113,4 +113,28 @@ class AuthUtilsTest {
         assertThat(AuthUtils.matches(SALT, PASSWORD, migratedHash)).isTrue();
         assertThat(AuthUtils.matches(SALT, "WrongPassword1", migratedHash)).isFalse();
     }
+
+    // --- constantTimeEquals ---
+
+    @Test
+    void shouldReturnTrueForEqualStrings() {
+        assertThat(AuthUtils.constantTimeEquals("admin@kestra.io", "admin@kestra.io")).isTrue();
+    }
+
+    @Test
+    void shouldReturnFalseForDifferentStrings() {
+        assertThat(AuthUtils.constantTimeEquals("admin@kestra.io", "other@kestra.io")).isFalse();
+    }
+
+    @Test
+    void shouldReturnFalseForDifferentLengthStrings() {
+        assertThat(AuthUtils.constantTimeEquals("admin@kestra.io", "admin@kestra.io.longer")).isFalse();
+    }
+
+    @Test
+    void shouldReturnFalseWhenEitherArgumentIsNull() {
+        assertThat(AuthUtils.constantTimeEquals(null, "admin@kestra.io")).isFalse();
+        assertThat(AuthUtils.constantTimeEquals("admin@kestra.io", null)).isFalse();
+        assertThat(AuthUtils.constantTimeEquals(null, null)).isFalse();
+    }
 }

--- a/webserver/src/main/java/io/kestra/webserver/services/BasicAuthService.java
+++ b/webserver/src/main/java/io/kestra/webserver/services/BasicAuthService.java
@@ -218,7 +218,7 @@ public class BasicAuthService {
         if (credentials == null || username == null || password == null) {
             return false;
         }
-        return username.equals(credentials.getUsername()) && AuthUtils.matches(credentials.getSalt(), password, credentials.getPassword());
+        return matchesConfiguredCredentials(credentials, username, password);
     }
 
     /**
@@ -252,14 +252,8 @@ public class BasicAuthService {
             String tokenSha256 = sha256Hex(token);
 
             // Fast path: same token as last verified — skip bcrypt entirely.
-            // compare via MessageDigest.isEqual to prevent timing attacks
             String cachedTokenSha256 = lastVerifiedTokenSha256.get();
-            if (
-                cachedTokenSha256 != null && MessageDigest.isEqual(
-                    tokenSha256.getBytes(StandardCharsets.UTF_8),
-                    cachedTokenSha256.getBytes(StandardCharsets.UTF_8)
-                )
-            ) {
+            if (AuthUtils.constantTimeEquals(tokenSha256, cachedTokenSha256)) {
                 return true;
             }
 
@@ -271,10 +265,9 @@ public class BasicAuthService {
             String username = decoded.substring(0, colonIdx);
             String password = decoded.substring(colonIdx + 1);
 
-            boolean valid = username.equals(credentials.getUsername())
-                && AuthUtils.matches(credentials.getSalt(), password, credentials.getPassword());
+            boolean valid = matchesConfiguredCredentials(credentials, username, password);
 
-            // Wrong passwords always pay the full bcrypt cost; only cache successes.
+            // Every failure now pays the full bcrypt cost; only cache successes.
             if (valid) {
                 lastVerifiedTokenSha256.set(tokenSha256);
             }
@@ -282,6 +275,17 @@ public class BasicAuthService {
         } catch (IllegalArgumentException e) {
             return false;
         }
+    }
+
+    /**
+     * Compares {@code username}/{@code password} against {@code credentials} without short-circuiting: bcrypt runs
+     * even when the username does not match, so a wrong username cannot be distinguished from a wrong password by
+     * response time (GHSA-38rc-2jxj-2h75).
+     */
+    private static boolean matchesConfiguredCredentials(SaltedBasicAuthCredentials credentials, String username, String password) {
+        boolean usernameMatches = AuthUtils.constantTimeEquals(username, credentials.getUsername());
+        boolean passwordMatches = AuthUtils.matches(credentials.getSalt(), password, credentials.getPassword());
+        return usernameMatches & passwordMatches;
     }
 
     private Optional<String> extractFromCookie(HttpRequest<?> request) {

--- a/webserver/src/test/java/io/kestra/webserver/services/BasicAuthServiceTest.java
+++ b/webserver/src/test/java/io/kestra/webserver/services/BasicAuthServiceTest.java
@@ -398,6 +398,55 @@ class BasicAuthServiceTest {
     }
 
     @Test
+    void shouldNotAuthenticate_withUnknownUsername() {
+        // Given
+        var tmpSettingsRepo = new InMemorySettingRepository();
+        var basicAuthService = new BasicAuthService(tmpSettingsRepo, yamlBasicAuthConfiguration, instanceService, ApplicationEventPublisher.noOp());
+        basicAuthService.init();
+
+        // When / Then – unknown username rejected
+        HttpRequest<?> badRequest = HttpRequest.GET("/test")
+            .basicAuth("nobody@kestra.io", "Kestra123");
+        assertThat(basicAuthService.isAuthenticated(badRequest)).isFalse();
+    }
+
+    @Test
+    void shouldPayBcryptCost_whenUsernameIsUnknown() {
+        // Regression guard for GHSA-38rc-2jxj-2h75: a wrong username used to short-circuit before bcrypt,
+        // making an unknown username roughly 2 orders of magnitude faster to reject than a known username
+        // with a wrong password. Both must now cost roughly the same.
+        var tmpSettingsRepo = new InMemorySettingRepository();
+        var basicAuthService = new BasicAuthService(tmpSettingsRepo, yamlBasicAuthConfiguration, instanceService, ApplicationEventPublisher.noOp());
+        basicAuthService.init();
+
+        HttpRequest<?> knownUsernameWrongPassword = HttpRequest.GET("/test")
+            .basicAuth("admin@kestra.io", "WrongPassword1");
+        HttpRequest<?> unknownUsername = HttpRequest.GET("/test")
+            .basicAuth("nobody@kestra.io", "WrongPassword1");
+
+        // Warm up the JIT before measuring.
+        basicAuthService.isAuthenticated(knownUsernameWrongPassword);
+        basicAuthService.isAuthenticated(unknownUsername);
+
+        long baselineNanos = fastestOf(3, () -> basicAuthService.isAuthenticated(knownUsernameWrongPassword));
+        long subjectNanos = fastestOf(3, () -> basicAuthService.isAuthenticated(unknownUsername));
+
+        assertThat(subjectNanos)
+            .as("rejecting an unknown username must pay at least half the bcrypt cost paid for a known username with a wrong password")
+            .isGreaterThanOrEqualTo(baselineNanos / 2);
+    }
+
+    private static long fastestOf(int runs, Runnable action) {
+        long fastest = Long.MAX_VALUE;
+        for (int i = 0; i < runs; i++) {
+            long start = System.nanoTime();
+            action.run();
+            fastest = Math.min(fastest, System.nanoTime() - start);
+        }
+        return fastest;
+    }
+
+    @Test
     void shouldInvalidateCache_whenPasswordChanges() {
         // Given – initialised with password "Kestra123"
         var tmpSettingsRepo = new InMemorySettingRepository();


### PR DESCRIPTION
Closes https://github.com/kestra-io/kestra/security/advisories/GHSA-38rc-2jxj-2h75.

## Problem

`BasicAuthService.isAuthenticated()` and `validateCredentials()` verified credentials with:

```java
username.equals(credentials.getUsername()) && AuthUtils.matches(...)
```

Java's `&&` short-circuits, so a wrong username never reached the bcrypt password check. A correct username with a wrong password paid the full bcrypt cost-12 verification (~250ms), while a wrong username returned in under a millisecond. The reporter's PoC measured a 36x timing gap (0.338s vs 0.005s), letting an unauthenticated attacker enumerate the configured basic-auth username purely from response time — both failure modes return an identical body-less 401.

`BasicAuthEndpointsFilter` (guards Micronaut management endpoints such as `/health`) had the same short-circuit shape comparing plaintext username and password.

## Fix

- Added `AuthUtils.constantTimeEquals(String, String)`: a null-safe comparison via `MessageDigest.isEqual` over SHA-256 digests of both inputs, which also avoids `MessageDigest.isEqual`'s own length-based short-circuit.
- `BasicAuthService.isAuthenticated()` / `validateCredentials()` now route through a `matchesConfiguredCredentials()` helper that evaluates the username and password checks into locals and combines them with non-short-circuiting `&`, so bcrypt always runs regardless of whether the username matched.
- Applied the identical fix to `BasicAuthEndpointsFilter.validateUser()`.
- Deduplicated `isAuthenticated()`'s existing cache-hit token comparison to reuse the new `constantTimeEquals` helper instead of a second hand-rolled `MessageDigest.isEqual` call.

**Deliberately not touched:** `BasicAuthService.save()` has the same `&&` shape when checking whether new credentials differ from the stored ones, but it has no unauthenticated caller (reachable only once already authenticated, or during initial onboarding before any credentials exist), so there is no timing oracle to close there.

## Trade-off

Every unauthenticated request carrying a Basic header or `BASIC_AUTH` cookie now costs ~250-300ms of bcrypt, where previously only requests using the correct username did. This runs on Reactor's `boundedElastic` pool, not the Netty event loop, so it cannot stall the server, but it does widen the existing CPU cost of probing this endpoint. There is currently no rate limiting or failed-auth logging on this path — a natural follow-up, out of scope here to keep this PR to one concern.

## Test plan

- [x] `AuthUtilsTest` — `constantTimeEquals` truth table (equal, different, different length, null arguments)
- [x] `BasicAuthEndpointsFilterTest` — added a wrong-username case
- [x] `BasicAuthServiceTest` — added `shouldNotAuthenticate_withUnknownUsername`, and a timing regression test `shouldPayBcryptCost_whenUsernameIsUnknown` that fails on the pre-fix code (asserts the unknown-username path pays at least half the bcrypt cost of the known-username-wrong-password path)
- [x] `:core:test --tests AuthUtilsTest,BasicAuthEndpointsFilterTest` and `:webserver:test --tests BasicAuthServiceTest,AuthenticationFilterTest,MiscControllerTest,McpServerAuthenticationFilterTest,CsrfTokenFilterTest` all pass
- [x] Full `:core:test :webserver:test` run: two unrelated pre-existing failures confirmed independent of this change (`HttpClientTest.errorUnreachable` — sandbox locale mismatch in an OS error string; `AiAgentControllerConcurrencyTest` — a `ReadTimeoutException` under load that passes cleanly in isolation)