### PR TITLE
docs(tests): correct build-comment's note on what an empty output is for

### DIFF
--- a/ui/scripts/translations/build-comment.mjs
+++ b/ui/scripts/translations/build-comment.mjs
@@ -1,7 +1,8 @@
 #!/usr/bin/env node
 // Turns the JSON reports written by check-translations.mjs (--report) into a
-// single Markdown PR comment body. Prints nothing (exit 0) if both reports
-// are clean, so the workflow can skip posting/updating a comment.
+// single Markdown PR comment body. Prints nothing (exit 0) if both reports are
+// clean, which the workflow hands to comment-update as an empty template so the
+// section a failing run left on the PR is cleared rather than outliving the fix.
 //
 // Usage: node ui-ee/scripts/translations/build-comment.mjs <oss-report.json> <ee-report.json>
 


### PR DESCRIPTION
Companion to kestra-io/kestra-ee#10642 (same branch name).

`build-comment.mjs` prints nothing when both reports are clean, and its header explained that as "so the workflow can skip posting/updating a comment". The EE workflow that consumes it no longer skips: it hands the empty output to `comment-update`, and that is precisely what clears a failure section a previous run left on the PR. Gated on failure, as it was, the block outlived the fix that made the check pass.

Comment only — no behaviour change in this repo, and OSS runs the checker without posting a comment at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HbP9h6LfpnY5f5NgEUmhbn

---
_Generated by [Claude Code](https://claude.ai/code/session_01HbP9h6LfpnY5f5NgEUmhbn)_