### PR TITLE
refactor(ui): type admin trigger modal

### DIFF
--- a/ui/scripts/explicit-any/baseline.json
+++ b/ui/scripts/explicit-any/baseline.json
@@ -91,8 +91,6 @@
   "src/components/MultiPanelGenericEditorView.vue": 1,
   "src/components/MultiPanelTabs.vue": 4,
   "src/components/SurveyDialog.vue": 1,
-  "src/components/admin/triggers/AddTriggerModal.spec.ts": 1,
-  "src/components/admin/triggers/AddTriggerModal.vue": 5,
   "src/components/ai/copilot/CopilotComposer.vue": 5,
   "src/components/basicauth/BasicAuthLogin.vue": 2,
   "src/components/basicauth/BasicAuthSetup.vue": 7,

--- a/ui/src/components/admin/triggers/AddTriggerModal.spec.ts
+++ b/ui/src/components/admin/triggers/AddTriggerModal.spec.ts
@@ -89,7 +89,7 @@ describe("AddTriggerModal", () => {
         const wrapper = mountModal()
         await flushPromises()
 
-        const vm = wrapper.vm as any
+        const vm = wrapper.vm as unknown as {formModel: {namespace: string; flowId: string; triggerId: string}}
         vm.formModel.namespace = "company.team"
         vm.formModel.flowId = "example"
         vm.formModel.triggerId = "schedule"

--- a/ui/src/components/admin/triggers/AddTriggerModal.vue
+++ b/ui/src/components/admin/triggers/AddTriggerModal.vue
@@ -171,7 +171,11 @@
 
     // Provide schema injection context so TaskObject can resolve $ref fields
     // (e.g. inherited labels, workerSelector from parent trigger types).
-    provide(FULL_SCHEMA_INJECTION_KEY, computed(() => (triggerPlugin.value?.schema ?? {}) as any))
+    provide(FULL_SCHEMA_INJECTION_KEY, computed(() => ({
+        ...triggerPlugin.value?.schema,
+        definitions: triggerPlugin.value?.schema?.definitions ?? {},
+        $ref: "",
+    })))
     provide(SCHEMA_DEFINITIONS_INJECTION_KEY, computed(() => triggerPlugin.value?.schema?.definitions ?? {}))
     provide(BLOCK_SCHEMA_PATH_INJECTION_KEY, computed(() => {
         return props.trigger.type ? `#/definitions/${props.trigger.type}` : ""
@@ -183,7 +187,7 @@
         flowId: "",
         triggerId: generateId(),
     })
-    const triggerPropertiesModel = ref<Record<string, any>>({})
+    const triggerPropertiesModel = ref<Record<string, unknown>>({})
 
     // Fields handled by the modal itself, not rendered through the no-code form.
     const RESERVED_FIELDS = new Set(["id", "type", "description"])
@@ -224,7 +228,7 @@
     const getTriggerId = () => formModel.value.triggerId.trim() || "mytrigger"
 
     const triggerBlock = computed(() => {
-        const trigger: Record<string, any> = {
+        const trigger: Record<string, unknown> = {
             id: getTriggerId(),
             type: props.trigger.type,
             ...triggerPropertiesModel.value,
@@ -248,7 +252,7 @@
         flowsLoading.value = true
         try {
             const response = await flowStore.findFlows({"filters[namespace][EQUALS]": namespace, sort: "id:asc"})
-            flowOptions.value = (response?.results ?? []).map((f: any) => ({id: f.id, namespace: f.namespace}))
+            flowOptions.value = (response?.results ?? []).map(f => ({id: f.id, namespace: f.namespace}))
         } finally {
             flowsLoading.value = false
         }
@@ -259,7 +263,7 @@
         loadFlows(typeof ns === "string" ? ns : "")
     }
 
-    const onPropertiesUpdate = (value: Record<string, any> | undefined) => {
+    const onPropertiesUpdate = (value: Record<string, unknown> | undefined) => {
         triggerPropertiesModel.value = value ?? {}
     }
 


### PR DESCRIPTION
## What\n\n- replace the six explicit `any` usages in the admin trigger modal and its test with existing schema, SDK, Vue, and router types\n- preserve the schema injection contract while making the required fields explicit\n- remove the two admin trigger entries from the explicit-any baseline\n\n## Validation\n\n- `npm run check:types`\n- `npm run check:ts-any -- --write`\n- `npm run test:unit -- src/components/admin/triggers/AddTriggerModal.spec.ts` (1 passed)\n- targeted Oxlint and ESLint\n- `git diff --check`\n\nCloses #19303.\n\nAssisted-by: Codex