### PR TITLE
fix(system): stop the version tooltip covering the theme toggle

### DIFF
--- a/ui/src/components/ContextInfoBar.vue
+++ b/ui/src/components/ContextInfoBar.vue
@@ -20,6 +20,7 @@
 
         <el-tooltip
             effect="light"
+            placement="top"
             :persistent="false"
             transition=""
             :hideAfter="0"


### PR DESCRIPTION
<!-- PR title must follow Conventional Commits with a single scope, lowercase description: `fix(core): handle empty trigger list`. See AGENTS.md for the allowed types and scopes. -->

---

### 🔗 Related Issue

<!-- Put the closing keyword on the first line so the link is visible without scrolling and survives squash merges: -->
Closes https://github.com/kestra-io/kestra/issues/18758

### ✨ Description

<!-- What does this PR change, from the user's point of view? Example: Replaces legacy scroll directive with the new API. -->
Change tooltip opening direction from bottom (default) to top, unblocking the theme toggle button. See bottom right of screenshot.

### 🎨 Frontend Checklist

<!-- If this PR does not include any frontend changes, delete this entire section. All commands run from the `ui/` directory. -->

- [x] Type checking passes (`npm run check:types`)
- [x] Code builds without errors (`npm run build`)
- [x] Unit tests pass (`npm run test:unit`)
- [x] Translations are complete if `en.json` changed (`npm run translations:check` reports no missing, extra, or stale keys)
- [x] Screenshots or video recordings attached showing the `UI` changes

<img width="1838" height="983" alt="image" src="https://github.com/user-attachments/assets/74e6e63b-0361-4fa1-9f0c-79e0447a0416" />

