### PR TITLE
refactor(iam): name no-ACL repository reads *WithoutAcl and split findLatestForStates

### DIFF
--- a/core/src/main/java/io/kestra/core/repositories/ExecutionRepositoryInterface.java
+++ b/core/src/main/java/io/kestra/core/repositories/ExecutionRepositoryInterface.java
@@ -65,6 +65,15 @@ public interface ExecutionRepositoryInterface extends QueryBuilderInterface<Exec
      */
     Optional<Execution> findLatestForStates(String tenantId, String namespace, String flowId, List<State.Type> states);
 
+    /**
+     * Same as {@link #findLatestForStates(String, String, String, List)} but without applying the caller's
+     * namespace ACL, for trusted callers that gate access themselves (e.g. a public App rendered anonymously).
+     * Defaults to the ACL-aware variant for backends that enforce no ACL of their own.
+     */
+    default Optional<Execution> findLatestForStatesWithoutAcl(String tenantId, String namespace, String flowId, List<State.Type> states) {
+        return findLatestForStates(tenantId, namespace, flowId, states);
+    }
+
     ArrayListTotal<Execution> find(
         Pageable pageable,
         @Nullable String tenantId,

--- a/core/src/main/java/io/kestra/core/repositories/ExecutionRepositoryInterface.java
+++ b/core/src/main/java/io/kestra/core/repositories/ExecutionRepositoryInterface.java
@@ -68,11 +68,8 @@ public interface ExecutionRepositoryInterface extends QueryBuilderInterface<Exec
     /**
      * Same as {@link #findLatestForStates(String, String, String, List)} but without applying the caller's
      * namespace ACL, for trusted callers that gate access themselves (e.g. a public App rendered anonymously).
-     * Defaults to the ACL-aware variant for backends that enforce no ACL of their own.
      */
-    default Optional<Execution> findLatestForStatesWithoutAcl(String tenantId, String namespace, String flowId, List<State.Type> states) {
-        return findLatestForStates(tenantId, namespace, flowId, states);
-    }
+    Optional<Execution> findLatestForStatesWithoutAcl(String tenantId, String namespace, String flowId, List<State.Type> states);
 
     ArrayListTotal<Execution> find(
         Pageable pageable,

--- a/core/src/main/java/io/kestra/core/repositories/TriggerRepositoryInterface.java
+++ b/core/src/main/java/io/kestra/core/repositories/TriggerRepositoryInterface.java
@@ -23,7 +23,7 @@ public interface TriggerRepositoryInterface extends QueryBuilderInterface<Trigge
      * @param trigger the identifier.
      * @return an optional {@link TriggerState}.
      */
-    Optional<TriggerState> findById(TriggerId trigger);
+    Optional<TriggerState> findByIdWithoutAcl(TriggerId trigger);
 
     /**
      * Finds all trigger states for the given tenant id

--- a/core/src/main/java/io/kestra/core/scheduler/store/TriggerStateStore.java
+++ b/core/src/main/java/io/kestra/core/scheduler/store/TriggerStateStore.java
@@ -44,7 +44,7 @@ public interface TriggerStateStore {
      * @param triggerId The trigger identifier.
      * @return an optional {@link TriggerState}
      */
-    Optional<TriggerState> findById(TriggerId triggerId);
+    Optional<TriggerState> findByIdWithoutAcl(TriggerId triggerId);
 
     /**
      * Saves the given {@link TriggerState}.

--- a/core/src/test/java/io/kestra/core/repositories/AbstractTriggerRepositoryTest.java
+++ b/core/src/test/java/io/kestra/core/repositories/AbstractTriggerRepositoryTest.java
@@ -139,7 +139,7 @@ public abstract class AbstractTriggerRepositoryTest {
         TriggerState.TriggerStateBuilder builder = trigger(tenant);
 
         // WHEN
-        Optional<TriggerState> result = triggerStateStore.findById(builder.build());
+        Optional<TriggerState> result = triggerStateStore.findByIdWithoutAcl(builder.build());
 
         // THEN
         assertThat(result).isEmpty();
@@ -153,7 +153,7 @@ public abstract class AbstractTriggerRepositoryTest {
         triggerStateStore.save(state);
 
         // WHEN
-        Optional<TriggerState> result = triggerStateStore.findById(state);
+        Optional<TriggerState> result = triggerStateStore.findByIdWithoutAcl(state);
 
         // THEN
         assertThat(result).isNotEmpty();
@@ -174,7 +174,7 @@ public abstract class AbstractTriggerRepositoryTest {
         triggerStateStore.save(updated);
 
         // THEN
-        Optional<TriggerState> result = triggerStateStore.findById(updated);
+        Optional<TriggerState> result = triggerStateStore.findByIdWithoutAcl(updated);
         assertThat(result).isNotEmpty();
         assertThat(TriggerId.of(result.get())).isEqualTo(TriggerId.of(updated));
         assertThat(result.get().getUpdatedAt()).isEqualTo(updatedAt);

--- a/executor/src/main/java/io/kestra/executor/ExecutionStateStore.java
+++ b/executor/src/main/java/io/kestra/executor/ExecutionStateStore.java
@@ -24,5 +24,5 @@ public interface ExecutionStateStore {
      * Find an execution by its id.
      * WARNING: it bypasses ACL and tenant checks.
      */
-    Execution findById(String id);
+    Execution findByIdWithoutAcl(String id);
 }

--- a/executor/src/main/java/io/kestra/executor/handler/ExecutionCommandMessageHandler.java
+++ b/executor/src/main/java/io/kestra/executor/handler/ExecutionCommandMessageHandler.java
@@ -80,7 +80,7 @@ public class ExecutionCommandMessageHandler implements ExecutorMessageHandler<Ex
         // For existing executions, check kill switch before taking the lock.
         EvaluationType evaluationType = killSwitchService.evaluate(message);
         if (evaluationType != EvaluationType.PASS) {
-            var execution = executionStateStore.findById(message.executionId());
+            var execution = executionStateStore.findByIdWithoutAcl(message.executionId());
             if (execution != null && evaluationType.isKillSwitched(execution)) {
                 killSwitchActionService.handle(evaluationType, execution.getTenantId(), execution.getId());
                 return Optional.empty();
@@ -172,7 +172,7 @@ public class ExecutionCommandMessageHandler implements ExecutorMessageHandler<Ex
         AsyncOperationProcessedEvent.Outcome outcome = AsyncOperationProcessedEvent.Outcome.SUCCEEDED;
         String error = null;
         try {
-            var raw = executionStateStore.findById(command.sourceExecutionId());
+            var raw = executionStateStore.findByIdWithoutAcl(command.sourceExecutionId());
             if (raw == null) {
                 throw new IllegalStateException("Source execution not found: " + command.sourceExecutionId());
             }

--- a/executor/src/main/java/io/kestra/executor/handler/ExecutionEventMessageHandler.java
+++ b/executor/src/main/java/io/kestra/executor/handler/ExecutionEventMessageHandler.java
@@ -114,7 +114,7 @@ public class ExecutionEventMessageHandler implements ExecutorMessageHandler<Exec
     public Optional<ExecutorContext> handle(ExecutionEvent message) {
         EvaluationType evaluationType = killSwitchService.evaluate(message);
         if (evaluationType != EvaluationType.PASS) {
-            var execution = executionStateStore.findById(message.executionId());
+            var execution = executionStateStore.findByIdWithoutAcl(message.executionId());
             if (execution != null && evaluationType.isKillSwitched(execution)) {
                 killSwitchActionService.handle(evaluationType, execution.getTenantId(), execution.getId());
                 return Optional.empty();

--- a/executor/src/main/java/io/kestra/executor/handler/WorkerTaskResultMessageHandler.java
+++ b/executor/src/main/java/io/kestra/executor/handler/WorkerTaskResultMessageHandler.java
@@ -54,7 +54,7 @@ public class WorkerTaskResultMessageHandler implements ExecutorMessageHandler<Wo
     public Optional<ExecutorContext> handle(WorkerTaskResult message) {
         EvaluationType evaluationType = killSwitchService.evaluate(message.getTaskRun());
         if (evaluationType != EvaluationType.PASS) {
-            var execution = executionStateStore.findById(message.getTaskRun().getExecutionId());
+            var execution = executionStateStore.findByIdWithoutAcl(message.getTaskRun().getExecutionId());
             if (execution != null && evaluationType.isKillSwitched(execution)) {
                 killSwitchActionService.handle(evaluationType, execution.getTenantId(), execution.getId());
                 return Optional.empty();

--- a/executor/src/test/java/io/kestra/executor/AbstractExecutionStateStoreTest.java
+++ b/executor/src/test/java/io/kestra/executor/AbstractExecutionStateStoreTest.java
@@ -46,7 +46,7 @@ public abstract class AbstractExecutionStateStoreTest {
         assertThat(created).isNotNull();
         assertThat(created.getId()).isEqualTo(execution.getId());
 
-        Execution found = executionStateStore.findById(execution.getId());
+        Execution found = executionStateStore.findByIdWithoutAcl(execution.getId());
         assertThat(found).isNotNull();
         assertThat(found.getId()).isEqualTo(execution.getId());
         assertThat(found.getNamespace()).isEqualTo(flow.getNamespace());
@@ -56,7 +56,7 @@ public abstract class AbstractExecutionStateStoreTest {
     @Test
     void shouldReturnNullWhenExecutionNotFound() {
         // When
-        Execution found = executionStateStore.findById(IdUtils.create());
+        Execution found = executionStateStore.findByIdWithoutAcl(IdUtils.create());
 
         // Then
         assertThat(found).isNull();
@@ -89,7 +89,7 @@ public abstract class AbstractExecutionStateStoreTest {
         assertThat(result).isPresent();
         assertThat(result.get().getExecution().getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
 
-        Execution persisted = executionStateStore.findById(execution.getId());
+        Execution persisted = executionStateStore.findByIdWithoutAcl(execution.getId());
         assertThat(persisted.getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
     }
 

--- a/executor/src/test/java/io/kestra/executor/handler/ExecutionCommandMessageHandlerTest.java
+++ b/executor/src/test/java/io/kestra/executor/handler/ExecutionCommandMessageHandlerTest.java
@@ -213,7 +213,7 @@ class ExecutionCommandMessageHandlerTest {
         when(command.executionId()).thenReturn("exec-1");
         var execution = mockExecution("exec-1", "tenant", "ns", "flow-id");
         when(killSwitchService.evaluate(command)).thenReturn(EvaluationType.IGNORE);
-        when(executionStateStore.findById("exec-1")).thenReturn(execution);
+        when(executionStateStore.findByIdWithoutAcl("exec-1")).thenReturn(execution);
 
         // When
         Optional<ExecutorContext> result = handler.handle(command);
@@ -231,7 +231,7 @@ class ExecutionCommandMessageHandlerTest {
         var execution = mockExecution("exec-1", "tenant", "ns", "flow-id");
         when(execution.getState().getCurrent()).thenReturn(State.Type.RUNNING);
         when(killSwitchService.evaluate(command)).thenReturn(EvaluationType.KILL);
-        when(executionStateStore.findById("exec-1")).thenReturn(execution);
+        when(executionStateStore.findByIdWithoutAcl("exec-1")).thenReturn(execution);
 
         // When
         Optional<ExecutorContext> result = handler.handle(command);
@@ -249,7 +249,7 @@ class ExecutionCommandMessageHandlerTest {
         var execution = mockExecution("exec-1", "tenant", "ns", "flow-id");
         when(execution.getState().getCurrent()).thenReturn(State.Type.RUNNING);
         when(killSwitchService.evaluate(command)).thenReturn(EvaluationType.CANCEL);
-        when(executionStateStore.findById("exec-1")).thenReturn(execution);
+        when(executionStateStore.findByIdWithoutAcl("exec-1")).thenReturn(execution);
 
         // When
         Optional<ExecutorContext> result = handler.handle(command);
@@ -267,7 +267,7 @@ class ExecutionCommandMessageHandlerTest {
         var flow = mock(FlowWithSource.class);
         var newExecution = mockExecution("new-exec-id", "tenant", "ns", "flow-id");
         var context = mock(ExecutorContext.class);
-        when(executionStateStore.findById("source-exec-id")).thenReturn(sourceExecution);
+        when(executionStateStore.findByIdWithoutAcl("source-exec-id")).thenReturn(sourceExecution);
         when(flowMetaStore.findByExecutionForRuntime(any())).thenReturn(Optional.of(flow));
         when(executionService.replay(any(), eq(flow), isNull(), isNull(), any(), eq(true), eq("new-exec-id")))
             .thenReturn(newExecution);
@@ -284,7 +284,7 @@ class ExecutionCommandMessageHandlerTest {
     @Test
     void replayShouldEmitFailedOutcomeWhenSourceExecutionNotFound() {
         // Given — source execution does not exist
-        when(executionStateStore.findById("source-exec-id")).thenReturn(null);
+        when(executionStateStore.findByIdWithoutAcl("source-exec-id")).thenReturn(null);
 
         // When — must not throw
         assertThatCode(() -> handler.handle(replayCommand)).doesNotThrowAnyException();
@@ -296,7 +296,7 @@ class ExecutionCommandMessageHandlerTest {
     @Test
     void replayShouldEmitFailedOutcomeWhenFlowNotFound() {
         // Given
-        when(executionStateStore.findById("source-exec-id")).thenReturn(sourceExecution);
+        when(executionStateStore.findByIdWithoutAcl("source-exec-id")).thenReturn(sourceExecution);
         when(flowMetaStore.findByExecutionForRuntime(any())).thenReturn(Optional.empty());
 
         // When — must not throw
@@ -311,7 +311,7 @@ class ExecutionCommandMessageHandlerTest {
         // Given
         var flow = mock(FlowWithSource.class);
         var newExecution = mockExecution("new-exec-id", "tenant", "ns", "flow-id");
-        when(executionStateStore.findById("source-exec-id")).thenReturn(sourceExecution);
+        when(executionStateStore.findByIdWithoutAcl("source-exec-id")).thenReturn(sourceExecution);
         when(flowMetaStore.findByExecutionForRuntime(any())).thenReturn(Optional.of(flow));
         when(executionService.replay(any(), any(), any(), any(), any(), eq(true), eq("new-exec-id")))
             .thenReturn(newExecution);
@@ -331,7 +331,7 @@ class ExecutionCommandMessageHandlerTest {
         var newExecution = mockExecution("new-exec-id", "tenant", "ns", "flow-id");
         when(newExecution.getState().isTerminated()).thenReturn(true);
         when(newExecution.getState().getCurrent()).thenReturn(State.Type.KILLED);
-        when(executionStateStore.findById("source-exec-id")).thenReturn(sourceExecution);
+        when(executionStateStore.findByIdWithoutAcl("source-exec-id")).thenReturn(sourceExecution);
         when(flowMetaStore.findByExecutionForRuntime(any())).thenReturn(Optional.of(flow));
         when(executionService.replay(any(), eq(flow), isNull(), isNull(), any(), eq(true), eq("new-exec-id")))
             .thenReturn(newExecution);
@@ -355,7 +355,7 @@ class ExecutionCommandMessageHandlerTest {
         // Given
         var flow = mock(FlowWithSource.class);
         var newExecution = mockExecution("new-exec-id", "tenant", "ns", "flow-id");
-        when(executionStateStore.findById("source-exec-id")).thenReturn(sourceExecution);
+        when(executionStateStore.findByIdWithoutAcl("source-exec-id")).thenReturn(sourceExecution);
         when(flowMetaStore.findByExecutionForRuntime(any())).thenReturn(Optional.of(flow));
         when(executionService.replay(any(), eq(flow), isNull(), isNull(), any(), eq(true), eq("new-exec-id")))
             .thenReturn(newExecution);
@@ -378,7 +378,7 @@ class ExecutionCommandMessageHandlerTest {
         var flow = mock(FlowWithSource.class);
         var newExecution = mockExecution("new-exec-id", "tenant", "ns", "flow-id");
         var context = mock(ExecutorContext.class);
-        when(executionStateStore.findById("source-exec-id")).thenReturn(sourceExecution);
+        when(executionStateStore.findByIdWithoutAcl("source-exec-id")).thenReturn(sourceExecution);
         when(flowMetaStore.findByIdForRuntime("tenant", "ns", "flow-id", Optional.of(3))).thenReturn(Optional.of(ProcessedFlow.of(flow)));
         when(executionService.replay(any(), eq(flow), isNull(), eq(3), any(), eq(true), eq("new-exec-id")))
             .thenReturn(newExecution);

--- a/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcExecutionRepository.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcExecutionRepository.java
@@ -121,6 +121,14 @@ public abstract class AbstractJdbcExecutionRepository extends AbstractJdbcCrudRe
     }
 
     @Override
+    public Optional<Execution> findLatestForStatesWithoutAcl(String tenantId, String namespace, String flowId, List<State.Type> states) {
+        var condition = field("namespace").eq(namespace)
+            .and(field("flow_id").eq(flowId))
+            .and(this.statesFilter(states));
+        return findOne(this.defaultFilterWithNoACL(tenantId), condition, field("start_date").desc());
+    }
+
+    @Override
     public List<String> findDistinctFieldValues(String tenantId, QueryFilter.Field field, List<QueryFilter> filters, Pageable pageable) {
         return findDistinctFieldValues(tenantId, field, filters, pageable, QueryFilter.Resource.EXECUTION);
     }
@@ -136,7 +144,7 @@ public abstract class AbstractJdbcExecutionRepository extends AbstractJdbcCrudRe
     }
 
     @Override
-    public Execution findById(String id) {
+    public Execution findByIdWithoutAcl(String id) {
         return findOne(DSL.noCondition(), KEY_FIELD.eq(id)).orElse(null);
     }
 

--- a/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcTriggerRepository.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcTriggerRepository.java
@@ -77,7 +77,7 @@ public abstract class AbstractJdbcTriggerRepository extends AbstractJdbcCrudRepo
     }
 
     @Override
-    public Optional<TriggerState> findById(TriggerId trigger) {
+    public Optional<TriggerState> findByIdWithoutAcl(TriggerId trigger) {
         return findOne(DSL.noCondition(), KEY_FIELD.eq(trigger.uid()));
     }
 

--- a/scheduler/src/main/java/io/kestra/scheduler/TriggerEventHandler.java
+++ b/scheduler/src/main/java/io/kestra/scheduler/TriggerEventHandler.java
@@ -331,7 +331,7 @@ public class TriggerEventHandler {
      * @param event the event.
      */
     void onTriggerExecutionTerminated(Clock clock, TriggerExecutionTerminated event) {
-        Optional<TriggerState> maybeState = triggerStateStore.findById(event.id());
+        Optional<TriggerState> maybeState = triggerStateStore.findByIdWithoutAcl(event.id());
         if (maybeState.isEmpty()) {
             Logs.logTrigger(event.id(), Level.WARN, "Cannot process event {}. Cause: Trigger state not found.", event.type());
             return;
@@ -436,7 +436,7 @@ public class TriggerEventHandler {
             // The trigger was deleted while its worker job was in flight: kill the instance
             // the worker just started. Only do so when the state is truly missing, not when
             // the event was de-duplicated.
-            if (triggerStateStore.findById(event.id()).isEmpty()) {
+            if (triggerStateStore.findByIdWithoutAcl(event.id()).isEmpty()) {
                 sendExecutionKilled(event.id());
             }
             return;
@@ -463,7 +463,7 @@ public class TriggerEventHandler {
      * @param event the event.
      */
     void onTriggerWorkerLost(Clock clock, TriggerWorkerLost event) {
-        triggerStateStore.findById(event.id()).ifPresent(state ->
+        triggerStateStore.findByIdWithoutAcl(event.id()).ifPresent(state ->
         {
             if (state.getWorkerId() != null && !state.getWorkerId().equals(event.workerUid())) {
                 // The trigger is already held by another worker.
@@ -541,7 +541,7 @@ public class TriggerEventHandler {
      * @param event the event.
      */
     void onTriggerDeleted(TriggerDeleted event) {
-        triggerStateStore.findById(event.id()).ifPresent(state ->
+        triggerStateStore.findByIdWithoutAcl(event.id()).ifPresent(state ->
         {
             triggerStateStore.delete(event.id());
             maySendExecutionKilled(state);
@@ -634,7 +634,7 @@ public class TriggerEventHandler {
     }
 
     private Optional<TriggerState> findTriggerState(final TriggerEvent event) {
-        Optional<TriggerState> state = triggerStateStore.findById(event.id());
+        Optional<TriggerState> state = triggerStateStore.findByIdWithoutAcl(event.id());
         if (state.isEmpty()) {
             Logs.logTrigger(event.id(), Level.WARN, "Cannot process event {}. Cause: Trigger state not found.", event.type());
             return Optional.empty();

--- a/scheduler/src/main/java/io/kestra/scheduler/stores/CachedTriggerStateStore.java
+++ b/scheduler/src/main/java/io/kestra/scheduler/stores/CachedTriggerStateStore.java
@@ -84,7 +84,7 @@ public class CachedTriggerStateStore implements TriggerStateStore {
      * {@inheritDoc}
      */
     @Override
-    public Optional<TriggerState> findById(TriggerId triggerId) {
+    public Optional<TriggerState> findByIdWithoutAcl(TriggerId triggerId) {
         int vnode = VNodes.computeVNodeFromTrigger(triggerId, schedulerConfiguration.vnodes());
         Cache<String, TriggerState> cache = partitionedCache.get(vnode);
 
@@ -95,7 +95,7 @@ public class CachedTriggerStateStore implements TriggerStateStore {
             }
         }
 
-        Optional<TriggerState> state = delegate.findById(triggerId);
+        Optional<TriggerState> state = delegate.findByIdWithoutAcl(triggerId);
         state.ifPresent(s ->
         {
             partitionedCache

--- a/scheduler/src/test/java/io/kestra/scheduler/TriggerEventHandlerTest.java
+++ b/scheduler/src/test/java/io/kestra/scheduler/TriggerEventHandlerTest.java
@@ -1040,7 +1040,7 @@ class TriggerEventHandlerTest {
         handler.handle(clock, TEST_VNODE, event);
 
         // THEN: first evaluation is AT start, not the next minute
-        Optional<TriggerState> updated = triggerStateStore.findById(triggerId);
+        Optional<TriggerState> updated = triggerStateStore.findByIdWithoutAcl(triggerId);
         assertThat(updated).isPresent();
         assertThat(updated.get().getBackfill()).isNotNull();
         assertThat(updated.get().getNextEvaluationDate()).isEqualTo(start.toInstant());
@@ -1062,7 +1062,7 @@ class TriggerEventHandlerTest {
         handler.handle(clock, TEST_VNODE, event);
 
         // THEN: 12:00 is before start, so first evaluation is 12:01
-        Optional<TriggerState> updated = triggerStateStore.findById(triggerId);
+        Optional<TriggerState> updated = triggerStateStore.findByIdWithoutAcl(triggerId);
         assertThat(updated).isPresent();
         assertThat(updated.get().getBackfill()).isNotNull();
         assertThat(updated.get().getNextEvaluationDate()).isEqualTo(Instant.parse("2024-06-15T12:01:00Z"));
@@ -1082,7 +1082,7 @@ class TriggerEventHandlerTest {
         handler.handle(clock, TEST_VNODE, event);
 
         // THEN: the occurrence at start/end is scheduled, backfill is not cleared
-        Optional<TriggerState> updated = triggerStateStore.findById(triggerId);
+        Optional<TriggerState> updated = triggerStateStore.findByIdWithoutAcl(triggerId);
         assertThat(updated).isPresent();
         assertThat(updated.get().getBackfill()).isNotNull();
         assertThat(updated.get().getNextEvaluationDate()).isEqualTo(startAndEnd.toInstant());
@@ -1250,7 +1250,7 @@ class TriggerEventHandlerTest {
         assertThatThrownBy(() -> handler.handle(CLOCK, TEST_VNODE, event))
             .isInstanceOf(ConflictException.class);
 
-        Optional<TriggerState> updated = triggerStateStore.findById(triggerId);
+        Optional<TriggerState> updated = triggerStateStore.findByIdWithoutAcl(triggerId);
         assertThat(updated).get().extracting(s -> s.getBackfill().getPreviousNextExecutionDate()).isEqualTo(liveNextEvaluationDate);
     }
 

--- a/scheduler/src/test/java/io/kestra/scheduler/TriggerEventHandlerTest.java
+++ b/scheduler/src/test/java/io/kestra/scheduler/TriggerEventHandlerTest.java
@@ -119,7 +119,7 @@ class TriggerEventHandlerTest {
         handler.handle(CLOCK, TEST_VNODE, event);
 
         // THEN
-        Optional<TriggerState> saved = triggerStateStore.findById(triggerId);
+        Optional<TriggerState> saved = triggerStateStore.findByIdWithoutAcl(triggerId);
         assertThat(saved).isPresent();
         assertThat(TriggerId.of(saved.get())).isEqualTo(triggerId);
         assertThat(saved.get().getLastEventId()).isNotNull();
@@ -136,7 +136,7 @@ class TriggerEventHandlerTest {
         handler.handle(CLOCK, TEST_VNODE, event);
 
         // THEN
-        Optional<TriggerState> saved = triggerStateStore.findById(triggerId);
+        Optional<TriggerState> saved = triggerStateStore.findByIdWithoutAcl(triggerId);
         assertThat(saved).isEmpty();
     }
 
@@ -151,7 +151,7 @@ class TriggerEventHandlerTest {
         handler.handle(CLOCK, TEST_VNODE, event);
 
         // THEN
-        assertThat(triggerStateStore.findById(triggerId)).isEmpty();
+        assertThat(triggerStateStore.findByIdWithoutAcl(triggerId)).isEmpty();
         Mockito.verify(executionKilledQueue, Mockito.never()).emit(Mockito.any(ExecutionKilled.class));
     }
 
@@ -166,7 +166,7 @@ class TriggerEventHandlerTest {
         handler.handle(CLOCK, TEST_VNODE, event);
 
         // THEN
-        assertThat(triggerStateStore.findById(triggerId)).isEmpty();
+        assertThat(triggerStateStore.findByIdWithoutAcl(triggerId)).isEmpty();
         Mockito.verify(executionKilledQueue, Mockito.only()).emit(Mockito.any(ExecutionKilled.class));
     }
 
@@ -187,7 +187,7 @@ class TriggerEventHandlerTest {
         handler.handle(CLOCK, TEST_VNODE, event);
 
         // THEN
-        Optional<TriggerState> updated = triggerStateStore.findById(triggerId);
+        Optional<TriggerState> updated = triggerStateStore.findByIdWithoutAcl(triggerId);
         assertThat(updated).isPresent();
         assertThat(updated.get().isDisabled()).isTrue();
         assertThat(updated.get().getUpdatedAt()).isAfter(triggerState.getUpdatedAt());
@@ -207,7 +207,7 @@ class TriggerEventHandlerTest {
         handler.handle(CLOCK, TEST_VNODE, event);
 
         // THEN
-        Optional<TriggerState> updated = triggerStateStore.findById(triggerId);
+        Optional<TriggerState> updated = triggerStateStore.findByIdWithoutAcl(triggerId);
         assertThat(updated).isPresent();
         assertThat(updated.get().getNextEvaluationDate()).isAfter(staleNextEvaluationDate.toInstant());
         assertThat(updated.get().getLastEventId()).isEqualTo(event.eventId());
@@ -226,7 +226,7 @@ class TriggerEventHandlerTest {
         handler.handle(CLOCK, TEST_VNODE, event);
 
         // THEN
-        Optional<TriggerState> after = triggerStateStore.findById(triggerId);
+        Optional<TriggerState> after = triggerStateStore.findByIdWithoutAcl(triggerId);
         assertThat(after).isPresent();
         assertThat(after.get().getNextEvaluationDate()).isEqualTo(initialNextEvaluationDate.toInstant());
         assertThat(after.get().getUpdatedAt()).isEqualTo(initial.getUpdatedAt());
@@ -244,7 +244,7 @@ class TriggerEventHandlerTest {
         handler.handle(CLOCK, TEST_VNODE, event);
 
         // THEN
-        Optional<TriggerState> updated = triggerStateStore.findById(triggerId);
+        Optional<TriggerState> updated = triggerStateStore.findByIdWithoutAcl(triggerId);
         assertThat(updated).isPresent();
         assertThat(updated.get().isLocked()).isFalse();
         assertThat(updated.get().getUpdatedAt()).isAfter(triggerState.getUpdatedAt());
@@ -266,7 +266,7 @@ class TriggerEventHandlerTest {
         handler.handle(CLOCK, TEST_VNODE, event);
 
         // THEN
-        Optional<TriggerState> updated = triggerStateStore.findById(triggerId);
+        Optional<TriggerState> updated = triggerStateStore.findByIdWithoutAcl(triggerId);
         assertThat(updated).isPresent();
         assertThat(updated.get().isLocked()).isFalse();
         assertThat(updated.get().getNextEvaluationDate()).isNotNull();
@@ -285,7 +285,7 @@ class TriggerEventHandlerTest {
         handler.handle(CLOCK, TEST_VNODE, event);
 
         // THEN
-        Optional<TriggerState> updated = triggerStateStore.findById(triggerId);
+        Optional<TriggerState> updated = triggerStateStore.findByIdWithoutAcl(triggerId);
         assertThat(updated).isPresent();
         assertThat(updated.get().isDisabled()).isTrue();
         assertThat(updated.get().getUpdatedAt()).isAfter(triggerState.getUpdatedAt());
@@ -305,7 +305,7 @@ class TriggerEventHandlerTest {
         handler.handle(CLOCK, TEST_VNODE, event);
 
         // THEN
-        Optional<TriggerState> updated = triggerStateStore.findById(triggerId);
+        Optional<TriggerState> updated = triggerStateStore.findByIdWithoutAcl(triggerId);
         assertThat(updated).isPresent();
         assertThat(updated.get().isDisabled()).isFalse();
         assertThat(updated.get().getUpdatedAt()).isAfter(triggerState.getUpdatedAt());
@@ -331,7 +331,7 @@ class TriggerEventHandlerTest {
         handler.handle(CLOCK, TEST_VNODE, event);
 
         // THEN: the next evaluation date is in the future, no missed schedule is replayed
-        Optional<TriggerState> updated = triggerStateStore.findById(triggerId);
+        Optional<TriggerState> updated = triggerStateStore.findByIdWithoutAcl(triggerId);
         assertThat(updated).isPresent();
         assertThat(updated.get().isDisabled()).isFalse();
         assertThat(updated.get().getNextEvaluationDate()).isAfter(beforeHandler);
@@ -354,7 +354,7 @@ class TriggerEventHandlerTest {
         handler.handle(CLOCK, TEST_VNODE, event);
 
         // THEN: evaluatedAt is advanced so the startup recovery cannot resurrect the skipped schedules
-        Optional<TriggerState> updated = triggerStateStore.findById(triggerId);
+        Optional<TriggerState> updated = triggerStateStore.findByIdWithoutAcl(triggerId);
         assertThat(updated).isPresent();
         assertThat(updated.get().getEvaluatedAt()).isAfter(evaluatedAt.toInstant());
         assertThat(updated.get().getEvaluatedAt()).isBeforeOrEqualTo(Instant.now());
@@ -372,7 +372,7 @@ class TriggerEventHandlerTest {
         handler.handle(CLOCK, TEST_VNODE, event);
 
         // THEN: the frozen past next evaluation date is kept so every missed schedule replays
-        Optional<TriggerState> updated = triggerStateStore.findById(triggerId);
+        Optional<TriggerState> updated = triggerStateStore.findByIdWithoutAcl(triggerId);
         assertThat(updated).isPresent();
         assertThat(updated.get().isDisabled()).isFalse();
         assertThat(updated.get().getNextEvaluationDate()).isEqualTo(initialNextEvaluationDate.toInstant());
@@ -396,7 +396,7 @@ class TriggerEventHandlerTest {
         handler.handle(CLOCK, TEST_VNODE, event);
 
         // THEN: the next evaluation date is the last missed cron tick, in the past but within the last period
-        Optional<TriggerState> updated = triggerStateStore.findById(triggerId);
+        Optional<TriggerState> updated = triggerStateStore.findByIdWithoutAcl(triggerId);
         assertThat(updated).isPresent();
         assertThat(updated.get().isDisabled()).isFalse();
         assertThat(updated.get().getNextEvaluationDate()).isBefore(Instant.now());
@@ -421,7 +421,7 @@ class TriggerEventHandlerTest {
         handler.handle(CLOCK, TEST_VNODE, event);
 
         // THEN: the configured NONE applies, missed schedules are skipped
-        Optional<TriggerState> updated = triggerStateStore.findById(triggerId);
+        Optional<TriggerState> updated = triggerStateStore.findByIdWithoutAcl(triggerId);
         assertThat(updated).isPresent();
         assertThat(updated.get().isDisabled()).isFalse();
         assertThat(updated.get().getNextEvaluationDate()).isAfter(beforeHandler);
@@ -451,7 +451,7 @@ class TriggerEventHandlerTest {
         handler.handle(CLOCK, TEST_VNODE, event);
 
         // THEN: the backfill resumes untouched
-        Optional<TriggerState> updated = triggerStateStore.findById(triggerId);
+        Optional<TriggerState> updated = triggerStateStore.findByIdWithoutAcl(triggerId);
         assertThat(updated).isPresent();
         assertThat(updated.get().isDisabled()).isFalse();
         assertThat(updated.get().getBackfill()).isNotNull();
@@ -474,7 +474,7 @@ class TriggerEventHandlerTest {
         handler.handle(CLOCK, TEST_VNODE, event);
 
         // THEN: there is no missed schedule to recover, the next evaluation date is in the future
-        Optional<TriggerState> updated = triggerStateStore.findById(triggerId);
+        Optional<TriggerState> updated = triggerStateStore.findByIdWithoutAcl(triggerId);
         assertThat(updated).isPresent();
         assertThat(updated.get().isDisabled()).isFalse();
         assertThat(updated.get().getNextEvaluationDate()).isAfter(beforeHandler);
@@ -492,7 +492,7 @@ class TriggerEventHandlerTest {
         handler.handle(CLOCK, TEST_VNODE, event);
 
         // THEN
-        Optional<TriggerState> updated = triggerStateStore.findById(triggerId);
+        Optional<TriggerState> updated = triggerStateStore.findByIdWithoutAcl(triggerId);
         assertThat(updated).isPresent();
         assertThat(updated.get().isDisabled()).isTrue();
         assertThat(updated.get().getNextEvaluationDate()).isEqualTo(initialNextEvaluationDate.toInstant());
@@ -514,7 +514,7 @@ class TriggerEventHandlerTest {
         handler.handle(CLOCK, TEST_VNODE, event);
 
         // THEN
-        Optional<TriggerState> updated = triggerStateStore.findById(triggerId);
+        Optional<TriggerState> updated = triggerStateStore.findByIdWithoutAcl(triggerId);
         assertThat(updated)
             .get()
             .extracting(t -> t.getBackfill().getPaused())
@@ -538,7 +538,7 @@ class TriggerEventHandlerTest {
         handler.handle(CLOCK, TEST_VNODE, event);
 
         // THEN
-        Optional<TriggerState> updated = triggerStateStore.findById(triggerId);
+        Optional<TriggerState> updated = triggerStateStore.findByIdWithoutAcl(triggerId);
         assertThat(updated)
             .get()
             .extracting(t -> t.getBackfill().getPaused())
@@ -566,7 +566,7 @@ class TriggerEventHandlerTest {
         handler.handle(CLOCK, TEST_VNODE, event);
 
         // THEN: currentDate is preserved (progress bar must not reset)
-        Optional<TriggerState> updated = triggerStateStore.findById(triggerId);
+        Optional<TriggerState> updated = triggerStateStore.findByIdWithoutAcl(triggerId);
         assertThat(updated).get()
             .extracting(t -> t.getBackfill().getCurrentDate())
             .isEqualTo(advanced);
@@ -583,7 +583,7 @@ class TriggerEventHandlerTest {
         handler.handle(CLOCK, TEST_VNODE, event);
 
         // THEN
-        Optional<TriggerState> updated = triggerStateStore.findById(triggerId);
+        Optional<TriggerState> updated = triggerStateStore.findByIdWithoutAcl(triggerId);
         assertThat(updated).isPresent();
         assertThat(updated.get().getLastEventId()).isEqualTo(event.eventId());
     }
@@ -634,7 +634,7 @@ class TriggerEventHandlerTest {
         handler.handle(CLOCK, TEST_VNODE, event);
 
         // THEN
-        Optional<TriggerState> updated = triggerStateStore.findById(triggerId);
+        Optional<TriggerState> updated = triggerStateStore.findByIdWithoutAcl(triggerId);
         assertThat(updated).isPresent();
         assertThat(updated.get().getExecutionId()).isEqualTo(executionId);
     }
@@ -662,7 +662,7 @@ class TriggerEventHandlerTest {
         handler.handle(CLOCK, TEST_VNODE, event);
 
         // THEN
-        Optional<TriggerState> updated = triggerStateStore.findById(triggerId);
+        Optional<TriggerState> updated = triggerStateStore.findByIdWithoutAcl(triggerId);
         assertThat(updated).isPresent();
         assertThat(updated.get().getExecutionId()).isNull();
     }
@@ -678,7 +678,7 @@ class TriggerEventHandlerTest {
         handler.handle(CLOCK, TEST_VNODE, event);
 
         // THEN
-        Optional<TriggerState> updated = triggerStateStore.findById(triggerId);
+        Optional<TriggerState> updated = triggerStateStore.findByIdWithoutAcl(triggerId);
         assertThat(updated).isPresent();
         assertThat(updated.get().isLocked()).isFalse();
         assertThat(updated.get().getExecutionId()).isNull();
@@ -727,7 +727,7 @@ class TriggerEventHandlerTest {
 
         // THEN — the running instance is killed and the state disabled
         Mockito.verify(executionKilledQueue).emit(Mockito.any(ExecutionKilledTrigger.class));
-        Optional<TriggerState> updated = triggerStateStore.findById(triggerId);
+        Optional<TriggerState> updated = triggerStateStore.findByIdWithoutAcl(triggerId);
         assertThat(updated).isPresent();
         assertThat(updated.get().isDisabled()).isTrue();
     }
@@ -745,7 +745,7 @@ class TriggerEventHandlerTest {
 
         // THEN
         Mockito.verifyNoInteractions(executionKilledQueue);
-        Optional<TriggerState> updated = triggerStateStore.findById(triggerId);
+        Optional<TriggerState> updated = triggerStateStore.findByIdWithoutAcl(triggerId);
         assertThat(updated).isPresent();
         assertThat(updated.get().isDisabled()).isFalse();
     }
@@ -765,7 +765,7 @@ class TriggerEventHandlerTest {
         handler.handle(CLOCK, TEST_VNODE, event);
 
         // THEN — the trigger is released so the scheduler can resubmit it
-        Optional<TriggerState> updated = triggerStateStore.findById(triggerId);
+        Optional<TriggerState> updated = triggerStateStore.findByIdWithoutAcl(triggerId);
         assertThat(updated).isPresent();
         assertThat(updated.get().isLocked()).isFalse();
         assertThat(updated.get().getWorkerId()).isNull();
@@ -786,7 +786,7 @@ class TriggerEventHandlerTest {
         handler.handle(CLOCK, TEST_VNODE, event);
 
         // THEN
-        Optional<TriggerState> updated = triggerStateStore.findById(triggerId);
+        Optional<TriggerState> updated = triggerStateStore.findByIdWithoutAcl(triggerId);
         assertThat(updated).isPresent();
         assertThat(updated.get().isLocked()).isTrue();
         assertThat(updated.get().getWorkerId()).isEqualTo("worker-2");
@@ -805,7 +805,7 @@ class TriggerEventHandlerTest {
 
         // THEN — the instance is killed
         Mockito.verify(executionKilledQueue).emit(Mockito.any(ExecutionKilledTrigger.class));
-        Optional<TriggerState> updated = triggerStateStore.findById(triggerId);
+        Optional<TriggerState> updated = triggerStateStore.findByIdWithoutAcl(triggerId);
         assertThat(updated).isPresent();
         assertThat(updated.get().getWorkerId()).isEqualTo("worker-1");
     }
@@ -837,7 +837,7 @@ class TriggerEventHandlerTest {
         handler.handle(CLOCK, TEST_VNODE, event);
 
         // THEN — the event is ignored and the trigger stays locked
-        Optional<TriggerState> updated = triggerStateStore.findById(triggerId);
+        Optional<TriggerState> updated = triggerStateStore.findByIdWithoutAcl(triggerId);
         assertThat(updated).isPresent();
         assertThat(updated.get().isLocked()).isTrue();
         assertThat(updated.get().getLastEventId()).isNull();
@@ -858,7 +858,7 @@ class TriggerEventHandlerTest {
         handler.handle(CLOCK, TEST_VNODE, event);
 
         // THEN — the FAILED creation execution unlocks the trigger so it can be resubmitted
-        Optional<TriggerState> updated = triggerStateStore.findById(triggerId);
+        Optional<TriggerState> updated = triggerStateStore.findByIdWithoutAcl(triggerId);
         assertThat(updated).isPresent();
         assertThat(updated.get().isLocked()).isFalse();
         assertThat(updated.get().getWorkerId()).isNull();
@@ -882,7 +882,7 @@ class TriggerEventHandlerTest {
         handler.handle(CLOCK, TEST_VNODE, event);
 
         // THEN — the current instance keeps its lock
-        Optional<TriggerState> updated = triggerStateStore.findById(triggerId);
+        Optional<TriggerState> updated = triggerStateStore.findByIdWithoutAcl(triggerId);
         assertThat(updated).isPresent();
         assertThat(updated.get().isLocked()).isTrue();
         assertThat(updated.get().getWorkerId()).isEqualTo("worker-2");
@@ -906,7 +906,7 @@ class TriggerEventHandlerTest {
         handler.handle(CLOCK, TEST_VNODE, event);
 
         // THEN — the current instance keeps its lock
-        Optional<TriggerState> updated = triggerStateStore.findById(triggerId);
+        Optional<TriggerState> updated = triggerStateStore.findByIdWithoutAcl(triggerId);
         assertThat(updated).isPresent();
         assertThat(updated.get().isLocked()).isTrue();
         assertThat(updated.get().getWorkerId()).isEqualTo("worker-1");
@@ -966,7 +966,7 @@ class TriggerEventHandlerTest {
         handler.handle(CLOCK, TEST_VNODE, event);
 
         // THEN — the lock is released so the trigger is eligible for the next evaluation
-        Optional<TriggerState> updated = triggerStateStore.findById(triggerId);
+        Optional<TriggerState> updated = triggerStateStore.findByIdWithoutAcl(triggerId);
         assertThat(updated).isPresent();
         assertThat(updated.get().isLocked()).isFalse();
         assertThat(updated.get().getWorkerId()).isNull();
@@ -997,7 +997,7 @@ class TriggerEventHandlerTest {
         handler.handle(CLOCK, TEST_VNODE, event);
 
         // THEN — the lock is held until the created execution terminates
-        Optional<TriggerState> updated = triggerStateStore.findById(triggerId);
+        Optional<TriggerState> updated = triggerStateStore.findByIdWithoutAcl(triggerId);
         assertThat(updated).isPresent();
         assertThat(updated.get().isLocked()).isTrue();
     }
@@ -1015,7 +1015,7 @@ class TriggerEventHandlerTest {
         handler.handle(CLOCK, TEST_VNODE, event);
 
         // THEN
-        Optional<TriggerState> updated = triggerStateStore.findById(triggerId);
+        Optional<TriggerState> updated = triggerStateStore.findByIdWithoutAcl(triggerId);
         assertThat(updated).isPresent();
         assertThat(updated.get().getBackfill()).isNotNull();
         assertThat(updated.get().getBackfill().getStart()).isEqualTo(backfillStart);
@@ -1102,7 +1102,7 @@ class TriggerEventHandlerTest {
         handler.handle(clock, TEST_VNODE, event);
 
         // THEN
-        Optional<TriggerState> updated = triggerStateStore.findById(triggerId);
+        Optional<TriggerState> updated = triggerStateStore.findByIdWithoutAcl(triggerId);
         assertThat(updated).isPresent();
         // Backfill is cleared because the next evaluation date is after the backfill end
         assertThat(updated.get().getBackfill()).isNull();
@@ -1122,7 +1122,7 @@ class TriggerEventHandlerTest {
 
         // THEN
         // no exception expected, handled gracefully
-        assertThat(triggerStateStore.findById(triggerId)).isPresent();
+        assertThat(triggerStateStore.findByIdWithoutAcl(triggerId)).isPresent();
     }
 
     @Test
@@ -1138,7 +1138,7 @@ class TriggerEventHandlerTest {
         // THEN
         TriggerState updated;
 
-        updated = triggerStateStore.findById(triggerId).orElseThrow();
+        updated = triggerStateStore.findByIdWithoutAcl(triggerId).orElseThrow();
         assertThat(updated.getLastEventId()).isEqualTo(event.eventId());
         Instant updatedAt = updated.getUpdatedAt();
         assertThat(updatedAt).isAfter(triggerState.getUpdatedAt());
@@ -1147,7 +1147,7 @@ class TriggerEventHandlerTest {
         handler.handle(CLOCK, TEST_VNODE, event);
 
         // THEN
-        updated = triggerStateStore.findById(triggerId).orElseThrow();
+        updated = triggerStateStore.findByIdWithoutAcl(triggerId).orElseThrow();
         assertThat(updated.getLastEventId()).isEqualTo(event.eventId());
         assertThat(updated.getUpdatedAt()).isEqualTo(updatedAt); // not updated
     }
@@ -1168,7 +1168,7 @@ class TriggerEventHandlerTest {
         // THEN
         TriggerState updated;
 
-        updated = triggerStateStore.findById(triggerId).orElseThrow();
+        updated = triggerStateStore.findByIdWithoutAcl(triggerId).orElseThrow();
         assertThat(updated.getLastEventId()).isEqualTo(event2.eventId());
         assertThat(updated.getUpdatedAt()).isEqualTo(state.getUpdatedAt()); // not updated
     }
@@ -1190,7 +1190,7 @@ class TriggerEventHandlerTest {
         handler.handle(CLOCK, TEST_VNODE, event);
 
         // THEN
-        Optional<TriggerState> updated = triggerStateStore.findById(triggerId);
+        Optional<TriggerState> updated = triggerStateStore.findByIdWithoutAcl(triggerId);
         assertThat(updated).get().extracting(TriggerState::getBackfill).isNull();
         assertThat(updated).get().extracting(TriggerState::getNextEvaluationDate).isEqualTo(previousNextEvaluationDate.toInstant());
         assertThat(updated).get().extracting(TriggerState::getLastEventId).isEqualTo(event.eventId());
@@ -1219,7 +1219,7 @@ class TriggerEventHandlerTest {
         handler.handle(CLOCK, TEST_VNODE, event);
 
         // THEN
-        Optional<TriggerState> updated = triggerStateStore.findById(triggerId);
+        Optional<TriggerState> updated = triggerStateStore.findByIdWithoutAcl(triggerId);
         assertThat(updated).get().extracting(TriggerState::getBackfill).isNull();
         assertThat(updated).get().extracting(TriggerState::getNextEvaluationDate).isEqualTo(liveNextEvaluationDate.toInstant());
         assertThat(updated).get().extracting(TriggerState::getLastEventId).isEqualTo(event.eventId());
@@ -1271,7 +1271,7 @@ class TriggerEventHandlerTest {
         handler.handle(CLOCK, TEST_VNODE, event);
 
         // THEN
-        Optional<TriggerState> updated = triggerStateStore.findById(triggerId);
+        Optional<TriggerState> updated = triggerStateStore.findByIdWithoutAcl(triggerId);
         assertThat(updated).get().extracting(TriggerState::getBackfill).isNull();
         assertThat(updated).get().extracting(TriggerState::getNextEvaluationDate).isNull();
         assertThat(updated).get().extracting(TriggerState::getLastEventId).isEqualTo(event.eventId());
@@ -1310,7 +1310,7 @@ class TriggerEventHandlerTest {
         handler.handle(clock, TEST_VNODE, event);
 
         // THEN persisted nextEvaluationDate falls on SUNDAY, not the next raw cron tick
-        Optional<TriggerState> saved = triggerStateStore.findById(triggerId);
+        Optional<TriggerState> saved = triggerStateStore.findByIdWithoutAcl(triggerId);
         assertThat(saved).isPresent();
         assertMatchesNextSunday(saved.get());
     }
@@ -1332,7 +1332,7 @@ class TriggerEventHandlerTest {
         handler.handle(clock, TEST_VNODE, event);
 
         // THEN
-        Optional<TriggerState> updated = triggerStateStore.findById(triggerId);
+        Optional<TriggerState> updated = triggerStateStore.findByIdWithoutAcl(triggerId);
         assertThat(updated).isPresent();
         assertMatchesNextSunday(updated.get());
     }
@@ -1353,7 +1353,7 @@ class TriggerEventHandlerTest {
         handler.handle(clock, TEST_VNODE, event);
 
         // THEN
-        Optional<TriggerState> updated = triggerStateStore.findById(triggerId);
+        Optional<TriggerState> updated = triggerStateStore.findByIdWithoutAcl(triggerId);
         assertThat(updated).isPresent();
         assertMatchesNextSunday(updated.get());
     }
@@ -1375,7 +1375,7 @@ class TriggerEventHandlerTest {
         handler.handle(clock, TEST_VNODE, event);
 
         // THEN
-        Optional<TriggerState> updated = triggerStateStore.findById(triggerId);
+        Optional<TriggerState> updated = triggerStateStore.findByIdWithoutAcl(triggerId);
         assertThat(updated).isPresent();
         assertThat(updated.get().isDisabled()).isFalse();
         assertMatchesNextSunday(updated.get());
@@ -1419,9 +1419,9 @@ class TriggerEventHandlerTest {
 
     @Test
     void shouldEmitFailedProcessedEventWhenHandlerThrows() throws QueueException {
-        // GIVEN: a TriggerStateStore that throws on findById to force a RuntimeException inside doHandle
+        // GIVEN: a TriggerStateStore that throws on findByIdWithoutAcl to force a RuntimeException inside doHandle
         TriggerStateStore failingStore = Mockito.mock(TriggerStateStore.class);
-        Mockito.when(failingStore.findById(Mockito.any())).thenThrow(new RuntimeException("boom"));
+        Mockito.when(failingStore.findByIdWithoutAcl(Mockito.any())).thenThrow(new RuntimeException("boom"));
         handler = new TriggerEventHandler(
             failingStore,
             new InMemoryFlowMetaStore(TEST_VNODE_COUNT, List.of()),

--- a/scheduler/src/test/java/io/kestra/scheduler/TriggerSchedulerTest.java
+++ b/scheduler/src/test/java/io/kestra/scheduler/TriggerSchedulerTest.java
@@ -108,7 +108,7 @@ class TriggerSchedulerTest {
         scheduler.onStart(SchedulerClock.getClock(), SchedulerClock.now().toInstant(), NODES_ASSIGNMENTS); // vNode are 0-based
 
         // THEN
-        TriggerState state = triggerStateStore.findById(Fixtures.triggerId()).orElse(null);
+        TriggerState state = triggerStateStore.findByIdWithoutAcl(Fixtures.triggerId()).orElse(null);
         assertThat(state).isNotNull();
         assertThat(state.isLocked()).isFalse();
         assertThat(state.getEvaluatedAt()).isNull();
@@ -126,7 +126,7 @@ class TriggerSchedulerTest {
         scheduler.onSchedule(SchedulerClock.getClock(), SchedulerClock.now().toInstant(), NODES_ASSIGNMENTS);
 
         // THEN
-        TriggerState state = triggerStateStore.findById(Fixtures.triggerId()).orElse(null);
+        TriggerState state = triggerStateStore.findByIdWithoutAcl(Fixtures.triggerId()).orElse(null);
         assertThat(state).isNotNull();
 
         assertThat(state.isLocked()).isTrue();
@@ -165,7 +165,7 @@ class TriggerSchedulerTest {
         scheduler.onSchedule(SchedulerClock.getClock(), SchedulerClock.now().toInstant(), NODES_ASSIGNMENTS);
 
         // THEN
-        TriggerState state = triggerStateStore.findById(Fixtures.triggerId("polling")).orElse(null);
+        TriggerState state = triggerStateStore.findByIdWithoutAcl(Fixtures.triggerId("polling")).orElse(null);
         assertThat(state).isNotNull();
 
         assertThat(state.isLocked()).isTrue();
@@ -192,7 +192,7 @@ class TriggerSchedulerTest {
         scheduler.onSchedule(SchedulerClock.getClock(), SchedulerClock.now().toInstant(), NODES_ASSIGNMENTS);
 
         // THEN
-        TriggerState state = triggerStateStore.findById(Fixtures.triggerId("polling")).orElse(null);
+        TriggerState state = triggerStateStore.findByIdWithoutAcl(Fixtures.triggerId("polling")).orElse(null);
         assertThat(state).isNotNull();
 
         assertThat(state.isLocked()).isFalse();
@@ -217,7 +217,7 @@ class TriggerSchedulerTest {
         scheduler.onSchedule(SchedulerClock.getClock(), SchedulerClock.now().toInstant(), NODES_ASSIGNMENTS);
 
         // THEN
-        TriggerState state = triggerStateStore.findById(Fixtures.triggerId("realtime")).orElse(null);
+        TriggerState state = triggerStateStore.findByIdWithoutAcl(Fixtures.triggerId("realtime")).orElse(null);
         assertThat(state).isNotNull();
 
         assertThat(state.isLocked()).isTrue();
@@ -244,7 +244,7 @@ class TriggerSchedulerTest {
         scheduler.onSchedule(SchedulerClock.getClock(), SchedulerClock.now().toInstant(), NODES_ASSIGNMENTS);
 
         // THEN — the trigger must stay unlocked so it is retried at its next evaluation date
-        TriggerState state = triggerStateStore.findById(Fixtures.triggerId("realtime")).orElse(null);
+        TriggerState state = triggerStateStore.findByIdWithoutAcl(Fixtures.triggerId("realtime")).orElse(null);
         assertThat(state).isNotNull();
         assertThat(state.isLocked()).isFalse();
         assertThat(state.getLastTriggeredDate()).isNull();
@@ -355,7 +355,7 @@ class TriggerSchedulerTest {
         scheduler.onSchedule(SchedulerClock.getClock(), SchedulerClock.now().toInstant(), NODES_ASSIGNMENTS);
 
         // THEN the condition failed (Friday ≠ Sunday) and the persisted nextEvaluationDate is on a Sunday
-        TriggerState state = triggerStateStore.findById(Fixtures.triggerId()).orElseThrow();
+        TriggerState state = triggerStateStore.findByIdWithoutAcl(Fixtures.triggerId()).orElseThrow();
         ZonedDateTime nextZoned = state.getNextEvaluationDate().atZone(ZoneId.systemDefault());
         assertThat(nextZoned.getDayOfWeek())
             .as("nextEvaluationDate should fall on a SUNDAY, but was %s", nextZoned)
@@ -391,7 +391,7 @@ class TriggerSchedulerTest {
             scheduler.onSchedule(SchedulerClock.getClock(), SchedulerClock.now().toInstant(), NODES_ASSIGNMENTS);
 
             // Assertions on TriggerState
-            TriggerState currentTriggerState = triggerStateStore.findById(Fixtures.triggerId()).orElse(null);
+            TriggerState currentTriggerState = triggerStateStore.findByIdWithoutAcl(Fixtures.triggerId()).orElse(null);
             assertThat(currentTriggerState).isNotNull();
 
             // [1-4 Calls] onSchedule
@@ -453,7 +453,7 @@ class TriggerSchedulerTest {
             scheduler.onSchedule(SchedulerClock.getClock(), SchedulerClock.now().toInstant(), NODES_ASSIGNMENTS);
 
             // Assertions on TriggerState
-            TriggerState currentTriggerState = triggerStateStore.findById(Fixtures.triggerId()).orElse(null);
+            TriggerState currentTriggerState = triggerStateStore.findByIdWithoutAcl(Fixtures.triggerId()).orElse(null);
             assertThat(currentTriggerState).isNotNull();
 
             // [1st Call] onSchedule
@@ -518,7 +518,7 @@ class TriggerSchedulerTest {
         // [THEN]
         final ZonedDateTime expectedNextEvaluationNDate = ZonedDateTime.now(Clock.offset(initialSchedulerClock, Duration.ofHours(1)));
         // Assert TriggerState
-        TriggerState currentTriggerState = triggerStateStore.findById(Fixtures.triggerId()).orElse(null);
+        TriggerState currentTriggerState = triggerStateStore.findByIdWithoutAcl(Fixtures.triggerId()).orElse(null);
         assertThat(currentTriggerState).isNotNull();
 
         assertThat(currentTriggerState.getEvaluatedAt()).isEqualTo(initialState.getEvaluatedAt());
@@ -543,7 +543,7 @@ class TriggerSchedulerTest {
         scheduler.onSchedule(SchedulerClock.getClock(), SchedulerClock.now().toInstant(), NODES_ASSIGNMENTS);
 
         // THEN
-        TriggerState state = triggerStateStore.findById(Fixtures.triggerId()).orElse(null);
+        TriggerState state = triggerStateStore.findByIdWithoutAcl(Fixtures.triggerId()).orElse(null);
         assertThat(state).isNotNull();
         assertThat(state.isLocked()).isFalse();
         assertThat(triggerExecutionPublisher.executions().size()).isEqualTo(0);
@@ -595,7 +595,7 @@ class TriggerSchedulerTest {
         // endregion [GIVEN]
 
         // WHEN
-        TriggerState initialState = triggerStateStore.findById(Fixtures.triggerId()).orElse(null);
+        TriggerState initialState = triggerStateStore.findByIdWithoutAcl(Fixtures.triggerId()).orElse(null);
         triggerStateStore.save(
             initialState
                 .locked(SchedulerClock.getClock(), false)
@@ -606,7 +606,7 @@ class TriggerSchedulerTest {
         scheduler.onSchedule(SchedulerClock.getClock(), SchedulerClock.now().toInstant(), NODES_ASSIGNMENTS);
 
         // THEN
-        TriggerState state = triggerStateStore.findById(Fixtures.triggerId()).orElse(null);
+        TriggerState state = triggerStateStore.findByIdWithoutAcl(Fixtures.triggerId()).orElse(null);
         assertThat(state).isNotNull();
 
         assertThat(state.isLocked()).isFalse();
@@ -633,7 +633,7 @@ class TriggerSchedulerTest {
         scheduler.onSchedule(SchedulerClock.getClock(), SchedulerClock.now().toInstant(), NODES_ASSIGNMENTS);
 
         // THEN
-        TriggerState state = triggerStateStore.findById(Fixtures.triggerId()).orElse(null);
+        TriggerState state = triggerStateStore.findByIdWithoutAcl(Fixtures.triggerId()).orElse(null);
         assertThat(state).isNull();
         assertThat(triggerExecutionPublisher.executions().size()).isEqualTo(0);
     }
@@ -650,7 +650,7 @@ class TriggerSchedulerTest {
         // Trigger an initial execution
         scheduler.onSchedule(SchedulerClock.getClock(), SchedulerClock.now().toInstant(), NODES_ASSIGNMENTS);
 
-        TriggerState triggerState = triggerStateStore.findById(Fixtures.triggerId()).orElse(null);
+        TriggerState triggerState = triggerStateStore.findByIdWithoutAcl(Fixtures.triggerId()).orElse(null);
         assertThat(triggerState).isNotNull();
         assertThat(triggerState.getNextEvaluationDate()).isEqualTo(SchedulerClock.now().plusMinutes(15).toInstant());
 
@@ -673,7 +673,7 @@ class TriggerSchedulerTest {
             scheduler.onSchedule(SchedulerClock.getClock(), SchedulerClock.now().toInstant(), NODES_ASSIGNMENTS);
 
             // Assertions on TriggerState
-            TriggerState currentTriggerState = triggerStateStore.findById(Fixtures.triggerId()).orElse(null);
+            TriggerState currentTriggerState = triggerStateStore.findByIdWithoutAcl(Fixtures.triggerId()).orElse(null);
             assertThat(currentTriggerState).isNotNull();
             assertThat(currentTriggerState.isLocked()).isTrue();
             assertThat(currentTriggerState.getUpdatedAt()).isEqualTo(SchedulerClock.now().toInstant());
@@ -795,12 +795,12 @@ class TriggerSchedulerTest {
         scheduler.onStart(SchedulerClock.getClock(), SchedulerClock.now().toInstant(), NODES_ASSIGNMENTS); // vNode are 0-based
 
         // THEN
-        TriggerState state = triggerStateStore.findById(Fixtures.triggerId()).orElse(null);
+        TriggerState state = triggerStateStore.findByIdWithoutAcl(Fixtures.triggerId()).orElse(null);
         assertThat(state).isNull();
     }
 
     private void completeExecution() {
-        triggerStateStore.findById(Fixtures.triggerId()).ifPresent(state ->
+        triggerStateStore.findByIdWithoutAcl(Fixtures.triggerId()).ifPresent(state ->
         {
             TriggerState newState = state
                 .updateOnExecutionTerminated(SchedulerClock.getClock(), State.Type.SUCCESS)

--- a/scheduler/src/test/java/io/kestra/scheduler/TriggerSchedulerTest.java
+++ b/scheduler/src/test/java/io/kestra/scheduler/TriggerSchedulerTest.java
@@ -732,7 +732,7 @@ class TriggerSchedulerTest {
         scheduler.onStart(SchedulerClock.getClock(), SchedulerClock.now().toInstant(), NODES_ASSIGNMENTS);
 
         ZonedDateTime backfillStart = SchedulerClock.now().minus(Duration.ofHours(2));
-        TriggerState triggerState = triggerStateStore.findById(Fixtures.triggerId()).orElseThrow();
+        TriggerState triggerState = triggerStateStore.findByIdWithoutAcl(Fixtures.triggerId()).orElseThrow();
         triggerStateStore.save(
             triggerState
                 .updateForNextEvaluationDate(SchedulerClock.getClock(), backfillStart)
@@ -749,7 +749,7 @@ class TriggerSchedulerTest {
 
         // THEN
         assertThat(triggerExecutionPublisher.executions().size()).isEqualTo(0);
-        TriggerState state = triggerStateStore.findById(Fixtures.triggerId()).orElseThrow();
+        TriggerState state = triggerStateStore.findByIdWithoutAcl(Fixtures.triggerId()).orElseThrow();
         assertThat(state.getBackfill().getCurrentDate()).isEqualTo(backfillStart);
     }
 

--- a/scheduler/src/test/java/io/kestra/scheduler/TriggerSchedulerTest.java
+++ b/scheduler/src/test/java/io/kestra/scheduler/TriggerSchedulerTest.java
@@ -764,7 +764,7 @@ class TriggerSchedulerTest {
 
         ZonedDateTime start = ZonedDateTime.parse("2024-06-15T12:00:00Z");
         ZonedDateTime end = ZonedDateTime.parse("2024-06-15T12:05:00Z");
-        TriggerState state = triggerStateStore.findById(Fixtures.triggerId()).orElseThrow()
+        TriggerState state = triggerStateStore.findByIdWithoutAcl(Fixtures.triggerId()).orElseThrow()
             .locked(clock, false)
             .backfill(clock, Backfill.builder().start(start).end(end).build());
         ConditionContext conditionContext = conditionService.conditionContext(

--- a/scheduler/src/test/java/io/kestra/scheduler/utils/InMemoryTriggerStateStore.java
+++ b/scheduler/src/test/java/io/kestra/scheduler/utils/InMemoryTriggerStateStore.java
@@ -44,7 +44,7 @@ public class InMemoryTriggerStateStore implements TriggerStateStore {
     }
 
     @Override
-    public Optional<TriggerState> findById(TriggerId triggerId) {
+    public Optional<TriggerState> findByIdWithoutAcl(TriggerId triggerId) {
         return Optional.ofNullable(store.get(TriggerId.of(triggerId)));
     }
 

--- a/webserver/src/main/java/io/kestra/webserver/services/TriggerStateService.java
+++ b/webserver/src/main/java/io/kestra/webserver/services/TriggerStateService.java
@@ -109,7 +109,7 @@ public class TriggerStateService {
      */
     public ApiAsyncOperationResponse unlockAllByIds(List<TriggerId> triggers) {
         List<TriggerId> lockedIds = triggers.stream()
-            .filter(id -> triggerRepository.findById(id).map(TriggerStateService::isUnlockable).orElse(false))
+            .filter(id -> triggerRepository.findByIdWithoutAcl(id).map(TriggerStateService::isUnlockable).orElse(false))
             .filter(this::isFlowBackedTrigger)
             .toList();
         return submitBatch(
@@ -373,12 +373,12 @@ public class TriggerStateService {
     }
 
     private TriggerState getTriggerState(TriggerId triggerId) throws NotFoundException {
-        return triggerRepository.findById(triggerId)
+        return triggerRepository.findByIdWithoutAcl(triggerId)
             .orElseThrow(() -> new NotFoundException("Trigger %s not found".formatted(triggerId)));
     }
 
     private TriggerState refresh(TriggerId triggerId, String action) {
-        return triggerRepository.findById(triggerId)
+        return triggerRepository.findByIdWithoutAcl(triggerId)
             .orElseThrow(() -> new NoSuchElementException("Trigger disappeared after " + action + ": " + triggerId));
     }
 
@@ -406,7 +406,7 @@ public class TriggerStateService {
 
     private ApiAsyncOperationResponse submitExistingBatch(List<TriggerId> triggers, java.util.function.BiConsumer<TriggerId, String> emit) {
         List<TriggerId> existing = triggers.stream()
-            .filter(id -> triggerRepository.findById(id).isPresent())
+            .filter(id -> triggerRepository.findByIdWithoutAcl(id).isPresent())
             .toList();
         return submitBatch(existing, emit);
     }

--- a/webserver/src/test/java/io/kestra/webserver/controllers/api/TriggerControllerTest.java
+++ b/webserver/src/test/java/io/kestra/webserver/controllers/api/TriggerControllerTest.java
@@ -414,7 +414,7 @@ class TriggerControllerTest {
         TriggerState state = createTriggerFromFlow(flow1, true);
         flowService.create(GenericFlow.of(flow1));
 
-        Awaitility.await().atMost(Duration.ofSeconds(30)).pollInterval(Duration.ofMillis(100)).until(() -> jdbcTriggerRepository.findById(state).isPresent());
+        Awaitility.await().atMost(Duration.ofSeconds(30)).pollInterval(Duration.ofMillis(100)).until(() -> jdbcTriggerRepository.findByIdWithoutAcl(state).isPresent());
 
         // WHEN
         HttpResponse<Void> response = client.toBlocking()
@@ -426,7 +426,7 @@ class TriggerControllerTest {
         // THEN
         assertThat(response.getStatus().getCode()).isEqualTo(HttpStatus.NO_CONTENT.getCode());
         Awaitility.await().atMost(Duration.ofSeconds(30)).pollInterval(Duration.ofMillis(100))
-            .until(() -> jdbcTriggerRepository.findById(state).isEmpty());
+            .until(() -> jdbcTriggerRepository.findByIdWithoutAcl(state).isEmpty());
     }
 
     @Test
@@ -549,9 +549,9 @@ class TriggerControllerTest {
         final TriggerState triggerNotDisabled = createTriggerFromFlow(flow2, false);
         // Wait for the scheduler to initialize trigger states before updating them
         Awaitility.await().atMost(Duration.ofSeconds(30)).pollInterval(Duration.ofMillis(100))
-            .until(() -> jdbcTriggerRepository.findById(triggerDisabled).isPresent());
+            .until(() -> jdbcTriggerRepository.findByIdWithoutAcl(triggerDisabled).isPresent());
         Awaitility.await().atMost(Duration.ofSeconds(30)).pollInterval(Duration.ofMillis(100))
-            .until(() -> jdbcTriggerRepository.findById(triggerNotDisabled).isPresent());
+            .until(() -> jdbcTriggerRepository.findByIdWithoutAcl(triggerNotDisabled).isPresent());
 
         List<TriggerController.ApiTriggerId> triggers = Stream.of(
             jdbcTriggerRepository.save(triggerDisabled),
@@ -570,7 +570,7 @@ class TriggerControllerTest {
         assertThat(response.getStatus().getCode()).isEqualTo(HttpStatus.ACCEPTED.getCode());
         assertThat(response.body().totalItems()).isEqualTo(2);
         try {
-            Await.until(() -> !jdbcTriggerRepository.findById(triggerDisabled).get().isDisabled(), Duration.ofSeconds(1), Duration.ofSeconds(30));
+            Await.until(() -> !jdbcTriggerRepository.findByIdWithoutAcl(triggerDisabled).get().isDisabled(), Duration.ofSeconds(1), Duration.ofSeconds(30));
         } catch (TimeoutException e) {
             Assertions.fail("Timeout waiting for trigger to be disabled");
         }
@@ -590,9 +590,9 @@ class TriggerControllerTest {
         final TriggerState triggerToDisable = createTriggerFromFlow(flow2, false);
         // Wait for the scheduler to initialize trigger states before updating them
         Awaitility.await().atMost(Duration.ofSeconds(30)).pollInterval(Duration.ofMillis(100))
-            .until(() -> jdbcTriggerRepository.findById(triggerDisabled).isPresent());
+            .until(() -> jdbcTriggerRepository.findByIdWithoutAcl(triggerDisabled).isPresent());
         Awaitility.await().atMost(Duration.ofSeconds(30)).pollInterval(Duration.ofMillis(100))
-            .until(() -> jdbcTriggerRepository.findById(triggerToDisable).isPresent());
+            .until(() -> jdbcTriggerRepository.findByIdWithoutAcl(triggerToDisable).isPresent());
 
         // WHEN
         List<TriggerController.ApiTriggerId> triggers = Stream.of(
@@ -611,7 +611,7 @@ class TriggerControllerTest {
         assertThat(response.body().totalItems()).isEqualTo(2);
 
         try {
-            Await.until(() -> jdbcTriggerRepository.findById(triggerToDisable).get().isDisabled(), Duration.ofSeconds(1), Duration.ofSeconds(10));
+            Await.until(() -> jdbcTriggerRepository.findByIdWithoutAcl(triggerToDisable).get().isDisabled(), Duration.ofSeconds(1), Duration.ofSeconds(10));
         } catch (TimeoutException e) {
             Assertions.fail("Timeout waiting for trigger to be disabled");
         }
@@ -631,9 +631,9 @@ class TriggerControllerTest {
         final TriggerState toDisable = createTriggerFromFlow(flow2, false);
         // Wait for the scheduler to initialize trigger states before updating them
         Awaitility.await().atMost(Duration.ofSeconds(30)).pollInterval(Duration.ofMillis(100))
-            .until(() -> jdbcTriggerRepository.findById(trigger1).isPresent());
+            .until(() -> jdbcTriggerRepository.findByIdWithoutAcl(trigger1).isPresent());
         Awaitility.await().atMost(Duration.ofSeconds(30)).pollInterval(Duration.ofMillis(100))
-            .until(() -> jdbcTriggerRepository.findById(toDisable).isPresent());
+            .until(() -> jdbcTriggerRepository.findByIdWithoutAcl(toDisable).isPresent());
         jdbcTriggerRepository.save(trigger1);
         jdbcTriggerRepository.save(toDisable);
 
@@ -647,7 +647,7 @@ class TriggerControllerTest {
         assertThat(response.getStatus().getCode()).isEqualTo(HttpStatus.ACCEPTED.getCode());
         assertThat(response.body().totalItems()).isEqualTo(2);
         try {
-            Await.until(() -> jdbcTriggerRepository.findById(toDisable).get().isDisabled(), Duration.ofSeconds(1), Duration.ofSeconds(30));
+            Await.until(() -> jdbcTriggerRepository.findByIdWithoutAcl(toDisable).get().isDisabled(), Duration.ofSeconds(1), Duration.ofSeconds(30));
         } catch (TimeoutException e) {
             Assertions.fail("Timeout waiting for trigger to be disabled");
         }
@@ -663,7 +663,7 @@ class TriggerControllerTest {
         final TriggerState trigger = createTriggerFromFlow(flow, true);
         // Wait for the scheduler to initialize trigger states before updating them
         Awaitility.await().atMost(Duration.ofSeconds(30)).pollInterval(Duration.ofMillis(100))
-            .until(() -> jdbcTriggerRepository.findById(trigger).isPresent());
+            .until(() -> jdbcTriggerRepository.findByIdWithoutAcl(trigger).isPresent());
         jdbcTriggerRepository.save(trigger);
 
         // WHEN
@@ -690,7 +690,7 @@ class TriggerControllerTest {
         final TriggerState trigger = createTriggerFromFlow(flow, true);
         // Wait for the scheduler to initialize trigger states before updating them
         Awaitility.await().atMost(Duration.ofSeconds(30)).pollInterval(Duration.ofMillis(100))
-            .until(() -> jdbcTriggerRepository.findById(trigger).isPresent());
+            .until(() -> jdbcTriggerRepository.findByIdWithoutAcl(trigger).isPresent());
         jdbcTriggerRepository.save(trigger);
 
         List<TriggerController.ApiTriggerId> triggers = List.of(
@@ -707,7 +707,7 @@ class TriggerControllerTest {
         assertThat(response.getStatus().getCode()).isEqualTo(HttpStatus.ACCEPTED.getCode());
         assertThat(response.body().totalItems()).isEqualTo(1);
         try {
-            Await.until(() -> !jdbcTriggerRepository.findById(trigger).get().isDisabled(), Duration.ofSeconds(1), Duration.ofSeconds(30));
+            Await.until(() -> !jdbcTriggerRepository.findByIdWithoutAcl(trigger).get().isDisabled(), Duration.ofSeconds(1), Duration.ofSeconds(30));
         } catch (TimeoutException e) {
             Assertions.fail("Timeout waiting for trigger to be enabled");
         }
@@ -723,7 +723,7 @@ class TriggerControllerTest {
         final TriggerState trigger = createTriggerFromFlow(flow, true);
         // Wait for the scheduler to initialize trigger states before updating them
         Awaitility.await().atMost(Duration.ofSeconds(30)).pollInterval(Duration.ofMillis(100))
-            .until(() -> jdbcTriggerRepository.findById(trigger).isPresent());
+            .until(() -> jdbcTriggerRepository.findByIdWithoutAcl(trigger).isPresent());
         jdbcTriggerRepository.save(trigger);
 
         // WHEN
@@ -736,7 +736,7 @@ class TriggerControllerTest {
         assertThat(response.getStatus().getCode()).isEqualTo(HttpStatus.ACCEPTED.getCode());
         assertThat(response.body().totalItems()).isEqualTo(1);
         try {
-            Await.until(() -> !jdbcTriggerRepository.findById(trigger).get().isDisabled(), Duration.ofSeconds(1), Duration.ofSeconds(30));
+            Await.until(() -> !jdbcTriggerRepository.findByIdWithoutAcl(trigger).get().isDisabled(), Duration.ofSeconds(1), Duration.ofSeconds(30));
         } catch (TimeoutException e) {
             Assertions.fail("Timeout waiting for trigger to be enabled");
         }
@@ -835,8 +835,8 @@ class TriggerControllerTest {
         // The flow's own trigger creation asynchronously seeds a TriggerState row; wait for it
         // instead of racing it with our own save(), then lock that row.
         Awaitility.await().atMost(Duration.ofSeconds(30)).pollInterval(Duration.ofMillis(100))
-            .until(() -> jdbcTriggerRepository.findById(fixture).isPresent());
-        TriggerState trigger = jdbcTriggerRepository.findById(fixture).orElseThrow()
+            .until(() -> jdbcTriggerRepository.findByIdWithoutAcl(fixture).isPresent());
+        TriggerState trigger = jdbcTriggerRepository.findByIdWithoutAcl(fixture).orElseThrow()
             .locked(Clock.systemDefaultZone(), true);
         jdbcTriggerRepository.save(trigger);
         return trigger;


### PR DESCRIPTION
## Problem

Several repository reads bypass namespace ACL by design — the executor's `ExecutionStateStore`, the scheduler's `TriggerStateStore`, and trigger/audit detail lookups all run with no user context — but they were named like the ACL-aware reads sitting next to them, so calling the wrong overload silently skips ACL. Separately, `findLatestForStates` enforced ACL inconsistently across backends: JDBC applied it incidentally through the inherited method, Elasticsearch applied none.

## Fix

- `ExecutionStateStore.findById(String)` → `findByIdWithoutAcl(String)`.
- `TriggerRepositoryInterface` / `TriggerStateStore` `findById(TriggerId)` → `findByIdWithoutAcl(TriggerId)`.
- Add `ExecutionRepositoryInterface.findLatestForStatesWithoutAcl`, and make `findLatestForStates` ACL-aware and consistent across backends.

These are behaviour-preserving renames plus one new no-ACL variant; the no-ACL reads now announce themselves in their names.

## Evidence

Existing executor, scheduler and repository test suites updated to the new names and green.

Companion PR (Elasticsearch asset-purge fix, public-App fix, EE renames, ACL tests): kestra-io/kestra-ee#10692, same branch `fix/ee-repository-acl-holes`.