### PR TITLE
fix(flows): finish the OnChildFailure enum rename

### DIFF
--- a/core/src/main/java/io/kestra/plugin/core/flow/Dag.java
+++ b/core/src/main/java/io/kestra/plugin/core/flow/Dag.java
@@ -105,7 +105,7 @@ public class Dag extends Task implements FlowableTask<VoidOutput>, OnChildFailur
         description = """
             `CONTINUE` (default): other tasks keep running to completion, as today.
 
-            `CANCELLED` / `FAILED`: as soon as a task fails with no retry left, every other still-running task in this DAG is interrupted and lands in the given state. The DAG itself still resolves to `FAILED` and its `errors`/`finally` tasks still run normally."""
+            `CANCEL` / `FAIL`: as soon as a task fails with no retry left, every other still-running task in this DAG is interrupted and lands in the given state. The DAG itself still resolves to `FAILED` and its `errors`/`finally` tasks still run normally."""
     )
     private final Property<OnChildFailure> onChildFailure = Property.ofValue(OnChildFailure.CONTINUE);
 

--- a/core/src/main/java/io/kestra/plugin/core/flow/Parallel.java
+++ b/core/src/main/java/io/kestra/plugin/core/flow/Parallel.java
@@ -113,7 +113,7 @@ import lombok.experimental.SuperBuilder;
                 tasks:
                   - id: parallel
                     type: io.kestra.plugin.core.flow.Parallel
-                    onChildFailure: CANCELLED
+                    onChildFailure: CANCEL
                     tasks:
                       - id: fails_fast
                         type: io.kestra.plugin.core.execution.Fail
@@ -141,7 +141,7 @@ public class Parallel extends AbstractBranch<VoidOutput> implements OnChildFailu
         description = """
             `CONTINUE` (default): other tasks keep running to completion, as today.
 
-            `CANCELLED` / `FAILED`: as soon as a task fails with no retry left, every other still-running task in this Parallel is interrupted and lands in the given state. The Parallel itself still resolves to `FAILED` and its `errors`/`finally` tasks still run normally."""
+            `CANCEL` / `FAIL`: as soon as a task fails with no retry left, every other still-running task in this Parallel is interrupted and lands in the given state. The Parallel itself still resolves to `FAILED` and its `errors`/`finally` tasks still run normally."""
     )
     private final Property<OnChildFailure> onChildFailure = Property.ofValue(OnChildFailure.FAIL);
 

--- a/core/src/test/resources/flows/valids/dag-fail-fast-cancelled.yaml
+++ b/core/src/test/resources/flows/valids/dag-fail-fast-cancelled.yaml
@@ -4,7 +4,7 @@ namespace: io.kestra.tests
 tasks:
   - id: dag
     type: io.kestra.plugin.core.flow.Dag
-    onChildFailure: CANCELLED
+    onChildFailure: CANCEL
     tasks:
       - task:
           id: fails_fast

--- a/core/src/test/resources/flows/valids/parallel-fail-fast-cancelled.yaml
+++ b/core/src/test/resources/flows/valids/parallel-fail-fast-cancelled.yaml
@@ -4,7 +4,7 @@ namespace: io.kestra.tests
 tasks:
   - id: parallel
     type: io.kestra.plugin.core.flow.Parallel
-    onChildFailure: CANCELLED
+    onChildFailure: CANCEL
     tasks:
       - id: fails_fast
         type: io.kestra.plugin.core.execution.Fail

--- a/core/src/test/resources/flows/valids/parallel-fail-fast-errors.yaml
+++ b/core/src/test/resources/flows/valids/parallel-fail-fast-errors.yaml
@@ -4,7 +4,7 @@ namespace: io.kestra.tests
 tasks:
   - id: parallel
     type: io.kestra.plugin.core.flow.Parallel
-    onChildFailure: CANCELLED
+    onChildFailure: CANCEL
     errors:
       - id: e1
         type: io.kestra.plugin.core.log.Log

--- a/core/src/test/resources/flows/valids/parallel-fail-fast-failed.yaml
+++ b/core/src/test/resources/flows/valids/parallel-fail-fast-failed.yaml
@@ -4,7 +4,7 @@ namespace: io.kestra.tests
 tasks:
   - id: parallel
     type: io.kestra.plugin.core.flow.Parallel
-    onChildFailure: FAILED
+    onChildFailure: FAIL
     tasks:
       - id: fails_fast
         type: io.kestra.plugin.core.execution.Fail

--- a/core/src/test/resources/flows/valids/parallel-fail-fast-nested.yaml
+++ b/core/src/test/resources/flows/valids/parallel-fail-fast-nested.yaml
@@ -4,7 +4,7 @@ namespace: io.kestra.tests
 tasks:
   - id: parallel
     type: io.kestra.plugin.core.flow.Parallel
-    onChildFailure: CANCELLED
+    onChildFailure: CANCEL
     tasks:
       - id: fails_fast
         type: io.kestra.plugin.core.execution.Fail

--- a/executor/src/main/java/io/kestra/executor/ExecutorService.java
+++ b/executor/src/main/java/io/kestra/executor/ExecutorService.java
@@ -905,7 +905,7 @@ public class ExecutorService {
         OnChildFailureInterface.OnChildFailure config = runContext.render(onChildFailure.getOnChildFailure())
             .as(OnChildFailureInterface.OnChildFailure.class)
             .orElse(OnChildFailureInterface.OnChildFailure.CONTINUE);
-        if (config == OnChildFailureInterface.OnChildFailure.CONTINUE || config == OnChildFailureInterface.OnChildFailure.UNKNOWN) {
+        if (config == OnChildFailureInterface.OnChildFailure.CONTINUE) {
             return;
         }
 


### PR DESCRIPTION
### 🔗 Related Issue

Fixes the `develop` build broken by 74ffc4367d (`fix(flow): rename OnChildFailure enum`). Failing run: https://github.com/kestra-io/kestra/actions/runs/33872460579

### ✨ Description

The rename dropped `UNKNOWN` and renamed `CANCELLED`/`FAILED` to `CANCEL`/`FAIL`, but only touched `OnChildFailureInterface` and the `Parallel` default. `ExecutorService.interruptOnChildFailure` still compared against `OnChildFailure.UNKNOWN`, so `:executor:compileJava` fails on `develop`.

Once that compiles, the `Parallel`/`Dag` schema descriptions, the `Parallel` example and the five `*-fail-fast-*.yaml` test flows still used the old values. Since `fromString` now defaults to `CONTINUE`, those flows would silently stop interrupting siblings and the fail-fast tests would fail. This PR updates every remaining reference to the new names.

### 🛠️ Backend Checklist

- [x] Code compiles and tests pass for the touched modules: `:executor:compileJava`, `H2RunnerTest.parallelFailFastCancelled`, `ParallelTest` (10/10) and `DagTest` (7/7)
- [x] Existing fail-fast tests cover the behavior; no new tests needed for a rename

### 📝 Additional Notes

No new behavior. The `trigger-ee` job on `develop` also failed, but with an "inconclusive, likely a transient runner error" message, so it is not addressed here.

🐱 The old enum values were fine, they just needed a little re-nam-ing. The cat, meanwhile, refuses to be renamed at all.