### PR TITLE
refactor(core): add a @TenantId constraint for the tenant-id format

### DIFF
--- a/core/src/main/java/io/kestra/core/mcp/models/McpServer.java
+++ b/core/src/main/java/io/kestra/core/mcp/models/McpServer.java
@@ -12,6 +12,7 @@ import io.kestra.core.models.SoftDeletable;
 import io.kestra.core.queues.event.BroadcastEvent;
 import io.kestra.core.utils.Enums;
 import io.kestra.core.utils.IdUtils;
+import io.kestra.core.validations.TenantId;
 
 import io.swagger.v3.oas.annotations.Hidden;
 import jakarta.validation.constraints.NotBlank;
@@ -23,7 +24,7 @@ import jakarta.validation.constraints.Pattern;
  */
 public record McpServer(
     @Hidden
-    @Pattern(regexp = "^[a-z0-9][a-z0-9_-]*") String tenantId,
+    @TenantId String tenantId,
 
     @NotNull
     @NotBlank

--- a/core/src/main/java/io/kestra/core/models/assets/Asset.java
+++ b/core/src/main/java/io/kestra/core/models/assets/Asset.java
@@ -12,6 +12,7 @@ import io.kestra.core.models.Plugin;
 import io.kestra.core.models.SoftDeletable;
 import io.kestra.core.utils.IdUtils;
 import io.kestra.core.utils.MapUtils;
+import io.kestra.core.validations.TenantId;
 
 import io.swagger.v3.oas.annotations.Hidden;
 import jakarta.annotation.Nullable;
@@ -25,7 +26,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public abstract class Asset implements HasUID, SoftDeletable<Asset>, Plugin {
     @Hidden
-    @Pattern(regexp = "^[a-z0-9][a-z0-9_-]*")
+    @TenantId
     protected String tenantId;
 
     @Pattern(regexp = "^[a-z0-9][a-z0-9._-]*")

--- a/core/src/main/java/io/kestra/core/models/dashboards/Dashboard.java
+++ b/core/src/main/java/io/kestra/core/models/dashboards/Dashboard.java
@@ -14,12 +14,12 @@ import io.kestra.core.models.SoftDeletable;
 import io.kestra.core.models.dashboards.charts.Chart;
 import io.kestra.core.serializers.YamlParser;
 import io.kestra.core.utils.IdUtils;
+import io.kestra.core.validations.TenantId;
 
 import io.swagger.v3.oas.annotations.Hidden;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Pattern;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -36,7 +36,7 @@ public class Dashboard implements HasUID, SoftDeletable<Dashboard> {
     private static final String DEFAULT_MAIN_DEFINITION_RESOURCE = "dashboards/default_main_definition.yaml";
 
     @Hidden
-    @Pattern(regexp = "^[a-z0-9][a-z0-9_-]*")
+    @TenantId
     private String tenantId;
 
     @NotNull

--- a/core/src/main/java/io/kestra/core/models/executions/Execution.java
+++ b/core/src/main/java/io/kestra/core/models/executions/Execution.java
@@ -32,6 +32,7 @@ import io.kestra.core.services.LabelService;
 import io.kestra.core.test.flow.TaskFixture;
 import io.kestra.core.utils.IdUtils;
 import io.kestra.core.utils.ListUtils;
+import io.kestra.core.validations.TenantId;
 
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.classic.spi.LoggingEvent;
@@ -40,7 +41,6 @@ import io.swagger.v3.oas.annotations.Hidden;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.annotation.Nullable;
 import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Pattern;
 import lombok.*;
 import lombok.experimental.FieldDefaults;
 import lombok.experimental.NonFinal;
@@ -64,7 +64,7 @@ public class Execution implements SoftDeletable<Execution>, TenantInterface, Has
     @NotNull
     @With
     @Hidden
-    @Pattern(regexp = "^[a-z0-9][a-z0-9_-]*")
+    @TenantId
     String tenantId;
 
     @NotNull

--- a/core/src/main/java/io/kestra/core/models/executions/LogEntry.java
+++ b/core/src/main/java/io/kestra/core/models/executions/LogEntry.java
@@ -16,13 +16,13 @@ import io.kestra.core.models.triggers.AbstractTrigger;
 import io.kestra.core.models.triggers.TriggerId;
 import io.kestra.core.queues.event.DispatchEvent;
 import io.kestra.core.utils.IdUtils;
+import io.kestra.core.validations.TenantId;
 
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.SpanContext;
 import io.swagger.v3.oas.annotations.Hidden;
 import jakarta.annotation.Nullable;
 import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Pattern;
 import lombok.Builder;
 import lombok.Value;
 
@@ -30,7 +30,7 @@ import lombok.Value;
 @Builder(toBuilder = true)
 public class LogEntry implements TenantInterface, DispatchEvent {
     @Hidden
-    @Pattern(regexp = "^[a-z0-9][a-z0-9_-]*")
+    @TenantId
     String tenantId;
 
     @NotNull

--- a/core/src/main/java/io/kestra/core/models/executions/MetricEntry.java
+++ b/core/src/main/java/io/kestra/core/models/executions/MetricEntry.java
@@ -11,11 +11,11 @@ import io.kestra.core.models.executions.metrics.Gauge;
 import io.kestra.core.models.executions.metrics.Timer;
 import io.kestra.core.queues.event.DispatchEvent;
 import io.kestra.core.utils.IdUtils;
+import io.kestra.core.validations.TenantId;
 
 import io.swagger.v3.oas.annotations.Hidden;
 import jakarta.annotation.Nullable;
 import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Pattern;
 import lombok.Builder;
 import lombok.Value;
 
@@ -23,7 +23,7 @@ import lombok.Value;
 @Builder(toBuilder = true)
 public class MetricEntry implements TenantInterface, DispatchEvent {
     @Hidden
-    @Pattern(regexp = "^[a-z0-9][a-z0-9_-]*")
+    @TenantId
     String tenantId;
 
     @NotNull

--- a/core/src/main/java/io/kestra/core/models/executions/TaskRun.java
+++ b/core/src/main/java/io/kestra/core/models/executions/TaskRun.java
@@ -14,12 +14,12 @@ import io.kestra.core.models.flows.State;
 import io.kestra.core.models.tasks.ResolvedTask;
 import io.kestra.core.models.tasks.retrys.AbstractRetry;
 import io.kestra.core.utils.IdUtils;
+import io.kestra.core.validations.TenantId;
 
 import io.swagger.v3.oas.annotations.Hidden;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.annotation.Nullable;
 import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Pattern;
 import lombok.*;
 
 @ToString
@@ -30,7 +30,7 @@ import lombok.*;
 public class TaskRun implements TenantInterface {
     @NotNull
     @Hidden
-    @Pattern(regexp = "^[a-z0-9][a-z0-9_-]*")
+    @TenantId
     String tenantId;
 
     @NotNull

--- a/core/src/main/java/io/kestra/core/models/flows/AbstractFlow.java
+++ b/core/src/main/java/io/kestra/core/models/flows/AbstractFlow.java
@@ -11,6 +11,7 @@ import io.kestra.core.models.Label;
 import io.kestra.core.models.tasks.WorkerSelector;
 import io.kestra.core.serializers.ListOrMapOfLabelDeserializer;
 import io.kestra.core.serializers.ListOrMapOfLabelSerializer;
+import io.kestra.core.validations.TenantId;
 
 import io.swagger.v3.oas.annotations.Hidden;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -72,7 +73,7 @@ public abstract class AbstractFlow implements FlowInterface {
     boolean draft = false;
 
     @Hidden
-    @Pattern(regexp = "^[a-z0-9][a-z0-9_-]*")
+    @TenantId
     String tenantId;
 
     @JsonSerialize(using = ListOrMapOfLabelSerializer.class)

--- a/core/src/main/java/io/kestra/core/models/kv/PersistedKvMetadata.java
+++ b/core/src/main/java/io/kestra/core/models/kv/PersistedKvMetadata.java
@@ -10,11 +10,11 @@ import io.kestra.core.models.SoftDeletable;
 import io.kestra.core.models.TenantInterface;
 import io.kestra.core.storages.kv.KVEntry;
 import io.kestra.core.utils.IdUtils;
+import io.kestra.core.validations.TenantId;
 
 import io.swagger.v3.oas.annotations.Hidden;
 import jakarta.annotation.Nullable;
 import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Pattern;
 import lombok.*;
 import lombok.experimental.FieldDefaults;
 import lombok.extern.slf4j.Slf4j;
@@ -28,7 +28,7 @@ import lombok.extern.slf4j.Slf4j;
 public class PersistedKvMetadata implements SoftDeletable<PersistedKvMetadata>, TenantInterface, HasUID {
     @With
     @Hidden
-    @Pattern(regexp = "^[a-z0-9][a-z0-9_-]*")
+    @TenantId
     private String tenantId;
 
     @NotNull

--- a/core/src/main/java/io/kestra/core/models/namespaces/files/NamespaceFileMetadata.java
+++ b/core/src/main/java/io/kestra/core/models/namespaces/files/NamespaceFileMetadata.java
@@ -12,11 +12,11 @@ import io.kestra.core.models.TenantInterface;
 import io.kestra.core.storages.FileAttributes;
 import io.kestra.core.storages.NamespaceFile;
 import io.kestra.core.utils.IdUtils;
+import io.kestra.core.validations.TenantId;
 
 import io.swagger.v3.oas.annotations.Hidden;
 import jakarta.annotation.Nullable;
 import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Pattern;
 import lombok.*;
 import lombok.experimental.FieldDefaults;
 import lombok.extern.slf4j.Slf4j;
@@ -30,7 +30,7 @@ import lombok.extern.slf4j.Slf4j;
 public class NamespaceFileMetadata implements SoftDeletable<NamespaceFileMetadata>, TenantInterface, HasUID {
     @With
     @Hidden
-    @Pattern(regexp = "^[a-z0-9][a-z0-9_-]*")
+    @TenantId
     private String tenantId;
 
     @NotNull

--- a/core/src/main/java/io/kestra/core/models/topologies/FlowNode.java
+++ b/core/src/main/java/io/kestra/core/models/topologies/FlowNode.java
@@ -4,10 +4,10 @@ import java.util.Objects;
 
 import io.kestra.core.models.TenantInterface;
 import io.kestra.core.models.flows.FlowInterface;
+import io.kestra.core.validations.TenantId;
 
 import io.swagger.v3.oas.annotations.Hidden;
 import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Pattern;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.experimental.SuperBuilder;
@@ -20,7 +20,7 @@ public class FlowNode implements TenantInterface {
     String uid;
 
     @Hidden
-    @Pattern(regexp = "^[a-z0-9][a-z0-9_-]*")
+    @TenantId
     String tenantId;
 
     String namespace;

--- a/core/src/main/java/io/kestra/core/models/triggers/TriggerContext.java
+++ b/core/src/main/java/io/kestra/core/models/triggers/TriggerContext.java
@@ -5,11 +5,11 @@ import java.util.List;
 
 import io.kestra.core.models.flows.State;
 import io.kestra.core.runners.WorkerTrigger;
+import io.kestra.core.validations.TenantId;
 
 import io.micronaut.core.annotation.Nullable;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Pattern;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -22,7 +22,7 @@ import lombok.experimental.SuperBuilder;
 @NoArgsConstructor
 public class TriggerContext implements TriggerId {
     @Setter
-    @Pattern(regexp = "^[a-z0-9][a-z0-9_-]")
+    @TenantId
     private String tenantId;
 
     @NotNull

--- a/core/src/main/java/io/kestra/core/test/TestSuite.java
+++ b/core/src/main/java/io/kestra/core/test/TestSuite.java
@@ -10,6 +10,7 @@ import io.kestra.core.models.SoftDeletable;
 import io.kestra.core.models.TenantInterface;
 import io.kestra.core.test.flow.UnitTest;
 import io.kestra.core.utils.IdUtils;
+import io.kestra.core.validations.TenantId;
 import io.kestra.core.validations.TestSuiteValidation;
 
 import io.swagger.v3.oas.annotations.Hidden;
@@ -33,7 +34,7 @@ public class TestSuite implements HasUID, TenantInterface, SoftDeletable<TestSui
     private String id;
 
     @Hidden
-    @Pattern(regexp = "^[a-z0-9][a-z0-9_-]*")
+    @TenantId
     private String tenantId;
 
     private String description;

--- a/core/src/main/java/io/kestra/core/validations/TenantId.java
+++ b/core/src/main/java/io/kestra/core/validations/TenantId.java
@@ -1,0 +1,32 @@
+package io.kestra.core.validations;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import io.kestra.core.validations.validator.TenantIdValidator;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import static java.lang.annotation.ElementType.*;
+
+/**
+ * Constrains a string to a tenant identifier: lowercase alphanumerics, underscores and hyphens,
+ * must start with an alphanumeric, max 100 characters.
+ *
+ * <p>
+ * Used as a single source of truth everywhere a tenant id is carried, so the format is declared
+ * once rather than repeated as a literal pattern on every model that has a {@code tenantId}.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = TenantIdValidator.class)
+@Target({ METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER, TYPE_USE })
+public @interface TenantId {
+    String message() default "must be a tenant id (lowercase alphanumerics, underscores and hyphens, "
+        + "must start with an alphanumeric, max 100 chars), got '${validatedValue}'";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+}

--- a/core/src/main/java/io/kestra/core/validations/validator/TenantIdValidator.java
+++ b/core/src/main/java/io/kestra/core/validations/validator/TenantIdValidator.java
@@ -1,0 +1,49 @@
+package io.kestra.core.validations.validator;
+
+import java.util.regex.Pattern;
+
+import io.kestra.core.validations.TenantId;
+
+import io.micronaut.core.annotation.AnnotationValue;
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.core.annotation.Nullable;
+import io.micronaut.validation.validator.constraints.ConstraintValidator;
+import io.micronaut.validation.validator.constraints.ConstraintValidatorContext;
+import jakarta.inject.Singleton;
+
+/**
+ * Validates that a value is a tenant identifier: lowercase alphanumerics, underscores and hyphens,
+ * starting with an alphanumeric, at most {@value #MAX_LENGTH} characters.
+ *
+ * <p>
+ * The bound matches the {@code tenant_id} columns, which are all {@code VARCHAR(250)}. Without it
+ * an over-long tenant id is only rejected by the database, and a write that fails there can be one
+ * the caller cannot retry past.
+ *
+ * <p>
+ * Exposes {@link #isValid(String)} as a static helper so record compact constructors and other
+ * non-CDI code paths can enforce the same invariant without going through the validator beans.
+ */
+@Singleton
+public final class TenantIdValidator implements ConstraintValidator<TenantId, String> {
+
+    public static final int MAX_LENGTH = 100;
+    public static final String PATTERN = "^[a-z0-9][a-z0-9_-]*$";
+
+    private static final Pattern COMPILED = Pattern.compile(PATTERN);
+
+    @Override
+    public boolean isValid(
+        @Nullable String value,
+        @NonNull AnnotationValue<TenantId> annotationMetadata,
+        @NonNull ConstraintValidatorContext context) {
+        return value == null || isValid(value);
+    }
+
+    /**
+     * Returns {@code true} if {@code value} is a non-null tenant id.
+     */
+    public static boolean isValid(String value) {
+        return value != null && value.length() <= MAX_LENGTH && COMPILED.matcher(value).matches();
+    }
+}

--- a/core/src/test/java/io/kestra/core/validations/TenantIdTest.java
+++ b/core/src/test/java/io/kestra/core/validations/TenantIdTest.java
@@ -1,0 +1,82 @@
+package io.kestra.core.validations;
+
+import org.junit.jupiter.api.Test;
+
+import io.kestra.core.junit.annotations.KestraTest;
+import io.kestra.core.models.validations.ModelValidator;
+import io.kestra.core.validations.validator.TenantIdValidator;
+
+import jakarta.inject.Inject;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@KestraTest
+class TenantIdTest {
+    @Inject
+    private ModelValidator modelValidator;
+
+    @AllArgsConstructor
+    @Getter
+    public static class TenantIdHolder {
+        @TenantId
+        String value;
+    }
+
+    @Test
+    void shouldAcceptValidTenantIds() {
+        for (String ok : new String[] {
+            "a", "1", "main",
+            "acme_corp", "acme-corp", "acme-corp_2",
+            "a".repeat(TenantIdValidator.MAX_LENGTH)
+        }) {
+            assertThat(modelValidator.isValid(new TenantIdHolder(ok)))
+                .as("expected '%s' to be a valid tenant id", ok)
+                .isEmpty();
+            assertThat(TenantIdValidator.isValid(ok))
+                .as("static isValid('%s')", ok)
+                .isTrue();
+        }
+    }
+
+    @Test
+    void shouldRejectInvalidTenantIds() {
+        for (String bad : new String[] {
+            "", // empty
+            "_a", // must start with an alphanumeric
+            "-a", // must start with an alphanumeric
+            "Acme", // uppercase not allowed
+            "acme corp", // space not allowed
+            "acme.corp", // dot not allowed
+            "acme|corp", // the uid separator must never appear in a tenant id
+            "a".repeat(TenantIdValidator.MAX_LENGTH + 1) // wider than the narrowest tenant_id column
+        }) {
+            assertThat(modelValidator.isValid(new TenantIdHolder(bad)))
+                .as("expected '%s' to be rejected", bad)
+                .isPresent();
+            assertThat(TenantIdValidator.isValid(bad))
+                .as("static isValid('%s')", bad)
+                .isFalse();
+        }
+    }
+
+    @Test
+    void shouldAcceptATenantIdLongerThanTwoCharacters() {
+        // TriggerContext carried "^[a-z0-9][a-z0-9_-]" — no quantifier — and @Pattern matches the
+        // whole value, so it accepted a two-character tenant id and nothing else.
+        assertThat(modelValidator.isValid(new TenantIdHolder("main"))).isEmpty();
+    }
+
+    @Test
+    void shouldAcceptNullViaAnnotation() {
+        // Bean Validation contract: null is left to @NotNull; the constraint itself does not
+        // reject null.
+        assertThat(modelValidator.isValid(new TenantIdHolder(null))).isEmpty();
+    }
+
+    @Test
+    void staticIsValidShouldRejectNull() {
+        assertThat(TenantIdValidator.isValid(null)).isFalse();
+    }
+}

--- a/webserver/src/main/java/io/kestra/webserver/controllers/api/DashboardController.java
+++ b/webserver/src/main/java/io/kestra/webserver/controllers/api/DashboardController.java
@@ -38,6 +38,7 @@ import io.kestra.core.serializers.FileSerde;
 import io.kestra.core.serializers.JacksonMapper;
 import io.kestra.core.serializers.YamlParser;
 import io.kestra.core.tenant.TenantService;
+import io.kestra.core.validations.TenantId;
 import io.kestra.plugin.core.dashboard.chart.Markdown;
 import io.kestra.plugin.core.dashboard.chart.mardown.sources.FlowDescription;
 import io.kestra.webserver.models.ChartFiltersOverrides;
@@ -544,7 +545,7 @@ public class DashboardController {
 
     @Getter
     public static class DashboardResponse {
-        @jakarta.validation.constraints.Pattern(regexp = "^[a-z0-9][a-z0-9_-]*")
+        @TenantId
         private final String tenantId;
         @NotNull
         @NotBlank


### PR DESCRIPTION
### 🔗 Related Issue

No issue — found while fixing https://github.com/kestra-io/kestra-ee/issues/10592, which was caused
by an id whose length nobody had bounded.

### ✨ Description

The tenant-id format was written out as a literal `@Pattern(regexp = "^[a-z0-9][a-z0-9_-]*")` on 27
models across OSS and EE. This declares it once as `@TenantId`, next to the existing
`@Rfc1123Label`, and applies it to the 14 OSS sites.

Consolidating the copies surfaced two things the duplication was hiding:

- **`TriggerContext` carried `"^[a-z0-9][a-z0-9_-]"` — no quantifier.** Bean Validation matches the
  whole value, so that pattern accepted a two-character tenant id and rejected every other one.
- **The format had no upper bound at all.** `@TenantId` caps it at 100 characters, so an over-long
  tenant id is rejected as invalid input instead of reaching an insert that cannot succeed.

100 is the narrowest `tenant_id` column in the schema (EE's `invitations`), which makes the bound
provably non-breaking: nothing longer than that can be stored today. A tenant id is also a URL path
segment, which is its own reason to keep it short.

`McpServer.id` and `ApiMcpServer.id` keep their own `@Pattern`: they share the regex today but are
server ids, not tenant ids.

### 🛠️ Backend Checklist

- [x] Code compiles and tests pass for the touched modules (`./gradlew :module-name:test`, or `./gradlew build` for cross-module changes)
- [x] New behavior is covered by unit or integration tests

### 📝 Additional Notes

`TenantIdTest` mirrors `Rfc1123LabelTest`: accepted and rejected forms through `ModelValidator` and
through the static `isValid` helper, the Bean Validation null contract, and an explicit case for the
two-character bug above so that regex cannot come back unnoticed. `:core:test --tests TenantIdTest`
passes; `:core` and `:webserver` compile.

**Companion PR:** https://github.com/kestra-io/kestra-ee/pull/10656, which applies `@TenantId` to
the 13 EE models. That PR does not compile without this one, so this should merge first.

**Follow-up, not fixed here.** The survey behind the 100-character bound also found that four EE
tables declare `tenant_id` with a *different* width per backend — `security_integrations` has three
different widths for one table. Filed as
https://github.com/kestra-io/kestra-ee/issues/10654. The cap added here is what currently keeps any
of them from being reachable.
