### PR TITLE
fix(design-system): icon sizes off the token scale render as invalid CSS

### DIFF
--- a/ui/packages/design-system/src/components/Basic/KsIcon.vue
+++ b/ui/packages/design-system/src/components/Basic/KsIcon.vue
@@ -39,7 +39,7 @@
     const SIZE_TOKENS: readonly IconSizeToken[] = ["xs", "sm", "base", "lg", "xl"] as const
 
     const props = defineProps<{
-        size?: number | string | IconSizeToken
+        size?: number | IconSizeToken
         color?: string
         tooltip?: string
         placement?: string

--- a/ui/src/components/logs/TaskRunDetails.vue
+++ b/ui/src/components/logs/TaskRunDetails.vue
@@ -100,7 +100,7 @@
                                         :aria-expanded="isGroupExpanded(currentTaskRunIndex, item)"
                                         @click="toggleGroup(currentTaskRunIndex, item)"
                                     >
-                                        <KsIcon class="log-group-chevron" :class="{collapsed: !isGroupExpanded(currentTaskRunIndex, item)}" size="s">
+                                        <KsIcon class="log-group-chevron" :class="{collapsed: !isGroupExpanded(currentTaskRunIndex, item)}">
                                             <ChevronDown />
                                         </KsIcon>
                                         <span class="log-group-count">×{{ item.members.length }}</span>


### PR DESCRIPTION
EE PR: https://github.com/kestra-io/kestra-ee/pull/10802

Issue: `KsIcon`'s `size` prop was typed `number | string | IconSizeToken`, which collapses to `number | string`, so any string compiled. `size="s"` in the log viewer produced `font-size: s`, which browsers drop.
Fix: narrow the prop to `number | IconSizeToken`. The chevron loses its `size` attribute rather than gaining a token, because its parent sets `font-size` from the user's log font-size setting and the invalid value already meant it inherited that, so keeping the inheritance preserves what is on screen today.
Now: a size off the token scale fails `check:types` instead of silently rendering wrong CSS. Every numeric caller already binds (`:size="24"`), so no other call site changes.

Merge the EE PR first. It fixes the five EE call sites this narrowing would otherwise turn into compile errors, the same way https://github.com/kestra-io/kestra/pull/18851 broke EE `develop` on `KsIconButton`.
