### PR TITLE
fix(core): never let the plugin auto-install migration stop the server

### DIFF
--- a/jdbc/src/main/java/io/kestra/jdbc/migration/V2_0_11PluginAutoInstallMigration.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/migration/V2_0_11PluginAutoInstallMigration.java
@@ -25,7 +25,8 @@ import lombok.extern.slf4j.Slf4j;
  * 1.3 → 2.0 first-sync migration: crawls the latest non-deleted revision of every flow, aggregates
  * the task/trigger types missing from the local plugin registry and bulk-installs their artifacts,
  * so an instance upgraded to a slim distribution does not fail every pre-existing flow.
- * Best-effort with a bounded wait: a failure is logged and never fails the startup.
+ * Best-effort with a bounded wait: a failure is logged and never fails the startup — see
+ * {@link #migrate()}.
  */
 @Slf4j
 @Singleton
@@ -69,26 +70,45 @@ public class V2_0_11PluginAutoInstallMigration implements MigrationScript {
         return null;
     }
 
+    /**
+     * Never throws — installing plugins is a convenience and must not be able to stop Kestra from
+     * starting. The guard covers the whole body, {@code autoInstallService.get()} included: that
+     * provider transitively pulls in a repository and therefore the queue, so a misconfigured queue
+     * used to abort {@code ApplicationContext.start()} from here — and {@code kestra migrate run} /
+     * {@code migrate plan} with it — reporting an unrelated queue error as a failed migration.
+     */
     @Override
-    public void migrate() throws Exception {
-        PluginAutoInstallService service = autoInstallService.get();
-        if (!service.isEnabled()) {
-            log.info("Plugin auto-install is disabled, skipping the first-sync plugin crawl.");
-            return;
+    public void migrate() {
+        try {
+            PluginAutoInstallService service = autoInstallService.get();
+            if (!service.isEnabled()) {
+                log.info("Plugin auto-install is disabled, skipping the first-sync plugin crawl.");
+                return;
+            }
+
+            // Migrations run before AbstractCommand.maybeInitPlugins() registers the external plugins
+            // directory — without this, every already-installed plugin would be re-downloaded.
+            registerExternalPluginsDirectory();
+
+            Set<String> missingTypes = findMissingTypesInAllFlows();
+            if (missingTypes.isEmpty()) {
+                log.info("All plugin types referenced by existing flows are available, nothing to install.");
+                return;
+            }
+
+            log.info("Detected {} plugin types referenced by existing flows but missing from the local registry: {}.", missingTypes.size(), missingTypes);
+            service.installMissingTypes(missingTypes);
+        } catch (Exception e) {
+            // The script is still recorded as applied, so startup is not retried into the same
+            // failure. Missing plugins are installed on the next flow save anyway, and can be
+            // installed by hand at any time.
+            log.warn(
+                "Skipping the first-sync plugin crawl: {}. Existing flows may reference plugins that are "
+                    + "not installed locally — install them manually if a flow fails to load.",
+                e.getMessage(),
+                e
+            );
         }
-
-        // Migrations run before AbstractCommand.maybeInitPlugins() registers the external plugins
-        // directory — without this, every already-installed plugin would be re-downloaded.
-        registerExternalPluginsDirectory();
-
-        Set<String> missingTypes = findMissingTypesInAllFlows();
-        if (missingTypes.isEmpty()) {
-            log.info("All plugin types referenced by existing flows are available, nothing to install.");
-            return;
-        }
-
-        log.info("Detected {} plugin types referenced by existing flows but missing from the local registry: {}.", missingTypes.size(), missingTypes);
-        service.installMissingTypes(missingTypes);
     }
 
     private void registerExternalPluginsDirectory() {

--- a/jdbc/src/test/java/io/kestra/jdbc/migration/V2_0_11PluginAutoInstallMigrationTest.java
+++ b/jdbc/src/test/java/io/kestra/jdbc/migration/V2_0_11PluginAutoInstallMigrationTest.java
@@ -18,8 +18,10 @@ import io.kestra.core.plugins.PluginRegistry;
 import io.kestra.jdbc.JooqDSLContextWrapper;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anySet;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -139,6 +141,49 @@ class V2_0_11PluginAutoInstallMigrationTest {
         migration.migrate();
 
         // Then
+        verify(autoInstallService, never()).installMissingTypes(anySet());
+    }
+
+    @Test
+    void shouldNotFailWhenTheServiceCannotBeResolved() {
+        // Given — resolving PluginAutoInstallService transitively pulls in a repository and therefore
+        // the queue, so a misconfigured queue fails right here. That must not abort the migration, and
+        // with it startup and `kestra migrate run`. Regression test for kestra-ee#7547.
+        insertFlowRow(null, "flow-a", 1, false, "source-a-rev1");
+        migration = new V2_0_11PluginAutoInstallMigration(
+            dslContextWrapper,
+            () ->
+            {
+                throw new IllegalStateException("Unable to connect to redis/<unresolved>:6379");
+            },
+            () -> mock(PluginRegistry.class)
+        );
+
+        // When / Then
+        assertThatCode(() -> migration.migrate()).doesNotThrowAnyException();
+    }
+
+    @Test
+    void shouldNotFailWhenTheInstallFails() {
+        // Given
+        insertFlowRow(null, "flow-a", 1, false, "source-a-rev1");
+        when(autoInstallService.isEnabled()).thenReturn(true);
+        when(autoInstallService.findMissingTypes("source-a-rev1")).thenReturn(Set.of("io.kestra.plugin.a.TaskA"));
+        doThrow(new RuntimeException("plugin repository unreachable"))
+            .when(autoInstallService).installMissingTypes(anySet());
+
+        // When / Then
+        assertThatCode(() -> migration.migrate()).doesNotThrowAnyException();
+    }
+
+    @Test
+    void shouldNotFailWhenTheFlowCrawlFails() {
+        // Given — the flows table is gone, so the crawl itself throws
+        dsl.execute("DROP TABLE flows");
+        when(autoInstallService.isEnabled()).thenReturn(true);
+
+        // When / Then
+        assertThatCode(() -> migration.migrate()).doesNotThrowAnyException();
         verify(autoInstallService, never()).installMissingTypes(anySet());
     }
 


### PR DESCRIPTION
## What

`V2_0_11PluginAutoInstallMigration` documents itself as *"Best-effort with a bounded wait: a failure is logged and never fails the startup."* It isn't: `migrate()` has no `try`/`catch` and `MigrationRunner.runScript` logs and rethrows, so any failure inside it aborts `ApplicationContext.start()`.

The risky statement is the very first one:

```java
PluginAutoInstallService service = autoInstallService.get();   // ← line 74
if (!service.isEnabled()) { … }                                // ← line 75
```

Resolving `PluginAutoInstallService` transitively pulls in a repository, and therefore the queue:

```
PluginAutoInstallService → namespaceMetaStore → NamespaceRepository
  → CurrentUserContext → AclService → RBACService → TenantRepository
    → BroadcastQueueInterface<Tenant> → queue connection
```

So a **misconfigured queue** fails here, and a fresh 2.0 instance crashloops with an incomplete migration set — reporting an unrelated queue error as `Migration [2.0.11-plugin-auto-install] failed`.

This is the cause behind kestra-io/kestra-ee#7547 ("Kestra v2 usual boot clashes with the Automated migration feature").

## Why it needs fixing in the migration, not just in the queue config

Three things follow from it, all verified against `v2.0.0` and `develop` on a real EE + Postgres + Redis stack:

1. **The instance never starts.** 16 of 19 scripts recorded, container restarts forever.
2. **`kestra migrate run` / `migrate plan` fail identically (exit 1).** `AbstractMigrationCommand` runs them in a minimal context that registers no repository — but this script resolves those beans *on demand inside* `migrate()`, so the minimal context instantiates them anyway. The documented way to migrate a misconfigured instance by hand is unavailable exactly when you need it.
3. **The two obvious mitigations don't work.** `kestra.migration.auto: false` is ignored on a fresh instance (`EeMigrationRunner` detects "no history + no legacy schema" and runs anyway), and `kestra.plugins.auto-install.enabled: false` can't help because the flag is read on line 75, one line *after* the crash.

Worth noting for EE reviewers: `PluginAutoInstallService.computeEnabled` returns `false` for every non-OSS edition, so on EE this script's entire contribution is `"Plugin auto-install is disabled, skipping the first-sync plugin crawl."` — measured at **2,962 ms** of building the repository + queue bean graph purely to ask a question whose EE answer is hard-coded. On EE it can only ever be a no-op or a boot failure.

## The change

Guard the whole body and log a warning instead. The script is still recorded as applied, so startup is not retried into the same failure; missing plugins are installed on the next flow save (#16054) and can be installed by hand at any time.

## Tests

Three new tests, one per failure path — service resolution, flow crawl, install. Each fails without this change:

```
✖ shouldNotFailWhenTheServiceCannotBeResolved()
✖ shouldNotFailWhenTheFlowCrawlFails()
✖ shouldNotFailWhenTheInstallFails()
```

and with it, `:jdbc:test --tests V2_0_11PluginAutoInstallMigrationTest` → 7/7 green.

## Follow-ups, not in this PR

- **Skip the crawl before resolving the service.** On EE the feature is always off, so the ~3 s spent building the repository + queue graph is pure waste. Injecting `PluginAutoInstallConfig` + `EditionProvider` (both trivial singletons with no repository dependencies) and returning early would avoid it. It needs a small shared helper for `computeEnabled`'s edition branch, hence a follow-up rather than part of this PR.
  <br>Gating the script with `@Requires` on the edition is *not* a viable route, for two reasons: edition is a runtime value from a `@Singleton` that EE swaps via `@Replaces`, so it cannot be a bean-definition condition (there is no such `@Requires` anywhere in `core`/`jdbc`); and gating by edition would not help OSS, where auto-install is **on by default** with local storage — so the registry call inside `installMissingTypes` runs during the migration and, before this PR, an unreachable registry stopped the server from starting. That OSS path is what `shouldNotFailWhenTheInstallFails` covers.
- **The auth error is never stated.** With wrong Redis credentials the only surfaced summary is `Message: Unable to connect to redis/<unresolved>:6379`, which points at DNS/host; `WRONGPASS` sits 171 lines below the headline. Worth translating `WRONGPASS`/`NOAUTH` into a message naming the config key.
- **`kestra.redis.client.password` is silently ignored unless `username` is also set** (`RedisClientFactory`: `if (username != null && password != null)`), so a `requirepass`-only Redis connects unauthenticated. EE-side; likely the original operator mistake in #7547. Happy to open that separately.

## Heads-up on CI

`origin/develop` at `2c7235c9c3` does not compile its test sources: `FlowInputOutputTest` uses `assertThatThrownBy` three times but only imports `assertThat`. Unrelated to this PR — I verified locally with that import added, and deliberately left the fix out of this branch.

