### PR TITLE
build(deps): translations check no longer downloads tsx

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -31,7 +31,7 @@
         "test:storybook": "vitest run --project=storybook",
         "test:e2e": "./run-e2e-tests.sh",
         "test:e2e-without-starting-backend": "playwright test --config=tests/e2e/playwright.config.ts",
-        "translations:check": "npx --yes tsx ./scripts/translations/check.ts",
+        "translations:check": "node --experimental-strip-types ./scripts/translations/check.ts",
         "translations:generate": "node --experimental-strip-types ./scripts/translations/generate.ts",
         "lint": "oxlint --fix src packages tests && eslint --fix",
         "storybook": "storybook dev -p 6006",

--- a/ui/scripts/translations/check.ts
+++ b/ui/scripts/translations/check.ts
@@ -1,6 +1,6 @@
 import path from "path"
 import {fileURLToPath} from "url"
-import {compareTranslations, DEFAULT_LANGUAGES} from "./compareTranslations"
+import {compareTranslations, DEFAULT_LANGUAGES} from "./compareTranslations.ts"
 
 const here = path.dirname(fileURLToPath(import.meta.url))
 


### PR DESCRIPTION
Issue: `translations:check` ran `npx --yes tsx`, and `tsx` is in neither `dependencies` nor `devDependencies`. Every run fetched an unpinned copy from the registry and executed it, so the check depended on registry availability and on a version the lockfile does not record. With the registry unreachable it fails with `ENOTCACHED`.
Fix: run it with Node's own type stripping, the way `translations:generate` on the next line already does. The only thing preventing that was a missing `.ts` extension on one relative import, which its six sibling scripts all carry.
Now: the check needs no network and no extra install, verified on Node 24 and Node 26, including a cold npm cache with `offline=true`.
