### PR TITLE
test(triggers): compile the backfill end-date test against the renamed trigger lookup

### DIFF
--- a/webserver/src/test/java/io/kestra/webserver/controllers/api/TriggerControllerTest.java
+++ b/webserver/src/test/java/io/kestra/webserver/controllers/api/TriggerControllerTest.java
@@ -774,7 +774,7 @@ class TriggerControllerTest {
         flowService.create(GenericFlow.of(flow));
         TriggerState trigger = createTriggerFromFlow(flow, false);
         Awaitility.await().atMost(Duration.ofSeconds(30)).pollInterval(Duration.ofMillis(100))
-            .until(() -> jdbcTriggerRepository.findById(trigger).isPresent());
+            .until(() -> jdbcTriggerRepository.findByIdWithoutAcl(trigger).isPresent());
 
         ZonedDateTime start = ZonedDateTime.parse("2026-06-10T00:00:00Z");
 
@@ -805,7 +805,7 @@ class TriggerControllerTest {
                 );
         }
 
-        assertThat(jdbcTriggerRepository.findById(trigger).orElseThrow().getBackfill()).isNull();
+        assertThat(jdbcTriggerRepository.findByIdWithoutAcl(trigger).orElseThrow().getBackfill()).isNull();
     }
 
     @Test


### PR DESCRIPTION
Related to https://github.com/kestra-io/kestra/pull/19097.
Related to https://github.com/kestra-io/kestra/pull/18944.

## What

`develop` does not compile its `webserver` tests since https://github.com/kestra-io/kestra/pull/19097 merged: its new `TriggerControllerTest.shouldReturnUnprocessableEntityWhenCreatingBackfillWithEndNotAfterStart` calls `jdbcTriggerRepository.findById(trigger)`, a method that https://github.com/kestra-io/kestra/pull/18944 had already renamed to `findByIdWithoutAcl` (the `PR` branch predated the rename and was merged without a rebase). Every `Backend - Tests` job on `develop` and on open `PRs` fails with `cannot find symbol: method findById(TriggerState)`, for example https://github.com/kestra-io/kestra/actions/runs/34460537621.

## How

The two calls now use `findByIdWithoutAcl`, as every other lookup in the same test class does. Verified locally: `webserver:compileTestJava` passes and the backfill end-date test is green.