### PR TITLE
refactor(triggers): type the two trigger tables against the SDK models

### DIFF
--- a/ui/src/components/admin/triggers/TriggersManage.vue
+++ b/ui/src/components/admin/triggers/TriggersManage.vue
@@ -12,7 +12,7 @@
             :selectable="canCheck"
             :selectionMapper="selectionMapper"
             :rowClassName="getClasses"
-            :rowKey="(row: any) => `${row.namespace}-${row.flowId}-${row.triggerId}`"
+            :rowKey="(row: TriggerRow) => `${row.namespace}-${row.flowId}-${row.triggerId}`"
             :forceExpandedRowKeys="expandedRowKeys"
             :no-data-text="$t('no_results.triggers')"
             @page-changed="({page, size}: {page: number; size: number}) => router.push({query: {...route.query, page: String(page), size: String(size)}})"
@@ -344,6 +344,16 @@
     import {ref, computed, watch, useTemplateRef} from "vue"
     import {useI18n} from "vue-i18n"
     import {asProblem} from "@kestra-io/kestra-sdk"
+    import type {
+        AbstractTrigger,
+        ApiAsyncOperationResponse,
+        ApiTriggerAndState,
+        ApiTriggerState,
+        Label,
+        QueryFilter,
+        TriggerControllerApiCreateBackfillRequest,
+        TriggerControllerApiTriggerId,
+    } from "@kestra-io/kestra-sdk"
     import {problemBulkBody, problemTitle} from "../../../utils/problem"
     import {useRoute, useRouter} from "vue-router"
     import {KsMessage, KsDrawer, KsMarkdown, KsTag, KsDropdown, KsDropdownMenu, KsDropdownItem} from "@kestra-io/design-system"
@@ -371,7 +381,7 @@
     import Restart from "vue-material-design-icons/Restart.vue"
     import TextSearch from "vue-material-design-icons/TextSearch.vue"
 
-    import FlowRun, {SelectedTrigger} from "../../flows/FlowRun.vue"
+    import FlowRun from "../../flows/FlowRun.vue"
     import LogsWrapper from "../../logs/LogsWrapper.vue"
     import BackfillBanner from "../../flows/BackfillBanner.vue"
     import Vars from "../../executions/Vars.vue"
@@ -391,14 +401,34 @@
 
     const {loadInit} = useRestoreUrl()
 
-    const dataTable = useTemplateRef<any>("dataTable")
+    // A row is the trigger definition merged over its runtime state; `inputs` and `logs` come from
+    // trigger plugin subclasses, which AbstractTrigger does not model.
+    type TriggerRow = Partial<AbstractTrigger> & ApiTriggerState & {
+        codeDisabled?: boolean;
+        missingSource: boolean;
+        inputs?: Record<string, unknown>;
+        logs?: unknown[];
+    }
+
+    /** The part of the KsDataTable instance this table drives. */
+    interface TriggersDataTable {
+        selection: TriggerControllerApiTriggerId[];
+        queryBulkAction: boolean;
+        reload: () => void;
+        resetAndReload: () => void;
+        setSelection: (selection: TriggerControllerApiTriggerId[]) => void;
+        toggleAllUnselected: () => void;
+        waitTableRender: () => Promise<void>;
+    }
+
+    const dataTable = useTemplateRef<TriggersDataTable>("dataTable")
 
     const total = ref(0)
-    const triggers = ref<any[]>([])
+    const triggers = ref<ApiTriggerAndState[]>([])
     const isBackfillOpen = ref(false)
     const isDetailsOpen = ref(false)
     const detailsTriggerId = ref<string | undefined>()
-    const selectedTrigger = ref<SelectedTrigger | undefined>()
+    const selectedTrigger = ref<TriggerRow | undefined>()
 
     // evaluatedAt/updatedAt are TriggerState JSON fields with no backing column on the triggers table, so they're excluded here.
     const SORTABLE_COLUMNS: readonly string[] = ["flowId", "namespace", "lastTriggeredDate", "nextEvaluationDate"]
@@ -411,8 +441,8 @@
     const backfill = ref<{
         start: Date | null;
         end: Date | null;
-        inputs: any;
-        labels: any[];
+        inputs: Record<string, unknown> | null;
+        labels: Label[];
     }>({
         start: null,
         end: null,
@@ -427,7 +457,7 @@
         backfill.value.start ||
         backfill.value.end ||
         Object.keys(backfillInputsNoDefault.value).length > 0 ||
-        backfill.value.labels?.some((label: any) => label.key || label.value)
+        backfill.value.labels.some(label => label.key || label.value)
     ))
 
     const optionalColumns = computed<ColumnConfig[]>(() => [
@@ -501,51 +531,51 @@
 
     const canCheck = computed(() => authStore.user?.hasAny(resource.TRIGGER) ?? false)
 
-    const selectionMapper = (row: any) => ({
+    const selectionMapper = (row: TriggerRow): TriggerControllerApiTriggerId => ({
         namespace: row.namespace,
         flowId: row.flowId,
         triggerId: row.triggerId ?? row.id,
     })
 
-    const isSchedule = (type: string) => type === "io.kestra.plugin.core.trigger.Schedule"
+    const isSchedule = (type?: string) => type === "io.kestra.plugin.core.trigger.Schedule"
 
-    const triggersMerged = computed(() => {
-        return triggers.value?.map((tr: any) => ({
-            ...tr?.trigger,
-            ...tr?.state,
-            codeDisabled: tr?.trigger?.disabled,
-            missingSource: !tr?.trigger,
-        })) ?? []
-    })
+    const triggersMerged = computed<TriggerRow[]>(() =>
+        triggers.value.map(tr => ({
+            ...tr.trigger,
+            ...tr.state,
+            codeDisabled: tr.trigger?.disabled,
+            missingSource: !tr.trigger,
+        })),
+    )
 
     const expandedRowKeys = computed<string[]>(() =>
         triggersMerged.value
-            .filter((row: any) => !!row.backfill)
-            .map((row: any) => `${row.namespace}-${row.flowId}-${row.triggerId}`),
+            .filter(row => !!row.backfill)
+            .map(row => `${row.namespace}-${row.flowId}-${row.triggerId}`),
     )
 
     const detailsTrigger = computed(() =>
-        triggersMerged.value.find((row: any) => row.triggerId === detailsTriggerId.value),
+        triggersMerged.value.find(row => row.triggerId === detailsTriggerId.value),
     )
 
-    const detailsData = computed(() => {
+    const detailsData = computed<Record<string, unknown>>(() => {
         const trigger = detailsTrigger.value
         if (!trigger) return {}
         return Object
             .entries(trigger)
             .filter(([key]) => !["tenantId", "namespace", "flowId", "flowRevision", "triggerId", "description"].includes(key))
-            .reduce((map, [key, value]) => {
+            .reduce<Record<string, unknown>>((map, [key, value]) => {
                 map[key] = value
                 return map
-            }, {} as any)
+            }, {})
     })
 
-    const selection = computed<any[]>(() => dataTable.value?.selection ?? [])
+    const selection = computed<TriggerControllerApiTriggerId[]>(() => dataTable.value?.selection ?? [])
     const queryBulkAction = computed<boolean>(() => dataTable.value?.queryBulkAction ?? false)
     const toggleAllUnselected = () => dataTable.value?.toggleAllUnselected()
 
-    const loadQuery = (base: any) => {
-        const {page: _p, size: _s, sort: _so, ...restQuery} = route.query as Record<string, any>
+    const loadQuery = <T extends object>(base: T): T => {
+        const {page: _p, size: _s, sort: _so, ...restQuery} = route.query
         const nonFilterRest = Object.fromEntries(
             Object.entries(restQuery).filter(([key]) => !key.startsWith("filters[")),
         )
@@ -587,7 +617,7 @@
 
     const refresh = () => dataTable.value?.reload()
 
-    const setBackfillModal = (trigger: any, bool: boolean) => {
+    const setBackfillModal = (trigger: TriggerRow | null, bool: boolean) => {
         if (!trigger) {
             isBackfillOpen.value = false
             selectedTrigger.value = undefined
@@ -606,38 +636,41 @@
         })
     }
 
-    const cleanBackfill = computed(() => {
-        const labels = backfill.value.labels?.filter((label: any) => label.key && label.value)
-        return {...backfill.value, labels: labels?.length ? labels : null}
+    type BackfillRequest = TriggerControllerApiCreateBackfillRequest["backfill"]
+
+    const cleanBackfill = computed<BackfillRequest>(() => {
+        const labels = backfill.value.labels.filter(label => label.key && label.value)
+        return {
+            start: backfill.value.start?.toISOString(),
+            end: backfill.value.end?.toISOString(),
+            // the spec models the endpoint's Map<String, Object> inputs as a map of maps
+            inputs: (backfill.value.inputs ?? undefined) as BackfillRequest["inputs"],
+            labels: labels.length ? labels : undefined,
+        }
     })
 
     const postBackfill = () => {
-        const trigger = selectedTrigger.value as any
+        const trigger = selectedTrigger.value
+        if (!trigger) return
+
         TriggersAPI.createBackfill({
             namespace: trigger.namespace,
             flowId: trigger.flowId,
             triggerId: trigger.triggerId,
-            backfill: cleanBackfill.value as any,
+            backfill: cleanBackfill.value,
         })
             .then(() => {
-                toast.saved(trigger?.triggerId)
+                toast.saved(trigger.triggerId)
                 setBackfillModal(null, false)
-                backfill.value = {
-                    start: null,
-                    end: null,
-                    inputs: null,
-                    labels: [],
-                }
+                backfill.value = {start: null, end: null, inputs: null, labels: []}
                 triggerLoadDataAfterBulkEditAction()
             })
     }
 
-    const hasLogsContent = (row: any) => row.logs && row.logs.length > 0
+    const hasLogsContent = (row: TriggerRow) => !!row.logs?.length
 
-    const getClasses = (arg: any) => {
-        const row = arg?.row ?? arg
-        return hasLogsContent(row) || row?.backfill ? "expandable" : "no-expand"
-    }
+    const getClasses = ({row}: {row: TriggerRow}) =>
+        hasLogsContent(row) || row.backfill ? "expandable" : "no-expand"
 
     const disabledStartDate = (time: Date): boolean => {
         return new Date() < time || (backfill.value.end !== null && time > backfill.value.end)
@@ -654,7 +687,7 @@
         setTimeout(() => dataTable.value?.reload(), 5000)
     }
 
-    const unlock = (row: any) => {
+    const unlock = (row: TriggerRow) => {
         TriggersAPI.unlockTrigger({
             namespace: row.namespace,
             flowId: row.flowId,
@@ -668,7 +701,7 @@
         })
     }
 
-    const restart = (row: any) => {
+    const restart = (row: TriggerRow) => {
         TriggersAPI.restartTrigger({
             namespace: row.namespace,
             flowId: row.flowId,
@@ -679,12 +712,12 @@
         })
     }
 
-    const openDetails = (row: any) => {
+    const openDetails = (row: TriggerRow) => {
         detailsTriggerId.value = row.triggerId
         isDetailsOpen.value = true
     }
 
-    const pauseBackfill = (row: any) => {
+    const pauseBackfill = (row: TriggerRow) => {
         TriggersAPI.pauseBackfill({
             namespace: row.namespace,
             flowId: row.flowId,
@@ -695,7 +728,7 @@
         })
     }
 
-    const unpauseBackfill = (row: any) => {
+    const unpauseBackfill = (row: TriggerRow) => {
         TriggersAPI.unpauseBackfill({
             namespace: row.namespace,
             flowId: row.flowId,
@@ -706,7 +739,7 @@
         })
     }
 
-    const deleteBackfill = (row: any) => {
+    const deleteBackfill = (row: TriggerRow) => {
         TriggersAPI.deleteBackfill({
             namespace: row.namespace,
             flowId: row.flowId,
@@ -719,11 +752,11 @@
 
     const isEnableDialogOpen = ref(false)
     // The schedule trigger being enabled; null when enabling in bulk.
-    const enableDialogTrigger = ref<any>(null)
+    const enableDialogTrigger = ref<TriggerRow | null>(null)
 
-    const isScheduleTrigger = (row: any) => row?.kind === "SCHEDULE" || row?.type === "io.kestra.plugin.core.trigger.Schedule"
+    const isScheduleTrigger = (row?: TriggerRow) => row?.kind === "SCHEDULE" || isSchedule(row?.type)
 
-    const setDisabled = (trigger: any, value: boolean) => {
+    const setDisabled = (trigger: TriggerRow, value: boolean) => {
         if (trigger.codeDisabled) {
             KsMessage({
                 message: t("triggerflow disabled"),
@@ -741,23 +774,27 @@
         doSetDisabled(trigger, !value)
     }
 
-    const doSetDisabled = (trigger: any, disabled: boolean, recoverMissedSchedules?: boolean) => {
-        const isTargetRow = (tr: any) => {
-            const {namespace, flowId, triggerId} = tr.state ?? tr.trigger ?? {}
-            return namespace === trigger.namespace
-                && flowId === trigger.flowId
-                && triggerId === trigger.triggerId
-        }
+    const doSetDisabled = (trigger: TriggerRow, disabled: boolean, recoverMissedSchedules?: boolean) => {
+        const isTargetRow = (tr: ApiTriggerAndState) => tr.state?.namespace === trigger.namespace
+            && tr.state?.flowId === trigger.flowId
+            && tr.state?.triggerId === trigger.triggerId
+
         // Flip the row before the API call so the knob animates on click instead of after the roundtrip.
-        const previousRow = triggers.value?.find(isTargetRow)
-        triggers.value = triggers.value?.map((tr: any) => isTargetRow(tr) ? {...tr, state: {...tr.state, disabled}} : tr)
-        TriggersAPI.disableTriggerById({...trigger, disabled, recoverMissedSchedules})
-            .then((updatedTrigger: any) => {
+        const previousRow = triggers.value.find(isTargetRow)
+        triggers.value = triggers.value.map(tr => isTargetRow(tr) ? {...tr, state: {...tr.state, disabled}} : tr)
+        TriggersAPI.disableTriggerById({
+            namespace: trigger.namespace,
+            flowId: trigger.flowId,
+            triggerId: trigger.triggerId,
+            disabled,
+            recoverMissedSchedules,
+        })
+            .then(updatedTrigger => {
                 toast.saved(updatedTrigger.triggerId)
-                triggers.value = triggers.value?.map((tr: any) => isTargetRow(tr) ? {...tr, state: updatedTrigger} : tr)
+                triggers.value = triggers.value.map(tr => isTargetRow(tr) ? {...tr, state: updatedTrigger} : tr)
             })
             .catch(() => {
-                triggers.value = triggers.value?.map((tr: any) => isTargetRow(tr) ? previousRow : tr)
+                triggers.value = triggers.value.map(tr => isTargetRow(tr) ? previousRow ?? tr : tr)
             })
     }
 
@@ -766,8 +803,7 @@
             doSetDisabled(enableDialogTrigger.value, false, recoverMissedSchedules)
         } else {
             genericConfirmCallback(
-                "setDisabledByQuery",
-                "setDisabledByTriggers",
+                "setDisabled",
                 "bulk success disabled status.false",
                 {disabled: false, recoverMissedSchedules},
             )
@@ -795,15 +831,14 @@
     const deleteTriggers = () => {
         genericConfirmAction(
             "bulk delete triggers",
-            "deleteByQuery",
-            "deleteByTriggers",
+            "delete",
             "bulk success delete triggers",
-            null,
+            undefined,
             "WARNING: deleting triggers may lead to duplicate executions if the triggers are still active in flows",
         )
     }
 
-    const genericConfirmAction = (toastKey: string, queryAction: string, byIdAction: string, success: string, data?: any, extraWarning?: string) => {
+    const genericConfirmAction = (toastKey: string, actionName: BulkActionName, success: string, data?: BulkDisableData, extraWarning?: string) => {
         let message = t(toastKey, {"count": queryBulkAction.value ? total.value : selection.value?.length}) + ". " + t("bulk action async warning")
 
         if (extraWarning) {
@@ -812,120 +847,143 @@
 
         toast.confirm(
             message,
-            () => genericConfirmCallback(queryAction, byIdAction, success, data),
+            () => genericConfirmCallback(actionName, success, data),
         )
     }
 
-    const genericConfirmCallback = (queryAction: string, byIdAction: string, success: string, data?: any) => {
-        const actionMap: Record<string, () => any> = {
-            "unpauseBackfillByQuery": () => (options: any) => TriggersAPI.unpauseBackfillByQuery(options),
-            "unpauseBackfillByTriggers": () => (triggers: any) => TriggersAPI.unpauseBackfillByIds({body: triggers}),
-            "pauseBackfillByQuery": () => (options: any) => TriggersAPI.pauseBackfillByQuery(options),
-            "pauseBackfillByTriggers": () => (triggers: any) => TriggersAPI.pauseBackfillByIds({body: triggers}),
-            "deleteBackfillByQuery": () => (options: any) => TriggersAPI.deleteBackfillByQuery(options),
-            "deleteBackfillByTriggers": () => (triggers: any) => TriggersAPI.deleteBackfillByIds({body: triggers}),
-            "unlockByQuery": () => (options: any) => TriggersAPI.unlockTriggersByQuery(options),
-            "unlockByTriggers": () => (triggers: any) => TriggersAPI.unlockTriggersByIds({body: triggers}),
-            "setDisabledByQuery": () => (options: any) => TriggersAPI.disabledTriggersByQuery(options),
-            "setDisabledByTriggers": () => (options: any) => TriggersAPI.disabledTriggersByIds(options),
-            "deleteByQuery": () => (options: any) => TriggersAPI.deleteTriggersByQuery(options),
-            "deleteByTriggers": () => (triggers: any) => TriggersAPI.deleteTriggersByIds({body: triggers}),
+    type BulkQueryOptions = {
+        filters?: QueryFilter[];
+        disabled?: boolean;
+        recoverMissedSchedules?: boolean;
+    }
+
+    type BulkDisableData = {disabled: boolean; recoverMissedSchedules?: boolean}
+
+    /** Query mode targets every trigger matching the filters, selection mode only the checked rows. */
+    interface BulkAction {
+        byQuery: (options: BulkQueryOptions) => Promise<ApiAsyncOperationResponse>;
+        byIds: (triggers: TriggerControllerApiTriggerId[], data?: BulkDisableData) => Promise<ApiAsyncOperationResponse>;
+    }
+
+    const BULK_ACTIONS = {
+        unpauseBackfill: {
+            byQuery: options => TriggersAPI.unpauseBackfillByQuery(options),
+            byIds: triggers => TriggersAPI.unpauseBackfillByIds({body: triggers}),
+        },
+        pauseBackfill: {
+            byQuery: options => TriggersAPI.pauseBackfillByQuery(options),
+            byIds: triggers => TriggersAPI.pauseBackfillByIds({body: triggers}),
+        },
+        deleteBackfill: {
+            byQuery: options => TriggersAPI.deleteBackfillByQuery(options),
+            byIds: triggers => TriggersAPI.deleteBackfillByIds({body: triggers}),
+        },
+        unlock: {
+            byQuery: options => TriggersAPI.unlockTriggersByQuery(options),
+            byIds: triggers => TriggersAPI.unlockTriggersByIds({body: triggers}),
+        },
+        setDisabled: {
+            byQuery: options => TriggersAPI.disabledTriggersByQuery(options),
+            byIds: (triggers, data) => TriggersAPI.disabledTriggersByIds({
+                triggers,
+                disabled: data?.disabled ?? false,
+                recoverMissedSchedules: data?.recoverMissedSchedules,
+            }),
+        },
+        delete: {
+            byQuery: options => TriggersAPI.deleteTriggersByQuery(options),
+            byIds: triggers => TriggersAPI.deleteTriggersByIds({body: triggers}),
+        },
+    } satisfies Record<string, BulkAction>
+
+    type BulkActionName = keyof typeof BULK_ACTIONS
+
+    const genericConfirmCallback = (actionName: BulkActionName, success: string, data?: BulkDisableData) => {
+        const action = BULK_ACTIONS[actionName]
+        const onSubmitted = (response: ApiAsyncOperationResponse) => {
+            toast.success(t(success, {count: response.totalItems}))
+            toggleAllUnselected()
+            triggerLoadDataAfterBulkEditAction()
         }
 
         if (queryBulkAction.value) {
             const query = loadQuery({filters: routeQueryToQueryFilters(route.query)})
-            const options = {...query, ...data}
-            const actions = actionMap[queryAction]()
-            return actions(options)
-                .then((d: any) => {
-                    toast.success(t(success, {count: d?.count}))
-                    toggleAllUnselected()
-                    triggerLoadDataAfterBulkEditAction()
-                })
-        } else {
-            const selectionData = selection.value
-            const options = {triggers: selectionData, ...data}
-            const actions = actionMap[byIdAction]()
-            return actions(byIdAction.includes("setDisabled") ? options : selectionData)
-                .then((d: any) => {
-                    toast.success(t(success, {count: d?.count}))
-                    toggleAllUnselected()
-                    triggerLoadDataAfterBulkEditAction()
-                }).catch((e: unknown) => {
-                    const problem = asProblem(e)
-                    toast.error(
-                        problemBulkBody(problem, t, te),
-                        problemTitle(problem, t, te),
-                    )
-                })
+            return action.byQuery({...query, ...data}).then(onSubmitted)
         }
+
+        return action.byIds(selection.value, data)
+            .then(onSubmitted)
+            .catch((e: unknown) => {
+                const problem = asProblem(e)
+                toast.error(
+                    problemBulkBody(problem, t, te),
+                    problemTitle(problem, t, te),
+                )
+            })
     }
 
     const unpauseBackfills = () => {
-        genericConfirmAction("bulk unpause backfills", "unpauseBackfillByQuery", "unpauseBackfillByTriggers", "bulk success unpause backfills")
+        genericConfirmAction("bulk unpause backfills", "unpauseBackfill", "bulk success unpause backfills")
     }
 
     const pauseBackfills = () => {
-        genericConfirmAction("bulk pause backfills", "pauseBackfillByQuery", "pauseBackfillByTriggers", "bulk success pause backfills")
+        genericConfirmAction("bulk pause backfills", "pauseBackfill", "bulk success pause backfills")
     }
 
     const deleteBackfills = () => {
-        genericConfirmAction("bulk delete backfills", "deleteBackfillByQuery", "deleteBackfillByTriggers", "bulk success delete backfills")
+        genericConfirmAction("bulk delete backfills", "deleteBackfill", "bulk success delete backfills")
     }
 
     const unlockTriggers = () => {
-        genericConfirmAction("bulk unlock", "unlockByQuery", "unlockByTriggers", "bulk success unlock")
+        genericConfirmAction("bulk unlock", "unlock", "bulk success unlock")
     }
 
     const setDisabledTriggers = (bool: boolean) => {
         // Enabling may recover missed schedules: the dialog carries both the confirmation and the
         // recovery choice. In query mode trigger types are unknowable so it is always shown; in
         // selection mode only when the selection contains a schedule trigger.
-        if (!bool && (queryBulkAction.value || selection.value?.some((sel: any) => isScheduleTrigger(findRowBySelection(sel))))) {
+        if (!bool && (queryBulkAction.value || selection.value.some(sel => isScheduleTrigger(findRowBySelection(sel))))) {
             enableDialogTrigger.value = null
             isEnableDialogOpen.value = true
             return
         }
         genericConfirmAction(
             `bulk disabled status.${bool}`,
-            "setDisabledByQuery",
-            "setDisabledByTriggers",
+            "setDisabled",
             `bulk success disabled status.${bool}`,
             {disabled: bool},
         )
     }
 
-    const findRowBySelection = (sel: any) => triggersMerged.value.find((row: any) =>
+    const findRowBySelection = (sel: TriggerControllerApiTriggerId) => triggersMerged.value.find(row =>
         (row.triggerId ?? row.id) === sel.triggerId && row.flowId === sel.flowId && row.namespace === sel.namespace)
 
     const checkBackfill = computed(() => {
-        if (!backfill.value?.start) {
+        const {start, end, inputs, labels} = backfill.value
+
+        if (!start) {
             return true
         }
-        if (backfill.value?.end && backfill.value.start > backfill.value.end) {
+        if (end && start > end) {
             return true
         }
         if (flowStore.flow?.inputs) {
-            const requiredInputs = flowStore.flow.inputs?.map((input: any) => input?.required !== false ? input?.id : null).filter((i: any) => i !== null) || []
+            const requiredInputs = flowStore.flow.inputs
+                .filter(input => input?.required !== false)
+                .map(input => input.id)
 
             if (requiredInputs.length > 0) {
-                if (!backfill.value?.inputs) {
+                if (!inputs) {
                     return true
                 }
-                const fillInputs = Object.keys(backfill.value.inputs).filter((i: string) => backfill.value?.inputs?.[i] !== null && backfill.value?.inputs?.[i] !== undefined)
+                const fillInputs = Object.keys(inputs).filter(key => inputs[key] !== null && inputs[key] !== undefined)
                 if (requiredInputs.sort().join(",") !== fillInputs.sort().join(",")) {
                     return true
                 }
             }
         }
-        if (backfill.value?.labels?.length > 0) {
-            for (let label of backfill.value.labels) {
-                if (((label as any)?.key && !(label as any)?.value) || (!(label as any)?.key && (label as any)?.value)) {
-                    return true
-                }
-            }
-        }
-        return false
+
+        return labels.some(label => Boolean(label.key) !== Boolean(label.value))
     })
 
 </script>

--- a/ui/src/components/flows/FlowTriggers.vue
+++ b/ui/src/components/flows/FlowTriggers.vue
@@ -27,9 +27,9 @@
             :data="triggersWithType"
             :total="triggersWithType.length"
             :defaultSort="{prop: 'triggerId', order: 'ascending'}"
-            :rowKey="(row: any) => row.id"
+            :rowKey="(row: TriggerRow) => row.id"
             :expandRowKeys="expandedRowKeys"
-            :rowClassName="(arg: any) => arg.row?.backfill ? 'force-expanded' : ''"
+            :rowClassName="(arg: {row: TriggerRow}) => arg.row.backfill ? 'force-expanded' : ''"
             :selectable="canCheck"
             :selectionMapper="selectionMapper"
         >
@@ -318,7 +318,7 @@
             <code>{{ triggerId }}</code>
         </template>
 
-        <KsMarkdown v-if="triggerDefinition && (triggerDefinition as any).description" :content="(triggerDefinition as any).description" />
+        <KsMarkdown v-if="triggerDefinition?.description" :content="triggerDefinition.description" />
         <Vars :data="modalData" />
     </KsDrawer>
 </template>
@@ -355,6 +355,14 @@
     import {useFlowStore} from "../../stores/flow"
     import {useAuthStore} from "override/stores/auth"
     import * as TriggersAPI from "@kestra-io/kestra-sdk/triggers"
+    import type {
+        AbstractTrigger,
+        ApiAsyncOperationResponse,
+        ApiTriggerState,
+        Label,
+        TriggerControllerApiCreateBackfillRequest,
+        TriggerControllerApiTriggerId,
+    } from "@kestra-io/kestra-sdk"
     import {searchTriggersForFlow} from "../../utils/triggers"
     import {useProductTourStore} from "../../stores/productTour"
     import TestEventDialog, {type TestEventTarget} from "./TestEventDialog.vue"
@@ -373,16 +381,36 @@
         embed: boolean;
     }>()
 
-    const backfill = ref({
-        start: null as Date | null,
-        end: null as Date | null,
-        inputs: null as any,
-        labels: [] as any[],
+    // A row is the flow's trigger definition merged with its scheduler state, which is absent until
+    // the trigger has been evaluated; `inputs` (Schedule) and `key` (Webhook) come from trigger
+    // plugin subclasses, which AbstractTrigger does not model.
+    type TriggerRow = AbstractTrigger & Partial<ApiTriggerState> & {
+        sourceDisabled: boolean;
+        inputs?: Record<string, unknown>;
+        key?: string;
+    }
+
+    /** The part of the KsDataTable instance this table drives. */
+    interface TriggersDataTable {
+        selection: TriggerControllerApiTriggerId[];
+        toggleAllUnselected: () => void;
+    }
+
+    const backfill = ref<{
+        start: Date | null;
+        end: Date | null;
+        inputs: Record<string, unknown> | null;
+        labels: Label[];
+    }>({
+        start: null,
+        end: null,
+        inputs: null,
+        labels: [],
     })
     const isOpen = ref(false)
-    const triggers = ref<any[]>([])
+    const triggers = ref<ApiTriggerState[]>([])
     const isBackfillOpen = ref(false)
-    const selectedTrigger = ref<any>(null)
+    const selectedTrigger = ref<TriggerRow | undefined>()
 
     // kept out of `backfill` so it never leaks into the submitted payload (cleanBackfill spreads backfill)
     const backfillInputsNoDefault = ref<Record<string, unknown>>({})
@@ -391,7 +419,7 @@
         backfill.value.start ||
         backfill.value.end ||
         Object.keys(backfillInputsNoDefault.value).length > 0 ||
-        backfill.value.labels?.some((label: any) => label.key || label.value)
+        backfill.value.labels.some(label => label.key || label.value)
     ))
     const triggerId = ref<string | undefined>()
 
@@ -455,10 +483,10 @@
 
     const updateDisplayColumns = (newColumns: string[]) => updateVisibleColumns(newColumns)
 
-    const expandedRowKeys = computed(() =>
+    const expandedRowKeys = computed<string[]>(() =>
         triggersWithType.value
-            .filter((row: any) => !!row.backfill)
-            .map((row: any) => row.id),
+            .filter(row => !!row.backfill)
+            .map(row => row.id),
     )
 
     const toast = useToast()
@@ -469,154 +497,158 @@
         return Array.isArray(route.query?.["filters[q][EQUALS]"]) ? route.query["filters[q][EQUALS]"][0] : route.query?.["filters[q][EQUALS]"]
     })
 
-    const modalData = computed(() => {
-        const filtered = triggersWithType.value.filter((trigger: any) => trigger?.triggerId === triggerId.value)
-        if (!filtered.length) return {}
+    const modalData = computed<Record<string, unknown>>(() => {
+        const trigger = triggersWithType.value.find(row => row.triggerId === triggerId.value)
+        if (!trigger) return {}
         return Object
-            .entries(filtered[0])
+            .entries(trigger)
             .filter(([key]) => !["tenantId", "namespace", "flowId", "flowRevision", "triggerId", "description"].includes(key))
-            .reduce(
-                (map, currentValue) => {
-                    map[currentValue[0]] = currentValue[1]
-                    return map
-                },
-                {} as any,
-            )
+            .reduce<Record<string, unknown>>((map, [key, value]) => {
+                map[key] = value
+                return map
+            }, {})
     })
 
-    const triggerDefinition = computed(() => {
-        if (!flowStore.flow?.triggers) return undefined
-        return flowStore.flow.triggers.find((trigger: any) => trigger.id === triggerId.value)
+    const triggerDefinition = computed(() =>
+        flowStore.flow?.triggers?.find(trigger => trigger.id === triggerId.value),
+    )
+
+    const triggersWithType = computed<TriggerRow[]>(() => {
+        const flowTriggers = flowStore.flow?.triggers
+        if (!flowTriggers) return []
+
+        const rows = flowTriggers.map(trigger => ({
+            ...trigger,
+            sourceDisabled: trigger.disabled ?? false,
+            ...triggers.value.find(state => state.triggerId === trigger.id),
+        }))
+
+        const search = query.value
+        return search ? rows.filter(row => row.id.includes(search)) : rows
     })
 
-    const triggersWithType = computed(() => {
-        if(!flowStore.flow?.triggers) return []
+    type BackfillRequest = TriggerControllerApiCreateBackfillRequest["backfill"]
 
-        let flowTriggers = flowStore.flow?.triggers.map((trigger: any) => {
-            return {...trigger, sourceDisabled: (trigger as any).disabled ?? false}
-        })
-        if (flowTriggers) {
-            const trigs = flowTriggers.map((flowTrigger: any) => {
-                let pollingTrigger = triggers.value.find((trigger: any) => trigger.triggerId === flowTrigger.id)
-                return {...flowTrigger, ...pollingTrigger}
-            })
-
-            return !query.value ? trigs : trigs.filter((trigger: any) => trigger?.id?.includes(query.value))
+    const cleanBackfill = computed<BackfillRequest>(() => {
+        const labels = backfill.value.labels.filter(label => label.key && label.value)
+        return {
+            start: backfill.value.start?.toISOString(),
+            end: backfill.value.end?.toISOString(),
+            // the spec models the endpoint's Map<String, Object> inputs as a map of maps
+            inputs: (backfill.value.inputs ?? undefined) as BackfillRequest["inputs"],
+            labels: labels.length ? labels : undefined,
         }
-        return triggers.value
-    })
-
-    const cleanBackfill = computed(() => {
-        const labels = backfill.value.labels?.filter((label: any) => label.key && label.value)
-        return {...backfill.value, labels: labels?.length ? labels : null}
     })
 
     const checkBackfill = computed(() => {
-        if (!backfill.value.start) {
+        const {start, end, inputs, labels} = backfill.value
+
+        if (!start) {
             return true
         }
-        if (backfill.value.end && backfill.value.start > backfill.value.end) {
+        if (end && start > end) {
             return true
         }
         if (flowStore.flow?.inputs) {
-            const requiredInputs = flowStore.flow?.inputs.map((input: any) => input.required !== false ? input.id : null).filter((i: any) => i !== null)
+            const requiredInputs = flowStore.flow.inputs
+                .filter(input => input.required !== false)
+                .map(input => input.id)
 
             if (requiredInputs.length > 0) {
-                if (!backfill.value.inputs) {
+                if (!inputs) {
                     return true
                 }
-                const fillInputs = Object.keys(backfill.value.inputs).filter((i: string) => backfill.value.inputs[i] !== null && backfill.value.inputs[i] !== undefined)
+                const fillInputs = Object.keys(inputs).filter(key => inputs[key] !== null && inputs[key] !== undefined)
                 if (requiredInputs.sort().join(",") !== fillInputs.sort().join(",")) {
                     return true
                 }
             }
         }
-        if (backfill.value.labels?.length > 0) {
-            for (let label of backfill.value.labels) {
-                if ((label.key && !label.value) || (!label.key && label.value)) {
-                    return true
-                }
-            }
-        }
-        return false
+
+        return labels.some(label => Boolean(label.key) !== Boolean(label.value))
     })
 
-    const userCan = (act: any) => {
+    const userCan = (act?: string) => {
         if (!flowStore.flow) return false
         return authStore.user?.isAllowed(resource.TRIGGER, act ? act : action.VIEW, flowStore.flow?.namespace)
     }
 
     const loadData = () => {
-        if(!triggersWithType.value.length || !flowStore.flow) return
+        const flow = flowStore.flow
+        if(!triggersWithType.value.length || !flow) return
 
-        searchTriggersForFlow({namespace: flowStore.flow?.namespace, flowId: flowStore.flow?.id, size: triggersWithType.value.length, q: query.value})
-            .then((trigs: any) => triggers.value = trigs.results)
+        searchTriggersForFlow({namespace: flow.namespace, flowId: flow.id, size: triggersWithType.value.length, q: query.value})
+            .then(trigs => triggers.value = trigs.results)
             .then(() => reloadLogs.value = Math.random())
     }
 
-    const setBackfillModal = (trigger: any, bool: boolean) => {
+    // The identity the trigger endpoints address a row by: a trigger with no state row yet carries
+    // only its definition id, and its namespace and flow are the ones being viewed.
+    const triggerIdentity = (row: TriggerRow) => ({
+        namespace: row.namespace ?? flowStore.flow?.namespace ?? "",
+        flowId: row.flowId ?? flowStore.flow?.id ?? "",
+        triggerId: row.triggerId ?? row.id,
+    })
+
+    const setBackfillModal = (trigger: TriggerRow | null, bool: boolean) => {
         if (bool) {
             backfill.value = {start: null, end: null, inputs: null, labels: []}
             backfillInputsNoDefault.value = {}
         }
         isBackfillOpen.value = bool
-        selectedTrigger.value = trigger
+        selectedTrigger.value = trigger ?? undefined
     }
 
     const loadDataAfterAction = () => loadData()
 
     const postBackfill = () => {
-        const trigger = selectedTrigger.value as any
-        TriggersAPI.createBackfill({
-            namespace: trigger.namespace,
-            flowId: trigger.flowId,
-            triggerId: trigger.triggerId,
-            backfill: cleanBackfill.value as any,
-        })
+        const trigger = selectedTrigger.value
+        if (!trigger) return
+
+        const identity = triggerIdentity(trigger)
+        TriggersAPI.createBackfill({...identity, backfill: cleanBackfill.value})
             .then(() => {
-                toast.saved(selectedTrigger.value?.triggerId)
+                toast.saved(identity.triggerId)
                 setBackfillModal(null, false)
-                backfill.value = {
-                    start: null,
-                    end: null,
-                    inputs: null,
-                    labels: [],
-                }
+                backfill.value = {start: null, end: null, inputs: null, labels: []}
                 loadDataAfterAction()
             })
     }
 
-    const pauseBackfill = (trigger: any) => {
-        TriggersAPI.pauseBackfill(trigger)
+    const pauseBackfill = (trigger: TriggerRow) => {
+        const identity = triggerIdentity(trigger)
+        TriggersAPI.pauseBackfill(identity)
             .then(() => {
-                toast.saved(trigger.triggerId)
+                toast.saved(identity.triggerId)
                 loadDataAfterAction()
             })
     }
 
-    const unpauseBackfill = (trigger: any) => {
-        TriggersAPI.unpauseBackfill(trigger)
+    const unpauseBackfill = (trigger: TriggerRow) => {
+        const identity = triggerIdentity(trigger)
+        TriggersAPI.unpauseBackfill(identity)
             .then(() => {
-                toast.saved(trigger.triggerId)
+                toast.saved(identity.triggerId)
                 loadDataAfterAction()
             })
     }
 
-    const deleteBackfill = (trigger: any) => {
-        TriggersAPI.deleteBackfill(trigger)
+    const deleteBackfill = (trigger: TriggerRow) => {
+        const identity = triggerIdentity(trigger)
+        TriggersAPI.deleteBackfill(identity)
             .then(() => {
-                toast.saved(trigger.triggerId)
+                toast.saved(identity.triggerId)
                 loadDataAfterAction()
             })
     }
 
     const isEnableDialogOpen = ref(false)
     // The schedule trigger being enabled; null when enabling the bulk selection.
-    const enableDialogTrigger = ref<any>(null)
+    const enableDialogTrigger = ref<TriggerRow | null>(null)
 
-    const isScheduleTrigger = (row: any) => row?.kind === "SCHEDULE" || isSchedule(row?.type)
+    const isScheduleTrigger = (row?: TriggerRow) => row?.kind === "SCHEDULE" || isSchedule(row?.type)
 
-    const setDisabled = (trigger: any, value: boolean) => {
+    const setDisabled = (trigger: TriggerRow, value: boolean) => {
         if (value && isScheduleTrigger(trigger)) {
             enableDialogTrigger.value = trigger
             isEnableDialogOpen.value = true
@@ -625,10 +657,11 @@
         doSetDisabled(trigger, !value)
     }
 
-    const doSetDisabled = (trigger: any, disabled: boolean, recoverMissedSchedules?: boolean) => {
-        TriggersAPI.disableTriggerById({...trigger, disabled, recoverMissedSchedules})
+    const doSetDisabled = (trigger: TriggerRow, disabled: boolean, recoverMissedSchedules?: boolean) => {
+        const identity = triggerIdentity(trigger)
+        TriggersAPI.disableTriggerById({...identity, disabled, recoverMissedSchedules})
             .then(() => {
-                toast.saved(trigger.triggerId)
+                toast.saved(identity.triggerId)
                 loadDataAfterAction()
             })
     }
@@ -638,36 +671,30 @@
             doSetDisabled(enableDialogTrigger.value, false, recoverMissedSchedules)
         } else {
             runBulk(
-                () => TriggersAPI.disabledTriggersByIds({triggers: selection.value, disabled: false, recoverMissedSchedules} as Parameters<typeof TriggersAPI.disabledTriggersByIds>[0]),
+                () => TriggersAPI.disabledTriggersByIds({triggers: selection.value, disabled: false, recoverMissedSchedules}),
                 "bulk success disabled status.false",
                 t("enable"),
             )
         }
     }
 
-    const unlock = (trigger: any) => {
-        TriggersAPI.unlockTrigger({
-            namespace: trigger.namespace,
-            flowId: trigger.flowId,
-            triggerId: trigger.triggerId,
-        }).then(() => {
-            toast.saved(trigger.triggerId)
+    const unlock = (trigger: TriggerRow) => {
+        const identity = triggerIdentity(trigger)
+        TriggersAPI.unlockTrigger(identity).then(() => {
+            toast.saved(identity.triggerId)
             loadDataAfterAction()
         })
     }
 
-    const restart = (trigger: any) => {
-        TriggersAPI.restartTrigger({
-            namespace: trigger.namespace,
-            flowId: trigger.flowId,
-            triggerId: trigger.triggerId,
-        }).then(() => {
-            toast.saved(trigger.triggerId)
+    const restart = (trigger: TriggerRow) => {
+        const identity = triggerIdentity(trigger)
+        TriggersAPI.restartTrigger(identity).then(() => {
+            toast.saved(identity.triggerId)
             loadDataAfterAction()
         })
     }
 
-    const openDetails = (row: any) => {
+    const openDetails = (row: TriggerRow) => {
         triggerId.value = row.id
         isOpen.value = true
     }
@@ -677,18 +704,13 @@
     const isTestEventOpen = ref(false)
 
     // Gated on execution-create: a test event creates a real execution.
-    const canSendTestEvent =(row: any) =>
+    const canSendTestEvent =(row: TriggerRow) =>
         row?.type === WEBHOOK_TRIGGER_TYPE
         && Boolean(row?.key)
         && Boolean(authStore.user?.isAllowed(resource.EXECUTION, action.CREATE, flowStore.flow?.namespace))
 
-    const sendTestEvent = (row: any) => {
-        testEventTarget.value = {
-            namespace: row.namespace ?? flowStore.flow?.namespace ?? "",
-            flowId: row.flowId ?? flowStore.flow?.id ?? "",
-            triggerId: row.triggerId ?? row.id,
-            key: row.key,
-        }
+    const sendTestEvent = (row: TriggerRow) => {
+        testEventTarget.value = {...triggerIdentity(row), key: row.key ?? ""}
         isTestEventOpen.value = true
     }
 
@@ -700,30 +722,30 @@
         })
     }
 
-    const dataTable = useTemplateRef<any>("dataTable")
+    const dataTable = useTemplateRef<TriggersDataTable>("dataTable")
     const canCheck = computed<boolean>(() => userCan(action.UPDATE) ?? false)
-    const selection = computed<any[]>(() => dataTable.value?.selection ?? [])
-    const selectionMapper = (row: any) => ({
+    const selection = computed<TriggerControllerApiTriggerId[]>(() => dataTable.value?.selection ?? [])
+    const selectionMapper = (row: TriggerRow): TriggerControllerApiTriggerId => ({
         namespace: row.namespace,
         flowId: row.flowId,
         triggerId: row.triggerId ?? row.id,
     })
 
-    const runBulk = (promiseFactory: () => Promise<any>, successKey: string, actionLabel: string) => {
+    const runBulk = (promiseFactory: () => Promise<ApiAsyncOperationResponse>, successKey: string, actionLabel: string) => {
         return promiseFactory()
-            .then((d: any) => {
-                toast.success(t(successKey, {count: d?.count}))
+            .then(response => {
+                toast.success(t(successKey, {count: response.totalItems}))
                 dataTable.value?.toggleAllUnselected()
                 loadDataAfterAction()
             })
             .catch((error: unknown) => {
-                toast.error(`${actionLabel}: ${(error as any)?.message ?? t("error")}`)
+                toast.error(`${actionLabel}: ${error instanceof Error ? error.message : t("error")}`)
                 console.error(error)
             })
     }
 
     const bulkSetDisabled = (disabled: boolean) => {
-        if (!disabled && selection.value.some((sel: any) => isScheduleTrigger(findRowBySelection(sel)))) {
+        if (!disabled && selection.value.some(sel => isScheduleTrigger(findRowBySelection(sel)))) {
             enableDialogTrigger.value = null
             isEnableDialogOpen.value = true
             return
@@ -741,8 +763,8 @@
         )
     }
 
-    const findRowBySelection = (sel: any) =>
-        triggersWithType.value.find((row: any) => (row.triggerId ?? row.id) === sel.triggerId)
+    const findRowBySelection = (sel: TriggerControllerApiTriggerId) =>
+        triggersWithType.value.find(row => (row.triggerId ?? row.id) === sel.triggerId)
 
     const bulkUnlock = () => {
         toast.confirm(
@@ -767,14 +789,10 @@
         )
     }
 
-    const confirmDeleteTrigger = (row: any) => {
+    const confirmDeleteTrigger = (row: TriggerRow) => {
         toast.confirm(
             t("delete trigger confirmation", {id: row.id}),
-            () => TriggersAPI.deleteTrigger({
-                namespace: row.namespace,
-                flowId: row.flowId,
-                triggerId: row.triggerId ?? row.id,
-            }).then(() => {
+            () => TriggersAPI.deleteTrigger(triggerIdentity(row)).then(() => {
                 toast.success(t("delete trigger success", {id: row.id}))
                 loadDataAfterAction()
             }).catch((error: unknown) => {
@@ -785,12 +803,12 @@
         )
     }
 
-    const isSchedule = (type: string) => {
+    const isSchedule = (type?: string) => {
         return type === "io.kestra.plugin.core.trigger.Schedule"
     }
 
-    const hasTrigger = (trigger: any) => {
-        return triggers.value.map((trigg: any) => trigg?.triggerId).includes(trigger?.id)
+    const hasTrigger = (row: TriggerRow) => {
+        return triggers.value.some(state => state.triggerId === row.id)
     }
 
     const addNewTrigger = () => {


### PR DESCRIPTION
### 🔗 Related Issue

None; picked up directly.

### ✨ Description

`TriggersManage.vue` (admin triggers) and `FlowTriggers.vue` (the flow's triggers tab) carried 55 `any` annotations between them, so nothing in either file was actually checked: row shapes, table instances, bulk selections and API payloads were all opaque. Both are now typed against the generated SDK models, and the type checker found two real bugs on the way in.

**Rows** are the merged shape the tables actually render:

- admin: `Partial<AbstractTrigger> & ApiTriggerState` (the search endpoint always returns a state, `@NotNull` in `ApiTriggerAndState`)
- flow tab: `AbstractTrigger & Partial<ApiTriggerState>` (the state is absent until the trigger has been evaluated)

Fields that come from trigger plugin subclasses rather than `AbstractTrigger` (`inputs` on Schedule, `key` on Webhook, `logs`) are declared explicitly, with a comment saying where they come from.

**Bulk actions**, admin table: the 12-entry `Record<string, () => any>` and the two mirrored string parameters (`"deleteByQuery"` + `"deleteByTriggers"`) collapse into one record keyed by action name, each entry pairing `byQuery` with `byIds`. A caller can no longer pair a name with the wrong endpoint, and `byIdAction.includes("setDisabled")` — string-sniffing to decide the payload shape — is gone.

**Endpoint identity**, flow tab: the six copies of "pick `namespace`/`flowId`/`triggerId` off the row" become one `triggerIdentity` helper. The endpoints' path parameters are non-optional strings, which is what forced the issue; the helper falls back to the flow being viewed, exactly as `sendTestEvent` already did.

Two bugs surfaced:

- **The bulk toasts had a blank count.** Those endpoints return `ApiAsyncOperationResponse` (`operationId`, `totalItems`) and the code read `d?.count`, so "{count} triggers unlocked" rendered as " triggers unlocked". Both files now read `totalItems`.
- **`triggersWithType` had unreachable code.** `return triggers.value` after `if (flowTriggers)`, where `flowTriggers` is a `.map()` result and so never falsy. Removed; it would also have put raw state objects into the table.

Also: backfill payloads are built from `TriggerControllerApiCreateBackfillRequest["backfill"]` instead of spreading the whole form state (dates converted with `toISOString()`, which is byte-for-byte what `JSON.stringify` was already doing to them), and the `disableTriggerById` call sends the five request fields instead of the entire row.

### 🎨 Frontend Checklist

- [x] Type checking passes (`vue-tsc --build tsconfig.app.json --force`; the `npm run check:types` wrapper wants node ≥ 24 and this box has 22)
- [x] Code builds without errors (`npm run build`)
- [x] Unit tests pass (`npm run test:unit` — 249 files, 2271 tests)
- [x] Translations are complete if `en.json` changed (no translation change)
- [ ] Screenshots or video recordings attached showing the `UI` changes

### 📝 Additional Notes

No screenshots: there is no visual delta to show. The one user-visible change is the bulk toast now printing its count, which needs a live backend and a bulk action against real triggers to capture — worth a reviewer check rather than a screenshot from me.

No tests added. Neither component has any, and a test asserting that a typed row is still a typed row would only restate the annotations; the check that can fail here is `vue-tsc`, which now covers both files. One cast survives in each file, on `backfill.inputs`: the spec models the endpoint's `Map<String, Object>` as a map of maps, so a flat input map cannot satisfy it without one.

The behaviour-adjacent edits, called out for review: `totalItems` in the toasts, narrowed request bodies on `disableTriggerById` / `pauseBackfill` / `unpauseBackfill` / `deleteBackfill` (the extra row fields were being ignored server-side by the receiving records), and `rowClassName` handlers now taking only `{row}` — the shape `KsDataTable` always calls them with.

### 🤖 AI Authors

I asked the trigger table why it kept using `any`. It said it was in a Schrödinger state: nobody knew what type it was until they opened the box, and by then the toast had already lost its count. 🐱

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EmgVM1hfKSEgGrG2CtxhGa

---
_Generated by [Claude Code](https://claude.ai/code/session_01EmgVM1hfKSEgGrG2CtxhGa)_

Closes https://github.com/kestra-io/kestra/issues/19267.
Closes https://github.com/kestra-io/kestra/issues/19270.
