### PR TITLE
fix(core): prevent UID collisions in IdUtils.fromParts

### DIFF
--- a/core/src/main/java/io/kestra/core/utils/IdUtils.java
+++ b/core/src/main/java/io/kestra/core/utils/IdUtils.java
@@ -11,7 +11,6 @@ import com.google.common.hash.Hashing;
 @SuppressWarnings({ "deprecation" })
 abstract public class IdUtils {
     private static final HashFunction HASH_FUNCTION = Hashing.md5();
-    private static final char ID_SEPARATOR = '_';
 
     public static String create() {
         return FriendlyId.createFriendlyId();
@@ -25,8 +24,30 @@ abstract public class IdUtils {
         );
     }
 
+    /**
+     * Produces a collision-safe identifier from the given parts.
+     *
+     * <p>Each non-null part is length-prefixed ({@code length:content}) so that
+     * different logical part arrays always produce different output, regardless of
+     * what characters appear inside individual parts.  For example,
+     * {@code fromParts("team", "x_y")} and {@code fromParts("team_x", "y")}
+     * produce distinct strings — a guarantee that a plain separator-based join
+     * cannot provide when parts may contain the separator character.
+     *
+     * <p>Null parts are silently skipped, so
+     * {@code fromParts(null, "a", "b")} equals {@code fromParts("a", "b")}.
+     *
+     * @param parts the parts to encode
+     * @return a collision-safe identifier string
+     */
     public static String fromParts(String... parts) {
-        return fromPartsAndSeparator(ID_SEPARATOR, parts);
+        StringBuilder sb = new StringBuilder();
+        for (String str : parts) {
+            if (str != null) {
+                sb.append(str.length()).append(':').append(str);
+            }
+        }
+        return sb.toString();
     }
 
     public static String fromPartsAndSeparator(char separator, String... parts) {

--- a/core/src/test/java/io/kestra/core/utils/IdUtilsTest.java
+++ b/core/src/test/java/io/kestra/core/utils/IdUtilsTest.java
@@ -29,11 +29,29 @@ class IdUtilsTest {
     void fromParts() {
         String id = IdUtils.fromParts("namespace", "flow");
         assertThat(id).isNotNull();
-        assertThat(id).isEqualTo("namespace_flow");
+        assertThat(id).isEqualTo("9:namespace4:flow");
 
         String idWithNull = IdUtils.fromParts(null, "namespace", "flow");
         assertThat(idWithNull).isNotNull();
-        assertThat(idWithNull).isEqualTo("namespace_flow");
+        assertThat(idWithNull).isEqualTo("9:namespace4:flow");
+    }
+
+    @Test
+    void shouldNotCollidWhenPartsContainSeparator() {
+        assertThat(IdUtils.fromParts("team", "x_y"))
+            .isNotEqualTo(IdUtils.fromParts("team_x", "y"));
+    }
+
+    @Test
+    void shouldSkipNullPartsIdentically() {
+        assertThat(IdUtils.fromParts(null, "namespace", "flow"))
+            .isEqualTo(IdUtils.fromParts("namespace", "flow"));
+
+        assertThat(IdUtils.fromParts("tenant", null, "namespace"))
+            .isEqualTo(IdUtils.fromParts("tenant", "namespace"));
+
+        assertThat(IdUtils.fromParts(null, null, "only"))
+            .isEqualTo(IdUtils.fromParts("only"));
     }
 
     @Test


### PR DESCRIPTION
Fixes #19015

## Problem
`IdUtils.fromParts()` joined parts with a plain `_` separator with no escaping. Since parts themselves can contain `_`, different logical inputs could produce the same UID e.g. `("team", "x_y")` and `("team_x", "y")` both collapsed to `team_x_y`.

## Fix
`fromParts()` now length-prefixes each part (`{length}:{content}`) before concatenating, instead of joining with a separator. Since the decoder always knows exactly how many characters belong to each part, no character inside a part can be mistaken for a boundary, two different part arrays can never produce the same output.

- Method signature is unchanged, so none of the ~30 existing call sites needed modification.
- `fromPartsAndSeparator()` is untouched `ConcurrencyLimit`, `ExecutionRunning`, and `AbstractJdbcConcurrencyLimitStateStore` continue using `|` exactly as before.
- Null-part-skipping behavior is preserved identically.

## Tests
Added to `IdUtilsTest`:
- `shouldNotCollidWhenPartsContainSeparator()` - asserts `fromParts("team", "x_y") != fromParts("team_x", "y")`
- `shouldSkipNullPartsIdentically()` - confirms null parts at any position are still skipped
- Updated the existing `fromParts()` test to reflect the new output format

All tests pass (`./gradlew :core:test --tests "io.kestra.core.utils.IdUtilsTest"` - 7/7 green).

## Note on scope
This changes `fromParts()`'s *output format*, which means any UID already persisted using the old `_`-joined format will no longer match on re-computation. As discussed on the issue, this PR intentionally keeps scope narrow (fixing the encoding itself) a data migration for already-persisted UIDs, if needed, would be a separate follow-up per domain.