### PR TITLE
ci: improve slot-contracts sync workflow reliability

### DIFF
--- a/.github/workflows/sync-slot-contracts.yml
+++ b/.github/workflows/sync-slot-contracts.yml
@@ -28,10 +28,23 @@ jobs:
         uses: actions/setup-node@v7
         with:
           node-version: 24.x
+          cache: npm
+          cache-dependency-path: ui/package-lock.json
 
+      # Installing from ui/packages/slot-contracts would install that workspace alone while still
+      # running ui's root postinstall (patch-package), which then fails on the root-only packages
+      # that install never brought in.
+      - name: Install UI dependencies
+        working-directory: ui
+        run: npm ci
+
+      # slot-contracts emits a flat .d.ts naming types imported from @kestra-io/kestra-sdk, whose
+      # declarations only exist once the committed SDK source is bundled.
       - name: Build slot-contracts
-        working-directory: ui/packages/slot-contracts
-        run: npm install && npm run build
+        working-directory: ui
+        run: |
+          npm run build:sdk
+          npm run build --workspace @kestra-io/slot-contracts
 
       - name: Set up Git
         run: |
@@ -52,8 +65,10 @@ jobs:
       - name: Sync contract files
         run: |
           DEST="artifact-sdk/packages/artifact-sdk/src/contracts"
-          rm -rf "$DEST"
           mkdir -p "$DEST"
+          # Prunes the previous sync's output only: the directory also holds artifact-sdk's own
+          # Readme.md, which nothing here regenerates.
+          find "$DEST" -maxdepth 1 -type f ! -name "*.md" -delete
           cp -r ui/packages/slot-contracts/dist/. "$DEST/"
 
       - name: Add changeset
@@ -82,17 +97,21 @@ jobs:
           fi
 
       - name: Commit and push
+        id: commit
         working-directory: artifact-sdk
         run: |
           git add packages/artifact-sdk/src/contracts .changeset
           if git diff --cached --quiet; then
             echo "No changes to sync. Exiting."
+            echo "pushed=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
           git commit -m "chore: sync slot contracts from kestra-io/kestra $(date +%s)"
           git push --force-with-lease origin chore/contracts
+          echo "pushed=true" >> "$GITHUB_OUTPUT"
 
       - name: Create or update PR
+        if: steps.commit.outputs.pushed == 'true'
         working-directory: artifact-sdk
         env:
           GH_TOKEN: ${{ secrets.GH_PERSONAL_TOKEN }}

--- a/ui/packages/slot-contracts/src/topology-task-modal.ts
+++ b/ui/packages/slot-contracts/src/topology-task-modal.ts
@@ -1,8 +1,7 @@
 import {defineArtifactSlot} from "./define-artifact-slot"
 import {propsSchema} from "./topology-details"
-import {z} from "zod"
 
-export default defineArtifactSlot(() => ({
+export default defineArtifactSlot((z) => ({
     key: "topology-task-modal",
     props: propsSchema,
     manifest: z.object({}),


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Put the closing keyword on the first line so the link is visible without scrolling and survives squash merges: -->
<!-- Closes https://github.com/kestra-io/kestra/issues/ISSUE_NUMBER. -->

### ✨ Description

Improves the `sync-slot-contracts` workflow to be more robust and maintainable:

1. **Fixed dependency installation**: Changed from installing only the `slot-contracts` workspace to installing all UI dependencies from the root. This ensures the root-level `postinstall` script (patch-package) runs correctly with all required packages available.

2. **Added SDK bundling step**: Added explicit `build:sdk` step before building slot-contracts, since the generated `.d.ts` files reference types from `@kestra-io/kestra-sdk` that only exist after the SDK source is bundled.

3. **Improved contract file syncing**: Changed from deleting the entire destination directory to selectively removing only generated files, preserving the directory's own `Readme.md` documentation that shouldn't be regenerated.

4. **Added conditional PR creation**: The "Create or update PR" step now only runs if changes were actually pushed, preventing unnecessary PR operations when there are no contract changes to sync.

5. **Added npm caching**: Configured Node.js action to cache npm dependencies for faster workflow execution.

### 📝 Additional Notes

These changes make the workflow more reliable by:
- Ensuring all dependencies are properly installed before building
- Explicitly handling the SDK bundling dependency
- Preserving documentation files during sync operations
- Avoiding unnecessary GitHub API calls when there are no changes

The workflow will now gracefully handle scenarios where there are no contract changes to sync, and will be faster due to npm caching.

https://claude.ai/code/session_01DNjv3eUzwze4UHiewvMnEQ