### PR TITLE
fix(flows): recipe panels and task picker stop mutating their props

### DIFF
--- a/ui/eslint.config.js
+++ b/ui/eslint.config.js
@@ -38,6 +38,7 @@ export default defineConfig([
             // Semantic rules
             "vue/block-lang": ["error", {"script": {"lang": "ts"}}],
             "vue/component-api-style": ["error", ["script-setup"]],
+            "vue/no-mutating-props": "error",
             "vue/this-in-template": "error",
             "vue/block-order": ["error", {order: ["template", "script", "style"]}],
             "vue/enforce-style-attribute": ["warn", {"allow": ["scoped"]}],

--- a/ui/src/components/flows/recipe/FlowRecipe.vue
+++ b/ui/src/components/flows/recipe/FlowRecipe.vue
@@ -53,6 +53,8 @@
                     <div class="trigger-config">
                         <ExecutionPanel
                             v-if="recipe.triggerType === 'execution'"
+                            v-model:watchNamespace="recipe.watchNamespace"
+                            v-model:includeSub="recipe.includeSub"
                             :recipe="recipe"
                             :namespaceOptions="namespaceOptions"
                             :namespacesLoading="namespacesLoading"
@@ -60,11 +62,12 @@
                         />
                         <SchedulePanel
                             v-else-if="recipe.triggerType === 'schedule'"
-                            :recipe="recipe"
+                            v-model:cron="recipe.cron"
+                            v-model:timezone="recipe.timezone"
                         />
                         <WebhookPanel
                             v-else-if="recipe.triggerType === 'webhook'"
-                            :recipe="recipe"
+                            v-model:webhookKey="recipe.webhookKey"
                             :systemNamespace="systemNamespace"
                             :flowId="flowId"
                         />
@@ -81,6 +84,9 @@
                     <span class="wizard-sub">{{ $t("recipe.then.subtitle") }}</span>
 
                     <NotifyGrid
+                        v-model:slackChannel="recipe.slackChannel"
+                        v-model:teamsWebhook="recipe.teamsWebhook"
+                        v-model:emailTo="recipe.emailTo"
                         :recipe="recipe"
                         :channelAvailability="channelAvailability"
                         :toggleNotify="toggleNotify"

--- a/ui/src/components/flows/recipe/FlowRecipe.vue
+++ b/ui/src/components/flows/recipe/FlowRecipe.vue
@@ -55,7 +55,7 @@
                             v-if="recipe.triggerType === 'execution'"
                             v-model:watchNamespace="recipe.watchNamespace"
                             v-model:includeSub="recipe.includeSub"
-                            :recipe="recipe"
+                            :states="recipe.states"
                             :namespaceOptions="namespaceOptions"
                             :namespacesLoading="namespacesLoading"
                             :toggleState="toggleState"
@@ -87,7 +87,8 @@
                         v-model:slackChannel="recipe.slackChannel"
                         v-model:teamsWebhook="recipe.teamsWebhook"
                         v-model:emailTo="recipe.emailTo"
-                        :recipe="recipe"
+                        :notify="recipe.notify"
+                        :triggerType="recipe.triggerType"
                         :channelAvailability="channelAvailability"
                         :toggleNotify="toggleNotify"
                     />

--- a/ui/src/components/flows/recipe/NotifyGrid.vue
+++ b/ui/src/components/flows/recipe/NotifyGrid.vue
@@ -5,7 +5,7 @@
             :key="channel.key"
             role="checkbox"
             layout="column"
-            :selected="recipe.notify[channel.key]"
+            :selected="notify[channel.key]"
             :disabled="!channelAvailability[channel.key]"
             :ariaLabel="channel.label"
             @select="toggleNotify(channel.key)"
@@ -17,7 +17,7 @@
                     </KsIcon>
                 </div>
                 <KsIcon class="check-indicator" aria-hidden="true">
-                    <component :is="recipe.notify[channel.key] ? CheckboxMarked : CheckboxBlankOutline" />
+                    <component :is="notify[channel.key] ? CheckboxMarked : CheckboxBlankOutline" />
                 </KsIcon>
             </div>
             <span class="channel-label">{{ channel.label }}</span>
@@ -28,7 +28,7 @@
 
             <template #config>
                 <KsInput
-                    v-if="channel.key === 'slack' && recipe.triggerType === 'execution'"
+                    v-if="channel.key === 'slack' && triggerType === 'execution'"
                     v-model="slackChannel"
                     :placeholder="$t('recipe.notify.slack_channel_placeholder')"
                     size="small"
@@ -59,7 +59,7 @@
 <script setup lang="ts">
     import {computed, type Component} from "vue"
     import {useI18n} from "vue-i18n"
-    import type {NotifyChannel, RecipeState} from "../../../composables/useFlowRecipe"
+    import type {NotifyChannel, TriggerType} from "../../../composables/useFlowRecipe"
     import SelectableTile from "./SelectableTile.vue"
 
     import Slack from "vue-material-design-icons/Slack.vue"
@@ -70,7 +70,8 @@
     import CheckboxBlankOutline from "vue-material-design-icons/CheckboxBlankOutline.vue"
 
     defineProps<{
-        recipe: RecipeState
+        notify: Record<NotifyChannel, boolean>
+        triggerType: TriggerType
         channelAvailability: Record<NotifyChannel, boolean>
         toggleNotify: (key: NotifyChannel) => void
     }>()

--- a/ui/src/components/flows/recipe/NotifyGrid.vue
+++ b/ui/src/components/flows/recipe/NotifyGrid.vue
@@ -29,21 +29,21 @@
             <template #config>
                 <KsInput
                     v-if="channel.key === 'slack' && recipe.triggerType === 'execution'"
-                    v-model="recipe.slackChannel"
+                    v-model="slackChannel"
                     :placeholder="$t('recipe.notify.slack_channel_placeholder')"
                     size="small"
                     data-test="recipe-slack-channel"
                 />
                 <KsInput
                     v-else-if="channel.key === 'teams'"
-                    v-model="recipe.teamsWebhook"
+                    v-model="teamsWebhook"
                     :placeholder="$t('recipe.notify.teams_webhook_placeholder')"
                     size="small"
                     data-test="recipe-teams-webhook"
                 />
                 <KsInput
                     v-else-if="channel.key === 'email'"
-                    v-model="recipe.emailTo"
+                    v-model="emailTo"
                     :placeholder="$t('recipe.notify.email_to_placeholder')"
                     size="small"
                     data-test="recipe-email-to"
@@ -74,6 +74,10 @@
         channelAvailability: Record<NotifyChannel, boolean>
         toggleNotify: (key: NotifyChannel) => void
     }>()
+
+    const slackChannel = defineModel<string>("slackChannel", {required: true})
+    const teamsWebhook = defineModel<string>("teamsWebhook", {required: true})
+    const emailTo = defineModel<string>("emailTo", {required: true})
 
     const {t} = useI18n()
 

--- a/ui/src/components/flows/recipe/triggerPanels/ExecutionPanel.vue
+++ b/ui/src/components/flows/recipe/triggerPanels/ExecutionPanel.vue
@@ -2,7 +2,7 @@
     <KsForm class="execution-panel" labelPosition="top" @submit.prevent>
         <KsFormItem :label="$t('recipe.execution.watch_namespace')">
             <KsSelect
-                v-model="recipe.watchNamespace"
+                v-model="watchNamespace"
                 filterable
                 clearable
                 :loading="namespacesLoading"
@@ -20,13 +20,13 @@
 
         <KsFormItem>
             <KsCheckbox
-                v-model="recipe.includeSub"
+                v-model="includeSub"
                 data-test="recipe-include-sub"
             >
                 {{ $t("recipe.execution.include_sub") }}
             </KsCheckbox>
             <span class="hint">
-                {{ recipe.includeSub ? $t("recipe.execution.include_sub_hint_on") : $t("recipe.execution.include_sub_hint_off") }}
+                {{ includeSub ? $t("recipe.execution.include_sub_hint_on") : $t("recipe.execution.include_sub_hint_off") }}
             </span>
         </KsFormItem>
 
@@ -67,6 +67,9 @@
     }>(), {
         namespacesLoading: false,
     })
+
+    const watchNamespace = defineModel<string>("watchNamespace", {required: true})
+    const includeSub = defineModel<boolean>("includeSub", {required: true})
 
     const watchableStates = ["FAILED", "WARNING", "SUCCESS", "KILLED", "PAUSED"]
 </script>

--- a/ui/src/components/flows/recipe/triggerPanels/ExecutionPanel.vue
+++ b/ui/src/components/flows/recipe/triggerPanels/ExecutionPanel.vue
@@ -35,7 +35,7 @@
                 <KsCheckTag
                     v-for="stateName in watchableStates"
                     :key="stateName"
-                    :checked="recipe.states.includes(stateName)"
+                    :checked="states.includes(stateName)"
                     pill
                     @change="toggleState(stateName)"
                 >
@@ -43,10 +43,10 @@
                     {{ stateName }}
                 </KsCheckTag>
             </div>
-            <span v-if="recipe.states.length === 0" class="hint hint-error">
+            <span v-if="states.length === 0" class="hint hint-error">
                 {{ $t("recipe.execution.states_required") }}
             </span>
-            <span v-else-if="recipe.states.includes('FAILED')" class="hint hint-reco">
+            <span v-else-if="states.includes('FAILED')" class="hint hint-reco">
                 <Check class="hint-icon" />
                 {{ $t("recipe.execution.states_recommended") }}
             </span>
@@ -57,10 +57,9 @@
 <script setup lang="ts">
     import {STATES} from "@kestra-io/design-system"
     import Check from "vue-material-design-icons/Check.vue"
-    import type {RecipeState} from "../../../../composables/useFlowRecipe"
 
     withDefaults(defineProps<{
-        recipe: RecipeState
+        states: string[]
         namespaceOptions: string[]
         namespacesLoading?: boolean
         toggleState: (stateName: string) => void
@@ -68,7 +67,7 @@
         namespacesLoading: false,
     })
 
-    const watchNamespace = defineModel<string>("watchNamespace", {required: true})
+    const watchNamespace = defineModel<string>("watchNamespace")
     const includeSub = defineModel<boolean>("includeSub", {required: true})
 
     const watchableStates = ["FAILED", "WARNING", "SUCCESS", "KILLED", "PAUSED"]

--- a/ui/src/components/flows/recipe/triggerPanels/SchedulePanel.vue
+++ b/ui/src/components/flows/recipe/triggerPanels/SchedulePanel.vue
@@ -10,7 +10,7 @@
 
         <KsFormItem :label="$t('recipe.schedule.cron')">
             <KsInput
-                v-model="recipe.cron"
+                v-model="cron"
                 class="cron-input"
                 :placeholder="DEFAULT_CRON"
                 data-test="recipe-cron-input"
@@ -20,7 +20,7 @@
 
         <KsFormItem :label="$t('recipe.schedule.timezone')">
             <KsSelect
-                v-model="recipe.timezone"
+                v-model="timezone"
                 filterable
                 clearable
                 :placeholder="$t('recipe.schedule.timezone_placeholder')"
@@ -40,13 +40,11 @@
 <script setup lang="ts">
     import {computed} from "vue"
     import {useI18n} from "vue-i18n"
-    import type {RecipeState} from "../../../../composables/useFlowRecipe"
     import {DEFAULT_CRON} from "../../../../utils/recipeToYaml"
     import {timeZones} from "../../../../utils/timeZones"
 
-    const props = defineProps<{
-        recipe: RecipeState
-    }>()
+    const cron = defineModel<string>("cron", {required: true})
+    const timezone = defineModel<string>("timezone", {required: true})
 
     const {t} = useI18n()
 
@@ -65,14 +63,14 @@
 
     const selectedFrequency = computed({
         get() {
-            for (const [key, cron] of Object.entries(FREQUENCY_CRONS)) {
-                if (props.recipe.cron === cron) return key
+            for (const [key, candidate] of Object.entries(FREQUENCY_CRONS)) {
+                if (cron.value === candidate) return key
             }
             return "custom"
         },
         set(value: string) {
             if (value !== "custom" && FREQUENCY_CRONS[value]) {
-                props.recipe.cron = FREQUENCY_CRONS[value]
+                cron.value = FREQUENCY_CRONS[value]
             }
         },
     })

--- a/ui/src/components/flows/recipe/triggerPanels/SchedulePanel.vue
+++ b/ui/src/components/flows/recipe/triggerPanels/SchedulePanel.vue
@@ -44,7 +44,7 @@
     import {timeZones} from "../../../../utils/timeZones"
 
     const cron = defineModel<string>("cron", {required: true})
-    const timezone = defineModel<string>("timezone", {required: true})
+    const timezone = defineModel<string>("timezone")
 
     const {t} = useI18n()
 

--- a/ui/src/components/flows/recipe/triggerPanels/WebhookPanel.vue
+++ b/ui/src/components/flows/recipe/triggerPanels/WebhookPanel.vue
@@ -2,7 +2,7 @@
     <KsForm class="webhook-panel" labelPosition="top" @submit.prevent>
         <KsFormItem :label="$t('recipe.webhook.key_label')">
             <KsInput
-                v-model="recipe.webhookKey"
+                v-model="webhookKey"
                 class="key-input"
                 :placeholder="$t('recipe.webhook.key_placeholder')"
                 data-test="recipe-webhook-key"
@@ -29,21 +29,21 @@
 <script setup lang="ts">
     import {computed} from "vue"
     import ContentCopy from "vue-material-design-icons/ContentCopy.vue"
-    import type {RecipeState} from "../../../../composables/useFlowRecipe"
     import * as Utils from "../../../../utils/utils"
     import {webhookUrl} from "../../../../utils/webhook"
     import {DEFAULT_WEBHOOK_KEY} from "../../../../utils/recipeToYaml"
 
     const props = defineProps<{
-        recipe: RecipeState
         systemNamespace: string
         flowId: string
     }>()
 
+    const webhookKey = defineModel<string>("webhookKey", {required: true})
+
     const endpointUrl = computed(() => webhookUrl({
         namespace: props.systemNamespace,
         id: props.flowId,
-        key: props.recipe.webhookKey || DEFAULT_WEBHOOK_KEY,
+        key: webhookKey.value || DEFAULT_WEBHOOK_KEY,
     }))
 
     const copyUrl = () => {

--- a/ui/src/components/no-code/blocks/BlockTaskPicker.vue
+++ b/ui/src/components/no-code/blocks/BlockTaskPicker.vue
@@ -17,7 +17,7 @@
                 <p class="block-editor-picker-context">{{ $t('block_editor.inserting_into', {section: sectionLabel}) }}</p>
 
                 <KsInput
-                    :ref="(el) => (picker.pickerSearchInput.value = el)"
+                    :ref="setSearchInput"
                     v-model="taskPickerSearch"
                     :placeholder="$t('block_editor.search_task_placeholder')"
                     :aria-label="$t('block_editor.search_task_placeholder')"
@@ -122,6 +122,7 @@
 </template>
 
 <script setup lang="ts">
+    import type {ComponentPublicInstance} from "vue"
     import ChevronLeft from "vue-material-design-icons/ChevronLeft.vue"
     import {KsInput, vKsLoading} from "@kestra-io/design-system"
     import TaskIcon from "../../plugins/TaskIcon.vue"
@@ -129,6 +130,11 @@
     import type {TaskPickerApi} from "./useTaskPicker"
 
     const props = defineProps<{picker: TaskPickerApi, modal?: boolean}>()
+
+    const {pickerSearchInput} = props.picker
+    const setSearchInput = (el: Element | ComponentPublicInstance | null) => {
+        pickerSearchInput.value = el
+    }
 
     const pluginsStore = usePluginsStore()
 


### PR DESCRIPTION
The recipe wizard panels wrote straight into the `recipe` prop with `v-model="recipe.cron"` and friends, and `BlockTaskPicker` assigned into `picker.pickerSearchInput.value` from a template ref. Ten `vue/no-mutating-props` violations in five files.

Each edited field is now its own `defineModel`, so `FlowRecipe.vue` binds `v-model:cron`, `v-model:webhookKey` and so on, and the parent keeps ownership of `recipe`. `BlockTaskPicker` destructures the ref out of `picker` and assigns through a `setSearchInput` handler.

After review: `watchNamespace` and `timezone` are bound to `clearable` selects, which emit `undefined` on clear, so those two models are no longer `required` and the `Invalid prop: type check failed` warning on clear is gone. `ExecutionPanel` and `NotifyGrid` now take `states`, `notify` and `triggerType` instead of the whole `recipe`, so each value reaches them by one route only.

`vue/no-mutating-props` is enabled in `eslint.config.js`. A new violation fails `npm run test:lint` locally; in CI eslint runs through reviewdog, so it shows up as a review comment rather than a red check.
