### PR TITLE
fix(flows): reject execution of soft-deleted flow revisions

### DIFF
--- a/core/src/main/java/io/kestra/core/models/flows/Flow.java
+++ b/core/src/main/java/io/kestra/core/models/flows/Flow.java
@@ -308,6 +308,7 @@ public class Flow extends AbstractFlow implements HasUID {
         return this.toBuilder()
             .revision(this.revision + 1)
             .deleted(true)
+            .draft(false) // switch to false to avoid resurrecting the previous revision
             .build();
     }
 

--- a/core/src/main/java/io/kestra/core/models/flows/FlowWithSource.java
+++ b/core/src/main/java/io/kestra/core/models/flows/FlowWithSource.java
@@ -54,6 +54,7 @@ public class FlowWithSource extends Flow {
         return this.toBuilder()
             .revision(this.revision + 1)
             .deleted(true)
+            .draft(false) // switch to false to avoid resurrecting the previous revision
             .build();
     }
 

--- a/core/src/main/java/io/kestra/core/services/FlowService.java
+++ b/core/src/main/java/io/kestra/core/services/FlowService.java
@@ -1086,7 +1086,9 @@ public class FlowService {
         Optional<Flow> optional = revision.isPresent()
             ? flowRepository.findByIdWithoutAcl(tenant, namespace, id, revision)
             : flowRepository.findByIdForExecutionWithoutAcl(tenant, namespace, id);
-        if (optional.isEmpty()) {
+        // A delete appends a revision flagged deleted, so the tombstone is reachable only through
+        // an explicit revision; the no-revision lookup above already filters it out.
+        if (optional.isEmpty() || optional.get().isDeleted()) {
             throw new NoSuchElementException("Requested Flow is not found.");
         }
 

--- a/core/src/test/java/io/kestra/core/models/flows/FlowWithSourceTest.java
+++ b/core/src/test/java/io/kestra/core/models/flows/FlowWithSourceTest.java
@@ -148,6 +148,35 @@ class FlowWithSourceTest {
     }
 
     @Test
+    void toDeletedShouldClearDraft() {
+        // A draft revision is skipped by the ranking used to resolve an execution without an
+        // explicit revision, so a deleted revision left as a draft would let the previous,
+        // still-live revision resurface as executable.
+        FlowWithSource flow = FlowWithSource.builder()
+            .id(IdUtils.create())
+            .namespace("io.kestra.unittest")
+            .revision(1)
+            .draft(true)
+            .tasks(
+                List.of(
+                    Log.builder()
+                        .id(IdUtils.create())
+                        .type(Log.class.getName())
+                        .message("Hello World")
+                        .build()
+                )
+            )
+            .source("source")
+            .build();
+
+        FlowWithSource deleted = flow.toDeleted();
+
+        assertThat(deleted.isDeleted()).isTrue();
+        assertThat(deleted.isDraft()).isFalse();
+        assertThat(deleted.getRevision()).isEqualTo(2);
+    }
+
+    @Test
     void toFlowShouldPreserveRevisionAndUpdated() {
         Instant updated = Instant.parse("2026-08-06T08:55:00.788514407Z");
         FlowWithSource flowWithSource = FlowWithSource.builder()

--- a/core/src/test/java/io/kestra/core/repositories/AbstractFlowRepositoryTest.java
+++ b/core/src/test/java/io/kestra/core/repositories/AbstractFlowRepositoryTest.java
@@ -603,6 +603,36 @@ public abstract class AbstractFlowRepositoryTest {
     }
 
     @Test
+    void findByIdForExecution_shouldExcludePublishedRevisionShadowedByADeletedDraftHead() {
+        String tenant = TestsUtils.randomTenant(this.getClass().getSimpleName());
+        String flowId = IdUtils.create();
+        final List<Flow> toDelete = new ArrayList<>();
+
+        try {
+            FlowWithSource published = flowRepository.create(createTestingLogFlow(tenant, flowId, "published", false));
+            toDelete.add(published);
+            FlowWithSource draft = flowRepository.update(createTestingLogFlow(tenant, flowId, "wip", true), published);
+            toDelete.add(draft);
+
+            // Before deleting: the published revision is reachable through the execution-time
+            // lookup because the draft head above it is skipped by design.
+            Optional<Flow> beforeDelete = flowRepository.findByIdForExecution(tenant, TEST_NAMESPACE, flowId);
+            assertThat(beforeDelete).isPresent();
+            assertThat(beforeDelete.get().getRevision()).isEqualTo(published.getRevision());
+
+            flowRepository.delete(draft);
+
+            // Deleting the draft head must not leave the published revision beneath it
+            // executable: the tombstone must not itself be skipped by the draft filter, or the
+            // published revision resurfaces as if nothing had been deleted.
+            assertThat(flowRepository.findByIdForExecution(tenant, TEST_NAMESPACE, flowId)).isEmpty();
+            assertThat(flowRepository.findByIdWithSourceForExecution(tenant, TEST_NAMESPACE, flowId)).isEmpty();
+        } finally {
+            toDelete.forEach(this::deleteFlow);
+        }
+    }
+
+    @Test
     void findAllWithSourceForExecutionForAllTenants_shouldExcludeFlowsWhoseLatestIsDraft() {
         String tenant = TestsUtils.randomTenant(this.getClass().getSimpleName());
         String publishedId = IdUtils.create();

--- a/core/src/test/java/io/kestra/core/runners/FlowInputOutputTest.java
+++ b/core/src/test/java/io/kestra/core/runners/FlowInputOutputTest.java
@@ -64,6 +64,7 @@ import reactor.core.publisher.Mono;
 
 import static io.kestra.core.tenant.TenantService.MAIN_TENANT;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @MicronautTest
 class FlowInputOutputTest {

--- a/core/src/test/java/io/kestra/core/services/FlowServiceTest.java
+++ b/core/src/test/java/io/kestra/core/services/FlowServiceTest.java
@@ -4,6 +4,7 @@ import java.time.Duration;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.NoSuchElementException;
 import java.util.Optional;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -1569,6 +1570,55 @@ class FlowServiceTest {
             // The flow has at least one violation - we don't pin the exact message so this stays
             // robust against bean-validation message wording changes.
             assertThat(violations.get().getConstraintViolations()).isNotEmpty();
+        } finally {
+            flowRepository.findByIdWithSource(saved.getTenantId(), saved.getNamespace(), saved.getId())
+                .ifPresent(f -> flowRepository.delete(f));
+        }
+    }
+
+    @Test
+    void shouldRejectExecutingADeletedFlowRevisionWhenRevisionIsExplicit() throws FlowProcessingException, QueueException {
+        String flowId = IdUtils.create();
+        String source = """
+            id: %s
+            namespace: %s
+            tasks:
+              - id: log
+                type: io.kestra.plugin.core.log.Log
+                message: hello
+            """.formatted(flowId, TEST_NAMESPACE);
+
+        FlowWithSource created = flowService.create(GenericFlow.fromYaml(TenantService.MAIN_TENANT, source));
+        FlowWithSource deleted = flowService.delete(created);
+
+        assertThatThrownBy(() -> flowService.getFlowIfExecutableOrThrow(
+            deleted.getTenantId(), deleted.getNamespace(), deleted.getId(), Optional.of(deleted.getRevision())
+        ))
+            .isInstanceOf(NoSuchElementException.class)
+            .hasMessage("Requested Flow is not found.");
+    }
+
+    @Test
+    void shouldAllowExecutingADraftRevisionWhenRevisionIsExplicit() throws FlowProcessingException, QueueException {
+        String flowId = IdUtils.create();
+        String source = """
+            id: %s
+            namespace: %s
+            draft: true
+            tasks:
+              - id: log
+                type: io.kestra.plugin.core.log.Log
+                message: hello
+            """.formatted(flowId, TEST_NAMESPACE);
+
+        FlowWithSource saved = flowService.create(GenericFlow.fromYaml(TenantService.MAIN_TENANT, source));
+
+        try {
+            Flow executable = flowService.getFlowIfExecutableOrThrow(
+                saved.getTenantId(), saved.getNamespace(), saved.getId(), Optional.of(saved.getRevision())
+            );
+
+            assertThat(executable.isDraft()).isTrue();
         } finally {
             flowRepository.findByIdWithSource(saved.getTenantId(), saved.getNamespace(), saved.getId())
                 .ifPresent(f -> flowRepository.delete(f));

--- a/webserver/src/main/java/io/kestra/webserver/controllers/api/ExecutionController.java
+++ b/webserver/src/main/java/io/kestra/webserver/controllers/api/ExecutionController.java
@@ -993,13 +993,13 @@ public class ExecutionController {
             // reject the request as unprocessable with an explanation instead of a bare 404, so the
             // user knows to save a published revision before executing without a revision.
             if (revision.isEmpty()) {
-                Optional<Flow> latestAny = flowRepository.findByIdWithoutAcl(tenantId, namespace, id, Optional.empty());
-                if (latestAny.isPresent() && latestAny.get().isDraft()) {
-                    Flow draftFlow = latestAny.get();
-                    throw new IllegalArgumentException(
-                        "Flow execution blocked: flow " + draftFlow.uid() + " only has draft revisions. Save it as a published revision before executing it without a revision."
-                    );
-                }
+                flowRepository.findByIdWithoutAcl(tenantId, namespace, id, Optional.empty())
+                    .filter(f -> !f.isDeleted() && f.isDraft())
+                    .ifPresent(draftFlow -> {
+                        throw new IllegalArgumentException(
+                            "Flow execution blocked: flow " + draftFlow.uid() + " only has draft revisions. Save it as a published revision before executing it without a revision."
+                        );
+                    });
             }
             throw e;
         }

--- a/webserver/src/test/java/io/kestra/webserver/controllers/api/ExecutionControllerRunnerTest.java
+++ b/webserver/src/test/java/io/kestra/webserver/controllers/api/ExecutionControllerRunnerTest.java
@@ -329,6 +329,46 @@ class ExecutionControllerRunnerTest {
     }
 
     @Test
+    void executingAFlowDeletedWhileItsHeadWasADraftIsRejected() {
+        // A flow that was published then edited into a draft, then deleted: the tombstone must
+        // shadow the published revision beneath it, or the published revision resurfaces as
+        // executable without a revision even though the flow was deleted.
+        String flowId = IdUtils.create();
+        String publishedSource = """
+            id: %s
+            namespace: %s
+            tasks:
+              - id: log
+                type: io.kestra.plugin.core.log.Log
+                message: hello
+            """.formatted(flowId, TESTS_FLOW_NS);
+        String draftSource = """
+            id: %s
+            namespace: %s
+            draft: true
+            tasks:
+              - id: log
+                type: io.kestra.plugin.core.log.Log
+                message: wip
+            """.formatted(flowId, TESTS_FLOW_NS);
+
+        FlowWithSource published = flowRepositoryInterface.create(GenericFlow.fromYaml(MAIN_TENANT, publishedSource));
+        FlowWithSource draft = flowRepositoryInterface.update(GenericFlow.fromYaml(MAIN_TENANT, draftSource), published);
+        flowRepositoryInterface.delete(draft);
+
+        HttpClientResponseException e = assertThrows(
+            HttpClientResponseException.class, () -> client.toBlocking().retrieve(
+                HttpRequest.POST("/api/v1/main/executions/" + TESTS_FLOW_NS + "/" + flowId, null),
+                Execution.class
+            )
+        );
+
+        assertThat(e.getStatus().getCode())
+            .as("the published revision beneath the deleted draft head must not resurface as executable")
+            .isEqualTo(HttpStatus.NOT_FOUND.getCode());
+    }
+
+    @Test
     @LoadFlows(value = { "flows/valids/minimal.yaml" })
     void shouldHaveAnUrlWhenCreated() {
         // ExecutionController.ExecutionResponse cannot be deserialized because it didn't have any default constructor.

--- a/webserver/src/test/java/io/kestra/webserver/controllers/api/ExecutionControllerRunnerTest.java
+++ b/webserver/src/test/java/io/kestra/webserver/controllers/api/ExecutionControllerRunnerTest.java
@@ -50,6 +50,8 @@ import io.kestra.core.models.executions.TaskRun;
 import io.kestra.core.models.flows.Flow;
 import io.kestra.core.models.flows.FlowForExecution;
 import io.kestra.core.models.flows.FlowInterface;
+import io.kestra.core.models.flows.FlowWithSource;
+import io.kestra.core.models.flows.GenericFlow;
 import io.kestra.core.models.flows.State;
 import io.kestra.core.models.flows.State.Type;
 import io.kestra.core.models.storage.FileMetas;
@@ -292,6 +294,38 @@ class ExecutionControllerRunnerTest {
             .as("the playground execution runs against the draft revision that was requested")
             .isEqualTo(1);
         assertThat(execution.getKind()).isEqualTo(ExecutionKind.PLAYGROUND);
+    }
+
+    @Test
+    void executingADeletedFlowRevisionIsRejected() {
+        // Deletion appends a revision flagged deleted rather than a fixture (@LoadFlows cannot
+        // express "deleted"), so build and delete the flow directly through the repository.
+        String flowId = IdUtils.create();
+        String source = """
+            id: %s
+            namespace: %s
+            tasks:
+              - id: log
+                type: io.kestra.plugin.core.log.Log
+                message: hello
+            """.formatted(flowId, TESTS_FLOW_NS);
+
+        FlowWithSource created = flowRepositoryInterface.create(GenericFlow.fromYaml(MAIN_TENANT, source));
+        FlowWithSource deleted = flowRepositoryInterface.delete(created);
+
+        HttpClientResponseException e = assertThrows(
+            HttpClientResponseException.class, () -> client.toBlocking().retrieve(
+                HttpRequest.POST(
+                    "/api/v1/main/executions/" + TESTS_FLOW_NS + "/" + flowId + "?revision=" + deleted.getRevision(),
+                    null
+                ),
+                Execution.class
+            )
+        );
+
+        assertThat(e.getStatus().getCode())
+            .as("explicitly targeting the deleted revision is rejected as not found, same as a nonexistent flow")
+            .isEqualTo(HttpStatus.NOT_FOUND.getCode());
     }
 
     @Test


### PR DESCRIPTION
### 🔗 Related Issue

No linked issue — found and fixed while reviewing an unpublished security advisory (GHSA-52wv-cgfg-4j6x). One follow-up filed separately, not addressed here: https://github.com/kestra-io/kestra/issues/19326.

Fixes https://github.com/kestra-io/kestra-ee/issues/10869

### ✨ Description

A soft-deleted flow (`deleted = true` on its latest revision) could still be executed in two ways:

- `POST /executions/{ns}/{id}?revision=<deleted>` resolved and ran the deleted revision directly: `getFlowIfExecutableOrThrow` checked disabled and invalid but never checked `isDeleted()`.
- Deleting a flow whose head was a **draft** left the tombstone itself flagged as a draft. The ranking used to resolve an execution without an explicit revision (`lastNonDraftRevision`) excludes draft revisions before applying the deleted filter, so the draft tombstone was invisible to it and the published revision underneath it resurfaced as executable — with **no revision parameter needed**.

Fix, in two commits:

1. `getFlowIfExecutableOrThrow` now rejects a resolved flow that `isDeleted()`, with the same "not found" message and status as a nonexistent flow — so an execute-only caller can't distinguish a deleted flow from one that never existed.
2. `Flow#toDeleted()` / `FlowWithSource#toDeleted()` now clear `draft` on the tombstone. A delete tombstone isn't a draft of anything: it's the flow's end state, and always the highest revision number, so once it's never draft-excluded from the ranking it correctly wins and gets filtered out — instead of the ranking falling through to the revision beneath it.

An adjacent existence leak is fixed alongside commit 1: a deleted flow whose tombstone had inherited `draft = true` (pre-fix behavior) made the no-revision execution path answer `422 "only has draft revisions"` instead of `404`, confirming the flow's existence to a caller who shouldn't be able to tell.

### 🛠️ Backend Checklist

- [x] Code compiles and tests pass for the touched modules (`:core:test`, `:jdbc-h2:test`, `:webserver:test`)
- [x] New behavior is covered by unit or integration tests

### 📝 Additional Notes

- 1.3.x is separately affected and needs its own backport — no `draft` column exists on that line, so this exact patch doesn't apply as-is.