### PR TITLE
fix(executions): reject negative concurrency running count and bind the limit to its path

### DIFF
--- a/core/src/main/java/io/kestra/core/runners/ConcurrencyLimit.java
+++ b/core/src/main/java/io/kestra/core/runners/ConcurrencyLimit.java
@@ -4,6 +4,7 @@ import io.kestra.core.models.HasUID;
 import io.kestra.core.utils.IdUtils;
 
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.PositiveOrZero;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Value;
@@ -23,6 +24,7 @@ public class ConcurrencyLimit implements HasUID {
     String flowId;
 
     @With
+    @PositiveOrZero
     Integer running;
 
     @Override

--- a/webserver/src/main/java/io/kestra/webserver/controllers/api/ConcurrencyLimitController.java
+++ b/webserver/src/main/java/io/kestra/webserver/controllers/api/ConcurrencyLimitController.java
@@ -45,11 +45,20 @@ public class ConcurrencyLimitController {
     @ExecuteOn(TaskExecutors.IO)
     @Put("/{namespace}/{flowId}")
     @Operation(tags = { "Flows" }, summary = "Update a flow concurrency limit")
-    public HttpResponse<ConcurrencyLimit> updateConcurrencyLimit(@Body @Valid ConcurrencyLimit concurrencyLimit) {
-        var existing = concurrencyLimitRepository.findById(tenantService.resolveTenant(), concurrencyLimit.getNamespace(), concurrencyLimit.getFlowId());
+    public HttpResponse<ConcurrencyLimit> updateConcurrencyLimit(String namespace, String flowId, @Body @Valid ConcurrencyLimit concurrencyLimit) {
+        String tenantId = tenantService.resolveTenant();
+        var existing = concurrencyLimitRepository.findById(tenantId, namespace, flowId);
         if (existing.isEmpty()) {
             return HttpResponse.notFound();
         }
-        return HttpResponse.ok(concurrencyLimitRepository.update(concurrencyLimit));
+
+        // The path identifies the resource; a body naming another flow must not retarget it.
+        ConcurrencyLimit toUpdate = ConcurrencyLimit.builder()
+            .tenantId(tenantId)
+            .namespace(namespace)
+            .flowId(flowId)
+            .running(concurrencyLimit.getRunning())
+            .build();
+        return HttpResponse.ok(concurrencyLimitRepository.update(toUpdate));
     }
 }

--- a/webserver/src/test/java/io/kestra/webserver/controllers/api/ConcurrencyLimitControllerTest.java
+++ b/webserver/src/test/java/io/kestra/webserver/controllers/api/ConcurrencyLimitControllerTest.java
@@ -77,6 +77,53 @@ class ConcurrencyLimitControllerTest {
     }
 
     @Test
+    @ExecuteFlow("flows/valids/flow-concurrency-queue.yml")
+    void shouldRejectNegativeRunningCount(Execution execution) {
+        ConcurrencyLimit existing = client.toBlocking().retrieve(
+            GET("/api/v1/main/concurrency-limit/" + execution.getNamespace() + "/" + execution.getFlowId()),
+            ConcurrencyLimit.class
+        );
+
+        HttpClientResponseException e = assertThrows(
+            HttpClientResponseException.class,
+            () -> client.toBlocking().exchange(
+                PUT("/api/v1/main/concurrency-limit/" + existing.getNamespace() + "/" + existing.getFlowId(), existing.withRunning(-5))
+            )
+        );
+
+        assertThat(e.getStatus().getCode()).isEqualTo(HttpStatus.UNPROCESSABLE_ENTITY.getCode());
+    }
+
+    @Test
+    @ExecuteFlow("flows/valids/flow-concurrency-queue.yml")
+    void shouldIdentifyConcurrencyLimitFromPathNotBody(Execution execution) {
+        // A body naming a different flow must not retarget it: the path identifies the resource.
+        ConcurrencyLimit spoofed = ConcurrencyLimit.builder()
+            .tenantId("main")
+            .namespace("evil.namespace")
+            .flowId("evil-flow")
+            .running(42)
+            .build();
+
+        ConcurrencyLimit updated = client.toBlocking().retrieve(
+            PUT("/api/v1/main/concurrency-limit/" + execution.getNamespace() + "/" + execution.getFlowId(), spoofed),
+            ConcurrencyLimit.class
+        );
+
+        assertThat(updated.getNamespace()).isEqualTo(execution.getNamespace());
+        assertThat(updated.getFlowId()).isEqualTo(execution.getFlowId());
+        assertThat(updated.getRunning()).isEqualTo(42);
+
+        HttpClientResponseException e = assertThrows(
+            HttpClientResponseException.class,
+            () -> client.toBlocking().exchange(
+                GET("/api/v1/main/concurrency-limit/evil.namespace/evil-flow")
+            )
+        );
+        assertThat(e.getStatus().getCode()).isEqualTo(HttpStatus.NOT_FOUND.getCode());
+    }
+
+    @Test
     void shouldReturnNotFoundWhenGettingConcurrencyLimitForUnknownFlow() {
         HttpClientResponseException e = assertThrows(
             HttpClientResponseException.class,


### PR DESCRIPTION
Companion PR: kestra-io/kestra-ee#10598 (same branch name).
Fixes kestra-io/kestra-ee#10294 (fix lives in OSS; the EE issue is closed by the companion EE PR).

### Problem

The flow concurrency-limit admin endpoint (`PUT /concurrency-limit/{namespace}/{flowId}`) had two input-handling holes:

- A **negative running count** was accepted with `200` and silently *disabled* the limit — a flow with `limit: 2` would then run every execution at once. `running: -5` went straight through.
- The **path was ignored**: the handler read `namespace`/`flowId` from the request *body*, not from the URL, so a request aimed at one flow could update a different flow named in the body.

### Fix

- `ConcurrencyLimit.running` now carries `@PositiveOrZero`; combined with the existing `@Body @Valid`, a negative count returns **422** instead of disabling the limit.
- The PUT handler binds `{namespace}`/`{flowId}` from the path and rebuilds the record from `path + resolved tenant + body's running`, so the URL is authoritative and a mismatched body can no longer retarget another flow.

### Evidence

`ConcurrencyLimitControllerTest` gains two tests — `shouldRejectNegativeRunningCount` (422) and `shouldIdentifyConcurrencyLimitFromPathNotBody` (path wins, spoofed flow is never created). Both fail on `develop` and pass here; the full class is green (5/5).
