### PR TITLE
build(core): fail the translation gate on stale fingerprints in the locale files

### DIFF
--- a/ui/scripts/translations/README.md
+++ b/ui/scripts/translations/README.md
@@ -97,11 +97,11 @@ Two checkers apply the same shared rules at different depths:
 
 | | `translations:check` ([`compareTranslations.ts`](compareTranslations.ts)) | PR gate ([`check-translations.mjs`](check-translations.mjs)) |
 |---|---|---|
-| Runs | Locally + at the end of the auto-translate workflow | CI, on every PR touching translations or UI source |
+| Runs | Locally + at the end of the auto-translate workflow | CI, on every PR touching translations or UI source, forks included |
 | Needs | `node_modules` (vue-i18n's real message compiler) | Nothing - Node builtins only, runs before `npm ci` |
-| Checks | Missing / extra / **stale** keys (fingerprints), placeholders through the actual compiler | Key parity, placeholder well-formedness + parity with English, untranslated English copies in non-Latin-script locales, EE keys shadowing OSS keys, keys used in code but defined in no `en.json` |
+| Checks | Missing / extra / **stale** keys (fingerprints), placeholders through the actual compiler | Key parity, **stale** keys (fingerprints), placeholder well-formedness + parity with English, untranslated English copies in non-Latin-script locales, EE keys shadowing OSS keys, keys used in code but defined in no `en.json` |
 
-A clean `translations:check` run reports **No missing keys / No extra keys / No stale keys** for every language - anything less blocks the merge.
+A clean `translations:check` run reports **No missing keys / No extra keys / No stale keys** for every language - anything less blocks the merge. The PR gate applies the same staleness rule, so a fork PR, which gets no generated commit, cannot merge an edited English value without regenerating the other languages either.
 
 The PR gate runs as two ownership-scoped passes so a failure points at the right repository:
 

--- a/ui/scripts/translations/build-comment.mjs
+++ b/ui/scripts/translations/build-comment.mjs
@@ -86,6 +86,27 @@ if (Object.keys(placeholdersOf(eeReport)).length > 0) {
     )
 }
 
+const staleOf = (report) => report?.stale ?? []
+
+if (staleOf(ossReport).length > 0) {
+    sections.push(
+        "### ❌ OSS translations - stale keys\n\n" +
+        staleOf(ossReport).map(key => `- \`${key}\``).join("\n") + "\n\n" +
+        "**What to do:** each key is new, or its English source changed after the other languages were generated, so those " +
+        "languages no longer say what English says. Run `npm run translations:generate` in [kestra-io/kestra](https://github.com/kestra-io/kestra)'s " +
+        "`ui/` and commit the result. Never paste the English text into the other locale files.",
+    )
+}
+
+if (staleOf(eeReport).length > 0) {
+    sections.push(
+        "### ❌ EE translations - stale keys\n\n" +
+        staleOf(eeReport).map(key => `- \`${key}\``).join("\n") + "\n\n" +
+        "**What to do:** each key is new, or its English source changed after the other languages were generated. " +
+        "Run `npm run translations:generate` in `ui-ee` (or trigger the `Auto-Translate UI keys` workflow) and commit the result.",
+    )
+}
+
 // Tolerates reports written before `undefinedKeys` existed, like `placeholdersOf` above.
 const undefinedKeysOf = (report) => report?.undefinedKeys ?? []
 

--- a/ui/scripts/translations/check-translations.mjs
+++ b/ui/scripts/translations/check-translations.mjs
@@ -25,6 +25,12 @@
 // non-Latin-script locale is still carrying the untouched English text - the
 // shape a failed generator run leaves behind, which every other check passes.
 //
+// Both scopes also compare every English message with the fingerprint its
+// translations were generated from: an edited English value whose twelve
+// translations were not regenerated is reported as stale. The design-system
+// locale files always had this; the JSON locales relied on the generator
+// running at PR time, which a fork PR never gets.
+//
 // Both scopes also read the source code: every literal key passed to `t()`,
 // `$t()` or `<i18n-t keypath>` has to exist in some `en.json` the app loads
 // (OSS + design system for OSS code, plus EE's own for EE code). The locale
@@ -49,6 +55,7 @@ import path from "node:path"
 import {fileURLToPath} from "node:url"
 import {allKeys, flattenStrings, leafKeys, placeholderProblems, shadowedOssKeys, untranslatedKeys} from "./translationRules.mjs"
 import {evalLocaleModule, staleLocaleEntries, untranslatedLocaleEntries} from "./localeFiles.mjs"
+import {staleKeys} from "./fingerprintRules.mjs"
 import {isScannedSourceFile, translationKeyUsages, undefinedKeyUsages} from "./usageRules.mjs"
 
 const here = path.dirname(fileURLToPath(import.meta.url))
@@ -134,6 +141,21 @@ function readLanguage(dir, lang) {
     return fs.existsSync(file) ? unwrapLanguage(readJson(file), lang) : {}
 }
 
+/**
+ * Adds `result.stale` for every key whose English text no longer matches the fingerprint its
+ * translations were generated from - a new key, or an edited value that was not regenerated.
+ * Key paths are the generator's `a|b|c` form, as they appear in the fingerprints file.
+ */
+function checkStaleJson(result, label, dir, fingerprintsFile, fixHint) {
+    if (!fs.existsSync(fingerprintsFile)) return
+
+    const stale = staleKeys(readLanguage(dir, "en"), readJson(fingerprintsFile))
+    if (stale.length === 0) return
+
+    result.stale.push(...stale)
+    annotate("error", `[${label}] ${stale.length} key(s) have no up-to-date translation, either new or with an English source that changed after they were translated: ${stale.join(", ")} - ${fixHint}`)
+}
+
 /** Every key path, namespaces included, of OSS's `en.json` plus the design-system `en` blocks. */
 function ossDefinedKeys() {
     const keys = new Set(allKeys(readLanguage(ossTranslationsDir, "en")))
@@ -188,7 +210,7 @@ function checkDesignSystem(result) {
     const stale = staleLocaleEntries(localeFiles, fingerprintsFile)
     if (stale.length === 0) return
 
-    result.stale = stale.map(({file, key}) => `${file}: ${key}`)
+    result.stale.push(...stale.map(({file, key}) => `${file}: ${key}`))
     for (const {file, key} of stale) {
         annotate("error", `[OSS] Design-system string "${key}" in ${file} has no up-to-date translation - it is either new, or its English source changed after it was translated. Run \`npm run translations:generate\` in ui/`)
     }
@@ -207,6 +229,7 @@ function checkOss() {
     checkPlaceholders(result, "OSS", ossTranslationsDir, "kestra-io/kestra's ui/src/translations/{lang}.json")
     checkUntranslated(result, "OSS", ossTranslationsDir, "kestra-io/kestra's ui/src/translations/{lang}.json")
     checkDesignSystem(result)
+    checkStaleJson(result, "OSS", ossTranslationsDir, path.join(here, "fingerprints.json"), "run `npm run translations:generate` in kestra-io/kestra's ui/ and commit the result")
     checkUsedKeys(result, "OSS", ossRoot, ["ui/src", "ui/packages/design-system/src", "ui/packages/topology/src"].map(dir => path.join(ossRoot, dir)), ossDefinedKeys())
 
     const ossEn = readLanguage(ossTranslationsDir, "en")
@@ -243,6 +266,7 @@ function checkEe() {
     const result = {missing: {}, duplicates: [], placeholders: {}, stale: [], untranslated: {}, undefinedKeys: []}
     checkPlaceholders(result, "EE", eeTranslationsDir, "ui-ee/src/translations/ee_translations/{lang}.json")
     checkUntranslated(result, "EE", eeTranslationsDir, "ui-ee/src/translations/ee_translations/{lang}.json")
+    checkStaleJson(result, "EE", eeTranslationsDir, path.join(eeRoot, "ui-ee/scripts/translations/fingerprints.json"), "run `npm run translations:generate` in ui-ee/ and commit the result")
     const eeEn = readLanguage(eeTranslationsDir, "en")
     const eeEnKeys = leafKeys(eeEn)
 


### PR DESCRIPTION
Closes https://github.com/kestra-io/kestra/issues/19039.

## What

The `PR` gate checked fingerprint staleness only for the design-system `*.locale.ts` files. For the twelve `JSON` locales it relied on the generator running at `PR` time, which a fork `PR` never gets, so an edited English value could merge with its translations still saying the old text until the scheduled bot healed it hours later.

The gate now applies the same staleness rule to the `OSS` and `EE` `JSON` locales (`checkStaleJson`, using the existing `staleKeys` from `fingerprintRules.mjs`, so it stays dependency-free), and `build-comment.mjs` gains a stale-keys section for both scopes.

## Evidence

On `develop` both scopes pass. Editing one English value without regenerating makes the `OSS` scope fail with:

```
::error::[OSS] 1 key(s) have no up-to-date translation, either new or with an English source that changed after they were translated: yes - run `npm run translations:generate` in kestra-io/kestra's ui/ and commit the result
```

## Backport

A 2.0 backport `PR` follows.

Related to https://github.com/kestra-io/kestra/pull/19021.