### PR TITLE
fix(core): a trigger carrying a removed property no longer loads with it dropped

### DIFF
--- a/core/src/main/java/io/kestra/core/exceptions/UnknownPropertyException.java
+++ b/core/src/main/java/io/kestra/core/exceptions/UnknownPropertyException.java
@@ -1,0 +1,24 @@
+package io.kestra.core.exceptions;
+
+import java.io.Serial;
+
+/**
+ * Thrown while deserializing a model that refuses unknown properties, such as
+ * {@link io.kestra.core.models.triggers.AbstractTrigger}.
+ *
+ * <p>
+ * It extends {@link IllegalArgumentException} on purpose: Jackson wraps it into a
+ * {@code JsonMappingException}, which every flow read path already handles — the flow repositories turn it
+ * into a {@code FlowWithException}, {@code YamlParser} into a {@code ConstraintViolationException}. A runtime
+ * exception of another kind would escape those handlers.
+ * </p>
+ */
+public class UnknownPropertyException extends IllegalArgumentException {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
+
+    public UnknownPropertyException(String message) {
+        super(message);
+    }
+}

--- a/core/src/main/java/io/kestra/core/models/flows/FlowWithException.java
+++ b/core/src/main/java/io/kestra/core/models/flows/FlowWithException.java
@@ -8,6 +8,7 @@ import org.slf4j.Logger;
 
 import com.fasterxml.jackson.databind.JsonNode;
 
+import io.kestra.core.exceptions.UnknownPropertyException;
 import io.kestra.core.serializers.JacksonMapper;
 
 import lombok.EqualsAndHashCode;
@@ -32,7 +33,7 @@ public class FlowWithException extends FlowWithSource {
             .revision(flow.getRevision())
             .deleted(flow.isDeleted())
             .disabled(flow.isDisabled())
-            .exception(exception.getMessage())
+            .exception(exceptionMessage(flow.getNamespace(), flow.getId(), exception))
             .tasks(List.of())
             // an execution is still created for a blocked flow and then failed, so it must keep carrying these:
             // dropping them leaves label-based filtering, notifications and SLA alerting blind to the failure
@@ -56,6 +57,8 @@ public class FlowWithException extends FlowWithSource {
 
     public static Optional<FlowWithException> from(JsonNode jsonNode, Exception exception) {
         if (jsonNode.hasNonNull("id") && jsonNode.hasNonNull("namespace")) {
+            final String id = jsonNode.get("id").asText();
+            final String namespace = jsonNode.get("namespace").asText();
 
             final String tenantId;
             if (jsonNode.hasNonNull("tenant_id")) {
@@ -69,13 +72,13 @@ public class FlowWithException extends FlowWithSource {
             }
 
             var flow = FlowWithException.builder()
-                .id(jsonNode.get("id").asText())
+                .id(id)
                 .tenantId(tenantId)
-                .namespace(jsonNode.get("namespace").asText())
+                .namespace(namespace)
                 .revision(jsonNode.hasNonNull("revision") ? jsonNode.get("revision").asInt() : 1)
                 .deleted(jsonNode.hasNonNull("deleted") && jsonNode.get("deleted").asBoolean())
                 .disabled(jsonNode.hasNonNull("disabled") && jsonNode.get("disabled").asBoolean())
-                .exception(exception.getMessage())
+                .exception(exceptionMessage(namespace, id, exception))
                 .tasks(List.of())
                 .source(jsonNode.hasNonNull("source") ? jsonNode.get("source").asText() : null)
                 .build();
@@ -84,6 +87,28 @@ public class FlowWithException extends FlowWithSource {
 
         // if there is no id and namespace, we return null as we cannot create a meaningful FlowWithException
         return Optional.empty();
+    }
+
+    /**
+     * The message shown for this flow by the API and the UI.
+     * <p>
+     * A model that frames its own error — see {@link io.kestra.core.models.triggers.AbstractTrigger} rejecting
+     * a property it does not declare — has that message buried under Jackson's wrapping
+     * ({@code Problem deserializing "any-property" … (through reference chain …)}). The framed message is what
+     * tells the user what to change, so it is used instead, prefixed with the flow it belongs to since this
+     * text also travels to logs and execution failures where the flow is not otherwise named.
+     */
+    private static String exceptionMessage(String namespace, String id, Exception exception) {
+        // bounded: a cause chain this deep is a bug, and this must never loop on a self-referencing cause
+        Throwable cause = exception;
+        for (int depth = 0; cause != null && depth < 10; depth++) {
+            if (cause instanceof UnknownPropertyException unknownProperty) {
+                return "Flow '" + namespace + "/" + id + "': " + unknownProperty.getMessage();
+            }
+            cause = cause.getCause() == cause ? null : cause.getCause();
+        }
+
+        return exception.getMessage();
     }
 
     /** {@inheritDoc} **/

--- a/core/src/main/java/io/kestra/core/models/triggers/AbstractTrigger.java
+++ b/core/src/main/java/io/kestra/core/models/triggers/AbstractTrigger.java
@@ -5,10 +5,12 @@ import java.util.Map;
 
 import org.slf4j.event.Level;
 
+import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 
+import io.kestra.core.exceptions.UnknownPropertyException;
 import io.kestra.core.models.Label;
 import io.kestra.core.models.annotations.Plugin;
 import io.kestra.core.models.annotations.PluginProperty;
@@ -106,4 +108,47 @@ abstract public class AbstractTrigger implements TriggerInterface {
 
     @PluginProperty(hidden = true, group = "advanced")
     private AssetsDeclaration assets;
+
+    private static final String MIGRATION_GUIDE = "https://kestra.io/docs/migration-guide/v2.0.0";
+
+    /**
+     * Properties that existed on a trigger before 2.0 and were removed by it. Deserializing them silently
+     * would drop the filtering the user configured — the removed `conditions` / `preconditions` are what kept
+     * a trigger from firing — so they get a message pointing at their replacement rather than the generic one.
+     */
+    private static final Map<String, String> REMOVED_PROPERTIES = Map.of(
+        "conditions",
+        "trigger conditions were replaced by \"when\" in 2.0 (and by \"dependsOn\" on io.kestra.plugin.core.trigger.Flow) - see the migration guide " + MIGRATION_GUIDE,
+        "preconditions",
+        "trigger preconditions were replaced by \"dependsOn\" in 2.0 - see the migration guide " + MIGRATION_GUIDE
+    );
+
+    /**
+     * Fails deserialization on any property that is not part of the trigger model.
+     * <p>
+     * Triggers must fail closed: the mappers used on the read paths (the flow repositories, and
+     * {@code parseForRuntime}) are lenient, so without this an unknown property is dropped and the trigger
+     * runs <em>without</em> it. For a filtering property such as the pre-2.0 {@code conditions} /
+     * {@code preconditions} that turns a narrow trigger into one that matches everything, which is how a
+     * 1.3 flow could start an execution storm right after an upgrade. Throwing here makes such a flow surface
+     * as a {@link io.kestra.core.models.flows.FlowWithException} — listable and visible in the UI, but skipped
+     * by the executor, the scheduler and the flow-trigger service — exactly like a trigger whose <em>type</em>
+     * no longer exists.
+     * <p>
+     * An {@link UnknownPropertyException} — an {@link IllegalArgumentException} — is deliberate: Jackson wraps
+     * it into a {@code JsonMappingException}, which every read path already handles (the repositories turn it
+     * into a {@code FlowWithException}, {@code YamlParser} into a {@code ConstraintViolationException}). A raw
+     * runtime exception of another kind would escape those handlers.
+     * <p>
+     * The trigger is named only when its {@code id} was read before the offending property, which is the order
+     * of both the YAML users write and the stored flow JSON.
+     */
+    @JsonAnySetter
+    public void failOnUnknownProperty(String name, Object value) {
+        throw new UnknownPropertyException(
+            "Unrecognized property \"" + name + "\" on trigger \"" + (this.id == null ? "<unknown>" : this.id) + "\" ("
+                + (this.type == null ? this.getClass().getName() : this.type) + "): "
+                + REMOVED_PROPERTIES.getOrDefault(name, "this property does not exist on this trigger")
+        );
+    }
 }

--- a/core/src/main/java/io/kestra/core/models/triggers/AbstractTrigger.java
+++ b/core/src/main/java/io/kestra/core/models/triggers/AbstractTrigger.java
@@ -141,7 +141,24 @@ abstract public class AbstractTrigger implements TriggerInterface {
      * runtime exception of another kind would escape those handlers.
      * <p>
      * The trigger is named only when its {@code id} was read before the offending property, which is the order
-     * of both the YAML users write and the stored flow JSON.
+     * of both the YAML users write and the stored flow JSON; otherwise the message says {@code "<unknown>"} and
+     * the caller identifies the trigger from the flow and the property.
+     * <p>
+     * Consequences to know about before touching a trigger class:
+     * <ul>
+     * <li>Jackson consults an any-setter <em>before</em> its unknown-property handling, so neither
+     * {@code @JsonIgnoreProperties(ignoreUnknown = true)} on a trigger nor a mapper's
+     * {@code FAIL_ON_UNKNOWN_PROPERTIES} has any effect on triggers any more. Ignoring a specific property
+     * still works: {@code @JsonIgnoreProperties({"foo"})} names it explicitly, and Jackson drops it before
+     * reaching here.</li>
+     * <li>A trigger deserialized through a builder — {@code @Jacksonized}, or any
+     * {@code @JsonDeserialize(builder = …)} — does not go through this method, which silently re-opens the
+     * hole for that trigger. Do not add one without moving the check into the builder.</li>
+     * <li>A flow authored against a <em>newer</em> plugin version than the one installed (a rollback, or a
+     * pinned version) fails the same way and becomes a {@code FlowWithException}: a property the installed
+     * class does not declare is indistinguishable from a removed one, and failing closed is the safe reading
+     * of both.</li>
+     * </ul>
      */
     @JsonAnySetter
     public void failOnUnknownProperty(String name, Object value) {

--- a/core/src/main/java/io/kestra/core/serializers/YamlParser.java
+++ b/core/src/main/java/io/kestra/core/serializers/YamlParser.java
@@ -14,11 +14,13 @@ import org.apache.commons.io.IOUtils;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.exc.InvalidTypeIdException;
 import com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException;
 
 import io.kestra.core.exceptions.InvalidTypeConstraintViolationException;
+import io.kestra.core.exceptions.UnknownPropertyException;
 import io.kestra.core.models.validations.ManualConstraintViolation;
 
 import jakarta.validation.ConstraintViolationException;
@@ -139,6 +141,21 @@ public final class YamlParser {
                         target,
                         (Class<T>) target.getClass(),
                         invalidTypeIdException.getPathReference(),
+                        null
+                    )
+                )
+            );
+        } else if (e.getCause() instanceof UnknownPropertyException unknownPropertyException) {
+            // a model that rejects unknown properties itself (see AbstractTrigger) already frames the error for
+            // the user: report it as-is rather than wrapped in a generic parsing message
+            return new ConstraintViolationException(
+                unknownPropertyException.getMessage(),
+                Collections.singleton(
+                    ManualConstraintViolation.of(
+                        unknownPropertyException.getMessage(),
+                        target,
+                        (Class<T>) target.getClass(),
+                        e instanceof JsonMappingException jsonMappingException ? jsonMappingException.getPathReference() : resource,
                         null
                     )
                 )

--- a/core/src/test/java/io/kestra/core/models/triggers/AbstractTriggerUnknownPropertyTest.java
+++ b/core/src/test/java/io/kestra/core/models/triggers/AbstractTriggerUnknownPropertyTest.java
@@ -6,21 +6,49 @@ import java.util.Map;
 
 import org.junit.jupiter.api.Test;
 
-import io.kestra.core.junit.annotations.KestraTest;
+import io.kestra.core.exceptions.FlowProcessingException;
 import io.kestra.core.models.flows.Flow;
+import io.kestra.core.models.flows.FlowWithException;
+import io.kestra.core.models.flows.FlowWithSource;
 import io.kestra.core.serializers.JacksonMapper;
+import io.kestra.core.serializers.YamlParser;
+import io.kestra.core.services.FlowParsingService;
+
+import jakarta.validation.ConstraintViolationException;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
- * A flow is read back from the repositories with the lenient JSON mapper. Properties removed from the trigger
- * model — pre-2.0 `conditions` / `preconditions` — must not be dropped silently there: the trigger would then
- * run without the filtering the user configured. See {@link AbstractTrigger#failOnUnknownProperty}.
+ * A flow is read back from the repositories with the lenient JSON mapper, and re-parsed for the executor and
+ * the scheduler with the lenient YAML one. Properties removed from the trigger model — pre-2.0 `conditions` /
+ * `preconditions` — must not be dropped silently on either path: the trigger would then run without the
+ * filtering the user configured. See {@link AbstractTrigger#failOnUnknownProperty}.
  */
-@KestraTest
 class AbstractTriggerUnknownPropertyTest {
+
+    private static final String LEGACY_CONDITIONS_SOURCE = """
+        id: legacy
+        namespace: qa.deprecated
+        tasks:
+          - id: hello
+            type: io.kestra.plugin.core.log.Log
+            message: hello
+        triggers:
+          - id: on_foreach
+            type: io.kestra.plugin.core.trigger.Flow
+            states: [SUCCESS, FAILED]
+            conditions:
+              - type: io.kestra.plugin.core.condition.ExecutionFlow
+                namespace: qa.deprecated
+                flowId: dep-foreach
+        """;
+
+    private static final String FRAMED_MESSAGE =
+        "Unrecognized property \"conditions\" on trigger \"on_foreach\" (io.kestra.plugin.core.trigger.Flow): "
+            + "trigger conditions were replaced by \"when\" in 2.0 (and by \"dependsOn\" on io.kestra.plugin.core.trigger.Flow) "
+            + "- see the migration guide https://kestra.io/docs/migration-guide/v2.0.0";
 
     /**
      * Builds the trigger as an ordered map: the message names the trigger only if its `id` was read before the
@@ -45,9 +73,8 @@ class AbstractTriggerUnknownPropertyTest {
         );
     }
 
-    @Test
-    void shouldRejectLegacyTriggerConditions() {
-        Map<String, Object> flow = flowWithTrigger(
+    private static Map<String, Object> legacyConditionsFlow() {
+        return flowWithTrigger(
             trigger(
                 "id", "on_foreach",
                 "type", "io.kestra.plugin.core.trigger.Flow",
@@ -61,8 +88,21 @@ class AbstractTriggerUnknownPropertyTest {
                 )
             )
         );
+    }
 
-        assertThatThrownBy(() -> JacksonMapper.ofJson().convertValue(flow, Flow.class))
+    private static FlowWithSource storedFlow() {
+        return FlowWithSource.builder()
+            .tenantId("main")
+            .namespace("qa.deprecated")
+            .id("legacy")
+            .revision(1)
+            .source(LEGACY_CONDITIONS_SOURCE)
+            .build();
+    }
+
+    @Test
+    void shouldRejectLegacyTriggerConditions() {
+        assertThatThrownBy(() -> JacksonMapper.ofJson().convertValue(legacyConditionsFlow(), Flow.class))
             .isInstanceOf(IllegalArgumentException.class)
             .hasMessageContaining("Unrecognized property \"conditions\" on trigger \"on_foreach\"")
             .hasMessageContaining("io.kestra.plugin.core.trigger.Flow")
@@ -125,6 +165,28 @@ class AbstractTriggerUnknownPropertyTest {
             .hasMessageContaining("this property does not exist on this trigger");
     }
 
+    /**
+     * The trigger id is only known if it was read before the offending property. When it was not, the message
+     * still names the property and the trigger type, and Jackson's reference chain gives the position of the
+     * trigger in the list.
+     */
+    @Test
+    void shouldFallBackToUnknownWhenTheRemovedPropertyPrecedesTheId() {
+        Map<String, Object> flow = flowWithTrigger(
+            trigger(
+                "conditions", List.of(Map.of("type", "io.kestra.plugin.core.condition.DayWeek", "dayOfWeek", "MONDAY")),
+                "id", "every_minute",
+                "type", "io.kestra.plugin.core.trigger.Schedule",
+                "cron", "* * * * *"
+            )
+        );
+
+        assertThatThrownBy(() -> JacksonMapper.ofJson().convertValue(flow, Flow.class))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("Unrecognized property \"conditions\" on trigger \"<unknown>\"")
+            .hasMessageContaining("io.kestra.plugin.core.trigger.Schedule[\"conditions\"]");
+    }
+
     @Test
     void shouldStillDeserializeAValidTrigger() {
         Map<String, Object> flow = flowWithTrigger(
@@ -142,5 +204,53 @@ class AbstractTriggerUnknownPropertyTest {
             assertThat(parsed.getTriggers()).hasSize(1);
             assertThat(parsed.getTriggers().getFirst().getId()).isEqualTo("on_foreach");
         }).doesNotThrowAnyException();
+    }
+
+    /**
+     * The YAML path — {@code YamlParser}, used by validation and by the runtime re-parse — reports the framed
+     * message as the violation instead of wrapping it in a generic parsing error.
+     */
+    @Test
+    void shouldReportTheFramedMessageAsAConstraintViolationOnTheYamlPath() {
+        assertThatThrownBy(() -> YamlParser.parse(LEGACY_CONDITIONS_SOURCE, FlowWithSource.class, false))
+            .isInstanceOf(ConstraintViolationException.class)
+            .hasMessage(FRAMED_MESSAGE);
+    }
+
+    /**
+     * The runtime path the executor and the scheduler go through: a stored flow whose trigger carries a removed
+     * property cannot be parsed for runtime, so callers keep the {@code FlowWithException} the repository gave
+     * them rather than a trigger that would fire on everything.
+     */
+    @Test
+    void shouldFailToParseForRuntime() {
+        assertThatThrownBy(() -> new FlowParsingService().parseForRuntime(storedFlow()))
+            .isInstanceOf(FlowProcessingException.class)
+            .hasMessageContaining(FRAMED_MESSAGE);
+    }
+
+    /**
+     * What the API and the UI show: the framed message prefixed with the flow, without the
+     * {@code (through reference chain: …)} tail Jackson appends — the trigger id, its type and the property
+     * already say where to look.
+     */
+    @Test
+    void shouldSurfaceTheFramedMessageOnTheFlowWithException() {
+        Exception jacksonWrapped = jacksonWrappedFailure();
+        // the wrapping this must not surface
+        assertThat(jacksonWrapped.getMessage()).contains("(through reference chain:");
+
+        FlowWithException flowWithException = FlowWithException.from(storedFlow(), jacksonWrapped);
+
+        assertThat(flowWithException.getException()).isEqualTo("Flow 'qa.deprecated/legacy': " + FRAMED_MESSAGE);
+    }
+
+    private static Exception jacksonWrappedFailure() {
+        try {
+            JacksonMapper.ofJson().convertValue(legacyConditionsFlow(), Flow.class);
+            throw new AssertionError("Expected the legacy trigger property to be rejected");
+        } catch (IllegalArgumentException e) {
+            return e;
+        }
     }
 }

--- a/core/src/test/java/io/kestra/core/models/triggers/AbstractTriggerUnknownPropertyTest.java
+++ b/core/src/test/java/io/kestra/core/models/triggers/AbstractTriggerUnknownPropertyTest.java
@@ -1,0 +1,146 @@
+package io.kestra.core.models.triggers;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import io.kestra.core.junit.annotations.KestraTest;
+import io.kestra.core.models.flows.Flow;
+import io.kestra.core.serializers.JacksonMapper;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * A flow is read back from the repositories with the lenient JSON mapper. Properties removed from the trigger
+ * model — pre-2.0 `conditions` / `preconditions` — must not be dropped silently there: the trigger would then
+ * run without the filtering the user configured. See {@link AbstractTrigger#failOnUnknownProperty}.
+ */
+@KestraTest
+class AbstractTriggerUnknownPropertyTest {
+
+    /**
+     * Builds the trigger as an ordered map: the message names the trigger only if its `id` was read before the
+     * offending property, which is the order both the YAML users write and the stored flow JSON have.
+     */
+    private static Map<String, Object> trigger(Object... keyValues) {
+        Map<String, Object> trigger = new LinkedHashMap<>();
+        for (int i = 0; i < keyValues.length; i += 2) {
+            trigger.put((String) keyValues[i], keyValues[i + 1]);
+        }
+        return trigger;
+    }
+
+    private static Map<String, Object> flowWithTrigger(Map<String, Object> trigger) {
+        return Map.of(
+            "id", "legacy",
+            "namespace", "qa.deprecated",
+            "revision", 1,
+            "deleted", false,
+            "tasks", List.of(Map.of("id", "hello", "type", "io.kestra.plugin.core.log.Log", "message", "hello")),
+            "triggers", List.of(trigger)
+        );
+    }
+
+    @Test
+    void shouldRejectLegacyTriggerConditions() {
+        Map<String, Object> flow = flowWithTrigger(
+            trigger(
+                "id", "on_foreach",
+                "type", "io.kestra.plugin.core.trigger.Flow",
+                "states", List.of("SUCCESS", "FAILED"),
+                "conditions", List.of(
+                    Map.of(
+                        "type", "io.kestra.plugin.core.condition.ExecutionFlow",
+                        "namespace", "qa.deprecated",
+                        "flowId", "dep-foreach"
+                    )
+                )
+            )
+        );
+
+        assertThatThrownBy(() -> JacksonMapper.ofJson().convertValue(flow, Flow.class))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("Unrecognized property \"conditions\" on trigger \"on_foreach\"")
+            .hasMessageContaining("io.kestra.plugin.core.trigger.Flow")
+            .hasMessageContaining("replaced by \"when\"")
+            .hasMessageContaining("https://kestra.io/docs/migration-guide/v2.0.0");
+    }
+
+    @Test
+    void shouldRejectLegacyFlowTriggerPreconditions() {
+        Map<String, Object> flow = flowWithTrigger(
+            trigger(
+                "id", "on_foreach",
+                "type", "io.kestra.plugin.core.trigger.Flow",
+                "states", List.of("SUCCESS"),
+                "preconditions", Map.of("id", "dep", "flows", List.of(Map.of("namespace", "qa.deprecated", "flowId", "dep-foreach")))
+            )
+        );
+
+        assertThatThrownBy(() -> JacksonMapper.ofJson().convertValue(flow, Flow.class))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("Unrecognized property \"preconditions\" on trigger \"on_foreach\"")
+            .hasMessageContaining("replaced by \"dependsOn\"");
+    }
+
+    @Test
+    void shouldRejectLegacyScheduleConditions() {
+        Map<String, Object> flow = flowWithTrigger(
+            trigger(
+                "id", "every_minute",
+                "type", "io.kestra.plugin.core.trigger.Schedule",
+                "cron", "* * * * *",
+                "conditions", List.of(Map.of("type", "io.kestra.plugin.core.condition.DayWeek", "dayOfWeek", "MONDAY"))
+            )
+        );
+
+        assertThatThrownBy(() -> JacksonMapper.ofJson().convertValue(flow, Flow.class))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("Unrecognized property \"conditions\" on trigger \"every_minute\"");
+    }
+
+    /**
+     * Strictness is not limited to the properties 2.0 removed: any property the trigger — core or plugin
+     * defined — does not declare fails the same way, so a renamed or dropped plugin property cannot silently
+     * change what a stored trigger does either.
+     */
+    @Test
+    void shouldRejectAnyUnknownTriggerProperty() {
+        Map<String, Object> flow = flowWithTrigger(
+            trigger(
+                "id", "every_minute",
+                "type", "io.kestra.plugin.core.trigger.Schedule",
+                "cron", "* * * * *",
+                "notAPropertyOfSchedule", "boom"
+            )
+        );
+
+        assertThatThrownBy(() -> JacksonMapper.ofJson().convertValue(flow, Flow.class))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("Unrecognized property \"notAPropertyOfSchedule\" on trigger \"every_minute\"")
+            .hasMessageContaining("this property does not exist on this trigger");
+    }
+
+    @Test
+    void shouldStillDeserializeAValidTrigger() {
+        Map<String, Object> flow = flowWithTrigger(
+            trigger(
+                "id", "on_foreach",
+                "type", "io.kestra.plugin.core.trigger.Flow",
+                "states", List.of("SUCCESS"),
+                "when", "{{ true }}"
+            )
+        );
+
+        assertThatCode(() ->
+        {
+            Flow parsed = JacksonMapper.ofJson().convertValue(flow, Flow.class);
+            assertThat(parsed.getTriggers()).hasSize(1);
+            assertThat(parsed.getTriggers().getFirst().getId()).isEqualTo("on_foreach");
+        }).doesNotThrowAnyException();
+    }
+}

--- a/core/src/test/java/io/kestra/core/runners/DefaultFlowMetaStoreTest.java
+++ b/core/src/test/java/io/kestra/core/runners/DefaultFlowMetaStoreTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.Test;
 
 import io.kestra.core.exceptions.FlowBlockedException;
 import io.kestra.core.exceptions.FlowProcessingException;
+import io.kestra.core.exceptions.UnknownPropertyException;
 import io.kestra.core.junit.annotations.KestraTest;
 import io.kestra.core.models.Label;
 import io.kestra.core.models.executions.Execution;
@@ -386,6 +387,48 @@ class DefaultFlowMetaStoreTest {
         assertThat(resolved).isPresent();
         assertThat(resolved.get()).isNotInstanceOf(FlowWithException.class);
         assertThat(resolved.get().getId()).isEqualTo(flow.getId());
+    }
+
+    /**
+     * A 1.x flow whose trigger carries a property 2.0 removed cannot be deserialized, so the repository hands
+     * over a {@link FlowWithException}. Re-parsing it for runtime fails the same way, and that stored
+     * FlowWithException is what the executor gets back — never a flow with the trigger's filtering dropped.
+     */
+    @Test
+    void shouldKeepTheStoredFlowWithExceptionOnTheExecutionPath() {
+        // Given the flow as the repository deserialized it: unparsable, kept with its source only
+        String legacySource = """
+            id: legacy
+            namespace: io.kestra.tests
+            tasks:
+              - id: log
+                type: io.kestra.plugin.core.log.Log
+                message: hello
+            triggers:
+              - id: on_foreach
+                type: io.kestra.plugin.core.trigger.Flow
+                states: [SUCCESS]
+                conditions:
+                  - type: io.kestra.plugin.core.condition.ExecutionFlow
+                    namespace: io.kestra.tests
+                    flowId: dep-foreach
+            """;
+        FlowWithSource stored = FlowWithException.from(
+            createFlow().toBuilder().revision(1).source(legacySource).build(),
+            new UnknownPropertyException("Unrecognized property \"conditions\" on trigger \"on_foreach\"")
+        );
+        // a real parsing service: the re-parse must fail on its own, not because a mock said so
+        DefaultFlowMetaStore metaStore = metaStore(stored, new FlowParsingService());
+
+        // When
+        Optional<FlowWithSource> resolved = metaStore.findByExecutionForRuntime(executionOf(stored));
+
+        // Then the flow stays unparsable and carries no trigger: nothing can fire from it
+        assertThat(resolved).isPresent();
+        assertThat(resolved.get()).isInstanceOf(FlowWithException.class);
+        assertThat(((FlowWithException) resolved.get()).getException())
+            .isEqualTo("Flow '" + stored.getNamespace() + "/" + stored.getId() + "': Unrecognized property \"conditions\" on trigger \"on_foreach\"");
+        assertThat(resolved.get().getTriggers()).isNull();
     }
 
     @Test

--- a/executor/src/main/java/io/kestra/executor/FlowTriggerService.java
+++ b/executor/src/main/java/io/kestra/executor/FlowTriggerService.java
@@ -39,15 +39,15 @@ import lombok.extern.slf4j.Slf4j;
 @Singleton
 @Slf4j
 public class FlowTriggerService {
-    private static final int MAX_WARNED_CATCH_ALL_TRIGGERS = 1000;
-    private final Set<String> warnedCatchAllTriggers = ConcurrentHashMap.newKeySet();
-
     private final ConditionService conditionService;
     private final RunContextFactory runContextFactory;
     private final FlowService flowService;
     private final FlowMetaStoreInterface flowMetaStore;
     private final ExecutionOutputService executionOutputService;
     private final ExecutionDepthConfiguration executionDepthConfiguration;
+
+    private static final int MAX_WARNED_CATCH_ALL_TRIGGERS = 1000;
+    private final Set<String> warnedCatchAllTriggers = ConcurrentHashMap.newKeySet();
 
     public FlowTriggerService(ConditionService conditionService, RunContextFactory runContextFactory, FlowService flowService, FlowMetaStoreInterface flowMetaStore,
         ExecutionOutputService executionOutputService,
@@ -63,7 +63,8 @@ public class FlowTriggerService {
     public Stream<FlowWithFlowTrigger> withFlowTriggersOnly(Stream<FlowWithSource> allFlows) {
         return allFlows
             .filter(flow -> !flow.isDisabled())
-            // a flow that could not be parsed carries no usable trigger: never evaluate one from it
+            // belt and braces: flowTriggers() below already drops it, and a FlowWithException carries no
+            // trigger anyway - but a caller reading this stream should not have to know that
             .filter(flow -> !(flow instanceof FlowWithException))
             // a draft revision is never picked up implicitly: a Flow trigger on a flow whose latest
             // revision is a draft must not fire, like webhooks/schedules/subflows
@@ -73,6 +74,8 @@ public class FlowTriggerService {
     }
 
     public Stream<io.kestra.plugin.core.trigger.Flow> flowTriggers(Flow flow) {
+        // load-bearing: this is the entry point every caller funnels through, and a FlowWithException has no
+        // trigger list at all, so without it the stream below throws on a null getTriggers()
         if (flow instanceof FlowWithException) {
             return Stream.empty();
         }
@@ -95,14 +98,19 @@ public class FlowTriggerService {
      * path still let one through, this at least names the flow in the logs instead of leaving an execution
      * storm unexplained. Save-time validation raises the same shape as a warning
      * ({@code FlowService.warnings}), which this mirrors at runtime.
+     * <p>
+     * At most {@value #MAX_WARNED_CATCH_ALL_TRIGGERS} distinct triggers are ever warned about; beyond that the
+     * warning is dropped rather than tracked.
      */
     private void warnOnceIfCatchAll(Flow flow, io.kestra.plugin.core.trigger.Flow trigger) {
         if (!ListUtils.isEmpty(trigger.getDependsOn()) || (trigger.getWhen() != null && !"true".equals(trigger.getWhen()))) {
             return;
         }
 
-        // bounded: a warning is emitted at most once per flow revision + trigger, and the set is capped so a
-        // long-lived executor cannot grow it without limit
+        // Bounded: at most one warning per flow revision + trigger, and the set stops growing at
+        // MAX_WARNED_CATCH_ALL_TRIGGERS distinct triggers - past that, further catch-all triggers are not
+        // warned about at all, which is the accepted trade for not letting a long-lived executor grow this
+        // set without limit.
         if (warnedCatchAllTriggers.size() < MAX_WARNED_CATCH_ALL_TRIGGERS && warnedCatchAllTriggers.add(flow.uid() + "/" + trigger.getId())) {
             log.warn(
                 "The Flow trigger '{}' of flow '{}' in namespace '{}' (tenant {}, revision {}) has no 'dependsOn' and no 'when': it is evaluated for EVERY execution of EVERY flow. "

--- a/executor/src/main/java/io/kestra/executor/FlowTriggerService.java
+++ b/executor/src/main/java/io/kestra/executor/FlowTriggerService.java
@@ -2,6 +2,7 @@ package io.kestra.executor;
 
 import java.time.ZonedDateTime;
 import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -38,6 +39,9 @@ import lombok.extern.slf4j.Slf4j;
 @Singleton
 @Slf4j
 public class FlowTriggerService {
+    private static final int MAX_WARNED_CATCH_ALL_TRIGGERS = 1000;
+    private final Set<String> warnedCatchAllTriggers = ConcurrentHashMap.newKeySet();
+
     private final ConditionService conditionService;
     private final RunContextFactory runContextFactory;
     private final FlowService flowService;
@@ -59,6 +63,8 @@ public class FlowTriggerService {
     public Stream<FlowWithFlowTrigger> withFlowTriggersOnly(Stream<FlowWithSource> allFlows) {
         return allFlows
             .filter(flow -> !flow.isDisabled())
+            // a flow that could not be parsed carries no usable trigger: never evaluate one from it
+            .filter(flow -> !(flow instanceof FlowWithException))
             // a draft revision is never picked up implicitly: a Flow trigger on a flow whose latest
             // revision is a draft must not fire, like webhooks/schedules/subflows
             .filter(flow -> !flow.isDraft())
@@ -67,11 +73,47 @@ public class FlowTriggerService {
     }
 
     public Stream<io.kestra.plugin.core.trigger.Flow> flowTriggers(Flow flow) {
+        if (flow instanceof FlowWithException) {
+            return Stream.empty();
+        }
+
         return flow.getTriggers()
             .stream()
             .filter(Predicate.not(AbstractTrigger::isDisabled))
             .filter(io.kestra.plugin.core.trigger.Flow.class::isInstance)
-            .map(io.kestra.plugin.core.trigger.Flow.class::cast);
+            .map(io.kestra.plugin.core.trigger.Flow.class::cast)
+            .peek(trigger -> warnOnceIfCatchAll(flow, trigger));
+    }
+
+    /**
+     * Warns — once per flow revision and trigger — about a Flow trigger that matches <em>every</em> execution
+     * on the instance because it has no {@code dependsOn} and a {@code when} that is always true.
+     * <p>
+     * Defense in depth for a pre-2.0 flow whose trigger filtering lived in the removed {@code conditions} /
+     * {@code preconditions} properties: those now fail deserialization, so such a flow surfaces as a
+     * {@link FlowWithException} and is filtered out above rather than firing on everything. Should any read
+     * path still let one through, this at least names the flow in the logs instead of leaving an execution
+     * storm unexplained. Save-time validation raises the same shape as a warning
+     * ({@code FlowService.warnings}), which this mirrors at runtime.
+     */
+    private void warnOnceIfCatchAll(Flow flow, io.kestra.plugin.core.trigger.Flow trigger) {
+        if (!ListUtils.isEmpty(trigger.getDependsOn()) || (trigger.getWhen() != null && !"true".equals(trigger.getWhen()))) {
+            return;
+        }
+
+        // bounded: a warning is emitted at most once per flow revision + trigger, and the set is capped so a
+        // long-lived executor cannot grow it without limit
+        if (warnedCatchAllTriggers.size() < MAX_WARNED_CATCH_ALL_TRIGGERS && warnedCatchAllTriggers.add(flow.uid() + "/" + trigger.getId())) {
+            log.warn(
+                "The Flow trigger '{}' of flow '{}' in namespace '{}' (tenant {}, revision {}) has no 'dependsOn' and no 'when': it is evaluated for EVERY execution of EVERY flow. "
+                    + "If this flow comes from a Kestra 1.x version, its trigger filtering may have used the removed 'conditions'/'preconditions' properties - see the migration guide.",
+                trigger.getId(),
+                flow.getId(),
+                flow.getNamespace(),
+                flow.getTenantId(),
+                flow.getRevision()
+            );
+        }
     }
 
     /**

--- a/executor/src/test/java/io/kestra/executor/FlowTriggerServiceTest.java
+++ b/executor/src/test/java/io/kestra/executor/FlowTriggerServiceTest.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.BiFunction;
+import java.util.stream.Stream;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -543,6 +544,21 @@ class FlowTriggerServiceTest {
         // Then
         assertThat(resultingExecutionsToRun).hasSize(1);
         assertThat(resultingExecutionsToRun.getFirst().getFlowId()).isEqualTo(flowWithFlowTrigger.getId());
+    }
+
+    @Test
+    void shouldNotEvaluateFlowTriggersOfAFlowWithException() {
+        // Given a flow that could not be parsed but that still carries triggers
+        FlowWithException unparsable = FlowWithException.from(
+            flowWithFlowTriggerSource(),
+            new IllegalArgumentException("Unrecognized property \"conditions\" on trigger \"flowTrigger\"")
+        ).toBuilder().triggers(List.of(flowTriggerWithNoConditions())).build();
+        var simpleFlowExecution = Execution.newExecution(aSimpleFlow(), EMPTY_LABELS).withState(State.Type.SUCCESS);
+
+        // Then none of its triggers is considered, whichever entry point is used
+        assertThat(flowTriggerService.flowTriggers(unparsable)).isEmpty();
+        assertThat(flowTriggerService.withFlowTriggersOnly(Stream.of(unparsable))).isEmpty();
+        assertThat(flowTriggerService.computeExecutionsFromFlowTriggerConditions(simpleFlowExecution, unparsable)).isEmpty();
     }
 
     private static io.kestra.plugin.core.trigger.Flow flowTriggerWithNoConditions() {

--- a/jdbc/src/test/java/io/kestra/jdbc/repository/AbstractJdbcFlowRepositoryTest.java
+++ b/jdbc/src/test/java/io/kestra/jdbc/repository/AbstractJdbcFlowRepositoryTest.java
@@ -6,6 +6,7 @@ import java.util.Map;
 import java.util.Optional;
 
 import org.jooq.DSLContext;
+import org.jooq.SQLDialect;
 import org.jooq.impl.DSL;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
@@ -15,6 +16,7 @@ import io.kestra.core.models.flows.FlowWithException;
 import io.kestra.core.models.flows.FlowWithSource;
 import io.kestra.core.serializers.JacksonMapper;
 import io.kestra.core.utils.TestsUtils;
+import io.kestra.jdbc.JdbcJsonbUtils;
 import io.kestra.jdbc.JooqDSLContextWrapper;
 
 import io.micronaut.data.model.Pageable;
@@ -119,6 +121,15 @@ public abstract class AbstractJdbcFlowRepositoryTest extends io.kestra.core.repo
         return trigger;
     }
 
+    /**
+     * Binds the `value` column the way the repository of the dialect under test does: Postgres stores it as
+     * `jsonb` and rejects a character-varying bind, while H2 and MySQL store it as text. Mirrors what
+     * `PostgresRepository#persistFields` does on the production path.
+     */
+    private static Object jsonValue(DSLContext context, String json) {
+        return context.family() == SQLDialect.POSTGRES ? DSL.val(JdbcJsonbUtils.valueOf(json)) : json;
+    }
+
     private void assertLegacyTriggerPropertyIsRejected(String flowId, Map<String, Object> trigger, String expectedMessage) {
         String tenant = TestsUtils.randomTenant(this.getClass().getSimpleName());
 
@@ -126,22 +137,22 @@ public abstract class AbstractJdbcFlowRepositoryTest extends io.kestra.core.repo
         {
             DSLContext context = DSL.using(configuration);
 
+            String value = JacksonMapper.ofJson().writeValueAsString(
+                Map.of(
+                    "id", flowId,
+                    "tenantId", tenant,
+                    "namespace", "io.kestra.unittest",
+                    "revision", 1,
+                    "deleted", false,
+                    "tasks", List.of(Map.of("id", "log", "type", "io.kestra.plugin.core.log.Log", "message", "hello")),
+                    "triggers", List.of(trigger)
+                )
+            );
+
             context.insertInto(flowRepository.jdbcRepository.getTable())
                 .set(field("key"), tenant + "_io.kestra.unittest_" + flowId)
                 .set(field("source_code"), "id: " + flowId)
-                .set(
-                    field("value"), JacksonMapper.ofJson().writeValueAsString(
-                        Map.of(
-                            "id", flowId,
-                            "tenantId", tenant,
-                            "namespace", "io.kestra.unittest",
-                            "revision", 1,
-                            "deleted", false,
-                            "tasks", List.of(Map.of("id", "log", "type", "io.kestra.plugin.core.log.Log", "message", "hello")),
-                            "triggers", List.of(trigger)
-                        )
-                    )
-                )
+                .set(field("value"), jsonValue(context, value))
                 .execute();
         });
 

--- a/jdbc/src/test/java/io/kestra/jdbc/repository/AbstractJdbcFlowRepositoryTest.java
+++ b/jdbc/src/test/java/io/kestra/jdbc/repository/AbstractJdbcFlowRepositoryTest.java
@@ -95,7 +95,9 @@ public abstract class AbstractJdbcFlowRepositoryTest extends io.kestra.core.repo
                     )
                 )
             ),
-            "Unrecognized property \"conditions\" on trigger \"on_foreach\""
+            "Unrecognized property \"conditions\" on trigger \"on_foreach\" (io.kestra.plugin.core.trigger.Flow): "
+                + "trigger conditions were replaced by \"when\" in 2.0 (and by \"dependsOn\" on io.kestra.plugin.core.trigger.Flow) "
+                + "- see the migration guide https://kestra.io/docs/migration-guide/v2.0.0"
         );
     }
 
@@ -104,7 +106,9 @@ public abstract class AbstractJdbcFlowRepositoryTest extends io.kestra.core.repo
         assertLegacyTriggerPropertyIsRejected(
             "legacy-trigger-preconditions",
             legacyTrigger("preconditions", Map.of("id", "dep", "flows", List.of(Map.of("namespace", "io.kestra.unittest", "flowId", "dep-foreach")))),
-            "Unrecognized property \"preconditions\" on trigger \"on_foreach\""
+            "Unrecognized property \"preconditions\" on trigger \"on_foreach\" (io.kestra.plugin.core.trigger.Flow): "
+                + "trigger preconditions were replaced by \"dependsOn\" in 2.0 "
+                + "- see the migration guide https://kestra.io/docs/migration-guide/v2.0.0"
         );
     }
 
@@ -160,7 +164,9 @@ public abstract class AbstractJdbcFlowRepositoryTest extends io.kestra.core.repo
 
         assertThat(flow).isPresent();
         assertThat(flow.get()).isInstanceOf(FlowWithException.class);
-        assertThat(((FlowWithException) flow.get()).getException()).contains(expectedMessage);
+        // exact: the framed message is what the API and the UI show, with no Jackson wrapping around it
+        assertThat(((FlowWithException) flow.get()).getException())
+            .isEqualTo("Flow 'io.kestra.unittest/" + flowId + "': " + expectedMessage);
     }
 
     @Test

--- a/jdbc/src/test/java/io/kestra/jdbc/repository/AbstractJdbcFlowRepositoryTest.java
+++ b/jdbc/src/test/java/io/kestra/jdbc/repository/AbstractJdbcFlowRepositoryTest.java
@@ -1,5 +1,6 @@
 package io.kestra.jdbc.repository;
 
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -72,6 +73,83 @@ public abstract class AbstractJdbcFlowRepositoryTest extends io.kestra.core.repo
         } finally {
             flow.ifPresent(value -> flowRepository.delete(value));
         }
+    }
+
+    /**
+     * A flow stored by Kestra 1.x whose trigger carries the removed `conditions` (or `preconditions`) must not
+     * be read back with the property silently dropped: the trigger would then match everything. It surfaces as
+     * a {@link FlowWithException}, like a trigger whose type no longer exists.
+     */
+    @Test
+    void shouldReturnFlowWithExceptionForLegacyTriggerConditions() {
+        assertLegacyTriggerPropertyIsRejected(
+            "legacy-trigger-conditions",
+            legacyTrigger(
+                "conditions", List.of(
+                    Map.of(
+                        "type", "io.kestra.plugin.core.condition.ExecutionFlow",
+                        "namespace", "io.kestra.unittest",
+                        "flowId", "dep-foreach"
+                    )
+                )
+            ),
+            "Unrecognized property \"conditions\" on trigger \"on_foreach\""
+        );
+    }
+
+    @Test
+    void shouldReturnFlowWithExceptionForLegacyTriggerPreconditions() {
+        assertLegacyTriggerPropertyIsRejected(
+            "legacy-trigger-preconditions",
+            legacyTrigger("preconditions", Map.of("id", "dep", "flows", List.of(Map.of("namespace", "io.kestra.unittest", "flowId", "dep-foreach")))),
+            "Unrecognized property \"preconditions\" on trigger \"on_foreach\""
+        );
+    }
+
+    /**
+     * A pre-2.0 Flow trigger, as an ordered map: the stored flow JSON has the trigger `id` before the removed
+     * property, which is what lets the error name the trigger.
+     */
+    private static Map<String, Object> legacyTrigger(String legacyProperty, Object value) {
+        Map<String, Object> trigger = new LinkedHashMap<>();
+        trigger.put("id", "on_foreach");
+        trigger.put("type", "io.kestra.plugin.core.trigger.Flow");
+        trigger.put("states", List.of("SUCCESS", "FAILED"));
+        trigger.put(legacyProperty, value);
+        return trigger;
+    }
+
+    private void assertLegacyTriggerPropertyIsRejected(String flowId, Map<String, Object> trigger, String expectedMessage) {
+        String tenant = TestsUtils.randomTenant(this.getClass().getSimpleName());
+
+        dslContextWrapper.transaction(configuration ->
+        {
+            DSLContext context = DSL.using(configuration);
+
+            context.insertInto(flowRepository.jdbcRepository.getTable())
+                .set(field("key"), tenant + "_io.kestra.unittest_" + flowId)
+                .set(field("source_code"), "id: " + flowId)
+                .set(
+                    field("value"), JacksonMapper.ofJson().writeValueAsString(
+                        Map.of(
+                            "id", flowId,
+                            "tenantId", tenant,
+                            "namespace", "io.kestra.unittest",
+                            "revision", 1,
+                            "deleted", false,
+                            "tasks", List.of(Map.of("id", "log", "type", "io.kestra.plugin.core.log.Log", "message", "hello")),
+                            "triggers", List.of(trigger)
+                        )
+                    )
+                )
+                .execute();
+        });
+
+        Optional<FlowWithSource> flow = flowRepository.findByIdWithSource(tenant, "io.kestra.unittest", flowId);
+
+        assertThat(flow).isPresent();
+        assertThat(flow.get()).isInstanceOf(FlowWithException.class);
+        assertThat(((FlowWithException) flow.get()).getException()).contains(expectedMessage);
     }
 
     @Test

--- a/scheduler/src/test/java/io/kestra/scheduler/internals/TriggerFlowParserTest.java
+++ b/scheduler/src/test/java/io/kestra/scheduler/internals/TriggerFlowParserTest.java
@@ -22,6 +22,22 @@ import static org.mockito.Mockito.when;
 class TriggerFlowParserTest {
     private static final Logger LOGGER = LoggerFactory.getLogger(TriggerFlowParserTest.class);
 
+    private static final String LEGACY_CONDITIONS_SOURCE = """
+        id: trigger-flow-parser
+        namespace: io.kestra.tests
+        tasks:
+          - id: log
+            type: io.kestra.plugin.core.log.Log
+            message: hello
+        triggers:
+          - id: schedule
+            type: io.kestra.plugin.core.trigger.Schedule
+            cron: "* * * * *"
+            conditions:
+              - type: io.kestra.plugin.core.condition.DayWeek
+                dayOfWeek: MONDAY
+        """;
+
     private final FlowWithSource flow = FlowWithSource.builder()
         .tenantId("main")
         .namespace("io.kestra.tests")
@@ -62,6 +78,28 @@ class TriggerFlowParserTest {
         assertThatThrownBy(() -> TriggerFlowParser.parseForTrigger(flowParsingService, stored, LOGGER))
             .isInstanceOf(FlowProcessingException.class)
             .hasMessage("Invalid type: io.kestra.plugin.core.flow.ForEach");
+    }
+
+    /**
+     * A 1.x flow whose Schedule still filters through the removed `conditions`: the repository could not
+     * deserialize it, so the scheduler gets a {@link FlowWithException} carrying only the source. Re-parsing it
+     * fails too, and with no trigger definitions to degrade to the caller is told why — the trigger must not be
+     * scheduled, since without its conditions it would fire on every occurrence.
+     */
+    @Test
+    void shouldThrowForAStoredFlowWhoseTriggerCarriesARemovedProperty() {
+        // Given the flow as the repository hands it over: unparsable, kept without its trigger definitions
+        FlowWithSource stored = FlowWithException.from(
+            flow.toBuilder().source(LEGACY_CONDITIONS_SOURCE).build(),
+            new FlowProcessingException("stored as unparsable")
+        );
+        assertThat(stored.getTriggers()).isNull();
+
+        // When / Then the real parsing service refuses it, so the scheduler skips the trigger
+        assertThatThrownBy(() -> TriggerFlowParser.parseForTrigger(new FlowParsingService(), stored, LOGGER))
+            .isInstanceOf(FlowProcessingException.class)
+            .hasMessageContaining("Unrecognized property \"conditions\" on trigger \"schedule\"")
+            .hasMessageContaining("replaced by \"when\"");
     }
 
     @Test

--- a/webserver/src/main/java/io/kestra/webserver/controllers/api/FlowController.java
+++ b/webserver/src/main/java/io/kestra/webserver/controllers/api/FlowController.java
@@ -1035,11 +1035,7 @@ public class FlowController {
             .stream()
             .map(id -> flowRepository.findByIdWithSource(tenantService.resolveTenant(), id.getNamespace(), id.getId()).orElseThrow())
             .filter(flowWithSource -> disable != flowWithSource.isDisabled())
-            .peek(throwConsumer(flow ->
-            {
-                GenericFlow genericFlowUpdated = parseFlowSource(FlowService.injectDisabled(flow.getSource(), disable));
-                flowService.update(genericFlowUpdated, flow);
-            }))
+            .peek(throwConsumer(flow -> setFlowDisabled(flow, disable)))
             .toList();
     }
 
@@ -1048,12 +1044,29 @@ public class FlowController {
             .findWithSource(Pageable.UNPAGED, tenantService.resolveTenant(), filters)
             .stream()
             .filter(flowWithSource -> disable != flowWithSource.isDisabled())
-            .peek(throwConsumer(flow ->
-            {
-                GenericFlow genericFlowUpdated = parseFlowSource(FlowService.injectDisabled(flow.getSource(), disable));
-                flowService.update(genericFlowUpdated, flow);
-            }))
+            .peek(throwConsumer(flow -> setFlowDisabled(flow, disable)))
             .toList();
+    }
+
+    /**
+     * Re-saves the flow with `disabled` injected into its source.
+     * <p>
+     * The save re-validates the source, so a stored flow the current model can no longer parse — a 1.x flow
+     * whose trigger still carries the removed `conditions`/`preconditions`, say — cannot be disabled. That is
+     * reported as the validation failure it is (422 with the violations, like {@code PUT /flows}) rather than
+     * as a 500: {@code flowService.update} wraps violations in a {@link FlowProcessingException}, which maps
+     * to an internal error.
+     */
+    private void setFlowDisabled(FlowWithSource flow, boolean disable) throws FlowProcessingException, QueueException {
+        GenericFlow genericFlowUpdated = parseFlowSource(FlowService.injectDisabled(flow.getSource(), disable));
+        try {
+            flowService.update(genericFlowUpdated, flow);
+        } catch (FlowProcessingException e) {
+            if (e.getCause() instanceof ConstraintViolationException cve) {
+                throw cve;
+            }
+            throw e;
+        }
     }
 
     protected <T> T parseTaskTrigger(String input, Class<T> cls) throws ConstraintViolationException {

--- a/webserver/src/main/java/io/kestra/webserver/controllers/api/FlowController.java
+++ b/webserver/src/main/java/io/kestra/webserver/controllers/api/FlowController.java
@@ -1052,10 +1052,14 @@ public class FlowController {
      * Re-saves the flow with `disabled` injected into its source.
      * <p>
      * The save re-validates the source, so a stored flow the current model can no longer parse — a 1.x flow
-     * whose trigger still carries the removed `conditions`/`preconditions`, say — cannot be disabled. That is
-     * reported as the validation failure it is (422 with the violations, like {@code PUT /flows}) rather than
-     * as a 500: {@code flowService.update} wraps violations in a {@link FlowProcessingException}, which maps
-     * to an internal error.
+     * whose trigger still carries the removed `conditions`/`preconditions`, say — cannot be disabled, and the
+     * caller gets its constraint violations as a 422, like {@code PUT /flows}. That is what the unwrapping
+     * below is for: {@code flowService.update} reports them inside a {@link FlowProcessingException}, which is
+     * mapped to an internal error. {@code parseFlowSource} sits outside the try on purpose — it raises a
+     * {@code ConstraintViolationException} directly, which is already a 422.
+     * <p>
+     * Bulk disable still aborts on the first failing flow, leaving the flows processed before it disabled: the
+     * response carries a count, not a per-flow outcome, so partial success cannot be reported as things stand.
      */
     private void setFlowDisabled(FlowWithSource flow, boolean disable) throws FlowProcessingException, QueueException {
         GenericFlow genericFlowUpdated = parseFlowSource(FlowService.injectDisabled(flow.getSource(), disable));

--- a/webserver/src/test/java/io/kestra/webserver/controllers/api/FlowControllerTest.java
+++ b/webserver/src/test/java/io/kestra/webserver/controllers/api/FlowControllerTest.java
@@ -1391,24 +1391,17 @@ class FlowControllerTest {
     }
 
     /**
-     * Disabling re-saves the flow, so a stored flow the current model no longer validates (one saved by an
-     * older version, whose trigger still carries the removed `conditions`, for instance) cannot be disabled.
-     * That must be reported as the validation failure it is, not as a 500.
+     * Disabling re-saves the flow, so a stored flow the current model no longer validates cannot be disabled —
+     * that must be reported as the validation failure it is, not as a 500. The flow here carries an unknown
+     * *task* property, which the lenient save path accepts and the strict re-validation rejects: the same
+     * shape as a 1.x flow whose trigger still carries the removed `conditions`, but reachable without going
+     * through the repository, since a trigger property is rejected on read too.
      */
     @Test
     void disableFlowsByIdsShouldReportViolationsWhenTheStoredFlowNoLongerValidates() {
-        String source = """
-            id: no-longer-valid
-            namespace: io.kestra.unittest.legacy
-            tasks:
-              - id: hello
-                type: io.kestra.plugin.core.log.Log
-                message: hello
-                removedInAFormerVersion: true
-            """;
-        jdbcFlowRepository.create(GenericFlow.fromYaml(MAIN_TENANT, source));
+        storeFlowThatNoLongerValidates("no-longer-valid-by-ids");
 
-        List<IdWithNamespace> ids = List.of(new IdWithNamespace("io.kestra.unittest.legacy", "no-longer-valid"));
+        List<IdWithNamespace> ids = List.of(new IdWithNamespace("io.kestra.unittest.legacy", "no-longer-valid-by-ids"));
 
         var exception = assertThrows(
             HttpClientResponseException.class,
@@ -1417,6 +1410,38 @@ class FlowControllerTest {
 
         assertThat(exception.getStatus().getCode()).isEqualTo(UNPROCESSABLE_ENTITY.getCode());
         assertThat(exception.getMessage()).contains("removedInAFormerVersion");
+    }
+
+    @Test
+    void disableFlowsByQueryShouldReportViolationsWhenTheStoredFlowNoLongerValidates() {
+        storeFlowThatNoLongerValidates("no-longer-valid-by-query");
+
+        var exception = assertThrows(
+            HttpClientResponseException.class,
+            () -> client.toBlocking().exchange(
+                POST(FLOW_PATH + "/disable/by-query?filters[namespace][PREFIX]=io.kestra.unittest.legacy", Map.of()),
+                BulkResponse.class
+            )
+        );
+
+        assertThat(exception.getStatus().getCode()).isEqualTo(UNPROCESSABLE_ENTITY.getCode());
+        assertThat(exception.getMessage()).contains("removedInAFormerVersion");
+    }
+
+    private void storeFlowThatNoLongerValidates(String id) {
+        jdbcFlowRepository.create(
+            GenericFlow.fromYaml(
+                MAIN_TENANT, """
+                    id: %s
+                    namespace: io.kestra.unittest.legacy
+                    tasks:
+                      - id: hello
+                        type: io.kestra.plugin.core.log.Log
+                        message: hello
+                        removedInAFormerVersion: true
+                    """.formatted(id)
+            )
+        );
     }
 
     @Test

--- a/webserver/src/test/java/io/kestra/webserver/controllers/api/FlowControllerTest.java
+++ b/webserver/src/test/java/io/kestra/webserver/controllers/api/FlowControllerTest.java
@@ -1390,6 +1390,35 @@ class FlowControllerTest {
         assertThat(taskFlow.isDisabled()).isFalse();
     }
 
+    /**
+     * Disabling re-saves the flow, so a stored flow the current model no longer validates (one saved by an
+     * older version, whose trigger still carries the removed `conditions`, for instance) cannot be disabled.
+     * That must be reported as the validation failure it is, not as a 500.
+     */
+    @Test
+    void disableFlowsByIdsShouldReportViolationsWhenTheStoredFlowNoLongerValidates() {
+        String source = """
+            id: no-longer-valid
+            namespace: io.kestra.unittest.legacy
+            tasks:
+              - id: hello
+                type: io.kestra.plugin.core.log.Log
+                message: hello
+                removedInAFormerVersion: true
+            """;
+        jdbcFlowRepository.create(GenericFlow.fromYaml(MAIN_TENANT, source));
+
+        List<IdWithNamespace> ids = List.of(new IdWithNamespace("io.kestra.unittest.legacy", "no-longer-valid"));
+
+        var exception = assertThrows(
+            HttpClientResponseException.class,
+            () -> client.toBlocking().exchange(POST(FLOW_PATH + "/disable/by-ids", ids), BulkResponse.class)
+        );
+
+        assertThat(exception.getStatus().getCode()).isEqualTo(UNPROCESSABLE_ENTITY.getCode());
+        assertThat(exception.getMessage()).contains("removedInAFormerVersion");
+    }
+
     @Test
     void disableEnableFlowsByQuery() throws InterruptedException {
         Flow flow = generateFlow("toDisable", "io.kestra.unittest.disabled", "a");
@@ -1821,7 +1850,8 @@ class FlowControllerTest {
         body = response.body();
 
         assertThat(body.size()).isEqualTo(1);
-        assertThat(body.get(0).getConstraints()).contains("Unrecognized field \"unknownProp\"");
+        // triggers reject unknown properties themselves, with a message naming the trigger
+        assertThat(body.get(0).getConstraints()).contains("Unrecognized property \"unknownProp\" on trigger");
 
         resource = TestsUtils.class.getClassLoader().getResource("triggers/invalidTriggerMissingProp.json");
         task = Files.readString(Path.of(Objects.requireNonNull(resource).getPath()), Charset.defaultCharset());


### PR DESCRIPTION
Fixes #19225

### What

- `AbstractTrigger` gets a `@JsonAnySetter` that rejects any undeclared property with an `UnknownPropertyException` (an `IllegalArgumentException`, so Jackson wraps it and every existing read path handles it). A stored 1.x flow whose trigger still has `conditions` / `preconditions` now loads as a `FlowWithException` — visible in the UI, never evaluated — exactly like a trigger whose *type* was removed. `FlowWithException.from` surfaces the framed message: `Flow 'ns/id': Unrecognized property "conditions" on trigger "on_foreach" (io.kestra.plugin.core.trigger.Flow): trigger conditions were replaced by "when" in 2.0 … see the migration guide`.
- `YamlParser` reports that message as-is (422 on validate / save instead of a generic "YAML parsing error").
- `FlowTriggerService`: explicit `FlowWithException` guards, plus a once-per-flow-revision WARN (capped at 1000 distinct triggers) when a Flow trigger has no `dependsOn` and `when == "true"`, i.e. would fire for every execution.
- `FlowController` `disable`/`enable` by ids and by query unwrap `FlowProcessingException` → `ConstraintViolationException`: 422 with the violations instead of a 500. Bulk semantics are unchanged (first failure aborts, earlier flows already toggled).

### What it fixes

After a 1.3 → 2.0 upgrade, triggers carrying the removed `conditions`/`preconditions` were deserialized with those properties silently dropped (non-strict mapper on the flow read paths), so a `core.trigger.Flow` matched every execution of the tenant — two such flows produced ~30 000 executions in 30 min in QA — and the flow could neither be edited nor disabled through the API.

### Scope / behaviour changes (please review)

- Strictness applies to triggers only (`AbstractTrigger`), not tasks; `GenericTrigger` keeps its catch-all.
- Because an any-setter is consulted before them, `@JsonIgnoreProperties(ignoreUnknown = true)` and `FAIL_ON_UNKNOWN_PROPERTIES` no longer apply to trigger properties (explicit-name `@JsonIgnoreProperties({"foo"})` still does). No core or first-party plugin trigger relies on either.
- A stored trigger property unknown to the installed plugin version — removed by a plugin upgrade, or authored against a newer plugin version — now fails closed (`FlowWithException`) instead of running without it.
- Adding `@Jacksonized` / a builder deserializer to a trigger would bypass the any-setter; documented in the javadoc.
- EE Elasticsearch repository already turns the wrapped exception into a `FlowWithException`; no EE change needed (verified against `kestra-ee@develop`).
- Follow-up (separate): a `2.0.x` migration script disabling/labelling already-stored flows with the removed syntax, so the upgrade is self-healing. Should be backported to `releases/v2.0.x`.

### Tests

New `AbstractTriggerUnknownPropertyTest` (plain unit test); new cases in `AbstractJdbcFlowRepositoryTest` (repository path → `FlowWithException`, exact message, jsonb-portable insert), `TriggerFlowParserTest` (scheduler path), `DefaultFlowMetaStoreTest` (runtime path), `YamlParserTest`-style YAML path, `FlowTriggerServiceTest`, `FlowControllerTest` (422 for by-ids and by-query). Ran the targeted classes on core, scheduler, executor, webserver, H2 and Postgres (Docker).