### PR TITLE
fix(triggers): schedule timezone description states the server timezone default

### DIFF
--- a/core/src/main/java/io/kestra/plugin/core/trigger/Schedule.java
+++ b/core/src/main/java/io/kestra/plugin/core/trigger/Schedule.java
@@ -44,7 +44,7 @@ import lombok.extern.slf4j.Slf4j;
 @Schema(
     title = "Schedule a Flow with a CRON expression.",
     description = """
-        Runs a Flow on a cron schedule (5 fields by default; enable seconds with `withSeconds`). Tracks last scheduled date to support backfill. Changing the trigger `id` starts a new schedule from “now”. Default timezone is UTC; override via `timezone`.
+        Runs a Flow on a cron schedule (5 fields by default; enable seconds with `withSeconds`). Tracks last scheduled date to support backfill. Changing the trigger `id` starts a new schedule from “now”. When `timezone` is not set, the cron expression is evaluated in the timezone configured on the Kestra server.
 
         Multiple Schedule triggers can coexist on one Flow."""
 )
@@ -217,6 +217,11 @@ public class Schedule extends AbstractTrigger implements Schedulable, TriggerOut
     @PluginProperty
     private Boolean withSeconds = false;
 
+    @Schema(
+        title = "The timezone used to evaluate the cron expression",
+        description = "Defaults to the timezone configured on the Kestra server. " +
+            "Set it explicitly so the schedule does not depend on the server configuration."
+    )
     @PluginProperty
     @TimezoneId
     @Builder.Default


### PR DESCRIPTION
### 🔗 Related Issue

Closes https://github.com/kestra-io/kestra/issues/18477.

### ✨ Description

The Schedule trigger description claimed `Default timezone is UTC`, but `timezone` has defaulted to `ZoneId.systemDefault()` since #746 (Sept 2022), so a cron with no `timezone` is evaluated in the server's timezone. The description was added in January 2026 and was never accurate; it went unnoticed because most installs run in a UTC container.

Changing the default to UTC is not an option — it would silently shift the firing time of every flow that omits `timezone` on a non-UTC server. So this fixes the description instead, and documents the `timezone` property, which had no `@Schema` at all.

### 🛠️ Backend Checklist

- [x] Code compiles and tests pass for the touched modules (`./gradlew :core:compileJava`)
- [ ] New behavior is covered by unit or integration tests

### 📝 Additional Notes

No tests: the change is annotation text only, with no behavior to assert.

The issue also reports that nothing in the UI shows which timezone a cron uses. That is a separate, non-breaking frontend improvement and is not addressed here.
