### PR TITLE
test(core): pin that formerly reserved flow ids are accepted

### DIFF
--- a/core/src/test/java/io/kestra/core/services/FlowServiceTest.java
+++ b/core/src/test/java/io/kestra/core/services/FlowServiceTest.java
@@ -317,6 +317,44 @@ class FlowServiceTest {
     }
 
     @Test
+    void shouldAcceptFlowIdsThatWereReservedBeforeTheExecutionEndpointRename() {
+        // Until the execution action endpoints moved under /{executionId}/actions/,
+        // POST /executions/{namespace}/{flowId} was ambiguous with them, and
+        // FlowValidator rejected any flow id that collided: pause, resume,
+        // force-run, change-status, kill, executions, search, source, disable and
+        // enable. The rename removed the ambiguity, so the restriction was lifted
+        // with it -- nothing asserted the freedom afterwards, which is what this
+        // covers. If a future change reintroduces the clash, or restores the
+        // keyword list, this fails.
+        List<String> formerlyReserved = List.of(
+            "pause", "resume", "force-run", "change-status", "kill",
+            "executions", "search", "source", "disable", "enable"
+        );
+
+        for (String flowId : formerlyReserved) {
+            // Given
+            String source = """
+                id: %s
+                namespace: io.kestra.unittest
+                tasks:
+                  - id: log
+                    type: io.kestra.plugin.core.log.Log
+                    message: This is a message
+                """.formatted(flowId);
+
+            // When
+            List<ValidateConstraintViolation> results = flowService.validate("my-tenant", List.of(new FlowSource(null, source)));
+
+            // Then
+            assertThat(results).as("flow id '%s'", flowId).hasSize(1);
+            assertThat(results.getFirst().getConstraints())
+                .as("flow id '%s' must not be rejected", flowId)
+                .isNull();
+            assertThat(results.getFirst().getFlow()).isEqualTo(flowId);
+        }
+    }
+
+    @Test
     void shouldReturnEmptyListGivenFlowWithNoChecks() {
         // Given
         Flow flow = mock(Flow.class);


### PR DESCRIPTION
## Why

`c6ca1a5` ("chore(execution)!: rename execution endpoints") moved the execution action endpoints under `/{executionId}/actions/` — in its own words, *"to avoid potential clash with the create execution endpoint"*. `POST /executions/{namespace}/{flowId}` was ambiguous with `POST /executions/{executionId}/{action}`, so `FlowValidator` carried a `RESERVED_FLOW_IDS` list forbidding ten flow ids: `pause`, `resume`, `force-run`, `change-status`, `kill`, `executions`, `search`, `source`, `disable`, `enable`.

The rename removed the ambiguity, so that guard was correctly removed in the same commit. **This PR is not proposing to bring it back** — lifting it was the point.

The gap is that the commit deleted `shouldReturnValidationErrorForReservedFlowId` and added nothing in its place. So the freedom the rename bought is untested: a change that reintroduced the clash, or restored the keyword list, would pass CI today.

## What

One test walking the ten formerly reserved ids, asserting each validates clean. The id is in the assertion description, so a failure names which one regressed rather than just "expected null".

## Verification

Ran green on `develop` (53/53 in `FlowServiceTest`).

More importantly, I checked it actually detects a regression rather than merely passing today — with the `RESERVED_FLOW_IDS` check temporarily restored in `FlowValidator`, it fails with:

```
[flow id 'pause' must not be rejected]
  at io.kestra.core.services.FlowServiceTest
     .shouldAcceptFlowIdsThatWereReservedBeforeTheExecutionEndpointRename
```

Mutation reverted; the only file changed here is the test.

## Context

Found while fixing kestra-io/kestractl#117, where kestractl had to rewrite execution action paths to work against both 1.x and 2.x servers. The client-side heuristic for telling `/executions/{id}/pause` from `/executions/{ns}/pause` collided precisely because 2.0 now allows a flow named `pause` — which is correct server behaviour, and is what made me notice nothing pinned it.
