### PR TITLE
fix(executions): trigger expressions built by the Input/Output tab

### DIFF
--- a/ui/packages/design-system/src/components/Data/KsJsonTree.vue
+++ b/ui/packages/design-system/src/components/Data/KsJsonTree.vue
@@ -79,7 +79,7 @@
     }
 
     function isValidVariable(key: string): boolean {
-        return /^[a-zA-Z][a-zA-Z0-9_]*$/.test(key)
+        return /^[a-zA-Z_][a-zA-Z0-9_]*$/.test(key)
     }
 
     function formatStep(key: string): string {

--- a/ui/src/components/executions/outputs/ExecutionVariableExplorer.vue
+++ b/ui/src/components/executions/outputs/ExecutionVariableExplorer.vue
@@ -109,7 +109,7 @@
 
     import ContentCopy from "vue-material-design-icons/ContentCopy.vue"
 
-    import {useExecutionsStore} from "../../../stores/executions"
+    import {useExecutionsStore, type Execution} from "../../../stores/executions"
     import {loadExecutionOutputs} from "../../../composables/useTaskRunOutputs"
     import {useEditorBindings} from "../../../composables/useEditorBindings"
 
@@ -129,7 +129,7 @@
     /* ----------------------------- Pebble paths ----------------------------- */
 
     function isValidVariable(key: string): boolean {
-        return /^[a-zA-Z][a-zA-Z0-9_]*$/.test(key)
+        return /^[a-zA-Z_][a-zA-Z0-9_]*$/.test(key)
     }
 
     function formatStep(key: string): string {
@@ -179,6 +179,12 @@
             preview: preview(value),
             expression: `${prefix}${formatStep(label)}`,
         }))
+    }
+
+    /** Mirrors RunVariables: trigger variables sit at the top level, id and type under `_context`. */
+    function triggerRecord(trigger: Execution["trigger"]): Record<string, unknown> | undefined {
+        if (!trigger) return undefined
+        return {...(trigger.variables ?? {}), _context: {id: trigger.id, type: trigger.type}}
     }
 
     /* ------------------------- Task outputs sourcing ------------------------- */
@@ -327,7 +333,7 @@
         const exec = execution.value
         return [
             {key: "variables", label: t("variables"), items: itemsFromRecord(exec?.variables, "vars")},
-            {key: "triggers", label: t("triggers"), items: itemsFromRecord(exec?.trigger as Record<string, unknown> | undefined, "trigger")},
+            {key: "triggers", label: t("triggers"), items: itemsFromRecord(triggerRecord(exec?.trigger), "trigger")},
             {key: "inputs", label: t("flow_inputs"), items: itemsFromRecord(exec?.inputs, "inputs")},
             {key: "tasksOutputs", label: t("variable_explorer.tasks_outputs"), items: taskItems.value},
             {key: "flowOutputs", label: t("flow_outputs"), items: itemsFromRecord(flowOutputs.value, "outputs")},

--- a/ui/src/components/onboarding/tour/tourScenes.ts
+++ b/ui/src/components/onboarding/tour/tourScenes.ts
@@ -281,7 +281,7 @@ export const TOUR_SCENES: TourScene[] = [
                 await actions.openExecution(
                     executionId,
                     undefined,
-                    {expression: "trigger.body", select: "trigger.variables"},
+                    {expression: "trigger.body", select: "trigger.body"},
                     "outputs",
                 )
             }

--- a/ui/tests/unit/components/executions/ExecutionVariableExplorer.spec.ts
+++ b/ui/tests/unit/components/executions/ExecutionVariableExplorer.spec.ts
@@ -71,7 +71,7 @@ const globalConfig = {
     },
 }
 
-function mountExplorer(variables: Record<string, unknown>) {
+function mountExplorer(variables: Record<string, unknown>, trigger?: {id: string; type: string; variables?: Record<string, unknown>}) {
     const executionsStore = useExecutionsStore()
     executionsStore.execution = {
         id: "execution-id",
@@ -84,6 +84,7 @@ function mountExplorer(variables: Record<string, unknown>) {
             attemptNumber: 1,
         },
         variables,
+        trigger,
         inputs: {},
         taskRunList: [],
         state: {
@@ -100,14 +101,14 @@ function mountExplorer(variables: Record<string, unknown>) {
     return mount(ExecutionVariableExplorer, {global: globalConfig})
 }
 
-async function selectVariable(wrapper: ReturnType<typeof mount>, variableName: string) {
+async function selectVariable(wrapper: ReturnType<typeof mount>, itemName: string, sectionKey = "variables") {
     const sidebar = wrapper.findComponent({name: "SidebarList"})
-    const variableItem = (sidebar.props("sections") as any[])
-        .find((section) => section.key === "variables")
+    const item = (sidebar.props("sections") as any[])
+        .find((section) => section.key === sectionKey)
         .items
-        .find((item: {label: string}) => item.label === variableName)
+        .find((candidate: {label: string}) => candidate.label === itemName)
 
-    await sidebar.vm.$emit("select", variableItem)
+    await sidebar.vm.$emit("select", item)
     await flushPromises()
 }
 
@@ -183,5 +184,34 @@ describe("ExecutionVariableExplorer", () => {
 
         expect(wrapper.findComponent({name: "ExpressionDebugger"}).props("expression"))
             .toBe("{{ vars.bundle.values.a.b }}")
+    })
+
+    test("maps the Triggers section onto the run-context shape, not the raw ExecutionTrigger DTO", async () => {
+        const wrapper = mountExplorer({}, {
+            id: "every_minute",
+            type: "io.kestra.plugin.core.trigger.Schedule",
+            variables: {date: "2026-01-01T00:00:00Z"},
+        })
+        await flushPromises()
+
+        const sidebar = wrapper.findComponent({name: "SidebarList"})
+        const triggerItems = (sidebar.props("sections") as any[])
+            .find((section) => section.key === "triggers")
+            .items as {label: string}[]
+
+        // trigger variables sit at the top level, id/type only under `_context` — mirroring
+        // RunVariables.java, not the DTO's own `id` / `type` / `variables` fields.
+        expect(triggerItems.map((item) => item.label)).toEqual(["date", "_context"])
+
+        await selectVariable(wrapper, "date", "triggers")
+        expect(wrapper.findComponent({name: "ExpressionDebugger"}).props("expression"))
+            .toBe("{{ trigger.date }}")
+
+        // `_context` starts with an underscore — asserts the dot form (`trigger._context`),
+        // not the bracket-subscript fallback (`trigger["_context"]`) that isValidVariable
+        // used to force for any leading-underscore key.
+        await selectVariable(wrapper, "_context", "triggers")
+        expect(wrapper.findComponent({name: "ExpressionDebugger"}).props("expression"))
+            .toBe("{{ trigger._context }}")
     })
 })


### PR DESCRIPTION
### 🔗 Related Issue

Closes https://github.com/kestra-io/kestra-ee/issues/10000.

### ✨ Description

On the Input/Output tab of an execution, the Triggers section listed `id`, `type` and `variables`, and clicking any of them seeded the Expression panel with an expression like `{{ trigger.type }}` that Debug Expression could not resolve.

The panel built these expressions from the raw `ExecutionTrigger` API shape (`id`/`type`/`variables`), but that is not the shape Pebble actually sees at runtime: `RunVariables` puts the trigger's own variables directly under `trigger`, with `id`/`type` nested one level deeper under `trigger._context` (see the code comment on `trigger._context.id`/`trigger._context.type` in `ui/src/assets/docs/basic.md`). Every node in the Triggers tree was therefore one level off, and copying any of them into a flow produced an expression that fails at runtime.

This PR reshapes the Triggers section in `ExecutionVariableExplorer.vue` to mirror `RunVariables` exactly (`{...trigger.variables, _context: {id, type}}`) instead of the DTO, and widens the `isValidVariable` check (duplicated in `KsJsonTree.vue`) to accept a leading underscore, so `_context` renders as `trigger._context` rather than `trigger["_context"]`. A stale onboarding-tour deep link that pointed at the now-removed `trigger.variables` node is updated to point at `trigger.body`, which is the node that actually exists post-fix.

Frontend-only change: `_context` is deliberately a run-context-only addition in `RunVariables.java`, never part of the API payload, so there is no backend change to make.

### 🎨 Frontend Checklist

- [x] Type checking passes (`npm run check:types`)
- [ ] Code builds without errors (`npm run build`)
- [x] Unit tests pass (`npm run test:unit`)
- [ ] Translations are complete if `en.json` changed (`npm run translations:check` reports no missing, extra, or stale keys) — not applicable, no translation keys touched
- [ ] Screenshots or video recordings attached showing the `UI` changes

### 📝 Additional Notes

- `npm run lint` and the Storybook tests for both touched components (`ExecutionVariableExplorer.stories.tsx`, `KsJsonTree.stories.tsx`) also pass locally.
- I did not run a full `npm run build` or capture a screenshot against a live instance in this session — the fix was validated with the Vitest suite (a new test asserts the Triggers section now yields `["date", "_context"]` for a Schedule trigger and that selecting either produces a resolving expression; it fails on the pre-fix code). Recommend a maintainer attach a before/after screenshot from a running instance before merging.
- Reviewed by an independent code-review pass against `RunVariables.java` and Pebble's identifier grammar; no issues found beyond the missing screenshot/coverage gap above, which is now closed in the test suite.

### 🤖 AI Authors

This PR was raised with the help of Claude Code. Why don't scientists trust atoms writing Pebble expressions? Because they make up everything, and apparently so did the old Triggers tree.