### PR TITLE
fix(iam): require route identity for open-urls prefix matches

### DIFF
--- a/cli/src/main/resources/application.yml
+++ b/cli/src/main/resources/application.yml
@@ -177,7 +177,6 @@ kestra:
         - "/api/v1/executions/webhook/"
         - "/api/v1/main/executions/webhook/"
         - "/api/v1/*/executions/webhook/"
-        - "/api/v1/basicAuthValidationErrors"
 
     preview:
       initial-rows: 100

--- a/webserver/src/main/java/io/kestra/webserver/annotation/AnonymousAccess.java
+++ b/webserver/src/main/java/io/kestra/webserver/annotation/AnonymousAccess.java
@@ -1,0 +1,17 @@
+package io.kestra.webserver.annotation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Marks a route that {@link io.kestra.webserver.filter.AuthenticationFilter} may serve without
+ * credentials, and only when its path is also listed in {@code kestra.server.basic-auth.open-urls}.
+ */
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ ElementType.TYPE, ElementType.METHOD })
+public @interface AnonymousAccess {
+}

--- a/webserver/src/main/java/io/kestra/webserver/controllers/api/ExecutionController.java
+++ b/webserver/src/main/java/io/kestra/webserver/controllers/api/ExecutionController.java
@@ -82,6 +82,7 @@ import io.kestra.core.utils.*;
 import io.kestra.plugin.core.trigger.AbstractWebhookTrigger;
 import io.kestra.plugin.core.trigger.WebhookContext;
 import io.kestra.plugin.core.trigger.WebhookResponse;
+import io.kestra.webserver.annotation.AnonymousAccess;
 import io.kestra.webserver.converters.QueryFilterFormat;
 import io.kestra.webserver.models.api.ApiAsyncOperationResponse;
 import io.kestra.webserver.models.api.ApiExecution;
@@ -573,6 +574,7 @@ public class ExecutionController {
         return PagedResults.of(new ArrayListTotal<>(apiExecution, executions.getTotal()));
     }
 
+    @AnonymousAccess
     @ExecuteOn(TaskExecutors.IO)
     @Post(uri = "/webhook/{namespace}/{id}/{key}{/path}", consumes = { MediaType.ALL })
     @Operation(tags = { "Executions" }, summary = "Trigger a new execution by POST webhook trigger")
@@ -608,6 +610,7 @@ public class ExecutionController {
     // Hidden from the API spec: this is the same endpoint as the route that takes any other content type, which
     // the spec already describes; a second operation on the same path and method would shadow it.
     @Hidden
+    @AnonymousAccess
     @ExecuteOn(TaskExecutors.IO)
     @Post(uri = "/webhook/{namespace}/{id}/{key}{/path}", consumes = MediaType.MULTIPART_FORM_DATA)
     @SingleResult
@@ -624,6 +627,7 @@ public class ExecutionController {
     // Hidden from the API spec: this is the same endpoint as the route that takes any other content type, which
     // the spec already describes; a second operation on the same path and method would shadow it.
     @Hidden
+    @AnonymousAccess
     @ExecuteOn(TaskExecutors.IO)
     @Put(uri = "/webhook/{namespace}/{id}/{key}{/path}", consumes = MediaType.MULTIPART_FORM_DATA)
     @SingleResult
@@ -637,6 +641,7 @@ public class ExecutionController {
         return this.webhookMultipart(namespace, id, key, path, parts, request);
     }
 
+    @AnonymousAccess
     @ExecuteOn(TaskExecutors.IO)
     @Get(uri = "/webhook/{namespace}/{id}/{key}{/path}", consumes = { MediaType.ALL })
     @Operation(tags = { "Executions" }, summary = "Trigger a new execution by GET webhook trigger")
@@ -651,6 +656,7 @@ public class ExecutionController {
         return this.webhook(namespace, id, key, path, request);
     }
 
+    @AnonymousAccess
     @ExecuteOn(TaskExecutors.IO)
     @Put(uri = "/webhook/{namespace}/{id}/{key}{/path}", consumes = { MediaType.ALL })
     @Operation(tags = { "Executions" }, summary = "Trigger a new execution by PUT webhook trigger")

--- a/webserver/src/main/java/io/kestra/webserver/filter/AuthenticationFilter.java
+++ b/webserver/src/main/java/io/kestra/webserver/filter/AuthenticationFilter.java
@@ -5,6 +5,7 @@ import java.util.Optional;
 
 import org.reactivestreams.Publisher;
 
+import io.kestra.webserver.annotation.AnonymousAccess;
 import io.kestra.webserver.services.BasicAuthService;
 
 import io.micronaut.context.annotation.Requires;
@@ -52,10 +53,13 @@ public class AuthenticationFilter implements HttpServerFilter {
                     || ((normalizedPath.matches("/api/v1(/[^/]+)?/basicAuth") || "/api/v1/basicAuthValidationErrors".equals(normalizedPath))
                         && !basicAuthService.isBasicAuthInitialized());
 
-                boolean isOpenUrl = Optional.ofNullable(basicAuthConfiguration.openUrls())
-                    .map(Collection::stream)
-                    .map(stream -> stream.anyMatch(s -> request.getPath().startsWith(s)))
-                    .orElse(false);
+                // A path prefix is not an identity: the router resolves it, so the route it picked must
+                // itself opt into anonymous access (GHSA-j5cv-8rw9-vv2p).
+                boolean isOpenUrl = isAnonymousRoute(request)
+                    && Optional.ofNullable(basicAuthConfiguration.openUrls())
+                        .map(Collection::stream)
+                        .map(stream -> stream.anyMatch(s -> request.getPath().startsWith(s)))
+                        .orElse(false);
 
                 boolean mcpAuthHandled = request.getAttribute(McpServerAuthenticationFilter.MCP_AUTH_HANDLED, Boolean.class)
                     .orElse(false);
@@ -86,6 +90,15 @@ public class AuthenticationFilter implements HttpServerFilter {
         Optional<RouteMatch> routeMatch = RouteMatchUtils.findRouteMatch(request);
         if (routeMatch.isPresent() && routeMatch.get() instanceof MethodBasedRouteMatch<?, ?> method) {
             return method.getAnnotation(Endpoint.class) != null;
+        }
+        return false;
+    }
+
+    @SuppressWarnings("rawtypes")
+    private boolean isAnonymousRoute(HttpRequest<?> request) {
+        Optional<RouteMatch> routeMatch = RouteMatchUtils.findRouteMatch(request);
+        if (routeMatch.isPresent() && routeMatch.get() instanceof MethodBasedRouteMatch<?, ?> method) {
+            return method.getAnnotation(AnonymousAccess.class) != null;
         }
         return false;
     }

--- a/webserver/src/test/java/io/kestra/webserver/filter/AuthenticationFilterTest.java
+++ b/webserver/src/test/java/io/kestra/webserver/filter/AuthenticationFilterTest.java
@@ -12,9 +12,11 @@ import io.kestra.webserver.services.BasicAuthService;
 import io.micronaut.http.HttpRequest;
 import io.micronaut.http.HttpResponse;
 import io.micronaut.http.HttpStatus;
+import io.micronaut.http.MediaType;
 import io.micronaut.http.MutableHttpResponse;
 import io.micronaut.http.client.annotation.Client;
 import io.micronaut.http.client.exceptions.HttpClientResponseException;
+import io.micronaut.http.client.multipart.MultipartBody;
 import io.micronaut.reactor.http.client.ReactorHttpClient;
 import jakarta.inject.Inject;
 import reactor.core.publisher.Mono;
@@ -275,6 +277,48 @@ class AuthenticationFilterTest {
         );
 
         assertThat(e.getResponse().getStatus().getCode()).isEqualTo(HttpStatus.UNAUTHORIZED.getCode());
+    }
+
+    @Test
+    void webhookOpenUrlShouldNotOpenTheGeneralExecutionRoute() {
+        // GHSA-j5cv-8rw9-vv2p: "/api/v1/main/executions/webhook/" as an open-url prefix also matched
+        // "/api/v1/main/executions/{namespace}/{id}" for a namespace literally named "webhook",
+        // letting anyone create an execution anonymously.
+        TestAuthFilter.ENABLED = false;
+        try {
+            HttpClientResponseException httpClientResponseException = assertThrows(
+                HttpClientResponseException.class, () -> client.toBlocking()
+                    .exchange(
+                        HttpRequest.POST(
+                            "/api/v1/main/executions/webhook/some-flow",
+                            MultipartBody.builder().addPart("string", "myString").build()
+                        ).contentType(MediaType.MULTIPART_FORM_DATA_TYPE)
+                    )
+            );
+            assertThat(httpClientResponseException.getStatus().getCode()).isEqualTo(HttpStatus.UNAUTHORIZED.getCode());
+        } finally {
+            TestAuthFilter.ENABLED = true;
+        }
+    }
+
+    @Test
+    void webhookRouteShouldStayOpenWithAndWithoutTenant() {
+        TestAuthFilter.ENABLED = false;
+        try {
+            HttpClientResponseException tenantFul = assertThrows(
+                HttpClientResponseException.class, () -> client.toBlocking()
+                    .exchange(HttpRequest.GET("/api/v1/main/executions/webhook/io.kestra.tests/unknown-flow/some-key"))
+            );
+            assertThat(tenantFul.getStatus().getCode()).isEqualTo(HttpStatus.NOT_FOUND.getCode());
+
+            HttpClientResponseException tenantLess = assertThrows(
+                HttpClientResponseException.class, () -> client.toBlocking()
+                    .exchange(HttpRequest.GET("/api/v1/executions/webhook/io.kestra.tests/unknown-flow/some-key"))
+            );
+            assertThat(tenantLess.getStatus().getCode()).isEqualTo(HttpStatus.NOT_FOUND.getCode());
+        } finally {
+            TestAuthFilter.ENABLED = true;
+        }
     }
 
     @Test


### PR DESCRIPTION
Closes https://github.com/kestra-io/kestra/security/advisories/GHSA-j5cv-8rw9-vv2p.

### ✨ Description

**Problem:** `AuthenticationFilter` decided whether a request could skip authentication by testing `kestra.server.basic-auth.open-urls` as a raw string prefix over `request.getPath()`. The shipped default opens `/api/v1/main/executions/webhook/`, but `ExecutionController` also serves the general create-execution route under the same controller prefix. A namespace literally named `webhook` satisfies the open-url prefix while Micronaut actually routes the request to `POST /{namespace}/{id}` — the ordinary "run this flow" endpoint — bypassing authentication entirely. An anonymous caller could create and execute any flow in a `webhook` namespace, with attacker-controlled inputs, and read its outputs (including any `secret()` value) via `?wait=true`.

**Fix:** `isOpenUrl` now also requires the route Micronaut actually resolved for the request to carry a new `@AnonymousAccess` marker annotation, applied only to the five webhook-trigger handler methods on `ExecutionController`. A string prefix can no longer stand in for route identity — this mirrors the file's existing `isManagementEndpoint` check for Micronaut's own `@Endpoint` beans. Also dropped `/api/v1/basicAuthValidationErrors` from the shipped `open-urls` defaults: that entry made the route unconditionally anonymous, silently overriding the `!isBasicAuthInitialized()` gate the filter already applies to the same route through `isConfigEndpoint`.

**Evidence:** Added a regression test that fails against the pre-fix code (`webhookOpenUrlShouldNotOpenTheGeneralExecutionRoute`, confirmed red before the fix / green after) plus a companion test proving the legitimate webhook route, tenant-ful and tenant-less, still works unauthenticated. Full `:webserver:test` module run: 1221 passing, 0 failing.

### 🛠️ Backend Checklist

- [x] Code compiles and tests pass for the touched modules (`./gradlew :webserver:test`)
- [x] New behavior is covered by unit or integration tests

### 📝 Additional Notes

- Enterprise Edition is unaffected: `AuthenticationFilter` only activates when `micronaut.security.enabled != true`, and EE always sets that to `true`; EE's own webhook routes are gated independently via `@Secured(SecurityRule.IS_ANONYMOUS)`.
- Backport candidates: `releases/v1.3.x` (clean cherry-pick) and `releases/v1.0.x` (3 webhook methods to annotate instead of 5, no multipart variants there).

### 🤖 AI Authors

Why did the cat sit on the `AuthenticationFilter`? Because it wanted to make sure every request had to go through it to pass "purr-mission" first.