### PR TITLE
[backport releases/v2.0.x] fix(flows): exclude drafts from the flow export endpoint

### DIFF
--- a/core/src/main/java/io/kestra/core/repositories/FlowRepositoryInterface.java
+++ b/core/src/main/java/io/kestra/core/repositories/FlowRepositoryInterface.java
@@ -224,6 +224,25 @@ public interface FlowRepositoryInterface extends QueryBuilderInterface<Flows.Fie
         @Nullable String tenantId,
         @Nullable List<QueryFilter> filters);
 
+    /**
+     * Same as {@link #findWithSource(Pageable, String, List)} but resolves each flow to its most
+     * recent non-draft revision. A flow whose latest revision is a draft therefore yields the last
+     * revision that was actually saved, and a flow with only draft revisions yields nothing.
+     * <p>
+     * Intended for consumers that must not observe drafts, such as exporting sources to Git. The
+     * revision fallback matters: returning nothing for a draft-headed flow that also has a saved
+     * revision would make external sync treat it as deleted.
+     * <p>
+     * The default implementation does not filter drafts. Implementations that track draft
+     * revisions should override it.
+     */
+    default ArrayListTotal<FlowWithSource> findWithSourceExcludingDrafts(
+        Pageable pageable,
+        @Nullable String tenantId,
+        @Nullable List<QueryFilter> filters) {
+        return this.findWithSource(pageable, tenantId, filters);
+    }
+
     ArrayListTotal<SearchResult<Flow>> findSourceCode(Pageable pageable, @Nullable String query, boolean caseSensitive, boolean wholeWord, boolean regex, SourceSearchScope scope, @Nullable String tenantId, @Nullable String namespace);
 
     List<String> findDistinctNamespace(String tenantId);

--- a/core/src/test/java/io/kestra/core/repositories/AbstractFlowRepositoryTest.java
+++ b/core/src/test/java/io/kestra/core/repositories/AbstractFlowRepositoryTest.java
@@ -647,6 +647,53 @@ public abstract class AbstractFlowRepositoryTest {
     }
 
     @Test
+    void findWithSourceExcludingDrafts_shouldFallBackToLastNonDraftRevision() {
+        String tenant = TestsUtils.randomTenant(this.getClass().getSimpleName());
+        String publishedId = IdUtils.create();
+        String draftLatestId = IdUtils.create();
+        String draftOnlyId = IdUtils.create();
+        final List<Flow> toDelete = new ArrayList<>();
+
+        try {
+            FlowWithSource published = flowRepository.create(createTestingLogFlow(tenant, publishedId, "p1"));
+            toDelete.add(published);
+
+            FlowWithSource draftLatestR1 = flowRepository.create(createTestingLogFlow(tenant, draftLatestId, "head"));
+            toDelete.add(draftLatestR1);
+            FlowWithSource draftLatestR2 = flowRepository.update(createTestingLogFlow(tenant, draftLatestId, "wip", true), draftLatestR1);
+            toDelete.add(draftLatestR2);
+
+            FlowWithSource draftOnly = flowRepository.create(createTestingLogFlow(tenant, draftOnlyId, "wip", true));
+            toDelete.add(draftOnly);
+
+            // findWithSource keeps showing the latest revision, drafts included.
+            assertThat(flowRepository.findWithSource(Pageable.UNPAGED, tenant, null).stream().map(Flow::getId).toList())
+                .contains(publishedId, draftLatestId, draftOnlyId);
+
+            List<FlowWithSource> exportable = flowRepository.findWithSourceExcludingDrafts(Pageable.UNPAGED, tenant, null);
+
+            assertThat(exportable.stream().filter(f -> f.getId().equals(publishedId)).findFirst())
+                .isPresent()
+                .hasValueSatisfying(f -> assertThat(f.getRevision()).isEqualTo(published.getRevision()));
+
+            // A draft on top of a saved revision must not hide the saved one, otherwise external
+            // sync would read the flow as deleted.
+            assertThat(exportable.stream().filter(f -> f.getId().equals(draftLatestId)).findFirst())
+                .isPresent()
+                .hasValueSatisfying(f ->
+                {
+                    assertThat(f.getRevision()).isEqualTo(draftLatestR1.getRevision());
+                    assertThat(f.isDraft()).isFalse();
+                    assertThat(f.getSource()).contains("head");
+                });
+
+            assertThat(exportable.stream().map(Flow::getId).toList()).doesNotContain(draftOnlyId);
+        } finally {
+            toDelete.forEach(this::deleteFlow);
+        }
+    }
+
+    @Test
     void saveNoRevision() {
         String tenant = TestsUtils.randomTenant(this.getClass().getSimpleName());
         FlowWithSource flow = builder(tenant).build();

--- a/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcFlowRepository.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcFlowRepository.java
@@ -708,8 +708,16 @@ public abstract class AbstractJdbcFlowRepository extends AbstractJdbcRepository 
             });
     }
 
-    @SuppressWarnings("unchecked")
     private <R extends Record, E> SelectConditionStep<R> fullTextSelect(String tenantId, DSLContext context, List<Field<Object>> field) {
+        return fullTextSelect(tenantId, context, field, false);
+    }
+
+    /**
+     * @param excludeDraft when true, resolves each flow to its most recent non-draft revision
+     *                     instead of its latest revision.
+     */
+    @SuppressWarnings("unchecked")
+    private <R extends Record, E> SelectConditionStep<R> fullTextSelect(String tenantId, DSLContext context, List<Field<Object>> field, boolean excludeDraft) {
         ArrayList<Field<?>> fields = new ArrayList<>();
         // add mandatory fields
         fields.add(VALUE_FIELD);
@@ -722,7 +730,7 @@ public abstract class AbstractJdbcFlowRepository extends AbstractJdbcRepository 
 
         return (SelectConditionStep<R>) context
             .select(fields)
-            .from(fromLastRevision(false))
+            .from(excludeDraft ? fromLastNonDraftRevision(false) : fromLastRevision(false))
             .join(jdbcRepository.getTable().as("ft"))
             .on(
                 DSL.field(DSL.quotedName("ft", "key")).eq(DSL.field(DSL.field(DSL.quotedName("rev", "key"))))
@@ -839,14 +847,23 @@ public abstract class AbstractJdbcFlowRepository extends AbstractJdbcRepository 
     }
 
     @Override
-    @SuppressWarnings({ "unchecked", "rawtypes" })
     public ArrayListTotal<FlowWithSource> findWithSource(Pageable pageable, @Nullable String tenantId, @Nullable List<QueryFilter> filters) {
+        return this.findWithSource(pageable, tenantId, filters, false);
+    }
+
+    @Override
+    public ArrayListTotal<FlowWithSource> findWithSourceExcludingDrafts(Pageable pageable, @Nullable String tenantId, @Nullable List<QueryFilter> filters) {
+        return this.findWithSource(pageable, tenantId, filters, true);
+    }
+
+    @SuppressWarnings({ "unchecked", "rawtypes" })
+    private ArrayListTotal<FlowWithSource> findWithSource(Pageable pageable, @Nullable String tenantId, @Nullable List<QueryFilter> filters, boolean excludeDraft) {
         return this.jdbcRepository
             .getDslContextWrapper()
             .transactionResult(configuration ->
             {
                 DSLContext context = DSL.using(configuration);
-                SelectConditionStep<Record> select = getFindFlowSelect(tenantId, filters, context, List.of(field("source_code")));
+                SelectConditionStep<Record> select = getFindFlowSelect(tenantId, filters, context, List.of(field("source_code")), excludeDraft);
 
                 return (ArrayListTotal) this.jdbcRepository.fetchPage(
                     context,
@@ -862,7 +879,11 @@ public abstract class AbstractJdbcFlowRepository extends AbstractJdbcRepository 
 
     @SuppressWarnings("unchecked")
     private <R extends Record> SelectConditionStep<R> getFindFlowSelect(String tenantId, List<QueryFilter> filters, DSLContext context, List<Field<Object>> additionalFieldsToSelect) {
-        var select = this.fullTextSelect(tenantId, context, additionalFieldsToSelect != null ? additionalFieldsToSelect : List.of());
+        return getFindFlowSelect(tenantId, filters, context, additionalFieldsToSelect, false);
+    }
+
+    private <R extends Record> SelectConditionStep<R> getFindFlowSelect(String tenantId, List<QueryFilter> filters, DSLContext context, List<Field<Object>> additionalFieldsToSelect, boolean excludeDraft) {
+        var select = this.fullTextSelect(tenantId, context, additionalFieldsToSelect != null ? additionalFieldsToSelect : List.of(), excludeDraft);
         select = select.and(this.filter(filters, null, Resource.FLOW));
         return (SelectConditionStep<R>) select;
     }

--- a/webserver/src/main/java/io/kestra/webserver/controllers/api/FlowController.java
+++ b/webserver/src/main/java/io/kestra/webserver/controllers/api/FlowController.java
@@ -825,7 +825,10 @@ public class FlowController {
     public HttpResponse<byte[]> exportFlowsByQuery(
         @Parameter(description = "Filters. PHP-style nested query is used - examples: `filters[labels][NOT_EQUALS][foo]=bar`, `filters[namespace][CONTAINS]=test`", in = ParameterIn.QUERY)
         @QueryFilterFormat(Resource.FLOW) List<QueryFilter> filters) throws IOException {
-        var flows = flowRepository.findWithSource(Pageable.UNPAGED, tenantService.resolveTenant(), filters);
+        // Drafts are not exportable: a draft-headed flow falls back to its last saved revision, and a
+        // flow that has only ever been a draft is omitted. Consumers such as the Git sync plugin read
+        // this ZIP as the authoritative set of saved flows.
+        var flows = flowRepository.findWithSourceExcludingDrafts(Pageable.UNPAGED, tenantService.resolveTenant(), filters);
         var bytes = HasSource.asZipFile(flows, flow -> flow.getNamespace() + "-" + flow.getId() + ".yml");
 
         return HttpResponse.ok(bytes).header("Content-Disposition", "attachment; filename=\"flows.zip\"");

--- a/webserver/src/test/java/io/kestra/webserver/controllers/api/FlowControllerTest.java
+++ b/webserver/src/test/java/io/kestra/webserver/controllers/api/FlowControllerTest.java
@@ -10,6 +10,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.*;
+import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 
 import org.hamcrest.Matchers;
@@ -1152,10 +1153,79 @@ class FlowControllerTest {
                     "by default /by-query endpoints should use specific PREFIX in legacy filter mapping, " +
                         "in this test, we should get all Flow when querying with namespace=io.kestra.tests, io.kestra.tests.subnamespace are accepted, but not io.kestra.tests2"
                 )
-                .isEqualTo(Helpers.FLOWS_COUNT - 1); // -1 because io.kestra.tests2 namespace
+                // -1 for the io.kestra.tests2 namespace, -2 for the invalid-draft-flow and
+                // webhook-draft fixtures, which the export endpoint excludes as drafts
+                .isEqualTo(Helpers.FLOWS_COUNT - 3);
         }
 
         file.delete();
+    }
+
+    @Test
+    void exportFlowsByQueryExcludesDrafts() throws IOException {
+        String savedId = "draftexportsaved";
+        String draftOnlyId = "draftexportdraftonly";
+
+        String savedSource = """
+            id: %s
+            namespace: %s
+
+            tasks:
+              - id: hello
+                type: io.kestra.plugin.core.log.Log
+                message: saved revision
+            """.formatted(savedId, TEST_NAMESPACE);
+        String draftOnTopSource = savedSource.replace("saved revision", "draft revision");
+        String draftOnlySource = """
+            id: %s
+            namespace: %s
+
+            tasks:
+              - id: hello
+                type: io.kestra.plugin.core.log.Log
+                message: never saved
+            """.formatted(draftOnlyId, TEST_NAMESPACE);
+
+        // saved normally, then a newer draft revision on top: the saved revision must still export
+        client.toBlocking().exchange(POST("/api/v1/main/flows", savedSource).contentType(MediaType.APPLICATION_YAML));
+        client.toBlocking().exchange(
+            PUT("/api/v1/main/flows/" + TEST_NAMESPACE + "/" + savedId + "?draft=true", draftOnTopSource).contentType(MediaType.APPLICATION_YAML)
+        );
+        // only ever a draft: must not export at all
+        client.toBlocking().exchange(POST("/api/v1/main/flows?draft=true", draftOnlySource).contentType(MediaType.APPLICATION_YAML));
+
+        File file = File.createTempFile("flows", ".zip");
+        try {
+            byte[] zip = client.toBlocking().retrieve(
+                HttpRequest.GET("/api/v1/main/flows/export/by-query?filters[namespace][EQUALS]=" + TEST_NAMESPACE),
+                Argument.of(byte[].class)
+            );
+            Files.write(file.toPath(), zip);
+
+            try (ZipFile zipFile = new ZipFile(file)) {
+                List<String> names = zipFile.stream().map(ZipEntry::getName).toList();
+
+                assertThat(names)
+                    .as("a flow whose only revision is a draft is not exported")
+                    .doesNotContain(TEST_NAMESPACE + "-" + draftOnlyId + ".yml");
+                assertThat(names)
+                    .as("a draft-headed flow still exports, through its last saved revision")
+                    .contains(TEST_NAMESPACE + "-" + savedId + ".yml");
+
+                String exported = new String(
+                    zipFile.getInputStream(zipFile.getEntry(TEST_NAMESPACE + "-" + savedId + ".yml")).readAllBytes(),
+                    StandardCharsets.UTF_8
+                );
+                assertThat(exported)
+                    .as("the exported source is the saved revision, not the draft on top")
+                    .contains("saved revision")
+                    .doesNotContain("draft revision");
+            }
+        } finally {
+            file.delete();
+            client.toBlocking().exchange(DELETE("/api/v1/main/flows/" + TEST_NAMESPACE + "/" + savedId));
+            client.toBlocking().exchange(DELETE("/api/v1/main/flows/" + TEST_NAMESPACE + "/" + draftOnlyId));
+        }
     }
 
     @Test


### PR DESCRIPTION
Backport of:
- kestra-io/kestra#18924 — fix(flows): exclude drafts from the flow export endpoint (cherry-picked from `26cd1eff2b1d746ce24a963c8e190e36a9afb55d`)

Cherry-picked with `-x`, applied cleanly. Drafts shipped in 2.0, so the bug is live on this branch.

Merge this before kestra-io/kestra-ee#10694, which implements the same behaviour for Elasticsearch and needs the interface method from here.