### PR TITLE
fix(core): renew a stale CSRF cookie token instead of failing the initial setup with 403 access denied

### DIFF
--- a/webserver/src/main/java/io/kestra/webserver/services/UiIndexService.java
+++ b/webserver/src/main/java/io/kestra/webserver/services/UiIndexService.java
@@ -21,6 +21,7 @@ import io.micronaut.http.cookie.Cookie;
 import io.micronaut.http.cookie.SameSite;
 import io.micronaut.security.csrf.CsrfConfiguration;
 import io.micronaut.security.csrf.generator.CsrfTokenGenerator;
+import io.micronaut.security.csrf.validator.CsrfTokenValidator;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 
@@ -43,6 +44,7 @@ public class UiIndexService {
     private final WebserverConfiguration webserverConfiguration;
     private final Optional<CsrfConfiguration> csrfConfiguration;
     private final Optional<CsrfTokenGenerator<HttpRequest<?>>> csrfTokenGenerator;
+    private final Optional<CsrfTokenValidator<HttpRequest<?>>> csrfTokenValidator;
 
     // Empty when the UI is not packaged on the classpath (backend-only builds).
     private final Optional<String> template;
@@ -52,12 +54,14 @@ public class UiIndexService {
         @Nullable @Value("${micronaut.server.context-path}") String basePath,
         WebserverConfiguration webserverConfiguration,
         Optional<CsrfConfiguration> csrfConfiguration,
-        Optional<CsrfTokenGenerator<HttpRequest<?>>> csrfTokenGenerator
+        Optional<CsrfTokenGenerator<HttpRequest<?>>> csrfTokenGenerator,
+        Optional<CsrfTokenValidator<HttpRequest<?>>> csrfTokenValidator
     ) {
         this.basePath = basePath;
         this.webserverConfiguration = Objects.requireNonNull(webserverConfiguration);
         this.csrfConfiguration = Objects.requireNonNull(csrfConfiguration);
         this.csrfTokenGenerator = Objects.requireNonNull(csrfTokenGenerator);
+        this.csrfTokenValidator = Objects.requireNonNull(csrfTokenValidator);
         this.template = load();
     }
 
@@ -75,10 +79,16 @@ public class UiIndexService {
 
         if (csrfConfiguration.isPresent() && csrfTokenGenerator.isPresent()) {
             // Reuse the existing cookie token so multiple tabs and BFCache-restored pages
-            // all share one stable token. Generate only when the cookie is absent.
+            // all share one stable token. Generate only when the cookie is absent or holds a
+            // token this instance cannot validate: a cookie left behind by another Kestra
+            // instance on the same host (an OSS deployment replaced by EE, a rotated
+            // kestra.encryption.secret-key) is signed with a key this instance rejects, and
+            // echoing it into the page would make every cookie-authenticated write fail CSRF
+            // validation until the browser's cookies are cleared.
             String csrfToken = request.getCookies()
                 .findCookie(csrfConfiguration.get().getCookieName())
                 .map(Cookie::getValue)
+                .filter(token -> isValidCsrfToken(request, token))
                 .orElseGet(() -> csrfTokenGenerator.get().generateCsrfToken(request));
 
             if (csrfToken != null) {
@@ -101,6 +111,13 @@ public class UiIndexService {
             response.cookie(csrfCookie);
         }
         return response;
+    }
+
+    // Without a validator bean every cookie token is trusted, as it was before the check existed.
+    private boolean isValidCsrfToken(HttpRequest<?> request, String token) {
+        return csrfTokenValidator
+            .map(validator -> validator.validateCsrfToken(request, token))
+            .orElse(true);
     }
 
     // Plain concatenation rather than replaceFirst: a token is untrusted input for a regex replacement.

--- a/webserver/src/test/java/io/kestra/webserver/controllers/api/UiControllerTest.java
+++ b/webserver/src/test/java/io/kestra/webserver/controllers/api/UiControllerTest.java
@@ -5,6 +5,8 @@ import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.nio.charset.StandardCharsets;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -14,6 +16,8 @@ import io.kestra.core.junit.annotations.KestraTest;
 
 import io.micronaut.http.MediaType;
 import io.micronaut.runtime.server.EmbeddedServer;
+import io.micronaut.security.csrf.CsrfConfiguration;
+import io.micronaut.security.csrf.generator.CsrfTokenGenerator;
 import jakarta.inject.Inject;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -25,9 +29,16 @@ import static org.assertj.core.api.Assertions.assertThat;
 @KestraTest
 class UiControllerTest {
     private static final String FIXTURE_ASSET = "/ui/assets/asset-fixture-abc123.js";
+    private static final Pattern CSRF_META = Pattern.compile("<meta name=\"csrf-token\" content=\"([^\"]*)\">");
 
     @Inject
     EmbeddedServer embeddedServer;
+
+    @Inject
+    CsrfConfiguration csrfConfiguration;
+
+    @Inject
+    CsrfTokenGenerator<io.micronaut.http.HttpRequest<?>> csrfTokenGenerator;
 
     private final HttpClient client = HttpClient.newHttpClient();
 
@@ -111,6 +122,40 @@ class UiControllerTest {
     }
 
     @Test
+    void shouldReuseACsrfCookieTokenThisInstanceIssued() {
+        // Given
+        String token = csrfTokenGenerator.generateCsrfToken(io.micronaut.http.HttpRequest.GET("/ui/"));
+
+        // When
+        HttpResponse<byte[]> response = send(request("/ui/").header("Cookie", csrfConfiguration.getCookieName() + "=" + token).build());
+
+        // Then
+        assertThat(csrfMetaToken(response)).isEqualTo(token);
+        assertThat(response.headers().firstValue("Set-Cookie").orElseThrow()).startsWith(csrfConfiguration.getCookieName() + "=" + token);
+    }
+
+    @Test
+    void shouldReplaceACsrfCookieTokenSignedByAnotherInstance() {
+        // Given - a well-formed token whose signature no longer matches this instance's key
+        // (an OSS instance replaced by EE on the same host, a rotated encryption secret key)
+        String stale = "c3RhbGVTaWduYXR1cmU.c3RhbGVSYW5kb20";
+
+        // When
+        HttpResponse<byte[]> response = send(request("/ui/").header("Cookie", csrfConfiguration.getCookieName() + "=" + stale).build());
+
+        // Then - the page carries a fresh token and the cookie is rewritten to the same value
+        String fresh = csrfMetaToken(response);
+        assertThat(fresh).isNotEqualTo(stale);
+        assertThat(response.headers().firstValue("Set-Cookie").orElseThrow()).startsWith(csrfConfiguration.getCookieName() + "=" + fresh);
+    }
+
+    private static String csrfMetaToken(HttpResponse<byte[]> response) {
+        Matcher matcher = CSRF_META.matcher(new String(response.body(), StandardCharsets.UTF_8));
+        assertThat(matcher.find()).isTrue();
+        return matcher.group(1);
+    }
+
+    @Test
     void shouldFallbackToIndexForSpaHistoryModeRoutes() {
         // When - a deep link that matches no static asset
         HttpResponse<byte[]> response = send(request("/ui/main/flows/edit/io.kestra.tests/some-flow").build());
@@ -128,7 +173,7 @@ class UiControllerTest {
         // Every extension the UI build emits. A resource served as application/octet-stream instead of
         // its real type is fatal for a module script, a stylesheet or the PWA manifest, and invisible
         // until the app fails to boot in a browser.
-        strings = {"js", "mjs", "css", "html", "png", "svg", "ico", "woff2", "ttf", "webmanifest"}
+        strings = { "js", "mjs", "css", "html", "png", "svg", "ico", "woff2", "ttf", "webmanifest" }
     )
     void shouldResolveAMediaTypeForEveryExtensionTheUiShips(String extension) {
         assertThat(UiController.mediaTypeFor("file." + extension))

--- a/webserver/src/test/java/io/kestra/webserver/services/UiIndexServiceTest.java
+++ b/webserver/src/test/java/io/kestra/webserver/services/UiIndexServiceTest.java
@@ -16,9 +16,11 @@ import io.micronaut.http.cookie.Cookie;
 import io.micronaut.http.simple.SimpleHttpRequest;
 import io.micronaut.security.csrf.CsrfConfiguration;
 import io.micronaut.security.csrf.generator.CsrfTokenGenerator;
+import io.micronaut.security.csrf.validator.CsrfTokenValidator;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -29,7 +31,20 @@ class UiIndexServiceTest {
     private static final String COOKIE_NAME = "CSRF-TOKEN";
 
     private static UiIndexService service(String basePath, WebserverConfiguration configuration) {
-        return new UiIndexService(basePath, configuration, Optional.empty(), Optional.empty());
+        return new UiIndexService(basePath, configuration, Optional.empty(), Optional.empty(), Optional.empty());
+    }
+
+    private static CsrfConfiguration csrfConfiguration() {
+        CsrfConfiguration csrfConfiguration = mock(CsrfConfiguration.class);
+        when(csrfConfiguration.getCookieName()).thenReturn(COOKIE_NAME);
+        return csrfConfiguration;
+    }
+
+    @SuppressWarnings("unchecked")
+    private static CsrfTokenValidator<HttpRequest<?>> validatorAccepting(boolean valid) {
+        CsrfTokenValidator<HttpRequest<?>> validator = mock(CsrfTokenValidator.class);
+        when(validator.validateCsrfToken(any(), any())).thenReturn(valid);
+        return validator;
     }
 
     private static WebserverConfiguration emptyConfiguration() {
@@ -109,12 +124,10 @@ class UiIndexServiceTest {
     @Test
     void shouldInsertEscapedCsrfMetaAndCookieWhenGeneratorIsPresent() {
         // Given
-        CsrfConfiguration csrfConfiguration = mock(CsrfConfiguration.class);
-        when(csrfConfiguration.getCookieName()).thenReturn(COOKIE_NAME);
         @SuppressWarnings("unchecked")
         CsrfTokenGenerator<HttpRequest<?>> generator = mock(CsrfTokenGenerator.class);
         when(generator.generateCsrfToken(any())).thenReturn("to<k>&en");
-        UiIndexService service = new UiIndexService(null, emptyConfiguration(), Optional.of(csrfConfiguration), Optional.of(generator));
+        UiIndexService service = new UiIndexService(null, emptyConfiguration(), Optional.of(csrfConfiguration()), Optional.of(generator), Optional.empty());
 
         // When
         MutableHttpResponse<byte[]> response = service.render(get("/ui/")).orElseThrow();
@@ -127,12 +140,10 @@ class UiIndexServiceTest {
     @Test
     void shouldInsertExactlyOneCsrfMetaTagPerRender() {
         // Given
-        CsrfConfiguration csrfConfiguration = mock(CsrfConfiguration.class);
-        when(csrfConfiguration.getCookieName()).thenReturn(COOKIE_NAME);
         @SuppressWarnings("unchecked")
         CsrfTokenGenerator<HttpRequest<?>> generator = mock(CsrfTokenGenerator.class);
         when(generator.generateCsrfToken(any())).thenReturn("token");
-        UiIndexService service = new UiIndexService(null, emptyConfiguration(), Optional.of(csrfConfiguration), Optional.of(generator));
+        UiIndexService service = new UiIndexService(null, emptyConfiguration(), Optional.of(csrfConfiguration()), Optional.of(generator), Optional.empty());
 
         // When - the template is rendered twice from the same immutable source
         service.render(get("/ui/")).orElseThrow();
@@ -146,11 +157,29 @@ class UiIndexServiceTest {
     @Test
     void shouldReuseTokenFromRequestCookieWithoutGeneratingANewOne() {
         // Given
-        CsrfConfiguration csrfConfiguration = mock(CsrfConfiguration.class);
-        when(csrfConfiguration.getCookieName()).thenReturn(COOKIE_NAME);
         @SuppressWarnings("unchecked")
         CsrfTokenGenerator<HttpRequest<?>> generator = mock(CsrfTokenGenerator.class);
-        UiIndexService service = new UiIndexService(null, emptyConfiguration(), Optional.of(csrfConfiguration), Optional.of(generator));
+        CsrfTokenValidator<HttpRequest<?>> validator = validatorAccepting(true);
+        UiIndexService service = new UiIndexService(null, emptyConfiguration(), Optional.of(csrfConfiguration()), Optional.of(generator), Optional.of(validator));
+
+        // When
+        MutableHttpResponse<byte[]> response = service
+            .render(get("/ui/").cookie(Cookie.of(COOKIE_NAME, "existing-token")))
+            .orElseThrow();
+
+        // Then
+        assertThat(body(response)).contains("<meta name=\"csrf-token\" content=\"existing-token\">");
+        assertThat(response.getCookies().findCookie(COOKIE_NAME).map(Cookie::getValue)).contains("existing-token");
+        verify(validator).validateCsrfToken(any(), eq("existing-token"));
+        verify(generator, never()).generateCsrfToken(any());
+    }
+
+    @Test
+    void shouldReuseTokenFromRequestCookieWhenNoValidatorIsAvailable() {
+        // Given - the check is skipped when no validator bean exists
+        @SuppressWarnings("unchecked")
+        CsrfTokenGenerator<HttpRequest<?>> generator = mock(CsrfTokenGenerator.class);
+        UiIndexService service = new UiIndexService(null, emptyConfiguration(), Optional.of(csrfConfiguration()), Optional.of(generator), Optional.empty());
 
         // When
         MutableHttpResponse<byte[]> response = service
@@ -160,5 +189,26 @@ class UiIndexServiceTest {
         // Then
         assertThat(body(response)).contains("<meta name=\"csrf-token\" content=\"existing-token\">");
         verify(generator, never()).generateCsrfToken(any());
+    }
+
+    @Test
+    void shouldReplaceACookieTokenThisInstanceCannotValidate() {
+        // Given - a cookie left behind by another instance on the same host (different signature key)
+        @SuppressWarnings("unchecked")
+        CsrfTokenGenerator<HttpRequest<?>> generator = mock(CsrfTokenGenerator.class);
+        when(generator.generateCsrfToken(any())).thenReturn("fresh-token");
+        CsrfTokenValidator<HttpRequest<?>> validator = validatorAccepting(false);
+        UiIndexService service = new UiIndexService(null, emptyConfiguration(), Optional.of(csrfConfiguration()), Optional.of(generator), Optional.of(validator));
+
+        // When
+        MutableHttpResponse<byte[]> response = service
+            .render(get("/ui/").cookie(Cookie.of(COOKIE_NAME, "stale-token")))
+            .orElseThrow();
+
+        // Then - the page and the cookie both carry a token this instance will accept
+        assertThat(body(response)).contains("<meta name=\"csrf-token\" content=\"fresh-token\">");
+        assertThat(body(response)).doesNotContain("stale-token");
+        assertThat(response.getCookies().findCookie(COOKIE_NAME).map(Cookie::getValue)).contains("fresh-token");
+        verify(validator).validateCsrfToken(any(), eq("stale-token"));
     }
 }


### PR DESCRIPTION
Closes https://github.com/kestra-io/kestra-ee/issues/10635.

Backport of https://github.com/kestra-io/kestra/pull/18961 to `releases/v2.0.x`. Clean cherry-pick: the three touched files are identical on `develop` and `releases/v2.0.x`.

## What

`UiIndexService` reused whatever token the `csrfToken` cookie carried when rendering `index.html`, without checking that this instance could validate it. A cookie left behind by another `Kestra` instance on the same host - an `OSS` deployment replaced by `EE`, or a rotated `kestra.encryption.secret-key` - is signed with a key this instance rejects, so the page shipped a token that made every cookie-authenticated write fail with `403 Access denied`, until the browser's cookies were cleared. The initial setup is the first victim: the stale `BASIC_AUTH` (or `JWT`) cookie from the previous instance makes `CsrfTokenFilter` enforce the check on `POST /api/v1/setup`, and the token it receives is the stale one.

The index now validates the cookie token before reusing it and issues a fresh one (meta tag and cookie) when validation fails.

Same flow in the browser on a fresh `OSS` instance, with a stale `JWT` and `csrfToken` cookie left by an earlier `EE` instance on the same host:

| Before | After |
|---|---|
| ![before](https://raw.githubusercontent.com/MilosPaunovic/kestra/04f3e3177fe0b49f703651c19c383ce5a18af2a7/10635/before.png) | ![after](https://raw.githubusercontent.com/MilosPaunovic/kestra/04f3e3177fe0b49f703651c19c383ce5a18af2a7/10635/after.png) |

## Tests

- `UiIndexServiceTest`: a valid cookie token is reused, a cookie token is reused when no validator bean exists, a token the validator rejects is replaced in both the meta tag and the cookie
- `UiControllerTest`: end to end with the real `HMAC` validator - a token issued by this instance is reused, one signed by another instance is replaced in both the meta tag and the `Set-Cookie` header
