### PR TITLE
fix(core): private cache-control on tenant-scoped execution downloads

### DIFF
--- a/webserver/src/main/java/io/kestra/webserver/controllers/api/ExecutionController.java
+++ b/webserver/src/main/java/io/kestra/webserver/controllers/api/ExecutionController.java
@@ -1286,16 +1286,20 @@ public class ExecutionController {
                     seq.write(record);
                 }
             }
+            // `private`, not `public`: this file is tenant-scoped, so a shared cache must not replay
+            // it to a different requester, even though the content itself never changes.
             return HttpResponse.ok(
                 new StreamedFile(new ByteArrayInputStream(baos.toByteArray()), new MediaType("application/x-ndjson"))
                     .attach(downloadFilename)
-            );
+            ).header(HttpHeaders.CACHE_CONTROL, "private, max-age=86400");
         }
 
+        // `private`, not `public`: this file is tenant-scoped, so a shared cache must not replay it
+        // to a different requester, even though the content itself never changes.
         return HttpResponse.ok(
             new StreamedFile(fileHandler, MediaType.APPLICATION_OCTET_STREAM_TYPE)
                 .attach(FilenameUtils.getName(path.toString()))
-        );
+        ).header(HttpHeaders.CACHE_CONTROL, "private, max-age=86400");
     }
 
     private URI nsFileToInternalStorageURI(URI path, Execution execution) throws IOException {

--- a/webserver/src/main/java/io/kestra/webserver/controllers/api/LogController.java
+++ b/webserver/src/main/java/io/kestra/webserver/controllers/api/LogController.java
@@ -132,7 +132,9 @@ public class LogController {
             return response.header(HttpHeaders.CACHE_CONTROL, "no-cache");
         }
 
-        return response;
+        // `private`, not `public`: these logs are tenant-scoped, so a shared cache must not replay
+        // them to a different requester, even though a terminated execution's logs never change.
+        return response.header(HttpHeaders.CACHE_CONTROL, "private, max-age=86400");
     }
 
     @ExecuteOn(TaskExecutors.IO)


### PR DESCRIPTION
### Description

`ExecutionController.downloadFileFromExecution` and `LogController.downloadLogsFromExecution` (once an execution is terminated) return a `StreamedFile` with no explicit `Cache-Control`, so the framework's default `public, max-age=86400` applies.

`public` tells any shared/intermediate cache (proxy, CDN) that it may store and replay the response to a *different* requester — which is wrong for tenant-scoped content, regardless of whether the content itself ever changes. Since execution files and terminated-execution logs are genuinely immutable once written, disabling caching entirely (`no-cache`) would throw away a legitimate performance win; the actual problem is visibility, not lifetime.

Both endpoints now explicitly send `Cache-Control: private, max-age=86400` — same cache lifetime as the framework default, scoped to the requesting client's own cache instead of any shared cache in between.

### Backend Checklist

- [x] Code compiles and tests pass for the touched modules (`LogControllerTest`: 42 tests, `ExecutionControllerRunnerTest`: 111 tests)
- [x] No new behavior requiring a new test — this only changes a response header value on existing, already-tested endpoints

### Additional Notes

Found while auditing `StreamedFile` usage across the codebase for a related security fix (GHSA-9gp7-896w-m3r7). Not itself a vulnerability — flagged separately since it's a different concern (cache visibility, not header injection).

### AI Authors

Why did the cache header go to therapy? It had trust issues about who it was letting in. 🐱