### PR TITLE
fix(plugins): space a property's title and description apart in the compact docs panel

### DIFF
--- a/ui/src/components/plugins/schema/SchemaPropertiesSection.vue
+++ b/ui/src/components/plugins/schema/SchemaPropertiesSection.vue
@@ -84,14 +84,8 @@
                                 class="compact-prop-desc"
                             >
                                 <slot
-                                    v-if="property.title"
                                     name="markdown"
-                                    :content="sanitizeForMarkdown(property.title)"
-                                />
-                                <slot
-                                    v-if="property.description"
-                                    name="markdown"
-                                    :content="sanitizeForMarkdown(property.description)"
+                                    :content="propertyDoc(property)"
                                 />
                             </div>
                         </div>
@@ -239,6 +233,20 @@
     watch(autoExpanded, (expanded) => {
         if (expanded) emit("expand")
     })
+
+    // The title says what a property is, the description carries the caveat, so the
+    // compact view renders both - matching PropertyDetail. Joined into a single slot
+    // call rather than one per field: every consumer wraps the `markdown` slot in its
+    // own element (SchemaToHtml adds `div.markdown` around each render), so two calls
+    // put the paragraphs in separate containers where neither `p + p` nor an
+    // `.ks-markdown + .ks-markdown` sibling rule can reach them, and the two lines
+    // collapse together. One render keeps them siblings, so `p + p` spaces them.
+    function propertyDoc(property: JSONProperty): string {
+        return [property.title, property.description]
+            .filter((text): text is string => Boolean(text))
+            .map(sanitizeForMarkdown)
+            .join("\n\n")
+    }
 
     function isPropertyVisible(key: string, property: JSONProperty): boolean {
         if (!props.showFilter) return true
@@ -521,10 +529,6 @@
         }
 
         :deep(p + p) {
-            margin-top: var(--ks-spacing-2);
-        }
-
-        :deep(.ks-markdown + .ks-markdown) {
             margin-top: var(--ks-spacing-2);
         }
 


### PR DESCRIPTION
Closes https://github.com/kestra-io/kestra/issues/17948.
Related to https://github.com/kestra-io/kestra/pull/18018.
Related to https://github.com/kestra-io/kestra/pull/18514.

### ✨ Description

`2.0` backport of https://github.com/kestra-io/kestra/pull/18018. The diff is byte-identical - `SchemaPropertiesSection.vue` is the same file on `develop` and on `releases/v2.0.x`, so the change applied without adjustment.

In the compact properties panel of the plugin documentation, a property's `title` and `description` are rendered through two separate `#markdown` slot calls. Every consumer wraps each render in its own element - `SchemaToHtml.vue` adds a `div.markdown` around it - so the two paragraphs land in separate containers, and neither spacing rule on `.compact-prop-desc` can reach them:

- `p + p` does not match, because each paragraph is the only child of its own container.
- `.ks-markdown + .ks-markdown` does not match either, because the two `.ks-markdown` elements are not siblings.

The `DOM` on `releases/v2.0.x` today:

```html
<div class="compact-prop-desc">
  <div class="markdown"><div class="ks-markdown"><p>title</p></div></div>
  <div class="markdown"><div class="ks-markdown"><p>description</p></div></div>
</div>
```

Measured against real `PurgeExecutions` schema data, the gap between the two lines is **0px**.

Both fields now go through a **single** slot call, joined as two markdown paragraphs and each still sanitized individually through `sanitizeForMarkdown`. That puts the two `<p>` back inside one `.ks-markdown`, where `p + p` applies and gives the intended `var(--ks-spacing-2)` gap - **8px** measured. The now-unreachable `.ks-markdown + .ks-markdown` rule is removed.

Properties that define only a `title` or only a `description` are unaffected, and the expanded view (`PropertyDetail.vue`) is untouched.

### 🖼️ Before / After

**Before** - `title` and `description` run together, no gap:

<img width="1660" alt="before" src="https://raw.githubusercontent.com/MilosPaunovic/kestra/8804935c7d8d10a32b3b4c9f7ec4a41aebd990ca/17948/before.png" />

**After** - one paragraph gap between them:

<img width="1660" alt="after" src="https://raw.githubusercontent.com/MilosPaunovic/kestra/8804935c7d8d10a32b3b4c9f7ec4a41aebd990ca/17948/after.png" />

### 🎨 Frontend Checklist

- [x] Type checking passes (`npm run check:types`)
- [x] `eslint` clean on the changed file
- [x] Screenshots attached showing the `UI` change

`releases/v1.3.x` and `releases/v1.0.x` need no backport - they do not have `ui/src/components/plugins/schema/` at all.
