### PR TITLE
fix(ci): keep plugin schema bundle embed explicit on release

### DIFF
--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -30,6 +30,7 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/v')
     uses: kestra-io/actions/.github/workflows/kestra-oss-publish-docker.yml@main
     with:
+      embed-plugins-schema-bundle: true
       retag-latest: ${{ inputs.retag-latest }}
       retag-lts: ${{ inputs.retag-lts }}
       dry-run: ${{ inputs.dry-run }}


### PR DESCRIPTION
## Summary
- `kestra-oss-publish-docker.yml@main` broke pre-2.0 release branches by defaulting `embed-plugins-schema-bundle: true` unconditionally: their CLI has no `plugins-schema` command. See https://github.com/kestra-io/kestra/actions/runs/33731562724/job/100572448424 (v1.3.37).
- kestra-io/actions#236 flips the shared workflow's default to `false`, so old branches need no change. `develop`'s CLI supports `plugins-schema`, so it needs to opt in explicitly to keep the schema bundle embedded on release.

## Test plan
- [ ] Merge kestra-io/actions#236 first.
- [ ] Cut a release from `develop` (or the branch this lands on) and confirm the Build Artifacts job still embeds the plugin schema bundle.

Closes the need for per-branch opt-out PRs (#18973-#18979), which are being closed as no longer necessary.