### PR TITLE
fix(system): stop the version tooltip covering the theme toggle

### DIFF
--- a/ui/src/components/ContextInfoBar.vue
+++ b/ui/src/components/ContextInfoBar.vue
@@ -20,6 +20,7 @@
 
         <el-tooltip
             effect="light"
+            placement="top"
             :persistent="false"
             transition=""
             :hide-after="0"


### PR DESCRIPTION
Related to https://github.com/kestra-io/kestra/issues/18758.
Related to https://github.com/kestra-io/kestra/pull/19099.

### ✨ Description

Backport of https://github.com/kestra-io/kestra/pull/19099 to `releases/v1.0.x`, which carries the same `ui/src/components/ContextInfoBar.vue` as 1.3.

The version number tooltip in the right context bar opened downwards, landing directly on top of the theme toggle button that sits immediately below it, so users had to route the cursor around the popup to click the toggle. `placement="top"` moves the popup into the empty flex gap above the version number instead.

`releases/v2.0.x` and `develop` are not affected: the component no longer exists there, since the version and commit info moved into `AdminItem.vue` and the theme toggle into settings, so the two are no longer adjacent.

### 🎨 Frontend Checklist

Same single attribute as the already-merged 1.3 `PR`, on an identical file, so the `UI` behaviour and the screenshot on https://github.com/kestra-io/kestra/pull/19099 apply verbatim here. Type checking, build and unit tests are left to `CI` on this branch rather than re-run locally for a one-attribute template change.
