### PR TITLE
fix(system): a parse failure no longer picks the no-database context

### DIFF
--- a/cli/src/main/java/io/kestra/cli/Kestra.java
+++ b/cli/src/main/java/io/kestra/cli/Kestra.java
@@ -217,7 +217,12 @@ public class Kestra implements Callable<Integer>, NoDatabaseCommandInterface {
             ? commandProperties(cls, commandLine)
             : Map.of();
 
-        return contextBuilder(cls, properties)
+        // A parse failure leaves the leaf unresolved, so picocli reports the root while going on to
+        // instantiate the command the arguments named. Choosing a flavour from the root would then
+        // build the wrong one — see contextBuilder.
+        boolean parsedCleanly = commandLine.getParseResult().errors().isEmpty();
+
+        return contextBuilder(cls, properties, parsedCleanly)
             .mainClass(mainClass)
             .environments(environments)
             .properties(properties)
@@ -258,7 +263,8 @@ public class Kestra implements Callable<Integer>, NoDatabaseCommandInterface {
     /**
      * Select the {@link ApplicationContext} flavour a command runs in.
      */
-    private static ApplicationContextBuilder contextBuilder(Class<?> cls, Map<String, Object> properties) {
+    private static ApplicationContextBuilder contextBuilder(Class<?> cls, Map<String, Object> properties,
+        boolean parsedCleanly) {
         // Pure migration commands run in a minimal context that never registers the other
         // Kestra @Context beans (repositories, server services, the migration startup trigger),
         // so nothing touches the database before the migration is applied explicitly.
@@ -272,8 +278,10 @@ public class Kestra implements Callable<Integer>, NoDatabaseCommandInterface {
         }
 
         // Commands that own no repository run without a datasource, so they work — and stay out of
-        // the schema — whatever the instance is configured with.
-        if (NoDatabaseCommandInterface.class.isAssignableFrom(cls)) {
+        // the schema — whatever the instance is configured with. Only when the arguments parsed:
+        // otherwise this class is the root standing in for a command that did not resolve, and that
+        // command may well own a repository.
+        if (parsedCleanly && NoDatabaseCommandInterface.class.isAssignableFrom(cls)) {
             return new NoDatabaseApplicationContextBuilder();
         }
 

--- a/cli/src/test/java/io/kestra/cli/commands/NoDatabaseCommandContextTest.java
+++ b/cli/src/test/java/io/kestra/cli/commands/NoDatabaseCommandContextTest.java
@@ -83,6 +83,16 @@ class NoDatabaseCommandContextTest {
     }
 
     @Test
+    void shouldKeepTheDatasourceWhenTheArgumentsDoNotParse() {
+        // A parse failure reports the root as the leaf, and the root owns no repository — but
+        // picocli goes on to instantiate the command the arguments named, which may. Enterprise
+        // Edition's `flow delete` resolves a tenant through one.
+        try (ApplicationContext ctx = context("flow", "delete")) {
+            assertThat(ctx.containsBean(DataSource.class)).isTrue();
+        }
+    }
+
+    @Test
     void shouldStillBuildADatasourceForACommandThatOwnsARepository(@TempDir Path tempDir) throws Exception {
         // Empty, so the database comes from the test configuration rather than from a developer's
         // own ~/.kestra/config.yml, which this one has to be able to reach.


### PR DESCRIPTION
### 🔗 Related Issue

Follow-up to https://github.com/kestra-io/kestra/issues/18945, fixing the last case missed by #18967 and #18989.

### ✨ Description

`kestra flow delete` with its required parameters missing exited 1 instead of printing usage, on an Enterprise Edition build:

```
picocli.CommandLine$InitializationException: Could not instantiate class FlowDeleteCommand:
  Failed to inject value for field [tenantRepository] of class: TenantIdSelectorEEService
Message: No bean of type [io.kestra.ee.repositories.TenantRepositoryInterface] exists.
Path Taken: new FlowDeleteCommand() \---> #tenantService \---> TenantIdSelectorEEService#tenantRepository
```

The context flavour is chosen from the leaf command picocli resolves. When the arguments fail to parse there is no leaf, so picocli reports the **root** — which owns no repository and therefore selected the no-database context. Picocli then goes on to instantiate the command the arguments actually named, and that command may own a repository: `flow delete` resolves a tenant through one in the Enterprise Edition, which is exactly why it is not marked.

So the flavour was being chosen for one command and applied to another. It is now only taken from the marker when the arguments parsed; a parse failure falls back to the default context, as before, and picocli prints usage.

Nothing changes for a genuine root invocation. `kestra` and `kestra --help` parse cleanly, so they keep the context that makes them work against a configured database — measured: for `{"flow","delete"}` the resolved leaf is `Kestra` with 1 parse error, while a bare invocation and `kestra --help` resolve to `Kestra` with none.

### 🛠️ Backend Checklist

- [x] Code compiles and tests pass for the touched modules (`./gradlew :cli:test` — 76/76)
- [x] New behavior is covered by unit or integration tests

`NoDatabaseCommandContextTest.shouldKeepTheDatasourceWhenTheArgumentsDoNotParse` asserts the datasource survives for `flow delete`, and fails on the current `develop`. It asserts the decision rather than the symptom, because the open-source `FlowDeleteCommand` needs no repository — only the Enterprise Edition's tenant selector does, so the symptom is not reproducible here.

### ✅ Verified against the Enterprise Edition

`io.kestra.ee.KestraTest` fails 1 of 9 on `develop` and passes 9 of 9 with this change, run locally with this branch checked out as the sibling of the kestra-ee branch — the same pairing CI uses. That is the test that has been red on kestra-io/kestra-ee#10700, and this branch is named to match so the same pairing picks it up.

### 📝 Additional Notes

The three CLI fixes in this series each came from the same blind spot: the OSS tests exercised a configuration the marker was never going to meet in production. #18989 added a declared `kestra.server-type` to the fixture; this one adds the parse-failure path. Both were found by the kestra-ee run rather than by OSS CI, because the Enterprise Edition is where an unmarked command actually reaches a repository.

Still red on kestra-io/kestra-ee#10700 and unrelated to this: `ElasticSearchServiceLivenessCoordinatorTest` (two parameterised cases). Worth a separate look — that module's tests were also reported as producing partial results after an abnormally terminated JVM.

### 🤖 AI Authors

The cat has been informed that when she fails to parse an instruction, the correct behaviour is to fall back to the previous one rather than to invent a new context. She has filed this under "suggestions". 🐱
