### PR TITLE
fix(ai): show the copilot unavailable state only after a prompt is sent

### DIFF
--- a/ui/src/components/ai/copilot/CopilotChat.vue
+++ b/ui/src/components/ai/copilot/CopilotChat.vue
@@ -10,11 +10,12 @@
             <CopilotThreadControls :activeId="thread?.uid" @select="onSelectThread" />
         </div>
 
-        <!-- AI unavailable: the backend has no configured provider — known up front from `/configs`,
-             or discovered mid-session (503). Configuring a provider is an instance-config change (a
-             restart), never something a retry in this panel could pick up, so the only action here
-             points at the docs that explain how to set one up. -->
-        <div v-if="isUnavailable" class="copilot-unavailable" data-test="copilot-unavailable">
+        <!-- AI unavailable: the copilot has no provider to run on — either `/configs` said so and the
+             user tried to send anyway, or the turn came back 503. It only ever replaces the chat once
+             a prompt has been attempted; opening the copilot never lands here (kestra-io/kestra-ee#10739).
+             Configuring a provider is an instance-config change (a restart), never something a retry in
+             this panel could pick up, so the only action here points at the docs. -->
+        <div v-if="unavailable" class="copilot-unavailable" data-test="copilot-unavailable">
             <KsIcon class="copilot-unavailable-icon">
                 <RobotOffOutline />
             </KsIcon>
@@ -272,12 +273,11 @@
 
     const {thread, messages, status, streaming, error, errorDetail, notice, pendingConfirmation, unavailable, canSend, nextThreadTitle, sendChat, confirm, cancel, reset, retryLastTurn, loadThread, restoreThread, noteContext, noteModelChange} = useAiChat()
 
-    // `/configs` reports whether any AI provider is configured, so the unavailable state renders on
-    // load rather than after the user composes a prompt that was always going to fail
-    // (kestra-io/kestra#18322). `unavailable` still covers the mid-session case (provider removed or
-    // unreachable → 503). An older backend that doesn't send the flag leaves the copilot usable.
+    // `/configs` reports whether any AI provider is configured. It's known up front, but the copilot
+    // waits for the user to actually try sending something before acting on it: an instance with no
+    // provider opens on the regular chat, not on the unavailable state (kestra-io/kestra-ee#10739).
+    // An older backend that doesn't send the flag leaves it undefined and the copilot usable.
     const noProviderConfigured = computed(() => miscStore.configs?.isAiApiKeyConfigured === false)
-    const isUnavailable = computed(() => unavailable.value || noProviderConfigured.value)
 
     /** Where the unavailable state sends the user: the Copilot docs, on the configuration section. */
     const docsUrl = "https://kestra.io/docs/ai-tools/ai-copilot?utm_source=kestra_app&utm_medium=referral&utm_campaign=ai_copilot_unavailable&utm_content=learn_more#configuration"
@@ -355,6 +355,12 @@
     )
 
     function onSubmit(prompt: string): void {
+        // Known-unconfigured instance: the turn could only come back 503, so raise the unavailable
+        // state here rather than round-tripping for it.
+        if (noProviderConfigured.value) {
+            unavailable.value = true
+            return
+        }
         sendChat({
             prompt,
             mode: mode.value,

--- a/ui/src/components/ai/copilot/useAiChat.ts
+++ b/ui/src/components/ai/copilot/useAiChat.ts
@@ -94,7 +94,10 @@ export function useAiChat() {
     const notice = ref<NoticeCode | null>(null)
     /** The proposal awaiting a confirm/reject decision, if any. */
     const pendingConfirmation = ref<ProposedActionEvent | null>(null)
-    /** True when the backend reports no AI provider is configured (503) — render an "unavailable" state. */
+    /**
+     * True when the copilot has no provider to run on — either the backend said so mid-turn (503) or
+     * the caller knew from `/configs` before sending. Renders the "unavailable" state.
+     */
     const unavailable = ref(false)
     /** Title for the next thread created by `ensureThread` (e.g. a seeded "Fix with AI" turn); consumed once. */
     const nextThreadTitle = ref<string | null>(null)

--- a/ui/tests/e2e/ai-copilot.spec.ts
+++ b/ui/tests/e2e/ai-copilot.spec.ts
@@ -447,17 +447,23 @@ test.describe("AI Copilot — full-page /ai surface", () => {
         await expect(help).toContainText("Slack")
     })
 
-    // kestra-io/kestra#18322: an instance with no provider used to render a working-looking chat and
-    // only owned up after the first turn failed.
-    test("says the copilot is unavailable on load when no provider is configured", async ({page}) => {
+    // kestra-io/kestra-ee#10739: an instance with no provider used to land on the unavailable state,
+    // so OSS users met a blank page. The page now opens as usual and only owns up once a prompt is
+    // sent — which never reaches the network, since `/configs` already said there's no provider.
+    test("opens the page as usual with no provider, and says so once a prompt is sent", async ({page}) => {
         await stubAiProviderConfigured(page, false)
         await disableProductTour(page)
         await page.goto("/ui/ai", {waitUntil: "load"})
 
-        await expect(page.locator("[data-test=\"copilot-unavailable\"]")).toBeVisible({timeout: 15000})
-        // Nothing invites a prompt: the composer is gone, and so is the empty state that hosts it
-        // together with the quick-action chips (Need Help is the page-layout marker for that block).
+        await expect(page.locator(D.chat)).toBeVisible({timeout: 15000})
+        await expect(page.locator("[data-test=\"copilot-unavailable\"]")).toBeHidden()
+        await expect(page.locator("[data-test=\"copilot-help\"]")).toBeVisible()
+
+        await page.locator(D.input).fill("build me a flow")
+        await page.locator(D.send).click()
+
+        await expect(page.locator("[data-test=\"copilot-unavailable\"]")).toBeVisible()
+        await expect(page.locator("[data-test=\"copilot-unavailable\"]")).toContainText("No AI provider is configured")
         await expect(page.locator(D.input)).toBeHidden()
-        await expect(page.locator("[data-test=\"copilot-help\"]")).toBeHidden()
     })
 })

--- a/ui/tests/e2e/fixtures/copilot.ts
+++ b/ui/tests/e2e/fixtures/copilot.ts
@@ -26,10 +26,11 @@ export const sse = (events: [string, unknown][]) =>
 /**
  * Reports whether an AI provider is configured, patching only that flag on the real `/configs`.
  *
- * The copilot renders its "unavailable" state up front when the instance has no provider
- * (kestra-io/kestra#18322), and the e2e backend has none - so a spec that stubs the turn itself
- * has to say `true` here to get the chat surface at all. Stubbing it both ways also keeps the
- * specs independent of whatever the instance under test happens to be configured with.
+ * With no provider, the copilot turns the first send attempt straight into its "unavailable" state
+ * instead of running the turn (kestra-io/kestra#18322, kestra-io/kestra-ee#10739) - and the e2e
+ * backend has none, so a spec that stubs the turn itself has to say `true` here for the stub to be
+ * reached at all. Stubbing it both ways also keeps the specs independent of whatever the instance
+ * under test happens to be configured with.
  */
 export async function stubAiProviderConfigured(page: Page, configured: boolean) {
     // The real configs are read once, up front, rather than with `route.fetch()` inside the handler:

--- a/ui/tests/unit/components/ai/copilot/CopilotChat.spec.ts
+++ b/ui/tests/unit/components/ai/copilot/CopilotChat.spec.ts
@@ -334,14 +334,27 @@ describe("CopilotChat", () => {
         expect(w.find("[data-test=\"copilot-unavailable-retry\"]").exists()).toBe(false)
     })
 
-    // kestra-io/kestra#18322: no provider configured is known from `/configs` before the first turn,
-    // so the surface must say so on load instead of offering a chat that can only fail.
-    it("shows the unavailable state on load when no AI provider is configured", () => {
+    // kestra-io/kestra-ee#10739: `/configs` says up front that no provider is configured, but the
+    // copilot still opens on the regular chat — the unavailable state waits for a send attempt.
+    it("opens on the regular chat when no AI provider is configured", () => {
         miscStore.configs = {isAiApiKeyConfigured: false}
         const w = mountChat()
+        expect(w.find("[data-test=\"copilot-unavailable\"]").exists()).toBe(false)
+        expect(w.text()).toContain("Turn your idea into a workflow")
+        expect(w.findComponent({name: "CopilotComposer"}).exists()).toBe(true)
+        expect(w.find(".copilot-suggestions").exists()).toBe(true)
+    })
+
+    it("shows the unavailable state once a prompt is attempted with no AI provider configured", async () => {
+        miscStore.configs = {isAiApiKeyConfigured: false}
+        const w = mountChat()
+
+        // A quick-start suggestion is a send attempt like any other.
+        await w.find(".copilot-suggestion").trigger("click")
+
         expect(w.find("[data-test=\"copilot-unavailable\"]").exists()).toBe(true)
-        expect(w.findComponent({name: "CopilotComposer"}).exists()).toBe(false)
-        expect(w.find(".copilot-suggestions").exists()).toBe(false)
+        // The turn is short-circuited: it could only ever come back 503.
+        expect(state.sendChat).not.toHaveBeenCalled()
     })
 
     it("keeps the copilot usable when the availability flag is absent (older backend)", () => {


### PR DESCRIPTION
Closes: https://github.com/kestra-io/kestra-ee/issues/10739