### PR TITLE
fix(plugins): show plugins hidden by their deprecated legacy subgroup

### DIFF
--- a/ui/src/components/plugins/PluginHome.vue
+++ b/ui/src/components/plugins/PluginHome.vue
@@ -115,9 +115,10 @@
             return acc;
         }, {});
 
-        const filtered = Object.values(grouped).flatMap(group =>
-            group.filter((p: any) => p.subGroup).length ? group.filter((p: any) => p.subGroup) : group.filter((p: any) => !p.subGroup)
-        );
+        const filtered = Object.values(grouped).flatMap(group => {
+            const subGroups = group.filter((p: any) => p.subGroup && isVisible(p));
+            return subGroups.length ? subGroups : group.filter((p: any) => !p.subGroup);
+        });
 
         return filtered
             .filter((plugin, index, self) =>


### PR DESCRIPTION
1.3.x backport fix for https://github.com/kestra-io/kestra/issues/17888.
