### PR TITLE
fix(dashboards): load the picked dashboard's charts after a dashboard switch

### DIFF
--- a/ui/src/components/dashboard/Dashboard.vue
+++ b/ui/src/components/dashboard/Dashboard.vue
@@ -157,6 +157,10 @@
             }
         }
 
+        // Unmount the charts before anything about the dashboard changes: a chart reads its dashboard id once, on
+        // setup, so one left mounted across the swap keeps requesting the previous dashboard's charts, now routed as
+        // the new dashboard's, and either 404s or shows data that belongs to the other dashboard.
+        charts.value = []
         isDashboardBundledWithUI.value = false
         if (id === "default") {
             // if requested dashboard is the default one, we first try to find if there is any configured in the DB by an admin

--- a/ui/src/components/dashboard/composables/useDashboards.ts
+++ b/ui/src/components/dashboard/composables/useDashboards.ts
@@ -32,7 +32,8 @@ export const isExportableChart = (type: string): boolean => !isMarkdownChart(typ
 
 export const getChartTitle = (chart: Chart): string => chart.chartOptions?.displayName ?? chart.id
 
-export const getPropertyValue = (data: Record<string, any>, property: "value" | "description"): string => data.results?.[0]?.[property]
+/** `data` is undefined when the chart went away before its request answered, or when the request 404ed. */
+export const getPropertyValue = (data: Record<string, any> | undefined, property: "value" | "description"): string | undefined => data?.results?.[0]?.[property]
 
 export const isPaginationEnabled = (chart: Chart): boolean => chart.chartOptions?.pagination?.enabled ?? false
 


### PR DESCRIPTION
Closes https://github.com/kestra-io/kestra-ee/issues/10682.
Related to https://github.com/kestra-io/kestra/pull/18954.
Related to https://github.com/kestra-io/kestra-ee/pull/10696.

Backport of https://github.com/kestra-io/kestra/pull/18954 to `releases/v2.0.x`, cherry-picked with no adaptation - the touched files are identical on both branches. Companion `EE` backport: https://github.com/kestra-io/kestra-ee/pull/10696. Both are needed for the full fix on 2.0; they can merge in either order.