### PR TITLE
fix(dashboards): exclude disabled triggers from next executions chart 

### DIFF
--- a/core/src/main/java/io/kestra/plugin/core/dashboard/data/ITriggers.java
+++ b/core/src/main/java/io/kestra/plugin/core/dashboard/data/ITriggers.java
@@ -45,6 +45,7 @@ public interface ITriggers extends IData<ITriggers.Fields> {
         TRIGGER_ID,
         EXECUTION_ID,
         NEXT_EXECUTION_DATE,
-        WORKER_ID
+        WORKER_ID, 
+        DISABLED
     }
 }

--- a/core/src/main/resources/dashboards/default_main_definition.yaml
+++ b/core/src/main/resources/dashboards/default_main_definition.yaml
@@ -162,6 +162,10 @@ charts:
       width: 6
     data:
       type: io.kestra.plugin.core.dashboard.data.Triggers
+      where:
+        - field: DISABLED
+          type: EQUAL_TO
+          value: false
       columns:
         namespace:
           field: NAMESPACE

--- a/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcTriggerRepository.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcTriggerRepository.java
@@ -57,7 +57,8 @@ public abstract class AbstractJdbcTriggerRepository extends AbstractJdbcCrudRepo
         Triggers.Fields.TRIGGER_ID, "trigger_id",
         Triggers.Fields.EXECUTION_ID, "execution_id",
         Triggers.Fields.NEXT_EXECUTION_DATE, NEXT_EVALUATION_DATE_COLUMN,
-        Triggers.Fields.WORKER_ID, WORKER_ID_FIELD.getName()
+        Triggers.Fields.WORKER_ID, WORKER_ID_FIELD.getName(),
+        Triggers.Fields.DISABLED, "disabled"
     );
 
     @Override

--- a/webserver/src/test/java/io/kestra/webserver/controllers/api/DashboardControllerTest.java
+++ b/webserver/src/test/java/io/kestra/webserver/controllers/api/DashboardControllerTest.java
@@ -22,6 +22,8 @@ import io.kestra.core.models.flows.State;
 import io.kestra.core.repositories.ExecutionRepositoryInterface;
 import io.kestra.core.repositories.LogDataStoreInterface;
 import io.kestra.core.utils.IdUtils;
+import io.kestra.core.scheduler.model.TriggerState;
+import io.kestra.core.scheduler.store.TriggerStateStore;
 import io.kestra.core.utils.TestsUtils;
 import io.kestra.webserver.models.ChartFiltersOverrides;
 import io.kestra.webserver.responses.PagedResults;
@@ -56,6 +58,9 @@ class DashboardControllerTest {
 
     @Inject
     ExecutionRepositoryInterface executionRepository;
+
+    @Inject
+    TriggerStateStore triggerStateStore;
 
     @Test
     void shouldExportAnAdHocPreviewChartToCsv() {
@@ -208,6 +213,7 @@ class DashboardControllerTest {
                 )
             ).build()
         );
+        
         PagedResults<Map<String, Object>> chartData = client.toBlocking().retrieve(
             POST(DASHBOARD_PATH + "/charts/preview", previewRequest),
             PagedResults.class
@@ -215,6 +221,65 @@ class DashboardControllerTest {
         assertThat(chartData).isNotNull();
         assertThat(chartData.getTotal()).isEqualTo(1);
         assertThat(chartData.getResults().get(0).get("execution_id")).isEqualTo(idForLabelAC);
+    }
+
+    @Test
+    void shouldExcludeDisabledTriggersFromNextExecutionsChart() {
+        String namespace = TestsUtils.randomNamespace();
+
+        String enabledTriggerId = IdUtils.create();
+        triggerStateStore.save(
+            TriggerState.builder()
+                .tenantId(MAIN_TENANT)
+                .namespace(namespace)
+                .flowId("flow")
+                .triggerId(enabledTriggerId)
+                .workerId("worker")
+                .nextEvaluationDate(Instant.now())
+                .disabled(false)
+                .build()
+        );
+
+        String disabledTriggerId = IdUtils.create();
+        triggerStateStore.save(
+            TriggerState.builder()
+                .tenantId(MAIN_TENANT)
+                .namespace(namespace)
+                .flowId("flow")
+                .triggerId(disabledTriggerId)
+                .workerId("worker")
+                .nextEvaluationDate(Instant.now())
+                .disabled(true)
+                .build()
+        );
+
+        String chartYaml = """
+            id: table_next_executions_chart_id
+            type: io.kestra.plugin.core.dashboard.chart.Table
+            data:
+              type: io.kestra.plugin.core.dashboard.data.Triggers
+              columns:
+                trigger_id:
+                  field: TRIGGER_ID
+              where:
+                - field: NAMESPACE
+                  type: EQUAL_TO
+                  value: "%s"
+                - field: DISABLED
+                  type: EQUAL_TO
+                  value: false
+            """.formatted(namespace);
+
+        var previewRequest = new DashboardController.PreviewRequest(chartYaml, null);
+
+        PagedResults<Map<String, Object>> chartData = client.toBlocking().retrieve(
+            POST(DASHBOARD_PATH + "/charts/preview", previewRequest),
+            PagedResults.class
+        );
+
+        assertThat(chartData).isNotNull();
+        assertThat(chartData.getTotal()).isEqualTo(1);
+        assertThat(chartData.getResults().get(0).get("trigger_id")).isEqualTo(enabledTriggerId);
     }
 
     @Test


### PR DESCRIPTION
### 🔗 Related Issue

Closes https://github.com/kestra-io/kestra/issues/19012. 

###Description

Disabled schedule triggers were still showing up in the "Next Executions" chart 
on the main dashboard. The trigger's `disabled` state was already being persisted 
as a generated column on the `triggers` table (H2, MySQL, and Postgres all already 
carry it via their baseline schema), and `default_main_definition.yaml` already 
referenced a `DISABLED` filter on that chart — but the field was never declared on 
`ITriggers.Fields` or mapped to an actual column in the JDBC repository, so the 
filter had no effect.

This PR:
- Adds `DISABLED` to `ITriggers.Fields`
- Maps `Triggers.Fields.DISABLED` to the existing `disabled` column in 
  `AbstractJdbcTriggerRepository`
- Applies a `DISABLED: false` filter on the Next Executions chart definition

No schema migration is needed; the `disabled` column already exists in every 
backend's baseline schema, so this is purely a mapping/query-layer fix.

### Backend Checklist

- [x] Code compiles and tests pass for the touched modules (`./gradlew :webserver:test`)
- [x] New behavior is covered by unit or integration tests

### Additional Notes

Added a regression test, `DashboardControllerTest#shouldExcludeDisabledTriggersFromNextExecutionsChart`, 
that persists one enabled and one disabled trigger in the same namespace and asserts 
only the enabled trigger's ID is returned by the chart query.