### PR TITLE
fix(executions): map oversized payloads to 413 instead of a raw 500

### DIFF
--- a/core/src/main/java/io/kestra/core/services/WebhookService.java
+++ b/core/src/main/java/io/kestra/core/services/WebhookService.java
@@ -23,6 +23,7 @@ import io.kestra.core.models.flows.FlowInterface;
 import io.kestra.core.models.flows.State;
 import io.kestra.core.models.triggers.AbstractTrigger;
 import io.kestra.core.queues.DispatchQueueInterface;
+import io.kestra.core.queues.MessageTooBigException;
 import io.kestra.core.runners.FlowInputOutput;
 import io.kestra.core.runners.FlowMetaStoreInterface;
 import io.kestra.core.runners.FlowMetaStores;
@@ -44,6 +45,7 @@ import io.opentelemetry.context.propagation.ContextPropagators;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 import lombok.extern.slf4j.Slf4j;
+import reactor.core.Exceptions;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
@@ -234,6 +236,9 @@ public class WebhookService {
                 try {
                     executionCommandQueue.emit(command.withOperationId(operationId));
                     eventPublisher.publishEvent(CrudEvent.create(execution));
+                } catch (MessageTooBigException e) {
+                    // Propagate the typed exception so the ErrorController handler maps it to 413.
+                    throw Exceptions.propagate(e);
                 } catch (Exception e) {
                     throw new RuntimeException(e);
                 }

--- a/core/src/main/java/io/kestra/core/services/WebhookService.java
+++ b/core/src/main/java/io/kestra/core/services/WebhookService.java
@@ -23,7 +23,6 @@ import io.kestra.core.models.flows.FlowInterface;
 import io.kestra.core.models.flows.State;
 import io.kestra.core.models.triggers.AbstractTrigger;
 import io.kestra.core.queues.DispatchQueueInterface;
-import io.kestra.core.queues.MessageTooBigException;
 import io.kestra.core.runners.FlowInputOutput;
 import io.kestra.core.runners.FlowMetaStoreInterface;
 import io.kestra.core.runners.FlowMetaStores;
@@ -236,11 +235,10 @@ public class WebhookService {
                 try {
                     executionCommandQueue.emit(command.withOperationId(operationId));
                     eventPublisher.publishEvent(CrudEvent.create(execution));
-                } catch (MessageTooBigException e) {
-                    // Propagate the typed exception so the ErrorController handler maps it to 413.
-                    throw Exceptions.propagate(e);
                 } catch (Exception e) {
-                    throw new RuntimeException(e);
+                    // Exceptions.propagate rethrows a runtime as-is and wraps a checked one, so a MessageTooBigException
+                    // stays its real type and the ErrorController handler can map it to 413.
+                    throw Exceptions.propagate(e);
                 }
             },
             asyncOperationsConfiguration.waitTimeout()

--- a/core/src/main/java/io/kestra/plugin/core/trigger/Webhook.java
+++ b/core/src/main/java/io/kestra/plugin/core/trigger/Webhook.java
@@ -15,6 +15,7 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import io.kestra.core.exceptions.InternalException;
+import io.kestra.core.queues.MessageTooBigException;
 import io.kestra.core.http.HttpRequest;
 import io.kestra.core.http.HttpResponse;
 import io.kestra.core.models.annotations.Example;
@@ -32,6 +33,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
+import reactor.core.Exceptions;
 import reactor.core.publisher.Mono;
 
 @SuperBuilder
@@ -275,7 +277,16 @@ public class Webhook extends AbstractWebhookTrigger implements TriggerOutput<Web
                         }
                     });
             })
-            .onErrorReturn(HttpResponse.of(HttpResponse.Status.INTERNAL_SERVER_ERROR));
+            .onErrorResume(e ->
+            {
+                // A body too large to enqueue is propagated so the ErrorController handler maps it to 413; any
+                // other error becomes a 500.
+                Throwable unwrapped = Exceptions.unwrap(e);
+                if (unwrapped instanceof MessageTooBigException) {
+                    return Mono.error(unwrapped);
+                }
+                return Mono.just(HttpResponse.of(HttpResponse.Status.INTERNAL_SERVER_ERROR));
+            });
     }
 
     private HttpResponse<?> buildOutputResponse(Object body, String responseContentType, HttpResponse.Status responseCode) {

--- a/core/src/test/resources/flows/valids/message-protection-input.yaml
+++ b/core/src/test/resources/flows/valids/message-protection-input.yaml
@@ -1,0 +1,11 @@
+id: message-protection-input
+namespace: io.kestra.tests
+
+inputs:
+  - id: v
+    type: STRING
+
+tasks:
+  - id: log
+    type: io.kestra.plugin.core.log.Log
+    message: ok

--- a/webserver/src/main/java/io/kestra/webserver/controllers/ErrorController.java
+++ b/webserver/src/main/java/io/kestra/webserver/controllers/ErrorController.java
@@ -15,6 +15,7 @@ import com.fasterxml.jackson.databind.exc.InvalidFormatException;
 import com.fasterxml.jackson.databind.exc.InvalidTypeIdException;
 
 import io.kestra.core.exceptions.*;
+import io.kestra.core.queues.MessageTooBigException;
 import io.kestra.core.utils.RegexUtils;
 import io.kestra.libs.copilot.exceptions.AiException;
 
@@ -194,6 +195,12 @@ public class ErrorController {
     @Error(global = true)
     public HttpResponse<JsonError> error(HttpRequest<?> request, HttpStatusException e) {
         return jsonError(request, e, e.getStatus(), e.getStatus().getReason());
+    }
+
+    @Error(global = true)
+    public HttpResponse<JsonError> error(HttpRequest<?> request, MessageTooBigException e) {
+        // The request exceeds the queue message-size limit, which is a client-input problem: surface it as 413.
+        return jsonError(request, e, HttpStatus.REQUEST_ENTITY_TOO_LARGE, "Request entity too large");
     }
 
     @Error(global = true)

--- a/webserver/src/main/java/io/kestra/webserver/controllers/api/ExecutionController.java
+++ b/webserver/src/main/java/io/kestra/webserver/controllers/api/ExecutionController.java
@@ -59,7 +59,6 @@ import io.kestra.core.preview.FilePreview;
 import io.kestra.core.preview.FileRenderer;
 import io.kestra.core.queues.BroadcastQueueInterface;
 import io.kestra.core.queues.DispatchQueueInterface;
-import io.kestra.core.queues.MessageTooBigException;
 import io.kestra.core.queues.QueueException;
 import io.kestra.core.repositories.ArrayListTotal;
 import io.kestra.core.repositories.ExecutionRepositoryInterface;
@@ -3037,11 +3036,10 @@ public class ExecutionController {
             {
                 try {
                     emit.accept(operationId);
-                } catch (MessageTooBigException e) {
-                    // Propagate the typed exception so the ErrorController handler maps it to 413.
-                    throw Exceptions.propagate(e);
                 } catch (QueueException e) {
-                    throw new RuntimeException(e);
+                    // Exceptions.propagate rethrows a runtime as-is and wraps a checked one, so a MessageTooBigException
+                    // stays its real type and the ErrorController handler can map it to 413.
+                    throw Exceptions.propagate(e);
                 }
             },
             asyncOperationsConfiguration.waitTimeout()

--- a/webserver/src/main/java/io/kestra/webserver/controllers/api/ExecutionController.java
+++ b/webserver/src/main/java/io/kestra/webserver/controllers/api/ExecutionController.java
@@ -59,6 +59,7 @@ import io.kestra.core.preview.FilePreview;
 import io.kestra.core.preview.FileRenderer;
 import io.kestra.core.queues.BroadcastQueueInterface;
 import io.kestra.core.queues.DispatchQueueInterface;
+import io.kestra.core.queues.MessageTooBigException;
 import io.kestra.core.queues.QueueException;
 import io.kestra.core.repositories.ArrayListTotal;
 import io.kestra.core.repositories.ExecutionRepositoryInterface;
@@ -142,6 +143,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
 import lombok.extern.slf4j.Slf4j;
+import reactor.core.Exceptions;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.FluxSink;
 import reactor.core.publisher.Mono;
@@ -3035,6 +3037,9 @@ public class ExecutionController {
             {
                 try {
                     emit.accept(operationId);
+                } catch (MessageTooBigException e) {
+                    // Propagate the typed exception so the ErrorController handler maps it to 413.
+                    throw Exceptions.propagate(e);
                 } catch (QueueException e) {
                     throw new RuntimeException(e);
                 }

--- a/webserver/src/test/java/io/kestra/webserver/controllers/api/ExecutionControllerMessageProtectionTest.java
+++ b/webserver/src/test/java/io/kestra/webserver/controllers/api/ExecutionControllerMessageProtectionTest.java
@@ -1,0 +1,68 @@
+package io.kestra.webserver.controllers.api;
+
+import io.kestra.core.junit.annotations.KestraTest;
+import io.kestra.core.junit.annotations.LoadFlows;
+
+import io.micronaut.context.annotation.Property;
+import io.micronaut.http.HttpRequest;
+import io.micronaut.http.MediaType;
+import io.micronaut.http.client.annotation.Client;
+import io.micronaut.http.client.exceptions.HttpClientResponseException;
+import io.micronaut.http.client.multipart.MultipartBody;
+import io.micronaut.reactor.http.client.ReactorHttpClient;
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.Test;
+
+import static io.micronaut.http.HttpStatus.REQUEST_ENTITY_TOO_LARGE;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+// Enable the queue message-size guard at its production 1MB limit; raise the HTTP limits so an oversized payload
+// reaches the guard rather than being rejected by the server first.
+@KestraTest
+@Property(name = "kestra.queue.message-protection.enabled", value = "true")
+@Property(name = "kestra.queue.message-protection.limit", value = "1048576")
+@Property(name = "micronaut.server.max-request-size", value = "10485760")
+@Property(name = "micronaut.server.multipart.max-file-size", value = "10485760")
+class ExecutionControllerMessageProtectionTest {
+    @Inject
+    @Client("/")
+    ReactorHttpClient client;
+
+    private static final String OVERSIZED_VALUE = "x".repeat(2_000_000);
+
+    @Test
+    @LoadFlows("flows/valids/message-protection-input.yaml")
+    void largeInputReturnsRequestEntityTooLarge() {
+        MultipartBody body = MultipartBody.builder()
+            .addPart("v", OVERSIZED_VALUE)
+            .build();
+
+        HttpClientResponseException exception = assertThrows(
+            HttpClientResponseException.class,
+            () -> client.toBlocking().exchange(
+                HttpRequest
+                    .POST("/api/v1/main/executions/io.kestra.tests/message-protection-input", body)
+                    .contentType(MediaType.MULTIPART_FORM_DATA_TYPE)
+            )
+        );
+
+        assertThat(exception.getStatus().getCode()).isEqualTo(REQUEST_ENTITY_TOO_LARGE.getCode());
+    }
+
+    @Test
+    @LoadFlows("flows/valids/webhook.yaml")
+    void largeWebhookBodyReturnsRequestEntityTooLarge() {
+        HttpClientResponseException exception = assertThrows(
+            HttpClientResponseException.class,
+            () -> client.toBlocking().exchange(
+                HttpRequest
+                    .POST("/api/v1/main/executions/webhook/io.kestra.tests/webhook/a-secret-key", OVERSIZED_VALUE)
+                    .contentType(MediaType.TEXT_PLAIN_TYPE)
+            )
+        );
+
+        assertThat(exception.getStatus().getCode()).isEqualTo(REQUEST_ENTITY_TOO_LARGE.getCode());
+    }
+}


### PR DESCRIPTION
### What this PR does

Two bug-bash issues where a request whose payload exceeds the queue message-size limit (`kestra.queue.message-protection.limit`, 1MB by default) surfaced as an opaque `500` instead of a clear `4xx`:

- **Large flow input** (kestra-ee#10263) — executing a flow with an input value ≥1MB returned `500 Internal server error: io.kestra.core.queues.MessageTooBigException: …`.
- **Large webhook body** (kestra-ee#10260) — posting a body >1MB to a Webhook trigger returned an empty `500`.

Both are the same underlying `MessageTooBigException` thrown when the `ExecutionCommand` is enqueued.

### Fix

A single global `ErrorController` handler maps `MessageTooBigException` to **413 Request Entity Too Large**, so any endpoint hitting the queue guard behaves consistently. The callers that enqueue the command previously erased the exception's type before it could reach that handler, and are updated to let it through:

- `ExecutionController.awaitBlockingAction` and `WebhookService.startExecution` wrapped every `QueueException` in a plain `RuntimeException`; they now propagate `MessageTooBigException` with `Exceptions.propagate` so the reactive chain delivers it as its real type.
- `Webhook.evaluate` ended with a blanket `onErrorReturn(INTERNAL_SERVER_ERROR)` that masked every error; it now re-raises `MessageTooBigException` (mapped to 413 upstream) and keeps the 500 for other errors.

Not raising the queue limit (cluster-wide implications) — only turning the breach into a clean client error.

### Evidence

New `ExecutionControllerMessageProtectionTest` enables `message-protection` at the production 1MB limit and posts ~2MB payloads: a flow input and a webhook body both return **413**. Existing `ExecutionControllerTest`, `ErrorControllerTest`, `WebhookRoutingTest` and `WebhookPluginTest` stay green.

### EE issues (same fix, cross-repo — close manually on merge)

GitHub only auto-closes issues in this repo:

- https://github.com/kestra-io/kestra-ee/issues/10260
- https://github.com/kestra-io/kestra-ee/issues/10263
