### PR TITLE
fix(core): reject unsatisfiable cron expressions

### DIFF
--- a/core/src/main/java/io/kestra/core/validations/validator/ScheduleValidator.java
+++ b/core/src/main/java/io/kestra/core/validations/validator/ScheduleValidator.java
@@ -1,5 +1,9 @@
 package io.kestra.core.validations.validator;
 
+import com.cronutils.model.Cron;
+import com.cronutils.model.time.ExecutionTime;
+
+import io.kestra.core.scheduler.SchedulerClock;
 import io.kestra.core.validations.ScheduleValidation;
 import io.kestra.plugin.core.trigger.Schedule;
 
@@ -23,9 +27,14 @@ public class ScheduleValidator implements ConstraintValidator<ScheduleValidation
 
         if (value.getCron() != null) { // if null, the standard @NotNull will do its job
             try {
-                // parseCron() now parses + validates on first call and caches the result,
-                // so repeated validation runs on the scheduler hot path are O(1).
-                value.parseCron();
+                Cron parsed = value.parseCron();
+                if (ExecutionTime.forCron(parsed).nextExecution(SchedulerClock.now()).isEmpty()) {
+                    context.disableDefaultConstraintViolation();
+                    context.buildConstraintViolationWithTemplate(
+                        "invalid cron expression '%s': no valid execution date exists".formatted(value.getCron())
+                    ).addConstraintViolation();
+                    return false;
+                }
             } catch (IllegalArgumentException e) {
                 context.disableDefaultConstraintViolation();
                 context.buildConstraintViolationWithTemplate("invalid cron expression '" + value.getCron() + "': " + e.getMessage())

--- a/core/src/main/java/io/kestra/core/validations/validator/ScheduleValidator.java
+++ b/core/src/main/java/io/kestra/core/validations/validator/ScheduleValidator.java
@@ -1,5 +1,9 @@
 package io.kestra.core.validations.validator;
 
+import java.time.DateTimeException;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+
 import com.cronutils.model.Cron;
 import com.cronutils.model.time.ExecutionTime;
 
@@ -28,7 +32,17 @@ public class ScheduleValidator implements ConstraintValidator<ScheduleValidation
         if (value.getCron() != null) { // if null, the standard @NotNull will do its job
             try {
                 Cron parsed = value.parseCron();
-                if (ExecutionTime.forCron(parsed).nextExecution(SchedulerClock.now()).isEmpty()) {
+                ZonedDateTime referenceDate = SchedulerClock.now();
+                if (value.getTimezone() != null) {
+                    try {
+                        referenceDate = referenceDate.withZoneSameInstant(ZoneId.of(value.getTimezone()));
+                    } catch (DateTimeException ignored) {
+                        // Invalid timezones are reported by @TimezoneId.
+                        return true;
+                    }
+                }
+
+                if (ExecutionTime.forCron(parsed).nextExecution(referenceDate).isEmpty()) {
                     context.disableDefaultConstraintViolation();
                     context.buildConstraintViolationWithTemplate(
                         "invalid cron expression '%s': no valid execution date exists".formatted(value.getCron())

--- a/core/src/test/java/io/kestra/core/validations/ScheduleValidationTest.java
+++ b/core/src/test/java/io/kestra/core/validations/ScheduleValidationTest.java
@@ -1,6 +1,7 @@
 package io.kestra.core.validations;
 
 import java.time.Duration;
+import java.util.List;
 
 import org.junit.jupiter.api.Test;
 
@@ -35,6 +36,35 @@ class ScheduleValidationTest {
 
         assertThat(modelValidator.isValid(build).isPresent()).isTrue();
         assertThat(modelValidator.isValid(build).get().getMessage()).contains("invalid cron expression");
+    }
+
+    @Test
+    void shouldRejectUnsatisfiableCronExpressions() {
+        for (String cron : List.of("0 0 30 2 *", "0 0 31 4 *", "0 0 31 6 *")) {
+            Schedule schedule = Schedule.builder()
+                .id(IdUtils.create())
+                .type(Schedule.class.getName())
+                .cron(cron)
+                .build();
+
+            var violation = modelValidator.isValid(schedule);
+
+            assertThat(violation).isPresent();
+            assertThat(violation.get().getMessage()).contains("invalid cron expression", cron);
+        }
+    }
+
+    @Test
+    void shouldAcceptSatisfiableCalendarCronExpressions() {
+        for (String cron : List.of("0 0 29 2 *", "0 0 31 1 *", "0 0 30 4 *")) {
+            Schedule schedule = Schedule.builder()
+                .id(IdUtils.create())
+                .type(Schedule.class.getName())
+                .cron(cron)
+                .build();
+
+            assertThat(modelValidator.isValid(schedule)).isEmpty();
+        }
     }
 
     @Test

--- a/core/src/test/java/io/kestra/core/validations/ScheduleValidationTest.java
+++ b/core/src/test/java/io/kestra/core/validations/ScheduleValidationTest.java
@@ -55,6 +55,23 @@ class ScheduleValidationTest {
     }
 
     @Test
+    void shouldNotReportCronValidationForInvalidTimezone() {
+        Schedule schedule = Schedule.builder()
+            .id(IdUtils.create())
+            .type(Schedule.class.getName())
+            .cron("* * * * *")
+            .timezone("Not/AZone")
+            .build();
+
+        var violation = modelValidator.isValid(schedule);
+
+        assertThat(violation).isPresent();
+        assertThat(violation.get().getMessage())
+            .contains("not a valid time-zone ID")
+            .doesNotContain("invalid cron expression");
+    }
+
+    @Test
     void shouldAcceptSatisfiableCalendarCronExpressions() {
         for (String cron : List.of("0 0 29 2 *", "0 0 31 1 *", "0 0 30 4 *")) {
             Schedule schedule = Schedule.builder()


### PR DESCRIPTION
### 🔗 Related Issue

Closes https://github.com/kestra-io/kestra/issues/18732.

### ✨ Description

Rejects cron expressions that are syntactically valid but can never produce an execution date, such as `0 0 30 2 *`.

The validator reuses cron-utils `ExecutionTime.nextExecution(...)` with Kestra’s existing current-time convention. This keeps valid cases such as February 29 on leap years accepted without introducing custom calendar rules.

### 🛠️ Backend Checklist

- [ ] Code compiles and tests pass for the touched module (`./gradlew :core:test --tests "io.kestra.core.validations.ScheduleValidationTest"`)
- [x] New behavior is covered by unit tests

### 📝 Additional Notes

Only `ScheduleValidator.java` and `ScheduleValidationTest.java` were changed. `Schedule.java`, frontend files, generated files, OpenAPI/YAML, and dependencies were left untouched.

The narrow test command could not run because the environment does not have Java 25 installed.

Why did the cron cat get rejected? It had no valid date to land on. 🐱