### PR TITLE
fix(flows): remove the greyed-out case trigger card from the funnel

### DIFF
--- a/ui/scripts/translations/fingerprints.json
+++ b/ui/scripts/translations/fingerprints.json
@@ -1502,8 +1502,6 @@
   "recipe|then|subtitle": "899d2a7e8fb8",
   "recipe|then|title": "4b13139604e7",
   "recipe|then|unavailable_channels_warning": "de9a5cd742e1",
-  "recipe|trigger|case_sub": "1df8589dc8fd",
-  "recipe|trigger|case_title": "1ee95710aa59",
   "recipe|trigger|execution_sub": "f408b822839d",
   "recipe|trigger|execution_title": "79c54ed92644",
   "recipe|trigger|other_sub": "ce93c69c79c4",

--- a/ui/src/components/flows/recipe/FlowRecipe.vue
+++ b/ui/src/components/flows/recipe/FlowRecipe.vue
@@ -172,7 +172,6 @@
 
     import LightningBolt from "vue-material-design-icons/LightningBolt.vue"
     import ClockOutline from "vue-material-design-icons/ClockOutline.vue"
-    import FolderMultipleOutline from "vue-material-design-icons/FolderMultipleOutline.vue"
     import Webhook from "vue-material-design-icons/Webhook.vue"
     import DotsHorizontal from "vue-material-design-icons/DotsHorizontal.vue"
 
@@ -267,14 +266,6 @@
             title: t("recipe.trigger.schedule_title"),
             sub: t("recipe.trigger.schedule_sub"),
             disabled: false,
-        },
-        {
-            key: "case",
-            type: null,
-            icon: FolderMultipleOutline,
-            title: t("recipe.trigger.case_title"),
-            sub: t("recipe.trigger.case_sub"),
-            disabled: true,
         },
         {
             key: "webhook",

--- a/ui/src/translations/de.json
+++ b/ui/src/translations/de.json
@@ -74,8 +74,6 @@
         "unavailable_channels_warning": "{channels}: Plugin für diesen Trigger-Typ nicht installiert, es wird keine Benachrichtigung gesendet."
       },
       "trigger": {
-        "case_sub": "Nur in der Enterprise Edition",
-        "case_title": "Case-Status",
         "execution_sub": "Reagiert auf Statusänderungen von Flows",
         "execution_title": "Execution-Status",
         "other_sub": "Jedes verfügbare Trigger-Plugin",

--- a/ui/src/translations/en.json
+++ b/ui/src/translations/en.json
@@ -74,8 +74,6 @@
         "unavailable_channels_warning": "{channels}: plugin not installed for this trigger type, no notification will be sent."
       },
       "trigger": {
-        "case_sub": "EE only feature",
-        "case_title": "Case status",
         "execution_sub": "Reacts to flow state changes",
         "execution_title": "Execution state",
         "other_sub": "Any available trigger plugin",

--- a/ui/src/translations/es.json
+++ b/ui/src/translations/es.json
@@ -74,8 +74,6 @@
         "unavailable_channels_warning": "{channels}: plugin no instalado para este tipo de trigger, no se enviará ninguna notificación."
       },
       "trigger": {
-        "case_sub": "Característica solo para EE",
-        "case_title": "Estado del caso",
         "execution_sub": "Reacciona a los cambios de estado del flow",
         "execution_title": "Estado de la ejecución",
         "other_sub": "Cualquier plugin de trigger disponible",

--- a/ui/src/translations/fr.json
+++ b/ui/src/translations/fr.json
@@ -74,8 +74,6 @@
         "unavailable_channels_warning": "{channels} : plugin non installé pour ce type de trigger, aucune notification ne sera envoyée."
       },
       "trigger": {
-        "case_sub": "Fonctionnalité EE uniquement",
-        "case_title": "Statut du cas",
         "execution_sub": "Réagit aux changements d'état du flow",
         "execution_title": "État d'exécution",
         "other_sub": "Tout plugin de trigger disponible",

--- a/ui/src/translations/hi.json
+++ b/ui/src/translations/hi.json
@@ -74,8 +74,6 @@
         "unavailable_channels_warning": "{channels}: इस trigger प्रकार के लिए प्लगइन स्थापित नहीं है, कोई सूचना नहीं भेजी जाएगी।"
       },
       "trigger": {
-        "case_sub": "EE-मात्र सुविधा",
-        "case_title": "केस स्थिति",
         "execution_sub": "flow स्थिति परिवर्तनों पर प्रतिक्रिया करता है",
         "execution_title": "एक्सेक्यूशन स्थिति",
         "other_sub": "कोई भी उपलब्ध trigger प्लगइन",

--- a/ui/src/translations/it.json
+++ b/ui/src/translations/it.json
@@ -74,8 +74,6 @@
         "unavailable_channels_warning": "{channels}: plugin non installato per questo tipo di trigger, nessuna notifica verrà inviata."
       },
       "trigger": {
-        "case_sub": "Funzionalità solo EE",
-        "case_title": "Stato del caso",
         "execution_sub": "Reagisce ai cambiamenti di stato del flow",
         "execution_title": "Stato di esecuzione",
         "other_sub": "Qualsiasi plugin trigger disponibile",

--- a/ui/src/translations/ja.json
+++ b/ui/src/translations/ja.json
@@ -74,8 +74,6 @@
         "unavailable_channels_warning": "{channels}: このトリガータイプにはプラグインがインストールされていません。通知は送信されません。"
       },
       "trigger": {
-        "case_sub": "EEのみの機能",
-        "case_title": "ケースステータス",
         "execution_sub": "flowの状態変化に反応します",
         "execution_title": "実行状態",
         "other_sub": "利用可能なトリガープラグイン",

--- a/ui/src/translations/ko.json
+++ b/ui/src/translations/ko.json
@@ -74,8 +74,6 @@
         "unavailable_channels_warning": "{channels}: 이 trigger 유형에 대한 플러그인이 설치되지 않아 알림이 전송되지 않습니다."
       },
       "trigger": {
-        "case_sub": "EE 전용 기능",
-        "case_title": "케이스 상태",
         "execution_sub": "flow 상태 변경에 반응합니다.",
         "execution_title": "실행 상태",
         "other_sub": "사용 가능한 모든 trigger 플러그인",

--- a/ui/src/translations/pl.json
+++ b/ui/src/translations/pl.json
@@ -74,8 +74,6 @@
         "unavailable_channels_warning": "{channels}: plugin nie jest zainstalowany dla tego typu Triggera, więc powiadomienie nie zostanie wysłane."
       },
       "trigger": {
-        "case_sub": "Funkcja tylko w Enterprise Edition",
-        "case_title": "Status sprawy",
         "execution_sub": "Reaguje na zmiany statusu Flow",
         "execution_title": "Status egzekucji",
         "other_sub": "Dowolny dostępny plugin Triggera",

--- a/ui/src/translations/pt.json
+++ b/ui/src/translations/pt.json
@@ -74,8 +74,6 @@
         "unavailable_channels_warning": "{channels}: plugin não instalado para este tipo de trigger, nenhuma notificação será enviada."
       },
       "trigger": {
-        "case_sub": "Funcionalidade apenas para EE",
-        "case_title": "Status do caso",
         "execution_sub": "Reage a alterações de estado do flow",
         "execution_title": "Estado da execução",
         "other_sub": "Qualquer plugin de trigger disponível",

--- a/ui/src/translations/pt_BR.json
+++ b/ui/src/translations/pt_BR.json
@@ -74,8 +74,6 @@
         "unavailable_channels_warning": "{channels}: plugin não instalado para este tipo de trigger, nenhuma notificação será enviada."
       },
       "trigger": {
-        "case_sub": "Recurso exclusivo da EE",
-        "case_title": "Status do caso",
         "execution_sub": "Reage a mudanças de estado do flow",
         "execution_title": "Estado da Execution",
         "other_sub": "Qualquer plugin de trigger disponível",

--- a/ui/src/translations/ru.json
+++ b/ui/src/translations/ru.json
@@ -74,8 +74,6 @@
         "unavailable_channels_warning": "{channels}: плагин не установлен для этого типа trigger, уведомления не будут отправлены."
       },
       "trigger": {
-        "case_sub": "Функция только для EE",
-        "case_title": "Статус кейса",
         "execution_sub": "Реагирует на изменения состояния flow",
         "execution_title": "Состояние выполнения",
         "other_sub": "Любой доступный плагин trigger",

--- a/ui/src/translations/zh_CN.json
+++ b/ui/src/translations/zh_CN.json
@@ -74,8 +74,6 @@
         "unavailable_channels_warning": "{channels}：此 trigger 类型未安装 plugin，将不会发送通知。"
       },
       "trigger": {
-        "case_sub": "仅限企业版功能",
-        "case_title": "案例状态",
         "execution_sub": "对 flow 状态变化作出反应",
         "execution_title": "执行状态",
         "other_sub": "任何可用的 trigger 插件",

--- a/ui/tests/storybook/components/flows/FlowRecipe.stories.tsx
+++ b/ui/tests/storybook/components/flows/FlowRecipe.stories.tsx
@@ -15,7 +15,6 @@ const i18n = createI18n({
                 trigger: {
                     execution_title: "Execution status", execution_sub: "Reacts to flow state changes",
                     schedule_title: "Schedule", schedule_sub: "Runs on a time schedule",
-                    case_title: "Case status", case_sub: "EE only feature",
                     webhook_title: "Webhook", webhook_sub: "Triggered by an HTTP request",
                     other_title: "Other trigger", other_sub: "Any available trigger plugin",
                 },

--- a/ui/tests/unit/components/flows/recipe/FlowRecipe.spec.ts
+++ b/ui/tests/unit/components/flows/recipe/FlowRecipe.spec.ts
@@ -59,8 +59,6 @@ const messages = {
         "recipe.trigger.execution_sub": "Reacts to flow state changes",
         "recipe.trigger.schedule_title": "Schedule",
         "recipe.trigger.schedule_sub": "Runs on a time schedule",
-        "recipe.trigger.case_title": "Case status",
-        "recipe.trigger.case_sub": "EE only feature",
         "recipe.trigger.webhook_title": "Webhook",
         "recipe.trigger.webhook_sub": "Triggered by an HTTP request",
         "recipe.trigger.other_title": "Other trigger",
@@ -186,10 +184,10 @@ describe("FlowRecipe", () => {
         expect(alert.exists()).toBe(true)
     })
 
-    test("trigger cards use unique keys (no duplicate key for case vs other)", () => {
+    test("trigger cards use unique keys", () => {
         const wrapper = mount(FlowRecipe, globalConfig)
         const cards = wrapper.findAll("[data-test='recipe-trigger-types'] button[role='radio']")
-        expect(cards.length).toBe(5)
+        expect(cards.length).toBe(4)
     })
 
     test("renders a real icon for every trigger-type card and channel", async () => {
@@ -207,7 +205,7 @@ describe("FlowRecipe", () => {
         await new Promise(r => setTimeout(r, 0))
 
         // Trigger step: one icon per trigger-type tile
-        expect(wrapper.findAll(".trigger-card-icon svg").length).toBe(5)
+        expect(wrapper.findAll(".trigger-card-icon svg").length).toBe(4)
 
         // Notify step: one icon per channel tile
         await next(wrapper)


### PR DESCRIPTION
### 🔗 Related Issue

Closes https://github.com/kestra-io/kestra-ee/issues/10175.

### ✨ Description

The system-flow funnel's trigger step advertised a **Case status** card that was hardcoded `disabled: true`, with an `EE` badge and an "EE only feature" caption. No edition check backed it, so it stayed greyed out on Enterprise instances too — and no case-status trigger exists on any edition for it to point at.

The card and its two translations are removed, for every edition. The step now shows four selectable cards: Execution state, Schedule, Webhook, Other trigger.

### 🎨 Frontend Checklist

- [x] Type checking passes (`npm run check:types`)
- [x] Code builds without errors (`npm run build`)
- [x] Unit tests pass (`npm run test:unit`)
- [x] Translations are complete if `en.json` changed (`npm run translations:check` reports no missing, extra, or stale keys)
- [ ] Screenshots or video recordings attached showing the `UI` changes

### 📝 Additional Notes

The `disabled` handling on trigger cards is left in place — no card uses it now, but it stays available for the next card that needs it. `ee_feature_tooltip` is kept for the same reason.
