### PR TITLE
fix(logs): explicit cursor:pointer on the icon-only copy button

### DIFF
--- a/ui/src/components/layout/CopyToClipboard.vue
+++ b/ui/src/components/layout/CopyToClipboard.vue
@@ -39,5 +39,6 @@
     min-width: 2rem;
     height: 2rem;
     padding: 0;
+    cursor: pointer;
 }
 </style>


### PR DESCRIPTION
### 🔗 Related Issue

Closes https://github.com/kestra-io/kestra/issues/18910.

### ✨ Description

Follow-up to #19058, which fixed the execution error panel collapsing when clicking Copy by removing the redundant `@click` handler and `cursor: pointer` from the `KsAlert` wrapper (`#error`). In the PR discussion, @fdelbrayelle flagged that this also dropped the pointer cursor's *source*, without anyone confirming whether the Copy button itself still showed one.

It does — Element Plus sets `cursor: pointer` directly on `.kel-button`, which always wins over an ancestor's value, so the button was never actually affected. But that made it an implicit, undocumented dependency on Element Plus internals rather than something owned by the component. This PR makes it explicit on `.copy-icon-button` in `CopyToClipboard.vue`, the component that actually owns the button, so a future Element Plus/theme change can't silently regress it.

No behavior change — this is a defensive/explicit style, verified against a running instance before and after.

### 🎨 Frontend Checklist

- [x] Type checking passes (`npm run check:types`)
- [x] Code builds without errors (implicit via type-check)
- [x] Lint passes (`npx eslint` on the changed file)
- [ ] Unit tests pass (no test exercises this CSS-only property; not added per "when a test earns its place" — nothing here can fail for a behavioral reason)
- [x] Verified against a running instance: expanded the execution error panel, hovered the log line's Copy icon, and confirmed `getComputedStyle(button).cursor === "pointer"` both before and after the change, and that clicking Copy still keeps the panel expanded.

### 📝 Additional Notes

Single-line CSS change, no `:deep()`, no new tokens, no design-system violations (`git diff -U0 develop... -- '*.vue' '*.scss'` on this branch is empty besides the added line).