### PR TITLE
fix(core): let the english-copy rule accept kestra entity nouns and product names

### DIFF
--- a/ui/scripts/translations/translationRules.mjs
+++ b/ui/scripts/translations/translationRules.mjs
@@ -186,7 +186,9 @@ const NEVER_TRANSLATED_WORDS = new Set([
     "outputs", "port", "ports", "worker", "workers", "backfill", "backfills", "healthcheck",
     "min", "max",
     // Terms of the same kind the model declines to translate in every locale, so an English value
-    // for them is a deliberate choice rather than a skipped translation.
+    // for them is a deliberate choice rather than a skipped translation. Execution and asset are
+    // Kestra entity nouns the German and Polish glossaries in the prompt already keep in English.
+    "execution", "executions", "asset", "assets", "vsphere",
     "secret", "secrets", "token", "tokens", "payload", "payloads", "context", "email", "webhook",
     "webhooks", "true", "false",
     // Brands, product and format names.


### PR DESCRIPTION
## What

The English-copy rule in `ui/scripts/translations/translationRules.mjs` (values identical to English in the non-Latin-script locales) is failing the `EE` `Translations - Generate translations` job on two feature branches today, `feat/tenant-focus` and `feat/bundle-blueprints`, for `Execution`, `Asset` and `vSphere`: the model returns those words unchanged in `hi`, `ja`, `ko`, `ru` and `zh_CN`, and rerolls cannot change that.

`Execution` and `asset` are `Kestra` entity nouns that the prompt's German and Polish glossaries already keep in English, and `vSphere` is a product name, so a value made only of those words is a deliberate choice, not a skipped translation. They join `NEVER_TRANSLATED_WORDS`, next to `flow`, `namespace` and `tenant`. The rule still fires when such a word sits inside real prose, since any other translatable word in the message keeps the check active.

## Evidence

`check-translations.mjs --scope oss` passes on `develop`. Run against the two blocked `EE` branches, the rule stops reporting `applications.requests.columns.execution`, `applications.requests.columns.asset` and `tenant.focus.infraNav.mappingsPage.vsphere`. What remains there after `CI`'s regeneration is `Mine`, `Flavor`, `secret`, `identity` and `metadata key`, ordinary words the model refused for those keys, which their authors need to reword or glossary; that is the rule doing its job.

Checked against the `kestra-io/actions` composite: it already checks out `ui/scripts/translations/`, and this file reads nothing new, so no `actions` change is needed for `OSS` or `EE`.

## Backport

A 2.0 backport `PR` follows.

Related to https://github.com/kestra-io/kestra/pull/19021.