### PR TITLE
docs(tests): correct build-comment's note on what an empty output is for (2.0 backport)

### DIFF
--- a/ui/scripts/translations/build-comment.mjs
+++ b/ui/scripts/translations/build-comment.mjs
@@ -1,7 +1,8 @@
 #!/usr/bin/env node
 // Turns the JSON reports written by check-translations.mjs (--report) into a
-// single Markdown PR comment body. Prints nothing (exit 0) if both reports
-// are clean, so the workflow can skip posting/updating a comment.
+// single Markdown PR comment body. Prints nothing (exit 0) if both reports are
+// clean, which the workflow hands to comment-update as an empty template so the
+// section a failing run left on the PR is cleared rather than outliving the fix.
 //
 // Usage: node ui-ee/scripts/translations/build-comment.mjs <oss-report.json> <ee-report.json>
 


### PR DESCRIPTION
Related to https://github.com/kestra-io/kestra/pull/18885.
Related to https://github.com/kestra-io/kestra-ee/pull/10642.

Comment-only change in `build-comment.mjs`, backported so the shared translation scripts stay byte-identical between `develop` and `releases/v2.0.x` and later cherry-picks apply cleanly. Companion of the `EE` workflow backport that clears the sticky translation comment once the check passes.