### PR TITLE
fix(scheduler): an unparseable flow no longer stalls its scheduling loop or floods the logs

### DIFF
--- a/scheduler/src/main/java/io/kestra/scheduler/TriggerEventHandler.java
+++ b/scheduler/src/main/java/io/kestra/scheduler/TriggerEventHandler.java
@@ -52,6 +52,7 @@ import io.kestra.core.scheduler.model.TriggerType;
 import io.kestra.core.scheduler.service.TriggerExecutionPublisher;
 import io.kestra.core.scheduler.store.TriggerStateStore;
 import io.kestra.core.services.ConditionService;
+import io.kestra.core.utils.ListUtils;
 import io.kestra.core.utils.Logs;
 import io.kestra.scheduler.internals.NextEvaluationDate;
 import io.kestra.scheduler.stores.FlowMetaStore;
@@ -611,7 +612,7 @@ public class TriggerEventHandler {
             return Pair.of(null, null);
         }
 
-        AbstractTrigger trigger = flow.getTriggers().stream()
+        AbstractTrigger trigger = ListUtils.emptyOnNull(flow.getTriggers()).stream()
             .filter(it -> it.getId().equals(event.id().getTriggerId()))
             .findFirst()
             .orElse(null);

--- a/scheduler/src/main/java/io/kestra/scheduler/TriggerScheduler.java
+++ b/scheduler/src/main/java/io/kestra/scheduler/TriggerScheduler.java
@@ -22,6 +22,7 @@ import org.slf4j.event.Level;
 import com.google.common.base.Throwables;
 
 import io.kestra.core.exceptions.FlowBlockedException;
+import io.kestra.core.exceptions.FlowProcessingException;
 import io.kestra.core.exceptions.InvalidTriggerConfigurationException;
 import io.kestra.core.metrics.MetricRegistry;
 import io.kestra.core.models.Label;
@@ -291,6 +292,8 @@ public class TriggerScheduler {
                 e.getMessage()
             );
             logBlockedByGovernance(flow, e);
+            return null;
+        } catch (FlowProcessingException e) {
             return null;
         }
     }

--- a/scheduler/src/main/java/io/kestra/scheduler/internals/DefaultSchedulableTriggerFetcher.java
+++ b/scheduler/src/main/java/io/kestra/scheduler/internals/DefaultSchedulableTriggerFetcher.java
@@ -16,6 +16,7 @@ import org.slf4j.LoggerFactory;
 import org.slf4j.event.Level;
 
 import io.kestra.core.exceptions.FlowBlockedException;
+import io.kestra.core.exceptions.FlowProcessingException;
 import io.kestra.core.exceptions.InvalidTriggerConfigurationException;
 import io.kestra.core.models.conditions.ConditionContext;
 import io.kestra.core.models.flows.FlowId;
@@ -97,6 +98,9 @@ public class DefaultSchedulableTriggerFetcher implements SchedulableTriggerFetch
                     // Skip the flow: it is blocked by governance and must not run.
                     logBlockedByGovernance(rawFlow, triggerState, e);
                     return null;
+                } catch (FlowProcessingException e) {
+                    disableUnparseable(clock, triggerState, e);
+                    return null;
                 }
 
                 // Validate that the trigger still exists and is enabled before processing. This check covers several cases:
@@ -107,7 +111,7 @@ public class DefaultSchedulableTriggerFetcher implements SchedulableTriggerFetch
                 // 2. and 3. can occur if the Flow has been updated but the associated TriggerEvent
                 // has not yet been processed. In these cases, 
                 final String triggerId = triggerState.getTriggerId();
-                Optional<AbstractTrigger> maybeTrigger = flow.getTriggers().stream().filter(it -> it.getId().equals(triggerId)).findFirst();
+                Optional<AbstractTrigger> maybeTrigger = ListUtils.emptyOnNull(flow.getTriggers()).stream().filter(it -> it.getId().equals(triggerId)).findFirst();
                 // Drafts are resolved away by the meta-store (find(revision=null) returns the latest
                 // non-draft revision), so no draft check is needed here — a draft never reaches this point.
                 if (flow.isDisabled() || maybeTrigger.isEmpty() || maybeTrigger.get().isDisabled()) {
@@ -156,6 +160,17 @@ public class DefaultSchedulableTriggerFetcher implements SchedulableTriggerFetch
         } catch (DateTimeException e) {
             throw new InvalidTriggerConfigurationException();
         }
+    }
+
+    private void disableUnparseable(final Clock clock, final TriggerState triggerState, final FlowProcessingException e) {
+        triggerStateStore.save(triggerState.disabled(clock, true));
+        Logs.logTrigger(
+            triggerState,
+            LOG,
+            Level.WARN,
+            "Disabled: the flow cannot be parsed on this version ({}). Fix the flow and save it to re-enable the trigger.",
+            e.getMessage()
+        );
     }
 
     /**

--- a/scheduler/src/main/java/io/kestra/scheduler/internals/TriggerFlowParser.java
+++ b/scheduler/src/main/java/io/kestra/scheduler/internals/TriggerFlowParser.java
@@ -3,6 +3,7 @@ package io.kestra.scheduler.internals;
 import org.slf4j.Logger;
 
 import io.kestra.core.exceptions.FlowBlockedException;
+import io.kestra.core.exceptions.FlowProcessingException;
 import io.kestra.core.models.flows.FlowWithSource;
 import io.kestra.core.services.FlowParsingService;
 
@@ -18,12 +19,17 @@ public final class TriggerFlowParser {
      * Parses the given flow for trigger evaluation, degrading to the flow as stored when parsing fails so
      * existing triggers keep evaluating.
      *
+     * @return the parsed flow, or the stored flow when parsing failed
+     *
+     * @throws FlowProcessingException when parsing failed and the stored flow carries no trigger definitions (a
+     *         deserialization failure kept as a {@code FlowWithException}): there is nothing to degrade to, and the
+     *         message tells the caller why so it can report it against the trigger
      * @throws FlowBlockedException when governance rejects the flow, whose triggers must then not run. Checked
      *         deliberately: a caller has to decide what to report, and a block reported as an ordinary parse
      *         failure is the confusion this guards against.
      */
     public static FlowWithSource parseForTrigger(final FlowParsingService flowParsingService, final FlowWithSource flow, final Logger logger)
-        throws FlowBlockedException {
+        throws FlowBlockedException, FlowProcessingException {
         try {
             return flowParsingService.parseForRuntime(flow).flow();
         } catch (FlowBlockedException e) {
@@ -34,9 +40,11 @@ public final class TriggerFlowParser {
                 flow.getTenantId(),
                 flow.getNamespace(),
                 flow.getId(),
-                e.getMessage(),
-                e
+                e.getMessage()
             );
+            if (flow.getTriggers() == null) {
+                throw e instanceof FlowProcessingException failure ? failure : new FlowProcessingException(e.getMessage());
+            }
             return flow;
         }
     }

--- a/scheduler/src/test/java/io/kestra/scheduler/internals/DefaultSchedulableTriggerFetcherTest.java
+++ b/scheduler/src/test/java/io/kestra/scheduler/internals/DefaultSchedulableTriggerFetcherTest.java
@@ -62,8 +62,8 @@ class DefaultSchedulableTriggerFetcherTest {
 
         // Then the valid trigger is still evaluated and the broken one is disabled until its flow is saved again
         assertThat(schedulable).extracting(context -> context.flow().getId()).containsExactly("valid");
-        assertThat(triggerStateStore.findById(brokenState).orElseThrow().isDisabled()).isTrue();
-        assertThat(triggerStateStore.findById(validState).orElseThrow().isDisabled()).isFalse();
+        assertThat(triggerStateStore.findByIdWithoutAcl(brokenState).orElseThrow().isDisabled()).isTrue();
+        assertThat(triggerStateStore.findByIdWithoutAcl(validState).orElseThrow().isDisabled()).isFalse();
     }
 
     private static FlowWithSource flow(String id) {

--- a/scheduler/src/test/java/io/kestra/scheduler/internals/DefaultSchedulableTriggerFetcherTest.java
+++ b/scheduler/src/test/java/io/kestra/scheduler/internals/DefaultSchedulableTriggerFetcherTest.java
@@ -1,0 +1,79 @@
+package io.kestra.scheduler.internals;
+
+import java.time.Clock;
+import java.time.ZonedDateTime;
+import java.util.List;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+
+import io.kestra.core.exceptions.FlowProcessingException;
+import io.kestra.core.models.flows.FlowWithException;
+import io.kestra.core.models.flows.FlowWithSource;
+import io.kestra.core.runners.ProcessedFlow;
+import io.kestra.core.runners.RunContextFactory;
+import io.kestra.core.scheduler.model.TriggerState;
+import io.kestra.core.services.FlowParsingService;
+import io.kestra.plugin.core.debug.Return;
+import io.kestra.plugin.core.trigger.Schedule;
+import io.kestra.scheduler.models.TriggerEvaluationContext;
+import io.kestra.scheduler.utils.InMemoryFlowMetaStore;
+import io.kestra.scheduler.utils.InMemoryTriggerStateStore;
+
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import jakarta.inject.Inject;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@MicronautTest
+class DefaultSchedulableTriggerFetcherTest {
+
+    private static final Schedule SCHEDULE = Schedule.builder().id("schedule").type(Schedule.class.getName()).cron("* * * * *").build();
+
+    @Inject
+    RunContextFactory runContextFactory;
+
+    @Test
+    void shouldDisableTriggerAndKeepOthersWhenFlowIsUnparseable() throws Exception {
+        // Given two due triggers on the same vNode, one whose flow could not be deserialized on this version
+        Clock clock = Clock.systemUTC();
+        ZonedDateTime now = ZonedDateTime.now(clock);
+        FlowWithSource valid = flow("valid");
+        FlowWithSource broken = FlowWithException.from(flow("broken"), new FlowProcessingException("Invalid type: io.kestra.plugin.core.flow.ForEach"));
+        InMemoryTriggerStateStore triggerStateStore = new InMemoryTriggerStateStore();
+        TriggerState validState = TriggerState.of(valid, SCHEDULE, 0).updateForNextEvaluationDate(clock, now.minusMinutes(1));
+        TriggerState brokenState = TriggerState.of(broken, SCHEDULE, 0).updateForNextEvaluationDate(clock, now.minusMinutes(1));
+        triggerStateStore.save(validState);
+        triggerStateStore.save(brokenState);
+        FlowParsingService flowParsingService = mock(FlowParsingService.class);
+        when(flowParsingService.parseForRuntime(valid)).thenReturn(ProcessedFlow.of(valid));
+        when(flowParsingService.parseForRuntime(broken)).thenThrow(new FlowProcessingException("Invalid type: io.kestra.plugin.core.flow.ForEach"));
+        DefaultSchedulableTriggerFetcher fetcher = new DefaultSchedulableTriggerFetcher(
+            runContextFactory,
+            triggerStateStore,
+            new InMemoryFlowMetaStore(1, List.of(valid, broken)),
+            flowParsingService
+        );
+
+        // When
+        List<TriggerEvaluationContext> schedulable = fetcher.getSchedulableTriggers(clock, now, Set.of(0));
+
+        // Then the valid trigger is still evaluated and the broken one is disabled until its flow is saved again
+        assertThat(schedulable).extracting(context -> context.flow().getId()).containsExactly("valid");
+        assertThat(triggerStateStore.findById(brokenState).orElseThrow().isDisabled()).isTrue();
+        assertThat(triggerStateStore.findById(validState).orElseThrow().isDisabled()).isFalse();
+    }
+
+    private static FlowWithSource flow(String id) {
+        return FlowWithSource.builder()
+            .tenantId("main")
+            .namespace("io.kestra.tests")
+            .id(id)
+            .revision(1)
+            .tasks(List.of(Return.builder().id("return").type(Return.class.getName()).build()))
+            .triggers(List.of(SCHEDULE))
+            .build();
+    }
+}

--- a/scheduler/src/test/java/io/kestra/scheduler/internals/TriggerFlowParserTest.java
+++ b/scheduler/src/test/java/io/kestra/scheduler/internals/TriggerFlowParserTest.java
@@ -1,14 +1,18 @@
 package io.kestra.scheduler.internals;
 
+import java.util.List;
+
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import io.kestra.core.exceptions.FlowBlockedException;
 import io.kestra.core.exceptions.FlowProcessingException;
+import io.kestra.core.models.flows.FlowWithException;
 import io.kestra.core.models.flows.FlowWithSource;
 import io.kestra.core.runners.ProcessedFlow;
 import io.kestra.core.services.FlowParsingService;
+import io.kestra.plugin.core.trigger.Schedule;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -22,6 +26,7 @@ class TriggerFlowParserTest {
         .tenantId("main")
         .namespace("io.kestra.tests")
         .id("trigger-flow-parser")
+        .triggers(List.of(Schedule.builder().id("schedule").type(Schedule.class.getName()).cron("* * * * *").build()))
         .build();
 
     @Test
@@ -44,6 +49,19 @@ class TriggerFlowParserTest {
 
         // When / Then a non-governance failure keeps the flow as stored so existing triggers keep evaluating
         assertThat(TriggerFlowParser.parseForTrigger(flowParsingService, flow, LOGGER)).isSameAs(flow);
+    }
+
+    @Test
+    void shouldThrowWithTheReasonWhenStoredFlowHasNoTriggersAndParsingFails() throws Exception {
+        // Given a flow 2.0 could not deserialize: kept as FlowWithException, without its trigger definitions
+        FlowWithSource stored = FlowWithException.from(flow, new FlowProcessingException("Invalid type: io.kestra.plugin.core.flow.ForEach"));
+        FlowParsingService flowParsingService = mock(FlowParsingService.class);
+        when(flowParsingService.parseForRuntime(stored)).thenThrow(new FlowProcessingException("Invalid type: io.kestra.plugin.core.flow.ForEach"));
+
+        // When / Then there is nothing to degrade to: the caller gets the reason to report against the trigger
+        assertThatThrownBy(() -> TriggerFlowParser.parseForTrigger(flowParsingService, stored, LOGGER))
+            .isInstanceOf(FlowProcessingException.class)
+            .hasMessage("Invalid type: io.kestra.plugin.core.flow.ForEach");
     }
 
     @Test


### PR DESCRIPTION
### 🔗 Related Issue

No issue yet: found by the 1.3 → 2.0 migration QA campaign (internal report `oss-postgres-standalone-unmigrated-schedule-atda`, finding F8).

### ✨ Description

**Problem.** After upgrading to 2.0, a flow that still uses a removed task type (for example `io.kestra.plugin.core.flow.ForEach` left unmigrated) is stored as a `FlowWithException` without trigger definitions. The first time its `Schedule` trigger comes due, `DefaultSchedulableTriggerFetcher` dereferences the null trigger list; the `NullPointerException` aborts the evaluation of every trigger of that loop's vNodes, and because `TriggerSchedulingLoop` only advances `nextScheduleTime` after `onSchedule` returns, the tick is re-run immediately. Measured on 2.0.0 (OSS, Postgres, standalone): ~360 iterations per second, two stack traces each, 2.4 GB of container logs in 20 minutes (≈ 8 GB/h), and every schedule sharing the thread (a quarter of them in standalone) silent until the flow is fixed. Nothing is visible in the UI: no execution, and the trigger row is not listed.

**Fix.**
- `TriggerFlowParser.parseForTrigger` returns `null` when the stored flow has no trigger definitions (there is nothing to degrade to) and logs the parse failure without the stack trace. Flows that still carry their triggers keep the existing degrade-to-stored-flow behaviour.
- `DefaultSchedulableTriggerFetcher` disables the trigger state once and writes the reason to the trigger's logs, the same way an `InvalidTriggerConfigurationException` is handled. Saving the fixed flow re-enables the trigger through the existing flow-update path (verified on 2.0.0: the rewritten flow fired at its next tick). The trigger-list dereference is also null-guarded as a safety net.
- Null guard on the remaining trigger-list dereference in `TriggerEventHandler.findTrigger`.

**Evidence.** The two new tests fail on `develop` and pass with this change: the fetcher test with `NullPointerException: Cannot invoke "java.util.List.stream()" because the return value of "FlowWithSource.getTriggers()" is null`, the parser test because the broken flow is returned instead of rejected.

End to end, on `v2.0.0` + this commit cherry-picked (OSS, Postgres, standalone, 1.3.37 auto-migrated with the same forgotten ForEach flow): 0 `Error in scheduling loop` in 33 minutes (161 353 in 7.5 minutes before), the every-minute schedule kept firing once a minute during an 11-minute soak (stalled before), and the invalid trigger was disabled once with `Disabled: the flow cannot be parsed on this version (… Invalid type: io.kestra.plugin.core.flow.ForEach). Fix the flow and save it to re-enable the trigger.` in its trigger log.

### 🛠️ Backend Checklist

- [x] Code compiles and tests pass for the touched modules (`./gradlew :scheduler:test`, `./gradlew :jdbc-h2:test --tests "H2RunnerTest"`)
- [x] New behavior is covered by unit or integration tests

### 📝 Additional Notes

- Not in this PR (review): `TriggerSchedulingLoop` only advances `nextScheduleTime` after `onSchedule` returns, so any exception escaping `onSchedule` re-runs the tick immediately; that is what turned this NPE into ~360 iterations/s and ~8 GB/h of logs. Left to the ongoing loop rework.
- Trade-off: a transient parse failure (a plugin not installed yet) also disables the trigger until the flow is saved again or the trigger is re-enabled by hand. The WARN and the trigger log say so. This felt safer than re-parsing and re-logging the same flow every second forever.
- Deliberately not in this PR (different module): `TriggerController.toApiTriggerAndState` drops the trigger record when the flow has no trigger definitions, so the disabled trigger is not visible in the Triggers page while the flow is broken. Follow-up `fix(triggers)` PR.
- Candidate for the 2.0.x patch branch: any customer with one forgotten scheduled flow hits this at the first cron tick after the upgrade.

### 🤖 AI Authors

Drafted with Claude Code from the QA findings, reviewed by @AcevedoR. Why did the cat refuse to migrate its ForEach flow? It only had nine lives and the scheduler was burning through 360 of them per second. 🐱

