### PR TITLE
fix(system): sync slot contracts as kestrabot, pre-formatted for artifact-sdk

### DIFF
--- a/.github/workflows/sync-slot-contracts.yml
+++ b/.github/workflows/sync-slot-contracts.yml
@@ -13,6 +13,8 @@ jobs:
     name: Sync contracts to kestra-io/artifact-sdk
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    env:
+      CHANGESET_FILE: .changeset/sync-slot-contracts.md
     steps:
       - name: Checkout kestra
         uses: actions/checkout@v7
@@ -88,7 +90,6 @@ jobs:
         working-directory: artifact-sdk
         run: |
           mkdir -p .changeset
-          CHANGESET_FILE=".changeset/sync-slot-contracts.md"
           TODAY=$(date -u +%Y-%m-%d)
           if [ -f "$CHANGESET_FILE" ]; then
             # Update the date line in-place (line starting with "Last synced:")
@@ -108,6 +109,14 @@ jobs:
           Last synced: $TODAY
           EOF
           fi
+
+      # artifact-sdk's CI checks formatting repo-wide, so run the pinned oxfmt from its own root
+      # devDependencies (--workspaces=false keeps the install to those) over what we just wrote.
+      - name: Format the synced files
+        working-directory: artifact-sdk
+        run: |
+          npm ci --workspaces=false --ignore-scripts
+          npx oxfmt --write packages/artifact-sdk/src/contracts "$CHANGESET_FILE"
 
       - name: Commit and push
         id: commit

--- a/.github/workflows/sync-slot-contracts.yml
+++ b/.github/workflows/sync-slot-contracts.yml
@@ -17,11 +17,22 @@ jobs:
       - name: Checkout kestra
         uses: actions/checkout@v7
 
+      # The branch, the commit and the PR in artifact-sdk are all attributed to whoever owns the
+      # token this job pushes with, so mint kestrabot's instead of using a maintainer's own.
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ secrets.GH_BOT_APP_ID }}
+          private-key: ${{ secrets.GH_BOT_PRIVATE_KEY }}
+          owner: kestra-io
+          repositories: artifact-sdk
+
       - name: Checkout artifact-sdk
         uses: actions/checkout@v7
         with:
           repository: kestra-io/artifact-sdk
-          token: ${{ secrets.GH_PERSONAL_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
           path: artifact-sdk
 
       - name: Set up Node.js
@@ -48,8 +59,10 @@ jobs:
 
       - name: Set up Git
         run: |
-          git config --global user.name "GitHub Action"
-          git config --global user.email "actions@github.com"
+          # The number is kestrabot[bot]'s own user id: without it GitHub renders the commit
+          # author as plain text rather than linking it to the bot.
+          git config --global user.name "kestrabot[bot]"
+          git config --global user.email "173464359+kestrabot[bot]@users.noreply.github.com"
 
       - name: Create or reset chore/contracts branch
         working-directory: artifact-sdk
@@ -114,7 +127,7 @@ jobs:
         if: steps.commit.outputs.pushed == 'true'
         working-directory: artifact-sdk
         env:
-          GH_TOKEN: ${{ secrets.GH_PERSONAL_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           PR_EXISTS=$(gh pr list --repo kestra-io/artifact-sdk --head chore/contracts --base main --json number --jq '.[0].number')
           if [ -n "$PR_EXISTS" ]; then


### PR DESCRIPTION
### 🔗 Related Issue

Follow-up to https://github.com/kestra-io/kestra/pull/18847, which got this workflow running for the first time. Its first sync — https://github.com/kestra-io/artifact-sdk/pull/82 — exposed the two problems fixed here.

### ✨ Description

**The PR went up under a maintainer's name.** The branch, the commit and the PR in artifact-sdk are all attributed to whoever owns the token the job pushes with, and `GH_PERSONAL_TOKEN` is a personal one, so artifact-sdk#82 reads as authored by `tchiotludo`. This now mints a `kestrabot` token from `GH_BOT_APP_ID` / `GH_BOT_PRIVATE_KEY` scoped to `artifact-sdk` — the same `actions/create-github-app-token` pattern `update-generated-sdk.yml` and `publish-hey-api-plugin.yml` already use — and sets the git identity to `kestrabot[bot]` so the commit links to the bot too.

**The PR failed Lint & Format.** artifact-sdk formats with oxfmt (2 spaces) and checks it repo-wide, while slot-contracts emits kestra's 4-space style, so every sync would land red and need a manual fix-up commit. The job now runs artifact-sdk's *own* pinned oxfmt over the two files it writes, installing only that repo's root devDependencies (`npm ci --workspaces=false --ignore-scripts`, 8s).

### 📝 Additional Notes

Verified against a real artifact-sdk checkout at `bd6d9dc`, with the contracts built from this branch: `npm run format` flags exactly `packages/artifact-sdk/src/contracts/index.d.ts` and `index.js` before the new step and reports *all matched files use the correct format* after; `npm run lint` (oxlint) is clean; and the formatted output differs from the committed contract only where the contract genuinely changed (`metrics` → `progress`, plus the new `tenant`, `source`, `fetchOutputs` and `fetchMetrics` props).

One prerequisite I cannot check from CI config alone: the kestrabot app installation has to cover `artifact-sdk` with contents and pull-requests write. If it does not, the token step fails first in the job, before anything is pushed — so the failure mode is loud and empty-handed rather than half-done. kestrabot has no recorded activity in that repo yet, so it is worth confirming the installation before the next merge that touches `slot-contracts/src`.

The changeset path moved to a job-level `env` because two steps now reference it.

### 🤖 AI Authors

Why did the cat sit on the keyboard? It heard the contracts needed a paws-itive format check. 🐱

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DNjv3eUzwze4UHiewvMnEQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01DNjv3eUzwze4UHiewvMnEQ)_