### PR TITLE
feat(plugins): paginate the plugin catalog

### DIFF
--- a/ui/src/components/plugins/PluginCatalog.vue
+++ b/ui/src/components/plugins/PluginCatalog.vue
@@ -96,18 +96,18 @@
             </KsTooltip>
         </section>
 
-        <KsPagination
-            v-if="pluginsList.length > 0"
-            class="plugins-pagination"
-            :currentPage
-            :pageSize
-            :total="pluginsList.length"
-            :pageSizes="PAGE_SIZES"
-            layout="sizes, prev, pager, next, total"
-            size="small"
-            @current-change="currentPage = $event"
-            @size-change="onSizeChange"
-        />
+        <div v-if="pluginsList.length > 0" class="plugins-pagination">
+            <KsPagination
+                :currentPage
+                :pageSize
+                :total="pluginsList.length"
+                :pageSizes="PAGE_SIZES"
+                layout="sizes, prev, pager, next, total"
+                size="small"
+                @current-change="currentPage = $event"
+                @size-change="onSizeChange"
+            />
+        </div>
     </template>
 </template>
 
@@ -404,6 +404,7 @@
     }
 
     .plugins-pagination {
+        display: flex;
         justify-content: flex-end;
         padding: 0 var(--ks-spacing-6) var(--ks-spacing-10) var(--ks-spacing-6);
     }

--- a/ui/src/components/plugins/PluginCatalog.vue
+++ b/ui/src/components/plugins/PluginCatalog.vue
@@ -404,6 +404,7 @@
     }
 
     .plugins-pagination {
+        justify-content: flex-end;
         padding: 0 var(--ks-spacing-6) var(--ks-spacing-10) var(--ks-spacing-6);
     }
 

--- a/ui/src/components/plugins/PluginCatalog.vue
+++ b/ui/src/components/plugins/PluginCatalog.vue
@@ -55,7 +55,7 @@
 
         <section v-else class="plugins-container">
             <KsTooltip
-                v-for="plugin in pluginsList"
+                v-for="plugin in pagedPlugins"
                 :showAfter="1000"
                 :key="`${plugin.name}-${plugin.subGroup ?? ''}`"
             >
@@ -95,6 +95,19 @@
                 />
             </KsTooltip>
         </section>
+
+        <KsPagination
+            v-if="pluginsList.length > 0"
+            class="plugins-pagination"
+            :currentPage
+            :pageSize
+            :total="pluginsList.length"
+            :pageSizes="PAGE_SIZES"
+            layout="sizes, prev, pager, next, total"
+            size="small"
+            @current-change="currentPage = $event"
+            @size-change="onSizeChange"
+        />
     </template>
 </template>
 
@@ -102,7 +115,7 @@
     import {ref, computed, markRaw, onMounted, watch, type Component} from "vue"
     import {useI18n} from "vue-i18n"
     import {useRoute, useRouter} from "vue-router"
-    import {KsSearch, KsAlert, KsSkeleton} from "@kestra-io/design-system"
+    import {KsSearch, KsAlert, KsPagination, KsSkeleton} from "@kestra-io/design-system"
     import PluginCard from "./PluginCard.vue"
     import {isEntryAPluginElementPredicate, isPluginMatched, type Plugin, type PluginElement} from "../../utils/pluginUtils"
     import {usePluginsStore} from "../../stores/plugins"
@@ -143,6 +156,10 @@
 
     type SortKey = "nameAsc" | "nameDesc" | "newest" | "mostUsed"
     const sortBy = ref<SortKey>("nameAsc")
+
+    const PAGE_SIZES = [25, 50, 100]
+    const currentPage = ref(1)
+    const pageSize = ref(50)
 
     const sortOptions = computed<{value: SortKey, label: string}[]>(() => [
         {value: "nameAsc", label: t("pluginPage.sort.nameAsc")},
@@ -237,6 +254,24 @@
             .filter(plugin => matchesSelectedCategories(plugin))
             .slice()
             .sort(comparators[sortBy.value] ?? nameAsc)
+    })
+
+    const pagedPlugins = computed<Plugin[]>(() => {
+        const start = (currentPage.value - 1) * pageSize.value
+        return pluginsList.value.slice(start, start + pageSize.value)
+    })
+
+    const onSizeChange = (size: number) => {
+        pageSize.value = size
+        currentPage.value = 1
+    }
+
+    // A string rather than the filters themselves, so the watcher fires on a content change instead of on every
+    // fresh object reference and bounces the user back to page one only when the filtering actually moved.
+    const filterKey = computed(() => JSON.stringify([searchInput.value, [...selectedCategories.value].sort(), sortBy.value]))
+
+    watch(filterKey, () => {
+        currentPage.value = 1
     })
 
     const loadPluginIcons = async () => {
@@ -361,11 +396,15 @@
         display: grid;
         gap: var(--ks-spacing-4);
         grid-template-columns: repeat(auto-fill, minmax(17.5rem, 1fr));
-        padding: 0 var(--ks-spacing-6) var(--ks-spacing-10) var(--ks-spacing-6);
+        padding: 0 var(--ks-spacing-6) var(--ks-spacing-4) var(--ks-spacing-6);
 
         &--loading {
             margin-top: var(--ks-spacing-4);
         }
+    }
+
+    .plugins-pagination {
+        padding: 0 var(--ks-spacing-6) var(--ks-spacing-10) var(--ks-spacing-6);
     }
 
     .plugin-skeleton {
@@ -386,7 +425,8 @@
             padding: var(--ks-spacing-3);
         }
 
-        .plugins-container {
+        .plugins-container,
+        .plugins-pagination {
             padding-left: var(--ks-spacing-3);
             padding-right: var(--ks-spacing-3);
         }


### PR DESCRIPTION
### 🔗 Related Issue

Closes https://github.com/kestra-io/kestra-ee/issues/10075.

The other half of that issue — lazy loading of the icons themselves — already landed in https://github.com/kestra-io/kestra/pull/18669, so this PR is all that is left.

### ✨ Description

The plugin catalog rendered every plugin card at once — around 500 on a full instance — so each visit built 500 cards and asked the webserver for 500 icons in a single burst.

It now shows one page at a time, 50 cards by default, with 25 / 50 / 100 available. Search, category filters and sorting still run over the whole catalog and the slice is taken last, so a page is a window on the full result rather than a filtered page. Changing any of the three returns to page one.

### 🎨 Frontend Checklist

- [x] Type checking passes (`npm run check:types`)
- [x] Code builds without errors (`npm run build`)
- [x] Unit tests pass (`npm run test:unit` — 227 files, 2126 tests)
- [x] No `en.json` change: `KsPagination` carries its own labels
- [x] Screenshot attached

### 🏞️ Screenshots

<img width="1728" height="1084" alt="Screenshot 2026-08-31 at 16 43 04" src="https://github.com/user-attachments/assets/91aa559f-d20c-4c8c-85f0-eb1d33a01ab0"/>

### 📝 Additional Notes

Page size defaults to 50 rather than the 25 `KsDataTable` uses: a card grid fits far more per screen than a table row, so 50 keeps a full catalog to ~10 pages while still cutting the initial icon burst tenfold. Page and size stay in local state rather than the URL, because search, categories and sort are local here too — putting only the page in the query would deep-link to page 7 of an unfiltered list.

`KsPagination` is wrapped in a plain div that this template owns, rather than styled through a class passed to it: its root is `ElConfigProvider`, which renders a fragment, so Vue cannot attach the scope id and a scoped rule aimed at the component never matches.

No test. The paging is a `slice` over an existing computed, and the one subtle part — returning to page one when the filtering changes — watches a stable string key rather than a fresh object, per the deep-watch trap in `ui/AGENTS.md`. Mounting the whole catalog page would mean stubbing the plugins, enrichment and misc stores plus the router, and the assertions would end up pinned to those mocks rather than to the behaviour.

🐱 The cat walked across the keyboard during review and selected "100 per page". We overruled her, but she remains the only one who has seen all 500 plugins at once.
