### PR TITLE
fix(secrets): stop presenting the OSS secrets page as locked

### DIFF
--- a/ui/src/override/components/useLeftMenu.ts
+++ b/ui/src/override/components/useLeftMenu.ts
@@ -302,9 +302,6 @@ export function useLeftMenu() {
                         icon: {
                             element: LockOutline,
                         },
-                        attributes: {
-                            locked: true,
-                        },
                     },
                     {
                         id: "triggers",


### PR DESCRIPTION
### 🔗 Related Issue

Closes https://github.com/kestra-io/kestra/issues/18348.

### ✨ Description

The Secrets entry in the sidebar carried `locked: true` unconditionally, so it rendered with the same greyed-out treatment and lock badge as Apps and Tests. Those two really are unavailable in OSS. Secrets is not: the page behind it documents the supported OSS path, declaring secrets through `SECRET_<KEY>` environment variables, alongside the EE upsell.

The lock therefore told users "not for you" about a page that works for them. The entry keeps its padlock icon, which belongs to the concept of a secret rather than to availability.

Measured on a running OSS instance, before and after:

| Item | before | after |
|---|---|---|
| Apps | `is-locked`, badge, `rgb(126,126,155)` | unchanged |
| Tests | `is-locked`, badge, `rgb(126,126,155)` | unchanged |
| **Secrets** | `is-locked`, **badge**, `rgb(126,126,155)` | no `is-locked`, **no badge**, normal palette |
| KV Store | none, `rgb(8,9,10)` | unchanged |

### 🎨 Frontend Checklist

- [x] Type checking passes (`npm run check:types`)
- [x] Code builds without errors (`npm run build`)
- [x] Unit tests pass (`npm run test:unit`)
- [x] Translations are complete — no string changed
- [ ] Screenshots or video recordings attached showing the `UI` changes

### 📝 Additional Notes

The issue also proposes adding a note on the page that secrets are read-only in OSS. That copy already exists there ("Create a New Secret", "Encode the secret value in Base64", "Set an environment variable named `SECRET_<MY_SECRET_KEY>`"), so this PR only removes the misleading lock. Say the word if you want the wording strengthened as well.

Only the OSS `override/` copy of the menu is touched, so the EE menu, where Secrets is a full feature, is unaffected.

### 🤖 AI Authors

This PR was written by Claude at @flcarre's request. The cat inspected the padlock, found the door open the whole time, and left without commenting. 🐱
