### PR TITLE
fix(assets): reject an asset declaration with a missing id

### DIFF
--- a/core/src/main/java/io/kestra/core/models/assets/AssetIdentifier.java
+++ b/core/src/main/java/io/kestra/core/models/assets/AssetIdentifier.java
@@ -3,8 +3,9 @@ package io.kestra.core.models.assets;
 import io.kestra.core.utils.IdUtils;
 
 import io.swagger.v3.oas.annotations.Hidden;
+import jakarta.validation.constraints.NotBlank;
 
-public record AssetIdentifier(@Hidden String tenantId, @Hidden String namespace, String id, String type) {
+public record AssetIdentifier(@Hidden String tenantId, @Hidden String namespace, @NotBlank String id, String type) {
 
     public AssetIdentifier withTenantId(String tenantId) {
         return new AssetIdentifier(tenantId, this.namespace, this.id, this.type);

--- a/core/src/main/java/io/kestra/core/models/assets/AssetsDeclaration.java
+++ b/core/src/main/java/io/kestra/core/models/assets/AssetsDeclaration.java
@@ -9,13 +9,14 @@ import io.kestra.core.models.property.Property;
 import io.kestra.core.models.tasks.AssetFailureBehavior;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.Valid;
 import lombok.Getter;
 
 @Getter
 public class AssetsDeclaration {
     private Property<Boolean> enableAuto;
-    private Property<List<AssetIdentifier>> inputs;
-    private Property<List<Asset>> outputs;
+    private Property<List<@Valid AssetIdentifier>> inputs;
+    private Property<List<@Valid Asset>> outputs;
 
     @Schema(
         title = "Asset failure behavior",
@@ -24,7 +25,8 @@ public class AssetsDeclaration {
     private Property<AssetFailureBehavior> assetFailureBehavior;
 
     @JsonCreator
-    public AssetsDeclaration(Property<Boolean> enableAuto, Property<List<AssetIdentifier>> inputs, Property<List<Asset>> outputs, Property<AssetFailureBehavior> assetFailureBehavior) {
+    public AssetsDeclaration(Property<Boolean> enableAuto, Property<List<@Valid AssetIdentifier>> inputs, Property<List<@Valid Asset>> outputs,
+        Property<AssetFailureBehavior> assetFailureBehavior) {
         this.enableAuto = Optional.ofNullable(enableAuto).orElse(Property.ofValue(false));
         this.inputs = inputs;
         this.outputs = outputs;

--- a/core/src/main/java/io/kestra/core/models/executions/TaskRunWithOutput.java
+++ b/core/src/main/java/io/kestra/core/models/executions/TaskRunWithOutput.java
@@ -6,8 +6,16 @@ import java.util.Map;
  * Utility class to hold a {@link TaskRun} and its outputs.
  * Must only be used as a temporary carrier for methods that must return both.
  */
-public record TaskRunWithOutput(TaskRun taskRun, Map<String, Object> outputs, boolean assetEmissionFailed) {
+public record TaskRunWithOutput(TaskRun taskRun, Map<String, Object> outputs, AssetEmission assetEmission) {
     public TaskRunWithOutput(TaskRun taskRun, Map<String, Object> outputs) {
-        this(taskRun, outputs, false);
+        this(taskRun, outputs, AssetEmission.OK);
+    }
+
+    public enum AssetEmission {
+        OK,
+        /** The declaration rendered but the assets could not be emitted — softened per {@code assetFailureBehavior}. */
+        FAILED,
+        /** The declaration itself is invalid, so no retry or later execution can make it succeed. */
+        DECLARATION_INVALID
     }
 }

--- a/core/src/test/java/io/kestra/core/validations/extractors/DynamicPropertyDto.java
+++ b/core/src/test/java/io/kestra/core/validations/extractors/DynamicPropertyDto.java
@@ -1,7 +1,10 @@
 package io.kestra.core.validations.extractors;
 
+import java.util.List;
+
 import io.kestra.core.models.property.Property;
 
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 
@@ -13,8 +16,16 @@ public class DynamicPropertyDto {
     @NotNull
     private Property<String> string;
 
+    private Property<List<@Valid NestedDto>> list;
+
     public DynamicPropertyDto(Property<@Min(value = 10, message = "must be greater than or equal to {value}") Integer> number, Property<String> string) {
         this.number = number;
         this.string = string;
+    }
+
+    public DynamicPropertyDto(Property<Integer> number, Property<String> string, Property<List<NestedDto>> list) {
+        this.number = number;
+        this.string = string;
+        this.list = list;
     }
 }

--- a/core/src/test/java/io/kestra/core/validations/extractors/NestedDto.java
+++ b/core/src/test/java/io/kestra/core/validations/extractors/NestedDto.java
@@ -1,0 +1,15 @@
+package io.kestra.core.validations.extractors;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+
+@Getter
+public class NestedDto {
+
+    @NotBlank
+    private String id;
+
+    public NestedDto(String id) {
+        this.id = id;
+    }
+}

--- a/core/src/test/java/io/kestra/core/validations/extractors/PropertyValueExtractorTest.java
+++ b/core/src/test/java/io/kestra/core/validations/extractors/PropertyValueExtractorTest.java
@@ -1,5 +1,6 @@
 package io.kestra.core.validations.extractors;
 
+import java.util.List;
 import java.util.Set;
 
 import org.junit.jupiter.api.Test;
@@ -31,6 +32,32 @@ public class PropertyValueExtractorTest {
         assertThat(violations.size()).isEqualTo(1);
         ConstraintViolation<DynamicPropertyDto> violation = violations.stream().findFirst().get();
         assertThat(violation.getMessage()).isEqualTo("must be greater than or equal to 10");
+    }
+
+    // @Valid only cascades into a Property's list elements when it is on the type argument
+    // (Property<List<@Valid X>>), never when it is on the field.
+    @Test
+    public void should_cascade_valid_into_property_list_elements() {
+        DynamicPropertyDto blank = new DynamicPropertyDto(
+            Property.ofValue(20), Property.ofValue("Test"), Property.ofValue(List.of(new NestedDto(" ")))
+        );
+        Set<ConstraintViolation<DynamicPropertyDto>> violations = validator.validate(blank);
+        assertThat(violations).isNotEmpty();
+        assertThat(violations.stream().findFirst().get().getPropertyPath().toString()).contains("list").contains("id");
+
+        DynamicPropertyDto valid = new DynamicPropertyDto(
+            Property.ofValue(20), Property.ofValue("Test"), Property.ofValue(List.of(new NestedDto("ok")))
+        );
+        assertThat(validator.validate(valid)).isEmpty();
+    }
+
+    @Test
+    public void should_not_cascade_valid_into_an_unrendered_expression() {
+        DynamicPropertyDto dto = new DynamicPropertyDto(
+            Property.ofValue(20), Property.ofValue("Test"), Property.ofExpression("{{ x }}")
+        );
+
+        assertThat(validator.validate(dto)).isEmpty();
     }
 
 }

--- a/worker/src/main/java/io/kestra/worker/processors/WorkerTaskProcessor.java
+++ b/worker/src/main/java/io/kestra/worker/processors/WorkerTaskProcessor.java
@@ -13,6 +13,7 @@ import java.time.Instant;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 import java.util.zip.ZipOutputStream;
@@ -48,6 +49,7 @@ import io.kestra.worker.processors.internals.WorkerTaskCallable;
 import io.kestra.worker.queues.WorkerQueue;
 import io.kestra.worker.services.ExecutionKilledManager;
 
+import jakarta.validation.ConstraintViolationException;
 import lombok.extern.slf4j.Slf4j;
 
 import static io.kestra.core.models.flows.State.Type.*;
@@ -289,13 +291,23 @@ public class WorkerTaskProcessor extends AbstractWorkerJobProcessor<WorkerTask> 
                 state = WARNING;
             }
 
-            if (taskRunWithOutput.assetEmissionFailed()) {
+            if (taskRunWithOutput.assetEmission() == TaskRunWithOutput.AssetEmission.DECLARATION_INVALID) {
+                // never rewrite a state that already terminated in error, mirroring AssetFailureBehavior.apply
+                if (!state.isTerminatedInError()) {
+                    runContext.logger().error(
+                        "Task state changed from {} to {} because its asset declaration is invalid, which assetFailureBehavior does not soften",
+                        state, FAILED
+                    );
+                    state = FAILED;
+                }
+            } else if (taskRunWithOutput.assetEmission() == TaskRunWithOutput.AssetEmission.FAILED) {
                 AssetsDeclaration assetsDeclaration = workerTask.getTask().getAssets();
                 AssetFailureBehavior assetFailureBehavior = AssetFailureBehavior.WARN;
                 if (assetsDeclaration != null) {
                     try {
                         assetFailureBehavior = runContext.render(assetsDeclaration.getAssetFailureBehavior()).as(AssetFailureBehavior.class).orElse(AssetFailureBehavior.WARN);
-                    } catch (IllegalVariableEvaluationException e) {
+                    } catch (IllegalVariableEvaluationException | ConstraintViolationException e) {
+                        // validate() re-checks the whole task bean, so an unrelated invalid field throws here too
                         runContext.logger().warn("Unable to render assetFailureBehavior, defaulting to WARN", e);
                     }
                 }
@@ -451,7 +463,7 @@ public class WorkerTaskProcessor extends AbstractWorkerJobProcessor<WorkerTask> 
 
         Map<String, Object> outputs = Optional.ofNullable(workerTaskCallable.getTaskOutput()).map(it -> it.toMap()).orElse(null);
 
-        boolean assetEmissionFailed = false;
+        TaskRunWithOutput.AssetEmission assetEmission = TaskRunWithOutput.AssetEmission.OK;
         try {
             if (workerTask.getTask().getAssets() != null) {
                 // We need to have the task outputs injected before rendering the assets
@@ -473,12 +485,29 @@ public class WorkerTaskProcessor extends AbstractWorkerJobProcessor<WorkerTask> 
                     taskRun = taskRun.withAssetEmits(bundles);
                 }
             }
+        } catch (ConstraintViolationException e) {
+            // validate() re-checks the whole task bean, so only an assets-scoped violation is the declaration's fault
+            String assetViolations = violationsUnder("assets", e);
+            if (assetViolations.isEmpty()) {
+                logger.warn("Unable to render asset declaration for taskRun '{}'", taskRun, e);
+                assetEmission = TaskRunWithOutput.AssetEmission.FAILED;
+            } else {
+                logger.error("Invalid asset declaration for taskRun '{}': {}", taskRun.getId(), assetViolations);
+                assetEmission = TaskRunWithOutput.AssetEmission.DECLARATION_INVALID;
+            }
         } catch (Exception e) {
             logger.warn("Unable to render asset declaration for taskRun '{}'", taskRun, e);
-            assetEmissionFailed = true;
+            assetEmission = TaskRunWithOutput.AssetEmission.FAILED;
         }
 
-        return new TaskRunWithOutput(taskRun, outputs, assetEmissionFailed);
+        return new TaskRunWithOutput(taskRun, outputs, assetEmission);
+    }
+
+    private static String violationsUnder(String propertyPathPrefix, ConstraintViolationException e) {
+        return e.getConstraintViolations().stream()
+            .filter(violation -> violation.getPropertyPath().toString().startsWith(propertyPathPrefix))
+            .map(violation -> violation.getPropertyPath() + " " + violation.getMessage())
+            .collect(Collectors.joining(", "));
     }
 
     private List<TaskRunAttempt> addAttempt(WorkerTask workerTask, TaskRunAttempt taskRunAttempt) {

--- a/worker/src/test/java/io/kestra/worker/processors/WorkerTaskProcessorTest.java
+++ b/worker/src/test/java/io/kestra/worker/processors/WorkerTaskProcessorTest.java
@@ -10,7 +10,9 @@ import org.junit.jupiter.api.Test;
 
 import io.kestra.core.junit.annotations.KestraTest;
 import io.kestra.core.metrics.MetricRegistry;
+import io.kestra.core.models.assets.AssetIdentifier;
 import io.kestra.core.models.assets.AssetsDeclaration;
+import io.kestra.core.models.assets.Custom;
 import io.kestra.core.models.executions.Execution;
 import io.kestra.core.models.executions.LogEntry;
 import io.kestra.core.models.executions.TaskRun;
@@ -42,6 +44,7 @@ import io.kestra.worker.queues.WorkerQueue;
 import io.kestra.worker.services.ExecutionKilledManager;
 
 import jakarta.inject.Inject;
+import jakarta.validation.constraints.Min;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
@@ -235,6 +238,123 @@ class WorkerTaskProcessorTest {
         assertThat(escalationLog.getMessage()).contains("SUCCESS").contains("WARNING").contains("WARN");
     }
 
+    // kestra-ee#10347: a declared asset with no id fails only its own task, outright rather than per
+    // assetFailureBehavior, since a malformed declaration cannot succeed on a retry or a later execution.
+    @Test
+    void shouldFailTaskWhenAssetOutputHasNoId() throws Exception {
+        InMemoryWorkerQueue<WorkerTaskResult> resultQueue = new InMemoryWorkerQueue<>(100);
+        WorkerTaskProcessor processor = newProcessor(resultQueue);
+        List<LogEntry> logs = new CopyOnWriteArrayList<>();
+        logQueue.addListener(logs::add);
+
+        processor.process(assetOutputMissingIdWorkerTask(AssetFailureBehavior.WARN));
+
+        List<WorkerTaskResult> results = drain(resultQueue);
+        String taskRunId = results.getLast().getTaskRun().getId();
+        assertThat(results.getLast().getTaskRun().getState().getCurrent()).isEqualTo(State.Type.FAILED);
+        assertThat(results.getLast().getTaskRun().getAssetEmits()).isNullOrEmpty();
+        LogEntry errorLog = TestsUtils.awaitLog(logs, log -> taskRunId.equals(log.getTaskRunId()) && log.getMessage() != null && log.getMessage().startsWith("Invalid asset declaration"));
+        assertThat(errorLog).isNotNull();
+        assertThat(errorLog.getMessage()).contains("assets.outputs[0].id").contains("must not be blank");
+    }
+
+    @Test
+    void shouldFailTaskWhenAssetInputHasNoId() throws Exception {
+        InMemoryWorkerQueue<WorkerTaskResult> resultQueue = new InMemoryWorkerQueue<>(100);
+        WorkerTaskProcessor processor = newProcessor(resultQueue);
+        List<LogEntry> logs = new CopyOnWriteArrayList<>();
+        logQueue.addListener(logs::add);
+
+        processor.process(assetInputMissingIdWorkerTask(AssetFailureBehavior.WARN));
+
+        List<WorkerTaskResult> results = drain(resultQueue);
+        String taskRunId = results.getLast().getTaskRun().getId();
+        assertThat(results.getLast().getTaskRun().getState().getCurrent()).isEqualTo(State.Type.FAILED);
+        assertThat(results.getLast().getTaskRun().getAssetEmits()).isNullOrEmpty();
+        LogEntry errorLog = TestsUtils.awaitLog(logs, log -> taskRunId.equals(log.getTaskRunId()) && log.getMessage() != null && log.getMessage().startsWith("Invalid asset declaration"));
+        assertThat(errorLog).isNotNull();
+        assertThat(errorLog.getMessage()).contains("assets.inputs[0].id").contains("must not be blank");
+    }
+
+    @Test
+    void shouldFailTaskWhenAssetOutputHasNoIdEvenWhenBehaviorIsIgnore() throws Exception {
+        InMemoryWorkerQueue<WorkerTaskResult> resultQueue = new InMemoryWorkerQueue<>(100);
+        WorkerTaskProcessor processor = newProcessor(resultQueue);
+
+        // IGNORE would otherwise silently drop a soft asset-emission failure (see
+        // shouldKeepSuccessWhenAssetEmissionFailsAndBehaviorIsIgnore); a malformed declaration
+        // must not be swallowed the same way — this is the exact regression the issue reports.
+        processor.process(assetOutputMissingIdWorkerTask(AssetFailureBehavior.IGNORE));
+
+        List<WorkerTaskResult> results = drain(resultQueue);
+        assertThat(results.getLast().getTaskRun().getState().getCurrent()).isEqualTo(State.Type.FAILED);
+    }
+
+    @Test
+    void shouldNotRewriteAKilledTaskWhenItsAssetDeclarationIsInvalid() throws Exception {
+        InMemoryWorkerQueue<WorkerTaskResult> resultQueue = new InMemoryWorkerQueue<>(100);
+        WorkerTaskProcessor processor = newProcessor(resultQueue);
+        // pre-kill so the callable reports KILLED; the asset block still runs on the way out
+        processor.kill();
+
+        processor.process(assetOutputMissingIdWorkerTask(AssetFailureBehavior.WARN));
+
+        List<WorkerTaskResult> results = drain(resultQueue);
+        assertThat(results.getLast().getTaskRun().getState().getCurrent()).isEqualTo(State.Type.KILLED);
+    }
+
+    // validate() re-checks the whole task bean, so an unrelated invalid field throws from the asset
+    // render too. That is not a malformed declaration and must keep going through assetFailureBehavior.
+    @Test
+    void shouldNotReportAnUnrelatedTaskViolationAsAnInvalidAssetDeclaration() throws Exception {
+        InMemoryWorkerQueue<WorkerTaskResult> resultQueue = new InMemoryWorkerQueue<>(100);
+        WorkerTaskProcessor processor = newProcessor(resultQueue);
+
+        processor.process(unrelatedViolationWithValidAssetsWorkerTask());
+
+        List<WorkerTaskResult> results = drain(resultQueue);
+        assertThat(results.getLast().getTaskRun().getState().getCurrent()).isEqualTo(State.Type.WARNING);
+    }
+
+    // The tests above populate Property.value eagerly, so the violation is visible to the first
+    // whole-bean validate. A flow's YAML leaves it null until rendered, so the violation only surfaces
+    // mid-attempt, after the task body succeeded — the path a user actually hits.
+    @Test
+    void shouldFailTaskWhenAssetDeclarationIsOnlyInvalidOnceRendered() throws Exception {
+        InMemoryWorkerQueue<WorkerTaskResult> resultQueue = new InMemoryWorkerQueue<>(100);
+        WorkerTaskProcessor processor = newProcessor(resultQueue);
+        List<LogEntry> logs = new CopyOnWriteArrayList<>();
+        logQueue.addListener(logs::add);
+
+        processor.process(assetInputMissingIdFromExpressionWorkerTask(AssetFailureBehavior.IGNORE));
+
+        List<WorkerTaskResult> results = drain(resultQueue);
+        String taskRunId = results.getLast().getTaskRun().getId();
+        assertThat(results.getLast().getTaskRun().getState().getCurrent()).isEqualTo(State.Type.FAILED);
+        assertThat(results.getLast().getTaskRun().getAssetEmits()).isNullOrEmpty();
+        LogEntry errorLog = TestsUtils.awaitLog(logs, log -> taskRunId.equals(log.getTaskRunId()) && log.getMessage() != null && log.getMessage().startsWith("Invalid asset declaration"));
+        assertThat(errorLog).isNotNull();
+        assertThat(errorLog.getMessage()).contains("assets.inputs[0].id").contains("must not be blank");
+    }
+
+    @Test
+    void shouldFailTaskWhenAssetOutputDeclarationIsOnlyInvalidOnceRendered() throws Exception {
+        InMemoryWorkerQueue<WorkerTaskResult> resultQueue = new InMemoryWorkerQueue<>(100);
+        WorkerTaskProcessor processor = newProcessor(resultQueue);
+        List<LogEntry> logs = new CopyOnWriteArrayList<>();
+        logQueue.addListener(logs::add);
+
+        processor.process(assetOutputMissingIdFromExpressionWorkerTask(AssetFailureBehavior.IGNORE));
+
+        List<WorkerTaskResult> results = drain(resultQueue);
+        String taskRunId = results.getLast().getTaskRun().getId();
+        assertThat(results.getLast().getTaskRun().getState().getCurrent()).isEqualTo(State.Type.FAILED);
+        assertThat(results.getLast().getTaskRun().getAssetEmits()).isNullOrEmpty();
+        LogEntry errorLog = TestsUtils.awaitLog(logs, log -> taskRunId.equals(log.getTaskRunId()) && log.getMessage() != null && log.getMessage().startsWith("Invalid asset declaration"));
+        assertThat(errorLog).isNotNull();
+        assertThat(errorLog.getMessage()).contains("assets.outputs[0].id").contains("must not be blank");
+    }
+
     private WorkerTaskProcessor newProcessor(WorkerQueue<WorkerTaskResult> resultQueue) {
         return new WorkerTaskProcessor(
             "test-worker",
@@ -285,6 +405,92 @@ class WorkerTaskProcessorTest {
             .allowWarning(allowWarning)
             // rendered value is a plain string, not JSON, so binding it as List<AssetIdentifier> fails
             .assets(new AssetsDeclaration(Property.ofValue(false), Property.ofExpression("{{ 'not-json' }}"), Property.ofValue(List.of()), Property.ofValue(assetFailureBehavior)))
+            .build();
+
+        return workerTaskFor(task);
+    }
+
+    private WorkerTask assetOutputMissingIdWorkerTask(AssetFailureBehavior assetFailureBehavior) {
+        AssetEmissionFailure task = AssetEmissionFailure.builder()
+            .type(AssetEmissionFailure.class.getName())
+            .id("asset-output-missing-id-task")
+            .assets(
+                new AssetsDeclaration(
+                    Property.ofValue(false),
+                    Property.ofValue(List.of()),
+                    Property.ofValue(List.of(Custom.builder().namespace("io.kestra.tests").type("custom").build())),
+                    Property.ofValue(assetFailureBehavior)
+                )
+            )
+            .build();
+
+        return workerTaskFor(task);
+    }
+
+    private WorkerTask assetInputMissingIdFromExpressionWorkerTask(AssetFailureBehavior assetFailureBehavior) {
+        AssetEmissionFailure task = AssetEmissionFailure.builder()
+            .type(AssetEmissionFailure.class.getName())
+            .id("asset-input-missing-id-expression-task")
+            .assets(
+                new AssetsDeclaration(
+                    Property.ofValue(false),
+                    Property.ofExpression("{{ '[{\"namespace\":\"io.kestra.tests\",\"type\":\"custom\"}]' }}"),
+                    Property.ofValue(List.of()),
+                    Property.ofValue(assetFailureBehavior)
+                )
+            )
+            .build();
+
+        return workerTaskFor(task);
+    }
+
+    private WorkerTask assetOutputMissingIdFromExpressionWorkerTask(AssetFailureBehavior assetFailureBehavior) {
+        AssetEmissionFailure task = AssetEmissionFailure.builder()
+            .type(AssetEmissionFailure.class.getName())
+            .id("asset-output-missing-id-expression-task")
+            .assets(
+                new AssetsDeclaration(
+                    Property.ofValue(false),
+                    Property.ofValue(List.of()),
+                    Property.ofExpression("{{ '[{\"type\":\"io.kestra.core.models.assets.Custom\",\"namespace\":\"io.kestra.tests\"}]' }}"),
+                    Property.ofValue(assetFailureBehavior)
+                )
+            )
+            .build();
+
+        return workerTaskFor(task);
+    }
+
+    private WorkerTask assetInputMissingIdWorkerTask(AssetFailureBehavior assetFailureBehavior) {
+        AssetEmissionFailure task = AssetEmissionFailure.builder()
+            .type(AssetEmissionFailure.class.getName())
+            .id("asset-input-missing-id-task")
+            .assets(
+                new AssetsDeclaration(
+                    Property.ofValue(false),
+                    Property.ofValue(List.of(new AssetIdentifier(null, "io.kestra.tests", null, "custom"))),
+                    Property.ofValue(List.of()),
+                    Property.ofValue(assetFailureBehavior)
+                )
+            )
+            .build();
+
+        return workerTaskFor(task);
+    }
+
+    private WorkerTask unrelatedViolationWithValidAssetsWorkerTask() {
+        UnrelatedViolation task = UnrelatedViolation.builder()
+            .type(UnrelatedViolation.class.getName())
+            .id("unrelated-violation-task")
+            .count(Property.ofExpression("{{ 5 }}"))
+            .assets(
+                new AssetsDeclaration(
+                    Property.ofValue(false),
+                    Property.ofValue(List.of()),
+                    Property.ofValue(List.of()),
+                    Property.ofValue(AssetFailureBehavior.WARN)
+                )
+            )
             .build();
 
         return workerTaskFor(task);
@@ -359,6 +565,24 @@ class WorkerTaskProcessorTest {
         public VoidOutput run(RunContext runContext) {
             // null, not new VoidOutput(): the empty bean has no properties and Jackson's
             // FAIL_ON_EMPTY_BEANS would blow up when the processor serializes the output to a map
+            return null;
+        }
+    }
+
+    /**
+     * A task that succeeds but leaves an invalid value on an unrelated property, by rendering it without
+     * going through the validating {@code RunContextProperty}. The asset render's whole-bean validate
+     * then reports that violation, which is not a malformed asset declaration.
+     */
+    @SuperBuilder
+    @Getter
+    @NoArgsConstructor
+    public static class UnrelatedViolation extends Task implements RunnableTask<VoidOutput> {
+        private Property<@Min(10) Integer> count;
+
+        @Override
+        public VoidOutput run(RunContext runContext) throws Exception {
+            Property.as(this.count, runContext, Integer.class);
             return null;
         }
     }


### PR DESCRIPTION
- `AssetsDeclaration.inputs`/`.outputs` carried no `@Valid` and `AssetIdentifier` had no constraint at all, so a task's `assets:` block with an entry missing its `id` was saved without complaint and only surfaced as a NOT NULL violation in the repository layer
- The cascade has to be a type-use `@Valid` on the list element (`Property<List<@Valid Asset>>`): Hibernate Validator's container detection does not recurse into `List` from a field-level `@Valid`, so the field form is inert. A gating test pins that behaviour
- Save time is unaffected — `Property.value` is null until the property is rendered, so no existing flow becomes unsavable
- A malformed declaration now fails the task outright rather than being softened by `assetFailureBehavior`. The violation only surfaces once the declaration is rendered, mid-attempt and after the task body has already succeeded, so it was previously escalated to WARNING — and `IGNORE` could not even be read, since rendering it re-runs the same whole-bean validation. `allowFailure` still has the final say
- A state that already terminated in error is never rewritten, mirroring `AssetFailureBehavior.apply`, so a KILLED or CANCELLED task keeps its state
- `RunContextProperty.validate()` re-checks the whole task bean, not just the property being rendered, so an unrelated invalid field throws from the asset render too. Only an `assets.`-scoped violation is treated as a malformed declaration; anything else stays a soft emission failure and keeps going through `assetFailureBehavior`

### Scope of the newly enforced constraints

`Asset` already carried `@NotBlank`, `@Pattern` and `@Size` on `id` and a `@Pattern`/`@Size` on `namespace`; until now they were only enforced by the REST asset editor, never on a flow-declared asset. They now apply there too, so a hand-written declaration with a slash, a space or an over-long `id`, or a non-lowercase `namespace`, fails instead of reaching the repository. Auto-emitted assets go through `runContext.assets().emitted()` and are not validated by this cascade, so the change only reaches hand-written `assets:` blocks — and no declaration or fixture in either repository carries such a value.

Verified on a live EE instance: the declaration never reaches the repository (no null-id asset row, no constraint violation).

Related to https://github.com/kestra-io/kestra-ee/issues/10347.
