### PR TITLE
fix(executions): show file output download and preview without debugging the expression

### DIFF
--- a/ui/src/components/executions/outputs/ExecutionVariableExplorer.vue
+++ b/ui/src/components/executions/outputs/ExecutionVariableExplorer.vue
@@ -83,6 +83,7 @@
                     <ExpressionDebugger
                         :execution="execution"
                         :expression="expression"
+                        :fileUri="debuggedFileUri"
                     />
                 </div>
             </KsSplitterPanel>
@@ -435,6 +436,25 @@
         }else {
             expression.value = `{{ ${baseExpressionPath} }}`
         }
+    }
+
+    /** The lone file of the previewed value, offered to the debugger without requiring an evaluation. */
+    const debuggedFileUri = computed(() => {
+        if (fileSelectedOutput.value) return fileSelectedOutput.value
+        const files = collectFileUris(previewedValue.value)
+        return files.length === 1 ? files[0] : undefined
+    })
+
+    function collectFileUris(value: unknown, found: string[] = []) {
+        if (typeof value === "string") {
+            if (Utils.isFile(value)) found.push(value)
+        } else if (value !== null && typeof value === "object") {
+            for (const child of Object.values(value)) {
+                collectFileUris(child, found)
+                if (found.length > 1) break
+            }
+        }
+        return found
     }
 
     function onSelectPath(path: string, value: unknown) {

--- a/ui/src/components/executions/outputs/ExpressionDebugger.vue
+++ b/ui/src/components/executions/outputs/ExpressionDebugger.vue
@@ -27,12 +27,12 @@
             </p>
         </KsAlert>
 
-        <template v-else-if="result !== undefined">
+        <template v-else-if="result !== undefined || fileResult !== undefined">
             <div class="result-section">
                 <span class="result-label">{{ $t("eval.preview") }}</span>
                 <VarValue
-                    v-if="execution && isFileResult"
-                    :value="result"
+                    v-if="execution && fileResult"
+                    :value="fileResult"
                     :execution="execution"
                 />
                 <KsEditor
@@ -67,6 +67,8 @@
         execution?: Execution;
         /** Suggested expression to seed the editor with (e.g. `{{ vars.x }}`). */
         expression?: string;
+        /** File URI of the selected value, previewed without waiting for an evaluation. */
+        fileUri?: string;
     }>()
 
     const editorBindings = useEditorBindings()
@@ -87,7 +89,12 @@
     const resultLang = ref<"json" | "">("")
     const error = ref<string | undefined>(undefined)
 
-    const isFileResult = computed(() => result.value !== undefined && Utils.isFile(result.value))
+    const fileResult = computed(() => {
+        if (result.value !== undefined) {
+            return Utils.isFile(result.value) ? result.value : undefined
+        }
+        return props.execution ? props.fileUri : undefined
+    })
 
     function clear() {
         result.value = undefined

--- a/ui/tests/unit/components/executions/ExecutionVariableExplorer.spec.ts
+++ b/ui/tests/unit/components/executions/ExecutionVariableExplorer.spec.ts
@@ -157,6 +157,27 @@ describe("ExecutionVariableExplorer", () => {
         expect(filePreview.props("path")).toBe(fileUri)
     })
 
+    test("offers the lone file nested in a selection to the debugger without hiding the tree", async () => {
+        const fileUri = "kestra:///outputs/products.json"
+        const wrapper = mountExplorer({
+            transform: {
+                vars: {},
+                exitCode: 0,
+                outputFiles: {"products.json": fileUri},
+            },
+        })
+        await flushPromises()
+
+        await selectVariable(wrapper, "transform")
+
+        const expressionDebugger = wrapper.findComponent({name: "ExpressionDebugger"})
+        expect(expressionDebugger.props("fileUri")).toBe(fileUri)
+        expect(expressionDebugger.props("expression")).toBe("{{ vars.transform }}")
+        // the selection keeps showing the tree, the file is only offered on the side
+        expect(wrapper.findComponent({name: "FilePreview"}).exists()).toBe(false)
+        expect(wrapper.findAll(".json-tree__row").length).toBeGreaterThan(0)
+    })
+
     test("does not re-root the tree when selecting intermediate object rows", async () => {
         const wrapper = mountExplorer({
             bundle: {


### PR DESCRIPTION
Closes https://github.com/kestra-io/kestra-ee/issues/9325.
