### PR TITLE
fix(core): return 401 instead of 500 on a malformed basic-auth header

### DIFF
--- a/core/src/main/java/io/kestra/core/endpoints/BasicAuthEndpointsFilter.java
+++ b/core/src/main/java/io/kestra/core/endpoints/BasicAuthEndpointsFilter.java
@@ -23,6 +23,8 @@ import io.micronaut.web.router.RouteMatchUtils;
 @Filter("/**")
 @Requires(property = "endpoints.all.basic-auth")
 public class BasicAuthEndpointsFilter implements HttpServerFilter {
+    private static final String BASIC_PREFIX = HttpHeaderValues.AUTHORIZATION_PREFIX_BASIC + " ";
+
     private final EndpointBasicAuthConfiguration endpointBasicAuthConfiguration;
 
     public BasicAuthEndpointsFilter(EndpointBasicAuthConfiguration endpointBasicAuthConfiguration) {
@@ -47,22 +49,33 @@ public class BasicAuthEndpointsFilter implements HttpServerFilter {
 
     private boolean validateUser(HttpRequest<?> request) {
         final String authorization = request.getHeaders().get(HttpHeaders.AUTHORIZATION);
-        if (authorization != null && authorization.startsWith(HttpHeaderValues.AUTHORIZATION_PREFIX_BASIC)) {
-            String base64Credentials = authorization.substring(6);
-            byte[] credDecoded = Base64.getDecoder().decode(base64Credentials);
-            String credentials = new String(credDecoded, StandardCharsets.UTF_8);
-
-            final String[] values = credentials.split(":", 2);
-            if (values.length == 2) {
-                // Compare both operands without short-circuiting so a wrong username cannot be
-                // distinguished from a wrong password by response time (GHSA-38rc-2jxj-2h75).
-                boolean usernameMatches = AuthUtils.constantTimeEquals(this.endpointBasicAuthConfiguration.getUsername(), values[0]);
-                boolean passwordMatches = AuthUtils.constantTimeEquals(this.endpointBasicAuthConfiguration.getPassword(), values[1]);
-                return usernameMatches & passwordMatches;
-            }
+        if (authorization == null || !authorization.startsWith(BASIC_PREFIX)) {
+            return false;
         }
 
-        return false;
+        final Optional<String> credentials = decodeCredentials(authorization.substring(BASIC_PREFIX.length()));
+        if (credentials.isEmpty()) {
+            return false;
+        }
+
+        final String[] values = credentials.get().split(":", 2);
+        if (values.length != 2) {
+            return false;
+        }
+
+        // Compare both operands without short-circuiting so a wrong username cannot be
+        // distinguished from a wrong password by response time (GHSA-38rc-2jxj-2h75).
+        boolean usernameMatches = AuthUtils.constantTimeEquals(this.endpointBasicAuthConfiguration.getUsername(), values[0]);
+        boolean passwordMatches = AuthUtils.constantTimeEquals(this.endpointBasicAuthConfiguration.getPassword(), values[1]);
+        return usernameMatches & passwordMatches;
+    }
+
+    private static Optional<String> decodeCredentials(String base64Credentials) {
+        try {
+            return Optional.of(new String(Base64.getDecoder().decode(base64Credentials), StandardCharsets.UTF_8));
+        } catch (IllegalArgumentException e) {
+            return Optional.empty();
+        }
     }
 
     @Override

--- a/core/src/test/java/io/kestra/core/endpoints/BasicAuthEndpointsFilterTest.java
+++ b/core/src/test/java/io/kestra/core/endpoints/BasicAuthEndpointsFilterTest.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.Test;
 import io.micronaut.context.ApplicationContext;
 import io.micronaut.context.env.Environment;
 import io.micronaut.context.env.MapPropertySource;
+import io.micronaut.http.HttpHeaders;
 import io.micronaut.http.HttpRequest;
 import io.micronaut.http.HttpResponse;
 import io.micronaut.http.HttpStatus;
@@ -81,6 +82,29 @@ class BasicAuthEndpointsFilterTest {
             HttpClientResponseException e = assertThrows(HttpClientResponseException.class, () ->
             {
                 client.toBlocking().exchange(httpRequest.basicAuth("wrongUser", "bar"));
+            });
+
+            assertThat(e.getStatus().getCode()).isEqualTo(HttpStatus.UNAUTHORIZED.getCode());
+        });
+    }
+
+    @Test
+    void shouldReturnUnauthorizedWhenAuthorizationHeaderIsMalformed() {
+        test(true, (client, httpRequest) ->
+        {
+            HttpClientResponseException e = assertThrows(HttpClientResponseException.class, () ->
+            {
+                client.toBlocking().exchange(httpRequest.header(HttpHeaders.AUTHORIZATION, "Basic !!!not-base64!!!"));
+            });
+
+            assertThat(e.getStatus().getCode()).isEqualTo(HttpStatus.UNAUTHORIZED.getCode());
+        });
+
+        test(true, (client, httpRequest) ->
+        {
+            HttpClientResponseException e = assertThrows(HttpClientResponseException.class, () ->
+            {
+                client.toBlocking().exchange(httpRequest.header(HttpHeaders.AUTHORIZATION, "Basic"));
             });
 
             assertThat(e.getStatus().getCode()).isEqualTo(HttpStatus.UNAUTHORIZED.getCode());


### PR DESCRIPTION
## Summary

`BasicAuthEndpointsFilter.validateUser()` guards Micronaut management endpoints (`/health`, `/metrics`, ...) when `endpoints.all.basic-auth` is configured. Two malformed `Authorization` headers crashed instead of being rejected:

- `Authorization: Basic <invalid-base64>` threw an uncaught `IllegalArgumentException` from `Base64.getDecoder().decode()`.
- A bare `Authorization: Basic` header (no payload) threw `StringIndexOutOfBoundsException`, because `HttpHeaderValues.AUTHORIZATION_PREFIX_BASIC` is `"Basic"` (5 chars) but the code did `substring(6)`.

Both surfaced as a 500 instead of a 401, on a pre-auth path reachable by any unauthenticated caller once basic-auth is enabled on management endpoints.

## Fix

Restructured `validateUser` into guard clauses keyed off a single `BASIC_PREFIX` constant (fixing the off-by-one), and wrapped the Base64 decode in a `decodeCredentials()` helper that fails closed to `Optional.empty()` on invalid input. The constant-time credential comparison (`AuthUtils.constantTimeEquals` + non-short-circuiting `&`) is unchanged — that part was already fixed in f08b4a08b6.

Fixes https://github.com/kestra-io/kestra-ee/issues/10534. Its other point (non-constant-time comparison) was already fixed in f08b4a08b6; that issue will be closed by hand with a comment, since it's a cross-repo issue and won't auto-close from this PR.

## Evidence

- Added `shouldReturnUnauthorizedWhenAuthorizationHeaderIsMalformed` to `BasicAuthEndpointsFilterTest`, covering both malformed shapes — verified it fails (500/422) against the pre-fix code and passes after the fix.
- `./gradlew :core:test --tests "io.kestra.core.endpoints.BasicAuthEndpointsFilterTest"` — 4/4 passing.
- `./gradlew :core:test --tests "io.kestra.core.utils.AuthUtilsTest"` — passing, no regression.