### PR TITLE
build(core): run the translation gate on every push to develop and the release branches

### DIFF
--- a/.github/workflows/translations-push.yml
+++ b/.github/workflows/translations-push.yml
@@ -1,0 +1,38 @@
+name: Translations - Push
+
+# The PR gate (`translations` job in pull-request.yml) only sees pull requests. A merge race between
+# two green PRs, a direct push or a cherry-pick that lands with a stale locale can still leave a
+# branch red, and nobody notices until the next unrelated PR against it fails the gate for its
+# author. This runs the same dependency-free check on every push to develop and the release
+# branches, so the branch itself reports the breakage.
+on:
+  push:
+    branches:
+      - develop
+      - 'releases/*'
+    paths:
+      # The used-key rule scans all of ui/src, so any UI change can introduce a key defined nowhere.
+      - 'ui/**'
+      - '.github/workflows/translations-push.yml'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  translations:
+    name: 'Translations - Key parity, placeholders and drift'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v7
+        name: Checkout
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version-file: 'ui/.nvmrc'
+
+      - name: Check translations
+        run: node ui/scripts/translations/check-translations.mjs --scope oss


### PR DESCRIPTION
Closes https://github.com/kestra-io/kestra/issues/19130.

## What

A small `Translations - Push` workflow that runs the dependency-free gate (`check-translations.mjs --scope oss`) on every push to `develop` and `releases/*` that touches `ui/**`. Same job as the `translations` job of the `PR` workflow, about a minute, no `npm ci`.

## Why

The gate only ran on pull requests. A merge race between two green `PRs`, a direct push or a cherry-pick with a stale locale could leave a branch red, and nobody noticed until the next unrelated `PR` against that branch failed the gate for its author. The `EE` counterpart is https://github.com/kestra-io/kestra-ee/pull/10839, which extends the existing `EE` push trigger to the release branches.

## `actions` repository

Checked for both repos: no composite is involved, the workflow is self-contained and the shared scripts read no new path.
