### PR TITLE
fix(executions): reject execution of soft-deleted flow revisions

### DIFF
--- a/core/src/main/java/io/kestra/core/services/FlowService.java
+++ b/core/src/main/java/io/kestra/core/services/FlowService.java
@@ -616,7 +616,8 @@ public class FlowService {
         }
 
         Optional<Flow> optional = flowRepository.get().findByIdWithoutAcl(tenant, namespace, id, revision);
-        if (optional.isEmpty()) {
+        // findByIdWithoutAcl is deleted-inclusive, so reject a resolved flow the same way as a nonexistent one.
+        if (optional.isEmpty() || optional.get().isDeleted()) {
             throw new NoSuchElementException("Requested Flow is not found.");
         }
 

--- a/core/src/test/java/io/kestra/core/services/FlowServiceTest.java
+++ b/core/src/test/java/io/kestra/core/services/FlowServiceTest.java
@@ -3,6 +3,7 @@ package io.kestra.core.services;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.NoSuchElementException;
 import java.util.Optional;
 import java.util.stream.Stream;
 
@@ -22,6 +23,7 @@ import io.kestra.plugin.core.debug.Return;
 import jakarta.inject.Inject;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -360,6 +362,35 @@ class FlowServiceTest {
         assertThat(flowRepository.findById(flow.getTenantId(), flow.getNamespace(), flow.getId()).isPresent()).isTrue();
         flowService.delete(saved);
         assertThat(flowRepository.findById(flow.getTenantId(), flow.getNamespace(), flow.getId()).isPresent()).isFalse();
+    }
+
+    @Test
+    void shouldRejectExecutingADeletedFlow() {
+        // findByIdWithoutAcl's last-revision lookup is deleted-inclusive, and getFlowIfExecutableOrThrow
+        // has no separate non-deleted path here (unlike develop), so this is the PoC shape from
+        // GHSA-52wv-cgfg-4j6x: no revision parameter needed.
+        FlowWithSource flow = create("deletedExecutionTest", "test", 1);
+        FlowWithSource saved = flowRepository.create(GenericFlow.of(flow));
+        FlowWithSource deleted = flowService.delete(saved);
+
+        assertThatThrownBy(() -> flowService.getFlowIfExecutableOrThrow(
+            deleted.getTenantId(), deleted.getNamespace(), deleted.getId(), Optional.empty()
+        ))
+            .isInstanceOf(NoSuchElementException.class)
+            .hasMessage("Requested Flow is not found.");
+    }
+
+    @Test
+    void shouldRejectExecutingADeletedFlowRevisionWhenRevisionIsExplicit() {
+        FlowWithSource flow = create("deletedExecutionExplicitRevisionTest", "test", 1);
+        FlowWithSource saved = flowRepository.create(GenericFlow.of(flow));
+        FlowWithSource deleted = flowService.delete(saved);
+
+        assertThatThrownBy(() -> flowService.getFlowIfExecutableOrThrow(
+            deleted.getTenantId(), deleted.getNamespace(), deleted.getId(), Optional.of(deleted.getRevision())
+        ))
+            .isInstanceOf(NoSuchElementException.class)
+            .hasMessage("Requested Flow is not found.");
     }
 
     @Test

--- a/webserver/src/test/java/io/kestra/webserver/controllers/api/ExecutionControllerRunnerTest.java
+++ b/webserver/src/test/java/io/kestra/webserver/controllers/api/ExecutionControllerRunnerTest.java
@@ -40,6 +40,8 @@ import io.kestra.core.models.executions.ExecutionKilledExecution;
 import io.kestra.core.models.executions.TaskRun;
 import io.kestra.core.models.flows.Flow;
 import io.kestra.core.models.flows.FlowInterface;
+import io.kestra.core.models.flows.FlowWithSource;
+import io.kestra.core.models.flows.GenericFlow;
 import io.kestra.core.models.flows.State;
 import io.kestra.core.models.flows.State.Type;
 import io.kestra.core.models.storage.FileMetas;
@@ -180,6 +182,66 @@ class ExecutionControllerRunnerTest {
     @BeforeEach
     public void initMock() {
         when(tenantService.resolveTenant()).thenReturn(MAIN_TENANT);
+    }
+
+    @Test
+    void executingADeletedFlowIsRejected() {
+        // Deletion appends a revision flagged deleted rather than a fixture (@LoadFlows cannot
+        // express "deleted"), so build and delete the flow directly through the repository. No
+        // revision parameter: this is the PoC shape from GHSA-52wv-cgfg-4j6x.
+        String flowId = IdUtils.create();
+        String source = """
+            id: %s
+            namespace: %s
+            tasks:
+              - id: log
+                type: io.kestra.plugin.core.log.Log
+                message: hello
+            """.formatted(flowId, TESTS_FLOW_NS);
+
+        FlowWithSource created = flowRepositoryInterface.create(GenericFlow.fromYaml(MAIN_TENANT, source));
+        flowRepositoryInterface.delete(created);
+
+        HttpClientResponseException e = assertThrows(
+            HttpClientResponseException.class, () -> client.toBlocking().retrieve(
+                HttpRequest.POST("/api/v1/main/executions/" + TESTS_FLOW_NS + "/" + flowId, null),
+                Execution.class
+            )
+        );
+
+        assertThat(e.getStatus().getCode())
+            .as("executing a deleted flow without a revision is rejected as not found, same as a nonexistent flow")
+            .isEqualTo(HttpStatus.NOT_FOUND.getCode());
+    }
+
+    @Test
+    void executingADeletedFlowRevisionIsRejected() {
+        String flowId = IdUtils.create();
+        String source = """
+            id: %s
+            namespace: %s
+            tasks:
+              - id: log
+                type: io.kestra.plugin.core.log.Log
+                message: hello
+            """.formatted(flowId, TESTS_FLOW_NS);
+
+        FlowWithSource created = flowRepositoryInterface.create(GenericFlow.fromYaml(MAIN_TENANT, source));
+        FlowWithSource deleted = flowRepositoryInterface.delete(created);
+
+        HttpClientResponseException e = assertThrows(
+            HttpClientResponseException.class, () -> client.toBlocking().retrieve(
+                HttpRequest.POST(
+                    "/api/v1/main/executions/" + TESTS_FLOW_NS + "/" + flowId + "?revision=" + deleted.getRevision(),
+                    null
+                ),
+                Execution.class
+            )
+        );
+
+        assertThat(e.getStatus().getCode())
+            .as("explicitly targeting the deleted revision is rejected as not found, same as a nonexistent flow")
+            .isEqualTo(HttpStatus.NOT_FOUND.getCode());
     }
 
     @Test

--- a/webserver/src/test/java/io/kestra/webserver/controllers/api/ExecutionControllerTest.java
+++ b/webserver/src/test/java/io/kestra/webserver/controllers/api/ExecutionControllerTest.java
@@ -471,6 +471,7 @@ class ExecutionControllerTest {
     }
 
     @Test
+    @LoadFlows(value = { "flows/valids/inputs.yaml" })
     void commaInOneOfMultiLabels() {
         String encodedCommaWithinLabel = URLEncoder.encode("project:foo,bar", StandardCharsets.UTF_8);
         String encodedRegularLabel = URLEncoder.encode("status:test", StandardCharsets.UTF_8);
@@ -507,6 +508,7 @@ class ExecutionControllerTest {
     }
 
     @Test
+    @LoadFlows(value = { "flows/valids/inputs.yaml" })
     void shouldValidateInputsForCreateExecutionGivenSimpleInputs() {
         // given
         String namespace = "io.kestra.tests";


### PR DESCRIPTION
### 🔗 Related Issue

No linked issue — backport of #19327, found and fixed while reviewing an unpublished security advisory (GHSA-52wv-cgfg-4j6x).

### ✨ Description

`releases/v1.3.x` is affected by the exact path described in the advisory: `getFlowIfExecutableOrThrow` resolves the flow through `findByIdWithoutAcl`, which is deleted-inclusive on **both** its explicit-revision and last-revision lookups, and the method checked `disabled`/invalid but never `deleted`. Unlike `develop`, this branch has no separate non-deleted lookup for the no-revision case (that split came later, as an incidental side effect of the draft-revisions feature, which doesn't exist on 1.3.x), so the bug reaches both:

- `POST /executions/{ns}/{id}` with no revision — the advisory's PoC exactly
- `POST /executions/{ns}/{id}?revision=<deleted>` — the explicit-revision variant #19327 fixes on `develop`

Fix: reject a resolved flow that `isDeleted()`, the same way as a nonexistent one, mirroring #19327's guard. No draft-related change carries over — 1.3.x has no `draft` column, so #19327's second commit doesn't apply here.

**Known accepted scope, matching #19327**: this rejects the *specific resolved revision* if it is the deleted tombstone; an older, still-live revision of a since-deleted flow (e.g. `?revision=1` for a flow now on a later, deleted revision) stays reachable by explicit revision number, consistent with how `restart`/`resume` (`findByExecutionWithoutAcl`) are deliberately deleted-inclusive on this branch too.

### 🛠️ Backend Checklist

- [x] Code compiles and tests pass for the touched modules (`:core:test`, `:webserver:test`, `:jdbc-h2:test` — `H2RunnerTest`, 86/86, since the executor's in-flight-execution path shares `flowRepository`)
- [x] New behavior is covered by unit or integration tests
