### PR TITLE
build(core): declare the node version the translation scripts need

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -5,6 +5,7 @@
     "type": "module",
     "packageManager": "npm@11.16.0",
     "engines": {
+        "node": ">=24",
         "npm": ">=11.7.0"
     },
     "workspaces": [


### PR DESCRIPTION
Closes https://github.com/kestra-io/kestra/issues/19186.

`ui/package.json` declares `engines.node` (`>=24`, matching `ui/.nvmrc` and CI) next to the existing npm floor, so `translations:check` and `translations:generate`, which run TypeScript through `node --experimental-strip-types`, fail with a clear unsupported-engine message on an old Node instead of a bare syntax error. `EE` counterpart: https://github.com/kestra-io/kestra-ee/pull/10877.

`actions` repository checked for both repos: the composites pin Node 24 through `setup-node` already; no path the scripts read changes.
