### PR TITLE
fix(design-system): separate the two halves of a split button with a visible divider

### DIFF
--- a/ui/packages/design-system/src/components/Navigation/KsDropdown/KsDropdown.vue
+++ b/ui/packages/design-system/src/components/Navigation/KsDropdown/KsDropdown.vue
@@ -46,6 +46,20 @@
     @use '../../../assets/styles/el-ns';
     @use 'element-plus/theme-chalk/src/dropdown';
 
+    .kel-dropdown {
+        // Element Plus draws the split-button divider as the border colour at half opacity,
+        // which vanishes against every Kestra button fill; use the strong border token instead
+        .kel-dropdown__caret-button.kel-button::before {
+            background: var(--ks-border-strong);
+            opacity: 1;
+        }
+
+        // a primary button is filled, so use the lighter button-group divide colour instead
+        .kel-dropdown__caret-button.kel-button--primary:not(.is-disabled)::before {
+            background: var(--kel-button-divide-border-color);
+        }
+    }
+
     .kel-dropdown__popper {
         --kel-popper-border-radius: var(--ks-radius-base);
         --kel-dropdown-menuItem-hover-fill: var(--ks-bg-hover-elevated);

--- a/ui/packages/design-system/tests/storybook/Navigation/KsDropdown.stories.ts
+++ b/ui/packages/design-system/tests/storybook/Navigation/KsDropdown.stories.ts
@@ -1,4 +1,5 @@
 import type {Meta, StoryObj} from "@storybook/vue3-vite"
+import {expect} from "storybook/test"
 import {ref} from "vue"
 import KsButton from "../../../src/components/Basic/KsButton/KsButton.vue"
 import KsDropdown from "../../../src/components/Navigation/KsDropdown/KsDropdown.vue"
@@ -127,4 +128,56 @@ export const WithDisabledItems: Story = {
             </div>
         `,
     }),
+}
+
+/**
+ * Split button – the label runs the default action, the caret opens the menu.
+ * The halves are plain `ElButton`s, so pass `buttonProps: {plain: true}` to get the
+ * secondary look that `KsButton` applies by default.
+ */
+export const SplitButton: Story = {
+    render: () => ({
+        components: {KsDropdown, KsDropdownItem, KsDropdownMenu},
+        template: `
+            <div style="padding:48px;display:flex;gap:16px;flex-wrap:wrap;align-items:center">
+                <ks-dropdown split-button type="primary">
+                    Save
+                    <template #dropdown>
+                        <ks-dropdown-menu>
+                            <ks-dropdown-item>Save as draft</ks-dropdown-item>
+                            <ks-dropdown-item>Save and execute</ks-dropdown-item>
+                        </ks-dropdown-menu>
+                    </template>
+                </ks-dropdown>
+                <ks-dropdown split-button type="default" :button-props="{plain: true}">
+                    Download
+                    <template #dropdown>
+                        <ks-dropdown-menu>
+                            <ks-dropdown-item>September 2026</ks-dropdown-item>
+                            <ks-dropdown-item>August 2026</ks-dropdown-item>
+                        </ks-dropdown-menu>
+                    </template>
+                </ks-dropdown>
+                <ks-dropdown split-button type="primary" disabled>
+                    Disabled
+                    <template #dropdown>
+                        <ks-dropdown-menu>
+                            <ks-dropdown-item>Option</ks-dropdown-item>
+                        </ks-dropdown-menu>
+                    </template>
+                </ks-dropdown>
+            </div>
+        `,
+    }),
+    async play({canvasElement}) {
+        const carets = Array.from(canvasElement.querySelectorAll<HTMLElement>(".kel-dropdown__caret-button"))
+        await expect(carets).toHaveLength(3)
+        // every variant separates its halves with a divider that stands out from the button fill
+        for (const caret of carets) {
+            const divider = getComputedStyle(caret, "::before")
+            await expect(divider.width).toBe("1px")
+            await expect(divider.opacity).toBe("1")
+            await expect(divider.backgroundColor).not.toBe(getComputedStyle(caret).backgroundColor)
+        }
+    },
 }


### PR DESCRIPTION
Closes https://github.com/kestra-io/kestra-ee/issues/10126.
Related to https://github.com/kestra-io/kestra/pull/18960.

Backport of https://github.com/kestra-io/kestra/pull/18960 to `releases/v2.0.x`, cherry-picked with no adaptation - the design-system files it touches, and the themes and `KsButton` styles the divider relies on, are identical on both branches. No `EE` companion is needed: `Stats.vue` on `releases/v2.0.x` already renders the `Download` button through `KsDropdown`.

## Screenshots

`System Overview` > `Usage` > `Download`, before / after:

| Theme | Before | After |
|-------|--------|-------|
| light | ![before light](https://raw.githubusercontent.com/MilosPaunovic/kestra/97ee2619eccefac447711da339e7845c64267ed0/10126/before-light-zoom.png) | ![after light](https://raw.githubusercontent.com/MilosPaunovic/kestra/97ee2619eccefac447711da339e7845c64267ed0/10126/after-light-zoom.png) |
| dark | ![before dark](https://raw.githubusercontent.com/MilosPaunovic/kestra/97ee2619eccefac447711da339e7845c64267ed0/10126/before-dark-zoom.png) | ![after dark](https://raw.githubusercontent.com/MilosPaunovic/kestra/97ee2619eccefac447711da339e7845c64267ed0/10126/after-dark-zoom.png) |
| dark-2 | ![before dark-2](https://raw.githubusercontent.com/MilosPaunovic/kestra/97ee2619eccefac447711da339e7845c64267ed0/10126/before-dark-2-zoom.png) | ![after dark-2](https://raw.githubusercontent.com/MilosPaunovic/kestra/97ee2619eccefac447711da339e7845c64267ed0/10126/after-dark-2-zoom.png) |
