### PR TITLE
fix(plugins): load task icons only once they are on screen

### DIFF
--- a/ui/src/components/plugins/TaskIcon.spec.ts
+++ b/ui/src/components/plugins/TaskIcon.spec.ts
@@ -1,0 +1,65 @@
+import {afterAll, afterEach, describe, expect, it, vi} from "vitest"
+import {nextTick} from "vue"
+import {mount} from "@vue/test-utils"
+
+import TaskIcon from "./TaskIcon.vue"
+
+type ObserverCallback = (entries: {target: Element; isIntersecting: boolean}[]) => void
+
+const observers: {callback: ObserverCallback}[] = []
+
+class FakeIntersectionObserver {
+    constructor(callback: ObserverCallback) {
+        observers.push({callback})
+    }
+
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+}
+
+const MONOCHROME_CLS = "io.kestra.plugin.core.log.Log"
+
+function mountMonochromeIcon() {
+    return mount(TaskIcon, {
+        props: {
+            cls: MONOCHROME_CLS,
+            onlyIcon: true,
+            icons: {[MONOCHROME_CLS]: {flowable: false, monochrome: true, hasIcon: true, hash: "abcdef"}},
+        },
+    })
+}
+
+afterEach(() => {
+    observers.length = 0
+})
+
+afterAll(() => {
+    vi.unstubAllGlobals()
+})
+
+describe("TaskIcon", () => {
+    it("should request the icon of a monochrome task only once it is on screen", async () => {
+        vi.stubGlobal("IntersectionObserver", FakeIntersectionObserver)
+
+        const wrapper = mountMonochromeIcon()
+        await nextTick()
+
+        const mask = wrapper.get(".task-icon__icon--mask")
+        expect(mask.attributes("style")).toBeUndefined()
+
+        observers.at(-1)!.callback([{target: wrapper.element, isIntersecting: true}])
+        await nextTick()
+
+        expect(mask.attributes("style")).toContain(`/plugins/icons/${encodeURIComponent(MONOCHROME_CLS)}/icon.svg`)
+    })
+
+    it("should render a monochrome icon eagerly when IntersectionObserver is unavailable", async () => {
+        vi.stubGlobal("IntersectionObserver", undefined)
+
+        const wrapper = mountMonochromeIcon()
+        await nextTick()
+
+        expect(wrapper.get(".task-icon__icon--mask").attributes("style")).toContain("icon.svg")
+    })
+})

--- a/ui/src/components/plugins/TaskIcon.vue
+++ b/ui/src/components/plugins/TaskIcon.vue
@@ -1,5 +1,6 @@
 <template>
     <div
+        ref="rootRef"
         :class="classes"
         class="task-icon"
     >
@@ -19,6 +20,7 @@
     import {computed, ref, watch} from "vue"
     import {KsTooltip, cssVar} from "@kestra-io/design-system"
     import fallbackIcon from "../../assets/plugins/plugin-icon-fallback.svg"
+    import {useOnScreenOnce} from "../../composables/useOnScreenOnce"
 
     defineOptions({
         name: "TaskIcon",
@@ -57,10 +59,13 @@
 
     const lazyIcon = ref<TaskIconData>()
 
-    watch(() => props.cls, cls => {
+    const rootRef = ref<HTMLElement>()
+    const isOnScreen = useOnScreenOnce(rootRef)
+
+    watch([() => props.cls, isOnScreen], ([cls, onScreen]) => {
         lazyIcon.value = undefined
 
-        if (!cls || providedIcon.value || !props.loadIcon) {
+        if (!cls || !onScreen || providedIcon.value || !props.loadIcon) {
             return
         }
 
@@ -111,11 +116,14 @@
         return icon.value?.hasIcon ? localIconUrl.value : fallbackIcon
     })
 
-    const maskStyle = computed(() => ({
-        maskImage: `url(${iconSrc.value})`,
-        WebkitMaskImage: `url(${iconSrc.value})`,
-        backgroundColor: (props.variable ? cssVar(props.variable) : "") || cssVar("--ks-text-primary"),
-    }))
+    // The masked variant cannot use `loading="lazy"`, so it holds its `mask-image` back until the icon is on screen.
+    const maskStyle = computed(() => isOnScreen.value
+        ? {
+            maskImage: `url(${iconSrc.value})`,
+            WebkitMaskImage: `url(${iconSrc.value})`,
+            backgroundColor: (props.variable ? cssVar(props.variable) : "") || cssVar("--ks-text-primary"),
+        }
+        : undefined)
 </script>
 
 <style lang="scss" scoped>

--- a/ui/src/composables/useOnScreenOnce.spec.ts
+++ b/ui/src/composables/useOnScreenOnce.spec.ts
@@ -1,0 +1,94 @@
+import {afterEach, describe, expect, it, vi} from "vitest"
+import {defineComponent, h, nextTick, ref} from "vue"
+import {mount} from "@vue/test-utils"
+
+import {useOnScreenOnce} from "./useOnScreenOnce"
+
+type ObserverCallback = (entries: {target: Element; isIntersecting: boolean}[]) => void
+
+const observers: {callback: ObserverCallback; observed: Set<Element>}[] = []
+
+class FakeIntersectionObserver {
+    private readonly index: number
+
+    constructor(callback: ObserverCallback) {
+        observers.push({callback, observed: new Set()})
+        this.index = observers.length - 1
+    }
+
+    observe(target: Element) {
+        observers[this.index].observed.add(target)
+    }
+
+    unobserve(target: Element) {
+        observers[this.index].observed.delete(target)
+    }
+
+    disconnect() {
+        observers[this.index].observed.clear()
+    }
+}
+
+function mountHost() {
+    const isOnScreen = ref<boolean>()
+
+    const wrapper = mount(defineComponent({
+        setup() {
+            const target = ref<HTMLElement>()
+            const state = useOnScreenOnce(target)
+
+            return () => {
+                isOnScreen.value = state.value
+                return h("div", {ref: target})
+            }
+        },
+    }), {attachTo: document.body})
+
+    return {wrapper, isOnScreen}
+}
+
+afterEach(() => {
+    observers.length = 0
+    vi.unstubAllGlobals()
+})
+
+describe("useOnScreenOnce", () => {
+    it("should stay false until the observed element intersects", async () => {
+        vi.stubGlobal("IntersectionObserver", FakeIntersectionObserver)
+
+        const {wrapper, isOnScreen} = mountHost()
+        await nextTick()
+
+        expect(isOnScreen.value).toBe(false)
+
+        const observer = observers.at(-1)!
+        observer.callback([{target: wrapper.element, isIntersecting: true}])
+        await nextTick()
+
+        expect(isOnScreen.value).toBe(true)
+    })
+
+    it("should stop observing once the element has been on screen", async () => {
+        vi.stubGlobal("IntersectionObserver", FakeIntersectionObserver)
+
+        const {wrapper} = mountHost()
+        await nextTick()
+
+        const observer = observers.at(-1)!
+        expect(observer.observed.size).toBe(1)
+
+        observer.callback([{target: wrapper.element, isIntersecting: true}])
+
+        expect(observer.observed.size).toBe(0)
+    })
+
+    it("should report true from the start when IntersectionObserver is unavailable", async () => {
+        vi.stubGlobal("IntersectionObserver", undefined)
+
+        const {isOnScreen} = mountHost()
+        await nextTick()
+
+        expect(isOnScreen.value).toBe(true)
+        expect(observers).toHaveLength(0)
+    })
+})

--- a/ui/src/composables/useOnScreenOnce.ts
+++ b/ui/src/composables/useOnScreenOnce.ts
@@ -1,0 +1,44 @@
+import {onBeforeUnmount, ref, watch, type Ref} from "vue"
+
+/** Roughly the distance ahead of the viewport at which browsers start fetching a `loading="lazy"` image. */
+const DEFAULT_MARGIN = "200px 0px"
+
+/**
+ * Reports whether an element has come within `rootMargin` of the viewport, latching to `true` on the first
+ * intersection so the content it gates is never torn down again once loaded.
+ *
+ * Answers `true` from the start where `IntersectionObserver` is unavailable (jsdom, older engines), so a missing
+ * API degrades to eager loading rather than to content that never appears.
+ */
+export function useOnScreenOnce(target: Ref<Element | null | undefined>, rootMargin: string = DEFAULT_MARGIN): Ref<boolean> {
+    const isOnScreen = ref(typeof IntersectionObserver === "undefined")
+    let observer: IntersectionObserver | undefined
+
+    const disconnect = () => {
+        observer?.disconnect()
+        observer = undefined
+    }
+
+    watch(target, element => {
+        disconnect()
+
+        if (!element || isOnScreen.value) {
+            return
+        }
+
+        observer = new IntersectionObserver(entries => {
+            if (!entries.some(entry => entry.isIntersecting)) {
+                return
+            }
+
+            isOnScreen.value = true
+            disconnect()
+        }, {rootMargin})
+
+        observer.observe(element)
+    }, {immediate: true, flush: "post"})
+
+    onBeforeUnmount(disconnect)
+
+    return isOnScreen
+}


### PR DESCRIPTION
### 🔗 Related Issue

Part of https://github.com/kestra-io/kestra-ee/issues/10075.

### ✨ Description

Opening the plugin catalog fires hundreds of icon requests in one burst: one `GET /api/v1/plugins/icons/{cls}/icon.svg` per card, plus an `api.kestra.io` probe for every group with no local icon.

`TaskIcon` renders an icon two ways, and only one of them was deferred:

- the `<img>` branch already carried `loading="lazy"`;
- the monochrome branch paints through `mask-image`, which no attribute defers;
- and the per-class lookup (`loadIcon`, which falls back to probing the ecosystem catalog with `new Image()`) ran from a watcher on mount, wherever the icon sat.

Both uncovered paths now wait until the icon comes within 200px of the viewport, tracked by `useOnScreenOnce` — a small latching `IntersectionObserver` composable. It reports `true` from the start where `IntersectionObserver` is unavailable, so a missing API degrades to today's eager loading rather than to icons that never appear.

### 🎨 Frontend Checklist

- [x] Type checking passes (`npm run check:types`)
- [x] Code builds without errors (`npm run build`)
- [x] Unit tests pass (`npm run test:unit` — 229 files, 2131 tests)
- [x] No `en.json` change, so no translation work
- [ ] Screenshots — see the note below

### 📝 Additional Notes

Two tests, both failing on `develop`: the composable's latch and its no-`IntersectionObserver` fallback, and `TaskIcon` leaving a monochrome icon's `mask-image` unset until the element intersects.

No screenshot is attached because there is nothing to see: the icons render exactly as before, they are just requested when they come into view. The behaviour that changed is visible in the network panel rather than on the page, and this session had no running instance to capture one from.

🐱 Our office cat has the same policy as this PR — she will not load until you scroll all the way over to her.

## Related PRs

- [feat(plugins): paginate the plugin catalog](https://github.com/kestra-io/kestra/pull/18842) — the other half of the same issue, independent of this branch.
