### PR TITLE
fix(design-system): filters no longer reset on page and sort changes

### DIFF
--- a/ui/packages/design-system/src/components/Data/KsDataTable/filter/composables/useRouteSync.ts
+++ b/ui/packages/design-system/src/components/Data/KsDataTable/filter/composables/useRouteSync.ts
@@ -3,6 +3,7 @@ import {useRoute, useRouter} from "vue-router"
 import {
     clearFilterQueryParams,
     encodeFilterGroupsToQuery,
+    filterQuerySignature,
     findUnrenderableFilterKeys,
     getUniqueFilters,
     isValidFilter,
@@ -149,7 +150,7 @@ export function useRouteSync({
         tree.replaceTree(finalGroups, parsedTop)
     }
 
-    watch(() => route.query, initializeFromRoute, {deep: true, immediate: false})
+    watch(() => filterQuerySignature(route.query), initializeFromRoute)
     watch(searchQuery, () => updateRoute(searchQuery.value.trim() !== ""))
     initializeFromRoute()
 

--- a/ui/packages/design-system/src/components/Data/KsDataTable/filter/utils/helpers.ts
+++ b/ui/packages/design-system/src/components/Data/KsDataTable/filter/utils/helpers.ts
@@ -1,6 +1,6 @@
 import type {LocationQuery} from "vue-router"
 import {type AppliedFilter, type FilterGroup, type LeafFilterGroup, type LogicalOperator, Comparators, isWrapperGroup} from "./filterTypes"
-import {MAX_RENDERABLE_NESTING_DEPTH} from "./constants"
+import {DATE_FILTER_KEY, MAX_RENDERABLE_NESTING_DEPTH} from "./constants"
 
 /**
  * Normalizes a `filters[...]` query-param value after vue-router (or
@@ -259,11 +259,25 @@ export const getUniqueFilters = <T extends { key: string; comparator?: any }>(fi
         ),
     )
 
+export const isFilterQueryKey = (key: string): boolean =>
+    key.startsWith("filters[") || key === DATE_FILTER_KEY
+
 export const clearFilterQueryParams = (query: Record<string, any>): void => {
     for (const key of Object.keys(query)) {
-        if (key.startsWith("filters[") || key === "dateFilter") delete query[key]
+        if (isFilterQueryKey(key)) delete query[key]
     }
 }
+
+/**
+ * Stable string over just the filter-carrying query entries, so a watcher fires when the filters
+ * change and not when `page`, `size` or `sort` do.
+ */
+export const filterQuerySignature = (query: LocationQuery | undefined): string =>
+    JSON.stringify(
+        Object.entries(query ?? {})
+            .filter(([key]) => isFilterQueryKey(key))
+            .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0)),
+    )
 
 /**
  * Returns true if a `filters[...]` key has more `[and|or][N]` prefix segments than the chip UI

--- a/ui/packages/design-system/tests/units/Data/filterQuerySignature.test.ts
+++ b/ui/packages/design-system/tests/units/Data/filterQuerySignature.test.ts
@@ -1,0 +1,56 @@
+import {describe, test, expect} from "vitest"
+import {filterQuerySignature, isFilterQueryKey} from "../../../src/components/Data/KsDataTable/filter/utils/helpers"
+import {DATE_FILTER_KEY, SEARCH_QUERY_KEY} from "../../../src/components/Data/KsDataTable/filter/utils/constants"
+
+describe("isFilterQueryKey", () => {
+    test("accepts encoded filter keys and the dateFilter selector", () => {
+        expect(isFilterQueryKey("filters[namespace][EQUALS]")).toBe(true)
+        expect(isFilterQueryKey("filters[and][0][or][1][flowId][EQUALS]")).toBe(true)
+        expect(isFilterQueryKey(SEARCH_QUERY_KEY)).toBe(true)
+        expect(isFilterQueryKey(DATE_FILTER_KEY)).toBe(true)
+    })
+
+    test("rejects the pagination and sort keys", () => {
+        expect(isFilterQueryKey("page")).toBe(false)
+        expect(isFilterQueryKey("size")).toBe(false)
+        expect(isFilterQueryKey("sort")).toBe(false)
+    })
+})
+
+describe("filterQuerySignature", () => {
+    const filters = {
+        "filters[namespace][EQUALS]": "company.team",
+        [DATE_FILTER_KEY]: "PT12H",
+    }
+
+    test("is unchanged when only page, size or sort move", () => {
+        expect(filterQuerySignature({...filters, page: "2", size: "25", sort: "id:asc"}))
+            .toBe(filterQuerySignature({...filters, page: "3", size: "50", sort: "id:desc"}))
+    })
+
+    test("changes when a filter value changes", () => {
+        expect(filterQuerySignature({...filters, "filters[namespace][EQUALS]": "company.other"}))
+            .not.toBe(filterQuerySignature(filters))
+    })
+
+    test("changes when a filter is added or removed", () => {
+        expect(filterQuerySignature({...filters, "filters[flowId][CONTAINS]": "hello"}))
+            .not.toBe(filterQuerySignature(filters))
+        expect(filterQuerySignature({[DATE_FILTER_KEY]: "PT12H"})).not.toBe(filterQuerySignature(filters))
+    })
+
+    test("ignores the order the keys appear in", () => {
+        expect(filterQuerySignature({"filters[a][EQUALS]": "1", "filters[b][EQUALS]": "2"}))
+            .toBe(filterQuerySignature({"filters[b][EQUALS]": "2", "filters[a][EQUALS]": "1"}))
+    })
+
+    test("tracks the search query, which is encoded as a filter key", () => {
+        expect(filterQuerySignature({[SEARCH_QUERY_KEY]: "first"}))
+            .not.toBe(filterQuerySignature({[SEARCH_QUERY_KEY]: "second"}))
+    })
+
+    test("distinguishes a repeated key from a single value", () => {
+        expect(filterQuerySignature({"filters[state][IN]": ["RUNNING", "FAILED"]}))
+            .not.toBe(filterQuerySignature({"filters[state][IN]": "RUNNING"}))
+    })
+})


### PR DESCRIPTION
The filter bar watched the whole URL query with `deep: true`, so it re-ran its route-parsing and rebuilt the filter tree on every query change, page and sort clicks included.

It now reacts only when the filter keys themselves change, which is the pattern `ui/AGENTS.md` prescribes under "The deep-watch / computed-spread trap".

I could not produce a user-visible difference from this. Clicking sort on the Flows page fires the same five API calls before and after, and the guard on line 134 already absorbed the rebuild when filters were applied. So this removes wasted work on every page and sort click rather than fixing a symptom you can see.
