### PR TITLE
fix(tests): unit tests pass on Node 26

### DIFF
--- a/ui/packages/design-system/vitest.unit.config.ts
+++ b/ui/packages/design-system/vitest.unit.config.ts
@@ -1,6 +1,9 @@
 import {defineConfig} from "vitest/config"
 import vue from "@vitejs/plugin-vue"
 
+/** Node 26's own `localStorage` shadows jsdom's and stays undefined, so let jsdom provide storage. */
+process.env.NODE_OPTIONS = `${process.env.NODE_OPTIONS ?? ""} --no-experimental-webstorage`.trim()
+
 export default defineConfig({
     plugins: [vue()],
     test: {


### PR DESCRIPTION
EE PR: https://github.com/kestra-io/kestra-ee/pull/10901
On a machine running Node 26 the design-system suite failed 30 tests and the EE suite 73, while CI and the Node 24 in .nvmrc were always fine.
The flag lets jsdom own localStorage instead of Node's own undefined global, which is what ui/vitest.config.js already does.
After it, design system 865 and EE 1022 tests pass on both Node versions, and the storybook projects are unchanged (505 and 40).
