### PR TITLE
fix(core): preserve title and description on retry type discriminator field

### DIFF
--- a/core/src/main/java/io/kestra/core/docs/JsonSchemaGenerator.java
+++ b/core/src/main/java/io/kestra/core/docs/JsonSchemaGenerator.java
@@ -929,31 +929,47 @@ public class JsonSchemaGenerator {
                         return defaultOpt;
                     }
 
-                    return p.optional("allOf").flatMap(node ->
-                    {
-                        if (node.isArray()) {
-                            Iterable<JsonNode> iterable = node::values;
-                            return StreamSupport.stream(
-                                iterable.spliterator(),
-                                false
-                            ).filter(subNode -> subNode.has("default"))
-                                .findFirst()
-                                .map(subNode -> subNode.get("default").asText());
-                        }
-
-                        return Optional.empty();
-                    });
+                    return findAllOfNodeWithField(p, "default")
+                        .map(node -> node.get("default").asText());
                 })
                 .orElse(null);
             if (defaultValue == null) {
                 return;
             }
 
-            properties.set(
-                property, context.getGeneratorConfig().createObjectNode()
-                    .put("const", defaultValue)
-            );
+            ObjectNode constNode = context.getGeneratorConfig().createObjectNode()
+                .put("const", defaultValue);
+
+            Schema schemaAnnotation = Arrays.stream(targetType.getDeclaredFields())
+                .filter(f -> f.getName().equals(property))
+                .findFirst()
+                .map(f -> f.getAnnotation(Schema.class))
+                .orElse(null);
+
+            if (schemaAnnotation != null) {
+                if (!schemaAnnotation.title().isEmpty()) {
+                    constNode.put("title", schemaAnnotation.title());
+                }
+                if (!schemaAnnotation.description().isEmpty()) {
+                    constNode.put("description", schemaAnnotation.description());
+                }
+            }
+
+            properties.set(property, constNode);
         });
+    }
+
+    private static Optional<JsonNode> findAllOfNodeWithField(JsonNode parent, String fieldName) {
+        JsonNode allOf = parent.get("allOf");
+        if (allOf == null || !allOf.isArray()) {
+            return Optional.empty();
+        }
+        for (JsonNode child : allOf) {
+            if (child.has(fieldName)) {
+                return Optional.of(child);
+            }
+        }
+        return Optional.empty();
     }
 
     protected List<ResolvedType> subtypeResolver(ResolvedType declaredType, TypeContext typeContext, List<String> allowedPluginTypes) {

--- a/core/src/main/java/io/kestra/core/models/tasks/retrys/Constant.java
+++ b/core/src/main/java/io/kestra/core/models/tasks/retrys/Constant.java
@@ -26,6 +26,10 @@ public class Constant extends AbstractRetry {
     @NotNull
     @JsonInclude
     @Builder.Default
+    @Schema(
+        title = "The retry type.",
+        description = "Fixed to `constant`, selecting a retry policy with a fixed delay between attempts."
+    )
     protected String type = "constant";
 
     @NotNull

--- a/core/src/main/java/io/kestra/core/models/tasks/retrys/Exponential.java
+++ b/core/src/main/java/io/kestra/core/models/tasks/retrys/Exponential.java
@@ -27,6 +27,10 @@ public class Exponential extends AbstractRetry {
     @NotNull
     @JsonInclude
     @Builder.Default
+    @Schema(
+        title = "The retry type.",
+        description = "Fixed to `exponential`, selecting a retry policy with exponentially increasing delays between attempts."
+    )
     protected String type = "exponential";
 
     @NotNull

--- a/core/src/main/java/io/kestra/core/models/tasks/retrys/Random.java
+++ b/core/src/main/java/io/kestra/core/models/tasks/retrys/Random.java
@@ -27,6 +27,10 @@ public class Random extends AbstractRetry {
     @NotNull
     @JsonInclude
     @Builder.Default
+    @Schema(
+        title = "The retry type.",
+        description = "Fixed to `random`, selecting a retry policy with a random delay within a configurable range between attempts."
+    )
     protected String type = "random";
 
     @NotNull

--- a/core/src/test/java/io/kestra/core/docs/JsonSchemaGeneratorTest.java
+++ b/core/src/test/java/io/kestra/core/docs/JsonSchemaGeneratorTest.java
@@ -478,6 +478,22 @@ class JsonSchemaGeneratorTest {
                 .get("const"),
             is(new Constant().getType())
         );
+        assertThat(
+            ((Map<String, Map<String, Object>>) ((Map<String, Map<String, Object>>) generate.get("$defs"))
+                .get("io.kestra.core.models.tasks.retrys.Constant")
+                .get("properties"))
+                .get("type")
+                .get("title"),
+            is("The retry type.")
+        );
+        assertThat(
+            ((Map<String, Map<String, Object>>) ((Map<String, Map<String, Object>>) generate.get("$defs"))
+                .get("io.kestra.core.models.tasks.retrys.Constant")
+                .get("properties"))
+                .get("type")
+                .get("description"),
+            is("Fixed to `constant`, selecting a retry policy with a fixed delay between attempts.")
+        );
     }
 
     @SuppressWarnings("unchecked")


### PR DESCRIPTION
Closes #18790

## Problem

The `KestraTask` plugin docs page shows the `type` field on `Constant` retry (and its siblings `Exponential`, `Random`) with no title or description, it just renders as a bare `object`.

## Root cause

Two contributing issues, both needed for a real fix:

1. The `type` field in `Constant`, `Exponential`, and `Random` (under `io.kestra.core.models.tasks.retrys`) had no `@Schema` annotation at all, so there was no title or description to show in the first place.
2. `typeDefiningPropertiesToConst()` in `JsonSchemaGenerator` rewrites this `type` property to a bare `{"const": "..."}` node so editors can offer correct auto-completion. That rewrite replaced the entire property node, discarding any title/description that might exist, so even adding `@Schema` alone would not have been enough.

## Fix

- Added `@Schema(title, description)` to the `type` field on `Constant`, `Exponential`, and `Random`.
- Updated `typeDefiningPropertiesToConst()` to read the `@Schema` annotation directly off the discriminator field via reflection, and carry title/description into the new const node instead of dropping them.
- Extended `subtypesTypePropertyAsConst()` to assert title and description survive alongside the existing const assertion.

## Scope

This is scoped to the Retry model only, matching the original issue. While investigating, I found the same missing-`@Schema` pattern on a few other `@JsonTypeInfo` hierarchies (`FilesPurgeBehavior`, `KvPurgeBehavior`, `ExecutionKilled`, etc.) — happy to open follow-up PRs for those if useful, but wanted to keep this one focused and reviewable.

## Testing

Ran `JsonSchemaGeneratorTest` locally, all 23 tests pass, including the extended `subtypesTypePropertyAsConst()`.