### PR TITLE
fix(scheduler): maintenance-mode stop race and unsynchronized vNode assignments

### DIFF
--- a/scheduler/src/main/java/io/kestra/scheduler/DefaultScheduler.java
+++ b/scheduler/src/main/java/io/kestra/scheduler/DefaultScheduler.java
@@ -2,7 +2,6 @@ package io.kestra.scheduler;
 
 import java.time.Clock;
 import java.time.Duration;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -12,6 +11,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import com.google.common.annotations.VisibleForTesting;
 
@@ -72,7 +72,9 @@ public class DefaultScheduler extends AbstractService implements Scheduler {
 
     private Disposable maintenanceListener;
 
-    private final Set<Integer> currentVNodesAssignment = new HashSet<>();
+    // Published as an immutable snapshot: written by the vNodes-assignment consumer and by the
+    // teardown, while the scheduler endpoint and the trigger monitor read it from their own threads.
+    private volatile Set<Integer> currentVNodesAssignment = Set.of();
 
     private Disposable rebalanceDisposable;
 
@@ -180,7 +182,8 @@ public class DefaultScheduler extends AbstractService implements Scheduler {
                 // (Re)initialize trigger state store for assigned VNodes
                 triggerStateStore.init(vNodes);
 
-                currentVNodesAssignment.addAll(vNodes);
+                currentVNodesAssignment = Stream.concat(currentVNodesAssignment.stream(), vNodes.stream())
+                    .collect(Collectors.toUnmodifiableSet());
 
                 // Create and assign the scheduling-loops even in maintenance mode, so that exiting
                 // maintenance only has to resubmit them.
@@ -226,18 +229,19 @@ public class DefaultScheduler extends AbstractService implements Scheduler {
      * those vNodes across them.
      */
     private void assignVNodesToSchedulingLoops() {
-        if (currentVNodesAssignment.isEmpty()) {
+        final Set<Integer> vNodes = currentVNodesAssignment;
+        if (vNodes.isEmpty()) {
             return; // nothing to assign
         }
 
-        final int numSchedulingLoop = Math.min(maxThreads, currentVNodesAssignment.size());
+        final int numSchedulingLoop = Math.min(maxThreads, vNodes.size());
         for (int i = schedulingLoops.size(); i < numSchedulingLoop; i++) {
             schedulingLoops.add(schedulerEventLoopFactory.create(i, clock));
         }
 
         schedulingLoops.forEach(schedulingLoop ->
         {
-            Set<Integer> assignments = currentVNodesAssignment.stream()
+            Set<Integer> assignments = vNodes.stream()
                 .filter(vNodeId -> vNodeId % schedulingLoops.size() == schedulingLoop.id())
                 .collect(Collectors.toSet());
             schedulingLoop.setAssignments(assignments);
@@ -305,7 +309,7 @@ public class DefaultScheduler extends AbstractService implements Scheduler {
         if (clearAssignment) {
             // Clear local assignments
             schedulingLoops.clear();
-            currentVNodesAssignment.clear();
+            currentVNodesAssignment = Set.of();
         }
     }
 

--- a/scheduler/src/main/java/io/kestra/scheduler/TriggerSchedulingLoop.java
+++ b/scheduler/src/main/java/io/kestra/scheduler/TriggerSchedulingLoop.java
@@ -14,6 +14,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.Condition;
 import java.util.concurrent.locks.ReentrantLock;
 
@@ -55,7 +56,7 @@ public class TriggerSchedulingLoop implements Runnable {
     private volatile Thread thread;
     private final AtomicBoolean initialized = new AtomicBoolean(false);
 
-    private final AtomicBoolean running = new AtomicBoolean(false);
+    private final AtomicReference<State> state = new AtomicReference<>(State.STARTING);
     private volatile CountDownLatch started = new CountDownLatch(1);
     private volatile CountDownLatch stopped = new CountDownLatch(1);
 
@@ -115,8 +116,15 @@ public class TriggerSchedulingLoop implements Runnable {
      **/
     @Override
     public void run() {
-        if (!this.running.compareAndSet(false, true)) {
+        State previous = state.getAndUpdate(current -> current == State.STARTING ? State.RUNNING : current);
+        if (State.RUNNING == previous) {
             throw new IllegalStateException("Already running");
+        }
+        if (State.STARTING != previous) {
+            // stop() already ran: release whoever waits on the latches, and never enter the loop.
+            started.countDown();
+            stopped.countDown();
+            return;
         }
 
         this.thread = Thread.currentThread();
@@ -128,13 +136,13 @@ public class TriggerSchedulingLoop implements Runnable {
         // duration says nothing about whether this loop can keep up.
         boolean coldEvaluation = true;
         try {
-            while (running.get()) {
+            while (isRunning()) {
                 long start = System.nanoTime();
                 try {
                     waitIfPaused();
 
                     // Check if the loop was stopped while being paused
-                    if (!running.get()) {
+                    if (!isRunning()) {
                         continue;
                     }
 
@@ -206,7 +214,7 @@ public class TriggerSchedulingLoop implements Runnable {
                 } catch (InterruptedException e) {
                     Thread.currentThread().interrupt();
                     LOG.warn("Interrupted while waiting in scheduling loop. Stopping.");
-                    running.set(false);
+                    state.compareAndSet(State.RUNNING, State.STOPPED);
                 } catch (Exception e) {
                     LOG.error("Error in scheduling loop", e);
                 } finally {
@@ -244,6 +252,7 @@ public class TriggerSchedulingLoop implements Runnable {
     public void prepareForStart() {
         this.started = new CountDownLatch(1);
         this.stopped = new CountDownLatch(1);
+        this.state.set(State.STARTING);
     }
 
     /**
@@ -267,22 +276,34 @@ public class TriggerSchedulingLoop implements Runnable {
      * This method blocks until the current processing loop is completed.
      */
     public void stop() {
-        if (!running.compareAndSet(true, false)) {
+        State previous = state.getAndSet(State.STOPPED);
+
+        if (State.STARTING == previous) {
+            // No thread to interrupt yet: the pending run() will see STOPPED and decline to start.
+            started.countDown();
+            stopped.countDown();
+            return;
+        }
+
+        if (State.RUNNING != previous) {
             LOG.debug("[{}] stop() called but not running", getClass().getSimpleName());
             return;
         }
 
         resume(); // In case it's paused and blocked
 
-        if (this.thread != null) {
-            this.thread.interrupt();
-            try {
-                if (!stopped.await(5, TimeUnit.SECONDS)) {
-                    LOG.warn("Timeout while waiting for {} to complete", this.thread.getName());
-                }
-            } catch (InterruptedException e) {
-                Thread.currentThread().interrupt();
+        Thread runner = this.thread;
+        if (runner != null) {
+            runner.interrupt();
+        }
+
+        // Awaited even with no thread to interrupt: the loop exits on the state change, not the interrupt.
+        try {
+            if (!stopped.await(5, TimeUnit.SECONDS)) {
+                LOG.warn("Timeout while waiting for scheduling loop {} to complete", schedulingLoopId);
             }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
         }
     }
 
@@ -292,7 +313,7 @@ public class TriggerSchedulingLoop implements Runnable {
         }
         pauseLock.lock();
         try {
-            while (paused.get() && running.get()) {
+            while (paused.get() && isRunning()) {
                 LOG.info("Paused. Waiting for scheduling loop to resume");
                 unpaused.await(); // Wait until resume() signals
                 LOG.info("Resumed");
@@ -431,7 +452,13 @@ public class TriggerSchedulingLoop implements Runnable {
      * @return {@code true} if running.
      */
     public boolean isRunning() {
-        return this.running.get();
+        return State.RUNNING == state.get();
+    }
+
+    private enum State {
+        STARTING,
+        RUNNING,
+        STOPPED
     }
 
     /**

--- a/scheduler/src/main/java/io/kestra/scheduler/TriggerSchedulingLoop.java
+++ b/scheduler/src/main/java/io/kestra/scheduler/TriggerSchedulingLoop.java
@@ -4,7 +4,6 @@ import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
@@ -67,7 +66,7 @@ public class TriggerSchedulingLoop implements Runnable {
 
     private final BlockingQueue<Runnable> internalLoopCallables = new LinkedBlockingQueue<>();
 
-    private final Set<Integer> assignments = new HashSet<>();
+    private volatile Set<Integer> assignments = Set.of();
 
     // Metrics
     private final Timer metricEventLoopTickTimer;
@@ -333,10 +332,7 @@ public class TriggerSchedulingLoop implements Runnable {
     }
 
     public void setAssignments(final Set<Integer> assignments) {
-        this.assignments.clear();
-        if (assignments != null) {
-            this.assignments.addAll(assignments);
-        }
+        this.assignments = assignments == null ? Set.of() : Set.copyOf(assignments);
         this.initialized.set(false);
     }
 

--- a/scheduler/src/test/java/io/kestra/scheduler/DefaultSchedulerTest.java
+++ b/scheduler/src/test/java/io/kestra/scheduler/DefaultSchedulerTest.java
@@ -66,6 +66,12 @@ class DefaultSchedulerTest {
 
     private static final SchedulerConfiguration SCHEDULER_CONFIGURATION = new SchedulerConfiguration(16, Duration.ofSeconds(5), 100);
 
+    // The injected publisher would run ServiceLivenessManager on this thread, where its state write
+    // contends with the heartbeat for the whole 30s H2 lock timeout; no assertion reads those events.
+    private static final ApplicationEventPublisher<ServiceStateChangeEvent> NOOP_EVENT_PUBLISHER = event ->
+    {
+    };
+
     @Inject
     MetricRegistry metricRegistry;
 
@@ -86,9 +92,6 @@ class DefaultSchedulerTest {
 
     @Inject
     ExecutorsUtils executorsUtils;
-
-    @Inject
-    ApplicationEventPublisher<ServiceStateChangeEvent> eventPublisher;
 
     @Inject
     private LockService lockService;
@@ -258,18 +261,23 @@ class DefaultSchedulerTest {
             // WHEN
             maintenanceService.setMaintenanceMode(true);
             org.awaitility.Awaitility.await().atMost(Duration.ofSeconds(5)).untilAsserted(() ->
-                assertThat(scheduler.schedulingLoops()).allMatch(Predicate.not(TriggerSchedulingLoop::isRunning))
-            );
+            {
+                assertThat(scheduler.schedulingLoops()).hasSize(2);
+                assertThat(scheduler.schedulingLoops()).allMatch(Predicate.not(TriggerSchedulingLoop::isRunning));
+            });
             maintenanceService.setMaintenanceMode(false);
             org.awaitility.Awaitility.await().atMost(Duration.ofSeconds(5)).untilAsserted(() ->
-                assertThat(scheduler.schedulingLoops()).allMatch(TriggerSchedulingLoop::isRunning)
-            );
+            {
+                assertThat(scheduler.schedulingLoops()).hasSize(2);
+                assertThat(scheduler.schedulingLoops()).allMatch(TriggerSchedulingLoop::isRunning);
+            });
 
             // THEN
             Set<Integer> loopAssignments = scheduler.schedulingLoops()
                 .stream()
                 .flatMap(loop -> loop.assignments().stream())
                 .collect(Collectors.toSet());
+            assertThat(loopAssignments).isNotEmpty();
             assertThat(loopAssignments).isEqualTo(scheduler.currentVNodesAssignment());
         }
     }
@@ -323,7 +331,7 @@ class DefaultSchedulerTest {
             triggerSchedulingLoopFactory,
             vNodesAssigner,
             executorsUtils,
-            eventPublisher,
+            NOOP_EVENT_PUBLISHER,
             triggerEventQueue,
             triggerStateStore,
             metricRegistry,

--- a/scheduler/src/test/java/io/kestra/scheduler/TriggerSchedulingLoopTest.java
+++ b/scheduler/src/test/java/io/kestra/scheduler/TriggerSchedulingLoopTest.java
@@ -231,6 +231,21 @@ class TriggerSchedulingLoopTest {
     }
 
     @Test
+    void shouldKeepAlreadyReturnedAssignmentsUnchangedWhenReassigned() {
+        // GIVEN
+        TriggerSchedulingLoop loop = createLoop();
+        loop.setAssignments(Set.of(1, 2));
+        Set<Integer> snapshot = loop.assignments();
+
+        // WHEN
+        loop.setAssignments(Set.of(3));
+
+        // THEN
+        assertThat(snapshot).containsExactlyInAnyOrder(1, 2);
+        assertThat(loop.assignments()).containsExactly(3);
+    }
+
+    @Test
     void shouldNotStartSchedulingWhenStoppedBeforeTheSubmissionRuns() throws InterruptedException {
         // GIVEN
         TriggerSchedulingLoop loop = createLoop();

--- a/scheduler/src/test/java/io/kestra/scheduler/TriggerSchedulingLoopTest.java
+++ b/scheduler/src/test/java/io/kestra/scheduler/TriggerSchedulingLoopTest.java
@@ -37,6 +37,7 @@ import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 class TriggerSchedulingLoopTest {
@@ -227,6 +228,24 @@ class TriggerSchedulingLoopTest {
 
         // THEN
         assertThat(thread.isAlive()).isFalse();
+    }
+
+    @Test
+    void shouldNotStartSchedulingWhenStoppedBeforeTheSubmissionRuns() throws InterruptedException {
+        // GIVEN
+        TriggerSchedulingLoop loop = createLoop();
+        loop.setAssignments(Set.of(1));
+
+        // WHEN
+        loop.stop();
+        Thread thread = new Thread(loop);
+        thread.start();
+        thread.join(2000);
+
+        // THEN
+        assertThat(loop.isRunning()).isFalse();
+        assertThat(thread.isAlive()).isFalse();
+        verifyNoInteractions(triggerScheduler);
     }
 
     @Test


### PR DESCRIPTION
### 🔗 Related Issue

None — found while investigating why `DefaultSchedulerTest` is flaky.

### ✨ Description

Three fixes in the scheduler, all found while tracing that flakiness.

**The test was timing out, not failing.** `DefaultSchedulerTest` passed the injected `ApplicationEventPublisher` to its hand-built `DefaultScheduler`, so every `setState()` ran `ServiceLivenessManager` on the test thread — a `SERVICE_INSTANCE` write that contends with the 3s heartbeat for H2's full 30s `LOCK_TIMEOUT`. Across 12 runs of the class, `shouldRestoreVNodesAssignmentsOnSchedulingLoopsWhenExitingMaintenanceMode` took 1.12s eight times, 31s once and 120s twice; the stalls landed on whichever method happened to be running, and 120s is 40% of the 5m per-test JUnit timeout on an idle machine. The scheduler now gets a no-op publisher: the test drives assignment through its own `InMemoryServiceLivenessStore`, no assertion reads those events, and `setState()` updates its `AtomicReference` before publishing, so `getState()` is unaffected. The maintenance assertions also passed on empty collections (`allMatch` is vacuously true, `{}` equals `{}`), so a run where the vNodes rebalance was skipped tested nothing; they now assert the loop count and a non-empty assignment set.

**A stop could be lost.** `startScheduling()` only warns when `awaitStarted(5s)` elapses, and `stop()` returned at its first branch whenever `running` was still false. That window is reachable because the two callbacks driving it run on unrelated threads: vNode assignment arrives on the `SchedulerEvent` broadcast-queue poller, maintenance enter/exit on the `ClusterEvent` one, and `QueueService` gives every subscriber its own thread. So `onVNodesAssigned` can sit between `execute()` and `run()` while `onMaintenanceModeEnter` calls `stop()` — the loop was "stopped" as a no-op, then started right afterwards and kept evaluating triggers for a service already in maintenance mode or terminated. The `running` boolean is replaced by an explicit `STARTING/RUNNING/STOPPED` state owned by a single submission, and `stop()` now waits for the loop to actually leave its cycle instead of returning as soon as it has no thread to interrupt.

**The vNode sets were shared across threads without synchronization.** `currentVNodesAssignment` is mutated by the vNodes-assignment consumer and cleared by the teardown, while `SchedulerEndpoint` (an HTTP thread) and `TriggerSchedulerMonitor` (a `@Scheduled` thread) read it; both hand it straight to `findTriggersEligibleForScheduling`, where jOOQ walks it to build the `IN (…)` bind list — so a rebalance landing mid-query could throw, or silently produce the wrong vNode list. `TriggerSchedulingLoop.assignments` had the same shape, handed out live by `assignments()` and mutated in place by `setAssignments()`. Both are now replaced rather than mutated, and published through a `volatile` field.

### 🛠️ Backend Checklist

- [x] Code compiles and tests pass for the touched modules (`./gradlew :module-name:test`, or `./gradlew build` for cross-module changes)
- [x] New behavior is covered by unit or integration tests

`:scheduler:test` 132/132 and `:jdbc-h2:test --tests H2RunnerTest` 101/101. Both new tests fail on the commit before this branch: `shouldNotStartSchedulingWhenStoppedBeforeTheSubmissionRuns` because the loop started after `stop()`, and `shouldKeepAlreadyReturnedAssignmentsUnchangedWhenReassigned` because `assignments()` returned the live set. After the test fix, class runtime over 8 fresh JVMs is 12.1s–13.3s against 22.8s–171.4s before.

### 📝 Additional Notes

- The synchronous `setState()` publish is not a production defect: the 30s stalls come from `@MicronautTest` wrapping each test method in a transaction, so the test thread's writes hold locks for the whole method. In production `DefaultServiceLivenessUpdater` does a short `findById` + `save`.
- Maintenance mode is EE-only (OSS ships `NoopMaintenanceService`), so the lost stop only bites on EE. `DefaultSchedulerTest` invokes its maintenance listener synchronously on the test thread and therefore cannot reproduce the cross-thread interleaving, which is why the new coverage targets the loop state machine directly instead.
- Left open on purpose: `onVNodesAssigned` reads `isInMaintenanceMode()` and submits the loops a few lines later, so the reverse interleaving can still start loops during maintenance. Closing that needs a lock shared by the two listeners, which is a larger change than this PR's scope.
- `:scheduler:spotlessCheck` already fails on `develop` for six files in this module. `DefaultSchedulerTest` is one of them and this PR touches it: what this PR adds there is formatted correctly, and the two violations left in the file (the import order, and the try-with-resources at line 285) are pre-existing and untouched.
- Not fixed here, worth a follow-up: with 3 schedulers and 16 vNodes, `VNodeConsistentHashRing` assigned 6, 10 and 0 in one observed run — one scheduler sat idle until the next rebalance.
