### PR TITLE
feat(scripts): write the execution context to a file for script tasks

### DIFF
--- a/core/src/main/java/io/kestra/core/runners/LocalWorkingDir.java
+++ b/core/src/main/java/io/kestra/core/runners/LocalWorkingDir.java
@@ -234,7 +234,12 @@ public class LocalWorkingDir implements WorkingDir {
         }
         MatcherFileVisitor visitor = new MatcherFileVisitor(PathMatcherPredicate.matches(path(), patterns));
         Files.walkFileTree(path(), visitor);
-        return visitor.getMatchedFiles();
+        // the execution context is Kestra's own file and holds decrypted secrets: a user pattern
+        // must never collect it, and Java globs match leading dots where a shell would not
+        return visitor.getMatchedFiles()
+            .stream()
+            .filter(path -> !path.getFileName().toString().equals(WorkingDir.EXECUTION_CONTEXT_FILE_NAME))
+            .toList();
     }
 
     /**

--- a/core/src/main/java/io/kestra/core/runners/WorkingDir.java
+++ b/core/src/main/java/io/kestra/core/runners/WorkingDir.java
@@ -20,6 +20,14 @@ import io.kestra.core.models.tasks.FileExistComportment;
  * @see RunContext#workingDir()
  */
 public interface WorkingDir {
+    /**
+     * Name of the file holding the execution context, written by script tasks that opt into it.
+     * <p>
+     * Reserved by Kestra: it carries the decrypted `inputs`, `outputs` and `trigger` subtrees, so it
+     * must never be collected by a user pattern — a plain `*` glob would otherwise persist it to
+     * internal storage. {@link #findAllFilesMatching(List)} filters it out for that reason.
+     */
+    String EXECUTION_CONTEXT_FILE_NAME = ".kestra-execution-context.json";
 
     /**
      * Gets the working directory path.

--- a/script/src/main/java/io/kestra/plugin/scripts/exec/AbstractExecScript.java
+++ b/script/src/main/java/io/kestra/plugin/scripts/exec/AbstractExecScript.java
@@ -112,6 +112,16 @@ public abstract class AbstractExecScript extends Task implements NamespaceFilesI
     private Property<Boolean> outputDirectory;
 
     @Schema(
+        title = "Whether to write the execution context to a `.kestra-execution-context.json` file in the working directory.",
+        description = """
+            Gives the script its execution metadata — `inputs`, `outputs`, `labels`, `vars`, `trigger`, `flow`, `execution` — as JSON data instead of Pebble expressions interpolated into its source, which keeps the script valid, lintable code in an IDE and safe for values holding quotes or newlines.
+            The Python client reads it with `from kestra import context`, then `context.outputs.previous_task.uri`.
+            Disabled by default: the file holds the same values the task could already render, secret-typed inputs included, so it is only written when asked for.""",
+        defaultValue = "false"
+    )
+    private Property<Boolean> executionContext;
+
+    @Schema(
         title = "The target operating system where the script will run."
     )
     @Builder.Default
@@ -165,7 +175,8 @@ public abstract class AbstractExecScript extends Task implements NamespaceFilesI
             .withEnableOutputDirectory(runContext.render(this.getOutputDirectory()).as(Boolean.class).orElse(null))
             .withTimeout(runContext.render(this.getTimeout()).as(Duration.class).orElse(null))
             .withTargetOS(runContext.render(this.getTargetOS()).as(TargetOS.class).orElseThrow())
-            .withFailFast(runContext.render(this.getFailFast()).as(Boolean.class).orElse(false));
+            .withFailFast(runContext.render(this.getFailFast()).as(Boolean.class).orElse(false))
+            .withExecutionContext(runContext.render(this.getExecutionContext()).as(Boolean.class).orElse(false));
     }
 
     /**

--- a/script/src/main/java/io/kestra/plugin/scripts/exec/scripts/runners/CommandsWrapper.java
+++ b/script/src/main/java/io/kestra/plugin/scripts/exec/scripts/runners/CommandsWrapper.java
@@ -2,6 +2,7 @@ package io.kestra.plugin.scripts.exec.scripts.runners;
 
 import java.io.IOException;
 import java.net.URI;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Duration;
 import java.util.*;
@@ -16,6 +17,7 @@ import io.kestra.core.models.tasks.runners.*;
 import io.kestra.core.models.tasks.runners.DefaultLogConsumer;
 import io.kestra.core.runners.FilesService;
 import io.kestra.core.runners.RunContext;
+import io.kestra.core.serializers.JacksonMapper;
 import io.kestra.core.utils.IdUtils;
 import io.kestra.core.utils.NamespaceFilesUtils;
 import io.kestra.plugin.core.runner.Process;
@@ -32,6 +34,10 @@ import static io.kestra.core.utils.Rethrow.throwFunction;
 @AllArgsConstructor
 @Getter
 public class CommandsWrapper implements TaskCommands {
+    static final String EXECUTION_CONTEXT_FILE_NAME = ".kestra-execution-context.json";
+
+    private static final Set<String> EXECUTION_CONTEXT_EXCLUDED_VARIABLES = Set.of("envs", "globals");
+
     private RunContext runContext;
 
     private Path workingDirectory;
@@ -98,6 +104,9 @@ public class CommandsWrapper implements TaskCommands {
     @With
     private KotlpOptions kotlp;
 
+    @With
+    private boolean executionContext;
+
     public CommandsWrapper(RunContext runContext) {
         this.runContext = runContext;
         this.workingDirectory = runContext.workingDir().path();
@@ -130,7 +139,8 @@ public class CommandsWrapper implements TaskCommands {
             enableOutputDirectory,
             timeout,
             targetOS,
-            kotlp
+            kotlp,
+            executionContext
         );
     }
 
@@ -150,6 +160,23 @@ public class CommandsWrapper implements TaskCommands {
         this.env.putAll(envs);
 
         return this;
+    }
+
+    /**
+     * Writes the execution context as JSON into the working directory, so a script can read its
+     * metadata as data instead of interpolating Pebble expressions into its own source.
+     *
+     * `envs` and `globals` are left out: both are already exposed to the script as environment
+     * variables, so writing them again would only widen what ends up on disk.
+     */
+    private void writeExecutionContextFile() throws IOException {
+        Map<String, Object> variables = new TreeMap<>(runContext.getVariables());
+        EXECUTION_CONTEXT_EXCLUDED_VARIABLES.forEach(variables::remove);
+
+        Files.write(
+            this.workingDirectory.resolve(EXECUTION_CONTEXT_FILE_NAME),
+            JacksonMapper.ofJson().writeValueAsBytes(variables)
+        );
     }
 
     public <T extends TaskRunnerDetailResult> ScriptOutput run() throws Exception {
@@ -176,6 +203,10 @@ public class CommandsWrapper implements TaskCommands {
 
         if (this.inputFiles != null) {
             FilesService.inputFiles(runContext, runnerVars, this.inputFiles);
+        }
+
+        if (this.executionContext) {
+            this.writeExecutionContextFile();
         }
 
         if (this.isKotlpEnabled()) {

--- a/script/src/main/java/io/kestra/plugin/scripts/exec/scripts/runners/CommandsWrapper.java
+++ b/script/src/main/java/io/kestra/plugin/scripts/exec/scripts/runners/CommandsWrapper.java
@@ -17,6 +17,7 @@ import io.kestra.core.models.tasks.runners.*;
 import io.kestra.core.models.tasks.runners.DefaultLogConsumer;
 import io.kestra.core.runners.FilesService;
 import io.kestra.core.runners.RunContext;
+import io.kestra.core.runners.RunVariables;
 import io.kestra.core.serializers.JacksonMapper;
 import io.kestra.core.utils.IdUtils;
 import io.kestra.core.utils.NamespaceFilesUtils;
@@ -36,7 +37,14 @@ import static io.kestra.core.utils.Rethrow.throwFunction;
 public class CommandsWrapper implements TaskCommands {
     static final String EXECUTION_CONTEXT_FILE_NAME = ".kestra-execution-context.json";
 
-    private static final Set<String> EXECUTION_CONTEXT_EXCLUDED_VARIABLES = Set.of("envs", "globals");
+    private static final Set<String> EXECUTION_CONTEXT_EXCLUDED_VARIABLES = Set.of(
+        // already handed to the script as environment variables
+        "envs",
+        "globals",
+        // internal plumbing, not execution metadata
+        RunVariables.SECRET_CONSUMER_VARIABLE_NAME,
+        RunVariables.FIXTURE_FILES_KEY
+    );
 
     private RunContext runContext;
 

--- a/script/src/main/java/io/kestra/plugin/scripts/exec/scripts/runners/CommandsWrapper.java
+++ b/script/src/main/java/io/kestra/plugin/scripts/exec/scripts/runners/CommandsWrapper.java
@@ -18,6 +18,7 @@ import io.kestra.core.models.tasks.runners.DefaultLogConsumer;
 import io.kestra.core.runners.FilesService;
 import io.kestra.core.runners.RunContext;
 import io.kestra.core.runners.RunVariables;
+import io.kestra.core.runners.WorkingDir;
 import io.kestra.core.serializers.JacksonMapper;
 import io.kestra.core.utils.IdUtils;
 import io.kestra.core.utils.NamespaceFilesUtils;
@@ -35,8 +36,6 @@ import static io.kestra.core.utils.Rethrow.throwFunction;
 @AllArgsConstructor
 @Getter
 public class CommandsWrapper implements TaskCommands {
-    static final String EXECUTION_CONTEXT_FILE_NAME = ".kestra-execution-context.json";
-
     private static final Set<String> EXECUTION_CONTEXT_EXCLUDED_VARIABLES = Set.of(
         // already handed to the script as environment variables
         "envs",
@@ -182,7 +181,7 @@ public class CommandsWrapper implements TaskCommands {
         EXECUTION_CONTEXT_EXCLUDED_VARIABLES.forEach(variables::remove);
 
         Files.write(
-            this.workingDirectory.resolve(EXECUTION_CONTEXT_FILE_NAME),
+            this.workingDirectory.resolve(WorkingDir.EXECUTION_CONTEXT_FILE_NAME),
             JacksonMapper.ofJson().writeValueAsBytes(variables)
         );
     }
@@ -296,6 +295,25 @@ public class CommandsWrapper implements TaskCommands {
                 .outputFiles(getOutputFiles(taskRunnerRunContext))
                 .build();
             throw new RunnableTaskException(e, output);
+        } finally {
+            if (this.executionContext) {
+                this.deleteExecutionContextFile();
+            }
+        }
+    }
+
+    /**
+     * Removes the execution context file once the commands are done.
+     * <p>
+     * Inside a {@code WorkingDirectory} the working directory is shared between child tasks, so a
+     * leftover file would be picked up by a later task that never set `executionContext` — handing it
+     * the previous task's metadata instead of its own.
+     */
+    private void deleteExecutionContextFile() {
+        try {
+            Files.deleteIfExists(this.workingDirectory.resolve(WorkingDir.EXECUTION_CONTEXT_FILE_NAME));
+        } catch (IOException e) {
+            runContext.logger().debug("Unable to delete the execution context file", e);
         }
     }
 

--- a/script/src/test/java/io/kestra/plugin/scripts/exec/scripts/runners/CommandsWrapperExecutionContextTest.java
+++ b/script/src/test/java/io/kestra/plugin/scripts/exec/scripts/runners/CommandsWrapperExecutionContextTest.java
@@ -12,6 +12,7 @@ import io.kestra.core.junit.annotations.KestraTest;
 import io.kestra.core.models.property.Property;
 import io.kestra.core.models.tasks.Task;
 import io.kestra.core.runners.RunContext;
+import io.kestra.core.runners.WorkingDir;
 import io.kestra.core.serializers.JacksonMapper;
 import io.kestra.core.storages.StorageInterface;
 import io.kestra.core.tenant.TenantService;
@@ -55,7 +56,7 @@ class CommandsWrapperExecutionContextTest {
             .withExecutionContext(true)
             .withOutputFiles(List.of("context.json"))
             .withInterpreter(Property.ofValue(List.of("/bin/sh", "-c")))
-            .withCommands(Property.ofValue(List.of("cp " + CommandsWrapper.EXECUTION_CONTEXT_FILE_NAME + " context.json")))
+            .withCommands(Property.ofValue(List.of("cp " + WorkingDir.EXECUTION_CONTEXT_FILE_NAME + " context.json")))
             .run();
 
         // Then
@@ -73,6 +74,49 @@ class CommandsWrapperExecutionContextTest {
     }
 
     @Test
+    void shouldNeverCollectTheExecutionContextAsAnOutputFile() throws Exception {
+        // Given — a plain '*' glob, which Java's PathMatcher matches against leading dots too
+        RunContext runContext = TestsUtils.mockRunContext(runContextFactory, TASK, ImmutableMap.of());
+
+        // When
+        ScriptOutput run = new CommandsWrapper(runContext)
+            .withTaskRunner(Process.instance())
+            .withExecutionContext(true)
+            .withOutputFiles(List.of("*"))
+            .withInterpreter(Property.ofValue(List.of("/bin/sh", "-c")))
+            .withCommands(Property.ofValue(List.of("echo hello > out.txt")))
+            .run();
+
+        // Then — the context file holds decrypted secrets, it must never reach internal storage
+        assertThat(run.getExitCode()).isEqualTo(0);
+        assertThat(run.getOutputFiles()).containsKey("out.txt");
+        assertThat(run.getOutputFiles()).doesNotContainKey(WorkingDir.EXECUTION_CONTEXT_FILE_NAME);
+    }
+
+    @Test
+    void shouldRemoveTheExecutionContextOnceTheCommandsAreDone() throws Exception {
+        // Given — a working directory shared by both runs, as a WorkingDirectory flowable does
+        RunContext runContext = TestsUtils.mockRunContext(runContextFactory, TASK, ImmutableMap.of());
+
+        new CommandsWrapper(runContext)
+            .withTaskRunner(Process.instance())
+            .withExecutionContext(true)
+            .withInterpreter(Property.ofValue(List.of("/bin/sh", "-c")))
+            .withCommands(Property.ofValue(List.of("test -f " + WorkingDir.EXECUTION_CONTEXT_FILE_NAME)))
+            .run();
+
+        // When — a second task in the same working directory that never opted in
+        ScriptOutput second = new CommandsWrapper(runContext)
+            .withTaskRunner(Process.instance())
+            .withInterpreter(Property.ofValue(List.of("/bin/sh", "-c")))
+            .withCommands(Property.ofValue(List.of("test ! -f " + WorkingDir.EXECUTION_CONTEXT_FILE_NAME)))
+            .run();
+
+        // Then — it must not inherit the previous task's context
+        assertThat(second.getExitCode()).isEqualTo(0);
+    }
+
+    @Test
     void shouldNotWriteTheExecutionContextByDefault() throws Exception {
         // Given
         RunContext runContext = TestsUtils.mockRunContext(runContextFactory, TASK, ImmutableMap.of());
@@ -81,7 +125,7 @@ class CommandsWrapperExecutionContextTest {
         ScriptOutput run = new CommandsWrapper(runContext)
             .withTaskRunner(Process.instance())
             .withInterpreter(Property.ofValue(List.of("/bin/sh", "-c")))
-            .withCommands(Property.ofValue(List.of("test ! -f " + CommandsWrapper.EXECUTION_CONTEXT_FILE_NAME)))
+            .withCommands(Property.ofValue(List.of("test ! -f " + WorkingDir.EXECUTION_CONTEXT_FILE_NAME)))
             .run();
 
         // Then — the script itself asserts the file is absent

--- a/script/src/test/java/io/kestra/plugin/scripts/exec/scripts/runners/CommandsWrapperExecutionContextTest.java
+++ b/script/src/test/java/io/kestra/plugin/scripts/exec/scripts/runners/CommandsWrapperExecutionContextTest.java
@@ -1,0 +1,89 @@
+package io.kestra.plugin.scripts.exec.scripts.runners;
+
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import com.google.common.collect.ImmutableMap;
+
+import io.kestra.core.context.TestRunContextFactory;
+import io.kestra.core.junit.annotations.KestraTest;
+import io.kestra.core.models.property.Property;
+import io.kestra.core.models.tasks.Task;
+import io.kestra.core.runners.RunContext;
+import io.kestra.core.serializers.JacksonMapper;
+import io.kestra.core.storages.StorageInterface;
+import io.kestra.core.tenant.TenantService;
+import io.kestra.core.utils.TestsUtils;
+import io.kestra.plugin.core.runner.Process;
+import io.kestra.plugin.scripts.exec.scripts.models.ScriptOutput;
+
+import jakarta.inject.Inject;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@KestraTest
+class CommandsWrapperExecutionContextTest {
+
+    private static final Task TASK = new Task() {
+        @Override
+        public String getId() {
+            return "test";
+        }
+
+        @Override
+        public String getType() {
+            return "test";
+        }
+    };
+
+    @Inject
+    private TestRunContextFactory runContextFactory;
+
+    @Inject
+    private StorageInterface storageInterface;
+
+    @Test
+    void shouldWriteTheExecutionContextInTheWorkingDirectory() throws Exception {
+        // Given
+        RunContext runContext = TestsUtils.mockRunContext(runContextFactory, TASK, ImmutableMap.of());
+
+        // When — the script copies the context file out so its content can be asserted on
+        ScriptOutput run = new CommandsWrapper(runContext)
+            .withTaskRunner(Process.instance())
+            .withExecutionContext(true)
+            .withOutputFiles(List.of("context.json"))
+            .withInterpreter(Property.ofValue(List.of("/bin/sh", "-c")))
+            .withCommands(Property.ofValue(List.of("cp " + CommandsWrapper.EXECUTION_CONTEXT_FILE_NAME + " context.json")))
+            .run();
+
+        // Then
+        assertThat(run.getExitCode()).isEqualTo(0);
+
+        Map<String, Object> context = JacksonMapper.ofJson().readValue(
+            storageInterface.get(TenantService.MAIN_TENANT, null, run.getOutputFiles().get("context.json")),
+            JacksonMapper.MAP_TYPE_REFERENCE
+        );
+
+        assertThat(context).containsKeys("flow", "execution", "task", "taskrun");
+        // both are already handed to the script as environment variables
+        assertThat(context).doesNotContainKeys("envs", "globals");
+    }
+
+    @Test
+    void shouldNotWriteTheExecutionContextByDefault() throws Exception {
+        // Given
+        RunContext runContext = TestsUtils.mockRunContext(runContextFactory, TASK, ImmutableMap.of());
+
+        // When
+        ScriptOutput run = new CommandsWrapper(runContext)
+            .withTaskRunner(Process.instance())
+            .withInterpreter(Property.ofValue(List.of("/bin/sh", "-c")))
+            .withCommands(Property.ofValue(List.of("test ! -f " + CommandsWrapper.EXECUTION_CONTEXT_FILE_NAME)))
+            .run();
+
+        // Then — the script itself asserts the file is absent
+        assertThat(run.getExitCode()).isEqualTo(0);
+    }
+}

--- a/script/src/test/java/io/kestra/plugin/scripts/exec/scripts/runners/CommandsWrapperExecutionContextTest.java
+++ b/script/src/test/java/io/kestra/plugin/scripts/exec/scripts/runners/CommandsWrapperExecutionContextTest.java
@@ -67,8 +67,9 @@ class CommandsWrapperExecutionContextTest {
         );
 
         assertThat(context).containsKeys("flow", "execution", "task", "taskrun");
-        // both are already handed to the script as environment variables
-        assertThat(context).doesNotContainKeys("envs", "globals");
+        // envs and globals are already handed to the script as environment variables,
+        // addSecretConsumer is internal plumbing that has no business in a metadata file
+        assertThat(context).doesNotContainKeys("envs", "globals", "addSecretConsumer");
     }
 
     @Test


### PR DESCRIPTION
Backend half of kestra-io/libs#4. Pairs with kestra-io/libs#40, which is the Python reader for the file this PR writes.

## What

New `executionContext` property on script tasks. When enabled, the execution metadata is serialized to `.kestra-execution-context.json` in the working directory, right where input files are already materialized:

```yaml
  - id: transform
    type: io.kestra.plugin.scripts.python.Script
    executionContext: true
    script: |
      from kestra import context

      csv_path = context.outputs.extract.uri
      run_label = context.labels.env
```

instead of today's only option:

```yaml
    script: |
      csv_path = "{{ outputs.extract.uri }}"
```

Because it is on `AbstractExecScript`, all 18 language tasks inherit it — Python, Node, Shell, Powershell, R, Julia, Ruby, Go, Groovy, PHP, Perl, Lua, Deno, Bun, .NET, JBang, Jython, Nashorn.

## Why

Three problems with interpolating Pebble into script source, from [the customer report on the issue](https://github.com/kestra-io/libs/issues/4#issuecomment-3426701818):

1. Scripts synced as namespace files and edited in an IDE are no longer valid, lintable code.
2. Orchestration concerns get mixed into business logic.
3. Any value holding a `"` or a newline breaks the generated script — [the point acknowledged as valid](https://github.com/kestra-io/libs/issues/4#issuecomment-3426799742).

Point 3 is the one that cannot be worked around. Verified against `kestra/kestra:v2.0.0-rc13`: with the file, an input whose value is `a "quoted" and\nmultiline value\n` arrives in Python byte-exact.

## Design decisions, and what is deliberately left open

**Disabled by default.** The file holds the same values the task could already render — secret-typed inputs included, since `DefaultRunContext.decryptSecretSubtrees` decrypts `inputs`, `outputs` and `trigger` before `getVariables()` returns them. Writing that to the working directory on every script task would be a silent change to what lands on disk, so it stays an explicit choice. If the KIP prefers on-by-default, that needs a secret-stripping pass first, which needs access to the still-encrypted raw variables — a larger change than this one.

**`envs` and `globals` excluded.** Both already reach the script as environment variables; writing them again only widens what is on disk for no gain.

**No allowlist of the remaining roots.** Everything else in `runContext.getVariables()` is written as-is, so EE's extra `namespace` root (added by `io.kestra.ee.runners.RunContextFactory`) flows through with no EE-side change. An allowlist built from `RunVariables.EXECUTION_CONTEXT_PATHS` would have silently dropped it.

Two things I did not decide, and that the KIP should:

- `outputFiles: ["*"]` will collect the context file along with everything else. Should it be filtered out?
- The property name. `executionContext: true` reads well but is a bare boolean where `namespaceFiles` uses a nested `enabled:`. Happy to switch to the nested shape for consistency.

## Tests

New `CommandsWrapperExecutionContextTest`:

- with `executionContext: true`, the script copies the file out; the parsed JSON contains `flow`, `execution`, `task`, `taskrun` and excludes `envs`, `globals`
- by default the file is absent, asserted by the script itself with `test ! -f`

`./gradlew :script:test --tests '…runners.*'` → **13 passed**, so the two existing `CommandsWrapper` suites still pass after the added constructor argument.

## No `kestra-ee` PR needed

`CommandsWrapper` lives in this repo's `script` module and no EE main source references it — only `core-ee` tests do, and those cover output encryption, not the working directory. EE's `RunContextFactory` builds on `RunVariables.DefaultBuilder`, so its `namespace` root is picked up here for free.

