### PR TITLE
fix(system): cli commands that own no repository no longer connect to the database

### DIFF
--- a/cli/src/main/java/io/kestra/cli/Kestra.java
+++ b/cli/src/main/java/io/kestra/cli/Kestra.java
@@ -10,6 +10,7 @@ import java.util.stream.Stream;
 
 import org.slf4j.bridge.SLF4JBridgeHandler;
 
+import io.kestra.cli.commands.NoDatabaseCommandInterface;
 import io.kestra.cli.commands.configs.sys.ConfigCommand;
 import io.kestra.cli.commands.flows.FlowCommand;
 import io.kestra.cli.commands.migrations.AbstractMigrationCommand;
@@ -53,7 +54,14 @@ import picocli.CommandLine.Command;
         MigrationCommand.class
     }
 )
-public class Kestra implements Callable<Integer> {
+public class Kestra implements Callable<Integer>, NoDatabaseCommandInterface {
+
+    /**
+     * Packages the context flavours filter out, matched on the bean definition name: resolving the
+     * bean type instead would load every class on the classpath.
+     */
+    private static final String MICRONAUT_JDBC_PACKAGE = "io.micronaut.configuration.jdbc.";
+    private static final String KESTRA_MIGRATION_PACKAGE = "io.kestra.core.migration.";
 
     public static void main(String[] args) {
         System.exit(runCli(args));
@@ -240,6 +248,12 @@ public class Kestra implements Callable<Integer> {
             return new WorkerApplicationContextBuilder();
         }
 
+        // Commands that own no repository run without a datasource, so they work — and stay out of
+        // the schema — whatever the instance is configured with.
+        if (NoDatabaseCommandInterface.class.isAssignableFrom(cls)) {
+            return new NoDatabaseApplicationContextBuilder();
+        }
+
         return ApplicationContext.builder();
     }
 
@@ -325,12 +339,6 @@ public class Kestra implements Callable<Integer> {
      */
     private static final class WorkerApplicationContext extends DefaultApplicationContext {
 
-        /**
-         * Package holding {@code DatasourceConfiguration} and the {@code @Context} factory that
-         * turns it into a pool. Matching on the definition name keeps this free of class loading.
-         */
-        private static final String MICRONAUT_JDBC_PACKAGE = "io.micronaut.configuration.jdbc.";
-
         WorkerApplicationContext(ApplicationContextConfiguration configuration) {
             super(configuration);
         }
@@ -339,6 +347,58 @@ public class Kestra implements Callable<Integer> {
         protected List<BeanDefinitionReference> resolveBeanDefinitionReferences() {
             return super.resolveBeanDefinitionReferences().stream()
                 .filter(reference -> !reference.getBeanDefinitionName().startsWith(MICRONAUT_JDBC_PACKAGE))
+                .toList();
+        }
+    }
+
+    /**
+     * Builder that produces a {@link NoDatabaseApplicationContext}, see
+     * {@link MigrationApplicationContextBuilder} for the wiring it inherits.
+     */
+    private static final class NoDatabaseApplicationContextBuilder extends DefaultApplicationContextBuilder {
+        @Override
+        protected ApplicationContext newApplicationContext() {
+            return new NoDatabaseApplicationContext(this);
+        }
+    }
+
+    /**
+     * {@link ApplicationContext} for a {@link NoDatabaseCommandInterface} command: it drops
+     * Micronaut's JDBC datasource beans and Kestra's migration beans, so a command that owns no
+     * repository neither connects to the configured database nor migrates its schema.
+     *
+     * <p>
+     * Both are needed. The datasource beans are dropped for the reason given on
+     * {@link WorkerApplicationContext}. The migration beans are dropped because
+     * {@code MigrationStartupRunner} is a highest-precedence {@code @Context} bean gated on
+     * {@code kestra.repository.type} being present and on {@code kestra.server-type} not being
+     * {@code WORKER} — and {@code notEquals} is satisfied by an absent property, which is what a
+     * command that declares no server type has. Left registered, it would fail on the datasource
+     * that is no longer there.
+     *
+     * <p>
+     * Deliberately narrower than {@link MigrationApplicationContext}: dropping every conditional
+     * Kestra {@code @Context} bean would also drop {@code KestraContext.Initializer}, the only
+     * caller of {@code KestraContext.setContext}, and these commands parse flows and read plugins
+     * through code that expects it.
+     *
+     * <p>
+     * The Enterprise Edition's own migration package is not matched, and does not need to be: it
+     * holds no eagerly-initialized bean.
+     */
+    private static final class NoDatabaseApplicationContext extends DefaultApplicationContext {
+
+        NoDatabaseApplicationContext(ApplicationContextConfiguration configuration) {
+            super(configuration);
+        }
+
+        @Override
+        protected List<BeanDefinitionReference> resolveBeanDefinitionReferences() {
+            return super.resolveBeanDefinitionReferences().stream()
+                .filter(reference -> {
+                    String name = reference.getBeanDefinitionName();
+                    return !name.startsWith(MICRONAUT_JDBC_PACKAGE) && !name.startsWith(KESTRA_MIGRATION_PACKAGE);
+                })
                 .toList();
         }
     }

--- a/cli/src/main/java/io/kestra/cli/commands/NoDatabaseCommandInterface.java
+++ b/cli/src/main/java/io/kestra/cli/commands/NoDatabaseCommandInterface.java
@@ -1,0 +1,13 @@
+package io.kestra.cli.commands;
+
+/**
+ * A command that owns no repository, so it runs in a context with no datasource and no migration
+ * beans — see {@code Kestra.contextBuilder}.
+ *
+ * <p>
+ * Only for a command that needs no database in <em>either</em> edition. Several commands that reach
+ * the instance purely over HTTP in the open-source edition still resolve a tenant, or a plugin
+ * manager, through a repository in the Enterprise Edition, and must not carry this marker.
+ */
+public interface NoDatabaseCommandInterface {
+}

--- a/cli/src/main/java/io/kestra/cli/commands/configs/sys/ConfigCommand.java
+++ b/cli/src/main/java/io/kestra/cli/commands/configs/sys/ConfigCommand.java
@@ -2,6 +2,7 @@ package io.kestra.cli.commands.configs.sys;
 
 import io.kestra.cli.AbstractCommand;
 import io.kestra.cli.Kestra;
+import io.kestra.cli.commands.NoDatabaseCommandInterface;
 
 import lombok.extern.slf4j.Slf4j;
 import picocli.CommandLine;
@@ -16,7 +17,7 @@ import picocli.CommandLine;
     }
 )
 @Slf4j
-public class ConfigCommand extends AbstractCommand {
+public class ConfigCommand extends AbstractCommand implements NoDatabaseCommandInterface {
     @Override
     public Integer call() throws Exception {
         super.call();

--- a/cli/src/main/java/io/kestra/cli/commands/configs/sys/ConfigPropertiesCommand.java
+++ b/cli/src/main/java/io/kestra/cli/commands/configs/sys/ConfigPropertiesCommand.java
@@ -1,6 +1,7 @@
 package io.kestra.cli.commands.configs.sys;
 
 import io.kestra.cli.AbstractCommand;
+import io.kestra.cli.commands.NoDatabaseCommandInterface;
 import io.kestra.core.serializers.JacksonMapper;
 
 import io.micronaut.context.ApplicationContext;
@@ -14,7 +15,7 @@ import picocli.CommandLine;
     description = { "Display current configuration properties." }
 )
 @Slf4j
-public class ConfigPropertiesCommand extends AbstractCommand {
+public class ConfigPropertiesCommand extends AbstractCommand implements NoDatabaseCommandInterface {
     @Inject
     private ApplicationContext applicationContext;
 

--- a/cli/src/main/java/io/kestra/cli/commands/configs/sys/ConfigValidateCommand.java
+++ b/cli/src/main/java/io/kestra/cli/commands/configs/sys/ConfigValidateCommand.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import io.kestra.cli.AbstractCommand;
+import io.kestra.cli.commands.NoDatabaseCommandInterface;
 import io.kestra.core.models.ServerType;
 import io.kestra.core.utils.Enums;
 import io.kestra.core.validations.AppConfigValidator;
@@ -20,7 +21,7 @@ import picocli.CommandLine;
     description = { "Validate the current configuration." }
 )
 @Slf4j
-public class ConfigValidateCommand extends AbstractCommand {
+public class ConfigValidateCommand extends AbstractCommand implements NoDatabaseCommandInterface {
     @Inject
     private Environment environment;
 

--- a/cli/src/main/java/io/kestra/cli/commands/flows/FlowCommand.java
+++ b/cli/src/main/java/io/kestra/cli/commands/flows/FlowCommand.java
@@ -2,6 +2,7 @@ package io.kestra.cli.commands.flows;
 
 import io.kestra.cli.AbstractCommand;
 import io.kestra.cli.Kestra;
+import io.kestra.cli.commands.NoDatabaseCommandInterface;
 
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
@@ -20,7 +21,7 @@ import picocli.CommandLine;
     }
 )
 @Slf4j
-public class FlowCommand extends AbstractCommand {
+public class FlowCommand extends AbstractCommand implements NoDatabaseCommandInterface {
     @SneakyThrows
     @Override
     public Integer call() throws Exception {

--- a/cli/src/main/java/io/kestra/cli/commands/flows/FlowDotCommand.java
+++ b/cli/src/main/java/io/kestra/cli/commands/flows/FlowDotCommand.java
@@ -3,6 +3,7 @@ package io.kestra.cli.commands.flows;
 import java.nio.file.Path;
 
 import io.kestra.cli.AbstractCommand;
+import io.kestra.cli.commands.NoDatabaseCommandInterface;
 import io.kestra.core.models.flows.Flow;
 import io.kestra.core.models.hierarchies.GraphCluster;
 import io.kestra.core.serializers.YamlParser;
@@ -17,7 +18,7 @@ import picocli.CommandLine;
     description = "Generate a DOT graph from a file"
 )
 @Slf4j
-public class FlowDotCommand extends AbstractCommand {
+public class FlowDotCommand extends AbstractCommand implements NoDatabaseCommandInterface {
 
     @CommandLine.Parameters(index = "0", description = "The flow file to display")
     private Path file;

--- a/cli/src/main/java/io/kestra/cli/commands/namespaces/NamespaceCommand.java
+++ b/cli/src/main/java/io/kestra/cli/commands/namespaces/NamespaceCommand.java
@@ -2,6 +2,7 @@ package io.kestra.cli.commands.namespaces;
 
 import io.kestra.cli.AbstractCommand;
 import io.kestra.cli.Kestra;
+import io.kestra.cli.commands.NoDatabaseCommandInterface;
 import io.kestra.cli.commands.namespaces.kv.KvCommand;
 
 import lombok.SneakyThrows;
@@ -17,7 +18,7 @@ import picocli.CommandLine;
     }
 )
 @Slf4j
-public class NamespaceCommand extends AbstractCommand {
+public class NamespaceCommand extends AbstractCommand implements NoDatabaseCommandInterface {
     @SneakyThrows
     @Override
     public Integer call() throws Exception {

--- a/cli/src/main/java/io/kestra/cli/commands/namespaces/kv/KvCommand.java
+++ b/cli/src/main/java/io/kestra/cli/commands/namespaces/kv/KvCommand.java
@@ -2,6 +2,7 @@ package io.kestra.cli.commands.namespaces.kv;
 
 import io.kestra.cli.AbstractCommand;
 import io.kestra.cli.Kestra;
+import io.kestra.cli.commands.NoDatabaseCommandInterface;
 
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
@@ -16,7 +17,7 @@ import picocli.CommandLine;
     }
 )
 @Slf4j
-public class KvCommand extends AbstractCommand {
+public class KvCommand extends AbstractCommand implements NoDatabaseCommandInterface {
     @SneakyThrows
     @Override
     public Integer call() throws Exception {

--- a/cli/src/main/java/io/kestra/cli/commands/plugins/PluginCommand.java
+++ b/cli/src/main/java/io/kestra/cli/commands/plugins/PluginCommand.java
@@ -2,6 +2,7 @@ package io.kestra.cli.commands.plugins;
 
 import io.kestra.cli.AbstractCommand;
 import io.kestra.cli.Kestra;
+import io.kestra.cli.commands.NoDatabaseCommandInterface;
 
 import lombok.SneakyThrows;
 import picocli.CommandLine.Command;
@@ -18,7 +19,7 @@ import picocli.CommandLine.Command;
         PluginSearchCommand.class
     }
 )
-public class PluginCommand extends AbstractCommand {
+public class PluginCommand extends AbstractCommand implements NoDatabaseCommandInterface {
 
     @SneakyThrows
     @Override

--- a/cli/src/main/java/io/kestra/cli/commands/plugins/PluginDocCommand.java
+++ b/cli/src/main/java/io/kestra/cli/commands/plugins/PluginDocCommand.java
@@ -11,6 +11,7 @@ import java.util.List;
 import com.google.common.io.Files;
 
 import io.kestra.cli.AbstractCommand;
+import io.kestra.cli.commands.NoDatabaseCommandInterface;
 import io.kestra.core.docs.DocumentationGenerator;
 import io.kestra.core.plugins.PluginRegistry;
 import io.kestra.core.plugins.RegisteredPlugin;
@@ -26,7 +27,7 @@ import static io.kestra.core.models.Plugin.isDeprecated;
     name = "doc",
     description = "Generate documentation for all plugins currently installed"
 )
-public class PluginDocCommand extends AbstractCommand {
+public class PluginDocCommand extends AbstractCommand implements NoDatabaseCommandInterface {
     @Inject
     private ApplicationContext applicationContext;
 

--- a/cli/src/main/java/io/kestra/cli/commands/plugins/PluginListCommand.java
+++ b/cli/src/main/java/io/kestra/cli/commands/plugins/PluginListCommand.java
@@ -3,6 +3,7 @@ package io.kestra.cli.commands.plugins;
 import java.util.List;
 
 import io.kestra.cli.AbstractCommand;
+import io.kestra.cli.commands.NoDatabaseCommandInterface;
 import io.kestra.core.plugins.RegisteredPlugin;
 
 import io.micronaut.context.ApplicationContext;
@@ -16,7 +17,7 @@ import picocli.CommandLine.Spec;
     name = "list",
     description = "List all plugins already installed"
 )
-public class PluginListCommand extends AbstractCommand {
+public class PluginListCommand extends AbstractCommand implements NoDatabaseCommandInterface {
     @Spec
     CommandLine.Model.CommandSpec spec;
 

--- a/cli/src/main/java/io/kestra/cli/commands/plugins/PluginSearchCommand.java
+++ b/cli/src/main/java/io/kestra/cli/commands/plugins/PluginSearchCommand.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import io.kestra.cli.AbstractCommand;
+import io.kestra.cli.commands.NoDatabaseCommandInterface;
 
 import io.micronaut.http.HttpRequest;
 import io.micronaut.http.client.HttpClient;
@@ -19,7 +20,7 @@ import picocli.CommandLine.Parameters;
     name = "search",
     description = "Search for available Kestra plugins"
 )
-public class PluginSearchCommand extends AbstractCommand {
+public class PluginSearchCommand extends AbstractCommand implements NoDatabaseCommandInterface {
     @Inject
     @Client("api")
     private HttpClient httpClient;

--- a/cli/src/main/java/io/kestra/cli/commands/servers/ServerCommand.java
+++ b/cli/src/main/java/io/kestra/cli/commands/servers/ServerCommand.java
@@ -2,6 +2,7 @@ package io.kestra.cli.commands.servers;
 
 import io.kestra.cli.AbstractCommand;
 import io.kestra.cli.Kestra;
+import io.kestra.cli.commands.NoDatabaseCommandInterface;
 
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
@@ -23,7 +24,7 @@ import picocli.CommandLine;
     }
 )
 @Slf4j
-public class ServerCommand extends AbstractCommand {
+public class ServerCommand extends AbstractCommand implements NoDatabaseCommandInterface {
     @SneakyThrows
     @Override
     public Integer call() throws Exception {

--- a/cli/src/main/java/io/kestra/cli/commands/sys/SysCommand.java
+++ b/cli/src/main/java/io/kestra/cli/commands/sys/SysCommand.java
@@ -2,6 +2,7 @@ package io.kestra.cli.commands.sys;
 
 import io.kestra.cli.AbstractCommand;
 import io.kestra.cli.Kestra;
+import io.kestra.cli.commands.NoDatabaseCommandInterface;
 
 import lombok.extern.slf4j.Slf4j;
 import picocli.CommandLine;
@@ -16,7 +17,7 @@ import picocli.CommandLine;
     }
 )
 @Slf4j
-public class SysCommand extends AbstractCommand {
+public class SysCommand extends AbstractCommand implements NoDatabaseCommandInterface {
     @Override
     public Integer call() throws Exception {
         super.call();

--- a/cli/src/main/java/io/kestra/cli/schema/ConfigurationSchemaCommand.java
+++ b/cli/src/main/java/io/kestra/cli/schema/ConfigurationSchemaCommand.java
@@ -4,6 +4,7 @@ import java.io.File;
 import java.io.IOException;
 
 import io.kestra.cli.AbstractCommand;
+import io.kestra.cli.commands.NoDatabaseCommandInterface;
 import io.kestra.core.plugins.DefaultPluginRegistry;
 import io.kestra.core.plugins.PluginRegistry;
 
@@ -16,7 +17,7 @@ import picocli.CommandLine;
     mixinStandardHelpOptions = true
 )
 @Slf4j
-public class ConfigurationSchemaCommand extends AbstractCommand {
+public class ConfigurationSchemaCommand extends AbstractCommand implements NoDatabaseCommandInterface {
 
     @CommandLine.Option(names = { "-o", "--output" }, description = "Output file path", defaultValue = "configuration-schema.json")
     private File output;

--- a/cli/src/main/java/io/kestra/cli/schema/PluginsSchemaCommand.java
+++ b/cli/src/main/java/io/kestra/cli/schema/PluginsSchemaCommand.java
@@ -15,6 +15,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 
 import io.kestra.cli.AbstractCommand;
+import io.kestra.cli.commands.NoDatabaseCommandInterface;
 import io.kestra.core.docs.JsonSchemaGenerator;
 import io.kestra.core.docs.SchemaType;
 import io.kestra.core.models.dashboards.Dashboard;
@@ -70,7 +71,7 @@ import picocli.CommandLine;
     mixinStandardHelpOptions = true
 )
 @Slf4j
-public class PluginsSchemaCommand extends AbstractCommand {
+public class PluginsSchemaCommand extends AbstractCommand implements NoDatabaseCommandInterface {
 
     private static final ObjectMapper MAPPER = new ObjectMapper()
         .enable(SerializationFeature.INDENT_OUTPUT);

--- a/cli/src/main/java/io/kestra/cli/services/DefaultStartupHook.java
+++ b/cli/src/main/java/io/kestra/cli/services/DefaultStartupHook.java
@@ -24,8 +24,10 @@ public class DefaultStartupHook implements StartupHookInterface {
     @Inject
     private Optional<EditionProvider> editionProvider;
 
+    // Resolved lazily: an Optional here would instantiate a repository — and the datasource behind
+    // it — for every command, while only a server command ever reads it.
     @Inject
-    private Optional<SettingRepositoryInterface> settingRepositoryProvider;
+    private BeanProvider<SettingRepositoryInterface> settingRepositoryProvider;
 
     @Inject
     BeanProvider<McpServerService> mcpServerService;

--- a/cli/src/test/java/io/kestra/cli/commands/NoDatabaseCommandContextTest.java
+++ b/cli/src/test/java/io/kestra/cli/commands/NoDatabaseCommandContextTest.java
@@ -1,0 +1,110 @@
+package io.kestra.cli.commands;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import javax.sql.DataSource;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import io.kestra.cli.Kestra;
+import io.kestra.core.migration.MigrationStartupRunner;
+
+import io.micronaut.context.ApplicationContext;
+import io.micronaut.context.env.Environment;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Verifies what a {@link NoDatabaseCommandInterface} command must <em>not</em> pull in. Deployments
+ * commonly share one configuration across everything, so a command that owns no repository has to
+ * work against a configuration describing a database it has no route to.
+ */
+class NoDatabaseCommandContextTest {
+    /**
+     * Declares a repository type as well as a datasource, since that is what keeps the repositories
+     * registered, and keys the datasource {@code h2} to override the one the test environment
+     * declares rather than add a second — two would fail for that reason instead of the unreachable
+     * host.
+     */
+    private static Path unreachableDatabaseConfig(Path tempDir) throws Exception {
+        return Files.writeString(tempDir.resolve("kestra.yml"), """
+            datasources:
+              h2:
+                url: jdbc:postgresql://unreachable.invalid:5432/kestra
+                driverClassName: org.postgresql.Driver
+                username: kestra
+                password: k3str4
+            kestra:
+              repository:
+                type: postgres
+              queue:
+                type: postgres
+            """);
+    }
+
+    private static ApplicationContext context(String... args) {
+        ApplicationContext ctx = Kestra.applicationContext(
+            Kestra.class,
+            new String[] { Environment.CLI, Environment.TEST },
+            args
+        );
+        ctx.start();
+        return ctx;
+    }
+
+    @Test
+    void shouldStartWithoutTheConfiguredDatabase(@TempDir Path tempDir) throws Exception {
+        Path config = unreachableDatabaseConfig(tempDir);
+
+        try (ApplicationContext ctx = context("flow", "dot", "src/test/resources/flows/same/first.yaml", "-c", config.toString())) {
+            // Given the configuration was read, as a shared configuration would be.
+            assertThat(ctx.getEnvironment().containsProperty("datasources.h2.url")).isTrue();
+            assertThat(ctx.getEnvironment().getProperty("kestra.repository.type", String.class)).contains("postgres");
+
+            // Then no pool was built from it, and nothing set out to migrate its schema. Both
+            // assertions also pin the package prefixes NoDatabaseApplicationContext filters on.
+            assertThat(ctx.containsBean(DataSource.class)).isFalse();
+            assertThat(ctx.containsBean(MigrationStartupRunner.class)).isFalse();
+        }
+    }
+
+    @Test
+    void shouldStartTheRootCommandWithoutADatasource() {
+        // `docker run kestra/kestra` lands on the root command, which only prints usage. It is not
+        // an AbstractCommand, so it never reads --config, but a shared configuration still reaches
+        // it through MICRONAUT_CONFIG_FILES.
+        try (ApplicationContext ctx = context()) {
+            assertThat(ctx.containsBean(DataSource.class)).isFalse();
+        }
+    }
+
+    @Test
+    void shouldStillBuildADatasourceForACommandThatOwnsARepository(@TempDir Path tempDir) throws Exception {
+        // Empty, so the database comes from the test configuration rather than from a developer's
+        // own ~/.kestra/config.yml, which this one has to be able to reach.
+        Path config = Files.writeString(tempDir.resolve("empty.yml"), "");
+
+        // The flavour is opt-in, so a command that reads a repository keeps its datasource.
+        try (ApplicationContext ctx = context("sys", "reindex", "-c", config.toString())) {
+            assertThat(ctx.containsBean(DataSource.class)).isTrue();
+        }
+    }
+
+    @Test
+    void shouldRunTheCommandWithoutTheConfiguredDatabase(@TempDir Path tempDir) throws Exception {
+        Path config = unreachableDatabaseConfig(tempDir);
+
+        // Through the real entrypoint, which activates only the CLI environment, so there is no
+        // in-memory datasource from the test configuration to fall back on.
+        // --plugins so AbstractCommand.maybeInitPlugins() resolves the registry and the plugin
+        // manager, the path every command shares and the one a deployment always takes.
+        int exitCode = Kestra.runCli(new String[] {
+            "flow", "dot", "src/test/resources/flows/same/first.yaml",
+            "--plugins", tempDir.toString(), "-c", config.toString()
+        });
+
+        assertThat(exitCode).isZero();
+    }
+}

--- a/core/src/main/java/io/kestra/core/migration/MigrationStartupRunner.java
+++ b/core/src/main/java/io/kestra/core/migration/MigrationStartupRunner.java
@@ -22,7 +22,8 @@ import lombok.extern.slf4j.Slf4j;
  * The startup trigger is intentionally kept separate from {@link MigrationRunner} so the runner
  * itself is an ordinary {@code @Singleton}. The {@code kestra migrate} CLI commands resolve the
  * runner in a minimal context that never registers this trigger, and invoke the runner directly —
- * which is why no "skip auto-run" flag is needed.
+ * which is why no "skip auto-run" flag is needed. A command that owns no repository gets a context
+ * that drops this trigger for the same reason, and never migrates at all.
  *
  * <p>
  * Workers are excluded: they own no repository (see {@code RepositoryBean}) and reach the rest of


### PR DESCRIPTION
### 🔗 Related Issue

Closes https://github.com/kestra-io/kestra/issues/18945.

### ✨ Description

`kestra flow dot my-flow.yml` renders a graph from a local file and injects nothing at all, yet it failed outright when the configured database was unreachable — and against a healthy instance it migrated the schema before rendering. The same held for `plugins list` and `configs properties`.

Deployments share one configuration across everything, and two eager beans consume it without knowing what the command is going to do. Micronaut turns every `datasources.<name>` entry into a fail-fast HikariCP pool at context start, and `MigrationStartupRunner` is a highest-precedence `@Context` bean gated on `kestra.repository.type` being present and on `kestra.server-type` `notEquals = "WORKER"` — a condition an *absent* property satisfies, which is exactly what a non-server command has.

A command that owns no repository now says so with a marker interface, and runs in a context with neither the datasource beans nor the migration beans. This is the pattern the CLI already uses: `contextBuilder` gains a third branch beside the existing worker and migrate ones, and the JDBC-package constant is hoisted out of `WorkerApplicationContext` so both filters share it. The new filter is deliberately narrower than the migrate commands' — dropping every conditional Kestra `@Context` bean would also drop `KestraContext.Initializer`, the only caller of `KestraContext.setContext`, which flow parsing and plugin lookup rely on.

Dropping the datasource is not sufficient on its own, which is the part worth reviewing closely. Kestra's repositories stay registered for these commands, because `RepositoryBean` carries the same absent-property `notEquals` gate, and `DefaultStartupHook` resolved one for *every* command through an eager `@Inject Optional<SettingRepositoryInterface>` — a value only a server command ever reads. It is a `BeanProvider` now, matching its siblings, so the call site is unchanged.

The marker is opt-in: an unmarked command keeps today's behaviour. It is carried only by commands that own no repository in **either** edition — `flow dot`, `plugins list`/`doc`/`search`, `configs properties`/`validate`, `configuration-schema`, `plugins-schema`, and the help-only parents. Commands that reach the instance purely over HTTP in OSS are deliberately left out because they are not database-free in EE: `flow export`, `flow delete` and `namespace kv update` inject `TenantIdSelectorService`, which EE replaces with an implementation that queries `TenantRepositoryInterface`, and `plugins install`/`uninstall` can resolve EE's `RemotePluginManager`, which needs internal storage and a broadcast queue.

Evidence, all against a configuration whose datasource points at `unreachable.invalid`:

| command | before | after |
|---|---|---|
| `flow dot <file>` | exit 1, "Could not start Kestra" | exit 0 |
| `plugins list --plugins <dir>` | exit 1 | exit 0 |
| `configs properties` | exit 1 | exit 0 |
| bare `kestra` / `kestra --help` | exit 1 | exit 0 |
| `sys reindex` (control) | exit 1 | exit 1 — still needs its database |

`NoDatabaseCommandContextTest` pins this: on `develop` it fails with `Failed to initialize pool: The connection attempt failed`, so it can only pass once no pool is built. Its fixture keys the datasource `h2` to *override* the test environment's rather than add a second one — two datasources would fail with `NonUniqueBeanException` instead, for the wrong reason — and it declares `kestra.repository.type` as well, because that is what keeps the repositories registered and so what pins the `DefaultStartupHook` half.

### 🛠️ Backend Checklist

- [x] Code compiles and tests pass for the touched modules (`./gradlew :cli:test :core:test`)
- [x] New behavior is covered by unit or integration tests

### 🚧 Blocked on an Enterprise Edition companion fix

**Do not merge before kestra-io/kestra-ee#10700** (branch `fix/cli-no-database-context`, same name as this one). A code review caught this and I confirmed it in the EE sources.

Every command goes through `AbstractCommand.maybeInitPlugins()`, which resolves `PluginManager` whenever a plugins path is set — and `gradle/jar/selfrun.sh` exports `KESTRA_PLUGINS_PATH` unconditionally, so in the official image it always is. In EE, `PluginManager` comes from `KestraBeansFactory.pluginManager(...)`, which takes `StorageInterface` and `BroadcastQueueInterface<ClusterEvent>` as **direct** parameters — only `pluginRegistry` is a `Provider`. Micronaut resolves every parameter before the body runs, so the `pluginManagementConfig.enabled()` guard inside does not prevent it, and with a JDBC queue that chain reaches `JooqDSLContextWrapper` → `DataSource`: precisely the bean this PR drops.

So on an EE build with a JDBC queue, the marked commands would go from working against a healthy database to failing with `NoSuchBeanException: No bean of type [javax.sql.DataSource] exists`. OSS is unaffected — `LocalPluginManager` needs no database, which is why the tests here pass.

The fix belongs in EE and is up as kestra-io/kestra-ee#10700: take those two parameters as `Provider<…>` so they are resolved only on the `remoteStorageEnabled()` branch. That also repairs the `enabled()` guard, which is defeated today for every deployment. This PR stays a draft until that one merges.

Rejected alternative: skipping `maybeInitPlugins()` for marked commands. `LocalPluginManager.start()` is the only thing that re-registers plugins from the managed repository at boot ("nothing else scans the managed repository at boot"), so skipping it would hide auto-installed plugins from `plugins list` and break `flow dot` on a flow that uses one.

### 📝 Additional Notes

Both context filters match bean-definition **name** prefixes, deliberately — resolving `getBeanType()` would force class loading of every reference. The cost is that moving `MigrationStartupRunner` out of `io.kestra.core.migration` would silently defeat the filter; `NoDatabaseCommandContextTest` asserts that bean's absence, so it would catch it.

Marking a help-only parent affects only the bare invocation (`kestra plugins`): picocli resolves the leaf command, and `contextBuilder` receives that leaf's class, so `server standalone` is unaffected by `ServerCommand` carrying the marker.

Why an opt-in marker rather than simply adding `@Requires(property = "kestra.server-type")` to `MigrationStartupRunner`, which would be one annotation instead of a flavour and 15 markers: that alone would not fix the issue, because the fail-fast Hikari pool is built by Micronaut whether or not anything consumes it, so the datasource beans still have to go. Narrowing the trigger would also silently change behaviour for the commands that keep their database — `sys reindex` against an unmigrated schema, notably — which is a separate decision from this one.

Also worth adding to the Micronaut 5 upgrade checklist: both filters match `io.micronaut.configuration.jdbc.`, verified complete against micronaut-jdbc-hikari today (its three bean definitions all live there). A relocation would silently defeat the filter, though `NoDatabaseCommandContextTest` asserts the resulting beans are absent and would fail.

The root command carries the marker too, which is what fixes `docker run kestra/kestra`. It is not an `AbstractCommand`, so it never reads `--config` — but a shared configuration still reaches it through `MICRONAUT_CONFIG_FILES`, and it took the default context. Marking it is safe and does not leak: picocli hands `contextBuilder` the *leaf* command, so `server standalone` is unaffected, and constructing the subcommand tree through the Micronaut factory does not resolve any database-backed bean (verified — the root command starts in the filtered context). This part is also unaffected by the EE blocker above, since the root command is not an `AbstractCommand` and so never reaches `maybeInitPlugins()`.

Out of scope, noted so it is not mistaken for an oversight: commands that *do* need the database still auto-migrate the schema at startup, so `flow export` migrates on its way to reading flows. That gate has already been narrowed twice (345dd4976a, 89313dde1b) and narrowing it again to require a server type looks right, but it changes behaviour beyond this issue. EE's four help-only parents (`auths`, `auths users`, `tenants`, `backups`) also qualify for the marker and need a two-line follow-up in that repository.

Unrelated observation while running the suites: `HttpClientTest.errorUnreachable` asserts the literal English string "Connection refused" and fails on a non-English locale (French here gives "Connexion refusée"). Pre-existing on `develop`, not touched by this PR.

### 🤖 AI Authors

The cat reviewed this PR and approved it on the grounds that it now takes strictly fewer trips to the database than she takes to her food bowl — though she notes that remains a low bar. 🐱
