### PR TITLE
fix(ui): keep custom columns footer fixed

### DIFF
--- a/ui/packages/design-system/src/components/Data/KsDataTable/filter/segments/CustomColumns.vue
+++ b/ui/packages/design-system/src/components/Data/KsDataTable/filter/segments/CustomColumns.vue
@@ -64,6 +64,7 @@
 <style lang="scss" scoped>
 .customize-columns-panel {
     height: fit-content;
+    max-height: 500px;
     display: flex;
     flex-direction: column;
     border-radius: 0.5rem;

--- a/ui/packages/design-system/tests/storybook/Data/CustomColumns.stories.ts
+++ b/ui/packages/design-system/tests/storybook/Data/CustomColumns.stories.ts
@@ -1,0 +1,47 @@
+import type {Meta, StoryObj} from "@storybook/vue3-vite"
+import {expect, waitFor} from "storybook/test"
+import CustomColumns from "../../../src/components/Data/KsDataTable/filter/segments/CustomColumns.vue"
+
+const columns = Array.from({length: 12}, (_, index) => ({
+    label: `Column ${index + 1}`,
+    prop: `column-${index + 1}`,
+    default: index < 8,
+}))
+
+const meta: Meta<typeof CustomColumns> = {
+    title: "Components/Data/CustomColumns",
+    component: CustomColumns,
+    args: {
+        storageKey: "custom-columns-story",
+        columns,
+        visibleColumns: columns.filter(column => column.default).map(column => column.prop),
+    },
+    render: args => ({
+        components: {CustomColumns},
+        setup: () => ({args}),
+        template: `
+            <div style="width: 300px">
+                <CustomColumns v-bind="args" />
+            </div>
+        `,
+    }),
+}
+
+export default meta
+type Story = StoryObj<typeof CustomColumns>
+
+export const ScrollableListWithFixedFooter: Story = {
+    async play({canvasElement}) {
+        const panel = canvasElement.querySelector<HTMLElement>(".customize-columns-panel")!
+        const list = panel.querySelector<HTMLElement>(".list")!
+        const footer = panel.querySelector<HTMLElement>(".footer")!
+
+        expect(list.scrollHeight).toBeGreaterThan(list.clientHeight)
+
+        const footerTop = footer.getBoundingClientRect().top
+        list.scrollTop = list.scrollHeight
+
+        await waitFor(() => expect(list.scrollTop).toBeGreaterThan(0))
+        expect(footer.getBoundingClientRect().top).toBe(footerTop)
+    },
+}


### PR DESCRIPTION
### 🔗 Related Issue

Closes https://github.com/kestra-io/kestra/issues/19078.

### ✨ Description

The custom columns panel already made the column list scrollable and marked its footer as sticky, but the panel itself had no height limit. As a result, the popover became the scroll container and moved the footer together with the column rows.

This adds the same 500px height limit used by the neighboring custom filters panel. The column list now takes the available space and scrolls independently, while the visible-column count stays at the bottom of the panel.

I also added a browser-level Storybook test with 12 columns. It checks that the list actually overflows and that the footer keeps the same position after scrolling to the bottom.

### 🎨 Frontend Checklist

- [x] Design system type checking passes (`npm run types:test --workspace=@kestra-io/design-system`)
- [x] Design system builds without errors (`npm run build:design`)
- [x] Existing `CustomColumns` unit tests pass (5/5)
- [x] New Chromium Storybook test passes (1/1)
- [x] No translation changes were needed

### 📝 Additional Notes

The full design system unit suite was also exercised locally, but its highly parallel default run hit unrelated 5-second timeouts under local resource contention. The component-specific unit and browser tests above pass consistently.