### PR TITLE
fix(kv): prevent namespace and key UID collisions

### DIFF
--- a/core/src/main/java/io/kestra/core/models/kv/PersistedKvMetadata.java
+++ b/core/src/main/java/io/kestra/core/models/kv/PersistedKvMetadata.java
@@ -98,6 +98,6 @@ public class PersistedKvMetadata implements SoftDeletable<PersistedKvMetadata>, 
 
     @Override
     public String uid() {
-        return IdUtils.fromParts(getTenantId(), getNamespace(), getName(), String.valueOf(getRevision()));
+        return IdUtils.fromPartsPipeDelimited(getTenantId(), getNamespace(), getName(), String.valueOf(getRevision()));
     }
 }

--- a/core/src/main/java/io/kestra/core/utils/IdUtils.java
+++ b/core/src/main/java/io/kestra/core/utils/IdUtils.java
@@ -12,6 +12,7 @@ import com.google.common.hash.Hashing;
 abstract public class IdUtils {
     private static final HashFunction HASH_FUNCTION = Hashing.md5();
     private static final char ID_SEPARATOR = '_';
+    private static final char ID_SEPARATOR_PIPE = '|';
 
     public static String create() {
         return FriendlyId.createFriendlyId();
@@ -27,6 +28,10 @@ abstract public class IdUtils {
 
     public static String fromParts(String... parts) {
         return fromPartsAndSeparator(ID_SEPARATOR, parts);
+    }
+
+    public static String fromPartsPipeDelimited(String... parts) {
+        return fromPartsAndSeparator(ID_SEPARATOR_PIPE, parts);
     }
 
     public static String fromPartsAndSeparator(char separator, String... parts) {

--- a/core/src/test/java/io/kestra/core/repositories/AbstractKvMetadataRepositoryTest.java
+++ b/core/src/test/java/io/kestra/core/repositories/AbstractKvMetadataRepositoryTest.java
@@ -281,6 +281,37 @@ public abstract class AbstractKvMetadataRepositoryTest {
         assertThat(namespaces).doesNotContain(deletedNamespace);
     }
 
+    @Test
+    void shouldNotOverwriteWhenNamespaceAndKeyConcatenateToSameString() throws IOException {
+        String tenantId = TestsUtils.randomTenant();
+        PersistedKvMetadata first = PersistedKvMetadata.builder()
+            .tenantId(tenantId)
+            .namespace("company.team")
+            .name("x_y")
+            .revision(1)
+            .build();
+        PersistedKvMetadata second = PersistedKvMetadata.builder()
+            .tenantId(tenantId)
+            .namespace("company.team_x")
+            .name("y")
+            .revision(1)
+            .build();
+
+        kvMetadataRepositoryInterface.save(first);
+        kvMetadataRepositoryInterface.save(second);
+
+        Optional<PersistedKvMetadata> foundFirst = kvMetadataRepositoryInterface.findByName(tenantId, "company.team", "x_y");
+        Optional<PersistedKvMetadata> foundSecond = kvMetadataRepositoryInterface.findByName(tenantId, "company.team_x", "y");
+
+        assertThat(foundFirst).isPresent();
+        assertThat(foundFirst.get().getName()).isEqualTo("x_y");
+        assertThat(foundFirst.get().getNamespace()).isEqualTo("company.team");
+
+        assertThat(foundSecond).isPresent();
+        assertThat(foundSecond.get().getName()).isEqualTo("y");
+        assertThat(foundSecond.get().getNamespace()).isEqualTo("company.team_x");
+    }
+
     protected static PersistedKvMetadata buildTestKvDescription(String tenantId, String namespace, String key) {
         return PersistedKvMetadata.builder()
             .tenantId(tenantId)

--- a/core/src/test/java/io/kestra/core/storages/InternalKVStoreTest.java
+++ b/core/src/test/java/io/kestra/core/storages/InternalKVStoreTest.java
@@ -311,6 +311,24 @@ class InternalKVStoreTest {
         assertThat(result.get().value()).isEqualTo(42);
     }
 
+    @Test
+    void shouldNotCollideWhenNamespaceAndKeyConcatenateToSameString() throws IOException, ResourceExpiredException {
+        String prefix = IdUtils.create();
+        InternalKVStore store1 = new InternalKVStore(MAIN_TENANT, prefix + ".company.team", storageInterface, kvMetadataStateStore);
+        InternalKVStore store2 = new InternalKVStore(MAIN_TENANT, prefix + ".company.team_x", storageInterface, kvMetadataStateStore);
+
+        store1.put("x_y", new KVValueAndMetadata(null, "valueA"));
+        store2.put("y", new KVValueAndMetadata(null, "valueB"));
+
+        Optional<KVValue> val1 = store1.getValue("x_y");
+        Optional<KVValue> val2 = store2.getValue("y");
+
+        assertThat(val1).isPresent();
+        assertThat(val1.get().value()).isEqualTo("valueA");
+        assertThat(val2).isPresent();
+        assertThat(val2.get().value()).isEqualTo("valueB");
+    }
+
     private InternalKVStore kv() {
         final String namespaceId = "io.kestra." + IdUtils.create();
         return new InternalKVStore(MAIN_TENANT, namespaceId, storageInterface, kvMetadataStateStore);

--- a/jdbc/src/main/java/io/kestra/jdbc/migration/V2_0_13KvMetadataUidMigration.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/migration/V2_0_13KvMetadataUidMigration.java
@@ -1,0 +1,160 @@
+package io.kestra.jdbc.migration;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.jooq.Field;
+import org.jooq.Query;
+import org.jooq.impl.DSL;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.kestra.core.models.kv.PersistedKvMetadata;
+import io.kestra.core.migration.MigrationScript;
+import io.kestra.core.serializers.JacksonMapper;
+import io.kestra.jdbc.JooqDSLContextWrapper;
+import io.kestra.jdbc.runner.JdbcRepositoryEnabled;
+
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Migrates KV Store metadata records to use the {@code |} (pipe) delimiter instead of
+ * {@code _} (underscore) in the {@code uid}.
+ *
+ * <p>
+ * The {@code kv_metadata} table stores each entry under a {@code key} column whose value
+ * is the record's {@code uid}. The {@code value} column contains the serialized
+ * {@link PersistedKvMetadata}, whose {@link PersistedKvMetadata#uid()} reflects the
+ * current UID format.
+ *
+ * <p>
+ * For each row, this migration deserializes the stored metadata, recomputes the expected
+ * {@code uid} using {@code metadata.uid()}, and updates the row's {@code key} when the
+ * computed UID differs from the stored key.
+ *
+ * <p>
+ * Idempotency: if the stored {@code key} already matches {@code metadata.uid()}, the row
+ * is left unchanged.
+ */
+@Slf4j
+@Singleton
+@JdbcRepositoryEnabled
+public class V2_0_13KvMetadataUidMigration implements MigrationScript {
+
+    private static final Field<Object> KEY_FIELD = DSL.field(DSL.quotedName("key"));
+    private static final Field<Object> VALUE_FIELD = DSL.field(DSL.quotedName("value"));
+    private static final ObjectMapper MAPPER = JacksonMapper.ofJson();
+
+    private final JooqDSLContextWrapper dslContextWrapper;
+
+    @Inject
+    public V2_0_13KvMetadataUidMigration(final JooqDSLContextWrapper dslContextWrapper) {
+        this.dslContextWrapper = dslContextWrapper;
+    }
+
+    @Override
+    public String scriptId() {
+        return "2.0.13-kv-metadata-uid-migration";
+    }
+
+    @Override
+    public String description() {
+        return "Migrate KV Store metadata to the collision-safe UID format";
+    }
+
+    @Override
+    public String checksum() {
+        // Java-only migration – no SQL resource file, checksum validation not applicable.
+        return null;
+    }
+
+    @Override
+    public void migrate() throws Exception {
+        dslContextWrapper.transaction(configuration -> {
+            var records = DSL.using(configuration)
+                .select(KEY_FIELD, VALUE_FIELD)
+                .from(DSL.table("kv_metadata"))
+                .fetch();
+
+            if (records.isEmpty()) {
+                log.info("KV metadata UID migration: no metadata found, skipping.");
+                return;
+            }
+
+            // Queries are build during the loop, then executed together via batch()
+            List<Query> updates = new ArrayList<>();
+
+            for (var record : records) {
+                String oldKey = record.get(KEY_FIELD, String.class);
+                String json = record.get(VALUE_FIELD, String.class);
+
+                if (json == null || json.isBlank()) {
+                    log.warn(
+                        "KV metadata UID migration: key [{}] has an empty value, skipping.",
+                        oldKey
+                    );
+                    continue;
+                }
+
+                PersistedKvMetadata metadata;
+                try {
+                    metadata = MAPPER.readValue(json, PersistedKvMetadata.class);
+                } catch (IOException e) {
+                    // Corrupt JSON must not be silently skipped: the migration runner would mark the
+                    // script as applied and skip it on future restarts, leaving this row's key
+                    // permanently unmigrated. Fail hard so the operator is forced to fix the row.
+                    log.error(
+                        "KV metadata UID migration: failed to parse metadata for key [{}].",
+                        oldKey,
+                        e
+                    );
+                    throw new RuntimeException(
+                        "KV metadata UID migration: failed to parse metadata",
+                        e
+                    );
+                }
+
+                // metadata.uid() is the source of truth for the current delimiter convention;
+                // recomputing it avoids mangling namespaces or keys that legitimately contain an underscore.
+                String newKey = metadata.uid();
+
+                if (newKey == null || newKey.isBlank()) {
+                    log.error("KV metadata UID migration: computed a null/blank uid for key [{}], skipping.", oldKey);
+                    throw new RuntimeException("KV metadata UID migration: computed null uid for key " + oldKey);
+                }
+
+                if (oldKey.equals(newKey)) {
+                    log.debug(
+                        "KV metadata UID migration: key [{}] is already up to date, skipping.",
+                        oldKey
+                    );
+                    continue;
+                }
+
+                updates.add(
+                    DSL.using(configuration)
+                        .update(DSL.table("kv_metadata"))
+                        .set(KEY_FIELD, newKey)
+                        .where(KEY_FIELD.eq(oldKey))
+                );
+
+                log.info(
+                    "KV metadata UID migration: migrated [{}] -> [{}].",
+                    oldKey,
+                    newKey
+                );
+            }
+
+            if (updates.isEmpty()) {
+                log.info("KV metadata UID migration: nothing to migrate, all keys already up to date.");
+                return;
+            }
+
+            int[] results = DSL.using(configuration).batch(updates).execute();
+            log.info("KV metadata UID migration: batch-updated {} rows.", results.length);
+        });
+    }
+}

--- a/jdbc/src/test/java/io/kestra/jdbc/migration/V2_0_13KvMetadataUidMigrationTest.java
+++ b/jdbc/src/test/java/io/kestra/jdbc/migration/V2_0_13KvMetadataUidMigrationTest.java
@@ -1,0 +1,174 @@
+package io.kestra.jdbc.migration;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+
+import javax.sql.DataSource;
+
+import org.h2.jdbcx.JdbcDataSource;
+import org.jooq.DSLContext;
+import org.jooq.Field;
+import org.jooq.SQLDialect;
+import org.jooq.impl.DSL;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.kestra.core.models.kv.PersistedKvMetadata;
+import io.kestra.core.serializers.JacksonMapper;
+import io.kestra.jdbc.JooqDSLContextWrapper;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Unit tests for {@link V2_0_13KvMetadataUidMigration} against an in-memory H2 database.
+ * Tests cover UID migration, idempotency, ambiguous namespace and key combinations,
+ * empty values, and invalid metadata JSON.
+ */
+class V2_0_13KvMetadataUidMigrationTest {
+
+    private static final Field<String> KEY_FIELD = DSL.field(DSL.quotedName("key"), String.class);
+    private static final Field<String> VALUE_FIELD = DSL.field(DSL.quotedName("value"), String.class);
+    private static final ObjectMapper MAPPER = JacksonMapper.ofJson();
+
+    private DSLContext dsl;
+    private JooqDSLContextWrapper dslContextWrapper;
+    private V2_0_13KvMetadataUidMigration migration;
+
+    @BeforeEach
+    void setUp() {
+        // Each test gets its own isolated in-memory database via a unique name.
+        JdbcDataSource ds = new JdbcDataSource();
+        ds.setURL("jdbc:h2:mem:test-" + UUID.randomUUID() + ";DB_CLOSE_DELAY=-1");
+        ds.setUser("sa");
+        ds.setPassword("");
+
+        dsl = DSL.using(ds, SQLDialect.H2);
+        // Column shape mirrors the real table closely enough for this migration: it only
+        // ever reads/writes "key" and "value", so the value column is a plain TEXT blob
+        // rather than the production JSONB type.
+        dsl.execute("""
+            CREATE TABLE kv_metadata (
+                "key" VARCHAR(500) NOT NULL PRIMARY KEY,
+                "value" TEXT NOT NULL
+            )
+            """);
+
+        dslContextWrapper = new JooqDSLContextWrapper(dsl, (DataSource) ds);
+        migration = new V2_0_13KvMetadataUidMigration(dslContextWrapper);
+    }
+
+    @Test
+    void shouldMigrateKeyToComputedUid() throws Exception {
+        // Given — a row stored under an arbitrary legacy key that predates uid()-based keys
+        PersistedKvMetadata metadata = metadata("main", "company.team", "a", 1);
+        insertRow("legacy-key-1", toJson(metadata));
+
+        // When
+        migration.migrate();
+
+        // Then
+        assertThat(fetchKeys()).containsExactly(metadata.uid());
+    }
+
+    @Test
+    void shouldBeIdempotentOnSecondRun() throws Exception {
+        // Given
+        PersistedKvMetadata metadata = metadata("main", "company.team", "a", 1);
+        insertRow("legacy-key-1", toJson(metadata));
+
+        // When — migrate twice
+        migration.migrate();
+        migration.migrate();
+
+        // Then — second run is a no-op, key is stable
+        assertThat(fetchKeys()).containsExactly(metadata.uid());
+    }
+
+    @Test
+    void shouldLeaveKeyUnchangedWhenAlreadyMatchesComputedUid() throws Exception {
+        // Given — a row already stored under its correct, up-to-date uid
+        PersistedKvMetadata metadata = metadata("main", "company.team", "a", 1);
+        insertRow(metadata.uid(), toJson(metadata));
+
+        // When
+        migration.migrate();
+
+        // Then
+        assertThat(fetchKeys()).containsExactly(metadata.uid());
+    }
+
+    @Test
+    void shouldMigrateEntriesWithAmbiguousNamespaceNameBoundariesToDistinctUids() throws Exception {
+        // Given — two entries whose namespace/name split at different points around the same
+        // characters. Under the old "_"-joined uid these collided into a single string; the
+        // fixed "|"-joined uid() must keep them distinct.
+        PersistedKvMetadata first = metadata("main", "company.team", "x_a", 1);
+        PersistedKvMetadata second = metadata("main", "company.team_x", "a", 1);
+        insertRow("legacy-key-1", toJson(first));
+        insertRow("legacy-key-2", toJson(second));
+
+        // When
+        migration.migrate();
+
+        // Then — both rows survive, under two distinct, correctly computed keys
+        assertThat(first.uid()).isNotEqualTo(second.uid());
+        assertThat(fetchKeys()).containsExactlyInAnyOrder(first.uid(), second.uid());
+    }
+
+    @Test
+    void shouldSkipRowsWithEmptyValue() throws Exception {
+        // Given — a row with a blank value (malformed/legacy state), and a normal row
+        insertRow("legacy-key-empty", "");
+        PersistedKvMetadata metadata = metadata("main", "company.team", "a", 1);
+        insertRow("legacy-key-1", toJson(metadata));
+
+        // When
+        migration.migrate();
+
+        // Then — the empty-value row is left untouched under its original key, the other is migrated
+        assertThat(fetchKeys()).containsExactlyInAnyOrder("legacy-key-empty", metadata.uid());
+    }
+
+    @Test
+    void shouldFailHardOnCorruptJson() {
+        // Given
+        insertRow("legacy-key-corrupt", "{not-valid-json");
+
+        // When / Then — the migration must not silently skip corrupt rows, since that would let
+        // the migration runner mark the script as applied and never retry it.
+        assertThatThrownBy(() -> migration.migrate())
+            .isInstanceOf(RuntimeException.class)
+            .hasMessageContaining("failed to parse metadata");
+    }
+
+    private PersistedKvMetadata metadata(String tenantId, String namespace, String name, int revision) {
+        return PersistedKvMetadata.builder()
+            .tenantId(tenantId)
+            .namespace(namespace)
+            .name(name)
+            .revision(revision)
+            .created(Instant.now())
+            .build();
+    }
+
+    private String toJson(PersistedKvMetadata metadata) throws Exception {
+        return MAPPER.writeValueAsString(metadata);
+    }
+
+    private void insertRow(String key, String value) {
+        dsl.insertInto(DSL.table("kv_metadata"))
+            .set(KEY_FIELD, key)
+            .set(VALUE_FIELD, value)
+            .execute();
+    }
+
+    private List<String> fetchKeys() {
+        return dsl.select(KEY_FIELD)
+            .from(DSL.table("kv_metadata"))
+            .fetch(KEY_FIELD);
+    }
+}


### PR DESCRIPTION
**Related Issue**

Closes https://github.com/kestra-io/kestra/issues/18506.

**Description**

Fixes a collision in KV metadata UIDs when a namespace and key combination can produce the same underscore-separated UID as another namespace and key combination.

The KV metadata UID now uses a pipe separator, ensuring that distinct (namespace, key) pairs produce distinct UIDs. A migration is also added to update existing KV metadata records to the new UID format.

**Demo Video**

Watch Here If embedded video doesn't work: []https://jam.dev/v/0a774d8f-c564-4c90-b66c-671965664efd

[jam-video.webm](https://github.com/user-attachments/assets/b57c9404-7461-4658-b4af-bfa77257f94e)