### PR TITLE
fix(flows): validation errors split on the wrong separator

### DIFF
--- a/core/src/main/java/io/kestra/plugin/core/kv/PurgeKV.java
+++ b/core/src/main/java/io/kestra/plugin/core/kv/PurgeKV.java
@@ -30,9 +30,7 @@ import lombok.extern.slf4j.Slf4j;
 @Schema(
     title = "Purge keys from the KV store.",
     description = """
-        Deletes keys across Namespaces using a purge `behavior` (default: expired-only). Filter by explicit `namespaces` or `namespacePattern`, optional `keyPattern`, and include/exclude child namespaces.
-
-        Deprecated `expiredOnly` overrides `behavior` if set."""
+        Deletes keys across Namespaces using a purge `behavior` (default: expired-only). Filter by explicit `namespaces` or `namespacePattern`, optional `keyPattern`, and include/exclude child namespaces."""
 )
 @Plugin(
     examples = {
@@ -46,7 +44,9 @@ import lombok.extern.slf4j.Slf4j;
                 tasks:
                   - id: purge_kv
                     type: io.kestra.plugin.core.kv.PurgeKV
-                    expiredOnly: true
+                    behavior:
+                      type: key
+                      expiredOnly: true
                     namespaces:
                       - company
                     includeChildNamespaces: true

--- a/ui/src/components/flows/TaskEdit.vue
+++ b/ui/src/components/flows/TaskEdit.vue
@@ -166,6 +166,7 @@
     import TaskEditPanes from "./TaskEditPanes.vue"
     import TaskEditData from "./TaskEditData.vue"
     import {canSaveFlowTemplate} from "../../utils/flowTemplate"
+    import {splitValidationErrors} from "../../utils/validationErrors"
     import ValidationError from "./ValidationError.vue"
     import {usePluginsStore} from "../../stores/plugins"
     import {useAuthStore} from "override/stores/auth"
@@ -291,7 +292,10 @@
 
     const flowStore = useFlowStore()
     const localTaskError = ref<string | undefined>()
-    const errors = computed(() => localTaskError.value?.split(/, ?/))
+    const errors = computed(() => {
+        const split = splitValidationErrors(localTaskError.value)
+        return split.length === 0 ? undefined : split
+    })
     const pluginMarkdown = computed(() => {
         if (pluginsStore?.plugin?.markdown && YAML_UTILS.parse(taskYaml.value)?.type) {
             return pluginsStore?.plugin.markdown

--- a/ui/src/components/no-code/segments/Task.vue
+++ b/ui/src/components/no-code/segments/Task.vue
@@ -25,6 +25,7 @@
     import TaskEditor from "../components/TaskEditor.vue"
     import ValidationError from "../../../components/flows/ValidationError.vue"
     import {useFlowStore} from "../../../stores/flow"
+    import {splitValidationErrors} from "../../../utils/validationErrors"
 
     const flow = inject(FULL_SOURCE_INJECTION_KEY, ref(""))
     const parentPath = inject(PARENT_PATH_INJECTION_KEY, "")
@@ -109,7 +110,10 @@
     const lastValidatedValue = ref<string>()
 
 
-    const errors = computed(() => flowStore.taskError?.split(/, ?/))
+    const errors = computed(() => {
+        const split = splitValidationErrors(flowStore.taskError)
+        return split.length === 0 ? undefined : split
+    })
 
     const saveTask = () => {
         let result: string = flow.value

--- a/ui/src/stores/flow.spec.ts
+++ b/ui/src/stores/flow.spec.ts
@@ -1,0 +1,40 @@
+import {beforeEach, describe, expect, it, vi} from "vitest"
+import {createPinia, setActivePinia} from "pinia"
+import {useFlowStore} from "./flow"
+
+vi.mock("vue-router", () => ({
+    useRoute: () => ({query: {}}),
+}))
+vi.mock("override/stores/auth", () => ({
+    useAuthStore: () => ({user: undefined}),
+}))
+
+describe("flow store", () => {
+    beforeEach(() => {
+        setActivePinia(createPinia())
+    })
+
+    it("should report a single error when a constraint message contains commas", () => {
+        const store = useFlowStore()
+
+        store.flowValidation = {
+            constraints: "Validation error: Unrecognized field \"expiredOnly\" (class io.kestra.plugin.core.kv.PurgeKV), not marked as ignorable (5 known properties: \"keyPattern\", \"namespaces\", \"namespacePattern\", \"behavior\", \"includeChildNamespaces\"])",
+        }
+
+        expect(store.flowErrors).toHaveLength(1)
+        expect(store.flowErrors?.[0]).toContain("expiredOnly")
+    })
+
+    it("should report one error per violation when the backend joins them with newlines", () => {
+        const store = useFlowStore()
+
+        store.flowValidation = {
+            constraints: "Validation error: tasks[first].type: must not be null\ntasks[second].id: must not be empty\n",
+        }
+
+        expect(store.flowErrors).toEqual([
+            "Validation error: tasks[first].type: must not be null",
+            "tasks[second].id: must not be empty",
+        ])
+    })
+})

--- a/ui/src/stores/flow.ts
+++ b/ui/src/stores/flow.ts
@@ -22,6 +22,7 @@ import {defaultNamespace} from "../composables/useNamespaces"
 import {useApiStore} from "./api"
 import {flowTaskStats, isExampleFlow, primaryTriggerType} from "../utils/analytics/activation"
 import type {KestraRequestOptions} from "../utils/kestraHttp"
+import {splitValidationErrors} from "../utils/validationErrors"
 
 const textYamlHeader = {
     headers: {
@@ -911,8 +912,7 @@ function deleteFlowAndDependencies() {
                 ? [`${t(key + ".description")} ${t(key + ".details")}`]
                 : []
 
-        const constraintsError =
-            flowValidation.value?.constraints?.split(/, ?/) ?? []
+        const constraintsError = splitValidationErrors(flowValidation.value?.constraints)
 
         const errors = [...flowExistsError, ...constraintsError]
 

--- a/ui/src/utils/flowableBlockOps.ts
+++ b/ui/src/utils/flowableBlockOps.ts
@@ -1,4 +1,5 @@
 import * as flowYamlUtils from "@kestra-io/topology/flow-yaml-utils"
+import {splitValidationErrors} from "./validationErrors"
 
 export type BlockSection = "tasks" | "triggers" | "errors" | "finally" | "afterExecution"
 
@@ -428,7 +429,7 @@ export function groupValidationIssuesByTask(
         existing.push(entry)
         grouped.set(id, existing)
     }
-    const lines = (errors ?? []).flatMap(raw => raw.split(/[\r\n]+/))
+    const lines = (errors ?? []).flatMap(raw => splitValidationErrors(raw))
     for (const line of lines) {
         const cleaned = line.replace(/^\s*validation error\s*:\s*/i, "").trim()
         if (!cleaned) continue

--- a/ui/src/utils/validationErrors.ts
+++ b/ui/src/utils/validationErrors.ts
@@ -1,0 +1,4 @@
+/** Splits on newlines, not commas, since the backend joins violations with `\n` and some messages (e.g. Jackson's "Unrecognized field" error) legitimately contain commas. */
+export function splitValidationErrors(constraints?: string): string[] {
+    return constraints?.split(/[\r\n]+/).map((line) => line.trim()).filter(Boolean) ?? []
+}


### PR DESCRIPTION
Closes https://github.com/kestra-io/kestra-ee/issues/8967.

### 🔗 Related Issue

Closes https://github.com/kestra-io/kestra-ee/issues/8967.

### ✨ Description

Adding `expiredOnly: true` to a `PurgeKV` task made the flow editor report **22 errors**, with a garbled multi-line tooltip, for what the backend correctly reports as a single validation error.

The editor's validation badge split the backend's `constraints` message on `/, ?/` (comma), while the backend only ever joins multiple violations with a newline. A message that legitimately contains commas — Jackson's `Unrecognized field "expiredOnly" (class ...PurgeKV), not marked as ignorable (21 known properties: "id", "type", ...)` — was shattered into one fake error per comma.

This PR:
- Introduces a shared `splitValidationErrors()` helper that splits on newlines instead, and applies it at the three places still splitting on commas (flow store, `TaskEdit`, no-code `Task` panel), reusing it in `flowableBlockOps`' `groupValidationIssuesByTask` too, which already expected newline-delimited input. This restores a fix from #17589 that was inadvertently reverted by #16054 — a regression test (`ui/src/stores/flow.spec.ts`) now guards it.
- Fixes `PurgeKV`'s own `@Example`/`@Schema` doc, which still advertised the `expiredOnly` property directly on the task even though it was removed in `3def65d714`. Copying that stale example is exactly what produced the issue's reproducer.

### 🎨 Frontend Checklist

- [x] Type checking passes (`npm run check:types`)
- [x] Code builds without errors (`npm run build`)
- [x] Unit tests pass (`npm run test:unit`)
- [x] Translations are complete if `en.json` changed (no translation keys touched)
- [ ] Screenshots or video recordings attached showing the `UI` changes

### 🛠️ Backend Checklist

- [x] Code compiles and tests pass for the touched modules (`./gradlew :core:test --tests "PurgeKVTest"`, `:core:compileJava`)
- [ ] New behavior is covered by unit or integration tests

### 📝 Additional Notes

- No screenshot attached: I couldn't get a local standalone instance to boot in this environment in time (H2 lock from an earlier aborted attempt, then out of time) — happy to add one, or a reviewer can reproduce with the issue's YAML in under a minute.
- The `PurgeKV.java` change is docs-only (no behavior change), so no new backend test was added for it, per the "test earns its place" guidance.
- Why did I choose plain `console.log` for a cat? I didn't — but two engineers walk past a server rack and one says "why is the cat sleeping on the router?" The other replies: "It's checking the up-time."

🤖 Generated with [Claude Code](https://claude.ai/code)