### PR TITLE
test(core): disable the HTTP basic-auth sanity checks (v1.0.x)

### DIFF
--- a/core/src/test/java/io/kestra/plugin/core/http/RequestRunnerTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/http/RequestRunnerTest.java
@@ -1,5 +1,6 @@
 package io.kestra.plugin.core.http;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import io.kestra.core.junit.annotations.ExecuteFlow;
@@ -26,6 +27,7 @@ public class RequestRunnerTest {
     }
 
     @Test
+    @Disabled("The remote page didn't work anymore")
     @ExecuteFlow("sanity-checks/request-basicauth.yaml")
     void requestBasicAuth(Execution execution) {
         assertThat(execution.getTaskRunList()).hasSize(2);
@@ -33,6 +35,7 @@ public class RequestRunnerTest {
     }
 
     @Test
+    @Disabled("The remote page didn't work anymore")
     @ExecuteFlow("sanity-checks/request-basicauth-deprecated.yaml")
     void requestBasicAuthDeprecated(Execution execution) {
         assertThat(execution.getTaskRunList()).hasSize(2);


### PR DESCRIPTION
`testpages.eviltester.com` restructured: `/styled/auth/basic-auth-results.html` now returns 404, and the replacement page (`/pages/auth/basic-auth/`) answers 200 without credentials, so there is no protected endpoint left on that host.

`RequestRunnerTest.requestBasicAuth` and `requestBasicAuthDeprecated` therefore fail on every release line whose `:core:test` actually runs (0.22 through 1.3 are all red on it; 2.0 only looks green because its test task came `FROM-CACHE`). `pre-release.yml` gates Publish Maven and Github Release on the backend tests, so this blocks the 1.0.x release.

Disabling both with `@Disabled("The remote page didn't work anymore")` to unblock the release. Follow-up: point the two sanity-check flows at an endpoint we control instead of a third-party site — the same URL is still on `develop` and every other release branch.