### PR TITLE
build: exit and dump heap on OOM in gradle jvmargs

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 version=1.3.36
 
-org.gradle.jvmargs=-Xmx2g -XX:MaxMetaspaceSize=512m -XX:+HeapDumpOnOutOfMemoryError
+org.gradle.jvmargs=-Xmx2g -XX:MaxMetaspaceSize=512m -XX:+ExitOnOutOfMemoryError -XX:+HeapDumpOnOutOfMemoryError
 org.gradle.parallel=true
 org.gradle.caching=true
 org.gradle.priority=low


### PR DESCRIPTION
Adds `-XX:+ExitOnOutOfMemoryError` and `-XX:+HeapDumpOnOutOfMemoryError` to `org.gradle.jvmargs` so the Gradle daemon dies immediately on an `OutOfMemoryError` (instead of limping along and producing confusing downstream failures) and leaves a heap dump behind for diagnosis.

Aligns this release branch with `develop`.