### PR TITLE
refactor(iam): centralize repository namespace ACL into one policy bean

### DIFF
--- a/core/src/main/java/io/kestra/core/repositories/GlobalNamespaceAccessControl.java
+++ b/core/src/main/java/io/kestra/core/repositories/GlobalNamespaceAccessControl.java
@@ -7,7 +7,7 @@ import jakarta.inject.Singleton;
 
 /**
  * Default OSS {@link NamespaceAccessControl}: grants global access to every resource, since OSS has no
- * namespace ACL. EE replaces this bean with a {@code CurrentUserContext} implementation.
+ * namespace ACL.
  */
 @Singleton
 public class GlobalNamespaceAccessControl implements NamespaceAccessControl {

--- a/core/src/main/java/io/kestra/core/repositories/GlobalNamespaceAccessControl.java
+++ b/core/src/main/java/io/kestra/core/repositories/GlobalNamespaceAccessControl.java
@@ -1,0 +1,19 @@
+package io.kestra.core.repositories;
+
+import io.kestra.core.models.AccessScope;
+import io.kestra.core.models.QueryFilter;
+
+import jakarta.inject.Singleton;
+
+/**
+ * Default OSS {@link NamespaceAccessControl}: grants global access to every resource, since OSS has no
+ * namespace ACL. EE replaces this bean with a {@code CurrentUserContext} implementation.
+ */
+@Singleton
+public class GlobalNamespaceAccessControl implements NamespaceAccessControl {
+
+    @Override
+    public AccessScope namespaceScope(QueryFilter.Resource resource) {
+        return AccessScope.global();
+    }
+}

--- a/core/src/main/java/io/kestra/core/repositories/NamespaceAccessControl.java
+++ b/core/src/main/java/io/kestra/core/repositories/NamespaceAccessControl.java
@@ -7,11 +7,8 @@ import io.kestra.core.models.QueryFilter;
  * Access-control collaborator for namespace-scoped repositories. A repository consults it at its
  * {@code defaultFilter} chokepoint and translates the returned {@link AccessScope} into its own query
  * language (a jOOQ condition, an Elasticsearch query). This keeps the access-control <em>policy</em> in
- * one place (a single EE bean) while the <em>translation</em> stays in each dialect-aware backend, so
- * there is no per-repository ACL subclass.
- * <p>
- * OSS provides a {@link #GLOBAL} no-op default; EE replaces the bean with a {@code CurrentUserContext}
- * implementation that maps each resource to the permission gating its namespaces.
+ * one place while the <em>translation</em> stays in each dialect-aware backend, so there is no
+ * per-repository ACL subclass.
  */
 public interface NamespaceAccessControl {
 

--- a/core/src/main/java/io/kestra/core/repositories/NamespaceAccessControl.java
+++ b/core/src/main/java/io/kestra/core/repositories/NamespaceAccessControl.java
@@ -1,0 +1,28 @@
+package io.kestra.core.repositories;
+
+import io.kestra.core.models.AccessScope;
+import io.kestra.core.models.QueryFilter;
+
+/**
+ * Access-control collaborator for namespace-scoped repositories. A repository consults it at its
+ * {@code defaultFilter} chokepoint and translates the returned {@link AccessScope} into its own query
+ * language (a jOOQ condition, an Elasticsearch query). This keeps the access-control <em>policy</em> in
+ * one place (a single EE bean) while the <em>translation</em> stays in each dialect-aware backend, so
+ * there is no per-repository ACL subclass.
+ * <p>
+ * OSS provides a {@link #GLOBAL} no-op default; EE replaces the bean with a {@code CurrentUserContext}
+ * implementation that maps each resource to the permission gating its namespaces.
+ */
+public interface NamespaceAccessControl {
+
+    /**
+     * A no-op collaborator granting global access, the safe default for OSS, which has no namespace ACL.
+     */
+    NamespaceAccessControl GLOBAL = resource -> AccessScope.global();
+
+    /**
+     * @param resource the resource being read.
+     * @return the namespaces the current caller may see for {@code resource}: global, a set, or none.
+     */
+    AccessScope namespaceScope(QueryFilter.Resource resource);
+}

--- a/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcExecutionRepository.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcExecutionRepository.java
@@ -90,6 +90,11 @@ public abstract class AbstractJdbcExecutionRepository extends AbstractJdbcCrudRe
         this.filterService = filterService;
     }
 
+    @Override
+    protected Condition defaultFilter(String tenantId, boolean allowDeleted) {
+        return super.defaultFilter(tenantId, allowDeleted).and(aclCondition(Resource.EXECUTION));
+    }
+
     /**
      * {@inheritDoc}
      **/

--- a/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcExecutionStatisticsRepository.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcExecutionStatisticsRepository.java
@@ -21,6 +21,7 @@ import org.jooq.SQLDialect;
 import org.jooq.SelectConditionStep;
 import org.jooq.impl.DSL;
 
+import io.kestra.core.models.QueryFilter;
 import io.kestra.core.models.executions.statistics.DailyExecutionStatistics;
 import io.kestra.core.models.executions.statistics.ExecutionStatistic;
 import io.kestra.core.models.flows.State;
@@ -50,7 +51,7 @@ public abstract class AbstractJdbcExecutionStatisticsRepository extends Abstract
     /** {@inheritDoc} **/
     @Override
     protected Condition defaultFilter(String tenantId) {
-        return tenantCondition(tenantId);
+        return tenantCondition(tenantId).and(aclCondition(QueryFilter.Resource.EXECUTION));
     }
 
     /** {@inheritDoc} **/

--- a/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcFlowRepository.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcFlowRepository.java
@@ -204,10 +204,15 @@ public abstract class AbstractJdbcFlowRepository extends AbstractJdbcRepository 
         return buildTenantCondition(tenantId);
     }
 
-    // "executable" filtering must stay independent of read-ACL, since users with
-    // execute-but-not-read permission are exactly who these two methods serve.
+    @Override
+    protected Condition defaultFilter(String tenantId, boolean allowDeleted) {
+        return super.defaultFilter(tenantId, allowDeleted).and(aclCondition(Resource.FLOW));
+    }
+
+    // "executable" filtering stays independent of read-ACL and is scoped by the EXECUTION grant instead,
+    // since users with execute-but-not-read permission are exactly who these two methods serve.
     protected Condition defaultExecutionFilter(String tenantId) {
-        return this.defaultFilterWithNoACL(tenantId).and(DISABLED_FIELD.eq(false));
+        return this.defaultFilterWithNoACL(tenantId).and(DISABLED_FIELD.eq(false)).and(aclCondition(Resource.EXECUTION));
     }
 
     @Override

--- a/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcKvMetadataRepository.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcKvMetadataRepository.java
@@ -26,6 +26,11 @@ public abstract class AbstractJdbcKvMetadataRepository extends AbstractJdbcCrudR
         super(jdbcRepository);
     }
 
+    @Override
+    protected Condition defaultFilter(String tenantId, boolean allowDeleted) {
+        return super.defaultFilter(tenantId, allowDeleted).and(aclCondition(QueryFilter.Resource.KV_METADATA));
+    }
+
     private static Condition lastCondition(boolean isLast) {
         return field("last").eq(isLast);
     }

--- a/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcMetricRepository.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcMetricRepository.java
@@ -15,6 +15,7 @@ import org.jooq.*;
 import org.jooq.Record;
 import org.jooq.impl.DSL;
 
+import io.kestra.core.models.QueryFilter;
 import io.kestra.core.models.dashboards.ColumnDescriptor;
 import io.kestra.core.models.dashboards.DataFilter;
 import io.kestra.core.models.dashboards.DataFilterKPI;
@@ -187,7 +188,7 @@ public abstract class AbstractJdbcMetricRepository extends AbstractJdbcCrudRepos
 
     @Override
     protected Condition defaultFilter(String tenantId) {
-        return buildTenantCondition(tenantId);
+        return buildTenantCondition(tenantId).and(aclCondition(QueryFilter.Resource.EXECUTION));
     }
 
     @Override

--- a/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcNamespaceFileMetadataRepository.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcNamespaceFileMetadataRepository.java
@@ -31,6 +31,11 @@ public abstract class AbstractJdbcNamespaceFileMetadataRepository extends Abstra
         this.jdbcRepository = jdbcRepository;
     }
 
+    @Override
+    protected Condition defaultFilter(String tenantId, boolean allowDeleted) {
+        return super.defaultFilter(tenantId, allowDeleted).and(aclCondition(QueryFilter.Resource.NAMESPACE_FILE_METADATA));
+    }
+
     private static Condition lastCondition(boolean isLast) {
         return field("last").eq(isLast);
     }

--- a/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcRepository.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcRepository.java
@@ -63,10 +63,8 @@ public abstract class AbstractJdbcRepository {
     protected SystemFlowsConfiguration systemFlowsConfiguration;
 
     @Inject
-    // Injected lazily as a provider: the EE bean depends (via CurrentUserContext → RBACService) on the
+    // Injected lazily as a provider: the EE bean depends on the
     // role repository, which itself extends this base, so eager injection would be a circular dependency.
-    // Resolved only when a query is built, by which point the bean graph is complete; null for
-    // non-bean-managed instances (deserialized log-store plugins), which enforce ACL another way.
     protected BeanProvider<NamespaceAccessControl> namespaceAccessControlProvider;
 
     protected NamespaceAccessControl namespaceAccessControl() {
@@ -119,7 +117,7 @@ public abstract class AbstractJdbcRepository {
         AccessScope scope = namespaceAccessControl().namespaceScope(resource);
         Field<String> column = field(namespaceColumn, String.class);
         return switch (scope.kind()) {
-            case GLOBAL -> DSL.trueCondition();
+            case GLOBAL -> DSL.noCondition();
             case DENY_ALL -> DSL.falseCondition();
             case NAMESPACES -> {
                 List<Condition> ors = new ArrayList<>(scope.namespaces().size() * 2);

--- a/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcRepository.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcRepository.java
@@ -24,8 +24,10 @@ import io.kestra.core.models.dashboards.filters.AbstractFilter;
 import io.kestra.core.models.executions.LogEntry;
 import io.kestra.core.models.flows.FlowScope;
 import io.kestra.core.models.flows.State;
+import io.kestra.core.models.AccessScope;
 import io.kestra.core.repositories.ArrayListTotal;
 import io.kestra.core.repositories.ExecutionRepositoryInterface.ChildFilter;
+import io.kestra.core.repositories.NamespaceAccessControl;
 import io.kestra.core.utils.DateUtils;
 import io.kestra.core.utils.Either;
 import io.kestra.core.utils.Enums;
@@ -33,6 +35,7 @@ import io.kestra.core.utils.ListUtils;
 import io.kestra.core.utils.TypeConverter;
 import io.kestra.jdbc.services.JdbcFilterService;
 
+import io.micronaut.context.BeanProvider;
 import io.micronaut.core.annotation.Nullable;
 import io.micronaut.data.model.Pageable;
 import jakarta.inject.Inject;
@@ -58,6 +61,17 @@ public abstract class AbstractJdbcRepository {
     // Micronaut field-injects this for bean-managed repositories; log-store plugins (deserialized,
     // not bean-managed) set it in AbstractJdbcLogDataStore.initFrom — hence protected, not private.
     protected SystemFlowsConfiguration systemFlowsConfiguration;
+
+    @Inject
+    // Injected lazily as a provider: the EE bean depends (via CurrentUserContext → RBACService) on the
+    // role repository, which itself extends this base, so eager injection would be a circular dependency.
+    // Resolved only when a query is built, by which point the bean graph is complete; null for
+    // non-bean-managed instances (deserialized log-store plugins), which enforce ACL another way.
+    protected BeanProvider<NamespaceAccessControl> namespaceAccessControlProvider;
+
+    protected NamespaceAccessControl namespaceAccessControl() {
+        return namespaceAccessControlProvider != null ? namespaceAccessControlProvider.get() : NamespaceAccessControl.GLOBAL;
+    }
 
     protected Condition defaultFilter() {
         return DELETED_FIELD.eq(false);
@@ -87,6 +101,35 @@ public abstract class AbstractJdbcRepository {
 
         // Always include `deleted` in the query filters as most database optimizers can only use and index if the leftmost columns are used in the query
         return deleted ? tenant.and(DELETED_FIELD.in(true, false)) : tenant.and(DELETED_FIELD.eq(false));
+    }
+
+    protected Condition aclCondition(Resource resource) {
+        return aclCondition(resource, "namespace");
+    }
+
+    /**
+     * The one namespace-ACL clause every JDBC repository ANDs onto its tenant filter, translating the
+     * backend-agnostic {@link AccessScope} from {@link NamespaceAccessControl} into jOOQ: {@code GLOBAL}
+     * imposes no restriction, {@code DENY_ALL} matches nothing, {@code NAMESPACES} matches a granted
+     * namespace or its dot-delimited subtree ({@code io.kestrax} is not inside {@code io.kestra}).
+     *
+     * @param namespaceColumn the column holding the namespace, which is not always named {@code namespace}.
+     */
+    protected Condition aclCondition(Resource resource, String namespaceColumn) {
+        AccessScope scope = namespaceAccessControl().namespaceScope(resource);
+        Field<String> column = field(namespaceColumn, String.class);
+        return switch (scope.kind()) {
+            case GLOBAL -> DSL.trueCondition();
+            case DENY_ALL -> DSL.falseCondition();
+            case NAMESPACES -> {
+                List<Condition> ors = new ArrayList<>(scope.namespaces().size() * 2);
+                for (String namespace : scope.namespaces()) {
+                    ors.add(column.eq(namespace));
+                    ors.add(column.startsWith(namespace + "."));
+                }
+                yield DSL.or(ors);
+            }
+        };
     }
 
     protected Condition buildTenantCondition(String tenantId) {

--- a/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcTriggerRepository.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcTriggerRepository.java
@@ -183,7 +183,7 @@ public abstract class AbstractJdbcTriggerRepository extends AbstractJdbcCrudRepo
 
     @Override
     protected Condition defaultFilter(String tenantId, boolean allowDeleted) {
-        return buildTenantCondition(tenantId);
+        return buildTenantCondition(tenantId).and(aclCondition(Resource.TRIGGER));
     }
 
     @Override


### PR DESCRIPTION
## Problem

Every namespace-scoped EE repository computed its own namespace ACL and ANDed it onto its tenant filter. The same clause was duplicated across each backend, and the JDBC and Elasticsearch implementations had drifted, so a caller could see different rows depending on the backend. The pattern also forced an EE subclass per repository whose only job was to add that filter.

## Fix

Introduce a single access-control collaborator, `NamespaceAccessControl`, that returns a backend-agnostic `AccessScope` (`GLOBAL` / `NAMESPACES` / `DENY_ALL`) for a `QueryFilter.Resource`. OSS ships a no-op `GlobalNamespaceAccessControl` (grants everything, since OSS has no namespace ACL); EE `@Replaces` it with a `CurrentUserContext`-based bean.

Each namespace-scoped JDBC repository consults the bean at its `defaultFilter` chokepoint, and `AbstractJdbcRepository.aclCondition(...)` translates the `AccessScope` into a jOOQ condition in one place. The bean is injected lazily (`BeanProvider`) because the EE implementation transitively depends on a repository of the same base, which would otherwise be a startup cycle. `AccessScope.namespaces(empty)` collapses to `DENY_ALL`, so an empty grant fails closed rather than degrading to allow-all.

This is the OSS half; the EE half (the `@Replaces` bean, deletion of the per-repository EE subclasses, and the matching Elasticsearch translator) is the companion PR.

## Evidence

`aclCondition` reproduces the previous EE clause exactly (global bypass → no restriction, otherwise the granted namespace or its dot-delimited subtree, prefix-sibling excluded). OSS behaviour is unchanged: under `GlobalNamespaceAccessControl` the clause is a no-op. JDBC repository tests pass on H2/Postgres/MySQL; the EE ACL suites (H2 + Elasticsearch) in the companion PR exercise the enforcing path.

Companion PR: kestra-io/kestra-ee#10853.
