### PR TITLE
fix(design-system): data table shows a failed load instead of an empty list

### DIFF
--- a/ui/packages/design-system/src/components/Data/KsDataTable/KsDataTable.locale.ts
+++ b/ui/packages/design-system/src/components/Data/KsDataTable/KsDataTable.locale.ts
@@ -8,13 +8,13 @@ export default {
     "de": {
         "ks_data_table": {
             "load_failed": "Diese Liste konnte nicht geladen werden.",
-            "retry": "Erneut versuchen",
+            "retry": "Versuche es erneut",
         },
     },
     "es": {
         "ks_data_table": {
-            "load_failed": "No se pudo cargar esta lista.",
-            "retry": "Intentar de nuevo",
+            "load_failed": "Esta lista no pudo ser cargada.",
+            "retry": "Inténtalo de nuevo",
         },
     },
     "fr": {
@@ -25,13 +25,13 @@ export default {
     },
     "hi": {
         "ks_data_table": {
-            "load_failed": "यह सूची लोड नहीं हो सकी।",
-            "retry": "पुन: प्रयास करें",
+            "load_failed": "यह सूची लोड नहीं की जा सकी।",
+            "retry": "पुनः प्रयास करें",
         },
     },
     "it": {
         "ks_data_table": {
-            "load_failed": "Impossibile caricare questo elenco.",
+            "load_failed": "Questo elenco non può essere caricato.",
             "retry": "Riprova",
         },
     },
@@ -43,32 +43,32 @@ export default {
     },
     "ko": {
         "ks_data_table": {
-            "load_failed": "이 목록을 불러올 수 없습니다.",
+            "load_failed": "이 목록을 로드할 수 없습니다.",
             "retry": "다시 시도",
         },
     },
     "pl": {
         "ks_data_table": {
-            "load_failed": "Nie udało się wczytać tej listy.",
+            "load_failed": "Nie można załadować tej listy.",
             "retry": "Spróbuj ponownie",
         },
     },
     "pt": {
         "ks_data_table": {
-            "load_failed": "Não foi possível carregar esta lista.",
+            "load_failed": "Esta lista não pôde ser carregada.",
             "retry": "Tentar novamente",
         },
     },
     "pt_BR": {
         "ks_data_table": {
-            "load_failed": "Não foi possível carregar esta lista.",
+            "load_failed": "Esta lista não pôde ser carregada.",
             "retry": "Tentar novamente",
         },
     },
     "ru": {
         "ks_data_table": {
-            "load_failed": "Не удалось загрузить этот список.",
-            "retry": "Повторить попытку",
+            "load_failed": "Этот список не удалось загрузить.",
+            "retry": "Повторите попытку",
         },
     },
     "zh_CN": {

--- a/ui/packages/design-system/src/components/Data/KsDataTable/KsDataTable.locale.ts
+++ b/ui/packages/design-system/src/components/Data/KsDataTable/KsDataTable.locale.ts
@@ -1,0 +1,80 @@
+export default {
+    "en": {
+        "ks_data_table": {
+            "load_failed": "This list could not be loaded.",
+            "retry": "Try again",
+        },
+    },
+    "de": {
+        "ks_data_table": {
+            "load_failed": "Diese Liste konnte nicht geladen werden.",
+            "retry": "Erneut versuchen",
+        },
+    },
+    "es": {
+        "ks_data_table": {
+            "load_failed": "No se pudo cargar esta lista.",
+            "retry": "Intentar de nuevo",
+        },
+    },
+    "fr": {
+        "ks_data_table": {
+            "load_failed": "Cette liste n'a pas pu être chargée.",
+            "retry": "Réessayer",
+        },
+    },
+    "hi": {
+        "ks_data_table": {
+            "load_failed": "यह सूची लोड नहीं हो सकी।",
+            "retry": "पुन: प्रयास करें",
+        },
+    },
+    "it": {
+        "ks_data_table": {
+            "load_failed": "Impossibile caricare questo elenco.",
+            "retry": "Riprova",
+        },
+    },
+    "ja": {
+        "ks_data_table": {
+            "load_failed": "このリストを読み込めませんでした。",
+            "retry": "再試行",
+        },
+    },
+    "ko": {
+        "ks_data_table": {
+            "load_failed": "이 목록을 불러올 수 없습니다.",
+            "retry": "다시 시도",
+        },
+    },
+    "pl": {
+        "ks_data_table": {
+            "load_failed": "Nie udało się wczytać tej listy.",
+            "retry": "Spróbuj ponownie",
+        },
+    },
+    "pt": {
+        "ks_data_table": {
+            "load_failed": "Não foi possível carregar esta lista.",
+            "retry": "Tentar novamente",
+        },
+    },
+    "pt_BR": {
+        "ks_data_table": {
+            "load_failed": "Não foi possível carregar esta lista.",
+            "retry": "Tentar novamente",
+        },
+    },
+    "ru": {
+        "ks_data_table": {
+            "load_failed": "Не удалось загрузить этот список.",
+            "retry": "Повторить попытку",
+        },
+    },
+    "zh_CN": {
+        "ks_data_table": {
+            "load_failed": "无法加载此列表。",
+            "retry": "重试",
+        },
+    },
+}

--- a/ui/packages/design-system/src/components/Data/KsDataTable/KsDataTable.vue
+++ b/ui/packages/design-system/src/components/Data/KsDataTable/KsDataTable.vue
@@ -52,7 +52,14 @@
                     <KsTableColumn v-if="selectable && showSelection" type="selection" reserveSelection :selectable="rowSelectable" />
                     <slot />
                     <template #empty>
-                        <KsNoData :title="noDataText" :description="noDataDescription" />
+                        <slot v-if="loadError" name="error" :error="loadError" :retry="reload">
+                            <div class="load-error">
+                                <AlertCircleOutlineIcon class="load-error-icon" />
+                                <strong>{{ $t("ks_data_table.load_failed") }}</strong>
+                                <KsButton size="small" @click="reload">{{ $t("ks_data_table.retry") }}</KsButton>
+                            </div>
+                        </slot>
+                        <KsNoData v-else :title="noDataText" :description="noDataDescription" />
                     </template>
                 </KsTable>
             </div>
@@ -82,6 +89,8 @@
     import KsPagination from "../KsPagination.vue"
     import KsBulkSelect from "./KsBulkSelect.vue"
     import KsNoData from "../KsNoData.vue"
+    import KsButton from "../../Basic/KsButton/KsButton.vue"
+    import AlertCircleOutlineIcon from "vue-material-design-icons/AlertCircleOutline.vue"
 
     defineOptions({inheritAttrs: false})
 
@@ -152,6 +161,7 @@
         "row-dblclick": [row: any, column: any, event: Event]
         "ready": []
         "loaded": []
+        "load-error": [error: unknown]
     }>()
 
     defineSlots<{
@@ -160,6 +170,7 @@
         top?(): unknown
         table?(): unknown
         empty?(): unknown
+        error?(props: {error: unknown; retry: () => void}): unknown
         "bulk-actions"?(): unknown
         "select-actions"?(): unknown
     }>()
@@ -196,6 +207,7 @@
     })
 
     const isLoading = ref(props.loading)
+    const loadError = ref<unknown>()
     const isReady = ref(false)
 
     const normalizePage = (value: number | undefined): number => {
@@ -328,12 +340,16 @@
     const callLoad = async () => {
         if (!props.loadData) return
         isLoading.value = true
+        loadError.value = undefined
         try {
             await props.loadData({
                 page: currentPageValue.value,
                 size: currentSizeValue.value,
                 sort: internalSort.value,
             })
+        } catch (error) {
+            loadError.value = error ?? new Error("loadData failed")
+            emit("load-error", error)
         } finally {
             isLoading.value = false
             if (!isReady.value) {
@@ -345,7 +361,7 @@
         }
     }
 
-    const showEmpty = computed(() => props.data.length === 0 && !isLoading.value)
+    const showEmpty = computed(() => props.data.length === 0 && !isLoading.value && !loadError.value)
 
     const showPagination = computed(() => {
         if (!props.total || props.total <= 0) return false
@@ -439,6 +455,27 @@
 </script>
 
 <style lang="scss">
+    .load-error {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        line-height: 1.4;
+        gap: var(--ks-spacing-2);
+        text-align: center;
+
+        strong {
+            color: var(--ks-text-primary);
+            font-size: var(--ks-font-size-md);
+            font-weight: var(--ks-font-weight-bold);
+        }
+    }
+
+    .load-error-icon {
+        height: 24px;
+        width: 24px;
+        color: var(--ks-icon-error);
+    }
+
     .ks-data-table-wrapper {
         --ks-data-table-gutter: 2rem;
         height: 100%;

--- a/ui/packages/design-system/tests/storybook/Data/KsDataTable.stories.ts
+++ b/ui/packages/design-system/tests/storybook/Data/KsDataTable.stories.ts
@@ -222,6 +222,44 @@ export const Empty: Story = {
     }),
 }
 
+export const LoadFailure: Story = {
+    name: "Load failure",
+    render: () => ({
+        components: {KsDataTable, KsTableColumn, KsButton},
+        setup() {
+            const attempts = ref(0)
+            const loadData = () => {
+                attempts.value += 1
+                return Promise.reject(new Error("boom"))
+            }
+            return {loadData, attempts}
+        },
+        template: `
+            <div style="padding: 24px">
+                <ks-data-table :data="[]" :total="0" :load-data="loadData" :current-page="1" :page-size="25" no-data-text="No flows found">
+                    <ks-table-column prop="id" label="Flow ID" />
+                    <template #error="{retry}">
+                        <p data-testid="load-error">Could not load the flows.</p>
+                        <ks-button size="small" @click="retry">Reload</ks-button>
+                    </template>
+                </ks-data-table>
+                <span data-testid="attempts">{{ attempts }}</span>
+            </div>
+        `,
+    }),
+    play: async ({canvasElement}) => {
+        const canvas = within(canvasElement)
+
+        // A rejected load must not be presented as an empty list.
+        await waitFor(() => expect(canvas.getByTestId("load-error")).toBeVisible())
+        expect(canvas.queryByText("No flows found")).toBeNull()
+
+        await waitFor(() => expect(canvas.getByTestId("attempts")).toHaveTextContent("1"))
+        await userEvent.click(canvas.getByRole("button", {name: "Reload"}))
+        await waitFor(() => expect(canvas.getByTestId("attempts")).toHaveTextContent("2"))
+    },
+}
+
 export const ForceExpandedRows: Story = {
     name: "Force-expanded rows",
     parameters: {

--- a/ui/scripts/translations/fingerprints-design-system.json
+++ b/ui/scripts/translations/fingerprints-design-system.json
@@ -1,6 +1,8 @@
 {
   "../../packages/design-system/src/components/Data/KsDataTable/KsBulkSelect.locale.ts|ks_bulk_select|all": "be32cb107e5a",
   "../../packages/design-system/src/components/Data/KsDataTable/KsBulkSelect.locale.ts|ks_bulk_select|selected": "894aa5fe9555",
+  "../../packages/design-system/src/components/Data/KsDataTable/KsDataTable.locale.ts|ks_data_table|load_failed": "4123f0f5558a",
+  "../../packages/design-system/src/components/Data/KsDataTable/KsDataTable.locale.ts|ks_data_table|retry": "d8b8392e2c54",
   "../../packages/design-system/src/components/Data/KsDataTable/KsFilter.locale.ts|add": "9fd728c66c9a",
   "../../packages/design-system/src/components/Data/KsDataTable/KsFilter.locale.ts|filter|active key value pairs": "083b0e2a07f2",
   "../../packages/design-system/src/components/Data/KsDataTable/KsFilter.locale.ts|filter|add_advanced_filter": "f71cb7ee1db3",


### PR DESCRIPTION
When a list request failed, the table fell back to its empty state, so an `HTTP 500` was shown to the user as "No Flows Found... Looks like there's nothing here yet". The rejection was also unhandled, and there was no way to retry.

It now shows a short error with a `Try again` button, and the empty state is only used when the request actually succeeded with no rows.

Reproduced on a local instance with the flows search endpoint forced to return `500`.
<img width="2818" height="646" alt="image" src="https://github.com/user-attachments/assets/782ac913-3d81-408d-b1c6-2d3b9ce34f7d" />
