### PR TITLE
fix(dashboards): drill-down page filters, clicked time bucket, drawer reload

### DIFF
--- a/ui/src/components/dashboard/DrillDownDrawer.vue
+++ b/ui/src/components/dashboard/DrillDownDrawer.vue
@@ -10,6 +10,7 @@
         </template>
         <template v-else-if="tablePreview && target">
             <KsDataTable
+                ref="dataTable"
                 :data="rows"
                 :total="total"
                 :loading="loading"
@@ -45,7 +46,7 @@
 </template>
 
 <script lang="ts" setup>
-    import {computed, defineAsyncComponent, ref} from "vue"
+    import {computed, defineAsyncComponent, ref, watch} from "vue"
     import {useRoute, useRouter} from "vue-router"
     import get from "lodash/get"
     import {KsExecutionStatus} from "@kestra-io/design-system"
@@ -69,24 +70,31 @@
         return currentPreview?.mode === "table" ? currentPreview : undefined
     })
 
+    const dataTable = ref<{resetAndReload: () => void} | null>(null)
     const rows = ref<any[]>([])
     const total = ref(0)
     const loading = ref(false)
     const page = ref(1)
     const size = ref(25)
 
+    // Clicking through segments leaves fetches in flight whose responses can land out of order.
+    let sequence = 0
+
     const loadData = async ({page: loadPage, size: loadSize}: {page: number; size: number}) => {
         const currentTarget = target.value
         const currentPreview = preview.value
         if (!currentTarget || currentPreview?.mode !== "table") return
 
+        const current = ++sequence
         loading.value = true
         try {
             const response = await currentPreview.fetch(buildFullQuery(currentTarget, {page: loadPage, size: loadSize}))
+            if (current !== sequence) return
+
             rows.value = response.results
             total.value = response.total
         } finally {
-            loading.value = false
+            if (current === sequence) loading.value = false
         }
     }
 
@@ -94,6 +102,10 @@
         page.value = newPage
         size.value = newSize
     }
+
+    watch(target, (value) => {
+        if (value) dataTable.value?.resetAndReload()
+    })
 
     const onRowDblClick = (row: any) => {
         const currentPreview = preview.value

--- a/ui/src/components/dashboard/composables/chartDrillDown.ts
+++ b/ui/src/components/dashboard/composables/chartDrillDown.ts
@@ -1,7 +1,8 @@
-import {useRoute, useRouter} from "vue-router"
+import {useRoute, useRouter, type LocationQuery} from "vue-router"
 import {STATES} from "@kestra-io/design-system"
 import {useMiscStore} from "override/stores/misc"
 import {useDrillDownStore, type DrillDownTarget} from "../../../stores/drillDown"
+import {keepTopLevelFilters} from "../../../utils/queryFilters"
 import {getDrillDownPreview} from "./drillDownPreview"
 
 interface WhereCondition {
@@ -20,6 +21,10 @@ export interface DrillDownDescriptor {
 }
 
 type ClickDimension = {column: {field?: string; key?: string} | undefined; value: string};
+
+const START_DATE_PARAM = "filters[startDate][GREATER_THAN_OR_EQUAL_TO]"
+const END_DATE_PARAM = "filters[endDate][LESS_THAN_OR_EQUAL_TO]"
+const TIME_RANGE_PARAM = "filters[timeRange][EQUALS]"
 
 const WHERE_TYPE_TO_COMPARATOR: Record<string, string> = {
     EQUAL_TO: "EQUALS",
@@ -156,37 +161,63 @@ function whereToFilters(descriptor: DrillDownDescriptor, where?: unknown): Recor
     return out
 }
 
-export function chartSegmentDrillDown(
+export function chartDrillDownTarget(
     chart: {data?: Record<string, any>} | undefined,
-    column: {field?: string; key?: string} | undefined,
-    value: string,
-): {name: string; query: Record<string, string>; timeFiltered: boolean} | null {
+    dimensions: ClickDimension[],
+    context?: {routeQuery?: LocationQuery; dateRange?: {startDate: string; endDate: string}},
+): DrillDownTarget | null {
     const descriptor = DRILL_DOWNS[chart?.data?.type?.split(".").pop() ?? ""]
     if (!descriptor) return null
+
+    const routeQuery = context?.routeQuery ?? {}
+    const query: LocationQuery = {
+        ...keepTopLevelFilters(routeQuery, Object.values(descriptor.fieldKey)),
+        ...whereToFilters(descriptor, chart?.data?.where),
+    }
+    for (const {column, value} of dimensions) {
+        Object.assign(query, dimensionFilter(descriptor, column, value))
+    }
+
+    const resolvedWindow = context?.dateRange
+        ? {[START_DATE_PARAM]: context.dateRange.startDate, [END_DATE_PARAM]: context.dateRange.endDate}
+        : routeTimeWindow(routeQuery)
 
     return {
         name: descriptor.route,
         timeFiltered: descriptor.timeFiltered,
-        query: {
-            ...whereToFilters(descriptor, chart?.data?.where),
-            ...dimensionFilter(descriptor, column, value),
-        },
+        query,
+        // A list declaring no time filter cannot take the clicked bucket either, so the target never
+        // carries a window that `buildFullQuery` would then have to know to ignore.
+        timeWindow: descriptor.timeFiltered ? resolvedWindow : undefined,
     }
 }
 
+// Only one of the two forms is returned, since the backend treats `startDate`/`endDate` and
+// `timeRange` as mutually exclusive.
+function routeTimeWindow(query: LocationQuery): Record<string, string> | undefined {
+    const startDate = query[START_DATE_PARAM]
+    const endDate = query[END_DATE_PARAM]
+    if (startDate && endDate) {
+        return {[START_DATE_PARAM]: String(startDate), [END_DATE_PARAM]: String(endDate)}
+    }
+
+    const timeRange = query[TIME_RANGE_PARAM]
+    return timeRange ? {[TIME_RANGE_PARAM]: String(timeRange)} : undefined
+}
+
 /**
- * Reproduces the query augmentation the full listing pages expect (scope, pagination, and the
- * default time-range filter), so the drawer's fetch, the drawer's "Open full page" push, and the
- * legacy full-page redirect all build the exact same query from a drill-down target.
+ * Reproduces the query augmentation the full listing pages expect (scope, pagination, and the time
+ * window), so the drawer's fetch, the drawer's "Open full page" push, and the legacy full-page
+ * redirect all build the exact same query from a drill-down target.
  */
 export function buildFullQuery(target: DrillDownTarget, pagination?: {size: number; page: number}): Record<string, any> {
     return {
         ...target.query,
         scope: "USER",
         ...(pagination ? {size: pagination.size, page: pagination.page} : {}),
-        ...(target.timeFiltered
-            ? {"filters[timeRange][EQUALS]": useMiscStore()?.configs?.chartDefaultDuration ?? "PT24H"}
-            : {}),
+        ...(target.timeWindow ?? (target.timeFiltered
+            ? {[TIME_RANGE_PARAM]: useMiscStore()?.configs?.chartDefaultDuration ?? "PT24H"}
+            : {})),
     }
 }
 
@@ -194,18 +225,12 @@ export function useChartDrillDown(chart: {data?: Record<string, any>} | undefine
     const route = useRoute()
     const router = useRouter()
 
-    function drillDown(dimensions: ClickDimension[]) {
-        const query: Record<string, string> = {}
-        let target: ReturnType<typeof chartSegmentDrillDown> = null
-
-        for (const {column, value} of dimensions) {
-            const resolved = chartSegmentDrillDown(chart, column, value)
-            if (!resolved) return
-            target = resolved
-            Object.assign(query, resolved.query)
-        }
+    function drillDown(dimensions: ClickDimension[], options?: {dateRange?: {startDate: string; endDate: string}}) {
+        const target = chartDrillDownTarget(chart, dimensions, {
+            routeQuery: route.query,
+            dateRange: options?.dateRange,
+        })
         if (!target) return
-        target = {...target, query}
 
         const preview = getDrillDownPreview(target.name)
         if (preview && preview.mode !== "none") {

--- a/ui/src/components/dashboard/sections/TimeSeries.vue
+++ b/ui/src/components/dashboard/sections/TimeSeries.vue
@@ -382,14 +382,36 @@
         return (key ? data?.columns?.[key] : undefined) as {field?: string; key?: string} | undefined
     })
 
+    // The row's date is already the boundary the backend truncated to: re-snapping it with `startOf`
+    // would re-anchor the window to the browser's calendar and to moment's Sunday-based week.
+    function bucketDateRange(dataIndex: number): {startDate: string; endDate: string} | undefined {
+        const label = (parsedData.value.labels as string[])[dataIndex]
+        const column = chartOptions?.column ?? ""
+
+        const dates = (generated.value?.results as Record<string, any>[] | undefined)
+            ?.map((row) => moment(row[column] as moment.MomentInput, moment.ISO_8601, true))
+            .filter((date) => date.isValid() && date.format(grouping.value.format) === label) ?? []
+        if (!dates.length) return undefined
+
+        const bucket = moment.min(dates)
+
+        return {
+            startDate: bucket.toISOString(),
+            endDate: bucket.clone().add(1, grouping.value.unit).subtract(1, "millisecond").toISOString(),
+        }
+    }
+
     function onChartClick(params: any) {
         if (params.seriesType !== "bar" || props.execution) return
 
-        drillDown([
-            {column: dimensionColumn.value, value: params.seriesName},
-            ...(props.namespace ? [{column: {field: "NAMESPACE"}, value: props.namespace}] : []),
-            ...(props.flow ? [{column: {field: "FLOW_ID"}, value: props.flow}] : []),
-        ])
+        drillDown(
+            [
+                {column: dimensionColumn.value, value: params.seriesName},
+                ...(props.namespace ? [{column: {field: "NAMESPACE"}, value: props.namespace}] : []),
+                ...(props.flow ? [{column: {field: "FLOW_ID"}, value: props.flow}] : []),
+            ],
+            {dateRange: bucketDateRange(params.dataIndex)},
+        )
     }
 
     function refresh(customFilters?: QueryFilter[]) {

--- a/ui/src/stores/drillDown.ts
+++ b/ui/src/stores/drillDown.ts
@@ -1,10 +1,12 @@
 import {defineStore} from "pinia"
 import {ref} from "vue"
+import type {LocationQuery} from "vue-router"
 
 export interface DrillDownTarget {
     name: string;
-    query: Record<string, string>;
+    query: LocationQuery;
     timeFiltered: boolean;
+    timeWindow?: Record<string, string>;
 }
 
 export const useDrillDownStore = defineStore("drillDown", () => {

--- a/ui/tests/unit/components/dashboard/DrillDownDrawer.spec.ts
+++ b/ui/tests/unit/components/dashboard/DrillDownDrawer.spec.ts
@@ -130,6 +130,64 @@ describe("DrillDownDrawer", () => {
         expect(fetchMock).toHaveBeenLastCalledWith(expect.objectContaining({page: 2, size: 25}))
     })
 
+    test("mode: table — opening a new target reloads instead of keeping the previous rows", async () => {
+        const fetchMock = vi.fn()
+            .mockResolvedValueOnce({results: [{id: "from-first-target"}], total: 1})
+            .mockResolvedValueOnce({results: [{id: "from-second-target"}], total: 1})
+        registerDrillDownPreview("test/drawer-retarget/list", {
+            mode: "table",
+            columns: [{prop: "id", label: "Id"}],
+            fetch: fetchMock,
+            rowDetail: vi.fn(),
+        })
+
+        const wrapper = mountDrawer()
+        const store = useDrillDownStore()
+        store.open({name: "test/drawer-retarget/list", query: {"filters[state][IN]": "SUCCESS"}, timeFiltered: false})
+        await flushPromises()
+
+        expect(wrapper.findComponent(KsDataTable).props("data")).toEqual([{id: "from-first-target"}])
+
+        // The drawer stays mounted between drill-downs, so nothing but the target changes here.
+        store.open({name: "test/drawer-retarget/list", query: {"filters[state][IN]": "FAILED"}, timeFiltered: false})
+        await flushPromises()
+
+        expect(fetchMock).toHaveBeenLastCalledWith(expect.objectContaining({"filters[state][IN]": "FAILED"}))
+        expect(wrapper.findComponent(KsDataTable).props("data")).toEqual([{id: "from-second-target"}])
+        expect(fetchMock).toHaveBeenCalledTimes(2)
+    })
+
+    test("mode: table — a superseded fetch landing last does not overwrite the current target's rows", async () => {
+        let resolveStale!: (value: unknown) => void
+        const stale = new Promise((resolve) => {
+            resolveStale = resolve
+        })
+        const fetchMock = vi.fn()
+            .mockReturnValueOnce(stale)
+            .mockResolvedValueOnce({results: [{id: "current"}], total: 1})
+        registerDrillDownPreview("test/drawer-race/list", {
+            mode: "table",
+            columns: [{prop: "id", label: "Id"}],
+            fetch: fetchMock,
+            rowDetail: vi.fn(),
+        })
+
+        const wrapper = mountDrawer()
+        const store = useDrillDownStore()
+        store.open({name: "test/drawer-race/list", query: {"filters[state][IN]": "SUCCESS"}, timeFiltered: false})
+        await flushPromises()
+
+        store.open({name: "test/drawer-race/list", query: {"filters[state][IN]": "FAILED"}, timeFiltered: false})
+        await flushPromises()
+
+        resolveStale({results: [{id: "stale"}], total: 99})
+        await flushPromises()
+
+        const dataTable = wrapper.findComponent(KsDataTable)
+        expect(dataTable.props("data")).toEqual([{id: "current"}])
+        expect(dataTable.props("total")).toBe(1)
+    })
+
     test("mode: logs — renders LogsWrapper with the encoded filters (no size/page)", async () => {
         registerDrillDownPreview("test/drawer-logs/list", {mode: "logs"})
 

--- a/ui/tests/unit/dashboard/charts.spec.ts
+++ b/ui/tests/unit/dashboard/charts.spec.ts
@@ -1,5 +1,10 @@
-import {describe, expect, it} from "vitest"
-import {chartSegmentDrillDown, registerDrillDown} from "../../../src/components/dashboard/composables/chartDrillDown"
+import {describe, expect, it, vi} from "vitest"
+
+vi.mock("override/stores/misc", () => ({
+    useMiscStore: () => ({configs: {chartDefaultDuration: "PT24H"}}),
+}))
+
+import {buildFullQuery, chartDrillDownTarget, registerDrillDown} from "../../../src/components/dashboard/composables/chartDrillDown"
 import {DEFAULT_BAR_CATEGORY_LIMIT, MAX_FILLED_TIME_BUCKETS, fillTimeBucketLabels, rankStackedBars} from "../../../src/components/dashboard/composables/charts"
 
 const EXEC = "io.kestra.plugin.core.dashboard.data.Executions"
@@ -7,7 +12,7 @@ const LOGS = "io.kestra.plugin.core.dashboard.data.Logs"
 const FLOWS = "io.kestra.plugin.core.dashboard.data.Flows"
 const METRICS = "io.kestra.plugin.core.dashboard.data.Metrics"
 
-describe("chartSegmentDrillDown", () => {
+describe("chartDrillDownTarget — chart where and clicked dimensions", () => {
     it("reproduces the CLEID dashboard: clicked label + the chart's where conditions, on the executions route", () => {
         const chart = {
             data: {
@@ -18,7 +23,7 @@ describe("chartSegmentDrillDown", () => {
                 ],
             },
         }
-        const result = chartSegmentDrillDown(chart, {field: "LABELS", key: "cleid"}, "cleid-010")
+        const result = chartDrillDownTarget(chart, [{column: {field: "LABELS", key: "cleid"}, value: "cleid-010"}])
         expect(result).toEqual({
             name: "executions/list",
             timeFiltered: true,
@@ -31,22 +36,22 @@ describe("chartSegmentDrillDown", () => {
     })
 
     it("maps a state-grouped executions pie to filters[state][IN] (state is multi-select)", () => {
-        const result = chartSegmentDrillDown({data: {type: EXEC}}, {field: "STATE"}, "FAILED")
+        const result = chartDrillDownTarget({data: {type: EXEC}}, [{column: {field: "STATE"}, value: "FAILED"}])
         expect(result).toEqual({name: "executions/list", timeFiltered: true, query: {"filters[state][IN]": "FAILED"}})
     })
 
     it("routes a Logs chart to the logs list with logs-specific filter keys", () => {
-        const result = chartSegmentDrillDown({data: {type: LOGS}}, {field: "TASK_ID"}, "my-task")
+        const result = chartDrillDownTarget({data: {type: LOGS}}, [{column: {field: "TASK_ID"}, value: "my-task"}])
         expect(result).toEqual({name: "logs/list", timeFiltered: true, query: {"filters[taskId][EQUALS]": "my-task"}})
     })
 
     it("returns null for a data source with no drill-down list (Metrics)", () => {
-        expect(chartSegmentDrillDown({data: {type: METRICS}}, {field: "NAMESPACE"}, "x")).toBeNull()
+        expect(chartDrillDownTarget({data: {type: METRICS}}, [{column: {field: "NAMESPACE"}, value: "x"}])).toBeNull()
     })
 
     it("returns null when the chart has no data type", () => {
-        expect(chartSegmentDrillDown({data: {}}, {field: "STATE"}, "FAILED")).toBeNull()
-        expect(chartSegmentDrillDown(undefined, undefined, "FAILED")).toBeNull()
+        expect(chartDrillDownTarget({data: {}}, [{column: {field: "STATE"}, value: "FAILED"}])).toBeNull()
+        expect(chartDrillDownTarget(undefined, [{column: undefined, value: "FAILED"}])).toBeNull()
     })
 
     it("skips where conditions and dimensions with no list equivalent (superset, never wrong rows)", () => {
@@ -61,7 +66,7 @@ describe("chartSegmentDrillDown", () => {
             },
         }
         // NAMESPACE is multi-select -> EQUAL_TO becomes IN; clicked FLOW_ID dimension also multi-select -> IN
-        const result = chartSegmentDrillDown(chart, {field: "FLOW_ID"}, "always-fail")
+        const result = chartDrillDownTarget(chart, [{column: {field: "FLOW_ID"}, value: "always-fail"}])
         expect(result).toEqual({
             name: "executions/list",
             timeFiltered: true,
@@ -74,7 +79,7 @@ describe("chartSegmentDrillDown", () => {
 
     it("joins array values for IN/NOT_IN where conditions", () => {
         const chart = {data: {type: EXEC, where: [{field: "STATE", type: "IN", value: ["FAILED", "WARNING"]}]}}
-        const result = chartSegmentDrillDown(chart, {field: "LABELS", key: "cleid"}, "cleid-001")
+        const result = chartDrillDownTarget(chart, [{column: {field: "LABELS", key: "cleid"}, value: "cleid-001"}])
         expect(result?.query["filters[state][IN]"]).toBe("FAILED,WARNING")
     })
 
@@ -85,7 +90,7 @@ describe("chartSegmentDrillDown", () => {
                 where: [{field: "NAMESPACE", type: "NOT_EQUAL_TO", value: "system"}],
             },
         }
-        const result = chartSegmentDrillDown(chart, {field: "NAMESPACE"}, "dashboard.test")
+        const result = chartDrillDownTarget(chart, [{column: {field: "NAMESPACE"}, value: "dashboard.test"}])
         expect(result).toEqual({
             name: "flows/list",
             timeFiltered: false, // flows have no time dimension
@@ -98,7 +103,7 @@ describe("chartSegmentDrillDown", () => {
 
     it("passes non-equality operators through on a multi-select field (namespace CONTAINS)", () => {
         const chart = {data: {type: EXEC, where: [{field: "NAMESPACE", type: "CONTAINS", value: "kestra"}]}}
-        const result = chartSegmentDrillDown(chart, undefined, "x")
+        const result = chartDrillDownTarget(chart, [{column: undefined, value: "x"}])
         expect(result?.query).toEqual({"filters[namespace][CONTAINS]": "kestra"})
     })
 
@@ -117,7 +122,7 @@ describe("chartSegmentDrillDown", () => {
             },
         }
         // A metadata-keyed dimension (e.g. grouped by metadata.os) is encoded as a nested key-value filter.
-        const result = chartSegmentDrillDown(chart, {field: "METADATA", key: "os"}, "linux")
+        const result = chartDrillDownTarget(chart, [{column: {field: "METADATA", key: "os"}, value: "linux"}])
         expect(result).toEqual({
             name: "custom/list",
             timeFiltered: false,
@@ -125,6 +130,90 @@ describe("chartSegmentDrillDown", () => {
                 "filters[type][EQUALS]": "vm",
                 "filters[metadata][EQUALS][os]": "linux",
             },
+        })
+    })
+})
+
+describe("chartDrillDownTarget — page filters and time window", () => {
+    const STATE_SEGMENT = [{column: {field: "STATE"}, value: "SUCCESS"}]
+
+    it("carries the list page filters alongside the clicked segment", () => {
+        const target = chartDrillDownTarget({data: {type: EXEC}}, STATE_SEGMENT, {
+            routeQuery: {"filters[namespace][IN]": "system", "filters[flowId][IN]": "test"},
+        })
+        expect(target?.query).toEqual({
+            "filters[namespace][IN]": "system",
+            "filters[flowId][IN]": "test",
+            "filters[state][IN]": "SUCCESS",
+        })
+    })
+
+    it("lets every clicked dimension narrow a page filter on the same field", () => {
+        const target = chartDrillDownTarget(
+            {data: {type: EXEC}},
+            [...STATE_SEGMENT, {column: {field: "FLOW_ID"}, value: "my-flow"}],
+            {routeQuery: {"filters[state][IN]": "RUNNING", "filters[flowId][IN]": "other"}},
+        )
+        expect(target?.query).toEqual({
+            "filters[state][IN]": "SUCCESS",
+            "filters[flowId][IN]": "my-flow",
+        })
+    })
+
+    it("carries the page's own time range when no bucket was clicked", () => {
+        const target = chartDrillDownTarget({data: {type: EXEC}}, STATE_SEGMENT, {
+            routeQuery: {"filters[timeRange][EQUALS]": "PT7D"},
+        })
+        expect(target?.timeWindow).toEqual({"filters[timeRange][EQUALS]": "PT7D"})
+    })
+
+    it("prefers the clicked bucket over the page's own time range", () => {
+        const target = chartDrillDownTarget({data: {type: EXEC}}, STATE_SEGMENT, {
+            routeQuery: {"filters[timeRange][EQUALS]": "PT7D"},
+            dateRange: {startDate: "2026-08-28T00:00:00.000Z", endDate: "2026-08-28T23:59:59.999Z"},
+        })
+        expect(target?.timeWindow).toEqual({
+            "filters[startDate][GREATER_THAN_OR_EQUAL_TO]": "2026-08-28T00:00:00.000Z",
+            "filters[endDate][LESS_THAN_OR_EQUAL_TO]": "2026-08-28T23:59:59.999Z",
+        })
+    })
+})
+
+describe("buildFullQuery", () => {
+    it("emits the resolved time window instead of the chart default duration", () => {
+        const query = buildFullQuery({
+            name: "executions/list",
+            query: {"filters[state][IN]": "SUCCESS"},
+            timeFiltered: true,
+            timeWindow: {"filters[timeRange][EQUALS]": "PT7D"},
+        })
+        expect(query).toEqual({
+            "filters[state][IN]": "SUCCESS",
+            "filters[timeRange][EQUALS]": "PT7D",
+            scope: "USER",
+        })
+    })
+
+    it("falls back to the chart default duration when no window was resolved", () => {
+        const query = buildFullQuery({name: "executions/list", query: {}, timeFiltered: true})
+        expect(query).toEqual({"filters[timeRange][EQUALS]": "PT24H", scope: "USER"})
+    })
+
+    it("emits no time filter at all for a list that is not time filtered", () => {
+        // A TimeSeries over a timeless data source (EE assets grouped by CREATED) still resolves a
+        // bucket on click, and `flows/list` / `assets/list` are not built to accept one.
+        const target = chartDrillDownTarget(
+            {data: {type: FLOWS}},
+            [{column: {field: "NAMESPACE"}, value: "dashboard.test"}],
+            {
+                routeQuery: {"filters[timeRange][EQUALS]": "PT7D"},
+                dateRange: {startDate: "2026-08-28T00:00:00.000Z", endDate: "2026-08-28T23:59:59.999Z"},
+            },
+        )
+
+        expect(buildFullQuery(target!)).toEqual({
+            "filters[namespace][IN]": "dashboard.test",
+            scope: "USER",
         })
     })
 })


### PR DESCRIPTION
### Related Issue

Related to https://github.com/kestra-io/kestra/pull/18988, the `develop` fix this backports.
Original issue: https://github.com/kestra-io/kestra/issues/18496.

### Description

Clicking a bar in a chart opened a preview that ignored the filters applied to the page and the bar's own time bucket: the query was built from the chart's `where` alone, then a default `chartDefaultDuration` was appended. With a filter applied you got rows that did not match it, and on a bar older than that default duration you got an empty list.

Three things now hold when a segment is clicked:

- The page's top-level filters seed the query, through the existing `keepTopLevelFilters`. They are resolved once per click rather than per dimension — resolved in the loop, the last dimension's copy landed back on top of the dimensions already applied and discarded their clicked values, which broke every Bar chart since those always pass two dimensions.
- The clicked bucket's `startDate`/`endDate` pair replaces the default duration instead of joining it, since the backend treats the two forms as mutually exclusive (`TimeLineSearch.extractFrom` throws otherwise). The row's own date is used as the boundary, the backend having already truncated it. With no bucket, the page's own range is carried over so the query is not half-inherited.
- The preview drawer reloads when the target changes and drops superseded responses. It only reloaded on a page change, so a second click showed the first segment's rows.

### Additional Notes

Straight backport of #18988: cherry-picked with no adaptation, and here the patch is byte-identical to the one merged on `develop` — the six touched files had not diverged between the two branches.

No EE companion is needed. `chartDrillDown.ts` renames `chartSegmentDrillDown` to `chartDrillDownTarget`, but `ui-ee` only imports `registerDrillDown` (in `registerAssetsDrillDown.ts`), whose signature and `DrillDownDescriptor` shape are untouched. No caller of the old name is left on this branch, and `keepTopLevelFilters` is already exported from `ui/src/utils/queryFilters.ts` here.

Not covered by tests: `bucketDateRange` is not exported from the `<script setup>` of `TimeSeries.vue`, and the drawer's reload and sequence guard are component-level. Both were checked in the browser on `develop`.

CI is the check here.
