### PR TITLE
fix(executions): redesign the worker information dialog

### DIFF
--- a/ui/src/components/executions/ServiceInfo.vue
+++ b/ui/src/components/executions/ServiceInfo.vue
@@ -1,38 +1,85 @@
 <template>
-    <component
-        :is="component"
-        v-if="service != null"
-    >
-        <template #default>
-            <strong>{{ service.id }}</strong>: {{ $t("hostname") }}={{ service.server.hostname }}, {{ $t("version") }}={{ service.server.version }}, {{ $t("state") }}={{ service.state }}
-        </template>
-    </component>
+    <div v-if="service" class="service-info">
+        <div class="heading">
+            <KsId :value="service.id" :shrink="false" />
+            <KsExecutionStatus
+                v-if="service.state"
+                size="small"
+                :status="SERVICE_STATE_TO_EXECUTION_STATUS[service.state] || 'CREATED'"
+                :title="service.state"
+                :icon="false"
+            />
+        </div>
+        <dl class="props">
+            <KsText tag="dt" size="small">
+                {{ $t("type") }}
+            </KsText>
+            <KsText tag="dd" size="small">
+                {{ service.type }}
+            </KsText>
+            <KsText tag="dt" size="small">
+                {{ $t("hostname") }}
+            </KsText>
+            <KsText tag="dd" size="small">
+                {{ service.server?.hostname }}
+            </KsText>
+            <KsText tag="dt" size="small">
+                {{ $t("version") }}
+            </KsText>
+            <KsText tag="dd" size="small">
+                {{ service.server?.version }}
+            </KsText>
+        </dl>
+    </div>
+    <KsSkeleton v-else animated :rows="3" />
 </template>
 
 <script setup lang="ts">
     import {ref, onMounted} from "vue"
     import * as ServicesAPI from "@kestra-io/kestra-sdk/services"
+    import type {ServiceInstance} from "@kestra-io/kestra-sdk"
+    import {SERVICE_STATE_TO_EXECUTION_STATUS} from "../../utils/serviceState"
 
-    interface Props {
-        component?: string;
+    const props = defineProps<{
         serviceId: string;
-    }
-
-    const props = withDefaults(defineProps<Props>(), {
-        component: "b-button",
-    })
-
-    defineEmits<{
-        follow: []
     }>()
 
-    const service = ref()
+    const service = ref<ServiceInstance>()
 
-    const load = async () => {
+    onMounted(async () => {
         service.value = await ServicesAPI.service({id: props.serviceId})
-    }
-
-    onMounted(() => {
-        load()
     })
 </script>
+
+<style scoped lang="scss">
+    .service-info {
+        display: flex;
+        flex-direction: column;
+        gap: var(--ks-spacing-2);
+        padding-inline: var(--ks-spacing-3);
+
+        .heading {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            gap: var(--ks-spacing-2);
+        }
+
+        .props {
+            margin: 0;
+            display: grid;
+            grid-template-columns: max-content 1fr;
+            column-gap: var(--ks-spacing-4);
+            row-gap: var(--ks-spacing-1);
+
+            dt {
+                color: var(--ks-text-primary);
+            }
+
+            dd {
+                margin: 0;
+                color: var(--ks-text-secondary);
+            }
+        }
+    }
+</style>

--- a/ui/src/components/executions/WorkerInfo.vue
+++ b/ui/src/components/executions/WorkerInfo.vue
@@ -12,15 +12,18 @@
             appendToBody
         >
             <template #header>
-                <h5>{{ $t("worker information") }}</h5>
+                <h6 class="title">{{ $t("worker information") }}</h6>
             </template>
 
             <template #default>
-                <ol>
-                    <li v-for="item in taskRun.attempts" :key="item.id">
+                <div class="workers">
+                    <div v-for="(item, index) in taskRun.attempts" :key="item.id">
+                        <KsText v-if="taskRun.attempts.length > 1" tag="p" size="small" type="info" class="attempt">
+                            {{ $t("attempt") }} {{ index + 1 }}
+                        </KsText>
                         <ServiceInfo :serviceId="String(item.workerId)" />
-                    </li>
-                </ol>
+                    </div>
+                </div>
             </template>
 
             <template #footer>
@@ -35,7 +38,6 @@
 <script setup lang="ts">
     import {ref, computed} from "vue"
     import ServiceInfo from "./ServiceInfo.vue"
-
     import Server from "vue-material-design-icons/Server.vue"
 
     interface Attempt {
@@ -57,3 +59,25 @@
 
     const uuid = computed(() => `workerinfo-${props.taskRun.id}`)
 </script>
+
+<style scoped lang="scss">
+    .title {
+        font-weight: var(--ks-font-weight-semibold);
+    }
+
+    .workers {
+        display: flex;
+        flex-direction: column;
+        gap: var(--ks-spacing-3);
+
+        > div + div {
+            border-top: var(--ks-border-block-secondary);
+            padding-top: var(--ks-spacing-3);
+        }
+    }
+
+    .attempt {
+        margin-bottom: var(--ks-spacing-1);
+        padding-inline: var(--ks-spacing-3);
+    }
+</style>

--- a/ui/src/utils/serviceState.ts
+++ b/ui/src/utils/serviceState.ts
@@ -1,0 +1,15 @@
+import type {ServiceServiceState} from "@kestra-io/kestra-sdk"
+import type {ExecutionStatus} from "@kestra-io/design-system"
+
+export const SERVICE_STATE_TO_EXECUTION_STATUS: Record<ServiceServiceState, ExecutionStatus> = {
+    RUNNING: "SUCCESS",
+    ERROR: "FAILED",
+    DISCONNECTED: "FAILED",
+    INACTIVE: "PAUSED",
+    CREATED: "PAUSED",
+    MAINTENANCE: "WARNING",
+    NOT_RUNNING: "PAUSED",
+    TERMINATED_FORCED: "FAILED",
+    TERMINATED_GRACEFULLY: "PAUSED",
+    TERMINATING: "WARNING",
+}


### PR DESCRIPTION
The worker information dialog printed one raw text line per attempt; it now shows a compact card per attempt with the id, type, hostname, version and a state badge, using the same state severity mapping as the EE cluster page (moved to a shared util).

<img width="2110" height="1826" alt="image" src="https://github.com/user-attachments/assets/98ec4cac-1999-4d05-91b4-ceb727dcb287" />


EE PR: https://github.com/kestra-io/kestra-ee/pull/10586
