### PR TITLE
fix(namespaces): escape file name in the delete confirmation dialog (1.3 backport)

### DIFF
--- a/ui/src/components/inputs/FileExplorer.vue
+++ b/ui/src/components/inputs/FileExplorer.vue
@@ -397,6 +397,7 @@
     import PlusBox from "vue-material-design-icons/PlusBox.vue";
     import FolderDownloadOutline from "vue-material-design-icons/FolderDownloadOutline.vue";
     import TypeIcon from "../utils/icons/Type.vue";
+    import escape from "lodash/escape";
     import {useI18n} from "vue-i18n";
     import {useToast} from "../../utils/toast";
     import {
@@ -506,8 +507,8 @@
         const folders = confirmation.value.nodes?.filter(n => n.type === "Directory");
         const foldersCount = folders?.length ?? 0;
         const labels = {title: t("namespace files.dialog.deletion.title"), message: ""};
-        if (foldersCount === 1) labels.message = t("namespace files.dialog.deletion.folder_single", {name: folders?.[0].fileName});
-        else if (filesCount === 1) labels.message = t("namespace files.dialog.deletion.file_single", {name: files?.[0].fileName});
+        if (foldersCount === 1) labels.message = t("namespace files.dialog.deletion.folder_single", {name: escape(folders?.[0].fileName)});
+        else if (filesCount === 1) labels.message = t("namespace files.dialog.deletion.file_single", {name: escape(files?.[0].fileName)});
         else if (foldersCount > 0 && filesCount > 0) labels.message = t("namespace files.dialog.deletion.mixed", {folders: foldersCount, files: filesCount});
         else if (foldersCount > 0) labels.message = t("namespace files.dialog.deletion.folders", {count: foldersCount});
         else labels.message = t("namespace files.dialog.deletion.files", {count: filesCount});


### PR DESCRIPTION
## What

Backports the delete-confirmation escaping fix to `releases/v1.3.x` (develop PR: https://github.com/kestra-io/kestra/pull/18786).

The namespace file explorer builds its delete-confirmation message by interpolating the file name into a translation string that contains HTML (`Are you sure you want to delete the file <code>{name}</code>?`) and renders the result with `v-html`. File names are stored and returned by the API byte-for-byte with no character allowlist, so a file named after markup (e.g. `<img src=x onerror=...>.txt`) is concatenated raw and executes as live HTML when the confirmation dialog renders.

## Fix

Wrap the interpolated file name in `lodash/escape` before it reaches the `v-html` sink, matching every sibling confirmation dialog. Identical to the develop change.

## Evidence

`npm run check:types` (exit 0) and `npm run lint` (no issues) pass locally on this branch.

Related to https://github.com/kestra-io/kestra/security/advisories/GHSA-crq7-3xg2-hjch.