### PR TITLE
fix(executions): scope the concurrency-limit read to the flow

### DIFF
--- a/openapi.yml
+++ b/openapi.yml
@@ -631,6 +631,34 @@ paths:
               schema:
                 $ref: "#/components/schemas/PagedResults_ConcurrencyLimit_"
   /api/v1/{tenant}/concurrency-limit/{namespace}/{flowId}:
+    get:
+      tags:
+      - Flows
+      summary: Get the concurrency limit of a flow
+      operationId: getConcurrencyLimit
+      parameters:
+      - name: namespace
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: flowId
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: tenant
+        in: path
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          description: getConcurrencyLimit 200 response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ConcurrencyLimit"
     put:
       tags:
       - Flows

--- a/ui/src/axios.d.ts
+++ b/ui/src/axios.d.ts
@@ -3,6 +3,7 @@ import "axios";
 declare module "axios" {
   export interface AxiosRequestConfig {
     showMessageOnError?: boolean;
+    ignoreNotFound?: boolean;
     skipAuthErrorHandling?: boolean;
   }
 }

--- a/ui/src/components/flows/FlowConcurrency.vue
+++ b/ui/src/components/flows/FlowConcurrency.vue
@@ -59,7 +59,7 @@
     const totalCount = ref(0);
     const runningCountSet = ref(false);
     const loading = ref(false);
-    const error = ref<string | undefined>(undefined);
+    const error = ref(false);
     const concurrencyLimit = ref<{ tenantId: string; namespace: string; flowId: string; running: number } | undefined>(undefined);
 
     const progress = computed(() => {
@@ -73,31 +73,27 @@
         }
 
         loading.value = true;
-        error.value = undefined;
+        error.value = false;
 
         try {
-            const response = await axios.get(`${apiUrl()}/concurrency-limit/search`);
-            const limits = response.data?.results || [];
-
-            const currentFlowLimit = limits.find(
-                (limit: any) =>
-                    limit.namespace === flowStore.flow?.namespace &&
-                    limit.flowId === flowStore.flow?.id
+            const response = await axios.get(
+                `${apiUrl()}/concurrency-limit/${flowStore.flow.namespace}/${flowStore.flow.id}`,
+                {ignoreNotFound: true, showMessageOnError: false},
             );
 
-            if (currentFlowLimit) {
-                concurrencyLimit.value = currentFlowLimit;
-                runningCount.value = currentFlowLimit.running;
-                runningCountSet.value = true;
-                totalCount.value = currentFlowLimit.running;
-            } else {
+            concurrencyLimit.value = response.data;
+            runningCount.value = response.data?.running ?? 0;
+            runningCountSet.value = true;
+            totalCount.value = runningCount.value;
+        } catch (err: any) {
+            if (err?.status === 404 || err?.response?.status === 404) {
                 concurrencyLimit.value = undefined;
                 runningCount.value = 0;
                 runningCountSet.value = true;
                 totalCount.value = 0;
+            } else {
+                error.value = true;
             }
-        } catch (e: any) {
-            error.value = e.message;
         } finally {
             loading.value = false;
         }

--- a/ui/src/utils/axios.ts
+++ b/ui/src/utils/axios.ts
@@ -94,7 +94,7 @@ export const createAxios = (
 
     instance.interceptors.response.use(
         (response) => response,
-        async (errorResponse: AxiosError & QueueItem & {config:{showMessageOnError: boolean, skipAuthErrorHandling?: boolean}}) => {
+        async (errorResponse: AxiosError & QueueItem & {config:{showMessageOnError: boolean, skipAuthErrorHandling?: boolean, ignoreNotFound?: boolean}}) => {
             if (errorResponse?.code === "ERR_BAD_RESPONSE" && !errorResponse?.response?.data) {
                 const coreStore = useCoreStore()
                 coreStore.message = {
@@ -110,8 +110,12 @@ export const createAxios = (
             }
 
             if (errorResponse.response.status === 404) {
-                const coreStore = useCoreStore()
-                coreStore.error = errorResponse.response.status
+                // A caller that treats a missing record as a normal outcome opts out of the
+                // global not-found page and handles the rejection itself.
+                if (errorResponse.config?.ignoreNotFound !== true) {
+                    const coreStore = useCoreStore()
+                    coreStore.error = errorResponse.response.status
+                }
                 return Promise.reject(errorResponse)
             }
 

--- a/ui/tests/unit/components/flows/FlowConcurrency.spec.ts
+++ b/ui/tests/unit/components/flows/FlowConcurrency.spec.ts
@@ -1,0 +1,90 @@
+import {describe, it, expect, beforeEach, vi} from "vitest"
+import {flushPromises, mount} from "@vue/test-utils"
+
+let mockFlow: Record<string, any> | undefined
+vi.mock("../../../../src/stores/flow", () => ({
+    useFlowStore: () => ({
+        get flow() {
+            return mockFlow
+        },
+    }),
+}))
+
+const getMock = vi.fn()
+vi.mock("../../../../src/utils/axios", () => ({
+    useAxios: () => ({
+        get: getMock,
+    }),
+}))
+
+vi.mock("override/utils/route", () => ({apiUrl: () => "/api/v1/main"}))
+
+vi.mock("@kestra-io/ui-libs", () => ({
+    Status: {template: "<span />"},
+}))
+
+vi.mock("../../../../src/components/executions/Executions.vue", () => ({
+    default: {template: "<div class=\"executions\" />"},
+}))
+
+import FlowConcurrency from "../../../../src/components/flows/FlowConcurrency.vue"
+
+const stubs = {
+    Empty: {props: ["type"], template: "<div class=\"empty\" :data-type=\"type\" />"},
+    ElCard: {template: "<div><slot /></div>"},
+    ElAlert: {props: ["type"], template: "<div class=\"alert\" :data-type=\"type\"><slot /></div>"},
+    ElProgress: {template: "<div />"},
+    ElIcon: {template: "<span><slot /></span>"},
+}
+
+async function mountComponent() {
+    const wrapper = mount(FlowConcurrency, {
+        global: {
+            stubs,
+            mocks: {$t: (key: string) => key},
+        },
+    })
+    await flushPromises()
+    return wrapper
+}
+
+describe("FlowConcurrency", () => {
+    beforeEach(() => {
+        mockFlow = undefined
+        getMock.mockReset()
+    })
+
+    it("reads the flow-scoped record instead of the instance-wide search", async () => {
+        mockFlow = {namespace: "io.kestra.tests", id: "flow", concurrency: {limit: 2, behavior: "QUEUE"}}
+        getMock.mockResolvedValue({data: {tenantId: "main", namespace: "io.kestra.tests", flowId: "flow", running: 1}})
+
+        const wrapper = await mountComponent()
+
+        expect(wrapper.text()).toContain("1/2")
+        // The regression this endpoint fixes: /concurrency-limit/search is superadmin-only in
+        // EE, so every other user got a 403 and an unreadable Concurrency tab.
+        expect(getMock).toHaveBeenCalledWith(
+            "/api/v1/main/concurrency-limit/io.kestra.tests/flow",
+            {ignoreNotFound: true, showMessageOnError: false},
+        )
+    })
+
+    it("keeps the empty state when the flow has a limit but no record yet", async () => {
+        mockFlow = {namespace: "io.kestra.tests", id: "flow", concurrency: {limit: 1, behavior: "CANCEL"}}
+        getMock.mockRejectedValue({status: 404, response: {status: 404}})
+
+        const wrapper = await mountComponent()
+
+        expect(wrapper.find(".empty").attributes("data-type")).toBe("concurrency_executions")
+        expect(wrapper.find(".alert").exists()).toBe(false)
+    })
+
+    it("shows an error when the request fails for a reason other than a missing record", async () => {
+        mockFlow = {namespace: "io.kestra.tests", id: "flow", concurrency: {limit: 1, behavior: "CANCEL"}}
+        getMock.mockRejectedValue({status: 500, response: {status: 500}})
+
+        const wrapper = await mountComponent()
+
+        expect(wrapper.find(".alert").attributes("data-type")).toBe("error")
+    })
+})

--- a/webserver/src/main/java/io/kestra/webserver/controllers/api/ConcurrencyLimitController.java
+++ b/webserver/src/main/java/io/kestra/webserver/controllers/api/ConcurrencyLimitController.java
@@ -34,6 +34,15 @@ public class ConcurrencyLimitController {
     }
 
     @ExecuteOn(TaskExecutors.IO)
+    @Get(uri = "/{namespace}/{flowId}")
+    @Operation(tags = { "Flows" }, summary = "Get the concurrency limit of a flow")
+    public HttpResponse<ConcurrencyLimit> getConcurrencyLimit(String namespace, String flowId) {
+        return concurrencyLimitService.findById(tenantService.resolveTenant(), namespace, flowId)
+            .map(HttpResponse::ok)
+            .orElseGet(HttpResponse::notFound);
+    }
+
+    @ExecuteOn(TaskExecutors.IO)
     @Put("/{namespace}/{flowId}")
     @Operation(tags = { "Flows" }, summary = "Update a flow concurrency limit")
     public HttpResponse<ConcurrencyLimit> updateConcurrencyLimit(@Body @Valid ConcurrencyLimit concurrencyLimit) {

--- a/webserver/src/test/java/io/kestra/webserver/controllers/api/ConcurrencyLimitControllerTest.java
+++ b/webserver/src/test/java/io/kestra/webserver/controllers/api/ConcurrencyLimitControllerTest.java
@@ -66,5 +66,25 @@ class ConcurrencyLimitControllerTest {
         );
         assertThat(updated).isNotNull();
         assertThat(updated.getRunning()).isEqualTo(99);
+
+        // the flow-scoped GET returns the same record
+        ConcurrencyLimit scoped = client.toBlocking().retrieve(
+            GET("/api/v1/main/concurrency-limit/" + concurrencyLimit.getNamespace() + "/" + concurrencyLimit.getFlowId()),
+            ConcurrencyLimit.class
+        );
+        assertThat(scoped.getNamespace()).isEqualTo(concurrencyLimit.getNamespace());
+        assertThat(scoped.getFlowId()).isEqualTo(concurrencyLimit.getFlowId());
+    }
+
+    @Test
+    void shouldReturnNotFoundWhenGettingConcurrencyLimitForUnknownFlow() {
+        HttpClientResponseException e = assertThrows(
+            HttpClientResponseException.class,
+            () -> client.toBlocking().exchange(
+                GET("/api/v1/main/concurrency-limit/unknown.namespace/unknown-flow")
+            )
+        );
+
+        assertThat(e.getStatus().getCode()).isEqualTo(HttpStatus.NOT_FOUND.getCode());
     }
 }


### PR DESCRIPTION
Backport of a1a31d5be9 (develop) to `releases/v1.3.x`.

### Problem

Reported in Pylon #2326 on **1.3.32**: a flow's **Concurrency** tab never opens for a flow that declares a `concurrency:` block — it renders `failed to load concurrency limit`.

`FlowConcurrency.vue` reads the running/limit ratio from `GET /concurrency-limit/search`. EE restricts that endpoint to superadmins (class-level `@IsSuperAdmin`), so every other user gets a **403**. No IAM role can grant it. The tab is pushed for every user (`FlowRoot.vue`), so a normal user always sees a broken tab. The same 403 also fires when opening a QUEUED execution.

Flows *without* a concurrency block appear to work only because the error branch lives inside `v-if="flow?.concurrency"` — the identical 403 happens and is never displayed.

### Fix

Add a flow-scoped `GET /api/v1/{tenant}/concurrency-limit/{namespace}/{flowId}` and read that instead of the instance-wide search. The companion EE PR gates it on `FLOW` `READ`, which the tab already requires to load the flow itself.

A flow declaring a concurrency block but never executed has no limit record, so the new endpoint legitimately 404s. On this branch a 404 sets `coreStore.error` and swaps in the global not-found page, so this also adds the `ignoreNotFound` request option (present on develop via `kestraHttp`, which does not exist here) to let a caller treat a missing record as a normal outcome.

### Not included

The **Force Run / Unqueue permission gating** from the original commit is deliberately left out. It depends on the granular `EXECUTION.FORCE_RUN` / `EXECUTION.UNQUEUE` actions, and `ui/src/models/action.js` on this branch defines only `READ/CREATE/UPDATE/DELETE`. Including it would mean backporting the granular action model and its EE permission counterpart — a much larger change than this fix warrants on a release branch.

### Conflicts resolved

The pick was **not** clean:

- `ConcurrencyLimitController.java` auto-merged but referenced `concurrencyLimitRepository`, which does not exist on this branch — retargeted to `concurrencyLimitService.findById(...)` (same signature, returns `Optional`).
- `FlowConcurrency.vue` — took the new fetch logic only; the surrounding template and the `runningCount`/`runningCountSet` refs this branch's template binds to are kept, and `error` becomes a boolean.
- `Executions.vue`, `ForceRun.vue`, `Unqueue.vue` — restored to the branch version (see *Not included*).
- `ui/tests/unit/components/FlowConcurrency.spec.ts` — develop's spec targets `@kestra-io/kestra-sdk` / `@kestra-io/design-system` and asserts the later `staleLimit` behaviour, none of which exist here. Rewritten against this branch's `useAxios` / `ui-libs` / `el-*` components, covering only what is backported.

### Verification (local)

- `./gradlew :webserver:test --tests "ConcurrencyLimitControllerTest"` → **3 passing**, including the flow-scoped GET and its 404 case.
- `npm run test:unit` → **222 passing (32 files)**, including the 3 new `FlowConcurrency` specs.
- `npx vue-tsc --noEmit` → clean.
- `npm run lint` → 0 errors (43 pre-existing warnings, all in untouched files).

Companion EE PR: kestra-io/kestra-ee (linked below once open).
Upstream issue: kestra-io/kestra-ee#10182.
