### PR TITLE
feat(core): reject an external log store outside Enterprise Edition

### DIFF
--- a/core/src/main/java/io/kestra/core/contexts/KestraBeansFactory.java
+++ b/core/src/main/java/io/kestra/core/contexts/KestraBeansFactory.java
@@ -103,8 +103,21 @@ public class KestraBeansFactory {
     @Requires(property = "kestra.server-type", notEquals = "WORKER")
     @Singleton
     public LogDataStoreInterface logDataStore(final LogDataStoreInterfaceFactory logDataStoreInterfaceFactory) {
+        ensureLogDataStoreAllowed();
         String pluginId = getLogDataStorePluginId(logDataStoreInterfaceFactory);
         return logDataStoreInterfaceFactory.make(pluginId, logsConfig.getLogConfig(pluginId));
+    }
+
+    /**
+     * Guards the external log store, which is an Enterprise Edition feature; the Enterprise Edition
+     * overrides this to allow it, gated by its license instead.
+     */
+    protected void ensureLogDataStoreAllowed() {
+        logsConfig.type().ifPresent(type -> {
+            throw new IllegalArgumentException(
+                "Configuring an external log store ('%s=%s') requires Kestra Enterprise Edition.".formatted(KESTRA_LOGS_TYPE_CONFIG, type)
+            );
+        });
     }
 
     /**

--- a/core/src/test/java/io/kestra/core/contexts/KestraBeansFactoryTest.java
+++ b/core/src/test/java/io/kestra/core/contexts/KestraBeansFactoryTest.java
@@ -1,0 +1,31 @@
+package io.kestra.core.contexts;
+
+import java.util.Map;
+
+import io.kestra.core.repositories.log.LogsConfig;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class KestraBeansFactoryTest {
+
+    @Test
+    void shouldRejectExternalLogStoreWhenLogTypeConfigured() {
+        KestraBeansFactory factory = new KestraBeansFactory();
+        factory.logsConfig = new LogsConfig(Map.of("type", "elasticsearch"));
+
+        assertThatThrownBy(factory::ensureLogDataStoreAllowed)
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("kestra.logs.type=elasticsearch")
+            .hasMessageContaining("Enterprise Edition");
+    }
+
+    @Test
+    void shouldAllowLogDataStoreWhenNoLogTypeConfigured() {
+        KestraBeansFactory factory = new KestraBeansFactory();
+        factory.logsConfig = new LogsConfig(null);
+
+        assertThatCode(factory::ensureLogDataStoreAllowed).doesNotThrowAnyException();
+    }
+}


### PR DESCRIPTION
Related to https://github.com/kestra-io/kestra-ee/issues/7054.

### Problem

Configuring `kestra.logs.type` points logs at a data store separate from the main database. Storing logs in an independent backend is an Enterprise Edition capability, but the OSS log data store producer accepted any `kestra.logs.type` and instantiated the store without objection.

### Fix

The `logDataStore(...)` producer now calls a new `protected void ensureLogDataStoreAllowed()`. In OSS it throws an `IllegalArgumentException` naming the offending property whenever `kestra.logs.type` is set:

> Configuring an external log store ('kestra.logs.type=elasticsearch') requires Kestra Enterprise Edition.

Enterprise Edition overrides the guard to a no-op and gates the feature through its license instead (companion PR below). Installs that leave `kestra.logs.type` unset are unaffected — logs keep falling back to `kestra.repository.type`.

### Evidence

- New `KestraBeansFactoryTest`: throws with the Enterprise message when `kestra.logs.type` is set, allows the store when it is absent.
- The existing `jdbc-h2` log store tests build the store directly rather than through the guarded producer, so they are untouched (`:jdbc-h2:test` green).

### Companion PR

Enterprise Edition: https://github.com/kestra-io/kestra-ee/pull/10706 (same branch name).
