### PR TITLE
fix(core): retry plugin catalog load instead of caching a failure for 1h

### DIFF
--- a/core/src/main/java/io/kestra/core/plugins/PluginCatalogService.java
+++ b/core/src/main/java/io/kestra/core/plugins/PluginCatalogService.java
@@ -38,6 +38,11 @@ public class PluginCatalogService {
 
     private static final Duration MAX_CACHE_DURATION = Duration.ofHours(1);
 
+    /**
+     * Minimum delay before retrying the hosted catalog after a failed or empty load. Package-private so tests can shorten it.
+     */
+    static Duration retryDelay = Duration.ofSeconds(30);
+
     private final HttpClient httpClient;
 
     private CompletableFuture<List<PluginManifest>> plugins;
@@ -45,6 +50,7 @@ public class PluginCatalogService {
     private List<PluginManifest> loaded = List.of();
 
     private Instant cacheLastLoaded = Instant.now();
+    private Instant retryNotBefore = Instant.MIN;
     private final AtomicBoolean isLoaded = new AtomicBoolean(false);
 
     private final Map<String, Optional<byte[]>> iconBytesByGroup = new ConcurrentHashMap<>();
@@ -142,13 +148,20 @@ public class PluginCatalogService {
 
     public synchronized List<PluginManifest> get() {
         try {
-            if (this.plugins == null) {
+            if (this.plugins == null && !Instant.now().isBefore(retryNotBefore)) {
                 this.isLoaded.set(true);
                 this.plugins = CompletableFuture.supplyAsync(this::load);
+            }
+            if (this.plugins == null) {
+                // a previous load failed recently: keep serving the last good list until the retry delay elapses
+                return withBundleEntries(loaded);
             }
             List<PluginManifest> artifacts = this.plugins.get();
             if (!artifacts.isEmpty()) {
                 loaded = artifacts;
+            } else if (loaded.isEmpty()) {
+                // nothing cached yet and the API returned nothing: don't cache the empty result, retry later
+                scheduleRetry();
             }
             if (cacheLastLoaded.plus(MAX_CACHE_DURATION).isBefore(Instant.now())) {
                 if (isLoaded.compareAndSet(false, true)) {
@@ -157,6 +170,9 @@ public class PluginCatalogService {
                 }
             }
         } catch (ExecutionException | InterruptedException e) {
+            // drop the failed future so the next call retries instead of serving the failure for MAX_CACHE_DURATION;
+            // `loaded` still holds the last good list, so a transient API outage never wipes the catalog.
+            scheduleRetry();
             if (e instanceof InterruptedException) {
                 Thread.currentThread().interrupt();
                 log.warn("Failed to retrieve available plugins from Kestra API. Cause: Interrupted");
@@ -198,6 +214,11 @@ public class PluginCatalogService {
             .forEach(merged::add);
 
         return List.copyOf(merged);
+    }
+
+    private void scheduleRetry() {
+        this.plugins = null;
+        this.retryNotBefore = Instant.now().plus(retryDelay);
     }
 
     private List<PluginManifest> load() {

--- a/core/src/test/java/io/kestra/core/plugins/PluginCatalogServiceTest.java
+++ b/core/src/test/java/io/kestra/core/plugins/PluginCatalogServiceTest.java
@@ -1,6 +1,7 @@
 package io.kestra.core.plugins;
 
 import java.nio.charset.StandardCharsets;
+import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -22,6 +23,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 class PluginCatalogServiceTest {
@@ -45,6 +48,7 @@ class PluginCatalogServiceTest {
     @AfterEach
     void tearDown() {
         KestraContext.setContext(null);
+        PluginCatalogService.retryDelay = Duration.ofSeconds(30);
     }
 
     // -- get() contract --
@@ -132,6 +136,49 @@ class PluginCatalogServiceTest {
 
         // Then
         assertThat(result).isEmpty();
+    }
+
+    @Test
+    void shouldRetryAfterFailedLoadInsteadOfCachingTheFailure() {
+        // Given: first call to the API fails, second succeeds
+        PluginCatalogService.retryDelay = Duration.ZERO;
+        when(blockingClient.exchange(any(), any(Argument.class)))
+            .thenThrow(new RuntimeException("api.kestra.io is restarting"))
+            .thenReturn(
+                HttpResponse.ok(
+                    List.of(
+                        Map.of("name", "plugin-serdes", "title", "Serdes", "group", "io.kestra.plugin", "license", "OPENSOURCE")
+                    )
+                )
+            );
+
+        PluginCatalogService service = new PluginCatalogService(httpClient, false, true, executorsUtils, null);
+
+        // When
+        List<PluginCatalogService.PluginManifest> firstResult = service.get();
+        List<PluginCatalogService.PluginManifest> secondResult = service.get();
+
+        // Then
+        assertThat(firstResult).isEmpty();
+        assertThat(secondResult).hasSize(1);
+        assertThat(secondResult.getFirst().artifactId()).isEqualTo("plugin-serdes");
+    }
+
+    @Test
+    void shouldNotRetryBeforeRetryDelayElapsed() {
+        // Given: a failing API and a long retry delay
+        PluginCatalogService.retryDelay = Duration.ofHours(1);
+        when(blockingClient.exchange(any(), any(Argument.class)))
+            .thenThrow(new RuntimeException("api.kestra.io is restarting"));
+
+        PluginCatalogService service = new PluginCatalogService(httpClient, false, true, executorsUtils, null);
+
+        // When
+        service.get();
+        service.get();
+
+        // Then: only one HTTP call was made, the second get() served the (empty) cache without hammering the API
+        verify(blockingClient, times(1)).exchange(any(), any(Argument.class));
     }
 
     // -- resolveVersions() contract --


### PR DESCRIPTION
## Summary
Fixes the root cause of kestra-io/api.kestra.io#421: an instance ended up with an empty plugin list (plugin versioning broken) after a single failed call to api.kestra.io during an API restart, and stayed that way until the instance was restarted.

`PluginCatalogService.get()` stored the `CompletableFuture` of the first load and never reset it. If that first call failed, the failed future was re-thrown on every subsequent `get()` for `MAX_CACHE_DURATION` (1h), so every caller (`PluginController.getPluginVersions`, `PluginAutoInstallService`, CLI `plugin install`, EE `InstanceController`) got an empty list.

### Changes
- A failed or empty load now drops the cached future and schedules a retry after `retryDelay` (30s, to avoid hammering an API that is down).
- The last good list is kept in `loaded` and served in the meantime, so a transient API outage never wipes the catalog.
- Tests: failure-then-success recovers on the next call; no retry before the delay elapses (single HTTP call).

Companion server-side PR (graceful pod shutdown + PDB): kestra-io/api.kestra.io#497

## Test plan
- [x] `./gradlew :core:test --tests io.kestra.core.plugins.PluginCatalogServiceTest` — 19/19 pass
- [ ] Manual: start Kestra with api.kestra.io unreachable, then restore connectivity — plugin versions appear within ~30s without restarting the instance