### PR TITLE
fix(iam): mark worker gRPC calls as internal calls

### DIFF
--- a/core/src/main/java/io/kestra/core/security/InternalCallContext.java
+++ b/core/src/main/java/io/kestra/core/security/InternalCallContext.java
@@ -1,0 +1,44 @@
+package io.kestra.core.security;
+
+import java.util.function.Supplier;
+
+/**
+ * Marks the calling thread as serving an internal call: one issued by another Kestra server rather
+ * than by a user, such as a worker asking the controller for namespace file metadata over gRPC.
+ * <p>
+ * Row-level permission filters are keyed on the authenticated user, and an internal caller has
+ * none, so enforcing them filters every row out instead of restricting anything. The marker is
+ * carried per call rather than derived from the server type because a webserver serves user
+ * requests and internal worker calls from the same process.
+ * <p>
+ * The marker is unbound by default and bound only for the duration of the given action, so a caller
+ * that does not set it is treated as a user request and stays subject to permission filtering.
+ */
+public final class InternalCallContext {
+
+    private static final ScopedValue<Boolean> INTERNAL_CALL = ScopedValue.newInstance();
+
+    private InternalCallContext() {
+    }
+
+    /**
+     * @return {@code true} if the calling thread is currently serving an internal call.
+     */
+    public static boolean isInternalCall() {
+        return INTERNAL_CALL.isBound();
+    }
+
+    /**
+     * Runs the given action with the calling thread marked as serving an internal call.
+     */
+    public static void runAsInternalCall(final Runnable action) {
+        ScopedValue.where(INTERNAL_CALL, Boolean.TRUE).run(action);
+    }
+
+    /**
+     * Same as {@link #runAsInternalCall(Runnable)} for an action that returns a value.
+     */
+    public static <T> T callAsInternalCall(final Supplier<T> action) {
+        return ScopedValue.where(INTERNAL_CALL, Boolean.TRUE).call(action::get);
+    }
+}

--- a/core/src/test/java/io/kestra/core/security/InternalCallContextTest.java
+++ b/core/src/test/java/io/kestra/core/security/InternalCallContextTest.java
@@ -1,0 +1,42 @@
+package io.kestra.core.security;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class InternalCallContextTest {
+
+    @Test
+    void shouldMarkTheCallingThreadForTheDurationOfTheAction() {
+        assertThat(InternalCallContext.isInternalCall()).isFalse();
+
+        InternalCallContext.runAsInternalCall(() -> assertThat(InternalCallContext.isInternalCall()).isTrue());
+
+        assertThat(InternalCallContext.isInternalCall()).isFalse();
+    }
+
+    @Test
+    void shouldKeepTheMarkerUntilTheOutermostActionReturnsWhenNested() {
+        InternalCallContext.runAsInternalCall(() ->
+        {
+            InternalCallContext.runAsInternalCall(() -> assertThat(InternalCallContext.isInternalCall()).isTrue());
+
+            assertThat(InternalCallContext.isInternalCall()).isTrue();
+        });
+
+        assertThat(InternalCallContext.isInternalCall()).isFalse();
+    }
+
+    @Test
+    void shouldNotMarkOtherThreads() throws InterruptedException {
+        AtomicBoolean internalOnOtherThread = new AtomicBoolean(true);
+        Thread other = new Thread(() -> internalOnOtherThread.set(InternalCallContext.isInternalCall()));
+
+        InternalCallContext.runAsInternalCall(other::start);
+        other.join();
+
+        assertThat(internalOnOtherThread).isFalse();
+    }
+}

--- a/worker-controller/src/main/java/io/kestra/controller/DefaultController.java
+++ b/worker-controller/src/main/java/io/kestra/controller/DefaultController.java
@@ -16,6 +16,7 @@ import com.google.common.annotations.VisibleForTesting;
 
 import io.kestra.controller.config.ControllerConfiguration;
 import io.kestra.controller.config.GrpcConfiguration;
+import io.kestra.controller.grpc.InternalCallServerInterceptor;
 import io.kestra.controller.grpc.WorkerControllerService;
 import io.kestra.core.metrics.MetricRegistry;
 import io.kestra.core.server.AbstractService;
@@ -148,6 +149,7 @@ public class DefaultController extends AbstractService implements Controller {
     protected ServerBuilder<?> buildServer(int port) {
         ServerCredentials credentials = createServerCredentials();
         ServerBuilder<?> serverBuilder = Grpc.newServerBuilderForPort(port, credentials)
+            .intercept(new InternalCallServerInterceptor())
             .addService(healthStatusManager.getHealthService());
 
         if (grpcConfiguration.reflectionEnabled()) {

--- a/worker-controller/src/main/java/io/kestra/controller/grpc/InternalCallServerInterceptor.java
+++ b/worker-controller/src/main/java/io/kestra/controller/grpc/InternalCallServerInterceptor.java
@@ -1,0 +1,43 @@
+package io.kestra.controller.grpc;
+
+import io.kestra.core.security.InternalCallContext;
+
+import io.grpc.ForwardingServerCallListener.SimpleForwardingServerCallListener;
+import io.grpc.Metadata;
+import io.grpc.ServerCall;
+import io.grpc.ServerCallHandler;
+import io.grpc.ServerInterceptor;
+
+/**
+ * Marks every call reaching the controller as an internal call, so that a worker is not subjected
+ * to the row-level permission filters that only a user request can satisfy.
+ * <p>
+ * The marker is bound around the three places a service method body runs: the handler start for a
+ * client-streaming method, {@code onMessage} for a streaming one and {@code onHalfClose} for a
+ * unary one.
+ *
+ * @see InternalCallContext
+ */
+public class InternalCallServerInterceptor implements ServerInterceptor {
+
+    @Override
+    public <ReqT, RespT> ServerCall.Listener<ReqT> interceptCall(
+        final ServerCall<ReqT, RespT> call,
+        final Metadata headers,
+        final ServerCallHandler<ReqT, RespT> next) {
+
+        ServerCall.Listener<ReqT> delegate = InternalCallContext.callAsInternalCall(() -> next.startCall(call, headers));
+
+        return new SimpleForwardingServerCallListener<>(delegate) {
+            @Override
+            public void onMessage(ReqT message) {
+                InternalCallContext.runAsInternalCall(() -> super.onMessage(message));
+            }
+
+            @Override
+            public void onHalfClose() {
+                InternalCallContext.runAsInternalCall(super::onHalfClose);
+            }
+        };
+    }
+}

--- a/worker-controller/src/test/java/io/kestra/controller/grpc/InternalCallServerInterceptorTest.java
+++ b/worker-controller/src/test/java/io/kestra/controller/grpc/InternalCallServerInterceptorTest.java
@@ -1,0 +1,52 @@
+package io.kestra.controller.grpc;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.junit.jupiter.api.Test;
+
+import io.kestra.core.security.InternalCallContext;
+
+import io.grpc.Metadata;
+import io.grpc.ServerCall;
+import io.grpc.ServerCallHandler;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+class InternalCallServerInterceptorTest {
+
+    @Test
+    void shouldMarkHandlerStartAndListenerCallbacksAsInternalCall() {
+        AtomicBoolean internalOnStartCall = new AtomicBoolean();
+        AtomicBoolean internalOnHalfClose = new AtomicBoolean();
+        AtomicBoolean internalOnMessage = new AtomicBoolean();
+
+        ServerCallHandler<String, String> handler = (call, headers) ->
+        {
+            internalOnStartCall.set(InternalCallContext.isInternalCall());
+            return new ServerCall.Listener<>() {
+                @Override
+                public void onMessage(String message) {
+                    internalOnMessage.set(InternalCallContext.isInternalCall());
+                }
+
+                @Override
+                public void onHalfClose() {
+                    internalOnHalfClose.set(InternalCallContext.isInternalCall());
+                }
+            };
+        };
+
+        @SuppressWarnings("unchecked")
+        ServerCall<String, String> call = mock(ServerCall.class);
+
+        ServerCall.Listener<String> listener = new InternalCallServerInterceptor().interceptCall(call, new Metadata(), handler);
+        listener.onMessage("request");
+        listener.onHalfClose();
+
+        assertThat(internalOnStartCall).isTrue();
+        assertThat(internalOnMessage).isTrue();
+        assertThat(internalOnHalfClose).isTrue();
+        assertThat(InternalCallContext.isInternalCall()).isFalse();
+    }
+}


### PR DESCRIPTION
### 🔗 Related Issue

Prerequisite for the fix of https://github.com/kestra-io/kestra-ee/issues/10647, which is closed by the matching `kestra-ee` PR.

### ✨ Description

A webserver starts an embedded controller by default, so one process serves user HTTP requests and worker gRPC calls at the same time. Any code that needs to tell a user call from an internal one had only the server type to go on, and the server type now has two answers for that process.

This adds the missing signal. `InternalCallContext` carries the caller kind per call, and the controller marks every incoming gRPC call as internal. It is a `ScopedValue`, following `SecurityContextHolder` in `kestra-ee`, so the marker is unbound by default and bound only for the duration of the wrapped action: a caller that does not set it is still treated as a user call, and a lost marker denies rather than permits.

Nothing consumes the marker in OSS; `kestra-ee` uses it to stop applying user permission filters to worker calls, which today filter every row out instead of restricting anything (`read()` reports namespace files as missing, `DownloadFiles` downloads nothing, and namespace file writes never leave revision 1).

The interceptor is registered in `DefaultController.buildServer`, so it covers every gRPC service on the controller, including the EE ones, without a per-service change.

### 🛠️ Backend Checklist

- [x] Code compiles and tests pass for the touched modules (`./gradlew :module-name:test`, or `./gradlew build` for cross-module changes)
- [x] New behavior is covered by unit or integration tests

### 📝 Additional Notes

Verified end to end on a distributed EE instance (webserver + executor + dedicated worker) with a flow that uploads a namespace file and reads it back in the same execution. Before, the read failed with `PebbleException: File '/repro/probe.txt' was not found in namespace 'repro.nsfiles'` one second after the upload logged `File '/repro/probe.txt' added to namespace`. After, the upload logs `overwritten into` — the write now finds the existing entry, so revisions advance — and both reads return their content.

The marker is bound around the three places a service method body runs, so streaming methods are covered as well as unary ones: the handler start for a client-streaming method, `onMessage` for a streaming one and `onHalfClose` for a unary one. A handler that hands its work to an unstructured thread loses the binding and falls back to being treated as a user call; none does today.
