### PR TITLE
refactor(ui): replace explicit any in Executions.vue

### DIFF
--- a/ui/scripts/explicit-any/baseline.json
+++ b/ui/scripts/explicit-any/baseline.json
@@ -120,7 +120,6 @@
   "src/components/executions/ChangeStatus.vue": 8,
   "src/components/executions/ExecutionRoot.vue": 1,
   "src/components/executions/ExecutionRootTopBar.vue": 1,
-  "src/components/executions/Executions.vue": 22,
   "src/components/executions/FilePreview.vue": 1,
   "src/components/executions/Gantt.vue": 4,
   "src/components/executions/Logs.vue": 9,

--- a/ui/src/components/executions/Executions.vue
+++ b/ui/src/components/executions/Executions.vue
@@ -43,14 +43,14 @@
             :currentPage="currentPage"
             :pageSize="currentSize"
             @page-changed="onPageChanged"
-            @sort-change="({prop, order}: {column: any; prop: string | null; order: string | null}) => { if (!props.embed) router.push({query: {...route.query, sort: `${prop}:${order === 'ascending' ? 'asc' : 'desc'}`}}) }"
-            @row-dblclick="(row: any) => router.push({name: dblClickRouteName, params: executionParams(row)})"
+            @sort-change="({prop, order}: {column: unknown; prop: string | null; order: string | null}) => { if (!props.embed) router.push({query: {...route.query, sort: `${prop}:${order === 'ascending' ? 'asc' : 'desc'}`}}) }"
+            @row-dblclick="(row: Execution) => router.push({name: dblClickRouteName, params: executionParams(row)})"
             :selectionMapper="selectionMapper"
             @ready="ready = true"
             :defaultSort="{prop: 'state.startDate', order: 'descending'}"
             :selectable="!hidden?.includes('selection') && canCheck"
             :no-data-text="$t('no_results.executions')"
-            :rowKey="(row: any) => row.id"
+            :rowKey="(row: Execution) => row.id"
             :fitHeight="fitHeightResolved"
         >
             <template #navbar v-if="isDisplayedTop">
@@ -467,7 +467,7 @@
     import {useFlowStore} from "../../stores/flow"
     import {useAuthStore} from "override/stores/auth"
     import {useMiscStore} from "override/stores/misc"
-    import {Label, useExecutionsStore} from "../../stores/executions"
+    import {type Execution, Label, useExecutionsStore} from "../../stores/executions"
     import {getExtraColumns, cellComponents, bulkActionComponents} from "override/components/executions/executionsExtensions"
 
     import {useExecutionFilter, useFlowExecutionFilter} from "../filter/configurations"
@@ -535,7 +535,7 @@
     const lastRefreshDate = ref(new Date())
     const unqueueDialogVisible = ref(false)
     const changeStatusDialogVisible = ref(false)
-    const actionOptions = ref<Record<string, any>>({})
+    const actionOptions = ref<Record<string, unknown>>({})
     const dblClickRouteName = ref("executions/update")
     const showChart = ref(localStorage.getItem(storageKeys.SHOW_CHART) !== "false")
 
@@ -636,7 +636,7 @@
             .filter(c => {
                 const condition = (c as {condition?: () => boolean})?.condition
                 return c && (!condition || condition())
-            }) as any[],
+            }) as NonNullable<typeof allColumns.value[number]>[],
     )
 
     const isColumnSortable = (prop: string) => {
@@ -644,7 +644,7 @@
         return !["labels", "flowRevision", "inputs", "taskRunList.taskId", "trigger", "trigger.variables.executionId"].includes(prop)
     }
 
-    const selectionMapper = (execution: any) => {
+    const selectionMapper = (execution: Execution) => {
         return execution.id
     }
 
@@ -663,7 +663,13 @@
     }
 
     const ready = ref(false)
-    const dataTable = useTemplateRef<any>("dataTable")
+    const dataTable = useTemplateRef<{
+        resetAndReload: () => void;
+        reload: () => void;
+        toggleAllUnselected: () => void;
+        selection?: string[];
+        queryBulkAction?: boolean;
+    }>("dataTable")
 
     const loadData = async ({page, size, sort}: {page: number; size: number; sort?: string}) => {
         if (!loadInit.value) return
@@ -779,7 +785,7 @@
         ]
     })
 
-    const filteredLabels = (labels: any[]) => {
+    const filteredLabels = (labels: Label[]) => {
         const toIgnore = miscStore.configs?.hiddenLabelsPrefixes || []
 
         const queryLabels = route.query?.labels
@@ -790,7 +796,7 @@
         })
     }
 
-    const executionParams = (row: any) => {
+    const executionParams = (row: Execution) => {
         return {
             namespace: row?.namespace,
             flowId: row?.flowId,
@@ -825,12 +831,12 @@
         return new Set(fields)
     })
 
-    const dropUnsupportedFilters = (query: Record<string, any>): Record<string, any> =>
-        keepSupportedFilters(query, supportedFilterFields.value) as Record<string, any>
+    const dropUnsupportedFilters = (query: Record<string, unknown>): Record<string, unknown> =>
+        keepSupportedFilters(query, supportedFilterFields.value) as Record<string, unknown>
 
-    const loadQuery = (base: any) => {
+    const loadQuery = (base: Record<string, unknown>) => {
         const {page: _p, size: _s, sort: _so, ...restQuery} = route.query
-        let queryFilter: Record<string, any> = dropUnsupportedFilters(restQuery)
+        let queryFilter: Record<string, unknown> = dropUnsupportedFilters(restQuery)
 
         if (props.namespace) {
             queryFilter["filters[namespace][PREFIX]"] = props.namespace
@@ -857,10 +863,14 @@
         )
     }
 
-    const affectedCount = (response: any) => response?.count ?? response?.totalItems ?? 0
+    const affectedCount = (response: unknown) => {
+        if (typeof response !== "object" || response === null) return 0
+        const result = response as {count?: unknown; totalItems?: unknown}
+        return typeof result.count === "number" ? result.count : typeof result.totalItems === "number" ? result.totalItems : 0
+    }
 
-    const genericConfirmCallback = (queryAction: string, byIdAction: string, success: string, params?: any) => {
-        const actionMap: Record<string, () => any> = {
+    const genericConfirmCallback = (queryAction: string, byIdAction: string, success: string, params?: Record<string, unknown>) => {
+        const actionMap: Record<string, () => (options: Record<string, unknown>) => Promise<unknown>> = {
             "queryResumeExecution": () => executionsStore.queryResumeExecution,
             "bulkResumeExecution": () => executionsStore.bulkResumeExecution,
             "queryPauseExecution": () => executionsStore.queryPauseExecution,
@@ -879,7 +889,7 @@
             "bulkDeleteExecution": () => executionsStore.bulkDeleteExecution,
             "queryKill": () => executionsStore.queryKill,
             "bulkKill": () => executionsStore.bulkKill,
-        }
+        } as unknown as Record<string, () => (options: Record<string, unknown>) => Promise<unknown>>
 
         if (queryBulkAction.value) {
             const query = loadQuery({
@@ -893,7 +903,7 @@
 
             const ac = actionMap[queryAction]()
             return ac(options)
-                .then((r: any) => {
+                .then((r: unknown) => {
                     toast.success(t(success, {executionCount: affectedCount(r)}))
                     toggleAllUnselected()
                     dataTable.value?.reload()
@@ -907,7 +917,7 @@
 
             const ac = actionMap[byIdAction]()
             return ac(options)
-                .then((r: any) => {
+                .then((r: unknown) => {
                     toast.success(t(success, {executionCount: affectedCount(r)}))
                     toggleAllUnselected()
                     dataTable.value?.reload()
@@ -1023,7 +1033,7 @@
             }, [
                 h(KsSwitch, {
                     modelValue: includeNonTerminated.value,
-                    "onUpdate:modelValue": (val: any) => {
+                    "onUpdate:modelValue": (val: unknown) => {
                         includeNonTerminated.value = Boolean(val)
                     },
                 }),
@@ -1037,17 +1047,17 @@
             h(KsCheckbox, {
                 modelValue: deleteLogs.value,
                 label: t("execution_deletion.logs"),
-                "onUpdate:modelValue": (val: any) => (deleteLogs.value = Boolean(val)),
+                "onUpdate:modelValue": (val: unknown) => (deleteLogs.value = Boolean(val)),
             }),
             h(KsCheckbox, {
                 modelValue: deleteMetrics.value,
                 label: t("execution_deletion.metrics"),
-                "onUpdate:modelValue": (val: any) => (deleteMetrics.value = Boolean(val)),
+                "onUpdate:modelValue": (val: unknown) => (deleteMetrics.value = Boolean(val)),
             }),
             h(KsCheckbox, {
                 modelValue: deleteStorage.value,
                 label: t("execution_deletion.storage"),
-                "onUpdate:modelValue": (val: any) => (deleteStorage.value = Boolean(val)),
+                "onUpdate:modelValue": (val: unknown) => (deleteStorage.value = Boolean(val)),
             }),
         ])
         KsMessageBox.confirm(message, t("confirmation")).then(() => {
@@ -1108,7 +1118,7 @@
                         }),
                         data: filtered.labels,
                     })
-                    .then((r: any) => {
+                    .then((r: unknown) => {
                         toast.success(t("Set labels done", {executionCount: affectedCount(r)}))
                         toggleAllUnselected()
                         dataTable.value?.reload()
@@ -1119,7 +1129,7 @@
                         executionsId: selection.value,
                         executionLabels: filtered.labels,
                     })
-                    .then((r: any) => {
+                    .then((r: unknown) => {
                         toast.success(t("Set labels done", {executionCount: affectedCount(r)}))
                         toggleAllUnselected()
                         dataTable.value?.reload()


### PR DESCRIPTION
Closes #19280.

`Executions.vue` contained 25 explicit `any` usages that bypassed the frontend compiler.

This replaces them with the existing `Execution` and `Label` types, typed table refs, unknown-safe query/action handling, typed callbacks, and constrained response parsing. The explicit-any baseline is updated accordingly.

Validation:
- `npm run check:types`
- `npm run test:lint` (passes; existing warnings remain)
- `npm run check:ts-any`
- `git diff --check`

No dedicated `Executions.vue` unit test exists in this repository; the full UI type and lint gates cover the changed component.