### PR TITLE
fix(namespaces): require a dot boundary when skipping the KV allow-list

### DIFF
--- a/core/src/main/java/io/kestra/core/services/KVStoreService.java
+++ b/core/src/main/java/io/kestra/core/services/KVStoreService.java
@@ -2,6 +2,7 @@ package io.kestra.core.services;
 
 import java.io.IOException;
 
+import io.kestra.core.exceptions.ResourceAccessDeniedException;
 import io.kestra.core.repositories.KvMetadataRepositoryInterface;
 import io.kestra.core.storages.StorageInterface;
 import io.kestra.core.storages.kv.InternalKVStore;
@@ -33,11 +34,13 @@ public class KVStoreService {
      * @return The {@link KVStore}.
      */
     public KVStore get(String tenant, String namespace, @Nullable String fromNamespace) {
-        boolean isNotSameNamespace = fromNamespace != null && !namespace.equals(fromNamespace);
-        if (isNotSameNamespace && isNotParentNamespace(namespace, fromNamespace)) {
+        // A namespace inherits the K/V store of its ancestors, so the allow-list only governs access to any other namespace.
+        boolean inheritsTargetNamespace = fromNamespace != null && isDescendantOrSelf(namespace, fromNamespace);
+
+        if (fromNamespace != null && !inheritsTargetNamespace) {
             try {
                 namespaceService.checkAllowedNamespace(tenant, namespace, tenant, fromNamespace);
-            } catch (IllegalArgumentException e) {
+            } catch (ResourceAccessDeniedException e) {
                 throw new KVStoreException(
                     String.format(
                         "Cannot access the KV store. Access to '%s' namespace is not allowed from '%s'.", namespace, fromNamespace
@@ -47,8 +50,7 @@ public class KVStoreService {
         }
 
         // Only check namespace existence if not a descendant
-        boolean checkIfNamespaceExists = fromNamespace == null || isNotParentNamespace(namespace, fromNamespace);
-        if (checkIfNamespaceExists && !namespaceService.isNamespaceExists(tenant, namespace)) {
+        if (!inheritsTargetNamespace && !namespaceService.isNamespaceExists(tenant, namespace)) {
             // if it didn't exist, we still check if there are KV as you can add KV without creating a namespace in DB or having flows in it
             KVStore kvStore = new InternalKVStore(tenant, namespace, storageInterface, kvMetadataRepository);
             try {
@@ -69,7 +71,10 @@ public class KVStoreService {
         return new InternalKVStore(tenant, namespace, storageInterface, kvMetadataRepository);
     }
 
-    private static boolean isNotParentNamespace(final String parentNamespace, final String childNamespace) {
-        return !childNamespace.startsWith(parentNamespace);
+    /**
+     * The trailing dot is required: without it 'prod2' would be treated as a descendant of 'prod' and skip the allow-list.
+     */
+    private static boolean isDescendantOrSelf(final String parentNamespace, final String childNamespace) {
+        return childNamespace.equals(parentNamespace) || childNamespace.startsWith(parentNamespace + ".");
     }
 }

--- a/core/src/test/java/io/kestra/core/services/KVStoreServiceTest.java
+++ b/core/src/test/java/io/kestra/core/services/KVStoreServiceTest.java
@@ -16,6 +16,7 @@ import io.micronaut.test.annotation.MockBean;
 import jakarta.inject.Inject;
 
 import static io.kestra.core.tenant.TenantService.MAIN_TENANT;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @KestraTest
 class KVStoreServiceTest {
@@ -47,6 +48,13 @@ class KVStoreServiceTest {
     }
 
     @Test
+    void shouldDenyKVStoreAccessWhenAccessingFromPrefixSiblingNamespace() {
+        assertThatThrownBy(() -> storeService.get(MAIN_TENANT, "prod", "prod2"))
+            .isInstanceOf(KVStoreException.class)
+            .hasMessageContaining("Access to 'prod' namespace is not allowed from 'prod2'");
+    }
+
+    @Test
     void shouldGetKVStoreFromNonExistingNamespaceWithAKV() throws IOException {
         KVStore kvStore = new InternalKVStore(MAIN_TENANT, "system", storageInterface, kvMetadataRepository);
         kvStore.put("key", new KVValueAndMetadata(new KVMetadata("myDescription", Duration.ofHours(1)), "value"));
@@ -63,6 +71,12 @@ class KVStoreServiceTest {
         @Override
         public boolean isNamespaceExists(String tenant, String namespace) {
             return namespace.equals(TEST_EXISTING_NAMESPACE);
+        }
+
+        /** Emulates an EE allow-list where every namespace allows only itself, which OSS never denies. */
+        @Override
+        public boolean isAllowedNamespace(String tenant, String namespace, String fromTenant, String fromNamespace) {
+            return namespace.equals(fromNamespace);
         }
     }
 }


### PR DESCRIPTION
## What

`KVStoreService.checkAccessNamespaceIsAllowed` skips the **Allowed Namespaces** check when the calling namespace is a descendant of the target so that KV inheritance keeps working. However, the descendant test was a bare `startsWith` with no dot boundary:

```java
return !childNamespace.startsWith(parentNamespace);

```

Because `"prod2".startsWith("prod")` evaluates to `true`, a flow in `prod2` was incorrectly treated as a child of `prod`. The allow-list was never consulted, granting access to `prod`'s KV store. The same flaw applies to sibling namespaces like `company.team2` against `company.team`.

**Why It Matters**

* **EE Scope:** EE only. In OSS, namespaces are not an authorization boundary and `isAllowedNamespace` is documented as always returning `true`.
* **Impacted Entry Points:** Reachable from `KvFunction` (`kv('key', namespace=…)`) and `RunContext.namespaceKv` (which backs `kv.Set` and `kv.Put`), meaning prefix-sibling writes are in scope, not just reads. `kv.Get`, `kv.Delete`, and `kv.GetKeys` invoke `acl().allowNamespace(…).check()` first and are not bypassed by this path.
* **REST Controllers:** Unaffected, as both call `kvStore(namespace)` where `fromNamespace == namespace`, so the shortcut never triggers.

**Changes Made**

* **Hierarchy Rule Standardization:** Replaced `isNotParentNamespace` with `isDescendantOrSelf`, utilizing `parent + "."`. This aligns with `Namespace.isInHierarchy` in EE, ensuring the allow-list and descendant check agree on what constitutes a descendant.
* **Call Sites Updated:** Applied to both the allow-list skip and the namespace-existence skip.
* **Exception Handling:** Swapped `catch (IllegalArgumentException)` to `catch (ResourceAccessDeniedException)`. The original catch block was dead code because `checkAllowedNamespace` throws `ResourceAccessDeniedException`. Without this change, a denial escaped as a raw access-denied exception rather than the documented `KVStoreException`.
* **Same-Namespace Behavior:** Unchanged. `isDescendantOrSelf` returns `true` for equal strings, matching the previous `startsWith` behavior.

**Testing**

* **New Coverage:** Added `KVStoreServiceTest.shouldDenyKVStoreAccessWhenAccessingFromPrefixSiblingNamespace` (`prod2` → `prod` is denied). Fails before the change, passes after.
* **Mock Refactoring:** Updated class mocks from OSS's always-allow behavior to emulate an EE allow-list (where each namespace allows only itself).
* **Regression Protection:** The mock update turns `shouldGetKVStoreForAnyNamespaceWhenAccessingFromChildNamespace` into a positive control, ensuring a real dot-descendant still skips the allow-list.