### PR TITLE
build(deps): translations check no longer downloads tsx (2.0 backport)

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -31,7 +31,7 @@
         "test:storybook": "vitest run --project=storybook",
         "test:e2e": "./run-e2e-tests.sh",
         "test:e2e-without-starting-backend": "playwright test --config=tests/e2e/playwright.config.ts",
-        "translations:check": "npx --yes tsx ./scripts/translations/check.ts",
+        "translations:check": "node --experimental-strip-types ./scripts/translations/check.ts",
         "translations:generate": "node --experimental-strip-types ./scripts/translations/generate.ts",
         "lint": "oxlint --fix src packages tests && eslint --fix",
         "storybook": "storybook dev -p 6006",

--- a/ui/scripts/translations/check.ts
+++ b/ui/scripts/translations/check.ts
@@ -1,6 +1,6 @@
 import path from "path"
 import {fileURLToPath} from "url"
-import {compareTranslations, DEFAULT_LANGUAGES} from "./compareTranslations"
+import {compareTranslations, DEFAULT_LANGUAGES} from "./compareTranslations.ts"
 
 const here = path.dirname(fileURLToPath(import.meta.url))
 


### PR DESCRIPTION
Backport of https://github.com/kestra-io/kestra/pull/19090 to `releases/v2.0.x`. Clean cherry-pick of the squash commit.

## What

`translations:check` ran `npx --yes tsx`, and `tsx` is declared nowhere, so every run fetched an unpinned copy from the registry. It now runs with Node's own type stripping, like `translations:generate` on the next line; the one relative import in `check.ts` that lacked its `.ts` extension gets it.

## Evidence

`npm run translations:check` runs through the new line on this branch and reports every locale clean.

Related to https://github.com/kestra-io/kestra/pull/19090.
Related to https://github.com/kestra-io/kestra-ee/pull/10803.