### PR TITLE
fix(apps): url-encode the file path in the app output download link

### DIFF
--- a/ui/src/components/executions/FilePreview.vue
+++ b/ui/src/components/executions/FilePreview.vue
@@ -119,7 +119,7 @@
     }>()
 
     const itemUrl = (value: string): string => {
-        return `${apiUrl()}/executions/${props.executionId}/file?path=${encodeURI(value)}`
+        return `${apiUrl()}/executions/${props.executionId}/file?path=${encodeURIComponent(value)}`
     }
 
     const maxRows = ref<number>()

--- a/ui/src/components/executions/VarValue.vue
+++ b/ui/src/components/executions/VarValue.vue
@@ -179,7 +179,7 @@
     })
 
     const itemUrl = (value: string): string => {
-        return `${apiUrl()}/executions/${props.execution?.id}/file?path=${encodeURI(value)}`
+        return `${apiUrl()}/executions/${props.execution?.id}/file?path=${encodeURIComponent(value)}`
     }
 
     const jsonlUrl = (value: string): string => {

--- a/ui/tests/unit/components/executions/FilePreview.spec.ts
+++ b/ui/tests/unit/components/executions/FilePreview.spec.ts
@@ -191,6 +191,25 @@ describe("FilePreview — HTML path", () => {
         expect(wrapper.find("iframe").attributes("srcdoc")).toBe(FULL_HTML)
     })
 
+    // Storage rewrites spaces in output file names to "+" and percent-encodes URI-special
+    // characters, so an unencoded ?path= query double-decodes server-side and 422s.
+    test("URL-encodes the storage path in the download link", async () => {
+        fileMetaMock.mockResolvedValue({size: SMALL_SIZE})
+        filePreviewMock.mockResolvedValue({content: "hello", type: "RAW", truncated: false})
+
+        const wrapper = shallowMount(FilePreview, {
+            props: {path: "kestra:///outputs/e1/abc-a%23b+c.txt", executionId: "exec-1"},
+            global: {
+                ...globalConfig,
+                stubs: {...globalConfig.stubs, KsButton: {inheritAttrs: false, template: "<a v-bind=\"$attrs\"><slot /></a>"}},
+            },
+        })
+        await flushPromises()
+
+        expect(wrapper.find("a[href]").attributes("href"))
+            .toBe("http://localhost:8080/api/v1/main/executions/exec-1/file?path=kestra%3A%2F%2F%2Foutputs%2Fe1%2Fabc-a%2523b%2Bc.txt")
+    })
+
     test("does not crash at render when the path prop is undefined", async () => {
         // A backend rejects a request with no path — the realistic outcome for a
         // caller that mounts FilePreview before path is set.

--- a/ui/tests/unit/components/executions/VarValue.spec.ts
+++ b/ui/tests/unit/components/executions/VarValue.spec.ts
@@ -1,0 +1,50 @@
+import {describe, test, expect, vi} from "vitest"
+import {shallowMount, flushPromises} from "@vue/test-utils"
+import {createI18n} from "vue-i18n"
+
+const fileMetaMock = vi.fn()
+
+vi.mock("@kestra-io/kestra-sdk/executions", () => ({
+    fileMetadatasFromExecution: (...args: unknown[]) => fileMetaMock(...args),
+}))
+
+vi.mock("override/utils/route", () => ({
+    apiUrl: () => "http://localhost:8080/api/v1/main",
+}))
+
+vi.mock("../../../../src/composables/useEditorBindings", () => ({
+    useEditorBindings: () => ({}),
+}))
+
+import VarValue from "../../../../src/components/executions/VarValue.vue"
+
+const i18n = createI18n({
+    legacy: false,
+    locale: "en",
+    messages: {en: {download: "Download", jsonl: "JSONL", open: "Open"}},
+    missingWarn: false,
+    fallbackWarn: false,
+})
+
+describe("VarValue download link", () => {
+    // Storage rewrites spaces in output file names to "+" and percent-encodes URI-special
+    // characters, so an unencoded ?path= query double-decodes server-side and 422s.
+    test("URL-encodes the storage path in the download link", async () => {
+        fileMetaMock.mockResolvedValue({size: 6})
+
+        const wrapper = shallowMount(VarValue, {
+            props: {value: "kestra:///company/e1/abc-a%23b+c.txt", execution: {id: "exec-1"}},
+            global: {
+                plugins: [i18n],
+                stubs: {
+                    KsButtonGroup: {template: "<div><slot /></div>"},
+                    KsButton: {inheritAttrs: false, template: "<a v-bind=\"$attrs\"><slot /></a>"},
+                },
+            },
+        })
+        await flushPromises()
+
+        expect(wrapper.find("a[href]").attributes("href"))
+            .toBe("http://localhost:8080/api/v1/main/executions/exec-1/file?path=kestra%3A%2F%2F%2Fcompany%2Fe1%2Fabc-a%2523b%2Bc.txt")
+    })
+})


### PR DESCRIPTION
Relates to https://github.com/kestra-io/kestra-ee/issues/9052.
EE PR: https://github.com/kestra-io/kestra-ee/pull/10616
