### PR TITLE
fix(plugins): avoid uninitialized KestraContext during migration-time plugin auto-install

### DIFF
--- a/core/src/main/java/io/kestra/core/plugins/PluginInstallJobRegistry.java
+++ b/core/src/main/java/io/kestra/core/plugins/PluginInstallJobRegistry.java
@@ -18,7 +18,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.stream.Collectors;
 
-import io.kestra.core.contexts.KestraContext;
 import io.kestra.core.docs.JsonSchemaCache;
 import io.kestra.core.exceptions.KestraRuntimeException;
 import io.kestra.core.utils.ExecutorsUtils;
@@ -172,7 +171,7 @@ public class PluginInstallJobRegistry {
                 // an instance that briefly needed a burst of installs.
                 int poolSize = concurrency > 0
                     ? concurrency
-                    : Math.max(8, 4 * KestraContext.getContext().getAllocatedCpuCores());
+                    : Math.max(8, 4 * executorsUtils.getAllocatedCpuCores());
                 installExecutor = executorsUtils.maxCachedThreadPool(poolSize, "plugin-install");
             }
         }


### PR DESCRIPTION
Closes https://github.com/kestra-io/kestra-ee/issues/10727.

## Problem

On a fresh slim-image start (`KESTRA_PLUGINS_AUTO_INSTALL_ENABLED=true`), every startup logs:

```
WARN  i.k.c.p.PluginAutoInstallService Plugin auto-install failed for artifacts [...].
java.lang.IllegalStateException: Kestra context not initialized
	at io.kestra.core.contexts.KestraContext.getContext(KestraContext.java:49)
	at io.kestra.core.plugins.PluginInstallJobRegistry.ensureStarted(PluginInstallJobRegistry.java:175)
	...
	at io.kestra.jdbc.migration.V2_0_11PluginAutoInstallMigration.migrate(...)
```

`PluginInstallJobRegistry.ensureStarted()` reads `KestraContext.getContext()` to size its thread pool. `KestraContext.Initializer` is a plain `@Context` bean with default init order, while `MigrationStartupRunner` is `@Context @Order(HIGHEST_PRECEDENCE)` and runs `V2_0_11PluginAutoInstallMigration`, which triggers plugin auto-install before `KestraContext` is set. The resulting `IllegalStateException` is caught by `PluginAutoInstallService.installArtifacts`'s best-effort catch block and logged as the WARN above — plugin auto-install then silently fails on every startup that hits this migration.

## Fix

`PluginInstallJobRegistry` already has `ExecutorsUtils` injected, which reads the allocated-CPU-cores configuration directly with no bean-init-order dependency. Swapped `KestraContext.getContext().getAllocatedCpuCores()` for `executorsUtils.getAllocatedCpuCores()`.

## Evidence

`./gradlew :core:compileJava` succeeds.