### PR TITLE
fix(assets): allow an output asset to be declared by its id alone

### DIFF
--- a/core/src/main/java/io/kestra/core/models/assets/Asset.java
+++ b/core/src/main/java/io/kestra/core/models/assets/Asset.java
@@ -97,6 +97,8 @@ public abstract class Asset implements HasUID, SoftDeletable<Asset>, Plugin {
         this.type = allowTypeChange
             ? ObjectUtils.firstNonNull(this.type, previousType)
             : ObjectUtils.firstNonNull(previousType, this.type);
+        // The namespace of an existing asset is immutable, as AssetsController.updateAsset already enforces
+        this.namespace = Optional.ofNullable(previousAsset).map(Asset::getNamespace).orElse(this.namespace);
         this.displayName = Optional.ofNullable(this.displayName).or(() -> Optional.ofNullable(previousAsset).map(Asset::getDisplayName)).orElse(null);
         this.description = Optional.ofNullable(this.description).or(() -> Optional.ofNullable(previousAsset).map(Asset::getDescription)).orElse(null);
         this.metadata = Optional.ofNullable(previousAsset).map(Asset::getMetadata).orElse(null) == null
@@ -134,6 +136,11 @@ public abstract class Asset implements HasUID, SoftDeletable<Asset>, Plugin {
 
     public Asset withTenantId(String tenantId) {
         this.tenantId = tenantId;
+        return this;
+    }
+
+    public Asset withNamespace(String namespace) {
+        this.namespace = namespace;
         return this;
     }
 }

--- a/core/src/main/java/io/kestra/core/models/assets/AssetIdentifier.java
+++ b/core/src/main/java/io/kestra/core/models/assets/AssetIdentifier.java
@@ -11,6 +11,10 @@ public record AssetIdentifier(@Hidden String tenantId, @Hidden String namespace,
         return new AssetIdentifier(tenantId, this.namespace, this.id, this.type);
     }
 
+    public AssetIdentifier withNamespace(String namespace) {
+        return new AssetIdentifier(this.tenantId, namespace, this.id, this.type);
+    }
+
     public String uid() {
         return IdUtils.fromParts(tenantId, id);
     }

--- a/core/src/main/java/io/kestra/core/plugins/serdes/AssetDeserializer.java
+++ b/core/src/main/java/io/kestra/core/plugins/serdes/AssetDeserializer.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.JsonDeserializer;
 import io.kestra.core.models.Plugin;
 import io.kestra.core.models.assets.Asset;
 import io.kestra.core.models.assets.Custom;
+import io.kestra.core.models.assets.External;
 
 /**
  * Specific {@link JsonDeserializer} for deserializing {@link Asset}.
@@ -13,5 +14,14 @@ public final class AssetDeserializer extends PluginDeserializer<Asset> {
     @Override
     protected Class<? extends Plugin> fallbackClass() {
         return Custom.class;
+    }
+
+    /**
+     * An asset declared by its id alone is external, as for the assets referenced in {@code assets.inputs}.
+     * An asset that already exists keeps its stored type, see {@link Asset#toUpdated(Asset, boolean)}.
+     */
+    @Override
+    protected Class<? extends Plugin> defaultClass() {
+        return External.class;
     }
 }

--- a/core/src/main/java/io/kestra/core/plugins/serdes/PluginDeserializer.java
+++ b/core/src/main/java/io/kestra/core/plugins/serdes/PluginDeserializer.java
@@ -85,10 +85,12 @@ public class PluginDeserializer<T extends Plugin> extends JsonDeserializer<T> {
     private T fromObjectNode(JsonParser jp,
         JsonNode node,
         DeserializationContext context) throws IOException {
-        Class<? extends Plugin> pluginType = null;
+        Class<? extends Plugin> pluginType;
 
         final String identifier = extractPluginRawIdentifier(node, pluginRegistry.isVersioningSupported());
-        if (identifier != null) {
+        if (identifier == null) {
+            pluginType = defaultClass();
+        } else {
             log.trace(
                 "Looking for Plugin for: {}",
                 identifier
@@ -165,6 +167,13 @@ public class PluginDeserializer<T extends Plugin> extends JsonDeserializer<T> {
     }
 
     protected Class<? extends Plugin> fallbackClass() {
+        return null;
+    }
+
+    /**
+     * The class to deserialize to when no type is declared, {@code null} making a missing type an error.
+     */
+    protected Class<? extends Plugin> defaultClass() {
         return null;
     }
 }

--- a/core/src/test/java/io/kestra/core/models/assets/AssetTest.java
+++ b/core/src/test/java/io/kestra/core/models/assets/AssetTest.java
@@ -6,9 +6,29 @@ import java.util.Map;
 
 import org.junit.jupiter.api.Test;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+
+import io.kestra.core.serializers.JacksonMapper;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 class AssetTest {
+    @Test
+    void shouldDeserializeAssetWithoutTypeAsExternal() throws JsonProcessingException {
+        Asset asset = JacksonMapper.ofYaml().readValue(
+            """
+                id: my-asset
+                metadata:
+                    owner: infra-team""",
+            Asset.class
+        );
+
+        assertThat(asset).isInstanceOf(External.class);
+        assertThat(asset.getType()).isEqualTo(External.ASSET_TYPE);
+        assertThat(asset.getId()).isEqualTo("my-asset");
+        assertThat(asset.getMetadata()).containsEntry("owner", "infra-team");
+    }
+
     @Test
     void shouldKeepPreviousTypeWhenTypeChangeIsNotAllowed() {
         // Given
@@ -79,5 +99,31 @@ class AssetTest {
 
         // Then
         assertThat(created.getType()).isEqualTo("EC2");
+    }
+
+    @Test
+    void shouldKeepPreviousNamespaceWhenNotDeclared() {
+        // Given an existing asset referenced by its id alone, so deserialized as External
+        Custom previous = Custom.builder().namespace("io.kestra").id("my-asset").type("EC2").build();
+        External incoming = External.builder().id("my-asset").build();
+
+        // When
+        Asset updated = incoming.toUpdated(previous, false);
+
+        // Then
+        assertThat(updated.getNamespace()).isEqualTo("io.kestra");
+    }
+
+    @Test
+    void shouldKeepPreviousNamespaceWhenAnotherOneIsDeclared() {
+        // Given
+        Custom previous = Custom.builder().namespace("io.kestra").id("my-asset").type("EC2").build();
+        Custom incoming = Custom.builder().namespace("io.kestra.other").id("my-asset").type("EC2").build();
+
+        // When
+        Custom updated = incoming.toUpdated(previous, false);
+
+        // Then
+        assertThat(updated.getNamespace()).isEqualTo("io.kestra");
     }
 }

--- a/worker/src/main/java/io/kestra/worker/processors/WorkerTaskProcessor.java
+++ b/worker/src/main/java/io/kestra/worker/processors/WorkerTaskProcessor.java
@@ -471,18 +471,33 @@ public class WorkerTaskProcessor extends AbstractWorkerJobProcessor<WorkerTask> 
 
                 AssetsDeclaration assetsDeclaration = workerTask.getTask().getAssets();
 
+                // Rendered independently so an unrenderable output doesn't discard the inputs of the same task.
+                List<AssetIdentifier> declaredInputs = List.of();
+                try {
+                    declaredInputs = runContext.render(assetsDeclaration.getInputs()).asList(AssetIdentifier.class, formattedOutputsMap);
+                } catch (IllegalVariableEvaluationException e) {
+                    logger.warn("Unable to render the declared asset inputs of task '{}'", taskRun.getTaskId(), e);
+                    assetEmission = TaskRunWithOutput.AssetEmission.FAILED;
+                }
+
+                List<Asset> declaredOutputs = List.of();
+                try {
+                    declaredOutputs = runContext.render(assetsDeclaration.getOutputs()).asList(Asset.class, formattedOutputsMap);
+                } catch (IllegalVariableEvaluationException e) {
+                    logger.warn("Unable to render the declared asset outputs of task '{}'", taskRun.getTaskId(), e);
+                    assetEmission = TaskRunWithOutput.AssetEmission.FAILED;
+                }
+
                 // One bundle per lineage pair (the manual `assets:` declaration plus each auto-emitted pair),
                 // kept unmerged so persistence writes one event per pair instead of a cartesian graph.
                 List<AssetsInOut> bundles = new ArrayList<>();
-                List<AssetIdentifier> declaredInputs = runContext.render(assetsDeclaration.getInputs()).asList(AssetIdentifier.class, formattedOutputsMap);
-                List<Asset> declaredOutputs = runContext.render(assetsDeclaration.getOutputs()).asList(Asset.class, formattedOutputsMap);
                 if (!declaredInputs.isEmpty() || !declaredOutputs.isEmpty()) {
                     bundles.add(new AssetsInOut(declaredInputs, declaredOutputs));
                 }
                 runContext.assets().emitted().forEach(emit -> bundles.add(new AssetsInOut(emit.inputs(), emit.outputs())));
 
                 if (!bundles.isEmpty()) {
-                    taskRun = taskRun.withAssetEmits(bundles);
+                    taskRun = taskRun.withAssetEmits(withDefaultNamespace(bundles, taskRun.getNamespace()));
                 }
             }
         } catch (ConstraintViolationException e) {
@@ -496,7 +511,7 @@ public class WorkerTaskProcessor extends AbstractWorkerJobProcessor<WorkerTask> 
                 assetEmission = TaskRunWithOutput.AssetEmission.DECLARATION_INVALID;
             }
         } catch (Exception e) {
-            logger.warn("Unable to render asset declaration for taskRun '{}'", taskRun, e);
+            logger.warn("Unable to emit the assets of task '{}'", taskRun.getTaskId(), e);
             assetEmission = TaskRunWithOutput.AssetEmission.FAILED;
         }
 
@@ -508,6 +523,25 @@ public class WorkerTaskProcessor extends AbstractWorkerJobProcessor<WorkerTask> 
             .filter(violation -> violation.getPropertyPath().toString().startsWith(propertyPathPrefix))
             .map(violation -> violation.getPropertyPath() + " " + violation.getMessage())
             .collect(Collectors.joining(", "));
+    }
+
+    /**
+     * An asset emitted without a namespace belongs to the flow emitting it, and left null it is filtered
+     * out of the view of every user whose asset permission is scoped to namespaces rather than global.
+     */
+    private static List<AssetsInOut> withDefaultNamespace(List<AssetsInOut> bundles, String namespace) {
+        return bundles.stream()
+            .map(
+                bundle -> new AssetsInOut(
+                    bundle.getInputs().stream()
+                        .map(input -> input.namespace() == null ? input.withNamespace(namespace) : input)
+                        .toList(),
+                    bundle.getOutputs().stream()
+                        .map(output -> output.getNamespace() == null ? output.withNamespace(namespace) : output)
+                        .toList()
+                )
+            )
+            .toList();
     }
 
     private List<TaskRunAttempt> addAttempt(WorkerTask workerTask, TaskRunAttempt taskRunAttempt) {

--- a/worker/src/test/java/io/kestra/worker/processors/WorkerTaskProcessorTest.java
+++ b/worker/src/test/java/io/kestra/worker/processors/WorkerTaskProcessorTest.java
@@ -10,9 +10,11 @@ import org.junit.jupiter.api.Test;
 
 import io.kestra.core.junit.annotations.KestraTest;
 import io.kestra.core.metrics.MetricRegistry;
+import io.kestra.core.models.assets.Asset;
 import io.kestra.core.models.assets.AssetIdentifier;
 import io.kestra.core.models.assets.AssetsDeclaration;
 import io.kestra.core.models.assets.Custom;
+import io.kestra.core.models.assets.External;
 import io.kestra.core.models.executions.Execution;
 import io.kestra.core.models.executions.LogEntry;
 import io.kestra.core.models.executions.TaskRun;
@@ -120,6 +122,53 @@ class WorkerTaskProcessorTest {
         assertThat(results)
             .as("an interrupted task's failure must be deferred for resubmission, not reported")
             .noneMatch(result -> result.getTaskRun().getState().isFailed());
+    }
+
+    @Test
+    void shouldKeepDeclaredInputsWhenOutputsCannotBeRendered() throws Exception {
+        // Given a task whose declared outputs cannot be rendered, while its declared inputs can
+        InMemoryWorkerQueue<WorkerTaskResult> resultQueue = new InMemoryWorkerQueue<>(100);
+        WorkerTaskProcessor processor = newProcessor(resultQueue);
+
+        // When the task runs
+        processor.process(unrenderableOutputsWorkerTask());
+
+        // Then the inputs are still emitted, and the unrendered outputs only show up in the state
+        List<WorkerTaskResult> results = drain(resultQueue);
+        TaskRun taskRun = results.getLast().getTaskRun();
+        assertThat(taskRun.getAssetEmits())
+            .as("a failing output must not discard the declared inputs")
+            .singleElement()
+            .satisfies(bundle ->
+            {
+                assertThat(bundle.getInputs()).extracting(AssetIdentifier::id).containsExactly("declared-input");
+                assertThat(bundle.getOutputs()).isEmpty();
+            });
+        assertThat(taskRun.getState().getCurrent())
+            .as("a partially emitted declaration is still an emission failure, escalated per assetFailureBehavior")
+            .isEqualTo(State.Type.WARNING);
+    }
+
+    @Test
+    void shouldDefaultAssetNamespaceToTheFlowNamespaceWhenNotDeclared() throws Exception {
+        // Given a task declaring an input and an output that carry no namespace
+        InMemoryWorkerQueue<WorkerTaskResult> resultQueue = new InMemoryWorkerQueue<>(100);
+        WorkerTaskProcessor processor = newProcessor(resultQueue);
+
+        // When the task runs
+        processor.process(namespacelessAssetsWorkerTask());
+
+        // Then both inherit the namespace of the flow
+        List<WorkerTaskResult> results = drain(resultQueue);
+        TaskRun taskRun = results.getLast().getTaskRun();
+        assertThat(taskRun.getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
+        assertThat(taskRun.getAssetEmits())
+            .singleElement()
+            .satisfies(bundle ->
+            {
+                assertThat(bundle.getInputs()).extracting(AssetIdentifier::namespace).containsExactly("io.kestra.unit-test");
+                assertThat(bundle.getOutputs()).extracting(Asset::getNamespace).containsExactly("io.kestra.unit-test");
+            });
     }
 
     @Test
@@ -393,6 +442,41 @@ class WorkerTaskProcessorTest {
             .build();
     }
 
+    private WorkerTask unrenderableOutputsWorkerTask() {
+        AssetEmissionFailure task = AssetEmissionFailure.builder()
+            .type(AssetEmissionFailure.class.getName())
+            .id("asset-task")
+            .assets(
+                new AssetsDeclaration(
+                    Property.ofValue(false),
+                    Property.ofValue(List.of(new AssetIdentifier(null, "io.kestra.unit-test", "declared-input", "MY_OWN_ASSET_TYPE"))),
+                    // rendered value is a plain string, not JSON, so binding it as List<Asset> fails
+                    Property.ofExpression("{{ 'not-json' }}"),
+                    Property.ofValue(AssetFailureBehavior.WARN)
+                )
+            )
+            .build();
+
+        return workerTaskFor(task);
+    }
+
+    private WorkerTask namespacelessAssetsWorkerTask() {
+        AssetEmissionFailure task = AssetEmissionFailure.builder()
+            .type(AssetEmissionFailure.class.getName())
+            .id("asset-task")
+            .assets(
+                new AssetsDeclaration(
+                    Property.ofValue(false),
+                    Property.ofValue(List.of(new AssetIdentifier(null, null, "declared-input", "MY_OWN_ASSET_TYPE"))),
+                    Property.ofValue(List.<Asset> of(External.builder().id("declared-output").build())),
+                    Property.ofValue(AssetFailureBehavior.WARN)
+                )
+            )
+            .build();
+
+        return workerTaskFor(task);
+    }
+
     private WorkerTask assetEmissionFailureWorkerTask(AssetFailureBehavior assetFailureBehavior) {
         return assetEmissionFailureWorkerTask(assetFailureBehavior, false, false);
     }
@@ -553,9 +637,8 @@ class WorkerTaskProcessorTest {
     }
 
     /**
-     * A task that succeeds on its own but whose asset declaration fails to render, modeling a task
-     * emitting a malformed asset. Constructed and executed directly by the processor, so no plugin
-     * registration is needed.
+     * A task that succeeds on its own, so only its asset declaration decides the outcome. Constructed and
+     * executed directly by the processor, so no plugin registration is needed.
      */
     @SuperBuilder
     @Getter


### PR DESCRIPTION
### 🔗 Related Issue

Related to https://github.com/kestra-io/kestra/pull/18519, the `develop` fix this backports.
Original issue: https://github.com/kestra-io/kestra-ee/issues/10084.

### ✨ Description

An output asset can now be declared by its `id` alone. Before, `assets.outputs: [{id: my-asset}]` failed at runtime with `Could not resolve type id '<null>'` even though the flow saved without a warning, and the whole `assets` block of that task was dropped — including its `inputs`, so the task lost its lineage on top of the failed output.

- An asset declared without a type deserializes as `External`, as already happens for the assets referenced in `assets.inputs`. An asset that already exists keeps its stored type, so a task can update the metadata of a typed asset without repeating its type.
- The namespace of an existing asset is no longer cleared when a declaration omits it, which previously left the asset with no namespace and therefore invisible to every user whose asset permission is scoped to namespaces. A declared namespace no longer overwrites the stored one either, matching what `AssetsController.updateAsset` already enforces.
- An asset emitted without a namespace inherits the namespace of the flow emitting it, which also covers the `External` assets auto-created from `assets.inputs`.
- Declared inputs and outputs are rendered independently, so an unrenderable output no longer discards the inputs of the same task. An invalid declaration is still classified as `DECLARATION_INVALID` and still fails the task, unchanged.

### 🛠️ Backend Checklist

- [x] Code compiles and tests pass for the touched modules (`./gradlew :core:test --tests "io.kestra.core.models.assets.AssetTest" :worker:test --tests "io.kestra.worker.processors.WorkerTaskProcessorTest"` → 26 passed)
- [x] New behavior is covered by unit or integration tests

### 📝 Additional Notes

Straight backport of #18519: the net diff applies to `releases/v2.0.x` with no adaptation and is byte-identical to the one merged on `develop`, since this branch already carries `toUpdated(Asset, boolean)` and the `AssetEmission` enum.

Needs the paired EE backport, which flips the assertion in `AbstractAssetRepositoryTest` that expects an update to overwrite the namespace. Merge this one first: between the two merges, EE `releases/v2.0.x` is red.

The isolation is between inputs and outputs, not per asset — a single malformed entry still discards the rest of its own list, since the property is rendered as a whole.

Why don't cats play poker in the jungle? Too many cheetahs. 🐱
