### PR TITLE
fix(namespaces): parent folders not created when a folder name contains a slash

### DIFF
--- a/core/src/main/java/io/kestra/core/storages/InternalNamespace.java
+++ b/core/src/main/java/io/kestra/core/storages/InternalNamespace.java
@@ -501,7 +501,7 @@ public class InternalNamespace implements Namespace {
             (maybeParentPath = Optional.ofNullable(NamespaceFileMetadata.parentPath(maybeParentPath.map(Path::toString).orElse(path))).map(Path::of)).isPresent()
                 && !this.exists(maybeParentPath.get())
         ) {
-            this.createDirectory(maybeParentPath.get());
+            this.createSingleDirectory(maybeParentPath.get());
             createdDirs.add(NamespaceFile.of(namespace, maybeParentPath.get().toString().endsWith("/") ? maybeParentPath.get().toString() : maybeParentPath.get() + "/", 1));
         }
 
@@ -516,7 +516,12 @@ public class InternalNamespace implements Namespace {
         final Path normalizedPath = NamespaceFile.normalize(path);
 
         ensureNoFileInHierarchy(normalizedPath);
+        mkDirs(normalizedPath.toString());
 
+        return createSingleDirectory(normalizedPath);
+    }
+
+    private NamespaceFile createSingleDirectory(Path normalizedPath) throws IOException {
         discardConflictingEntry(findByPath(normalizedPath, true), true, normalizedPath);
 
         NamespaceFileMetadata nsFileMetadata = stateStore.save(

--- a/core/src/main/java/io/kestra/core/storages/Namespace.java
+++ b/core/src/main/java/io/kestra/core/storages/Namespace.java
@@ -141,10 +141,10 @@ public interface Namespace {
     }
 
     /**
-     * Creates a new directory for the current namespace.
+     * Creates a new directory for the current namespace, along with any missing parent directory.
      *
      * @param path The {@link Path} of the directory.
-     * @return The created namespace file.
+     * @return The created namespace file of the deepest directory.
      * @throws IOException if an error happens while accessing the file.
      */
     NamespaceFile createDirectory(Path path) throws IOException;

--- a/core/src/test/java/io/kestra/core/storages/InternalNamespaceTest.java
+++ b/core/src/test/java/io/kestra/core/storages/InternalNamespaceTest.java
@@ -296,6 +296,22 @@ class InternalNamespaceTest {
     }
 
     @Test
+    void shouldCreateMissingParentDirectoriesWhenCreatingANestedDirectory() throws IOException {
+        // Given
+        final String namespaceId = TestsUtils.randomNamespace();
+        final InternalNamespace namespace = new InternalNamespace(log, MAIN_TENANT, namespaceId, storageInterface, namespaceFileMetadataStateStore);
+
+        // When
+        NamespaceFile directory = namespace.createDirectory(Path.of("parent/child"));
+
+        // Then the parent is listed at the root, so the new directory is reachable instead of being
+        // orphaned under an ancestor that was never created.
+        assertThat(directory.path()).isEqualTo("parent/child/");
+        assertThat(namespace.children("/", false).stream().map(NamespaceFileMetadata::getPath)).containsExactly("/parent/");
+        assertThat(namespace.children("/parent/", false).stream().map(NamespaceFileMetadata::getPath)).containsExactly("/parent/child/");
+    }
+
+    @Test
     void shouldServeLatestAvailableRevisionWhenLatestRevisionObjectIsMissing() throws IOException, URISyntaxException {
         // Given a file with two revisions whose latest-revision object has been removed from storage
         // out-of-band, leaving the metadata index ahead of storage (the drift that produced 404s).


### PR DESCRIPTION
Closes https://github.com/kestra-io/kestra-ee/issues/6553.

### ✨ Description

Creating a folder named `a/a` from the namespace files editor left a hidden entry behind. `POST /namespaces/{ns}/files/directory?path=/a/a` persisted only `/a/a/`, without the `/a/` entry above it, so the root listing had nothing to show and the folder was gone after a refresh - while still occupying the path in the index. Creating `a` afterwards then made a phantom `a` child appear underneath it.

`Namespace.createDirectory` now creates the missing parent directories, the way `putFile` already does for the ancestors of a new file (`mkDirs`), so a slash in a folder name creates the whole chain like it does in an editor. Nothing changed in the `UI`: the file tree already splits the name on `/` and posts the nested path.

Verified against a local instance, same namespace, same request, before and after the change:

| | before | after |
|---|---|---|
| `POST .../files/directory?path=/a/a` | `200` | `200` |
| `GET .../files/directory` (root) | `[]` | `[{"fileName": "a", "type": "Directory"}]` |
| `GET .../files/directory?path=/a` | `404 Directory not found: /a` | `[{"fileName": "a", "type": "Directory"}]` |

On the unpatched build, creating `a` after that left `/a` holding a child `a` nobody asked for - that is the phantom folder from the issue, and it no longer happens.

### 🛠️ Backend Checklist

- [x] Code compiles and tests pass for the touched modules (`./gradlew :core:test --tests "InternalNamespaceTest"`, `./gradlew :webserver:test --tests "NamespaceFileControllerTest"`, `./gradlew :core:test --tests "*Namespace*"`)
- [x] New behavior is covered by unit or integration tests

### 📝 Additional Notes

No screenshots: the change is backend-only and the `UI` is untouched, so the evidence above is the `API` the file tree calls, captured on a running instance rather than in a test.

One thing deliberately left alone: `createNamespaceDirectory` still publishes a single audit event for the requested path in `EE`, so the parents created underneath it are not audited individually. The file endpoint does audit implicitly created parents (`innerCreateNamespaceFile` returns them), so closing that gap means returning the created list from the directory endpoint too - a small cross-repo change that does not belong in this fix.

Why did the folder cross the road? To get to the other `/side` - it had no parent to stop it. 🐱
