### PR TITLE
fix(executions): copy tooltip and hover state on execute-flow input labels

### DIFF
--- a/ui/src/components/inputs/InputsForm.vue
+++ b/ui/src/components/inputs/InputsForm.vue
@@ -21,10 +21,10 @@
                     >
                         <KsMarkdown :content="inputLabel(input)" class="d-inline-flex md-label" />
                         <KsButton
-                            type="text"
                             :icon="ContentCopyIcon"
-                            :tooltip="$t('copy_to_clipboard')"
-                            class="input-copy-btn"
+                            :tooltip="`${$t('copy_to_clipboard')}: ${inputRefExpression(input.id)}`"
+                            tooltipPlacement="right"
+                            link
                             @click.prevent="copyInputRef(input.id)"
                         />
                     </span>
@@ -1026,16 +1026,6 @@
     display: inline-flex;
     align-items: center;
     gap: var(--ks-spacing-1);
-
-    .input-copy-btn {
-        opacity: 0;
-        transition: opacity 0.15s ease-in-out;
-    }
-
-    &:hover .input-copy-btn,
-    &[draggable="true"]:focus-within .input-copy-btn {
-        opacity: 1;
-    }
 }
 
 .wizard-progress {


### PR DESCRIPTION
closes https://github.com/kestra-io/kestra-ee/issues/10257

This pull request updates the copy-to-clipboard button in the `InputsForm.vue` component to improve its usability and appearance. The most important changes are grouped below:

**UI/UX Improvements:**

* The copy button now always appears as a link-styled button (`link` prop) instead of using a text button style, making it more visually consistent and accessible.
* The tooltip for the copy button now displays both the "copy to clipboard" text and the input reference expression, providing clearer feedback to the user.
* The button's tooltip placement is explicitly set to "right" for better positioning.