### PR TITLE
fix(core): shiki background in markdown code blocks

### DIFF
--- a/ui/packages/design-system/src/components/Data/KsMarkdown/KsMarkdown.vue
+++ b/ui/packages/design-system/src/components/Data/KsMarkdown/KsMarkdown.vue
@@ -480,9 +480,8 @@
     .ks-markdown__code-shiki {
         .shiki {
             margin: 0;
-            padding: 1rem;
+            padding: var(--ks-spacing-3);
             overflow-x: auto;
-            background-color: var(--kel-bg-color-overlay);
             border-radius: var(--kel-border-radius-base);
 
             span { color: var(--shiki-light); }

--- a/ui/src/components/plugins/PluginDocumentation.vue
+++ b/ui/src/components/plugins/PluginDocumentation.vue
@@ -1148,7 +1148,6 @@
   }
 
   .dp-intro-md :deep(pre) {
-    background: var(--ks-bg-base);
     border: 1px solid var(--ks-border-default);
     border-radius: var(--ks-radius-base);
     padding: var(--ks-spacing-3);


### PR DESCRIPTION
Markdown code blocks overrode the shiki theme background with a surface token, so the syntax theme and the block background did not match. The overrides are removed and the shiki theme now paints the block.

To address comment from https://github.com/kestra-io/kestra-ee/issues/10477#issuecomment-5478635470