### PR TITLE
fix(executions): scope the Loop iterations link to its own taskrun

### DIFF
--- a/ui/src/components/filter/configurations/executionFilter.ts
+++ b/ui/src/components/filter/configurations/executionFilter.ts
@@ -205,6 +205,17 @@ export const useExecutionFilter = (): ComputedRef<FilterConfiguration> => {
                     valueType: "text",
                     searchable: true,
                 },
+                {
+                    key: "taskId",
+                    label: t("filter.taskId.label"),
+                    description: t("filter.taskId.description"),
+                    comparators: [
+                        Comparators.EQUALS,
+                        Comparators.NOT_EQUALS,
+                    ],
+                    valueType: "text",
+                    searchable: true,
+                },
             ],
         }
     })

--- a/ui/src/components/filter/configurations/flowExecutionFilter.ts
+++ b/ui/src/components/filter/configurations/flowExecutionFilter.ts
@@ -126,6 +126,17 @@ export const useFlowExecutionFilter = (): ComputedRef<FilterConfiguration> => {
                     valueType: "text",
                     searchable: true,
                 },
+                {
+                    key: "taskId",
+                    label: t("filter.taskId.label"),
+                    description: t("filter.taskId.description"),
+                    comparators: [
+                        Comparators.EQUALS,
+                        Comparators.NOT_EQUALS,
+                    ],
+                    valueType: "text",
+                    searchable: true,
+                },
             ],
         }
     })

--- a/ui/src/components/logs/TaskRunDetails.vue
+++ b/ui/src/components/logs/TaskRunDetails.vue
@@ -240,7 +240,7 @@
                         :to="{
                             name: 'executions/list',
                             query: {
-                                'filters[parentId][EQUALS]': asTaskRun(currentTaskRun).executionId,
+                                'filters[parentId][EQUALS]': followedExecution.id,
                                 'filters[kind][EQUALS]': 'LOOP',
                                 'filters[taskId][EQUALS]': asTaskRun(currentTaskRun).taskId,
                             }
@@ -252,7 +252,7 @@
                     <TaskRunLoopProgress
                         :currentTaskRunId="asTaskRun(currentTaskRun).id"
                         :loopOutputsByTaskRunId="loopOutputsByTaskRunId"
-                        :executionId="asTaskRun(currentTaskRun).executionId"
+                        :executionId="followedExecution.id"
                         :taskId="asTaskRun(currentTaskRun).taskId"
                     />
                 </div>

--- a/ui/src/components/logs/TaskRunLoopProgress.vue
+++ b/ui/src/components/logs/TaskRunLoopProgress.vue
@@ -20,7 +20,7 @@
                         'filters[parentId][EQUALS]': executionId,
                         'filters[kind][EQUALS]': 'LOOP',
                         'filters[taskId][EQUALS]': taskId,
-                        'filters[state][EQUALS]': loopTerminatedSegment.state
+                        'filters[state][IN]': loopTerminatedSegment.state
                     }
                 }"
             >

--- a/ui/tests/unit/components/executions/utils.spec.ts
+++ b/ui/tests/unit/components/executions/utils.spec.ts
@@ -3,7 +3,7 @@ import {keepSupportedFilters, FILTER_FIELD_PATTERN} from "../../../../src/compon
 
 const SUPPORTED = new Set([
     "namespace", "flowId", "kind", "state", "scope", "childFilter",
-    "timeRange", "startDate", "endDate", "labels", "triggerExecutionId", "parentId", "q",
+    "timeRange", "startDate", "endDate", "labels", "triggerExecutionId", "parentId", "taskId", "q",
 ])
 
 describe("keepSupportedFilters", () => {
@@ -85,6 +85,17 @@ describe("keepSupportedFilters", () => {
 
     it("returns an empty object for an empty query", () => {
         expect(keepSupportedFilters({}, SUPPORTED)).toEqual({})
+    })
+
+    it("keeps the Loop iterations deep-link filters (regression: taskId was silently dropped, #18438)", () => {
+        // Given the query built by the Gantt/Logs "iterations" link for a Loop taskrun.
+        const query = {
+            "filters[parentId][EQUALS]": "parent-execution-id",
+            "filters[kind][EQUALS]": "LOOP",
+            "filters[taskId][EQUALS]": "sub-loop",
+        }
+
+        expect(keepSupportedFilters(query, SUPPORTED)).toEqual(query)
     })
 })
 

--- a/ui/tests/unit/components/filter/configurations/executionFilter.spec.ts
+++ b/ui/tests/unit/components/filter/configurations/executionFilter.spec.ts
@@ -1,0 +1,41 @@
+import {describe, it, expect, vi} from "vitest"
+import {defineComponent, h} from "vue"
+import {mount} from "@vue/test-utils"
+import {createI18n} from "vue-i18n"
+
+vi.mock("vue-router", () => ({
+    useRoute: () => ({name: "executions/list", query: {}}),
+}))
+
+import {useExecutionFilter} from "../../../../../src/components/filter/configurations/executionFilter"
+import {useFlowExecutionFilter} from "../../../../../src/components/filter/configurations/flowExecutionFilter"
+
+const i18n = createI18n({legacy: false, locale: "en", missingWarn: false, fallbackWarn: false, messages: {en: {}}})
+
+function setup<T>(useComposable: () => T): T {
+    let api!: T
+    const Comp = defineComponent({
+        setup() {
+            api = useComposable()
+            return () => h("div")
+        },
+    })
+    mount(Comp, {global: {plugins: [i18n]}})
+    return api
+}
+
+// Regression #18438: the Gantt/Logs "iterations" link scopes the executions list with
+// filters[parentId]/[kind]/[taskId], but `taskId` was never declared here, so
+// keepSupportedFilters (ui/src/components/executions/utils.ts) silently dropped it before
+// the search request ever reached the API.
+describe("execution filter configurations declare taskId", () => {
+    it("useExecutionFilter", () => {
+        const config = setup(() => useExecutionFilter())
+        expect(config.value.keys.map((k: {key: string}) => k.key)).toContain("taskId")
+    })
+
+    it("useFlowExecutionFilter", () => {
+        const config = setup(() => useFlowExecutionFilter())
+        expect(config.value.keys.map((k: {key: string}) => k.key)).toContain("taskId")
+    })
+})


### PR DESCRIPTION
## Summary

Fixes #18438: with nested `Loop` tasks, clicking **iterations** on the inner loop's taskrun listed sub-executions from both loop levels instead of just its own.

The Gantt/Logs "iterations" link already builds a scoped query (`filters[parentId]`, `filters[kind]=LOOP`, `filters[taskId]`), and the backend already supports all three filters — but two frontend bugs silently dropped the scoping before the request ever reached the API:

- `ApiTaskRun` has no `executionId` field, so `filters[parentId][EQUALS]` read `undefined` whenever the execution was loaded via the REST payload (only a live, SSE-followed execution happened to carry it, since that path returns the raw `Execution` model). Fixed by using `followedExecution.id` instead, which is always correct — `currentTaskRuns` is derived from that same execution.
- `taskId` was never registered in `executionFilter.ts` / `flowExecutionFilter.ts`, so `keepSupportedFilters` silently stripped `filters[taskId][EQUALS]` before the search request, making the list fall back to every `LOOP` sub-execution under the parent execution — the exact symptom reported (and also affects #17364: two sibling `Loop` tasks at the same level).

Also switched the per-state pill links to `filters[state][IN]` to match the configured comparator (`state` only supports `IN`/`NOT_IN`), so the State filter chip actually renders instead of leaving a phantom empty one.

## Test plan

- [x] `keepSupportedFilters` unit tests pass (12/12), including a new regression case for the loop-iterations deep link
- [x] `oxlint` / `eslint` clean on all touched files
- [ ] Manual verification with the flow from the issue (outer `loop` `[1,2,3]`, inner `sub-loop` `[4,5,6]`): iterations button on each level shows only that level's sub-executions