### PR TITLE
fix(core): the browser back button no longer skips the page you came from

### DIFF
--- a/ui/src/composables/useTenant.ts
+++ b/ui/src/composables/useTenant.ts
@@ -31,7 +31,15 @@ export function setupTenantRouter(router: Router, app: App): void {
         if (to.path !== "/" && !to.params.tenant) {
             // Use current tenant from route context, fallback to "main"
             const currentTenant = from.params?.tenant || "main"
-            return {path: `/${currentTenant}${to.path}`, query: to.query, hash: to.hash, replace: true}
+            // No `replace` here: vue-router merges whatever this guard returns
+            // over the outer navigation's own options, so setting it explicitly
+            // - even to `false` - would override a caller's `router.replace()`
+            // and silently turn it into a `push`. Leaving it out lets
+            // vue-router's own first-navigation handling (which already forces
+            // a replace when there is no real previous page to preserve) do the
+            // right thing, while every later navigation keeps whatever
+            // push/replace semantics its caller intended.
+            return {path: `/${currentTenant}${to.path}`, query: to.query, hash: to.hash}
         }
         return true
     })

--- a/ui/tests/unit/composables/useTenant.spec.ts
+++ b/ui/tests/unit/composables/useTenant.spec.ts
@@ -1,0 +1,40 @@
+import {describe, it, expect, vi} from "vitest"
+import {createApp} from "vue"
+import {createRouter, createMemoryHistory} from "vue-router"
+
+import {setupTenantRouter} from "../../../src/composables/useTenant"
+
+function buildRouter() {
+    const router = createRouter({
+        history: createMemoryHistory(),
+        routes: [
+            {path: "/", name: "home", component: {template: "<div/>"}},
+            {path: "/:tenant?/logs", name: "logs/list", component: {template: "<div/>"}},
+            {path: "/:tenant?/executions/:id", name: "executions/update", component: {template: "<div/>"}},
+        ],
+    })
+    const app = createApp({template: "<router-view/>"})
+    app.use(router)
+    setupTenantRouter(router, app)
+    return router
+}
+
+describe("setupTenantRouter", () => {
+    it("does not collapse a later in-app navigation that also lacks an explicit tenant", async () => {
+        const router = buildRouter()
+        await router.isReady()
+        await router.push({name: "logs/list"})
+
+        const replaceSpy = vi.spyOn(router.options.history, "replace")
+        const pushSpy = vi.spyOn(router.options.history, "push")
+
+        // A real second hop - e.g. a <router-link> built without $routeTo, so it
+        // still lacks an explicit tenant param - must still land on a *new*
+        // history entry, not overwrite the page the user was already on.
+        await router.push({name: "executions/update", params: {id: "123"}})
+
+        expect(router.currentRoute.value.fullPath).toBe("/main/executions/123")
+        expect(pushSpy).toHaveBeenCalledTimes(1)
+        expect(replaceSpy).not.toHaveBeenCalled()
+    })
+})


### PR DESCRIPTION
Closes https://github.com/kestra-io/kestra/issues/18994.

Related to https://github.com/kestra-io/kestra/pull/19100.

## What

Backport of https://github.com/kestra-io/kestra/pull/19100 to `releases/v2.0.x`. The issue was reported on 1.3.35, and `releases/v2.0.x` carries the same guard, so 2.0 needs it too.

The tenant-redirect guard in `setupTenantRouter` hardcoded `replace: true` for every navigation whose target was missing an explicit `tenant` param, so the tenant-corrected navigation overwrote the current history entry instead of pushing a new one. Any in-app link built without `$routeTo` hits that branch, including the `namespace`, `flowId` and `executionId` links in a log line, which is why the browser back button skipped `Logs` and landed on the dashboard after opening an `execution` from there.

The guard no longer sets `replace` at all, so each navigation keeps whatever push or replace semantics its caller intended, and `vue-router`'s own first-navigation handling still collapses the one case where there is no previous page to preserve. Setting the key explicitly, even to `false`, is not an option: `vue-router` merges the guard's return value over the outer navigation's own options, so it would override a caller's `router.replace()` and turn it into a `push`.

## Notes

- Applies cleanly on `releases/v2.0.x`: same guard shape and the same `vue-router` `^5.1.0` as `develop`. Authorship of the original commit is preserved.
- `EE` needs no companion `PR`: `ui-ee` never calls `setupTenantRouter`, it has its own `router.resolve` patch plus `router/authGuard.ts`, which corrects a missing `tenant` without `replace`.
- `releases/v1.3.x` still uses the callback form (`next({..., replace: true})`) and so needs the change written by hand, in a separate `PR`.

## Verification

- `ui/tests/unit/composables/useTenant.spec.ts` passes on this branch, and `eslint` is clean on both changed files.
- Verified the resulting semantics against the real source over a four-hop sequence: the `Logs` -> `execution` hop pushes a new entry, and a caller's `router.replace()` without an explicit `tenant` still replaces.
