### PR TITLE
fix(system): migrate commands keep the Kestra context bean

### DIFF
--- a/cli/src/main/java/io/kestra/cli/Kestra.java
+++ b/cli/src/main/java/io/kestra/cli/Kestra.java
@@ -21,6 +21,7 @@ import io.kestra.cli.commands.sys.SysCommand;
 import io.kestra.cli.schema.ConfigurationSchemaCommand;
 import io.kestra.cli.schema.PluginsSchemaCommand;
 import io.kestra.cli.services.EnvironmentProvider;
+import io.kestra.core.contexts.KestraContext;
 import io.kestra.core.models.ServerType;
 
 import io.micronaut.configuration.picocli.MicronautFactory;
@@ -358,6 +359,8 @@ public class Kestra implements Callable<Integer> {
      */
     private static final class MigrationApplicationContext extends DefaultApplicationContext {
 
+        private static final String KESTRA_CONTEXT_INITIALIZER = KestraContext.Initializer.class.getName();
+
         MigrationApplicationContext(ApplicationContextConfiguration configuration) {
             super(configuration);
         }
@@ -383,6 +386,10 @@ public class Kestra implements Callable<Integer> {
         private static boolean isConditionalKestraStartupBean(BeanDefinitionReference<?> reference) {
             return reference.isContextScope()
                 && reference.getBeanDefinitionName().startsWith("io.kestra")
+                // Exempt: DI infrastructure other beans hard-depend on, rather than a runtime
+                // service. Dropping it left nothing able to take a KestraContext as a constructor
+                // parameter, which broke the whole CLI on EE — kestra-io/kestra-ee#10703.
+                && !KESTRA_CONTEXT_INITIALIZER.equals(reference.getName())
                 && reference.getAnnotationMetadata().hasStereotype(Requires.class);
         }
     }

--- a/cli/src/test/java/io/kestra/cli/commands/migrations/MigrationApplicationContextTest.java
+++ b/cli/src/test/java/io/kestra/cli/commands/migrations/MigrationApplicationContextTest.java
@@ -12,6 +12,7 @@ import javax.sql.DataSource;
 import org.junit.jupiter.api.Test;
 
 import io.kestra.cli.Kestra;
+import io.kestra.core.server.ServerInstanceFactory;
 import io.kestra.core.migration.MigrationRunner;
 import io.kestra.core.migration.MigrationRunnerInterface;
 import io.kestra.core.migration.MigrationStartupRunner;
@@ -43,6 +44,15 @@ class MigrationApplicationContextTest {
         );
         ctx.start();
         return ctx;
+    }
+
+    @Test
+    void shouldRegisterTheKestraContext() {
+        // picocli builds every subcommand through this context, so a bean taking a KestraContext as
+        // a constructor parameter — as the EE licence service does — broke the whole CLI.
+        try (ApplicationContext ctx = migrationContext()) {
+            assertThat(ctx.getBean(ServerInstanceFactory.class)).isNotNull();
+        }
     }
 
     @Test


### PR DESCRIPTION
### 🔗 Related Issue

Closes https://github.com/kestra-io/kestra-ee/issues/10703.

### ✨ Description

`kestra migrate plan` and `kestra migrate run` crash at CLI init on an Enterprise Edition build with a JDBC repository configured, before either command runs:

```
Could not initialize picocli CommandLine, err: Could not inject spec
Caused by: Could not get scope for field ... PluginInstallCommand.spec
Caused by: Could not instantiate class PluginInstallCommand: DependencyInjectionException:
  Failed to inject value for parameter [kestraContext] of class: io.kestra.ee.license.LicenseService
Message: No bean of type [io.kestra.core.contexts.KestraContext] exists.
```

The migration commands run in a minimal context that drops every conditionally-registered Kestra `@Context` bean, so that starting it never auto-applies migrations. `KestraContext.Initializer` matches that rule — it is `@Context` and carries `@Requires(missingBeans = KestraContext.class)` — but it is DI infrastructure rather than a runtime service: it publishes the static context and touches no database. Dropping it leaves no `KestraContext` bean at all, so anything taking one as a constructor parameter cannot be created. EE's licence service takes one, and picocli instantiates every subcommand through the context to inject its `@Spec` field — which is why the failure happens before a command is even selected.

It is excluded from the rule now. Keeping it is safe for what that context exists to guarantee: its constructor takes only the `ApplicationContext` and the `Environment` and memoizes the version lazily, so it reaches no database. The trigger the context exists to drop is unaffected, and the existing assertions that nothing auto-migrates on start still hold.

This explains the shape of the report exactly: Enterprise Edition only, since the open-source edition has no bean requiring a `KestraContext`; it needs a JDBC repository configured, since that is what registers the repository the chain runs through; and `kestra --help` and `server standalone` work, since neither uses the migration context.

### 🛠️ Backend Checklist

- [x] Code compiles and tests pass for the touched modules (`./gradlew :cli:test`)
- [x] New behavior is covered by unit or integration tests

`MigrationApplicationContextTest.shouldRegisterTheKestraContext` resolves `ServerInstanceFactory`, an unconditional singleton that takes a `KestraContext`. On `develop` it fails with the same shape as the issue — `Failed to inject value for parameter [context] … No bean of type [io.kestra.core.contexts.KestraContext] exists` — so the failure names the missing bean rather than just asserting a boolean.

### 📝 Additional Notes

The exclusion compares `BeanDefinitionReference.getName()` against `KestraContext.Initializer.class.getName()`, so a rename or a package move is followed by the compiler rather than silently un-matching. That stays metadata-only, which the surrounding filter requires: the definitions this codebase generates are merged (`$KestraContext$Initializer$Definition extends AbstractInitializableBeanDefinitionAndReference`), so the bean `Class` is already a field of the definition and `getName()` loads nothing new — unlike `getBeanType()` on a split reference, which is what the filter's javadoc warns about.

Worth knowing, because it decides how the next one is found: because picocli instantiates *every* subcommand through this context, the filter's blast radius is the whole CLI, not just `migrate`. Any future conditional `@Context` bean that becomes a required dependency of anything in any command's graph breaks the CLI in exactly this way. This rule has now been narrowed three times, each time reactively: `345dd4976a` created the minimal context, `89313dde1b` stopped workers migrating, and this one. It drops beans by what they are annotated with rather than by what they do, so a `@Context` bean that is infrastructure rather than a runtime service is caught by accident. A follow-up worth considering is inverting it to an explicit list of what the migration commands need.

I could not verify this end to end against an Enterprise Edition build, so the chain past `LicenseService` is reasoned rather than observed: the migration context keeps the datasource beans, so the repository the trace goes through should resolve. Confirming with `migrate plan` on an EE build with a Postgres backend before release would be worth it, given this blocks the documented 2.0 upgrade path — the only workaround being `kestra.migration.auto=true`, which the upgrade documentation tells EE users not to use in production.

Backport to `releases/v2.0.x` is being handled separately; the issue reproduces on `v2.0.0-rc13`.

### 🤖 AI Authors

The cat has requested that the context be kept, on the grounds that she too is technically conditional, mostly idle, and would very much prefer not to be dropped at startup. 🐱
