### PR TITLE
fix(triggers): reject a backfill whose end date is not after its start

### DIFF
--- a/webserver/src/main/java/io/kestra/webserver/controllers/api/TriggerController.java
+++ b/webserver/src/main/java/io/kestra/webserver/controllers/api/TriggerController.java
@@ -223,6 +223,7 @@ public class TriggerController {
     @Operation(tags = { "Triggers" }, summary = "Create a backfill")
     @ApiResponse(responseCode = "200", description = "On success", content = { @Content(schema = @Schema(implementation = ApiTriggerState.class)) })
     @ApiResponse(responseCode = "409", description = "If the backfill cannot be created")
+    @ApiResponse(responseCode = "422", description = "If the backfill end date is not after its start date")
     public HttpResponse<ApiTriggerState> createBackfill(
         @Parameter(description = "The trigger that need the backfill to be created") @Body @Valid ApiCreateBackfillRequest request) {
         TriggerId triggerId = TriggerId.of(tenantService.resolveTenant(), request.namespace(), request.flowId(), request.triggerId());

--- a/webserver/src/main/java/io/kestra/webserver/services/TriggerStateService.java
+++ b/webserver/src/main/java/io/kestra/webserver/services/TriggerStateService.java
@@ -10,6 +10,7 @@ import io.kestra.core.async.AsyncOperationProcessedEvent;
 import io.kestra.core.async.AsyncOperationsConfiguration;
 import io.kestra.core.exceptions.ConflictException;
 import io.kestra.core.exceptions.NotFoundException;
+import io.kestra.core.exceptions.ValidationErrorException;
 import io.kestra.core.models.QueryFilter;
 import io.kestra.core.models.executions.ExecutionKilled;
 import io.kestra.core.models.executions.ExecutionKilledTrigger;
@@ -175,10 +176,13 @@ public class TriggerStateService {
     /**
      * Creates a backfill and waits for the scheduler to acknowledge.
      *
+     * @throws ValidationErrorException if the backfill window is empty, which the scheduler would otherwise
+     *                                  accept and then immediately discard.
      * @throws NotFoundException if the trigger does not exist.
      * @throws ConflictException if the backfill cannot be created.
      */
     public TriggerState createBackfill(TriggerId triggerId, CreateBackfillTrigger.Backfill backfill) throws NotFoundException, ConflictException {
+        validateBackfillWindow(backfill);
         getTriggerState(triggerId);
         awaitBlockingAction(
             triggerId.uid(),
@@ -366,6 +370,24 @@ public class TriggerStateService {
             .blockOptional()
             .orElse(0);
         return new ApiAsyncOperationResponse(operationId, count);
+    }
+
+    /**
+     * Rejects a backfill whose window holds no schedule date: the scheduler seeds the backfill cursor just
+     * before {@code start} and clears the backfill as soon as the cursor passes {@code end}, so such a
+     * backfill would be created and dropped again without ever running.
+     */
+    private static void validateBackfillWindow(CreateBackfillTrigger.Backfill backfill) {
+        if (backfill.start() == null) {
+            throw new ValidationErrorException(List.of("The backfill start date is required."));
+        }
+
+        if (backfill.end() != null && !backfill.end().isAfter(backfill.start())) {
+            throw new ValidationErrorException(List.of(
+                "The backfill end date must be after its start date, but got start '%s' and end '%s'."
+                    .formatted(backfill.start(), backfill.end())
+            ));
+        }
     }
 
     private static boolean isUnlockable(TriggerState state) {

--- a/webserver/src/test/java/io/kestra/webserver/controllers/api/TriggerControllerTest.java
+++ b/webserver/src/test/java/io/kestra/webserver/controllers/api/TriggerControllerTest.java
@@ -3,6 +3,7 @@ package io.kestra.webserver.controllers.api;
 import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
+import java.time.ZonedDateTime;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -34,6 +35,7 @@ import io.kestra.jdbc.JdbcTestUtils;
 import io.kestra.jdbc.repository.AbstractJdbcTriggerRepository;
 import io.kestra.plugin.core.debug.Return;
 import io.kestra.plugin.core.trigger.Schedule;
+import io.kestra.webserver.controllers.api.TriggerController.ApiCreateBackfillRequest;
 import io.kestra.webserver.controllers.api.TriggerController.SetDisabledRequest;
 import io.kestra.webserver.models.api.ApiAsyncOperationResponse;
 import io.kestra.webserver.models.api.ApiTriggerAndState;
@@ -46,6 +48,7 @@ import io.micronaut.http.HttpResponse;
 import io.micronaut.http.HttpStatus;
 import io.micronaut.http.client.annotation.Client;
 import io.kestra.core.junit.assertions.Problems;
+import io.kestra.webserver.errors.ProblemError;
 import io.kestra.webserver.errors.ProblemTypes;
 import io.micronaut.http.client.exceptions.HttpClientResponseException;
 import io.micronaut.reactor.http.client.ReactorHttpClient;
@@ -762,6 +765,47 @@ class TriggerControllerTest {
 
         // THEN
         assertThat(exception.getStatus().getCode()).isEqualTo(HttpStatus.UNPROCESSABLE_ENTITY.getCode());
+    }
+
+    @Test
+    void shouldReturnUnprocessableEntityWhenCreatingBackfillWithEndNotAfterStart() throws FlowProcessingException, QueueException {
+        // GIVEN
+        Flow flow = generateFlowWithTrigger("ns-" + IdUtils.create().toLowerCase());
+        flowService.create(GenericFlow.of(flow));
+        TriggerState trigger = createTriggerFromFlow(flow, false);
+        Awaitility.await().atMost(Duration.ofSeconds(30)).pollInterval(Duration.ofMillis(100))
+            .until(() -> jdbcTriggerRepository.findById(trigger).isPresent());
+
+        ZonedDateTime start = ZonedDateTime.parse("2026-06-10T00:00:00Z");
+
+        for (ZonedDateTime end : List.of(start.minusDays(9), start)) {
+            // WHEN
+            HttpClientResponseException e = assertThrows(
+                HttpClientResponseException.class,
+                () -> client.toBlocking().retrieve(
+                    HttpRequest.PUT(
+                        TRIGGER_PATH + "/backfill/create",
+                        new ApiCreateBackfillRequest(
+                            flow.getNamespace(),
+                            flow.getId(),
+                            trigger.getTriggerId(),
+                            new ApiCreateBackfillRequest.Backfill(start, end, Map.of(), List.of())
+                        )
+                    ),
+                    ApiTriggerState.class
+                )
+            );
+
+            // THEN
+            Problems.assertProblem(e, ProblemTypes.VALIDATION_FAILED);
+            Problems.assertErrors(e)
+                .extracting(ProblemError::detail)
+                .containsExactly(
+                    "The backfill end date must be after its start date, but got start '%s' and end '%s'.".formatted(start, end)
+                );
+        }
+
+        assertThat(jdbcTriggerRepository.findById(trigger).orElseThrow().getBackfill()).isNull();
     }
 
     @Test


### PR DESCRIPTION
### 🔗 Related Issue

Closes https://github.com/kestra-io/kestra-ee/issues/10159.

### ✨ Description

`PUT /api/v1/{tenant}/triggers/backfill/create` accepted a backfill with an end
date on or before the start date as a silent no-op: HTTP 200 with
`backfill: null`, nothing created, no error. The UI already refuses it — the
date picker disables any end date at or before the selected start — so the gap
was API-only, and reproduced on both OSS and EE.

The cause is in the scheduler rather than the endpoint: `onCreateBackfill`
stores the backfill and then calls `updateForNextEvaluationDate`, and
`TriggerState.getBackFillForNextEvaluationDate` returns `null` as soon as the
next evaluation date is after `backfill.end`. With `end <= start` that holds on
the first evaluation, so the backfill was created and dropped in the same event
and the API had nothing left to report.

`TriggerStateService.createBackfill` now validates the window before emitting
the event and throws `ValidationErrorException`, which maps to
`VALIDATION_FAILED` → **422**:

* `end < start` (Jun 10 -> Jun 01) -> 422
* `end == start` (Jun 05 -> Jun 05) -> 422
* `end > start` (Jun 01 -> Jun 03) -> 200, backfill created (unchanged)