### PR TITLE
fix(flows): carry the flow editor buffer as AI copilot context

### DIFF
--- a/ui/src/components/ai/copilot/CopilotChat.vue
+++ b/ui/src/components/ai/copilot/CopilotChat.vue
@@ -145,6 +145,7 @@
     import {scopeFromRoute, scopeToContext, CONTEXT_PART_I18N, CONTEXT_PRIMARY} from "./routeScope"
     import type {ScopeBinding, ContextPart} from "./types"
     import {useMiscStore} from "override/stores/misc"
+    import {useFlowStore} from "../../../stores/flow"
 
     const props = withDefaults(defineProps<{
         /** Initial mode; defaults to EDIT. */
@@ -158,6 +159,7 @@
     const {t} = useI18n()
     const route = useRoute()
     const miscStore = useMiscStore()
+    const flowStore = useFlowStore()
 
     const mode = ref<AgentMode>(props.initialMode ?? "EDIT")
 
@@ -204,6 +206,14 @@
             previousFocus = current
         },
     )
+
+    // The flow editor's buffer is the only place a new (flows/create) or edited-but-unsaved flow
+    // exists, and no tool can read it, so a turn focused on a flow carries it (kestra-io/kestra-ee#10419).
+    // Dismissing the flow pill drops it along with the flow id.
+    const editorFlowSource = computed<string | undefined>(() => {
+        if (routeInFocus.value?.kind !== "FLOW" || dismissedParts.value.has("flowId")) return undefined
+        return flowStore.flowYaml || undefined
+    })
 
     /** Dismiss a single context pill and note its removal in the transcript. */
     function removeContext(part: ContextPart): void {
@@ -342,7 +352,12 @@
     )
 
     function onSubmit(prompt: string): void {
-        sendChat({prompt, mode: mode.value, additionalContext: scopeToContext(activeScope.value), providerId: selectedProvider.value})
+        sendChat({
+            prompt,
+            mode: mode.value,
+            additionalContext: scopeToContext(activeScope.value, editorFlowSource.value),
+            providerId: selectedProvider.value,
+        })
     }
 
     // Keep the transcript pinned to the bottom as content arrives: new messages, streamed

--- a/ui/src/components/ai/copilot/routeScope.ts
+++ b/ui/src/components/ai/copilot/routeScope.ts
@@ -68,6 +68,9 @@ export function scopeFromRoute(route: RouteLike | undefined | null): ScopeBindin
     if (name === FLOW_PARENT_ROUTE || name.startsWith(`${FLOW_PARENT_ROUTE}/`)) {
         return {kind: "FLOW", namespace: param(params, "namespace"), flowId: param(params, "id")}
     }
+    if (name === "flows/create") {
+        return {kind: "FLOW"}
+    }
     if (name === NAMESPACE_PARENT_ROUTE || name.startsWith(`${NAMESPACE_PARENT_ROUTE}/`)) {
         return {kind: "NAMESPACE", namespace: param(params, "id")}
     }
@@ -93,18 +96,21 @@ export function scopeFromRoute(route: RouteLike | undefined | null): ScopeBindin
 
 /**
  * Converts a scope into the free-form `additionalContext` map sent on a chat turn (what the user is
- * currently viewing). Returns undefined when there's no scope, and omits absent fields.
+ * currently viewing). Returns undefined when there's no scope and no source, and omits absent fields.
+ * `flowSource` is the flow editor's current buffer: the only place a new or edited-but-unsaved flow
+ * exists, so the agent cannot read it through a tool (kestra-io/kestra-ee#10419).
  */
-export function scopeToContext(scope: ScopeBinding | null | undefined): Record<string, unknown> | undefined {
-    if (!scope) return undefined
-    const currentView: Record<string, unknown> = {kind: scope.kind}
-    if (scope.namespace) currentView.namespace = scope.namespace
-    if (scope.flowId) currentView.flowId = scope.flowId
-    if (scope.executionId) currentView.executionId = scope.executionId
-    if (scope.dashboardId) currentView.dashboardId = scope.dashboardId
-    if (scope.appId) currentView.appId = scope.appId
-    if (scope.testId) currentView.testId = scope.testId
-    if (scope.blueprintId) currentView.blueprintId = scope.blueprintId
-    if (scope.pluginId) currentView.pluginId = scope.pluginId
+export function scopeToContext(scope: ScopeBinding | null | undefined, flowSource?: string): Record<string, unknown> | undefined {
+    if (!scope && !flowSource) return undefined
+    const currentView: Record<string, unknown> = {kind: scope?.kind ?? "FLOW"}
+    if (scope?.namespace) currentView.namespace = scope.namespace
+    if (scope?.flowId) currentView.flowId = scope.flowId
+    if (scope?.executionId) currentView.executionId = scope.executionId
+    if (scope?.dashboardId) currentView.dashboardId = scope.dashboardId
+    if (scope?.appId) currentView.appId = scope.appId
+    if (scope?.testId) currentView.testId = scope.testId
+    if (scope?.blueprintId) currentView.blueprintId = scope.blueprintId
+    if (scope?.pluginId) currentView.pluginId = scope.pluginId
+    if (flowSource) currentView.flowSource = flowSource
     return {currentView}
 }

--- a/ui/tests/unit/components/ai/copilot/CopilotChat.spec.ts
+++ b/ui/tests/unit/components/ai/copilot/CopilotChat.spec.ts
@@ -45,6 +45,10 @@ const miscStore = reactive({
     promptCopilot: vi.fn(),
 })
 vi.mock("override/stores/misc", () => ({useMiscStore: () => miscStore}))
+// CopilotChat reads the flow editor's buffer from the flow store so a turn on the flow
+// create/edit pages can carry the unsaved source (kestra-io/kestra-ee#10419).
+const flowStore = reactive({flowYaml: ""})
+vi.mock("../../../../../src/stores/flow", () => ({useFlowStore: () => flowStore}))
 
 import CopilotChat from "../../../../../src/components/ai/copilot/CopilotChat.vue"
 import CopilotThreadControls from "override/components/ai/copilot/CopilotThreadControls.vue"
@@ -77,6 +81,7 @@ describe("CopilotChat", () => {
         miscStore.copilotNewThread = false
         miscStore.configs = {isAiApiKeyConfigured: true}
         miscStore.loadConfigs.mockReset()
+        flowStore.flowYaml = ""
     })
 
     it("shows the empty state when there are no messages", () => {
@@ -152,6 +157,43 @@ describe("CopilotChat", () => {
         expect(state.sendChat).toHaveBeenCalledWith(expect.objectContaining({
             prompt: "why did this fail?",
             additionalContext: {currentView: {kind: "EXECUTION", namespace: "company.team", flowId: "my-flow", executionId: "exec-1"}},
+        }))
+    })
+
+    // kestra-io/kestra-ee#10419: a flow pasted on the create page was never saved, so the agent
+    // has nothing to read — the turn must carry the editor buffer itself.
+    it("sends the editor buffer as flowSource on the flow create page", async () => {
+        routeStub = {name: "flows/create", params: {}}
+        flowStore.flowYaml = "id: repro\nnamespace: company.team"
+        const w = mountChat()
+        w.findComponent({name: "CopilotComposer"}).vm.$emit("submit", "fix this error")
+        await flushPromises()
+        expect(state.sendChat).toHaveBeenCalledWith(expect.objectContaining({
+            additionalContext: {currentView: {kind: "FLOW", flowSource: "id: repro\nnamespace: company.team"}},
+        }))
+    })
+
+    it("sends the editor buffer alongside the flow ids on a flow detail route", async () => {
+        routeStub = {name: "flows/update/edit", params: {namespace: "company.team", id: "my-flow"}}
+        flowStore.flowYaml = "id: my-flow"
+        const w = mountChat()
+        w.findComponent({name: "CopilotComposer"}).vm.$emit("submit", "what does this flow do?")
+        await flushPromises()
+        expect(state.sendChat).toHaveBeenCalledWith(expect.objectContaining({
+            additionalContext: {currentView: {kind: "FLOW", namespace: "company.team", flowId: "my-flow", flowSource: "id: my-flow"}},
+        }))
+    })
+
+    it("drops the editor buffer when the flow context pill is dismissed", async () => {
+        routeStub = {name: "flows/update/edit", params: {namespace: "company.team", id: "my-flow"}}
+        flowStore.flowYaml = "id: my-flow"
+        const w = mountChat()
+        w.findComponent({name: "CopilotContextChip"}).vm.$emit("remove", "flowId")
+        await flushPromises()
+        w.findComponent({name: "CopilotComposer"}).vm.$emit("submit", "no flow please")
+        await flushPromises()
+        expect(state.sendChat).toHaveBeenCalledWith(expect.objectContaining({
+            additionalContext: {currentView: {kind: "FLOW", namespace: "company.team"}},
         }))
     })
 

--- a/ui/tests/unit/components/ai/copilot/routeScope.spec.ts
+++ b/ui/tests/unit/components/ai/copilot/routeScope.spec.ts
@@ -35,6 +35,12 @@ describe("scopeFromRoute", () => {
         expect(scopeFromRoute({name: "home", params: {}})).toBeNull()
     })
 
+    // kestra-io/kestra-ee#10419: the create page has no saved resource, but must still bind
+    // the FLOW kind so the editor buffer can attach as context.
+    it("maps the flow create route to a FLOW scope with no ids", () => {
+        expect(scopeFromRoute({name: "flows/create", params: {}})).toEqual({kind: "FLOW"})
+    })
+
     it("maps a detail page's actual (child) route name, not just its redirecting parent", () => {
         expect(scopeFromRoute({name: "executions/update/overview", params: {namespace: "company.team", flowId: "my-flow", id: "exec-1"}}))
             .toEqual({kind: "EXECUTION", namespace: "company.team", flowId: "my-flow", executionId: "exec-1"})
@@ -80,5 +86,14 @@ describe("scopeToContext", () => {
     it("returns undefined when there is no scope", () => {
         expect(scopeToContext(null)).toBeUndefined()
         expect(scopeToContext(undefined)).toBeUndefined()
+    })
+
+    // kestra-io/kestra-ee#10419: a new or unsaved flow exists only in the editor buffer,
+    // so the turn context must carry its source even without a saved flow to reference.
+    it("carries the editor's flow source into currentView, with or without a scope", () => {
+        expect(scopeToContext({kind: "FLOW", namespace: "company.team", flowId: "my-flow"}, "id: my-flow"))
+            .toEqual({currentView: {kind: "FLOW", namespace: "company.team", flowId: "my-flow", flowSource: "id: my-flow"}})
+        expect(scopeToContext(null, "id: repro"))
+            .toEqual({currentView: {kind: "FLOW", flowSource: "id: repro"}})
     })
 })


### PR DESCRIPTION
Closes https://github.com/kestra-io/kestra-ee/issues/10419.


**Needs a running Kestra with an AI provider configured.**

## Steps

1. Open **Flows → Create** and paste the example flow below.
2. Click **Save**: a 422 error toast appears.
3. Click **Fix with AI** and send the prefilled prompt.

**Expected:** the copilot fixes your pasted flow directly (it suggests removing or converting `pluginDefaults`).
**Before the fix:** it asked you to paste the full YAML.

## Extra checks

- Edit a saved flow without saving, ask the copilot about it: it sees your unsaved edit.
- Dismiss the "Flow" context pill and ask again: it no longer knows the flow.

## Example flow

```yaml
id: repro
namespace: company.team
tasks:
  - id: hello
    type: io.kestra.plugin.core.log.Log
    message: hi
pluginDefaults:
  - type: io.kestra.plugin.core.log.Log
    values:
      level: INFO
```

`pluginDefaults` was removed on develop, so saving this flow always returns the 422 needed for step 2.