### PR TITLE
fix(triggers): keep a single catalog entry per trigger type on the triggers add page

### DIFF
--- a/ui/src/stores/plugins.ts
+++ b/ui/src/stores/plugins.ts
@@ -346,7 +346,15 @@ export const usePluginsStore = defineStore("plugins", () => {
 
     async function listTriggers() {
         const response = await PluginsAPI.listTriggerPlugins() as unknown as {results: TriggerPluginDto[]; total: number}
-        return response?.results ?? []
+        // The triggers grid keys its cards by type, and duplicate keys corrupt Vue's keyed diff on
+        // every filter change (https://github.com/kestra-io/kestra/issues/18419), so drop duplicates
+        // even if the API misbehaves.
+        const seen = new Set<string>()
+        return (response?.results ?? []).filter(trigger => {
+            if (seen.has(trigger.type)) return false
+            seen.add(trigger.type)
+            return true
+        })
     }
 
     async function listWithSubgroup(_options?: Record<string, any>) {

--- a/ui/tests/unit/stores/pluginsTriggersDedupe.spec.ts
+++ b/ui/tests/unit/stores/pluginsTriggersDedupe.spec.ts
@@ -1,0 +1,67 @@
+import {beforeEach, describe, expect, it, vi} from "vitest"
+import {createPinia, setActivePinia} from "pinia"
+
+vi.mock("override/utils/route", () => ({
+    apiUrlWithoutTenants: () => "/api/v1",
+}))
+
+vi.mock("override/stores/misc", () => ({
+    useMiscStore: () => ({configs: {}}),
+}))
+
+vi.mock("../../../src/utils/tabTracking", () => ({
+    trackPluginDocumentationView: vi.fn(),
+}))
+
+const listTriggerPluginsFn = vi.fn()
+
+vi.mock("@kestra-io/kestra-sdk", () => ({
+    useClient: () => ({get: vi.fn(), post: vi.fn()}),
+}))
+
+vi.mock("@kestra-io/kestra-sdk/plugins", () => ({
+    listTriggerPlugins: (...args: unknown[]) => listTriggerPluginsFn(...args),
+}))
+
+const trigger = (type: string) => ({
+    type,
+    name: "RealtimeTrigger",
+    pluginTitle: "TCP",
+    description: null,
+    group: "realtime",
+    ee: false,
+    icon: "",
+    deprecated: null,
+})
+
+const TEST_TIMEOUT_MS = 20_000
+
+describe("plugins store trigger catalog", () => {
+    beforeEach(() => {
+        vi.resetModules()
+        setActivePinia(createPinia())
+        listTriggerPluginsFn.mockReset()
+    })
+
+    it("should keep a single entry per trigger type when the API returns duplicates", {timeout: TEST_TIMEOUT_MS}, async () => {
+        // Regression test for https://github.com/kestra-io/kestra/issues/18419: a plugin installed
+        // in several versions makes the API repeat its trigger types, and the duplicated types
+        // corrupt the triggers grid, which keys its cards by type.
+        listTriggerPluginsFn.mockResolvedValue({
+            results: [
+                trigger("io.kestra.plugin.tcp.RealtimeTrigger"),
+                trigger("io.kestra.plugin.tcp.RealtimeTrigger"),
+                trigger("io.kestra.plugin.udp.RealtimeTrigger"),
+            ],
+            total: 3,
+        })
+        const {usePluginsStore} = await import("../../../src/stores/plugins")
+
+        const triggers = await usePluginsStore().listTriggers()
+
+        expect(triggers.map(t => t.type)).toEqual([
+            "io.kestra.plugin.tcp.RealtimeTrigger",
+            "io.kestra.plugin.udp.RealtimeTrigger",
+        ])
+    })
+})

--- a/webserver/src/main/java/io/kestra/webserver/controllers/api/PluginController.java
+++ b/webserver/src/main/java/io/kestra/webserver/controllers/api/PluginController.java
@@ -337,7 +337,15 @@ public class PluginController {
             "RealtimeTriggerInterface) or app (implements PollingTriggerInterface)."
     )
     public PagedResults<ApiTriggerPlugin> listTriggerPlugins() {
-        List<ApiTriggerPlugin> all = pluginRegistry.plugins().stream()
+        List<ApiTriggerPlugin> all = toTriggerPluginCatalog(pluginRegistry.plugins());
+
+        return PagedResults.of(new ArrayListTotal<>(all, all.size()));
+    }
+
+    // A plugin installed in several versions registers one RegisteredPlugin per version, each
+    // exposing the same trigger classes - keep a single catalog entry per trigger type.
+    protected List<ApiTriggerPlugin> toTriggerPluginCatalog(List<RegisteredPlugin> plugins) {
+        return plugins.stream()
             .flatMap(
                 registeredPlugin -> registeredPlugin.getTriggers().stream()
                     .filter(c -> !isInternal(c))
@@ -345,13 +353,13 @@ public class PluginController {
                     .map(c -> toApiTriggerPlugin(registeredPlugin, c))
             )
             .filter(dto -> dto.group() != TriggerPluginCategory.UNKNOWN)
+            .collect(Collectors.toMap(ApiTriggerPlugin::type, dto -> dto, (first, duplicate) -> first, LinkedHashMap::new))
+            .values().stream()
             .sorted(
                 Comparator.comparing((ApiTriggerPlugin dto) -> dto.group().ordinal())
                     .thenComparing(ApiTriggerPlugin::name, String.CASE_INSENSITIVE_ORDER)
             )
             .toList();
-
-        return PagedResults.of(new ArrayListTotal<>(all, all.size()));
     }
 
     protected ApiTriggerPlugin toApiTriggerPlugin(RegisteredPlugin registeredPlugin, Class<? extends AbstractTrigger> triggerClass) {

--- a/webserver/src/test/java/io/kestra/webserver/controllers/api/PluginControllerTest.java
+++ b/webserver/src/test/java/io/kestra/webserver/controllers/api/PluginControllerTest.java
@@ -15,6 +15,7 @@ import io.kestra.core.docs.Plugin;
 import io.kestra.core.docs.PluginIcon;
 import io.kestra.core.junit.annotations.KestraTest;
 import io.kestra.core.models.annotations.PluginSubGroup;
+import io.kestra.core.models.triggers.AbstractTrigger;
 import io.kestra.core.models.ui.PluginDistribution;
 import io.kestra.core.models.ui.PluginUiManifest;
 import io.kestra.core.models.ui.PluginUiModuleWithGroup;
@@ -529,9 +530,31 @@ class PluginControllerTest {
         assertThat(mongodbTrigger.pluginGroupTitle()).isEqualTo("MongoDB");
     }
 
+    @Test
+    void shouldReturnASingleCatalogEntryPerTriggerTypeWhenAPluginIsRegisteredInSeveralVersions() {
+        // Regression test for https://github.com/kestra-io/kestra/issues/18419: a plugin installed
+        // in several versions registers one RegisteredPlugin per version, and the duplicated trigger
+        // types corrupted the "Add Trigger" grid, which keys its cards by type.
+        PluginController controller = new PluginController();
+
+        RegisteredPlugin plugin = pluginWithTriggers(Schedule.class, Webhook.class);
+        RegisteredPlugin samePluginOtherVersion = pluginWithTriggers(Schedule.class, Webhook.class);
+
+        List<ApiTriggerPlugin> catalog = controller.toTriggerPluginCatalog(List.of(plugin, samePluginOtherVersion));
+
+        assertThat(catalog).map(ApiTriggerPlugin::type).containsExactlyInAnyOrder(Schedule.class.getName(), Webhook.class.getName());
+    }
+
     private static RegisteredPlugin pluginWithTitle(String title) {
         Manifest manifest = new Manifest();
         manifest.getMainAttributes().putValue("X-Kestra-Title", title);
         return RegisteredPlugin.builder().manifest(manifest).build();
+    }
+
+    @SafeVarargs
+    private static RegisteredPlugin pluginWithTriggers(Class<? extends AbstractTrigger>... triggers) {
+        Manifest manifest = new Manifest();
+        manifest.getMainAttributes().putValue("X-Kestra-Title", "Core");
+        return RegisteredPlugin.builder().manifest(manifest).triggers(List.of(triggers)).build();
     }
 }


### PR DESCRIPTION
Backport of https://github.com/kestra-io/kestra/pull/18708 to `releases/v2.0.x`.

Related to https://github.com/kestra-io/kestra/issues/18419.

### ✨ Description

On the Triggers Add page, re-applying a category filter (All -> Realtime -> All -> ...) made the trigger list visibly grow and duplicate on every round. A plugin installed in several versions registers one `RegisteredPlugin` per version, so `GET /api/v1/plugins/triggers` returned the same trigger `type` once per installed version; the grid keys its cards by `type`, and the duplicated keys make Vue's keyed diff leak stale DOM nodes on every filter re-apply.

Clean cherry-pick of the two-layer fix: `PluginController#listTriggerPlugins` keeps a single catalog entry per trigger `type`, and the plugins store drops duplicate `type`s defensively. Before/after evidence is in the original `PR`.

### 🎨 Frontend Checklist

- [x] Type checking passes (`npm run check:types`)
- [x] Unit tests pass (`npm run test:unit`)

### 🛠️ Backend Checklist

- [x] Code compiles and tests pass for the touched modules (`./gradlew :webserver:test --tests "PluginControllerTest"`)
- [x] New behavior is covered by unit or integration tests

Meow-ver to 2.0 complete: the cat insisted every trigger be uniquely chipped before adoption. 🐱
