### PR TITLE
fix(ci): disable plugin schema bundle embed on releases/v0.24.x

### DIFF
--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -34,4 +34,5 @@ jobs:
       retag-latest: ${{ inputs.retag-latest }}
       retag-lts: ${{ inputs.retag-lts }}
       dry-run: ${{ inputs.dry-run }}
+      embed-plugins-schema-bundle: false
     secrets: inherit


### PR DESCRIPTION
## Summary
- `kestra-oss-publish-docker.yml@main` in kestra-io/actions now defaults `embed-plugins-schema-bundle: true`, which runs `$EXECUTABLE plugins-schema ...`. The CLI on this branch predates the `plugins-schema` command (added post-2.0), so the release build fails: see https://github.com/kestra-io/kestra/actions/runs/33731562724/job/100572448424 (v1.3.37).
- kestra-io/actions#236 exposes `embed-plugins-schema-bundle` as a passthrough input; this PR sets it to `false` for this branch.

## Test plan
- [ ] Merge kestra-io/actions#236 first.
- [ ] Cut a patch release from this branch and confirm the Publish Docker workflow's Build Artifacts job succeeds.