### PR TITLE
docs(system): report vulnerabilities via GitHub Security Advisories

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,32 +2,44 @@
 
 ## Supported Versions
 
-We provide security updates for the following versions of Kestra:
+We provide security updates for:
 
-- The `latest` release 
-- Up to two previous minor versions released as a backport upon customer request.
+- The `latest` release
+- All actively supported LTS versions (see [release policy](https://kestra.io/docs/releases) for the current list)
 
-If you are using an unsupported version, we recommend upgrading to the `latest` version to receive security fixes.
+Unsupported versions won't receive patches, please upgrade to a supported one before reporting an issue tied to it.
 
 ## Reporting a Vulnerability
 
-If you discover a security vulnerability in Kestra, please report it to us privately to ensure a responsible disclosure process. You can contact our security team at:
+Please report security vulnerabilities through **GitHub Security Advisories**, not public issues or PRs:
 
-**security@kestra.io**
+👉 [Report a vulnerability](https://github.com/kestra-io/kestra/security/advisories/new)
 
-### Guidelines for Reporting
-- Provide a detailed description of the issue, including steps to reproduce it if possible.
-- Do not disclose the vulnerability publicly until we have confirmed and patched the issue.
-- If you believe the issue has critical severity, please indicate so in your report to help us prioritize.
+This opens a private draft advisory visible only to maintainers, so details stay confidential until we're ready to disclose.
+
+If you're unable to use GitHub for any reason, you can email us instead at **security@kestra.io**, but the GitHub flow is preferred since it keeps everything in one place.
+
+### What to include
+
+- A clear description of the vulnerability and its impact
+- Steps to reproduce (PoC code or a minimal repro if possible)
+- Affected version(s) and component(s)
+- Your assessment of severity, if you have one (CVSS vector is welcome but not required)
+
+### Guidelines
+
+- Please don't disclose the issue publicly (blog, social media, public issue, etc.) until we've published the advisory or given you the go-ahead.
+- Give us a reasonable amount of time to investigate and patch before disclosure. We aim to move fast, see our commitment below.
+- If you're not sure whether something is a security issue, report it privately anyway, we'd rather triage a false positive than miss a real one.
 
 ## Our Commitment
 
-- We will acknowledge your report within **2 business days**.
-- We will work to verify and address the issue as quickly as possible.
-- Once the issue is resolved, we will notify you of the fix.
+- We'll acknowledge new reports within **2 business days**.
+- We'll keep you updated as we validate, fix, and prepare a release.
+- Once a fix is released, we coordinate disclosure with you: affected customers are notified directly before the advisory goes public, and we credit you in the published advisory (or keep you anonymous, your call).
 
 ## Acknowledgments
 
-We are happy to credit those who report vulnerabilities responsibly in our release notes, unless you prefer to remain anonymous. If you would like to be acknowledged, please include this in your report.
+We're happy to publicly credit anyone who reports a vulnerability responsibly, in the advisory itself and/or release notes. Let us know in your report if you'd prefer to stay anonymous instead.
 
-Thank you for helping to make Kestra more secure!
+Thanks for helping keep Kestra secure.


### PR DESCRIPTION
## Summary
- Vulnerability reports now go through GitHub Security Advisories' private draft flow instead of email-only, keeping details confidential until disclosure.
- Clarifies supported versions (latest + LTS), what to include in a report, and our disclosure/credit commitments.

## Test plan
- [x] Rendered `SECURITY.md` locally to confirm formatting and links.

🤖 Generated with [Claude Code](https://claude.com/claude-code)