### PR TITLE
fix(tests): unit suite fails to start on Node 26

### DIFF
--- a/ui/tests/unit/leakGuard.ts
+++ b/ui/tests/unit/leakGuard.ts
@@ -40,6 +40,12 @@ function describeNode(node: Element): string {
     return `${node.tagName.toLowerCase()}${id}${cls}`
 }
 
+// vitest.config.js keeps Node's own web storage out of the way so jsdom can install these;
+// tolerate them being absent anyway, so a future storage global costs one check rather than
+// every spec in the suite.
+const storageKeys = (storage: Storage | undefined) =>
+    storage ? Object.keys(storage).sort().join(",") : ""
+
 const snapshot = () => ({
     globals: new Map(WATCHED_GLOBALS.map((key) => [key, (globalThis as any)[key]])),
     title: document.title,
@@ -47,8 +53,8 @@ const snapshot = () => ({
     teleported: teleportedCount(),
     bodyClass: document.body.className,
     fakeTimers: vi.isFakeTimers(),
-    localStorageKeys: Object.keys(localStorage).sort().join(","),
-    sessionStorageKeys: Object.keys(sessionStorage).sort().join(","),
+    localStorageKeys: storageKeys(globalThis.localStorage),
+    sessionStorageKeys: storageKeys(globalThis.sessionStorage),
 })
 
 const before = snapshot()

--- a/ui/vitest.config.js
+++ b/ui/vitest.config.js
@@ -34,6 +34,14 @@ console.warn = (...args) => {
     originalConsoleWarn(...args)
 }
 
+// Node 26 defines a `localStorage` global that stays undefined unless --localstorage-file is
+// given, and it shadows the one jsdom installs, so every unit spec touching storage throws.
+// Disabling Node's own web storage lets jsdom provide it, as it does on the Node 24 in .nvmrc,
+// where the global does not exist and the flag is a no-op. Set here rather than in
+// poolOptions.execArgv, which vitest overrides with its own, and rather than in the npm script,
+// which would not survive someone running vitest directly.
+process.env.NODE_OPTIONS = `${process.env.NODE_OPTIONS ?? ""} --no-experimental-webstorage`.trim()
+
 // Vite writes logger warnings to process.stderr. Silence the
 // "Sourcemap for X points to a source file outside its package" noise
 // emitted when node_modules packages reference scss from sibling packages


### PR DESCRIPTION
Issue: `npm run test:unit` cannot start on Node 26. Node added a `localStorage` global that stays undefined unless `--localstorage-file` is passed, and it shadows the one jsdom installs. `tests/unit/leakGuard.ts` is a setup file, so it re-runs per spec and every file fails to collect. On `develop` at Node 26.4.0:

```
$ npx vitest run --project=unit
TypeError: Cannot convert undefined or null to object
 ❯ snapshot tests/unit/leakGuard.ts:50:30
 ❯ tests/unit/leakGuard.ts:54:16

 Test Files  244 failed (244)
```

Nothing to do with an editor or a local setup: that is a plain shell run. CI stays green only because `.nvmrc` pins Node 24, where the global does not exist.

Fix: disable Node's own web storage for the test run so jsdom provides it, as it already does on Node 24, and let the leak guard tolerate a missing storage global rather than throwing. The flag is a no-op on Node 24.
Now: the suite passes on Node 24 and Node 26 with identical results, 244 files and 2235 tests.
