### PR TITLE
fix(design-system): match Monaco sticky scroll background to the editor

### DIFF
--- a/ui/packages/design-system/src/components/Form/KsEditor.vue
+++ b/ui/packages/design-system/src/components/Form/KsEditor.vue
@@ -313,6 +313,8 @@
             --vscode-editor-background: var(--ks-bg-input);
             --vscode-breadcrumb-background: var(--ks-bg-input);
             --vscode-editorGutter-background: var(--ks-bg-input);
+            --vscode-editorStickyScrollGutter-background: var(--ks-bg-input);
+            --vscode-editorStickyScroll-background: var(--ks-bg-input);
         }
 
         .monaco-editor .margin {


### PR DESCRIPTION
Fixing Issue: With Monaco's sticky scroll on, the pinned parent lines at the top of the flow editor (inputs:, tasks:, etc.) rendered as a mismatched dark band, because Monaco's editorStickyScroll.background and editorStickyScrollGutter.background colors still came from the stock vs-dark theme instead of Kestra's editor background.


**Before**

<img width="2626" height="500" alt="image" src="https://github.com/user-attachments/assets/0d2a0d2f-b2f2-42f5-82c1-b311514d7659" />


After

<img width="2626" height="500" alt="image" src="https://github.com/user-attachments/assets/e4b8ee5a-afc2-4b21-bbca-37b3eb65cd08" />
