### PR TITLE
refactor(ui): replace explicit any in KsTree.vue

### DIFF
--- a/ui/packages/design-system/src/components/Data/KsTree.vue
+++ b/ui/packages/design-system/src/components/Data/KsTree.vue
@@ -1,7 +1,7 @@
 <template>
     <ElTree
         ref="treeRef"
-        v-bind="({...filteredProps(), ...$attrs} as any)"
+        v-bind="{...filteredProps(), ...$attrs}"
         @node-drag-start="(node, event) => emit('nodeDragStart', node, event)"
         @node-drop="(draggingNode, dropNode, dropType, event) => emit('nodeDrop', draggingNode, dropNode, dropType, event)"
         @node-click="(data, node, el, event) => emit('nodeClick', data, node, el, event)"
@@ -16,33 +16,45 @@
 </template>
 
 <script setup lang="ts">
-    import {ref} from "vue"
-    import {ElTree} from "element-plus"
+    import {ref, type ComponentInternalInstance} from "vue"
+    import {
+        ElTree,
+        type AllowDropFunction,
+        type LoadFunction,
+        type NodeDropType,
+        type TreeData,
+        type TreeInstance,
+        type TreeKey,
+        type TreeNodeData,
+        type TreeOptionProps,
+    } from "element-plus"
     import {useFilteredProps} from "../../utils/filteredProps"
 
     defineOptions({inheritAttrs: false})
 
     const props = defineProps<{
-        data?: any[]
+        data?: TreeData
         lazy?: boolean
-        load?: (node: any, resolve: (data: any[]) => void) => void
-        allowDrop?: (draggingNode: any, dropNode: any, type: string) => boolean
+        load?: LoadFunction
+        allowDrop?: AllowDropFunction
         draggable?: boolean
         nodeKey?: string
-        props?: {label?: string; children?: string; disabled?: string; isLeaf?: string}
+        props?: TreeOptionProps
         defaultExpandAll?: boolean
-        defaultExpandedKeys?: any[]
-        defaultCheckedKeys?: any[]
+        defaultExpandedKeys?: TreeKey[]
+        defaultCheckedKeys?: TreeKey[]
     }>()
 
+    type TreeNode = Parameters<AllowDropFunction>[0]
+
     const emit = defineEmits<{
-        nodeDragStart: [node: any, event: DragEvent]
-        nodeDrop: [draggingNode: any, dropNode: any, dropType: string, event: DragEvent]
-        nodeClick: [data: any, node: any, el: any, event: MouseEvent]
+        nodeDragStart: [node: TreeNode, event: DragEvent]
+        nodeDrop: [draggingNode: TreeNode, dropNode: TreeNode, dropType: NodeDropType, event: DragEvent]
+        nodeClick: [data: TreeNodeData, node: TreeNode, el: ComponentInternalInstance | null, event: MouseEvent]
     }>()
 
     defineSlots<{
-        default?: (scope: {node: any; data: any}) => unknown
+        default?: (scope: {node: TreeNode; data: TreeNodeData}) => unknown
         empty?(): unknown
     }>()
 
@@ -51,13 +63,16 @@
     const filteredProps = useFilteredProps(props)
 
     defineExpose({
-        getNode: (data: any) => treeRef.value?.getNode(data),
-        remove: (data: any) => treeRef.value?.remove(data),
-        append: (data: any, parent: any) => treeRef.value?.append(data, parent),
-        getCheckedNodes: (...args: any[]) => (treeRef.value?.getCheckedNodes as any)?.(...args),
-        setCheckedKeys: (...args: any[]) => (treeRef.value?.setCheckedKeys as any)?.(...args),
+        getNode: (data: TreeKey | TreeNodeData | TreeNode) => treeRef.value?.getNode(data),
+        remove: (data: TreeKey | TreeNodeData | TreeNode) => {
+            const node = typeof data === "string" || typeof data === "number" ? treeRef.value?.getNode(data) : data
+            if (node) treeRef.value?.remove(node)
+        },
+        append: (data: TreeNodeData, parent: TreeNodeData | TreeKey | TreeNode) => treeRef.value?.append(data, parent),
+        getCheckedNodes: (...args: Parameters<TreeInstance["getCheckedNodes"]>) => treeRef.value?.getCheckedNodes(...args),
+        setCheckedKeys: (...args: Parameters<TreeInstance["setCheckedKeys"]>) => treeRef.value?.setCheckedKeys(...args),
         getCurrentKey: () => treeRef.value?.getCurrentKey(),
-        setCurrentKey: (key: any) => treeRef.value?.setCurrentKey(key),
+        setCurrentKey: (key: TreeKey | null) => treeRef.value?.setCurrentKey(key),
     })
 </script>
 

--- a/ui/scripts/explicit-any/baseline.json
+++ b/ui/scripts/explicit-any/baseline.json
@@ -22,7 +22,6 @@
   "packages/design-system/src/components/Data/KsTable/KsTable.vue": 15,
   "packages/design-system/src/components/Data/KsTable/KsTableColumn.vue": 3,
   "packages/design-system/src/components/Data/KsTimeline/KsTimelineItem.vue": 1,
-  "packages/design-system/src/components/Data/KsTree.vue": 24,
   "packages/design-system/src/components/Form/KsAutocomplete.vue": 4,
   "packages/design-system/src/components/Form/KsCascaderPanel.vue": 5,
   "packages/design-system/src/components/Form/KsCheckbox/KsCheckbox.vue": 2,

--- a/ui/src/components/inputs/FileExplorer.vue
+++ b/ui/src/components/inputs/FileExplorer.vue
@@ -96,7 +96,7 @@
         <KsTree
             ref="tree"
             lazy
-            :load="filesStore.loadNodes"
+            :load="loadTreeNodes"
             :data="filesStore.fileTree"
             :allowDrop="
                 (_: any, drop: any, dropType: string) => !drop.data?.leaf || dropType !== 'inner'
@@ -107,7 +107,7 @@
             :props="({class: nodeClass, isLeaf: 'leaf'} as any)"
             class="mt-3"
             :class="{'is-drop-not-allow': isDropOutsideSidebar}"
-            @node-drag-start="onNodeDragStart"
+            @node-drag-start="onTreeNodeDragStart"
             @node-drop="nodeMoved"
             @keydown.delete.prevent="removeSelectedFiles"
         >
@@ -128,14 +128,14 @@
                     <div
                         class="tree-node-hitbox"
                         @mousedown.stop
-                        @click.stop="(e) => { if(!selectionMode) onRowClickWrapper(data, node, e) }"
+                        @click.stop="(e) => { if(!selectionMode) onRowClickWrapper(data as unknown as TreeNode, node as unknown as ElTreeNode, e) }"
                     >
                         <div class="item-line">
                             <KsCheckbox
                                 v-if="selectionMode"
                                 class="me-2"
                                 :modelValue="selectedNodes.includes(data.id)"
-                                @change="checked => toggleCheckboxSelection(checked, node)"
+                                @change="checked => toggleCheckboxSelection(checked, node as unknown as ElTreeNode)"
                                 @mousedown.stop
                                 @click.stop
                             />
@@ -144,7 +144,7 @@
                                 :folder="!data.leaf"
                                 class="me-2"
                             />
-                            <span class="filename" @click="(e) => { if(selectionMode) onRowClickWrapper(data, node, e) }">{{ data.fileName }}</span>
+                            <span class="filename" @click="(e) => { if(selectionMode) onRowClickWrapper(data as unknown as TreeNode, node as unknown as ElTreeNode, e) }">{{ data.fileName }}</span>
                         </div>
                     </div>
                     <template #dropdown>
@@ -163,13 +163,13 @@
                             >
                                 {{ $t("namespace files.create.folder") }}
                             </KsDropdownItem>
-                            <KsDropdownItem v-if="data.leaf && !multiSelected" @click="showRevisionsHistory(data)">
+                            <KsDropdownItem v-if="data.leaf && !multiSelected" @click="showRevisionsHistory(data as unknown as TreeNode)">
                                 {{ $t("namespace files.revisions.history") }}
                             </KsDropdownItem>
-                            <KsDropdownItem v-if="!multiSelected" @click="copyPath(data)">
+                            <KsDropdownItem v-if="!multiSelected" @click="copyPath(data as unknown as TreeNode)">
                                 {{ $t("namespace files.path.copy") }}
                             </KsDropdownItem>
-                            <KsDropdownItem v-if="data.leaf && !multiSelected" @click="exportFile(data)">
+                            <KsDropdownItem v-if="data.leaf && !multiSelected" @click="exportFile(data as unknown as TreeNode)">
                                 {{ $t("namespace files.export_single") }}
                             </KsDropdownItem>
                             <KsDropdownItem
@@ -180,7 +180,7 @@
                                         true,
                                         !data.leaf ? 'folder' : 'file',
                                         data.fileName,
-                                        node,
+                                        node as unknown as ElTreeNode,
                                     )
                                 "
                             >
@@ -192,7 +192,7 @@
                                     )
                                 }}
                             </KsDropdownItem>
-                            <KsDropdownItem :disabled="!canManageFiles" @click="removeSelectedFiles(data, node)">
+                            <KsDropdownItem :disabled="!canManageFiles" @click="removeSelectedFiles(data, node as unknown as ElTreeNode)">
                                 {{
                                     selectedNodes.length <= 1 ? $t(
                                         `namespace files.delete.${
@@ -404,6 +404,9 @@
     import {useAuthStore} from "override/stores/auth"
     import resource from "../../models/resource"
     import action from "../../models/action"
+    import type {AllowDropFunction, LoadFunction, TreeNodeData} from "element-plus"
+
+    type ElementTreeNode = Parameters<AllowDropFunction>[0]
 
     const DIALOG_DEFAULTS:Dialog = {
         visible: false,
@@ -525,6 +528,13 @@
         else labels.message = t("namespace files.dialog.deletion.files", {count: filesCount})
         return labels
     })
+
+    const loadTreeNodes: LoadFunction = (node, resolve) => {
+        filesStore.loadNodes(
+            node.level === 0 ? {level: 0} : node as unknown as ElTreeNode,
+            children => resolve(children as unknown as TreeNodeData[]),
+        )
+    }
 
     function nodeClass(data: any) {
         if (selectedNodes.value.includes(data.id)) {
@@ -882,6 +892,10 @@
             .map(id => filesStore.getPath(id))
             .filter((path): path is string => !!path && !selectedPaths.some(p => p !== path && path.startsWith(`${p}/`)))
             .map(path => ({path, fileName: path.split("/").pop() ?? ""}))
+    }
+
+    function onTreeNodeDragStart(node: ElementTreeNode, _event: DragEvent) {
+        onNodeDragStart(node as unknown as FileExplorerNode)
     }
 
     async function nodeMoved(draggedNode: any) {


### PR DESCRIPTION
Closes #19275.

Replace the explicit `any` types in `KsTree.vue` with Element Plus tree types, and keep the file explorer integration type-safe at the component boundary.

Validation:
- `npm run check:types`
- `npm run check:ts-any -- --write`
- `npx oxlint src/components/inputs/FileExplorer.vue packages/design-system/src/components/Data/KsTree.vue`
- `npx eslint src/components/inputs/FileExplorer.vue packages/design-system/src/components/Data/KsTree.vue`
- `git diff --check`

There is no dedicated unit test for this presentational tree wrapper.