### PR TITLE
build(tests): eslint rejects JavaScript files in the app, test and storybook trees

### DIFF
--- a/ui/eslint.config.js
+++ b/ui/eslint.config.js
@@ -5,6 +5,25 @@ import {defineConfig, globalIgnores} from "eslint/config"
 export default defineConfig([
     globalIgnores(["**/node_modules/*", "node/*", "playwright-report/*", "test-results/*", "coverage/*", "**/dist/*", "packages/kestra-sdk/src/openapi/*"]),
     ...pluginVue.configs["flat/base"],
+    // Tooling (plugins/, scripts/, lint-rules/, *.config.js) stays JS on purpose; the app, test and storybook trees do not.
+    {
+        files: [
+            "src/**/*.{js,jsx,mjs,cjs}",
+            "tests/**/*.{js,jsx,mjs,cjs}",
+            ".storybook/**/*.{js,jsx,mjs,cjs}",
+            "packages/*/src/**/*.{js,jsx,mjs,cjs}",
+            "packages/*/tests/**/*.{js,jsx,mjs,cjs}",
+            "packages/*/.storybook/**/*.{js,jsx,mjs,cjs}",
+        ],
+        languageOptions: {parser: tsParser, parserOptions: {ecmaFeatures: {jsx: true}}},
+        linterOptions: {noInlineConfig: true},
+        rules: {
+            "no-restricted-syntax": ["error", {
+                selector: "Program",
+                message: "Write this as TypeScript: JavaScript files are not allowed in the app, test or storybook trees.",
+            }],
+        },
+    },
     // Formatting rules for JS/TS files (not .vue — handled below by vue/* variants)
     {
         files: ["**/*.{js,mjs,cjs,ts}"],


### PR DESCRIPTION
Follows up on review comment of kestra-io/kestra-ee#10794, "maybe we could check and lint away files that are js": https://github.com/kestra-io/kestra-ee/pull/10794#pullrequestreview-5138774804

Now that every story, spec and setup file is TypeScript, this adds an eslint rule so it stays that way. Any `.js`, `.jsx`, `.mjs` or `.cjs` file under `src/`, `tests/`, `.storybook/`, or the same folders inside `packages/*`, fails lint with "Write this as TypeScript". Inline `eslint-disable` comments cannot switch it off for those files.

<img width="3394" height="1942" alt="kestra-js-guard-failure" src="https://github.com/user-attachments/assets/9e6ed76a-0d7c-4cef-9ed2-687c12e0b966" />
<img width="2594" height="1357" alt="kestra-js-guard-success" src="https://github.com/user-attachments/assets/0d9b5391-3605-478d-be5e-69672dc92e4c" />
