### PR TITLE
build(core): make translations:check run the PR gate before the comparer

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -31,7 +31,7 @@
         "test:storybook": "vitest run --project=storybook",
         "test:e2e": "./run-e2e-tests.sh",
         "test:e2e-without-starting-backend": "playwright test --config=tests/e2e/playwright.config.ts",
-        "translations:check": "node --experimental-strip-types ./scripts/translations/check.ts",
+        "translations:check": "node ./scripts/translations/check-translations.mjs --scope oss && node --experimental-strip-types ./scripts/translations/check.ts",
         "translations:generate": "node --experimental-strip-types ./scripts/translations/generate.ts",
         "lint": "oxlint --fix src packages tests && eslint --fix",
         "storybook": "storybook dev -p 6006",

--- a/ui/scripts/translations/README.md
+++ b/ui/scripts/translations/README.md
@@ -7,7 +7,7 @@ This directory holds the tooling that keeps the Kestra UI translated. This READM
 - English is the single source of truth: [`ui/src/translations/en.json`](../../src/translations/en.json) here, `ui-ee/src/translations/ee_translations/en.json` in EE. The twelve other languages are **generated** from it via Gemini - never hand-written.
 - Every key carries a **fingerprint** of the English text its translations were generated from. Editing an English value (even just capitalisation) marks the key stale in all languages and fails the check until regenerated.
 - **One shared implementation** lives here. EE keeps only thin entry points that import from this directory, so the two repositories cannot drift into different prompts, rules, or change detection.
-- Two commands, the same in both repositories: `npm run translations:generate` (needs `GEMINI_API_KEY`) and `npm run translations:check` (must report no missing / no extra / no stale keys for every language).
+- Two commands, the same in both repositories: `npm run translations:generate` (needs `GEMINI_API_KEY`) and `npm run translations:check`, which runs the PR gate and then the compiler-backed comparer, so a green local run is the same verdict CI gives.
 - A scheduled GitHub Action runs the generator every 3 hours on weekdays and opens a bot PR when there is anything to translate. A dependency-free PR gate checks key parity and placeholders on every PR.
 
 ## The files
@@ -95,13 +95,13 @@ Key points:
 
 Two checkers apply the same shared rules at different depths:
 
-| | `translations:check` ([`compareTranslations.ts`](compareTranslations.ts)) | PR gate ([`check-translations.mjs`](check-translations.mjs)) |
+| | Comparer ([`compareTranslations.ts`](compareTranslations.ts)) | PR gate ([`check-translations.mjs`](check-translations.mjs)) |
 |---|---|---|
-| Runs | Locally + at the end of the auto-translate workflow | CI, on every PR touching translations or UI source, forks included |
+| Runs | Second half of `npm run translations:check`, and at the end of the auto-translate workflow | CI, on every PR touching translations or UI source (forks included) and on every push to `develop` and `releases/*`; first half of `npm run translations:check` |
 | Needs | `node_modules` (vue-i18n's real message compiler) | Nothing - Node builtins only, runs before `npm ci` |
 | Checks | Missing / extra / **stale** keys (fingerprints), placeholders through the actual compiler | Key parity, **stale** keys (fingerprints), placeholder well-formedness + parity with English, untranslated English copies in non-Latin-script locales, EE keys shadowing OSS keys, keys used in code but defined in no `en.json` |
 
-A clean `translations:check` run reports **No missing keys / No extra keys / No stale keys** for every language - anything less blocks the merge. The PR gate applies the same staleness rule, so a fork PR, which gets no generated commit, cannot merge an edited English value without regenerating the other languages either.
+A clean `translations:check` run prints `Translation check passed (scope: oss)` from the gate and then **No missing keys / No extra keys / No stale keys** for every language from the comparer - anything less blocks the merge. `translations:check` runs both on purpose: the gate carries the rules the comparer does not have (used-but-undefined keys, runtime-built namespaces, EE keys shadowing OSS keys) and the comparer carries the real message compiler the dependency-free gate cannot load, so neither alone matches CI. The gate applies the same staleness rule, so a fork PR, which gets no generated commit, cannot merge an edited English value without regenerating the other languages either.
 
 The PR gate runs as two ownership-scoped passes so a failure points at the right repository:
 
@@ -143,7 +143,7 @@ sequenceDiagram
 
 1. Add the key to `en.json` (here, or `ee_translations/en.json` for EE-only strings). Reuse existing generic keys (`cancel`, `save`, `delete`, ...) instead of duplicating.
 2. Run `npm run translations:generate`, commit the locale files **and** `fingerprints.json` together.
-3. Run `npm run translations:check` - every language must report no missing / extra / stale keys.
+3. Run `npm run translations:check` - the gate must pass and every language must report no missing / extra / stale keys.
 
 Merging with only `en.json` updated also works - the bot fills the languages within a few hours - but the PR gate flags the missing keys, so generating yourself is the clean path.
 


### PR DESCRIPTION
Closes https://github.com/kestra-io/kestra/issues/19131.

## What

`npm run translations:check` now runs `check-translations.mjs --scope oss` first and the compiler-backed comparer (`check.ts`) second, and the `README` describes the two halves.

## Why

The local command only ran the comparer, so the rules that live only in the gate (keys used in code but defined in no `en.json`, runtime-built namespaces, `EE` keys shadowing `OSS` keys) were never checked locally and a green local run could still fail CI. The reverse gap holds too: the dependency-free gate cannot load vue-i18n's real compiler. Running both gives one local command with the CI verdict. `EE` counterpart: https://github.com/kestra-io/kestra-ee/pull/10840.

The auto-translate workflow calls `npm run translations:check` after `npm ci`, so it now also runs the gate at the end; both halves pass on `develop`.

## `actions` repository

Checked for both repos: the `kestra-ee-generate-translations` composite calls `translations:generate` and the gate shim directly, never `translations:check`, and the scripts read no new path.
