### PR TITLE
fix(core): replay from a task run that moved in the requested flow revision

### DIFF
--- a/core/src/main/java/io/kestra/core/services/ExecutionService.java
+++ b/core/src/main/java/io/kestra/core/services/ExecutionService.java
@@ -430,12 +430,19 @@ public class ExecutionService {
         String newExecutionId) throws Exception {
         List<TaskRun> newTaskRuns = new ArrayList<>();
         if (taskRunId != null) {
-            GraphCluster graphCluster = GraphUtils.of(flow, execution);
-
             Set<String> taskRunToRestart = this.taskRunToRestart(
                 execution,
                 taskRun -> taskRun.getId().equals(taskRunId)
             );
+
+            GraphCluster graphCluster = GraphUtils.of(flow, execution);
+            if (!GraphUtils.hasTaskRun(graphCluster, taskRunId)) {
+                TaskRun replayedTaskRun = execution.findTaskRunByTaskRunId(taskRunId);
+                throw new IllegalArgumentException(
+                    "Cannot replay execution '%s' from task run '%s': task '%s' does not exist at the same position in revision %s of flow '%s'."
+                        .formatted(execution.getId(), taskRunId, replayedTaskRun.getTaskId(), flow.getRevision(), flow.getId())
+                );
+            }
 
             Map<String, String> mappingTaskRunId = this.mapTaskRunId(execution, false);
 

--- a/core/src/main/java/io/kestra/core/utils/GraphUtils.java
+++ b/core/src/main/java/io/kestra/core/utils/GraphUtils.java
@@ -178,6 +178,18 @@ public class GraphUtils {
             .collect(Collectors.toSet());
     }
 
+    /**
+     * A graph node carries a task run only when the flow revision the graph was built from
+     * still has that task at the same place in the hierarchy as the revision it ran on.
+     */
+    public static boolean hasTaskRun(GraphCluster graphCluster, String taskRunId) {
+        return nodes(graphCluster)
+            .stream()
+            .filter(AbstractGraphTask.class::isInstance)
+            .map(AbstractGraphTask.class::cast)
+            .anyMatch(node -> node.getTaskRun() != null && node.getTaskRun().getId().equals(taskRunId));
+    }
+
     private static Set<String> reachableEdgeSources(List<FlowGraph.Edge> edges, Set<String> fromUuids) {
         Map<String, List<FlowGraph.Edge>> edgesBySource = edges
             .stream()
@@ -637,15 +649,14 @@ public class GraphUtils {
     }
 
     private static List<TaskRun> findTaskRuns(Task task, Execution execution, TaskRun parent) {
-        List<TaskRun> taskRuns = execution != null ? execution.findTaskRunsByTaskId(task.getId()) : new ArrayList<>();
+        List<TaskRun> taskRuns = execution != null ? execution.findTaskRunsByTaskId(task.getId()) : List.of();
 
-        if (taskRuns.isEmpty()) {
-            return Collections.singletonList(null);
-        }
-
-        return taskRuns
+        List<TaskRun> matching = taskRuns
             .stream()
-            .filter(taskRun -> parent == null || (taskRun.getParentTaskRunId().equals(parent.getId())))
+            .filter(taskRun -> parent == null || parent.getId().equals(taskRun.getParentTaskRunId()))
             .toList();
+
+        // an empty result would drop the node from the graph and spin fillGraphDag's completion loop forever
+        return matching.isEmpty() ? Collections.singletonList(null) : matching;
     }
 }

--- a/core/src/test/java/io/kestra/core/runners/ExecutionServiceTest.java
+++ b/core/src/test/java/io/kestra/core/runners/ExecutionServiceTest.java
@@ -40,6 +40,7 @@ import lombok.extern.slf4j.Slf4j;
 
 import static io.kestra.core.tenant.TenantService.MAIN_TENANT;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
@@ -413,6 +414,36 @@ class ExecutionServiceTest {
 
         assertThat(restart.getFlowRevision()).isEqualTo(updated.getRevision());
         assertThat(restart.getVariables()).containsEntry("greeting", "Hello World");
+    }
+
+    @Test
+    @LoadFlows(value = { "flows/valids/replay-moved-task.yaml" }, tenantId = TENANT_1)
+    void shouldThrowWhenReplayingATaskThatMovedInTheRequestedRevision() throws Exception {
+        Execution execution = runnerUtils.runOne(TENANT_1, "io.kestra.tests", "replay-moved-task");
+        assertThat(execution.getState().getCurrent()).isEqualTo(State.Type.FAILED);
+        String standaloneTaskRunId = execution.findTaskRunsByTaskId("standalone").getFirst().getId();
+
+        // move "standalone" inside "seq" in the new revision
+        FlowWithSource flow = flowRepository.findByExecutionWithSource(execution);
+        String newSource = """
+            id: replay-moved-task
+            namespace: io.kestra.tests
+
+            tasks:
+              - id: seq
+                type: io.kestra.plugin.core.flow.Sequential
+                tasks:
+                  - id: standalone
+                    type: io.kestra.plugin.core.log.Log
+                    message: standalone moved inside seq
+                  - id: boom
+                    type: io.kestra.plugin.core.execution.Fail
+            """;
+        FlowWithSource updated = flowService.update(GenericFlow.fromYaml(flow.getTenantId(), newSource), flow);
+
+        assertThatThrownBy(() -> executionService.replay(execution, updated, standaloneTaskRunId, updated.getRevision(), Optional.empty()))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("standalone");
     }
 
     @Test

--- a/core/src/test/java/io/kestra/core/utils/GraphUtilsTest.java
+++ b/core/src/test/java/io/kestra/core/utils/GraphUtilsTest.java
@@ -1,5 +1,6 @@
 package io.kestra.core.utils;
 
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
@@ -24,6 +25,7 @@ import io.kestra.plugin.core.log.Log;
 import static io.kestra.core.tenant.TenantService.MAIN_TENANT;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
 
 class GraphUtilsTest {
     private static final int CHAIN_LONGER_THAN_A_RECURSIVE_WALK_CAN_FOLLOW = 2000;
@@ -133,7 +135,86 @@ class GraphUtilsTest {
             .doesNotContain("root.task_0");
     }
 
+    @Test
+    void shouldKeepTaskNodeWhenTaskRunMovedIntoAFlowable() throws Exception {
+        Flow flow = YamlParser.parse(
+            """
+                id: replay-moved-task
+                namespace: io.kestra.tests
+                tasks:
+                  - id: seq
+                    type: io.kestra.plugin.core.flow.Sequential
+                    tasks:
+                      - id: standalone
+                        type: io.kestra.plugin.core.log.Log
+                        message: hello
+                      - id: boom
+                        type: io.kestra.plugin.core.log.Log
+                        message: hello
+                """,
+            Flow.class
+        );
+        String executionId = IdUtils.create();
+        TaskRun seq = taskRun(executionId, flow, "seq", null);
+        TaskRun standalone = taskRun(executionId, flow, "standalone", null);
+        TaskRun boom = taskRun(executionId, flow, "boom", seq.getId());
+
+        Execution execution = Execution.newExecution(flow, List.of())
+            .toBuilder()
+            .id(executionId)
+            .taskRunList(List.of(seq, standalone, boom))
+            .build();
+
+        GraphCluster graph = GraphUtils.of(flow, execution);
+
+        assertThat(GraphUtils.hasTaskRun(graph, boom.getId())).isTrue();
+        assertThat(GraphUtils.hasTaskRun(graph, standalone.getId())).isFalse();
+    }
+
+    @Test
+    void shouldNotHangWhenADagTaskRunBelongsToAnotherParent() throws Exception {
+        Flow flow = YamlParser.parse(
+            """
+                id: replay-moved-dag-task
+                namespace: io.kestra.tests
+                tasks:
+                  - id: d
+                    type: io.kestra.plugin.core.flow.Dag
+                    tasks:
+                      - task:
+                          id: a
+                          type: io.kestra.plugin.core.log.Log
+                          message: hello
+                      - task:
+                          id: x
+                          type: io.kestra.plugin.core.log.Log
+                          message: hello
+                        dependsOn: [a]
+                """,
+            Flow.class
+        );
+        String executionId = IdUtils.create();
+        TaskRun d = taskRun(executionId, flow, "d", null);
+        TaskRun a = taskRun(executionId, flow, "a", d.getId());
+        TaskRun x = taskRun(executionId, flow, "x", null);
+
+        Execution execution = Execution.newExecution(flow, List.of())
+            .toBuilder()
+            .id(executionId)
+            .taskRunList(List.of(d, a, x))
+            .build();
+
+        assertTimeoutPreemptively(
+            Duration.ofSeconds(5),
+            () -> GraphUtils.of(flow, execution)
+        );
+    }
+
     private TaskRun taskRun(String executionId, Flow flow, String taskId) {
+        return taskRun(executionId, flow, taskId, null);
+    }
+
+    private TaskRun taskRun(String executionId, Flow flow, String taskId, String parentTaskRunId) {
         return TaskRun.builder()
             .id(IdUtils.create())
             .executionId(executionId)
@@ -141,6 +222,7 @@ class GraphUtilsTest {
             .namespace(flow.getNamespace())
             .flowId(flow.getId())
             .taskId(taskId)
+            .parentTaskRunId(parentTaskRunId)
             .state(new State())
             .build();
     }

--- a/core/src/test/resources/flows/valids/replay-moved-task.yaml
+++ b/core/src/test/resources/flows/valids/replay-moved-task.yaml
@@ -1,0 +1,12 @@
+id: replay-moved-task
+namespace: io.kestra.tests
+
+tasks:
+  - id: standalone
+    type: io.kestra.plugin.core.log.Log
+    message: standalone ran at top level
+  - id: seq
+    type: io.kestra.plugin.core.flow.Sequential
+    tasks:
+      - id: boom
+        type: io.kestra.plugin.core.execution.Fail


### PR DESCRIPTION
## Summary

Closes https://github.com/kestra-io/kestra-ee/issues/10529.

**Problem:** `POST /executions/{id}/replay?revision=N&taskRunId=X` returns HTTP 500 (NPE) whenever the flow revision used to build the replay graph moved the target task's position relative to a flowable (e.g. a task ran top-level, then a later revision nested it inside a `Sequential`). `GraphUtils.of(flow, execution)` builds the graph from the *requested* revision while `execution` carries task runs from the revision it *actually ran on* — `GraphUtils.findTaskRuns` then dereferenced a null `parentTaskRunId` once the walk descended past the top level, where the `parent == null` short-circuit no longer applies.

The same code path is also reachable from `restart(execution, flow, revision)` (via `removeWorkerTask`), and a null-check-only fix would have left a related bug: `fillGraphDag`'s completion loop only grows once a task run is matched, so an *empty* filter result (rather than an NPE) spins it forever. A null-check fix would also have let `GraphUtils.successors` silently match nothing for the orphaned task run, turning the 500 into a silently wrong replay instead of a clear error.

**Fix:**
- `GraphUtils.findTaskRuns` is now null-safe and never returns an empty list, closing both the NPE and the `fillGraphDag` hang.
- New `GraphUtils.hasTaskRun(GraphCluster, String)` checks whether a task run is actually represented in a built graph.
- `ExecutionService.replay` uses it to reject a replay target that has no place in the requested revision's structure with a clear `IllegalArgumentException` (422 via the webserver's existing handler), instead of NPEing or silently producing a broken execution.

**Known, deliberately out-of-scope gap:** replaying from an *unmoved* task when a *different* sibling moved into the same flowable is not rejected by this guard, and can still leave the new execution stuck `RUNNING`. Fixing that requires checking the entire preceding structure inside the target's enclosing flowable, not just the target itself — meaningfully more machinery than this bugfix should carry. Filing a follow-up issue for it.

## Evidence

- `GraphUtilsTest`: 2 new unit tests reproduce the NPE and the `fillGraphDag` hang directly (`shouldKeepTaskNodeWhenTaskRunMovedIntoAFlowable`, `shouldNotHangWhenADagTaskRunBelongsToAnotherParent`) — both fail on the commit before this fix.
- `ExecutionServiceTest`: new `shouldThrowWhenReplayingATaskThatMovedInTheRequestedRevision` end-to-end test, plus all 9 pre-existing replay tests (`replayEachSeq`, `replayEachPara`, `replayParallel`, `replayFlowable`, `replaySequentialWithErrorHandler`, `replayWithADynamicTask`, `replayDifferentRevision`, etc.) still pass, confirming no regression in loop sub-executions, dynamic task runs, or nested parallel/flowable replays.
- `H2RunnerTest`: 100/100 passing (mandatory for executor-touching changes per AGENTS.md).
- `core:test`: 3497/3498 passing — the one failure (`HttpClientTest.errorUnreachable`) is an unrelated pre-existing locale-dependent assertion, confirmed failing identically on unmodified `develop`.
- `webserver:ExecutionControllerRunnerTest`: 110/110 passing.