### PR TITLE
fix(scheduler): spurious thread-starvation warning on fresh start

### DIFF
--- a/scheduler/src/main/java/io/kestra/scheduler/TriggerScheduler.java
+++ b/scheduler/src/main/java/io/kestra/scheduler/TriggerScheduler.java
@@ -144,6 +144,7 @@ public class TriggerScheduler {
      */
     public void onStart(final Clock clock, final Instant scheduledTime, final Set<Integer> vNodesAssignments) {
         log.info("Starting trigger scheduling for {} vNodes", vNodesAssignments);
+        final long start = System.nanoTime();
 
         Map<String, TriggerState> triggers = triggerStateStore.findAllForVNodes(vNodesAssignments).stream()
             .collect(Collectors.toMap(TriggerId::uid, Function.identity(), (existing, replacement) ->
@@ -234,6 +235,8 @@ public class TriggerScheduler {
                     }
                 }
             });
+
+        log.debug("Started trigger scheduling in {}ms", Duration.ofNanos(System.nanoTime() - start).toMillis());
     }
 
     /**
@@ -248,8 +251,9 @@ public class TriggerScheduler {
      * @param scheduledTime the target time for which triggers should be evaluated and potentially scheduled;
      *        represents the scheduler’s current cycle timestamp.
      * @param vNodesAssignments the set of virtual node identifiers whose associated triggers should be evaluated.
+     * @return the number of triggers evaluated.
      */
-    public void onSchedule(final Clock clock, final Instant scheduledTime, final Set<Integer> vNodesAssignments) {
+    public int onSchedule(final Clock clock, final Instant scheduledTime, final Set<Integer> vNodesAssignments) {
         metricScheduleLoopCounter.increment();
 
         ZonedDateTime zoneScheduleTime = ZonedDateTime.ofInstant(scheduledTime, clock.getZone());
@@ -268,6 +272,8 @@ public class TriggerScheduler {
 
         // Record metrics
         metricEvaluationLoopDuration.record(Duration.between(scheduledTime, clock.instant()));
+
+        return schedulableTriggers.size();
     }
 
     /**

--- a/scheduler/src/main/java/io/kestra/scheduler/TriggerSchedulingLoop.java
+++ b/scheduler/src/main/java/io/kestra/scheduler/TriggerSchedulingLoop.java
@@ -36,6 +36,8 @@ public class TriggerSchedulingLoop implements Runnable {
     private static final Logger LOG = LoggerFactory.getLogger(TriggerSchedulingLoop.class);
 
     private static final long SCHEDULE_INTERVAL_MILLIS = Duration.ofSeconds(1).toMillis();
+    // Trigger work overrunning the interval has already cost a scheduling slot, so only jitter is tolerated.
+    private static final long MAX_CYCLE_WORK_MILLIS = SCHEDULE_INTERVAL_MILLIS + (SCHEDULE_INTERVAL_MILLIS / 10);
 
     private final int schedulingLoopId;
     private final TriggerScheduler triggerScheduler;
@@ -122,19 +124,13 @@ public class TriggerSchedulingLoop implements Runnable {
         // submission cannot race startup and be silently dropped (see awaitStarted/stop).
         this.started.countDown();
         Instant nextScheduleTime = clock.instant();
-        // Use the monotonic clock to measure the loop period.
-        long tick = System.nanoTime();
+        // An evaluation that follows an initialization re-reads the whole trigger set on a cold path, so its
+        // duration says nothing about whether this loop can keep up.
+        boolean coldEvaluation = true;
         try {
             while (running.get()) {
                 long start = System.nanoTime();
                 try {
-                    long elapsed = (start - tick) / 1_000_000;
-                    if (elapsed > (SCHEDULE_INTERVAL_MILLIS + (SCHEDULE_INTERVAL_MILLIS / 10))) {
-                        // useful for debugging unexpected schedule delay
-                        LOG.warn("Thread starvation or too many triggers to evaluate (elapsed since previous loop {}ms)", elapsed);
-                    }
-                    tick = start;
-
                     waitIfPaused();
 
                     // Check if the loop was stopped while being paused
@@ -155,21 +151,48 @@ public class TriggerSchedulingLoop implements Runnable {
                         continue;
                     }
 
-                    final Instant now = clock.instant();
-
                     if (!initialized.get()) {
-                        triggerScheduler.onStart(clock, now, assignments);
+                        triggerScheduler.onStart(clock, clock.instant(), assignments);
                         initialized.set(true);
+                        // setAssignments() resets `initialized`, so a rebalance goes through here too.
+                        coldEvaluation = true;
                     }
+
+                    // Only the trigger work is measured: a pause, the initialization above and the end-loop
+                    // actions below are not the load this loop is sized for.
+                    long workStart = System.nanoTime();
 
                     // Process all received triggers events for current assignments.
-                    processTriggerEvents();
+                    int processedEvents = processTriggerEvents();
+
+                    // Sampled after the initialization and the event drain, either of which can take seconds:
+                    // this instant is the eligibility cut-off, the schedule date of the executions created from
+                    // it, and the left bound of scheduler.evaluation.loop.duration.
+                    Instant now = clock.instant();
 
                     // Check whether triggers should be scheduled
-                    if (now.isAfter(nextScheduleTime) || now.equals(nextScheduleTime)) {
-                        triggerScheduler.onSchedule(clock, now, assignments);
-                        nextScheduleTime = nextScheduleTime.plusMillis(SCHEDULE_INTERVAL_MILLIS);
+                    int evaluatedTriggers = 0;
+                    boolean evaluated = !now.isBefore(nextScheduleTime);
+                    if (evaluated) {
+                        evaluatedTriggers = triggerScheduler.onSchedule(clock, now, assignments);
+                        // Move to the first slot after `now`: the slots in between are not replayed, since the
+                        // evaluation above already served their triggers, but the one-second grid is kept so
+                        // that the schedule dates never drift.
+                        long slots = (now.toEpochMilli() - nextScheduleTime.toEpochMilli()) / SCHEDULE_INTERVAL_MILLIS + 1;
+                        nextScheduleTime = nextScheduleTime.plusMillis(SCHEDULE_INTERVAL_MILLIS * slots);
                     }
+
+                    long workMillis = (System.nanoTime() - workStart) / 1_000_000;
+                    if (workMillis > MAX_CYCLE_WORK_MILLIS && !coldEvaluation) {
+                        LOG.warn(
+                            "Scheduling loop {} cannot keep up with its trigger load: one cycle spent {}ms processing {} trigger event(s) and evaluating {} trigger(s).",
+                            schedulingLoopId,
+                            workMillis,
+                            processedEvents,
+                            evaluatedTriggers
+                        );
+                    }
+                    coldEvaluation &= !evaluated;
 
                     // Execute end-loop actions
                     doOnEndLoop();

--- a/scheduler/src/test/java/io/kestra/scheduler/TriggerSchedulingLoopTest.java
+++ b/scheduler/src/test/java/io/kestra/scheduler/TriggerSchedulingLoopTest.java
@@ -1,17 +1,28 @@
 package io.kestra.scheduler;
 
 import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneId;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
+import org.slf4j.LoggerFactory;
 
 import io.kestra.core.metrics.MetricRegistry;
 import io.kestra.core.scheduler.events.TriggerEvent;
+import io.kestra.core.utils.Await;
 
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.noop.NoopTimer;
@@ -107,6 +118,101 @@ class TriggerSchedulingLoopTest {
     }
 
     @Test
+    void shouldWarnOnEveryEvaluationButTheColdOneWhenEvaluationOverrunsTheInterval() throws Exception {
+        // GIVEN
+        Logger logger = (Logger) LoggerFactory.getLogger(TriggerSchedulingLoop.class);
+        ListAppender<ILoggingEvent> appender = new ListAppender<>();
+        appender.start();
+        logger.addAppender(appender);
+
+        AtomicInteger evaluations = new AtomicInteger();
+        TriggerSchedulingLoop loop = createLoop();
+        loop.setAssignments(Set.of(1));
+        // Every evaluation overruns the interval, so a clean first cycle can only come from the skip.
+        Mockito.when(triggerScheduler.onSchedule(any(), any(), any())).thenAnswer(invocation ->
+        {
+            Thread.sleep(1_300);
+            return evaluations.incrementAndGet();
+        });
+
+        Thread thread = new Thread(loop);
+        thread.start();
+
+        try {
+            // WHEN
+            Await.until(() -> evaluations.get() >= 2, Duration.ofMillis(10), Duration.ofSeconds(30));
+        } finally {
+            loop.stop();
+            thread.join();
+            logger.detachAppender(appender);
+        }
+
+        // THEN
+        long warnings = appender.list.stream()
+            .filter(event -> event.getFormattedMessage().contains("cannot keep up with its trigger load"))
+            .count();
+        assertThat(warnings).isEqualTo(evaluations.get() - 1);
+    }
+
+    @Test
+    void shouldKeepScheduleGridWhenPreviousIterationRanLate() throws Exception {
+        // GIVEN
+        AdjustableClock adjustableClock = new AdjustableClock(Instant.parse("2026-01-01T00:00:00Z"));
+        clock = adjustableClock;
+        AtomicInteger evaluations = new AtomicInteger();
+        TriggerSchedulingLoop loop = createLoop();
+        Mockito.when(triggerScheduler.onSchedule(any(), any(), any())).thenAnswer(invocation -> evaluations.incrementAndGet());
+
+        Thread thread = new Thread(loop);
+        thread.start();
+
+        try {
+            // WHEN
+            awaitFirstIteration(loop);
+            adjustableClock.advance(Duration.ofMillis(5_400));
+            loop.setAssignments(Set.of(1));
+            Await.until(() -> evaluations.get() == 1, Duration.ofMillis(10), Duration.ofSeconds(10));
+
+            // THEN
+            adjustableClock.advance(Duration.ofMillis(600));
+            Await.until(() -> evaluations.get() == 2, Duration.ofMillis(10), Duration.ofSeconds(10));
+        } finally {
+            loop.stop();
+            thread.join();
+        }
+    }
+
+    @Test
+    void shouldNotEvaluateTwiceWhenWakingExactlyOneIntervalLate() throws Exception {
+        // GIVEN
+        AdjustableClock adjustableClock = new AdjustableClock(Instant.parse("2026-01-01T00:00:00Z"));
+        clock = adjustableClock;
+        AtomicInteger evaluations = new AtomicInteger();
+        TriggerSchedulingLoop loop = createLoop();
+        Mockito.when(triggerScheduler.onSchedule(any(), any(), any())).thenAnswer(invocation -> evaluations.incrementAndGet());
+
+        Thread thread = new Thread(loop);
+        thread.start();
+
+        try {
+            // WHEN
+            awaitFirstIteration(loop);
+            loop.setAssignments(Set.of(1));
+            Await.until(() -> evaluations.get() >= 1, Duration.ofMillis(10), Duration.ofSeconds(10));
+            // The slot is now one interval ahead, so the next iteration lands exactly on it plus one interval.
+            adjustableClock.advance(Duration.ofSeconds(2));
+
+            // THEN
+            Await.until(() -> evaluations.get() >= 2, Duration.ofMillis(10), Duration.ofSeconds(10));
+            Thread.sleep(200); // leave room for any catch-up iteration to fire
+            assertThat(evaluations.get()).isEqualTo(2);
+        } finally {
+            loop.stop();
+            thread.join();
+        }
+    }
+
+    @Test
     void shouldStopLoopGracefullyGivenRunningLoop() throws InterruptedException {
         // GIVEN
         TriggerSchedulingLoop loop = createLoop();
@@ -167,5 +273,43 @@ class TriggerSchedulingLoopTest {
 
         // THEN
         assertThat(processed).isEqualTo(0);
+    }
+
+    /**
+     * Waits for the loop to complete one iteration, so that it has read its initial schedule time
+     * before the test moves the clock.
+     */
+    private static void awaitFirstIteration(TriggerSchedulingLoop loop) throws Exception {
+        loop.doOnEndLoop(() ->
+        {
+        }).get(10, TimeUnit.SECONDS);
+    }
+
+    private static final class AdjustableClock extends Clock {
+
+        private final AtomicReference<Instant> instant;
+
+        private AdjustableClock(Instant instant) {
+            this.instant = new AtomicReference<>(instant);
+        }
+
+        private void advance(Duration duration) {
+            instant.updateAndGet(current -> current.plus(duration));
+        }
+
+        @Override
+        public ZoneId getZone() {
+            return ZoneId.of("UTC");
+        }
+
+        @Override
+        public Clock withZone(ZoneId zone) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Instant instant() {
+            return instant.get();
+        }
     }
 }


### PR DESCRIPTION
### 🔗 Related Issue

Closes https://github.com/kestra-io/kestra-ee/issues/8388.

### ✨ Description

On a fresh start with only the tutorial flows loaded, every scheduling loop logged `Thread starvation or too many triggers to evaluate (elapsed since previous loop 1216ms)`. Nothing was starved. `elapsed` was measured from one cycle's start to the next, and the loop deliberately waits out the rest of its second on the schedule grid, so `elapsed > 1.1s` really meant *"this cycle spent more than 100ms not blocked in the wait"*. Trigger initialization, a pause and the end-loop actions all fall inside that window, and all were reported as thread starvation.

The warning now measures the work it names — `processTriggerEvents()` plus `onSchedule()` for one cycle — so those cases fall outside the measurement instead of having to be excluded one at a time. The threshold is unchanged at one interval + 10%: a cycle whose trigger work exceeds a second genuinely cannot hold the per-second guarantee, which is the only thing this warning exists to detect. It now names the load rather than listing candidate causes:

```
Scheduling loop 1 cannot keep up with its trigger load: one cycle spent 1400ms processing 0 trigger event(s) and evaluating 12043 trigger(s).
```

An evaluation that directly follows an initialization is exempt, because it re-reads the whole trigger set on a cold path and its duration says nothing about steady-state load. `setAssignments()` resets `initialized`, so this covers a rebalance as well as a fresh start — and it makes the fix independent of whether the reported 1216–1430ms was spent in `onStart` or in the first `onSchedule`.

Two timing bugs found alongside it, both independent of the diagnostic:

- `onSchedule` ran for an instant sampled *before* `onStart` and before the trigger-event drain, up to the whole initialization duration in the past. That booked initialization and drain time into `scheduler.evaluation.loop.duration` and into the schedule date of the executions the cycle creates. The cycle instant is now sampled once, after both.
- after a stretch with no vNode assigned, `nextScheduleTime` advanced one interval at a time, so N gone slots fired N immediate evaluations of the very same due triggers. It now moves to the first slot after `now`, staying on the one-second grid so a late cycle does not shift every later evaluation. No trigger is lost: `onSchedule` fetches everything due at or before the cycle instant, so one evaluation serves the slots it skipped.

`TriggerScheduler#onSchedule` returns the evaluated count for the message, and `onStart` logs its own duration at debug, so the initialization cost stays reachable without a warning being raised for it.

### 🛠️ Backend Checklist

- [x] Code compiles and tests pass for the touched modules (`./gradlew :scheduler:test` — 128/128)
- [x] New behavior is covered by unit or integration tests

### 📝 Additional Notes

- `shouldWarnOnEveryEvaluationButTheColdOneWhenEvaluationOverrunsTheInterval` makes every evaluation overrun the interval and asserts one warning per evaluation bar the cold one, via a log appender; verified it fails with the exemption removed. `shouldKeepScheduleGridWhenPreviousIterationRanLate` and `shouldNotEvaluateTwiceWhenWakingExactlyOneIntervalLate` drive the loop with an adjustable clock and cover the realignment and its exact-multiple boundary.
- Deliberately left out: a metric for the slots a late cycle skips. Skipping them removes the only visible symptom a late loop had, so the counter is worth having, but a trustworthy one has to reconcile the wall-clock slot grid against `System.nanoTime()` or a forward NTP step reports as a stall. That is a feature with its own failure modes and does not belong in a log-noise fix — follow-up.
- Also left out: `scheduler.eventloop.tick.duration` is recorded after the wait, so it measures `max(work, 1s)`, is dominated by sleep, and cannot serve as the saturation trend in Prometheus. Making it record cycle work redefines an existing metric and belongs in its own PR.
- Pre-existing and unrelated, worth its own issue: `assignments` is a plain `HashSet`, mutated by `onVNodesAssigned` from the membership-callback thread while the loop thread reads and iterates it (`DefaultScheduler#assignVNodesToSchedulingLoops`).
- `:scheduler:spotlessCheck` is red on 6 other files in the module, identically on `develop`. Left untouched to keep unrelated reformatting out of the diff; the two files this PR changes are clean.
