### PR TITLE
fix(executions): count a failed loop iteration and drop the NaN% prog…

### DIFF
--- a/core/src/test/java/io/kestra/plugin/core/flow/LoopCaseTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/flow/LoopCaseTest.java
@@ -85,11 +85,14 @@ public class LoopCaseTest {
         assertThat(subExecutions).allMatch(sub -> sub.getTaskRunList().size() == 2);
     }
 
-    public void loopFailed(Execution execution) {
+    public void loopFailed(Execution execution) throws InternalException {
         // Then — first failing iteration terminates the loop immediately with transmitFailed=true (default)
         assertThat(execution.getState().getCurrent()).isEqualTo(State.Type.FAILED);
         assertThat(execution.getTaskRunList()).hasSize(1);
-        assertThat(execution.getTaskRunList().getFirst().getState().getCurrent()).isEqualTo(State.Type.FAILED);
+        TaskRun loopTaskRun = execution.getTaskRunList().getFirst();
+        assertThat(loopTaskRun.getState().getCurrent()).isEqualTo(State.Type.FAILED);
+        assertThat(taskOutputService.getOutputs(loopTaskRun))
+            .containsEntry(Loop.TERMINATED_ITERATIONS_OUTPUT, Map.of("FAILED", 1));
 
         // Only one sub-execution ran before the loop was terminated
         List<Execution> subExecutions = executionRepository.findLoopSubExecutions(execution.getTenantId(), execution.getId(), null);

--- a/executor/src/main/java/io/kestra/executor/ExecutorService.java
+++ b/executor/src/main/java/io/kestra/executor/ExecutorService.java
@@ -764,7 +764,12 @@ public class ExecutorService {
                                     // re-initializing from scratch.
                                     Optional<Execution> failingSubExecution = executionService.findLastFailingLoopSubExecution(executor.getExecution(), taskRun);
                                     if (failingSubExecution.isPresent()) {
-                                        Execution restarted = executionService.restart(failingSubExecution.get(), executor.getFlow(), null);
+                                        Execution subExecution = failingSubExecution.get();
+                                        // The failing iteration's terminal state was recorded in terminatedIterations
+                                        // when the loop terminated; undo it now so the retry's real outcome
+                                        // (recorded once it reaches a new terminal state) isn't double-counted.
+                                        revertLoopIterationTermination(taskRun, subExecution.getState().getCurrent());
+                                        Execution restarted = executionService.restart(subExecution, executor.getFlow(), null);
                                         executor.withLoopExecution(restarted, "restartLoopExecution");
                                         executor.withExecution(
                                             executor.getExecution()
@@ -867,6 +872,29 @@ public class ExecutorService {
         this.addWorkerTaskResults(executor, list);
 
         return executor;
+    }
+
+    /**
+     * Undoes the terminal-state bookkeeping {@link io.kestra.executor.handler.LoopExecutionEventMessageHandler}
+     * recorded for a loop iteration that terminated the loop in error, before that iteration is restarted.
+     * Without this, the retry's own terminal event would be merged on top of the stale one, double-counting
+     * the iteration in {@link Loop#TERMINATED_ITERATIONS_OUTPUT} and corrupting the running-iteration count
+     * used to compute the next iteration index.
+     */
+    private void revertLoopIterationTermination(TaskRun loopTaskRun, State.Type terminatedState) throws InternalException {
+        Map<String, Object> outputs = taskOutputService.getOutputs(loopTaskRun);
+        if (!outputs.containsKey(Loop.RUNNING_ITERATIONS_OUTPUT) || !outputs.containsKey(Loop.TERMINATED_ITERATIONS_OUTPUT)) {
+            return;
+        }
+
+        int runningIterations = (Integer) outputs.get(Loop.RUNNING_ITERATIONS_OUTPUT);
+        @SuppressWarnings("unchecked")
+        Map<String, Integer> terminatedByState = new HashMap<>((Map<String, Integer>) outputs.get(Loop.TERMINATED_ITERATIONS_OUTPUT));
+        terminatedByState.computeIfPresent(terminatedState.name(), (state, count) -> count > 1 ? count - 1 : null);
+
+        outputs.put(Loop.RUNNING_ITERATIONS_OUTPUT, runningIterations + 1);
+        outputs.put(Loop.TERMINATED_ITERATIONS_OUTPUT, terminatedByState);
+        taskOutputService.saveOutputs(loopTaskRun, outputs);
     }
 
     /**

--- a/executor/src/main/java/io/kestra/executor/handler/LoopExecutionEventMessageHandler.java
+++ b/executor/src/main/java/io/kestra/executor/handler/LoopExecutionEventMessageHandler.java
@@ -100,28 +100,29 @@ public class LoopExecutionEventMessageHandler implements ExecutorMessageHandler<
                 TaskRun parentTaskRun = execution.findTaskRunByTaskRunId(message.loopRun().taskRunId());
                 Loop loop = (Loop) executor.getFlow().findTaskByTaskId(message.loopRun().taskId());
 
+                // record this iteration's terminal state before deciding whether to keep looping
+                Map<String, Object> outputs = taskOutputService.getOutputs(parentTaskRun);
+                int iterationCount = (Integer) outputs.get(Loop.ITERATION_COUNT_OUTPUT);
+                int runningIteration = (Integer) outputs.get(Loop.RUNNING_ITERATIONS_OUTPUT) - 1;
+                @SuppressWarnings("unchecked")
+                Map<String, Integer> terminatedByState = outputs.containsKey(Loop.TERMINATED_ITERATIONS_OUTPUT)
+                    ? (Map<String, Integer>) outputs.get(Loop.TERMINATED_ITERATIONS_OUTPUT)
+                    : HashMap.newHashMap(6);
+                terminatedByState.merge(message.state().name(), 1, Integer::sum);
+                int terminatedIteration = terminatedByState.values().stream().mapToInt(Integer::intValue).sum();
+                @SuppressWarnings("unchecked")
+                List<Map<String, Object>> taskOutputs = outputs.containsKey(Loop.OUTPUTS_OUTPUT) ? (List<Map<String, Object>>) outputs.get(Loop.OUTPUTS_OUTPUT) : new ArrayList<>();
+                if (!MapUtils.isEmpty(message.outputs())) {
+                    taskOutputs.add(buildIterationOutput(message));
+                }
+
                 if (loop.getTransmitFailed() && message.state().isTerminatedInError()) {
                     // the failure happened inside an isolated loop sub-execution: log inside the parent exec
+                    computeOutputs(parentTaskRun, taskOutputs, iterationCount, runningIteration, terminatedByState, null);
                     logLoopIterationFailure(parentTaskRun, loop, executor, message);
                     // immediately terminate the loop
                     return terminateLoop(parentTaskRun, loop, executor, message.state());
                 } else {
-                    // increment iteration
-                    Map<String, Object> outputs = taskOutputService.getOutputs(parentTaskRun);
-                    int iterationCount = (Integer) outputs.get(Loop.ITERATION_COUNT_OUTPUT);
-                    int runningIteration = (Integer) outputs.get(Loop.RUNNING_ITERATIONS_OUTPUT) - 1;
-                    @SuppressWarnings("unchecked")
-                    Map<String, Integer> terminatedByState = outputs.containsKey(Loop.TERMINATED_ITERATIONS_OUTPUT)
-                        ? (Map<String, Integer>) outputs.get(Loop.TERMINATED_ITERATIONS_OUTPUT)
-                        : HashMap.newHashMap(6);
-                    terminatedByState.merge(message.state().name(), 1, Integer::sum);
-                    int terminatedIteration = terminatedByState.values().stream().mapToInt(Integer::intValue).sum();
-                    @SuppressWarnings("unchecked")
-                    List<Map<String, Object>> taskOutputs = outputs.containsKey(Loop.OUTPUTS_OUTPUT) ? (List<Map<String, Object>>) outputs.get(Loop.OUTPUTS_OUTPUT) : new ArrayList<>();
-                    if (!MapUtils.isEmpty(message.outputs())) {
-                        taskOutputs.add(buildIterationOutput(message));
-                    }
-
                     // Check the next iteration index
                     int nextIndex = runningIteration + terminatedIteration;
                     if (nextIndex < iterationCount) {

--- a/executor/src/test/java/io/kestra/executor/handler/LoopExecutionEventMessageHandlerTest.java
+++ b/executor/src/test/java/io/kestra/executor/handler/LoopExecutionEventMessageHandlerTest.java
@@ -135,6 +135,13 @@ class LoopExecutionEventMessageHandlerTest {
         String loopTaskRunId = IdUtils.create();
         var loopTaskRun = loopTaskRun(loopTaskRunId, execution);
         executionRepository.save(execution.withTaskRunList(List.of(loopTaskRun)));
+        taskOutputService.saveOutputs(
+            loopTaskRun, Map.of(
+                Loop.ITERATION_COUNT_OUTPUT, 3,
+                Loop.RUNNING_ITERATIONS_OUTPUT, 1,
+                Loop.TERMINATED_ITERATIONS_OUTPUT, Collections.emptyMap()
+            )
+        );
         List<LogEntry> logs = new CopyOnWriteArrayList<>();
         logQueue.addListener(logs::add);
 
@@ -147,6 +154,10 @@ class LoopExecutionEventMessageHandlerTest {
         assertThat(maybeExecutor).isPresent();
         var taskRun = maybeExecutor.get().getExecution().findTaskRunByTaskRunId(loopTaskRunId);
         assertThat(taskRun.getState().getCurrent()).isEqualTo(State.Type.FAILED);
+
+        // the failed iteration is still recorded in the per-state count
+        assertThat(taskOutputService.getOutputs(loopTaskRun))
+            .containsEntry(Loop.TERMINATED_ITERATIONS_OUTPUT, Map.of("FAILED", 1));
 
         // check that a log was created for the parent execution
         List<LogEntry> matchingLog = TestsUtils.awaitLogs(logs, 1);

--- a/ui/src/components/logs/TaskRunLoopProgress.spec.ts
+++ b/ui/src/components/logs/TaskRunLoopProgress.spec.ts
@@ -1,0 +1,60 @@
+import {describe, expect, it, vi} from "vitest"
+import {mount} from "@vue/test-utils"
+import {defineComponent} from "vue"
+import "../../utils/global"
+import TaskRunLoopProgress from "./TaskRunLoopProgress.vue"
+
+vi.mock("@kestra-io/design-system", () => ({
+    State: {color: () => ({SUCCESS: "green", FAILED: "red"})},
+}))
+
+const KsProgressStub = defineComponent({
+    name: "KsProgress",
+    props: {percentage: {type: Number, default: undefined}},
+    template: "<div data-test=\"progress\" :data-percentage=\"percentage\" />",
+})
+
+const KsButtonStub = defineComponent({
+    name: "KsButton",
+    template: "<button data-test=\"pill\"><slot /></button>",
+})
+
+function mountProgress(loopOutputsByTaskRunId: Record<string, any>) {
+    return mount(TaskRunLoopProgress, {
+        props: {
+            executionId: "exec-1",
+            currentTaskRunId: "taskrun-1",
+            taskId: "loop",
+            loopOutputsByTaskRunId,
+        },
+        global: {
+            stubs: {KsProgress: KsProgressStub, KsButton: KsButtonStub},
+        },
+    })
+}
+
+describe("TaskRunLoopProgress", () => {
+    it("should hide the progress bar instead of showing NaN% when outputs are not loaded yet", () => {
+        const wrapper = mountProgress({})
+
+        expect(wrapper.find("[data-test=progress]").exists()).toBe(false)
+        expect(wrapper.text()).not.toContain("NaN")
+    })
+
+    it("should show the failed iteration alongside successes once outputs are loaded", () => {
+        const wrapper = mountProgress({
+            "taskrun-1": {
+                iterationCount: 3,
+                terminatedIterations: {SUCCESS: 1, FAILED: 1},
+            },
+        })
+
+        const progress = wrapper.find("[data-test=progress]")
+        expect(Number(progress.attributes("data-percentage"))).toBeCloseTo(200 / 3)
+
+        const pills = wrapper.findAll("[data-test=pill]")
+        expect(pills).toHaveLength(2)
+        expect(pills[0].text()).toBe("1 Success")
+        expect(pills[1].text()).toBe("1 Failed")
+    })
+})

--- a/ui/src/components/logs/TaskRunLoopProgress.vue
+++ b/ui/src/components/logs/TaskRunLoopProgress.vue
@@ -1,6 +1,7 @@
 <template>
     <div style="flex:1">
         <KsProgress
+            v-if="loopIterationCount > 0"
             :percentage="consolidatedTerminalStates / loopIterationCount * 100"
             :strokeWidth="7"
             :radius="81"


### PR DESCRIPTION
…ress bar

A loop iteration that fails under the default transmitFailed=true was never recorded in the parent taskrun's terminatedIterations output, so the Iterations progress bar showed no failed pill, and it divided by zero whenever iterationCount had not yet loaded, rendering NaN%.

Record the terminal state before terminating the loop, and revert that bookkeeping in ExecutorService right before a failed iteration is restarted so the retry's real outcome isn't double-counted against the iteration-index arithmetic. Guard the progress bar so it only renders once loopIterationCount is known.

Closes https://github.com/kestra-io/kestra/issues/17251.