### PR TITLE
fix(webserver): normalize namespace paths before _flows guard

### DIFF
--- a/webserver/src/main/java/io/kestra/webserver/controllers/api/NamespaceFileController.java
+++ b/webserver/src/main/java/io/kestra/webserver/controllers/api/NamespaceFileController.java
@@ -236,7 +236,10 @@ public class NamespaceFileController {
     }
 
     private List<NamespaceFile> putNamespaceFile(String tenantId, String namespace, URI path, BufferedInputStream inputStream) throws Exception {
-        String filePath = path.getPath();
+        // Normalize before the _flows special-case and the forbidden-path guard so paths like
+        // /./_flows/... or ///_flows/... cannot bypass either check (see #19370).
+        URI normalizedPath = normalizeFileUri(path);
+        String filePath = normalizedPath.getPath();
         if (filePath.matches("/" + FLOWS_FOLDER + "/.*")) {
             if (filePath.split("/").length != 3) {
                 throw new IllegalArgumentException("Invalid flow file path: " + filePath);
@@ -247,7 +250,7 @@ public class NamespaceFileController {
             this.importFlow(tenantId, flowSource);
             return Collections.emptyList();
         }
-        forbiddenPathsGuard(path);
+        forbiddenPathsGuard(normalizedPath);
 
         // Reject over-long names before writing: otherwise the filesystem raises ENAMETOOLONG, which
         // surfaces as a 500 leaking the absolute internal-storage path. The limit is per path component
@@ -260,7 +263,7 @@ public class NamespaceFileController {
         }
 
         Namespace namespaceStorage = namespaceFactory.of(tenantId, namespace, storageInterface);
-        return namespaceStorage.putFile(Path.of(path.getPath()), inputStream);
+        return namespaceStorage.putFile(Path.of(filePath), inputStream);
     }
 
     protected void importFlow(String tenantId, String source) throws FlowProcessingException {
@@ -370,6 +373,18 @@ public class NamespaceFileController {
         return new URI(null, null, path, null);
     }
 
+    /**
+     * Collapses {@code .} / duplicate slashes (and rejects {@code ..}) so path guards see the same
+     * canonical form that storage uses after {@link NamespaceFile#normalize(Path)}.
+     */
+    private static URI normalizeFileUri(URI path) throws URISyntaxException {
+        if (path == null || path.getPath() == null) {
+            return path;
+        }
+        String normalized = NamespaceFile.toLogicalPath(NamespaceFile.normalize(Path.of(path.getPath())));
+        return toFileUri(normalized);
+    }
+
     private void forbiddenPathsGuard(URI path) {
         if (path == null) {
             return;
@@ -379,8 +394,11 @@ public class NamespaceFileController {
             throw new HttpStatusException(HttpStatus.UNPROCESSABLE_ENTITY, "The path '%s' is not a valid hierarchical path.".formatted(path));
         }
 
-        if (forbiddenPathPatterns.stream().anyMatch(pattern -> pattern.matcher(path.getPath()).matches())) {
-            throw new IllegalArgumentException("Forbidden path: " + path.getPath());
+        // Match against the normalized path: raw "/./_flows/..." would otherwise miss the regex
+        // while Path.normalize() later maps it onto the reserved "/_flows/..." tree (#19370).
+        String normalizedPath = NamespaceFile.toLogicalPath(NamespaceFile.normalize(Path.of(path.getPath())));
+        if (forbiddenPathPatterns.stream().anyMatch(pattern -> pattern.matcher(normalizedPath).matches())) {
+            throw new IllegalArgumentException("Forbidden path: " + normalizedPath);
         }
     }
 

--- a/webserver/src/test/java/io/kestra/webserver/controllers/api/NamespaceFileControllerTest.java
+++ b/webserver/src/test/java/io/kestra/webserver/controllers/api/NamespaceFileControllerTest.java
@@ -12,6 +12,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
+import java.util.zip.ZipOutputStream;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -568,6 +569,67 @@ class NamespaceFileControllerTest {
         assertForbiddenErrorThrown(() -> client.toBlocking().exchange(HttpRequest.PUT("/api/v1/main/namespaces/" + namespace + "/files?from=/_flows/test&to=/foo", null)));
         assertForbiddenErrorThrown(() -> client.toBlocking().exchange(HttpRequest.PUT("/api/v1/main/namespaces/" + namespace + "/files?from=/foo&to=/_flows/test", null)));
         assertForbiddenErrorThrown(() -> client.toBlocking().exchange(HttpRequest.DELETE("/api/v1/main/namespaces/" + namespace + "/files?path=/_flows/test.txt", null)));
+
+        // #19370: raw-path bypasses that normalize onto /_flows must also be forbidden
+        assertForbiddenErrorThrown(() -> client.toBlocking().retrieve(HttpRequest.GET("/api/v1/main/namespaces/" + namespace + "/files?path=/./_flows/test.yml")));
+        assertForbiddenErrorThrown(() -> client.toBlocking().retrieve(HttpRequest.GET("/api/v1/main/namespaces/" + namespace + "/files?path=///_flows/test.yml")));
+        assertForbiddenErrorThrown(
+            () -> client.toBlocking().retrieve(HttpRequest.GET("/api/v1/main/namespaces/" + namespace + "/files/stats?path=/./_flows/test.yml"), TestFileAttributes.class)
+        );
+        assertForbiddenErrorThrown(() -> client.toBlocking().retrieve(HttpRequest.GET("/api/v1/main/namespaces/" + namespace + "/files/directory?path=/./_flows"), TestFileAttributes[].class));
+        assertForbiddenErrorThrown(() -> client.toBlocking().exchange(HttpRequest.DELETE("/api/v1/main/namespaces/" + namespace + "/files?path=/./_flows/test.txt", null)));
+        assertForbiddenErrorThrown(() -> client.toBlocking().exchange(HttpRequest.PUT("/api/v1/main/namespaces/" + namespace + "/files?from=/./_flows/test&to=/foo", null)));
+        assertForbiddenErrorThrown(() -> client.toBlocking().exchange(HttpRequest.PUT("/api/v1/main/namespaces/" + namespace + "/files?from=/foo&to=///_flows/test", null)));
+    }
+
+    @Test
+    @LoadFlows({ "flows/valids/task-flow.yaml" })
+    void createFileContent_AddFlowViaNormalizedFlowsPath() throws IOException {
+        // /./_flows/... must hit the flow-import special-case after normalization, not land as a reserved-folder file
+        String namespace = TestsUtils.randomNamespace();
+        String flowSource = flowRepository.findByIdWithSource(TENANT_ID, "io.kestra.tests", "task-flow").get().getSource();
+        File temp = File.createTempFile("task-flow", ".yml");
+        Files.write(temp.toPath(), flowSource.getBytes());
+
+        MultipartBody body = MultipartBody.builder()
+            .addPart("fileContent", "task-flow.yml", temp)
+            .build();
+        client.toBlocking().exchange(
+            HttpRequest.POST("/api/v1/main/namespaces/" + namespace + "/files?path=/./_flows/task-flow.yml", body)
+                .contentType(MediaType.MULTIPART_FORM_DATA_TYPE)
+        );
+
+        assertThat(flowRepository.findByIdWithSource(TENANT_ID, namespace, "task-flow").get().getSource())
+            .isEqualTo(flowSource.replaceFirst("(?m)^namespace: .*$", "namespace: " + namespace));
+        assertThat(storageInterface.exists(TENANT_ID, namespace, toNamespacedStorageUri(namespace, URI.create("/_flows/task-flow.yml")))).isFalse();
+        assertThat(storageInterface.exists(TENANT_ID, namespace, toNamespacedStorageUri(namespace, URI.create("/./_flows/task-flow.yml")))).isFalse();
+    }
+
+    @Test
+    @LoadFlows({ "flows/valids/task-flow.yaml" })
+    void createFileContent_ExtractZipWithDotFlowsEntryImportsFlow() throws IOException {
+        // Zip entries named ./_flows/... must not bypass the reserved-folder handling (#19370)
+        String namespace = TestsUtils.randomNamespace();
+        String flowSource = flowRepository.findByIdWithSource(TENANT_ID, "io.kestra.tests", "task-flow").get().getSource();
+
+        File tempZip = File.createTempFile("flows-bypass", ".zip");
+        try (ZipOutputStream archive = new ZipOutputStream(Files.newOutputStream(tempZip.toPath()))) {
+            archive.putNextEntry(new ZipEntry("./_flows/task-flow.yml"));
+            archive.write(flowSource.getBytes());
+            archive.closeEntry();
+        }
+
+        MultipartBody body = MultipartBody.builder()
+            .addPart("fileContent", "flows-bypass.zip", tempZip)
+            .build();
+        client.toBlocking().exchange(
+            HttpRequest.POST("/api/v1/main/namespaces/" + namespace + "/files?path=/flows-bypass.zip", body)
+                .contentType(MediaType.MULTIPART_FORM_DATA_TYPE)
+        );
+
+        assertThat(flowRepository.findByIdWithSource(TENANT_ID, namespace, "task-flow").get().getSource())
+            .isEqualTo(flowSource.replaceFirst("(?m)^namespace: .*$", "namespace: " + namespace));
+        assertThat(storageInterface.exists(TENANT_ID, namespace, toNamespacedStorageUri(namespace, URI.create("/_flows/task-flow.yml")))).isFalse();
     }
 
     @Test


### PR DESCRIPTION
## Summary
Fixes #19370

`forbiddenPathsGuard` and the `putNamespaceFile` `_flows` import special-case matched the **raw** request path. Paths like `/./_flows/...` and `///_flows/...` missed the regex, while storage later collapsed them onto `/_flows/...` via `Path.normalize()` / `NamespaceFile.normalize()`.

Same class of bug as earlier `_flows*` / path-normalization GHSAs: guard looked at a pre-canonical path, storage used the canonical one.

### Changes
- Normalize with `NamespaceFile.normalize` + `toLogicalPath` before the forbidden-path regex
- Normalize in `putNamespaceFile` before the flow-import special-case and storage write
- Tests for `/./_flows/...`, `///_flows/...`, and zip entries named `./_flows/...`

## Checklist
- [x] I have tested this change locally (code + regression tests added; full Gradle run blocked by wrapper download timeout in this environment)
- [x] This change is related to an existing issue