### PR TITLE
fix(scheduler): include the schedule occurrence at the backfill start date

### DIFF
--- a/core/src/main/java/io/kestra/core/scheduler/model/TriggerState.java
+++ b/core/src/main/java/io/kestra/core/scheduler/model/TriggerState.java
@@ -231,7 +231,9 @@ public final class TriggerState implements TriggerId {
             backfill = backfill
                 .toBuilder()
                 .end(backfill.getEnd() != null ? backfill.getEnd() : ZonedDateTime.now(clock))
-                .currentDate(backfill.getCurrentDate() != null ? backfill.getCurrentDate() : backfill.getStart())
+                // Exclusive nextExecution(start) skips a cron tick that falls on start.
+                // Seed just before start so the first evaluation is at-or-after start.
+                .currentDate(backfill.getCurrentDate() != null ? backfill.getCurrentDate() : backfill.getStart().minusNanos(1))
                 // captured once, on backfill creation: pausing re-enters this method while
                 // nextEvaluationDate points inside the backfill window.
                 .previousNextExecutionDate(backfill.getPreviousNextExecutionDate() != null ? backfill.getPreviousNextExecutionDate() : toZonedDateTime(nextEvaluationDate))

--- a/scheduler/src/test/java/io/kestra/scheduler/TriggerEventHandlerTest.java
+++ b/scheduler/src/test/java/io/kestra/scheduler/TriggerEventHandlerTest.java
@@ -5,6 +5,7 @@ import java.time.DayOfWeek;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
+import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Optional;
@@ -1018,21 +1019,22 @@ class TriggerEventHandlerTest {
         assertThat(updated.get().getBackfill().getStart()).isEqualTo(backfillStart);
         assertThat(updated.get().getBackfill().getEnd()).isEqualTo(backfillEnd);
         assertThat(updated.get().getNextEvaluationDate()).isNotNull();
-        assertThat(updated.get().getNextEvaluationDate()).isAfter(backfillStart.toInstant());
+        assertThat(updated.get().getNextEvaluationDate()).isAfterOrEqualTo(backfillStart.toInstant());
         assertThat(updated.get().getLastEventId()).isEqualTo(event.eventId());
     }
 
     @Test
     void shouldClearBackfillWhenBackfillRangeIsAlreadyComplete() {
-        // GIVEN
+        // GIVEN: start == end between cron ticks, so the next tick is after end
+        Clock clock = Clock.fixed(Instant.parse("2024-06-15T10:07:00Z"), ZoneOffset.UTC);
+        SchedulerClock.setClock(clock);
         triggerStateStore.save(triggerState);
-        handler = newTriggerEventHandler(List.of(Fixtures.defaultFlow()));
-        // Backfill with start == end == now: the next cron tick is after end, so backfill completes immediately
-        ZonedDateTime now = ZonedDateTime.now(CLOCK);
+        handler = newTriggerEventHandler(List.of(Fixtures.defaultFlow(b -> b.timezone("UTC").build())));
+        ZonedDateTime now = ZonedDateTime.now(clock);
         CreateBackfillTrigger event = new CreateBackfillTrigger(triggerId, new CreateBackfillTrigger.Backfill(now, now, null, null));
 
         // WHEN
-        handler.handle(CLOCK, TEST_VNODE, event);
+        handler.handle(clock, TEST_VNODE, event);
 
         // THEN
         Optional<TriggerState> updated = triggerStateStore.findById(triggerId);

--- a/scheduler/src/test/java/io/kestra/scheduler/TriggerEventHandlerTest.java
+++ b/scheduler/src/test/java/io/kestra/scheduler/TriggerEventHandlerTest.java
@@ -1024,6 +1024,69 @@ class TriggerEventHandlerTest {
     }
 
     @Test
+    void shouldIncludeStartOccurrenceWhenBackfillCreatedOnACronTick() {
+        // GIVEN: every-minute cron, backfill start is itself a cron occurrence
+        Clock clock = Clock.fixed(Instant.parse("2024-06-15T12:00:00Z"), ZoneOffset.UTC);
+        SchedulerClock.setClock(clock);
+        triggerStateStore.save(triggerState);
+        handler = newTriggerEventHandler(List.of(Fixtures.defaultFlow(b -> b.cron("* * * * *").timezone("UTC").build())));
+        ZonedDateTime start = ZonedDateTime.parse("2024-06-15T12:00:00Z");
+        ZonedDateTime end = ZonedDateTime.parse("2024-06-15T12:05:00Z");
+        CreateBackfillTrigger event = new CreateBackfillTrigger(triggerId, new CreateBackfillTrigger.Backfill(start, end, null, null));
+
+        // WHEN
+        handler.handle(clock, TEST_VNODE, event);
+
+        // THEN: first evaluation is AT start, not the next minute
+        Optional<TriggerState> updated = triggerStateStore.findById(triggerId);
+        assertThat(updated).isPresent();
+        assertThat(updated.get().getBackfill()).isNotNull();
+        assertThat(updated.get().getNextEvaluationDate()).isEqualTo(start.toInstant());
+        assertThat(updated.get().getBackfill().getCurrentDate()).isEqualTo(start);
+    }
+
+    @Test
+    void shouldSkipToNextOccurrenceWhenBackfillStartIsNotACronTick() {
+        // GIVEN: start sits between minute ticks
+        Clock clock = Clock.fixed(Instant.parse("2024-06-15T12:00:30Z"), ZoneOffset.UTC);
+        SchedulerClock.setClock(clock);
+        triggerStateStore.save(triggerState);
+        handler = newTriggerEventHandler(List.of(Fixtures.defaultFlow(b -> b.cron("* * * * *").timezone("UTC").build())));
+        ZonedDateTime start = ZonedDateTime.parse("2024-06-15T12:00:30Z");
+        ZonedDateTime end = ZonedDateTime.parse("2024-06-15T12:05:00Z");
+        CreateBackfillTrigger event = new CreateBackfillTrigger(triggerId, new CreateBackfillTrigger.Backfill(start, end, null, null));
+
+        // WHEN
+        handler.handle(clock, TEST_VNODE, event);
+
+        // THEN: 12:00 is before start, so first evaluation is 12:01
+        Optional<TriggerState> updated = triggerStateStore.findById(triggerId);
+        assertThat(updated).isPresent();
+        assertThat(updated.get().getBackfill()).isNotNull();
+        assertThat(updated.get().getNextEvaluationDate()).isEqualTo(Instant.parse("2024-06-15T12:01:00Z"));
+    }
+
+    @Test
+    void shouldKeepBackfillWhenStartEqualsEndOnACronTick() {
+        // GIVEN: a single-tick range [12:00, 12:00]
+        Clock clock = Clock.fixed(Instant.parse("2024-06-15T12:00:00Z"), ZoneOffset.UTC);
+        SchedulerClock.setClock(clock);
+        triggerStateStore.save(triggerState);
+        handler = newTriggerEventHandler(List.of(Fixtures.defaultFlow(b -> b.cron("* * * * *").timezone("UTC").build())));
+        ZonedDateTime startAndEnd = ZonedDateTime.parse("2024-06-15T12:00:00Z");
+        CreateBackfillTrigger event = new CreateBackfillTrigger(triggerId, new CreateBackfillTrigger.Backfill(startAndEnd, startAndEnd, null, null));
+
+        // WHEN
+        handler.handle(clock, TEST_VNODE, event);
+
+        // THEN: the occurrence at start/end is scheduled, backfill is not cleared
+        Optional<TriggerState> updated = triggerStateStore.findById(triggerId);
+        assertThat(updated).isPresent();
+        assertThat(updated.get().getBackfill()).isNotNull();
+        assertThat(updated.get().getNextEvaluationDate()).isEqualTo(startAndEnd.toInstant());
+    }
+
+    @Test
     void shouldClearBackfillWhenBackfillRangeIsAlreadyComplete() {
         // GIVEN: start == end between cron ticks, so the next tick is after end
         Clock clock = Clock.fixed(Instant.parse("2024-06-15T10:07:00Z"), ZoneOffset.UTC);

--- a/scheduler/src/test/java/io/kestra/scheduler/TriggerSchedulerTest.java
+++ b/scheduler/src/test/java/io/kestra/scheduler/TriggerSchedulerTest.java
@@ -736,7 +736,7 @@ class TriggerSchedulerTest {
         triggerStateStore.save(
             triggerState
                 .updateForNextEvaluationDate(SchedulerClock.getClock(), backfillStart)
-                .backfill(SchedulerClock.getClock(), Backfill.builder().start(backfillStart).paused(true).build())
+                .backfill(SchedulerClock.getClock(), Backfill.builder().start(backfillStart).currentDate(backfillStart).paused(true).build())
         );
         // endregion [GIVEN]
 

--- a/scheduler/src/test/java/io/kestra/scheduler/TriggerSchedulerTest.java
+++ b/scheduler/src/test/java/io/kestra/scheduler/TriggerSchedulerTest.java
@@ -662,7 +662,7 @@ class TriggerSchedulerTest {
             triggerState
                 .locked(SchedulerClock.getClock(), false)
                 .updateForNextEvaluationDate(SchedulerClock.getClock(), backfillStart)
-                .backfill(SchedulerClock.getClock(), Backfill.builder().start(backfillStart).build())
+                .backfill(SchedulerClock.getClock(), Backfill.builder().start(backfillStart).currentDate(backfillStart).build())
         );
 
         // Simulate multiple 'onSchedule'

--- a/scheduler/src/test/java/io/kestra/scheduler/TriggerSchedulerTest.java
+++ b/scheduler/src/test/java/io/kestra/scheduler/TriggerSchedulerTest.java
@@ -5,6 +5,7 @@ import java.time.DayOfWeek;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.ZoneId;
+import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Map;
@@ -33,6 +34,7 @@ import io.kestra.core.scheduler.model.TriggerType;
 import io.kestra.core.services.ConditionService;
 import io.kestra.core.services.FlowParsingService;
 import io.kestra.scheduler.internals.DefaultSchedulableTriggerFetcher;
+import io.kestra.scheduler.internals.NextEvaluationDate;
 import io.kestra.scheduler.internals.SchedulableEvaluator;
 import io.kestra.scheduler.pubsub.TriggerWorkerJobPublisher;
 import io.kestra.scheduler.utils.CollectorTriggerExecutionPublisher;
@@ -749,6 +751,37 @@ class TriggerSchedulerTest {
         assertThat(triggerExecutionPublisher.executions().size()).isEqualTo(0);
         TriggerState state = triggerStateStore.findById(Fixtures.triggerId()).orElseThrow();
         assertThat(state.getBackfill().getCurrentDate()).isEqualTo(backfillStart);
+    }
+
+    @Test
+    void shouldCreateExecutionAtBackfillStartWhenStartIsACronTick() {
+        // GIVEN: same create order as TriggerEventHandler.onCreateBackfill (seed, then nextEvaluationDate)
+        Clock clock = Clock.fixed(Instant.parse("2024-06-15T13:00:00Z"), ZoneOffset.UTC);
+        SchedulerClock.setClock(clock);
+        FlowWithSource flow = Fixtures.defaultFlow(b -> b.cron("* * * * *").timezone("UTC").build());
+        TriggerScheduler scheduler = newTriggerScheduler(List.of(flow));
+        scheduler.onStart(clock, clock.instant(), NODES_ASSIGNMENTS);
+
+        ZonedDateTime start = ZonedDateTime.parse("2024-06-15T12:00:00Z");
+        ZonedDateTime end = ZonedDateTime.parse("2024-06-15T12:05:00Z");
+        TriggerState state = triggerStateStore.findById(Fixtures.triggerId()).orElseThrow()
+            .locked(clock, false)
+            .backfill(clock, Backfill.builder().start(start).end(end).build());
+        ConditionContext conditionContext = conditionService.conditionContext(
+            runContextFactory.of(flow, flow.getTriggers().getFirst()), flow, null);
+        ZonedDateTime next = NextEvaluationDate.get(
+            clock, flow.getTriggers().getFirst(), state.context(), conditionContext);
+        triggerStateStore.save(state.updateForNextEvaluationDate(clock, next));
+
+        // WHEN
+        scheduler.onSchedule(clock, clock.instant(), NODES_ASSIGNMENTS);
+
+        // THEN: the first backfilled execution is the start tick, not start+1 minute
+        assertThat(triggerExecutionPublisher.executions().size()).isEqualTo(1);
+        PublishedExecution execution = triggerExecutionPublisher.executions().getFirst();
+        assertThat(execution.evaluation().trigger()).isNotNull();
+        assertThat(ZonedDateTime.parse((String) execution.evaluation().trigger().getVariables().get("date")).toInstant())
+            .isEqualTo(start.toInstant());
     }
 
     @Test


### PR DESCRIPTION
## Summary

A backfill on a `Schedule` trigger treated the range as `(start, end]`: the occurrence at the end date ran, the one at the start date did not.

A backfill from `01:00` to `01:05` on `* * * * *` now creates executions for `01:00` through `01:05`.

Fixes #18504

## Root cause

Creating a backfill set `currentDate = start`, then computed the first evaluation with exclusive `nextExecution(start)`. That jumps to the next cron tick, so `01:00` was skipped.

End was already inclusive (`isAfter(end)`). Only start was exclusive.

`eval()` was already inclusive. Making `nextEvaluationDate()` inclusive in general would re-fire the same tick.

## Change

In `TriggerState.backfill()`, when `currentDate` is unset, seed the cursor at `start.minusNanos(1)` instead of `start`.

The existing exclusive `nextExecution()` then lands on start if start is a cron tick. After that, `currentDate` is advanced to that first tick and later steps stay exclusive.

`currentDate` is left alone when it is already set (pause/resume, in-progress backfill).

## Tests

- Create path: start on a tick, start between ticks, start == end on a tick
- Empty range (`start == end` between ticks) still completes immediately (fixed clock)
- Scheduler loop: first execution `trigger.date` is the start tick
- Existing tests that assumed exclusive start were updated

## How to verify

1. Flow with `cron: "* * * * *"`
2. Backfill `01:00:00` → `01:05:00` (past window)
3. `trigger.date` values: `01:00`, `01:01`, `01:02`, `01:03`, `01:04`, `01:05`