### PR TITLE
fix(core): post the silent token refresh under the context-path (1.3 backport)

### DIFF
--- a/ui/src/utils/axios.ts
+++ b/ui/src/utils/axios.ts
@@ -184,7 +184,8 @@ export const createAxios = (
                     refreshing = true
 
                     try {
-                        await instance.post("/oauth/access_token?grant_type=refresh_token", null, {
+                        const refreshBasePath = window.KESTRA_BASE_PATH.endsWith("/") ? window.KESTRA_BASE_PATH.slice(0, -1) : window.KESTRA_BASE_PATH
+                        await instance.post(`${refreshBasePath}/oauth/access_token?grant_type=refresh_token`, null, {
                             headers: {"Content-Type": "application/json"},
                             timeout: 5000
                         })


### PR DESCRIPTION
Related to https://github.com/kestra-io/kestra-ee/issues/8807.

`OSS` half of the 1.3 backport of https://github.com/kestra-io/kestra-ee/pull/10713. Companion `EE` `PR`: https://github.com/kestra-io/kestra-ee/pull/10716.

## What

On 1.3 the silent token refresh lives in the shared axios interceptor (`ui/src/utils/axios.ts`). It posted to a root-relative `/oauth/access_token`, which does not exist when `Kestra` runs under `micronaut.server.context-path`, so every expired access token ended in a logout instead of a refresh. The call now carries the configured base path, the same way the login redirect a few lines above already does.

Only the `EE` login flow issues refresh cookies, so this has no effect on `OSS` alone. Merge order does not matter: each half is safe on its own.

