### PR TITLE
refactor(ui): type basic auth components

### DIFF
--- a/ui/scripts/explicit-any/baseline.json
+++ b/ui/scripts/explicit-any/baseline.json
@@ -94,8 +94,6 @@
   "src/components/admin/triggers/AddTriggerModal.spec.ts": 1,
   "src/components/admin/triggers/AddTriggerModal.vue": 5,
   "src/components/ai/copilot/CopilotComposer.vue": 5,
-  "src/components/basicauth/BasicAuthLogin.vue": 2,
-  "src/components/basicauth/BasicAuthSetup.vue": 7,
   "src/components/content/BigChildCards.vue": 1,
   "src/components/content/ChildTableOfContents.vue": 3,
   "src/components/dashboard/DrillDownDrawer.vue": 2,

--- a/ui/src/components/basicauth/BasicAuthLogin.vue
+++ b/ui/src/components/basicauth/BasicAuthLogin.vue
@@ -74,6 +74,14 @@
         password: string
     }
 
+    interface AuthError {
+        code?: string;
+        response?: {status?: number};
+    }
+
+    const authError = (error: unknown): AuthError =>
+        typeof error === "object" && error !== null ? error as AuthError : {}
+
     const router = useRouter()
     const route = useRoute()
     const {t} = useI18n()
@@ -124,10 +132,11 @@
         return response.data?.isBasicAuthInitialized
     }
 
-    const handleNetworkError = (error: any) => {
-        return error.code === "ERR_NETWORK" ||
-            error.code === "ECONNREFUSED" ||
-            (!error.response && error instanceof TypeError)
+    const handleNetworkError = (error: unknown) => {
+        const details = authError(error)
+        return details.code === "ERR_NETWORK" ||
+            details.code === "ECONNREFUSED" ||
+            (!details.response && error instanceof TypeError)
     }
 
     const loadAuthConfigErrors = async () => {
@@ -173,11 +182,12 @@
             } else {
                 router.push({name: "home", params: {tenant: route.params.tenant}})
             }
-        } catch (error: any) {
+        } catch (error: unknown) {
             if (handleNetworkError(error)) { router.push({name: "setup"}); return }
-            if (error?.response?.status === 401) {
+            const status = authError(error).response?.status
+            if (status === 401) {
                 await loadAuthConfigErrors()
-            } else if (error?.response?.status === 404) {
+            } else if (status === 404) {
                 router.push({name: "setup"})
             } else {
                 KsMessage.error(t("setup.validation.incorrect_creds"))

--- a/ui/src/components/basicauth/BasicAuthSetup.vue
+++ b/ui/src/components/basicauth/BasicAuthSetup.vue
@@ -154,9 +154,10 @@
 
 <script setup lang="ts">
     import MailChecker from "mailchecker"
-    import {ref, computed, onUnmounted, type Ref} from "vue"
+    import {ref, computed, onUnmounted} from "vue"
     import {useRouter} from "vue-router"
     import {useI18n} from "vue-i18n"
+    import type {FormInstance} from "@kestra-io/design-system"
     import {useMiscStore} from "override/stores/misc"
     import {useSurveySkip} from "../../composables/useSurveyData"
     import {trackSetupEvent} from "../../composables/usePosthog"
@@ -191,7 +192,7 @@
     const {storeSurveySkipData} = useSurveySkip()
 
     const activeStep = ref(0)
-    const userForm: Ref<any> = ref(null)
+    const userForm = ref<FormInstance | null>(null)
 
     const userFormData = ref<UserFormData>({
         username: "",
@@ -257,7 +258,7 @@
 
     const EMAIL_REGEX = /^[a-zA-Z0-9_!#$%&'*+/=?`{|}~^.-]+@[a-zA-Z0-9.-]+$/
 
-    const validateEmail = (_rule: any, value: string, callback: (error?: Error) => void) => {
+    const validateEmail = (_rule: unknown, value: string, callback: (error?: Error) => void) => {
         if (!value) {
             callback(new Error(t("setup.validation.email_required")))
             return
@@ -297,9 +298,9 @@
     })
 
     const getFieldError = (fieldName: string) => {
-        if (!userForm.value) return null
-        const field = userForm.value.fields?.find((f: any) => f.prop === fieldName)
-        return field?.validateState === "error" ? field.validateMessage : null
+        if (!userForm.value) return undefined
+        const field = userForm.value.fields?.find(f => f.prop === fieldName)
+        return field?.validateState === "error" ? field.validateMessage ?? undefined : undefined
     }
 
     const handleUserFormSubmit = async () => {
@@ -321,9 +322,10 @@
             localStorage.setItem("basicAuthUserCreated", "true")
 
             activeStep.value = 1
-        } catch (error: any) {
+        } catch (error: unknown) {
+            const message = error instanceof Error ? error.message : "Unknown error"
             trackSetupEvent("setup_flow:account_creation_failed", {
-                error_message: error.message || "Unknown error",
+                error_message: message,
             }, userFormData.value)
             console.error("Failed to create basic auth account:", error)
         }
@@ -332,7 +334,7 @@
     const handleSurveyContinue = () => {
         localStorage.setItem("basicAuthSurveyData", JSON.stringify(surveyData.value))
 
-        const surveySelections: Record<string, any> = {
+        const surveySelections: Record<string, string | boolean | number | string[]> = {
             main_goal: surveyData.value.mainGoal,
             use_cases: surveyData.value.useCases,
             use_cases_count: surveyData.value.useCases.length,
@@ -354,7 +356,7 @@
     }
 
     const handleSurveySkip = () => {
-        const surveySelections: Record<string, any> = {
+        const surveySelections: Record<string, string | boolean | number | string[]> = {
             main_goal: surveyData.value.mainGoal,
             newsletter_opted_in: surveyData.value.newsletter,
             survey_action: "skipped",
@@ -382,7 +384,7 @@
         const surveySelections = savedSurveyData ? JSON.parse(savedSurveyData) : {}
         const normalizedEmail = userFormData.value.username.trim()
 
-        const completeEventPayload: Record<string, any> = {
+        const completeEventPayload: Record<string, string | boolean | number | string[]> = {
             user_email: normalizedEmail,
             newsletter_opted_in: surveyData.value.newsletter,
             ...surveySelections,


### PR DESCRIPTION
## What\n\n- replace nine explicit `any` usages in the basic-auth setup and login flows with Element Plus form, error, and analytics payload types\n- preserve the form validation and authentication error handling behavior\n- remove the basic-auth entries from the explicit-any baseline\n\n## Validation\n\n- `npm run check:types`\n- `npm run check:ts-any -- --write`\n- `npm run test:unit -- tests/unit/components/BasicAuthLogin.spec.ts` (4 passed)\n- targeted Oxlint and ESLint\n- `git diff --check`\n\nCloses #19298.\n\nAssisted-by: Codex