### PR TITLE
fix(executions): unify webhook 404 so flow existence isn't leaked

### DIFF
--- a/core/src/test/resources/flows/valids/webhook-flow-disabled.yaml
+++ b/core/src/test/resources/flows/valids/webhook-flow-disabled.yaml
@@ -1,0 +1,13 @@
+id: webhook-flow-disabled
+namespace: io.kestra.tests
+disabled: true
+
+tasks:
+  - id: out
+    type: io.kestra.plugin.core.debug.Return
+    format: "{{trigger | json }}"
+
+triggers:
+  - id: webhook
+    type: io.kestra.plugin.core.trigger.Webhook
+    key: webhook-flow-disabled-key

--- a/webserver/src/main/java/io/kestra/webserver/controllers/api/ExecutionController.java
+++ b/webserver/src/main/java/io/kestra/webserver/controllers/api/ExecutionController.java
@@ -602,8 +602,19 @@ public class ExecutionController {
         String key,
         String path,
         HttpRequest<String> request) throws IllegalVariableEvaluationException {
-        Optional<Flow> find = flowRepository.findById(tenantService.resolveTenant(), namespace, id);
-        return webhook(find, key, path, request);
+        return webhook(findFlowForWebhook(namespace, id), key, path, request);
+    }
+
+    /**
+     * The response the caller sees never says whether the flow was absent (GHSA-6wcq-4vx6-rx53); this is
+     * where that distinction is still recorded, for whoever operates the instance.
+     */
+    private Optional<Flow> findFlowForWebhook(String namespace, String id) {
+        Optional<Flow> maybeFlow = flowRepository.findById(tenantService.resolveTenant(), namespace, id);
+        if (maybeFlow.isEmpty()) {
+            log.debug("Rejected a webhook call: no flow '{}.{}' found.", namespace, id);
+        }
+        return maybeFlow;
     }
 
     protected Mono<HttpResponse<?>> webhook(
@@ -611,44 +622,9 @@ public class ExecutionController {
         String key,
         String path,
         HttpRequest<String> request) throws IllegalVariableEvaluationException {
-        if (maybeFlow.isEmpty()) {
-            throw new HttpStatusException(HttpStatus.NOT_FOUND, "Flow not found");
-        }
-
-        var flow = maybeFlow.get();
-        if (flow.isDisabled()) {
-            throw new IllegalStateException("Cannot execute a disabled flow");
-        }
-        if (flow instanceof FlowWithException fwe) {
-            throw new IllegalStateException("Cannot execute an invalid flow: " + fwe.getException());
-        }
-
-        Optional<AbstractWebhookTrigger> maybeWebhook = (flow.getTriggers() == null ? new ArrayList<AbstractTrigger>()
-            : flow
-                .getTriggers())
-            .stream()
-            .filter(o -> o instanceof AbstractWebhookTrigger)
-            .map(o -> (AbstractWebhookTrigger) o)
-            .filter(w ->
-            {
-                RunContext runContext = runContextFactory.of(flow, w);
-                try {
-                    String webhookKey = runContext.render(w.getKey()).trim();
-                    // compare via MessageDigest.isEqual to prevent timing attacks
-                    return MessageDigest.isEqual(webhookKey.getBytes(StandardCharsets.UTF_8), key.getBytes(StandardCharsets.UTF_8));
-                } catch (IllegalVariableEvaluationException e) {
-                    // be conservative, don't crash but filter the webhook
-                    log.warn("Unable to render the webhook key {}, the webhook will be ignored", key, e);
-                    return false;
-                }
-            })
-            .findFirst();
-
-        if (maybeWebhook.isEmpty()) {
-            throw new HttpStatusException(HttpStatus.NOT_FOUND, "Webhook not found");
-        }
-
-        final AbstractWebhookTrigger webhook = maybeWebhook.get();
+        Flow flow = maybeFlow.orElseThrow(ExecutionController::webhookNotFound);
+        final AbstractWebhookTrigger webhook = findWebhook(flow, key);
+        ensureExecutable(flow);
 
         // Webhook context
         var webhookContext = new WebhookContext(
@@ -684,6 +660,55 @@ public class ExecutionController {
 
             return Mono.just(HttpResponse.status(HttpStatus.INTERNAL_SERVER_ERROR));
         }
+    }
+
+    /**
+     * @throws IllegalStateException if the flow cannot be executed
+     */
+    private static void ensureExecutable(Flow flow) {
+        if (flow.isDisabled()) {
+            throw new IllegalStateException("Cannot execute a disabled flow");
+        }
+        if (flow instanceof FlowWithException fwe) {
+            throw new IllegalStateException("Cannot execute an invalid flow: " + fwe.getException());
+        }
+    }
+
+    private static HttpStatusException webhookNotFound() {
+        return new HttpStatusException(HttpStatus.NOT_FOUND, "Webhook not found");
+    }
+
+    /**
+     * @return the webhook trigger of the flow the given key matches
+     * @throws HttpStatusException if no webhook trigger matches the key
+     */
+    private AbstractWebhookTrigger findWebhook(Flow flow, String key) {
+        return (flow.getTriggers() == null ? new ArrayList<AbstractTrigger>()
+            : flow
+                .getTriggers())
+            .stream()
+            .filter(o -> o instanceof AbstractWebhookTrigger)
+            .map(o -> (AbstractWebhookTrigger) o)
+            .filter(w ->
+            {
+                RunContext runContext = runContextFactory.of(flow, w);
+                try {
+                    String webhookKey = runContext.render(w.getKey()).trim();
+                    // compare via MessageDigest.isEqual to prevent timing attacks
+                    return MessageDigest.isEqual(webhookKey.getBytes(StandardCharsets.UTF_8), key.getBytes(StandardCharsets.UTF_8));
+                } catch (IllegalVariableEvaluationException e) {
+                    // Neither key is logged: `w.getKey()` is the trigger's own secret, and the caller-supplied
+                    // one is attacker-controlled on this anonymous route and reachable on every call to this
+                    // flow regardless of what it guesses.
+                    log.warn("Unable to render the key of webhook trigger '{}' on flow '{}.{}', the webhook will be ignored.", w.getId(), flow.getNamespace(), flow.getId(), e);
+                    return false;
+                }
+            })
+            .findFirst()
+            .orElseThrow(() -> {
+                log.debug("Rejected a webhook call: no trigger on flow '{}.{}' matches the given key.", flow.getNamespace(), flow.getId());
+                return webhookNotFound();
+            });
     }
 
     @ExecuteOn(TaskExecutors.IO)

--- a/webserver/src/test/java/io/kestra/webserver/controllers/api/ExecutionControllerTest.java
+++ b/webserver/src/test/java/io/kestra/webserver/controllers/api/ExecutionControllerTest.java
@@ -135,7 +135,7 @@ class ExecutionControllerTest {
             )
         );
         assertThat(exception.getStatus().getCode()).isEqualTo(HttpStatus.NOT_FOUND.getCode());
-        assertThat(exception.getMessage()).contains("Not Found: Flow not found");
+        assertThat(exception.getMessage()).contains("Not Found: Webhook not found");
 
         exception = assertThrows(
             HttpClientResponseException.class,
@@ -149,7 +149,7 @@ class ExecutionControllerTest {
             )
         );
         assertThat(exception.getStatus().getCode()).isEqualTo(HttpStatus.NOT_FOUND.getCode());
-        assertThat(exception.getMessage()).contains("Not Found: Flow not found");
+        assertThat(exception.getMessage()).contains("Not Found: Webhook not found");
 
         exception = assertThrows(
             HttpClientResponseException.class,
@@ -163,7 +163,7 @@ class ExecutionControllerTest {
             )
         );
         assertThat(exception.getStatus().getCode()).isEqualTo(HttpStatus.NOT_FOUND.getCode());
-        assertThat(exception.getMessage()).contains("Not Found: Flow not found");
+        assertThat(exception.getMessage()).contains("Not Found: Webhook not found");
 
         exception = assertThrows(
             HttpClientResponseException.class,
@@ -173,7 +173,7 @@ class ExecutionControllerTest {
             )
         );
         assertThat(exception.getStatus().getCode()).isEqualTo(HttpStatus.NOT_FOUND.getCode());
-        assertThat(exception.getMessage()).contains("Not Found: Flow not found");
+        assertThat(exception.getMessage()).contains("Not Found: Webhook not found");
 
         exception = assertThrows(
             HttpClientResponseException.class,
@@ -187,7 +187,7 @@ class ExecutionControllerTest {
             )
         );
         assertThat(exception.getStatus().getCode()).isEqualTo(HttpStatus.NOT_FOUND.getCode());
-        assertThat(exception.getMessage()).contains("Not Found: Flow not found");
+        assertThat(exception.getMessage()).contains("Not Found: Webhook not found");
     }
 
     @Test

--- a/webserver/src/test/java/io/kestra/webserver/controllers/api/WebhookRoutingTest.java
+++ b/webserver/src/test/java/io/kestra/webserver/controllers/api/WebhookRoutingTest.java
@@ -1,5 +1,7 @@
 package io.kestra.webserver.controllers.api;
 
+import java.util.List;
+
 import org.junit.jupiter.api.Test;
 
 import io.kestra.core.junit.annotations.KestraTest;
@@ -150,61 +152,69 @@ public class WebhookRoutingTest {
         assertThat((Object) response.getStatus()).isEqualTo(HttpStatus.OK);
     }
 
+    /**
+     * A caller without the correct key must not be able to tell a wrong key on a real flow apart from a
+     * flow, namespace or trigger that does not exist at all: the webhook route is anonymous by design, so
+     * any distinguishable response is an enumeration oracle (GHSA-6wcq-4vx6-rx53).
+     */
     @Test
-    @LoadFlows(value = { "flows/valids/webhook-routing-test.yaml" })
-    void webhookInvalidKey() {
-        // Test that wrong key returns 404
-        HttpClientResponseException exception = assertThrows(
+    @LoadFlows(value = { "flows/valids/webhook-routing-test.yaml", "flows/valids/webhook-flow-disabled.yaml" })
+    void webhookWithoutTheCorrectKeyIsIndistinguishableFromANonExistentWebhook() {
+        HttpClientResponseException wrongKeyOnExistingFlow = assertThrows(
             HttpClientResponseException.class,
             () -> client.toBlocking().exchange(
-                POST(
-                    "/api/v1/main/executions/webhook/" + TESTS_FLOW_NS + "/webhook-routing-test/wrongkey",
-                    "{\"test\": \"data\"}"
-                ),
+                POST("/api/v1/main/executions/webhook/" + TESTS_FLOW_NS + "/webhook-routing-test/wrongkey", "{\"test\": \"data\"}"),
+                String.class
+            )
+        );
+        assertThat((Object) wrongKeyOnExistingFlow.getStatus()).isEqualTo(HttpStatus.NOT_FOUND);
+        assertThat(wrongKeyOnExistingFlow.getMessage()).contains("Webhook not found");
+
+        HttpClientResponseException nonExistentFlow = assertThrows(
+            HttpClientResponseException.class,
+            () -> client.toBlocking().exchange(
+                POST("/api/v1/main/executions/webhook/" + TESTS_FLOW_NS + "/nonexistent-flow/testkey", "{\"test\": \"data\"}"),
+                String.class
+            )
+        );
+        HttpClientResponseException nonExistentNamespace = assertThrows(
+            HttpClientResponseException.class,
+            () -> client.toBlocking().exchange(
+                POST("/api/v1/main/executions/webhook/invalid.namespace/webhook-routing-test/testkey", "{\"test\": \"data\"}"),
+                String.class
+            )
+        );
+        HttpClientResponseException wrongKeyOnDisabledFlow = assertThrows(
+            HttpClientResponseException.class,
+            () -> client.toBlocking().exchange(
+                POST("/api/v1/main/executions/webhook/" + TESTS_FLOW_NS + "/webhook-flow-disabled/wrongkey", "{\"test\": \"data\"}"),
                 String.class
             )
         );
 
-        assertThat((Object) exception.getStatus()).isEqualTo(HttpStatus.NOT_FOUND);
-        assertThat(exception.getMessage()).contains("Webhook not found");
+        for (HttpClientResponseException other : List.of(nonExistentFlow, nonExistentNamespace, wrongKeyOnDisabledFlow)) {
+            assertThat((Object) other.getStatus()).isEqualTo(HttpStatus.NOT_FOUND);
+            assertThat(other.getMessage()).isEqualTo(wrongKeyOnExistingFlow.getMessage());
+        }
     }
 
+    /**
+     * The reorder that closes the oracle above must not weaken the disabled-flow check for a caller who
+     * does know the key: it is only deferred past the key match, not removed.
+     */
     @Test
-    @LoadFlows(value = { "flows/valids/webhook-routing-test.yaml" })
-    void webhookInvalidFlow() {
-        // Test that wrong flow returns 404
+    @LoadFlows(value = { "flows/valids/webhook-flow-disabled.yaml" })
+    void webhookWithTheCorrectKeyOnADisabledFlowStillReturnsConflict() {
         HttpClientResponseException exception = assertThrows(
             HttpClientResponseException.class,
             () -> client.toBlocking().exchange(
-                POST(
-                    "/api/v1/main/executions/webhook/" + TESTS_FLOW_NS + "/nonexistent-flow/testkey",
-                    "{\"test\": \"data\"}"
-                ),
+                POST("/api/v1/main/executions/webhook/" + TESTS_FLOW_NS + "/webhook-flow-disabled/webhook-flow-disabled-key", "{\"test\": \"data\"}"),
                 String.class
             )
         );
 
-        assertThat((Object) exception.getStatus()).isEqualTo(HttpStatus.NOT_FOUND);
-        assertThat(exception.getMessage()).contains("Flow not found");
-    }
-
-    @Test
-    @LoadFlows(value = { "flows/valids/webhook-routing-test.yaml" })
-    void webhookInvalidNamespace() {
-        // Test that wrong namespace returns 404
-        HttpClientResponseException exception = assertThrows(
-            HttpClientResponseException.class,
-            () -> client.toBlocking().exchange(
-                POST(
-                    "/api/v1/main/executions/webhook/invalid.namespace/webhook-routing-test/testkey",
-                    "{\"test\": \"data\"}"
-                ),
-                String.class
-            )
-        );
-
-        assertThat((Object) exception.getStatus()).isEqualTo(HttpStatus.NOT_FOUND);
-        assertThat(exception.getMessage()).contains("Flow not found");
+        assertThat((Object) exception.getStatus()).isEqualTo(HttpStatus.CONFLICT);
+        assertThat(exception.getMessage()).contains("Cannot execute a disabled flow");
     }
 
     @Test


### PR DESCRIPTION
## Problem

Backport of the fix for [GHSA-6wcq-4vx6-rx53](https://github.com/kestra-io/kestra/security/advisories/GHSA-6wcq-4vx6-rx53)
to `releases/v1.3.x` (already merged into `develop`).

The webhook trigger endpoint (`GET|POST|PUT /api/v1/{tenant}/executions/webhook/{namespace}/{id}/{key}`)
is anonymous by design — the key is the only secret guarding it. Before checking the key it answered
a bad flow/namespace, a disabled flow and an invalid flow each with a different message and status:

| Condition (reachable with no key) | Response before this fix |
|---|---|
| flow absent or namespace absent | `404 "Flow not found"` |
| flow present but disabled | `409 "Cannot execute a disabled flow"` |
| flow present but unparseable | `409 "Cannot execute an invalid flow: <parse error>"` |
| flow present, key wrong or absent | `404 "Webhook not found"` |

An unauthenticated caller could use this as an oracle to enumerate the instance's whole namespace/flow
inventory with a wordlist, then focus key-guessing on flows that actually exist.

## Fix

`webhook(Optional<Flow>, ...)` in `ExecutionController` now enforces **presence → key match →
executability**. Every failure reachable without the correct key returns the identical
`404 "Webhook not found"`. The disabled/invalid-flow check moved past the key match, so a caller who
has proven they know the key still gets the precise reason (still `409`, via `IllegalStateException`
on this branch). A legitimate caller hitting an unparseable flow now gets the generic 404 too —
unavoidable, since such a flow has no parsed triggers and its key can never be proven.

Since the response can no longer say which branch failed, the real cause is now recorded server-side
at `DEBUG` (never returned to the caller, and never logging either key):
- absent flow → `"Rejected a webhook call: no flow '{}.{}' found."`
- key mismatch → `"Rejected a webhook call: no trigger on flow '{}.{}' matches the given key."`

Also fixed in the same pass: the pre-existing render-failure log line named the *caller-supplied*
guess as "the webhook key" that failed to render, when the actual failure is in the *trigger's own*
key template — and it printed that attacker-controlled value from this anonymous route on every call
against the flow. It now names the trigger and flow instead, and logs neither key.

This branch has a simpler, single-method webhook handler than `develop` (no separate multipart
variant, no `onWebhookMatched` governance hook, `MessageDigest.isEqual` inline rather than
`AuthUtils.constantTimeEquals`), so the backport is adapted to that shape rather than a direct
cherry-pick.

## Evidence

`./gradlew :webserver:test --tests "WebhookRoutingTest" --tests "ExecutionControllerTest" --tests
"ExecutionControllerRunnerTest" --tests "WebhookPluginTest" --tests "AuthenticationFilterTest"` — 136
passing, no regressions.

## Test plan

- [x] `WebhookRoutingTest#webhookWithoutTheCorrectKeyIsIndistinguishableFromANonExistentWebhook` —
      new: wrong key on an existing flow, unknown flow, unknown namespace, and wrong key on a
      disabled flow all produce the identical status + message.
- [x] `WebhookRoutingTest#webhookWithTheCorrectKeyOnADisabledFlowStillReturnsConflict` — new
      regression guard: the reorder must not weaken the disabled-flow check for a caller who does
      know the key.
- [x] `ExecutionControllerTest#webhookFlowNotFound` — updated to assert the unified message.