### PR TITLE
feat(core): add a @DurationMin constraint beside @DurationMax

### DIFF
--- a/core/src/main/java/io/kestra/core/validations/DurationMin.java
+++ b/core/src/main/java/io/kestra/core/validations/DurationMin.java
@@ -1,0 +1,41 @@
+package io.kestra.core.validations;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+import io.kestra.core.validations.validator.DurationMinValidator;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+/**
+ * Rejects a {@link java.time.Duration} shorter than {@link #min()} (default 1 millisecond, so a
+ * bare {@code @DurationMin} rejects zero and negative durations).
+ *
+ * <p>
+ * Prefer this over Hibernate's identically named {@code @DurationMin}: Micronaut resolves only its
+ * own constraint validators when it constructs an {@code @Introspected} type from JSON, so the
+ * Hibernate constraint raises {@code UnexpectedTypeException} there and fails deserialization for
+ * every payload rather than only the invalid ones.
+ * </p>
+ *
+ * <p>
+ * A {@link #min()} other than the default only applies where Micronaut validates the constructor
+ * of an {@code @Introspected} type, such as an HTTP request body. Validation delegated to Hibernate
+ * ({@code Validator.validate(bean)}, and so {@code ModelValidator} and every flow model) receives
+ * no annotation members and always applies the default, silently. Use the bare form outside a
+ * request body, as {@link DurationMax} does everywhere it appears.
+ * </p>
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = DurationMinValidator.class)
+public @interface DurationMin {
+    /** Minimum allowed duration, as an ISO-8601 string. Defaults to 1 millisecond. */
+    String min() default "PT0.001S";
+
+    String message() default "duration must be at least {min}";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+}

--- a/core/src/main/java/io/kestra/core/validations/validator/DurationMinValidator.java
+++ b/core/src/main/java/io/kestra/core/validations/validator/DurationMinValidator.java
@@ -1,0 +1,39 @@
+package io.kestra.core.validations.validator;
+
+import java.time.Duration;
+
+import io.kestra.core.validations.DurationMin;
+
+import io.micronaut.core.annotation.AnnotationValue;
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.core.annotation.Nullable;
+import io.micronaut.validation.validator.constraints.ConstraintValidator;
+import io.micronaut.validation.validator.constraints.ConstraintValidatorContext;
+import jakarta.inject.Singleton;
+
+@Singleton
+public class DurationMinValidator implements ConstraintValidator<DurationMin, Duration> {
+    @Override
+    public boolean isValid(
+        @Nullable Duration value,
+        @NonNull AnnotationValue<DurationMin> annotationMetadata,
+        @NonNull ConstraintValidatorContext context) {
+        if (value == null) {
+            return true;
+        }
+
+        // Not merely defensive: validation delegated to Hibernate passes a bare @Constraint with no
+        // members, so this literal is the only bound that path ever sees. Keep it equal to min()'s default.
+        String minValue = annotationMetadata.stringValue("min").orElse("PT0.001S");
+        Duration min = Duration.parse(minValue);
+
+        if (value.compareTo(min) < 0) {
+            context.disableDefaultConstraintViolation();
+            context.buildConstraintViolationWithTemplate("duration '" + value + "' must be at least " + minValue)
+                .addConstraintViolation();
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/core/src/test/java/io/kestra/core/validations/DurationMinValidationTest.java
+++ b/core/src/test/java/io/kestra/core/validations/DurationMinValidationTest.java
@@ -1,0 +1,63 @@
+package io.kestra.core.validations;
+
+import java.time.Duration;
+
+import org.junit.jupiter.api.Test;
+
+import io.kestra.core.junit.annotations.KestraTest;
+
+import io.micronaut.core.annotation.Introspected;
+import io.micronaut.core.beans.BeanIntrospection;
+import io.micronaut.validation.validator.Validator;
+import jakarta.inject.Inject;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@KestraTest
+class DurationMinValidationTest {
+    @Inject
+    private Validator validator;
+
+    @Test
+    void shouldAcceptNullOrDurationAboveDefaultMinimum() {
+        assertThat(validator.validate(new Bounded(null))).isEmpty();
+        assertThat(validator.validate(new Bounded(Duration.ofMillis(1)))).isEmpty();
+        assertThat(validator.validate(new Bounded(Duration.ofMinutes(10)))).isEmpty();
+    }
+
+    @Test
+    void shouldRejectZeroOrNegativeGivenDefaultMinimum() {
+        assertThat(validator.validate(new Bounded(Duration.ZERO)))
+            .anyMatch(v -> v.getMessage().contains("must be at least PT0.001S"));
+        assertThat(validator.validate(new Bounded(Duration.ofMinutes(-10))))
+            .anyMatch(v -> v.getMessage().contains("must be at least PT0.001S"));
+    }
+
+    /**
+     * An explicit {@code min} reaches the validator only through constructor validation, which is the
+     * path an HTTP request body takes. Hibernate-delegated validation drops annotation members.
+     */
+    @Test
+    void shouldHonourExplicitMinimumWhenValidatingAConstructor() {
+        BeanIntrospection<AtLeastOneMinute> introspection = BeanIntrospection.getIntrospection(AtLeastOneMinute.class);
+
+        assertThat(
+            validator.forExecutables()
+                .validateConstructorParameters(introspection, new Object[] { Duration.ofMinutes(1) }, new Class[0])
+        )
+            .isEmpty();
+        assertThat(
+            validator.forExecutables()
+                .validateConstructorParameters(introspection, new Object[] { Duration.ofSeconds(59) }, new Class[0])
+        )
+            .anyMatch(v -> v.getMessage().contains("must be at least PT1M"));
+    }
+
+    @Introspected
+    record Bounded(@DurationMin Duration duration) {
+    }
+
+    @Introspected
+    record AtLeastOneMinute(@DurationMin(min = "PT1M") Duration duration) {
+    }
+}


### PR DESCRIPTION
### 🔗 Related Issue

No OSS issue. This is the OSS half of kestra-io/kestra-ee#10281, whose closing keyword lives on the EE companion PR kestra-io/kestra-ee#10708 so that the issue is not closed before the EE half merges.

### ✨ Description

`io.kestra.core.validations` has an upper bound for durations (`@DurationMax`) but no lower one. Rejecting a non-positive duration therefore means repeating Hibernate's identically named `@DurationMin(millis = 1, message = "must be a positive duration")`, which this repository already does across 15 files.

That constraint cannot be used on a JSON request body. When Micronaut constructs an `@Introspected` type from JSON, `ValidationJacksonDeserializationPreInstantiateCallback` validates the constructor arguments through `DefaultValidator`, which resolves only Micronaut's own `ConstraintValidator` beans — `micronaut-hibernate-validator` delegates the jakarta-signature methods to Hibernate but not that overload. A Hibernate constraint there raises `UnexpectedTypeException`, failing deserialization for *every* payload rather than only the invalid ones. This `@DurationMin` is Micronaut-native, so it works on both the request-body cascade and post-construction validation.

`min()` defaults to `PT0.001S` rather than to the smallest positive duration, so that a bare `@DurationMin` rejects zero and negative values on the bound #18676 settled on after trying 1ns.

No OSS behaviour changes: nothing in this repository uses the new constraint yet.

### 🛠️ Backend Checklist

- [x] Code compiles and tests pass for the touched modules (`./gradlew :core:test`)
- [x] New behavior is covered by unit or integration tests

### 📝 Additional Notes

Its first consumer is the Enterprise Edition companion PR kestra-io/kestra-ee#10708, which uses it to reject a case SLA of zero or less.

**An explicit `min()` only applies to constructor validation.** Hibernate-delegated validation — `Validator.validate(bean)`, and therefore `ModelValidator` and every flow model — receives a bare `@Constraint` with no annotation members and silently applies the default instead. Both the Javadoc and the validator record this, and the test for an explicit `min` deliberately goes through `forExecutables().validateConstructorParameters`, the path an HTTP body takes. `@DurationMax` has the same property; it is invisible there only because every site uses the bare form, so `DurationMaxValidator`'s own `orElse` literal is the bound they get.

Migrating the existing Hibernate `@DurationMin` sites onto this one is deliberately out of scope, which does leave two annotations sharing a simple name for now. Those sites are flow-model fields validated after construction, where the Hibernate constraint works; seven sit on `Property<>` generic type arguments whose value-extractor path would need separate verification; and per the note above they would each have to keep a bound equal to the default to behave identically.
