### PR TITLE
fix(worker): surface the controller rejection reason on worker connect

### DIFF
--- a/worker-controller/src/main/java/io/kestra/controller/grpc/services/GrpcConnectControllerService.java
+++ b/worker-controller/src/main/java/io/kestra/controller/grpc/services/GrpcConnectControllerService.java
@@ -7,6 +7,7 @@ import io.kestra.controller.grpc.WorkerControllerService;
 import io.kestra.controller.messages.MessageFormats;
 import io.kestra.core.worker.WorkerGroups;
 
+import io.grpc.StatusRuntimeException;
 import io.grpc.stub.StreamObserver;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
@@ -31,7 +32,21 @@ public class GrpcConnectControllerService extends ConnectControllerServiceGrpc.C
 
     @Override
     public void connect(ConnectRequest request, StreamObserver<ConnectResponse> responseObserver) {
-        String workerGroupId = resolveWorkerGroupId(request);
+        final String workerGroupId;
+        try {
+            workerGroupId = resolveWorkerGroupId(request);
+        } catch (StatusRuntimeException e) {
+            // A status escaping this method reaches the worker as UNKNOWN and is dumped as an ERROR
+            // stack trace by the gRPC executor, so the rejection is delivered on the observer instead.
+            log.warn(
+                "Worker '{}' connect request rejected with {}: {}",
+                request.getHeader().getClientId(),
+                e.getStatus().getCode(),
+                e.getStatus().getDescription()
+            );
+            responseObserver.onError(e);
+            return;
+        }
         log.info("Worker connect request received with workerGroup: {}", workerGroupId);
 
         ConnectResponse response = ConnectResponse.newBuilder()
@@ -47,7 +62,8 @@ public class GrpcConnectControllerService extends ConnectControllerServiceGrpc.C
     /**
      * Resolves the Worker Group id for the connecting worker. OSS always returns
      * {@link WorkerGroups#DEFAULT_ID}; the EE override resolves it from the authenticated
-     * worker context and may reject the connection.
+     * worker context and may reject the connection by throwing a {@link StatusRuntimeException},
+     * whose status is then returned to the worker as-is.
      */
     protected String resolveWorkerGroupId(ConnectRequest request) {
         return WorkerGroups.DEFAULT_ID;

--- a/worker-controller/src/test/java/io/kestra/controller/grpc/services/GrpcConnectControllerServiceTest.java
+++ b/worker-controller/src/test/java/io/kestra/controller/grpc/services/GrpcConnectControllerServiceTest.java
@@ -1,0 +1,76 @@
+package io.kestra.controller.grpc.services;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import io.kestra.controller.grpc.ConnectRequest;
+import io.kestra.controller.grpc.ConnectResponse;
+import io.kestra.core.worker.WorkerGroups;
+
+import io.grpc.Status;
+import io.grpc.StatusRuntimeException;
+import io.grpc.stub.StreamObserver;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class GrpcConnectControllerServiceTest {
+
+    @Test
+    void shouldReportRejectionOnObserverWhenResolveThrowsStatus() {
+        StatusRuntimeException rejection = Status.FAILED_PRECONDITION
+            .withDescription("Too many worker threads.")
+            .asRuntimeException();
+        GrpcConnectControllerService service = new GrpcConnectControllerService(Map::of) {
+            @Override
+            protected String resolveWorkerGroupId(ConnectRequest request) {
+                throw rejection;
+            }
+        };
+        RecordingObserver observer = new RecordingObserver();
+
+        service.connect(ConnectRequest.getDefaultInstance(), observer);
+
+        assertThat(observer.responses).isEmpty();
+        assertThat(observer.completed).isFalse();
+        assertThat(Status.fromThrowable(observer.error).getCode()).isEqualTo(Status.Code.FAILED_PRECONDITION);
+        assertThat(Status.fromThrowable(observer.error).getDescription()).isEqualTo("Too many worker threads.");
+    }
+
+    @Test
+    void shouldRespondWithResolvedWorkerGroupWhenConnectSucceeds() {
+        GrpcConnectControllerService service = new GrpcConnectControllerService(Map::of);
+        RecordingObserver observer = new RecordingObserver();
+
+        service.connect(ConnectRequest.getDefaultInstance(), observer);
+
+        assertThat(observer.error).isNull();
+        assertThat(observer.completed).isTrue();
+        assertThat(observer.responses)
+            .singleElement()
+            .satisfies(response -> assertThat(response.getWorkerGroupId()).isEqualTo(WorkerGroups.DEFAULT_ID));
+    }
+
+    private static class RecordingObserver implements StreamObserver<ConnectResponse> {
+        private final List<ConnectResponse> responses = new ArrayList<>();
+        private Throwable error;
+        private boolean completed;
+
+        @Override
+        public void onNext(ConnectResponse value) {
+            responses.add(value);
+        }
+
+        @Override
+        public void onError(Throwable t) {
+            error = t;
+        }
+
+        @Override
+        public void onCompleted() {
+            completed = true;
+        }
+    }
+}

--- a/worker/src/main/java/io/kestra/worker/services/GrpcWorkerConnectionService.java
+++ b/worker/src/main/java/io/kestra/worker/services/GrpcWorkerConnectionService.java
@@ -18,6 +18,8 @@ import io.kestra.core.reporter.UsageReportConfig;
 import io.kestra.core.serializers.JacksonMapper;
 
 import io.grpc.Deadline;
+import io.grpc.Status;
+import io.grpc.StatusRuntimeException;
 import io.micronaut.core.annotation.Nullable;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
@@ -79,9 +81,16 @@ public class GrpcWorkerConnectionService implements WorkerConnectionService {
             String workerGroupId = response.getWorkerGroupId();
             log.info("Connected to controller, workerGroup: {}", workerGroupId);
             return new ConnectionResult(workerGroupId);
+        } catch (StatusRuntimeException e) {
+            // The controller reports why it refused or could not serve the connection, and its gRPC
+            // stack trace adds nothing to that description, so it is only kept for debugging.
+            String message = connectFailureMessage(e.getStatus());
+            log.error(message);
+            log.debug("Connect request to controller failed", e);
+            throw new WorkerConnectionFailedException(message);
         } catch (Exception e) {
             log.error("Failed to send connect request to controller", e);
-            throw new WorkerConnectionFailedException("Failed connecting to Kestra controller. Cause: " + e.getMessage());
+            throw new WorkerConnectionFailedException("Failed connecting to Kestra controller. Cause: " + e.getMessage(), e);
         }
     }
 
@@ -114,5 +123,11 @@ public class GrpcWorkerConnectionService implements WorkerConnectionService {
                 }
             }
         }
+    }
+
+    private static String connectFailureMessage(Status status) {
+        String description = status.getDescription() == null ? "no error description" : status.getDescription();
+        String cause = status.getCause() == null ? "" : " Cause: %s.".formatted(status.getCause().getMessage());
+        return "Failed connecting to Kestra controller (%s): %s%s".formatted(status.getCode(), description, cause);
     }
 }


### PR DESCRIPTION
### ✨ Description

A worker rejected by the controller (license thread limit, revoked registration token, missing token) got `UNKNOWN: Application error processing RPC` and no reason, plus an ERROR stack trace from the gRPC executor on the controller.

`GrpcConnectControllerService.connect` now delivers a `StatusRuntimeException` thrown by `resolveWorkerGroupId` through `responseObserver.onError`, instead of letting it escape the service method where gRPC rewrites it to `UNKNOWN` and dumps the stack. The rejection is logged as one WARN line with the worker id, status code and description.

On the worker, a `StatusRuntimeException` is now reported as a single ERROR line built from the status code, the controller's description and the transport cause when there is one; its gRPC stack trace is kept at DEBUG. Other exceptions keep the ERROR-with-stack and now propagate their cause.

Before:

```
ERROR grpc-default-executor-0 i.grpc.internal.SerializingExecutor Exception while executing runnable ...
io.grpc.StatusRuntimeException: FAILED_PRECONDITION: The number of worker threads (32) exceeds the maximum authorized (16).
    at io.grpc.Status.asRuntimeException(Status.java:524)
    ... 16 more frames

ERROR worker i.k.w.s.GrpcWorkerConnectionService Failed to send connect request to controller
io.grpc.StatusRuntimeException: UNKNOWN: Application error processing RPC
```

After:

```
WARN  grpc-default-executor-0 i.k.c.g.s.GrpcConnectControllerService Worker 'worker_1' connect request rejected with FAILED_PRECONDITION: This worker requests 32 threads but the license authorizes at most 16 worker threads. Reduce the number of worker threads to 16 or fewer, or reach out to sales@kestra.io to raise the limit.

ERROR worker i.k.w.s.GrpcWorkerConnectionService Failed connecting to Kestra controller (FAILED_PRECONDITION): This worker requests 32 threads but the license authorizes at most 16 worker threads. Reduce the number of worker threads to 16 or fewer, or reach out to sales@kestra.io to raise the limit.
```

The wording above comes from the companion EE PR kestra-io/kestra-ee#10679 (branch `fix/worker-connect-error`).

### 🛠️ Backend Checklist

- [x] Code compiles and tests pass for the touched modules (`./gradlew :module-name:test`, or `./gradlew build` for cross-module changes)
- [x] New behavior is covered by unit or integration tests

### 📝 Additional Notes

picocli still prints the `WorkerConnectionFailedException` stack after that ERROR line. The cause is deliberately left off the exception on the status path so the dump stays short and does not repeat the gRPC internals; suppressing it entirely would mean handling the exception in `WorkerCommand`, which is out of scope here.