### PR TITLE
fix(assets): accept expressions and free-form types on output assets in the flow editor

### DIFF
--- a/core/src/main/java/io/kestra/core/docs/JsonSchemaGenerator.java
+++ b/core/src/main/java/io/kestra/core/docs/JsonSchemaGenerator.java
@@ -6,6 +6,7 @@ import java.time.LocalTime;
 import java.util.*;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
 import com.fasterxml.classmate.ResolvedType;
@@ -33,6 +34,7 @@ import io.kestra.core.models.annotations.Plugin;
 import io.kestra.core.models.annotations.PluginProperty;
 import io.kestra.core.models.assets.Asset;
 import io.kestra.core.models.assets.AssetExporter;
+import io.kestra.core.models.assets.Custom;
 import io.kestra.core.models.conditions.Condition;
 import io.kestra.core.models.conditions.ScheduleCondition;
 import io.kestra.core.models.dashboards.DataFilter;
@@ -77,6 +79,9 @@ public class JsonSchemaGenerator {
 
     private static final ObjectMapper YAML_MAPPER = JacksonMapper.ofYaml().copy()
         .configure(SerializationFeature.WRITE_DURATIONS_AS_TIMESTAMPS, false);
+
+    // A value holding a Pebble expression, accepted next to the literal format of an output asset property.
+    private static final String PEBBLE_EXPRESSION_PATTERN = ".*\\{\\{.*\\}\\}.*";
 
     private final PluginRegistry pluginRegistry;
 
@@ -467,6 +472,24 @@ public class JsonSchemaGenerator {
             }
         });
 
+        // The output assets of a task are declared through a Property<List<Asset>>: the whole declaration is rendered
+        // at runtime, so any asset property may hold a Pebble expression, as in `namespace: "{{ flow.namespace }}"`.
+        // Keep the format of a @Pattern-constrained property for literals, but accept an expression next to it.
+        builder.forFields().withInstanceAttributeOverride((memberAttributes, member, context) ->
+        {
+            if (!Asset.class.isAssignableFrom(member.getDeclaringType().getErasedType()) || !memberAttributes.has("pattern")) {
+                return;
+            }
+            ObjectNode literalBranch = context.getGeneratorConfig().createObjectNode();
+            literalBranch.set("pattern", memberAttributes.remove("pattern"));
+            ObjectNode expressionBranch = context.getGeneratorConfig().createObjectNode();
+            expressionBranch.put("pattern", PEBBLE_EXPRESSION_PATTERN);
+            ArrayNode anyOf = context.getGeneratorConfig().createArrayNode();
+            anyOf.add(literalBranch);
+            anyOf.add(expressionBranch);
+            memberAttributes.set("anyOf", anyOf);
+        });
+
         // Add Plugin annotation special docs
         builder.forTypesInGeneral()
             .withTypeAttributeOverride((collectedTypeAttributes, scope, context) ->
@@ -650,6 +673,16 @@ public class JsonSchemaGenerator {
             if (pluginAnnotation != null) {
                 ObjectNode properties = (ObjectNode) collectedTypeAttributes.get("properties");
                 if (properties != null) {
+                    if (pluginType == Custom.class) {
+                        // The free-form branch of the output assets: where every other plugin pins its type to a
+                        // constant, a custom asset keeps any type that no asset plugin provides.
+                        ObjectNode typeNode = properties.get("type") instanceof ObjectNode existing ? existing : properties.putObject("type");
+                        typeNode.put("type", "string");
+                        typeNode.put("title", "Custom asset type");
+                        typeNode.put("markdownDescription", "Any type that no asset plugin provides: the asset is stored with this type as is.");
+                        return;
+                    }
+
                     LinkedHashSet<String> allowedTypeValues = new LinkedHashSet<>();
                     allowedTypeValues.add(pluginType.getName());
 
@@ -862,11 +895,14 @@ public class JsonSchemaGenerator {
                     }
                 }).toList();
         } else if (declaredType.getErasedType() == Asset.class) {
-            return getRegisteredPlugins()
+            // Custom is what the asset deserializer falls back to for a type no asset plugin provides. It is hidden
+            // from the plugin registry, so it is added by hand as the free-form branch that lets such a type validate.
+            Stream<Class<? extends Asset>> registeredAssets = getRegisteredPlugins()
                 .stream()
                 .flatMap(registeredPlugin -> registeredPlugin.getAssets().stream())
                 .filter(p -> allowedPluginTypes.isEmpty() || allowedPluginTypes.contains(p.getName()))
-                .filter(Predicate.not(io.kestra.core.models.Plugin::isInternal))
+                .filter(Predicate.not(io.kestra.core.models.Plugin::isInternal));
+            return Stream.concat(registeredAssets, Stream.of(Custom.class))
                 .map(typeContext::resolve)
                 .toList();
         } else if (declaredType.getErasedType() == AssetExporter.class) {

--- a/core/src/test/java/io/kestra/core/docs/ClassPluginDocumentationTest.java
+++ b/core/src/test/java/io/kestra/core/docs/ClassPluginDocumentationTest.java
@@ -107,7 +107,8 @@ class ClassPluginDocumentationTest {
             PluginClassAndMetadata<AbstractTrigger> metadata = PluginClassAndMetadata.create(scan, Schedule.class, AbstractTrigger.class, null);
             ClassPluginDocumentation<? extends AbstractTrigger> doc = ClassPluginDocumentation.of(jsonSchemaGenerator, metadata, scan.version(), true);
 
-            assertThat(doc.getDefs()).hasSize(23);
+            // the assets declaration of the trigger base counts the custom asset, the free-form branch of assets.outputs
+            assertThat(doc.getDefs()).hasSize(24);
             assertThat(doc.getDocLicense()).isNull();
 
             assertThat(((Map<String, Object>) doc.getDefs().get("io.kestra.core.models.tasks.WorkerGroup")).get("type")).isEqualTo("object");
@@ -148,7 +149,7 @@ class ClassPluginDocumentationTest {
             ClassPluginDocumentation<? extends DynamicPropertyExampleTask> doc = ClassPluginDocumentation.of(jsonSchemaGenerator, metadata, scan.version(), true);
 
             assertThat(doc.getCls()).isEqualTo("io.kestra.core.models.property.DynamicPropertyExampleTask");
-            assertThat(doc.getDefs()).hasSize(9);
+            assertThat(doc.getDefs()).hasSize(10);
             Map<String, Object> properties = (Map<String, Object>) doc.getPropertiesSchema().get("properties");
             assertThat(properties).hasSize(23);
 

--- a/core/src/test/java/io/kestra/core/docs/JsonSchemaGeneratorTest.java
+++ b/core/src/test/java/io/kestra/core/docs/JsonSchemaGeneratorTest.java
@@ -16,6 +16,8 @@ import io.kestra.core.junit.annotations.KestraTest;
 import io.kestra.core.models.annotations.Example;
 import io.kestra.core.models.annotations.Plugin;
 import io.kestra.core.models.annotations.PluginProperty;
+import io.kestra.core.models.assets.Custom;
+import io.kestra.core.models.assets.External;
 import io.kestra.core.models.dashboards.Dashboard;
 import io.kestra.core.models.dashboards.GraphStyle;
 import io.kestra.core.models.enums.MonacoLanguages;
@@ -76,6 +78,35 @@ class JsonSchemaGeneratorTest {
 
         generate = jsonSchemaGenerator.outputs(Task.class, cls);
         assertThat(((Map<String, Map<String, Object>>) generate.get("properties")).size(), is(1));
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    void outputAssetsAcceptExpressionsAndFreeFormTypes() throws URISyntaxException {
+        Helpers.runApplicationContext((applicationContext) ->
+        {
+            JsonSchemaGenerator jsonSchemaGenerator = applicationContext.getBean(JsonSchemaGenerator.class);
+            Map<String, Object> generate = jsonSchemaGenerator.schemas(Flow.class);
+            var definitions = (Map<String, Map<String, Object>>) generate.get("definitions");
+
+            // an asset type provided by a plugin keeps its constant, which is what the editor autocompletes
+            var external = properties(definitions.get(External.class.getName()));
+            assertThat(external.get("type").get("const"), is(External.class.getName()));
+            // the whole assets.outputs declaration is rendered at runtime, so an expression is as valid as a literal
+            for (String property : List.of("namespace", "id")) {
+                var branches = (List<Map<String, Object>>) external.get(property).get("anyOf");
+                assertThat(external.get(property), not(hasKey("pattern")));
+                assertThat(branches.stream().map(branch -> (String) branch.get("pattern")).toList(), hasItem(containsString("\\{\\{")));
+                assertThat(branches.size(), is(2));
+            }
+
+            // the custom asset is the free-form branch of assets.outputs, so its type stays an open string
+            var items = map(map(properties(definitions.get("io.kestra.core.models.assets.AssetsDeclaration")).get("outputs")).get("items"));
+            assertThat(items.toString(), containsString(Custom.class.getName()));
+            var customType = properties(definitions.get(Custom.class.getName())).get("type");
+            assertThat(customType.get("type"), is("string"));
+            assertThat(customType, not(hasKey("const")));
+        });
     }
 
     @SuppressWarnings("unchecked")
@@ -375,7 +406,8 @@ class JsonSchemaGeneratorTest {
     void pluginSchemaShouldNotResolveTaskAndTriggerSubtypes() {
         Map<String, Object> generate = jsonSchemaGenerator.properties(null, TaskWithSubTaskAndSubTrigger.class);
         var definitions = (Map<String, Map<String, Object>>) generate.get("$defs");
-        assertThat(definitions.size(), is(30));
+        // the assets declaration of the task base counts the custom asset, the free-form branch of assets.outputs
+        assertThat(definitions.size(), is(31));
     }
 
     @SuppressWarnings("unchecked")

--- a/core/src/test/java/io/kestra/core/plugins/AdditionalPluginTest.java
+++ b/core/src/test/java/io/kestra/core/plugins/AdditionalPluginTest.java
@@ -44,7 +44,8 @@ class AdditionalPluginTest {
     void shouldResolveAdditionalPluginSubtypes() {
         Map<String, Object> generate = jsonSchemaGenerator.properties(null, AdditionalPluginTest.AdditionalPluginTestTask.class);
         var definitions = (Map<String, Map<String, Object>>) generate.get("$defs");
-        assertThat(definitions).hasSize(10);
+        // the assets declaration of the task base counts the custom asset, the free-form branch of assets.outputs
+        assertThat(definitions).hasSize(11);
         assertThat(definitions).containsKey("io.kestra.core.plugins.AdditionalPluginTest-AdditionalPluginTest1");
         assertThat(definitions).containsKey("io.kestra.core.plugins.AdditionalPluginTest-AdditionalPluginTest2");
     }


### PR DESCRIPTION
Closes https://github.com/kestra-io/kestra-ee/issues/6508.
Related to https://github.com/kestra-io/kestra/pull/19310 (the same fix on `develop`, ported here to `releases/v1.3.x`).

## What

The flow editor underlined two valid things in an `assets.outputs` declaration:

- `namespace: "{{ flow.namespace }}"` - the flow schema copied the literal format of an asset `namespace` and `id` (`^[a-z0-9][a-z0-9._-]*`) as is, so a Pebble expression failed the pattern. The whole `assets.outputs` declaration is a `Property<List<Asset>>` rendered at runtime, and the docs recommend exactly this form.
- a free-form `type` - the schema only offered the asset types provided by plugins, each pinned to a `const`, so any other type was flagged. `Custom`, the class `AssetDeserializer` falls back to for such a type, is `@Hidden`, hence skipped by `PluginScanner` and absent from the schema, while the docs document free-form types as supported.

## How

`JsonSchemaGenerator` only, no `EE` change needed (the `EE` generator inherits the `Asset` branch):

- on `Asset` properties carrying a `pattern`, the pattern becomes an `anyOf` of the literal format and a Pebble-expression pattern: a literal is still held to its format, an expression is accepted. This is schema-side only, the `@Pattern` bean validation behind the assets `API` is untouched.
- `Custom` is added by hand to the `Asset` subtypes of the schema as the free-form branch, with its `type` left as an open string instead of a `const`. The plugin-provided types keep their `const`, so autocompletion is unchanged.

Manual port of the `develop` commit: the generator code is the same, but the regression test asserts on the generated schema structure instead of validating a flow against it, because the `json-schema-validator` dependency the `develop` test relies on is not on the 1.3 classpath.

## Screenshots

Captured on an `OSS` `develop` instance, so the only asset type available is `External` and the free-form type stands in for `io.kestra.plugin.ee.assets.Table`. The `1 Error(s)` badge on both captures is the `OSS` server-side validation (`assets` are `EE` only), unrelated to the editor markers.

Before:

![before](https://raw.githubusercontent.com/MilosPaunovic/kestra/c25f5de9f7dbbac1ab9322bce7bd4bf342293734/6508/before.png)

After:

![after](https://raw.githubusercontent.com/MilosPaunovic/kestra/c25f5de9f7dbbac1ab9322bce7bd4bf342293734/6508/after.png)