### PR TITLE
fix(tests): missing assertThatThrownBy import in FlowInputOutputTest

### DIFF
--- a/core/src/test/java/io/kestra/core/runners/FlowInputOutputTest.java
+++ b/core/src/test/java/io/kestra/core/runners/FlowInputOutputTest.java
@@ -64,6 +64,7 @@ import reactor.core.publisher.Mono;
 
 import static io.kestra.core.tenant.TenantService.MAIN_TENANT;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @MicronautTest
 class FlowInputOutputTest {


### PR DESCRIPTION
### ✨ Description

`develop` does not compile: `FlowInputOutputTest` uses `assertThatThrownBy` in three tests without importing it, so `:core:compileTestJava` fails with three `cannot find symbol` errors and every backend test job on the branch is dead.

Adding the missing `import static org.assertj.core.api.Assertions.assertThatThrownBy;` is the whole fix — no test or production behavior changes.

Evidence: `./gradlew compileJava compileTestJava` failed on `develop` at `FlowInputOutputTest.java:795, 822, 843` and is `BUILD SUCCESSFUL` with this commit.

### 🛠️ Backend Checklist

- [x] Code compiles and tests pass for the touched modules
- [x] New behavior is covered by unit or integration tests (no new behavior — restores compilation of existing tests)

### 🤖 AI Authors

Why did the compiler refuse to let the cat in? It couldn't find the symbol — the cat had no imports, only exports. 🐱
