### PR TITLE
fix(ui): document title on the flows and plugins pages

### DIFF
--- a/ui/src/components/dashboard/components/Header.vue
+++ b/ui/src/components/dashboard/components/Header.vue
@@ -70,7 +70,7 @@
 
     const isAllowedDashboardUpdate = computed(() => authStore.user?.isAllowed(permission.DASHBOARD, action.UPDATE, "*"));
 
-    const routeInfo = computed(() => ({title: props.dashboard?.title ?? t("overview")}));
+    const routeInfo = computed(() => ({title: props.dashboard?.title || t("overview")}));
 
     import useRouteContext from "../../../composables/useRouteContext";
     useRouteContext(routeInfo);

--- a/ui/src/components/docs/Docs.vue
+++ b/ui/src/components/docs/Docs.vue
@@ -16,6 +16,7 @@
 <script setup lang="ts">
     import {MDCRenderer, getMDCParser} from "@kestra-io/ui-libs";
     import TopNavBar from "../layout/TopNavBar.vue";
+    import useRouteContext from "../../composables/useRouteContext";
     import {useDocStore} from "../../stores/doc";
     import DocsLayout from "./DocsLayout.vue";
     import Toc from "./Toc.vue";
@@ -43,6 +44,8 @@
     const routeInfo = computed(() => ({
         title: docStore.pageMetadata?.title ?? t("docs"),
     }));
+
+    useRouteContext(routeInfo);
 
     watch(
         () => route.params.path,

--- a/ui/src/components/flows/FlowExecutions.vue
+++ b/ui/src/components/flows/FlowExecutions.vue
@@ -4,6 +4,7 @@
         :flowId="flowStore.flow?.id"
         :topbar="false"
         :defaultScopeFilter="false"
+        :embed="embed"
         filter
     />
 </template>
@@ -13,6 +14,10 @@
 
     import {useFlowStore} from "../../stores/flow";
     const flowStore = useFlowStore();
+
+    defineProps<{
+        embed?: boolean;
+    }>();
 
     defineOptions({inheritAttrs: false});
 </script>

--- a/ui/src/components/flows/FlowRoot.vue
+++ b/ui/src/components/flows/FlowRoot.vue
@@ -165,6 +165,9 @@
                         name: "executions",
                         component: FlowExecutions,
                         title: this.$t("executions"),
+                        props: {
+                            embed: true,
+                        },
                     });
                 }
 

--- a/ui/src/components/flows/Flows.vue
+++ b/ui/src/components/flows/Flows.vue
@@ -351,11 +351,13 @@
 
     const props = withDefaults(defineProps<{
         topbar?: boolean;
+        embed?: boolean;
         namespace?: string;
         id?: string | null;
         defaultScopeFilter?: boolean,
     }>(), {
         topbar: true,
+        embed: false,
         namespace: undefined,
         id: undefined,
         defaultScopeFilter: false,
@@ -437,7 +439,7 @@
 
     const routeInfo = computed(() => ({title: t("flows")}));
 
-    useRouteContext(routeInfo, !props.topbar);
+    useRouteContext(routeInfo, props.embed);
 
     const dataTableRef = useTemplateRef<DataTableRef>("dataTable");
     const selectTableRef = useTemplateRef<typeof SelectTable>("selectTable");

--- a/ui/src/components/flows/Flows.vue
+++ b/ui/src/components/flows/Flows.vue
@@ -347,6 +347,7 @@
     import {useTableColumns} from "../../composables/useTableColumns";
     import {DataTableRef, useDataTableActions} from "../../composables/useDataTableActions";
     import {useSelectTableActions} from "../../composables/useSelectTableActions";
+    import useRouteContext from "../../composables/useRouteContext";
 
     const props = withDefaults(defineProps<{
         topbar?: boolean;
@@ -435,6 +436,8 @@
     const canExecute = (flow: Record<string, any>) => flow && !flow.deleted && user?.value?.isAllowed(permission.EXECUTION, action.CREATE, flow.namespace);
 
     const routeInfo = computed(() => ({title: t("flows")}));
+
+    useRouteContext(routeInfo, !props.topbar);
 
     const dataTableRef = useTemplateRef<DataTableRef>("dataTable");
     const selectTableRef = useTemplateRef<typeof SelectTable>("selectTable");

--- a/ui/src/components/namespaces/utils/useHelpers.ts
+++ b/ui/src/components/namespaces/utils/useHelpers.ts
@@ -104,6 +104,7 @@ export function useHelpers() {
             props: {
                 namespace: namespace.value,
                 topbar: false,
+                embed: true,
                 defaultScopeFilter: false,
             },
         },
@@ -115,7 +116,7 @@ export function useHelpers() {
                 namespace: namespace.value,
                 topbar: false,
                 visibleCharts: true,
-                embed: false,
+                embed: true,
                 defaultScopeFilter: false,
             },
         },

--- a/ui/src/components/plugins/Plugin.vue
+++ b/ui/src/components/plugins/Plugin.vue
@@ -96,6 +96,7 @@
     import {usePluginsStore} from "../../stores/plugins";
     import {useMiscStore} from "override/stores/misc";
     import {getPluginReleaseUrl} from "../../utils/pluginUtils";
+    import useRouteContext from "../../composables/useRouteContext";
 
 
     const pluginsStore = usePluginsStore();
@@ -123,6 +124,8 @@
                     },
                 ],
     }));
+
+    useRouteContext(routeInfo);
 
     const hash = computed(() => miscStore.configs?.pluginsHash ?? 0);
 

--- a/ui/src/composables/useRouteContext.ts
+++ b/ui/src/composables/useRouteContext.ts
@@ -1,24 +1,19 @@
 import {Ref, watch} from "vue";
-import {useRoute} from "vue-router";
 
 export default function useRouteContext(routeInfo: Ref<{title: string}>, embed: boolean = false) {
-    const route = useRoute();
-
     function handleTitle(){
         if(!embed) {
             let baseTitle;
 
-            if (document.title.lastIndexOf("|") > 0) {
-                baseTitle = document.title.substring(document.title.lastIndexOf("|") + 1);
+            if (document.title.lastIndexOf("|") >= 0) {
+                baseTitle = document.title.substring(document.title.lastIndexOf("|") + 1).trim();
             } else {
                 baseTitle = document.title;
             }
 
-            document.title = routeInfo.value?.title + " | " + baseTitle;
+            document.title = (routeInfo.value?.title ?? "") + " | " + baseTitle;
         }
     }
 
-    watch(() => route, () => {
-        handleTitle()
-    }, {immediate: true})
+    watch(() => routeInfo.value?.title, handleTitle, {immediate: true});
 }

--- a/ui/src/mixins/routeContext.js
+++ b/ui/src/mixins/routeContext.js
@@ -18,8 +18,8 @@ export default {
             if(!this.embed) {
                 let baseTitle;
 
-                if (document.title.lastIndexOf("|") > 0) {
-                    baseTitle = document.title.substring(document.title.lastIndexOf("|") + 1);
+                if (document.title.lastIndexOf("|") >= 0) {
+                    baseTitle = document.title.substring(document.title.lastIndexOf("|") + 1).trim();
                 } else {
                     baseTitle = document.title;
                 }

--- a/ui/tests/unit/components/dashboard/Header.spec.ts
+++ b/ui/tests/unit/components/dashboard/Header.spec.ts
@@ -1,0 +1,39 @@
+import {describe, test, expect, beforeEach, vi} from "vitest";
+import {createI18n} from "vue-i18n";
+import {shallowMount} from "@vue/test-utils";
+
+vi.mock("vue-router", () => ({
+    useRoute: () => ({name: "home"}),
+}));
+
+vi.mock("override/stores/auth", () => ({
+    useAuthStore: () => ({user: {isAllowed: () => false}}),
+}));
+
+import Header from "../../../../src/components/dashboard/components/Header.vue";
+
+const i18n = createI18n({legacy: false, locale: "en", messages: {en: {overview: "Overview"}}, missingWarn: false, fallbackWarn: false});
+
+const setup = (dashboard: any) => {
+    return shallowMount(Header, {props: {dashboard}, global: {plugins: [i18n]}});
+};
+
+describe("dashboard Header.vue document title", () => {
+    beforeEach(() => {
+        document.title = "Kestra";
+    });
+
+    test("should fall back to 'Overview' when the dashboard title is an empty string", () => {
+        const wrapper = setup({id: "default", title: "", deleted: false, charts: []});
+
+        expect(document.title).toBe("Overview | Kestra");
+        wrapper.unmount();
+    });
+
+    test("should use the dashboard title once it is set", () => {
+        const wrapper = setup({id: "default", title: "Default Dashboard", deleted: false, charts: []});
+
+        expect(document.title).toBe("Default Dashboard | Kestra");
+        wrapper.unmount();
+    });
+});

--- a/ui/tests/unit/components/flows/FlowExecutions.spec.ts
+++ b/ui/tests/unit/components/flows/FlowExecutions.spec.ts
@@ -1,0 +1,37 @@
+import {describe, test, expect, vi} from "vitest";
+import {defineComponent, h} from "vue";
+import {shallowMount} from "@vue/test-utils";
+
+vi.mock("../../../../src/stores/flow", () => ({
+    useFlowStore: () => ({flow: {id: "my_flow", namespace: "company.team"}}),
+}));
+
+vi.mock("../../../../src/components/executions/Executions.vue", () => ({
+    default: defineComponent({
+        props: {embed: {type: Boolean, default: false}},
+        render: () => h("div"),
+    }),
+}));
+
+import FlowExecutions from "../../../../src/components/flows/FlowExecutions.vue";
+import Executions from "../../../../src/components/executions/Executions.vue";
+
+const setup = (embed?: boolean) => {
+    return shallowMount(FlowExecutions, {
+        props: embed === undefined ? {} : {embed},
+    });
+};
+
+describe("FlowExecutions.vue embed forwarding", () => {
+    test("should forward embed to Executions so it does not overwrite the flow title", () => {
+        const wrapper = setup(true);
+
+        expect(wrapper.findComponent(Executions).props("embed")).toBe(true);
+    });
+
+    test("should leave Executions standalone when embed is not set", () => {
+        const wrapper = setup();
+
+        expect(wrapper.findComponent(Executions).props("embed")).toBeFalsy();
+    });
+});

--- a/ui/tests/unit/components/namespaces/useHelpers.spec.ts
+++ b/ui/tests/unit/components/namespaces/useHelpers.spec.ts
@@ -1,0 +1,54 @@
+import {describe, test, expect, vi} from "vitest";
+import {defineComponent, h} from "vue";
+import {mount} from "@vue/test-utils";
+import {createI18n} from "vue-i18n";
+
+vi.mock("vue-router", () => ({
+    useRoute: () => ({params: {id: "company.team"}}),
+}));
+
+const {stub} = vi.hoisted(() => ({
+    stub: async () => {
+        const {defineComponent, h} = await import("vue");
+        return {default: defineComponent({render: () => h("div")})};
+    },
+}));
+
+vi.mock("../../../../src/components/flows/blueprints/BlueprintsBrowser.vue", stub);
+vi.mock("../../../../src/components/flows/Flows.vue", stub);
+vi.mock("../../../../src/components/executions/Executions.vue", stub);
+vi.mock("../../../../src/components/dependencies/Dependencies.vue", stub);
+vi.mock("../../../../src/components/namespaces/components/NamespaceFilesEditorView.vue", stub);
+vi.mock("../../../../src/components/namespaces/components/NamespaceOverview.vue", stub);
+
+import {useHelpers} from "../../../../src/components/namespaces/utils/useHelpers";
+
+const i18n = createI18n({legacy: false, locale: "en", messages: {en: {}}, missingWarn: false, fallbackWarn: false});
+
+const setup = () => {
+    let captured: ReturnType<typeof useHelpers>;
+    const wrapper = mount(defineComponent({
+        setup() {
+            captured = useHelpers();
+            return () => h("div");
+        },
+    }), {global: {plugins: [i18n]}});
+    wrapper.unmount();
+    return captured!;
+};
+
+describe("namespaces useHelpers embedded tabs", () => {
+    test("should pass embed to the flows tab so it does not overwrite the namespace title", () => {
+        const {tabs} = setup();
+        const flowsTab = tabs.find((tab) => tab.name === "flows");
+
+        expect(flowsTab?.props?.embed).toBe(true);
+    });
+
+    test("should pass embed to the executions tab so it does not overwrite the namespace title", () => {
+        const {tabs} = setup();
+        const executionsTab = tabs.find((tab) => tab.name === "executions");
+
+        expect(executionsTab?.props?.embed).toBe(true);
+    });
+});

--- a/ui/tests/unit/composables/useRouteContext.spec.ts
+++ b/ui/tests/unit/composables/useRouteContext.spec.ts
@@ -1,0 +1,60 @@
+import {describe, test, expect, afterEach, beforeEach} from "vitest";
+import {defineComponent, h, nextTick, ref, type Ref} from "vue";
+import {mount, VueWrapper} from "@vue/test-utils";
+
+import useRouteContext from "../../../src/composables/useRouteContext";
+
+const setup = (routeInfo: Ref<{title: string}>, embed = false) => {
+    return mount(defineComponent({
+        setup() {
+            useRouteContext(routeInfo, embed);
+        },
+        render: () => h("div")
+    }));
+};
+
+describe("useRouteContext", () => {
+    let wrapper: VueWrapper;
+
+    beforeEach(() => {
+        document.title = "Kestra";
+    });
+
+    afterEach(() => {
+        wrapper?.unmount();
+    });
+
+    test("should set the document title on mount", () => {
+        wrapper = setup(ref({title: "Flows"}));
+
+        expect(document.title).toBe("Flows | Kestra");
+    });
+
+    test("should update the document title when the route title changes after mount", async () => {
+        const routeInfo = ref({title: "Plugins"});
+        wrapper = setup(routeInfo);
+
+        routeInfo.value = {title: "io.kestra.plugin.core.log.Log"};
+        await nextTick();
+
+        expect(document.title).toBe("io.kestra.plugin.core.log.Log | Kestra");
+    });
+
+    test("should not accumulate whitespace across repeated title changes", async () => {
+        const routeInfo = ref({title: "First"});
+        wrapper = setup(routeInfo);
+
+        routeInfo.value = {title: "Second"};
+        await nextTick();
+        routeInfo.value = {title: "Third"};
+        await nextTick();
+
+        expect(document.title).toBe("Third | Kestra");
+    });
+
+    test("should leave the document title untouched when embedded", () => {
+        wrapper = setup(ref({title: "Flows"}), true);
+
+        expect(document.title).toBe("Kestra");
+    });
+});

--- a/ui/tests/unit/composables/useRouteContext.spec.ts
+++ b/ui/tests/unit/composables/useRouteContext.spec.ts
@@ -40,7 +40,7 @@ describe("useRouteContext", () => {
         expect(document.title).toBe("io.kestra.plugin.core.log.Log | Kestra");
     });
 
-    test("should not accumulate whitespace across repeated title changes", async () => {
+    test("should keep a single separator across repeated title changes", async () => {
         const routeInfo = ref({title: "First"});
         wrapper = setup(routeInfo);
 
@@ -50,6 +50,19 @@ describe("useRouteContext", () => {
         await nextTick();
 
         expect(document.title).toBe("Third | Kestra");
+    });
+
+    test("should not double the pipe when the base title starts with '|'", () => {
+        document.title = "| Kestra";
+        wrapper = setup(ref({title: "Default Dashboard"}));
+
+        expect(document.title).toBe("Default Dashboard | Kestra");
+    });
+
+    test("should not print 'undefined' when the route title is missing", () => {
+        wrapper = setup(ref({title: undefined as unknown as string}));
+
+        expect(document.title).toBe("| Kestra");
     });
 
     test("should leave the document title untouched when embedded", () => {


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Put the closing keyword on the first line so the link is visible without scrolling and survives squash merges: -->
Closes https://github.com/kestra-io/kestra/issues/18682

### ✨ Description

<!-- What does this PR change, from the user's point of view? Example: Replaces legacy scroll directive with the new API. -->
Backport of dc1b78e0f3 from the 2.0 line. Both pages built a routeInfo for the nav bar without passing it to useRouteContext, so nothing set the tab title. The composable also watched the route object rather than the title and kept the space after the separator, so the title latched at mount and the gap widened on every navigation.

### 🎨 Frontend Checklist

<!-- If this PR does not include any frontend changes, delete this entire section. All commands run from the `ui/` directory. -->

- [x] Type checking passes (`npm run check:types`)
- [x] Code builds without errors (`npm run build`)
- [x] Unit tests pass (`npm run test:unit`)
- [x] Translations are complete if `en.json` changed (`npm run translations:check` reports no missing, extra, or stale keys)
- [x] Screenshots or video recordings attached showing the `UI` changes


https://github.com/user-attachments/assets/31c48c5b-9ff7-4c92-941c-8f9701411858






