### PR TITLE
fix(plugins): include rule plugins in the icon index

### DIFF
--- a/webserver/src/main/java/io/kestra/webserver/controllers/api/PluginController.java
+++ b/webserver/src/main/java/io/kestra/webserver/controllers/api/PluginController.java
@@ -507,6 +507,7 @@ public class PluginController {
                     plugin.getLogExporters().stream(),
                     plugin.getApps().stream(),
                     plugin.getAppBlocks().stream(),
+                    plugin.getRules().stream(),
                     plugin.getAdditionalPlugins().stream()
                 )
                     .flatMap(i -> i)


### PR DESCRIPTION
### What

`RegisteredPlugin` exposes rule plugins (`RulePluginInterface`) as a first-class plugin category (`getRules()`), but `PluginController.pluginIconsIndex()` iterated every category **except** `getRules()`. As a result rule icons were never added to the plugin icon index, so `resolvePluginIcon` returned nothing for a rule class and the frontend fell back to the generic ecosystem-catalog glyph — even when the plugin shipped a bundled icon.

This adds `plugin.getRules().stream()` to the indexed categories.

### Why

Companion of the EE PR kestra-io/kestra-ee#10587, which adds the SVG icons for the policy rule plugins (Add / Delete / Deny / Require / Restrict). Those icons are inert without this change — the EE icons only render once rule plugins are part of the icon index.

### Validation

Verified end-to-end against a local EE standalone instance (H2): `/api/v1/plugins/icons` now lists the rule classes with a hash, and each rule renders its bundled icon in the Policies editor instead of the generic remote fallback.