### PR TITLE
fix(namespaces): gate namespace file actions in the editor on the NAMESPACE permission (backport to 1.3.x)

### DIFF
--- a/ui/src/components/inputs/EditorWrapper.vue
+++ b/ui/src/components/inputs/EditorWrapper.vue
@@ -171,10 +171,10 @@
         return !onboardingStore.isGuidedActive && authStore.user?.isAllowed(permission.AI_COPILOT, action.READ, namespace.value);
     });
 
-    // Saving a namespace file hits POST /namespaces/{namespace}/files, guarded by FLOW:CREATE.
+    // Saving a namespace file hits POST /namespaces/{namespace}/files, guarded by NAMESPACE:CREATE.
     const canWriteFiles = computed<boolean>(() => {
         const fileNamespace = namespace.value ?? route.params?.namespace;
-        return authStore.user?.isAllowed(permission.FLOW, action.CREATE, fileNamespace?.toString()) ?? false;
+        return authStore.user?.isAllowed(permission.NAMESPACE, action.CREATE, fileNamespace?.toString()) ?? false;
     });
 
     /** 10MB */

--- a/ui/src/components/inputs/FileExplorer.vue
+++ b/ui/src/components/inputs/FileExplorer.vue
@@ -492,12 +492,13 @@
 
     const namespaceId = computed<string>(() => props.currentNS ?? route.params.namespace as string);
 
-    // Namespace files are governed by the FLOW permission on the file's namespace (see NamespaceFileController):
-    // read/export need READ, create/import need CREATE, rename/move need UPDATE, delete needs DELETE.
+    // Namespace files are read through the FLOW permission but written through the NAMESPACE permission
+    // on the file's namespace (see NamespaceFileController): read/export need FLOW READ, while
+    // create/import need NAMESPACE CREATE, rename/move need NAMESPACE UPDATE and delete needs NAMESPACE DELETE.
     const authStore = useAuthStore();
-    const canCreate = computed(() => authStore.user?.isAllowed(permission.FLOW, action.CREATE, namespaceId.value) ?? false);
-    const canUpdate = computed(() => authStore.user?.isAllowed(permission.FLOW, action.UPDATE, namespaceId.value) ?? false);
-    const canDelete = computed(() => authStore.user?.isAllowed(permission.FLOW, action.DELETE, namespaceId.value) ?? false);
+    const canCreate = computed(() => authStore.user?.isAllowed(permission.NAMESPACE, action.CREATE, namespaceId.value) ?? false);
+    const canUpdate = computed(() => authStore.user?.isAllowed(permission.NAMESPACE, action.UPDATE, namespaceId.value) ?? false);
+    const canDelete = computed(() => authStore.user?.isAllowed(permission.NAMESPACE, action.DELETE, namespaceId.value) ?? false);
 
     const multiSelected = computed(() => selectedNodes.value.length > 1);
 


### PR DESCRIPTION
Related to https://github.com/kestra-io/kestra-ee/issues/7022.

## What

The file explorer and the editor save button enabled create, import, rename, move and delete on `namespace` files for users holding the `FLOW` permission, matching the `EE` backend of the time. The `EE` backend on `releases/v1.3.x` now requires the `NAMESPACE` permission (`CREATE`, `UPDATE`, `DELETE`) for those writes, so the `UI` checks the same permission instead of offering actions that end in a `403`.

- `FileExplorer.vue`: `canCreate`, `canUpdate`, `canDelete` now check `NAMESPACE` instead of `FLOW`.
- `EditorWrapper.vue`: `canWriteFiles` (saving a `namespace` file) now checks `NAMESPACE` `CREATE`.

Reading files is unchanged. `OSS` has no permission checks, so this only affects `EE`.

## Companion

`EE` companion: https://github.com/kestra-io/kestra-ee/pull/10714. Merge order: `EE` first, then this `PR`.