### PR TITLE
fix(plugins): show installed script plugins on the catalog with proper titles

### DIFF
--- a/ui/src/components/plugins/PluginCatalog.vue
+++ b/ui/src/components/plugins/PluginCatalog.vue
@@ -86,7 +86,7 @@
                     :iconCls="hasIcon(plugin.subGroup) ? plugin.subGroup : plugin.group"
                     :icons
                     :loadIcon="pluginsStore.loadIcon"
-                    :title="plugin.title.capitalize()"
+                    :title="enrichmentStore.getEnrichment(plugin)?.title ?? plugin.title.capitalize()"
                     :description="plugin.description"
                     :categories="plugin.categories"
                     :taskCount="taskCount(plugin)"
@@ -162,9 +162,10 @@
             return acc
         }, {})
 
-        const filtered = Object.values(grouped).flatMap(group =>
-            group.filter(p => p.subGroup).length ? group.filter(p => p.subGroup) : group.filter(p => !p.subGroup),
-        )
+        const filtered = Object.values(grouped).flatMap(group => {
+            const subGroups = group.filter(p => p.subGroup && isVisible(p))
+            return subGroups.length ? subGroups : group.filter(p => !p.subGroup)
+        })
 
         return filtered
             .filter((plugin, index, self) =>
@@ -235,8 +236,7 @@
         return baseList.value
             .filter(plugin => isPluginMatched(plugin, searchInput.value))
             .filter(plugin => matchesSelectedCategories(plugin))
-            .slice()
-            .sort(comparators[sortBy.value] ?? nameAsc)
+            .sort(comparators[sortBy.value])
     })
 
     const loadPluginIcons = async () => {
@@ -308,7 +308,6 @@
 </script>
 
 <style scoped lang="scss">
-    
     .filter-toolbar {
         display: flex;
         flex-wrap: wrap;
@@ -382,10 +381,6 @@
     }
 
     @media (max-width: 650px) {
-        .plugin-header {
-            padding: var(--ks-spacing-3);
-        }
-
         .plugins-container {
             padding-left: var(--ks-spacing-3);
             padding-right: var(--ks-spacing-3);

--- a/ui/src/components/plugins/PluginDetail.vue
+++ b/ui/src/components/plugins/PluginDetail.vue
@@ -50,12 +50,14 @@
     import {KsMarkdown, KsAlert, KsSkeleton, type KsBreadcrumbItem} from "@kestra-io/design-system"
     import PluginLayout from "./PluginLayout.vue"
     import {usePluginsStore} from "../../stores/plugins"
+    import {usePluginsEnrichmentStore} from "../../stores/pluginsEnrichment"
     import {useMiscStore} from "override/stores/misc"
     import {isEntryAPluginElementPredicate, isEnterpriseEditionPlugin, type Plugin} from "../../utils/pluginUtils"
     import {getTheme} from "../../utils/utils"
     import useRouteContext from "../../composables/useRouteContext"
 
     const pluginsStore = usePluginsStore()
+    const enrichmentStore = usePluginsEnrichmentStore()
     const miscStore = useMiscStore()
     const isDarkTheme = computed(() => {
         void miscStore.theme
@@ -131,13 +133,13 @@
         if (grp) {
             if (grp.subGroup && parentGroup.value?.title) {
                 crumbs.push({
-                    label: parentGroup.value.title,
+                    label: enrichmentStore.getEnrichment(parentGroup.value)?.title ?? parentGroup.value.title,
                     link: {name: "plugins/group", params: {name: parentGroup.value.name}},
                 })
             }
             if (grp.title) {
                 crumbs.push({
-                    label: grp.title,
+                    label: enrichmentStore.getEnrichment(grp)?.title ?? grp.title,
                     link: {
                         name: "plugins/group",
                         params: {name: grp.name, subGroup: grp.subGroup},

--- a/ui/src/components/plugins/PluginGroup.vue
+++ b/ui/src/components/plugins/PluginGroup.vue
@@ -25,7 +25,7 @@
                         :iconCls="sub.subGroup"
                         :icons="allIcons"
                         :loadIcon="pluginsStore.loadIcon"
-                        :title="sub.title"
+                        :title="enrichmentStore.getEnrichment(sub)?.title ?? sub.title"
                         :description="sub.description"
                         :categories="sub.categories"
                         :taskCount="elementCountFor(sub)"
@@ -97,7 +97,7 @@
     import {usePluginsStore} from "../../stores/plugins"
     import {usePluginsEnrichmentStore} from "../../stores/pluginsEnrichment"
     import {useMiscStore} from "override/stores/misc"
-    import {isEntryAPluginElementPredicate, isEnterpriseEditionPlugin, type Plugin, type PluginElement} from "../../utils/pluginUtils"
+    import {extractPluginElements, isEntryAPluginElementPredicate, isEnterpriseEditionPlugin, type Plugin, type PluginElement} from "../../utils/pluginUtils"
     import useRouteContext from "../../composables/useRouteContext"
     import {blueprintTaskTypes} from "../../composables/useBlueprintPlugins"
     import {API_URL} from "../../stores/api"
@@ -138,7 +138,7 @@
     const childSubGroups = computed<Plugin[]>(() => {
         const g = groupPlugin.value
         if (!g || g.subGroup) return []
-        return (pluginsStore.plugins ?? []).filter(p => p.name === g.name && p.subGroup)
+        return (pluginsStore.plugins ?? []).filter(p => p.name === g.name && p.subGroup && elementCountFor(p) > 0)
     })
 
     const isShowingSubGroups = computed<boolean>(() => childSubGroups.value.length > 0)
@@ -159,7 +159,7 @@
         return out.sort((a, b) => shortClassName(a.cls).localeCompare(shortClassName(b.cls)))
     })
 
-    const headerTitle = computed<string>(() => groupPlugin.value?.title ?? "")
+    const headerTitle = computed<string>(() => enrichmentStore.getEnrichment(groupPlugin.value)?.title ?? groupPlugin.value?.title ?? "")
 
     const headerIconCls = computed<string | undefined>(() => {
         const g = groupPlugin.value
@@ -198,14 +198,14 @@
         ]
         if (parentGroup.value?.title) {
             crumbs.push({
-                label: parentGroup.value.title,
+                label: enrichmentStore.getEnrichment(parentGroup.value)?.title ?? parentGroup.value.title,
                 link: {name: "plugins/group", params: {name: parentGroup.value.name}},
             })
         }
         return crumbs
     })
 
-    const title = computed(() => groupPlugin.value?.title ?? (route.params.name as string))
+    const title = computed(() => headerTitle.value || (route.params.name as string))
 
     const routeInfo = computed(() => ({title: title.value, breadcrumb: breadcrumb.value}))
     useRouteContext(routeInfo)
@@ -216,13 +216,7 @@
     }
 
     function elementCountFor(plugin: Plugin): number {
-        let count = 0
-        for (const [key, value] of Object.entries(plugin)) {
-            if (isEntryAPluginElementPredicate(key, value)) {
-                count += value.filter(el => !el?.deprecated).length
-            }
-        }
-        return count
+        return Object.values(extractPluginElements(plugin)).flat().length
     }
 
     function blueprintCountFor(plugin: Plugin): number {
@@ -276,7 +270,7 @@
     }
 
     watch(
-        () => groupPlugin.value,
+        groupPlugin,
         (g) => {
             if (g) loadGroupBlueprints()
         },

--- a/ui/src/stores/pluginsEnrichment.ts
+++ b/ui/src/stores/pluginsEnrichment.ts
@@ -20,6 +20,13 @@ type MetadataEntry = {
     body?: string;
 }
 
+// https://api.kestra.io/v1/plugins/subgroups
+type SubGroupEntry = {
+    group?: string;
+    subGroup?: string | null;
+    title?: string;
+}
+
 export type PluginEnrichment = {
     blueprintCount?: number;
     lastReleasedAt?: string;
@@ -28,6 +35,7 @@ export type PluginEnrichment = {
     managedBy?: string;
     description?: string;
     body?: string;
+    title?: string;
 }
 
 // https://api.kestra.io/v1/plugins/{cls}/versions
@@ -68,8 +76,12 @@ export const usePluginsEnrichmentStore = defineStore("pluginsEnrichment", () => 
             `${API_URL}/v1/plugins/metadata`,
             {signal: controller.signal},
         )
+        const subgroupsPromise = axios.get<SubGroupEntry[]>(
+            `${API_URL}/v1/plugins/subgroups`,
+            {signal: controller.signal},
+        )
 
-        pending = Promise.allSettled([informationPromise, metadataPromise]).then(([info, meta]) => {
+        pending = Promise.allSettled([informationPromise, metadataPromise, subgroupsPromise]).then(([info, meta, subgroups]) => {
             if (info.status === "fulfilled") {
                 for (const [key, entry] of Object.entries(info.value.data?.byPlugin ?? {})) {
                     upsert(key, {
@@ -90,11 +102,18 @@ export const usePluginsEnrichmentStore = defineStore("pluginsEnrichment", () => 
                     })
                 }
             }
-            if (info.status === "fulfilled" || meta.status === "fulfilled") {
+            if (subgroups.status === "fulfilled") {
+                for (const entry of subgroups.value.data ?? []) {
+                    const key = entry.subGroup ?? entry.group
+                    if (!key || !entry.title) continue
+                    upsert(key, {title: entry.title})
+                }
+            }
+            if (info.status === "fulfilled" || meta.status === "fulfilled" || subgroups.status === "fulfilled") {
                 loaded.value = true
             } else {
                 failed.value = true
-                console.warn("Plugin enrichment unavailable", {info, meta})
+                console.warn("Plugin enrichment unavailable", {info, meta, subgroups})
             }
         }).finally(() => {
             clearTimeout(timeout)

--- a/ui/tests/unit/components/plugins/PluginCatalog.spec.ts
+++ b/ui/tests/unit/components/plugins/PluginCatalog.spec.ts
@@ -1,0 +1,144 @@
+import {describe, test, expect, beforeEach, afterEach, vi} from "vitest"
+import {ref} from "vue"
+import {mount, flushPromises} from "@vue/test-utils"
+import {createPinia, setActivePinia} from "pinia"
+import {createI18n} from "vue-i18n"
+import KestraDesignSystem from "@kestra-io/design-system"
+import PluginCatalog from "../../../../src/components/plugins/PluginCatalog.vue"
+import "../../../../src/utils/global"
+
+vi.mock("axios", () => ({
+    default: {get: vi.fn().mockResolvedValue({data: []})},
+}))
+
+vi.mock("@kestra-io/kestra-sdk", () => ({
+    useClient: () => ({get: vi.fn().mockResolvedValue({data: {}}), post: vi.fn()}),
+}))
+
+// Shape captured from GET /api/v1/plugins/groups/subgroups with plugin-script-python and
+// plugin-dbt installed (kestra-io/kestra#17888): python's only subgroup is the bundled legacy
+// package whose single task is deprecated, while dbt has two real, visible subgroups.
+vi.mock("@kestra-io/kestra-sdk/plugins", () => ({
+    pluginBySubgroups: vi.fn().mockResolvedValue([
+        {
+            name: "plugin-script-python",
+            title: "Python",
+            group: "io.kestra.plugin.scripts.python",
+            tasks: [
+                {cls: "io.kestra.core.tasks.scripts.Python", deprecated: true},
+                {cls: "io.kestra.plugin.scripts.python.Commands"},
+                {cls: "io.kestra.plugin.scripts.python.Script"},
+            ],
+            triggers: [
+                {cls: "io.kestra.plugin.scripts.python.CommandsTrigger"},
+                {cls: "io.kestra.plugin.scripts.python.ScriptTrigger"},
+            ],
+        },
+        {
+            name: "plugin-script-python",
+            title: "scripts",
+            group: "io.kestra.plugin.scripts.python",
+            subGroup: "io.kestra.core.tasks.scripts",
+            tasks: [{cls: "io.kestra.core.tasks.scripts.Python", deprecated: true}],
+        },
+        {
+            name: "plugin-dbt",
+            title: "DBT",
+            group: "io.kestra.plugin.dbt",
+            tasks: [
+                {cls: "io.kestra.plugin.dbt.cli.DbtCLI"},
+                {cls: "io.kestra.plugin.dbt.cloud.CheckStatus"},
+                {cls: "io.kestra.plugin.dbt.cloud.TriggerRun"},
+            ],
+        },
+        {
+            name: "plugin-dbt",
+            title: "dbt CLI",
+            group: "io.kestra.plugin.dbt",
+            subGroup: "io.kestra.plugin.dbt.cli",
+            tasks: [{cls: "io.kestra.plugin.dbt.cli.DbtCLI"}],
+        },
+        {
+            name: "plugin-dbt",
+            title: "dbt Cloud",
+            group: "io.kestra.plugin.dbt",
+            subGroup: "io.kestra.plugin.dbt.cloud",
+            tasks: [
+                {cls: "io.kestra.plugin.dbt.cloud.CheckStatus"},
+                {cls: "io.kestra.plugin.dbt.cloud.TriggerRun"},
+            ],
+        },
+    ]),
+}))
+
+vi.mock("override/utils/route", () => ({
+    apiUrl: () => "/api/v1",
+    apiUrlWithoutTenants: () => "/api/v1",
+    baseUrl: "/",
+}))
+
+vi.mock("override/stores/misc", () => ({
+    useMiscStore: () => ({theme: "light", loadConfigs: vi.fn()}),
+}))
+
+vi.mock("vue-router", () => ({
+    useRoute: () => ({params: {}, query: {}}),
+    useRouter: () => ({push: vi.fn()}),
+}))
+
+vi.mock("../../../../src/composables/usePluginsCount", () => ({
+    usePluginsCount: () => ({totalPlugins: ref(900)}),
+}))
+
+vi.mock("../../../../src/stores/pluginsEnrichment", () => ({
+    usePluginsEnrichmentStore: () => ({fetchEnrichment: vi.fn(), getEnrichment: () => undefined}),
+}))
+
+const i18n = createI18n({
+    legacy: false,
+    locale: "en",
+    missingWarn: false,
+    fallbackWarn: false,
+    messages: {en: {}},
+})
+
+async function mountCatalog() {
+    const wrapper = mount(PluginCatalog, {
+        global: {
+            plugins: [i18n, KestraDesignSystem],
+            stubs: {TopNavBar: true, TaskIcon: true},
+        },
+    })
+    await flushPromises()
+    return wrapper
+}
+
+describe("PluginCatalog", () => {
+    beforeEach(() => {
+        setActivePinia(createPinia())
+    })
+
+    afterEach(() => {
+        document.title = ""
+    })
+
+    test("shows the main card of a plugin whose only subgroup holds deprecated tasks", async () => {
+        const wrapper = await mountCatalog()
+        const titles = wrapper.findAll("h5").map(t => t.text())
+
+        expect(titles).toContain("Python")
+        expect(titles).not.toContain("Scripts")
+
+        const pythonCard = wrapper.findAll("article").find(card => card.find("h5").text() === "Python")!
+        expect(pythonCard.text()).toContain("4")
+    })
+
+    test("shows only the subgroup cards of a plugin with visible subgroups", async () => {
+        const wrapper = await mountCatalog()
+        const titles = wrapper.findAll("h5").map(t => t.text())
+
+        expect(titles).toContain("Dbt CLI")
+        expect(titles).toContain("Dbt Cloud")
+        expect(titles).not.toContain("DBT")
+    })
+})

--- a/ui/tests/unit/components/plugins/PluginGroup.spec.ts
+++ b/ui/tests/unit/components/plugins/PluginGroup.spec.ts
@@ -1,0 +1,159 @@
+import {describe, test, expect, beforeEach, afterEach, vi} from "vitest"
+import {mount, flushPromises} from "@vue/test-utils"
+import {createPinia, setActivePinia} from "pinia"
+import {createI18n} from "vue-i18n"
+import KestraDesignSystem from "@kestra-io/design-system"
+import PluginGroup from "../../../../src/components/plugins/PluginGroup.vue"
+
+vi.mock("axios", () => ({
+    default: {get: vi.fn().mockResolvedValue({data: []})},
+}))
+
+vi.mock("@kestra-io/kestra-sdk", () => ({
+    useClient: () => ({get: vi.fn().mockResolvedValue({data: {}}), post: vi.fn()}),
+}))
+
+// Same captured shape as PluginCatalog.spec.ts (kestra-io/kestra#17888): python's only subgroup
+// is the bundled legacy package whose single task is deprecated, dbt has two visible subgroups.
+vi.mock("@kestra-io/kestra-sdk/plugins", () => ({
+    pluginBySubgroups: vi.fn().mockResolvedValue([
+        {
+            name: "plugin-script-python",
+            title: "Python",
+            group: "io.kestra.plugin.scripts.python",
+            tasks: [
+                {cls: "io.kestra.core.tasks.scripts.Python", deprecated: true},
+                {cls: "io.kestra.plugin.scripts.python.Commands"},
+                {cls: "io.kestra.plugin.scripts.python.Script"},
+            ],
+            triggers: [
+                {cls: "io.kestra.plugin.scripts.python.CommandsTrigger"},
+                {cls: "io.kestra.plugin.scripts.python.ScriptTrigger"},
+            ],
+        },
+        {
+            name: "plugin-script-python",
+            title: "scripts",
+            group: "io.kestra.plugin.scripts.python",
+            subGroup: "io.kestra.core.tasks.scripts",
+            tasks: [{cls: "io.kestra.core.tasks.scripts.Python", deprecated: true}],
+        },
+        {
+            name: "plugin-dbt",
+            title: "DBT",
+            group: "io.kestra.plugin.dbt",
+            tasks: [
+                {cls: "io.kestra.plugin.dbt.cli.DbtCLI"},
+                {cls: "io.kestra.plugin.dbt.cloud.CheckStatus"},
+            ],
+        },
+        {
+            name: "plugin-dbt",
+            title: "dbt CLI",
+            group: "io.kestra.plugin.dbt",
+            subGroup: "io.kestra.plugin.dbt.cli",
+            tasks: [{cls: "io.kestra.plugin.dbt.cli.DbtCLI"}],
+        },
+        {
+            name: "plugin-dbt",
+            title: "dbt Cloud",
+            group: "io.kestra.plugin.dbt",
+            subGroup: "io.kestra.plugin.dbt.cloud",
+            tasks: [{cls: "io.kestra.plugin.dbt.cloud.CheckStatus"}],
+        },
+    ]),
+}))
+
+vi.mock("override/utils/route", () => ({
+    apiUrl: () => "/api/v1",
+    apiUrlWithoutTenants: () => "/api/v1",
+    baseUrl: "/",
+}))
+
+vi.mock("override/stores/misc", () => ({
+    useMiscStore: () => ({theme: "light", loadConfigs: vi.fn()}),
+}))
+
+const routeParams = vi.hoisted(() => ({} as Record<string, string>))
+
+vi.mock("vue-router", () => ({
+    useRoute: () => ({params: routeParams, query: {}}),
+    useRouter: () => ({push: vi.fn()}),
+}))
+
+const enrichmentTitles = vi.hoisted(() => ({} as Record<string, string>))
+
+vi.mock("../../../../src/stores/pluginsEnrichment", () => ({
+    usePluginsEnrichmentStore: () => ({
+        fetchEnrichment: vi.fn(),
+        getEnrichment: (plugin: {subGroup?: string, group?: string} | undefined) => {
+            const title = enrichmentTitles[plugin?.subGroup ?? plugin?.group ?? ""]
+            return title ? {title} : null
+        },
+    }),
+}))
+
+const i18n = createI18n({
+    legacy: false,
+    locale: "en",
+    missingWarn: false,
+    fallbackWarn: false,
+    messages: {en: {}},
+})
+
+async function mountGroup(name: string) {
+    Object.keys(routeParams).forEach(key => delete routeParams[key])
+    routeParams.name = name
+    const wrapper = mount(PluginGroup, {
+        global: {
+            plugins: [i18n, KestraDesignSystem],
+            stubs: {
+                PluginLayout: {template: "<div><slot /></div>"},
+                TaskIcon: true,
+            },
+        },
+    })
+    await flushPromises()
+    return wrapper
+}
+
+describe("PluginGroup", () => {
+    beforeEach(() => {
+        setActivePinia(createPinia())
+        Object.keys(enrichmentTitles).forEach(key => delete enrichmentTitles[key])
+    })
+
+    afterEach(() => {
+        document.title = ""
+    })
+
+    test("lists tasks instead of a subgroup card when the only subgroup holds deprecated tasks", async () => {
+        const wrapper = await mountGroup("plugin-script-python")
+        const titles = wrapper.findAll("h5").map(t => t.text())
+
+        expect(titles).not.toContain("scripts")
+        expect(titles).toContain("Script")
+        expect(titles).toContain("Commands")
+        expect(titles).toContain("ScriptTrigger")
+        expect(titles).toContain("CommandsTrigger")
+        expect(titles).not.toContain("Python")
+    })
+
+    test("prefers the display title from the public catalog when available", async () => {
+        enrichmentTitles["io.kestra.plugin.dbt.cli"] = "dbt CLI from catalog"
+        const wrapper = await mountGroup("plugin-dbt")
+        const titles = wrapper.findAll("h5").map(t => t.text())
+
+        expect(titles).toContain("dbt CLI from catalog")
+        expect(titles).not.toContain("dbt CLI")
+    })
+
+    test("lists subgroup cards when the subgroups have visible tasks", async () => {
+        const wrapper = await mountGroup("plugin-dbt")
+        const titles = wrapper.findAll("h5").map(t => t.text())
+
+        expect(titles).toContain("dbt CLI")
+        expect(titles).toContain("dbt Cloud")
+        expect(titles).not.toContain("DbtCLI")
+    })
+})

--- a/ui/tests/unit/stores/pluginsEnrichment.spec.ts
+++ b/ui/tests/unit/stores/pluginsEnrichment.spec.ts
@@ -62,3 +62,33 @@ describe("pluginsEnrichment store — fetchVersions cache", () => {
         warnSpy.mockRestore()
     })
 })
+
+describe("pluginsEnrichment store — fetchEnrichment titles", () => {
+    let store: any
+
+    beforeEach(async () => {
+        vi.clearAllMocks()
+        setActivePinia(createPinia())
+        const {usePluginsEnrichmentStore} = await import("../../../src/stores/pluginsEnrichment")
+        store = usePluginsEnrichmentStore()
+    })
+
+    it("enriches display titles from the public subgroups catalog", async () => {
+        mockedGet.mockImplementation(((url: string) => {
+            if (url.endsWith("/v1/plugins/subgroups")) {
+                return Promise.resolve({data: [
+                    {group: "io.kestra.plugin.core", subGroup: "io.kestra.plugin.core.debug", title: "Debug"},
+                    {group: "io.kestra.plugin.core", subGroup: null, title: "Core Plugins and tasks"},
+                    {group: "io.kestra.plugin.x", subGroup: "io.kestra.plugin.x.y"},
+                ]})
+            }
+            return Promise.reject(new Error("unavailable"))
+        }) as any)
+
+        await store.fetchEnrichment()
+
+        expect(store.getEnrichment({group: "io.kestra.plugin.core", subGroup: "io.kestra.plugin.core.debug"})?.title).toBe("Debug")
+        expect(store.getEnrichment({group: "io.kestra.plugin.core"})?.title).toBe("Core Plugins and tasks")
+        expect(store.getEnrichment({group: "io.kestra.plugin.x", subGroup: "io.kestra.plugin.x.y"})).toBeNull()
+    })
+})


### PR DESCRIPTION
closes #17888

## What was fixed

- **Missing plugin cards on the Plugins page.** Script plugins (e.g. python) bundle the legacy deprecated `io.kestra.core.tasks.scripts` package, which the API reports as a subgroup. The catalog rule "subgroups replace the main entry" then dropped the real card, and the phantom subgroup was hidden as deprecated-only, so the plugin vanished. The main card now survives when a group has no visible subgroup.
- **Bogus "scripts" card on the plugin group page.** The same phantom subgroup rendered as its own card (with a wrong icon). Deprecated-only subgroups are now skipped and the tasks grid shows instead.
- **Lowercase titles ("debug", "agent", "mcp", "s3").** Display titles now come from the public catalog (`api.kestra.io/v1/plugins/subgroups`) via the enrichment store, on: catalog cards, group page cards + header + breadcrumb, and the task page breadcrumb. Falls back to the local title when the public API is unreachable.
- **Cleanup.** Dead CSS rule, redundant `.slice()` and unreachable fallback in the catalog, `elementCountFor` now reuses `extractPluginElements`.
- **Tests.** New specs for PluginCatalog and PluginGroup (fail on pre-fix code) plus a title test in the enrichment store spec.

## QA the original issue

1. `docker run -d --name qa17888 -p 8090:8080 kestra/kestra:latest-no-plugins server local`
2. `docker exec qa17888 sh /app/kestra plugins install io.kestra.plugin:plugin-script-python:LATEST`
   (the `sh` matters: `/app/kestra` has no shebang, calling it directly gives "exec format error")
3. `docker restart qa17888`, open `http://localhost:8090/ui`, finish the setup login.
4. Go to **Plugins**:
   - broken: no Python card, searching "python" finds nothing
   - fixed: a "Python" card with 4 tasks; search finds it
5. Click the Python card:
   - broken: a single "scripts" card with a wrong icon
   - fixed: Tasks grid with Script, Commands, CommandsTrigger, ScriptTrigger (no deprecated legacy task)
6. Titles everywhere (cards, header, breadcrumb) are properly cased, e.g. "Python", not "python".
