### PR TITLE
build(core): tell the enterprise repository when a push changes the translation keys (2.0 backport)

### DIFF
--- a/.github/workflows/translations-push.yml
+++ b/.github/workflows/translations-push.yml
@@ -36,3 +36,21 @@ jobs:
 
       - name: Check translations
         run: node ui/scripts/translations/check-translations.mjs --scope oss
+
+  # EE resolves most of its keys from this repository's en.json, so an OSS push that renames or
+  # deletes a key can break EE without any EE change. Once the gate above passed, tell kestra-ee
+  # which commit landed on which branch; its Translation Tests workflow checks the same-name EE
+  # branch against exactly this commit (https://github.com/kestra-io/kestra-ee/issues/10873).
+  notify-ee:
+    name: 'Translations - Notify EE'
+    needs: translations
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: kestra-io/actions/composite/repository-dispatch@main
+        with:
+          gh-app-id: ${{ secrets.GH_BOT_APP_ID }}
+          gh-app-private-key: ${{ secrets.GH_BOT_PRIVATE_KEY }}
+          repository: kestra-io/kestra-ee
+          event-type: "oss-translations-updated"
+          client-payload: '{"branch": "${{ github.ref_name }}", "commit_sha": "${{ github.sha }}"}'


### PR DESCRIPTION
Related to https://github.com/kestra-io/kestra/issues/19184.
Related to https://github.com/kestra-io/kestra/pull/19188.

Backport: `Translations - Push` fires `oss-translations-updated` at `kestra-io/kestra-ee` (branch + commit) once its gate passed, so `EE` checks its `releases/v2.0.x` against exactly this commit. Workflows only run from the branch they live on, so the `develop` copy alone would never cover 2.0 pushes. `EE` listener backport: https://github.com/kestra-io/kestra-ee/pull/10884.

`actions` repository checked for both repos: the `repository-dispatch` composite is reused unchanged.
