### PR TITLE
fix(ui): playground panel is now resizable

### DIFF
--- a/ui/src/components/MultiPanelGenericEditorView.vue
+++ b/ui/src/components/MultiPanelGenericEditorView.vue
@@ -14,10 +14,10 @@
         </MultiPanelEditorTabs>
         <div class="editor-wrapper">
             <KsSplitter class="default-theme editor-panels" :layout="splitOrientation">
-                <KsSplitterPanel>
+                <KsSplitterPanel min="100">
                     <MultiPanelTabs v-model="panels" @remove-tab="onRemoveTab" />
                 </KsSplitterPanel>
-                <KsSplitterPanel v-if="bottomVisible && slots['bottom-panel']">
+                <KsSplitterPanel v-if="bottomVisible && slots['bottom-panel']" size="30%" min="100">
                     <slot name="bottom-panel" />
                 </KsSplitterPanel>
             </KsSplitter>
@@ -163,11 +163,18 @@
     :deep(.editor-panels){
         position: absolute;
     }
-    :deep(.kel-splitter-bar){
-        width: 2px !important;
-    }
 
     .default-theme{
+        :deep(.kel-splitter__horizontal > .kel-splitter-bar){
+            width: 2px !important;
+        }
+
+        :deep(.kel-splitter__vertical > .kel-splitter-bar){
+            height: 4px !important;
+            width: 100% !important;
+            cursor: ns-resize;
+        }
+
         :deep(.kel-splitter-panel) {
             background-color: var(--ks-bg-surface);
         }


### PR DESCRIPTION
Related to https://github.com/kestra-io/kestra/issues/18475.
Related to https://github.com/kestra-io/kestra/pull/18488.

### Problem

In `MultiPanelGenericEditorView.vue`, the flow editor's `Playground` panel splitter could not be resized. The `:deep(.kel-splitter-bar)` `CSS` rule forced a `2px` width across all split orientations, but the actual divider element for a vertical (top/bottom) split needs to be a thin horizontal bar spanning the full container width, not a narrow vertical sliver - so it collapsed visually and failed to capture drag gestures.

### Fix

Backport of https://github.com/kestra-io/kestra/pull/18488 to `2.0`. Sets an initial `size="30%"` and `min="100"` bound on the bottom `KsSplitterPanel`, and replaces the blanket override with two orientation-scoped rules keyed off the classes `ElSplitter` actually renders (`.kel-splitter__horizontal` / `.kel-splitter__vertical` - confirmed against the rendered `DOM` via the design-system `KsSplitter` Storybook stories, not the `--horizontal`/`--vertical` modifier syntax the original `PR` first tried).

### Evidence

`check:types`, `lint`, and the existing `MultiPanelGenericEditorView.spec.ts` unit test all pass.