### PR TITLE
fix(core): replay from a task run that moved in the requested flow revision

### DIFF
--- a/core/src/main/java/io/kestra/core/services/ExecutionService.java
+++ b/core/src/main/java/io/kestra/core/services/ExecutionService.java
@@ -318,12 +318,19 @@ public class ExecutionService {
         final String newExecutionId = IdUtils.create();
         List<TaskRun> newTaskRuns = new ArrayList<>();
         if (taskRunId != null) {
-            GraphCluster graphCluster = GraphUtils.of(flow, execution);
-
             Set<String> taskRunToRestart = this.taskRunToRestart(
                 execution,
                 taskRun -> taskRun.getId().equals(taskRunId)
             );
+
+            GraphCluster graphCluster = GraphUtils.of(flow, execution);
+            if (!GraphUtils.hasTaskRun(graphCluster, taskRunId)) {
+                TaskRun replayedTaskRun = execution.findTaskRunByTaskRunId(taskRunId);
+                throw new IllegalArgumentException(
+                    "Cannot replay execution '%s' from task run '%s': task '%s' does not exist at the same position in revision %s of flow '%s'."
+                        .formatted(execution.getId(), taskRunId, replayedTaskRun.getTaskId(), flow.getRevision(), flow.getId())
+                );
+            }
 
             Map<String, String> mappingTaskRunId = this.mapTaskRunId(execution, false);
 

--- a/core/src/main/java/io/kestra/core/utils/GraphUtils.java
+++ b/core/src/main/java/io/kestra/core/utils/GraphUtils.java
@@ -140,6 +140,18 @@ public class GraphUtils {
             .toList();
     }
 
+    /**
+     * A graph node carries a task run only when the flow revision the graph was built from
+     * still has that task at the same place in the hierarchy as the revision it ran on.
+     */
+    public static boolean hasTaskRun(GraphCluster graphCluster, String taskRunId) {
+        return nodes(graphCluster)
+            .stream()
+            .filter(AbstractGraphTask.class::isInstance)
+            .map(AbstractGraphTask.class::cast)
+            .anyMatch(node -> node.getTaskRun() != null && node.getTaskRun().getId().equals(taskRunId));
+    }
+
     public static Set<AbstractGraph> successors(GraphCluster graphCluster, Set<String> taskRunIds) {
         List<FlowGraph.Edge> edges = GraphUtils.edges(graphCluster);
         List<AbstractGraph> nodes = GraphUtils.nodes(graphCluster);
@@ -594,15 +606,14 @@ public class GraphUtils {
     }
 
     private static List<TaskRun> findTaskRuns(Task task, Execution execution, TaskRun parent) {
-        List<TaskRun> taskRuns = execution != null ? execution.findTaskRunsByTaskId(task.getId()) : new ArrayList<>();
+        List<TaskRun> taskRuns = execution != null ? execution.findTaskRunsByTaskId(task.getId()) : List.of();
 
-        if (taskRuns.isEmpty()) {
-            return Collections.singletonList(null);
-        }
-
-        return taskRuns
+        List<TaskRun> matching = taskRuns
             .stream()
-            .filter(taskRun -> parent == null || (taskRun.getParentTaskRunId().equals(parent.getId())))
+            .filter(taskRun -> parent == null || parent.getId().equals(taskRun.getParentTaskRunId()))
             .toList();
+
+        // an empty result would drop the node from the graph and spin fillGraphDag's completion loop forever
+        return matching.isEmpty() ? Collections.singletonList(null) : matching;
     }
 }

--- a/core/src/test/java/io/kestra/core/runners/ExecutionServiceTest.java
+++ b/core/src/test/java/io/kestra/core/runners/ExecutionServiceTest.java
@@ -38,6 +38,7 @@ import lombok.extern.slf4j.Slf4j;
 
 import static io.kestra.core.tenant.TenantService.MAIN_TENANT;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
@@ -392,6 +393,36 @@ class ExecutionServiceTest {
 
         assertThat(restart.getFlowRevision()).isEqualTo(updated.getRevision());
         assertThat(restart.getVariables()).containsEntry("greeting", "Hello World");
+    }
+
+    @Test
+    @LoadFlows(value = { "flows/valids/replay-moved-task.yaml" }, tenantId = TENANT_1)
+    void shouldThrowWhenReplayingATaskThatMovedInTheRequestedRevision() throws Exception {
+        Execution execution = runnerUtils.runOne(TENANT_1, "io.kestra.tests", "replay-moved-task");
+        assertThat(execution.getState().getCurrent()).isEqualTo(State.Type.FAILED);
+        String standaloneTaskRunId = execution.findTaskRunsByTaskId("standalone").getFirst().getId();
+
+        // move "standalone" inside "seq" in the new revision
+        FlowWithSource flow = flowRepository.findByExecutionWithSource(execution);
+        String newSource = """
+            id: replay-moved-task
+            namespace: io.kestra.tests
+
+            tasks:
+              - id: seq
+                type: io.kestra.plugin.core.flow.Sequential
+                tasks:
+                  - id: standalone
+                    type: io.kestra.plugin.core.log.Log
+                    message: standalone moved inside seq
+                  - id: boom
+                    type: io.kestra.plugin.core.execution.Fail
+            """;
+        FlowWithSource updated = flowRepository.update(GenericFlow.fromYaml(flow.getTenantId(), newSource), flow);
+
+        assertThatThrownBy(() -> executionService.replay(execution, updated, standaloneTaskRunId, updated.getRevision()))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("standalone");
     }
 
     @Test

--- a/core/src/test/java/io/kestra/core/utils/GraphUtilsTest.java
+++ b/core/src/test/java/io/kestra/core/utils/GraphUtilsTest.java
@@ -1,0 +1,107 @@
+package io.kestra.core.utils;
+
+import java.time.Duration;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import io.kestra.core.models.executions.Execution;
+import io.kestra.core.models.executions.TaskRun;
+import io.kestra.core.models.flows.Flow;
+import io.kestra.core.models.flows.State;
+import io.kestra.core.models.hierarchies.GraphCluster;
+import io.kestra.core.serializers.YamlParser;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
+
+class GraphUtilsTest {
+
+    @Test
+    void shouldKeepTaskNodeWhenTaskRunMovedIntoAFlowable() throws Exception {
+        Flow flow = YamlParser.parse(
+            """
+                id: replay-moved-task
+                namespace: io.kestra.tests
+                tasks:
+                  - id: seq
+                    type: io.kestra.plugin.core.flow.Sequential
+                    tasks:
+                      - id: standalone
+                        type: io.kestra.plugin.core.log.Log
+                        message: hello
+                      - id: boom
+                        type: io.kestra.plugin.core.log.Log
+                        message: hello
+                """,
+            Flow.class
+        );
+        String executionId = IdUtils.create();
+        TaskRun seq = taskRun(executionId, flow, "seq", null);
+        TaskRun standalone = taskRun(executionId, flow, "standalone", null);
+        TaskRun boom = taskRun(executionId, flow, "boom", seq.getId());
+
+        Execution execution = Execution.newExecution(flow, List.of())
+            .toBuilder()
+            .id(executionId)
+            .taskRunList(List.of(seq, standalone, boom))
+            .build();
+
+        GraphCluster graph = GraphUtils.of(flow, execution);
+
+        assertThat(GraphUtils.hasTaskRun(graph, boom.getId())).isTrue();
+        assertThat(GraphUtils.hasTaskRun(graph, standalone.getId())).isFalse();
+    }
+
+    @Test
+    void shouldNotHangWhenADagTaskRunBelongsToAnotherParent() throws Exception {
+        Flow flow = YamlParser.parse(
+            """
+                id: replay-moved-dag-task
+                namespace: io.kestra.tests
+                tasks:
+                  - id: d
+                    type: io.kestra.plugin.core.flow.Dag
+                    tasks:
+                      - task:
+                          id: a
+                          type: io.kestra.plugin.core.log.Log
+                          message: hello
+                      - task:
+                          id: x
+                          type: io.kestra.plugin.core.log.Log
+                          message: hello
+                        dependsOn: [a]
+                """,
+            Flow.class
+        );
+        String executionId = IdUtils.create();
+        TaskRun d = taskRun(executionId, flow, "d", null);
+        TaskRun a = taskRun(executionId, flow, "a", d.getId());
+        TaskRun x = taskRun(executionId, flow, "x", null);
+
+        Execution execution = Execution.newExecution(flow, List.of())
+            .toBuilder()
+            .id(executionId)
+            .taskRunList(List.of(d, a, x))
+            .build();
+
+        assertTimeoutPreemptively(
+            Duration.ofSeconds(5),
+            () -> GraphUtils.of(flow, execution)
+        );
+    }
+
+    private TaskRun taskRun(String executionId, Flow flow, String taskId, String parentTaskRunId) {
+        return TaskRun.builder()
+            .id(IdUtils.create())
+            .executionId(executionId)
+            .tenantId(flow.getTenantId())
+            .namespace(flow.getNamespace())
+            .flowId(flow.getId())
+            .taskId(taskId)
+            .parentTaskRunId(parentTaskRunId)
+            .state(new State())
+            .build();
+    }
+}

--- a/core/src/test/resources/flows/valids/replay-moved-task.yaml
+++ b/core/src/test/resources/flows/valids/replay-moved-task.yaml
@@ -1,0 +1,12 @@
+id: replay-moved-task
+namespace: io.kestra.tests
+
+tasks:
+  - id: standalone
+    type: io.kestra.plugin.core.log.Log
+    message: standalone ran at top level
+  - id: seq
+    type: io.kestra.plugin.core.flow.Sequential
+    tasks:
+      - id: boom
+        type: io.kestra.plugin.core.execution.Fail


### PR DESCRIPTION
## Summary
- Backport to `releases/v1.3.x` of the fix on `develop` (commit 794322b5b8) for a 500 NPE when replaying an execution from a task run whose position relative to a flowable differs between the execution's original revision and the requested replay-target revision. The cherry-pick conflicted (1.3 lacks a later commit that made `GraphUtils`' topology walk iterative/cycle-safe, and lacks `GraphUtilsTest.java`), so the fix was manually reapplied against 1.3's current code.
- `GraphUtils.findTaskRuns` no longer dereferences a null `parentTaskRunId` once the graph walk descends past the top level, and never returns an empty list (which previously could spin `fillGraphDag`'s completion loop forever on the same mismatch).
- Added `GraphUtils.hasTaskRun(...)`, used in `ExecutionService.replay` to reject a replay target that has no place in the requested revision's graph with a clear `IllegalArgumentException` instead of NPEing.
- Added a minimal `GraphUtilsTest.java` (didn't exist on this branch) with two unit tests ported from develop that are applicable to 1.3's code, including a regression test for the `Dag` task completion-loop hang that the same fix also addresses.

Closes https://github.com/kestra-io/kestra-ee/issues/10529.

## Test plan
- [x] `./gradlew :core:test --tests "io.kestra.core.runners.ExecutionServiceTest"` — 28/28 passed
- [x] `./gradlew :core:test --tests "io.kestra.core.utils.GraphUtilsTest"` — 2/2 passed
- [x] Reviewed via the `code-review` agent