### PR TITLE
fix(scheduler): compile the unparseable-flow trigger test against the 2.0.x store API

### DIFF
--- a/scheduler/src/test/java/io/kestra/scheduler/internals/DefaultSchedulableTriggerFetcherTest.java
+++ b/scheduler/src/test/java/io/kestra/scheduler/internals/DefaultSchedulableTriggerFetcherTest.java
@@ -62,8 +62,8 @@ class DefaultSchedulableTriggerFetcherTest {
 
         // Then the valid trigger is still evaluated and the broken one is disabled until its flow is saved again
         assertThat(schedulable).extracting(context -> context.flow().getId()).containsExactly("valid");
-        assertThat(triggerStateStore.findById(brokenState).orElseThrow().isDisabled()).isTrue();
-        assertThat(triggerStateStore.findById(validState).orElseThrow().isDisabled()).isFalse();
+        assertThat(triggerStateStore.findByIdWithoutAcl(brokenState).orElseThrow().isDisabled()).isTrue();
+        assertThat(triggerStateStore.findByIdWithoutAcl(validState).orElseThrow().isDisabled()).isFalse();
     }
 
     private static FlowWithSource flow(String id) {


### PR DESCRIPTION
## Problem

`releases/v2.0.x` does not compile. `:scheduler:compileTestJava` fails at `DefaultSchedulableTriggerFetcherTest.java:65-66`:

```
symbol:   method findById(TriggerState)
location: variable triggerStateStore of type InMemoryTriggerStateStore
```

`TriggerStateStore.findById(TriggerState)` only exists on `develop`; on 2.0.x the method is `findByIdWithoutAcl(TriggerId)`. The test came in with the #19137 backport (8a2162a9ef) without being adapted to the branch's API.

The impact is wider than one test: the Backend - Tests job dies at the `javadoc`/`testClasses` step, so `Gradle - check` never runs and **no test executes at all** on any PR targeting the branch. Every open 2.0.x PR is red for this reason.

## Fix

Call `findByIdWithoutAcl` instead. `TriggerState implements TriggerId`, so the two call sites need no other change — the assertions and the behaviour under test are untouched.

## Evidence

Reproduced on a clean detached `origin/releases/v2.0.x` with no other commits — same two errors. After the fix, `./gradlew :scheduler:compileTestJava` and `./gradlew :scheduler:test --tests "DefaultSchedulableTriggerFetcherTest"` both pass locally.
