### PR TITLE
fix(triggers): reject creating a backfill while one is already running

### DIFF
--- a/scheduler/src/main/java/io/kestra/scheduler/TriggerEventHandler.java
+++ b/scheduler/src/main/java/io/kestra/scheduler/TriggerEventHandler.java
@@ -13,6 +13,7 @@ import io.kestra.core.async.AsyncOperation;
 import io.kestra.core.async.AsyncOperationProcessedEvent;
 import io.kestra.core.async.AsyncOperationService;
 import io.kestra.core.events.EventId;
+import io.kestra.core.exceptions.ConflictException;
 import io.kestra.core.exceptions.IllegalVariableEvaluationException;
 import io.kestra.core.models.conditions.ConditionContext;
 import io.kestra.core.models.executions.ExecutionKilled;
@@ -153,6 +154,14 @@ public class TriggerEventHandler {
     void onCreateBackfill(Clock clock, CreateBackfillTrigger event) {
         findTriggerState(event).ifPresent(state ->
         {
+            // A second backfill would capture the running backfill's cursor as the pre-backfill schedule
+            // date, so deleting it would rewind the trigger and replay every schedule from that cursor.
+            if (state.getBackfill() != null) {
+                throw new ConflictException(
+                    "A backfill is already running on trigger '%s'. Delete it before creating a new one.".formatted(event.uid())
+                );
+            }
+
             state = state
                 .lastEventId(clock, event.eventId())
                 .backfill(

--- a/scheduler/src/test/java/io/kestra/scheduler/TriggerEventHandlerTest.java
+++ b/scheduler/src/test/java/io/kestra/scheduler/TriggerEventHandlerTest.java
@@ -17,6 +17,7 @@ import org.mockito.Mockito;
 
 import io.kestra.core.async.AsyncOperationProcessedEvent;
 import io.kestra.core.async.AsyncOperationService;
+import io.kestra.core.exceptions.ConflictException;
 import io.kestra.core.models.executions.ExecutionKilled;
 import io.kestra.core.models.executions.ExecutionKilledTrigger;
 import io.kestra.core.models.flows.FlowWithSource;
@@ -54,6 +55,7 @@ import io.kestra.scheduler.utils.InMemoryTriggerStateStore;
 import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
 import jakarta.inject.Inject;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
 @MicronautTest
@@ -1159,6 +1161,35 @@ class TriggerEventHandlerTest {
     }
 
     @Test
+    void shouldRejectCreateBackfillWhenBackfillAlreadyRunning() {
+        // GIVEN
+        ZonedDateTime liveNextEvaluationDate = SchedulerClock.now().plusHours(1);
+        Backfill running = Backfill.builder()
+            .start(SchedulerClock.now().minusDays(7))
+            .end(SchedulerClock.now().minusDays(6))
+            .paused(false)
+            .build();
+        // the running backfill has progressed, so the next evaluation date now points inside its window
+        triggerStateStore.save(triggerState
+            .updateForNextEvaluationDate(CLOCK, liveNextEvaluationDate)
+            .backfill(CLOCK, running)
+            .updateForNextEvaluationDate(CLOCK, running.getStart().plusHours(8))
+        );
+        handler = newTriggerEventHandler(List.of(Fixtures.defaultFlow()));
+        CreateBackfillTrigger event = new CreateBackfillTrigger(
+            triggerId,
+            new CreateBackfillTrigger.Backfill(SchedulerClock.now().minusDays(3), SchedulerClock.now().minusDays(2), null, null)
+        );
+
+        // WHEN / THEN
+        assertThatThrownBy(() -> handler.handle(CLOCK, TEST_VNODE, event))
+            .isInstanceOf(ConflictException.class);
+
+        Optional<TriggerState> updated = triggerStateStore.findById(triggerId);
+        assertThat(updated).get().extracting(s -> s.getBackfill().getPreviousNextExecutionDate()).isEqualTo(liveNextEvaluationDate);
+    }
+
+    @Test
     void shouldClearNextEvaluationDateWhenDeleteBackfillEventHandledGivenTriggerNeverEvaluated() {
         // GIVEN
         Backfill backfill = Backfill.builder()
@@ -1339,7 +1370,7 @@ class TriggerEventHandlerTest {
         SetDisableTrigger event = new SetDisableTrigger(triggerId, true).withOperationId(operationId);
 
         // WHEN / THEN
-        org.assertj.core.api.Assertions.assertThatThrownBy(() -> handler.handle(CLOCK, TEST_VNODE, event))
+        assertThatThrownBy(() -> handler.handle(CLOCK, TEST_VNODE, event))
             .isInstanceOf(RuntimeException.class)
             .hasMessage("boom");
 


### PR DESCRIPTION
### 🔗 Related Issue

Closes https://github.com/kestra-io/kestra-ee/issues/10737.

Follow-up to `e08da237dc` (which closed kestra-io/kestra-ee#9998 and ships in `v2.0.0-rc12`): that fix closed the pause/unpause vector, this one closes the concurrent-create vector reported alongside it in kestra-io/kestra-ee#10256.

### ✨ Description

Creating a backfill on a Schedule trigger while another one was **already running** turned a bounded backfill into an unbounded replay of every schedule since the running backfill's cursor.

`onCreateBackfill` built a fresh `Backfill` from the event with no `previousNextExecutionDate`, so `TriggerState.backfill()` captured it from the current `nextEvaluationDate` — and while a backfill is running, that date *is* the backfill cursor. The trigger's pre-backfill restore point was therefore overwritten with a past date; deleting the backfill restored the trigger to it, and the scheduling loop replayed every cron slot from there up to now at roughly 1/s. Those executions carry no backfill label, so they are indistinguishable from genuine scheduled runs, and disabling the trigger was the only way to stop them.

The create is now rejected while a backfill is running. The guard lives in the event handler rather than in `TriggerStateService`, because the handler is the serialized authority: a service-side pre-check reads the state and then emits, so two concurrent `backfill/create` calls both pass it and the second still clobbers the restore point. Throwing from the handler yields a `FAILED` outcome, which `awaitBlockingAction` already converts into the **409** that `TriggerController.createBackfill` documents — so no API, DTO or OpenAPI change.

No UI change is needed: `FlowTriggers.vue` already hides the backfill action while `row.backfill` is set, so this only closes the direct-API hole.

### 🛠️ Backend Checklist

- [x] Code compiles and tests pass for the touched modules (`./gradlew :scheduler:test` — 121/121 passed)
- [x] New behavior is covered by unit or integration tests

### 📝 Additional Notes

`shouldRejectCreateBackfillWhenBackfillAlreadyRunning` asserts the rejection *and* that `previousNextExecutionDate` still holds the live pre-backfill date — the second assertion is the one that catches the storm if the guard is ever moved below the state mutation, or if this is later "fixed" by carrying the date forward instead of rejecting. Confirmed red before the fix (`Expecting code to raise a throwable`) by stashing only the production file.

Deliberately not done: no duplicate pre-check in `TriggerStateService`, for the race reason above, and no overlap *validation* between backfill ranges — a trigger holds a single backfill, so rejecting the second create is the whole invariant.
