### PR TITLE
fix(playground): give the tab content a definite height so Outputs renders

### DIFF
--- a/ui/src/components/flows/FlowPlayground.vue
+++ b/ui/src/components/flows/FlowPlayground.vue
@@ -190,7 +190,9 @@
     }
 
     .current-run {
+        display: flex;
         flex: 1;
+        flex-direction: column;
     }
 
 .extra-options{
@@ -273,6 +275,7 @@
     }
 
     .tab-content{
+        flex: 1;
         overflow: auto;
         padding: 1rem;
         background-color: var(--ks-bg-surface);


### PR DESCRIPTION
closes https://github.com/kestra-io/kestra-ee/issues/10289

This pull request makes minor layout improvements to the `FlowPlayground.vue` component. The changes enhance the flexibility and responsiveness of the layout by adjusting the flexbox properties of key container elements.

Layout improvements:

* Made `.current-run` use a column flex layout and ensured it expands to fill available space, improving the arrangement of its child components.
* Set `.tab-content` to flex and fill available space, contributing to a more responsive and consistent layout.