### PR TITLE
fix(scheduler): stop evaluating a trigger whose backfill is paused

### DIFF
--- a/core/src/main/java/io/kestra/core/scheduler/model/TriggerState.java
+++ b/core/src/main/java/io/kestra/core/scheduler/model/TriggerState.java
@@ -335,9 +335,21 @@ public final class TriggerState implements TriggerId {
             .build();
     }
 
+    /**
+     * Checks whether this state carries a backfill that is currently paused.
+     * <p>
+     * A paused backfill freezes its {@code currentDate}, hence the trigger's next evaluation date, so such a
+     * trigger must not be evaluated until the backfill is resumed.
+     *
+     * @return {@code true} if the backfill is paused.
+     */
+    public boolean hasPausedBackfill() {
+        return backfill != null && Boolean.TRUE.equals(backfill.getPaused());
+    }
+
     private Backfill getBackFillForNextEvaluationDate(final Instant nextEvaluationDate) {
         final ZonedDateTime localNextEvaluationDate = toZonedDateTime(nextEvaluationDate);
-        if (backfill != null && !backfill.getPaused()) {
+        if (backfill != null && !hasPausedBackfill()) {
             if (localNextEvaluationDate.isAfter(backfill.getEnd())) {
                 return null;
             } else {

--- a/core/src/main/java/io/kestra/plugin/core/trigger/Schedule.java
+++ b/core/src/main/java/io/kestra/plugin/core/trigger/Schedule.java
@@ -348,9 +348,6 @@ public class Schedule extends AbstractTrigger implements Schedulable, TriggerOut
         final Backfill backfill = triggerContext.getBackfill();
 
         if (backfill != null) {
-            if (backfill.getPaused()) {
-                return Optional.empty();
-            }
             currentDateTimeExecution = convertDateTime(backfill.getCurrentDate());
         }
 

--- a/scheduler/src/main/java/io/kestra/scheduler/internals/DefaultSchedulableTriggerFetcher.java
+++ b/scheduler/src/main/java/io/kestra/scheduler/internals/DefaultSchedulableTriggerFetcher.java
@@ -69,6 +69,9 @@ public class DefaultSchedulableTriggerFetcher implements SchedulableTriggerFetch
 
         return triggers.stream()
             .filter(triggerState -> !triggerState.isDisabled())
+            // A paused backfill freezes the trigger's next evaluation date, so the trigger stays eligible on
+            // every loop: evaluating it would re-create an execution for the same date about once per second.
+            .filter(triggerState -> !triggerState.hasPausedBackfill())
             .map(triggerState ->
             {
                 Optional<FlowWithSource> maybeFlowTrigger = flowMetaStore.find(

--- a/scheduler/src/test/java/io/kestra/scheduler/TriggerSchedulerTest.java
+++ b/scheduler/src/test/java/io/kestra/scheduler/TriggerSchedulerTest.java
@@ -706,6 +706,52 @@ class TriggerSchedulerTest {
     }
 
     @Test
+    void shouldNotScheduleExecutionWhenBackfillIsPausedGivenScheduleOnDatesTrigger() {
+        assertNoExecutionScheduledWhileBackfillIsPaused(
+            Fixtures.flowWithScheduleOnDate(
+                TEST_TZ,
+                List.of(
+                    SchedulerClock.now().minusHours(2),
+                    SchedulerClock.now().minusHours(1),
+                    SchedulerClock.now().plusHours(1)
+                )
+            )
+        );
+    }
+
+    @Test
+    void shouldNotScheduleExecutionWhenBackfillIsPausedGivenScheduleTrigger() {
+        assertNoExecutionScheduledWhileBackfillIsPaused(Fixtures.flowWithSchedulePT15M(TEST_TZ));
+    }
+
+    private void assertNoExecutionScheduledWhileBackfillIsPaused(FlowWithSource flow) {
+        // region [GIVEN]
+        TriggerScheduler scheduler = newTriggerScheduler(List.of(flow));
+        scheduler.onStart(SchedulerClock.getClock(), SchedulerClock.now().toInstant(), NODES_ASSIGNMENTS);
+
+        ZonedDateTime backfillStart = SchedulerClock.now().minus(Duration.ofHours(2));
+        TriggerState triggerState = triggerStateStore.findById(Fixtures.triggerId()).orElseThrow();
+        triggerStateStore.save(
+            triggerState
+                .updateForNextEvaluationDate(SchedulerClock.getClock(), backfillStart)
+                .backfill(SchedulerClock.getClock(), Backfill.builder().start(backfillStart).paused(true).build())
+        );
+        // endregion [GIVEN]
+
+        // WHEN
+        for (int i = 0; i < 5; i++) {
+            scheduler.onSchedule(SchedulerClock.getClock(), SchedulerClock.now().toInstant(), NODES_ASSIGNMENTS);
+            completeExecution();
+            SchedulerClock.offset(Duration.ofSeconds(1));
+        }
+
+        // THEN
+        assertThat(triggerExecutionPublisher.executions().size()).isEqualTo(0);
+        TriggerState state = triggerStateStore.findById(Fixtures.triggerId()).orElseThrow();
+        assertThat(state.getBackfill().getCurrentDate()).isEqualTo(backfillStart);
+    }
+
+    @Test
     void shouldFailInitMissingScheduleTriggerGivenInvalidTimeZone() {
         // region [GIVEN]
         FlowWithSource flow = Fixtures.flowWithSchedulePT15M("Asia/Delhi");


### PR DESCRIPTION
### 🔗 Related Issue

Closes https://github.com/kestra-io/kestra-ee/issues/10255.

### ✨ Description

Pausing a backfill on a `ScheduleOnDates` trigger created an execution roughly once per second, forever, all on the same trigger date. The backfill `end` was never reached, so nothing terminated it — disabling the trigger was the only way out. Reproduced on a running instance: 22 executions after 10s, 32 after 20s, 43 after 30s, 53 after 40s, `evaluatedAt` and `nextEvaluationDate` both frozen at `2026-05-04T00:00:00Z` and `backfill.currentDate` frozen at `2026-05-03`.

A paused backfill deliberately freezes its `currentDate` (`TriggerState.getBackFillForNextEvaluationDate`), so the trigger's next evaluation date stops advancing and the trigger stays eligible on every scheduling loop. `Schedule.eval` absorbed that with its own `backfill.getPaused()` early return; `ScheduleOnDates.eval` never had one, so it kept minting an execution for the frozen date each tick, the instant task released the concurrency lock, and the loop went around again.

The check is now applied once, where eligibility is decided: `DefaultSchedulableTriggerFetcher` skips any trigger state whose backfill is paused, next to the existing `disabled` filter. That makes the guarantee hold for every `Schedulable` instead of being restated per plugin, so the redundant branch in `Schedule.eval` is deleted. It also removes the per-second no-op evaluation a paused `Schedule` was burning — invisible to users, but it was inflating `scheduler.trigger.evaluation` counters.

Pausing a backfill now stops execution creation for both trigger types; resuming picks up from the backfill's `currentDate` exactly as before.

### 🛠️ Backend Checklist

- [x] Code compiles and tests pass for the touched modules (`./gradlew :scheduler:test` 120/120, `./gradlew :core:test --tests "io.kestra.plugin.core.trigger.*"` 36/36)
- [x] New behavior is covered by unit or integration tests

### 📝 Additional Notes

- The regression test drives five scheduling loops against a paused backfill and asserts zero executions plus a frozen `currentDate`. It is parameterized over both `Schedulable` implementations: the `ScheduleOnDates` case fails on the parent commit (`expected: 0 but was: 5`), and the `Schedule` case passes there — it exists to guard the check being removed from `Schedule.eval`.
- No EE counterpart is needed. The filter sits above `TriggerStateStore`, so every backend is covered, including EE's Elasticsearch `findTriggersEligibleForScheduling`; EE overrides neither the fetcher nor the evaluator.
- The issue lives in the EE tracker, so the closing keyword above is only a reference — GitHub does not auto-close across repositories. kestra-io/kestra-ee#10255 has to be closed by hand once this ships.
- A paused-backfill trigger on a deleted flow no longer has its stale trigger state cleaned up by the fetcher. That was already true for disabled triggers, and `TriggerEventHandler` handles flow deletion, so this is called out rather than fixed here.
