### PR TITLE
fix(flows): reject a past schedule date in the execute dialog

### DIFF
--- a/ui/scripts/translations/fingerprints.json
+++ b/ui/scripts/translations/fingerprints.json
@@ -1573,6 +1573,7 @@
   "saved as draft done": "c091e80d0451",
   "saved done": "efcf90f1d961",
   "scheduleDate": "d9d5b45dcaee",
+  "scheduleDateInPast": "61c651c86799",
   "scope_filter|system": "fc6ac64143b3",
   "scope_filter|system_description": "45545f4cf7f0",
   "scope_filter|user": "d17265612e4d",

--- a/ui/src/components/flows/FlowRun.vue
+++ b/ui/src/components/flows/FlowRun.vue
@@ -54,6 +54,7 @@
                         <KsDatePicker
                             v-model="scheduleDate"
                             type="datetime"
+                            :disabledDate="disabledScheduleDate"
                         />
                     </KsFormItem>
                     <KsFormItem
@@ -117,6 +118,7 @@
     import {useRouter, useRoute} from "vue-router"
     import {useI18n} from "vue-i18n"
     import {useToast} from "../../utils/toast"
+    import {buildScheduleDateParam, isPastScheduleDate, isScheduleDayDisabled} from "../../utils/scheduleDate"
     import moment from "moment-timezone"
     import {useCoreStore} from "../../stores/core"
     import {useApiStore} from "../../stores/api"
@@ -261,6 +263,14 @@
         hasInvalidLabelKeys(executionLabels.value),
     )
 
+    const validationClock = ref(Date.now())
+
+    const hasPastScheduleDate = computed(() =>
+        isPastScheduleDate(scheduleDate.value, new Date(validationClock.value)),
+    )
+
+    const disabledScheduleDate = (day: Date) => isScheduleDayDisabled(day)
+
     const validationMessages = computed(() => {
         const messages: string[] = []
         if (haveBadLabels.value) {
@@ -272,11 +282,14 @@
         if (haveInvalidLabelKeys.value) {
             messages.push(t("invalid label key"))
         }
+        if (hasPastScheduleDate.value) {
+            messages.push(t("scheduleDateInPast"))
+        }
         return messages
     })
 
     const flowCanBeExecuted = computed(() =>
-        Boolean(flow.value && !flow.value.disabled && !haveBadLabels.value && !haveForbiddenSystemLabels.value && !haveInvalidLabelKeys.value),
+        Boolean(flow.value && !flow.value.disabled && !haveBadLabels.value && !haveForbiddenSystemLabels.value && !haveInvalidLabelKeys.value && !hasPastScheduleDate.value),
     )
 
     const isDirty = computed(() =>
@@ -388,6 +401,8 @@
     }
 
     function onSubmit() {
+        validationClock.value = Date.now()
+
         if (form.value && flowCanBeExecuted.value) {
             checks.value = []
             executeClicked.value = false
@@ -432,9 +447,10 @@
                                 // Drafts are playground-only: omit the revision so the backend runs the latest published one.
                                 revision: flow.value.draft ? undefined : flow.value.revision,
                                 labels: labelStrings,
-                                scheduleDate: moment(scheduleDate.value)
-                                    .tz(localStorage.getItem(storageKeys.TIMEZONE_STORAGE_KEY) ?? moment.tz.guess())
-                                    .toISOString(true),
+                                scheduleDate: buildScheduleDateParam(
+                                    scheduleDate.value,
+                                    localStorage.getItem(storageKeys.TIMEZONE_STORAGE_KEY) ?? moment.tz.guess(),
+                                ),
                                 nextStep: true,
                                 breakpoints: breakpoints.value,
                             })
@@ -448,6 +464,10 @@
             })
         }
     }
+
+    watch(scheduleDate, () => {
+        validationClock.value = Date.now()
+    })
 
     watch(inputs, () => {
         emit("updateInputs", inputs.value)

--- a/ui/src/components/flows/FlowRun.vue
+++ b/ui/src/components/flows/FlowRun.vue
@@ -54,7 +54,7 @@
                         <KsDatePicker
                             v-model="scheduleDate"
                             type="datetime"
-                            :disabledDate="disabledScheduleDate"
+                            :disabledDate="isScheduleDayDisabled"
                         />
                     </KsFormItem>
                     <KsFormItem
@@ -268,8 +268,6 @@
     const hasPastScheduleDate = computed(() =>
         isPastScheduleDate(scheduleDate.value, new Date(validationClock.value)),
     )
-
-    const disabledScheduleDate = (day: Date) => isScheduleDayDisabled(day)
 
     const validationMessages = computed(() => {
         const messages: string[] = []

--- a/ui/src/translations/de.json
+++ b/ui/src/translations/de.json
@@ -1603,6 +1603,7 @@
     "webhook link copied": "Webhook-Link kopiert.",
     "copy url": "URL kopieren",
     "scheduleDate": "Geplantes Datum",
+    "scheduleDateInPast": "Das geplante Datum muss in der Zukunft liegen",
     "warning": "Warnung",
     "trigger_check_warning": "Trigger-Variablen funktionieren nicht bei einer manuell gestarteten Execution. Füge den Coalesce-Operator `??` hinzu, um das Problem zu lösen. Verwende zum Beispiel statt `trigger.date` den Ausdruck `trigger.date ?? execution.startDate`.",
     "docs": "Docs",

--- a/ui/src/translations/en.json
+++ b/ui/src/translations/en.json
@@ -1603,6 +1603,7 @@
     "webhook link copied": "Webhook link copied.",
     "copy url": "Copy URL",
     "scheduleDate": "Schedule date",
+    "scheduleDateInPast": "Schedule date must be in the future",
     "warning": "Warning",
     "trigger_check_warning": "Using trigger variables won't work with manual flow execution. Add the `??` coalesce operator to solve the issue. For example, instead of `trigger.date`, use `trigger.date ?? execution.startDate`.",
     "docs": "Docs",

--- a/ui/src/translations/es.json
+++ b/ui/src/translations/es.json
@@ -1603,6 +1603,7 @@
     "webhook link copied": "Enlace de Webhook copiado.",
     "copy url": "Copiar URL",
     "scheduleDate": "Fecha de programación",
+    "scheduleDateInPast": "La fecha de programación debe ser en el futuro",
     "warning": "Advertencia",
     "trigger_check_warning": "Al usar variables de trigger no funcionará con la ejecución manual de flow. Agrega el operador de coalescencia `??` para resolver el problema. Por ejemplo, en lugar de `trigger.date`, usa `trigger.date ?? execution.startDate`.",
     "docs": "Documentos",

--- a/ui/src/translations/fr.json
+++ b/ui/src/translations/fr.json
@@ -1603,6 +1603,7 @@
     "webhook link copied": "Lien du webhook copié.",
     "copy url": "Copier l'URL",
     "scheduleDate": "Date de planification",
+    "scheduleDateInPast": "La date de planification doit être future",
     "warning": "Avertissement",
     "trigger_check_warning": "L'utilisation des variables de trigger ne fonctionnera pas avec l'exécution manuelle du flow. Ajoutez l'opérateur de coalescence `??` pour résoudre le problème. Par exemple, au lieu de `trigger.date`, utilisez `trigger.date ?? execution.startDate`.",
     "docs": "Documentation",

--- a/ui/src/translations/hi.json
+++ b/ui/src/translations/hi.json
@@ -1603,6 +1603,7 @@
     "webhook link copied": "Webhook लिंक कॉपी किया गया।",
     "copy url": "URL कॉपी करें",
     "scheduleDate": "अनुसूची तिथि",
+    "scheduleDateInPast": "शेड्यूल की तारीख भविष्य में होनी चाहिए",
     "warning": "चेतावनी",
     "trigger_check_warning": "ट्रिगर वेरिएबल्स का उपयोग मैनुअल flow निष्पादन के साथ काम नहीं करेगा। समस्या को हल करने के लिए `??` कोएलस ऑपरेटर जोड़ें। उदाहरण के लिए, `trigger.date` के बजाय `trigger.date ?? execution.startDate` का उपयोग करें।",
     "docs": "डॉक्स",

--- a/ui/src/translations/it.json
+++ b/ui/src/translations/it.json
@@ -1603,6 +1603,7 @@
     "webhook link copied": "Link del Webhook copiato.",
     "copy url": "Copia URL",
     "scheduleDate": "Data di pianificazione",
+    "scheduleDateInPast": "La data di pianificazione deve essere nel futuro",
     "warning": "Avviso",
     "trigger_check_warning": "Utilizzare le variabili trigger non funzionerà con l'esecuzione manuale del flow. Aggiungi l'operatore di coalescenza `??` per risolvere il problema. Ad esempio, invece di `trigger.date`, usa `trigger.date ?? execution.startDate`.",
     "docs": "Documenti",

--- a/ui/src/translations/ja.json
+++ b/ui/src/translations/ja.json
@@ -1603,6 +1603,7 @@
     "webhook link copied": "Webhookリンクがコピーされました。",
     "copy url": "URLをコピー",
     "scheduleDate": "スケジュール日付",
+    "scheduleDateInPast": "スケジュール日は未来である必要があります",
     "warning": "警告",
     "trigger_check_warning": "トリガー変数を使用すると、手動でのflow実行では機能しません。問題を解決するために`??`コアレス演算子を追加してください。例えば、`trigger.date`の代わりに`trigger.date ?? execution.startDate`を使用してください。",
     "docs": "ドキュメント",

--- a/ui/src/translations/ko.json
+++ b/ui/src/translations/ko.json
@@ -1603,6 +1603,7 @@
     "webhook link copied": "웹훅 링크가 복사되었습니다.",
     "copy url": "URL 복사",
     "scheduleDate": "일정 날짜",
+    "scheduleDateInPast": "예약 날짜는 미래여야 합니다.",
     "warning": "경고",
     "trigger_check_warning": "트리거 변수를 사용하는 것은 수동 flow 실행과 함께 작동하지 않습니다. 문제를 해결하려면 `??` 병합 연산자를 추가하세요. 예를 들어, `trigger.date` 대신 `trigger.date ?? execution.startDate`를 사용하세요.",
     "docs": "문서",

--- a/ui/src/translations/pl.json
+++ b/ui/src/translations/pl.json
@@ -1603,6 +1603,7 @@
     "webhook link copied": "Link webhooka skopiowany.",
     "copy url": "Kopiuj URL",
     "scheduleDate": "Data harmonogramu",
+    "scheduleDateInPast": "Data harmonogramu musi być w przyszłości",
     "warning": "Ostrzeżenie",
     "trigger_check_warning": "Zmienne Triggera nie zadziałają przy ręcznym uruchomieniu Flow. Dodaj operator koalescencji `??`, aby rozwiązać problem. Na przykład zamiast `trigger.date` użyj `trigger.date ?? execution.startDate`.",
     "docs": "Dokumentacja",

--- a/ui/src/translations/pt.json
+++ b/ui/src/translations/pt.json
@@ -1603,6 +1603,7 @@
     "webhook link copied": "Link do Webhook copiado.",
     "copy url": "Copiar URL",
     "scheduleDate": "Data de agendamento",
+    "scheduleDateInPast": "A data de agendamento deve ser no futuro",
     "warning": "Aviso",
     "trigger_check_warning": "Usar variáveis de trigger não funcionará com a execução manual de flow. Adicione o operador de coalescência `??` para resolver o problema. Por exemplo, em vez de `trigger.date`, use `trigger.date ?? execution.startDate`.",
     "docs": "Documentos",

--- a/ui/src/translations/pt_BR.json
+++ b/ui/src/translations/pt_BR.json
@@ -1603,6 +1603,7 @@
     "webhook link copied": "Link do Webhook copiado.",
     "copy url": "Copiar URL",
     "scheduleDate": "Data de agendamento",
+    "scheduleDateInPast": "A data do agendamento deve ser no futuro",
     "warning": "Aviso",
     "trigger_check_warning": "Usar variáveis de trigger não funcionará com a execução manual de flow. Adicione o operador de coalescência `??` para resolver o problema. Por exemplo, em vez de `trigger.date`, use `trigger.date ?? execution.startDate`.",
     "docs": "Documentos",

--- a/ui/src/translations/ru.json
+++ b/ui/src/translations/ru.json
@@ -1603,6 +1603,7 @@
     "webhook link copied": "Ссылка на Webhook скопирована.",
     "copy url": "Скопировать URL",
     "scheduleDate": "Дата расписания",
+    "scheduleDateInPast": "Дата расписания должна быть в будущем",
     "warning": "Предупреждение",
     "trigger_check_warning": "Использование переменных trigger не будет работать с ручным выполнением flow. Добавьте оператор объединения `??`, чтобы решить проблему. Например, вместо `trigger.date` используйте `trigger.date ?? execution.startDate`.",
     "docs": "Документы",

--- a/ui/src/translations/zh_CN.json
+++ b/ui/src/translations/zh_CN.json
@@ -1603,6 +1603,7 @@
     "webhook link copied": "Webhook链接已复制。",
     "copy url": "复制 URL",
     "scheduleDate": "计划日期",
+    "scheduleDateInPast": "计划日期必须在未来",
     "warning": "警告",
     "trigger_check_warning": "使用 trigger 变量无法与手动 flow 执行一起工作。添加 `??` 合并运算符来解决此问题。例如，不要使用 `trigger.date`，而是使用 `trigger.date ?? execution.startDate`。",
     "docs": "文档",

--- a/ui/src/utils/scheduleDate.ts
+++ b/ui/src/utils/scheduleDate.ts
@@ -1,0 +1,23 @@
+import moment from "moment-timezone"
+
+export function isPastScheduleDate(value: string | undefined | null, now: Date = new Date()): boolean {
+    if (!value) {
+        return false
+    }
+
+    const parsed = moment(value)
+
+    return parsed.isValid() && parsed.valueOf() < now.getTime()
+}
+
+export function isScheduleDayDisabled(day: Date, now: Date = new Date()): boolean {
+    return moment(day).startOf("day").isBefore(moment(now).startOf("day"))
+}
+
+export function buildScheduleDateParam(value: string | undefined | null, timezone: string): string | undefined {
+    if (!value) {
+        return undefined
+    }
+
+    return moment(value).tz(timezone).toISOString(true)
+}

--- a/ui/tests/unit/utils/scheduleDate.spec.ts
+++ b/ui/tests/unit/utils/scheduleDate.spec.ts
@@ -1,0 +1,49 @@
+import {describe, expect, it} from "vitest"
+import {
+    buildScheduleDateParam,
+    isPastScheduleDate,
+    isScheduleDayDisabled,
+} from "../../../src/utils/scheduleDate"
+
+const NOW = new Date("2026-09-03T12:00:00.000Z")
+
+describe("scheduleDate", () => {
+    it("shouldRejectAPastDateTime", () => {
+        expect(isPastScheduleDate("2026-09-03T11:59:00.000Z", NOW)).toBe(true)
+        expect(isPastScheduleDate("2026-09-01T10:00:00.000Z", NOW)).toBe(true)
+    })
+
+    it("shouldAcceptAFutureDateTime", () => {
+        expect(isPastScheduleDate("2026-09-03T12:01:00.000Z", NOW)).toBe(false)
+        expect(isPastScheduleDate("2026-12-01T00:00:00.000Z", NOW)).toBe(false)
+    })
+
+    it("shouldAcceptTheAbsenceOfASchedule", () => {
+        expect(isPastScheduleDate(undefined, NOW)).toBe(false)
+        expect(isPastScheduleDate("", NOW)).toBe(false)
+    })
+
+    it("shouldNotRejectAnUnparsableValue", () => {
+        expect(isPastScheduleDate("not a date", NOW)).toBe(false)
+    })
+
+    it("shouldKeepTodaySelectableWhileDisablingEarlierDays", () => {
+        const localNow = new Date(2026, 8, 3, 12, 0, 0)
+        expect(isScheduleDayDisabled(new Date(2026, 8, 3, 0, 0, 0), localNow)).toBe(false)
+        expect(isScheduleDayDisabled(new Date(2026, 8, 3, 23, 30, 0), localNow)).toBe(false)
+        expect(isScheduleDayDisabled(new Date(2026, 8, 2, 23, 30, 0), localNow)).toBe(true)
+        expect(isScheduleDayDisabled(new Date(2026, 8, 4, 0, 0, 0), localNow)).toBe(false)
+    })
+
+    it("shouldOmitTheParamWhenNoDateIsSet", () => {
+        expect(buildScheduleDateParam(undefined, "UTC")).toBeUndefined()
+        expect(buildScheduleDateParam("", "UTC")).toBeUndefined()
+    })
+
+    it("shouldBuildATimezoneAwareIsoStringWhenSet", () => {
+        expect(buildScheduleDateParam("2026-09-03T12:00:00.000Z", "Europe/Paris"))
+            .toBe("2026-09-03T14:00:00.000+02:00")
+        expect(buildScheduleDateParam("2026-09-03T12:00:00.000Z", "UTC"))
+            .toBe("2026-09-03T12:00:00.000+00:00")
+    })
+})


### PR DESCRIPTION
### 🔗 Related Issue

Closes https://github.com/kestra-io/kestra/issues/17348.

### ✨ Description

In the **Execute** dialog, the *Schedule date* picker accepted a date and time in the past. The executor only delays an execution whose schedule date is in the future, so the run started immediately and the value the user chose was silently dropped. On top of that, executing with **no** schedule date still sent a `scheduleDate` query parameter equal to the click time, because the conversion ran `moment(undefined)`.

Reproduced in a browser against `kestra/kestra:develop`: with `2026-09-01 10:00` selected, the request carried `scheduleDate=2026-09-01T10:00:00.000+02:00` and the execution was created and finished at click time.

This PR:
- disables past days in the picker (today stays selectable);
- blocks the submit with a validation message (*Schedule date must be in the future*) when the selected time has already passed, re-checking the clock at click time so a date that went stale while the dialog was open is caught too;
- omits the `scheduleDate` parameter entirely when no date is set.

The date logic lives in a small `ui/src/utils/scheduleDate.ts` module covered by unit tests with an injected clock.

Verified in Chrome through the Vite dev server:
- today's date with an earlier time → Execute disabled, message shown, no request sent;
- past days greyed out in the calendar;
- no date → request has no `scheduleDate` parameter;
- future date → request carries it and the execution is delayed.

### 🎨 Frontend Checklist

- [x] Type checking passes (`npm run check:types`)
- [ ] Code builds without errors (`npm run build`) — not run locally, CI covers it
- [x] Unit tests pass (`npm run test:unit`)
- [ ] Translations are complete if `en.json` changed — one English key added (`scheduleDateInPast`); the other twelve languages are left to the CI translations job
- [ ] Screenshots or video recordings attached showing the `UI` changes — verified with a scripted browser run, see above

### 📝 Additional Notes

The backend is unchanged: a past `scheduleDate` sent directly to the API is still ignored rather than rejected, to avoid breaking API clients on clock skew.

### 🤖 AI Authors

Why did the cat refuse to schedule an execution in the past? Because it already used up that one of its nine lives. 🐱