### PR TITLE
build: optimize test runner parallelism and per-module heap sizing

### DIFF
--- a/.github/workflows/e2e-scheduling.yml
+++ b/.github/workflows/e2e-scheduling.yml
@@ -36,7 +36,7 @@ jobs:
       OTLP_ENDPOINT: ${{ secrets.OTLP_ENDPOINT }}
     steps:
       - name: OpenTelemetry - Export trace
-        uses: kestra-io/actions/actions/otel-collect@main
+        uses: kestra-io/actions/actions/otel-export-trace@main
         if: ${{ env.OTLP_ENDPOINT != '' }}
         with:
           mode: export-all

--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -174,7 +174,7 @@ jobs:
       OTLP_ENDPOINT: ${{ secrets.OTLP_ENDPOINT }}
     steps:
       - name: OpenTelemetry - Export trace
-        uses: kestra-io/actions/actions/otel-collect@main
+        uses: kestra-io/actions/actions/otel-export-trace@main
         if: ${{ env.OTLP_ENDPOINT != '' }}
         with:
           mode: export-all

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -120,7 +120,7 @@ jobs:
       OTLP_ENDPOINT: ${{ secrets.OTLP_ENDPOINT }}
     steps:
       - name: OpenTelemetry - Export trace
-        uses: kestra-io/actions/actions/otel-collect@main
+        uses: kestra-io/actions/actions/otel-export-trace@main
         if: ${{ env.OTLP_ENDPOINT != '' }}
         with:
           mode: export-all

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -308,7 +308,7 @@ jobs:
       OTLP_ENDPOINT: ${{ secrets.OTLP_ENDPOINT }}
     steps:
       - name: OpenTelemetry - Export trace
-        uses: kestra-io/actions/actions/otel-collect@main
+        uses: kestra-io/actions/actions/otel-export-trace@main
         if: ${{ env.OTLP_ENDPOINT != '' }}
         with:
           mode: export-all

--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -57,7 +57,7 @@ jobs:
       OTLP_ENDPOINT: ${{ secrets.OTLP_ENDPOINT }}
     steps:
       - name: OpenTelemetry - Export trace
-        uses: kestra-io/actions/actions/otel-collect@main
+        uses: kestra-io/actions/actions/otel-export-trace@main
         if: ${{ env.OTLP_ENDPOINT != '' }}
         with:
           mode: export-all

--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,6 @@ plugins {
     id "application"
 
     // test
-    id "com.adarshr.test-logger" version "4.0.0"
     id "org.sonarqube" version "7.4.0.8496"
     id 'jacoco-report-aggregation'
 
@@ -34,7 +33,7 @@ plugins {
     id "org.owasp.dependencycheck" version "12.2.2" apply false
 
     // Formatting
-    id "io.kestra.gradle.spotless-conventions" version "1.2.6"
+    id "io.kestra.gradle.spotless-conventions" version "1.2.10"
 }
 
 idea {
@@ -171,11 +170,29 @@ allprojects {
 /**********************************************************************************************************************\
  * Test
  **********************************************************************************************************************/
+
+// Per-module test heap, sized from measured peak GC heap occupancy (dev-tools/analyze-test-heap.sh,
+// run with -PprofileHeap) plus ~30% headroom. A single blanket value either wastes memory on small
+// modules or starves large ones — re-profile and bump a module's entry here if it starts failing
+// with OutOfMemoryError / GC overhead limit exceeded.
+ext.testHeapSizes = [
+    'processor'        : '256m',
+    'executor'         : '768m',
+    'scheduler'        : '768m',
+    'worker'           : '768m',
+    'jdbc-mysql'       : '768m',
+    'jdbc-postgres'    : '1024m',
+    'tests'            : '1024m',
+    'cli'              : '1280m',
+    'jdbc-h2'          : '1280m',
+    'webserver'        : '1280m',
+    'core'             : '2560m',
+]
+
 subprojects {subProj ->
 
     if (subProj.name != 'platform' && subProj.name != 'jmh-benchmarks') {
 
-        apply plugin: "com.adarshr.test-logger"
         apply plugin: 'jacoco'
 
         java {
@@ -251,8 +268,22 @@ subprojects {subProj ->
                 logger.lifecycle("[TASK END]   ${t.path}")
             }
 
-            // set Xmx for test workers
-            t.maxHeapSize = '4g'
+            // -PprofileHeap: raise the ceiling so no module is heap-starved, and log real GC
+            // occupancy per module so per-module maxHeapSize can be set from measurements
+            // instead of guessed. See dev-tools/analyze-test-heap.sh.
+            if (project.hasProperty('profileHeap')) {
+                t.maxHeapSize = '8g'
+                def heapProfileDir = "${rootDir}/heap-profile"
+                mkdir(heapProfileDir)
+                t.jvmArgs += ["-Xlog:gc:file=${heapProfileDir}/${project.name}-gc.log:time,uptime,level,tags"]
+            } else {
+                t.maxHeapSize = rootProject.ext.testHeapSizes.getOrDefault(project.name, '512m')
+            }
+
+            // By default a thread that hits OutOfMemoryError just dies silently (JVM default
+            // UncaughtExceptionHandler) while the rest of the JVM limps on in a degraded state.
+            // Exit immediately instead.
+            t.jvmArgs += ["-XX:+ExitOnOutOfMemoryError"]
 
             // configure en_US default locale for tests
             t.systemProperty 'user.language', 'en'
@@ -360,17 +391,6 @@ subprojects {subProj ->
         tasks.named('check') {
             dependsOn(tasks.named('test'))// default behaviour
             dependsOn(tasks.named('flakyTest'))
-        }
-
-        testlogger {
-            theme = 'mocha-parallel'
-            showExceptions = true
-            showFullStackTraces = true
-            showCauses = true
-            slowThreshold = 2000
-            showStandardStreams = true
-            showPassedStandardStreams = false
-            showSkippedStandardStreams = true
         }
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -261,12 +261,7 @@ subprojects {subProj ->
             t.systemProperty 'junit.jupiter.execution.timeout.default',
                 System.getenv('JUNIT_TEST_TIMEOUT_MIN') ? "${System.getenv('JUNIT_TEST_TIMEOUT_MIN')} m" : '5 m'
             t.finalizedBy jacocoTestReport
-            t.doFirst {
-                logger.lifecycle("[TASK START] ${t.path}")
-            }
-            t.doLast {
-                logger.lifecycle("[TASK END]   ${t.path}")
-            }
+
 
             // -PprofileHeap: raise the ceiling so no module is heap-starved, and log real GC
             // occupancy per module so per-module maxHeapSize can be set from measurements

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 version=2.0.0-SNAPSHOT
 
-org.gradle.jvmargs=-Xmx2g -XX:MaxMetaspaceSize=512m -XX:+HeapDumpOnOutOfMemoryError
+org.gradle.jvmargs=-Xmx2g -XX:MaxMetaspaceSize=512m -XX:+ExitOnOutOfMemoryError -XX:+HeapDumpOnOutOfMemoryError
 org.gradle.parallel=true
 org.gradle.caching=true
 org.gradle.priority=low

--- a/settings.gradle
+++ b/settings.gradle
@@ -2,6 +2,15 @@ plugins {
     id("io.kestra.gradle.develocity-conventions") version "1.2.6"
     id("com.gradle.common-custom-user-data-gradle-plugin") version "2.8.0"
     id("io.github.ben-manes.versions.settings") version "0.61.0"
+    id 'io.kestra.gradle.test-scheduling' version '1.2.10'
+    id 'io.kestra.gradle.logger' version '1.2.10'
+}
+
+// Longest test modules first, measured with dev-tools/analyze-test-heap.sh. Gradle's scheduler has
+// no duration awareness, so without this the light modules — which become dependency-ready first —
+// grab every worker slot and the multi-minute modules start late and set the critical path.
+kestraTestScheduling {
+    priority = [':jdbc-postgres', ':jdbc-h2', ':jdbc-mysql', ':webserver', ':core', ':scheduler']
 }
 
 rootProject.name = "kestra"

--- a/settings.gradle
+++ b/settings.gradle
@@ -10,7 +10,7 @@ plugins {
 // no duration awareness, so without this the light modules — which become dependency-ready first —
 // grab every worker slot and the multi-minute modules start late and set the critical path.
 kestraTestScheduling {
-    priority = [':jdbc-postgres', ':jdbc-h2', ':jdbc-mysql', ':webserver', ':core', ':scheduler']
+    priority = [':jdbc-mysql', ':jdbc-postgres', ':jdbc-h2', ':webserver', ':core', ':scheduler']
 }
 
 rootProject.name = "kestra"

--- a/settings.gradle
+++ b/settings.gradle
@@ -10,7 +10,7 @@ plugins {
 // no duration awareness, so without this the light modules — which become dependency-ready first —
 // grab every worker slot and the multi-minute modules start late and set the critical path.
 kestraTestScheduling {
-    priority = [':jdbc-mysql', ':jdbc-postgres', ':jdbc-h2', ':webserver', ':core', ':scheduler']
+    priority = [':webserver', ':jdbc-mysql', ':jdbc-postgres', ':jdbc-h2', ':core', ':scheduler']
 }
 
 rootProject.name = "kestra"


### PR DESCRIPTION
## Summary
- Companion to kestra-io/kestra-ee#9961 for the OSS repo.
- Apply `io.kestra.gradle.test-scheduling` to run the longest-running test modules first (`jdbc-postgres`, `jdbc-h2`, `jdbc-mysql`, `webserver`, `core`, `scheduler`) instead of letting whichever module becomes dependency-ready first grab worker slots.
- Apply `io.kestra.gradle.logger` in place of `com.adarshr.test-logger`, which also reports per-module peak heap usage.
- Replace the blanket `maxHeapSize = '4g'` for all test JVMs with per-module sizes based on measured GC peak occupancy plus ~30% headroom, avoiding both wasted memory on small modules and starvation on large ones.
- Add `-XX:+ExitOnOutOfMemoryError` so a test JVM that OOMs exits immediately instead of limping on in a degraded state after a thread silently dies.
- Bump `io.kestra.gradle.spotless-conventions` to `1.2.10` to match the other `io.kestra.gradle.*` plugins pulled in here.

The `dev-tools/analyze-test-heap.sh` profiling script used to measure the per-module heap values (and its `heap-profile/` output) are intentionally not included in this PR.

## Test plan
- [x] `./gradlew help` resolves cleanly with the new plugin versions.
- [x] `./gradlew :core:test --tests "io.kestra.core.utils.ListUtilsTest"` runs successfully and reports per-module peak heap via the new logger plugin.