### PR TITLE
feat(topology): add run from task actions to flow editor task menu

### DIFF
--- a/ui/packages/topology/src/nodes/NodeMenu.vue
+++ b/ui/packages/topology/src/nodes/NodeMenu.vue
@@ -42,6 +42,7 @@
         tooltip?: string;
         danger?: boolean;
         divided?: boolean;
+        disabled?: boolean;
         onClick: () => void;
     }
 

--- a/ui/packages/topology/src/nodes/NodeMenuItem.vue
+++ b/ui/packages/topology/src/nodes/NodeMenuItem.vue
@@ -1,6 +1,7 @@
 <template>
     <KsDropdownItem
         :divided="action.divided"
+        :disabled="action.disabled"
         :icon="action.icon"
         :class="{'node-action--danger': action.danger}"
         @click="action.onClick()"

--- a/ui/packages/topology/src/nodes/TaskNode.vue
+++ b/ui/packages/topology/src/nodes/TaskNode.vue
@@ -182,8 +182,8 @@
         (event: typeof EVENTS.DELETE, data: any) :void;
         (event: typeof EVENTS.ADD_TASK, data: any) :void;
         (event: typeof EVENTS.SHOW_CONDITION, data: any) :void;
-        (event: typeof EVENTS.SHOW_DESCRIPTION, data: any) :void;
-        (event: typeof EVENTS.RUN_TASK, data: { task: any }) :void;
+        (event: typeof EVENTS.SHOW_DESCRIPTION, data: any): void;
+        (event: typeof EVENTS.RUN_TASK, data: { task: any; runDownstreamTasks?: boolean }) :void;
         (event: typeof EVENTS.SHOW_CUSTOM_ACTION, data: { task: any; customAction: CustomActionConfig }) :void;
         (event: typeof EVENTS.SHOW_DETAILS, data: { task: any; showDetails: ShowDetailsConfig }) :void;
     }>()
@@ -396,6 +396,22 @@
                 label: t("edit"),
                 icon: Pencil,
                 onClick: () => emit(EVENTS.EDIT, {task, section: SECTIONS.TASKS}),
+            })
+        }
+        if (!taskExecution.value && task) {
+            list.push({
+                key: "run-from-task",
+                label: t("playground.run_task_and_downstream"),
+                icon: PlayBoxMultiple,
+                disabled: !props.playgroundReadyToStart,
+                onClick: () => emit(EVENTS.RUN_TASK, {task, runDownstreamTasks: true}),
+            })
+            list.push({
+                key: "run-only-task",
+                label: t("playground.run_this_task"),
+                icon: PlayIcon,
+                disabled: !props.playgroundReadyToStart,
+                onClick: () => emit(EVENTS.RUN_TASK, {task, runDownstreamTasks: false}),
             })
         }
         if (actionConfig.value && task) {

--- a/ui/src/components/inputs/LowCodeEditor.vue
+++ b/ui/src/components/inputs/LowCodeEditor.vue
@@ -38,7 +38,7 @@
             @on-add-flowable-error="onAddFlowableError"
             @add-task="onCreateNewTask"
             @expand-subflow="expandSubflow"
-            @run-task="playgroundStore.runUntilTask($event.task.id)"
+            @run-task="playgroundStore.runUntilTask($event.task.id, Boolean($event.runDownstreamTasks))"
         >
             <template #taskDetails="taskProps">
                 <slot name="taskDetails" v-bind="taskProps">


### PR DESCRIPTION
### 🔗 Related Issue

Closes https://github.com/kestra-io/kestra/issues/18887

### Description

Adds **"Run task & downstream"** and **"Run this task"** actions to the task node context menu in the Flow Topology view.
This allows users to execute a workflow starting from any selected task during workflow editing, skipping upstream tasks or testing only an isolated task with downstream breakpoints.

- Supports `disabled` state on node menu actions when an execution is already running.
- Reuses existing design system components and localized translation keys across all 13 supported languages.

### 🎨 Frontend Checklist

- [x] Type checking passes (`npm run check:types`)
- [x] Code builds without errors (`npm run build`)
- [x] Unit tests pass (`npm run test:unit`)
- [x] Translations are complete if `en.json` changed (`npm run translations:check` reports no missing, extra, or stale keys)
