### PR TITLE
fix(design-system): align the "last 30 days" filter value with the app's PT720H

### DIFF
--- a/ui/packages/design-system/src/components/Data/KsDataTable/filter/layout/FilterChip.vue
+++ b/ui/packages/design-system/src/components/Data/KsDataTable/filter/layout/FilterChip.vue
@@ -59,7 +59,7 @@
         {label: t("datepicker.last24hours"), value: "PT24H"},
         {label: t("datepicker.last48hours"), value: "PT48H"},
         {label: t("datepicker.last7days"), value: "PT168H"},
-        {label: t("datepicker.last30days"), value: "P30D"},
+        {label: t("datepicker.last30days"), value: "PT720H"},
         {label: t("datepicker.last365days"), value: "PT8760H"},
     ]
 

--- a/ui/packages/design-system/src/components/Data/KsDataTable/filter/layout/FilterChip.vue
+++ b/ui/packages/design-system/src/components/Data/KsDataTable/filter/layout/FilterChip.vue
@@ -63,19 +63,8 @@
         {label: t("datepicker.last365days"), value: "PT8760H"},
     ]
 
-    // A duration typed by hand or shipped as a `defaultDuration` may use an equivalent spelling of
-    // an option above (P30D for PT720H), which would otherwise render as the raw ISO string.
-    const RELATIVE_DATE_ALIASES: Record<string, string> = {
-        P1D: "PT24H",
-        P2D: "PT48H",
-        P7D: "PT168H",
-        P30D: "PT720H",
-        P365D: "PT8760H",
-    }
-
     const getRelativeDateLabel = (value: string): string => {
-        const normalized = RELATIVE_DATE_ALIASES[value] ?? value
-        const found = RELATIVE_DATE.find((item) => item.value === normalized)
+        const found = RELATIVE_DATE.find((item) => item.value === value)
         return found ? found.label : value
     }
 

--- a/ui/packages/design-system/src/components/Data/KsDataTable/filter/layout/FilterChip.vue
+++ b/ui/packages/design-system/src/components/Data/KsDataTable/filter/layout/FilterChip.vue
@@ -63,8 +63,19 @@
         {label: t("datepicker.last365days"), value: "PT8760H"},
     ]
 
+    // A duration typed by hand or shipped as a `defaultDuration` may use an equivalent spelling of
+    // an option above (P30D for PT720H), which would otherwise render as the raw ISO string.
+    const RELATIVE_DATE_ALIASES: Record<string, string> = {
+        P1D: "PT24H",
+        P2D: "PT48H",
+        P7D: "PT168H",
+        P30D: "PT720H",
+        P365D: "PT8760H",
+    }
+
     const getRelativeDateLabel = (value: string): string => {
-        const found = RELATIVE_DATE.find((item) => item.value === value)
+        const normalized = RELATIVE_DATE_ALIASES[value] ?? value
+        const found = RELATIVE_DATE.find((item) => item.value === normalized)
         return found ? found.label : value
     }
 

--- a/ui/packages/design-system/src/components/Data/KsDataTable/filter/layout/FilterEditPopper.vue
+++ b/ui/packages/design-system/src/components/Data/KsDataTable/filter/layout/FilterEditPopper.vue
@@ -67,7 +67,7 @@
         {label: t("datepicker.last24hours"), value: "PT24H"},
         {label: t("datepicker.last48hours"), value: "PT48H"},
         {label: t("datepicker.last7days"), value: "PT168H"},
-        {label: t("datepicker.last30days"), value: "P30D"},
+        {label: t("datepicker.last30days"), value: "PT720H"},
         {label: t("datepicker.last365days"), value: "PT8760H"},
     ]
 

--- a/ui/packages/design-system/src/components/Data/KsDataTable/filter/layout/FilterEditPopper.vue
+++ b/ui/packages/design-system/src/components/Data/KsDataTable/filter/layout/FilterEditPopper.vue
@@ -71,8 +71,19 @@
         {label: t("datepicker.last365days"), value: "PT8760H"},
     ]
 
+    // A duration typed by hand or shipped as a `defaultDuration` may use an equivalent spelling of
+    // an option above (P30D for PT720H), which would otherwise render as the raw ISO string.
+    const RELATIVE_DATE_ALIASES: Record<string, string> = {
+        P1D: "PT24H",
+        P2D: "PT48H",
+        P7D: "PT168H",
+        P30D: "PT720H",
+        P365D: "PT8760H",
+    }
+
     const getRelativeDateLabel = (value: string): string => {
-        const item = RELATIVE_DATE.find((i) => i.value === value)
+        const normalized = RELATIVE_DATE_ALIASES[value] ?? value
+        const item = RELATIVE_DATE.find((i) => i.value === normalized)
         return item ? item.label : value
     }
 

--- a/ui/packages/design-system/src/components/Data/KsDataTable/filter/layout/FilterEditPopper.vue
+++ b/ui/packages/design-system/src/components/Data/KsDataTable/filter/layout/FilterEditPopper.vue
@@ -71,19 +71,8 @@
         {label: t("datepicker.last365days"), value: "PT8760H"},
     ]
 
-    // A duration typed by hand or shipped as a `defaultDuration` may use an equivalent spelling of
-    // an option above (P30D for PT720H), which would otherwise render as the raw ISO string.
-    const RELATIVE_DATE_ALIASES: Record<string, string> = {
-        P1D: "PT24H",
-        P2D: "PT48H",
-        P7D: "PT168H",
-        P30D: "PT720H",
-        P365D: "PT8760H",
-    }
-
     const getRelativeDateLabel = (value: string): string => {
-        const normalized = RELATIVE_DATE_ALIASES[value] ?? value
-        const item = RELATIVE_DATE.find((i) => i.value === normalized)
+        const item = RELATIVE_DATE.find((i) => i.value === value)
         return item ? item.label : value
     }
 

--- a/ui/packages/design-system/src/components/Data/KsDataTable/filter/utils/filterChipFactory.ts
+++ b/ui/packages/design-system/src/components/Data/KsDataTable/filter/utils/filterChipFactory.ts
@@ -9,6 +9,7 @@ import {
 } from "./filterTypes"
 import {type DecodedParam, keyOfComparator} from "./helpers"
 import {TIME_RANGE_KEY} from "./constants"
+import {normalizeRelativeDate} from "./relativeDates"
 
 export const buildNewFilter = (key: FilterKeyConfig): AppliedFilter | null => {
     const comparator = key.comparators?.[0]
@@ -125,10 +126,10 @@ export const processFieldValue = (
 
     if (config?.valueType === "date" && typeof value === "string") {
         value = new Date(value)
-    } else if (config?.valueType === "time-range" && typeof value === "string" && !/^P/i.test(value)) {
-        // A custom single absolute date for a time-range field. Predefined relative durations
-        // (PT24H, P30D, …) start with "P" and must stay as the raw duration string.
-        value = new Date(value)
+    } else if (config?.valueType === "time-range" && typeof value === "string") {
+        // Predefined relative durations start with "P" and stay durations, normalized to the
+        // spelling the option lists and the API use; anything else is a custom absolute date.
+        value = /^P/i.test(value) ? normalizeRelativeDate(value) : new Date(value)
     }
 
     return {

--- a/ui/packages/design-system/src/components/Data/KsDataTable/filter/utils/relativeDates.ts
+++ b/ui/packages/design-system/src/components/Data/KsDataTable/filter/utils/relativeDates.ts
@@ -1,0 +1,12 @@
+// Equivalent spellings of the predefined relative ranges, normalized to the one the option lists
+// and the API use - Java's Duration.parse, which the API applies, rejects the week designator.
+const RELATIVE_DATE_ALIASES: Record<string, string> = {
+    P1D: "PT24H",
+    P2D: "PT48H",
+    P7D: "PT168H",
+    P1W: "PT168H",
+    P30D: "PT720H",
+    P365D: "PT8760H",
+}
+
+export const normalizeRelativeDate = (value: string): string => RELATIVE_DATE_ALIASES[value] ?? value

--- a/ui/packages/design-system/tests/units/Data/KsFilter/FilterChip.test.ts
+++ b/ui/packages/design-system/tests/units/Data/KsFilter/FilterChip.test.ts
@@ -1,0 +1,37 @@
+import {describe, test, expect} from "vitest"
+import {mount} from "@vue/test-utils"
+import {createI18n} from "vue-i18n"
+import KestraDesignSystem from "../../../../src/index"
+import FilterChip from "../../../../src/components/Data/KsDataTable/filter/layout/FilterChip.vue"
+import {Comparators, type AppliedFilter} from "../../../../src/components/Data/KsDataTable/filter/utils/filterTypes"
+
+const i18n = createI18n({legacy: false, locale: "en", messages: {en: {}}})
+
+const timeRangeChip = (value: string): AppliedFilter => ({
+    id: "f1",
+    key: "timeRange",
+    keyLabel: "Time Range",
+    comparator: Comparators.EQUALS,
+    comparatorLabel: "is",
+    value,
+    valueLabel: value,
+})
+
+const mountChip = (value: string) =>
+    mount(FilterChip, {
+        props: {filter: timeRangeChip(value)},
+        global: {plugins: [i18n, KestraDesignSystem]},
+    })
+
+describe("FilterChip relative date labels", () => {
+    test.each(["PT720H", "P30D"])("labels %s as the last-30-days option rather than the raw duration", (value) => {
+        const wrapper = mountChip(value)
+
+        expect(wrapper.text()).toContain("datepicker.last30days")
+        expect(wrapper.text()).not.toContain(value)
+    })
+
+    test("falls back to the raw duration for a value with no matching option", () => {
+        expect(mountChip("PT3H").text()).toContain("PT3H")
+    })
+})

--- a/ui/packages/design-system/tests/units/Data/KsFilter/FilterChip.test.ts
+++ b/ui/packages/design-system/tests/units/Data/KsFilter/FilterChip.test.ts
@@ -7,15 +7,12 @@ import {Comparators, type AppliedFilter} from "../../../../src/components/Data/K
 
 const i18n = createI18n({legacy: false, locale: "en", messages: {en: {}}})
 
-const timeRangeChip = (value: string): AppliedFilter => ({
+const timeRangeChip = (value: string) => ({
     id: "f1",
     key: "timeRange",
-    keyLabel: "Time Range",
     comparator: Comparators.EQUALS,
-    comparatorLabel: "is",
     value,
-    valueLabel: value,
-})
+} as AppliedFilter)
 
 const mountChip = (value: string) =>
     mount(FilterChip, {
@@ -24,10 +21,13 @@ const mountChip = (value: string) =>
     })
 
 describe("FilterChip relative date labels", () => {
-    test.each(["PT720H", "P30D"])("labels %s as the last-30-days option rather than the raw duration", (value) => {
+    test.each([
+        ["PT720H", "datepicker.last30days"],
+        ["PT168H", "datepicker.last7days"],
+    ])("labels %s as %s rather than the raw duration", (value, label) => {
         const wrapper = mountChip(value)
 
-        expect(wrapper.text()).toContain("datepicker.last30days")
+        expect(wrapper.text()).toContain(label)
         expect(wrapper.text()).not.toContain(value)
     })
 

--- a/ui/packages/design-system/tests/units/Data/KsFilter/filterChipFactory.test.ts
+++ b/ui/packages/design-system/tests/units/Data/KsFilter/filterChipFactory.test.ts
@@ -193,3 +193,47 @@ describe("custom range decoding", () => {
         expect(group.filters[0]?.meta).toBeUndefined()
     })
 })
+
+const relativeRangeConfiguration: FilterConfiguration = {
+    title: "Executions",
+    keys: [
+        {
+            key: "timeRange",
+            label: "Interval",
+            valueType: "time-range",
+            comparators: [Comparators.EQUALS],
+        },
+    ],
+}
+
+describe("relative date decoding", () => {
+    test.each([
+        ["P30D", "PT720H"],
+        ["P1W", "PT168H"],
+        ["P7D", "PT168H"],
+        ["PT720H", "PT720H"],
+    ])("normalizes the %s duration to %s", (value, expected) => {
+        const {groups} = parseEncodedGroups({"filters[timeRange][EQUALS]": value}, relativeRangeConfiguration)
+        const [group] = groups
+
+        if (!group || !isLeafGroup(group)) {
+            throw new Error("Expected the decoded group to be a leaf group")
+        }
+
+        expect(group.filters[0]).toMatchObject({key: "timeRange", value: expected})
+    })
+
+    test("still reads an absolute date as a date rather than a duration", () => {
+        const {groups} = parseEncodedGroups(
+            {"filters[timeRange][EQUALS]": "2026-08-01T00:00:00.000Z"},
+            relativeRangeConfiguration,
+        )
+        const [group] = groups
+
+        if (!group || !isLeafGroup(group)) {
+            throw new Error("Expected the decoded group to be a leaf group")
+        }
+
+        expect(group.filters[0]?.value).toBeInstanceOf(Date)
+    })
+})


### PR DESCRIPTION
- `FilterChip.vue` and `FilterEditPopper.vue` each carry their own copy of the relative-date preset list, mapping "last 30 days" to `P30D`. The app's own filter options (`useValues.ts`) map it to `PT720H`. A filter set to `PT720H` — including any page using it as a default duration — falls through the label lookup and renders the raw string `PT720H` instead of "Last 30 days".
- Align both copies to `PT720H`, and normalize equivalent spellings (`P1D`/`P2D`/`P7D`/`P1W`/`P30D`/`P365D`) to the hour form in `processFieldValue`, the single point where a URL param becomes a time-range filter value. Normalizing the value rather than just the label also fixes `P1W`, which `Duration.parse` — used by the API via `TypeConverter.toDuration` — rejects outright, since a Java `Duration` has no week designator.
- Collapsing the three duplicated `RELATIVE_DATE` lists into one source is still a separate refactor; the alias map itself lives in one place (`filter/utils/relativeDates.ts`).
- Tests: `filterChipFactory.test.ts` covers the normalization and the absolute-date path; `FilterChip.test.ts` covers the label lookup.
- Surfaced while giving Cases (kestra-ee) a 30-day default; companion PR kestra-io/kestra-ee#10847.