### PR TITLE
fix(executions): gantt task name column width

### DIFF
--- a/ui/src/components/executions/Gantt.vue
+++ b/ui/src/components/executions/Gantt.vue
@@ -796,7 +796,7 @@
                 }
 
                 .task-label {
-                    flex: 1;
+                    flex: 1 1 12rem;
                     min-width: 0;
                     display: flex;
                     align-items: center;


### PR DESCRIPTION
closes https://github.com/kestra-io/kestra-ee/issues/10340

This pull request makes a minor update to the Gantt chart layout in the `Gantt.vue` component. The change adjusts the flex property of the `.task-label` class to improve label sizing and layout consistency.

- Updated the `.task-label` class in `Gantt.vue` to use `flex: 1 1 12rem;` instead of `flex: 1;`, allowing the label to have a minimum basis of 12rem for better sizing behavior.