### PR TITLE
refactor(ui): replace explicit any in translation loader

### DIFF
--- a/ui/scripts/explicit-any/baseline.json
+++ b/ui/scripts/explicit-any/baseline.json
@@ -258,7 +258,6 @@
   "src/stores/playground.ts": 3,
   "src/stores/plugins.ts": 5,
   "src/stores/routeTabs.ts": 1,
-  "src/translations/i18n.ts": 5,
   "src/utils/analytics/eventNaming.spec.ts": 1,
   "src/utils/analytics/eventNaming.ts": 7,
   "src/utils/eventsRouter.ts": 2,

--- a/ui/src/translations/i18n.ts
+++ b/ui/src/translations/i18n.ts
@@ -6,8 +6,10 @@ const translations = import.meta.glob(["./*.json", "!./en.json"])
 import {SUPPORT_LOCALES} from "./languages"
 
 type Locales = (typeof SUPPORT_LOCALES)[number]
+type TranslationMessages = Record<string, Record<string, unknown>>
+type TranslationModule = {default: TranslationMessages}
 
-export const globalI18n = ref<I18n<any, any, any, Locales, false>["global"]>()
+export const globalI18n = ref<I18n<Record<string, unknown>, Record<string, unknown>, Record<string, unknown>, Locales, false>["global"]>()
 
 /**
  * What happens when `t()` is asked for a key no locale defines.
@@ -97,8 +99,8 @@ export function setI18nLanguage(i18n: I18n, locale: (typeof SUPPORT_LOCALES)[num
   document.querySelector("html")?.setAttribute("lang", locale.replace(/_/g, "-"))
 }
 
-export async function loadLocaleMessages(i18n: I18n, locale: (typeof SUPPORT_LOCALES)[number], additionalTranslationsProvider: Record<string, () => Promise<any>>) {
-  let messages = {} as any
+export async function loadLocaleMessages(i18n: I18n, locale: (typeof SUPPORT_LOCALES)[number], additionalTranslationsProvider: Record<string, () => Promise<TranslationModule>>) {
+  let messages: TranslationMessages
 
   if(additionalTranslationsProvider[locale]){
     // load additional translations from the provider
@@ -106,7 +108,7 @@ export async function loadLocaleMessages(i18n: I18n, locale: (typeof SUPPORT_LOC
     messages = additionalTranslations.default
   }else{
     // load locale messages with dynamic import
-    messages = await translations[`./${locale}.json`]()
+    messages = await translations[`./${locale}.json`]() as TranslationMessages
   }
 
   // set locale and locale message


### PR DESCRIPTION
Closes #19306.

Replace the translation loader's untyped vue-i18n generics and dynamic locale module values with explicit message/module types.

Validation:
- `npm run check:types` (app/design-system passed; test project also passed separately with `npx vue-tsc --project tsconfig.test.json --pretty false`)
- `npm run check:ts-any -- --write`
- `npm run test:unit -- tests/unit/translations/i18n.spec.ts` (3 passed)
- `npx oxlint src/translations/i18n.ts`
- `npx eslint src/translations/i18n.ts`
- `git diff --check`