### PR TITLE
fix(core): drop the definitions of input types excluded from a schema (2.0 backport)

### DIFF
--- a/core/src/main/java/io/kestra/core/docs/JsonSchemaGenerator.java
+++ b/core/src/main/java/io/kestra/core/docs/JsonSchemaGenerator.java
@@ -162,15 +162,24 @@ public class JsonSchemaGenerator {
      * such as {@code REUSABLE_INPUTS}) from the generated flow schema. The {@code Type} enum is carried in two places:
      * the {@code enum} arrays (the {@code type} discriminator and {@code ArrayInput.itemType}) AND the polymorphic
      * {@code anyOf}/{@code oneOf}/{@code allOf} discriminator branches ({@code {properties:{type:{const:...}}}}); both
-     * must be pruned. Open-source removes the {@code @EeOnly} types; the Enterprise override of
-     * {@code includeInputSubtype} keeps them all, so the excluded set is empty here (no-op).
+     * must be pruned, along with the subtype's own definitions — a branch reaching one by {@code $ref} keeps
+     * validating the excluded input, only without the {@code type} that identifies it. Open-source removes the
+     * {@code @EeOnly} types; the Enterprise override of {@code includeInputSubtype} keeps them all, so the excluded
+     * set is empty here (no-op).
      */
-    private void stripEditionRestrictedInputTypes(Object node, Class<?> cls) {
+    private void stripEditionRestrictedInputTypes(Map<String, Object> schema, Class<?> cls) {
         Set<String> excluded = this.excludedInputTypes(cls);
 
-        if (!excluded.isEmpty()) {
-            stripEditionRestrictedInputTypes(node, excluded);
+        if (excluded.isEmpty()) {
+            return;
         }
+
+        // the subtype definitions have to be spotted first: the strip below removes the discriminator branch that
+        // tells them apart from an ordinary input definition
+        Set<String> excludedDefinitions = excludedSubtypeDefinitions(schema, excluded);
+
+        stripEditionRestrictedInputTypes(schema, excluded, excludedDefinitions);
+        removeExcludedDefinitions(schema, excludedDefinitions);
     }
 
     /**
@@ -186,7 +195,7 @@ public class JsonSchemaGenerator {
     }
 
     @SuppressWarnings("unchecked")
-    private static void stripEditionRestrictedInputTypes(Object node, Set<String> excluded) {
+    private static void stripEditionRestrictedInputTypes(Object node, Set<String> excluded, Set<String> excludedDefinitions) {
         if (node instanceof Map<?, ?> rawMap) {
             Map<String, Object> map = (Map<String, Object>) rawMap;
 
@@ -195,13 +204,104 @@ public class JsonSchemaGenerator {
             }
             for (String key : List.of("anyOf", "oneOf", "allOf")) {
                 if (map.get(key) instanceof List<?> branches) {
-                    branches.removeIf(branch -> isExcludedDiscriminatorBranch(branch, excluded));
+                    branches.removeIf(
+                        branch -> isExcludedDiscriminatorBranch(branch, excluded)
+                            || referencesExcludedDefinition(branch, excludedDefinitions)
+                    );
                 }
             }
-            map.values().forEach(value -> stripEditionRestrictedInputTypes(value, excluded));
+            map.values().forEach(value -> stripEditionRestrictedInputTypes(value, excluded, excludedDefinitions));
         } else if (node instanceof List<?> list) {
-            list.forEach(value -> stripEditionRestrictedInputTypes(value, excluded));
+            list.forEach(value -> stripEditionRestrictedInputTypes(value, excluded, excludedDefinitions));
         }
+    }
+
+    /** The definitions of the excluded subtypes: the discriminator branch itself, or the wrapper carrying it. */
+    @SuppressWarnings("unchecked")
+    private static Set<String> excludedSubtypeDefinitions(Map<String, Object> schema, Set<String> excluded) {
+        if (!(schema.get("definitions") instanceof Map<?, ?> definitions)) {
+            return Set.of();
+        }
+
+        return ((Map<String, Object>) definitions).entrySet().stream()
+            .filter(entry -> isExcludedSubtypeDefinition(entry.getValue(), excluded))
+            .map(Map.Entry::getKey)
+            .collect(Collectors.toSet());
+    }
+
+    @SuppressWarnings("unchecked")
+    private static boolean isExcludedSubtypeDefinition(Object definition, Set<String> excluded) {
+        if (isExcludedDiscriminatorBranch(definition, excluded)) {
+            return true;
+        }
+        if (!(definition instanceof Map<?, ?> map)) {
+            return false;
+        }
+
+        for (String key : List.of("anyOf", "oneOf", "allOf")) {
+            if (
+                ((Map<String, Object>) map).get(key) instanceof List<?> branches
+                    && branches.stream().anyMatch(branch -> isExcludedDiscriminatorBranch(branch, excluded))
+            ) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Drops the excluded subtype definitions, then whatever only they referenced: a discriminator wrapper points at a
+     * plain body definition no other subtype uses, while shared ones (e.g. {@code DependsOn}) stay referenced.
+     */
+    @SuppressWarnings("unchecked")
+    private static void removeExcludedDefinitions(Map<String, Object> schema, Set<String> excludedDefinitions) {
+        if (excludedDefinitions.isEmpty() || !(schema.get("definitions") instanceof Map<?, ?> rawDefinitions)) {
+            return;
+        }
+
+        Map<String, Object> definitions = (Map<String, Object>) rawDefinitions;
+        Set<String> orphanCandidates = new HashSet<>();
+        excludedDefinitions.forEach(name -> collectRefs(definitions.remove(name), orphanCandidates));
+
+        boolean removedAny = true;
+        while (removedAny) {
+            removedAny = false;
+            Set<String> referenced = new HashSet<>();
+            collectRefs(schema, referenced);
+
+            for (String candidate : Set.copyOf(orphanCandidates)) {
+                if (!referenced.contains(candidate) && definitions.containsKey(candidate)) {
+                    orphanCandidates.remove(candidate);
+                    collectRefs(definitions.remove(candidate), orphanCandidates);
+                    removedAny = true;
+                }
+            }
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private static boolean referencesExcludedDefinition(Object node, Set<String> definitions) {
+        return node instanceof Map<?, ?> map
+            && ((Map<String, Object>) map).get("$ref") instanceof String ref
+            && definitions.contains(definitionName(ref));
+    }
+
+    @SuppressWarnings("unchecked")
+    private static void collectRefs(Object node, Set<String> refs) {
+        if (node instanceof Map<?, ?> rawMap) {
+            Map<String, Object> map = (Map<String, Object>) rawMap;
+
+            if (map.get("$ref") instanceof String ref) {
+                refs.add(definitionName(ref));
+            }
+            map.values().forEach(value -> collectRefs(value, refs));
+        } else if (node instanceof List<?> list) {
+            list.forEach(value -> collectRefs(value, refs));
+        }
+    }
+
+    private static String definitionName(String ref) {
+        return ref.substring(ref.lastIndexOf('/') + 1);
     }
 
     @SuppressWarnings("unchecked")

--- a/core/src/test/java/io/kestra/core/docs/JsonSchemaGeneratorTest.java
+++ b/core/src/test/java/io/kestra/core/docs/JsonSchemaGeneratorTest.java
@@ -21,7 +21,9 @@ import io.kestra.core.models.annotations.PluginProperty;
 import io.kestra.core.models.dashboards.Dashboard;
 import io.kestra.core.models.dashboards.GraphStyle;
 import io.kestra.core.models.enums.MonacoLanguages;
+import io.kestra.core.models.flows.DependsOn;
 import io.kestra.core.models.flows.Flow;
+import io.kestra.core.models.flows.input.ReusableInputsInput;
 import io.kestra.core.models.property.Property;
 import io.kestra.core.models.tasks.RunnableTask;
 import io.kestra.core.models.tasks.Task;
@@ -161,8 +163,42 @@ class JsonSchemaGeneratorTest {
             // the polymorphic anyOf/const subtype branches nor in the type/itemType enum arrays (REUSABLE_INPUTS was
             // leaking through the latter).
             assertThat(schema, not(containsString("REUSABLE_INPUTS")));
+            // the class name is not the type name, so it survives the string strip: the subtype's definitions and the
+            // anyOf branch reaching them by $ref have to go too, or a reusable-inputs input still validates, minus its
+            // discriminator
+            assertThat(schema, not(containsString("ReusableInputsInput")));
             // sanity: ordinary input types are still present
             assertThat(schema, containsString("EMAIL"));
+        });
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    void excludedInputTypesLeaveNoBranchOrDefinitionBehind() throws URISyntaxException {
+        Helpers.runApplicationContext((applicationContext) ->
+        {
+            JsonSchemaGenerator jsonSchemaGenerator = applicationContext.getBean(JsonSchemaGenerator.class);
+
+            Map<String, Object> schema = jsonSchemaGenerator.schemas(Flow.class);
+            var definitions = (Map<String, Map<String, Object>>) schema.get("definitions");
+            var flow = definitions.get(Flow.class.getName());
+            var inputs = (Map<String, Object>) ((Map<String, Object>) flow.get("properties")).get("inputs");
+            var items = (Map<String, Object>) inputs.get("items");
+            var branches = (List<Map<String, Object>>) items.get("anyOf");
+
+            String excluded = ReusableInputsInput.class.getName();
+            assertThat(
+                "no anyOf branch may reach the excluded subtype",
+                branches.stream().map(branch -> String.valueOf(branch.get("$ref"))).toList(),
+                everyItem(not(containsString(excluded)))
+            );
+            assertThat(
+                "the excluded subtype's definitions, orphaned by the branch removal, must go with it",
+                definitions.keySet().stream().filter(key -> key.startsWith(excluded)).toList(), is(empty())
+            );
+            // a body definition shared with the surviving subtypes must stay
+            assertThat(definitions, hasKey(DependsOn.class.getName()));
+            assertThat(branches, hasSize(greaterThan(1)));
         });
     }
 


### PR DESCRIPTION
Backport of https://github.com/kestra-io/kestra/pull/19142 (commit `9b5c624289`) to `releases/v2.0.x`. Cherry-picked clean.

- Stripping an edition-restricted input type from a generated schema removed the `type` const branch and the enum values, but not the subtype's own definitions, nor the `anyOf` branch reaching them by `$ref`. The open-source flow schema therefore still validated a `REUSABLE_INPUTS` input under `Flow.inputs`, `FormInput.inputs` and `Pause.onResume`, only without the discriminator that names it. The same held for the EE reusable-inputs block schema.
- The subtype definitions are now identified before the strip, then removed along with whatever only they referenced: a wrapper's plain body definition goes, shared ones like `DependsOn` stay because other subtypes still reference them.
- `flowSchemaExcludesEeOnlyInputTypes` only looked for the string `REUSABLE_INPUTS`, which the class name `ReusableInputsInput` does not contain; that is why this shipped. Replaced with a structural assertion on the branches and on the definition keys.
- Nothing changes when no input type is excluded, which is every schema in EE except the block one.

`./gradlew :core:test --tests "JsonSchemaGeneratorTest"` passes on the release branch.