### PR TITLE
feat(core): X-Kestra-Version header on calls to Kestra's API

### DIFF
--- a/core/src/main/java/io/kestra/core/contexts/ApiClientVersionFilter.java
+++ b/core/src/main/java/io/kestra/core/contexts/ApiClientVersionFilter.java
@@ -1,0 +1,32 @@
+package io.kestra.core.contexts;
+
+import java.util.Objects;
+
+import io.kestra.core.utils.VersionProvider;
+import io.micronaut.http.MutableHttpRequest;
+import io.micronaut.http.annotation.ClientFilter;
+import io.micronaut.http.annotation.RequestFilter;
+
+/**
+ * Declares the instance's Kestra version on every call to Kestra's own API, so the API can answer
+ * for the caller's version instead of its own.
+ *
+ * <p>Scoped to the {@code api} service id rather than to a URL pattern on purpose: the
+ * {@code remote-api} and {@code proxy} services, and the unnamed client, all reach endpoints a user
+ * configures, and the instance version must not leak to those.
+ */
+@ClientFilter(serviceId = "api")
+public class ApiClientVersionFilter {
+    public static final String VERSION_HEADER = "X-Kestra-Version";
+
+    private final VersionProvider versionProvider;
+
+    public ApiClientVersionFilter(VersionProvider versionProvider) {
+        this.versionProvider = Objects.requireNonNull(versionProvider);
+    }
+
+    @RequestFilter
+    public void declareVersion(MutableHttpRequest<?> request) {
+        request.header(VERSION_HEADER, versionProvider.getVersion());
+    }
+}

--- a/core/src/test/java/io/kestra/core/contexts/ApiClientVersionFilterTest.java
+++ b/core/src/test/java/io/kestra/core/contexts/ApiClientVersionFilterTest.java
@@ -1,0 +1,95 @@
+package io.kestra.core.contexts;
+
+import java.io.IOException;
+import java.net.ServerSocket;
+import java.util.Map;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+
+import io.kestra.core.utils.VersionProvider;
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.http.HttpRequest;
+import io.micronaut.http.annotation.Controller;
+import io.micronaut.http.annotation.Get;
+import io.micronaut.http.client.annotation.Client;
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import io.micronaut.test.support.TestPropertyProvider;
+import jakarta.inject.Inject;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@MicronautTest
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class ApiClientVersionFilterTest implements TestPropertyProvider {
+    private static final String ENABLED = "kestra.test.api-client-version-filter";
+    private static final String NO_HEADER = "none";
+
+    @Inject
+    private ApiClient apiClient;
+
+    @Inject
+    private RemoteApiClient remoteApiClient;
+
+    @Inject
+    private VersionProvider versionProvider;
+
+    // micronaut.http.services binds through @EachProperty, so the url has to be known before the
+    // context starts — which means picking the port the embedded server will bind to.
+    @Override
+    public @NonNull Map<String, String> getProperties() {
+        int port = freePort();
+        String url = "http://localhost:" + port;
+
+        return Map.of(
+            ENABLED, "true",
+            "micronaut.server.port", String.valueOf(port),
+            "micronaut.http.services.api.url", url,
+            "micronaut.http.services.remote-api.url", url
+        );
+    }
+
+    @Test
+    void shouldDeclareTheInstanceVersionOnCallsToKestrasApi() {
+        assertThat(apiClient.version()).isEqualTo(versionProvider.getVersion());
+    }
+
+    @Test
+    void shouldNotDeclareItOnServicesAUserCanRepoint() {
+        assertThat(remoteApiClient.version()).isEqualTo(NO_HEADER);
+    }
+
+    private static int freePort() {
+        try (ServerSocket socket = new ServerSocket(0)) {
+            return socket.getLocalPort();
+        } catch (IOException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    @Client("api")
+    @Requires(property = ENABLED, value = "true")
+    public interface ApiClient {
+        @Get("/echo-kestra-version")
+        String version();
+    }
+
+    @Client("remote-api")
+    @Requires(property = ENABLED, value = "true")
+    public interface RemoteApiClient {
+        @Get("/echo-kestra-version")
+        String version();
+    }
+
+    @Controller("/echo-kestra-version")
+    @Requires(property = ENABLED, value = "true")
+    public static class EchoController {
+        @Get
+        public String version(HttpRequest<?> request) {
+            return Optional.ofNullable(request.getHeaders().get(ApiClientVersionFilter.VERSION_HEADER))
+                .orElse(NO_HEADER);
+        }
+    }
+}


### PR DESCRIPTION
Here is the cleaned-up Markdown formatting without the extra blockquote symbols, stray whitespace, or raw copy-paste artifacts:

✨ **Description**

Nothing tells `api.kestra.io` which Kestra instance is calling it. Outbound calls through the API client carry no identifying headers, and Micronaut adds no `User-Agent` of its own. Where a caller needs to identify the instance today, it does so in the request body (e.g., `PosthogService` puts `iid` in the event payload). As a result, every endpoint has to answer from its own view of the world rather than the caller's.

This PR adds a client filter that stamps `X-Kestra-Version` on outbound calls, scoped to the `api` service ID. Every caller of `api.kestra.io` across both editions goes through `@Client("api")`—including blueprints, plugin catalog, flow autoloader, OSS auth listener, PostHog, CLI plugin search, and in EE, the license service and instance controller. One bean covers them all, meaning `kestra-ee` requires no additional changes.

Scoping by service ID rather than by URL pattern is deliberate: `remote-api`, `proxy`, and the unnamed client all reach user-configured endpoints, and the instance version must not be stamped onto those. `User-Agent` is left alone, since `ServerEventSender`, EE's `InstanceController`, and `GithubAppFetcher` each set their own.