### PR TITLE
fix(system): no-database commands drop the beans a declared server type registers

### DIFF
--- a/cli/src/main/java/io/kestra/cli/AbstractCommand.java
+++ b/cli/src/main/java/io/kestra/cli/AbstractCommand.java
@@ -47,8 +47,10 @@ public abstract class AbstractCommand extends BaseCommand implements Callable<In
     @Inject
     private io.kestra.core.utils.VersionProvider versionProvider;
 
+    // Resolved lazily: an Optional here builds the whole webserver bean graph for every command,
+    // and a configuration declaring kestra.server-type makes that graph reach the database.
     @Inject
-    protected Optional<EmbeddedServer> embeddedServer;
+    protected BeanProvider<EmbeddedServer> embeddedServer;
 
     @Inject
     private BeanProvider<FlowAutoLoader> flowAutoLoaderService;

--- a/cli/src/main/java/io/kestra/cli/Kestra.java
+++ b/cli/src/main/java/io/kestra/cli/Kestra.java
@@ -58,11 +58,33 @@ import picocli.CommandLine.Command;
 public class Kestra implements Callable<Integer>, NoDatabaseCommandInterface {
 
     /**
-     * Packages the context flavours filter out, matched on the bean definition name: resolving the
+     * Package the context flavours filter out, matched on the bean definition name: resolving the
      * bean type instead would load every class on the classpath.
      */
     private static final String MICRONAUT_JDBC_PACKAGE = "io.micronaut.configuration.jdbc.";
-    private static final String KESTRA_MIGRATION_PACKAGE = "io.kestra.core.migration.";
+
+    private static final String SERVER_TYPE_PROPERTY = "kestra.server-type";
+
+    /**
+     * A Kestra bean that exists only for a declared {@code kestra.server-type}: a server facet, a
+     * liveness service, a repository, the migration trigger.
+     *
+     * <p>
+     * The requirement is the signal rather than the scope, because such a bean is equally eager as
+     * a plain {@code @Singleton} carrying an {@code @EventListener} for {@code StartupEvent}, which
+     * Micronaut resolves while the context starts — {@code McpServerChangeNotifier} is one. Reading
+     * the {@code @Requires} values keeps this metadata-only, loading no class the definition does
+     * not already hold.
+     */
+    private static boolean requiresServerType(BeanDefinitionReference<?> reference) {
+        return reference.getBeanDefinitionName().startsWith("io.kestra")
+            && reference.getAnnotationMetadata()
+                .getAnnotationValuesByType(Requires.class)
+                .stream()
+                .anyMatch(requires -> requires.stringValue("property")
+                    .filter(SERVER_TYPE_PROPERTY::equals)
+                    .isPresent());
+    }
 
     public static void main(String[] args) {
         System.exit(runCli(args));
@@ -365,27 +387,21 @@ public class Kestra implements Callable<Integer>, NoDatabaseCommandInterface {
 
     /**
      * {@link ApplicationContext} for a {@link NoDatabaseCommandInterface} command: it drops
-     * Micronaut's JDBC datasource beans and Kestra's migration beans, so a command that owns no
-     * repository neither connects to the configured database nor migrates its schema.
+     * Micronaut's JDBC datasource beans and every Kestra bean that requires a server type, so a
+     * command that owns no repository neither connects to the configured database nor starts a
+     * service that would.
      *
      * <p>
      * Both are needed. The datasource beans are dropped for the reason given on
-     * {@link WorkerApplicationContext}. The migration beans are dropped because
-     * {@code MigrationStartupRunner} is a highest-precedence {@code @Context} bean gated on
-     * {@code kestra.repository.type} being present and on {@code kestra.server-type} not being
-     * {@code WORKER} — and {@code notEquals} is satisfied by an absent property, which is what a
-     * command that declares no server type has. Left registered, it would fail on the datasource
-     * that is no longer there.
+     * {@link WorkerApplicationContext}. The server beans are dropped because a configuration shared
+     * across server types commonly declares {@code kestra.server-type}, and everything gated on it
+     * then registers for a command that is not a server — the liveness coordinator, the MCP change
+     * notifier, the migration trigger — and fails on the datasource that is no longer there.
      *
      * <p>
-     * Deliberately narrower than {@link MigrationApplicationContext}: dropping every conditional
-     * Kestra {@code @Context} bean would also drop {@code KestraContext.Initializer}, the only
-     * caller of {@code KestraContext.setContext}, and these commands parse flows and read plugins
-     * through code that expects it.
-     *
-     * <p>
-     * The Enterprise Edition's own migration package is not matched, and does not need to be: it
-     * holds no eagerly-initialized bean.
+     * Narrower than {@link MigrationApplicationContext}, which drops every conditional Kestra
+     * {@code @Context} bean: these commands parse flows and read plugins, so they need the rest of
+     * the DI infrastructure to stay.
      */
     private static final class NoDatabaseApplicationContext extends DefaultApplicationContext {
 
@@ -396,10 +412,8 @@ public class Kestra implements Callable<Integer>, NoDatabaseCommandInterface {
         @Override
         protected List<BeanDefinitionReference> resolveBeanDefinitionReferences() {
             return super.resolveBeanDefinitionReferences().stream()
-                .filter(reference -> {
-                    String name = reference.getBeanDefinitionName();
-                    return !name.startsWith(MICRONAUT_JDBC_PACKAGE) && !name.startsWith(KESTRA_MIGRATION_PACKAGE);
-                })
+                .filter(reference -> !reference.getBeanDefinitionName().startsWith(MICRONAUT_JDBC_PACKAGE))
+                .filter(reference -> !requiresServerType(reference))
                 .toList();
         }
     }

--- a/cli/src/main/java/io/kestra/cli/commands/flows/FlowTestCommand.java
+++ b/cli/src/main/java/io/kestra/cli/commands/flows/FlowTestCommand.java
@@ -81,10 +81,11 @@ public class FlowTestCommand extends AbstractApiCommand {
             .put("kestra.server-type", ServerType.STANDALONE)
             // The flow is read from a file rather than from the instance, so the run gets a database
             // and a storage directory of its own. EphemeralDatabase.URL_PROPERTY repoints every
-            // datasource, including the log store's own.
+            // datasource; the log store follows the repository type, and its own pool is skipped on
+            // the same marker. Setting kestra.logs.type here would instead trip the licence gate on
+            // an external log store.
             .put("kestra.repository.type", "h2")
             .put("kestra.queue.type", "h2")
-            .put("kestra.logs.type", "h2")
             .put(EphemeralDatabase.URL_PROPERTY, EPHEMERAL_DATABASE_URL)
             .put("kestra.storage.type", "local")
             .put("kestra.storage.local.base-path", TEMP_STORAGE.toAbsolutePath().toString())

--- a/cli/src/test/java/io/kestra/cli/commands/NoDatabaseCommandContextTest.java
+++ b/cli/src/test/java/io/kestra/cli/commands/NoDatabaseCommandContextTest.java
@@ -23,10 +23,11 @@ import static org.assertj.core.api.Assertions.assertThat;
  */
 class NoDatabaseCommandContextTest {
     /**
-     * Declares a repository type as well as a datasource, since that is what keeps the repositories
-     * registered, and keys the datasource {@code h2} to override the one the test environment
-     * declares rather than add a second — two would fail for that reason instead of the unreachable
-     * host.
+     * Shaped like a configuration shared across server types: a repository type, which is what
+     * keeps the repositories registered, and a server type, which is what registers the server
+     * facets gated on it. The datasource is keyed {@code h2} to override the one the test
+     * environment declares rather than add a second — two would fail for that reason instead of the
+     * unreachable host.
      */
     private static Path unreachableDatabaseConfig(Path tempDir) throws Exception {
         return Files.writeString(tempDir.resolve("kestra.yml"), """
@@ -37,6 +38,7 @@ class NoDatabaseCommandContextTest {
                 username: kestra
                 password: k3str4
             kestra:
+              server-type: STANDALONE
               repository:
                 type: postgres
               queue:


### PR DESCRIPTION
### 🔗 Related Issue

Follow-up to https://github.com/kestra-io/kestra/issues/18945, fixing a regression in the merged #18967.

### ✨ Description

A command marked `NoDatabaseCommandInterface` still failed to start whenever the configuration declared `kestra.server-type`:

```
Bean definition [io.kestra.executor.DefaultServiceLivenessCoordinator] could not be loaded:
  Failed to inject value for parameter [dslContext] of class: io.kestra.jdbc.JooqDSLContextWrapper
Message: No bean of type [org.jooq.DSLContext] exists.
```

Dropping the datasource beans is not enough on its own. The server facets are gated on `kestra.server-type`, and a configuration shared across server types commonly declares it — which is the very case `WorkerApplicationContext` exists for. Everything gated on it then registers for a command that is not a server, and fails on the datasource that is no longer there.

Those beans are dropped now, keyed on the **requirement** rather than on the scope. Scope is the wrong signal here: `McpServerChangeNotifier` is a plain `@Singleton` whose `@EventListener` for `StartupEvent` makes it just as eager as a `@Context` bean, so an `isContextScope()` check misses it. Reading the `@Requires` values stays metadata-only, loading no class the bean definition does not already hold. The migration-package filter goes away with it, since the migration trigger requires a server type and the general rule now covers it.

`AbstractCommand` also stops injecting the embedded server as an `Optional`. That resolved the whole webserver bean graph for every command, while only a `ServerCommandInterface` command ever starts one — the same eager-`Optional` shape already removed from `DefaultStartupHook`. Not strictly required by the tests here, but it removes the other route into that graph, which is where the Enterprise Edition reaches its security and MCP beans.

### 🛠️ Backend Checklist

- [x] Code compiles and tests pass for the touched modules (`./gradlew :cli:test :jdbc:test` — 75/75 and 81 passed with 4 pre-existing skips)
- [x] New behavior is covered by unit or integration tests

`NoDatabaseCommandContextTest`'s fixture now declares `kestra.server-type: STANDALONE` alongside the datasource, so it is shaped like the shared configuration that exposed this. On the current `develop` it fails with exactly the error above.

### 📝 How this was found

`fix/cli-no-database-context` on kestra-ee (kestra-io/kestra-ee#10700) went red on `KestraTest.testHelp` and `KestraTest.missingRequiredParamsPrintHelpInsteadOfException`, both exiting 1 instead of 0/2. EE CI resolves the OSS branch with the same name as the EE PR's head ref, so that run was the first to exercise #18967 against EE — and EE's own test configuration (`cli-ee/src/test/resources/application-memory.yml`) declares `kestra.server-type: STANDALONE`, which is what registered `DefaultServiceLivenessCoordinator`.

This branch is named to match that EE branch so the same pairing picks it up.

My analysis of #18967 asserted these beans were "already inert for CLI commands because they are gated on `kestra.server-type` being present". That was wrong: it is only true when *nothing* sets the property. The command does not — but a configuration file can, and the OSS test that would have caught it did not declare one.

### 🩹 Second commit: `flow test` no longer forces an external log store

`FlowTestCommandTest` was failing on `develop` before this PR, for an unrelated reason that is fixed in the second commit:

```
java.lang.IllegalArgumentException: Configuring an external log store ('kestra.logs.type=h2')
  requires Kestra Enterprise Edition.
```

An external log store became an Enterprise Edition feature after #18943, and the open-source guard rejects `kestra.logs.type` whenever it is set at all — while #18943 forces it. So `kestra flow test` could not start in the open-source edition.

Nothing replaces it. The log store falls back to `kestra.repository.type`, which the command already forces to the ephemeral H2, and `LogJdbcDataSourceProvider` skips a configured dedicated pool on the ephemeral marker alone, before it reads any type — so the logs stay in the throwaway database either way. Both commits are the same failure mode (a CLI command that cannot start against a real configuration), which is why they travel together.

### 🤖 AI Authors

The cat notes that she, too, registers unpredictably when the configuration mentions a server, and asks to be exempted on the grounds of owning no repository. 🐱
