### PR TITLE
fix(core): blank table when every column is hidden in kv store

### DIFF
--- a/ui/src/components/kv/KVTable.vue
+++ b/ui/src/components/kv/KVTable.vue
@@ -1,5 +1,5 @@
 <template>
-    <DataTable @page-changed="onPageChanged" ref="dataTable" :total="total">
+    <DataTable @page-changed="onPageChanged" ref="dataTable" :total="hasVisibleColumns ? total : 0">
         <template #top>
             <KSFilter
                 :configuration="kvFilter"
@@ -21,14 +21,14 @@
 
         <template #table>
             <SelectTable
-                :data="kvs"
+                :data="hasVisibleColumns ? kvs : []"
                 ref="selectTable"
                 :defaultSort="{prop: 'key', order: 'ascending'}"
                 tableLayout="auto"
                 fixed
                 @selection-change="handleSelectionChange"
                 @sort-change="onSort"
-                :no-data-text="$t('no_results.kv_pairs')"
+                :no-data-text="hasVisibleColumns ? $t('no_results.kv_pairs') : $t('no_results.all_columns_hidden')"
                 class="fill-height"
                 :showSelection="!paneView"
                 :rowKey="(row: any) => `${row.namespace}-${row.key}`"
@@ -96,7 +96,7 @@
                     </el-table-column>
                 </template>
 
-                <el-table-column columnKey="copy" className="row-action">
+                <el-table-column v-if="hasVisibleColumns" columnKey="copy" className="row-action">
                     <template #default="scope">
                         <IconButton
                             v-if="scope.row.key !== undefined"
@@ -109,7 +109,7 @@
                     </template>
                 </el-table-column>
 
-                <el-table-column v-if="!paneView" columnKey="view" className="row-action">
+                <el-table-column v-if="!paneView && hasVisibleColumns" columnKey="view" className="row-action">
                     <template #default="scope">
                         <IconButton
                             v-if="!canUpdate(scope.row) && canRead(scope.row)"
@@ -122,7 +122,7 @@
                     </template>
                 </el-table-column>
 
-                <el-table-column v-if="!paneView" columnKey="update" className="row-action">
+                <el-table-column v-if="!paneView && hasVisibleColumns" columnKey="update" className="row-action">
                     <template #default="scope">
                         <IconButton
                             v-if="canUpdate(scope.row)"
@@ -135,7 +135,7 @@
                     </template>
                 </el-table-column>
 
-                <el-table-column v-if="!paneView" columnKey="delete" className="row-action">
+                <el-table-column v-if="!paneView && hasVisibleColumns" columnKey="delete" className="row-action">
                     <template #default="scope">
                         <IconButton
                             v-if="canDelete(scope.row)"
@@ -484,6 +484,8 @@
         columns: optionalColumns.value,
         storageKey: storageKey
     });
+
+    const hasVisibleColumns = computed(() => orderedVisibleColumns.value.length > 0);
 
     const {
         selection,

--- a/ui/src/translations/de.json
+++ b/ui/src/translations/de.json
@@ -1377,7 +1377,8 @@
       "kv_pairs": "Keine Key-Value-Paare gefunden",
       "secrets": "Keine Secrets gefunden",
       "templates": "Keine Vorlagen gefunden",
-      "triggers": "Keine Trigger gefunden"
+      "triggers": "Keine Trigger gefunden",
+      "all_columns_hidden": "Alle Spalten sind ausgeblendet"
     },
     "no_results_found": "Keine Ergebnisse gefunden",
     "no_tasks_running": "Noch keine Tasks laufen.",

--- a/ui/src/translations/en.json
+++ b/ui/src/translations/en.json
@@ -1586,7 +1586,8 @@
             "kv_pairs": "No Key-Value pairs Found",
             "secrets": "No Secrets Found",
             "templates": "No Templates Found",
-            "assets": "No Assets Found"
+            "assets": "No Assets Found",
+            "all_columns_hidden": "All columns are hidden"
         },
         "duplicate-pair": "{label} \"{key}\" is duplicated, first key ignored.",
         "dashboards": {

--- a/ui/src/translations/es.json
+++ b/ui/src/translations/es.json
@@ -1377,7 +1377,8 @@
       "kv_pairs": "No se encontraron pares Key-Value",
       "secrets": "No se encontraron Secrets",
       "templates": "No se encontraron plantillas",
-      "triggers": "No se encontraron Triggers"
+      "triggers": "No se encontraron Triggers",
+      "all_columns_hidden": "Todas las columnas están ocultas"
     },
     "no_results_found": "No se encontraron resultados",
     "no_tasks_running": "Todavía no hay tasks en ejecución.",

--- a/ui/src/translations/fr.json
+++ b/ui/src/translations/fr.json
@@ -1377,7 +1377,8 @@
       "kv_pairs": "Aucune paire clé-valeur trouvée",
       "secrets": "Aucun secret trouvé",
       "templates": "Aucun modèle trouvé",
-      "triggers": "Aucun Trigger trouvé"
+      "triggers": "Aucun Trigger trouvé",
+      "all_columns_hidden": "Toutes les colonnes sont masquées"
     },
     "no_results_found": "Aucun résultat trouvé",
     "no_tasks_running": "Aucune tâche n'est encore en cours d'exécution.",

--- a/ui/src/translations/hi.json
+++ b/ui/src/translations/hi.json
@@ -1377,7 +1377,8 @@
       "kv_pairs": "कोई Key-Value जोड़े नहीं मिले",
       "secrets": "कोई Secrets नहीं मिले",
       "templates": "कोई टेम्पलेट नहीं मिला",
-      "triggers": "कोई Triggers नहीं मिले"
+      "triggers": "कोई Triggers नहीं मिले",
+      "all_columns_hidden": "सभी कॉलम छिपे हुए हैं"
     },
     "no_results_found": "कोई परिणाम नहीं मिला",
     "no_tasks_running": "अभी कोई task नहीं चल रहा है।",

--- a/ui/src/translations/it.json
+++ b/ui/src/translations/it.json
@@ -1377,7 +1377,8 @@
       "kv_pairs": "Nessuna coppia Key-Value trovata",
       "secrets": "Nessun Secret Trovato",
       "templates": "Nessun Template Trovato",
-      "triggers": "Nessun Trigger Trovato"
+      "triggers": "Nessun Trigger Trovato",
+      "all_columns_hidden": "Tutte le colonne sono nascoste"
     },
     "no_results_found": "Nessun risultato trovato",
     "no_tasks_running": "Nessun task è ancora in esecuzione.",

--- a/ui/src/translations/ja.json
+++ b/ui/src/translations/ja.json
@@ -1377,7 +1377,8 @@
       "kv_pairs": "キー-バリュー ペアが見つかりません",
       "secrets": "シークレットが見つかりません",
       "templates": "テンプレートが見つかりません",
-      "triggers": "トリガーが見つかりません"
+      "triggers": "トリガーが見つかりません",
+      "all_columns_hidden": "すべての列が非表示です"
     },
     "no_results_found": "結果が見つかりません",
     "no_tasks_running": "タスクはまだ実行されていません。",

--- a/ui/src/translations/ko.json
+++ b/ui/src/translations/ko.json
@@ -1377,7 +1377,8 @@
       "kv_pairs": "Key-Value 쌍을 찾을 수 없음",
       "secrets": "비밀 없음",
       "templates": "템플릿을 찾을 수 없음",
-      "triggers": "트리거를 찾을 수 없음"
+      "triggers": "트리거를 찾을 수 없음",
+      "all_columns_hidden": "모든 열이 숨겨짐"
     },
     "no_results_found": "결과를 찾을 수 없습니다",
     "no_tasks_running": "아직 실행 중인 task가 없습니다.",

--- a/ui/src/translations/pl.json
+++ b/ui/src/translations/pl.json
@@ -1377,7 +1377,8 @@
       "kv_pairs": "Nie znaleziono par klucz-wartość",
       "secrets": "Nie znaleziono sekretów",
       "templates": "Nie znaleziono szablonów",
-      "triggers": "Nie znaleziono Triggerów"
+      "triggers": "Nie znaleziono Triggerów",
+      "all_columns_hidden": "Wszystkie kolumny są ukryte"
     },
     "no_results_found": "Nie znaleziono wyników",
     "no_tasks_running": "Jeszcze nie ma uruchomionych tasków.",

--- a/ui/src/translations/pt.json
+++ b/ui/src/translations/pt.json
@@ -1377,7 +1377,8 @@
       "kv_pairs": "Nenhum par de Key-Value encontrado",
       "secrets": "Nenhum Secret Encontrado",
       "templates": "Nenhum Template Encontrado",
-      "triggers": "Nenhum Trigger Encontrado"
+      "triggers": "Nenhum Trigger Encontrado",
+      "all_columns_hidden": "Todas as colunas estão ocultas"
     },
     "no_results_found": "Nenhum resultado encontrado",
     "no_tasks_running": "Ainda não há tasks em execução.",

--- a/ui/src/translations/pt_BR.json
+++ b/ui/src/translations/pt_BR.json
@@ -1377,7 +1377,8 @@
       "kv_pairs": "Nenhum par de Key-Value encontrado",
       "secrets": "Nenhum Secret Encontrado",
       "templates": "Nenhum Template Encontrado",
-      "triggers": "Nenhum Trigger Encontrado"
+      "triggers": "Nenhum Trigger Encontrado",
+      "all_columns_hidden": "Todas as colunas estão ocultas"
     },
     "no_results_found": "Nenhum resultado encontrado",
     "no_tasks_running": "Ainda não há tasks em execução.",

--- a/ui/src/translations/ru.json
+++ b/ui/src/translations/ru.json
@@ -1377,7 +1377,8 @@
       "kv_pairs": "Пары kv store не найдены",
       "secrets": "Секреты не найдены",
       "templates": "Шаблоны не найдены",
-      "triggers": "Триггеры не найдены"
+      "triggers": "Триггеры не найдены",
+      "all_columns_hidden": "Все столбцы скрыты"
     },
     "no_results_found": "Результаты не найдены",
     "no_tasks_running": "Ещё нет запущенных tasks.",

--- a/ui/src/translations/zh_CN.json
+++ b/ui/src/translations/zh_CN.json
@@ -1377,7 +1377,8 @@
       "kv_pairs": "未找到Key-Value对",
       "secrets": "未找到Secrets",
       "templates": "未找到模板",
-      "triggers": "未找到Triggers"
+      "triggers": "未找到Triggers",
+      "all_columns_hidden": "所有列均已隐藏"
     },
     "no_results_found": "未找到结果",
     "no_tasks_running": "尚无任务正在运行。",


### PR DESCRIPTION
Closes https://github.com/kestra-io/kestra/issues/18579.

Backport of https://github.com/kestra-io/kestra/pull/18756 to `releases/v1.3.x`. **Not a cherry-pick** - `1.3` predates the design system, so this is the same fix re-implemented against the older table stack. See the deviations below.

## What

Hiding every column in the `KV Store` table left the headers and data gone while the four row-level action icons kept rendering, floating unaligned across an empty grid. `1.3` is affected because its `KVTable.vue` renders those `el-table-column`s outside the `v-for="colProp in orderedVisibleColumns"` loop with no guard, and the all-hidden selection persists across a refresh (the `stored === ""` branch in `useTableColumns`, backported with https://github.com/kestra-io/kestra/pull/18531).

- The four row-action columns are gated on `hasVisibleColumns`.
- The rows are blanked with them, and `:total` is zeroed so the pagination footer stops reporting records the table cannot show.
- The empty text becomes `no_results.all_columns_hidden` instead of the generic no-results copy.

## Deviations from the `develop` fix

- **No `noDataDescription` second line.** `develop` adds that prop to `KsDataTable`, but `1.3` has no design system: `SelectTable` hands `noDataText` straight to `el-table`'s `emptyText`, which is a single plain string with nowhere to put a description. Only the `all_columns_hidden` title key is added here, and `all_columns_hidden_description` is deliberately left out rather than shipped as a dead key.
- **No `MetricsTable` change.** Unlike on `develop`, `1.3`'s `MetricsTable` already renders its row-action column *inside* the `v-for`, so it never reached the broken state.
- **Translations were copied, not generated.** `1.3` has no `translations:generate` script - only `check.js`. The English string is byte-identical to the one on `develop`, so the twelve locale values are the same machine-generated ones from https://github.com/kestra-io/kestra/pull/18756 rather than hand-written.

`1.0` is **not** affected: its `KVTable.vue` has no column picker at all, every column is a static `el-table-column`.

## Evidence

`node src/translations/check.js` reports no missing and no extra keys for all twelve locales. `npm run check:types` and `eslint` on the changed file are clean.

Screenshots of the bug and the fixed empty state are on the `develop` `PR`: https://github.com/kestra-io/kestra/pull/18756#issuecomment-5493924820. They are captured against the 2.0 `UI`, so the `1.3` empty state renders the same message through `el-table`'s plainer empty text.