### PR TITLE
fix(namespaces): parent folders not created when a folder name contains a slash

### DIFF
--- a/core/src/main/java/io/kestra/core/storages/InternalNamespace.java
+++ b/core/src/main/java/io/kestra/core/storages/InternalNamespace.java
@@ -509,7 +509,7 @@ public class InternalNamespace implements Namespace {
             (maybeParentPath = Optional.ofNullable(NamespaceFileMetadata.parentPath(maybeParentPath.map(Path::toString).orElse(path))).map(Path::of)).isPresent()
                 && !this.exists(maybeParentPath.get())
         ) {
-            this.createDirectory(maybeParentPath.get());
+            this.createSingleDirectory(maybeParentPath.get());
             createdDirs.add(NamespaceFile.of(namespace, maybeParentPath.get().toString().endsWith("/") ? maybeParentPath.get().toString() : maybeParentPath.get() + "/", 1));
         }
 
@@ -523,6 +523,12 @@ public class InternalNamespace implements Namespace {
     public NamespaceFile createDirectory(Path path) throws IOException {
         final Path normalizedPath = NamespaceFile.normalize(path);
 
+        mkDirs(normalizedPath.toString());
+
+        return createSingleDirectory(normalizedPath);
+    }
+
+    private NamespaceFile createSingleDirectory(Path normalizedPath) throws IOException {
         discardConflictingEntry(findByPath(normalizedPath, true), true, normalizedPath);
 
         NamespaceFileMetadata nsFileMetadata = namespaceFileMetadataRepository.save(

--- a/core/src/main/java/io/kestra/core/storages/Namespace.java
+++ b/core/src/main/java/io/kestra/core/storages/Namespace.java
@@ -142,10 +142,10 @@ public interface Namespace {
     }
 
     /**
-     * Creates a new directory for the current namespace.
+     * Creates a new directory for the current namespace, along with any missing parent directory.
      *
      * @param path The {@link Path} of the directory.
-     * @return The created namespace file.
+     * @return The created namespace file of the deepest directory.
      * @throws IOException if an error happens while accessing the file.
      */
     NamespaceFile createDirectory(Path path) throws IOException;

--- a/core/src/test/java/io/kestra/core/storages/InternalNamespaceTest.java
+++ b/core/src/test/java/io/kestra/core/storages/InternalNamespaceTest.java
@@ -296,6 +296,22 @@ class InternalNamespaceTest {
     }
 
     @Test
+    void shouldCreateMissingParentDirectoriesWhenCreatingANestedDirectory() throws IOException {
+        // Given
+        final String namespaceId = TestsUtils.randomNamespace();
+        final InternalNamespace namespace = new InternalNamespace(log, MAIN_TENANT, namespaceId, storageInterface, namespaceFileMetadataRepository);
+
+        // When
+        NamespaceFile directory = namespace.createDirectory(Path.of("parent/child"));
+
+        // Then the parent is listed at the root, so the new directory is reachable instead of being
+        // orphaned under an ancestor that was never created.
+        assertThat(directory.path()).isEqualTo("parent/child/");
+        assertThat(namespace.children("/", false).stream().map(NamespaceFileMetadata::getPath)).containsExactly("/parent/");
+        assertThat(namespace.children("/parent/", false).stream().map(NamespaceFileMetadata::getPath)).containsExactly("/parent/child/");
+    }
+
+    @Test
     void shouldServeLatestAvailableRevisionWhenLatestRevisionObjectIsMissing() throws IOException, URISyntaxException {
         // Given a file with two revisions whose latest-revision object has been removed from storage
         // out-of-band, leaving the metadata index ahead of storage (the drift that produced 404s).


### PR DESCRIPTION
Closes https://github.com/kestra-io/kestra-ee/issues/6553.

Backport of https://github.com/kestra-io/kestra/pull/18875 to `releases/v1.3.x`. Not a clean cherry-pick: on this branch `createDirectory` has no `ensureNoFileInHierarchy` call and the metadata goes through `namespaceFileMetadataRepository` rather than the state store, so the same restructure was applied by hand.

### ✨ Description

Creating a folder named `a/a` from the namespace files editor left a hidden entry behind. `POST /namespaces/{ns}/files/directory?path=/a/a` persisted only `/a/a/`, without the `/a/` entry above it, so the root listing had nothing to show and the folder was gone after a refresh - while still occupying the path in the index. Creating `a` afterwards then made a phantom `a` child appear underneath it.

`Namespace.createDirectory` now creates the missing parent directories, the way `putFile` already does for the ancestors of a new file (`mkDirs`), so a slash in a folder name creates the whole chain like it does in an editor. Nothing changed in the `UI`: the file tree already splits the name on `/` and posts the nested path.

### 🛠️ Backend Checklist

- [x] Code compiles and tests pass for the touched modules (`./gradlew :core:test --tests "InternalNamespaceTest"`, `./gradlew :webserver:test --tests "NamespaceFileControllerTest"`)
- [x] New behavior is covered by unit or integration tests

### 📝 Additional Notes

`releases/v1.0.x` needs no backport: there `createDirectory` delegates straight to `storage.createDirectory`, whose local implementation is `File.mkdirs()`, and the listing comes from the filesystem - so the parents were always created.

No screenshots: the change is backend-only and the `UI` is untouched. The `develop` `PR` carries the before/after `API` responses captured on a running instance, and was verified by the issue reporter.

Why did the folder need a parent? Because without one it had no place to call home. 🐱
