### PR TITLE
fix(worker): honour terminationGracePeriod when draining jobs on shutdown

### DIFF
--- a/worker/src/main/java/io/kestra/worker/AbstractWorker.java
+++ b/worker/src/main/java/io/kestra/worker/AbstractWorker.java
@@ -36,6 +36,7 @@ import io.kestra.worker.senders.WorkerIOSender;
 
 import io.micronaut.context.event.ApplicationEventPublisher;
 import lombok.extern.slf4j.Slf4j;
+import org.awaitility.core.ConditionTimeoutException;
 
 import static io.kestra.core.server.Service.ServiceState.TERMINATED_FORCED;
 import static io.kestra.core.server.Service.ServiceState.TERMINATED_GRACEFULLY;
@@ -330,25 +331,37 @@ public abstract class AbstractWorker extends AbstractService {
             }
         );
 
-        Await.await()
-            .pollInterval(Duration.ofSeconds(1))
-            .ignoreExceptions()
-            .until(() ->
-            {
-                ServiceState serviceState = shutdownState.get();
-                if (serviceState == TERMINATED_FORCED || serviceState == TERMINATED_GRACEFULLY) {
-                    log.info("All worker jobs are terminated");
-                    return true;
-                }
+        try {
+            Await.await()
+                // Awaitility caps at 10s by default, and honouring the grace period is the whole point here.
+                .atMost(timeout)
+                .pollInterval(Duration.ofSeconds(1))
+                .ignoreExceptions()
+                .until(() ->
+                {
+                    ServiceState serviceState = shutdownState.get();
+                    if (serviceState == TERMINATED_FORCED || serviceState == TERMINATED_GRACEFULLY) {
+                        log.info("All worker jobs are terminated");
+                        return true;
+                    }
 
-                long runningJobs = this.workerJobExecutor.getRunningJobCount();
-                if (runningJobs == 0) {
-                    log.info("All worker threads are terminated");
-                } else {
-                    log.warn("Waiting for all worker job to terminate (remaining: {}).", runningJobs);
-                }
-                return false;
-            });
+                    long runningJobs = this.workerJobExecutor.getRunningJobCount();
+                    if (runningJobs == 0) {
+                        log.info("All worker threads are terminated");
+                    } else {
+                        log.warn("Waiting for all worker job to terminate (remaining: {}).", runningJobs);
+                    }
+                    return false;
+                });
+        } catch (ConditionTimeoutException e) {
+            // Returning instead of propagating keeps doStop() on its normal path, which still has the
+            // Worker IO senders to flush.
+            log.warn(
+                "Grace period of {} elapsed with {} job(s) still running, forcing termination.",
+                timeout, this.workerJobExecutor.getRunningJobCount()
+            );
+            return false;
+        }
 
         return shutdownState.get() == TERMINATED_GRACEFULLY;
     }

--- a/worker/src/main/java/io/kestra/worker/AbstractWorker.java
+++ b/worker/src/main/java/io/kestra/worker/AbstractWorker.java
@@ -60,6 +60,10 @@ import static io.kestra.core.server.Service.ServiceState.TERMINATED_GRACEFULLY;
 @Slf4j
 public abstract class AbstractWorker extends AbstractService {
 
+    // Keeps the shutdown wait outliving the executor shutdown it observes, so the two deadlines never
+    // expire together and race on the resulting state. Must stay above the wait's poll interval.
+    private static final Duration FORCED_SHUTDOWN_MARGIN = Duration.ofSeconds(5);
+
     protected final MetricRegistry metricRegistry;
     protected final ServerConfig serverConfig;
     protected final MaintenanceService maintenanceService;
@@ -334,7 +338,7 @@ public abstract class AbstractWorker extends AbstractService {
         try {
             Await.await()
                 // Awaitility caps at 10s by default, and honouring the grace period is the whole point here.
-                .atMost(timeout)
+                .atMost(timeout.plus(FORCED_SHUTDOWN_MARGIN))
                 .pollInterval(Duration.ofSeconds(1))
                 .ignoreExceptions()
                 .until(() ->
@@ -357,8 +361,9 @@ public abstract class AbstractWorker extends AbstractService {
             // Returning instead of propagating keeps doStop() on its normal path, which still has the
             // Worker IO senders to flush.
             log.warn(
-                "Grace period of {} elapsed with {} job(s) still running, forcing termination.",
-                timeout, this.workerJobExecutor.getRunningJobCount()
+                "Worker job executor did not report back {} past its {} deadline, forcing termination "
+                    + "({} job(s) still running).",
+                FORCED_SHUTDOWN_MARGIN, timeout, this.workerJobExecutor.getRunningJobCount()
             );
             return false;
         }


### PR DESCRIPTION
Fixes the worker shutdown drain, which gave up after 10 seconds instead of the configured kestra.server.terminationGracePeriod, so a scaled-down or restarted worker abandoned its in-flight tasks and skipped the Worker IO flush entirely