### PR TITLE
fix(webserver): make bulk flow delete by-ids atomic and validate ids upfront

### DIFF
--- a/webserver/src/main/java/io/kestra/webserver/controllers/api/FlowController.java
+++ b/webserver/src/main/java/io/kestra/webserver/controllers/api/FlowController.java
@@ -53,6 +53,11 @@ import io.kestra.webserver.responses.PagedResults;
 import io.kestra.webserver.services.SourceSearchService;
 import io.kestra.webserver.utils.CSVUtils;
 import io.kestra.webserver.utils.PageableUtils;
+import io.kestra.webserver.errors.ProblemDetail;
+import io.kestra.webserver.errors.ProblemError;
+import io.kestra.webserver.errors.ProblemType;
+import io.kestra.webserver.errors.ProblemTypes;
+import io.kestra.webserver.exceptions.BulkValidationException;
 
 import io.micronaut.core.annotation.Nullable;
 import io.micronaut.data.model.Pageable;
@@ -875,16 +880,28 @@ public class FlowController {
         summary = "Delete flows by their IDs."
     )
     @ApiResponse(responseCode = "200", description = "On success", content = { @Content(schema = @Schema(implementation = BulkResponse.class)) })
+    @ApiResponse(responseCode = "400", description = "Validation errors", content = { @Content(schema = @Schema(implementation = ProblemDetail.class)) })
     public HttpResponse<BulkResponse> deleteFlowsByIds(
         @RequestBody(description = "A list of tuple flow ID and namespace as flow identifiers") @Body List<IdWithNamespace> ids) throws QueueException {
-        List<Flow> list = ids
-            .stream()
-            .map(id -> flowRepository.findByIdWithSource(tenantService.resolveTenant(), id.getNamespace(), id.getId()).orElseThrow())
-            .peek(throwConsumer(flow -> flowService.delete(flow)))
-            .collect(Collectors.toList());
+            List<FlowWithSource> flows = new ArrayList<>();
+            List<ProblemError> invalids = new ArrayList<>();
 
-        return HttpResponse.ok(BulkResponse.builder().count(list.size()).build());
-    }
+            for (IdWithNamespace id : ids) {
+                Optional<FlowWithSource> flow = flowRepository.findByIdWithSource(tenantService.resolveTenant(), id.getNamespace(), id.getId());
+                if (flow.isPresent()) {
+                    flows.add(flow.get());
+                } else {
+                    invalids.add(flowProblem(id, "flow not found", ProblemTypes.NOT_FOUND));
+                }
+            }
+            if (!invalids.isEmpty()) {
+                throw new BulkValidationException("One or more flows could not be deleted.", invalids);
+            }
+
+            flows.forEach(throwConsumer(flow -> flowService.delete(flow)));
+
+            return HttpResponse.ok(BulkResponse.builder().count(flows.size()).build());
+        }
 
     @ExecuteOn(TaskExecutors.IO)
     @Post(uri = "/disable/by-query")
@@ -1094,5 +1111,9 @@ public class FlowController {
         String flowId,
         Integer revision,
         List<FlowService.TaskDeprecation> deprecatedTasks) {
+    }
+
+        private static ProblemError flowProblem(IdWithNamespace id, String detail, ProblemType type) {
+        return ProblemError.ofItem(detail, "flows[" + id.getNamespace() + "." + id.getId() + "]", type);
     }
 }

--- a/webserver/src/test/java/io/kestra/webserver/controllers/api/FlowControllerTest.java
+++ b/webserver/src/test/java/io/kestra/webserver/controllers/api/FlowControllerTest.java
@@ -1462,6 +1462,49 @@ class FlowControllerTest {
     }
 
     @Test
+    void deleteFlowsByIdsShouldDeleteAllGivenFlows() {
+        postFlow("byIdsA", "io.kestra.unittest.deletebyids", "a");
+        postFlow("byIdsB", "io.kestra.unittest.deletebyids", "b");
+
+        List<IdWithNamespace> ids = List.of(
+            new IdWithNamespace("io.kestra.unittest.deletebyids", "byIdsA"),
+            new IdWithNamespace("io.kestra.unittest.deletebyids", "byIdsB")
+        );
+
+        HttpResponse<BulkResponse> response = client
+            .toBlocking()
+            .exchange(DELETE("/api/v1/main/flows/delete/by-ids", ids), BulkResponse.class);
+
+        assertThat(response.getBody().get().getCount()).isEqualTo(2);
+
+        assertThrows(HttpClientResponseException.class, () ->
+            client.toBlocking().retrieve(HttpRequest.GET("/api/v1/main/flows/io.kestra.unittest.deletebyids/byIdsA")));
+        assertThrows(HttpClientResponseException.class, () ->
+            client.toBlocking().retrieve(HttpRequest.GET("/api/v1/main/flows/io.kestra.unittest.deletebyids/byIdsB")));
+    }
+
+    @Test
+    void deleteFlowsByIdsShouldNotDeleteAnyFlowWhenOneIdIsMissing() {
+        postFlow("keepMe", "io.kestra.unittest.deletebyidspartial", "a");
+
+        List<IdWithNamespace> ids = List.of(
+            new IdWithNamespace("io.kestra.unittest.deletebyidspartial", "keepMe"),
+            new IdWithNamespace("io.kestra.unittest.deletebyidspartial", "doesNotExist")
+        );
+
+        HttpClientResponseException e = assertThrows(HttpClientResponseException.class, () ->
+            client.toBlocking().exchange(DELETE("/api/v1/main/flows/delete/by-ids", ids), BulkResponse.class));
+
+        assertThat(e.getStatus().getCode()).isEqualTo(HttpStatus.BAD_REQUEST.getCode());
+        Problems.assertProblem(e, ProblemTypes.BULK_VALIDATION_FAILED);
+
+        // The valid flow must survive: the endpoint validates every id up front and mutates
+        // nothing when any id in the batch does not exist.
+        String flow = client.toBlocking().retrieve(HttpRequest.GET("/api/v1/main/flows/io.kestra.unittest.deletebyidspartial/keepMe"), String.class);
+        assertThat(flow).isNotNull();
+    }
+
+    @Test
     void validateFlows() throws IOException {
         URL resource = TestsUtils.class.getClassLoader().getResource("flows/validateMultipleValidFlows.yaml");
         String flow = Files.readString(Path.of(Objects.requireNonNull(resource).getPath()), Charset.defaultCharset());

--- a/webserver/src/test/java/io/kestra/webserver/controllers/api/FlowControllerTest.java
+++ b/webserver/src/test/java/io/kestra/webserver/controllers/api/FlowControllerTest.java
@@ -51,6 +51,7 @@ import io.kestra.webserver.models.flows.SourceSearchReplacePreviewResponse;
 import io.kestra.webserver.models.flows.SourceSearchResult;
 import io.kestra.webserver.responses.BulkResponse;
 import io.kestra.webserver.responses.PagedResults;
+import io.kestra.webserver.errors.ProblemTypes;
 
 import io.micronaut.core.type.Argument;
 import io.micronaut.http.*;


### PR DESCRIPTION
## What
Fixes #18511 — bulk-deleting flows via `DELETE /api/v1/{tenant}/flows/delete/by-ids` deleted valid flows before checking later ids in the list, then returned a 404 as soon as it hit a missing id. This made the operation non-atomic and the error response misleading (it looked like nothing was deleted, when in fact prior flows in the list were already gone).

## Why it happened
The endpoint used a single Java stream that mapped each id to a lookup (`.orElseThrow()`) and deleted it via `.peek()` in the same pass. Streams evaluate lazily per element, so flows before a bad id were deleted before the bad id was even reached.

## Fix
Validate every id upfront, collect any missing ones, and only delete if the whole batch is valid — mirroring the existing pattern already used in `ExecutionController#deleteExecutionsByIds`. If any id is missing, the request fails with `400 Bulk Validation Failed` (one `ProblemError` per missing flow) and nothing is deleted.

## Testing
- Added `deleteFlowsByIdsShouldDeleteAllGivenFlows` — happy path, all ids valid.
- Added `deleteFlowsByIdsShouldNotDeleteAnyFlowWhenOneIdIsMissing` — regression test for the reported bug: asserts a `400`/`bulk-validation-failed` problem is returned and the valid flow in the batch is *not* deleted.