### PR TITLE
fix(flows): flow test runs on an ephemeral database instead of the configured one

### DIFF
--- a/cli/src/main/java/io/kestra/cli/commands/flows/FlowTestCommand.java
+++ b/cli/src/main/java/io/kestra/cli/commands/flows/FlowTestCommand.java
@@ -15,15 +15,19 @@ import io.kestra.cli.StandAloneRunner;
 import io.kestra.cli.services.TenantIdSelectorService;
 import io.kestra.core.executor.command.Create;
 import io.kestra.core.executor.command.ExecutionCommand;
+import io.kestra.core.models.ServerType;
 import io.kestra.core.models.executions.Execution;
-import io.kestra.core.models.flows.Flow;
+import io.kestra.core.models.flows.FlowWithSource;
 import io.kestra.core.queues.DispatchQueueInterface;
 import io.kestra.core.repositories.ExecutionRepositoryInterface;
-import io.kestra.core.repositories.FlowRepositoryInterface;
 import io.kestra.core.repositories.LocalFlowRepositoryLoader;
 import io.kestra.core.runners.FlowInputOutput;
+import io.kestra.core.utils.IdUtils;
+import io.kestra.controller.config.WorkerControllersConfiguration.DiscoveryType;
+import io.kestra.jdbc.EphemeralDatabase;
 
 import io.micronaut.context.ApplicationContext;
+import io.micronaut.core.io.socket.SocketUtils;
 import io.micronaut.inject.qualifiers.Qualifiers;
 import jakarta.inject.Inject;
 import jakarta.validation.ConstraintViolationException;
@@ -56,14 +60,44 @@ public class FlowTestCommand extends AbstractApiCommand {
 
     private static final SecureRandom random = new SecureRandom();
 
+    // Resolved once per JVM so the forced values stay stable: the database URL is read back by
+    // EphemeralDatasourceRewriter, and the storage directory by the cleanup in call().
+    private static final Path TEMP_STORAGE = generateTempDir();
+
+    private static final String EPHEMERAL_DATABASE_URL =
+        "jdbc:h2:mem:flow-test-%s;LOCK_TIMEOUT=30000;TIME ZONE=UTC;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE".formatted(IdUtils.create());
+
+    /**
+     * Kept out of the ephemeral port range (32768-60999 on Linux), where an outbound socket could
+     * steal the port between this lookup and the controller binding it.
+     */
+    private static final int CONTROLLER_PORT = SocketUtils.findAvailableTcpPort(20000, 32000);
+
     @SuppressWarnings("unused")
     public static Map<String, Object> propertiesOverrides() {
-        return ImmutableMap.of(
-            "kestra.repository.type", "memory",
-            "kestra.queue.type", "memory",
-            "kestra.storage.type", "local",
-            "kestra.storage.local.base-path", generateTempDir().toAbsolutePath().toString()
-        );
+        return ImmutableMap.<String, Object> builder()
+            // The runner starts the services a standalone server does, and they are only registered
+            // for a declared server type.
+            .put("kestra.server-type", ServerType.STANDALONE)
+            // The flow is read from a file rather than from the instance, so the run gets a database
+            // and a storage directory of its own. EphemeralDatabase.URL_PROPERTY repoints every
+            // datasource, including the log store's own.
+            .put("kestra.repository.type", "h2")
+            .put("kestra.queue.type", "h2")
+            .put("kestra.logs.type", "h2")
+            .put(EphemeralDatabase.URL_PROPERTY, EPHEMERAL_DATABASE_URL)
+            .put("kestra.storage.type", "local")
+            .put("kestra.storage.local.base-path", TEMP_STORAGE.toAbsolutePath().toString())
+            // The worker started here must reach the controller started here. Left on the
+            // instance's discovery, a distributed configuration would send it to the real
+            // controller, where it would pick up and run production work.
+            .put("kestra.worker.controllers.type", DiscoveryType.STATIC)
+            .put("kestra.worker.controllers.static.endpoints[0].host", "localhost")
+            .put("kestra.worker.controllers.static.endpoints[0].port", CONTROLLER_PORT)
+            .put("kestra.controller.port", CONTROLLER_PORT)
+            // Testing a flow is not the instance doing work, so it reports no usage.
+            .put("kestra.anonymous-usage-report.enabled", false)
+            .build();
     }
 
     private static Path generateTempDir() {
@@ -74,13 +108,20 @@ public class FlowTestCommand extends AbstractApiCommand {
         );
     }
 
+    /**
+     * The flow runs in this JVM rather than on a server, so its tasks have to be loadable.
+     */
+    @Override
+    protected boolean loadExternalPlugins() {
+        return true;
+    }
+
     @Override
     @SuppressWarnings("unchecked")
     public Integer call() throws Exception {
         super.call();
 
         LocalFlowRepositoryLoader repositoryLoader = applicationContext.getBean(LocalFlowRepositoryLoader.class);
-        FlowRepositoryInterface flowRepository = applicationContext.getBean(FlowRepositoryInterface.class);
         ExecutionRepositoryInterface executionRepository = applicationContext.getBean(ExecutionRepositoryInterface.class);
         FlowInputOutput flowInputOutput = applicationContext.getBean(FlowInputOutput.class);
         TenantIdSelectorService tenantService = applicationContext.getBean(TenantIdSelectorService.class);
@@ -96,22 +137,36 @@ public class FlowTestCommand extends AbstractApiCommand {
             inputs.put(this.inputs.get(i), this.inputs.get(i + 1));
         }
 
-        try (StandAloneRunner runner = applicationContext.createBean(StandAloneRunner.class);) {
-            runner.run();
-            repositoryLoader.load(tenantService.getTenantId(tenantId), file.toFile());
+        // The database is created empty, so the tenant the flow is loaded under has to be created
+        // too. Resolved without the existence check the Enterprise Edition applies, which no row
+        // could satisfy here, and created up front because that check runs on every later read.
+        String tenant = tenantService.getTenantIdAndAllowEETenants(tenantId);
 
-            List<Flow> all = flowRepository.findAllForAllTenants();
-            if (all.size() != 1) {
-                throw new IllegalArgumentException("Too many flow found, need 1, found " + all.size());
+        try (StandAloneRunner runner = applicationContext.createBean(StandAloneRunner.class);) {
+            tenantService.createTenant(tenant);
+            runner.run();
+
+            List<FlowWithSource> loaded = repositoryLoader.load(tenant, file.toFile());
+            if (loaded.isEmpty()) {
+                throw new CommandLine.ParameterException(
+                    this.spec.commandLine(),
+                    "No valid flow was found in '%s'. The validation errors are reported in the logs above.".formatted(file)
+                );
+            }
+            if (loaded.size() > 1) {
+                throw new CommandLine.ParameterException(
+                    this.spec.commandLine(),
+                    "Found %d flows in '%s' but a test runs a single flow. Pass one flow file.".formatted(loaded.size(), file)
+                );
             }
 
-            var flow = all.getFirst();
+            var flow = loaded.getFirst();
             var createCommand = Create.of(flow.toFlowId()).withInputsFromReader((executionId) -> flowInputOutput.readExecutionInputs(flow, executionId, inputs));
             executionCommandQueue.emit(
                 createCommand
             );
             Execution terminated = await().atMost(Duration.ofHours(1)).until(
-                () -> executionRepository.findById(tenantService.getTenantId(tenantId), createCommand.executionId()).orElse(null),
+                () -> executionRepository.findById(tenant, createCommand.executionId()).orElse(null),
                 e -> e != null && e.getState().isTerminated()
             );
             stdOut("Successfully executed the flow with execution %s in state %s", terminated.getId(), terminated.getState().getCurrent());
@@ -120,14 +175,9 @@ public class FlowTestCommand extends AbstractApiCommand {
         } catch (IOException e) {
             throw new IllegalStateException(e);
         } finally {
-            applicationContext.getProperty("kestra.storage.local.base-path", Path.class)
-                .ifPresent(path ->
-                {
-                    try {
-                        FileUtils.deleteDirectory(path.toFile());
-                    } catch (IOException ignored) {
-                    }
-                });
+            // The directory this command generated, so the cleanup does not depend on the storage
+            // override having been the one that won.
+            FileUtils.deleteQuietly(TEMP_STORAGE.toFile());
         }
 
         return 0;

--- a/cli/src/test/java/io/kestra/cli/commands/flows/FlowTestCommandTest.java
+++ b/cli/src/test/java/io/kestra/cli/commands/flows/FlowTestCommandTest.java
@@ -2,32 +2,54 @@ package io.kestra.cli.commands.flows;
 
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
-import io.micronaut.configuration.picocli.PicocliRunner;
-import io.micronaut.context.ApplicationContext;
-import io.micronaut.context.env.Environment;
+import io.kestra.cli.Kestra;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@Disabled
 class FlowTestCommandTest {
     @Test
-    void run() {
+    void shouldRunTheFlowOnAnEphemeralDatabaseRatherThanTheConfiguredOne(@TempDir Path tempDir) throws Exception {
+        // Given a configuration describing a database this command must not use — and could not
+        // use, since nothing listens on that port. Keyed 'h2' to override the datasource the test
+        // environment declares: a second key would produce a second datasource, which no Kestra
+        // deployment supports.
+        Path config = Files.writeString(tempDir.resolve("kestra.yml"), """
+            datasources:
+              h2:
+                url: jdbc:postgresql://127.0.0.1:1/kestra
+                driverClassName: org.postgresql.Driver
+                username: kestra
+                password: k3str4
+            kestra:
+              repository:
+                type: postgres
+              queue:
+                type: postgres
+            """);
+
+        PrintStream originalOut = System.out;
         ByteArrayOutputStream out = new ByteArrayOutputStream();
         System.setOut(new PrintStream(out));
 
-        try (ApplicationContext ctx = ApplicationContext.run(Environment.CLI, Environment.TEST)) {
-            String[] args = {
-                "src/test/resources/flows/same/first.yaml"
-            };
-            Integer call = PicocliRunner.call(FlowTestCommand.class, ctx, args);
-
-            assertThat(call).isZero();
-            assertThat(out.toString()).contains("Successfully executed the flow with execution");
-            assertThat(out.toString()).contains("SUCCESS");
+        int exitCode;
+        try {
+            // When
+            exitCode = Kestra.runCli(new String[] {
+                "flow", "test", "src/test/resources/flows/same/first.yaml", "-c", config.toString()
+            });
+        } finally {
+            System.setOut(originalOut);
         }
+
+        // Then the flow ran, which it only can on a database of its own.
+        assertThat(exitCode).isZero();
+        assertThat(out.toString()).contains("Successfully executed the flow with execution");
+        assertThat(out.toString()).contains("SUCCESS");
     }
 }

--- a/jdbc/src/main/java/io/kestra/jdbc/EphemeralDatabase.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/EphemeralDatabase.java
@@ -1,0 +1,32 @@
+package io.kestra.jdbc;
+
+/**
+ * The contract for a command that runs against a throwaway database instead of the configured one.
+ * <p>
+ * A command opting in sets {@link #URL_PROPERTY} to an in-memory H2 URL. Every JDBC datasource is
+ * then repointed at that URL, and no pool is ever opened against the datasource the user configured
+ * — see {@code io.kestra.runner.memory.EphemeralDatasourceRewriter} and
+ * {@link LogJdbcDataSourceProvider}, the only two places in the codebase that build a connection
+ * pool.
+ */
+public final class EphemeralDatabase {
+    /**
+     * The in-memory H2 URL to run against; absent unless the command opted in. Always include
+     * {@code DB_CLOSE_DELAY=-1}, since H2 discards an in-memory database once the last connection
+     * to it closes.
+     */
+    public static final String URL_PROPERTY = "kestra.ephemeral-database.url";
+
+    /**
+     * Whether {@link #URL_PROPERTY} opts this run in, so that everything deciding on it agrees on
+     * what a blank value means.
+     *
+     * @param url the resolved {@link #URL_PROPERTY}, empty when unset.
+     */
+    public static boolean isEnabled(final String url) {
+        return url != null && !url.isBlank();
+    }
+
+    private EphemeralDatabase() {
+    }
+}

--- a/jdbc/src/main/java/io/kestra/jdbc/LogJdbcDataSourceProvider.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/LogJdbcDataSourceProvider.java
@@ -16,6 +16,7 @@ import io.kestra.core.contexts.configuration.RepositoryConfiguration;
 import io.kestra.core.exceptions.KestraRuntimeException;
 import io.kestra.core.repositories.log.LogsConfig;
 
+import io.micronaut.context.annotation.Value;
 import io.micronaut.core.annotation.Nullable;
 import jakarta.annotation.PreDestroy;
 import jakarta.inject.Singleton;
@@ -39,6 +40,7 @@ public class LogJdbcDataSourceProvider implements AutoCloseable {
     private final Settings jooqSettings;
     private final DataSource primaryDataSource;
     private final RepositoryConfiguration repositoryConfiguration;
+    private final boolean ephemeralDatabase;
 
     private boolean initialized;
     private HikariDataSource dedicatedDataSource;
@@ -49,15 +51,25 @@ public class LogJdbcDataSourceProvider implements AutoCloseable {
     public LogJdbcDataSourceProvider(final LogsConfig logsConfig,
         final Settings jooqSettings,
         @Nullable final DataSource primaryDataSource,
-        final RepositoryConfiguration repositoryConfiguration) {
+        final RepositoryConfiguration repositoryConfiguration,
+        @Value("${" + EphemeralDatabase.URL_PROPERTY + ":}") final String ephemeralDatabaseUrl) {
         this.logsConfig = logsConfig;
         this.jooqSettings = jooqSettings;
         this.primaryDataSource = primaryDataSource;
         this.repositoryConfiguration = repositoryConfiguration;
+        this.ephemeralDatabase = EphemeralDatabase.isEnabled(ephemeralDatabaseUrl);
     }
 
     private synchronized void ensureInitialized() {
         if (initialized) {
+            return;
+        }
+
+        // A dedicated log database is the one datasource an ephemeral run cannot repoint through
+        // configuration: overriding a property cannot remove it, and a blank URL would fail
+        // validation instead of disabling it. Keep the logs in the ephemeral database.
+        if (ephemeralDatabase) {
+            initialized = true;
             return;
         }
 

--- a/jdbc/src/test/java/io/kestra/jdbc/LogJdbcDataSourceProviderTest.java
+++ b/jdbc/src/test/java/io/kestra/jdbc/LogJdbcDataSourceProviderTest.java
@@ -16,11 +16,17 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 class LogJdbcDataSourceProviderTest {
 
     private static LogJdbcDataSourceProvider provider(Map<String, Object> logs, String repositoryType) {
+        return provider(logs, repositoryType, "");
+    }
+
+    private static LogJdbcDataSourceProvider provider(Map<String, Object> logs, String repositoryType,
+        String ephemeralDatabaseUrl) {
         return new LogJdbcDataSourceProvider(
             new LogsConfig(logs),
             new Settings(),
             null,
-            new RepositoryConfiguration(repositoryType)
+            new RepositoryConfiguration(repositoryType),
+            ephemeralDatabaseUrl
         );
     }
 
@@ -61,6 +67,28 @@ class LogJdbcDataSourceProviderTest {
             .hasMessageContaining("kestra.logs.postgres.url")
             .hasMessageContaining("kestra.logs.postgres.username")
             .hasMessageContaining("never inherited");
+    }
+
+    @Test
+    void shouldIgnoreADedicatedLogDatabaseWhenRunningOnAnEphemeralDatabase() {
+        // Given: a dedicated logs database, and a run that must not reach the configured
+        // infrastructure at all. Overriding a property cannot remove the configured url, so the
+        // provider has to ignore it rather than build a pool against it.
+        LogJdbcDataSourceProvider provider = provider(
+            Map.of(
+                "type", "postgres", "postgres", Map.of(
+                    "url", "jdbc:postgresql://postgres-logs:5432/kestra_logs",
+                    "username", "kestra"
+                )
+            ),
+            "postgres",
+            "jdbc:h2:mem:flow-test-1;DB_CLOSE_DELAY=-1"
+        );
+
+        // When-Then: the logs stay in the ephemeral database, alongside everything else
+        assertThat(provider.isDedicated()).isFalse();
+        assertThat(provider.dedicatedWrapper()).isNull();
+        assertThat(provider.table()).isEqualTo("logs");
     }
 
     @Test

--- a/repository-memory/src/main/java/io/kestra/runner/memory/EphemeralDatasourceRewriter.java
+++ b/repository-memory/src/main/java/io/kestra/runner/memory/EphemeralDatasourceRewriter.java
@@ -1,0 +1,63 @@
+package io.kestra.runner.memory;
+
+import java.util.Objects;
+
+import io.kestra.jdbc.EphemeralDatabase;
+
+import io.micronaut.configuration.jdbc.hikari.DatasourceConfiguration;
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.context.annotation.Value;
+import io.micronaut.context.event.BeanCreatedEvent;
+import io.micronaut.context.event.BeanCreatedEventListener;
+import io.micronaut.core.annotation.Order;
+import io.micronaut.core.order.Ordered;
+import jakarta.inject.Singleton;
+
+/**
+ * Repoints every datasource at the ephemeral in-memory database declared by
+ * {@link EphemeralDatabase#URL_PROPERTY}.
+ * <p>
+ * Micronaut turns each user-chosen {@code datasources.<name>} entry into an eagerly-initialized
+ * Hikari pool, and the names cannot be known by a command in advance, so a command cannot switch
+ * them off through configuration. Rewriting the configuration is what makes the ephemeral run
+ * possible: the pool is built from this bean by {@code DatasourceFactory}, which runs after the
+ * listener, so the configured database is never connected to.
+ */
+@Singleton
+@Order(Ordered.HIGHEST_PRECEDENCE)
+@Requires(property = EphemeralDatabase.URL_PROPERTY, pattern = ".+")
+public class EphemeralDatasourceRewriter implements BeanCreatedEventListener<DatasourceConfiguration> {
+    private static final String H2_DRIVER = "org.h2.Driver";
+
+    private final String url;
+
+    public EphemeralDatasourceRewriter(@Value("${" + EphemeralDatabase.URL_PROPERTY + "}") String url) {
+        this.url = Objects.requireNonNull(url);
+    }
+
+    @Override
+    public DatasourceConfiguration onCreated(BeanCreatedEvent<DatasourceConfiguration> event) {
+        DatasourceConfiguration configuration = event.getBean();
+
+        configuration.setUrl(url);
+        configuration.setDriverClassName(H2_DRIVER);
+        configuration.setUsername("sa");
+        configuration.setPassword("");
+
+        // HikariCP picks its connection source in the order dataSource, dataSourceClassName,
+        // jdbcUrl, then JNDI name, so the URL above only wins once the earlier ones are cleared.
+        configuration.setDataSourceClassName(null);
+        configuration.setJndiName(null);
+
+        // Whatever remains describes the database we just stopped pointing at: driver properties
+        // and an init statement are rejected outright by H2, and its schema and catalog do not
+        // exist in a database created empty a moment ago.
+        configuration.getDataSourceProperties().clear();
+        configuration.setConnectionInitSql(null);
+        configuration.setConnectionTestQuery(null);
+        configuration.setCatalog(null);
+        configuration.setSchema(null);
+
+        return configuration;
+    }
+}

--- a/repository-memory/src/test/java/io/kestra/runner/memory/EphemeralDatasourceRewriterTest.java
+++ b/repository-memory/src/test/java/io/kestra/runner/memory/EphemeralDatasourceRewriterTest.java
@@ -1,0 +1,52 @@
+package io.kestra.runner.memory;
+
+import org.junit.jupiter.api.Test;
+
+import io.micronaut.configuration.jdbc.hikari.DatasourceConfiguration;
+import io.micronaut.context.event.BeanCreatedEvent;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class EphemeralDatasourceRewriterTest {
+    private static final String EPHEMERAL_URL = "jdbc:h2:mem:flow-test-1;DB_CLOSE_DELAY=-1";
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void shouldLeaveNothingOfTheConfiguredDatabaseBehind() {
+        // Given a datasource describing a database elsewhere, through every field HikariCP would
+        // accept a connection source or connection settings from.
+        DatasourceConfiguration configured = new DatasourceConfiguration("postgres");
+        configured.setUrl("jdbc:postgresql://db.internal:5432/kestra");
+        configured.setUsername("kestra");
+        configured.setPassword("k3str4");
+        configured.setDataSourceClassName("org.postgresql.ds.PGSimpleDataSource");
+        configured.setJndiName("java:comp/env/jdbc/kestra");
+        configured.addDataSourceProperty("sslmode", "require");
+        configured.setConnectionInitSql("SET search_path TO kestra");
+        configured.setConnectionTestQuery("SELECT 1");
+        configured.setCatalog("kestra");
+        configured.setSchema("kestra");
+
+        BeanCreatedEvent<DatasourceConfiguration> event = mock(BeanCreatedEvent.class);
+        when(event.getBean()).thenReturn(configured);
+
+        // When
+        DatasourceConfiguration rewritten = new EphemeralDatasourceRewriter(EPHEMERAL_URL).onCreated(event);
+
+        // Then: asserted through the fields HikariCP copies out of the configuration, rather than
+        // the calculated getters, which cache a value derived before the rewrite.
+        assertThat(rewritten.getJdbcUrl()).isEqualTo(EPHEMERAL_URL);
+        assertThat(rewritten.getConfiguredDriverClassName()).isEqualTo("org.h2.Driver");
+        assertThat(rewritten.getConfiguredUsername()).isEqualTo("sa");
+        assertThat(rewritten.getConfiguredPassword()).isEmpty();
+        assertThat(rewritten.getDataSourceClassName()).isNull();
+        assertThat(rewritten.getDataSourceJNDI()).isNull();
+        assertThat(rewritten.getDataSourceProperties()).isEmpty();
+        assertThat(rewritten.getConnectionInitSql()).isNull();
+        assertThat(rewritten.getConnectionTestQuery()).isNull();
+        assertThat(rewritten.getCatalog()).isNull();
+        assertThat(rewritten.getSchema()).isNull();
+    }
+}


### PR DESCRIPTION
### 🔗 Related Issue

Closes https://github.com/kestra-io/kestra-ee/issues/5869.

### ✨ Description

`kestra flow test` does not start, and what it reached before failing was the database the instance is configured with.

It forced `kestra.repository.type=memory`, which has only been an alias enabling the H2 beans since the in-memory runner was removed in b15d2cf409, and forced no datasource to go with it. `DatasourceProvider` supplies an in-memory one only under `@Requires(missingProperty = "datasources")`, so a single `datasources.postgres.url` key disables it and any configured instance left the H2 beans — and the H2 baseline migration, which does run — bound to its own datasource. That is where the reported error comes from: the H2 path binds the flow JSON as a `character varying` where Postgres expects `jsonb`. The command also declared no server type, so the system worker that `StandAloneRunner` resolves unconditionally was never registered and it threw `NoSuchBeanException` before running anything.

A test runs a flow read from a file, so it should never persist to the instance. It now gets a database of its own: the command declares a server type and an ephemeral H2 URL, and a `BeanCreatedEventListener<DatasourceConfiguration>` repoints every datasource at that URL before `DatasourceFactory` builds its pool, so the configured database is never connected to. Property overrides cannot do this on their own, because datasource names are user-chosen (`@EachProperty`) — the same constraint that `WorkerApplicationContext` already documents.

Three further things had to follow for the run to be self-contained:

- the log store builds a pool of its own from `kestra.logs.<type>.url`, which no override can remove, so it now stays in the ephemeral database;
- the worker is pinned to the controller started here, since on a distributed configuration its discovery would otherwise resolve the real controller and it would pick up production work;
- external plugins are loaded, because the flow runs in this JVM rather than on a server — inherited `false` from `AbstractApiCommand` meant no non-core task could run.

Also in passing: the flow is read back from `LocalFlowRepositoryLoader.load`'s return value instead of from the whole repository (which assumed it was empty and reported a bad flow file as `Too many flow found, need 1, found 0`), and the temporary storage directory deleted afterwards is the one this command generated rather than whatever the storage property resolves to.

Evidence: `FlowTestCommandTest` drives the real CLI against a configuration whose datasource points at a closed port. On `develop` it fails with `Failed to initialize pool: Connection to 127.0.0.1:1 refused`; with this change the flow runs to `SUCCESS`, which it can only do on a database of its own.

### 🛠️ Backend Checklist

- [x] Code compiles and tests pass for the touched modules (`./gradlew :cli:test :jdbc:test :repository-memory:test`)
- [x] New behavior is covered by unit or integration tests

### 📝 Additional Notes

The issue is filed against `kestra-ee`, but nothing here is EE code — `cli-ee` only adds subcommands and the `ee` environment. Worth transferring to this repository.

`EphemeralDatasourceRewriter` sits in `repository-memory` rather than `jdbc`: `jdbc` has H2 only as a test dependency, while `repository-memory` already carries both `micronaut-jdbc-hikari` and the H2 driver, and its `DatasourceProvider` already hardcodes `org.h2.Driver`.

Deliberately not done here:

- **EE without a licence key.** `LicenseService.getFeatureLimit` dereferences a null licence, and declaring a server type un-masks that path via `EEGrpcConnectControllerService`. Filed as kestra-io/kestra-ee#10690; a licensed EE instance is unaffected.
- **Two or more `datasources.*` entries.** Every configuration, chart and test in the repo declares exactly one, and more than one already fails at startup with `NonUniqueBeanException` since nothing is `@Primary` — so the rewriter is neutral there rather than a fix.
- **`kestra.jdbc.tables`.** An instance that renamed its tables keeps those names, while the ephemeral schema is created from `baseline-h2.sql` with the defaults. Known unsupported case.
- **OSS's “tenant id can only be 'main'” check on `--tenant`.** The tenant is resolved with `getTenantIdAndAllowEETenants` and created up front, because EE's `getTenantId` requires the row to already exist and an ephemeral database starts empty. The side effect is that OSS no longer rejects `--tenant something-else`; it runs the flow under that id in the throwaway database. Preserving both invariants wants a dedicated method on `TenantIdSelectorService`, which touches EE semantics I would rather agree on first.
- **`kestra.plugins.management.localRepositoryPath`.** It defaults under the storage base path, which is now a temp directory, so an auto-install during a test is not cached between runs.

A flow reading from the instance's KV store or internal storage cannot be tested this way, which is inherent to running on a throwaway database.

### 🤖 AI Authors

Why did the cat refuse to use the production database? It already had nine ephemeral ones, and it wasn't about to let anyone `DROP` it. 🐱
