### PR TITLE
fix(ui): format duration aggregations in dashboard chart legends

### DIFF
--- a/ui/src/components/dashboard/sections/Bar.vue
+++ b/ui/src/components/dashboard/sections/Bar.vue
@@ -15,6 +15,7 @@
                 v-if="showLegend"
                 :items="legendItems"
                 :chart="ksBarRef"
+                :formatValue="isDurationAgg() ? durationUtils.humanDuration : undefined"
                 @toggle="onLegendToggle"
             />
             <KsBar

--- a/ui/src/components/dashboard/sections/ChartLegend.vue
+++ b/ui/src/components/dashboard/sections/ChartLegend.vue
@@ -8,7 +8,7 @@
             @click="toggle(item.label)"
         >
             <span :style="swatchStyle(item.color)" />
-            {{ displayLabel(item.label) }} ({{ item.count }})
+            {{ displayLabel(item.label) }} ({{ formatCount(item.count) }})
         </span>
 
         <KsTooltip v-if="hidden.length" placement="top">
@@ -22,7 +22,7 @@
                     >
                         <span :style="swatchStyle(item.color)" />
                         <span style="flex:1;">{{ displayLabel(item.label) }}</span>
-                        <span>{{ item.count }}</span>
+                        <span>{{ formatCount(item.count) }}</span>
                     </span>
                 </div>
             </template>
@@ -58,11 +58,13 @@
         durationLabel?: string;
         center?: boolean;
         chart?: {getEchartsInstance: () => EChartsType | null} | null;
+        formatValue?: (value: number) => string;
     }>(), {
         maxVisible: 5,
         durationLabel: undefined,
         center: false,
         chart: null,
+        formatValue: undefined,
     })
 
     const emit = defineEmits<{toggle: [name: string]}>()
@@ -90,6 +92,8 @@
         props.chart?.getEchartsInstance?.()?.dispatchAction({type: "legendToggleSelect", name})
         emit("toggle", name)
     }
+
+    const formatCount = (count: number) => props.formatValue?.(count) ?? String(count)
 
     const displayLabel = (label: string) =>
         label.replace(/\w\S*/g, (word) => word.charAt(0).toUpperCase() + word.slice(1).toLowerCase())

--- a/ui/src/components/dashboard/sections/Pie.vue
+++ b/ui/src/components/dashboard/sections/Pie.vue
@@ -27,6 +27,7 @@
             :maxVisible="6"
             center
             :chart="ksPieRef"
+            :formatValue="isDuration ? durationUtils.humanDuration : undefined"
         />
     </div>
 </template>

--- a/ui/tests/unit/dashboard/ChartLegend.spec.ts
+++ b/ui/tests/unit/dashboard/ChartLegend.spec.ts
@@ -16,4 +16,20 @@ describe("ChartLegend", () => {
         expect(wrapper.text()).toContain("Info (1292)")
         expect(wrapper.text()).toContain("Error (61)")
     })
+
+    test("renders duration aggregations through the provided formatter", () => {
+        const wrapper = mount(ChartLegend, {
+            props: {
+                items: [
+                    {label: "SUCCESS", color: "#028090", count: 6.3},
+                    {label: "FAILED", color: "#F05A5A", count: 0.11},
+                ],
+                formatValue: (value: number) => `${value.toFixed(2)}s`,
+            },
+        })
+
+        expect(wrapper.text()).toContain("Success (6.30s)")
+        expect(wrapper.text()).toContain("Failed (0.11s)")
+        expect(wrapper.text()).not.toContain("(6.3)")
+    })
 })


### PR DESCRIPTION
closes https://github.com/kestra-io/kestra-ee/issues/10185

This pull request improves the formatting of values displayed in chart legends within the dashboard components. The main enhancement is the introduction of a flexible value formatting mechanism, allowing legends to display human-friendly representations—such as durations—when appropriate. This is achieved by passing a formatting function to the `ChartLegend` component, which is then used to render legend item values.

**Enhancements to chart legend value formatting:**

* Added a new `formatValue` prop to the `ChartLegend` component, enabling custom formatting of legend item values (e.g., for durations) (`ui/src/components/dashboard/sections/ChartLegend.vue`).
* Updated the `Bar.vue` and `Pie.vue` dashboard section components to pass a duration formatting function to `ChartLegend` when displaying duration aggregations (`ui/src/components/dashboard/sections/Bar.vue`, `ui/src/components/dashboard/sections/Pie.vue`) [[1]](diffhunk://#diff-00cccb97c154db4abbc653d8a20a183afff705f3e5a2692f4afbfeed40a6ae09R18) [[2]](diffhunk://#diff-d20d7c05f4c605cc88887abfa2ece9cbbb3335de814c42f32c0b56d531696ab6R30).

**User interface improvements:**

* Modified the legend item rendering in `ChartLegend` to use the new formatting function for displaying item counts, ensuring consistent and human-readable values in both main and overflow legend sections (`ui/src/components/dashboard/sections/ChartLegend.vue`) [[1]](diffhunk://#diff-3ab84340724224a1861beeddaf800bb795c251febc43465c15af64e62ae3cfbeL11-R11) [[2]](diffhunk://#diff-3ab84340724224a1861beeddaf800bb795c251febc43465c15af64e62ae3cfbeL25-R25) [[3]](diffhunk://#diff-3ab84340724224a1861beeddaf800bb795c251febc43465c15af64e62ae3cfbeR96-R97).

**Testing:**

* Added a unit test to verify that the `ChartLegend` component correctly formats values using the provided formatter function, ensuring accurate and user-friendly display of duration values (`ui/tests/unit/dashboard/ChartLegend.spec.ts`).