### PR TITLE
build(core): declare the node version the translation scripts need (2.0 backport)

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -5,6 +5,7 @@
     "type": "module",
     "packageManager": "npm@11.16.0",
     "engines": {
+        "node": ">=24",
         "npm": ">=11.7.0"
     },
     "workspaces": [


### PR DESCRIPTION
Related to https://github.com/kestra-io/kestra/issues/19186.
Related to https://github.com/kestra-io/kestra/pull/19187.

Backport: `ui/package.json` declares `engines.node` (`>=24`) next to the npm floor, so the translation scripts fail with a clear message on an old Node.

`actions` repository checked for both repos: nothing changes there.