### PR TITLE
test(triggers): type the TaskAnyOf stories schemas instead of casting them to any

### DIFF
--- a/ui/scripts/explicit-any/baseline.json
+++ b/ui/scripts/explicit-any/baseline.json
@@ -305,7 +305,6 @@
   "tests/storybook/components/no-code/BlockEditorFeedbackFullExperience.stories.tsx": 1,
   "tests/storybook/components/no-code/NoCode.stories.tsx": 1,
   "tests/storybook/components/no-code/blockEditorFeedbackFixtures.ts": 1,
-  "tests/storybook/components/no-code/components/tasks/TaskAnyOf.stories.tsx": 13,
   "tests/storybook/components/no-code/components/tasks/TaskArray.stories.tsx": 1,
   "tests/storybook/components/no-code/components/tasks/TaskComplex.stories.tsx": 2,
   "tests/storybook/components/no-code/components/tasks/TaskDict.stories.tsx": 1,

--- a/ui/tests/storybook/components/no-code/components/tasks/TaskAnyOf.stories.tsx
+++ b/ui/tests/storybook/components/no-code/components/tasks/TaskAnyOf.stories.tsx
@@ -4,6 +4,7 @@ import {Meta, StoryObj} from "@storybook/vue3-vite";
 import {expect, fireEvent, waitFor, within} from "storybook/test";
 import {vueRouter} from "storybook-vue3-router";
 import {SCHEMA_DEFINITIONS_INJECTION_KEY} from "../../../../../../src/components/no-code/injectionKeys";
+import type {Schema} from "../../../../../../src/components/no-code/components/tasks/getTaskComponent";
 
 const meta: Meta<typeof TaskAnyOf> = {
     title: "Components/NoCode/TaskAnyOf",
@@ -38,11 +39,11 @@ export const SimpleTypes: Story = {
         modelValue: undefined,
         schema: {
             anyOf: [
-                {type: "string"} as any,
-                {type: "number"} as any,
-                {type: "boolean"} as any,
+                {type: "string"},
+                {type: "number"},
+                {type: "boolean"},
             ],
-        } as any,
+        } as Schema,
     },
 };
 
@@ -67,10 +68,10 @@ export const ArrayVariants: Story = {
         modelValue: undefined,
         schema: {
             anyOf: [
-                {type: "array", items: {type: "string"}} as any,
-                {type: "array", items: {type: "number"}} as any,
+                {type: "array", items: {type: "string"}},
+                {type: "array", items: {type: "number"}},
             ],
-        } as any,
+        } as Schema,
     },
 };
 
@@ -104,10 +105,10 @@ export const EnumAndPatternBranches: Story = {
         schema: {
             type: "string",
             anyOf: [
-                {enum: ["UTC", "Europe/Paris", "Asia/Tokyo"]} as any,
-                {pattern: "^(Z|[+-]\\d{2}(:?\\d{2})?)$"} as any,
+                {enum: ["UTC", "Europe/Paris", "Asia/Tokyo"]},
+                {pattern: "^(Z|[+-]\\d{2}(:?\\d{2})?)$"},
             ],
-        } as any,
+        } as Schema,
     },
     async play({canvasElement}) {
         const canvas = within(canvasElement);
@@ -137,10 +138,10 @@ export const PatternOnlyBranches: Story = {
         schema: {
             type: "string",
             anyOf: [
-                {pattern: "^[a-z]+$"} as any,
-                {pattern: "^[0-9]+$"} as any,
+                {pattern: "^[a-z]+$"},
+                {pattern: "^[0-9]+$"},
             ],
-        } as any,
+        } as Schema,
     },
     async play({canvasElement}) {
         const canvas = within(canvasElement);


### PR DESCRIPTION
Related to https://github.com/kestra-io/kestra/pull/18959.

## What

The `Frontend - Tests` job on `develop` is red since https://github.com/kestra-io/kestra/pull/18959 merged: its two new `TaskAnyOf` stories cast their schemas to `any`, which pushed `tests/storybook/components/no-code/components/tasks/TaskAnyOf.stories.tsx` from 7 to 13 explicit `any` and failed the `check ts-any` gate, skipping the unit and storybook tests behind it.

```
tests/storybook/components/no-code/components/tasks/TaskAnyOf.stories.tsx: 7 -> 13
explicit any went from 7 to 13; type it or update the baseline
```

The branch predated the explicit-any gate, so the gate never ran on the `PR` itself - a merge race, not a red `PR`.

## How

- Every schema in the stories is now typed as the component's own `Schema` (from `getTaskComponent.ts`) instead of `as any`, including the seven casts that were already on the baseline, so the file goes from 13 explicit `any` to 0.
- `baseline.json` drops the file, as `npm run check:ts-any -- --write` produces.

No runtime change: only type assertions moved, so the emitted stories are identical.

## Verification

- `node scripts/explicit-any/baseline.mjs src packages tests`: `No change against the baseline`.
- `vue-tsc -p tsconfig.test.json`: no errors in the changed file.
- `oxlint` on the file: clean.

`releases/v2.0.x` is not affected: the explicit-any gate does not exist there, and the 2.0 backport https://github.com/kestra-io/kestra/pull/18963 is green.