### PR TITLE
fix: disable MCP docs client health checks

### DIFF
--- a/webserver/src/main/java/io/kestra/webserver/services/ai/KestraDocsContextTool.java
+++ b/webserver/src/main/java/io/kestra/webserver/services/ai/KestraDocsContextTool.java
@@ -48,6 +48,7 @@ public class KestraDocsContextTool implements AutoCloseable {
                 )
                 .clientName("Kestra/" + versionProvider.getVersion())
                 .toolExecutionTimeout(MCP_TIMEOUT)
+                .autoHealthCheck(false)
                 .build();
         } catch (Exception e) {
             log.warn("Failed to initialize Kestra docs MCP client, documentation context will be unavailable: {}", e.getMessage());

--- a/webserver/src/main/java/io/kestra/webserver/services/ai/agent/tool/DocsMcpToolProvider.java
+++ b/webserver/src/main/java/io/kestra/webserver/services/ai/agent/tool/DocsMcpToolProvider.java
@@ -46,6 +46,7 @@ public class DocsMcpToolProvider {
                 .build();
             this.client = new DefaultMcpClient.Builder()
                 .transport(transport)
+                .autoHealthCheck(false)
                 .build();
             this.tools = client.listTools().stream()
                 .collect(Collectors.toMap(spec -> spec, spec -> new McpToolExecutor(client)));

--- a/webserver/src/test/java/io/kestra/webserver/services/ai/KestraDocsContextToolTest.java
+++ b/webserver/src/test/java/io/kestra/webserver/services/ai/KestraDocsContextToolTest.java
@@ -1,0 +1,70 @@
+package io.kestra.webserver.services.ai;
+
+import java.lang.reflect.Field;
+
+import org.junit.jupiter.api.Test;
+
+import io.kestra.core.utils.VersionProvider;
+
+import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
+import com.github.tomakehurst.wiremock.junit5.WireMockTest;
+import dev.langchain4j.mcp.client.DefaultMcpClient;
+import dev.langchain4j.mcp.client.McpClient;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.okJson;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathMatching;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@WireMockTest
+class KestraDocsContextToolTest {
+
+    @Test
+    void shouldDisableAutoHealthCheckOnMcpClient(WireMockRuntimeInfo wmRuntimeInfo) throws Exception {
+        // Given
+        stubFor(post(urlPathMatching("/v1/mcp.*"))
+            .willReturn(okJson("""
+                {"jsonrpc":"2.0","id":0,"result":{"protocolVersion":"2024-11-05","capabilities":{"tools":{}},"serverInfo":{"name":"mock-docs","version":"1.0"}}}
+            """)));
+
+        VersionProvider versionProvider = mock(VersionProvider.class);
+        when(versionProvider.getVersion()).thenReturn("2.1.0");
+
+        // When
+        try (KestraDocsContextTool tool = new KestraDocsContextTool(wmRuntimeInfo.getHttpBaseUrl(), versionProvider)) {
+            Field clientField = KestraDocsContextTool.class.getDeclaredField("mcpClient");
+            clientField.setAccessible(true);
+            McpClient client = (McpClient) clientField.get(tool);
+
+            // Then
+            assertThat(client).isNotNull();
+            assertThat(client).isInstanceOf(DefaultMcpClient.class);
+
+            Field autoHealthCheckField = DefaultMcpClient.class.getDeclaredField("autoHealthCheck");
+            autoHealthCheckField.setAccessible(true);
+            assertThat(autoHealthCheckField.get(client)).isEqualTo(Boolean.FALSE);
+
+            Field schedulerField = DefaultMcpClient.class.getDeclaredField("healthCheckScheduler");
+            schedulerField.setAccessible(true);
+            assertThat(schedulerField.get(client)).isNull();
+        }
+    }
+
+    @Test
+    void shouldDegradeGracefullyWhenUnreachable() {
+        // Given
+        VersionProvider versionProvider = mock(VersionProvider.class);
+        when(versionProvider.getVersion()).thenReturn("2.1.0");
+
+        // When / Then
+        try (KestraDocsContextTool tool = new KestraDocsContextTool("http://localhost:1", versionProvider)) {
+            assertThat(tool.searchDocs("flow")).isNull();
+            assertThat(tool.getDoc("url")).isNull();
+            assertThat(tool.searchBlueprints("query")).isNull();
+            assertThat(tool.getBlueprintFlow(123)).isNull();
+        }
+    }
+}

--- a/webserver/src/test/java/io/kestra/webserver/services/ai/agent/tool/DocsMcpToolProviderTest.java
+++ b/webserver/src/test/java/io/kestra/webserver/services/ai/agent/tool/DocsMcpToolProviderTest.java
@@ -1,0 +1,88 @@
+package io.kestra.webserver.services.ai.agent.tool;
+
+import java.lang.reflect.Field;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import io.kestra.webserver.services.ai.agent.AgentConfiguration;
+
+import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
+import com.github.tomakehurst.wiremock.junit5.WireMockTest;
+import dev.langchain4j.agent.tool.ToolSpecification;
+import dev.langchain4j.mcp.client.DefaultMcpClient;
+import dev.langchain4j.mcp.client.McpClient;
+import dev.langchain4j.service.tool.ToolExecutor;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.containing;
+import static com.github.tomakehurst.wiremock.client.WireMock.ok;
+import static com.github.tomakehurst.wiremock.client.WireMock.okJson;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathMatching;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@WireMockTest
+class DocsMcpToolProviderTest {
+
+    @Test
+    void shouldDisableAutoHealthCheckOnMcpClient(WireMockRuntimeInfo wmRuntimeInfo) throws Exception {
+        // Given
+        stubFor(post(urlPathMatching("/v1/mcp.*"))
+            .withRequestBody(containing("notifications/"))
+            .willReturn(ok()));
+
+        stubFor(post(urlPathMatching("/v1/mcp.*"))
+            .withRequestBody(containing("tools/list"))
+            .willReturn(okJson("""
+                {"jsonrpc":"2.0","id":2,"result":{"tools":[]}}
+            """)));
+
+        stubFor(post(urlPathMatching("/v1/mcp.*"))
+            .withRequestBody(containing("initialize"))
+            .willReturn(okJson("""
+                {"jsonrpc":"2.0","id":0,"result":{"protocolVersion":"2024-11-05","capabilities":{"tools":{}},"serverInfo":{"name":"mock-docs","version":"1.0"}}}
+            """)));
+
+        AgentConfiguration configuration = AgentConfiguration.builder()
+            .docsMcpUrl(wmRuntimeInfo.getHttpBaseUrl() + "/v1/mcp")
+            .build();
+
+        // When
+        DocsMcpToolProvider provider = new DocsMcpToolProvider(configuration);
+        Map<ToolSpecification, ToolExecutor> tools = provider.tools();
+
+        // Then
+        assertThat(tools).isNotNull();
+
+        Field clientField = DocsMcpToolProvider.class.getDeclaredField("client");
+        clientField.setAccessible(true);
+        McpClient client = (McpClient) clientField.get(provider);
+
+        assertThat(client).isNotNull();
+        assertThat(client).isInstanceOf(DefaultMcpClient.class);
+
+        Field autoHealthCheckField = DefaultMcpClient.class.getDeclaredField("autoHealthCheck");
+        autoHealthCheckField.setAccessible(true);
+        assertThat(autoHealthCheckField.get(client)).isEqualTo(Boolean.FALSE);
+
+        Field schedulerField = DefaultMcpClient.class.getDeclaredField("healthCheckScheduler");
+        schedulerField.setAccessible(true);
+        assertThat(schedulerField.get(client)).isNull();
+    }
+
+    @Test
+    void shouldDegradeGracefullyWhenUnreachable() {
+        // Given
+        AgentConfiguration configuration = AgentConfiguration.builder()
+            .docsMcpUrl("http://localhost:1/v1/mcp")
+            .build();
+
+        // When
+        DocsMcpToolProvider provider = new DocsMcpToolProvider(configuration);
+        Map<ToolSpecification, ToolExecutor> tools = provider.tools();
+
+        // Then
+        assertThat(tools).isEmpty();
+    }
+}


### PR DESCRIPTION
## Description

Fixes #18981.

The AI Copilot docs MCP clients were starting an automatic health-check scheduler every 30 seconds. When the public docs MCP endpoint was unreachable, this resulted in recurring WARN logs with a full stack trace even when the Copilot feature was not being actively used.

## Changes

- Disabled automatic MCP health checks in `KestraDocsContextTool`.
- Disabled automatic MCP health checks in `DocsMcpToolProvider`.
- Preserved the existing MCP transport failure/reconnection behavior.
- Added regression tests covering both MCP clients.
- Added coverage verifying that the automatic health-check scheduler is not created.
- Added coverage verifying graceful behavior when the docs MCP endpoint is unreachable.

## Testing

- `./gradlew :webserver:test --tests "io.kestra.webserver.services.ai.KestraDocsContextToolTest" --tests "io.kestra.webserver.services.ai.agent.tool.DocsMcpToolProviderTest"`
- `./gradlew :webserver:test --tests "io.kestra.webserver.services.ai.*"`

All tests passed.