### PR TITLE
fix(iam): basic-auth cache staleness and password-change re-auth

### DIFF
--- a/webserver/src/main/java/io/kestra/webserver/controllers/api/MiscController.java
+++ b/webserver/src/main/java/io/kestra/webserver/controllers/api/MiscController.java
@@ -9,6 +9,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.core.JsonProcessingException;
 
 import io.kestra.core.contexts.configuration.SystemFlowsConfiguration;
+import io.kestra.core.exceptions.ValidationErrorException;
 import io.kestra.core.models.collectors.ExecutionUsage;
 import io.kestra.core.models.collectors.FlowUsage;
 import io.kestra.core.plugins.PluginAutoInstallService;
@@ -200,13 +201,27 @@ public class MiscController {
 
     @Post(uri = "/{tenant}/basicAuth")
     @ExecuteOn(TaskExecutors.IO)
-    @Operation(tags = { "Misc" }, summary = "Configure basic authentication for the instance.", description = "Sets up basic authentication credentials.")
+    @Operation(
+        tags = { "Misc" }, summary = "Configure basic authentication for the instance.",
+        description = "Sets up basic authentication credentials. Once credentials already exist, the request must also carry the current password."
+    )
     public MutableHttpResponse<?> createBasicAuth(
         HttpRequest<?> request,
         @RequestBody @Valid @Body BasicAuthCredentials basicAuthCredentials) {
-        basicAuthService
-            .orElseThrow(() -> new IllegalStateException("basicAuthService bean is required in OSS"))
-            .save(basicAuthCredentials);
+        BasicAuthService service = basicAuthService
+            .orElseThrow(() -> new IllegalStateException("basicAuthService bean is required in OSS"));
+
+        // Being authenticated is not enough to prove the caller still knows the *current*
+        // password: isAuthenticated() caches verified tokens, so a password already rotated on
+        // another webserver node sharing this settings store can still pass it here. Re-checking
+        // directly against the stored credentials closes that window.
+        if (service.isBasicAuthInitialized() && !service.validateCurrentPassword(basicAuthCredentials.getCurrentPassword())) {
+            throw new ValidationErrorException(List.of(
+                "The current password is required and must be correct to change Basic Authentication credentials."
+            ));
+        }
+
+        service.save(basicAuthCredentials);
 
         // Log the caller in immediately: they just proved they know these credentials by submitting them.
         return HttpResponse.noContent()

--- a/webserver/src/main/java/io/kestra/webserver/services/BasicAuthCredentials.java
+++ b/webserver/src/main/java/io/kestra/webserver/services/BasicAuthCredentials.java
@@ -3,7 +3,12 @@ package io.kestra.webserver.services;
 public record BasicAuthCredentials(
     String uid,
     String username,
-    String password) {
+    String password,
+    String currentPassword) {
+    public BasicAuthCredentials(String uid, String username, String password) {
+        this(uid, username, password, null);
+    }
+
     public String getUsername() {
         return username;
     }
@@ -14,5 +19,13 @@ public record BasicAuthCredentials(
 
     public String getUid() {
         return uid;
+    }
+
+    /**
+     * The password the caller must currently know, required to change already-configured
+     * Basic Authentication credentials. See {@link BasicAuthService#validateCurrentPassword}.
+     */
+    public String getCurrentPassword() {
+        return currentPassword;
     }
 }

--- a/webserver/src/main/java/io/kestra/webserver/services/BasicAuthService.java
+++ b/webserver/src/main/java/io/kestra/webserver/services/BasicAuthService.java
@@ -52,12 +52,20 @@ public class BasicAuthService {
     private static final int EMAIL_PASSWORD_MAX_LEN = 256;
 
     /**
-     * SHA-256 of the last successfully verified token, or {@code null} if not yet verified or
-     * invalidated. Because there is only one valid username/password at any time, a single field
-     * is sufficient: every valid token encodes the same credentials and produces the same digest.
-     * Cleared by {@link #save} whenever credentials change so an old token stops working immediately.
+     * The last successfully verified token, keyed by both its SHA-256 and a fingerprint of the
+     * credentials it was verified against, or {@code null} if not yet verified or invalidated.
+     * The fingerprint is re-derived from {@link #credentials()} — already fetched fresh on every
+     * call — on every fast-path check, so a credential change on any webserver node sharing the
+     * same settings store (not just this one) invalidates the cache on this node's very next
+     * request, without any cross-node signal. A cache keyed on the token hash alone would let a
+     * password already revoked on another node keep authenticating here indefinitely.
+     * Cleared by {@link #save} whenever credentials change so an old token stops working
+     * immediately on this node too.
      */
-    private final AtomicReference<String> lastVerifiedTokenSha256 = new AtomicReference<>();
+    private final AtomicReference<CachedToken> lastVerifiedToken = new AtomicReference<>();
+
+    private record CachedToken(String tokenSha256, String credentialsFingerprint) {
+    }
 
     @Inject
     private SettingRepositoryInterface settingRepository;
@@ -165,7 +173,7 @@ public class BasicAuthService {
             );
 
             // Clear the cached token so an old password stops working immediately.
-            lastVerifiedTokenSha256.set(null);
+            lastVerifiedToken.set(null);
 
             ossAuthEventPublisher.publishEventAsync(
                 OssAuthEvent.builder()
@@ -222,6 +230,20 @@ public class BasicAuthService {
     }
 
     /**
+     * Returns {@code true} if {@code currentPassword} matches the currently configured password.
+     * Always re-checks against {@link #credentials()} directly, bypassing the {@link #isAuthenticated}
+     * cache, so it cannot be satisfied by a credential already revoked elsewhere. Used to require
+     * proof of the current password before {@link #save} is allowed to replace it.
+     */
+    public boolean validateCurrentPassword(String currentPassword) {
+        SaltedBasicAuthCredentials credentials = credentials();
+        if (credentials == null || currentPassword == null) {
+            return false;
+        }
+        return AuthUtils.matches(credentials.getSalt(), currentPassword, credentials.getPassword());
+    }
+
+    /**
      * Builds the {@value BASIC_AUTH_COOKIE_NAME} cookie token for a set of credentials, i.e. the same
      * base64(username:password) value historically computed client-side, now issued only by the server.
      */
@@ -234,9 +256,10 @@ public class BasicAuthService {
      * (either via the {@value BASIC_AUTH_COOKIE_NAME} cookie or an {@code Authorization: Basic} header).
      *
      * <p>
-     * bcrypt verification is only performed on a cache miss. Subsequent requests
-     * with the same token hit the in-memory cache and pay only a SHA-256 hash cost,
-     * keeping per-request latency negligible while the at-rest hash remains bcrypt-strength.
+     * bcrypt verification is only performed on a cache miss. Subsequent requests with the same
+     * token, verified against unchanged credentials, hit the in-memory cache and pay only a
+     * SHA-256 hash cost, keeping per-request latency negligible while the at-rest hash remains
+     * bcrypt-strength.
      */
     public boolean isAuthenticated(HttpRequest<?> request) {
         SaltedBasicAuthCredentials credentials = credentials();
@@ -250,10 +273,18 @@ public class BasicAuthService {
         try {
             String token = encoded.get();
             String tokenSha256 = sha256Hex(token);
+            String credentialsFingerprint = credentialsFingerprint(credentials);
 
-            // Fast path: same token as last verified — skip bcrypt entirely.
-            String cachedTokenSha256 = lastVerifiedTokenSha256.get();
-            if (AuthUtils.constantTimeEquals(tokenSha256, cachedTokenSha256)) {
+            // Fast path: same token verified against these exact credentials — skip bcrypt
+            // entirely. Re-deriving the fingerprint from the freshly-fetched `credentials` above
+            // on every call means a password change (on this node or a peer sharing the same
+            // settings store) invalidates the cache on the very next request.
+            CachedToken cached = lastVerifiedToken.get();
+            if (
+                cached != null
+                    && AuthUtils.constantTimeEquals(tokenSha256, cached.tokenSha256())
+                    && AuthUtils.constantTimeEquals(credentialsFingerprint, cached.credentialsFingerprint())
+            ) {
                 return true;
             }
 
@@ -269,7 +300,7 @@ public class BasicAuthService {
 
             // Every failure now pays the full bcrypt cost; only cache successes.
             if (valid) {
-                lastVerifiedTokenSha256.set(tokenSha256);
+                lastVerifiedToken.set(new CachedToken(tokenSha256, credentialsFingerprint));
             }
             return valid;
         } catch (IllegalArgumentException e) {
@@ -286,6 +317,14 @@ public class BasicAuthService {
         boolean usernameMatches = AuthUtils.constantTimeEquals(username, credentials.getUsername());
         boolean passwordMatches = AuthUtils.matches(credentials.getSalt(), password, credentials.getPassword());
         return usernameMatches & passwordMatches;
+    }
+
+    /**
+     * Returns a cache key identifying {@code credentials}, so a cached token can be told apart
+     * from one verified against a since-replaced username/password.
+     */
+    private static String credentialsFingerprint(SaltedBasicAuthCredentials credentials) {
+        return sha256Hex(credentials.getUsername() + ":" + credentials.getSalt() + ":" + credentials.getPassword());
     }
 
     private Optional<String> extractFromCookie(HttpRequest<?> request) {

--- a/webserver/src/test/java/io/kestra/webserver/controllers/api/MiscControllerTest.java
+++ b/webserver/src/test/java/io/kestra/webserver/controllers/api/MiscControllerTest.java
@@ -143,7 +143,7 @@ class MiscControllerTest {
             () -> client.toBlocking().exchange(
                 HttpRequest.POST(
                     "/api/v1/main/basicAuth",
-                    new BasicAuthCredentials("uid", "invalid", "invalid")
+                    new BasicAuthCredentials("uid", "invalid", "invalid", basicAuthConfiguration.getPassword())
                 )
             )
         );
@@ -157,13 +157,79 @@ class MiscControllerTest {
 
     @FlakyTest(description = "BasicAuth state from other tests leaks; needs full security lifecycle isolation")
     @Test
+    void changeBasicAuth_shouldRejectWrongCurrentPassword_whenAlreadyInitialized() {
+        // GHSA-94pv-f379-3gp3: changing Basic Authentication credentials must re-check the
+        // current password directly against the stored value, not rely on isAuthenticated()
+        // alone, which can be satisfied by a token cached before a peer node's password rotation.
+        String uid = "requireCurrentPasswordUid";
+        String username = "require.current.password@kestra.io";
+        String password = "newSecurePassword1";
+
+        try {
+            HttpClientResponseException e = assertThrows(
+                HttpClientResponseException.class,
+                () -> client.toBlocking().exchange(
+                    HttpRequest.POST("/api/v1/main/basicAuth", new BasicAuthCredentials(uid, username, password, "WrongCurrentPassword1"))
+                )
+            );
+            assertThat(e.getStatus().getCode()).isEqualTo(HttpStatus.BAD_REQUEST.getCode());
+
+            // the rejected attempt must not have changed anything
+            assertThatCode(
+                () -> client.toBlocking().retrieve(
+                    GET("/api/v1/main/dashboards").basicAuth(basicAuthConfiguration.getUsername(), basicAuthConfiguration.getPassword()),
+                    MiscController.Configuration.class
+                )
+            ).as("original credentials must still work after a rejected change").doesNotThrowAnyException();
+
+            // the correct current password is accepted
+            client.toBlocking().exchange(
+                HttpRequest.POST("/api/v1/main/basicAuth", new BasicAuthCredentials(uid, username, password, basicAuthConfiguration.getPassword()))
+            );
+            assertThatCode(
+                () -> client.toBlocking().retrieve(
+                    GET("/api/v1/main/dashboards").basicAuth(username, password),
+                    MiscController.Configuration.class
+                )
+            ).as("new credentials must work after a change with the correct current password").doesNotThrowAnyException();
+        } finally {
+            basicAuthService.save(new BasicAuthCredentials(null, basicAuthConfiguration.getUsername(), basicAuthConfiguration.getPassword()));
+        }
+    }
+
+    @Test
+    void changeBasicAuth_shouldNotRequireCurrentPassword_beforeInitialization() {
+        // TestAuthFilter transparently re-initializes Basic Authentication before every outgoing
+        // test request whenever credentials are absent, which would silently undo the delete
+        // below before the request even reaches the server; disable it to genuinely exercise
+        // the not-yet-initialized path.
+        TestAuthFilter.ENABLED = false;
+        try {
+            settingRepository.delete(Setting.builder().key(BasicAuthService.BASIC_AUTH_SETTINGS_KEY).build());
+            assertThat(basicAuthService.isBasicAuthInitialized()).isFalse();
+
+            assertThatCode(
+                () -> client.toBlocking().exchange(
+                    HttpRequest.POST("/api/v1/main/basicAuth", new BasicAuthCredentials("initUid", "first.setup@kestra.io", "FirstSetupPassword1"))
+                )
+            ).as("initial setup must not require a current password").doesNotThrowAnyException();
+
+            assertThat(basicAuthService.isBasicAuthInitialized()).isTrue();
+        } finally {
+            TestAuthFilter.ENABLED = true;
+            basicAuthService.save(new BasicAuthCredentials(null, basicAuthConfiguration.getUsername(), basicAuthConfiguration.getPassword()));
+        }
+    }
+
+    @FlakyTest(description = "BasicAuth state from other tests leaks; needs full security lifecycle isolation")
+    @Test
     void basicAuth() {
         assertThatCode(() -> client.toBlocking().retrieve("/api/v1/configs", MiscController.Configuration.class)).doesNotThrowAnyException();
 
         String uid = "someUid";
         String username = "my.email@kestra.io";
         String password = "myPassword1";
-        client.toBlocking().exchange(HttpRequest.POST("/api/v1/main/basicAuth", new BasicAuthCredentials(uid, username, password)));
+        client.toBlocking().exchange(HttpRequest.POST("/api/v1/main/basicAuth", new BasicAuthCredentials(uid, username, password, basicAuthConfiguration.getPassword())));
         try {
             assertThatThrownBy(
                 () -> client.toBlocking().retrieve("/api/v1/main/dashboards", MiscController.Configuration.class)
@@ -203,7 +269,7 @@ class MiscControllerTest {
         String uid = "loginUid";
         String username = "login.success@kestra.io";
         String password = "loginPassword1";
-        client.toBlocking().exchange(HttpRequest.POST("/api/v1/main/basicAuth", new BasicAuthCredentials(uid, username, password)));
+        client.toBlocking().exchange(HttpRequest.POST("/api/v1/main/basicAuth", new BasicAuthCredentials(uid, username, password, basicAuthConfiguration.getPassword())));
 
         try {
             var response = client.toBlocking().exchange(
@@ -225,7 +291,7 @@ class MiscControllerTest {
         String uid = "loginFlagUid";
         String username = "login.flag.success@kestra.io";
         String password = "loginPassword1";
-        client.toBlocking().exchange(HttpRequest.POST("/api/v1/main/basicAuth", new BasicAuthCredentials(uid, username, password)));
+        client.toBlocking().exchange(HttpRequest.POST("/api/v1/main/basicAuth", new BasicAuthCredentials(uid, username, password, basicAuthConfiguration.getPassword())));
 
         try {
             var response = client.toBlocking().exchange(
@@ -247,7 +313,7 @@ class MiscControllerTest {
         String uid = "loginUid2";
         String username = "login.fail@kestra.io";
         String password = "loginPassword2";
-        client.toBlocking().exchange(HttpRequest.POST("/api/v1/main/basicAuth", new BasicAuthCredentials(uid, username, password)));
+        client.toBlocking().exchange(HttpRequest.POST("/api/v1/main/basicAuth", new BasicAuthCredentials(uid, username, password, basicAuthConfiguration.getPassword())));
 
         try {
             assertThatThrownBy(
@@ -281,7 +347,7 @@ class MiscControllerTest {
         String uid = "logoutUid";
         String username = "logout.success@kestra.io";
         String password = "logoutPassword1";
-        client.toBlocking().exchange(HttpRequest.POST("/api/v1/main/basicAuth", new BasicAuthCredentials(uid, username, password)));
+        client.toBlocking().exchange(HttpRequest.POST("/api/v1/main/basicAuth", new BasicAuthCredentials(uid, username, password, basicAuthConfiguration.getPassword())));
 
         try {
             var response = client.toBlocking().exchange(POST("/api/v1/logout", null).basicAuth(username, password));
@@ -322,7 +388,7 @@ class MiscControllerTest {
         String uid = "someUid2";
         String username = "my.email2@kestra.io";
         String password = "myPassword2";
-        client.toBlocking().exchange(HttpRequest.POST("/api/v1/main/basicAuth", new BasicAuthCredentials(uid, username, password)));
+        client.toBlocking().exchange(HttpRequest.POST("/api/v1/main/basicAuth", new BasicAuthCredentials(uid, username, password, basicAuthConfiguration.getPassword())));
 
         try {
             var namespace = "namespace1";

--- a/webserver/src/test/java/io/kestra/webserver/filter/AuthenticationFilterTest.java
+++ b/webserver/src/test/java/io/kestra/webserver/filter/AuthenticationFilterTest.java
@@ -147,7 +147,8 @@ class AuthenticationFilterTest {
                     "/api/v1/basicAuth", new BasicAuthCredentials(
                         IdUtils.create(),
                         "anonymous@hacker",
-                        "hackerPassword1"
+                        "hackerPassword1",
+                        basicAuthConfiguration.getPassword()
                     )
                 ).basicAuth(basicAuthConfiguration.getUsername(), basicAuthConfiguration.getPassword())
             );

--- a/webserver/src/test/java/io/kestra/webserver/services/BasicAuthServiceTest.java
+++ b/webserver/src/test/java/io/kestra/webserver/services/BasicAuthServiceTest.java
@@ -472,6 +472,30 @@ class BasicAuthServiceTest {
     }
 
     @Test
+    void shouldRejectRevokedCredential_onPeerNodeSharingSameSettingsStore() {
+        // Given – two BasicAuthService instances simulate two webserver nodes in an HA
+        // deployment sharing one settings store, each with its own in-process cache.
+        var sharedSettingsRepo = new InMemorySettingRepository();
+        var nodeA = new BasicAuthService(sharedSettingsRepo, yamlBasicAuthConfiguration, instanceService, ApplicationEventPublisher.noOp());
+        var nodeB = new BasicAuthService(sharedSettingsRepo, yamlBasicAuthConfiguration, instanceService, ApplicationEventPublisher.noOp());
+        nodeA.init();
+
+        HttpRequest<?> oldPasswordRequest = HttpRequest.GET("/test")
+            .basicAuth("admin@kestra.io", "Kestra123");
+
+        // nodeB caches a positive verification for the soon-to-be-revoked password
+        assertThat(nodeB.isAuthenticated(oldPasswordRequest)).isTrue();
+
+        // When – the password is rotated through nodeA only; nodeB's cache is never told
+        nodeA.save(new BasicAuthCredentials(null, "admin@kestra.io", "NewPassword1"));
+
+        // Then – nodeB must not keep accepting the revoked credential from its stale cache
+        assertThat(nodeB.isAuthenticated(oldPasswordRequest))
+            .as("a credential revoked on one node must not remain valid on a peer sharing the same settings store")
+            .isFalse();
+    }
+
+    @Test
     void shouldRejectAuthentication_withUnmigratedSha512StoredPassword() {
         // Given – simulate a pre-migration row where the password is stored as plain SHA-512
         // (as it would be before V2_0_04BasicAuthPasswordMigration runs).
@@ -538,6 +562,50 @@ class BasicAuthServiceTest {
         var basicAuthService = new BasicAuthService(tmpSettingsRepo, null, instanceService, ApplicationEventPublisher.noOp());
 
         assertThat(basicAuthService.validateCredentials("admin@kestra.io", "Kestra123")).isFalse();
+    }
+
+    @Test
+    void shouldValidateCurrentPassword_withCorrectPassword() {
+        var tmpSettingsRepo = new InMemorySettingRepository();
+        var basicAuthService = new BasicAuthService(tmpSettingsRepo, yamlBasicAuthConfiguration, instanceService, ApplicationEventPublisher.noOp());
+        basicAuthService.init();
+
+        assertThat(basicAuthService.validateCurrentPassword("Kestra123")).isTrue();
+    }
+
+    @Test
+    void shouldNotValidateCurrentPassword_withWrongPassword() {
+        var tmpSettingsRepo = new InMemorySettingRepository();
+        var basicAuthService = new BasicAuthService(tmpSettingsRepo, yamlBasicAuthConfiguration, instanceService, ApplicationEventPublisher.noOp());
+        basicAuthService.init();
+
+        assertThat(basicAuthService.validateCurrentPassword("WrongPassword1")).isFalse();
+        assertThat(basicAuthService.validateCurrentPassword(null)).isFalse();
+    }
+
+    @Test
+    void shouldNotValidateCurrentPassword_whenNotInitialized() {
+        var tmpSettingsRepo = new InMemorySettingRepository();
+        var basicAuthService = new BasicAuthService(tmpSettingsRepo, null, instanceService, ApplicationEventPublisher.noOp());
+
+        assertThat(basicAuthService.validateCurrentPassword("Kestra123")).isFalse();
+    }
+
+    @Test
+    void shouldNotValidateCurrentPassword_forARevokedPassword_evenIfCachedByIsAuthenticated() {
+        // A password already rotated away from must never pass as "current", even though
+        // isAuthenticated() cached it as valid moments earlier: validateCurrentPassword always
+        // re-checks the live stored credentials rather than that cache.
+        var tmpSettingsRepo = new InMemorySettingRepository();
+        var basicAuthService = new BasicAuthService(tmpSettingsRepo, yamlBasicAuthConfiguration, instanceService, ApplicationEventPublisher.noOp());
+        basicAuthService.init();
+
+        HttpRequest<?> oldRequest = HttpRequest.GET("/test").basicAuth("admin@kestra.io", "Kestra123");
+        assertThat(basicAuthService.isAuthenticated(oldRequest)).isTrue();
+
+        basicAuthService.save(new BasicAuthCredentials(null, "admin@kestra.io", "NewPassword1"));
+
+        assertThat(basicAuthService.validateCurrentPassword("Kestra123")).isFalse();
     }
 
     @Test


### PR DESCRIPTION
### 🔗 Related Issue

Related advisory: https://github.com/kestra-io/kestra/security/advisories/GHSA-94pv-f379-3gp3 (private security advisory, no public issue to close).

### ✨ Description

In a multi-webserver-node deployment sharing one settings store, `BasicAuthService.isAuthenticated()` cached a verified Basic-Auth token by the SHA-256 of the raw token alone. When an admin rotated the password on node A, only node A's local cache was cleared — a peer node B that had already verified the old token kept accepting it indefinitely, since nothing ever told node B the credentials had changed. That still-accepted, already-revoked credential could then be replayed against `POST /{tenant}/basicAuth` on node B to overwrite the shared admin password, giving a revoked credential holder persistent admin takeover across the cluster.

Two independent changes close this:

1. **`BasicAuthService`**: the auth cache is now keyed by `(token hash, credentials fingerprint)` instead of the token hash alone. The fingerprint is re-derived from the credentials fetched fresh from the shared settings store on every call, so a password rotation on *any* node invalidates the cache on *every* node's very next request — no cross-node signalling needed.
2. **`MiscController#createBasicAuth`**: changing already-initialized Basic Authentication credentials now also requires proving the *current* password via a new, always-fresh (never cached) check — closing the escalation path even independent of fix 1. This only applies once credentials already exist; first-time setup is unaffected, and the new field is optional so it never breaks a caller that doesn't send it.

Verified the UI never calls this endpoint to change an existing password (only for first-time setup, which redirects away once already initialized), so no frontend change is needed.

### 🛠️ Backend Checklist

- [x] Code compiles and tests pass for the touched modules (`./gradlew :webserver:test`, plus `:webserver:flakyTest` for the pre-existing-flaky-tagged tests in `MiscControllerTest`)
- [x] New behavior is covered by unit or integration tests, including a regression test simulating two webserver nodes sharing one settings store, which fails on the pre-fix code

### 📝 Additional Notes

No cross-node messaging/queue was introduced — the fix relies on the fact that credentials are already re-fetched from the shared store on every authentication check, so binding the cache to their fingerprint is enough to self-invalidate cluster-wide.

### 🤖 AI Authors

Why was the cat kicked out of the Kestra cluster? It kept caching mice on one node and refusing to admit they'd already been revoked on the other. 🐱