### PR TITLE
fix(namespaces): clean 404 on directory reads and 409 for writes under a file

### DIFF
--- a/core/src/main/java/io/kestra/core/storages/InternalNamespace.java
+++ b/core/src/main/java/io/kestra/core/storages/InternalNamespace.java
@@ -260,6 +260,12 @@ public class InternalNamespace implements Namespace {
         // Throw if file not found OR if it's deleted
         NamespaceFileMetadata namespaceFileMetadata = findByPath(normalizedPath, revision).orElseThrow(() -> fileNotFound(normalizedPath, revision));
 
+        if (namespaceFileMetadata.isDirectory()) {
+            throw new FileNotFoundException(
+                "'%s' is a directory in namespace '%s', it has no content to read.".formatted(normalizedPath, namespace)
+            );
+        }
+
         return storage.get(tenant, namespace, resolveExistingRevisionUri(normalizedPath, namespaceFileMetadata.getRevision()));
     }
 
@@ -337,6 +343,8 @@ public class InternalNamespace implements Namespace {
     @Override
     public List<NamespaceFile> putFile(final Path path, final InputStream content, final Conflicts onAlreadyExist) throws IOException, URISyntaxException {
         final Path normalizedPath = NamespaceFile.normalize(path);
+
+        ensureNoFileInHierarchy(normalizedPath);
 
         Optional<NamespaceFileMetadata> inRepository = discardConflictingEntry(findByPath(normalizedPath, true), false, normalizedPath);
         int currentRevision = inRepository.map(NamespaceFileMetadata::getRevision).orElse(0);
@@ -450,6 +458,40 @@ public class InternalNamespace implements Namespace {
     }
 
     /**
+     * Rejects a write whose path runs through an existing file.
+     * <p>
+     * A file can never hold children, and the ancestor directories are created implicitly by the write, so
+     * such a path is only caught by the storage layer, which fails with a raw filesystem error surfacing as
+     * a 500 that exposes the absolute storage path.
+     *
+     * @throws ConflictException if any ancestor of the given path is an existing file.
+     */
+    private void ensureNoFileInHierarchy(Path path) throws IOException {
+        List<String> ancestors = new ArrayList<>();
+        String parentPath = NamespaceFileMetadata.parentPath(path.toString());
+        while (parentPath != null && !parentPath.equals("/")) {
+            // Directories are stored with a trailing slash, so looking the ancestors up without one only
+            // matches files.
+            ancestors.add(NamespaceFileMetadata.path(parentPath, false));
+            parentPath = NamespaceFileMetadata.parentPath(parentPath);
+        }
+
+        if (ancestors.isEmpty()) {
+            return;
+        }
+
+        stateStore.findByPaths(tenant, namespace, ancestors, false).stream()
+            .filter(Predicate.not(NamespaceFileMetadata::isDirectory))
+            .findFirst()
+            .ifPresent(file ->
+            {
+                throw new ConflictException(
+                    "Cannot create '%s' in namespace '%s': '%s' is a file, not a directory.".formatted(path, namespace, file.getPath())
+                );
+            });
+    }
+
+    /**
      * Make all parent directories for a given path.
      */
     private List<NamespaceFile> mkDirs(String path) throws IOException {
@@ -472,6 +514,8 @@ public class InternalNamespace implements Namespace {
     @Override
     public NamespaceFile createDirectory(Path path) throws IOException {
         final Path normalizedPath = NamespaceFile.normalize(path);
+
+        ensureNoFileInHierarchy(normalizedPath);
 
         discardConflictingEntry(findByPath(normalizedPath, true), true, normalizedPath);
 

--- a/storage-local/src/main/java/io/kestra/storage/local/LocalStorage.java
+++ b/storage-local/src/main/java/io/kestra/storage/local/LocalStorage.java
@@ -89,12 +89,22 @@ public class LocalStorage implements StorageInterface {
 
     @Override
     public InputStream get(String tenantId, @Nullable String namespace, URI uri) throws IOException {
-        return new BufferedInputStream(new FileInputStream(getLocalPath(tenantId, uri).toAbsolutePath().toString()));
+        return newInputStream(getLocalPath(tenantId, uri), uri);
     }
 
     @Override
     public InputStream getInstanceResource(@Nullable String namespace, URI uri) throws IOException {
-        return new BufferedInputStream(new FileInputStream(getInstancePath(uri).toAbsolutePath().toString()));
+        return newInputStream(getInstancePath(uri), uri);
+    }
+
+    private static InputStream newInputStream(Path path, URI uri) throws IOException {
+        try {
+            return new BufferedInputStream(new FileInputStream(path.toAbsolutePath().toString()));
+        } catch (FileNotFoundException e) {
+            // The JDK message carries the absolute server path, for a missing file as much as for a
+            // directory opened as a file.
+            throw newFileNotFound(uri, e);
+        }
     }
 
     @Override
@@ -185,6 +195,18 @@ public class LocalStorage implements StorageInterface {
         return new FileNotFoundException("File not found for URI: " + uri.toString());
     }
 
+    /**
+     * To prevent information disclosure, we don't include the cause exception message in the thrown exception.
+     * We log the original cause in DEBUG for analysis.
+     */
+    private static IOException newParentDirectoryFailure(URI uri, FileSystemException cause) {
+        log.debug("Cannot create the parent directory of {}", uri, cause);
+        if (cause instanceof FileAlreadyExistsException) {
+            return new FileAlreadyExistsException(uri.getPath(), null, "a file already exists in the parent hierarchy.");
+        }
+        return new IOException("Cannot create the parent directory of the URI: " + uri.toString());
+    }
+
     @Override
     public List<FileAttributes> listInstanceResource(@Nullable String namespace, URI uri) throws IOException {
         try (Stream<Path> stream = Files.list(getInstancePath(uri))) {
@@ -224,7 +246,12 @@ public class LocalStorage implements StorageInterface {
         // FileAlreadyExistsException) when the parent hierarchy cannot be created, unlike
         // File#mkdirs whose boolean result was previously ignored and let the subsequent
         // FileOutputStream fail with a misleading FileNotFoundException.
-        Files.createDirectories(file.toPath().getParent());
+        try {
+            Files.createDirectories(file.toPath().getParent());
+        } catch (FileSystemException e) {
+            // The message of a filesystem exception carries the absolute server path.
+            throw newParentDirectoryFailure(uri, e);
+        }
 
         try (InputStream data = storageObject.inputStream(); OutputStream outStream = new FileOutputStream(file)) {
             byte[] buffer = new byte[8 * 1024];

--- a/webserver/src/test/java/io/kestra/webserver/controllers/api/NamespaceFileControllerTest.java
+++ b/webserver/src/test/java/io/kestra/webserver/controllers/api/NamespaceFileControllerTest.java
@@ -290,6 +290,46 @@ class NamespaceFileControllerTest {
     }
 
     @Test
+    void getFileContentOnDirectoryReturnsCleanNotFound() throws IOException, URISyntaxException {
+        String namespace = TestsUtils.randomNamespace();
+        Namespace namespaceStorage = namespaceFactory.of(TENANT_ID, namespace, storageInterface);
+        namespaceStorage.putFile(Path.of("/t.txt"), new ByteArrayInputStream("Hello".getBytes()));
+
+        HttpClientResponseException e = assertThrows(
+            HttpClientResponseException.class,
+            () -> client.toBlocking().retrieve(HttpRequest.GET("/api/v1/main/namespaces/" + namespace + "/files?path=/"))
+        );
+
+        assertThat(e.getStatus().getCode()).isEqualTo(HttpStatus.NOT_FOUND.getCode());
+        String responseBody = e.getResponse().getBody(String.class).orElse("");
+        assertThat(responseBody).doesNotContain("_files");
+        assertThat(responseBody).doesNotContain("Is a directory");
+    }
+
+    @Test
+    void createFileUnderAnExistingFileReturnsCleanConflict() throws IOException, URISyntaxException {
+        String namespace = TestsUtils.randomNamespace();
+        Namespace namespaceStorage = namespaceFactory.of(TENANT_ID, namespace, storageInterface);
+        namespaceStorage.putFile(Path.of("/t.txt"), new ByteArrayInputStream("Hello".getBytes()));
+
+        MultipartBody body = MultipartBody.builder()
+            .addPart("fileContent", "child.txt", "Hello".getBytes())
+            .build();
+
+        HttpClientResponseException e = assertThrows(
+            HttpClientResponseException.class, () -> client.toBlocking().exchange(
+                HttpRequest.POST("/api/v1/main/namespaces/" + namespace + "/files?path=/t.txt/child.txt", body)
+                    .contentType(MediaType.MULTIPART_FORM_DATA_TYPE)
+            )
+        );
+
+        assertThat(e.getStatus().getCode()).isEqualTo(HttpStatus.CONFLICT.getCode());
+        String responseBody = e.getResponse().getBody(String.class).orElse("");
+        assertThat(responseBody).doesNotContain("_files");
+        assertThat(responseBody).doesNotContain("Internal server error");
+    }
+
+    @Test
     void createFileWithTooLongNameReturnsCleanError() {
         String namespace = TestsUtils.randomNamespace();
         String longName = "x".repeat(300) + ".txt";


### PR DESCRIPTION
Closes [https://github.com/kestra-io/kestra-ee/issues/10325](https://github.com/kestra-io/kestra-ee/issues/10325).

### ✨ Description

Two namespace-file error responses were wrong, and both are reachable from the Files panel:

1. **Directory read error:** `GET /namespaces/{ns}/files?path=/` asked the storage layer for the content of a directory. The JDK's own error came back to the caller as `404 Not Found: /app/storage/{tenant}/{ns}/_files (Is a directory)`, exposing the storage root, the tenant ID, and the namespace-to-directory mapping.
2. **Path collision error:** Creating a file whose parent path is an existing file (`/t.txt/child.txt`) reached the storage layer too, where `Files.createDirectories` cannot make a directory out of a file — returning a 500 carrying the same absolute path for what is actually a client error.

`InternalNamespace` now answers both cases itself:

* A directory read raises the same namespace-relative not-found used for a missing file, keeping the status unchanged while updating only the message.
* A write (file or directory) whose path runs through an existing file raises a `ConflictException` (409). The ancestor check uses a single `findByPaths` lookup of the path's ancestors without a trailing slash (since only directories are stored with one, any hit is a file). This also covers deeper paths like `/t.txt/a/b.txt`, which would otherwise bypass the immediate parent check and fail later in `mkDirs`.

`LocalStorage` no longer lets an absolute path escape in its own exceptions either, providing defense in depth for every other caller: the existing sanitization now covers both reads and parent-directory creation on write. The `FileAlreadyExistsException` from #17093 is preserved, naming the storage URI instead of the server path.