### PR TITLE
fix(compose): wait for healthy Postgres before starting Kestra

### DIFF
--- a/docker-compose-dind.yml
+++ b/docker-compose-dind.yml
@@ -24,7 +24,7 @@ services:
       POSTGRES_PASSWORD: k3str4
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -d $${POSTGRES_DB} -U $${POSTGRES_USER}"]
-      interval: 30s
+      interval: 5s
       timeout: 10s
       retries: 10
 
@@ -44,6 +44,7 @@ services:
   kestra:
     image: kestra/kestra:latest
     pull_policy: always
+    restart: unless-stopped
     # Kestra, by default, has a termination grace period of 5m. We need to wait a little more to be sure no active tasks are running.
     stop_grace_period: 6m
     # Note that this is meant for development only. Refer to the documentation for production deployments of Kestra which runs without a root user.
@@ -79,6 +80,6 @@ services:
       - "8081:8081"
     depends_on:
       postgres:
-        condition: service_started
+        condition: service_healthy
       dind:
         condition: service_started

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,13 +15,14 @@ services:
       POSTGRES_PASSWORD: k3str4
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -d $${POSTGRES_DB} -U $${POSTGRES_USER}"]
-      interval: 30s
+      interval: 5s
       timeout: 10s
       retries: 10
 
   kestra:
     image: kestra/kestra:latest
     pull_policy: always
+    restart: unless-stopped
     # Kestra, by default, has a termination grace period of 5m. We need to wait a little more to be sure no active tasks are running.
     stop_grace_period: 6m
     # Note that this setup with a root user is intended for development purpose.
@@ -65,4 +66,4 @@ services:
       # - "8081:8081"
     depends_on:
       postgres:
-        condition: service_started
+        condition: service_healthy


### PR DESCRIPTION
## Summary
Fixes #19369

Getting-started Compose files defined a Postgres `pg_isready` healthcheck but Kestra only waited for `service_started`. With an eagerly-initialized fail-fast JDBC pool and no `restart` policy, a first-boot race can leave Kestra exited.

### Changes
- `docker-compose.yml` and `docker-compose-dind.yml`: `depends_on.postgres.condition: service_healthy`
- Shorten Postgres healthcheck `interval` from `30s` to `5s`
- Add `restart: unless-stopped` on the Kestra service

Matches the pattern already used in `ui/tests/e2e/docker-compose-postgres.yml`.

## Checklist
- [x] I have tested this change locally (validated Compose YAML structure / depends_on conditions)
- [x] This change is related to an existing issue