### PR TITLE
fix(core): reset pagination when returning to a list page

### DIFF
--- a/ui/src/composables/useRestoreUrl.ts
+++ b/ui/src/composables/useRestoreUrl.ts
@@ -1,6 +1,7 @@
 /**
- * Persists a page's URL query (filters, sort, pagination, etc.) to sessionStorage
- * so it can be restored when the user navigates back to that page with no query.
+ * Persists a page's URL query (filters, sort, etc.) to sessionStorage so it can be
+ * restored when the user navigates back to that page with no query. Pagination
+ * (page/size) is excluded (PY-1529) from restoration so returning lands on the default page.
  *
  * Auto-saves on every same-path query change and auto-restores on mount when the
  * URL has no query but a saved state exists. Exposes `loadInit` so consumers can
@@ -34,7 +35,7 @@ export function getRestoredQuery(route: RouteLocation) {
 
     for (const key in localStorageValue) {
         const value = localStorageValue[key]
-        if (query[key] || !value) continue
+        if (key === "page" || key === "size" || query[key] || !value) continue
         // empty array breaks the application
         if (Array.isArray(value) && value.length === 0) continue
         query[key] = value

--- a/ui/tests/unit/composables/useRestoreUrl.spec.ts
+++ b/ui/tests/unit/composables/useRestoreUrl.spec.ts
@@ -64,6 +64,17 @@ describe("useRestoreUrl", () => {
         expect(router.currentRoute.value.query).toEqual(SAVED_QUERY)
     })
 
+    it("does not restore pagination from the saved query", async () => {
+        const router = createTestRouter()
+        await router.push({name: "home", params: {tenant: "main", dashboard: "default"}})
+        window.sessionStorage.setItem("home_main_restore_url", JSON.stringify({...SAVED_QUERY, page: "10", size: "100"}))
+
+        wrapper = mountRestoreUrl(router)
+        await new Promise((resolve) => setTimeout(resolve, 150))
+
+        expect(router.currentRoute.value.query).toEqual(SAVED_QUERY)
+    })
+
     it("leaves an explicit query untouched", async () => {
         const router = createTestRouter()
         const explicit = {"filters[timeRange][EQUALS]": "P7D"}


### PR DESCRIPTION
Closes https://github.com/kestra-io/kestra-ee/issues/7241.

Issue: after paginating a list, say Executions page 10, navigating elsewhere and coming back through the menu restored page 10 instead of starting over.
Fix: the URL restore now skips page and size, so only filters and sort are brought back when a page is reopened with a bare URL.
Now: returning to any list lands on page 1 with the default size, while restored filters and shared links with explicit pagination keep working as before.
