### PR TITLE
fix(dashboards): avoid tenant defaults before config loads

### DIFF
--- a/ui/src/stores/dashboard.ts
+++ b/ui/src/stores/dashboard.ts
@@ -93,7 +93,7 @@ export const useDashboardStore = defineStore("dashboard", () => {
 
     /** Loads the tenant default dashboards; an instance that cannot store dashboards has none and does not serve the route. */
     async function loadDefaults() {
-        if (useMiscStore().configs?.isCustomDashboardsEnabled === false) {
+        if (useMiscStore().configs?.isCustomDashboardsEnabled !== true) {
             defaultDashboards.value = {}
             return defaultDashboards.value
         }

--- a/ui/tests/unit/stores/dashboardTenantDefaults.spec.ts
+++ b/ui/tests/unit/stores/dashboardTenantDefaults.spec.ts
@@ -69,6 +69,16 @@ describe("dashboard store tenant defaults", () => {
         expect(get).not.toHaveBeenCalled()
     })
 
+    it("does not ask for tenant defaults before the dashboard capability is known", {timeout: TEST_TIMEOUT_MS}, async () => {
+        isCustomDashboardsEnabled = undefined
+        get.mockResolvedValue({data: {defaultHomeDashboard: "tenant-default"}})
+
+        const {useDashboardStore} = await import("../../../src/stores/dashboard")
+
+        await expect(useDashboardStore().getDashboardId(route)).resolves.toBe("default")
+        expect(get).not.toHaveBeenCalled()
+    })
+
     it("asks for tenant defaults when the instance can store dashboards", {timeout: TEST_TIMEOUT_MS}, async () => {
         isCustomDashboardsEnabled = true
         get.mockResolvedValue({data: {defaultHomeDashboard: "tenant-default"}})


### PR DESCRIPTION
Closes https://github.com/kestra-io/kestra/issues/19055.

---

### Related Issue

The dashboard can try to load tenant defaults before the custom-dashboard capability is known. On OSS, that endpoint does not exist, so the initial dashboard navigation can end up on the 404 page.

### Description

Only fetch tenant dashboard defaults when the instance explicitly reports that custom dashboards are enabled. Until then, use the bundled default dashboard.

This also adds a regression test for the startup state where the capability has not loaded yet.

### Frontend Checklist

- [x] Type checking passes (`npm run check:types`)
- [x] Code builds without errors (`npm run build`)
- [x] Unit tests pass (`npm run test:unit`)
- [x] Translations are complete if `en.json` changed (`en.json` is unchanged)
- [x] Screenshots attached showing the UI change

### Backend Checklist

- [x] Code compiles for the touched module (`:executor:compileJava`)
- [x] No backend behavior was added; the follow-up only removes a stale reference to an enum value deleted on `develop`

### Screenshots

Before:

<img width="1374" height="814" alt="Dashboard route showing the 404 page" src="https://github.com/user-attachments/assets/45de74b0-dbe1-4820-9578-ce0c945bd970" />

After:

<img width="1374" height="814" alt="Bundled default dashboard loading successfully" src="https://raw.githubusercontent.com/ayush-singh-0601/kestra/7babc4a83f46f01b941c508d5826ed5e57d5283c/docs/pr-assets/19055/dashboard-after.png" />

### Additional Notes

The initial E2E job failed before running Playwright because the current `develop` head removed `OnChildFailure.UNKNOWN` but `ExecutorService` still referenced it. The second commit removes that stale comparison; unknown values already deserialize to `CONTINUE`. The exact failing target now compiles successfully under JDK 25.

The dashboard change was also verified with the focused unit suite, the app and test TypeScript projects, lint, and a production build.

### AI Authors

Cat joke: the dashboard stopped chasing a 404 and finally landed on its default paws.
