### PR TITLE
fix(core): let the english-copy rule accept kestra entity nouns and product names (2.0 backport)

### DIFF
--- a/ui/scripts/translations/translationRules.mjs
+++ b/ui/scripts/translations/translationRules.mjs
@@ -186,7 +186,9 @@ const NEVER_TRANSLATED_WORDS = new Set([
     "outputs", "port", "ports", "worker", "workers", "backfill", "backfills", "healthcheck",
     "min", "max",
     // Terms of the same kind the model declines to translate in every locale, so an English value
-    // for them is a deliberate choice rather than a skipped translation.
+    // for them is a deliberate choice rather than a skipped translation. Execution and asset are
+    // Kestra entity nouns the German and Polish glossaries in the prompt already keep in English.
+    "execution", "executions", "asset", "assets", "vsphere",
     "secret", "secrets", "token", "tokens", "payload", "payloads", "context", "email", "webhook",
     "webhooks", "true", "false",
     // Brands, product and format names.


### PR DESCRIPTION
Backport of https://github.com/kestra-io/kestra/pull/19117 to `releases/v2.0.x`. Clean cherry-pick of the `develop` commit.

## What

`execution`, `asset` and `vsphere` join the never-translated word list of the English-copy rule: the first two are `Kestra` entity nouns the prompt's German and Polish glossaries already keep in English, the third a product name. The rule was failing `EE` feature branches on exactly those single-word values.

## Evidence

`check-translations.mjs --scope oss` passes on this branch. The file reads nothing new, so the `kestra-io/actions` composite needs no change.

Related to https://github.com/kestra-io/kestra/pull/19117.