### PR TITLE
fix(core): stop LoopUntil after maxIterations instead of maxIterations + 1

### DIFF
--- a/core/src/main/java/io/kestra/plugin/core/flow/LoopUntil.java
+++ b/core/src/main/java/io/kestra/plugin/core/flow/LoopUntil.java
@@ -144,7 +144,7 @@ public class LoopUntil extends AbstractBranch<LoopUntil.Output> {
             .orElse(0);
 
         Optional<Integer> maxIterations = runContext.render(this.getCheckFrequency().getMaxIterations()).as(Integer.class);
-        if (maxIterations.isPresent() && iterationCount > maxIterations.get()) {
+        if (maxIterations.isPresent() && iterationCount >= maxIterations.get()) {
             if (printLog) {
                 logger.warn("Max iterations reached");
             }

--- a/core/src/test/java/io/kestra/plugin/core/flow/LoopUntilCaseTest.java
+++ b/core/src/test/java/io/kestra/plugin/core/flow/LoopUntilCaseTest.java
@@ -40,7 +40,8 @@ public class LoopUntilCaseTest {
 
         assertThat(execution.getState().getCurrent()).isEqualTo(State.Type.FAILED);
         assertThat(taskOutputService.getOutputs(execution.getTaskRunList().getFirst())).isNotNull();
-        assertThat((Integer) taskOutputService.getOutputs(execution.getTaskRunList().getFirst()).get("iterationCount")).isEqualTo(4);
+        // the flow sets maxIterations: 3, so the loop must stop after three iterations
+        assertThat((Integer) taskOutputService.getOutputs(execution.getTaskRunList().getFirst()).get("iterationCount")).isEqualTo(3);
     }
 
     public void waitforMaxDuration(String tenantId) throws TimeoutException, QueueException {


### PR DESCRIPTION
Backport of d2144bbe7fb30a62de3abca336cd327e5fac0ace to `releases/v2.0.x`. Cherry-picked cleanly, no conflicts, diff identical to the one on `develop`.

### 🔗 Related Issue

Closes https://github.com/kestra-io/kestra-ee/issues/10323.

### ✨ Description

`LoopUntil` ran one iteration too many. `reachedMaximums` compared the completed-iteration count with `>`, so `maxIterations: 1` ran the body twice and `maxIterations: 2` ran it three times, with `iterationCount` reporting the inflated number. `CheckFrequency.maxIterations` documents itself as "Maximum count of iterations", so the loop now stops once the count reaches it.

The existing `waitfor-max-iterations` expectation (`iterationCount == 4` for `maxIterations: 3`) encoded the off-by-one and is corrected to 3.

### 🛠️ Backend Checklist

- [x] Code compiles and tests pass for the touched modules
- [x] New behavior is covered by unit or integration tests

### 📝 Additional Notes

No code changes on top of the original commit — review already happened on the `develop` PR.

### 🤖 AI Authors

Why did the cat stop the loop? Because after nine lives it finally read the `maxIterations` docs. 🐱
