### PR TITLE
fix(flows): breadcrumb navigation from execution to flow edit no longer blanks the page

### DIFF
--- a/ui/src/components/executions/composables/useExecutionRoot.ts
+++ b/ui/src/components/executions/composables/useExecutionRoot.ts
@@ -53,6 +53,11 @@ export function useExecutionRoot() {
         return executionsStore.execution !== undefined
     })
 
+    // By the time either cleanup below runs, router navigation has already updated `route` to the
+    // destination: if the store holds the flow being navigated to (e.g. breadcrumb -> flow edit,
+    // #10722), clearing it here would erase data the destination page already loaded and rendered.
+    const flowMatchesTarget = () => flowStore.flow?.namespace === route.params.namespace && flowStore.flow?.id === route.params.id
+
     const follow = () => {
         previousExecutionId.value = route.params.id as string
         executionsStore.followExecution(route.params as any, t)
@@ -95,8 +100,10 @@ export function useExecutionRoot() {
         watch(route, () => {
             if (previousExecutionId.value !== route.params.id) {
                 executionsStore.logs = {total: 0, results: []}
-                flowStore.flow = undefined
-                flowStore.flowGraph = undefined
+                if (!flowMatchesTarget()) {
+                    flowStore.flow = undefined
+                    flowStore.flowGraph = undefined
+                }
                 follow()
             }
         })
@@ -106,8 +113,10 @@ export function useExecutionRoot() {
             window.removeEventListener("popstate", follow)
             executionsStore.execution = undefined
             executionsStore.logs = {total: 0, results: []}
-            flowStore.flow = undefined
-            flowStore.flowGraph = undefined
+            if (!flowMatchesTarget()) {
+                flowStore.flow = undefined
+                flowStore.flowGraph = undefined
+            }
         })
     }
 

--- a/ui/src/components/flows/FlowRoot.vue
+++ b/ui/src/components/flows/FlowRoot.vue
@@ -9,6 +9,7 @@
             :tabs="tabs"
         />
     </template>
+    <div v-else class="full-space" v-ks-loading="true" />
 </template>
 
 <script setup lang="ts">
@@ -27,3 +28,9 @@
 
     setupLifecycle()
 </script>
+
+<style scoped lang="scss">
+    .full-space {
+        flex: 1 1 auto;
+    }
+</style>

--- a/ui/src/stores/flow.ts
+++ b/ui/src/stores/flow.ts
@@ -435,13 +435,19 @@ export const useFlowStore = defineStore("flow", () => {
         })
     }
 
-    let latestFlowLoad = 0
+    // Tracks the flow the user is currently navigating to, so a load for a flow they have since
+    // moved away from can be dropped without an unrelated caller's own load for the *same* flow
+    // (e.g. Topology.vue re-syncing in the background) being able to drop it too (#10722).
+    let latestFlowLoadKey: string | undefined
 
     async function loadFlow(
         options: { namespace: string, id: string, revision?: string, allowDeleted?: boolean, source?: boolean, store?: boolean, deleted?: boolean },
         requestOptions?: KestraRequestOptions,
     ) {
-        const load = options.store === false ? undefined : ++latestFlowLoad
+        const key = `${options.namespace}/${options.id}`
+        if (options.store !== false) {
+            latestFlowLoadKey = key
+        }
         let data: Flow & {exception?: string}
         try {
             data = await FlowsAPI.flow({
@@ -458,9 +464,9 @@ export const useFlowStore = defineStore("flow", () => {
             throw e
         }
 
-        // A load the user has navigated away from must not become the flow on screen, the same way a
-        // superseded search is dropped in `stores/logs.ts`.
-        if (options.store === false || load !== latestFlowLoad) {
+        // A load for a flow the user has navigated away from must not become the flow on screen,
+        // the same way a superseded search is dropped in `stores/logs.ts`.
+        if (options.store === false || key !== latestFlowLoadKey) {
             return data
         }
 

--- a/ui/tests/unit/components/executions/useExecutionRoot.spec.ts
+++ b/ui/tests/unit/components/executions/useExecutionRoot.spec.ts
@@ -1,0 +1,88 @@
+import {beforeEach, describe, expect, it, vi} from "vitest"
+import {reactive} from "vue"
+import {mount} from "@vue/test-utils"
+
+const route = reactive<{params: Record<string, string>}>({
+    params: {namespace: "company.team", flowId: "demo_breadcrumb_fix", id: "exec-1"},
+})
+
+vi.mock("vue-router", () => ({
+    useRoute: () => route,
+}))
+
+vi.mock("vue-i18n", () => ({
+    useI18n: () => ({t: (key: string) => key}),
+}))
+
+vi.mock("../../../../src/stores/flow", async () => {
+    const {reactive: reactiveVue} = await import("vue")
+    const flowStore = reactiveVue({
+        flow: undefined,
+        flowGraph: undefined,
+        loadDependencies: vi.fn().mockResolvedValue({count: 0}),
+    })
+    return {useFlowStore: () => flowStore}
+})
+
+vi.mock("../../../../src/stores/executions", () => ({
+    useExecutionsStore: () => ({
+        execution: undefined,
+        logs: {total: 0, results: []},
+        closeSSE: vi.fn(),
+        followExecution: vi.fn(),
+    }),
+}))
+
+vi.mock("../../../../src/components/executions/executionTabs", () => ({
+    EXECUTION_PARENT_ROUTE: "executions/update",
+    EXECUTION_TAB_ROUTES: [],
+}))
+
+import {useFlowStore} from "../../../../src/stores/flow"
+import {useExecutionRoot} from "../../../../src/components/executions/composables/useExecutionRoot"
+
+function mountExecutionRoot() {
+    return mount({
+        template: "<div></div>",
+        setup() {
+            useExecutionRoot().setupLifecycle()
+        },
+    })
+}
+
+describe("useExecutionRoot unmount cleanup", () => {
+    const flowStore = useFlowStore()
+
+    beforeEach(() => {
+        route.params = {namespace: "company.team", flowId: "demo_breadcrumb_fix", id: "exec-1"}
+        flowStore.flow = undefined
+        flowStore.flowGraph = undefined
+    })
+
+    it("clears the flow store when navigating away from any flow", () => {
+        flowStore.flow = {namespace: "company.team", id: "some-other-flow"} as any
+        flowStore.flowGraph = {} as any
+
+        const wrapper = mountExecutionRoot()
+        route.params = {}
+        wrapper.unmount()
+
+        expect(flowStore.flow).toBeUndefined()
+        expect(flowStore.flowGraph).toBeUndefined()
+    })
+
+    it("keeps the flow store when navigating to that flow's edit page (breadcrumb, #10722)", () => {
+        flowStore.flow = {namespace: "company.team", id: "demo_breadcrumb_fix"} as any
+        flowStore.flowGraph = {some: "graph"} as any
+
+        const wrapper = mountExecutionRoot()
+
+        // Router navigation resolves before the outgoing component unmounts: `route` already
+        // reflects the flow-edit destination (`namespace`/`id`, no `flowId`) by the time this runs.
+        route.params = {namespace: "company.team", id: "demo_breadcrumb_fix"}
+        wrapper.unmount()
+
+        expect(flowStore.flow).toEqual({namespace: "company.team", id: "demo_breadcrumb_fix"})
+        expect(flowStore.flowGraph).toEqual({some: "graph"})
+    })
+})

--- a/ui/tests/unit/stores/entityLoadRace.spec.ts
+++ b/ui/tests/unit/stores/entityLoadRace.spec.ts
@@ -56,6 +56,28 @@ describe("entity load ordering", () => {
         expect(store.flowYaml).toBe("id: fast")
     })
 
+    it("does not drop a successful flow load when a later, same-flow load fails", async () => {
+        const store = useFlowStore()
+        let resolveFirst: (flow: unknown) => void = () => {}
+        let callCount = 0
+        flowApi.mockImplementation(() => {
+            callCount++
+            return callCount === 1
+                ? new Promise((resolve) => {
+                    resolveFirst = resolve
+                })
+                : Promise.reject(new Error("network error"))
+        })
+
+        const first = store.loadFlow({namespace: "ns", id: "target"})
+        await store.loadFlow({namespace: "ns", id: "target"}).catch(() => {})
+        resolveFirst({id: "target", namespace: "ns", revision: 1, source: "id: target"})
+        await first
+
+        expect(store.flow?.id).toBe("target")
+        expect(store.flowYaml).toBe("id: target")
+    })
+
     it("drops an execution load the user has navigated away from", async () => {
         const store = useExecutionsStore()
         let resolveSlow: (execution: unknown) => void = () => {}


### PR DESCRIPTION
Closes https://github.com/kestra-io/kestra-ee/issues/10722

## Problem
Clicking the breadcrumb from any execution tab to that execution's flow edit page left the
main content area completely blank (sidebar rendered fine, no spinner, no error).

## Fix
Two independent races had to be fixed:
- `stores/flow.ts`: scope the "superseded load" drop-check to the flow being loaded
  (namespace/id) instead of a single global counter, so an unrelated concurrent flow load
  can no longer drop the response for the flow actually being navigated to.
- `FlowRoot.vue`: render a loading state (matching `ExecutionRoot.vue`'s existing pattern)
  instead of nothing while `!ready`, so a future race is a flicker, not a permanent blank
  page.
- `useExecutionRoot.ts`: the execution page's unmount cleanup unconditionally cleared
  `flowStore.flow`/`flowGraph`. Vue unmounts the outgoing execution view *after* the
  incoming flow view has already loaded and rendered, so this cleanup was firing late and
  wiping out the destination page's already-loaded data — turning the original blank page
  into a permanent stuck loading spinner instead. The cleanup now skips clearing when the
  store already holds the flow the app is navigating to.

## Evidence
- Regression tests: `tests/unit/stores/entityLoadRace.spec.ts` and
  `tests/unit/components/executions/useExecutionRoot.spec.ts`, both verified to fail on
  pre-fix code and pass after.
- `check:types`, `test:unit`, `test:lint` all pass. CI green.
- Manual browser verification, independently reproduced twice (once during initial QA,
  once after the follow-up fix): breadcrumb navigation from an execution to its flow now
  renders the editor and stays rendered — confirmed via DOM polling over several seconds,
  not just a single frame.

## Demo

https://github.com/user-attachments/assets/41a339a7-186c-4e1a-9828-e71827e3318e
