### PR TITLE
fix(dashboards): duration filters take an ISO-8601 duration or a number of seconds

### DIFF
--- a/core/src/main/java/io/kestra/core/models/dashboards/filters/DurationFilters.java
+++ b/core/src/main/java/io/kestra/core/models/dashboards/filters/DurationFilters.java
@@ -1,5 +1,6 @@
 package io.kestra.core.models.dashboards.filters;
 
+import java.math.BigDecimal;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
@@ -7,8 +8,8 @@ import java.util.Set;
 import java.util.function.Function;
 
 import io.kestra.core.exceptions.InvalidQueryFiltersException;
-import io.kestra.core.serializers.JacksonMapper;
 import io.kestra.core.utils.ListUtils;
+import io.kestra.core.utils.TypeConverter;
 
 /**
  * Rewrites the filters set on a duration field so that their values are expressed in the unit the store persists.
@@ -104,24 +105,27 @@ public final class DurationFilters {
         };
     }
 
-    private static Duration parse(Object value) {
-        if (value instanceof Duration duration) {
-            return duration;
-        }
-
+    private static Duration toDuration(Object value) {
         if (value == null) {
             throw new InvalidQueryFiltersException("a duration filter requires a value.");
         }
 
         try {
-            return JacksonMapper.ofJson().convertValue(value, Duration.class);
-        } catch (IllegalArgumentException e) {
+            // TypeConverter parses ISO-8601 only, a plain number is the number of seconds a duration is authored as elsewhere
+            return value instanceof Number seconds ? ofSeconds(seconds) : TypeConverter.toDuration(value);
+        } catch (IllegalArgumentException | ArithmeticException e) {
             throw new InvalidQueryFiltersException("`%s` is not a valid duration, use an ISO-8601 duration such as `PT1S` or a number of seconds.".formatted(value), e);
         }
     }
 
+    private static Duration ofSeconds(Number seconds) {
+        BigDecimal value = new BigDecimal(seconds.toString());
+
+        return Duration.ofSeconds(value.longValue(), value.remainder(BigDecimal.ONE).movePointRight(9).longValue());
+    }
+
     private static Number value(Object value, Function<Duration, Number> toStoreUnit) {
-        return toStoreUnit.apply(parse(value));
+        return toStoreUnit.apply(toDuration(value));
     }
 
     private static List<Object> values(List<Object> values, Function<Duration, Number> toStoreUnit) {

--- a/core/src/main/java/io/kestra/core/models/dashboards/filters/DurationFilters.java
+++ b/core/src/main/java/io/kestra/core/models/dashboards/filters/DurationFilters.java
@@ -1,0 +1,130 @@
+package io.kestra.core.models.dashboards.filters;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.function.Function;
+
+import io.kestra.core.exceptions.InvalidQueryFiltersException;
+import io.kestra.core.serializers.JacksonMapper;
+import io.kestra.core.utils.ListUtils;
+
+/**
+ * Rewrites the filters set on a duration field so that their values are expressed in the unit the store persists.
+ * <p>
+ * A dashboard writes a duration the way the rest of Kestra does — an ISO-8601 duration such as {@code PT1S}, or a
+ * plain number of seconds — while the stores keep a number: milliseconds on JDBC, seconds on ElasticSearch. The
+ * authored value can therefore not be handed to the store as-is: it would be compared to a numeric column and fail in
+ * the database. Every store normalizes its duration filters through {@link #normalize} first, and
+ * {@link #violations} reports the same rules at save time.
+ */
+public final class DurationFilters {
+    private DurationFilters() {
+    }
+
+    /**
+     * @param durationFields the duration-typed fields, as declared by {@link io.kestra.plugin.core.dashboard.data.IData#durationFields()}
+     * @param toStoreUnit    converts a duration to the number the store holds for it
+     * @return the filters, each one on a duration field replaced by an equivalent filter carrying a store-unit value
+     * @throws InvalidQueryFiltersException when a value is not a duration, or the filter type cannot apply to one
+     */
+    public static <F extends Enum<F>> List<AbstractFilter<F>> normalize(List<AbstractFilter<F>> filters, Set<? extends Enum<?>> durationFields, Function<Duration, Number> toStoreUnit) {
+        if (ListUtils.isEmpty(filters) || durationFields.isEmpty()) {
+            return filters;
+        }
+
+        return filters.stream().map(filter -> normalizeFilter(filter, durationFields, toStoreUnit)).toList();
+    }
+
+    /**
+     * Collects the reasons why the duration filters of a chart cannot be queried, so that they are reported when the
+     * dashboard is saved rather than when the chart is rendered.
+     *
+     * @return one message per invalid filter, empty when they are all valid
+     */
+    public static List<String> violations(List<? extends AbstractFilter<?>> filters, Set<? extends Enum<?>> durationFields) {
+        if (ListUtils.isEmpty(filters) || durationFields.isEmpty()) {
+            return List.of();
+        }
+
+        List<String> violations = new ArrayList<>();
+        for (AbstractFilter<?> filter : filters) {
+            if (filter instanceof Or<?> or) {
+                violations.addAll(violations(or.getValues(), durationFields));
+            } else if (durationFields.contains(filter.getField())) {
+                // the unit is irrelevant here: a filter is valid when every one of its values is a duration
+                try {
+                    rewrite(filter, Duration::toMillis);
+                } catch (InvalidQueryFiltersException e) {
+                    violations.add(e.getMessage());
+                }
+            }
+        }
+
+        return violations;
+    }
+
+    private static <F extends Enum<F>> AbstractFilter<F> normalizeFilter(AbstractFilter<F> filter, Set<? extends Enum<?>> durationFields, Function<Duration, Number> toStoreUnit) {
+        if (filter instanceof Or<F> or) {
+            return Or.<F> builder()
+                .field(or.getField())
+                .key(or.getKey())
+                .values(normalize(or.getValues(), durationFields, toStoreUnit))
+                .build();
+        }
+
+        if (!durationFields.contains(filter.getField())) {
+            return filter;
+        }
+
+        return rewrite(filter, toStoreUnit);
+    }
+
+    // the field of a wildcard filter can only be the enum the caller matched it against
+    @SuppressWarnings("unchecked")
+    private static <F extends Enum<F>> AbstractFilter<F> rewrite(AbstractFilter<?> filter, Function<Duration, Number> toStoreUnit) {
+        F field = (F) filter.getField();
+        String key = filter.getKey();
+
+        return switch (filter) {
+            case EqualTo<?> f -> EqualTo.<F> builder().field(field).key(key).value(value(f.getValue(), toStoreUnit)).build();
+            case NotEqualTo<?> f -> NotEqualTo.<F> builder().field(field).key(key).value(value(f.getValue(), toStoreUnit)).build();
+            case GreaterThan<?> f -> GreaterThan.<F> builder().field(field).key(key).value(value(f.getValue(), toStoreUnit)).build();
+            case GreaterThanOrEqualTo<?> f -> GreaterThanOrEqualTo.<F> builder().field(field).key(key).value(value(f.getValue(), toStoreUnit)).build();
+            case LessThan<?> f -> LessThan.<F> builder().field(field).key(key).value(value(f.getValue(), toStoreUnit)).build();
+            case LessThanOrEqualTo<?> f -> LessThanOrEqualTo.<F> builder().field(field).key(key).value(value(f.getValue(), toStoreUnit)).build();
+            case In<?> f -> In.<F> builder().field(field).key(key).values(values(f.getValues(), toStoreUnit)).build();
+            case NotIn<?> f -> NotIn.<F> builder().field(field).key(key).values(values(f.getValues(), toStoreUnit)).build();
+            case IsNull<?> f -> (AbstractFilter<F>) f;
+            case IsNotNull<?> f -> (AbstractFilter<F>) f;
+            default -> throw new InvalidQueryFiltersException(
+                "filter type `%s` cannot be used on the duration field `%s`.".formatted(filter.getType(), filter.getField())
+            );
+        };
+    }
+
+    private static Duration parse(Object value) {
+        if (value instanceof Duration duration) {
+            return duration;
+        }
+
+        if (value == null) {
+            throw new InvalidQueryFiltersException("a duration filter requires a value.");
+        }
+
+        try {
+            return JacksonMapper.ofJson().convertValue(value, Duration.class);
+        } catch (IllegalArgumentException e) {
+            throw new InvalidQueryFiltersException("`%s` is not a valid duration, use an ISO-8601 duration such as `PT1S` or a number of seconds.".formatted(value), e);
+        }
+    }
+
+    private static Number value(Object value, Function<Duration, Number> toStoreUnit) {
+        return toStoreUnit.apply(parse(value));
+    }
+
+    private static List<Object> values(List<Object> values, Function<Duration, Number> toStoreUnit) {
+        return values.stream().map(value -> (Object) value(value, toStoreUnit)).toList();
+    }
+}

--- a/core/src/main/java/io/kestra/core/validations/validator/DataChartKPIValidator.java
+++ b/core/src/main/java/io/kestra/core/validations/validator/DataChartKPIValidator.java
@@ -5,6 +5,7 @@ import java.util.List;
 
 import io.kestra.core.contexts.configuration.RepositoryConfiguration;
 import io.kestra.core.models.dashboards.charts.DataChartKPI;
+import io.kestra.core.models.dashboards.filters.DurationFilters;
 import io.kestra.core.validations.DataChartKPIValidation;
 import io.kestra.plugin.core.dashboard.data.Executions;
 
@@ -44,6 +45,9 @@ public class DataChartKPIValidator implements ConstraintValidator<DataChartKPIVa
         ) {
             violations.add("LABELS column is only supported with an ElasticSearch database.");
         }
+
+        violations.addAll(DurationFilters.violations(dataChart.getData().getWhere(), dataChart.getData().durationFields()));
+        violations.addAll(DurationFilters.violations(dataChart.getData().getNumerator(), dataChart.getData().durationFields()));
 
         if (!violations.isEmpty()) {
             context.disableDefaultConstraintViolation();

--- a/core/src/main/java/io/kestra/core/validations/validator/DataChartValidator.java
+++ b/core/src/main/java/io/kestra/core/validations/validator/DataChartValidator.java
@@ -11,6 +11,7 @@ import io.kestra.core.models.dashboards.AggregationType;
 import io.kestra.core.models.dashboards.ColumnDescriptor;
 import io.kestra.core.models.dashboards.OrderBy;
 import io.kestra.core.models.dashboards.charts.DataChart;
+import io.kestra.core.models.dashboards.filters.DurationFilters;
 import io.kestra.core.utils.MapUtils;
 import io.kestra.core.validations.DataChartValidation;
 import io.kestra.plugin.core.dashboard.data.Executions;
@@ -102,6 +103,8 @@ public class DataChartValidator implements ConstraintValidator<DataChartValidati
         ) {
             violations.add("LABELS column is only supported with an ElasticSearch database.");
         }
+
+        violations.addAll(DurationFilters.violations(dataChart.getData().getWhere(), dataChart.getData().durationFields()));
 
         if (!violations.isEmpty()) {
             context.disableDefaultConstraintViolation();

--- a/core/src/main/java/io/kestra/plugin/core/dashboard/data/Executions.java
+++ b/core/src/main/java/io/kestra/plugin/core/dashboard/data/Executions.java
@@ -53,6 +53,28 @@ import lombok.experimental.SuperBuilder;
                           displayName: Executions
                           agg: COUNT
                 """
+        ),
+        @Example(
+            title = "Display the executions that ran for longer than ten seconds. A DURATION filter takes an ISO-8601 duration, or a number of seconds.",
+            full = true,
+            code = """
+                charts:
+                  - id: slow_executions
+                    type: io.kestra.plugin.core.dashboard.chart.Table
+                    chartOptions:
+                      displayName: Slow executions
+                    data:
+                      type: io.kestra.plugin.core.dashboard.data.Executions
+                      columns:
+                        id:
+                          field: ID
+                        duration:
+                          field: DURATION
+                      where:
+                        - field: DURATION
+                          type: GREATER_THAN
+                          value: PT10S
+                """
         )
     }
 )

--- a/core/src/main/java/io/kestra/plugin/core/dashboard/data/IData.java
+++ b/core/src/main/java/io/kestra/plugin/core/dashboard/data/IData.java
@@ -1,11 +1,23 @@
 package io.kestra.plugin.core.dashboard.data;
 
 import java.time.ZonedDateTime;
+import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 
 import io.kestra.core.models.QueryFilter;
 import io.kestra.core.models.dashboards.filters.AbstractFilter;
 
 public interface IData<F extends Enum<F>> {
     List<AbstractFilter<F>> whereWithGlobalFilters(List<QueryFilter> queryFilterList, ZonedDateTime startDate, ZonedDateTime endDate, List<AbstractFilter<F>> where);
+
+    /**
+     * Fields filtered by a duration — an ISO-8601 duration such as {@code PT1S}, or a number of seconds — rather than
+     * by the raw number the store persists for them.
+     *
+     * @see io.kestra.core.models.dashboards.filters.DurationFilters
+     */
+    default Set<F> durationFields() {
+        return Collections.emptySet();
+    }
 }

--- a/core/src/main/java/io/kestra/plugin/core/dashboard/data/IExecutions.java
+++ b/core/src/main/java/io/kestra/plugin/core/dashboard/data/IExecutions.java
@@ -5,6 +5,7 @@ import java.util.ArrayList;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import io.kestra.core.models.QueryFilter;
 import io.kestra.core.models.dashboards.filters.AbstractFilter;
@@ -21,6 +22,12 @@ import io.kestra.core.models.dashboards.filters.NotIn;
 import io.kestra.core.models.dashboards.filters.Or;
 
 public interface IExecutions extends IData<IExecutions.Fields> {
+    Set<Fields> DURATION_FIELDS = Set.of(Fields.DURATION);
+
+    @Override
+    default Set<Fields> durationFields() {
+        return DURATION_FIELDS;
+    }
 
     default List<AbstractFilter<Fields>> whereWithGlobalFilters(List<QueryFilter> filters, ZonedDateTime startDate, ZonedDateTime endDate, List<AbstractFilter<Fields>> where) {
         List<AbstractFilter<Fields>> updatedWhere = where != null ? new ArrayList<>(where) : new ArrayList<>();

--- a/core/src/test/java/io/kestra/core/models/dashboards/filters/DurationFiltersTest.java
+++ b/core/src/test/java/io/kestra/core/models/dashboards/filters/DurationFiltersTest.java
@@ -1,0 +1,116 @@
+package io.kestra.core.models.dashboards.filters;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+
+import io.kestra.core.exceptions.InvalidQueryFiltersException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class DurationFiltersTest {
+    private static final Set<TestField> DURATION_FIELDS = Set.of(TestField.DURATION);
+
+    enum TestField {
+        DURATION,
+        NAMESPACE
+    }
+
+    @Test
+    void shouldConvertAnIso8601ValueToTheStoreUnit() {
+        List<AbstractFilter<TestField>> filters = List.of(
+            GreaterThan.<TestField> builder().field(TestField.DURATION).value("PT1.5S").build()
+        );
+
+        List<AbstractFilter<TestField>> normalized = DurationFilters.normalize(filters, DURATION_FIELDS, Duration::toMillis);
+
+        assertThat(((GreaterThan<TestField>) normalized.getFirst()).getValue()).isEqualTo(1500L);
+    }
+
+    @Test
+    void shouldReadAPlainNumberAsSeconds() {
+        List<AbstractFilter<TestField>> filters = List.of(
+            LessThanOrEqualTo.<TestField> builder().field(TestField.DURATION).value(2).build()
+        );
+
+        List<AbstractFilter<TestField>> normalized = DurationFilters.normalize(filters, DURATION_FIELDS, Duration::toMillis);
+
+        assertThat(((LessThanOrEqualTo<TestField>) normalized.getFirst()).getValue()).isEqualTo(2000L);
+    }
+
+    @Test
+    void shouldConvertEveryValueOfAnInFilter() {
+        List<AbstractFilter<TestField>> filters = List.of(
+            In.<TestField> builder().field(TestField.DURATION).values(List.of("PT1S", 2)).build()
+        );
+
+        List<AbstractFilter<TestField>> normalized = DurationFilters.normalize(filters, DURATION_FIELDS, Duration::toMillis);
+
+        assertThat(((In<TestField>) normalized.getFirst()).getValues()).containsExactly(1000L, 2000L);
+    }
+
+    @Test
+    void shouldConvertTheDurationFiltersNestedInAnOrFilter() {
+        List<AbstractFilter<TestField>> filters = List.of(
+            Or.<TestField> builder().values(
+                List.of(
+                    GreaterThan.<TestField> builder().field(TestField.DURATION).value("PT1S").build(),
+                    EqualTo.<TestField> builder().field(TestField.NAMESPACE).value("company").build()
+                )
+            ).build()
+        );
+
+        List<AbstractFilter<TestField>> normalized = DurationFilters.normalize(filters, DURATION_FIELDS, Duration::toMillis);
+
+        List<AbstractFilter<TestField>> nested = ((Or<TestField>) normalized.getFirst()).getValues();
+        assertThat(((GreaterThan<TestField>) nested.getFirst()).getValue()).isEqualTo(1000L);
+        assertThat(((EqualTo<TestField>) nested.getLast()).getValue()).isEqualTo("company");
+    }
+
+    @Test
+    void shouldLeaveTheFiltersOnOtherFieldsUntouched() {
+        List<AbstractFilter<TestField>> filters = List.of(
+            GreaterThan.<TestField> builder().field(TestField.NAMESPACE).value("PT1S").build()
+        );
+
+        List<AbstractFilter<TestField>> normalized = DurationFilters.normalize(filters, DURATION_FIELDS, Duration::toMillis);
+
+        assertThat(normalized.getFirst()).isSameAs(filters.getFirst());
+    }
+
+    @Test
+    void shouldRejectAValueThatIsNotADuration() {
+        List<AbstractFilter<TestField>> filters = List.of(
+            GreaterThan.<TestField> builder().field(TestField.DURATION).value("1 second").build()
+        );
+
+        assertThatThrownBy(() -> DurationFilters.normalize(filters, DURATION_FIELDS, Duration::toMillis))
+            .isInstanceOf(InvalidQueryFiltersException.class)
+            .hasMessageContaining("`1 second` is not a valid duration");
+    }
+
+    @Test
+    void shouldRejectAFilterTypeThatCannotApplyToADuration() {
+        List<AbstractFilter<TestField>> filters = List.of(
+            StartsWith.<TestField> builder().field(TestField.DURATION).value("PT1S").build()
+        );
+
+        assertThatThrownBy(() -> DurationFilters.normalize(filters, DURATION_FIELDS, Duration::toMillis))
+            .isInstanceOf(InvalidQueryFiltersException.class)
+            .hasMessageContaining("filter type `STARTS_WITH` cannot be used on the duration field `DURATION`");
+    }
+
+    @Test
+    void shouldReportOneViolationPerInvalidFilter() {
+        List<AbstractFilter<TestField>> filters = List.of(
+            GreaterThan.<TestField> builder().field(TestField.DURATION).value("PT1S").build(),
+            LessThan.<TestField> builder().field(TestField.DURATION).value("nope").build(),
+            StartsWith.<TestField> builder().field(TestField.DURATION).value("PT1S").build()
+        );
+
+        assertThat(DurationFilters.violations(filters, DURATION_FIELDS)).hasSize(2);
+    }
+}

--- a/core/src/test/java/io/kestra/core/repositories/AbstractExecutionRepositoryTest.java
+++ b/core/src/test/java/io/kestra/core/repositories/AbstractExecutionRepositoryTest.java
@@ -29,6 +29,7 @@ import io.kestra.core.models.QueryFilter.Logical;
 import io.kestra.core.models.QueryFilter.Op;
 import io.kestra.core.models.dashboards.AggregationType;
 import io.kestra.core.models.dashboards.ColumnDescriptor;
+import io.kestra.core.models.dashboards.filters.GreaterThan;
 import io.kestra.core.models.executions.Execution;
 import io.kestra.core.models.executions.ExecutionKind;
 import io.kestra.core.models.executions.ExecutionTrigger;
@@ -849,6 +850,43 @@ public abstract class AbstractExecutionRepositoryTest {
         assertThat(data).first().extracting("total").hasToString("2");
         // the DURATION column is exposed in seconds, keeping the sub-second part: 0.5s + 1.5s
         assertThat(((Number) data.getFirst().get("duration")).doubleValue()).isCloseTo(2.0d, within(0.001d));
+    }
+
+    @Test
+    protected void shouldFilterOnDurationGivenAnIso8601Value() throws IOException {
+        var tenantId = TestsUtils.randomTenant(this.getClass().getSimpleName());
+        var executionCreateDate = Instant.now().minus(Duration.ofMinutes(5));
+
+        executionRepository.save(executionWithDuration(tenantId, executionCreateDate, Duration.ofMillis(500)));
+        Execution slowExecution = executionRepository.save(executionWithDuration(tenantId, executionCreateDate, Duration.ofMillis(1500)));
+
+        var now = ZonedDateTime.now();
+        ArrayListTotal<Map<String, Object>> data = executionRepository.fetchData(
+            tenantId, Executions.builder()
+                .type(Executions.class.getName())
+                .columns(Map.of("id", ColumnDescriptor.<Executions.Fields> builder().field(Executions.Fields.ID).build()))
+                .where(List.of(GreaterThan.<Executions.Fields> builder().field(Executions.Fields.DURATION).value("PT1S").build()))
+                .build(),
+            now.minusHours(1),
+            now,
+            null
+        );
+
+        assertThat(data).hasSize(1);
+        assertThat(data).first().hasFieldOrPropertyWithValue("id", slowExecution.getId());
+    }
+
+    @Test
+    protected void shouldRejectADurationFilterThatIsNotADuration() {
+        var tenantId = TestsUtils.randomTenant(this.getClass().getSimpleName());
+        var now = ZonedDateTime.now();
+        Executions<ColumnDescriptor<Executions.Fields>> dataFilter = Executions.<ColumnDescriptor<Executions.Fields>> builder()
+            .type(Executions.class.getName())
+            .columns(Map.of("id", ColumnDescriptor.<Executions.Fields> builder().field(Executions.Fields.ID).build()))
+            .where(List.of(GreaterThan.<Executions.Fields> builder().field(Executions.Fields.DURATION).value("1 second").build()))
+            .build();
+
+        assertThrows(InvalidQueryFiltersException.class, () -> executionRepository.fetchData(tenantId, dataFilter, now.minusHours(1), now, null));
     }
 
     private Execution executionWithDuration(String tenantId, Instant createDate, Duration duration) {

--- a/core/src/test/java/io/kestra/core/validations/DurationFilterValidationTest.java
+++ b/core/src/test/java/io/kestra/core/validations/DurationFilterValidationTest.java
@@ -1,0 +1,59 @@
+package io.kestra.core.validations;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+
+import io.kestra.core.junit.annotations.KestraTest;
+import io.kestra.core.models.dashboards.charts.Chart;
+import io.kestra.core.models.validations.ModelValidator;
+import io.kestra.core.serializers.YamlParser;
+
+import jakarta.inject.Inject;
+import jakarta.validation.ConstraintViolationException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@KestraTest
+class DurationFilterValidationTest {
+    @Inject
+    private ModelValidator modelValidator;
+
+    @Test
+    void shouldAcceptADurationFilterWrittenAsADuration() {
+        assertThat(modelValidator.isValid(chartFilteringDurationBy("PT1S")).isEmpty()).isTrue();
+    }
+
+    @Test
+    void shouldRejectADurationFilterThatIsNotADuration() {
+        Optional<ConstraintViolationException> valid = modelValidator.isValid(chartFilteringDurationBy("1 second"));
+
+        assertThat(valid.isEmpty()).isFalse();
+        assertThat(valid.get().getMessage()).contains("`1 second` is not a valid duration");
+    }
+
+    private static Chart<?> chartFilteringDurationBy(String value) {
+        return YamlParser.parse(
+            """
+                id: executions_by_state
+                type: io.kestra.plugin.core.dashboard.chart.Table
+                chartOptions:
+                  displayName: Executions by state
+                  pagination:
+                    enabled: false
+                data:
+                  type: io.kestra.plugin.core.dashboard.data.Executions
+                  columns:
+                    state:
+                      field: STATE
+                    count:
+                      agg: COUNT
+                  where:
+                    - field: DURATION
+                      type: GREATER_THAN
+                      value: "%s"
+                """.formatted(value),
+            Chart.class
+        );
+    }
+}

--- a/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcExecutionRepository.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcExecutionRepository.java
@@ -1,5 +1,6 @@
 package io.kestra.jdbc.repository;
 
+import java.time.Duration;
 import java.time.ZonedDateTime;
 import java.util.*;
 import java.util.function.Function;
@@ -34,6 +35,7 @@ import io.kestra.executor.ExecutionStateStore;
 import io.kestra.executor.ExecutorContext;
 import io.kestra.jdbc.services.JdbcFilterService;
 import io.kestra.plugin.core.dashboard.data.Executions;
+import io.kestra.plugin.core.dashboard.data.IExecutions;
 
 import io.micronaut.context.event.ApplicationEventPublisher;
 import io.micronaut.data.model.Pageable;
@@ -635,6 +637,9 @@ public abstract class AbstractJdbcExecutionRepository extends AbstractJdbcCrudRe
     protected <F extends Enum<F>> SelectConditionStep<Record> where(SelectConditionStep<Record> selectConditionStep, JdbcFilterService jdbcFilterService, List<AbstractFilter<F>> filters,
         Map<F, String> fieldsMapping) {
         if (!ListUtils.isEmpty(filters)) {
+            // state_duration holds milliseconds, while a DURATION filter carries a duration (`PT1S`, or a number of seconds)
+            filters = DurationFilters.normalize(filters, IExecutions.DURATION_FIELDS, Duration::toMillis);
+
             // Check if descriptors contain a filter of type Executions.Fields.STATE and apply the custom filter "statesFilter" if present
             selectConditionStep = applyStateFilters(filters, selectConditionStep);
 


### PR DESCRIPTION
Closes [https://github.com/kestra-io/kestra-ee/issues/10327](https://github.com/kestra-io/kestra-ee/issues/10327).

### ✨ Description

A dashboard chart whose `data.where` filtered `DURATION` with `value: PT1S` answered HTTP 500, and the response body carried the SQL that failed (`operator does not exist: bigint > character varying`). `value: 1000` returned 200, but meant milliseconds — while the DURATION column is rendered in seconds, so there was no format that both worked and matched what the chart displayed.

Three things were wrong:

1. **The value reached the store untouched.** `DURATION` maps to `state_duration` and `JdbcFilterService.greaterThan` binds the filter value as-is, so the query became `state_duration > 'PT1S'`. Every JDBC backend fails on this; Postgres is just the one whose message names the column.
2. **Units disagreed.** `state_duration` is milliseconds on all three JDBC backends, and `columnToField` divides by 1000 for display — so filtering used a different unit from the chart. ElasticSearch indexes `state.duration` in seconds, so a numeric filter also meant different things per edition.
3. **Bad input was a 500.** Nothing validated the value, at save time or at query time.

**How it is addressed**

* A data type declares its duration-typed fields — `IData.durationFields()`, overridden in `IExecutions` — so the rule lives in one place instead of being restated per store.
* New `DurationFilters` (core) rewrites the filters on those fields into the unit the store persists, recursing into `OR` and covering the comparison, `IN` and `NOT_IN` types; `IS_NULL`/`IS_NOT_NULL` pass through. Values are parsed through `JacksonMapper`, so a duration filter accepts exactly what every other duration in Kestra accepts: an ISO-8601 duration, or a number of seconds.
* `AbstractJdbcExecutionRepository.where()` normalizes with `Duration::toMillis`, which covers `fetchData`, KPI `fetchValue` and every EE JDBC repository, since those extend this class. The EE PR does the same with seconds for ElasticSearch.
* An unparseable value or an inapplicable filter type raises `InvalidQueryFiltersException`, which `ErrorController` already maps to 400, and `DataChartValidator`/`DataChartKPIValidator` report it as a chart violation — so a bad duration is rejected with a 422 when the dashboard is saved rather than surfacing when the chart renders.