### PR TITLE
ci: point kestra-io/actions refs at propose-parallel-composite-actions

### DIFF
--- a/.github/workflows/e2e-scheduling.yml
+++ b/.github/workflows/e2e-scheduling.yml
@@ -20,7 +20,7 @@ concurrency:
 
 jobs:
   e2e:
-    uses: kestra-io/actions/.github/workflows/kestra-oss-e2e-tests.yml@main
+    uses: kestra-io/actions/.github/workflows/kestra-oss-e2e-tests.yml@propose-parallel-composite-actions
     secrets:
       OTLP_ENDPOINT: ${{ secrets.OTLP_ENDPOINT }}
       OTLP_HEADERS: ${{ secrets.OTLP_HEADERS }}
@@ -36,7 +36,7 @@ jobs:
       OTLP_ENDPOINT: ${{ secrets.OTLP_ENDPOINT }}
     steps:
       - name: OpenTelemetry - Export trace
-        uses: kestra-io/actions/actions/otel-collect@main
+        uses: kestra-io/actions/actions/otel-collect@propose-parallel-composite-actions
         if: ${{ env.OTLP_ENDPOINT != '' }}
         with:
           mode: export-all

--- a/.github/workflows/ee-openapi-result.yml
+++ b/.github/workflows/ee-openapi-result.yml
@@ -49,7 +49,7 @@ jobs:
 
       - name: Update PR comment
         if: steps.body.outputs.body != ''
-        uses: kestra-io/actions/actions/comment-update@main
+        uses: kestra-io/actions/actions/comment-update@propose-parallel-composite-actions
         env:
           BODY: ${{ steps.body.outputs.body }}
         with:

--- a/.github/workflows/global-create-new-release-branch.yml
+++ b/.github/workflows/global-create-new-release-branch.yml
@@ -33,7 +33,7 @@ jobs:
             exit 1;
           fi
       # Checkout
-      - uses: kestra-io/actions/composite/checkout-and-auth@main
+      - uses: kestra-io/actions/composite/checkout-and-auth@propose-parallel-composite-actions
         with:
           gh-app-id: ${{ secrets.GH_BOT_APP_ID }}
           gh-app-private-key: ${{ secrets.GH_BOT_PRIVATE_KEY }}
@@ -41,7 +41,7 @@ jobs:
           path: kestra
 
       # Setup build
-      - uses: kestra-io/actions/composite/setup-build@main
+      - uses: kestra-io/actions/composite/setup-build@propose-parallel-composite-actions
         id: build
         with:
           java-enabled: true

--- a/.github/workflows/global-push-base-image.yml
+++ b/.github/workflows/global-push-base-image.yml
@@ -108,7 +108,7 @@ jobs:
 
       - name: Slack - Notification
         if: ${{ failure() }}
-        uses: kestra-io/actions/composite/slack-status@main
+        uses: kestra-io/actions/composite/slack-status@propose-parallel-composite-actions
         with:
           webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
           channel: 'C09FF36GKE1'

--- a/.github/workflows/global-start-release.yml
+++ b/.github/workflows/global-start-release.yml
@@ -39,7 +39,7 @@ jobs:
 
       # Checkout
       - name: Checkout
-        uses: kestra-io/actions/composite/checkout-and-auth@main
+        uses: kestra-io/actions/composite/checkout-and-auth@propose-parallel-composite-actions
         with:
           gh-app-id: ${{ secrets.GH_BOT_APP_ID }}
           gh-app-private-key: ${{ secrets.GH_BOT_PRIVATE_KEY }}

--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -17,6 +17,7 @@ on:
           - "true"
           - "false"
 
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-main
   cancel-in-progress: true
@@ -30,7 +31,7 @@ jobs:
       # Targeting develop branch from develop — async, fire-and-forget full EE CI
       - name: Trigger EE Workflow (develop push, no payload)
         if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/develop' }}
-        uses: kestra-io/actions/composite/repository-dispatch@main
+        uses: kestra-io/actions/composite/repository-dispatch@propose-parallel-composite-actions
         with:
           gh-app-id: ${{ secrets.GH_BOT_APP_ID }}
           gh-app-private-key: ${{ secrets.GH_BOT_PRIVATE_KEY }}
@@ -56,7 +57,7 @@ jobs:
   backend-tests:
     name: Backend tests
     if: ${{ github.event.inputs.skip-test == 'false' || github.event.inputs.skip-test == '' }}
-    uses: kestra-io/actions/.github/workflows/kestra-oss-backend-tests.yml@main
+    uses: kestra-io/actions/.github/workflows/kestra-oss-backend-tests.yml@propose-parallel-composite-actions
     secrets:
       GITHUB_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
@@ -71,7 +72,7 @@ jobs:
   frontend-tests:
     name: Frontend tests
     if: ${{ github.event.inputs.skip-test == 'false' || github.event.inputs.skip-test == '' }}
-    uses: kestra-io/actions/.github/workflows/kestra-oss-frontend-tests.yml@main
+    uses: kestra-io/actions/.github/workflows/kestra-oss-frontend-tests.yml@propose-parallel-composite-actions
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
       GITHUB_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -81,7 +82,7 @@ jobs:
   design-system-frontend-tests:
     name: Design System Frontend tests
     if: ${{ github.event.inputs.skip-test == 'false' || github.event.inputs.skip-test == '' }}
-    uses: kestra-io/actions/.github/workflows/kestra-oss-designsystem-tests.yml@main
+    uses: kestra-io/actions/.github/workflows/kestra-oss-designsystem-tests.yml@propose-parallel-composite-actions
     secrets:
       GITHUB_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       OTLP_ENDPOINT: ${{ secrets.OTLP_ENDPOINT }}
@@ -91,7 +92,7 @@ jobs:
     name: Publish Docker
     needs: [backend-tests, frontend-tests, design-system-frontend-tests]
     if: "!failure() && !cancelled() && github.ref == 'refs/heads/develop'"
-    uses: kestra-io/actions/.github/workflows/kestra-oss-publish-docker.yml@main
+    uses: kestra-io/actions/.github/workflows/kestra-oss-publish-docker.yml@propose-parallel-composite-actions
     with:
       java-version: 25
       notify-in-slack-release-channel: false
@@ -103,7 +104,7 @@ jobs:
     name: Publish develop Maven
     needs: [ backend-tests, frontend-tests ]
     if: "!failure() && !cancelled() && github.ref == 'refs/heads/develop'"
-    uses: kestra-io/actions/.github/workflows/kestra-oss-publish-maven.yml@main
+    uses: kestra-io/actions/.github/workflows/kestra-oss-publish-maven.yml@propose-parallel-composite-actions
     secrets:
       SONATYPE_USER: ${{ secrets.SONATYPE_USER }}
       SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
@@ -132,7 +133,7 @@ jobs:
         run: cp build/executable/* build/executable/kestra && chmod +x build/executable/kestra
 
       - name: Generate and publish schema
-        uses: kestra-io/actions/composite/kestra/kestra-configuration-schema@main
+        uses: kestra-io/actions/composite/kestra/kestra-configuration-schema@propose-parallel-composite-actions
         with:
           kestra-version: develop
           executable-path: build/executable/kestra
@@ -142,7 +143,7 @@ jobs:
 
       - name: Slack - Schema generation failure
         if: failure()
-        uses: kestra-io/actions/composite/slack-status@main
+        uses: kestra-io/actions/composite/slack-status@propose-parallel-composite-actions
         with:
           webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
           channel: 'C09FF36GKE1'
@@ -159,7 +160,7 @@ jobs:
         if: ${{ contains(needs.*.result, 'failure') }}
       - name: Slack - Notification
         if: ${{ always() && contains(needs.*.result, 'failure') }}
-        uses: kestra-io/actions/composite/slack-status@main
+        uses: kestra-io/actions/composite/slack-status@propose-parallel-composite-actions
         with:
           webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
           channel: 'C09FF36GKE1'
@@ -174,7 +175,7 @@ jobs:
       OTLP_ENDPOINT: ${{ secrets.OTLP_ENDPOINT }}
     steps:
       - name: OpenTelemetry - Export trace
-        uses: kestra-io/actions/actions/otel-collect@main
+        uses: kestra-io/actions/actions/otel-collect@propose-parallel-composite-actions
         if: ${{ env.OTLP_ENDPOINT != '' }}
         with:
           mode: export-all

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -18,7 +18,7 @@ on:
 jobs:
   build-artifacts:
     name: Build Artifacts
-    uses: kestra-io/actions/.github/workflows/kestra-oss-build-artifacts.yml@main
+    uses: kestra-io/actions/.github/workflows/kestra-oss-build-artifacts.yml@propose-parallel-composite-actions
     secrets:
       OTLP_ENDPOINT: ${{ secrets.OTLP_ENDPOINT }}
       OTLP_HEADERS: ${{ secrets.OTLP_HEADERS }}
@@ -32,7 +32,7 @@ jobs:
 
   backend-tests:
     name: Backend tests
-    uses: kestra-io/actions/.github/workflows/kestra-oss-backend-tests.yml@main
+    uses: kestra-io/actions/.github/workflows/kestra-oss-backend-tests.yml@propose-parallel-composite-actions
     if: ${{ github.event.inputs.skip-test == 'false' || github.event.inputs.skip-test == '' }}
     secrets:
       GITHUB_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -44,7 +44,7 @@ jobs:
 
   frontend-tests:
     name: Frontend tests
-    uses: kestra-io/actions/.github/workflows/kestra-oss-frontend-tests.yml@main
+    uses: kestra-io/actions/.github/workflows/kestra-oss-frontend-tests.yml@propose-parallel-composite-actions
     if: ${{ github.event.inputs.skip-test == 'false' || github.event.inputs.skip-test == '' }}
     secrets:
       GITHUB_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -52,7 +52,7 @@ jobs:
 
   design-system-frontend-tests:
     name: Design System Frontend tests
-    uses: kestra-io/actions/.github/workflows/kestra-oss-designsystem-tests.yml@main
+    uses: kestra-io/actions/.github/workflows/kestra-oss-designsystem-tests.yml@propose-parallel-composite-actions
     if: ${{ github.event.inputs.skip-test == 'false' || github.event.inputs.skip-test == '' }}
     secrets:
       GITHUB_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -61,7 +61,7 @@ jobs:
     name: Publish Maven
     needs: [ backend-tests, frontend-tests, design-system-frontend-tests ]
     if: "!failure() && !cancelled()"
-    uses: kestra-io/actions/.github/workflows/kestra-oss-publish-maven.yml@main
+    uses: kestra-io/actions/.github/workflows/kestra-oss-publish-maven.yml@propose-parallel-composite-actions
     secrets:
       SONATYPE_USER: ${{ secrets.SONATYPE_USER }}
       SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
@@ -90,7 +90,7 @@ jobs:
         run: cp build/executable/* build/executable/kestra && chmod +x build/executable/kestra
 
       - name: Generate and publish schema
-        uses: kestra-io/actions/composite/kestra/kestra-configuration-schema@main
+        uses: kestra-io/actions/composite/kestra/kestra-configuration-schema@propose-parallel-composite-actions
         with:
           kestra-version: ${{ github.ref_name }}
           executable-path: build/executable/kestra
@@ -100,7 +100,7 @@ jobs:
 
       - name: Slack - Schema generation failure
         if: failure()
-        uses: kestra-io/actions/composite/slack-status@main
+        uses: kestra-io/actions/composite/slack-status@propose-parallel-composite-actions
         with:
           webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
           channel: 'C09FF36GKE1'
@@ -109,7 +109,7 @@ jobs:
     name: Github Release
     needs: [build-artifacts, backend-tests, frontend-tests]
     if: "!failure() && !cancelled()"
-    uses: kestra-io/actions/.github/workflows/kestra-oss-publish-github.yml@main
+    uses: kestra-io/actions/.github/workflows/kestra-oss-publish-github.yml@propose-parallel-composite-actions
     secrets: inherit
 
   otel-export-trace:
@@ -121,7 +121,7 @@ jobs:
       OTLP_ENDPOINT: ${{ secrets.OTLP_ENDPOINT }}
     steps:
       - name: OpenTelemetry - Export trace
-        uses: kestra-io/actions/actions/otel-collect@main
+        uses: kestra-io/actions/actions/otel-collect@propose-parallel-composite-actions
         if: ${{ env.OTLP_ENDPOINT != '' }}
         with:
           mode: export-all

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -227,7 +227,7 @@ jobs:
     name: Frontend - Tests
     needs: [file-changes]
     if: "needs.file-changes.outputs.ui == 'true'"
-    uses: kestra-io/actions/.github/workflows/kestra-oss-frontend-tests.yml@main
+    uses: kestra-io/actions/.github/workflows/kestra-oss-frontend-tests.yml@propose-parallel-composite-actions
     secrets:
       GITHUB_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
@@ -236,7 +236,7 @@ jobs:
     name: Frontend - Design System tests
     needs: [file-changes]
     if: "needs.file-changes.outputs.ui-design-system == 'true'"
-    uses: kestra-io/actions/.github/workflows/kestra-oss-designsystem-tests.yml@main
+    uses: kestra-io/actions/.github/workflows/kestra-oss-designsystem-tests.yml@propose-parallel-composite-actions
     secrets:
       GITHUB_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -244,7 +244,7 @@ jobs:
     name: Backend - Tests
     needs: file-changes
     if: "needs.file-changes.outputs.backend == 'true'"
-    uses: kestra-io/actions/.github/workflows/kestra-oss-backend-tests.yml@main
+    uses: kestra-io/actions/.github/workflows/kestra-oss-backend-tests.yml@propose-parallel-composite-actions
     secrets:
       GITHUB_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
@@ -264,7 +264,7 @@ jobs:
     # share artifacts (their runs hold no repo write token), so they keep
     # the E2E build-from-source fallback below.
     if: "(needs.file-changes.outputs.ui == 'true' || needs.file-changes.outputs.backend == 'true') && github.event.pull_request.head.repo.fork == false"
-    uses: kestra-io/actions/.github/workflows/kestra-oss-build-artifacts.yml@main
+    uses: kestra-io/actions/.github/workflows/kestra-oss-build-artifacts.yml@propose-parallel-composite-actions
     secrets:
       OTLP_ENDPOINT: ${{ secrets.OTLP_ENDPOINT }}
       OTLP_HEADERS: ${{ secrets.OTLP_HEADERS }}
@@ -277,7 +277,7 @@ jobs:
     # Runs when build-artifacts succeeded (prebuilt exe) or was skipped for a
     # fork (falls back to building from source); not when the build failed.
     if: "!cancelled() && needs.build-artifacts.result != 'failure' && (needs.file-changes.outputs.ui == 'true' || needs.file-changes.outputs.backend == 'true')"
-    uses: kestra-io/actions/.github/workflows/kestra-oss-e2e-tests.yml@main
+    uses: kestra-io/actions/.github/workflows/kestra-oss-e2e-tests.yml@propose-parallel-composite-actions
     secrets:
       OTLP_ENDPOINT: ${{ secrets.OTLP_ENDPOINT }}
       OTLP_HEADERS: ${{ secrets.OTLP_HEADERS }}
@@ -294,7 +294,7 @@ jobs:
     # otherwise let the reusable workflow build it from source itself.
     # Dependabot runs get a read-only GITHUB_TOKEN so it cannot publish an image : skip the job.
     if: "!cancelled() && needs.build-artifacts.result != 'failure' && github.actor != 'dependabot[bot]'"
-    uses: kestra-io/actions/.github/workflows/kestra-oss-pullrequest-publish-docker.yml@main
+    uses: kestra-io/actions/.github/workflows/kestra-oss-pullrequest-publish-docker.yml@propose-parallel-composite-actions
     with:
       java-version: 25
       skip-build: ${{ needs.build-artifacts.result == 'success' }}
@@ -308,7 +308,7 @@ jobs:
       OTLP_ENDPOINT: ${{ secrets.OTLP_ENDPOINT }}
     steps:
       - name: OpenTelemetry - Export trace
-        uses: kestra-io/actions/actions/otel-collect@main
+        uses: kestra-io/actions/actions/otel-collect@propose-parallel-composite-actions
         if: ${{ env.OTLP_ENDPOINT != '' }}
         with:
           mode: export-all

--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -28,7 +28,7 @@ jobs:
   publish-docker:
     name: Publish Docker
     if: startsWith(github.ref, 'refs/tags/v')
-    uses: kestra-io/actions/.github/workflows/kestra-oss-publish-docker.yml@main
+    uses: kestra-io/actions/.github/workflows/kestra-oss-publish-docker.yml@propose-parallel-composite-actions
     with:
       retag-latest: ${{ inputs.retag-latest }}
       retag-lts: ${{ inputs.retag-lts }}
@@ -44,7 +44,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    uses: kestra-io/actions/.github/workflows/kestra-oss-helm-release.yml@main
+    uses: kestra-io/actions/.github/workflows/kestra-oss-helm-release.yml@propose-parallel-composite-actions
     with:
       dry-run: ${{ inputs.dry-run }}
 
@@ -57,7 +57,7 @@ jobs:
       OTLP_ENDPOINT: ${{ secrets.OTLP_ENDPOINT }}
     steps:
       - name: OpenTelemetry - Export trace
-        uses: kestra-io/actions/actions/otel-collect@main
+        uses: kestra-io/actions/actions/otel-collect@propose-parallel-composite-actions
         if: ${{ env.OTLP_ENDPOINT != '' }}
         with:
           mode: export-all

--- a/.github/workflows/update-generated-sdk.yml
+++ b/.github/workflows/update-generated-sdk.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.repository == 'kestra-io/kestra'
     steps:
-      - uses: kestra-io/actions/composite/checkout-and-auth@main
+      - uses: kestra-io/actions/composite/checkout-and-auth@propose-parallel-composite-actions
         name: Checkout
         with:
           gh-app-id: ${{ secrets.GH_BOT_APP_ID }}
@@ -34,7 +34,7 @@ jobs:
         shell: bash
         run: echo "message=$(git log -1 --format=%s)" >> "$GITHUB_OUTPUT"
 
-      - uses: kestra-io/actions/composite/setup-build@main
+      - uses: kestra-io/actions/composite/setup-build@propose-parallel-composite-actions
         name: Setup - Build
         with:
           java-enabled: true

--- a/.github/workflows/vulnerabilities-check.yml
+++ b/.github/workflows/vulnerabilities-check.yml
@@ -22,7 +22,7 @@ jobs:
           fetch-depth: 0
 
       # Setup build
-      - uses: kestra-io/actions/composite/setup-build@main
+      - uses: kestra-io/actions/composite/setup-build@propose-parallel-composite-actions
         id: build
         with:
           java-enabled: true
@@ -64,7 +64,7 @@ jobs:
           fetch-depth: 0
 
       # Setup build
-      - uses: kestra-io/actions/composite/setup-build@main
+      - uses: kestra-io/actions/composite/setup-build@propose-parallel-composite-actions
         id: build
         with:
           java-enabled: false
@@ -102,7 +102,7 @@ jobs:
           fetch-depth: 0
 
       # Setup build
-      - uses: kestra-io/actions/composite/setup-build@main
+      - uses: kestra-io/actions/composite/setup-build@propose-parallel-composite-actions
         id: build
         with:
           java-enabled: false


### PR DESCRIPTION
## Summary
- Test consumer for [kestra-io/actions#218](https://github.com/kestra-io/actions/pull/218), which adds GitHub's parallel/background step controls (`parallel:`, `background:`, `wait:`) to the shared reusable workflows to overlap independent I/O-wait steps.
- Repoints every `uses: kestra-io/actions/...@main` reference in `.github/workflows/*.yml` to `@propose-parallel-composite-actions` so the full CI matrix here (`kestra-oss-backend-tests`, `kestra-oss-frontend-tests`, `kestra-oss-build-artifacts`, `kestra-oss-e2e-tests`, `kestra-oss-publish-docker`, `kestra-oss-helm-release`) exercises that branch for real, per the PR's own test plan.
- Companion PR in EE: kestra-io/kestra-ee#10572 (same branch name, same substitution against `kestra-ee-*` workflows).

**This is a temporary test pin — do not merge.** Revert to `@main` once kestra-io/actions#218 merges or is closed.

## Test plan
- [ ] Compare CI step timings before/after across the touched jobs
- [ ] Confirm no job regressions from the parallel/background step changes