### PR TITLE
build(core): tell the enterprise repository when a push changes the translation keys

### DIFF
--- a/.github/workflows/translations-push.yml
+++ b/.github/workflows/translations-push.yml
@@ -36,3 +36,21 @@ jobs:
 
       - name: Check translations
         run: node ui/scripts/translations/check-translations.mjs --scope oss
+
+  # EE resolves most of its keys from this repository's en.json, so an OSS push that renames or
+  # deletes a key can break EE without any EE change. Once the gate above passed, tell kestra-ee
+  # which commit landed on which branch; its Translation Tests workflow checks the same-name EE
+  # branch against exactly this commit (https://github.com/kestra-io/kestra-ee/issues/10873).
+  notify-ee:
+    name: 'Translations - Notify EE'
+    needs: translations
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: kestra-io/actions/composite/repository-dispatch@main
+        with:
+          gh-app-id: ${{ secrets.GH_BOT_APP_ID }}
+          gh-app-private-key: ${{ secrets.GH_BOT_PRIVATE_KEY }}
+          repository: kestra-io/kestra-ee
+          event-type: "oss-translations-updated"
+          client-payload: '{"branch": "${{ github.ref_name }}", "commit_sha": "${{ github.sha }}"}'


### PR DESCRIPTION
Closes https://github.com/kestra-io/kestra/issues/19184.

## What

`Translations - Push` gains a `notify-ee` job: once the gate passed on a push to `develop` or `releases/*`, it fires a `repository_dispatch` of type `oss-translations-updated` at `kestra-io/kestra-ee` with the branch name and the commit `SHA`, through the existing `kestra-io/actions/composite/repository-dispatch` composite and the bot app secrets `main-build.yml` already uses.

## Why

`EE` resolves most of its keys from this repository's `en.json`. An `OSS` push that renames or deletes a key `EE` uses breaks `EE` without any `EE` change, and today nobody sees it until the next unrelated `EE` `PR` fails the gate for its author. With the `EE` listener in https://github.com/kestra-io/kestra-ee/pull/10880, the same-name `EE` branch is checked against exactly this commit the moment it lands, on `develop` and on the release branches alike.

`actions` repository checked for both repos: the `repository-dispatch` composite is reused unchanged (it mints the app token and fires the event); no sparse checkout is involved.
