### PR TITLE
fix(flows): remove the empty gap between the Context panel sections

### DIFF
--- a/ui/src/styles/app.scss
+++ b/ui/src/styles/app.scss
@@ -102,7 +102,9 @@ main {
             flex: 1;
             min-height: 0;
 
-            :has(.ks-data-table-wrapper) {
+            // Every ancestor of the table is matched here, so keep the stretch out of
+            // collapsible sections, which have to hug their summary when closed.
+            :has(.ks-data-table-wrapper):not(details, details *) {
                 height: 100%;
             }
         }


### PR DESCRIPTION
Related to https://github.com/kestra-io/kestra/issues/18495.
Related to https://github.com/kestra-io/kestra/pull/18761.

Backport of https://github.com/kestra-io/kestra/pull/18761 to `releases/v2.0.x`, cherry-picked from b969120b7734faf32c7d3cef45f4e111cbb7ffbc with no conflicts.

`app.scss` stretches a listing section to full height when its data table renders an empty state. The inner rule was an unqualified descendant selector, `:has(.ks-data-table-wrapper) { height: 100% }`, which matches every ancestor of a `.ks-data-table-wrapper` - including the `<details>` of the `KV Pair` and `Secrets` collapsibles in the flow editor `Context` panel. Each took the full height of the panel even while closed, leaving the reported gap.

Keeping the stretch out of `<details>` subtrees fixes it: a collapsible has to hug its summary when closed, so it is never a candidate for the full-height treatment.

Verified on `develop` against a running Enterprise instance: section heights go from 29 / 629 / 629 to 29 / 29 / 29, and the new selector drops exactly the nine elements inside those two collapsibles while every other match is untouched. `releases/v2.0.x` carries the identical rule, and the cherry-pick applied cleanly, so the same reasoning holds here.
