### PR TITLE
fix(worker): re-queue task results rejected with UNAUTHENTICATED

### DIFF
--- a/worker/src/main/java/io/kestra/worker/senders/GrpcWorkerIOSender.java
+++ b/worker/src/main/java/io/kestra/worker/senders/GrpcWorkerIOSender.java
@@ -6,6 +6,7 @@ import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 import java.util.function.BiConsumer;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -14,6 +15,7 @@ import io.kestra.controller.grpc.OpaqueData;
 import io.kestra.controller.messages.BatchMessage;
 import io.kestra.controller.messages.MessageFormats;
 import io.kestra.controller.messages.RequestOrResponseHeaderFactory;
+import io.kestra.core.models.HasUID;
 import io.kestra.core.worker.models.WorkerContext;
 import io.kestra.worker.WorkerLoop;
 import io.kestra.worker.queues.WorkerQueue;
@@ -206,19 +208,44 @@ public class GrpcWorkerIOSender<T> extends WorkerLoop implements WorkerIOSender 
             );
             batchMessage.records().forEach(queue::put);
             resendBackoffUntilNanos = System.nanoTime() + RESEND_BACKOFF.toNanos();
+        } else if (resendOnFailure) {
+            LOG.error(
+                "Failed to send {} to the controller, dropping {}. The task runs or triggers they belong to stay in a non-terminal state until the executor detects this worker as lost.",
+                eventType.getSimpleName(), describeRecords(batchMessage), t
+            );
         } else {
-            LOG.error("Error while sending request", t);
+            LOG.error(
+                "Failed to send {} to the controller, dropping {}.",
+                eventType.getSimpleName(), describeRecords(batchMessage), t
+            );
         }
     }
 
     /**
-     * Whether a send failure is a transient transport error worth re-queuing. {@code UNAVAILABLE} covers a
-     * partition or a controller restart; {@code DEADLINE_EXCEEDED} a send that timed out in transit.
+     * Describes the items of a batch for a log message: their uids when the event type carries one, so a
+     * dropped result can be traced back to the task run it belonged to, and their count otherwise, since
+     * logs and metrics have no stable identifier.
+     */
+    private String describeRecords(final BatchMessage<T> batchMessage) {
+        if (!HasUID.class.isAssignableFrom(eventType)) {
+            return batchMessage.records().size() + " item(s)";
+        }
+        return batchMessage.records().stream()
+            .map(record -> ((HasUID) record).uid())
+            .collect(Collectors.joining(", "));
+    }
+
+    /**
+     * Whether a send failure is worth re-queuing. {@code UNAVAILABLE} covers a partition or a controller
+     * restart; {@code DEADLINE_EXCEEDED} a send that timed out in transit; {@code UNAUTHENTICATED} an
+     * access token the controller rejected, which the worker recovers from asynchronously by refreshing
+     * or re-registering, so the batch has to wait for that instead of being dropped. The single immediate
+     * retry in {@link RetryOnUnauthenticatedObserver} only covers a token that has already been renewed.
      */
     private static boolean isRetryable(final Throwable t) {
         return t instanceof StatusRuntimeException sre
             && switch (sre.getStatus().getCode()) {
-                case UNAVAILABLE, DEADLINE_EXCEEDED -> true;
+                case UNAVAILABLE, DEADLINE_EXCEEDED, UNAUTHENTICATED -> true;
                 default -> false;
             };
     }

--- a/worker/src/test/java/io/kestra/worker/senders/GrpcWorkerIOSenderTest.java
+++ b/worker/src/test/java/io/kestra/worker/senders/GrpcWorkerIOSenderTest.java
@@ -229,6 +229,47 @@ class GrpcWorkerIOSenderTest {
     }
 
     @Test
+    void shouldRequeueAndRedeliverWhenUnauthenticatedPersistsAfterRetry() throws Exception {
+        // Given - the initial send and its immediate retry both find the access token rejected, then the
+        // worker recovers its credentials and the next send succeeds.
+        AtomicInteger callCount = new AtomicInteger(0);
+        doAnswer(inv ->
+        {
+            OpaqueData req = inv.getArgument(0);
+            StreamObserver<OpaqueData> obs = inv.getArgument(1);
+            if (callCount.getAndIncrement() < 2) {
+                obs.onError(new StatusRuntimeException(Status.UNAUTHENTICATED.withDescription("Invalid or expired access token")));
+            } else {
+                obs.onNext(OpaqueData.newBuilder().setHeader(req.getHeader()).build());
+                obs.onCompleted();
+            }
+            return null;
+        }).when(grpcWorkerControllerService).sendWorkerTaskResults(any(), any());
+
+        WorkerTaskResult result = buildTaskResult(Map.of("key", "value"));
+
+        // When - the retry exhausts the single in-call attempt, so the result is re-queued instead of dropped.
+        taskResultSender.send(List.of(result));
+
+        // Then - the loop redrives until the controller receives the result (initial attempt, in-call retry,
+        // then redelivery). doOnLoop() runs inside the await because the failures arrive asynchronously on
+        // gRPC callback threads, so a single redrive could poll before the item is re-queued.
+        ArgumentCaptor<OpaqueData> captor = ArgumentCaptor.forClass(OpaqueData.class);
+        await()
+            .atMost(Duration.ofSeconds(10))
+            .untilAsserted(() ->
+            {
+                taskResultSender.doOnLoop();
+                verify(grpcWorkerControllerService, org.mockito.Mockito.atLeast(3))
+                    .sendWorkerTaskResults(captor.capture(), any());
+            });
+
+        WorkerTaskResult redelivered = deserialize(captor.getAllValues().getLast()).records().getFirst();
+        assertThat(redelivered.getTaskRun().getId()).isEqualTo(result.getTaskRun().getId());
+        assertThat(redelivered.getOutputs()).isEqualTo(Map.of("key", "value"));
+    }
+
+    @Test
     void shouldRedeliverFallbackResultWhenFallbackResendFailsWithRetryableError() throws Exception {
         // Given - the initial send is rejected with RESOURCE_EXHAUSTED (outputs too large), so the fallback
         // mapper fires and resends a stripped failed-state result; that fallback resend then fails once with


### PR DESCRIPTION
### ✨ Description

A worker whose access token the controller rejects loses the task results it was sending. `UNAUTHENTICATED` was not in the retryable set, so the single in-call retry in `RetryOnUnauthenticatedObserver` was the last chance: if the token was still rejected on that retry, the batch was dropped even on the streams that carry non-losable work. The task run then stayed non-terminal until the executor declared the worker lost and resubmitted its jobs, and never recovered at all when the worker's authentication recovered before the liveness timeout.

`UNAUTHENTICATED` is now retryable, so such a batch is re-queued and redriven at the existing 1s backoff while the worker's token manager refreshes or re-registers. The immediate retry is kept: it covers a token that has already been renewed, while the re-queue covers one that has not. Behaviour for a permanently revoked worker matches a permanent partition — re-queue until the executor declares it lost — and re-queuing stays bounded to the running loop, so shutdown still drains. Logs and metrics keep dropping, which is what `resendOnFailure = false` selects.

The drop path also logged `Error while sending request` with no execution or task-run context, which made this class of loss undiagnosable. It now names the impacted items, using `HasUID` where the event type has one and a count for logs and metrics, which have no stable identifier:

```
Failed to send WorkerTaskResult to the controller, dropping 1fwLWPrUxUH4fSa5uaPUjD. The task runs or
triggers they belong to stay in a non-terminal state until the executor detects this worker as lost.
```

### 🛠️ Backend Checklist

- [x] Code compiles and tests pass for the touched modules (`./gradlew :worker:test --tests "GrpcWorkerIOSenderTest"`, 6/6)
- [x] New behavior is covered by unit or integration tests

### 📝 Additional Notes

`shouldRequeueAndRedeliverWhenUnauthenticatedPersistsAfterRetry` fails with the fix reverted (`case UNAVAILABLE, DEADLINE_EXCEEDED -> true`) and passes with it, so it can fail for the right reason.

`WorkerTriggerResult` deliberately does not implement `HasUID` just to get its id into that log line — the interface feeds queue routing and partitioning keys, and changing it for a log message is not worth the risk. Trigger-result batches therefore log a count.

Not addressed here: there is no reconciliation of `WorkerJobRunning` against the live worker set, so any *other* non-retryable send failure still leaves a task run stuck with no recovery path. That is the systemic gap behind this symptom and is worth its own issue.
