### PR TITLE
fix(design-system): apply-to option highlight in the interval filter

### DIFF
--- a/ui/packages/design-system/src/components/Data/KsDataTable/filter/layout/FilterSelect.vue
+++ b/ui/packages/design-system/src/components/Data/KsDataTable/filter/layout/FilterSelect.vue
@@ -159,7 +159,7 @@
     }
 
     .date-filter-section {
-        border-top: 1px solid var(--ks-border-primary);
+        border-top: 1px solid var(--ks-border-default);
         padding-top: 0.75rem;
 
         .form-label {
@@ -177,9 +177,9 @@
         }
 
         .date-filter-option {
-            background: var(--ks-background-body);
-            border: 1px solid var(--ks-border-primary);
-            border-radius: var(--ks-border-radius-sm);
+            background: var(--ks-bg-surface);
+            border: 1px solid var(--ks-border-default);
+            border-radius: var(--ks-radius-sm);
             color: var(--ks-text-primary);
             cursor: pointer;
             font-size: var(--ks-font-size-xs);
@@ -188,13 +188,13 @@
             transition: background 0.15s, border-color 0.15s;
 
             &:hover {
-                background: var(--ks-background-card);
+                background: var(--ks-bg-hover);
             }
 
             &.active {
-                background: var(--ks-background-card);
-                border-color: var(--ks-primary);
-                color: var(--ks-primary);
+                background: var(--ks-bg-tag-active);
+                border-color: var(--ks-border-focus);
+                color: var(--ks-text-link);
             }
         }
     }

--- a/ui/packages/design-system/tests/storybook/Data/KsDataTable.stories.ts
+++ b/ui/packages/design-system/tests/storybook/Data/KsDataTable.stories.ts
@@ -275,7 +275,7 @@ export const CustomContent: Story = {
                             <div
                                 v-for="row in pagedData"
                                 :key="row.id"
-                                style="border: 1px solid var(--ks-border-primary); border-radius: 8px; padding: 12px"
+                                style="border: 1px solid var(--ks-border-default); border-radius: 8px; padding: 12px"
                             >
                                 <strong style="font-size: 13px">{{ row.id }}</strong>
                                 <p style="margin: 4px 0; font-size: 12px; color: var(--ks-text-secondary)">{{ row.namespace }}</p>
@@ -345,7 +345,7 @@ export const FitHeight: Story = {
     render: () => ({
         components: {KsDataTable},
         template: `
-            <div style="height: 400px; display: flex; flex-direction: column; border: 1px solid var(--ks-border-primary); border-radius: 8px; overflow: hidden">
+            <div style="height: 400px; display: flex; flex-direction: column; border: 1px solid var(--ks-border-default); border-radius: 8px; overflow: hidden">
                 <ks-data-table :total="0" fit-height>
                     <template #table>
                         <div style="overflow-y: auto; height: 100%; padding: 8px">

--- a/ui/packages/topology/src/Topology.vue
+++ b/ui/packages/topology/src/Topology.vue
@@ -464,7 +464,7 @@
         z-index: 1000;
         list-style-type: none;
         background: var(--ks-bg-surface);
-        border: 1px solid var(--ks-border-primary);
+        border: 1px solid var(--ks-border-default);
         box-shadow: 0 12px 12px rgba(130, 103, 158, 0.1019607843);
         border-radius: 5px;
         text-align:left;
@@ -477,11 +477,11 @@
             width: 110px;
 
             &:first-child{
-                border-bottom: 1px solid var(--ks-border-primary);
+                border-bottom: 1px solid var(--ks-border-default);
             }
 
             &:hover {
-                background: var(--ks-button-background-secondary-hover);;
+                background: var(--ks-btn-secondary-bg-hover);
             }
         }
     }

--- a/ui/src/components/docs/ContextDocs.vue
+++ b/ui/src/components/docs/ContextDocs.vue
@@ -233,7 +233,7 @@
         &:focus:not(.disabled) {
             background: var(--ks-bg-hover);
             border-color: var(--ks-border-strong);
-            color: var(--ks-primary);
+            color: var(--ks-text-link);
             outline: none;
         }
 

--- a/ui/src/components/docs/ContextDocsMenu.vue
+++ b/ui/src/components/docs/ContextDocsMenu.vue
@@ -203,7 +203,7 @@
             }
 
             &:hover {
-                color: var(--ks-primary);
+                color: var(--ks-text-link);
                 background-color: var(--ks-btn-secondary-bg-hover);
             }
 

--- a/ui/src/components/flows/BackfillBanner.vue
+++ b/ui/src/components/flows/BackfillBanner.vue
@@ -90,8 +90,8 @@
     align-items: center;
     gap: 0.75rem;
     padding: 0.625rem 1rem;
-    background: var(--ks-background-card);
-    border-top: 1px dashed var(--ks-border-primary);
+    background: var(--ks-bg-base);
+    border-top: 1px dashed var(--ks-border-default);
 }
 
 .bf-meta {


### PR DESCRIPTION
### 🔗 Related Issue

Closes https://github.com/kestra-io/kestra/issues/18777.

### ✨ Description

The interval filter's **Apply to** row showed no selection. The state was never the problem: the chosen option carries `.active` and the chip label already switches between "Started" and "Ended". The style block simply painted with five custom properties that are not declared in the Figma-generated themes, so the browser dropped every one of those declarations and the selected option computed identically to the other two, down to the pixel.

| was, undeclared | now |
|---|---|
| `--ks-background-body` | `--ks-bg-surface` |
| `--ks-border-primary` | `--ks-border-default` |
| `--ks-border-radius-sm` | `--ks-radius-sm` |
| `--ks-background-card` (hover) | `--ks-bg-hover` |
| `--ks-background-card` (active) | `--ks-bg-tag-active` |
| `--ks-primary` (border, text) | `--ks-border-focus`, `--ks-text-link` |

The active triple is the pairing `FilterComparatorSelect.vue` and `FilterMultiSelect.vue` already use for their own selected state, so this follows the neighbours in the same popper rather than proposing a new look. The tokens are generated from Figma and are not declared by hand, which is why the call site moves rather than the palette.

The two inactive options gain a visible outline as a side effect: their resting border was painted with the same undeclared `--ks-border-primary` and had been invisible too.

<img width="1576" height="990" alt="18777-apply-to-highlight" src="https://github.com/user-attachments/assets/6023d654-be8c-4abb-bc15-39e3d58759a4" />

Dark theme, where the fill is `rgba(primary-300, 0.4)` behind `primary-200` text:

<img width="764" height="784" alt="18777-apply-to-dark" src="https://github.com/user-attachments/assets/c7c38723-5ab3-44fe-93f0-925ffc1f5ea9" />

Both captures come from a running instance (`kestra/kestra:develop-slim` behind `npm run dev`), reading the computed styles rather than trusting the screenshot: before, all three options compute to `color rgb(8, 9, 10)` over a transparent background; after, the active one is the only one that differs, in both themes.

### 🎨 Frontend Checklist

- [x] Type checking passes (`npm run check:types`)
- [x] Code builds without errors (`npm run build`)
- [x] Unit tests pass (`npm run test:unit`) — 2240 passed / 245 files
- [x] Translations are complete if `en.json` changed — `en.json` is untouched
- [x] Screenshots or video recordings attached showing the `UI` changes

### 📝 Additional Notes

**No test.** This is a stylesheet change and the repo has no visual-regression baseline to hang one on; a unit assertion on the computed `background`/`border-color` would only restate the stylesheet, and it would pass just as happily with an undeclared token, which is the failure being fixed here. What would actually catch the class of bug is a lint rule checking every `var(--ks-*)` against the declared set. Worth doing, and too large for this PR.

**The rest of the same defect is folded in**, in a second commit, so no reference to these names is left in the repo:

| file | was | now |
|---|---|---|
| `ContextDocs.vue`, `ContextDocsMenu.vue` | `--ks-primary` | `--ks-text-link` |
| `BackfillBanner.vue` | `--ks-background-card`, `--ks-border-primary` | `--ks-bg-base`, `--ks-border-default` |
| `Topology.vue` | `--ks-border-primary` ×2, `--ks-button-background-secondary-hover` | `--ks-border-default`, `--ks-btn-secondary-bg-hover` |
| `KsDataTable.stories.ts` | `--ks-border-primary` ×2 | `--ks-border-default` |

`ContextDocsMenu.vue` already used `--ks-text-link` for its active page, and the app already uses `--ks-btn-secondary-bg-hover` for the hover fill Topology was reaching for, so five of the six follow a choice made elsewhere in the same file or feature.

The sixth is a judgement call worth a reviewer's eye: **`BackfillBanner`'s fill**. It was transparent, so any value changes how it looks. `--ks-bg-base` recesses the strip against the white expanded row in light and against the surface-800 table in dark; `--ks-bg-elevated` would raise it instead. Say which you prefer.

**There is more of this.** Diffing every `var(--ks-*)` in `ui/src` and `ui/packages` against the declared set turns up about ten further names, once the interpolated ones (`var(--ks-status-#{$state})`) and the deliberate `var(--ks-content-link, var(--ks-text-link))` fallbacks are discounted. At least `--ks-border-active`, `--ks-surface-secondary` and `--ks-shadow-md` are dead with no fallback, exactly as these were. A lint rule is in progress on a separate branch.

**Found while screenshotting #18851**, which closed this issue on the strength of a decoder change. That change is a real correctness fix, but it is latent: the branch it repairs needs one key carrying `valueType: "time-range"` **and** `customDateMode: "range"` **and** `dateFilterOptions`, and no configuration in OSS or EE has all three today.

### 🤖 AI Authors

This PR was written by Claude at @elevatebart's request. The cat walked across the keyboard and declared `--ks-primary` herself; nothing changed, so she has been quietly shipping CSS here for months. 🐱

