### PR TITLE
fix(core): map sort keys before table reload

### DIFF
--- a/ui/AGENTS.md
+++ b/ui/AGENTS.md
@@ -120,6 +120,7 @@ Every async surface must render all four states. "Happy path only" is a bug.
 - Listen to `@page-changed` (or rely on `@update:currentPage`/`@update:pageSize` via v-model) and propagate the change to the bound state — typically a `router.push({...route.query, page: String(page), size: String(size)})`.
 - The component watches `[currentPage, pageSize]` and re-fires `loadData` automatically when either prop changes. Do **not** call `dataTable.reload()` from the parent in response to a page click — the prop change handles it.
 - `resetAndReload()` emits `update:currentPage(1)` and `page-changed`; if the page was already 1 it just reloads. Useful from a filter-change watcher to bounce back to page 1 + re-fetch.
+- When a column's `prop` is not the backend sort key (e.g. `auditLog.detail.resourceType` vs `detail.resourceType`), pass `:sortKeyMapper` (`(key: string) => string`); a sort click reloads immediately with the raw column prop otherwise, and the backend rejects it with a 422.
 
 **URL-driven pattern** — the default for top-level list pages (Logs, Flows, Executions, KV, Secrets, Triggers, FlowsSearch, Blueprints):
 

--- a/ui/packages/design-system/src/components/Data/KsDataTable/KsDataTable.vue
+++ b/ui/packages/design-system/src/components/Data/KsDataTable/KsDataTable.vue
@@ -103,6 +103,7 @@
         noDataDescription?: string
         pageSizeOptions?: number[]
         loadData?: (params: {page: number; size: number; sort?: string}) => void | Promise<void>
+        sortKeyMapper?: (key: string) => string
         selectionMapper?: (element: any) => any
         forceExpandedRowKeys?: string[]
         noPaginationGutter?: boolean
@@ -124,6 +125,7 @@
         noDataDescription: undefined,
         pageSizeOptions: () => [10, 25, 50, 100],
         loadData: undefined,
+        sortKeyMapper: undefined,
         selectionMapper: undefined,
         forceExpandedRowKeys: () => [],
         noPaginationGutter: false,
@@ -410,7 +412,8 @@
 
     const onSortChange = (sort: {column: any; prop: string | null; order: string | null}) => {
         if (sort.prop && sort.order) {
-            internalSort.value = `${sort.prop}:${sort.order === "descending" ? "desc" : "asc"}`
+            const key = props.sortKeyMapper?.(sort.prop) ?? sort.prop
+            internalSort.value = `${key}:${sort.order === "descending" ? "desc" : "asc"}`
         } else {
             internalSort.value = undefined
         }

--- a/ui/packages/design-system/tests/units/Data/KsDataTable.test.ts
+++ b/ui/packages/design-system/tests/units/Data/KsDataTable.test.ts
@@ -427,6 +427,36 @@ describe("KsDataTable", () => {
         expect(lastLoad(loads)).toEqual({page: 3, size: 50, sort: undefined})
     })
 
+    const mountWithSortSpy = (props: Record<string, any>) => {
+        const loads: Load[] = []
+        const wrapper = mount(KsDataTable, {
+            props: {
+                data: SAMPLE_DATA,
+                total: 100,
+                loadData: async (p: Load) => { loads.push(p) },
+                ...props,
+            },
+            global: globalConfig,
+        })
+        return {loads, wrapper}
+    }
+
+    test("passes the raw column prop as sort key to loadData when no sortKeyMapper is set", async () => {
+        const {loads, wrapper} = mountWithSortSpy({})
+        wrapper.findComponent(KsTable).vm.$emit("sortChange", {column: {}, prop: "id", order: "descending"})
+        await tick()
+        expect(lastLoad(loads).sort).toBe("id:desc")
+    })
+
+    test("applies sortKeyMapper to the column prop before calling loadData", async () => {
+        const {loads, wrapper} = mountWithSortSpy({
+            sortKeyMapper: (key: string) => key.replace(/^auditLog\./, ""),
+        })
+        wrapper.findComponent(KsTable).vm.$emit("sortChange", {column: {}, prop: "auditLog.detail.resourceType", order: "ascending"})
+        await tick()
+        expect(lastLoad(loads).sort).toBe("detail.resourceType:asc")
+    })
+
     test("applies ks-data-table-body--fit modifier class when fitHeight is true", () => {
         const wrapper = mount(KsDataTable, {
             props: {data: SAMPLE_DATA, total: 3, fitHeight: true},


### PR DESCRIPTION
Relates to https://github.com/kestra-io/kestra-ee/issues/10212.
EE PR: https://github.com/kestra-io/kestra-ee/pull/10645
