### PR TITLE
fix(flows): load a row's execution chart once it nears the viewport

### DIFF
--- a/ui/src/components/flows/Flows.vue
+++ b/ui/src/components/flows/Flows.vue
@@ -212,14 +212,17 @@
                     className="row-graph"
                 >
                     <template #default="scope">
-                        <TimeSeries
-                            :chart="mappedChart(scope.row.id, scope.row.namespace)"
-                            :filters="chartFilters()"
-                            showDefault
-                            short
-                            :flow="scope.row.id"
-                            :namespace="scope.row.namespace"
-                        />
+                        <div :ref="(el) => observeChartBlock(el, chartKey(scope.row))" class="row-graph-cell">
+                            <TimeSeries
+                                v-if="activatedCharts.has(chartKey(scope.row))"
+                                :chart="mappedChart(scope.row.id, scope.row.namespace)"
+                                :filters="chartFilters()"
+                                showDefault
+                                short
+                                :flow="scope.row.id"
+                                :namespace="scope.row.namespace"
+                            />
+                        </div>
                     </template>
                 </KsTableColumn>
 
@@ -333,6 +336,7 @@
     import {KsFilter as KSFilter, type FilterConfiguration} from "@kestra-io/design-system"
     import MarkdownTooltip from "../layout/MarkdownTooltip.vue"
     import TimeSeries from "../dashboard/sections/TimeSeries.vue"
+    import {useLazyChartBlocks} from "../dashboard/composables/useLazyChartBlocks"
     import type {Chart} from "../dashboard/types"
     import TopNavBar from "../../components/layout/TopNavBar.vue"
 
@@ -647,6 +651,12 @@
         if (row.row.draft) classes.push("draft")
         return classes.join(" ")
     }
+
+    // One chart per row means one preview request per row on arrival. Rows only load once their cell
+    // nears the viewport, and are never recycled: remounting would re-issue the request we are saving.
+    const {activatedCharts, observeChartBlock} = useLazyChartBlocks(() => false)
+
+    const chartKey = (row: {id: string; namespace: string}) => `${row.namespace}/${row.id}`
 
     function mappedChart(id: string, namespace: string) {
         let MAPPED_CHARTS = JSON.parse(JSON.stringify(CHART_DEFINITION))


### PR DESCRIPTION
### 🔗 Related Issue

Closes https://github.com/kestra-io/kestra/issues/18405.

### ✨ Description

The Execution statistics column renders one `TimeSeries` per row, each with a chart definition filtered to that flow, and each asking the backend for its own preview on mount. Opening **Flows** therefore fired one `POST /api/v1/main/dashboards/charts/preview` per listed flow, whether or not the row was on screen.

Rows now go through `useLazyChartBlocks`, the composable the dashboard grid already uses for the same reason, so a row's chart mounts once its cell nears the viewport.

Rows are declared **non-recyclable**. The composable can unmount a chart that scrolled far away to bound memory, which is right for full-size dashboard charts; for a row sparkline it would re-issue on the way back the very request this is saving.

**Measured on a running instance**, 15 flows listed, counting `charts/preview` for one navigation into Flows:

| | requests |
|---|---|
| before | **15** |
| after, on arrival | **9** |
| after, once scrolled to the bottom of the table | 15 |

So the rows the user cannot see cost nothing, and nothing is lost: every chart still loads as its row is reached. The saving grows with the page size, 25 by default.

### 🎨 Frontend Checklist

- [x] Type checking passes (`npm run check:types`)
- [x] Code builds without errors (`npm run build`)
- [x] Unit tests pass (`npm run test:unit`) — flows suites: 88 passed / 14 files
- [x] Translations are complete — no string changed
- [ ] Screenshots or video recordings attached showing the `UI` changes

### 📝 Additional Notes

This bounds the requests to what is visible; it does not merge them. One request per visible row remains, and collapsing those into a single grouped query would need either a backend endpoint returning per-flow series or a chart query grouped by flow. That is a larger change and is deliberately not attempted here.

`useLazyChartBlocks` falls back to activating everything eagerly when `IntersectionObserver` is unavailable, which is what keeps jsdom-based tests loading every chart.

One measurement caveat worth recording: a row whose flow has no executions renders nothing at all in `short` mode, so an empty cell is not evidence that the chart failed to mount. The request count is the reliable signal.

### 🤖 AI Authors

This PR was written by Claude at @flcarre's request. The cat only loads the charts it can see, which it maintains has always been its policy on everything. 🐱
