### PR TITLE
fix(core): stop retry race from duplicating task runs and ending executions early

### DIFF
--- a/core/src/main/java/io/kestra/core/models/executions/Execution.java
+++ b/core/src/main/java/io/kestra/core/models/executions/Execution.java
@@ -722,13 +722,18 @@ public class Execution implements SoftDeletable<Execution>, TenantInterface, Has
     }
 
     public boolean isTerminated(List<ResolvedTask> resolvedTasks, TaskRun parentTaskRun) {
-        long terminatedCount = this
+        // Per-task coverage: every resolved task must have at least one terminated task run.
+        // A bare count of terminated task runs can be inflated by a duplicated task run
+        // (e.g. a retry race appending a second run for the same task id), letting the
+        // execution report terminated while a task never ran.
+        Set<String> terminatedTaskUids = this
             .findTaskRunByTasks(resolvedTasks, parentTaskRun)
             .stream()
             .filter(taskRun -> taskRun.getState().isTerminated())
-            .count();
+            .map(taskRun -> IdUtils.fromParts(taskRun.getTaskId(), taskRun.getValue()))
+            .collect(Collectors.toSet());
 
-        return terminatedCount == resolvedTasks.size();
+        return resolvedTasks.stream().allMatch(resolvedTask -> terminatedTaskUids.contains(resolvedTask.uid()));
     }
 
     public boolean hasFailed() {

--- a/core/src/main/java/io/kestra/core/runners/FlowableUtils.java
+++ b/core/src/main/java/io/kestra/core/runners/FlowableUtils.java
@@ -93,7 +93,7 @@ public class FlowableUtils {
         // if it has any created/submitted or running, we leave
         if (
             taskRuns.stream()
-                .anyMatch(taskRun -> taskRun.getState().isCreated() || taskRun.getState().getCurrent() == State.Type.SUBMITTED || taskRun.getState().isRunning())
+                .anyMatch(taskRun -> taskRun.getState().isCreated() || taskRun.getState().getCurrent() == State.Type.SUBMITTED || taskRun.getState().isRunning() || taskRun.getState().getCurrent() == State.Type.RETRYING)
         ) {
             return Collections.emptyList();
         }
@@ -134,7 +134,7 @@ public class FlowableUtils {
         // if it has any created/submitted or running, we leave
         if (
             taskRuns.stream()
-                .anyMatch(taskRun -> taskRun.getState().isCreated() || taskRun.getState().getCurrent() == State.Type.SUBMITTED || taskRun.getState().isRunning())
+                .anyMatch(taskRun -> taskRun.getState().isCreated() || taskRun.getState().getCurrent() == State.Type.SUBMITTED || taskRun.getState().isRunning() || taskRun.getState().getCurrent() == State.Type.RETRYING)
         ) {
             return Collections.emptyList();
         }

--- a/core/src/test/java/io/kestra/core/models/executions/ExecutionTest.java
+++ b/core/src/test/java/io/kestra/core/models/executions/ExecutionTest.java
@@ -12,6 +12,7 @@ import io.kestra.core.exceptions.InternalException;
 import io.kestra.core.models.Label;
 import io.kestra.core.models.flows.Flow;
 import io.kestra.core.models.flows.State;
+import io.kestra.core.models.tasks.ResolvedTask;
 import io.kestra.core.utils.IdUtils;
 import io.kestra.plugin.core.debug.Return;
 
@@ -437,4 +438,70 @@ class ExecutionTest {
             )
             .build();
     }
+
+    @Test
+    void isTerminatedShouldRequireEveryTaskNotJustATerminatedCount() {
+        // Regression for #18909: with a duplicated task run (retry race), the terminated
+        // task run COUNT can match the number of tasks while one task never ran - the old
+        // count-based check then reported terminated and the flow ended SUCCESS with its
+        // last task silently skipped.
+        ResolvedTask a = resolvedTask("a");
+        ResolvedTask b = resolvedTask("b");
+        ResolvedTask c = resolvedTask("c");
+
+        Execution.ExecutionBuilder base = Execution.builder()
+            .id("executionId")
+            .state(new State());
+
+        // two terminated runs for task b, none for task c
+        Execution withDuplicate = base
+            .taskRunList(List.of(
+                taskRun(a, State.Type.SUCCESS),
+                taskRun(b, State.Type.SUCCESS),
+                taskRun(b, State.Type.SUCCESS)
+            ))
+            .build();
+        assertThat(withDuplicate.isTerminated(List.of(a, b, c))).isFalse();
+
+        // one terminated run per task: terminated
+        Execution complete = base
+            .taskRunList(List.of(
+                taskRun(a, State.Type.SUCCESS),
+                taskRun(b, State.Type.SUCCESS),
+                taskRun(c, State.Type.SUCCESS)
+            ))
+            .build();
+        assertThat(complete.isTerminated(List.of(a, b, c))).isTrue();
+
+        // one task still running: not terminated
+        Execution inFlight = base
+            .taskRunList(List.of(
+                taskRun(a, State.Type.SUCCESS),
+                taskRun(b, State.Type.RUNNING),
+                taskRun(c, State.Type.SUCCESS)
+            ))
+            .build();
+        assertThat(inFlight.isTerminated(List.of(a, b, c))).isFalse();
+    }
+
+    private static ResolvedTask resolvedTask(String id) {
+        return ResolvedTask.of(
+            Return.builder()
+                .id(id)
+                .type(Return.class.getName())
+                .format(io.kestra.core.models.property.Property.ofValue(id))
+                .build()
+        );
+    }
+
+    private static int taskRunSeq = 0;
+
+    private static TaskRun taskRun(ResolvedTask task, State.Type state) {
+        return TaskRun.builder()
+            .id("taskrun-" + (++taskRunSeq))
+            .taskId(task.getTask().getId())
+            .state(new State().withState(state))
+            .build();
+    }
+
 }

--- a/core/src/test/java/io/kestra/core/runners/FlowableUtilsTest.java
+++ b/core/src/test/java/io/kestra/core/runners/FlowableUtilsTest.java
@@ -558,6 +558,79 @@ class FlowableUtilsTest {
         assertThat(result.getRight()).isEqualTo(4L);
     }
 
+
+    @Test
+    void resolveSequentialNexts_shouldNotDuplicateTaskRunWhenTaskIsRetrying() {
+        // Regression for #18909: a task run in RETRYING (task-level retry pending its
+        // ExecutionDelay) is neither created/submitted/running nor terminated, so it used to
+        // slip through the in-flight guard. With a terminated predecessor present, the nexts
+        // engine then resolved "the task after the last terminated one" - the retried task
+        // itself - and appended a SECOND task run for the same task id.
+        Execution base = Execution.builder()
+            .id("test-execution")
+            .namespace("io.kestra.test")
+            .flowId("test-flow")
+            .flowRevision(1)
+            .state(new State().withState(State.Type.RUNNING))
+            .build();
+
+        ResolvedTask setup = resolvedTask("setup");
+        ResolvedTask waiting = resolvedTask("waiting");
+        ResolvedTask last = resolvedTask("last");
+
+        TaskRun setupRun = TaskRun.of(base, setup).withState(State.Type.SUCCESS);
+        TaskRun waitingRun = TaskRun.of(base, waiting).withState(State.Type.RETRYING);
+
+        Execution execution = base.toBuilder()
+            .taskRunList(List.of(setupRun, waitingRun))
+            .build();
+
+        // When
+        List<NextTaskRun> next = FlowableUtils.resolveSequentialNexts(
+            execution,
+            List.of(setup, waiting, last)
+        );
+
+        // Then: the retried task is in-flight, so nothing may be dispatched - no duplicate
+        // task run for "waiting" and no premature dispatch of "last".
+        assertThat(next).isEmpty();
+    }
+
+    @Test
+    void resolveWaitForNext_shouldNotDuplicateTaskRunWhenTaskIsRetrying() {
+        // Same RETRYING in-flight leak as above, on the resolveWaitForNext path used by
+        // LoopUntil children.
+        Execution base = Execution.builder()
+            .id("test-execution")
+            .namespace("io.kestra.test")
+            .flowId("test-flow")
+            .flowRevision(1)
+            .state(new State().withState(State.Type.RUNNING))
+            .build();
+
+        ResolvedTask setup = resolvedTask("setup");
+        ResolvedTask waiting = resolvedTask("waiting");
+        ResolvedTask last = resolvedTask("last");
+
+        TaskRun parentRun = TaskRun.builder().id("parent").taskId("loop").build();
+        TaskRun setupRun = TaskRun.of(base, setup).withState(State.Type.SUCCESS).toBuilder().parentTaskRunId("parent").build();
+        TaskRun waitingRun = TaskRun.of(base, waiting).withState(State.Type.RETRYING).toBuilder().parentTaskRunId("parent").build();
+
+        Execution execution = base.toBuilder()
+            .taskRunList(List.of(setupRun, waitingRun))
+            .build();
+
+        List<NextTaskRun> next = FlowableUtils.resolveWaitForNext(
+            execution,
+            List.of(setup, waiting, last),
+            List.of(),
+            List.of(),
+            parentRun
+        );
+
+        assertThat(next).isEmpty();
+    }
+
     private static ResolvedTask resolvedTask(String id) {
         return ResolvedTask.of(
             Return.builder()


### PR DESCRIPTION
Closes #18909.

### What happens

With a task-level `retry` (e.g. constant every 5s) on a JDBC query task, every executor cycle between the FAILED -> RETRYING mark and the delay expiry appends a second task run for the same task id (visible ~250ms after the failure, as reported), and the execution can report SUCCESS while its last task never ran.

### Root cause

Two holes, one race:

1. **Duplicate task run** - `FlowableUtils.innerResolveSequentialNexts` (and `resolveWaitForNext` on the LoopUntil path) treat a task as in-flight only when its run is CREATED/SUBMITTED/running. A run in RETRYING matches nothing, and `findLastTerminated` skips it because RETRYING is not terminated. So "the task after the last terminated one" resolves to the retried task itself, and a duplicate `TaskRun` is appended. The parallel path already got a RETRYING-slot guard upstream (`resolveParallelNexts_retryingChildShouldConsumeConcurrencySlot`); the sequential path was missed.

2. **False terminated** - `Execution.isTerminated(resolvedTasks, parentTaskRun)` compares the *count* of terminated task runs to the number of resolved tasks. The duplicate run compensates for the never-created final task, so the count matches and `handleEnd` ends the execution SUCCESS before the last task is ever dispatched (`ExecutorService.process` runs `handleEnd` before `handleNext`).

### Fix

- `FlowableUtils`: treat `RETRYING` as in-flight in both `innerResolveSequentialNexts` and `resolveWaitForNext`.
- `Execution.isTerminated`: require per-task coverage - every resolved task must have at least one terminated run, matched by `taskId`+`value` uid, instead of comparing counts. Identical semantics when there is exactly one run per task; a duplicate can no longer mask a task that never ran.

### Tests

- `FlowableUtilsTest.resolveSequentialNexts_shouldNotDuplicateTaskRunWhenTaskIsRetrying`
- `FlowableUtilsTest.resolveWaitForNext_shouldNotDuplicateTaskRunWhenTaskIsRetrying`
- `ExecutionTest.isTerminatedShouldRequireEveryTaskNotJustATerminatedCount` (duplicate masking a missing task -> false; full coverage -> true; one task running -> false)

> Built by breken, your AI support engineer - breken.ai - this one's on us.