### PR TITLE
fix(dashboards): include headers in empty CSV exports

### DIFF
--- a/webserver/src/main/java/io/kestra/webserver/controllers/api/DashboardController.java
+++ b/webserver/src/main/java/io/kestra/webserver/controllers/api/DashboardController.java
@@ -296,7 +296,7 @@ public class DashboardController {
         assertExportable(fetchChartDataQuery.chart());
         var fetchedData = fetchChartData(fetchChartDataQuery);
 
-        return export(fetchedData.getResults(), "%s_%s_export".formatted(id, chartId), format);
+        return export(fetchChartDataQuery.chart(), fetchedData.getResults(), "%s_%s_export".formatted(id, chartId), format);
     }
 
     @ExecuteOn(TaskExecutors.IO)
@@ -309,7 +309,7 @@ public class DashboardController {
         assertExportable(fetchChartDataQuery.chart());
         var fetchedData = fetchChartData(fetchChartDataQuery);
 
-        return export(fetchedData.getResults(), "%s_%s_export".formatted("default-dashboard", fetchChartDataQuery.chart().getId()), format);
+        return export(fetchChartDataQuery.chart(), fetchedData.getResults(), "%s_%s_export".formatted("default-dashboard", fetchChartDataQuery.chart().getId()), format);
     }
 
     private void assertExportable(Chart<?> chart) {
@@ -318,14 +318,18 @@ public class DashboardController {
         }
     }
 
-    private HttpResponse<byte[]> export(List<Map<String, Object>> rows, String filename, ExportFormat format) throws IOException {
+    private HttpResponse<byte[]> export(Chart<?> chart, List<Map<String, Object>> rows, String filename, ExportFormat format) throws IOException {
         var byteArrayOutputStream = new ByteArrayOutputStream();
 
         if (format == ExportFormat.ION) {
             FileSerde.writeAll(byteArrayOutputStream, Flux.fromIterable(rows)).block();
         } else {
             var outputStreamWriter = new OutputStreamWriter(byteArrayOutputStream, StandardCharsets.UTF_8);
-            CSVUtils.toCSV(outputStreamWriter, rows);
+            if (rows.isEmpty() && chart instanceof DataChart<?, ?> dataChart) {
+                CSVUtils.toCSV(outputStreamWriter, rows, List.copyOf(dataChart.getData().getColumns().keySet()));
+            } else {
+                CSVUtils.toCSV(outputStreamWriter, rows);
+            }
         }
 
         var fullFilename = "%s.%s".formatted(filename, format.name().toLowerCase());

--- a/webserver/src/main/java/io/kestra/webserver/utils/CSVUtils.java
+++ b/webserver/src/main/java/io/kestra/webserver/utils/CSVUtils.java
@@ -14,7 +14,8 @@ import reactor.core.publisher.Flux;
 /**
  * Renders records to RFC 4180 compliant CSV.
  *
- * <p>The keys of the first record define the columns: every subsequent record is projected onto them, so a record
+ * <p>
+ * Columns are either provided explicitly or derived from the first record. Every subsequent record is projected onto them, so a record
  * holding extra or missing keys can never shift the remaining values into the wrong columns.
  */
 public final class CSVUtils {
@@ -28,12 +29,21 @@ public final class CSVUtils {
      * @param lines the records to render, nothing is written when empty
      */
     public static void toCSV(Writer outWriter, List<Map<String, Object>> lines) {
+        if (lines.isEmpty()) {
+            return;
+        }
+        toCSV(outWriter, lines, headers(lines.getFirst()));
+    }
 
+    /**
+     * Writes all records using the provided headers.
+     *
+     * @param outWriter the writer to render the CSV to
+     * @param lines the records to render
+     * @param headers the columns to render, including when there are no records
+     */
+    public static void toCSV(Writer outWriter, List<Map<String, Object>> lines, List<String> headers) {
         try (var csvWriter = CsvWriter.builder().build(outWriter)) {
-            if (lines.isEmpty()) {
-                return;
-            }
-            List<String> headers = headers(lines.getFirst());
             csvWriter.writeRecord(headers);
             for (Map<String, Object> record : lines) {
                 csvWriter.writeRecord(values(record, headers));

--- a/webserver/src/test/java/io/kestra/webserver/controllers/api/DashboardControllerTest.java
+++ b/webserver/src/test/java/io/kestra/webserver/controllers/api/DashboardControllerTest.java
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.Test;
 import org.slf4j.event.Level;
 
 import io.kestra.core.junit.annotations.KestraTest;
+import io.kestra.core.junit.assertions.Problems;
 import io.kestra.core.models.Label;
 import io.kestra.core.models.QueryFilter;
 import io.kestra.core.models.QueryFilter.Op;
@@ -56,6 +57,41 @@ class DashboardControllerTest {
 
     @Inject
     ExecutionRepositoryInterface executionRepository;
+
+    @Test
+    void shouldExportCsvHeadersWhenAdHocChartHasNoRows() {
+        var fakeNamespace = "a-namespace_" + IdUtils.create();
+        String chartYaml = """
+            id: empty_logs_chart_id
+            type: io.kestra.plugin.core.dashboard.chart.Table
+            data:
+              type: io.kestra.plugin.core.dashboard.data.Logs
+              columns:
+                chart_namespace:
+                  field: NAMESPACE
+                chart_execution_id:
+                  field: EXECUTION_ID
+              where:
+                - field: NAMESPACE
+                  type: EQUAL_TO
+                  value: "%s"
+            """.formatted(fakeNamespace);
+
+        var previewRequest = new DashboardController.PreviewRequest(chartYaml, ChartFiltersOverrides.builder().filters(Collections.emptyList()).build());
+        PagedResults<Map<String, Object>> chartData = client.toBlocking().retrieve(
+            POST(DASHBOARD_PATH + "/charts/preview", previewRequest),
+            PagedResults.class
+        );
+        assertThat(chartData.getTotal()).isZero();
+        assertThat(chartData.getResults()).isEmpty();
+
+        HttpResponse<byte[]> csvResponse = client.toBlocking().exchange(
+            POST(DASHBOARD_PATH + "/charts/export", previewRequest),
+            Argument.of(byte[].class)
+        );
+        var csv = new String(csvResponse.getBody().orElse(new byte[0]), StandardCharsets.UTF_8);
+        assertThat(csv).isEqualTo("chart_namespace,chart_execution_id\r\n");
+    }
 
     @Test
     void shouldExportAnAdHocPreviewChartToCsv() {


### PR DESCRIPTION
Closes https://github.com/kestra-io/kestra/issues/18577.

### 🔗 Related Issue

https://github.com/kestra-io/kestra/issues/18577

### ✨ Description

Dashboard CSV exports returned a 0-byte response when a chart had no results. Data charts now use their declared columns for both empty and populated exports, producing a header-only CSV when empty and keeping the column order consistent when rows are present. Values are written in that same column order.

The existing controller export test now exports the same chart before and after inserting a row, with declared columns in the opposite order to the JDBC result. It replaces the separate empty-result test and verifies both header consistency and value alignment. The unused import identified in review has also been removed.

### 🛠️ Backend Checklist

- [x] Code compiles and tests pass for the touched modules (`./gradlew :webserver:test`)
- [x] New behavior is covered by unit or integration tests

### 📝 Additional Notes

The regression test failed with the previous header-selection logic and passes with the fix. All 1,299 webserver tests passed with no failures or skipped tests in 8m 23s. Spotless completed successfully with Java 25.

Rebased onto `develop`, preserving the upstream `StreamedFile` filename handling.