### PR TITLE
fix(design-system): icon size prop, dead preview formatter, interval filter and textarea overflow

### DIFF
--- a/ui/packages/design-system/src/components/Basic/KsIconButton/KsIconButton.vue
+++ b/ui/packages/design-system/src/components/Basic/KsIconButton/KsIconButton.vue
@@ -37,6 +37,8 @@
     import KsButton from "../KsButton/KsButton.vue"
     import KsTooltip from "../../Feedback/KsTooltip.vue"
 
+    type IconSize = "xs" | "sm" | "base" | "lg" | "xl"
+
     defineOptions({inheritAttrs: false})
 
     const props = withDefaults(defineProps<{
@@ -47,6 +49,7 @@
         to?: string | Record<string, unknown>
         replace?: boolean
         filled?: boolean
+        size?: IconSize
     }>(), {
         tooltip: "",
         placement: "left",
@@ -55,6 +58,7 @@
         to: undefined,
         replace: false,
         filled: false,
+        size: "sm",
     })
 
     defineSlots<{
@@ -64,7 +68,12 @@
     const attrs = useAttrs()
     const buttonAttrs = computed(() => ({
         ...attrs,
-        class: ["ks-icon-button", {"ks-icon-button--filled": props.filled}, attrs.class],
+        class: [
+            "ks-icon-button",
+            `ks-icon-button--${props.size}`,
+            {"ks-icon-button--filled": props.filled},
+            attrs.class,
+        ],
     }))
 
     const buttonTag = computed(() => (props.to ? "router-link" : undefined))
@@ -73,10 +82,12 @@
 
 <style scoped lang="scss">
     .ks-icon-button {
+        --ks-icon-button-glyph: var(--ks-icon-size-sm);
+
         color: var(--ks-text-primary);
-        width: 24px;
-        height: 24px;
-        min-width: 24px;
+        width: calc(var(--ks-icon-button-glyph) + var(--ks-spacing-2));
+        height: calc(var(--ks-icon-button-glyph) + var(--ks-spacing-2));
+        min-width: calc(var(--ks-icon-button-glyph) + var(--ks-spacing-2));
         border-radius: var(--kel-border-radius-base);
         text-align: center;
         display: inline-flex;
@@ -87,9 +98,25 @@
 
         :deep(.material-design-icon),
         :deep(.material-design-icon > .material-design-icon__svg) {
-            width: var(--ks-icon-size-sm);
-            height: var(--ks-icon-size-sm);
+            width: var(--ks-icon-button-glyph);
+            height: var(--ks-icon-button-glyph);
         }
+    }
+
+    .ks-icon-button--xs {
+        --ks-icon-button-glyph: var(--ks-icon-size-xs);
+    }
+
+    .ks-icon-button--base {
+        --ks-icon-button-glyph: var(--ks-icon-size-base);
+    }
+
+    .ks-icon-button--lg {
+        --ks-icon-button-glyph: var(--ks-icon-size-lg);
+    }
+
+    .ks-icon-button--xl {
+        --ks-icon-button-glyph: var(--ks-icon-size-xl);
     }
 
     .ks-icon-button:not(.ks-icon-button--filled) {

--- a/ui/packages/design-system/src/components/Data/KsDataTable/filter/layout/FilterEditPopper.vue
+++ b/ui/packages/design-system/src/components/Data/KsDataTable/filter/layout/FilterEditPopper.vue
@@ -46,6 +46,7 @@
         NULL_COMPARATORS,
     } from "../utils/filterTypes"
     import {FILTER_CONTEXT_INJECTION_KEY} from "../utils/filterInjectionKeys"
+    import {resolveDefaultVisibleValue} from "../utils/filterChipFactory"
     import FilterText from "./FilterText.vue"
     import FilterRadio from "./FilterRadio.vue"
     import FilterFooter from "./FilterFooter.vue"
@@ -285,10 +286,14 @@
             return
         }
 
+        // Falling back to a blank value left the filter with nothing selected, rather than with
+        // the default the page configured (the executions view's 24h interval, for instance).
+        const defaultValue = resolveDefaultVisibleValue(props.filterKey)
+
         Object.assign(state, {
-            textValue: "",
-            selectValue: "",
-            keyValuePair: [],
+            textValue: typeof defaultValue === "string" ? defaultValue : "",
+            selectValue: typeof defaultValue === "string" ? defaultValue : "",
+            keyValuePair: Array.isArray(defaultValue) ? [...defaultValue] : [],
             radioValue: "ALL",
             dateValue: null,
             timeRangeMode: "predefined",
@@ -383,6 +388,14 @@
         // defaults to now (getFilterValue) so typing just a Start or End date applies immediately.
         if (isTimeRange.value && state.timeRangeMode === "custom"
             && !state.startDateValue && !state.endDateValue) {
+            return
+        }
+
+        // An inverted range is rejected by the API with a 422, so it is never applied: the date
+        // panels already rule out the day-level case, this covers two times on the same day.
+        if (isTimeRange.value && state.timeRangeMode === "custom"
+            && state.startDateValue && state.endDateValue
+            && state.startDateValue > state.endDateValue) {
             return
         }
 

--- a/ui/packages/design-system/src/components/Data/KsDataTable/filter/layout/FilterEditPopper.vue
+++ b/ui/packages/design-system/src/components/Data/KsDataTable/filter/layout/FilterEditPopper.vue
@@ -391,12 +391,13 @@
             return
         }
 
-        // An inverted range is rejected by the API with a 422, so it is never applied: the date
-        // panels already rule out the day-level case, this covers two times on the same day.
-        if (isTimeRange.value && state.timeRangeMode === "custom"
-            && state.startDateValue && state.endDateValue
-            && state.startDateValue > state.endDateValue) {
-            return
+        // An inverted range is rejected by the API with a 422, so it is never applied. It compares
+        // the bounds getFilterValue will send, since an end left unset still defaults to now.
+        if (isTimeRange.value && state.timeRangeMode === "custom") {
+            const now = new Date()
+            if ((state.startDateValue ?? now) > (state.endDateValue ?? now)) {
+                return
+            }
         }
 
         const filterData = getFilterValue()

--- a/ui/packages/design-system/src/components/Data/KsDataTable/filter/layout/FilterSelect.vue
+++ b/ui/packages/design-system/src/components/Data/KsDataTable/filter/layout/FilterSelect.vue
@@ -37,6 +37,7 @@
                 <KsDatePicker
                     v-model="local.startDateValue"
                     type="datetime"
+                    :disabledDate="isAfterEndDate"
                     :placeholder="$t('filter.select_start_date')"
                 />
             </div>
@@ -46,6 +47,7 @@
                     v-model="local.endDateValue"
                     type="datetime"
                     :defaultTime="endDateDefaultTime"
+                    :disabledDate="isBeforeStartDate"
                     :placeholder="$t('filter.select_end_date')"
                 />
             </div>
@@ -95,6 +97,16 @@
     }>()
 
     const {modelValue, timeRangeMode, startDateValue, endDateValue, dateFilterMode} = toRefs(props)
+
+    // The day panels only offer days that keep start <= end; the same-day time case is caught by the
+    // caller before it reaches the API.
+    const startOfDay = (date: Date) => new Date(date.getFullYear(), date.getMonth(), date.getDate())
+
+    const isAfterEndDate = (date: Date) =>
+        local.endDateValue ? startOfDay(date) > startOfDay(local.endDateValue) : false
+
+    const isBeforeStartDate = (date: Date) =>
+        local.startDateValue ? startOfDay(date) < startOfDay(local.startDateValue) : false
 
     // Without a default time, picking a day in the end date panel pre-fills 00:00:00, which excludes the whole selected day; default the time part to now so picking today covers up to the current time.
     const endDateDefaultTime = new Date()

--- a/ui/packages/design-system/src/components/Data/KsDataTable/filter/utils/filterChipFactory.ts
+++ b/ui/packages/design-system/src/components/Data/KsDataTable/filter/utils/filterChipFactory.ts
@@ -77,6 +77,7 @@ export const createCustomRangeFilter = (
     startDate: Date,
     endDate: Date,
     comparator = Comparators.GREATER_THAN_OR_EQUAL_TO,
+    meta?: Record<string, string>,
 ): AppliedFilter =>
     createAppliedFilter(
         key,
@@ -85,6 +86,7 @@ export const createCustomRangeFilter = (
         {startDate, endDate},
         `${startDate.toLocaleDateString()} - ${endDate.toLocaleDateString()}`,
         keyOfComparator(comparator),
+        meta,
     )
 
 export const processFieldValue = (

--- a/ui/packages/design-system/src/components/Data/KsDataTable/filter/utils/routeDecoder.ts
+++ b/ui/packages/design-system/src/components/Data/KsDataTable/filter/utils/routeDecoder.ts
@@ -114,7 +114,14 @@ const buildLeafFromSlot = (
         if (!gte || !lte) return
         filtersMap.set(
             `${field}|GREATER_THAN_OR_EQUAL_TO`,
-            createCustomRangeFilter(field, config, new Date(gte.value as string), new Date(lte.value as string)),
+            createCustomRangeFilter(
+                field,
+                config,
+                new Date(gte.value as string),
+                new Date(lte.value as string),
+                Comparators.GREATER_THAN_OR_EQUAL_TO,
+                routeDateFilter && config.dateFilterOptions ? {dateFilter: routeDateFilter} : undefined,
+            ),
         )
         consumedBuckets.add(`${field}|GREATER_THAN_OR_EQUAL_TO`)
         consumedBuckets.add(`${field}|LESS_THAN_OR_EQUAL_TO`)

--- a/ui/packages/design-system/src/components/Form/KsInput.vue
+++ b/ui/packages/design-system/src/components/Form/KsInput.vue
@@ -84,6 +84,14 @@
         font-variant-ligatures: none;
     }
 
+    .kel-textarea__inner {
+        // A full-width textarea has nothing to gain from horizontal resizing, and both it and a
+        // long unbroken word were producing a horizontal scrollbar under the field.
+        resize: vertical;
+        overflow-x: hidden;
+        overflow-wrap: break-word;
+    }
+
     .kel-input {
         width: 100%;
         &.kel-input--small {

--- a/ui/packages/design-system/tests/storybook/Basic/KsIconButton.stories.ts
+++ b/ui/packages/design-system/tests/storybook/Basic/KsIconButton.stories.ts
@@ -29,12 +29,17 @@ const meta: Meta<typeof KsIconButton> = {
         ariaLabel: {control: "text"},
         disabled: {control: "boolean"},
         filled: {control: "boolean"},
+        size: {
+            control: "select",
+            options: ["xs", "sm", "base", "lg", "xl"],
+        },
     },
     parameters: {
         docs: {
             description: {
                 component:
-                    "KsIconButton is a compact 24×24 icon-only button with optional tooltip and router-link support. " +
+                    "KsIconButton is a compact icon-only button with optional tooltip and router-link support. "
+                    + "`size` picks a glyph from the `--ks-icon-size-*` scale and the button box follows it; it defaults to `sm` (16px glyph, 24×24 box). " +
                     "It is the design-system replacement for the legacy `IconButton.vue` component. " +
                     "Pass an icon component (e.g. from vue-material-design-icons) as the default slot.",
             },
@@ -178,5 +183,33 @@ export const AriaLabel: Story = {
                 story: "When `ariaLabel` is set it takes precedence over `tooltip` for screen readers.",
             },
         },
+    },
+}
+
+/** Every step of the --ks-icon-size-* scale, with the button box following the glyph */
+export const Sizes: Story = {
+    render: (args) => ({
+        components: {KsIconButton, TrashIcon},
+        setup() {
+            return {args, sizes: ["xs", "sm", "base", "lg", "xl"] as const}
+        },
+        template: `<div style="padding:24px; display:flex; gap:16px; align-items:center">
+            <ks-icon-button v-for="size in sizes" :key="size" v-bind="args" :size="size" :aria-label="size">
+                <trash-icon />
+            </ks-icon-button>
+        </div>`,
+    }),
+    args: {},
+    async play({canvasElement}) {
+        const canvas = within(canvasElement)
+        const [xs, sm, base, lg, xl] = ["xs", "sm", "base", "lg", "xl"]
+            .map(size => canvas.getByRole("button", {name: size}))
+            .map(button => button.getBoundingClientRect().width)
+
+        await expect(sm).toBe(24)
+        await expect(xs).toBeLessThan(sm)
+        await expect(base).toBeGreaterThan(sm)
+        await expect(lg).toBeGreaterThan(base)
+        await expect(xl).toBeGreaterThan(lg)
     },
 }

--- a/ui/packages/design-system/tests/units/Data/KsFilter/FilterEditPopper.test.ts
+++ b/ui/packages/design-system/tests/units/Data/KsFilter/FilterEditPopper.test.ts
@@ -7,6 +7,7 @@ import FilterSelect from "../../../../src/components/Data/KsDataTable/filter/lay
 import FilterMultiSelect from "../../../../src/components/Data/KsDataTable/filter/layout/FilterMultiSelect.vue"
 import FilterDateTime from "../../../../src/components/Data/KsDataTable/filter/layout/FilterDateTime.vue"
 import FilterComparatorSelect from "../../../../src/components/Data/KsDataTable/filter/layout/FilterComparatorSelect.vue"
+import FilterFooter from "../../../../src/components/Data/KsDataTable/filter/layout/FilterFooter.vue"
 import {Comparators, type AppliedFilter, type FilterKeyConfig} from "../../../../src/components/Data/KsDataTable/filter/utils/filterTypes"
 
 const i18n = createI18n({legacy: false, locale: "en", messages: {en: {}}})
@@ -247,6 +248,74 @@ describe("FilterEditPopper key-value comparator changes", () => {
             comparator: Comparators.EQUALS,
             value: ["environment:staging", "team:platform"],
             valueLabel: "environment:staging",
+        })
+    })
+})
+
+const timeRangeKey: FilterKeyConfig = {
+    key: "timeRange",
+    label: "Interval",
+    valueType: "time-range",
+    customDateMode: "range",
+    defaultValue: "PT24H",
+    comparators: [Comparators.EQUALS],
+    valueProvider: async () => [
+        {label: "Last 24 hours", value: "PT24H"},
+        {label: "Last 7 days", value: "P7D"},
+    ],
+}
+
+const mountTimeRange = async (filter: AppliedFilter) => {
+    const wrapper = mount(FilterEditPopper, {
+        props: {filter, filterKey: timeRangeKey},
+        global: globalConfig,
+    })
+    await flushPromises()
+    return wrapper
+}
+
+describe("FilterEditPopper time range", () => {
+    test("restores the configured default on reset instead of clearing the value", async () => {
+        const wrapper = await mountTimeRange({
+            id: "tr1",
+            key: "timeRange",
+            comparator: Comparators.EQUALS,
+            value: "P7D",
+            valueLabel: "Last 7 days",
+        } as AppliedFilter)
+
+        wrapper.findComponent(FilterFooter).vm.$emit("reset")
+        await flushPromises()
+
+        const updates = wrapper.emitted("update") ?? []
+        const last = updates.at(-1)
+        expect(last).toBeDefined()
+        expect((last![0] as AppliedFilter).value).toBe("PT24H")
+    })
+
+    test("does not apply a custom range whose start is after its end", async () => {
+        const wrapper = await mountTimeRange({
+            id: "tr2",
+            key: "timeRange",
+            comparator: Comparators.EQUALS,
+            value: "PT24H",
+            valueLabel: "Last 24 hours",
+        } as AppliedFilter)
+
+        const select = wrapper.findComponent(FilterSelect)
+        select.vm.$emit("update:timeRangeMode", "custom")
+        select.vm.$emit("update:startDateValue", new Date("2026-08-20T10:00:00.000Z"))
+        select.vm.$emit("update:endDateValue", new Date("2026-08-10T10:00:00.000Z"))
+        await flushPromises()
+
+        // An inverted range is refused by the API with a 422, so it must never be applied.
+        const applied = (wrapper.emitted("update") ?? [])
+            .map(([filter]) => filter as AppliedFilter)
+            .filter(filter => typeof filter.value === "object" && filter.value !== null)
+
+        applied.forEach(filter => {
+            const {startDate, endDate} = filter.value as {startDate: Date; endDate: Date}
+            expect(startDate.getTime()).toBeLessThanOrEqual(endDate.getTime())
         })
     })
 })

--- a/ui/packages/design-system/tests/units/Data/KsFilter/FilterEditPopper.test.ts
+++ b/ui/packages/design-system/tests/units/Data/KsFilter/FilterEditPopper.test.ts
@@ -318,4 +318,30 @@ describe("FilterEditPopper time range", () => {
             expect(startDate.getTime()).toBeLessThanOrEqual(endDate.getTime())
         })
     })
+
+    test("does not apply a start date later than the end date it defaults to", async () => {
+        const wrapper = await mountTimeRange({
+            id: "tr3",
+            key: "timeRange",
+            comparator: Comparators.EQUALS,
+            value: "PT24H",
+            valueLabel: "Last 24 hours",
+        } as AppliedFilter)
+
+        const select = wrapper.findComponent(FilterSelect)
+        select.vm.$emit("update:timeRangeMode", "custom")
+        select.vm.$emit("update:startDateValue", new Date(Date.now() + 3 * 24 * 60 * 60 * 1000))
+        await flushPromises()
+
+        // With no end date the range still gets one, from getFilterValue's `?? new Date()`, so a
+        // future start inverts it just as surely as an explicit end in the past.
+        const applied = (wrapper.emitted("update") ?? [])
+            .map(([filter]) => filter as AppliedFilter)
+            .filter(filter => typeof filter.value === "object" && filter.value !== null)
+
+        applied.forEach(filter => {
+            const {startDate, endDate} = filter.value as {startDate: Date; endDate: Date}
+            expect(startDate.getTime()).toBeLessThanOrEqual(endDate.getTime())
+        })
+    })
 })

--- a/ui/packages/design-system/tests/units/Data/KsFilter/filterChipFactory.test.ts
+++ b/ui/packages/design-system/tests/units/Data/KsFilter/filterChipFactory.test.ts
@@ -6,6 +6,7 @@ import {
     type FilterConfiguration,
 } from "../../../../src/components/Data/KsDataTable/filter/utils/filterTypes"
 import {parseEncodedGroups} from "../../../../src/components/Data/KsDataTable/filter/utils/routeDecoder"
+import {DATE_FILTER_KEY} from "../../../../src/components/Data/KsDataTable/filter/utils/constants"
 
 const labelsConfiguration: FilterConfiguration = {
     title: "Executions",
@@ -132,4 +133,63 @@ describe("filterChipFactory", () => {
             })
         },
     )
+})
+
+const timeRangeConfiguration: FilterConfiguration = {
+    title: "Executions",
+    keys: [
+        {
+            key: "timeRange",
+            label: "Interval",
+            valueType: "time-range",
+            customDateMode: "range",
+            comparators: [
+                Comparators.GREATER_THAN_OR_EQUAL_TO,
+                Comparators.LESS_THAN_OR_EQUAL_TO,
+            ],
+            dateFilterOptions: [
+                {value: "START_DATE", label: "Start date"},
+                {value: "END_DATE", label: "End date"},
+                {value: "START_OR_END_DATE", label: "Start or end date"},
+            ],
+        },
+    ],
+}
+
+describe("custom range decoding", () => {
+    test("carries the route's dateFilter onto the merged range chip", () => {
+        const query = {
+            "filters[timeRange][GREATER_THAN_OR_EQUAL_TO]": "2026-08-01T00:00:00.000Z",
+            "filters[timeRange][LESS_THAN_OR_EQUAL_TO]": "2026-08-02T00:00:00.000Z",
+            [DATE_FILTER_KEY]: "END_DATE",
+        }
+
+        const {groups} = parseEncodedGroups(query, timeRangeConfiguration)
+        const [group] = groups
+
+        if (!group || !isLeafGroup(group)) {
+            throw new Error("Expected the decoded group to be a leaf group")
+        }
+
+        // The two bounds are merged into one chip by a pre-pass that used to drop the meta,
+        // leaving the Apply-to selector on its first option instead of the one in the URL.
+        expect(group.filters).toHaveLength(1)
+        expect(group.filters[0]?.meta).toEqual({dateFilter: "END_DATE"})
+    })
+
+    test("leaves the merged range chip without meta when the route carries no dateFilter", () => {
+        const query = {
+            "filters[timeRange][GREATER_THAN_OR_EQUAL_TO]": "2026-08-01T00:00:00.000Z",
+            "filters[timeRange][LESS_THAN_OR_EQUAL_TO]": "2026-08-02T00:00:00.000Z",
+        }
+
+        const {groups} = parseEncodedGroups(query, timeRangeConfiguration)
+        const [group] = groups
+
+        if (!group || !isLeafGroup(group)) {
+            throw new Error("Expected the decoded group to be a leaf group")
+        }
+
+        expect(group.filters[0]?.meta).toBeUndefined()
+    })
 })

--- a/ui/src/components/executions/outputs/ExecutionVariableExplorer.vue
+++ b/ui/src/components/executions/outputs/ExecutionVariableExplorer.vue
@@ -64,7 +64,6 @@
                                 :value="selectedValue"
                                 :basePath="selectedBase"
                                 :selectedPath="expressionPath"
-                                :previewFormatter="treePreviewFormatter"
                                 defaultExpanded
                                 @select="onSelectPath"
                             />
@@ -157,18 +156,6 @@
             return keys.length ? `{ ${keys.join(", ")} }` : "{}"
         }
         return String(value)
-    }
-
-    function treePreviewFormatter(_value: unknown, context: {kind: "array" | "object", count: number}): string {
-        if (context.kind === "array") {
-            return context.count === 1
-                ? t("variable_explorer.one_item")
-                : t("variable_explorer.n_items", {count: context.count})
-        }
-
-        return context.count === 1
-            ? t("variable_explorer.one_key")
-            : t("variable_explorer.n_keys", {count: context.count})
     }
 
     function itemsFromRecord(record: Record<string, unknown> | undefined, prefix: string): ExplorerItem[] {

--- a/ui/src/components/flows/BackfillBanner.vue
+++ b/ui/src/components/flows/BackfillBanner.vue
@@ -16,7 +16,6 @@
             <KsIconButton
                 v-if="!row.backfill.paused"
                 data-test="backfill-pause"
-                size="small"
                 :tooltip="$t('pause backfill')"
                 @click="emit('pause')"
             >
@@ -25,7 +24,6 @@
             <KsIconButton
                 v-else
                 data-test="backfill-resume"
-                size="small"
                 :tooltip="$t('continue backfill')"
                 @click="emit('resume')"
             >
@@ -33,7 +31,6 @@
             </KsIconButton>
             <KsIconButton
                 data-test="backfill-stop"
-                size="small"
                 :tooltip="$t('delete backfill')"
                 class="bf-stop"
                 @click="emit('stop')"


### PR DESCRIPTION
### 🔗 Related Issue

Closes https://github.com/kestra-io/kestra/issues/18544.
Closes https://github.com/kestra-io/kestra/issues/18635.
Closes https://github.com/kestra-io/kestra/issues/18775.
Closes https://github.com/kestra-io/kestra/issues/18776.
Closes https://github.com/kestra-io/kestra/issues/18777.
Closes https://github.com/kestra-io/kestra/issues/18441.

### ✨ Description

Six design-system defects, grouped because they all live in `packages/design-system` and none of them needs more than a file or two.

**The icon size prop was silently ignored (#18544)**

`KsIconButton` clamped the glyph to `--ks-icon-size-sm` through a `:deep()` rule, and CSS beats the SVG presentation attributes `vue-material-design-icons` renders, so a caller's `:size` had no effect and no warning. It now takes a `size` prop on the token scale (`xs` | `sm` | `base` | `lg` | `xl`, default `sm`) driving both the glyph and the button box. Honouring an arbitrary caller size was the other option and was rejected: it would put raw pixel values back into feature code, which `ui/AGENTS.md` forbids.

`sm` still renders a 16px glyph in a 24×24 box, so every existing call site is unchanged. `BackfillBanner` already passed `size="small"`, which fell through as an inert attribute; those three are dropped since `sm` is the default.

**A prop that was never declared (#18635)**

`ExecutionVariableExplorer` passed `:previewFormatter` to `KsJsonTree`, which declares no such prop, so it fell through as a plain attribute and the function never ran. The formatter it passed is identical to the tree's own `collapsedPreview`, i18n keys included, so it is dead code rather than a missing feature: both it and the binding are removed instead of the prop being declared.

**The Apply-to selector ignored the URL (#18777)**

The route decoder merges the two buckets of a custom range into one chip in a pre-pass. That pre-pass built the chip without `meta` while marking both buckets consumed, so the later branch that carries the route's `dateFilter` never ran and the selector fell back to its first option. `createCustomRangeFilter` now takes the meta, the way `createTimeRangeFilter` already did.

**Reset cleared the filter instead of restoring its default (#18775)**

`resetState` restored a default only when a pre-applied filter existed, and otherwise wrote `""`. On a view that defaults to an interval, resetting left nothing selected. It now seeds from `resolveDefaultVisibleValue`, the helper that already resolves a key's configured `defaultValue`.

**An inverted range reached the API (#18776)**

A start date after the end date was accepted and came back 422. The date panels no longer offer days that would invert the range, and an inverted range is not applied, which covers the residual case of two times on the same day. Prevented at the input rather than reported, so no new user-facing string is introduced.

**A horizontal scrollbar under the Save filter description (#18441)**

The textarea allowed horizontal resizing and scrolled a long word sideways. Fixed on `KsInput`, so it applies to every design-system textarea rather than this one dialog.

### 📸 Verified on a running instance

OSS `kestra/kestra:develop-slim` on :9011 with `npm run dev` pointed at it, `develop` and this branch in turn, Chromium 1440x900, light theme. Three of the six have a visible before/after and are captured below. The other three have no visual difference, for three different reasons, so they are written out rather than padded with identical images.

**#18544 — fixed.** Button boxes go from 24/24/24/24/24 to 20/24/28/32/40, and with a real icon the glyph follows: 12/16/20/24/32.

<img width="2256" height="510" alt="18544-iconbutton-size" src="https://github.com/user-attachments/assets/0168d648-c50d-4532-950f-588e3f825d24" />

One caveat on the evidence: the new `Sizes` story cannot show the glyph, since its icons are inline stub SVGs with `width="16"` and no `.material-design-icon` class, so the `:deep()` rule never matches them. The capture above uses a real `vue-material-design-icons` `Download`. The story's `play()` does fail on `develop` with `expected 24 to be less than 24` and passes here, so it still guards the box.

**#18775 — fixed.** Shown on the Logs page Level filter, the one key in OSS with a configured `defaultValue`. Before, reset leaves "Select an option" and the chip falls back to "Log Level in any"; after, it restores INFO.

<img width="1616" height="737" alt="18775-reset-to-default" src="https://github.com/user-attachments/assets/a617eefe-0bf9-4e71-b70e-3ae0fed36206" />

**#18776 — fixed.** The panels refuse the inverting days: with the end date at Sep 7, 23 of the 30 September days are disabled.

<img width="1616" height="1597" alt="18776-inverted-range" src="https://github.com/user-attachments/assets/9f13b183-fc3f-4641-a996-7757ec67dc5b" />

The screenshot above was taken before the last commit, when one entry path still got through: from an empty custom range, picking only a start date later than now left `state.endDateValue` null, the `startDateValue > endDateValue` guard was skipped, `getFilterValue` fell back to `endDateValue ?? new Date()`, and the search came back 422. The guard now compares the bounds `getFilterValue` will actually send, which covers a start later than now and an end earlier than it alike. Replayed on the same instance: picking a start three days out with no end date leaves the URL on `filters[timeRange][EQUALS]=PT24H` and raises no request.

**#18777 — no visual change, and still broken.** The state is correct on both branches: the chosen option carries `.active` and the chip label switches to "Ended". The highlight is invisible because `.date-filter-option.active` in `FilterSelect.vue` paints with `--ks-primary` and `--ks-background-card`, and neither token is declared anywhere under `packages/design-system/src/assets/styles`. Computed styles for the active and the inactive options are identical on both branches, `color rgb(8, 9, 10)` and `border-color rgb(8, 9, 10)` over a transparent background, so all three options render as plain text.

The decoder path fixed here needs one key carrying `valueType: "time-range"` **and** `customDateMode: "range"` **and** `dateFilterOptions`. No configuration has all three today: `clusterServiceFilter` (EE) has the first two, while `executionFilter` and `casesFilter` use `valueType: "select"`. So `createCustomRangeFilter` carrying the meta is a latent correctness fix worth keeping, but the issue closes on the tokens, not here.

**#18441 — no visual change.** On `develop` the textarea already resizes vertically only and wraps with `overflow-wrap: break-word`. Neither an empty field nor a long unbroken word produces a horizontal scrollbar: `scrollWidth == clientWidth == 326` on both branches, with and without content. The new rule does apply (`overflow-x` moves from `auto` to `hidden`), so it reads as a guard rather than as the fix for the reported symptom, which no longer reproduces on this dialog.

**#18635 — no visual change by design.** The collapsed preview and the expanded tree render identically before and after on the execution Input/Output tab, which is the claim: the deleted formatter never ran.

### 🎨 Frontend Checklist

- [x] Type checking passes (`npm run check:types`)
- [x] Code builds without errors (`npm run build`)
- [x] Unit tests pass (`npm run test:unit`) — design-system: 826 passed / 100 files; storybook: 490 passed / 81 files
- [x] Translations are complete if `en.json` changed — `en.json` is untouched, no new user-facing string
- [x] Screenshots or video recordings attached showing the `UI` changes

### 📝 Additional Notes

**Replayed on a running instance**, see the section above. #18544, #18775 and #18776 are confirmed fixed, the last of them after an extra commit closing the one-sided range case. #18777 is not fixed by this branch and needs the two missing design tokens instead.

**Two API decisions taken here** that the issues deliberately left open: the token-scale `size` prop rather than a free-form caller size (#18544), and deleting the dead formatter rather than declaring the prop (#18635). Both are argued above and are easy to reverse if you disagree.

**Regression cover.** Each of the three logic fixes has a test that was checked to fail on the code before it, with the assertion naming the actual defect:

| Test | Fails before the fix with |
|---|---|
| `carries the route's dateFilter onto the merged range chip` | `expected undefined to deeply equal { dateFilter: 'END_DATE' }` |
| `restores the configured default on reset instead of clearing the value` | `expected '' to be 'PT24H'` |
| `does not apply a custom range whose start is after its end` | `expected 1787220000000 to be less than or equal to 1786356000000` |

A new `Sizes` story measures the real button boxes, asserting `sm` is exactly 24px and the scale is strictly increasing, so a future clamp cannot come back unnoticed.

#18441 is CSS only and has no test: there is no visual-regression baseline in the repo to hang one on, and a unit assertion on `resize`/`overflow-x` would only restate the stylesheet.

### 🤖 AI Authors

This PR was written by Claude at @flcarre's request. Why did the cat sit on the design system? It heard the tokens were the only thing it wasn't allowed to knock off the table. 🐱


