### PR TITLE
fix(design-system): drop the trailing comma that makes the manifest unparseable

### DIFF
--- a/ui/packages/design-system/package.json
+++ b/ui/packages/design-system/package.json
@@ -39,7 +39,7 @@
     "test:unit": "vitest run --config vitest.unit.config.ts",
     "test:unit:watch": "vitest",
     "test:storybook": "vitest run --config vitest.config.ts --project 'storybook:*'",
-    "generate:palette": "node scripts/generate-palette.mjs",
+    "generate:palette": "node scripts/generate-palette.mjs"
   },
   "peerDependencies": {
     "@vueuse/core": ">=11.0.0",


### PR DESCRIPTION
Removing the back-compat script aliases while merging https://github.com/kestra-io/kestra/pull/19257 (commit `6839fe3a7e`) left the comma behind:

```json
    "generate:palette": "node scripts/generate-palette.mjs",
  },
```

`ui/packages/design-system/package.json` is therefore not valid JSON. npm cannot read the workspace manifest, and the failure surfaces as a misleading `npm error code EUSAGE — The npm ci command can only install with an existing package-lock.json`, even though `ui/package-lock.json` is present and intact. Every pull request on `releases/v2.0.x` fails at its npm install step: `Build Artifacts`, `Frontend - Tests` and `Frontend - Design System tests` all die within ~25s.

Reproduced by bisecting the branch locally:

| commit | `npm ci` in `ui/` |
| --- | --- |
| `495cfda485` (before #19257) | `added 1457 packages` |
| `6887c66b51` (#19257 merge) | `EUSAGE`, no lockfile |
| this PR | `added 1457 packages` |

Only the comma is removed — the aliases stay deleted, which is what #19257 intended and matches https://github.com/kestra-io/kestra/pull/19212 on `develop`. Nothing in this repository, in `kestra-ee`, or in the shared `kestra-io/actions` workflows calls the removed names.