### PR TITLE
fix(worker): honour the JVM proxy configuration on the controller gRPC channel

### DIFF
--- a/worker-controller/src/main/java/io/kestra/controller/grpc/resolver/ProxiedAddresses.java
+++ b/worker-controller/src/main/java/io/kestra/controller/grpc/resolver/ProxiedAddresses.java
@@ -1,0 +1,66 @@
+package io.kestra.controller.grpc.resolver;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.SocketAddress;
+import java.util.ArrayList;
+import java.util.List;
+
+import io.grpc.EquivalentAddressGroup;
+import io.grpc.ProxiedSocketAddress;
+import io.grpc.ProxyDetector;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Routes controller endpoints through the HTTP proxy selected by the channel's {@link ProxyDetector}.
+ * <p>
+ * gRPC only ever consults the detector from a name resolver, never from the transport, so a resolver
+ * that skips this step dials its endpoints directly and silently ignores {@code https.proxyHost} and
+ * the rest of the standard JVM proxy configuration.
+ */
+@Slf4j
+final class ProxiedAddresses {
+
+    private ProxiedAddresses() {
+    }
+
+    /**
+     * Returns the given groups with every endpoint the detector selects a proxy for replaced by the
+     * matching {@link ProxiedSocketAddress}. Endpoints with no proxy are kept as they are, and so is an
+     * endpoint whose detection fails, so that a proxy configuration gRPC cannot read degrades to a
+     * direct dial rather than to an empty address list.
+     */
+    static List<EquivalentAddressGroup> proxied(final ProxyDetector proxyDetector, final List<EquivalentAddressGroup> groups) {
+        List<EquivalentAddressGroup> proxied = new ArrayList<>(groups.size());
+        for (EquivalentAddressGroup group : groups) {
+            List<SocketAddress> addresses = new ArrayList<>(group.getAddresses().size());
+            for (SocketAddress address : group.getAddresses()) {
+                addresses.add(proxiedOrDirect(proxyDetector, address));
+            }
+            proxied.add(new EquivalentAddressGroup(addresses, group.getAttributes()));
+        }
+        return proxied;
+    }
+
+    private static SocketAddress proxiedOrDirect(final ProxyDetector proxyDetector, final SocketAddress address) {
+        if (!(address instanceof InetSocketAddress inetAddress)) {
+            return address;
+        }
+
+        // The detector hands the address it was given back as the CONNECT target, so it must be unresolved:
+        // a resolved one makes the tunnel request carry an IP, and needs the DNS lookup that an endpoint
+        // reachable only through the proxy cannot satisfy.
+        InetSocketAddress target = InetSocketAddress.createUnresolved(inetAddress.getHostString(), inetAddress.getPort());
+        try {
+            ProxiedSocketAddress proxiedAddress = proxyDetector.proxyFor(target);
+            if (proxiedAddress == null) {
+                return address;
+            }
+            log.debug("Routing controller endpoint {} through proxy {}", target, proxiedAddress);
+            return proxiedAddress;
+        } catch (IOException e) {
+            log.warn("Cannot determine the proxy for controller endpoint {}: connecting directly.", target, e);
+            return address;
+        }
+    }
+}

--- a/worker-controller/src/main/java/io/kestra/controller/grpc/resolver/StaticNameResolver.java
+++ b/worker-controller/src/main/java/io/kestra/controller/grpc/resolver/StaticNameResolver.java
@@ -1,9 +1,11 @@
 package io.kestra.controller.grpc.resolver;
 
 import java.util.List;
+import java.util.Objects;
 
 import io.grpc.EquivalentAddressGroup;
 import io.grpc.NameResolver;
+import io.grpc.ProxyDetector;
 import io.grpc.StatusOr;
 
 /**
@@ -11,21 +13,27 @@ import io.grpc.StatusOr;
  * <p>
  * This resolver returns the same list of addresses on every resolution,
  * enabling load balancing across a fixed set of controller endpoints.
+ * <p>
+ * Each address is passed through the channel's {@link ProxyDetector} on every resolution, so that the
+ * standard JVM proxy configuration is honoured as it is by gRPC's own {@code dns:///} resolver.
  */
 public class StaticNameResolver extends NameResolver {
 
     private static final String AUTHORITY = "controllers";
 
     private final List<EquivalentAddressGroup> addresses;
+    private final ProxyDetector proxyDetector;
     private volatile Listener2 listener;
 
     /**
      * Creates a new StaticNameResolver with the given addresses.
      *
      * @param addresses the list of controller addresses
+     * @param proxyDetector the channel's proxy detector
      */
-    public StaticNameResolver(List<EquivalentAddressGroup> addresses) {
+    public StaticNameResolver(List<EquivalentAddressGroup> addresses, ProxyDetector proxyDetector) {
         this.addresses = addresses;
+        this.proxyDetector = Objects.requireNonNull(proxyDetector);
     }
 
     /**
@@ -49,7 +57,7 @@ public class StaticNameResolver extends NameResolver {
         if (listener != null) {
             listener.onResult2(
                 ResolutionResult.newBuilder()
-                    .setAddressesOrError(StatusOr.fromValue(addresses))
+                    .setAddressesOrError(StatusOr.fromValue(ProxiedAddresses.proxied(proxyDetector, addresses)))
                     .build()
             );
         }

--- a/worker-controller/src/main/java/io/kestra/controller/grpc/resolver/StaticNameResolverProvider.java
+++ b/worker-controller/src/main/java/io/kestra/controller/grpc/resolver/StaticNameResolverProvider.java
@@ -53,7 +53,7 @@ public class StaticNameResolverProvider extends NameResolverProvider {
         if (!SCHEME.equals(targetUri.getScheme())) {
             return null;
         }
-        return new StaticNameResolver(parseAddresses(targetUri));
+        return new StaticNameResolver(parseAddresses(targetUri), args.getProxyDetector());
     }
 
     /**

--- a/worker-controller/src/main/java/io/kestra/controller/grpc/resolver/StorageNameResolver.java
+++ b/worker-controller/src/main/java/io/kestra/controller/grpc/resolver/StorageNameResolver.java
@@ -14,6 +14,7 @@ import io.kestra.core.utils.ExecutorsUtils;
 
 import io.grpc.EquivalentAddressGroup;
 import io.grpc.NameResolver;
+import io.grpc.ProxyDetector;
 import io.grpc.StatusOr;
 import io.grpc.SynchronizationContext;
 import lombok.extern.slf4j.Slf4j;
@@ -25,6 +26,9 @@ import lombok.extern.slf4j.Slf4j;
  * using the configured interval. Each tick queries the supplier and notifies the listener only
  * when the resolved set of addresses actually changes, to avoid churning the gRPC load-balancing
  * pool.
+ * <p>
+ * Each address is passed through the channel's {@link ProxyDetector}, so that the standard JVM proxy
+ * configuration is honoured as it is by gRPC's own {@code dns:///} resolver.
  */
 @Slf4j
 public class StorageNameResolver extends NameResolver {
@@ -34,6 +38,7 @@ public class StorageNameResolver extends NameResolver {
     private final Supplier<List<EquivalentAddressGroup>> addressSupplier;
     private final Duration refreshInterval;
     private final SynchronizationContext syncContext;
+    private final ProxyDetector proxyDetector;
 
     private volatile Listener2 listener;
     private volatile ScheduledExecutorService scheduler;
@@ -47,14 +52,17 @@ public class StorageNameResolver extends NameResolver {
      * @param refreshInterval how often to poll the supplier.
      * @param syncContext the channel's synchronization context; all listener notifications
      *        must be delivered on it (see {@link #resolve()}).
+     * @param proxyDetector the channel's proxy detector.
      */
     public StorageNameResolver(
         final Supplier<List<EquivalentAddressGroup>> addressSupplier,
         final Duration refreshInterval,
-        final SynchronizationContext syncContext) {
+        final SynchronizationContext syncContext,
+        final ProxyDetector proxyDetector) {
         this.addressSupplier = Objects.requireNonNull(addressSupplier);
         this.refreshInterval = Objects.requireNonNull(refreshInterval);
         this.syncContext = Objects.requireNonNull(syncContext);
+        this.proxyDetector = Objects.requireNonNull(proxyDetector);
     }
 
     /**
@@ -120,7 +128,7 @@ public class StorageNameResolver extends NameResolver {
         if (listener == null) {
             return;
         }
-        List<EquivalentAddressGroup> addresses = addressSupplier.get();
+        List<EquivalentAddressGroup> addresses = ProxiedAddresses.proxied(proxyDetector, addressSupplier.get());
         Set<EquivalentAddressGroup> next = Set.copyOf(addresses);
         if (next.equals(lastAddresses)) {
             return;

--- a/worker-controller/src/main/java/io/kestra/controller/grpc/resolver/StorageNameResolverProvider.java
+++ b/worker-controller/src/main/java/io/kestra/controller/grpc/resolver/StorageNameResolverProvider.java
@@ -46,7 +46,7 @@ public class StorageNameResolverProvider extends NameResolverProvider {
         if (!SCHEME.equals(targetUri.getScheme())) {
             return null;
         }
-        return new StorageNameResolver(addressSupplier, refreshInterval, args.getSynchronizationContext());
+        return new StorageNameResolver(addressSupplier, refreshInterval, args.getSynchronizationContext(), args.getProxyDetector());
     }
 
     @Override

--- a/worker-controller/src/test/java/io/kestra/controller/resolver/StaticNameResolverTest.java
+++ b/worker-controller/src/test/java/io/kestra/controller/resolver/StaticNameResolverTest.java
@@ -1,8 +1,11 @@
 package io.kestra.controller.resolver;
 
+import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.URI;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.junit.jupiter.api.Test;
@@ -11,12 +14,17 @@ import io.kestra.controller.grpc.resolver.StaticNameResolver;
 import io.kestra.controller.grpc.resolver.StaticNameResolverProvider;
 
 import io.grpc.EquivalentAddressGroup;
+import io.grpc.HttpConnectProxiedSocketAddress;
 import io.grpc.NameResolver;
+import io.grpc.ProxyDetector;
+import io.grpc.SynchronizationContext;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class StaticNameResolverTest {
+
+    private static final ProxyDetector NO_PROXY = target -> null;
 
     @Test
     void shouldResolveToStaticAddresses() {
@@ -25,7 +33,7 @@ class StaticNameResolverTest {
             new EquivalentAddressGroup(new InetSocketAddress("controller-2.example.com", 9097))
         );
 
-        StaticNameResolver resolver = new StaticNameResolver(addresses);
+        StaticNameResolver resolver = new StaticNameResolver(addresses, NO_PROXY);
 
         AtomicReference<NameResolver.ResolutionResult> result = new AtomicReference<>();
         resolver.start(new TestListener(result));
@@ -40,7 +48,7 @@ class StaticNameResolverTest {
             new EquivalentAddressGroup(new InetSocketAddress("localhost", 9096))
         );
 
-        StaticNameResolver resolver = new StaticNameResolver(addresses);
+        StaticNameResolver resolver = new StaticNameResolver(addresses, NO_PROXY);
 
         AtomicReference<NameResolver.ResolutionResult> result = new AtomicReference<>();
         resolver.start(new TestListener(result));
@@ -57,7 +65,7 @@ class StaticNameResolverTest {
 
     @Test
     void shouldReturnControllersAuthority() {
-        StaticNameResolver resolver = new StaticNameResolver(List.of());
+        StaticNameResolver resolver = new StaticNameResolver(List.of(), NO_PROXY);
         assertThat(resolver.getServiceAuthority()).isEqualTo("controllers");
     }
 
@@ -67,7 +75,7 @@ class StaticNameResolverTest {
 
         assertThat(provider.getDefaultScheme()).isEqualTo("static");
 
-        NameResolver resolver = provider.newNameResolver(URI.create("static:///localhost:9096"), null);
+        NameResolver resolver = provider.newNameResolver(URI.create("static:///localhost:9096"), resolverArgs(NO_PROXY));
         assertThat(resolver).isNotNull();
         assertThat(resolver).isInstanceOf(StaticNameResolver.class);
 
@@ -92,7 +100,7 @@ class StaticNameResolverTest {
         // Then
         assertThat(target).isEqualTo("static:///controller-1.example.com:9096,controller-2.example.com:9097");
 
-        NameResolver resolver = new StaticNameResolverProvider().newNameResolver(URI.create(target), null);
+        NameResolver resolver = new StaticNameResolverProvider().newNameResolver(URI.create(target), resolverArgs(NO_PROXY));
         AtomicReference<NameResolver.ResolutionResult> result = new AtomicReference<>();
         resolver.start(new TestListener(result));
         assertThat(result.get().getAddresses()).containsExactly(
@@ -109,7 +117,7 @@ class StaticNameResolverTest {
         // Then - brackets are stripped so the target stays a valid URI
         assertThat(target).isEqualTo("static:///::1:9096");
 
-        NameResolver resolver = new StaticNameResolverProvider().newNameResolver(URI.create(target), null);
+        NameResolver resolver = new StaticNameResolverProvider().newNameResolver(URI.create(target), resolverArgs(NO_PROXY));
         AtomicReference<NameResolver.ResolutionResult> result = new AtomicReference<>();
         resolver.start(new TestListener(result));
         assertThat(result.get().getAddresses()).containsExactly(
@@ -121,13 +129,13 @@ class StaticNameResolverTest {
     void providerShouldRejectTargetUriWithoutEndpoints() {
         StaticNameResolverProvider provider = new StaticNameResolverProvider();
 
-        assertThatThrownBy(() -> provider.newNameResolver(URI.create("static:///"), null))
+        assertThatThrownBy(() -> provider.newNameResolver(URI.create("static:///"), resolverArgs(NO_PROXY)))
             .isInstanceOf(IllegalArgumentException.class)
             .hasMessageContaining("No controller endpoint");
-        assertThatThrownBy(() -> provider.newNameResolver(URI.create("static:///localhost"), null))
+        assertThatThrownBy(() -> provider.newNameResolver(URI.create("static:///localhost"), resolverArgs(NO_PROXY)))
             .isInstanceOf(IllegalArgumentException.class)
             .hasMessageContaining("Invalid controller endpoint");
-        assertThatThrownBy(() -> provider.newNameResolver(URI.create("static:///localhost:abc"), null))
+        assertThatThrownBy(() -> provider.newNameResolver(URI.create("static:///localhost:abc"), resolverArgs(NO_PROXY)))
             .isInstanceOf(IllegalArgumentException.class)
             .hasMessageContaining("Invalid controller endpoint");
     }
@@ -136,8 +144,60 @@ class StaticNameResolverTest {
     void providerShouldReturnNullForWrongScheme() {
         StaticNameResolverProvider provider = new StaticNameResolverProvider();
 
-        NameResolver resolver = provider.newNameResolver(URI.create("dns:///localhost"), null);
+        NameResolver resolver = provider.newNameResolver(URI.create("dns:///localhost"), resolverArgs(NO_PROXY));
         assertThat(resolver).isNull();
+    }
+
+    @Test
+    void providerShouldRouteEndpointsThroughProxyWhenDetectorSelectsOne() {
+        // Given
+        InetSocketAddress proxy = new InetSocketAddress(InetAddress.getLoopbackAddress(), 3128);
+        List<InetSocketAddress> detected = new ArrayList<>();
+        ProxyDetector detector = target ->
+        {
+            detected.add((InetSocketAddress) target);
+            return HttpConnectProxiedSocketAddress.newBuilder()
+                .setTargetAddress((InetSocketAddress) target)
+                .setProxyAddress(proxy)
+                .build();
+        };
+
+        // When
+        NameResolver resolver = new StaticNameResolverProvider()
+            .newNameResolver(URI.create("static:///controller-1.example.com:9096"), resolverArgs(detector));
+        AtomicReference<NameResolver.ResolutionResult> result = new AtomicReference<>();
+        resolver.start(new TestListener(result));
+
+        // Then
+        assertThat(detected).singleElement().satisfies(target ->
+        {
+            assertThat(target.isUnresolved()).isTrue();
+            assertThat(target.getHostString()).isEqualTo("controller-1.example.com");
+            assertThat(target.getPort()).isEqualTo(9096);
+        });
+        assertThat(result.get().getAddresses()).singleElement()
+            .satisfies(group -> assertThat(group.getAddresses()).singleElement()
+                .isInstanceOfSatisfying(HttpConnectProxiedSocketAddress.class, address ->
+                {
+                    assertThat(address.getProxyAddress()).isEqualTo(proxy);
+                    assertThat(address.getTargetAddress().getHostString()).isEqualTo("controller-1.example.com");
+                }));
+    }
+
+    private static NameResolver.Args resolverArgs(ProxyDetector proxyDetector) {
+        return NameResolver.Args.newBuilder()
+            .setDefaultPort(50051)
+            .setProxyDetector(proxyDetector)
+            .setSynchronizationContext(new SynchronizationContext((t, e) ->
+            {
+                /* no-op */ }))
+            .setServiceConfigParser(new NameResolver.ServiceConfigParser() {
+                @Override
+                public NameResolver.ConfigOrError parseServiceConfig(Map<String, ?> rawServiceConfig) {
+                    return NameResolver.ConfigOrError.fromConfig(rawServiceConfig);
+                }
+            })
+            .build();
     }
 
     private static class TestListener extends NameResolver.Listener2 {

--- a/worker-controller/src/test/java/io/kestra/controller/resolver/StorageNameResolverTest.java
+++ b/worker-controller/src/test/java/io/kestra/controller/resolver/StorageNameResolverTest.java
@@ -1,5 +1,6 @@
 package io.kestra.controller.resolver;
 
+import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.URI;
 import java.time.Duration;
@@ -16,12 +17,16 @@ import io.kestra.controller.grpc.resolver.StorageNameResolver;
 import io.kestra.controller.grpc.resolver.StorageNameResolverProvider;
 
 import io.grpc.EquivalentAddressGroup;
+import io.grpc.HttpConnectProxiedSocketAddress;
 import io.grpc.NameResolver;
+import io.grpc.ProxyDetector;
 import io.grpc.SynchronizationContext;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 class StorageNameResolverTest {
+
+    private static final ProxyDetector NO_PROXY = target -> null;
 
     private final SynchronizationContext syncContext = new SynchronizationContext((t, e) ->
     {
@@ -34,7 +39,7 @@ class StorageNameResolverTest {
             new EquivalentAddressGroup(new InetSocketAddress("controller-1", 9096)),
             new EquivalentAddressGroup(new InetSocketAddress("controller-2", 9097))
         );
-        StorageNameResolver resolver = new StorageNameResolver(() -> addresses, Duration.ofMinutes(1), syncContext);
+        StorageNameResolver resolver = new StorageNameResolver(() -> addresses, Duration.ofMinutes(1), syncContext, NO_PROXY);
         AtomicReference<NameResolver.ResolutionResult> result = new AtomicReference<>();
 
         // When
@@ -53,7 +58,7 @@ class StorageNameResolverTest {
         List<EquivalentAddressGroup> addresses = List.of(
             new EquivalentAddressGroup(new InetSocketAddress("controller-1", 9096))
         );
-        StorageNameResolver resolver = new StorageNameResolver(() -> addresses, Duration.ofMinutes(1), syncContext);
+        StorageNameResolver resolver = new StorageNameResolver(() -> addresses, Duration.ofMinutes(1), syncContext, NO_PROXY);
         AtomicInteger callCount = new AtomicInteger();
         resolver.start(new TestListener(new AtomicReference<>(), callCount));
 
@@ -75,7 +80,7 @@ class StorageNameResolverTest {
                 new EquivalentAddressGroup(new InetSocketAddress("controller-1", 9096))
             )
         );
-        StorageNameResolver resolver = new StorageNameResolver(supplied::get, Duration.ofMinutes(1), syncContext);
+        StorageNameResolver resolver = new StorageNameResolver(supplied::get, Duration.ofMinutes(1), syncContext, NO_PROXY);
         AtomicInteger callCount = new AtomicInteger();
         AtomicReference<NameResolver.ResolutionResult> result = new AtomicReference<>();
         resolver.start(new TestListener(result, callCount));
@@ -104,7 +109,7 @@ class StorageNameResolverTest {
         {
             supplierCalls.incrementAndGet();
             return List.of(new EquivalentAddressGroup(new InetSocketAddress("controller", 9096)));
-        }, Duration.ofMillis(100), syncContext);
+        }, Duration.ofMillis(100), syncContext, NO_PROXY);
         resolver.start(new TestListener(new AtomicReference<>(), new AtomicInteger()));
 
         // When — wait for the scheduler to tick at least a couple of times
@@ -125,7 +130,7 @@ class StorageNameResolverTest {
         StorageNameResolverProvider provider = new StorageNameResolverProvider(List::of, Duration.ofMinutes(1));
 
         // When
-        NameResolver resolver = provider.newNameResolver(URI.create("storage:///controllers"), resolverArgs());
+        NameResolver resolver = provider.newNameResolver(URI.create("storage:///controllers"), resolverArgs(NO_PROXY));
 
         // Then
         assertThat(resolver).isInstanceOf(StorageNameResolver.class);
@@ -149,7 +154,7 @@ class StorageNameResolverTest {
                 new EquivalentAddressGroup(new InetSocketAddress("controller-1", 9096))
             )
         );
-        StorageNameResolver resolver = new StorageNameResolver(supplied::get, Duration.ofMillis(100), syncContext);
+        StorageNameResolver resolver = new StorageNameResolver(supplied::get, Duration.ofMillis(100), syncContext, NO_PROXY);
         AtomicBoolean offContext = new AtomicBoolean(false);
         AtomicInteger notifications = new AtomicInteger();
         resolver.start(new ContextCheckingListener(offContext, notifications));
@@ -172,10 +177,40 @@ class StorageNameResolverTest {
         assertThat(offContext.get()).isFalse();
     }
 
-    private NameResolver.Args resolverArgs() {
+    @Test
+    void providerShouldRouteEndpointsThroughProxyWhenDetectorSelectsOne() {
+        // Given
+        InetSocketAddress proxy = new InetSocketAddress(InetAddress.getLoopbackAddress(), 3128);
+        ProxyDetector detector = target -> HttpConnectProxiedSocketAddress.newBuilder()
+            .setTargetAddress((InetSocketAddress) target)
+            .setProxyAddress(proxy)
+            .build();
+        StorageNameResolverProvider provider = new StorageNameResolverProvider(
+            () -> List.of(new EquivalentAddressGroup(new InetSocketAddress("controller-1", 9096))),
+            Duration.ofMinutes(1)
+        );
+
+        // When
+        NameResolver resolver = provider.newNameResolver(URI.create("storage:///controllers"), resolverArgs(detector));
+        AtomicReference<NameResolver.ResolutionResult> result = new AtomicReference<>();
+        resolver.start(new TestListener(result, new AtomicInteger()));
+
+        // Then
+        assertThat(result.get().getAddresses()).singleElement()
+            .satisfies(group -> assertThat(group.getAddresses()).singleElement()
+                .isInstanceOfSatisfying(HttpConnectProxiedSocketAddress.class, address ->
+                {
+                    assertThat(address.getProxyAddress()).isEqualTo(proxy);
+                    assertThat(address.getTargetAddress().getHostString()).isEqualTo("controller-1");
+                }));
+
+        resolver.shutdown();
+    }
+
+    private NameResolver.Args resolverArgs(ProxyDetector proxyDetector) {
         return NameResolver.Args.newBuilder()
             .setDefaultPort(50051)
-            .setProxyDetector(target -> null)
+            .setProxyDetector(proxyDetector)
             .setSynchronizationContext(syncContext)
             .setServiceConfigParser(new NameResolver.ServiceConfigParser() {
                 @Override


### PR DESCRIPTION
### 🔗 Related Issue

Closes https://github.com/kestra-io/kestra-ee/issues/10606.

### ✨ Description

A worker whose only egress is a forward proxy could not reach the controller. With `-Dhttps.proxyHost` / `-Dhttps.proxyPort` set, HTTP traffic from the same JVM went through the proxy as expected, but the worker→controller gRPC channel dialled the controller address directly — no `CONNECT` ever reached the proxy. Operators reasonably read the MITM proxy documentation as general proxy support and were surprised.

The cause is that gRPC only ever consults its `ProxyDetector` from a **name resolver**, never from the transport. In `grpc-core` only `DnsNameResolver` calls `ProxyDetector.proxyFor`; `grpc-netty` merely *consumes* an `HttpConnectProxiedSocketAddress` and never produces one. Kestra's `static:///` and `storage:///` resolvers are custom, never asked the detector, and threw away the `NameResolver.Args` that carries it — so they silently bypassed the proxy. `dns:///` discovery was unaffected, since it uses gRPC's own resolver.

Both resolvers now pass every endpoint through the channel's detector, so `https.proxyHost` / `https.proxyPort`, `http.nonProxyHosts`, `GRPC_PROXY_EXP` and proxy Basic auth from `https.proxyUser` / `https.proxyPassword` all start working with **no new configuration surface**.

Two details worth a reviewer's attention:

- The detector is asked with an **unresolved** address. `ProxyDetectorImpl` hands the address it was given straight back as the CONNECT target, so a resolved one would make the tunnel request carry an IP and would need the DNS lookup that an endpoint reachable only through the proxy cannot satisfy. This is what makes the fix work when the controller hostname does not resolve at all.
- Detection failure (an `IOException`, i.e. a `ProxySelector` contract violation) logs a warning and falls back to a direct dial rather than emptying the address list.

With `STATIC` discovery each endpoint becomes its own proxied address, so client-side round-robin across controller replicas survives proxying. gRPC's own DNS resolver collapses to a single address group when a proxy is in play, so `STATIC` is actually better off here. TLS composes unchanged — `CONNECT`, then TLS inside the tunnel — and `kestra.grpc.tls.authority-override` remains relevant with `STATIC` exactly as before.

### 🛠️ Backend Checklist

- [x] Code compiles and tests pass for the touched modules (`./gradlew :worker-controller:test` — 161 tests, all pass)
- [x] New behavior is covered by unit or integration tests

### 📝 Additional Notes

Both new tests were confirmed to fail with the mapping removed, and only those two (17 run, 2 failed). The static one also asserts the detector was asked with an unresolved address — the subtle property that would otherwise silently regress the `CONNECT` line to an IP.

Not verified here: a live squid tunnel. The tests exercise the resolver contract, not an actual `CONNECT`; the reporter has a reproducible environment and is best placed to confirm end to end.

Deliberately not done:

- **No `kestra.worker.controllers.proxy` configuration block.** The issue suggests one as a follow-up, and the argument for it is good (reviewable alongside the rest of the worker config, no collision with `micronaut.http.client.proxy-address`, credentials from secret references instead of JVM arguments visible in `ps`). It belongs in its own PR — this one makes the ambient JVM settings work, which is what the docs already imply.
- **No docs change.** The MITM proxy page is in `kestra-io/docs` and should get a line saying the worker channel now follows the same JVM settings.
- **`STORAGE` discovery still resolves each registration eagerly** in `GrpcChannelManager.discoverControllersFromStorage`, costing a failing DNS lookup per poll in a proxy-only environment. Harmless (the mapping recovers the hostname via `getHostString()`) and out of scope.
