### PR TITLE
fix(core): mask secrets in log-to-file exception traces

### DIFF
--- a/core/src/main/java/io/kestra/core/runners/RunContextLogger.java
+++ b/core/src/main/java/io/kestra/core/runners/RunContextLogger.java
@@ -517,7 +517,7 @@ public class RunContextLogger implements Supplier<org.slf4j.Logger> {
             e = this.transform(e);
 
             try {
-                String line = PATTERN_LAYOUT.doLayout(e);
+                String line = replaceSecret(PATTERN_LAYOUT.doLayout(e));
                 fileOS.write(line.getBytes());
             } catch (IOException ex) {
                 // silently do nothing, the message will still be forwarded to the server log

--- a/core/src/test/java/io/kestra/core/runners/RunContextLoggerTest.java
+++ b/core/src/test/java/io/kestra/core/runners/RunContextLoggerTest.java
@@ -393,6 +393,29 @@ class RunContextLoggerTest {
     }
 
     @Test
+    void shouldMaskThrowableWhenLoggingToFile() throws Exception {
+        Flow flow = TestsUtils.mockFlow();
+        Execution execution = TestsUtils.mockExecution(flow, Map.of());
+        RunContextLogger runContextLogger = new RunContextLogger(
+            logEntryEmitter,
+            LogEntry.of(execution),
+            Level.TRACE,
+            true
+        );
+        String secret = "super-secret-value";
+        runContextLogger.usedSecret(secret);
+
+        runContextLogger.logger().error("Task failure {}", secret, new Exception("Task failure %s".formatted(secret)));
+
+        runContextLogger.closeLogFile();
+        String fileContent = java.nio.file.Files.readString(runContextLogger.getLogFile().toPath());
+        assertThat(fileContent)
+            .contains("Task failure ******")
+            .contains("java.lang.Exception: Task failure ******")
+            .doesNotContain(secret);
+    }
+
+    @Test
     void emitDynamicTaskRunLogs_seedsMDCWithDynamicTaskRunIdentity() {
         Flow flow = TestsUtils.mockFlow();
         Execution execution = TestsUtils.mockExecution(flow, Map.of());


### PR DESCRIPTION
Closes https://github.com/kestra-io/kestra/issues/18737.

---

### 🔗 Related Issue

When `logToFile: true` is enabled, the log statement is masked before formatting, but Logback appends the attached throwable during `PatternLayout.doLayout(e)`. Secrets contained in exception messages or stack traces can therefore reach the generated log file unmasked.

### ✨ Description

Applies the existing secret replacement pass to the final rendered file-log output, following the same post-render masking approach used by `ContextAppender` in #18283. This preserves the exception trace while preventing registered secrets from being written to the log file.

Adds a regression test covering a secret in both the formatted log message and the attached throwable output.

### 🛠️ Backend Checklist

- [ ] Code compiles and tests pass for the touched modules (`./gradlew :module-name:test`, or `./gradlew build` for cross-module changes)
- [x] New behavior is covered by unit or integration tests
