### PR TITLE
fix(design-system): normalize equivalent relative-duration spellings at decode (2.0 backport)

### DIFF
--- a/ui/packages/design-system/src/components/Data/KsDataTable/filter/layout/FilterChip.vue
+++ b/ui/packages/design-system/src/components/Data/KsDataTable/filter/layout/FilterChip.vue
@@ -59,7 +59,7 @@
         {label: t("datepicker.last24hours"), value: "PT24H"},
         {label: t("datepicker.last48hours"), value: "PT48H"},
         {label: t("datepicker.last7days"), value: "PT168H"},
-        {label: t("datepicker.last30days"), value: "P30D"},
+        {label: t("datepicker.last30days"), value: "PT720H"},
         {label: t("datepicker.last365days"), value: "PT8760H"},
     ]
 

--- a/ui/packages/design-system/src/components/Data/KsDataTable/filter/layout/FilterEditPopper.vue
+++ b/ui/packages/design-system/src/components/Data/KsDataTable/filter/layout/FilterEditPopper.vue
@@ -66,7 +66,7 @@
         {label: t("datepicker.last24hours"), value: "PT24H"},
         {label: t("datepicker.last48hours"), value: "PT48H"},
         {label: t("datepicker.last7days"), value: "PT168H"},
-        {label: t("datepicker.last30days"), value: "P30D"},
+        {label: t("datepicker.last30days"), value: "PT720H"},
         {label: t("datepicker.last365days"), value: "PT8760H"},
     ]
 

--- a/ui/packages/design-system/src/components/Data/KsDataTable/filter/utils/filterChipFactory.ts
+++ b/ui/packages/design-system/src/components/Data/KsDataTable/filter/utils/filterChipFactory.ts
@@ -9,6 +9,7 @@ import {
 } from "./filterTypes"
 import {type DecodedParam, keyOfComparator} from "./helpers"
 import {TIME_RANGE_KEY} from "./constants"
+import {normalizeRelativeDate} from "./relativeDates"
 
 export const buildNewFilter = (key: FilterKeyConfig): AppliedFilter | null => {
     const comparator = key.comparators?.[0]
@@ -123,10 +124,10 @@ export const processFieldValue = (
 
     if (config?.valueType === "date" && typeof value === "string") {
         value = new Date(value)
-    } else if (config?.valueType === "time-range" && typeof value === "string" && !/^P/i.test(value)) {
-        // A custom single absolute date for a time-range field. Predefined relative durations
-        // (PT24H, P30D, …) start with "P" and must stay as the raw duration string.
-        value = new Date(value)
+    } else if (config?.valueType === "time-range" && typeof value === "string") {
+        // Predefined relative durations start with "P" and stay durations, normalized to the
+        // spelling the option lists and the API use; anything else is a custom absolute date.
+        value = /^P/i.test(value) ? normalizeRelativeDate(value) : new Date(value)
     }
 
     return {

--- a/ui/packages/design-system/src/components/Data/KsDataTable/filter/utils/relativeDates.ts
+++ b/ui/packages/design-system/src/components/Data/KsDataTable/filter/utils/relativeDates.ts
@@ -1,0 +1,12 @@
+// Equivalent spellings of the predefined relative ranges, normalized to the one the option lists
+// and the API use - Java's Duration.parse, which the API applies, rejects the week designator.
+const RELATIVE_DATE_ALIASES: Record<string, string> = {
+    P1D: "PT24H",
+    P2D: "PT48H",
+    P7D: "PT168H",
+    P1W: "PT168H",
+    P30D: "PT720H",
+    P365D: "PT8760H",
+}
+
+export const normalizeRelativeDate = (value: string): string => RELATIVE_DATE_ALIASES[value] ?? value

--- a/ui/packages/design-system/tests/units/Data/KsFilter/FilterChip.test.ts
+++ b/ui/packages/design-system/tests/units/Data/KsFilter/FilterChip.test.ts
@@ -1,0 +1,37 @@
+import {describe, test, expect} from "vitest"
+import {mount} from "@vue/test-utils"
+import {createI18n} from "vue-i18n"
+import KestraDesignSystem from "../../../../src/index"
+import FilterChip from "../../../../src/components/Data/KsDataTable/filter/layout/FilterChip.vue"
+import {Comparators, type AppliedFilter} from "../../../../src/components/Data/KsDataTable/filter/utils/filterTypes"
+
+const i18n = createI18n({legacy: false, locale: "en", messages: {en: {}}})
+
+const timeRangeChip = (value: string) => ({
+    id: "f1",
+    key: "timeRange",
+    comparator: Comparators.EQUALS,
+    value,
+} as AppliedFilter)
+
+const mountChip = (value: string) =>
+    mount(FilterChip, {
+        props: {filter: timeRangeChip(value)},
+        global: {plugins: [i18n, KestraDesignSystem]},
+    })
+
+describe("FilterChip relative date labels", () => {
+    test.each([
+        ["PT720H", "datepicker.last30days"],
+        ["PT168H", "datepicker.last7days"],
+    ])("labels %s as %s rather than the raw duration", (value, label) => {
+        const wrapper = mountChip(value)
+
+        expect(wrapper.text()).toContain(label)
+        expect(wrapper.text()).not.toContain(value)
+    })
+
+    test("falls back to the raw duration for a value with no matching option", () => {
+        expect(mountChip("PT3H").text()).toContain("PT3H")
+    })
+})

--- a/ui/packages/design-system/tests/units/Data/KsFilter/filterChipFactory.test.ts
+++ b/ui/packages/design-system/tests/units/Data/KsFilter/filterChipFactory.test.ts
@@ -133,3 +133,47 @@ describe("filterChipFactory", () => {
         },
     )
 })
+
+const relativeRangeConfiguration: FilterConfiguration = {
+    title: "Executions",
+    keys: [
+        {
+            key: "timeRange",
+            label: "Interval",
+            valueType: "time-range",
+            comparators: [Comparators.EQUALS],
+        },
+    ],
+}
+
+describe("relative date decoding", () => {
+    test.each([
+        ["P30D", "PT720H"],
+        ["P1W", "PT168H"],
+        ["P7D", "PT168H"],
+        ["PT720H", "PT720H"],
+    ])("normalizes the %s duration to %s", (value, expected) => {
+        const {groups} = parseEncodedGroups({"filters[timeRange][EQUALS]": value}, relativeRangeConfiguration)
+        const [group] = groups
+
+        if (!group || !isLeafGroup(group)) {
+            throw new Error("Expected the decoded group to be a leaf group")
+        }
+
+        expect(group.filters[0]).toMatchObject({key: "timeRange", value: expected})
+    })
+
+    test("still reads an absolute date as a date rather than a duration", () => {
+        const {groups} = parseEncodedGroups(
+            {"filters[timeRange][EQUALS]": "2026-08-01T00:00:00.000Z"},
+            relativeRangeConfiguration,
+        )
+        const [group] = groups
+
+        if (!group || !isLeafGroup(group)) {
+            throw new Error("Expected the decoded group to be a leaf group")
+        }
+
+        expect(group.filters[0]?.value).toBeInstanceOf(Date)
+    })
+})


### PR DESCRIPTION
Backport of https://github.com/kestra-io/kestra/pull/19141 (commit `a8ab9a285c`) to `releases/v2.0.x`.

- `FilterChip.vue` and `FilterEditPopper.vue` each carry their own copy of the relative-date preset list, mapping "last 30 days" to `P30D`, while the app's own filter options (`useValues.ts`) map it to `PT720H` on 2.0.x as well. A filter set to `PT720H` falls through the label lookup and renders the raw ISO string.
- Align both copies to `PT720H`, and normalize equivalent spellings (`P1D`/`P2D`/`P7D`/`P1W`/`P30D`/`P365D`) to the hour form in `processFieldValue`, the single point where a URL param becomes a time-range filter value. Normalizing the value rather than just the label also fixes `P1W`, which `Duration.parse` — used by the API via `TypeConverter.toDuration` — rejects outright, since a Java `Duration` has no week designator.
- Conflict resolved in `filterChipFactory.test.ts`: `releases/v2.0.x` has no `custom range decoding` block (an unbackported develop change), so only the new `relative date decoding` section was taken from the cherry-pick.
- Companion of the EE 2.0 backport, kestra-io/kestra-ee#10921, whose Cases default duration renders as the raw `PT720H` without this.

Design-system unit suite on the release branch: 834 passing. The two failures (`KsIconButton`, `KsEmptyState`) are already red on `releases/v2.0.x` without this change.

Blocked on https://github.com/kestra-io/kestra/pull/19257: the shared design-system workflow is pinned to `kestra-io/actions@main`, which now calls script names that only exist on `develop`, so this PR's design-system job fails on `Missing script: "check:types"` before running anything.