### PR TITLE
fix(plugins): pebble docs table renders its own text as HTML

### DIFF
--- a/ui/src/components/plugins/PluginDocumentation.vue
+++ b/ui/src/components/plugins/PluginDocumentation.vue
@@ -276,6 +276,7 @@
     import SchemaToHtml from "./schema/SchemaToHtml.vue"
     import {KsButton, KsInput, KsMarkdown, KsTag, KsTooltip} from "@kestra-io/design-system"
     import TaskIcon from "./TaskIcon.vue"
+    import {buildHighlightHtml} from "../../utils/crossResourceSearch"
     import {getPluginReleaseUrl} from "../../utils/pluginUtils"
     import {getTheme, copy} from "../../utils/utils"
     import {useMiscStore} from "override/stores/misc"
@@ -484,7 +485,7 @@
             const exMatch = rest.match(/`([^`]+)`\s*(?:—|-)/)
             const example = exMatch ? exMatch[1] : ""
             const desc = rest.replace(/`[^`]+`\s*(?:—|-)\s*/, "").replace(/\\\|/g, "|").trim()
-            rows.push({name, nameHtml: name, desc, descHtml: desc, example})
+            rows.push({name, nameHtml: buildHighlightHtml(name, ""), desc, descHtml: buildHighlightHtml(desc, ""), example})
         }
         return rows
     })
@@ -492,14 +493,12 @@
     const filteredPebbleRows = computed<PebbleRow[]>(() => {
         const q = introSearch.value.trim().toLowerCase()
         if (!q) return pebbleRows.value
-        const esc = q.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
-        const re = new RegExp(`(${esc})`, "gi")
         return pebbleRows.value
             .filter(r => r.name.toLowerCase().includes(q) || r.desc.toLowerCase().includes(q) || r.example.toLowerCase().includes(q))
             .map(r => ({
                 ...r,
-                nameHtml: r.name.replace(re, "<mark class=\"dp-intro-hl\">$1</mark>"),
-                descHtml: r.desc.replace(re, "<mark class=\"dp-intro-hl\">$1</mark>"),
+                nameHtml: buildHighlightHtml(r.name, q),
+                descHtml: buildHighlightHtml(r.desc, q),
             }))
     })
 
@@ -1160,7 +1159,8 @@
     font-size: var(--ks-font-size-xs);
   }
 
-  :deep(.dp-intro-hl) {
+  .dp-intro-fn-name mark,
+  .dp-intro-fn-desc mark {
     background: color-mix(in srgb, var(--ks-primary-500) 18%, transparent);
     border-radius: 3px;
     padding: 0 2px;


### PR DESCRIPTION
Issue: the Pebble table in the flow editor docs panel renders its own text as HTML, so the `nl2br` row breaks its line where it should print a `<br>` tag.
Fix: the row name and description now go through `buildHighlightHtml`, the same escaping helper the cross-resource search already uses for its `<mark>` highlighting.
Now: the tag shows as text, and searching the table still highlights matches.
