### PR TITLE
fix(system): merge duplicate secrets block in pre-release build-artifacts job

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -22,13 +22,12 @@ jobs:
     secrets:
       OTLP_ENDPOINT: ${{ secrets.OTLP_ENDPOINT }}
       OTLP_HEADERS: ${{ secrets.OTLP_HEADERS }}
+      GCP_SERVICE_ACCOUNT: ${{ secrets.GCP_SERVICE_ACCOUNT }}
     with:
       java-version: 25
       # Embed the plugin schema bundle in the jar, so the zip/tar and executable published
       # to the GitHub release carry it just like the Docker images do.
       embed-plugins-schema-bundle: true
-    secrets:
-      GCP_SERVICE_ACCOUNT: ${{ secrets.GCP_SERVICE_ACCOUNT }}
 
   backend-tests:
     name: Backend tests


### PR DESCRIPTION
## Summary
- `build-artifacts` job in `pre-release.yml` declared two `secrets:` keys; YAML silently keeps only the last one, so `OTLP_ENDPOINT` and `OTLP_HEADERS` were dropped and never passed to the reusable workflow.
- Merged both into a single `secrets:` block.

## Test plan
- [x] `yamllint`/visual diff: single `secrets:` key remains, all three secrets present.