### PR TITLE
fix(ui): add required indicator to setting row label

### DIFF
--- a/ui/src/components/settings/components/block/SettingRow.vue
+++ b/ui/src/components/settings/components/block/SettingRow.vue
@@ -1,7 +1,9 @@
 <template>
     <div class="setting-row" :class="{'setting-row--stacked': stacked}">
         <div class="setting-row__info">
-            <KsText tag="div" class="setting-row__label">{{ label }}</KsText>
+            <KsText tag="div" class="setting-row__label">
+                <span v-if="required" class="setting-row__required">*</span>{{ label }}
+            </KsText>
             <KsText v-if="description || $slots.description" tag="div" size="small" class="setting-row__description">
                 <slot name="description">{{ description }}</slot>
             </KsText>
@@ -17,6 +19,7 @@
         label: string
         description?: string
         stacked?: boolean
+        required?: boolean
     }>()
 </script>
 
@@ -44,6 +47,11 @@
             align-self: flex-start;
             font-weight: 600;
             color: var(--ks-text-primary);
+        }
+
+        &__required {
+            margin-right: var(--ks-spacing-1);
+            color: var(--ks-text-error);
         }
 
         &__description {


### PR DESCRIPTION
Part of https://github.com/kestra-io/kestra-ee/issues/10332

This pull request enhances the `SettingRow` component to support marking required fields more clearly in the UI. The main change is the addition of a visual indicator (an asterisk) for required settings, along with the necessary prop and styling updates.

**Required field indicator support:**

* Added a `required` prop to the `SettingRow` component, allowing parent components to specify if a setting is required.
* Updated the template to display a red asterisk before the label when the `required` prop is true.
* Added CSS styling for the required asterisk, using the error color and appropriate spacing.