### PR TITLE
fix(executions): preserve working directory subtask results on failur…

### DIFF
--- a/core/src/main/java/io/kestra/core/repositories/TaskOutputRepositoryInterface.java
+++ b/core/src/main/java/io/kestra/core/repositories/TaskOutputRepositoryInterface.java
@@ -18,6 +18,13 @@ public interface TaskOutputRepositoryInterface {
     Optional<TaskOutput> findById(String tenantId, String taskRunId);
 
     /**
+     * Returns whether a task output exists.
+     */
+    default boolean exists(String tenantId, String taskRunId) {
+        return findById(tenantId, taskRunId).isPresent();
+    }
+
+    /**
      * Save a task output.
      */
     TaskOutput save(TaskOutput taskOutput);

--- a/core/src/main/java/io/kestra/core/runners/WorkerTaskResult.java
+++ b/core/src/main/java/io/kestra/core/runners/WorkerTaskResult.java
@@ -4,7 +4,9 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 import io.kestra.core.models.HasUID;
 import io.kestra.core.models.executions.TaskRun;
@@ -12,13 +14,11 @@ import io.kestra.core.queues.event.DispatchEvent;
 
 import jakarta.annotation.Nullable;
 import jakarta.validation.constraints.NotNull;
-import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Value;
 import lombok.With;
 
 @Value
-@AllArgsConstructor
 @Builder
 public class WorkerTaskResult implements DispatchEvent, HasUID {
     @NotNull
@@ -32,12 +32,38 @@ public class WorkerTaskResult implements DispatchEvent, HasUID {
     @JsonInclude(JsonInclude.Include.ALWAYS)
     Map<String, Object> outputs;
 
+    /** Results already emitted for the same WorkingDirectory that must be joined before this result. */
+    @With
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    List<WorkerTaskResultPayload> precedingResults;
+
     public WorkerTaskResult(TaskRun taskRun) {
-        this(taskRun, new ArrayList<>(1), null); // there are usually very few dynamic task runs, so we init the list with a capacity of 1
+        this(taskRun, new ArrayList<>(1), null, List.of()); // there are usually very few dynamic task runs, so we init the list with a capacity of 1
     }
 
     public WorkerTaskResult(TaskRun taskRun, Map<String, Object> outputs) {
-        this(taskRun, new ArrayList<>(1), outputs); // there are usually very few dynamic task runs, so we init the list with a capacity of 1
+        this(taskRun, new ArrayList<>(1), outputs, List.of()); // there are usually very few dynamic task runs, so we init the list with a capacity of 1
+    }
+
+    public WorkerTaskResult(TaskRun taskRun, List<TaskRun> dynamicTaskRuns, Map<String, Object> outputs) {
+        this(taskRun, dynamicTaskRuns, outputs, List.of());
+    }
+
+    @JsonCreator
+    public WorkerTaskResult(
+        @JsonProperty("taskRun") TaskRun taskRun,
+        @JsonProperty("dynamicTaskRuns") List<TaskRun> dynamicTaskRuns,
+        @JsonProperty("outputs") Map<String, Object> outputs,
+        @JsonProperty("precedingResults") List<WorkerTaskResultPayload> precedingResults
+    ) {
+        this.taskRun = taskRun;
+        this.dynamicTaskRuns = dynamicTaskRuns;
+        this.outputs = outputs;
+        this.precedingResults = precedingResults == null ? List.of() : precedingResults;
+    }
+
+    public WorkerTaskResult withoutOutputs() {
+        return withOutputs(null).withPrecedingResults(precedingResults.stream().map(WorkerTaskResultPayload::withoutOutputs).toList());
     }
 
     /**
@@ -54,5 +80,23 @@ public class WorkerTaskResult implements DispatchEvent, HasUID {
     @Override
     public String key() {
         return uid();
+    }
+
+    public record WorkerTaskResultPayload(
+        @NotNull TaskRun taskRun,
+        List<TaskRun> dynamicTaskRuns,
+        @Nullable @JsonInclude(JsonInclude.Include.ALWAYS) Map<String, Object> outputs
+    ) {
+        public static WorkerTaskResultPayload from(WorkerTaskResult result) {
+            return new WorkerTaskResultPayload(result.getTaskRun(), result.getDynamicTaskRuns(), result.getOutputs());
+        }
+
+        public WorkerTaskResult toWorkerTaskResult() {
+            return new WorkerTaskResult(taskRun, dynamicTaskRuns, outputs);
+        }
+
+        public WorkerTaskResultPayload withoutOutputs() {
+            return new WorkerTaskResultPayload(taskRun, dynamicTaskRuns, null);
+        }
     }
 }

--- a/core/src/main/java/io/kestra/core/services/TaskOutputService.java
+++ b/core/src/main/java/io/kestra/core/services/TaskOutputService.java
@@ -72,6 +72,14 @@ public class TaskOutputService extends AbstractOutputService {
     }
 
     /**
+     * Returns whether outputs exist without reading their stored payload.
+     */
+    @SuppressWarnings("deprecation")
+    public boolean hasOutputs(TaskRun taskRun) {
+        return !MapUtils.isEmpty(taskRun.getOutputs()) || outputRepository.exists(taskRun.getTenantId(), taskRun.getId());
+    }
+
+    /**
      * Get the outputs of a task run. This method will read the outputs from the database or from the internal storage depending on where they are stored.
      */
     @SuppressWarnings("deprecation")

--- a/core/src/test/java/io/kestra/core/services/TaskOutputServiceTest.java
+++ b/core/src/test/java/io/kestra/core/services/TaskOutputServiceTest.java
@@ -168,6 +168,31 @@ class TaskOutputServiceTest {
     }
 
     @Test
+    @SuppressWarnings({"deprecation", "removal"})
+    void shouldDetectStoredAndLegacyInlineOutputs() throws InternalException {
+        String tenant = TestsUtils.randomTenant(this.getClass().getSimpleName());
+        TaskRun taskRun = TaskRun.builder()
+            .id(IdUtils.create())
+            .tenantId(tenant)
+            .executionId(IdUtils.create())
+            .namespace("io.kestra.test")
+            .flowId("test-flow")
+            .taskId("test-task")
+            .state(new State())
+            .build();
+
+        TaskRun taskRunWithEmptyInlineOutputs = taskRun.toBuilder().outputs(Map.of()).build();
+        assertThat(taskOutputService.hasOutputs(taskRun)).isFalse();
+        assertThat(taskOutputService.hasOutputs(taskRunWithEmptyInlineOutputs)).isFalse();
+
+        taskOutputService.saveOutputs(taskRun, Map.of("value", "stored"));
+
+        assertThat(taskOutputService.hasOutputs(taskRun)).isTrue();
+        assertThat(taskOutputService.hasOutputs(taskRunWithEmptyInlineOutputs)).isTrue();
+        assertThat(taskOutputService.hasOutputs(taskRun.toBuilder().id(IdUtils.create()).outputs(Map.of("value", "inline")).build())).isTrue();
+    }
+
+    @Test
     void saveOutputs_withTaskRunAndOutputInterface() throws InternalException {
         // Given
         String tenant = TestsUtils.randomTenant(this.getClass().getSimpleName());

--- a/executor/src/main/java/io/kestra/executor/handler/WorkerTaskResultMessageHandler.java
+++ b/executor/src/main/java/io/kestra/executor/handler/WorkerTaskResultMessageHandler.java
@@ -1,5 +1,6 @@
 package io.kestra.executor.handler;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
@@ -10,6 +11,7 @@ import io.kestra.core.killswitch.KillSwitchService;
 import io.kestra.core.models.executions.Execution;
 import io.kestra.core.runners.FlowMetaStoreInterface;
 import io.kestra.core.runners.WorkerTaskResult;
+import io.kestra.core.services.TaskOutputService;
 import io.kestra.executor.ExecutionStateStore;
 import io.kestra.executor.ExecutorContext;
 import io.kestra.executor.ExecutorMessageHandler;
@@ -29,6 +31,8 @@ public class WorkerTaskResultMessageHandler implements ExecutorMessageHandler<Wo
 
     private final FlowMetaStoreInterface flowMetaStore;
 
+    private final TaskOutputService taskOutputService;
+
     private final KillSwitchService killSwitchService;
     private final KillSwitchActionService killSwitchActionService;
 
@@ -39,12 +43,14 @@ public class WorkerTaskResultMessageHandler implements ExecutorMessageHandler<Wo
         ExecutionStateStore executionStateStore,
         ExecutorService executorService,
         FlowMetaStoreInterface flowMetaStore,
+        TaskOutputService taskOutputService,
         KillSwitchService killSwitchService,
         KillSwitchActionService killSwitchActionService,
         List<WorkerTaskResultListener> workerTaskResultListeners) {
         this.executionStateStore = executionStateStore;
         this.executorService = executorService;
         this.flowMetaStore = flowMetaStore;
+        this.taskOutputService = taskOutputService;
         this.killSwitchService = killSwitchService;
         this.killSwitchActionService = killSwitchActionService;
         this.workerTaskResultListeners = workerTaskResultListeners;
@@ -65,39 +71,67 @@ public class WorkerTaskResultMessageHandler implements ExecutorMessageHandler<Wo
             executorService.log(log, true, message);
         }
 
+        List<JoinedWorkerTaskResult> joinedResults = new ArrayList<>();
         Optional<ExecutorContext> result = executionStateStore.lock(message.getTaskRun().getExecutionId(), execution ->
         {
             ExecutorContext current = new ExecutorContext(execution);
 
-            if (execution.hasTaskRunJoinable(message.getTaskRun())) {
-                try {
-                    // process worker task result
-                    executorService.addWorkerTaskResult(
-                        current,
-                        () -> flowMetaStore.findByExecutionForRuntime(execution).orElseThrow(() -> new FlowNotFoundException(execution)),
-                        message
-                    );
-                    // join worker result
-                    return current;
-                } catch (InternalException e) {
-                    return executorService.handleFailedExecutionFromExecutor(current, e);
-                } catch (FlowNotFoundException e) {
-                    // avoid infinite for FlowNotFoundException
-                    if (!current.getExecution().getState().getCurrent().isFailed()) {
-                        return executorService.handleFailedExecutionFromExecutor(current, e);
-                    }
+            try {
+                for (WorkerTaskResult.WorkerTaskResultPayload precedingResult : message.getPrecedingResults()) {
+                    joinIfPossible(current, execution, precedingResult.toWorkerTaskResult(), joinedResults);
                 }
+                joinIfPossible(current, execution, message, joinedResults);
+                return joinedResults.isEmpty() ? null : current;
+            } catch (InternalException e) {
+                ExecutorContext failed = executorService.handleFailedExecutionFromExecutor(current, e);
+                updateLastJoinedExecution(joinedResults, failed.getExecution());
+                return failed;
+            } catch (FlowNotFoundException e) {
+                if (!current.getExecution().getState().getCurrent().isFailed()) {
+                    ExecutorContext failed = executorService.handleFailedExecutionFromExecutor(current, e);
+                    updateLastJoinedExecution(joinedResults, failed.getExecution());
+                    return failed;
+                }
+                return null;
             }
-
-            return null;
         });
 
-        // a present result means the taskrun was joined here (redeliveries come back empty): notify listeners once
         if (result.isPresent()) {
-            notifyJoined(message, result.get().getExecution());
+            joinedResults.forEach(joined -> notifyJoined(joined.result(), joined.execution()));
         }
 
         return result;
+    }
+
+    private void joinIfPossible(
+        ExecutorContext current,
+        Execution execution,
+        WorkerTaskResult message,
+        List<JoinedWorkerTaskResult> joinedResults
+    ) throws InternalException, FlowNotFoundException {
+        if (current.getExecution().hasTaskRunJoinable(message.getTaskRun())) {
+            int joinedResultIndex = joinedResults.size();
+            joinedResults.add(new JoinedWorkerTaskResult(message, current.getExecution()));
+            executorService.addWorkerTaskResult(
+                current,
+                () -> flowMetaStore.findByExecutionForRuntime(execution).orElseThrow(() -> new FlowNotFoundException(execution)),
+                message
+            );
+            joinedResults.set(joinedResultIndex, new JoinedWorkerTaskResult(message, current.getExecution()));
+        } else if (
+            message.getOutputs() != null &&
+                !message.getOutputs().isEmpty() &&
+                !taskOutputService.hasOutputs(message.getTaskRun())
+        ) {
+            taskOutputService.saveOutputs(message.getTaskRun(), message.getOutputs());
+        }
+    }
+
+    private void updateLastJoinedExecution(List<JoinedWorkerTaskResult> joinedResults, Execution execution) {
+        if (!joinedResults.isEmpty()) {
+            int lastIndex = joinedResults.size() - 1;
+            joinedResults.set(lastIndex, new JoinedWorkerTaskResult(joinedResults.get(lastIndex).result(), execution));
+        }
     }
 
     private void notifyJoined(WorkerTaskResult message, Execution execution) {
@@ -108,5 +142,8 @@ public class WorkerTaskResultMessageHandler implements ExecutorMessageHandler<Wo
                 log.error("Worker task result listener {} failed", listener.getClass().getName(), e);
             }
         }
+    }
+
+    private record JoinedWorkerTaskResult(WorkerTaskResult result, Execution execution) {
     }
 }

--- a/executor/src/test/java/io/kestra/executor/handler/WorkerTaskResultMessageHandlerTest.java
+++ b/executor/src/test/java/io/kestra/executor/handler/WorkerTaskResultMessageHandlerTest.java
@@ -11,13 +11,18 @@ import io.kestra.core.killswitch.EvaluationType;
 import io.kestra.core.killswitch.KillSwitchService;
 import io.kestra.core.models.executions.Execution;
 import io.kestra.core.models.executions.TaskRun;
+import io.kestra.core.models.flows.Flow;
 import io.kestra.core.models.flows.GenericFlow;
 import io.kestra.core.models.flows.State;
+import io.kestra.core.models.property.Property;
 import io.kestra.core.repositories.ExecutionRepositoryInterface;
 import io.kestra.core.repositories.FlowRepositoryInterface;
 import io.kestra.core.runners.WorkerTaskResult;
+import io.kestra.core.services.TaskOutputService;
 import io.kestra.executor.ExecutorContext;
 import io.kestra.executor.KillSwitchActionService;
+import io.kestra.plugin.core.debug.Return;
+import io.kestra.plugin.core.flow.WorkingDirectory;
 
 import io.micronaut.test.annotation.MockBean;
 import jakarta.inject.Inject;
@@ -51,6 +56,9 @@ class WorkerTaskResultMessageHandlerTest {
 
     @Inject
     WorkerTaskResultListener workerTaskResultListener;
+
+    @Inject
+    TaskOutputService taskOutputService;
 
     @MockBean(KillSwitchService.class)
     KillSwitchService killSwitchService() {
@@ -178,6 +186,84 @@ class WorkerTaskResultMessageHandlerTest {
     }
 
     @Test
+    @SuppressWarnings({"deprecation", "removal"})
+    void shouldRestoreOutputsFromDuplicateAfterJoiningStrippedAggregate() throws Exception {
+        var childTask = Return.builder()
+            .id("s1")
+            .type(Return.class.getName())
+            .format(Property.ofValue("value"))
+            .build();
+        var workingDirectory = WorkingDirectory.builder()
+            .id("workingDirectory")
+            .type(WorkingDirectory.class.getName())
+            .tasks(Collections.singletonList(childTask))
+            .build();
+        var flow = flowRepository.create(GenericFlow.of(Flow.builder()
+            .tenantId("tenant")
+            .namespace("namespace")
+            .id("flow")
+            .tasks(Collections.singletonList(workingDirectory))
+            .build()));
+        var execution = Execution.newExecution(flow, Collections.emptyList());
+        var parentTaskRun = TaskRun.builder()
+            .tenantId(execution.getTenantId())
+            .executionId(execution.getId())
+            .namespace(execution.getNamespace())
+            .flowId(execution.getFlowId())
+            .id("parent-run")
+            .taskId(workingDirectory.getId())
+            .state(new State().withState(State.Type.RUNNING))
+            .build();
+        executionRepository.save(execution.withTaskRunList(Collections.singletonList(parentTaskRun)));
+        var childTaskRun = TaskRun.builder()
+            .tenantId(execution.getTenantId())
+            .executionId(execution.getId())
+            .namespace(execution.getNamespace())
+            .flowId(execution.getFlowId())
+            .id("child-run")
+            .taskId(childTask.getId())
+            .parentTaskRunId(parentTaskRun.getId())
+            .state(new State().withState(State.Type.SUCCESS))
+            .build();
+        var childResult = new WorkerTaskResult(childTaskRun, Collections.singletonMap("value", "s1"));
+        var strippedChildResult = childResult.withOutputs(null);
+        var parentFailure = new WorkerTaskResult(
+            parentTaskRun.withState(State.Type.FAILED),
+            Collections.emptyList(),
+            null,
+            Collections.singletonList(WorkerTaskResult.WorkerTaskResultPayload.from(strippedChildResult))
+        );
+
+        var maybeExecutor = workerTaskResultMessageHandler.handle(parentFailure);
+
+        assertThat(maybeExecutor).isPresent();
+        assertThat(maybeExecutor.get().getExecution().getTaskRunList())
+            .extracting(TaskRun::getId)
+            .containsExactly(parentTaskRun.getId(), childTaskRun.getId());
+        assertThat(maybeExecutor.get().getExecution().findTaskRunByTaskRunId(parentTaskRun.getId()).getState().getCurrent())
+            .isEqualTo(State.Type.FAILED);
+        assertThat(taskOutputService.getOutputs(childTaskRun)).isEmpty();
+        State.Type executionState = maybeExecutor.get().getExecution().getState().getCurrent();
+        verify(workerTaskResultListener).onJoined(eq(strippedChildResult), any());
+        verify(workerTaskResultListener).onJoined(eq(parentFailure), any());
+
+        assertThat(workerTaskResultMessageHandler.handle(childResult)).isEmpty();
+        assertThat(taskOutputService.getOutputs(childTaskRun)).containsEntry("value", "s1");
+        verify(workerTaskResultListener, times(1)).onJoined(eq(strippedChildResult), any());
+        verify(workerTaskResultListener, never()).onJoined(eq(childResult), any());
+
+        var replacement = childResult
+            .withTaskRun(childTaskRun.toBuilder().outputs(Collections.emptyMap()).build())
+            .withOutputs(Collections.singletonMap("value", "replacement"));
+        assertThat(workerTaskResultMessageHandler.handle(replacement)).isEmpty();
+        assertThat(taskOutputService.getOutputs(childTaskRun)).containsEntry("value", "s1");
+        var persistedExecution = executionRepository.findById(execution.getTenantId(), execution.getId()).orElseThrow();
+        assertThat(persistedExecution.getState().getCurrent()).isEqualTo(executionState);
+        assertThat(persistedExecution.getTaskRunList()).hasSize(2);
+        verify(workerTaskResultListener, never()).onJoined(eq(replacement), any());
+    }
+
+    @Test
     void shouldFailTheExecutionForMissingTask() {
         var flow = Fixtures.flow();
         flowRepository.create(GenericFlow.of(flow));
@@ -197,6 +283,7 @@ class WorkerTaskResultMessageHandlerTest {
 
         assertThat(maybeExecutor).isPresent();
         assertThat(maybeExecutor.get().getExecution().getState().getCurrent()).isEqualTo(State.Type.FAILED);
+        verify(workerTaskResultListener).onJoined(eq(workerTaskResult), any());
     }
 
     @Test

--- a/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcTaskOutputRepository.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcTaskOutputRepository.java
@@ -38,6 +38,19 @@ public class AbstractJdbcTaskOutputRepository extends io.kestra.jdbc.repository.
     }
 
     @Override
+    public boolean exists(String tenantId, String taskRunId) {
+        return jdbcRepository
+            .getDslContextWrapper()
+            .transactionResult(
+                configuration -> DSL.using(configuration)
+                    .fetchExists(
+                        jdbcRepository.getTable(),
+                        buildTenantCondition(tenantId).and(TASK_RUN_ID_FIELD.eq(taskRunId))
+                    )
+            );
+    }
+
+    @Override
     public Optional<TaskOutput> findById(String tenantId, String taskRunId) {
         var condition = TASK_RUN_ID_FIELD.eq(taskRunId);
         return this.jdbcRepository

--- a/worker-controller/src/main/java/io/kestra/controller/grpc/services/GrpcWorkerControllerService.java
+++ b/worker-controller/src/main/java/io/kestra/controller/grpc/services/GrpcWorkerControllerService.java
@@ -206,15 +206,15 @@ public class GrpcWorkerControllerService extends WorkerControllerServiceGrpc.Wor
             } catch (QueueException e) {
                 // If there is a QueueException it can either be caused by the message limit or another queue issue.
                 // We fail the task and try to resend it.
-                WorkerTaskResult failed = new WorkerTaskResult(workerTaskResult.getTaskRun().fail(), workerTaskResult.getOutputs());
+                WorkerTaskResult failed = workerTaskResult.withTaskRun(workerTaskResult.getTaskRun().fail());
                 if (e instanceof MessageTooBigException) {
                     // If it's a message too big, we remove the outputs
-                    failed = failed.withOutputs(null);
+                    failed = failed.withoutOutputs();
                 }
                 if (e instanceof UnsupportedMessageException) {
                     // Unsupported queue payloads are most likely caused by a bad output value,
                     // so retry without outputs instead of crashing the worker/controller loop.
-                    failed = failed.withOutputs(null);
+                    failed = failed.withoutOutputs();
                 }
                 RunContextLogger contextLogger = runContextLoggerFactory.create(workerTaskResult);
                 contextLogger.logger().error("Unable to emit the worker task result to the queue: {}", e.getMessage(), e);

--- a/worker/src/main/java/io/kestra/worker/processors/WorkerTaskProcessor.java
+++ b/worker/src/main/java/io/kestra/worker/processors/WorkerTaskProcessor.java
@@ -35,6 +35,7 @@ import io.kestra.core.models.tasks.AssetFailureBehavior;
 import io.kestra.core.models.tasks.RunnableTask;
 import io.kestra.core.models.tasks.Task;
 import io.kestra.core.runners.*;
+import io.kestra.core.runners.WorkerTaskResult.WorkerTaskResultPayload;
 import io.kestra.core.serializers.JacksonMapper;
 import io.kestra.core.server.ServerConfig;
 import io.kestra.core.server.WorkerTaskRestartStrategy;
@@ -109,6 +110,7 @@ public class WorkerTaskProcessor extends AbstractWorkerJobProcessor<WorkerTask> 
     private void runWorkingDirectory(WorkerTask workerTask, WorkingDirectory workingDirectory) {
         DefaultRunContext runContext = runContextInitializer.forWorkingDirectory(workerTask);
         final RunContext workingDirectoryRunContext = runContext.clone();
+        List<WorkerTaskResultPayload> precedingResults = new ArrayList<>();
 
         try {
             // preExecuteTasks
@@ -151,7 +153,13 @@ public class WorkerTaskProcessor extends AbstractWorkerJobProcessor<WorkerTask> 
                 } catch (IllegalVariableEvaluationException e) {
                     RunContextLogger contextLogger = runContextLoggerFactory.create(currentWorkerTask);
                     contextLogger.logger().error("Failed evaluating runIf: {}", e.getMessage(), e);
-                    workerTaskResultQueue.put(new WorkerTaskResult(workerTask.fail()));
+                    workerTaskResultQueue.put(
+                        new WorkerTaskResult(workerTask.fail(), new ArrayList<>(1), null, List.copyOf(precedingResults))
+                    );
+                }
+
+                if (workerTaskResult != null) {
+                    precedingResults.add(WorkerTaskResultPayload.from(workerTaskResult));
                 }
 
                 if (workerTaskResult == null || workerTaskResult.getTaskRun().getState().isFailed() && !currentWorkerTask.getTask().isAllowFailure()) {
@@ -167,7 +175,9 @@ public class WorkerTaskProcessor extends AbstractWorkerJobProcessor<WorkerTask> 
                 workingDirectory.postExecuteTasks(workingDirectoryRunContext, workerTask.getTaskRun());
             } catch (Exception e) {
                 workingDirectoryRunContext.logger().error("Failed postExecuteTasks on WorkingDirectory: {}", e.getMessage(), e);
-                workerTaskResultQueue.put(new WorkerTaskResult(workerTask.fail()));
+                workerTaskResultQueue.put(
+                    new WorkerTaskResult(workerTask.fail(), new ArrayList<>(1), null, List.copyOf(precedingResults))
+                );
             }
             this.logTerminated(workerTask, workerTask.getTaskRun());
         } finally {

--- a/worker/src/main/java/io/kestra/worker/senders/GrpcWorkerIOSenderFactory.java
+++ b/worker/src/main/java/io/kestra/worker/senders/GrpcWorkerIOSenderFactory.java
@@ -54,7 +54,7 @@ public class GrpcWorkerIOSenderFactory {
             {
                 Logs.logTaskRun(result.getTaskRun(), Level.ERROR, RESULT_TOO_LARGE_MESSAGE);
                 logEntryEmitter.emits(taskRunLogEntry(result.getTaskRun(), RESULT_TOO_LARGE_MESSAGE));
-                return result.withTaskRun(result.getTaskRun().withStateAndAttempt(State.Type.FAILED)).withOutputs(null);
+                return result.withTaskRun(result.getTaskRun().withStateAndAttempt(State.Type.FAILED)).withoutOutputs();
             },
             // Task results must survive a transient network partition: re-queue and redrive rather than
             // drop, otherwise a completed task is left stuck RUNNING because its result is lost.

--- a/worker/src/test/java/io/kestra/worker/processors/WorkerTaskProcessorTest.java
+++ b/worker/src/test/java/io/kestra/worker/processors/WorkerTaskProcessorTest.java
@@ -36,6 +36,8 @@ import io.kestra.core.trace.TracerFactory;
 import io.kestra.core.utils.IdUtils;
 import io.kestra.core.utils.TestsUtils;
 import io.kestra.core.worker.WorkerGroups;
+import io.kestra.plugin.core.debug.Return;
+import io.kestra.plugin.core.flow.WorkingDirectory;
 import io.kestra.worker.WorkerSecurityService;
 import io.kestra.worker.queues.InMemoryWorkerQueue;
 import io.kestra.worker.queues.WorkerQueue;
@@ -48,12 +50,6 @@ import lombok.experimental.SuperBuilder;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-/**
- * Component-level tests for {@link WorkerTaskProcessor}'s behavior when the worker is shutting down,
- * covering the regression from <a href="https://github.com/kestra-io/kestra/issues/17124">#17124</a>:
- * a task that fails on its own during the termination grace period must still have its terminal
- * result emitted, while a task the shutdown actually interrupted is deferred for resubmission.
- */
 @KestraTest
 class WorkerTaskProcessorTest {
 
@@ -83,6 +79,61 @@ class WorkerTaskProcessorTest {
 
     @Inject
     private DispatchQueueInterface<LogEntry> logQueue;
+
+    @Test
+    void shouldAttachCompletedSubtaskWhenWorkingDirectoryRunIfIsInvalid() throws Exception {
+        InMemoryWorkerQueue<WorkerTaskResult> resultQueue = new InMemoryWorkerQueue<>(100);
+        WorkerTaskProcessor processor = newProcessor(resultQueue);
+        WorkingDirectory workingDirectory = WorkingDirectory.builder()
+            .id("workingDirectory")
+            .type(WorkingDirectory.class.getName())
+            .tasks(List.of(
+                Return.builder().id("s1").type(Return.class.getName()).format(Property.ofValue("one")).build(),
+                Return.builder().id("s2").type(Return.class.getName()).runIf("{{ outputs.missing }}").format(Property.ofValue("two")).build()
+            ))
+            .build();
+        WorkerTask workerTask = workerTaskFor(workingDirectory);
+
+        processor.process(workerTask);
+
+        WorkerTaskResult parentFailure = drain(resultQueue).stream()
+            .filter(result -> result.getTaskRun().getId().equals(workerTask.getTaskRun().getId()) && result.getTaskRun().getState().isFailed())
+            .findFirst()
+            .orElseThrow();
+        assertThat(parentFailure.getPrecedingResults()).singleElement().satisfies(result ->
+        {
+            assertThat(result.taskRun().getTaskId()).isEqualTo("s1");
+            assertThat(result.taskRun().getState().getCurrent()).isEqualTo(State.Type.SUCCESS);
+            assertThat(result.outputs()).isNotEmpty();
+        });
+    }
+
+    @Test
+    void shouldAttachCompletedSubtasksWhenWorkingDirectoryPostExecuteFails() throws Exception {
+        InMemoryWorkerQueue<WorkerTaskResult> resultQueue = new InMemoryWorkerQueue<>(100);
+        WorkerTaskProcessor processor = newProcessor(resultQueue);
+        WorkingDirectory workingDirectory = FailingPostWorkingDirectory.builder()
+            .id("workingDirectory")
+            .type(FailingPostWorkingDirectory.class.getName())
+            .tasks(List.of(
+                Return.builder().id("s1").type(Return.class.getName()).format(Property.ofValue("one")).build(),
+                Return.builder().id("s2").type(Return.class.getName()).format(Property.ofValue("two")).build()
+            ))
+            .build();
+        WorkerTask workerTask = workerTaskFor(workingDirectory);
+
+        processor.process(workerTask);
+
+        WorkerTaskResult parentFailure = drain(resultQueue).stream()
+            .filter(result -> result.getTaskRun().getId().equals(workerTask.getTaskRun().getId()) && result.getTaskRun().getState().isFailed())
+            .findFirst()
+            .orElseThrow();
+        assertThat(parentFailure.getPrecedingResults())
+            .extracting(result -> result.taskRun().getTaskId())
+            .containsExactly("s1", "s2");
+        assertThat(parentFailure.getPrecedingResults())
+            .allSatisfy(result -> assertThat(result.taskRun().getState().getCurrent()).isEqualTo(State.Type.SUCCESS));
+    }
 
     @Test
     void shouldEmitFailedResultWhenTaskFailsOnItsOwnDuringShutdownDrain() throws Exception {
@@ -351,6 +402,16 @@ class WorkerTaskProcessorTest {
      * emitting a malformed asset. Constructed and executed directly by the processor, so no plugin
      * registration is needed.
      */
+    @SuperBuilder
+    @Getter
+    @NoArgsConstructor
+    public static class FailingPostWorkingDirectory extends WorkingDirectory {
+        @Override
+        public void postExecuteTasks(RunContext runContext, TaskRun taskRun) {
+            throw new RuntimeException("simulated postExecuteTasks failure");
+        }
+    }
+
     @SuperBuilder
     @Getter
     @NoArgsConstructor

--- a/worker/src/test/java/io/kestra/worker/senders/GrpcWorkerIOSenderTest.java
+++ b/worker/src/test/java/io/kestra/worker/senders/GrpcWorkerIOSenderTest.java
@@ -122,7 +122,13 @@ class GrpcWorkerIOSenderTest {
         TaskRun taskRun = buildTaskResult(Map.of()).getTaskRun()
             .withAttempts(List.of(TaskRunAttempt.builder().state(new State().withState(State.Type.SUCCESS)).build()))
             .withState(State.Type.SUCCESS);
-        WorkerTaskResult large = new WorkerTaskResult(taskRun, Map.of("output", new String(largePayload)));
+        WorkerTaskResult preceding = buildTaskResult(Map.of("child", "value"));
+        WorkerTaskResult large = new WorkerTaskResult(
+            taskRun,
+            List.of(),
+            Map.of("output", new String(largePayload)),
+            List.of(WorkerTaskResult.WorkerTaskResultPayload.from(preceding))
+        );
 
         taskResultSender.send(List.of(large));
 
@@ -137,6 +143,7 @@ class GrpcWorkerIOSenderTest {
         assertThat(received.getTaskRun().getId()).isEqualTo(large.getTaskRun().getId());
         assertThat(received.getTaskRun().getState().getCurrent()).isEqualTo(State.Type.FAILED);
         assertThat(received.getOutputs()).isNull();
+        assertThat(received.getPrecedingResults()).singleElement().satisfies(result -> assertThat(result.outputs()).isNull());
         assertThat(received.getTaskRun().getAttempts()).hasSize(1);
         assertThat(received.getTaskRun().lastAttempt().getState().getCurrent()).isEqualTo(State.Type.FAILED);
 


### PR DESCRIPTION
## Title

`fix(executions): preserve working directory subtask results on failure`

## Body

Closes https://github.com/kestra-io/kestra/issues/18917.

### 🔗 Related Issue

A `WorkingDirectory` parent failure can overtake results from subtasks that already finished, exposing a terminal execution with an incomplete task-run list.

### ✨ Description

This change attaches preceding subtask results to applicable `WorkingDirectory` parent failures and joins them atomically before the parent result. It preserves subtask state and outputs when an invalid `runIf` or `postExecuteTasks` failure is delivered first, while keeping duplicate delivery idempotent.

Transport fallbacks continue to remove unsupported output payloads. If the original result arrives later with valid outputs, those outputs are restored without rejoining the task run, changing execution state, or notifying listeners twice.

### 🛠️ Backend Checklist

- [x] Code compiles and tests pass for the touched modules (`./gradlew :module-name:test`, or `./gradlew build` for cross-module changes)
- [x] New behavior is covered by unit or integration tests

### 📝 Additional Notes

`preExecuteTasks` has no preceding subtask result to aggregate. The successful `postExecuteTasks` timing tracked by #13134 remains unchanged; this fix is limited to the parent-failure paths in #18917.

Validated with focused Core, Executor, and Worker tests, Worker Controller compilation, and the mandatory `H2RunnerTest` suite.
