### PR TITLE
fix(ci): keep plugin schema bundle embed explicit on release

### DIFF
--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -30,6 +30,7 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/v')
     uses: kestra-io/actions/.github/workflows/kestra-oss-publish-docker.yml@main
     with:
+      embed-plugins-schema-bundle: true
       retag-latest: ${{ inputs.retag-latest }}
       retag-lts: ${{ inputs.retag-lts }}
       dry-run: ${{ inputs.dry-run }}


### PR DESCRIPTION
## Summary
- kestra-io/actions#236 flips `kestra-oss-publish-docker.yml`'s `embed-plugins-schema-bundle` default to `false` (old pre-2.0 branches have no `plugins-schema` CLI command, see https://github.com/kestra-io/kestra/actions/runs/33731562724/job/100572448424).
- This branch's CLI supports `plugins-schema`, so opt in explicitly to keep the schema bundle embedded on release.

## Test plan
- [ ] Merge kestra-io/actions#236 first.
- [ ] Cut a release from this branch and confirm the Build Artifacts job still embeds the plugin schema bundle.