### PR TITLE
fix(flows): expose EE-only flow fields (quotas, policyRefs) in the no-code editor

### DIFF
--- a/ui/scripts/translations/fingerprints.json
+++ b/ui/scripts/translations/fingerprints.json
@@ -1122,6 +1122,7 @@
   "no_code|fields|general|labels": "934b8899c3d9",
   "no_code|fields|general|listeners": "a16c88ba4c0c",
   "no_code|fields|general|outputs": "e7ce99764a2d",
+  "no_code|fields|general|policyRefs": "8dea678b710b",
   "no_code|fields|general|quotas": "422b384753c3",
   "no_code|fields|general|retry": "942087cc2d41",
   "no_code|fields|general|sla": "0653cccd663d",

--- a/ui/src/components/no-code/blocks/FlowPropertiesEdit.vue
+++ b/ui/src/components/no-code/blocks/FlowPropertiesEdit.vue
@@ -73,6 +73,8 @@
     import {useFlowStore} from "../../../stores/flow"
     import {useFlowFields} from "../utils/useFlowFields"
     import {removeNullAndUndefined} from "../utils/cleanUp"
+    import {getFlowFields} from "./flowFields"
+    import {useMiscStore} from "override/stores/misc"
     import {
         CREATE_TASK_FUNCTION_INJECTION_KEY,
         FULL_SOURCE_INJECTION_KEY,
@@ -80,26 +82,13 @@
     } from "../injectionKeys"
 
     const flowStore = useFlowStore()
+    const miscStore = useMiscStore()
 
     const props = defineProps<{hideHeader?: boolean; hostedInModal?: boolean}>()
 
     const emit = defineEmits<{(e: "close"): void}>()
 
-    const FLOW_FIELDS = [
-        "id",
-        "namespace",
-        "description",
-        "labels",
-        "inputs",
-        "variables",
-        "outputs",
-        "concurrency",
-        "retry",
-        "sla",
-        "checks",
-        "workerSelector",
-        "disabled",
-    ]
+    const FLOW_FIELDS = computed(() => getFlowFields(miscStore.configs?.edition))
 
     const bubbleCreate = inject(CREATE_TASK_FUNCTION_INJECTION_KEY, () => {})
     const flowYaml = inject(FULL_SOURCE_INJECTION_KEY, ref(""))
@@ -177,7 +166,7 @@
 
     const fields = computed(() => {
         const all = [...fieldsFromSchemaTop.value, ...fieldsFromSchemaRest.value]
-        return FLOW_FIELDS
+        return FLOW_FIELDS.value
             .map((key) => all.find((field) => field.fieldKey === key))
             .filter((field): field is NonNullable<typeof field> => Boolean(field))
     })

--- a/ui/src/components/no-code/blocks/flowFields.ts
+++ b/ui/src/components/no-code/blocks/flowFields.ts
@@ -11,12 +11,16 @@ export const BASE_FLOW_FIELDS = [
     "sla",
     "checks",
     "quotas",
+    "policyRefs",
     "workerSelector",
     "disabled",
 ]
 
-// quotas is EE-only: on OSS the executor rejects it at runtime in a way that
-// crash-loops the server, so the no-code editor must not offer a way to add it.
+// quotas and policyRefs are EE-only: on OSS the executor rejects quotas at runtime in a way
+// that crash-loops the server, and policyRefs is parsed but silently ignored — so the no-code
+// editor must not offer a way to add either on OSS.
+const OSS_EXCLUDED_FIELDS = ["quotas", "policyRefs"]
+
 export function getFlowFields(edition?: string): string[] {
-    return edition === "OSS" ? BASE_FLOW_FIELDS.filter((key) => key !== "quotas") : BASE_FLOW_FIELDS
+    return edition === "OSS" ? BASE_FLOW_FIELDS.filter((key) => !OSS_EXCLUDED_FIELDS.includes(key)) : BASE_FLOW_FIELDS
 }

--- a/ui/src/components/no-code/blocks/flowFields.ts
+++ b/ui/src/components/no-code/blocks/flowFields.ts
@@ -1,0 +1,22 @@
+export const BASE_FLOW_FIELDS = [
+    "id",
+    "namespace",
+    "description",
+    "labels",
+    "inputs",
+    "variables",
+    "outputs",
+    "concurrency",
+    "retry",
+    "sla",
+    "checks",
+    "quotas",
+    "workerSelector",
+    "disabled",
+]
+
+// quotas is EE-only: on OSS the executor rejects it at runtime in a way that
+// crash-loops the server, so the no-code editor must not offer a way to add it.
+export function getFlowFields(edition?: string): string[] {
+    return edition === "OSS" ? BASE_FLOW_FIELDS.filter((key) => key !== "quotas") : BASE_FLOW_FIELDS
+}

--- a/ui/src/translations/de.json
+++ b/ui/src/translations/de.json
@@ -1725,7 +1725,8 @@
           "workerSelector": "Worker-Selektor",
           "checks": "Checks",
           "updated": "Aktualisiert",
-          "quotas": "Quotas"
+          "quotas": "Quotas",
+          "policyRefs": "Policy-Referenzen"
         }
       },
       "select": {

--- a/ui/src/translations/en.json
+++ b/ui/src/translations/en.json
@@ -1725,7 +1725,8 @@
           "workerSelector": "Worker Selector",
           "checks": "Checks",
           "updated": "Updated",
-          "quotas": "Quotas"
+          "quotas": "Quotas",
+          "policyRefs": "Policy References"
         }
       },
       "select": {

--- a/ui/src/translations/es.json
+++ b/ui/src/translations/es.json
@@ -1725,7 +1725,8 @@
           "workerSelector": "Selector de Worker",
           "checks": "Comprobaciones",
           "updated": "Actualizado",
-          "quotas": "Cuotas"
+          "quotas": "Cuotas",
+          "policyRefs": "Referencias de Policy"
         }
       },
       "select": {

--- a/ui/src/translations/fr.json
+++ b/ui/src/translations/fr.json
@@ -1725,7 +1725,8 @@
           "workerSelector": "Sélecteur de Worker",
           "checks": "Vérifications",
           "updated": "Mis à jour",
-          "quotas": "Quotas"
+          "quotas": "Quotas",
+          "policyRefs": "Références de Policy"
         }
       },
       "select": {

--- a/ui/src/translations/hi.json
+++ b/ui/src/translations/hi.json
@@ -1725,7 +1725,8 @@
           "workerSelector": "वर्कर सेलेक्टर",
           "checks": "जांचें",
           "updated": "अपडेट किया गया",
-          "quotas": "कोटा"
+          "quotas": "कोटा",
+          "policyRefs": "पॉलिसी संदर्भ"
         }
       },
       "select": {

--- a/ui/src/translations/it.json
+++ b/ui/src/translations/it.json
@@ -1725,7 +1725,8 @@
           "workerSelector": "Selettore Worker",
           "checks": "Controlli",
           "updated": "Aggiornato",
-          "quotas": "Quote"
+          "quotas": "Quote",
+          "policyRefs": "Riferimenti Policy"
         }
       },
       "select": {

--- a/ui/src/translations/ja.json
+++ b/ui/src/translations/ja.json
@@ -1725,7 +1725,8 @@
           "workerSelector": "ワーカーセレクター",
           "checks": "チェック",
           "updated": "更新済み",
-          "quotas": "クォータ"
+          "quotas": "クォータ",
+          "policyRefs": "ポリシー参照"
         }
       },
       "select": {

--- a/ui/src/translations/ko.json
+++ b/ui/src/translations/ko.json
@@ -1725,7 +1725,8 @@
           "workerSelector": "워커 선택기",
           "checks": "점검",
           "updated": "업데이트됨",
-          "quotas": "할당량"
+          "quotas": "할당량",
+          "policyRefs": "정책 참조"
         }
       },
       "select": {

--- a/ui/src/translations/pl.json
+++ b/ui/src/translations/pl.json
@@ -1725,7 +1725,8 @@
           "workerSelector": "Worker Selector",
           "checks": "Kontrole",
           "updated": "Zaktualizowano",
-          "quotas": "Limity"
+          "quotas": "Limity",
+          "policyRefs": "Odwołania do polityk"
         }
       },
       "select": {

--- a/ui/src/translations/pt.json
+++ b/ui/src/translations/pt.json
@@ -1725,7 +1725,8 @@
           "workerSelector": "Seletor de Worker",
           "checks": "Verificações",
           "updated": "Atualizado",
-          "quotas": "Quotas"
+          "quotas": "Quotas",
+          "policyRefs": "Referências de Policy"
         }
       },
       "select": {

--- a/ui/src/translations/pt_BR.json
+++ b/ui/src/translations/pt_BR.json
@@ -1725,7 +1725,8 @@
           "workerSelector": "Seletor de Worker",
           "checks": "Verificações",
           "updated": "Atualizado",
-          "quotas": "Cotas"
+          "quotas": "Cotas",
+          "policyRefs": "Referências de Policy"
         }
       },
       "select": {

--- a/ui/src/translations/ru.json
+++ b/ui/src/translations/ru.json
@@ -1725,7 +1725,8 @@
           "workerSelector": "Селектор Worker",
           "checks": "Проверки",
           "updated": "Обновлено",
-          "quotas": "Квоты"
+          "quotas": "Квоты",
+          "policyRefs": "Ссылки на Policy"
         }
       },
       "select": {

--- a/ui/src/translations/zh_CN.json
+++ b/ui/src/translations/zh_CN.json
@@ -1725,7 +1725,8 @@
           "workerSelector": "Worker 选择器",
           "checks": "检查",
           "updated": "已更新",
-          "quotas": "配额"
+          "quotas": "配额",
+          "policyRefs": "Policy 引用"
         }
       },
       "select": {

--- a/ui/tests/unit/no-code/flowFields.spec.ts
+++ b/ui/tests/unit/no-code/flowFields.spec.ts
@@ -2,15 +2,17 @@ import {describe, it, expect} from "vitest"
 import {getFlowFields} from "../../../src/components/no-code/blocks/flowFields"
 
 describe("getFlowFields", () => {
-    it("excludes quotas on OSS, where the executor rejects it at runtime", () => {
-        expect(getFlowFields("OSS")).not.toContain("quotas")
-    })
+    for (const key of ["quotas", "policyRefs"]) {
+        it(`excludes ${key} on OSS, where it either crash-loops the server or is silently ignored`, () => {
+            expect(getFlowFields("OSS")).not.toContain(key)
+        })
 
-    it("includes quotas on EE", () => {
-        expect(getFlowFields("EE")).toContain("quotas")
-    })
+        it(`includes ${key} on EE`, () => {
+            expect(getFlowFields("EE")).toContain(key)
+        })
 
-    it("includes quotas when the edition is unknown", () => {
-        expect(getFlowFields(undefined)).toContain("quotas")
-    })
+        it(`includes ${key} when the edition is unknown`, () => {
+            expect(getFlowFields(undefined)).toContain(key)
+        })
+    }
 })

--- a/ui/tests/unit/no-code/flowFields.spec.ts
+++ b/ui/tests/unit/no-code/flowFields.spec.ts
@@ -1,0 +1,16 @@
+import {describe, it, expect} from "vitest"
+import {getFlowFields} from "../../../src/components/no-code/blocks/flowFields"
+
+describe("getFlowFields", () => {
+    it("excludes quotas on OSS, where the executor rejects it at runtime", () => {
+        expect(getFlowFields("OSS")).not.toContain("quotas")
+    })
+
+    it("includes quotas on EE", () => {
+        expect(getFlowFields("EE")).toContain("quotas")
+    })
+
+    it("includes quotas when the edition is unknown", () => {
+        expect(getFlowFields(undefined)).toContain("quotas")
+    })
+})


### PR DESCRIPTION
### 🔗 Related Issue

Closes kestra-io/kestra-ee#10728.
Closes https://github.com/kestra-io/kestra/issues/19006.

### ✨ Description

Two EE-only flow-level fields were missing from the no-code flow properties panel — both could only be set through the YAML/Code editor:

- **`quotas`** (execution rate limiting): missing from `FlowPropertiesEdit.vue`'s `FLOW_FIELDS` allowlist. On OSS, the executor rejects `quotas` at runtime in a way that crash-loops the server, so it must stay excluded there — matching the existing e2e expectation in `blocks-flow-properties.spec.ts`.
- **`policyRefs`** (governance policy references, EE only): same gap — completely absent from the UI, no translation key staged, no dedicated component. On OSS this field is parsed but silently ignored rather than crash-looping, but the same OSS-exclusion treatment applies for consistency (no point offering a field that does nothing there).

Both now render the same way `sla`/`checks` already do — `quotas` as an array of governed objects (matches EE's `QuotasForm.vue` treatment at the namespace/tenant level), `policyRefs` as a plain array-of-strings — gated behind `edition !== "OSS"`.

The allowlist + gating logic lives in a small pure helper (`getFlowFields(edition)`) so it's unit-testable without mounting the component.

### 🎨 Frontend Checklist

- [x] Type checking passes (`npm run check:types` — pre-existing, unrelated `@kestra-io/kestra-sdk` type errors exist on `develop` in this checkout; none touch the files in this diff)
- [ ] Code builds without errors (not run — see note)
- [x] Unit tests pass (`npm run test:unit` — `flowFields.spec.ts`, `flowFieldTypes.spec.ts`)
- [x] Translations: `no_code.fields.general.quotas` already existed; added `no_code.fields.general.policyRefs` to `en.json` only — CI's `translations-generate` job fills in the other 11 languages on push (no `GEMINI_API_KEY` available locally)
- [x] Screenshots attached below, both taken on a live EE instance

### 📸 Screenshots

`quotas` rendered as an `Array` field between `checks` and `workerSelector`, same treatment as `sla`/`checks`:

<img width="600" alt="quotas field rendered in the no-code flow properties panel" src="https://github.com/user-attachments/assets/698077d9-6f0b-4788-8d3d-321dd1d95eca" />

Full panel with both fixes applied — `quotas` and `policyRefs` both rendering, right after `checks` and before `workerSelector`:

<img width="450" alt="full flow properties panel showing quotas and policyRefs fields" src="https://github.com/user-attachments/assets/1f840656-cc27-4816-8ccc-57798452f3c1" />

### 📝 Additional Notes

Captured from a fresh Postgres-backed EE boot (migrations applied, RBAC-provisioned superadmin), with `useMiscStore().configs.edition` forced to `"EE"` to mount `FlowPropertiesEdit.vue` directly against the live flow schema — the local module-federation dev host wasn't cooperating with a full login round-trip in this session.

### 🤖 AI Authors

Why did the cat sit on the YAML file? Because it wanted to be the only one with `access: all`. 🐱
