### PR TITLE
feat(core): add keyset findAfterWithoutAcl to the log data store

### DIFF
--- a/core/src/main/java/io/kestra/core/repositories/LogDataStoreInterface.java
+++ b/core/src/main/java/io/kestra/core/repositories/LogDataStoreInterface.java
@@ -1,5 +1,6 @@
 package io.kestra.core.repositories;
 
+import java.time.Instant;
 import java.time.ZonedDateTime;
 import java.util.List;
 
@@ -116,6 +117,32 @@ public interface LogDataStoreInterface extends IndexingRepository<LogEntry>, Que
         List<QueryFilter> filters);
 
     Flux<LogEntry> findAllAsync(@Nullable String tenantId);
+
+    /**
+     * A log entry together with its stable storage key (the unique row/document id), needed to
+     * resume keyset pagination — the deserialized {@link LogEntry} does not carry its own key.
+     */
+    record KeyedLog(String key, LogEntry log) {}
+
+    /**
+     * Keyset-paginated fetch ordered by (timestamp ASC, key ASC), strictly after the given position.
+     * Each call is an independent, short-lived query holding no cursor or transaction across calls,
+     * so an arbitrarily large result set is exported one bounded page at a time without exhausting heap.
+     * <p>
+     * No ACL is enforced (hence {@code WithoutAcl}): this is called from log-shipping tasks that run
+     * without a user context, so authorization must be checked by the caller before invoking it.
+     *
+     * @param afterTimestamp exclusive lower-bound timestamp — the window start (offset or lookback), always present
+     * @param afterKey       exclusive lower-bound key paired with {@code afterTimestamp}, or null to resume on the timestamp alone
+     * @param pageSize       maximum number of rows to return; fewer than this means the source is exhausted
+     * @return up to {@code pageSize} keyed log entries in (timestamp, key) ascending order
+     */
+    List<KeyedLog> findAfterWithoutAcl(
+        @Nullable String tenantId,
+        List<QueryFilter> filters,
+        Instant afterTimestamp,
+        @Nullable String afterKey,
+        int pageSize);
 
     LogEntry save(LogEntry log);
 

--- a/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcLogDataStore.java
+++ b/jdbc/src/main/java/io/kestra/jdbc/repository/AbstractJdbcLogDataStore.java
@@ -1,5 +1,8 @@
 package io.kestra.jdbc.repository;
 
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.util.*;
 import java.util.function.BiFunction;
@@ -207,6 +210,42 @@ public abstract class AbstractJdbcLogDataStore extends AbstractJdbcCrudRepositor
             condition = NORMAL_KIND_CONDITION.and(condition);
         }
         return findAsync(tenantId, condition, field(DATE_COLUMN).asc());
+    }
+
+    @Override
+    public List<KeyedLog> findAfterWithoutAcl(
+        @Nullable String tenantId,
+        List<QueryFilter> filters,
+        Instant afterTimestamp,
+        @Nullable String afterKey,
+        int pageSize) {
+        // Same default-kind rule as findAsync: NORMAL only unless a KIND or executionId filter is present.
+        var condition = this.filter(filters, DATE_COLUMN, Resource.LOG);
+        if (!QueryFilter.hasField(filters, QueryFilter.Field.KIND) && !QueryFilter.hasField(filters, QueryFilter.Field.EXECUTION_ID)) {
+            condition = NORMAL_KIND_CONDITION.and(condition);
+        }
+
+        // With a key, seek strictly after the (timestamp, key) row; without one (first run or a legacy date-only
+        // offset), fall back to a strict timestamp lower bound (which matches the previous START_DATE behaviour).
+        Field<OffsetDateTime> dateField = field(DATE_COLUMN, OffsetDateTime.class);
+        OffsetDateTime after = afterTimestamp.atOffset(ZoneOffset.UTC);
+        Condition seek = afterKey == null
+            ? dateField.gt(after)
+            : DSL.row(dateField, KEY_FIELD).gt(DSL.row(DSL.val(after), DSL.val(afterKey)));
+
+        final Condition finalCondition = condition;
+        return this.jdbcRepository.getDslContextWrapper().transactionResult(configuration ->
+            DSL.using(configuration)
+                .select(KEY_FIELD, VALUE_FIELD)
+                .from(this.jdbcRepository.getTable())
+                .where(this.defaultFilter(tenantId))
+                .and(finalCondition)
+                .and(seek)
+                .orderBy(dateField.asc(), KEY_FIELD.asc())
+                .limit(pageSize)
+                .fetch()
+                .map(record -> new KeyedLog(record.get(KEY_FIELD), this.jdbcRepository.map(record)))
+        );
     }
 
     @Override

--- a/tests/src/main/java/io/kestra/core/repositories/AbstractLogDataStoreTest.java
+++ b/tests/src/main/java/io/kestra/core/repositories/AbstractLogDataStoreTest.java
@@ -91,6 +91,7 @@ public abstract class AbstractLogDataStoreTest {
     protected String scopeTenant;
     protected String familyTenant;
     protected String pageTenant;
+    protected String keysetTenant;
 
     protected enum Group {
         LEVELS,
@@ -193,6 +194,18 @@ public abstract class AbstractLogDataStoreTest {
     // Pagination fixture: 102 entries for one execution (80 on taskId, 22 on taskId2/taskRunId2).
     static final String PAGE_EXEC = "exec-page";
 
+    // Keyset fixture: five entries sharing the EXACT same timestamp, so timestamp alone cannot paginate them
+    // (a page boundary can fall inside the group). Distinct levels give each backend a working tiebreaker:
+    // JDBC seeks on the unique (timestamp, key) row, Elasticsearch on (timestamp, level).
+    private static final Instant T_KEYSET = Instant.now().minus(3, ChronoUnit.DAYS).truncatedTo(ChronoUnit.MILLIS);
+    private static final List<LogEntry> KEYSET_LOGS = List.of(
+        log(Level.TRACE, "exec-keyset").timestamp(T_KEYSET).message("m0").build(),
+        log(Level.DEBUG, "exec-keyset").timestamp(T_KEYSET).message("m1").build(),
+        log(Level.INFO, "exec-keyset").timestamp(T_KEYSET).message("m2").build(),
+        log(Level.WARN, "exec-keyset").timestamp(T_KEYSET).message("m3").build(),
+        log(Level.ERROR, "exec-keyset").timestamp(T_KEYSET).message("m4").build()
+    );
+
     @BeforeAll
     void seed() {
         levelsTenant = randomTenant();
@@ -203,6 +216,7 @@ public abstract class AbstractLogDataStoreTest {
         scopeTenant = randomTenant();
         familyTenant = randomTenant();
         pageTenant = randomTenant();
+        keysetTenant = randomTenant();
 
         // One bulk write per group (saveBatch) — far fewer requests than a save() per entry on remote backends.
         logDataStore.saveBatch(withTenant(levelsTenant, LEVELS_LOGS));
@@ -212,6 +226,7 @@ public abstract class AbstractLogDataStoreTest {
         logDataStore.saveBatch(withTenant(kindTenant, KIND_LOGS));
         logDataStore.saveBatch(withTenant(scopeTenant, SCOPE_LOGS));
         logDataStore.saveBatch(withTenant(familyTenant, FAMILY_LOGS));
+        logDataStore.saveBatch(withTenant(keysetTenant, KEYSET_LOGS));
 
         List<LogEntry> pageLogs = new ArrayList<>(102);
         for (int i = 0; i < 80; i++) {
@@ -507,6 +522,35 @@ public abstract class AbstractLogDataStoreTest {
         ).collectList().block();
 
         assertThat(results).extracting(LogEntry::getExecutionId).containsExactlyInAnyOrder("exec-alpha", "exec-beta");
+    }
+
+    @Test
+    void findAfterWithoutAcl_paginatesAcrossEqualTimestampsWithoutLossOrDuplicates() {
+        // Given: five logs sharing the exact same timestamp (timestamp alone cannot paginate them)
+        List<QueryFilter> filters = List.of();
+
+        // When: pages of size 2 are read, each seeking strictly after the last row of the previous page.
+        // The first page seeds from a timestamp before the fixture (key null), like the shipper's offset/lookback.
+        List<LogDataStoreInterface.KeyedLog> all = new ArrayList<>();
+        Instant afterTs = T_KEYSET.minus(1, ChronoUnit.DAYS);
+        String afterKey = null;
+        while (true) {
+            List<LogDataStoreInterface.KeyedLog> page =
+                logDataStore.findAfterWithoutAcl(keysetTenant, filters, afterTs, afterKey, 2);
+            all.addAll(page);
+            if (page.size() < 2) {
+                break; // a non-full page marks exhaustion
+            }
+            LogDataStoreInterface.KeyedLog last = page.get(page.size() - 1);
+            afterTs = last.log().getTimestamp();
+            afterKey = last.key();
+        }
+
+        // Then: every row shipped exactly once, with a stable total order and no duplicate keys
+        assertThat(all).hasSize(5);
+        assertThat(all.stream().map(LogDataStoreInterface.KeyedLog::key).distinct().count()).isEqualTo(5L);
+        assertThat(all.stream().map(k -> k.log().getMessage()).toList())
+            .containsExactlyInAnyOrder("m0", "m1", "m2", "m3", "m4");
     }
 
     @Test


### PR DESCRIPTION
## What

Adds a demand-driven, keyset-paginated read to the log data store:
`LogDataStoreInterface.findAfterWithoutAcl(tenantId, filters, afterTimestamp, afterKey, pageSize)`
returning one bounded page ordered by `(timestamp, key)`, strictly after the given
position, holding no cursor or transaction between calls. JDBC implements it as a
jOOQ row-value seek `(timestamp, key) > (?, ?)`.

This is the OSS half of the EE `LogShipper` OOM fix (companion EE PR below).
`findAsync` is left unchanged (still used elsewhere).

## Why

The EE log shipper reads the whole backlog through the eager, unbounded `findAsync`
(`Flux.create(..., BUFFER)`), which OOMs on large exports when the destination upload
lags and the reactive buffer grows without bound. Keyset pagination lets the shipper
export one bounded page at a time.

## Tests

- `AbstractLogDataStoreTest.findAfterWithoutAcl_paginatesAcrossEqualTimestampsWithoutLossOrDuplicates`
  pages across a same-timestamp group asserting exactly-once. Green on H2, Postgres, MySQL.

## Notes

- `WithoutAcl`: no repository-layer ACL (matches `findAsync`); the caller (the shipper, which has
  no user context during execution) checks authorization before reading.
- A `(tenant_id, timestamp, key)` composite index is a planned follow-up; correctness holds without
  it (Postgres incremental sort).

Part of https://github.com/kestra-io/plugin-ee-aws/issues/198

Companion PR (EE, consumes this): https://github.com/kestra-io/kestra-ee/pull/10981