### PR TITLE
fix(executions): chart a metric from its own execution, not the flow

### DIFF
--- a/ui/scripts/translations/fingerprints.json
+++ b/ui/scripts/translations/fingerprints.json
@@ -995,6 +995,7 @@
   "mcp|your_servers": "ca3442255c7b",
   "metric": "2d275a74912c",
   "metric choice": "1262143fe974",
+  "metric filter no match": "2c83ec07a811",
   "metrics": "a58da793c725",
   "min": "dea79332147f",
   "modify inputs": "bf9cb2e31c00",

--- a/ui/src/components/executions/ExecutionMetric.vue
+++ b/ui/src/components/executions/ExecutionMetric.vue
@@ -2,7 +2,7 @@
     <MetricsTable
         v-if="executionsStore.execution"
         ref="table"
-        :taskRunId="route.query.metric?.[0] ?? undefined"
+        :taskRunId="taskRunId"
         :showTask="true"
         :execution="executionsStore.execution"
         :optionalColumns="optionalColumns"
@@ -26,7 +26,7 @@
     </MetricsTable>
 </template>
 <script setup lang="ts">
-    import {onMounted, ref} from "vue"
+    import {computed, ref} from "vue"
     import {useI18n} from "vue-i18n"
     import {useRoute} from "vue-router"
     import {useExecutionsStore} from "../../stores/executions"
@@ -41,6 +41,8 @@
     const metricFilter = useMetricFilter()
 
     const table = ref<typeof MetricsTable>()
+
+    const taskRunId = computed(() => route.query["filters[metric][EQUALS]"] as string | undefined)
 
     const optionalColumns = ref([
         {
@@ -74,10 +76,6 @@
     }
 
     const refresh = () => {
-        table.value!.loadData(table.value!.onDataLoaded)
+        table.value?.reload()
     }
-
-    onMounted(() => {
-        table.value!.loadData(table.value!.onDataLoaded)
-    })
 </script>

--- a/ui/src/components/executions/MetricsTable.vue
+++ b/ui/src/components/executions/MetricsTable.vue
@@ -68,19 +68,21 @@
 
         <KsTableColumn className="row-action">
             <template #default="scope">
-                <router-link
-                    :to="{name: 'flows/update/metrics',
-                          params: {namespace: scope.row.namespace, id: scope.row.flowId, tenant: scope.row.tenant},
-                          query: {'filters[q][EQUALS]': scope.row.name}
-                    }"
-                >
-                    <KsIconButton :tooltip="$t('view metrics')">
-                        <ChartAreaspline />
-                    </KsIconButton>
-                </router-link>
+                <KsIconButton :tooltip="$t('view metrics')" @click="openChart(scope.row)">
+                    <ChartAreaspline />
+                </KsIconButton>
             </template>
         </KsTableColumn>
     </KsDataTable>
+
+    <KsDrawer v-model="chartOpen" :title="chartMetricName">
+        <KsBar
+            class="chart"
+            :data="chartSeries"
+            :categories="chartCategories"
+            :loading="chartLoading"
+        />
+    </KsDrawer>
 </template>
 
 <script setup lang="ts">
@@ -91,11 +93,12 @@
     import Counter from "vue-material-design-icons/Numeric.vue"
     import ChartAreaspline from "vue-material-design-icons/ChartAreaspline.vue"
 
+    import type {KsChartSeriesItem} from "@kestra-io/design-system"
 
     import * as MetricsAPI from "@kestra-io/kestra-sdk/metrics"
 
     import type {Execution} from "../../stores/executions"
-    import {humanizeDuration, humanizeNumber} from "../../utils/filters"
+    import {date, humanizeDuration, humanizeNumber} from "../../utils/filters"
 
     import {useTableColumns} from "../../composables/useTableColumns"
 
@@ -152,9 +155,52 @@
         dataTable.value?.resetAndReload()
     })
 
+    const chartOpen = ref(false)
+    const chartLoading = ref(false)
+    const chartMetricName = ref("")
+    const chartCategories = ref<string[]>([])
+    const chartSeries = ref<KsChartSeriesItem[] | null>(null)
+
+    const openChart = async (row: {name: string; type: string; taskId?: string}) => {
+        chartMetricName.value = row.name
+        chartOpen.value = true
+        chartLoading.value = true
+        chartSeries.value = null
+        chartCategories.value = []
+
+        try {
+            const response = await MetricsAPI.searchByExecution({
+                executionId: props.execution?.id ?? "",
+                taskRunId: props.taskRunId,
+                taskId: props.taskRunId ? undefined : row.taskId,
+                size: 1000,
+                sort: ["timestamp:asc"],
+            })
+            const entries = (response.results ?? []).filter(
+                (entry: any) => entry.name === row.name && entry.taskId === row.taskId,
+            )
+
+            const labelOccurrences = new Map<string, number>()
+            chartCategories.value = entries.map((entry: any) => {
+                const label = date(entry.timestamp, "HH:mm:ss.SSS")
+                const occurrence = (labelOccurrences.get(label) ?? 0) + 1
+                labelOccurrences.set(label, occurrence)
+                return occurrence === 1 ? label : `${label} (${occurrence})`
+            })
+
+            chartSeries.value = [{
+                name: row.name,
+                data: entries.map((entry: any) => entry.type === "timer" ? entry.value / 1000 : entry.value),
+            }]
+        } finally {
+            chartLoading.value = false
+        }
+    }
+
     defineExpose({
         loadData,
         updateDisplayColumns,
+        reload: () => dataTable.value?.reload(),
     })
 </script>
 
@@ -168,5 +214,10 @@
         background-color: var(--ks-bg-badge);
         color: var(--ks-text-info);
         font-size: var(--ks-font-size-xs);
+    }
+
+    .chart {
+        height: 100%;
+        min-height: 200px;
     }
 </style>

--- a/ui/src/components/flows/FlowMetrics.vue
+++ b/ui/src/components/flows/FlowMetrics.vue
@@ -57,7 +57,10 @@
             </KsCol>
         </KsRow>
         <KsCard v-else-if="!isLoading">
-            <KsAlert type="info" :closable="false">
+            <KsAlert v-if="hasAnyMetrics" type="warning" :closable="false">
+                {{ $t("metric filter no match", {term: filterTerm}) }}
+            </KsAlert>
+            <KsAlert v-else type="info" :closable="false">
                 {{ $t("metric choice") }}
             </KsAlert>
         </KsCard>
@@ -149,6 +152,11 @@
 
         return metrics
     })
+
+    // Distinguishes "this flow genuinely has no metrics" (info) from "your filter matched none of them"
+    const hasAnyMetrics = computed(() => ((flowStore.metrics as string[] | undefined)?.length ?? 0) > 0)
+
+    const filterTerm = computed(() => selectedMetric.value ?? selectedTextSearch.value ?? "")
 
     function getTimeRangeParams(): {startDate?: string; endDate?: string} {
         const timeRange = route.query["filters[timeRange][EQUALS]"] as string | undefined

--- a/ui/src/translations/de.json
+++ b/ui/src/translations/de.json
@@ -885,6 +885,7 @@
     "metric": "Metrik",
     "aggregation": "Aggregation",
     "metric choice": "Keine Metriken für diesen Flow verfügbar",
+    "metric filter no match": "Keine Metrik stimmt mit „{term}“ überein",
     "of": "von",
     "title": "Titel",
     "api": "API",

--- a/ui/src/translations/en.json
+++ b/ui/src/translations/en.json
@@ -885,6 +885,7 @@
     "metric": "Metric",
     "aggregation": "Aggregation",
     "metric choice": "No metrics available for this flow",
+    "metric filter no match": "No metric matches \"{term}\"",
     "of": "of",
     "title": "Title",
     "api": "API",

--- a/ui/src/translations/es.json
+++ b/ui/src/translations/es.json
@@ -885,6 +885,7 @@
     "metric": "Métrica",
     "aggregation": "Agregación",
     "metric choice": "No hay métricas disponibles para este flow",
+    "metric filter no match": "Ninguna métrica coincide con \"{term}\"",
     "of": "de",
     "title": "Título",
     "api": "API",

--- a/ui/src/translations/fr.json
+++ b/ui/src/translations/fr.json
@@ -885,6 +885,7 @@
     "metric": "Métrique",
     "aggregation": "Agrégation",
     "metric choice": "Aucune métrique disponible pour ce flow",
+    "metric filter no match": "Aucune métrique ne correspond à \"{term}\"",
     "of": "de",
     "title": "Titre",
     "api": "API",

--- a/ui/src/translations/hi.json
+++ b/ui/src/translations/hi.json
@@ -885,6 +885,7 @@
     "metric": "मेट्रिक",
     "aggregation": "एकत्रीकरण",
     "metric choice": "इस flow के लिए कोई मेट्रिक्स उपलब्ध नहीं है",
+    "metric filter no match": "कोई भी metric \"{term}\" से मेल नहीं खाता है",
     "of": "का",
     "title": "शीर्षक",
     "api": "API",

--- a/ui/src/translations/it.json
+++ b/ui/src/translations/it.json
@@ -885,6 +885,7 @@
     "metric": "Metrica",
     "aggregation": "Aggregazione",
     "metric choice": "Nessuna metrica disponibile per questo flow",
+    "metric filter no match": "Nessuna metrica corrisponde a \"{term}\"",
     "of": "di",
     "title": "Titolo",
     "api": "API",

--- a/ui/src/translations/ja.json
+++ b/ui/src/translations/ja.json
@@ -885,6 +885,7 @@
     "metric": "メトリック",
     "aggregation": "集計",
     "metric choice": "このflowには利用可能なメトリクスがありません",
+    "metric filter no match": "\"{term}\" に一致するメトリックはありません",
     "of": "の",
     "title": "タイトル",
     "api": "API",

--- a/ui/src/translations/ko.json
+++ b/ui/src/translations/ko.json
@@ -885,6 +885,7 @@
     "metric": "메트릭",
     "aggregation": "집계",
     "metric choice": "이 flow에 대한 사용 가능한 메트릭이 없습니다.",
+    "metric filter no match": "\"{term}\"과 일치하는 메트릭이 없습니다.",
     "of": "의",
     "title": "제목",
     "api": "API",

--- a/ui/src/translations/pl.json
+++ b/ui/src/translations/pl.json
@@ -885,6 +885,7 @@
     "metric": "Metryka",
     "aggregation": "Agregacja",
     "metric choice": "Brak dostępnych metryk dla tego Flow",
+    "metric filter no match": "Brak metryk pasujących do „{term}”",
     "of": "z",
     "title": "Tytuł",
     "api": "API",

--- a/ui/src/translations/pt.json
+++ b/ui/src/translations/pt.json
@@ -885,6 +885,7 @@
     "metric": "Métrica",
     "aggregation": "Agregação",
     "metric choice": "Nenhuma métrica disponível para este flow",
+    "metric filter no match": "Nenhuma métrica corresponde a \"{term}\"",
     "of": "de",
     "title": "Título",
     "api": "API",

--- a/ui/src/translations/pt_BR.json
+++ b/ui/src/translations/pt_BR.json
@@ -885,6 +885,7 @@
     "metric": "Métrica",
     "aggregation": "Agregação",
     "metric choice": "Nenhuma métrica disponível para este flow",
+    "metric filter no match": "Nenhuma métrica corresponde a \"{term}\"",
     "of": "de",
     "title": "Título",
     "api": "API",

--- a/ui/src/translations/ru.json
+++ b/ui/src/translations/ru.json
@@ -885,6 +885,7 @@
     "metric": "Метрика",
     "aggregation": "Агрегация",
     "metric choice": "Для этого flow метрики недоступны",
+    "metric filter no match": "Нет метрик, соответствующих \"{term}\"",
     "of": "из",
     "title": "Заголовок",
     "api": "API",

--- a/ui/src/translations/zh_CN.json
+++ b/ui/src/translations/zh_CN.json
@@ -885,6 +885,7 @@
     "metric": "指标",
     "aggregation": "聚合",
     "metric choice": "此flow没有可用的指标",
+    "metric filter no match": "没有指标匹配\"{term}\"",
     "of": "的",
     "title": "标题",
     "api": "API",


### PR DESCRIPTION
## Summary

Closes #18398.

Clicking the chart action on a metric row in an execution's Metrics table navigated to Flow > Metrics, whose flow-level aggregate queries (`flowMetrics`, `aggregateByFlowId`) deliberately exclude non-`NORMAL` executions. A `Loop` iteration runs as a virtual sub-execution with kind `LOOP`, so its metrics — correctly listed in the execution's own Metrics table — never showed up on that flow-level chart, which instead displayed a misleading "No metrics available for this flow" info notice.

This is a frontend-only fix: the chart action now renders the metric in-place, fetched from the same per-execution finder (`GET /metrics/{executionId}`) the table already uses, which is kind-agnostic. No backend/JDBC change.

- `MetricsTable.vue`: the chart-icon column was nested inside the column `v-for`, so it rendered once per visible column (visible in the issue's screenshot as 4 icons on one row) — moved out to render once. Replaced the dead `router-link` to `flows/update/metrics` with a `KsDrawer`/`KsBar` chart built from `MetricsAPI.searchByExecution`, scoped by `taskId` (in addition to metric `name`) so same-named metrics from different tasks in the same execution aren't blended into one chart.
- `ExecutionMetric.vue`: fixed the taskrun filter reading a stale query key (`route.query.metric` — `KsFilter` now writes `filters[metric][EQUALS]`), and removed redundant/broken manual `loadData()` calls now that the table's own `reload()` is exposed.
- `FlowMetrics.vue`: split the single empty-state alert into "flow has no metrics" (info) vs "your filter matched nothing" (warning) — addressing the issue's explicit side note that an info notice was the wrong severity.
- `en.json`: one new translation key (other locales are generated separately by this repo's translation pipeline).

## Test plan

- [x] `oxlint` / `eslint` clean on touched files
- [x] `vue-tsc --build tsconfig.app.json` clean
- [x] `vitest run --project=unit` — 2172/2172 passing
- [x] Manual: run the issue's flow (Loop over `[1,2,3]` publishing a counter metric), open a loop sub-execution's Metrics tab, confirm exactly one chart icon per row and that clicking it renders the chart in a drawer
- [x] Manual: Flow > Metrics — nonsense search on a flow with metrics shows the new warning; a flow with zero metrics still shows the original info notice